### PR TITLE
test(sparq-reason): default-OFF materialization + isolated incremental_explain unit tests (sq-bif.11) [OPUS-4.8]

### DIFF
--- a/crates/sparq-reason/tests/default_off_materialization.rs
+++ b/crates/sparq-reason/tests/default_off_materialization.rs
@@ -1,0 +1,227 @@
+//! Default-feature (explain OFF) forward-chaining correctness + compile-out guard
+//! ([OPUS-4.8] sq-bif.11).
+//!
+//! The crate's `explain` feature is NON-DEFAULT by design: when it is off, every
+//! explanation structure and hook is `cfg`'d out entirely and the reasoning path must be
+//! byte-identical to a build that never knew about explanations. The big differential
+//! sweeps in `explain_rdfs.rs` / `explain_owl.rs` / `explain_n3.rs` are all
+//! `#![cfg(feature = "explain")]`, so before this file the DEFAULT-OFF reasoning path had
+//! no test of its own.
+//!
+//! This file is deliberately NOT feature-gated: it compiles and runs in BOTH states, and
+//! it pins two things the bead calls out:
+//!   1. forward-chaining materialization (RDFS + a small OWL-RL fragment) is correct with
+//!      `explain` off, and
+//!   2. the `explain` surface is gated by the feature flag from BOTH cfg arms (the
+//!      `explain_off` / `explain_on` modules below each compile under exactly one arm).
+//!
+//! It exercises the REAL `materialize` / `materialize_rdfs` / `materialize_owl_rl` /
+//! `MaterializedGraph` path, not a mock.
+
+use rustc_hash::FxHashSet;
+use sparq_core::dict::{Dict, Id};
+use sparq_reason::{
+    materialize, materialize_owl_rl, materialize_rdfs, MaterializedGraph, Profile,
+};
+
+fn ex(dict: &mut Dict, l: &str) -> Id {
+    dict.intern_iri(&format!("http://ex/{l}"))
+}
+
+fn rdfs_ids(dict: &mut Dict) -> (Id, Id, Id, Id, Id) {
+    use oxrdf::vocab::{rdf, rdfs};
+    (
+        dict.intern_iri(rdf::TYPE.as_str()),
+        dict.intern_iri(rdfs::SUB_CLASS_OF.as_str()),
+        dict.intern_iri(rdfs::SUB_PROPERTY_OF.as_str()),
+        dict.intern_iri(rdfs::DOMAIN.as_str()),
+        dict.intern_iri(rdfs::RANGE.as_str()),
+    )
+}
+
+/// Does the closure contain this triple?
+fn has(set: &FxHashSet<[Id; 3]>, s: Id, p: Id, o: Id) -> bool {
+    set.contains(&[s, p, o])
+}
+
+#[test]
+fn rdfs_forward_chaining_correct_default_off() {
+    // Dog sc Mammal sc Animal ; rex a Dog. rdfs11 closes the chain; rdfs9 types rex up.
+    let mut dict = Dict::new();
+    let (ty, sc, _sp, _dom, _rng) = rdfs_ids(&mut dict);
+    let (dog, mammal, animal, rex) = (
+        ex(&mut dict, "Dog"),
+        ex(&mut dict, "Mammal"),
+        ex(&mut dict, "Animal"),
+        ex(&mut dict, "rex"),
+    );
+    let mut triples = vec![[dog, sc, mammal], [mammal, sc, animal], [rex, ty, dog]];
+    let before = triples.len();
+    let added = materialize_rdfs(&mut dict, &mut triples);
+    assert!(added > 0, "RDFS closure must add entailed triples");
+    assert_eq!(triples.len(), before + added, "added count must match growth");
+
+    let set: FxHashSet<[Id; 3]> = triples.iter().copied().collect();
+    // rdfs11: (Dog sc Animal) is the transitive-closure schema fact.
+    assert!(has(&set, dog, sc, animal), "rdfs11: Dog sc Animal");
+    // rdfs9: (rex a Mammal) and (rex a Animal) follow from the chain.
+    assert!(has(&set, rex, ty, mammal), "rdfs9: rex a Mammal");
+    assert!(has(&set, rex, ty, animal), "rdfs9: rex a Animal");
+    // A triple that is NOT entailed must be absent (non-vacuity guard).
+    assert!(!has(&set, animal, ty, rex), "non-entailed triple leaked");
+
+    // Idempotence: a second pass adds nothing (the materialization is a fixpoint).
+    let again = materialize_rdfs(&mut dict, &mut triples);
+    assert_eq!(again, 0, "materialization must be idempotent");
+}
+
+#[test]
+fn rdfs_domain_range_subproperty_default_off() {
+    // p sp q ; q domain C ; q range D ; a p b — rdfs7 lifts p→q, rdfs2/rdfs3 type the
+    // endpoints. Exercises the dom/range/subproperty rules, not just subclass.
+    let mut dict = Dict::new();
+    let (ty, _sc, sp, dom, rng) = rdfs_ids(&mut dict);
+    let (p, q, c, d, a, b) = (
+        ex(&mut dict, "p"),
+        ex(&mut dict, "q"),
+        ex(&mut dict, "C"),
+        ex(&mut dict, "D"),
+        ex(&mut dict, "a"),
+        ex(&mut dict, "b"),
+    );
+    let mut triples = vec![[p, sp, q], [q, dom, c], [q, rng, d], [a, p, b]];
+    let added = materialize_rdfs(&mut dict, &mut triples);
+    assert!(added > 0);
+    let set: FxHashSet<[Id; 3]> = triples.iter().copied().collect();
+    assert!(has(&set, a, q, b), "rdfs7: a q b (p sp q)");
+    assert!(has(&set, a, ty, c), "rdfs2: a type C (domain of q)");
+    assert!(has(&set, b, ty, d), "rdfs3: b type D (range of q)");
+}
+
+#[test]
+fn owl_rl_fragment_correct_default_off() {
+    // Small OWL-RL fragment: inverseOf, TransitiveProperty, SymmetricProperty. Mirrors the
+    // crate's own owl.rs unit test, but asserted through the DEFAULT-OFF public entry point.
+    let mut dict = Dict::new();
+    let ty = dict.intern_iri(oxrdf::vocab::rdf::TYPE.as_str());
+    let owl = |dict: &mut Dict, frag: &str| {
+        dict.intern_iri(&format!("http://www.w3.org/2002/07/owl#{frag}"))
+    };
+    let (parent, child, anc, knows, a, b, c) = (
+        ex(&mut dict, "parentOf"),
+        ex(&mut dict, "childOf"),
+        ex(&mut dict, "ancestorOf"),
+        ex(&mut dict, "knows"),
+        ex(&mut dict, "a"),
+        ex(&mut dict, "b"),
+        ex(&mut dict, "c"),
+    );
+    let inv = owl(&mut dict, "inverseOf");
+    let trans = owl(&mut dict, "TransitiveProperty");
+    let sym = owl(&mut dict, "SymmetricProperty");
+    let mut triples = vec![
+        [parent, inv, child], // parentOf inverseOf childOf
+        [anc, ty, trans],     // ancestorOf a TransitiveProperty
+        [knows, ty, sym],     // knows a SymmetricProperty
+        [a, parent, b],
+        [a, anc, b],
+        [b, anc, c],
+        [a, knows, b],
+    ];
+    // Cross-check the dedicated entry point against the generic dispatcher: identical input
+    // must close to the identical triple set (both routes are the supported default-OFF API).
+    let mut direct = triples.clone();
+    materialize_owl_rl(&mut dict, &mut direct);
+    let added = materialize(Profile::OwlRl, &mut dict, &mut triples);
+    assert!(added > 0, "OWL-RL closure must add entailed triples");
+    let set: FxHashSet<[Id; 3]> = triples.iter().copied().collect();
+    let direct_set: FxHashSet<[Id; 3]> = direct.iter().copied().collect();
+    assert_eq!(set, direct_set, "materialize(OwlRl) must match materialize_owl_rl");
+
+    assert!(has(&set, b, child, a), "prp-inv: b childOf a");
+    assert!(has(&set, a, anc, c), "prp-trp: a ancestorOf c");
+    assert!(has(&set, b, knows, a), "prp-symp: b knows a");
+    // A transitive property must NOT run backwards (non-vacuity guard).
+    assert!(!has(&set, c, anc, a), "transitive must not run backwards");
+
+    // Idempotence via the generic entry point.
+    assert_eq!(materialize(Profile::OwlRl, &mut dict, &mut triples), 0);
+}
+
+#[test]
+fn materialized_graph_incremental_correct_default_off() {
+    // The incremental MaterializedGraph handle is available in BOTH feature states (only
+    // its `why()` explanation method is explain-gated). Confirm insert/delete maintenance
+    // is correct with explain OFF.
+    let mut dict = Dict::new();
+    let (ty, sc, _sp, _dom, _rng) = rdfs_ids(&mut dict);
+    let (dog, mammal, animal, rex, fido) = (
+        ex(&mut dict, "Dog"),
+        ex(&mut dict, "Mammal"),
+        ex(&mut dict, "Animal"),
+        ex(&mut dict, "rex"),
+        ex(&mut dict, "fido"),
+    );
+    let mut g = MaterializedGraph::new(
+        &mut dict,
+        &[[dog, sc, mammal], [mammal, sc, animal], [rex, ty, dog]],
+    );
+    assert!(g.contains(&[rex, ty, animal]), "initial closure types rex up");
+
+    // Insert a second individual: its typing must close up the same chain.
+    g.insert(&[[fido, ty, dog]]);
+    assert!(g.contains(&[fido, ty, animal]), "insert maintains the closure");
+
+    // Delete the only support of (rex a animal): it must leave the closure.
+    g.delete(&[[rex, ty, dog]]);
+    assert!(!g.contains(&[rex, ty, animal]), "delete retracts the entailment");
+    // fido's typing is independent and must survive.
+    assert!(g.contains(&[fido, ty, animal]), "unrelated entailment survives the delete");
+    // The schema chain is untouched by an ABox delete.
+    assert!(g.contains(&[dog, sc, animal]), "schema closure intact");
+}
+
+/// Compile-out guard (default arm): with `explain` OFF this module compiles and uses ONLY
+/// the materialization surface — it names NO explain symbol. It is the supported
+/// default-OFF API. Compiling only under `not(feature = "explain")` pins the default arm.
+#[cfg(not(feature = "explain"))]
+mod explain_off {
+    use sparq_core::dict::Dict;
+    use sparq_reason::MaterializedGraph;
+
+    #[test]
+    fn graph_usable_without_explain_symbols() {
+        let mut dict = Dict::new();
+        let a = dict.intern_iri("http://ex/a");
+        let ty = dict.intern_iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+        let sc = dict.intern_iri("http://www.w3.org/2000/01/rdf-schema#subClassOf");
+        let (cc, dd) = (dict.intern_iri("http://ex/C"), dict.intern_iri("http://ex/D"));
+        let g = MaterializedGraph::new(&mut dict, &[[cc, sc, dd], [a, ty, cc]]);
+        assert!(g.contains(&[a, ty, dd]));
+        // Sanity: the closure is non-trivial (base 2 + the derived typing).
+        assert!(g.len() >= 3);
+    }
+}
+
+/// Symmetric guard (feature arm): with `explain` ON the `why()` method IS present and
+/// returns a proof for a derived triple. Compiling this only under the feature pins that
+/// the gate flips the surface on, complementing `explain_off` above (so the two together
+/// cover BOTH cfg arms).
+#[cfg(feature = "explain")]
+mod explain_on {
+    use sparq_core::dict::Dict;
+    use sparq_reason::MaterializedGraph;
+
+    #[test]
+    fn why_present_when_feature_on() {
+        let mut dict = Dict::new();
+        let a = dict.intern_iri("http://ex/a");
+        let ty = dict.intern_iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type");
+        let sc = dict.intern_iri("http://www.w3.org/2000/01/rdf-schema#subClassOf");
+        let (cc, dd) = (dict.intern_iri("http://ex/C"), dict.intern_iri("http://ex/D"));
+        let g = MaterializedGraph::new(&mut dict, &[[cc, sc, dd], [a, ty, cc]]);
+        let tree = g.why(&dict, [a, ty, dd]).expect("derived triple must explain");
+        assert!(!tree.nodes().is_empty());
+        assert_eq!(tree.conclusion()[1], dict.term(ty).to_string());
+    }
+}

--- a/crates/sparq-reason/tests/incremental_explain_unit.rs
+++ b/crates/sparq-reason/tests/incremental_explain_unit.rs
@@ -1,0 +1,346 @@
+//! Focused, ISOLATED unit tests for `src/incremental_explain.rs` — the
+//! delta-with-explanation path ([OPUS-4.8] sq-bif.11).
+//!
+//! Before this file `incremental_explain.rs` (~1188 LOC) had no focused coverage: it was
+//! exercised only transitively by the big randomized differential sweeps in
+//! `explain_rdfs.rs` / `explain_owl.rs` / `explain_n3.rs`. Those sweeps prove the prover is
+//! sound over large random closures, but they do NOT isolate the incremental
+//! delta-WITH-explanation behaviour: `insert` a fact and explain its newly-derived
+//! consequence; `delete` a support and watch the explanation update (drop the retracted
+//! leaf, find an alternative support, or report the triple gone).
+//!
+//! These are small, hand-checked fixtures over the REAL `why()` / `why_with()` provers on
+//! all three maintenance handles (RDFS, OWL, N3), plus the `ExplainOpts` cap surface. They
+//! assert structural proof invariants directly (leaves currently asserted, conclusion
+//! correct, premises-before-conclusion, retracted leaf absent) rather than reusing the
+//! heavyweight naive oracle, keeping each test independent and fast.
+
+#![cfg(feature = "explain")]
+
+use rustc_hash::FxHashSet;
+use sparq_core::dict::{Dict, Id};
+use sparq_reason::n3::Term;
+use sparq_reason::{
+    ExplainOpts, MaterializedGraph, MaterializedN3Graph, MaterializedOwlGraph, N3Mode, OwlMode,
+    ProofTree,
+};
+
+fn ex(dict: &mut Dict, l: &str) -> Id {
+    dict.intern_iri(&format!("http://ex/{l}"))
+}
+
+fn rdfs_ids(dict: &mut Dict) -> (Id, Id, Id, Id, Id) {
+    use oxrdf::vocab::{rdf, rdfs};
+    (
+        dict.intern_iri(rdf::TYPE.as_str()),
+        dict.intern_iri(rdfs::SUB_CLASS_OF.as_str()),
+        dict.intern_iri(rdfs::SUB_PROPERTY_OF.as_str()),
+        dict.intern_iri(rdfs::DOMAIN.as_str()),
+        dict.intern_iri(rdfs::RANGE.as_str()),
+    )
+}
+
+fn render(dict: &Dict, t: [Id; 3]) -> [String; 3] {
+    [dict.term(t[0]).to_string(), dict.term(t[1]).to_string(), dict.term(t[2]).to_string()]
+}
+
+/// Lightweight structural invariants every well-formed [`ProofTree`] must satisfy,
+/// independent of the rule table: non-empty, root last, premises strictly before their
+/// node, exactly one root reachable, and every conclusion well-formed (3 non-empty terms).
+fn assert_structurally_sound(tree: &ProofTree, expect_conclusion: &[String; 3]) {
+    let nodes = tree.nodes();
+    assert!(!nodes.is_empty(), "empty proof");
+    assert_eq!(tree.root() as usize, nodes.len() - 1, "root must be the last node");
+    assert_eq!(tree.conclusion(), expect_conclusion, "wrong conclusion");
+    for (i, n) in nodes.iter().enumerate() {
+        for &p in &n.premises {
+            assert!((p as usize) < i, "node {i}: premise {p} not strictly before it");
+        }
+        assert!(!n.rule.is_empty(), "node {i}: empty rule label");
+        for term in &n.conclusion {
+            assert!(!term.is_empty(), "node {i}: empty term in conclusion");
+        }
+        if n.rule == "asserted" {
+            assert!(n.premises.is_empty(), "node {i}: asserted leaf with premises");
+        }
+    }
+}
+
+/// The set of `asserted`-leaf conclusions of a proof (the facts the proof actually leans on
+/// from the base; axioms are not base facts).
+fn asserted_leaves(tree: &ProofTree) -> Vec<[String; 3]> {
+    tree.nodes()
+        .iter()
+        .filter(|n| n.rule == "asserted")
+        .map(|n| n.conclusion.clone())
+        .collect()
+}
+
+// ════════════════════════════════════════════════════════════════════════════════════════
+// RDFS — MaterializedGraph: delta-with-explanation
+// ════════════════════════════════════════════════════════════════════════════════════════
+
+#[test]
+fn rdfs_insert_then_explain_new_derivation() {
+    // Base schema only (Dog sc Mammal sc Animal). Insert the ABox fact (rex a Dog) and
+    // explain the NEWLY-derived (rex a Animal): the proof must be sound, conclude the right
+    // triple, and have a top rule of rdfs9 (typing up the subclass chain).
+    let mut dict = Dict::new();
+    let (ty, sc, _sp, _dom, _rng) = rdfs_ids(&mut dict);
+    let (dog, mammal, animal, rex) = (
+        ex(&mut dict, "Dog"),
+        ex(&mut dict, "Mammal"),
+        ex(&mut dict, "Animal"),
+        ex(&mut dict, "rex"),
+    );
+    let mut g = MaterializedGraph::new(&mut dict, &[[dog, sc, mammal], [mammal, sc, animal]]);
+    // Before the insert the typing is not in the closure and has no proof.
+    assert!(!g.contains(&[rex, ty, animal]));
+    assert!(g.why(&dict, [rex, ty, animal]).is_none(), "no proof before the fact exists");
+
+    let added = g.insert(&[[rex, ty, dog]]);
+    assert!(added > 0, "insert must add the asserted fact + its consequences");
+    assert!(g.contains(&[rex, ty, animal]), "incremental closure types rex up");
+
+    let t = [rex, ty, animal];
+    let tree = g.why(&dict, t).expect("newly-derived triple must explain");
+    assert_structurally_sound(&tree, &render(&dict, t));
+    assert_eq!(
+        tree.nodes()[tree.root() as usize].rule,
+        "rdfs9",
+        "the typing-up step is rdfs9"
+    );
+    // Every asserted leaf is CURRENTLY in the base (the consistency model).
+    let base: FxHashSet<[String; 3]> = g.base_triples().map(|b| render(&dict, b)).collect();
+    for leaf in asserted_leaves(&tree) {
+        assert!(base.contains(&leaf), "proof leaf {leaf:?} not in the current base");
+    }
+    // The just-inserted fact is one of those leaves.
+    assert!(asserted_leaves(&tree).contains(&render(&dict, [rex, ty, dog])));
+}
+
+#[test]
+fn rdfs_retract_updates_explanation_to_alternative_support() {
+    // Two independent supports for (a type C): p sp q, q dom C, a p b, a q b. Retracting one
+    // support must keep (a type C) derivable and the explanation must NOT cite the retracted
+    // leaf; retracting BOTH must drop the triple and its proof.
+    let mut dict = Dict::new();
+    let (ty, _sc, sp, dom, _rng) = rdfs_ids(&mut dict);
+    let (p, q, c, a, b) = (
+        ex(&mut dict, "p"),
+        ex(&mut dict, "q"),
+        ex(&mut dict, "C"),
+        ex(&mut dict, "a"),
+        ex(&mut dict, "b"),
+    );
+    let mut g = MaterializedGraph::new(
+        &mut dict,
+        &[[p, sp, q], [q, dom, c], [a, p, b], [a, q, b]],
+    );
+    let t = [a, ty, c];
+    assert!(g.contains(&t));
+    let tree0 = g.why(&dict, t).expect("initial proof");
+    assert_structurally_sound(&tree0, &render(&dict, t));
+
+    // Retract (a p b): the triple survives via (a q b); the proof must not lean on (a p b).
+    g.delete(&[[a, p, b]]);
+    assert!(g.contains(&t), "alternative support keeps the triple");
+    let tree1 = g.why(&dict, t).expect("surviving support yields a proof");
+    assert_structurally_sound(&tree1, &render(&dict, t));
+    let retracted = render(&dict, [a, p, b]);
+    assert!(
+        tree1.nodes().iter().all(|n| n.conclusion != retracted),
+        "explanation still cites the retracted (a p b)"
+    );
+    let base: FxHashSet<[String; 3]> = g.base_triples().map(|x| render(&dict, x)).collect();
+    for leaf in asserted_leaves(&tree1) {
+        assert!(base.contains(&leaf), "stale leaf {leaf:?} after retraction");
+    }
+
+    // Retract the second support: triple leaves the closure, no proof.
+    g.delete(&[[a, q, b]]);
+    assert!(!g.contains(&t));
+    assert!(g.why(&dict, t).is_none(), "no proof for a triple that left the closure");
+
+    // Re-insert: support and proof return.
+    g.insert(&[[a, q, b]]);
+    assert!(g.contains(&t));
+    let tree2 = g.why(&dict, t).expect("re-inserted support restores the proof");
+    assert_structurally_sound(&tree2, &render(&dict, t));
+}
+
+#[test]
+fn rdfs_why_respects_node_cap() {
+    // A long subclass chain forces a multi-node proof; a tight max_nodes cap must make
+    // why_with abort (return None) rather than exceed it, while the default caps succeed.
+    let mut dict = Dict::new();
+    let (ty, sc, _sp, _dom, _rng) = rdfs_ids(&mut dict);
+    let chain: Vec<Id> = (0..8).map(|i| ex(&mut dict, &format!("C{i}"))).collect();
+    let rex = ex(&mut dict, "rex");
+    let mut base: Vec<[Id; 3]> = chain.windows(2).map(|w| [w[0], sc, w[1]]).collect();
+    base.push([rex, ty, chain[0]]);
+    let g = MaterializedGraph::new(&mut dict, &base);
+    let top = [rex, ty, chain[chain.len() - 1]];
+    assert!(g.contains(&top));
+
+    // Default caps: a proof exists.
+    let full = g.why(&dict, top).expect("default caps prove the deep chain");
+    assert!(full.nodes().len() > 2, "deep chain should need several nodes");
+    // Tight node cap: aborts to None.
+    let capped = g.why_with(&dict, top, ExplainOpts { max_depth: 128, max_nodes: 2 });
+    assert!(capped.is_none(), "max_nodes=2 must abort the deep proof");
+    // Tight depth cap: also aborts.
+    let depth_capped = g.why_with(&dict, top, ExplainOpts { max_depth: 1, max_nodes: 65_536 });
+    assert!(depth_capped.is_none(), "max_depth=1 must abort the deep proof");
+}
+
+// ════════════════════════════════════════════════════════════════════════════════════════
+// OWL — MaterializedOwlGraph: delta-with-explanation in both counting modes
+// ════════════════════════════════════════════════════════════════════════════════════════
+
+fn owl_iri(dict: &mut Dict, frag: &str) -> Id {
+    dict.intern_iri(&format!("http://www.w3.org/2002/07/owl#{frag}"))
+}
+
+#[test]
+fn owl_mono_insert_then_explain_inverse() {
+    // CountingMono fixture (inverseOf, no transitive property). Insert (a parentOf b) and
+    // explain the prp-inv consequence (b childOf a).
+    let mut dict = Dict::new();
+    let (parent, child, a, b) = (
+        ex(&mut dict, "parentOf"),
+        ex(&mut dict, "childOf"),
+        ex(&mut dict, "a"),
+        ex(&mut dict, "b"),
+    );
+    let inv = owl_iri(&mut dict, "inverseOf");
+    let mut g = MaterializedOwlGraph::new(&mut dict, &[[parent, inv, child]]);
+    assert_eq!(g.mode(), OwlMode::CountingMono, "no transitive prop => mono mode");
+    assert!(!g.contains(&[b, child, a]), "nothing derived before the edge exists");
+
+    g.insert(&mut dict, &[[a, parent, b]]);
+    let t = [b, child, a];
+    assert!(g.contains(&t), "prp-inv fires incrementally");
+    let tree = g.why(&dict, t).expect("inverse consequence must explain");
+    assert_structurally_sound(&tree, &render(&dict, t));
+    // The proof's asserted leaves are all currently in the base.
+    let base: FxHashSet<[String; 3]> = g.base_triples().map(|x| render(&dict, x)).collect();
+    for leaf in asserted_leaves(&tree) {
+        assert!(base.contains(&leaf), "stale OWL leaf {leaf:?}");
+    }
+    assert!(asserted_leaves(&tree).contains(&render(&dict, [a, parent, b])));
+}
+
+#[test]
+fn owl_fixpoint_transitive_insert_retract_explanation() {
+    // CountingFixpoint fixture (ancestorOf a TransitiveProperty). Inserting the bridging
+    // edge derives (a ancestorOf c) via prp-trp; retracting it removes the derivation.
+    let mut dict = Dict::new();
+    let ty = dict.intern_iri(oxrdf::vocab::rdf::TYPE.as_str());
+    let (anc, a, b, c) = (
+        ex(&mut dict, "ancestorOf"),
+        ex(&mut dict, "a"),
+        ex(&mut dict, "b"),
+        ex(&mut dict, "c"),
+    );
+    let trans = owl_iri(&mut dict, "TransitiveProperty");
+    let mut g = MaterializedOwlGraph::new(
+        &mut dict,
+        &[[anc, ty, trans], [a, anc, b]],
+    );
+    assert_eq!(g.mode(), OwlMode::CountingFixpoint, "transitive prop => fixpoint mode");
+    let derived = [a, anc, c];
+    assert!(!g.contains(&derived), "no bridge yet");
+
+    // Insert the bridge (b ancestorOf c): prp-trp now derives (a ancestorOf c).
+    g.insert(&mut dict, &[[b, anc, c]]);
+    assert!(g.contains(&derived), "prp-trp derives the transitive edge");
+    let tree = g.why(&dict, derived).expect("transitive consequence must explain");
+    assert_structurally_sound(&tree, &render(&dict, derived));
+    let base: FxHashSet<[String; 3]> = g.base_triples().map(|x| render(&dict, x)).collect();
+    for leaf in asserted_leaves(&tree) {
+        assert!(base.contains(&leaf), "stale transitive leaf {leaf:?}");
+    }
+
+    // Retract the bridge: the transitive edge and its explanation disappear.
+    g.delete(&mut dict, &[[b, anc, c]]);
+    assert!(!g.contains(&derived), "retracting the bridge removes the transitive edge");
+    assert!(g.why(&dict, derived).is_none(), "no proof once the bridge is gone");
+}
+
+// ════════════════════════════════════════════════════════════════════════════════════════
+// N3 — MaterializedN3Graph: delta-with-explanation (re-derive-per-call prover)
+// ════════════════════════════════════════════════════════════════════════════════════════
+
+const N3_RULES: &str = r#"
+@prefix : <http://ex/> .
+{ ?x :parent ?y } => { ?x :ancestor ?y } .
+{ ?x :ancestor ?y . ?y :ancestor ?z } => { ?x :ancestor ?z } .
+"#;
+
+fn n3_ex(local: &str) -> Term {
+    Term::Iri(format!("http://ex/{local}"))
+}
+
+fn n3_render(f: &[Term; 3]) -> [String; 3] {
+    f.clone().map(|t| match t {
+        Term::Iri(i) => format!("<{i}>"),
+        other => panic!("unexpected term in fixture: {other:?}"),
+    })
+}
+
+#[test]
+fn n3_insert_then_explain_transitive_chain() {
+    // a parent b ; b parent c. Insert and explain the transitively-derived (a ancestor c):
+    // its asserted leaves must all be currently-asserted base facts, and the conclusion the
+    // ancestor edge.
+    let base = vec![[n3_ex("a"), n3_ex("parent"), n3_ex("b")]];
+    let mut g = MaterializedN3Graph::new(N3_RULES, &base).expect("rules parse");
+    assert_eq!(g.mode(), N3Mode::Counting);
+    let target = [n3_ex("a"), n3_ex("ancestor"), n3_ex("c")];
+    assert!(!g.contains(&target), "no chain to c yet");
+
+    g.insert(&[[n3_ex("b"), n3_ex("parent"), n3_ex("c")]]);
+    assert!(g.contains(&target), "the transitive ancestor edge is derived after the insert");
+    let tree = g.why(&target).expect("derived N3 fact must explain");
+    assert_structurally_sound(&tree, &n3_render(&target));
+    // `MaterializedN3Graph` exposes no base iterator, but every asserted leaf is necessarily
+    // also in the closure; check that, and that the just-inserted bridge is one of them.
+    let closure_set: FxHashSet<[String; 3]> =
+        g.closure().iter().map(n3_render).collect();
+    for leaf in asserted_leaves(&tree) {
+        assert!(closure_set.contains(&leaf), "stale N3 leaf {leaf:?}");
+    }
+    assert!(
+        asserted_leaves(&tree).contains(&n3_render(&[n3_ex("b"), n3_ex("parent"), n3_ex("c")])),
+        "the inserted bridge fact must be an asserted leaf of the proof"
+    );
+    // The root rule is one of the document's forward rules.
+    assert!(
+        tree.nodes()[tree.root() as usize].rule.starts_with("n3-rule-"),
+        "derived N3 fact's top step names a rule"
+    );
+}
+
+#[test]
+fn n3_retract_drops_explanation() {
+    // a parent b ; b parent c derives a ancestor c. Retract (b parent c): the chain (and its
+    // explanation) to c is gone; the direct (a ancestor b) survives.
+    let base = vec![
+        [n3_ex("a"), n3_ex("parent"), n3_ex("b")],
+        [n3_ex("b"), n3_ex("parent"), n3_ex("c")],
+    ];
+    let mut g = MaterializedN3Graph::new(N3_RULES, &base).expect("rules parse");
+    let to_c = [n3_ex("a"), n3_ex("ancestor"), n3_ex("c")];
+    let to_b = [n3_ex("a"), n3_ex("ancestor"), n3_ex("b")];
+    assert!(g.contains(&to_c));
+    assert!(g.why(&to_c).is_some(), "chain to c explains before the retraction");
+
+    g.delete(&[[n3_ex("b"), n3_ex("parent"), n3_ex("c")]]);
+    assert!(!g.contains(&to_c), "no path to c after retracting the bridge");
+    assert!(g.why(&to_c).is_none(), "no explanation for a fact that left the closure");
+    // The independent (a ancestor b) survives and still explains.
+    assert!(g.contains(&to_b));
+    let tree = g.why(&to_b).expect("surviving fact still explains");
+    assert_structurally_sound(&tree, &n3_render(&to_b));
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — test-coverage PR for **sq-bif.11** (decomposed from sq-bif). Touches `crates/sparq-reason/tests/` ONLY; no production `src/` logic changed.

Closes the two honest both-feature-state / isolated-coverage gaps the bead assessment found for the `explain` feature.

## What this adds

**`tests/default_off_materialization.rs`** (NOT feature-gated — runs in BOTH states)
- Forward-chaining materialization is correct with `explain` OFF: RDFS (rdfs2/3/7/9/11), a small OWL-RL fragment (`prp-inv` / `prp-trp` / `prp-symp`) routed through the generic `materialize(Profile::OwlRl, …)` dispatcher and cross-checked against `materialize_owl_rl`, and incremental `MaterializedGraph` insert/delete maintenance.
- Idempotence (second pass adds 0) and non-entailment guards (a transitive property must not run backwards; absent triples stay absent) keep the assertions non-vacuous.
- Symmetric `explain_off` / `explain_on` modules pin the feature gate from BOTH `cfg` arms: the default arm uses only the materialization surface (names no explain symbol), the feature arm asserts `why()` is present and returns a proof.

**`tests/incremental_explain_unit.rs`** (`#![cfg(feature = "explain")]`)
- Focused, isolated coverage of the delta-WITH-explanation path in `src/incremental_explain.rs` (~1188 LOC), which was previously exercised only transitively by the large randomized differential sweeps:
  - RDFS: insert-then-explain a newly-derived triple (top rule `rdfs9`, leaves currently asserted); retract one of two supports and confirm the explanation no longer cites the retracted leaf (alternative support found); retract both → triple gone → `why()` returns `None`; re-insert restores the proof.
  - `ExplainOpts` caps: a deep subclass chain proves under default caps but aborts to `None` under `max_nodes=2` and under `max_depth=1`.
  - OWL: `CountingMono` (`prp-inv`) insert-then-explain; `CountingFixpoint` (`prp-trp`) insert-then-explain and retract-to-gone.
  - N3: transitive-chain insert-then-explain (asserted leaves in the closure; top step `n3-rule-*`) and retract-drops-explanation while an independent fact survives.
- Assertions are non-vacuous: positive `contains` + negative non-entailment + structural proof invariants (root last, premises strictly before their node, asserted leaves premise-free).

## Feature states verified (both GREEN)

| command | state |
|---|---|
| `cargo clippy -p sparq-reason --all-targets -- -D warnings` | default (explain OFF) |
| `cargo test -p sparq-reason` | default (explain OFF) |
| `cargo clippy -p sparq-reason --all-targets --features explain -- -D warnings` | explain ON |
| `cargo test -p sparq-reason --features explain` | explain ON |

In the default state `incremental_explain_unit.rs` compiles to 0 tests (correct — it is feature-gated) and `default_off_materialization.rs` runs its 4 materialization tests + the `explain_off` compile-out guard. No public API, feature, or semantics changed, so no README/SKILL update is warranted (both already document the `explain` feature, its opt-in/default-OFF boundary, the `why()`-is-a-witness semantics, and the `ExplainOpts` caps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)