### PR TITLE
test(sparq-engine): vectorized columnar differential + result-cache write-invalidation (sq-bif.12) [OPUS-4.8]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -193,6 +193,36 @@ jobs:
             crate: sparq-engine
             features: txn
             test: true
+          # [OPUS-4.8] sq-bif.12: vectorized (columnar / vector-at-a-time) primitives. The
+          # `chunk` module (`pub mod chunk` + the `DataChunk`/`VecCmp`/`SelVec` re-exports),
+          # its 9 in-src unit tests AND the new end-to-end differential suite
+          # (`tests/vectorized_exec_differential.rs`, `#![cfg(feature = "vectorized")]`,
+          # which proves the columnar gather/selection kernels are multiset-equal to the
+          # scalar SPARQL FILTER path) are ALL `#[cfg(feature = "vectorized")]`, so the
+          # default build (and ci.yml's `--workspace --all-targets` archive, which passes NO
+          # `--features`) compiled them EMPTY and ran ZERO of them — the silent gap this lane
+          # exists to close, and `vectorized` had NO leg here. No new dep (`vectorized = []`,
+          # only sparq-core's already-direct `Graph`/`Id`) and no `not(feature=…)`
+          # divergence, so one isolated leg (matching the per-feature engine legs above)
+          # covers it; verified `cargo nextest list -p sparq-engine --features vectorized`
+          # shows the previously-skipped differential tests.
+          - name: sparq-engine (vectorized)
+            crate: sparq-engine
+            features: vectorized
+            test: true
+          # [OPUS-4.8] sq-bif.12: the materialised-view / query-result cache. The `cache`
+          # module + the `ResultCache`/`CacheStats`/`is_cacheable` re-exports and the whole
+          # `tests/result_cache.rs` suite (`#![cfg(feature = "result-cache")]`, incl. the new
+          # INSERT/DELETE/UPDATE/CLEAR write-invalidation tests) are all
+          # `#[cfg(feature = "result-cache")]`, so the default build compiled them EMPTY and
+          # ran ZERO of them — `result-cache` had NO leg here (a pre-existing silent gap). No
+          # new dep (`result-cache = []`, std `HashMap`/`Mutex`/`Arc` only) and no
+          # `not(feature=…)` divergence, so one isolated leg covers it; verified `cargo
+          # nextest list -p sparq-engine --features result-cache` shows the result_cache tests.
+          - name: sparq-engine (result-cache)
+            crate: sparq-engine
+            features: result-cache
+            test: true
           # sparq-cli: the `dump` re-serializer (forwards sparq-engine/serialize-rdf).
           - name: sparq-cli (serialize-rdf)
             crate: sparq-cli

--- a/crates/sparq-engine/tests/result_cache.rs
+++ b/crates/sparq-engine/tests/result_cache.rs
@@ -231,3 +231,207 @@ fn clear_empties() {
     assert_eq!(cache.stats().entries, 0);
     assert_eq!(cache.capacity(), 4);
 }
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-bif.12) WRITE-INVALIDATION coverage.
+//
+// The existing tests above prove the *mechanism* (a version bump misses + reclaims
+// the stale generation). What was missing is the END-TO-END contract over the FOUR
+// real mutation shapes — INSERT / DELETE / UPDATE / CLEAR — driven through the actual
+// `Graph` mutation path: after a writer mutates and bumps the version (the documented
+// soundness contract), the next `get_or_eval` at the new version must be a MISS that
+// serves the POST-mutation result, and a stale generation must NEVER be served.
+//
+// The load-bearing assertion in each is the *value*: we don't merely count misses, we
+// assert the served result equals a FRESH evaluation of the mutated graph (so the test
+// fails if invalidation regressed to a stale read), and DIFFERS from the pre-mutation
+// snapshot (so it fails if the mutation never reached the served result).
+// ---------------------------------------------------------------------------
+
+/// Count `?s` (the number of bound rows) for an all-triples scan — a query whose
+/// result changes under any insert/delete, so it is a sharp staleness witness.
+const COUNT_Q: &str = "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o }";
+
+/// Extracts the integer COUNT value from a `QueryResult` (a `"<n>"^^xsd:integer`
+/// term) as a `usize` — the leading run of digits in the term's lexical form.
+fn cached_count(result: &sparq_engine::QueryResult) -> usize {
+    let term = result.rows[0][0].as_ref().unwrap().to_string();
+    term.chars()
+        .skip_while(|c| !c.is_ascii_digit())
+        .take_while(char::is_ascii_digit)
+        .collect::<String>()
+        .parse()
+        .unwrap()
+}
+
+/// The COUNT of a graph via a direct, uncached evaluation — the ground truth the
+/// cache must agree with after a mutation.
+fn count_of(graph: &Graph) -> usize {
+    cached_count(&query(graph, COUNT_Q).unwrap())
+}
+
+/// INSERT: after `apply_delta_nquads` adds a triple and the writer bumps the version,
+/// the cached COUNT at the new version is a MISS that serves the larger, fresh count —
+/// never the stale pre-insert count.
+#[test]
+fn insert_invalidates_via_version_bump() {
+    let mut graph = g(); // 3 triples
+    let cache = ResultCache::new(16);
+    let budget = QueryBudget::unlimited();
+    let q = parse(COUNT_Q);
+
+    let before = cache.get_or_eval(&graph, &q, 0, &budget).unwrap();
+    assert_eq!(cached_count(&before), 3);
+    assert_eq!(cache.stats().misses, 1);
+
+    // Writer mutates the graph IN PLACE and bumps its epoch.
+    graph
+        .apply_delta_nquads(
+            "<http://ex/d> <http://ex/p> \"4\"^^<http://www.w3.org/2001/XMLSchema#integer> .",
+            "",
+        )
+        .unwrap();
+    let version = 1u64;
+
+    let after = cache.get_or_eval(&graph, &q, version, &budget).unwrap();
+    assert_eq!(cache.stats().misses, 2, "the new version misses (invalidated)");
+    assert_eq!(cache.stats().hits, 0, "no stale hit was served");
+    // The served result is the FRESH post-insert count, and it grew.
+    assert_eq!(cached_count(&after), count_of(&graph));
+    assert_eq!(cached_count(&after), 4);
+    assert!(
+        cached_count(&after) > cached_count(&before),
+        "insert must increase the served count"
+    );
+    // The bumped read is itself now cached (a re-read at v1 is a hit on the fresh entry).
+    let again = cache.get_or_eval(&graph, &q, version, &budget).unwrap();
+    assert!(std::sync::Arc::ptr_eq(&after, &again));
+    assert_eq!(cache.stats().hits, 1);
+    assert_eq!(cache.stats().entries, 1, "stale v0 entry was reclaimed");
+}
+
+/// DELETE: after `apply_delta_nquads` removes a triple and the writer bumps the
+/// version, the cached COUNT at the new version serves the smaller, fresh count.
+#[test]
+fn delete_invalidates_via_version_bump() {
+    let mut graph = g(); // 3 triples
+    let cache = ResultCache::new(16);
+    let budget = QueryBudget::unlimited();
+    let q = parse(COUNT_Q);
+
+    let before = cache.get_or_eval(&graph, &q, 0, &budget).unwrap();
+    assert_eq!(cached_count(&before), 3);
+
+    // Retract `ex:a ex:p 1`.
+    graph
+        .apply_delta_nquads(
+            "",
+            "<http://ex/a> <http://ex/p> \"1\"^^<http://www.w3.org/2001/XMLSchema#integer> .",
+        )
+        .unwrap();
+
+    let after = cache.get_or_eval(&graph, &q, 1, &budget).unwrap();
+    assert_eq!(cache.stats().hits, 0, "no stale hit served after delete");
+    assert_eq!(cached_count(&after), count_of(&graph));
+    assert_eq!(cached_count(&after), 2);
+    assert!(
+        cached_count(&after) < cached_count(&before),
+        "delete must decrease the served count"
+    );
+}
+
+/// UPDATE (SPARQL `INSERT DATA`/`DELETE DATA` via `sparq_engine::update`, which returns
+/// a NEW graph): the writer queries the cache against the NEW graph at a bumped
+/// version, so the prior entry (keyed on the old version) is invalidated and the served
+/// result reflects the update. Also exercises a non-count query whose BOUND VALUE
+/// changes — the strongest staleness witness.
+#[test]
+fn sparql_update_invalidates_and_serves_new_binding() {
+    let graph0 = g(); // ex:a ex:p 1 . ex:b ex:p 2 . ex:c ex:p 3 .
+    let cache = ResultCache::new(16);
+    let budget = QueryBudget::unlimited();
+    // The object bound to ex:a — changes when the update rewrites it.
+    let q = parse("PREFIX ex: <http://ex/> SELECT ?o WHERE { ex:a ex:p ?o }");
+
+    let before = cache.get_or_eval(&graph0, &q, 0, &budget).unwrap();
+    let o_before = before.rows[0][0].as_ref().unwrap().to_string();
+    assert!(o_before.contains('1'), "ex:a starts bound to 1, got {o_before}");
+
+    // SPARQL UPDATE: rebind ex:a from 1 to 99. `update` rebuilds a fresh graph.
+    let graph1 = sparq_engine::update(
+        &graph0,
+        "PREFIX ex: <http://ex/> DELETE DATA { ex:a ex:p 1 } ; INSERT DATA { ex:a ex:p 99 }",
+    )
+    .unwrap();
+
+    // Writer routes the read at the bumped version against the UPDATED graph.
+    let after = cache.get_or_eval(&graph1, &q, 1, &budget).unwrap();
+    assert_eq!(cache.stats().hits, 0, "no stale binding served after UPDATE");
+    let o_after = after.rows[0][0].as_ref().unwrap().to_string();
+    assert!(o_after.contains("99"), "ex:a must now bind to 99, got {o_after}");
+    assert_ne!(o_before, o_after, "the served binding changed after the UPDATE");
+    // It matches a fresh, uncached evaluation of the updated graph.
+    let fresh = query(&graph1, "PREFIX ex: <http://ex/> SELECT ?o WHERE { ex:a ex:p ?o }").unwrap();
+    assert_eq!(o_after, fresh.rows[0][0].as_ref().unwrap().to_string());
+}
+
+/// CLEAR (delete every triple + bump): the cached non-empty result is invalidated and
+/// the new version serves the EMPTY result of the cleared graph — the prior, non-empty
+/// generation is never served and is reclaimed.
+#[test]
+fn clear_invalidates_to_empty_result() {
+    let mut graph = g(); // 3 triples
+    let cache = ResultCache::new(16);
+    let budget = QueryBudget::unlimited();
+    let rows_q = parse("SELECT ?s WHERE { ?s ?p ?o }");
+
+    let before = cache.get_or_eval(&graph, &rows_q, 0, &budget).unwrap();
+    assert_eq!(before.rows.len(), 3, "three rows before CLEAR");
+    assert_eq!(cache.stats().entries, 1);
+
+    // CLEAR the default graph: retract all three triples.
+    graph
+        .apply_delta_nquads(
+            "",
+            "<http://ex/a> <http://ex/p> \"1\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n\
+             <http://ex/b> <http://ex/p> \"2\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n\
+             <http://ex/c> <http://ex/p> \"3\"^^<http://www.w3.org/2001/XMLSchema#integer> .",
+        )
+        .unwrap();
+
+    let after = cache.get_or_eval(&graph, &rows_q, 1, &budget).unwrap();
+    assert_eq!(cache.stats().hits, 0, "the non-empty result was not re-served");
+    assert!(after.rows.is_empty(), "CLEARed graph yields an empty result");
+    assert_eq!(after.rows.len(), query(&graph, "SELECT ?s WHERE { ?s ?p ?o }").unwrap().rows.len());
+    assert_eq!(cache.stats().entries, 1, "the stale v0 entry was reclaimed, not kept");
+}
+
+/// Reusing the OLD version after a mutation is the documented caller bug — and the
+/// cache makes it observable (a stale HIT), which is exactly why the contract requires
+/// the writer to bump. This pins that boundary so a future change that silently started
+/// keying on something else would be caught by the contract test, not in production.
+#[test]
+fn stale_version_after_mutation_is_a_hit_contract_boundary() {
+    let mut graph = g();
+    let cache = ResultCache::new(16);
+    let budget = QueryBudget::unlimited();
+    let q = parse(COUNT_Q);
+
+    let before = cache.get_or_eval(&graph, &q, 0, &budget).unwrap();
+    assert_eq!(cached_count(&before), 3);
+
+    graph
+        .apply_delta_nquads(
+            "<http://ex/d> <http://ex/p> \"4\"^^<http://www.w3.org/2001/XMLSchema#integer> .",
+            "",
+        )
+        .unwrap();
+
+    // Caller forgot to bump: SAME version => stale hit (the documented hazard).
+    let stale = cache.get_or_eval(&graph, &q, 0, &budget).unwrap();
+    assert_eq!(cache.stats().hits, 1, "same-version read is a hit (no auto-detection)");
+    assert_eq!(cached_count(&stale), 3, "the stale (pre-insert) count is served");
+    // Bumping recovers correctness immediately.
+    let fresh = cache.get_or_eval(&graph, &q, 1, &budget).unwrap();
+    assert_eq!(cached_count(&fresh), 4);
+}

--- a/crates/sparq-engine/tests/vectorized_exec_differential.rs
+++ b/crates/sparq-engine/tests/vectorized_exec_differential.rs
@@ -1,0 +1,215 @@
+//! [OPUS-4.8] (sq-bif.12) End-to-end differential coverage for the opt-in `vectorized`
+//! (columnar / vector-at-a-time) execution path.
+//!
+//! The `chunk` module's in-`src` unit tests already cover the columnar PRIMITIVES in
+//! isolation (`from_rows`/`to_rows` round-trip, ragged rejection, `select_numeric`,
+//! `apply_selection`, the `NaN`-never-passes rule). What was missing — and what this
+//! file adds — is an END-TO-END check that drives the columnar kernels off a column
+//! produced by *real SPARQL execution* over a `Graph` and proves the survivors are
+//! **multiset-equal** to the rows a row-at-a-time scalar SPARQL `FILTER` keeps over the
+//! same data. That differential is the load-bearing invariant the M4 vectorisation
+//! roadmap rests on (`research/optimization-techniques.md`, bead `sq-hvfe`): a vector
+//! path may only be wired into the evaluator if it returns the *same* result the scalar
+//! path does.
+//!
+//! Only built under the opt-in `vectorized` feature; the whole file is empty otherwise
+//! so the default `cargo test` is unaffected (and the `vectorized` matrix leg in
+//! `.github/workflows/feature-matrix.yml` is what actually runs it in CI).
+#![cfg(feature = "vectorized")]
+
+use sparq_core::dict::Id;
+use sparq_core::Graph;
+use sparq_engine::{query, DataChunk, VecCmp};
+
+const XSD_INT: &str = "http://www.w3.org/2001/XMLSchema#integer";
+
+/// A graph of `n` `(ex:s{i}, ex:age, i)` integer-literal triples, plus a couple of
+/// NON-numeric `ex:name` triples so the scan column can contain cells the numeric
+/// kernel must reject (mirroring the row evaluator excluding a non-numeric FILTER
+/// operand). Returns the graph.
+fn ages_graph(n: usize) -> Graph {
+    let mut nt = String::new();
+    for i in 0..n {
+        nt.push_str(&format!(
+            "<http://ex/s{i}> <http://ex/age> \"{i}\"^^<{XSD_INT}> .\n"
+        ));
+    }
+    // Two non-numeric objects under a different predicate (never selected by an
+    // integer FILTER, but they DO live in the dictionary so a column built over them
+    // exercises the kernel's `numeric_value(...) == None` reject path).
+    nt.push_str("<http://ex/p1> <http://ex/name> \"alice\" .\n");
+    nt.push_str("<http://ex/p2> <http://ex/name> \"bob\" .\n");
+    Graph::load_str(&nt, "ntriples").unwrap()
+}
+
+const PFX: &str = "PREFIX ex: <http://ex/> PREFIX xsd: <http://www.w3.org/2001/XMLSchema#> ";
+
+/// The dictionary id of every `?o` bound by `query`, in row order. The query MUST
+/// project exactly one variable. Panics if a bound term is not in the dictionary
+/// (impossible here — every projected term was just read out of the same graph).
+fn object_ids(graph: &Graph, q: &str) -> Vec<Id> {
+    query(graph, &format!("{PFX}{q}"))
+        .unwrap()
+        .rows
+        .iter()
+        .map(|row| {
+            let term = row[0].as_ref().expect("projected ?o is bound");
+            graph.id_of(term).expect("a queried term is interned")
+        })
+        .collect()
+}
+
+/// A multiset (sorted vec) helper so we compare result *bags*, not order — the
+/// columnar path and the scalar FILTER path need not enumerate in the same order.
+fn bag(mut ids: Vec<Id>) -> Vec<Id> {
+    ids.sort_unstable();
+    ids
+}
+
+/// CORE DIFFERENTIAL: for a range of comparisons, the columnar
+/// `select_numeric` → `apply_selection` survivors equal (as a multiset) the object
+/// ids a scalar SPARQL `FILTER(?o <cmp> t)` returns over the same column. This drives
+/// the gather/selection kernels off a real-execution column AND ties them to the
+/// engine's actual scalar FILTER semantics.
+#[test]
+fn columnar_filter_multiset_equals_scalar_sparql() {
+    let n = 200;
+    let g = ages_graph(n);
+
+    // The full numeric column, exactly as the scalar engine sees it (row order of an
+    // unfiltered scan). This is the input batch the vector path would receive.
+    let all_ids = object_ids(&g, "SELECT ?o WHERE { ?s ex:age ?o }");
+    assert_eq!(all_ids.len(), n, "every age triple is scanned");
+    let chunk = DataChunk::from_columns(vec![all_ids.clone()], n).unwrap();
+
+    // (VecCmp kernel, equivalent SPARQL FILTER tail) pairs.
+    let cases: &[(VecCmp, &str)] = &[
+        (VecCmp::Gt(30.0), "FILTER(?o > 30)"),
+        (VecCmp::Ge(30.0), "FILTER(?o >= 30)"),
+        (VecCmp::Lt(10.0), "FILTER(?o < 10)"),
+        (VecCmp::Le(10.0), "FILTER(?o <= 10)"),
+        (VecCmp::Eq(42.0), "FILTER(?o = 42)"),
+        // Boundary: nothing passes (threshold above the max value).
+        (VecCmp::Gt((n as f64) + 5.0), "FILTER(?o > 205)"),
+        // Boundary: everything passes (threshold below the min value).
+        (VecCmp::Ge(0.0), "FILTER(?o >= 0)"),
+    ];
+
+    for (cmp, filter) in cases {
+        // Vector path: comparison kernel produces a selection vector, gather compacts.
+        let sel = chunk.select_numeric(&g, 0, *cmp);
+        let gathered = chunk.apply_selection(&sel);
+        let vec_ids: Vec<Id> = gathered.column(0).unwrap().to_vec();
+
+        // Scalar path: the engine's own row-at-a-time FILTER over the same triples.
+        let scalar_ids = object_ids(&g, &format!("SELECT ?o WHERE {{ ?s ex:age ?o {filter} }}"));
+
+        assert_eq!(
+            bag(vec_ids.clone()),
+            bag(scalar_ids.clone()),
+            "columnar {cmp:?} survivors must be the SAME bag as scalar `{filter}` \
+             (vec={} scalar={})",
+            vec_ids.len(),
+            scalar_ids.len()
+        );
+        // The selection-vector length must equal the gathered row count (gather is the
+        // faithful compaction of the selection, not a re-filter).
+        assert_eq!(sel.len(), gathered.len());
+        assert_eq!(gathered.len(), scalar_ids.len());
+    }
+}
+
+/// The kernel rejects NON-numeric cells exactly as the scalar FILTER does: a column
+/// containing the two `ex:name` string literals yields ZERO survivors for any numeric
+/// comparison, matching a scalar `FILTER(?o > -1)` over those same string objects
+/// (which is a type error per row → row excluded → empty result).
+#[test]
+fn non_numeric_column_cells_are_rejected_like_scalar() {
+    let g = ages_graph(8);
+    let name_ids = object_ids(&g, "SELECT ?o WHERE { ?s ex:name ?o }");
+    assert_eq!(name_ids.len(), 2, "two string-literal objects");
+    let chunk = DataChunk::from_columns(vec![name_ids], 2).unwrap();
+
+    for cmp in [
+        VecCmp::Gt(-1.0),
+        VecCmp::Ge(-1.0),
+        VecCmp::Lt(1e9),
+        VecCmp::Le(1e9),
+        VecCmp::Eq(0.0),
+    ] {
+        let sel = chunk.select_numeric(&g, 0, cmp);
+        assert!(
+            sel.is_empty(),
+            "{cmp:?} must reject every non-numeric cell (kernel)"
+        );
+    }
+
+    // Scalar reference: a numeric comparison over the string objects returns nothing.
+    let scalar = object_ids(&g, "SELECT ?o WHERE { ?s ex:name ?o FILTER(?o > -1) }");
+    assert!(scalar.is_empty(), "scalar FILTER also excludes string objects");
+}
+
+/// A two-column chunk (subject id + age id) gathered by a numeric selection on the
+/// AGE column keeps the matching SUBJECT ids aligned — the gather is row-preserving
+/// across all columns, so the surviving `(subject, age)` pairs are exactly the pairs a
+/// scalar `SELECT ?s ?o WHERE { ?s ex:age ?o FILTER(?o >= t) }` binds. Proves the
+/// selection kernel does not desynchronise columns.
+#[test]
+fn gather_keeps_columns_row_aligned_vs_scalar_pairs() {
+    let n = 50;
+    let g = ages_graph(n);
+    let pfx = PFX;
+
+    // Build a (subject, age) two-column batch from one ordered scan so the columns are
+    // row-aligned by construction.
+    let rows = query(&g, &format!("{pfx}SELECT ?s ?o WHERE {{ ?s ex:age ?o }}"))
+        .unwrap()
+        .rows;
+    let subj: Vec<Id> = rows
+        .iter()
+        .map(|r| g.id_of(r[0].as_ref().unwrap()).unwrap())
+        .collect();
+    let age: Vec<Id> = rows
+        .iter()
+        .map(|r| g.id_of(r[1].as_ref().unwrap()).unwrap())
+        .collect();
+    let chunk = DataChunk::from_columns(vec![subj, age], rows.len()).unwrap();
+
+    // Filter on the AGE column (index 1), keep both columns.
+    let t = 25.0;
+    let sel = chunk.select_numeric(&g, 1, VecCmp::Ge(t));
+    let gathered = chunk.apply_selection(&sel);
+
+    // The surviving (subject, age) id pairs from the vector path.
+    let mut vec_pairs: Vec<(Id, Id)> = gathered
+        .column(0)
+        .unwrap()
+        .iter()
+        .copied()
+        .zip(gathered.column(1).unwrap().iter().copied())
+        .collect();
+    vec_pairs.sort_unstable();
+
+    // The scalar engine's (subject, age) id pairs for the same FILTER.
+    let mut scalar_pairs: Vec<(Id, Id)> = query(
+        &g,
+        &format!("{pfx}SELECT ?s ?o WHERE {{ ?s ex:age ?o FILTER(?o >= {t}) }}"),
+    )
+    .unwrap()
+    .rows
+    .iter()
+    .map(|r| {
+        (
+            g.id_of(r[0].as_ref().unwrap()).unwrap(),
+            g.id_of(r[1].as_ref().unwrap()).unwrap(),
+        )
+    })
+    .collect();
+    scalar_pairs.sort_unstable();
+
+    assert_eq!(
+        vec_pairs, scalar_pairs,
+        "gathered (subject, age) pairs must match the scalar FILTER's pairs exactly"
+    );
+    assert!(!vec_pairs.is_empty(), "the FILTER must keep some rows (non-vacuous)");
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — bead `sq-bif.12` (parent `sq-bif`: comprehensive correctness tests across all packages + all features + CI coverage gate).

## What

End-to-end test coverage for two opt-in, **default-OFF** `sparq-engine` features that had a confirmed gap — **neither had a leg in `feature-matrix.yml`**, so the default-feature CI archive (which passes NO `--features`) compiled their suites EMPTY and ran ZERO of them.

### 1. `vectorized` — columnar path multiset-equal to the scalar path
`tests/vectorized_exec_differential.rs` (`#![cfg(feature = "vectorized")]`) drives the columnar gather/selection kernels (`DataChunk::select_numeric` → `apply_selection`) off a column produced by **real SPARQL execution** over a `Graph`, and proves the survivors are **multiset-equal** to the rows the row-at-a-time scalar SPARQL `FILTER` keeps over the same data — the load-bearing M4 vectorisation invariant (`sq-hvfe`). The `chunk` module's in-`src` unit tests already cover the primitives in isolation; this is the missing **end-to-end differential**:
- `Gt`/`Ge`/`Lt`/`Le`/`Eq` each tied to the equivalent `FILTER(?o <cmp> t)`, plus all-pass / none-pass boundaries;
- non-numeric column cells rejected exactly as the scalar type-error exclusion;
- a two-column `(subject, age)` gather proving the selection keeps columns **row-aligned** vs the scalar `(s, o)` pairs (no desync).

### 2. `result-cache` — write-invalidation
`tests/result_cache.rs` gains **INSERT / DELETE / UPDATE / CLEAR** write-invalidation tests driven through the real `Graph` mutation path (`apply_delta_nquads` / `sparq_engine::update`). The prior suite covered hits/misses/TTL/`is_cacheable` and the version-bump *mechanism*; these add the end-to-end contract over the four real mutation shapes. Each is **non-vacuous** — it asserts the served result after a writer mutation + version bump equals a FRESH uncached evaluation of the mutated graph AND differs from the pre-mutation snapshot (so it fails on a stale read OR a missed mutation), plus the documented same-version stale-hit contract boundary.

### 3. CI
Adds isolated `sparq-engine (vectorized)` and `sparq-engine (result-cache)` legs to `.github/workflows/feature-matrix.yml`, so both suites are built, clippied (`--all-targets -D warnings`) and tested in CI. The aggregator gate (`ci-summary`) auto-discovers each leg by name as REQUIRED.

## Scope

Test-coverage bead — **no production `src` logic changed**. Touches only `crates/sparq-engine/tests/` + the two `sparq-engine` legs in `feature-matrix.yml`.

## Feature states verified (locally)

| state | clippy `--all-targets -D warnings` | `cargo test` |
| --- | --- | --- |
| default (features OFF) | green | green (new files compile empty) |
| `--features vectorized` | green | 3/3 differential tests pass |
| `--features result-cache` | green | 15/15 (5 new invalidation tests) pass |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
