### PR TITLE
feat(site): Turtle syntax highlighting in editor/results (#788, sq-8uew) [OPUS-4.8]

### DIFF
--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -380,6 +380,15 @@ export {
   tokenizeSparql,
 } from "./sparql-highlight.js";
 
+// [OPUS-4.8] sq-8uew — the Turtle/TriG/N-Triples/N-Quads highlighting tokenizer, the sibling
+// of `tokenizeSparql`. Shares the `SparqlTokenType` token classes (so one CSS palette styles
+// both) and powers the RDF-document highlighting in the playground results / dataset views.
+export {
+  type TurtleToken,
+  type TurtleTokenType,
+  tokenizeTurtle,
+} from "./turtle-highlight.js";
+
 export {
   type PrefixBinding,
   COMMON_PREFIXES,

--- a/packages/sparq-client/src/turtle-highlight.ts
+++ b/packages/sparq-client/src/turtle-highlight.ts
@@ -1,0 +1,273 @@
+// [OPUS-4.8] sq-8uew — a framework-agnostic Turtle/TriG/N-Triples/N-Quads tokenizer for
+// syntax highlighting.
+//
+// The sibling of `sparql-highlight.ts`: a pure `tokenizeTurtle(text)` over a string returning
+// a flat, gap-free token list a renderer wraps in styled spans. It is deliberately
+// DEPENDENCY-FREE and FRAMEWORK-AGNOSTIC (no DOM, no React) so the SAME tokenizer serves the
+// Next.js site results/dataset views and the Tauri 2 webview. It is a pragmatic LEXER for
+// highlighting, not an RDF parser: it never rejects input and always reproduces the source
+// exactly when the token texts are concatenated (the load-bearing property the overlay editor
+// relies on — the highlight layer must align with the source glyph-for-glyph).
+//
+// Coverage — the family of RDF text serialisations the lean wasm bundle reads and writes:
+//   * Turtle / TriG — `@prefix` / `@base` directives, the SPARQL-style `PREFIX` / `BASE`
+//     directives (Turtle 1.1), the `a` keyword, prefixed names (`foaf:name`, `:local`),
+//     IRIs (`<…>`), string literals (single / long / `^^datatype` / `@lang`), numbers,
+//     booleans, blank-node labels (`_:b`), `#` comments, and the `{ } [ ] ( ) ; , .`
+//     structural punctuation. TriG named-graph braces are just punctuation.
+//   * N-Triples / N-Quads — a strict subset of the above (only IRIs, strings, `_:` bnodes,
+//     and the `.` terminator; N-Quads adds a trailing graph IRI), highlighted by the same
+//     rules.
+//
+// The token TYPE set is intentionally identical to `SparqlTokenType` so the existing
+// `.sq-tok-*` CSS classes style both — no new palette, theme-following highlighting for free.
+// No performance claim is made here (this repo's work box is non-canonical).
+
+import type { SparqlToken, SparqlTokenType } from "./sparql-highlight.js";
+
+/** The lexical class of a highlighted Turtle/TriG/N-Triples/N-Quads token. Aliased to
+ * {@link SparqlTokenType} so one renderer + one CSS palette styles both languages. */
+export type TurtleTokenType = SparqlTokenType;
+
+/** One token: its source `text` and lexical `type`. Concatenating every `text` in order
+ * reproduces the input string exactly. Aliased to {@link SparqlToken}. */
+export type TurtleToken = SparqlToken;
+
+// The directive / keyword set Turtle (and TriG) recognise. `@prefix` / `@base` are the
+// classic `@`-prefixed forms; `PREFIX` / `BASE` are the case-insensitive SPARQL-style forms
+// Turtle 1.1 also accepts. `a` (the rdf:type shorthand) and the boolean literals are handled
+// in the lexer, not this set. `GRAPH` is not a Turtle/TriG keyword (TriG uses bare graph
+// labels + braces), so it is deliberately absent.
+const TURTLE_DIRECTIVES = new Set<string>(["PREFIX", "BASE"]);
+
+const BOOLEANS = new Set<string>(["true", "false"]);
+
+// Character-class helpers (ASCII fast paths; PN_CHARS_BASE/U is approximated for highlighting,
+// matching the SPARQL lexer's policy).
+const isWs = (c: string): boolean =>
+  c === " " || c === "\t" || c === "\n" || c === "\r" || c === "\f" || c === "\v";
+const isDigit = (c: string): boolean => c >= "0" && c <= "9";
+const isNameStart = (c: string): boolean =>
+  (c >= "a" && c <= "z") || (c >= "A" && c <= "Z") || c === "_" || c.charCodeAt(0) > 127;
+const isNameChar = (c: string): boolean =>
+  isNameStart(c) || isDigit(c) || c === "-" || c === "." || c === "·";
+
+/**
+ * Tokenize a Turtle / TriG / N-Triples / N-Quads document for HIGHLIGHTING. Pure: no side
+ * effects, no DOM. The returned tokens are gap-free and ordered — `tokens.map(t => t.text)
+ * .join("")` equals the input exactly (so an overlay renderer aligns with the source). This is
+ * a forgiving lexer, not a validator: malformed input (an unterminated string/IRI, a stray
+ * character) is still tokenized to end-of-input rather than throwing.
+ */
+export function tokenizeTurtle(input: string): TurtleToken[] {
+  const tokens: TurtleToken[] = [];
+  const n = input.length;
+  let i = 0;
+  const push = (text: string, type: TurtleTokenType): void => {
+    if (text.length > 0) tokens.push({ text, type });
+  };
+
+  while (i < n) {
+    const c = input[i];
+
+    // Whitespace run.
+    if (isWs(c)) {
+      let j = i + 1;
+      while (j < n && isWs(input[j])) j++;
+      push(input.slice(i, j), "plain");
+      i = j;
+      continue;
+    }
+
+    // Comment: `#` to end of line. (`#` is only a comment outside an IRI/string, which is
+    // already handled because those are consumed whole below.)
+    if (c === "#") {
+      let j = i + 1;
+      while (j < n && input[j] !== "\n") j++;
+      push(input.slice(i, j), "comment");
+      i = j;
+      continue;
+    }
+
+    // IRI ref: `<` … `>` (no whitespace/`<` inside per the grammar; stop forgivingly at EOL).
+    if (c === "<") {
+      let j = i + 1;
+      while (j < n && input[j] !== ">" && input[j] !== "\n" && input[j] !== "<") j++;
+      if (j < n && input[j] === ">") {
+        push(input.slice(i, j + 1), "iri");
+        i = j + 1;
+        continue;
+      }
+      // Not a closed IRI — emit one punctuation char and continue.
+      push(c, "punctuation");
+      i += 1;
+      continue;
+    }
+
+    // String literal: '...', "...", '''...''', """...""" (with \-escapes). A following
+    // `@lang` or `^^datatype` is emitted as its own adjacent token (below).
+    if (c === '"' || c === "'") {
+      const j = scanString(input, i, c);
+      push(input.slice(i, j), "string");
+      i = j;
+      continue;
+    }
+
+    // `@prefix` / `@base` directive, or a `@lang` tag immediately after a string literal.
+    // Both start with `@`; classify by the directive word that follows.
+    if (c === "@") {
+      let j = i + 1;
+      while (j < n && isNameChar(input[j]) && input[j] !== ".") j++;
+      const word = input.slice(i, j);
+      // `@prefix` / `@base` are directives (keyword); a bare `@en` / `@en-GB` lang tag is part
+      // of the literal so we colour it as a string.
+      const bare = word.slice(1).toLowerCase();
+      push(word, bare === "prefix" || bare === "base" ? "keyword" : "string");
+      i = j;
+      continue;
+    }
+
+    // `^^` datatype marker — punctuation; the datatype IRI/prefixed name follows as its own
+    // token.
+    if (c === "^" && input[i + 1] === "^") {
+      push("^^", "punctuation");
+      i += 2;
+      continue;
+    }
+
+    // Number: a leading digit, or a `+`/`-`/`.` immediately followed by a digit.
+    if (
+      isDigit(c) ||
+      ((c === "+" || c === "-" || c === ".") && i + 1 < n && isDigit(input[i + 1]))
+    ) {
+      const j = scanNumber(input, i);
+      // A bare `.` (statement terminator) is punctuation, not a number — scanNumber returns
+      // i unchanged in that case.
+      if (j > i) {
+        push(input.slice(i, j), "number");
+        i = j;
+        continue;
+      }
+    }
+
+    // `_:bnode` blank-node label. Checked BEFORE the generic name-like run so the `_:` form is
+    // coloured as a node (prefixed) rather than mis-split.
+    if (c === "_" && input[i + 1] === ":") {
+      let j = i + 2;
+      while (j < n && isNameChar(input[j])) j++;
+      // Trim a trailing `.` that is really a statement terminator.
+      while (j > i + 2 && input[j - 1] === ".") j--;
+      push(input.slice(i, j), "prefixed");
+      i = j;
+      continue;
+    }
+
+    // Name-like run: a directive (`PREFIX`/`BASE`), a prefixed name (`foaf:name`, `:local`),
+    // the `a` shorthand, or a boolean.
+    if (isNameStart(c) || c === ":") {
+      const j = scanNameLike(input, i);
+      const text = input.slice(i, j);
+      push(text, classifyNameLike(text));
+      i = j;
+      continue;
+    }
+
+    // Single-char structural punctuation: `{ } [ ] ( ) ; , .`
+    push(c, "punctuation");
+    i += 1;
+  }
+
+  return tokens;
+}
+
+/** Scan a quoted string starting at `start` (quote char `q`), returning the index PAST the
+ * closing quote (or end of input for an unterminated literal). Handles `'''`/`"""` long
+ * forms and `\`-escapes. Identical policy to the SPARQL lexer. */
+function scanString(input: string, start: number, q: string): number {
+  const n = input.length;
+  const isLong = input[start + 1] === q && input[start + 2] === q;
+  if (isLong) {
+    let j = start + 3;
+    while (j < n) {
+      if (input[j] === "\\") {
+        j += 2;
+        continue;
+      }
+      if (input[j] === q && input[j + 1] === q && input[j + 2] === q) return j + 3;
+      j++;
+    }
+    return n;
+  }
+  let j = start + 1;
+  while (j < n) {
+    if (input[j] === "\\") {
+      j += 2;
+      continue;
+    }
+    if (input[j] === q) return j + 1;
+    if (input[j] === "\n") return j; // single-line string ends at a newline (forgiving)
+    j++;
+  }
+  return n;
+}
+
+/** Scan a numeric literal at `start`; returns the index past it, or `start` if no digit was
+ * actually consumed (so a bare `.`/`+`/`-` is NOT misread as a number). */
+function scanNumber(input: string, start: number): number {
+  const n = input.length;
+  let j = start;
+  if (input[j] === "+" || input[j] === "-") j++;
+  let sawDigit = false;
+  while (j < n && isDigit(input[j])) {
+    j++;
+    sawDigit = true;
+  }
+  if (j < n && input[j] === ".") {
+    j++;
+    while (j < n && isDigit(input[j])) {
+      j++;
+      sawDigit = true;
+    }
+  }
+  // Exponent.
+  if (sawDigit && j < n && (input[j] === "e" || input[j] === "E")) {
+    let k = j + 1;
+    if (k < n && (input[k] === "+" || input[k] === "-")) k++;
+    if (k < n && isDigit(input[k])) {
+      k++;
+      while (k < n && isDigit(input[k])) k++;
+      j = k;
+    }
+  }
+  return sawDigit ? j : start;
+}
+
+/** Scan a name-like run (directive / prefixed name / `a` / boolean), including an optional `:`
+ * and a local part. Returns the index past it. */
+function scanNameLike(input: string, start: number): number {
+  const n = input.length;
+  let j = start;
+  // Optional leading prefix label (or empty for `:local`).
+  while (j < n && isNameChar(input[j])) j++;
+  // A `:` makes it a prefixed name — consume the colon and the local part.
+  if (j < n && input[j] === ":") {
+    j++;
+    while (j < n && (isNameChar(input[j]) || input[j] === ":" || input[j] === "%")) j++;
+  }
+  // Trim a trailing `.` that is really a statement terminator (not part of a local-name end)
+  // — but only when the run is NOT a prefixed name (a dot inside `ex:a.b` is legal).
+  if (input.slice(start, j).indexOf(":") === -1) {
+    while (j > start && input[j - 1] === ".") j--;
+  }
+  return Math.max(j, start + 1);
+}
+
+/** Classify a name-like run already extracted by {@link scanNameLike}. */
+function classifyNameLike(text: string): TurtleTokenType {
+  if (text.indexOf(":") !== -1) return "prefixed"; // foaf:name, ex:alice, :local, rdf:type
+  if (text === "a") return "keyword"; // the rdf:type shorthand
+  const upper = text.toUpperCase();
+  if (TURTLE_DIRECTIVES.has(upper)) return "keyword"; // PREFIX / BASE (case-insensitive)
+  if (BOOLEANS.has(text.toLowerCase())) return "keyword";
+  return "plain";
+}

--- a/site/src/components/data-formats-demo.tsx
+++ b/site/src/components/data-formats-demo.tsx
@@ -41,6 +41,8 @@ import {
   formatBytes,
   type DataFormat,
 } from "@/lib/data-formats";
+// [OPUS-4.8] sq-8uew — Turtle/TriG/N-Triples/N-Quads syntax-highlighting input editor.
+import { RdfEditor } from "@/components/rdf-editor";
 
 // The whole-dataset enumeration: default graph UNION every named graph, so a sample of an
 // N-Quads / TriG document shows its named-graph rows too (?g bound). Same shape the REPL uses.
@@ -193,13 +195,13 @@ export function DataFormatsDemo() {
           <label htmlFor="data-formats-input" className="sr-only">
             RDF document to parse
           </label>
-          <textarea
+          {/* [OPUS-4.8] sq-8uew — syntax-highlighting Turtle/TriG/N-Triples/N-Quads input. */}
+          <RdfEditor
             id="data-formats-input"
+            ariaLabel="RDF document to parse"
             value={text}
-            spellCheck={false}
-            onChange={(e) => setText(e.target.value)}
+            onChange={setText}
             rows={10}
-            className="w-full resize-y rounded-lg border bg-muted/40 p-3 font-mono text-[13px] leading-relaxed outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
           />
 
           <div className="flex items-center gap-3">

--- a/site/src/components/inference-playground.tsx
+++ b/site/src/components/inference-playground.tsx
@@ -45,6 +45,8 @@ import {
   shortenTerm,
   type Triple,
 } from "@/lib/inference";
+// [OPUS-4.8] sq-8uew — Turtle syntax-highlighting input editor (Turtle mode only).
+import { RdfEditor } from "@/components/rdf-editor";
 import {
   INFERENCE_EXAMPLES,
   type InferenceMode,
@@ -241,14 +243,27 @@ export function InferencePlayground() {
               ? "N3 rules + facts"
               : "Ontology + facts (Turtle)"}
           </label>
-          <textarea
-            id="reason-data"
-            value={data}
-            spellCheck={false}
-            onChange={(e) => setData(e.target.value)}
-            rows={12}
-            className="w-full resize-y rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
-          />
+          {/* [OPUS-4.8] sq-8uew — Turtle syntax highlighting for the Turtle ontology+facts
+              input. N3 mode keeps the plain textarea: the Turtle lexer would mis-style
+              N3-specific rule syntax (`{ } => @forAll`), so we only highlight pure Turtle. */}
+          {mode === "n3" ? (
+            <textarea
+              id="reason-data"
+              value={data}
+              spellCheck={false}
+              onChange={(e) => setData(e.target.value)}
+              rows={12}
+              className="w-full resize-y rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+            />
+          ) : (
+            <RdfEditor
+              id="reason-data"
+              ariaLabel="Ontology and facts (Turtle)"
+              value={data}
+              onChange={setData}
+              rows={12}
+            />
+          )}
         </div>
 
         <div className="flex flex-wrap items-center gap-3">

--- a/site/src/components/rdf-editor.tsx
+++ b/site/src/components/rdf-editor.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+// [OPUS-4.8] sq-8uew — a syntax-highlighting EDITOR for Turtle/TriG/N-Triples/N-Quads input.
+//
+// The Turtle-input counterpart of `SparqlEditor` (sq-n5aw): a transparent-text `<textarea>`
+// rendered over a highlighted `<pre>`, the standard zero-dependency overlay technique. The two
+// layers share identical font metrics, padding, tab size and scroll offset so glyphs align
+// exactly. Tokenization is the framework-agnostic `@sparq/client` `tokenizeTurtle` core, and
+// the spans use the SAME `.sq-tok-*` classes `globals.css` already defines for the SPARQL
+// editor — no new palette, theme-following highlighting, no new npm dependency, static-export
+// safe. Use it anywhere the playground lets a user TYPE an RDF document (e.g. the data-formats
+// parse panel). The lighter read-only display counterpart is `RdfHighlight`.
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { type TurtleToken, tokenizeTurtle } from "@sparq/client";
+
+// Shared text-metrics: the highlight `<pre>` and the `<textarea>` MUST use identical font,
+// size, line-height, padding, tab size and wrapping, or the layers drift. Centralised so they
+// can never diverge. Matches the data-formats textarea's prior `text-[13px] leading-relaxed`.
+const EDITOR_TEXT_CLASS =
+  "font-mono text-[13px] leading-relaxed whitespace-pre-wrap break-words [tab-size:2]";
+const EDITOR_PAD_CLASS = "p-3";
+
+const TOKEN_CLASS: Record<TurtleToken["type"], string> = {
+  keyword: "sq-tok-keyword",
+  variable: "sq-tok-variable", // unused by Turtle, kept for the shared token-type map
+  iri: "sq-tok-iri",
+  prefixed: "sq-tok-prefixed",
+  string: "sq-tok-string",
+  number: "sq-tok-number",
+  comment: "sq-tok-comment",
+  punctuation: "",
+  plain: "",
+};
+
+export interface RdfEditorProps {
+  /** Current document text (controlled). */
+  value: string;
+  /** Called with the new text on edit. */
+  onChange: (next: string) => void;
+  /** Visible rows (the textarea is resizable vertically from here). */
+  rows?: number;
+  /** Accessible label for the editing surface. */
+  ariaLabel?: string;
+  /** id for the textarea (so an external `<label htmlFor>` can target it). */
+  id?: string;
+  /** Disable editing (e.g. while the engine is warming). */
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * A syntax-highlighting Turtle/TriG/N-Triples/N-Quads editor: a transparent-caret `<textarea>`
+ * over a highlighted `<pre>`. Fully controlled; emits edits through {@link onChange}.
+ */
+export function RdfEditor({
+  value,
+  onChange,
+  rows = 10,
+  ariaLabel = "RDF document",
+  id,
+  disabled,
+  className,
+}: RdfEditorProps) {
+  const preRef = React.useRef<HTMLPreElement>(null);
+
+  // Keep the highlight layer's scroll offset in lockstep with the textarea.
+  const syncScroll = React.useCallback((el: HTMLTextAreaElement) => {
+    if (preRef.current) {
+      preRef.current.scrollTop = el.scrollTop;
+      preRef.current.scrollLeft = el.scrollLeft;
+    }
+  }, []);
+
+  const tokens = React.useMemo(() => tokenizeTurtle(value), [value]);
+
+  return (
+    <div className={cn("relative rounded-lg border bg-muted/40", className)}>
+      {/* Highlight layer: aria-hidden (the textarea is the accessible control). A trailing
+          newline keeps the last line's height stable while typing at the very end. */}
+      <pre
+        ref={preRef}
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-0 m-0 overflow-auto",
+          EDITOR_PAD_CLASS,
+          EDITOR_TEXT_CLASS,
+        )}
+      >
+        {tokens.map((t, idx) => {
+          const cls = TOKEN_CLASS[t.type];
+          return cls ? (
+            <span key={idx} className={cls}>
+              {t.text}
+            </span>
+          ) : (
+            <React.Fragment key={idx}>{t.text}</React.Fragment>
+          );
+        })}
+        {"\n"}
+      </pre>
+
+      {/* Editing layer: transparent text (so the highlight shows through) but a visible
+          caret. `spellCheck` off — RDF is not prose. */}
+      <textarea
+        id={id}
+        aria-label={ariaLabel}
+        value={value}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        rows={rows}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        onScroll={(e) => syncScroll(e.currentTarget)}
+        className={cn(
+          "relative block w-full resize-y bg-transparent text-transparent caret-foreground outline-none",
+          "selection:bg-primary/30 focus-visible:ring-3 focus-visible:ring-ring/40 rounded-lg",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+          EDITOR_PAD_CLASS,
+          EDITOR_TEXT_CLASS,
+        )}
+      />
+    </div>
+  );
+}

--- a/site/src/components/rdf-highlight.tsx
+++ b/site/src/components/rdf-highlight.tsx
@@ -1,0 +1,61 @@
+// [OPUS-4.8] sq-8uew — a read-only Turtle/TriG/N-Triples/N-Quads syntax-highlight renderer.
+//
+// Where Turtle-family RDF is DISPLAYED (CONSTRUCT/DESCRIBE graph output, the dataset N-Triples
+// view, the data-formats sample read-back) we want the same theme-aware colours the SPARQL
+// editor already shows — keywords, IRIs, prefixed names, strings, numbers, comments — instead
+// of a flat monochrome `<pre>`. This component is the display counterpart of `SparqlEditor`:
+// it tokenizes via the dependency-free `@sparq/client` `tokenizeTurtle` core and wraps each
+// token in a `.sq-tok-*` span (the SAME classes `globals.css` already defines for SPARQL, so
+// there is no new palette and highlighting follows light/dark automatically).
+//
+// It renders a plain styled `<pre>` (NOT an editor overlay) so it drops in anywhere a `<pre>`
+// already shows RDF text. Styling props (`className`) are forwarded so each call site keeps
+// its existing sizing/scroll/border. Dependency-free, static-export-safe.
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { type TurtleToken, tokenizeTurtle } from "@sparq/client";
+
+const TOKEN_CLASS: Record<TurtleToken["type"], string> = {
+  keyword: "sq-tok-keyword",
+  variable: "sq-tok-variable", // unused by Turtle, kept for the shared token-type map
+  iri: "sq-tok-iri",
+  prefixed: "sq-tok-prefixed",
+  string: "sq-tok-string",
+  number: "sq-tok-number",
+  comment: "sq-tok-comment",
+  punctuation: "",
+  plain: "",
+};
+
+export interface RdfHighlightProps {
+  /** The RDF document (Turtle / TriG / N-Triples / N-Quads) to highlight. */
+  text: string;
+  /** Classes for the `<pre>` host (sizing, scroll, border, padding, font). */
+  className?: string;
+  /** Optional `data-*` hook for tests/inspection. */
+  "data-testid"?: string;
+}
+
+/**
+ * Render an RDF document as a syntax-highlighted, read-only `<pre>`. Pure presentation: the
+ * tokenizer is gap-free, so the rendered text reproduces `text` exactly.
+ */
+export function RdfHighlight({ text, className, ...rest }: RdfHighlightProps) {
+  const tokens = React.useMemo(() => tokenizeTurtle(text), [text]);
+  return (
+    <pre className={cn("font-mono", className)} {...rest}>
+      {tokens.map((t, idx) => {
+        const cls = TOKEN_CLASS[t.type];
+        return cls ? (
+          <span key={idx} className={cls}>
+            {t.text}
+          </span>
+        ) : (
+          <React.Fragment key={idx}>{t.text}</React.Fragment>
+        );
+      })}
+    </pre>
+  );
+}

--- a/site/src/components/repl-datasets.tsx
+++ b/site/src/components/repl-datasets.tsx
@@ -28,6 +28,8 @@ import {
   type SparqlResults,
   type WasmStore,
 } from "@/lib/sparq-wasm";
+// [OPUS-4.8] sq-8uew — Turtle/N-Triples/N-Quads syntax highlighting for the text view.
+import { RdfHighlight } from "@/components/rdf-highlight";
 import {
   ALL_QUADS_BODY,
   FORMAT_OPTIONS,
@@ -454,9 +456,10 @@ export function DatasetViewer({
               </tbody>
             </table>
           ) : (
-            <pre className="overflow-x-auto p-3 font-mono text-[12px] leading-relaxed">
-              {serialised}
-            </pre>
+            <RdfHighlight
+              text={serialised}
+              className="overflow-x-auto p-3 text-[12px] leading-relaxed"
+            />
           )}
         </div>
       </DialogContent>

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -54,6 +54,8 @@ import {
 import { DatasetPanel } from "@/components/repl-dataset-panel";
 // [OPUS-4.8] sq-n5aw — the syntax-highlighting SPARQL editor replaces the plain <textarea>.
 import { SparqlEditor } from "@/components/sparql-editor";
+// [OPUS-4.8] sq-8uew — Turtle/N-Triples syntax highlighting for the CONSTRUCT/DESCRIBE graph.
+import { RdfHighlight } from "@/components/rdf-highlight";
 // [OPUS-4.8] sq-2mke — endpoint mode: the Connect panel + the SPARQL 1.1 Protocol client.
 import { ConnectPanel } from "@/components/connect-panel";
 // [OPUS-4.8] sq-9ij6 — endpoint mode: the live subscriptions view (SSE result deltas).
@@ -696,9 +698,10 @@ function ResultPanel({ state }: { state: RunState }) {
       );
     }
     return (
-      <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
-        {state.ntriples}
-      </pre>
+      <RdfHighlight
+        text={state.ntriples}
+        className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 text-[12.5px] leading-relaxed"
+      />
     );
   }
   if (state.kind === "explain") {


### PR DESCRIPTION
> 🤖 **SPARQ agent** — this PR was prepared by an automated SPARQ site agent (Opus 4.8). @jeswr runs several agents on this account; ping me on the PR for follow-ups.

Closes #788.

## What this adds

Turtle (and TriG / N-Triples / N-Quads) **syntax highlighting** on the website — wherever RDF is shown as results/dataset content, and in the playground surfaces where users **type** an RDF document.

The approach mirrors the existing dependency-free SPARQL highlighter (`tokenizeSparql`, sq-n5aw): a new framework-agnostic `tokenizeTurtle` in `@sparq/client` that **reuses the same `SparqlTokenType` token classes**, so the existing `.sq-tok-*` CSS palette in `globals.css` styles both languages. That means:

- **No new npm dependency** (no CodeMirror/Prism/Shiki) — pure-TS lexer + a transparent-textarea-over-highlight overlay, the same technique already shipped for the SPARQL editor.
- **No new palette** — highlighting follows the light/dark theme automatically.
- **Static-export safe** — no SSR-incompatible client lib.
- The lexer is **forgiving and gap-free**: concatenating the token texts reproduces the source exactly, so the highlight layer aligns glyph-for-glyph with the textarea and never drops characters.

## What gets highlighted + where

| Surface | Component | Mode |
|---|---|---|
| `/try` — CONSTRUCT/DESCRIBE graph output | `RdfHighlight` (read-only) | display |
| `/try` — dataset viewer N-Triples / N-Quads text view | `RdfHighlight` (read-only) | display |
| `/surface/data-formats` — Turtle/TriG/N-Triples/N-Quads parse **input** | `RdfEditor` (overlay) | typed input |
| `/surface/inference` — Turtle ontology+facts **input** | `RdfEditor` (overlay) | typed input (Turtle mode only) |

The inference page's **N3 mode keeps the plain textarea** — the Turtle lexer would mis-style N3-specific rule syntax (`{ } => @forAll`), so only pure-Turtle input is highlighted there (honest scoping, no false colouring).

SPARQL highlighting is **untouched** — the SPARQL editor and its tokenizer are unchanged.

## New / changed files

- `packages/sparq-client/src/turtle-highlight.ts` — the `tokenizeTurtle` lexer (new).
- `packages/sparq-client/src/index.ts` — export the tokenizer + types.
- `site/src/components/rdf-highlight.tsx` — read-only highlighted `<pre>` host (new).
- `site/src/components/rdf-editor.tsx` — overlay editing host (new).
- `site/src/components/repl.tsx`, `repl-datasets.tsx`, `data-formats-demo.tsx`, `inference-playground.tsx` — wired in.

## Stack / dependency

Dependency-free. Reuses the in-repo `@sparq/client` highlighting core and the existing `.sq-tok-*` CSS. **Bundle impact:** the shared tokenizer is a few hundred bytes of pure JS; per-route First-Load JS is unchanged in the build report (e.g. `/try` 158 kB, `/surface/data-formats` 198 kB, `/surface/inference` 205 kB).

## Gates (all green on this work box)

- **WASM prereq:** `cd js && npm run build:wasm` — exit 0 (build artifact only; no `crates/` change).
- `cd site && npm install` — exit 0.
- `npx tsc --noEmit` (site) — exit 0. `@sparq/client` `tsc --noEmit` — exit 0.
- `npm run lint` (site) — ✔ No ESLint warnings or errors.
- `npm run build` (site static export) — exit 0; all affected routes emitted to `out/` (`/try`, `/surface/data-formats`, `/surface/inference`), base routes (`/`, `/benchmarks`, `/papers`) intact.
- Tokenizer round-trip + token-classification spot-checks pass against the live Turtle/TriG/N-Triples/N-Quads samples (verified out-of-band; `@sparq/client` has no in-repo test harness for the SPARQL highlighter sibling either).

## Honest notes

- The terminology gate is respected — no "RDF-star"/"quoted triple" wording introduced.
- No performance/benchmark numbers are claimed (this work box is non-canonical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)