### PR TITLE
docs(book): document SPARQL 1.2 Update support (#813, sq-tfpq) [OPUS-4.8]

### DIFF
--- a/book/src/getting-started/capabilities.md
+++ b/book/src/getting-started/capabilities.md
@@ -2,7 +2,10 @@
 (no lorem). The ZK / MPC entries KEEP the research-scaffold / not-externally-audited
 caveats from the source — do not relabel them as sound or maliciously secure (privacy-claims-allow: meta-instruction WARNING against relabeling as sound/maliciously-secure, not an achieved-property claim; sq-toze.35)
 (privacy-claims gate). The include-wiring bead (sq-im8u) will single-source each
-capability description from its skills/<surface>/SKILL.md. -->
+capability description from its skills/<surface>/SKILL.md.
+[OPUS-4.8] sq-tfpq / issue #813 — Update row now links SPARQL 1.2 Update alongside 1.1
+and a short note documents the 1.2 triple-term delta (no new ops); honest scoping kept
+(engine write tests, not a formal conformance run). -->
 
 # Capabilities at a glance
 
@@ -13,7 +16,7 @@ usage guide.
 | Capability | Standard | Guide |
 | --- | --- | --- |
 | SPARQL query | [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) / [1.2](https://www.w3.org/TR/sparql12-query/) | [sparql-query](https://github.com/jeswr/sparq/blob/main/skills/sparql-query/SKILL.md) |
-| SPARQL Update | [SPARQL 1.1 Update](https://www.w3.org/TR/sparql11-update/) | [sparql-query](https://github.com/jeswr/sparq/blob/main/skills/sparql-query/SKILL.md) |
+| SPARQL Update | [SPARQL 1.1 Update](https://www.w3.org/TR/sparql11-update/) / [1.2](https://www.w3.org/TR/sparql12-update/) | [sparql-query](https://github.com/jeswr/sparq/blob/main/skills/sparql-query/SKILL.md) |
 | RDF parsing & ingest | Turtle / N-Triples / N-Quads / TriG (+ `.gz` / `.bz2` / `.zst`) | [data-formats](https://github.com/jeswr/sparq/blob/main/skills/data-formats/SKILL.md) |
 | RDF 1.2 triple terms | [RDF 1.2 Concepts](https://www.w3.org/TR/rdf12-concepts/) | [sparql-query](https://github.com/jeswr/sparq/blob/main/skills/sparql-query/SKILL.md) |
 | RDFS / OWL-RL / N3 reasoning | [RDFS](https://www.w3.org/TR/rdf-schema/), [OWL 2 RL](https://www.w3.org/TR/owl2-profiles/#OWL_2_RL), [N3](https://w3c.github.io/N3/spec/) | [inference](https://github.com/jeswr/sparq/blob/main/skills/inference/SKILL.md) |
@@ -26,6 +29,22 @@ usage guide.
 | RDF stream processing | [RSP-QL](https://www.w3.org/community/rsp/) | [streaming-rsp](https://github.com/jeswr/sparq/blob/main/skills/streaming-rsp/SKILL.md) |
 | Solid access control | [Solid WAC](https://solidproject.org/TR/wac) / [ACP](https://solidproject.org/TR/acp) | [solid crate](https://github.com/jeswr/sparq/tree/main/crates/sparq-solid) |
 | Dataset canonicalization | [RDFC-1.0](https://www.w3.org/TR/rdf-canon/) | [rdf-canon](https://github.com/jeswr/sparq/blob/main/skills/rdf-canon/SKILL.md) |
+
+## A note on SPARQL Update 1.1 vs 1.2
+
+SPARQL 1.1 Update is fully supported: `INSERT DATA`, `DELETE DATA`, `DELETE`/`INSERT … WHERE`
+(with `USING` / `WITH`), `LOAD`, `CLEAR`, `CREATE`, `DROP`, `COPY`, `MOVE`, and `ADD`, with
+request-level atomicity for `;`-separated bodies.
+
+[SPARQL 1.2 Update](https://www.w3.org/TR/sparql12-update/) adds **no new operations** over 1.1;
+its substantive change is the [RDF 1.2](https://www.w3.org/TR/rdf12-concepts/) triple-term
+semantics inside `INSERT DATA` / `DELETE DATA` and `DELETE`/`INSERT … WHERE` — inserting or
+deleting a reifying triple (`rdf:reifies <<( s p o )>>`) operates on that triple term itself and
+does **not** automatically assert or retract the asserted triple it refers to. sparq handles this:
+triple terms are stored and matched as structural object terms, so a reifying triple is added or
+removed as an exact term with no coupling to its asserted counterpart. This behaviour is exercised
+by the engine's write tests (`crates/sparq-engine/tests/rdfstar_write.rs`); it has not been checked
+against a formal SPARQL 1.2 conformance suite.
 
 ## Research scaffolds (no security guarantee yet)
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — autonomous SPARQ agent (bead sq-tfpq, follow-up to #813). @jeswr runs several agents on one account.

Closes #813.

## What

The book's capabilities table (`book/src/getting-started/capabilities.md`) linked **SPARQL 1.1 Update only** on the Update row, while the Query row already links **1.1 / 1.2**. That was a version asymmetry in the docs — not a missing feature.

sparq implements UPDATE fully (vendored `spargebra` parser → `crates/sparq-engine/src/update.rs`; request-level atomicity for `;`-separated bodies; WAL-durable `CLEAR`/`DROP`), and it handles the one substantive **SPARQL 1.2 Update** delta — the [RDF 1.2](https://www.w3.org/TR/rdf12-concepts/) triple-term semantics inside `INSERT DATA` / `DELETE DATA` and `DELETE`/`INSERT … WHERE`: inserting or deleting a reifying triple operates on the triple term itself and does **not** auto-assert/retract its asserted counterpart.

## Changes (doc-only)

- **Update row** now links [SPARQL 1.2 Update](https://www.w3.org/TR/sparql12-update/) alongside 1.1, matching the Query row's `1.1 / 1.2` form.
- Adds a short **"A note on SPARQL Update 1.1 vs 1.2"** subsection: 1.1 is fully supported (lists the op set); 1.2 adds **no new operations**, just the triple-term delta, which sparq handles (triple terms stored/matched as structural object terms, no coupling to the asserted triple).

## Honest scoping

The note explicitly cites the engine's write tests (`crates/sparq-engine/tests/rdfstar_write.rs`, e.g. `insert_data_triple_term_object_roundtrips`, `delete_data_triple_term_object_removes_exact_term`, `delete_insert_where_rewrites_a_reified_statement`) as the evidence, and states the behaviour **has not been checked against a formal SPARQL 1.2 conformance suite**. No overclaim. RDF 1.2 / triple-term terminology only (no "RDF-star" / "quoted triple").

## Gates run (all green, locally, in worktree)

- `mdbook build book` — no `[ERROR]` lines; `mdbook test book` — pass
- `scripts/check-terminology.py` — clean
- `scripts/check-no-perf-numbers.py --enforce` — 0 findings
- `scripts/check-privacy-claims.sh` — OK (no unqualified ZK/MPC claim; existing semi-honest/not-audited caveats preserved untouched)
- `markdownlint-cli2` — 0 errors; `typos` — 0; `lychee --offline` — 0 errors
