### PR TITLE
bench(dashboard): register sim/introspect/nlq/mpc/wasm trend rows (featured=false) — clear drift (sq-5o5.5-.9) [OPUS-4.8]

### DIFF
--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -816,6 +816,14 @@ quiet_box_sensitive = true
 pinning     = "olympics dataset version; ground truth = rdf:type classes"
 records_to  = "stdout; research/genai-design.md §4 gate"
 status      = "ok"
+# [OPUS-4.8] sq-5o5.5: trend-only DISPOSITION (featured = false). The sim metrics
+# route to the GenAI capability family on the dashboard (familyOf: `sim_*` -> genai),
+# so the suite is accounted for as a trend row — but it is NOT promoted to a
+# head-to-head FEATURED_SUITES competitor card. A competitor card would make a perf
+# claim and needs a same-scale canonical-host gather (sq-v4if / competitor-gather,
+# EC2-blocked); promote-to-card is deferred to the maintainer. `featured = false`
+# is the documented escape hatch honored by gate G3 and the drift scanner (§5.D).
+featured    = false
 
 [[benchmark]]
 id          = "introspect-olympics"
@@ -829,6 +837,13 @@ quiet_box_sensitive = true
 pinning     = "dataset version"
 records_to  = "stdout; research/genai-design.md §4 gate"
 status      = "ok"
+# [OPUS-4.8] sq-5o5.6: trend-only DISPOSITION (featured = false). The introspect
+# metrics route to the GenAI capability family on the dashboard (familyOf:
+# `introspect_*` -> genai) as a trend row, but the suite is NOT a head-to-head
+# FEATURED_SUITES competitor card. Promote-to-card (which makes a perf claim +
+# needs a canonical-host gather) is deferred to the maintainer. `featured = false`
+# is the documented escape hatch honored by gate G3 and the drift scanner (§5.D).
+featured    = false
 
 # [OPUS-4.8] sq-ncvq.12 (drift catch-up A) — sparq-nlq OFFLINE NL→SPARQL micro-bench.
 # Closes the bench-missing drift item for sparq-nlq. Pure offline: the LLM is an
@@ -847,6 +862,13 @@ quiet_box_sensitive = true
 pinning     = "in-example synthetic graph is deterministic; pin N for comparable numbers; offline path (no `live` feature)"
 records_to  = "stdout (us per phase)"
 status      = "ok"
+# [OPUS-4.8] sq-5o5.7: trend-only DISPOSITION (featured = false). NL→SPARQL is part
+# of the GenAI estate; the nlq metrics route to the GenAI capability family on the
+# dashboard (familyOf: `nlq_*` -> genai) as a trend row. It is NOT a head-to-head
+# FEATURED_SUITES competitor card — the trend-only disposition makes NO perf claim.
+# HONESTY: LIVE exec-accuracy on a canonical host (sq-qidj / sq-g0lw, EC2-blocked) is
+# a SEPARATE concern and is NOT required to clear this dashboard-row drift.
+featured    = false
 
 # [OPUS-4.8] sq-ncvq.12 (drift catch-up A) — sparq-serve concurrent-serving-core
 # micro-bench. Closes the bench-missing drift item for sparq-serve. Lightweight:
@@ -888,6 +910,14 @@ quiet_box_sensitive = false  # modelled bytes/rounds/mults are DETERMINISTIC (co
 pinning     = "DEFAULT_PARTIES {2,3,5,7}, join/shuffle scales fixed in the example; correctness-gate seed 0x5347585140D5043... fixed under insecure-test-rng (simulation reproducibility only, NEVER a production claim)"
 records_to  = "stdout (human table + JSON schema); research/mpc design record §5"
 status      = "ok"
+# [OPUS-4.8] sq-5o5.8: trend-only DISPOSITION (featured = false). This is a
+# DETERMINISTIC MODELLED-cost counting tier (bytes/rounds/mults), NOT a measured
+# wall-clock competitor card — promoting a head-to-head perf card would be
+# inappropriate (modelled, not measured). The mpc metrics route to the MPC capability
+# family on the dashboard as a trend row. HONESTY: MPC here is semi-honest-only and
+# the ZK estate is NOT externally audited — any dashboard text stays caveated and the
+# privacy-claims CI gate must pass. `featured = false` is the documented escape hatch.
+featured    = false
 
 # [OPUS-4.8] sq-ncvq.12 (drift catch-up A) — sparq-wasm browser-bundle size.
 # Closes the bench-missing drift item for sparq-wasm. The wasm crate is a thin
@@ -910,6 +940,15 @@ quiet_box_sensitive = false  # byte count is fully deterministic (runner-noise-i
 pinning     = "release profile + wasm32-unknown-unknown target; the crate's no-default-features (no rayon) + compact 3-perm cfg pin the bundle composition"
 records_to  = "stdout (wc -c); CI emits wasm_bundle_bytes into benchmark-data (dev/bench) via scripts/ci-bench.sh (a DETERMINISTIC regression gate, NOT trend-only)"
 status      = "ok"
+# [OPUS-4.8] sq-5o5.9: featured = false records that this is a deterministic
+# browser-bundle-size BYTE GATE, NOT a query-perf head-to-head FEATURED_SUITES
+# competitor card — sparq-wasm's query logic is already measured via the
+# CLI/operator-coverage suites over the same engine. The `wasm_bundle_bytes` metric
+# routes to the Core family on the dashboard and remains the per-commit DETERMINISTIC
+# regression gate it already is (see records_to above); `featured = false` only means
+# "no competitor card", it does NOT relax that regression gate. The proposed wasm
+# query micro-bench (sq-5pnl, a NEW wasm_query_us metric) is a SEPARATE concern.
+featured    = false
 
 # =============================================================================
 # CONFORMANCE — correctness against official W3C suites (NOT perf)

--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -659,11 +659,31 @@
     { key: 'rsp', title: 'RDF Stream Processing (continuous queries)', kind: 'capability',
       suites: ['rsp', 'rdf stream processing', 'streaming'],
       prefixes: ['rsp', 'stream', 'window'] },
-    { key: 'genai', title: 'GenAI (similarity · introspection)', kind: 'capability',
-      suites: ['similarity', 'introspect', 'introspection', 'genai'],
-      prefixes: ['sim', 'similarity', 'introspect'] },
+    { key: 'genai', title: 'GenAI (similarity · introspection · NL→SPARQL)', kind: 'capability',
+      // [OPUS-4.8] sq-5o5.5-.7 (featured = false trend-only disposition): the sim
+      // (sim-olympics-eval), introspect (introspect-olympics) AND nlq (nlq-offline-bench)
+      // bench families are part of the GenAI estate. Their benchmarks.toml entries are
+      // flagged `featured = false` — a trend-only DISPOSITION, NOT a head-to-head
+      // competitor card (promote-to-card would make a perf claim + needs a same-scale
+      // canonical-host gather; deferred to the maintainer). They route here so the
+      // dashboard renders them as a GenAI trend row (or "not yet reported" until a
+      // ci-bench hook emits, the same HONEST graceful-degradation contract as the other
+      // capability families). NL→SPARQL adds the `nlq`/`nl→sparql` suite + `nlq` prefix.
+      suites: ['similarity', 'introspect', 'introspection', 'genai', 'nlq', 'nl→sparql', 'nl-to-sparql'],
+      prefixes: ['sim', 'similarity', 'introspect', 'nlq'] },
     { key: 'gpu', title: 'GPU kernels (experimental)', kind: 'capability',
-      suites: ['gpu'], prefixes: ['gpu'] }
+      suites: ['gpu'], prefixes: ['gpu'] },
+    // [OPUS-4.8] sq-5o5.8 (featured = false trend-only disposition): the mpc family
+    // (mpc-bench-matrix). HONESTY: this is a DETERMINISTIC MODELLED-cost counting tier
+    // (bytes/party · rounds · multiplications), NOT a measured wall-clock competitor
+    // card, and MPC here is semi-honest-only with a ZK estate that is NOT externally
+    // audited — so it is registered as its OWN trend row (never swallowed into Core /
+    // never a head-to-head perf card), and its benchmarks.toml entry is `featured = false`.
+    // Prefixes cover the likely ci-bench emit names (mpc_*_bytes / mpc_rounds / mpc_mults /
+    // mpcmatrix_*); the row renders "not yet reported" until such a hook lands.
+    { key: 'mpc', title: 'Secure MPC (modelled counting tier · semi-honest)', kind: 'capability',
+      suites: ['mpc', 'secure mpc', 'multi-party computation'],
+      prefixes: ['mpc', 'mpcmatrix'] }
   ];
 
   // The top-level family a metric belongs to. Consults suiteFor() (label-map driven) FIRST, then a
@@ -673,17 +693,35 @@
   function familyOf(name) {
     var suite = (suiteFor(name) || '').toLowerCase();
     var token = (name || '').toLowerCase().split('_')[0];
-    // suite match first (the source of truth)
-    for (var i = 0; i < FAMILIES.length; i++) {
-      if (FAMILIES[i].suites.indexOf(suite) !== -1) return FAMILIES[i];
+    // [OPUS-4.8] sq-5o5.8: suiteFor()'s STRUCTURAL fallback groups (assigned to an unlabelled
+    // metric by shape, not a deliberate label-map placement) are too generic to bucket a metric
+    // that ALSO carries an explicit capability token. e.g. a modelled-MPC `mpc_join_bytes` gets the
+    // structural "Memory / Size" group purely from its `_bytes` suffix — that must NOT silently sink
+    // it into Core when its `mpc` prefix names a real capability family. So a structural-fallback
+    // suite does NOT win over a capability prefix; a REAL (label-map) suite still does.
+    var STRUCTURAL_FALLBACK = { 'memory / size': 1, 'pipeline': 1, 'other': 1 };
+    var suiteIsStructural = Object.prototype.hasOwnProperty.call(STRUCTURAL_FALLBACK, suite);
+    // suite match first (the source of truth) — but only when it is a REAL label-map suite.
+    if (!suiteIsStructural) {
+      for (var i = 0; i < FAMILIES.length; i++) {
+        if (FAMILIES[i].suites.indexOf(suite) !== -1) return FAMILIES[i];
+      }
     }
     // structural prefix fallback. We must check CAPABILITY families (shacl/geo/fts/vector/
-    // reasoning) BEFORE core+sparql so a capability metric is never mis-bucketed into SPARQL by a
-    // generic `op`/`q` prefix. FAMILIES is declared in DISPLAY order (core, sparql, then the
-    // capability families), so a single forward pass would hit sparql first; do an explicit
-    // two-pass scan — capability families first (kind === 'capability'), then the rest.
+    // reasoning/mpc) BEFORE core+sparql so a capability metric is never mis-bucketed into SPARQL by a
+    // generic `op`/`q` prefix NOR into Core by a generic `_bytes` structural suite. FAMILIES is
+    // declared in DISPLAY order (core, sparql, then the capability families), so a single forward
+    // pass would hit core/sparql first; do an explicit two-pass scan — capability families first
+    // (kind === 'capability'), then the rest.
     for (var j = 0; j < FAMILIES.length; j++) {
       if (FAMILIES[j].kind === 'capability' && FAMILIES[j].prefixes.indexOf(token) !== -1) return FAMILIES[j];
+    }
+    // A structural-fallback suite that maps to core/sparql still applies here (it was deferred above
+    // ONLY to let a capability prefix win) — e.g. `rdfs_infer_s`'s "Pipeline" group keeps it in Core.
+    if (suiteIsStructural) {
+      for (var s = 0; s < FAMILIES.length; s++) {
+        if (FAMILIES[s].suites.indexOf(suite) !== -1) return FAMILIES[s];
+      }
     }
     for (var k = 0; k < FAMILIES.length; k++) {
       if (FAMILIES[k].kind !== 'capability' && FAMILIES[k].prefixes.indexOf(token) !== -1) return FAMILIES[k];

--- a/scripts/dashboard-smoke.js
+++ b/scripts/dashboard-smoke.js
@@ -415,6 +415,22 @@ eq(D.familyOf('rsp_throughput').key, 'rsp', 'unlabelled RSP-throughput metric ->
 eq(D.familyOf('sim_most_similar_us').key, 'genai', 'unlabelled similarity metric -> GenAI family');
 eq(D.familyOf('introspect_build_s').key, 'genai', 'unlabelled introspection metric -> GenAI family');
 eq(D.familyOf('gpu_filter_us').key, 'gpu', 'unlabelled GPU-kernel metric -> GPU family');
+// [OPUS-4.8] sq-5o5.5-.9: the featured=false trend-only dispositions. NL→SPARQL (nlq) is part of the
+// GenAI estate; MPC gets its OWN caveated trend family (modelled counting tier, semi-honest). The
+// sim/introspect/nlq/mpc benches are flagged `featured = false` in bench/benchmarks.toml (trend-only,
+// NO competitor card), and route to a real dashboard family so coverage is HONEST, not silent.
+ok(D.FAMILIES.some(function (f) { return f.key === 'mpc'; }), 'FAMILIES includes the new mpc family (trend-only, featured=false)');
+eq(D.familyOf('nlq_ground_us').key, 'genai', 'unlabelled NL→SPARQL (nlq) metric -> GenAI family');
+eq(D.familyOf('nlq_ask_us').key, 'genai', 'unlabelled nlq ask-loop metric -> GenAI family');
+eq(D.familyOf('mpc_rounds').key, 'mpc', 'unlabelled modelled-MPC rounds metric -> MPC family');
+// the load-bearing one: an MPC `_bytes` counting-tier metric must NOT be sunk into Core by the
+// generic "Memory / Size" STRUCTURAL fallback — its `mpc` capability prefix wins (sq-5o5.8).
+eq(D.familyOf('mpc_join_bytes').key, 'mpc', 'modelled-MPC byte-count metric -> MPC family (capability prefix beats the structural Memory/Size fallback)');
+eq(D.familyOf('mpcmatrix_total_bytes').key, 'mpc', 'mpc-matrix byte-count metric -> MPC family');
+// wasm-bundle is a deterministic SIZE GATE, not its own capability card: wasm_bundle_bytes stays in
+// Core (the `wasm` token is a Core prefix + its Memory/Size suite) — featured=false only means "no
+// competitor card", it does not move the size gate out of Core (sq-5o5.9).
+eq(D.familyOf('wasm_bundle_bytes').key, 'core', 'wasm bundle-size byte gate -> Core family (size gate, NOT a separate capability card)');
 // selective + u64 are SPARQL micro-suites (cli `bench` q01_* stems) — recognise them under SPARQL.
 eq(D.familyOf('selective_q01_count_us').key, 'sparql', 'unlabelled selective-join metric -> SPARQL family');
 eq(D.familyOf('u64_q03_materialize_us').key, 'sparql', 'unlabelled u64 value-id metric -> SPARQL family');


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

`python3 scripts/drift-scan.py` reported 5 `dashboard-row` gaps — the **sim** (`sim-olympics-eval`), **introspect** (`introspect-olympics`), **nlq** (`nlq-offline-bench`), **mpc** (`mpc-bench-matrix`) and **wasm** (`wasm-bundle`) bench families each had a registered `[[benchmark]]` but no dashboard row. This clears all 5 via the **`featured = false` (trend-only) disposition** — the recommended default.

This makes **NO performance claim** and needs **NO EC2 number-gathering**. Promoting any of these to a head-to-head `FEATURED_SUITES` competitor card is **deliberately deferred to the maintainer** (that would require a same-scale canonical-host competitor gather = EC2 number-gathering, owned by separate beads: sq-v4if / sq-qidj / sq-g0lw).

## How

- **`bench/benchmarks.toml`** — mark all 5 entries `featured = false` with an honest per-family rationale. This alone clears the drift: the flag is the registry's documented escape hatch, honored by gate **G3** (`check-new-bench-registered.py`) and — since sq-5o5.2 — by `drift-scan.py`'s `scan_dashboard_row` (via `featured_false_bench_ids`).
- **`bench/dashboard/dashboard.js`** — give the families a real dashboard home so coverage is honest, not silent:
  - `sim` / `introspect` already route to the **GenAI** capability family;
  - `nlq` (NL→SPARQL) added to **GenAI**;
  - `mpc` gets its **own caveated** capability family — title `Secure MPC (modelled counting tier · semi-honest)` — so it is never swallowed into Core and never rendered as a perf card;
  - `wasm` stays in **Core** (its bundle-size byte count is a Core/size-gate metric, not a separate card);
  - `familyOf()` hardened so an explicit capability prefix (e.g. `mpc_join_bytes`) wins over the generic **STRUCTURAL** fallback suites (`Memory / Size` / `Pipeline` / `Other`) while a **real** label-map suite still wins — `rdfs_infer_s` stays in Core, all existing routings unchanged.
- **`scripts/dashboard-smoke.js`** — assert the new `nlq`/`mpc` routings + the load-bearing `mpc_*_bytes` → MPC (not Core) + `wasm-bundle` → Core.

These families render as a trend row (or "not yet reported" until a `ci-bench` hook emits) — the same HONEST graceful-degradation contract as the other capability families.

## Honesty notes

- **MPC** here is semi-honest-only and the ZK estate is **NOT** externally audited — the dashboard title stays caveated and the **privacy-claims gate passes**.
- **wasm-bundle** remains the per-commit **DETERMINISTIC regression gate** it already is; `featured = false` only means "no competitor card", it does not relax that gate.

## Gates (all green, locally reproduced)

| Gate | Command | Result |
|---|---|---|
| drift-scan | `python3 scripts/drift-scan.py --dry-run` | exit 0 — no drift (was exit 2, 5 `dashboard-row` items) |
| dashboard syntax | `node --check bench/dashboard/dashboard.js` | OK |
| dashboard smoke | `node scripts/dashboard-smoke.js` | exit 0 (incl. new assertions) |
| metric-labels drift | `python3 scripts/gen-metric-labels.py --check` | up to date |
| G3 new-bench | `python3 scripts/check-new-bench-registered.py` | PASS |
| privacy-claims | `bash scripts/check-privacy-claims.sh` | OK (362 files) |
| terminology | `python3 scripts/check-terminology.py` | clean |
| no-perf-numbers | `python3 scripts/check-no-perf-numbers.py --enforce` | 0 findings (no markdown touched) |
| typos | `typos` on changed files | clean |

Closes sq-5o5.5, sq-5o5.6, sq-5o5.7, sq-5o5.8, sq-5o5.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)