### PR TITLE
test(sparq-algos,sparq-canon): integration/unit suites + coverage-gate wiring (sq-bif.8, sq-bif.9) [OPUS-4.8]

### DIFF
--- a/bench/coverage-floor.json
+++ b/bench/coverage-floor.json
@@ -7,6 +7,14 @@
     "Regenerate after a deliberate coverage rise: scripts/coverage.sh && scripts/coverage-gate.py --seed target/coverage/coverage-summary.json"
   ],
   "crates": {
+    "sparq-algos": {
+      "floor": 97,
+      "note": "[OPUS-4.8] sq-bif.8: OPT-IN graph analytics (PageRank / degree centrality / WCC + label-propagation communities). Standalone crate (`default = []`, no opt-in features) measured with default features \u2014 its whole surface compiles in a default build. Measured line% 99.14 (575/580) over the inline src oracles + the new tests/topology_oracles.rs (dangling-node PageRank, disconnected/chain WCC+LP, all-singleton communities, NodeFilter::All literal path); floor = floor(measured) - 2 margin. Conservative work-box seed; CI's --check-robust is the ratchet of record."
+    },
+    "sparq-canon": {
+      "floor": 77,
+      "note": "[OPUS-4.8] sq-bif.9: OPT-IN RDFC-1.0 (RDF Dataset Canonicalization) public API. Standalone crate (no `[features]` table) measured with default features. Measured line% 79.04 (181/229) over tests/rdf_canon_suite.rs (full 86-entry W3C manifest: eval + issued-id map + negative poison-graph) + the new tests/bnode_isomorphism_and_bridge.rs (bnode-isomorphism equivalence, oxrdf-bridge triple-term/Display/literal-roundtrip edge paths); floor = floor(measured) - 2 margin. Conservative work-box seed; CI is the ratchet of record."
+    },
     "sparq-cli": {
       "floor": 0,
       "note": "subprocess artifact: tests spawn the COMPILED binary (assert_cmd / CARGO_BIN_EXE), not the instrumented profile \u2014 line% is ~0 by construction, not a real gap. Presence-gated instead."

--- a/bench/coverage-presence.json
+++ b/bench/coverage-presence.json
@@ -4,10 +4,20 @@
     "Counted from source (no compile) by scripts/coverage-presence.py, run every commit by the .github/workflows/ci.yml coverage job. The floor only RISES (--seed will not lower without --allow-lower). Regenerate after adding tests: scripts/coverage-presence.py --seed."
   ],
   "crates": {
+    "sparq-algos": {
+      "had_integration_dir": true,
+      "min_tests": 26,
+      "note": "[OPUS-4.8] sq-bif.8: 28 #[test]s measured (22 inline src oracles + 6 tests/topology_oracles.rs integration cases); floor 26 leaves a small margin. integration dir added by this bead."
+    },
     "sparq-bench": {
       "had_integration_dir": false,
       "min_tests": 0,
       "note": "perf-harness crate (benchmarks, not #[test]s)"
+    },
+    "sparq-canon": {
+      "had_integration_dir": true,
+      "min_tests": 12,
+      "note": "[OPUS-4.8] sq-bif.9: 14 #[test]s measured (5 inline src + 7 tests/bnode_isomorphism_and_bridge.rs + 2 tests/rdf_canon_suite.rs manifest drivers); floor 12 leaves a small margin. The suite itself spans the full 86-entry W3C RDFC-1.0 manifest inside those driver tests."
     },
     "sparq-cli": {
       "had_integration_dir": true,

--- a/crates/sparq-algos/tests/topology_oracles.rs
+++ b/crates/sparq-algos/tests/topology_oracles.rs
@@ -1,0 +1,289 @@
+//! [OPUS-4.8] sq-bif.8: integration suite for `sparq-algos` over the crate's PUBLIC API.
+//!
+//! The crate already has a strong body of inline unit tests in `src/lib.rs` (a
+//! hand-computed PageRank stationary-distribution oracle, LP exact-membership,
+//! determinism / tie-break, NaN guards). This `tests/` suite deliberately exercises the
+//! TOPOLOGY classes those unit tests do NOT cover, with known-answer / property oracles
+//! that fail on a real regression:
+//!
+//! * **Dangling-node PageRank** — sink (out-degree-0) nodes that would otherwise leak rank
+//!   mass; the result must still be a probability distribution (sums to 1) and the sink
+//!   must out-rank its sources.
+//! * **Disconnected + isolated-node + chain topologies** — WCC partition correctness and
+//!   LP membership across components that the connected unit-test graphs never reach.
+//! * **All-singleton community case** — a graph whose only edges are self-loops, so every
+//!   node is its own community in both WCC and LP.
+//! * **`NodeFilter::All` literal-inclusion `build_with` path** — literals promoted to
+//!   sink nodes, and their downstream effect on degree / PageRank.
+//!
+//! Everything goes through the published surface (`Graph::load_str`, `NodeGraph`,
+//! `pagerank`, `weakly_connected_components`, `label_propagation`, the centralities) — the
+//! same entry points a downstream analytics consumer uses.
+
+use oxrdf::{NamedNode, Term};
+use sparq_algos::{
+    degree_centrality, label_propagation, num_communities, pagerank, weakly_connected_components,
+    Direction, LabelPropConfig, NodeFilter, NodeGraph, PageRankConfig,
+};
+use sparq_core::Graph;
+
+/// Builds a graph from N-Triples and the default entity node-graph view.
+fn build(nt: &str) -> (Graph, NodeGraph) {
+    let g = Graph::load_str(nt, "nt").expect("parse N-Triples");
+    let ng = NodeGraph::build(&g);
+    (g, ng)
+}
+
+fn iri(s: &str) -> Term {
+    Term::NamedNode(NamedNode::new(s).unwrap())
+}
+
+/// Resolves the dense node index of an IRI in `(graph, node_graph)`.
+fn idx(g: &Graph, ng: &NodeGraph, name: &str) -> usize {
+    ng.index_of(g.id_of(&iri(name)).unwrap())
+        .unwrap_or_else(|| panic!("node {name} not in view"))
+}
+
+// ---------------------------------------------------------------------------
+// Dangling-node PageRank.
+// ---------------------------------------------------------------------------
+
+/// A "star INTO a sink": three sources each point at one sink `s`; `s` has NO out-edges,
+/// so it is a dangling node. The dangling-mass redistribution must keep the result a
+/// probability distribution (sum == 1), and the sink must collect more rank than any of
+/// its leaves. This is the property the unit tests' connected (cyclic) graphs cannot show,
+/// because there every node has an out-edge.
+#[test]
+fn pagerank_dangling_sink_redistributes_mass_and_sums_to_one() {
+    let nt = r#"
+<http://e/p> <http://r/k> <http://e/s> .
+<http://e/q> <http://r/k> <http://e/s> .
+<http://e/t> <http://r/k> <http://e/s> .
+"#;
+    let (g, ng) = build(nt);
+    // `s` is dangling (out-degree 0); the three sources are dangling too (they only emit),
+    // so EVERY node is a sink here except via teleport — the redistribution path is fully
+    // exercised.
+    let s = idx(&g, &ng, "http://e/s");
+    assert_eq!(ng.out_degree(s), 0, "sink must have no out-edges");
+
+    let r = pagerank(&ng, PageRankConfig::default());
+    let sum: f64 = r.iter().sum();
+    assert!(
+        (sum - 1.0).abs() < 1e-9,
+        "dangling-node PageRank must still sum to 1, got {}",
+        sum
+    );
+    // The sink is the only node with in-edges, so it must hold the most mass.
+    for name in ["http://e/p", "http://e/q", "http://e/t"] {
+        let leaf = idx(&g, &ng, name);
+        assert!(
+            r[s] > r[leaf],
+            "sink rank {} must exceed leaf {} rank {}",
+            r[s],
+            name,
+            r[leaf]
+        );
+    }
+}
+
+/// A chain that ENDS in a dangling node: `a -> b -> c`, `c` has no out-edge. Without the
+/// dangling-mass fix, `c`'s rank would leak away each iteration and the vector would NOT
+/// sum to 1. Pin both: sum == 1, and the strictly-monotone rank along the chain (`c`
+/// accumulates the most, `a` the least) since rank flows downstream.
+#[test]
+fn pagerank_chain_terminating_in_dangling_node_conserves_mass() {
+    let nt = r#"
+<http://e/a> <http://r/k> <http://e/b> .
+<http://e/b> <http://r/k> <http://e/c> .
+"#;
+    let (g, ng) = build(nt);
+    let (a, b, c) = (
+        idx(&g, &ng, "http://e/a"),
+        idx(&g, &ng, "http://e/b"),
+        idx(&g, &ng, "http://e/c"),
+    );
+    assert_eq!(ng.out_degree(c), 0, "chain end is dangling");
+
+    let r = pagerank(&ng, PageRankConfig::default());
+    let sum: f64 = r.iter().sum();
+    assert!((sum - 1.0).abs() < 1e-9, "mass must be conserved: {}", sum);
+    // Rank flows a -> b -> c, so it accumulates downstream.
+    assert!(r[c] > r[b], "tail {} should outrank middle {}", r[c], r[b]);
+    assert!(r[b] > r[a], "middle {} should outrank head {}", r[b], r[a]);
+}
+
+// ---------------------------------------------------------------------------
+// Disconnected / isolated-node / chain topologies (WCC + LP).
+// ---------------------------------------------------------------------------
+
+/// Three disjoint components of DIFFERENT shapes — a 3-chain `{a,b,c}`, a single edge
+/// `{d,e}`, and a self-loop singleton `{f}` (an isolated-by-others node). WCC must produce
+/// exactly three communities with the expected membership, and LP must AGREE on the
+/// coarse partition (no node ends in a community spanning two WCCs — LP only ever refines
+/// within a component, never merges across one).
+#[test]
+fn wcc_partitions_three_disjoint_components_and_lp_does_not_cross_them() {
+    let nt = r#"
+<http://e/a> <http://r/k> <http://e/b> .
+<http://e/b> <http://r/k> <http://e/c> .
+<http://e/d> <http://r/k> <http://e/e> .
+<http://e/f> <http://r/k> <http://e/f> .
+"#;
+    let (g, ng) = build(nt);
+    assert_eq!(ng.len(), 6, "a,b,c,d,e,f");
+
+    let comp = weakly_connected_components(&ng);
+    assert_eq!(
+        num_communities(&comp),
+        3,
+        "three disjoint components: {comp:?}"
+    );
+    let (a, b, c) = (
+        idx(&g, &ng, "http://e/a"),
+        idx(&g, &ng, "http://e/b"),
+        idx(&g, &ng, "http://e/c"),
+    );
+    let (d, e, f) = (
+        idx(&g, &ng, "http://e/d"),
+        idx(&g, &ng, "http://e/e"),
+        idx(&g, &ng, "http://e/f"),
+    );
+    // Chain {a,b,c} all together.
+    assert_eq!(comp[a], comp[b]);
+    assert_eq!(comp[b], comp[c]);
+    // Edge {d,e} together, distinct from the chain.
+    assert_eq!(comp[d], comp[e]);
+    assert_ne!(comp[a], comp[d]);
+    // Self-loop singleton {f} alone, distinct from both.
+    assert_ne!(comp[f], comp[a]);
+    assert_ne!(comp[f], comp[d]);
+
+    // LP must NOT merge two distinct WCCs into one community: two nodes in different WCCs
+    // can never share an LP community (LP only propagates along edges, which never cross
+    // components). Assert it for every cross-component pair.
+    let lp = label_propagation(&ng, LabelPropConfig::default());
+    assert_eq!(lp.len(), ng.len());
+    for &x in &[a, b, c] {
+        for &y in &[d, e, f] {
+            assert_ne!(
+                lp[x], lp[y],
+                "LP community spilled across two WCC components"
+            );
+        }
+    }
+}
+
+/// A pure chain `a -> b -> c -> d` is ONE weakly connected component even though no two
+/// non-adjacent nodes are directly connected — WCC ignores direction and follows the path.
+/// This is the chain-topology case the bead calls out for WCC.
+#[test]
+fn chain_is_one_weakly_connected_component() {
+    let nt = r#"
+<http://e/a> <http://r/k> <http://e/b> .
+<http://e/b> <http://r/k> <http://e/c> .
+<http://e/c> <http://r/k> <http://e/d> .
+"#;
+    let (_g, ng) = build(nt);
+    assert_eq!(ng.len(), 4);
+    let comp = weakly_connected_components(&ng);
+    assert_eq!(num_communities(&comp), 1, "a 4-chain is one WCC: {comp:?}");
+    // Every node carries the SAME (densified) component id 0.
+    assert!(comp.iter().all(|&c| c == comp[0]));
+}
+
+// ---------------------------------------------------------------------------
+// All-singleton community case.
+// ---------------------------------------------------------------------------
+
+/// A graph whose only edges are self-loops on distinct nodes: there are no inter-node
+/// edges at all, so EVERY node is its own community under BOTH WCC and LP. The bead
+/// explicitly calls out the "all-singleton communities" case, which the existing tests
+/// (all of which produce >= 1 multi-member community) never reach.
+#[test]
+fn all_self_loops_yield_all_singleton_communities() {
+    let nt = r#"
+<http://e/a> <http://r/k> <http://e/a> .
+<http://e/b> <http://r/k> <http://e/b> .
+<http://e/c> <http://r/k> <http://e/c> .
+"#;
+    let (_g, ng) = build(nt);
+    assert_eq!(ng.len(), 3);
+
+    // WCC: a self-loop unions a node with itself, so it stays alone -> 3 singletons.
+    let comp = weakly_connected_components(&ng);
+    assert_eq!(
+        num_communities(&comp),
+        3,
+        "self-loops only -> all singletons (WCC): {comp:?}"
+    );
+    // Every community id is distinct.
+    let mut ids = comp.clone();
+    ids.sort_unstable();
+    ids.dedup();
+    assert_eq!(ids.len(), 3, "no two nodes share a WCC community");
+
+    // LP: a node's only neighbour (via the self-loop) is ITSELF, so its plurality label is
+    // its own — nothing ever changes, every node stays a singleton.
+    let lp = label_propagation(&ng, LabelPropConfig::default());
+    assert_eq!(
+        num_communities(&lp),
+        3,
+        "self-loops only -> all singletons (LP): {lp:?}"
+    );
+    let mut lp_ids = lp.clone();
+    lp_ids.sort_unstable();
+    lp_ids.dedup();
+    assert_eq!(lp_ids.len(), 3, "no two nodes share an LP community");
+}
+
+// ---------------------------------------------------------------------------
+// NodeFilter::All literal-inclusion build_with path.
+// ---------------------------------------------------------------------------
+
+/// `NodeFilter::All` promotes literal objects to (sink) nodes, so the same data yields a
+/// LARGER view than the default `EntitiesOnly`. Pin the structural difference AND the
+/// downstream consequence: the literal becomes a dangling in-edge target, so under `All`
+/// the literal node has in-degree 1 / out-degree 0, and PageRank still sums to 1 over the
+/// enlarged node set. The unit test `literals_excluded_by_default_but_included_with_all`
+/// covers node/edge counts; this drives the literal node through the analytics layer.
+#[test]
+fn node_filter_all_promotes_literal_to_a_pagerank_sink() {
+    let nt = r#"
+<http://e/a> <http://r/name> "Alice" .
+<http://e/a> <http://r/k> <http://e/b> .
+"#;
+    let g = Graph::load_str(nt, "nt").unwrap();
+
+    let entities = NodeGraph::build(&g);
+    let all = NodeGraph::build_with(&g, NodeFilter::All);
+    // The literal is a third node + a second edge only under `All`.
+    assert_eq!(entities.len(), 2);
+    assert_eq!(all.len(), 3);
+    assert_eq!(entities.edge_count(), 1);
+    assert_eq!(all.edge_count(), 2);
+
+    // The literal node: in-degree 1 (a -> "Alice"), out-degree 0 (a literal is never a
+    // subject), i.e. a dangling sink. Find it as the node that is NOT one of the IRIs.
+    let a = all.index_of(g.id_of(&iri("http://e/a")).unwrap()).unwrap();
+    let b = all.index_of(g.id_of(&iri("http://e/b")).unwrap()).unwrap();
+    let lit = (0..all.len())
+        .find(|&i| i != a && i != b)
+        .expect("literal node present under NodeFilter::All");
+    assert_eq!(all.in_degree(lit), 1, "literal has one in-edge from a");
+    assert_eq!(all.out_degree(lit), 0, "literal is a sink (never a subject)");
+
+    // Degree centrality sees the literal as an in-degree-1 node.
+    let inc = degree_centrality(&all, Direction::In);
+    assert_eq!(inc[lit], 1);
+
+    // PageRank over the enlarged (literal-bearing) view is still a distribution.
+    let r = pagerank(&all, PageRankConfig::default());
+    assert_eq!(r.len(), 3);
+    let sum: f64 = r.iter().sum();
+    assert!(
+        (sum - 1.0).abs() < 1e-9,
+        "PageRank over NodeFilter::All view must sum to 1, got {}",
+        sum
+    );
+}

--- a/crates/sparq-canon/tests/bnode_isomorphism_and_bridge.rs
+++ b/crates/sparq-canon/tests/bnode_isomorphism_and_bridge.rs
@@ -1,0 +1,240 @@
+//! [OPUS-4.8] sq-bif.9: focused isolated cases for `sparq-canon`'s PUBLIC API.
+//!
+//! The manifest-driven `tests/rdf_canon_suite.rs` already drives the FULL 86-entry W3C
+//! RDFC-1.0 suite (eval + issued-id map + negative poison-graph), so this crate's test
+//! BREADTH is strong. This file adds the two pin-point cases the bead calls out, which the
+//! suite exercises only implicitly:
+//!
+//! 1. **Blank-node-isomorphism equivalence** — two graphs that differ ONLY in their
+//!    (lexical) blank-node labels and triple order must canonicalize to BYTE-IDENTICAL
+//!    output; a graph that is NOT isomorphic must canonicalize differently. The suite
+//!    proves isomorphism transitively across its vectors; this pins the core property
+//!    directly with a hand-built pair.
+//! 2. **oxrdf-bridge error / edge paths** — the single oxrdf-0.3 -> text -> oxrdf-0.2
+//!    bridge is the seam every sparq consumer shares. We pin (a) the RDF-1.2 triple-term
+//!    rejection on BOTH the quad (`canonicalize`) and the single-graph
+//!    (`canonicalize_triples`) entry points (they reject via different code paths), (b)
+//!    that the `CanonError` `Display` is non-empty and distinct per variant, and (c) that
+//!    datatyped / language-tagged literals survive the text round-trip losslessly (the
+//!    bridge's most fragile case).
+
+use oxrdf::{BlankNode, GraphName, Literal, NamedNode, NamedOrBlankNode, Quad, Term, Triple};
+use sparq_canon::{
+    canonicalize, canonicalize_triples, issued_identifiers, CanonError, CanonicalGraph,
+};
+
+fn iri(s: &str) -> NamedNode {
+    NamedNode::new(s).unwrap()
+}
+
+fn bnode(label: &str) -> NamedOrBlankNode {
+    NamedOrBlankNode::BlankNode(BlankNode::new(label).unwrap())
+}
+
+// ---------------------------------------------------------------------------
+// 1. Blank-node-isomorphism equivalence.
+// ---------------------------------------------------------------------------
+
+/// Builds a 2-triple, 2-blank-node "diamond" graph parameterized by the input blank-node
+/// labels and triple order. Shape (independent of labels):
+///   `_:x  <p>  _:y`
+///   `_:y  <q>  "v"`
+fn linked_bnode_graph(x: &str, y: &str, swap_order: bool) -> CanonicalGraph {
+    let t1 = Triple::new(
+        bnode(x),
+        iri("http://ex/p"),
+        Term::BlankNode(BlankNode::new(y).unwrap()),
+    );
+    let t2 = Triple::new(
+        bnode(y),
+        iri("http://ex/q"),
+        Term::Literal(Literal::new_simple_literal("v")),
+    );
+    let triples = if swap_order { vec![t2, t1] } else { vec![t1, t2] };
+    canonicalize_triples(&triples).expect("canonicalize")
+}
+
+/// Two graphs that differ ONLY in blank-node labels (`zzz/aaa` vs `p/q`) and triple order
+/// must produce byte-identical canonical N-Quads — that IS the RDFC-1.0 guarantee. Distinct
+/// from the inline `src` unit test in that it also asserts the canonical labels are the
+/// fully-relabelled `c14n` form and the line count, so a regression that, e.g., stopped
+/// relabelling is caught here too.
+#[test]
+fn isomorphic_graphs_under_different_bnode_labels_canonicalize_identically() {
+    let a = linked_bnode_graph("zzz", "aaa", false);
+    let b = linked_bnode_graph("p", "q", true);
+
+    assert_eq!(a.lines.len(), 2, "two triples -> two canonical lines");
+    assert_eq!(
+        a.lines, b.lines,
+        "isomorphic graphs (relabelled bnodes + permuted order) must be byte-identical"
+    );
+    // Every blank node was relabelled to the canonical c14n form; NO input label leaks.
+    let joined = a.to_nquads();
+    assert!(
+        joined.contains("_:c14n"),
+        "canonical form must use c14n labels: {joined}"
+    );
+    for leaked in ["zzz", "aaa", "_:p", "_:q"] {
+        assert!(
+            !joined.contains(leaked),
+            "input bnode label {leaked} leaked into canonical form: {joined}"
+        );
+    }
+}
+
+/// The negative side: a graph that is NOT isomorphic to the above (the literal differs)
+/// must canonicalize DIFFERENTLY. Without this, a degenerate "always return the same
+/// string" implementation would pass the positive test; this pins that canonicalization
+/// actually discriminates non-isomorphic graphs.
+#[test]
+fn non_isomorphic_graphs_canonicalize_differently() {
+    let a = linked_bnode_graph("zzz", "aaa", false);
+    // Same shape but a different literal value -> not isomorphic.
+    let t1 = Triple::new(
+        bnode("m"),
+        iri("http://ex/p"),
+        Term::BlankNode(BlankNode::new("n").unwrap()),
+    );
+    let t2 = Triple::new(
+        bnode("n"),
+        iri("http://ex/q"),
+        Term::Literal(Literal::new_simple_literal("DIFFERENT")),
+    );
+    let c = canonicalize_triples(&[t1, t2]).unwrap();
+    assert_ne!(
+        a.lines, c.lines,
+        "graphs differing in a literal must NOT share a canonical form"
+    );
+}
+
+/// Two blank nodes that are structurally INDISTINGUISHABLE (both are subjects of the same
+/// triple shape pointing at the same IRI) must each still receive a distinct, stable c14n
+/// label, and the issued-identifier map must be a bijection onto `{c14n0, c14n1}`. This is
+/// the "twins" case RDFC-1.0's n-degree hashing exists to disambiguate.
+#[test]
+fn structurally_symmetric_bnodes_get_distinct_stable_canonical_labels() {
+    let q1 = Quad::new(
+        bnode("aaa"),
+        iri("http://ex/p"),
+        Term::NamedNode(iri("http://ex/o")),
+        GraphName::DefaultGraph,
+    );
+    let q2 = Quad::new(
+        bnode("bbb"),
+        iri("http://ex/p"),
+        Term::NamedNode(iri("http://ex/o")),
+        GraphName::DefaultGraph,
+    );
+    let map = issued_identifiers(&[q1, q2]).unwrap();
+    assert_eq!(map.len(), 2, "two distinct input bnodes -> two issued ids");
+    let mut issued: Vec<&str> = map.values().map(String::as_str).collect();
+    issued.sort_unstable();
+    assert_eq!(
+        issued,
+        vec!["c14n0", "c14n1"],
+        "issued ids must be the canonical c14n0/c14n1 set: {map:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. oxrdf-bridge error / edge paths.
+// ---------------------------------------------------------------------------
+
+/// The RDF-1.2 triple-term rejection on the QUAD entry point (`canonicalize`). This is a
+/// DISTINCT code path from the single-graph `canonicalize_triples` rejection (validated by
+/// the inline unit test): `bridge_to_02` inspects `q.object` directly, whereas
+/// `canonicalize_triples` pre-scans with `contains_triple_term`. Both must fail closed.
+#[test]
+fn quad_with_triple_term_object_is_rejected_by_bridge() {
+    let inner = Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+        iri("http://ex/p"),
+        Term::Literal(Literal::new_simple_literal("v")),
+    );
+    let q = Quad::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+        iri("http://ex/p"),
+        Term::Triple(Box::new(inner)),
+        GraphName::DefaultGraph,
+    );
+    assert!(
+        matches!(canonicalize(&[q]), Err(CanonError::TripleTerm)),
+        "a quad with a triple-term object must be rejected (RDFC-1.0 data model)"
+    );
+}
+
+/// `CanonError`'s `Display` must be non-empty and DISTINCT per variant (so a fail-closed
+/// caller surfaces a meaningful message, and the variants are not accidentally collapsed
+/// to one string). The `Bridge` variant is otherwise only reachable internally, so this is
+/// the focused coverage of its formatting path the suite never triggers.
+#[test]
+fn canon_error_display_is_distinct_and_nonempty_per_variant() {
+    let tt = CanonError::TripleTerm.to_string();
+    let br = CanonError::Bridge("parse boom".into()).to_string();
+    let cz = CanonError::Canonicalization("hndq limit".into()).to_string();
+
+    for (label, msg) in [("TripleTerm", &tt), ("Bridge", &br), ("Canonicalization", &cz)] {
+        assert!(!msg.is_empty(), "{label} Display must be non-empty");
+    }
+    // The wrapped detail must be carried through, and the three messages must differ.
+    assert!(br.contains("parse boom"), "Bridge must carry its detail: {br}");
+    assert!(cz.contains("hndq limit"), "Canon must carry its detail: {cz}");
+    assert_ne!(tt, br);
+    assert_ne!(tt, cz);
+    assert_ne!(br, cz);
+}
+
+/// Bridge round-trip fidelity for the FRAGILE literal forms: a language-tagged literal and
+/// a datatyped literal must survive the oxrdf-0.3 -> canonical N-Quads text -> oxrdf-0.2
+/// seam losslessly (these are exactly where a naive `Display`/parse bridge silently drops
+/// the tag/datatype). Pin that the canonical output still carries both the language tag and
+/// the datatype IRI, and that the literal object is preserved byte-for-byte in the
+/// re-parsed canonical triple.
+#[test]
+fn bridge_preserves_language_tag_and_datatype_through_text_roundtrip() {
+    let lang = Literal::new_language_tagged_literal("chat", "fr").unwrap();
+    let typed = Literal::new_typed_literal("42", iri("http://www.w3.org/2001/XMLSchema#integer"));
+    let t_lang = Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+        iri("http://ex/says"),
+        Term::Literal(lang.clone()),
+    );
+    let t_typed = Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+        iri("http://ex/count"),
+        Term::Literal(typed.clone()),
+    );
+
+    let c = canonicalize_triples(&[t_lang, t_typed]).unwrap();
+    let doc = c.to_nquads();
+    assert!(
+        doc.contains("@fr"),
+        "language tag must survive the bridge: {doc}"
+    );
+    assert!(
+        doc.contains("XMLSchema#integer"),
+        "datatype IRI must survive the bridge: {doc}"
+    );
+    // The re-parsed canonical triples must carry back the EXACT literal terms.
+    let objects: Vec<Term> = c.triples.iter().map(|t| t.object.clone()).collect();
+    assert!(
+        objects.contains(&Term::Literal(lang)),
+        "language-tagged literal not preserved in canonical triple: {objects:?}"
+    );
+    assert!(
+        objects.contains(&Term::Literal(typed)),
+        "datatyped literal not preserved in canonical triple: {objects:?}"
+    );
+}
+
+/// Edge case: the empty dataset canonicalizes to the empty document (no error, no spurious
+/// lines). A trivial-but-real boundary the suite's non-empty vectors never hit.
+#[test]
+fn empty_dataset_canonicalizes_to_empty_document() {
+    assert_eq!(canonicalize(&[]).unwrap(), "");
+    let c = canonicalize_triples(&[]).unwrap();
+    assert!(c.lines.is_empty());
+    assert!(c.triples.is_empty());
+    assert_eq!(c.to_nquads(), "");
+}

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -110,6 +110,15 @@ PER_COMMIT_CRATES=(
   # WITH --features count-enforcement (the `case` in measure() below names it) — a default
   # build compiles that whole surface out and reports a non-representative number.
   sparq-policy
+  # [OPUS-4.8] sq-bif.8 / sq-bif.9: two OPT-IN, standalone crates that nothing in the
+  # default build depends on, both untracked by BOTH gates. Unlike the federation/policy
+  # crates above they have NO opt-in features (sparq-algos: `default = []` only; sparq-canon:
+  # no `[features]` table), so their WHOLE surface is compiled in a default-feature build —
+  # they need NO `case` arm in measure() and are measured exactly as-is. sparq-canon's number
+  # reflects its tests/rdf_canon_suite.rs driving the full 86-entry W3C RDFC-1.0 manifest plus
+  # the focused bnode-isomorphism / oxrdf-bridge unit cases; sparq-algos' reflects the inline
+  # PageRank/centrality/community oracles plus the tests/topology_oracles.rs integration suite.
+  sparq-algos sparq-canon
 )
 # Crates whose HEAVY tests are only run in the nightly tier.
 NIGHTLY_ONLY_NOTE="sparq-vectors heavy 50k recall/diskann tests run only in nightly tier"


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing **sq-bif.8** (`sparq-algos`) + **sq-bif.9** (`sparq-canon`) in ONE PR. They go together because BOTH wire into the shared per-crate coverage gate; separate PRs would conflict on `bench/coverage-floor.json` / `bench/coverage-presence.json` / `scripts/coverage.sh`. Mirrors the just-merged sq-bif.7 (#838) `sparq-policy` wiring. **No production `src/` change.**

## What

Both crates are OPT-IN, standalone members that nothing in the default build depends on, and both were **untracked by BOTH coverage gates** (absent from the floor JSON, the presence JSON, and `PER_COMMIT_CRATES`). This registers them + adds the focused tests each bead calls out.

### sq-bif.8 — `sparq-algos` integration suite
`crates/sparq-algos/tests/topology_oracles.rs` (NEW, 6 tests) drives the PUBLIC API over the topology classes the strong inline `src/lib.rs` oracles do **not** reach:
- **Dangling-node PageRank** — star-into-a-sink + chain-terminating-in-a-sink: mass is redistributed so the vector still sums to 1, and the sink out-ranks its sources / rank flows downstream.
- **Disconnected + isolated-node + chain topologies** — three disjoint components of different shapes (chain / edge / self-loop singleton): WCC partitions into exactly 3, and LP never merges across a WCC; a pure 4-chain is one WCC.
- **All-singleton community case** — a self-loops-only graph: every node is its own community under both WCC and LP.
- **`NodeFilter::All` literal-inclusion `build_with` path** — the literal becomes a dangling in-degree-1 sink node; PageRank over the enlarged view still sums to 1.

### sq-bif.9 — `sparq-canon` focused cases
`crates/sparq-canon/tests/bnode_isomorphism_and_bridge.rs` (NEW, 7 tests). The crate's breadth is already strong (`tests/rdf_canon_suite.rs` drives the full 86-entry W3C RDFC-1.0 manifest); this pins the cases the suite covers only implicitly:
- **Blank-node-isomorphism equivalence** — graphs differing only in bnode labels + triple order canonicalize byte-identically; a non-isomorphic graph differs; structurally-symmetric "twin" bnodes still get distinct stable `c14n` ids.
- **oxrdf-bridge error / edge paths** — RDF-1.2 triple-term rejection on the *quad* path (distinct from the `triples` path), `CanonError` `Display` non-empty + distinct per variant, language-tag / datatype literal lossless text round-trip, empty-dataset edge.

## Coverage-gate wiring + floors
- `scripts/coverage.sh` — both added to `PER_COMMIT_CRATES`. **No `measure()` `case` arm**: unlike the federation/policy crates, neither has opt-in features (sparq-algos `default = []`; sparq-canon no `[features]` table), so the default build is the full surface.
- `bench/coverage-floor.json` — floors = `floor(measured) − 2` margin: **sparq-algos 97** (measured 99.14%, 575/580), **sparq-canon 77** (measured 79.04%, 181/229). Conservative work-box seed; CI's `--check-robust` is the ratchet of record. (Floors set to CURRENT coverage — not raised; the floor-raise is sq-qcnn's mandate.)
- `bench/coverage-presence.json` — **sparq-algos** `min_tests 26` (28 measured) + integration dir; **sparq-canon** `min_tests 12` (14 measured) + integration dir.

## Gates verified (local, work box)

Both crates have a single, complete feature state (no opt-in features → "both feature states" collapses to the default state for each):
- `cargo clippy -p sparq-algos --all-targets -- -D warnings` ✅
- `cargo clippy -p sparq-canon --all-targets -- -D warnings` ✅
- `cargo test -p sparq-algos` ✅ (22 unit + 6 new integration + doctest)
- `cargo test -p sparq-canon` ✅ (5 unit + 7 new + W3C suite drivers + doctest)

Gate self-checks (local):
- `coverage-presence.py --check` → `sparq-algos: 28 (floor 26) +integ`, `sparq-canon: 14 (floor 12) +integ`, 35 ok / 0 fail.
- `coverage-gate.py --check <summary>` → `sparq-algos 99.14% ≥ 97`, `sparq-canon 79.04% ≥ 77`.
- `coverage-gate.py --check-monotonic` → PASS (new crates; no floor lowered).

Privacy-claims gate: N/A (no ZK/MPC claims). No bug found — no bead filed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)