### PR TITLE
chore(hygiene): periodic sweep + UPSTREAM.md currency (sq-v7be) [OPUS-4.8]

### DIFF
--- a/.claude/agents/compliance-engineer.md
+++ b/.claude/agents/compliance-engineer.md
@@ -67,7 +67,7 @@ assigned **one framework** (your worktree branch is `cert-<framework>`). Produce
   gap to a higher level (e.g. cargo-auditable, reproducibility evidence).
 - **OpenSSF Scorecard + Best-Practices/CII Badge** — Scorecard is wired; produce the Best-Practices
   (bestpractices.dev) self-certification questionnaire mapping + raise the Scorecard score.
-- **Memory-safety attestation** — the `#![forbid(unsafe_code)]` posture (23 crates), the concentrated
+- **Memory-safety attestation** — the `#![forbid(unsafe_code)]` posture (31 crates as of 2026-06-19), the concentrated
   unsafe surface in `sparq-core` (mmap/dict-spill/SIMD, the B5 boundary), Miri + fuzz + the oracle for
   the sites Miri can't reach; a per-unsafe-site justification register and (ideally) an unsafe-count
   ratchet promoting cargo-geiger from informational to gating.

--- a/crates/sparq-hdt/UPSTREAM.md
+++ b/crates/sparq-hdt/UPSTREAM.md
@@ -1,83 +1,73 @@
-<!-- [OPUS-4.8] sq-2te — upstream contributions queued against KonradHoeffner/hdt. -->
+<!-- [OPUS-4.8] sq-2te / sq-v7be — upstream-contribution status for KonradHoeffner/hdt. -->
 # Upstream contributions to `KonradHoeffner/hdt`
 
-This crate WRAPS [`hdt`](https://github.com/KonradHoeffner/hdt) (MIT). One API
-gap in the wrapped crate (as of `hdt` 0.4) makes our `save` / `load` paths pull a
-dependency they should not have to. It is a tractable upstream addition; the text
-below is ready to file.
+This crate WRAPS [`hdt`](https://github.com/KonradHoeffner/hdt) (MIT). This file
+tracks the two upstream gaps the sparq-hdt work originally queued against it and
+their CURRENT status against `hdt` master / 0.6.x.
 
-> **Update (sq-ashy):** the temp-N-Triples round-trip in `write.rs` is GONE. `save`
-> now encodes the FourSectDict PFC + BitmapTriples sections DIRECTLY from sparq's
-> in-memory dict + triples (`src/encode.rs`, the inverse of `decode.rs`) by feeding
-> the wrapped crate's **public** section builders (`DictSectPFC::compress`,
-> `TriplesBitmap::from_triples`) and replaying `Hdt::write`'s section order with the
-> public section writers. So we no longer NEED an upstream in-memory builder; the
-> only residual cost is that those builders are reachable solely via the `sophia`
-> feature (see below).
+> **Status (sq-v7be, verified 2026-06-19 against `KonradHoeffner/hdt` master):**
+> - **Builder gap — OBVIATED (no upstream change needed from us).** See item 1.
+> - **Decode-only entry point — OPEN UPSTREAM DRAFT PR
+>   [`KonradHoeffner/hdt#124`](https://github.com/KonradHoeffner/hdt/pull/124).**
+>   See item 2.
 
 ---
 
-## Issue / PR 1 — sq-ashy: feature-gate the section builders off `sophia`
+## Item 1 — in-memory section builders without `sophia` — OBVIATED
 
-**Title:** Make the in-memory section builders usable without the `sophia` feature
+**Original ask (sq-ashy):** make the in-memory section builders usable without
+pulling the `sophia` adapter dependency tree, so sparq could WRITE a `.hdt` from
+its own in-memory dict + triples with no N-Triples text round-trip.
 
-**Body:**
+**Why it is obviated.** On current `hdt` master the section builders sparq needs
+are already `pub` and **not** gated behind `sophia`:
 
-The pieces needed to BUILD an archive in memory — `DictSectPFC::compress`,
-`FourSectDict { … }`, `TriplesBitmap::from_triples`, and the `*::write` methods —
-are already `pub`. A consumer that holds triples in memory can build + write a
-spec-conformant `.hdt` directly from them (we do exactly this in
-`sparq-hdt/src/encode.rs`), with NO N-Triples text round-trip.
+- `DictSectPFC::compress(&BTreeSet<&str>, block_size) -> DictSectPFC` — gate-free.
+- `TriplesBitmap::from_triples(&[TripleId]) -> TriplesBitmap` — gate-free.
 
-The remaining friction is the FEATURE GATE: the only documented build entry point,
-`Hdt::read_nt`, lives behind `sophia`, and enabling it pulls the whole sophia
-adapter dependency tree (oxttl + the sophia term model) even for a consumer that
-never touches a sophia term — it only wants `compress` / `from_triples` / `write`.
+Upstream also split the N-Triples ingest path (`lasso` / `oxttl`) out into its own
+`nt` feature, so the `sophia` term adapter is no longer dragged in just to reach
+the builders. (Note: there is **no** `Hdt::from_triples` constructor on the `Hdt`
+struct itself — the in-memory build is done at the section level via the two
+builders above, which is what sparq does.)
 
-**Request.** Expose an in-memory builder (and/or move the existing section builders)
-behind a lighter, sophia-free feature, e.g.
+sparq already builds + writes a spec-conformant archive directly from these:
+`sparq-hdt/src/encode.rs` calls `DictSectPFC::compress` per FourSectDict section and
+`TriplesBitmap::from_triples` for the SPO bitmaps, with **no** N-Triples text
+round-trip (the `save` path — `crates/sparq-hdt/src/write.rs` — and the
+`encode.rs`/`decode.rs` round-trip oracle confirm this). So no upstream change is
+required for the write path; this item is closed (tracked under landed bead
+`sq-ashy`).
 
-```rust
-impl Hdt {
-    /// Build an archive from an iterator of (subject, predicate, object) term
-    /// strings (IRIs bare, blank nodes `_:label`, literals in N-Triples lexical
-    /// shape — i.e. the dictionary's own string encoding).
-    pub fn from_triples<I, S>(triples: I) -> Result<Self>
-    where
-        I: IntoIterator<Item = (S, S, S)>,
-        S: AsRef<str>;
-}
-```
-
-This is essentially what `read_nt` does AFTER it has parsed the file:
-`FourSectDict::read_nt` builds the dictionary and the encoded triples, then
-`TriplesBitmap::from_triples` builds the bitmaps — both already exist. A builder /
-feature that does not depend on `sophia`/oxttl would decouple "I want to WRITE HDT"
-from "I want the sophia term adapter".
-
-We're happy to open the PR. Reference implementations for cross-checking the
-on-disk layout: ENCODE — `sparq-hdt/src/encode.rs`; DECODE — `sparq-hdt/src/decode.rs`.
+> **Caveat — sparq is still pinned to `hdt` 0.4.** On the wrapped crate's **0.4**
+> line these section builders are reachable only via the experimental `sophia`
+> feature, so sparq-hdt's `write` cargo-feature still turns it on
+> (`Cargo.toml: write = ["hdt/sophia"]`); the `sophia`-free reachability described
+> above is the situation on `hdt` **master / 0.6**. The 0.4 → 0.6 bump is itself
+> blocked (the 0.6 path pulls `qwt`, whose default `prefetch` feature needs nightly
+> on aarch64) — tracked by `sq-2l1` / `sq-th5i`. So the *upstream contribution* is
+> obviated (we never need to file it), but sparq keeps paying the `sophia` gate for
+> writes until that dependency bump lands.
 
 ---
 
-## Issue / PR 2 — sq-fkj: a decode-only / streaming-triples entry point (skip query indexes on bulk ingest)
+## Item 2 — decode-only / streaming-triples entry point — OPEN UPSTREAM DRAFT PR
 
-**Title:** Add a decode-only `Hdt::triples_streaming(reader)` that skips
-`TriplesBitmap` query-index construction
+**Status:** open **draft** PR
+[`KonradHoeffner/hdt#124`](https://github.com/KonradHoeffner/hdt/pull/124)
+(`feat: decode-only Hdt::triples_streaming (skip query-index build on bulk reads)`),
+authored by `@jeswr`. It is **jeswr-review-gated** — not yet marked ready for
+maintainer review — so it is not merged. Tracking bead: `sq-fkj`.
 
-**Body:**
-
-`Hdt::read` eagerly calls `TriplesBitmap::new`, which builds — purely to serve
-triple-pattern / object / predicate QUERIES — a `WaveletMatrix`, a per-object
-`Vec<Vec<u32>>`, a `sort_by_cached_key`, and an OP-index (`CompactVector` +
-`Rank9Sel` bitmap). A consumer doing a one-shot bulk load (read every triple once,
-in SPO order, into its own store) never issues those queries, so all of that is
-built and immediately dropped — a large, cache-hostile cost on ingest.
-
-**Request.** A decode-only entry point that reads the dictionary + the `bitmap_y`,
-`bitmap_z`, `sequence_y`, `sequence_z` sections and yields `(s, p, o)` ids (or term
-strings) in SPO order **without** constructing the `TriplesBitmap` query
-structures, e.g.
+**What it adds.** `Hdt::read` eagerly calls `TriplesBitmap::new`, which builds —
+purely to serve triple-pattern / object / predicate QUERIES — a `WaveletMatrix`,
+a per-object `Vec<Vec<u32>>`, a `sort_by_cached_key`, and an OP-index
+(`CompactVector` + `Rank9Sel` bitmap). A consumer doing a one-shot bulk load (read
+every triple once, in SPO order, into its own store) never issues those queries, so
+all of that is built and immediately dropped — a large, cache-hostile cost on
+ingest. The PR adds a decode-only entry point that reads the dictionary +
+`bitmap_y` / `bitmap_z` / `sequence_y` / `sequence_z` and yields triples in SPO
+order WITHOUT constructing the `TriplesBitmap` query structures, e.g.
 
 ```rust
 impl Hdt {
@@ -88,8 +78,11 @@ impl Hdt {
 }
 ```
 
-Reference implementation: `sparq-hdt/src/decode.rs` already does exactly this
-(it reads the same on-disk bytes, walks the bitmaps with a plain bit read, and
-skips the rank/select build) and is differentially tested against the full
-`Hdt::read` path on real and generated archives. If upstream adopts a decode-only
-path we can delete our vendored decoder and call it instead.
+**Reference implementation.** `sparq-hdt/src/decode.rs` already does exactly this —
+it is the DEFAULT load path (`decode::graph_from_reader`, driven by the public
+`load_reader` in `lib.rs`): it reads the same on-disk bytes, walks the bitmaps with
+a plain bit read, and skips the rank/select build. It is differentially tested
+against the full `Hdt::read` path (retained only as the oracle,
+`load_reader_via_upstream` in `lib.rs`) on real and generated archives. If the
+upstream PR lands we can delete our vendored decoder and call the upstream entry
+point instead.

--- a/research/production-certification-plan.md
+++ b/research/production-certification-plan.md
@@ -56,7 +56,7 @@ sparq is different in three load-bearing ways, and the framework set must follow
 | **SLSA build provenance** | A dependency's supply-chain trust hinges on *verifiable build provenance*. sparq already emits `attest-build-provenance` + buildkit `provenance: mode=max` on release; declare the honest level (≈L2 on GitHub-hosted runners) + the gap to higher (reproducibility, cargo-auditable). |
 | **OpenSSF Scorecard + Best-Practices (CII) Badge** | The de-facto open-source-security posture signal consumers check. Scorecard is wired (`scorecard.yml`, `publish_results`); add the Best-Practices self-certification + raise the score. |
 | **EU Cyber Resilience Act (CRA)** | sparq, distributed on crates.io/npm/PyPI/ghcr, is a "product with digital elements." CRA's Annex I essential requirements + vuln-handling obligations (coordinated disclosure, SBOM, security updates, support period) are the *binding regulatory* regime — replaces Cyber Essentials as the right "you must do this to ship in the EU" anchor. |
-| **Memory-safety attestation** | sparq's headline safety claim. Attest the `#![forbid(unsafe_code)]` posture (23 crates), enumerate + justify the concentrated `sparq-core` unsafe (mmap/dict-spill/SIMD = threat-model boundary **B5**), and the Miri + fuzz + oracle coverage; promote cargo-geiger to a gating unsafe-count ratchet. |
+| **Memory-safety attestation** | sparq's headline safety claim. Attest the `#![forbid(unsafe_code)]` posture (31 of the 34 lib crates as of 2026-06-19 — verify live with `grep -lE 'forbid\(unsafe_code\)' $(git ls-files 'crates/*/src/lib.rs') \| wc -l`; the three lib crates that do NOT forbid are `sparq-core`, `sparq-vectors`, `sparq-zk-compose`), enumerate + justify the concentrated `sparq-core` unsafe (mmap/dict-spill/SIMD = threat-model boundary **B5**), and the Miri + fuzz + oracle coverage; promote cargo-geiger to a gating unsafe-count ratchet. |
 | **Cryptographic review (ZK/MPC)** | sparq ships `sparq-zk`/`sparq-zk-compose`/`sparq-mpc`. A documented crypto review of the soundness/privacy claims (anchored on `research/zk-soundness-audit.md`), constant-time + FIPS considerations, and the explicit "research scaffold, NO guarantee" statement. External-cryptographer sign-off is out of agent scope. |
 
 ### Final target set (12 worktrees)
@@ -98,7 +98,7 @@ nightly), Miri lane (nightly, `sparq-core`), SLSA `attest-build-provenance` + bu
 mode=max` + SHA256SUMS on release, distroless non-root SHA-pinned `Dockerfile` + docker-smoke gate,
 SHA-pinned actions (policy), ci-summary branch-protection aggregator, `SECURITY.md` (GHSA + email,
 response targets, the ZK-not-sound + MPC-deferred caveats), `research/threat-model.md` (STRIDE,
-boundaries B1–B5), `#![forbid(unsafe_code)]` in 23 crates, daily dependency-monitoring advisory
+boundaries B1–B5), `#![forbid(unsafe_code)]` in 31 crates, daily dependency-monitoring advisory
 watchdog, Dependabot (4 ecosystems), CODEOWNERS, CONTRIBUTING.md (with disclosure redirect).
 
 ### Cross-cutting gaps

--- a/research/release-ci-design.md
+++ b/research/release-ci-design.md
@@ -35,9 +35,9 @@ the manual path has fallen behind:
 
 Supporting facts, all verified in this checkout:
 
-- **Versioning is a single locked version.** All 35 workspace crates set
-  `version.workspace = true` (verified: `grep -l 'version.workspace = true' crates/*/Cargo.toml`
-  returns 35), inheriting one value `[workspace.package] version = "0.1.0"`
+- **Versioning is a single locked version.** All 36 workspace crates set
+  `version.workspace = true` (verified 2026-06-19: `grep -l 'version.workspace = true' crates/*/Cargo.toml`
+  returns 36), inheriting one value `[workspace.package] version = "0.1.0"`
   (`Cargo.toml:18`). There is no independent per-crate versioning. Several crates also
   carry hard-coded `version = "0.1.0"` pins on internal path-deps, so a bump touches two
   kinds of location — the dual-bump chore `docs/release.md` documents by hand.
@@ -334,8 +334,8 @@ the credential/store-signing items are `needs:user` and sit at the end of their 
 
 ## Files cited (all real, in this checkout)
 
-- `Cargo.toml` (`:18` workspace version; 35-member workspace; no `[workspace.metadata.dist]`)
-- `crates/*/Cargo.toml` (all 35 use `version.workspace = true`; 17 publishable;
+- `Cargo.toml` (`:18` workspace version; 36-member workspace; no `[workspace.metadata.dist]`)
+- `crates/*/Cargo.toml` (all 36 use `version.workspace = true`; 17 publishable;
   `crates/sparq-algos/Cargo.toml` has no `publish = false`;
   `crates/sparq-server/Cargo.toml` `[[bin]] name = "sparq-server"`,
   `required-features = ["server"]`)


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the `jeswr/sparq` RDF/SPARQL engine (Claude Opus 4.8). @jeswr runs multiple agents; this was opened by the **SPARQ** agent.

Periodic repo-hygiene sweep + the folded-in `sq-v7be` doc-currency bead. **DOC/HYGIENE-ONLY** (no `crates/` source).

## `crates/sparq-hdt/UPSTREAM.md` — reconciled to current upstream reality
Verified 2026-06-19 against `KonradHoeffner/hdt` master.
- **Item 1 (sophia-free in-memory section builders) → OBVIATED upstream.** `DictSectPFC::compress` and `TriplesBitmap::from_triples` are `pub` and **gate-free** on master/0.6, and the N-Triples ingest path is now a separate `nt` feature — so the upstream contribution we had queued is no longer needed. Corrected the prior draft's overstatement: there is **no** `Hdt::from_triples` constructor on the `Hdt` struct; the in-memory build is at the section level. **Preserved the load-bearing caveat** that sparq is still pinned to `hdt` **0.4** (where those builders are `sophia`-gated, so `write = ["hdt/sophia"]` still applies) until the 0.4→0.6 bump (`sq-2l1`/`sq-th5i`) lands.
- **Item 2 (decode-only entry point) → OPEN DRAFT upstream PR** [`KonradHoeffner/hdt#124`](https://github.com/KonradHoeffner/hdt/pull/124) (jeswr-review-gated, **not merged**); recorded the URL + status. Tracking bead `sq-fkj`.

## Verified count-drift fixes (invent no numbers; repro command cited inline)
- `forbid(unsafe_code)` crate count **23 → 31** in `research/production-certification-plan.md` (×2) + `.claude/agents/compliance-engineer.md`. 31 of the 34 lib crates; exceptions `sparq-core`/`sparq-vectors`/`sparq-zk-compose`. Repro: `grep -lE 'forbid\(unsafe_code\)' $(git ls-files 'crates/*/src/lib.rs') | wc -l`.
- Workspace total **35 → 36** crates in `research/release-ci-design.md` (all 36 set `version.workspace=true`). The **17 publishable** figure was already correct everywhere (`docs/release.md`, `release-plz.toml`/`.yml`) and is unchanged.

## Obligations checked (all clean on main)
- Honesty gates re-run clean after edits: `check-terminology.py`, `check-no-perf-numbers.py --enforce`, `check-privacy-claims.sh` (all wired LIVE in `docs-quality.yml`). markdownlint: 0 errors.
- Counts re-verified against the latest main: skill-surface router enumerates all **25** surfaces (no drift); ZK circuit family = **28** compiled members matching the SKILL bucket enumeration; SHACL floors `BASELINE_PASS=98` (98/98) + `BASELINE_PASS_CORE=44` (44/45 af-off, 45/45 af-on) match the README.
- No new scratch/handover docs; no actionable markdown TODOs (the `[ ]` items found are a TDD template + an operator runbook checklist — legitimate).
- **No unqualified ZK/MPC privacy/soundness claim introduced**; the ZK not-yet-sound / `sq-qhy4` open-audit caveat is preserved.

Bead/issue work (not in this PR): closed `sq-0enu` + `sq-cvwl` (confirmed already on main); `sq-v7be` closed on merge. from-pss `#53`/`#55` confirmed legitimately open with existing tracking beads.

Opened **without** auto-merge per the sweep brief.