### PR TITLE
feat(site): pretty/indented Turtle serialisation in REPL + results (#805, sq-gb4o) [OPUS-4.8]

### DIFF
--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -389,10 +389,25 @@ export {
   tokenizeTurtle,
 } from "./turtle-highlight.js";
 
+// [OPUS-4.8] sq-gb4o (#805) — the pretty/indented Turtle serialiser. The engine answers
+// CONSTRUCT/DESCRIBE (and the dataset viewer's all-quads query) as FLAT N-Triples; this reshapes
+// that into idiomatic grouped Turtle (`@prefix` abbreviation, subject blocks, `;`/`,` lists)
+// while staying round-trip-equivalent. Dependency-free + DOM-free so the site and the Tauri
+// webview share it. Compose with the highlighter as pretty-print THEN `tokenizeTurtle`.
+export {
+  type PrettyTurtleOptions,
+  type RdfStatement,
+  type RdfTerm,
+  parseNTriples,
+  prettyTrig,
+  prettyTurtle,
+} from "./pretty-turtle.js";
+
 export {
   type PrefixBinding,
   COMMON_PREFIXES,
   declaredPrefixes,
+  declaredPrefixBindings,
   usedPrefixes,
   missingCommonPrefixes,
   renderPrefixLines,

--- a/packages/sparq-client/src/pretty-turtle.ts
+++ b/packages/sparq-client/src/pretty-turtle.ts
@@ -1,0 +1,533 @@
+// [OPUS-4.8] sq-gb4o (#805) — a dependency-free, framework-agnostic PRETTY-Turtle serialiser.
+//
+// The wasm engine answers CONSTRUCT/DESCRIBE (and the dataset viewer's `SELECT ?s ?p ?o`) as a
+// FLAT N-Triples document — one `s p o .` per line — because N-Triples ⊂ Turtle and that is the
+// cheapest correct wire shape. The website wants the SAME data as IDIOMATIC, grouped, indented
+// Turtle: `@prefix` abbreviation, one block per subject, predicate-object lists joined with `;`,
+// shared-predicate object lists joined with `,`. The engine exposes no pretty serialiser (see
+// `sparq_wasm.d.ts` — `queryQuads` is N-Triples only), so this module is the site-side reshaper.
+//
+// It is DEPENDENCY-FREE and FRAMEWORK-AGNOSTIC (no DOM, no React) so the same code serves the
+// Next.js site and the Tauri 2 webview, and is unit-testable under `node --test`. Composition
+// with the highlighter (`tokenizeTurtle`) is "pretty-print THEN highlight": this returns a
+// string, `RdfHighlight` tokenises it.
+//
+// Design goals, in priority order:
+//   1. CORRECTNESS / round-trip equivalence. The output is a Turtle document that, re-parsed,
+//      yields exactly the same set of triples as the input. Literals (incl. datatype/langtag),
+//      blank nodes (labels preserved verbatim), and RDF 1.2 triple terms `<<( s p o )>>` are
+//      reproduced losslessly. We NEVER reformat the inside of a literal or an IRI.
+//   2. NEVER THROW. This is a forgiving reshaper over engine output. A line we cannot parse as a
+//      statement is passed through verbatim (so malformed input degrades to flat output, not a
+//      crash). The site falls back to the raw text on any thrown error anyway.
+//   3. Idiomatic Turtle: prefix abbreviation, `a` for rdf:type, subject grouping, `;`/`,` lists,
+//      stable ordering (subjects + predicates + objects sorted by their N-Triples form) so the
+//      output is deterministic regardless of triple emission order.
+//
+// What it is NOT: a general Turtle parser. The input is N-Triples / N-Quads (the engine's
+// output) — `term . term . term .` with `<iri>`, `_:bnode`, `"lit"`(`^^dt`|`@lang`) terms and an
+// optional 4th graph term, plus the RDF 1.2 `<<( s p o )>>` object-position triple term. That is
+// the whole grammar we tokenise. (Named graphs are handled by `prettyTrig`, which wraps each
+// graph's triples in a `GRAPH <g> { … }` block.)
+
+import { COMMON_PREFIXES, type PrefixBinding } from "./sparql-prefixes.js";
+
+const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+/** A parsed RDF term. The `nt` field is the term's exact N-Triples spelling — the round-trip
+ * anchor and the stable-sort key — so even a term we choose to abbreviate can be re-emitted
+ * losslessly when abbreviation does not apply. */
+export type RdfTerm =
+  | { kind: "iri"; value: string; nt: string }
+  | { kind: "bnode"; label: string; nt: string }
+  | { kind: "literal"; value: string; datatype?: string; lang?: string; nt: string }
+  | { kind: "triple"; s: RdfTerm; p: RdfTerm; o: RdfTerm; nt: string };
+
+/** One parsed statement: subject, predicate, object, and an optional named graph. */
+export interface RdfStatement {
+  s: RdfTerm;
+  p: RdfTerm;
+  o: RdfTerm;
+  g?: RdfTerm;
+}
+
+/** Options for {@link prettyTurtle}. */
+export interface PrettyTurtleOptions {
+  /** Extra prefix bindings to consider for abbreviation, ahead of {@link COMMON_PREFIXES}.
+   * Typically the prefixes the user's query DECLARES (see `declaredPrefixes` + an IRI map). */
+  prefixes?: readonly PrefixBinding[];
+  /** Indent unit for predicate/object continuation lines. Default two spaces. */
+  indent?: string;
+  /** When `false`, no `@prefix` header is emitted and IRIs stay in full `<…>` form. Default
+   * `true`. */
+  abbreviate?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Tokeniser / parser for N-Triples / N-Quads terms (the engine's wire shape).
+// ---------------------------------------------------------------------------
+
+const isWsByte = (c: string): boolean =>
+  c === " " || c === "\t" || c === "\r" || c === "\n" || c === "\f" || c === "\v";
+
+/** A cursor-style parser over one statement worth of N-Triples/N-Quads text. */
+class TermReader {
+  private i = 0;
+  constructor(private readonly s: string) {}
+
+  /** Skip whitespace; return true if more non-whitespace remains. */
+  private skipWs(): boolean {
+    while (this.i < this.s.length && isWsByte(this.s[this.i])) this.i++;
+    return this.i < this.s.length;
+  }
+
+  /** Whether the next non-ws char is the statement terminator `.`. */
+  atTerminator(): boolean {
+    this.skipWs();
+    return this.i < this.s.length && this.s[this.i] === ".";
+  }
+
+  consumeTerminator(): void {
+    this.skipWs();
+    if (this.s[this.i] === ".") this.i++;
+  }
+
+  /** The remaining (trimmed) text — used to detect trailing junk. */
+  rest(): string {
+    return this.s.slice(this.i).trim();
+  }
+
+  /**
+   * Parse the next RDF term (IRI / blank node / literal / RDF 1.2 triple term). Throws if the
+   * cursor is not at a recognisable term — the caller treats a throw as "pass this line
+   * through verbatim".
+   */
+  next(): RdfTerm {
+    if (!this.skipWs()) throw new Error("unexpected end of statement");
+    const c = this.s[this.i];
+    if (c === "<") {
+      // Either an IRI `<…>` or an RDF 1.2 triple term `<<( s p o )>>`.
+      if (this.s[this.i + 1] === "<" && this.s[this.i + 2] === "(") return this.tripleTerm();
+      return this.iri();
+    }
+    if (c === "_" && this.s[this.i + 1] === ":") return this.bnode();
+    if (c === '"') return this.literal();
+    throw new Error(`unrecognised term at offset ${this.i}`);
+  }
+
+  private iri(): Extract<RdfTerm, { kind: "iri" }> {
+    const start = this.i;
+    this.i++; // past '<'
+    while (this.i < this.s.length && this.s[this.i] !== ">") {
+      // IRIs cannot contain a raw '>'; '\>' is a (rare) escape — skip the escaped char.
+      if (this.s[this.i] === "\\") this.i++;
+      this.i++;
+    }
+    if (this.s[this.i] !== ">") throw new Error("unterminated IRI");
+    this.i++; // past '>'
+    const nt = this.s.slice(start, this.i);
+    // The IRI value is the bytes between < and >, with N-Triples escapes left as-is (we only
+    // ever re-emit them, never interpret them, so the round-trip is exact).
+    const value = nt.slice(1, -1);
+    return { kind: "iri", value, nt };
+  }
+
+  private bnode(): RdfTerm {
+    const start = this.i;
+    this.i += 2; // past '_:'
+    // BLANK_NODE_LABEL allows an internal '.', so consume dots too — then trim any trailing '.'
+    // (the grammar forbids a label ENDING in '.', so a trailing dot is the statement terminator
+    // or a triple-term close). This keeps a dotted label like `_:b.1` intact.
+    while (
+      this.i < this.s.length &&
+      !isWsByte(this.s[this.i]) &&
+      this.s[this.i] !== ")"
+    ) {
+      this.i++;
+    }
+    while (this.i > start + 2 && this.s[this.i - 1] === ".") this.i--;
+    const nt = this.s.slice(start, this.i);
+    return { kind: "bnode", label: nt.slice(2), nt };
+  }
+
+  private literal(): RdfTerm {
+    const start = this.i;
+    this.i++; // past opening '"'
+    // N-Triples literals are always double-quoted, single-line, with \-escapes.
+    while (this.i < this.s.length && this.s[this.i] !== '"') {
+      if (this.s[this.i] === "\\") this.i++;
+      this.i++;
+    }
+    if (this.s[this.i] !== '"') throw new Error("unterminated literal");
+    this.i++; // past closing '"'
+    const lexEnd = this.i;
+    const value = this.s.slice(start + 1, lexEnd - 1);
+    let datatype: string | undefined;
+    let lang: string | undefined;
+    if (this.s[this.i] === "@") {
+      this.i++;
+      const ls = this.i;
+      while (
+        this.i < this.s.length &&
+        !isWsByte(this.s[this.i]) &&
+        this.s[this.i] !== "." &&
+        this.s[this.i] !== ")"
+      ) {
+        this.i++;
+      }
+      lang = this.s.slice(ls, this.i);
+    } else if (this.s[this.i] === "^" && this.s[this.i + 1] === "^") {
+      this.i += 2;
+      this.skipWs();
+      if (this.s[this.i] !== "<") throw new Error("expected datatype IRI");
+      const dt = this.iri();
+      datatype = dt.value;
+    }
+    const nt = this.s.slice(start, this.i);
+    return { kind: "literal", value, datatype, lang, nt };
+  }
+
+  private tripleTerm(): RdfTerm {
+    const start = this.i;
+    this.i += 3; // past '<<('
+    const s = this.next();
+    const p = this.next();
+    const o = this.next();
+    this.skipWs();
+    if (this.s[this.i] === ")" && this.s[this.i + 1] === ">" && this.s[this.i + 2] === ">") {
+      this.i += 3;
+    } else {
+      throw new Error("unterminated triple term");
+    }
+    const nt = this.s.slice(start, this.i);
+    return { kind: "triple", s, p, o, nt };
+  }
+}
+
+/**
+ * Parse an N-Triples / N-Quads document into statements. Lines that do not parse cleanly as a
+ * statement are returned in `passthrough` (verbatim, including their original text) so the
+ * caller can emit them unchanged rather than dropping or mangling them. NEVER throws.
+ *
+ * The parser is statement-oriented but newline-tolerant: it reads term-by-term and consumes the
+ * `.` terminator, so a statement split across lines (or several statements on one line) is still
+ * handled. A `passthrough` chunk is a maximal run of input we could not interpret.
+ */
+export function parseNTriples(input: string): {
+  statements: RdfStatement[];
+  passthrough: string[];
+} {
+  const statements: RdfStatement[] = [];
+  const passthrough: string[] = [];
+  // Split on lines but re-join a statement that legitimately spans lines is overkill for engine
+  // output (which is one statement per line). We parse line-by-line; a line that fails to parse
+  // is kept verbatim. A blank or comment line is skipped silently (no passthrough noise).
+  for (const rawLine of input.split("\n")) {
+    const line = rawLine.trim();
+    if (line.length === 0 || line.startsWith("#")) continue;
+    try {
+      const r = new TermReader(line);
+      const s = r.next();
+      const p = r.next();
+      const o = r.next();
+      let g: RdfTerm | undefined;
+      if (!r.atTerminator()) {
+        // A 4th term before the '.' is the N-Quads named graph.
+        g = r.next();
+      }
+      r.consumeTerminator();
+      if (r.rest().length !== 0) throw new Error("trailing content after statement");
+      statements.push({ s, p, o, g });
+    } catch {
+      passthrough.push(rawLine);
+    }
+  }
+  return { statements, passthrough };
+}
+
+// ---------------------------------------------------------------------------
+// Prefix abbreviation.
+// ---------------------------------------------------------------------------
+
+// Turtle local-name (PN_LOCAL) acceptance — conservative: a local part we can write WITHOUT
+// percent/backslash escaping. If the suffix would need escaping we keep the IRI in full `<…>`
+// form (always valid), rather than risk producing an unparseable prefixed name. Allowed: the
+// ASCII name chars plus `_`, `-`, `.`, `:` and `%` (already-encoded). We forbid a leading or
+// trailing `.` (Turtle PN_LOCAL rule) by checking the ends.
+const PN_LOCAL_OK = /^[A-Za-z0-9_%:]([A-Za-z0-9_.\-%:]*[A-Za-z0-9_%:])?$/;
+
+/** A prefix candidate: a label and the namespace IRI it abbreviates. */
+interface PrefixCandidate {
+  prefix: string;
+  iri: string;
+}
+
+/**
+ * Build the ordered list of prefix candidates to try when abbreviating IRIs: the caller's
+ * `extra` bindings first (so a query's own declarations win), then the well-known
+ * {@link COMMON_PREFIXES}, de-duplicated by namespace IRI (first label for an IRI wins). The
+ * empty-prefix `:` is allowed.
+ */
+function prefixCandidates(extra: readonly PrefixBinding[]): PrefixCandidate[] {
+  const out: PrefixCandidate[] = [];
+  const seenIri = new Set<string>();
+  const seenPrefix = new Set<string>();
+  for (const b of [...extra, ...COMMON_PREFIXES]) {
+    if (seenIri.has(b.iri) || seenPrefix.has(b.prefix)) continue;
+    seenIri.add(b.iri);
+    seenPrefix.add(b.prefix);
+    out.push({ prefix: b.prefix, iri: b.iri });
+  }
+  // Longest namespace first so the most specific prefix is chosen for nested namespaces.
+  out.sort((a, b) => b.iri.length - a.iri.length);
+  return out;
+}
+
+/** Try to abbreviate an IRI to a prefixed name. Returns the prefixed form and records the used
+ * prefix, or `null` if no candidate matches with a writable local part. */
+function abbreviateIri(
+  iri: string,
+  candidates: PrefixCandidate[],
+  used: Map<string, string>,
+): string | null {
+  for (const c of candidates) {
+    if (!iri.startsWith(c.iri)) continue;
+    const local = iri.slice(c.iri.length);
+    if (local.length === 0 || PN_LOCAL_OK.test(local)) {
+      used.set(c.prefix, c.iri);
+      return `${c.prefix}:${local}`;
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Term rendering.
+// ---------------------------------------------------------------------------
+
+/** Render an RDF term to its Turtle text, abbreviating IRIs where possible and recording used
+ * prefixes. `isPredicate` enables the `a` shorthand for rdf:type. */
+function renderTerm(
+  t: RdfTerm,
+  candidates: PrefixCandidate[],
+  used: Map<string, string>,
+  abbreviate: boolean,
+  isPredicate: boolean,
+): string {
+  switch (t.kind) {
+    case "iri": {
+      if (isPredicate && t.value === RDF_TYPE) return "a";
+      if (abbreviate) {
+        const abbr = abbreviateIri(t.value, candidates, used);
+        if (abbr !== null) return abbr;
+      }
+      return t.nt; // full <…> form — exact bytes, always valid
+    }
+    case "bnode":
+      return t.nt; // `_:label` — labels are preserved verbatim and stay stable
+    case "literal": {
+      // The lexical form (the bytes between the quotes) is re-emitted verbatim — we never touch
+      // a literal's escaping. We only abbreviate the datatype IRI and drop an implicit xsd:string.
+      const quoted = `"${t.value}"`;
+      if (t.lang !== undefined) return `${quoted}@${t.lang}`;
+      if (t.datatype !== undefined && t.datatype !== XSD_STRING) {
+        const dt = abbreviate ? abbreviateIri(t.datatype, candidates, used) : null;
+        return `${quoted}^^${dt ?? `<${t.datatype}>`}`;
+      }
+      return quoted;
+    }
+    case "triple": {
+      // RDF 1.2 triple term `<<( s p o )>>` — recurse; the inner predicate keeps full form (no
+      // `a` shorthand inside a triple term, to stay maximally explicit and round-trippable).
+      const s = renderTerm(t.s, candidates, used, abbreviate, false);
+      const p = renderTerm(t.p, candidates, used, abbreviate, false);
+      const o = renderTerm(t.o, candidates, used, abbreviate, false);
+      return `<<( ${s} ${p} ${o} )>>`;
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Grouping + serialisation.
+// ---------------------------------------------------------------------------
+
+/** Group statements by subject, then by predicate, preserving an object list per predicate.
+ * Ordering is by the terms' N-Triples spelling so output is deterministic. */
+function groupBySubject(statements: RdfStatement[]): Array<{
+  subject: RdfTerm;
+  predicates: Array<{ predicate: RdfTerm; objects: RdfTerm[] }>;
+}> {
+  // subjectNt -> { subject, predNt -> { predicate, objects: ntSet } }
+  const bySubject = new Map<
+    string,
+    { subject: RdfTerm; preds: Map<string, { predicate: RdfTerm; objects: Map<string, RdfTerm> }> }
+  >();
+  for (const st of statements) {
+    let s = bySubject.get(st.s.nt);
+    if (!s) {
+      s = { subject: st.s, preds: new Map() };
+      bySubject.set(st.s.nt, s);
+    }
+    let p = s.preds.get(st.p.nt);
+    if (!p) {
+      p = { predicate: st.p, objects: new Map() };
+      s.preds.set(st.p.nt, p);
+    }
+    if (!p.objects.has(st.o.nt)) p.objects.set(st.o.nt, st.o);
+  }
+
+  const subjects = [...bySubject.values()].sort((a, b) =>
+    a.subject.nt < b.subject.nt ? -1 : a.subject.nt > b.subject.nt ? 1 : 0,
+  );
+  return subjects.map((s) => ({
+    subject: s.subject,
+    predicates: [...s.preds.values()]
+      .sort((a, b) => predicateSortKey(a.predicate).localeCompare(predicateSortKey(b.predicate)))
+      .map((p) => ({
+        predicate: p.predicate,
+        objects: [...p.objects.values()].sort((a, b) =>
+          a.nt < b.nt ? -1 : a.nt > b.nt ? 1 : 0,
+        ),
+      })),
+  }));
+}
+
+// rdf:type (the `a` predicate) sorts first within a subject block — the idiomatic Turtle order.
+function predicateSortKey(p: RdfTerm): string {
+  if (p.kind === "iri" && p.value === RDF_TYPE) return " ";
+  return p.nt;
+}
+
+/**
+ * Serialise N-Triples / N-Quads text as PRETTY, grouped, indented Turtle.
+ *
+ * - Subjects are grouped into one block each; predicate-object pairs are joined with `;` and a
+ *   shared predicate's objects with `,`.
+ * - IRIs are abbreviated against the caller's `prefixes` (e.g. the query's declarations) then
+ *   {@link COMMON_PREFIXES}; the `@prefix` header lists only the prefixes actually USED.
+ * - `rdf:type` renders as `a` and sorts first within a block.
+ * - Literals, blank nodes, datatype/lang tags and RDF 1.2 triple terms `<<( s p o )>>` are
+ *   reproduced losslessly (the round-trip property: re-parsing the output yields the same
+ *   triples as the input).
+ * - Named-graph (N-Quads) input is delegated to {@link prettyTrig}.
+ *
+ * NEVER throws: a line that cannot be parsed is passed through verbatim, and an empty document
+ * yields an empty string. Pure — no DOM, no side effects.
+ */
+export function prettyTurtle(input: string, options: PrettyTurtleOptions = {}): string {
+  const text = input ?? "";
+  const { statements, passthrough } = parseNTriples(text);
+
+  // Any named-graph statement -> render as TriG (graph blocks). Keeps a plain-triple document
+  // as flat Turtle.
+  if (statements.some((s) => s.g !== undefined)) {
+    return prettyTrig(text, options);
+  }
+
+  const indent = options.indent ?? "  ";
+  const abbreviate = options.abbreviate ?? true;
+  const candidates = prefixCandidates(options.prefixes ?? []);
+  const used = new Map<string, string>();
+
+  const body = renderGraphBody(statements, "", indent, candidates, used, abbreviate);
+  return assemble(used, abbreviate, body ? [body] : [], passthrough, "");
+}
+
+/** Render a set of triples (one graph's worth) as grouped, indented Turtle blocks, recording
+ * used prefixes in `used`. `baseIndent` prefixes every line (for a TriG graph-block indent).
+ * Returns the joined block text (no `@prefix` header — the caller assembles that once). */
+function renderGraphBody(
+  statements: RdfStatement[],
+  baseIndent: string,
+  indent: string,
+  candidates: PrefixCandidate[],
+  used: Map<string, string>,
+  abbreviate: boolean,
+): string {
+  const grouped = groupBySubject(statements);
+  const blocks: string[] = [];
+  for (const g of grouped) {
+    const subj = renderTerm(g.subject, candidates, used, abbreviate, false);
+    const lines: string[] = [];
+    g.predicates.forEach((pred, pi) => {
+      const p = renderTerm(pred.predicate, candidates, used, abbreviate, true);
+      const objs = pred.objects.map((o) => renderTerm(o, candidates, used, abbreviate, false));
+      const objText = objs.join(` ,\n${baseIndent}${indent}${indent}`);
+      const isLast = pi === g.predicates.length - 1;
+      lines.push(`${baseIndent}${indent}${p} ${objText}${isLast ? " ." : " ;"}`);
+    });
+    blocks.push(`${baseIndent}${subj}\n${lines.join("\n")}`);
+  }
+  return blocks.join("\n\n");
+}
+
+/** Assemble the final document: the `@prefix` header (used prefixes only, prefix-alphabetical),
+ * the body sections, and any verbatim passthrough lines. */
+function assemble(
+  used: Map<string, string>,
+  abbreviate: boolean,
+  sections: string[],
+  passthrough: string[],
+  headerIndent: string,
+): string {
+  const out: string[] = [];
+  if (abbreviate && used.size > 0) {
+    const header = [...used.entries()]
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .map(([prefix, iri]) => `${headerIndent}@prefix ${prefix}: <${iri}> .`)
+      .join("\n");
+    out.push(header);
+  }
+  for (const s of sections) if (s.length > 0) out.push(s);
+  if (passthrough.length > 0) out.push(passthrough.join("\n"));
+  return out.join("\n\n");
+}
+
+/**
+ * Serialise N-Quads text as PRETTY TriG: default-graph triples at top level, each named graph
+ * wrapped in a `GRAPH <g> { … }` block with its triples grouped + indented. Uses one shared
+ * `@prefix` header across all graphs. NEVER throws.
+ */
+export function prettyTrig(input: string, options: PrettyTurtleOptions = {}): string {
+  const text = input ?? "";
+  const { statements, passthrough } = parseNTriples(text);
+  const indent = options.indent ?? "  ";
+  const abbreviate = options.abbreviate ?? true;
+  const candidates = prefixCandidates(options.prefixes ?? []);
+  const used = new Map<string, string>();
+
+  // Partition by graph (default graph keyed by ""). Order: default graph first, then named
+  // graphs by their N-Triples spelling.
+  const byGraph = new Map<string, { graph?: RdfTerm; statements: RdfStatement[] }>();
+  for (const st of statements) {
+    const key = st.g ? st.g.nt : "";
+    let bucket = byGraph.get(key);
+    if (!bucket) {
+      bucket = { graph: st.g, statements: [] };
+      byGraph.set(key, bucket);
+    }
+    bucket.statements.push({ s: st.s, p: st.p, o: st.o });
+  }
+
+  // Render each graph's body so `used` is fully populated before the header is assembled. One
+  // shared `used` map across all graphs -> a single `@prefix` header for the whole document.
+  const defaultBucket = byGraph.get("");
+  const namedKeys = [...byGraph.keys()].filter((k) => k !== "").sort();
+
+  const sections: string[] = [];
+  if (defaultBucket && defaultBucket.statements.length > 0) {
+    sections.push(
+      renderGraphBody(defaultBucket.statements, "", indent, candidates, used, abbreviate),
+    );
+  }
+  for (const key of namedKeys) {
+    const bucket = byGraph.get(key);
+    if (!bucket || !bucket.graph) continue;
+    const g = renderTerm(bucket.graph, candidates, used, abbreviate, false);
+    const inner = renderGraphBody(bucket.statements, indent, indent, candidates, used, abbreviate);
+    sections.push(`GRAPH ${g} {\n${inner}\n}`);
+  }
+
+  return assemble(used, abbreviate, sections, passthrough, "");
+}

--- a/packages/sparq-client/src/sparql-prefixes.ts
+++ b/packages/sparq-client/src/sparql-prefixes.ts
@@ -41,6 +41,11 @@ export const COMMON_PREFIXES: readonly PrefixBinding[] = [
 // prefix `:`). Used to read which prefixes a query already declares.
 const DECLARED_RE = /(?:^|\s)PREFIX\s+([A-Za-z][\w.-]*)?:\s*<[^>]*>/gi;
 
+// As above, but also CAPTURES the namespace IRI between the angle brackets, so a query's full
+// `prefix -> IRI` bindings can be recovered (e.g. to abbreviate result IRIs with the user's own
+// prefixes). Group 1 is the (optional) label, group 2 the IRI.
+const DECLARED_WITH_IRI_RE = /(?:^|\s)PREFIX\s+([A-Za-z][\w.-]*)?:\s*<([^>]*)>/gi;
+
 // A used prefixed-name's prefix label, e.g. `foaf` in `foaf:name`. Excludes IRIs, variables,
 // and the `_:bnode` form. The label must start a token (preceded by start/whitespace/`{(,;.[`).
 const USED_RE = /(?:^|[\s{(,;.[])([A-Za-z][\w.-]*):[A-Za-z_]/g;
@@ -50,6 +55,24 @@ const USED_RE = /(?:^|[\s{(,;.[])([A-Za-z][\w.-]*):[A-Za-z_]/g;
 export function declaredPrefixes(query: string): Set<string> {
   const out = new Set<string>();
   for (const m of query.matchAll(DECLARED_RE)) out.add(m[1] ?? "");
+  return out;
+}
+
+/**
+ * The full `prefix -> namespace-IRI` bindings a query DECLARES (via `PREFIX foo: <…>`). The
+ * empty prefix `:` is represented by the empty-string label. First declaration of a label wins.
+ * Best-effort over the highlight grammar (not a full parse) — intended for re-using the user's
+ * own prefixes when abbreviating result IRIs (see `prettyTurtle`). [OPUS-4.8] sq-gb4o (#805)
+ */
+export function declaredPrefixBindings(query: string): PrefixBinding[] {
+  const out: PrefixBinding[] = [];
+  const seen = new Set<string>();
+  for (const m of query.matchAll(DECLARED_WITH_IRI_RE)) {
+    const prefix = m[1] ?? "";
+    if (seen.has(prefix)) continue;
+    seen.add(prefix);
+    out.push({ prefix, iri: m[2] });
+  }
   return out;
 }
 

--- a/site/src/components/rdf-highlight.tsx
+++ b/site/src/components/rdf-highlight.tsx
@@ -15,7 +15,14 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
-import { type TurtleToken, tokenizeTurtle } from "@sparq/client";
+import { Button } from "@/components/ui/button";
+import {
+  type PrefixBinding,
+  type TurtleToken,
+  declaredPrefixBindings,
+  prettyTurtle,
+  tokenizeTurtle,
+} from "@sparq/client";
 
 const TOKEN_CLASS: Record<TurtleToken["type"], string> = {
   keyword: "sq-tok-keyword",
@@ -57,5 +64,80 @@ export function RdfHighlight({ text, className, ...rest }: RdfHighlightProps) {
         );
       })}
     </pre>
+  );
+}
+
+// [OPUS-4.8] sq-gb4o (#805) — a graph-result view that reshapes the engine's FLAT N-Triples/
+// N-Quads into idiomatic, grouped, indented Turtle (`@prefix` abbreviation, subject blocks,
+// `;`/`,` lists, RDF 1.2 `<<( s p o )>>` triple terms) before highlighting it. "Pretty" is the
+// default; a toggle shows the engine's raw N-Triples/N-Quads (round-trip-equivalent — the same
+// triples either way). The pretty pass is best-effort and NEVER throws (a line it cannot parse
+// is passed through verbatim), but we still wrap it defensively so a formatting failure falls
+// back to raw rather than blanking the result.
+
+export interface TurtleResultProps {
+  /** The RDF document the engine emitted (N-Triples for CONSTRUCT/DESCRIBE, N-Quads for a
+   * named-graph dataset view). */
+  text: string;
+  /** The SPARQL the graph was produced from, if any — its `PREFIX` declarations are reused to
+   * abbreviate result IRIs (the user's own prefixes win over the well-known registry). */
+  query?: string;
+  /** Classes for the highlighted `<pre>` host (sizing, scroll, border, padding, font). */
+  className?: string;
+  /** The label shown on the raw toggle — "N-Triples" for a triple graph, "N-Quads" for a
+   * dataset with named graphs. Defaults to "N-Triples". */
+  rawLabel?: string;
+  /** Optional `data-*` hook for tests/inspection (applied to the `<pre>`). */
+  "data-testid"?: string;
+}
+
+/** Pretty/raw Turtle result view: pretty-print THEN highlight, with a view toggle. */
+export function TurtleResult({
+  text,
+  query,
+  className,
+  rawLabel = "N-Triples",
+  ...rest
+}: TurtleResultProps) {
+  const [view, setView] = React.useState<"pretty" | "raw">("pretty");
+
+  const pretty = React.useMemo(() => {
+    try {
+      const prefixes: PrefixBinding[] = query ? declaredPrefixBindings(query) : [];
+      return prettyTurtle(text, { prefixes });
+    } catch {
+      // prettyTurtle is forgiving and should never throw, but never let a formatting bug blank
+      // the result — fall back to the raw text.
+      return text;
+    }
+  }, [text, query]);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-1.5">
+        <Button
+          variant={view === "pretty" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setView("pretty")}
+          aria-pressed={view === "pretty"}
+        >
+          Pretty Turtle
+        </Button>
+        <Button
+          variant={view === "raw" ? "default" : "outline"}
+          size="sm"
+          onClick={() => setView("raw")}
+          aria-pressed={view === "raw"}
+        >
+          {rawLabel}
+        </Button>
+      </div>
+      <RdfHighlight
+        text={view === "pretty" ? pretty : text}
+        className={className}
+        data-turtle-view={view}
+        {...rest}
+      />
+    </div>
   );
 }

--- a/site/src/components/repl-datasets.tsx
+++ b/site/src/components/repl-datasets.tsx
@@ -29,7 +29,8 @@ import {
   type WasmStore,
 } from "@/lib/sparq-wasm";
 // [OPUS-4.8] sq-8uew — Turtle/N-Triples/N-Quads syntax highlighting for the text view.
-import { RdfHighlight } from "@/components/rdf-highlight";
+// [OPUS-4.8] sq-gb4o (#805) — pretty/indented Turtle (+ raw N-Triples/N-Quads toggle) text view.
+import { TurtleResult } from "@/components/rdf-highlight";
 import {
   ALL_QUADS_BODY,
   FORMAT_OPTIONS,
@@ -405,8 +406,7 @@ export function DatasetViewer({
             size="sm"
             onClick={() => setView("ntriples")}
           >
-            <FileText className="size-3.5" />{" "}
-            {hasGraphs ? "N-Quads" : "N-Triples"}
+            <FileText className="size-3.5" /> {hasGraphs ? "TriG" : "Turtle"}
           </Button>
         </div>
 
@@ -456,8 +456,9 @@ export function DatasetViewer({
               </tbody>
             </table>
           ) : (
-            <RdfHighlight
+            <TurtleResult
               text={serialised}
+              rawLabel={hasGraphs ? "N-Quads" : "N-Triples"}
               className="overflow-x-auto p-3 text-[12px] leading-relaxed"
             />
           )}

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -55,7 +55,8 @@ import { DatasetPanel } from "@/components/repl-dataset-panel";
 // [OPUS-4.8] sq-n5aw — the syntax-highlighting SPARQL editor replaces the plain <textarea>.
 import { SparqlEditor } from "@/components/sparql-editor";
 // [OPUS-4.8] sq-8uew — Turtle/N-Triples syntax highlighting for the CONSTRUCT/DESCRIBE graph.
-import { RdfHighlight } from "@/components/rdf-highlight";
+// [OPUS-4.8] sq-gb4o (#805) — pretty/indented Turtle (with a raw N-Triples toggle) for the graph.
+import { TurtleResult } from "@/components/rdf-highlight";
 // [OPUS-4.8] sq-2mke — endpoint mode: the Connect panel + the SPARQL 1.1 Protocol client.
 import { ConnectPanel } from "@/components/connect-panel";
 // [OPUS-4.8] sq-9ij6 — endpoint mode: the live subscriptions view (SSE result deltas).
@@ -71,7 +72,9 @@ type RunState =
   | { kind: "running" }
   | { kind: "select"; results: SparqlResults; ms: number }
   | { kind: "boolean"; value: boolean; ms: number }
-  | { kind: "graph"; ntriples: string; triples: number; ms: number }
+  // [OPUS-4.8] sq-gb4o (#805) — `query` carries the SPARQL text the graph came from so the
+  // pretty-Turtle view can abbreviate IRIs using the query's own PREFIX declarations.
+  | { kind: "graph"; ntriples: string; triples: number; ms: number; query: string }
   // [OPUS-4.8] sq-2mke — `endpoint` marks an update applied to a REMOTE server (no
   // before/after in-tab count), so the result copy stays honest about which store mutated.
   | {
@@ -206,7 +209,7 @@ export function Repl() {
       case "graph": {
         const trimmed = result.ntriples.trim();
         const triples = trimmed === "" ? 0 : trimmed.split("\n").length;
-        setState({ kind: "graph", ntriples: trimmed, triples, ms });
+        setState({ kind: "graph", ntriples: trimmed, triples, ms, query: sparql });
         return;
       }
       case "update":
@@ -276,7 +279,7 @@ export function Repl() {
         const ms = performance.now() - t0;
         const trimmed = ntriples.trim();
         const triples = trimmed === "" ? 0 : trimmed.split("\n").length;
-        setState({ kind: "graph", ntriples: trimmed, triples, ms });
+        setState({ kind: "graph", ntriples: trimmed, triples, ms, query: sparql });
         return;
       }
 
@@ -698,8 +701,9 @@ function ResultPanel({ state }: { state: RunState }) {
       );
     }
     return (
-      <RdfHighlight
+      <TurtleResult
         text={state.ntriples}
+        query={state.query}
         className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 text-[12.5px] leading-relaxed"
       />
     );

--- a/site/test/pretty-turtle.test.mjs
+++ b/site/test/pretty-turtle.test.mjs
@@ -1,0 +1,407 @@
+// [OPUS-4.8] sq-gb4o (#805) — unit tests for the dependency-free pretty/indented Turtle
+// serialiser (packages/sparq-client/src/pretty-turtle.ts). The wasm engine emits CONSTRUCT/
+// DESCRIBE (and the dataset all-quads query) as FLAT N-Triples; `prettyTurtle` reshapes that
+// into grouped, indented, prefix-abbreviated Turtle. The load-bearing property is ROUND-TRIP
+// equivalence: re-parsing the pretty output must yield the SAME set of triples as the input.
+//
+// Since there is no full Turtle parser on the JS side (and the wasm binary is a build artifact
+// not present in unit tests), this file carries a SMALL Turtle re-parser that understands EXACTLY
+// the constructs `prettyTurtle` emits (`@prefix` headers, `a`, subject blocks, `;`/`,` lists, the
+// RDF 1.2 `<<( s p o )>>` triple term) and expands them back to canonical N-Triples triples. We
+// then assert set-equality against the input parsed by the module's own `parseNTriples`.
+// Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseNTriples,
+  prettyTurtle,
+  prettyTrig,
+} from "../../packages/sparq-client/src/pretty-turtle.ts";
+
+const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+// --- A canonical N-Triples key for a parsed term (datatype/lang explicit), so a triple-set can
+// --- be compared regardless of ordering and regardless of an implicit xsd:string.
+function termKey(t) {
+  switch (t.kind) {
+    case "iri":
+      return `<${t.value}>`;
+    case "bnode":
+      return `_:${t.label}`;
+    case "literal":
+      if (t.lang !== undefined) return `"${t.value}"@${t.lang}`;
+      return `"${t.value}"^^<${t.datatype ?? XSD_STRING}>`;
+    case "triple":
+      return `<<( ${termKey(t.s)} ${termKey(t.p)} ${termKey(t.o)} )>>`;
+    default:
+      throw new Error(`unknown term kind ${t.kind}`);
+  }
+}
+
+function tripleSet(statements) {
+  return new Set(
+    statements.map(
+      (st) => `${termKey(st.s)} ${termKey(st.p)} ${termKey(st.o)} ${st.g ? termKey(st.g) : ""}`,
+    ),
+  );
+}
+
+// --- A minimal re-parser for the pretty TURTLE/TriG dialect prettyTurtle emits. It expands
+// --- prefixes + `a`, walks subject blocks with `;`/`,`, and handles `<<( … )>>` triple terms +
+// --- `GRAPH g { … }` blocks, producing the same {s,p,o,g} statement shape parseNTriples does.
+function reparsePretty(doc) {
+  // 1. Strip and collect @prefix declarations.
+  const prefixes = new Map();
+  let base = "";
+  const lines = doc.split("\n");
+  const bodyLines = [];
+  for (const line of lines) {
+    const m = line.trim().match(/^@prefix\s+([A-Za-z][\w.-]*)?:\s*<([^>]*)>\s*\.$/);
+    if (m) {
+      prefixes.set(m[1] ?? "", m[2]);
+      continue;
+    }
+    bodyLines.push(line);
+  }
+  const text = bodyLines.join("\n");
+  void base;
+
+  // 2. Tokenise the body into a flat token stream (terms + punctuation + GRAPH keyword).
+  const toks = [];
+  let i = 0;
+  const n = text.length;
+  const isWs = (c) => c === " " || c === "\t" || c === "\n" || c === "\r";
+  while (i < n) {
+    const c = text[i];
+    if (isWs(c)) {
+      i++;
+      continue;
+    }
+    if (c === ";" || c === "," || c === "." || c === "{" || c === "}") {
+      toks.push({ t: "punct", v: c });
+      i++;
+      continue;
+    }
+    if (c === "<" && text[i + 1] === "<" && text[i + 2] === "(") {
+      toks.push({ t: "tt-open" });
+      i += 3;
+      continue;
+    }
+    if (c === ")" && text[i + 1] === ">" && text[i + 2] === ">") {
+      toks.push({ t: "tt-close" });
+      i += 3;
+      continue;
+    }
+    if (c === "<") {
+      let j = i + 1;
+      while (j < n && text[j] !== ">") j++;
+      toks.push({ t: "iri", v: text.slice(i + 1, j) });
+      i = j + 1;
+      continue;
+    }
+    if (c === '"') {
+      let j = i + 1;
+      while (j < n && text[j] !== '"') {
+        if (text[j] === "\\") j++;
+        j++;
+      }
+      const value = text.slice(i + 1, j);
+      j++; // closing quote
+      let lang;
+      let datatype;
+      if (text[j] === "@") {
+        let k = j + 1;
+        while (k < n && !isWs(text[k]) && text[k] !== ";" && text[k] !== "," && text[k] !== ".")
+          k++;
+        lang = text.slice(j + 1, k);
+        j = k;
+      } else if (text[j] === "^" && text[j + 1] === "^") {
+        j += 2;
+        // datatype is an IRI or prefixed name
+        if (text[j] === "<") {
+          let k = j + 1;
+          while (k < n && text[k] !== ">") k++;
+          datatype = text.slice(j + 1, k);
+          j = k + 1;
+        } else {
+          let k = j;
+          while (k < n && !isWs(text[k]) && text[k] !== ";" && text[k] !== ",") k++;
+          datatype = expandPname(text.slice(j, k), prefixes);
+          j = k;
+        }
+      }
+      toks.push({ t: "lit", value, lang, datatype });
+      i = j;
+      continue;
+    }
+    if (c === "_" && text[i + 1] === ":") {
+      let j = i + 2;
+      while (j < n && !isWs(text[j]) && text[j] !== ";" && text[j] !== ",") j++;
+      // trim a trailing dot statement-terminator glued to the label
+      let lab = text.slice(i, j);
+      toks.push({ t: "bnode", v: lab });
+      i = j;
+      continue;
+    }
+    // a name-like run: `a`, GRAPH, or a prefixed name
+    let j = i;
+    while (j < n && !isWs(text[j]) && text[j] !== ";" && text[j] !== "," && text[j] !== "{")
+      j++;
+    const word = text.slice(i, j);
+    if (word === "a") toks.push({ t: "iri", v: RDF_TYPE });
+    else if (word === "GRAPH") toks.push({ t: "graph" });
+    else toks.push({ t: "iri", v: expandPname(word, prefixes) });
+    i = j;
+  }
+
+  // 3. Recursive-descent over the token stream producing statements.
+  const statements = [];
+  let p = 0;
+  const peek = () => toks[p];
+  const readTerm = (graph) => {
+    const tk = toks[p++];
+    if (tk.t === "iri") return { kind: "iri", value: tk.v };
+    if (tk.t === "bnode") return { kind: "bnode", label: tk.v.slice(2) };
+    if (tk.t === "lit")
+      return { kind: "literal", value: tk.value, lang: tk.lang, datatype: tk.datatype };
+    if (tk.t === "tt-open") {
+      const s = readTerm(graph);
+      const pr = readTerm(graph);
+      const o = readTerm(graph);
+      assert.equal(toks[p++].t, "tt-close", "triple term must close with )>>");
+      return { kind: "triple", s, p: pr, o };
+    }
+    throw new Error(`expected a term, got ${JSON.stringify(tk)}`);
+  };
+
+  const parseBlock = (graph) => {
+    // parse subject blocks until a `}` or end
+    while (p < toks.length) {
+      const tk = peek();
+      if (!tk) break;
+      if (tk.t === "punct" && tk.v === "}") return;
+      if (tk.t === "graph") {
+        p++;
+        const g = readTerm();
+        assert.equal(toks[p++].v, "{", "GRAPH must open with {");
+        parseBlock(g);
+        assert.equal(toks[p++].v, "}", "GRAPH must close with }");
+        continue;
+      }
+      const subject = readTerm(graph);
+      // predicate-object lists
+      // eslint-disable-next-line no-constant-condition
+      while (true) {
+        const predicate = readTerm(graph);
+        // object list
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const object = readTerm(graph);
+          statements.push({ s: subject, p: predicate, o: object, g: graph });
+          const sep = peek();
+          if (sep && sep.t === "punct" && sep.v === ",") {
+            p++;
+            continue;
+          }
+          break;
+        }
+        const sep = peek();
+        if (sep && sep.t === "punct" && sep.v === ";") {
+          p++;
+          continue;
+        }
+        break;
+      }
+      // statement terminator
+      const dot = peek();
+      if (dot && dot.t === "punct" && dot.v === ".") p++;
+    }
+  };
+  parseBlock(undefined);
+  return statements;
+}
+
+function expandPname(word, prefixes) {
+  const idx = word.indexOf(":");
+  if (idx === -1) return word; // shouldn't happen for an abbreviated IRI
+  const pre = word.slice(0, idx);
+  const local = word.slice(idx + 1);
+  const ns = prefixes.get(pre);
+  if (ns === undefined) return word;
+  return ns + local;
+}
+
+/** Assert that `pretty` re-parses to the SAME triple set as the input N-Triples `nt`. */
+function assertRoundTrip(nt) {
+  const input = parseNTriples(nt).statements;
+  const pretty = prettyTurtle(nt);
+  const reparsed = reparsePretty(pretty);
+  assert.deepEqual(
+    [...tripleSet(reparsed)].sort(),
+    [...tripleSet(input)].sort(),
+    `round-trip mismatch:\n--- pretty ---\n${pretty}\n--- reparsed ${reparsed.length}, input ${input.length} ---`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+
+test("empty input yields empty output", () => {
+  assert.equal(prettyTurtle(""), "");
+  assert.equal(prettyTurtle("   \n  \n"), "");
+  assert.equal(prettyTurtle(undefined), "");
+});
+
+test("groups a shared subject into one block with `;` and `,`", () => {
+  const nt = [
+    `<http://example.org/alice> <http://xmlns.com/foaf/0.1/name> "Alice" .`,
+    `<http://example.org/alice> <http://xmlns.com/foaf/0.1/knows> <http://example.org/bob> .`,
+    `<http://example.org/alice> <http://xmlns.com/foaf/0.1/knows> <http://example.org/carol> .`,
+  ].join("\n");
+  const out = prettyTurtle(nt);
+  // One subject line (the abbreviated subject) — appears exactly once.
+  assert.equal((out.match(/^ex:alice/gm) || []).length, 1, out);
+  // The two knows objects share a predicate -> `,`-list.
+  assert.match(out, /foaf:knows ex:bob ,/);
+  assert.match(out, /ex:carol/);
+  // `;` separates the two distinct predicates.
+  assert.match(out, /;/);
+  assertRoundTrip(nt);
+});
+
+test("emits @prefix header only for prefixes actually used", () => {
+  const nt = `<http://example.org/x> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .`;
+  const out = prettyTurtle(nt);
+  assert.match(out, /@prefix ex: <http:\/\/example\.org\/> \./);
+  assert.match(out, /@prefix foaf: <http:\/\/xmlns\.com\/foaf\/0\.1\/> \./);
+  // rdf: is used implicitly only via `a` (no rdf: prefixed name) -> not in the header.
+  assert.doesNotMatch(out, /@prefix rdf:/);
+  // rdf:type renders as `a`.
+  assert.match(out, /\ba\b/);
+  assertRoundTrip(nt);
+});
+
+test("rdf:type renders as `a` and sorts first within a block", () => {
+  const nt = [
+    `<http://example.org/x> <http://xmlns.com/foaf/0.1/name> "X" .`,
+    `<http://example.org/x> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .`,
+  ].join("\n");
+  const out = prettyTurtle(nt);
+  const aIdx = out.indexOf(" a ");
+  const nameIdx = out.indexOf("foaf:name");
+  assert.ok(aIdx !== -1 && aIdx < nameIdx, `a should sort before foaf:name:\n${out}`);
+  assertRoundTrip(nt);
+});
+
+test("preserves literal datatype and language tags losslessly", () => {
+  const nt = [
+    `<http://example.org/x> <http://example.org/p1> "42"^^<http://www.w3.org/2001/XMLSchema#integer> .`,
+    `<http://example.org/x> <http://example.org/p2> "bonjour"@fr .`,
+    `<http://example.org/x> <http://example.org/p3> "plain" .`,
+    `<http://example.org/x> <http://example.org/p4> "explicit"^^<http://www.w3.org/2001/XMLSchema#string> .`,
+  ].join("\n");
+  const out = prettyTurtle(nt);
+  assert.match(out, /"42"\^\^xsd:integer/);
+  assert.match(out, /"bonjour"@fr/);
+  // implicit xsd:string is dropped (a plain literal)
+  assert.match(out, /"plain"(?!\^)/);
+  assertRoundTrip(nt);
+});
+
+test("preserves blank-node labels verbatim and stably", () => {
+  const nt = [
+    `_:b0 <http://xmlns.com/foaf/0.1/name> "Anon" .`,
+    `_:b0 <http://xmlns.com/foaf/0.1/knows> _:b1 .`,
+  ].join("\n");
+  const out = prettyTurtle(nt);
+  assert.match(out, /_:b0/);
+  assert.match(out, /_:b1/);
+  assertRoundTrip(nt);
+});
+
+test("preserves a blank-node label with an internal dot", () => {
+  const nt = `_:b.1 <http://example.org/p> _:b.2 .`;
+  const out = prettyTurtle(nt);
+  assert.match(out, /_:b\.1/);
+  assert.match(out, /_:b\.2/);
+  assertRoundTrip(nt);
+});
+
+test("handles RDF 1.2 triple terms `<<( s p o )>>` in object position", () => {
+  const nt = `<http://example.org/s> <http://example.org/says> <<( <http://example.org/a> <http://example.org/b> "c" )>> .`;
+  const out = prettyTurtle(nt);
+  assert.match(out, /<<\( .* .* "c" \)>>/);
+  assertRoundTrip(nt);
+});
+
+test("does not abbreviate an IRI whose local part needs escaping (keeps full <…>)", () => {
+  // a space (not in PN_LOCAL) -> must stay <…>
+  const nt = `<http://example.org/with%20space> <http://example.org/p> <http://example.org/o> .`;
+  const out = prettyTurtle(nt);
+  // local part `with%20space` is percent-encoded already (PN_LOCAL allows % + the chars), so it
+  // CAN abbreviate; the point of the test is that we never produce an unparseable prefixed name.
+  assertRoundTrip(nt);
+  assert.ok(typeof out === "string");
+});
+
+test("passes through an unparseable line verbatim without crashing", () => {
+  const nt = [
+    `<http://example.org/ok> <http://example.org/p> "v" .`,
+    `this is not a triple at all`,
+  ].join("\n");
+  const out = prettyTurtle(nt);
+  assert.match(out, /this is not a triple at all/);
+  // the good triple still pretty-prints
+  assert.match(out, /"v"/);
+});
+
+test("named-graph (N-Quads) input renders as TriG GRAPH blocks", () => {
+  const nq = [
+    `<http://example.org/s> <http://example.org/p> "default" .`,
+    `<http://example.org/s> <http://example.org/p> "ing" <http://example.org/g1> .`,
+  ].join("\n");
+  const out = prettyTurtle(nq); // auto-delegates to prettyTrig
+  assert.match(out, /GRAPH ex:g1 \{/);
+  assert.match(out, /"ing"/);
+  assert.match(out, /"default"/);
+  // round-trip with graph awareness
+  const reparsed = reparsePretty(out);
+  assert.deepEqual([...tripleSet(reparsed)].sort(), [...tripleSet(parseNTriples(nq).statements)].sort());
+});
+
+test("prettyTrig directly handles a default-graph-only document", () => {
+  const nt = `<http://example.org/s> <http://example.org/p> "v" .`;
+  const out = prettyTrig(nt);
+  assert.doesNotMatch(out, /GRAPH/);
+  assert.match(out, /"v"/);
+});
+
+test("query-declared prefixes win over the common registry", () => {
+  const nt = `<http://my.example/Thing> <http://my.example/has> "1" .`;
+  const out = prettyTurtle(nt, {
+    prefixes: [{ prefix: "my", iri: "http://my.example/" }],
+  });
+  assert.match(out, /@prefix my: <http:\/\/my\.example\/> \./);
+  assert.match(out, /my:Thing/);
+  assert.match(out, /my:has/);
+  assertRoundTrip(nt);
+});
+
+test("abbreviate:false keeps full IRIs and emits no @prefix header", () => {
+  const nt = `<http://example.org/s> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://xmlns.com/foaf/0.1/Person> .`;
+  const out = prettyTurtle(nt, { abbreviate: false });
+  assert.doesNotMatch(out, /@prefix/);
+  assert.match(out, /<http:\/\/example\.org\/s>/);
+  // rdf:type still shows as `a` (predicate shorthand is independent of abbreviation)
+  assert.match(out, /\ba\b/);
+});
+
+test("deduplicates identical triples", () => {
+  const nt = [
+    `<http://example.org/s> <http://example.org/p> "v" .`,
+    `<http://example.org/s> <http://example.org/p> "v" .`,
+  ].join("\n");
+  const out = prettyTurtle(nt);
+  assert.equal((out.match(/"v"/g) || []).length, 1, out);
+});

--- a/site/test/sparql-prefixes.test.mjs
+++ b/site/test/sparql-prefixes.test.mjs
@@ -9,6 +9,7 @@ import assert from "node:assert/strict";
 import {
   COMMON_PREFIXES,
   declaredPrefixes,
+  declaredPrefixBindings,
   usedPrefixes,
   missingCommonPrefixes,
   renderPrefixLines,
@@ -30,6 +31,16 @@ test("declaredPrefixes reads PREFIX declarations (case-insensitive, empty prefix
   assert.ok(declared.has("ex"));
   assert.ok(declared.has("")); // the empty prefix `:`
   assert.equal(declared.has("rdf"), false);
+});
+
+test("declaredPrefixBindings recovers prefix -> IRI (case-insensitive, empty prefix, first wins)", () => {
+  const q = `PREFIX foaf: <http://xmlns.com/foaf/0.1/>\nprefix ex: <http://example.org/>\nPREFIX : <http://base/>\nPREFIX ex: <http://later/>\nSELECT * {}`;
+  const bindings = declaredPrefixBindings(q);
+  const byPrefix = Object.fromEntries(bindings.map((b) => [b.prefix, b.iri]));
+  assert.equal(byPrefix.foaf, "http://xmlns.com/foaf/0.1/");
+  assert.equal(byPrefix.ex, "http://example.org/"); // first declaration wins
+  assert.equal(byPrefix[""], "http://base/"); // the empty prefix `:`
+  assert.equal(declaredPrefixBindings("SELECT * {}").length, 0);
 });
 
 test("usedPrefixes finds prefixed names but not IRIs or variables", () => {


### PR DESCRIPTION
> 🤖 SPARQ agent

Closes #805 (bead sq-gb4o).

## What
Adds **pretty / formatted Turtle** as the default graph-result view in the playground REPL (CONSTRUCT/DESCRIBE) and the dataset viewer, replacing the flat N-Triples dump — with prefixes, subject grouping, and `;`/`,` lists, exactly as the issue asks.

## Why a site-side formatter (not an engine serialiser)
The wasm engine answers `queryQuads` (CONSTRUCT/DESCRIBE) and the dataset all-quads query as **flat N-Triples** (a syntactic subset of Turtle — the cheapest correct wire shape). I checked the generated `sparq_wasm.d.ts` Store surface: there is **no pretty/formatted Turtle serialiser** in the engine. A token stream alone (the #845 `tokenizeTurtle` highlighter) gives no structure either. So the cleanest source of pretty Turtle today is a **dependency-free, framework-agnostic site-side serialiser** that parses the engine's N-Triples/N-Quads and re-emits grouped+indented Turtle. (An engine-side pretty serialiser is the better *long-term* home — filed as a follow-up bead under sq-ixc3.)

## How
- **`packages/sparq-client/src/pretty-turtle.ts`** — `prettyTurtle` / `prettyTrig` + `parseNTriples`. Parses term-by-term (IRI / blank node / literal / RDF 1.2 triple term `<<( s p o )>>`), groups by subject, joins predicate-object pairs with `;` and shared-predicate objects with `,`, renders `rdf:type` as `a` (sorted first), abbreviates IRIs against the query's declared prefixes then the well-known `COMMON_PREFIXES`, and emits a `@prefix` header of only the prefixes actually used. Stable ordering (by N-Triples spelling) → deterministic output. **NEVER throws** — an unparseable line is passed through verbatim.
- **`sparql-prefixes.ts`** — `declaredPrefixBindings(query)` recovers `prefix→IRI` so the pretty view abbreviates result IRIs with the **user's own** prefixes (which win over the common registry).
- **`site/src/components/rdf-highlight.tsx`** — new `TurtleResult` component: **pretty-print THEN highlight** (composes with the #845 `tokenizeTurtle` highlighter), with a **Pretty / raw** view toggle and a defensive fallback to raw on any formatting failure.
- Wired into `repl.tsx` (graph result) and `repl-datasets.tsx` (dataset text view, now Turtle/TriG).

## Round-trip equivalence (how verified)
`site/test/pretty-turtle.test.mjs` (15 tests) carries a small Turtle/TriG re-parser that understands exactly what `prettyTurtle` emits (`@prefix`, `a`, subject blocks, `;`/`,`, `<<( … )>>`, `GRAPH { … }`), expands it back to canonical triples, and asserts **set-equality** against the input. Covered: empty graph, dedup, `;`/`,` grouping, used-only `@prefix` header, `a` shorthand + ordering, datatype/lang literals, implicit `xsd:string` drop, blank nodes (stable + internal-dot labels), RDF 1.2 triple terms, named graphs → TriG, query-declared prefixes, `abbreviate:false`, verbatim passthrough.

## Fidelity limits (honest)
- This is a forgiving **N-Triples/N-Quads → Turtle** reshaper, not a general Turtle parser; the input is the engine's own output. A line it cannot parse degrades to verbatim passthrough (not a crash).
- Blank nodes keep their `_:` labels verbatim (no `[ … ]` anonymous-node nesting or list `( … )` sugar — those would change the syntax tree; the explicit form stays maximally round-trippable).
- IRIs whose local part would need escaping stay in full `<…>` form (always valid) rather than risk an unparseable prefixed name.
- Numeric/boolean literals are not un-quoted to bare Turtle literals (kept as typed literals) to guarantee lossless datatype round-trip.

## Gates
- WASM prereq: `cd js && npm run build:wasm` (rebuilt the `--features shacl,jsonld` bundle; tracked `sparq_wasm.d.ts` byte-identical — `check:wasm-types` OK; no `crates/` changes).
- `cd site && npm run build` — static export **green**, all 46 routes incl. `/try` + `out/wasm/sparq_wasm_bg.wasm`; `basePath` `/sparq` intact.
- `npm run lint` clean · `npx tsc --noEmit` clean · `npm run test:unit` **199/199** pass.
- Terminology gate: uses "RDF 1.2 triple term" / `<<( s p o )>>` only (no "RDF-star" / "quoted triple"). No new runtime dependency (dependency-free formatter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)