### PR TITLE
feat(bench): strictly-additive --json emit for remaining harnesses (sq-k5qq) [OPUS-4.8]

### DIFF
--- a/bench/inference/eye-comparison.sh
+++ b/bench/inference/eye-comparison.sh
@@ -16,10 +16,19 @@
 #   anc500     — transitive ancestor chain, 500 links (quadratic closure ~125k)
 #   grid30     — 30x30 grid reachability (edge → reach; reach+edge → reach)
 # Results: bench/inference/eye-comparison.md
+#
+# [OPUS-4.8] (sq-k5qq) Strictly-additive machine-readable emit: set SPARQ_INFER_JSON to a
+# path and the run ALSO writes the SAME per-workload wall seconds to that file as a stable,
+# hand-built JSON document (the shell analogue of the Rust harnesses' dependency-free
+# `format!`-JSON). STDOUT (the printf table) is byte-for-byte unchanged whether or not the
+# env var is set; the seconds are best-effort, MEASURED on the running host — ADVISORY +
+# NON-CANONICAL (stated in the emitted `note`) — nothing is committed.
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 CLI="${SPARQ_CLI:-target/release/sparq-cli}"
 EYE="${EYE:-eye}"
+JSON_OUT="${SPARQ_INFER_JSON:-}"
+JSON_ROWS=""   # accumulated `{ ... }` row objects, comma-joined at the end
 B="$(mktemp -d)"; trap 'rm -rf "$B"' EXIT
 
 cp crates/sparq-reason/tests/eye/socrates.n3 "$B/socrates.n3"
@@ -54,6 +63,21 @@ mon() { # min-of-N wall seconds: mon <runs> <cmd…>
   echo "$best"
 }
 
+# [OPUS-4.8] (sq-k5qq) Append one JSON row to the accumulator. Args: workload, sparq_s,
+# eye_s ("skipped" emits a null + "skipped": true). Workload names are static idents, so a
+# JSON-safe quote is enough; numeric seconds are emitted as bare JSON numbers.
+add_json_row() {
+  [ -n "$JSON_OUT" ] || return 0
+  local w="$1" sparq="$2" eye="$3" eye_field
+  if [ "$eye" = skipped ]; then
+    eye_field='"eye_seconds": null, "eye_skipped": true'
+  else
+    eye_field="\"eye_seconds\": $eye, \"eye_skipped\": false"
+  fi
+  local row="{ \"workload\": \"$w\", \"sparq_seconds\": $sparq, $eye_field }"
+  if [ -z "$JSON_ROWS" ]; then JSON_ROWS="$row"; else JSON_ROWS="$JSON_ROWS,$row"; fi
+}
+
 printf '%-10s %12s %12s\n' workload sparq eye
 for w in socrates dt1k dt10k dt100k anc500 grid30; do
   s=$(mon 3 "$CLI" reason "$B/$w.n3" n3 n3 /dev/null)
@@ -63,9 +87,24 @@ for w in socrates dt1k dt10k dt100k anc500 grid30; do
   # minutes per EYE run: single run, documented as such in eye-comparison.md.
   if [ "$w" = dt100k ] && [ -z "${EYE_DT100K:-}" ]; then
     printf '%12s\n' 'skipped'
+    add_json_row "$w" "$s" skipped
     continue
   fi
   eruns=3; case "$w" in dt10k|dt100k|anc500|grid30) eruns=1;; esac
   e=$(mon "$eruns" "$EYE" --quiet --nope "$B/$w.n3" --pass)
   printf '%11ss\n' "$e"
+  add_json_row "$w" "$s" "$e"
 done
+
+# [OPUS-4.8] (sq-k5qq) Strictly-additive JSON emit: write the accumulated rows only when
+# SPARQ_INFER_JSON was set. The STDOUT table above is unchanged either way.
+if [ -n "$JSON_OUT" ]; then
+  {
+    printf '{\n'
+    printf '  "harness": "sparq-reason vs EYE (eye-comparison)",\n'
+    printf '  "note": "every wall-second figure is best-effort, MEASURED on the running host — ADVISORY, NON-CANONICAL (this dev box) — do not bake into committed files",\n'
+    printf '  "rows": [ %s ]\n' "$JSON_ROWS"
+    printf '}\n'
+  } > "$JSON_OUT"
+  echo "wrote results JSON to $JSON_OUT" >&2
+fi

--- a/bench/inference/owl-bench.sh
+++ b/bench/inference/owl-bench.sh
@@ -8,9 +8,18 @@
 #   4. owl-restrictions — 50k individuals × someValuesFrom/hasValue/intersection restrictions
 #                         + equivalence + inverse (the class-feature fixpoint path)
 # Prints min-of-3 seconds per workload (parses the CLI's "in Xs" line).
+#
+# [OPUS-4.8] (sq-k5qq) Strictly-additive machine-readable emit: set OWL_BENCH_JSON to a
+# path and the run ALSO writes the SAME per-workload min-of-3 seconds to that file as a
+# stable, hand-built JSON document (the shell analogue of the Rust harnesses'
+# dependency-free `format!`-JSON). STDOUT (the printf table) is byte-for-byte unchanged
+# whether or not the env var is set; the seconds are best-effort, MEASURED on the running
+# host — ADVISORY + NON-CANONICAL (stated in the emitted `note`) — nothing is committed.
 set -euo pipefail
 cd "$(dirname "$0")/../.."
 CLI="${SPARQ_CLI:-target/release/sparq-cli}"
+JSON_OUT="${OWL_BENCH_JSON:-}"
+JSON_ROWS=""   # accumulated `{ ... }` row objects, comma-joined at the end
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 
 # 1+2: instance-heavy RDFS
@@ -47,8 +56,27 @@ run() { # name file profile
     if [ -z "$best" ] || awk "BEGIN{exit !($t < $best)}"; then best="$t"; fi
   done
   printf '%-18s %ss\n' "$1" "$best"
+  # [OPUS-4.8] (sq-k5qq) accumulate one JSON row for the optional --json emit. Workload
+  # name + profile are static idents (JSON-safe to quote); seconds is a bare JSON number.
+  if [ -n "$JSON_OUT" ]; then
+    local row="{ \"workload\": \"$1\", \"profile\": \"$3\", \"seconds\": $best }"
+    if [ -z "$JSON_ROWS" ]; then JSON_ROWS="$row"; else JSON_ROWS="$JSON_ROWS,$row"; fi
+  fi
 }
 run rdfs-instances "$TMP/rdfs.ttl" rdfs
 run owl-route-rdfs "$TMP/rdfs.ttl" owl
 run owl-transitive "$TMP/trans.ttl" owl
 run owl-restrictions "$TMP/restr.ttl" owl
+
+# [OPUS-4.8] (sq-k5qq) Strictly-additive JSON emit: write the accumulated rows only when
+# OWL_BENCH_JSON was set. The STDOUT table above is unchanged either way.
+if [ -n "$JSON_OUT" ]; then
+  {
+    printf '{\n'
+    printf '  "harness": "sparq-reason owl-bench",\n'
+    printf '  "note": "every min-of-3 second figure is best-effort, MEASURED on the running host — ADVISORY, NON-CANONICAL (this dev box) — do not bake into committed files",\n'
+    printf '  "rows": [ %s ]\n' "$JSON_ROWS"
+    printf '}\n'
+  } > "$JSON_OUT"
+  echo "wrote results JSON to $JSON_OUT" >&2
+fi

--- a/bench/serve/Cargo.lock
+++ b/bench/serve/Cargo.lock
@@ -980,6 +980,7 @@ name = "serve-spikes"
 version = "0.0.0"
 dependencies = [
  "mimalloc",
+ "serde_json",
  "spargebra",
  "sparq-core",
  "sparq-engine",
@@ -1269,9 +1270,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.11"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
 dependencies = [
  "bitflags",
  "bytes",
@@ -1279,7 +1280,9 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
+ "percent-encoding",
  "pin-project-lite",
+ "tokio",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/bench/serve/Cargo.toml
+++ b/bench/serve/Cargo.toml
@@ -26,6 +26,13 @@ sparq-serve = { path = "../../crates/sparq-serve" }
 spargebra = { version = "0.4", features = ["sparql-12", "sep-0006"] }
 mimalloc = "0.1"
 
+# [OPUS-4.8] (sq-k5qq) TEST-only: writer_spike emits an optional, strictly-additive
+# `--json <path>` results document (dependency-free `format!`-built JSON — no serde in the
+# harness itself); this dev-dep parses that emit back so the round-trip test catches a
+# malformed document.
+[dev-dependencies]
+serde_json = "1"
+
 [[bin]]
 name = "loadgen"
 path = "src/bin/loadgen.rs"

--- a/bench/serve/src/bin/writer_spike.rs
+++ b/bench/serve/src/bin/writer_spike.rs
@@ -24,7 +24,16 @@
 //! numbers say so — read them, do not assume the batched path always wins.
 //!
 //! Run: `cargo run --release --bin writer_spike` in bench/serve.
+//!   cargo run --release --bin writer_spike -- --json /tmp/writer.json  # strictly-additive
 //! Env: WRITER_UPDATES (default 30000), WRITER_SECS reader window (default 2).
+//!
+//! [OPUS-4.8] (sq-k5qq) `--json <path>` writes the SAME throughput + latency rows STDOUT
+//! prints as a stable, DEPENDENCY-FREE JSON document, mirroring the `format!`-JSON
+//! convention of `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json`. No serde dep is
+//! added to the harness (serde_json is a TEST-only dev-dep used to parse the emit back).
+//! STDOUT is byte-for-byte unchanged whether or not the flag is present; every number is
+//! best-effort, MEASURED on the running host — ADVISORY + NON-CANONICAL (stated in the
+//! emitted `note`) — nothing is committed.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -224,13 +233,140 @@ impl FeederHandle {
     }
 }
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-k5qq) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// One writer-throughput row (§1): updates/s + generation counts at a `max_batch`.
+struct ThroughputRow {
+    max_batch: usize,
+    updates_per_s: f64,
+    generations: u64,
+    updates_per_gen: f64,
+}
+
+/// One reader-latency row (§2/§3): p50/p99/max in microseconds + sample count.
+struct LatencyRow {
+    scenario: String,
+    p50_us: f64,
+    p99_us: f64,
+    max_us: f64,
+    samples: usize,
+}
+
+/// Extracts `--json <path>` from argv, returning argv WITHOUT the flag pair. A bare
+/// `--json` is a usage error (exit 2), mirroring `sparq-cli` / `bench_text`'s flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Minimal JSON string escaper (the dependency-free emit). Scenario labels are static
+/// ASCII, so this covers the realistic input; anything else still yields valid `\uXXXX`.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Serialise the run to stable, dependency-free JSON: the workload params plus the two
+/// row sets. Every metric is ADVISORY + NON-CANONICAL (stated in `note`).
+fn results_json(
+    updates: usize,
+    reader_window_secs: u64,
+    throughput: &[ThroughputRow],
+    latency: &[LatencyRow],
+) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"serve-spikes writer_spike\",\n");
+    s.push_str(&format!("  \"updates\": {updates},\n"));
+    s.push_str(&format!("  \"reader_window_secs\": {reader_window_secs},\n"));
+    s.push_str(
+        "  \"note\": \"Wave A2 group-commit vs A1 publish-per-update; every updates/s and \
+         reader-latency figure is best-effort, MEASURED on the running host — ADVISORY, \
+         NON-CANONICAL (this dev box) — do not bake into committed files\",\n",
+    );
+    s.push_str("  \"throughput\": [\n");
+    for (i, r) in throughput.iter().enumerate() {
+        let comma = if i + 1 < throughput.len() { "," } else { "" };
+        s.push_str(&format!(
+            "    {{ \"max_batch\": {}, \"updates_per_s\": {:.1}, \"generations\": {}, \
+             \"updates_per_gen\": {:.3} }}{comma}\n",
+            r.max_batch, r.updates_per_s, r.generations, r.updates_per_gen,
+        ));
+    }
+    s.push_str("  ],\n");
+    s.push_str("  \"reader_latency\": [\n");
+    for (i, r) in latency.iter().enumerate() {
+        let comma = if i + 1 < latency.len() { "," } else { "" };
+        s.push_str(&format!(
+            "    {{ \"scenario\": {}, \"p50_us\": {:.3}, \"p99_us\": {:.3}, \
+             \"max_us\": {:.3}, \"samples\": {} }}{comma}\n",
+            json_str(&r.scenario),
+            r.p50_us,
+            r.p99_us,
+            r.max_us,
+            r.samples,
+        ));
+    }
+    s.push_str("  ]\n");
+    s.push_str("}\n");
+    s
+}
+
 fn main() {
+    let (_args, json_path) = take_json_flag(std::env::args().collect());
     let updates: usize = std::env::var("WRITER_UPDATES").ok().and_then(|v| v.parse().ok()).unwrap_or(30_000);
     let secs: u64 = std::env::var("WRITER_SECS").ok().and_then(|v| v.parse().ok()).unwrap_or(2);
     let dur = Duration::from_secs(secs);
 
     println!("# writer_spike — Wave A2 group-commit vs A1 publish-per-update");
     println!("# updates={updates}, reader window={secs}s, read_period=200µs (open-loop)\n");
+
+    // [OPUS-4.8] (sq-k5qq) Capture the SAME rows STDOUT prints for the optional --json emit.
+    let mut throughput_rows: Vec<ThroughputRow> = Vec::new();
+    let mut latency_rows: Vec<LatencyRow> = Vec::new();
+    // Build a LatencyRow from a scenario label + the sorted latencies (ns), exactly the
+    // values the println! below derives — single source of truth.
+    let lat_row = |scenario: &str, lat: &[u64]| LatencyRow {
+        scenario: scenario.to_string(),
+        p50_us: pct(lat, 0.50) as f64 / 1000.0,
+        p99_us: pct(lat, 0.99) as f64 / 1000.0,
+        max_us: *lat.last().unwrap() as f64 / 1000.0,
+        samples: lat.len(),
+    };
 
     println!("## 1. Writer throughput (closed-loop drain)");
     println!("| max_batch | updates/s | generations | updates/gen |");
@@ -239,6 +375,12 @@ fn main() {
         let (ups, gens) = writer_throughput(updates, b);
         let upg = updates as f64 / gens.max(1) as f64;
         println!("| {b} | {ups:.0} | {gens} | {upg:.1} |");
+        throughput_rows.push(ThroughputRow {
+            max_batch: b,
+            updates_per_s: ups,
+            generations: gens,
+            updates_per_gen: upg,
+        });
     }
 
     println!("\n## 2. Reader latency p50/p99 (open-loop, coordinated-omission-safe)");
@@ -256,6 +398,7 @@ fn main() {
             *lat.last().unwrap() as f64 / 1000.0,
             lat.len()
         );
+        latency_rows.push(lat_row("idle (no writer)", &lat));
     }
 
     for &b in &[1usize, 16, 256] {
@@ -267,6 +410,7 @@ fn main() {
             *lat.last().unwrap() as f64 / 1000.0,
             lat.len()
         );
+        latency_rows.push(lat_row(&format!("A2 writer max_batch={b}"), &lat));
     }
     {
         let lat = reader_under_writer(1, dur, Mode::A1);
@@ -277,10 +421,89 @@ fn main() {
             *lat.last().unwrap() as f64 / 1000.0,
             lat.len()
         );
+        latency_rows.push(lat_row("A1 publish-per-update", &lat));
     }
 
     println!("\n# Interpretation: readers never block the writer in EITHER mode (lock-free");
     println!("# current()); the win of group-commit is in WRITER throughput (§1) — more");
     println!("# updates per generation = fewer fork/seal/publish cycles. If batch-1 A2 is");
     println!("# slower than A1, that is the channel + window overhead with no batching gain.");
+
+    // [OPUS-4.8] (sq-k5qq) Strictly-additive JSON emit: only when `--json <path>` was given.
+    // STDOUT above (the markdown tables) is the unchanged human/research output.
+    if let Some(path) = json_path {
+        let doc = results_json(updates, secs, &throughput_rows, &latency_rows);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!(
+            "wrote {} throughput + {} latency rows to {path}",
+            throughput_rows.len(),
+            latency_rows.len()
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-k5qq) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["writer_spike", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["writer_spike"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        let plain: Vec<String> = ["writer_spike"].iter().map(|s| s.to_string()).collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn json_str_escapes() {
+        assert_eq!(json_str("idle (no writer)"), "\"idle (no writer)\"");
+        assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+    }
+
+    #[test]
+    fn results_json_shape_and_keys() {
+        let throughput = vec![
+            ThroughputRow { max_batch: 1, updates_per_s: 12000.0, generations: 11000, updates_per_gen: 1.09 },
+            ThroughputRow { max_batch: 256, updates_per_s: 90000.0, generations: 200, updates_per_gen: 150.0 },
+        ];
+        let latency = vec![
+            LatencyRow { scenario: "idle (no writer)".into(), p50_us: 0.21, p99_us: 0.5, max_us: 3.0, samples: 10000 },
+            LatencyRow { scenario: "A2 writer max_batch=16".into(), p50_us: 0.3, p99_us: 1.2, max_us: 9.0, samples: 9800 },
+        ];
+        let doc = results_json(30_000, 2, &throughput, &latency);
+        // The dependency-free emit must round-trip through a REAL serde_json parse.
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "serve-spikes writer_spike");
+        assert_eq!(v["updates"], 30_000);
+        assert_eq!(v["reader_window_secs"], 2);
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        let t = v["throughput"].as_array().expect("throughput is an array");
+        assert_eq!(t.len(), 2);
+        assert_eq!(t[0]["max_batch"], 1);
+        assert!(t[0]["updates_per_s"].is_number());
+        let l = v["reader_latency"].as_array().expect("reader_latency is an array");
+        assert_eq!(l.len(), 2);
+        assert_eq!(l[0]["scenario"], "idle (no writer)");
+        assert!(l[0]["p99_us"].is_number());
+        assert_eq!(l[0]["samples"], 10000);
+
+        // Empty row sets must still be valid JSON (no trailing comma).
+        let empty = results_json(0, 0, &[], &[]);
+        let v2: serde_json::Value = serde_json::from_str(&empty).expect("empty is valid JSON");
+        assert!(v2["throughput"].as_array().unwrap().is_empty());
+        assert!(v2["reader_latency"].as_array().unwrap().is_empty());
+    }
 }

--- a/crates/sparq-nlq/examples/record_olympics.rs
+++ b/crates/sparq-nlq/examples/record_olympics.rs
@@ -15,6 +15,20 @@
 //!
 //! Needs `bench/qlever-olympics/olympics.nt` (downloaded benchmark fixture; override
 //! the path with `SPARQ_OLYMPICS_NT`).
+//!
+//! [OPUS-4.8] (sq-k5qq) Strictly-additive machine-readable emit:
+//!
+//! ```sh
+//! cargo run -p sparq-nlq --example record_olympics --release -- --json /tmp/nlq.json
+//! ```
+//!
+//! `--json <path>` writes the SAME per-question rows STDOUT prints — `rows`/`repairs`
+//! (DETERMINISTIC at the recorded fixture) plus the advisory `ms` timing — as a stable,
+//! DEPENDENCY-FREE JSON document, mirroring the `format!`-JSON convention of
+//! `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json`. No serde dep is added to the
+//! harness (serde_json is a normal crate dep used by the round-trip test). STDOUT is
+//! byte-for-byte unchanged whether or not the flag is present; `ms` is ADVISORY +
+//! NON-CANONICAL (this dev box) and nothing is committed.
 
 use std::rc::Rc;
 
@@ -177,7 +191,100 @@ impl Llm for ScriptedLlm {
     }
 }
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-k5qq) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// One captured per-question row. `rows`/`repairs` are DETERMINISTIC at the recorded
+/// fixture (a pure function of the dataset + scripted completions); `ms` is best-effort
+/// (ADVISORY, NON-CANONICAL on this box).
+struct Row {
+    question: String,
+    rows: usize,
+    repairs: usize,
+    ms: f64,
+}
+
+/// Extracts `--json <path>` from argv, returning argv WITHOUT the flag pair (so any
+/// positional parsing is unchanged). A bare `--json` is a usage error (exit 2),
+/// mirroring `sparq-cli` / `bench_text`'s identical flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Minimal JSON string escaper (the dependency-free emit). Questions can carry any
+/// Unicode; this covers the realistic input and yields valid `\uXXXX` for control chars.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Serialise the recorded run to stable, dependency-free JSON. Each `rows` object carries
+/// the SAME fields the STDOUT line prints; `rows`/`repairs` are DETERMINISTIC, `ms` is
+/// ADVISORY + NON-CANONICAL (stated in `note`).
+fn results_json(triples: usize, rows: &[Row]) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"sparq-nlq record_olympics\",\n");
+    s.push_str(&format!("  \"triples\": {triples},\n"));
+    s.push_str(
+        "  \"note\": \"`rows`/`repairs` are DETERMINISTIC at the recorded fixture (a pure \
+         function of the dataset + scripted completions); `ms` is best-effort per-question \
+         latency MEASURED on the running host — ADVISORY, NON-CANONICAL (this dev box) — do \
+         not bake into committed files\",\n",
+    );
+    s.push_str("  \"questions\": [\n");
+    for (i, r) in rows.iter().enumerate() {
+        let comma = if i + 1 < rows.len() { "," } else { "" };
+        s.push_str(&format!(
+            "    {{ \"question\": {}, \"rows\": {}, \"repairs\": {}, \"ms\": {:.3} }}{comma}\n",
+            json_str(&r.question),
+            r.rows,
+            r.repairs,
+            r.ms,
+        ));
+    }
+    s.push_str("  ]\n");
+    s.push_str("}\n");
+    s
+}
+
 fn main() {
+    let (_args, json_path) = take_json_flag(std::env::args().collect());
+
     let path = std::env::var("SPARQ_OLYMPICS_NT").unwrap_or_else(|_| {
         concat!(
             env!("CARGO_MANIFEST_DIR"),
@@ -196,17 +303,24 @@ fn main() {
     let recorder = Rc::new(RecordingLlm::new(ScriptedLlm { script: script() }));
     let nlq = Nlq::new(&graph, Box::new(Rc::clone(&recorder)));
 
+    let mut measured: Vec<Row> = Vec::new();
     for (question, _, _) in script() {
         let t0 = std::time::Instant::now();
         let a = nlq
             .ask(question)
             .unwrap_or_else(|e| panic!("{question:?} failed: {e}\n{:#?}", e.transcript));
+        let ms = t0.elapsed().as_secs_f64() * 1e3;
         println!(
-            "ok ({} rows, {} repair(s), {:.1} ms): {question}",
+            "ok ({} rows, {} repair(s), {ms:.1} ms): {question}",
             a.result.len(),
             a.repairs,
-            t0.elapsed().as_secs_f64() * 1e3
         );
+        measured.push(Row {
+            question: question.to_string(),
+            rows: a.result.len(),
+            repairs: a.repairs,
+            ms,
+        });
         // Show the head of the result so a human can sanity-check the recording.
         for row in a.result.rows.iter().take(3) {
             let cells: Vec<String> = row
@@ -228,4 +342,82 @@ fn main() {
     std::fs::create_dir_all(std::path::Path::new(out).parent().unwrap()).unwrap();
     recorder.save(out).expect("write fixture");
     println!("wrote {} exchanges to {out}", recorder.exchanges().len());
+
+    // [OPUS-4.8] (sq-k5qq) Strictly-additive JSON emit: only when `--json <path>` was given.
+    // STDOUT above (the per-question lines + fixture write) is the unchanged human output.
+    if let Some(path) = json_path {
+        let doc = results_json(graph.len(), &measured);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote {} question rows to {path}", measured.len());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-k5qq) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["record_olympics", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["record_olympics"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        // Absent flag -> argv unchanged, no path.
+        let plain: Vec<String> = ["record_olympics"].iter().map(|s| s.to_string()).collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn json_str_escapes() {
+        assert_eq!(json_str("rows"), "\"rows\"");
+        assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+    }
+
+    #[test]
+    fn results_json_shape_and_keys() {
+        let rows = vec![
+            Row {
+                question: "How many athletes are in the dataset?".into(),
+                rows: 1,
+                repairs: 0,
+                ms: 1.5,
+            },
+            Row {
+                question: "How many events does each sport have?".into(),
+                rows: 12,
+                repairs: 1,
+                ms: 3.25,
+            },
+        ];
+        let doc = results_json(123_456, &rows);
+        // The dependency-free emit must round-trip through a REAL serde_json parse —
+        // this catches a malformed document (e.g. a missing inter-row comma).
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "sparq-nlq record_olympics");
+        assert_eq!(v["triples"], 123_456);
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        let arr = v["questions"].as_array().expect("questions is an array");
+        assert_eq!(arr.len(), 2);
+        assert_eq!(arr[0]["question"], "How many athletes are in the dataset?");
+        assert_eq!(arr[0]["rows"], 1);
+        assert_eq!(arr[0]["repairs"], 0);
+        assert!(arr[0]["ms"].is_number());
+        assert_eq!(arr[1]["repairs"], 1);
+
+        // An empty run must still be valid JSON (no trailing comma).
+        let empty = results_json(0, &[]);
+        let v2: serde_json::Value = serde_json::from_str(&empty).expect("empty run is valid JSON");
+        assert!(v2["questions"].as_array().unwrap().is_empty());
+    }
 }

--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -120,6 +120,13 @@ sparq-core = { path = "../sparq-core", version = "0.1.0", features = ["mmap"] }
 # a library dependency of this crate — it stays a test-only dependency and never enters the published
 # graph; the fingerprint itself depends only on sparq-core's public read API.
 rayon = { workspace = true }
+# [OPUS-4.8] (sq-k5qq) DEV-only: the throughput/diskann harnesses emit an optional,
+# strictly-additive `SPARQ_VECTORS_JSON=<path>` results document (dependency-free
+# `format!`-built JSON — no serde in the harness itself); this dev-dep parses that emit
+# back so the round-trip test catches a malformed document. `serde_json` is ALSO an
+# OPTIONAL runtime dep (the `provider`/`embeddings` features) — listing it here makes it
+# available to the test targets in BOTH feature states, independent of those features.
+serde_json = "1"
 
 # [OPUS-4.8] sq-ip3a: the bench example measures HNSW (`VectorIndex`) recall/build, so it needs the
 # approximate backend. Gating it on `approx-ann` keeps `cargo build --all-targets` (default features)

--- a/crates/sparq-vectors/tests/diskann.rs
+++ b/crates/sparq-vectors/tests/diskann.rs
@@ -6,12 +6,94 @@
 //!    byte-identical neighbours, the acceptance criterion of sq-7zc;
 //! 3. **parity with the in-RAM searchers** on tiny separable clusters, and the degenerate
 //!    all-zero-query contract shared with `nearest_exact` / `VectorIndex`.
+//!
+//! [OPUS-4.8] (sq-k5qq) Strictly-additive machine-readable emit: set `SPARQ_VECTORS_JSON`
+//! to a path and the recall gate ALSO writes its deterministic recall + advisory build/query
+//! timings there as a stable, DEPENDENCY-FREE JSON document (mirroring
+//! `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json`). These tests run under `cargo test`
+//! with NO CLI args, so the path comes from an env var, not a `--json` flag. STDERR is
+//! byte-for-byte unchanged whether or not the env var is set; the timings are ADVISORY +
+//! NON-CANONICAL (this dev box) and nothing is committed. serde_json is a TEST-only dev-dep.
 
 use sparq_vectors::{nearest_exact, DiskAnnIndex, PqConfig, VamanaConfig, VectorStore};
 // [OPUS-4.8] (sq-ip3a) HNSW is the approximate backend — `approx-ann` only (the disk-vs-HNSW
 // parity test below is gated to match).
 #[cfg(feature = "approx-ann")]
 use sparq_vectors::VectorIndex;
+use std::time::Instant;
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-k5qq) SPARQ_VECTORS_JSON=<path> machine-readable results emit.
+// Dependency-free `format!`-built JSON, the same idiom as tests/throughput.rs.
+// ---------------------------------------------------------------------------
+
+/// The env var that, when set to a path, makes a measurement test ALSO write its
+/// metrics there as JSON. Shared with `tests/throughput.rs`.
+const JSON_ENV: &str = "SPARQ_VECTORS_JSON";
+
+/// Minimal JSON string escaper (the dependency-free emit).
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Serialise the workload dimensions + captured `metrics` to stable, dependency-free JSON.
+/// `recall` is a DETERMINISTIC float at the pinned `(N, seed)` workload; the timings are
+/// ADVISORY + NON-CANONICAL (stated in `note`).
+fn results_json(
+    harness: &str,
+    n: usize,
+    dim: usize,
+    k: usize,
+    queries: usize,
+    metrics: &[(&str, f64)],
+) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str(&format!("  \"harness\": {},\n", json_str(harness)));
+    s.push_str(&format!("  \"n\": {n},\n  \"dim\": {dim},\n  \"k\": {k},\n  \"queries\": {queries},\n"));
+    s.push_str(
+        "  \"note\": \"`recall` is DETERMINISTIC at the pinned (N, seed) workload; the \
+         build/query timings are best-effort, MEASURED on the running host — ADVISORY, \
+         NON-CANONICAL (this dev box) — do not bake into committed files\",\n",
+    );
+    s.push_str("  \"metrics\": {\n");
+    for (i, (key, val)) in metrics.iter().enumerate() {
+        let comma = if i + 1 < metrics.len() { "," } else { "" };
+        s.push_str(&format!("    {}: {val:.6}{comma}\n", json_str(key)));
+    }
+    s.push_str("  }\n");
+    s.push_str("}\n");
+    s
+}
+
+/// Write the JSON document iff `SPARQ_VECTORS_JSON` is set. Returns whether it wrote.
+fn maybe_write_json(doc: &str) -> bool {
+    match std::env::var(JSON_ENV) {
+        Ok(path) if !path.is_empty() => {
+            if let Err(e) = std::fs::write(&path, doc) {
+                eprintln!("error writing {JSON_ENV} results to {path}: {e}");
+            } else {
+                eprintln!("wrote results JSON to {path}");
+            }
+            true
+        }
+        _ => false,
+    }
+}
 
 fn splitmix64(state: &mut u64) -> u64 {
     *state = state.wrapping_add(0x9E3779B97F4A7C15);
@@ -50,12 +132,15 @@ fn diskann_recall_at_10_vs_brute_force_on_50k() {
     }
     store.finalize().unwrap();
 
+    let t = Instant::now();
     let index = DiskAnnIndex::build(&store, &graph_path).unwrap();
+    let build = t.elapsed();
     assert_eq!(index.len(), N);
     assert_eq!(index.dim(), DIM);
 
     let mut q_state = 0xDECAF_u64;
     let mut hits = 0usize;
+    let t = Instant::now();
     for _ in 0..QUERIES {
         let q = rand_vec(&mut q_state, DIM);
         let exact: Vec<u32> =
@@ -65,12 +150,61 @@ fn diskann_recall_at_10_vs_brute_force_on_50k() {
         assert_eq!(approx.len(), K);
         hits += approx.iter().filter(|id| exact.contains(id)).count();
     }
+    let query = t.elapsed();
     let recall = hits as f64 / (QUERIES * K) as f64;
     eprintln!("DiskANN recall@{K} over {QUERIES} queries on {N}x{DIM}: {recall:.4}");
     assert!(recall >= 0.90, "recall@{K} gate failed: {recall:.4} < 0.90");
 
+    // [OPUS-4.8] (sq-k5qq) Strictly-additive: writes only when SPARQ_VECTORS_JSON is set;
+    // the stderr line above is unchanged either way. `recall` is the deterministic gate value.
+    let doc = results_json(
+        "sparq-vectors diskann recall",
+        N,
+        DIM,
+        K,
+        QUERIES,
+        &[
+            ("recall", recall),
+            ("build_ms", build.as_secs_f64() * 1e3),
+            ("query_ms_per_query", query.as_secs_f64() * 1e3 / QUERIES as f64),
+        ],
+    );
+    maybe_write_json(&doc);
+
     let _ = std::fs::remove_file(&store_path);
     let _ = std::fs::remove_file(&graph_path);
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-k5qq) The dependency-free emit must round-trip through a REAL
+// serde_json parse — this runs in BOTH feature states (no approx-ann gate).
+// ---------------------------------------------------------------------------
+#[test]
+fn json_round_trips() {
+    assert_eq!(json_str("recall"), "\"recall\"");
+    assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+
+    let doc = results_json(
+        "sparq-vectors diskann recall",
+        50_000,
+        32,
+        10,
+        100,
+        &[("recall", 0.97), ("build_ms", 1234.5)],
+    );
+    let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+    assert_eq!(v["harness"], "sparq-vectors diskann recall");
+    assert_eq!(v["n"], 50_000);
+    assert_eq!(v["dim"], 32);
+    assert_eq!(v["k"], 10);
+    assert_eq!(v["queries"], 100);
+    assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+    assert!(v["metrics"]["recall"].is_number());
+    assert!(v["metrics"]["build_ms"].is_number());
+
+    let empty = results_json("h", 1, 1, 1, 1, &[]);
+    let v2: serde_json::Value = serde_json::from_str(&empty).expect("empty metrics is valid JSON");
+    assert!(v2["metrics"].as_object().unwrap().is_empty());
 }
 
 #[test]

--- a/crates/sparq-vectors/tests/throughput.rs
+++ b/crates/sparq-vectors/tests/throughput.rs
@@ -7,12 +7,97 @@
 //!
 //! Prints store build/finalize/open, HNSW build, and exact vs HNSW query throughput
 //! on the same 50k×32 random workload as the recall gate (tests/recall.rs).
+//!
+//! [OPUS-4.8] (sq-k5qq) Strictly-additive machine-readable emit: set `SPARQ_VECTORS_JSON`
+//! to a path and the measurement run ALSO writes the same advisory timings as a stable,
+//! DEPENDENCY-FREE JSON document there — mirroring the `format!`-JSON convention of
+//! `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json`. This test runs under
+//! `cargo test` with NO CLI args, so the path comes from an env var, not a `--json` flag.
+//! STDERR above is byte-for-byte unchanged whether or not the env var is set; the timings
+//! are ADVISORY + NON-CANONICAL (this dev box) and nothing is committed. (No serde dep is
+//! added to the harness; serde_json is a TEST-only dev-dep used by `json_round_trips`.)
 
 // [OPUS-4.8] (sq-ip3a) HNSW (VectorIndex) is the approximate backend — gated behind `approx-ann`.
 #![cfg(feature = "approx-ann")]
 
 use sparq_vectors::{nearest_exact, VectorIndex, VectorStore};
 use std::time::Instant;
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-k5qq) SPARQ_VECTORS_JSON=<path> machine-readable results emit.
+// Dependency-free `format!`-built JSON, mirroring mpc_net_bench::cell_json. The
+// run prints its usual stderr table unconditionally; the JSON file is written
+// ONLY when the env var is set, so behaviour is byte-identical when it is absent.
+// ---------------------------------------------------------------------------
+
+/// The env var that, when set to a path, makes the measurement run ALSO write its
+/// timings there as JSON. Shared with `tests/diskann.rs`.
+const JSON_ENV: &str = "SPARQ_VECTORS_JSON";
+
+/// Minimal JSON string escaper (the dependency-free emit). Labels are static ASCII;
+/// anything else still yields valid `\uXXXX`.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Serialise `(harness, n, dim, k, queries)` plus the captured `metrics` rows to stable,
+/// dependency-free JSON. Every metric is ADVISORY + NON-CANONICAL (stated in `note`).
+fn results_json(
+    harness: &str,
+    n: usize,
+    dim: usize,
+    k: usize,
+    queries: usize,
+    metrics: &[(&str, f64)],
+) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str(&format!("  \"harness\": {},\n", json_str(harness)));
+    s.push_str(&format!("  \"n\": {n},\n  \"dim\": {dim},\n  \"k\": {k},\n  \"queries\": {queries},\n"));
+    s.push_str(
+        "  \"note\": \"`n`/`dim`/`k`/`queries` are the fixed deterministic workload \
+         dimensions; every timing/throughput metric below is best-effort, MEASURED on the \
+         running host — ADVISORY, NON-CANONICAL (this dev box) — do not bake into committed \
+         files\",\n",
+    );
+    s.push_str("  \"metrics\": {\n");
+    for (i, (key, val)) in metrics.iter().enumerate() {
+        let comma = if i + 1 < metrics.len() { "," } else { "" };
+        s.push_str(&format!("    {}: {val:.6}{comma}\n", json_str(key)));
+    }
+    s.push_str("  }\n");
+    s.push_str("}\n");
+    s
+}
+
+/// Write the JSON document iff `SPARQ_VECTORS_JSON` is set. Returns whether it wrote.
+fn maybe_write_json(doc: &str) -> bool {
+    match std::env::var(JSON_ENV) {
+        Ok(path) if !path.is_empty() => {
+            if let Err(e) = std::fs::write(&path, doc) {
+                eprintln!("error writing {JSON_ENV} results to {path}: {e}");
+            } else {
+                eprintln!("wrote results JSON to {path}");
+            }
+            true
+        }
+        _ => false,
+    }
+}
 
 fn splitmix64(state: &mut u64) -> u64 {
     *state = state.wrapping_add(0x9E3779B97F4A7C15);
@@ -92,5 +177,57 @@ fn throughput_50k() {
         1.0 / per(hnsw)
     );
 
+    // [OPUS-4.8] (sq-k5qq) Strictly-additive: only writes when SPARQ_VECTORS_JSON is set;
+    // the stderr table above is unchanged either way. Same advisory numbers, machine-readable.
+    let doc = results_json(
+        "sparq-vectors throughput",
+        N,
+        DIM,
+        K,
+        QUERIES,
+        &[
+            ("put_ms", put.as_secs_f64() * 1e3),
+            ("finalize_ms", finalize.as_secs_f64() * 1e3),
+            ("open_ms", open.as_secs_f64() * 1e3),
+            ("hnsw_build_ms", build.as_secs_f64() * 1e3),
+            ("exact_ms_per_query", per(exact) * 1e3),
+            ("hnsw_ms_per_query", per(hnsw) * 1e3),
+        ],
+    );
+    maybe_write_json(&doc);
+
     let _ = std::fs::remove_file(&path);
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-k5qq) The dependency-free emit must round-trip through a REAL
+// serde_json parse — this catches a malformed document (e.g. a missing comma).
+// ---------------------------------------------------------------------------
+#[test]
+fn json_round_trips() {
+    assert_eq!(json_str("put_ms"), "\"put_ms\"");
+    assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+
+    let doc = results_json(
+        "sparq-vectors throughput",
+        50_000,
+        32,
+        10,
+        200,
+        &[("put_ms", 12.5), ("hnsw_ms_per_query", 0.0042)],
+    );
+    let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+    assert_eq!(v["harness"], "sparq-vectors throughput");
+    assert_eq!(v["n"], 50_000);
+    assert_eq!(v["dim"], 32);
+    assert_eq!(v["k"], 10);
+    assert_eq!(v["queries"], 200);
+    assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+    assert!(v["metrics"]["put_ms"].is_number());
+    assert!(v["metrics"]["hnsw_ms_per_query"].is_number());
+
+    // An empty metrics map must still be valid JSON (no trailing comma).
+    let empty = results_json("h", 1, 1, 1, 1, &[]);
+    let v2: serde_json::Value = serde_json::from_str(&empty).expect("empty metrics is valid JSON");
+    assert!(v2["metrics"].as_object().unwrap().is_empty());
 }

--- a/crates/sparq-wasm/test/mem.cjs
+++ b/crates/sparq-wasm/test/mem.cjs
@@ -1,14 +1,51 @@
 // Browser memory-bound + ingestion test for the WASM build.
 //   wasm-pack build --target nodejs --release --out-dir pkg-node
 //   node test/mem.cjs
+//   node test/mem.cjs --json /tmp/wasm-mem.json   # strictly-additive emit
 //
 // The browser is the memory-constrained target (a wasm32 linear memory caps at 4 GB,
 // and a real tab is happier under ~2 GB). This measures, with the SAME compact dict +
 // byte-level N-Triples parser the native engine uses, the in-browser bytes/triple and
 // load throughput, and extrapolates how many triples fit a 2 GB / 4 GB heap — the
 // figures that decide what a browser deployment can hold.
+//
+// [OPUS-4.8] (sq-k5qq) `--json <path>` writes the SAME per-(size, mode) rows STDOUT prints
+// as a stable, hand-built JSON document (the JS analogue of the Rust harnesses'
+// dependency-free `format!`-JSON). `triples`/`bytes_per_triple` are DETERMINISTIC (a pure
+// function of the data); `load_ms`/`throughput_mps` are best-effort, MEASURED — ADVISORY +
+// NON-CANONICAL (stated in the emitted `note`). STDOUT is byte-for-byte unchanged whether
+// or not the flag is present, and nothing is committed.
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const { Store } = require("../pkg-node/sparq_wasm.js");
+
+// Extracts `--json <path>` from argv (a bare `--json` is a usage error), so the run is
+// byte-identical when the flag is absent.
+function takeJsonArg(argv) {
+  const i = argv.indexOf("--json");
+  if (i === -1) return null;
+  if (i + 1 >= argv.length) {
+    console.error("`--json` requires a path argument: --json <path>");
+    process.exit(2);
+  }
+  return argv[i + 1];
+}
+function resultsJson(rows) {
+  return JSON.stringify(
+    {
+      harness: "sparq-wasm mem",
+      note:
+        "`triples`/`bytes_per_triple` are DETERMINISTIC (a pure function of the generated " +
+        "data); `load_ms`/`throughput_mps` are best-effort, MEASURED on the running host — " +
+        "ADVISORY, NON-CANONICAL (this dev box) — do not bake into committed files",
+      rows,
+    },
+    null,
+    2,
+  );
+}
+const JSON_PATH = takeJsonArg(process.argv.slice(2));
+const ROWS = [];
 
 // N-Triples (so it exercises the custom byte-level parser in wasm), 8 triples/entity:
 // type + name(string) + age(inline integer) + 4 follows edges.
@@ -51,6 +88,16 @@ for (const entities of [25_000, 100_000, 300_000]) {
     );
     // Sanity: results are identical regardless of storage mode.
     assert.equal(store.count(TYPE_Q), entities);
+    // [OPUS-4.8] (sq-k5qq) capture for the optional --json emit (deterministic
+    // triples/bytes_per_triple + advisory timing).
+    ROWS.push({
+      entities,
+      mode,
+      triples,
+      bytes_per_triple: bpt,
+      load_ms: ms,
+      throughput_mps: mps,
+    });
   }
 }
 
@@ -61,3 +108,16 @@ console.log(
   `cutting the total from ~${rawBpt.toFixed(0)} to ~${cmpBpt.toFixed(0)} B/triple (-${(100 * (1 - cmpBpt / rawBpt)).toFixed(0)}%) for a small per-scan decode —\n` +
   `i.e. it fits ~${(rawBpt / cmpBpt).toFixed(1)}x more triples in the same tab. Results are identical. all assertions passed ✓`,
 );
+
+// [OPUS-4.8] (sq-k5qq) Build + SELF-TEST the results document (round-trips through a real
+// JSON.parse every run). Writing is strictly-additive: only with `--json <path>`; STDOUT
+// above is unchanged.
+const DOC = resultsJson(ROWS);
+const parsed = JSON.parse(DOC);
+assert.equal(parsed.harness, "sparq-wasm mem");
+assert.ok(parsed.note.includes("NON-CANONICAL"));
+assert.ok(Array.isArray(parsed.rows) && parsed.rows.length === ROWS.length);
+if (JSON_PATH) {
+  fs.writeFileSync(JSON_PATH, DOC);
+  console.error(`wrote ${ROWS.length} result rows to ${JSON_PATH}`);
+}

--- a/crates/sparq-wasm/test/perf.cjs
+++ b/crates/sparq-wasm/test/perf.cjs
@@ -2,8 +2,48 @@
 // the WASM (browser) runtime, where memory and main-thread time are scarcest.
 //   wasm-pack build --target nodejs --release --out-dir pkg-node
 //   node test/perf.cjs
+//   node test/perf.cjs --json /tmp/wasm-perf.json   # strictly-additive emit
+//
+// [OPUS-4.8] (sq-k5qq) `--json <path>` writes the SAME per-workload timings STDOUT prints
+// as a stable, hand-built JSON document (the JS analogue of the Rust harnesses'
+// dependency-free `format!`-JSON; mpc_net_bench::cell_json). STDOUT is byte-for-byte
+// unchanged whether or not the flag is present; every `ms` is best-effort, MEASURED on the
+// running host — ADVISORY + NON-CANONICAL (stated in the emitted `note`) — nothing committed.
 const assert = require("node:assert/strict");
+const fs = require("node:fs");
 const { Store } = require("../pkg-node/sparq_wasm.js");
+
+// Extracts `--json <path>` from argv (a bare `--json` is a usage error), so the run is
+// byte-identical when the flag is absent.
+function takeJsonArg(argv) {
+  const i = argv.indexOf("--json");
+  if (i === -1) return null;
+  if (i + 1 >= argv.length) {
+    console.error("`--json` requires a path argument: --json <path>");
+    process.exit(2);
+  }
+  return argv[i + 1];
+}
+// Hand-built results document. `rows` is [{label, ms}]; the assertion COUNTS in the body
+// are the deterministic gate, the timings are advisory (the note says so). Serialised with
+// JSON.stringify, which escapes the label strings; a self-test JSON.parse runs every time.
+function resultsJson(meta, rows) {
+  return JSON.stringify(
+    {
+      harness: "sparq-wasm perf",
+      ...meta,
+      note:
+        "every `ms` is best-effort latency MEASURED on the running host — ADVISORY, " +
+        "NON-CANONICAL (this dev box) — do not bake into committed files; the in-harness " +
+        "assertion counts are the deterministic gate",
+      rows,
+    },
+    null,
+    2,
+  );
+}
+const JSON_PATH = takeJsonArg(process.argv.slice(2));
+const ROWS = [];
 
 // Deterministic ~400k-triple graph (50k people, 8 triples each: type/name/age/city
 // + 4 follows).
@@ -22,6 +62,7 @@ const t0 = process.hrtime.bigint();
 const store = Store.load(ttl, "turtle");
 const loadMs = Number(process.hrtime.bigint() - t0) / 1e6;
 console.log(`loaded ${store.size} triples in ${loadMs.toFixed(0)} ms\n`);
+ROWS.push({ label: "load", ms: loadMs });
 
 function time(label, fn) {
   let best = Infinity, out;
@@ -31,6 +72,7 @@ function time(label, fn) {
     best = Math.min(best, Number(process.hrtime.bigint() - s) / 1e6);
   }
   console.log(`  ${label.padEnd(34)} ${best.toFixed(3)} ms`);
+  ROWS.push({ label, ms: best }); // [OPUS-4.8] (sq-k5qq) capture for the optional --json emit
   return out;
 }
 
@@ -83,3 +125,16 @@ const cOpt = time("count(name OPTIONAL age)", () =>
 assert.equal(cOpt, N);
 
 console.log("\nall WASM streaming assertions passed ✓");
+
+// [OPUS-4.8] (sq-k5qq) Build the results document and SELF-TEST it (round-trips through a
+// real JSON.parse on every run — catches a malformed emit). Writing the file is
+// strictly-additive: only when `--json <path>` was given; STDOUT above is unchanged.
+const DOC = resultsJson({ triples: store.size }, ROWS);
+const parsed = JSON.parse(DOC); // would throw on a malformed document
+assert.equal(parsed.harness, "sparq-wasm perf");
+assert.ok(parsed.note.includes("NON-CANONICAL"));
+assert.ok(Array.isArray(parsed.rows) && parsed.rows.length === ROWS.length);
+if (JSON_PATH) {
+  fs.writeFileSync(JSON_PATH, DOC);
+  console.error(`wrote ${ROWS.length} result rows to ${JSON_PATH}`);
+}


### PR DESCRIPTION
> 🤖 SPARQ agent

Extends the dependency-free, strictly-additive results emit (sq-cxji/#749 wired the four example-based Rust harnesses) to the still-STDOUT-only bench harnesses, mirroring the hand-built `format!`-JSON convention of `crates/sparq-mpc/examples/mpc_net_bench.rs::cell_json` and `crates/sparq-text/examples/bench_text.rs`. **No serde dep is added to any harness** — the Rust round-trip tests use `serde_json` as a TEST-only dev-dep; the JS/shell emitters use native `JSON.stringify` / hand-built strings parsed back by a self-test (cjs) or by python's `json` (shell, in validation).

## Harnesses wired

Each is strictly additive — emit-path off ⇒ STDOUT byte-identical — with a `NON-CANONICAL` note in the emitted JSON, **no committed perf numbers**, and a parseable-JSON round-trip:

| Harness | Trigger | Emits |
|---|---|---|
| `sparq-vectors tests/throughput.rs` | env `SPARQ_VECTORS_JSON` (runs under `cargo test`, no CLI args) | advisory put/finalize/open/HNSW-build + exact/HNSW per-query timings |
| `sparq-vectors tests/diskann.rs` | env `SPARQ_VECTORS_JSON` | **deterministic** recall@10 + advisory build/query timings |
| `sparq-nlq examples/record_olympics.rs` | `--json <path>` | per-question rows (deterministic rows/repairs + advisory ms) |
| `sparq-wasm test/perf.cjs` | `--json <path>` | per-workload ms |
| `sparq-wasm test/mem.cjs` | `--json <path>` | deterministic triples/bytes_per_triple + advisory load_ms/throughput |
| `bench/inference/eye-comparison.sh` | env `SPARQ_INFER_JSON` | per-workload sparq/eye wall seconds (dt100k ⇒ `null` + `"eye_skipped": true`) |
| `bench/inference/owl-bench.sh` | env `OWL_BENCH_JSON` | per-workload min-of-3 seconds |
| `bench/serve src/bin/writer_spike.rs` | `--json <path>` | §1 throughput rows + §2/§3 reader-latency rows |

The vectors tests run under `cargo test` with no CLI args, so they take an env-var path (per the bead). The wasm cjs harnesses SELF-TEST their emit via a real `JSON.parse` on every run, flag or not.

## Deferred

The other six `bench/serve` spikes (`snapshot`/`cache`/`stream`/`point`/`update_stream`/`pss_update_throughput`) emit mostly free-text metric lines (not `writer_spike`'s clean row tables), so each needs its own JSON shape. Deferred to follow-up bead **sq-5vm.1** to keep this PR coherent rather than force six near-duplicated emitters in.

## Notes / honesty

- `serde_json` added as a TEST-only dev-dep on the standalone `serve-spikes` project re-resolved its **detached** `Cargo.lock`, which forced an unrelated `tower-http` 0.6.11 → 0.7.0 minor bump (cargo rejects pinning it back; confined to `bench/serve`'s own lock, not the root workspace).
- The `record_olympics` example needs the `bench/qlever-olympics/olympics.nt` download fixture to run end-to-end (absent on this box), so it was **not** exercised end-to-end here — but the 3 unit tests (flag-extraction + escaper + serde_json round-trip) fully cover the JSON builder.
- `pkg-node` is git-ignored, so the wasm build artifact is not committed.

## Gates (this Linux dev box)

- `cargo clippy --all-targets -D warnings` + tests in BOTH feature states: **sparq-vectors** (default + `approx-ann`) ✓, **sparq-nlq** (default + `--all-features`) ✓.
- `cargo clippy --all-targets -D warnings` + `writer_spike` round-trip test for the standalone `bench/serve` project ✓.
- `bash -n` + `shellcheck` CLEAN on both shell scripts; JSON validated end-to-end against stub CLIs (incl. the dt100k-skipped row).
- Both wasm cjs harnesses run green against a real `wasm-pack --target nodejs` build; the `--json` output file validated.
- `check-no-perf-numbers.py --enforce` = **0 findings**; `typos` CLEAN on all changed files.