### PR TITLE
fix(ci): bead-autoclose fail-soft on ruleset-blocked push + document the bypass/periodic-PR path (sq-roe3) [OPUS-4.8]

### DIFF
--- a/.github/workflows/bead-autoclose.yml
+++ b/.github/workflows/bead-autoclose.yml
@@ -80,7 +80,24 @@ jobs:
             --subject "$SUBJECT" \
             --jsonl .beads/issues.jsonl
 
-      - name: Commit the regenerated bead JSONL back to main (only if it changed)
+      # [OPUS-4.8] FAIL-SOFT push (sq-roe3). The default GITHUB_TOKEN CANNOT push to the
+      # protected `main` branch: the repo ruleset (id 17688455, rules: pull_request +
+      # required_status_checks "gate" + code_scanning + non_fast_forward) rejects a direct
+      # push with `GH013: Repository rule violations` and an empty bypass list. Confirmed on
+      # the first real run (bead-autoclose.yml #27828093722, PR #830):
+      #   remote: error: GH013: Repository rule violations found for refs/heads/main
+      #   remote: - Changes must be made through a pull request.
+      #   remote: - Required status check "gate" is expected.
+      #   remote: - Code scanning is waiting for results from CodeQL ...
+      # Until a ruleset bypass-list entry for the github-actions bot exists (owner-only,
+      # needs:user) OR bead-state is folded into the periodic .beads-export PR (sq-2xdg),
+      # the push WILL be rejected. This job runs post-merge (on `closed`) and never gates a
+      # PR, so a red run is pure noise — but it should not be red. We therefore treat a
+      # rejected push as a best-effort no-op: warn clearly and exit 0. The bead-ID
+      # extraction + close logic above still runs every time, so the moment pushing becomes
+      # possible (bypass added) this lands the close with no further change. The orchestrator
+      # closes beads manually in the interim.
+      - name: Commit the regenerated bead JSONL back to main (best-effort; non-fatal on ruleset-blocked push)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -95,5 +112,15 @@ jobs:
           git add .beads/issues.jsonl
           git commit -m "chore(beads): auto-close bead(s) mapped to merged PR #${PR_NUMBER} [skip ci]" \
                      -m "Durable replacement for the ephemeral watcher b1kzhfxq5 (sq-84a8). [OPUS-4.8]"
+          # Best-effort push. A protected-branch ruleset rejection (GH013) or a
+          # non-fast-forward race must NOT fail this non-gating post-merge job. Disable
+          # `errexit` only around the push so we can inspect its status and fail soft.
+          set +e
           git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" HEAD:main
+          push_rc=$?
+          set -e
+          if [ "$push_rc" -ne 0 ]; then
+            echo "::warning title=bead-autoclose push declined::Could not push the .beads close for PR #${PR_NUMBER} to protected main (git push exit ${push_rc}; likely GH013 ruleset rejection — direct pushes to main are blocked). Best-effort no-op: the bead-ID extraction + close logic ran, but the commit was NOT landed. Resolve by adding the github-actions bot to the main ruleset bypass list (owner-only; sq-roe3 needs:user) or folding bead-state into the periodic .beads-export PR (sq-2xdg). The orchestrator closes the bead(s) manually in the meantime."
+            exit 0
+          fi
           echo "committed + pushed bead auto-close for PR #${PR_NUMBER} to main."


### PR DESCRIPTION
> 🤖 SPARQ agent

## Root cause (GH013)

The `bead-autoclose` workflow runs post-merge (`pull_request: [closed]`, gated on `merged == true`) and tries to commit the regenerated `.beads/issues.jsonl` back to `main` via `git push HEAD:main` using the default `GITHUB_TOKEN`. That push is **rejected by the `main` ruleset** (id `17688455`; rules: `pull_request` + `required_status_checks "gate"` + `code_scanning` + `non_fast_forward`; **empty bypass list**). Confirmed on the first real run — `bead-autoclose` run **#27828093722** (PR #830):

```
remote: error: GH013: Repository rule violations found for refs/heads/main
remote: - Changes must be made through a pull request.
remote: - Required status check "gate" is expected.
remote: - Code scanning is waiting for results from CodeQL for the commit 9e52814.
 ! [remote rejected] HEAD -> main (push declined due to repository rule violations)
##[error]Process completed with exit code 1.
```

Because the step ran under `set -euo pipefail` / `bash -e`, the rejected push turned the **whole job RED on every merge**, and no bead was auto-closed.

## What changed (immediate fail-soft)

`.github/workflows/bead-autoclose.yml` — the commit/push step now treats a rejected push as a best-effort no-op: it disables `errexit` only around the `git push`, captures the exit code, and on non-zero emits a clear `::warning::` and `exit 0`. The job is GREEN whether or not the push lands.

- The bead-ID extraction + `scripts/ci-close-merged-beads.py` close logic is **unchanged** — it still runs every merge, so the moment pushing becomes possible the close lands with no further code change.
- **No** change to triggers / job name / `permissions` / `concurrency`. Still `pull_request: [closed]` only — it never runs on a PR head ref, so `ci-summary / gate` never sees it; topology unchanged, this leg does not gate.

## Recommended ruleset-compatible path

Two viable durable fixes (in addition to the fail-soft, which only stops the red noise — it does NOT by itself land the close):

**Option A — bypass-list entry (cleanest; OWNER-ONLY → `needs:user`).** Add the `github-actions` bot (or a dedicated GitHub App) to the `main` ruleset bypass list so the workflow can push directly. Exact click-path: **Settings → Rules → Rulesets → `main` → Bypass list → Add bypass → select "Repository admin" / a deploy-key / GitHub App / the `github-actions` actor → Save.** (The bypass list is currently empty, so this requires the repo owner; I have not and cannot perform owner-only settings changes.) Note the `non_fast_forward` rule still applies — the step would also need a `git fetch && rebase` before push to survive concurrent merges.

**Option C — fold into the periodic `.beads`-export PR (`sq-2xdg`).** Let the autoclose log the intended close (pure no-op push, exactly the fail-soft state this PR ships) and let the canonical periodic `.beads` export PR carry the actual status change through the normal PR → `gate` → merge flow. No owner action; no PR-per-merge churn.

**Option B (not recommended)** — have the workflow open a PR per merged bead-close. Heavy (a PR per merge) and noisy.

**Recommendation:** ship this fail-soft now (done), then either (A) add the bypass entry — `needs:user` — for true auto-close, or (C) defer bead-state to `sq-2xdg`. Until then, the orchestrator closes beads manually as it already does.

## Sibling finding — `bench.yml` auto-ratchet (filed as bead sq-llxc)

`bench.yml`'s "Auto-ratchet the perf floor" step (`sq-52e`) uses the **same** `git push HEAD:main` pattern and **also fails** on `push:main` — runs **#27827073571** and **#27826231986** both went red at that step with `! [rejected] HEAD -> main (fetch first)` (a `non_fast_forward` race; it would additionally hit GH013 once past that). Unlike `bead-autoclose` it is **not** fail-soft, so the perf-baseline floor never actually lands on `main` via that path and the Benchmarks workflow goes red on every improving `push:main`. Filed as **sq-llxc** (`ci,bench`, P1) with the same fix options. Not touched in this PR to keep it scoped.

## Gates
- YAML valid: `python3 -c "import yaml;yaml.safe_load(open('.github/workflows/bead-autoclose.yml'))"` ✅
- `actionlint .github/workflows/bead-autoclose.yml` clean ✅
- `shellcheck -S style` clean on the modified run block ✅
- SHA-pins intact (no action refs changed) ✅
- `scripts/ci-close-merged-beads.py --self-test` passes ✅
- ci-summary gate topology unchanged (trigger still `closed`-only; never a PR ref) ✅
- Local reproduction: a failing push now yields `::warning::` + step exit 0 (verified); pre-change behaviour was exit 1 as seen in run #27828093722.

🤖 Generated with [Claude Code](https://claude.com/claude-code)