### PR TITLE
chore(i18n): RDF 1.2 terminology in runtime error messages (sq-ja92) [OPUS-4.8]

### DIFF
--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -1369,7 +1369,7 @@ impl Dict {
             TermParts::Lit { value, datatype, lang } => self.intern_lit(value, datatype, *lang),
             TermParts::Blank(b) => self.intern_blank(b),
             TermParts::Triple(_) => {
-                panic!("RDF-star triple terms must be interned structurally (intern_triple_ids), not via the parts-based leaf path")
+                panic!("RDF 1.2 triple terms must be interned structurally (intern_triple_ids), not via the parts-based leaf path")
             }
         }
     }
@@ -2281,7 +2281,7 @@ impl ShardedDict {
         for (tag, idx, t) in items {
             assert!(
                 !matches!(t, Term::Triple(_)),
-                "RDF-star triple terms are not supported by the sharded bulk interner; use the serial loader"
+                "RDF 1.2 triple terms are not supported by the sharded bulk interner; use the serial loader"
             );
             let s = (hash_term(&t) % n as u64) as usize;
             buckets[s].push((tag, idx, t));

--- a/crates/sparq-core/src/dictspill.rs
+++ b/crates/sparq-core/src/dictspill.rs
@@ -210,7 +210,7 @@ fn serialize_termparts(tp: &TermParts, out: &mut Vec<u8>) {
             // content is their components' ids (resolvable only after the leaf dedup), so they
             // take the dedicated in-RAM triple-term arena (`SpillInterner::triples`) and are
             // finalised in `finalize_triple_terms`. This leaf serializer must never see one.
-            panic!("RDF-star triple terms take the triple-term arena, not the leaf serializer (sq-jvbr)")
+            panic!("RDF 1.2 triple terms take the triple-term arena, not the leaf serializer (sq-jvbr)")
         }
     }
 }

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -8451,7 +8451,7 @@ fn term_pattern_to_term(tp: &TermPattern) -> Result<Term, String> {
             let subject: oxrdf::NamedOrBlankNode = match term_pattern_to_term(&t.subject)? {
                 Term::NamedNode(n) => n.into(),
                 Term::BlankNode(b) => b.into(),
-                _ => return Err("RDF-star triple-term subject must be an IRI or blank node".into()),
+                _ => return Err("RDF 1.2 triple-term subject must be an IRI or blank node".into()),
             };
             let predicate = match &t.predicate {
                 NamedNodePattern::NamedNode(n) => n.clone(),

--- a/crates/sparq-py/src/lib.rs
+++ b/crates/sparq-py/src/lib.rs
@@ -488,7 +488,7 @@ impl Graph {
                         let term = inner.dict.term(id);
                         match term {
                             oxrdf::Term::Triple(_) => {
-                                return Err("RDF-star triple terms cannot participate in N3 reasoning".into());
+                                return Err("RDF 1.2 triple terms cannot participate in N3 reasoning".into());
                             }
                             // [OPUS-4.8] roborev 1961: rename this graph's blank
                             // nodes under the reserved `sparqg` prefix before

--- a/js/src/sparql.ts
+++ b/js/src/sparql.ts
@@ -210,7 +210,7 @@ export function quadsToNQuads(quads: Iterable<RDF.Quad>): string {
   let out = '';
   for (const quad of quads) {
     if (quad.subject.termType === 'Quad' || quad.object.termType === 'Quad') {
-      throw new Error('RDF-star quoted triples are not supported');
+      throw new Error('RDF 1.2 triple terms are not supported');
     }
     const graph = quad.graph.termType === 'DefaultGraph' ? '' : ` ${termToNT(quad.graph)}`;
     out += `${termToNT(quad.subject)} ${termToNT(quad.predicate)} ${termToNT(quad.object)}${graph} .\n`;


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-ja92 (deferred from the DOC-ONLY terminology sweep #825/sq-2p8z).

Updates the outdated **RDF-star** wording in runtime error/panic/throw **string literals** (the doc-comments were already swept) to spec-correct **RDF 1.2** terminology ("RDF 1.2 triple terms"). Pure terminology reword — each message's meaning is preserved; no behaviour, no new surface, no feature gate.

## Messages changed (before → after)
| File | Before | After |
|---|---|---|
| `js/src/sparql.ts:213` (thrown `Error` in `quadsToNQuads`) | `RDF-star quoted triples are not supported` | `RDF 1.2 triple terms are not supported` |
| `crates/sparq-core/src/dictspill.rs:213` (leaf-serializer `panic!`) | `RDF-star triple terms take the triple-term arena, not the leaf serializer (sq-jvbr)` | `RDF 1.2 triple terms take the triple-term arena, not the leaf serializer (sq-jvbr)` |
| `crates/sparq-core/src/dict.rs:1372` (parts-based interner `panic!`) | `RDF-star triple terms must be interned structurally (intern_triple_ids), not via the parts-based leaf path` | `RDF 1.2 triple terms must be interned structurally (intern_triple_ids), not via the parts-based leaf path` |
| `crates/sparq-core/src/dict.rs:2284` (sharded-interner `assert!`) | `RDF-star triple terms are not supported by the sharded bulk interner; use the serial loader` | `RDF 1.2 triple terms are not supported by the sharded bulk interner; use the serial loader` |
| `crates/sparq-engine/src/exec.rs:8454` (term-pattern `Err`) | `RDF-star triple-term subject must be an IRI or blank node` | `RDF 1.2 triple-term subject must be an IRI or blank node` |
| `crates/sparq-py/src/lib.rs:491` (N3-reasoning `Err`) | `RDF-star triple terms cannot participate in N3 reasoning` | `RDF 1.2 triple terms cannot participate in N3 reasoning` |

## Coupled test
The only test asserting on a changed string is `dictspill::tests::serialize_rejects_triple_terms` — `#[should_panic(expected = "triple term")]`. It asserts on the `"triple term"` substring, which BOTH the old and new strings carry, so no test edit was required. Verified explicitly: ran by name under `--features dict-spill,mmap,parallel` → panics at `dictspill.rs:213` (the edited line) and passes.

## Deliberately left unchanged
`crates/sparq-core/src/nt.rs:326,597` mention the **legacy RDF-star CG `<< … >>`** syntax — these are doc-**comments** providing a historical/proper-noun contrast against RDF 1.2's object-only triple terms (the W3C Community Group's prior design). Out of scope per the bead (no doc-comments; preserve proper nouns). The `serializer_oracle.rs` `"rdf-star"` strings are test-fixture *labels*, not error messages — also left.

## Gates (run in both feature states where applicable)
- **terminology gate** (`scripts/check-terminology.py`): clean.
- **typos**: clean on changed lines (the only hits in `typos` are pre-existing unrelated identifiers, `numer_w` / a `"hel"` SUBSTR fixture).
- **sparq-core**: `clippy --all-targets -D warnings` + `test` GREEN in **default** AND in **`dict-spill,mmap,parallel`** (covers the changed `dictspill.rs` panic + the coupled `should_panic` test).
- **sparq-engine**: `clippy --all-targets -D warnings` + `test` GREEN in **default**; each non-default feature (`cs-planner` / `zk` / `serialize-rdf` / `window-functions` / `vectorized` / `result-cache` / `txn`) `cargo check --all-targets` GREEN individually, and all tested pairs GREEN. (The changed `exec.rs` string is on the base path, covered by default.)
- **sparq-py**: `clippy --all-targets -D warnings` + `test` GREEN (single state — no `[features]`).
- **js**: `tsc --noEmit` GREEN; no JS test asserts on the message.

## Pre-existing issue discovered (NOT introduced here)
`cargo {clippy,test} -p sparq-engine --all-targets` with **3+ non-default features combined** (e.g. `cs-planner,zk,serialize-rdf,window-functions,vectorized,result-cache,txn`) fails to compile the lib **test** target with `E0282`/`E0283` — a `Vec<Vec<u32>>` equality in a test becomes ambiguous against `impl PartialEq<serde_json::Value> for u32` once `serde_json` is unified into the graph. **Confirmed to reproduce on clean `origin/main` with my changes stashed**, so it predates this PR and is unrelated to the string reword (each feature + every tested pair compiles fine). Flagging for a follow-up bead; not fixed here to keep this PR a pure terminology change.