### PR TITLE
test(sparq-engine): disambiguate Vec<Vec<u32>> assertion under 3+-feature unification (sq-xx3u) [OPUS-4.8]

### DIFF
--- a/crates/sparq-engine/src/chunk.rs
+++ b/crates/sparq-engine/src/chunk.rs
@@ -284,7 +284,14 @@ mod tests {
         let unit = DataChunk::from_columns(vec![], 3).unwrap();
         assert_eq!(unit.len(), 3);
         assert_eq!(unit.width(), 0);
-        assert_eq!(unit.to_rows(), vec![vec![], vec![], vec![]]);
+        // [OPUS-4.8] (sq-xx3u) Annotate the expected value as `Vec<Vec<Id>>`. The inner
+        // `vec![]` literals carry no elements to pin their type, and once `serde_json`
+        // unifies into the test build's dependency graph (3+ features, e.g.
+        // `service`/`serialize-rdf`), its `impl PartialEq<serde_json::Value> for u32`
+        // makes the `Id: PartialEq<_>` resolution ambiguous (E0282/E0283). The explicit
+        // type fixes the element to `Id` regardless of which `PartialEq` impls are in scope.
+        let expected: Vec<Vec<Id>> = vec![vec![], vec![], vec![]];
+        assert_eq!(unit.to_rows(), expected);
     }
 
     #[test]


### PR DESCRIPTION
> 🤖 SPARQ agent — sq-xx3u

## What

Fixes a pre-existing latent compile gap: `cargo test -p sparq-engine` fails to compile the **lib test target** with **E0282/E0283** once **3+ non-default features** are combined.

### Root cause
`src/chunk.rs::empty_and_zero_width` compared `unit.to_rows()` (`Vec<Vec<Id>>`, `Id = u32`) against `vec![vec![], vec![], vec![]]`. The inner empty `vec![]` literals have no elements to pin their type. Once `serde_json` unifies into the lib-test dependency graph — which happens at 3+ features (the `service` feature pulls `serde_json` as a real dep; `serde_json` is also a dev-dep for the `serialize-rdf` round-trip tests) — its `impl PartialEq<serde_json::Value> for u32` makes `u32: PartialEq<_>` ambiguous:

```
error[E0283]: type annotations needed
   --> crates/sparq-engine/src/chunk.rs:287:9
    = note: multiple `impl`s satisfying `u32: PartialEq<_>` found in the following crates: `core`, `serde_json`:
            - impl PartialEq for u32;
            - impl PartialEq<serde_json::Value> for u32;
    = note: required for `Vec<Vec<u32>>` to implement `PartialEq<Vec<Vec<_>>>`
```

Every individual feature and every tested **pair** compiles fine, so CI's pair-matrix never surfaced it; only 3+ combined trips it. **Single site** — lines 273/346 use non-empty literals, so their element type is already pinned to an integer.

### Fix — `crates/sparq-engine/src/chunk.rs:287`
Minimal, intent-preserving: bind the expected value with an explicit `Vec<Vec<Id>>` annotation (matching the existing `Vec::<Vec<Id>>::new()` idiom two lines above), so the element type is fixed to `Id` regardless of which `PartialEq` impls are in scope.

Before:
```rust
assert_eq!(unit.to_rows(), vec![vec![], vec![], vec![]]);
```
After:
```rust
let expected: Vec<Vec<Id>> = vec![vec![], vec![], vec![]];
assert_eq!(unit.to_rows(), expected);
```

No production code changed.

## Gates

Failing combo (one of several 3+ combos): `--features vectorized,service,window-functions` (also reproduced with `vectorized,serialize-rdf,window-functions`).

- `cargo test -p sparq-engine --features vectorized,service,window-functions --lib --no-run` — was E0282/E0283, now **compiles** ✅
- `cargo test -p sparq-engine --features vectorized,service,window-functions --lib chunk::` — affected test **passes** ✅
- `cargo test -p sparq-engine --features cs-planner,zk,service,serialize-rdf,window-functions,vectorized,result-cache,txn --all-targets --no-run` (all 8 non-default features) — **compiles** ✅
- `cargo test -p sparq-engine` (default) — **green** (21 test-result lines, 0 failures) ✅
- `cargo clippy -p sparq-engine --all-targets -- -D warnings` (default) — **clean** ✅
- `cargo clippy -p sparq-engine --features vectorized,service,window-functions --all-targets -- -D warnings` — **clean** ✅

No auto-merge per the bead.