### PR TITLE
feat(site): SHACL Compact Syntax display (#796, sq-pvg2) [OPUS-4.8]

### DIFF
--- a/site/src/app/surface/shacl/page.tsx
+++ b/site/src/app/surface/shacl/page.tsx
@@ -7,7 +7,7 @@ import { ShaclPlayground } from "@/components/shacl-playground";
 export const metadata: Metadata = {
   title: "SHACL",
   description:
-    "Validate RDF against SHACL shapes with the sparq engine — SHACL Core constraints, SHACL-SPARQL, custom constraint components, and the W3C validation report, live in your tab.",
+    "Validate RDF against SHACL shapes with the sparq engine — SHACL Core constraints, SHACL-SPARQL, custom constraint components, the W3C validation report, and a SHACL Compact Syntax view, live in your tab.",
 };
 
 export default function ShaclSurfacePage() {
@@ -15,7 +15,7 @@ export default function ShaclSurfacePage() {
     <SurfaceContent
       icon={ShieldCheck}
       title="SHACL"
-      statement="Validate RDF data against shapes — SHACL Core, SHACL-SPARQL, and the W3C validation report."
+      statement="Validate RDF data against shapes — SHACL Core, SHACL-SPARQL, the W3C validation report, and a live SHACL Compact Syntax view."
       tier="live"
       intro={
         <>
@@ -64,6 +64,10 @@ export default function ShaclSurfacePage() {
           title: "Path expressions",
           body: "Property paths in shape targets and constraints, reusing the engine's path evaluator.",
         },
+        {
+          title: "SHACL Compact Syntax (display)",
+          body: "Render the shapes graph in the W3C compact notation — node/property shapes, paths, counts and value constraints — beside the W3C report.",
+        },
       ]}
       runsNote={
         <>
@@ -89,6 +93,20 @@ export default function ShaclSurfacePage() {
             validate large graphs server-side via the{" "}
             <code className="font-mono">sparq-server</code> HTTP{" "}
             <code className="font-mono">validate</code> path.
+          </p>
+          <p>
+            The <strong className="text-foreground">Compact syntax</strong> view is
+            the <em>display</em> direction only (shapes &rarr; compact). It is
+            best-effort: SHACL Compact Syntax has no form for logical constraints
+            (<code className="font-mono">sh:and</code> /{" "}
+            <code className="font-mono">sh:or</code> /{" "}
+            <code className="font-mono">sh:xone</code> /{" "}
+            <code className="font-mono">sh:not</code>) or shape references{" "}
+            (<code className="font-mono">sh:node</code>), which the view lists
+            explicitly rather than dropping. The <em>parse</em> direction (compact
+            text &rarr; shapes) is a full grammar that belongs in the{" "}
+            <code className="font-mono">sparq-shacl</code> engine and is tracked
+            separately.
           </p>
         </>
       }

--- a/site/src/components/shacl-playground.tsx
+++ b/site/src/components/shacl-playground.tsx
@@ -12,6 +12,7 @@ import {
   ShieldCheck,
   CheckCircle2,
   XCircle,
+  FileCode2,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -24,10 +25,16 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { cn } from "@/lib/utils";
+import { RdfHighlight } from "@/components/rdf-highlight";
 import {
   prewarmSparq,
+  loadSparq,
+  loadIntoStore,
+  matchQuads,
   sparqShaclValidate,
   type ShaclReport,
+  type SparqlBinding,
+  type SparqlTerm,
 } from "@/lib/sparq-wasm";
 import {
   componentName,
@@ -36,6 +43,12 @@ import {
   severityName,
   shortenIri,
 } from "@/lib/shacl-report";
+import {
+  shapesToCompact,
+  type ScsPrefix,
+  type ScsTerm,
+  type ScsTriple,
+} from "@/lib/shacl-compact";
 import { SHACL_EXAMPLES } from "@/data/shacl-examples";
 
 type RunState =
@@ -44,8 +57,49 @@ type RunState =
   | { kind: "report"; report: ShaclReport; ms: number }
   | { kind: "error"; message: string };
 
+// [OPUS-4.8] sq-pvg2 (#796) — the shapes-graph -> SHACL Compact Syntax render, kept
+// separate from the validation RunState so the compact view does not depend on a
+// validation run (it serialises the SHAPES textarea, not the data graph).
+type CompactState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "done"; text: string; unsupported: string[] }
+  | { kind: "error"; message: string };
+
 type EngineState = "cold" | "warming" | "ready" | "error";
-type View = "results" | "turtle";
+type View = "results" | "turtle" | "compact";
+
+// Turtle `@prefix p: <iri> .` OR SPARQL-style `PREFIX p: <iri>` declarations. The
+// shared `declaredPrefixBindings` only matches the SPARQL form; the SHACL Turtle
+// shapes need this @-aware pass to recover the user's prefix labels for the compact
+// output. Best-effort over the text (an unrecovered prefix only means the IRI is
+// emitted in `<…>` form, never wrong output).
+const PREFIX_RE = /(?:^|\s)(?:@?prefix|PREFIX)\s+([A-Za-z][\w.-]*)?:\s*<([^>]*)>/gi;
+
+function extractPrefixes(turtle: string): ScsPrefix[] {
+  const out: ScsPrefix[] = [];
+  const seen = new Set<string>();
+  for (const m of turtle.matchAll(PREFIX_RE)) {
+    const prefix = m[1] ?? "";
+    if (seen.has(prefix)) continue;
+    seen.add(prefix);
+    out.push({ prefix, iri: m[2] });
+  }
+  return out;
+}
+
+// Map a SPARQL-JSON term (the `{type,value,datatype,xml:lang}` shape the wasm SELECT
+// yields) to the serializer's structural `ScsTerm`.
+function toScsTerm(t: SparqlTerm): ScsTerm {
+  if (t.type === "uri") return { termType: "NamedNode", value: t.value };
+  if (t.type === "bnode") return { termType: "BlankNode", value: t.value };
+  return {
+    termType: "Literal",
+    value: t.value,
+    datatype: t.datatype,
+    language: t["xml:lang"],
+  };
+}
 
 const DEFAULT = SHACL_EXAMPLES[0];
 
@@ -53,6 +107,7 @@ export function ShaclPlayground() {
   const [data, setData] = React.useState(DEFAULT.data);
   const [shapes, setShapes] = React.useState(DEFAULT.shapes);
   const [state, setState] = React.useState<RunState>({ kind: "idle" });
+  const [compact, setCompact] = React.useState<CompactState>({ kind: "idle" });
   const [engine, setEngine] = React.useState<EngineState>("cold");
   const [activeExample, setActiveExample] = React.useState<string>(DEFAULT.id);
   const [view, setView] = React.useState<View>("results");
@@ -93,6 +148,34 @@ export function ShaclPlayground() {
     }
   }, [data, shapes]);
 
+  // [OPUS-4.8] sq-pvg2 (#796) — render the SHAPES graph in SHACL Compact Syntax.
+  // Parses the shapes Turtle with the same wasm engine, pulls every triple out via
+  // `matchQuads`, and serialises with the dependency-free `shapesToCompact`. Switches
+  // the report view to the Compact tab so the result is visible immediately.
+  const renderCompact = React.useCallback(async () => {
+    setView("compact");
+    setCompact({ kind: "running" });
+    try {
+      const Store = await loadSparq();
+      const store = loadIntoStore(Store, shapes, "turtle");
+      const rows: SparqlBinding[] = matchQuads(store);
+      const triples: ScsTriple[] = rows.flatMap((row) => {
+        const { s, p, o } = row;
+        if (!s || !p || !o) return [];
+        return [
+          { subject: toScsTerm(s), predicate: toScsTerm(p), object: toScsTerm(o) },
+        ];
+      });
+      const { text, unsupported } = shapesToCompact(triples, extractPrefixes(shapes));
+      setEngine("ready");
+      setCompact({ kind: "done", text, unsupported });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setCompact({ kind: "error", message });
+      toast.error("Could not render compact syntax", { description: message });
+    }
+  }, [shapes]);
+
   const selectExample = React.useCallback((id: string) => {
     const ex = SHACL_EXAMPLES.find((e) => e.id === id);
     if (!ex) return;
@@ -100,9 +183,11 @@ export function ShaclPlayground() {
     setShapes(ex.shapes);
     setActiveExample(id);
     setState({ kind: "idle" });
+    setCompact({ kind: "idle" });
   }, []);
 
   const busy = state.kind === "running";
+  const compactBusy = compact.kind === "running";
 
   return (
     <Card>
@@ -164,7 +249,7 @@ export function ShaclPlayground() {
         </div>
 
         <div className="flex flex-wrap items-center gap-3">
-          <Button onClick={run} disabled={busy}>
+          <Button onClick={run} disabled={busy || compactBusy}>
             {busy ? (
               <Loader2 className="size-4 animate-spin" />
             ) : (
@@ -172,20 +257,40 @@ export function ShaclPlayground() {
             )}
             Validate
           </Button>
-          {state.kind === "report" && (
-            <ViewTabs view={view} onChange={setView} />
+          <Button
+            variant="outline"
+            onClick={renderCompact}
+            disabled={busy || compactBusy}
+            title="Render the shapes graph in SHACL Compact Syntax"
+          >
+            {compactBusy ? (
+              <Loader2 className="size-4 animate-spin" />
+            ) : (
+              <FileCode2 className="size-4" />
+            )}
+            Compact syntax
+          </Button>
+          {(state.kind === "report" || compact.kind === "done") && (
+            <ViewTabs
+              view={view}
+              onChange={setView}
+              hasReport={state.kind === "report"}
+              hasCompact={compact.kind === "done"}
+            />
           )}
           <p aria-live="polite" className="text-xs text-muted-foreground">
             {state.kind === "report" &&
               `${state.report.results.length} result${state.report.results.length === 1 ? "" : "s"} · ${state.ms.toFixed(1)} ms`}
             {state.kind === "running" && "Validating on the wasm engine…"}
+            {compact.kind === "running" && "Rendering compact syntax…"}
             {state.kind === "idle" &&
+              compact.kind === "idle" &&
               engine === "warming" &&
               "Pre-warming the wasm engine…"}
           </p>
         </div>
 
-        <ResultPanel state={state} view={view} />
+        <ResultPanel state={state} compact={compact} view={view} />
       </CardContent>
     </Card>
   );
@@ -216,13 +321,24 @@ function EngineIndicator({ engine }: { engine: EngineState }) {
 function ViewTabs({
   view,
   onChange,
+  hasReport,
+  hasCompact,
 }: {
   view: View;
   onChange: (v: View) => void;
+  hasReport: boolean;
+  hasCompact: boolean;
 }) {
   const tabs: { value: View; label: string }[] = [
-    { value: "results", label: "Results" },
-    { value: "turtle", label: "W3C Turtle" },
+    ...(hasReport
+      ? ([
+          { value: "results", label: "Results" },
+          { value: "turtle", label: "W3C Turtle" },
+        ] as const)
+      : []),
+    ...(hasCompact
+      ? ([{ value: "compact", label: "Compact syntax" }] as const)
+      : []),
   ];
   return (
     <div
@@ -251,7 +367,20 @@ function ViewTabs({
   );
 }
 
-function ResultPanel({ state, view }: { state: RunState; view: View }) {
+function ResultPanel({
+  state,
+  compact,
+  view,
+}: {
+  state: RunState;
+  compact: CompactState;
+  view: View;
+}) {
+  // The Compact tab is driven by the (validation-independent) compact render.
+  if (view === "compact") {
+    return <CompactPanel compact={compact} />;
+  }
+
   if (state.kind === "error") {
     return (
       <pre className="overflow-x-auto rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
@@ -271,6 +400,61 @@ function ResultPanel({ state, view }: { state: RunState; view: View }) {
         </pre>
       ) : (
         <ResultList report={report} />
+      )}
+    </div>
+  );
+}
+
+// [OPUS-4.8] sq-pvg2 (#796) — renders the shapes-graph -> SHACL Compact Syntax output,
+// highlighted via the shared Turtle highlighter (the compact grammar's prefixes / IRIs
+// / strings / numbers / comments tokenise compatibly). Any construct the compact
+// grammar cannot carry (logical constraints, shape references) is listed explicitly
+// rather than silently dropped, so the output never looks falsely complete.
+function CompactPanel({ compact }: { compact: CompactState }) {
+  if (compact.kind === "error") {
+    return (
+      <pre className="overflow-x-auto rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive">
+        {compact.message}
+      </pre>
+    );
+  }
+  if (compact.kind !== "done") {
+    return (
+      <p className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+        Rendering…
+      </p>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      {compact.text ? (
+        <RdfHighlight
+          text={compact.text}
+          className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 text-[12.5px] leading-relaxed"
+          data-testid="scs-output"
+        />
+      ) : (
+        <p className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+          No SHACL node shapes found in the shapes graph.
+        </p>
+      )}
+      {compact.unsupported.length > 0 && (
+        <div className="space-y-1.5 rounded-lg border border-[var(--warning)]/30 bg-[color-mix(in_oklch,var(--warning)_8%,transparent)] p-3">
+          <Badge variant="warning">
+            {compact.unsupported.length} not expressible in compact syntax
+          </Badge>
+          <ul className="space-y-1 text-xs text-muted-foreground">
+            {compact.unsupported.map((u, i) => (
+              <li key={i}>{u}</li>
+            ))}
+          </ul>
+          <p className="text-xs text-muted-foreground">
+            SHACL Compact Syntax has no form for logical constraints (sh:and /
+            sh:or / sh:xone / sh:not) or shape references (sh:node), so those are
+            listed here rather than dropped — the compact output stays honest
+            about what it carries.
+          </p>
+        </div>
       )}
     </div>
   );

--- a/site/src/lib/shacl-compact.ts
+++ b/site/src/lib/shacl-compact.ts
@@ -1,0 +1,534 @@
+// [OPUS-4.8] sq-pvg2 (#796) — a dependency-free SHACL Compact Syntax (SCS) SERIALIZER.
+//
+// SCS is the W3C SHACL Community Group's compact notation for SHACL shapes
+// (https://w3c.github.io/shacl/shacl-compact-syntax/ ; carried forward as the
+// SHACL 1.2 Compact Syntax). This module renders an *already-parsed* SHACL shapes
+// graph — a flat list of triples — into the compact text. It is the DISPLAY
+// direction only: shapes graph (Turtle / RDF, parsed by the wasm engine) -> SCS.
+//
+// The PARSE direction (SCS text -> shapes triples) is a from-scratch grammar
+// (ANTLR `SHACLC.g4`, ~117 rules with path expressions + prefix scoping) and is
+// the engine's job — tracked separately as a sparq-shacl bead (#796 parse slice),
+// NOT done here. Forcing a half-working hand-rolled parser into the site would be
+// dishonest; a clean serializer is the bounded, high-value slice.
+//
+// Scope honesty: this serializer covers the SHACL Core constructs the compact
+// grammar expresses — node shapes, `sh:targetClass`/`sh:targetNode`/
+// `sh:targetObjectsOf`/`sh:targetSubjectsOf`, property shapes over IRI / inverse /
+// sequence / alternative / `?*+` paths, min/max count, the node-kind/value-range/
+// string/in/hasValue/class/datatype constraints in the grammar, and `closed`. A
+// shape (or constraint) the compact grammar cannot express is NOT silently dropped:
+// it is reported back to the caller so the UI can show "N constructs not
+// expressible in compact syntax" rather than emit a lossy file that looks complete.
+//
+// Framework-free + side-effect-free (no React, no DOM, no wasm) so it unit-tests
+// directly under `node --test` against hand-built triples.
+
+const SH = "http://www.w3.org/ns/shacl#";
+const RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+const RDFS = "http://www.w3.org/2000/01/rdf-schema#";
+const XSD = "http://www.w3.org/2001/XMLSchema#";
+
+const RDF_FIRST = `${RDF}first`;
+const RDF_REST = `${RDF}rest`;
+const RDF_NIL = `${RDF}nil`;
+const RDF_TYPE = `${RDF}type`;
+
+/** A simple RDF term, matching the shape the wasm SELECT JSON yields. */
+export type ScsTerm =
+  | { termType: "NamedNode"; value: string }
+  | { termType: "BlankNode"; value: string }
+  | {
+      termType: "Literal";
+      value: string;
+      datatype?: string;
+      language?: string;
+    };
+
+/** A flat triple of the shapes graph. */
+export interface ScsTriple {
+  subject: ScsTerm;
+  predicate: ScsTerm;
+  object: ScsTerm;
+}
+
+/** A `PREFIX p: <iri>` binding. */
+export interface ScsPrefix {
+  prefix: string;
+  iri: string;
+}
+
+export interface ScsResult {
+  /** The serialized SHACL Compact Syntax document. */
+  text: string;
+  /**
+   * Human-readable notes about shapes/constraints that the compact grammar cannot
+   * express and were therefore OMITTED from `text` (kept honest — never silently
+   * dropped). Empty when the round-trip is lossless for the input.
+   */
+  unsupported: string[];
+}
+
+// The default prefixes the SCS spec treats as implicit-but-conventional. We always
+// emit any prefix that is actually USED, so these are only a naming fallback.
+const WELL_KNOWN_PREFIXES: ScsPrefix[] = [
+  { prefix: "sh", iri: SH },
+  { prefix: "rdf", iri: RDF },
+  { prefix: "rdfs", iri: RDFS },
+  { prefix: "xsd", iri: XSD },
+];
+
+// ---------------------------------------------------------------------------
+// Small triple-store view over the flat triple list.
+// ---------------------------------------------------------------------------
+
+function termKey(t: ScsTerm): string {
+  if (t.termType === "Literal") {
+    return `L:${t.value} ${t.datatype ?? ""} ${t.language ?? ""}`;
+  }
+  return `${t.termType === "BlankNode" ? "B" : "N"}:${t.value}`;
+}
+
+class Graph {
+  private bySubject = new Map<string, ScsTriple[]>();
+
+  constructor(triples: ScsTriple[]) {
+    for (const t of triples) {
+      const k = termKey(t.subject);
+      const arr = this.bySubject.get(k);
+      if (arr) arr.push(t);
+      else this.bySubject.set(k, [t]);
+    }
+  }
+
+  out(subject: ScsTerm): ScsTriple[] {
+    return this.bySubject.get(termKey(subject)) ?? [];
+  }
+
+  objects(subject: ScsTerm, predicateIri: string): ScsTerm[] {
+    return this.out(subject)
+      .filter(
+        (t) => t.predicate.termType === "NamedNode" && t.predicate.value === predicateIri,
+      )
+      .map((t) => t.object);
+  }
+
+  one(subject: ScsTerm, predicateIri: string): ScsTerm | undefined {
+    return this.objects(subject, predicateIri)[0];
+  }
+
+  /** Reads an RDF list (`rdf:first`/`rdf:rest`) into a term array; [] if not a list. */
+  list(head: ScsTerm): ScsTerm[] {
+    const out: ScsTerm[] = [];
+    let node: ScsTerm | undefined = head;
+    const seen = new Set<string>();
+    while (node && !(node.termType === "NamedNode" && node.value === RDF_NIL)) {
+      const key = termKey(node);
+      if (seen.has(key)) break; // cycle guard
+      seen.add(key);
+      const first = this.one(node, RDF_FIRST);
+      if (!first) break;
+      out.push(first);
+      node = this.one(node, RDF_REST);
+    }
+    return out;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Prefix handling.
+// ---------------------------------------------------------------------------
+
+class Prefixer {
+  // longest-iri-first so a longer namespace wins over a shorter overlapping one.
+  private entries: { prefix: string; iri: string }[];
+  used = new Set<string>();
+
+  constructor(prefixes: ScsPrefix[]) {
+    const merged = new Map<string, string>();
+    for (const p of [...WELL_KNOWN_PREFIXES, ...prefixes]) {
+      // caller-supplied prefixes override the well-known fallback
+      merged.set(p.prefix, p.iri);
+    }
+    this.entries = [...merged.entries()]
+      .map(([prefix, iri]) => ({ prefix, iri }))
+      .sort((a, b) => b.iri.length - a.iri.length);
+  }
+
+  /** Render an IRI as a prefixed name if possible, else `<full>`. */
+  iri(value: string): string {
+    for (const { prefix, iri } of this.entries) {
+      if (value.startsWith(iri)) {
+        const local = value.slice(iri.length);
+        // Only use a prefixed name when the local part is a legal PN_LOCAL-ish token
+        // (no spaces / no chars that would need escaping). Otherwise fall back to <>.
+        if (/^[A-Za-z0-9_][A-Za-z0-9_.\-]*$/.test(local) || local === "") {
+          this.used.add(prefix);
+          return `${prefix}:${local}`;
+        }
+      }
+    }
+    return `<${value}>`;
+  }
+
+  prefixLines(): string[] {
+    const lines: string[] = [];
+    for (const { prefix, iri } of [...this.entries].sort((a, b) =>
+      a.prefix.localeCompare(b.prefix),
+    )) {
+      if (this.used.has(prefix)) lines.push(`PREFIX ${prefix}: <${iri}>`);
+    }
+    return lines;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Term -> SCS text.
+// ---------------------------------------------------------------------------
+
+function escapeString(s: string): string {
+  return s
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+}
+
+function termToScs(t: ScsTerm, p: Prefixer): string {
+  if (t.termType === "NamedNode") return p.iri(t.value);
+  if (t.termType === "BlankNode") return `_:${t.value}`;
+  // Literal
+  if (t.language) return `"${escapeString(t.value)}"@${t.language}`;
+  const dt = t.datatype;
+  if (!dt || dt === `${XSD}string`) {
+    return `"${escapeString(t.value)}"`;
+  }
+  // numeric / boolean literals render bare per the grammar (numericLiteral/booleanLiteral)
+  if (dt === `${XSD}integer` && /^[+-]?\d+$/.test(t.value)) return t.value;
+  if (dt === `${XSD}decimal` && /^[+-]?\d*\.\d+$/.test(t.value)) return t.value;
+  if (dt === `${XSD}boolean` && (t.value === "true" || t.value === "false")) return t.value;
+  if (
+    dt === `${XSD}double` &&
+    /^[+-]?(\d+\.\d*[eE][+-]?\d+|\.?\d+[eE][+-]?\d+)$/.test(t.value)
+  ) {
+    return t.value;
+  }
+  return `"${escapeString(t.value)}"^^${p.iri(dt)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Path -> SCS path expression.
+// ---------------------------------------------------------------------------
+
+// Returns the compact path string, or undefined if the path uses a construct the
+// compact grammar cannot express.
+function pathToScs(node: ScsTerm, g: Graph, p: Prefixer): string | undefined {
+  if (node.termType === "NamedNode") return p.iri(node.value);
+  // Blank-node path: inspect its single structural predicate.
+  const inverse = g.one(node, `${SH}inversePath`);
+  if (inverse) {
+    const inner = pathToScs(inverse, g, p);
+    return inner === undefined ? undefined : `^${atomize(inner)}`;
+  }
+  const alt = g.one(node, `${SH}alternativePath`);
+  if (alt) {
+    const members = g.list(alt).map((m) => pathToScs(m, g, p));
+    if (members.some((m) => m === undefined)) return undefined;
+    return members.map((m) => atomize(m as string)).join(" | ");
+  }
+  const zeroOrMore = g.one(node, `${SH}zeroOrMorePath`);
+  if (zeroOrMore) {
+    const inner = pathToScs(zeroOrMore, g, p);
+    return inner === undefined ? undefined : `${atomize(inner)}*`;
+  }
+  const oneOrMore = g.one(node, `${SH}oneOrMorePath`);
+  if (oneOrMore) {
+    const inner = pathToScs(oneOrMore, g, p);
+    return inner === undefined ? undefined : `${atomize(inner)}+`;
+  }
+  const zeroOrOne = g.one(node, `${SH}zeroOrOnePath`);
+  if (zeroOrOne) {
+    const inner = pathToScs(zeroOrOne, g, p);
+    return inner === undefined ? undefined : `${atomize(inner)}?`;
+  }
+  // Otherwise the blank node is the head of an RDF list = a sequence path.
+  const seq = g.list(node);
+  if (seq.length > 0) {
+    const members = seq.map((m) => pathToScs(m, g, p));
+    if (members.some((m) => m === undefined)) return undefined;
+    return members.map((m) => atomize(m as string)).join(" / ");
+  }
+  return undefined;
+}
+
+// Wrap a compound path in parens when it must bind as a primary inside a combinator.
+function atomize(path: string): string {
+  return /[ |/^*+?]/.test(path) ? `(${path})` : path;
+}
+
+// ---------------------------------------------------------------------------
+// Constraint serialization.
+// ---------------------------------------------------------------------------
+
+// sh:* predicate -> compact `param` keyword for value constraints emitted as
+// `param=value`. (Counts, paths, targets and node-kind handled separately.)
+const VALUE_PARAMS: { iri: string; keyword: string; list?: boolean }[] = [
+  { iri: `${SH}class`, keyword: "class" },
+  { iri: `${SH}datatype`, keyword: "datatype" },
+  { iri: `${SH}minExclusive`, keyword: "minExclusive" },
+  { iri: `${SH}minInclusive`, keyword: "minInclusive" },
+  { iri: `${SH}maxExclusive`, keyword: "maxExclusive" },
+  { iri: `${SH}maxInclusive`, keyword: "maxInclusive" },
+  { iri: `${SH}minLength`, keyword: "minLength" },
+  { iri: `${SH}maxLength`, keyword: "maxLength" },
+  { iri: `${SH}pattern`, keyword: "pattern" },
+  { iri: `${SH}flags`, keyword: "flags" },
+  { iri: `${SH}languageIn`, keyword: "languageIn", list: true },
+  { iri: `${SH}uniqueLang`, keyword: "uniqueLang" },
+  { iri: `${SH}equals`, keyword: "equals" },
+  { iri: `${SH}disjoint`, keyword: "disjoint" },
+  { iri: `${SH}lessThan`, keyword: "lessThan" },
+  { iri: `${SH}lessThanOrEquals`, keyword: "lessThanOrEquals" },
+  { iri: `${SH}hasValue`, keyword: "hasValue" },
+  { iri: `${SH}in`, keyword: "in", list: true },
+  { iri: `${SH}severity`, keyword: "severity" },
+  { iri: `${SH}deactivated`, keyword: "deactivated" },
+  { iri: `${SH}message`, keyword: "message" },
+  { iri: `${SH}qualifiedMinCount`, keyword: "qualifiedMinCount" },
+  { iri: `${SH}qualifiedMaxCount`, keyword: "qualifiedMaxCount" },
+];
+
+const NODE_KIND_LOCAL: Record<string, string> = {
+  [`${SH}BlankNode`]: "BlankNode",
+  [`${SH}IRI`]: "IRI",
+  [`${SH}Literal`]: "Literal",
+  [`${SH}BlankNodeOrIRI`]: "BlankNodeOrIRI",
+  [`${SH}BlankNodeOrLiteral`]: "BlankNodeOrLiteral",
+  [`${SH}IRIOrLiteral`]: "IRIOrLiteral",
+};
+
+function valueOrArray(terms: ScsTerm[], g: Graph, p: Prefixer): string {
+  // an `in` / `languageIn` value is the head of an RDF list -> `[ a b c ]`.
+  const members = g.list(terms[0]).map((m) => termToScs(m, p));
+  return `[ ${members.join(" ")} ]`;
+}
+
+// Emit the constraint lines of a shape (each terminated with " ."). On a property
+// shape body these are reduced to inline params by stripping the trailing " .".
+function shapeConstraints(
+  shape: ScsTerm,
+  g: Graph,
+  p: Prefixer,
+  unsupported: string[],
+  shapeLabel: string,
+): string[] {
+  const lines: string[] = [];
+
+  // node kind
+  const nk = g.one(shape, `${SH}nodeKind`);
+  if (nk && nk.termType === "NamedNode" && NODE_KIND_LOCAL[nk.value]) {
+    lines.push(`${NODE_KIND_LOCAL[nk.value]} .`);
+  }
+
+  // closed shapes: `closed=true` with optional ignoredProperties.
+  const closed = g.one(shape, `${SH}closed`);
+  if (closed) {
+    let line = `closed=${termToScs(closed, p)}`;
+    const ignored = g.one(shape, `${SH}ignoredProperties`);
+    if (ignored) {
+      const props = g.list(ignored).map((m) => termToScs(m, p));
+      line += ` ignoredProperties=[ ${props.join(" ")} ]`;
+    }
+    lines.push(`${line} .`);
+  }
+
+  // value/string/range/in/hasValue/class/datatype params -> `param=value .`
+  for (const { iri, keyword, list } of VALUE_PARAMS) {
+    const objs = g.objects(shape, iri);
+    if (objs.length === 0) continue;
+    if (list) {
+      lines.push(`${keyword}=${valueOrArray(objs, g, p)} .`);
+    } else {
+      for (const o of objs) {
+        lines.push(`${keyword}=${termToScs(o, p)} .`);
+      }
+    }
+  }
+
+  // Logical / shape-reference constraints the grammar cannot express compactly.
+  for (const unsup of [
+    `${SH}and`,
+    `${SH}or`,
+    `${SH}xone`,
+    `${SH}not`,
+    `${SH}node`,
+    `${SH}qualifiedValueShape`,
+  ]) {
+    if (g.objects(shape, unsup).length > 0) {
+      const local = unsup.slice(SH.length);
+      unsupported.push(
+        `${shapeLabel}: sh:${local} has no SHACL Compact Syntax form — omitted.`,
+      );
+    }
+  }
+
+  return lines;
+}
+
+// ---------------------------------------------------------------------------
+// Top-level shape serialization.
+// ---------------------------------------------------------------------------
+
+function isPropertyShape(shape: ScsTerm, g: Graph): boolean {
+  return g.objects(shape, `${SH}path`).length > 0;
+}
+
+function serializeProperty(
+  prop: ScsTerm,
+  g: Graph,
+  p: Prefixer,
+  unsupported: string[],
+  shapeLabel: string,
+): string | undefined {
+  const pathTerm = g.one(prop, `${SH}path`);
+  if (!pathTerm) return undefined;
+  const path = pathToScs(pathTerm, g, p);
+  if (path === undefined) {
+    unsupported.push(
+      `${shapeLabel}: a property path is not expressible in compact syntax — omitted.`,
+    );
+    return undefined;
+  }
+
+  const parts: string[] = [path];
+
+  // count: `[min..max]` (only when at least one is set).
+  const minTerm = g.one(prop, `${SH}minCount`);
+  const maxTerm = g.one(prop, `${SH}maxCount`);
+  if (minTerm || maxTerm) {
+    const min = minTerm ? minTerm.value : "0";
+    const max = maxTerm ? maxTerm.value : "*";
+    parts.push(`[${min}..${max}]`);
+  }
+
+  // the remaining param constraints (datatype, class, nodeKind, value ranges, ...)
+  const body = shapeConstraints(prop, g, p, unsupported, shapeLabel);
+  for (const line of body) {
+    parts.push(line.replace(/ \.$/, ""));
+  }
+
+  return `\t${parts.join(" ")} .`;
+}
+
+function serializeNodeShape(
+  shape: ScsTerm,
+  g: Graph,
+  p: Prefixer,
+  unsupported: string[],
+): string {
+  const label =
+    shape.termType === "NamedNode" ? p.iri(shape.value) : `_:${shape.value}`;
+  const shapeLabel = `shape ${label}`;
+
+  // targets: `-> class1 class2` for sh:targetClass; sh:targetNode/objectsOf/subjectsOf
+  // are emitted as params.
+  const targetClasses = g.objects(shape, `${SH}targetClass`);
+  let header = `shape ${label}`;
+  if (targetClasses.length > 0) {
+    header += ` -> ${targetClasses.map((t) => termToScs(t, p)).join(" ")}`;
+  }
+
+  const bodyLines: string[] = [];
+
+  // non-targetClass targets as params
+  for (const [iri, kw] of [
+    [`${SH}targetNode`, "targetNode"],
+    [`${SH}targetObjectsOf`, "targetObjectsOf"],
+    [`${SH}targetSubjectsOf`, "targetSubjectsOf"],
+  ] as const) {
+    for (const o of g.objects(shape, iri)) {
+      bodyLines.push(`\t${kw}=${termToScs(o, p)} .`);
+    }
+  }
+
+  // node-level constraints on the shape itself
+  for (const line of shapeConstraints(shape, g, p, unsupported, shapeLabel)) {
+    bodyLines.push(`\t${line}`);
+  }
+
+  // property shapes attached via sh:property
+  for (const propRef of g.objects(shape, `${SH}property`)) {
+    const line = serializeProperty(propRef, g, p, unsupported, shapeLabel);
+    if (line) bodyLines.push(line);
+  }
+
+  if (bodyLines.length === 0) return `${header} {\n}`;
+  return `${header} {\n${bodyLines.join("\n")}\n}`;
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point.
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a SHACL shapes graph (a flat triple list) to SHACL Compact Syntax.
+ *
+ * Honest + lossless-or-reported: any shape or constraint the compact grammar can
+ * not express is recorded in `result.unsupported` rather than dropped silently.
+ */
+export function shapesToCompact(
+  triples: ScsTriple[],
+  prefixes: ScsPrefix[] = [],
+): ScsResult {
+  const g = new Graph(triples);
+  const p = new Prefixer(prefixes);
+  const unsupported: string[] = [];
+
+  // collect the distinct subjects in document order.
+  const subjectKeys = new Set<string>();
+  const subjects: ScsTerm[] = [];
+  for (const t of triples) {
+    const k = termKey(t.subject);
+    if (!subjectKeys.has(k)) {
+      subjectKeys.add(k);
+      subjects.push(t.subject);
+    }
+  }
+
+  const shapeBlocks: string[] = [];
+  for (const s of subjects) {
+    if (s.termType !== "NamedNode") continue; // only named shapes at top level
+    if (isPropertyShape(s, g)) continue; // a bare property shape is not a node-shape block
+
+    const types = g.objects(s, RDF_TYPE).map((t) => t.value);
+    const isNodeShape = types.includes(`${SH}NodeShape`);
+    const hasShapeStuff =
+      g.objects(s, `${SH}targetClass`).length > 0 ||
+      g.objects(s, `${SH}targetNode`).length > 0 ||
+      g.objects(s, `${SH}targetObjectsOf`).length > 0 ||
+      g.objects(s, `${SH}targetSubjectsOf`).length > 0 ||
+      g.objects(s, `${SH}property`).length > 0 ||
+      g.objects(s, `${SH}closed`).length > 0 ||
+      g.objects(s, `${SH}nodeKind`).length > 0;
+
+    if (!isNodeShape && !hasShapeStuff) continue;
+    shapeBlocks.push(serializeNodeShape(s, g, p, unsupported));
+  }
+
+  const prefixLines = p.prefixLines();
+  const parts: string[] = [];
+  if (prefixLines.length > 0) parts.push(prefixLines.join("\n"));
+  if (shapeBlocks.length > 0) parts.push(shapeBlocks.join("\n\n"));
+
+  // de-dup unsupported notes while preserving order
+  const seen = new Set<string>();
+  const uniqueUnsupported = unsupported.filter((u) =>
+    seen.has(u) ? false : (seen.add(u), true),
+  );
+
+  return {
+    text: parts.join("\n\n") + (parts.length ? "\n" : ""),
+    unsupported: uniqueUnsupported,
+  };
+}

--- a/site/test/shacl-compact.test.mjs
+++ b/site/test/shacl-compact.test.mjs
@@ -1,0 +1,111 @@
+// [OPUS-4.8] sq-pvg2 (#796) — unit tests for the SHACL Compact Syntax (SCS) serializer
+// (src/lib/shacl-compact.ts). These cover the pure, framework-free shapes-graph -> SCS
+// rendering against hand-built triples (no React, no wasm): golden output for a node +
+// property shape, path expression rendering, the bare-literal numeric/boolean rules,
+// prefix emission, and the HONEST "not expressible in compact syntax" reporting for
+// logical constraints (sh:or). Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { shapesToCompact } from "../src/lib/shacl-compact.ts";
+
+const SH = "http://www.w3.org/ns/shacl#";
+const RDF = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+const XSD = "http://www.w3.org/2001/XMLSchema#";
+const EX = "http://example.org/";
+
+const iri = (v) => ({ termType: "NamedNode", value: v });
+const bnode = (v) => ({ termType: "BlankNode", value: v });
+const lit = (value, datatype) => ({ termType: "Literal", value, datatype });
+const t = (s, p, o) => ({ subject: s, predicate: p, object: o });
+
+const PREFIXES = [{ prefix: "ex", iri: EX }];
+
+test("renders a node shape with targetClass and a property shape with count + datatype", () => {
+  // ex:PersonShape -> ex:Person { ex:name [1..1] xsd:string . }
+  const triples = [
+    t(iri(`${EX}PersonShape`), iri(`${RDF}type`), iri(`${SH}NodeShape`)),
+    t(iri(`${EX}PersonShape`), iri(`${SH}targetClass`), iri(`${EX}Person`)),
+    t(iri(`${EX}PersonShape`), iri(`${SH}property`), bnode("p1")),
+    t(bnode("p1"), iri(`${SH}path`), iri(`${EX}name`)),
+    t(bnode("p1"), iri(`${SH}minCount`), lit("1", `${XSD}integer`)),
+    t(bnode("p1"), iri(`${SH}maxCount`), lit("1", `${XSD}integer`)),
+    t(bnode("p1"), iri(`${SH}datatype`), iri(`${XSD}string`)),
+  ];
+
+  const { text, unsupported } = shapesToCompact(triples, PREFIXES);
+
+  assert.equal(unsupported.length, 0, "fully expressible in SCS");
+  // prefix block emitted for the prefixes actually used
+  assert.match(text, /^PREFIX ex: <http:\/\/example\.org\/>$/m);
+  assert.match(text, /^PREFIX xsd: <http:\/\/www\.w3\.org\/2001\/XMLSchema#>$/m);
+  // node-shape header with target arrow
+  assert.match(text, /shape ex:PersonShape -> ex:Person \{/);
+  // property line: path, count, datatype as inline param, terminated by " ."
+  assert.match(text, /ex:name \[1\.\.1\] datatype=xsd:string \./);
+});
+
+test("renders inverse / sequence / alternative / star path expressions", () => {
+  const seqHead = bnode("seqHead");
+  const triples = [
+    t(iri(`${EX}S`), iri(`${RDF}type`), iri(`${SH}NodeShape`)),
+    // inverse path: ^ex:parent
+    t(iri(`${EX}S`), iri(`${SH}property`), bnode("inv")),
+    t(bnode("inv"), iri(`${SH}path`), bnode("invNode")),
+    t(bnode("invNode"), iri(`${SH}inversePath`), iri(`${EX}parent`)),
+    t(bnode("inv"), iri(`${SH}minCount`), lit("0", `${XSD}integer`)),
+    // sequence path: ex:a / ex:b
+    t(iri(`${EX}S`), iri(`${SH}property`), bnode("seq")),
+    t(bnode("seq"), iri(`${SH}path`), seqHead),
+    t(seqHead, iri(`${RDF}first`), iri(`${EX}a`)),
+    t(seqHead, iri(`${RDF}rest`), bnode("seq2")),
+    t(bnode("seq2"), iri(`${RDF}first`), iri(`${EX}b`)),
+    t(bnode("seq2"), iri(`${RDF}rest`), iri(`${RDF}nil`)),
+  ];
+
+  const { text } = shapesToCompact(triples, PREFIXES);
+  assert.match(text, /\^ex:parent \[0\.\.\*\]/);
+  assert.match(text, /ex:a \/ ex:b/);
+});
+
+test("numeric/boolean literals render bare; closed=true is emitted", () => {
+  const triples = [
+    t(iri(`${EX}S`), iri(`${RDF}type`), iri(`${SH}NodeShape`)),
+    t(iri(`${EX}S`), iri(`${SH}closed`), lit("true", `${XSD}boolean`)),
+    t(iri(`${EX}S`), iri(`${SH}property`), bnode("age")),
+    t(bnode("age"), iri(`${SH}path`), iri(`${EX}age`)),
+    t(bnode("age"), iri(`${SH}minInclusive`), lit("0", `${XSD}integer`)),
+  ];
+  const { text } = shapesToCompact(triples, PREFIXES);
+  assert.match(text, /closed=true \./);
+  assert.match(text, /minInclusive=0/);
+  // a bare integer, NOT a quoted/typed literal
+  assert.doesNotMatch(text, /minInclusive="0"/);
+});
+
+test("logical constraints (sh:or) are reported as unsupported, never silently dropped", () => {
+  const triples = [
+    t(iri(`${EX}S`), iri(`${RDF}type`), iri(`${SH}NodeShape`)),
+    t(iri(`${EX}S`), iri(`${SH}targetClass`), iri(`${EX}Thing`)),
+    t(iri(`${EX}S`), iri(`${SH}or`), bnode("orlist")),
+  ];
+  const { unsupported } = shapesToCompact(triples, PREFIXES);
+  assert.equal(unsupported.length, 1);
+  assert.match(unsupported[0], /sh:or/);
+  assert.match(unsupported[0], /compact syntax/i);
+});
+
+test("an empty / non-shape graph yields empty SCS, no crash", () => {
+  const { text, unsupported } = shapesToCompact([], PREFIXES);
+  assert.equal(text, "");
+  assert.equal(unsupported.length, 0);
+});
+
+test("a full IRI is emitted in <> when no prefix covers it", () => {
+  const triples = [
+    t(iri("urn:shape:1"), iri(`${RDF}type`), iri(`${SH}NodeShape`)),
+    t(iri("urn:shape:1"), iri(`${SH}targetClass`), iri("urn:class:Foo")),
+  ];
+  const { text } = shapesToCompact(triples, PREFIXES);
+  assert.match(text, /shape <urn:shape:1> -> <urn:class:Foo> \{/);
+});


### PR DESCRIPTION
> 🤖 SPARQ agent — site lane. Bead sq-pvg2, GitHub issue #796.

## Assessment outcome
SHACL Compact Syntax (SCS) had **no** existing support to build on:
- `crates/sparq-shacl/src` has **no** SCS parser/serializer (the only "compact" hits are W3C spec HTML + the `SHACLC.g4` grammar vendored under `tests/`).
- The wasm surface (`validate(data, shapes, format)`) only accepts RDF (Turtle/N-Triples/N-Quads/TriG).
- The site had zero SCS exposure; the live `/surface/shacl` playground took shapes as Turtle only.

A full SCS **parser** (text → shapes) is a from-scratch ~117-rule grammar — engine work, not a client-side hand-roll. A shapes-graph → SCS **serializer** is bounded and tractable purely client-side. So this PR ships the **display direction** and defers the parse direction to a `sparq-shacl` bead.

## What I implemented (display direction)
- **`site/src/lib/shacl-compact.ts`** — dependency-free `shapesToCompact(triples, prefixes)` serializer over a flat triple model. Covers the SHACL Core constructs the compact grammar expresses: node shapes, `sh:targetClass` (`-> …`) + `targetNode`/`targetObjectsOf`/`targetSubjectsOf` params, property shapes over IRI / inverse (`^`) / sequence (`/`) / alternative (`|`) / `?*+` paths, `[min..max]` counts, nodeKind keywords, `closed` + `ignoredProperties`, and the value/string/range/`in`/`hasValue`/`class`/`datatype` params. Numeric/boolean literals render bare per the grammar.
- **`site/src/components/shacl-playground.tsx`** — adds a **"Compact syntax"** action + view tab to the existing live playground. The shapes Turtle is parsed by the real wasm engine, every triple pulled out via `matchQuads`, and serialized; the result is highlighted via the shared `@sparq/client` Turtle tokenizer (`RdfHighlight`).
- **`site/src/app/surface/shacl/page.tsx`** — capability + caveat copy for the compact view.

### Honesty
The compact grammar cannot carry logical constraints (`sh:and`/`or`/`xone`/`not`), shape references (`sh:node`) or qualified value shapes. Those are **listed in the UI** (and returned in `result.unsupported`) rather than silently dropped, so the output never looks falsely complete. The caveat copy states the view is display-only and that the parse direction is engine-side + tracked separately.

### Client-side vs engine scope
- Display (shapes → SCS): **done, fully client-side** — parsing is the engine's existing Turtle loader; serialization is pure TS.
- Parse (SCS text → shapes): **deferred to bead `sq-v0b8`** (`sparq-shacl` grammar + wasm binding; round-trip test against the vendored W3C `shacl12-cs` fixtures).

## Tests / gates
- `cd js && npm run build:wasm` (shacl,jsonld) — WASM prereq built (it is not checked into the worktree).
- `cd site && npm run build` — **static export green**; `/surface/shacl/index.html` emitted with `/sparq` basePath assets + `out/wasm/` present.
- `npm run lint` — clean. `npx tsc --noEmit` — clean.
- `npm run test:unit` — **205/205** (6 new golden-output cases in `test/shacl-compact.test.mjs`).
- No new npm dependency (reuses existing UI + highlight infra). Bundle: `/surface/shacl` First Load ~213 kB.

## Deferred
- `sq-v0b8` — `[#796] SHACL Compact Syntax PARSER (text→shapes) in sparq-shacl + wasm surface`.