### PR TITLE
feat(bench): strictly-additive --json emit for the 6 remaining bench/serve spikes (sq-5vm.1) [OPUS-4.8]

### DIFF
--- a/bench/serve/Cargo.toml
+++ b/bench/serve/Cargo.toml
@@ -26,10 +26,11 @@ sparq-serve = { path = "../../crates/sparq-serve" }
 spargebra = { version = "0.4", features = ["sparql-12", "sep-0006"] }
 mimalloc = "0.1"
 
-# [OPUS-4.8] (sq-k5qq) TEST-only: writer_spike emits an optional, strictly-additive
-# `--json <path>` results document (dependency-free `format!`-built JSON — no serde in the
-# harness itself); this dev-dep parses that emit back so the round-trip test catches a
-# malformed document.
+# [OPUS-4.8] (sq-k5qq / sq-5vm.1) TEST-only: every spike (writer_spike, plus snapshot_spike,
+# cache_spike, stream_spike, point_spike, update_stream_spike, pss_update_throughput) emits an
+# optional, strictly-additive `--json <path>` results document (dependency-free `format!`-built
+# JSON — no serde in the harness itself); this dev-dep parses that emit back so the per-binary
+# round-trip test catches a malformed document.
 [dev-dependencies]
 serde_json = "1"
 

--- a/bench/serve/src/bin/cache_spike.rs
+++ b/bench/serve/src/bin/cache_spike.rs
@@ -14,6 +14,16 @@
 //!
 //! No HTTP here on purpose: the loadgen baseline tells us what the HTTP layer costs;
 //! this isolates the cache data structure itself.
+//!
+//! Run: `cargo run --release --bin cache_spike [threads]` in bench/serve.
+//!   cargo run --release --bin cache_spike -- [threads] --json /tmp/cache.json  # strictly-additive
+//!
+//! [OPUS-4.8] (sq-5vm.1) `--json <path>` writes the SAME parse / cache-hit / miss / insert
+//! figures STDOUT prints as a stable, DEPENDENCY-FREE JSON document, mirroring writer_spike's
+//! emit (sq-k5qq). No serde dep is added to the harness (serde_json is a TEST-only dev-dep that
+//! parses the emit back). STDOUT is byte-for-byte unchanged whether or not the flag is present;
+//! every number is best-effort, MEASURED on the running host — ADVISORY + NON-CANONICAL (stated
+//! in the emitted `note`) — nothing is committed.
 
 use std::collections::HashMap;
 use std::hash::{Hash, Hasher};
@@ -34,8 +44,119 @@ type ResponseCache = HashMap<String, Arc<Vec<u8>>>;
 /// `--all-targets -D warnings` (this standalone spike workspace is not gated by root CI).
 type ShardedCache = Arc<Vec<RwLock<ResponseCache>>>;
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// One multi-thread `bench_threads` row: the lock-strategy label + its aggregate
+/// throughput and per-thread ns/op.
+struct ThreadsRow {
+    label: String,
+    threads: usize,
+    total_m_ops_per_s: f64,
+    ns_per_op_per_thread: f64,
+}
+
+/// All scalar figures this spike prints (the multi-thread rows live in their own Vec).
+#[derive(Default)]
+struct Results {
+    threads: usize,
+    parse_us_per_op: f64,
+    parse_query_chars: usize,
+    hit_1t_m_ops_per_s: f64,
+    hit_1t_ns_per_op: f64,
+    miss_1t_ns_per_op: f64,
+    insert_ns_per_op: f64,
+}
+
+/// Extracts `--json <path>` from argv, returning argv WITHOUT the flag pair. A bare
+/// `--json` is a usage error (exit 2), mirroring `sparq-cli` / `writer_spike`'s flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Minimal JSON string escaper (the dependency-free emit). Strategy labels are static
+/// ASCII, so this covers the realistic input; anything else still yields valid `\uXXXX`.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Serialise the run to stable, dependency-free JSON. Every metric is ADVISORY +
+/// NON-CANONICAL (stated in `note`).
+fn results_json(r: &Results, multi: &[ThreadsRow]) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"serve-spikes cache_spike\",\n");
+    s.push_str(
+        "  \"note\": \"result-cache hit-path ceiling (no HTTP); every parse-µs, M-ops/s, ns/op \
+         figure is best-effort, MEASURED on the running host — ADVISORY, NON-CANONICAL (this dev \
+         box) — do not bake into committed files\",\n",
+    );
+    s.push_str(&format!("  \"threads\": {},\n", r.threads));
+    s.push_str(&format!("  \"parse_us_per_op\": {:.3},\n", r.parse_us_per_op));
+    s.push_str(&format!("  \"parse_query_chars\": {},\n", r.parse_query_chars));
+    s.push_str(&format!("  \"hit_1t_m_ops_per_s\": {:.3},\n", r.hit_1t_m_ops_per_s));
+    s.push_str(&format!("  \"hit_1t_ns_per_op\": {:.1},\n", r.hit_1t_ns_per_op));
+    s.push_str(&format!("  \"miss_1t_ns_per_op\": {:.1},\n", r.miss_1t_ns_per_op));
+    s.push_str(&format!("  \"insert_ns_per_op\": {:.1},\n", r.insert_ns_per_op));
+    s.push_str("  \"multi_thread_hit\": [\n");
+    for (i, row) in multi.iter().enumerate() {
+        let comma = if i + 1 < multi.len() { "," } else { "" };
+        s.push_str(&format!(
+            "    {{ \"label\": {}, \"threads\": {}, \"total_m_ops_per_s\": {:.3}, \
+             \"ns_per_op_per_thread\": {:.1} }}{comma}\n",
+            json_str(&row.label),
+            row.threads,
+            row.total_m_ops_per_s,
+            row.ns_per_op_per_thread,
+        ));
+    }
+    s.push_str("  ]\n");
+    s.push_str("}\n");
+    s
+}
+
 fn main() {
-    let threads: usize = std::env::args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(8);
+    // Strictly-additive: pull `--json <path>` out before reading the optional thread count,
+    // so the positional `[threads]` argument is unaffected when the flag is absent.
+    let (args, json_path) = take_json_flag(std::env::args().collect());
+    let threads: usize = args.into_iter().nth(1).and_then(|s| s.parse().ok()).unwrap_or(8);
+    let mut res = Results { threads, ..Results::default() };
+    let mut multi: Vec<ThreadsRow> = Vec::new();
 
     // --- parse cost calibration -------------------------------------------------
     let q = "PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT ?n WHERE { <http://example.org/person/123> foaf:name ?n }";
@@ -46,6 +167,8 @@ fn main() {
         std::hint::black_box(&p);
     }
     let per = t.elapsed().as_nanos() as f64 / iters as f64;
+    res.parse_query_chars = q.len();
+    res.parse_us_per_op = per / 1000.0;
     println!("spargebra parse (point query, {} chars): {:.2} us/parse", q.len(), per / 1000.0);
 
     // --- build the cache ----------------------------------------------------------
@@ -75,17 +198,19 @@ fn main() {
         }
     }
     let el = t.elapsed().as_secs_f64();
+    res.hit_1t_m_ops_per_s = ops as f64 / el / 1e6;
+    res.hit_1t_ns_per_op = el / ops as f64 * 1e9;
     println!(
         "cache hit, 1 thread (RwLock<HashMap>, SipHash): {:.2} M ops/s ({:.0} ns/op) [{sink}]",
-        ops as f64 / el / 1e6,
-        el / ops as f64 * 1e9
+        res.hit_1t_m_ops_per_s,
+        res.hit_1t_ns_per_op
     );
 
     // --- multi-thread hit path: RwLock<HashMap> ----------------------------------
-    bench_threads("RwLock<HashMap>", threads, &queries, &cdf, {
+    multi.push(bench_threads("RwLock<HashMap>", threads, &queries, &cdf, {
         let cache = cache.clone();
         move |k| cache.read().unwrap().get(k).map(|v| v.len()).unwrap_or(0)
-    });
+    }));
 
     // --- multi-thread hit path: sharded maps (no writer contention modelled) ------
     const SHARDS: usize = 64;
@@ -94,22 +219,22 @@ fn main() {
         shards[shard_of(s, SHARDS)].insert(s.clone(), blob.clone());
     }
     let shards: ShardedCache = Arc::new(shards.into_iter().map(RwLock::new).collect());
-    bench_threads("sharded(64) RwLock", threads, &queries, &cdf, {
+    multi.push(bench_threads("sharded(64) RwLock", threads, &queries, &cdf, {
         let shards = shards.clone();
         move |k| {
             let g = shards[shard_of(k, SHARDS)].read().unwrap();
             g.get(k).map(|v| v.len()).unwrap_or(0)
         }
-    });
+    }));
 
     // --- multi-thread: lock-free reads via an immutable Arc-swapped map ----------
     // Models the "generation cache": readers clone an Arc to the whole map (as the
     // server already does for the graph) and look up with zero locking.
     let frozen: Arc<ResponseCache> = Arc::new(cache.read().unwrap().clone());
-    bench_threads("Arc-swapped immutable map", threads, &queries, &cdf, {
+    multi.push(bench_threads("Arc-swapped immutable map", threads, &queries, &cdf, {
         let frozen = frozen.clone();
         move |k| frozen.get(k).map(|v| v.len()).unwrap_or(0)
-    });
+    }));
 
     // --- degenerate: all-distinct queries, 100% miss ------------------------------
     // The overhead the cache adds to a workload it cannot help: hash + miss lookup
@@ -127,9 +252,10 @@ fn main() {
         }
     }
     let el = t.elapsed().as_secs_f64();
+    res.miss_1t_ns_per_op = el / distinct.len() as f64 * 1e9;
     println!(
         "cache MISS lookup (all-distinct, 1 thread): {:.0} ns/op — pure per-request overhead when the cache cannot help [{sink}]",
-        el / distinct.len() as f64 * 1e9
+        res.miss_1t_ns_per_op
     );
 
     // Insert-on-miss cost (what an all-distinct workload would also pay, with the
@@ -141,19 +267,33 @@ fn main() {
             g.insert(k.clone(), blob.clone());
         }
     }
+    res.insert_ns_per_op = t.elapsed().as_secs_f64() / 200_000.0 * 1e9;
     println!(
         "cache insert (lower bound, lock held once): {:.0} ns/op",
-        t.elapsed().as_secs_f64() / 200_000.0 * 1e9
+        res.insert_ns_per_op
     );
+
+    // [OPUS-4.8] (sq-5vm.1) Strictly-additive JSON emit: only when `--json <path>` was given.
+    // STDOUT above (the free-text metric lines) is the unchanged human/research output.
+    if let Some(path) = json_path {
+        let doc = results_json(&res, &multi);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote cache_spike results ({} multi-thread rows) to {path}", multi.len());
+    }
 }
 
+/// Runs the N-thread hit-path benchmark for one lock strategy, PRINTS the same line it
+/// always did, and RETURNS the row so the optional `--json` emit shares one source of truth.
 fn bench_threads(
     label: &str,
     threads: usize,
     queries: &[String],
     cdf: &Arc<Vec<f64>>,
     f: impl Fn(&str) -> usize + Send + Sync + Clone + 'static,
-) {
+) -> ThreadsRow {
     let ops_per_thread = 3_000_000u64;
     let queries = Arc::new(queries.to_vec());
     let t = Instant::now();
@@ -179,11 +319,19 @@ fn bench_threads(
     }
     let el = t.elapsed().as_secs_f64();
     let total = ops_per_thread * threads as u64;
+    let total_m_ops_per_s = total as f64 / el / 1e6;
+    let ns_per_op_per_thread = el / (total as f64 / threads as f64) * 1e9;
     println!(
         "cache hit, {threads} threads ({label}): {:.2} M ops/s total ({:.0} ns/op/thread) [{sink}]",
-        total as f64 / el / 1e6,
-        el / (total as f64 / threads as f64) * 1e9
+        total_m_ops_per_s,
+        ns_per_op_per_thread
     );
+    ThreadsRow {
+        label: label.to_string(),
+        threads,
+        total_m_ops_per_s,
+        ns_per_op_per_thread,
+    }
 }
 
 fn zipf_cdf(n: usize, s: f64) -> Arc<Vec<f64>> {
@@ -209,4 +357,80 @@ fn shard_of(s: &str, shards: usize) -> usize {
     let mut h = std::collections::hash_map::DefaultHasher::new();
     s.hash(&mut h);
     (h.finish() as usize) % shards
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["cache_spike", "16", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["cache_spike", "16"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        let plain: Vec<String> = ["cache_spike", "16"].iter().map(|s| s.to_string()).collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn json_str_escapes() {
+        assert_eq!(json_str("sharded(64) RwLock"), "\"sharded(64) RwLock\"");
+        assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+    }
+
+    #[test]
+    fn results_json_round_trips() {
+        let r = Results {
+            threads: 8,
+            parse_us_per_op: 1.23,
+            parse_query_chars: 110,
+            hit_1t_m_ops_per_s: 30.5,
+            hit_1t_ns_per_op: 33.0,
+            miss_1t_ns_per_op: 45.0,
+            insert_ns_per_op: 120.0,
+        };
+        let multi = vec![
+            ThreadsRow {
+                label: "RwLock<HashMap>".into(),
+                threads: 8,
+                total_m_ops_per_s: 80.0,
+                ns_per_op_per_thread: 100.0,
+            },
+            ThreadsRow {
+                label: "Arc-swapped immutable map".into(),
+                threads: 8,
+                total_m_ops_per_s: 200.0,
+                ns_per_op_per_thread: 40.0,
+            },
+        ];
+        let doc = results_json(&r, &multi);
+        // The dependency-free emit must round-trip through a REAL serde_json parse.
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "serve-spikes cache_spike");
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        assert_eq!(v["threads"], 8);
+        assert!(v["parse_us_per_op"].is_number());
+        assert!(v["hit_1t_m_ops_per_s"].is_number());
+        assert_eq!(v["parse_query_chars"], 110);
+        let m = v["multi_thread_hit"].as_array().expect("multi_thread_hit is an array");
+        assert_eq!(m.len(), 2);
+        assert_eq!(m[0]["label"], "RwLock<HashMap>");
+        assert_eq!(m[1]["label"], "Arc-swapped immutable map");
+        assert!(m[0]["total_m_ops_per_s"].is_number());
+        assert_eq!(m[0]["threads"], 8);
+
+        // Empty multi-thread set must still be valid JSON (no trailing comma).
+        let empty = results_json(&Results::default(), &[]);
+        let v2: serde_json::Value = serde_json::from_str(&empty).expect("empty is valid JSON");
+        assert!(v2["multi_thread_hit"].as_array().unwrap().is_empty());
+    }
 }

--- a/bench/serve/src/bin/point_spike.rs
+++ b/bench/serve/src/bin/point_spike.rs
@@ -11,6 +11,16 @@
 //!   * `query_json` end-to-end (what the server's SELECT path pays after snapshot);
 //!   * parse-only (spargebra) for the same strings — isolating parse share;
 //!   * `ask` on a bound triple (the cheapest possible engine round-trip).
+//!
+//! Run: `cargo run --release --bin point_spike [threads]` in bench/serve.
+//!   cargo run --release --bin point_spike -- [threads] --json /tmp/point.json  # strictly-additive
+//!
+//! [OPUS-4.8] (sq-5vm.1) `--json <path>` writes the SAME parse / point-SELECT / ASK / N-thread
+//! figures STDOUT prints as a stable, DEPENDENCY-FREE JSON document, mirroring writer_spike's
+//! emit (sq-k5qq). No serde dep is added to the harness (serde_json is a TEST-only dev-dep that
+//! parses the emit back). STDOUT is byte-for-byte unchanged whether or not the flag is present;
+//! every number is best-effort, MEASURED on the running host — ADVISORY + NON-CANONICAL (stated
+//! in the emitted `note`) — nothing is committed.
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -21,8 +31,96 @@ use sparq_engine::QueryBudget;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// All the figures this spike prints, captured once so STDOUT and the optional JSON
+/// emit share a single source of truth.
+#[derive(Default)]
+struct Results {
+    triples: usize,
+    threads: usize,
+    parse_us_per_op: f64,
+    point_select_1t_us_per_op: f64,
+    point_select_1t_k_ops_per_s: f64,
+    bound_ask_1t_us_per_op: f64,
+    bound_ask_1t_k_ops_per_s: f64,
+    point_select_nt_m_ops_per_s: f64,
+    point_select_nt_us_per_op_per_thread: f64,
+}
+
+/// Extracts `--json <path>` from argv, returning argv WITHOUT the flag pair. A bare
+/// `--json` is a usage error (exit 2), mirroring `sparq-cli` / `writer_spike`'s flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Serialise the run to stable, dependency-free JSON. Every metric is ADVISORY +
+/// NON-CANONICAL (stated in `note`).
+fn results_json(r: &Results) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"serve-spikes point_spike\",\n");
+    s.push_str(
+        "  \"note\": \"point-BGP lookup ceiling (cache MISS fast path); every µs/op, K-ops/s and \
+         M-ops/s figure is best-effort, MEASURED on the running host — ADVISORY, NON-CANONICAL \
+         (this dev box) — do not bake into committed files\",\n",
+    );
+    s.push_str(&format!("  \"triples\": {},\n", r.triples));
+    s.push_str(&format!("  \"threads\": {},\n", r.threads));
+    s.push_str(&format!("  \"parse_us_per_op\": {:.3},\n", r.parse_us_per_op));
+    s.push_str(&format!(
+        "  \"point_select_1t_us_per_op\": {:.3},\n",
+        r.point_select_1t_us_per_op
+    ));
+    s.push_str(&format!(
+        "  \"point_select_1t_k_ops_per_s\": {:.1},\n",
+        r.point_select_1t_k_ops_per_s
+    ));
+    s.push_str(&format!("  \"bound_ask_1t_us_per_op\": {:.3},\n", r.bound_ask_1t_us_per_op));
+    s.push_str(&format!(
+        "  \"bound_ask_1t_k_ops_per_s\": {:.1},\n",
+        r.bound_ask_1t_k_ops_per_s
+    ));
+    s.push_str(&format!(
+        "  \"point_select_nt_m_ops_per_s\": {:.3},\n",
+        r.point_select_nt_m_ops_per_s
+    ));
+    s.push_str(&format!(
+        "  \"point_select_nt_us_per_op_per_thread\": {:.3}\n",
+        r.point_select_nt_us_per_op_per_thread
+    ));
+    s.push_str("}\n");
+    s
+}
+
 fn main() {
-    let threads: usize = std::env::args().nth(1).and_then(|s| s.parse().ok()).unwrap_or(8);
+    // Strictly-additive: pull `--json <path>` out before reading the optional thread count,
+    // so the positional `[threads]` argument is unaffected when the flag is absent.
+    let (args, json_path) = take_json_flag(std::env::args().collect());
+    let threads: usize = args.into_iter().nth(1).and_then(|s| s.parse().ok()).unwrap_or(8);
+    let mut res = Results { threads, ..Results::default() };
     let mut nt = String::new();
     for i in 0..1_000_000 {
         nt.push_str(&format!(
@@ -31,6 +129,7 @@ fn main() {
         ));
     }
     let graph = Arc::new(Graph::load_str(&nt, "ntriples").expect("load"));
+    res.triples = graph.len();
     println!("graph: {} triples", graph.len());
 
     let q_of = |i: usize| {
@@ -44,9 +143,10 @@ fn main() {
         let q = q_of(i as usize % 1_000_000);
         std::hint::black_box(spargebra::SparqlParser::new().parse_query(&q).unwrap());
     }
+    res.parse_us_per_op = t.elapsed().as_nanos() as f64 / iters as f64 / 1000.0;
     println!(
         "parse only (incl. format!): {:.2} us/op",
-        t.elapsed().as_nanos() as f64 / iters as f64 / 1000.0
+        res.parse_us_per_op
     );
 
     // single-thread end-to-end point SELECT → JSON
@@ -59,10 +159,12 @@ fn main() {
         sink = sink.wrapping_add(sparq_engine::query_json_with_budget(&graph, &q, &b).unwrap().len());
     }
     let el = t.elapsed();
+    res.point_select_1t_us_per_op = el.as_nanos() as f64 / iters as f64 / 1000.0;
+    res.point_select_1t_k_ops_per_s = iters as f64 / el.as_secs_f64() / 1e3;
     println!(
         "point SELECT->JSON, 1 thread: {:.2} us/op = {:.0} K ops/s [{sink}]",
-        el.as_nanos() as f64 / iters as f64 / 1000.0,
-        iters as f64 / el.as_secs_f64() / 1e3
+        res.point_select_1t_us_per_op,
+        res.point_select_1t_k_ops_per_s
     );
 
     // ASK on a fully bound triple — cheapest engine round-trip
@@ -75,10 +177,12 @@ fn main() {
         std::hint::black_box(sparq_engine::ask_with_budget(&graph, &q, &b).unwrap());
     }
     let el = t.elapsed();
+    res.bound_ask_1t_us_per_op = el.as_nanos() as f64 / iters as f64 / 1000.0;
+    res.bound_ask_1t_k_ops_per_s = iters as f64 / el.as_secs_f64() / 1e3;
     println!(
         "bound ASK, 1 thread: {:.2} us/op = {:.0} K ops/s",
-        el.as_nanos() as f64 / iters as f64 / 1000.0,
-        iters as f64 / el.as_secs_f64() / 1e3
+        res.bound_ask_1t_us_per_op,
+        res.bound_ask_1t_k_ops_per_s
     );
 
     // N-thread point SELECT → JSON on shared snapshot
@@ -108,9 +212,78 @@ fn main() {
     }
     let el = t.elapsed();
     let total = per_thread * threads as u64;
+    res.point_select_nt_m_ops_per_s = total as f64 / el.as_secs_f64() / 1e6;
+    res.point_select_nt_us_per_op_per_thread =
+        el.as_nanos() as f64 / (total as f64 / threads as f64) / 1000.0;
     println!(
         "point SELECT->JSON, {threads} threads: {:.2} M ops/s total ({:.2} us/op/thread) [{sink}]",
-        total as f64 / el.as_secs_f64() / 1e6,
-        el.as_nanos() as f64 / (total as f64 / threads as f64) / 1000.0
+        res.point_select_nt_m_ops_per_s,
+        res.point_select_nt_us_per_op_per_thread
     );
+
+    // [OPUS-4.8] (sq-5vm.1) Strictly-additive JSON emit: only when `--json <path>` was given.
+    // STDOUT above (the free-text metric lines) is the unchanged human/research output.
+    if let Some(path) = json_path {
+        let doc = results_json(&res);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote point_spike results to {path}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["point_spike", "16", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["point_spike", "16"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        let plain: Vec<String> = ["point_spike"].iter().map(|s| s.to_string()).collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn results_json_round_trips() {
+        let r = Results {
+            triples: 1_000_000,
+            threads: 8,
+            parse_us_per_op: 1.1,
+            point_select_1t_us_per_op: 4.2,
+            point_select_1t_k_ops_per_s: 238.0,
+            bound_ask_1t_us_per_op: 2.0,
+            bound_ask_1t_k_ops_per_s: 500.0,
+            point_select_nt_m_ops_per_s: 1.5,
+            point_select_nt_us_per_op_per_thread: 5.3,
+        };
+        let doc = results_json(&r);
+        // The dependency-free emit must round-trip through a REAL serde_json parse.
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "serve-spikes point_spike");
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        assert_eq!(v["triples"], 1_000_000);
+        assert_eq!(v["threads"], 8);
+        assert!(v["parse_us_per_op"].is_number());
+        assert!(v["point_select_1t_us_per_op"].is_number());
+        assert!(v["bound_ask_1t_k_ops_per_s"].is_number());
+        assert!(v["point_select_nt_m_ops_per_s"].is_number());
+        assert!(v["point_select_nt_us_per_op_per_thread"].is_number());
+
+        // A defaulted (all-zero) Results is still valid JSON.
+        let empty = results_json(&Results::default());
+        let v2: serde_json::Value = serde_json::from_str(&empty).expect("default is valid JSON");
+        assert_eq!(v2["triples"], 0);
+    }
 }

--- a/bench/serve/src/bin/pss_update_throughput.rs
+++ b/bench/serve/src/bin/pss_update_throughput.rs
@@ -51,6 +51,14 @@
 //! Run: `cargo run --release --bin pss_update_throughput` in `bench/serve`.
 //! Flags: `--profile crud|provision`, `--updates N`, `--resources N`, `--readers N`,
 //! `--children N`, `--qlever-baseline-ms F`, `--tolerance F`.
+//!   `… -- --json /tmp/pss.json`  # strictly-additive
+//!
+//! [OPUS-4.8] (sq-5vm.1) `--json <path>` writes the SAME per-window + TOTAL + parity-gate
+//! figures STDOUT prints as a stable, DEPENDENCY-FREE JSON document, mirroring writer_spike's
+//! emit (sq-k5qq). No serde dep is added to the harness (serde_json is a TEST-only dev-dep that
+//! parses the emit back). STDOUT is byte-for-byte unchanged whether or not the flag is present;
+//! every number is best-effort, MEASURED on the running host — ADVISORY + NON-CANONICAL (stated
+//! in the emitted `note`) — nothing is committed.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -181,6 +189,160 @@ struct Run {
     wall: Duration,
 }
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// One 1k-window of the CRUD stream (the `crud` profile only emits these).
+struct WindowRow {
+    from: usize,
+    to: usize,
+    throughput_per_s: f64,
+    p50_us: u64,
+    p99_us: u64,
+    max_us: u64,
+    rss_mb: f64,
+}
+
+/// Run-level summary (params + the TOTAL line + reference / parity-gate verdicts).
+#[derive(Default)]
+struct Summary {
+    profile: String,
+    updates: usize,
+    resources: usize,
+    readers: usize,
+    children: usize,
+    base_triples_target: usize,
+    base_triples: usize,
+    base_rss_mb: f64,
+    committed: usize,
+    wall_secs: f64,
+    throughput_per_s: f64,
+    p50_ms: f64,
+    p99_ms: f64,
+    max_ms: f64,
+    final_graph_triples: usize,
+    reader_queries: u64,
+    final_rss_mb: f64,
+    /// the gh-52 reference verdict on p99 (< ~50ms): "PASS" or "OVER".
+    reference_p99_verdict: String,
+    /// when `--qlever-baseline-ms` is supplied: the recorded QLever p99 + the parity bar.
+    qlever_baseline_ms: Option<f64>,
+    tolerance: f64,
+    parity_bar_ms: Option<f64>,
+    /// "PASS"/"FAIL" when a baseline was supplied, else "n/a".
+    parity_verdict: String,
+}
+
+/// Extracts `--json <path>` from argv, returning argv WITHOUT the flag pair. A bare
+/// `--json` is a usage error (exit 2), mirroring `sparq-cli` / `writer_spike`'s flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Minimal JSON string escaper (the dependency-free emit). Labels are static ASCII, so
+/// this covers the realistic input; anything else still yields valid `\uXXXX`.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Render an `Option<f64>` as a JSON number or `null` (parity fields are absent unless a
+/// QLever baseline was supplied).
+fn opt_num(v: Option<f64>) -> String {
+    match v {
+        Some(n) => format!("{:.3}", n),
+        None => "null".to_string(),
+    }
+}
+
+/// Serialise the run to stable, dependency-free JSON. Every metric is ADVISORY +
+/// NON-CANONICAL (stated in `note`).
+fn results_json(sum: &Summary, windows: &[WindowRow]) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"serve-spikes pss_update_throughput\",\n");
+    s.push_str(
+        "  \"note\": \"single-writer write-throughput on the PSS update set (gh-52); the binding \
+         metric is p99 commit latency, single-client throughput is ~1/window-bound by design. \
+         Every µs/ms-latency, updates/s and RSS figure is best-effort, MEASURED on the running \
+         host — ADVISORY, NON-CANONICAL (this dev box) — do not bake into committed files\",\n",
+    );
+    s.push_str(&format!("  \"profile\": {},\n", json_str(&sum.profile)));
+    s.push_str(&format!("  \"updates\": {},\n", sum.updates));
+    s.push_str(&format!("  \"resources\": {},\n", sum.resources));
+    s.push_str(&format!("  \"readers\": {},\n", sum.readers));
+    s.push_str(&format!("  \"children\": {},\n", sum.children));
+    s.push_str(&format!("  \"base_triples_target\": {},\n", sum.base_triples_target));
+    s.push_str(&format!("  \"base_triples\": {},\n", sum.base_triples));
+    s.push_str(&format!("  \"base_rss_mb\": {:.0},\n", sum.base_rss_mb));
+    s.push_str(&format!("  \"committed\": {},\n", sum.committed));
+    s.push_str(&format!("  \"wall_secs\": {:.3},\n", sum.wall_secs));
+    s.push_str(&format!("  \"throughput_per_s\": {:.1},\n", sum.throughput_per_s));
+    s.push_str(&format!("  \"p50_ms\": {:.3},\n", sum.p50_ms));
+    s.push_str(&format!("  \"p99_ms\": {:.3},\n", sum.p99_ms));
+    s.push_str(&format!("  \"max_ms\": {:.3},\n", sum.max_ms));
+    s.push_str(&format!("  \"final_graph_triples\": {},\n", sum.final_graph_triples));
+    s.push_str(&format!("  \"reader_queries\": {},\n", sum.reader_queries));
+    s.push_str(&format!("  \"final_rss_mb\": {:.0},\n", sum.final_rss_mb));
+    s.push_str(&format!(
+        "  \"reference_p99_verdict\": {},\n",
+        json_str(&sum.reference_p99_verdict)
+    ));
+    s.push_str(&format!(
+        "  \"qlever_baseline_ms\": {},\n",
+        opt_num(sum.qlever_baseline_ms)
+    ));
+    s.push_str(&format!("  \"tolerance\": {:.3},\n", sum.tolerance));
+    s.push_str(&format!("  \"parity_bar_ms\": {},\n", opt_num(sum.parity_bar_ms)));
+    s.push_str(&format!("  \"parity_verdict\": {},\n", json_str(&sum.parity_verdict)));
+    s.push_str("  \"windows\": [\n");
+    for (i, w) in windows.iter().enumerate() {
+        let comma = if i + 1 < windows.len() { "," } else { "" };
+        s.push_str(&format!(
+            "    {{ \"from\": {}, \"to\": {}, \"throughput_per_s\": {:.1}, \"p50_us\": {}, \
+             \"p99_us\": {}, \"max_us\": {}, \"rss_mb\": {:.0} }}{comma}\n",
+            w.from, w.to, w.throughput_per_s, w.p50_us, w.p99_us, w.max_us, w.rss_mb,
+        ));
+    }
+    s.push_str("  ]\n");
+    s.push_str("}\n");
+    s
+}
+
 /// CRUD stream: round-robin over a resource pool, cycling put → set_acl → put → delete so
 /// every shape (and a real DELETE) is exercised; latency is the synchronous `apply_update`
 /// commit time (group-commit window + delta apply + publish) on the single writer.
@@ -193,7 +355,7 @@ struct Run {
 /// write throughput rises with CONCURRENT clients filling the window — that ceiling is
 /// `writer_spike` (group-commit throughput at `max_batch` 1/16/256), not this binary. Do NOT
 /// read the single-client `updates/s` here as the writer's capacity.
-fn crud_stream(state: &AppState, updates: usize, resources: usize) -> Run {
+fn crud_stream(state: &AppState, updates: usize, resources: usize, windows: &mut Vec<WindowRow>) -> Run {
     let pod = 0usize;
     let mut lat_us = Vec::with_capacity(updates);
     let window = 1_000usize;
@@ -215,16 +377,26 @@ fn crud_stream(state: &AppState, updates: usize, resources: usize) -> Run {
         window_lat.push(us);
         if window_lat.len() == window {
             window_lat.sort_unstable();
+            let from = i + 1 - window;
+            let to = i + 1;
+            let throughput = window as f64 / window_start.elapsed().as_secs_f64();
+            let p50 = window_lat[window / 2];
+            let p99 = window_lat[window * 99 / 100];
+            let max = window_lat[window - 1];
+            let rss = rss_mb();
             println!(
                 "updates {:>7}-{:>7}: thr={:>7.0}/s  p50={:>5}us  p99={:>6}us  max={:>8}us  RSS={:>5.0}MB",
-                i + 1 - window,
-                i + 1,
-                window as f64 / window_start.elapsed().as_secs_f64(),
-                window_lat[window / 2],
-                window_lat[window * 99 / 100],
-                window_lat[window - 1],
-                rss_mb()
+                from, to, throughput, p50, p99, max, rss
             );
+            windows.push(WindowRow {
+                from,
+                to,
+                throughput_per_s: throughput,
+                p50_us: p50,
+                p99_us: p99,
+                max_us: max,
+                rss_mb: rss,
+            });
             window_lat.clear();
             window_start = Instant::now();
         }
@@ -267,7 +439,10 @@ fn main() {
     let mut base_triples_target = 1_000_000usize;
     let mut qlever_baseline_ms: Option<f64> = None;
     let mut tolerance = 1.0f64;
-    let mut args = std::env::args().skip(1);
+    // Strictly-additive: pull `--json <path>` out before the spike's own flag parse, so the
+    // existing flag loop is unaffected when the flag is absent.
+    let (argv, json_path) = take_json_flag(std::env::args().collect());
+    let mut args = argv.into_iter().skip(1);
     while let Some(a) = args.next() {
         let mut next = || args.next().expect("flag value");
         match a.as_str() {
@@ -286,6 +461,20 @@ fn main() {
     // exercise the "readers never block the writer" invariant under concurrent write load.
     resources = resources.max(1);
 
+    let mut sum = Summary {
+        profile: profile.clone(),
+        updates,
+        resources,
+        readers,
+        children,
+        base_triples_target,
+        qlever_baseline_ms,
+        tolerance,
+        parity_verdict: "n/a".to_string(),
+        ..Summary::default()
+    };
+    let mut windows: Vec<WindowRow> = Vec::new();
+
     // Build the pre-existing working set (`--base-triples`) of unrelated data so the
     // delta-overlay's periodic O(graph) compaction is exercised against a real graph.
     let mut nt = String::with_capacity(base_triples_target.saturating_mul(48));
@@ -300,6 +489,7 @@ fn main() {
     }
     let graph = Graph::load_str(&nt, "ntriples").expect("base graph load");
     let base_triples = graph.len();
+    sum.base_triples = base_triples;
 
     let config = ServerConfig {
         query_timeout: Some(Duration::from_secs(5)),
@@ -308,6 +498,7 @@ fn main() {
     let state = AppState::with_config(graph, config);
     let stop = Arc::new(AtomicBool::new(false));
 
+    sum.base_rss_mb = rss_mb();
     println!(
         "# pss_update_throughput — single-writer write-throughput on the PSS update set (gh-52)"
     );
@@ -316,7 +507,7 @@ fn main() {
     );
     println!(
         "# base graph: {base_triples} triples, RSS {:.0}MB\n",
-        rss_mb()
+        sum.base_rss_mb
     );
 
     // Optional concurrent readers: snapshot + point query in a loop (the N-readers side of
@@ -330,7 +521,7 @@ fn main() {
                 let b = QueryBudget::unlimited();
                 let mut n = 0u64;
                 while !stop.load(Ordering::Relaxed) {
-                    // Pin the current generation (lock-free atomic load); never blocked by the
+                    // Pin the current generation (lock-free ~10–20ns); never blocked by the
                     // writer — the N-readers side of the contract.
                     let pin = st.current();
                     let g = pin.snapshot();
@@ -345,21 +536,30 @@ fn main() {
         .collect();
 
     let mut run = match profile.as_str() {
-        "crud" => crud_stream(&state, updates, resources),
+        "crud" => crud_stream(&state, updates, resources, &mut windows),
         "provision" => provision_bursts(&state, updates, children),
         other => panic!("unknown profile {other} (use crud|provision)"),
     };
 
     stop.store(true, Ordering::Relaxed);
     let reads: u64 = reader_handles.into_iter().map(|h| h.join().unwrap()).sum();
+    sum.reader_queries = reads;
 
     run.lat_us.sort_unstable();
     let thr = run.updates as f64 / run.wall.as_secs_f64();
     let p50 = pct(&run.lat_us, 0.50) as f64 / 1000.0;
     let p99 = pct(&run.lat_us, 0.99) as f64 / 1000.0;
     let max = *run.lat_us.last().unwrap_or(&0) as f64 / 1000.0;
+    sum.committed = run.updates;
+    sum.wall_secs = run.wall.as_secs_f64();
+    sum.throughput_per_s = thr;
+    sum.p50_ms = p50;
+    sum.p99_ms = p99;
+    sum.max_ms = max;
     let pin = state.current();
     let g = pin.snapshot();
+    sum.final_graph_triples = g.len();
+    sum.final_rss_mb = rss_mb();
     println!(
         "\nTOTAL: {} commits in {:.2}s = {:.0} updates/s (SINGLE-client, window-bound); p50={:.3}ms p99={:.3}ms max={:.3}ms",
         run.updates,
@@ -372,16 +572,17 @@ fn main() {
     println!(
         "       final graph {} triples (base {base_triples}); concurrent reader queries: {reads}; final RSS {:.0}MB",
         g.len(),
-        rss_mb()
+        sum.final_rss_mb
     );
 
     // Reference targets from gh-52 (NOT the gate — the gate is QLever-parity). The BINDING
     // interactive metric is p99 commit latency (< ~50 ms). Single-client throughput is
     // ~1/window-bound by design (see crud_stream doc + writer_spike for the concurrent ceiling),
     // so "below few-hundred/s" here is the single-client window bound, not a writer limit.
+    sum.reference_p99_verdict = if p99 < 50.0 { "PASS" } else { "OVER" }.to_string();
     println!(
         "# reference (gh-52, non-gating): p99 {} < ~50ms (BINDING interactive metric); single-client thr {:.0}/s is ~1/window-bound (writer_spike = concurrent ceiling)",
-        if p99 < 50.0 { "PASS" } else { "OVER" },
+        sum.reference_p99_verdict,
         thr
     );
 
@@ -389,17 +590,145 @@ fn main() {
     // sparq p99 ≤ QLever p99 × tolerance.
     if let Some(q) = qlever_baseline_ms {
         let bar = q * tolerance;
+        sum.parity_bar_ms = Some(bar);
         println!(
             "# parity gate: sparq p99 {p99:.3}ms vs QLever baseline {q:.3}ms × tol {tolerance} = {bar:.3}ms"
         );
         if p99 > bar {
+            sum.parity_verdict = "FAIL".to_string();
+            // Emit the optional JSON BEFORE exiting non-zero so a recorded run is still captured.
+            emit_json(&json_path, &sum, &windows);
             eprintln!(
                 "PARITY FAIL: sparq single-writer p99 {p99:.3}ms regressed past QLever-parity bar {bar:.3}ms"
             );
             std::process::exit(1);
         }
+        sum.parity_verdict = "PASS".to_string();
         println!(
             "PARITY OK: single-writer p99 is parity-or-better vs QLever on the PSS update set"
         );
+    }
+
+    // [OPUS-4.8] (sq-5vm.1) Strictly-additive JSON emit: only when `--json <path>` was given.
+    // STDOUT above (the per-window + TOTAL + reference + parity lines) is the unchanged output.
+    emit_json(&json_path, &sum, &windows);
+}
+
+/// Write the optional `--json` results document, or do nothing when the flag is absent.
+/// Factored out so the parity-FAIL early-exit path still captures the recorded run.
+fn emit_json(json_path: &Option<String>, sum: &Summary, windows: &[WindowRow]) {
+    if let Some(path) = json_path {
+        let doc = results_json(sum, windows);
+        if let Err(e) = std::fs::write(path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote pss_update_throughput results ({} window rows) to {path}", windows.len());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["pss_update_throughput", "--profile", "crud", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["pss_update_throughput", "--profile", "crud"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        let plain: Vec<String> = ["pss_update_throughput", "--profile", "crud"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn json_str_escapes_and_opt_num() {
+        assert_eq!(json_str("crud"), "\"crud\"");
+        assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+        assert_eq!(opt_num(None), "null");
+        assert_eq!(opt_num(Some(12.5)), "12.500");
+    }
+
+    #[test]
+    fn results_json_round_trips() {
+        // crud run WITH a parity baseline: parity fields are present and numeric.
+        let sum = Summary {
+            profile: "crud".to_string(),
+            updates: 20_000,
+            resources: 2_000,
+            readers: 0,
+            children: 8,
+            base_triples_target: 1_000_000,
+            base_triples: 1_000_000,
+            base_rss_mb: 250.0,
+            committed: 20_000,
+            wall_secs: 60.0,
+            throughput_per_s: 333.0,
+            p50_ms: 3.0,
+            p99_ms: 4.5,
+            max_ms: 12.0,
+            final_graph_triples: 1_010_000,
+            reader_queries: 0,
+            final_rss_mb: 280.0,
+            reference_p99_verdict: "PASS".to_string(),
+            qlever_baseline_ms: Some(6.0),
+            tolerance: 1.0,
+            parity_bar_ms: Some(6.0),
+            parity_verdict: "PASS".to_string(),
+        };
+        let windows = vec![
+            WindowRow {
+                from: 0,
+                to: 1_000,
+                throughput_per_s: 333.0,
+                p50_us: 3_000,
+                p99_us: 4_500,
+                max_us: 12_000,
+                rss_mb: 260.0,
+            },
+        ];
+        let doc = results_json(&sum, &windows);
+        // The dependency-free emit must round-trip through a REAL serde_json parse.
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "serve-spikes pss_update_throughput");
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        assert_eq!(v["profile"], "crud");
+        assert_eq!(v["updates"], 20_000);
+        assert!(v["p99_ms"].is_number());
+        assert_eq!(v["reference_p99_verdict"], "PASS");
+        assert!(v["qlever_baseline_ms"].is_number());
+        assert!(v["parity_bar_ms"].is_number());
+        assert_eq!(v["parity_verdict"], "PASS");
+        let w = v["windows"].as_array().expect("windows is an array");
+        assert_eq!(w.len(), 1);
+        assert_eq!(w[0]["from"], 0);
+        assert_eq!(w[0]["p99_us"], 4_500);
+
+        // provision run with NO parity baseline: parity numerics are JSON null, verdict "n/a",
+        // and the window array is empty — still valid JSON.
+        let bare = Summary {
+            profile: "provision".to_string(),
+            tolerance: 1.0,
+            parity_verdict: "n/a".to_string(),
+            ..Summary::default()
+        };
+        let doc2 = results_json(&bare, &[]);
+        let v2: serde_json::Value = serde_json::from_str(&doc2).expect("bare is valid JSON");
+        assert_eq!(v2["profile"], "provision");
+        assert!(v2["qlever_baseline_ms"].is_null());
+        assert!(v2["parity_bar_ms"].is_null());
+        assert_eq!(v2["parity_verdict"], "n/a");
+        assert!(v2["windows"].as_array().unwrap().is_empty());
     }
 }

--- a/bench/serve/src/bin/snapshot_spike.rs
+++ b/bench/serve/src/bin/snapshot_spike.rs
@@ -25,6 +25,16 @@
 //! Honest scope: the 1s query-timeout is now immaterial to step 3 (there is no reclaim
 //! wait to bound), kept only so the budget matches the original run; it no longer makes
 //! the stall "proportionally worse" because there is no stall.
+//!
+//! Run: `cargo run --release --bin snapshot_spike [data.nt]` in bench/serve.
+//!   cargo run --release --bin snapshot_spike -- [data.nt] --json /tmp/snap.json  # strictly-additive
+//!
+//! [OPUS-4.8] (sq-5vm.1) `--json <path>` writes the SAME snapshot/update/RSS figures STDOUT
+//! prints as a stable, DEPENDENCY-FREE JSON document, mirroring writer_spike's emit (sq-k5qq).
+//! No serde dep is added to the harness (serde_json is a TEST-only dev-dep that parses the emit
+//! back). STDOUT is byte-for-byte unchanged whether or not the flag is present; every number is
+//! best-effort, MEASURED on the running host — ADVISORY + NON-CANONICAL (stated in the emitted
+//! `note`) — nothing is committed.
 
 use std::time::{Duration, Instant};
 
@@ -42,8 +52,105 @@ fn rss_mb() -> f64 {
     String::from_utf8_lossy(&out.stdout).trim().parse::<f64>().unwrap_or(0.0) / 1024.0
 }
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// All the figures this spike prints, captured once so STDOUT and the optional JSON
+/// emit share a single source of truth.
+#[derive(Default)]
+struct Results {
+    triples: usize,
+    load_secs: f64,
+    rss_after_load_mb: f64,
+    snapshot_ns_per_op: f64,
+    snapshots_per_s_millions: f64,
+    first_update_secs: f64,
+    rss_after_first_update_mb: f64,
+    steady_p50_us: u64,
+    steady_max_us: u64,
+    pinned_update1_secs: f64,
+    pinned_update2_secs: f64,
+    rss_with_pinned_mb: f64,
+    pinned_snapshot_triples: usize,
+    after_drop_p50_us: u64,
+    after_drop_max_us: u64,
+    final_rss_mb: f64,
+}
+
+/// Extracts `--json <path>` from argv, returning argv WITHOUT the flag pair. A bare
+/// `--json` is a usage error (exit 2), mirroring `sparq-cli` / `writer_spike`'s flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Serialise the run to stable, dependency-free JSON. Every metric is ADVISORY +
+/// NON-CANONICAL (stated in `note`).
+fn results_json(r: &Results) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"serve-spikes snapshot_spike\",\n");
+    s.push_str(
+        "  \"note\": \"snapshot cost + generation-ring retention semantics; every ns/op, \
+         update-latency, M-snapshots/s and RSS figure is best-effort, MEASURED on the running \
+         host — ADVISORY, NON-CANONICAL (this dev box) — do not bake into committed files\",\n",
+    );
+    s.push_str(&format!("  \"triples\": {},\n", r.triples));
+    s.push_str(&format!("  \"load_secs\": {:.3},\n", r.load_secs));
+    s.push_str(&format!("  \"rss_after_load_mb\": {:.0},\n", r.rss_after_load_mb));
+    s.push_str(&format!("  \"snapshot_ns_per_op\": {:.3},\n", r.snapshot_ns_per_op));
+    s.push_str(&format!(
+        "  \"snapshots_per_s_millions\": {:.3},\n",
+        r.snapshots_per_s_millions
+    ));
+    s.push_str(&format!("  \"first_update_secs\": {:.3},\n", r.first_update_secs));
+    s.push_str(&format!(
+        "  \"rss_after_first_update_mb\": {:.0},\n",
+        r.rss_after_first_update_mb
+    ));
+    s.push_str(&format!("  \"steady_p50_us\": {},\n", r.steady_p50_us));
+    s.push_str(&format!("  \"steady_max_us\": {},\n", r.steady_max_us));
+    s.push_str(&format!("  \"pinned_update1_secs\": {:.3},\n", r.pinned_update1_secs));
+    s.push_str(&format!("  \"pinned_update2_secs\": {:.3},\n", r.pinned_update2_secs));
+    s.push_str(&format!("  \"rss_with_pinned_mb\": {:.0},\n", r.rss_with_pinned_mb));
+    s.push_str(&format!(
+        "  \"pinned_snapshot_triples\": {},\n",
+        r.pinned_snapshot_triples
+    ));
+    s.push_str(&format!("  \"after_drop_p50_us\": {},\n", r.after_drop_p50_us));
+    s.push_str(&format!("  \"after_drop_max_us\": {},\n", r.after_drop_max_us));
+    s.push_str(&format!("  \"final_rss_mb\": {:.0}\n", r.final_rss_mb));
+    s.push_str("}\n");
+    s
+}
+
 fn main() {
-    let path = std::env::args().nth(1);
+    // Strictly-additive: pull `--json <path>` out before reading the optional data path,
+    // so the positional `.nt` argument is unaffected when the flag is absent.
+    let (args, json_path) = take_json_flag(std::env::args().collect());
+    let path = args.into_iter().nth(1);
+    let mut res = Results::default();
+
     let t = Instant::now();
     let graph = match &path {
         Some(p) => {
@@ -64,7 +171,10 @@ fn main() {
         }
     };
     let triples = graph.len();
-    println!("loaded {triples} triples in {:.1}s; RSS after load: {:.0} MB", t.elapsed().as_secs_f64(), rss_mb());
+    res.triples = triples;
+    res.load_secs = t.elapsed().as_secs_f64();
+    res.rss_after_load_mb = rss_mb();
+    println!("loaded {triples} triples in {:.1}s; RSS after load: {:.0} MB", res.load_secs, res.rss_after_load_mb);
 
     let config = ServerConfig {
         query_timeout: Some(Duration::from_secs(1)), // keeps step 3 short; default is 30s
@@ -78,18 +188,22 @@ fn main() {
     for _ in 0..iters {
         std::hint::black_box(state.current());
     }
+    res.snapshot_ns_per_op = t.elapsed().as_nanos() as f64 / iters as f64;
+    res.snapshots_per_s_millions = iters as f64 / t.elapsed().as_secs_f64() / 1e6;
     println!(
         "snapshot (lock-free current(): ArcSwap load + Arc clone): {:.1} ns/op — {:.1} M snapshots/s single thread",
-        t.elapsed().as_nanos() as f64 / iters as f64,
-        iters as f64 / t.elapsed().as_secs_f64() / 1e6
+        res.snapshot_ns_per_op,
+        res.snapshots_per_s_millions
     );
 
     // 2. update latencies, no snapshot held.
     let upd = |i: usize| format!("INSERT DATA {{ <http://ex/new{i}> <http://ex/p0> \"fresh{i}\" }}");
     let t = Instant::now();
     state.apply_update(&upd(0)).expect("first update");
-    println!("update #1 (first => one-time O(graph) dictionary/cache freeze to mint the shared fork base): {:.2}s", t.elapsed().as_secs_f64());
-    println!("RSS after first update (base + first forked generation live): {:.0} MB", rss_mb());
+    res.first_update_secs = t.elapsed().as_secs_f64();
+    println!("update #1 (first => one-time O(graph) dictionary/cache freeze to mint the shared fork base): {:.2}s", res.first_update_secs);
+    res.rss_after_first_update_mb = rss_mb();
+    println!("RSS after first update (base + first forked generation live): {:.0} MB", res.rss_after_first_update_mb);
 
     let mut steady = Vec::new();
     for i in 1..21 {
@@ -98,10 +212,12 @@ fn main() {
         steady.push(t.elapsed().as_micros() as u64);
     }
     steady.sort_unstable();
+    res.steady_p50_us = steady[steady.len() / 2];
+    res.steady_max_us = *steady.last().unwrap();
     println!(
         "updates #2-#21 (steady in-place): p50={}us max={}us",
-        steady[steady.len() / 2],
-        steady.last().unwrap()
+        res.steady_p50_us,
+        res.steady_max_us
     );
 
     // 3. update while a reader pins the PREVIOUS generation (a long-lived stream).
@@ -111,15 +227,19 @@ fn main() {
     let pinned = state.current(); // pins the currently-published generation
     let t = Instant::now();
     state.apply_update(&upd(100)).expect("update while previous gen pinned");
-    println!("update #1 with a generation pinned (writer publishes a fresh generation, no reclaim): {:.3}s", t.elapsed().as_secs_f64());
+    res.pinned_update1_secs = t.elapsed().as_secs_f64();
+    println!("update #1 with a generation pinned (writer publishes a fresh generation, no reclaim): {:.3}s", res.pinned_update1_secs);
     let t = Instant::now();
     state.apply_update(&upd(101)).expect("update while previous gen still pinned");
+    res.pinned_update2_secs = t.elapsed().as_secs_f64();
     println!(
         "update #2 with a generation still pinned: {:.3}s  (ring: NO reclaim wait, NO O(graph) rebuild — should match step 2 steady-state)",
-        t.elapsed().as_secs_f64()
+        res.pinned_update2_secs
     );
-    println!("RSS with the pinned generation + the newer published generations live: {:.0} MB", rss_mb());
-    println!("pinned snapshot still answers at its generation: {} triples (published now has more)", pinned.snapshot().len());
+    res.rss_with_pinned_mb = rss_mb();
+    println!("RSS with the pinned generation + the newer published generations live: {:.0} MB", res.rss_with_pinned_mb);
+    res.pinned_snapshot_triples = pinned.snapshot().len();
+    println!("pinned snapshot still answers at its generation: {} triples (published now has more)", res.pinned_snapshot_triples);
     drop(pinned);
 
     // 4. after the stream ends: the pinned generation has dropped, so the ring holds one
@@ -132,6 +252,84 @@ fn main() {
         after.push(t.elapsed().as_micros() as u64);
     }
     after.sort_unstable();
-    println!("updates after snapshot dropped: p50={}us max={}us (no recovery transient under the ring)", after[after.len() / 2], after.last().unwrap());
-    println!("final RSS: {:.0} MB", rss_mb());
+    res.after_drop_p50_us = after[after.len() / 2];
+    res.after_drop_max_us = *after.last().unwrap();
+    println!("updates after snapshot dropped: p50={}us max={}us (no recovery transient under the ring)", res.after_drop_p50_us, res.after_drop_max_us);
+    res.final_rss_mb = rss_mb();
+    println!("final RSS: {:.0} MB", res.final_rss_mb);
+
+    // [OPUS-4.8] (sq-5vm.1) Strictly-additive JSON emit: only when `--json <path>` was given.
+    // STDOUT above (the free-text metric lines) is the unchanged human/research output.
+    if let Some(path) = json_path {
+        let doc = results_json(&res);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote snapshot_spike results to {path}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["snapshot_spike", "data.nt", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["snapshot_spike", "data.nt"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        // Absent flag: argv passes through untouched, no path.
+        let plain: Vec<String> = ["snapshot_spike", "data.nt"].iter().map(|s| s.to_string()).collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn results_json_round_trips() {
+        let r = Results {
+            triples: 1_000_000,
+            load_secs: 1.5,
+            rss_after_load_mb: 250.0,
+            snapshot_ns_per_op: 18.4,
+            snapshots_per_s_millions: 54.3,
+            first_update_secs: 0.42,
+            rss_after_first_update_mb: 480.0,
+            steady_p50_us: 30,
+            steady_max_us: 120,
+            pinned_update1_secs: 0.031,
+            pinned_update2_secs: 0.029,
+            rss_with_pinned_mb: 510.0,
+            pinned_snapshot_triples: 1_000_001,
+            after_drop_p50_us: 28,
+            after_drop_max_us: 95,
+            final_rss_mb: 500.0,
+        };
+        let doc = results_json(&r);
+        // The dependency-free emit must round-trip through a REAL serde_json parse.
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "serve-spikes snapshot_spike");
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        assert_eq!(v["triples"], 1_000_000);
+        assert!(v["snapshot_ns_per_op"].is_number());
+        assert!(v["snapshots_per_s_millions"].is_number());
+        assert_eq!(v["steady_p50_us"], 30);
+        assert_eq!(v["pinned_snapshot_triples"], 1_000_001);
+        assert!(v["pinned_update2_secs"].is_number());
+        assert_eq!(v["after_drop_max_us"], 95);
+        assert!(v["final_rss_mb"].is_number());
+
+        // A defaulted (all-zero) Results is still valid JSON.
+        let empty = results_json(&Results::default());
+        let v2: serde_json::Value = serde_json::from_str(&empty).expect("default is valid JSON");
+        assert_eq!(v2["triples"], 0);
+    }
 }

--- a/bench/serve/src/bin/stream_spike.rs
+++ b/bench/serve/src/bin/stream_spike.rs
@@ -9,6 +9,16 @@
 //! so time-to-first-chunk == full evaluation time — i.e. today's seam removes the
 //! second result copy but does NOT give a pull-streaming executor; true streaming
 //! needs an iterator/callback seam in the engine (an engine-hooks ask).
+//!
+//! Run: `cargo run --release --bin stream_spike [data.nt]` in bench/serve.
+//!   cargo run --release --bin stream_spike -- [data.nt] --json /tmp/stream.json  # strictly-additive
+//!
+//! [OPUS-4.8] (sq-5vm.1) `--json <path>` writes the SAME per-query timing rows STDOUT prints
+//! as a stable, DEPENDENCY-FREE JSON document, mirroring writer_spike's emit (sq-k5qq). No serde
+//! dep is added to the harness (serde_json is a TEST-only dev-dep that parses the emit back).
+//! STDOUT is byte-for-byte unchanged whether or not the flag is present; every number is
+//! best-effort, MEASURED on the running host — ADVISORY + NON-CANONICAL (stated in the emitted
+//! `note`) — nothing is committed.
 
 use std::time::Instant;
 
@@ -18,8 +28,111 @@ use sparq_engine::QueryBudget;
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// One query's streaming-seam timings: rows/chunks/bytes plus the four phase times (ms)
+/// and the derived first-chunk share of full evaluation.
+struct QueryRow {
+    query: String,
+    rows: usize,
+    chunks: usize,
+    bytes: usize,
+    count_compute_ms: f64,
+    chunks_time_to_first_ms: f64,
+    chunks_drain_ms: f64,
+    query_json_ms: f64,
+    first_chunk_pct_of_full: f64,
+}
+
+/// Extracts `--json <path>` from argv, returning argv WITHOUT the flag pair. A bare
+/// `--json` is a usage error (exit 2), mirroring `sparq-cli` / `writer_spike`'s flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Minimal JSON string escaper (the dependency-free emit). Query strings are ASCII
+/// SPARQL, so this covers the realistic input; anything else still yields valid `\uXXXX`.
+fn json_str(raw: &str) -> String {
+    let mut out = String::with_capacity(raw.len() + 2);
+    out.push('"');
+    for c in raw.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out.push('"');
+    out
+}
+
+/// Serialise the run to stable, dependency-free JSON. Every metric is ADVISORY +
+/// NON-CANONICAL (stated in `note`).
+fn results_json(triples: usize, rows: &[QueryRow]) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"serve-spikes stream_spike\",\n");
+    s.push_str(
+        "  \"note\": \"streaming-seam assessment (time-to-first-chunk vs full evaluation); every \
+         millisecond figure is best-effort, MEASURED on the running host — ADVISORY, NON-CANONICAL \
+         (this dev box) — do not bake into committed files\",\n",
+    );
+    s.push_str(&format!("  \"triples\": {},\n", triples));
+    s.push_str("  \"queries\": [\n");
+    for (i, r) in rows.iter().enumerate() {
+        let comma = if i + 1 < rows.len() { "," } else { "" };
+        s.push_str(&format!(
+            "    {{ \"query\": {}, \"rows\": {}, \"chunks\": {}, \"bytes\": {}, \
+             \"count_compute_ms\": {:.3}, \"chunks_time_to_first_ms\": {:.3}, \
+             \"chunks_drain_ms\": {:.3}, \"query_json_ms\": {:.3}, \
+             \"first_chunk_pct_of_full\": {:.1} }}{comma}\n",
+            json_str(&r.query),
+            r.rows,
+            r.chunks,
+            r.bytes,
+            r.count_compute_ms,
+            r.chunks_time_to_first_ms,
+            r.chunks_drain_ms,
+            r.query_json_ms,
+            r.first_chunk_pct_of_full,
+        ));
+    }
+    s.push_str("  ]\n");
+    s.push_str("}\n");
+    s
+}
+
 fn main() {
-    let path = std::env::args().nth(1);
+    // Strictly-additive: pull `--json <path>` out before reading the optional data path,
+    // so the positional `.nt` argument is unaffected when the flag is absent.
+    let (args, json_path) = take_json_flag(std::env::args().collect());
+    let path = args.into_iter().nth(1);
     let graph = match &path {
         Some(p) => {
             eprintln!("loading {p} ...");
@@ -33,8 +146,10 @@ fn main() {
             Graph::load_str(&nt, "ntriples").expect("load synthetic")
         }
     };
-    println!("loaded {} triples", graph.len());
+    let triples = graph.len();
+    println!("loaded {triples} triples");
 
+    let mut rows: Vec<QueryRow> = Vec::new();
     for q in [
         "SELECT ?s ?p ?o WHERE { ?s ?p ?o }",                 // full scan, graph-sized result
         "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 100000",    // large but bounded
@@ -66,14 +181,114 @@ fn main() {
         let s = sparq_engine::query_json(&graph, q).expect("json");
         let t_single = t.elapsed();
 
+        let first_chunk_pct = t_first.as_secs_f64() / t_single.as_secs_f64() * 100.0;
         println!(
             "{q}\n  rows={n} chunks={n_chunks} bytes={total_bytes}\n  count(compute only)      {:>10.1} ms\n  chunks: time-to-first    {:>10.1} ms   drain {:.3} ms  [{sink}]\n  query_json (one string)  {:>10.1} ms\n  => first-chunk latency is {:.0}% of full evaluation (1.0 == no time streaming)",
             t_count.as_secs_f64() * 1e3,
             t_first.as_secs_f64() * 1e3,
             t_drain.as_secs_f64() * 1e3,
             t_single.as_secs_f64() * 1e3,
-            t_first.as_secs_f64() / t_single.as_secs_f64() * 100.0,
+            first_chunk_pct,
         );
         let _ = s;
+        rows.push(QueryRow {
+            query: q.to_string(),
+            rows: n,
+            chunks: n_chunks,
+            bytes: total_bytes,
+            count_compute_ms: t_count.as_secs_f64() * 1e3,
+            chunks_time_to_first_ms: t_first.as_secs_f64() * 1e3,
+            chunks_drain_ms: t_drain.as_secs_f64() * 1e3,
+            query_json_ms: t_single.as_secs_f64() * 1e3,
+            first_chunk_pct_of_full: first_chunk_pct,
+        });
+    }
+
+    // [OPUS-4.8] (sq-5vm.1) Strictly-additive JSON emit: only when `--json <path>` was given.
+    // STDOUT above (the per-query text blocks) is the unchanged human/research output.
+    if let Some(path) = json_path {
+        let doc = results_json(triples, &rows);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote {} query rows to {path}", rows.len());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["stream_spike", "data.nt", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["stream_spike", "data.nt"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        let plain: Vec<String> = ["stream_spike"].iter().map(|s| s.to_string()).collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn json_str_escapes() {
+        assert_eq!(
+            json_str("SELECT ?s WHERE { ?s ?p ?o }"),
+            "\"SELECT ?s WHERE { ?s ?p ?o }\""
+        );
+        assert_eq!(json_str("a\"b\\c\n"), "\"a\\\"b\\\\c\\n\"");
+    }
+
+    #[test]
+    fn results_json_round_trips() {
+        let rows = vec![
+            QueryRow {
+                query: "SELECT ?s ?p ?o WHERE { ?s ?p ?o }".into(),
+                rows: 1_000_000,
+                chunks: 100,
+                bytes: 50_000_000,
+                count_compute_ms: 12.0,
+                chunks_time_to_first_ms: 90.0,
+                chunks_drain_ms: 0.5,
+                query_json_ms: 95.0,
+                first_chunk_pct_of_full: 94.7,
+            },
+            QueryRow {
+                query: "SELECT ?s ?p ?o WHERE { ?s ?p ?o } LIMIT 10".into(),
+                rows: 10,
+                chunks: 1,
+                bytes: 600,
+                count_compute_ms: 0.1,
+                chunks_time_to_first_ms: 0.2,
+                chunks_drain_ms: 0.001,
+                query_json_ms: 0.2,
+                first_chunk_pct_of_full: 100.0,
+            },
+        ];
+        let doc = results_json(1_000_000, &rows);
+        // The dependency-free emit must round-trip through a REAL serde_json parse.
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "serve-spikes stream_spike");
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        assert_eq!(v["triples"], 1_000_000);
+        let qs = v["queries"].as_array().expect("queries is an array");
+        assert_eq!(qs.len(), 2);
+        assert_eq!(qs[0]["query"], "SELECT ?s ?p ?o WHERE { ?s ?p ?o }");
+        assert_eq!(qs[0]["rows"], 1_000_000);
+        assert!(qs[0]["chunks_time_to_first_ms"].is_number());
+        assert!(qs[0]["first_chunk_pct_of_full"].is_number());
+
+        // Empty query set must still be valid JSON (no trailing comma).
+        let empty = results_json(0, &[]);
+        let v2: serde_json::Value = serde_json::from_str(&empty).expect("empty is valid JSON");
+        assert!(v2["queries"].as_array().unwrap().is_empty());
     }
 }

--- a/bench/serve/src/bin/update_stream_spike.rs
+++ b/bench/serve/src/bin/update_stream_spike.rs
@@ -19,6 +19,17 @@
 //! lock-free and never stall the writer under sustained read load.
 //!
 //! Output: update p50/p99/max per 1k-window, RSS per window, total throughput.
+//!
+//! Run: `cargo run --release --bin update_stream_spike [--updates N --resources N --readers N]`
+//!      in bench/serve.
+//!   cargo run --release --bin update_stream_spike -- --json /tmp/upd.json  # strictly-additive
+//!
+//! [OPUS-4.8] (sq-5vm.1) `--json <path>` writes the SAME per-window + TOTAL figures STDOUT
+//! prints as a stable, DEPENDENCY-FREE JSON document, mirroring writer_spike's emit (sq-k5qq).
+//! No serde dep is added to the harness (serde_json is a TEST-only dev-dep that parses the emit
+//! back). STDOUT is byte-for-byte unchanged whether or not the flag is present; every number is
+//! best-effort, MEASURED on the running host — ADVISORY + NON-CANONICAL (stated in the emitted
+//! `note`) — nothing is committed.
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -58,11 +69,109 @@ fn put_document_update(res: usize, version: usize) -> String {
     )
 }
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json <path> machine-readable results emit
+// ---------------------------------------------------------------------------
+
+/// One 1k-window of the sustained update stream: the index range plus throughput,
+/// latency percentiles and RSS at that point — the flat-latency / flat-RSS evidence.
+struct WindowRow {
+    from: usize,
+    to: usize,
+    throughput_per_s: f64,
+    p50_us: u64,
+    p99_us: u64,
+    max_us: u64,
+    rss_mb: f64,
+}
+
+/// Run-level summary (the workload params + the TOTAL line + final state).
+#[derive(Default)]
+struct Summary {
+    updates: usize,
+    resources: usize,
+    readers: usize,
+    base_triples: usize,
+    base_rss_mb: f64,
+    total_secs: f64,
+    sustained_updates_per_s: f64,
+    reader_queries: u64,
+    final_rss_mb: f64,
+    final_graph_triples: usize,
+}
+
+/// Extracts `--json <path>` from argv, returning argv WITHOUT the flag pair. A bare
+/// `--json` is a usage error (exit 2), mirroring `sparq-cli` / `writer_spike`'s flag.
+fn take_json_flag(args: Vec<String>) -> (Vec<String>, Option<String>) {
+    let mut out = Vec::with_capacity(args.len());
+    let mut json_path = None;
+    let mut i = 0;
+    while i < args.len() {
+        if args[i] == "--json" {
+            match args.get(i + 1) {
+                Some(p) => {
+                    json_path = Some(p.clone());
+                    i += 2;
+                    continue;
+                }
+                None => {
+                    eprintln!("`--json` requires a path argument: --json <path>");
+                    std::process::exit(2);
+                }
+            }
+        }
+        out.push(args[i].clone());
+        i += 1;
+    }
+    (out, json_path)
+}
+
+/// Serialise the run to stable, dependency-free JSON. Every metric is ADVISORY +
+/// NON-CANONICAL (stated in `note`).
+fn results_json(sum: &Summary, windows: &[WindowRow]) -> String {
+    let mut s = String::new();
+    s.push_str("{\n");
+    s.push_str("  \"harness\": \"serve-spikes update_stream_spike\",\n");
+    s.push_str(
+        "  \"note\": \"sustained small-update stream (QLever-OOM failure mode test); every \
+         updates/s, µs-latency and RSS figure is best-effort, MEASURED on the running host — \
+         ADVISORY, NON-CANONICAL (this dev box) — do not bake into committed files\",\n",
+    );
+    s.push_str(&format!("  \"updates\": {},\n", sum.updates));
+    s.push_str(&format!("  \"resources\": {},\n", sum.resources));
+    s.push_str(&format!("  \"readers\": {},\n", sum.readers));
+    s.push_str(&format!("  \"base_triples\": {},\n", sum.base_triples));
+    s.push_str(&format!("  \"base_rss_mb\": {:.0},\n", sum.base_rss_mb));
+    s.push_str(&format!("  \"total_secs\": {:.3},\n", sum.total_secs));
+    s.push_str(&format!(
+        "  \"sustained_updates_per_s\": {:.1},\n",
+        sum.sustained_updates_per_s
+    ));
+    s.push_str(&format!("  \"reader_queries\": {},\n", sum.reader_queries));
+    s.push_str(&format!("  \"final_rss_mb\": {:.0},\n", sum.final_rss_mb));
+    s.push_str(&format!("  \"final_graph_triples\": {},\n", sum.final_graph_triples));
+    s.push_str("  \"windows\": [\n");
+    for (i, w) in windows.iter().enumerate() {
+        let comma = if i + 1 < windows.len() { "," } else { "" };
+        s.push_str(&format!(
+            "    {{ \"from\": {}, \"to\": {}, \"throughput_per_s\": {:.1}, \"p50_us\": {}, \
+             \"p99_us\": {}, \"max_us\": {}, \"rss_mb\": {:.0} }}{comma}\n",
+            w.from, w.to, w.throughput_per_s, w.p50_us, w.p99_us, w.max_us, w.rss_mb,
+        ));
+    }
+    s.push_str("  ]\n");
+    s.push_str("}\n");
+    s
+}
+
 fn main() {
     let mut updates = 20_000usize;
     let mut resources = 2_000usize;
     let mut readers = 0usize;
-    let mut args = std::env::args().skip(1);
+    // Strictly-additive: pull `--json <path>` out before the spike's own flag parse, so the
+    // `--updates/--resources/--readers` loop below is unaffected when the flag is absent.
+    let (argv, json_path) = take_json_flag(std::env::args().collect());
+    let mut args = argv.into_iter().skip(1);
     while let Some(a) = args.next() {
         let mut next = || args.next().expect("flag value").parse::<usize>().expect("number");
         match a.as_str() {
@@ -72,6 +181,13 @@ fn main() {
             other => panic!("unknown arg {other}"),
         }
     }
+    let mut sum = Summary {
+        updates,
+        resources,
+        readers,
+        ..Summary::default()
+    };
+    let mut windows: Vec<WindowRow> = Vec::new();
 
     // Base graph: 1M triples of unrelated data + initial resource metadata.
     let mut nt = String::new();
@@ -79,10 +195,12 @@ fn main() {
         nt.push_str(&format!("<http://ex/s{}> <http://ex/p{}> \"v{}\" .\n", i % 200_000, i % 50, i));
     }
     let graph = Graph::load_str(&nt, "ntriples").expect("load");
+    sum.base_triples = graph.len();
+    sum.base_rss_mb = rss_mb();
     println!(
         "base graph: {} triples, RSS {:.0} MB; {updates} updates over {resources} resources, readers={readers}",
         graph.len(),
-        rss_mb()
+        sum.base_rss_mb
     );
 
     // Compaction is no longer a ServerConfig knob: as of Wave A4 the writer's
@@ -105,7 +223,7 @@ fn main() {
                 let b = QueryBudget::unlimited();
                 let mut n = 0u64;
                 while !stop.load(Ordering::Relaxed) {
-                    // Pin the current generation (lock-free); never blocked by the
+                    // Pin the current generation (lock-free ~10–20ns); never blocked by the
                     // writer. Hold `pin` for the whole query so its snapshot stays readable.
                     let pin = st.current();
                     let g = pin.snapshot();
@@ -131,29 +249,137 @@ fn main() {
         lat.push(t.elapsed().as_micros() as u64);
         if lat.len() == window {
             lat.sort_unstable();
+            let from = i + 1 - window;
+            let to = i + 1;
+            let throughput = window as f64 / window_start.elapsed().as_secs_f64();
+            let p50 = lat[window / 2];
+            let p99 = lat[window * 99 / 100];
+            let max = lat[window - 1];
+            let rss = rss_mb();
             println!(
                 "updates {:>6}-{:>6}: thr={:>6.0}/s p50={:>5}us p99={:>6}us max={:>8}us  RSS={:>5.0} MB",
-                i + 1 - window,
-                i + 1,
-                window as f64 / window_start.elapsed().as_secs_f64(),
-                lat[window / 2],
-                lat[window * 99 / 100],
-                lat[window - 1],
-                rss_mb()
+                from, to, throughput, p50, p99, max, rss
             );
+            windows.push(WindowRow {
+                from,
+                to,
+                throughput_per_s: throughput,
+                p50_us: p50,
+                p99_us: p99,
+                max_us: max,
+                rss_mb: rss,
+            });
             lat.clear();
             window_start = Instant::now();
         }
     }
     stop.store(true, Ordering::Relaxed);
     let reads: u64 = reader_handles.into_iter().map(|h| h.join().unwrap()).sum();
+    sum.total_secs = run_start.elapsed().as_secs_f64();
+    sum.sustained_updates_per_s = updates as f64 / sum.total_secs;
+    sum.reader_queries = reads;
+    sum.final_rss_mb = rss_mb();
     println!(
         "TOTAL: {updates} updates in {:.1}s = {:.0} updates/s sustained; reader queries completed: {reads}; final RSS {:.0} MB",
-        run_start.elapsed().as_secs_f64(),
-        updates as f64 / run_start.elapsed().as_secs_f64(),
-        rss_mb()
+        sum.total_secs,
+        sum.sustained_updates_per_s,
+        sum.final_rss_mb
     );
     // Final published graph sanity: each resource should have exactly 8 triples + parent containment.
     let pin = state.current();
-    println!("final graph: {} triples", pin.snapshot().len());
+    sum.final_graph_triples = pin.snapshot().len();
+    println!("final graph: {} triples", sum.final_graph_triples);
+
+    // [OPUS-4.8] (sq-5vm.1) Strictly-additive JSON emit: only when `--json <path>` was given.
+    // STDOUT above (the per-window + TOTAL lines) is the unchanged human/research output.
+    if let Some(path) = json_path {
+        let doc = results_json(&sum, &windows);
+        if let Err(e) = std::fs::write(&path, doc) {
+            eprintln!("error writing --json results to {path}: {e}");
+            std::process::exit(1);
+        }
+        eprintln!("wrote {} window rows + summary to {path}", windows.len());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-5vm.1) --json emit tests
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_flag_extraction() {
+        let argv: Vec<String> = ["update_stream_spike", "--updates", "5000", "--json", "/tmp/o.json"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (positional, path) = take_json_flag(argv);
+        assert_eq!(positional, vec!["update_stream_spike", "--updates", "5000"]);
+        assert_eq!(path.as_deref(), Some("/tmp/o.json"));
+        let plain: Vec<String> = ["update_stream_spike", "--updates", "5000"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        let (p2, none) = take_json_flag(plain.clone());
+        assert_eq!(p2, plain);
+        assert!(none.is_none());
+    }
+
+    #[test]
+    fn results_json_round_trips() {
+        let sum = Summary {
+            updates: 20_000,
+            resources: 2_000,
+            readers: 4,
+            base_triples: 1_000_000,
+            base_rss_mb: 250.0,
+            total_secs: 12.5,
+            sustained_updates_per_s: 1600.0,
+            reader_queries: 5_000_000,
+            final_rss_mb: 300.0,
+            final_graph_triples: 1_016_001,
+        };
+        let windows = vec![
+            WindowRow {
+                from: 0,
+                to: 1_000,
+                throughput_per_s: 1700.0,
+                p50_us: 400,
+                p99_us: 900,
+                max_us: 5_000,
+                rss_mb: 260.0,
+            },
+            WindowRow {
+                from: 1_000,
+                to: 2_000,
+                throughput_per_s: 1650.0,
+                p50_us: 410,
+                p99_us: 950,
+                max_us: 6_000,
+                rss_mb: 265.0,
+            },
+        ];
+        let doc = results_json(&sum, &windows);
+        // The dependency-free emit must round-trip through a REAL serde_json parse.
+        let v: serde_json::Value = serde_json::from_str(&doc).expect("emit must be valid JSON");
+        assert_eq!(v["harness"], "serve-spikes update_stream_spike");
+        assert!(v["note"].as_str().unwrap().contains("NON-CANONICAL"));
+        assert_eq!(v["updates"], 20_000);
+        assert_eq!(v["readers"], 4);
+        assert!(v["sustained_updates_per_s"].is_number());
+        assert_eq!(v["final_graph_triples"], 1_016_001);
+        let w = v["windows"].as_array().expect("windows is an array");
+        assert_eq!(w.len(), 2);
+        assert_eq!(w[0]["from"], 0);
+        assert_eq!(w[0]["to"], 1_000);
+        assert_eq!(w[1]["p50_us"], 410);
+        assert!(w[0]["throughput_per_s"].is_number());
+
+        // Empty window set must still be valid JSON (no trailing comma).
+        let empty = results_json(&Summary::default(), &[]);
+        let v2: serde_json::Value = serde_json::from_str(&empty).expect("empty is valid JSON");
+        assert!(v2["windows"].as_array().unwrap().is_empty());
+    }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-5vm.1.

Extends the strictly-additive `--json <path>` results emit (landed on `writer_spike` by sq-k5qq / #855) to the six remaining `serve-spikes` binaries that previously printed ad-hoc STDOUT only. Each copies writer_spike's `take_json_flag` / dependency-free `format!`-JSON / `#[cfg(test)]` serde_json round-trip idiom exactly; `serde_json` stays a TEST-only dev-dep.

**Contract held per binary:** `--json <path>` is strictly additive (STDOUT byte-identical when absent — the emit writes only to the file + a STDERR notice); the document carries a NON-CANONICAL note (work-box numbers, not canonical); a per-binary round-trip test asserts the emit parses back. No committed performance numbers (diff is `.rs`/`.toml` only).

### The 6 binaries + their JSON shape

| binary | hand-built results-JSON shape |
|---|---|
| `snapshot_spike` | flat object: `triples`, `load_secs`, `snapshot_ns_per_op`, `snapshots_per_s_millions`, first-update / steady p50+max / pinned-gen update#1+#2 / after-drop p50+max latencies, and RSS at each stage |
| `cache_spike` | scalars (`parse_us_per_op`, single-thread hit M-ops/s + ns/op, miss ns/op, insert ns/op) + a `multi_thread_hit[]` array, one row per lock strategy (`RwLock<HashMap>`, `sharded(64) RwLock`, `Arc-swapped immutable map`) with total M-ops/s + ns/op/thread |
| `stream_spike` | `triples` + a `queries[]` array, one row per query: rows/chunks/bytes + the four phase times (count-compute / time-to-first-chunk / drain / query_json ms) + `first_chunk_pct_of_full` |
| `point_spike` | flat object: `triples`, `threads`, parse µs/op, point-SELECT 1-thread µs/op + K-ops/s, bound-ASK 1-thread µs/op + K-ops/s, N-thread point-SELECT M-ops/s + µs/op/thread |
| `update_stream_spike` | run summary (updates / resources / readers / base triples + RSS / total secs / sustained ups / reader queries / final RSS + graph triples) + a `windows[]` array, one per 1k window (thr + p50/p99/max µs + RSS) |
| `pss_update_throughput` | run summary (profile / params / TOTAL p50/p99/max ms / final state) + the gh-52 `reference_p99_verdict`, the optional parity-gate fields (`qlever_baseline_ms`/`tolerance`/`parity_bar_ms` as JSON `null` when no baseline, `parity_verdict`) + a `windows[]` array (crud profile) |

The free-text spikes did not fit one shared schema, so each got its own shape capturing its real metrics; both window-series and array-shaped spikes use the no-trailing-comma loop emit so an empty set is still valid JSON.

### Round-trip tests
Each binary gains a `#[cfg(test)]` module with `json_flag_extraction` (flag pair removed; absent flag passes argv through untouched) + `results_json_round_trips` (the emit parses through a REAL `serde_json::from_str`, asserts harness/note/key fields + that an empty/default set is still valid JSON). cache/stream/pss also test `json_str` escaping; pss tests the `null`/numeric parity rendering.

### Gates (run in the worktree, `bench/serve`)
- `cargo clippy -p serve-spikes --all-targets -- -D warnings` — clean.
- `cargo test -p serve-spikes` — green; the 6 new round-trip tests pass.
- Built each spike release and ran with + without `--json`: number-masked STDOUT diff is structurally identical for all six (flag adds nothing to stdout). The pss parity-FAIL early-exit path still emits the JSON before exiting non-zero. Bare `--json` exits 2.
- `check-no-perf-numbers.py --enforce` — 0 findings (diff is `.rs`/`.toml`, no markdown).
- `typos` — clean on all changed files.

**Feature states:** `serve-spikes` is a standalone bench package with no cargo features of its own; `--json` is purely additive runtime behaviour gated by argv (not a compile feature), and the optional `serde_json` is a pre-existing TEST-only dev-dep — so there is no feature matrix to sweep, the build/tests are identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)