### PR TITLE
chore(hygiene): periodic sweep — SKILL-currency/counts/stale-bead/from-pss [OPUS-4.8]

### DIFF
--- a/packages/sparq-client/README.md
+++ b/packages/sparq-client/README.md
@@ -26,6 +26,25 @@ copy is the **single source of truth**, kept byte-identical to a fresh wasm buil
   unchanged; a desktop GUI passes its own `tauri://` / `file://` origin).
 - The framework-agnostic query helpers: `matchQuads`, `countQuads`, `streamQueryRows`,
   `sparqShaclValidate`, `formatTerm`.
+- **RDF-document display + serialisation helpers** (`sq-8uew` / `sq-gb4o`, all dependency-free
+  and DOM-free so the site and the Tauri 2 webview share one copy): `prettyTurtle(input, opts?)`
+  / `prettyTrig(input, opts?)` reshape the engine's FLAT N-Triples / N-Quads
+  CONSTRUCT/DESCRIBE output (`WasmStore.queryQuads` is N-Triples only) into idiomatic, indented
+  Turtle/TriG — `@prefix` abbreviation, one block per subject, `;`/`,` predicate-object lists,
+  `a` for `rdf:type` — while staying ROUND-TRIP-EQUIVALENT (re-parsing the output yields the
+  same triple set; literals, blank-node labels and RDF 1.2 triple terms `<<( s p o )>>` are
+  lossless) and NEVER throwing (an unparseable line passes through verbatim).
+  `PrettyTurtleOptions` takes `{ prefixes?, indent?, abbreviate? }`; `parseNTriples(input)`
+  exposes the underlying tokeniser (`{ statements, passthrough }`) over the `RdfTerm` /
+  `RdfStatement` shapes. `tokenizeTurtle(text)` is the sibling Turtle/TriG/N-Triples/N-Quads
+  highlighting tokenizer (`TurtleToken` / `TurtleTokenType`) — compose as pretty-print THEN
+  highlight. The `sparql-prefixes` helpers recover prefix bindings from a query so the pretty
+  view abbreviates result IRIs with the USER's own declared prefixes: `declaredPrefixBindings`
+  / `declaredPrefixes` / `usedPrefixes` / `missingCommonPrefixes` / `renderPrefixLines` /
+  `withPrefixes`, plus the `COMMON_PREFIXES` well-known registry and the `PrefixBinding` type.
+  (The PARSE direction — Turtle/SHACL-Compact text → engine — is the engine's job, not this
+  package's: SHACL Compact Syntax *display* lives in `site/` and its parser is tracked under a
+  separate `sparq-shacl` bead.)
 - **Endpoint mode** (`src/endpoint.ts`, `sq-2mke`): the SPARQL 1.1 Protocol HTTP client —
   the companion to the in-tab `WasmStore`. Run the SAME editor against any running
   `sparq-server` (or any conformant endpoint) over `fetch`. `runEndpointQuery(config, sparql)`


### PR DESCRIPTION
> 🤖 SPARQ agent — periodic repository-hygiene sweep (doc/hygiene only; no `crates/` source changes). I am @jeswr's agent; this is the SPARQ agent.

## What this changes

One doc fix: the **public-API → doc rule** for the `@sparq/client` package. Recent site merges added new symbols to the package barrel (`packages/sparq-client/src/index.ts`) but left them undocumented in `packages/sparq-client/README.md`. Added a "What's in it" bullet covering:

- `prettyTurtle` / `prettyTrig` / `parseNTriples` + `PrettyTurtleOptions` / `RdfTerm` / `RdfStatement` — the dependency-free, round-trip-equivalent N-Triples→idiomatic-Turtle reshaper (sq-gb4o, #854 / #805).
- `tokenizeTurtle` + `TurtleToken` / `TurtleTokenType` — the Turtle/TriG/N-Triples/N-Quads highlighting tokenizer (sq-8uew, #845 / #788).
- the `sparql-prefixes` helpers (`declaredPrefixBindings`/`declaredPrefixes`/`usedPrefixes`/`missingCommonPrefixes`/`renderPrefixLines`/`withPrefixes`), `COMMON_PREFIXES`, `PrefixBinding`.

The note also points the PARSE direction (Turtle/SHACL-Compact text → engine) at the engine, where it belongs (SHACL Compact Syntax *display* shipped in `site/` via #860; its parser is tracked under the still-open `sq-v0b8`).

## Honesty gates

- `check-terminology.py` — clean.
- `check-no-perf-numbers.py --enforce` — 0 findings.
- `check-privacy-claims.sh` — OK (no unqualified ZK/MPC privacy/soundness claim; my addition asserts none).
- `markdownlint-cli2` — 0 errors across 217 files.

## Counts verified — NO drift (deliberately not changed)

A counts pass flagged candidate "drift" that turned out to be false positives on closer reading — recording the verified truth so it is not re-flagged:

- **Publishable crates = 17.** `docs/release.md`'s "17 publishable crates" is the deliberate crates.io release set and matches EXACTLY the 17 crates lacking `publish = false` (the wasm bindings, bench, py, zk/mpc/fed/canon/etc. all carry `publish = false`). Not stale; not touched.
- **ZK circuit members = 27.** `skills/zk-query-proofs/SKILL.md` §"Honest scope" already enumerates all 27 compiled members (scan ×8, filter_int ×4, filter_f64 ×4, filter_signed_int ×2, filter_decimal ×1, join_eq ×4, revoke/hidden_issuer/holder_pok/holder_set), matching `crates/sparq-zk-compose/tests/gate_count_snapshot.json`. Not touched.
- **`forbid(unsafe_code)` = 31 crates** — compliance docs already correct.
- **SHACL floor = 90** (`bench/coverage-floor.json`); SKILL's "98/98 core suite" carries a reproduce command.

## Beads / from-pss

- Stale-DONE sweep: all recently-merged beads (sq-gb4o, sq-pvg2, sq-8uew, sq-k5qq, sq-ja92, sq-7lrq, sq-f8gu, sq-yzca, …) are already CLOSED. No conservative close warranted this round.
- `sq-bif` epic is NOT closeable — `sq-bif.6` (sparq-zk-compose glue tests; verified build/driver/toml still carry 0 `#[cfg(test)]` blocks on main) is open and `sq-bif.14` is in_progress.
- from-pss: only #53 (publish prerequisites → sq-c4ej/sq-4w4m/sq-1n7) and #55 (sparq-solid research track → sq-t58w.*) remain open; both are genuinely open with bead coverage. No close.
- No new beads; no scratch/HANDOVER docs or markdown TODO violations found.

ZK/MPC remain research-grade / not externally audited (sq-qhy4 pending); work-box numbers are non-canonical. No auto-merge.

🤖 SPARQ agent