### PR TITLE
test(sparq-zk-compose): glue unit tests for build/driver/toml (circuit-id, subprocess error, witness TOML) (sq-bif.6) [OPUS-4.8]

### DIFF
--- a/crates/sparq-zk-compose/README.md
+++ b/crates/sparq-zk-compose/README.md
@@ -25,24 +25,6 @@ How-to + the covered/deferred matrix: [`skills/zk-query-proofs/SKILL.md`](../../
 Benchmarks (gate counts, timing): [`bench/zk-compose/`](../../bench/zk-compose).
 Contributing: [`AGENTS.md`](../../AGENTS.md).
 
-## Testing
-
-Two layers:
-
-- **Toolchain-free glue unit tests** (fast, run by default `cargo test`): the
-  `#[cfg(test)]` modules in `build.rs` / `driver.rs` / `toml.rs` exercise the
-  NON-cryptographic composition plumbing — circuit-family id derivation
-  (`derive_*_id`: smallest-fitting bucket, EXACT digit-count discipline,
-  out-of-family `None` never a wrong member, package-name determinism), the
-  nargo/bb subprocess wrapper's typed error classification (`Spawn` vs `Tool`
-  vs `Io`) and tag-based witness-path isolation, and `Prover.toml` witness
-  serialization (`FieldHex` hex round-trip, scalar-vs-array shape, declaration
-  order, the recoverable missing-witness error arms). These assert nothing about
-  in-circuit soundness or any privacy property — the verifier is **not-yet-sound**
-  (see the caveat above, sq-qhy4).
-- **Toolchain e2e tests** (`tests/`): the real prove/verify path via nargo/bb,
-  which skip cleanly when the toolchain is absent from `PATH`.
-
 ## License
 
 [MIT](../../LICENSE).

--- a/crates/sparq-zk-compose/README.md
+++ b/crates/sparq-zk-compose/README.md
@@ -25,6 +25,24 @@ How-to + the covered/deferred matrix: [`skills/zk-query-proofs/SKILL.md`](../../
 Benchmarks (gate counts, timing): [`bench/zk-compose/`](../../bench/zk-compose).
 Contributing: [`AGENTS.md`](../../AGENTS.md).
 
+## Testing
+
+Two layers:
+
+- **Toolchain-free glue unit tests** (fast, run by default `cargo test`): the
+  `#[cfg(test)]` modules in `build.rs` / `driver.rs` / `toml.rs` exercise the
+  NON-cryptographic composition plumbing — circuit-family id derivation
+  (`derive_*_id`: smallest-fitting bucket, EXACT digit-count discipline,
+  out-of-family `None` never a wrong member, package-name determinism), the
+  nargo/bb subprocess wrapper's typed error classification (`Spawn` vs `Tool`
+  vs `Io`) and tag-based witness-path isolation, and `Prover.toml` witness
+  serialization (`FieldHex` hex round-trip, scalar-vs-array shape, declaration
+  order, the recoverable missing-witness error arms). These assert nothing about
+  in-circuit soundness or any privacy property — the verifier is **not-yet-sound**
+  (see the caveat above, sq-qhy4).
+- **Toolchain e2e tests** (`tests/`): the real prove/verify path via nargo/bb,
+  which skip cleanly when the toolchain is absent from `PATH`.
+
 ## License
 
 [MIT](../../LICENSE).

--- a/crates/sparq-zk-compose/src/build.rs
+++ b/crates/sparq-zk-compose/src/build.rs
@@ -758,3 +758,251 @@ pub fn build_join(
         },
     })
 }
+
+// [OPUS-4.8] sq-bif.6: GLUE unit tests for the circuit-family id derivation —
+// the (data shape -> compiled member) plumbing the prover AND verifier both call
+// so a proof can only fit its member. These cover the NON-cryptographic
+// composition logic ONLY (bucket selection, exact-digit-count discipline,
+// out-of-family rejection, package-name determinism); they assert NOTHING about
+// in-circuit soundness or any privacy guarantee (the verifier remains NOT-yet-sound,
+// sq-qhy4 — external accredited-cryptographer sign-off pending).
+#[cfg(test)]
+mod derive_id_tests {
+    use super::*;
+
+    // --- scan (k, n, r) bucket lattice -----------------------------------
+
+    /// `derive_scan_id` maps the largest-graph size / disclosed-row count to the
+    /// SMALLEST compiled bucket that fits, and the result is deterministic.
+    #[test]
+    fn scan_id_picks_smallest_fitting_bucket_and_is_deterministic() {
+        // n picks 16 for <=16 triples, 64 for 17..=64. r picks 4 for <=4, 8 for 5..=8.
+        let id = derive_scan_id(1, 10, 3).expect("10<=16, 3<=4 fits");
+        assert_eq!(id, CircuitId::Scan { k: 1, n: 16, r: 4 });
+        // Exactly-N (the bucket boundary) selects that bucket, not the next.
+        assert_eq!(
+            derive_scan_id(2, 16, 4),
+            Some(CircuitId::Scan { k: 2, n: 16, r: 4 }),
+            "max_graph == 16 and match_rows == 4 fit the {{16,4}} bucket exactly"
+        );
+        // One over a boundary rolls up to the next compiled bucket.
+        assert_eq!(
+            derive_scan_id(1, 17, 5),
+            Some(CircuitId::Scan { k: 1, n: 64, r: 8 }),
+            "17 triples needs n=64; 5 rows needs r=8"
+        );
+        // Determinism: same inputs -> identical id across repeated calls.
+        assert_eq!(derive_scan_id(2, 64, 8), derive_scan_id(2, 64, 8));
+    }
+
+    /// A zero size / zero match-count is clamped to the smallest live bucket
+    /// (the circuit always commits at least one slot / discloses at least the
+    /// padded row word), not rejected.
+    #[test]
+    fn scan_id_clamps_zero_to_smallest_bucket() {
+        assert_eq!(
+            derive_scan_id(1, 0, 0),
+            Some(CircuitId::Scan { k: 1, n: 16, r: 4 }),
+            "max_graph/match_rows clamp up to 1, selecting the smallest bucket"
+        );
+    }
+
+    /// Out-of-family inputs return `None` (a clean error at the call site),
+    /// never a wrong member: an uncompiled `k`, or a size past every bucket.
+    #[test]
+    fn scan_id_out_of_family_is_none() {
+        assert!(derive_scan_id(3, 10, 3).is_none(), "k=3 is not compiled");
+        assert!(derive_scan_id(0, 10, 3).is_none(), "k=0 is not compiled");
+        assert!(
+            derive_scan_id(1, 65, 3).is_none(),
+            "65 triples exceeds the largest n bucket (64)"
+        );
+        assert!(
+            derive_scan_id(1, 10, 9).is_none(),
+            "9 rows exceeds the largest r bucket (8)"
+        );
+    }
+
+    // --- filter_int / filter_f64 EXACT digit-count discipline (sq-wto) ----
+
+    /// `derive_filter_int_id` is an EXACT digit-count match: every compiled D in
+    /// `FILTER_INT_D_VALUES` yields its own member; the count drives the id.
+    #[test]
+    fn filter_int_id_exact_match_per_compiled_digit_count() {
+        for &d in FILTER_INT_D_VALUES {
+            assert_eq!(
+                derive_filter_int_id(d),
+                Some(CircuitId::FilterInt { d }),
+                "compiled D={} derives its own filter_int member",
+                d
+            );
+        }
+        // 0 clamps to the 1-digit canonical form ("0").
+        assert_eq!(derive_filter_int_id(0), Some(CircuitId::FilterInt { d: 1 }));
+    }
+
+    /// The sq-wto correctness invariant: an out-of-family digit count returns
+    /// `None` — NOT the next-larger member (which would be silently unprovable
+    /// because the `digits: [u8; D]` witness pins the count to D exactly).
+    #[test]
+    fn filter_int_id_out_of_family_is_none_not_wrong_d() {
+        // 5 is the first count past the compiled 1..=4 range — the regression
+        // the differential fuzzer (sq-61g) caught: 5 must NOT derive d=anything.
+        assert_eq!(derive_filter_int_id(5), None, "d=5 has no member (sq-wto)");
+        for d in [6u32, 10, 19, 20, 100] {
+            assert!(
+                derive_filter_int_id(d).is_none(),
+                "out-of-family digit count {} must return None, never a wrong-D member",
+                d
+            );
+        }
+    }
+
+    /// `filter_f64` shares the EXACT-match discipline with `filter_int`.
+    #[test]
+    fn filter_f64_id_exact_match_and_out_of_family_none() {
+        for &d in FILTER_F64_D_VALUES {
+            assert_eq!(derive_filter_f64_id(d), Some(CircuitId::FilterF64 { d }));
+        }
+        assert_eq!(derive_filter_f64_id(0), Some(CircuitId::FilterF64 { d: 1 }));
+        assert_eq!(derive_filter_f64_id(5), None, "no f64 member past the compiled range");
+        assert!(derive_filter_f64_id(16).is_none(), "16 digits is past the f64 family");
+    }
+
+    // --- filter_signed_int (md magnitude-digit) ---------------------------
+
+    /// `derive_filter_signed_int_id` is an EXACT magnitude-digit-count match over
+    /// the compiled `{2, 4}` set; the IN-RANGE gap (3) and out-of-family counts
+    /// both return `None` (never a wrong-MD member).
+    #[test]
+    fn filter_signed_int_id_exact_match_with_gap() {
+        for &md in FILTER_SIGNED_INT_MD_VALUES {
+            assert_eq!(
+                derive_filter_signed_int_id(md),
+                Some(CircuitId::FilterSignedInt { md })
+            );
+        }
+        // 3 is INSIDE [2,4] numerically but is NOT a compiled member — exact match.
+        assert_eq!(
+            derive_filter_signed_int_id(3),
+            None,
+            "md=3 is not compiled ({{2,4}} only); exact match returns None, not md=4"
+        );
+        // 1 clamps from 0 but is also uncompiled.
+        assert_eq!(derive_filter_signed_int_id(0), None, "md clamps to 1, which is uncompiled");
+        assert!(derive_filter_signed_int_id(5).is_none(), "md=5 out of family");
+    }
+
+    // --- filter_decimal (id, fd) pair ------------------------------------
+
+    /// `derive_filter_decimal_id` matches the `(int_digits, frac_digits)` PAIR
+    /// exactly against the compiled set; a wrong integer OR fraction count gives
+    /// `None`.
+    #[test]
+    fn filter_decimal_id_exact_pair_match() {
+        for &(id, fd) in FILTER_DECIMAL_ID_FD_VALUES {
+            assert_eq!(
+                derive_filter_decimal_id(id, fd),
+                Some(CircuitId::FilterDecimal { id, fd }),
+                "compiled ({},{}) pair derives its member",
+                id,
+                fd
+            );
+        }
+        // The lone compiled member is (3, 2). Either coordinate off => None.
+        assert_eq!(derive_filter_decimal_id(3, 2), Some(CircuitId::FilterDecimal { id: 3, fd: 2 }));
+        assert_eq!(derive_filter_decimal_id(2, 2), None, "wrong integer-digit count");
+        assert_eq!(derive_filter_decimal_id(3, 3), None, "wrong fraction-digit count");
+        assert_eq!(derive_filter_decimal_id(4, 2), None, "wrong integer-digit count");
+        // int_digits clamps to >=1 (canonical "0.xx" has one integer digit).
+        assert_eq!(
+            derive_filter_decimal_id(0, 2),
+            None,
+            "id clamps to 1; (1,2) is not the compiled (3,2) member"
+        );
+    }
+
+    // --- join_eq (n_a, n_b) bucket pair ----------------------------------
+
+    /// `derive_join_eq_id` selects the smallest fitting `JOIN_EQ_N_BUCKETS` bucket
+    /// for EACH side independently (mirrors the scan n-bucket discipline), so the
+    /// four `(16|64, 16|64)` combinations are all reachable.
+    #[test]
+    fn join_eq_id_buckets_each_side_independently() {
+        assert_eq!(derive_join_eq_id(10, 10), Some(CircuitId::JoinEq { n_a: 16, n_b: 16 }));
+        assert_eq!(derive_join_eq_id(16, 64), Some(CircuitId::JoinEq { n_a: 16, n_b: 64 }));
+        assert_eq!(derive_join_eq_id(64, 16), Some(CircuitId::JoinEq { n_a: 64, n_b: 16 }));
+        assert_eq!(derive_join_eq_id(17, 50), Some(CircuitId::JoinEq { n_a: 64, n_b: 64 }));
+        // Exactly-N boundary selects that bucket.
+        assert_eq!(derive_join_eq_id(16, 16), Some(CircuitId::JoinEq { n_a: 16, n_b: 16 }));
+        // Clamp zero to the smallest bucket on either side.
+        assert_eq!(derive_join_eq_id(0, 0), Some(CircuitId::JoinEq { n_a: 16, n_b: 16 }));
+    }
+
+    /// Either side past every compiled bucket returns `None`, never a wrong-N member.
+    #[test]
+    fn join_eq_id_out_of_family_is_none() {
+        assert!(derive_join_eq_id(65, 16).is_none(), "n_a=65 exceeds the largest bucket");
+        assert!(derive_join_eq_id(16, 65).is_none(), "n_b=65 exceeds the largest bucket");
+    }
+
+    // --- package() name determinism + distinctness -----------------------
+
+    /// `CircuitId::package()` is a pure, deterministic function of the id, and it
+    /// names DISTINCT members for distinct (family × bucket) ids — the property
+    /// the driver relies on to locate the right `zk/compose/<pkg>` directory.
+    #[test]
+    fn package_names_are_deterministic_and_distinct_per_family_and_bucket() {
+        let ids = [
+            CircuitId::Scan { k: 1, n: 16, r: 4 },
+            CircuitId::Scan { k: 2, n: 16, r: 4 },
+            CircuitId::Scan { k: 1, n: 64, r: 4 },
+            CircuitId::Scan { k: 1, n: 16, r: 8 },
+            CircuitId::FilterInt { d: 1 },
+            CircuitId::FilterInt { d: 4 },
+            CircuitId::FilterF64 { d: 1 },
+            CircuitId::FilterSignedInt { md: 2 },
+            CircuitId::FilterDecimal { id: 3, fd: 2 },
+            CircuitId::JoinEq { n_a: 16, n_b: 64 },
+            CircuitId::JoinEq { n_a: 64, n_b: 16 },
+        ];
+        // Deterministic: the same id renders the same package name every call.
+        for id in &ids {
+            assert_eq!(id.package(), id.package(), "package() is pure");
+        }
+        // Distinct: no two distinct ids collide on a package name (one directory
+        // per member — a collision would prove the wrong relation under a shared dir).
+        let mut names: Vec<String> = ids.iter().map(|i| i.package()).collect();
+        let total = names.len();
+        names.sort();
+        names.dedup();
+        assert_eq!(names.len(), total, "every distinct id maps to a distinct package dir");
+        // Spot-check the exact wire names the zk/compose/ directories use.
+        assert_eq!(CircuitId::Scan { k: 2, n: 64, r: 8 }.package(), "scan_k2_n64_r8");
+        assert_eq!(CircuitId::FilterInt { d: 3 }.package(), "filter_int_d3");
+        assert_eq!(CircuitId::FilterF64 { d: 2 }.package(), "filter_f64_d2");
+        assert_eq!(CircuitId::FilterSignedInt { md: 4 }.package(), "filter_signed_int_d4");
+        assert_eq!(CircuitId::FilterDecimal { id: 3, fd: 2 }.package(), "filter_decimal_i3_f2");
+        assert_eq!(CircuitId::JoinEq { n_a: 64, n_b: 64 }.package(), "join_eq_na64_nb64");
+    }
+
+    /// The scan / filter_int builders thread the SAME derive-id discipline: the
+    /// id carried in the built `ProofInputs` equals the id `derive_*` returns for
+    /// the same shape, and an out-of-family operand makes the whole build `None`.
+    #[test]
+    fn builders_carry_the_derived_id_and_propagate_out_of_family_none() {
+        // A 3-digit operand builds the filter_int_d3 member.
+        let enc = encode_int_literal(123);
+        let (inputs, digits) =
+            build_filter_int(enc, 123, FilterOp::Gt, 100, true).expect("3-digit operand has d3");
+        assert_eq!(*inputs.circuit_id(), CircuitId::FilterInt { d: 3 });
+        assert_eq!(digits, b"123", "digit witness is the canonical decimal bytes");
+        // A 5-digit operand is out of family -> the builder returns None (sq-wto),
+        // exactly as derive_filter_int_id(5) does.
+        let enc5 = encode_int_literal(12345);
+        assert!(
+            build_filter_int(enc5, 12345, FilterOp::Lt, 0, false).is_none(),
+            "5-digit operand: out-of-family build is None, never a wrong-D witness"
+        );
+    }
+}

--- a/crates/sparq-zk-compose/src/driver.rs
+++ b/crates/sparq-zk-compose/src/driver.rs
@@ -314,3 +314,153 @@ fn run(tool: &str, cmd: &mut Command) -> Result<(), DriverError> {
     }
     Ok(())
 }
+
+// [OPUS-4.8] sq-bif.6: GLUE unit tests for the nargo/bb subprocess wrapper's
+// ERROR-classification + tag-based path isolation. These are toolchain-FREE: they
+// drive the error arms with a guaranteed-absent binary (the `Spawn` arm) and a
+// real-but-failing binary (the `Tool` arm), and check the tag-isolation file-naming
+// glue against a scratch dir — NO nargo/bb proving, NO cryptographic claim. The
+// real proving e2e lives in `tests/e2e.rs`, gated on the toolchain being present.
+#[cfg(test)]
+mod driver_glue_tests {
+    use super::*;
+
+    /// A name no executable on a sane PATH resolves to — drives the `Spawn` arm
+    /// (`std::io::Error` from a failed `fork`/`exec`) deterministically, with or
+    /// without the nargo/bb toolchain installed.
+    const ABSENT_TOOL: &str = "sparq-zk-compose-no-such-tool-xyzzy";
+    /// A binary that EXISTS but always exits non-zero — drives the `Tool` arm
+    /// (the process ran but reported failure). POSIX `false` is universally present.
+    const FAILING_TOOL: &str = "/usr/bin/false";
+
+    // --- error classification: the `run` helper --------------------------
+
+    /// Spawning a non-existent tool is classified as `DriverError::Spawn` (a typed
+    /// error carrying the io source), NOT a panic / unwrap. This is the contract the
+    /// public `compile`/`prove`/`canonical_vk` wrappers rely on.
+    #[test]
+    fn run_missing_tool_is_spawn_error_not_panic() {
+        let err = run(ABSENT_TOOL, &mut Command::new(ABSENT_TOOL))
+            .expect_err("a non-existent tool must surface an error, never spawn");
+        match err {
+            DriverError::Spawn { tool, source } => {
+                assert_eq!(tool, ABSENT_TOOL, "the Spawn error names the failing tool");
+                // The io source is NotFound (the binary is not on PATH).
+                assert_eq!(source.kind(), std::io::ErrorKind::NotFound);
+            }
+            other => panic!("expected Spawn classification, got {:?}", other),
+        }
+    }
+
+    /// A tool that runs but exits non-zero is classified as `DriverError::Tool`
+    /// (distinct from `Spawn`) and carries the tool name. `false` writes nothing to
+    /// stderr, so the captured stderr is empty — the glue still classifies on the
+    /// exit status, not on stderr content.
+    #[test]
+    fn run_failing_tool_is_tool_error_distinct_from_spawn() {
+        let err = run("false", &mut Command::new(FAILING_TOOL))
+            .expect_err("a non-zero exit must be an error");
+        match err {
+            DriverError::Tool { tool, stderr } => {
+                assert_eq!(tool, "false", "the Tool error names the failing tool");
+                assert!(stderr.is_empty(), "`false` emits no stderr");
+            }
+            other => panic!("expected Tool classification, got {:?}", other),
+        }
+    }
+
+    /// A tool that exists and exits zero is `Ok(())` — the success arm of the same
+    /// classifier (so the error tests above are not vacuously always-erroring).
+    #[test]
+    fn run_succeeding_tool_is_ok() {
+        run("true", &mut Command::new("/usr/bin/true")).expect("exit 0 is Ok");
+    }
+
+    // --- Display + From glue ---------------------------------------------
+
+    /// Each `DriverError` variant renders a distinct, human-readable message that
+    /// names its tool / cause — the operator-facing surface the CLI prints.
+    #[test]
+    fn display_renders_each_variant_distinctly() {
+        let spawn = DriverError::Spawn {
+            tool: "nargo".into(),
+            source: std::io::Error::new(std::io::ErrorKind::NotFound, "not found"),
+        };
+        let tool = DriverError::Tool {
+            tool: "bb".into(),
+            stderr: "boom".into(),
+        };
+        let io = DriverError::Io(std::io::Error::other("disk full"));
+        let s_msg = spawn.to_string();
+        let t_msg = tool.to_string();
+        let io_msg = io.to_string();
+        assert!(s_msg.contains("spawn") && s_msg.contains("nargo"), "Spawn names the tool");
+        assert!(t_msg.contains("bb") && t_msg.contains("boom"), "Tool carries name + stderr");
+        assert!(io_msg.contains("io error") && io_msg.contains("disk full"));
+        // The three renderings are mutually distinct (no two variants collide).
+        assert_ne!(s_msg, t_msg);
+        assert_ne!(t_msg, io_msg);
+        assert_ne!(s_msg, io_msg);
+    }
+
+    /// `?` on a bare `std::io::Error` lands in the `Io` arm via the `From` impl
+    /// (the `std::fs::read`/`write`/`create_dir_all` calls in `prove`/`verify_with`
+    /// rely on this conversion).
+    #[test]
+    fn io_error_converts_into_io_variant() {
+        let e: DriverError = std::io::Error::new(std::io::ErrorKind::PermissionDenied, "nope").into();
+        match e {
+            DriverError::Io(inner) => assert_eq!(inner.kind(), std::io::ErrorKind::PermissionDenied),
+            other => panic!("io::Error must convert to DriverError::Io, got {:?}", other),
+        }
+    }
+
+    // --- tag-based witness-path isolation --------------------------------
+
+    /// The tag-isolation glue (roborev codex job 2180): a non-empty `tag` MUST route
+    /// the prover-input toml AND the emitted witness to per-call-unique paths so two
+    /// concurrent witness generations against the SAME member cannot clobber each
+    /// other's `Prover.toml` / `target/<pkg>_w.gz`. We verify this WITHOUT a real
+    /// toolchain: `gen_witness_tagged` writes the toml BEFORE spawning nargo, so even
+    /// though `nargo execute` then fails (no compiled member in this scratch dir), the
+    /// two tags leave two DISTINCT, COEXISTING toml files — the collision-avoidance
+    /// property. The failure is the typed `Tool` error (no witness produced), never a
+    /// panic, and its message names the per-tag witness file.
+    #[test]
+    fn tagged_witness_paths_do_not_collide() {
+        let tmp = std::env::temp_dir().join(format!("sq-bif6-driver-{}", std::process::id()));
+        let id = CircuitId::FilterInt { d: 1 };
+        let pkg = id.package();
+        // The package dir must exist for the toml write to land.
+        std::fs::create_dir_all(tmp.join(&pkg)).expect("scratch package dir");
+        std::fs::create_dir_all(tmp.join("target")).expect("scratch target dir");
+        let prover = CircuitProver::new(&tmp);
+
+        // Two distinct tags -> two distinct prover-input toml files in the package
+        // dir. If `nargo` is absent this is a Spawn error AFTER the toml write; if
+        // present it is a Tool error (no member compiled) — either way the toml is
+        // written first, which is the isolation behaviour we assert.
+        let r_a = prover.gen_witness_tagged(&id, "challenge = \"0x1\"\n", "taga");
+        let r_b = prover.gen_witness_tagged(&id, "challenge = \"0x2\"\n", "tagb");
+        assert!(r_a.is_err() && r_b.is_err(), "no real witness without the toolchain");
+
+        let toml_a = tmp.join(&pkg).join("Prover_taga.toml");
+        let toml_b = tmp.join(&pkg).join("Prover_tagb.toml");
+        assert!(toml_a.exists(), "tag `taga` wrote its own Prover_taga.toml");
+        assert!(toml_b.exists(), "tag `tagb` wrote its own Prover_tagb.toml");
+        assert_ne!(toml_a, toml_b, "the two tags use distinct toml paths");
+        // The two inputs coexist with their original, non-clobbered contents — the
+        // collision the tag isolation prevents.
+        assert_eq!(std::fs::read_to_string(&toml_a).unwrap(), "challenge = \"0x1\"\n");
+        assert_eq!(std::fs::read_to_string(&toml_b).unwrap(), "challenge = \"0x2\"\n");
+
+        // The empty tag uses the LEGACY shared `Prover.toml` name (distinct from any
+        // tagged name), so a tagged call never overwrites the untagged one.
+        let _ = prover.gen_witness_tagged(&id, "challenge = \"0x3\"\n", "");
+        let toml_shared = tmp.join(&pkg).join("Prover.toml");
+        assert!(toml_shared.exists(), "empty tag uses the shared Prover.toml name");
+        assert_ne!(toml_shared, toml_a, "shared name differs from a tagged name");
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+}

--- a/crates/sparq-zk-compose/src/toml.rs
+++ b/crates/sparq-zk-compose/src/toml.rs
@@ -543,3 +543,280 @@ pub fn prover_toml_for(
     };
     Ok(out)
 }
+
+// [OPUS-4.8] sq-bif.6: GLUE unit tests for the witness `Prover.toml` SERIALIZATION
+// — the `FieldHex` hex round-trip, the array-vs-scalar rendering shape, the
+// declaration-order field layout each `*_prover_toml` emits, and the recoverable
+// missing-witness error arms of the public `prover_toml_for`. These cover the
+// NON-cryptographic serialization plumbing ONLY; no soundness / privacy property is
+// asserted (the circuit family is NOT-yet-sound, sq-qhy4). The real prove/verify
+// e2e lives in `tests/e2e.rs`, gated on the nargo/bb toolchain.
+#[cfg(test)]
+mod toml_glue_tests {
+    use super::*;
+    use crate::build::FilterSignedWitness;
+    use crate::manifest::FilterOp;
+    use sparq_zk::field::Fr;
+
+    fn fh(s: &str) -> FieldHex {
+        FieldHex(s.to_string())
+    }
+
+    // --- FieldHex hex round-trip + rejection -----------------------------
+
+    /// `FieldHex` round-trips through the field: `from_field(to_field) == self`
+    /// (canonicalised), and a value re-rendered is byte-stable. This is the
+    /// representation every `*_prover_toml` writes verbatim, so its round-trip is
+    /// load-bearing for the witness contract.
+    #[test]
+    fn field_hex_round_trips_through_the_field() {
+        let f = Fr::from(0x1a2bu64);
+        let hex = FieldHex::from_field(&f);
+        // The canonical rendering is 0x-prefixed 64-nibble hex.
+        assert!(hex.0.starts_with("0x") && hex.0.len() == 66, "canonical 0x + 64 nibbles");
+        // Parse back to the same field element.
+        assert_eq!(hex.to_field(), Some(f), "to_field inverts from_field");
+        // Re-rendering the parsed field is byte-identical (idempotent canonical form).
+        assert_eq!(FieldHex::from_field(&hex.to_field().unwrap()), hex);
+        // A short, non-canonical literal parses to the SAME field element (the
+        // circuit reduces 0x-hex), so the toml may carry either form.
+        assert_eq!(fh("0x1a2b").to_field(), Some(f));
+    }
+
+    /// Malformed hex returns `None` from `to_field` — the parse never panics, so a
+    /// hand-edited / corrupt manifest surfaces a recoverable error.
+    #[test]
+    fn field_hex_rejects_malformed_input() {
+        assert_eq!(fh("0xzz").to_field(), None, "non-hex digits rejected");
+        assert_eq!(fh("").to_field(), None, "empty rejected");
+        assert_eq!(fh(&format!("0x{}", "f".repeat(65))).to_field(), None, "over-long rejected");
+    }
+
+    // --- scalar vs array rendering shape ---------------------------------
+
+    /// `filter_int_prover_toml` renders SCALARS as quoted Field literals and the
+    /// digit witness as an inline ARRAY of quoted bytes, in the declaration order
+    /// the `filter_int_d{d}` member's `main` expects.
+    #[test]
+    fn filter_int_toml_scalar_and_array_shape_and_order() {
+        let toml = filter_int_prover_toml(
+            &fh("0x1"),       // challenge
+            &fh("0xabc"),     // operand_enc
+            FilterOp::Gt.code(),
+            42,               // bound
+            true,             // expected
+            b"123",
+        );
+        // Scalars: quoted Field literals (nargo's toml reader accepts 0x-prefixed).
+        assert!(toml.contains("challenge = \"0x1\"\n"));
+        assert!(toml.contains("operand_enc = \"0xabc\"\n"));
+        assert!(toml.contains("op = \"2\"\n"), "FilterOp::Gt.code() == 2, rendered as a string");
+        assert!(toml.contains("bound = \"42\"\n"), "u64 bound is a quoted Field");
+        // expected is a BARE bool (not quoted) — the circuit's `pub bool`.
+        assert!(toml.contains("expected = true\n"));
+        // digits: an inline array of quoted ASCII codepoints, one per decimal digit.
+        assert!(toml.contains("digits = [\"49\", \"50\", \"51\"]\n"), "b'1'=49, b'2'=50, b'3'=51");
+        // Declaration order: challenge < operand_enc < op < bound < expected < digits.
+        let order: Vec<&str> = ["challenge", "operand_enc", "op", "bound", "expected", "digits"]
+            .iter()
+            .map(|k| {
+                let pat = format!("{} =", k);
+                assert!(toml.contains(&pat), "field `{}` present", k);
+                *k
+            })
+            .collect();
+        let positions: Vec<usize> = order
+            .iter()
+            .map(|k| toml.find(&format!("{} =", k)).unwrap())
+            .collect();
+        assert!(positions.windows(2).all(|w| w[0] < w[1]), "fields in declaration order");
+    }
+
+    /// `scan_prover_toml` renders the nested `enc` as `[[[..];3];N];K]` and emits
+    /// the bool vectors (`pattern_is_const`, `attribution`) as BARE-bool arrays —
+    /// the array-shape contract the scan member's `main` consumes.
+    #[test]
+    fn scan_toml_nested_array_and_bool_array_shape() {
+        let commitments = [fh("0xc0"), fh("0xc1")];
+        let pattern_is_const = [true, false, true];
+        let pattern_const_enc = [fh("0xs"), fh("0x0"), fh("0xo")];
+        let rows = [[fh("0x1"), fh("0x2"), fh("0x3")]];
+        let attribution = [true, false];
+        let counts = [2u32, 1u32];
+        let g0 = vec![[fh("0xa"), fh("0xb"), fh("0xc")], [fh("0xd"), fh("0xe"), fh("0xf")]];
+        let g1 = vec![[fh("0x4"), fh("0x5"), fh("0x6")]];
+        let enc = [g0, g1];
+        let toml = scan_prover_toml(
+            &fh("0x9"),
+            &commitments,
+            &pattern_is_const,
+            &pattern_const_enc,
+            &rows,
+            1,
+            &attribution,
+            &counts,
+            &enc,
+        );
+        // commitments: flat array of quoted Fields.
+        assert!(toml.contains("commitments = [\"0xc0\", \"0xc1\"]\n"));
+        // pattern_is_const + attribution: BARE bools (not quoted).
+        assert!(toml.contains("pattern_is_const = [true, false, true]\n"));
+        assert!(toml.contains("attribution = [true, false]\n"));
+        // row_count + counts: quoted Field-ish.
+        assert!(toml.contains("row_count = \"1\"\n"));
+        assert!(toml.contains("counts = [\"2\", \"1\"]\n"));
+        // rows: [[Field;3]] — one inner triple here.
+        assert!(toml.contains("rows = [[\"0x1\", \"0x2\", \"0x3\"]]\n"));
+        // enc: [[[Field;3];N];K] — two graphs, the first with two triples.
+        assert!(
+            toml.contains(
+                "enc = [[[\"0xa\", \"0xb\", \"0xc\"], [\"0xd\", \"0xe\", \"0xf\"]], \
+                 [[\"0x4\", \"0x5\", \"0x6\"]]]\n"
+            ),
+            "nested K-by-N-by-3 array; toml was:\n{}",
+            toml
+        );
+    }
+
+    /// `filter_signed_int_prover_toml` and `filter_decimal_prover_toml` render the
+    /// PRIVATE `neg` flag as a bare bool and the magnitude / int / frac digit arrays
+    /// in the member's declaration order (the sq-7lrq members).
+    #[test]
+    fn signed_and_decimal_toml_shape_and_order() {
+        let signed = filter_signed_int_prover_toml(
+            &fh("0x1"),
+            &fh("0xop"),
+            FilterOp::Lt.code(),
+            true,     // bound_neg
+            7,        // bound magnitude
+            false,    // expected
+            true,     // neg (operand)
+            b"42",
+        );
+        assert!(signed.contains("bound_neg = true\n"), "bound sign is a bare bool");
+        assert!(signed.contains("bound = \"7\"\n"));
+        assert!(signed.contains("neg = true\n"), "operand sign is a bare bool");
+        assert!(signed.contains("mag_digits = [\"52\", \"50\"]\n"), "b'4'=52, b'2'=50");
+
+        let decimal = filter_decimal_prover_toml(
+            &fh("0x1"),
+            &fh("0xop"),
+            FilterOp::Ge.code(),
+            false,    // bound_neg
+            12345,    // bound_scaled
+            true,     // expected
+            false,    // neg
+            b"123",
+            b"45",
+        );
+        assert!(decimal.contains("bound_scaled = \"12345\"\n"));
+        assert!(decimal.contains("int_digits = [\"49\", \"50\", \"51\"]\n"));
+        assert!(decimal.contains("frac_digits = [\"52\", \"53\"]\n"));
+    }
+
+    // --- pad / canonical-digits helpers ----------------------------------
+
+    /// `pad_hex` / `pad_rows` extend to the member's bucket length with ZERO field
+    /// elements (the circuit's inactive padding slots) and never truncate.
+    #[test]
+    fn pad_helpers_extend_with_zero_and_never_truncate() {
+        let padded = pad_hex(vec![fh("0x1")], 3);
+        assert_eq!(padded.len(), 3);
+        assert_eq!(padded[0], fh("0x1"));
+        assert_eq!(padded[1], FieldHex("0x0".to_string()), "pad slot is the zero field element");
+        // Already-long input is left intact (no truncation).
+        let same = pad_hex(vec![fh("0xa"), fh("0xb")], 1);
+        assert_eq!(same.len(), 2, "pad_hex never shortens");
+
+        let rows = pad_rows(vec![[fh("0x1"), fh("0x2"), fh("0x3")]], 2);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[1], [FieldHex("0x0".into()), FieldHex("0x0".into()), FieldHex("0x0".into())]);
+    }
+
+    /// `canonical_digits` is the ASCII-decimal byte witness the digit arrays carry.
+    #[test]
+    fn canonical_digits_are_ascii_decimal_bytes() {
+        assert_eq!(canonical_digits(0), b"0");
+        assert_eq!(canonical_digits(1234), b"1234");
+        assert_eq!(canonical_digits(u64::MAX), u64::MAX.to_string().as_bytes());
+    }
+
+    // --- prover_toml_for: dispatch + recoverable missing-witness errors --
+
+    /// `prover_toml_for` on a `FilterInt` input returns the member id + a toml that
+    /// matches the direct `filter_int_prover_toml` rendering — the public dispatcher
+    /// agrees with the per-member renderer.
+    #[test]
+    fn prover_toml_for_filter_int_dispatches_to_member_renderer() {
+        let inputs = ProofInputs::FilterInt {
+            id: CircuitId::FilterInt { d: 2 },
+            operand_enc: fh("0xab"),
+            op: FilterOp::Eq,
+            bound: 50,
+            expected: true,
+        };
+        let (id, toml) =
+            prover_toml_for(&inputs, &fh("0x1"), &[], &[], b"50", None, None)
+                .expect("filter_int needs no extra witness");
+        assert_eq!(id, CircuitId::FilterInt { d: 2 });
+        let direct = filter_int_prover_toml(&fh("0x1"), &fh("0xab"), FilterOp::Eq.code(), 50, true, b"50");
+        assert_eq!(toml, direct, "dispatcher output matches the member renderer");
+    }
+
+    /// A `JoinEq` input WITHOUT its private `JoinWitness` returns the recoverable
+    /// `JoinEqMissingWitness` error — NOT a panic in this public fn (the witness
+    /// holds the join's private inputs the manifest never carries).
+    #[test]
+    fn prover_toml_for_join_eq_without_witness_is_recoverable_error() {
+        let inputs = ProofInputs::JoinEq {
+            id: CircuitId::JoinEq { n_a: 16, n_b: 16 },
+            commit_a: fh("0x0a"),
+            commit_b: fh("0x0b"),
+            join_commitment: fh("0x0c"),
+            slot_a: 0,
+            slot_b: 2,
+        };
+        let err = prover_toml_for(&inputs, &fh("0x1"), &[], &[], &[], None, None)
+            .expect_err("join_eq without its witness must be an Err, never a panic");
+        assert_eq!(err, ProverTomlError::JoinEqMissingWitness);
+        // And the message points the caller at build_join / the join_witness arg.
+        assert!(err.to_string().contains("build_join"), "the error message is actionable");
+    }
+
+    /// A `FilterSignedInt` / `FilterDecimal` input WITHOUT its `FilterSignedWitness`
+    /// returns the recoverable `FilterSignedMissingWitness` error (the sign flag +
+    /// canonical digits live in the witness, not the manifest).
+    #[test]
+    fn prover_toml_for_signed_without_witness_is_recoverable_error() {
+        let inputs = ProofInputs::FilterSignedInt {
+            id: CircuitId::FilterSignedInt { md: 2 },
+            operand_enc: fh("0xop"),
+            op: FilterOp::Lt,
+            bound_neg: false,
+            bound: 9,
+            expected: true,
+        };
+        let err = prover_toml_for(&inputs, &fh("0x1"), &[], &[], &[], None, None)
+            .expect_err("signed-int without its witness must be an Err");
+        assert_eq!(err, ProverTomlError::FilterSignedMissingWitness);
+
+        // Supplying the witness renders successfully and carries the operand sign.
+        let w = FilterSignedWitness { neg: true, int_digits: vec![b'4', b'2'], frac_digits: vec![] };
+        let (id, toml) = prover_toml_for(&inputs, &fh("0x1"), &[], &[], &[], None, Some(&w))
+            .expect("with witness it renders");
+        assert_eq!(id, CircuitId::FilterSignedInt { md: 2 });
+        assert!(toml.contains("neg = true\n") && toml.contains("mag_digits = [\"52\", \"50\"]\n"));
+    }
+
+    /// The two `ProverTomlError` variants render distinct, actionable messages and
+    /// compare by value (the public error is `PartialEq`).
+    #[test]
+    fn prover_toml_error_variants_are_distinct() {
+        let a = ProverTomlError::JoinEqMissingWitness;
+        let b = ProverTomlError::FilterSignedMissingWitness;
+        assert_ne!(a, b);
+        assert_ne!(a.to_string(), b.to_string());
+        assert!(a.to_string().contains("join_eq"));
+        assert!(b.to_string().contains("FilterSignedWitness"));
+    }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus 4.8, 1M context) — bead sq-bif.6.

Adds **29 toolchain-free GLUE unit tests** to `sparq-zk-compose` (the lowest-covered surface; ~1621 LOC across build/driver/toml previously exercised only via the slow nargo/bb e2e suite). These cover the **non-cryptographic composition plumbing only** — NO circuit/soundness change, and no privacy or soundness property is asserted (the verifier remains **not-yet-sound**, sq-qhy4; external accredited-cryptographer sign-off pending).

## Test areas (per file)

- **`src/build.rs` — `derive_id_tests` (12 tests): circuit-family id derivation.**
  - scan `(k,n,r)`: smallest-fitting bucket, exactly-N boundary, zero-clamp, out-of-family `None`.
  - `filter_int` / `filter_f64`: EXACT digit-count discipline — `d=5` returns `None`, never a wrong-D silently-unprovable member (the sq-wto / sq-61g regression).
  - `filter_signed_int`: in-range gap (`md=3` is between compiled `{2,4}` but returns `None`).
  - `filter_decimal`: `(int_digits, frac_digits)` PAIR match (either coordinate off → `None`).
  - `join_eq`: per-side independent bucketing across `{16,64}`; out-of-family `None`.
  - `CircuitId::package()` determinism + distinctness per (family × bucket).
  - `build_filter_int` builder propagates out-of-family `None`.

- **`src/driver.rs` — `driver_glue_tests` (6 tests): subprocess error classification.**
  - REAL `run()` helper: `Spawn` (absent tool) vs `Tool` (`/usr/bin/false` exits nonzero) vs the `Ok` success arm — typed errors, never a panic/unwrap.
  - `DriverError` `Display` per-variant distinctness; `From<io::Error>` → `Io`.
  - **Tag-based witness-path isolation**: distinct tags write distinct, coexisting `Prover_<tag>.toml` (no clobber) — verified against a scratch dir without the toolchain.

- **`src/toml.rs` — `toml_glue_tests` (11 tests): witness `Prover.toml` serialization.**
  - `FieldHex` hex round-trip (`from_field`∘`to_field`) + malformed/empty/over-long rejection.
  - Scalar-vs-array rendering shape + declaration order (filter_int; scan nested `[[[Field;3];N];K]` + bare-bool arrays; signed/decimal).
  - `pad_hex`/`pad_rows` zero-pad-never-truncate; `canonical_digits`.
  - `prover_toml_for` dispatch agreement + the recoverable `JoinEqMissingWitness` / `FilterSignedMissingWitness` error arms (no panic in a public fn).

All tests are non-vacuous (real assertions on determinism, exact-match, fail-closed `None`, typed-error classification, and golden TOML shapes).

## Scope / honesty

- Tests only — no production logic change. `#[cfg(test)]` modules inside `build.rs`/`driver.rs`/`toml.rs`.
- Strictly the build/driver/toml GLUE. No overlap with the held #637 decimal value-lane internals (tests target the stable glue API).
- No circuit, soundness, or cryptographic-claim change. Privacy-claims gate: every soundness/privacy mention is explicitly negated/caveated.
- The real prove/verify path stays in `tests/` (gated on the nargo/bb toolchain).

## Gates (both feature states)

This crate defines **no cargo features**, so default == `--all-features`; both run green:

- `cargo clippy -p sparq-zk-compose --all-targets -- -D warnings` — GREEN
- `cargo clippy -p sparq-zk-compose --all-targets --all-features -- -D warnings` — GREEN
- `cargo test -p sparq-zk-compose` — GREEN (full suite, toolchain present)
- `cargo test -p sparq-zk-compose --lib --all-features` — GREEN (97 lib tests, incl. the 29 new)

README updated with a short Testing note (glue layer vs toolchain e2e). No public API added, so `skills/zk-query-proofs/SKILL.md` is unchanged.