### PR TITLE
ci(release): refresh deprecated macos-13 runner pin (sq-v286.12) [OPUS-4.8]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -253,7 +253,11 @@ jobs:
           - runner: macos-latest
             target: aarch64-apple-darwin
             manylinux: ""
-          - runner: macos-13
+          # [OPUS-4.8] sq-v286.12: macos-13 was retired by GitHub. macos-15-intel is the
+          # supported Intel-Mac runner line (matches dist.yml + release.yml), so the
+          # x86_64-apple-darwin wheel arch is preserved — NOT macos-14/macos-latest, which
+          # are Apple silicon and would clash with the aarch64-apple-darwin line above.
+          - runner: macos-15-intel
             target: x86_64-apple-darwin
             manylinux: ""
           - runner: windows-latest


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-v286.12

## What
GitHub is retiring the `macos-13` runner image. `publish.yml`'s `pypi-build` matrix still pinned `macos-13` for the `x86_64-apple-darwin` wheel. This refreshes the stale pin to the supported runner.

**Before → after:** `runner: macos-13` → `runner: macos-15-intel` (for `target: x86_64-apple-darwin`).

## Why macos-15-intel (not macos-14 / macos-latest)
`macos-15-intel` is the supported **Intel-Mac** runner line, already the repo convention used by both `dist.yml` and `release.yml` for the `x86_64-apple-darwin` tier. Because it is an Intel runner, the **wheel architecture is preserved as `x86_64-apple-darwin`** — no arch change.

Choosing `macos-14`/`macos-latest` (Apple silicon) would have been wrong: it would build an **arm64** wheel, clashing with the existing `aarch64-apple-darwin` matrix line above it. #818 set up this matrix to ship one x86_64 + one aarch64 macOS wheel; that shape is intact.

## Scope / gates
- Scoped to the runner-image refresh — the only `runs-on`/`runner:` pin to `macos-13` in the repo (the other `macos-13` greps are comments documenting the retirement).
- No action SHA-pins touched (this changes a `runner:` value, not a `uses:` ref).
- Matrix shape unchanged: the wheel artifact name keys on `matrix.platform.target` (not the runner), and downstream `pypi-publish` consumes by target.
- YAML valid (`python3 -c "import yaml; yaml.safe_load(...)"`), `actionlint` clean.
- `publish.yml` triggers only on `release: published` + `workflow_dispatch` — it is **non-gating** on PRs, so the `ci-summary / gate` aggregator topology is unchanged.

## Maintainer note (arch)
No published-wheel arch change here — `x86_64-apple-darwin` stays `x86_64-apple-darwin`. Flagging for visibility since #818 established the dual-arch macOS wheel matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)