### PR TITLE
feat(site): JSON-LD syntax highlighting in editor/results (sq-ixc3.1) [OPUS-4.8]

### DIFF
--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -389,6 +389,17 @@ export {
   tokenizeTurtle,
 } from "./turtle-highlight.js";
 
+// [OPUS-4.8] sq-ixc3.1 — the JSON-LD highlighting tokenizer, the third sibling of
+// `tokenizeSparql`/`tokenizeTurtle`, completing the data-formats picker's set. JSON-LD is JSON,
+// so this is a small forgiving JSON lexer (keys / string values / numbers / `true`/`false`/
+// `null` / `@…` JSON-LD keywords / punctuation). Shares the `SparqlTokenType` classes (so one
+// CSS palette styles all three) and powers the JSON-LD editor/display on the site.
+export {
+  type JsonLdToken,
+  type JsonLdTokenType,
+  tokenizeJsonLd,
+} from "./jsonld-highlight.js";
+
 // [OPUS-4.8] sq-gb4o (#805) — the pretty/indented Turtle serialiser. The engine answers
 // CONSTRUCT/DESCRIBE (and the dataset viewer's all-quads query) as FLAT N-Triples; this reshapes
 // that into idiomatic grouped Turtle (`@prefix` abbreviation, subject blocks, `;`/`,` lists)

--- a/packages/sparq-client/src/jsonld-highlight.ts
+++ b/packages/sparq-client/src/jsonld-highlight.ts
@@ -1,0 +1,199 @@
+// [OPUS-4.8] sq-ixc3.1 — a framework-agnostic JSON-LD tokenizer for syntax highlighting.
+//
+// The third sibling of `sparql-highlight.ts` / `turtle-highlight.ts`, completing the set of
+// formats the data-formats picker accepts: JSON-LD (`.jsonld` / `application/ld+json`). Unlike
+// Turtle, JSON-LD is JSON, so this is a small forgiving JSON LEXER — keys, string values,
+// numbers, the JSON literals (`true` / `false` / `null`) and structural punctuation
+// (`{ } [ ] : ,`), with the JSON-LD KEYWORDS (`@context`, `@id`, `@type`, `@graph`, `@value`,
+// `@language`, …) coloured distinctly so the linked-data structure stands out.
+//
+// Like its siblings it is deliberately DEPENDENCY-FREE and FRAMEWORK-AGNOSTIC (no DOM, no
+// React, no JSON.parse) so the SAME tokenizer serves the Next.js site and the Tauri 2 webview,
+// and is unit-testable under `node:test`. It is a pragmatic lexer for highlighting, not a JSON
+// parser/validator: it never rejects input and always reproduces the source EXACTLY when the
+// token texts are concatenated (the load-bearing property the overlay editor relies on — the
+// highlight layer must align with the textarea glyph-for-glyph).
+//
+// The token TYPE set is the shared {@link SparqlTokenType} so the existing `.sq-tok-*` CSS
+// classes style it — no new palette, theme-following highlighting for free. The mapping:
+//   * `keyword`     — JSON-LD `@…` keywords (`@context`/`@id`/`@type`/…) AND `true`/`false`/`null`
+//   * `prefixed`    — an OBJECT KEY (a string in key position, i.e. immediately before a `:`)
+//   * `string`      — a string VALUE
+//   * `number`      — a numeric value
+//   * `punctuation` — `{ } [ ] : ,`
+//   * `plain`       — whitespace and anything unclassified
+// `iri` / `variable` / `comment` are unused by JSON (kept in the shared type for one renderer).
+// No performance claim is made here (this repo's work box is non-canonical).
+
+import type { SparqlToken, SparqlTokenType } from "./sparql-highlight.js";
+
+/** The lexical class of a highlighted JSON-LD token. Aliased to {@link SparqlTokenType} so one
+ * renderer + one CSS palette styles SPARQL, Turtle and JSON-LD alike. */
+export type JsonLdTokenType = SparqlTokenType;
+
+/** One token: its source `text` and lexical `type`. Concatenating every `text` in order
+ * reproduces the input string exactly. Aliased to {@link SparqlToken}. */
+export type JsonLdToken = SparqlToken;
+
+// The JSON-LD keyword set (JSON-LD 1.1 §1.7 "Syntax Tokens and Keywords"). These are the `@…`
+// terms that carry structural meaning regardless of the active context. A `"@something"` not in
+// this set is treated as a key/value string like any other (forgiving — we never reject input).
+const JSONLD_KEYWORDS = new Set<string>([
+  "@base", "@container", "@context", "@direction", "@graph", "@id", "@import",
+  "@included", "@index", "@json", "@language", "@list", "@nest", "@none",
+  "@prefix", "@propagate", "@protected", "@reverse", "@set", "@type", "@value",
+  "@version", "@vocab",
+]);
+
+// The bare JSON literals (`true` / `false` / `null`), coloured as keywords (the same class the
+// SPARQL/Turtle lexers give their boolean literals).
+const JSON_LITERALS = new Set<string>(["true", "false", "null"]);
+
+const isWs = (c: string): boolean =>
+  c === " " || c === "\t" || c === "\n" || c === "\r" || c === "\f" || c === "\v";
+const isDigit = (c: string): boolean => c >= "0" && c <= "9";
+
+/**
+ * Tokenize a JSON-LD (JSON) document for HIGHLIGHTING. Pure: no side effects, no DOM, no
+ * `JSON.parse`. The returned tokens are gap-free and ordered — `tokens.map(t => t.text)
+ * .join("")` equals the input exactly (so an overlay renderer aligns with the source). This is
+ * a forgiving lexer, not a validator: malformed input (an unterminated string, a stray
+ * character) is still tokenized to end-of-input rather than throwing.
+ *
+ * Key vs value distinction: a string is classified `prefixed` (a KEY) when the next significant
+ * character after it is `:`, else `string` (a VALUE). A JSON-LD `@…` keyword (in either
+ * position) is `keyword`. This single-pass lookahead is a heuristic, not a grammar — but a
+ * highlighter only needs it to read right, and it does for well-formed JSON-LD.
+ */
+export function tokenizeJsonLd(input: string): JsonLdToken[] {
+  const tokens: JsonLdToken[] = [];
+  const n = input.length;
+  let i = 0;
+  const push = (text: string, type: JsonLdTokenType): void => {
+    if (text.length > 0) tokens.push({ text, type });
+  };
+
+  while (i < n) {
+    const c = input[i];
+
+    // Whitespace run.
+    if (isWs(c)) {
+      let j = i + 1;
+      while (j < n && isWs(input[j])) j++;
+      push(input.slice(i, j), "plain");
+      i = j;
+      continue;
+    }
+
+    // String: `"…"` with `\`-escapes (JSON has no single-quoted strings). After scanning, peek
+    // past whitespace for a `:` — if found, this string is an object KEY (so colour it
+    // `prefixed`, distinct from a value); a JSON-LD `@…` keyword is `keyword` either way.
+    if (c === '"') {
+      const j = scanJsonString(input, i);
+      const text = input.slice(i, j);
+      push(text, classifyString(text, input, j));
+      i = j;
+      continue;
+    }
+
+    // Number: an optional `-`, integer part, optional fraction, optional exponent. JSON does
+    // not allow a leading `+` or a leading `.`, so only `-`/digit can start a number here.
+    if (isDigit(c) || (c === "-" && i + 1 < n && isDigit(input[i + 1]))) {
+      const j = scanJsonNumber(input, i);
+      if (j > i) {
+        push(input.slice(i, j), "number");
+        i = j;
+        continue;
+      }
+    }
+
+    // Bare word: a JSON literal (`true`/`false`/`null`). Any other unquoted word is invalid
+    // JSON but tokenized forgivingly as `plain` so the lexer stays lossless.
+    if ((c >= "a" && c <= "z") || (c >= "A" && c <= "Z")) {
+      let j = i + 1;
+      while (j < n && ((input[j] >= "a" && input[j] <= "z") || (input[j] >= "A" && input[j] <= "Z"))) {
+        j++;
+      }
+      const word = input.slice(i, j);
+      push(word, JSON_LITERALS.has(word) ? "keyword" : "plain");
+      i = j;
+      continue;
+    }
+
+    // Structural punctuation: `{ } [ ] : ,` (and anything else, forgivingly, one char at a time).
+    push(c, "punctuation");
+    i += 1;
+  }
+
+  return tokens;
+}
+
+/** Scan a JSON string starting at the opening `"` (`start`), returning the index PAST the
+ * closing `"` (or end of input for an unterminated literal). Handles `\`-escapes; a JSON string
+ * cannot span a raw newline, so an unterminated string ends at EOL (forgiving). */
+function scanJsonString(input: string, start: number): number {
+  const n = input.length;
+  let j = start + 1;
+  while (j < n) {
+    const c = input[j];
+    if (c === "\\") {
+      j += 2; // skip the escaped char (`\"`, `\\`, `\n`, `\uXXXX`, …)
+      continue;
+    }
+    if (c === '"') return j + 1;
+    if (c === "\n") return j; // unterminated — stop at the newline (forgiving)
+    j++;
+  }
+  return n;
+}
+
+/** Classify a just-scanned `"…"` token. A JSON-LD `@…` keyword is `keyword`; otherwise a string
+ * in KEY position (the next significant char is `:`) is `prefixed`, a string VALUE is `string`.
+ * `at` is the index just past the closing quote. */
+function classifyString(text: string, input: string, at: number): JsonLdTokenType {
+  // The string's content without the surrounding quotes (the closing quote may be absent for an
+  // unterminated literal, hence the defensive slice).
+  const content = text.endsWith('"') && text.length >= 2 ? text.slice(1, -1) : text.slice(1);
+  if (content.startsWith("@") && JSONLD_KEYWORDS.has(content)) return "keyword";
+  return nextSignificantIsColon(input, at) ? "prefixed" : "string";
+}
+
+/** True if the next non-whitespace character at or after `at` is `:` (so the preceding string
+ * is an object key). */
+function nextSignificantIsColon(input: string, at: number): boolean {
+  const n = input.length;
+  let j = at;
+  while (j < n && isWs(input[j])) j++;
+  return j < n && input[j] === ":";
+}
+
+/** Scan a JSON number at `start` (a leading digit, or `-` then a digit); returns the index past
+ * it, or `start` if no digit was actually consumed. Follows the JSON grammar: optional `-`,
+ * an integer part, an optional `.fraction`, an optional `e`/`E` exponent. */
+function scanJsonNumber(input: string, start: number): number {
+  const n = input.length;
+  let j = start;
+  if (input[j] === "-") j++;
+  let sawDigit = false;
+  while (j < n && isDigit(input[j])) {
+    j++;
+    sawDigit = true;
+  }
+  if (j < n && input[j] === ".") {
+    j++;
+    while (j < n && isDigit(input[j])) {
+      j++;
+      sawDigit = true;
+    }
+  }
+  if (sawDigit && j < n && (input[j] === "e" || input[j] === "E")) {
+    let k = j + 1;
+    if (k < n && (input[k] === "+" || input[k] === "-")) k++;
+    if (k < n && isDigit(input[k])) {
+      k++;
+      while (k < n && isDigit(input[k])) k++;
+      j = k;
+    }
+  }
+  return sawDigit ? j : start;
+}

--- a/site/src/app/surface/data-formats/page.tsx
+++ b/site/src/app/surface/data-formats/page.tsx
@@ -7,7 +7,7 @@ import { DataFormatsDemo } from "@/components/data-formats-demo";
 export const metadata: Metadata = {
   title: "Data formats",
   description:
-    "Parse and load RDF into a sparq Graph — Turtle, N-Triples, N-Quads, TriG, compressed dumps, and the binary HDT archive format.",
+    "Parse and load RDF into a sparq Graph — Turtle, N-Triples, N-Quads, TriG, JSON-LD, compressed dumps, and the binary HDT archive format.",
 };
 
 export default function DataFormatsSurfacePage() {
@@ -34,6 +34,13 @@ export default function DataFormatsSurfacePage() {
             crate.
           </p>
           <p>
+            <strong className="text-foreground">JSON-LD 1.1</strong> (JSON for
+            linked data) parses through the opt-in{" "}
+            <code className="font-mono text-foreground">jsonld</code> feature
+            (oxjsonld) — which the site&apos;s wasm bundle enables, so the picker
+            below reads it too.
+          </p>
+          <p>
             These crates parse RDF <em>in</em>; to write RDF <em>out</em>, the
             engine ships a writer matrix (Turtle / TriG / N-Quads / JSON-LD 1.1)
             behind its <code className="font-mono">serialize-rdf</code> feature,
@@ -45,6 +52,10 @@ export default function DataFormatsSurfacePage() {
         {
           title: "Turtle / N-Triples / N-Quads / TriG",
           body: "All four text formats, with named-graph preservation for the quad formats.",
+        },
+        {
+          title: "JSON-LD 1.1",
+          body: "JSON for linked data — parsed via the opt-in jsonld feature (oxjsonld), which the site bundle enables.",
         },
         {
           title: "Compressed ingest",
@@ -71,7 +82,7 @@ export default function DataFormatsSurfacePage() {
         <>
           <p>
             <strong className="text-foreground">Live in your tab</strong> for the
-            four text formats — the demo above runs the same{" "}
+            four text formats and JSON-LD — the demo above runs the same{" "}
             <code className="font-mono">Store.load</code> /{" "}
             <code className="font-mono">loadDataset</code> loaders that ship in{" "}
             <code className="font-mono">@jeswr/sparq</code>, compiled to wasm. The

--- a/site/src/components/data-formats-demo.tsx
+++ b/site/src/components/data-formats-demo.tsx
@@ -43,6 +43,8 @@ import {
 } from "@/lib/data-formats";
 // [OPUS-4.8] sq-8uew — Turtle/TriG/N-Triples/N-Quads syntax-highlighting input editor.
 import { RdfEditor } from "@/components/rdf-editor";
+// [OPUS-4.8] sq-ixc3.1 — JSON-LD syntax-highlighting input editor (the remaining picker format).
+import { JsonLdEditor } from "@/components/jsonld-editor";
 
 // The whole-dataset enumeration: default graph UNION every named graph, so a sample of an
 // N-Quads / TriG document shows its named-graph rows too (?g bound). Same shape the REPL uses.
@@ -195,14 +197,26 @@ export function DataFormatsDemo() {
           <label htmlFor="data-formats-input" className="sr-only">
             RDF document to parse
           </label>
-          {/* [OPUS-4.8] sq-8uew — syntax-highlighting Turtle/TriG/N-Triples/N-Quads input. */}
-          <RdfEditor
-            id="data-formats-input"
-            ariaLabel="RDF document to parse"
-            value={text}
-            onChange={setText}
-            rows={10}
-          />
+          {/* [OPUS-4.8] sq-8uew / sq-ixc3.1 — syntax-highlighting input. JSON-LD is JSON (a
+              different tokenizer), so the picker routes it to the JSON-LD editor; the four text
+              formats share the Turtle-family editor. Both reuse the shared `.sq-tok-*` palette. */}
+          {format === "jsonld" ? (
+            <JsonLdEditor
+              id="data-formats-input"
+              ariaLabel="JSON-LD document to parse"
+              value={text}
+              onChange={setText}
+              rows={10}
+            />
+          ) : (
+            <RdfEditor
+              id="data-formats-input"
+              ariaLabel="RDF document to parse"
+              value={text}
+              onChange={setText}
+              rows={10}
+            />
+          )}
 
           <div className="flex items-center gap-3">
             <Button onClick={runParse} disabled={busy || disabled}>

--- a/site/src/components/jsonld-editor.tsx
+++ b/site/src/components/jsonld-editor.tsx
@@ -1,0 +1,166 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.1 — a syntax-highlighting EDITOR for JSON-LD input.
+//
+// The JSON-LD counterpart of `RdfEditor` (Turtle, sq-8uew) and `SparqlEditor` (sq-n5aw): a
+// transparent-text `<textarea>` rendered over a highlighted `<pre>`, the standard
+// zero-dependency overlay technique. The two layers share identical font metrics, padding, tab
+// size and scroll offset so glyphs align exactly. Tokenization is the framework-agnostic
+// `@sparq/client` `tokenizeJsonLd` core, and the spans reuse the SAME `.sq-tok-*` classes
+// `globals.css` already defines for the SPARQL/Turtle editors — no new palette, theme-following
+// highlighting, no new npm dependency, static-export safe. Used in the data-formats parse panel
+// when the JSON-LD format is picked. The lighter read-only display counterpart is
+// `JsonLdHighlight`.
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { type JsonLdToken, tokenizeJsonLd } from "@sparq/client";
+
+// Shared text-metrics: the highlight `<pre>` and the `<textarea>` MUST use identical font,
+// size, line-height, padding, tab size and wrapping, or the layers drift. Matches `RdfEditor`.
+const EDITOR_TEXT_CLASS =
+  "font-mono text-[13px] leading-relaxed whitespace-pre-wrap break-words [tab-size:2]";
+const EDITOR_PAD_CLASS = "p-3";
+
+// JSON-LD uses keyword (`@…` / true/false/null), prefixed (object keys), string (values),
+// number and punctuation. `iri` / `variable` / `comment` never occur in JSON, but the shared
+// token-type map keeps every `SparqlTokenType` key so one renderer styles all three languages.
+const TOKEN_CLASS: Record<JsonLdToken["type"], string> = {
+  keyword: "sq-tok-keyword",
+  variable: "", // unused by JSON-LD
+  iri: "", // unused by JSON-LD
+  prefixed: "sq-tok-prefixed", // object keys
+  string: "sq-tok-string",
+  number: "sq-tok-number",
+  comment: "", // JSON has no comments
+  punctuation: "",
+  plain: "",
+};
+
+export interface JsonLdEditorProps {
+  /** Current document text (controlled). */
+  value: string;
+  /** Called with the new text on edit. */
+  onChange: (next: string) => void;
+  /** Visible rows (the textarea is resizable vertically from here). */
+  rows?: number;
+  /** Accessible label for the editing surface. */
+  ariaLabel?: string;
+  /** id for the textarea (so an external `<label htmlFor>` can target it). */
+  id?: string;
+  /** Disable editing (e.g. while the engine is warming). */
+  disabled?: boolean;
+  className?: string;
+}
+
+/**
+ * A syntax-highlighting JSON-LD editor: a transparent-caret `<textarea>` over a highlighted
+ * `<pre>`. Fully controlled; emits edits through {@link onChange}.
+ */
+export function JsonLdEditor({
+  value,
+  onChange,
+  rows = 10,
+  ariaLabel = "JSON-LD document",
+  id,
+  disabled,
+  className,
+}: JsonLdEditorProps) {
+  const preRef = React.useRef<HTMLPreElement>(null);
+
+  // Keep the highlight layer's scroll offset in lockstep with the textarea.
+  const syncScroll = React.useCallback((el: HTMLTextAreaElement) => {
+    if (preRef.current) {
+      preRef.current.scrollTop = el.scrollTop;
+      preRef.current.scrollLeft = el.scrollLeft;
+    }
+  }, []);
+
+  const tokens = React.useMemo(() => tokenizeJsonLd(value), [value]);
+
+  return (
+    <div className={cn("relative rounded-lg border bg-muted/40", className)}>
+      {/* Highlight layer: aria-hidden (the textarea is the accessible control). A trailing
+          newline keeps the last line's height stable while typing at the very end. */}
+      <pre
+        ref={preRef}
+        aria-hidden="true"
+        className={cn(
+          "pointer-events-none absolute inset-0 m-0 overflow-auto",
+          EDITOR_PAD_CLASS,
+          EDITOR_TEXT_CLASS,
+        )}
+      >
+        {tokens.map((t, idx) => {
+          const cls = TOKEN_CLASS[t.type];
+          return cls ? (
+            <span key={idx} className={cls}>
+              {t.text}
+            </span>
+          ) : (
+            <React.Fragment key={idx}>{t.text}</React.Fragment>
+          );
+        })}
+        {"\n"}
+      </pre>
+
+      {/* Editing layer: transparent text (so the highlight shows through) but a visible
+          caret. `spellCheck` off — JSON-LD is not prose. */}
+      <textarea
+        id={id}
+        aria-label={ariaLabel}
+        value={value}
+        spellCheck={false}
+        autoCapitalize="off"
+        autoCorrect="off"
+        rows={rows}
+        disabled={disabled}
+        onChange={(e) => onChange(e.target.value)}
+        onScroll={(e) => syncScroll(e.currentTarget)}
+        className={cn(
+          "relative block w-full resize-y bg-transparent text-transparent caret-foreground outline-none",
+          "selection:bg-primary/30 focus-visible:ring-3 focus-visible:ring-ring/40 rounded-lg",
+          "disabled:cursor-not-allowed disabled:opacity-60",
+          EDITOR_PAD_CLASS,
+          EDITOR_TEXT_CLASS,
+        )}
+      />
+    </div>
+  );
+}
+
+/**
+ * Read-only JSON-LD syntax-highlight renderer — the display counterpart of {@link JsonLdEditor}
+ * (mirrors `RdfHighlight` for Turtle). Renders a plain styled `<pre>`, so it drops in anywhere a
+ * `<pre>` already shows JSON-LD text. The tokenizer is gap-free, so the rendered text reproduces
+ * `text` exactly.
+ */
+export function JsonLdHighlight({
+  text,
+  className,
+  ...rest
+}: {
+  /** The JSON-LD document to highlight. */
+  text: string;
+  /** Classes for the `<pre>` host (sizing, scroll, border, padding, font). */
+  className?: string;
+  /** Optional `data-*` hook for tests/inspection. */
+  "data-testid"?: string;
+}) {
+  const tokens = React.useMemo(() => tokenizeJsonLd(text), [text]);
+  return (
+    <pre className={cn("font-mono", className)} {...rest}>
+      {tokens.map((t, idx) => {
+        const cls = TOKEN_CLASS[t.type];
+        return cls ? (
+          <span key={idx} className={cls}>
+            {t.text}
+          </span>
+        ) : (
+          <React.Fragment key={idx}>{t.text}</React.Fragment>
+        );
+      })}
+    </pre>
+  );
+}

--- a/site/src/lib/data-formats.ts
+++ b/site/src/lib/data-formats.ts
@@ -11,7 +11,7 @@
 // unit-test directly under `node --test` (the Web Streams API is in Node ≥ 18).
 
 /** The engine format string each picker entry loads through. */
-export type DataFormat = "turtle" | "ntriples" | "nquads" | "trig";
+export type DataFormat = "turtle" | "ntriples" | "nquads" | "trig" | "jsonld";
 
 export interface FormatSample {
   /** Engine format string for `Store.load` / `Store.loadDataset`. */
@@ -70,7 +70,34 @@ ex:social {
 }
 `;
 
-/** The four text formats, each with a live sample the picker seeds the textarea with. */
+// [OPUS-4.8] sq-ixc3.1 — JSON-LD: the same Alice/Bob graph as a `@context`-abbreviated node
+// array. Engine-side JSON-LD parsing is the site wasm bundle's opt-in `jsonld` feature
+// (oxjsonld). Compact-IRI keys (`foaf:name`) resolve via the `@context`, `@type` is the rdf:type
+// shorthand, and `@id` carries the node IRI — the linked-data structure the `@…`-keyword
+// highlighting makes legible.
+const JSONLD_SAMPLE = `{
+  "@context": {
+    "ex": "http://example.org/",
+    "foaf": "http://xmlns.com/foaf/0.1/",
+    "knows": { "@id": "foaf:knows", "@type": "@id" }
+  },
+  "@graph": [
+    {
+      "@id": "ex:alice",
+      "@type": "foaf:Person",
+      "foaf:name": "Alice",
+      "knows": "ex:bob"
+    },
+    {
+      "@id": "ex:bob",
+      "@type": "foaf:Person",
+      "foaf:name": { "@value": "Bob", "@language": "en" }
+    }
+  ]
+}
+`;
+
+/** The five RDF formats, each with a live sample the picker seeds the textarea with. */
 export const FORMAT_SAMPLES: FormatSample[] = [
   {
     format: "turtle",
@@ -100,10 +127,19 @@ export const FORMAT_SAMPLES: FormatSample[] = [
     blurb: "Turtle plus { … } named-graph blocks.",
     sample: TRIG_SAMPLE,
   },
+  {
+    format: "jsonld",
+    label: "JSON-LD",
+    ext: ".jsonld",
+    blurb: "JSON for linked data — `@context`-mapped IRIs, `@id`, `@type`, `@graph`.",
+    sample: JSONLD_SAMPLE,
+  },
 ];
 
-/** Whether a format carries named graphs (so the REPL must use `loadDataset`). */
-const DATASET_FORMATS = new Set<DataFormat>(["nquads", "trig"]);
+// [OPUS-4.8] sq-ixc3.1: JSON-LD can carry named graphs (`@graph` under an outer `@id`), so it
+// joins nquads/trig as a dataset format routed through `loadDataset` (mirrors repl-dataset.ts).
+/** Whether a format carries named graphs (so the demo must use `loadDataset`). */
+const DATASET_FORMATS = new Set<DataFormat>(["nquads", "trig", "jsonld"]);
 
 /** True for the quad-bearing formats (`nquads` / `trig`). */
 export function isDatasetFormat(format: DataFormat): boolean {

--- a/site/test/data-formats.test.mjs
+++ b/site/test/data-formats.test.mjs
@@ -1,6 +1,6 @@
-// [OPUS-4.8] sq-j50v — unit tests for the /surface/data-formats demo helpers: the
-// four-format sample catalogue and the in-tab gzip round-trip. These cover the pure,
-// framework-free logic (no React, no wasm); the engine-level parse of each sample is
+// [OPUS-4.8] sq-j50v / sq-ixc3.1 — unit tests for the /surface/data-formats demo helpers: the
+// sample catalogue (four text formats + JSON-LD) and the in-tab gzip round-trip. These cover
+// the pure, framework-free logic (no React, no wasm); the engine-level parse of each sample is
 // covered by the Rust tests + js/test/store.test.mjs. Run via `npm run test:unit`.
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -14,10 +14,10 @@ import {
   formatBytes,
 } from "../src/lib/data-formats.ts";
 
-test("the catalogue covers exactly the four text formats", () => {
+test("the catalogue covers the four text formats plus JSON-LD", () => {
   assert.deepEqual(
     FORMAT_SAMPLES.map((f) => f.format),
-    ["turtle", "ntriples", "nquads", "trig"],
+    ["turtle", "ntriples", "nquads", "trig", "jsonld"],
   );
 });
 
@@ -30,11 +30,17 @@ test("every sample is non-empty and carries the right named-graph syntax", () =>
   assert.match(sampleFor("trig").sample, /ex:social\s*\{/);
   // The triple-only formats do NOT (no 4th term / no graph block).
   assert.doesNotMatch(sampleFor("turtle").sample, /\{/);
+  // The JSON-LD sample is real JSON-LD: it carries a `@context` and a `@graph`.
+  assert.match(sampleFor("jsonld").sample, /"@context"/);
+  assert.match(sampleFor("jsonld").sample, /"@graph"/);
 });
 
 test("isDatasetFormat is true exactly for the quad-bearing formats", () => {
   assert.equal(isDatasetFormat("nquads"), true);
   assert.equal(isDatasetFormat("trig"), true);
+  // JSON-LD can carry named graphs (`@graph` under an outer `@id`), so it routes through
+  // loadDataset too.
+  assert.equal(isDatasetFormat("jsonld"), true);
   assert.equal(isDatasetFormat("turtle"), false);
   assert.equal(isDatasetFormat("ntriples"), false);
 });

--- a/site/test/jsonld-highlight.test.mjs
+++ b/site/test/jsonld-highlight.test.mjs
@@ -1,0 +1,135 @@
+// [OPUS-4.8] sq-ixc3.1 — unit tests for the framework-agnostic JSON-LD highlighting tokenizer
+// (packages/sparq-client/src/jsonld-highlight.ts), the third sibling of tokenizeSparql /
+// tokenizeTurtle. The two load-bearing invariants mirror the SPARQL/Turtle tests: (1) the
+// tokenizer is LOSSLESS — concatenating every token's text reproduces the input exactly (the
+// overlay editor aligns the highlight layer glyph-for-glyph, so any drift mis-renders), and
+// (2) each construct gets the right lexical class — JSON-LD `@…` keywords + true/false/null as
+// `keyword`, object KEYS as `prefixed`, string VALUES as `string`, numbers as `number`, and
+// `{ } [ ] : ,` as `punctuation`. Imported via relative path (the node:test TS loader has no
+// `@sparq/client` alias). Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  tokenizeJsonLd,
+} from "../../packages/sparq-client/src/jsonld-highlight.ts";
+
+/** Concatenate token texts — must equal the input for any string (the lossless invariant). */
+function roundtrip(src) {
+  return tokenizeJsonLd(src)
+    .map((t) => t.text)
+    .join("");
+}
+
+/** The token types covering a given source, in order, dropping pure-whitespace `plain` runs. */
+function typesOf(src) {
+  return tokenizeJsonLd(src)
+    .filter((t) => !(t.type === "plain" && t.text.trim() === ""))
+    .map((t) => t.type);
+}
+
+/** First token of a given type, or undefined. */
+function firstOfType(src, type) {
+  return tokenizeJsonLd(src).find((t) => t.type === type)?.text;
+}
+
+test("lossless: concatenating tokens reproduces the input exactly", () => {
+  const samples = [
+    "",
+    "   ",
+    "{}",
+    "[]",
+    '{ "@id": "ex:alice" }',
+    `{
+  "@context": { "ex": "http://example.org/" },
+  "@graph": [
+    { "@id": "ex:alice", "@type": "foaf:Person", "foaf:name": "Alice", "age": 30 }
+  ]
+}`,
+    '{ "n": -1.5e10, "ok": true, "no": false, "nil": null }',
+    '{ "esc": "a \\"quote\\" and a \\\\ slash" }',
+    '{ "unterminated": "no close', // forgiving: no closing quote
+    "garbage £ ™ not json",
+  ];
+  for (const s of samples) {
+    assert.equal(roundtrip(s), s, `roundtrip mismatch for: ${JSON.stringify(s)}`);
+  }
+});
+
+test("JSON-LD @-keywords are classified as keyword (key or value position)", () => {
+  // `@context` / `@id` / `@type` / `@graph` / `@value` / `@language` are JSON-LD keywords.
+  assert.equal(firstOfType('{ "@context": {} }', "keyword"), '"@context"');
+  assert.equal(firstOfType('{ "@id": "x" }', "keyword"), '"@id"');
+  // `@type` mapped to `@id` (a keyword in VALUE position too).
+  const toks = tokenizeJsonLd('{ "knows": { "@type": "@id" } }');
+  const keywords = toks.filter((t) => t.type === "keyword").map((t) => t.text);
+  assert.deepEqual(keywords, ['"@type"', '"@id"']);
+});
+
+test("an unknown @-token is NOT a keyword (treated as a normal string/key)", () => {
+  // `@notakeyword` is not in the JSON-LD keyword set — so it is a key (prefixed), not a keyword.
+  assert.equal(firstOfType('{ "@notakeyword": 1 }', "keyword"), undefined);
+  assert.equal(firstOfType('{ "@notakeyword": 1 }', "prefixed"), '"@notakeyword"');
+});
+
+test("object keys are prefixed; string values are string", () => {
+  const toks = tokenizeJsonLd('{ "foaf:name": "Alice" }');
+  // "foaf:name" is a key (before a colon) → prefixed; "Alice" is a value → string.
+  assert.equal(firstOfType('{ "foaf:name": "Alice" }', "prefixed"), '"foaf:name"');
+  assert.equal(firstOfType('{ "foaf:name": "Alice" }', "string"), '"Alice"');
+  // The string just before the `:` is the key; verify the value is NOT misclassified as a key.
+  const valueTok = toks.find((t) => t.text === '"Alice"');
+  assert.equal(valueTok.type, "string");
+});
+
+test("a string element inside an array is a value, not a key (no following colon)", () => {
+  // ["a", "b"] — neither array element is followed by a colon, so both are string values.
+  const types = typesOf('{ "list": ["a", "b"] }');
+  // "list"(prefixed) :(punct) [(punct) "a"(string) ,(punct) "b"(string) ](punct) }(punct)
+  assert.equal(firstOfType('{ "list": ["a", "b"] }', "prefixed"), '"list"');
+  const strings = tokenizeJsonLd('{ "list": ["a", "b"] }')
+    .filter((t) => t.type === "string")
+    .map((t) => t.text);
+  assert.deepEqual(strings, ['"a"', '"b"']);
+  assert.ok(types.includes("string"));
+});
+
+test("numbers (int, negative, fraction, exponent) are classified as number", () => {
+  assert.equal(firstOfType('{ "n": 42 }', "number"), "42");
+  assert.equal(firstOfType('{ "n": -7 }', "number"), "-7");
+  assert.equal(firstOfType('{ "n": 3.14 }', "number"), "3.14");
+  assert.equal(firstOfType('{ "n": -1.5e10 }', "number"), "-1.5e10");
+  assert.equal(firstOfType('{ "n": 6.022E23 }', "number"), "6.022E23");
+});
+
+test("true / false / null are keywords", () => {
+  assert.equal(firstOfType('{ "ok": true }', "keyword"), "true");
+  assert.equal(firstOfType('{ "ok": false }', "keyword"), "false");
+  assert.equal(firstOfType('{ "ok": null }', "keyword"), "null");
+});
+
+test("structural punctuation { } [ ] : , each tokenizes as punctuation", () => {
+  const punct = tokenizeJsonLd('{ "a": [1], "b": 2 }')
+    .filter((t) => t.type === "punctuation")
+    .map((t) => t.text);
+  // { : [ ] , : }  — order preserved.
+  assert.deepEqual(punct, ["{", ":", "[", "]", ",", ":", "}"]);
+});
+
+test("a realistic JSON-LD node yields a sensible class sequence", () => {
+  const types = typesOf('{ "@id": "ex:alice", "@type": "foaf:Person" }');
+  // {(punct) "@id"(keyword) :(punct) "ex:alice"(string) ,(punct) "@type"(keyword) :(punct) "foaf:Person"(string) }(punct)
+  assert.equal(types[0], "punctuation"); // {
+  assert.equal(types[1], "keyword"); // "@id"
+  assert.equal(types[2], "punctuation"); // :
+  assert.equal(types[3], "string"); // "ex:alice"
+  assert.equal(types[4], "punctuation"); // ,
+  assert.equal(types[5], "keyword"); // "@type"
+});
+
+test("forgiving: an unterminated string does not throw and stays lossless", () => {
+  const bad = '{ "k": "unterminated';
+  assert.equal(roundtrip(bad), bad);
+  // It is still tokenized (as a string), not dropped.
+  assert.ok(tokenizeJsonLd(bad).some((t) => t.type === "string"));
+});


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-ixc3.1 (follow-up to sq-8uew/#845).

## What this does

Completes the data-formats highlighting set. SPARQL (`tokenizeSparql`) and Turtle/TriG/N-Triples/N-Quads (`tokenizeTurtle`, #845) were already highlighted; **JSON-LD** was the one remaining format the data-formats picker accepts (`.jsonld` / `application/ld+json`) that was still typed/shown un-highlighted — because it is JSON, not Turtle, so `tokenizeTurtle` does not apply.

## The tokenizer / stack

- **`@sparq/client` `tokenizeJsonLd`** — a small, dependency-free, framework-agnostic JSON lexer, the third sibling of `tokenizeSparql`/`tokenizeTurtle` (no DOM, no React, no `JSON.parse`). It reuses the shared `SparqlTokenType` classes, so the existing `.sq-tok-*` CSS palette styles it — **no new palette, no new dependency**, theme-following highlighting for free. Mapping:
  - `keyword` — JSON-LD `@…` keywords (`@context`/`@id`/`@type`/`@graph`/`@value`/`@language`/…) **and** `true`/`false`/`null`
  - `prefixed` — object **keys** (a string immediately before a `:`)
  - `string` — string **values**
  - `number` — numeric values
  - `punctuation` — `{ } [ ] : ,`
  - `plain` — whitespace / anything unclassified
  - It is **lossless** (concatenating token texts reproduces the input exactly — the overlay editor relies on glyph-for-glyph alignment) and **forgiving** (an unterminated string never throws).

## Where it's wired

- New `JsonLdEditor` (transparent-textarea-over-highlighted-`<pre>` overlay) + `JsonLdHighlight` (read-only display) site components, mirroring `RdfEditor`/`RdfHighlight`.
- The **`/surface/data-formats` demo** gains a **JSON-LD picker entry** (with a `@context`-abbreviated Alice/Bob sample) and routes that format to `JsonLdEditor`; the four text formats keep the Turtle-family editor. JSON-LD loads through `loadDataset` like the other graph-bearing formats (it can carry named graphs via `@graph`).
- Page copy + capabilities updated to introduce JSON-LD **honestly** as the opt-in `jsonld` (oxjsonld) feature the site's wasm bundle enables — not as a sparq-core text loader.

## Honest fidelity limits

This is a **highlighting lexer, not a JSON/JSON-LD parser**. The key-vs-value distinction is a single-char lookahead heuristic (`"x":` → key); it reads correctly for well-formed JSON-LD but does not validate. `@`-tokens outside the JSON-LD keyword set are treated as ordinary keys/strings (not flagged). No `iri`/`comment`/`variable` tokens are produced (those classes are unused by JSON). Like its siblings, it is forgiving — malformed input is tokenized, not rejected.

## Gates (all green)

- WASM prereq built: `cd js && npm run build:wasm` (`--features shacl,jsonld`) — exit 0.
- `cd site && npm run build` (static export) — exit 0; `/surface/data-formats` (+ `/`, `/try`, all `/surface/*` / `/showcase/*` / `/benchmarks/*` / `/papers`) exported into `out/`, `basePath` `/sparq` intact.
- `npm run lint` — clean.
- `npx tsc --noEmit` — clean (site + `@sparq/client`).
- `npm run test:unit` — 215/215 pass (10 new JSON-LD tokenizer tests in `site/test/jsonld-highlight.test.mjs`; `data-formats.test.mjs` updated for the fifth format).

Terminology gate respected (RDF 1.2 / SPARQL 1.2; "JSON-LD 1.1" is the JSON-LD spec version). Typos gate clean. No privacy/ZK/MPC copy touched. No hard-coded performance numbers (work-box timings remain non-canonical).