### PR TITLE
feat(bench): wire ZK/Solid/HDT/RSP/GenAI/GPU family metrics into the CI bench feed (sq-k0km) [OPUS-4.8]

### DIFF
--- a/bench/dashboard/dashboard.js
+++ b/bench/dashboard/dashboard.js
@@ -604,13 +604,19 @@
   // surfaces + reasoning). The drift scan flagged that MANY registered benchmark families
   // (bench/benchmarks.toml) had NO dashboard row at all — most notably the entire ZK estate
   // (zk / zk-trace / zk-compose), plus Solid/WAC access-control, HDT ingest, RSP streaming,
-  // GenAI (similarity / introspection) and the GPU kernel experiment. These are stdout/criterion
-  // benches today (they do NOT yet emit into ci-bench.sh's customSmallerIsBetter feed), so the rows
-  // below render as "not yet reported" until a ci-bench hook lands — which is exactly the dashboard's
-  // HONEST graceful-degradation contract (buildFamilies keeps every family, count 0 -> a nav chip +
-  // a "not yet reported" section). When a hook DOES start emitting (e.g. `zk_commit_us`,
-  // `hdt_load_s`, …), the metric lands in the right family automatically via these prefixes — no
-  // further dashboard change. The headline gap (ZK) is listed FIRST among the new families.
+  // GenAI (similarity / introspection / NL→SPARQL) and the GPU kernel experiment. So the rows below
+  // render as "not yet reported" until a ci-bench hook lands — exactly the dashboard's HONEST
+  // graceful-degradation contract (buildFamilies keeps every family, count 0 -> a nav chip + a "not
+  // yet reported" section). When a hook DOES start emitting, the metric lands in the right family
+  // automatically via these prefixes — no further dashboard change.
+  //
+  // [OPUS-4.8] sq-k0km UPDATE — ci-bench hooks have since LANDED for: ZK (zk_compose_*_gates +
+  // zk_commit_*/zk_trace_* criterion means), HDT (snikmeta_* load-decode counts + hdt_load_s), RSP
+  // (rsp_*_rows per-window counts), Solid (solid_* WAC/ACP auth-view counts) and GenAI's NL→SPARQL
+  // (nlq_* offline-loop counts). Those families now render REAL data. STILL "not yet reported" (and
+  // HONESTLY so): GenAI's sim/introspect suites (need the gitignored 1.78M-triple olympics.nt — NOT
+  // in CI), the GPU experiment (no GPU on gh runners) and MPC (modelled tier). Those are
+  // EC2/dataset-gathered and intentionally not in the per-commit feed.
   var FAMILIES = [
     { key: 'core',     title: 'Core (load · dict · memory)', kind: 'core',
       suites: ['pipeline', 'memory / size'],

--- a/bench/dashboard/metric-labels.json
+++ b/bench/dashboard/metric-labels.json
@@ -969,6 +969,38 @@
       "regime": "extensional",
       "unit": "µs"
     },
+    "nlq_ask_repairs": {
+      "label": "NL→SPARQL ask loop — repair rounds",
+      "suite": "NL→SPARQL",
+      "dataset": "synthetic typed graph generated in-example at N=2000 entities (rdf:type/rdfs:label/ex:age per entity); deterministic, no external data, offline stub LLM (no `live` feature, no network)",
+      "query": "repair rounds the ask loop needed (0 = stub's first SPARQL was valid + executable)",
+      "mode": "count",
+      "unit": "count"
+    },
+    "nlq_ask_result_rows": {
+      "label": "NL→SPARQL ask loop — result rows",
+      "suite": "NL→SPARQL",
+      "dataset": "synthetic typed graph generated in-example at N=2000 entities (rdf:type/rdfs:label/ex:age per entity); deterministic, no external data, offline stub LLM (no `live` feature, no network)",
+      "query": "rows the full ask loop returns (GROUP BY ?type -> one row per type)",
+      "mode": "count",
+      "unit": "count"
+    },
+    "nlq_prompt_chars": {
+      "label": "NL→SPARQL grounded prompt — char length (token-budget proxy)",
+      "suite": "NL→SPARQL",
+      "dataset": "synthetic typed graph generated in-example at N=2000 entities (rdf:type/rdfs:label/ex:age per entity); deterministic, no external data, offline stub LLM (no `live` feature, no network)",
+      "query": "length of the schema-grounded prompt prompt_for(question) builds; smaller = leaner",
+      "mode": "count",
+      "unit": "chars"
+    },
+    "nlq_synth_triples": {
+      "label": "NL→SPARQL synthetic graph — triple count",
+      "suite": "NL→SPARQL",
+      "dataset": "synthetic typed graph generated in-example at N=2000 entities (rdf:type/rdfs:label/ex:age per entity); deterministic, no external data, offline stub LLM (no `live` feature, no network)",
+      "query": "triples in the synthetic typed graph (3 per entity)",
+      "mode": "count",
+      "unit": "count"
+    },
     "op_q01_bgp_count": {
       "label": "Operator — BGP — single triple pattern, count",
       "suite": "Operators",
@@ -1876,6 +1908,62 @@
       "suite": "HDT",
       "dataset": "vendored real-world snikmeta.hdt (hdt-cpp/java-shaped FourSectDict+BitmapTriples; 328 triples) for the gate; deterministic ~250k-triple synthetic archive for the advisory timing (HDT_BENCH_N)",
       "query": "stored triples of the decoded graph (load-and-decode-to-native)",
+      "mode": "count",
+      "unit": "count"
+    },
+    "solid_acp_auth_triples": {
+      "label": "Solid acp_auth_triples — WAC/ACP auth-view count",
+      "suite": "Solid",
+      "dataset": "in-crate ~1.1k-graph WAC fixture (+ ACP variant), built deterministically by sparq_solid::fixture::{wac_fixture, acp_fixture}",
+      "query": "triples in the materialised ACP auth view (materialize_acp, 3 strata)",
+      "mode": "count",
+      "unit": "count"
+    },
+    "solid_alice_readable_graphs": {
+      "label": "Solid alice_readable_graphs — WAC/ACP auth-view count",
+      "suite": "Solid",
+      "dataset": "in-crate ~1.1k-graph WAC fixture (+ ACP variant), built deterministically by sparq_solid::fixture::{wac_fixture, acp_fixture}",
+      "query": "graphs visible to ALICE in Mode::Read (AuthIndex walk)",
+      "mode": "count",
+      "unit": "count"
+    },
+    "solid_authorized_rows": {
+      "label": "Solid authorized_rows — WAC/ACP auth-view count",
+      "suite": "Solid",
+      "dataset": "in-crate ~1.1k-graph WAC fixture (+ ACP variant), built deterministically by sparq_solid::fixture::{wac_fixture, acp_fixture}",
+      "query": "rows of the title query restricted to alice's authorized subset",
+      "mode": "count",
+      "unit": "count"
+    },
+    "solid_full_dataset_rows": {
+      "label": "Solid full_dataset_rows — WAC/ACP auth-view count",
+      "suite": "Solid",
+      "dataset": "in-crate ~1.1k-graph WAC fixture (+ ACP variant), built deterministically by sparq_solid::fixture::{wac_fixture, acp_fixture}",
+      "query": "rows of the title query over the FULL dataset (GRAPH ?g)",
+      "mode": "count",
+      "unit": "count"
+    },
+    "solid_wac_auth_triples": {
+      "label": "Solid wac_auth_triples — WAC/ACP auth-view count",
+      "suite": "Solid",
+      "dataset": "in-crate ~1.1k-graph WAC fixture (+ ACP variant), built deterministically by sparq_solid::fixture::{wac_fixture, acp_fixture}",
+      "query": "triples in the materialised WAC auth view (materialize_wac)",
+      "mode": "count",
+      "unit": "count"
+    },
+    "solid_wac_named_graphs": {
+      "label": "Solid wac_named_graphs — WAC/ACP auth-view count",
+      "suite": "Solid",
+      "dataset": "in-crate ~1.1k-graph WAC fixture (+ ACP variant), built deterministically by sparq_solid::fixture::{wac_fixture, acp_fixture}",
+      "query": "named graphs in the WAC fixture",
+      "mode": "count",
+      "unit": "count"
+    },
+    "solid_wac_quads": {
+      "label": "Solid wac_quads — WAC/ACP auth-view count",
+      "suite": "Solid",
+      "dataset": "in-crate ~1.1k-graph WAC fixture (+ ACP variant), built deterministically by sparq_solid::fixture::{wac_fixture, acp_fixture}",
+      "query": "total quads across the WAC fixture's named graphs",
       "mode": "count",
       "unit": "count"
     },

--- a/bench/nlq/README.md
+++ b/bench/nlq/README.md
@@ -1,0 +1,62 @@
+<!-- [OPUS-4.8] sq-k0km — sparq-nlq OFFLINE NL->SPARQL feed for the CI bench dashboard. -->
+# sparq-nlq offline NL→SPARQL feed
+
+A small, self-asserting per-commit runner that feeds the dashboard's **GenAI
+family** card (`similarity · introspection · NL→SPARQL`) so it stops rendering
+"not yet reported". It mirrors the LUBM / SHACL / HDT / RSP / Solid template: a
+crate-example runner wrapped by a `run.sh` built around a **deterministic count
+gate**.
+
+It exercises [`sparq-nlq`](../../crates/sparq-nlq)'s **offline** core: schema
+grounding (the `sparq-introspect` scan + token-budgeted summary render), prompt
+construction, and the `extract → spargebra-validate → budgeted-execute` loop.
+
+## Fully offline, deterministic (honest)
+
+The LLM is a tiny **in-example fixed-completion stub** — **no network, no `live`
+feature, no Anthropic round-trip** — so the example measures the crate's
+deterministic core, never a model call. The synthetic typed graph is generated
+in-example at a **pinned** `N` (the `run.sh` `NLQ_N` default), so every harvested
+value is a pure function of `N` + the synthetic schema and is byte-stable across
+machines. The per-phase microsecond timings the example prints are
+**NON-CANONICAL** and are **NOT** harvested.
+
+What IS harvested and asserted are the deterministic counts: the synthetic triple
+count, the grounded-prompt **char length** (a token-budget proxy — smaller is a
+leaner prompt), the `ask` loop's result-row count, and its repair-round count.
+
+This is a `featured = false` trend/coverage row, not a head-to-head competitor
+card. **HONESTY:** this is the *offline* deterministic loop only — LIVE
+NL→SPARQL exec-accuracy on a canonical host is a **separate** concern (beads
+`sq-qidj` / `sq-g0lw`, EC2-blocked) and is **not** claimed by this feed.
+
+## Sibling GenAI suites are EC2/dataset-gathered, not here
+
+The other GenAI suites — `sim-olympics-eval` (entity-similarity AUC/precision)
+and `introspect-olympics` (introspection build/output) — depend on the
+**gitignored** `bench/qlever-olympics/olympics.nt` (~1.78M triples), which is
+**not present in CI**. They are therefore **not** wired into this feed; their
+metrics are EC2/dataset-gathered. NL→SPARQL alone lights up the GenAI family row.
+
+## The gate: offline-loop counts (deterministic)
+
+`run.sh` runs the example at the pinned `N`, parses its stdout into the counts
+above, and diffs each against [`expected.tsv`](./expected.tsv) (DERIVED by
+running the example, not guessed). It exits non-zero on any drift, so a grounding
+or generation regression fails the whole `ci-bench` run. If you change `NLQ_N`
+you must re-derive `expected.tsv`.
+
+The metric names lead with the `nlq` token so the dashboard's `familyOf` prefix
+routing buckets them into the GenAI family automatically.
+
+## Run it
+
+```sh
+cargo build --release -p sparq-nlq --example bench
+bench/nlq/run.sh          # asserts vs expected.tsv; prints the <metric>\t<value>\t<unit> contract
+```
+
+The `nlq` hook in [`scripts/ci-bench.sh`](../../scripts/ci-bench.sh) builds the
+example and invokes `run.sh` on the **main / local tier** (skipped on the PR
+tier, like the Solid/RSP/HDT/ZK example hooks), harvesting the counts into the
+`customSmallerIsBetter` feed the dashboard reads.

--- a/bench/nlq/expected.tsv
+++ b/bench/nlq/expected.tsv
@@ -1,0 +1,22 @@
+# [OPUS-4.8] (sq-k0km) sparq-nlq OFFLINE NL->SPARQL suite DETERMINISTIC golden counts at the
+# PINNED N=2000 (bench/nlq/run.sh's NLQ_N default). These are a pure function of N + the
+# synthetic typed schema generated in crates/sparq-nlq/examples/bench.rs (no external data, no
+# network, offline fixed-completion stub LLM), so they are byte-stable across machines (NOT
+# wall-clock). Format: <metric>\t<count>. If you change NLQ_N you MUST re-derive these.
+#
+# DERIVED by RUNNING `cargo run -p sparq-nlq --example bench --release 2000` and reading its
+# stdout (not guessed); bench/nlq/run.sh re-runs it every commit and exits 1 on any drift,
+# exactly like LUBM's row-count diff / HDT's load-decode diff / Solid's auth-view diff. The us
+# timings the example also prints are NON-CANONICAL (dev/gh-runner box) and are NOT asserted.
+#
+#   nlq_synth_triples    triples in the synthetic typed graph (3 per entity: type/label/age)
+#   nlq_prompt_chars     length of the schema-grounded prompt prompt_for(question) builds
+#                        (a token-budget proxy — smaller = leaner grounded prompt)
+#   nlq_ask_result_rows  rows the full ask loop returns (GROUP BY ?type over the synthetic
+#                        graph -> one row per type)
+#   nlq_ask_repairs      repair rounds the ask loop needed (0 = the stub's first SPARQL was
+#                        spargebra-valid + executable)
+nlq_synth_triples	6000
+nlq_prompt_chars	1973
+nlq_ask_result_rows	2
+nlq_ask_repairs	0

--- a/bench/nlq/run.sh
+++ b/bench/nlq/run.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] (sq-k0km) sparq-nlq OFFLINE NL->SPARQL per-commit runner — the self-asserting
+# entry point CI calls, mirroring bench/solid/run.sh + bench/hdt/run.sh + bench/rsp/run.sh.
+# Self-contained + FULLY OFFLINE (no network, no `live` feature, no Anthropic round-trip):
+#   1. run the sparq-nlq `bench` EXAMPLE at a PINNED entity count (the example takes N as its
+#      first arg; pin it so the counts are comparable across commits). The LLM is a tiny
+#      in-example fixed-completion stub, so the example measures the crate's DETERMINISTIC
+#      core — schema grounding (sparq-introspect scan + token-budgeted summary render),
+#      prompt construction, and the extract->spargebra-validate->budgeted-execute loop — on a
+#      synthetic typed graph generated in-example from a fixed shape (NO external dataset).
+#   2. PARSE the example's human-readable stdout into the DETERMINISTIC STRUCTURAL COUNTS
+#      (synthetic triple count, grounded-prompt char length, ask result-row count, ask repair
+#      rounds — all a pure function of the FIXED N + synthetic schema, so byte-stable across
+#      machines: NOT wall-clock) and ASSERT each vs expected.tsv (exit 1 on any drift — the
+#      HARD correctness gate). The example does NOT emit a TSV itself, so the parse lives here
+#      (no crate change needed). The us timings the example also prints are NON-CANONICAL
+#      (dev/gh-runner box) and are NOT harvested.
+#   3. forward on STDOUT the 3-column `<metric>\t<value>\t<unit>` contract the ci-bench `nlq`
+#      hook consumes. The prompt-char length is a real token-budget proxy (smaller = leaner
+#      grounded prompt); the rest are structural counts. Correctness lives in expected.tsv,
+#      exactly like LUBM / FTS / HDT / RSP / Solid.
+#
+# These light up the dashboard's GenAI family row (familyOf: `nlq_*` -> genai). HONESTY: this
+# is the OFFLINE deterministic core only; LIVE NL->SPARQL exec-accuracy on a canonical host is
+# a SEPARATE concern (sq-qidj / sq-g0lw, EC2-blocked) and is NOT claimed here. The sibling
+# GenAI suites sim-olympics-eval + introspect-olympics need the gitignored 1.78M-triple
+# olympics.nt dataset (NOT in CI) and so are NOT wired here — they are EC2/dataset-gathered.
+# This is a TREND/coverage feed, NOT a head-to-head competitor card (featured = false).
+#
+# Usage: bench/nlq/run.sh   (run from anywhere; honours $NLQ_BIN / $NLQ_N overrides)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+EXP="$ROOT/bench/nlq/expected.tsv"
+# Pinned entity count — the counts (triples = 3*N, prompt chars, rows) are a function of N,
+# so it MUST match the value baked into expected.tsv. Override with $NLQ_N only when also
+# re-deriving expected.tsv.
+N="${NLQ_N:-2000}"
+# The runner: a sparq-nlq example (the crate is isolated — not a sparq-cli dependency).
+# Override with $NLQ_BIN for a custom build. NB the example's target name is `bench`, which
+# collides with other crates' `--example bench` binaries at target/release/examples/bench;
+# the ci-bench hook builds THIS crate's example immediately before invoking run.sh.
+BIN="${NLQ_BIN:-$ROOT/target/release/examples/bench}"
+
+if [ ! -x "$BIN" ]; then
+  echo "[nlq] ERROR: sparq-nlq bench example not found at $BIN" >&2
+  echo "[nlq]   build: cargo build --release -p sparq-nlq --example bench" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---- 1. run the example OFFLINE at the pinned N (human-readable stdout) --------------------
+"$BIN" "$N" > "$TMP/nlq.out" 2>"$TMP/nlq.err" || {
+  echo "[nlq] ERROR: sparq-nlq bench example exited non-zero" >&2
+  cat "$TMP/nlq.err" >&2 || true
+  exit 1
+}
+
+# ---- 2. extract the DETERMINISTIC counts (pure function of N + the synthetic schema) -------
+emit() { printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$TMP/nlq.tsv"; }
+: > "$TMP/nlq.tsv"
+
+# "synthetic graph: <N> entities, <T> triples"
+triples=$(grep -oE 'synthetic graph: [0-9]+ entities, [0-9]+ triples' "$TMP/nlq.out" | grep -oE '[0-9]+ triples' | grep -oE '[0-9]+' | head -1)
+# "  prompt: <C> chars"
+prompt_chars=$(grep -oE 'prompt: [0-9]+ chars' "$TMP/nlq.out" | grep -oE '[0-9]+' | head -1)
+# "  answered in <R> repair round(s); result rows = <X>"
+repairs=$(grep -oE 'answered in [0-9]+ repair round' "$TMP/nlq.out" | grep -oE '[0-9]+' | head -1)
+result_rows=$(grep -oE 'result rows = [0-9]+' "$TMP/nlq.out" | grep -oE '[0-9]+' | head -1)
+
+[ -n "$triples" ]      && emit nlq_synth_triples   "$triples"      count
+[ -n "$prompt_chars" ] && emit nlq_prompt_chars    "$prompt_chars" chars
+[ -n "$repairs" ]      && emit nlq_ask_repairs     "$repairs"      count
+[ -n "$result_rows" ]  && emit nlq_ask_result_rows "$result_rows"  count
+
+# ---- 3. assert vs expected.tsv (exit 1 on any drift) + forward the hook contract ----------
+fail=0
+seen=0
+while IFS=$'\t' read -r metric value unit; do
+  [ -n "$metric" ] || continue
+  exp="$(awk -F'\t' -v k="$metric" '$1==k{print $2}' "$EXP")"
+  if [ -z "$exp" ]; then
+    echo "[nlq] ERROR: $metric has no expected.tsv entry" >&2; fail=1; continue
+  fi
+  if [ "$value" != "$exp" ]; then
+    echo "[nlq] ERROR: $metric=$value expected=$exp (NLQ offline-loop count regression)" >&2; fail=1
+  fi
+  seen=$((seen+1))
+  printf '%s\t%s\t%s\n' "$metric" "$value" "$unit"
+done < "$TMP/nlq.tsv"
+
+# Every expected metric must have been emitted (a vanished count = a parse break or regression).
+exp_rows=$(grep -cvE '^#|^$' "$EXP")
+if [ "$seen" != "$exp_rows" ]; then
+  echo "[nlq] ERROR: emitted $seen metrics, expected $exp_rows (a metric vanished — parse break or schema change)" >&2; fail=1
+fi
+
+if [ "$fail" = 0 ]; then
+  echo "[nlq] OK: all $seen offline NL->SPARQL counts match expected.tsv (triples/prompt-chars/rows/repairs at N=$N)" >&2
+else
+  echo "[nlq] FAILED: one or more offline-loop counts diverged from expected.tsv" >&2
+fi
+exit "$fail"

--- a/bench/solid/README.md
+++ b/bench/solid/README.md
@@ -1,0 +1,50 @@
+<!-- [OPUS-4.8] sq-k0km — Solid WAC/ACP auth-view feed for the CI bench dashboard. -->
+# Solid WAC/ACP auth-view feed
+
+A small, self-asserting per-commit runner that feeds the dashboard's **Solid /
+access-control family** card so it stops rendering "not yet reported". It mirrors
+the LUBM / SHACL / HDT / RSP template: a crate-example runner wrapped by a
+`run.sh` built around a **deterministic count gate**.
+
+It exercises [`sparq-solid`](../../crates/sparq-solid): WAC + ACP authorization-view
+materialization over the in-crate fixture
+(`sparq_solid::fixture::{wac_fixture, acp_fixture}`).
+
+## Why counts, not timings (honest)
+
+The example (`crates/sparq-solid/examples/bench.rs`) also prints per-phase
+millisecond timings, but those are **NON-CANONICAL** (a dev / GitHub-runner box
+is not a quiet bench instance) and are **NOT** harvested. What IS harvested and
+asserted are the **deterministic structural counts** — a pure function of the
+**fixed** in-crate fixture, so they are byte-stable across machines: how many
+named graphs / quads the fixture holds, how many triples each materialised auth
+view contains, how many graphs are visible to ALICE, and the authorized-subset
+row count of the title query (the `query_as` vs `query_as_rewrite` paths
+assert-equal in the example).
+
+There is **no competitor perf column**: no Solid peer engine computes a
+like-for-like WAC/ACP auth view, and this suite is `featured = false` in
+`bench/benchmarks.toml` (a dashboard disposition — a trend/coverage row, never a
+head-to-head card).
+
+## The gate: auth-view counts (deterministic)
+
+`run.sh` runs the example, parses its stdout into the counts above, and diffs
+each against [`expected.tsv`](./expected.tsv) (DERIVED by running the example, not
+guessed). It exits non-zero on any drift — exactly like LUBM's row-count diff —
+so a fixture or materialization regression fails the whole `ci-bench` run.
+
+The metric names lead with the `solid` token so the dashboard's `familyOf`
+prefix routing buckets them into the Solid family automatically.
+
+## Run it
+
+```sh
+cargo build --release -p sparq-solid --example bench
+bench/solid/run.sh        # asserts vs expected.tsv; prints the <metric>\t<value>\tcount contract
+```
+
+The `solid` hook in [`scripts/ci-bench.sh`](../../scripts/ci-bench.sh) builds the
+example and invokes `run.sh` on the **main / local tier** (skipped on the PR
+tier, like the RSP/HDT/ZK example hooks, to keep per-PR CI lean), harvesting the
+counts into the `customSmallerIsBetter` feed the dashboard reads.

--- a/bench/solid/expected.tsv
+++ b/bench/solid/expected.tsv
@@ -1,0 +1,26 @@
+# [OPUS-4.8] (sq-k0km) Solid WAC/ACP suite DETERMINISTIC golden counts. These are a pure
+# function of the in-crate fixture (sparq_solid::fixture::{wac_fixture, acp_fixture}) — the
+# materialised auth-view sizes + authorized-subset row counts — so they are byte-stable
+# across machines (NOT wall-clock). Format: <metric>\t<count>.
+#
+# DERIVED by RUNNING crates/sparq-solid/examples/bench.rs and reading its stdout (not
+# guessed); bench/solid/run.sh re-runs it every commit and exits 1 on any drift, exactly
+# like LUBM's row-count diff / HDT's load-decode diff / RSP's per-window-row diff. The ms
+# timings the example also prints are NON-CANONICAL (dev/gh-runner box) and are NOT asserted.
+#
+#   solid_wac_named_graphs      named graphs in the WAC fixture
+#   solid_wac_quads             total quads across the WAC fixture's named graphs
+#   solid_wac_auth_triples      triples in the materialised WAC auth view (materialize_wac)
+#   solid_acp_auth_triples      triples in the materialised ACP auth view (materialize_acp,
+#                               3 strata)
+#   solid_alice_readable_graphs graphs visible to ALICE in Mode::Read (AuthIndex walk)
+#   solid_full_dataset_rows     rows of the title query over the FULL dataset (GRAPH ?g)
+#   solid_authorized_rows       rows of the title query restricted to alice's authorized
+#                               subset (query_as / query_as_rewrite assert-equal)
+solid_wac_named_graphs	1148
+solid_wac_quads	3060
+solid_wac_auth_triples	3783
+solid_acp_auth_triples	6355
+solid_alice_readable_graphs	800
+solid_full_dataset_rows	864
+solid_authorized_rows	599

--- a/bench/solid/run.sh
+++ b/bench/solid/run.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] (sq-k0km) Solid WAC/ACP per-commit runner — the self-asserting entry point CI
+# calls, mirroring bench/hdt/run.sh + bench/rsp/run.sh + bench/fts/run.sh. Self-contained:
+#   1. run the sparq-solid `bench` EXAMPLE (the crate is isolated — not a sparq-cli
+#      dependency, so the runner is a crate example, like HDT's bench_oracle / RSP's
+#      rsp_oracle). It builds the in-crate ~1.1k-graph WAC fixture (+ the ACP variant),
+#      materialises each auth view, and runs the authorized-subset queries.
+#   2. PARSE the example's human-readable stdout into the DETERMINISTIC STRUCTURAL COUNTS
+#      (named-graph / quad / auth-triple / authorized-row counts — all a pure function of
+#      the FIXED in-crate fixture, so byte-stable across machines: NOT wall-clock) and
+#      ASSERT each vs expected.tsv (exit 1 on any drift — the HARD correctness gate). The
+#      example does NOT emit a TSV itself, so the parse lives here (no crate change needed):
+#      these counts are the deterministic load-bearing signal, the ms timings the example
+#      also prints are NON-CANONICAL (dev/gh-runner box) and are NOT harvested.
+#   3. forward on STDOUT the 3-column `<metric>\t<value>\t<unit>` contract the ci-bench
+#      `solid` hook consumes — the asserted DETERMINISTIC counts, every one a `count` unit.
+#      Correctness lives in expected.tsv, exactly like LUBM / FTS / HDT / RSP.
+#
+# These are the access-control auth-view materialisation COUNTS (how many graphs/quads the
+# WAC + ACP fixtures contain, how many triples each materialised auth view holds, how many
+# graphs are visible to alice, and the authorized-subset row count of the title query). They
+# light up the dashboard's Solid / access-control family row (familyOf: `solid_*` -> solid).
+# This is a TREND/coverage feed, NOT a head-to-head competitor card (no Solid peer engine
+# computes a like-for-like WAC auth view — featured = false in bench/benchmarks.toml).
+#
+# Usage: bench/solid/run.sh   (run from anywhere; honours $SOLID_BIN override)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+EXP="$ROOT/bench/solid/expected.tsv"
+# The runner: a sparq-solid example (the crate is isolated — not a sparq-cli dependency).
+# Override with $SOLID_BIN for a custom build. NB the example's target name is `bench`, which
+# collides with other crates' `--example bench` binaries at target/release/examples/bench;
+# the ci-bench hook builds THIS crate's example immediately before invoking run.sh so the
+# binary on disk is sparq-solid's, but $SOLID_BIN lets a caller point at an unambiguous path.
+BIN="${SOLID_BIN:-$ROOT/target/release/examples/bench}"
+
+if [ ! -x "$BIN" ]; then
+  echo "[solid] ERROR: sparq-solid bench example not found at $BIN" >&2
+  echo "[solid]   build: cargo build --release -p sparq-solid --example bench" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# ---- 1. run the example (human-readable stdout; deterministic structural counts within) ---
+"$BIN" > "$TMP/solid.out" 2>"$TMP/solid.err" || {
+  echo "[solid] ERROR: sparq-solid bench example exited non-zero" >&2
+  cat "$TMP/solid.err" >&2 || true
+  exit 1
+}
+
+# ---- 2. extract the DETERMINISTIC counts from the stdout (pure function of the fixture) ----
+# Each grep targets a stable, anchored phrase the example prints. A missing capture leaves the
+# var empty so the expected.tsv cross-check below fails loudly (never a silent skip).
+emit() { printf '%s\t%s\t%s\n' "$1" "$2" "count" >> "$TMP/solid.tsv"; }
+: > "$TMP/solid.tsv"
+
+# "WAC fixture: <G> named graphs, <Q> quads"
+wac_graphs=$(grep -oE 'WAC fixture: [0-9]+ named graphs' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1)
+wac_quads=$(grep -oE 'WAC fixture: [0-9]+ named graphs, [0-9]+ quads' "$TMP/solid.out" | grep -oE '[0-9]+ quads' | grep -oE '[0-9]+' | head -1)
+# The first "auth view: <T> triples" line is the WAC materialisation; the second is ACP.
+mapfile -t auth_triples < <(grep -oE 'auth view: [0-9]+ triples' "$TMP/solid.out" | grep -oE '[0-9]+')
+wac_auth=${auth_triples[0]:-}
+acp_auth=${auth_triples[1]:-}
+# "alice readable graphs: <N>"
+alice_graphs=$(grep -oE 'alice readable graphs: [0-9]+' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1)
+# The FULL-dataset GRAPH-?g query row count (first "rows: <N>" line) and the authorized-subset
+# row count (the "rows: <N> (authorized subset)" line — v1 and v2 assert-equal in the example).
+full_rows=$(grep -oE '    rows: [0-9]+' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1)
+auth_rows=$(grep -oE 'rows: [0-9]+ \(authorized subset\)' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1)
+
+[ -n "$wac_graphs" ]  && emit solid_wac_named_graphs      "$wac_graphs"
+[ -n "$wac_quads" ]   && emit solid_wac_quads             "$wac_quads"
+[ -n "$wac_auth" ]    && emit solid_wac_auth_triples      "$wac_auth"
+[ -n "$acp_auth" ]    && emit solid_acp_auth_triples      "$acp_auth"
+[ -n "$alice_graphs" ]&& emit solid_alice_readable_graphs "$alice_graphs"
+[ -n "$full_rows" ]   && emit solid_full_dataset_rows     "$full_rows"
+[ -n "$auth_rows" ]   && emit solid_authorized_rows       "$auth_rows"
+
+# ---- 3. assert vs expected.tsv (exit 1 on any drift) + forward the hook contract ----------
+fail=0
+seen=0
+while IFS=$'\t' read -r metric value unit; do
+  [ -n "$metric" ] || continue
+  exp="$(awk -F'\t' -v k="$metric" '$1==k{print $2}' "$EXP")"
+  if [ -z "$exp" ]; then
+    echo "[solid] ERROR: $metric has no expected.tsv entry" >&2; fail=1; continue
+  fi
+  if [ "$value" != "$exp" ]; then
+    echo "[solid] ERROR: $metric=$value expected=$exp (Solid auth-view count regression)" >&2; fail=1
+  fi
+  seen=$((seen+1))
+  printf '%s\t%s\t%s\n' "$metric" "$value" "$unit"
+done < "$TMP/solid.tsv"
+
+# Every expected metric must have been emitted (a vanished count = a parse break or regression).
+exp_rows=$(grep -cvE '^#|^$' "$EXP")
+if [ "$seen" != "$exp_rows" ]; then
+  echo "[solid] ERROR: emitted $seen count metrics, expected $exp_rows (a count metric vanished — parse break or fixture change)" >&2; fail=1
+fi
+
+if [ "$fail" = 0 ]; then
+  echo "[solid] OK: all $seen WAC/ACP auth-view counts match expected.tsv (graphs/quads/auth-triples/authorized-rows)" >&2
+else
+  echo "[solid] FAILED: one or more auth-view counts diverged from expected.tsv" >&2
+fi
+exit "$fail"

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -166,6 +166,25 @@ RSP_RUN=bench/rsp/run.sh
 # (a contention-robust RATIO) are trend-only (NOT in scripts/perf-gate.py). Registry:
 # bench/benchmarks.toml (hdt-suite); details: bench/hdt/README.md.
 HDT_RUN=bench/hdt/run.sh
+# [OPUS-4.8] Solid WAC/ACP per-commit hook (sq-k0km). Like RSP/HDT the runner is a crate
+# EXAMPLE (sparq-solid's `bench`) that only needs `cargo`. run.sh is the self-asserting entry
+# point: it materialises the in-crate WAC + ACP fixtures and asserts every DETERMINISTIC
+# STRUCTURAL count (named-graph/quad/auth-triple/authorized-row counts — a pure function of the
+# FIXED fixture, byte-stable across machines) vs bench/solid/expected.tsv (exit 1 on drift), then
+# prints the `<metric>\t<value>\tcount` contract. These light up the dashboard's Solid/access-
+# control family row (familyOf: `solid_*` -> solid). Registry: bench/benchmarks.toml
+# (solid-wac-bench); details: bench/solid/README.md.
+SOLID_RUN=bench/solid/run.sh
+# [OPUS-4.8] sparq-nlq OFFLINE NL->SPARQL per-commit hook (sq-k0km). Crate-example runner
+# (sparq-nlq's `bench`), cargo-only, FULLY OFFLINE (no network, no `live` feature). run.sh pins
+# N and asserts the DETERMINISTIC counts (synthetic triples / grounded-prompt chars / ask rows /
+# repair rounds — a pure function of N + the synthetic schema) vs bench/nlq/expected.tsv (exit 1
+# on drift), then prints the `<metric>\t<value>\t<unit>` contract. These light up the dashboard's
+# GenAI family row (familyOf: `nlq_*` -> genai). HONESTY: offline deterministic core only; the
+# sibling GenAI suites (sim-olympics-eval / introspect-olympics) need the gitignored 1.78M-triple
+# olympics.nt dataset (NOT in CI) and the GPU suite needs a GPU backend (NOT on gh runners) — both
+# are EC2/dataset-gathered, NOT wired here. Registry: bench/benchmarks.toml (nlq-offline-bench).
+NLQ_RUN=bench/nlq/run.sh
 TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
 RES="$TMP/res.tsv"; : > "$RES"
 add() { printf '%s\t%s\t%s\n' "$1" "$2" "$3" >> "$RES"; }
@@ -851,6 +870,74 @@ elif command -v cargo >/dev/null 2>&1 && [ -f "$ZK_HARVEST" ]; then
   fi
 else
   echo "note: zk criterion suites skipped (cargo not on PATH or $ZK_HARVEST missing)" >&2
+fi
+
+# [OPUS-4.8] Solid WAC/ACP per-commit hook (sq-k0km). Crate-example runner (sparq-solid's
+# `bench`), cargo-only — so, exactly like the RSP/HDT/ZK-criterion hooks, PINNED to the
+# MAIN/local tier (run on push-to-main or a LOCAL run where GITHUB_REF is unset; SKIPPED on
+# the PR tier) to keep the example build off per-PR CI. run.sh asserts every DETERMINISTIC
+# count vs expected.tsv internally (exit 1 on drift), failing the whole ci-bench run on a
+# regression exactly like RSP/HDT. We harvest its `<metric>\t<value>\tcount` stdout; every row
+# is a DETERMINISTIC structural count emitted for the dashboard's Solid family card (correctness
+# is the run.sh internal gate, so these are trend rows, NOT perf-gate ratchets).
+SOLID_BIN=target/release/examples/bench
+SOLID_REF="${GITHUB_REF:-}"
+if [ -n "$SOLID_REF" ] && [ "$SOLID_REF" != "refs/heads/main" ]; then
+  echo "note: solid skipped (PR tier — sparq-solid example build/run is main-only, like the rsp/hdt hooks)" >&2
+elif command -v cargo >/dev/null 2>&1 && [ -x "$SOLID_RUN" ]; then
+  # Always (re)build: rust-cache restores target/, AND the example target name `bench` is shared
+  # by several crates, so build sparq-solid's IMMEDIATELY before invoking run.sh to be sure the
+  # binary on disk is this crate's.
+  if ! cargo build --release -q -p sparq-solid --example bench; then
+    echo "ERROR: sparq-solid bench example failed to build" >&2
+    exit 1
+  fi
+  if SOLID_BIN="$SOLID_BIN" bash "$SOLID_RUN" > "$TMP/solid.tsv" 2>"$TMP/solid.err"; then
+    while IFS=$'\t' read -r metric value unit; do
+      [ -n "${metric:-}" ] && [ -n "${value:-}" ] || continue
+      add "$metric" "${unit:-count}" "$value"
+    done < "$TMP/solid.tsv"
+  else
+    echo "ERROR: solid run.sh failed (auth-view count regression)" >&2
+    cat "$TMP/solid.err" >&2 || true
+    exit 1
+  fi
+else
+  echo "note: solid skipped (cargo not on PATH or $SOLID_RUN missing)" >&2
+fi
+
+# [OPUS-4.8] sparq-nlq OFFLINE NL->SPARQL per-commit hook (sq-k0km). Crate-example runner
+# (sparq-nlq's `bench`), cargo-only + FULLY OFFLINE — so, like the solid/rsp/hdt hooks, PINNED
+# to the MAIN/local tier (SKIPPED on the PR tier). run.sh pins N and asserts every DETERMINISTIC
+# count vs expected.tsv internally (exit 1 on drift), failing the whole ci-bench run on a
+# regression. We harvest its `<metric>\t<value>\t<unit>` stdout for the dashboard's GenAI family
+# card (correctness is the run.sh internal gate, so these are trend rows). The sibling GenAI
+# suites (sim/introspect) need the gitignored olympics.nt (NOT in CI) and the GPU suite needs a
+# GPU backend (NOT on gh runners): both are EC2/dataset-gathered and intentionally NOT emitted.
+NLQ_BIN=target/release/examples/bench
+NLQ_REF="${GITHUB_REF:-}"
+if [ -n "$NLQ_REF" ] && [ "$NLQ_REF" != "refs/heads/main" ]; then
+  echo "note: nlq skipped (PR tier — sparq-nlq example build/run is main-only, like the solid/rsp/hdt hooks)" >&2
+elif command -v cargo >/dev/null 2>&1 && [ -x "$NLQ_RUN" ]; then
+  # Always (re)build IMMEDIATELY before run.sh: the example target name `bench` is shared by
+  # several crates (e.g. sparq-solid's, built just above), so this build resets the on-disk
+  # binary to sparq-nlq's before the runner invokes it.
+  if ! cargo build --release -q -p sparq-nlq --example bench; then
+    echo "ERROR: sparq-nlq bench example failed to build" >&2
+    exit 1
+  fi
+  if NLQ_BIN="$NLQ_BIN" bash "$NLQ_RUN" > "$TMP/nlq.tsv" 2>"$TMP/nlq.err"; then
+    while IFS=$'\t' read -r metric value unit; do
+      [ -n "${metric:-}" ] && [ -n "${value:-}" ] || continue
+      add "$metric" "${unit:-count}" "$value"
+    done < "$TMP/nlq.tsv"
+  else
+    echo "ERROR: nlq run.sh failed (offline-loop count regression)" >&2
+    cat "$TMP/nlq.err" >&2 || true
+    exit 1
+  fi
+else
+  echo "note: nlq skipped (cargo not on PATH or $NLQ_RUN missing)" >&2
 fi
 
 # RDFS inference (seconds) — instance-heavy: SCALE individuals under a depth-20 class hierarchy.

--- a/scripts/gen-metric-labels.py
+++ b/scripts/gen-metric-labels.py
@@ -565,6 +565,63 @@ def build():
         "mode": "ratio", "unit": "ratio",
     }
 
+    # 13.6) SOLID WAC/ACP auth-view suite (sq-k0km). The ci-bench `solid` hook (bench/solid/run.sh)
+    # emits DETERMINISTIC STRUCTURAL counts — a pure function of the in-crate WAC + ACP fixtures
+    # (sparq_solid::fixture), byte-stable across machines (NOT wall-clock). These are the gate (the
+    # run.sh self-assertion vs bench/solid/expected.tsv) and the dashboard's Solid/access-control
+    # family card data. The `suite` lowercases to "solid", which the dashboard's `solid` FAMILY
+    # (familyOf) matches, so every metric routes to the Solid card. The metric STEMS here MUST match
+    # what scripts/ci-bench.sh emits so the gen-metric-labels --check drift gate stays green.
+    SOLID_DATASET = ("in-crate ~1.1k-graph WAC fixture (+ ACP variant), built deterministically by "
+                     "sparq_solid::fixture::{wac_fixture, acp_fixture}")
+    SOLID_GATE = {
+        "solid_wac_named_graphs": "named graphs in the WAC fixture",
+        "solid_wac_quads": "total quads across the WAC fixture's named graphs",
+        "solid_wac_auth_triples": "triples in the materialised WAC auth view (materialize_wac)",
+        "solid_acp_auth_triples": "triples in the materialised ACP auth view (materialize_acp, 3 strata)",
+        "solid_alice_readable_graphs": "graphs visible to ALICE in Mode::Read (AuthIndex walk)",
+        "solid_full_dataset_rows": "rows of the title query over the FULL dataset (GRAPH ?g)",
+        "solid_authorized_rows": "rows of the title query restricted to alice's authorized subset",
+    }
+    for name, desc in SOLID_GATE.items():
+        labels[name] = {
+            "label": "Solid %s — WAC/ACP auth-view count" % name.replace("solid_", ""),
+            "suite": "Solid", "dataset": SOLID_DATASET,
+            "query": desc, "mode": "count", "unit": "count",
+        }
+
+    # 13.7) GenAI — sparq-nlq OFFLINE NL->SPARQL suite (sq-k0km). The ci-bench `nlq` hook
+    # (bench/nlq/run.sh) emits DETERMINISTIC counts at a PINNED N=2000 — a pure function of N + the
+    # synthetic typed schema (no external data, no network, offline fixed-completion stub LLM), so
+    # byte-stable across machines (NOT wall-clock). These are the gate (run.sh self-assertion vs
+    # bench/nlq/expected.tsv) and the dashboard's GenAI family card data. The `nlq` token / "NL→SPARQL"
+    # suite both route the metrics to the dashboard's `genai` FAMILY (familyOf). HONESTY: offline
+    # deterministic core only — LIVE exec-accuracy on a canonical host is a SEPARATE concern (sq-qidj/
+    # sq-g0lw, EC2-blocked) and the sibling sim/introspect GenAI suites need the gitignored olympics.nt
+    # (NOT in CI); both are EC2/dataset-gathered, not in this feed.
+    NLQ_DATASET = ("synthetic typed graph generated in-example at N=2000 entities "
+                   "(rdf:type/rdfs:label/ex:age per entity); deterministic, no external data, "
+                   "offline stub LLM (no `live` feature, no network)")
+    labels["nlq_synth_triples"] = {
+        "label": "NL→SPARQL synthetic graph — triple count",
+        "suite": "NL→SPARQL", "dataset": NLQ_DATASET,
+        "query": "triples in the synthetic typed graph (3 per entity)", "mode": "count", "unit": "count"}
+    labels["nlq_prompt_chars"] = {
+        "label": "NL→SPARQL grounded prompt — char length (token-budget proxy)",
+        "suite": "NL→SPARQL", "dataset": NLQ_DATASET,
+        "query": "length of the schema-grounded prompt prompt_for(question) builds; smaller = leaner",
+        "mode": "count", "unit": "chars"}
+    labels["nlq_ask_result_rows"] = {
+        "label": "NL→SPARQL ask loop — result rows",
+        "suite": "NL→SPARQL", "dataset": NLQ_DATASET,
+        "query": "rows the full ask loop returns (GROUP BY ?type -> one row per type)",
+        "mode": "count", "unit": "count"}
+    labels["nlq_ask_repairs"] = {
+        "label": "NL→SPARQL ask loop — repair rounds",
+        "suite": "NL→SPARQL", "dataset": NLQ_DATASET,
+        "query": "repair rounds the ask loop needed (0 = stub's first SPARQL was valid + executable)",
+        "mode": "count", "unit": "count"}
+
     # 14) ZERO-KNOWLEDGE family (sq dashboard-data-feed; ci-bench ZK hooks). EVERY ZK metric
     # name leads with the token `zk` so the dashboard's Zero-knowledge family prefix routing
     # buckets it. Three feeds, each grounded in an EXISTING bench (bench/benchmarks.toml zk-*):


### PR DESCRIPTION
> 🤖 SPARQ agent

Wires the remaining capability-family metrics into the github-action-benchmark `customSmallerIsBetter` series that `bench.yml` publishes, so the in-site dashboard family cards registered in #362 stop rendering "not yet reported". Closes bead **sq-k0km**.

## Families WIRED (real, deterministic, CI-runnable)

| family | already? | this PR | metrics |
|---|---|---|---|
| ZK | ✅ landed (sq earlier) | — | `zk_compose_*_gates`, `zk_commit_*`, `zk_trace_*` |
| HDT | ✅ landed | — | `snikmeta_*`, `hdt_load_s`, `hdt_vs_ntgz_load_s` |
| RSP | ✅ landed | — | `rsp_*_rows`, `rsp_persistentdict_triples_per_s` |
| **Solid** | — | **NEW** | `solid_wac_named_graphs/quads/auth_triples`, `solid_acp_auth_triples`, `solid_alice_readable_graphs`, `solid_full_dataset_rows`, `solid_authorized_rows` |
| **GenAI (NL→SPARQL)** | — | **NEW** | `nlq_synth_triples`, `nlq_prompt_chars`, `nlq_ask_result_rows`, `nlq_ask_repairs` |

Both new feeds harvest **deterministic structural counts** (a pure function of the fixed in-crate fixture / synthetic schema — byte-stable across machines, NOT wall-clock). The per-phase timings the examples print are NON-CANONICAL and are deliberately NOT harvested. Each is wrapped by a self-asserting `bench/<family>/run.sh` (mirroring `bench/rsp` / `bench/hdt`) that diffs against `expected.tsv` and **exits 1 on drift** — so a fixture/materialization/grounding regression fails the whole `ci-bench` run.

NL→SPARQL is **fully offline** (no network, no `live` feature, in-example fixed-completion stub LLM).

## Families HONESTLY DEFERRED (no fake work-box numbers)

- **GenAI sim/introspect** (`sim-olympics-eval`, `introspect-olympics`) — depend on the **gitignored** `bench/qlever-olympics/olympics.nt` (~1.78M triples), which is **not present in CI**. EC2/dataset-gathered; the dashboard keeps these rows "not yet reported" (honest coverage), and they remain `featured = false`.
- **GPU** (`gpu-bench`) — needs a GPU backend; **GitHub-hosted runners have no GPU**. EC2-gathered.
- **MPC** (`mpc-bench-matrix`) — modelled counting tier; out of this bead's scope.

No fabricated numbers were emitted for any deferred family.

## What changed (no `crates/` source)

- `scripts/ci-bench.sh` — new `solid` + `nlq` hooks (cargo-only crate-example runners), pinned to the **main/local tier** (skipped on the PR tier, like the rsp/hdt/zk example hooks) to keep per-PR CI lean. The runners parse the existing example stdout (no crate edit).
- `bench/solid/{run.sh,expected.tsv,README.md}`, `bench/nlq/{run.sh,expected.tsv,README.md}` — new self-asserting runners + golden counts + docs.
- `scripts/gen-metric-labels.py` — Solid + NL→SPARQL label sections; `bench/dashboard/metric-labels.json` regenerated (`--check` green, 428 metrics).
- `bench/dashboard/dashboard.js` — stale FAMILIES comment updated (which hooks landed vs which stay EC2/dataset-deferred). No logic change.

## Gates (all green, locally reproduced)

- Full `scripts/ci-bench.sh` run (exit 0) emits **all 11 new metrics** into the `customSmallerIsBetter` JSON (466 total, 0 malformed) — the exact artifact bench.yml feeds the action + the dashboard reads.
- Both `run.sh`: exit 0 on match, exit 1 on injected drift.
- `bench.yml`: valid YAML + `actionlint` clean (no actions added; SHA-pins intact).
- `bash -n` clean on all 3 scripts; new `run.sh` shellcheck-clean.
- `gen-metric-labels.py --check` up to date; `drift-scan.py` dry-run exit 0; `check-no-perf-numbers.py --enforce` 0 findings.
- `node --check dashboard.js` + `dashboard-smoke.js` pass; `familyOf` routes every new metric to the correct family (`solid_*` → solid, `nlq_*` → genai).
- **gate aggregator (`ci-summary`) topology unchanged** — new metrics flow through the existing `bash scripts/ci-bench.sh` step into the existing feed; no new gating leg.

Compliance gap closed: the dashboard's Solid + GenAI(NL→SPARQL) family cards now render real per-commit deterministic data instead of "not yet reported"; remaining gaps (sim/introspect/GPU/MPC) are honestly attributed to EC2/dataset constraints, not faked.