### PR TITLE
feat(sparq-introspect): ABSTAT-style type minimalization over rdfs:subClassOf (sq-lc3)

### DIFF
--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -16,6 +16,13 @@ use sparq_introspect::{Introspection, BuildOptions};
 
 let ix = Introspection::build(&graph);              // or build_with(&graph, &BuildOptions{..})
 
+// ABSTAT-style type minimalization (opt-in): fold each subject's types to the
+// most-specific via the graph's own rdfs:subClassOf chains, so e.g. a subject typed
+// both dbo:SportsEvent and dbo:Sport (SportsEvent ⊑ Sport) is profiled only under the
+// minimal dbo:SportsEvent — not both.
+let opts = BuildOptions { minimalize_types: true, ..BuildOptions::default() };
+let ix_min = Introspection::build_with(&graph, &opts);
+
 ix.classes              // Vec<ClassProfile>      — by instance count, with per-class usage
 ix.predicates           // Vec<PredicateProfile>  — global stats + observed/declared domain/range
 ix.characteristic_sets  // CharacteristicSets     — top sets + exact tail aggregates
@@ -74,6 +81,18 @@ let ix = sparq_introspect::Introspection::load("data/g.nt.introspect")?; // O(ou
   predicate, and `sh:maxCount 1` exactly when avg multiplicity is 1. Constraints are mined
   from what the data asserts — a data-grounded effective-schema floor, not an aspirational
   contract. Sets with no universal class yield a reusable but target-less shape.
+- **ABSTAT-style type minimalization** (`BuildOptions::minimalize_types`, off by default) —
+  folds each subject's asserted types to the **minimal** (most-specific) set via the graph's
+  own `rdfs:subClassOf` chains: a type `D` is dropped from a subject whenever the subject also
+  carries a `C` with `C rdfs:subClassOf+ D` (`C ≠ D`), so a subject typed both
+  `dbo:SportsEvent` and `dbo:Sport` (where `SportsEvent ⊑ Sport`) is profiled only under the
+  minimal `dbo:SportsEvent`. The subsumption relation is the transitive closure of the
+  `subClassOf` triples **present in the graph** — no external ontology fetch and no OWL
+  reasoning — and `subClassOf` cycles are tolerated as class-equivalence (neither member
+  dropped). It applies uniformly to class extents, per-class usage, characteristic-set type
+  histograms, observed domain/range, and the cross-class join hints. Additive: no new
+  dependency, and the default output (every asserted type — the ABSTAT "full" profile) is
+  unchanged.
 - **Vocabulary detection** — namespaces in use (split at the last `#`/`/`) with distinct-term
   counts, recognised against a bundled offline table (rdf/rdfs/owl/xsd/foaf/skos/schema.org/
   dcterms/wd/dbo/…).

--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -16,13 +16,6 @@ use sparq_introspect::{Introspection, BuildOptions};
 
 let ix = Introspection::build(&graph);              // or build_with(&graph, &BuildOptions{..})
 
-// ABSTAT-style type minimalization (opt-in): fold each subject's types to the
-// most-specific via the graph's own rdfs:subClassOf chains, so e.g. a subject typed
-// both dbo:SportsEvent and dbo:Sport (SportsEvent ⊑ Sport) is profiled only under the
-// minimal dbo:SportsEvent — not both.
-let opts = BuildOptions { minimalize_types: true, ..BuildOptions::default() };
-let ix_min = Introspection::build_with(&graph, &opts);
-
 ix.classes              // Vec<ClassProfile>      — by instance count, with per-class usage
 ix.predicates           // Vec<PredicateProfile>  — global stats + observed/declared domain/range
 ix.characteristic_sets  // CharacteristicSets     — top sets + exact tail aggregates
@@ -81,18 +74,7 @@ let ix = sparq_introspect::Introspection::load("data/g.nt.introspect")?; // O(ou
   predicate, and `sh:maxCount 1` exactly when avg multiplicity is 1. Constraints are mined
   from what the data asserts — a data-grounded effective-schema floor, not an aspirational
   contract. Sets with no universal class yield a reusable but target-less shape.
-- **ABSTAT-style type minimalization** (`BuildOptions::minimalize_types`, off by default) —
-  folds each subject's asserted types to the **minimal** (most-specific) set via the graph's
-  own `rdfs:subClassOf` chains: a type `D` is dropped from a subject whenever the subject also
-  carries a `C` with `C rdfs:subClassOf+ D` (`C ≠ D`), so a subject typed both
-  `dbo:SportsEvent` and `dbo:Sport` (where `SportsEvent ⊑ Sport`) is profiled only under the
-  minimal `dbo:SportsEvent`. The subsumption relation is the transitive closure of the
-  `subClassOf` triples **present in the graph** — no external ontology fetch and no OWL
-  reasoning — and `subClassOf` cycles are tolerated as class-equivalence (neither member
-  dropped). It applies uniformly to class extents, per-class usage, characteristic-set type
-  histograms, observed domain/range, and the cross-class join hints. Additive: no new
-  dependency, and the default output (every asserted type — the ABSTAT "full" profile) is
-  unchanged.
+- **ABSTAT-style type minimalization** (`BuildOptions::minimalize_types`, off by default) — folds each subject's types to the most-specific set via the in-graph `rdfs:subClassOf` closure (no OWL/fetch; cycles tolerated); default full-type output unchanged. See the rustdoc.
 - **Vocabulary detection** — namespaces in use (split at the last `#`/`/`) with distinct-term
   counts, recognised against a bundled offline table (rdf/rdfs/owl/xsd/foaf/skos/schema.org/
   dcterms/wd/dbo/…).

--- a/crates/sparq-introspect/src/lib.rs
+++ b/crates/sparq-introspect/src/lib.rs
@@ -14,6 +14,11 @@ use sparq_core::Graph;
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
 const RDFS_DOMAIN: &str = "http://www.w3.org/2000/01/rdf-schema#domain";
 const RDFS_RANGE: &str = "http://www.w3.org/2000/01/rdf-schema#range";
+// [OPUS-4.8] sq-lc3: the class-subsumption predicate driving ABSTAT-style type
+// minimalization. A `(C rdfs:subClassOf D)` triple makes `D` a superclass of `C`
+// (proper when `C ≠ D`); minimalization drops a subject's superclass types in favour
+// of its most-specific (minimal) types — see `BuildOptions::minimalize_types`.
+const RDFS_SUBCLASS_OF: &str = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
 const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
 const VOID_NS: &str = "http://rdfs.org/ns/void#";
 /// [OPUS-4.8] sq-bde: the W3C SHACL namespace. [`Introspection::to_shacl`] exports each
@@ -152,6 +157,25 @@ pub struct BuildOptions {
     pub max_join_hints: usize,
     /// Sample values are truncated to this many characters.
     pub max_sample_chars: usize,
+    /// [OPUS-4.8] sq-lc3: **ABSTAT-style type minimalization** over the graph's
+    /// `rdfs:subClassOf` hierarchy. When `true`, before any pattern is mined each
+    /// subject's asserted type set is folded to its **minimal** (most-specific) types:
+    /// a type `D` is dropped from a subject iff the subject also carries some type `C`
+    /// for which `(C rdfs:subClassOf+ D)` holds and `C ≠ D` — i.e. `D` is a proper
+    /// superclass of an asserted (more specific) class of the same subject. The
+    /// subsumption relation is the transitive closure of the `rdfs:subClassOf` triples
+    /// **present in the graph** (no external ontology fetch, no OWL reasoning); cycles
+    /// are tolerated (mutually-`subClassOf` classes are treated as equivalent and none
+    /// is dropped). Minimalization is applied uniformly: it changes `class_instances`,
+    /// per-class predicate usage, characteristic-set `rdf:type` histograms, observed
+    /// domain/range, and the cross-class join hints — every pattern reads the same
+    /// minimalized type map. Untyped subjects, literal/blank type objects, and classes
+    /// with no `subClassOf` edge are unaffected.
+    ///
+    /// Default `false`: the mined schema reports **every** asserted type (the ABSTAT
+    /// "full" profile). This is opt-in and additive — it neither pulls a new dependency
+    /// nor changes the default output.
+    pub minimalize_types: bool,
 }
 
 impl Default for BuildOptions {
@@ -163,6 +187,9 @@ impl Default for BuildOptions {
             max_namespaces: 200,
             max_join_hints: 1000,
             max_sample_chars: 60,
+            // [OPUS-4.8] sq-lc3: report every asserted type by default; minimalization
+            // is opt-in.
+            minimalize_types: false,
         }
     }
 }
@@ -508,18 +535,44 @@ impl Introspection {
         let id_of = |iri: &str| graph.id_of(&Term::NamedNode(NamedNode::new_unchecked(iri)));
         let type_id = id_of(RDF_TYPE);
 
-        // ---- 1. Type map: subject -> class ids, class -> instance count. One range
-        // scan of the rdf:type block. Only IRI objects count as classes.
+        // ---- 1. Type map: subject -> class ids. One range scan of the rdf:type block.
+        // Only IRI objects count as classes.
         let mut subj_types: FxHashMap<Id, Vec<Id>> = FxHashMap::default();
-        let mut class_instances: FxHashMap<Id, u64> = FxHashMap::default();
         if let Some(tid) = type_id {
             let scan = graph.store.scan(&[None, Some(tid), None]);
             for row in scan.rows.iter() {
                 let [s, _, c] = scan.to_spo(row);
                 if is_iri(graph, c) {
                     subj_types.entry(s).or_default().push(c);
-                    *class_instances.entry(c).or_default() += 1;
                 }
+            }
+        }
+
+        // [OPUS-4.8] sq-lc3: ABSTAT-style type minimalization over the graph's
+        // `rdfs:subClassOf` hierarchy. Opt-in (`BuildOptions::minimalize_types`) and
+        // applied here, once, so EVERY downstream pattern (class extents, per-class
+        // predicate usage, characteristic-set type histograms, observed domain/range,
+        // cross-class join hints) reads the same minimal type map. We fold each
+        // subject's asserted type set to its most-specific members: a type `D` is
+        // dropped iff the subject also carries some `C ≠ D` with `(C subClassOf+ D)` —
+        // i.e. `D` is a proper superclass of a more specific asserted class. The
+        // subsumption relation is the transitive closure of the `subClassOf` edges
+        // present in the graph; cycles are tolerated (treated as class equivalence, so
+        // neither member is dropped on account of the other).
+        if opts.minimalize_types && !subj_types.is_empty() {
+            if let Some(supers) = build_superclass_closure(graph) {
+                for types in subj_types.values_mut() {
+                    minimalize_type_set(types, &supers);
+                }
+            }
+        }
+
+        // class -> instance count, derived from the (possibly minimalized) type map so
+        // it stays consistent with every other pattern.
+        let mut class_instances: FxHashMap<Id, u64> = FxHashMap::default();
+        for classes in subj_types.values() {
+            for &c in classes {
+                *class_instances.entry(c).or_default() += 1;
             }
         }
 
@@ -1577,6 +1630,105 @@ fn is_iri(graph: &Graph, id: Id) -> bool {
     !dict::is_inline(id) && matches!(graph.dict.term_parts(id), TermParts::Iri { .. })
 }
 
+/// [OPUS-4.8] sq-lc3: build the **transitive** superclass relation from the graph's
+/// `rdfs:subClassOf` triples — `supers[c]` is the set of classes strictly above `c`
+/// (every `d` with `c subClassOf+ d`, excluding `c` itself). Returns `None` when the
+/// graph carries no `rdfs:subClassOf` predicate at all (the common case — minimalization
+/// is then a no-op and the caller skips it).
+///
+/// Only IRI–IRI `subClassOf` edges are considered (literal/blank class terms are
+/// ignored). The closure is computed by repeated relaxation over the direct edges until
+/// a fixpoint, so multi-step chains (`A ⊑ B ⊑ C` ⇒ `C ∈ supers[A]`) and cycles both
+/// settle: in a cycle every member ends up in every other member's superclass set, so
+/// [`minimalize_type_set`] — which never drops a class that is *also* a superclass of
+/// the class it would be dropped for — keeps both, treating them as equivalent.
+fn build_superclass_closure(graph: &Graph) -> Option<FxHashMap<Id, FxHashMap<Id, ()>>> {
+    let sub_id = graph.id_of(&Term::NamedNode(NamedNode::new_unchecked(RDFS_SUBCLASS_OF)))?;
+    // Direct edges: c -> { d : (c subClassOf d) }.
+    let mut direct: FxHashMap<Id, FxHashMap<Id, ()>> = FxHashMap::default();
+    let scan = graph.store.scan(&[None, Some(sub_id), None]);
+    for row in scan.rows.iter() {
+        let [c, _, d] = scan.to_spo(row);
+        if c != d && is_iri(graph, c) && is_iri(graph, d) {
+            direct.entry(c).or_default().insert(d, ());
+        }
+    }
+    drop(scan);
+    if direct.is_empty() {
+        // The predicate exists in the dictionary but no usable edge was asserted.
+        return Some(FxHashMap::default());
+    }
+
+    // Transitive closure by fixpoint relaxation over the direct edges. Graphs carry
+    // few `subClassOf` edges relative to data triples, so a naive O(edges × iterations)
+    // pass is ample (and avoids any heavy graph-algorithm dependency — core stays lean).
+    let mut supers = direct.clone();
+    let keys: Vec<Id> = supers.keys().copied().collect();
+    loop {
+        let mut changed = false;
+        for &c in &keys {
+            // Pull every superclass-of-a-superclass into c's set. Snapshot the current
+            // closure parents to avoid borrowing `supers` mutably and immutably at once.
+            let parents: Vec<Id> = supers[&c].keys().copied().collect();
+            let mut additions: Vec<Id> = Vec::new();
+            for p in parents {
+                if let Some(grand) = supers.get(&p) {
+                    for &g in grand.keys() {
+                        if g != c && !supers[&c].contains_key(&g) {
+                            additions.push(g);
+                        }
+                    }
+                }
+            }
+            if !additions.is_empty() {
+                let set = supers.get_mut(&c).expect("c is a known key");
+                for g in additions {
+                    set.insert(g, ());
+                }
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    Some(supers)
+}
+
+/// [OPUS-4.8] sq-lc3: fold one subject's asserted type list to its **minimal**
+/// (most-specific) members. A type `d` is removed iff some *other* type `c` in the same
+/// asserted list has `d` among its strict superclasses (`c subClassOf+ d`) AND `c` is
+/// not itself subsumed by `d` (the cycle / mutual-equivalence guard — when `c` and `d`
+/// subsume each other neither is dropped). Order is preserved for the survivors;
+/// duplicates already present in the list are also collapsed.
+fn minimalize_type_set(types: &mut Vec<Id>, supers: &FxHashMap<Id, FxHashMap<Id, ()>>) {
+    if types.len() <= 1 {
+        return;
+    }
+    // Snapshot the original set so the "dropped because a more specific sibling exists"
+    // test is against the full asserted set, not a partially-pruned one.
+    let original: Vec<Id> = types.clone();
+    let mut seen: FxHashMap<Id, ()> = FxHashMap::default();
+    types.retain(|&d| {
+        // Collapse duplicates deterministically (keep first occurrence).
+        if seen.insert(d, ()).is_some() {
+            return false;
+        }
+        // Keep `d` unless some sibling `c` is strictly more specific than `d`.
+        let dropped = original.iter().any(|&c| {
+            if c == d {
+                return false;
+            }
+            let c_subclass_of_d = supers.get(&c).is_some_and(|s| s.contains_key(&d));
+            let d_subclass_of_c = supers.get(&d).is_some_and(|s| s.contains_key(&c));
+            // `c` is a proper subclass of `d` (and not mutually equivalent) ⇒ `d` is a
+            // superclass type that ABSTAT drops in favour of the minimal `c`.
+            c_subclass_of_d && !d_subclass_of_c
+        });
+        !dropped
+    });
+}
+
 /// [OPUS-4.8] sq-3n4: renders an object id to the sample-string form used by every
 /// histogram in this crate — literals quoted (`"v"`, `"v"@en`), IRIs bare, blanks
 /// `_:b`, triple terms via the dict's Display — truncated to `max_chars`. Factored out
@@ -1793,6 +1945,100 @@ mod tests {
         let company = &ix.classes[1];
         assert_eq!(company.class, ex("Company"));
         assert_eq!(company.instances, 1);
+    }
+
+    // [OPUS-4.8] sq-lc3: ABSTAT-style type minimalization over rdfs:subClassOf.
+    #[test]
+    fn minimalize_types_keeps_only_the_minimal_class() {
+        // The bead's olympics shape: a subject typed both as a subclass and its
+        // declared superclass (dbo:SportsEvent rdfs:subClassOf dbo:Sport). Here
+        // :swimming100m is typed both :SportsEvent and :Sport, with
+        // :SportsEvent rdfs:subClassOf :Sport.
+        let g = graph(
+            ":swimming100m rdf:type :SportsEvent , :Sport ; :name \"100m\" .
+             :SportsEvent rdfs:subClassOf :Sport .",
+        );
+
+        // Default (minimalize_types = false): BOTH types are reported.
+        let full = Introspection::build(&g);
+        let full_classes: Vec<&str> = full.classes.iter().map(|c| c.class.as_str()).collect();
+        assert!(
+            full_classes.contains(&ex("SportsEvent").as_str())
+                && full_classes.contains(&ex("Sport").as_str()),
+            "without minimalization both the subclass and superclass type appear: {:?}",
+            full_classes
+        );
+
+        // Opt-in minimalization: only the minimal (most-specific) type survives.
+        let opts = BuildOptions {
+            minimalize_types: true,
+            ..BuildOptions::default()
+        };
+        let min = Introspection::build_with(&g, &opts);
+        let min_classes: Vec<&str> = min.classes.iter().map(|c| c.class.as_str()).collect();
+        assert_eq!(
+            min_classes,
+            vec![ex("SportsEvent").as_str()],
+            "minimalization drops the superclass :Sport, keeping only :SportsEvent"
+        );
+        // The surviving class still carries the subject's predicate usage.
+        let se = &min.classes[0];
+        assert_eq!(se.instances, 1);
+        assert!(se.predicates.iter().any(|p| p.predicate == ex("name")));
+
+        // The characteristic set's rdf:type histogram is likewise minimal.
+        let cs = &min.characteristic_sets.sets[0];
+        let cs_classes: Vec<&str> = cs.classes.iter().map(|c| c.iri.as_str()).collect();
+        assert_eq!(cs_classes, vec![ex("SportsEvent").as_str()]);
+    }
+
+    // [OPUS-4.8] sq-lc3: minimalization follows multi-step subClassOf chains and does
+    // not cross-contaminate independent subjects.
+    #[test]
+    fn minimalize_types_chain_and_independence() {
+        // Chain :C ⊑ :B ⊑ :A. A subject typed all three folds to :C only.
+        // A second, independent subject typed only :A keeps :A (it has no more
+        // specific sibling).
+        let g = graph(
+            ":x rdf:type :A , :B , :C .
+             :y rdf:type :A .
+             :C rdfs:subClassOf :B . :B rdfs:subClassOf :A .",
+        );
+        let opts = BuildOptions {
+            minimalize_types: true,
+            ..BuildOptions::default()
+        };
+        let ix = Introspection::build_with(&g, &opts);
+        // :C: 1 instance (x). :A: 1 instance (y). :B: dropped entirely.
+        let c = ix.classes.iter().find(|p| p.class == ex("C")).unwrap();
+        assert_eq!(c.instances, 1);
+        let a = ix.classes.iter().find(|p| p.class == ex("A")).unwrap();
+        assert_eq!(a.instances, 1);
+        assert!(
+            ix.classes.iter().all(|p| p.class != ex("B")),
+            "transitive superclass :B is dropped for x and was never the minimal type"
+        );
+    }
+
+    // [OPUS-4.8] sq-lc3: a subClassOf cycle (mutually-equivalent classes) is tolerated —
+    // neither member is dropped.
+    #[test]
+    fn minimalize_types_tolerates_cycles() {
+        let g = graph(
+            ":x rdf:type :P , :Q .
+             :P rdfs:subClassOf :Q . :Q rdfs:subClassOf :P .",
+        );
+        let opts = BuildOptions {
+            minimalize_types: true,
+            ..BuildOptions::default()
+        };
+        let ix = Introspection::build_with(&g, &opts);
+        let names: Vec<&str> = ix.classes.iter().map(|c| c.class.as_str()).collect();
+        assert!(
+            names.contains(&ex("P").as_str()) && names.contains(&ex("Q").as_str()),
+            "mutually-subClassOf classes are equivalent; neither is dropped: {:?}",
+            names
+        );
     }
 
     #[test]

--- a/skills/genai-retrieval/SKILL.md
+++ b/skills/genai-retrieval/SKILL.md
@@ -79,6 +79,13 @@ for row in &answer.result.rows {                  // Vec<Vec<Option<oxrdf::Term>
 // sized for LLM grounding; tune with build_with.
 Introspection::build(graph: &Graph) -> Introspection
 Introspection::build_with(graph: &Graph, opts: &BuildOptions) -> Introspection
+// opts.minimalize_types (default false, sq-lc3): ABSTAT-style type minimalization —
+// fold each subject's types to the most-specific via the graph's own rdfs:subClassOf
+// chains (transitive closure of in-graph edges; no ontology fetch, no OWL reasoning;
+// cycles tolerated as equivalence). A subject typed both dbo:SportsEvent and dbo:Sport
+// (SportsEvent ⊑ Sport) is then profiled ONLY under the minimal dbo:SportsEvent.
+// Applies uniformly to class extents, per-class usage, CS type histograms, observed
+// domain/range, and join hints. Additive (no new dependency); default = full profile.
 
 // Renderers.
 Introspection::to_text_summary(&self, budget_chars: usize) -> String   // schema card


### PR DESCRIPTION
> 🤖 **SPARQ agent** (one of several @jeswr runs on this account).

## Summary

Implements **sq-lc3**: ABSTAT-style pattern minimalization via the class hierarchy in `crates/sparq-introspect`. The pattern-extraction previously emitted patterns over **every** asserted `rdf:type`. This adds an **opt-in** `BuildOptions::minimalize_types` (default `false`) that folds each subject's asserted type set to its **minimal** (most-specific) members before any pattern is mined.

A type `D` is dropped from a subject iff the subject also carries some `C ≠ D` with `(C rdfs:subClassOf+ D)` — i.e. `D` is a proper superclass of a more specific asserted class. The bead's olympics example (`dbo:SportsEvent rdfs:subClassOf dbo:Sport`): a subject typed both yields the minimal-type pattern (`dbo:SportsEvent`), not both.

### Design
- **Subsumption relation** = transitive closure of the `rdfs:subClassOf` triples **present in the graph**. No external ontology fetch, no OWL reasoning. IRI–IRI edges only.
- **Cycles tolerated**: mutually-`subClassOf` classes are treated as equivalent — neither member is dropped on account of the other.
- **Single seam, uniform effect**: minimalization is applied once to the subject→types map, so it propagates consistently to **every** pattern — class extents (`class_instances`), per-class predicate usage, characteristic-set `rdf:type` histograms, observed domain/range, and the cross-class `(C, p, D)` join hints. `class_instances` is now derived from the (possibly minimalized) map for consistency.
- **Additive / lean**: pure data over `sparq-core`'s existing public scan API — no new dependency, no cargo feature, no change to the default output (the ABSTAT "full" profile reporting every asserted type). Matches the crate's established API idiom (all tuning via `BuildOptions`).

### New tests (exercise the real path + load-bearing invariant)
- `minimalize_types_keeps_only_the_minimal_class` — the SportsEvent/Sport subclass+superclass case: default reports both types; with the flag, only the minimal `:SportsEvent` survives in `classes` **and** the characteristic-set type histogram.
- `minimalize_types_chain_and_independence` — multi-step `:C ⊑ :B ⊑ :A` folds to `:C`; an independent subject typed only `:A` keeps `:A`.
- `minimalize_types_tolerates_cycles` — `:P ⊑ :Q ⊑ :P` keeps both.

## Gate commands + results (BOTH feature states)

Default (feature OFF) — native:
- `cargo clippy -p sparq-introspect --all-targets -- -D warnings` → clean
- `cargo test -p sparq-introspect` → **25 unit + 1 olympics integration + doc-test** green

Second state — `wasm32-unknown-unknown` (the crate's only build-config variant: takes `sparq-core` with `default-features = false`):
- `cargo clippy -p sparq-introspect --target wasm32-unknown-unknown --all-targets -- -D warnings` → clean
- `cargo build -p sparq-introspect --target wasm32-unknown-unknown` → ok

- `typos crates/sparq-introspect/{README.md,src/lib.rs} skills/genai-retrieval/SKILL.md` → rc 0
- rustfmt: my added regions are rustfmt-conformant; I did **not** run `cargo fmt` over untouched lines (the repo's intentionally-deferred reformat), so the diff is confined to this feature.

## Honest caveats / boundary
- This is **closure over the graph's own `subClassOf` edges**, not OWL/RDFS entailment — it sees only `subClassOf` triples physically present in the store. No external ontology is fetched. Subjects with no `subClassOf` info, untyped subjects, and literal/blank type objects are unaffected.
- No performance claims are made.

## Files
- `crates/sparq-introspect/src/lib.rs` — `BuildOptions::minimalize_types`, `RDFS_SUBCLASS_OF`, `build_superclass_closure`, `minimalize_type_set`, tests.
- `crates/sparq-introspect/README.md`, `skills/genai-retrieval/SKILL.md` — document the knob + boundary.

Note: the markdown `TODO.md` that beaded this (`crates/sparq-introspect/TODO.md:121`) was already removed wholesale in an earlier hygiene cleanup (commit `b1ea87c7`), so there is no TODO line left to strip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)