### PR TITLE
feat(sparq-server): categorised unmatched-route 404 + document GSP-DELETE 404 IRI reflection (sq-pj6u, sq-ttv2) [OPUS-4.8]

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -58,7 +58,7 @@ By default: **no auth, loopback-only.** Hardening is opt-in but honest where it 
   (`--auth-token-read`) — a write-token alone still leaves reads open on a remote bind. The 401 is
   byte-identical for a missing vs a wrong token. The Bearer gate is one shared secret with no
   per-user identity — for real authz front it with a gateway or [`sparq-solid`](../sparq-solid), over TLS.
-- **Error responses do not leak internals** — every error is a generic `{"error":"…"}` class (never the caller's input, an RDF fragment, a path, or a token); detail to the log, class to the body (regression-guarded by `tests/hardening.rs`).
+- **Error responses do not leak internals** — every error is a generic `{"error":"…"}` class (never the caller's input, an RDF fragment, a path, or a token); detail to the log, class to the body (regression-guarded by `tests/hardening.rs`). An unmatched route is a categorised `404 {"error":"not found"}` (the message never echoes the requested path).
 - **Stable retry contract** — **transient** (`429`/`503`): retry; **permanent** (`4xx`): fix the
   request — a `413` row/byte cap is a permanent honest refusal, **not** a silent truncation;
   **defect** (`500`): surface, don't hot-retry. Versioned table in the `status_contract` crate doc.

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -2100,6 +2100,15 @@ pub fn router(state: AppState) -> Router {
     // See [`shacl_validate_endpoint`].
     #[cfg(feature = "shacl")]
     let routes = routes.route("/shacl/validate", post(shacl_validate_endpoint));
+    // [OPUS-4.8] (sq-pj6u) Categorised unmatched-route 404. Without an explicit fallback,
+    // axum answers an unmatched path with a 404 whose body is EMPTY; `json_error_bodies`
+    // then wraps that into the uncategorised `{"error":""}` envelope — leak-free but with no
+    // actionable category. Register a fallback that mints the SAME structured 404 a handler
+    // does for a disabled opt-in route (`{"error":"not found"}`), so every unmatched route
+    // carries the stable `not found` category. The message is a fixed, server-constructed
+    // string — it never echoes the request path, so the body stays leak-free (no internal
+    // paths, no stack info, no request internals), matching the existing error contract.
+    let routes = routes.fallback(unmatched_route);
     let routes = routes.with_state(state.clone());
     // The metrics middleware wraps the WHOLE hardened stack so shed requests
     // (429), body-limit rejections (413) and panics (500) are counted with the
@@ -2108,6 +2117,17 @@ pub fn router(state: AppState) -> Router {
         state,
         crate::metrics::track,
     ))
+}
+
+/// [OPUS-4.8] (sq-pj6u) Router fallback for any path that matched no route: a CATEGORISED,
+/// leak-free `404 Not Found`. Returns the same structured `{"error":"not found"}` envelope a
+/// handler mints for a disabled opt-in route (e.g. `/.well-known/void`, `/tpf`,
+/// `/shacl/validate` with their flags off), so an unmatched route is no longer the bare
+/// `{"error":""}` axum produces. The message is a fixed, server-constructed string and the
+/// request path is deliberately NOT echoed — the body discloses no internal path, stack
+/// information or request internal, exactly the [`json_error`] info-leak posture (#241).
+async fn unmatched_route() -> Response {
+    json_error(StatusCode::NOT_FOUND, "not found")
 }
 
 /// `GET /metrics` — Prometheus text exposition (T22). The gauges (graph triple
@@ -4612,6 +4632,16 @@ async fn gsp_delete(state: &AppState, graph: GraphRef) -> Response {
         }
         GraphRef::Named(iri) => {
             if !graph_exists(state, &graph) {
+                // [OPUS-4.8] (sq-ttv2) The 404 reflects the REQUESTED graph IRI. Assessed and
+                // accepted as standard REST: `iri` is the CLIENT'S OWN input — either the
+                // verbatim `?graph=<uri>` value (indirect identification) or
+                // `http://<Host>/graphs/<path>` reconstructed from the client's request line +
+                // Host header (direct identification, `graph_store_direct` →
+                // `direct_graph_iri`). It carries NO server-internal information (no filesystem
+                // path, no enumeration of OTHER stored graphs, no engine state), so echoing it
+                // back is not an info leak — it is the addressed resource, exactly as a REST 404
+                // names the resource that was not found. Stays inside the structured
+                // `{"error":...}` envelope, so it matches the error contract.
                 return json_error(
                     StatusCode::NOT_FOUND,
                     &format!("graph <{iri}> does not exist"),

--- a/crates/sparq-server/tests/hardening.rs
+++ b/crates/sparq-server/tests/hardening.rs
@@ -741,23 +741,27 @@ async fn unauthorized_error_is_clean_and_actionable() {
     assert!(!body.contains("the-write-token"), "401 leaked the token: {body}");
 }
 
-/// The not-found (404) class: structured shape and no internals. A BARE unmatched route is
-/// axum's catch-all 404, whose body is empty (`{"error":""}`) — trivially leak-free but with
-/// no actionable category; that empty-body 404 is captured as deferred work (a bead). A 404
-/// that a HANDLER mints (a `GET /.well-known/void` when the federation-descriptor feature/flag
-/// is off) DOES carry the generic "not found" category, so we assert the categorised shape
-/// there and only the no-internals property on the bare route.
+/// The not-found (404) class: structured shape, an actionable category, and no internals.
+/// [OPUS-4.8] (sq-pj6u) A BARE unmatched route now goes through the router fallback
+/// (`unmatched_route`), so its body is the CATEGORISED `{"error":"not found"}` envelope —
+/// previously it was axum's catch-all empty 404 that `json_error_bodies` wrapped into the
+/// uncategorised `{"error":""}`. So we now assert the same categorised + clean shape on the
+/// bare route as on a HANDLER-minted 404 (a `GET /.well-known/void` when the
+/// federation-descriptor feature/flag is off). The message is server-constructed and never
+/// echoes the request path, so it stays leak-free.
 #[tokio::test]
 async fn not_found_error_is_clean() {
     let base = spawn_with(DATA, ServerConfig::default()).await;
-    // Bare unmatched route: empty body, but it must still be clean (no internal markers).
+    // Bare unmatched route: now the categorised `{"error":"not found"}` body, still clean.
     let resp = client().get(format!("{base}/no-such-route")).send().await.unwrap();
     assert_eq!(resp.status(), 404);
     let body = resp.text().await.unwrap();
-    assert!(body.starts_with("{\"error\":"), "structured JSON error, got: {body}");
-    for marker in FORBIDDEN_INTERNALS {
-        assert!(!body.contains(marker), "404 leaked an internal marker {marker:?}: {body}");
-    }
+    // [OPUS-4.8] (sq-pj6u) Non-empty, categorised `not found` — no longer `{"error":""}`.
+    assert_clean_error(&body, "not found");
+    assert_ne!(
+        body, "{\"error\":\"\"}",
+        "unmatched-route 404 must now be CATEGORISED, not the bare empty envelope"
+    );
 }
 
 /// A blanket assertion across the main client-facing failure classes (malformed query,

--- a/crates/sparq-server/tests/status_contract.rs
+++ b/crates/sparq-server/tests/status_contract.rs
@@ -220,6 +220,17 @@ async fn unknown_route_is_permanent_404() {
     let status = resp.status().as_u16();
     assert_eq!(status, 404);
     assert!(!is_transient(status));
+    // [OPUS-4.8] (sq-pj6u) The unmatched-route 404 carries the SAME structured envelope as
+    // every other error, now with the CATEGORISED `not found` message (was the bare empty
+    // `{"error":""}`). It must NOT echo the requested path — leak-free.
+    let body = resp.text().await.unwrap();
+    assert_structured_error(&body);
+    let v: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert_eq!(v["error"], "not found", "categorised, generic 404 message");
+    assert!(
+        !body.contains("no-such-route"),
+        "404 must not echo the requested path: {body}"
+    );
 }
 
 #[tokio::test]

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -997,7 +997,9 @@ identities and resource IRIs by design (see the privacy-boundary note above).
 - **Error bodies.** Every error is structured JSON `{"error": "..."}` with
   `Content-Type: application/json` (the `405` keeps its `Allow` header). POST query
   requires `Content-Type: application/sparql-query` or `application/x-www-form-urlencoded`
-  (else `415`); a GET without `query=` is `400`.
+  (else `415`); a GET without `query=` is `400`. An **unmatched route** is a `404` with the
+  categorised body `{"error":"not found"}` ([OPUS-4.8] sq-pj6u — previously the bare
+  `{"error":""}`); the message is server-constructed and never echoes the requested path.
 - **Transient vs permanent status contract (for retry classifiers — sq-r5bv / gh-50).** A retry
   classifier should treat **only `429` and `503` as transient** (a retry of the identical request
   may succeed): `429` is a concurrency shed (the request never ran), `503` is a query/UPDATE


### PR DESCRIPTION
> 🤖 **SPARQ agent** (one of several @jeswr runs on this account).

## Summary

**sq-pj6u — categorised 404 fallback.** The bare unmatched-route fallback returned axum's empty `404`, which the `json_error_bodies` `map_response` middleware then wrapped into the **uncategorised** `{"error":""}` envelope — leak-free but with no actionable category. This registers an explicit router `.fallback(unmatched_route)` that mints the **same** structured `{"error":"not found"}` `404` a handler already returns for a disabled opt-in route (e.g. `/.well-known/void`, `/tpf`, `/shacl/validate` with their flags off). It reuses the existing `json_error(StatusCode::NOT_FOUND, "not found")` helper — **no new error schema**.

Leak-free: the message is a fixed, server-constructed string; the requested path is deliberately **not** echoed (no internal paths, no stack info, no request internals), matching the `#241` info-leak posture.

**sq-ttv2 — GSP DELETE 404 IRI reflection (assessed → acceptable, closed).** The `DELETE <graph>` 404 reflects the requested graph IRI. Assessed in code: that `iri` is purely the **client's own input** — either the verbatim `?graph=<uri>` value (indirect identification) or `http://<Host>/graphs/<path>` reconstructed from the client's request line + `Host` header (direct identification, `graph_store_direct` → `direct_graph_iri`). It carries **no** server-internal information (no filesystem path, no enumeration of other stored graphs, no engine state), so echoing it back is **not** an info leak — it is the addressed resource, exactly as a REST 404 names the resource that was not found, and it stays inside the structured `{"error":...}` envelope. **Accepted as standard REST; documented with a code comment at the DELETE-404 site.** No code change needed there.

## Files
- `crates/sparq-server/src/http.rs` — `.fallback(unmatched_route)` + the `unmatched_route` handler; sq-ttv2 rationale comment at the `gsp_delete` 404 site.
- `crates/sparq-server/tests/status_contract.rs` — strengthened the sq-r5bv contract test `unknown_route_is_permanent_404` to assert the categorised, non-empty body and no path echo.
- `crates/sparq-server/tests/hardening.rs` — `not_found_error_is_clean` now asserts the categorised + clean shape on the bare unmatched route (was: only no-internals on the empty body).
- `crates/sparq-server/README.md`, `skills/http-server/SKILL.md` — documented the categorised unmatched-route 404.

## Gates (run in both feature states)

| Gate | Default (`server` on) | `--all-features` |
|---|---|---|
| `cargo clippy -p sparq-server --all-targets -- -D warnings` | clean | clean (`--all-features`) |
| `cargo test -p sparq-server` | green (incl. `status_contract`, `hardening`, `protocol`) | green |

Exact commands:
- `cargo clippy -p sparq-server --all-targets -- -D warnings` → clean
- `cargo clippy -p sparq-server --all-targets --all-features -- -D warnings` → clean
- `cargo test -p sparq-server` → all suites green, 0 failed
- `cargo test -p sparq-server --all-features` → all suites green, 0 failed
- The existing sq-r5bv error/status contract test (`tests/status_contract.rs`) still passes; the strengthened `unknown_route_is_permanent_404` + `not_found_error_is_clean` assert the new categorised body.

`cargo fmt`: not run package-wide — the workspace has the intentionally-deferred reformat (CI fmt is informational; clippy is the hard gate). My added lines are already rustfmt-conformant; I matched the surrounding committed style and did not churn untouched lines.

## Caveats
- The `--no-default-features --all-targets` clippy lane fails to compile `tests/persist.rs` (it uses `serde_json` without the `server` feature, and lacks a `#![cfg(feature = "server")]` guard). This is **pre-existing** and unrelated to this change; both files I touched are `#![cfg(feature = "server")]`-gated. The pure-serializer library itself (`cargo build -p sparq-server --no-default-features`) builds fine.
- No perf claims.

Auto-merge intentionally **not** enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)