### PR TITLE
feat(sparq-vectors): incremental add/remove/update via in-RAM delta sidecar + compact (sq-pi44) [OPUS-4.8]

### DIFF
--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -37,6 +37,17 @@ default = []
 # engine-side automatic BGP → mask wiring (a filtered form of the `vec:` predicate) is wired in
 # `rewrite.rs` and activates when this composes with `vec-predicate` (sq-bvmd, follow-up to sq-1wc1).
 filtered-ann = []
+# [OPUS-4.8] sq-pi44: incremental add / remove / update of vectors against an already-finalized
+# store via an in-RAM DELTA SIDECAR (+ `compact` to fold it back into a fresh base), so a single
+# graph change no longer forces a full re-embed + file rebuild. OPT-IN and OFF by default; a LEAN
+# feature — it adds NO new dependency (the append map + tombstone set reuse the in-tree
+# `rustc-hash`) and pulls in NEITHER the engine NOR any heavy crate, so the default `sparq-vectors`
+# build carries zero delta code. Gates `delta.rs` (the `VectorDelta` value) and the
+# `VectorStore::{add,remove,update,compact,apply_delta,take_delta,delta,has_delta}` methods; the
+# read paths (`get`/`iter`/`len`) consult the delta only under this feature. The delta is IN-RAM
+# only (lost on handle drop; `compact` is the durability path) — a persisted on-disk delta sidecar
+# is a tracked follow-up.
+delta = []
 # [OPUS-4.8] sq-ip3a (epic sq-3183, follow-up to sq-7hx6): the **approximate** ANN backend.
 # OPT-IN and OFF by default — this is the feature that pulls the heavy HNSW crate
 # (`instant-distance`) into the dependency graph. With it OFF the default `sparq-vectors` build

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -74,6 +74,18 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   **necessary but not sufficient** — to serve a persisted store, `Graph::save` its graph
   and reopen **that** (`Graph::open`, frozen id order); **never** re-parse the source RDF
   (pinned in `tests/staleness_contract.rs`).
+- **Incremental add / remove / update (opt-in `delta`)** — a `.spqv` is build-once-immutable
+  (`put` errors after `finalize`), so today one new/removed entity forces a full re-embed +
+  rebuild. The `delta` feature adds an in-RAM **delta sidecar** over the immutable base:
+  `add` / `remove` / `update` write an append map + tombstone set, and `get` / `iter` / `len`
+  (hence search) transparently union base + delta and honour tombstones — no file rebuild.
+  `compact(out, graph)` folds the delta into a fresh base **equivalent to a from-scratch
+  rebuild** over the same final vector set. The delta is tied to the base's graph
+  **generation** (the sq-32i5 fingerprint): `apply_delta` rejects a delta built against a
+  different generation, so its ids can never mis-key. Lean (no new dependency). **Honest
+  boundary:** the delta is **in-RAM only** — it is lost when the handle is dropped (the base
+  file is unchanged until `compact` writes a new one); a *persisted* on-disk delta sidecar is
+  a tracked follow-up. `compact` is the durability path today.
 - **Verbalization, quantization, hybrid fusion** — `verbalize` / `embed_entities` render
   per-entity text (multilingual, char-budgeted, single named graph at a time);
   `ScalarQuantizer` (4×) and `ProductQuantizer` for large stores; `fuse_rrf` /

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -74,18 +74,10 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   **necessary but not sufficient** — to serve a persisted store, `Graph::save` its graph
   and reopen **that** (`Graph::open`, frozen id order); **never** re-parse the source RDF
   (pinned in `tests/staleness_contract.rs`).
-- **Incremental add / remove / update (opt-in `delta`)** — a `.spqv` is build-once-immutable
-  (`put` errors after `finalize`), so today one new/removed entity forces a full re-embed +
-  rebuild. The `delta` feature adds an in-RAM **delta sidecar** over the immutable base:
-  `add` / `remove` / `update` write an append map + tombstone set, and `get` / `iter` / `len`
-  (hence search) transparently union base + delta and honour tombstones — no file rebuild.
-  `compact(out, graph)` folds the delta into a fresh base **equivalent to a from-scratch
-  rebuild** over the same final vector set. The delta is tied to the base's graph
-  **generation** (the sq-32i5 fingerprint): `apply_delta` rejects a delta built against a
-  different generation, so its ids can never mis-key. Lean (no new dependency). **Honest
-  boundary:** the delta is **in-RAM only** — it is lost when the handle is dropped (the base
-  file is unchanged until `compact` writes a new one); a *persisted* on-disk delta sidecar is
-  a tracked follow-up. `compact` is the durability path today.
+- **Incremental add / remove / update (opt-in `delta`)** — a `.spqv` is build-once-immutable; the
+  `delta` feature adds an **in-RAM delta sidecar** (`add`/`remove`/`update` → append map + tombstones)
+  that `get`/`iter`/search transparently union (honouring tombstones), generation-tied to the base
+  (sq-32i5). `compact` folds it into a from-scratch-equivalent base. **In-RAM only** (lost on drop; `compact` is the durability path); a persisted delta is a tracked follow-up. No new dep. See rustdoc/SKILL.
 - **Verbalization, quantization, hybrid fusion** — `verbalize` / `embed_entities` render
   per-entity text (multilingual, char-budgeted, single named graph at a time);
   `ScalarQuantizer` (4×) and `ProductQuantizer` for large stores; `fuse_rrf` /

--- a/crates/sparq-vectors/src/delta.rs
+++ b/crates/sparq-vectors/src/delta.rs
@@ -33,14 +33,14 @@
 //!
 //! A delta is only meaningful against the graph generation it was built against — the ids it
 //! appends/tombstones are that generation's dictionary ids. A [`VectorDelta`] therefore carries
-//! the [`Fingerprint`] of the graph it targets, and [`VectorStore::apply_delta`] REJECTS a delta
+//! the [`Fingerprint`] of the graph it targets, and [`VectorStore::apply_delta`](crate::store::VectorStore::apply_delta) REJECTS a delta
 //! whose generation does not match the base store's bound fingerprint (gate: a delta tied to
 //! generation N applied to a base of generation M ≠ N is an error, not a silent mis-key). This
 //! reuses the sq-32i5 header fingerprint rather than inventing a second staleness mechanism.
 //!
 //! # Scope (honest boundary)
 //!
-//! The delta is **in-RAM only**: it lives on the open [`VectorStore`] handle and is lost when the
+//! The delta is **in-RAM only**: it lives on the open [`VectorStore`](crate::store::VectorStore) handle and is lost when the
 //! handle is dropped (the base `.spqv` on disk is unchanged until
 //! [`compact`](crate::store::VectorStore::compact) writes a new one). A *persisted* delta sidecar
 //! (its own on-disk format, crash-durable across process restarts) is tracked as a follow-up — see
@@ -65,7 +65,7 @@ use sparq_core::dict::Id;
 #[derive(Clone, Debug, Default)]
 pub struct VectorDelta {
     /// The graph generation this delta targets, or `None` for a delta over a store with no base
-    /// fingerprint. [`VectorStore::apply_delta`] checks it against the receiving store.
+    /// fingerprint. [`VectorStore::apply_delta`](crate::store::VectorStore::apply_delta) checks it against the receiving store.
     pub(crate) generation: Option<Fingerprint>,
     /// `id → vector` for vectors added or updated since the base; SHADOWS the base for a shared id.
     pub(crate) appended: FxHashMap<Id, Vec<f32>>,

--- a/crates/sparq-vectors/src/delta.rs
+++ b/crates/sparq-vectors/src/delta.rs
@@ -1,0 +1,106 @@
+//! [OPUS-4.8] (sq-pi44) **Incremental add / remove / update of vectors** against an
+//! already-finalized [`VectorStore`](crate::store::VectorStore) — WITHOUT a full re-embed
+//! and file rebuild.
+//!
+//! # Why
+//!
+//! A `.spqv` store is build-once-immutable: [`VectorStore::put`](crate::store::VectorStore::put)
+//! errors after [`finalize`](crate::store::VectorStore::finalize), and there is no remove or
+//! update. So today *any* graph change — one new entity, one deleted entity — forces a full
+//! re-embed and a fresh file. The structural indexes ([`sparq-sim`](https://docs.rs/sparq-sim)
+//! style) track graph mutation for free because the index *is* the data; the vector store does
+//! not, because it is keyed by dictionary id and stored densely.
+//!
+//! # What this adds (the **delta sidecar**)
+//!
+//! A small in-RAM layer over the immutable base mmap:
+//!   * an **append map** `id → vector` of vectors added or updated since the base was built, and
+//!   * a **tombstone set** of ids removed since the base was built.
+//!
+//! Every read path on the store ([`get`](crate::store::VectorStore::get),
+//! [`iter`](crate::store::VectorStore::iter), [`len`](crate::store::VectorStore::len)) consults
+//! the delta transparently: a tombstoned id reads as absent, an appended/updated id reads its
+//! delta vector (the delta SHADOWS the base for an id present in both), and a plain base id reads
+//! the mmap. Search (`nearest_exact`, the ANN indexes that consume `iter`) therefore unions
+//! base+delta and honours tombstones with no change to the search code itself.
+//!
+//! [`VectorStore::compact`](crate::store::VectorStore::compact) folds the delta back into a fresh
+//! base file: the result is **equivalent to a from-scratch rebuild over the same final vector
+//! set** (same `(id, vector)` pairs ⇒ a store whose `get`/`iter`/`len` agree exactly with one
+//! built by `create` + `put` over that set).
+//!
+//! # Generation tie (the staleness guard, sq-32i5)
+//!
+//! A delta is only meaningful against the graph generation it was built against — the ids it
+//! appends/tombstones are that generation's dictionary ids. A [`VectorDelta`] therefore carries
+//! the [`Fingerprint`] of the graph it targets, and [`VectorStore::apply_delta`] REJECTS a delta
+//! whose generation does not match the base store's bound fingerprint (gate: a delta tied to
+//! generation N applied to a base of generation M ≠ N is an error, not a silent mis-key). This
+//! reuses the sq-32i5 header fingerprint rather than inventing a second staleness mechanism.
+//!
+//! # Scope (honest boundary)
+//!
+//! The delta is **in-RAM only**: it lives on the open [`VectorStore`] handle and is lost when the
+//! handle is dropped (the base `.spqv` on disk is unchanged until
+//! [`compact`](crate::store::VectorStore::compact) writes a new one). A *persisted* delta sidecar
+//! (its own on-disk format, crash-durable across process restarts) is tracked as a follow-up — see
+//! the crate docs / the sq-pi44 follow-up bead. `compact` is the durability path today: it
+//! materializes the delta into a normal, validated `.spqv`.
+//!
+//! Opt-in: the whole layer is gated behind the **`delta`** cargo feature, off by default, and adds
+//! NO dependency (it reuses the in-tree `rustc-hash` map/set), so the default build carries zero
+//! delta code.
+
+use crate::fingerprint::Fingerprint;
+use rustc_hash::{FxHashMap, FxHashSet};
+use sparq_core::dict::Id;
+
+/// [OPUS-4.8] (sq-pi44) The in-RAM delta sidecar: vectors appended/updated and ids tombstoned
+/// since the base store was built, plus the graph [`Fingerprint`] the delta is keyed against.
+///
+/// An id is in AT MOST one of `appended` / `tombstones` at any time — adding/updating an id clears
+/// its tombstone, removing an id drops it from `appended` and tombstones it. The base store is never
+/// mutated; the delta merely shadows it on read until
+/// [`compact`](crate::store::VectorStore::compact) folds it in.
+#[derive(Clone, Debug, Default)]
+pub struct VectorDelta {
+    /// The graph generation this delta targets, or `None` for a delta over a store with no base
+    /// fingerprint. [`VectorStore::apply_delta`] checks it against the receiving store.
+    pub(crate) generation: Option<Fingerprint>,
+    /// `id → vector` for vectors added or updated since the base; SHADOWS the base for a shared id.
+    pub(crate) appended: FxHashMap<Id, Vec<f32>>,
+    /// ids removed since the base (a base id reads as absent; an appended id is dropped, not kept).
+    pub(crate) tombstones: FxHashSet<Id>,
+}
+
+impl VectorDelta {
+    /// A fresh empty delta bound to `generation` (the fingerprint of the graph it targets).
+    pub(crate) fn new(generation: Option<Fingerprint>) -> VectorDelta {
+        VectorDelta {
+            generation,
+            appended: FxHashMap::default(),
+            tombstones: FxHashSet::default(),
+        }
+    }
+
+    /// The graph generation this delta is keyed against (the base store's fingerprint), or `None`
+    /// if the base carried none. See [`VectorStore::apply_delta`](crate::store::VectorStore::apply_delta).
+    pub fn generation(&self) -> Option<Fingerprint> {
+        self.generation
+    }
+
+    /// Number of appended/updated vectors held in the delta.
+    pub fn appended_len(&self) -> usize {
+        self.appended.len()
+    }
+
+    /// Number of tombstoned ids held in the delta.
+    pub fn tombstone_len(&self) -> usize {
+        self.tombstones.len()
+    }
+
+    /// Whether the delta holds no appends and no tombstones (a no-op delta).
+    pub fn is_empty(&self) -> bool {
+        self.appended.is_empty() && self.tombstones.is_empty()
+    }
+}

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -10,6 +10,11 @@ pub mod backend;
 // [OPUS-4.8] (sq-7hx6) Filtered-ANN pre-filter vs post-filter cost model — `filtered-ann` only.
 #[cfg(feature = "filtered-ann")]
 pub mod cost;
+// [OPUS-4.8] (sq-pi44) Incremental add/remove/update of vectors against a finalized store via an
+// in-RAM delta sidecar (+ `compact`) — `delta` feature only. Additive and dependency-free; the
+// default build carries no delta code.
+#[cfg(feature = "delta")]
+pub mod delta;
 pub mod diskann;
 pub mod embed;
 #[cfg(feature = "filtered-ann")]
@@ -84,6 +89,10 @@ pub use rewrite::{prepare_vec_approx, query_vec_approx, query_vec_approx_with_bu
 // declare a direct `sparq-engine` dependency. [OPUS-4.8] (sq-k6ex; query_prepared added sq-z589)
 #[cfg(feature = "vec-predicate")]
 pub use sparq_engine::{query_prepared, PreparedQuery, QueryBudget, QueryResult};
+// [OPUS-4.8] (sq-pi44) The incremental delta sidecar value type — `delta` feature only. The
+// add/remove/update/compact APIs live on `VectorStore` (also `delta`-gated).
+#[cfg(feature = "delta")]
+pub use delta::VectorDelta;
 pub use store::{StreamingWriter, VectorStore, SPQV_MAGIC, SPQV_VERSION};
 pub use verbalize::{
     description_predicates, embed_entities, label_predicates, verbalize, EntityTextConfig,

--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -149,6 +149,15 @@ pub struct VectorStore {
     /// slot→id for mmap mode (the on-disk index is sorted by id, the data by slot);
     /// built lazily on the first [`iter`](Self::iter), O(count) once.
     inverse: std::sync::OnceLock<Vec<Id>>,
+    /// [OPUS-4.8] (sq-pi44) The in-RAM delta sidecar: vectors appended/updated and ids tombstoned
+    /// since the immutable base was built. `None` until the first delta mutation
+    /// ([`add`](Self::add)/[`remove`](Self::remove)/[`update`](Self::update)) allocates it, bound to
+    /// the base fingerprint. Every read path
+    /// ([`get`](Self::get)/[`iter`](Self::iter)/[`len`](Self::len)) consults it transparently;
+    /// [`compact`](Self::compact) folds it back into a fresh base. Gated behind the opt-in `delta`
+    /// feature, so the default build carries no delta state. See [`crate::delta`].
+    #[cfg(feature = "delta")]
+    delta: Option<crate::delta::VectorDelta>,
 }
 
 impl VectorStore {
@@ -168,6 +177,8 @@ impl VectorStore {
             fingerprint: None,
             data_offset: HEADER_LEN,
             inverse: std::sync::OnceLock::new(),
+            #[cfg(feature = "delta")]
+            delta: None,
         })
     }
 
@@ -302,6 +313,8 @@ impl VectorStore {
             fingerprint,
             data_offset,
             inverse: std::sync::OnceLock::new(),
+            #[cfg(feature = "delta")]
+            delta: None,
         })
     }
 
@@ -379,14 +392,36 @@ impl VectorStore {
 
     /// The vector for term `id`, or `None` if it has none. Works in both phases:
     /// a hash lookup during build, a binary search over the mmap'd index after.
+    ///
+    /// [OPUS-4.8] (sq-pi44) With the `delta` feature, the in-RAM delta is consulted FIRST: a
+    /// tombstoned id reads as absent, an appended/updated id reads its delta vector (shadowing the
+    /// base), and any other id reads the immutable base — so search transparently sees the delta.
     pub fn get(&self, id: Id) -> Option<&[f32]> {
+        #[cfg(feature = "delta")]
+        if let Some(delta) = &self.delta {
+            if delta.tombstones.contains(&id) {
+                return None;
+            }
+            if let Some(v) = delta.appended.get(&id) {
+                return Some(v.as_slice());
+            }
+        }
+        self.base_get(id)
+    }
+
+    /// The vector for `id` from the immutable base only (no delta) — the original `get` body. The
+    /// delta-aware [`get`](Self::get) calls this after consulting the delta.
+    fn base_get(&self, id: Id) -> Option<&[f32]> {
         match &self.backing {
             Backing::Build { data, slots, .. } => {
                 let slot = *slots.get(&id)? as usize;
                 Some(&data[slot * self.dim..(slot + 1) * self.dim])
             }
             Backing::Map(map) => {
-                let count = self.len();
+                // [OPUS-4.8] (sq-pi44) The BASE count (not the delta-aware `len`): this reads the
+                // on-disk index, and the delta-aware `len` calls back into `base_get`, so using it
+                // here would recurse infinitely.
+                let count = self.base_len();
                 let index = &map[self.data_offset + count * self.dim * 4..];
                 let id_at = |i: usize| -> Id {
                     u32::from_le_bytes(index[i * 8..i * 8 + 4].try_into().unwrap())
@@ -410,8 +445,27 @@ impl VectorStore {
         }
     }
 
-    /// Number of stored vectors.
+    /// Number of stored vectors — the EFFECTIVE count once the in-RAM delta (appended/updated
+    /// vectors and tombstones) is applied. With the `delta` feature off, or no delta yet, this is
+    /// the base count.
     pub fn len(&self) -> usize {
+        #[cfg(feature = "delta")]
+        if let Some(delta) = &self.delta {
+            // effective = base − (base ids that are tombstoned) − (base ids shadowed by an append)
+            //             + (appended ids). Tombstones and appends are disjoint by construction, so
+            // a base id is double-counted with the appended set only via the `append` branch.
+            let base = self.base_len();
+            let removed = delta.tombstones.iter().filter(|&&id| self.base_get(id).is_some()).count();
+            let shadowed =
+                delta.appended.keys().filter(|&&id| self.base_get(id).is_some()).count();
+            return base - removed - shadowed + delta.appended.len();
+        }
+        self.base_len()
+    }
+
+    /// The base (on-disk / build-phase) vector count, ignoring any in-RAM delta — the original
+    /// `len` body. The delta-aware [`len`](Self::len) builds on this.
+    fn base_len(&self) -> usize {
         match &self.backing {
             Backing::Build { ids, .. } => ids.len(),
             Backing::Map(map) => u64::from_le_bytes(map[12..20].try_into().unwrap()) as usize,
@@ -452,16 +506,51 @@ impl VectorStore {
         fingerprint::check_against(self.fingerprint, graph, fingerprint::Artifact::Store, &origin)
     }
 
-    /// Iterates all `(id, vector)` pairs in insertion-slot order (the dense data
-    /// order) — what ANN index construction consumes.
+    /// Iterates all `(id, vector)` pairs — what ANN index construction consumes. Base entries come
+    /// first in insertion-slot order, then any delta-appended entries.
+    ///
+    /// [OPUS-4.8] (sq-pi44) With the `delta` feature, the EFFECTIVE set is yielded: a tombstoned
+    /// base id is skipped, a base id shadowed by a delta append is skipped (the appended vector is
+    /// yielded instead, from the delta tail), and delta-only appends are appended after the base —
+    /// so search over `iter` transparently unions base+delta and honours tombstones.
     pub fn iter(&self) -> impl Iterator<Item = (Id, &[f32])> + '_ {
-        let count = self.len();
-        (0..count).map(move |slot| match &self.backing {
-            Backing::Build { data, ids, .. } => {
-                (ids[slot], &data[slot * self.dim..(slot + 1) * self.dim])
-            }
-            Backing::Map(map) => (self.slot_id(map, slot), self.slot_vector(map, slot)),
-        })
+        let base_count = self.base_len();
+        let base = (0..base_count)
+            .map(move |slot| match &self.backing {
+                Backing::Build { data, ids, .. } => {
+                    (ids[slot], &data[slot * self.dim..(slot + 1) * self.dim])
+                }
+                Backing::Map(map) => (self.slot_id(map, slot), self.slot_vector(map, slot)),
+            })
+            .filter(move |&(id, _)| self.base_id_is_live(id));
+        base.chain(self.delta_iter())
+    }
+
+    /// Whether base id `id` survives the delta into the effective view: not tombstoned and not
+    /// shadowed by a delta append (the append is yielded from the delta tail instead, to avoid a
+    /// duplicate). Always `true` with the `delta` feature off / no delta.
+    #[allow(unused_variables)]
+    fn base_id_is_live(&self, id: Id) -> bool {
+        #[cfg(feature = "delta")]
+        if let Some(delta) = &self.delta {
+            return !delta.tombstones.contains(&id) && !delta.appended.contains_key(&id);
+        }
+        true
+    }
+
+    /// The delta-appended `(id, vector)` pairs (empty with the `delta` feature off / no delta), to
+    /// chain after the base in [`iter`](Self::iter).
+    fn delta_iter(&self) -> impl Iterator<Item = (Id, &[f32])> + '_ {
+        #[cfg(feature = "delta")]
+        {
+            self.delta
+                .iter()
+                .flat_map(|d| d.appended.iter().map(|(&id, v)| (id, v.as_slice())))
+        }
+        #[cfg(not(feature = "delta"))]
+        {
+            std::iter::empty()
+        }
     }
 
     /// The id stored at insertion `slot` (mmap mode). The on-disk index only maps
@@ -498,6 +587,177 @@ impl VectorStore {
         // f32-aligned; the range is in bounds (validated in `open`); f32 accepts any bit pattern;
         // the slice borrows the backing, owned by `self`.
         unsafe { std::slice::from_raw_parts(bytes.as_ptr() as *const f32, self.dim) }
+    }
+}
+
+// [OPUS-4.8] (sq-pi44) The incremental delta layer: add / remove / update against a finalized store
+// plus `compact`. Gated behind the opt-in `delta` feature so the default build carries no delta
+// surface. See [`crate::delta`] for the design and the honest in-RAM-only scope.
+#[cfg(feature = "delta")]
+impl VectorStore {
+    /// The in-RAM delta sidecar, allocated on first mutation and bound to the base store's
+    /// fingerprint (the generation the appended/tombstoned ids are keyed against).
+    fn delta_mut(&mut self) -> &mut crate::delta::VectorDelta {
+        let generation = self.fingerprint;
+        self.delta.get_or_insert_with(|| crate::delta::VectorDelta::new(generation))
+    }
+
+    /// [OPUS-4.8] (sq-pi44) **Add a NEW vector** for term `id` against an already-finalized store,
+    /// writing it to the in-RAM delta (no file rebuild). Errors on the same vector validation as
+    /// [`put`](Self::put) (dimension, finiteness, non-zero direction), or if `id` ALREADY has an
+    /// effective vector (present in the base and not tombstoned, or already in the delta) — use
+    /// [`update`](Self::update) to replace an existing one. May be called before or after
+    /// `finalize`; on a build-phase store it is equivalent to `put`.
+    pub fn add(&mut self, id: Id, vector: &[f32]) -> Result<(), String> {
+        validate_vector(self.dim, id, vector)?;
+        // On a build-phase store, route to the in-RAM data exactly like `put` (no delta needed).
+        if matches!(self.backing, Backing::Build { .. }) {
+            return self.put(id, vector);
+        }
+        if self.get(id).is_some() {
+            return Err(format!(
+                "id {id} already has a vector; use `update` to replace it"
+            ));
+        }
+        let delta = self.delta_mut();
+        delta.tombstones.remove(&id);
+        delta.appended.insert(id, vector.to_vec());
+        Ok(())
+    }
+
+    /// [OPUS-4.8] (sq-pi44) **Remove** term `id`'s vector from the effective view by tombstoning it
+    /// in the in-RAM delta (no file rebuild). A subsequent [`get`](Self::get)/[`iter`](Self::iter)
+    /// excludes it. Works whether the id lives in the base or only in the delta. Returns `true` if
+    /// the id had an effective vector that this removed, `false` if it had none (a no-op). On a
+    /// build-phase store the vector is dropped directly from the in-RAM build set.
+    pub fn remove(&mut self, id: Id) -> bool {
+        let dim = self.dim;
+        // Build phase: drop directly from the accumulating data (re-pack the dense slots).
+        if let Backing::Build { data, slots, ids } = &mut self.backing {
+            let Some(slot) = slots.remove(&id) else { return false };
+            let slot = slot as usize;
+            // Remove the dense vector and the id at `slot`, then renumber the slots after it.
+            data.drain(slot * dim..(slot + 1) * dim);
+            ids.remove(slot);
+            for s in slots.values_mut() {
+                if (*s as usize) > slot {
+                    *s -= 1;
+                }
+            }
+            return true;
+        }
+        let had = self.get(id).is_some();
+        if had {
+            let delta = self.delta_mut();
+            delta.appended.remove(&id);
+            delta.tombstones.insert(id);
+        }
+        had
+    }
+
+    /// [OPUS-4.8] (sq-pi44) **Update** (replace) the vector for an EXISTING term `id`, writing the
+    /// new vector to the in-RAM delta (no file rebuild). Errors on the same vector validation as
+    /// [`put`](Self::put), or if `id` has no effective vector to replace (use [`add`](Self::add)
+    /// for a new id). On a build-phase store it rewrites the in-RAM vector in place.
+    pub fn update(&mut self, id: Id, vector: &[f32]) -> Result<(), String> {
+        validate_vector(self.dim, id, vector)?;
+        let dim = self.dim;
+        if self.get(id).is_none() {
+            return Err(format!("id {id} has no vector to update; use `add` for a new id"));
+        }
+        // Build phase: rewrite the dense slot in place.
+        if let Backing::Build { data, slots, .. } = &mut self.backing {
+            if let Some(&slot) = slots.get(&id) {
+                let slot = slot as usize;
+                data[slot * dim..(slot + 1) * dim].copy_from_slice(vector);
+                return Ok(());
+            }
+        }
+        let delta = self.delta_mut();
+        delta.tombstones.remove(&id);
+        delta.appended.insert(id, vector.to_vec());
+        Ok(())
+    }
+
+    /// [OPUS-4.8] (sq-pi44) Whether this store has any pending in-RAM delta (appends or tombstones)
+    /// not yet folded into the base by [`compact`](Self::compact).
+    pub fn has_delta(&self) -> bool {
+        self.delta.as_ref().is_some_and(|d| !d.is_empty())
+    }
+
+    /// [OPUS-4.8] (sq-pi44) The pending delta (appended/updated vectors + tombstones + the
+    /// generation it is bound to), or `None` if none has been started. Read-only; for the
+    /// generation-tie staleness check ([`apply_delta`](Self::apply_delta)) and introspection.
+    pub fn delta(&self) -> Option<&crate::delta::VectorDelta> {
+        self.delta.as_ref()
+    }
+
+    /// [OPUS-4.8] (sq-pi44) Removes and returns the pending in-RAM delta, leaving the store reading
+    /// the bare base again. Pair with [`apply_delta`](Self::apply_delta) to move a delta from one
+    /// store handle to another (the generation tie guards a mismatch).
+    pub fn take_delta(&mut self) -> Option<crate::delta::VectorDelta> {
+        self.delta.take()
+    }
+
+    /// [OPUS-4.8] (sq-pi44) Installs `delta` onto this store, REJECTING it if its bound graph
+    /// generation does not match this base store's fingerprint — a delta built against generation N
+    /// must not be applied to a base of generation M ≠ N (its ids would mis-key). Both a present
+    /// mismatch and a delta-without-generation against a fingerprinted base (or vice-versa) are
+    /// errors; only an exact generation match (or both `None`, the unverified-by-design case) is
+    /// accepted. Replaces any delta already present.
+    pub fn apply_delta(&mut self, delta: crate::delta::VectorDelta) -> Result<(), String> {
+        if delta.generation() != self.fingerprint {
+            return Err(format!(
+                "delta generation mismatch: the delta was built against {}, this store is {} — \
+                 applying it would mis-key the appended/tombstoned ids",
+                describe_generation(delta.generation()),
+                describe_generation(self.fingerprint),
+            ));
+        }
+        self.delta = Some(delta);
+        Ok(())
+    }
+
+    /// [OPUS-4.8] (sq-pi44) **Compaction**: folds the in-RAM delta into a FRESH base `.spqv` at
+    /// `out_path`, returning the opened, fully validated store. The result is **equivalent to a
+    /// from-scratch rebuild over the same final vector set**: its `get`/`iter`/`len` agree exactly
+    /// with a store built by `create` + `put` over `self.iter()`'s effective `(id, vector)` pairs.
+    /// The new base is bound to `graph`'s fingerprint (pass the SAME graph the effective ids are
+    /// keyed by); the compacted store carries no delta.
+    ///
+    /// `out_path` may equal the base path — the new file is written first, then opened, so a
+    /// same-path compaction replaces the old base atomically enough for the single-writer contract
+    /// (concurrent external mutation is out of contract, as for [`open`](Self::open)).
+    pub fn compact<P: Into<PathBuf>>(
+        &self,
+        out_path: P,
+        graph: &Graph,
+    ) -> Result<VectorStore, String> {
+        let out_path = out_path.into();
+        let mut fresh = VectorStore::create(&out_path, self.dim)?.with_fingerprint(graph);
+        // Collect first so the new file is independent of `self`'s mmap (which may be the same
+        // path): `iter()` yields the effective base+delta view in a deterministic order, and `put`
+        // re-sorts the id→slot index on `finalize`, so the output is order-independent of the
+        // collection order — i.e. byte-for-byte a from-scratch rebuild for the same id→vector map.
+        let pairs: Vec<(Id, Vec<f32>)> =
+            self.iter().map(|(id, v)| (id, v.to_vec())).collect();
+        for (id, v) in &pairs {
+            fresh.put(*id, v)?;
+        }
+        fresh.finalize()?;
+        Ok(fresh)
+    }
+}
+
+/// [OPUS-4.8] (sq-pi44) A one-line description of a delta/store generation for the mismatch error.
+#[cfg(feature = "delta")]
+fn describe_generation(fp: Option<Fingerprint>) -> String {
+    match fp {
+        Some(f) => format!(
+            "generation(dict_len={}, triples={}, hash={:#018x})",
+            f.dict_len, f.triple_count, f.content_hash
+        ),
+        None => "an unbound/unverified generation".to_string(),
     }
 }
 

--- a/crates/sparq-vectors/tests/delta.rs
+++ b/crates/sparq-vectors/tests/delta.rs
@@ -1,0 +1,295 @@
+//! [OPUS-4.8] (sq-pi44) Incremental delta-sidecar tests for `VectorStore`: add / remove / update
+//! against an already-finalized store (no full rebuild), `compact` result-equivalence to a
+//! from-scratch rebuild, and the generation-tie staleness guard.
+//!
+//! The whole file is gated on the opt-in `delta` feature — with it off the file compiles to an
+//! empty test crate (the add/remove/update/compact APIs do not exist), mirroring the crate's
+//! `filtered-ann` / `vec-predicate` test gating. Style matches the crate's other test modules
+//! (the workspace's intentionally-deferred reformat keeps a compact hand-written layout).
+#![cfg(feature = "delta")]
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_vectors::{nearest_exact, nearest_term_exact, Fingerprint, VectorDelta, VectorStore};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn tmp(tag: &str) -> PathBuf {
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("sparq_delta_{tag}_{}_{n}.spqv", std::process::id()))
+}
+
+fn graph(ttl: &str) -> Graph {
+    Graph::load_str(ttl, "turtle").expect("load test turtle")
+}
+
+fn iri(s: &str) -> Term {
+    Term::NamedNode(NamedNode::new(s).unwrap())
+}
+
+fn id_of(g: &Graph, s: &str) -> u32 {
+    g.id_of(&iri(s)).unwrap()
+}
+
+const A: &str = r#"
+    @prefix ex: <http://example.org/> .
+    ex:alice ex:knows ex:bob .
+    ex:bob ex:knows ex:carol .
+    ex:carol ex:knows ex:dave .
+"#;
+// B has a DIFFERENT dictionary AND a different triple count — a different graph generation.
+const B: &str = r#"
+    @prefix ex: <http://example.org/> .
+    ex:eve ex:likes ex:frank .
+"#;
+
+/// Builds a finalized 4-d store over graph A: alice nearest bob, carol far.
+fn build_finalized(g: &Graph, path: &std::path::Path) -> VectorStore {
+    let mut s = VectorStore::create(path, 4).unwrap().with_fingerprint(g);
+    s.put(id_of(g, "http://example.org/alice"), &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    s.put(id_of(g, "http://example.org/bob"), &[0.9, 0.1, 0.0, 0.0]).unwrap();
+    s.put(id_of(g, "http://example.org/carol"), &[0.0, 0.0, 0.0, 1.0]).unwrap();
+    s.finalize().unwrap();
+    s
+}
+
+// ---------------------------------------------------------------- gate (a): add after finalize
+
+#[test]
+fn add_after_finalize_is_found_by_search() {
+    let g = graph(A);
+    let path = tmp("add");
+    let mut store = build_finalized(&g, &path);
+    let dave = id_of(&g, "http://example.org/dave");
+    let bob = id_of(&g, "http://example.org/bob");
+
+    // `put` is still rejected after finalize (the immutable-file contract is preserved)…
+    assert!(
+        store.put(dave, &[0.95, 0.05, 0.0, 0.0]).is_err(),
+        "put after finalize must still error — the delta API is the additive path"
+    );
+
+    // …but `add` writes into the in-RAM delta against the finalized store.
+    store.add(dave, &[0.99, 0.01, 0.0, 0.0]).unwrap();
+    assert!(store.has_delta());
+    assert_eq!(store.len(), 4, "the appended vector counts in len");
+    assert_eq!(store.get(dave), Some(&[0.99f32, 0.01, 0.0, 0.0][..]), "get reads the delta vector");
+
+    // Exact search (which consumes iter()) now returns the added vector, ranked correctly. alice is
+    // the exact query (cosine 1.0) so ranks first; dave (0.99, 0.01) outranks bob (0.9, 0.1).
+    let q = [1.0f32, 0.0, 0.0, 0.0];
+    let ids: Vec<u32> = nearest_exact(&store, &q, 4).iter().map(|&(id, _)| id).collect();
+    assert!(ids.contains(&dave), "the newly added vector must be found by search: {ids:?}");
+    let dave_rank = ids.iter().position(|&i| i == dave).unwrap();
+    let bob_rank = ids.iter().position(|&i| i == bob).unwrap();
+    assert!(dave_rank < bob_rank, "the added vector outranks bob: {ids:?}");
+
+    // term-by-term search of alice (excludes alice itself): the added dave is now alice's nearest.
+    let neigh = nearest_term_exact(&store, &g, &iri("http://example.org/alice"), 2);
+    assert_eq!(neigh[0].0, iri("http://example.org/dave"));
+    assert_eq!(neigh[1].0, iri("http://example.org/bob"));
+
+    // add of an id that already has a vector is rejected (use update instead).
+    assert!(store.add(dave, &[0.5, 0.5, 0.0, 0.0]).is_err(), "duplicate add rejected");
+    assert!(store.add(bob, &[0.5, 0.5, 0.0, 0.0]).is_err(), "add over an existing base id rejected");
+    std::fs::remove_file(&path).ok();
+}
+
+// ---------------------------------------------------------------- gate (b): remove tombstones
+
+#[test]
+fn remove_tombstones_an_id_search_excludes_it() {
+    let g = graph(A);
+    let path = tmp("remove");
+    let mut store = build_finalized(&g, &path);
+    let bob = id_of(&g, "http://example.org/bob");
+    let alice = iri("http://example.org/alice");
+
+    // Before removal, bob is alice's nearest.
+    assert_eq!(nearest_term_exact(&store, &g, &alice, 1)[0].0, iri("http://example.org/bob"));
+
+    // Remove bob: it is now absent from get / iter / len / search.
+    assert!(store.remove(bob), "removing an existing base id returns true");
+    assert_eq!(store.get(bob), None, "a tombstoned id reads as absent");
+    assert_eq!(store.len(), 2, "len drops by one after the tombstone");
+    let live: Vec<u32> = store.iter().map(|(id, _)| id).collect();
+    assert!(!live.contains(&bob), "iter excludes the tombstoned id: {live:?}");
+
+    // Search no longer surfaces bob.
+    let q = [1.0f32, 0.0, 0.0, 0.0];
+    let ids: Vec<u32> = nearest_exact(&store, &q, 10).iter().map(|&(id, _)| id).collect();
+    assert!(!ids.contains(&bob), "search must exclude the tombstoned id: {ids:?}");
+
+    // Removing an absent id is a no-op (false); removing twice is idempotent.
+    assert!(!store.remove(bob), "second remove is a no-op");
+    assert!(!store.remove(424242), "removing a never-present id is a no-op");
+
+    // A removed id can be re-added (the tombstone is cleared by add).
+    store.add(bob, &[0.8, 0.2, 0.0, 0.0]).unwrap();
+    assert_eq!(store.get(bob), Some(&[0.8f32, 0.2, 0.0, 0.0][..]));
+    assert_eq!(store.len(), 3, "re-add restores the count");
+    std::fs::remove_file(&path).ok();
+}
+
+#[test]
+fn update_replaces_an_existing_vector() {
+    let g = graph(A);
+    let path = tmp("update");
+    let mut store = build_finalized(&g, &path);
+    let carol = id_of(&g, "http://example.org/carol");
+
+    // update an existing (base) id → the new vector shadows the base on every read path.
+    store.update(carol, &[0.97, 0.03, 0.0, 0.0]).unwrap();
+    assert_eq!(store.get(carol), Some(&[0.97f32, 0.03, 0.0, 0.0][..]));
+    assert_eq!(store.len(), 3, "update does not change the count");
+    let q = [1.0f32, 0.0, 0.0, 0.0];
+    let ids: Vec<u32> = nearest_exact(&store, &q, 3).iter().map(|&(id, _)| id).collect();
+    assert!(ids.contains(&carol), "the updated vector is now near the query: {ids:?}");
+
+    // update of an absent id is rejected (use add); validation still applies.
+    assert!(store.update(424242, &[1.0, 0.0, 0.0, 0.0]).is_err(), "update of an absent id errors");
+    assert!(store.update(carol, &[0.0, 0.0, 0.0, 0.0]).is_err(), "all-zero rejected");
+    assert!(store.update(carol, &[f32::NAN, 0.0, 0.0, 0.0]).is_err(), "non-finite rejected");
+    std::fs::remove_file(&path).ok();
+}
+
+// --------------------------------------------------- gate (c): compact == from-scratch rebuild
+
+#[test]
+fn compact_equals_a_from_scratch_rebuild_over_the_final_set() {
+    let g = graph(A);
+    let base_path = tmp("compact-base");
+    let mut store = build_finalized(&g, &base_path);
+
+    let alice = id_of(&g, "http://example.org/alice");
+    let bob = id_of(&g, "http://example.org/bob");
+    let carol = id_of(&g, "http://example.org/carol");
+    let dave = id_of(&g, "http://example.org/dave");
+
+    // A mix of mutations: add a new id, remove a base id, update a base id.
+    store.add(dave, &[0.2, 0.8, 0.0, 0.0]).unwrap();
+    assert!(store.remove(bob));
+    store.update(carol, &[0.0, 0.0, 1.0, 0.0]).unwrap();
+
+    // The EFFECTIVE final set, computed independently of the store.
+    let mut want: Vec<(u32, Vec<f32>)> = vec![
+        (alice, vec![1.0, 0.0, 0.0, 0.0]),
+        (carol, vec![0.0, 0.0, 1.0, 0.0]),
+        (dave, vec![0.2, 0.8, 0.0, 0.0]),
+    ];
+    want.sort_by_key(|&(id, _)| id);
+
+    // (1) compact() into a fresh base.
+    let compact_path = tmp("compact-out");
+    let compacted = store.compact(&compact_path, &g).unwrap();
+    assert!(!compacted.has_delta(), "the compacted store carries no delta");
+
+    // (2) a from-scratch rebuild over the SAME final set, via the ordinary build path.
+    let rebuild_path = tmp("compact-rebuild");
+    let mut rebuilt = VectorStore::create(&rebuild_path, 4).unwrap().with_fingerprint(&g);
+    for (id, v) in &want {
+        rebuilt.put(*id, v).unwrap();
+    }
+    rebuilt.finalize().unwrap();
+
+    // Result-equivalence: same len, same get for every id, same effective iter() set, same
+    // fingerprint as a from-scratch rebuild over the final set. (The two FILES need NOT be
+    // byte-identical: the dense data section follows INSERTION order, which differs between the
+    // compaction's effective-iter order and the rebuild's sorted order — but the trailing id→slot
+    // index is re-sorted on finalize, so every logical read agrees, which is the equivalence that
+    // matters; a query never observes physical slot order.)
+    assert_eq!(compacted.len(), rebuilt.len());
+    assert_eq!(compacted.len(), want.len());
+    for (id, v) in &want {
+        assert_eq!(compacted.get(*id), Some(v.as_slice()), "get mismatch for id {id}");
+        assert_eq!(rebuilt.get(*id), Some(v.as_slice()));
+    }
+    assert_eq!(compacted.get(bob), None, "the tombstoned id is gone from the compacted base");
+    let mut got: Vec<(u32, Vec<f32>)> = compacted.iter().map(|(id, v)| (id, v.to_vec())).collect();
+    got.sort_by_key(|&(id, _)| id);
+    assert_eq!(got, want, "the compacted base's effective set equals the final set");
+    assert_eq!(compacted.fingerprint(), rebuilt.fingerprint());
+    assert!(compacted.check_graph(&g).is_ok());
+
+    // A search over the compacted base agrees with the same search over the rebuilt base.
+    let q = [0.1f32, 0.9, 0.0, 0.0];
+    assert_eq!(nearest_exact(&compacted, &q, 3), nearest_exact(&rebuilt, &q, 3));
+
+    std::fs::remove_file(&base_path).ok();
+    std::fs::remove_file(&compact_path).ok();
+    std::fs::remove_file(&rebuild_path).ok();
+}
+
+// ----------------------------------------- gate (d): a delta tied to gen N rejected against gen M
+
+#[test]
+fn delta_tied_to_generation_n_is_rejected_against_a_base_of_generation_m() {
+    let ga = graph(A);
+    let gb = graph(B); // a DIFFERENT graph generation (different dict + triple count)
+    assert_ne!(
+        Fingerprint::of(&ga),
+        Fingerprint::of(&gb),
+        "A and B must be distinct generations for this test to be meaningful"
+    );
+
+    // A store + delta built against generation A.
+    let a_path = tmp("gen-a");
+    let mut store_a = build_finalized(&ga, &a_path);
+    let dave = id_of(&ga, "http://example.org/dave");
+    store_a.add(dave, &[0.3, 0.7, 0.0, 0.0]).unwrap();
+    let delta_a: VectorDelta = store_a.take_delta().expect("a delta was started");
+    assert_eq!(delta_a.generation(), Some(Fingerprint::of(&ga)));
+
+    // A separate store built against generation B.
+    let b_path = tmp("gen-b");
+    let mut store_b = VectorStore::create(&b_path, 4).unwrap().with_fingerprint(&gb);
+    store_b.put(id_of(&gb, "http://example.org/eve"), &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store_b.finalize().unwrap();
+
+    // Applying the gen-A delta to the gen-B base must be a descriptive ERROR, not a silent mis-key.
+    let err = store_b
+        .apply_delta(delta_a.clone())
+        .expect_err("a delta from a different generation must be rejected");
+    assert!(err.contains("generation mismatch"), "err was: {err}");
+    assert!(!store_b.has_delta(), "the rejected delta must not be installed");
+
+    // The same delta applies cleanly onto a fresh handle of its OWN generation (gen A).
+    let mut store_a2 = VectorStore::open(&a_path).unwrap();
+    store_a2.apply_delta(delta_a).expect("the delta matches its own generation");
+    assert_eq!(store_a2.get(dave), Some(&[0.3f32, 0.7, 0.0, 0.0][..]));
+
+    std::fs::remove_file(&a_path).ok();
+    std::fs::remove_file(&b_path).ok();
+}
+
+// ---------------------------------------------------------------- delta on a build-phase store
+
+#[test]
+fn add_remove_update_on_a_build_phase_store() {
+    // The delta API also works before finalize: add == put, remove/update edit the in-RAM build
+    // set, and finalize then writes the resulting set (no delta carried into the read phase).
+    let g = graph(A);
+    let path = tmp("buildphase");
+    let alice = id_of(&g, "http://example.org/alice");
+    let bob = id_of(&g, "http://example.org/bob");
+    let carol = id_of(&g, "http://example.org/carol");
+
+    let mut store = VectorStore::create(&path, 4).unwrap().with_fingerprint(&g);
+    store.add(alice, &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store.add(bob, &[0.0, 1.0, 0.0, 0.0]).unwrap();
+    store.add(carol, &[0.0, 0.0, 1.0, 0.0]).unwrap();
+    assert!(store.remove(bob), "remove a build-phase vector");
+    store.update(carol, &[0.0, 0.0, 0.0, 1.0]).unwrap();
+    assert_eq!(store.get(bob), None);
+    assert_eq!(store.get(carol), Some(&[0.0f32, 0.0, 0.0, 1.0][..]));
+    assert_eq!(store.len(), 2);
+
+    store.finalize().unwrap();
+    assert_eq!(store.len(), 2);
+    assert_eq!(store.get(alice), Some(&[1.0f32, 0.0, 0.0, 0.0][..]));
+    assert_eq!(store.get(carol), Some(&[0.0f32, 0.0, 0.0, 1.0][..]));
+    assert_eq!(store.get(bob), None);
+    std::fs::remove_file(&path).ok();
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -103,6 +103,18 @@ store.fingerprint() -> Option<Fingerprint>;  store.check_graph(&Graph) -> Result
 //   (Graph::open -- mmaps the FROZEN id order) to resolve query terms; NEVER re-parse the source RDF (Graph::load_str etc.).
 //   (Graph::save/open need sparq-core's `mmap` feature.) Round-trip vs re-parse trap pinned in tests/staleness_contract.rs.
 
+// --- incremental add/remove/update (src/delta.rs) --- feature = "delta" ONLY; LEAN, no new dep [OPUS-4.8] sq-pi44
+// In-RAM DELTA SIDECAR over the immutable base: append map + tombstone set. No file rebuild; a single graph change no
+// longer forces a full re-embed. get/iter/len (hence search) transparently union base+delta and honour tombstones.
+store.add(id, &[f32]) -> Result<(), String>      // NEW id; errs if id already present (use update) or on the put validation
+store.remove(id) -> bool                          // tombstone id (true if it had a vector); a removed id can be re-added
+store.update(id, &[f32]) -> Result<(), String>   // replace an EXISTING id's vector; errs if absent (use add)
+store.compact(out_path, &Graph) -> Result<VectorStore, String>  // fold delta into a FRESH base == a from-scratch rebuild
+store.has_delta() -> bool;  store.delta() -> Option<&VectorDelta>;  store.take_delta() -> Option<VectorDelta>
+store.apply_delta(VectorDelta) -> Result<(), String>  // GENERATION TIE: rejects a delta whose fingerprint != this base's
+// `put` is UNCHANGED (still errs after finalize) — `add` is the additive path. delta is IN-RAM ONLY (lost on drop; `compact`
+//   is the durability path) — persisted on-disk delta sidecar is a tracked follow-up. On a build-phase store add==put.
+
 // --- search (src/ann.rs) --- all return cosine in [-1,1], best first; zero query -> empty
 nearest_exact(&VectorStore, query: &[f32], k) -> Vec<(Id, f32)>                 // ground-truth full scan
 nearest_term_exact(&VectorStore, &Graph, &Term, k) -> Vec<(Term, f32)>          // UNCHECKED: stale store -> silently wrong
@@ -634,6 +646,37 @@ stays < 1.0** (measured floor 0.90@10 in `tests/overfetch.rs`, NOT claimed as ex
 path (recipe 10), and does **not** transfer to this approximate path. Implement your own backend by
 `impl`-ing `AnnBackend` (one `candidates(query, fetch)` method + `len`).
 
+### 12. Incremental add / remove / update without a full rebuild (opt-in, feature = `delta`)
+
+A `.spqv` is build-once-immutable, so one new/removed entity would otherwise force a full re-embed +
+rebuild. The `delta` feature adds an in-RAM **delta sidecar** over the immutable base — `add` / `remove`
+/ `update` write an append map + tombstone set, and `get` / `iter` / `len` (hence search) transparently
+union base+delta and honour tombstones. `compact` folds it back into a fresh base. Lean (no new dep).
+
+```rust,ignore
+# // cargo build -p sparq-vectors --features delta
+use sparq_vectors::VectorStore;
+let mut store = VectorStore::open("graph.spqv")?;   // a finalized base
+
+store.add(new_id, &vec_for_new_id)?;                 // NEW id (errs if already present)
+store.update(existing_id, &new_vec)?;                // replace an existing id (errs if absent)
+store.remove(stale_id);                              // tombstone (returns bool; re-add allowed)
+
+// search transparently sees the delta — no rebuild, no extra API:
+let hits = sparq_vectors::nearest_exact(&store, &query, 10);
+
+// fold the delta into a fresh base == a from-scratch rebuild over the final vector set:
+let compacted = store.compact("graph.spqv", &graph)?;   // bound to graph's fingerprint generation
+# Ok::<(), String>(())
+```
+
+**Generation tie.** A delta carries the graph **generation** (the sq-32i5 fingerprint) it was built
+against; `apply_delta` rejects a delta whose generation differs from the receiving base, so its dict-ids
+can never mis-key onto a different graph. **Honesty (load-bearing):** the delta is **in-RAM only** — it
+is lost when the handle is dropped (the base file is unchanged until `compact` writes a new one). A
+*persisted* on-disk delta sidecar is a tracked follow-up; `compact` is the durability path today. `put`
+is unchanged (still errors after `finalize`) — `add` is the additive path.
+
 ## Gotchas / feature flags / prerequisites
 
 - **Opt-in.** Nothing in the workspace depends on `sparq-vectors`; the default engine
@@ -644,6 +687,11 @@ path (recipe 10), and does **not** transfer to this approximate path. Implement 
   dependency and the base engine/core query path is byte-identical (see recipe 8). There is
   still no `SERVICE`/function binding. Predicate-constrained (filtered) ANN (recipe 9) is a
   separate **non-default `filtered-ann`** feature — also lean (no new dep, no engine pull).
+- **Incremental add/remove/update is the non-default `delta` feature (sq-pi44).** Also lean (no new
+  dep, no engine pull). With it OFF the store is build-once-immutable as before (`put` errors after
+  `finalize`; no `add`/`remove`/`update`/`compact`); with it ON those methods write an in-RAM delta
+  the read paths consult transparently (recipe 12). The delta is **in-RAM only** (lost on handle drop;
+  `compact` is the durability path) — a persisted on-disk delta sidecar is a tracked follow-up.
 - **`approx-ann` is the ONLY heavy ANN dependency, and it is OFF by default (sq-ip3a).** The HNSW
   index (`VectorIndex`/`HnswConfig`) and the `ApproxBackend` are gated behind it — it is the only
   thing pulling `instant-distance`. With it OFF the default build is lean: exact brute-force


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-pi44**: incremental add / remove / update of vectors against an already-finalized `VectorStore` via an in-RAM **delta sidecar**, so a single graph change no longer forces a full re-embed + rebuild. Opt-in, additive, lean.

## What changed

A `.spqv` store was build-once-immutable (`put` errors after `finalize`; no remove/update). This adds an opt-in (`delta` cargo feature, **off by default, no new dependency**) in-RAM delta layer over the immutable base mmap:

- **`VectorStore::{add, remove, update}`** write an *append map* (`id → vector`) + a *tombstone set* against a finalized base — no file rebuild. `add` rejects an id that already has an effective vector (use `update`); `update` rejects an absent id (use `add`); `remove` tombstones (returns whether it removed anything; a removed id can be re-added). Vector validation matches `put` (dim / finiteness / non-zero direction).
- **Transparent search** — `get` / `iter` / `len` consult the delta first (tombstone → absent, append → shadows the base), so `nearest_exact` and the ANN indexes that consume `iter` union base+delta and honour tombstones **with no change to the search code**.
- **`compact(out, &Graph)`** folds the delta into a fresh base **equivalent to a from-scratch rebuild** over the same final vector set.
- **Generation tie (reuses the sq-32i5 fingerprint)** — a `VectorDelta` carries the graph generation it targets; `apply_delta` rejects a delta built against generation N applied to a base of generation M ≠ N, so its dict-ids can never mis-key.

New `src/delta.rs` holds the `VectorDelta` value; the methods live on `VectorStore` behind `#[cfg(feature = "delta")]`. `put`'s after-`finalize` error contract is unchanged — `add` is the additive path.

## Honest boundary / scope

The delta is **in-RAM only** — it lives on the open handle and is lost on drop (the base file is unchanged until `compact` writes a new one). `compact` is the durability path today. A *persisted* on-disk delta sidecar (its own format, crash-durable) is **out of scope for this PR** and captured as a follow-up bead. No performance claims (work-box numbers are non-canonical).

## Gates — green in BOTH feature states

| gate | default (delta OFF) | `--features delta` (ON) |
|------|---------------------|--------------------------|
| `cargo clippy -p sparq-vectors --all-targets -- -D warnings` | clean | clean |
| `cargo test -p sparq-vectors` | 24 bins, 111 passed, 0 failed | 24 bins, 117 passed, 0 failed |

Also clean: `--all-features` clippy, `--no-default-features` clippy. `typos` clean on all changed files. `rustfmt` applied to the two new files (the workspace's deferred reformat keeps a compact committed style; new code matches the surrounding modules).

New tests (`tests/delta.rs`, gated on `delta`) exercise the **real** path:
- (a) add-after-finalize then `nearest_exact` / `nearest_term_exact` returns the new vector, ranked correctly;
- (b) `remove` tombstones an id (search + `get` + `iter` + `len` all exclude it; re-add works);
- (c) `compact()` yields a base whose `len` / `get` / `iter` / `fingerprint` and a `nearest_exact` query all match a from-scratch rebuild over the same final set;
- (d) a delta tied to generation N is rejected against a base of generation M ≠ N;
- plus `update`-replaces and build-phase add/remove/update.

## Feature flag

`delta` (off by default; lean — reuses in-tree `rustc-hash`, pulls neither the engine nor any heavy crate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)