### PR TITLE
feat(site): GUI Phase 2 server health panel — Prometheus /metrics + VoID/Service Description (sq-he72) [OPUS-4.8]

### DIFF
--- a/packages/sparq-client/README.md
+++ b/packages/sparq-client/README.md
@@ -70,6 +70,25 @@ copy is the **single source of truth**, kept byte-identical to a fresh wasm buil
   renders a live row exactly like a queried one. It reuses endpoint mode's `EndpointConfig` +
   bearer posture verbatim, runs the SAME `connectionSafetyWarnings` classifier, and **bypasses no
   server gate** (the SSE read surface is gated by `--auth-token-read` exactly as `/sparql` GET).
+- **Server health / capabilities** (`src/server-health.ts`, `sq-he72`): reads the connected
+  server's OPERATIONAL surface, reusing the SAME `EndpointConfig` + bearer posture.
+  `fetchServerHealth(config)` reads `/health`, the Prometheus `/metrics`, the opt-in VoID
+  (`/.well-known/void`) and the opt-in SPARQL Service Description (a `GET /sparql` with no
+  `query`) concurrently off the configured endpoint's ORIGIN (the operational endpoints live at
+  the server root, NOT under `/sparql` — `deriveServerUrl` does the path swap), and returns each
+  as a discriminated `FetchOutcome` (`ok` / `not-exposed` / `unauthorized` / `error`).
+  `parsePrometheusMetrics` is a focused, dependency-free parser for the server's hand-rolled
+  Prometheus [text exposition format] (`crates/sparq-server/src/metrics.rs`) → `MetricFamily[]`
+  (HELP / TYPE / labelled samples, with histogram buckets grouped under their base family).
+  `extractVoidSummary` / `extractServiceDescription` reshape the RDF descriptors (requested as
+  `application/n-triples`, parsed via `parseNTriples`) into readable `VoidSummary` /
+  `ServiceDescriptionSummary` facts (dataset counts; endpoint, supported languages, features,
+  result/input formats, registered extension functions, named graphs). Crucially, a disabled
+  opt-in feature answers `404`, surfaced as `not-exposed` — an **honest "the operator turned this
+  off"**, never a fabricated metric or capability. Consumes the existing `sparq-server` API and
+  **bypasses no server gate**.
+
+  [text exposition format]: https://prometheus.io/docs/instrumenting/exposition_formats/
 
 ## Endpoint-mode safety posture (honest, never an overclaim)
 

--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -499,6 +499,40 @@ export {
   splitSseFrames,
 } from "./subscriptions.js";
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-he72 — server health / capabilities: read the connected server's
+// operational surface (`/health`, the Prometheus `/metrics`, and the opt-in VoID / SPARQL
+// Service Description). Reuses the SAME `EndpointConfig` + bearer posture as the query client;
+// parses the Prometheus text exposition + the RDF descriptors into readable structures, and
+// reports the server's honest `404` for a disabled opt-in feature as a `"not-exposed"`
+// outcome (never a fabricated value). Consumes the existing `sparq-server` API; bypasses no
+// gate; claims no capability the server does not advertise.
+// ---------------------------------------------------------------------------
+
+export {
+  type CapabilitiesSummary,
+  type FetchOutcome,
+  type MetricFamily,
+  type MetricSample,
+  type MetricType,
+  type NamedGraphSummary,
+  type ParsedMetrics,
+  type ServerHealth,
+  type ServiceDescriptionSummary,
+  type VoidSummary,
+  HEALTH_PATH,
+  METRICS_PATH,
+  VOID_PATH,
+  deriveServerUrl,
+  extractCapabilities,
+  extractServiceDescription,
+  extractVoidSummary,
+  fetchServerHealth,
+  formatMetricLabels,
+  parsePrometheusMetrics,
+  shortenIri,
+} from "./server-health.js";
+
 /** Renders a term for display, with a compact datatype/lang suffix. */
 export function formatTerm(t: SparqlTerm | undefined): string {
   if (!t) return "";

--- a/packages/sparq-client/src/server-health.ts
+++ b/packages/sparq-client/src/server-health.ts
@@ -1,0 +1,662 @@
+// [OPUS-4.8] sq-he72 — GUI Phase 2 item 8: the server HEALTH / CAPABILITIES client.
+//
+// This is the framework-agnostic companion to the endpoint-mode query client
+// (`./endpoint.ts`): where that one runs SPARQL against a connected `sparq-server`, this one
+// reads the server's OPERATIONAL surface — its liveness, its Prometheus `/metrics`, and its
+// opt-in VoID / SPARQL Service Description — and reshapes those wire documents into the
+// readable structures a "server health / capabilities" view renders.
+//
+// It CONSUMES the existing `sparq-server` HTTP API (`crates/sparq-server/src/http.rs`,
+// `metrics.rs`, `descriptors.rs`) verbatim — it changes nothing server-side and claims no
+// capability the server does not advertise. It reuses the SAME `EndpointConfig` (URL +
+// optional bearer token) the Connect panel owns, so one connection + bearer posture serves
+// queries, subscriptions, AND this panel. The bearer token is sent ONLY in the
+// `Authorization: Bearer` header (the channel the server's read gate `--auth-token-read`
+// validates) — never logged, never echoed.
+//
+// HONESTY is load-bearing here. The `/metrics` and `/.well-known/void` surfaces are BOTH
+// opt-in and OFF by default (the VoID/SD endpoints need the `federation-descriptors` feature
+// AND a config flag). When the server has them disabled it answers `404`; this module reports
+// that as a first-class `"not-exposed"` outcome so the UI can say so honestly rather than
+// inventing data or surfacing a scary error. Likewise a metrics COUNTER/GAUGE value is
+// whatever the server reports at scrape time — never relabelled, never a benchmark claim.
+//
+// No React, no Next.js, no DOM beyond the `fetch` / `URL` web-platform globals. No
+// performance claim is made here (this repo's work box is non-canonical); a caller MAY time a
+// single fetch with `performance.now()` and label it as a measured per-request latency.
+
+import type { EndpointConfig } from "./endpoint.js";
+import { parseEndpointUrl } from "./endpoint.js";
+import { parseNTriples, type RdfStatement, type RdfTerm } from "./pretty-turtle.js";
+
+// ---------------------------------------------------------------------------
+// Endpoint URL derivation — the sibling operational endpoints off the /sparql URL.
+// ---------------------------------------------------------------------------
+
+/**
+ * The configured endpoint URL points at the SPARQL query path (e.g.
+ * `http://127.0.0.1:3030/sparql`). The operational endpoints — `/health`, `/metrics`,
+ * `/.well-known/void` — live at the ROOT of the same origin, NOT under `/sparql`. Derive a
+ * sibling URL by replacing the whole path of the configured URL with `path`, preserving the
+ * origin (scheme + host + port) and dropping any query string. Returns `null` when the
+ * configured URL is not a valid absolute http(s) URL (the same gate `parseEndpointUrl` uses),
+ * so the caller can surface an honest "fix the endpoint URL" rather than build a bad request.
+ *
+ * `path` MUST begin with `/` (an absolute path on the origin). The mapping is deliberately
+ * "replace the path", not "append": a server bound at `http://host:3030/sparql` exposes
+ * `/metrics` at `http://host:3030/metrics`, never `http://host:3030/sparql/metrics`.
+ */
+export function deriveServerUrl(endpointUrl: string, path: string): string | null {
+  const parsed = parseEndpointUrl(endpointUrl);
+  if (!parsed) return null;
+  // Rebuild from the origin so the configured path + query never leak into the sibling URL.
+  return `${parsed.origin}${path}`;
+}
+
+/** The server-root paths this module reads (each off the configured endpoint's origin). */
+export const HEALTH_PATH = "/health";
+export const METRICS_PATH = "/metrics";
+export const VOID_PATH = "/.well-known/void";
+
+// ---------------------------------------------------------------------------
+// Prometheus text-exposition parsing (mirrors `crates/sparq-server/src/metrics.rs`).
+// ---------------------------------------------------------------------------
+//
+// The server hand-rolls the Prometheus [text exposition format] — `# HELP <name> <help>`
+// and `# TYPE <name> <counter|gauge|histogram|summary|untyped>` comment lines, then one
+// `name{label="v",…} <value>` sample line per series. We parse exactly that grammar into a
+// list of metric FAMILIES (one per `name`), each carrying its help text, type, and samples.
+// This is a focused parser for the well-formed output `metrics.rs` emits, not a general
+// Prometheus parser — but it tolerates the variations the spec allows (missing HELP/TYPE,
+// `+Inf`/`NaN` values, escaped label values) so it never throws on a conformant document.
+//
+// [text exposition format]: https://prometheus.io/docs/instrumenting/exposition_formats/
+
+/** A Prometheus metric type, as declared by a `# TYPE` line (defaults to `untyped`). */
+export type MetricType =
+  | "counter"
+  | "gauge"
+  | "histogram"
+  | "summary"
+  | "untyped";
+
+/** One sample (time-series point): the metric name, its label set, and its numeric value. */
+export interface MetricSample {
+  /** The metric name (for a histogram, e.g. `sparq_query_duration_seconds_bucket`). */
+  name: string;
+  /** The label set, in declaration order (`{}` → empty). */
+  labels: { name: string; value: string }[];
+  /** The numeric value. `+Inf` / `-Inf` / `NaN` parse to the JS equivalents. */
+  value: number;
+}
+
+/** A metric FAMILY: every sample sharing a base `name`, plus its declared help + type. */
+export interface MetricFamily {
+  /** The base metric name (the `# HELP` / `# TYPE` subject). */
+  name: string;
+  /** The `# HELP` text, or `null` when the document declared none. */
+  help: string | null;
+  /** The `# TYPE`, defaulting to `untyped` when the document declared none. */
+  type: MetricType;
+  /** Every sample of this family, in document order. */
+  samples: MetricSample[];
+}
+
+/** The parsed `/metrics` document: the metric families, in first-seen order. */
+export interface ParsedMetrics {
+  families: MetricFamily[];
+}
+
+const METRIC_TYPES: ReadonlySet<string> = new Set([
+  "counter",
+  "gauge",
+  "histogram",
+  "summary",
+  "untyped",
+]);
+
+/** Parse a Prometheus value token (`+Inf` / `-Inf` / `Nan` / a float) to a JS number. */
+function parseMetricValue(token: string): number {
+  const t = token.trim();
+  if (t === "+Inf" || t === "Inf") return Number.POSITIVE_INFINITY;
+  if (t === "-Inf") return Number.NEGATIVE_INFINITY;
+  if (t === "NaN" || t === "Nan") return Number.NaN;
+  const n = Number(t);
+  return Number.isNaN(n) ? Number.NaN : n;
+}
+
+/**
+ * Parse the label set inside a `{ … }` block: `name="value",name2="value2"`. Label values
+ * are double-quoted and may carry the Prometheus escapes (`\\`, `\"`, `\n`); we unescape
+ * those three. A bare `{}` yields `[]`. This is a forgiving scanner — a label it cannot read
+ * is skipped rather than throwing, so a slightly-off line degrades to fewer labels, not a
+ * crash.
+ */
+function parseLabels(block: string): { name: string; value: string }[] {
+  const labels: { name: string; value: string }[] = [];
+  let i = 0;
+  const s = block;
+  while (i < s.length) {
+    // Skip whitespace / commas between labels.
+    while (i < s.length && (s[i] === " " || s[i] === "," || s[i] === "\t")) i++;
+    if (i >= s.length) break;
+    // Read the label name (up to `=`).
+    const eq = s.indexOf("=", i);
+    if (eq === -1) break;
+    const name = s.slice(i, eq).trim();
+    i = eq + 1;
+    if (s[i] !== '"') break; // value must be a quoted string
+    i++; // past opening quote
+    let value = "";
+    while (i < s.length && s[i] !== '"') {
+      if (s[i] === "\\" && i + 1 < s.length) {
+        const next = s[i + 1];
+        value += next === "n" ? "\n" : next; // \\ and \" fall through to the literal char
+        i += 2;
+      } else {
+        value += s[i];
+        i++;
+      }
+    }
+    i++; // past closing quote
+    if (name !== "") labels.push({ name, value });
+  }
+  return labels;
+}
+
+/**
+ * [OPUS-4.8] sq-he72 — parse a Prometheus text-exposition document into metric families.
+ *
+ * Walks the document line by line: `# HELP <name> <text>` and `# TYPE <name> <type>` comments
+ * attach to the named family (created on first reference); every other non-blank, non-comment
+ * line is a sample `name{labels} value [timestamp]`. Samples whose name shares the family's
+ * base name (or a histogram/summary suffix — `_bucket` / `_sum` / `_count` — of it) are
+ * grouped under that family; a sample for an as-yet-undeclared name creates an `untyped`
+ * family. Families are returned in first-seen order so the rendered view is stable.
+ *
+ * Never throws: a line it cannot classify is ignored. An empty / whitespace-only document
+ * yields `{ families: [] }`.
+ */
+export function parsePrometheusMetrics(text: string): ParsedMetrics {
+  const families: MetricFamily[] = [];
+  const byName = new Map<string, MetricFamily>();
+
+  const family = (name: string): MetricFamily => {
+    let f = byName.get(name);
+    if (!f) {
+      f = { name, help: null, type: "untyped", samples: [] };
+      byName.set(name, f);
+      families.push(f);
+    }
+    return f;
+  };
+
+  // Find the family a sample belongs to: an exact name match, else strip a histogram/summary
+  // suffix (`_bucket` / `_sum` / `_count`) and match the base. Falls back to a fresh family.
+  const familyForSample = (sampleName: string): MetricFamily => {
+    if (byName.has(sampleName)) return byName.get(sampleName)!;
+    for (const suffix of ["_bucket", "_sum", "_count"]) {
+      if (sampleName.endsWith(suffix)) {
+        const base = sampleName.slice(0, -suffix.length);
+        const f = byName.get(base);
+        if (f) return f;
+      }
+    }
+    return family(sampleName);
+  };
+
+  for (const rawLine of text.split("\n")) {
+    const line = rawLine.trim();
+    if (line === "") continue;
+    if (line.startsWith("#")) {
+      // `# HELP <name> <text>` or `# TYPE <name> <type>` — anything else is a comment.
+      const m = /^#\s+(HELP|TYPE)\s+(\S+)\s*(.*)$/.exec(line);
+      if (!m) continue;
+      const [, kind, name, rest] = m;
+      const f = family(name);
+      if (kind === "HELP") {
+        f.help = rest;
+      } else {
+        const t = rest.trim().toLowerCase();
+        f.type = METRIC_TYPES.has(t) ? (t as MetricType) : "untyped";
+      }
+      continue;
+    }
+    // A sample line: `name{labels} value [timestamp]` or `name value [timestamp]`.
+    const brace = line.indexOf("{");
+    let name: string;
+    let labels: { name: string; value: string }[] = [];
+    let valuePart: string;
+    if (brace !== -1) {
+      const close = line.indexOf("}", brace);
+      if (close === -1) continue; // malformed — skip
+      name = line.slice(0, brace).trim();
+      labels = parseLabels(line.slice(brace + 1, close));
+      valuePart = line.slice(close + 1).trim();
+    } else {
+      const sp = line.search(/\s/);
+      if (sp === -1) continue; // no value — skip
+      name = line.slice(0, sp).trim();
+      valuePart = line.slice(sp).trim();
+    }
+    if (name === "") continue;
+    // The value is the first whitespace-separated token (a trailing timestamp is ignored).
+    const valueToken = valuePart.split(/\s+/)[0] ?? "";
+    const value = parseMetricValue(valueToken);
+    familyForSample(name).samples.push({ name, labels, value });
+  }
+
+  return { families };
+}
+
+// ---------------------------------------------------------------------------
+// VoID + SPARQL Service Description → a readable capabilities view.
+// ---------------------------------------------------------------------------
+//
+// The server serialises BOTH descriptors as RDF. We request `application/n-triples` (the
+// server serialises it; `descriptors.rs` `serialise`) and reshape the triples into the
+// structured facts a capabilities panel renders. We do NOT re-implement an RDF store: a flat
+// linear pass keyed on the well-known VoID / SD vocabulary IRIs is enough for the small,
+// shaped documents the server emits (`crates/sparq-introspect` `to_void`,
+// `crates/sparq-server/src/descriptors.rs` `sd_ntriples`).
+
+const RDF_TYPE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const VOID_NS = "http://rdfs.org/ns/void#";
+const SD_NS = "http://www.w3.org/ns/sparql-service-description#";
+
+/** The VoID dataset-level counts (`crates/sparq-introspect` `to_void`). */
+export interface VoidSummary {
+  /** The `void:Dataset` IRI the server names (`{base}/.well-known/void#dataset`), or `null`. */
+  datasetIri: string | null;
+  /** `void:triples` — total triples (exact). `null` when absent. */
+  triples: number | null;
+  /** `void:entities` — distinct subjects carrying an `rdf:type` (exact). `null` when absent. */
+  entities: number | null;
+  /** `void:distinctSubjects` — distinct subjects (exact). `null` when absent. */
+  distinctSubjects: number | null;
+  /** `void:classes` — distinct classes (`rdf:type` objects). `null` when absent. */
+  classes: number | null;
+  /** `void:properties` — distinct predicates. `null` when absent. */
+  properties: number | null;
+}
+
+/** One named graph the Service Description advertises (`sd:namedGraph` → `sd:name`). */
+export interface NamedGraphSummary {
+  /** The graph's `sd:name` IRI (usable in `FROM NAMED` / `GRAPH <name>`). */
+  name: string;
+  /** The graph's `void:triples` count, or `null` when not advertised. */
+  triples: number | null;
+}
+
+/** The SPARQL Service Description facts (`crates/sparq-server/src/descriptors.rs`). */
+export interface ServiceDescriptionSummary {
+  /** The `sd:Service` IRI, or `null` when no `sd:Service` was found. */
+  serviceIri: string | null;
+  /** The `sd:endpoint` IRI. `null` when absent. */
+  endpoint: string | null;
+  /** `sd:supportedLanguage` IRIs (e.g. `sd:SPARQL11Query`, `sd:SPARQL11Update`). */
+  supportedLanguages: string[];
+  /** `sd:feature` IRIs (e.g. `sd:BasicFederatedQuery` when the server feature is on). */
+  features: string[];
+  /** `sd:resultFormat` IRIs the server can RETURN. */
+  resultFormats: string[];
+  /** `sd:inputFormat` IRIs the server can PARSE. */
+  inputFormats: string[];
+  /** `sd:extensionFunction` IRIs the engine has registered (e.g. the `geof:` set). */
+  extensionFunctions: string[];
+  /** The named graphs the SD enumerates (`sd:namedGraph`), sorted as the server emits them. */
+  namedGraphs: NamedGraphSummary[];
+}
+
+/** The combined capabilities view extracted from the VoID + SD documents. */
+export interface CapabilitiesSummary {
+  void: VoidSummary;
+  service: ServiceDescriptionSummary;
+}
+
+/** An IRI term's value, or `null` for a non-IRI (blank node / literal) term. */
+function iriValue(t: RdfTerm): string | null {
+  return t.kind === "iri" ? t.value : null;
+}
+
+/** A literal's integer value, or `null` for a non-integer / non-literal term. */
+function intValue(t: RdfTerm): number | null {
+  if (t.kind !== "literal") return null;
+  const n = Number(t.value);
+  return Number.isInteger(n) ? n : null;
+}
+
+/** A stable key for a term, used to follow blank-node / IRI links in the SD graph. */
+function termKey(t: RdfTerm): string {
+  return t.kind === "bnode" ? `_:${t.label}` : t.nt;
+}
+
+/**
+ * [OPUS-4.8] sq-he72 — extract the readable capabilities facts from the VoID document the
+ * server serves at `/.well-known/void` (parsed N-Triples statements). Reads the dataset-level
+ * `void:triples` / `void:entities` / `void:distinctSubjects` / `void:classes` /
+ * `void:properties` off the `void:Dataset` subject. The per-class / per-predicate partitions
+ * are intentionally NOT surfaced here (the panel shows the dataset summary, not every
+ * partition); a caller wanting them can read the raw document.
+ */
+export function extractVoidSummary(statements: RdfStatement[]): VoidSummary {
+  // Find the dataset subject (the one typed `void:Dataset`). The introspect emits exactly one.
+  let datasetKey: string | null = null;
+  let datasetIri: string | null = null;
+  for (const st of statements) {
+    if (
+      iriValue(st.p) === RDF_TYPE &&
+      iriValue(st.o) === `${VOID_NS}Dataset` &&
+      st.s.kind === "iri"
+    ) {
+      datasetKey = termKey(st.s);
+      datasetIri = st.s.value;
+      break;
+    }
+  }
+  const summary: VoidSummary = {
+    datasetIri,
+    triples: null,
+    entities: null,
+    distinctSubjects: null,
+    classes: null,
+    properties: null,
+  };
+  if (datasetKey === null) return summary;
+  for (const st of statements) {
+    if (termKey(st.s) !== datasetKey) continue;
+    const p = iriValue(st.p);
+    if (p === `${VOID_NS}triples`) summary.triples = intValue(st.o);
+    else if (p === `${VOID_NS}entities`) summary.entities = intValue(st.o);
+    else if (p === `${VOID_NS}distinctSubjects`) summary.distinctSubjects = intValue(st.o);
+    else if (p === `${VOID_NS}classes`) summary.classes = intValue(st.o);
+    else if (p === `${VOID_NS}properties`) summary.properties = intValue(st.o);
+  }
+  return summary;
+}
+
+/**
+ * [OPUS-4.8] sq-he72 — extract the readable capabilities facts from the SPARQL Service
+ * Description the server serves for a `GET /sparql` with no `query` (parsed N-Triples
+ * statements). Reads the `sd:Service` subject's `sd:endpoint`, `sd:supportedLanguage`,
+ * `sd:feature`, `sd:resultFormat`, `sd:inputFormat`, `sd:extensionFunction`, and follows the
+ * `sd:defaultDataset` → `sd:namedGraph` → (`sd:name`, `sd:graph` → `void:triples`) blank-node
+ * chain (`descriptors.rs` `sd_ntriples`) to enumerate the named graphs.
+ */
+export function extractServiceDescription(
+  statements: RdfStatement[],
+): ServiceDescriptionSummary {
+  const summary: ServiceDescriptionSummary = {
+    serviceIri: null,
+    endpoint: null,
+    supportedLanguages: [],
+    features: [],
+    resultFormats: [],
+    inputFormats: [],
+    extensionFunctions: [],
+    namedGraphs: [],
+  };
+
+  // The sd:Service subject (the document's root).
+  let serviceKey: string | null = null;
+  for (const st of statements) {
+    if (
+      iriValue(st.p) === RDF_TYPE &&
+      iriValue(st.o) === `${SD_NS}Service` &&
+      st.s.kind === "iri"
+    ) {
+      serviceKey = termKey(st.s);
+      summary.serviceIri = st.s.value;
+      break;
+    }
+  }
+  if (serviceKey === null) return summary;
+
+  let defaultDatasetKey: string | null = null;
+  for (const st of statements) {
+    if (termKey(st.s) !== serviceKey) continue;
+    const p = iriValue(st.p);
+    const o = iriValue(st.o);
+    if (p === `${SD_NS}endpoint` && o) summary.endpoint = o;
+    else if (p === `${SD_NS}supportedLanguage` && o) summary.supportedLanguages.push(o);
+    else if (p === `${SD_NS}feature` && o) summary.features.push(o);
+    else if (p === `${SD_NS}resultFormat` && o) summary.resultFormats.push(o);
+    else if (p === `${SD_NS}inputFormat` && o) summary.inputFormats.push(o);
+    else if (p === `${SD_NS}extensionFunction` && o) summary.extensionFunctions.push(o);
+    else if (p === `${SD_NS}defaultDataset`) defaultDatasetKey = termKey(st.o);
+  }
+
+  // Follow defaultDataset → sd:namedGraph → (_:ng) → sd:name / sd:graph → (_:ngG) → void:triples.
+  if (defaultDatasetKey !== null) {
+    const namedGraphKeys: string[] = [];
+    for (const st of statements) {
+      if (termKey(st.s) === defaultDatasetKey && iriValue(st.p) === `${SD_NS}namedGraph`) {
+        namedGraphKeys.push(termKey(st.o));
+      }
+    }
+    for (const ngKey of namedGraphKeys) {
+      let name: string | null = null;
+      let graphKey: string | null = null;
+      for (const st of statements) {
+        if (termKey(st.s) !== ngKey) continue;
+        const p = iriValue(st.p);
+        if (p === `${SD_NS}name`) name = iriValue(st.o);
+        else if (p === `${SD_NS}graph`) graphKey = termKey(st.o);
+      }
+      if (name === null) continue; // an sd:name-less entry is not FROM NAMED-referenceable
+      let triples: number | null = null;
+      if (graphKey !== null) {
+        for (const st of statements) {
+          if (termKey(st.s) === graphKey && iriValue(st.p) === `${VOID_NS}triples`) {
+            triples = intValue(st.o);
+            break;
+          }
+        }
+      }
+      summary.namedGraphs.push({ name, triples });
+    }
+  }
+
+  return summary;
+}
+
+/** Extract both descriptors' facts from a single parsed-statements list (used for SD which
+ * also carries the default-graph `void:triples` count; VoID is a separate document). */
+export function extractCapabilities(statements: RdfStatement[]): CapabilitiesSummary {
+  return {
+    void: extractVoidSummary(statements),
+    service: extractServiceDescription(statements),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The fetch orchestration — health + metrics + descriptors, with honest 404 handling.
+// ---------------------------------------------------------------------------
+
+/**
+ * The outcome of reading ONE operational endpoint. `"ok"` carries the parsed payload;
+ * `"not-exposed"` is the server's honest `404` (the opt-in feature is OFF — the panel says
+ * so, it is not an error); `"unauthorized"` is a `401` (the read gate needs a token);
+ * `"error"` is any other HTTP failure or a transport failure (CORS / refused / mixed-content)
+ * with an honest message. A discriminated union so the UI renders each state distinctly.
+ */
+export type FetchOutcome<T> =
+  | { status: "ok"; data: T }
+  | { status: "not-exposed" }
+  | { status: "unauthorized"; message: string }
+  | { status: "error"; message: string };
+
+/** The aggregate server-health snapshot: liveness + metrics + capabilities, each outcome-tagged. */
+export interface ServerHealth {
+  /** `GET /health` — plaintext `ok` when live. */
+  health: FetchOutcome<{ body: string }>;
+  /** `GET /metrics` — the parsed Prometheus exposition. `not-exposed` is not used (always on). */
+  metrics: FetchOutcome<ParsedMetrics>;
+  /** `GET /.well-known/void` — the VoID dataset summary (opt-in; `not-exposed` when the feature is off). */
+  voidDescriptor: FetchOutcome<VoidSummary>;
+  /** `GET /sparql` (no query) — the SPARQL Service Description (opt-in; `not-exposed` when off). */
+  serviceDescription: FetchOutcome<ServiceDescriptionSummary>;
+}
+
+/** Add `Authorization: Bearer <token>` iff a non-empty token is configured. */
+function authHeaders(
+  base: Record<string, string>,
+  token?: string,
+): Record<string, string> {
+  const t = (token ?? "").trim();
+  if (t !== "") base["Authorization"] = `Bearer ${t}`;
+  return base;
+}
+
+/** Map a transport failure (the opaque browser `TypeError`) to an honest error message. */
+function transportError(e: unknown): string {
+  const base = e instanceof Error ? e.message : String(e);
+  return (
+    `Could not reach the server (${base}). This is usually a CORS block (sparq-server emits ` +
+    `no CORS headers by default — opt this origin in with --cors-allow-origin), a refused ` +
+    `connection (is the server running and reachable?), or a mixed-content block (HTTPS page ` +
+    `→ http endpoint).`
+  );
+}
+
+/**
+ * Fetch one operational endpoint and map its response to a {@link FetchOutcome} via `onOk`.
+ * Classifies a status in `notExposedStatuses` → `not-exposed` (the opt-in feature is off),
+ * `401` → `unauthorized`, any other non-2xx → `error`, and a transport failure → `error`
+ * with the CORS/refused hint.
+ *
+ * `notExposedStatuses` defaults to `[404]` — the VoID endpoint and a disabled `/metrics`
+ * answer `404`. The Service Description is the exception: it is served on `GET /sparql` with
+ * NO `query`, and when the opt-in `federation-descriptors` feature is OFF the server falls
+ * through to the historical `400 missing 'query'` (`crates/sparq-server/src/http.rs`), so the
+ * SD read passes `[404, 400]` to treat that fall-through as "not exposed" too rather than a
+ * scary error.
+ */
+async function fetchOutcome<T>(
+  url: string,
+  init: RequestInit,
+  fetchImpl: typeof fetch,
+  onOk: (resp: Response) => Promise<T>,
+  notExposedStatuses: readonly number[] = [404],
+): Promise<FetchOutcome<T>> {
+  let resp: Response;
+  try {
+    resp = await fetchImpl(url, init);
+  } catch (e) {
+    return { status: "error", message: transportError(e) };
+  }
+  if (notExposedStatuses.includes(resp.status)) return { status: "not-exposed" };
+  if (resp.status === 401) {
+    return {
+      status: "unauthorized",
+      message:
+        "The server gates reads behind a Bearer token (--auth-token-read). Enter a valid token in the Connect panel.",
+    };
+  }
+  if (!resp.ok) {
+    return { status: "error", message: `Request rejected (${resp.status}).` };
+  }
+  try {
+    return { status: "ok", data: await onOk(resp) };
+  } catch (e) {
+    const base = e instanceof Error ? e.message : String(e);
+    return { status: "error", message: `Could not parse the server response: ${base}` };
+  }
+}
+
+/** Parse an RDF descriptor body (N-Triples) into statements, then reshape via `extract`. */
+async function parseDescriptor<T>(
+  resp: Response,
+  extract: (statements: RdfStatement[]) => T,
+): Promise<T> {
+  const text = await resp.text();
+  const { statements } = parseNTriples(text);
+  return extract(statements);
+}
+
+/**
+ * [OPUS-4.8] sq-he72 — read the connected server's full operational surface: `/health`,
+ * `/metrics`, the opt-in `/.well-known/void` and the opt-in Service Description (a
+ * `GET /sparql` with no `query`). Each is fetched independently off the configured endpoint's
+ * ORIGIN (not under `/sparql`) so one disabled feature never blocks the others, and each is
+ * outcome-tagged so the UI can render "live / not exposed / unauthorized / error" honestly.
+ *
+ * The bearer token (if configured) is sent only in the `Authorization: Bearer` header — the
+ * channel the server's read gate validates — and is never logged. Descriptors are requested
+ * as `application/n-triples` (the server serialises it) so this client parses one wire shape.
+ *
+ * Throws only if the configured endpoint URL is not a valid absolute http(s) URL (a caller
+ * should gate on `connectionSafetyWarnings` first); every reachable-but-failing case is folded
+ * into a {@link FetchOutcome} rather than thrown.
+ */
+export async function fetchServerHealth(
+  config: EndpointConfig,
+  fetchImpl: typeof fetch = fetch,
+): Promise<ServerHealth> {
+  const healthUrl = deriveServerUrl(config.url, HEALTH_PATH);
+  const metricsUrl = deriveServerUrl(config.url, METRICS_PATH);
+  const voidUrl = deriveServerUrl(config.url, VOID_PATH);
+  // The Service Description is served on the SPARQL endpoint itself (a GET with no `query`).
+  const sdUrl = parseEndpointUrl(config.url)?.toString() ?? null;
+  if (!healthUrl || !metricsUrl || !voidUrl || !sdUrl) {
+    throw new Error(
+      "Enter a valid absolute endpoint URL (http:// or https://) in the Connect panel before reading server health.",
+    );
+  }
+
+  const auth = (extra: Record<string, string> = {}) =>
+    authHeaders({ ...extra }, config.token);
+
+  // Run the four reads concurrently — each is independent and outcome-tagged.
+  const [health, metrics, voidDescriptor, serviceDescription] = await Promise.all([
+    fetchOutcome(
+      healthUrl,
+      { method: "GET", headers: auth() },
+      fetchImpl,
+      async (r) => ({ body: (await r.text()).trim() }),
+    ),
+    fetchOutcome(
+      metricsUrl,
+      { method: "GET", headers: auth() },
+      fetchImpl,
+      async (r) => parsePrometheusMetrics(await r.text()),
+    ),
+    fetchOutcome(
+      voidUrl,
+      { method: "GET", headers: auth({ Accept: "application/n-triples" }) },
+      fetchImpl,
+      (r) => parseDescriptor(r, extractVoidSummary),
+    ),
+    fetchOutcome(
+      sdUrl,
+      { method: "GET", headers: auth({ Accept: "application/n-triples" }) },
+      fetchImpl,
+      (r) => parseDescriptor(r, extractServiceDescription),
+      // SD-off falls through to `400 missing 'query'`, not a 404 — treat both as not-exposed.
+      [404, 400],
+    ),
+  ]);
+
+  return { health, metrics, voidDescriptor, serviceDescription };
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers (pure shaping — so the site + a Tauri webview render identically).
+// ---------------------------------------------------------------------------
+
+/** Abbreviate a well-known VoID / SD IRI to a short `prefix:Local` form for display. */
+export function shortenIri(iri: string): string {
+  if (iri.startsWith(SD_NS)) return `sd:${iri.slice(SD_NS.length)}`;
+  if (iri.startsWith(VOID_NS)) return `void:${iri.slice(VOID_NS.length)}`;
+  if (iri === RDF_TYPE) return "rdf:type";
+  return iri;
+}
+
+/**
+ * Format a metric sample's label set as a compact `{name="v",…}` string (empty `""` when the
+ * sample has no labels), for inline display next to its value.
+ */
+export function formatMetricLabels(labels: MetricSample["labels"]): string {
+  if (labels.length === 0) return "";
+  return `{${labels.map((l) => `${l.name}="${l.value}"`).join(",")}}`;
+}

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -61,6 +61,8 @@ import { TurtleResult } from "@/components/rdf-highlight";
 import { ConnectPanel } from "@/components/connect-panel";
 // [OPUS-4.8] sq-9ij6 — endpoint mode: the live subscriptions view (SSE result deltas).
 import { SubscriptionsView } from "@/components/subscriptions-view";
+// [OPUS-4.8] sq-he72 — endpoint mode: the server health / capabilities panel (metrics + VoID/SD).
+import { ServerHealthPanel } from "@/components/server-health-panel";
 import { type EndpointConfig, runEndpointQuery } from "@sparq/client";
 
 // [OPUS-4.8] sq-vfbm — the REPL now dispatches across the whole lean-bundle query
@@ -532,6 +534,13 @@ export function Repl() {
             renders an honest "switch on endpoint mode" hint otherwise. It reuses the SAME
             endpoint config + bearer/connection-safety posture the Connect panel established. */}
         <SubscriptionsView config={endpointConfig} active={endpointActive} />
+
+        {/* [OPUS-4.8] sq-he72 — the server health / capabilities panel. Reads the connected
+            server's /health, Prometheus /metrics, and the opt-in VoID / SPARQL Service
+            Description, rendering "not exposed" honestly when the operator left a feature off.
+            Like the subscriptions view, it only runs in endpoint mode and reuses the SAME
+            endpoint config + bearer/connection-safety posture. */}
+        <ServerHealthPanel config={endpointConfig} active={endpointActive} />
       </CardContent>
 
       <DatasetViewer

--- a/site/src/components/server-health-panel.tsx
+++ b/site/src/components/server-health-panel.tsx
@@ -1,0 +1,515 @@
+"use client";
+
+// [OPUS-4.8] sq-he72 — GUI Phase 2 item 8: the server HEALTH / CAPABILITIES panel.
+//
+// In endpoint mode this panel reads the connected sparq-server's OPERATIONAL surface — its
+// `/health` liveness, its Prometheus `/metrics`, and its opt-in VoID / SPARQL Service
+// Description — and renders them as a readable "server health / capabilities" view.
+//
+// It REUSES the sq-2mke endpoint-mode connection + bearer posture (the SAME `EndpointConfig`
+// the Connect panel owns), never reinventing it: the bearer token is sent only in the
+// `Authorization: Bearer` header by the shared `@sparq/client` `fetchServerHealth`, the same
+// channel the server's read gate (`--auth-token-read`) validates. This view never logs the
+// token and never bypasses a server gate.
+//
+// HONESTY is load-bearing. The `/metrics` and VoID/SD surfaces are opt-in and OFF by default;
+// a disabled feature answers `404`, which the client reports as a `"not-exposed"` outcome —
+// rendered here as an explicit "not exposed by this server" note, NEVER a fabricated metric or
+// capability. Metric VALUES are whatever the server reports at scrape time; they are server
+// operational counters, NOT a benchmark claim (this repo's work box is non-canonical).
+//
+// All wire-protocol + parsing logic lives in the framework-agnostic `@sparq/client`
+// server-health module; this component is just the React host that draws the metric tables,
+// the capabilities lists, and the honest fetch lifecycle.
+
+import * as React from "react";
+import {
+  HeartPulse,
+  Gauge,
+  Boxes,
+  RefreshCw,
+  Loader2,
+  CircleCheck,
+  CircleSlash,
+  ShieldAlert,
+  Network,
+  Database,
+  ServerCog,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  type EndpointConfig,
+  type FetchOutcome,
+  type MetricFamily,
+  type ServerHealth,
+  type ServiceDescriptionSummary,
+  type VoidSummary,
+  connectionSafetyWarnings,
+  fetchServerHealth,
+  formatMetricLabels,
+  hasBlockingWarning,
+  shortenIri,
+} from "@sparq/client";
+
+/** The panel's fetch lifecycle, surfaced honestly. */
+type LoadState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; health: ServerHealth }
+  | { kind: "error"; message: string };
+
+export interface ServerHealthPanelProps {
+  /** The endpoint connection (URL + optional bearer token), shared with the REPL. */
+  config: EndpointConfig;
+  /** Whether endpoint mode is active — health is only read from a real server. */
+  active: boolean;
+}
+
+/**
+ * [OPUS-4.8] sq-he72 — the server health / capabilities panel. Renders a Refresh control, the
+ * honest connection-safety findings (reused from sq-2mke), the server liveness, the parsed
+ * Prometheus metrics grouped by family, and the VoID + Service-Description capabilities — each
+ * gracefully showing "not exposed" when the server has the opt-in feature off (a `404`).
+ */
+export function ServerHealthPanel({ config, active }: ServerHealthPanelProps) {
+  const [state, setState] = React.useState<LoadState>({ kind: "idle" });
+
+  // Reuse the SAME honest classifier the Connect panel uses; a hard block (invalid URL /
+  // mixed content) disables Refresh exactly as it disables turning endpoint mode on.
+  const warnings = React.useMemo(() => connectionSafetyWarnings(config), [config]);
+  const blocked = hasBlockingWarning(warnings);
+
+  const refresh = React.useCallback(async () => {
+    setState({ kind: "loading" });
+    try {
+      const health = await fetchServerHealth(config);
+      setState({ kind: "loaded", health });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setState({ kind: "error", message });
+    }
+  }, [config]);
+
+  // Reset the snapshot whenever endpoint mode is switched off, or the connection changes — a
+  // stale snapshot from a previous server must never linger.
+  React.useEffect(() => {
+    setState({ kind: "idle" });
+  }, [active, config.url, config.token]);
+
+  if (!active) {
+    return (
+      <div className="space-y-2 rounded-lg border bg-muted/30 p-3">
+        <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+          <HeartPulse className="size-3.5" />
+          Server health &amp; capabilities
+          <span className="font-normal text-muted-foreground/80">
+            — the connected server&apos;s metrics + VoID / Service Description
+          </span>
+        </div>
+        <p className="text-[11.5px] leading-relaxed text-muted-foreground">
+          Switch on <span className="font-medium">Endpoint mode</span> above and connect to a
+          running sparq-server to read its <code className="font-mono">/health</code>, its
+          Prometheus <code className="font-mono">/metrics</code>, and — when the operator
+          enabled them — the VoID dataset description and SPARQL Service Description that
+          advertise its capabilities.
+        </p>
+      </div>
+    );
+  }
+
+  const loading = state.kind === "loading";
+
+  return (
+    <div className="space-y-3 rounded-lg border bg-muted/30 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
+          <HeartPulse
+            className={cn(
+              "size-3.5",
+              state.kind === "loaded" &&
+                state.health.health.status === "ok" &&
+                "text-primary",
+            )}
+          />
+          Server health &amp; capabilities
+          <span className="font-normal text-muted-foreground/80">
+            — read from the connected server
+          </span>
+        </div>
+        {state.kind === "loaded" ? (
+          <LivenessBadge outcome={state.health.health} />
+        ) : null}
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={refresh}
+          disabled={blocked || loading}
+          title={
+            blocked
+              ? "Fix the endpoint URL / transport warning before reading server health"
+              : "Read the server's /health, /metrics and VoID / Service Description"
+          }
+        >
+          {loading ? (
+            <Loader2 className="size-3.5 animate-spin" />
+          ) : (
+            <RefreshCw className="size-3.5" />
+          )}
+          {state.kind === "loaded" ? "Refresh" : "Read server health"}
+        </Button>
+        <StatusLine state={state} />
+      </div>
+
+      <SafetyWarningList warnings={warnings} />
+
+      {state.kind === "error" ? (
+        <pre className="overflow-x-auto rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-[12px] text-destructive">
+          {state.message}
+        </pre>
+      ) : null}
+
+      {state.kind === "loaded" ? (
+        <div className="space-y-3" data-testid="server-health">
+          <MetricsSection outcome={state.health.metrics} />
+          <CapabilitiesSection
+            voidOutcome={state.health.voidDescriptor}
+            sdOutcome={state.health.serviceDescription}
+          />
+        </div>
+      ) : null}
+
+      <p className="text-[11px] leading-relaxed text-muted-foreground">
+        Metric values are the server&apos;s own operational counters/gauges, read at scrape
+        time — not a benchmark claim. The token is sent only in the{" "}
+        <code className="font-mono">Authorization: Bearer</code> header; the VoID dataset
+        description and Service Description are <span className="font-medium">opt-in</span> (the{" "}
+        <code className="font-mono">federation-descriptors</code> feature) and shown as{" "}
+        <span className="font-medium">not exposed</span> when the operator left them off.
+      </p>
+    </div>
+  );
+}
+
+// [OPUS-4.8] sq-he72 — the liveness pill from the /health outcome.
+function LivenessBadge({ outcome }: { outcome: FetchOutcome<{ body: string }> }) {
+  if (outcome.status === "ok") {
+    return (
+      <Badge variant="success" aria-live="polite">
+        <CircleCheck className="size-3" /> Live
+      </Badge>
+    );
+  }
+  if (outcome.status === "unauthorized") {
+    return (
+      <Badge variant="warning" aria-live="polite">
+        <ShieldAlert className="size-3" /> Auth required
+      </Badge>
+    );
+  }
+  return (
+    <Badge variant="warning" aria-live="polite">
+      <CircleSlash className="size-3" /> Unreachable
+    </Badge>
+  );
+}
+
+function StatusLine({ state }: { state: LoadState }) {
+  return (
+    <p aria-live="polite" className="text-xs text-muted-foreground">
+      {state.kind === "loading" && "Reading the server's operational surface…"}
+      {state.kind === "loaded" &&
+        state.health.health.status === "ok" &&
+        "Server responded."}
+      {state.kind === "loaded" &&
+        state.health.health.status !== "ok" &&
+        "Read complete — see the findings below."}
+      {state.kind === "error" && (
+        <span className="text-destructive">Could not read server health.</span>
+      )}
+    </p>
+  );
+}
+
+// [OPUS-4.8] sq-he72 — render the SAME classified connection-safety findings the Connect
+// panel uses (this panel rides the same transport as a query, so the same posture applies).
+function SafetyWarningList({
+  warnings,
+}: {
+  warnings: ReturnType<typeof connectionSafetyWarnings>;
+}) {
+  if (warnings.length === 0) return null;
+  return (
+    <ul className="space-y-1.5">
+      {warnings.map((w) => (
+        <li
+          key={w.code}
+          data-safety-code={w.code}
+          data-safety-level={w.level}
+          className={cn(
+            "flex items-start gap-2 rounded-md border p-2 text-[11.5px] leading-relaxed",
+            w.level === "error" &&
+              "border-destructive/30 bg-destructive/5 text-destructive",
+            w.level === "warning" &&
+              "border-[color-mix(in_oklch,var(--warning)_35%,transparent)] bg-[color-mix(in_oklch,var(--warning)_10%,transparent)] text-[color-mix(in_oklch,var(--warning)_80%,var(--foreground))]",
+            w.level === "info" && "border-border bg-muted/40 text-muted-foreground",
+          )}
+        >
+          <span>{w.message}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// [OPUS-4.8] sq-he72 — a small "not exposed / unauthorized / error" note reused by every
+// outcome-tagged section, so a disabled opt-in feature reads honestly everywhere.
+function OutcomeNote({
+  outcome,
+  notExposedLabel,
+}: {
+  outcome: { status: "not-exposed" } | { status: "unauthorized"; message: string } | { status: "error"; message: string };
+  notExposedLabel: string;
+}) {
+  if (outcome.status === "not-exposed") {
+    return (
+      <p className="flex items-start gap-2 rounded-md border bg-muted/40 p-2 text-[11.5px] leading-relaxed text-muted-foreground">
+        <CircleSlash className="mt-0.5 size-3.5 shrink-0" />
+        <span>{notExposedLabel}</span>
+      </p>
+    );
+  }
+  if (outcome.status === "unauthorized") {
+    return (
+      <p className="flex items-start gap-2 rounded-md border border-[color-mix(in_oklch,var(--warning)_35%,transparent)] bg-[color-mix(in_oklch,var(--warning)_10%,transparent)] p-2 text-[11.5px] leading-relaxed text-[color-mix(in_oklch,var(--warning)_80%,var(--foreground))]">
+        <ShieldAlert className="mt-0.5 size-3.5 shrink-0" />
+        <span>{outcome.message}</span>
+      </p>
+    );
+  }
+  return (
+    <p className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 p-2 text-[11.5px] leading-relaxed text-destructive">
+      <ShieldAlert className="mt-0.5 size-3.5 shrink-0" />
+      <span>{outcome.message}</span>
+    </p>
+  );
+}
+
+// [OPUS-4.8] sq-he72 — the Prometheus metrics section: one block per metric family, each with
+// its help text, type, and a value table over its samples (with the label set rendered
+// inline). No charting library — a formatted table is the honest, dependency-free shape.
+function MetricsSection({ outcome }: { outcome: FetchOutcome<{ families: MetricFamily[] }> }) {
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <Gauge className="size-3.5" />
+        Prometheus metrics
+        <span className="font-normal text-muted-foreground/70">
+          (<code className="font-mono">/metrics</code>)
+        </span>
+      </div>
+      {outcome.status !== "ok" ? (
+        <OutcomeNote
+          outcome={outcome}
+          notExposedLabel="This server does not expose /metrics."
+        />
+      ) : outcome.data.families.length === 0 ? (
+        <p className="rounded-md border bg-muted/40 p-2 text-[11.5px] text-muted-foreground">
+          The server returned no metric families.
+        </p>
+      ) : (
+        <ul className="space-y-2">
+          {outcome.data.families.map((f) => (
+            <MetricFamilyBlock key={f.name} family={f} />
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function MetricFamilyBlock({ family }: { family: MetricFamily }) {
+  return (
+    <li
+      data-metric-family={family.name}
+      className="rounded-md border bg-background/60 p-2.5"
+    >
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <code className="font-mono text-[12px] font-medium">{family.name}</code>
+        <Badge variant="muted" className="text-[10px]">
+          {family.type}
+        </Badge>
+      </div>
+      {family.help ? (
+        <p className="mt-0.5 text-[11px] leading-relaxed text-muted-foreground">
+          {family.help}
+        </p>
+      ) : null}
+      <table className="mt-1.5 w-full text-left text-[11.5px]">
+        <tbody>
+          {family.samples.map((s, i) => {
+            const labels = formatMetricLabels(s.labels);
+            return (
+              <tr key={i} className="border-t border-border/60">
+                <td className="py-1 pr-3 font-mono text-muted-foreground">
+                  {labels === "" ? (
+                    <span className="text-muted-foreground/60">(no labels)</span>
+                  ) : (
+                    labels
+                  )}
+                </td>
+                <td className="py-1 text-right font-mono tabular">
+                  {Number.isFinite(s.value) ? s.value : String(s.value)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </li>
+  );
+}
+
+// [OPUS-4.8] sq-he72 — the capabilities section: the VoID dataset summary + the SPARQL
+// Service Description, each shown as "not exposed" when the opt-in feature is off.
+function CapabilitiesSection({
+  voidOutcome,
+  sdOutcome,
+}: {
+  voidOutcome: FetchOutcome<VoidSummary>;
+  sdOutcome: FetchOutcome<ServiceDescriptionSummary>;
+}) {
+  return (
+    <section className="space-y-2">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+        <ServerCog className="size-3.5" />
+        Capabilities
+        <span className="font-normal text-muted-foreground/70">
+          (VoID + SPARQL Service Description — opt-in)
+        </span>
+      </div>
+
+      <div className="space-y-2 rounded-md border bg-background/60 p-2.5">
+        <div className="flex items-center gap-1.5 text-[11.5px] font-medium">
+          <Database className="size-3.5 text-muted-foreground" />
+          VoID dataset (<code className="font-mono">/.well-known/void</code>)
+        </div>
+        {voidOutcome.status !== "ok" ? (
+          <OutcomeNote
+            outcome={voidOutcome}
+            notExposedLabel="The VoID dataset description is not exposed (the federation-descriptors feature is off)."
+          />
+        ) : (
+          <VoidView summary={voidOutcome.data} />
+        )}
+      </div>
+
+      <div className="space-y-2 rounded-md border bg-background/60 p-2.5">
+        <div className="flex items-center gap-1.5 text-[11.5px] font-medium">
+          <Network className="size-3.5 text-muted-foreground" />
+          Service Description (<code className="font-mono">GET /sparql</code>, no query)
+        </div>
+        {sdOutcome.status !== "ok" ? (
+          <OutcomeNote
+            outcome={sdOutcome}
+            notExposedLabel="The SPARQL Service Description is not exposed (the federation-descriptors feature is off)."
+          />
+        ) : (
+          <ServiceDescriptionView summary={sdOutcome.data} />
+        )}
+      </div>
+    </section>
+  );
+}
+
+// [OPUS-4.8] sq-he72 — the VoID dataset counts as a small fact list. A `null` count means the
+// document did not carry it (honest "—"), never a zero we invented.
+function VoidView({ summary }: { summary: VoidSummary }) {
+  const rows: { label: string; value: number | null }[] = [
+    { label: "Triples", value: summary.triples },
+    { label: "Entities (typed subjects)", value: summary.entities },
+    { label: "Distinct subjects", value: summary.distinctSubjects },
+    { label: "Classes", value: summary.classes },
+    { label: "Properties", value: summary.properties },
+  ];
+  return (
+    <dl className="grid grid-cols-2 gap-x-4 gap-y-1 text-[11.5px] sm:grid-cols-3">
+      {rows.map((r) => (
+        <div key={r.label} className="flex flex-col">
+          <dt className="text-muted-foreground">{r.label}</dt>
+          <dd className="font-mono tabular font-medium">
+            {r.value === null ? <span className="text-muted-foreground/60">—</span> : r.value}
+          </dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+// [OPUS-4.8] sq-he72 — the Service Description capabilities. The well-known sd:/void: IRIs are
+// abbreviated for display; everything is rendered verbatim from the document (no fiction).
+function ServiceDescriptionView({ summary }: { summary: ServiceDescriptionSummary }) {
+  return (
+    <div className="space-y-2 text-[11.5px]">
+      {summary.endpoint ? (
+        <FactRow label="Endpoint">
+          <code className="font-mono">{summary.endpoint}</code>
+        </FactRow>
+      ) : null}
+      <IriListRow label="Supported languages" iris={summary.supportedLanguages} />
+      <IriListRow label="Features" iris={summary.features} />
+      <IriListRow label="Result formats" iris={summary.resultFormats} />
+      <IriListRow label="Input formats" iris={summary.inputFormats} />
+      <IriListRow label="Extension functions" iris={summary.extensionFunctions} />
+      {summary.namedGraphs.length > 0 ? (
+        <FactRow label="Named graphs">
+          <ul className="space-y-0.5">
+            {summary.namedGraphs.map((ng) => (
+              <li key={ng.name} className="flex items-baseline gap-2">
+                <Boxes className="size-3 shrink-0 text-muted-foreground" />
+                <code className="font-mono break-all">{ng.name}</code>
+                {ng.triples !== null ? (
+                  <span className="text-muted-foreground">· {ng.triples} triples</span>
+                ) : null}
+              </li>
+            ))}
+          </ul>
+        </FactRow>
+      ) : null}
+    </div>
+  );
+}
+
+function FactRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="flex flex-col gap-0.5">
+      <span className="text-muted-foreground">{label}</span>
+      <div className="font-medium">{children}</div>
+    </div>
+  );
+}
+
+// One labelled list of abbreviated IRIs, or an honest "none advertised" when the document
+// carried no values for it.
+function IriListRow({ label, iris }: { label: string; iris: string[] }) {
+  return (
+    <FactRow label={label}>
+      {iris.length === 0 ? (
+        <span className="font-normal text-muted-foreground/60">none advertised</span>
+      ) : (
+        <div className="flex flex-wrap gap-1">
+          {iris.map((iri) => (
+            <Badge key={iri} variant="muted" className="font-mono text-[10px]" title={iri}>
+              {shortenIri(iri)}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </FactRow>
+  );
+}

--- a/site/test/server-health.test.mjs
+++ b/site/test/server-health.test.mjs
@@ -1,0 +1,366 @@
+// [OPUS-4.8] sq-he72 — unit tests for the server health / capabilities client
+// (`@sparq/client` `server-health.ts`): the endpoint-URL derivation, the Prometheus
+// text-exposition parser (against the EXACT shape `crates/sparq-server/src/metrics.rs`
+// emits), the VoID + Service-Description extractors (against the EXACT N-Triples
+// `crates/sparq-introspect` `to_void` / `crates/sparq-server/src/descriptors.rs` `sd_ntriples`
+// emit), and the `fetchServerHealth` outcome classification (404 → not-exposed, 401 →
+// unauthorized, transport failure → error) over an injected `fetch`. These cover the pure,
+// framework-free logic the server-health panel renders. Run via `npm run test:unit`.
+//
+// Imported by RELATIVE path (not the `@sparq/client` alias) so the build-free ts-loader
+// resolves it without a custom alias resolver — matching `endpoint.test.mjs`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  deriveServerUrl,
+  parsePrometheusMetrics,
+  extractVoidSummary,
+  extractServiceDescription,
+  fetchServerHealth,
+  shortenIri,
+  formatMetricLabels,
+  HEALTH_PATH,
+  METRICS_PATH,
+  VOID_PATH,
+} from "../../packages/sparq-client/src/server-health.ts";
+import { parseNTriples } from "../../packages/sparq-client/src/pretty-turtle.ts";
+
+// --- deriveServerUrl --------------------------------------------------------
+
+test("deriveServerUrl rebases the path onto the endpoint origin (not under /sparql)", () => {
+  assert.equal(
+    deriveServerUrl("http://127.0.0.1:3030/sparql", METRICS_PATH),
+    "http://127.0.0.1:3030/metrics",
+  );
+  assert.equal(
+    deriveServerUrl("http://127.0.0.1:3030/sparql", HEALTH_PATH),
+    "http://127.0.0.1:3030/health",
+  );
+  assert.equal(
+    deriveServerUrl("http://127.0.0.1:3030/sparql", VOID_PATH),
+    "http://127.0.0.1:3030/.well-known/void",
+  );
+});
+
+test("deriveServerUrl preserves a non-default port + drops any query string", () => {
+  assert.equal(
+    deriveServerUrl("https://data.example.org:8443/sparql?foo=bar", METRICS_PATH),
+    "https://data.example.org:8443/metrics",
+  );
+});
+
+test("deriveServerUrl returns null for an invalid endpoint URL", () => {
+  assert.equal(deriveServerUrl("not a url", METRICS_PATH), null);
+  assert.equal(deriveServerUrl("", METRICS_PATH), null);
+  assert.equal(deriveServerUrl("ftp://host/sparql", METRICS_PATH), null);
+});
+
+// --- parsePrometheusMetrics -------------------------------------------------
+
+// The EXACT exposition `metrics.rs::render` emits (a representative snapshot).
+const METRICS_DOC = `# HELP sparq_http_requests_total Total HTTP requests by endpoint and response status.
+# TYPE sparq_http_requests_total counter
+sparq_http_requests_total{endpoint="/sparql",status="200"} 2
+sparq_http_requests_total{endpoint="/sparql",status="400"} 1
+sparq_http_requests_total{endpoint="/health",status="200"} 1
+# HELP sparq_query_duration_seconds Wall time of /sparql requests (query + update operations).
+# TYPE sparq_query_duration_seconds histogram
+sparq_query_duration_seconds_bucket{le="0.001"} 1
+sparq_query_duration_seconds_bucket{le="0.005"} 2
+sparq_query_duration_seconds_bucket{le="0.1"} 3
+sparq_query_duration_seconds_bucket{le="+Inf"} 3
+sparq_query_duration_seconds_sum 0.062
+sparq_query_duration_seconds_count 3
+# HELP sparq_active_subscriptions Currently active WebSocket subscriptions.
+# TYPE sparq_active_subscriptions gauge
+sparq_active_subscriptions 3
+# HELP sparq_graph_triples Triples in the published graph.
+# TYPE sparq_graph_triples gauge
+sparq_graph_triples 42
+# HELP sparq_updates_total Successfully applied SPARQL updates.
+# TYPE sparq_updates_total counter
+sparq_updates_total 1
+`;
+
+test("parsePrometheusMetrics parses families, types, help and labelled samples", () => {
+  const { families } = parsePrometheusMetrics(METRICS_DOC);
+  const byName = new Map(families.map((f) => [f.name, f]));
+
+  // The counter family with three labelled samples.
+  const reqs = byName.get("sparq_http_requests_total");
+  assert.ok(reqs, "request counter family present");
+  assert.equal(reqs.type, "counter");
+  assert.match(reqs.help, /Total HTTP requests/);
+  assert.equal(reqs.samples.length, 3);
+  const sparql200 = reqs.samples.find(
+    (s) =>
+      s.labels.some((l) => l.name === "endpoint" && l.value === "/sparql") &&
+      s.labels.some((l) => l.name === "status" && l.value === "200"),
+  );
+  assert.ok(sparql200, "the /sparql 200 sample is parsed");
+  assert.equal(sparql200.value, 2);
+
+  // The two gauges.
+  assert.equal(byName.get("sparq_active_subscriptions").type, "gauge");
+  assert.equal(byName.get("sparq_active_subscriptions").samples[0].value, 3);
+  assert.equal(byName.get("sparq_graph_triples").samples[0].value, 42);
+  assert.equal(byName.get("sparq_updates_total").samples[0].value, 1);
+});
+
+test("parsePrometheusMetrics groups histogram _bucket/_sum/_count under the base family", () => {
+  const { families } = parsePrometheusMetrics(METRICS_DOC);
+  const hist = families.find((f) => f.name === "sparq_query_duration_seconds");
+  assert.ok(hist, "the histogram family exists under its base name");
+  assert.equal(hist.type, "histogram");
+  // 4 buckets + _sum + _count = 6 samples, all under the one family (no stray families).
+  assert.equal(hist.samples.length, 6);
+  const inf = hist.samples.find((s) =>
+    s.labels.some((l) => l.name === "le" && l.value === "+Inf"),
+  );
+  assert.ok(inf, "+Inf bucket present");
+  assert.equal(inf.value, 3);
+  const count = hist.samples.find((s) => s.name === "sparq_query_duration_seconds_count");
+  assert.equal(count.value, 3);
+  // No spurious top-level families for the suffixed sample names.
+  assert.equal(
+    families.filter((f) => f.name.endsWith("_bucket")).length,
+    0,
+    "no family was created for a _bucket sample name",
+  );
+});
+
+test("parsePrometheusMetrics handles +Inf / -Inf / NaN values and empty input", () => {
+  const { families } = parsePrometheusMetrics(
+    "# TYPE g gauge\ng_inf +Inf\ng_ninf -Inf\ng_nan NaN\n",
+  );
+  const byName = new Map(families.map((f) => [f.name, f]));
+  assert.equal(byName.get("g_inf").samples[0].value, Number.POSITIVE_INFINITY);
+  assert.equal(byName.get("g_ninf").samples[0].value, Number.NEGATIVE_INFINITY);
+  assert.ok(Number.isNaN(byName.get("g_nan").samples[0].value));
+  assert.deepEqual(parsePrometheusMetrics("").families, []);
+  assert.deepEqual(parsePrometheusMetrics("   \n\n").families, []);
+});
+
+test("parsePrometheusMetrics is total — junk lines are ignored, not thrown on", () => {
+  assert.doesNotThrow(() =>
+    parsePrometheusMetrics("this is not metrics\n{malformed\nfoo{bar} \n"),
+  );
+});
+
+// --- extractVoidSummary -----------------------------------------------------
+
+// The EXACT N-Triples `Introspection::to_void` emits (dataset summary + a class + a
+// property partition). The dataset IRI matches the server's `{base}/.well-known/void#dataset`.
+const VOID_DOC = `<http://127.0.0.1:3030/.well-known/void#dataset> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rdfs.org/ns/void#Dataset> .
+<http://127.0.0.1:3030/.well-known/void#dataset> <http://rdfs.org/ns/void#triples> "42"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://127.0.0.1:3030/.well-known/void#dataset> <http://rdfs.org/ns/void#entities> "7"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://127.0.0.1:3030/.well-known/void#dataset> <http://rdfs.org/ns/void#distinctSubjects> "9"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://127.0.0.1:3030/.well-known/void#dataset> <http://rdfs.org/ns/void#classes> "2"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://127.0.0.1:3030/.well-known/void#dataset> <http://rdfs.org/ns/void#properties> "5"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://127.0.0.1:3030/.well-known/void#dataset> <http://rdfs.org/ns/void#classPartition> _:c0 .
+_:c0 <http://rdfs.org/ns/void#class> <http://ex/Person> .
+_:c0 <http://rdfs.org/ns/void#entities> "3"^^<http://www.w3.org/2001/XMLSchema#integer> .
+<http://127.0.0.1:3030/.well-known/void#dataset> <http://rdfs.org/ns/void#propertyPartition> _:p1 .
+_:p1 <http://rdfs.org/ns/void#property> <http://ex/age> .
+_:p1 <http://rdfs.org/ns/void#triples> "3"^^<http://www.w3.org/2001/XMLSchema#integer> .
+_:p1 <http://rdfs.org/ns/void#distinctSubjects> "3"^^<http://www.w3.org/2001/XMLSchema#integer> .
+`;
+
+test("extractVoidSummary reads the dataset-level VoID counts", () => {
+  const { statements } = parseNTriples(VOID_DOC);
+  const summary = extractVoidSummary(statements);
+  assert.equal(summary.datasetIri, "http://127.0.0.1:3030/.well-known/void#dataset");
+  assert.equal(summary.triples, 42);
+  assert.equal(summary.entities, 7);
+  assert.equal(summary.distinctSubjects, 9);
+  assert.equal(summary.classes, 2);
+  assert.equal(summary.properties, 5);
+});
+
+test("extractVoidSummary yields all-null when no void:Dataset subject is present", () => {
+  const { statements } = parseNTriples(
+    "<http://ex/s> <http://ex/p> <http://ex/o> .\n",
+  );
+  const summary = extractVoidSummary(statements);
+  assert.equal(summary.datasetIri, null);
+  assert.equal(summary.triples, null);
+  assert.equal(summary.classes, null);
+});
+
+// --- extractServiceDescription ---------------------------------------------
+
+// The EXACT N-Triples `descriptors.rs::sd_ntriples` emits (anonymous update allowed,
+// federated query on, one extension function, one named graph with a triple count).
+const SD_DOC = `<http://127.0.0.1:3030/sparql> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sparql-service-description#Service> .
+<http://127.0.0.1:3030/sparql> <http://www.w3.org/ns/sparql-service-description#endpoint> <http://127.0.0.1:3030/sparql> .
+<http://127.0.0.1:3030/sparql> <http://www.w3.org/ns/sparql-service-description#supportedLanguage> <http://www.w3.org/ns/sparql-service-description#SPARQL11Query> .
+<http://127.0.0.1:3030/sparql> <http://www.w3.org/ns/sparql-service-description#supportedLanguage> <http://www.w3.org/ns/sparql-service-description#SPARQL11Update> .
+<http://127.0.0.1:3030/sparql> <http://www.w3.org/ns/sparql-service-description#resultFormat> <http://www.w3.org/ns/formats/SPARQL_Results_JSON> .
+<http://127.0.0.1:3030/sparql> <http://www.w3.org/ns/sparql-service-description#inputFormat> <http://www.w3.org/ns/formats/Turtle> .
+<http://127.0.0.1:3030/sparql> <http://www.w3.org/ns/sparql-service-description#feature> <http://www.w3.org/ns/sparql-service-description#BasicFederatedQuery> .
+<http://127.0.0.1:3030/sparql> <http://www.w3.org/ns/sparql-service-description#extensionFunction> <http://www.opengis.net/def/function/geosparql/distance> .
+<http://127.0.0.1:3030/sparql> <http://www.w3.org/ns/sparql-service-description#defaultDataset> _:dataset .
+_:dataset <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sparql-service-description#Dataset> .
+_:dataset <http://www.w3.org/ns/sparql-service-description#defaultGraph> _:defaultGraph .
+_:defaultGraph <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sparql-service-description#Graph> .
+_:defaultGraph <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://rdfs.org/ns/void#Dataset> .
+<http://127.0.0.1:3030/sparql> <http://purl.org/dc/terms/source> <http://127.0.0.1:3030/.well-known/void#dataset> .
+_:dataset <http://www.w3.org/ns/sparql-service-description#namedGraph> _:ng0 .
+_:ng0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sparql-service-description#NamedGraph> .
+_:ng0 <http://www.w3.org/ns/sparql-service-description#name> <http://ex/graph1> .
+_:ng0 <http://www.w3.org/ns/sparql-service-description#graph> _:ngG0 .
+_:ngG0 <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/sparql-service-description#Graph> .
+_:ngG0 <http://rdfs.org/ns/void#triples> "11"^^<http://www.w3.org/2001/XMLSchema#integer> .
+`;
+
+test("extractServiceDescription reads the service capabilities + named graphs", () => {
+  const { statements } = parseNTriples(SD_DOC);
+  const sd = extractServiceDescription(statements);
+  assert.equal(sd.serviceIri, "http://127.0.0.1:3030/sparql");
+  assert.equal(sd.endpoint, "http://127.0.0.1:3030/sparql");
+  assert.deepEqual(sd.supportedLanguages, [
+    "http://www.w3.org/ns/sparql-service-description#SPARQL11Query",
+    "http://www.w3.org/ns/sparql-service-description#SPARQL11Update",
+  ]);
+  assert.deepEqual(sd.features, [
+    "http://www.w3.org/ns/sparql-service-description#BasicFederatedQuery",
+  ]);
+  assert.deepEqual(sd.resultFormats, [
+    "http://www.w3.org/ns/formats/SPARQL_Results_JSON",
+  ]);
+  assert.deepEqual(sd.inputFormats, ["http://www.w3.org/ns/formats/Turtle"]);
+  assert.deepEqual(sd.extensionFunctions, [
+    "http://www.opengis.net/def/function/geosparql/distance",
+  ]);
+  // The named graph followed through the defaultDataset → namedGraph → name/graph chain.
+  assert.equal(sd.namedGraphs.length, 1);
+  assert.equal(sd.namedGraphs[0].name, "http://ex/graph1");
+  assert.equal(sd.namedGraphs[0].triples, 11);
+});
+
+test("extractServiceDescription yields empty when no sd:Service subject is present", () => {
+  const { statements } = parseNTriples(
+    "<http://ex/s> <http://ex/p> <http://ex/o> .\n",
+  );
+  const sd = extractServiceDescription(statements);
+  assert.equal(sd.serviceIri, null);
+  assert.equal(sd.endpoint, null);
+  assert.deepEqual(sd.supportedLanguages, []);
+  assert.deepEqual(sd.namedGraphs, []);
+});
+
+// --- shortenIri / formatMetricLabels ---------------------------------------
+
+test("shortenIri abbreviates the well-known sd: / void: namespaces", () => {
+  assert.equal(
+    shortenIri("http://www.w3.org/ns/sparql-service-description#SPARQL11Query"),
+    "sd:SPARQL11Query",
+  );
+  assert.equal(shortenIri("http://rdfs.org/ns/void#triples"), "void:triples");
+  assert.equal(shortenIri("http://ex/other"), "http://ex/other");
+});
+
+test("formatMetricLabels renders a compact label block (empty for no labels)", () => {
+  assert.equal(formatMetricLabels([]), "");
+  assert.equal(
+    formatMetricLabels([
+      { name: "endpoint", value: "/sparql" },
+      { name: "status", value: "200" },
+    ]),
+    '{endpoint="/sparql",status="200"}',
+  );
+});
+
+// --- fetchServerHealth (outcome classification over an injected fetch) ------
+
+/** A fetch stub keyed by the requested URL's path; missing path → a transport rejection. */
+function stubFetch(responsesByPath) {
+  return async (url) => {
+    const path = new URL(url).pathname;
+    const r = responsesByPath[path];
+    if (!r) throw new TypeError("Failed to fetch");
+    return {
+      ok: r.status >= 200 && r.status < 300,
+      status: r.status,
+      text: async () => r.body ?? "",
+    };
+  };
+}
+
+test("fetchServerHealth classifies ok / not-exposed / unauthorized / error per endpoint", async () => {
+  const fetchImpl = stubFetch({
+    "/health": { status: 200, body: "ok" },
+    "/metrics": { status: 200, body: METRICS_DOC },
+    // The opt-in descriptor endpoints are OFF → the server answers 404.
+    "/.well-known/void": { status: 404, body: "not found" },
+    // The Service Description is served on /sparql (no query); here it is gated by a read token.
+    "/sparql": { status: 401, body: '{"error":"unauthorized"}' },
+  });
+  const health = await fetchServerHealth(
+    { url: "http://127.0.0.1:3030/sparql", token: "" },
+    fetchImpl,
+  );
+  assert.equal(health.health.status, "ok");
+  assert.equal(health.health.data.body, "ok");
+  assert.equal(health.metrics.status, "ok");
+  assert.equal(health.metrics.data.families.length > 0, true);
+  assert.equal(health.voidDescriptor.status, "not-exposed");
+  assert.equal(health.serviceDescription.status, "unauthorized");
+});
+
+test("fetchServerHealth treats the SD's 400 'missing query' fall-through as not-exposed", async () => {
+  // With the federation-descriptors feature OFF, GET /sparql (no query) returns the historical
+  // 400, NOT a 404 — the SD read must still report that honestly as "not exposed".
+  const fetchImpl = stubFetch({
+    "/health": { status: 200, body: "ok" },
+    "/metrics": { status: 200, body: METRICS_DOC },
+    "/.well-known/void": { status: 404, body: "not found" },
+    "/sparql": { status: 400, body: '{"error":"missing \'query\' parameter"}' },
+  });
+  const health = await fetchServerHealth(
+    { url: "http://127.0.0.1:3030/sparql" },
+    fetchImpl,
+  );
+  assert.equal(health.serviceDescription.status, "not-exposed");
+  // The VoID 404 stays not-exposed; metrics (no 400 mapping) would still be an error on a 400,
+  // but here it is ok.
+  assert.equal(health.voidDescriptor.status, "not-exposed");
+  assert.equal(health.metrics.status, "ok");
+});
+
+test("fetchServerHealth folds a transport failure into an error outcome (never throws)", async () => {
+  // Every path rejects (server unreachable / CORS block).
+  const fetchImpl = stubFetch({});
+  const health = await fetchServerHealth(
+    { url: "http://127.0.0.1:3030/sparql" },
+    fetchImpl,
+  );
+  assert.equal(health.health.status, "error");
+  assert.match(health.health.message, /Could not reach the server/);
+  assert.equal(health.metrics.status, "error");
+});
+
+test("fetchServerHealth throws only for an invalid endpoint URL", async () => {
+  await assert.rejects(
+    () => fetchServerHealth({ url: "not a url" }, stubFetch({})),
+    /valid absolute endpoint URL/,
+  );
+});
+
+test("fetchServerHealth extracts the VoID + SD summaries when both are exposed", async () => {
+  const fetchImpl = stubFetch({
+    "/health": { status: 200, body: "ok" },
+    "/metrics": { status: 200, body: METRICS_DOC },
+    "/.well-known/void": { status: 200, body: VOID_DOC },
+    "/sparql": { status: 200, body: SD_DOC },
+  });
+  const health = await fetchServerHealth(
+    { url: "http://127.0.0.1:3030/sparql" },
+    fetchImpl,
+  );
+  assert.equal(health.voidDescriptor.status, "ok");
+  assert.equal(health.voidDescriptor.data.triples, 42);
+  assert.equal(health.serviceDescription.status, "ok");
+  assert.equal(health.serviceDescription.data.namedGraphs[0].name, "http://ex/graph1");
+});


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements bead **sq-he72** — GUI Phase 2 item 8 (`research/gui-design.md` §2): a **server health / capabilities panel** that, in endpoint mode, reads the connected `sparq-server`'s operational surface and renders it honestly. Depends on the landed endpoint-mode work (sq-2mke, #795) and reuses its connection / bearer-auth state verbatim.

## What it does

When endpoint mode is active, a new panel reads the connected server and renders:

1. **Prometheus `/metrics`** — parsed from the server's hand-rolled text exposition (`crates/sparq-server/src/metrics.rs`) into metric families (HELP / TYPE / labelled samples; histogram `_bucket`/`_sum`/`_count` grouped under their base family), rendered as a **formatted per-family table** — no charting library, **no new npm dependency**.
2. **VoID** (`/.well-known/void`) + **SPARQL Service Description** (`GET /sparql`, no query) — the opt-in `federation-descriptors` surface — reshaped into a readable capabilities view (dataset counts; endpoint, supported languages, features, result/input formats, registered extension functions, named graphs).
3. **`/health`** liveness.

**Honest "not exposed" handling**: a disabled opt-in feature answers `404` (or, for the SD served on `GET /sparql` with the feature off, the historical `400 missing 'query'` fall-through) — surfaced as a first-class `not-exposed` outcome and rendered **"not exposed by this server"**, never a fabricated metric or capability. Metric values are labelled the server's **own operational counters/gauges, not a benchmark claim** (this work box is non-canonical). The bearer token is sent only in the `Authorization: Bearer` header; the panel reuses the same `connectionSafetyWarnings` classifier and **bypasses no server gate**.

## Files / routes

- **NEW** `packages/sparq-client/src/server-health.ts` — framework-agnostic, dependency-free, DOM-free: `fetchServerHealth` (concurrent reads off the endpoint origin via `deriveServerUrl`), `parsePrometheusMetrics`, `extractVoidSummary` / `extractServiceDescription` (over the existing `parseNTriples`), `FetchOutcome` discriminated union, display helpers. Shared by the site **and** the proposed Tauri GUI webview.
- `packages/sparq-client/src/index.ts` + `README.md` — export + document the module.
- **NEW** `site/src/components/server-health-panel.tsx` — React host, following the `SubscriptionsView` pattern (config + active props, honest "switch on endpoint mode" hint, Refresh lifecycle, metric tables + capabilities lists).
- `site/src/components/repl.tsx` — wires the panel into the REPL (route `/try`) after the live-subscriptions view.
- **NEW** `site/test/server-health.test.mjs` — 17 unit tests over URL derivation, the metrics parser (against the exact `metrics.rs` shape), the VoID/SD extractors (against the exact `to_void` / `sd_ntriples` N-Triples), and the fetch outcome classification.

## Gate results

- WASM prereq: `cd js && npm run build:wasm` (artifact only — no `crates/` changes) → exit 0 (bundle ~2.59 MB).
- `cd site && npm run build` static export → **exit 0**; all 46 routes generated, `basePath` `/sparq` intact (verified on `out/try/index.html` asset prefixes + `out/wasm/sparq_wasm_bg.wasm`).
- `npm run lint` → clean.
- `npx tsc --noEmit` → clean (site + `@sparq/client` + `js`).
- `npm run check:wasm-types` → clean (generated d.ts byte-identical to a fresh build).
- `npm run test:unit` → **233/233 pass** (17 new).
- `scripts/check-privacy-claims.sh` → clean; `typos` on the README → clean; no ZK/MPC copy added.

## Caveats / deferred

- No new dependency added (metrics rendered as a table, per the brief).
- No `crates/sparq-wasm` or `packages/sparq-client/src/generated` changes (another agent owns the wasm regen); no root `package-lock.json` edits beyond the existing install.
- The per-class / per-predicate VoID partitions are intentionally **not** surfaced in the panel (dataset summary only) — captured as a possible follow-up if the maintainer wants them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)