### PR TITLE
feat(site): basePath-aware coi-serviceworker self-registration fallback for Tauri webview (sq-9zjy) [OPUS-4.8]

### DIFF
--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -41,15 +41,36 @@ export default function RootLayout({
   return (
     <html lang="en" suppressHydrationWarning>
       <head>
+        {/* [OPUS-4.8] sq-9zjy — basePath the vendored SW's self-registration fallback.
+            coi-serviceworker.js falls back to `window.coiServiceWorkerPath` (else its
+            hardcoded literal `/sparq/coi-serviceworker.js`) when `document.currentScript`
+            is null — which can happen in the Tauri webview, where that `/sparq/…` literal
+            404s. Seed the hook from the same env-derived basePath the external <Script>
+            below uses, BEFORE that script runs, so the last-resort path is correct under
+            both Pages (`/sparq/…`) and the Tauri root-relative build (`/coi-serviceworker.js`).
+            This sets ONLY which URL the SW registers from — it never touches what coi
+            synthesises (COOP/COEP → SharedArrayBuffer for the prover's worker threads,
+            a thread-count optimisation), and NEVER any ZK soundness/property. Editing the
+            vendored file is avoided by design; this is the hook it already reads. */}
+        <Script
+          id="coi-serviceworker-path"
+          strategy="beforeInteractive"
+          dangerouslySetInnerHTML={{
+            __html: `window.coiServiceWorkerPath=${JSON.stringify(
+              withBasePath("/coi-serviceworker.js"),
+            )};`,
+          }}
+        />
         {/* [OPUS-4.8] coi-serviceworker shim — synthesises COOP/COEP so
             `window.crossOriginIsolated` becomes true on GitHub Pages (which cannot
             set those headers itself). That unlocks SharedArrayBuffer, so @aztec/bb.js
-            can spin worker threads and the in-tab ZK prover multithreads. Loaded
-            beforeInteractive with an absolute, basePath-prefixed src so the service
-            worker registers from `${basePath}/coi-serviceworker.js` with that scope.
-            [OPUS-4.8] sq-9vw5 — basePath-switched (was hardcoded `/sparq/…`) so it
-            resolves under both Pages and the Tauri root-relative build. It changes only
-            thread count — never what any proof proves or its ZK property. */}
+            can spin worker threads and the in-tab ZK prover multithreads. The native
+            Tauri webview sets those headers natively; this shim is Pages-specific.
+            Loaded beforeInteractive with an absolute, basePath-prefixed src so the
+            service worker registers from `${basePath}/coi-serviceworker.js` with that
+            scope. [OPUS-4.8] sq-9vw5 — basePath-switched (was hardcoded `/sparq/…`) so
+            it resolves under both Pages and the Tauri root-relative build. It changes
+            only thread count — never what any proof proves or its ZK property. */}
         <Script
           src={withBasePath("/coi-serviceworker.js")}
           strategy="beforeInteractive"


### PR DESCRIPTION
> 🤖 I am a SPARQ agent. This PR was authored by an automated agent (Opus 4.8, 1M context) working bead **sq-9zjy** in the site lane. @jeswr runs multiple agents on one account.

## What & why

Make the vendored `coi-serviceworker.js` **self-registration fallback** basePath-aware for the Tauri webview **without editing the vendored file**.

The vendored `site/public/coi-serviceworker.js` registers from `document.currentScript.src`, but falls back to `window.coiServiceWorkerPath` — else its hardcoded literal `/sparq/coi-serviceworker.js` (~L153) — when `currentScript` is `null`. That can happen in the Tauri webview, where the `/sparq/…` literal 404s.

This PR adds an inline `beforeInteractive` `<script>` in `site/src/app/layout.tsx`, rendered **before** the existing COOP/COEP `<Script src=…>`, that seeds:

```js
window.coiServiceWorkerPath = withBasePath('/coi-serviceworker.js');
```

from the same env-derived basePath helper (`site/src/lib/base-path.ts`, dep **sq-9vw5** ✓) the external `<Script>` already uses — matching how the favicon/PDF asset refs are env-switched off `NEXT_PUBLIC_BASE_PATH`. So the last-resort path is correct under both Pages (`/sparq/…`) and the Tauri root-relative export (`/coi-serviceworker.js`), using only the hook the vendored SW already reads. The vendored file is **not** touched.

## Honesty

`coi-serviceworker` only synthesises COOP/COEP to unlock `SharedArrayBuffer` for the in-tab ZK prover's worker threads — a **thread-count optimisation, NEVER a ZK soundness/property change**. It is **Pages-specific**: the native Tauri webview sets those headers natively. The code comments state this explicitly.

## Files / routes

- `site/src/app/layout.tsx` — inline path-setter added before the SW `<Script>`; the existing SW comment refreshed (Pages-specific note). No route changes; all existing routes (`/`, `/benchmarks/*`, `/papers`, `/try`, `/surface/*`, `/showcase/*`) re-emit unchanged.

No new npm dependency. No changes to root `package-lock.json`, `crates/`, `packages/sparq-client/src/generated`, or `js/`.

## Gates (all green)

- **WASM prereq:** built first via `cd js && npm run build:wasm` (build artifact only; no `crates/` source change). The `wasm-opt` post-step hits a pre-existing wasm-pack Cargo-metadata parse quirk *after* the artifact is produced+copied; the `.wasm`/`.js`/`.d.ts` were verified present and identical to `crates/sparq-wasm/pkg/` (so `sync-wasm.mjs` is satisfied).
- **`cd site && npm run build` → exit 0** in default `/sparq` mode.
- **`npm run build:tauri` (`NEXT_PUBLIC_BASE_PATH=''`) → exit 0** in root-relative mode.
- **Path-emission verified in BOTH modes** from `out/index.html`:
  - `/sparq` mode → `window.coiServiceWorkerPath="/sparq/coi-serviceworker.js"`; external SW push `/sparq/coi-serviceworker.js`; preload `/sparq/coi-serviceworker.js`.
  - root mode → `window.coiServiceWorkerPath="/coi-serviceworker.js"`; external SW push `/coi-serviceworker.js`; no `/sparq` prefix anywhere; preload `/coi-serviceworker.js`.
  - **Ordering** confirmed in both: the inline `__next_s` push (`id":"coi-serviceworker-path"`) precedes the external SW `__next_s` push, so `coiServiceWorkerPath` is set before the vendored SW external script runs.
- **`npm run lint`** → `✔ No ESLint warnings or errors`.
- **`npx tsc --noEmit`** → clean (exit 0).
- Root `npm ci` (not member-dir) → exit 0.

## Validation caveat (honest)

Full **webview** validation needs the GUI CI matrix (**sq-var9**, currently blocked). This PR is validated via **static-export build + emitted-path inspection** in both basePath modes — **not** a live Tauri webview run. Path emission and script ordering are confirmed; the actual `currentScript === null → fallback` branch firing under the Tauri runtime is not exercised here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)