### PR TITLE
fix(ci/sbom): harden derive-workspace-member-lock against link:true workspace deps (sq-f04e) [OPUS-4.8]

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -351,6 +351,21 @@ jobs:
       # trusted. (Measured numbers are runtime-only / NON-CANONICAL by design.)
       - name: Self-test agent-telemetry harness (parser + cache-ratio + cost math)
         run: python3 scripts/agent-telemetry/tests/test_agent_telemetry.py
+      # [OPUS-4.8] sq-f04e: gen-js-sbom.sh DERIVES a standalone per-member lock via
+      # scripts/derive-workspace-member-lock.mjs, then cyclonedx-npm shells out to `npm ls
+      # --omit=dev`. A workspace-to-workspace dep edge (a `link: true` node — a published member
+      # depending on a sibling @sparq/* in packages/*) USED TO derive a dangling link stub that
+      # crashed npm ls with "Cannot read properties of undefined (reading 'extraneous')" -> exit
+      # 254 (the cryptic SBOM-lane failure discovered in #876/sq-jpki.2). The fix materializes the
+      # link target + its nested closure. This hermetic self-test (synthetic root lock, no network,
+      # node+npm only) pins the TEETH: a member with a workspace-link dev dep derives a lock on
+      # which BOTH `npm ls --omit=dev` and the full `npm ls` exit 0, while the runtime (--omit=dev)
+      # closure stays exactly the real runtime dep set (no dev-link leak into the published SBOM
+      # surface). HARD job (no "advisory" token) — a regression reds the ci-summary gate.
+      - name: shellcheck gen-js-sbom.sh + the derive-lock self-test
+        run: shellcheck scripts/gen-js-sbom.sh scripts/tests/test_derive_workspace_member_lock.sh
+      - name: "Self-test derive-workspace-member-lock.mjs (workspace-link materialization — sq-f04e)"
+        run: bash scripts/tests/test_derive_workspace_member_lock.sh
 
   # ----------------------------- ADVISORY -----------------------------
   markdownlint-advisory:

--- a/scripts/derive-workspace-member-lock.mjs
+++ b/scripts/derive-workspace-member-lock.mjs
@@ -23,6 +23,15 @@
 // looks there and re-homes it to top-level in the standalone lock; an UNRESOLVED dep is a
 // hard error (so a future hoisting change fails LOUDLY rather than silently dropping a
 // component from the SBOM).
+//
+// [OPUS-4.8] sq-f04e: a workspace-to-workspace dep edge (a `link: true` node, e.g. a member
+// depending on a sibling `@sparq/client` in `packages/*`) is handled by MATERIALIZING the link
+// target's real package node AND its own nested closure into the standalone lock (see
+// `materializeLinkTarget`). Previously such a dep was re-homed VERBATIM as a dangling link stub,
+// which made `npm ls` (and thus cyclonedx-npm, incl. its runtime `--omit=dev` view) crash with the
+// cryptic "Cannot read properties of undefined (reading 'extraneous')" -> exit 254. Since a
+// workspace link is a dev-graph edge, this materialization changes the FULL (dev) tree but never
+// the RUNTIME (`--omit=dev`) set when the link is a devDependency of the member.
 import fs from "node:fs";
 import path from "node:path";
 
@@ -67,6 +76,28 @@ const resolveKey = (name) => {
   return null;
 };
 
+// [OPUS-4.8] sq-f04e: resolve <name> as REQUIRED BY the package living at lock-key `fromKey`,
+// mirroring npm's nearest-ancestor `node_modules` walk: try `<fromKey>/node_modules/<name>`,
+// then peel one trailing `node_modules/<seg>` segment and retry, down to top-level. Used to
+// reconstruct a LINK TARGET's own (possibly version-conflicting, hence NESTED) closure at the
+// exact keys npm pins it under in the root lock — so the materialized node stays valid and the
+// target's `typescript@5.9.3` does NOT collide with a top-level `typescript@6`.
+const resolveFrom = (fromKey, name) => {
+  let base = fromKey;
+  for (;;) {
+    const k = `${base ? `${base}/` : ""}node_modules/${name}`;
+    if (root.packages[k]) return { key: k, node: root.packages[k] };
+    if (base === "") break;
+    const i = base.lastIndexOf("/node_modules/");
+    if (i < 0) {
+      base = ""; // a member-root key like "packages/x" — next probe is top-level.
+      continue;
+    }
+    base = base.slice(0, i);
+  }
+  return null;
+};
+
 const out = {
   name: memberPkg.name,
   version: memberPkg.version,
@@ -77,9 +108,57 @@ const out = {
 // The standalone lock's root ("") IS the member — this anchors cyclonedx's root component.
 out.packages[""] = { ...memberPkg };
 
+let unresolved = 0;
+
+// [OPUS-4.8] sq-f04e: materialize the FULL subtree of a workspace-link TARGET into the standalone
+// lock at the keys the root lock uses (link node at `node_modules/<name>` PLUS the real package
+// node at its `resolved` path PLUS the target's own nested closure). WHY: the derive script used
+// to re-home a `link: true` dep VERBATIM (just the link stub) and drop its target, leaving an
+// UNRESOLVED link node; `npm ls` (which cyclonedx-npm shells out to, incl. the runtime `--omit=dev`
+// view) then crashed on the dangling node with "Cannot read properties of undefined (reading
+// 'extraneous')" -> exit 254 — the cryptic failure that ANY future workspace-to-workspace dep edge
+// on a published member (js/ or packages/*) would re-trip (sq-f04e; discovered #876/sq-jpki.2).
+// Reconstructing the target node + its closure makes `npm ls` resolve the link cleanly in BOTH the
+// runtime and full views. A workspace link is a DEV-graph/in-repo edge, so this changes the FULL
+// (dev) tree but NEVER the runtime (`--omit=dev`) set when the link is a devDependency.
+const materializeLinkTarget = (linkNode, seenKeys) => {
+  const tgtKey = linkNode.resolved;
+  const tgt = root.packages[tgtKey];
+  if (!tgt) {
+    console.error(`ERROR: workspace-link target "${tgtKey}" is not present in the root lock`);
+    unresolved++;
+    return;
+  }
+  if (seenKeys.has(tgtKey)) return;
+  seenKeys.add(tgtKey);
+  out.packages[tgtKey] = tgt;
+  // BFS the target's own closure, resolving each edge FROM the target's directory (so a nested,
+  // version-conflicting dep keeps its nested key and does not collide with a hoisted top-level one).
+  const q = declared(tgt).map((n) => ({ from: tgtKey, name: n }));
+  while (q.length) {
+    const { from, name } = q.shift();
+    const r = resolveFrom(from, name);
+    if (!r) {
+      console.error(`ERROR: dependency "${name}" of workspace-link target "${tgtKey}" is not present in the root lock`);
+      unresolved++;
+      continue;
+    }
+    if (seenKeys.has(r.key)) continue;
+    seenKeys.add(r.key);
+    out.packages[r.key] = r.node;
+    if (r.node.link === true && r.node.resolved) {
+      materializeLinkTarget(r.node, seenKeys); // chained workspace link.
+    } else {
+      for (const d of declared(r.node)) q.push({ from: r.key, name: d });
+    }
+  }
+};
+
+// Member closure: re-home each resolved dep to a flat top-level `node_modules/<name>` key (hoisted),
+// exactly as before. A `link: true` dep additionally pulls in its target subtree (above).
 const queue = declared(memberPkg).map((n) => n);
 const seen = new Set();
-let unresolved = 0;
+const seenKeys = new Set();
 while (queue.length) {
   const name = queue.shift();
   if (seen.has(name)) continue;
@@ -91,8 +170,17 @@ while (queue.length) {
     continue;
   }
   // Re-home to a top-level node_modules/<name> key in the standalone lock (flat, hoisted).
-  out.packages[`node_modules/${name}`] = r.node;
-  for (const d of declared(r.node)) queue.push(d);
+  const memberLinkKey = `node_modules/${name}`;
+  out.packages[memberLinkKey] = r.node;
+  seenKeys.add(memberLinkKey);
+  if (r.node.link === true && r.node.resolved) {
+    // [OPUS-4.8] sq-f04e: a workspace-link dep — emit its real target node + closure so npm ls
+    // resolves it instead of crashing on a dangling link (sq-f04e). Do NOT recurse into the link
+    // node's (empty) own deps; the target carries the real dependency edges.
+    materializeLinkTarget(r.node, seenKeys);
+  } else {
+    for (const d of declared(r.node)) queue.push(d);
+  }
 }
 if (unresolved > 0) {
   console.error(`ERROR: ${unresolved} dependency(ies) could not be resolved from the root lock`);

--- a/scripts/tests/test_derive_workspace_member_lock.sh
+++ b/scripts/tests/test_derive_workspace_member_lock.sh
@@ -1,0 +1,187 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] sq-f04e — hermetic regression self-test for
+# scripts/derive-workspace-member-lock.mjs, specifically its WORKSPACE-LINK (`link: true`)
+# handling. Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# WHY: gen-js-sbom.sh DERIVES a standalone per-member lock out of the repo-root
+# package-lock.json, then runs cyclonedx-npm, which shells out to
+# `npm ls --json --long --all --package-lock-only --omit=dev --workspaces=false`. The derive
+# script USED TO re-home a workspace-to-workspace dep edge (a `link: true` node — e.g. a
+# published member depending on a sibling `@sparq/*` in packages/*) into the standalone lock
+# VERBATIM, as a dangling link stub whose target package node was absent. `npm ls` then crashed
+# on the unresolved link with "Cannot read properties of undefined (reading 'extraneous')" ->
+# exit 254 — the cryptic SBOM-lane failure discovered in #876/sq-jpki.2. ANY future
+# workspace-to-workspace dep edge on a published member would re-trip it. The fix (sq-f04e)
+# MATERIALIZES the link target's real package node + its nested closure so npm ls resolves it.
+#
+# This pins TWO load-bearing behaviours over a tiny SYNTHETIC root lock (no real repo content):
+#   1. TEETH (the regression itself) — a member with a `link: true` workspace devDep must derive
+#      a lock on which BOTH `npm ls --omit=dev` (runtime view) AND `npm ls` (full/dev view) exit
+#      0. (Before the fix, --omit=dev exited 254 with the 'extraneous' crash.) The derived lock
+#      must materialize the link TARGET node + its nested, version-conflicting closure.
+#   2. RUNTIME INVARIANCE — the runtime (`--omit=dev`) closure must contain ONLY the member's real
+#      runtime dep (here `fzstd`), NOT the dev-only workspace link, so the published SBOM's
+#      runtime surface is unchanged by the presence of a workspace-link DEV edge.
+#
+# HERMETIC: builds its own throwaway root package-lock.json under a mktemp dir; no repo content,
+# no network (`--package-lock-only`). Requires `node` + `npm` (the ci-scripts runner ships both;
+# the SBOM lane already depends on them). If either is absent we SKIP with a clear message rather
+# than fail, so the harness never reds a contributor box that simply lacks the toolchain.
+#
+# Run:  bash scripts/tests/test_derive_workspace_member_lock.sh   (exit 0 = pass, 1 = a case failed)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DERIVE="${ROOT}/scripts/derive-workspace-member-lock.mjs"
+
+[ -f "$DERIVE" ] || { echo "FATAL: derive script not found at ${DERIVE}"; exit 2; }
+
+if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+  echo "SKIP: 'node' and/or 'npm' not on PATH — both are needed to run this self-test."
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --------------------------------------------------------------------------- #
+# Synthetic repo-root lock (lockfileVersion 3) mirroring the real npm-workspaces shape:
+#   * member "mbr"   — the "published" member (stands in for js/), runtime dep `fzstd`,
+#                      dev deps `typescript` + a WORKSPACE LINK to sibling "pkgs/cli".
+#   * "pkgs/cli"      — the link TARGET (stands in for packages/sparq-client), with its OWN
+#                      dev dep `typescript` at a CONFLICTING version, pinned NESTED in the lock
+#                      (so the materializer must preserve the nested key, not collide top-level).
+# The derive script is invoked exactly as gen-js-sbom.sh invokes it: <member-dir> <out-lock>.
+# NOTE: derive-workspace-member-lock.mjs resolves the root lock RELATIVE TO ITS OWN LOCATION
+# (scripts/../package-lock.json), so the synthetic lock is written to the REPO ROOT under a
+# unique temp name is NOT possible; instead we copy the script into the temp project so its
+# `..` points at the synthetic root. This keeps the test fully hermetic.
+# --------------------------------------------------------------------------- #
+PROJ="${TMP}/proj"
+mkdir -p "${PROJ}/scripts" "${PROJ}/mbr" "${PROJ}/pkgs/cli"
+cp "$DERIVE" "${PROJ}/scripts/derive-workspace-member-lock.mjs"
+
+cat > "${PROJ}/package-lock.json" <<'JSON'
+{
+  "name": "synthetic-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": { "name": "synthetic-monorepo", "workspaces": ["mbr", "pkgs/*"] },
+    "mbr": {
+      "name": "@synthetic/mbr",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": { "fzstd": "^0.1.1" },
+      "devDependencies": { "typescript": "^6.0.0", "@synthetic/cli": "*" }
+    },
+    "pkgs/cli": {
+      "name": "@synthetic/cli",
+      "version": "0.2.0",
+      "license": "MIT",
+      "devDependencies": { "typescript": "^5.7.0" }
+    },
+    "node_modules/@synthetic/cli": { "resolved": "pkgs/cli", "link": true },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB=="
+    },
+    "pkgs/cli/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC=="
+    }
+  }
+}
+JSON
+
+# Minimal member manifest so `npm ls` has a manifest co-located with the derived lock.
+cat > "${PROJ}/mbr/package.json" <<'JSON'
+{
+  "name": "@synthetic/mbr",
+  "version": "0.1.0",
+  "dependencies": { "fzstd": "^0.1.1" },
+  "devDependencies": { "typescript": "^6.0.0", "@synthetic/cli": "*" }
+}
+JSON
+
+OUT_LOCK="${PROJ}/mbr/package-lock.json"
+if ! node "${PROJ}/scripts/derive-workspace-member-lock.mjs" mbr "$OUT_LOCK" >/tmp/derive-link.log 2>&1; then
+  echo "FAIL: derive script exited non-zero on a member with a workspace-link dev dep:"
+  sed 's/^/    /' /tmp/derive-link.log
+  exit 1
+fi
+
+# --------------------------------------------------------------------------- #
+# Case 1 (TEETH): the link TARGET node + its nested closure must be materialized
+# (not left as a dangling `link: true` stub).
+# --------------------------------------------------------------------------- #
+node - "$OUT_LOCK" <<'NODE'
+const fs = require("fs");
+const lock = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const p = lock.packages;
+const fail = (m) => { console.error("FAIL: " + m); process.exit(1); };
+if (!p["node_modules/@synthetic/cli"] || p["node_modules/@synthetic/cli"].link !== true) {
+  fail("expected the workspace-link stub node_modules/@synthetic/cli (link:true) in the derived lock");
+}
+if (!p["pkgs/cli"] || p["pkgs/cli"].name !== "@synthetic/cli") {
+  fail("workspace-link TARGET pkgs/cli was NOT materialized as a real package node (the sq-f04e regression)");
+}
+if (!p["pkgs/cli/node_modules/typescript"] || p["pkgs/cli/node_modules/typescript"].version !== "5.9.3") {
+  fail("the link target's NESTED, version-conflicting dep (typescript@5.9.3) was not preserved under its nested key");
+}
+if (!p["node_modules/typescript"] || p["node_modules/typescript"].version !== "6.0.3") {
+  fail("the member's own top-level typescript@6.0.3 must remain hoisted, distinct from the target's nested 5.9.3");
+}
+console.log("PASS: workspace-link target + nested closure materialized in the derived lock");
+NODE
+
+# --------------------------------------------------------------------------- #
+# Case 2 (TEETH): `npm ls --omit=dev` (the RUNTIME view cyclonedx-npm runs) must exit 0 —
+# this is the exact command that crashed with exit 254 before the fix.
+# --------------------------------------------------------------------------- #
+if ( cd "${PROJ}/mbr" && npm ls --json --long --all --package-lock-only --omit=dev --workspaces=false ) \
+     >/tmp/npmls-omitdev.json 2>/tmp/npmls-omitdev.err; then
+  echo "PASS: npm ls --omit=dev exits 0 on a derived lock with a workspace link (no 'extraneous' crash)"
+else
+  echo "FAIL: npm ls --omit=dev crashed on the derived lock (the sq-f04e regression — exit 254):"
+  sed 's/^/    /' /tmp/npmls-omitdev.err
+  exit 1
+fi
+
+# --------------------------------------------------------------------------- #
+# Case 3 (TEETH): the FULL (dev) view npm ls must ALSO exit 0 — the materialized nested
+# closure must not introduce an ELSPROBLEMS version-conflict.
+# --------------------------------------------------------------------------- #
+if ( cd "${PROJ}/mbr" && npm ls --json --long --all --package-lock-only --workspaces=false ) \
+     >/tmp/npmls-full.json 2>/tmp/npmls-full.err; then
+  echo "PASS: npm ls (full/dev view) exits 0 on the derived lock"
+else
+  echo "FAIL: npm ls (full/dev view) errored on the derived lock:"
+  sed 's/^/    /' /tmp/npmls-full.err
+  exit 1
+fi
+
+# --------------------------------------------------------------------------- #
+# Case 4 (RUNTIME INVARIANCE): the runtime (`--omit=dev`) closure must contain the member's
+# real runtime dep `fzstd` and MUST NOT contain the dev-only workspace link or its dev-only
+# `typescript` — i.e. a workspace-link DEV edge never leaks into the published runtime surface.
+# --------------------------------------------------------------------------- #
+node - /tmp/npmls-omitdev.json <<'NODE'
+const fs = require("fs");
+const tree = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const deps = Object.keys(tree.dependencies || {});
+const fail = (m) => { console.error("FAIL: " + m + " (runtime deps were: " + JSON.stringify(deps) + ")"); process.exit(1); };
+if (!deps.includes("fzstd")) fail("runtime (--omit=dev) tree is missing the real runtime dep fzstd");
+if (deps.includes("@synthetic/cli")) fail("the dev-only workspace LINK leaked into the runtime (--omit=dev) tree");
+if (deps.includes("typescript")) fail("a dev-only dep (typescript) leaked into the runtime (--omit=dev) tree");
+console.log("PASS: runtime (--omit=dev) closure is exactly the real runtime dep set (fzstd); no dev-link leak");
+NODE
+
+echo "All derive-workspace-member-lock workspace-link self-tests passed."


### PR DESCRIPTION
> 🤖 **SPARQ agent** (one of several @jeswr runs on this account).

## Summary

Hardens `scripts/derive-workspace-member-lock.mjs` so a workspace-to-workspace dep edge (a `link: true` node — a published member depending on a sibling `@sparq/*` in `packages/*`, or any future `js/`↔member edge) no longer crashes the JS-SBOM lane with the cryptic exit-254 `'extraneous'` error.

**Problem** (discovered during #876/sq-jpki.2): `scripts/gen-js-sbom.sh` derives a standalone per-member lock, then cyclonedx-npm shells out to `npm ls --json --long --all --package-lock-only --omit=dev --workspaces=false`. The derive script re-homed any `link: true` dep into the derived lock **verbatim** as a dangling link stub whose target package node was absent; `npm ls` then crashed on the unresolved link with `Cannot read properties of undefined (reading 'extraneous')` → exit 254. #876 only sidestepped the immediate `@sparq/client` case (tsconfig `paths` instead of a devDep edge); any future workspace-to-workspace dep edge on a published member would re-trip it.

**Fix**: when a resolved dep is a `link: true` node, **materialize** the link target's real package node plus its own (possibly nested, version-conflicting) closure into the standalone lock at the exact keys the root lock pins them under (`materializeLinkTarget` + a nearest-ancestor `resolveFrom` walk). `npm ls` then resolves the link cleanly in both views. A workspace link is a dev-graph edge, so this changes the **full (dev)** tree but never the **runtime (`--omit=dev`)** set when the link is a devDependency.

## What changed + where
- `scripts/derive-workspace-member-lock.mjs` — link-target materialization (new `resolveFrom` + `materializeLinkTarget`); member-closure flat-rehoming preserved unchanged.
- `scripts/tests/test_derive_workspace_member_lock.sh` — **new** hermetic regression self-test (synthetic root lock; `node`+`npm` only; no network; skips gracefully if the toolchain is absent).
- `.github/workflows/docs-quality.yml` — wires the self-test + `shellcheck scripts/gen-js-sbom.sh` into the **existing gating `ci-scripts`** job (no new check-run; no `advisory`/`informational` token, so it gates).

## Repro / gate commands + results
Ran root `npm ci` (exit 0), then:

**1. Reproduced the original crash** — added a temporary `link:true` workspace devDep (`@sparq/client`) to `js`, regenerated the root lock, ran the lane with the **old** script:
```
bash scripts/gen-js-sbom.sh
# -> Error: npm-ls exited with errors: 1 noSignal
# -> npm error Cannot read properties of undefined (reading 'extraneous')
# -> lane exit: 254
```

**2. Hardened script handles it** (same temp dep):
```
bash scripts/gen-js-sbom.sh   # -> exit 0
# runtime (--omit=dev) set UNCHANGED: root `sparq`, components = fzstd@0.1.1 only
# dev set now also enumerates the link target @sparq/client@0.1.0 + its nested closure (no crash)
```
Then **reverted** the temp dep (working tree back to the single root lock).

**3. Real lane on the clean tree** — `bash scripts/gen-js-sbom.sh` → **exit 0**; root component `sparq` (`@jeswr/sparq@0.1.0`); runtime = `fzstd@0.1.1` (1 component); dev tree = 5 components. The clean-tree derived lock is **byte-identical** to the pre-change output (`diff` empty) — runtime + dev sets provably unchanged.

**Gates:**
- `bash scripts/gen-js-sbom.sh` → exit 0 + correct SBOM ✅
- `shellcheck scripts/gen-js-sbom.sh scripts/tests/test_derive_workspace_member_lock.sh` → clean ✅
- `node --check scripts/derive-workspace-member-lock.mjs` → OK ✅
- `bash scripts/tests/test_derive_workspace_member_lock.sh` → 4/4 PASS ✅ (and **fails** against the pre-fix script with the exact exit-254 `'extraneous'` crash — the test has teeth)
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs-quality.yml'))"` → YAML valid ✅ (actionlint not installable in-sandbox; YAML validated)
- typos / privacy-claims / perf-number gates: N/A for this change (no new prose claims) ✅

## Gate aggregator
Change is two new steps inside the **existing** `ci-scripts (CI-helper self-tests + workflow lints)` job — no new check-run, so `ci-summary / gate` is unaffected and the new self-test gates (job name carries no `advisory`/`informational` token).

## Compliance gap closed
Removes a brittleness in the **published-npm-client CycloneDX SBOM (GS-3)** generation path: a workspace-link dep edge on a published member is now handled rather than crashing the lane, while the published runtime-dep surface the SBOM reports stays unchanged and correct. The GS-1/GS-6/GS-7 assertions operate over the disjoint **Rust/cargo** SBOM (`pkg:cargo/...`) and are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)