### PR TITLE
docs(gui): re-lead embedded-native app as PRIMARY + workspace model + cred/Solid proposal (sq-uau8) [OPUS-4.8]

### DIFF
--- a/research/gui-design.md
+++ b/research/gui-design.md
@@ -1,16 +1,46 @@
 # sparq GUI — design record (design-for-review)
 
-Status: **design-only, for maintainer review.** Nothing in this document is built yet. It
-is the deliverable of the open epic `sq-ixc3` ("EPIC: cross-platform GUI to interact with
-the sparq engine — developed + maintained"). Its sibling epic is `sq-v286` (the
-release-CI epic; deliverable `research/release-ci-design.md`, also not yet written). Both
-are **open** in `.beads/issues.jsonl` and explicitly design-phase.
+<!-- [OPUS-4.8] sq-uau8 — re-lead per maintainer #757: the PRIMARY purpose is a
+     self-contained downloadable app embedding the native engine per platform (usable with
+     NO deployed server); server-connect mode is an explicitly-KEPT secondary use-case.
+     Adds the persistent-workspace model + a credential/Solid workspace-types proposal. -->
 
-This record (1) recommends a concrete framework with justification, (2) defines an MVP
-feature set plus later phases, (3) gives a maintenance / architecture plan (component
-sharing with the site, CI, tests, releases, versioning), and (4) is explicit about scope:
-every claim below is tagged **feasible-now** (the infrastructure or code already exists in
-this repo) or **proposed** (design-for-review, not built).
+Status: **part-built, part design-for-review.** This record began as a fully design-only
+proposal; since then the framework decision and the first phases have **shipped to `main`**,
+so it is now a mixed record. Each claim is tagged: **shipped** (landed on `main`, cited to
+the file/bead), **feasible-now** (infrastructure exists, not yet wired for the GUI), or
+**proposed** (design-for-review, not built). It is the deliverable of the open epic
+`sq-ixc3` ("EPIC: cross-platform GUI to interact with the sparq engine — developed +
+maintained"). Its sibling epic is `sq-v286` (the release-CI epic; deliverable
+`research/release-ci-design.md`). The GUI scaffold (`gui/README.md`) cites this record back
+as its single source of truth.
+
+## The headline framing (maintainer #757)
+
+The **primary** purpose of the GUI is a **self-contained, downloadable desktop application
+that embeds the built `sparq` engine for the user's platform as a direct native Rust
+link** — so a user can download the app and use the full engine **without having to connect
+it to a `sparq-server` that is already deployed**. The app *is* a Rust binary with the
+engine compiled in, not a thin client. Everything below is organised around that goal.
+
+The **server-connect mode** (point the same editor at an already-running SPARQL 1.1
+endpoint) is an explicitly **kept** secondary use-case, **not** a thing to remove. It has
+already shipped (endpoint mode `sq-2mke`, the live-subscriptions view `sq-9ij6`, the server
+health panel `sq-he72`) and stays a first-class connection mode alongside the embedded
+engine. The two modes coexist: embedded-native for "just download and run", and endpoint
+mode for "drive my deployed server / a third-party endpoint".
+
+Within the app, work is organised into persistent, cross-session **workspaces** (§2a) —
+each with its own imported data, SPARQL editor state, optional natural-language querying
+(gated on a user-supplied model API key), and live inference-mode toggles. Credentials and
+Solid are handled via **feature-customised workspace types** (§2b), a proposal for
+maintainer review.
+
+This record (1) records the framework decision + why (shipped), (2) defines the workspace
+model and the per-workspace feature surface, (3) defines the MVP/phase feature set (early
+phases shipped), (4) gives a maintenance / architecture plan (component sharing with the
+site, CI, tests, releases, versioning), and (5) proposes credential/Solid handling for
+review.
 
 ## Honesty preamble (load-bearing, non-negotiable)
 
@@ -18,11 +48,12 @@ These constraints are inherited from the repo's standing honesty discipline and 
 survive into any GUI that ships:
 
 - **No performance numbers.** This work box is non-canonical (see `AGENTS.md` and the
-  MEMORY hygiene rule). The only quantitative figure cited in this document is a static
-  on-disk artifact size (`js/wasm/sparq_wasm_bg.wasm` = 2,583,006 bytes / ~2.58 MB),
-  which is a build-output size, not a benchmark. GUI copy may show a live in-tab
-  `performance.now()` latency for the query the user just ran (measured, labelled), but
-  must never bake in a benchmark claim.
+  MEMORY hygiene rule). The only quantitative figure this document gestures at is the
+  on-disk size of the site's WASM bundle (`js/wasm/sparq_wasm_bg.wasm`, on the order of
+  ~2.6 MB for the `shacl,jsonld` build) — a build-output size that drifts with the build,
+  **not** a benchmark, and not load-bearing to any design choice here. GUI copy may show a
+  live in-tab `performance.now()` latency for the query the user just ran (measured,
+  labelled), but must never bake in a benchmark claim.
 - **ZK and MPC are NOT externally audited.** The in-browser ZK proving path is real
   (`site/src/lib/zk-prover.ts` drives `@aztec/bb.js` UltraHonk), but the file itself
   records that the broader ZK estate is "research-grade, internally reviewed only, and NOT
@@ -40,11 +71,54 @@ survive into any GUI that ships:
 
 ## 0. Ground truth — what exists today
 
-A word-boundary grep for `tauri|electron|egui|iced` across `*.rs / *.toml / *.md / *.ts /
-*.tsx` (minus `node_modules`) returns nothing, and there is no `uniffi` / `cargo-ndk` /
-`xcframework` anywhere in the tree. So the GUI is **greenfield**: every framework and
-architecture choice below is **proposed**, built on **feasible-now** primitives that
-already ship.
+<!-- [OPUS-4.8] sq-uau8 — CORRECTED. The earlier draft said "Nothing is built yet /
+     greenfield, grep for tauri returns nothing". That is now FALSE: the Tauri scaffold,
+     the shared TS package, the editor uplift, endpoint mode, subscriptions, the health
+     panel, the dataset panel, and CSV/TSV export have all landed on main. -->
+
+**Correction to the original draft.** This section once read "the GUI is greenfield; a grep
+for `tauri` returns nothing." That is no longer true and the doc must describe reality. The
+GUI framework decision and several phases have **shipped to `main`**. What exists today:
+
+- **`gui/` — a Tauri 2 scaffold (shipped, `sq-2e93`).** `gui/src-tauri/` is a real Rust
+  crate (`gui/src-tauri/Cargo.toml`, `tauri.conf.json`, `build.rs`, a least-privilege
+  `capabilities/default.json`) whose `src/engine.rs` is the **direct native engine link**: a
+  `sparq_core::Graph` behind a `Mutex` in Tauri managed state, exposing nine `#[tauri::command]`
+  handlers that mirror the wasm `Store` surface (`load`, `query`, `query_quads`,
+  `update_in_place`, `explain`, `explain_analyze`, `count`, `ask`, `store_size`) but backed
+  by the full native store. `gui/README.md` is explicit that this is a **CI-validated
+  scaffold, not a shipped app**: a full `cargo tauri build` needs the webview system
+  libraries (webkit2gtk / WebView2 / WKWebView) not present on every dev box, so the
+  end-to-end build is validated only in the path-scoped lane `.github/workflows/gui.yml`
+  (`sq-bu69`). The engine command layer itself is unit-tested natively.
+- **`packages/sparq-client` — the shared TS package (shipped, `sq-jpki`).** The repo now
+  has a **root `package.json` with npm workspaces** (`"workspaces": ["packages/*", "js",
+  "site", "gui/e2e"]`). `@sparq/client` is the framework-agnostic single source for the
+  `WasmStore` type, loaders, SPARQL/Turtle/JSON-LD highlighters, the SPARQL-JSON result
+  shapes, and the endpoint client. The site and the GUI both consume it, so the GUI is a
+  **zero-new-copy** consumer rather than the third hand-redeclaration the original draft
+  warned about — the §0 "biggest long-term liability" below is **resolved**.
+- **The editor uplift (shipped, `sq-n5aw` + `sq-ixc3.1`).** The plain `<textarea>` is
+  replaced by a real code editor (`site/src/components/sparql-editor.tsx`,
+  `rdf-editor.tsx`) with SPARQL syntax highlighting, prefix awareness, keyword/example
+  completion, and JSON-LD highlighting in editor + results.
+- **Server-connect mode (shipped, `sq-2mke` / `sq-9ij6` / `sq-he72`).** `connect-panel.tsx`
+  routes the same editor at any SPARQL 1.1 endpoint with optional bearer auth and live
+  connection-safety warnings (all wire logic in `@sparq/client`'s endpoint module);
+  `subscriptions-view.tsx` streams `/subscriptions/sse` (or WS) result deltas; a health
+  panel renders Prometheus `/metrics` + the VoID / Service Description.
+- **Dataset panel + results (shipped, `sq-daru` / `sq-x0kp`).** `repl-dataset-panel.tsx`
+  gives a named-graph list with per-graph triple counts; the results panel adds a raw
+  SPARQL-JSON view and CSV/TSV export alongside the table + N-Triples toggle.
+- **Release matrix + CI (shipped, `sq-8n1c` / `sq-bu69` / `sq-9zjy`).** `release.yml` carries
+  the desktop GUI bundles (`.dmg`/`.msi`/AppImage/`.deb`) on the existing per-platform rows
+  with SLSA/SBOM/VEX riding for free; `gui.yml` is the path-scoped per-platform GUI lane;
+  the COOP/COEP service-worker registration is basePath-aware for the Tauri webview.
+
+What is **still greenfield**: there is no `uniffi` / `cargo-ndk` / `xcframework` in the tree
+(the mobile leg is unstarted), and the persistent **workspace model**, the per-workspace
+**inference toggles**, **in-workspace NLQ**, and **credential/Solid workspace types** below
+are **proposed** — they are the remaining design surface this revision adds.
 
 ### The reuse surface that already exists
 
@@ -86,9 +160,9 @@ Documented in `crates/sparq-wasm/src/lib.rs`: the wasm `Store` is **single-threa
 rayon), has **no filesystem** (`save`/`open`/`mmap` unavailable), grows **append-only**
 until rebuild, and lives under the browser tab's **~4 GiB / practically <2 GiB**
 linear-memory ceiling. The doc-comment frames the wasm store as "read-replica shaped," not
-a full-power primary store. The built artifact is **2,583,006 bytes (~2.58 MB)** for the
-`shacl,jsonld` site build (the "~1.2 MB" note in `site/src/lib/sparq-wasm.ts:6` is the
-lean, feature-less baseline, not what the site ships).
+a full-power primary store. The built artifact is on the order of **~2.6 MB** for the
+`shacl,jsonld` site build (a build-output size that drifts; the "~1.2 MB" note in
+`site/src/lib/sparq-wasm.ts` is the lean, feature-less baseline, not what the site ships).
 
 ### The two structural gaps a static site cannot close
 
@@ -97,20 +171,24 @@ lean, feature-less baseline, not what the site ships).
   GitHub-Pages site has no backend to talk to." The vector / genai / geosparql surfaces are
   `walkthrough` for the same reason, and MPC is `live-sim`. A desktop app with a real local
   engine is exactly what closes these.
-- **No shared type source.** The WASM `Store` surface is declared once in `js/` (the
-  `wasm-pack`-generated `sparq_wasm.d.ts`, copied by `js/package.json:36`) and
-  **re-declared by hand** as the `WasmStore` interface in `site/src/lib/sparq-wasm.ts:36`.
-  The site does not depend on `@jeswr/sparq` as a package — it runs its own
-  `scripts/sync-wasm.mjs` (the `prebuild` hook, `site/package.json:12`) to copy
-  `js/wasm/` → `site/public/wasm/`. So there are two copies of the engine's TS surface kept
-  in sync manually. This is the single biggest long-term-maintenance liability today, and a
-  GUI would become a third hand-copy unless it is fixed (see §4).
+- **No shared type source (RESOLVED — `sq-jpki`).** The WASM `Store` surface was once
+  declared once in `js/` (the `wasm-pack`-generated `sparq_wasm.d.ts`) and **re-declared by
+  hand** as the `WasmStore` interface in `site/src/lib/sparq-wasm.ts`, giving two
+  hand-synced copies — flagged here originally as the single biggest long-term-maintenance
+  liability and the reason a GUI risked becoming a third copy. That is now **fixed**:
+  `packages/sparq-client` (`@sparq/client`) is the one shared TS surface, adopted via
+  repo-root npm workspaces, and both the site and the GUI consume it (§3). The GUI is
+  therefore a zero-new-copy consumer; this gap is closed.
 
 ## 1. Framework recommendation
 
-**Recommendation (proposed): Tauri 2.** On desktop, embed the engine as a **direct native
-Rust link** (the app *is* a Rust binary, so it depends on `sparq-engine` / `sparq-core`
-and the `sparq-server` rlib directly — not WASM, not HTTP). Reuse the existing Next.js /
+**Decision (SHIPPED): Tauri 2** — the framework choice below is no longer a proposal; the
+scaffold landed on `main` (`sq-2e93`, `gui/src-tauri/`). On desktop, the engine is embedded
+as a **direct native Rust link** (the app *is* a Rust binary, so it depends on
+`sparq-engine` / `sparq-core` and the `sparq-server` rlib directly — not WASM, not HTTP).
+This direct link is **the headline of the whole design** (maintainer #757): it is exactly
+what lets the downloaded app run the full engine with **no deployed server** in the loop.
+The reasoning is retained below for the record. The existing Next.js /
 React / Tailwind / radix frontend for the webview. Treat mobile (Android / iOS) and a thin
 WASM-only web fallback as **separate, spike-gated, later tracks**.
 
@@ -171,11 +249,201 @@ This matches the lead candidate named in `sq-ixc3`'s own description.
   Android/iOS is unproven *in this repo* and may force a reduced feature set per target.
   Validate with a spike before committing.
 
-## 2. Feature set — MVP and later phases
+## 2a. Workspaces — the persistent, cross-session organising model (proposed)
+
+<!-- [OPUS-4.8] sq-uau8 — NEW section per maintainer #757: the first-class "workspace"
+     concept. Realised by impl beads sq-atb0 (model + persistence), sq-tp1m (inference
+     toggles), sq-96o1 (in-workspace NLQ), and §2b's sq-tlo2/sq-3p0z. -->
+
+Maintainer #757 floated the central UX concept: the app is organised into **workspaces**
+that **persist between sessions**. A workspace is the unit a user opens, fills with data,
+queries, and returns to later. This is the spine the embedded-native app hangs everything
+off — without it, "download and run with no server" has nowhere to keep state.
+
+### What a workspace is
+
+A workspace is a named, persisted bundle of:
+
+1. **Imported data** — one or more data sources, each either a **local file** (loaded from
+   disk via the Tauri file-open dialog, already permitted by the scaffold's
+   `dialog:allow-open` capability) **or a URL** the user points at (fetched and parsed). The
+   embedded native store ingests them into the workspace's `sparq_core::Graph`,
+   named-graph-preserving, via the existing `load` command. (On desktop this is the full
+   native ingest — `rayon`, no ~2 GiB ceiling — not the wasm read-replica.)
+2. **SPARQL editor state** — the current query text, prefix declarations, and recent-query
+   history, restored on reopen.
+3. **An optional natural-language-query (NLQ) configuration** — see "Honesty tier" below;
+   active only when the user supplies a model API key.
+4. **Inference-mode toggles** — per-workspace on/off switches for RDFS / OWL-RL / N3 closure
+   (see below).
+5. **A workspace *type*** — see §2b: the type selects which feature surfaces and credential
+   handling the workspace exposes.
+
+### How workspaces persist, switch, and isolate
+
+- **Persistence (proposed, Tauri local storage).** Each workspace's metadata (name, type,
+  source list, editor state, inference toggles, NLQ-config *without* the secret key) is
+  serialised to the app's per-user data directory under Tauri's app-local path
+  (`tauri::path` app-data dir). The Tauri `store` plugin (or a small JSON-file store behind a
+  new IPC command) is the persistence layer; the scaffold currently registers no plugins
+  (`tauri.conf.json` `plugins: []`) and a least-privilege `capabilities/default.json`, so
+  adding persistence means **adding one plugin + one capability**, called out here for
+  review. **Honest open question:** whether the *imported triples* themselves are persisted
+  (re-ingested cheaply from the recorded sources on reopen) or **snapshotted** to disk via
+  the engine's native `save`/`open` (`sparq-core`) so a large workspace reopens without
+  re-fetching. The native `save`/`open` path is real but **not yet wired into the GUI** (the
+  scaffold's `engine.rs` notes it as a follow-up); the recommendation is to start with
+  re-ingest-from-sources (simple, no new format on disk) and add a `save`/`open` snapshot
+  cache once large workspaces justify it (a future bead).
+- **Switching.** A workspace switcher (sidebar / dropdown) swaps the active
+  `sparq_core::Graph`. Two designs: (a) one managed `EngineState` whose `Graph` is replaced
+  on switch (simplest; only the active workspace is resident — matches the current
+  single-`Mutex<Graph>` scaffold), or (b) a map of `workspace-id → Graph` kept resident for
+  instant switching at a higher memory cost. **Recommendation:** start with (a) — load on
+  activate, drop on switch — and revisit (b) only if switch latency is felt.
+- **Isolation.** Each workspace is its own store, so queries, updates, and inference in one
+  workspace never see another's data. Credentials/keys are scoped to the workspace that owns
+  them (§2b). This isolation is what makes a "Solid workspace" and a throwaway
+  "scratch workspace" safe to keep side by side.
+
+### Per-workspace inference-mode toggles (proposed, `sq-tp1m`)
+
+Each workspace exposes live on/off toggles for the engine's reasoning regimes (RDFS /
+OWL-RL / N3), wired to the embedded engine the same way the site's
+`inference-playground.tsx` / `reason-wasm.ts` drive materialisation today. **Honesty tier:
+this is the native / in-browser-wasm tier (`live-new-wasm`)** — real closure computed by the
+engine (with the proof-tree `why()` view available), not a mock. Toggling a regime on
+materialises (or, on toggle-off, drops back to) the base graph; the design must make clear
+to the user whether a query runs over the base or the materialised graph at that moment. No
+performance claim is made about materialisation cost (this work box is non-canonical).
+
+### In-workspace natural-language query (proposed, `sq-96o1`)
+
+When — and only when — the user supplies their **own model API key**, a workspace can offer
+NL→SPARQL: the user types a question, the engine's introspection grounds a schema summary,
+a model proposes SPARQL, and the engine validates + executes it (with a repair round on a
+parse/exec failure). This is the **native `sparq-nlq` loop** (ground → generate → validate
+→ execute → repair); the GUI is a front door to it with the user's key as the model backend.
+
+**Honesty tier — do NOT overclaim (load-bearing).** On the static site this surface is a
+**captured-output `walkthrough`** with `IS_LIVE_LLM = false`: the *plumbing and executed
+results* are real, but the NL→SPARQL *generation step* is a committed `ReplayLlm` fixture,
+NOT a live model (`site/src/lib/genai.ts` header). In the embedded app the generation step
+becomes **live only because the user brought a model + key** — it is the **model-backed /
+native tier**, contingent on that key and a reachable model host. The GUI must (a) state
+that the key is the user's and never bundle one, (b) keep the standing caveat that
+**NLQ exec-accuracy is not a correctness guarantee** — a query can parse, execute and return
+rows while answering the wrong question (the site's genai page already says this), and
+(c) never silently dress the captured `walkthrough` up as live when no key is present. The
+key is a credential and is handled per §2b (workspace-scoped, OS-keychain, never persisted in
+plaintext workspace metadata).
+
+## 2b. Credential & Solid handling — feature-customised workspace types (proposal for review)
+
+<!-- [OPUS-4.8] sq-uau8 — proposal per maintainer #757 ("Perhaps we have different types of
+     workspaces customised based on the features enabled? Could you propose the right
+     approach"). Realised by impl beads sq-tlo2 (cred/Solid) + sq-3p0z (VC import, #822). -->
+
+Maintainer #757 asked specifically: *"I haven't thought as much about how credentials, or
+Solid would be handled. Perhaps we have different types of workspaces that are set up in a
+way that is customised based on the features that are enabled? Could you propose the right
+approach here."* This section is that proposal — **design-for-review, options + a
+recommendation, not over-committed.**
+
+### The core idea: a workspace *type* selects features + a credential profile
+
+Rather than one monolithic workspace with every toggle, a workspace has a **type** chosen at
+creation that customises (a) which feature panels are shown, and (b) what credentials the
+workspace is allowed to hold and how they are stored. Proposed types:
+
+| Workspace type | Data sources | Credentials it holds | Feature panels it adds | Tier honesty |
+|---|---|---|---|---|
+| **Local / scratch** (default) | local files + plain URLs | *none* (optional NLQ key, OS-keychain) | the core workbench (editor, results, inference toggles) | all `live` / `live-new-wasm` |
+| **Endpoint** | a remote SPARQL 1.1 endpoint | optional bearer token (read/write) | the shipped connect panel + subscriptions + health (`sq-2mke`/`sq-9ij6`/`sq-he72`) | `live` against the user's own server |
+| **Solid** (proposed) | Pod resources behind a WebID | a Solid OIDC session (DPoP token) | login, Pod data-source browser, WAC/ACP-aware querying | see below — engine restriction is `live`, the auth flow is new |
+| **Verifiable-Credentials** (proposed) | imported / dragged-in VCs | the VCs themselves (signed docs) + optional issuer keys | a VC import + query surface (`sq-3p0z`, #822) | see below — query is `live`; ZK over them is **not externally audited** |
+
+A workspace's type is **mostly additive** to the base workbench: a Solid or VC workspace is
+a Local workspace plus a credential profile and one or two extra panels. This keeps the core
+lean (the repo's opt-in-feature discipline) and means a user who never touches Solid never
+sees its UI or its credential prompts.
+
+### Credential storage — the cross-cutting rule
+
+All secrets (NLQ API keys, bearer tokens, Solid sessions, issuer keys) follow one rule:
+**store in the OS secret store, never in the plaintext workspace metadata file.** Tauri's
+ecosystem has a keychain/`stronghold`-style plugin path for this; the workspace metadata
+persists only a *reference* (which credential, which service) and the secret lives in the OS
+keychain (macOS Keychain / Windows Credential Manager / libsecret). This is a new capability
++ plugin to add (called out for review, like the persistence plugin in §2a). Bearer tokens
+are already handled correctly by the shipped connect panel (sent only in the `Authorization`
+header, never logged) — extend that discipline to all credential types.
+
+### Solid workspace (proposed)
+
+- **What is feasible-now.** The engine half already exists: `sparq-solid` does WAC/ACP-aware
+  query rewriting — `rewrite_for(sparql, allowed)` injects a `FROM NAMED <g>` clause per
+  authorised graph and maps the empty set to a guaranteed-absent sentinel
+  (`urn:sparq:nothing`) so an ungranted query is **fail-closed** (zero rows, never an
+  accidental union-of-everything) (`crates/sparq-solid/src/rewrite.rs`, mirrored in
+  `site/src/lib/solid-acl.ts`). The crate also has loader / materialize / ACP-conformance
+  modules. So "query a Solid Pod under its access-control decision" is **already an engine
+  capability**, and the embedded app can link it directly.
+- **What is new (the auth flow).** What does *not* exist is the interactive **WebID / Solid
+  OIDC login + DPoP-bound token acquisition** and the **Pod resource discovery** that feeds
+  the Pod's named graphs into the workspace. That is net-new GUI + a thin client. Two
+  options: (a) run the OIDC flow in the Tauri webview against the user's identity provider
+  and hold the DPoP key in the OS keychain; (b) shell to an external browser for login and
+  catch the redirect via a custom URL scheme. **Recommendation:** (a) — keeps the flow
+  in-app and the key in the keychain — but flag this as the **highest-uncertainty piece**:
+  Solid-OIDC + DPoP in a Tauri webview is unproven *in this repo* and warrants a spike before
+  committing (a future bead).
+- **Honesty.** The access-control *restriction* is the real SPARQL engine (`live`); on the
+  static site the access *decision* is materialised at build time (`solid-pairs-demo.tsx`),
+  but in the embedded app with a live Solid session the decision comes from the Pod's actual
+  WAC/ACP — an honest upgrade, but only once the live auth flow exists. Until then, the Solid
+  workspace type is **proposed**, not shipped.
+
+### Verifiable-Credentials workspace (proposed; relates to #822 + `sq-3p0z` + `sq-1s2.5`)
+
+- **The ask (#822 / `sq-3p0z`).** Let a user **import VCs (drag-drop or URL) and run SPARQL
+  queries over them.** A VC is an RDF document (or a JSON-LD doc that maps to RDF), so the
+  base capability — load it into a workspace graph and query it — is **just the existing
+  ingest path** and is `live`. The new GUI work is the **import surface** (drag-drop zone,
+  URL fetch, a "credentials" view listing imported VCs with issuer/subject/validity), and
+  parsing the common VC envelopes (JSON-LD VC, and recognising — not necessarily verifying —
+  SD-JWT-VC / JWT-VC forms).
+- **Verification vs. querying — keep them distinct (honesty).** *Querying* over VC triples
+  is `live`. *Cryptographically verifying* a VC's signature, or producing a **zero-knowledge
+  proof** about it, is the separate VC/ZK estate (`sq-1s2.5` configurable
+  commitment/circuit/signature framework; `sparq-zk` / `sparq-zk-compose`). That estate is
+  **research-grade, internally re-audited, and NOT externally audited** — external
+  accredited-cryptographer sign-off is **pending** (`sq-qhy4`). So a VC workspace may show
+  "imported, parsed, queryable" as a `live` fact, but must **not** present "verified" or any
+  ZK property as a production guarantee; any verify/ZK affordance carries the existing
+  not-externally-audited caveat (the `scripts/check-privacy-claims.sh` gate enforces this on
+  user-facing copy). **Recommendation:** ship VC *import + query* first (`live`, low risk),
+  and treat in-app VC *verification* / ZK-over-VCs as a later, explicitly-caveated phase
+  riding the `sq-1s2.5` estate — do not couple the simple import surface to the unaudited
+  crypto.
+
+### Recommendation (credential/Solid)
+
+Adopt the **feature-customised workspace-type** model the maintainer floated. Concretely:
+ship **Local** and **Endpoint** types first (both are essentially the already-shipped
+surfaces, re-housed under a workspace); add a **VC** type as **import + query only** (`live`,
+no crypto coupling); and treat the **Solid** type as a spike-gated proposal whose engine half
+(`sparq-solid` rewrite) is feasible-now but whose live OIDC/DPoP auth flow is the real new
+work. Store every secret in the OS keychain, never in workspace metadata. Keep types
+additive so the core stays lean and a user only ever sees the credential UI for the features
+they opted into.
+
+## 2c. Feature set — MVP and later phases (MVP + Phase 2 shipped)
 
 The GUI is **not greenfield in features**: the site already has a genuinely-live in-tab
-SPARQL engine and ~20 showcase surfaces. The job is consolidation into a credible
-*workbench* plus the editor uplift, not building a playground from zero.
+SPARQL engine and ~20 showcase surfaces, and the MVP workbench + server-connect phases have
+**shipped** (§0). The remaining job is the workspace model (§2a), the credential/Solid types
+(§2b), and the later-phase showcases — not building a playground from zero.
 
 ### Engine capability → GUI feature → current tier
 
@@ -193,7 +461,7 @@ SPARQL engine and ~20 showcase surfaces. The job is consolidation into a credibl
 | ZK query proofs (BGP+FILTER, attestation, revocation) | Commit → prove → verify, in-tab | **`live-bbjs`** — `zk-car-hire.tsx`, `zk-prover.ts` via `@noir-lang/noir_js` + `@aztec/bb.js` UltraHonk. **Not externally audited** |
 | MPC federation (additive sharing) | Multi-party threshold demo | **`live-sim`** — `mpc-demo.tsx`, `mpc-sim.ts` — a faithful JS illustration, **not** the native `sparq-mpc` protocol, no CSPRNG, **not** live MPC |
 | Access control (Solid WAC/ACP) FROM NAMED restriction | (user, app)-pair → different result sets | **`live`** (engine restriction) — `solid-pairs-demo.tsx`; ACP decision materialized at build time |
-| HTTP server: SPARQL Protocol, GSP, `/metrics`, WS+SSE subscriptions, VoID/Service Description | Connect-to-endpoint mode + live subscription stream | **`walkthrough`** — static Pages has no backend; real endpoints exist in `crates/sparq-server` but aren't hosted |
+| HTTP server: SPARQL Protocol, GSP, `/metrics`, WS+SSE subscriptions, VoID/Service Description | Connect-to-endpoint mode + live subscription stream + health panel | **`live` (against the user's own server)** — SHIPPED in the GUI/site as endpoint mode (`sq-2mke`, `connect-panel.tsx`), subscriptions (`sq-9ij6`, `subscriptions-view.tsx`), health (`sq-he72`). The static Pages demo of these stays a `walkthrough`; the app drives a real endpoint |
 | Federation client (TPF/brTPF/SPARQL, pushdown) | Multi-source federation plan + per-leaf fan-out | **`soon`** — `sparq-fedclient` native, feature-gated; no GUI surface yet |
 | Usage-control policy (ODRL) conflict/containment | Policy editor + conflict/refinement view | **`soon`** — `sparq-policy` (`contains` / `detect_conflicts`); no GUI |
 | PROV-O lineage of derived data | Lineage graph of a CONSTRUCT derivation | **`soon`** — `sparq-prov` (`derive_construct`); no GUI |
@@ -203,49 +471,53 @@ SHACL) is `live`. Everything that is an opt-in **native crate not compiled to wa
 (vector, geo, nlq, fedclient, policy, prov, native MPC) is `walkthrough` / `live-sim` /
 `soon`, because the GitHub Pages host has no backend and those crates aren't in `js/wasm`.
 
-### MVP — a credible workbench around the existing live engine (mostly `live`, no backend)
+### MVP — a credible workbench around the live engine (SHIPPED)
 
-The MVP is **consolidation + the editor uplift**, almost entirely `live` tier:
+The MVP was **consolidation + the editor uplift + the Tauri shell**, almost entirely `live`
+tier. All of it has **shipped**:
 
-1. **Query editor uplift** (feasible-now; the single biggest real UX gap). The current
-   editor is a plain `<textarea>` (`repl.tsx:327`). MVP: syntax highlighting, prefix
-   awareness, keyword/example completion (a SPARQL mode on a client-side code editor such
-   as CodeMirror 6). No engine change. Highest-leverage GUI improvement.
-2. **Results: table + raw SPARQL-JSON + N-Triples, plus CSV/TSV export** (feasible-now,
-   `live`). Table + N-Triples already render (`ResultPanel`, `repl.tsx:473`); add a raw
-   SPARQL-JSON view (the wasm already returns that document) and a CSV/TSV export.
-3. **Dataset load / manage panel** (feasible-now, `live`). Already present
-   (`repl-datasets.tsx`: built-in picker, upload, URL, merge, dataset viewer). MVP polish:
-   named-graph list with per-graph triple counts. HDT upload stays out of scope
-   (native-only).
-4. **Keep the showcase surfaces exactly as tiered** (the honesty discipline). SHACL /
+1. **Query editor uplift (SHIPPED, `sq-n5aw` + `sq-ixc3.1`).** The plain `<textarea>` is now
+   a real code editor (`site/src/components/sparql-editor.tsx`) with SPARQL syntax
+   highlighting, prefix awareness, keyword/example completion, and JSON-LD highlighting in
+   editor + results. The highlighters live in `@sparq/client`.
+2. **Results: table + raw SPARQL-JSON + N-Triples + CSV/TSV export (SHIPPED, `sq-x0kp`).**
+3. **Dataset load / manage panel (SHIPPED, `sq-daru`).** `repl-dataset-panel.tsx`: built-in
+   picker, upload, URL, merge, dataset viewer, **and a named-graph list with per-graph
+   triple counts**. HDT upload stays out of scope (native-only).
+4. **Keep the showcase surfaces exactly as tiered (ongoing honesty discipline).** SHACL /
    inference / full-text / RSP stay `live` / `live-new-wasm`; ZK stays `live-bbjs`; MPC /
    Solid stay `live-sim` / `live`. **Never silently upgrade a `walkthrough` to look live.**
-5. **The Tauri desktop shell itself** (proposed, the gating MVP work). Wrap the existing
-   frontend in a Tauri 2 webview with the conditional-`basePath` config change, and link
-   the native engine for a first "real local store" command path (load file from disk via
-   `save`/`open`, run a query) — proving the direct-Rust-link embedding end to end.
+5. **The Tauri desktop shell itself (SHIPPED scaffold, `sq-2e93`).** The frontend is wrapped
+   in a Tauri 2 webview with the env-switched `basePath` (`sq-9zjy` made the COOP/COEP
+   service-worker registration basePath-aware), and the native engine is linked with a
+   command path that loads a file from disk and runs a query — proving the direct-Rust-link
+   embedding end to end. Note the standing caveat in `gui/README.md`: this is a
+   **CI-validated scaffold**, and the native `save`/`open` persistence path is a follow-up,
+   not yet wired (it is the backbone of workspace snapshotting, §2a).
 
-### Phase 2 — connect to a running `sparq-server` (closes the live-backend gap; proposed)
+### Phase 2 — connect to a running `sparq-server` (SHIPPED)
 
-The server API already exists (`crates/sparq-server/src/http.rs:2046-2102`): `/sparql`
-(GET + both POST forms), `/sparql/graph` + `/graphs/{*path}` (Graph Store read **and**
-write), `/subscriptions` (WS) + `/subscriptions/sse` (SSE), `/health`, `/metrics`,
-`/admin/compact`, and the opt-in `/.well-known/void`, `/tpf`, `/shacl/validate`. The GUI
-work is a client + auth/CORS UX, not new engine work.
+The server API already existed (`crates/sparq-server/src/http.rs`): `/sparql` (GET + both
+POST forms), `/sparql/graph` + `/graphs/{*path}` (Graph Store read **and** write),
+`/subscriptions` (WS) + `/subscriptions/sse` (SSE), `/health`, `/metrics`, `/admin/compact`,
+and the opt-in `/.well-known/void`, `/tpf`, `/shacl/validate`. The GUI work was a client +
+auth/CORS UX, not new engine work — and it has **shipped**. This whole phase is the
+**server-connect mode** the headline framing (#757) marks as an explicitly-KEPT secondary
+use-case, NOT removable:
 
-6. **Endpoint mode** — a "Connect" panel: endpoint URL, optional bearer token, run the
-   *same* editor against any SPARQL 1.1 Protocol endpoint. The server already supports a
-   constant-time Bearer **write gate** (`--auth-token`) and optional **read gate**
-   (`--auth-token-read`); on a WebSocket handshake (where browsers can't set
-   `Authorization`) it accepts `Sec-WebSocket-Protocol: bearer.<token>`. Unlocks persistent
-   datasets, GSP graph management, and the server-only `geo` / `vec-predicate` features
-   without a wasm port.
-7. **Live subscriptions view** — consume `/subscriptions/sse` (or WS) and stream result
-   deltas as the dataset mutates. This is the standout "live" demo a static site
-   fundamentally cannot do.
-8. **`/metrics` + Service Description panel** — render the Prometheus `/metrics` and the
-   VoID / SPARQL Service Description as a "server health / capabilities" view.
+6. **Endpoint mode (SHIPPED, `sq-2mke`).** `connect-panel.tsx` runs the *same* editor against
+   any SPARQL 1.1 Protocol endpoint with an optional bearer token. The wire logic lives in
+   `@sparq/client`'s endpoint module; the panel renders the form, the classified
+   connection-safety warnings, and a "Test connection" `ASK {}` result. The token is sent
+   only in the `Authorization` header and never logged. The server's constant-time Bearer
+   write gate (`--auth-token`) / optional read gate (`--auth-token-read`) and the WebSocket
+   `Sec-WebSocket-Protocol: bearer.<token>` handshake are honoured.
+7. **Live subscriptions view (SHIPPED, `sq-9ij6`).** `subscriptions-view.tsx` consumes
+   `/subscriptions/sse` (or WS) and streams result deltas as the dataset mutates — the
+   standout "live" demo a static site fundamentally cannot do.
+8. **`/metrics` + Service Description panel (SHIPPED, `sq-he72`).** Renders the Prometheus
+   `/metrics` and the VoID / SPARQL Service Description as a "server health / capabilities"
+   view.
 
 The GUI must respect the server's security posture (`crates/sparq-server/README.md`): **no
 auth by default** (anyone reaching the port reads and writes), loopback bind by default
@@ -254,18 +526,40 @@ auth by default** (anyone reaching the port reads and writes), loopback bind by 
 when empty (the default). The GUI surfaces these as connection-safety UX, never bypasses
 them.
 
+### Phase 2.5 — the workspace model + per-workspace features (proposed; the next track)
+
+This is the **new core track** this revision adds (§2a/§2b), the spine of the
+embedded-native app. The impl beads already exist:
+
+a. **Persistent cross-session workspace model + Tauri local persistence (`sq-atb0`)** — the
+   foundational concept that **blocks** the per-workspace feature beads (per-workspace data
+   import local + URL, saved SPARQL editor state, switch/isolate). §2a.
+b. **Per-workspace inference-mode toggles (`sq-tp1m`)** — RDFS/OWL-RL/N3 on/off wired to the
+   embedded engine; `live-new-wasm` tier. Depends on (a).
+c. **In-workspace NLQ gated on a user-supplied API key (`sq-96o1`)** — the native
+   `sparq-nlq` loop fronted by the user's key; model-backed/native tier, NOT a silent
+   live-upgrade of the captured `walkthrough`. Depends on (a).
+d. **Credential/Solid handling via feature-customised workspace types (`sq-tlo2`)** — the
+   §2b proposal; itself design-first, then impl beads. Relates to `sq-1s2.5`.
+e. **Drag-drop / import Verifiable Credentials and query over them (`sq-3p0z`, #822)** — the
+   VC workspace's import + query surface; `live` query, ZK-over-VCs explicitly later +
+   caveated.
+
 ### Phase 3 — visualisation + heavier showcases going live (proposed)
 
-9. **Graph/triple visualisation of results** (`live`). CONSTRUCT/DESCRIBE already returns
-   N-Triples in-tab; render it as a node-link graph. Pure client-side over existing output.
-10. **Vector + Geo go `live-new-wasm`**. Portability spikes to add `sparq-vectors` /
-    `sparq-geo` to a wasm bundle (the surfaces' own tier comments name this as the blocker),
-    upgrading kNN viz and the GeoSPARQL map overlay from `walkthrough` to live. Follows the
-    proven `sparq-{shacl,reason,text,rsp}-wasm` pattern.
-11. **Policy / PROV / Federation views** (`soon` today). An ODRL policy editor + conflict /
-    containment view over `sparq-policy`; a PROV-O lineage graph over
+9. **Graph/triple visualisation of results (`sq-lyp8`, `live`).** CONSTRUCT/DESCRIBE already
+   returns N-Triples in-tab; render it as a node-link graph. Pure client-side over existing
+   output.
+10. **Vector + Geo go `live-new-wasm` (`sq-zeai`).** Portability spikes to add
+    `sparq-vectors` / `sparq-geo` to a wasm bundle (the surfaces' own tier comments name this
+    as the blocker), upgrading kNN viz and the GeoSPARQL map overlay from `walkthrough` to
+    live. Follows the proven `sparq-{shacl,reason,text,rsp}-wasm` pattern.
+11. **Policy / PROV / Federation views (`sq-6v53`, `soon` today).** An ODRL policy editor +
+    conflict / containment view over `sparq-policy`; a PROV-O lineage graph over
     `sparq-prov::derive_construct`; a federation-plan visualiser over `sparq-fedclient`.
     Each needs either a wasm port or endpoint mode first.
+12. **Paginated / lazy results (`sq-9w4t`).** Page-wise query evaluation with a bounded
+    read-ahead cache, for large result sets in the embedded store.
 
 ### Explicitly out of scope / stays caveated
 
@@ -279,47 +573,48 @@ them.
 
 ## 3. Architecture & maintenance plan
 
-### Monorepo structure (proposed) — extend, don't fork
+### Monorepo structure (SHIPPED) — extend, don't fork
 
 ```text
-packages/sparq-client/   # NEW shared TS pkg: the ONE WasmStore type + loaders
-js/                      # @jeswr/sparq — npm wrapper; consumes packages/sparq-client
-site/                    # Next.js site — consumes packages/sparq-client
-gui/                     # NEW Tauri 2 app: frontend consumes packages/sparq-client;
-                         #   gui/src-tauri/ is the Rust shell linking sparq-engine
+packages/sparq-client/   # SHIPPED shared TS pkg: the ONE WasmStore type + loaders + endpoint client
+js/                      # @jeswr/sparq — npm wrapper; consumes @sparq/client
+site/                    # Next.js site — consumes @sparq/client
+gui/                     # SHIPPED Tauri 2 scaffold: frontend consumes @sparq/client;
+                         #   gui/src-tauri/ is the Rust shell linking sparq-engine; gui/e2e/ is the e2e pkg
 ```
 
-The shared package's job is to **kill the hand-redeclared `WasmStore`** (§0): `js/`
-generates the wasm `.d.ts`; `packages/sparq-client` re-exports it plus the loaders; both
-`site/` and `gui/` import from it. This collapses today's 2-copy manual sync into one
-source and makes the GUI a **zero-new-copy** consumer rather than a third hand-copy. The
-npm `@jeswr/sparq` package already ships a handwritten `dist/index.d.ts`, so a shared TS
-package is consistent with existing direction.
+This is **shipped** (`sq-jpki`): the repo now has a root `package.json` with
+`"workspaces": ["packages/*", "js", "site", "gui/e2e"]`, and `@sparq/client` is the one
+shared TS surface (the `WasmStore` type, loaders, the SPARQL/Turtle/JSON-LD highlighters,
+result shapes, and the endpoint client). Both `site/` and `gui/` import from it, so the GUI
+is a **zero-new-copy** consumer — the hand-redeclared `WasmStore` drift the original draft
+flagged as the single biggest liability is **eliminated**. The earlier "adopting npm
+workspaces is a reviewable change" caveat is **resolved**: the adoption already happened.
 
-**Tooling caveat (real, not free).** `site/` and `js/` are independent npm roots today —
-there is no root `package.json` and no workspaces field; `site/` has its own
-`package-lock.json`. Introducing `packages/` means adopting npm (or pnpm) workspaces at a
-new repo-root `package.json` — a reviewable change to the JS build topology, called out
-here so the maintainer signs off.
+### Engine embedding (desktop SHIPPED; mobile + persistence proposed)
 
-### Engine embedding (proposed)
-
-- **Desktop**: `gui/src-tauri/` is a Rust crate that depends on the engine library crates
-  directly (and the `sparq-server` rlib if endpoint-mode wants an in-process server). A
-  Tauri IPC command layer bridges the webview UI to the engine: load/query/update/explain
-  map onto the same operations the WASM `Store` exposes, but backed by the full native
-  store (threads, mmap, persistence). The GUI Rust crate should inherit the workspace's
-  `forbid(unsafe_code)` posture (see the `unsafe-rust-attestation` skill) and the
-  clippy-`-D warnings` discipline.
+- **Desktop (SHIPPED scaffold)**: `gui/src-tauri/` is a Rust crate that depends on the engine
+  library crates directly. The Tauri IPC command layer (`src/engine.rs`) bridges the webview
+  UI to the engine: nine commands (`load`, `query`, `query_quads`, `update_in_place`,
+  `explain`, `explain_analyze`, `count`, `ask`, `store_size`) map onto the same operations
+  the WASM `Store` exposes, but backed by a native `sparq_core::Graph` behind a `Mutex` in
+  Tauri managed state. The command layer is unit-tested natively; the full `cargo tauri
+  build` is CI-only (needs the webview system libraries). **Workspace persistence (proposed,
+  §2a)** extends this: a persistence plugin + capability for workspace metadata, and
+  optionally the engine's native `save`/`open` for a snapshot cache (not yet wired). The GUI
+  Rust crate inherits the workspace's `forbid(unsafe_code)` posture (see the
+  `unsafe-rust-attestation` skill) and the clippy-`-D warnings` discipline.
 - **Mobile** (later track): the same native library cross-compiled via NDK (Android) and an
   xcframework (iOS) — net-new `uniffi` / `cargo-ndk` work that does not exist in the repo
   yet; spike-gated, possibly with a reduced per-target feature set.
 - **Web fallback** (optional): the existing WASM bundle, inheriting the documented
   single-thread / no-mmap / <2 GiB ceilings — i.e. exactly the site as it is today.
 
-### CI for the GUI (proposed, modelled on existing lanes)
+### CI for the GUI (SHIPPED, `sq-bu69`)
 
-The repo already has the exact patterns to clone. The GUI lane (`gui.yml`) should be
+The path-scoped per-platform `gui.yml` lane (build + lint + typecheck + clippy + tauri-driver
+e2e) has **shipped**, modelled on `site-e2e.yml`. The design notes below are retained as the
+record of how it was shaped. The GUI lane (`gui.yml`) is
 **path-scoped, per-platform, and NOT a merge-queue lane**, mirroring `site-e2e.yml` and
 `js.yml`:
 
@@ -403,31 +698,59 @@ does not re-open it.
 
 ## 5. Bottom line (verdict)
 
-- **Feasible-now (infra exists):** the per-platform CI patterns (`site-e2e.yml` / `js.yml`),
-  the desktop build matrix + full supply-chain attestation (`release.yml`), single-workspace
-  versioning (`Cargo.toml` + `version.workspace = true`), and a real reusable React/WASM
-  frontend (`site/src/`) — the GUI rides all of these with extensions, not rewrites.
-- **Proposed (design-for-review):** Tauri 2 with a direct native-Rust engine link on
-  desktop; an npm-workspaces monorepo with a `packages/sparq-client` shared-TS package to
-  eliminate the current hand-redeclared `WasmStore` drift (the single biggest long-term
-  liability today); a path-scoped non-merge-queue `gui.yml` matrix lane; a `tauri-driver`
-  e2e harness (new, not Playwright-reusable); GUI bundles added to `release.yml`'s
-  `subject-path`; lockstep versioning via `release-plz` / `cargo-release`.
+- **The headline (maintainer #757):** the **primary** product is a downloadable, per-platform
+  desktop app that embeds the native engine as a **direct Rust link** — full engine, **no
+  deployed server required**. That decision is **shipped** (Tauri 2 scaffold, `sq-2e93`).
+  **Server-connect mode is explicitly KEPT** as a secondary use-case (endpoint / subscriptions
+  / health, `sq-2mke` / `sq-9ij6` / `sq-he72`), not removed.
+- **Shipped (landed on `main`):** the Tauri 2 scaffold with the direct native-engine link
+  (`gui/src-tauri/`, `sq-2e93`); the `@sparq/client` shared-TS package on repo-root npm
+  workspaces, which **eliminated** the hand-redeclared `WasmStore` drift (`sq-jpki`); the
+  editor uplift (`sq-n5aw`/`sq-ixc3.1`); the results SPARQL-JSON + CSV/TSV (`sq-x0kp`); the
+  dataset/named-graph panel (`sq-daru`); endpoint mode + subscriptions + health (`sq-2mke` /
+  `sq-9ij6` / `sq-he72`); the `gui.yml` CI lane (`sq-bu69`); GUI bundles on `release.yml`
+  (`sq-8n1c`); the basePath-aware service-worker fallback (`sq-9zjy`).
+- **Proposed (design-for-review — this revision's new surface):** the persistent
+  cross-session **workspace model** + Tauri local persistence (`sq-atb0`); per-workspace
+  **inference toggles** (`sq-tp1m`); in-workspace **NLQ** gated on a user-supplied key
+  (`sq-96o1`); **credential/Solid feature-customised workspace types** (`sq-tlo2`) and the
+  **VC import + query** surface (`sq-3p0z`, #822); plus the Phase-3 viz/heavy-showcase beads
+  (`sq-lyp8` / `sq-zeai` / `sq-6v53` / `sq-9w4t`) and the still-greenfield **mobile** leg
+  (no `uniffi`/`cargo-ndk` yet).
 - **Hard `needs:user` blockers (cannot be designed away):** Apple notarization / Windows
   Authenticode / Android keystore credentials for a *distributable* GUI; the `sq-svtt`
-  Pages-root decision; and branch-protection required-contexts if the GUI lane is to be a
-  *hard* merge gate. Mobile (Android/iOS) GUI artifacts are net-new — no rows exist in the
-  `release.yml` matrix today.
-- **Caveats:** the ZK/MPC surfaces this GUI would expose (`zk-car-hire.tsx`, `mpc-demo.tsx`)
-  are **not externally audited** — the GUI inherits the existing "what runs where" honesty
-  framing, never presenting them as production-trust. No performance numbers are asserted
-  (this work box is non-canonical).
+  Pages-root decision; branch-protection required-contexts if the GUI lane is to be a *hard*
+  merge gate; and the highest-uncertainty new piece, the **Solid OIDC/DPoP auth flow** in a
+  Tauri webview (spike-gated). Mobile GUI artifacts are net-new — no rows in `release.yml`.
+- **Caveats (honesty tiers preserved):** **in-workspace NLQ is model-backed** — live only
+  when the user supplies their own key and a reachable model; otherwise the captured
+  `walkthrough` (`IS_LIVE_LLM = false`, `genai.ts`) — and exec-accuracy is **not** a
+  correctness guarantee. **Inference toggles are the native / in-browser-wasm tier**
+  (`live-new-wasm`) — real closure, never a mock. The ZK/MPC surfaces (`zk-car-hire.tsx`,
+  `mpc-demo.tsx`) and any VC verification / ZK-over-VCs are **research-grade, not externally
+  audited** (external accredited-cryptographer sign-off pending, `sq-qhy4`; `sparq-mpc` is
+  honest-majority semi-honest only) — never presented as production-trust; the
+  `scripts/check-privacy-claims.sh` gate enforces this on user-facing copy. No performance
+  numbers are asserted (this work box is non-canonical).
 
 ## Key file citations
 
 - Epics: `sq-ixc3`, `sq-v286`, `sq-svtt`, `sq-w9sr` (`.beads/issues.jsonl`).
+- GUI (shipped): `gui/README.md`, `gui/src-tauri/{Cargo.toml,tauri.conf.json,src/lib.rs,
+  src/engine.rs,src/main.rs,capabilities/default.json}`, `gui/e2e/`, the root
+  `package.json` (`workspaces`), `packages/sparq-client/`,
+  `site/src/components/{connect-panel.tsx,subscriptions-view.tsx,repl-dataset-panel.tsx,
+  sparql-editor.tsx,rdf-editor.tsx,solid-pairs-demo.tsx}`,
+  `.github/workflows/gui.yml`.
+- GUI impl beads (proposed track): `sq-atb0` (workspace model), `sq-tp1m` (inference
+  toggles), `sq-96o1` (NLQ), `sq-tlo2` (cred/Solid), `sq-3p0z` (VC import, #822);
+  shipped: `sq-2e93` / `sq-jpki` / `sq-n5aw` / `sq-x0kp` / `sq-daru` / `sq-2mke` / `sq-9ij6` /
+  `sq-he72` / `sq-bu69` / `sq-8n1c` / `sq-9zjy`.
+- Honesty tiers: `site/src/lib/genai.ts` (`IS_LIVE_LLM = false`), `site/src/lib/inference.ts`
+  + `reason-wasm.ts`, `site/src/lib/solid-acl.ts`, `crates/sparq-solid/src/rewrite.rs`,
+  `crates/sparq-nlq/`, the VC/ZK estate `crates/sparq-zk*/` (`sq-1s2.5`, audit pending
+  `sq-qhy4`), `scripts/check-privacy-claims.sh`.
 - Site: `site/package.json`, `site/next.config.ts`, `site/src/components/repl.tsx`,
-  `site/src/components/repl-datasets.tsx`,
   `site/src/lib/{sparq-wasm.ts,zk-prover.ts,mpc-sim.ts,http-server.ts}`,
   `site/src/data/surfaces.ts`, `site/README.md`, `research/feature-showcase-site-design.md`.
 - Engine / WASM: `crates/sparq-wasm/{src/lib.rs,Cargo.toml}`,
@@ -435,7 +758,7 @@ does not re-open it.
   `js/wasm/sparq_wasm_bg.wasm`.
 - Server: `crates/sparq-server/src/{http.rs,negotiate.rs,service_config.rs}`,
   `crates/sparq-server/README.md`.
-- CI / release: `.github/workflows/{site-e2e.yml,js.yml,pages.yml,release.yml,ci-summary.yml}`,
+- CI / release: `.github/workflows/{gui.yml,site-e2e.yml,js.yml,pages.yml,release.yml,ci-summary.yml}`,
   `scripts/gen-sbom-vex.sh`.
-- Workspace: `Cargo.toml`.
-- Opt-in crates: `crates/sparq-{vectors,geo,nlq,fedclient,policy,prov,mpc,introspect}/`.
+- Workspace: `Cargo.toml`, root `package.json`.
+- Opt-in crates: `crates/sparq-{vectors,geo,nlq,fedclient,policy,prov,mpc,introspect,solid,zk,zk-compose}/`.


### PR DESCRIPTION
> 🤖 SPARQ agent — design-for-review (doc-only). Revises `research/gui-design.md` per maintainer @jeswr's #757 direction. **No auto-merge** — flagged for your review.

## What this PR does (bead `sq-uau8`)

Doc-only revision of `research/gui-design.md`. No `crates/*` source touched.

### Premise correction (honesty)

The old doc opened with *"Nothing in this document is built yet / the GUI is greenfield"*. **That is now false** and the doc said so itself — so I corrected it. Since the doc was written, the framework decision and several phases **shipped to `main`**: the Tauri 2 scaffold (`sq-2e93`, `gui/src-tauri/` — direct native engine link), the `@sparq/client` shared-TS package on **repo-root npm workspaces** (`sq-jpki`, which *eliminated* the hand-redeclared `WasmStore` drift the doc flagged as its #1 liability), the editor uplift (`sq-n5aw`/`sq-ixc3.1`), endpoint mode + subscriptions + health (`sq-2mke`/`sq-9ij6`/`sq-he72`), the dataset/named-graph panel (`sq-daru`), SPARQL-JSON + CSV/TSV (`sq-x0kp`), the `gui.yml` lane (`sq-bu69`), release bundles (`sq-8n1c`). Every claim is now tagged **shipped** / **feasible-now** / **proposed**.

### 1. Re-lead — embedded-native app is PRIMARY; server-connect is KEPT

The doc now leads with the **downloadable per-platform app that embeds the native engine as a direct Rust link**, usable **with no deployed server**. **Server-connect mode is explicitly KEPT** as a first-class secondary use-case (endpoint/subscriptions/health), **not** framed as removable.

### 2. NEW §2a — persistent cross-session Workspaces

A workspace = imported data (local file + URL), saved SPARQL editor state, key-gated NLQ config, inference toggles, and a *type*. Covers Tauri local-storage persistence (with an honest open question: re-ingest-from-sources vs `save`/`open` snapshot — the native persistence path is real but not yet GUI-wired), switching (replace the managed `Graph`), and isolation.

### 3. NEW §2b — credential/Solid via feature-customised workspace types (your floated idea)

Proposes **workspace types** — **Local**, **Endpoint**, **Solid**, **Verifiable-Credentials** — each additive to the core workbench, with a cross-cutting rule: **all secrets in the OS keychain, never in plaintext workspace metadata**.

- **Solid workspace:** the engine half is *feasible-now* (`sparq-solid`'s WAC/ACP-aware `rewrite_for` fail-closed `FROM NAMED` injection); the new + highest-uncertainty work is the live **WebID / Solid-OIDC + DPoP** auth flow in a Tauri webview (spike-gated).
- **VC workspace (#822):** *import + query* over VC triples is `live` (just the ingest path). In-app **verification / ZK-over-VCs** is the separate, **research-grade, not-externally-audited** estate (`sq-1s2.5`; sign-off pending `sq-qhy4`) — ship import+query first, keep crypto explicitly later + caveated.
- **Recommendation:** ship Local + Endpoint first (re-house the shipped surfaces), add VC as import+query only, treat Solid as a spike-gated proposal.

### 4. Honesty tiers preserved

- **NLQ** = model-backed: live *only* when the user supplies their own key + a reachable model; otherwise the captured `walkthrough` (`IS_LIVE_LLM = false`) — and exec-accuracy is **not** a correctness guarantee.
- **Inference toggles** = native / in-browser-wasm tier (`live-new-wasm`), real closure.
- **ZK/MPC + VC-verification** = research-grade, **not externally audited**; `sparq-mpc` honest-majority semi-honest only. No perf numbers (work box non-canonical); softened a now-drifted exact wasm-byte figure.

### Downstream impl beads this design realises

`sq-atb0` (workspace model + persistence), `sq-tp1m` (inference toggles), `sq-96o1` (NLQ), `sq-tlo2` (cred/Solid), `sq-3p0z` (VC import, #822) — already created; this doc is their design-for-review.

### Gates

`typos` clean · `markdownlint-cli2` 0 errors · `check-privacy-claims.sh` OK · doc-only (no `crates/*/src`).
