### PR TITLE
test(sparq-solid): WAC/ACP differential oracle vs independent procedural reference (sq-t58w.7) [OPUS-4.8]

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -39,18 +39,16 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
 
 - **WAC + ACP** — Web Access Control (`.acl`) and Access Control Policy (`.acr`): inheritance, agent
   classes, groups, `allOf`/`anyOf`/`noneOf`, the ACP matcher's three-dimensional `(agent, client,
-  issuer)` principal, `acp:CreatorAgent`/`acp:OwnerAgent`, and normative deny-overrides. Full
-  support matrix in the design doc.
+  issuer)` principal, `acp:CreatorAgent`/`acp:OwnerAgent`, normative deny-overrides (matrix in the design doc).
 - **Trusted creator/owner provenance** — `acp:CreatorAgent`/`acp:OwnerAgent` resolve only against
   per-resource WebIDs the storage layer supplies through the trusted `AccessProvenance` channel,
   **never** graph content. The loader hard-rejects any control-document triple in the
-  derivation-internal `solidx:` namespace, so a writer cannot embed `solidx:creator`/
-  `solidx:appliesToResource` to self-grant. Each grant is resource-scoped; with no provenance, no
-  such matcher grants (fail-closed).
+  derivation-internal `solidx:` namespace, so a writer cannot embed `solidx:creator` to self-grant.
+  Each grant is resource-scoped; with no provenance, no such matcher grants (fail-closed).
 - **Triples-native + zero-copy enforcement** — pods, ACL/ACR docs, and the auth view are all
   ordinary named graphs ("who can read G?" is one SPARQL pattern); the default path evaluates
   through the engine's zero-copy dataset view, with a v1 `FROM NAMED` rewrite kept as a portability
-  path for any standard SPARQL 1.1 engine.
+  path for standard SPARQL 1.1 engines.
 - **Write-path gating** — `update_as` / `update_as_acp` check every graph an update could mutate
   before applying, and auto-re-materialize on `.acl`/`.acr` writes.
 - **ODRL bridge (opt-in `odrl-bridge`, research-track — not a production cutover)** — runs the
@@ -90,28 +88,30 @@ so refresh can't widen or drop them.
   engine against the [WAC](https://solidproject.org/TR/wac) / [ACP](https://solidproject.org/TR/acp)
   specs at the *library* level (data-declared `(agent, client, mode, resource) → allow|deny`
   scenarios). **Scope (honest):** the realistic library-level oracle, **not** the Solid
-  CTH-over-HTTP (this crate has no HTTP surface); a JS-reference differential oracle is
-  **research-open**, not built here (`research/sparq-solid-scope.md` §4).
-- **Security posture — fail-closed.** Absence of a grant makes a graph **invisible** and
-  indistinguishable from an absent one. The reasoner is fed only ACL/ACR + structural facts —
-  **never pod content** — so no writable document can grant itself access; the reserved `urn:sparq:`
-  namespace is rejected on input and forged `<urn:sparq:auth>` graphs are stripped at load.
+  CTH-over-HTTP (no HTTP surface here) — see `research/sparq-solid-scope.md` §4.
+- **In-repo differential oracle** (`tests/differential_oracle.rs`) runs the shared corpus through
+  THREE deciders — the engine (N3 rules), an **independent procedural reference evaluator**
+  (`tests/reference/`, a *different paradigm*, no shared code) and the hand `Expect` table — and
+  asserts **zero divergence** (fail-closed). A correctness oracle, **not** a security audit.
+- **Security posture — fail-closed.** Absence of a grant makes a graph **invisible**. The reasoner
+  is fed only ACL/ACR + structural facts — **never pod content** — so no writable document can
+  grant itself access; the reserved `urn:sparq:` namespace is rejected on input and forged
+  `<urn:sparq:auth>` graphs are stripped at load.
 - **`ldp:contains` is PSS-written, not sparq-derived** — stored as opaque content, **never** derived
   from IRI structure, mutated on a write, or read into the reasoner. Containment *ancestry* is derived
-  structurally only to drive ACL inheritance; pinned by `tests/containment_view_ownership.rs`.
+  structurally only to drive ACL inheritance (pinned by `tests/containment_view_ownership.rs`).
 
 ## 📚 Learn more
 
 - **How-to** — [`skills/access-control/SKILL.md`](../../skills/access-control/SKILL.md) (public
-  API, WAC/ACP capability notes, conformance harnesses, the full ODRL-bridge mapping detail).
-- **Design + threat model + measured baseline** —
-  [`research/solid-access-control-design.md`](../../research/solid-access-control-design.md) (storage
-  model, support matrix, strata, security boundaries) and the scope decisions in
-  [`research/sparq-solid-scope.md`](../../research/sparq-solid-scope.md).
-- **API reference** — [docs.rs/sparq-solid](https://docs.rs/sparq-solid); runnable walk-through
+  API, WAC/ACP notes, conformance harnesses + the differential oracle, ODRL-bridge mapping detail).
+- **Design + threat model** —
+  [`research/solid-access-control-design.md`](../../research/solid-access-control-design.md) (model,
+  matrix, strata, boundaries) + scope [`research/sparq-solid-scope.md`](../../research/sparq-solid-scope.md).
+- **API reference** — [docs.rs/sparq-solid](https://docs.rs/sparq-solid); walk-through
   `cargo run -p sparq-solid --example quickstart --release`.
-- **Performance** — not baked into docs; the two query paths are measured side by side via
-  `cargo run -p sparq-solid --example bench --release` and on the
+- **Performance** — not baked into docs; the two query paths are measured via
+  `cargo run -p sparq-solid --example bench --release` + the
   [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench).
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md), [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 

--- a/crates/sparq-solid/src/conformance.rs
+++ b/crates/sparq-solid/src/conformance.rs
@@ -521,6 +521,23 @@ impl AcpScenario {
         &self.name
     }
 
+    /// The scenario's accumulated N-Quads corpus (its `.acr` graphs + document
+    /// placeholders). [OPUS-4.8] sq-t58w.7 — exposed read-only so a SECOND consumer (the
+    /// differential oracle, `tests/differential_oracle.rs`) can feed the IDENTICAL RDF to
+    /// an **independent** procedural ACP evaluator without re-emitting it. This is the raw
+    /// input the engine's [`AcpScenario::run`] loads via `Graph::load_dataset`; a
+    /// different-paradigm reference reader parses the same bytes by hand.
+    pub fn nquads_str(&self) -> &str {
+        &self.nquads
+    }
+
+    /// The scenario's expected `(agent, client, mode, resource) → decision` table.
+    /// [OPUS-4.8] sq-t58w.7 — exposed read-only so the differential oracle can use the hand
+    /// table as a THIRD decider alongside the engine and the reference evaluator.
+    pub fn expects(&self) -> &[Expect] {
+        &self.expects
+    }
+
     /// Materialize the scenario's ACP corpus and check every expected decision against
     /// the engine's verdict, returning a [`ScenarioReport`].
     ///

--- a/crates/sparq-solid/src/wac_conformance.rs
+++ b/crates/sparq-solid/src/wac_conformance.rs
@@ -371,6 +371,23 @@ impl WacScenario {
         &self.name
     }
 
+    /// The scenario's accumulated N-Quads corpus (its `.acl` graphs + document
+    /// placeholders). [OPUS-4.8] sq-t58w.7 — exposed read-only so a SECOND consumer (the
+    /// differential oracle, `tests/differential_oracle.rs`) can feed the IDENTICAL RDF to
+    /// an **independent** procedural WAC evaluator without re-emitting it. This is the raw
+    /// input the engine's [`WacScenario::run`] loads via `Graph::load_dataset`; a
+    /// different-paradigm reference reader parses the same bytes by hand.
+    pub fn nquads_str(&self) -> &str {
+        &self.nquads
+    }
+
+    /// The scenario's expected `(agent, client, mode, resource) → decision` table.
+    /// [OPUS-4.8] sq-t58w.7 — exposed read-only so the differential oracle can use the hand
+    /// table as a THIRD decider alongside the engine and the reference evaluator.
+    pub fn expects(&self) -> &[Expect] {
+        &self.expects
+    }
+
     /// Materialize the scenario's WAC corpus and check every expected decision against the
     /// engine's verdict, returning a [`ScenarioReport`].
     ///

--- a/crates/sparq-solid/tests/differential_oracle.rs
+++ b/crates/sparq-solid/tests/differential_oracle.rs
@@ -1,0 +1,331 @@
+//! [OPUS-4.8] sq-t58w.7 — THE differential oracle: a three-way agreement check proving the
+//! engine's WAC/ACP authorization decisions match an INDEPENDENT reference evaluator AND the
+//! hand-written `Expect` decision table, with **zero divergence**.
+//!
+//! Design record: `research/solid-acp-differential-oracle-design.md` §3-4. The oracle runs
+//! the SHARED parity corpus (`tests/common/{wac,acp}.rs` from sq-t58w.6 — `wac_corpus()` /
+//! `acp_corpus()`, the IDENTICAL scenarios `conformance_{wac,acp}.rs` assert) through THREE
+//! deciders for every `(agent, client, mode, resource)` request in every scenario's table:
+//!
+//! 1. **the engine** — `materialize_{wac,acp}` + [`AuthIndex::accessible`] (the N3-rules
+//!    paradigm), exactly as the conformance suites drive it;
+//! 2. **the reference evaluator** — `tests/reference/{wac,acp}.rs`, a from-scratch
+//!    PROCEDURAL reading of the spec over a hand-parsed model (a DIFFERENT paradigm — it
+//!    shares no code with `materialize.rs`/`rules/*.n3`, so a shared bug cannot hide in
+//!    both);
+//! 3. **the hand `Expect` table** — the human-authored expected decision baked into each
+//!    corpus scenario.
+//!
+//! A **divergence** is recorded whenever any two of the three disagree on a request. An
+//! unclassifiable or erroring request (a corpus that fails to load/materialize, or a
+//! reference parse failure) is itself counted as a divergence — **fail-closed**. The oracle
+//! asserts `divergences == 0` and prints, in the SHACL/geo runner shape:
+//!
+//! ```text
+//! WAC differential pairs <N> / divergences 0 (floor 0)
+//! ACP differential pairs <N> / divergences 0 (floor 0)
+//! ```
+//!
+//! so a later CI ratchet (`sq-t58w.3`) can grep it. Constraints honoured: no JS toolchain,
+//! no network, no clock, no Docker — pure in-crate Rust.
+
+mod common;
+mod reference;
+
+use common::{acp_corpus, wac_corpus};
+use reference::{RefDecision, RefMode};
+use sparq_core::Graph;
+use sparq_solid::conformance::{AcpScenario, Decision, Expect};
+use sparq_solid::wac_conformance::WacScenario;
+use sparq_solid::{materialize_acp, materialize_wac, AuthIndex, Mode, Session};
+
+/// The floor for the divergence count — it is and must stay ZERO. A ratchet that only ever
+/// goes UP would be meaningless for a divergence count (the only acceptable value is 0), so
+/// the "floor" printed for grep-parity with the SHACL/geo runners is the hard 0.
+const DIVERGENCE_FLOOR: usize = 0;
+
+/// Map the engine's [`Mode`] to the reference evaluator's independent [`RefMode`].
+fn ref_mode(mode: Mode) -> RefMode {
+    match mode {
+        Mode::Read => RefMode::Read,
+        Mode::Write => RefMode::Write,
+        Mode::Append => RefMode::Append,
+        Mode::Control => RefMode::Control,
+    }
+}
+
+/// Map a reference [`RefDecision`] to the shared [`Decision`] vocabulary so all three
+/// deciders are compared in one type.
+fn from_ref(d: RefDecision) -> Decision {
+    match d {
+        RefDecision::Allow => Decision::Allow,
+        RefDecision::Deny => Decision::Deny,
+    }
+}
+
+/// The engine's verdict for one request over a materialized graph (the exact path
+/// `WacScenario::run`/`AcpScenario::run` use): the resource is in the session's accessible
+/// set for the mode ⇒ Allow.
+fn engine_decide(index: &AuthIndex, e: &Expect) -> Decision {
+    let session = Session {
+        agent: e.req_agent(),
+        client: e.req_client(),
+        issuer: None,
+        now: None,
+    };
+    let granted = index
+        .accessible(&session, e.req_mode())
+        .iter()
+        .any(|g| g.as_str() == e.req_resource());
+    if granted {
+        Decision::Allow
+    } else {
+        Decision::Deny
+    }
+}
+
+/// One recorded divergence: which scenario + request, and the three deciders' verdicts (an
+/// `Err` string when a decider could not classify the request — counted fail-closed).
+#[derive(Debug)]
+struct Divergence {
+    scenario: String,
+    request: String,
+    engine: Result<Decision, String>,
+    reference: Result<Decision, String>,
+    expect: Decision,
+}
+
+impl std::fmt::Display for Divergence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let show = |r: &Result<Decision, String>| match r {
+            Ok(d) => d.to_string(),
+            Err(e) => format!("ERROR({e})"),
+        };
+        write!(
+            f,
+            "  DIVERGENCE [{}] {}: engine={}, reference={}, expect={}",
+            self.scenario,
+            self.request,
+            show(&self.engine),
+            show(&self.reference),
+            self.expect,
+        )
+    }
+}
+
+/// Render an `Expect` request for the divergence report.
+fn request_label(e: &Expect) -> String {
+    let who = match (e.req_agent(), e.req_client()) {
+        (Some(a), Some(c)) => format!("(agent {}, client {})", a, c),
+        (Some(a), None) => format!("agent {}", a),
+        (None, _) => "anonymous".to_owned(),
+    };
+    format!("{} {:?} {}", who, e.req_mode(), e.req_resource())
+}
+
+/// Compare three deciders for one request and, if they do not all agree, return a recorded
+/// [`Divergence`]. An `Err` from either real decider is a divergence on its own (fail-closed).
+fn check_request(
+    scenario: &str,
+    e: &Expect,
+    engine: Result<Decision, String>,
+    reference: Result<Decision, String>,
+) -> Option<Divergence> {
+    let expect = e.decision();
+    let agree = matches!((&engine, &reference), (Ok(en), Ok(rf)) if *en == expect && *rf == expect);
+    if agree {
+        None
+    } else {
+        Some(Divergence {
+            scenario: scenario.to_owned(),
+            request: request_label(e),
+            engine,
+            reference,
+            expect,
+        })
+    }
+}
+
+/// Run the WAC corpus through the three deciders. Returns `(pairs, divergences)`.
+fn run_wac(scenarios: &[WacScenario]) -> (usize, Vec<Divergence>) {
+    let mut pairs = 0usize;
+    let mut divergences = Vec::new();
+    for scenario in scenarios {
+        // Decider 1: the engine. Materialize ONCE per scenario (the conformance path).
+        let engine_index = materialize_wac_index(scenario.nquads_str());
+        for e in scenario.expects() {
+            pairs += 1;
+            let engine = engine_index
+                .as_ref()
+                .map(|ix| engine_decide(ix, e))
+                .map_err(|err| err.clone());
+            // Decider 2: the independent reference evaluator (fresh parse per request keeps
+            // it dependency-free of the engine state; cheap on this corpus).
+            let reference = reference::wac::decide(
+                scenario.nquads_str(),
+                &reference::wac::Request {
+                    agent: e.req_agent(),
+                    client: e.req_client(),
+                    mode: ref_mode(e.req_mode()),
+                    resource: e.req_resource(),
+                },
+            )
+            .map(from_ref);
+            if let Some(d) = check_request(scenario.name(), e, engine, reference) {
+                divergences.push(d);
+            }
+        }
+    }
+    (pairs, divergences)
+}
+
+/// Run the ACP corpus through the three deciders. Returns `(pairs, divergences)`.
+fn run_acp(scenarios: &[AcpScenario]) -> (usize, Vec<Divergence>) {
+    let mut pairs = 0usize;
+    let mut divergences = Vec::new();
+    for scenario in scenarios {
+        let engine_index = materialize_acp_index(scenario.nquads_str());
+        for e in scenario.expects() {
+            pairs += 1;
+            let engine = engine_index
+                .as_ref()
+                .map(|ix| engine_decide(ix, e))
+                .map_err(|err| err.clone());
+            let reference = reference::acp::decide(
+                scenario.nquads_str(),
+                &reference::acp::Request {
+                    agent: e.req_agent(),
+                    client: e.req_client(),
+                    mode: ref_mode(e.req_mode()),
+                    resource: e.req_resource(),
+                },
+            )
+            .map(from_ref);
+            if let Some(d) = check_request(scenario.name(), e, engine, reference) {
+                divergences.push(d);
+            }
+        }
+    }
+    (pairs, divergences)
+}
+
+/// Materialize the WAC engine's auth index for a scenario's N-Quads (the engine decider's
+/// setup). An `Err` here makes every request in the scenario diverge (fail-closed).
+fn materialize_wac_index(nquads: &str) -> Result<AuthIndex, String> {
+    let mut graph = Graph::load_dataset(nquads, "nquads").map_err(|e| format!("load: {}", e))?;
+    materialize_wac(&mut graph).map_err(|e| format!("materialize_wac: {}", e))?;
+    Ok(AuthIndex::from_graph(&graph))
+}
+
+/// Materialize the ACP engine's auth index for a scenario's N-Quads.
+fn materialize_acp_index(nquads: &str) -> Result<AuthIndex, String> {
+    let mut graph = Graph::load_dataset(nquads, "nquads").map_err(|e| format!("load: {}", e))?;
+    materialize_acp(&mut graph).map_err(|e| format!("materialize_acp: {}", e))?;
+    Ok(AuthIndex::from_graph(&graph))
+}
+
+#[test]
+fn wac_differential_oracle_zero_divergence() {
+    let scenarios = wac_corpus();
+    let (pairs, divergences) = run_wac(&scenarios);
+
+    // The runner-shape summary line (grep-parity with SHACL/geo + the
+    // `WAC scenarios pass …` conformance line) so the sq-t58w.3 ratchet can re-check it.
+    println!(
+        "WAC differential pairs {} / divergences {} (floor {})",
+        pairs,
+        divergences.len(),
+        DIVERGENCE_FLOOR
+    );
+
+    // Guard against a corpus that silently checks nothing: the floor is the same 12
+    // scenarios × multiple requests the conformance suite asserts.
+    assert_eq!(
+        scenarios.len(),
+        common::WAC_SCENARIO_FLOOR,
+        "expected the pinned WAC corpus"
+    );
+    assert!(
+        pairs >= 40,
+        "expected a substantive WAC request table, got {}",
+        pairs
+    );
+
+    if !divergences.is_empty() {
+        let report: String = divergences.iter().map(|d| format!("{}\n", d)).collect();
+        panic!(
+            "WAC differential oracle found {} divergence(s) across {} pairs (floor {}):\n{}",
+            divergences.len(),
+            pairs,
+            DIVERGENCE_FLOOR,
+            report
+        );
+    }
+}
+
+#[test]
+fn acp_differential_oracle_zero_divergence() {
+    let scenarios = acp_corpus();
+    let (pairs, divergences) = run_acp(&scenarios);
+
+    println!(
+        "ACP differential pairs {} / divergences {} (floor {})",
+        pairs,
+        divergences.len(),
+        DIVERGENCE_FLOOR
+    );
+
+    assert_eq!(
+        scenarios.len(),
+        common::ACP_SCENARIO_FLOOR,
+        "expected the pinned ACP corpus"
+    );
+    assert!(
+        pairs >= 35,
+        "expected a substantive ACP request table, got {}",
+        pairs
+    );
+
+    if !divergences.is_empty() {
+        let report: String = divergences.iter().map(|d| format!("{}\n", d)).collect();
+        panic!(
+            "ACP differential oracle found {} divergence(s) across {} pairs (floor {}):\n{}",
+            divergences.len(),
+            pairs,
+            DIVERGENCE_FLOOR,
+            report
+        );
+    }
+}
+
+/// A NEGATIVE control: the three-way checker MUST flag a disagreement when one decider is
+/// wrong. This proves the oracle actually compares (it would be worthless if `check_request`
+/// silently passed). It does not assert any real decider is wrong — it feeds a synthetic
+/// disagreeing verdict and asserts a divergence is recorded.
+#[test]
+fn oracle_flags_a_synthetic_disagreement() {
+    let doc = "https://pod.example/neg/d1";
+    let e = Expect::agent("https://bob.example/card#me")
+        .read(doc)
+        .is(Decision::Deny);
+    // engine says Allow but expect says Deny → must be a divergence.
+    let d = check_request("synthetic", &e, Ok(Decision::Allow), Ok(Decision::Deny));
+    assert!(d.is_some(), "oracle must flag engine≠expect");
+
+    // An Err from a decider is itself a divergence (fail-closed on an unclassifiable request).
+    let d2 = check_request("synthetic", &e, Err("boom".to_owned()), Ok(Decision::Deny));
+    assert!(
+        d2.is_some(),
+        "oracle must count an erroring decider as a divergence"
+    );
+
+    // All three agreeing → no divergence.
+    let agree = Expect::agent("https://bob.example/card#me")
+        .read(doc)
+        .is(Decision::Deny);
+    let none = check_request("synthetic", &agree, Ok(Decision::Deny), Ok(Decision::Deny));
+    assert!(
+        none.is_none(),
+        "full agreement must not record a divergence"
+    );
+}

--- a/crates/sparq-solid/tests/reference/acp.rs
+++ b/crates/sparq-solid/tests/reference/acp.rs
@@ -1,0 +1,431 @@
+//! [OPUS-4.8] sq-t58w.7 — the **independent procedural ACP reference evaluator**.
+//!
+//! A from-scratch, hand-written reading of Solid Access Control Policy
+//! (<https://solidproject.org/TR/acp>) over the parsed N-Quad model — the second paradigm
+//! the differential oracle diffs against the engine's N3-rules decider. It implements,
+//! procedurally:
+//!
+//! - **Matchers.** `acp:anyOf` (disjunction — at least one matches), `acp:allOf`
+//!   (conjunction — all match), `acp:noneOf` (the "except" carve-out — none may match). A
+//!   matcher with both `acp:agent` and `acp:client` requires BOTH dimensions; the special
+//!   agents `acp:PublicAgent` (every requestor) and `acp:AuthenticatedAgent` (any
+//!   authenticated requestor) are recognised.
+//! - **Policies, allow/deny + deny-overrides.** A satisfied policy contributes its
+//!   `acp:allow` modes as grants and its `acp:deny` modes as denials; deny overrides allow
+//!   for the same (request, mode, resource).
+//! - **Cumulative inheritance.** `acp:accessControl` applies to the resource itself;
+//!   `acp:memberAccessControl` applies to members (IRI-structural descendants), accruing
+//!   from EVERY ancestor (the ACP difference from WAC's nearest-wins shadowing).
+//! - **Fail-closed.** A resource with no applicable, satisfied allow policy is denied.
+//!
+//! This code shares NO logic with `materialize.rs` / `rules/*.n3`: the policy-satisfaction
+//! and inheritance logic is written by hand over a plain model parsed by the independent
+//! N-Quad reader.
+
+use super::{
+    ancestors_nearest_first, is_structural_descendant, parse_nquads, Obj, Quad, RefDecision,
+    RefMode,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+const ACP: &str = "http://www.w3.org/ns/solid/acp#";
+const ACL: &str = "http://www.w3.org/ns/auth/acl#";
+const PUBLIC_AGENT: &str = "http://www.w3.org/ns/solid/acp#PublicAgent";
+const AUTHENTICATED_AGENT: &str = "http://www.w3.org/ns/solid/acp#AuthenticatedAgent";
+const ACR_SUFFIX: &str = ".acr";
+
+/// A request the reference evaluator decides (the ACP twin of the WAC one).
+#[derive(Debug, Clone)]
+pub struct Request<'a> {
+    pub agent: Option<&'a str>,
+    pub client: Option<&'a str>,
+    pub mode: RefMode,
+    pub resource: &'a str,
+}
+
+/// One matcher: its `acp:agent` and `acp:client` accept-sets. A matcher with an agent set
+/// constrains the agent dimension; with a client set, the client dimension; with both, both.
+#[derive(Debug, Default, Clone)]
+struct Matcher {
+    agents: BTreeSet<String>,
+    clients: BTreeSet<String>,
+}
+
+impl Matcher {
+    fn is_empty(&self) -> bool {
+        self.agents.is_empty() && self.clients.is_empty()
+    }
+
+    /// Does this matcher match the request? A constrained dimension must be satisfied; an
+    /// unconstrained one (empty set) imposes no requirement on that dimension.
+    fn matches(&self, req: &Request) -> bool {
+        let agent_ok = if self.agents.is_empty() {
+            true
+        } else {
+            self.agents.iter().any(|a| Self::agent_matches(a, req))
+        };
+        let client_ok = if self.clients.is_empty() {
+            true
+        } else {
+            req.client.is_some_and(|c| self.clients.contains(c))
+        };
+        // A matcher with no attributes at all matches nothing (fail-closed).
+        agent_ok && client_ok && !self.is_empty()
+    }
+
+    fn agent_matches(spec: &str, req: &Request) -> bool {
+        match spec {
+            PUBLIC_AGENT => true,
+            AUTHENTICATED_AGENT => req.agent.is_some(),
+            concrete => req.agent == Some(concrete),
+        }
+    }
+}
+
+/// One policy: its allow/deny mode sets and its `allOf`/`anyOf`/`noneOf` matcher lists.
+#[derive(Debug, Default, Clone)]
+struct Policy {
+    allow: BTreeSet<String>, // acl: mode IRIs
+    deny: BTreeSet<String>,
+    all_of: Vec<String>, // matcher IRIs
+    any_of: Vec<String>,
+    none_of: Vec<String>,
+}
+
+/// One access control: whether it is member-scoped, and the policies it applies.
+#[derive(Debug, Default, Clone)]
+struct AccessControl {
+    /// `true` for `acp:memberAccessControl` (applies to descendants), `false` for
+    /// `acp:accessControl` (applies to the resource itself).
+    member: bool,
+    policies: Vec<String>, // policy IRIs
+}
+
+/// The independent ACP model assembled from the corpus N-Quads.
+#[derive(Debug, Default)]
+pub struct AcpModel {
+    /// resource IRI → its access controls (from `acp:resource` + `acp:accessControl` /
+    /// `acp:memberAccessControl`).
+    controls_by_resource: BTreeMap<String, Vec<AccessControl>>,
+    policies: BTreeMap<String, Policy>,
+    matchers: BTreeMap<String, Matcher>,
+    /// Every concrete protected resource graph present (so containment anchors are known).
+    resources: BTreeSet<String>,
+}
+
+impl AcpModel {
+    /// Parse a scenario's raw N-Quads into the independent ACP model (no engine code).
+    ///
+    /// # Errors
+    ///
+    /// Propagates a parse failure from [`parse_nquads`] (fail-closed at the oracle).
+    pub fn from_nquads(src: &str) -> Result<AcpModel, String> {
+        let quads = parse_nquads(src)?;
+        Ok(Self::from_quads(&quads))
+    }
+
+    fn from_quads(quads: &[Quad]) -> AcpModel {
+        let mut model = AcpModel::default();
+        // ACR-graph → (resource it binds); a control node carries its scope (member?) and
+        // its applied policies. We resolve these in two passes since N-Quads are unordered.
+        let mut acr_resource: BTreeMap<String, String> = BTreeMap::new(); // acr graph → resource
+                                                                          // control IRI → (member?, policies); built directly into model.controls below.
+        let mut control_member: BTreeMap<String, bool> = BTreeMap::new();
+        let mut control_policies: BTreeMap<String, Vec<String>> = BTreeMap::new();
+        let mut control_graph: BTreeMap<String, String> = BTreeMap::new(); // control IRI → acr graph
+
+        for q in quads {
+            let g = q.graph.as_str();
+            if g.ends_with(ACR_SUFFIX) {
+                self_absorb_acr(
+                    q,
+                    &mut acr_resource,
+                    &mut control_member,
+                    &mut control_policies,
+                    &mut control_graph,
+                    &mut model,
+                );
+            } else {
+                // A non-control graph: any triple marks it a concrete resource.
+                model.resources.insert(g.to_owned());
+            }
+        }
+
+        // Stitch controls onto their bound resource. A control in ACR graph `acr` applies to
+        // the resource `acr_resource[acr]`.
+        for (control, member) in &control_member {
+            let Some(acr) = control_graph.get(control) else {
+                continue;
+            };
+            let Some(resource) = acr_resource.get(acr) else {
+                continue;
+            };
+            let policies = control_policies.get(control).cloned().unwrap_or_default();
+            model
+                .controls_by_resource
+                .entry(resource.clone())
+                .or_default()
+                .push(AccessControl {
+                    member: *member,
+                    policies,
+                });
+            // The bound resource is itself a known resource / inheritance anchor.
+            model.resources.insert(resource.clone());
+        }
+
+        // Containers are inheritance anchors even without their own graph: add structural
+        // prefixes of every known resource.
+        let seeds: Vec<String> = model.resources.iter().cloned().collect();
+        for r in seeds {
+            for anc in ancestors_nearest_first(&r) {
+                model.resources.insert(anc);
+            }
+        }
+
+        model
+    }
+
+    /// Decide a request, procedurally, per the ACP spec (deny-overrides over the cumulative
+    /// applicable policy set).
+    pub fn decide(&self, req: &Request) -> RefDecision {
+        let mut any_allow = false;
+        let mut any_deny = false;
+
+        for (resource, controls) in &self.controls_by_resource {
+            for ctl in controls {
+                // Does this control apply to `req.resource`?
+                let applies = if ctl.member {
+                    // memberAccessControl: applies to the resource's members (descendants).
+                    is_structural_descendant(resource, req.resource)
+                } else {
+                    // accessControl: applies to the resource itself.
+                    resource == req.resource
+                };
+                if !applies {
+                    continue;
+                }
+                for pol_iri in &ctl.policies {
+                    let Some(pol) = self.policies.get(pol_iri) else {
+                        continue;
+                    };
+                    if !self.policy_satisfied(pol, req) {
+                        continue;
+                    }
+                    if Self::policy_has_mode(&pol.allow, req.mode) {
+                        any_allow = true;
+                    }
+                    if Self::policy_has_mode(&pol.deny, req.mode) {
+                        any_deny = true;
+                    }
+                }
+            }
+        }
+
+        // Deny overrides allow; an absent allow is fail-closed.
+        if any_deny || !any_allow {
+            RefDecision::Deny
+        } else {
+            RefDecision::Allow
+        }
+    }
+
+    /// Is `policy` satisfied for `req`? Every `allOf` matcher matches AND (no `anyOf`, or at
+    /// least one `anyOf` matches) AND no `noneOf` matcher matches.
+    fn policy_satisfied(&self, pol: &Policy, req: &Request) -> bool {
+        let all_of_ok = pol
+            .all_of
+            .iter()
+            .all(|m| self.matcher(m).is_some_and(|mat| mat.matches(req)));
+        if !all_of_ok {
+            return false;
+        }
+        let any_of_ok = pol.any_of.is_empty()
+            || pol
+                .any_of
+                .iter()
+                .any(|m| self.matcher(m).is_some_and(|mat| mat.matches(req)));
+        if !any_of_ok {
+            return false;
+        }
+        let none_of_blocks = pol
+            .none_of
+            .iter()
+            .any(|m| self.matcher(m).is_some_and(|mat| mat.matches(req)));
+        !none_of_blocks
+    }
+
+    fn matcher(&self, iri: &str) -> Option<&Matcher> {
+        self.matchers.get(iri)
+    }
+
+    fn policy_has_mode(modes: &BTreeSet<String>, mode: RefMode) -> bool {
+        modes
+            .iter()
+            .filter_map(|m| RefMode::from_acl_iri(m))
+            .any(|m| m == mode)
+    }
+}
+
+/// Absorb one ACR-graph triple into the in-progress model + scratch maps. A free function
+/// (not a method) so it can take disjoint `&mut` borrows of the scratch maps + model.
+fn self_absorb_acr(
+    q: &Quad,
+    acr_resource: &mut BTreeMap<String, String>,
+    control_member: &mut BTreeMap<String, bool>,
+    control_policies: &mut BTreeMap<String, Vec<String>>,
+    control_graph: &mut BTreeMap<String, String>,
+    model: &mut AcpModel,
+) {
+    let g = q.graph.clone();
+    let local = match q.predicate.strip_prefix(ACP) {
+        Some(l) => l,
+        None => {
+            // An `acp:allow`/`acp:deny` predicate is in ACP space; modes are acl: IRIs in
+            // the object, predicate in acp:. Anything else (e.g. a stray triple) is ignored.
+            return;
+        }
+    };
+    match (local, &q.object) {
+        ("resource", Obj::Iri(o)) => {
+            acr_resource.insert(g, o.clone());
+        }
+        ("accessControl", Obj::Iri(ctl)) => {
+            control_member.insert(ctl.clone(), false);
+            control_graph.insert(ctl.clone(), g);
+        }
+        ("memberAccessControl", Obj::Iri(ctl)) => {
+            control_member.insert(ctl.clone(), true);
+            control_graph.insert(ctl.clone(), g);
+        }
+        ("apply", Obj::Iri(pol)) => {
+            control_policies
+                .entry(q.subject.clone())
+                .or_default()
+                .push(pol.clone());
+        }
+        ("allow", Obj::Iri(mode)) => {
+            model
+                .policies
+                .entry(q.subject.clone())
+                .or_default()
+                .allow
+                .insert(mode.clone());
+        }
+        ("deny", Obj::Iri(mode)) => {
+            model
+                .policies
+                .entry(q.subject.clone())
+                .or_default()
+                .deny
+                .insert(mode.clone());
+        }
+        ("allOf", Obj::Iri(m)) => {
+            model
+                .policies
+                .entry(q.subject.clone())
+                .or_default()
+                .all_of
+                .push(m.clone());
+        }
+        ("anyOf", Obj::Iri(m)) => {
+            model
+                .policies
+                .entry(q.subject.clone())
+                .or_default()
+                .any_of
+                .push(m.clone());
+        }
+        ("noneOf", Obj::Iri(m)) => {
+            model
+                .policies
+                .entry(q.subject.clone())
+                .or_default()
+                .none_of
+                .push(m.clone());
+        }
+        ("agent", Obj::Iri(o)) => {
+            model
+                .matchers
+                .entry(q.subject.clone())
+                .or_default()
+                .agents
+                .insert(o.clone());
+        }
+        ("client", Obj::Iri(o)) => {
+            model
+                .matchers
+                .entry(q.subject.clone())
+                .or_default()
+                .clients
+                .insert(o.clone());
+        }
+        _ => {}
+    }
+    // The acl: mode constant on allow/deny is handled by the object branch above; the ACL
+    // namespace itself is never a predicate in an ACR graph here.
+    let _ = ACL;
+}
+
+/// Decide one request against a freshly-parsed model for `nquads` (per-call convenience).
+///
+/// # Errors
+///
+/// Propagates a corpus parse failure (fail-closed at the oracle).
+pub fn decide(nquads: &str, req: &Request) -> Result<RefDecision, String> {
+    Ok(AcpModel::from_nquads(nquads)?.decide(req))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req<'a>(
+        agent: Option<&'a str>,
+        client: Option<&'a str>,
+        mode: RefMode,
+        resource: &'a str,
+    ) -> Request<'a> {
+        Request {
+            agent,
+            client,
+            mode,
+            resource,
+        }
+    }
+
+    #[test]
+    fn agent_anyof_grants_only_named() {
+        let n = "\
+<https://pod.ex/d1.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.ex/d1> <https://pod.ex/d1.acr> .
+<https://pod.ex/d1.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.ex/d1.acr#ctl0> <https://pod.ex/d1.acr> .
+<https://pod.ex/d1.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.ex/d1.acr#pol0> <https://pod.ex/d1.acr> .
+<https://pod.ex/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/d1.acr> .
+<https://pod.ex/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.ex/d1.acr#m0> <https://pod.ex/d1.acr> .
+<https://pod.ex/d1.acr#m0> <http://www.w3.org/ns/solid/acp#agent> <https://alice.ex/#me> <https://pod.ex/d1.acr> .
+<https://pod.ex/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.ex/d1> .
+";
+        let m = AcpModel::from_nquads(n).unwrap();
+        assert_eq!(
+            m.decide(&req(
+                Some("https://alice.ex/#me"),
+                None,
+                RefMode::Read,
+                "https://pod.ex/d1"
+            )),
+            RefDecision::Allow
+        );
+        assert_eq!(
+            m.decide(&req(
+                Some("https://bob.ex/#me"),
+                None,
+                RefMode::Read,
+                "https://pod.ex/d1"
+            )),
+            RefDecision::Deny
+        );
+        assert_eq!(
+            m.decide(&req(None, None, RefMode::Read, "https://pod.ex/d1")),
+            RefDecision::Deny
+        );
+    }
+}

--- a/crates/sparq-solid/tests/reference/mod.rs
+++ b/crates/sparq-solid/tests/reference/mod.rs
@@ -1,0 +1,268 @@
+//! [OPUS-4.8] sq-t58w.7 — an **independent reference evaluator** for Solid WAC + ACP.
+//!
+//! This module is the second paradigm in the differential oracle
+//! (`tests/differential_oracle.rs`, design record `research/solid-acp-differential-oracle-design.md`
+//! §3-4). The engine ([`sparq_solid::materialize_wac`]/[`materialize_acp`] +
+//! [`sparq_solid::AuthIndex::accessible`]) decides authorization by running **N3 rules**
+//! (`rules/*.n3`) through `sparq-reason` over a dictionary-encoded `Graph`. This module
+//! decides the SAME `(agent, client, mode, resource) → allow | deny` question by a
+//! **completely different mechanism**: a hand-written, procedural reading of the spec over
+//! a plain in-memory model, parsed by a tiny independent N-Quad reader.
+//!
+//! The whole value of this code is being a DIFFERENT implementation: it deliberately shares
+//! **nothing** with the engine's decision path —
+//!
+//! - it does NOT call `materialize.rs`, `loader.rs`, `assemble_input`, `parent_iri`, or any
+//!   `rules/*.n3` (a shared bug in those cannot hide in both deciders);
+//! - it does NOT use `Graph::load_dataset` / `sparq-core` to parse the corpus — it parses
+//!   the raw N-Quads the builders emit with its own line reader ([`parse_nquads`]);
+//! - it re-derives containment ancestry, nearest-ACL resolution (WAC) vs. cumulative
+//!   inheritance (ACP), the matcher logic, and deny-overrides from scratch.
+//!
+//! It reads only the scenario corpus's `nquads_str()` (the IDENTICAL bytes the engine
+//! loads) and emits a [`RefDecision`]; the oracle then diffs the two deciders plus the
+//! hand `Expect` table and asserts zero divergence.
+//!
+//! Scope (honest): this is a CORRECTNESS oracle over the parity corpus, not a security
+//! audit and not a full WAC/ACP implementation — it implements exactly the constructs the
+//! corpus exercises (and fails closed on anything it does not recognise, which the oracle
+//! counts as a divergence).
+
+#![allow(dead_code)]
+
+pub mod acp;
+pub mod wac;
+
+/// The reference evaluator's verdict for one request. Mirrors
+/// [`sparq_solid::conformance::Decision`] but is a distinct type so the two paradigms never
+/// share a decision enum by accident.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefDecision {
+    /// The access mode is granted on the resource for the requestor.
+    Allow,
+    /// The access mode is refused (no matching grant, a deny overrides, or fail-closed).
+    Deny,
+}
+
+/// The four WAC/ACP access modes, named independently of the engine's `Mode` so the
+/// reference reader does not borrow the engine's enum.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefMode {
+    Read,
+    Write,
+    Append,
+    Control,
+}
+
+impl RefMode {
+    /// Parse an `acl:`-namespace mode IRI (`…#Read`/`Write`/`Append`/`Control`).
+    pub fn from_acl_iri(iri: &str) -> Option<RefMode> {
+        match iri {
+            "http://www.w3.org/ns/auth/acl#Read" => Some(RefMode::Read),
+            "http://www.w3.org/ns/auth/acl#Write" => Some(RefMode::Write),
+            "http://www.w3.org/ns/auth/acl#Append" => Some(RefMode::Append),
+            "http://www.w3.org/ns/auth/acl#Control" => Some(RefMode::Control),
+            _ => None,
+        }
+    }
+}
+
+/// A parsed N-Quad: subject/predicate IRIs, an object that is either an IRI or a literal,
+/// and the graph IRI. The reference reader only ever needs IRI subjects/predicates/graphs
+/// and distinguishes an IRI object from a literal one (document placeholders are literals).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Quad {
+    pub subject: String,
+    pub predicate: String,
+    pub object: Obj,
+    pub graph: String,
+}
+
+/// An N-Quad object: a named node (IRI) or a literal value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Obj {
+    Iri(String),
+    Literal(String),
+}
+
+impl Obj {
+    /// The IRI if this object is a named node, else `None`.
+    pub fn iri(&self) -> Option<&str> {
+        match self {
+            Obj::Iri(s) => Some(s),
+            Obj::Literal(_) => None,
+        }
+    }
+}
+
+/// A tiny, INDEPENDENT N-Quad line reader for exactly the shape the corpus builders emit:
+/// `<s> <p> <o> <g> .` per line, where `<o>` is either `<iri>` or a `"…"` literal (the
+/// document placeholders). It is deliberately NOT a general N-Quads parser and NOT
+/// `sparq-core`'s loader — its only job is to read back the bytes
+/// `AclBuilder`/`AcrBuilder` produced, by hand, so the reference decider shares no parsing
+/// code with the engine.
+///
+/// Lines that do not match the four-`<>`/literal-then-`.` shape are skipped (blank lines);
+/// a line that *looks* like a quad but fails to tokenize is returned as an error so the
+/// oracle fails closed rather than silently dropping an authorization.
+pub fn parse_nquads(src: &str) -> Result<Vec<Quad>, String> {
+    let mut out = Vec::new();
+    for (lineno, raw) in src.lines().enumerate() {
+        let line = raw.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let quad = parse_quad_line(line).ok_or_else(|| {
+            format!(
+                "reference n-quad parse failed at line {}: {:?}",
+                lineno + 1,
+                raw
+            )
+        })?;
+        out.push(quad);
+    }
+    Ok(out)
+}
+
+/// Parse one `<s> <p> <o> <g> .` line into a [`Quad`], or `None` if it does not match.
+fn parse_quad_line(line: &str) -> Option<Quad> {
+    // Must end with " ." (N-Triples/N-Quads statement terminator).
+    let body = line.strip_suffix('.')?.trim_end();
+    let mut rest = body;
+
+    let subject = take_iri(&mut rest)?;
+    let predicate = take_iri(&mut rest)?;
+    let object = take_obj(&mut rest)?;
+    let graph = take_iri(&mut rest)?;
+    // Nothing should remain after the graph token.
+    if !rest.trim().is_empty() {
+        return None;
+    }
+    Some(Quad {
+        subject,
+        predicate,
+        object,
+        graph,
+    })
+}
+
+/// Consume a leading `<iri>` token from `rest` (skipping leading whitespace), returning the
+/// IRI text and advancing `rest` past it.
+fn take_iri(rest: &mut &str) -> Option<String> {
+    let s = rest.trim_start();
+    let s = s.strip_prefix('<')?;
+    let end = s.find('>')?;
+    let iri = &s[..end];
+    *rest = &s[end + 1..];
+    Some(iri.to_owned())
+}
+
+/// Consume a leading object token — either `<iri>` or `"literal"` — from `rest`.
+fn take_obj(rest: &mut &str) -> Option<Obj> {
+    let s = rest.trim_start();
+    if s.starts_with('<') {
+        let iri = take_iri(rest)?;
+        Some(Obj::Iri(iri))
+    } else if let Some(after) = s.strip_prefix('"') {
+        // The corpus emits only simple `"x"` placeholder literals (no escapes, no
+        // datatype/lang). Read up to the closing quote.
+        let end = after.find('"')?;
+        let val = &after[..end];
+        *rest = &after[end + 1..];
+        Some(Obj::Literal(val.to_owned()))
+    } else {
+        None
+    }
+}
+
+/// The Solid slash-semantics parent container of an IRI, derived INDEPENDENTLY (this is the
+/// reference reader's own ancestry walk — it does not call the engine's
+/// `loader::parent_iri`). `None` at or above the authority root.
+///
+/// Rule: strip a trailing `/` (so a container is parented like its own path), then cut at
+/// the last `/` that is still in the path (after the `scheme://host` authority). A fragment
+/// or query is treated as part of the final path segment (the corpus never parents through
+/// one).
+pub fn parent_container(iri: &str) -> Option<String> {
+    let scheme_end = iri.find("://")? + 3;
+    let after_authority = iri.get(scheme_end..)?;
+    let first_slash = after_authority.find('/')?;
+    let host_end = scheme_end + first_slash; // index of the first '/' after the host
+                                             // Trim exactly one trailing slash so `…/c/` parents to `…/`, not to itself.
+    let trimmed = iri.strip_suffix('/').unwrap_or(iri);
+    if trimmed.len() <= host_end {
+        return None; // already the root container `scheme://host/`
+    }
+    let cut = trimmed.rfind('/')?;
+    if cut < host_end {
+        return None;
+    }
+    Some(iri[..cut + 1].to_owned())
+}
+
+/// All structural ancestors of `iri`, nearest-first (its parent container, then that
+/// container's parent, … up to the root). Excludes `iri` itself.
+pub fn ancestors_nearest_first(iri: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut cur = iri.to_owned();
+    while let Some(parent) = parent_container(&cur) {
+        out.push(parent.clone());
+        cur = parent;
+    }
+    out
+}
+
+/// Is `descendant` an IRI-structural descendant of `container`? (A container's own IRI is
+/// NOT a descendant of itself — `acl:default` / `acp:memberAccessControl` reach members,
+/// not the container resource.) Independent of any engine code.
+pub fn is_structural_descendant(container: &str, descendant: &str) -> bool {
+    container != descendant
+        && descendant.starts_with(container)
+        // The container IRI ends in `/` for a real container; require the descendant to be
+        // strictly under it (the prefix relation over a slash boundary). The corpus always
+        // names containers with a trailing slash, so a plain prefix check after the
+        // equality guard is the structural-descendant test.
+        && container.ends_with('/')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_a_simple_quad() {
+        let q =
+            parse_quad_line("<https://a/s> <https://a/p> <https://a/o> <https://a/g> .").unwrap();
+        assert_eq!(q.subject, "https://a/s");
+        assert_eq!(q.object, Obj::Iri("https://a/o".to_owned()));
+        assert_eq!(q.graph, "https://a/g");
+    }
+
+    #[test]
+    fn parses_a_literal_object() {
+        let q = parse_quad_line("<https://a/s#it> <https://ex.dev/ns#prop> \"x\" <https://a/s> .")
+            .unwrap();
+        assert_eq!(q.object, Obj::Literal("x".to_owned()));
+    }
+
+    #[test]
+    fn parent_and_descendants() {
+        assert_eq!(
+            parent_container("https://pod.ex/a/b/d1").as_deref(),
+            Some("https://pod.ex/a/b/")
+        );
+        assert_eq!(
+            parent_container("https://pod.ex/a/b/").as_deref(),
+            Some("https://pod.ex/a/")
+        );
+        assert_eq!(parent_container("https://pod.ex/"), None);
+        assert!(is_structural_descendant(
+            "https://pod.ex/c/",
+            "https://pod.ex/c/sub/d1"
+        ));
+        assert!(!is_structural_descendant(
+            "https://pod.ex/c/",
+            "https://pod.ex/c/"
+        ));
+    }
+}

--- a/crates/sparq-solid/tests/reference/wac.rs
+++ b/crates/sparq-solid/tests/reference/wac.rs
@@ -1,0 +1,373 @@
+//! [OPUS-4.8] sq-t58w.7 — the **independent procedural WAC reference evaluator**.
+//!
+//! A from-scratch, hand-written reading of Solid Web Access Control
+//! (<https://solidproject.org/TR/wac>) over the parsed N-Quad model — the second paradigm
+//! the differential oracle diffs against the engine's N3-rules decider. It implements,
+//! procedurally:
+//!
+//! - **ACL resolution (nearest-wins).** A resource `R`'s effective ACL is `R.acl` if it
+//!   exists, else the ACL of the **nearest** ancestor container — a closer ACL fully
+//!   SHADOWS the ones above it (the WAC difference from ACP's cumulative inheritance).
+//! - **`acl:accessTo` vs `acl:default`.** Within the effective ACL, `accessTo <R>`
+//!   authorizations apply to `R` itself (only when the ACL is `R`'s own); `default <C>`
+//!   authorizations apply to `C`'s members (its IRI-structural descendants), not to `C`.
+//! - **Access subjects.** `acl:agent` (a WebID), `acl:agentClass foaf:Agent` (public, every
+//!   requestor incl. anonymous), `acl:agentClass acl:AuthenticatedAgent` (any authenticated
+//!   requestor), `acl:agentGroup` via `vcard:hasMember` (every group member), and
+//!   `acl:origin` (the grant is a (user, application) pair — the agent matches only through
+//!   that client).
+//! - **The mode set.** `acl:Read`/`Write`/`Append`/`Control`, independent.
+//! - **Control governs the `.acl` document.** A `Control` grant on `R` is Read+Write on
+//!   `R.acl` (and Control on `R`), NOT read access to `R`.
+//! - **Fail-closed.** A resource with no applicable ACL grants nobody.
+//!
+//! WAC has no deny — access is the union of all applicable grants, narrowed only by the
+//! nearest-ACL resolution. This code shares NO logic with `materialize.rs` / `rules/*.n3`.
+
+use super::{
+    ancestors_nearest_first, is_structural_descendant, parse_nquads, Obj, Quad, RefDecision,
+    RefMode,
+};
+use std::collections::{BTreeMap, BTreeSet};
+
+const ACL: &str = "http://www.w3.org/ns/auth/acl#";
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const FOAF_AGENT: &str = "http://xmlns.com/foaf/0.1/Agent";
+const VCARD_MEMBER: &str = "http://www.w3.org/2006/vcard/ns#hasMember";
+const AUTHENTICATED_AGENT: &str = "http://www.w3.org/ns/auth/acl#AuthenticatedAgent";
+const ACL_SUFFIX: &str = ".acl";
+
+/// A request the reference evaluator decides: who (agent WebID, `None` = anonymous),
+/// through what client (`None` = no client presented), in which mode, on which resource.
+#[derive(Debug, Clone)]
+pub struct Request<'a> {
+    pub agent: Option<&'a str>,
+    pub client: Option<&'a str>,
+    pub mode: RefMode,
+    pub resource: &'a str,
+}
+
+/// One parsed `acl:Authorization`: its target sets (`accessTo`/`default`), access subjects,
+/// and modes. Independent of the engine's representation.
+#[derive(Debug, Default, Clone)]
+struct Authorization {
+    access_to: BTreeSet<String>,
+    default_for: BTreeSet<String>,
+    agents: BTreeSet<String>,
+    agent_classes: BTreeSet<String>,
+    agent_groups: BTreeSet<String>,
+    origins: BTreeSet<String>,
+    modes: BTreeSet<String>, // acl: mode IRIs
+}
+
+/// The independent WAC model assembled from the corpus N-Quads.
+#[derive(Debug, Default)]
+pub struct WacModel {
+    /// ACL graph IRI (`R.acl`) → the authorizations declared in it.
+    acls: BTreeMap<String, Vec<Authorization>>,
+    /// group IRI → its members (from `vcard:hasMember`).
+    groups: BTreeMap<String, BTreeSet<String>>,
+    /// Every concrete resource graph present (non-control, non-group document graphs),
+    /// PLUS every structural container prefix (containers exist as inheritance anchors).
+    resources: BTreeSet<String>,
+    /// The set of ACL graph IRIs that exist (so nearest-ACL resolution can test ancestors).
+    acl_graphs: BTreeSet<String>,
+}
+
+impl WacModel {
+    /// Parse a scenario's raw N-Quads into the independent WAC model (no engine code).
+    ///
+    /// # Errors
+    ///
+    /// Propagates a parse failure from [`parse_nquads`] (fail-closed at the oracle).
+    pub fn from_nquads(src: &str) -> Result<WacModel, String> {
+        let quads = parse_nquads(src)?;
+        Ok(Self::from_quads(&quads))
+    }
+
+    fn from_quads(quads: &[Quad]) -> WacModel {
+        let mut model = WacModel::default();
+        // Per-authorization scratch keyed by the authorization subject IRI within its graph.
+        let mut auth_scratch: BTreeMap<(String, String), Authorization> = BTreeMap::new();
+
+        // First pass: collect resources, ACL graphs, group docs, and per-auth attributes.
+        for q in quads {
+            let g = q.graph.as_str();
+            if g.ends_with(ACL_SUFFIX) {
+                model.acl_graphs.insert(g.to_owned());
+                Self::absorb_acl_triple(&mut auth_scratch, q);
+            } else {
+                // A non-control graph. It might be a resource (its document placeholder) or a
+                // group document (`vcard:hasMember`). Group membership lives in its own graph.
+                if q.predicate == VCARD_MEMBER {
+                    if let Obj::Iri(member) = &q.object {
+                        model
+                            .groups
+                            .entry(q.subject.clone())
+                            .or_default()
+                            .insert(member.clone());
+                    }
+                } else {
+                    // Any other triple in a non-control graph marks the graph as a resource.
+                    model.resources.insert(g.to_owned());
+                }
+            }
+        }
+
+        // Fold the per-auth scratch into the model, keyed by ACL graph.
+        for ((graph, _auth), authz) in auth_scratch {
+            model.acls.entry(graph).or_default().push(authz);
+        }
+
+        // Containers are inheritance anchors even without their own graph: add every
+        // structural prefix of a known resource (and of each ACL graph's governed resource).
+        let seeds: Vec<String> = model
+            .resources
+            .iter()
+            .cloned()
+            .chain(
+                model
+                    .acl_graphs
+                    .iter()
+                    .map(|a| a[..a.len() - ACL_SUFFIX.len()].to_owned()),
+            )
+            .collect();
+        for r in seeds {
+            for anc in ancestors_nearest_first(&r) {
+                model.resources.insert(anc);
+            }
+            model.resources.insert(r);
+        }
+
+        model
+    }
+
+    fn absorb_acl_triple(scratch: &mut BTreeMap<(String, String), Authorization>, q: &Quad) {
+        let key = (q.graph.clone(), q.subject.clone());
+        let local = match q.predicate.strip_prefix(ACL) {
+            Some(l) => l,
+            None => {
+                // rdf:type acl:Authorization — confirms this subject is an authorization,
+                // but carries no attribute. Touch the scratch entry so an empty auth still
+                // exists (harmless; it grants nobody).
+                if q.predicate == RDF_TYPE {
+                    scratch.entry(key).or_default();
+                }
+                return;
+            }
+        };
+        let entry = scratch.entry(key).or_default();
+        match (local, &q.object) {
+            ("accessTo", Obj::Iri(o)) => {
+                entry.access_to.insert(o.clone());
+            }
+            ("default", Obj::Iri(o)) => {
+                entry.default_for.insert(o.clone());
+            }
+            ("agent", Obj::Iri(o)) => {
+                entry.agents.insert(o.clone());
+            }
+            ("agentClass", Obj::Iri(o)) => {
+                entry.agent_classes.insert(o.clone());
+            }
+            ("agentGroup", Obj::Iri(o)) => {
+                entry.agent_groups.insert(o.clone());
+            }
+            ("origin", Obj::Iri(o)) => {
+                entry.origins.insert(o.clone());
+            }
+            ("mode", Obj::Iri(o)) => {
+                entry.modes.insert(o.clone());
+            }
+            _ => {}
+        }
+    }
+
+    /// Decide a request, procedurally, per the WAC spec. Returns
+    /// [`RefDecision::Allow`]/[`RefDecision::Deny`].
+    pub fn decide(&self, req: &Request) -> RefDecision {
+        // Control governs the resource's `.acl` document, not the resource. So a request on a
+        // graph that is itself an ACL document (`X.acl`) for Read/Write is granted iff the
+        // requestor holds Control on `X`. (Control on `X.acl` itself is not modelled by the
+        // corpus.)
+        if let Some(target) = req.resource.strip_suffix(ACL_SUFFIX) {
+            match req.mode {
+                RefMode::Read | RefMode::Write => {
+                    // Read/Write of the .acl ⇔ Control of the resource it governs.
+                    let control_req = Request {
+                        agent: req.agent,
+                        client: req.client,
+                        mode: RefMode::Control,
+                        resource: target,
+                    };
+                    return self.decide_resource(&control_req);
+                }
+                _ => {}
+            }
+        }
+        self.decide_resource(req)
+    }
+
+    /// Decide a request against the resource's effective (nearest) ACL.
+    fn decide_resource(&self, req: &Request) -> RefDecision {
+        let Some((acl_graph, is_own)) = self.effective_acl(req.resource) else {
+            return RefDecision::Deny; // no applicable ACL → fail-closed.
+        };
+        let governed = &acl_graph[..acl_graph.len() - ACL_SUFFIX.len()];
+        let Some(auths) = self.acls.get(&acl_graph) else {
+            return RefDecision::Deny;
+        };
+        for authz in auths {
+            if !Self::auth_has_mode(authz, req.mode) {
+                continue;
+            }
+            // Does this authorization APPLY to `req.resource`?
+            let applies = if is_own {
+                // The resource's own ACL: `accessTo R` applies to R. `default R` applies to
+                // members of R (R itself is not a member of itself).
+                authz.access_to.contains(req.resource)
+            } else {
+                // Inherited from the nearest ancestor container `governed`: `default
+                // governed` applies to the member `req.resource` (a descendant of governed).
+                authz.default_for.contains(governed)
+                    && is_structural_descendant(governed, req.resource)
+            };
+            if !applies {
+                continue;
+            }
+            if self.auth_matches_subject(authz, req) {
+                return RefDecision::Allow;
+            }
+        }
+        RefDecision::Deny
+    }
+
+    /// Resolve the nearest-wins effective ACL for `resource`: `resource.acl` if it exists
+    /// (returned with `is_own = true`), else the ACL of the nearest ancestor container
+    /// (`is_own = false`). `None` if no ancestor (or the resource) has an ACL — fail-closed.
+    fn effective_acl(&self, resource: &str) -> Option<(String, bool)> {
+        let own = format!("{resource}{ACL_SUFFIX}");
+        if self.acl_graphs.contains(&own) {
+            return Some((own, true));
+        }
+        for anc in ancestors_nearest_first(resource) {
+            let candidate = format!("{anc}{ACL_SUFFIX}");
+            if self.acl_graphs.contains(&candidate) {
+                return Some((candidate, false));
+            }
+        }
+        None
+    }
+
+    fn auth_has_mode(authz: &Authorization, mode: RefMode) -> bool {
+        authz
+            .modes
+            .iter()
+            .filter_map(|m| RefMode::from_acl_iri(m))
+            .any(|m| m == mode)
+    }
+
+    /// Does this authorization's access-subject set match the request's principal?
+    ///
+    /// WAC subject semantics (disjunction over subjects), with the `acl:origin` (user,
+    /// application) pair handled procedurally: an authorization carrying an `acl:origin`
+    /// grants its named agents ONLY when the session presents that origin/client.
+    fn auth_matches_subject(&self, authz: &Authorization, req: &Request) -> bool {
+        // `acl:agentClass foaf:Agent` — public, grants every requestor incl. anonymous.
+        if authz.agent_classes.contains(FOAF_AGENT) {
+            return true;
+        }
+        // `acl:agentClass acl:AuthenticatedAgent` — any authenticated requestor.
+        if authz.agent_classes.contains(AUTHENTICATED_AGENT) && req.agent.is_some() {
+            return true;
+        }
+
+        // The agent half: the request's WebID is in this authorization's named agents, or a
+        // member of one of its groups.
+        let Some(agent) = req.agent else {
+            // anonymous: only the public class (handled above) can grant; named-agent /
+            // group / origin subjects all require an agent.
+            return false;
+        };
+        let named = authz.agents.contains(agent);
+        let in_group = authz
+            .agent_groups
+            .iter()
+            .any(|grp| self.groups.get(grp).is_some_and(|m| m.contains(agent)));
+        let agent_ok = named || in_group;
+        if !agent_ok {
+            return false;
+        }
+
+        // The origin half: if the authorization constrains origin, the session must present a
+        // matching client (the (user, application) pair). No `acl:origin` ⇒ any client.
+        if authz.origins.is_empty() {
+            true
+        } else {
+            req.client.is_some_and(|c| authz.origins.contains(c))
+        }
+    }
+}
+
+/// Decide one request against a freshly-parsed model for `nquads` (the per-call convenience
+/// used by the oracle; for many requests over one scenario, build a [`WacModel`] once).
+///
+/// # Errors
+///
+/// Propagates a corpus parse failure (fail-closed at the oracle).
+pub fn decide(nquads: &str, req: &Request) -> Result<RefDecision, String> {
+    Ok(WacModel::from_nquads(nquads)?.decide(req))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn req<'a>(
+        agent: Option<&'a str>,
+        client: Option<&'a str>,
+        mode: RefMode,
+        resource: &'a str,
+    ) -> Request<'a> {
+        Request {
+            agent,
+            client,
+            mode,
+            resource,
+        }
+    }
+
+    #[test]
+    fn agent_access_to_grants_only_named() {
+        let n = "\
+<https://pod.ex/d1.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/d1.acl> .
+<https://pod.ex/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.ex/d1> <https://pod.ex/d1.acl> .
+<https://pod.ex/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#agent> <https://alice.ex/#me> <https://pod.ex/d1.acl> .
+<https://pod.ex/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/d1.acl> .
+<https://pod.ex/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.ex/d1> .
+";
+        let m = WacModel::from_nquads(n).unwrap();
+        assert_eq!(
+            m.decide(&req(
+                Some("https://alice.ex/#me"),
+                None,
+                RefMode::Read,
+                "https://pod.ex/d1"
+            )),
+            RefDecision::Allow
+        );
+        assert_eq!(
+            m.decide(&req(
+                Some("https://bob.ex/#me"),
+                None,
+                RefMode::Read,
+                "https://pod.ex/d1"
+            )),
+            RefDecision::Deny
+        );
+        assert_eq!(
+            m.decide(&req(None, None, RefMode::Read, "https://pod.ex/d1")),
+            RefDecision::Deny
+        );
+    }
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -249,7 +249,9 @@ Public surface (`pub mod conformance`, re-exported from the crate root for the e
 - `AcpScenario` — `new(name)`, `.acr(AcrBuilder)` / `.nquads(&str)` (the corpus),
   `.expect(Expect)` / `.expect_all(iter)` (the decision table), `.run() ->
   Result<ScenarioReport, String>` (materializes + checks). `run_corpus(&[AcpScenario])` runs
-  a whole corpus.
+  a whole corpus. Read-only accessors `.name()`, `.nquads_str() -> &str` (the raw N-Quad
+  corpus the engine loads) and `.expects() -> &[Expect]` (the decision table) let a SECOND
+  consumer — the differential oracle — feed the IDENTICAL corpus to an independent decider.
 - `Expect` — one expected decision, built fluently: `Expect::agent(webid)` /
   `Expect::anonymous()` / `Expect::pair(agent, client)`, then `.read/.write/.append/.control(
   resource)`, then `.is(Decision::Allow | Decision::Deny)`.
@@ -293,10 +295,43 @@ ScenarioReport}`):
   `.expect_all(iter)`, `.run() -> Result<ScenarioReport, String>` (materializes via the free
   `AuthIndex` path + checks), and `.run_via_podstore()` (the same check through the full
   `PodStore` method form — proves the path a PSS integration uses). `run_corpus(&[WacScenario])`
-  runs a whole corpus.
+  runs a whole corpus. Read-only accessors `.name()`, `.nquads_str() -> &str` and `.expects()
+  -> &[Expect]` expose the raw corpus + decision table to the differential oracle (below).
 - The `Expect` builder, `Decision`, and `ScenarioReport` are the same shared types as the ACP
   harness — `Expect::agent(webid)` / `Expect::anonymous()` / `Expect::pair(agent, client)`,
   `.read/.write/.append/.control(resource)`, `.is(Decision::Allow | Deny)`.
+
+## Differential oracle — [OPUS-4.8] sq-t58w.7
+
+`crates/sparq-solid/tests/differential_oracle.rs` is a **three-way agreement check** that
+runs the shared parity corpus (`common::wac_corpus()` / `common::acp_corpus()`) through
+THREE deciders for every `(agent, client, mode, resource)` request and asserts they all
+agree:
+
+1. **the engine** — `materialize_{wac,acp}` + `AuthIndex::accessible` (the **N3-rules**
+   paradigm — `rules/*.n3` run by `sparq-reason`);
+2. **an independent reference evaluator** — `crates/sparq-solid/tests/reference/{wac,acp}.rs`,
+   a from-scratch **PROCEDURAL** reading of the WAC/ACP spec over a hand-parsed model. Its
+   whole value is being a **different paradigm**: it shares **no** code with `materialize.rs`
+   / `loader.rs` / `rules/*.n3`, and parses the corpus with its own tiny N-Quad reader (not
+   `Graph::load_dataset`), so a shared bug cannot hide in both deciders;
+3. **the hand `Expect` table** — the human-authored expected decision in each scenario.
+
+A **divergence** is recorded whenever any two disagree; an unclassifiable/erroring request
+(failed load/materialize, or a reference parse error) counts as a divergence — **fail-closed**.
+The test asserts `divergences == 0` and prints, in the SHACL/geo runner shape (so a CI ratchet
+can grep it):
+
+```text
+WAC differential pairs <N> / divergences 0 (floor 0)
+ACP differential pairs <N> / divergences 0 (floor 0)
+```
+
+It is a **correctness oracle over the parity corpus, not a security audit**, and the reference
+evaluator implements exactly the constructs the corpus exercises (anything it does not
+recognise fails closed → a divergence). Pure in-crate Rust — no JS toolchain, no network, no
+clock, no Docker. A JS-reference differential twin (vs. `@solidlab/policy-engine` /
+`@solid/acl-check`) is a separate research-open follow-up (`sq-t58w.9`), NOT built here.
 
 ## Security posture — fail-closed
 


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing **sq-t58w.7**, THE core deliverable of the Solid WAC/ACP differential-oracle design (research record sq-t58w.2 §3-4). I am one of several agents @jeswr runs on this account.

## What this is

A **differential oracle** proving the engine's WAC/ACP authorization decisions agree with an **independent reference evaluator** AND the hand-written `Expect` decision table — with **zero divergence**.

The load-bearing point is **paradigm independence**. The engine decides authorization by running **N3 rules** (`rules/*.n3`) through `sparq-reason`. The new reference evaluator (`tests/reference/{wac,acp}.rs`) decides the SAME `(agent, client, mode, resource) → allow | deny` question by a **completely different mechanism**: a from-scratch, hand-written **procedural** reading of the spec over a plain in-memory model, parsed by its own tiny N-Quad reader. It shares **no** code with `materialize.rs` / `loader.rs` / `rules/*.n3` and does **not** use `Graph::load_dataset` — so a shared bug cannot hide in both deciders.

## Changes

- **`tests/reference/{mod,wac,acp}.rs`** — the independent procedural evaluator.
  - WAC: nearest-ACL resolution (closer ACL shadows ancestors), `accessTo`/`default`, `agent`/`agentClass`/`agentGroup`/`origin`, the four-mode set, Control-governs-`.acl`.
  - ACP: `anyOf`/`allOf`/`noneOf` matchers, allow/deny with deny-overrides, **cumulative** `accessControl`/`memberAccessControl` inheritance, fail-closed.
- **`tests/differential_oracle.rs`** — runs the shared corpus (`tests/common/` `wac_corpus()`/`acp_corpus()` from sq-t58w.6) through THREE deciders (engine `AuthIndex::accessible`, the reference evaluator, the hand `Expect` table). Records a **divergence** whenever any two disagree; an unclassifiable/erroring request counts as a divergence (**fail-closed**). Asserts `divergences == 0` and prints, in the SHACL/geo runner shape:
  ```
  WAC differential pairs 47 / divergences 0 (floor 0)
  ACP differential pairs 40 / divergences 0 (floor 0)
  ```
  A negative-control test proves the three-way check is load-bearing (it would be worthless if `check_request` silently passed).
- **Public-API:** read-only `nquads_str()` / `expects()` accessors on `WacScenario`/`AcpScenario` so the second test target consumes the IDENTICAL corpus. Documented in the same change → `crates/sparq-solid/README.md` + `skills/access-control/SKILL.md` (public-API → SKILL rule).

## Divergence count

**Zero.** 47 WAC request-pairs + 40 ACP request-pairs, all three deciders agreeing on every one.

**Mutation-checked** (not in the diff — local proof the oracle is real): breaking the reference's WAC nearest-ACL (farthest-wins) produces 2 divergences; breaking ACP deny-overrides produces 1. Both make the oracle fail, so it is not trivially passing.

## Honesty / scope

This is a **correctness oracle over the parity corpus, not a security audit** and not a full WAC/ACP implementation — the reference evaluator implements exactly the constructs the corpus exercises and **fails closed** on anything it does not recognise (→ a divergence). Pure in-crate Rust: **no JS toolchain, no network, no clock, no Docker**. A JS-reference differential twin is a separate research-open follow-up (sq-t58w.9). No perf claims.

## Gates (both feature states)

- `cargo clippy -p sparq-solid --all-targets -- -D warnings` — clean, **default** AND `--features odrl-bridge`.
- `cargo test -p sparq-solid` — green both states, incl. the new `differential_oracle` target (divergences == 0), the existing `conformance_wac`/`conformance_acp` + their ratchet lines (`WAC|ACP scenarios pass 12 / fail 0 (floor 12)`), and the unchanged `scoreboard_floors` test (the WAC/ACP floors in `tests/common/mod.rs` are untouched).
- `rustfmt` on the new files; the #872 corpus (`tests/common/`) is left byte-for-byte unchanged.
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations.

No auto-merge requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)