### PR TITLE
feat(sparq-conformance): register the Solid WAC/ACP differential oracle in the conformance scoreboard (sq-t58w.8)

### DIFF
--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -110,6 +110,10 @@ pub struct Suite {
 ///   (sq-j174; floor const moved to the shared parity-corpus module in sq-t58w.6).
 /// * Solid ACP 12 — `sparq-solid` `tests/common/mod.rs` `ACP_SCENARIO_FLOOR = 12`
 ///   (sq-j174; floor const moved to the shared parity-corpus module in sq-t58w.6).
+/// * Solid WAC differential 0 — `sparq-solid` `tests/differential_oracle.rs`
+///   `DIVERGENCE_FLOOR = 0` (sq-t58w.8; a divergence-count floor, hard 0 — the WAC
+///   and ACP differential rows share this one const).
+/// * Solid ACP differential 0 — same `DIVERGENCE_FLOOR = 0` (sq-t58w.8).
 pub const SUITES: &[Suite] = &[
     Suite {
         label: "W3C SPARQL (1.0 / 1.1 / 1.2, query+update+syntax)",
@@ -181,6 +185,39 @@ pub const SUITES: &[Suite] = &[
         floor_basis: "scenario",
         note: "library-level allow/deny parity over minimal per-construct ACP ACR scenarios",
     },
+    // [OPUS-4.8] sq-t58w.8 — the Solid WAC + ACP DIFFERENTIAL ORACLE (harness landed
+    // under sq-t58w.7, `crates/sparq-solid/tests/differential_oracle.rs`). It runs the
+    // SAME shared parity corpus through THREE independent deciders (the engine, a
+    // from-scratch procedural reference evaluator, and the hand `Expect` table) and
+    // asserts they never disagree. The ratchet is a DIVERGENCE count whose ONLY
+    // acceptable value is 0 — so unlike the scenario-COUNT floors above (which rise as
+    // the corpus grows), this floor is the hard `DIVERGENCE_FLOOR = 0` the runner
+    // asserts. Both rows share that ONE source const; the floor-sync guard
+    // (`tests/scoreboard_floors.rs`) keeps them locked to it. The runner stays
+    // crate-local in sparq-solid (this dev-only crate must not take sparq-solid as a
+    // dep — same constraint as SHACL/geo/the conformance suites above). `ci_job` is the
+    // Solid conformance lane; the dedicated `<WAC|ACP> differential … divergences N`
+    // grep-ratchet is sq-t58w.3.
+    Suite {
+        label: "Solid WAC differential oracle",
+        family: "Solid WAC",
+        runner: Runner::CrateTest { krate: "sparq-solid", target: "differential_oracle" },
+        ci_job: "solid-conformance",
+        ratchet_floor: 0,
+        floor_basis: "0 divergences",
+        note: "engine vs an independent reference evaluator vs the hand Expect table, \
+               over the WAC parity corpus (zero divergence)",
+    },
+    Suite {
+        label: "Solid ACP differential oracle",
+        family: "Solid ACP",
+        runner: Runner::CrateTest { krate: "sparq-solid", target: "differential_oracle" },
+        ci_job: "solid-conformance",
+        ratchet_floor: 0,
+        floor_basis: "0 divergences",
+        note: "engine vs an independent reference evaluator vs the hand Expect table, \
+               over the ACP parity corpus (zero divergence)",
+    },
 ];
 
 /// Render the registry as one markdown scoreboard. This is a STATIC view of what
@@ -195,11 +232,13 @@ pub fn render_scoreboard() -> String {
     let _ = writeln!(
         md,
         "The single index of EVERY conformance suite sparq ratchets, across crates. \
-         Each suite has a pass-count (or pass+divergence) FLOOR that CI enforces and \
-         that may only RISE. The per-suite detail reports are produced by the runners \
-         in the *run* column; this table is the consolidated map (sq-ncvq.16 brought \
-         the SHACL + GeoSPARQL ratchets in; sq-j174 the Solid WAC + ACP ones — all \
-         previously lived outside this scoreboard).\n"
+         Each suite has a FLOOR that CI enforces: a pass-count (or pass+divergence) \
+         floor that may only RISE, or — for the differential oracles — a hard \
+         divergence-count floor of 0. The per-suite detail reports are produced by the \
+         runners in the *run* column; this table is the consolidated map (sq-ncvq.16 \
+         brought the SHACL + GeoSPARQL ratchets in; sq-j174 the Solid WAC + ACP \
+         decision-parity ones; sq-t58w.8 the Solid WAC + ACP differential oracles — \
+         all previously lived outside this scoreboard).\n"
     );
     let _ = writeln!(
         md,

--- a/crates/sparq-conformance/tests/scoreboard_floors.rs
+++ b/crates/sparq-conformance/tests/scoreboard_floors.rs
@@ -85,6 +85,23 @@ const CRATE_LOCAL_FLOORS: &[(&str, &str, &str)] = &[
         "crates/sparq-solid/tests/common/mod.rs",
         "ACP_SCENARIO_FLOOR",
     ),
+    // [OPUS-4.8] sq-t58w.8 — the Solid WAC + ACP DIFFERENTIAL ORACLE ratchets. Both
+    // rows mirror the SAME hard divergence-count floor const (`DIVERGENCE_FLOOR = 0`)
+    // declared in `tests/differential_oracle.rs` (the oracle landed under sq-t58w.7).
+    // Unlike the scenario-count floors above (which rise as the corpus grows), the
+    // only acceptable divergence count is 0, so this floor is the fixed 0 — and this
+    // guard pins the central scoreboard's `ratchet_floor: 0` to that source const so
+    // the two can never silently diverge.
+    (
+        "Solid WAC differential oracle",
+        "crates/sparq-solid/tests/differential_oracle.rs",
+        "DIVERGENCE_FLOOR",
+    ),
+    (
+        "Solid ACP differential oracle",
+        "crates/sparq-solid/tests/differential_oracle.rs",
+        "DIVERGENCE_FLOOR",
+    ),
 ];
 
 #[test]
@@ -138,10 +155,13 @@ fn scoreboard_renders_all_suites() {
             suite.label
         );
     }
-    // The consolidation claim: SHACL + GeoSPARQL (sq-ncvq.16) and Solid WAC/ACP
-    // (sq-j174) now appear in this central report.
+    // The consolidation claim: SHACL + GeoSPARQL (sq-ncvq.16), Solid WAC/ACP
+    // decision parity (sq-j174), and the Solid WAC/ACP differential oracles
+    // (sq-t58w.8) now all appear in this central report.
     assert!(md.contains("W3C SHACL core"));
     assert!(md.contains("OGC GeoSPARQL"));
     assert!(md.contains("Solid WAC decision parity"));
     assert!(md.contains("Solid ACP decision parity"));
+    assert!(md.contains("Solid WAC differential oracle"));
+    assert!(md.contains("Solid ACP differential oracle"));
 }


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Implements **sq-t58w.8** (design §3.3): register the Solid differential oracle + verify the WAC/ACP parity floors in the central conformance scoreboard. Crate: `sparq-conformance`.

## What this does

1. **Two new `SUITES` rows** in `crates/sparq-conformance/src/scoreboard.rs` for the Solid differential oracle (the harness that landed under sq-t58w.7, `crates/sparq-solid/tests/differential_oracle.rs`):
   - `Solid WAC differential oracle` and `Solid ACP differential oracle`
   - both `Runner::CrateTest { krate: "sparq-solid", target: "differential_oracle" }`
   - `ratchet_floor: 0`, `floor_basis: "0 divergences"` — a hard divergence-count floor (the only acceptable value is 0), unlike the scenario-COUNT floors which rise as the corpus grows.

   The oracle runs the shared WAC/ACP parity corpus through three independent deciders (the engine vs a from-scratch procedural reference evaluator vs the hand `Expect` table) and asserts they never disagree.

2. **Floor-guard extension** in `crates/sparq-conformance/tests/scoreboard_floors.rs` (the central-vs-crate-local guard — the #872 failure mode): both differential rows are now pinned to the single `DIVERGENCE_FLOOR = 0` source const in `differential_oracle.rs` and stay in lock-step with it; the render smoke check asserts both new labels appear.

## Honest scoping note on the "backfill" step

The brief asked to **backfill** the WAC/ACP parity floors (12/12), flagging that the parent feasibility record claimed they were *not* mirrored. **Verified first — they ARE already mirrored.** sq-j174 + sq-t58w.6 already landed `Solid WAC decision parity` / `Solid ACP decision parity` rows in `SUITES` (floor 12 each) and the matching `WAC_SCENARIO_FLOOR` / `ACP_SCENARIO_FLOOR` entries in `CRATE_LOCAL_FLOORS` (pointing at `tests/common/mod.rs`). So the genuinely-new work here is the two **differential** floors (= 0); the scenario floors needed no re-add. The floor guard now covers all four Solid floors (WAC scenarios 12, ACP scenarios 12, WAC differential 0, ACP differential 0).

Floor-0 rows do not change the scoreboard total (still 3442); the suite count rises 7 → 9.

## Gates (both feature states — `sparq-conformance` has NO opt-in features, so default == `--all-features`)

- `cargo clippy -p sparq-conformance --all-targets -- -D warnings` — **clean** (default and `--all-features`).
- `cargo test -p sparq-conformance` — **green**, including `scoreboard_floors` (`central_floors_match_crate_local_sources`, `all_crate_test_suites_are_guarded`, `scoreboard_renders_all_suites` all pass).
- `cargo test -p sparq-solid` (default features) — **green**, including `differential_oracle` (WAC + ACP, 8 tests) and the WAC/ACP conformance suites.
- `python3 scripts/check-readme-template.py --enforce` — **0 deviations** (no README change needed; the scoreboard README already lists the Solid WAC + ACP family).
- `cargo fmt`: matched the surrounding committed single-line `Runner::CrateTest { .. }` style; did NOT run the deferred whole-crate reformat (per the fmt gate — clippy is the hard gate, CI fmt is informational).

No public-API surface changed (data rows added to the existing `pub const SUITES`), no perf claims, no privacy/ZK/MPC claims. New code marked `[OPUS-4.8]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)