### PR TITLE
test(js): cross-language Solid WAC/ACP differential oracle (sq-t58w.9) [OPUS-4.8]

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -61,10 +61,7 @@
   ],
   "devDependencies": {
     "@rdfjs/types": "^2.0.1",
-    "@solid/acl-check": "^0.4.5",
-    "@solidlab/policy-engine": "^0.0.2",
     "@types/node": "^25.9.3",
-    "n3": "^1.26.0",
     "typescript": "^6.0.3"
   },
   "dependencies": {

--- a/js/package.json
+++ b/js/package.json
@@ -61,7 +61,10 @@
   ],
   "devDependencies": {
     "@rdfjs/types": "^2.0.1",
+    "@solid/acl-check": "^0.4.5",
+    "@solidlab/policy-engine": "^0.0.2",
     "@types/node": "^25.9.3",
+    "n3": "^1.26.0",
     "typescript": "^6.0.3"
   },
   "dependencies": {

--- a/js/test/fixtures/solid-acl-corpus.json
+++ b/js/test/fixtures/solid-acl-corpus.json
@@ -1,0 +1,869 @@
+{
+  "_generated": "sparq-solid engine decisions (AuthIndex::accessible) — sq-t58w.9 generator",
+  "scenarios": [
+    {
+      "mechanism": "wac",
+      "name": "agent-accessTo",
+      "nquads": "<https://pod.example/agent/d1.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/agent/d1.acl> .\n<https://pod.example/agent/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.example/agent/d1> <https://pod.example/agent/d1.acl> .\n<https://pod.example/agent/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#agent> <https://alice.example/card#me> <https://pod.example/agent/d1.acl> .\n<https://pod.example/agent/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/agent/d1.acl> .\n<https://pod.example/agent/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/agent/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/agent/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/agent/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/agent/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "wac",
+      "name": "agentClass-foaf-Agent-public",
+      "nquads": "<https://pod.example/public/d1.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/public/d1.acl> .\n<https://pod.example/public/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.example/public/d1> <https://pod.example/public/d1.acl> .\n<https://pod.example/public/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent> <https://pod.example/public/d1.acl> .\n<https://pod.example/public/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/public/d1.acl> .\n<https://pod.example/public/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/public/d1> .\n",
+      "requests": [
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/public/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/public/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/public/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": "https://app.example",
+          "mode": "Read",
+          "resource": "https://pod.example/public/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://carol.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/public/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        }
+      ]
+    },
+    {
+      "mechanism": "wac",
+      "name": "agentClass-AuthenticatedAgent",
+      "nquads": "<https://pod.example/authn/d1.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/authn/d1.acl> .\n<https://pod.example/authn/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.example/authn/d1> <https://pod.example/authn/d1.acl> .\n<https://pod.example/authn/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#agentClass> <http://www.w3.org/ns/auth/acl#AuthenticatedAgent> <https://pod.example/authn/d1.acl> .\n<https://pod.example/authn/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/authn/d1.acl> .\n<https://pod.example/authn/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/authn/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/authn/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/authn/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/authn/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "wac",
+      "name": "agentGroup-vcard-members",
+      "nquads": "<https://pod.example/team/d1.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/team/d1.acl> .\n<https://pod.example/team/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.example/team/d1> <https://pod.example/team/d1.acl> .\n<https://pod.example/team/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#agentGroup> <https://pod.example/groups/team#g> <https://pod.example/team/d1.acl> .\n<https://pod.example/groups/team#g> <http://www.w3.org/2006/vcard/ns#hasMember> <https://bob.example/card#me> <https://pod.example/groups/team> .\n<https://pod.example/groups/team#g> <http://www.w3.org/2006/vcard/ns#hasMember> <https://carol.example/card#me> <https://pod.example/groups/team> .\n<https://pod.example/team/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/team/d1.acl> .\n<https://pod.example/team/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Write> <https://pod.example/team/d1.acl> .\n<https://pod.example/team/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/team/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/team/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://carol.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/team/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Write",
+          "resource": "https://pod.example/team/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://dave.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/team/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/team/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "wac",
+      "name": "default-inheritance-vs-accessTo",
+      "nquads": "<https://pod.example/c/.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/c/.acl> .\n<https://pod.example/c/.acl#auth0> <http://www.w3.org/ns/auth/acl#default> <https://pod.example/c/> <https://pod.example/c/.acl> .\n<https://pod.example/c/.acl#auth0> <http://www.w3.org/ns/auth/acl#agent> <https://alice.example/card#me> <https://pod.example/c/.acl> .\n<https://pod.example/c/.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/c/.acl> .\n<https://pod.example/c/sub/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/c/sub/d1> .\n<https://pod.example/c/#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/c/> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/c/sub/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/c/sub/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/c/",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "wac",
+      "name": "nearest-acl-shadows-ancestor",
+      "nquads": "<https://pod.example/.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/.acl> .\n<https://pod.example/.acl#auth0> <http://www.w3.org/ns/auth/acl#default> <https://pod.example/> <https://pod.example/.acl> .\n<https://pod.example/.acl#auth0> <http://www.w3.org/ns/auth/acl#agent> <https://alice.example/card#me> <https://pod.example/.acl> .\n<https://pod.example/.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/.acl> .\n<https://pod.example/proj/.acl#auth1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/proj/.acl> .\n<https://pod.example/proj/.acl#auth1> <http://www.w3.org/ns/auth/acl#default> <https://pod.example/proj/> <https://pod.example/proj/.acl> .\n<https://pod.example/proj/.acl#auth1> <http://www.w3.org/ns/auth/acl#agent> <https://bob.example/card#me> <https://pod.example/proj/.acl> .\n<https://pod.example/proj/.acl#auth1> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/proj/.acl> .\n<https://pod.example/proj/c/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/proj/c/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/proj/c/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/proj/c/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": "https://carol.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/proj/c/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "wac",
+      "name": "resource-specific-override",
+      "nquads": "<https://pod.example/docs/.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/docs/.acl> .\n<https://pod.example/docs/.acl#auth0> <http://www.w3.org/ns/auth/acl#default> <https://pod.example/docs/> <https://pod.example/docs/.acl> .\n<https://pod.example/docs/.acl#auth0> <http://www.w3.org/ns/auth/acl#agent> <https://alice.example/card#me> <https://pod.example/docs/.acl> .\n<https://pod.example/docs/.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/docs/.acl> .\n<https://pod.example/docs/#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/docs/> .\n<https://pod.example/docs/d0.acl#auth1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/docs/d0.acl> .\n<https://pod.example/docs/d0.acl#auth1> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.example/docs/d0> <https://pod.example/docs/d0.acl> .\n<https://pod.example/docs/d0.acl#auth1> <http://www.w3.org/ns/auth/acl#agent> <https://bob.example/card#me> <https://pod.example/docs/d0.acl> .\n<https://pod.example/docs/d0.acl#auth1> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/docs/d0.acl> .\n<https://pod.example/docs/d0#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/docs/d0> .\n<https://pod.example/docs/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/docs/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/docs/d0",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/docs/d0",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/docs/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/docs/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "wac",
+      "name": "origin-user-app-pair",
+      "nquads": "<https://pod.example/origin/d1.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/origin/d1.acl> .\n<https://pod.example/origin/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.example/origin/d1> <https://pod.example/origin/d1.acl> .\n<https://pod.example/origin/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#agent> <https://bob.example/card#me> <https://pod.example/origin/d1.acl> .\n<https://pod.example/origin/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#origin> <https://app.example> <https://pod.example/origin/d1.acl> .\n<https://pod.example/origin/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/origin/d1.acl> .\n<https://pod.example/origin/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/origin/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://bob.example/card#me",
+          "client": "https://app.example",
+          "mode": "Read",
+          "resource": "https://pod.example/origin/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": "https://evil.example",
+          "mode": "Read",
+          "resource": "https://pod.example/origin/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/origin/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": "https://carol.example/card#me",
+          "client": "https://app.example",
+          "mode": "Read",
+          "resource": "https://pod.example/origin/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/origin/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "wac",
+      "name": "mode-independence",
+      "nquads": "<https://pod.example/modes/rw.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/modes/rw.acl> .\n<https://pod.example/modes/rw.acl#auth0> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.example/modes/rw> <https://pod.example/modes/rw.acl> .\n<https://pod.example/modes/rw.acl#auth0> <http://www.w3.org/ns/auth/acl#agent> <https://alice.example/card#me> <https://pod.example/modes/rw.acl> .\n<https://pod.example/modes/rw.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/modes/rw.acl> .\n<https://pod.example/modes/rw.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Write> <https://pod.example/modes/rw.acl> .\n<https://pod.example/modes/ro.acl#auth1> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/modes/ro.acl> .\n<https://pod.example/modes/ro.acl#auth1> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.example/modes/ro> <https://pod.example/modes/ro.acl> .\n<https://pod.example/modes/ro.acl#auth1> <http://www.w3.org/ns/auth/acl#agent> <https://alice.example/card#me> <https://pod.example/modes/ro.acl> .\n<https://pod.example/modes/ro.acl#auth1> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/modes/ro.acl> .\n<https://pod.example/modes/rw#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/modes/rw> .\n<https://pod.example/modes/ro#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/modes/ro> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/modes/rw",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Write",
+          "resource": "https://pod.example/modes/rw",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/modes/ro",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Write",
+          "resource": "https://pod.example/modes/ro",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Append",
+          "resource": "https://pod.example/modes/ro",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "wac",
+      "name": "control-governs-acl-document",
+      "nquads": "<https://pod.example/ctl/d1.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/ctl/d1.acl> .\n<https://pod.example/ctl/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.example/ctl/d1> <https://pod.example/ctl/d1.acl> .\n<https://pod.example/ctl/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#agent> <https://alice.example/card#me> <https://pod.example/ctl/d1.acl> .\n<https://pod.example/ctl/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/ctl/d1.acl> .\n<https://pod.example/ctl/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Control> <https://pod.example/ctl/d1.acl> .\n<https://pod.example/ctl/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/ctl/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/ctl/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Control",
+          "resource": "https://pod.example/ctl/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/ctl/d1.acl",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Write",
+          "resource": "https://pod.example/ctl/d1.acl",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/ctl/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/ctl/d1.acl",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "wac",
+      "name": "fail-closed-no-acl",
+      "nquads": "<https://pod.example/orphan/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/orphan/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/orphan/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/orphan/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "wac",
+      "name": "multi-agent-union",
+      "nquads": "<https://pod.example/multi/d1.acl#auth0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.example/multi/d1.acl> .\n<https://pod.example/multi/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#accessTo> <https://pod.example/multi/d1> <https://pod.example/multi/d1.acl> .\n<https://pod.example/multi/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#agent> <https://bob.example/card#me> <https://pod.example/multi/d1.acl> .\n<https://pod.example/multi/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#agent> <https://carol.example/card#me> <https://pod.example/multi/d1.acl> .\n<https://pod.example/multi/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/multi/d1.acl> .\n<https://pod.example/multi/d1.acl#auth0> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Write> <https://pod.example/multi/d1.acl> .\n<https://pod.example/multi/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/multi/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/multi/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://carol.example/card#me",
+          "client": null,
+          "mode": "Write",
+          "resource": "https://pod.example/multi/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/multi/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "agent-anyOf-allow",
+      "nquads": "<https://pod.example/agent/d1.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/agent/d1> <https://pod.example/agent/d1.acr> .\n<https://pod.example/agent/d1.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.example/agent/d1.acr#ctl0> <https://pod.example/agent/d1.acr> .\n<https://pod.example/agent/d1.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/agent/d1.acr#pol0> <https://pod.example/agent/d1.acr> .\n<https://pod.example/agent/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/agent/d1.acr> .\n<https://pod.example/agent/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/agent/d1.acr#m0-anyOf0> <https://pod.example/agent/d1.acr> .\n<https://pod.example/agent/d1.acr#m0-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <https://alice.example/card#me> <https://pod.example/agent/d1.acr> .\n<https://pod.example/agent/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/agent/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/agent/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/agent/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/agent/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "public-agent",
+      "nquads": "<https://pod.example/public/d1.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/public/d1> <https://pod.example/public/d1.acr> .\n<https://pod.example/public/d1.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.example/public/d1.acr#ctl0> <https://pod.example/public/d1.acr> .\n<https://pod.example/public/d1.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/public/d1.acr#pol0> <https://pod.example/public/d1.acr> .\n<https://pod.example/public/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/public/d1.acr> .\n<https://pod.example/public/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/public/d1.acr#m0-anyOf0> <https://pod.example/public/d1.acr> .\n<https://pod.example/public/d1.acr#m0-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <http://www.w3.org/ns/solid/acp#PublicAgent> <https://pod.example/public/d1.acr> .\n<https://pod.example/public/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/public/d1> .\n",
+      "requests": [
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/public/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/public/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/public/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": "https://app.example",
+          "mode": "Read",
+          "resource": "https://pod.example/public/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "authenticated-agent",
+      "nquads": "<https://pod.example/authn/d1.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/authn/d1> <https://pod.example/authn/d1.acr> .\n<https://pod.example/authn/d1.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.example/authn/d1.acr#ctl0> <https://pod.example/authn/d1.acr> .\n<https://pod.example/authn/d1.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/authn/d1.acr#pol0> <https://pod.example/authn/d1.acr> .\n<https://pod.example/authn/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/authn/d1.acr> .\n<https://pod.example/authn/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/authn/d1.acr#m0-anyOf0> <https://pod.example/authn/d1.acr> .\n<https://pod.example/authn/d1.acr#m0-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <http://www.w3.org/ns/solid/acp#AuthenticatedAgent> <https://pod.example/authn/d1.acr> .\n<https://pod.example/authn/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/authn/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/authn/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/authn/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/authn/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "allOf-user-app-pair",
+      "nquads": "<https://pod.example/pair/d1.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/pair/d1> <https://pod.example/pair/d1.acr> .\n<https://pod.example/pair/d1.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.example/pair/d1.acr#ctl0> <https://pod.example/pair/d1.acr> .\n<https://pod.example/pair/d1.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/pair/d1.acr#pol0> <https://pod.example/pair/d1.acr> .\n<https://pod.example/pair/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/pair/d1.acr> .\n<https://pod.example/pair/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allOf> <https://pod.example/pair/d1.acr#m0-allOf0> <https://pod.example/pair/d1.acr> .\n<https://pod.example/pair/d1.acr#m0-allOf0> <http://www.w3.org/ns/solid/acp#agent> <https://bob.example/card#me> <https://pod.example/pair/d1.acr> .\n<https://pod.example/pair/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allOf> <https://pod.example/pair/d1.acr#m0-allOf1> <https://pod.example/pair/d1.acr> .\n<https://pod.example/pair/d1.acr#m0-allOf1> <http://www.w3.org/ns/solid/acp#client> <https://app.example> <https://pod.example/pair/d1.acr> .\n<https://pod.example/pair/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/pair/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://bob.example/card#me",
+          "client": "https://app.example",
+          "mode": "Read",
+          "resource": "https://pod.example/pair/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": "https://evil.example",
+          "mode": "Read",
+          "resource": "https://pod.example/pair/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/pair/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": "https://carol.example/card#me",
+          "client": "https://app.example",
+          "mode": "Read",
+          "resource": "https://pod.example/pair/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/pair/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "allOf-single-matcher-pair",
+      "nquads": "<https://pod.example/pair2/d1.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/pair2/d1> <https://pod.example/pair2/d1.acr> .\n<https://pod.example/pair2/d1.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.example/pair2/d1.acr#ctl0> <https://pod.example/pair2/d1.acr> .\n<https://pod.example/pair2/d1.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/pair2/d1.acr#pol0> <https://pod.example/pair2/d1.acr> .\n<https://pod.example/pair2/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/pair2/d1.acr> .\n<https://pod.example/pair2/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allOf> <https://pod.example/pair2/d1.acr#m0-allOf0> <https://pod.example/pair2/d1.acr> .\n<https://pod.example/pair2/d1.acr#m0-allOf0> <http://www.w3.org/ns/solid/acp#agent> <https://bob.example/card#me> <https://pod.example/pair2/d1.acr> .\n<https://pod.example/pair2/d1.acr#m0-allOf0> <http://www.w3.org/ns/solid/acp#client> <https://app.example> <https://pod.example/pair2/d1.acr> .\n<https://pod.example/pair2/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/pair2/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://bob.example/card#me",
+          "client": "https://app.example",
+          "mode": "Read",
+          "resource": "https://pod.example/pair2/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": "https://evil.example",
+          "mode": "Read",
+          "resource": "https://pod.example/pair2/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": "https://carol.example/card#me",
+          "client": "https://app.example",
+          "mode": "Read",
+          "resource": "https://pod.example/pair2/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "deny-overrides",
+      "nquads": "<https://pod.example/deny/d1.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/deny/d1> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.example/deny/d1.acr#ctl0> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/deny/d1.acr#pol0> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/deny/d1.acr#m0-anyOf0> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1.acr#m0-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <http://www.w3.org/ns/solid/acp#PublicAgent> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/deny/d1> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.example/deny/d1.acr#ctl1> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1.acr#ctl1> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/deny/d1.acr#pol1> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1.acr#pol1> <http://www.w3.org/ns/solid/acp#deny> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1.acr#pol1> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/deny/d1.acr#m1-anyOf0> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1.acr#m1-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <https://bob.example/card#me> <https://pod.example/deny/d1.acr> .\n<https://pod.example/deny/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/deny/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/deny/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/deny/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/deny/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "noneOf-public-except-carol",
+      "nquads": "<https://pod.example/except/d1.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/except/d1> <https://pod.example/except/d1.acr> .\n<https://pod.example/except/d1.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.example/except/d1.acr#ctl0> <https://pod.example/except/d1.acr> .\n<https://pod.example/except/d1.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/except/d1.acr#pol0> <https://pod.example/except/d1.acr> .\n<https://pod.example/except/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/except/d1.acr> .\n<https://pod.example/except/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/except/d1.acr#m0-anyOf0> <https://pod.example/except/d1.acr> .\n<https://pod.example/except/d1.acr#m0-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <http://www.w3.org/ns/solid/acp#PublicAgent> <https://pod.example/except/d1.acr> .\n<https://pod.example/except/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#noneOf> <https://pod.example/except/d1.acr#m0-noneOf1> <https://pod.example/except/d1.acr> .\n<https://pod.example/except/d1.acr#m0-noneOf1> <http://www.w3.org/ns/solid/acp#agent> <https://carol.example/card#me> <https://pod.example/except/d1.acr> .\n<https://pod.example/except/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/except/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/except/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/except/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/except/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://carol.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/except/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "memberAccessControl-inheritance",
+      "nquads": "<https://pod.example/team/.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/team/> <https://pod.example/team/.acr> .\n<https://pod.example/team/.acr> <http://www.w3.org/ns/solid/acp#memberAccessControl> <https://pod.example/team/.acr#ctl0> <https://pod.example/team/.acr> .\n<https://pod.example/team/.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/team/.acr#pol0> <https://pod.example/team/.acr> .\n<https://pod.example/team/.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/team/.acr> .\n<https://pod.example/team/.acr#pol0> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/team/.acr#m0-anyOf0> <https://pod.example/team/.acr> .\n<https://pod.example/team/.acr#m0-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <https://alice.example/card#me> <https://pod.example/team/.acr> .\n<https://pod.example/team/sub/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/team/sub/d1> .\n<https://pod.example/team/#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/team/> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/team/sub/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/team/sub/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/team/",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "cumulative-inheritance",
+      "nquads": "<https://pod.example/.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/> <https://pod.example/.acr> .\n<https://pod.example/.acr> <http://www.w3.org/ns/solid/acp#memberAccessControl> <https://pod.example/.acr#ctl0> <https://pod.example/.acr> .\n<https://pod.example/.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/.acr#pol0> <https://pod.example/.acr> .\n<https://pod.example/.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/.acr> .\n<https://pod.example/.acr#pol0> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/.acr#m0-anyOf0> <https://pod.example/.acr> .\n<https://pod.example/.acr#m0-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <https://alice.example/card#me> <https://pod.example/.acr> .\n<https://pod.example/proj/.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/proj/> <https://pod.example/proj/.acr> .\n<https://pod.example/proj/.acr> <http://www.w3.org/ns/solid/acp#memberAccessControl> <https://pod.example/proj/.acr#ctl1> <https://pod.example/proj/.acr> .\n<https://pod.example/proj/.acr#ctl1> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/proj/.acr#pol1> <https://pod.example/proj/.acr> .\n<https://pod.example/proj/.acr#pol1> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/proj/.acr> .\n<https://pod.example/proj/.acr#pol1> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/proj/.acr#m1-anyOf0> <https://pod.example/proj/.acr> .\n<https://pod.example/proj/.acr#m1-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <https://bob.example/card#me> <https://pod.example/proj/.acr> .\n<https://pod.example/proj/c/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/proj/c/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/proj/c/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/proj/c/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://carol.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/proj/c/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "mode-independence",
+      "nquads": "<https://pod.example/modes/rw.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/modes/rw> <https://pod.example/modes/rw.acr> .\n<https://pod.example/modes/rw.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.example/modes/rw.acr#ctl0> <https://pod.example/modes/rw.acr> .\n<https://pod.example/modes/rw.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/modes/rw.acr#pol0> <https://pod.example/modes/rw.acr> .\n<https://pod.example/modes/rw.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/modes/rw.acr> .\n<https://pod.example/modes/rw.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Write> <https://pod.example/modes/rw.acr> .\n<https://pod.example/modes/rw.acr#pol0> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/modes/rw.acr#m0-anyOf0> <https://pod.example/modes/rw.acr> .\n<https://pod.example/modes/rw.acr#m0-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <https://alice.example/card#me> <https://pod.example/modes/rw.acr> .\n<https://pod.example/modes/ro.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/modes/ro> <https://pod.example/modes/ro.acr> .\n<https://pod.example/modes/ro.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.example/modes/ro.acr#ctl1> <https://pod.example/modes/ro.acr> .\n<https://pod.example/modes/ro.acr#ctl1> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/modes/ro.acr#pol1> <https://pod.example/modes/ro.acr> .\n<https://pod.example/modes/ro.acr#pol1> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/modes/ro.acr> .\n<https://pod.example/modes/ro.acr#pol1> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/modes/ro.acr#m1-anyOf0> <https://pod.example/modes/ro.acr> .\n<https://pod.example/modes/ro.acr#m1-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <https://alice.example/card#me> <https://pod.example/modes/ro.acr> .\n<https://pod.example/modes/rw#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/modes/rw> .\n<https://pod.example/modes/ro#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/modes/ro> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/modes/rw",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Write",
+          "resource": "https://pod.example/modes/rw",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/modes/ro",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Write",
+          "resource": "https://pod.example/modes/ro",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "fail-closed-no-policy",
+      "nquads": "<https://pod.example/orphan/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/orphan/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/orphan/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        },
+        {
+          "agent": null,
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/orphan/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    },
+    {
+      "mechanism": "acp",
+      "name": "anyOf-disjunction",
+      "nquads": "<https://pod.example/anyof/d1.acr> <http://www.w3.org/ns/solid/acp#resource> <https://pod.example/anyof/d1> <https://pod.example/anyof/d1.acr> .\n<https://pod.example/anyof/d1.acr> <http://www.w3.org/ns/solid/acp#accessControl> <https://pod.example/anyof/d1.acr#ctl0> <https://pod.example/anyof/d1.acr> .\n<https://pod.example/anyof/d1.acr#ctl0> <http://www.w3.org/ns/solid/acp#apply> <https://pod.example/anyof/d1.acr#pol0> <https://pod.example/anyof/d1.acr> .\n<https://pod.example/anyof/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.example/anyof/d1.acr> .\n<https://pod.example/anyof/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Write> <https://pod.example/anyof/d1.acr> .\n<https://pod.example/anyof/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/anyof/d1.acr#m0-anyOf0> <https://pod.example/anyof/d1.acr> .\n<https://pod.example/anyof/d1.acr#m0-anyOf0> <http://www.w3.org/ns/solid/acp#agent> <https://bob.example/card#me> <https://pod.example/anyof/d1.acr> .\n<https://pod.example/anyof/d1.acr#pol0> <http://www.w3.org/ns/solid/acp#anyOf> <https://pod.example/anyof/d1.acr#m0-anyOf1> <https://pod.example/anyof/d1.acr> .\n<https://pod.example/anyof/d1.acr#m0-anyOf1> <http://www.w3.org/ns/solid/acp#agent> <https://carol.example/card#me> <https://pod.example/anyof/d1.acr> .\n<https://pod.example/anyof/d1#it> <https://ex.dev/ns#prop> \"x\" <https://pod.example/anyof/d1> .\n",
+      "requests": [
+        {
+          "agent": "https://bob.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/anyof/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://carol.example/card#me",
+          "client": null,
+          "mode": "Write",
+          "resource": "https://pod.example/anyof/d1",
+          "sparqDecision": "allow",
+          "specExpect": "allow"
+        },
+        {
+          "agent": "https://alice.example/card#me",
+          "client": null,
+          "mode": "Read",
+          "resource": "https://pod.example/anyof/d1",
+          "sparqDecision": "deny",
+          "specExpect": "deny"
+        }
+      ]
+    }
+  ]
+}

--- a/js/test/solid-differential.test.mjs
+++ b/js/test/solid-differential.test.mjs
@@ -1,0 +1,504 @@
+// [OPUS-4.8] sq-t58w.9 — a STRONG SECOND, CROSS-LANGUAGE differential oracle for the
+// sparq-solid WAC/ACP authorization engine.
+//
+// What this is
+// ------------
+// The Rust differential oracle (sq-t58w.7, crates/sparq-solid/tests/differential_oracle.rs)
+// cross-checks sparq-solid's engine against a SECOND Rust decider (an independent procedural
+// reading of the spec) over a shared WAC/ACP corpus, with zero divergence. This file is the
+// *cross-language* counterpart: it replays the IDENTICAL corpus through INDEPENDENT JavaScript
+// Solid reference engines and asserts they agree with sparq-solid's own decisions.
+//
+//   - WAC: `@solid/acl-check` (the rdflib-based Solid WAC checker — a pure, in-memory
+//     `checkAccess` over an in-memory store, the same library Community-Solid-Server family
+//     code paths build on) PLUS, as a second WAC opinion, `@solidlab/policy-engine`'s
+//     `WacPolicyEngine`.
+//   - ACP: `@solidlab/policy-engine`'s `AcpPolicyEngine` (acl-check is WAC-only).
+//
+// How sparq-solid's decisions are obtained
+// ----------------------------------------
+// sparq-solid is a Rust crate and is NOT exposed through the wasm build, so there is no
+// in-process wasm path. Its decisions are captured in `fixtures/solid-acl-corpus.json`, an
+// artifact emitted by a one-shot Rust generator that `include!`s the SAME shared corpus
+// (`crates/sparq-solid/tests/common/{wac,acp}.rs`, the source consumed by both the Rust
+// conformance suites AND the Rust oracle) and records, per `(agent, client, mode, resource)`
+// request, sparq-solid's ACTUAL engine verdict via `AuthIndex::accessible` — NOT a hand table.
+// The fixture also carries the spec `Expect` value; the in-repo Rust conformance + oracle prove
+// `sparqDecision === specExpect` with zero divergence on `main`, and this test re-asserts that
+// invariant as a fixture-integrity check.
+//
+// HONEST CAVEAT (research-grade reference)
+// ----------------------------------------
+// `@solidlab/policy-engine` is PRE-1.0 (v0.0.2) — it encodes implementation-truth, not
+// spec-truth. `@solid/acl-check` (v0.4.5) is mature but makes its own interpretation choices
+// (notably around `acl:origin` and the `acl:Control`→`.acl` relationship). Therefore a
+// disagreement here is a TRIAGE SIGNAL, not proof sparq is wrong. Where a divergence is a
+// known, understood difference in the reference engine's semantics (documented in
+// KNOWN_DIFFERENCES below, each with a rationale), it is printed as TRIAGED and does NOT fail
+// the test — it is never auto-attributed to sparq. Any UNEXPECTED divergence fails the test
+// and is printed in full for inspection.
+//
+// Constraints honoured: NO docker, NO server, NO network at test time. Everything is parsed and
+// evaluated in-memory.
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import { Store, Parser } from 'n3';
+import policyEngine from '@solidlab/policy-engine';
+import * as aclCheckNs from '@solid/acl-check';
+import * as rdflibNs from 'rdflib';
+
+const {
+  WacPolicyEngine,
+  AcpPolicyEngine,
+  ManagedWacRepository,
+  ManagedAcpRepository,
+  UnionAccessChecker,
+  AgentAccessChecker,
+  AgentClassAccessChecker,
+  AgentGroupAccessChecker,
+} = policyEngine;
+
+// Both packages are published as CommonJS; under ESM the named exports land on `.default`
+// for the namespace-imported ones.
+const aclCheck = aclCheckNs.default ?? aclCheckNs;
+const $rdf = rdflibNs.default ?? rdflibNs;
+
+// Silence acl-check's chatty per-decision console logging so the test output stays the
+// runner-shape summary + any triaged/unexpected divergence lines only.
+aclCheck.configureLogger(() => {});
+
+const ACL = (mode) => `http://www.w3.org/ns/auth/acl#${mode}`;
+const ACL_NS = $rdf.Namespace('http://www.w3.org/ns/auth/acl#');
+
+const CORPUS = JSON.parse(
+  readFileSync(new URL('./fixtures/solid-acl-corpus.json', import.meta.url), 'utf8'),
+);
+
+// ---------------------------------------------------------------------------------------------
+// KNOWN, TRIAGED engine-semantics differences (NOT sparq bugs).
+//
+// Each entry is keyed by `${mechanism}|${scenario}|${engine}` and lists a `match(request)`
+// predicate selecting the specific requests that legitimately differ, plus a `rationale`. A
+// divergence on a matched request is reported as TRIAGED and does not fail the gate; the
+// triage is explicit, auditable, and attributed to the reference engine's interpretation —
+// never silently swallowed.
+// ---------------------------------------------------------------------------------------------
+const KNOWN_DIFFERENCES = [
+  {
+    key: 'wac|origin-user-app-pair|acl-check',
+    // sparq treats `acl:origin` as a REQUIRED (user, application) pair: an agent matches only
+    // through the named client/origin. `@solid/acl-check` enforces origin trust only when an
+    // origin is *presented*; with no origin presented it grants on the agent alone (and does
+    // not fail-closed on the authorization's `acl:origin`). Implementation-choice difference.
+    match: (r, verdict, sparq) => r.client === null && verdict === 'allow' && sparq === 'deny',
+    rationale:
+      'acl-check ignores acl:origin when no origin is presented (grants on agent alone); ' +
+      'sparq requires the user+app pair.',
+  },
+  {
+    key: 'wac|origin-user-app-pair|policy-engine',
+    // policy-engine likewise does not fail-closed on the authorization's `acl:origin`: it
+    // grants on the agent alone regardless of the presented origin (incl. a non-matching one).
+    match: (r, verdict, sparq) =>
+      (r.client === null || r.client === 'https://evil.example') &&
+      verdict === 'allow' &&
+      sparq === 'deny',
+    rationale:
+      'policy-engine does not enforce acl:origin as a required pair (grants on agent alone, ' +
+      'including a non-matching origin); sparq requires the named client/origin.',
+  },
+  {
+    key: 'wac|control-governs-acl-document|acl-check',
+    // sparq (and the in-repo Rust reference oracle) model `acl:Control` as granting Read+Write
+    // of the resource's `.acl` document. acl-check evaluates `<R>.acl` as a plain resource with
+    // no governing ACL of its own, so it denies. The `<R>.acl` requests are sparq-/oracle-only.
+    match: (r, verdict, sparq) =>
+      r.resource.endsWith('.acl') && verdict === 'deny' && sparq === 'allow',
+    rationale:
+      'acl-check does not model acl:Control => R/W of the <R>.acl document; it treats <R>.acl ' +
+      'as an ungoverned plain resource. sparq + the Rust reference oracle grant it.',
+  },
+  {
+    key: 'wac|control-governs-acl-document|policy-engine',
+    // Same Control-governs-.acl semantics gap; additionally policy-engine raises
+    // "No ACL document found for root container" while recursing for `<R>.acl` (it has no ACL),
+    // surfaced here as an ERROR verdict — fail-closed and triaged.
+    // sparq grants <R>.acl (allow); policy-engine errors recursing to the root → not 'allow'.
+    match: (r, verdict, sparq) =>
+      r.resource.endsWith('.acl') && verdict !== sparq && verdict !== 'allow',
+    rationale:
+      'policy-engine does not model acl:Control => R/W of <R>.acl and errors recursing to the ' +
+      'root for the .acl resource; sparq + the Rust reference oracle grant it.',
+  },
+  {
+    key: 'wac|agentGroup-vcard-members|policy-engine',
+    // policy-engine's AgentGroupAccessChecker resolves `acl:agentGroup` membership by HTTP-
+    // `fetch`ing the vCard group document (`@rdfjs/fetch`). With the corpus held entirely
+    // in-memory and the no-network mandate, that fetch fails and the group never matches, so
+    // policy-engine denies every group member. `@solid/acl-check` (run alongside) resolves the
+    // SAME group from the in-memory store and AGREES with sparq, so WAC group coverage is
+    // intact — this is a policy-engine transport limitation, not a sparq disagreement.
+    // Members are denied where sparq allows; the non-member/anon cases already agree.
+    match: (r, verdict, sparq) => r.agent !== null && verdict === 'deny' && sparq === 'allow',
+    rationale:
+      'policy-engine resolves acl:agentGroup by HTTP-fetching the vCard group document, which ' +
+      'cannot run under the in-memory/no-network constraint; acl-check resolves the group from ' +
+      'memory and agrees with sparq.',
+  },
+  {
+    key: 'wac|fail-closed-no-acl|policy-engine',
+    // For a resource with NO ACL anywhere (orphan), policy-engine's getAclRecursive THROWS
+    // "No ACL document found for root container" rather than denying. sparq fail-closes to deny
+    // (the WAC-correct outcome); acl-check (run alongside) also returns deny and agrees.
+    // sparq denies (fail-closed); policy-engine errors instead of denying — any non-deny verdict.
+    match: (_r, verdict, sparq) => sparq === 'deny' && verdict !== 'deny',
+    rationale:
+      'policy-engine throws "No ACL document found for root container" for a resource with no ' +
+      'ACL instead of denying; sparq (and acl-check) fail-closed to deny.',
+  },
+];
+
+function knownDifference(mechanism, scenario, engine, request, verdict, sparq) {
+  const entry = KNOWN_DIFFERENCES.find((d) => d.key === `${mechanism}|${scenario}|${engine}`);
+  if (!entry) return null;
+  // The matcher is verdict-aware: it selects the EXACT divergence direction we have triaged,
+  // so an opposite-direction regression (e.g. the reference engine wrongly granting where it
+  // used to deny) is NOT masked — it surfaces as an unexpected divergence.
+  return entry.match(request, verdict, sparq) ? entry.rationale : null;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Corpus parsing helpers.
+// ---------------------------------------------------------------------------------------------
+
+/**
+ * Parse a scenario's N-Quads into a map: graph IRI -> Quad[] (default-graph quads). The corpus
+ * places each ACL/ACR document into the named graph `<R>.acl` / `<R>.acr`, and resource content
+ * into `<R>`, mirroring the Solid `R -> R.acl` linkage the Rust loader resolves.
+ */
+function parseByGraph(nquads) {
+  const quads = new Parser({ format: 'application/n-quads' }).parse(nquads);
+  const byGraph = new Map();
+  for (const q of quads) {
+    const g = q.graph.value;
+    if (!byGraph.has(g)) byGraph.set(g, []);
+    byGraph.get(g).push(q);
+  }
+  return byGraph;
+}
+
+/**
+ * The parent container IRI of a Solid resource by slash-path structure (containment is by IRI
+ * structure in this corpus, not by an `ldp:contains` triple). Returns `undefined` at/above the
+ * storage root so the policy-engine ancestor walk terminates.
+ */
+function getParent(id) {
+  const SCHEME = 'https://';
+  if (id.endsWith('/')) {
+    const trimmed = id.slice(0, -1);
+    const idx = trimmed.lastIndexOf('/');
+    if (idx < SCHEME.length) return undefined;
+    return trimmed.slice(0, idx + 1);
+  }
+  const idx = id.lastIndexOf('/');
+  if (idx < SCHEME.length) return undefined;
+  return id.slice(0, idx + 1);
+}
+
+/**
+ * Build a policy-engine `AuthorizationManager` over the in-memory corpus graphs. `suffix` is
+ * `.acl` (WAC) or `.acr` (ACP); `getAuthorizationData(id)` returns the contents of `<id+suffix>`
+ * as an n3 Store (flattened to the default graph, the shape the repositories consume), or
+ * `undefined` when no such document exists.
+ */
+function buildManager(byGraph, suffix) {
+  return {
+    getParent,
+    getAuthorizationData: async (id) => {
+      const quads = byGraph.get(`${id}${suffix}`);
+      if (!quads || quads.length === 0) return undefined;
+      const store = new Store();
+      for (const q of quads) store.addQuad(q.subject, q.predicate, q.object);
+      return store;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------------------------
+// Reference engine adapters: each maps a corpus request to an `'allow' | 'deny' | 'error:…'`.
+// ---------------------------------------------------------------------------------------------
+
+/** `@solidlab/policy-engine` WAC adapter. */
+function makePolicyEngineWac(byGraph) {
+  const checker = new UnionAccessChecker([
+    new AgentAccessChecker(),
+    new AgentClassAccessChecker(),
+    new AgentGroupAccessChecker(),
+  ]);
+  const engine = new WacPolicyEngine(checker, new ManagedWacRepository(buildManager(byGraph, '.acl')));
+  return async (request) => {
+    const creds = {};
+    if (request.agent) creds.agent = request.agent;
+    if (request.client) creds.client = request.client;
+    try {
+      const perms = await engine.getPermissions(request.resource, creds, [ACL(request.mode)]);
+      return perms[ACL(request.mode)] === true ? 'allow' : 'deny';
+    } catch (e) {
+      return `error:${e.message}`;
+    }
+  };
+}
+
+/** `@solidlab/policy-engine` ACP adapter. */
+function makePolicyEngineAcp(byGraph) {
+  const engine = new AcpPolicyEngine(new ManagedAcpRepository(buildManager(byGraph, '.acr')));
+  return async (request) => {
+    const creds = {};
+    if (request.agent) creds.agent = request.agent;
+    if (request.client) creds.client = request.client;
+    try {
+      const perms = await engine.getPermissions(request.resource, creds, [ACL(request.mode)]);
+      return perms[ACL(request.mode)] === true ? 'allow' : 'deny';
+    } catch (e) {
+      return `error:${e.message}`;
+    }
+  };
+}
+
+/**
+ * Find the effective ACL document for a resource per WAC's nearest-ACL resolution: the closest
+ * of the resource itself, then its ancestor containers, whose `<X>.acl` graph carries any
+ * triples. Returns `{ aclDoc, subject, isDirect }`, or `null` when no ancestor has an ACL
+ * (fail-closed). Mirrors the loader linkage acl-check needs (it filters by the ACL-doc graph,
+ * and uses `acl:accessTo` for the direct case vs `acl:default` for an inherited ancestor).
+ */
+function effectiveAcl(kb, resource) {
+  const candidates = [resource];
+  let cur = resource;
+  for (;;) {
+    const parent = getParent(cur);
+    if (!parent) break;
+    candidates.push(parent);
+    cur = parent;
+  }
+  for (const subject of candidates) {
+    const aclDoc = `${subject}.acl`;
+    const n = kb.statementsMatching(null, null, null, $rdf.sym(aclDoc)).length;
+    if (n > 0) return { aclDoc, subject, isDirect: subject === resource };
+  }
+  return null;
+}
+
+/** `@solid/acl-check` WAC adapter over an rdflib store loaded from the scenario N-Quads. */
+function makeAclCheckWac(kb) {
+  return (request) => {
+    const eff = effectiveAcl(kb, request.resource);
+    if (!eff) return 'deny'; // no applicable ACL anywhere: fail-closed (WAC).
+    const agent = request.agent ? $rdf.sym(request.agent) : null;
+    // `directory` selects acl:default (inherited) vs acl:accessTo (direct) inside acl-check.
+    const directory = eff.isDirect ? null : $rdf.sym(eff.subject);
+    const origin = request.client ? $rdf.sym(request.client) : null;
+    try {
+      const allowed = aclCheck.checkAccess(
+        kb,
+        $rdf.sym(request.resource),
+        directory,
+        $rdf.sym(eff.aclDoc),
+        agent,
+        [ACL_NS(request.mode)],
+        origin,
+        null,
+        [],
+      );
+      return allowed ? 'allow' : 'deny';
+    } catch (e) {
+      return `error:${e.message}`;
+    }
+  };
+}
+
+/** Load a scenario's N-Quads into a fresh rdflib store (graphs preserved). */
+function loadRdflib(nquads) {
+  const kb = $rdf.graph();
+  return new Promise((resolve, reject) => {
+    // N-Quads parsing in rdflib is async (callback); the 4th term becomes the named graph.
+    $rdf.parse(nquads, kb, 'https://pod.example/', 'application/n-quads', (err) => {
+      if (err) reject(err);
+      else resolve(kb);
+    });
+  });
+}
+
+function requestLabel(r) {
+  const who =
+    r.agent && r.client
+      ? `(agent ${r.agent}, client ${r.client})`
+      : r.agent
+        ? `agent ${r.agent}`
+        : 'anonymous';
+  return `${who} ${r.mode} ${r.resource}`;
+}
+
+// ---------------------------------------------------------------------------------------------
+// The oracle: run one mechanism's corpus through one or more JS engines, comparing every
+// request to sparq-solid's recorded decision. Returns { pairs, unexpected[], triaged[] }.
+// ---------------------------------------------------------------------------------------------
+async function runMechanism(mechanism, engineFactories) {
+  const scenarios = CORPUS.scenarios.filter((s) => s.mechanism === mechanism);
+  let pairs = 0;
+  const unexpected = [];
+  const triaged = [];
+
+  for (const scenario of scenarios) {
+    const byGraph = parseByGraph(scenario.nquads);
+    // Engine adapters may need either the n3-graph map or an rdflib store; build both lazily.
+    const kb = mechanism === 'wac' ? await loadRdflib(scenario.nquads) : null;
+
+    const engines = engineFactories.map(({ name, build }) => ({
+      name,
+      decide: build({ byGraph, kb }),
+    }));
+
+    for (const request of scenario.requests) {
+      pairs += 1;
+      const sparq = request.sparqDecision; // 'allow' | 'deny'
+      for (const engine of engines) {
+        const verdict = await engine.decide(request);
+        const agrees = verdict === sparq;
+        if (agrees) continue;
+        const rationale = knownDifference(
+          mechanism,
+          scenario.name,
+          engine.name,
+          request,
+          verdict,
+          sparq,
+        );
+        const record = {
+          scenario: scenario.name,
+          engine: engine.name,
+          request: requestLabel(request),
+          js: verdict,
+          sparq,
+          rationale,
+        };
+        if (rationale) triaged.push(record);
+        else unexpected.push(record);
+      }
+    }
+  }
+  return { pairs, unexpected, triaged };
+}
+
+function printReport(mechanism, engineNames, result) {
+  // Runner-shape summary line (grep-parity with the Rust oracle's
+  // "WAC differential pairs N / divergences 0 (floor 0)").
+  console.log(
+    `${mechanism.toUpperCase()} JS differential pairs ${result.pairs} ` +
+      `/ engines [${engineNames.join(', ')}] ` +
+      `/ unexpected divergences ${result.unexpected.length} (floor 0) ` +
+      `/ triaged known-differences ${result.triaged.length}`,
+  );
+  for (const t of result.triaged) {
+    console.log(
+      `  TRIAGED [${t.scenario}] ${t.engine}: ${t.request} => js=${t.js}, sparq=${t.sparq} ` +
+        `— ${t.rationale}`,
+    );
+  }
+  for (const u of result.unexpected) {
+    console.log(
+      `  UNEXPECTED DIVERGENCE [${u.scenario}] ${u.engine}: ${u.request} => js=${u.js}, sparq=${u.sparq}`,
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------------------------
+// Tests.
+// ---------------------------------------------------------------------------------------------
+
+test('fixture integrity: sparq-solid decisions match the spec Expect table (0 mismatch)', () => {
+  // The fixture carries both sparq's actual engine verdict (sparqDecision) and the spec Expect
+  // (specExpect). The in-repo Rust conformance suites + oracle prove these are identical with
+  // zero divergence on main; re-assert it here so a stale/garbled fixture is caught early.
+  let mismatches = 0;
+  let wacPairs = 0;
+  let acpPairs = 0;
+  for (const s of CORPUS.scenarios) {
+    for (const r of s.requests) {
+      if (s.mechanism === 'wac') wacPairs += 1;
+      else acpPairs += 1;
+      if (r.sparqDecision !== r.specExpect) mismatches += 1;
+    }
+  }
+  assert.equal(mismatches, 0, 'sparqDecision must equal specExpect for every request');
+  // Guard against a silently-empty corpus (the Rust oracle's pinned floors: 47 WAC / 40 ACP).
+  assert.equal(wacPairs, 47, 'expected the pinned WAC request table (47 pairs)');
+  assert.equal(acpPairs, 40, 'expected the pinned ACP request table (40 pairs)');
+  assert.equal(
+    CORPUS.scenarios.filter((s) => s.mechanism === 'wac').length,
+    12,
+    'expected 12 WAC scenarios',
+  );
+  assert.equal(
+    CORPUS.scenarios.filter((s) => s.mechanism === 'acp').length,
+    12,
+    'expected 12 ACP scenarios',
+  );
+});
+
+test('WAC: sparq-solid agrees with @solid/acl-check and @solidlab/policy-engine (0 unexpected divergences)', async () => {
+  const result = await runMechanism('wac', [
+    { name: 'acl-check', build: ({ kb }) => makeAclCheckWac(kb) },
+    { name: 'policy-engine', build: ({ byGraph }) => makePolicyEngineWac(byGraph) },
+  ]);
+  printReport('wac', ['acl-check', 'policy-engine'], result);
+  assert.equal(
+    result.unexpected.length,
+    0,
+    `WAC: ${result.unexpected.length} unexpected divergence(s) — see UNEXPECTED lines above`,
+  );
+});
+
+test('ACP: sparq-solid agrees with @solidlab/policy-engine (0 unexpected divergences)', async () => {
+  const result = await runMechanism('acp', [
+    { name: 'policy-engine', build: ({ byGraph }) => makePolicyEngineAcp(byGraph) },
+  ]);
+  printReport('acp', ['policy-engine'], result);
+  assert.equal(
+    result.unexpected.length,
+    0,
+    `ACP: ${result.unexpected.length} unexpected divergence(s) — see UNEXPECTED lines above`,
+  );
+});
+
+test('the oracle is load-bearing: a deliberately wrong expectation IS flagged', async () => {
+  // Negative control — prove the comparison actually compares. Mutate the corpus so one known
+  // WAC allow is recorded as a deny; the acl-check adapter (which says allow) must then surface
+  // an UNEXPECTED divergence on a request NOT in KNOWN_DIFFERENCES.
+  const scenario = CORPUS.scenarios.find((s) => s.name === 'agent-accessTo');
+  assert.ok(scenario, 'agent-accessTo scenario present');
+  const kb = await loadRdflib(scenario.nquads);
+  const decide = makeAclCheckWac(kb);
+  const allowReq = scenario.requests.find((r) => r.sparqDecision === 'allow');
+  assert.ok(allowReq, 'expected an allow request to mutate');
+
+  const jsVerdict = await decide(allowReq); // acl-check: allow
+  assert.equal(jsVerdict, 'allow', 'sanity: acl-check allows the granted request');
+
+  // Simulate a corrupted sparq decision and confirm the agreement check would flag it.
+  const mutatedSparq = 'deny';
+  assert.notEqual(
+    jsVerdict,
+    mutatedSparq,
+    'a wrong sparq decision must disagree with the JS engine (oracle is not trivially passing)',
+  );
+  // And confirm this request is NOT masked by a known-difference entry.
+  assert.equal(
+    knownDifference('wac', scenario.name, 'acl-check', allowReq, jsVerdict, mutatedSparq),
+    null,
+    'the negative-control request must not be a triaged known-difference',
+  );
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,12 @@
         "js",
         "site",
         "gui/e2e"
-      ]
+      ],
+      "devDependencies": {
+        "@solid/acl-check": "^0.4.5",
+        "@solidlab/policy-engine": "^0.0.2",
+        "n3": "^1.26.0"
+      }
     },
     "gui/e2e": {
       "name": "sparq-gui-e2e",
@@ -33,10 +38,7 @@
       },
       "devDependencies": {
         "@rdfjs/types": "^2.0.1",
-        "@solid/acl-check": "^0.4.5",
-        "@solidlab/policy-engine": "^0.0.2",
         "@types/node": "^25.9.3",
-        "n3": "^1.26.0",
         "typescript": "^6.0.3"
       },
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,10 @@
       },
       "devDependencies": {
         "@rdfjs/types": "^2.0.1",
+        "@solid/acl-check": "^0.4.5",
+        "@solidlab/policy-engine": "^0.0.2",
         "@types/node": "^25.9.3",
+        "n3": "^1.26.0",
         "typescript": "^6.0.3"
       },
       "engines": {
@@ -68,6 +71,62 @@
       },
       "bin": {
         "bb": "dest/node/bin/index.js"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.6.0.tgz",
+      "integrity": "sha512-Ir+AOibqzrIsL6ajt3Rz3LskB7OiMVHqltZmspbW/TJuTVuyOMirVqAkjfY6JISiLHgyNqicAC8AyHHGzNd/dA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@dabh/diagnostics": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@dabh/diagnostics/-/diagnostics-2.0.8.tgz",
+      "integrity": "sha512-R4MSXTVnuMzGD7bzHdW2ZhhdPC/igELENcq5IjEverBvq5hn1SXCWcsi6eSsdWP0/Ur+SItRRjAktmdoX/8R/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@so-ric/colorspace": "^1.1.6",
+        "enabled": "2.0.x",
+        "kuler": "^2.0.0"
+      }
+    },
+    "node_modules/@digitalbazaar/http-client": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@digitalbazaar/http-client/-/http-client-4.3.0.tgz",
+      "integrity": "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "ky": "^1.14.2",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@digitalbazaar/http-client/node_modules/undici": {
+      "version": "6.27.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.27.0.tgz",
+      "integrity": "sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/@emnapi/core": {
@@ -284,6 +343,16 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@frogcat/ttl2jsonld": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@frogcat/ttl2jsonld/-/ttl2jsonld-0.0.10.tgz",
+      "integrity": "sha512-0NLM96V3ziZkkOlhixSZiXe8CzewECVNtSj04s2hW2e65SgzQPzM12VWSovuRIy+2UJA2Bjkf9405yrty9tgcg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "ttl2jsonld": "bin/cli.js"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
@@ -2781,6 +2850,225 @@
       "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
       "license": "MIT"
     },
+    "node_modules/@rdfjs/data-model": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.3.4.tgz",
+      "integrity": "sha512-iKzNcKvJotgbFDdti7GTQDCYmL7GsGldkYStiP0K8EYtN7deJu5t7U11rKTz+nR7RtesUggT+lriZ7BakFv8QQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.1"
+      },
+      "bin": {
+        "rdfjs-data-model-test": "bin/test.js"
+      }
+    },
+    "node_modules/@rdfjs/dataset": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/dataset/-/dataset-1.1.1.tgz",
+      "integrity": "sha512-BNwCSvG0cz0srsG5esq6CQKJc1m8g/M0DZpLuiEp0MMpfwguXX7VeS8TCg4UUG3DV/DqEvhy83ZKSEjdsYseeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^1.2.0"
+      },
+      "bin": {
+        "rdfjs-dataset-test": "bin/test.js"
+      }
+    },
+    "node_modules/@rdfjs/fetch": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/fetch/-/fetch-2.1.0.tgz",
+      "integrity": "sha512-1bhXqGfbQQKHrmuZOmUUQmCpDNQC25fksYoGXUvlQ80kWuk8r/PdcdUmzApCp7HSyHFUjmgH89Pkym/9WXyDkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/dataset": "^1.0.1",
+        "@rdfjs/fetch-lite": "^2.1.0",
+        "@rdfjs/formats-common": "^2.0.1"
+      }
+    },
+    "node_modules/@rdfjs/fetch-lite": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/fetch-lite/-/fetch-lite-2.1.2.tgz",
+      "integrity": "sha512-M66ShQbQH94/XdavOuCWLu5TFbx4pHxNLolC7oUvmIZI03mQOYyapEinGaaUozpdQoY8iOrekree4OORdRKFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "isstream": "^0.1.2",
+        "nodeify-fetch": "^2.2.1",
+        "readable-stream": "^3.3.0"
+      }
+    },
+    "node_modules/@rdfjs/fetch-lite/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@rdfjs/formats-common": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/formats-common/-/formats-common-2.2.0.tgz",
+      "integrity": "sha512-XuW5tfTqN9gfbI/P3Duvai++m1fhp3idb7lmZYyP6F4EvgC7L6U9MgeRkFvqx8Vxq813+R09NeHBT5vC4BU3Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/parser-jsonld": "^1.2.1",
+        "@rdfjs/parser-n3": "^1.1.4",
+        "@rdfjs/serializer-jsonld": "^1.2.3",
+        "@rdfjs/serializer-ntriples": "^1.0.3",
+        "@rdfjs/sink-map": "^1.0.0",
+        "rdfxml-streaming-parser": "^1.4.0"
+      }
+    },
+    "node_modules/@rdfjs/namespace": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rdfjs/namespace/-/namespace-1.1.0.tgz",
+      "integrity": "sha512-utO5rtaOKxk8B90qzaQ0N+J5WrCI28DtfAY/zExCmXE7cOfC5uRI/oMKbLaVEPj2P7uArekt/T4IPATtj7Tjug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rdfjs/parser-jsonld": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/parser-jsonld/-/parser-jsonld-1.3.1.tgz",
+      "integrity": "sha512-5eoG1YCq/uJvEBe0Hiw/TzPvRODLcUmWrGnOpzrvxkEvvmF8FUX8KYFfYtROEIjCuPywG2TBb0ID8F9/sqG0tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^1.3.4",
+        "@rdfjs/sink": "^1.0.3",
+        "jsonld-streaming-parser": "^2.4.3",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/@rdfjs/parser-jsonld/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@rdfjs/parser-n3": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@rdfjs/parser-n3/-/parser-n3-1.1.4.tgz",
+      "integrity": "sha512-PUKSNlfD2Zq3GcQZuOF2ndfrLbc+N96FUe2gNIzARlR2er0BcOHBHEFUJvVGg1Xmsg3hVKwfg0nwn1JZ7qKKMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/data-model": "^1.0.1",
+        "@rdfjs/sink": "^1.0.2",
+        "n3": "^1.3.5",
+        "readable-stream": "^3.6.0",
+        "readable-to-readable": "^0.1.0"
+      }
+    },
+    "node_modules/@rdfjs/parser-n3/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@rdfjs/serializer-jsonld": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rdfjs/serializer-jsonld/-/serializer-jsonld-1.2.3.tgz",
+      "integrity": "sha512-Y6jGvXvtI4eIpHIizkY6WQnwUZNWcNfkwO4ZVTIGZpc7mHrlBMaXpcXc3f6XOBVeeb4k1dNy7Fqu2CL0B5+Uew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/namespace": "^1.1.0",
+        "@rdfjs/sink": "^1.0.3",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/@rdfjs/serializer-jsonld/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@rdfjs/serializer-ntriples": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rdfjs/serializer-ntriples/-/serializer-ntriples-1.0.3.tgz",
+      "integrity": "sha512-XXFgzNJyYrix0YgysqYowKw40hCJ+zeVqA/CGgO3y5XyKY+NL/VJJELMn7cTwjJteiLVCgRNAvaUVn4CjJ2PCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/sink": "^1.0.3",
+        "@rdfjs/to-ntriples": "^1.0.2",
+        "readable-to-readable": "^0.1.0"
+      }
+    },
+    "node_modules/@rdfjs/sink": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rdfjs/sink/-/sink-1.0.3.tgz",
+      "integrity": "sha512-2KfYa8mAnptRNeogxhQqkWNXqfYVWO04jQThtXKepySrIwYmz83+WlevQtA4VDLFe+kFd2TwgL29ekPe5XVUfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rdfjs/sink-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rdfjs/sink-map/-/sink-map-1.0.1.tgz",
+      "integrity": "sha512-PRp5TjULHe2oRcupR80SClZ/l50wnSuX2Pl+TlkcRazt1w7AT86kLmQYFbDfjqGM7uDwSyD6evLJxXBDf5UuvQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@rdfjs/to-ntriples": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/to-ntriples/-/to-ntriples-1.0.2.tgz",
+      "integrity": "sha512-ngw5XAaGHjgGiwWWBPGlfdCclHftonmbje5lMys4G2j4NvfExraPIuRZgjSnd5lg4dnulRVUll8tRbgKO+7EDA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@rdfjs/types": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-2.0.1.tgz",
@@ -2798,12 +3086,77 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@rubensworks/saxes": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@rubensworks/saxes/-/saxes-6.0.1.tgz",
+      "integrity": "sha512-UW4OTIsOtJ5KSXo2Tchi4lhZqu+tlHrOAs4nNti7CrtB53kAZl3/hyrTi6HkMihxdbDM6m2Zc3swc/ZewEe1xw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.12"
+      }
+    },
     "node_modules/@rushstack/eslint-patch": {
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@so-ric/colorspace": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@so-ric/colorspace/-/colorspace-1.1.6.tgz",
+      "integrity": "sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color": "^5.0.2",
+        "text-hex": "1.0.x"
+      }
+    },
+    "node_modules/@solid/acl-check": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@solid/acl-check/-/acl-check-0.4.5.tgz",
+      "integrity": "sha512-zq3AEsUT2SLdtgYv5ii3o8BLsZvpsosn1S1QkTUj9PWGLX0SJCV8gMTlI+uqa3AAuxv+CeDNBnYNkBSjY6YJrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rdflib": "^2.1.7",
+        "solid-namespace": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@solidlab/policy-engine": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@solidlab/policy-engine/-/policy-engine-0.0.2.tgz",
+      "integrity": "sha512-kWWNMXwxIVOTkgCOa5EEiO5um98cJZ0hREu6LKe3O/7O0BZ5XkeYfsZWuHbtgwXR+vblkRkQ7EBQffkNAjT/JA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/fetch": "^2.1.0",
+        "@rdfjs/types": "^1.1.0",
+        "@types/n3": "^1.21.0",
+        "@types/rdfjs__fetch": "^2.0.3",
+        "asynchronous-handlers": "^1.0.2",
+        "global-logger-factory": "^1.0.0",
+        "n3": "^1.21.1",
+        "rdf-vocabulary": "^1.0.0"
+      }
+    },
+    "node_modules/@solidlab/policy-engine/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@sparq/client": {
       "resolved": "packages/sparq-client",
@@ -3113,6 +3466,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/http-link-header": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@types/http-link-header/-/http-link-header-1.0.7.tgz",
+      "integrity": "sha512-snm5oLckop0K3cTDAiBnZDy6ncx9DJ3mCRDvs42C884MbVYPP74Tiq2hFsSDRTyjK6RyDYDIulPiW23ge+g5Lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3127,6 +3490,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/jsonld": {
+      "version": "1.5.15",
+      "resolved": "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.15.tgz",
+      "integrity": "sha512-PlAFPZjL+AuGYmwlqwKEL0IMP8M8RexH0NIPGfCVWSQ041H2rR/8OlyZSD7KsCVoN8vCfWdtWDBxX8yBVP+xow==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/n3": {
+      "version": "1.26.1",
+      "resolved": "https://registry.npmjs.org/@types/n3/-/n3-1.26.1.tgz",
+      "integrity": "sha512-TilYHzpU6ecXVJAbV+6o17Z8ZkWLWx6ZJD3IluaU4RiGHxqjU2or9fopxFHS6iXS6qcl5Mg1K3wSx9L8xxJaJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/node": {
       "version": "25.9.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.4.tgz",
@@ -3134,6 +3515,167 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
+    "node_modules/@types/rdfjs__fetch": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__fetch/-/rdfjs__fetch-2.0.3.tgz",
+      "integrity": "sha512-QP0C7+yQ2Y4Y0tvWCW8J20OwWnbZy1e7XkPA5QzjzvnV5Nx9p0FTUkhZWSbp2ta/Ao8+CB3I2V/xk++cQrO3+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/rdfjs__fetch-lite": "*",
+        "rdf-js": "^4.0.2"
+      }
+    },
+    "node_modules/@types/rdfjs__fetch-lite": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__fetch-lite/-/rdfjs__fetch-lite-3.0.11.tgz",
+      "integrity": "sha512-1bHxBn62bmTPq/HY9Jr+iKCdBp8RTEJ4WA0ycihghRF8zWQfw6T7E5CqdPi4nncmgF70LOz7jF/4jeLGdb6H2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/node": "*",
+        "@types/rdfjs__formats": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__formats": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__formats/-/rdfjs__formats-4.0.1.tgz",
+      "integrity": "sha512-Zj7hQEn5HeCj+pJCWshY2gqBcdBdwyc2j20Ht3PH91pkdRuG2AlGDD3N9PQ1oZ3+J6Q96rAlhxUbjQUp9+s3FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0",
+        "@types/node": "*",
+        "@types/rdfjs__parser-jsonld": "*",
+        "@types/rdfjs__parser-n3": "*",
+        "@types/rdfjs__serializer-jsonld": "*",
+        "@types/rdfjs__serializer-jsonld-ext": "*",
+        "@types/rdfjs__serializer-ntriples": "*",
+        "@types/rdfjs__serializer-turtle": "*",
+        "@types/rdfjs__sink-map": "*",
+        "rdfxml-streaming-parser": ">=2"
+      }
+    },
+    "node_modules/@types/rdfjs__formats/node_modules/rdf-data-factory": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-2.0.2.tgz",
+      "integrity": "sha512-WzPoYHwQYWvIP9k+7IBLY1b4nIDitzAK4mA37WumAF/Cjvu/KOtYJH9IPZnUTWNSd5K2+pq4vrcE9WZC4sRHhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^2.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@types/rdfjs__formats/node_modules/rdfxml-streaming-parser": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-3.2.0.tgz",
+      "integrity": "sha512-SgQGK0EkbXd0jQ1PZk7dEpfDxf4CZpezkO6cTuGWesa9twdWaaW5elMoNBcbMT+2tOZC1EYZjs0JaXx0HnifcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rubensworks/saxes": "^6.0.1",
+        "@types/readable-stream": "^4.0.18",
+        "buffer": "^6.0.3",
+        "rdf-data-factory": "^2.0.2",
+        "readable-stream": "^4.4.2",
+        "relative-to-absolute-iri": "^1.0.0",
+        "validate-iri": "^1.0.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
+      }
+    },
+    "node_modules/@types/rdfjs__parser-jsonld": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-jsonld/-/rdfjs__parser-jsonld-2.1.7.tgz",
+      "integrity": "sha512-n35K+c1Y95580N202Jxly6xjFE953FF+Y2mwxok6zLfMo4rgIfgMBElnNwpja0IeYXTuzGm1tEz7va3lItGrTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0",
+        "@types/jsonld": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__parser-n3": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__parser-n3/-/rdfjs__parser-n3-2.0.6.tgz",
+      "integrity": "sha512-VHfdq7BDV6iMCtHkzTFSOuUWnqGlMUmEF0UZyK4+g9SzLWvc6TMcU5TYwQPQIz/e0s7dZ+xomxx6mVtIzsRQ/A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0"
+      }
+    },
+    "node_modules/@types/rdfjs__prefix-map": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__prefix-map/-/rdfjs__prefix-map-0.1.5.tgz",
+      "integrity": "sha512-RAwyS/2dT9X79QwM0F8KLweTfuBoe6xtiAlU7wKPB+/t/sfk6A50LYtAWaDVP5qBjcu50UkKkZT+VR47CiLkfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__serializer-jsonld": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-jsonld/-/rdfjs__serializer-jsonld-2.0.5.tgz",
+      "integrity": "sha512-ubdLD9QgZzAt+65NSPzh2qWCPWcGYlHEWgkP6uRwfm7JC48Xh/QjzwOTG13MTomOkQqcN4R7PIG0j3Ca8iyNWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0"
+      }
+    },
+    "node_modules/@types/rdfjs__serializer-jsonld-ext": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-jsonld-ext/-/rdfjs__serializer-jsonld-ext-4.0.1.tgz",
+      "integrity": "sha512-jgbQ/1kV7nESKG7SY8FJED6K4OFznr6Sz3ybF1ncpBR7TUBTuy3InpZOVRK4Wjpy2zi84iIAzJ1CIIo9NZh2Xw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0",
+        "@types/jsonld": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__serializer-ntriples": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-ntriples/-/rdfjs__serializer-ntriples-2.0.6.tgz",
+      "integrity": "sha512-Nn3e3eyuymLvbI5MFzI7ODD/X6ZGpbB9fLaWOB00RtFHd2vttk3wQL2fzzsZZQPJ/ihC/xlFE4cNQkO6SoHa7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0"
+      }
+    },
+    "node_modules/@types/rdfjs__serializer-turtle": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__serializer-turtle/-/rdfjs__serializer-turtle-1.1.0.tgz",
+      "integrity": "sha512-NGHnbz5985UwS/YS6WL/FkS94B+QiVTdsfvJCqPwLmY3E7UeClw91c2KbiphZUR/uh7uwLwxeKKhV2T1gYgT5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": ">=1.0.0",
+        "@types/node": "*",
+        "@types/rdfjs__prefix-map": "*"
+      }
+    },
+    "node_modules/@types/rdfjs__sink-map": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/rdfjs__sink-map/-/rdfjs__sink-map-2.0.5.tgz",
+      "integrity": "sha512-ycUBlOMbp9YpjrBrMwGv3uiqulOWgodess06cinYLxomOTc2ET9rEQklgM5rJqnu5WMsVP8SFG3fFw36/5hADQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*"
       }
     },
     "node_modules/@types/react": {
@@ -3156,10 +3698,27 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/readable-stream": {
+      "version": "4.0.23",
+      "resolved": "https://registry.npmjs.org/@types/readable-stream/-/readable-stream-4.0.23.tgz",
+      "integrity": "sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.5",
       "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/triple-beam": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/triple-beam/-/triple-beam-1.3.5.tgz",
+      "integrity": "sha512-6WaYesThRMCl19iryMYP7/x2OVgCtbIVflDGFpWnb9irXI3UjYE4AzmYuiUKY1AJstGijoY+MgUszMgRxIYTYw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/which": {
@@ -3924,6 +4483,29 @@
         "node": ">=18.20.0"
       }
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/@zazuko/node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/@zazuko/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-mrEqq7BJyNBlK5oT7U1S0EfLbFPpVHLXQJswhrN8Mv/3BKmWIBtMBaphK8AXF7XEhgK9vzRs/f3AIG8oHlPdpg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      }
+    },
     "node_modules/@zip.js/zip.js": {
       "version": "2.8.26",
       "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
@@ -3945,6 +4527,16 @@
       },
       "engines": {
         "node": ">=6.5"
+      }
+    },
+    "node_modules/abs": {
+      "version": "1.3.15",
+      "resolved": "https://registry.npmjs.org/abs/-/abs-1.3.15.tgz",
+      "integrity": "sha512-bpFChpVyZ2F2ppgx7qjZ5TTEO6VVwBauUZDZibpclRGhfcXTHyj11nlqwrg5dN1knxCchssROehm76uCcCayRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ul": "^5.0.0"
       }
     },
     "node_modules/acorn": {
@@ -4294,6 +4886,16 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynchronous-handlers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/asynchronous-handlers/-/asynchronous-handlers-1.0.2.tgz",
+      "integrity": "sha512-Jl5zQuDrq5owcX6Y5SD0Q3ZE73lR6hOaUw9Uwz0jglrrNauKYyczOtak/kfJ+u0rfoqbZa6jG4dtYPq5c6w08w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "global-logger-factory": "^1.0.0"
+      }
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -4534,6 +5136,13 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/call-bind": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
@@ -4613,6 +5222,26 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canonicalize": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-1.0.8.tgz",
+      "integrity": "sha512-0CNTVCLZggSh7bc5VkX5WWPWO+cyZbNd07IHIsSXLia/eAq+r836hgk+8BKoEh7949Mda87VUOitx5OddVj64A==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/capture-stack-trace": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.2.tgz",
+      "integrity": "sha512-X/WM2UQs6VMHUtjUDnZTRI+i1crWteJySFzr9UpGoQa4WQffXVTTXuekjl7TjZRlcF2XfjgITT0HxZ9RnxeT0w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4771,6 +5400,20 @@
         "node": ">=6"
       }
     },
+    "node_modules/color": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
+      "integrity": "sha512-ezmVcLR3xAVp8kYOm4GS45ZLLgIE6SPAFoduLr6hTDajwb3KZ2F46gulK3XpcwRFb5KKGCSezCBAY4Dw4HsyXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^3.1.3",
+        "color-string": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -4788,6 +5431,52 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-2.1.4.tgz",
+      "integrity": "sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/color-string/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/color/node_modules/color-convert": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-3.1.3.tgz",
+      "integrity": "sha512-fasDH2ont2GqF5HpyO4w0+BcewlhHEZOFn9c1ckZdHpJ56Qb7MHhH/IcJZbBGgvdtwdwNbLvxiBEdg336iA9Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/color/node_modules/color-name": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.1.0.tgz",
+      "integrity": "sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
     },
     "node_modules/comlink": {
       "version": "4.4.2",
@@ -4827,6 +5516,62 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "dev": true,
+      "engines": [
+        "node >= 0.8"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/concat-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/concat-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/concat-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -4858,6 +5603,19 @@
         "node": ">= 14"
       }
     },
+    "node_modules/create-error-class": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
+      "integrity": "sha512-gYTKKexFO3kh200H1Nit76sRwRtOY32vQd3jpAQKpLtZqyNsSQNfI4N7o3eP2wUjV35pTWKRYqFUDBvUha/Pkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "capture-stack-trace": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/cross-env": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
@@ -4875,6 +5633,16 @@
         "node": ">=10.14",
         "npm": ">=6",
         "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
       }
     },
     "node_modules/cross-spawn": {
@@ -5036,6 +5804,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -5050,6 +5828,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/deffy": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/deffy/-/deffy-2.2.5.tgz",
+      "integrity": "sha512-6TX2cfIo97eKqWmqgMDAUulCwnveAe3K+4VGsTGPJsL3NtSEnSBFZ3sUXdS4EBhZ8GbdaZBzXQ04ton18dJrug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typpy": "^2.0.0"
       }
     },
     "node_modules/define-data-property": {
@@ -5201,6 +5989,56 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer2": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha512-asLFVfWWtJ90ZyOUHMqk7/S2w2guQKxUI2itj3d92ADHhxUSbCMGi1f1cBcJ7xM1To+pE/Khbwo1yuNbMEPKeA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "node_modules/duplexer2/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/duplexer2/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/duplexer2/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -5276,6 +6114,13 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "license": "MIT"
     },
+    "node_modules/enabled": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/enabled/-/enabled-2.0.0.tgz",
+      "integrity": "sha512-AKrN98kuwOzMIdAizXGI86UFBoo26CL21UM763y1h/GMSJ4/OHU9k2YlsmBpyScFo/wbLzWQJBMCW4+IO3/+OQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
@@ -5322,6 +6167,26 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/err": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/err/-/err-1.1.1.tgz",
+      "integrity": "sha512-N97Ybd2jJHVQ+Ft3Q5+C2gM3kgygkdeQmEqbN2z15UTVyyEsIwLA1VK39O1DHEJhXbwIFcJLqm6iARNhFANcQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typpy": "^2.2.0"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-abstract": {
@@ -6010,6 +6875,17 @@
         "bare-events": "^2.7.0"
       }
     },
+    "node_modules/exec-limiter": {
+      "version": "3.2.14",
+      "resolved": "https://registry.npmjs.org/exec-limiter/-/exec-limiter-3.2.14.tgz",
+      "integrity": "sha512-ZQjJmAnXD+1kQ6ejMZAS5Vxdt7LLMz0Eq7mEu6+7NhlauykuyLihhUkpp4S784QKsmJQIpuuERhQ8Tav8bF3zQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "limit-it": "^3.0.0",
+        "typpy": "^2.1.0"
+      }
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -6145,6 +7021,13 @@
         "pend": "~1.2.0"
       }
     },
+    "node_modules/fecha": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/fecha/-/fecha-4.2.3.tgz",
+      "integrity": "sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -6209,6 +7092,13 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fn.name": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
+      "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -6264,6 +7154,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/function.name": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/function.name/-/function.name-1.0.14.tgz",
+      "integrity": "sha512-s99L814NRuLxwF2sJMIcLhkQhueGXb3oKyvorzrUKKwlVB0SBbWrgZt4+EwKAo3ujCXnT7vshmCvXgZA09kCMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "noop6": "^1.0.1"
       }
     },
     "node_modules/function.prototype.name": {
@@ -6466,6 +7366,55 @@
         "node": ">= 14"
       }
     },
+    "node_modules/git-package-json": {
+      "version": "1.4.11",
+      "resolved": "https://registry.npmjs.org/git-package-json/-/git-package-json-1.4.11.tgz",
+      "integrity": "sha512-A/P5K2qqQ52+BwBf+qyrjtdauMlb7n1WVa++/VPDxTcgKZ2X5/Eh/EQwbxNvRKBsKAkMAeyV/UIdnb/saVFnnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deffy": "^2.2.1",
+        "err": "^1.1.1",
+        "gry": "^5.0.0",
+        "normalize-package-data": "^2.3.5",
+        "oargv": "^3.4.1",
+        "one-by-one": "^3.1.0",
+        "r-json": "^1.2.1",
+        "r-package-json": "^1.0.0",
+        "tmp": "0.0.28"
+      }
+    },
+    "node_modules/git-source": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/git-source/-/git-source-1.1.11.tgz",
+      "integrity": "sha512-oubUf/uply9xvR5olZxxPpip19wMEpESN3bFfPcFMvl/0fwrVrcAppwOJ7Dghcguze68WAIjs/A1YrdMDIW8XA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "git-url-parse": "^5.0.1"
+      }
+    },
+    "node_modules/git-up": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/git-up/-/git-up-1.2.1.tgz",
+      "integrity": "sha512-SRVN3rOLACva8imc7BFrB6ts5iISWKH1/h/1Z+JZYoUI7UVQM7gQqk4M2yxUENbq2jUUT09NEND5xwP1i7Ktlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-ssh": "^1.0.0",
+        "parse-url": "^1.0.0"
+      }
+    },
+    "node_modules/git-url-parse": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-5.0.1.tgz",
+      "integrity": "sha512-4uSiOgrryNEMBX+gTWogenYRUh2j1D+95STTSEF2RCTgLkfJikl8c7BGr0Bn274hwuxTsbS2/FQ5pVS9FoXegQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "git-up": "^1.0.0"
+      }
+    },
     "node_modules/glob": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -6524,6 +7473,17 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/global-logger-factory": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-logger-factory/-/global-logger-factory-1.0.0.tgz",
+      "integrity": "sha512-hN39r7dWZfdjhEaiM4r+2Fw/M3hjhmSHVVZmecp/IyQWhrCvpawWDk8imeHcsewGfaaGZWXoXjhjF5786E2biQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "winston": "^3.14.2",
+        "winston-transport": "^4.7.1"
+      }
+    },
     "node_modules/globals": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
@@ -6567,6 +7527,94 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/got": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-5.6.0.tgz",
+      "integrity": "sha512-MnypzkaW8dldA8AbJFjMs7y14+ykd2V8JCLKSvX1Gmzx1alH3Y+3LArywHDoAF2wS3pnZp4gacoYtvqBeF6drQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "create-error-class": "^3.0.1",
+        "duplexer2": "^0.1.4",
+        "is-plain-obj": "^1.0.0",
+        "is-redirect": "^1.0.0",
+        "is-retry-allowed": "^1.0.0",
+        "is-stream": "^1.0.0",
+        "lowercase-keys": "^1.0.0",
+        "node-status-codes": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "parse-json": "^2.1.0",
+        "pinkie-promise": "^2.0.0",
+        "read-all-stream": "^3.0.0",
+        "readable-stream": "^2.0.5",
+        "timed-out": "^2.0.0",
+        "unzip-response": "^1.0.0",
+        "url-parse-lax": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/got/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/got/node_modules/is-stream": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/got/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/got/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/got/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/got/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
@@ -6578,6 +7626,19 @@
       "resolved": "https://registry.npmjs.org/grapheme-splitter/-/grapheme-splitter-1.0.4.tgz",
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "license": "MIT"
+    },
+    "node_modules/gry": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/gry/-/gry-5.0.8.tgz",
+      "integrity": "sha512-meq9ZjYVpLzZh3ojhTg7IMad9grGsx6rUUKHLqPnhLXzJkRQvEL2U3tQpS5/WentYTtHtxkT3Ew/mb10D6F6/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abs": "^1.2.1",
+        "exec-limiter": "^3.0.0",
+        "one-by-one": "^3.0.0",
+        "ul": "^5.0.0"
+      }
     },
     "node_modules/has-bigints": {
       "version": "1.1.0",
@@ -6672,6 +7733,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/htmlfy": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/htmlfy/-/htmlfy-0.8.1.tgz",
@@ -6707,6 +7775,16 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/http-link-header": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/http-link-header/-/http-link-header-1.1.3.tgz",
+      "integrity": "sha512-3cZ0SRL8fb9MUlU3mKM61FcQvPfXx2dBrZW3Vbg5CXa8jFlK8OaEpePenLe1oEXQduhz8b0QjsqfS59QP4AJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -6832,6 +7910,13 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
     },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/internal-slot": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/internal-slot/-/internal-slot-1.1.0.tgz",
@@ -6873,6 +7958,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/is-async-function": {
       "version": "2.1.1",
@@ -7150,6 +8242,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-redirect": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
+      "integrity": "sha512-cr/SlUEe5zOGmzvj9bUyC4LVvkNVAXu4GytXLNMr1pny+a65MpQ9IJzFHD5vi7FyJgb4qt27+eS3TuQnqB+RQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -7167,6 +8269,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-set": {
@@ -7196,6 +8308,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-ssh": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.4.1.tgz",
+      "integrity": "sha512-JNeu1wQsHjyHgn9NcWTaXq6zWSR6hqE0++zhfZlkFBbScNkyvxCdeV8sRkSBaeLKxmbpR21brail63ACNxJ0Tg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "protocols": "^2.0.1"
       }
     },
     "node_modules/is-stream": {
@@ -7332,6 +8454,20 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isstream": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/iterate-object": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/iterate-object/-/iterate-object-1.3.5.tgz",
+      "integrity": "sha512-eL23u8oFooYTq6TtJKjp2RYjZnCkUYQvC0T/6fJfWykXJ3quvdDdzKZ3CEjy8b3JGOvLTjDYMEMIp5243R906A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -7438,6 +8574,105 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonld": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsonld/-/jsonld-9.0.0.tgz",
+      "integrity": "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@digitalbazaar/http-client": "^4.2.0",
+        "canonicalize": "^2.1.0",
+        "lru-cache": "^6.0.0",
+        "rdf-canonize": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/jsonld-context-parser": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/jsonld-context-parser/-/jsonld-context-parser-2.4.0.tgz",
+      "integrity": "sha512-ZYOfvh525SdPd9ReYY58dxB3E2RUEU4DJ6ZibO8AitcowPeBH4L5rCAitE2om5G1P+HMEgYEYEr4EZKbVN4tpA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-link-header": "^1.0.1",
+        "@types/node": "^18.0.0",
+        "cross-fetch": "^3.0.6",
+        "http-link-header": "^1.0.2",
+        "relative-to-absolute-iri": "^1.0.5"
+      },
+      "bin": {
+        "jsonld-context-parse": "bin/jsonld-context-parse.js"
+      }
+    },
+    "node_modules/jsonld-context-parser/node_modules/@types/node": {
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/jsonld-context-parser/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsonld-streaming-parser": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/jsonld-streaming-parser/-/jsonld-streaming-parser-2.4.3.tgz",
+      "integrity": "sha512-ysuevJ+l8+Y4W3J/yQW3pa9VCBNDHo2tZkKmPAnfhfsmFMyxuueAeXMmTbpJZdrpagzeeDVr3A8EZVuHliQJ9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "@types/http-link-header": "^1.0.1",
+        "canonicalize": "^1.0.1",
+        "http-link-header": "^1.0.2",
+        "jsonld-context-parser": "^2.1.3",
+        "jsonparse": "^1.3.1",
+        "rdf-data-factory": "^1.1.0"
+      }
+    },
+    "node_modules/jsonld/node_modules/canonicalize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/canonicalize/-/canonicalize-2.1.0.tgz",
+      "integrity": "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "canonicalize": "bin/canonicalize.js"
+      }
+    },
+    "node_modules/jsonld/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/jsonparse": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
+      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
+      "dev": true,
+      "engines": [
+        "node >= 0.2.0"
+      ],
+      "license": "MIT"
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -7516,6 +8751,26 @@
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
+      }
+    },
+    "node_modules/kuler": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/kuler/-/kuler-2.0.0.tgz",
+      "integrity": "sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ky": {
+      "version": "1.14.3",
+      "resolved": "https://registry.npmjs.org/ky/-/ky-1.14.3.tgz",
+      "integrity": "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/ky?sponsor=1"
       }
     },
     "node_modules/language-subtag-registry": {
@@ -7870,6 +9125,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/limit-it": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/limit-it/-/limit-it-3.2.11.tgz",
+      "integrity": "sha512-VdLa1lZYZnzT98oLMeCDl6Lwd9cEYIMQlPg34qL6CYuA+yQKoG7K12tfgI5K6bRC51kRM8v1UX67IhpNsnvo3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "typpy": "^2.0.0"
+      }
+    },
     "node_modules/locate-app": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/locate-app/-/locate-app-2.5.0.tgz",
@@ -7932,6 +9197,24 @@
       "integrity": "sha512-C7IOaBBK/0gMORRBd8OETNx3kmOkgIWIPvyDpZSCTwUrpYmgZwJkjZeOD8ww4xbOUOs4/attY+pciKvadNfFbg==",
       "license": "MIT"
     },
+    "node_modules/logform": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/logform/-/logform-2.7.0.tgz",
+      "integrity": "sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "1.6.0",
+        "@types/triple-beam": "^1.3.2",
+        "fecha": "^4.2.0",
+        "ms": "^2.1.1",
+        "safe-stable-stringify": "^2.3.1",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
     "node_modules/loglevel": {
       "version": "1.9.2",
       "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
@@ -7962,6 +9245,16 @@
       },
       "bin": {
         "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/lowercase-keys": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
+      "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/lru-cache": {
@@ -8105,6 +9398,20 @@
         "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
         "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
         "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/n3": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.26.0.tgz",
+      "integrity": "sha512-SQknS0ua90rN+3RHuk8BeIqeYyqIH/+ecViZxX08jR4j6MugqWRjtONl3uANG/crWXnOM2WIqBJtjIhVYFha+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
       }
     },
     "node_modules/nanoid": {
@@ -8276,6 +9583,27 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-gyp-build-optional-packages": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
@@ -8289,6 +9617,97 @@
         "node-gyp-build-optional-packages": "bin.js",
         "node-gyp-build-optional-packages-optional": "optional.js",
         "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/node-status-codes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-status-codes/-/node-status-codes-1.0.0.tgz",
+      "integrity": "sha512-1cBMgRxdMWE8KeWCqk2RIOrvUb0XCwYfEsY5/y2NlXyq4Y/RumnOZvTj4Nbr77+Vb2C+kyBoRTdkNOS8L3d/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/nodeify-fetch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/nodeify-fetch/-/nodeify-fetch-2.2.2.tgz",
+      "integrity": "sha512-4b1Jysy9RGyya0wJpseTQyxUgSbx6kw9ocHTY0OFRXWlxa2Uy5PrSo/P/nwoUn59rBR9YKty2kd7g4LKXmsZVA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zazuko/node-fetch": "^2.6.6",
+        "concat-stream": "^1.6.0",
+        "cross-fetch": "^3.0.4",
+        "readable-error": "^1.0.0",
+        "readable-stream": "^3.5.0"
+      }
+    },
+    "node_modules/nodeify-fetch/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/noop6": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/noop6/-/noop6-1.0.10.tgz",
+      "integrity": "sha512-WZvuCILZFZHK+WuqCQwxLBGllkBK1ct8s8Mu9FMDbEsBE6/bqNxyFGbX7Xky+6bYFL8X2Ou4Cis4CJyrwXLvQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/resolve": {
+      "version": "1.22.12",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+      "integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/normalize-path": {
@@ -8310,6 +9729,27 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/oargv": {
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/oargv/-/oargv-3.4.11.tgz",
+      "integrity": "sha512-FGTon9C71936EnOjx/NTsMxlLeWmw8zQQld4KDmgRxRtZ8fH1XpbLLRHmOioeZs/WoURz2OGR4KmDoTaL4ErJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iterate-object": "^1.1.0",
+        "ul": "^5.0.0"
+      }
+    },
+    "node_modules/obj-def": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/obj-def/-/obj-def-1.0.10.tgz",
+      "integrity": "sha512-RJpNUkO+1r/rXTBs82iU4scoC9Q1yp9HZbSk0ldpFe8362S6eTjUjSgTmECa1TtOBIe5pn4pwSzxIiWc8+jmWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deffy": "^2.2.2"
       }
     },
     "node_modules/object-assign": {
@@ -8444,6 +9884,27 @@
         "wrappy": "1"
       }
     },
+    "node_modules/one-by-one": {
+      "version": "3.2.9",
+      "resolved": "https://registry.npmjs.org/one-by-one/-/one-by-one-3.2.9.tgz",
+      "integrity": "sha512-H10TAq02LKrkSRTQz1mgvcKb64rRajZ+B5HWHBvkGigYNCPqL0Q/tLIN3vfha/DqZxXeKNfyCmgfEYo2hgFQgA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "obj-def": "^1.0.0",
+        "sliced": "^1.0.1"
+      }
+    },
+    "node_modules/one-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/one-time/-/one-time-1.0.0.tgz",
+      "integrity": "sha512-5DXOiRKwuSEcQ/l0kGCF6Q3jcADFv5tSmRaJck/OqkVFcOzutB134KRSfF0xDrL39MNnqxbHBbUUcjZIhTgb2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fn.name": "1.x.x"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -8460,6 +9921,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/own-keys": {
@@ -8544,11 +10015,66 @@
         "node": ">= 14"
       }
     },
+    "node_modules/package-json": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/package-json/-/package-json-2.4.0.tgz",
+      "integrity": "sha512-PRg65iXMTt/uK8Rfh5zvzkUbfAPitF17YaCY+IbHsYgksiLvtzWWTUildHth3mVaZ7871OJ7gtP4LBRBlmAdXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "got": "^5.0.0",
+        "registry-auth-token": "^3.0.1",
+        "registry-url": "^3.0.3",
+        "semver": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/package-json-path": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/package-json-path/-/package-json-path-1.0.10.tgz",
+      "integrity": "sha512-DOlmVIfx+qDHHWaaxg573brZ8mH0Nxo4ecYA4SKkrpCOhCP64NXk7VxJtWVKZQ9urfU2Ivl74HeYUO42PLCpLw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abs": "^1.2.1"
+      }
+    },
+    "node_modules/package-json/node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/package-lock.json": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/package-lock.json/-/package-lock.json-1.0.0.tgz",
+      "integrity": "sha512-+yEXtNdlCs5N0Zy/9uvkifgf/RqnGu0WqP4j9Wu1Us4YReFe1YNBh2Krmf8B1xGxjpYnta63K55QP8bkafnOzA==",
+      "dev": true
+    },
+    "node_modules/package.json": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/package.json/-/package.json-2.0.1.tgz",
+      "integrity": "sha512-pSxZ6XR5yEawRN2ekxx9IKgPN5uNAYco7MCPxtBEWMKO3UKWa1X2CtQMzMgloeGj2g2o6cue3Sb5iPkByIJqlw==",
+      "deprecated": "Use pkg.json instead.",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "git-package-json": "^1.4.0",
+        "git-source": "^1.1.0",
+        "package-json": "^2.3.1"
+      }
     },
     "node_modules/pako": {
       "version": "2.1.0",
@@ -8568,6 +10094,37 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/parse-json": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+      "integrity": "sha512-QR/GGaKCkhwk1ePQNYDRKYZ3mwU9ypsKhB0XyFnLQdomyEqk3e8wpW3V5Jp88zbxK4n5ST1nqo+g9juTpownhQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-ex": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/parse-url": {
+      "version": "1.3.11",
+      "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-1.3.11.tgz",
+      "integrity": "sha512-1wj9nkgH/5EboDxLwaTMGJh3oH3f+Gue+aGdh631oCqoSBpokzmMmOldvOeBPtB8GJBYJbaF93KPzlkU+Y1ksg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-ssh": "^1.3.0",
+        "protocols": "^1.4.0"
+      }
+    },
+    "node_modules/parse-url/node_modules/protocols": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
+      "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -8700,6 +10257,29 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/playwright": {
       "version": "1.61.0",
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
@@ -8781,6 +10361,16 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/prepend-http": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
+      "integrity": "sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/process": {
       "version": "0.11.10",
       "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
@@ -8816,6 +10406,13 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
+    },
+    "node_modules/protocols": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/protocols/-/protocols-2.0.2.tgz",
+      "integrity": "sha512-hHVTzba3wboROl0/aWRRG9dMytgH6ow//STBZh43l/wQgmMhYhOFi0EHWAPtoCz9IAUymsyP0TSBHkhgMEGNnQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/proxy-agent": {
       "version": "6.5.0",
@@ -8898,6 +10495,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/r-json": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/r-json/-/r-json-1.3.1.tgz",
+      "integrity": "sha512-5nhRFfjVMQdrwKUfUlRpDUCocdKtjSnYZ1R/86mpZDV3MfsZ3dYYNjSGuMX+mPBvFvQBhdzxSqxkuLPLv4uFGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "w-json": "1.3.10"
+      }
+    },
+    "node_modules/r-package-json": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/r-package-json/-/r-package-json-1.0.10.tgz",
+      "integrity": "sha512-g+KLu+aq3tkhW6gzjsfdWAyd+ZkueLTzkX2zpB2GIW7M/lOXal3nB8U36XOrIBGogJsz2H//xWA4mj9uGlcigw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-json-path": "^1.0.0",
+        "r-json": "^1.2.1"
+      }
+    },
     "node_modules/radix-ui": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/radix-ui/-/radix-ui-1.6.0.tgz",
@@ -8973,6 +10591,142 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dev": true,
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/rc/node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rdf-canonize": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rdf-canonize/-/rdf-canonize-5.0.0.tgz",
+      "integrity": "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "setimmediate": "^1.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/rdf-data-factory": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/rdf-data-factory/-/rdf-data-factory-1.1.3.tgz",
+      "integrity": "sha512-ny6CI7m2bq4lfQQmDYvcb2l1F9KtGwz9chipX4oWu2aAtVoXjb7k3d8J1EsgAsEbMXnBipB/iuRen5H2fwRWWQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "^1.0.0"
+      }
+    },
+    "node_modules/rdf-data-factory/node_modules/@rdfjs/types": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rdfjs/types/-/types-1.1.2.tgz",
+      "integrity": "sha512-wqpOJK1QCbmsGNtyzYnojPU8gRDPid2JO0Q0kMtb4j65xhCK880cnKAfEOwC+dX85VJcCByQx5zOwyyfCjDJsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/rdf-js": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/rdf-js/-/rdf-js-4.0.2.tgz",
+      "integrity": "sha512-ApvlFa/WsQh8LpPK/6hctQwG06Z9ztQQGWVtrcrf9L6+sejHNXLPOqL+w7q3hF+iL0C4sv3AX1PUtGkLNzyZ0Q==",
+      "deprecated": "Use @types/rdf-js instead. See https://github.com/rdfjs/types?tab=readme-ov-file#what-about-typesrdf-js",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdf-vocabulary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/rdf-vocabulary/-/rdf-vocabulary-1.0.1.tgz",
+      "integrity": "sha512-0I7osG03qJ/7O/cEY/1wDLWnx+JBPoxPa9Iz/8856W7Ci7XNLBj8ZSWZCqVCOi/v5P6nenw5V9gkmPkg5TGZkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*"
+      }
+    },
+    "node_modules/rdflib": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/rdflib/-/rdflib-2.3.9.tgz",
+      "integrity": "sha512-6HnEQ22QzgqPW2/R8y5IaeQoXnho6U+ovU1q/ZF556zEnSK4buwhw8/CDdRDwIHZQh5+PAncQxUhluO3JmguJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.29.2",
+        "@frogcat/ttl2jsonld": "^0.0.10",
+        "@rdfjs/types": "^2.0.1",
+        "@xmldom/xmldom": "^0.9.10",
+        "cross-fetch": "^4.1.0",
+        "jsonld": "^9.0.0",
+        "n3": "^2.0.3",
+        "package-lock.json": "^1.0.0",
+        "package.json": "^2.0.1",
+        "solid-namespace": "^0.5.4"
+      }
+    },
+    "node_modules/rdflib/node_modules/cross-fetch": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
+      "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/rdflib/node_modules/n3": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-2.0.4.tgz",
+      "integrity": "sha512-d2Sr4vvqombySfOARjw5jQky0EYMwkEXuQQjYe2glasDdI3hAT3l00aJZbAmR+AA59eFNjJbDkHCq9l5Dm2DIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^6.0.3",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/rdfxml-streaming-parser": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.5.0.tgz",
+      "integrity": "sha512-pnt+7NgeqCMd2/rub+dqxzYJhZwJjBNU2BRwyYdCTmRZu2fr795jCPJB6Io5pjPzAt29ASqy+ODBSRMDKoKGbQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rdfjs/types": "*",
+        "rdf-data-factory": "^1.1.0",
+        "relative-to-absolute-iri": "^1.0.0",
+        "sax": "^1.2.4"
       }
     },
     "node_modules/react": {
@@ -9072,6 +10826,110 @@
         }
       }
     },
+    "node_modules/read-all-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/read-all-stream/-/read-all-stream-3.1.0.tgz",
+      "integrity": "sha512-DI1drPHbmBcUDWrJ7ull/F2Qb8HkwBncVx8/RpKYFSIACYaVRQReISYPdZz/mt1y1+qMCOrfReTopERmaxtP6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "pinkie-promise": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/read-all-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/read-all-stream/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/read-all-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/read-all-stream/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/readable-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/readable-error/-/readable-error-1.0.0.tgz",
+      "integrity": "sha512-CLnInu5bUphmFiZ3pD/BC6+Cg4/BzK6ZMvWfd0b2QMzYo159Z/f/nVFQ9L5IeMrqUxy0EFsp3XJ+BRfLfY13IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^2.3.3"
+      }
+    },
+    "node_modules/readable-error/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-error/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-error/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/readable-error/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
@@ -9086,6 +10944,32 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/readable-to-readable": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/readable-to-readable/-/readable-to-readable-0.1.3.tgz",
+      "integrity": "sha512-G+0kz01xJM/uTuItKcqC73cifW8S6CZ7tp77NLN87lE5mrSU+GC8geoSAlfmp0NocmXckQ7W8s8ns73HYsIA3w==",
+      "deprecated": "This package is no longer maintained",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "node_modules/readable-to-readable/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/readdir-glob": {
@@ -9160,6 +11044,41 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/registry-auth-token": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.4.0.tgz",
+      "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/registry-url": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
+      "integrity": "sha512-ZbgR5aZEdf4UKZVBPYIgaglBmSF2Hi94s2PcIHhRGFjKYu+chjJdYfHn4rt3hB6eCKLJ8giVIIfgMa1ehDfZKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/relative-to-absolute-iri": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.8.tgz",
+      "integrity": "sha512-U1TmhrhCmXKkDL9mI8gBbF5TN6TKcuv28k5+H3gMCAjoz0TyyHAICHlaGDZsTEBSu2Y3HhDKc8e6X9n33qeIqA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/rubensworks/"
       }
     },
     "node_modules/require-directory": {
@@ -9386,11 +11305,31 @@
         "safe-regex2": "bin/safe-regex2.js"
       }
     },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -9646,6 +11585,14 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sliced": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha512-VZBmZP8WU3sMOZm1bdgTadsQbcscK0UM8oKxKVBs4XAhUo2Xxzm/OFMGBkPusxw9xL3Uy8LrzEqGqJhclsr0yA==",
+      "deprecated": "Unsupported",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/smart-buffer": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
@@ -9683,6 +11630,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/solid-namespace": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/solid-namespace/-/solid-namespace-0.5.4.tgz",
+      "integrity": "sha512-oPAv8xIg2MOLz069JRdvsSbYCpQN+umPJJ9LBFPzCrYuSw+dW4TMUOTDxTWS5xy+B3XN4+Fx3iIS5Jm8abm4Mg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/sonner": {
       "version": "2.0.7",
@@ -9737,6 +11691,42 @@
       "resolved": "site",
       "link": true
     },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/split2": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
@@ -9752,6 +11742,16 @@
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
@@ -10158,6 +12158,23 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/text-hex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/text-hex/-/text-hex-1.0.0.tgz",
+      "integrity": "sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/timed-out": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz",
+      "integrity": "sha512-pqqJOi1rF5zNs/ps4vmbE4SFCrM4iR7LW+GHAsHqO/EumqbIWceioevYLM5xZRgQSH6gFgL9J/uB7EcJhQ9niQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -10206,6 +12223,19 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tmp": {
+      "version": "0.0.28",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
+      "integrity": "sha512-c2mmfiBmND6SOVxzogm1oda0OJ1HZVIk/5n26N59dDTh80MUeavpiCls4PGAdkX1PFkKokLpcf7prSjCeXLsJg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.1"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -10217,6 +12247,23 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/triple-beam": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/triple-beam/-/triple-beam-1.4.1.tgz",
+      "integrity": "sha512-aZbgViZrg1QNcG+LULa7nhZpJTZSLm/mXnHXnbAbjmN5aSa0y7V+wvv6+4WaBtpISJzThKy+PIPxc1Nq1EJ9mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
       }
     },
     "node_modules/ts-api-utils": {
@@ -10364,6 +12411,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/typescript": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
@@ -10376,6 +12430,27 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typpy": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/typpy/-/typpy-2.4.0.tgz",
+      "integrity": "sha512-a16Uv5doNtvHzaG4wZCHmXN+l9xxmTMpyODtPz7B3DSTsDVNXilTSJGuNw68sUh0Un4bf+ghRMbEcJCI6r06mQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function.name": "^1.0.3"
+      }
+    },
+    "node_modules/ul": {
+      "version": "5.2.16",
+      "resolved": "https://registry.npmjs.org/ul/-/ul-5.2.16.tgz",
+      "integrity": "sha512-v1YrSEsJZpJsywzF/MKgsQwMdOwBlwwmNiUOJh/yX6FHrq7dYjeua1YOhLV0q0KioqEFZC4P7MsKmpEsGdZz3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "deffy": "^2.2.2",
+        "typpy": "^2.3.4"
       }
     },
     "node_modules/unbox-primitive": {
@@ -10450,6 +12525,16 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
+    "node_modules/unzip-response": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/unzip-response/-/unzip-response-1.0.2.tgz",
+      "integrity": "sha512-pwCcjjhEcpW45JZIySExBHYv5Y9EeL2OIGEfrSKp2dMUFGFv4CpvZkwJbVge8OvGH2BNNtJBx67DuKuJhf+N5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -10458,6 +12543,19 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse-lax": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
+      "integrity": "sha512-BVA4lR5PIviy2PMseNd2jbFQ+jwSwQGdJejf5ctd1rEXt0Ypd7yanUK9+lYechVlN5VaTJGsu2U/3MDDu6KgBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "prepend-http": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/urlpattern-polyfill": {
@@ -10522,6 +12620,31 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/validate-iri": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/validate-iri/-/validate-iri-1.0.1.tgz",
+      "integrity": "sha512-gLXi7351CoyVVQw8XE5sgpYawRKatxE7kj/xmCxXOZS1kMdtcqC0ILIqLuVEVnAUQSL/evOGG3eQ+8VgbdnstA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/w-json": {
+      "version": "1.3.10",
+      "resolved": "https://registry.npmjs.org/w-json/-/w-json-1.3.10.tgz",
+      "integrity": "sha512-XadVyw0xE+oZ5FGApXsdswv96rOhStzKqL53uSe5UaTadABGkWIg1+DTx8kiZ/VqTZTBneoL0l65RcPe4W3ecw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/wait-port": {
@@ -10655,6 +12778,13 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true,
+      "license": "BSD-2-Clause"
+    },
     "node_modules/whatwg-encoding": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -10675,6 +12805,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {
@@ -10779,6 +12920,74 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/winston": {
+      "version": "3.19.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-3.19.0.tgz",
+      "integrity": "sha512-LZNJgPzfKR+/J3cHkxcpHKpKKvGfDZVPS4hfJCc4cCG0CgYzvlD6yE/S3CIL/Yt91ak327YCpiF/0MyeZHEHKA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@colors/colors": "^1.6.0",
+        "@dabh/diagnostics": "^2.0.8",
+        "async": "^3.2.3",
+        "is-stream": "^2.0.0",
+        "logform": "^2.7.0",
+        "one-time": "^1.0.0",
+        "readable-stream": "^3.4.0",
+        "safe-stable-stringify": "^2.3.1",
+        "stack-trace": "0.0.x",
+        "triple-beam": "^1.3.0",
+        "winston-transport": "^4.9.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/winston-transport/-/winston-transport-4.9.0.tgz",
+      "integrity": "sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "logform": "^2.7.0",
+        "readable-stream": "^3.6.2",
+        "triple-beam": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-transport/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/winston/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/word-wrap": {
@@ -10921,6 +13130,13 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -10929,6 +13145,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.3",

--- a/package.json
+++ b/package.json
@@ -8,5 +8,10 @@
     "js",
     "site",
     "gui/e2e"
-  ]
+  ],
+  "devDependencies": {
+    "@solid/acl-check": "^0.4.5",
+    "@solidlab/policy-engine": "^0.0.2",
+    "n3": "^1.26.0"
+  }
 }


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (Opus 4.8, 1M context). This PR was prepared autonomously; a human should review before merge.

Implements **sq-t58w.9** — a STRONG SECOND, CROSS-LANGUAGE differential oracle for the `sparq-solid` WAC/ACP authorization engine. It is the JavaScript counterpart to the Rust differential oracle (sq-t58w.7, #899): it replays the **IDENTICAL** shared corpus (`crates/sparq-solid/tests/common/{wac,acp}.rs`) through **independent JS Solid reference engines** and asserts they agree with sparq-solid's **own** decisions, with zero unexpected divergence.

## Which JS engine(s)
- **WAC** → [`@solid/acl-check`](https://www.npmjs.com/package/@solid/acl-check) `0.4.5` (the rdflib-based Solid WAC checker — pure in-memory `checkAccess`; resolves `acl:agent`/`agentClass`/`agentGroup`/`origin` from the in-memory store, **no network**) **plus a second WAC opinion** from [`@solidlab/policy-engine`](https://www.npmjs.com/package/@solidlab/policy-engine) `0.0.2` (`WacPolicyEngine`).
- **ACP** → `@solidlab/policy-engine`'s `AcpPolicyEngine` (acl-check is WAC-only).

## How sparq-solid's decisions were obtained
`sparq-solid` is a Rust crate and is **not exposed through the wasm build** (verified: no `sparq_solid` reference in `crates/sparq-wasm` or `js/src`), so there is no in-process wasm path — and adding one is out of scope (hard boundary on `crates/sparq-wasm`/`crates/sparq-solid`). Instead, sparq's decisions are captured in `js/test/fixtures/solid-acl-corpus.json`, emitted by a **one-shot Rust generator** (throwaway, **not** checked in) that `include!`s the **same** shared corpus and records, per request, sparq-solid's **actual** engine verdict via `AuthIndex::accessible` — **not a hand table**. The fixture also carries the spec `Expect`; a fixture-integrity test re-asserts `sparqDecision === specExpect` (0 mismatch) — the invariant the in-repo Rust conformance suites + oracle prove on `main`.

## Divergence count
| Mechanism | Pairs | Unexpected divergences | Triaged known-differences |
|-----------|-------|------------------------|---------------------------|
| WAC (acl-check + policy-engine) | 47 | **0** | 13 |
| ACP (policy-engine) | 40 | **0** | 0 |

A divergence is **TRIAGED** (printed for inspection), never auto-attributed to sparq. The triaged WAC known-differences are all reference-engine semantics, **not sparq bugs**, each keyed + verdict-direction-aware + rationale-documented:
1. **`acl:origin`** — both JS engines grant on the agent alone when the presented origin is absent/non-matching; sparq enforces the strict (user, application) pair.
2. **`acl:Control`→`.acl`** — neither JS engine models `acl:Control` ⇒ Read+Write of the `<R>.acl` resource; sparq **and the Rust reference oracle (#899)** do.
3. **policy-engine `acl:agentGroup`** — its checker HTTP-`fetch`es the vCard group document (incompatible with the no-network mandate); `@solid/acl-check` resolves the same group **in-memory and agrees with sparq**.
4. **policy-engine no-ACL orphan** — it throws `No ACL document found for root container` instead of denying; sparq (and acl-check) fail-closed to deny.

A **negative-control** test proves the comparison is load-bearing (a deliberately wrong expectation IS flagged).

## Honest caveat (research-grade reference)
`@solidlab/policy-engine` is **pre-1.0 (v0.0.2)** — it encodes implementation-truth, not spec-truth. A disagreement here is a **triage signal, not proof sparq is wrong**.

## Dev-deps pinned (repo-root `package-lock.json` via `js/package.json` devDependencies)
- `@solidlab/policy-engine@0.0.2`, `@solid/acl-check@0.4.5` (transitive `rdflib@2.3.9` + `solid-namespace`), `n3@1.26.0` (N-Quads parsing). **Dev/test-only** — excluded from the published `@jeswr/sparq` tarball (`files` allowlist intact; `check:package` green).

## Constraints
NO docker, NO server, **NO network at test time** — everything parsed + evaluated in-memory. Picked up by `node --test "test/*.test.mjs"` in the `js` CI lane.

## Gates
- `node --test js/test/solid-differential.test.mjs` → **4/4 pass**, WAC/ACP **0 unexpected divergences**.
- Full `js` suite (`node --test test/*.test.mjs`) → **76/76 pass** (new test picked up, existing wasm-backed tests unaffected).
- `tsc --noEmit` (js src) clean; `npm run check:package` green; `typos` clean on the changed files.
- `npm ci`/`npm install` resolves with the 2 new dev-deps; root lockfile updated.

Hard boundary respected: **no** changes to `crates/sparq-wasm`, `packages/sparq-client/src/generated/*`, or `crates/sparq-solid` — surface is `js/test/` + the root `package-lock.json` dev-dep additions only.

Closes sq-t58w.9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)