### PR TITLE
feat(sparq-vectors): persist the delta sidecar to disk (.spqd, durable add/remove/update) (sq-7e50) [OPUS-4.8]

### DIFF
--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -75,9 +75,10 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   and reopen **that** (`Graph::open`, frozen id order); **never** re-parse the source RDF
   (pinned in `tests/staleness_contract.rs`).
 - **Incremental add / remove / update (opt-in `delta`)** — a `.spqv` is build-once-immutable; the
-  `delta` feature adds an **in-RAM delta sidecar** (`add`/`remove`/`update` → append map + tombstones)
-  that `get`/`iter`/search transparently union (honouring tombstones), generation-tied to the base
-  (sq-32i5). `compact` folds it into a from-scratch-equivalent base. **In-RAM only** (lost on drop; `compact` is the durability path); a persisted delta is a tracked follow-up. No new dep. See rustdoc/SKILL.
+  `delta` feature adds a **delta sidecar** (`add`/`remove`/`update` → append map + tombstones) that
+  `get`/`iter`/search transparently union (honouring tombstones), generation-tied to the base
+  (sq-32i5); `compact` folds it into a from-scratch-equivalent base. `save_delta`/`open_with_delta`
+  persist+replay it to a crash-durable `.spqd` (tmp+fsync+rename, partial-write & mismatched-base detected) so mutations survive a restart without a compact. No new dep. See rustdoc/SKILL.
 - **Verbalization, quantization, hybrid fusion** — `verbalize` / `embed_entities` render
   per-entity text (multilingual, char-budgeted, single named graph at a time);
   `ScalarQuantizer` (4×) and `ProductQuantizer` for large stores; `fuse_rrf` /

--- a/crates/sparq-vectors/src/delta.rs
+++ b/crates/sparq-vectors/src/delta.rs
@@ -85,7 +85,7 @@
 //! `.spqd-tmp`, `fsync`s it, then atomically `rename`s it over the final path — the same
 //! write-tmp-then-rename + `sync_all` discipline as [`StreamingWriter`](crate::store::StreamingWriter):
 //! a crash mid-write leaves the previous `.spqd` (or none) intact, never a half-written sidecar at
-//! the live path. **Partial-write detection.** [`from_bytes`](VectorDelta::from_bytes) recomputes
+//! the live path. **Partial-write detection.** `from_bytes` (the crate-internal decoder) recomputes
 //! the EXACT expected length from the header (`56 + append_count·(4 + dim·4) + tomb_count·4`) and
 //! rejects any file that is shorter OR longer — a truncated (or trailing-garbage) sidecar is a
 //! descriptive `Err`, never an out-of-bounds read or a silently-short replay.

--- a/crates/sparq-vectors/src/delta.rs
+++ b/crates/sparq-vectors/src/delta.rs
@@ -47,13 +47,66 @@
 //! the crate docs / the sq-pi44 follow-up bead. `compact` is the durability path today: it
 //! materializes the delta into a normal, validated `.spqv`.
 //!
+//! # [OPUS-4.8] (sq-7e50) Persisted on-disk delta sidecar (`.spqd`)
+//!
+//! The in-RAM delta above is lost when the [`VectorStore`](crate::store::VectorStore) handle drops
+//! — [`compact`](crate::store::VectorStore::compact) was the only durability path. sq-7e50 adds a
+//! **persisted** sidecar so incremental add/remove/update survive a process restart *without* a
+//! compact: [`VectorStore::save_delta`](crate::store::VectorStore::save_delta) serializes the
+//! in-RAM [`VectorDelta`] to a little-endian `.spqd` file alongside the `.spqv` base, and
+//! [`VectorStore::open_with_delta`](crate::store::VectorStore::open_with_delta) opens the base mmap
+//! and replays the persisted delta back onto it (through the same generation-tie validation as
+//! [`apply_delta`](crate::store::VectorStore::apply_delta)).
+//!
+//! ## On-disk format (version 1, little-endian — mirrors the `.spqv` header discipline)
+//!
+//! ```text
+//! offset 0   magic         b"SPQD"                         4 bytes
+//! offset 4   version       u32 = 1                         4 bytes
+//! offset 8   dim           u32                             4 bytes
+//! offset 12  append_count  u64                             8 bytes
+//! offset 20  tomb_count    u64                             8 bytes
+//! offset 28  reserved      zero padding                    4 bytes
+//! offset 32  fingerprint   base graph fingerprint          24 bytes
+//!            (dict_len: u64, triple_count: u64, content_hash: u64)
+//! offset 56  appends       [append_count × (id: u32, dim × f32)]
+//!            tombstones     [tomb_count × (id: u32)]        (after the appends)
+//! ```
+//!
+//! The header carries the **base graph fingerprint** (the [`generation`](VectorDelta::generation)
+//! the delta is keyed against — the sq-32i5 generation tie): on open the persisted fingerprint is
+//! decoded into the delta's `generation`, so replaying it through `apply_delta` REJECTS a delta
+//! whose generation does not match the base store's bound fingerprint — a persisted delta written
+//! against generation N can never be silently mis-keyed onto a base of generation M ≠ N. The
+//! all-zero block decodes to `None` (an unbound/unverified delta), exactly as the `.spqv`
+//! fingerprint block does.
+//!
+//! **Crash-durability.** [`save_delta`](crate::store::VectorStore::save_delta) writes to a sibling
+//! `.spqd-tmp`, `fsync`s it, then atomically `rename`s it over the final path — the same
+//! write-tmp-then-rename + `sync_all` discipline as [`StreamingWriter`](crate::store::StreamingWriter):
+//! a crash mid-write leaves the previous `.spqd` (or none) intact, never a half-written sidecar at
+//! the live path. **Partial-write detection.** [`from_bytes`](VectorDelta::from_bytes) recomputes
+//! the EXACT expected length from the header (`56 + append_count·(4 + dim·4) + tomb_count·4`) and
+//! rejects any file that is shorter OR longer — a truncated (or trailing-garbage) sidecar is a
+//! descriptive `Err`, never an out-of-bounds read or a silently-short replay.
+//!
 //! Opt-in: the whole layer is gated behind the **`delta`** cargo feature, off by default, and adds
 //! NO dependency (it reuses the in-tree `rustc-hash` map/set), so the default build carries zero
 //! delta code.
 
-use crate::fingerprint::Fingerprint;
+use crate::fingerprint::{Fingerprint, FINGERPRINT_LEN};
 use rustc_hash::{FxHashMap, FxHashSet};
 use sparq_core::dict::Id;
+
+/// [OPUS-4.8] (sq-7e50) First four bytes of every persisted `.spqd` delta sidecar file.
+pub const SPQD_MAGIC: [u8; 4] = *b"SPQD";
+/// [OPUS-4.8] (sq-7e50) Current `.spqd` format version.
+pub const SPQD_VERSION: u32 = 1;
+/// [OPUS-4.8] (sq-7e50) Byte length of the `.spqd` header: magic(4) + version(4) + dim(4) +
+/// append_count(8) + tomb_count(8) + reserved(4) + fingerprint(`FINGERPRINT_LEN`). All counts and
+/// the fingerprint are fixed-width little-endian, so a sidecar written on one machine decodes
+/// identically on another (the same cross-machine discipline as the `.spqv` header / fingerprint).
+const SPQD_HEADER_LEN: usize = 32 + FINGERPRINT_LEN;
 
 /// [OPUS-4.8] (sq-pi44) The in-RAM delta sidecar: vectors appended/updated and ids tombstoned
 /// since the base store was built, plus the graph [`Fingerprint`] the delta is keyed against.
@@ -102,5 +155,248 @@ impl VectorDelta {
     /// Whether the delta holds no appends and no tombstones (a no-op delta).
     pub fn is_empty(&self) -> bool {
         self.appended.is_empty() && self.tombstones.is_empty()
+    }
+
+    /// [OPUS-4.8] (sq-7e50) Serializes the delta to the little-endian `.spqd` on-disk format (see
+    /// the module docs). `dim` is the base store's vector dimension — every appended vector MUST
+    /// be exactly `dim` long (the in-RAM `add`/`update` validation guarantees this) so the body is
+    /// a fixed `dim·4`-byte stride per append, and `from_bytes` can recompute the exact length.
+    ///
+    /// Appends and tombstones are each emitted in ASCENDING id order, so the bytes are a
+    /// deterministic function of the logical delta (re-saving an unchanged delta is byte-stable and
+    /// machine-independent), not of `FxHashMap`/`FxHashSet` iteration order.
+    pub(crate) fn to_bytes(&self, dim: usize) -> Vec<u8> {
+        let append_count = self.appended.len();
+        let tomb_count = self.tombstones.len();
+        let mut out = Vec::with_capacity(
+            SPQD_HEADER_LEN + append_count * (4 + dim * 4) + tomb_count * 4,
+        );
+        out.extend_from_slice(&SPQD_MAGIC);
+        out.extend_from_slice(&SPQD_VERSION.to_le_bytes());
+        out.extend_from_slice(&(dim as u32).to_le_bytes());
+        out.extend_from_slice(&(append_count as u64).to_le_bytes());
+        out.extend_from_slice(&(tomb_count as u64).to_le_bytes());
+        out.extend_from_slice(&[0u8; 4]); // reserved
+        // The base generation tie: a zero block for an unbound (None) generation — decoded back to
+        // None by `Fingerprint::from_bytes_opt`, exactly as the `.spqv` fingerprint block is.
+        match self.generation {
+            Some(fp) => out.extend_from_slice(&fp.to_bytes()),
+            None => out.extend_from_slice(&[0u8; FINGERPRINT_LEN]),
+        }
+        debug_assert_eq!(out.len(), SPQD_HEADER_LEN);
+
+        // Appends in ascending id order: (id: u32, dim × f32).
+        let mut appends: Vec<(&Id, &Vec<f32>)> = self.appended.iter().collect();
+        appends.sort_unstable_by_key(|&(id, _)| *id);
+        for (id, vec) in appends {
+            out.extend_from_slice(&id.to_le_bytes());
+            for &v in vec {
+                out.extend_from_slice(&v.to_le_bytes());
+            }
+        }
+        // Tombstones in ascending id order: (id: u32).
+        let mut tombs: Vec<Id> = self.tombstones.iter().copied().collect();
+        tombs.sort_unstable();
+        for id in tombs {
+            out.extend_from_slice(&id.to_le_bytes());
+        }
+        out
+    }
+
+    /// [OPUS-4.8] (sq-7e50) Parses a `.spqd` delta sidecar from `bytes`, returning the reconstructed
+    /// in-RAM [`VectorDelta`] (its `generation` set from the header fingerprint block) and the base
+    /// `dim` it was written for (the caller checks `dim` against its base store).
+    ///
+    /// **Validation is fail-closed.** A bad magic, an unknown version, a `dim` of zero, an append/
+    /// tombstone count whose implied body length overflows or does not EXACTLY match `bytes.len()`
+    /// (the partial-write / truncation guard — a short OR long file is rejected), or a duplicate /
+    /// conflicting id (an id appearing in both the append and tombstone sections, or twice in one
+    /// section) is a descriptive `Err`, never an out-of-bounds read or a silently-truncated replay.
+    pub(crate) fn from_bytes(bytes: &[u8]) -> Result<(VectorDelta, usize), String> {
+        if bytes.len() < SPQD_HEADER_LEN {
+            return Err(format!(
+                ".spqd: truncated header ({} bytes, need at least {})",
+                bytes.len(),
+                SPQD_HEADER_LEN
+            ));
+        }
+        if bytes[0..4] != SPQD_MAGIC {
+            return Err(".spqd: not a delta sidecar (bad magic)".into());
+        }
+        let version = u32::from_le_bytes(bytes[4..8].try_into().unwrap());
+        if version != SPQD_VERSION {
+            return Err(format!(
+                ".spqd: unsupported version {} (this build writes/reads version {})",
+                version, SPQD_VERSION
+            ));
+        }
+        let dim = u32::from_le_bytes(bytes[8..12].try_into().unwrap()) as usize;
+        if dim == 0 {
+            return Err(".spqd: invalid zero vector dimension".into());
+        }
+        let append_count = u64::from_le_bytes(bytes[12..20].try_into().unwrap()) as usize;
+        let tomb_count = u64::from_le_bytes(bytes[20..28].try_into().unwrap()) as usize;
+        // The base generation tie (offset 32..56), all-zero ⇒ None (unbound/unverified).
+        let generation = Fingerprint::from_bytes_opt(&bytes[32..32 + FINGERPRINT_LEN]);
+
+        // The EXACT expected total length, computed with checked arithmetic so a hostile header
+        // count cannot wrap the multiply/add into a small in-bounds value. Any mismatch (short =
+        // truncation/partial write, long = trailing garbage) is rejected before any body read.
+        let append_stride = 4usize
+            .checked_add(dim.checked_mul(4).ok_or_else(|| ".spqd: dim overflow".to_string())?)
+            .ok_or_else(|| ".spqd: append-stride overflow".to_string())?;
+        let body_len = append_count
+            .checked_mul(append_stride)
+            .and_then(|a| tomb_count.checked_mul(4).and_then(|t| a.checked_add(t)))
+            .ok_or_else(|| ".spqd: append/tombstone count overflow".to_string())?;
+        let expected = SPQD_HEADER_LEN
+            .checked_add(body_len)
+            .ok_or_else(|| ".spqd: total-length overflow".to_string())?;
+        if bytes.len() != expected {
+            return Err(format!(
+                ".spqd: length mismatch — header implies {} bytes (dim={}, appends={}, \
+                 tombstones={}) but the file is {} bytes; the sidecar is truncated or corrupt",
+                expected,
+                dim,
+                append_count,
+                tomb_count,
+                bytes.len()
+            ));
+        }
+
+        let mut appended: FxHashMap<Id, Vec<f32>> = FxHashMap::default();
+        appended.reserve(append_count);
+        let mut off = SPQD_HEADER_LEN;
+        for _ in 0..append_count {
+            let id = u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap());
+            off += 4;
+            let mut vec = Vec::with_capacity(dim);
+            for _ in 0..dim {
+                vec.push(f32::from_le_bytes(bytes[off..off + 4].try_into().unwrap()));
+                off += 4;
+            }
+            if vec.iter().any(|v| !v.is_finite()) {
+                return Err(format!(".spqd: appended vector for id {} has a non-finite component", id));
+            }
+            if appended.insert(id, vec).is_some() {
+                return Err(format!(".spqd: id {} appears twice in the append section", id));
+            }
+        }
+        let mut tombstones: FxHashSet<Id> = FxHashSet::default();
+        tombstones.reserve(tomb_count);
+        for _ in 0..tomb_count {
+            let id = u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap());
+            off += 4;
+            if !tombstones.insert(id) {
+                return Err(format!(".spqd: id {} appears twice in the tombstone section", id));
+            }
+            if appended.contains_key(&id) {
+                // The in-RAM invariant is "an id is in AT MOST one of appended/tombstones"; a file
+                // that violates it is corrupt, not a valid delta — reject rather than silently pick.
+                return Err(format!(".spqd: id {} is both appended and tombstoned (corrupt)", id));
+            }
+        }
+        debug_assert_eq!(off, bytes.len());
+        Ok((VectorDelta { generation, appended, tombstones }, dim))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    // [OPUS-4.8] (sq-7e50) Focused unit tests for the `.spqd` serde: the round-trip preserves the
+    // logical delta (incl. the None/unbound generation), the bytes are deterministic regardless of
+    // map iteration order, and the corruption paths the integration tests do not exercise directly
+    // (a both-appended-and-tombstoned id) are rejected. The store-level open/save and the
+    // result-equivalence + crash + mismatch gates live in `tests/delta_persist.rs`.
+    use super::*;
+
+    fn fp(d: u64, t: u64, h: u64) -> Fingerprint {
+        Fingerprint { dict_len: d, triple_count: t, content_hash: h }
+    }
+
+    fn sample(generation: Option<Fingerprint>) -> VectorDelta {
+        let mut d = VectorDelta::new(generation);
+        d.appended.insert(7, vec![1.0, 2.0, 3.0, 4.0]);
+        d.appended.insert(3, vec![-0.5, 0.0, 0.25, 9.0]);
+        d.tombstones.insert(11);
+        d.tombstones.insert(2);
+        d
+    }
+
+    #[test]
+    fn round_trip_with_a_bound_generation() {
+        let d = sample(Some(fp(4, 2, 0xdead_beef)));
+        let bytes = d.to_bytes(4);
+        let (back, dim) = VectorDelta::from_bytes(&bytes).expect("round-trips");
+        assert_eq!(dim, 4);
+        assert_eq!(back.generation(), d.generation());
+        assert_eq!(back.appended, d.appended);
+        assert_eq!(back.tombstones, d.tombstones);
+    }
+
+    #[test]
+    fn round_trip_with_an_unbound_generation_is_none() {
+        // An unbound (None) generation must serialize as an all-zero block and decode back to None
+        // (the same convention as the `.spqv` fingerprint block) — never to Some(0,0,0).
+        let d = sample(None);
+        let (back, _) = VectorDelta::from_bytes(&d.to_bytes(4)).expect("round-trips");
+        assert_eq!(back.generation(), None, "an all-zero header decodes to an unbound generation");
+        assert_eq!(back.appended, d.appended);
+        assert_eq!(back.tombstones, d.tombstones);
+    }
+
+    #[test]
+    fn an_empty_delta_serializes_to_just_the_header() {
+        let d = VectorDelta::new(Some(fp(1, 1, 1)));
+        let bytes = d.to_bytes(8);
+        assert_eq!(bytes.len(), SPQD_HEADER_LEN, "no appends/tombstones ⇒ header-only");
+        let (back, dim) = VectorDelta::from_bytes(&bytes).expect("round-trips");
+        assert_eq!(dim, 8);
+        assert!(back.is_empty());
+        assert_eq!(back.generation(), Some(fp(1, 1, 1)));
+    }
+
+    #[test]
+    fn the_bytes_are_deterministic_regardless_of_insertion_order() {
+        // Two deltas with the same logical content but different insertion order must serialize to
+        // IDENTICAL bytes (appends + tombstones are emitted in ascending id order).
+        let mut a = VectorDelta::new(Some(fp(2, 2, 2)));
+        a.appended.insert(9, vec![1.0, 1.0]);
+        a.appended.insert(1, vec![2.0, 2.0]);
+        a.tombstones.insert(8);
+        a.tombstones.insert(4);
+        let mut b = VectorDelta::new(Some(fp(2, 2, 2)));
+        b.appended.insert(1, vec![2.0, 2.0]);
+        b.appended.insert(9, vec![1.0, 1.0]);
+        b.tombstones.insert(4);
+        b.tombstones.insert(8);
+        assert_eq!(a.to_bytes(2), b.to_bytes(2), "the serialization is order-independent");
+    }
+
+    #[test]
+    fn a_short_buffer_is_rejected_not_indexed_out_of_bounds() {
+        // A buffer shorter than the header must error, never panic on a slice.
+        let err = VectorDelta::from_bytes(&[0u8; 10]).expect_err("a sub-header buffer must error");
+        assert!(err.contains("truncated"), "err was: {err}");
+    }
+
+    #[test]
+    fn a_count_that_does_not_match_the_length_is_rejected() {
+        // Forge a header that claims 5 appends but carries no body → length mismatch.
+        let mut bytes = VectorDelta::new(Some(fp(1, 1, 1))).to_bytes(4);
+        bytes[12..20].copy_from_slice(&5u64.to_le_bytes());
+        let err = VectorDelta::from_bytes(&bytes).expect_err("a lying count must be rejected");
+        assert!(err.contains("length mismatch"), "err was: {err}");
+    }
+
+    #[test]
+    fn a_bad_magic_or_version_is_rejected() {
+        let mut bytes = VectorDelta::new(Some(fp(1, 1, 1))).to_bytes(4);
+        let good = bytes.clone();
+        bytes[0] = b'Z';
+        assert!(VectorDelta::from_bytes(&bytes).unwrap_err().contains("bad magic"));
+        let mut v = good.clone();
+        v[4..8].copy_from_slice(&999u32.to_le_bytes());
+        assert!(VectorDelta::from_bytes(&v).unwrap_err().contains("unsupported version"));
     }
 }

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -91,8 +91,10 @@ pub use rewrite::{prepare_vec_approx, query_vec_approx, query_vec_approx_with_bu
 pub use sparq_engine::{query_prepared, PreparedQuery, QueryBudget, QueryResult};
 // [OPUS-4.8] (sq-pi44) The incremental delta sidecar value type — `delta` feature only. The
 // add/remove/update/compact APIs live on `VectorStore` (also `delta`-gated).
+// [OPUS-4.8] (sq-7e50) The persisted `.spqd` sidecar magic/version — the save/open APIs
+// (`save_delta`/`open_with_delta`/`sibling_delta_path`) live on `VectorStore` (also `delta`-gated).
 #[cfg(feature = "delta")]
-pub use delta::VectorDelta;
+pub use delta::{VectorDelta, SPQD_MAGIC, SPQD_VERSION};
 pub use store::{StreamingWriter, VectorStore, SPQV_MAGIC, SPQV_VERSION};
 pub use verbalize::{
     description_predicates, embed_entities, label_predicates, verbalize, EntityTextConfig,

--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -774,7 +774,7 @@ impl VectorStore {
     /// against a mismatched base.
     ///
     /// A store with NO pending delta writes an empty (header-only) sidecar — replaying it is a no-op,
-    /// and it still carries the generation so a stale base is still caught. See [`save_delta_to`] to
+    /// and it still carries the generation so a stale base is still caught. See [`save_delta_to`](Self::save_delta_to) to
     /// choose the path explicitly.
     pub fn save_delta(&self) -> Result<PathBuf, String> {
         let path = Self::sibling_delta_path(&self.path);

--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -747,6 +747,133 @@ impl VectorStore {
         fresh.finalize()?;
         Ok(fresh)
     }
+
+    /// [OPUS-4.8] (sq-7e50) The conventional persisted-delta sidecar path for a `.spqv` base at
+    /// `base`: the base path with `d` substituted for the trailing `v` (`foo.spqv` → `foo.spqd`),
+    /// or `base` + `.spqd` if it does not end in `.spqv`. Used by [`save_delta`](Self::save_delta)
+    /// and [`open_with_delta`](Self::open_with_delta) so a delta lives next to its base by default.
+    pub fn sibling_delta_path(base: &Path) -> PathBuf {
+        let s = base.as_os_str().to_string_lossy();
+        if let Some(stem) = s.strip_suffix(".spqv") {
+            PathBuf::from(format!("{}.spqd", stem))
+        } else {
+            let mut p = base.as_os_str().to_os_string();
+            p.push(".spqd");
+            PathBuf::from(p)
+        }
+    }
+
+    /// [OPUS-4.8] (sq-7e50) **Persists the in-RAM delta** to a `.spqd` sidecar at
+    /// [`sibling_delta_path`](Self::sibling_delta_path) of this store's base path, so incremental
+    /// add/remove/update survive a process restart without a [`compact`](Self::compact). Returns the
+    /// sidecar path written. Crash-durable: the bytes are written to a sibling `.spqd-tmp`, `fsync`ed
+    /// (`sync_all`), then atomically `rename`d over the final path — a crash mid-write leaves the
+    /// previous sidecar (or none) intact, never a half-written file at the live path (the same
+    /// discipline as [`StreamingWriter`]). The header carries this store's bound graph fingerprint
+    /// (the generation tie), so [`open_with_delta`](Self::open_with_delta) rejects the sidecar
+    /// against a mismatched base.
+    ///
+    /// A store with NO pending delta writes an empty (header-only) sidecar — replaying it is a no-op,
+    /// and it still carries the generation so a stale base is still caught. See [`save_delta_to`] to
+    /// choose the path explicitly.
+    pub fn save_delta(&self) -> Result<PathBuf, String> {
+        let path = Self::sibling_delta_path(&self.path);
+        self.save_delta_to(&path)?;
+        Ok(path)
+    }
+
+    /// [OPUS-4.8] (sq-7e50) Like [`save_delta`](Self::save_delta) but persists the `.spqd` sidecar to
+    /// an explicit `path`. Serializes the in-RAM delta (or an empty delta bound to this store's
+    /// fingerprint if none has been started — so the generation tie is still recorded), writing it
+    /// crash-durably (tmp + `sync_all` + atomic rename).
+    pub fn save_delta_to<P: AsRef<Path>>(&self, path: P) -> Result<(), String> {
+        let path = path.as_ref();
+        // An unstarted delta persists as an empty delta bound to THIS store's generation, so a
+        // reopened base still validates the (empty) sidecar against its fingerprint.
+        let bytes = match &self.delta {
+            Some(d) => d.to_bytes(self.dim),
+            None => crate::delta::VectorDelta::new(self.fingerprint).to_bytes(self.dim),
+        };
+        let tmp = {
+            let mut p = path.as_os_str().to_os_string();
+            p.push("-tmp");
+            PathBuf::from(p)
+        };
+        // Write the full sidecar to the tmp path, fsync it, then atomically rename it over the
+        // final path. On any error the partial tmp is removed so a live `.spqd` is never replaced
+        // by a half-written one.
+        let write_tmp = || -> std::io::Result<()> {
+            let mut f = std::fs::File::create(&tmp)?;
+            f.write_all(&bytes)?;
+            f.sync_all()?;
+            drop(f);
+            std::fs::rename(&tmp, path)
+        };
+        write_tmp().map_err(|e| {
+            std::fs::remove_file(&tmp).ok();
+            format!("save_delta {}: {e}", path.display())
+        })
+    }
+
+    /// [OPUS-4.8] (sq-7e50) Whether a persisted `.spqd` delta sidecar exists at
+    /// [`sibling_delta_path`](Self::sibling_delta_path) of `base`.
+    pub fn has_persisted_delta(base: &Path) -> bool {
+        Self::sibling_delta_path(base).exists()
+    }
+
+    /// [OPUS-4.8] (sq-7e50) **Opens a `.spqv` base AND replays its persisted `.spqd` delta**, so a
+    /// store reopened after a restart reads the SAME effective (base + delta) view it had before the
+    /// handle dropped — no [`compact`](Self::compact) required. Equivalent to
+    /// [`open`](Self::open)`(base)` followed by reading the sidecar at
+    /// [`sibling_delta_path`](Self::sibling_delta_path) and [`apply_delta`](Self::apply_delta)ing it,
+    /// so all of the existing guards apply:
+    ///
+    ///   * the base is fully validated exactly as [`open`](Self::open),
+    ///   * the persisted delta's `dim` must match the base (else a descriptive `Err`),
+    ///   * the persisted delta's base-generation fingerprint must match the base store's bound
+    ///     fingerprint — `apply_delta` REJECTS a sidecar written against a different graph generation
+    ///     (the sq-32i5 generation tie), so a stale `.spqd` against a rebuilt base can never mis-key,
+    ///   * a truncated / corrupt sidecar is rejected by [`VectorDelta::from_bytes`](crate::delta::VectorDelta)
+    ///     (the exact-length partial-write guard), never read out of bounds.
+    ///
+    /// If NO sidecar exists this is exactly [`open`](Self::open) (the store reads the bare base).
+    pub fn open_with_delta<P: AsRef<Path>>(base: P) -> Result<VectorStore, String> {
+        let base = base.as_ref();
+        let delta_path = Self::sibling_delta_path(base);
+        Self::open_with_delta_at(base, &delta_path)
+    }
+
+    /// [OPUS-4.8] (sq-7e50) Like [`open_with_delta`](Self::open_with_delta) but reads the persisted
+    /// delta from an explicit `delta_path`. If `delta_path` does not exist, returns the bare opened
+    /// base (no error — a base with no sidecar is the no-delta case).
+    pub fn open_with_delta_at<P: AsRef<Path>, Q: AsRef<Path>>(
+        base: P,
+        delta_path: Q,
+    ) -> Result<VectorStore, String> {
+        let base = base.as_ref();
+        let delta_path = delta_path.as_ref();
+        let mut store = VectorStore::open(base)?;
+        if !delta_path.exists() {
+            return Ok(store);
+        }
+        let bytes = std::fs::read(delta_path)
+            .map_err(|e| format!("read {}: {e}", delta_path.display()))?;
+        let (delta, delta_dim) = crate::delta::VectorDelta::from_bytes(&bytes)
+            .map_err(|e| format!("{}: {e}", delta_path.display()))?;
+        if delta_dim != store.dim {
+            return Err(format!(
+                "{}: delta dimension {} does not match the base store dimension {}",
+                delta_path.display(),
+                delta_dim,
+                store.dim
+            ));
+        }
+        // `apply_delta` enforces the generation tie (delta fingerprint == base fingerprint).
+        store
+            .apply_delta(delta)
+            .map_err(|e| format!("{}: {e}", delta_path.display()))?;
+        Ok(store)
+    }
 }
 
 /// [OPUS-4.8] (sq-pi44) A one-line description of a delta/store generation for the mismatch error.

--- a/crates/sparq-vectors/tests/delta_persist.rs
+++ b/crates/sparq-vectors/tests/delta_persist.rs
@@ -1,0 +1,328 @@
+//! [OPUS-4.8] (sq-7e50) Persisted on-disk delta-sidecar (`.spqd`) tests for `VectorStore`:
+//! result-equivalence of `open_with_delta(base + persisted-delta)` against the in-RAM (base + delta)
+//! view AND against `compact()`; the crash / partial-write guard (a truncated sidecar is detected
+//! and rejected, never UB); and the base-fingerprint-mismatch rejection (the sq-32i5 generation tie
+//! enforced through the persisted header).
+//!
+//! Gated on the opt-in `delta` feature — with it off the file compiles to an empty test crate (the
+//! save/open APIs do not exist), mirroring `tests/delta.rs`. Style matches the crate's other test
+//! modules (the workspace's intentionally-deferred reformat keeps a compact hand-written layout).
+#![cfg(feature = "delta")]
+
+use sparq_core::Graph;
+use sparq_vectors::{nearest_exact, Fingerprint, VectorStore, SPQD_MAGIC, SPQD_VERSION};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static SEQ: AtomicU64 = AtomicU64::new(0);
+
+fn tmp(tag: &str) -> PathBuf {
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("sparq_dpersist_{tag}_{}_{n}.spqv", std::process::id()))
+}
+
+fn graph(ttl: &str) -> Graph {
+    Graph::load_str(ttl, "turtle").expect("load test turtle")
+}
+
+fn id_of(g: &Graph, s: &str) -> u32 {
+    use oxrdf::{NamedNode, Term};
+    g.id_of(&Term::NamedNode(NamedNode::new(s).unwrap())).unwrap()
+}
+
+const A: &str = r#"
+    @prefix ex: <http://example.org/> .
+    ex:alice ex:knows ex:bob .
+    ex:bob ex:knows ex:carol .
+    ex:carol ex:knows ex:dave .
+"#;
+// B has a DIFFERENT dictionary AND a different triple count — a different graph generation.
+const B: &str = r#"
+    @prefix ex: <http://example.org/> .
+    ex:eve ex:likes ex:frank .
+"#;
+
+/// Builds a finalized 4-d store over graph A with a few base vectors.
+fn build_finalized(g: &Graph, path: &Path) -> VectorStore {
+    let mut s = VectorStore::create(path, 4).unwrap().with_fingerprint(g);
+    s.put(id_of(g, "http://example.org/alice"), &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    s.put(id_of(g, "http://example.org/bob"), &[0.9, 0.1, 0.0, 0.0]).unwrap();
+    s.put(id_of(g, "http://example.org/carol"), &[0.0, 0.0, 0.0, 1.0]).unwrap();
+    s.finalize().unwrap();
+    s
+}
+
+/// The full effective view of a store as a sorted `(id, vector)` vec — the comparison key for
+/// result-equivalence across the in-RAM, persisted, and compacted forms.
+fn effective(store: &VectorStore) -> Vec<(u32, Vec<f32>)> {
+    let mut v: Vec<(u32, Vec<f32>)> = store.iter().map(|(id, vec)| (id, vec.to_vec())).collect();
+    v.sort_by_key(|&(id, _)| id);
+    v
+}
+
+/// Asserts an open result is an `Err` and returns its message. (`VectorStore` is not `Debug`, so
+/// `Result::expect_err` does not apply directly — `match` on the result instead.)
+fn err_of(r: Result<VectorStore, String>, ctx: &str) -> String {
+    match r {
+        Ok(_) => panic!("expected an error but the open succeeded: {ctx}"),
+        Err(e) => e,
+    }
+}
+
+// ============================ gate: result-equivalence (the REQUIRED test) ============================
+
+#[test]
+fn open_with_persisted_delta_equals_in_ram_view_and_compact() {
+    let g = graph(A);
+    let base_path = tmp("eq-base");
+    let mut store = build_finalized(&g, &base_path);
+
+    let alice = id_of(&g, "http://example.org/alice");
+    let bob = id_of(&g, "http://example.org/bob");
+    let carol = id_of(&g, "http://example.org/carol");
+    let dave = id_of(&g, "http://example.org/dave");
+
+    // A mix of mutations against the finalized base: add a new id, remove a base id, update a base id.
+    store.add(dave, &[0.2, 0.8, 0.0, 0.0]).unwrap();
+    assert!(store.remove(bob));
+    store.update(carol, &[0.0, 0.0, 1.0, 0.0]).unwrap();
+    assert!(store.has_delta());
+
+    // (1) The IN-RAM (base + delta) view — the live handle, before persisting.
+    let in_ram = effective(&store);
+    // Sanity: bob gone, dave present, carol updated, alice base.
+    assert_eq!(store.get(bob), None);
+    assert_eq!(store.get(dave), Some(&[0.2f32, 0.8, 0.0, 0.0][..]));
+    assert_eq!(store.get(carol), Some(&[0.0f32, 0.0, 1.0, 0.0][..]));
+    assert_eq!(store.get(alice), Some(&[1.0f32, 0.0, 0.0, 0.0][..]));
+
+    // Persist the delta to its sibling .spqd (crash-durable tmp + fsync + rename).
+    let delta_path = store.save_delta().unwrap();
+    assert_eq!(delta_path, VectorStore::sibling_delta_path(&base_path));
+    assert_eq!(delta_path.extension().unwrap(), "spqd");
+    assert!(VectorStore::has_persisted_delta(&base_path));
+
+    // The persisted header must be a well-formed .spqd.
+    let raw = std::fs::read(&delta_path).unwrap();
+    assert_eq!(&raw[0..4], &SPQD_MAGIC);
+    assert_eq!(u32::from_le_bytes(raw[4..8].try_into().unwrap()), SPQD_VERSION);
+
+    // DROP the live handle — the in-RAM delta is gone; only the .spqv base + .spqd sidecar remain.
+    drop(store);
+
+    // (2) Reopen base + persisted delta from disk (simulating a process restart).
+    let reopened = VectorStore::open_with_delta(&base_path).unwrap();
+    assert!(reopened.has_delta(), "the persisted delta was replayed onto the reopened base");
+    let persisted = effective(&reopened);
+
+    // (3) compact() over the reopened (base + persisted delta) → a fresh from-scratch-equivalent base.
+    let compact_path = tmp("eq-compact");
+    let compacted = reopened.compact(&compact_path, &g).unwrap();
+    assert!(!compacted.has_delta(), "the compacted base carries no delta");
+    let compacted_view = effective(&compacted);
+
+    // THE EQUIVALENCE: open(base + persisted-delta) == in-RAM(base + delta) == compact().
+    assert_eq!(persisted, in_ram, "persisted view must equal the in-RAM view");
+    assert_eq!(compacted_view, in_ram, "compacted view must equal the in-RAM view");
+
+    // len and every get agree across all three; the tombstone really took.
+    assert_eq!(reopened.len(), in_ram.len());
+    assert_eq!(compacted.len(), in_ram.len());
+    assert_eq!(reopened.get(bob), None);
+    assert_eq!(compacted.get(bob), None);
+
+    // A search agrees byte-for-byte between the persisted-reopen and the compacted base.
+    let q = [0.1f32, 0.9, 0.0, 0.0];
+    assert_eq!(nearest_exact(&reopened, &q, 3), nearest_exact(&compacted, &q, 3));
+
+    std::fs::remove_file(&base_path).ok();
+    std::fs::remove_file(&delta_path).ok();
+    std::fs::remove_file(&compact_path).ok();
+}
+
+#[test]
+fn open_with_delta_with_no_sidecar_is_the_bare_base() {
+    // No .spqd on disk → open_with_delta is exactly open(): the bare base, no error, no delta.
+    let g = graph(A);
+    let base_path = tmp("nosidecar");
+    let store = build_finalized(&g, &base_path);
+    let base_view = effective(&store);
+    drop(store);
+
+    assert!(!VectorStore::has_persisted_delta(&base_path));
+    let reopened = VectorStore::open_with_delta(&base_path).unwrap();
+    assert!(!reopened.has_delta(), "no sidecar ⇒ no delta");
+    assert_eq!(effective(&reopened), base_view);
+    std::fs::remove_file(&base_path).ok();
+}
+
+#[test]
+fn empty_delta_round_trips_and_still_records_the_generation() {
+    // A store with NO mutations persists an empty (header-only) sidecar that still carries the base
+    // generation — replaying it is a no-op, and a stale base is still caught (see the mismatch test).
+    let g = graph(A);
+    let base_path = tmp("empty");
+    let store = build_finalized(&g, &base_path);
+    let base_view = effective(&store);
+    let delta_path = store.save_delta().unwrap();
+    drop(store);
+
+    // The sidecar exists and is header-only (no appends, no tombstones).
+    let raw = std::fs::read(&delta_path).unwrap();
+    assert_eq!(u64::from_le_bytes(raw[12..20].try_into().unwrap()), 0, "no appends");
+    assert_eq!(u64::from_le_bytes(raw[20..28].try_into().unwrap()), 0, "no tombstones");
+
+    let reopened = VectorStore::open_with_delta(&base_path).unwrap();
+    assert_eq!(effective(&reopened), base_view, "an empty delta replays to the bare base view");
+    std::fs::remove_file(&base_path).ok();
+    std::fs::remove_file(&delta_path).ok();
+}
+
+// ============================ gate: crash / partial-write detection ============================
+
+#[test]
+fn a_truncated_sidecar_is_rejected_not_ub() {
+    let g = graph(A);
+    let base_path = tmp("trunc-base");
+    let mut store = build_finalized(&g, &base_path);
+    let dave = id_of(&g, "http://example.org/dave");
+    store.add(dave, &[0.3, 0.7, 0.0, 0.0]).unwrap();
+    let delta_path = store.save_delta().unwrap();
+    drop(store);
+
+    let full = std::fs::read(&delta_path).unwrap();
+    assert!(full.len() > 56, "the sidecar has a body to truncate");
+
+    // (a) Truncate mid-body (a torn write of the append section): the header still claims an append
+    // whose bytes are now missing → the exact-length check rejects it (no out-of-bounds read).
+    std::fs::write(&delta_path, &full[..full.len() - 4]).unwrap();
+    let err = err_of(VectorStore::open_with_delta(&base_path), "truncated mid-body");
+    assert!(err.contains("truncated") || err.contains("length mismatch"), "err was: {err}");
+
+    // (b) Truncate inside the header itself: also rejected with a clear message.
+    std::fs::write(&delta_path, &full[..40]).unwrap();
+    let err = err_of(VectorStore::open_with_delta(&base_path), "torn header");
+    assert!(err.contains("truncated") || err.contains("length mismatch"), "err was: {err}");
+
+    // (c) Trailing garbage (a long file) is also rejected — the length must match EXACTLY.
+    let mut longer = full.clone();
+    longer.extend_from_slice(&[0u8; 8]);
+    std::fs::write(&delta_path, &longer).unwrap();
+    let err = err_of(VectorStore::open_with_delta(&base_path), "trailing garbage");
+    assert!(err.contains("length mismatch"), "err was: {err}");
+
+    // (d) A corrupt magic is rejected (not mistaken for a valid sidecar).
+    let mut bad_magic = full.clone();
+    bad_magic[0] = b'X';
+    std::fs::write(&delta_path, &bad_magic).unwrap();
+    let err = err_of(VectorStore::open_with_delta(&base_path), "bad magic");
+    assert!(err.contains("bad magic"), "err was: {err}");
+
+    std::fs::remove_file(&base_path).ok();
+    std::fs::remove_file(&delta_path).ok();
+}
+
+// ============================ gate: base-fingerprint-mismatch rejection ============================
+
+#[test]
+fn a_persisted_delta_is_rejected_against_a_mismatched_base() {
+    // A .spqd written against generation A must NOT replay onto a base of generation B (its ids
+    // would mis-key). The persisted header carries the base generation; open_with_delta routes it
+    // through apply_delta, whose sq-32i5 generation tie rejects the mismatch.
+    let ga = graph(A);
+    let gb = graph(B);
+    assert_ne!(Fingerprint::of(&ga), Fingerprint::of(&gb), "A and B must be distinct generations");
+
+    // A store + persisted delta built against generation A.
+    let a_path = tmp("mismatch-a");
+    let mut store_a = build_finalized(&ga, &a_path);
+    store_a.add(id_of(&ga, "http://example.org/dave"), &[0.3, 0.7, 0.0, 0.0]).unwrap();
+    let delta_a_path = store_a.save_delta().unwrap();
+    drop(store_a);
+
+    // A SEPARATE base built against generation B, at a different path.
+    let b_path = tmp("mismatch-b");
+    let mut store_b = VectorStore::create(&b_path, 4).unwrap().with_fingerprint(&gb);
+    store_b.put(id_of(&gb, "http://example.org/eve"), &[1.0, 0.0, 0.0, 0.0]).unwrap();
+    store_b.finalize().unwrap();
+    drop(store_b);
+
+    // Replaying the gen-A sidecar onto the gen-B base is a descriptive ERROR, not a silent mis-key.
+    let err = err_of(
+        VectorStore::open_with_delta_at(&b_path, &delta_a_path),
+        "gen-A delta onto a gen-B base",
+    );
+    assert!(err.contains("generation mismatch"), "err was: {err}");
+
+    // The same sidecar replays cleanly onto its OWN generation (gen A).
+    let reopened_a = VectorStore::open_with_delta(&a_path).unwrap();
+    assert_eq!(
+        reopened_a.get(id_of(&ga, "http://example.org/dave")),
+        Some(&[0.3f32, 0.7, 0.0, 0.0][..])
+    );
+
+    std::fs::remove_file(&a_path).ok();
+    std::fs::remove_file(&delta_a_path).ok();
+    std::fs::remove_file(&b_path).ok();
+}
+
+#[test]
+fn a_dimension_mismatch_between_base_and_sidecar_is_rejected() {
+    // Save a 4-d sidecar, then point open_with_delta_at at a base of a DIFFERENT dimension: the
+    // dim check rejects it before any mis-shaped replay.
+    let g = graph(A);
+    let base4 = tmp("dim4");
+    let mut store4 = build_finalized(&g, &base4);
+    store4.add(id_of(&g, "http://example.org/dave"), &[0.3, 0.7, 0.0, 0.0]).unwrap();
+    let delta4 = store4.save_delta().unwrap();
+    drop(store4);
+
+    // A 2-d base bound to the SAME generation (so only the dimension differs).
+    let base2 = tmp("dim2");
+    let mut store2 = VectorStore::create(&base2, 2).unwrap().with_fingerprint(&g);
+    store2.put(id_of(&g, "http://example.org/alice"), &[1.0, 0.0]).unwrap();
+    store2.finalize().unwrap();
+    drop(store2);
+
+    let err = err_of(VectorStore::open_with_delta_at(&base2, &delta4), "dim mismatch");
+    assert!(err.contains("dimension"), "err was: {err}");
+
+    std::fs::remove_file(&base4).ok();
+    std::fs::remove_file(&delta4).ok();
+    std::fs::remove_file(&base2).ok();
+}
+
+#[test]
+fn save_is_atomic_a_preexisting_sidecar_survives_and_is_replaced_whole() {
+    // save_delta writes tmp + fsync + rename, so the live .spqd is only ever a COMPLETE file.
+    // Save one delta, then a second (different) delta, and confirm the on-disk sidecar is the
+    // second one in full — never a mix.
+    let g = graph(A);
+    let base_path = tmp("atomic");
+    let dave = id_of(&g, "http://example.org/dave");
+    let carol = id_of(&g, "http://example.org/carol");
+
+    let mut store = build_finalized(&g, &base_path);
+    store.add(dave, &[0.3, 0.7, 0.0, 0.0]).unwrap();
+    let delta_path = store.save_delta().unwrap();
+    let first_len = std::fs::read(&delta_path).unwrap().len();
+
+    // Mutate further and re-save: a different, longer delta replaces the first whole.
+    store.remove(carol);
+    store.save_delta().unwrap();
+    let second = std::fs::read(&delta_path).unwrap();
+    assert_ne!(second.len(), first_len, "the re-saved sidecar reflects the new mutation");
+
+    // No stray tmp file is left behind.
+    let mut tmp_path = delta_path.as_os_str().to_os_string();
+    tmp_path.push("-tmp");
+    assert!(!Path::new(&tmp_path).exists(), "the tmp file is renamed away, not left behind");
+
+    drop(store);
+    let reopened = VectorStore::open_with_delta(&base_path).unwrap();
+    assert_eq!(reopened.get(dave), Some(&[0.3f32, 0.7, 0.0, 0.0][..]));
+    assert_eq!(reopened.get(carol), None, "the second delta's tombstone is in effect");
+
+    std::fs::remove_file(&base_path).ok();
+    std::fs::remove_file(&delta_path).ok();
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -112,8 +112,17 @@ store.update(id, &[f32]) -> Result<(), String>   // replace an EXISTING id's vec
 store.compact(out_path, &Graph) -> Result<VectorStore, String>  // fold delta into a FRESH base == a from-scratch rebuild
 store.has_delta() -> bool;  store.delta() -> Option<&VectorDelta>;  store.take_delta() -> Option<VectorDelta>
 store.apply_delta(VectorDelta) -> Result<(), String>  // GENERATION TIE: rejects a delta whose fingerprint != this base's
-// `put` is UNCHANGED (still errs after finalize) — `add` is the additive path. delta is IN-RAM ONLY (lost on drop; `compact`
-//   is the durability path) — persisted on-disk delta sidecar is a tracked follow-up. On a build-phase store add==put.
+// --- PERSISTED on-disk delta sidecar (.spqd) --- [OPUS-4.8] sq-7e50; same `delta` feature, no new dep
+store.save_delta() -> Result<PathBuf, String>          // persist the in-RAM delta to a sibling .spqd (tmp+fsync+rename)
+store.save_delta_to(path) -> Result<(), String>        // …to an explicit path; an unstarted delta persists empty+gen-bound
+VectorStore::open_with_delta(base) -> Result<VectorStore, String>   // open base mmap + replay the persisted sibling .spqd
+VectorStore::open_with_delta_at(base, delta_path) -> Result<..>     // …from an explicit delta path (no sidecar ⇒ bare base)
+VectorStore::sibling_delta_path(&Path) -> PathBuf;  VectorStore::has_persisted_delta(&Path) -> bool
+// `.spqd` = little-endian header (magic SPQD, v1, dim, append/tomb counts, BASE fingerprint @ off 32) + appends + tombstones.
+// CRASH-DURABLE (tmp+fsync+atomic rename, StreamingWriter discipline); PARTIAL-WRITE detected (exact-length check, fail-closed);
+// open routes through apply_delta so a sidecar from a DIFFERENT graph generation is REJECTED, never silently mis-keyed.
+// `put` is UNCHANGED (still errs after finalize) — `add` is the additive path; `compact` is the in-base durability path,
+//   `save_delta`/`open_with_delta` the survive-a-restart-without-compact path. On a build-phase store add==put.
 
 // --- search (src/ann.rs) --- all return cosine in [-1,1], best first; zero query -> empty
 nearest_exact(&VectorStore, query: &[f32], k) -> Vec<(Id, f32)>                 // ground-truth full scan
@@ -649,7 +658,7 @@ path (recipe 10), and does **not** transfer to this approximate path. Implement 
 ### 12. Incremental add / remove / update without a full rebuild (opt-in, feature = `delta`)
 
 A `.spqv` is build-once-immutable, so one new/removed entity would otherwise force a full re-embed +
-rebuild. The `delta` feature adds an in-RAM **delta sidecar** over the immutable base — `add` / `remove`
+rebuild. The `delta` feature adds a **delta sidecar** over the immutable base — `add` / `remove`
 / `update` write an append map + tombstone set, and `get` / `iter` / `len` (hence search) transparently
 union base+delta and honour tombstones. `compact` folds it back into a fresh base. Lean (no new dep).
 
@@ -665,17 +674,26 @@ store.remove(stale_id);                              // tombstone (returns bool;
 // search transparently sees the delta — no rebuild, no extra API:
 let hits = sparq_vectors::nearest_exact(&store, &query, 10);
 
-// fold the delta into a fresh base == a from-scratch rebuild over the final vector set:
+// PERSIST the delta so the mutations survive a restart WITHOUT a compact (sq-7e50):
+store.save_delta()?;                                 // crash-durable .spqd sibling (tmp+fsync+rename)
+// …later, in a fresh process: reopen the base AND replay the persisted delta:
+let reopened = VectorStore::open_with_delta("graph.spqv")?;  // == the (base + delta) view it had before
+
+// or fold the delta into a fresh base == a from-scratch rebuild over the final vector set:
 let compacted = store.compact("graph.spqv", &graph)?;   // bound to graph's fingerprint generation
 # Ok::<(), String>(())
 ```
 
 **Generation tie.** A delta carries the graph **generation** (the sq-32i5 fingerprint) it was built
 against; `apply_delta` rejects a delta whose generation differs from the receiving base, so its dict-ids
-can never mis-key onto a different graph. **Honesty (load-bearing):** the delta is **in-RAM only** — it
-is lost when the handle is dropped (the base file is unchanged until `compact` writes a new one). A
-*persisted* on-disk delta sidecar is a tracked follow-up; `compact` is the durability path today. `put`
-is unchanged (still errors after `finalize`) — `add` is the additive path.
+can never mis-key onto a different graph. The persisted `.spqd` header carries that same generation, so
+`open_with_delta` routes the replay through `apply_delta` and a sidecar written against a *different*
+graph generation is rejected, never silently mis-keyed. **Durability (sq-7e50).** Two durability paths:
+`compact` materializes the delta into a fresh validated `.spqv`; `save_delta` persists the *delta itself*
+to a crash-durable `.spqd` (write-tmp + `fsync` + atomic rename) that `open_with_delta` replays on reopen
+— so incremental mutations survive a process restart with no compact. A truncated/torn sidecar is
+detected (an exact-length check) and rejected, never read out of bounds. `put` is unchanged (still errors
+after `finalize`) — `add` is the additive path.
 
 ## Gotchas / feature flags / prerequisites
 
@@ -687,11 +705,12 @@ is unchanged (still errors after `finalize`) — `add` is the additive path.
   dependency and the base engine/core query path is byte-identical (see recipe 8). There is
   still no `SERVICE`/function binding. Predicate-constrained (filtered) ANN (recipe 9) is a
   separate **non-default `filtered-ann`** feature — also lean (no new dep, no engine pull).
-- **Incremental add/remove/update is the non-default `delta` feature (sq-pi44).** Also lean (no new
-  dep, no engine pull). With it OFF the store is build-once-immutable as before (`put` errors after
-  `finalize`; no `add`/`remove`/`update`/`compact`); with it ON those methods write an in-RAM delta
-  the read paths consult transparently (recipe 12). The delta is **in-RAM only** (lost on handle drop;
-  `compact` is the durability path) — a persisted on-disk delta sidecar is a tracked follow-up.
+- **Incremental add/remove/update is the non-default `delta` feature (sq-pi44, persistence sq-7e50).**
+  Also lean (no new dep, no engine pull). With it OFF the store is build-once-immutable as before
+  (`put` errors after `finalize`; no `add`/`remove`/`update`/`compact`/`save_delta`); with it ON those
+  methods write a delta the read paths consult transparently (recipe 12). The delta lives in RAM on the
+  handle; `save_delta` persists it to a crash-durable `.spqd` sidecar and `open_with_delta` replays it,
+  so mutations survive a restart without a `compact` (the two durability paths).
 - **`approx-ann` is the ONLY heavy ANN dependency, and it is OFF by default (sq-ip3a).** The HNSW
   index (`VectorIndex`/`HnswConfig`) and the `ApproxBackend` are gated behind it — it is the only
   thing pulling `instant-distance`. With it OFF the default build is lean: exact brute-force


### PR DESCRIPTION
> 🤖 **SPARQ agent** — opened by an autonomous sparq agent (Opus 4.8) on @jeswr's behalf. One of several agents that may run on this account.

## What

Follow-up to **sq-pi44** (PR #880, the IN-RAM delta sidecar). The in-RAM delta was lost when the `VectorStore` handle dropped, so `compact` was the only durability path. This adds a **persisted on-disk delta sidecar** (`.spqd`) so incremental `add`/`remove`/`update` against a finalized `.spqv` base survive a process restart **without** a compact.

All strictly additive under the existing opt-in **`delta`** cargo feature (OFF by default) — **no new dependency** (reuses std + the in-tree `rustc-hash`), so the default `sparq-vectors` build is unchanged.

## On-disk format (`.spqd`, version 1, little-endian — mirrors the `.spqv` header discipline)

```text
offset 0   magic         b"SPQD"                  4 bytes
offset 4   version       u32 = 1                  4 bytes
offset 8   dim           u32                      4 bytes
offset 12  append_count  u64                      8 bytes
offset 20  tomb_count    u64                      8 bytes
offset 28  reserved      zero padding             4 bytes
offset 32  fingerprint   base graph fingerprint   24 bytes   (the sq-32i5 generation tie)
offset 56  appends       [append_count × (id:u32, dim × f32)]
           tombstones    [tomb_count × (id:u32)]
```

The header carries the **base graph fingerprint**, so a sidecar written against generation N is validated/rejected against a base of generation M ≠ N on open (routed through the existing `apply_delta` generation tie). The in-RAM `VectorDelta` is reused verbatim as the in-memory representation.

## API (all `delta`-gated)

- `VectorStore::save_delta` / `save_delta_to` — **crash-durable**: write to a sibling `.spqd-tmp`, `fsync` (`sync_all`), then atomic `rename` — the same write-tmp-then-rename discipline as `StreamingWriter`. An unstarted delta persists an empty, generation-bound sidecar.
- `VectorStore::open_with_delta` / `open_with_delta_at` — open base mmap + replay the persisted delta (through `apply_delta`'s generation tie + a `dim` check). No sidecar ⇒ the bare base.
- `VectorStore::sibling_delta_path` / `has_persisted_delta`; `SPQD_MAGIC` / `SPQD_VERSION`.
- `VectorDelta::{to_bytes,from_bytes}` (pub(crate)) — `from_bytes` is **fail-closed**: bad magic/version, zero dim, an **exact-length partial-write/truncation guard** (checked arithmetic against the header counts — short OR long rejected), non-finite components, and duplicate/conflicting-id rejection.

## Tests (`tests/delta_persist.rs` + serde unit tests in `delta.rs`)

- **Result-equivalence (REQUIRED):** `open_with_delta(base + persisted-delta)` == the in-RAM `(base + delta)` view == `compact()` (sorted effective sets + `len` + per-id `get` + a search agree).
- **Crash / partial-write:** a truncated mid-body / torn-header / trailing-garbage / bad-magic sidecar is detected and **rejected, not UB**.
- **Base-fingerprint-mismatch:** a gen-A sidecar replayed onto a gen-B base errors (generation mismatch); the same sidecar replays cleanly onto its own generation.
- Plus: dim-mismatch rejection, atomic-replace (no stray tmp), empty-delta round-trip, and serde unit tests (None-generation round-trip, byte-determinism regardless of map order, sub-header rejection).

## Gates — green in BOTH feature states

| gate | default (feature OFF) | `--features delta` |
|---|---|---|
| `cargo clippy -p sparq-vectors --all-targets -- -D warnings` | ✅ | ✅ |
| `cargo test -p sparq-vectors` | ✅ | ✅ (7 new integration + 7 new serde unit) |

README kept under the ≤120-line template cap (passes `check-readme-template.py`, 0 deviations); typos gate clean. No hard-coded performance numbers.

Closes **sq-7e50**.