### PR TITLE
docs(agents): correct PyPI distribution name sparq → sparq-rdf [OPUS-4.8]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ sparq is a from-scratch **RDF triplestore and SPARQL 1.1 engine in Rust** — di
 
 - **Rust crates** (crates.io): `sparq-core`, `sparq-engine` (core), `sparq-cli`, `sparq-server`, plus opt-in capability crates (`sparq-reason`, `sparq-shacl`, `sparq-geo`, `sparq-text`, `sparq-rsp`, `sparq-hdt`, `sparq-solid`, ...).
 - **npm**: `@jeswr/sparq` — RDF/JS-typed API over the wasm build, zero runtime deps.
-- **PyPI**: `sparq` — pyo3/maturin bindings.
+- **PyPI**: `sparq-rdf` (import name `sparq`) — pyo3/maturin bindings.
 
 Status: experimental research engine; the API is unstable.
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

## What

Doc-only honesty fix: `AGENTS.md` line 11 still listed the PyPI **distribution** name as `sparq`, but the crate actually ships as **`sparq-rdf`** (the bare `sparq` distribution name is taken on PyPI). The **import** name stays `sparq`.

```diff
-- **PyPI**: `sparq` — pyo3/maturin bindings.
+- **PyPI**: `sparq-rdf` (import name `sparq`) — pyo3/maturin bindings.
```

## Why this is correct

- `crates/sparq-py/pyproject.toml` → `[project] name = "sparq-rdf"`.
- `crates/sparq-py/Cargo.toml` carries the `[OPUS-4.8] sq-8slf` rationale: distribution `sparq-rdf`, import name pinned to `sparq` via `[tool.maturin] module-name`.
- The per-surface `skills/python/SKILL.md`, the router `skills/SKILL.md`, and the javascript-wasm SKILL already say `sparq-rdf` / `pip install sparq-rdf` — this aligns `AGENTS.md` with them.

## Scope of the hygiene sweep this came from

The rest of the AGENTS.md headline facts checked out and need no change:
- **Workspace crates = 36** (root `Cargo.toml` members == `crates/*` dirs); AGENTS.md uses an open-ended `…` list, no stale count.
- **Skills = 25** top-level surfaces; AGENTS.md says "every surface" / enumerates via the router, no stale count.
- **ZK gate-count snapshot** = 28 `members` + 1 `exempt`; no count baked into AGENTS.md.
- **npm** `@jeswr/sparq` — already correct.
- No honesty-drift "not implemented / not yet wired" markers for now-shipped capabilities in AGENTS.md or the router SKILL.md (the SKILL status blocks were re-verified 2026-06-19 and explicitly note no stale caveats remain).

Auto-merge intentionally **OFF** — doc-only, for normal review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
