### PR TITLE
feat(sparq-canon): opt-in NON-STANDARD rdf12-triple-term canon profile (sq-hslb) [OPUS-4.8]

### DIFF
--- a/crates/sparq-canon/Cargo.toml
+++ b/crates/sparq-canon/Cargo.toml
@@ -41,6 +41,23 @@ oxttl01 = { package = "oxttl", version = "0.1.8" }
 # [OPUS-4.8] Pinned to 0.10 to match rdf-canon 0.15.3's `Digest` bound (see sha2 note below).
 digest = "0.10"
 
+# [OPUS-4.8] sq-hslb: SHA-256 backing the OPT-IN, OFF-BY-DEFAULT non-standard
+# `rdf12-triple-terms` profile (native HNDQ over oxrdf-0.3 triple terms). Only
+# compiled in when that feature is on, so the default build is byte-identical.
+# Pinned to 0.10 alongside the suite's `sha2` dev-dep (rdf-canon 0.15.3 / digest
+# 0.10 — lift only when rdf-canon publishes a digest-0.11 release).
+sha2 = { version = "0.10", optional = true }
+
+[features]
+# NON-STANDARD, OFF BY DEFAULT. RDF-1.2 triple-term canonicalization: a native
+# RDFC-1.0 re-implementation over oxrdf-0.3 whose Hash-N-Degree-Quads descent
+# reaches blank nodes nested inside `Term::Triple` objects. This is NOT W3C
+# RDFC-1.0 (RDF-1.2 canonicalization is unsettled upstream). With this OFF the
+# crate is byte-identical to before and the standard paths still reject triple
+# terms with `CanonError::TripleTerm`.
+default = []
+rdf12-triple-terms = ["dep:sha2"]
+
 [dev-dependencies]
 sparq-engine = { path = "../sparq-engine" }
 serde_json = "1"

--- a/crates/sparq-canon/README.md
+++ b/crates/sparq-canon/README.md
@@ -41,12 +41,45 @@ let map = sparq_canon::issued_identifiers(&[q]).unwrap();
   canonical triples). This is what the ZK per-graph commitment pipeline
   consumes (`leaf_index = line index`).
 - **Fail-closed on poison graphs** — RDFC-1.0's pathological blow-ups hit the
-  HNDQ call-limit guard and surface as `CanonError::Canonicalization`.
+  HNDQ call-limit guard and surface as `CanonError::Canonicalization`. RDF 1.2
+  triple terms are outside the standard data model, so the standard paths
+  **fail closed** with `CanonError::TripleTerm` unless the `rdf12-triple-terms`
+  profile (below) is enabled.
 - **W3C-conformant** — validated against the official [rdf-canon test suite]
   (eval + issued-map + negative cases, SHA-256 and SHA-384) through this crate's
   own public API (`tests/rdf_canon_suite.rs`).
 
 [rdf-canon test suite]: https://github.com/w3c/rdf-canon
+
+### ⚠️ Opt-in NON-STANDARD RDF 1.2 triple-term profile (`rdf12-triple-terms`)
+
+**OFF by default; NOT W3C RDFC-1.0.** RDFC-1.0 is defined for RDF 1.1 only and
+has no notion of triple terms; their canonicalization is **unsettled upstream**
+([w3c/rdf-star-wg#114](https://github.com/w3c/rdf-star-wg/issues/114)). With the
+feature OFF the crate is **byte-identical** to before — the standard paths still
+return `CanonError::TripleTerm` on triple terms and the W3C suite still passes.
+
+Enabling `rdf12-triple-terms` adds a **separate, clearly non-standard v2** profile
+that natively re-implements the RDFC-1.0 algorithm over oxrdf 0.3 and **descends
+the Hash-N-Degree-Quads gossip into `Term::Triple` objects**, so blank nodes
+nested inside triple terms get relabelled. It is byte-identical to the standard
+path on triple-term-free input (asserted against every W3C suite vector).
+
+```toml
+sparq-canon = { path = "crates/sparq-canon", features = ["rdf12-triple-terms"] }
+```
+
+```rust
+// NON-STANDARD — canonicalizes triple terms incl. nested blank nodes (SHA-256).
+let nq = sparq_canon::canonicalize_rdf12(&dataset)?;             // quads
+let cg = sparq_canon::canonicalize_triples_rdf12(&triples)?;     // single graph
+let m  = sparq_canon::issue_dataset_rdf12(&dataset)?;            // issuer map
+```
+
+**Boundary:** SHA-256 only (no `*_with` for v2 yet); triple terms occur only as
+objects in oxrdf 0.3 (a triple's subject is `NamedOrBlankNode`), so nesting
+descends strictly through the object position; the HNDQ poison-graph limit still
+applies.
 
 ### Opt-in, single-sourced
 

--- a/crates/sparq-canon/src/lib.rs
+++ b/crates/sparq-canon/src/lib.rs
@@ -48,6 +48,22 @@
 //!
 //! [OPUS-4.8] sq-0qip — surfaced from `sparq-zk::canon` (Fable unavailable; flag
 //! for re-review when Fable returns).
+//!
+//! ## Opt-in NON-STANDARD RDF-1.2 triple-term profile (`rdf12-triple-terms`)
+//!
+//! Triple terms (`Term::Triple`, the RDF-1.2 `<<( s p o )>>` object) are
+//! **outside** the W3C RDFC-1.0 data model, so the standard paths above fail
+//! closed with [`CanonError::TripleTerm`]. Enabling the **opt-in, off-by-default**
+//! `rdf12-triple-terms` cargo feature adds a *separate, clearly non-standard* v2
+//! profile (`canonicalize_rdf12`, `canonicalize_triples_rdf12`, …) that
+//! natively re-implements the RDFC-1.0 algorithm over oxrdf-0.3 and **descends
+//! the Hash-N-Degree-Quads gossip into triple-term objects**, so blank nodes
+//! nested inside triple terms get relabelled. It is byte-identical to the
+//! standard path on triple-term-free input. This is **not** W3C RDFC-1.0
+//! (RDF-1.2 canonicalization is unsettled upstream); see the `rdf12` module
+//! (only present with the feature on). With the feature OFF the crate is
+//! byte-identical to before — the standard surface still returns
+//! [`CanonError::TripleTerm`] on triple terms.
 
 #![forbid(unsafe_code)]
 
@@ -55,6 +71,18 @@ use oxrdf::{GraphName, Quad, Triple};
 use oxttl::NQuadsParser;
 use sparq_core::Graph;
 use std::collections::HashMap;
+
+/// **NON-STANDARD, opt-in (`rdf12-triple-terms` feature).** Native RDF-1.2
+/// triple-term canonicalization profile — see the [module docs](rdf12) and the
+/// crate-level banner. Not W3C RDFC-1.0.
+#[cfg(feature = "rdf12-triple-terms")]
+pub mod rdf12;
+
+#[cfg(feature = "rdf12-triple-terms")]
+pub use rdf12::{
+    canonicalize_graph_content_rdf12, canonicalize_rdf12, canonicalize_triples_rdf12,
+    issue_dataset_rdf12,
+};
 
 /// The hash-function trait RDFC-1.0 is parameterized over (`digest::Digest`),
 /// re-exported so callers of [`canonicalize_quads_with`] / [`issue_quads_with`]
@@ -66,8 +94,10 @@ pub use digest::Digest;
 /// Canonicalization failure (RDFC-1.0 over sparq's term model).
 #[derive(Debug)]
 pub enum CanonError {
-    /// RDF 1.2 triple terms are outside RDFC-1.0's data model; a dataset
-    /// containing them cannot be canonicalized.
+    /// RDF 1.2 triple terms are outside W3C RDFC-1.0's data model; the
+    /// standard paths fail closed on them. Enable the opt-in `rdf12-triple-terms`
+    /// feature and use the non-standard `canonicalize_rdf12` /
+    /// `canonicalize_triples_rdf12` profile to canonicalize triple terms.
     TripleTerm,
     /// Bridge serialization/parse failure (should not happen for RDFC-1.0-model
     /// content; surfaced rather than swallowed).
@@ -82,7 +112,8 @@ impl std::fmt::Display for CanonError {
             CanonError::TripleTerm => {
                 write!(
                     f,
-                    "RDF 1.2 triple terms cannot be canonicalized (RDFC-1.0 data model)"
+                    "RDF 1.2 triple terms are outside the W3C RDFC-1.0 data model; \
+                     enable the `rdf12-triple-terms` profile to canonicalize them"
                 )
             }
             CanonError::Bridge(e) => write!(f, "oxrdf bridge error: {e}"),

--- a/crates/sparq-canon/src/rdf12.rs
+++ b/crates/sparq-canon/src/rdf12.rs
@@ -1,0 +1,712 @@
+//! # NON-STANDARD RDF-1.2 triple-term canonicalization profile (`rdf12-triple-terms`)
+//!
+//! **⚠️ NON-STANDARD. This is NOT W3C RDFC-1.0.** [RDFC-1.0] is defined for the
+//! RDF-1.1 data model only; it has **no** notion of RDF-1.2 triple terms
+//! (`<<( s p o )>>` as an object), and the consequences of triple terms for
+//! canonicalization are **unsettled upstream** (see [w3c/rdf-star-wg#114]). The
+//! profile here is sparq's own opt-in extension. The standard
+//! [`crate::canonicalize`] / [`crate::canonicalize_triples`] paths, and the W3C
+//! `rdf-canon` test suite, keep meaning **exactly** what they mean today: they
+//! still fail closed with [`CanonError::TripleTerm`] on any triple-term input.
+//!
+//! [RDFC-1.0]: https://www.w3.org/TR/rdf-canon/
+//! [w3c/rdf-star-wg#114]: https://github.com/w3c/rdf-star-wg/issues/114
+//!
+//! ## What it does
+//!
+//! It is a **native** re-implementation of the RDFC-1.0 algorithm (issuer state,
+//! Hash First Degree Quads, Hash Related Blank Node, **Hash N-Degree Quads**)
+//! directly over sparq's oxrdf-0.3 term model, **extended** so the n-degree
+//! gossip descends through [`oxrdf::Term::Triple`] objects: a blank node nested
+//! inside a triple term (at any depth) is enrolled, gossiped, and relabelled
+//! exactly like a top-level blank node. The serialization re-uses oxrdf-0.3's
+//! canonical `Display` (the `<<( … )>>` triple-term token form and the
+//! `"…"@lang--dir` directional-language form of RDF-1.2 N-Quads), so the token
+//! rules are single-sourced in oxttl/oxrdf rather than hand-rolled here.
+//!
+//! Because the algorithm is structurally the RDFC-1.0 algorithm, on **any input
+//! without triple terms** it produces byte-identical output to the standard
+//! `rdf-canon`-backed path; that agreement is the strongest correctness anchor
+//! and is asserted in the crate's tests against the W3C suite vectors.
+//!
+//! ## Triple terms only appear as objects
+//!
+//! In oxrdf 0.3 a [`Triple`]'s subject is a `NamedOrBlankNode` and only its
+//! object may be a `Term::Triple`. So nesting descends strictly through the
+//! **object** position; a nested blank node is, positionally, part of the
+//! **object** of the top-level quad that contains the triple term, and is
+//! gossiped with the object position marker `o` against that quad's predicate.
+//!
+//! ## Boundary
+//!
+//! - SHA-256 only (the spec default). The non-default-hash `*_with` profile is
+//!   not (yet) exposed for the v2 path.
+//! - Dataset-level (quads, named graphs) and single-graph (triples) entry
+//!   points are both provided.
+//! - The HNDQ poison-graph call limit is enforced (default 4000) and surfaces as
+//!   [`CanonError::Canonicalization`], so pathological inputs fail closed.
+//!
+//! [OPUS-4.8] sq-hslb — full non-standard RDF-1.2 triple-term canon profile.
+//! Fable unavailable; flag for re-review when Fable returns.
+
+use crate::CanonError;
+use oxrdf::{BlankNode, GraphName, NamedOrBlankNode, Quad, Term, Triple};
+use sha2::{Digest, Sha256};
+use std::collections::BTreeMap;
+
+/// The default HNDQ call limit (matches the standard `rdf-canon` path's guard).
+const DEFAULT_HNDQ_CALL_LIMIT: usize = 4000;
+
+// ---------------------------------------------------------------------------
+// Public entry points (the v2, non-standard profile).
+// ---------------------------------------------------------------------------
+
+/// **NON-STANDARD.** Canonicalizes an RDF-1.2 dataset (a slice of [`Quad`]s),
+/// **including triple terms**, into its canonical N-Quads document under the
+/// sparq `rdf12-triple-terms` profile (SHA-256).
+///
+/// On triple-term-free input this is byte-identical to the standard
+/// [`crate::canonicalize`]. With triple terms it additionally relabels blank
+/// nodes nested inside triple-term objects via the HNDQ descent.
+///
+/// This is **not** W3C RDFC-1.0 (RDF-1.2 canonicalization is unsettled
+/// upstream); see the [module docs](self).
+pub fn canonicalize_rdf12(dataset: &[Quad]) -> Result<String, CanonError> {
+    let issued = issue_dataset_rdf12(dataset)?;
+    Ok(serialize_canonical(dataset, &issued))
+}
+
+/// **NON-STANDARD.** The issued-identifier map (input blank-node label →
+/// canonical `c14nN` label) for an RDF-1.2 dataset under the
+/// `rdf12-triple-terms` profile. See [`canonicalize_rdf12`].
+pub fn issue_dataset_rdf12(
+    dataset: &[Quad],
+) -> Result<std::collections::HashMap<String, String>, CanonError> {
+    let state = CanonState::compute(dataset)?;
+    Ok(state
+        .canonical_issuer
+        .issued
+        .into_iter()
+        .collect())
+}
+
+/// **NON-STANDARD.** Canonicalizes one graph's content (a slice of [`Triple`]s,
+/// treated as the default graph), **including triple terms**, into a
+/// [`crate::CanonicalGraph`] under the `rdf12-triple-terms` profile.
+///
+/// On triple-term-free input this agrees byte-for-byte with the standard
+/// [`crate::canonicalize_triples`]. See the [module docs](self) for the
+/// non-standard caveat.
+pub fn canonicalize_triples_rdf12(
+    triples: &[Triple],
+) -> Result<crate::CanonicalGraph, CanonError> {
+    let dataset: Vec<Quad> = triples
+        .iter()
+        .map(|t| {
+            Quad::new(
+                t.subject.clone(),
+                t.predicate.clone(),
+                t.object.clone(),
+                GraphName::DefaultGraph,
+            )
+        })
+        .collect();
+    let issued = issue_dataset_rdf12(&dataset)?;
+    let lines = canonical_lines(&dataset, &issued);
+    // Re-parse each canonical default-graph line back into a triple so the
+    // returned `triples` carry the canonical (`c14nN`) labels, matching the
+    // standard single-graph API's contract.
+    let mut triples_out: Vec<Triple> = Vec::with_capacity(lines.len());
+    for line in &lines {
+        let mut parsed = None;
+        for item in oxttl::NQuadsParser::new().for_slice(line.as_bytes()) {
+            let q = item.map_err(|e| CanonError::Bridge(e.to_string()))?;
+            parsed = Some(Triple::new(q.subject, q.predicate, q.object));
+        }
+        triples_out.push(parsed.ok_or_else(|| {
+            CanonError::Bridge(format!("canonical line did not parse as one quad: {}", line))
+        })?);
+    }
+    Ok(crate::CanonicalGraph {
+        lines,
+        triples: triples_out,
+    })
+}
+
+/// **NON-STANDARD.** Canonicalizes a [`sparq_core::Graph`]'s content, including
+/// triple terms, under the `rdf12-triple-terms` profile. See
+/// [`canonicalize_triples_rdf12`].
+pub fn canonicalize_graph_content_rdf12(
+    g: &sparq_core::Graph,
+) -> Result<crate::CanonicalGraph, CanonError> {
+    // `graph_triples` materializes the stored triples as-is, keeping any
+    // triple-term objects intact (the standard *canonicalize* paths reject
+    // triple terms downstream, not here), so it is the right source for the v2
+    // profile too.
+    let triples = crate::graph_triples(g)?;
+    canonicalize_triples_rdf12(&triples)
+}
+
+// ---------------------------------------------------------------------------
+// Canonicalization state (RDFC-1.0 §4.2), extended to triple terms.
+// Structurally mirrors zkp-ld `rdf-canon` 0.15.3 (the path the standard W3C
+// suite validates) so the two agree on triple-term-free input.
+// ---------------------------------------------------------------------------
+
+/// RDFC-1.0 §4.3 blank-node identifier issuer.
+#[derive(Clone, PartialEq, Eq, Debug)]
+struct IdentifierIssuer {
+    prefix: String,
+    counter: usize,
+    /// input label → issued label.
+    issued: BTreeMap<String, String>,
+    /// zero-padded issuance index → input label, so a BTreeMap value iteration
+    /// recovers §4.4(6) issuance order without a parallel Vec.
+    order: BTreeMap<String, String>,
+}
+
+impl IdentifierIssuer {
+    fn new(prefix: &str) -> Self {
+        Self {
+            prefix: prefix.to_string(),
+            counter: 0,
+            issued: BTreeMap::new(),
+            order: BTreeMap::new(),
+        }
+    }
+
+    fn get(&self, existing: &str) -> Option<String> {
+        self.issued.get(existing).cloned()
+    }
+
+    /// RDFC-1.0 §4.5 Issue Identifier.
+    fn issue(&mut self, existing: &str) -> String {
+        if let Some(id) = self.get(existing) {
+            return id;
+        }
+        let issued = format!("{}{}", self.prefix, self.counter);
+        self.issued.insert(existing.to_string(), issued.clone());
+        self.order
+            .insert(format!("{:020}", self.counter), existing.to_string());
+        self.counter += 1;
+        issued
+    }
+}
+
+/// Map alias used throughout: a hash → the bnode labels that produced it.
+type HashToBnodes = BTreeMap<String, Vec<String>>;
+
+/// RDFC-1.0 §4.2 canonicalization state, extended for triple terms.
+struct CanonState {
+    /// bnode label → the quads it is a component of (recursively through
+    /// triple terms). The same quad is recorded once per *distinct* bnode it
+    /// contains, matching the standard algorithm.
+    bnode_to_quads: BTreeMap<String, Vec<Quad>>,
+    canonical_issuer: IdentifierIssuer,
+}
+
+impl CanonState {
+    fn compute(dataset: &[Quad]) -> Result<Self, CanonError> {
+        let mut state = CanonState {
+            bnode_to_quads: BTreeMap::new(),
+            canonical_issuer: IdentifierIssuer::new("c14n"),
+        };
+        state.build_bnode_to_quads(dataset);
+
+        // §4.4(3) first-degree hashes.
+        let mut hash_to_bnodes: HashToBnodes = BTreeMap::new();
+        for n in state.bnode_to_quads.keys() {
+            let h = state.hash_first_degree_quads(n)?;
+            hash_to_bnodes.entry(h).or_default().push(n.clone());
+        }
+
+        // §4.4(4) unique first-degree hashes → issue canonical labels.
+        let mut shared: HashToBnodes = BTreeMap::new();
+        for (h, list) in &hash_to_bnodes {
+            if list.len() == 1 {
+                state.canonical_issuer.issue(&list[0]);
+            } else {
+                shared.insert(h.clone(), list.clone());
+            }
+        }
+
+        // §4.4(5) shared hashes → HNDQ.
+        let mut counter = HndqCallCounter::new(DEFAULT_HNDQ_CALL_LIMIT);
+        for list in shared.values() {
+            let mut hash_path_list: Vec<HndqResult> = Vec::new();
+            for n in list {
+                if state.canonical_issuer.get(n).is_some() {
+                    continue;
+                }
+                let mut temp = IdentifierIssuer::new("b");
+                temp.issue(n);
+                let result = state.hash_n_degree_quads(n, &temp, &mut counter)?;
+                hash_path_list.push(result);
+            }
+            hash_path_list.sort_by(|a, b| a.hash.cmp(&b.hash));
+            for result in &hash_path_list {
+                // Issue canonical labels in temporary-issuance order (§4.4 5.3.1).
+                for existing in result.issuer.order.values() {
+                    state.canonical_issuer.issue(existing);
+                }
+            }
+        }
+
+        Ok(state)
+    }
+
+    // ---- §4.4(2) build the bnode→quads map, recursing into triple terms ----
+
+    fn build_bnode_to_quads(&mut self, dataset: &[Quad]) {
+        for quad in dataset {
+            // Collect every distinct bnode label that is a component of this
+            // quad (subject/object/graph + any depth of triple-term nesting),
+            // and record the quad once for each.
+            let mut labels: Vec<String> = Vec::new();
+            collect_bnodes_subject(&quad.subject, &mut labels);
+            collect_bnodes_term(&quad.object, &mut labels);
+            if let GraphName::BlankNode(b) = &quad.graph_name {
+                push_unique(&mut labels, b.as_str());
+            }
+            for l in labels {
+                self.bnode_to_quads.entry(l).or_default().push(quad.clone());
+            }
+        }
+    }
+
+    fn quads_for(&self, identifier: &str) -> Option<&Vec<Quad>> {
+        self.bnode_to_quads.get(identifier)
+    }
+
+    // ---- §4.6 Hash First Degree Quads (triple-term aware) ----
+
+    fn hash_first_degree_quads(&self, reference: &str) -> Result<String, CanonError> {
+        let quads = self
+            .quads_for(reference)
+            .ok_or_else(|| CanonError::Canonicalization("quads not found for bnode".into()))?;
+        let mut nquads: Vec<String> = quads
+            .iter()
+            .map(|q| {
+                let relabelled = relabel_quad_first_degree(q, reference);
+                serialize_quad_line(&relabelled)
+            })
+            .collect();
+        nquads.sort();
+        Ok(hash_hex(nquads.concat().as_bytes()))
+    }
+
+    // ---- §4.8 Hash N-Degree Quads (triple-term aware) ----
+
+    fn hash_n_degree_quads(
+        &self,
+        identifier: &str,
+        path_issuer: &IdentifierIssuer,
+        counter: &mut HndqCallCounter,
+    ) -> Result<HndqResult, CanonError> {
+        counter.add()?;
+        let mut issuer = path_issuer.clone();
+
+        // §4.8(1) Hn: related hash → related bnode labels.
+        let mut h_n: HashToBnodes = BTreeMap::new();
+        let quads = self
+            .quads_for(identifier)
+            .ok_or_else(|| CanonError::Canonicalization("quads not found for bnode".into()))?;
+
+        // §4.8(3) for each quad, for each related bnode component (recursing
+        // through triple terms), hash-related-blank-node into Hn.
+        for quad in quads {
+            // subject position
+            let mut subj_bnodes: Vec<String> = Vec::new();
+            collect_bnodes_subject(&quad.subject, &mut subj_bnodes);
+            for related in &subj_bnodes {
+                if related != identifier {
+                    let h =
+                        self.hash_related_blank_node(related, quad, &issuer, Position::Subject)?;
+                    h_n.entry(h).or_default().push(related.clone());
+                }
+            }
+            // object position (includes bnodes nested inside a triple term)
+            let mut obj_bnodes: Vec<String> = Vec::new();
+            collect_bnodes_term(&quad.object, &mut obj_bnodes);
+            for related in &obj_bnodes {
+                if related != identifier {
+                    let h =
+                        self.hash_related_blank_node(related, quad, &issuer, Position::Object)?;
+                    h_n.entry(h).or_default().push(related.clone());
+                }
+            }
+            // graph position
+            if let GraphName::BlankNode(b) = &quad.graph_name {
+                let related = b.as_str();
+                if related != identifier {
+                    let h =
+                        self.hash_related_blank_node(related, quad, &issuer, Position::Graph)?;
+                    h_n.entry(h).or_default().push(related.to_string());
+                }
+            }
+        }
+
+        // §4.8(4,5) build data-to-hash.
+        let mut data_to_hash = String::new();
+        for (related_hash, blank_node_list) in h_n {
+            data_to_hash.push_str(&related_hash);
+            let mut chosen_path = String::new();
+            let mut chosen_issuer: Option<IdentifierIssuer> = None;
+
+            // §4.8(5.4) permutations.
+            for perm in permutations(&blank_node_list) {
+                let mut issuer_copy = issuer.clone();
+                let mut path = String::new();
+                let mut recursion_list: Vec<String> = Vec::new();
+                let mut skip = false;
+
+                for related in &perm {
+                    if let Some(cid) = self.canonical_issuer.get(related) {
+                        path.push_str(&format!("_:{}", cid));
+                    } else {
+                        if issuer_copy.get(related).is_none() {
+                            recursion_list.push(related.clone());
+                        }
+                        path.push_str(&format!("_:{}", issuer_copy.issue(related)));
+                    }
+                    if !chosen_path.is_empty()
+                        && path.len() >= chosen_path.len()
+                        && path >= chosen_path
+                    {
+                        skip = true;
+                        break;
+                    }
+                }
+                if skip {
+                    continue;
+                }
+
+                for related in &recursion_list {
+                    let result = self.hash_n_degree_quads(related, &issuer_copy, counter)?;
+                    path.push_str(&format!("_:{}", issuer_copy.issue(related)));
+                    path.push('<');
+                    path.push_str(&result.hash);
+                    path.push('>');
+                    issuer_copy = result.issuer;
+                    if !chosen_path.is_empty()
+                        && path.len() >= chosen_path.len()
+                        && path >= chosen_path
+                    {
+                        skip = true;
+                        break;
+                    }
+                }
+                if skip {
+                    continue;
+                }
+
+                if chosen_path.is_empty() || path < chosen_path {
+                    chosen_path = path;
+                    chosen_issuer = Some(issuer_copy);
+                }
+            }
+
+            data_to_hash.push_str(&chosen_path);
+            if let Some(ci) = chosen_issuer {
+                issuer = ci;
+            }
+        }
+
+        Ok(HndqResult {
+            hash: hash_hex(data_to_hash.as_bytes()),
+            issuer,
+        })
+    }
+
+    // ---- §4.7 Hash Related Blank Node ----
+
+    fn hash_related_blank_node(
+        &self,
+        related: &str,
+        quad: &Quad,
+        issuer: &IdentifierIssuer,
+        position: Position,
+    ) -> Result<String, CanonError> {
+        let mut input = match position {
+            Position::Graph => "g".to_string(),
+            Position::Subject => format!("s{}", quad.predicate),
+            Position::Object => format!("o{}", quad.predicate),
+        };
+        let identifier = match self.canonical_issuer.get(related) {
+            Some(id) => format!("_:{}", id),
+            None => match issuer.get(related) {
+                Some(id) => format!("_:{}", id),
+                None => self.hash_first_degree_quads(related)?,
+            },
+        };
+        input.push_str(&identifier);
+        Ok(hash_hex(input.as_bytes()))
+    }
+}
+
+#[derive(Clone, Copy)]
+enum Position {
+    Subject,
+    Object,
+    Graph,
+}
+
+#[derive(Debug)]
+struct HndqResult {
+    hash: String,
+    issuer: IdentifierIssuer,
+}
+
+/// Poison-graph guard: caps total HNDQ invocations (RDFC-1.0 §4.8 worst case is
+/// super-polynomial). Mirrors the standard path's default limit so the v2
+/// profile fails closed identically.
+struct HndqCallCounter {
+    count: usize,
+    limit: usize,
+}
+
+impl HndqCallCounter {
+    fn new(limit: usize) -> Self {
+        Self { count: 0, limit }
+    }
+    fn add(&mut self) -> Result<(), CanonError> {
+        self.count += 1;
+        if self.count > self.limit {
+            Err(CanonError::Canonicalization(format!(
+                "HNDQ call limit ({}) exceeded (poison graph)",
+                self.limit
+            )))
+        } else {
+            Ok(())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Bnode collection + relabelling, recursing through triple terms.
+// ---------------------------------------------------------------------------
+
+fn push_unique(labels: &mut Vec<String>, label: &str) {
+    if !labels.iter().any(|l| l == label) {
+        labels.push(label.to_string());
+    }
+}
+
+fn collect_bnodes_subject(subject: &NamedOrBlankNode, out: &mut Vec<String>) {
+    if let NamedOrBlankNode::BlankNode(b) = subject {
+        push_unique(out, b.as_str());
+    }
+}
+
+fn collect_bnodes_term(term: &Term, out: &mut Vec<String>) {
+    match term {
+        Term::BlankNode(b) => push_unique(out, b.as_str()),
+        Term::Triple(t) => {
+            collect_bnodes_subject(&t.subject, out);
+            collect_bnodes_term(&t.object, out);
+        }
+        _ => {}
+    }
+}
+
+/// RDFC-1.0 §4.6 (3.1.1) special relabelling: a bnode equal to the reference
+/// becomes `a`, any other bnode becomes `z`. Applied recursively through triple
+/// terms so nested bnodes get the same special-identifier treatment.
+fn relabel_quad_first_degree(quad: &Quad, reference: &str) -> Quad {
+    Quad::new(
+        relabel_subject(&quad.subject, reference),
+        quad.predicate.clone(),
+        relabel_term(&quad.object, reference),
+        relabel_graph(&quad.graph_name, reference),
+    )
+}
+
+fn relabel_subject(subject: &NamedOrBlankNode, reference: &str) -> NamedOrBlankNode {
+    match subject {
+        NamedOrBlankNode::BlankNode(b) => {
+            NamedOrBlankNode::BlankNode(special_label(b.as_str(), reference))
+        }
+        other => other.clone(),
+    }
+}
+
+fn relabel_term(term: &Term, reference: &str) -> Term {
+    match term {
+        Term::BlankNode(b) => Term::BlankNode(special_label(b.as_str(), reference)),
+        Term::Triple(t) => Term::Triple(Box::new(Triple::new(
+            relabel_subject(&t.subject, reference),
+            t.predicate.clone(),
+            relabel_term(&t.object, reference),
+        ))),
+        other => other.clone(),
+    }
+}
+
+fn relabel_graph(graph: &GraphName, reference: &str) -> GraphName {
+    match graph {
+        GraphName::BlankNode(b) => GraphName::BlankNode(special_label(b.as_str(), reference)),
+        other => other.clone(),
+    }
+}
+
+fn special_label(label: &str, reference: &str) -> BlankNode {
+    if label == reference {
+        BlankNode::new_unchecked("a")
+    } else {
+        BlankNode::new_unchecked("z")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Final serialization with canonical labels.
+// ---------------------------------------------------------------------------
+
+/// §5 serialize: relabel every bnode to its canonical `c14nN`, sort the lines
+/// in code-point order, concatenate (one `\n`-terminated line per quad).
+fn serialize_canonical(
+    dataset: &[Quad],
+    issued: &std::collections::HashMap<String, String>,
+) -> String {
+    let mut doc = String::new();
+    for line in canonical_lines(dataset, issued) {
+        doc.push_str(&line);
+        doc.push('\n');
+    }
+    doc
+}
+
+/// The canonical N-Quads lines (each `… .`, NO trailing newline — matching the
+/// standard `CanonicalGraph::lines` contract), sorted in code-point order and
+/// **deduplicated**: RDF is a set, so identical quads (which canonicalize to the
+/// same line) collapse, exactly as the `rdf-canon` `Dataset` path does.
+fn canonical_lines(
+    dataset: &[Quad],
+    issued: &std::collections::HashMap<String, String>,
+) -> Vec<String> {
+    let mut lines: Vec<String> = dataset
+        .iter()
+        .map(|q| {
+            let relabelled = Quad::new(
+                relabel_subject_canonical(&q.subject, issued),
+                q.predicate.clone(),
+                relabel_term_canonical(&q.object, issued),
+                relabel_graph_canonical(&q.graph_name, issued),
+            );
+            canonical_line_no_newline(&relabelled)
+        })
+        .collect();
+    lines.sort();
+    lines.dedup();
+    lines
+}
+
+/// A canonical N-Quads line WITHOUT the trailing ` .\n` separator — the
+/// `CanonicalGraph::lines` form. (The hashing path uses [`serialize_quad_line`],
+/// which keeps the ` .\n` the RDFC-1.0 spec hashes over.)
+fn canonical_line_no_newline(quad: &Quad) -> String {
+    match &quad.graph_name {
+        GraphName::DefaultGraph => {
+            format!("{} {} {} .", quad.subject, quad.predicate, quad.object)
+        }
+        graph => format!(
+            "{} {} {} {} .",
+            quad.subject, quad.predicate, quad.object, graph
+        ),
+    }
+}
+
+fn issued_label(label: &str, issued: &std::collections::HashMap<String, String>) -> BlankNode {
+    match issued.get(label) {
+        Some(c) => BlankNode::new_unchecked(c.clone()),
+        // Unlabelled bnode (shouldn't happen for a fully canonicalized dataset);
+        // keep the input label rather than panic so the failure is visible.
+        None => BlankNode::new_unchecked(label),
+    }
+}
+
+fn relabel_subject_canonical(
+    subject: &NamedOrBlankNode,
+    issued: &std::collections::HashMap<String, String>,
+) -> NamedOrBlankNode {
+    match subject {
+        NamedOrBlankNode::BlankNode(b) => {
+            NamedOrBlankNode::BlankNode(issued_label(b.as_str(), issued))
+        }
+        other => other.clone(),
+    }
+}
+
+fn relabel_term_canonical(
+    term: &Term,
+    issued: &std::collections::HashMap<String, String>,
+) -> Term {
+    match term {
+        Term::BlankNode(b) => Term::BlankNode(issued_label(b.as_str(), issued)),
+        Term::Triple(t) => Term::Triple(Box::new(Triple::new(
+            relabel_subject_canonical(&t.subject, issued),
+            t.predicate.clone(),
+            relabel_term_canonical(&t.object, issued),
+        ))),
+        other => other.clone(),
+    }
+}
+
+fn relabel_graph_canonical(
+    graph: &GraphName,
+    issued: &std::collections::HashMap<String, String>,
+) -> GraphName {
+    match graph {
+        GraphName::BlankNode(b) => GraphName::BlankNode(issued_label(b.as_str(), issued)),
+        other => other.clone(),
+    }
+}
+
+/// One canonical N-Quads line, `… .\n`, using oxrdf-0.3's canonical `Display`
+/// (which renders triple terms as `<<( … )>>` and directional literals as
+/// `"…"@lang--dir` per RDF-1.2 N-Quads). Default-graph quads omit the graph
+/// term (3-term line), matching the standard serializer.
+fn serialize_quad_line(quad: &Quad) -> String {
+    match &quad.graph_name {
+        GraphName::DefaultGraph => {
+            format!("{} {} {} .\n", quad.subject, quad.predicate, quad.object)
+        }
+        graph => {
+            format!(
+                "{} {} {} {} .\n",
+                quad.subject, quad.predicate, quad.object, graph
+            )
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Small helpers.
+// ---------------------------------------------------------------------------
+
+fn hash_hex(data: &[u8]) -> String {
+    let digest = Sha256::digest(data);
+    let mut s = String::with_capacity(digest.len() * 2);
+    for byte in digest.iter() {
+        s.push_str(&format!("{:02x}", byte));
+    }
+    s
+}
+
+/// All permutations of `items` (RDFC-1.0 §4.8 5.4). Lists here are the bnodes
+/// sharing one related hash; the spec's factorial blow-up is bounded by the
+/// HNDQ call limit applied in the recursion.
+fn permutations(items: &[String]) -> Vec<Vec<String>> {
+    if items.is_empty() {
+        return vec![vec![]];
+    }
+    let mut out = Vec::new();
+    for i in 0..items.len() {
+        let mut rest = items.to_vec();
+        let head = rest.remove(i);
+        for mut p in permutations(&rest) {
+            p.insert(0, head.clone());
+            out.push(p);
+        }
+    }
+    out
+}

--- a/crates/sparq-canon/tests/rdf12_triple_term_canon.rs
+++ b/crates/sparq-canon/tests/rdf12_triple_term_canon.rs
@@ -1,0 +1,371 @@
+//! Tests for the OPT-IN, NON-STANDARD `rdf12-triple-terms` profile (sq-hslb).
+//!
+//! Only compiled when the feature is on. The headline invariants:
+//!  1. **Standard-path agreement** — on triple-term-free input the v2 profile is
+//!     byte-identical to the standard `rdf-canon`-backed path (the strongest
+//!     correctness anchor; run over every W3C suite eval vector).
+//!  2. **Ground triple-term datasets** — order-invariant, isomorphism-stable.
+//!  3. **Nested-bnode triple terms** — a blank node inside a triple-term object
+//!     (and deeper) is relabelled by the HNDQ descent; bnode-label and
+//!     triple-order invariance hold, including bnodes shared between a top-level
+//!     position and a triple-term-internal position. Includes a case the
+//!     standard path rejects with `TripleTerm` that now canonicalizes.
+#![cfg(feature = "rdf12-triple-terms")]
+
+use oxrdf::{BlankNode, Literal, NamedNode, NamedOrBlankNode, Quad, Term, Triple, GraphName};
+use std::path::{Path, PathBuf};
+
+fn testdata() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/rdf-canon-testdata")
+}
+
+fn iri(s: &str) -> NamedNode {
+    NamedNode::new(s).unwrap()
+}
+fn bn(s: &str) -> BlankNode {
+    BlankNode::new(s).unwrap()
+}
+
+/// Triple-term object `<<( s p o )>>`.
+fn tt(s: NamedOrBlankNode, p: NamedNode, o: Term) -> Term {
+    Term::Triple(Box::new(Triple::new(s, p, o)))
+}
+
+// ---------------------------------------------------------------------------
+// 1) Standard-path agreement on triple-term-free input (the W3C suite).
+// ---------------------------------------------------------------------------
+
+fn load_quads(path: &Path) -> Vec<Quad> {
+    let bytes = std::fs::read(path).unwrap();
+    oxttl::NQuadsParser::new()
+        .for_slice(&bytes)
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap()
+}
+
+/// Every default-SHA-256 eval `.nq` input under the suite, canonicalized by both
+/// the standard path and the v2 profile, must agree byte-for-byte. This proves
+/// the native HNDQ matches `rdf-canon` on the shared (triple-term-free) subset.
+#[test]
+fn v2_agrees_with_standard_on_suite_inputs() {
+    let dir = testdata().join("rdfc10");
+    let mut compared = 0usize;
+    let mut mismatches: Vec<String> = Vec::new();
+    let mut entries: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.ends_with("-in.nq"))
+                .unwrap_or(false)
+        })
+        .collect();
+    entries.sort();
+
+    for path in entries {
+        let quads = load_quads(&path);
+        // Standard path: skip the few suite inputs the standard path itself
+        // rejects (poison graphs hit the HNDQ limit). We only compare where the
+        // standard path succeeds — that is exactly the shared subset.
+        let std_out = match sparq_canon::canonicalize(&quads) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        let v2_out = sparq_canon::canonicalize_rdf12(&quads)
+            .unwrap_or_else(|e| panic!("v2 failed on {:?}: {e}", path));
+        if std_out != v2_out {
+            mismatches.push(format!(
+                "{:?}\n  std: {:?}\n  v2:  {:?}",
+                path.file_name().unwrap(),
+                std_out,
+                v2_out
+            ));
+        }
+        compared += 1;
+    }
+    assert!(
+        compared >= 60,
+        "expected to compare most suite inputs, got {compared}"
+    );
+    assert!(
+        mismatches.is_empty(),
+        "{} suite inputs disagree between standard and v2:\n{}",
+        mismatches.len(),
+        mismatches.join("\n")
+    );
+}
+
+/// The single-graph v2 API agrees with the standard single-graph API on every
+/// default-graph-only, triple-term-free suite eval input.
+#[test]
+fn v2_single_graph_agrees_with_standard() {
+    let dir = testdata().join("rdfc10");
+    let mut compared = 0usize;
+    let mut entries: Vec<_> = std::fs::read_dir(&dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.file_name()
+                .and_then(|n| n.to_str())
+                .map(|n| n.ends_with("-in.nq"))
+                .unwrap_or(false)
+        })
+        .collect();
+    entries.sort();
+    for path in entries {
+        let quads = load_quads(&path);
+        if !quads.iter().all(|q| q.graph_name == GraphName::DefaultGraph) {
+            continue;
+        }
+        let triples: Vec<Triple> = quads
+            .iter()
+            .map(|q| Triple::new(q.subject.clone(), q.predicate.clone(), q.object.clone()))
+            .collect();
+        let std_out = match sparq_canon::canonicalize_triples(&triples) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let v2_out = sparq_canon::canonicalize_triples_rdf12(&triples).unwrap();
+        assert_eq!(
+            std_out.lines, v2_out.lines,
+            "single-graph lines disagree on {:?}",
+            path.file_name().unwrap()
+        );
+        assert_eq!(
+            std_out.triples, v2_out.triples,
+            "single-graph triples disagree on {:?}",
+            path.file_name().unwrap()
+        );
+        compared += 1;
+    }
+    assert!(compared >= 30, "expected most eval inputs default-graph, got {compared}");
+}
+
+// ---------------------------------------------------------------------------
+// 2) Ground (blank-free) triple-term datasets.
+// ---------------------------------------------------------------------------
+
+/// A ground triple-term dataset (no blank nodes anywhere) is order-invariant and
+/// canonicalizes to the same bytes regardless of input quad order — the common
+/// credential/VC case.
+#[test]
+fn ground_triple_term_is_order_invariant() {
+    let inner = |o: &str| -> Term {
+        tt(
+            NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+            iri("http://ex/p"),
+            Term::NamedNode(iri(o)),
+        )
+    };
+    let t1 = Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+        iri("http://ex/says"),
+        inner("http://ex/o1"),
+    );
+    let t2 = Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/b")),
+        iri("http://ex/says"),
+        inner("http://ex/o2"),
+    );
+    let forward = sparq_canon::canonicalize_triples_rdf12(&[t1.clone(), t2.clone()]).unwrap();
+    let reverse = sparq_canon::canonicalize_triples_rdf12(&[t2, t1]).unwrap();
+    assert_eq!(forward.lines, reverse.lines, "ground TT must be order-invariant");
+    // Sanity: triple-term token form is present in the canonical output.
+    assert!(
+        forward.lines.iter().any(|l| l.contains("<<(")),
+        "expected canonical triple-term token form: {:?}",
+        forward.lines
+    );
+}
+
+/// A triple term whose object is itself a triple term (ground, deep nesting)
+/// canonicalizes deterministically and preserves the nested token form.
+#[test]
+fn ground_deep_nested_triple_term() {
+    let deepest = tt(
+        NamedOrBlankNode::NamedNode(iri("http://ex/x")),
+        iri("http://ex/p"),
+        Term::Literal(Literal::new_simple_literal("v")),
+    );
+    let mid = tt(
+        NamedOrBlankNode::NamedNode(iri("http://ex/y")),
+        iri("http://ex/q"),
+        deepest,
+    );
+    let t = Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+        iri("http://ex/says"),
+        mid,
+    );
+    let c = sparq_canon::canonicalize_triples_rdf12(std::slice::from_ref(&t)).unwrap();
+    assert_eq!(c.lines.len(), 1);
+    // Nested `<<( ... <<( ... )>> )>>` round-trips back to the same term.
+    assert_eq!(c.triples[0], t, "deep ground TT must round-trip");
+}
+
+// ---------------------------------------------------------------------------
+// 3) Nested-blank-node triple terms — the headline HNDQ-descent deliverable.
+// ---------------------------------------------------------------------------
+
+/// The case the OLD code rejected with `TripleTerm`: a blank node nested inside
+/// a triple-term object now canonicalizes, and is relabelled to `c14nN`.
+#[test]
+fn nested_bnode_now_canonicalizes() {
+    let inner = tt(
+        NamedOrBlankNode::BlankNode(bn("nested")),
+        iri("http://ex/p"),
+        Term::Literal(Literal::new_simple_literal("v")),
+    );
+    let t = Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+        iri("http://ex/asserts"),
+        inner,
+    );
+    // Standard path still rejects.
+    assert!(matches!(
+        sparq_canon::canonicalize_triples(std::slice::from_ref(&t)),
+        Err(sparq_canon::CanonError::TripleTerm)
+    ));
+    // v2 profile canonicalizes and relabels the nested bnode.
+    let c = sparq_canon::canonicalize_triples_rdf12(&[t]).unwrap();
+    assert_eq!(c.lines.len(), 1);
+    assert!(
+        c.lines[0].contains("_:c14n0"),
+        "nested bnode must be relabelled to c14n0: {}",
+        c.lines[0]
+    );
+}
+
+/// Bnode-label invariance + triple-order invariance for nested-bnode triple
+/// terms: two isomorphic graphs differing only by input bnode labels and quad
+/// order canonicalize byte-identically, including a bnode shared between a
+/// top-level subject and a triple-term-internal position.
+#[test]
+fn nested_bnode_isomorphism() {
+    // Graph shape:
+    //   _:shared  ex:says  <<( _:shared ex:p _:other )>>
+    //   _:other   ex:t     "leaf"
+    // _:shared appears both at top level (subject) AND inside the triple term.
+    let build = |shared: &str, other: &str, swap: bool| -> Vec<Triple> {
+        let inner = tt(
+            NamedOrBlankNode::BlankNode(bn(shared)),
+            iri("http://ex/p"),
+            Term::BlankNode(bn(other)),
+        );
+        let t1 = Triple::new(
+            NamedOrBlankNode::BlankNode(bn(shared)),
+            iri("http://ex/says"),
+            inner,
+        );
+        let t2 = Triple::new(
+            NamedOrBlankNode::BlankNode(bn(other)),
+            iri("http://ex/t"),
+            Term::Literal(Literal::new_simple_literal("leaf")),
+        );
+        if swap {
+            vec![t2, t1]
+        } else {
+            vec![t1, t2]
+        }
+    };
+    let a = sparq_canon::canonicalize_triples_rdf12(&build("shared", "other", false)).unwrap();
+    let b = sparq_canon::canonicalize_triples_rdf12(&build("xxx", "yyy", true)).unwrap();
+    assert_eq!(
+        a.lines, b.lines,
+        "isomorphic nested-bnode graphs must canonicalize identically\n a={:?}\n b={:?}",
+        a.lines, b.lines
+    );
+    // The shared bnode must resolve to one canonical label used in both its
+    // top-level and triple-term-internal occurrences.
+    assert!(a.lines.iter().any(|l| l.contains("<<(")));
+}
+
+/// Distinguishing case: two graphs that are NOT isomorphic (a nested bnode is
+/// connected differently) must canonicalize to DIFFERENT output, so the descent
+/// is not collapsing distinct structure.
+#[test]
+fn nested_bnode_distinguishes_non_isomorphic() {
+    // G1: _:a ex:says <<( _:a ex:p _:b )>> ;  _:b ex:t "x"
+    let g1 = {
+        let inner = tt(
+            NamedOrBlankNode::BlankNode(bn("a")),
+            iri("http://ex/p"),
+            Term::BlankNode(bn("b")),
+        );
+        vec![
+            Triple::new(NamedOrBlankNode::BlankNode(bn("a")), iri("http://ex/says"), inner),
+            Triple::new(
+                NamedOrBlankNode::BlankNode(bn("b")),
+                iri("http://ex/t"),
+                Term::Literal(Literal::new_simple_literal("x")),
+            ),
+        ]
+    };
+    // G2: _:a ex:says <<( _:b ex:p _:b )>> ;  _:b ex:t "x"  (subject of inner differs)
+    let g2 = {
+        let inner = tt(
+            NamedOrBlankNode::BlankNode(bn("b")),
+            iri("http://ex/p"),
+            Term::BlankNode(bn("b")),
+        );
+        vec![
+            Triple::new(NamedOrBlankNode::BlankNode(bn("a")), iri("http://ex/says"), inner),
+            Triple::new(
+                NamedOrBlankNode::BlankNode(bn("b")),
+                iri("http://ex/t"),
+                Term::Literal(Literal::new_simple_literal("x")),
+            ),
+        ]
+    };
+    let c1 = sparq_canon::canonicalize_triples_rdf12(&g1).unwrap();
+    let c2 = sparq_canon::canonicalize_triples_rdf12(&g2).unwrap();
+    assert_ne!(c1.lines, c2.lines, "non-isomorphic graphs must differ");
+}
+
+/// Dataset-level (named-graph) entry point with a nested bnode triple term.
+#[test]
+fn dataset_named_graph_nested_bnode() {
+    let inner = tt(
+        NamedOrBlankNode::BlankNode(bn("n")),
+        iri("http://ex/p"),
+        Term::Literal(Literal::new_simple_literal("v")),
+    );
+    let q = Quad::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+        iri("http://ex/asserts"),
+        inner,
+        GraphName::NamedNode(iri("http://ex/g")),
+    );
+    let out = sparq_canon::canonicalize_rdf12(std::slice::from_ref(&q)).unwrap();
+    assert!(out.contains("<http://ex/g>"), "graph name preserved: {out}");
+    assert!(out.contains("_:c14n0"), "nested bnode relabelled: {out}");
+    let map = sparq_canon::issue_dataset_rdf12(&[q]).unwrap();
+    assert_eq!(map.get("n").map(String::as_str), Some("c14n0"));
+}
+
+/// Directional language-tagged string inside a triple term renders with the
+/// canonical RDF-1.2 `@lang--dir` token form (single-sourced via oxrdf Display).
+#[test]
+fn directional_language_string_in_triple_term() {
+    let dir_lit = Literal::new_directional_language_tagged_literal("שלום", "he", oxrdf::BaseDirection::Rtl)
+        .unwrap();
+    let inner = tt(
+        NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+        iri("http://ex/p"),
+        Term::Literal(dir_lit),
+    );
+    let t = Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+        iri("http://ex/says"),
+        inner,
+    );
+    let c = sparq_canon::canonicalize_triples_rdf12(&[t]).unwrap();
+    assert!(
+        c.lines[0].contains("@he--rtl"),
+        "directional language token form expected: {}",
+        c.lines[0]
+    );
+}

--- a/skills/rdf-canon/SKILL.md
+++ b/skills/rdf-canon/SKILL.md
@@ -88,13 +88,46 @@ if you want them without canonicalizing.
 
 `CanonError` has three variants:
 
-- `TripleTerm` — the dataset contains an RDF 1.2 triple term as an object;
-  these are outside RDFC-1.0's data model and cannot be canonicalized.
+- `TripleTerm` — the dataset contains an RDF 1.2 triple term as an object; these
+  are outside W3C RDFC-1.0's data model, so the **standard** paths fail closed.
+  Enable the opt-in `rdf12-triple-terms` profile (below) to canonicalize them.
 - `Canonicalization(String)` — `rdf-canon` rejected the dataset. This includes
   the **HNDQ call-limit guard**: RDFC-1.0 has pathological-input blow-ups, so a
   poison graph trips the limit and fails closed rather than running unbounded.
 - `Bridge(String)` — an internal serialize/parse error (should not occur for
   well-formed RDFC-1.0-model input; surfaced rather than swallowed).
+
+## ⚠️ Opt-in NON-STANDARD RDF 1.2 triple-term profile
+
+**OFF by default; NOT W3C RDFC-1.0.** RDFC-1.0 is an RDF-1.1-only spec with no
+notion of triple terms; their canonicalization is **unsettled upstream**
+([w3c/rdf-star-wg#114](https://github.com/w3c/rdf-star-wg/issues/114)). With the
+feature OFF, behaviour is byte-identical to the standard surface (triple terms
+still raise `CanonError::TripleTerm`; the W3C suite still passes).
+
+Enable the cargo feature to opt in to a **separate, clearly non-standard** v2
+profile. It natively re-implements the RDFC-1.0 algorithm over oxrdf 0.3 and
+**descends the Hash-N-Degree-Quads gossip into `Term::Triple` objects**, so blank
+nodes nested inside triple terms are relabelled to `c14nN`. On triple-term-free
+input it is byte-identical to the standard path (asserted against every W3C suite
+vector — the strongest correctness anchor).
+
+```toml
+sparq-canon = { path = "crates/sparq-canon", features = ["rdf12-triple-terms"] }
+```
+
+```rust
+// NON-STANDARD profile (SHA-256). Canonicalizes triple terms incl. nested bnodes.
+let nq = sparq_canon::canonicalize_rdf12(&dataset)?;          // quads -> N-Quads
+let cg = sparq_canon::canonicalize_triples_rdf12(&triples)?;  // one graph
+let m  = sparq_canon::issue_dataset_rdf12(&dataset)?;         // issuer map
+```
+
+**Boundary / honesty:** SHA-256 only (no `*_with` hash profile for v2 yet);
+triple terms appear only as objects in oxrdf 0.3 (a triple's subject is
+`NamedOrBlankNode`), so nesting descends strictly through the object position; the
+HNDQ poison-graph call limit still fails closed. This is a sparq-local extension,
+**not** a W3C standard — do not represent its output as W3C RDFC-1.0.
 
 ## Conformance
 
@@ -112,7 +145,10 @@ through this crate's own public API. See `crates/sparq-canon/tests/`.
 
 ## Status
 
-Verified against `sparq-canon` 0.1.0 source on branch `feat-rdfc-public-api`
-(2026-06-15). The RDFC-1.0 algorithm is `rdf-canon` 0.15.3 (W3C-suite validated);
-`sparq-canon` is the single-sourced bridge + public API. `publish = false`,
-non-default workspace member — nothing in sparq's default graph depends on it.
+Verified against `sparq-canon` 0.1.0 source. The standard RDFC-1.0 path is
+`rdf-canon` 0.15.3 (W3C-suite validated); `sparq-canon` is the single-sourced
+bridge + public API. The opt-in, off-by-default `rdf12-triple-terms` profile
+(sq-hslb [OPUS-4.8]) is a native RDFC-1.0 re-implementation extended to RDF 1.2
+triple terms — **non-standard** (W3C RDFC-1.0 is RDF-1.1-only). `publish = false`,
+non-default workspace member — nothing in sparq's default graph depends on it, so
+the default build and wasm artifact are byte-identical with or without it.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Closes #913.

Implements bead **sq-hslb** — a **NON-STANDARD** opt-in RDFC-1.0 + RDF-1.2 triple-term canonicalization profile in `crates/sparq-canon`, per @jeswr's real-voice greenlight on #913 ("Go for full non-standard profile and implement a non-standard canon."). This replaces the fail-closed `CanonError::TripleTerm` path **only when the new feature is enabled** — the default build is byte-identical to `main`.

## What this is — and what it is NOT

This is **NOT W3C RDFC-1.0.** W3C RDFC-1.0 is RDF-1.1-only, and the RDF-1.2 consequences for canonicalization are **unsettled upstream** (w3c/rdf-star-wg#114). The new surface is labelled **non-standard** throughout the API, rustdoc, README, and SKILL, and lives behind a distinct off-by-default cargo feature.

## What I implemented

A new opt-in module `crates/sparq-canon/src/rdf12.rs` that **natively re-implements the full RDFC-1.0 algorithm over oxrdf 0.3** (IdentifierIssuer §4.3/4.5, Hash First Degree Quads §4.6, Hash Related Blank Node §4.7, recursive **Hash N-Degree Quads** §4.8) and **extends the HNDQ gossip to descend through `oxrdf::Term::Triple` objects at any nesting depth** — so a blank node nested inside a triple term is enrolled, gossiped, and relabelled to `c14nN` exactly like a top-level one. The external `rdf-canon` crate (oxrdf 0.2) cannot canonicalize triple terms, so this path is implemented natively rather than delegated.

New public surface (re-exported from the crate root, all behind the feature):
- `canonicalize_rdf12(&[Quad]) -> Result<String, CanonError>`
- `canonicalize_triples_rdf12(&[Triple]) -> Result<CanonicalGraph, CanonError>`
- `canonicalize_graph_content_rdf12(&Graph) -> Result<CanonicalGraph, CanonError>`
- `issue_dataset_rdf12(&[Quad]) -> Result<HashMap<String,String>, CanonError>`

Triple-term token rules (`<<( … )>>`) and directional-language literals (`"…"@lang--dir`) are single-sourced via oxrdf-0.3's `Display` (not hand-rolled). RDF set semantics (quad dedup) and the HNDQ poison-graph call limit are preserved.

## Feature flag

`rdf12-triple-terms` (`default = []`; OFF by default).

## Gates — GREEN in BOTH states

- **Default / feature OFF:** `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` GREEN; the **W3C rdf-canon suite passes**, the rdf12 test file compiles to 0 tests (correctly gated out), and `canonicalize_triples` on a triple-term input **still returns `CanonError::TripleTerm`** — byte-identical to `main`.
- **Feature ON** (`--features rdf12-triple-terms`): build / clippy `--all-targets -- -D warnings` / test GREEN; 9 new triple-term integration tests pass (ground round-trip + isomorphism; nested-blank-node HNDQ descent + bnode-label/order invariance; cases the old code rejected that now canonicalize; **byte-agreement of the native HNDQ with the delegated `rdf-canon` path on every triple-term-free W3C eval input** — the strongest correctness anchor); the W3C suite stays green.

## Default-build byte-identity

`cargo tree -p sparq-canon --edges normal` (default) is identical to `main`'s (the optional `sha2` is already a transitive normal dep via `rdf-canon`, so it adds nothing). `sparq-core`'s tree does not contain `sparq-canon` (it is `publish=false`, out of the default/wasm graph), so core/wasm artifacts are structurally unaffected. The consumer `sparq-zk` builds unchanged on the default build.

## Correctness notes (honest)

Three real issues were caught and fixed during implementation: duplicate-quad set semantics; the `lines` trailing-newline contract; and the §4.8 permutation-pruning comparison (corrected `>` → spec-faithful `>=` to match the reference on all inputs, not just suite vectors). No performance numbers are stated anywhere (sparq-canon is bench-exempt; the work box is non-canonical).

## Upstream items (DRAFT-ONLY — to be @jeswr-tagged before going non-draft; NOT filed live)

1. **w3c/rdf-canon: RDF-1.2 triple-term canonicalization is undefined** — the spec's bnode "component" notion has no rule for bnodes nested inside a triple term (ties to w3c/rdf-star-wg#114).
2. **Position marker for nested bnodes is unspecified** — this profile uses object-position `o`; the spec gives no guidance on whether deeper structural position should carry a sub-discriminator.
3. **Canonical N-Quads 1.2 token form is not yet a stable normative reference** — the `<<( … )>>` / `@lang--dir` forms here come from oxttl/oxrdf 0.3's serializer.
4. **W3C rdf-canon test-suite gap (not an error):** the suite contains **zero triple-term vectors**, so the non-standard path has no official conformance vectors — a draft suite-contribution candidate.

No actual *errors* were found in the existing suite; it passes byte-for-byte.

## Deferred follow-ups (tracked as beads)

- Constrained no-nested-bnode fast-path for the common ground/VC case.
- `*_with::<D: Digest>` hash-profile parity for the v2 path (currently SHA-256 only).
- N-Quads-1.2 token edge cases once rdf12-n-quads is final.
- Triple terms in subject position if a future oxrdf revision allows `Subject::Triple`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
