### PR TITLE
feat(sparq-server): GSP PATCH — atomic SPARQL-Update body (always-on) + opt-in Solid N3-Patch (sq-hj4n)

### DIFF
--- a/crates/sparq-server/Cargo.toml
+++ b/crates/sparq-server/Cargo.toml
@@ -165,6 +165,21 @@ brtpf = ["tpf"]
 # `SPARQ_SHACL=1` (`ServerConfig::shacl`), mirroring `tpf` / `federation-descriptors`;
 # validation is a READ over the store, so it is gated by the read auth like any GET.
 shacl = ["server", "dep:sparq-shacl"]
+# [OPUS-4.8] (sq-hj4n, gh-916) `n3-patch` (default OFF) adds the OPTIONAL Solid-style N3-Patch
+# (`solid:InsertDeletePatch`, media type `text/n3`) dialect to the Graph-Store-Protocol `PATCH`
+# method. With it on, a `PATCH` carrying a `text/n3` body is parsed into its `solid:deletes` /
+# `solid:inserts` / `solid:where` formulas and translated into ONE atomic graph-scoped SPARQL
+# Update submitted through the SAME sequenced group-commit writer the `application/sparql-update`
+# PATCH path uses (so it inherits atomicity + the auth gate). The N3 parsing rides the `oxttl`
+# `N3Parser` — `oxttl` is ALREADY a server dependency (the GSP read-side Turtle serialiser), so
+# this pulls NO new dependency. The OTHER PATCH dialect (`application/sparql-update` body) is
+# ALWAYS-ON and is NOT behind this feature. Without the `n3-patch` feature the N3-Patch parser +
+# its dispatch arm are `#[cfg]`-stripped: a `text/n3` PATCH body is then a plain `415` and the
+# crate is byte-identical to before — sparq-core / sparq-engine / the wasm bundle untouched
+# either way (sparq-wasm depends on sparq-core/-engine directly, never on sparq-server). STILL OFF
+# AT RUNTIME by default even when compiled in — the operator must additionally set `--n3-patch` /
+# `SPARQ_N3_PATCH=1` (`ServerConfig::n3_patch`), mirroring `tpf` / `shacl` / `federation-descriptors`.
+n3-patch = ["server"]
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -96,13 +96,8 @@ distributed/sharded writer is an **explicit Phase-2 non-goal**; the external-top
 ## Durable persistence (`--persist DIR`)
 
 `--persist <DIR>` makes the on-disk index the durable source of truth (QLever's `--persist-updates`):
-every update is WAL-fsync'd **before the `204` ack**, so a restart replays the WAL with no rebuild.
-A rejected update is never persisted; a durable-write failure refuses the write with a **retryable
-`503`** (never acked, writer stays alive — fail-closed). The persisted delta is the resolved acked
-value, so non-deterministic updates (`NOW()`/`RAND()`/`LOAD`) persist exactly what the client saw.
-WAL compaction (`POST /admin/compact` or offline `sparq-cli compact`) physically purges deleted
-bytes — incl. orphaned literal values — for erasure-completeness, but **cannot** reach bytes copied
-off-box (snapshots, backups — operator's responsibility). See the SKILL for the compaction details.
+every update is WAL-fsync'd **before the `204` ack** (restart replays the WAL, no rebuild); a rejected
+update is never persisted, a durable-write failure refuses with a **retryable `503`** (fail-closed), and WAL compaction (`POST /admin/compact` / `sparq-cli compact`) purges deleted bytes for erasure-completeness but **cannot** reach off-box copies (snapshots/backups) — see the SKILL.
 
 ## 📚 Learn more
 

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -31,7 +31,11 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
   (`application/sparql-update` → `204`, atomic), including the protocol dataset-override params.
 - **Named graphs + Graph Store Protocol** — a full RDF dataset (`GRAPH` patterns, cross-graph
   joins, `FROM`/`FROM NAMED`, graph-scoped updates through the same writer) plus GSP `GET`/`HEAD`
-  read and `PUT`/`POST`/`DELETE` write (indirect `?graph=`/`?default` or direct request-URI).
+  read and `PUT`/`POST`/`DELETE`/`PATCH` write (indirect `?graph=`/`?default` or direct request-URI).
+  A `PATCH` applies an **atomic, graph-scoped in-place modify**: an always-on
+  `application/sparql-update` body (executed atomically through the same writer, with its WHERE
+  dataset scoped to the addressed graph), and — behind the OPT-IN `n3-patch` feature + `--n3-patch`
+  flag — a Solid-style `text/n3` **N3-Patch** (`solid:InsertDeletePatch`).
 - **Content negotiation** — q-value aware; SELECT/ASK in JSON/XML/CSV/TSV, CONSTRUCT/DESCRIBE and
   GSP read in N-Triples / prefix-Turtle / RDF-XML; streamed SELECT bodies. Plus **EXPLAIN /
   EXPLAIN ANALYZE**, Prometheus **`/metrics`**, and SEPA-style **WebSocket + SSE** live SELECT diffs.
@@ -47,7 +51,8 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
   (`?generation=N` snapshot pinning), `geo` (`geof:` functions), `service` (SERVICE federation,
   **default-deny** SSRF guard), `federation-descriptors` (VoID + Service Description discovery),
   `tpf`/`brtpf` (Triple Pattern Fragments / bind-restricted LDF source), `shacl`
-  (`POST /shacl/validate`), `audit-log`/`access-audit` (access trails), `zlib-ng` (faster gzip).
+  (`POST /shacl/validate`), `n3-patch` (Solid `text/n3` N3-Patch on GSP `PATCH`),
+  `audit-log`/`access-audit` (access trails), `zlib-ng` (faster gzip).
 
 ## Security posture (essentials — full detail in the SKILL)
 

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -577,6 +577,20 @@ pub struct ServerConfig {
     /// is a READ over the store, so the endpoint is gated by the read auth like any GET.
     #[cfg(feature = "shacl")]
     pub shacl: bool,
+    /// [OPUS-4.8] (sq-hj4n, gh-916) OPT-IN Solid-style **N3-Patch** (`text/n3`) dialect for the
+    /// Graph-Store-Protocol `PATCH` method. When `true`, a `PATCH` whose body is `text/n3` (a
+    /// `solid:InsertDeletePatch`) is parsed into its `solid:deletes` / `solid:inserts` /
+    /// `solid:where` formulas and applied as ONE atomic graph-scoped SPARQL Update through the same
+    /// sequenced writer the always-on `application/sparql-update` `PATCH` body uses. `false` (the
+    /// default) leaves it off: a `text/n3` `PATCH` body is `415` (the always-on
+    /// `application/sparql-update` `PATCH` dialect is unaffected — it never depends on this flag).
+    ///
+    /// This field exists only with the `n3-patch` cargo feature (like [`tpf`](Self::tpf) under
+    /// `tpf`); a build without that feature compiles no N3-Patch code and pays zero cost. Set by
+    /// the binary's `--n3-patch` flag / `SPARQ_N3_PATCH=1` env. A `PATCH` is a WRITE, so it is
+    /// gated by `--auth-token` exactly like an UPDATE.
+    #[cfg(feature = "n3-patch")]
+    pub n3_patch: bool,
 }
 
 impl Default for ServerConfig {
@@ -673,6 +687,11 @@ impl Default for ServerConfig {
             // SPARQ_SHACL=1).
             #[cfg(feature = "shacl")]
             shacl: false,
+            // [OPUS-4.8] sq-hj4n: safe default — the OPT-IN N3-Patch PATCH dialect is OFF even when
+            // the feature is compiled in (the operator opts in deliberately via --n3-patch /
+            // SPARQ_N3_PATCH=1). The always-on application/sparql-update PATCH dialect is unaffected.
+            #[cfg(feature = "n3-patch")]
+            n3_patch: false,
         }
     }
 }
@@ -902,6 +921,13 @@ impl ServerConfig {
         #[cfg(feature = "shacl")]
         if let Ok(v) = std::env::var("SPARQ_SHACL") {
             cfg.shacl = env_truthy(&v);
+        }
+        // [OPUS-4.8] sq-hj4n: SPARQ_N3_PATCH truthy ("1"/"true"/"yes"/"on") enables the OPT-IN
+        // Solid N3-Patch PATCH dialect (text/n3). Off by default. Only present with the
+        // `n3-patch` feature.
+        #[cfg(feature = "n3-patch")]
+        if let Ok(v) = std::env::var("SPARQ_N3_PATCH") {
+            cfg.n3_patch = env_truthy(&v);
         }
         Ok(cfg)
     }
@@ -4338,13 +4364,20 @@ async fn graph_store(
         Method::PUT => gsp_put(state, graph, headers, &body).await,
         Method::POST => gsp_post(state, graph, headers, &body).await,
         Method::DELETE => gsp_delete(state, graph).await,
-        // PATCH is not part of the Graph Store HTTP Protocol.
+        // [OPUS-4.8] (sq-hj4n, gh-916) PATCH = a graph-scoped, atomic in-place modify. Two body
+        // dialects: an always-on `application/sparql-update` body (executed atomically through the
+        // same sequenced writer the /sparql update path uses, scoped to this graph), and — only
+        // with the `n3-patch` feature AND the `--n3-patch` runtime flag — a Solid-style `text/n3`
+        // N3-Patch body. An unsupported PATCH content type is a `415`.
+        Method::PATCH => gsp_patch(state, graph, headers, &body).await,
+        // Any other method is not part of the Graph Store HTTP Protocol.
         _ => method_not_allowed(&[
             Method::GET,
             Method::HEAD,
             Method::PUT,
             Method::POST,
             Method::DELETE,
+            Method::PATCH,
         ]),
     };
     #[cfg(feature = "audit-log")]
@@ -4650,6 +4683,188 @@ async fn gsp_delete(state: &AppState, graph: GraphRef) -> Response {
             let update = format!("DROP GRAPH <{}>", escape_iri(iri));
             apply_gsp_update(state, update, StatusCode::NO_CONTENT).await
         }
+    }
+}
+
+/// [OPUS-4.8] (sq-hj4n, gh-916) `PATCH <graph>` — apply an ATOMIC, graph-scoped in-place modify
+/// to the addressed graph. Two body dialects, classified by `Content-Type`:
+///
+///   * **`application/sparql-update`** (ALWAYS-ON, no feature, no new dep) — the body IS a SPARQL
+///     Update. It is applied atomically through the SAME sequenced group-commit writer the
+///     `/sparql` `application/sparql-update` path uses, so the whole multi-operation body lands in
+///     ONE durable generation. It is **scoped** to the addressed graph by defaulting the update's
+///     WHERE dataset to that graph (the SPARQL 1.1 Protocol §2.2 `using-graph-uri` mechanism, via
+///     the in-tree [`rewrite_update`]). HONEST SCOPE: this scopes what the WHERE *reads*; an
+///     operation that names a DIFFERENT graph explicitly (`INSERT DATA { GRAPH <other> { … } }` /
+///     a `WITH`/`USING` clause) still writes/reads where it says, exactly as SPARQL specifies —
+///     supplying the override alongside an in-string `USING`/`WITH` is a `400` (§2.2), the existing
+///     protocol behaviour. For the default graph the override is a no-op (the default graph is
+///     already the WHERE default). Success → `204`.
+///
+///   * **`text/n3`** (OPT-IN, behind the `n3-patch` cargo feature AND the `--n3-patch` runtime
+///     flag) — a Solid-style N3-Patch (`solid:InsertDeletePatch`). Parsed into its
+///     `solid:deletes` / `solid:inserts` / `solid:where` formulas and translated into ONE atomic
+///     graph-scoped SPARQL Update (every block wrapped in `GRAPH <g> { … }` for a named graph),
+///     submitted through the same writer. Success → `204`. With the feature OFF this arm is
+///     `#[cfg]`-stripped entirely, so a `text/n3` body is a plain `415`. With the feature ON but
+///     the runtime flag OFF it is also `415` (double-opt-in, mirroring `tpf`/`shacl`).
+///
+/// Any other `Content-Type` is a `415`. A `PATCH` is a WRITE, gated like an UPDATE; the auth gate
+/// already ran in [`graph_store`] before this handler.
+async fn gsp_patch(
+    state: &AppState,
+    graph: GraphRef,
+    headers: &HeaderMap,
+    body: &Bytes,
+) -> Response {
+    // [OPUS-4.8] sq-hj4n: inflate a `Content-Encoding: gzip` body under the decompression-ratio
+    // cap (zip-bomb guard) before parsing it, exactly as the GSP PUT/POST write paths do.
+    let body = match decode_request_body(body, headers, state.config()) {
+        Ok(b) => b,
+        Err(e) => return e.into_response(),
+    };
+    let ct = content_type(headers);
+    let mt = ct.split(';').next().unwrap_or("").trim();
+    match mt {
+        // ----- ALWAYS-ON dialect: a SPARQL Update body, scoped to the addressed graph. -----
+        "application/sparql-update" => {
+            let update = match std::str::from_utf8(&body) {
+                Ok(u) => u,
+                Err(_) => return bad_request("request body is not valid UTF-8"),
+            };
+            // Scope the update's WHERE dataset to the addressed named graph (§2.2 using-graph-uri,
+            // reusing the in-tree rewrite). The default graph is already the WHERE default → no
+            // override. `rewrite_update` rejects a conflict with an in-string USING/WITH (400) and
+            // a malformed update (400), sanitizing the detail.
+            let over = match &graph {
+                GraphRef::Default => UsingOverride::default(),
+                GraphRef::Named(iri) => UsingOverride {
+                    default: vec![iri.clone()],
+                    named: Vec::new(),
+                },
+            };
+            match rewrite_update(update, &over) {
+                // Reuse the shared update path: atomic group-commit, 204 on success, the same
+                // budget/timeout/sanitized-rejection discipline as the /sparql update body.
+                Ok(rewritten) => run_update(state, rewritten).await,
+                Err(resp) => resp,
+            }
+        }
+        // ----- OPT-IN dialect: Solid N3-Patch. Compiled out entirely without the feature. -----
+        #[cfg(feature = "n3-patch")]
+        "text/n3" => gsp_patch_n3(state, graph, &body).await,
+        // Anything else (including `text/n3` when the feature is off) is an unsupported media type.
+        _ => json_error(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            n3_patch_unsupported_media_msg(),
+        ),
+    }
+}
+
+/// [OPUS-4.8] (sq-hj4n) The `415` message for an unsupported `PATCH` body media type. With the
+/// `n3-patch` feature on, `text/n3` is offered (so it is named); with the feature off it is not.
+/// Two literals (not a runtime `if`) so the message is exactly right per build, and the
+/// feature-off message never advertises a dialect the build cannot serve.
+#[cfg(feature = "n3-patch")]
+fn n3_patch_unsupported_media_msg() -> &'static str {
+    "PATCH body must be a graph patch: Content-Type 'application/sparql-update' \
+     (always available) or 'text/n3' (Solid N3-Patch, when --n3-patch is enabled)"
+}
+
+/// [OPUS-4.8] (sq-hj4n) The feature-OFF `415` message — names only the always-on dialect.
+#[cfg(not(feature = "n3-patch"))]
+fn n3_patch_unsupported_media_msg() -> &'static str {
+    "PATCH body must be a graph patch: Content-Type 'application/sparql-update'"
+}
+
+/// [OPUS-4.8] (sq-hj4n, gh-916) Applies a Solid N3-Patch (`text/n3`) body to the addressed graph.
+/// Compiled ONLY behind the `n3-patch` feature. Honours the `--n3-patch` runtime flag: with it off
+/// the dialect is `415` even though the feature is compiled in (the double-opt-in posture). Parses
+/// the body, builds ONE atomic graph-scoped SPARQL Update, and submits it through the shared
+/// writer (atomic, 204 on success).
+#[cfg(feature = "n3-patch")]
+async fn gsp_patch_n3(state: &AppState, graph: GraphRef, body: &Bytes) -> Response {
+    // Double-opt-in: the feature is compiled in, but the operator must also flip the runtime flag.
+    if !state.config().n3_patch {
+        return json_error(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            "the Solid N3-Patch (text/n3) PATCH dialect is disabled on this server; enable it with \
+             --n3-patch / SPARQ_N3_PATCH=1, or send an 'application/sparql-update' PATCH body",
+        );
+    }
+    // The base IRI relative references resolve against — the addressed named graph's IRI (or None
+    // for the default graph), exactly as the GSP RDF-body write path does (`base_iri`).
+    let base = base_iri(&graph);
+    let patch = match crate::n3_patch::parse(body, base) {
+        Ok(p) => p,
+        // [OPUS-4.8] (sq-cz89/sq-j9zs) The parse error can quote the offending body token —
+        // withhold it from the client (the operator gets the detail in the server log) via the
+        // same sanitized-error discipline the other body-parse paths use.
+        Err(e) => {
+            return sanitized_error(
+                StatusCode::BAD_REQUEST,
+                "n3-patch-parse",
+                &e.to_string(),
+                &e.detail(),
+            )
+        }
+    };
+    // Build ONE atomic SPARQL Update from the parsed formulas, graph-scoped via the exact
+    // `graph_data_block` helper the rest of the GSP write path uses (so a named-graph patch wraps
+    // each block in `GRAPH <g> { … }`, the default graph is bare).
+    let update = build_n3_patch_update(&graph, &patch);
+    // Submit through the shared writer: atomic group-commit, 204 on success, the same
+    // budget/timeout/sanitized-rejection discipline as every other update entry point.
+    run_update(state, update).await
+}
+
+/// [OPUS-4.8] (sq-hj4n) Assembles the ATOMIC, graph-scoped SPARQL Update for a parsed N3-Patch.
+///
+/// * With a `solid:where` clause → a single pattern-based `DELETE { … } INSERT { … } WHERE { … }`
+///   (one atomic modify; the empty blocks are omitted). The `WHERE` block reads the addressed
+///   graph (`GRAPH <g> { … }` for a named graph), so the variables bind against that graph only.
+/// * Without a `where` clause (ground triples) → `DELETE DATA { … } ; INSERT DATA { … }` (the
+///   DATA-form the GSP write path already uses for concrete triples), the two ops in ONE update so
+///   they commit in ONE generation. The delete runs before the insert (an N3-Patch that deletes a
+///   triple and re-inserts a changed one is then correct).
+///
+/// Each block is wrapped in `GRAPH <g> { … }` for a named graph, or left bare for the default
+/// graph — reusing [`graph_data_block`], the exact helper `gsp_put`/`gsp_post` use.
+#[cfg(feature = "n3-patch")]
+fn build_n3_patch_update(graph: &GraphRef, patch: &crate::n3_patch::N3Patch) -> String {
+    if patch.has_where {
+        // Pattern-based modify: DELETE { … } INSERT { … } WHERE { … }. Omit empty templates.
+        let mut update = String::new();
+        if !patch.deletes.is_empty() {
+            update.push_str("DELETE { ");
+            update.push_str(&graph_data_block(graph, &patch.deletes));
+            update.push_str(" }\n");
+        }
+        if !patch.inserts.is_empty() {
+            update.push_str("INSERT { ");
+            update.push_str(&graph_data_block(graph, &patch.inserts));
+            update.push_str(" }\n");
+        }
+        update.push_str("WHERE { ");
+        update.push_str(&graph_data_block(graph, &patch.conditions));
+        update.push_str(" }");
+        update
+    } else {
+        // Ground DATA-form: DELETE DATA { … } ; INSERT DATA { … } — both in one atomic update.
+        let mut ops: Vec<String> = Vec::new();
+        if !patch.deletes.is_empty() {
+            ops.push(format!(
+                "DELETE DATA {{ {} }}",
+                graph_data_block(graph, &patch.deletes)
+            ));
+        }
+        if !patch.inserts.is_empty() {
+            ops.push(format!(
+                "INSERT DATA {{ {} }}",
+                graph_data_block(graph, &patch.inserts)
+            ));
+        }
+        ops.join(" ;\n")
     }
 }
 

--- a/crates/sparq-server/src/lib.rs
+++ b/crates/sparq-server/src/lib.rs
@@ -93,6 +93,20 @@ pub mod descriptors;
 #[cfg(feature = "tpf")]
 pub mod tpf;
 
+/// [OPUS-4.8] (sq-hj4n, gh-916) OPT-IN Solid-style **N3-Patch** parsing (`text/n3`) for the
+/// Graph-Store-Protocol `PATCH` method — the `solid:InsertDeletePatch` dialect (`solid:where` /
+/// `solid:deletes` / `solid:inserts` formulas), translated into ONE atomic graph-scoped SPARQL
+/// Update. Pure (no async; the async dispatch is in [`http`]). Compiled ONLY behind the `n3-patch`
+/// feature, and served only when [`ServerConfig::n3_patch`] is also set (`--n3-patch` /
+/// `SPARQ_N3_PATCH=1`) — the same double-opt-in as [`tpf`]. The N3 parsing rides the `oxttl`
+/// `N3Parser` (already a server dependency for the GSP read-side Turtle serialiser), so it pulls
+/// NO new dependency. With the feature off this module and its dispatch arm are `#[cfg]`-stripped:
+/// a `text/n3` `PATCH` body is then a plain `415`, byte-identical to before. The OTHER `PATCH`
+/// dialect (`application/sparql-update` body) is always-on, in [`http`], and NOT behind this
+/// feature.
+#[cfg(feature = "n3-patch")]
+pub mod n3_patch;
+
 /// Prometheus metrics — hand-rolled text exposition at `GET /metrics` (T22).
 #[cfg(feature = "server")]
 pub mod metrics;

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -108,6 +108,10 @@
 //!                             endpoint `POST /shacl/validate`: POST a shapes graph, the server validates
 //!                             its loaded data graph against it. Read-only. Off by default
 //!                                                                        [off, env SPARQ_SHACL=1]
+//!   --n3-patch                [OPUS-4.8 sq-hj4n] (feature `n3-patch`) enable the OPT-IN Solid N3-Patch
+//!                             (`text/n3`) dialect on the Graph-Store-Protocol `PATCH` method. The
+//!                             always-on `application/sparql-update` PATCH dialect needs no flag.
+//!                             Off by default                            [off, env SPARQ_N3_PATCH=1]
 //!   --verbose                 per-request logging (TraceLayer)
 //!   --log-full-requests       [OPUS-4.8 sq-toze.34] OPT OUT of request-log redaction: log the
 //!                             raw request URI (incl. the full `?query=` SPARQL text) verbatim.
@@ -366,6 +370,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             // loaded data graph against it. Read-only. Off by default (env SPARQ_SHACL=1).
             #[cfg(feature = "shacl")]
             "--shacl" => config.shacl = true,
+            // [OPUS-4.8] sq-hj4n (gh-916): OPT-IN Solid N3-Patch (text/n3) PATCH dialect on the
+            // Graph-Store-Protocol graph route. The always-on application/sparql-update PATCH
+            // dialect needs no flag; this enables the OPTIONAL text/n3 one. Off by default
+            // (env SPARQ_N3_PATCH=1).
+            #[cfg(feature = "n3-patch")]
+            "--n3-patch" => config.n3_patch = true,
             // [OPUS-4.8] sq-4w18: SERVICE egress allowlist. Repeatable: each value adds one
             // host (`sparql.example.org`) or suffix wildcard (`*.example.org`). With NO
             // allowlist (the default) every SERVICE clause is refused (default-DENY-all).
@@ -415,6 +425,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     ""
                 };
+                // [OPUS-4.8] sq-hj4n: surface the OPT-IN N3-Patch PATCH dialect flag (feature n3-patch).
+                let n3_patch = if cfg!(feature = "n3-patch") {
+                    " [--n3-patch]"
+                } else {
+                    ""
+                };
                 eprintln!(
                     "usage: sparq-server [--addr HOST:PORT] [--allow-remote] [--persist DIR] \
                      [--auth-token TOKEN] [--auth-token-read] [--format FMT] \
@@ -422,7 +438,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                      [--max-body-bytes N] [--max-concurrent N] \
                      [--max-results N] [--max-query-rows N] [--max-query-bytes N] [--max-decompress-ratio N] \
                      [--max-subscriptions N] \
-                     [--max-subscriptions-per-conn N]{time_travel}{service}{brtpf}{shacl} \
+                     [--max-subscriptions-per-conn N]{time_travel}{service}{brtpf}{shacl}{n3_patch} \
                      [--cors-allow-origin ORIGIN]... [--cors-allow-origin-file PATH] [--verbose] \
                      [--log-full-requests] [DATA_FILE]\n  \
                      or: sparq-server --health-probe [--health-probe-addr HOST:PORT]\n\n  \

--- a/crates/sparq-server/src/n3_patch.rs
+++ b/crates/sparq-server/src/n3_patch.rs
@@ -1,0 +1,497 @@
+//! [OPUS-4.8] (sq-hj4n, gh-916) OPT-IN Solid-style **N3-Patch** parsing for the Graph-Store-
+//! Protocol `PATCH` method.
+//!
+//! 🤖 SPARQ agent — feature-gated capability (`n3-patch`, default OFF).
+//!
+//! This module is compiled ONLY behind the `n3-patch` cargo feature. With the feature off the
+//! whole module — and its single dispatch arm in [`crate::http`] — is `#[cfg]`-stripped, so a
+//! `text/n3` `PATCH` body is a plain `415 Unsupported Media Type` and the crate is byte-identical
+//! to before. The OTHER `PATCH` dialect (`application/sparql-update` body) is always-on and lives
+//! in [`crate::http`], NOT here.
+//!
+//! ## What an N3-Patch is
+//!
+//! The Solid Protocol's N3-Patch (`text/n3`) is an N3 document describing exactly ONE
+//! `solid:InsertDeletePatch` resource with up to three formula properties:
+//!
+//! ```text
+//! @prefix solid: <http://www.w3.org/ns/solid/terms#>.
+//! @prefix ex:    <http://example.org/>.
+//! _:patch a solid:InsertDeletePatch;
+//!   solid:where   { ?person ex:name "Jane". };
+//!   solid:deletes { ?person ex:age 12. };
+//!   solid:inserts { ?person ex:age 13. }.
+//! ```
+//!
+//! * `solid:where`   — a graph pattern that binds the variables used in the other two formulas;
+//! * `solid:deletes` — the triples to remove (may reference `where`-bound variables);
+//! * `solid:inserts` — the triples to add (may reference `where`-bound variables).
+//!
+//! Each property is OPTIONAL but at least one of `deletes` / `inserts` MUST be present, and each
+//! MUST appear at most once (Solid §N3 Patch conformance). A blank node may appear only in
+//! `inserts` (it mints a fresh node); `deletes` and `where` may not introduce blank nodes (they
+//! would be unsatisfiable / unsafe to delete), so we reject them — fail-closed.
+//!
+//! ## Translation — one ATOMIC, graph-scoped SPARQL Update
+//!
+//! We translate the parsed patch into a single SPARQL Update and submit it through the SAME
+//! sequenced group-commit writer the `application/sparql-update` PATCH path uses, so the whole
+//! delete+insert lands in ONE durable generation (atomic) — never a partial effect. The caller
+//! ([`crate::http`]) supplies the graph-scoping (`GRAPH <g> { … }` for a named graph, bare for the
+//! default graph), reusing the exact `graph_data_block` helper the GSP write path already uses.
+//!
+//! With a `where` clause the shape is `DELETE { … } INSERT { … } WHERE { … }` (one atomic
+//! pattern-based modify). Without a `where` clause (concrete triples only) the shape is
+//! `DELETE DATA { … } ; INSERT DATA { … }` — DATA-form for ground triples, matching the GSP
+//! write path's `INSERT DATA` discipline. Either way it is one writer submission.
+
+use oxrdf::GraphName;
+use oxttl::n3::{N3Parser, N3Quad, N3Term};
+use std::collections::BTreeMap;
+
+/// The Solid terms vocabulary base.
+const SOLID: &str = "http://www.w3.org/ns/solid/terms#";
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+/// A failure parsing or validating an N3-Patch body. Each maps to a client `400` in the handler
+/// (a malformed/invalid patch is the caller's error). The message is SAFE to return: it describes
+/// the structural rule that was violated, never echoing attacker-controlled term text (the
+/// underlying oxttl parse error — which CAN quote body tokens — is folded into a single generic
+/// `Parse` message; the operator gets the detail in the server log via the handler's
+/// `sanitized_error`).
+#[derive(Debug)]
+pub enum N3PatchError {
+    /// The N3 body did not parse (syntax error). Detail withheld from the client.
+    Parse(String),
+    /// No `solid:InsertDeletePatch` resource was found.
+    NoPatch,
+    /// More than one `solid:InsertDeletePatch` resource was found (the document must describe
+    /// exactly one patch).
+    MultiplePatches,
+    /// A formula property (`solid:where` / `solid:deletes` / `solid:inserts`) appeared more than
+    /// once on the patch resource.
+    DuplicateProperty(&'static str),
+    /// Neither `solid:deletes` nor `solid:inserts` was present (an empty patch is meaningless).
+    Empty,
+    /// A `solid:deletes` or `solid:where` formula introduced a blank node (only `solid:inserts`
+    /// may mint blank nodes; a blank node in a delete/where pattern is unsafe / unsatisfiable).
+    BlankNodeInPattern(&'static str),
+    /// A formula referenced by `solid:where`/`deletes`/`inserts` was not a `{ … }` block (the
+    /// object was a literal or a node that names no formula graph).
+    NotAFormula(&'static str),
+}
+
+impl std::fmt::Display for N3PatchError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // Generic — never interpolates the body's parse-error text (which can quote tokens).
+            N3PatchError::Parse(_) => write!(f, "malformed N3-Patch body"),
+            N3PatchError::NoPatch => write!(
+                f,
+                "N3-Patch body has no solid:InsertDeletePatch resource"
+            ),
+            N3PatchError::MultiplePatches => write!(
+                f,
+                "N3-Patch body must describe exactly one solid:InsertDeletePatch resource"
+            ),
+            N3PatchError::DuplicateProperty(p) => {
+                write!(f, "N3-Patch property solid:{} appears more than once", p)
+            }
+            N3PatchError::Empty => write!(
+                f,
+                "N3-Patch must have at least one of solid:deletes or solid:inserts"
+            ),
+            N3PatchError::BlankNodeInPattern(p) => write!(
+                f,
+                "N3-Patch solid:{} must not contain a blank node (only solid:inserts may)",
+                p
+            ),
+            N3PatchError::NotAFormula(p) => {
+                write!(f, "N3-Patch solid:{} must reference an {{ … }} formula", p)
+            }
+        }
+    }
+}
+
+/// The under-the-hood detail of a parse failure (for the SERVER LOG only — `sanitized_error`
+/// withholds it from the client because the oxttl error can echo body tokens). For the
+/// structural errors there is no extra detail, so the Display message is reused.
+impl N3PatchError {
+    /// The detail string the handler logs server-side (never returned to the client).
+    pub fn detail(&self) -> String {
+        match self {
+            N3PatchError::Parse(d) => d.clone(),
+            other => other.to_string(),
+        }
+    }
+}
+
+/// A parsed N3-Patch, reduced to the three SPARQL block bodies (one triple-pattern per line, in
+/// SPARQL term syntax). Empty when the corresponding formula was absent. The caller assembles
+/// these into a graph-scoped SPARQL Update (see [`crate::http`]); keeping the graph-scoping in the
+/// handler reuses the exact `graph_data_block` helper the rest of the GSP write path uses.
+pub struct N3Patch {
+    /// The `solid:deletes` triples (SPARQL term syntax, one per line, may use `where` variables).
+    pub deletes: String,
+    /// The `solid:inserts` triples (SPARQL term syntax, one per line, may use `where` variables).
+    pub inserts: String,
+    /// The `solid:where` graph pattern (SPARQL term syntax, one triple per line). Empty when no
+    /// `solid:where` was given (then the patch is a ground DATA-form modify).
+    pub conditions: String,
+    /// Whether a `solid:where` formula was present (distinguishes a ground DATA-form patch from a
+    /// pattern-based `DELETE/INSERT … WHERE`).
+    pub has_where: bool,
+}
+
+/// Parses + validates an N3-Patch body into its three SPARQL block bodies.
+///
+/// `base` is the IRI relative references in the body resolve against — the caller passes the
+/// addressed graph's IRI (or `None` for the default graph), exactly as the GSP write path does for
+/// an RDF/XML body. On any structural or syntactic violation returns an [`N3PatchError`] (the
+/// caller's `400`).
+pub fn parse(body: &[u8], base: Option<&str>) -> Result<N3Patch, N3PatchError> {
+    // oxttl's N3Parser flattens nested `{ … }` formulas into quads whose `graph_name` is a fresh
+    // blank node, and emits the top-level `?patch solid:inserts _:formula` statements in the
+    // DEFAULT graph linking to that blank node — so a single pass collects both the patch's
+    // properties and each formula's contents.
+    let mut parser = N3Parser::new();
+    if let Some(b) = base {
+        parser = parser
+            .with_base_iri(b)
+            .map_err(|e| N3PatchError::Parse(e.to_string()))?;
+    }
+    let mut quads: Vec<N3Quad> = Vec::new();
+    for q in parser.for_slice(body) {
+        quads.push(q.map_err(|e| N3PatchError::Parse(e.to_string()))?);
+    }
+
+    // 1) Find the single solid:InsertDeletePatch resource and its where/deletes/inserts formula
+    //    references. The patch resource term-prints once (blank node or IRI); we key formulas by
+    //    the printed graph-name string.
+    let mut patch_subject: Option<String> = None;
+    // property name -> formula graph-name key (the blank node that names the `{ … }` block).
+    let mut where_ref: Option<String> = None;
+    let mut deletes_ref: Option<String> = None;
+    let mut inserts_ref: Option<String> = None;
+    let mut where_seen = false;
+    let mut deletes_seen = false;
+    let mut inserts_seen = false;
+
+    for q in &quads {
+        // Patch metadata lives in the DEFAULT graph (top-level statements).
+        if q.graph_name != GraphName::DefaultGraph {
+            continue;
+        }
+        let pred = match &q.predicate {
+            N3Term::NamedNode(n) => n.as_str().to_string(),
+            _ => continue,
+        };
+        if pred == RDF_TYPE {
+            if let N3Term::NamedNode(obj) = &q.object {
+                if obj.as_str() == format!("{}InsertDeletePatch", SOLID) {
+                    let subj = term_key(&q.subject);
+                    match &patch_subject {
+                        Some(existing) if *existing != subj => {
+                            return Err(N3PatchError::MultiplePatches)
+                        }
+                        Some(_) => {}
+                        None => patch_subject = Some(subj),
+                    }
+                }
+            }
+            continue;
+        }
+        // The three formula-valued properties.
+        let prop = match pred.strip_prefix(SOLID) {
+            Some("where") => "where",
+            Some("deletes") => "deletes",
+            Some("inserts") => "inserts",
+            _ => continue,
+        };
+        let formula_key = formula_object_key(&q.object).ok_or(N3PatchError::NotAFormula(
+            match prop {
+                "where" => "where",
+                "deletes" => "deletes",
+                _ => "inserts",
+            },
+        ))?;
+        match prop {
+            "where" => {
+                if where_seen {
+                    return Err(N3PatchError::DuplicateProperty("where"));
+                }
+                where_seen = true;
+                where_ref = Some(formula_key);
+            }
+            "deletes" => {
+                if deletes_seen {
+                    return Err(N3PatchError::DuplicateProperty("deletes"));
+                }
+                deletes_seen = true;
+                deletes_ref = Some(formula_key);
+            }
+            _ => {
+                if inserts_seen {
+                    return Err(N3PatchError::DuplicateProperty("inserts"));
+                }
+                inserts_seen = true;
+                inserts_ref = Some(formula_key);
+            }
+        }
+    }
+
+    if patch_subject.is_none() {
+        return Err(N3PatchError::NoPatch);
+    }
+    if deletes_ref.is_none() && inserts_ref.is_none() {
+        return Err(N3PatchError::Empty);
+    }
+
+    // 2) Group every formula's triples by graph-name key (one pass over the non-default quads).
+    let mut formulas: BTreeMap<String, Vec<&N3Quad>> = BTreeMap::new();
+    for q in &quads {
+        if let Some(key) = graph_name_key(&q.graph_name) {
+            formulas.entry(key).or_default().push(q);
+        }
+    }
+
+    // 3) Render each referenced formula to SPARQL term-syntax lines, enforcing the blank-node
+    //    rule: `deletes` / `where` may not introduce blank nodes (only `inserts` may).
+    let conditions = match &where_ref {
+        Some(k) => render_formula(formulas.get(k), false, "where")?,
+        None => String::new(),
+    };
+    let deletes = match &deletes_ref {
+        Some(k) => render_formula(formulas.get(k), false, "deletes")?,
+        None => String::new(),
+    };
+    let inserts = match &inserts_ref {
+        Some(k) => render_formula(formulas.get(k), true, "inserts")?,
+        None => String::new(),
+    };
+
+    Ok(N3Patch {
+        deletes,
+        inserts,
+        conditions,
+        has_where: where_ref.is_some(),
+    })
+}
+
+/// Renders one formula's quads to SPARQL term-syntax triple lines (`s p o .`), one per line. When
+/// `allow_blanks` is false a blank node anywhere in the formula is a hard error (the delete/where
+/// blank-node rule). The N3-term Display is N-Triples/SPARQL term syntax, which is exactly what a
+/// SPARQL `DELETE`/`INSERT`/`WHERE` block accepts.
+fn render_formula(
+    quads: Option<&Vec<&N3Quad>>,
+    allow_blanks: bool,
+    prop: &'static str,
+) -> Result<String, N3PatchError> {
+    let mut out = String::new();
+    let empty = Vec::new();
+    for q in quads.unwrap_or(&empty) {
+        if !allow_blanks
+            && (matches!(q.subject, N3Term::BlankNode(_))
+                || matches!(q.object, N3Term::BlankNode(_)))
+        {
+            return Err(N3PatchError::BlankNodeInPattern(prop));
+        }
+        let s = render_term(&q.subject);
+        let p = render_term(&q.predicate);
+        let o = render_term(&q.object);
+        out.push_str(&s);
+        out.push(' ');
+        out.push_str(&p);
+        out.push(' ');
+        out.push_str(&o);
+        out.push_str(" .\n");
+    }
+    Ok(out)
+}
+
+/// SPARQL/N-Triples term syntax for an [`N3Term`]. oxttl/oxrdf Display already emits canonical
+/// term syntax (`<iri>`, `"lit"^^<dt>`, `"lit"@lang`, `_:b`, `?var`, RDF-star `<< … >>`), which a
+/// SPARQL block accepts verbatim — no escaping needed beyond what Display already does.
+fn render_term(t: &N3Term) -> String {
+    t.to_string()
+}
+
+/// A stable key for the patch subject (for the single-subject check). Blank nodes and IRIs print
+/// distinctly, so the printed form is a sound identity key here.
+fn term_key(t: &N3Term) -> String {
+    t.to_string()
+}
+
+/// If `object` names a formula graph (a blank node minted by oxttl for a `{ … }` block), the
+/// graph-name key. A literal / IRI object is NOT a formula → `None`.
+fn formula_object_key(object: &N3Term) -> Option<String> {
+    match object {
+        N3Term::BlankNode(b) => Some(b.to_string()),
+        _ => None,
+    }
+}
+
+/// The graph-name key for a quad's graph (the blank node oxttl assigned to a `{ … }` formula).
+/// The default graph (top-level statements) has no key.
+fn graph_name_key(g: &GraphName) -> Option<String> {
+    match g {
+        GraphName::BlankNode(b) => Some(b.to_string()),
+        // A formula could in principle be named by an IRI graph; oxttl mints blank nodes for
+        // `{ … }` blocks, so this is the live path. Handle the IRI case for completeness.
+        GraphName::NamedNode(n) => Some(n.to_string()),
+        GraphName::DefaultGraph => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_where_delete_insert() {
+        let doc = br#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+_:patch a solid:InsertDeletePatch;
+  solid:where   { ?person ex:name "Jane". };
+  solid:deletes { ?person ex:age 12. };
+  solid:inserts { ?person ex:age 13. }.
+"#;
+        let p = parse(doc, None).unwrap();
+        assert!(p.has_where);
+        assert!(p.conditions.contains("?person"));
+        assert!(p.conditions.contains("<http://ex/name>"));
+        assert!(p.deletes.contains("<http://ex/age>"));
+        assert!(p.inserts.contains("<http://ex/age>"));
+        // The integer literal round-trips as a typed literal.
+        assert!(p.deletes.contains("12"));
+        assert!(p.inserts.contains("13"));
+    }
+
+    #[test]
+    fn ground_insert_only_no_where() {
+        let doc = br#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+_:p a solid:InsertDeletePatch; solid:inserts { ex:s ex:p ex:o. }.
+"#;
+        let p = parse(doc, None).unwrap();
+        assert!(!p.has_where);
+        assert!(p.deletes.is_empty());
+        assert!(p.inserts.contains("<http://ex/s> <http://ex/p> <http://ex/o> ."));
+    }
+
+    #[test]
+    fn iri_named_patch_resolves_against_base() {
+        // `<#patch>` is relative; the base IRI must resolve it (else oxttl errors "no scheme").
+        let doc = br#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+<#patch> a solid:InsertDeletePatch; solid:inserts { ex:s ex:p ex:o. }.
+"#;
+        let p = parse(doc, Some("http://example.org/doc")).unwrap();
+        assert!(p.inserts.contains("<http://ex/s>"));
+    }
+
+    #[test]
+    fn rejects_no_patch() {
+        let doc = br#"@prefix ex: <http://ex/>.
+ex:s ex:p ex:o.
+"#;
+        assert!(matches!(parse(doc, None), Err(N3PatchError::NoPatch)));
+    }
+
+    #[test]
+    fn rejects_empty_patch() {
+        let doc = br#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+_:p a solid:InsertDeletePatch.
+"#;
+        assert!(matches!(parse(doc, None), Err(N3PatchError::Empty)));
+    }
+
+    #[test]
+    fn rejects_duplicate_inserts() {
+        let doc = br#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+_:p a solid:InsertDeletePatch;
+  solid:inserts { ex:s ex:p ex:o. };
+  solid:inserts { ex:s ex:p ex:o2. }.
+"#;
+        assert!(matches!(
+            parse(doc, None),
+            Err(N3PatchError::DuplicateProperty("inserts"))
+        ));
+    }
+
+    #[test]
+    fn rejects_blank_node_in_deletes() {
+        let doc = br#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+_:p a solid:InsertDeletePatch;
+  solid:deletes { [ ex:p ex:o ]. }.
+"#;
+        assert!(matches!(
+            parse(doc, None),
+            Err(N3PatchError::BlankNodeInPattern("deletes"))
+        ));
+    }
+
+    #[test]
+    fn allows_blank_node_in_inserts() {
+        let doc = br#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+_:p a solid:InsertDeletePatch;
+  solid:inserts { ex:s ex:p [ ex:q ex:r ]. }.
+"#;
+        let p = parse(doc, None).unwrap();
+        assert!(p.inserts.contains("<http://ex/q>"));
+    }
+
+    #[test]
+    fn rejects_two_patch_resources() {
+        let doc = br#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+ex:p1 a solid:InsertDeletePatch; solid:inserts { ex:s ex:p ex:o. }.
+ex:p2 a solid:InsertDeletePatch; solid:inserts { ex:s ex:p ex:o2. }.
+"#;
+        assert!(matches!(
+            parse(doc, None),
+            Err(N3PatchError::MultiplePatches)
+        ));
+    }
+
+    /// Load-bearing INJECTION-SAFETY invariant: a literal whose lexical form contains the
+    /// characters that would break out of a generated SPARQL block (`"`, newline, `}`) is escaped
+    /// by the oxttl term Display, so the rendered triple line cannot inject a second clause. We
+    /// assert the raw `}` / unescaped newline do NOT appear bare in the rendered insert.
+    #[test]
+    fn literal_with_break_chars_is_escaped() {
+        let doc = "@prefix solid: <http://www.w3.org/ns/solid/terms#>.\n\
+@prefix ex: <http://ex/>.\n\
+_:p a solid:InsertDeletePatch;\n\
+  solid:inserts { ex:s ex:p \"evil}\\n} INSERT DATA { ex:x ex:y ex:z } #\" . }.\n";
+        let p = parse(doc.as_bytes(), None).unwrap();
+        // The malicious payload is INSIDE a single escaped literal, so a bare `}` that would close
+        // the INSERT block early is not present as an unescaped delimiter, and the injected
+        // `INSERT DATA` is part of the literal lexical, not a second operation.
+        assert!(p.inserts.contains("<http://ex/s>"));
+        // The dangerous `}` and newline survive only in escaped form (`\}` is not a thing; oxttl
+        // escapes `}`-in-literal as a literal char inside the quotes, and the newline as `\n`).
+        assert!(
+            p.inserts.contains("\\n"),
+            "newline in literal must be escaped: {}",
+            p.inserts
+        );
+        // The whole insert is exactly ONE triple line (one trailing " .\n"), not two.
+        assert_eq!(
+            p.inserts.matches(" .\n").count(),
+            1,
+            "must render exactly one triple: {}",
+            p.inserts
+        );
+    }
+
+    #[test]
+    fn rejects_malformed_n3() {
+        let doc = br#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+_:p a solid:InsertDeletePatch; solid:inserts { this is not n3 "#;
+        assert!(matches!(parse(doc, None), Err(N3PatchError::Parse(_))));
+    }
+}

--- a/crates/sparq-server/tests/gsp_patch.rs
+++ b/crates/sparq-server/tests/gsp_patch.rs
@@ -1,0 +1,440 @@
+//! [OPUS-4.8] (sq-hj4n, gh-916) Integration tests for the Graph-Store-Protocol `PATCH` method —
+//! 🤖 SPARQ agent.
+//!
+//! Two dialects:
+//!   * `application/sparql-update` — ALWAYS-ON (no feature). These tests run in BOTH feature
+//!     states and assert the patch is atomic + scoped to the addressed graph.
+//!   * `text/n3` (Solid N3-Patch) — OPT-IN behind the `n3-patch` cargo feature AND the `--n3-patch`
+//!     runtime flag. The N3-Patch tests are `#[cfg(feature = "n3-patch")]`; a `#[cfg(not(...))]`
+//!     test asserts the feature-OFF behaviour (a `text/n3` PATCH body is a plain `415`).
+//!
+//! The server runs on an ephemeral port in-process and is driven over real HTTP with `reqwest`.
+
+use sparq_core::Graph;
+use sparq_server::{router, AppState, ServerConfig};
+use tokio::net::TcpListener;
+
+const DATA: &str = r#"
+    @prefix ex: <http://ex/> .
+    ex:alice ex:age 30 ; ex:name "Alice" .
+    ex:bob   ex:age 25 .
+"#;
+
+/// Boots a server with the given config and returns its base URL.
+async fn spawn_with(config: ServerConfig) -> String {
+    let graph = Graph::load_str(DATA, "turtle").unwrap();
+    let app = router(AppState::with_config(graph, config));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// Boots a default server (no opt-in flags).
+async fn spawn() -> String {
+    spawn_with(ServerConfig::default()).await
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+/// Convenience: run a SELECT and return the JSON body text.
+async fn select(base: &str, q: &str) -> String {
+    client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", q)])
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap()
+}
+
+// ---------------------------------------------------------------------------
+// Allow header + method posture
+// ---------------------------------------------------------------------------
+
+/// An unsupported method on a graph resource is `405` and its `Allow` header now advertises PATCH.
+#[tokio::test]
+async fn unsupported_method_allow_lists_patch() {
+    let base = spawn().await;
+    // OPTIONS is not a GSP method, so the dispatcher answers 405 with the Allow set.
+    let resp = client()
+        .request(
+            reqwest::Method::OPTIONS,
+            format!("{base}/sparql/graph?default"),
+        )
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 405);
+    let allow = resp.headers()["allow"].to_str().unwrap().to_string();
+    assert!(allow.contains("PATCH"), "Allow header must list PATCH: {allow}");
+    assert!(allow.contains("PUT") && allow.contains("DELETE"));
+}
+
+// ---------------------------------------------------------------------------
+// ALWAYS-ON dialect: application/sparql-update PATCH (runs in BOTH feature states)
+// ---------------------------------------------------------------------------
+
+/// A SPARQL-Update PATCH body modifies the addressed default graph in place: delete one triple,
+/// insert another, in ONE atomic update → 204.
+#[tokio::test]
+async fn sparql_update_patch_default_graph_atomic() {
+    let base = spawn().await;
+    let body = "DELETE DATA { <http://ex/alice> <http://ex/age> 30 } ; \
+                INSERT DATA { <http://ex/alice> <http://ex/age> 31 }";
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?default"))
+        .header("content-type", "application/sparql-update")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+    // The old triple is gone, the new one present (atomic delete+insert applied).
+    let got = select(
+        &base,
+        "SELECT ?a WHERE { <http://ex/alice> <http://ex/age> ?a }",
+    )
+    .await;
+    assert!(got.contains("31"), "age must be updated to 31: {got}");
+    assert!(!got.contains("\"30\""), "old age 30 must be gone: {got}");
+}
+
+/// A SPARQL-Update PATCH on a NAMED graph is scoped to that graph: the WHERE dataset defaults to
+/// the addressed graph, and an `INSERT { GRAPH <g> { … } }` writes into it.
+#[tokio::test]
+async fn sparql_update_patch_named_graph_scoped() {
+    let base = spawn().await;
+    let g = "http://ex/g1";
+    // Seed the named graph via GSP PUT.
+    let put = client()
+        .put(format!("{base}/sparql/graph?graph={g}"))
+        .header("content-type", "text/turtle")
+        .body("<http://ex/s> <http://ex/p> <http://ex/o> .")
+        .send()
+        .await
+        .unwrap();
+    assert!(put.status().is_success());
+    // PATCH the named graph: delete the seeded triple, insert a new one (explicit GRAPH targets).
+    let body = format!(
+        "DELETE DATA {{ GRAPH <{g}> {{ <http://ex/s> <http://ex/p> <http://ex/o> }} }} ; \
+         INSERT DATA {{ GRAPH <{g}> {{ <http://ex/s> <http://ex/p2> <http://ex/o2> }} }}"
+    );
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?graph={g}"))
+        .header("content-type", "application/sparql-update")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+    // The named graph now holds only the new triple.
+    let got = select(
+        &base,
+        &format!("SELECT ?p WHERE {{ GRAPH <{g}> {{ <http://ex/s> ?p ?o }} }}"),
+    )
+    .await;
+    assert!(got.contains("p2"), "named-graph PATCH must apply: {got}");
+    assert!(!got.contains("\"p\"") || got.contains("p2"));
+}
+
+/// A SPARQL-Update PATCH with a WHERE template scoped to the named graph: the override defaults the
+/// WHERE dataset to the addressed graph, so variables bind against THAT graph.
+#[tokio::test]
+async fn sparql_update_patch_named_graph_where_dataset_scoped() {
+    let base = spawn().await;
+    let g = "http://ex/gscope";
+    // Seed graph g with one triple.
+    client()
+        .put(format!("{base}/sparql/graph?graph={g}"))
+        .header("content-type", "text/turtle")
+        .body("<http://ex/x> <http://ex/k> \"v\" .")
+        .send()
+        .await
+        .unwrap();
+    // PATCH: DELETE { GRAPH g { ?s ?p ?o } } WHERE { ?s ?p ?o } — WHERE reads the addressed graph
+    // (the using-graph-uri override), so it matches the seeded triple and removes it.
+    let body = format!(
+        "DELETE {{ GRAPH <{g}> {{ ?s ?p ?o }} }} WHERE {{ ?s ?p ?o }}"
+    );
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?graph={g}"))
+        .header("content-type", "application/sparql-update")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+    let got = select(
+        &base,
+        &format!("SELECT ?s WHERE {{ GRAPH <{g}> {{ ?s ?p ?o }} }}"),
+    )
+    .await;
+    assert!(
+        !got.contains("http://ex/x"),
+        "WHERE-scoped delete must empty the graph: {got}"
+    );
+}
+
+/// A malformed SPARQL-Update PATCH body is a 400 (and does not echo the body token verbatim).
+#[tokio::test]
+async fn sparql_update_patch_malformed_is_400() {
+    let base = spawn().await;
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?default"))
+        .header("content-type", "application/sparql-update")
+        .body("DELETE DATA { this is not sparql")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+/// Supplying the named-graph PATCH alongside an in-body WITH/USING is the §2.2 conflict → 400.
+#[tokio::test]
+async fn sparql_update_patch_named_with_in_body_using_conflicts() {
+    let base = spawn().await;
+    let g = "http://ex/gc";
+    let body = format!(
+        "WITH <{g}> DELETE {{ ?s ?p ?o }} USING <{g}> WHERE {{ ?s ?p ?o }}"
+    );
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?graph={g}"))
+        .header("content-type", "application/sparql-update")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    // The using-graph-uri override (from the named-graph scoping) conflicts with the in-body
+    // USING/WITH → 400 (SPARQL 1.1 Protocol §2.2).
+    assert_eq!(resp.status(), 400);
+}
+
+/// An unsupported PATCH body Content-Type is a 415.
+#[tokio::test]
+async fn patch_unsupported_content_type_is_415() {
+    let base = spawn().await;
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?default"))
+        .header("content-type", "application/json")
+        .body("{}")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 415);
+}
+
+// ---------------------------------------------------------------------------
+// FEATURE-OFF: a text/n3 PATCH body is a plain 415 (byte-identical posture)
+// ---------------------------------------------------------------------------
+
+/// With the `n3-patch` feature COMPILED OUT, a `text/n3` PATCH body is an unsupported media type
+/// (`415`) — the N3-Patch dialect does not exist in the build, and the 415 message names only the
+/// always-on dialect.
+#[cfg(not(feature = "n3-patch"))]
+#[tokio::test]
+async fn n3_patch_body_is_415_without_feature() {
+    let base = spawn().await;
+    let body = r#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+_:p a solid:InsertDeletePatch; solid:inserts { ex:s ex:p ex:o. }."#;
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?default"))
+        .header("content-type", "text/n3")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 415);
+    let msg = resp.text().await.unwrap();
+    // The feature-off message must NOT advertise text/n3 (the build cannot serve it).
+    assert!(
+        !msg.contains("text/n3"),
+        "feature-off 415 must not advertise text/n3: {msg}"
+    );
+    // The always-on dialect IS named.
+    assert!(msg.contains("application/sparql-update"));
+}
+
+// ---------------------------------------------------------------------------
+// FEATURE-ON: Solid N3-Patch (text/n3) — double-opt-in + atomic graph-scoped apply
+// ---------------------------------------------------------------------------
+
+/// With the feature ON but the runtime flag OFF, a `text/n3` PATCH body is still `415` (the
+/// double-opt-in posture mirroring tpf/shacl).
+#[cfg(feature = "n3-patch")]
+#[tokio::test]
+async fn n3_patch_415_when_flag_off() {
+    // Feature compiled in, but ServerConfig::n3_patch defaults to false.
+    let base = spawn().await;
+    let body = r#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+_:p a solid:InsertDeletePatch; solid:inserts { ex:s ex:p ex:o. }."#;
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?default"))
+        .header("content-type", "text/n3")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 415);
+}
+
+/// With the feature ON and the flag ON, a ground N3-Patch (inserts only) applies to the default
+/// graph atomically → 204.
+#[cfg(feature = "n3-patch")]
+#[tokio::test]
+async fn n3_patch_ground_insert_default_graph() {
+    let base = spawn_with(ServerConfig {
+        n3_patch: true,
+        ..ServerConfig::default()
+    })
+    .await;
+    let body = r#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+_:p a solid:InsertDeletePatch;
+  solid:inserts { <http://ex/carol> <http://ex/age> 40 . }."#;
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?default"))
+        .header("content-type", "text/n3")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+    let got = select(
+        &base,
+        "SELECT ?a WHERE { <http://ex/carol> <http://ex/age> ?a }",
+    )
+    .await;
+    assert!(got.contains("40"), "N3-Patch insert must apply: {got}");
+}
+
+/// A pattern-based N3-Patch with a `solid:where` clause: bind ?p by name, delete the old age and
+/// insert a new one — in ONE atomic update → 204. The load-bearing invariant: the delete and
+/// insert are atomic (the read after sees BOTH effects, never a partial state).
+#[cfg(feature = "n3-patch")]
+#[tokio::test]
+async fn n3_patch_where_delete_insert_atomic() {
+    let base = spawn_with(ServerConfig {
+        n3_patch: true,
+        ..ServerConfig::default()
+    })
+    .await;
+    // alice has age 30 + name "Alice"; bind ?p via name, change her age 30 -> 31.
+    let body = r#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+_:patch a solid:InsertDeletePatch;
+  solid:where   { ?p <http://ex/name> "Alice" . };
+  solid:deletes { ?p <http://ex/age> 30 . };
+  solid:inserts { ?p <http://ex/age> 31 . }."#;
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?default"))
+        .header("content-type", "text/n3")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+    let got = select(
+        &base,
+        "SELECT ?a WHERE { <http://ex/alice> <http://ex/age> ?a }",
+    )
+    .await;
+    assert!(got.contains("31"), "patched age must be 31: {got}");
+    assert!(!got.contains("\"30\""), "old age 30 must be gone: {got}");
+    // bob is untouched (the WHERE bound only alice).
+    let bob = select(
+        &base,
+        "SELECT ?a WHERE { <http://ex/bob> <http://ex/age> ?a }",
+    )
+    .await;
+    assert!(bob.contains("25"), "bob must be untouched: {bob}");
+}
+
+/// An N3-Patch on a NAMED graph is graph-scoped: every block is wrapped in `GRAPH <g> { … }`, so
+/// the patch only touches that graph and is invisible to the default graph.
+#[cfg(feature = "n3-patch")]
+#[tokio::test]
+async fn n3_patch_named_graph_scoped() {
+    let base = spawn_with(ServerConfig {
+        n3_patch: true,
+        ..ServerConfig::default()
+    })
+    .await;
+    let g = "http://ex/n3g";
+    let body = r#"@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+_:p a solid:InsertDeletePatch;
+  solid:inserts { <http://ex/s> <http://ex/p> <http://ex/o> . }."#;
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?graph={g}"))
+        .header("content-type", "text/n3")
+        .body(body)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 204);
+    // The triple is in graph g...
+    let in_g = select(
+        &base,
+        &format!("SELECT ?o WHERE {{ GRAPH <{g}> {{ <http://ex/s> <http://ex/p> ?o }} }}"),
+    )
+    .await;
+    assert!(in_g.contains("http://ex/o"), "must be in named graph: {in_g}");
+    // ...and NOT in the default graph (scoping held).
+    let in_default = select(
+        &base,
+        "SELECT ?o WHERE { <http://ex/s> <http://ex/p> ?o }",
+    )
+    .await;
+    assert!(
+        !in_default.contains("http://ex/o"),
+        "named-graph PATCH must not leak into the default graph: {in_default}"
+    );
+}
+
+/// A malformed N3-Patch body (feature on, flag on) is a 400 — and the response does not echo the
+/// offending body token verbatim (sanitized).
+#[cfg(feature = "n3-patch")]
+#[tokio::test]
+async fn n3_patch_malformed_is_400() {
+    let base = spawn_with(ServerConfig {
+        n3_patch: true,
+        ..ServerConfig::default()
+    })
+    .await;
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?default"))
+        .header("content-type", "text/n3")
+        .body("@prefix solid: <http://www.w3.org/ns/solid/terms#>. _:p a solid:InsertDeletePatch; solid:inserts { not valid n3 ")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+/// An N3-Patch with no `solid:InsertDeletePatch` resource is a 400 (structural validation).
+#[cfg(feature = "n3-patch")]
+#[tokio::test]
+async fn n3_patch_no_patch_resource_is_400() {
+    let base = spawn_with(ServerConfig {
+        n3_patch: true,
+        ..ServerConfig::default()
+    })
+    .await;
+    let resp = client()
+        .patch(format!("{base}/sparql/graph?default"))
+        .header("content-type", "text/n3")
+        .body("@prefix ex: <http://ex/>. ex:s ex:p ex:o .")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}

--- a/crates/sparq-server/tests/protocol.rs
+++ b/crates/sparq-server/tests/protocol.rs
@@ -710,17 +710,41 @@ async fn gsp_post_no_selector_creates_fresh_graph() {
         "fresh-graph triple not queryable: {q}");
 }
 
-/// An unsupported method on a graph resource is a 405 with an Allow header listing the
-/// supported GSP verbs.
+/// An unsupported method (not GET/HEAD/PUT/POST/DELETE/PATCH) on a graph resource is a 405 with an
+/// Allow header listing the supported GSP verbs — now INCLUDING PATCH ([OPUS-4.8] sq-hj4n, gh-916:
+/// PATCH is a real GSP method, not a 405). The full PATCH behaviour is exercised in
+/// `tests/gsp_patch.rs`.
 #[tokio::test]
-async fn gsp_patch_is_405_with_allow() {
+async fn gsp_unsupported_method_is_405_with_allow() {
     let base = spawn().await;
     let resp = client()
-        .request(reqwest::Method::PATCH, format!("{base}/sparql/graph?default"))
+        .request(reqwest::Method::OPTIONS, format!("{base}/sparql/graph?default"))
         .send().await.unwrap();
     assert_eq!(resp.status(), 405);
     let allow = resp.headers()["allow"].to_str().unwrap();
-    assert!(allow.contains("PUT") && allow.contains("POST") && allow.contains("DELETE") && allow.contains("GET"));
+    assert!(
+        allow.contains("PUT")
+            && allow.contains("POST")
+            && allow.contains("DELETE")
+            && allow.contains("GET")
+            && allow.contains("PATCH"),
+        "Allow must list all GSP verbs incl PATCH: {allow}"
+    );
+}
+
+/// [OPUS-4.8] (sq-hj4n, gh-916) A PATCH on a graph resource is NO LONGER a 405 — it is a real GSP
+/// method. A PATCH with no recognised body Content-Type is a 415 (the PATCH route was reached and
+/// classified the body), proving PATCH is handled rather than method-not-allowed.
+#[tokio::test]
+async fn gsp_patch_is_handled_not_405() {
+    let base = spawn().await;
+    let resp = client()
+        .request(reqwest::Method::PATCH, format!("{base}/sparql/graph?default"))
+        .body("anything")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 415, "PATCH is handled (415 unsupported body), not 405");
 }
 
 #[tokio::test]

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: http-server
-description: Run or point an agent at a sparq SPARQL 1.1 Protocol HTTP endpoint (sparq-server) — /sparql query+update over GET/POST, content negotiation (SELECT/ASK JSON/XML/CSV/TSV; CONSTRUCT/DESCRIBE + Graph Store N-Triples/prefix-Turtle/RDF-XML), Graph Store read AND write (PUT/POST/DELETE on graph resources, RDF/XML bodies accepted), EXPLAIN, Prometheus /metrics, WebSocket + SSE subscriptions, and opt-in time-travel ?generation pinning. Use when starting the server, querying/updating a running endpoint, choosing Accept/Content-Type, or embedding the axum router.
+description: Run or point an agent at a sparq SPARQL 1.1 Protocol HTTP endpoint (sparq-server) — /sparql query+update over GET/POST, content negotiation (SELECT/ASK JSON/XML/CSV/TSV; CONSTRUCT/DESCRIBE + Graph Store N-Triples/prefix-Turtle/RDF-XML), Graph Store read AND write (PUT/POST/DELETE/PATCH on graph resources, RDF/XML bodies accepted, atomic SPARQL-Update + opt-in Solid N3-Patch on PATCH), EXPLAIN, Prometheus /metrics, WebSocket + SSE subscriptions, and opt-in time-travel ?generation pinning. Use when starting the server, querying/updating a running endpoint, choosing Accept/Content-Type, or embedding the axum router.
 ---
 
 # sparq-http-server
@@ -332,6 +332,23 @@ curl -X POST 'http://127.0.0.1:3030/sparql/graph?graph=http://ex/g' \
 # DELETE = DROP the graph (204; 404 if a named graph is absent; ?default → CLEAR DEFAULT, always 204):
 curl -X DELETE 'http://127.0.0.1:3030/sparql/graph?graph=http://ex/g'
 
+# PATCH = atomic, graph-scoped in-place MODIFY (sq-hj4n; 204 on success). Two body dialects:
+#   1) application/sparql-update (ALWAYS-ON) — the body IS a SPARQL Update, applied atomically
+#      through the same writer, with its WHERE dataset scoped to the addressed graph:
+curl -X PATCH 'http://127.0.0.1:3030/sparql/graph?graph=http://ex/g' \
+     -H 'content-type: application/sparql-update' \
+     --data 'DELETE DATA { GRAPH <http://ex/g> { <http://ex/s> <http://ex/p> <http://ex/o> } } ;
+             INSERT DATA { GRAPH <http://ex/g> { <http://ex/s> <http://ex/p> <http://ex/o2> } }'
+#   2) text/n3 (Solid N3-Patch, OPT-IN: needs the `n3-patch` build feature AND --n3-patch / SPARQ_N3_PATCH=1;
+#      else 415). A solid:InsertDeletePatch translated into ONE atomic graph-scoped DELETE/INSERT … WHERE:
+curl -X PATCH 'http://127.0.0.1:3030/sparql/graph?default' \
+     -H 'content-type: text/n3' --data '@prefix solid: <http://www.w3.org/ns/solid/terms#>.
+@prefix ex: <http://ex/>.
+_:p a solid:InsertDeletePatch;
+  solid:where   { ?s ex:name "Alice" . };
+  solid:deletes { ?s ex:age 30 . };
+  solid:inserts { ?s ex:age 31 . }.'
+
 curl http://127.0.0.1:3030/health                               # -> "ok"
 curl http://127.0.0.1:3030/metrics                              # Prometheus text exposition (gated by --auth-token-read; sq-9jrx)
 
@@ -377,8 +394,34 @@ DATA`) and submit through the SAME sequenced group-commit writer the
 `application/sparql-update` operation uses — so they share its atomicity, snapshot
 consistency, blocking-on-commit semantics, the `Sparq-Generation` header (time-travel
 feature), AND its **auth gate** (a GSP write is as powerful as an UPDATE, so `PUT`/`POST`/
-`DELETE` are gated by `--auth-token` exactly like an UPDATE; `GET`/`HEAD` are reads). A
+`DELETE`/`PATCH` are gated by `--auth-token` exactly like an UPDATE; `GET`/`HEAD` are reads). A
 malformed body → `400`; an unsupported body Content-Type → `415`.
+
+**`PATCH` — atomic, graph-scoped in-place modify (`sq-hj4n`, gh-916).** A `PATCH` on a graph
+resource applies an atomic modify to the addressed graph, with two body dialects:
+
+- **`application/sparql-update` (ALWAYS-ON, no feature):** the body IS a SPARQL Update, applied
+  atomically through the shared writer. It is **scoped** to the addressed graph by defaulting the
+  update's WHERE dataset to that graph (the SPARQL 1.1 Protocol §2.2 `using-graph-uri` mechanism).
+  **Honest scope:** this scopes what the WHERE *reads*; an operation that explicitly names a
+  *different* graph (`INSERT DATA { GRAPH <other> { … } }`, or an in-body `WITH`/`USING`) still
+  targets where it says — and supplying the override alongside an in-body `USING`/`WITH` on a
+  *named*-graph PATCH is the §2.2 conflict `400`. For `?default` the scoping is a no-op (the default
+  graph is already the WHERE default). Success → `204`.
+- **`text/n3` (OPT-IN — the `n3-patch` build feature AND `--n3-patch` / `SPARQ_N3_PATCH=1`):** a
+  Solid-style **N3-Patch** (`solid:InsertDeletePatch` with `solid:where` / `solid:deletes` /
+  `solid:inserts` formulas), translated into ONE atomic graph-scoped SPARQL Update (every block
+  wrapped in `GRAPH <g> { … }` for a named graph). With a `solid:where` it is a pattern-based
+  `DELETE/INSERT … WHERE`; without one it is ground `DELETE DATA`/`INSERT DATA` — either way one
+  writer submission. Validation: exactly one patch resource, each formula property at most once, at
+  least one of `deletes`/`inserts`, and no blank node in `deletes`/`where` (only `inserts` may mint
+  one) → otherwise `400`. **Double opt-in** (build feature + runtime flag) mirrors `tpf`/`shacl`:
+  with the feature **off** the N3-Patch parser + dispatch are `#[cfg]`-stripped (a `text/n3` body is
+  then a plain `415`, byte-identical to before, and no new dependency / no `sparq-core` /
+  `sparq-engine` / wasm impact); with the feature **on** but the flag **off** a `text/n3` body is
+  also `415`. The N3 parsing rides `oxttl`'s `N3Parser` — already a server dependency — so even
+  feature-on adds NO new crate. Success → `204`. `PATCH` is a WRITE, gated by `--auth-token` like an
+  UPDATE.
 
 **5b. Container (ghcr.io).** Published on every release tag (`ghcr.io/jeswr/sparq-server`,
 distroless). The image sets `SPARQ_ALLOW_REMOTE=1` so the `0.0.0.0` bind it needs (loopback


### PR DESCRIPTION
> 🤖 SPARQ agent — this PR was prepared by an automated SPARQ agent (Opus 4.8, 1M context) on @jeswr's behalf. @jeswr runs multiple agents on one account.

Implements **sq-hj4n** (gh-916, maintainer-greenlit): HTTP **PATCH** on the existing Graph-Store-Protocol graph route in `crates/sparq-server/src/http.rs`, replacing the hard `405` in `graph_store()` with a real, atomic, graph-scoped in-place modify.

## What changed

Two PATCH body dialects, classified by `Content-Type`:

- **`application/sparql-update` — ALWAYS-ON** (no feature, no new dependency). The body IS a SPARQL Update, applied **atomically** through the SAME sequenced group-commit writer the `/sparql` `application/sparql-update` path uses (so the whole multi-operation body lands in ONE durable generation). It is **scoped** to the addressed graph by defaulting the update's WHERE dataset to that graph via the in-tree SPARQL 1.1 Protocol §2.2 `using-graph-uri` rewrite (`rewrite_update`). *Honest scope:* this scopes what the WHERE reads; an operation that explicitly names a different graph (`GRAPH <other>` / in-body `WITH`/`USING`) targets where it says, and an in-body `USING`/`WITH` on a named-graph PATCH is the §2.2 conflict `400`. For `?default` the override is a no-op. Success → `204`.
- **`text/n3` (Solid N3-Patch) — OPT-IN.** A `solid:InsertDeletePatch` (with `solid:where`/`solid:deletes`/`solid:inserts` formulas) parsed and translated into ONE atomic graph-scoped SPARQL Update (`DELETE/INSERT … WHERE` with a `where` clause, else ground `DELETE DATA`/`INSERT DATA`). Gated behind a **NEW default-OFF `n3-patch` cargo feature** AND a `--n3-patch` / `SPARQ_N3_PATCH=1` runtime flag (double opt-in, mirroring `tpf`/`shacl`/`federation-descriptors`).

Also: `PATCH` added to the `Allow` header + `method_not_allowed` list; new `crates/sparq-server/src/n3_patch.rs` (parse + validate + SPARQL build); `--n3-patch` CLI flag + `--help` + module usage doc; README + `skills/http-server/SKILL.md`.

## How N3-Patch is fully compiled out when off

- `n3-patch = ["server"]` — the only thing it implies is the already-present `server`. The N3 parsing rides `oxttl`'s `N3Parser`, **already a `sparq-server` dependency** (GSP read-side Turtle serialiser), so **no new crate** is pulled — `Cargo.lock` is unchanged.
- With the feature OFF: `pub mod n3_patch`, the `ServerConfig::n3_patch` field + its default + env parse, the `"text/n3" =>` dispatch arm, and `gsp_patch_n3`/`build_n3_patch_update` are all `#[cfg(feature = "n3-patch")]`-stripped. A `text/n3` PATCH body is then a plain `415` whose message names only the always-on dialect. The N3-Patch surface is byte-identical to before.
- `sparq-wasm` has **zero** dependency on `sparq-server` (verified `cargo tree -p sparq-wasm | grep -c sparq-server` = 0), so `sparq-core`/`sparq-engine`/the wasm bundle are untouched either way.

## Gates — GREEN in BOTH feature states

| Gate | default (feature OFF) | `--features n3-patch` (ON) |
| --- | --- | --- |
| `cargo build -p sparq-server` (+ `--bin`) | ✅ | ✅ |
| `cargo clippy -p sparq-server --all-targets -- -D warnings` | ✅ | ✅ |
| `cargo test -p sparq-server` | ✅ all green | ✅ all green |

Tests (`tests/gsp_patch.rs` + `n3_patch` unit tests + an updated `protocol.rs` PATCH test):
- **SPARQL-Update PATCH (always-on, runs in both states):** atomic delete+insert on the default graph; named-graph scoped (explicit `GRAPH` targets + WHERE-dataset scoping); §2.2 `USING`/`WITH` conflict `400`; malformed `400`; unsupported content-type `415`.
- **N3-Patch (feature-on):** ground insert, `where`/delete/insert atomic (with a neighbour-untouched assertion), named-graph scoping (no leak into the default graph), double-opt-in `415` when the flag is off, malformed `400`, no-patch-resource `400`, plus 11 `n3_patch` unit tests incl. the **literal-escaping injection-safety** invariant.
- **Feature-off posture:** a `text/n3` PATCH body → `415` whose message does not advertise `text/n3`.

Single-writer hot crate — the diff is scoped to the PATCH route + the new module + docs/tests. Auto-merge intentionally **OFF**.

Closes #916.