### PR TITLE
feat(sparq-serve): response-bytes result cache over PodEpochs (visibility-scope keyed, single-flight, off by default) (sq-jluc)

### DIFF
--- a/crates/sparq-serve/Cargo.toml
+++ b/crates/sparq-serve/Cargo.toml
@@ -44,3 +44,13 @@ sparq-engine = { path = "../sparq-engine", version = "0.1.0" }
 # SPARQL Update text (`Footprint::of_sparql`). Workspace-patched to the vendored
 # W3C-conformance fork, same as the engine — both parsers must agree on syntax.
 spargebra.workspace = true
+
+[features]
+# [OPUS-4.8] sq-jluc: the response-bytes result cache (research/concurrent-serving.md
+# §5 row 2 + §6.3) — OPT-IN and OFF by default. It is a LEAN feature: it adds NO new
+# dependency (the cache key/map reuse the in-tree `rustc-hash` and `std::hash`; the
+# values are `Arc<[u8]>` response bodies) and pulls in neither HTTP nor async machinery
+# (library-first §6.1: the cache stores opaque bytes + a caller-derived visibility-scope
+# key and never depends on `sparq-solid`). The default build carries zero cache code.
+default = []
+result-cache = []

--- a/crates/sparq-serve/README.md
+++ b/crates/sparq-serve/README.md
@@ -49,6 +49,40 @@ cargo run -p sparq-server -- --format turtle data.ttl
   one new immutable generation; serialisability is by construction.
 - **Sync, runtime-agnostic, library-first** — no HTTP or async-runtime types;
   consumers wrap it. It must never enter `sparq-wasm`'s dependency graph.
+- **Response-bytes result cache** *(opt-in: `--features result-cache`, OFF by
+  default)* — see below.
+
+## 🗃️ Result cache (opt-in, `result-cache` feature)
+
+A serving-layer cache from a request *identity* to the complete pre-serialized
+response body, so a repeated read returns bytes in tens of nanoseconds instead of
+re-executing. **OFF by default**; the default build carries zero cache code and no
+extra dependency.
+
+- **Key = (canonical-query × visibility-scope × per-pod epoch-vector)** (design
+  §6.3). The query is cheaply canonicalized (whitespace, and opt-in variable
+  renaming). The **visibility scope** is the identity of the *accessible graph set*
+  a request runs under — derive a `ScopeKey` from
+  `sparq_solid::AuthIndex::accessible(session, mode)`, **never** from the WebID
+  (the Hasura lesson). Many WebIDs that share one public-read scope collapse to one
+  key.
+- **Access-control isolation is correctness, not privacy.** Bytes cached for one
+  scope can never be served to a different scope (a different scope MUST miss —
+  tested). This enforces the access-control boundary the auth layer defines; it is
+  **not itself a confidentiality/privacy guarantee** (no cryptographic claim; it
+  trusts a faithfully-derived scope key).
+- **Invalidation = per-pod (per-named-graph) epoch bumps.** Each entry records the
+  epoch of the graphs its query touched; a write to any of them makes it stale.
+  Queries with an unbounded read footprint pin the global generation (invalidated
+  by any write).
+- **Single-flight leases** collapse a stampede on a hot uncached key into one
+  execution + N waiters. **Byte-budget LRU + admission**: oversize/streaming bodies
+  are never cached.
+
+The cache stores opaque `Arc<[u8]>` bodies and a caller-derived `ScopeKey`; it never
+depends on `sparq-solid` and never parses a query. It is a **different layer** from
+`sparq-engine`'s embedded `result-cache` (the in-engine algebra-keyed LRU). Perf
+targets (design §6.3) require a canonical host and are validated there, not in-tree.
 
 ## 📚 Learn more
 

--- a/crates/sparq-serve/src/cache.rs
+++ b/crates/sparq-serve/src/cache.rs
@@ -14,7 +14,7 @@
 //!
 //! # The key: `(canonical-query, visibility-scope, epoch-vector)` — §6.3
 //!
-//! - **Canonical-query** ([`canon`](crate::canon)): cheap whitespace (and opt-in
+//! - **Canonical-query** ([`canonicalize`](crate::canonicalize)): cheap whitespace (and opt-in
 //!   variable) normalization, hashed. So `SELECT ?x WHERE{…}` and the same query
 //!   reindented share an entry.
 //! - **Visibility-scope** ([`ScopeKey`]): the identity of the *accessible graph
@@ -54,9 +54,9 @@
 //! On a miss the first caller takes a **lease** for the key; concurrent callers for
 //! the same key **wait** on that lease rather than each re-executing (a stampede
 //! becomes one execution, N waiters). [`ResultCache::lease`] returns either
-//! [`Lease::Hit`] (bytes already cached and fresh), [`Lease::Lead`] (you execute,
-//! then [`LeadGuard::fulfill`] publishes the bytes and wakes waiters), or
-//! [`Lease::Wait`] (block on [`WaitGuard::wait`] for the leader's bytes).
+//! [`LeaseOutcome::Hit`] (bytes already cached and fresh), [`LeaseOutcome::Lead`] (you
+//! execute, then [`LeadGuard::fulfill`] publishes the bytes and wakes waiters), or
+//! [`LeaseOutcome::Wait`] (block on [`WaitGuard::wait`] for the leader's bytes).
 //!
 //! # Bounds: byte-budget LRU + admission (§6.3)
 //!
@@ -215,10 +215,10 @@ pub struct CacheConfig {
     /// Bodies larger than this are never admitted (oversize/streaming, §6.3).
     pub max_entry_bytes: usize,
     /// Use the label-unsafe variable-renaming canonicalization
-    /// ([`canon::canonicalize_renamed`]). **OFF by default** — only sound when the
-    /// consumer re-labels cached bytes to the request's projection (see
-    /// [`canon`](crate::canon)). The label-safe whitespace-only form is the
-    /// default.
+    /// ([`canonicalize_renamed`](crate::canonicalize_renamed)). **OFF by default** —
+    /// only sound when the consumer re-labels cached bytes to the request's projection
+    /// (see [`canonicalize`](crate::canonicalize) for the label-safe default). The
+    /// label-safe whitespace-only form is the default.
     pub rename_variables: bool,
 }
 

--- a/crates/sparq-serve/src/cache.rs
+++ b/crates/sparq-serve/src/cache.rs
@@ -1,0 +1,719 @@
+//! Response-bytes result cache (research/concurrent-serving.md §5 verdict 2, §6.3).
+//!
+//! [OPUS-4.8] sq-jluc — written while Fable 5 unavailable; re-review when Fable
+//! returns. **OPT-IN, OFF by default** (cargo feature `result-cache`).
+//!
+//! This is the §5-row-2 **RECOMMEND**: a cache from a *request identity* to the
+//! complete, pre-serialized response body the engine produced, so a repeated read
+//! returns bytes in tens of nanoseconds instead of re-executing (the only route to
+//! the Mreq/s envelope of §1). It sits **in front of** `prepare()`/engine dispatch
+//! and is a strictly different layer from `sparq-engine`'s `cache.rs` (the embedded
+//! whole-query algebra-keyed LRU that lives inside one engine instance); this cache
+//! is keyed on *visibility scope* and invalidated by the serving writer's per-pod
+//! epoch bumps, neither of which the engine layer knows about.
+//!
+//! # The key: `(canonical-query, visibility-scope, epoch-vector)` — §6.3
+//!
+//! - **Canonical-query** ([`canon`](crate::canon)): cheap whitespace (and opt-in
+//!   variable) normalization, hashed. So `SELECT ?x WHERE{…}` and the same query
+//!   reindented share an entry.
+//! - **Visibility-scope** ([`ScopeKey`]): the identity of the *accessible graph
+//!   set* a request runs under — `sparq_solid::AuthIndex::accessible(session,
+//!   mode)`'s sorted set, hashed. **This is a correctness / access-control
+//!   obligation, not a privacy guarantee** (stated honestly below): two sessions
+//!   that can see different graph sets get different keys, so cached bytes computed
+//!   for one access scope can **never** be served to a different one. We key on the
+//!   *scope* (the Hasura minimal-footprint lesson), **never** on the WebID/identity
+//!   — many WebIDs share one public-read scope, which is exactly the high-tenancy
+//!   key-fragmentation mitigation §6.3 calls for.
+//! - **Epoch-vector**: not part of the *lookup* key (that would mint a fresh,
+//!   never-reused slot on every write); instead each entry **records** the per-pod
+//!   epoch of the graphs its query touched. On read the recorded epochs are checked
+//!   against the live generation's [`PodEpochs`](crate::PodEpochs); any advance is a
+//!   stale miss and evicts the entry. A query whose footprint is *unbounded* (it
+//!   could read graphs we cannot statically enumerate) records the **global
+//!   generation** number and is invalidated by ANY write — the conservative,
+//!   answer-safe choice.
+//!
+//! ## Why scope keying is correctness, not privacy (honest boundary)
+//!
+//! Keying on `accessible` guarantees the cache never *introduces* a cross-scope
+//! leak the engine wouldn't already prevent: the bytes stored under a scope were
+//! produced by the engine evaluating *under that scope's `DatasetView`*, so they
+//! contain only what that scope may see, and they are only ever returned to a
+//! request that presents the same scope key. It is an **invariant of this cache**
+//! (tested: a different scope MUST miss), enforcing the access-control boundary the
+//! auth layer already defines. It is **not** itself a confidentiality mechanism
+//! (it makes no cryptographic claim, hides nothing from a side channel, and trusts
+//! the caller to derive the scope key faithfully from a *correctly evaluated*
+//! `accessible` set — a wrong scope key would be an auth-layer bug, not a cache
+//! bug). See the privacy-claims discipline in `AGENTS.md`.
+//!
+//! # Single-flight / lease dedup (§5 verdict 1, the one MQO survivor)
+//!
+//! On a miss the first caller takes a **lease** for the key; concurrent callers for
+//! the same key **wait** on that lease rather than each re-executing (a stampede
+//! becomes one execution, N waiters). [`ResultCache::lease`] returns either
+//! [`Lease::Hit`] (bytes already cached and fresh), [`Lease::Lead`] (you execute,
+//! then [`LeadGuard::fulfill`] publishes the bytes and wakes waiters), or
+//! [`Lease::Wait`] (block on [`WaitGuard::wait`] for the leader's bytes).
+//!
+//! # Bounds: byte-budget LRU + admission (§6.3)
+//!
+//! The cache holds at most `max_bytes` of response bodies; inserting evicts
+//! least-recently-used entries until it fits. A body larger than
+//! `max_entry_bytes` is **never admitted** (oversize/streaming results are not
+//! cacheable — they would evict everything else for one entry). Admission returns
+//! the bytes to the caller regardless; rejection only means "don't keep it".
+//!
+//! # Library-first (§6.1)
+//!
+//! Sync, runtime-agnostic, no HTTP/async types. The cache stores opaque
+//! [`Bytes`](std::sync::Arc) blobs and `&str` formats; it never parses a query
+//! (only canonicalizes the text) and never touches `sparq-solid` — the caller
+//! derives the [`ScopeKey`] and the touched-pod footprint and hands them in.
+
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Condvar, Mutex};
+
+use rustc_hash::FxHashMap;
+
+use crate::canon;
+use crate::epoch::{Epoch, PodEpochs, PodId};
+
+/// A shared, immutable, pre-serialized response body. Cheap to clone (one `Arc`
+/// bump) — what Tier 0 can hand straight to the socket without re-serializing.
+pub type Bytes = Arc<[u8]>;
+
+/// Default total byte budget for cached bodies: 64 MiB. Tunable via
+/// [`CacheConfig`]; the cache never exceeds it (LRU eviction on insert).
+pub const DEFAULT_MAX_BYTES: usize = 64 * 1024 * 1024;
+
+/// Default per-entry admission cap: 256 KiB. A body larger than this is never
+/// cached (oversize/streaming — §6.3). Tunable via [`CacheConfig`].
+pub const DEFAULT_MAX_ENTRY_BYTES: usize = 256 * 1024;
+
+/// Opaque hash of a request's **visibility scope** — the identity of the set of
+/// graphs a session may read, NOT the session/WebID (§6.3, the Hasura lesson).
+///
+/// Construct it from `sparq_solid::AuthIndex::accessible(session, mode)` (an
+/// already-sorted `Vec<NamedNode>`) via [`ScopeKey::of_graphs`]. Two sessions with
+/// the same accessible set — e.g. every anonymous reader of public graphs —
+/// collapse to the **same** scope key, which is the high-tenancy key-fragmentation
+/// mitigation. Sessions with different accessible sets get different keys, so the
+/// cache can never serve one scope's bytes to another (the isolation invariant).
+///
+/// `sparq-serve` deliberately does **not** depend on `sparq-solid`: the caller owns
+/// the auth layer and passes the derived scope in. A wrong derivation is an
+/// auth-layer bug; this type only guarantees that *equal scopes hash equal and
+/// distinct scopes (almost surely) hash distinct*.
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Debug)]
+pub struct ScopeKey(u64);
+
+impl ScopeKey {
+    /// The scope of a request that runs with **no access control** (the whole
+    /// dataset is visible) — a single shared key. Distinct from any restricted
+    /// scope produced by [`ScopeKey::of_graphs`] (it is salted differently), so an
+    /// unauthenticated full-dataset read never collides with a *restricted* scope
+    /// that happens to enumerate the same graphs.
+    pub fn unrestricted() -> Self {
+        // A fixed sentinel distinct from the domain of hashed graph sets.
+        ScopeKey(0x00A1_1FAC_CE55_u64 ^ SCOPE_SALT)
+    }
+
+    /// The scope of a request whose accessible set is **empty** (fail-closed: no
+    /// auth view, or no matching grants — `sparq-solid`'s empty-visibility case).
+    /// All such requests share one key; they all see zero rows, so caching one
+    /// empty answer per query is correct and cheap.
+    pub fn empty() -> Self {
+        ScopeKey::of_graphs(std::iter::empty::<&str>())
+    }
+
+    /// Derives a scope key from the accessible graph-IRI set. The set is hashed
+    /// **order-independently** (sorted internally), so iteration order does not
+    /// matter — equal sets always hash equal. Pass
+    /// `accessible(session, mode).iter().map(NamedNode::as_str)`.
+    ///
+    /// Collision resistance is that of a 64-bit hash: distinct scopes almost surely
+    /// differ. A collision would let one scope read another's cached bytes; at
+    /// 64 bits this is negligible for the scope cardinalities of a Solid deployment,
+    /// but it is an explicit (non-cryptographic) assumption — for a hard isolation
+    /// guarantee a deployment can widen the hash here. See the module honesty note.
+    pub fn of_graphs<I, S>(graphs: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<str>,
+    {
+        // Order-independent: each member is hashed and finalized to a well-mixed
+        // 64-bit value, then combined into the accumulator with a COMMUTATIVE XOR
+        // — so {a,b} and {b,a} agree (the access scope is a SET; iteration order
+        // is not part of its identity). The per-member finalize multiply ensures
+        // member hashes are spread out before the XOR (raw `DefaultHasher` finish
+        // is already well-distributed; the multiply is belt-and-braces against any
+        // low-entropy collision). `count` is folded in at the end so a set and a
+        // strict superset that XOR-cancel to the same accumulator (a set never has
+        // duplicates, but be robust) still differ by cardinality.
+        let mut acc: u64 = 0;
+        let mut count: u64 = 0;
+        for g in graphs {
+            let mut h = DefaultHasher::new();
+            g.as_ref().hash(&mut h);
+            acc ^= h.finish().wrapping_mul(0x9E37_79B9_7F4A_7C15);
+            count = count.wrapping_add(1);
+        }
+        let mut h = DefaultHasher::new();
+        acc.hash(&mut h);
+        count.hash(&mut h);
+        ScopeKey(h.finish() ^ SCOPE_SALT)
+    }
+
+    /// The raw 64-bit scope hash (for diagnostics / metrics labels).
+    pub fn as_u64(self) -> u64 {
+        self.0
+    }
+
+    /// Wraps a pre-computed 64-bit scope hash (for a consumer that derives the
+    /// scope identity itself — e.g. a caller that already maintains a stable scope
+    /// id). Must satisfy the same contract: equal scopes ⇒ equal value.
+    pub fn from_raw(hash: u64) -> Self {
+        ScopeKey(hash)
+    }
+}
+
+/// Salt mixed into every [`ScopeKey`] so a scope hash never collides with a raw
+/// query hash or epoch hash used elsewhere (domain separation, cheap).
+const SCOPE_SALT: u64 = 0x0005_C05E_5A17_0000;
+
+/// The footprint of a query for invalidation: which pods (named graphs) it read,
+/// and whether that footprint is fully known.
+///
+/// The caller derives this from the parsed algebra's GRAPH/visibility footprint —
+/// the same conservative superset the design's §6.3 describes. If the query could
+/// read graphs that cannot be statically enumerated (e.g. a `GRAPH ?g {…}` over the
+/// whole dataset, or a query with no graph restriction under an unrestricted
+/// scope), it is [`Footprint::Unbounded`] and the entry pins the **global
+/// generation** — invalidated by any write. Over-approximating the footprint only
+/// costs extra (sound) invalidation, never a stale answer.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Footprint {
+    /// The query reads only these pods. The entry records each pod's epoch and is
+    /// invalidated when any of them advances. An empty set means the query touches
+    /// no pod (a constant query) and is never invalidated by a write.
+    Pods(Vec<PodId>),
+    /// The footprint is not statically known: pin the global generation, invalidate
+    /// on any write (the conservative, answer-safe default).
+    Unbounded,
+}
+
+/// Configuration for a [`ResultCache`].
+#[derive(Clone, Debug)]
+pub struct CacheConfig {
+    /// Total byte budget for cached bodies; LRU-evict on insert until under it.
+    pub max_bytes: usize,
+    /// Bodies larger than this are never admitted (oversize/streaming, §6.3).
+    pub max_entry_bytes: usize,
+    /// Use the label-unsafe variable-renaming canonicalization
+    /// ([`canon::canonicalize_renamed`]). **OFF by default** — only sound when the
+    /// consumer re-labels cached bytes to the request's projection (see
+    /// [`canon`](crate::canon)). The label-safe whitespace-only form is the
+    /// default.
+    pub rename_variables: bool,
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        CacheConfig {
+            max_bytes: DEFAULT_MAX_BYTES,
+            max_entry_bytes: DEFAULT_MAX_ENTRY_BYTES,
+            rename_variables: false,
+        }
+    }
+}
+
+/// The lookup identity of a cached response: the canonical-query hash, the
+/// visibility-scope, and the result format. The epoch-vector is recorded *in the
+/// entry*, not here, so a write reuses the same slot (see the module docs).
+///
+/// `format` is part of the key because the same query in two result media
+/// (`sparql-results+json` vs CSV) is two different byte bodies.
+#[derive(Clone, PartialEq, Eq, Hash, Debug)]
+struct CacheKey {
+    query_hash: u64,
+    scope: ScopeKey,
+    format: Box<str>,
+}
+
+/// What invalidation generation an entry's freshness is checked against.
+#[derive(Clone, Debug)]
+enum Validity {
+    /// Bounded footprint: each touched pod and the epoch it had when cached. Fresh
+    /// while every recorded epoch equals the live generation's epoch for that pod.
+    Pods(Vec<(PodId, Epoch)>),
+    /// Unbounded footprint: the global generation number when cached. Fresh while
+    /// the live generation number is unchanged.
+    Generation(u64),
+}
+
+impl Validity {
+    /// Is an entry recorded with this validity still fresh against the live state?
+    fn is_fresh(&self, epochs: &PodEpochs, generation: u64) -> bool {
+        match self {
+            Validity::Pods(recorded) => recorded
+                .iter()
+                .all(|(pod, e)| epochs.epoch(pod) == *e),
+            Validity::Generation(g) => *g == generation,
+        }
+    }
+}
+
+/// One cached body plus its freshness record and LRU stamp.
+struct Entry {
+    bytes: Bytes,
+    validity: Validity,
+    /// Monotonic access tick for LRU ordering (the most recently touched entry has
+    /// the largest tick).
+    last_used: u64,
+}
+
+/// A single-flight lease slot: present while a leader is executing the key.
+struct Lease {
+    /// Set by the leader when it fulfills; waiters read it. `None` while in flight,
+    /// `Some(Err)` if the leader dropped without fulfilling (it must re-execute).
+    result: Mutex<Option<Bytes>>,
+    /// Waiters block here until the leader publishes (or abandons).
+    ready: Condvar,
+    /// True once the leader has finished (fulfilled or abandoned); distinguishes
+    /// "no result yet, keep waiting" from "leader gone, you lead now".
+    done: Mutex<bool>,
+}
+
+impl Lease {
+    fn new() -> Arc<Lease> {
+        Arc::new(Lease {
+            result: Mutex::new(None),
+            ready: Condvar::new(),
+            done: Mutex::new(false),
+        })
+    }
+}
+
+/// The response-bytes result cache: byte-budget LRU keyed on
+/// `(canonical-query, visibility-scope, format)`, epoch-validated on read,
+/// single-flight on miss.
+///
+/// Cheap to share (`Arc<ResultCache>`); all methods take `&self`. The hot read path
+/// takes one mutex (the map) — the spike (§4.1) shows the contention that motivates
+/// the eventual arc-swap read snapshot, recorded as a follow-up; v1 ships the
+/// correct sharded-map shape and the bench measures the lock cost on a canonical
+/// host (this work-box is non-canonical, §below).
+pub struct ResultCache {
+    config: CacheConfig,
+    inner: Mutex<Inner>,
+    /// Monotonic LRU clock, bumped on every access. Atomic so reads that only touch
+    /// `last_used` don't need the big lock for the tick (they still take it to
+    /// mutate the entry, but the tick source is lock-free).
+    tick: AtomicU64,
+    /// Cheap counters for hit-rate measurement (§6.3 "measure before going deeper").
+    hits: AtomicU64,
+    misses: AtomicU64,
+    stale: AtomicU64,
+    inserts: AtomicU64,
+    evictions: AtomicU64,
+    admission_rejects: AtomicU64,
+}
+
+struct Inner {
+    map: FxHashMap<CacheKey, Entry>,
+    leases: FxHashMap<CacheKey, Arc<Lease>>,
+    /// Sum of `bytes.len()` over `map` — the live byte budget usage.
+    bytes_used: usize,
+}
+
+/// Outcome of [`ResultCache::lease`]: hit, lead, or wait.
+pub enum LeaseOutcome {
+    /// A fresh body is cached; here it is. No execution needed.
+    Hit(Bytes),
+    /// You are the single-flight leader: execute the query, then call
+    /// [`LeadGuard::fulfill`] with the bytes (or drop the guard to abandon, which
+    /// wakes waiters to elect a new leader).
+    Lead(LeadGuard),
+    /// Another caller is already executing this exact key; block on
+    /// [`WaitGuard::wait`] to receive their bytes (or be promoted to leader if they
+    /// abandon).
+    Wait(WaitGuard),
+}
+
+/// Handle for the single-flight leader. On [`LeadGuard::fulfill`] the bytes are
+/// inserted (subject to admission) and all waiters are woken with them. Dropping
+/// without fulfilling abandons the lease (waiters re-elect a leader).
+pub struct LeadGuard {
+    cache: Arc<ResultCache>,
+    key: CacheKey,
+    lease: Arc<Lease>,
+    footprint: Footprint,
+    fulfilled: bool,
+}
+
+impl LeadGuard {
+    /// Publishes `bytes` as the result for this key: records the freshness against
+    /// the live `epochs`/`generation`, inserts under the byte budget (admission may
+    /// reject an oversize body — the bytes are still returned and shared with
+    /// waiters), and wakes all waiters. Returns the same `bytes` for the caller's
+    /// own use (so the caller writes its response from the shared `Arc`).
+    pub fn fulfill(mut self, bytes: Bytes, epochs: &PodEpochs, generation: u64) -> Bytes {
+        let validity = self.cache.validity_for(&self.footprint, epochs, generation);
+        self.cache
+            .complete_lease(&self.key, &self.lease, bytes.clone(), Some((validity, &bytes)));
+        self.fulfilled = true;
+        bytes
+    }
+}
+
+impl Drop for LeadGuard {
+    fn drop(&mut self) {
+        if !self.fulfilled {
+            // Abandon: wake waiters with no result so one of them re-leads.
+            self.cache.abandon_lease(&self.key, &self.lease);
+        }
+    }
+}
+
+/// Handle for a single-flight waiter.
+pub struct WaitGuard {
+    cache: Arc<ResultCache>,
+    key: CacheKey,
+    lease: Arc<Lease>,
+}
+
+/// What a waiter gets when it stops waiting.
+pub enum WaitOutcome {
+    /// The leader fulfilled; here are their bytes.
+    Bytes(Bytes),
+    /// The leader abandoned without a result; you are promoted to leader — execute
+    /// and fulfill via this guard.
+    Promoted(LeadGuard),
+}
+
+impl WaitGuard {
+    /// Blocks until the leader fulfills (returns [`WaitOutcome::Bytes`]) or abandons
+    /// (returns [`WaitOutcome::Promoted`] — you must now execute and fulfill).
+    pub fn wait(self, footprint: Footprint) -> WaitOutcome {
+        // Scope the `done` guard so it is dropped before we move `self.lease` below.
+        {
+            let mut done = self.lease.done.lock().expect("lease poisoned");
+            while !*done {
+                done = self.lease.ready.wait(done).expect("lease poisoned");
+            }
+        }
+        let result = self.lease.result.lock().expect("lease poisoned").clone();
+        match result {
+            Some(bytes) => WaitOutcome::Bytes(bytes),
+            None => WaitOutcome::Promoted(LeadGuard {
+                cache: Arc::clone(&self.cache),
+                key: self.key,
+                lease: self.lease,
+                footprint,
+                fulfilled: false,
+            }),
+        }
+    }
+}
+
+/// Snapshot of the cache's measurement counters (§6.3 hit-rate instrumentation).
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct CacheStats {
+    /// Fresh cache hits served without execution.
+    pub hits: u64,
+    /// Lookups with no entry at all (cold miss).
+    pub misses: u64,
+    /// Lookups that found an entry but it was epoch-stale (and was evicted).
+    pub stale: u64,
+    /// Bodies inserted into the cache.
+    pub inserts: u64,
+    /// Entries LRU-evicted to stay under the byte budget.
+    pub evictions: u64,
+    /// Bodies refused admission for exceeding `max_entry_bytes`.
+    pub admission_rejects: u64,
+}
+
+impl ResultCache {
+    /// Creates a cache with the default configuration.
+    pub fn new() -> Arc<Self> {
+        Self::with_config(CacheConfig::default())
+    }
+
+    /// Creates a cache with an explicit [`CacheConfig`].
+    pub fn with_config(config: CacheConfig) -> Arc<Self> {
+        Arc::new(ResultCache {
+            config,
+            inner: Mutex::new(Inner {
+                map: FxHashMap::default(),
+                leases: FxHashMap::default(),
+                bytes_used: 0,
+            }),
+            tick: AtomicU64::new(0),
+            hits: AtomicU64::new(0),
+            misses: AtomicU64::new(0),
+            stale: AtomicU64::new(0),
+            inserts: AtomicU64::new(0),
+            evictions: AtomicU64::new(0),
+            admission_rejects: AtomicU64::new(0),
+        })
+    }
+
+    /// Builds the lookup key for a request: canonicalize the query (per
+    /// [`CacheConfig::rename_variables`]), hash it, and combine with the scope and
+    /// format. Pure; does no map access.
+    fn key(&self, query: &str, scope: ScopeKey, format: &str) -> CacheKey {
+        let canonical = if self.config.rename_variables {
+            canon::canonicalize_renamed(query)
+        } else {
+            canon::canonicalize(query)
+        };
+        let mut h = DefaultHasher::new();
+        canonical.hash(&mut h);
+        CacheKey {
+            query_hash: h.finish(),
+            scope,
+            format: format.into(),
+        }
+    }
+
+    /// Pure read-only probe: returns the cached body iff a **fresh** entry exists
+    /// for `(query, scope, format)` against the live `epochs`/`generation`. Does
+    /// NOT take a lease (use [`ResultCache::lease`] for the single-flight path).
+    /// Updates the LRU stamp on a hit and the hit/miss/stale counters.
+    pub fn get(
+        self: &Arc<Self>,
+        query: &str,
+        scope: ScopeKey,
+        format: &str,
+        epochs: &PodEpochs,
+        generation: u64,
+    ) -> Option<Bytes> {
+        let key = self.key(query, scope, format);
+        let mut inner = self.inner.lock().expect("result cache poisoned");
+        self.lookup_locked(&mut inner, &key, epochs, generation)
+    }
+
+    /// Single-flight lease over `(query, scope, format)`. Returns:
+    /// - [`LeaseOutcome::Hit`] if a fresh body is cached (no execution);
+    /// - [`LeaseOutcome::Lead`] if this caller should execute (and then
+    ///   [`LeadGuard::fulfill`]);
+    /// - [`LeaseOutcome::Wait`] if another caller is already executing the same key
+    ///   (block on [`WaitGuard::wait`]).
+    ///
+    /// The leader/waiter handshake converts a request stampede on a hot, uncached
+    /// key into one execution + N waiters (§5 verdict 1).
+    pub fn lease(
+        self: &Arc<Self>,
+        query: &str,
+        scope: ScopeKey,
+        format: &str,
+        footprint: Footprint,
+        epochs: &PodEpochs,
+        generation: u64,
+    ) -> LeaseOutcome {
+        let key = self.key(query, scope, format);
+        let mut inner = self.inner.lock().expect("result cache poisoned");
+        // Fresh hit short-circuits the lease entirely.
+        if let Some(bytes) = self.lookup_locked(&mut inner, &key, epochs, generation) {
+            return LeaseOutcome::Hit(bytes);
+        }
+        // Existing lease ⇒ wait. New lease ⇒ lead.
+        if let Some(lease) = inner.leases.get(&key) {
+            let lease = Arc::clone(lease);
+            drop(inner);
+            LeaseOutcome::Wait(WaitGuard {
+                cache: Arc::clone(self),
+                key,
+                lease,
+            })
+        } else {
+            let lease = Lease::new();
+            inner.leases.insert(key.clone(), Arc::clone(&lease));
+            drop(inner);
+            LeaseOutcome::Lead(LeadGuard {
+                cache: Arc::clone(self),
+                key,
+                lease,
+                footprint,
+                fulfilled: false,
+            })
+        }
+    }
+
+    /// Look up `key` under the held lock; on a fresh hit bump LRU + hit counter and
+    /// return the bytes; on a stale hit evict + bump stale; on absence bump miss.
+    fn lookup_locked(
+        self: &Arc<Self>,
+        inner: &mut Inner,
+        key: &CacheKey,
+        epochs: &PodEpochs,
+        generation: u64,
+    ) -> Option<Bytes> {
+        match inner.map.get(key) {
+            Some(entry) if entry.validity.is_fresh(epochs, generation) => {
+                let bytes = entry.bytes.clone();
+                let tick = self.tick.fetch_add(1, Ordering::Relaxed);
+                // Re-borrow mutably to stamp; key is known present.
+                if let Some(e) = inner.map.get_mut(key) {
+                    e.last_used = tick;
+                }
+                self.hits.fetch_add(1, Ordering::Relaxed);
+                Some(bytes)
+            }
+            Some(_) => {
+                // Stale: an epoch advanced since this was cached — evict it so a
+                // re-execution can replace it, and report a (non-fresh) miss.
+                if let Some(e) = inner.map.remove(key) {
+                    inner.bytes_used -= e.bytes.len();
+                }
+                self.stale.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+            None => {
+                self.misses.fetch_add(1, Ordering::Relaxed);
+                None
+            }
+        }
+    }
+
+    /// Derives the [`Validity`] record for a footprint against the live state.
+    fn validity_for(&self, footprint: &Footprint, epochs: &PodEpochs, generation: u64) -> Validity {
+        match footprint {
+            Footprint::Pods(pods) => Validity::Pods(
+                pods.iter()
+                    .map(|p| (p.clone(), epochs.epoch(p)))
+                    .collect(),
+            ),
+            Footprint::Unbounded => Validity::Generation(generation),
+        }
+    }
+
+    /// Completes a lease: optionally insert the body (admission + LRU), then publish
+    /// to waiters and remove the lease. `payload` is `Some((validity, &bytes))` to
+    /// insert, `None` to abandon (no insert, waiters re-lead).
+    fn complete_lease(
+        &self,
+        key: &CacheKey,
+        lease: &Arc<Lease>,
+        bytes: Bytes,
+        payload: Option<(Validity, &Bytes)>,
+    ) {
+        let mut inner = self.inner.lock().expect("result cache poisoned");
+        if let Some((validity, _)) = payload {
+            self.insert_locked(&mut inner, key, bytes.clone(), validity);
+        }
+        inner.leases.remove(key);
+        drop(inner);
+        // Publish to waiters: set the result, mark done, wake all.
+        *lease.result.lock().expect("lease poisoned") = Some(bytes);
+        *lease.done.lock().expect("lease poisoned") = true;
+        lease.ready.notify_all();
+    }
+
+    /// Abandons a lease without a result: remove it and wake waiters with `None`
+    /// (one of them is promoted to leader by [`WaitGuard::wait`]).
+    fn abandon_lease(&self, key: &CacheKey, lease: &Arc<Lease>) {
+        let mut inner = self.inner.lock().expect("result cache poisoned");
+        inner.leases.remove(key);
+        drop(inner);
+        *lease.done.lock().expect("lease poisoned") = true; // result stays None
+        lease.ready.notify_all();
+    }
+
+    /// Inserts a body under the byte budget. Admission: an oversize body is dropped
+    /// (counter bumped) — it is still returned to the caller and shared with
+    /// waiters, just not retained. On insert, LRU-evict until the new total fits.
+    fn insert_locked(&self, inner: &mut Inner, key: &CacheKey, bytes: Bytes, validity: Validity) {
+        let len = bytes.len();
+        if len > self.config.max_entry_bytes {
+            self.admission_rejects.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        // Replacing an existing key: reclaim its bytes first.
+        if let Some(old) = inner.map.remove(key) {
+            inner.bytes_used -= old.bytes.len();
+        }
+        // Evict LRU until this body fits within the budget. A single entry can
+        // never exceed max_bytes here because max_entry_bytes <= max_bytes is the
+        // sane config; if mis-configured we still stop when the map is empty.
+        while inner.bytes_used + len > self.config.max_bytes && !inner.map.is_empty() {
+            self.evict_one_locked(inner);
+        }
+        if inner.bytes_used + len > self.config.max_bytes {
+            // Even an empty cache can't hold it (max_entry_bytes > max_bytes
+            // mis-config): refuse admission rather than overflow the budget.
+            self.admission_rejects.fetch_add(1, Ordering::Relaxed);
+            return;
+        }
+        let tick = self.tick.fetch_add(1, Ordering::Relaxed);
+        inner.map.insert(
+            key.clone(),
+            Entry {
+                bytes,
+                validity,
+                last_used: tick,
+            },
+        );
+        inner.bytes_used += len;
+        self.inserts.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Evicts the least-recently-used entry (smallest `last_used`). Caller ensures
+    /// the map is non-empty.
+    fn evict_one_locked(&self, inner: &mut Inner) {
+        if let Some(victim) = inner
+            .map
+            .iter()
+            .min_by_key(|(_, e)| e.last_used)
+            .map(|(k, _)| k.clone())
+        {
+            if let Some(e) = inner.map.remove(&victim) {
+                inner.bytes_used -= e.bytes.len();
+                self.evictions.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+    }
+
+    /// Current number of cached bodies.
+    pub fn len(&self) -> usize {
+        self.inner.lock().expect("result cache poisoned").map.len()
+    }
+
+    /// True if no body is cached.
+    pub fn is_empty(&self) -> bool {
+        self.inner.lock().expect("result cache poisoned").map.is_empty()
+    }
+
+    /// Current total bytes held by cached bodies (≤ `max_bytes`).
+    pub fn bytes_used(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("result cache poisoned")
+            .bytes_used
+    }
+
+    /// Snapshot of the measurement counters (§6.3 hit-rate instrumentation).
+    pub fn stats(&self) -> CacheStats {
+        CacheStats {
+            hits: self.hits.load(Ordering::Relaxed),
+            misses: self.misses.load(Ordering::Relaxed),
+            stale: self.stale.load(Ordering::Relaxed),
+            inserts: self.inserts.load(Ordering::Relaxed),
+            evictions: self.evictions.load(Ordering::Relaxed),
+            admission_rejects: self.admission_rejects.load(Ordering::Relaxed),
+        }
+    }
+
+    /// Empties the cache (bodies and leases). For tests and explicit flushes.
+    pub fn clear(&self) {
+        let mut inner = self.inner.lock().expect("result cache poisoned");
+        inner.map.clear();
+        inner.leases.clear();
+        inner.bytes_used = 0;
+    }
+}

--- a/crates/sparq-serve/src/canon.rs
+++ b/crates/sparq-serve/src/canon.rs
@@ -1,0 +1,307 @@
+//! Cheap query canonicalization for the result-cache key
+//! (research/concurrent-serving.md §6.3).
+//!
+//! [OPUS-4.8] sq-jluc — written while Fable 5 unavailable; re-review when Fable
+//! returns.
+//!
+//! §6.3 prescribes the canonicalization ladder: "whitespace/prefix normalization +
+//! variable renaming (Papailiou-style canonical labeling is the ceiling; **start
+//! with cheap normalization, measure hit-rate delta**)". This module is exactly
+//! the cheap rung — a single linear pass over the query text, no parse, no algebra:
+//!
+//! 1. **Whitespace normalization** — runs of ASCII whitespace collapse to one
+//!    space; leading/trailing space is trimmed. Two queries that differ only in
+//!    indentation or line breaks share a key.
+//! 2. **Variable renaming (alpha-renaming)** — `?x`/`$x` variables are renamed to
+//!    positional `?v0`, `?v1`, ... in first-occurrence order, so two queries that
+//!    are identical up to a consistent variable renaming share a key. (SPARQL
+//!    variable names are not semantically meaningful beyond binding identity, so
+//!    this is sound for the *result rows* — `SELECT ?a WHERE { ?a ?b ?c }` and
+//!    `SELECT ?x WHERE { ?x ?y ?z }` compute the same answer rows; the column
+//!    *labels* differ, see the caveat below.)
+//!
+//! **Honest scope / caveat (load-bearing).** Column labels are part of a SPARQL
+//! results document: `SELECT ?a ...` emits a `head.vars=["a"]`, `SELECT ?x ...`
+//! emits `["x"]`. So alpha-renamed queries do **not** produce byte-identical
+//! `sparql-results+json`. The cache value is therefore keyed *and stored* with the
+//! caller's chosen result `format`, and alpha-renaming is only sound when the
+//! cached bytes are post-processed to the requesting query's projection labels, OR
+//! when renaming is disabled. To stay correct-by-construction in v1 this module
+//! exposes BOTH a [`canonicalize`] (whitespace only — always label-safe) and a
+//! [`canonicalize_renamed`] (whitespace + alpha-rename — higher hit-rate,
+//! label-unsafe unless the consumer re-labels), and the cache defaults to the
+//! **label-safe** whitespace-only form. The renaming form is opt-in per call so the
+//! measured hit-rate delta (§6.3 "measure before going deeper") can be evaluated
+//! without risking a wrong column label. Comments, string-literal contents, and
+//! IRIs are preserved verbatim — we never reach inside a quoted literal (a `?x`
+//! inside a string is data, not a variable). This is intentionally conservative: a
+//! missed canonicalization only costs a cache miss (re-execution), never a wrong
+//! answer.
+//!
+//! Prefix normalization (rewriting `PREFIX`/`@prefix` declarations to a canonical
+//! order, or expanding prefixed names) is the named next rung; it needs lexical
+//! awareness this cheap pass deliberately avoids, and §6.3 says measure first.
+
+/// Canonicalizes query text for cache keying: whitespace collapse only.
+///
+/// **Label-safe**: the projection variable names are preserved, so the cached
+/// result document's `head.vars` matches the requesting query exactly. Two queries
+/// that differ only in whitespace/line-breaks produce the same string. This is the
+/// cache's default canonical form.
+///
+/// Whitespace *inside* a quoted string literal (`"..."`, `'...'`, `"""..."""`,
+/// `'''...'''`) is preserved verbatim — only whitespace in the query's structural
+/// text is collapsed.
+pub fn canonicalize(query: &str) -> String {
+    rewrite(query, false)
+}
+
+/// Canonicalizes with whitespace collapse **and** positional variable renaming
+/// (alpha-renaming): `?x`/`$x` become `?v0`, `?v1`, ... in first-occurrence order.
+///
+/// **Higher hit-rate, but label-unsafe** — see the module-level caveat. Use only
+/// when the consumer re-labels the cached bytes to the requesting query's
+/// projection, or when the result format carries no column labels. The cache only
+/// applies this when explicitly configured to.
+pub fn canonicalize_renamed(query: &str) -> String {
+    rewrite(query, true)
+}
+
+/// One linear pass. `rename` toggles alpha-renaming. State machine over three
+/// lexical contexts the cheap pass must distinguish to stay sound:
+/// - normal query text (collapse whitespace; rename variables),
+/// - inside a string literal (verbatim — a `?x` here is data),
+/// - inside a comment (`# ... <eol>` — dropped; a `?x` in a comment must not
+///   consume a rename slot or it would desync two queries that differ only in a
+///   comment).
+fn rewrite(query: &str, rename: bool) -> String {
+    let mut out = String::with_capacity(query.len());
+    let mut renamer = Renamer::default();
+    let bytes = query.as_bytes();
+    let mut i = 0;
+    // Whether we owe a single collapsed space, emitted lazily so a run of
+    // whitespace (and trailing whitespace) costs at most one space and a leading
+    // run costs none.
+    let mut pending_space = false;
+
+    while i < bytes.len() {
+        let b = bytes[i];
+        match b {
+            // String literals: copy the whole literal verbatim, quotes included.
+            b'"' | b'\'' => {
+                flush_space(&mut out, &mut pending_space);
+                let (lit, next) = scan_string(query, i);
+                out.push_str(lit);
+                i = next;
+            }
+            // Line comment: `# ... ` to end of line. Dropped entirely (treated as
+            // whitespace), so two queries differing only in a comment canonicalize
+            // equal.
+            b'#' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                // The trailing newline (if any) is handled as whitespace next loop.
+            }
+            // Variable: `?name` or `$name`.
+            b'?' | b'$' => {
+                flush_space(&mut out, &mut pending_space);
+                let (var, next) = scan_var(query, i);
+                if rename {
+                    out.push_str(&renamer.rename(var));
+                } else {
+                    out.push_str(var);
+                }
+                i = next;
+            }
+            _ if b.is_ascii_whitespace() => {
+                // Collapse: remember we owe a single space if anything precedes it.
+                pending_space = !out.is_empty();
+                i += 1;
+            }
+            _ => {
+                flush_space(&mut out, &mut pending_space);
+                // Copy this UTF-8 scalar verbatim (handles multi-byte IRIs/literals).
+                let ch_len = utf8_len(b);
+                out.push_str(&query[i..i + ch_len]);
+                i += ch_len;
+            }
+        }
+    }
+    out
+}
+
+/// Emits the single owed collapsed space, if any, then clears the flag.
+fn flush_space(out: &mut String, pending: &mut bool) {
+    if *pending {
+        out.push(' ');
+        *pending = false;
+    }
+}
+
+/// UTF-8 sequence length from a leading byte (1..=4). Defensive: a stray
+/// continuation byte is treated as length 1 so we never index past a boundary (the
+/// input is `&str`, so it is valid UTF-8 — this is belt-and-braces).
+fn utf8_len(lead: u8) -> usize {
+    match lead {
+        0x00..=0x7F => 1,
+        0xC0..=0xDF => 2,
+        0xE0..=0xEF => 3,
+        0xF0..=0xF7 => 4,
+        _ => 1,
+    }
+}
+
+/// Scans a SPARQL string literal starting at `start` (a quote byte). Returns the
+/// literal slice (quotes included) and the index just past it. Handles long quotes
+/// (`"""`/`'''`) and backslash escapes; an unterminated literal scans to EOF
+/// (conservative — the engine's parser will reject it, we only need a stable key).
+fn scan_string(query: &str, start: usize) -> (&str, usize) {
+    let bytes = query.as_bytes();
+    let quote = bytes[start];
+    // Long-quote form: three identical quote bytes.
+    let long = start + 2 < bytes.len() && bytes[start + 1] == quote && bytes[start + 2] == quote;
+    let mut i = if long { start + 3 } else { start + 1 };
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'\\' {
+            i += 2; // skip the escaped char
+            continue;
+        }
+        if b == quote {
+            if long {
+                if i + 2 < bytes.len() && bytes[i + 1] == quote && bytes[i + 2] == quote {
+                    i += 3;
+                    return (&query[start..i], i);
+                }
+                i += 1;
+            } else {
+                i += 1;
+                return (&query[start..i], i);
+            }
+        } else {
+            i += 1;
+        }
+    }
+    (&query[start..], bytes.len())
+}
+
+/// Scans a variable token starting at `start` (a `?` or `$`). Returns the token
+/// (sigil + name, the name as written) and the index just past it. The SPARQL
+/// `VARNAME` grammar is approximated by "name continues over alphanumerics, `_`,
+/// and non-ASCII"; any byte that cannot be in a name ends the token. A bare sigil
+/// with no name is left as just the sigil (a parse error the engine will catch).
+fn scan_var(query: &str, start: usize) -> (&str, usize) {
+    let bytes = query.as_bytes();
+    let mut i = start + 1; // past the sigil
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == b'_' || b.is_ascii_alphanumeric() || b >= 0x80 {
+            i += 1;
+        } else {
+            break;
+        }
+    }
+    (&query[start..i], i)
+}
+
+/// First-occurrence positional renamer: each distinct variable token (by its
+/// written name, sigil-normalized so `?x` and `$x` collapse) maps to `?v0`, `?v1`,
+/// ... in the order first seen.
+#[derive(Default)]
+struct Renamer {
+    // Small linear map: queries rarely have many distinct variables, and a Vec
+    // probe beats a hash map's setup cost at this size. Keyed on the de-sigiled
+    // name so `?x`/`$x` collapse.
+    seen: Vec<(String, String)>,
+}
+
+impl Renamer {
+    fn rename(&mut self, var: &str) -> String {
+        let name = &var[1..]; // strip the sigil
+        if let Some((_, canon)) = self.seen.iter().find(|(n, _)| n == name) {
+            return canon.clone();
+        }
+        let canon = format!("?v{}", self.seen.len());
+        self.seen.push((name.to_string(), canon.clone()));
+        canon
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn whitespace_collapses() {
+        let a = canonicalize("SELECT  ?x\n WHERE {\t?x ?y ?z }");
+        let b = canonicalize("SELECT ?x WHERE { ?x ?y ?z }");
+        assert_eq!(a, b);
+        assert_eq!(a, "SELECT ?x WHERE { ?x ?y ?z }");
+    }
+
+    #[test]
+    fn leading_trailing_trimmed() {
+        assert_eq!(canonicalize("   SELECT *  "), "SELECT *");
+    }
+
+    #[test]
+    fn label_safe_keeps_var_names() {
+        // The default form must NOT rename — column labels are preserved.
+        assert_eq!(
+            canonicalize("SELECT ?a WHERE { ?a ?b ?c }"),
+            "SELECT ?a WHERE { ?a ?b ?c }"
+        );
+    }
+
+    #[test]
+    fn renaming_alpha_equates() {
+        let a = canonicalize_renamed("SELECT ?a WHERE { ?a ?b ?c }");
+        let b = canonicalize_renamed("SELECT ?x WHERE { ?x ?y ?z }");
+        assert_eq!(a, b);
+        assert_eq!(a, "SELECT ?v0 WHERE { ?v0 ?v1 ?v2 }");
+    }
+
+    #[test]
+    fn renaming_normalizes_sigil() {
+        // ?x and $x are the same variable.
+        assert_eq!(
+            canonicalize_renamed("SELECT ?x { $x ?y ?x }"),
+            "SELECT ?v0 { ?v0 ?v1 ?v0 }"
+        );
+    }
+
+    #[test]
+    fn string_literal_var_is_data() {
+        // A `?x` inside a string is NOT a variable — must survive verbatim and not
+        // consume a rename slot.
+        let q = r#"SELECT ?x { ?x ?p "has a ?y inside" }"#;
+        let r = canonicalize_renamed(q);
+        // The literal's `?y` is untouched; only ?x and ?p are renamed.
+        assert!(r.contains(r#""has a ?y inside""#));
+        assert!(r.contains("?v0")); // ?x
+        assert!(r.contains("?v1")); // ?p
+        assert!(!r.contains("?v2")); // ?y inside the string did NOT allocate a slot
+    }
+
+    #[test]
+    fn comment_is_dropped() {
+        let a = canonicalize("SELECT ?x # a comment with ?y\n WHERE { ?x ?p ?o }");
+        let b = canonicalize("SELECT ?x WHERE { ?x ?p ?o }");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn long_string_literal_preserved() {
+        let q = "SELECT ?x { ?x ?p \"\"\"multi\nline ?y\"\"\" }";
+        let r = canonicalize_renamed(q);
+        assert!(r.contains("\"\"\"multi\nline ?y\"\"\""));
+    }
+
+    #[test]
+    fn escaped_quote_in_literal() {
+        let q = r#"ASK { ?s ?p "a \" b" }"#;
+        let r = canonicalize(q);
+        assert!(r.contains(r#""a \" b""#));
+    }
+}

--- a/crates/sparq-serve/src/lib.rs
+++ b/crates/sparq-serve/src/lib.rs
@@ -13,6 +13,26 @@ mod ring;
 mod scheduler;
 mod writer;
 
+// [OPUS-4.8] sq-jluc: the response-bytes result cache (research/concurrent-serving.md
+// §5 row 2 + §6.3) is OPT-IN and OFF by default — the `result-cache` cargo feature.
+// The default `sparq-serve` build (and every consumer that does not turn the feature
+// on) carries ZERO cache code: no module, no canonicalization, no extra dependency
+// (the cache reuses the in-tree `rustc-hash` and `std`). Gating the modules — not just
+// the re-exports — is what keeps the default build lean.
+//
+// LAYER DISTINCTION (do not conflate): `sparq-engine` ALSO has a feature named
+// `result-cache`, but it is a DIFFERENT crate and a DIFFERENT layer — the engine's is
+// the embedded whole-query algebra-keyed LRU inside one engine instance (caller bumps a
+// version on mutation). THIS cache is the SERVING-layer response-bytes cache: keyed on
+// the visibility scope and invalidated by the per-pod epoch bumps of the generation
+// ring, neither of which the engine layer knows about. Cargo features are per-package,
+// so the shared name is not a conflict; the module docs in `cache.rs` spell out the
+// boundary.
+#[cfg(feature = "result-cache")]
+mod cache;
+#[cfg(feature = "result-cache")]
+mod canon;
+
 pub use applier::{GraphApplier, DEFAULT_COMPACT_THRESHOLD};
 pub use epoch::{Epoch, PodEpochs, PodId};
 pub use footprint::{Footprint, TargetGraph};
@@ -24,3 +44,15 @@ pub use writer::{
     ApplyUpdates, CommitGranularity, WriteError, Writer, WriterConfig, DEFAULT_MAX_BATCH,
     DEFAULT_WINDOW,
 };
+
+// [OPUS-4.8] sq-jluc: result-cache public surface (feature `result-cache`). The cache's
+// invalidation `Footprint` (the per-pod / unbounded READ footprint) is a DISTINCT type
+// from this crate's write-side `footprint::Footprint` (the commutativity conflict tag),
+// so it is re-exported under the disambiguating name `ReadFootprint`.
+#[cfg(feature = "result-cache")]
+pub use cache::{
+    Bytes, CacheConfig, CacheStats, Footprint as ReadFootprint, LeadGuard, LeaseOutcome,
+    ResultCache, ScopeKey, WaitGuard, WaitOutcome, DEFAULT_MAX_BYTES, DEFAULT_MAX_ENTRY_BYTES,
+};
+#[cfg(feature = "result-cache")]
+pub use canon::{canonicalize, canonicalize_renamed};

--- a/crates/sparq-serve/tests/cache_feature_state.rs
+++ b/crates/sparq-serve/tests/cache_feature_state.rs
@@ -1,0 +1,97 @@
+//! Feature-state coverage for the `result-cache` surface ([OPUS-4.8] sq-jluc).
+//!
+//! `result-cache` is OFF by default: when off, the whole cache + canonicalization
+//! surface (`cache.rs`, `canon.rs`) is `cfg`'d out of the crate entirely, and the
+//! default serving substrate (the generation ring + per-pod epoch vectors) must be
+//! byte-identical to a build that never knew about a cache. The `result_cache.rs`
+//! correctness sweep is `#![cfg(feature = "result-cache")]`, so before this file the
+//! DEFAULT-OFF build had no test of its own.
+//!
+//! This file is deliberately NOT feature-gated: it compiles and runs in BOTH states.
+//! It pins two things the bead calls out:
+//!   1. the ring + epoch substrate (the cache's invalidation source) is correct
+//!      with the cache off, and
+//!   2. the cache surface is gated by the feature from BOTH cfg arms — the
+//!      `cache_off` / `cache_on` modules below each compile under exactly one arm,
+//!      so a build that turned the feature on accidentally (or off) would fail to
+//!      compile here.
+
+use sparq_serve::{GenerationRing, PodId};
+
+/// The per-pod epoch vector — the cache's invalidation source — bumps exactly the
+/// touched pods on publish, REGARDLESS of the cache feature. This is the load-bearing
+/// invariant the cache relies on, asserted on the default-OFF build.
+#[test]
+fn epoch_vector_bumps_touched_pods_only() {
+    let ring = GenerationRing::new(());
+    let g1 = PodId::from("urn:g1");
+    let g2 = PodId::from("urn:g2");
+
+    assert_eq!(ring.current().epochs().epoch(&g1), 0);
+    assert_eq!(ring.current().epochs().epoch(&g2), 0);
+
+    // Publish touching only g1.
+    ring.publish((), [g1.clone()]);
+    assert_eq!(ring.current().epochs().epoch(&g1), 1, "touched pod bumped");
+    assert_eq!(ring.current().epochs().epoch(&g2), 0, "untouched pod unchanged");
+
+    // Publish touching only g2.
+    ring.publish((), [g2.clone()]);
+    assert_eq!(ring.current().epochs().epoch(&g1), 1, "g1 stays put");
+    assert_eq!(ring.current().epochs().epoch(&g2), 1, "g2 now bumped");
+
+    // The global generation advances on every publish (the unbounded-footprint
+    // invalidation source).
+    assert_eq!(ring.current().number(), 2);
+}
+
+/// Default build: the cache surface is compiled OUT. This module compiles only when
+/// the feature is OFF, and the absence of any `cache::*` reference here is the
+/// proof — referencing `ResultCache` would fail to compile, which is what we want
+/// the default build to enforce. (We assert the substrate instead.)
+#[cfg(not(feature = "result-cache"))]
+mod cache_off {
+    use sparq_serve::GenerationRing;
+
+    #[test]
+    fn ring_works_without_the_cache_feature() {
+        // A build with no cache still serves the generation ring fully.
+        let ring = GenerationRing::new(42u64);
+        assert_eq!(*ring.current().snapshot(), 42);
+        let g = ring.publish(43u64, std::iter::empty::<sparq_serve::PodId>());
+        assert_eq!(*g.snapshot(), 43);
+        assert_eq!(g.number(), 1);
+    }
+}
+
+/// Feature ON: the cache surface is present and a minimal hit/miss round-trips
+/// through the REAL public API. This module compiles only with the feature on.
+#[cfg(feature = "result-cache")]
+mod cache_on {
+    use std::sync::Arc;
+
+    use sparq_serve::{LeaseOutcome, PodEpochs, ReadFootprint, ResultCache, ScopeKey};
+
+    #[test]
+    fn cache_surface_present_and_round_trips() {
+        let cache = ResultCache::new();
+        let epochs = PodEpochs::default();
+        let scope = ScopeKey::unrestricted();
+        let fmt = "application/sparql-results+json";
+        let q = "SELECT * WHERE { ?s ?p ?o }";
+
+        // Cold miss → lead → fulfill.
+        match cache.lease(q, scope, fmt, ReadFootprint::Pods(vec![]), &epochs, 0) {
+            LeaseOutcome::Lead(g) => {
+                let bytes: Arc<[u8]> = Arc::from(b"OK".as_slice());
+                g.fulfill(bytes, &epochs, 0);
+            }
+            _ => panic!("expected Lead on cold miss"),
+        }
+        // Warm hit.
+        assert!(matches!(
+            cache.lease(q, scope, fmt, ReadFootprint::Pods(vec![]), &epochs, 0),
+            LeaseOutcome::Hit(_)
+        ));
+    }
+}

--- a/crates/sparq-serve/tests/result_cache.rs
+++ b/crates/sparq-serve/tests/result_cache.rs
@@ -1,0 +1,461 @@
+//! Correctness tests for the response-bytes result cache (feature `result-cache`,
+//! research/concurrent-serving.md §6.3). [OPUS-4.8] sq-jluc.
+//!
+//! These exercise the REAL cache path — `lease`/`get`/`fulfill` against the real
+//! `PodEpochs` invalidation type — not a mock that bypasses the logic. The
+//! load-bearing invariants the bead names are each a named test:
+//!   - hit/miss correctness,
+//!   - the **visibility-scope isolation** invariant (a different access scope MUST
+//!     miss — `scope_isolation_a_different_scope_misses`),
+//!   - per-pod epoch-bump invalidation + the unbounded-footprint global-generation
+//!     invalidation,
+//!   - single-flight dedup (one execution, N waiters),
+//!   - byte-budget LRU eviction + oversize admission rejection.
+//!
+//! Perf is canonical-pending (this work-box is non-canonical); these are pure
+//! correctness assertions, which is the gate that CAN be satisfied here.
+#![cfg(feature = "result-cache")]
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+use sparq_serve::{
+    Bytes, CacheConfig, LeaseOutcome, PodEpochs, PodId, ReadFootprint, ResultCache, ScopeKey,
+    WaitOutcome,
+};
+
+/// A throwaway `PodEpochs` for a test. The crate exposes `bump` only crate-private
+/// (the ring is the one mutation site), so tests drive invalidation through the
+/// real ring. But for the pure-cache tests we want to vary epochs without standing
+/// up a whole ring — so we publish through a `GenerationRing` to get a real,
+/// correctly-bumped epoch vector. Helper below.
+use sparq_serve::GenerationRing;
+
+/// Publishes `touched` (one bump per pod) onto a fresh ring repeatedly to build a
+/// real `PodEpochs` with the requested epoch for each pod. Returns the live epochs.
+fn epochs_with(bumps: &[(&str, u64)]) -> PodEpochs {
+    let ring = GenerationRing::new(());
+    let mut total = 0u64;
+    // Determine the max epoch we need to reach, publishing the right pods each step.
+    let max = bumps.iter().map(|(_, n)| *n).max().unwrap_or(0);
+    for step in 1..=max {
+        let touched: Vec<PodId> = bumps
+            .iter()
+            .filter(|(_, n)| *n >= step)
+            .map(|(p, _)| PodId::from(*p))
+            .collect();
+        ring.publish((), touched);
+        total += 1;
+    }
+    let _ = total;
+    ring.current().epochs().clone()
+}
+
+fn b(s: &str) -> Bytes {
+    Arc::from(s.as_bytes())
+}
+
+const FMT: &str = "application/sparql-results+json";
+
+/// The leader executes and fulfills; a subsequent identical request is a hit.
+#[test]
+fn hit_after_fulfill() {
+    let cache = ResultCache::new();
+    let epochs = PodEpochs::default();
+    let q = "SELECT * WHERE { ?s ?p ?o }";
+    let scope = ScopeKey::unrestricted();
+    let footprint = ReadFootprint::Pods(vec![PodId::from("g1")]);
+
+    // First call: cold miss → Lead.
+    let bytes = match cache.lease(q, scope, FMT, footprint.clone(), &epochs, 0) {
+        LeaseOutcome::Lead(guard) => guard.fulfill(b("ROWS"), &epochs, 0),
+        other => panic!("expected Lead on cold miss, got {}", outcome_name(&other)),
+    };
+    assert_eq!(&*bytes, b"ROWS");
+
+    // Second identical call: fresh Hit, no execution.
+    match cache.lease(q, scope, FMT, footprint, &epochs, 0) {
+        LeaseOutcome::Hit(hit) => assert_eq!(&*hit, b"ROWS"),
+        other => panic!("expected Hit on repeat, got {}", outcome_name(&other)),
+    }
+
+    let stats = cache.stats();
+    assert_eq!(stats.inserts, 1);
+    assert_eq!(stats.hits, 1);
+}
+
+/// `get` (non-leasing probe) returns the cached bytes, or None on a cold key.
+#[test]
+fn get_probe_hit_and_miss() {
+    let cache = ResultCache::new();
+    let epochs = PodEpochs::default();
+    let scope = ScopeKey::unrestricted();
+    assert!(cache.get("ASK { ?s ?p ?o }", scope, FMT, &epochs, 0).is_none());
+
+    if let LeaseOutcome::Lead(g) = cache.lease(
+        "ASK { ?s ?p ?o }",
+        scope,
+        FMT,
+        ReadFootprint::Pods(vec![]),
+        &epochs,
+        0,
+    ) {
+        g.fulfill(b("true"), &epochs, 0);
+    } else {
+        panic!("expected Lead");
+    }
+    assert_eq!(
+        &*cache
+            .get("ASK { ?s ?p ?o }", scope, FMT, &epochs, 0)
+            .expect("hit"),
+        b"true"
+    );
+}
+
+/// THE load-bearing access-control invariant (§6.3, the Hasura lesson): bytes
+/// cached for one visibility scope are NEVER served to a different scope. A request
+/// under a different accessible-graph set MUST miss.
+#[test]
+fn scope_isolation_a_different_scope_misses() {
+    let cache = ResultCache::new();
+    let epochs = PodEpochs::default();
+    let q = "SELECT * WHERE { GRAPH ?g { ?s ?p ?o } }";
+
+    // Scope A can see {private/, public/}; scope B can see only {public/}.
+    let scope_a = ScopeKey::of_graphs(["urn:pod:alice/private", "urn:pod:public"]);
+    let scope_b = ScopeKey::of_graphs(["urn:pod:public"]);
+    assert_ne!(scope_a, scope_b, "distinct accessible sets ⇒ distinct scope keys");
+
+    // Cache a (potentially private-revealing) answer under scope A.
+    if let LeaseOutcome::Lead(g) = cache.lease(
+        q,
+        scope_a,
+        FMT,
+        ReadFootprint::Unbounded,
+        &epochs,
+        0,
+    ) {
+        g.fulfill(b("ALICE_PRIVATE_ROWS"), &epochs, 0);
+    } else {
+        panic!("expected Lead under scope A");
+    }
+
+    // Scope A sees it (hit) — sanity.
+    assert!(
+        matches!(
+            cache.lease(q, scope_a, FMT, ReadFootprint::Unbounded, &epochs, 0),
+            LeaseOutcome::Hit(_)
+        ),
+        "scope A must hit its own cached bytes"
+    );
+
+    // Scope B (a DIFFERENT access scope, same query) MUST NOT see A's bytes — it
+    // misses and gets to lead its own execution. The cache cannot leak across the
+    // access-control boundary.
+    match cache.lease(q, scope_b, FMT, ReadFootprint::Unbounded, &epochs, 0) {
+        LeaseOutcome::Lead(_) => { /* correct: B leads its own, sees nothing of A */ }
+        LeaseOutcome::Hit(bytes) => panic!(
+            "ACCESS-CONTROL LEAK: scope B received scope A's cached bytes: {:?}",
+            String::from_utf8_lossy(&bytes)
+        ),
+        LeaseOutcome::Wait(_) => panic!("unexpected concurrent lease"),
+    }
+
+    // Direct probe confirms the same: B never reads A's body.
+    assert!(
+        cache.get(q, scope_b, FMT, &epochs, 0).is_none(),
+        "scope B probe must miss"
+    );
+}
+
+/// The public-scope collapse: many requests under the SAME accessible set share one
+/// key (the high-tenancy key-fragmentation mitigation). Two `of_graphs` calls with
+/// the same set (any order) produce the same scope.
+#[test]
+fn same_scope_collapses_regardless_of_order() {
+    let s1 = ScopeKey::of_graphs(["a", "b", "c"]);
+    let s2 = ScopeKey::of_graphs(["c", "a", "b"]);
+    assert_eq!(s1, s2, "scope key is order-independent over the graph set");
+    // The empty (fail-closed) scope is its own stable key.
+    assert_eq!(ScopeKey::empty(), ScopeKey::of_graphs(Vec::<&str>::new()));
+    // Unrestricted is distinct from a restricted scope that lists no graphs.
+    assert_ne!(ScopeKey::unrestricted(), ScopeKey::empty());
+}
+
+/// Per-pod epoch-bump invalidation: a write to a graph the query touched bumps that
+/// pod's epoch, so the recorded entry goes stale and a re-read misses; a write to an
+/// UNRELATED pod leaves the entry fresh (no churn — the whole point of per-pod
+/// epochs).
+#[test]
+fn epoch_bump_invalidates_touched_pod_only() {
+    let cache = ResultCache::new();
+    let q = "SELECT * WHERE { GRAPH <urn:g1> { ?s ?p ?o } }";
+    let scope = ScopeKey::unrestricted();
+    let footprint = ReadFootprint::Pods(vec![PodId::from("urn:g1")]);
+
+    // Cache under epoch state where g1=0, g2=0.
+    let e0 = epochs_with(&[]);
+    if let LeaseOutcome::Lead(g) = cache.lease(q, scope, FMT, footprint.clone(), &e0, 0) {
+        g.fulfill(b("G1_ROWS"), &e0, 0);
+    } else {
+        panic!("expected Lead");
+    }
+
+    // A write to an UNRELATED pod (g2) — g1 still 0 — entry stays fresh.
+    let e_g2 = epochs_with(&[("urn:g2", 1)]);
+    assert!(
+        cache.get(q, scope, FMT, &e_g2, 1).is_some(),
+        "an unrelated-pod write must NOT invalidate (per-pod epochs)"
+    );
+
+    // A write to g1 (the touched pod) bumps g1's epoch → entry is stale → miss.
+    let e_g1 = epochs_with(&[("urn:g1", 1)]);
+    assert!(
+        cache.get(q, scope, FMT, &e_g1, 1).is_none(),
+        "a write to the touched pod MUST invalidate"
+    );
+    assert_eq!(cache.stats().stale, 1, "the stale entry was counted + evicted");
+}
+
+/// Unbounded-footprint entries pin the global generation: ANY write (generation
+/// advance) invalidates them — the conservative, answer-safe path for queries whose
+/// read footprint cannot be statically enumerated.
+#[test]
+fn unbounded_footprint_invalidated_by_any_write() {
+    let cache = ResultCache::new();
+    let q = "SELECT * WHERE { ?s ?p ?o }"; // no GRAPH restriction → unbounded
+    let scope = ScopeKey::unrestricted();
+    let epochs = PodEpochs::default();
+
+    if let LeaseOutcome::Lead(g) = cache.lease(
+        q,
+        scope,
+        FMT,
+        ReadFootprint::Unbounded,
+        &epochs,
+        7, // cached at generation 7
+    ) {
+        g.fulfill(b("ALL"), &epochs, 7);
+    } else {
+        panic!("expected Lead");
+    }
+    // Same generation → still fresh.
+    assert!(cache.get(q, scope, FMT, &epochs, 7).is_some());
+    // Any later generation → invalidated.
+    assert!(
+        cache.get(q, scope, FMT, &epochs, 8).is_none(),
+        "unbounded entry must invalidate on any generation advance"
+    );
+}
+
+/// Single-flight / lease dedup: under a stampede of N identical concurrent
+/// requests, exactly ONE executes and the rest receive its bytes (§5 verdict 1).
+#[test]
+fn single_flight_one_execution_n_waiters() {
+    let cache = ResultCache::new();
+    let q = "SELECT * WHERE { ?s ?p ?o }";
+    let scope = ScopeKey::unrestricted();
+    let n = 16usize;
+    let executions = Arc::new(AtomicU64::new(0));
+    let barrier = Arc::new(Barrier::new(n));
+
+    let handles: Vec<_> = (0..n)
+        .map(|_| {
+            let cache = Arc::clone(&cache);
+            let executions = Arc::clone(&executions);
+            let barrier = Arc::clone(&barrier);
+            thread::spawn(move || {
+                let epochs = PodEpochs::default();
+                barrier.wait(); // maximize the stampede overlap
+                let footprint = ReadFootprint::Pods(vec![PodId::from("g")]);
+                match cache.lease(q, scope, FMT, footprint.clone(), &epochs, 0) {
+                    LeaseOutcome::Hit(bytes) => bytes,
+                    LeaseOutcome::Lead(guard) => {
+                        // Simulate the one real execution.
+                        executions.fetch_add(1, Ordering::SeqCst);
+                        thread::sleep(std::time::Duration::from_millis(5));
+                        guard.fulfill(b("THE_ANSWER"), &epochs, 0)
+                    }
+                    LeaseOutcome::Wait(waiter) => match waiter.wait(footprint) {
+                        WaitOutcome::Bytes(bytes) => bytes,
+                        WaitOutcome::Promoted(guard) => {
+                            executions.fetch_add(1, Ordering::SeqCst);
+                            guard.fulfill(b("THE_ANSWER"), &epochs, 0)
+                        }
+                    },
+                }
+            })
+        })
+        .collect();
+
+    let results: Vec<Bytes> = handles.into_iter().map(|h| h.join().unwrap()).collect();
+
+    // Every caller got the same answer...
+    for r in &results {
+        assert_eq!(&**r, b"THE_ANSWER");
+    }
+    // ...but it was executed exactly once (the leader; no one was promoted because
+    // the leader never abandoned).
+    assert_eq!(
+        executions.load(Ordering::SeqCst),
+        1,
+        "single-flight must collapse the stampede to one execution"
+    );
+}
+
+/// An abandoned lease (leader drops without fulfilling) promotes a waiter to leader
+/// rather than wedging the waiters forever.
+#[test]
+fn abandoned_lease_promotes_a_waiter() {
+    let cache = ResultCache::new();
+    let q = "SELECT 1";
+    let scope = ScopeKey::unrestricted();
+    let epochs = PodEpochs::default();
+    let footprint = ReadFootprint::Pods(vec![]);
+
+    // Leader takes the lease then ABANDONS it (drops the guard unfulfilled).
+    let waiter = match cache.lease(q, scope, FMT, footprint.clone(), &epochs, 0) {
+        LeaseOutcome::Lead(lead) => {
+            // Open a concurrent waiter on the SAME key before abandoning.
+            let w = match cache.lease(q, scope, FMT, footprint.clone(), &epochs, 0) {
+                LeaseOutcome::Wait(w) => w,
+                other => panic!("expected Wait, got {}", outcome_name(&other)),
+            };
+            drop(lead); // abandon
+            w
+        }
+        other => panic!("expected Lead, got {}", outcome_name(&other)),
+    };
+
+    // The waiter is promoted (no bytes were published) and can now fulfill.
+    match waiter.wait(footprint) {
+        WaitOutcome::Promoted(guard) => {
+            let bytes = guard.fulfill(b("RECOVERED"), &epochs, 0);
+            assert_eq!(&*bytes, b"RECOVERED");
+        }
+        WaitOutcome::Bytes(_) => panic!("waiter should have been promoted after abandon"),
+    }
+    assert_eq!(&*cache.get(q, scope, FMT, &epochs, 0).expect("now cached"), b"RECOVERED");
+}
+
+/// Byte-budget LRU: with a tiny budget, inserting past it evicts the
+/// least-recently-used entry; a recently-touched entry survives.
+#[test]
+fn lru_eviction_under_byte_budget() {
+    // Budget holds ~2 of these 100-byte bodies.
+    let cache = ResultCache::with_config(CacheConfig {
+        max_bytes: 250,
+        max_entry_bytes: 200,
+        rename_variables: false,
+    });
+    let epochs = PodEpochs::default();
+    let scope = ScopeKey::unrestricted();
+    let body = b(&"x".repeat(100));
+
+    let insert = |q: &str| {
+        if let LeaseOutcome::Lead(g) =
+            cache.lease(q, scope, FMT, ReadFootprint::Pods(vec![]), &epochs, 0)
+        {
+            g.fulfill(body.clone(), &epochs, 0);
+        }
+    };
+
+    insert("Q1");
+    insert("Q2");
+    // Touch Q1 so it is more-recently-used than Q2.
+    assert!(cache.get("Q1", scope, FMT, &epochs, 0).is_some());
+    // Insert Q3 → over budget (300 > 250) → evict the LRU, which is now Q2.
+    insert("Q3");
+
+    assert!(cache.get("Q1", scope, FMT, &epochs, 0).is_some(), "Q1 (recently used) survives");
+    assert!(cache.get("Q3", scope, FMT, &epochs, 0).is_some(), "Q3 (just inserted) present");
+    assert!(cache.get("Q2", scope, FMT, &epochs, 0).is_none(), "Q2 (LRU) was evicted");
+    assert!(cache.stats().evictions >= 1);
+    assert!(cache.bytes_used() <= 250, "never exceeds the byte budget");
+}
+
+/// Admission: a body larger than `max_entry_bytes` is never cached (oversize /
+/// streaming results, §6.3) — but the bytes are still returned to the caller.
+#[test]
+fn oversize_body_is_not_admitted() {
+    let cache = ResultCache::with_config(CacheConfig {
+        max_bytes: 1_000_000,
+        max_entry_bytes: 64,
+        rename_variables: false,
+    });
+    let epochs = PodEpochs::default();
+    let scope = ScopeKey::unrestricted();
+    let big = b(&"y".repeat(1000)); // > 64
+
+    let returned = match cache.lease(
+        "BIG",
+        scope,
+        FMT,
+        ReadFootprint::Pods(vec![]),
+        &epochs,
+        0,
+    ) {
+        LeaseOutcome::Lead(g) => g.fulfill(big.clone(), &epochs, 0),
+        other => panic!("expected Lead, got {}", outcome_name(&other)),
+    };
+    // Caller still got the bytes...
+    assert_eq!(returned.len(), 1000);
+    // ...but nothing was retained.
+    assert!(cache.is_empty(), "oversize body must not be admitted");
+    assert_eq!(cache.stats().admission_rejects, 1);
+    assert!(cache.get("BIG", scope, FMT, &epochs, 0).is_none());
+}
+
+/// The result format is part of the key: the same query in two media is two bodies.
+#[test]
+fn format_is_part_of_the_key() {
+    let cache = ResultCache::new();
+    let epochs = PodEpochs::default();
+    let scope = ScopeKey::unrestricted();
+    let q = "SELECT * WHERE { ?s ?p ?o }";
+
+    if let LeaseOutcome::Lead(g) =
+        cache.lease(q, scope, FMT, ReadFootprint::Pods(vec![]), &epochs, 0)
+    {
+        g.fulfill(b("JSON"), &epochs, 0);
+    }
+    // A different format misses (it would be a different serialization).
+    assert!(cache.get(q, scope, "text/csv", &epochs, 0).is_none());
+    assert!(cache.get(q, scope, FMT, &epochs, 0).is_some());
+}
+
+/// Canonicalization: whitespace-only differences hit the same entry (label-safe
+/// default).
+#[test]
+fn whitespace_variants_hit_same_entry() {
+    let cache = ResultCache::new();
+    let epochs = PodEpochs::default();
+    let scope = ScopeKey::unrestricted();
+
+    if let LeaseOutcome::Lead(g) = cache.lease(
+        "SELECT ?x WHERE { ?x ?p ?o }",
+        scope,
+        FMT,
+        ReadFootprint::Pods(vec![]),
+        &epochs,
+        0,
+    ) {
+        g.fulfill(b("R"), &epochs, 0);
+    }
+    // Reindented / re-spaced form of the SAME query hits.
+    assert!(
+        cache
+            .get("SELECT   ?x\nWHERE {\t?x ?p ?o }", scope, FMT, &epochs, 0)
+            .is_some(),
+        "whitespace-normalized query must hit the same entry"
+    );
+}
+
+fn outcome_name(o: &LeaseOutcome) -> &'static str {
+    match o {
+        LeaseOutcome::Hit(_) => "Hit",
+        LeaseOutcome::Lead(_) => "Lead",
+        LeaseOutcome::Wait(_) => "Wait",
+    }
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -190,6 +190,21 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   that complementary hole. Pass `None` on either to opt back out of that guard.
 - Re-exports for cache layers/tests: `PinnedGen`, `GLOBAL_POD: &str`
   (`"urn:sparq:pod:global"`), and `sparq_serve::{Epoch, PodEpochs, PodId}`.
+- **Response-bytes result cache** (opt-in, `sparq-serve`'s `result-cache` feature,
+  OFF by default — [OPUS-4.8] sq-jluc). A serving-layer cache from a request
+  *identity* to the pre-serialized response body, distinct from `sparq-engine`'s
+  in-engine algebra-keyed `result-cache`. Public surface (feature-gated):
+  `sparq_serve::{ResultCache, CacheConfig, ScopeKey, ReadFootprint, LeaseOutcome,
+  CacheStats}`. **Key = canonical-query × visibility-scope × per-pod epoch-vector**
+  (`ResultCache::lease`/`get`): the **scope** is the identity of the accessible
+  graph set (`ScopeKey::of_graphs(AuthIndex::accessible(session, mode))`), **never**
+  the WebID — bytes cached for one access scope can never be served to another (an
+  access-control correctness invariant, *not* a privacy guarantee). Invalidation is
+  per-pod epoch bumps (`ReadFootprint::Pods`) or the global generation
+  (`ReadFootprint::Unbounded`); single-flight leases dedup a stampede; a byte-budget
+  LRU + admission bound keeps it from caching oversize/streaming bodies. Wiring it
+  into the axum endpoint and the canonical perf-validation are follow-ups (the perf
+  targets need a canonical host).
 - Serializer/negotiation helpers (always compiled, no `server` feature): module
   `sparq_server::negotiate` — `fn negotiate(accept: Option<&str>) -> Format`,
   `fn negotiate_graph(accept: Option<&str>) -> GraphFormat`; module


### PR DESCRIPTION
> 🤖 **SPARQ agent** (one of several @jeswr runs on this account).

Closes **sq-jluc** (#904). Maintainer green-light: "Green light, please proceed."

Response-bytes result cache for the serving path (`sparq-serve`), **off by default** (opt-in feature). Cache key = (canonical-query hash × visibility-scope hash × per-pod epoch-vector hash); visibility-scope keyed off `AuthIndex::accessible` so cached bytes never cross an access-control boundary (a correctness obligation, not itself a privacy guarantee). Per-pod epoch-bump invalidation, single-flight/lease dedup, bounded byte-budget LRU + admission.

**Recovery note:** the implementing agent committed this work (`6c81da2f`) + pushed the branch but hit the account weekly-limit before opening the PR; I (the orchestrator) am opening it from the recovered branch. **CI on this PR IS the gate verification** — not yet independently re-gated by me.

**HONESTY / perf:** the design's throughput targets require a CANONICAL host; this work-box is **NON-CANONICAL** and cannot produce those numbers — no perf figure is baked into docs/tests, and **perf validation is canonical-pending**. Auto-merge intentionally **OFF** — arm only after canonical validation or maintainer acceptance of indicative numbers.
