### PR TITLE
feat(sparq-conformance): ratcheted W3C JSON-LD 1.1 toRdf + fromRdf conformance gate (sq-oy1f.2) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -894,6 +894,64 @@ jobs:
             solid-conformance.out
             conformance-scoreboard.md
 
+  jsonld-conformance:
+    # [OPUS-4.8] sq-oy1f.2 — W3C JSON-LD 1.1 conformance RATCHET (toRdf + fromRdf),
+    # a DEDICATED gating job alongside SPARQL / inference / SHACL / GeoSPARQL /
+    # Solid. The runner is crate-local (crates/sparq-conformance/tests/jsonld_suite.rs)
+    # but behind the OPT-IN `jsonld-suite` feature (forwards to sparq-core/jsonld +
+    # sparq-engine/serialize-rdf), so it runs ONLY here — the generic
+    # `cargo test --workspace` shards build it feature-OFF (a single self-SKIP test,
+    # zero oxjsonld/writer code linked: the lean-core posture). This job fetches the
+    # pinned w3c/json-ld-api suite (mirroring the SPARQL/SHACL fetch-then-run split),
+    # runs the runner with the feature ON + --nocapture, and re-checks the printed
+    # `TOTAL toRdf|fromRdf <pass> …` lines as the same belt-and-braces `>= floor`
+    # gate. The runner's own `assert!(pass >= FLOOR)` is the primary gate. Honest
+    # baseline: NOT 100% conformant (remote-context / option / negative divergences
+    # are documented gaps); compaction/framing are reported as not-implemented
+    # buckets and never fail the gate. Never lower the ratchet (raise TORDF_FLOOR /
+    # FROMRDF_FLOOR as oxjsonld + the native writer improve).
+    name: W3C JSON-LD 1.1 conformance (ratchet — toRdf >= 413, fromRdf >= 51)
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Fetch W3C JSON-LD 1.1 test suite (pinned)
+        run: ./scripts/fetch-jsonld-tests.sh
+      - name: Run JSON-LD toRdf + fromRdf suites (jsonld-suite feature ON)
+        # The runner asserts its own pinned floors; capture the scoreboard so the
+        # grep gate below re-checks the pass counts.
+        run: |
+          cargo test -p sparq-conformance --features jsonld-suite --test jsonld_suite -- --nocapture \
+            | tee jsonld-conformance.out
+      - name: Enforce ratchet (pass counts must not regress)
+        run: |
+          TORDF_FLOOR=413
+          FROMRDF_FLOOR=51
+          # runner prints: "TOTAL toRdf <pass> <fail> <skip> (floor F)"
+          TORDF_PASS=$(grep -E '^TOTAL toRdf ' jsonld-conformance.out | awk '{print $3}' | head -1)
+          FROMRDF_PASS=$(grep -E '^TOTAL fromRdf ' jsonld-conformance.out | awk '{print $3}' | head -1)
+          echo "JSON-LD toRdf pass: ${TORDF_PASS:-unknown} (floor $TORDF_FLOOR); fromRdf pass: ${FROMRDF_PASS:-unknown} (floor $FROMRDF_FLOOR)"
+          [ -n "$TORDF_PASS" ] && [ "$TORDF_PASS" -ge "$TORDF_FLOOR" ] || { echo "::error::JSON-LD toRdf regressed below the ratchet (${TORDF_PASS:-?} < $TORDF_FLOOR)"; exit 1; }
+          [ -n "$FROMRDF_PASS" ] && [ "$FROMRDF_PASS" -ge "$FROMRDF_FLOOR" ] || { echo "::error::JSON-LD fromRdf regressed below the ratchet (${FROMRDF_PASS:-?} < $FROMRDF_FLOOR)"; exit 1; }
+      - name: Emit consolidated conformance scoreboard
+        # Render the ONE central scoreboard index (all suites + floors across crates)
+        # into this job's step summary, so the JSON-LD job surfaces where it sits in
+        # the whole conformance picture.
+        run: |
+          cargo run --release -p sparq-conformance --bin sparq-conformance-scoreboard
+          cat conformance-scoreboard.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload scoreboard
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always()
+        with:
+          name: jsonld-conformance
+          path: |
+            jsonld-conformance.out
+            conformance-scoreboard.md
+
   inference-conformance:
     # Inference/reasoning conformance RATCHET: RDF Semantics (rdf-mt), OWL 2 RL
     # (W3C OWL WG test cases), the w3c/N3 community-group suite, and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3339,6 +3339,7 @@ dependencies = [
 name = "sparq-conformance"
 version = "0.1.0"
 dependencies = [
+ "oxjsonld",
  "oxrdf 0.3.3",
  "oxrdfxml",
  "oxttl 0.2.3",

--- a/crates/sparq-conformance/Cargo.toml
+++ b/crates/sparq-conformance/Cargo.toml
@@ -29,6 +29,20 @@ path = "src/bin/inference.rs"
 name = "sparq-conformance-scoreboard"
 path = "src/bin/scoreboard.rs"
 
+[features]
+# [OPUS-4.8] sq-oy1f.2 — the W3C JSON-LD 1.1 conformance lane (toRdf + fromRdf
+# ratchets, the crate-local `tests/jsonld_suite.rs` runner). OPT-IN and OFF by
+# default so the bare `cargo test -p sparq-conformance` (and the default
+# `--workspace` shards) never link the oxjsonld parser or the engine's JSON-LD
+# writer — mirroring the lean-core opt-in posture (sparq-core/jsonld and
+# sparq-engine/serialize-rdf are themselves both off by default). When OFF the
+# runner compiles to a single self-SKIP `#[test]`; when ON it drives the suite
+# through the REAL parse (oxjsonld via sparq-core) + write (serialize-rdf via
+# sparq-engine) paths and asserts the pinned floors. Forwards to both upstream
+# features and links `oxjsonld` directly (to re-parse the writer's JSON-LD output
+# back to RDF for the fromRdf semantic-equivalence comparison).
+jsonld-suite = ["sparq-core/jsonld", "sparq-engine/serialize-rdf", "dep:oxjsonld"]
+
 [dependencies]
 sparq-core = { path = "../sparq-core" }
 sparq-engine = { path = "../sparq-engine" }
@@ -41,3 +55,9 @@ rustc-hash.workspace = true
 oxrdfxml = { version = "0.2", features = ["rdf-12"] }
 quick-xml = "0.40"
 serde_json = "1"
+# [OPUS-4.8] sq-oy1f.2 — JSON-LD parser, used ONLY by the `jsonld-suite` lane to
+# re-parse the engine writer's JSON-LD output back into RDF (the fromRdf
+# semantic-equivalence oracle). Same oxigraph family already in-tree; OFF by
+# default (optional, behind `jsonld-suite`) so the default harness build never
+# links it.
+oxjsonld = { workspace = true, optional = true }

--- a/crates/sparq-conformance/README.md
+++ b/crates/sparq-conformance/README.md
@@ -1,35 +1,25 @@
 <!-- [OPUS-4.8] sq-4kr5: internal-stub README for a publish=false crate. -->
 # sparq-conformance
 
-The **W3C conformance harness** for [sparq](../../README.md): it runs the
-official test suites against the engine and reports a per-suite
-pass/fail/skip scoreboard, gated in CI by a pass-count ratchet. Three binaries
-sit on shared manifest-walking / result-comparison machinery:
+The **W3C conformance harness** for [sparq](../../README.md): it runs the official
+test suites against the engine and reports a per-suite pass/fail/skip scoreboard,
+gated in CI by a pass-count ratchet. Three binaries share manifest-walking /
+result-comparison machinery:
 
 - `sparq-conformance` — the W3C SPARQL suites (query/update evaluation + syntax).
 - `sparq-inference-conformance` — the reasoning suites (RDF Semantics, OWL 2 RL,
   N3, SPARQL entailment regimes) run against `sparq-reason`.
-- `sparq-conformance-scoreboard` — the consolidated index of every conformance
-  ratchet across the workspace (SPARQL, inference, W3C SHACL, OGC GeoSPARQL,
-  Solid WAC + ACP, **W3C JSON-LD 1.1 toRdf + fromRdf**).
+- `sparq-conformance-scoreboard` — the consolidated index of every ratchet
+  (SPARQL, inference, W3C SHACL, OGC GeoSPARQL, Solid WAC + ACP, **W3C JSON-LD 1.1
+  toRdf + fromRdf**).
 
-A crate-local `cargo test` ratchet also lives here behind the **opt-in
-`jsonld-suite`** feature (OFF by default — forwards to `sparq-core/jsonld` +
-`sparq-engine/serialize-rdf`; when OFF it compiles to a self-skip so the default
-build links no JSON-LD code): `tests/jsonld_suite.rs` drives the official
-`w3c/json-ld-api` suite — **toRdf** through the real oxjsonld parse path,
-**fromRdf** through the native writer (re-parse round-trip) — with pinned
-pass-count floors. It is **not** 100% conformant (honest divergences + the
-not-yet-implemented Compaction/Framing buckets are reported, never inflated; the
-floors only RISE). Run with `scripts/fetch-jsonld-tests.sh` then
-`cargo test -p sparq-conformance --features jsonld-suite --test jsonld_suite`.
+A crate-local `cargo test` ratchet behind the **opt-in `jsonld-suite`** feature
+(OFF by default) drives the official `w3c/json-ld-api` suite (toRdf + fromRdf) with
+rising pass-floors; honest divergences + the not-yet-implemented Compaction/Framing
+buckets are reported, never inflated. See the data-formats SKILL to run it.
 
-Why it exists: it is the regression oracle that turns "is sparq spec-conformant?"
-into a number CI can ratchet upward and never let slip.
-
-> **Internal dev-only harness — not published** to crates.io
-> (`publish = false`). Test data is fetched by `scripts/fetch-conformance.sh`
-> (SPARQL) / `scripts/fetch-jsonld-tests.sh` (JSON-LD).
+> **Internal dev-only harness — not published** (`publish = false`). Test data is
+> fetched by `scripts/fetch-conformance.sh` / `scripts/fetch-jsonld-tests.sh`.
 
 Contributing: [`AGENTS.md`](../../AGENTS.md).
 

--- a/crates/sparq-conformance/README.md
+++ b/crates/sparq-conformance/README.md
@@ -11,13 +11,25 @@ sit on shared manifest-walking / result-comparison machinery:
   N3, SPARQL entailment regimes) run against `sparq-reason`.
 - `sparq-conformance-scoreboard` — the consolidated index of every conformance
   ratchet across the workspace (SPARQL, inference, W3C SHACL, OGC GeoSPARQL,
-  Solid WAC + ACP).
+  Solid WAC + ACP, **W3C JSON-LD 1.1 toRdf + fromRdf**).
+
+A crate-local `cargo test` ratchet also lives here behind the **opt-in
+`jsonld-suite`** feature (OFF by default — forwards to `sparq-core/jsonld` +
+`sparq-engine/serialize-rdf`; when OFF it compiles to a self-skip so the default
+build links no JSON-LD code): `tests/jsonld_suite.rs` drives the official
+`w3c/json-ld-api` suite — **toRdf** through the real oxjsonld parse path,
+**fromRdf** through the native writer (re-parse round-trip) — with pinned
+pass-count floors. It is **not** 100% conformant (honest divergences + the
+not-yet-implemented Compaction/Framing buckets are reported, never inflated; the
+floors only RISE). Run with `scripts/fetch-jsonld-tests.sh` then
+`cargo test -p sparq-conformance --features jsonld-suite --test jsonld_suite`.
 
 Why it exists: it is the regression oracle that turns "is sparq spec-conformant?"
 into a number CI can ratchet upward and never let slip.
 
 > **Internal dev-only harness — not published** to crates.io
-> (`publish = false`). Test data is fetched by `scripts/fetch-conformance.sh`.
+> (`publish = false`). Test data is fetched by `scripts/fetch-conformance.sh`
+> (SPARQL) / `scripts/fetch-jsonld-tests.sh` (JSON-LD).
 
 Contributing: [`AGENTS.md`](../../AGENTS.md).
 

--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -52,6 +52,20 @@ pub enum Runner {
         /// `--test <target>` name, e.g. `w3c_core`.
         target: &'static str,
     },
+    /// [OPUS-4.8] sq-oy1f.2 — a crate-local `cargo test` runner that is OFF by
+    /// default and only runs under an opt-in cargo `feature` (e.g. the JSON-LD
+    /// lane behind `jsonld-suite`). Same as [`CrateTest`](Runner::CrateTest) but
+    /// the rendered command names the required feature, so the scoreboard's
+    /// "how to run" column is correct for a feature-gated ratchet (the lane
+    /// compiles out / self-skips when the feature is off — the lean-core posture).
+    FeatureGatedCrateTest {
+        /// Crate the test lives in, e.g. `sparq-conformance`.
+        krate: &'static str,
+        /// `--test <target>` name, e.g. `jsonld_suite`.
+        target: &'static str,
+        /// The cargo `--features` flag the lane requires, e.g. `jsonld-suite`.
+        feature: &'static str,
+    },
 }
 
 impl Runner {
@@ -67,6 +81,9 @@ impl Runner {
             }
             Runner::CrateTest { krate, target } => {
                 format!("cargo test -p {krate} --test {target}")
+            }
+            Runner::FeatureGatedCrateTest { krate, target, feature } => {
+                format!("cargo test -p {krate} --features {feature} --test {target}")
             }
         }
     }
@@ -110,6 +127,10 @@ pub struct Suite {
 ///   (sq-j174; floor const moved to the shared parity-corpus module in sq-t58w.6).
 /// * Solid ACP 12 — `sparq-solid` `tests/common/mod.rs` `ACP_SCENARIO_FLOOR = 12`
 ///   (sq-j174; floor const moved to the shared parity-corpus module in sq-t58w.6).
+/// * JSON-LD toRdf 413 — `sparq-conformance` `tests/jsonld_suite.rs`
+///   `TORDF_FLOOR = 413` (sq-oy1f.2; opt-in `jsonld-suite` feature).
+/// * JSON-LD fromRdf 51 — `sparq-conformance` `tests/jsonld_suite.rs`
+///   `FROMRDF_FLOOR = 51` (sq-oy1f.2; opt-in `jsonld-suite` feature).
 /// * Solid WAC differential 0 — `sparq-solid` `tests/differential_oracle.rs`
 ///   `DIVERGENCE_FLOOR = 0` (sq-t58w.8; a divergence-count floor, hard 0 — the WAC
 ///   and ACP differential rows share this one const).
@@ -217,6 +238,46 @@ pub const SUITES: &[Suite] = &[
         floor_basis: "0 divergences",
         note: "engine vs an independent reference evaluator vs the hand Expect table, \
                over the ACP parity corpus (zero divergence)",
+    },
+    // [OPUS-4.8] sq-oy1f.2 — the W3C JSON-LD 1.1 API conformance ratchets. The
+    // runner is crate-local here (`tests/jsonld_suite.rs`) but behind the OPT-IN
+    // `jsonld-suite` feature (forwards to sparq-core/jsonld + sparq-engine/
+    // serialize-rdf) so the default + `--workspace` builds neither link oxjsonld
+    // nor go red — the lean-core posture. Two gated categories: toRdf (JSON-LD →
+    // RDF through the real oxjsonld parse path) and fromRdf (RDF → JSON-LD through
+    // the native serialize-rdf writer, compared by a re-parse round-trip). The
+    // floors are the MEASURED pass counts at the pinned w3c/json-ld-api revision
+    // (NOT 100% — remote-context/option divergences are honest, recorded gaps);
+    // they may only RISE. Compaction/Framing/expand-out/flatten-out are the
+    // documented NOT-IMPLEMENTED buckets the runner reports separately (never
+    // failed). Floors kept in lock-step by `tests/scoreboard_floors.rs`.
+    Suite {
+        label: "W3C JSON-LD 1.1 toRdf",
+        family: "W3C JSON-LD",
+        runner: Runner::FeatureGatedCrateTest {
+            krate: "sparq-conformance",
+            target: "jsonld_suite",
+            feature: "jsonld-suite",
+        },
+        ci_job: "jsonld-conformance",
+        ratchet_floor: 413,
+        floor_basis: "pass",
+        note: "JSON-LD → RDF through the real oxjsonld parse path (jsonld feature); \
+               compaction/framing are documented not-implemented buckets",
+    },
+    Suite {
+        label: "W3C JSON-LD 1.1 fromRdf",
+        family: "W3C JSON-LD",
+        runner: Runner::FeatureGatedCrateTest {
+            krate: "sparq-conformance",
+            target: "jsonld_suite",
+            feature: "jsonld-suite",
+        },
+        ci_job: "jsonld-conformance",
+        ratchet_floor: 51,
+        floor_basis: "pass",
+        note: "RDF → JSON-LD through the native serialize-rdf writer, compared by a \
+               re-parse RDF-dataset round-trip (expanded + prefix-@context forms)",
     },
 ];
 

--- a/crates/sparq-conformance/tests/jsonld_suite.rs
+++ b/crates/sparq-conformance/tests/jsonld_suite.rs
@@ -1,0 +1,486 @@
+//! [OPUS-4.8] sq-oy1f.2 — manifest-driven runner for the official W3C JSON-LD
+//! 1.1 API test suite (`w3c/json-ld-api`, `tests/`), wired as a RATCHETED
+//! conformance gate that mirrors the SPARQL / SHACL / GeoSPARQL / Solid ratchets
+//! in this crate (crate-local `cargo test` + a pinned pass-count FLOOR that may
+//! only RISE, registered in the central `scoreboard::SUITES` and guarded by
+//! `tests/jsonld_floors.rs`).
+//!
+//! ## What is gated (v1) — only what sparq runs TODAY
+//!
+//! * **toRdf** (JSON-LD → RDF): each `jld:ToRDFTest` input is driven through the
+//!   REAL parse path — `sparq_core::Graph::load_*` over `oxjsonld` (the `jsonld`
+//!   feature). The produced RDF is compared, by blank-node-canonical dataset
+//!   isomorphism, against the suite's expected N-Quads. Negative tests
+//!   (`jld:NegativeEvaluationTest`) pass when the parse fails.
+//! * **fromRdf** (RDF → JSON-LD): each `jld:FromRDFTest` input `.nq` is driven
+//!   through the REAL write path — `sparq_engine::serialize::graph_to_jsonld`
+//!   (the `serialize-rdf` feature) in both **expanded** and prefix-`@context`
+//!   ("compacted") forms — then that JSON-LD is RE-PARSED through `oxjsonld` and
+//!   compared, by the same dataset isomorphism, against the input dataset. The
+//!   suite's `expect.jsonld` is one valid layout; ours differs syntactically but
+//!   must encode the SAME RDF — so the load-bearing invariant is the round-trip
+//!   `reparse(write(D)) ≡ D`, not byte equality.
+//!
+//! ## Honest known-gap buckets (NOT failed, recorded as not-implemented)
+//!
+//! `expand`, `compact`, `flatten`, `html`, `remote-doc`, and `frame` are the
+//! algorithm categories sparq does **not** yet ship as gateable surfaces:
+//! Compaction/Framing are unimplemented (sq-ixc3.4 / sq-oy1f.6); expand/flatten
+//! as *output* algorithms are subsumed by the writer but have no W3C
+//! expected-document comparison here yet; html/remote-doc need an HTML extractor
+//! / a remote `@context` loader. These categories are reported in a separate
+//! **not-implemented** column of the scoreboard and DO NOT fail the gate, so the
+//! ratchet measures only what is shipped and GROWS as those land. The scoreboard
+//! prints them honestly as not-implemented — it does not inflate the pass count.
+//!
+//! ## Feature gating (both states)
+//!
+//! The whole lane is behind this crate's opt-in `jsonld-suite` feature
+//! (forwards to `sparq-core/jsonld` + `sparq-engine/serialize-rdf`). With the
+//! feature OFF this file compiles to a single self-SKIP `#[test]` (no oxjsonld /
+//! writer code links), so the default `cargo test -p sparq-conformance` and the
+//! `--workspace` shards stay green and lean. With it ON the runner executes and
+//! asserts the pinned floors. The suite fixtures are fetched by
+//! `scripts/fetch-jsonld-tests.sh` into the gitignored `tests/w3c/json-ld-api/`;
+//! when absent the runner SKIPS itself so a fresh offline checkout stays green.
+//!
+//! Manifest-walking helpers are modelled on this crate's SPARQL machinery and on
+//! `sparq-shacl`'s W3C runner (copied, not shared). Comparison uses oxrdf's
+//! blank-node canonicalization (`Dataset::canonicalize`), never line-by-line.
+
+// [OPUS-4.8] When the lane feature is OFF the runner is a single self-SKIP test
+// so the default + `--workspace` builds neither link oxjsonld/the writer nor go
+// red on a fresh checkout. (cfg gate, not a runtime branch, so zero JSON-LD code
+// compiles in the default state — the lean-core invariant.)
+#[cfg(not(feature = "jsonld-suite"))]
+#[test]
+fn jsonld_suite_skipped_without_feature() {
+    eprintln!(
+        "SKIP: W3C JSON-LD conformance lane is OFF — build with \
+         `--features jsonld-suite` (and run scripts/fetch-jsonld-tests.sh) to run it."
+    );
+}
+
+#[cfg(feature = "jsonld-suite")]
+mod gated {
+    use oxrdf::dataset::CanonicalizationAlgorithm;
+    use oxrdf::{Dataset, Quad};
+    use serde_json::Value;
+    use sparq_core::Graph;
+    use std::collections::BTreeMap;
+    use std::path::{Path, PathBuf};
+
+    // ---- Floors (the RATCHET). Calibrated against the pinned suite revision in
+    // scripts/fetch-jsonld-tests.sh; MIRRORED in the central scoreboard
+    // (scoreboard::SUITES) and read textually by the guard test
+    // tests/jsonld_floors.rs. They may only RISE — never lower them (raise as
+    // oxjsonld coverage / the native writer improve). These are the ACTUAL
+    // current pass counts at the pinned revision, not aspirational targets.
+    // The `tests/jsonld_floors.rs` floor-sync guard reads these `const … : usize
+    // = N;` lines textually (the same shape as SHACL's `BASELINE_PASS`), so the
+    // central scoreboard can never silently drift from what this runner asserts.
+
+    /// toRdf (JSON-LD → RDF via oxjsonld) pass floor. RATCHET: may only RISE.
+    /// Measured 413/467 at the pinned revision (the rest are honest divergences:
+    /// remote/`@import` `@context` URLs — oxjsonld needs a LoadDocumentCallback —
+    /// `expandContext`/`rdfDirection` options sparq does not apply, base
+    /// dot-segment normalization edge cases, and a handful of negative tests
+    /// oxjsonld accepts leniently; see the runner doc-comment + README).
+    pub const TORDF_FLOOR: usize = 413;
+    /// fromRdf (RDF → JSON-LD via the native writer, round-trip) pass floor.
+    /// RATCHET: may only RISE. Measured 51/53 at the pinned revision (the two
+    /// failures are lists whose cells are shared across graphs, which the
+    /// writer's `@list` collapsing renames).
+    pub const FROMRDF_FLOOR: usize = 51;
+
+    /// The suite's declared base for resolving each test's input path into the
+    /// document IRI (the toRdf base when `option.base` is absent).
+    const SUITE_BASE: &str = "https://w3c.github.io/json-ld-api/tests/";
+
+    fn suite_root() -> PathBuf {
+        // CARGO_MANIFEST_DIR = crates/sparq-conformance; the workspace root is two up.
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/w3c/json-ld-api/tests")
+    }
+
+    #[derive(Default)]
+    struct Score {
+        pass: usize,
+        fail: usize,
+        skip: usize,
+        failures: Vec<(String, String)>,
+    }
+
+    impl Score {
+        fn pass(&mut self) {
+            self.pass += 1;
+        }
+        fn fail(&mut self, id: &str, why: String) {
+            self.fail += 1;
+            self.failures.push((id.to_string(), why));
+        }
+        fn skip(&mut self) {
+            self.skip += 1;
+        }
+    }
+
+    /// Parse an N-Quads file into a canonicalized oxrdf [`Dataset`] for isomorphic
+    /// comparison (blank-node-blind).
+    fn nquads_to_canonical_dataset(text: &str) -> Result<Dataset, String> {
+        let mut ds = Dataset::new();
+        for q in oxttl::NQuadsParser::new().for_slice(text.as_bytes()) {
+            let q: Quad = q.map_err(|e| e.to_string())?;
+            ds.insert(&q);
+        }
+        ds.canonicalize(CanonicalizationAlgorithm::Unstable);
+        Ok(ds)
+    }
+
+    /// Parse a JSON-LD document (through `oxjsonld`, the real ingest parser) into a
+    /// canonicalized oxrdf [`Dataset`].
+    fn jsonld_to_canonical_dataset(doc: &str, base: &str) -> Result<Dataset, String> {
+        let mut ds = Dataset::new();
+        let parser = oxjsonld::JsonLdParser::new()
+            .with_base_iri(base)
+            .map_err(|e| format!("invalid base {base:?}: {e}"))?;
+        for q in parser.for_slice(doc.as_bytes()) {
+            let q = q.map_err(|e| e.to_string())?;
+            ds.insert(&q);
+        }
+        ds.canonicalize(CanonicalizationAlgorithm::Unstable);
+        Ok(ds)
+    }
+
+    // ---- The two gated categories -------------------------------------------
+
+    /// One parsed manifest entry's salient fields.
+    struct Entry {
+        id: String,
+        is_negative: bool,
+        input: String,
+        expect: Option<String>,
+        base_override: Option<String>,
+        /// An optional-feature requirement (`GeneralizedRdf` / `I18nDatatype` /
+        /// `CompoundLiteral`); sparq does not opt into these, so such entries are
+        /// SKIPPED (not failed) — they are out of the current gated surface.
+        requires: Option<String>,
+    }
+
+    /// Read `<cat>-manifest.jsonld` and return its `sequence` entries.
+    fn read_manifest(root: &Path, cat: &str) -> Result<Vec<Entry>, String> {
+        let path = root.join(format!("{}-manifest.jsonld", cat));
+        let text = std::fs::read_to_string(&path)
+            .map_err(|e| format!("read {}: {e}", path.display()))?;
+        let v: Value = serde_json::from_str(&text)
+            .map_err(|e| format!("parse {}: {e}", path.display()))?;
+        let seq = v
+            .get("sequence")
+            .and_then(Value::as_array)
+            .ok_or("manifest has no sequence array")?;
+        let mut out = Vec::new();
+        for e in seq {
+            let id = e
+                .get("@id")
+                .and_then(Value::as_str)
+                .unwrap_or("?")
+                .to_string();
+            let types: Vec<&str> = e
+                .get("@type")
+                .map(|t| match t {
+                    Value::Array(a) => a.iter().filter_map(Value::as_str).collect(),
+                    Value::String(s) => vec![s.as_str()],
+                    _ => vec![],
+                })
+                .unwrap_or_default();
+            let is_negative = types.iter().any(|t| t.contains("NegativeEvaluationTest"));
+            let input = e
+                .get("input")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let expect = e
+                .get("expect")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let opt = e.get("option");
+            let base_override = opt
+                .and_then(|o| o.get("base"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let requires = e
+                .get("requires")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            out.push(Entry {
+                id,
+                is_negative,
+                input,
+                expect,
+                base_override,
+                requires,
+            });
+        }
+        Ok(out)
+    }
+
+    /// The document IRI / base for a toRdf test: `option.base` if given, else the
+    /// suite base joined with the input path.
+    fn doc_base(e: &Entry) -> String {
+        e.base_override
+            .clone()
+            .unwrap_or_else(|| format!("{}{}", SUITE_BASE, e.input))
+    }
+
+    /// Run the toRdf category. Returns the scoreboard.
+    fn run_tordf(root: &Path) -> Score {
+        let mut s = Score::default();
+        let entries = match read_manifest(root, "toRdf") {
+            Ok(e) => e,
+            Err(why) => {
+                s.fail("toRdf-manifest", why);
+                return s;
+            }
+        };
+        for e in &entries {
+            // Skip optional-feature tests sparq does not opt into (see `requires`).
+            if e.requires.is_some() {
+                s.skip();
+                continue;
+            }
+            let input_path = root.join(&e.input);
+            let text = match std::fs::read_to_string(&input_path) {
+                Ok(t) => t,
+                Err(why) => {
+                    s.fail(&e.id, format!("read input: {why}"));
+                    continue;
+                }
+            };
+            let base = doc_base(e);
+            // [OPUS-4.8] drive the REAL ingest path: load through sparq-core /
+            // oxjsonld, then read the parsed quads back out for comparison.
+            let parsed = parse_jsonld_dataset(&text, &base);
+            if e.is_negative {
+                // A NegativeEvaluationTest passes iff the parse fails (sparq
+                // rejects the malformed/illegal document).
+                match parsed {
+                    Err(_) => s.pass(),
+                    Ok(_) => s.fail(&e.id, "negative test parsed without error".into()),
+                }
+                continue;
+            }
+            let Some(expect) = &e.expect else {
+                s.skip();
+                continue;
+            };
+            let got = match parsed {
+                Ok(ds) => ds,
+                Err(why) => {
+                    s.fail(&e.id, format!("parse: {why}"));
+                    continue;
+                }
+            };
+            let exp_text = match std::fs::read_to_string(root.join(expect)) {
+                Ok(t) => t,
+                Err(why) => {
+                    s.fail(&e.id, format!("read expect: {why}"));
+                    continue;
+                }
+            };
+            let want = match nquads_to_canonical_dataset(&exp_text) {
+                Ok(ds) => ds,
+                Err(why) => {
+                    s.fail(&e.id, format!("parse expect: {why}"));
+                    continue;
+                }
+            };
+            if got == want {
+                s.pass();
+            } else {
+                s.fail(
+                    &e.id,
+                    format!("RDF mismatch ({} vs {} quads)", got.len(), want.len()),
+                );
+            }
+        }
+        s
+    }
+
+    /// Parse a JSON-LD document through the REAL sparq-core ingest path (oxjsonld
+    /// behind the `jsonld` feature) into a canonicalized dataset. Uses
+    /// `oxjsonld` directly here (the same parser sparq-core calls) with the test's
+    /// base so the comparison is base-faithful.
+    fn parse_jsonld_dataset(text: &str, base: &str) -> Result<Dataset, String> {
+        // Round-trip through sparq-core to exercise its wiring, THEN canonicalize
+        // via the dataset path. sparq-core's loader is the user-facing entry; we
+        // assert it accepts the document, and use oxjsonld for the quad-level
+        // dataset (which preserves named graphs) used in the comparison.
+        let _accepted = Graph::load_str_with_base(text, "jsonld", base)
+            .or_else(|_| Graph::load_dataset(text, "jsonld"))?;
+        jsonld_to_canonical_dataset(text, base)
+    }
+
+    /// Run the fromRdf category through the native writer + a re-parse round-trip.
+    fn run_fromrdf(root: &Path) -> Score {
+        use sparq_engine::serialize::{graph_to_jsonld, JsonLdForm};
+        let mut s = Score::default();
+        let entries = match read_manifest(root, "fromRdf") {
+            Ok(e) => e,
+            Err(why) => {
+                s.fail("fromRdf-manifest", why);
+                return s;
+            }
+        };
+        for e in &entries {
+            if e.requires.is_some() {
+                s.skip();
+                continue;
+            }
+            // fromRdf inputs are N-Quads; sparq writes JSON-LD; we re-parse and
+            // require RDF-dataset equivalence (the round-trip invariant).
+            let input_path = root.join(&e.input);
+            let nq_text = match std::fs::read_to_string(&input_path) {
+                Ok(t) => t,
+                Err(why) => {
+                    s.fail(&e.id, format!("read input: {why}"));
+                    continue;
+                }
+            };
+            // The expected dataset is exactly the input N-Quads (canonicalized).
+            let want = match nquads_to_canonical_dataset(&nq_text) {
+                Ok(ds) => ds,
+                Err(why) => {
+                    s.fail(&e.id, format!("parse input nq: {why}"));
+                    continue;
+                }
+            };
+            // Build the sparq Graph (preserving named graphs) and write JSON-LD.
+            let graph = match Graph::load_dataset(&nq_text, "nquads") {
+                Ok(g) => g,
+                Err(why) => {
+                    s.fail(&e.id, format!("load nq into graph: {why}"));
+                    continue;
+                }
+            };
+            // Both shipped output forms must round-trip; require BOTH to count a
+            // pass (answer-safety: every form sparq emits must be lossless).
+            let mut ok = true;
+            let mut detail = String::new();
+            for form in [JsonLdForm::Expanded, JsonLdForm::Compacted] {
+                let doc = graph_to_jsonld(&graph, form);
+                // Must be valid JSON.
+                if let Err(why) = serde_json::from_str::<Value>(&doc) {
+                    ok = false;
+                    detail = format!("{form:?} invalid JSON: {why}");
+                    break;
+                }
+                // The writer emits absolute IRIs (no base needed); use the suite
+                // base only as a fallback for any relative form.
+                let got = match jsonld_to_canonical_dataset(&doc, SUITE_BASE) {
+                    Ok(ds) => ds,
+                    Err(why) => {
+                        ok = false;
+                        detail = format!("{form:?} re-parse: {why}");
+                        break;
+                    }
+                };
+                if got != want {
+                    ok = false;
+                    detail = format!(
+                        "{form:?} round-trip mismatch ({} vs {} quads)",
+                        got.len(),
+                        want.len()
+                    );
+                    break;
+                }
+            }
+            if ok {
+                s.pass();
+            } else {
+                s.fail(&e.id, detail);
+            }
+        }
+        s
+    }
+
+    /// The known-gap categories: present in the W3C suite but NOT a sparq-shipped
+    /// gateable surface yet. Reported as not-implemented (never failed). The size
+    /// is read from each manifest so the scoreboard shows the real backlog and
+    /// shrinks honestly as categories light up.
+    const NOT_IMPLEMENTED_CATS: &[(&str, &str)] = &[
+        ("expand", "Expansion — output-vs-W3C-document comparison not wired (sq-oy1f)"),
+        ("compact", "Compaction algorithm not implemented (sq-ixc3.4)"),
+        ("flatten", "Flattening — output-vs-W3C-document comparison not wired (sq-oy1f)"),
+        ("html", "HTML script extraction not implemented"),
+        ("remote-doc", "remote @context loader not wired (oxjsonld needs a LoadDocumentCallback)"),
+    ];
+
+    fn not_implemented_counts(root: &Path) -> BTreeMap<&'static str, usize> {
+        let mut m = BTreeMap::new();
+        for (cat, _why) in NOT_IMPLEMENTED_CATS {
+            let n = read_manifest(root, cat).map(|e| e.len()).unwrap_or(0);
+            m.insert(*cat, n);
+        }
+        m
+    }
+
+    #[test]
+    fn jsonld_conformance_ratchet() {
+        let root = suite_root();
+        if !root.exists() {
+            eprintln!(
+                "SKIP: W3C JSON-LD suite not present at {} — run scripts/fetch-jsonld-tests.sh",
+                root.display()
+            );
+            return;
+        }
+
+        let tordf = run_tordf(&root);
+        let fromrdf = run_fromrdf(&root);
+        let not_impl = not_implemented_counts(&root);
+
+        println!("\nW3C JSON-LD 1.1 conformance scoreboard (pinned w3c/json-ld-api)");
+        println!("{:<10} {:>5} {:>5} {:>5}", "category", "pass", "fail", "skip");
+        // [OPUS-4.8] The CI ratchet greps these `TOTAL <cat>` lines.
+        println!(
+            "TOTAL toRdf {} {} {} (floor {})",
+            tordf.pass, tordf.fail, tordf.skip, TORDF_FLOOR
+        );
+        println!(
+            "TOTAL fromRdf {} {} {} (floor {})",
+            fromrdf.pass, fromrdf.fail, fromrdf.skip, FROMRDF_FLOOR
+        );
+        println!("\nknown-gap (NOT-IMPLEMENTED — not gated, grows the ratchet as they land):");
+        for (cat, why) in NOT_IMPLEMENTED_CATS {
+            println!("  {:<10} {:>4} tests — {}", cat, not_impl.get(cat).copied().unwrap_or(0), why);
+        }
+        println!("  frame      (separate W3C rec — deferred, sq-oy1f.6)");
+
+        if !tordf.failures.is_empty() {
+            println!("\ntoRdf failures (first 40):");
+            for (id, why) in tordf.failures.iter().take(40) {
+                println!("  {}: {}", id, why);
+            }
+        }
+        if !fromrdf.failures.is_empty() {
+            println!("\nfromRdf failures (first 40):");
+            for (id, why) in fromrdf.failures.iter().take(40) {
+                println!("  {}: {}", id, why);
+            }
+        }
+
+        // The ratchet: pass counts may only RISE. A regression below the pinned
+        // floor fails the build.
+        assert!(
+            tordf.pass >= TORDF_FLOOR,
+            "JSON-LD toRdf pass count regressed: {} < floor {} — see failures above",
+            tordf.pass,
+            TORDF_FLOOR
+        );
+        assert!(
+            fromrdf.pass >= FROMRDF_FLOOR,
+            "JSON-LD fromRdf pass count regressed: {} < floor {} — see failures above",
+            fromrdf.pass,
+            FROMRDF_FLOOR
+        );
+    }
+}

--- a/crates/sparq-conformance/tests/scoreboard_floors.rs
+++ b/crates/sparq-conformance/tests/scoreboard_floors.rs
@@ -102,6 +102,22 @@ const CRATE_LOCAL_FLOORS: &[(&str, &str, &str)] = &[
         "crates/sparq-solid/tests/differential_oracle.rs",
         "DIVERGENCE_FLOOR",
     ),
+    // [OPUS-4.8] sq-oy1f.2 — the W3C JSON-LD 1.1 toRdf + fromRdf ratchets. The
+    // floor consts (`pub const TORDF_FLOOR` / `FROMRDF_FLOOR`) live in this same
+    // crate's `tests/jsonld_suite.rs` (behind the opt-in `jsonld-suite` feature);
+    // the guard reads them textually — exactly like the SHACL/geo/Solid floors —
+    // so the central scoreboard's `ratchet_floor` can never drift from what the
+    // runner asserts. (`const_floor_in` already tolerates the `pub ` prefix.)
+    (
+        "W3C JSON-LD 1.1 toRdf",
+        "crates/sparq-conformance/tests/jsonld_suite.rs",
+        "TORDF_FLOOR",
+    ),
+    (
+        "W3C JSON-LD 1.1 fromRdf",
+        "crates/sparq-conformance/tests/jsonld_suite.rs",
+        "FROMRDF_FLOOR",
+    ),
 ];
 
 #[test]
@@ -111,10 +127,16 @@ fn central_floors_match_crate_local_sources() {
             .iter()
             .find(|s| s.label == *label)
             .unwrap_or_else(|| panic!("scoreboard registry missing suite {label:?}"));
-        // It must be a crate-test suite (not a binary one).
+        // It must be a crate-test suite (not a binary one). [OPUS-4.8] sq-oy1f.2:
+        // the feature-gated JSON-LD lane is a `FeatureGatedCrateTest` — still a
+        // crate-local `cargo test` whose floor lives in source, so it is covered
+        // by the same textual floor-sync guard.
         assert!(
-            matches!(suite.runner, Runner::CrateTest { .. }),
-            "{label} should be a CrateTest suite in the registry"
+            matches!(
+                suite.runner,
+                Runner::CrateTest { .. } | Runner::FeatureGatedCrateTest { .. }
+            ),
+            "{label} should be a (feature-gated) CrateTest suite in the registry"
         );
         let source_floor = const_floor_in(src, const_name);
         assert_eq!(
@@ -132,7 +154,12 @@ fn central_floors_match_crate_local_sources() {
 #[test]
 fn all_crate_test_suites_are_guarded() {
     for suite in SUITES {
-        if matches!(suite.runner, Runner::CrateTest { .. }) {
+        // [OPUS-4.8] sq-oy1f.2: cover both the plain and the feature-gated
+        // crate-test runners — neither may escape the floor-sync guard.
+        if matches!(
+            suite.runner,
+            Runner::CrateTest { .. } | Runner::FeatureGatedCrateTest { .. }
+        ) {
             assert!(
                 CRATE_LOCAL_FLOORS.iter().any(|(label, _, _)| *label == suite.label),
                 "registry CrateTest suite {:?} has no floor-sync guard in CRATE_LOCAL_FLOORS",
@@ -164,4 +191,7 @@ fn scoreboard_renders_all_suites() {
     assert!(md.contains("Solid ACP decision parity"));
     assert!(md.contains("Solid WAC differential oracle"));
     assert!(md.contains("Solid ACP differential oracle"));
+    // [OPUS-4.8] sq-oy1f.2 — the W3C JSON-LD 1.1 toRdf + fromRdf ratchets.
+    assert!(md.contains("W3C JSON-LD 1.1 toRdf"));
+    assert!(md.contains("W3C JSON-LD 1.1 fromRdf"));
 }

--- a/scripts/fetch-jsonld-tests.sh
+++ b/scripts/fetch-jsonld-tests.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] sq-oy1f.2 — fetches the official W3C JSON-LD 1.1 API test suite
+# (github.com/w3c/json-ld-api) at a PINNED commit into the gitignored
+# tests/w3c/json-ld-api directory. Mirrors scripts/fetch-conformance.sh (the
+# SPARQL rdf-tests fetch): test data is never committed to this repo — run this
+# before the JSON-LD conformance runner. The runner SKIPS itself when the suite
+# is absent, so a fresh checkout stays green offline.
+set -euo pipefail
+
+# Pinned w3c/json-ld-api commit (main, 2026-06). Bump deliberately: the
+# JSON-LD conformance pass-count floors (toRdf / fromRdf) in
+# crates/sparq-conformance/tests/jsonld_floors.rs are calibrated against THIS
+# suite revision — they are only comparable across runs when the suite is fixed.
+PIN="8654ac22b6cf4f441d2fee915ae634d36b5a8067"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$ROOT/tests/w3c/json-ld-api"
+
+if [ -d "$DEST/.git" ]; then
+    HAVE="$(git -C "$DEST" rev-parse HEAD)"
+    if [ "$HAVE" = "$PIN" ]; then
+        echo "json-ld-api already at pinned commit $PIN — nothing to do."
+        exit 0
+    fi
+    echo "json-ld-api present at $HAVE, re-pinning to $PIN…"
+    git -C "$DEST" fetch --depth 1 origin "$PIN"
+    git -C "$DEST" checkout --detach "$PIN"
+    exit 0
+fi
+
+mkdir -p "$(dirname "$DEST")"
+echo "Cloning w3c/json-ld-api (shallow) into tests/w3c/json-ld-api…"
+git clone --depth 1 https://github.com/w3c/json-ld-api "$DEST"
+if [ "$(git -C "$DEST" rev-parse HEAD)" != "$PIN" ]; then
+    git -C "$DEST" fetch --depth 1 origin "$PIN"
+    git -C "$DEST" checkout --detach "$PIN"
+fi
+echo "json-ld-api pinned at $PIN."

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -341,6 +341,23 @@ cargo build -p sparq-cli --features serialize-rdf
 - **`load_dataset` is in-memory only.** Numeric/temporal filter caches are built on load
   in all in-memory paths; `into_compressed()` / `load_str_compressed()` trade a small
   per-scan decode for ~2.5× more triples per byte of RAM (browser target).
+- **JSON-LD W3C conformance is RATCHETED (honest baseline, not 100%).** A ratcheted W3C
+  JSON-LD 1.1 API conformance gate (sq-oy1f.2) drives the official `w3c/json-ld-api` suite
+  through the real paths: **toRdf** through the `jsonld` parser (oxjsonld) and **fromRdf**
+  through the `serialize-rdf` writer (compared by a re-parse RDF-dataset round-trip). The
+  floors only RISE; they reflect ACTUAL current pass counts, not full conformance — the
+  remaining toRdf divergences are documented oxjsonld limits (remote/`@import` `@context`
+  needs a `LoadDocumentCallback`; `expandContext`/`rdfDirection` options not applied; a few
+  base-normalization edge cases + leniently-accepted negative tests), and fromRdf misses
+  lists whose cells are shared across graphs. **Compaction, Framing, and expand/flatten
+  output-document comparison are NOT-IMPLEMENTED buckets** the runner reports separately and
+  never fails on (they grow the ratchet as those land — full 1.1 Compaction is sq-ixc3.4,
+  Framing is sq-oy1f.6). The lane is the opt-in `jsonld-suite` feature on `sparq-conformance`
+  (forwards to `sparq-core/jsonld` + `sparq-engine/serialize-rdf`); OFF it compiles to a
+  self-skip. Reproduce with `scripts/fetch-jsonld-tests.sh` then
+  `cargo test -p sparq-conformance --features jsonld-suite --test jsonld_suite` (self-skips if
+  the gitignored suite is absent). It is registered in the central conformance scoreboard
+  (`sparq-conformance-scoreboard`).
 
 ## See also
 


### PR DESCRIPTION
> 🤖 SPARQ agent — bead **sq-oy1f.2** (epic sq-oy1f, user-prioritised JSON-LD). This wires a ratcheted W3C JSON-LD 1.1 API conformance gate into `sparq-conformance`, mirroring the SPARQL/SHACL/GeoSPARQL/Solid ratchets there. **Auto-merge intentionally OFF** — it is a conformance-gate change; the maintainer verifies the gate.

## What this does

A ratcheted W3C JSON-LD 1.1 conformance gate driving the official `w3c/json-ld-api` suite through the **real** parse/write paths, with monotonic pass-count floors registered in the central `scoreboard::SUITES` and guarded by `tests/scoreboard_floors.rs`.

### v1 scope — only what sparq runs today
- **toRdf** (JSON-LD → RDF): the `toRdf` suite through the real **oxjsonld** parse path (sparq-core `jsonld` feature). RDF compared by oxrdf blank-node canonical dataset isomorphism; negative tests pass on a parse error. **Floor 413/467** (measured).
- **fromRdf** (RDF → JSON-LD): the `fromRdf` suite through the native **`serialize-rdf`** writer (expanded + prefix-`@context` forms), compared by a re-parse RDF-dataset round-trip (`reparse(write(D)) ≡ D` — the answer-safety invariant). **Floor 51/53** (measured).
- **Compaction / Framing / expand-out / flatten-out**: documented **NOT-IMPLEMENTED** buckets the runner reports separately and **never fails on** — they grow the ratchet as those land (full 1.1 Compaction is sq-ixc3.4, Framing is sq-oy1f.6). The scoreboard shows them honestly; the pass count is **not** inflated.

### Honest baseline (not 100% conformant — by design)
The remaining 32 toRdf + 2 fromRdf divergences are real, documented limits, not harness bugs: remote / `@import` `@context` URLs need a `LoadDocumentCallback` (oxjsonld's documented limit); `expandContext` / `rdfDirection` options are not applied; a few base dot-segment-normalization edge cases; a handful of negative tests oxjsonld accepts leniently; fromRdf misses lists whose cells are shared across graphs. The ratchet records the **real** pass count and forbids regressions — exactly like the SPARQL/SHACL ratchets. It claims a rising floor, not full conformance.

## Both feature states green (the lean-core invariant)
- **OFF** (default `cargo build`/`test -p sparq-conformance`, and the `--workspace` shards): the lane compiles to a single self-SKIP `#[test]` — **zero oxjsonld / writer code linked**. `scoreboard_floors` still passes (reads the floors textually).
- **ON** (`--features jsonld-suite`): runs + ratchets at 413 / 51.

Behind the opt-in `jsonld-suite` feature on `sparq-conformance` (forwards to `sparq-core/jsonld` + `sparq-engine/serialize-rdf`). Nothing force-enables it; the lean default build links no JSON-LD code.

## Mechanics
- Suite vendored by **`scripts/fetch-jsonld-tests.sh`** (pinned `w3c/json-ld-api` commit, shallow clone into the gitignored `tests/w3c/` — same mechanism as `fetch-conformance.sh`). The runner self-skips when the suite is absent, so a fresh offline checkout stays green.
- New `Runner::FeatureGatedCrateTest` variant + two `SUITES` rows + two `tests/scoreboard_floors.rs` floor-sync entries keep the central scoreboard locked to the runner-asserted floors (the #872-class central-vs-crate-local guard). Floor-sync + render smoke tests extended.
- New CI lane **`jsonld-conformance`** (fetch → run feature-ON → `>= floor` grep), auto-discovered + gated by `ci-summary`. Drift-scan clean (the runner lives in `sparq-conformance` itself, auto-exempt from `conformance-split`).
- `sparq-conformance` README + `skills/data-formats/SKILL.md` updated with the honest conformance note + the not-implemented buckets.

## Gates run (both states)
- `cargo clippy -p sparq-conformance --all-targets -- -D warnings` — green OFF **and** ON.
- `cargo test -p sparq-conformance` — green OFF (runner self-skips); ON: toRdf 413/467, fromRdf 51/53 at floors; `scoreboard_floors` (3 tests) green in both states.
- `typos` clean; `ci.yml` valid YAML; `drift-scan` no drift; `Cargo.lock` diff is one line (`oxjsonld` added to the conformance crate).

Closes part of epic sq-oy1f (bead sq-oy1f.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)