### PR TITLE
fix(ci/js): root install so Solid differential test deps resolve — unblock red main js gate (sq-fvz8) [OPUS-4.8]

### DIFF
--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -43,7 +43,19 @@ jobs:
       - name: Install wasm-pack
         run: cargo install wasm-pack --locked
 
-      - name: Install npm dependencies
+      # [OPUS-4.8] sq-fvz8: install the FULL workspace from the repo ROOT, not just the
+      # `js/` member. The cross-language Solid differential oracle (test/solid-differential
+      # .test.mjs, PR #922) imports n3 / @solid/acl-check / @solidlab/policy-engine / rdflib,
+      # which are declared as ROOT devDependencies (deliberately NOT in js/package.json — the
+      # js-sbom lane derives the published @jeswr/sparq SBOM from js/package.json's deps, so
+      # putting test-only deps there would pollute the runtime SBOM, sq-f04e/#887). A member-
+      # scoped `npm ci` (working-directory: js) installs ONLY @jeswr/sparq's own closure and
+      # NOT the root workspace devDeps, so those imports were ERR_MODULE_NOT_FOUND -> red `js`
+      # gate. A root install hoists them into the workspace node_modules where the test (and
+      # the `js`-member build) both resolve them. js/package.json is untouched, so the
+      # published-client SBOM stays clean (runtime tree = {fzstd} only).
+      - name: Install npm dependencies (full workspace, from repo root)
+        working-directory: .
         run: npm ci
 
       - name: Build (wasm-pack + tsc)


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (Opus 4.8, 1M context) working on `jeswr/sparq` CI infrastructure. This is an automated change; @jeswr runs multiple agents on one account.

## P0 STOP-THE-LINE: main `js` gate is RED (bead sq-fvz8)

The `js` gating check fails on main HEAD, so **every open PR's merge-ref inherits the failure** and nothing can merge until this lands.

### Root cause (confirmed)
`js/test/solid-differential.test.mjs` — the cross-language Solid WAC/ACP differential oracle landed in #922 (sq-t58w.9) — hard-imports `n3`, `@solidlab/policy-engine`, `@solid/acl-check` and (transitively) `rdflib`. Those are declared as **root-workspace** `devDependencies`, **deliberately NOT in `js/package.json`**: `scripts/gen-js-sbom.sh` derives the published `@jeswr/sparq` CycloneDX SBOM from `js/package.json`'s declared deps (via `derive-workspace-member-lock.mjs`), so declaring test-only deps there pollutes the runtime (`--omit dev`) SBOM — the exact constraint that drove the relocation in sq-f04e / #887.

But `js.yml` ran `npm ci` with `working-directory: js`, which installs **only** the `@jeswr/sparq` member's own closure (fzstd + the TypeScript devDeps), **not** the root-workspace devDeps. So the test's imports were `ERR_MODULE_NOT_FOUND` → `npm test` exit 1 → red `js` gate.

### Fix (chosen) — root install, keep the test where it is
Install the **full workspace from the repo root** (`working-directory: .`) in the `js` job's install step, so the root-hoisted test deps land in the workspace `node_modules` where both the test **and** the `js`-member build resolve them. `js/package.json` is **untouched**, so the published-client SBOM stays clean.

Why this over moving the test out of `js/`: the deps are already correctly **owned at root** (root `devDependencies`), and the SBOM is already clean because the relocation works as designed — I verified it. Moving the test + fixtures would churn the tree and add a new CI glob for **zero** SBOM benefit. This is the minimal, lowest-risk stop-the-line fix; build/test/pack steps still run from `js/`.

### Verifications (local, on this branch)
- **Test passes:** root `npm ci` (exit 0) installs `n3` / `rdflib` / `@solid/acl-check` / `@solidlab/policy-engine` into `node_modules`; `node --test test/*.test.mjs` → **76 tests, 76 pass, 0 fail** (incl. `solid-differential`). *(The `node --test "glob"` pattern needs Node ≥21; CI uses Node 22 where it expands natively — locally I shell-expanded the glob to emulate it.)*
- **SBOM stays clean:** `bash scripts/gen-js-sbom.sh` exits 0; runtime SBOM = **1 component (`fzstd`)**, dev SBOM = 5; **none** of the test deps appear in either view — identical to before this change.
- **YAML / actionlint:** `js.yml` is valid YAML and `actionlint` clean (exit 0). Only the install step changed (13 +/1 -). The `ci-summary` gate aggregator is unaffected — the check name `js` carries no `advisory`/`informational` token, so it still GATES.

### Compliance posture
No change to the supply-chain posture: the published `@jeswr/sparq` runtime SBOM remains `{fzstd}` only (no test/dev deps leak into the released SBOM). This restores the green `js` gate without weakening any gate.

Note: `js.yml` triggers on `push: branches: [main]` only, so this check re-runs (and goes green) on the **post-merge** main push — it does not run on this PR's `pull_request` event.

Closes sq-fvz8.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
