### PR TITLE
ci(lint): gate workspace clippy --all-features so default-OFF feature-gated lints are caught centrally (sq-4sbk) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,6 +617,28 @@ jobs:
       # A new warning — from new code or a Rust-stable bump that adds a lint — fails CI.
       - name: clippy (deny warnings)
         run: cargo clippy --workspace --all-targets -- -D warnings
+      # [OPUS-4.8] sq-4sbk: clippy -D warnings, WORKSPACE-WIDE, with `--all-features` — the
+      # clippy sibling of the two-state rustdoc gate below. The default-features clippy above
+      # NEVER compiles code inside default-OFF `#[cfg(feature = "…")]` modules (result-cache,
+      # txn, vectorized, service, fedplan, fedclient, odrl-bridge, …), so a clippy lint inside
+      # an opt-in feature module slips the central gate and only surfaces — if at all — via a
+      # feature-matrix.yml leg that happens to enable that exact feature (the legs there clippy
+      # per-crate `-p <crate> --features <set>`). This workspace-wide `--all-features` pass
+      # catches such lints centrally AND the cross-crate feature-unification interactions that a
+      # per-crate `-p` leg structurally cannot see (a default-feature edit that only mis-lints
+      # once the unified all-features build turns another crate's feature on). VERIFIED SOUND on
+      # main before being made gating (sq-4sbk crux check): the workspace has NO `compile_error!`
+      # mutual-exclusion guard and NO `not(feature=…)` *compile-time* assert that breaks under
+      # unification — `cargo clippy --workspace --all-targets --all-features -- -D warnings`
+      # compiles every opt-in crate (sparq-hdt/-gpu/-py/-fedplan-mpc included) and is CLEAN.
+      # The network features (`live`/`embeddings`) only COMPILE reqwest here; no socket is
+      # opened (clippy does not run tests), so they are safe in this lint-only pass. Cost: the
+      # lint job already builds the workspace twice over (default clippy + two rustdoc passes);
+      # this adds only the off-by-default feature code on a warm target dir — a modest increment,
+      # not a second full build (the bulk of the dependency + first-party graph is already
+      # compiled by the default-features clippy above).
+      - name: clippy (deny warnings, workspace — all features)
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
       # [OPUS-4.8] sq-8gsv: rustdoc -D warnings, WORKSPACE-WIDE. A broken/private intra-doc
       # link (e.g. a public item linking to a crate-private const/fn, or an unresolved
       # `[`Foo`]` that renders as literal text) is a rustdoc warning — NOT a clippy/build


### PR DESCRIPTION
> 🤖 **SPARQ agent** (one of several @jeswr runs on this account).

## Summary

Closes the **CI-side half** of the feature-gated clippy/rustdoc-gate prevention class (`sq-4sbk`). The agent-definition half landed in #955; this is the central-gate enforcement.

The `lint` job's clippy gate ran `cargo clippy --workspace --all-targets -- -D warnings` **without `--all-features`**, so a clippy lint inside a default-OFF `#[cfg(feature = "…")]` module (e.g. `result-cache`, `txn`, `vectorized`, `service`, `fedplan`, `fedclient`, `odrl-bridge`, …) was **never compiled by the central gate**. Such a lint would slip the aggregate `ci-summary / gate` and only surface — if at all — via a `feature-matrix.yml` leg that happens to enable that exact feature (those legs clippy *per-crate* `-p <crate> --features <set>`). Two PRs (#926, #936) already hit the rustdoc sibling of this class.

This PR adds **one** workspace-wide step to the gating `lint` job — the clippy twin of the existing two-state rustdoc gate (which already runs `cargo doc --all-features -D warnings`):

```yaml
- name: clippy (deny warnings, workspace — all features)
  run: cargo clippy --workspace --all-targets --all-features -- -D warnings
```

It catches feature-gated lints centrally **and** the cross-crate feature-unification interactions that a per-crate `-p` leg structurally cannot see (a default-feature edit that only mis-lints once the unified build turns another crate's feature on).

## Approach (a) — and why it's safe

The bead required assessing **soundness under cargo feature unification FIRST** (the reference-ci-failure-debugging lesson: a `not(feature=…)` compiled-out assert can panic when the unified build turns the feature on). Verified on `origin/main` before making the step gating:

| Crux check (run on `origin/main`) | Result |
|---|---|
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | **exit 0, CLEAN** (0 lint warnings) — compiled every opt-in crate incl. `sparq-hdt` / `sparq-gpu` / `sparq-py` / `sparq-fedplan-mpc` |
| `cargo test --workspace --all-features --no-run` (compile-only) | **exit 0** — all test binaries compile under unification |
| `compile_error!` mutual-exclusion guards in workspace src | **none** |
| `not(feature=…)` *runtime-assert* tests | **none** (and clippy runs no tests anyway) |

So there is **no feature-unification breakage** → approach (a) is the cheapest and most complete option. (Approach (b) — per-feature clippy legs — is already substantially in place: every `feature-matrix.yml` leg already ends with `cargo clippy -p <crate> --features <set> --all-targets -- -D warnings`. But those `-p` legs cannot see cross-crate unification effects, which (a) does.) The network features `live`/`embeddings` only *compile* `reqwest` under clippy — no socket opens (clippy runs no tests) — so they are safe in this lint-only pass.

## CI-time impact (work-box, illustrative — non-canonical)

The `lint` job already builds the workspace for the default clippy + two rustdoc passes, so the new step runs on a **warm** target dir:

- cold default-features clippy (existing step 1): ~37 s
- **incremental** `--all-features` clippy (this new step, warm dir): **~20 s**

i.e. roughly **+20 s incremental** (only the off-by-default feature code), not a second full build. On the real runner with `Swatinem/rust-cache` the warm-incremental figure is the relevant one. Modest, acceptable. (These are EC2 work-box timings, illustrative of the rough delta only — not canonical.)

## Gate / validity

- Rides the existing `clippy (gate) + fmt (non-blocking)` check name (no `advisory`/`informational` token) → **gates** via the `ci-summary / gate` aggregator with **no edit to `ci-summary.yml`**.
- Sits under the path-filtered `lint` job (`if: needs.changes.outputs.rust_changed == 'true'`) → a doc/CI-only PR still skips it. Preserved.
- `python3 -c "import yaml…"` → **valid YAML**; `actionlint` → **no new findings** (the change is a plain `run:` step, adds no shell; the only pre-existing findings are SC2015 *info* notes on unrelated lines).
- Diff is **purely additive** (one step + its rationale comment).

## Note for the reviewer

Auto-merge is **OFF** by request (CI-gate change). The added step is verified clean on `origin/main`, so it will not red `main`. Please verify the gate yourself, then arm.

Compliance gap closed: feature-gated lints in default-OFF code are now caught by the central required gate (the supply-chain/lint-hygiene posture for opt-in feature code), not silently dependent on a matrix leg happening to enable the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
