### PR TITLE
feat(sparq-canon): SHA-384 hash-profile parity for the rdf12 v2 canon path (generic over Digest) (sq-5i1d)

### DIFF
--- a/crates/sparq-canon/README.md
+++ b/crates/sparq-canon/README.md
@@ -74,12 +74,18 @@ sparq-canon = { path = "crates/sparq-canon", features = ["rdf12-triple-terms"] }
 let nq = sparq_canon::canonicalize_rdf12(&dataset)?;             // quads
 let cg = sparq_canon::canonicalize_triples_rdf12(&triples)?;     // single graph
 let m  = sparq_canon::issue_dataset_rdf12(&dataset)?;            // issuer map
+// Hash-profile parity with the standard path: pick a hash via `*_with::<D: Digest>`.
+let nq384 = sparq_canon::canonicalize_rdf12_with::<sha2::Sha384>(&dataset)?;
 ```
 
-**Boundary:** SHA-256 only (no `*_with` for v2 yet); triple terms occur only as
-objects in oxrdf 0.3 (a triple's subject is `NamedOrBlankNode`), so nesting
-descends strictly through the object position; the HNDQ poison-graph limit still
-applies.
+**Boundary:** SHA-256 is the default; a `*_with::<D: Digest>` sibling of each v2
+entry point (e.g. `canonicalize_rdf12_with`) selects another hash — notably
+`sha2::Sha384` — for parity with the standard path's `canonicalize_quads_with`.
+The non-generic entry points are SHA-256 and byte-identical to before; a
+different `D` may yield a different (still canonical, isomorphism-stable under
+that `D`) relabelling. Triple terms occur only as objects in oxrdf 0.3 (a
+triple's subject is `NamedOrBlankNode`), so nesting descends strictly through
+the object position; the HNDQ poison-graph limit still applies.
 
 ### Opt-in, single-sourced
 

--- a/crates/sparq-canon/src/lib.rs
+++ b/crates/sparq-canon/src/lib.rs
@@ -80,8 +80,9 @@ pub mod rdf12;
 
 #[cfg(feature = "rdf12-triple-terms")]
 pub use rdf12::{
-    canonicalize_graph_content_rdf12, canonicalize_rdf12, canonicalize_triples_rdf12,
-    issue_dataset_rdf12,
+    canonicalize_graph_content_rdf12, canonicalize_graph_content_rdf12_with, canonicalize_rdf12,
+    canonicalize_rdf12_with, canonicalize_triples_rdf12, canonicalize_triples_rdf12_with,
+    issue_dataset_rdf12, issue_dataset_rdf12_with,
 };
 
 /// The hash-function trait RDFC-1.0 is parameterized over (`digest::Digest`),

--- a/crates/sparq-canon/src/rdf12.rs
+++ b/crates/sparq-canon/src/rdf12.rs
@@ -39,19 +39,29 @@
 //!
 //! ## Boundary
 //!
-//! - SHA-256 only (the spec default). The non-default-hash `*_with` profile is
-//!   not (yet) exposed for the v2 path.
+//! - SHA-256 is the default (the spec hash). A `*_with::<D: Digest>` profile
+//!   (e.g. [`canonicalize_rdf12_with`]) lets a caller select a different hash —
+//!   notably SHA-384 (`sha2::Sha384`) for parity with the standard delegated
+//!   path's [`crate::canonicalize_quads_with`]. The non-generic entry points
+//!   are SHA-256 and produce byte-identical output to before. Because all
+//!   intermediate RDFC-1.0 hashes are emitted as lowercase hex of the full
+//!   digest, the chosen `D` flows through first-degree, related, and n-degree
+//!   hashing uniformly; the canonical *labels* (`c14nN`) and their *order* are
+//!   determined by hash comparison, so a different `D` can yield a different
+//!   relabelling while every input remains isomorphism-stable under that `D`.
 //! - Dataset-level (quads, named graphs) and single-graph (triples) entry
-//!   points are both provided.
+//!   points are both provided, each with a `*_with` hash-generic sibling.
 //! - The HNDQ poison-graph call limit is enforced (default 4000) and surfaces as
 //!   [`CanonError::Canonicalization`], so pathological inputs fail closed.
 //!
-//! [OPUS-4.8] sq-hslb — full non-standard RDF-1.2 triple-term canon profile.
+//! [OPUS-4.8] sq-hslb — full non-standard RDF-1.2 triple-term canon profile;
+//! sq-5i1d — `*_with::<D: Digest>` hash-profile parity (SHA-384).
 //! Fable unavailable; flag for re-review when Fable returns.
 
 use crate::CanonError;
+use digest::Digest;
 use oxrdf::{BlankNode, GraphName, NamedOrBlankNode, Quad, Term, Triple};
-use sha2::{Digest, Sha256};
+use sha2::Sha256;
 use std::collections::BTreeMap;
 
 /// The default HNDQ call limit (matches the standard `rdf-canon` path's guard).
@@ -72,22 +82,41 @@ const DEFAULT_HNDQ_CALL_LIMIT: usize = 4000;
 /// This is **not** W3C RDFC-1.0 (RDF-1.2 canonicalization is unsettled
 /// upstream); see the [module docs](self).
 pub fn canonicalize_rdf12(dataset: &[Quad]) -> Result<String, CanonError> {
-    let issued = issue_dataset_rdf12(dataset)?;
+    canonicalize_rdf12_with::<Sha256>(dataset)
+}
+
+/// **NON-STANDARD.** Like [`canonicalize_rdf12`] but parameterized over the
+/// RDFC-1.0 hash function `D` ([`crate::Digest`]). The profile default is
+/// SHA-256 ([`canonicalize_rdf12`]); pass `sha2::Sha384` to select the SHA-384
+/// profile, for parity with the standard delegated path's
+/// [`crate::canonicalize_quads_with`].
+///
+/// The relabelling and line order are determined by hash comparison, so a
+/// different `D` may produce a different (but still canonical and
+/// isomorphism-stable) `c14nN` assignment; the SHA-256 default
+/// ([`canonicalize_rdf12`]) is byte-identical to before.
+pub fn canonicalize_rdf12_with<D: Digest>(dataset: &[Quad]) -> Result<String, CanonError> {
+    let issued = issue_dataset_rdf12_with::<D>(dataset)?;
     Ok(serialize_canonical(dataset, &issued))
 }
 
 /// **NON-STANDARD.** The issued-identifier map (input blank-node label →
 /// canonical `c14nN` label) for an RDF-1.2 dataset under the
-/// `rdf12-triple-terms` profile. See [`canonicalize_rdf12`].
+/// `rdf12-triple-terms` profile (SHA-256). See [`canonicalize_rdf12`].
 pub fn issue_dataset_rdf12(
     dataset: &[Quad],
 ) -> Result<std::collections::HashMap<String, String>, CanonError> {
-    let state = CanonState::compute(dataset)?;
-    Ok(state
-        .canonical_issuer
-        .issued
-        .into_iter()
-        .collect())
+    issue_dataset_rdf12_with::<Sha256>(dataset)
+}
+
+/// **NON-STANDARD.** Like [`issue_dataset_rdf12`] but parameterized over the
+/// RDFC-1.0 hash function `D` ([`crate::Digest`]). See
+/// [`canonicalize_rdf12_with`].
+pub fn issue_dataset_rdf12_with<D: Digest>(
+    dataset: &[Quad],
+) -> Result<std::collections::HashMap<String, String>, CanonError> {
+    let state = CanonState::compute::<D>(dataset)?;
+    Ok(state.canonical_issuer.issued.into_iter().collect())
 }
 
 /// **NON-STANDARD.** Canonicalizes one graph's content (a slice of [`Triple`]s,
@@ -97,7 +126,14 @@ pub fn issue_dataset_rdf12(
 /// On triple-term-free input this agrees byte-for-byte with the standard
 /// [`crate::canonicalize_triples`]. See the [module docs](self) for the
 /// non-standard caveat.
-pub fn canonicalize_triples_rdf12(
+pub fn canonicalize_triples_rdf12(triples: &[Triple]) -> Result<crate::CanonicalGraph, CanonError> {
+    canonicalize_triples_rdf12_with::<Sha256>(triples)
+}
+
+/// **NON-STANDARD.** Like [`canonicalize_triples_rdf12`] but parameterized over
+/// the RDFC-1.0 hash function `D` ([`crate::Digest`]). See
+/// [`canonicalize_rdf12_with`].
+pub fn canonicalize_triples_rdf12_with<D: Digest>(
     triples: &[Triple],
 ) -> Result<crate::CanonicalGraph, CanonError> {
     let dataset: Vec<Quad> = triples
@@ -111,7 +147,7 @@ pub fn canonicalize_triples_rdf12(
             )
         })
         .collect();
-    let issued = issue_dataset_rdf12(&dataset)?;
+    let issued = issue_dataset_rdf12_with::<D>(&dataset)?;
     let lines = canonical_lines(&dataset, &issued);
     // Re-parse each canonical default-graph line back into a triple so the
     // returned `triples` carry the canonical (`c14nN`) labels, matching the
@@ -124,7 +160,10 @@ pub fn canonicalize_triples_rdf12(
             parsed = Some(Triple::new(q.subject, q.predicate, q.object));
         }
         triples_out.push(parsed.ok_or_else(|| {
-            CanonError::Bridge(format!("canonical line did not parse as one quad: {}", line))
+            CanonError::Bridge(format!(
+                "canonical line did not parse as one quad: {}",
+                line
+            ))
         })?);
     }
     Ok(crate::CanonicalGraph {
@@ -139,12 +178,21 @@ pub fn canonicalize_triples_rdf12(
 pub fn canonicalize_graph_content_rdf12(
     g: &sparq_core::Graph,
 ) -> Result<crate::CanonicalGraph, CanonError> {
+    canonicalize_graph_content_rdf12_with::<Sha256>(g)
+}
+
+/// **NON-STANDARD.** Like [`canonicalize_graph_content_rdf12`] but parameterized
+/// over the RDFC-1.0 hash function `D` ([`crate::Digest`]). See
+/// [`canonicalize_rdf12_with`].
+pub fn canonicalize_graph_content_rdf12_with<D: Digest>(
+    g: &sparq_core::Graph,
+) -> Result<crate::CanonicalGraph, CanonError> {
     // `graph_triples` materializes the stored triples as-is, keeping any
     // triple-term objects intact (the standard *canonicalize* paths reject
     // triple terms downstream, not here), so it is the right source for the v2
     // profile too.
     let triples = crate::graph_triples(g)?;
-    canonicalize_triples_rdf12(&triples)
+    canonicalize_triples_rdf12_with::<D>(&triples)
 }
 
 // ---------------------------------------------------------------------------
@@ -206,7 +254,7 @@ struct CanonState {
 }
 
 impl CanonState {
-    fn compute(dataset: &[Quad]) -> Result<Self, CanonError> {
+    fn compute<D: Digest>(dataset: &[Quad]) -> Result<Self, CanonError> {
         let mut state = CanonState {
             bnode_to_quads: BTreeMap::new(),
             canonical_issuer: IdentifierIssuer::new("c14n"),
@@ -216,7 +264,7 @@ impl CanonState {
         // §4.4(3) first-degree hashes.
         let mut hash_to_bnodes: HashToBnodes = BTreeMap::new();
         for n in state.bnode_to_quads.keys() {
-            let h = state.hash_first_degree_quads(n)?;
+            let h = state.hash_first_degree_quads::<D>(n)?;
             hash_to_bnodes.entry(h).or_default().push(n.clone());
         }
 
@@ -240,7 +288,7 @@ impl CanonState {
                 }
                 let mut temp = IdentifierIssuer::new("b");
                 temp.issue(n);
-                let result = state.hash_n_degree_quads(n, &temp, &mut counter)?;
+                let result = state.hash_n_degree_quads::<D>(n, &temp, &mut counter)?;
                 hash_path_list.push(result);
             }
             hash_path_list.sort_by(|a, b| a.hash.cmp(&b.hash));
@@ -280,7 +328,7 @@ impl CanonState {
 
     // ---- §4.6 Hash First Degree Quads (triple-term aware) ----
 
-    fn hash_first_degree_quads(&self, reference: &str) -> Result<String, CanonError> {
+    fn hash_first_degree_quads<D: Digest>(&self, reference: &str) -> Result<String, CanonError> {
         let quads = self
             .quads_for(reference)
             .ok_or_else(|| CanonError::Canonicalization("quads not found for bnode".into()))?;
@@ -292,12 +340,12 @@ impl CanonState {
             })
             .collect();
         nquads.sort();
-        Ok(hash_hex(nquads.concat().as_bytes()))
+        Ok(hash_hex::<D>(nquads.concat().as_bytes()))
     }
 
     // ---- §4.8 Hash N-Degree Quads (triple-term aware) ----
 
-    fn hash_n_degree_quads(
+    fn hash_n_degree_quads<D: Digest>(
         &self,
         identifier: &str,
         path_issuer: &IdentifierIssuer,
@@ -320,8 +368,12 @@ impl CanonState {
             collect_bnodes_subject(&quad.subject, &mut subj_bnodes);
             for related in &subj_bnodes {
                 if related != identifier {
-                    let h =
-                        self.hash_related_blank_node(related, quad, &issuer, Position::Subject)?;
+                    let h = self.hash_related_blank_node::<D>(
+                        related,
+                        quad,
+                        &issuer,
+                        Position::Subject,
+                    )?;
                     h_n.entry(h).or_default().push(related.clone());
                 }
             }
@@ -330,8 +382,12 @@ impl CanonState {
             collect_bnodes_term(&quad.object, &mut obj_bnodes);
             for related in &obj_bnodes {
                 if related != identifier {
-                    let h =
-                        self.hash_related_blank_node(related, quad, &issuer, Position::Object)?;
+                    let h = self.hash_related_blank_node::<D>(
+                        related,
+                        quad,
+                        &issuer,
+                        Position::Object,
+                    )?;
                     h_n.entry(h).or_default().push(related.clone());
                 }
             }
@@ -340,7 +396,7 @@ impl CanonState {
                 let related = b.as_str();
                 if related != identifier {
                     let h =
-                        self.hash_related_blank_node(related, quad, &issuer, Position::Graph)?;
+                        self.hash_related_blank_node::<D>(related, quad, &issuer, Position::Graph)?;
                     h_n.entry(h).or_default().push(related.to_string());
                 }
             }
@@ -382,7 +438,7 @@ impl CanonState {
                 }
 
                 for related in &recursion_list {
-                    let result = self.hash_n_degree_quads(related, &issuer_copy, counter)?;
+                    let result = self.hash_n_degree_quads::<D>(related, &issuer_copy, counter)?;
                     path.push_str(&format!("_:{}", issuer_copy.issue(related)));
                     path.push('<');
                     path.push_str(&result.hash);
@@ -413,14 +469,14 @@ impl CanonState {
         }
 
         Ok(HndqResult {
-            hash: hash_hex(data_to_hash.as_bytes()),
+            hash: hash_hex::<D>(data_to_hash.as_bytes()),
             issuer,
         })
     }
 
     // ---- §4.7 Hash Related Blank Node ----
 
-    fn hash_related_blank_node(
+    fn hash_related_blank_node<D: Digest>(
         &self,
         related: &str,
         quad: &Quad,
@@ -436,11 +492,11 @@ impl CanonState {
             Some(id) => format!("_:{}", id),
             None => match issuer.get(related) {
                 Some(id) => format!("_:{}", id),
-                None => self.hash_first_degree_quads(related)?,
+                None => self.hash_first_degree_quads::<D>(related)?,
             },
         };
         input.push_str(&identifier);
-        Ok(hash_hex(input.as_bytes()))
+        Ok(hash_hex::<D>(input.as_bytes()))
     }
 }
 
@@ -636,10 +692,7 @@ fn relabel_subject_canonical(
     }
 }
 
-fn relabel_term_canonical(
-    term: &Term,
-    issued: &std::collections::HashMap<String, String>,
-) -> Term {
+fn relabel_term_canonical(term: &Term, issued: &std::collections::HashMap<String, String>) -> Term {
     match term {
         Term::BlankNode(b) => Term::BlankNode(issued_label(b.as_str(), issued)),
         Term::Triple(t) => Term::Triple(Box::new(Triple::new(
@@ -683,8 +736,14 @@ fn serialize_quad_line(quad: &Quad) -> String {
 // Small helpers.
 // ---------------------------------------------------------------------------
 
-fn hash_hex(data: &[u8]) -> String {
-    let digest = Sha256::digest(data);
+/// Lowercase-hex of `D`'s digest over `data`. The RDFC-1.0 algorithm is
+/// parameterized over its hash function; `D` is threaded through every hashing
+/// step (first-degree, related, n-degree) so the canonical labels are computed
+/// entirely under the caller's chosen hash. SHA-256 (`canonicalize_rdf12`) is
+/// the spec default; SHA-384 (`canonicalize_rdf12_with::<Sha384>`) the parity
+/// target.
+fn hash_hex<D: Digest>(data: &[u8]) -> String {
+    let digest = D::digest(data);
     let mut s = String::with_capacity(digest.len() * 2);
     for byte in digest.iter() {
         s.push_str(&format!("{:02x}", byte));

--- a/crates/sparq-canon/tests/bnode_isomorphism_and_bridge.rs
+++ b/crates/sparq-canon/tests/bnode_isomorphism_and_bridge.rs
@@ -50,7 +50,11 @@ fn linked_bnode_graph(x: &str, y: &str, swap_order: bool) -> CanonicalGraph {
         iri("http://ex/q"),
         Term::Literal(Literal::new_simple_literal("v")),
     );
-    let triples = if swap_order { vec![t2, t1] } else { vec![t1, t2] };
+    let triples = if swap_order {
+        vec![t2, t1]
+    } else {
+        vec![t1, t2]
+    };
     canonicalize_triples(&triples).expect("canonicalize")
 }
 
@@ -174,12 +178,22 @@ fn canon_error_display_is_distinct_and_nonempty_per_variant() {
     let br = CanonError::Bridge("parse boom".into()).to_string();
     let cz = CanonError::Canonicalization("hndq limit".into()).to_string();
 
-    for (label, msg) in [("TripleTerm", &tt), ("Bridge", &br), ("Canonicalization", &cz)] {
+    for (label, msg) in [
+        ("TripleTerm", &tt),
+        ("Bridge", &br),
+        ("Canonicalization", &cz),
+    ] {
         assert!(!msg.is_empty(), "{label} Display must be non-empty");
     }
     // The wrapped detail must be carried through, and the three messages must differ.
-    assert!(br.contains("parse boom"), "Bridge must carry its detail: {br}");
-    assert!(cz.contains("hndq limit"), "Canon must carry its detail: {cz}");
+    assert!(
+        br.contains("parse boom"),
+        "Bridge must carry its detail: {br}"
+    );
+    assert!(
+        cz.contains("hndq limit"),
+        "Canon must carry its detail: {cz}"
+    );
     assert_ne!(tt, br);
     assert_ne!(tt, cz);
     assert_ne!(br, cz);

--- a/crates/sparq-canon/tests/rdf12_triple_term_canon.rs
+++ b/crates/sparq-canon/tests/rdf12_triple_term_canon.rs
@@ -12,7 +12,7 @@
 //!     standard path rejects with `TripleTerm` that now canonicalizes.
 #![cfg(feature = "rdf12-triple-terms")]
 
-use oxrdf::{BlankNode, Literal, NamedNode, NamedOrBlankNode, Quad, Term, Triple, GraphName};
+use oxrdf::{BlankNode, GraphName, Literal, NamedNode, NamedOrBlankNode, Quad, Term, Triple};
 use std::path::{Path, PathBuf};
 
 fn testdata() -> PathBuf {
@@ -117,7 +117,10 @@ fn v2_single_graph_agrees_with_standard() {
     entries.sort();
     for path in entries {
         let quads = load_quads(&path);
-        if !quads.iter().all(|q| q.graph_name == GraphName::DefaultGraph) {
+        if !quads
+            .iter()
+            .all(|q| q.graph_name == GraphName::DefaultGraph)
+        {
             continue;
         }
         let triples: Vec<Triple> = quads
@@ -130,18 +133,23 @@ fn v2_single_graph_agrees_with_standard() {
         };
         let v2_out = sparq_canon::canonicalize_triples_rdf12(&triples).unwrap();
         assert_eq!(
-            std_out.lines, v2_out.lines,
+            std_out.lines,
+            v2_out.lines,
             "single-graph lines disagree on {:?}",
             path.file_name().unwrap()
         );
         assert_eq!(
-            std_out.triples, v2_out.triples,
+            std_out.triples,
+            v2_out.triples,
             "single-graph triples disagree on {:?}",
             path.file_name().unwrap()
         );
         compared += 1;
     }
-    assert!(compared >= 30, "expected most eval inputs default-graph, got {compared}");
+    assert!(
+        compared >= 30,
+        "expected most eval inputs default-graph, got {compared}"
+    );
 }
 
 // ---------------------------------------------------------------------------
@@ -172,7 +180,10 @@ fn ground_triple_term_is_order_invariant() {
     );
     let forward = sparq_canon::canonicalize_triples_rdf12(&[t1.clone(), t2.clone()]).unwrap();
     let reverse = sparq_canon::canonicalize_triples_rdf12(&[t2, t1]).unwrap();
-    assert_eq!(forward.lines, reverse.lines, "ground TT must be order-invariant");
+    assert_eq!(
+        forward.lines, reverse.lines,
+        "ground TT must be order-invariant"
+    );
     // Sanity: triple-term token form is present in the canonical output.
     assert!(
         forward.lines.iter().any(|l| l.contains("<<(")),
@@ -296,7 +307,11 @@ fn nested_bnode_distinguishes_non_isomorphic() {
             Term::BlankNode(bn("b")),
         );
         vec![
-            Triple::new(NamedOrBlankNode::BlankNode(bn("a")), iri("http://ex/says"), inner),
+            Triple::new(
+                NamedOrBlankNode::BlankNode(bn("a")),
+                iri("http://ex/says"),
+                inner,
+            ),
             Triple::new(
                 NamedOrBlankNode::BlankNode(bn("b")),
                 iri("http://ex/t"),
@@ -312,7 +327,11 @@ fn nested_bnode_distinguishes_non_isomorphic() {
             Term::BlankNode(bn("b")),
         );
         vec![
-            Triple::new(NamedOrBlankNode::BlankNode(bn("a")), iri("http://ex/says"), inner),
+            Triple::new(
+                NamedOrBlankNode::BlankNode(bn("a")),
+                iri("http://ex/says"),
+                inner,
+            ),
             Triple::new(
                 NamedOrBlankNode::BlankNode(bn("b")),
                 iri("http://ex/t"),
@@ -350,8 +369,9 @@ fn dataset_named_graph_nested_bnode() {
 /// canonical RDF-1.2 `@lang--dir` token form (single-sourced via oxrdf Display).
 #[test]
 fn directional_language_string_in_triple_term() {
-    let dir_lit = Literal::new_directional_language_tagged_literal("שלום", "he", oxrdf::BaseDirection::Rtl)
-        .unwrap();
+    let dir_lit =
+        Literal::new_directional_language_tagged_literal("שלום", "he", oxrdf::BaseDirection::Rtl)
+            .unwrap();
     let inner = tt(
         NamedOrBlankNode::NamedNode(iri("http://ex/s")),
         iri("http://ex/p"),
@@ -368,4 +388,219 @@ fn directional_language_string_in_triple_term() {
         "directional language token form expected: {}",
         c.lines[0]
     );
+}
+
+// ---------------------------------------------------------------------------
+// 4) Hash-profile parity: `*_with::<D: Digest>` (SHA-384) + back-compat guard
+//    (sq-5i1d). The non-generic default stays byte-identical to today; SHA-384
+//    is purely additive.
+// ---------------------------------------------------------------------------
+
+use sha2::{Sha256, Sha384};
+
+/// A symmetric two-bnode cycle whose c14n order is decided by the n-degree hash
+/// (the two bnodes share a first-degree hash), so the choice of hash function is
+/// observable in the relabelling. Shared by the parity tests below.
+fn symmetric_cycle_dataset() -> Vec<Quad> {
+    let mk = |s: &str, o: &str| {
+        Quad::new(
+            NamedOrBlankNode::BlankNode(bn(s)),
+            iri("http://ex/p"),
+            Term::BlankNode(bn(o)),
+            GraphName::DefaultGraph,
+        )
+    };
+    vec![
+        mk("a", "b"),
+        mk("b", "a"),
+        Quad::new(
+            NamedOrBlankNode::BlankNode(bn("a")),
+            iri("http://ex/t"),
+            Term::Literal(Literal::new_simple_literal("x")),
+            GraphName::DefaultGraph,
+        ),
+        Quad::new(
+            NamedOrBlankNode::BlankNode(bn("b")),
+            iri("http://ex/u"),
+            Term::Literal(Literal::new_simple_literal("y")),
+            GraphName::DefaultGraph,
+        ),
+    ]
+}
+
+/// BACK-COMPAT GUARD: the non-generic default (`canonicalize_rdf12`) must be
+/// byte-identical to the explicit SHA-256 profile (`canonicalize_rdf12_with::<
+/// Sha256>`) across every entry point. This is the load-bearing back-compat
+/// invariant: the SHA-384 variant is purely additive.
+#[test]
+fn default_is_sha256_byte_identical() {
+    let ds = symmetric_cycle_dataset();
+    assert_eq!(
+        sparq_canon::canonicalize_rdf12(&ds).unwrap(),
+        sparq_canon::canonicalize_rdf12_with::<Sha256>(&ds).unwrap(),
+        "non-generic default must equal the explicit SHA-256 profile"
+    );
+    assert_eq!(
+        sparq_canon::issue_dataset_rdf12(&ds).unwrap(),
+        sparq_canon::issue_dataset_rdf12_with::<Sha256>(&ds).unwrap(),
+        "issuer maps must match"
+    );
+    let triples: Vec<Triple> = ds
+        .iter()
+        .map(|q| Triple::new(q.subject.clone(), q.predicate.clone(), q.object.clone()))
+        .collect();
+    let g_default = sparq_canon::canonicalize_triples_rdf12(&triples).unwrap();
+    let g_sha256 = sparq_canon::canonicalize_triples_rdf12_with::<Sha256>(&triples).unwrap();
+    assert_eq!(g_default.lines, g_sha256.lines);
+    assert_eq!(g_default.triples, g_sha256.triples);
+}
+
+/// On a ground (blank-node-free) dataset no hash feeds into a relabelling, so the
+/// canonical OUTPUT is identical under any hash. This guards against an
+/// accidental hash leak into the serialized line text: the hash only ever shows
+/// up in intermediate labelling, never in the output bytes.
+#[test]
+fn sha384_ground_output_equals_sha256() {
+    let inner = tt(
+        NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+        iri("http://ex/p"),
+        Term::NamedNode(iri("http://ex/o")),
+    );
+    let t = Triple::new(
+        NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+        iri("http://ex/says"),
+        inner,
+    );
+    let sha256 =
+        sparq_canon::canonicalize_triples_rdf12_with::<Sha256>(std::slice::from_ref(&t)).unwrap();
+    let sha384 =
+        sparq_canon::canonicalize_triples_rdf12_with::<Sha384>(std::slice::from_ref(&t)).unwrap();
+    assert_eq!(
+        sha256.lines, sha384.lines,
+        "ground (bnode-free) output must not depend on the hash function"
+    );
+}
+
+/// The SHA-384 profile is DETERMINISTIC: the same dataset canonicalizes to the
+/// same bytes on repeated runs.
+#[test]
+fn sha384_is_deterministic() {
+    let ds = symmetric_cycle_dataset();
+    let a = sparq_canon::canonicalize_rdf12_with::<Sha384>(&ds).unwrap();
+    let b = sparq_canon::canonicalize_rdf12_with::<Sha384>(&ds).unwrap();
+    assert_eq!(a, b, "SHA-384 profile must be deterministic");
+}
+
+/// The SHA-384 profile is ISOMORPHISM-STABLE under that hash: two isomorphic
+/// graphs (relabelled bnodes + permuted quad order) canonicalize byte-identically
+/// — including a nested-bnode triple term.
+#[test]
+fn sha384_isomorphism_stable() {
+    let build = |shared: &str, other: &str, swap: bool| -> Vec<Triple> {
+        let inner = tt(
+            NamedOrBlankNode::BlankNode(bn(shared)),
+            iri("http://ex/p"),
+            Term::BlankNode(bn(other)),
+        );
+        let t1 = Triple::new(
+            NamedOrBlankNode::BlankNode(bn(shared)),
+            iri("http://ex/says"),
+            inner,
+        );
+        let t2 = Triple::new(
+            NamedOrBlankNode::BlankNode(bn(other)),
+            iri("http://ex/t"),
+            Term::Literal(Literal::new_simple_literal("leaf")),
+        );
+        if swap {
+            vec![t2, t1]
+        } else {
+            vec![t1, t2]
+        }
+    };
+    let a =
+        sparq_canon::canonicalize_triples_rdf12_with::<Sha384>(&build("shared", "other", false))
+            .unwrap();
+    let b =
+        sparq_canon::canonicalize_triples_rdf12_with::<Sha384>(&build("xxx", "yyy", true)).unwrap();
+    assert_eq!(
+        a.lines, b.lines,
+        "SHA-384 profile must be isomorphism-stable\n a={:?}\n b={:?}",
+        a.lines, b.lines
+    );
+    assert!(a.lines.iter().any(|l| l.contains("<<(")));
+}
+
+/// SHA-384 still DISTINGUISHES non-isomorphic graphs (the descent isn't
+/// collapsing distinct structure under the wider hash).
+#[test]
+fn sha384_distinguishes_non_isomorphic() {
+    let g1 = {
+        let inner = tt(
+            NamedOrBlankNode::BlankNode(bn("a")),
+            iri("http://ex/p"),
+            Term::BlankNode(bn("b")),
+        );
+        vec![
+            Triple::new(
+                NamedOrBlankNode::BlankNode(bn("a")),
+                iri("http://ex/says"),
+                inner,
+            ),
+            Triple::new(
+                NamedOrBlankNode::BlankNode(bn("b")),
+                iri("http://ex/t"),
+                Term::Literal(Literal::new_simple_literal("x")),
+            ),
+        ]
+    };
+    let g2 = {
+        let inner = tt(
+            NamedOrBlankNode::BlankNode(bn("b")),
+            iri("http://ex/p"),
+            Term::BlankNode(bn("b")),
+        );
+        vec![
+            Triple::new(
+                NamedOrBlankNode::BlankNode(bn("a")),
+                iri("http://ex/says"),
+                inner,
+            ),
+            Triple::new(
+                NamedOrBlankNode::BlankNode(bn("b")),
+                iri("http://ex/t"),
+                Term::Literal(Literal::new_simple_literal("x")),
+            ),
+        ]
+    };
+    let c1 = sparq_canon::canonicalize_triples_rdf12_with::<Sha384>(&g1).unwrap();
+    let c2 = sparq_canon::canonicalize_triples_rdf12_with::<Sha384>(&g2).unwrap();
+    assert_ne!(
+        c1.lines, c2.lines,
+        "non-isomorphic graphs must differ under SHA-384"
+    );
+}
+
+/// REAL-PATH PROOF that `D` is load-bearing (not a no-op generic): on the
+/// symmetric two-bnode cycle, SHA-256 and SHA-384 issue the SAME canonical
+/// labels to OPPOSITE input bnodes, so the two relabelling maps differ. If the
+/// hash were ever dropped (e.g. a hardcoded `Sha256` left in a call site), this
+/// assertion would fail.
+#[test]
+fn sha384_relabels_differently_from_sha256_on_symmetric_cycle() {
+    let ds = symmetric_cycle_dataset();
+    let m256 = sparq_canon::issue_dataset_rdf12_with::<Sha256>(&ds).unwrap();
+    let m384 = sparq_canon::issue_dataset_rdf12_with::<Sha384>(&ds).unwrap();
+    assert_ne!(
+        m256, m384,
+        "the chosen hash must actually drive the relabelling (D is load-bearing)"
+    );
+    // Both are still valid bijections onto {c14n0, c14n1}.
+    let labels256: std::collections::BTreeSet<_> = m256.values().cloned().collect();
+    let labels384: std::collections::BTreeSet<_> = m384.values().cloned().collect();
+    let expected: std::collections::BTreeSet<_> = ["c14n0".to_string(), "c14n1".to_string()]
+        .into_iter()
+        .collect();
+    assert_eq!(labels256, expected);
+    assert_eq!(labels384, expected);
 }

--- a/skills/rdf-canon/SKILL.md
+++ b/skills/rdf-canon/SKILL.md
@@ -121,13 +121,23 @@ sparq-canon = { path = "crates/sparq-canon", features = ["rdf12-triple-terms"] }
 let nq = sparq_canon::canonicalize_rdf12(&dataset)?;          // quads -> N-Quads
 let cg = sparq_canon::canonicalize_triples_rdf12(&triples)?;  // one graph
 let m  = sparq_canon::issue_dataset_rdf12(&dataset)?;         // issuer map
+
+// Hash-profile parity with the standard path: each v2 entry point has a
+// `*_with::<D: Digest>` sibling (SHA-384 = parity target).
+let nq384 = sparq_canon::canonicalize_rdf12_with::<sha2::Sha384>(&dataset)?;
+let cg384 = sparq_canon::canonicalize_triples_rdf12_with::<sha2::Sha384>(&triples)?;
+let m384  = sparq_canon::issue_dataset_rdf12_with::<sha2::Sha384>(&dataset)?;
 ```
 
-**Boundary / honesty:** SHA-256 only (no `*_with` hash profile for v2 yet);
-triple terms appear only as objects in oxrdf 0.3 (a triple's subject is
-`NamedOrBlankNode`), so nesting descends strictly through the object position; the
-HNDQ poison-graph call limit still fails closed. This is a sparq-local extension,
-**not** a W3C standard — do not represent its output as W3C RDFC-1.0.
+**Boundary / honesty:** SHA-256 is the default; a `*_with::<D: Digest>` sibling of
+each v2 entry point selects another hash (notably `sha2::Sha384`) for parity with
+the standard path's `canonicalize_quads_with`. The non-generic entry points are
+SHA-256 and byte-identical to before; a different `D` may produce a different
+(still canonical, isomorphism-stable under that `D`) relabelling. Triple terms
+appear only as objects in oxrdf 0.3 (a triple's subject is `NamedOrBlankNode`), so
+nesting descends strictly through the object position; the HNDQ poison-graph call
+limit still fails closed. This is a sparq-local extension, **not** a W3C standard
+— do not represent its output as W3C RDFC-1.0.
 
 ## Conformance
 
@@ -149,6 +159,8 @@ Verified against `sparq-canon` 0.1.0 source. The standard RDFC-1.0 path is
 `rdf-canon` 0.15.3 (W3C-suite validated); `sparq-canon` is the single-sourced
 bridge + public API. The opt-in, off-by-default `rdf12-triple-terms` profile
 (sq-hslb [OPUS-4.8]) is a native RDFC-1.0 re-implementation extended to RDF 1.2
-triple terms — **non-standard** (W3C RDFC-1.0 is RDF-1.1-only). `publish = false`,
+triple terms — **non-standard** (W3C RDFC-1.0 is RDF-1.1-only) — now with a
+`*_with::<D: Digest>` hash-profile sibling on every entry point for SHA-384
+parity (sq-5i1d [OPUS-4.8]). `publish = false`,
 non-default workspace member — nothing in sparq's default graph depends on it, so
 the default build and wasm artifact are byte-identical with or without it.


### PR DESCRIPTION
> 🤖 **SPARQ agent** (one of several @jeswr runs on this account).

Closes **sq-5i1d**. Follow-up to the #933 sparq-canon RDF-1.2 work.

Adds **SHA-384 hash-profile parity** to the non-standard RDF-1.2 v2 canon path: generic `*_with::<D: Digest>` entry points so a caller can opt into SHA-384 while the default (SHA-256) output stays **byte-identical** to today (guarded by a test). Opt-in, behind the existing `rdf12-triple-terms` feature; `sparq-core` default build + wasm artifact unaffected.

**Recovery note:** the implementing agent was killed by a process restart immediately *before* committing (work complete, tests passing). I (the orchestrator) recovered the uncommitted work and **re-verified the gates in-worktree** before opening: clippy `--all-features` clean, `cargo doc --all-features -D warnings` clean (the recurring rustdoc class — avoided), `cargo fmt` clean, and `cargo test -p sparq-canon` green in BOTH feature states (**15 passed** with `rdf12-triple-terms` on, incl. the new SHA-384 + SHA-256-byte-identical-guard tests). CI is the authoritative final gate. No perf numbers; [OPUS-4.8].
