### PR TITLE
ci(release-plz,bench): stop two recurring non-gating main reds (sq-owci) [OPUS-4.8]

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -302,6 +302,39 @@ jobs:
               benchmark-data:benchmark-data
             echo "Created and pushed orphan benchmark-data branch."
           fi
+      # [OPUS-4.8] sq-owci — clean the working tree before github-action-benchmark switches branches.
+      # ROOT CAUSE: the "Run benchmarks" step (scripts/ci-bench.sh) does `cd bench/zk && cargo bench`
+      # and `cd bench/zk-trace && cargo bench` (two STANDALONE cargo projects, run WITHOUT --locked),
+      # so Cargo re-resolves and REWRITES their committed bench/zk{,-trace}/Cargo.lock. That leaves the
+      # working tree dirty. The Store step below then runs with auto-push=true (main only), and the
+      # action internally does `git fetch ... benchmark-data:benchmark-data` + `git switch benchmark-data`,
+      # which ABORTS: "Your local changes to the following files would be overwritten by checkout:
+      # bench/zk-trace/Cargo.lock, bench/zk/Cargo.lock ... Aborting" (live: Benchmarks run 27867742598).
+      # That failed the whole (non-gating) Benchmarks job on every main push and masked real CI signal.
+      # It only ever bit main because on PRs auto-push=false, so the action never switches branches.
+      #
+      # FIX: restore exactly the TRACKED files the build/bench dirtied, so the action's branch switch is
+      # clean. `git checkout --` only touches tracked paths, so the UNtracked run outputs the next step
+      # reads (bench-results.json, prev-data.js) are left intact. Enumerating via `git diff --name-only`
+      # (tracked-modified only) future-proofs this against any other lockfile a future bench may rewrite.
+      # This does NOT alter the measurement — bench-results.json is already written; we only drop the
+      # incidental lockfile churn. main-guarded to mirror the auto-push gate (the only path that switches).
+      - name: Clean bench-induced tracked churn before history switch (main only)
+        if: github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          dirty="$(git diff --name-only)"
+          if [ -n "$dirty" ]; then
+            echo "Restoring tracked files the benchmark run modified (incidental Cargo.lock re-resolve):"
+            while IFS= read -r f; do echo "  $f"; done <<< "$dirty"
+            # Restore ALL tracked modifications. `git checkout -- .` only rewrites TRACKED paths,
+            # so the untracked run outputs the next step reads (bench-results.json, prev-data.js)
+            # are left intact — and it is whitespace-safe (no word-splitting of the path list).
+            git checkout -- .
+          else
+            echo "Working tree clean — no tracked churn to restore."
+          fi
+          git status --porcelain
       - name: Store + compare against history
         uses: benchmark-action/github-action-benchmark@52576c92bccf6ac60c8223ec7eb2565637cae9ba # v1.22.1
         with:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -40,6 +40,30 @@ semver_check = true
 # `vX.Y.Z`, which fires release.yml unchanged.
 git_tag_name = "v{{ version }}"
 
+# [OPUS-4.8] sq-owci — tolerate the four tracked-yet-gitignored artifacts on a fresh checkout.
+# WHY THIS EXISTS: on every `push: main`, `release-plz release-pr` (the Release-PR job in
+# .github/workflows/release-plz.yml) ABORTED its `determine next versions` step with
+#   "the working directory of this project has uncommitted changes. If these files are both
+#    committed and in .gitignore, either delete them or remove them from .gitignore.
+#    [".beads/interactions.jsonl", "bench/wikidata-8b/STATUS.md",
+#     "inference-conformance-report.md", "zk/compose/STATUS.md"]"
+# (live: run 27867775455). release-plz reuses cargo's VCS dirty-check, which treats a file that
+# is BOTH committed AND matched by a .gitignore rule as "uncommitted" — independently of any
+# real source change. On a fresh CI checkout those four files are the ONLY thing it flags, so the
+# Release-PR step failed on every main push, perennially marking this (non-gating) workflow red
+# and masking real CI signal (the `tag` job is unaffected — `release-plz release` does no such
+# check, hence it has always succeeded).
+#
+# allow_dirty = true makes `release-plz release-pr`/`update` proceed despite a dirty tree (per
+# release-plz config docs). It is SAFE here and does NOT mask a release regression: the four
+# offending paths are committed-but-ignored, so there is no diff content to fold into the
+# Release-PR — release-plz still computes versions from the conventional-commit history exactly
+# as before, it just stops treating the ignore-rule shadow as a blocker. The genuine root-cause
+# repo-hygiene fix (untrack the 3 generated artifacts; remove inference-conformance-report.md
+# from .gitignore since AGENTS.md §"Conformance" says it IS committed) is out of this CI lane's
+# staging scope and is filed as a follow-up bead for the maintainer.
+allow_dirty = true
+
 # --- Tag-only handoff to release.yml (activated by the release-plz WORKFLOW) -----------
 # [OPUS-4.8] sq-v286.4 (the workflow bead this file's header defers "activation" to;
 # .github/workflows/release-plz.yml). The two keys below are what make the `release-plz


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bead **sq-owci**. CI hygiene: kill the two persistent NON-GATING red workflows on \`main\` that pollute every "is main CI green?" check and mask real failures. No \`crates/\` source touched; only \`release-plz.toml\` (release tooling) + \`.github/workflows/bench.yml\`.

## Root causes (diagnosed from the live failed-run logs)

### 1. \`release-plz / Release-PR\` — fails on every \`push: main\`
\`release-plz release-pr\` reuses cargo's VCS dirty-check, which flags a file that is **both committed AND matched by a \`.gitignore\` rule** as "uncommitted". On a fresh CI checkout the only such files are four tracked-yet-gitignored artifacts, so the *determine next versions* step aborts every time (live: run \`27867775455\`):

\`\`\`
ERROR failed to update packages
  0: failed to determine next versions
  1: the working directory of this project has uncommitted changes. If these files are both
     committed and in .gitignore, either delete them or remove them from .gitignore.
     [".beads/interactions.jsonl", "bench/wikidata-8b/STATUS.md",
      "inference-conformance-report.md", "zk/compose/STATUS.md"]
Process completed with exit code 1.
\`\`\`

The sibling \`tag\` job has always been **green** (\`release-plz release\` does no such dirty-check — confirmed in the same run: "Tag v0.1.0 already exists", exit 0).

**Fix:** \`allow_dirty = true\` in \`release-plz.toml\` \`[workspace]\` (the documented key that makes \`release-pr\`/\`update\` tolerate a dirty tree). **Safe — masks no release regression:** the four offending paths are committed-but-ignored, so there is *no diff content* to fold into the Release-PR; versions are still computed from the conventional-commit history exactly as before. It just stops treating the ignore-rule shadow as a blocker.

### 2. \`Benchmarks\` / \`run + track benchmarks\` — fails on every \`push: main\`
\`scripts/ci-bench.sh\` runs \`cd bench/zk && cargo bench\` and \`cd bench/zk-trace && cargo bench\` (two **standalone** cargo projects, **without** \`--locked\`), so Cargo re-resolves and **rewrites** their committed \`Cargo.lock\`, dirtying the tree. \`github-action-benchmark\`'s \`auto-push\` (main only) then does \`git switch benchmark-data\`, which aborts (live: run \`27867742598\`):

\`\`\`
error: Your local changes to the following files would be overwritten by checkout:
  bench/zk-trace/Cargo.lock
  bench/zk/Cargo.lock
Please commit your changes or stash them before you switch branches. Aborting
\`\`\`

It only ever bit \`main\` because on PRs \`auto-push=false\`, so the action never switches branches.

**Fix:** a **main-only** step right before the Store step that \`git checkout -- .\` restores the incidental tracked churn so the branch switch is clean. \`git checkout -- .\` only rewrites *tracked* paths, so the untracked run outputs the next step reads (\`bench-results.json\`, \`prev-data.js\`) are left intact, and the measurement is unchanged.

## Gate safety (verified)
- **\`release-plz\`** triggers **only** on \`push: main\` — never \`pull_request\`/\`merge_group\` — so it never appears on a PR/merge-queue head commit and **never registers on the \`ci-summary / gate\` aggregator**. Cannot affect any gate.
- The new bench step is \`if: github.ref == 'refs/heads/main'\` → it **skips** (non-failing) on PR/merge_group, and it is a *step inside an existing job*, so it adds **no new check-run name** to the aggregator's set. The \`bench\` job's PR/merge_group gating behavior is unchanged.
- No GATING lane and no part of \`ci-summary.yml\` was touched.

## Validation
- \`bench.yml\`: **valid YAML**, **actionlint CLEAN** (1.7.12); \`release-plz.toml\`: valid TOML, \`allow_dirty = true\`.
- **Local reproduction of the bench fix** (sandbox git repo): a dirtied tracked \`Cargo.lock\` is restored to committed content (so \`git switch\` no longer aborts) while an untracked \`bench-results.json\` survives intact.
- \`allow_dirty\` confirmed as the documented \`[workspace]\`-level release-plz key for exactly this dirty-tree case.

## Follow-up (out of this CI lane's staging scope → filed as a bead)
The genuine repo-hygiene root cause is the four tracked-yet-gitignored files: untrack the 3 generated artifacts (\`bench/wikidata-8b/STATUS.md\`, \`zk/compose/STATUS.md\`, \`.beads/interactions.jsonl\`) and **remove \`inference-conformance-report.md\` from \`.gitignore\`** (AGENTS.md §"Conformance" says that report **is** committed — the ignore rule is a bug). That belongs to repo-content/orchestrator scope (and \`.beads/\` must not be staged by a sub-agent), so it is left for the maintainer.

---
**Auto-merge: OFF** — @jeswr verifies, then arms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)