### PR TITLE
feat(site): persistent cross-session workspace model + Tauri/web/memory persistence (sq-atb0) [OPUS-4.8]

### DIFF
--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -533,6 +533,41 @@ export {
   shortenIri,
 } from "./server-health.js";
 
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-atb0 — the persistent cross-session WORKSPACE model + persistence
+// abstraction. The framework-agnostic data shape of a named workspace (its imported sources,
+// the whole-dataset N-Quads save/open snapshot, and the saved SPARQL editor state) plus the
+// ONE `WorkspaceStore` interface with three runtime-selected backends — Tauri on-disk (when a
+// Tauri webview exposes the fs plugin), browser `localStorage` (the static-export path), and
+// an in-memory session fallback. No Tauri/DOM dependency: each tier is feature-detected. No
+// secret (a bearer token) is ever persisted. Consumed by the site's REPL workspace panel and
+// portable to the Tauri GUI unchanged.
+// ---------------------------------------------------------------------------
+
+export {
+  type Workspace,
+  type WorkspaceSummary,
+  type WorkspaceSourceMeta,
+  type WorkspaceEditorState,
+  type WorkspaceRunMode,
+  type WorkspaceBackend,
+  type WorkspaceStore,
+  type WorkspaceStoreOptions,
+  type KeyValueStorage,
+  type TauriFsApi,
+  WORKSPACE_SCHEMA,
+  WebWorkspaceStore,
+  MemoryWorkspaceStore,
+  TauriWorkspaceStore,
+  createWorkspaceStore,
+  detectWebStorage,
+  isTauriRuntime,
+  newWorkspace,
+  parseWorkspace,
+  workspaceId,
+  workspaceSummary,
+} from "./workspace.js";
+
 /** Renders a term for display, with a compact datatype/lang suffix. */
 export function formatTerm(t: SparqlTerm | undefined): string {
   if (!t) return "";

--- a/packages/sparq-client/src/workspace.ts
+++ b/packages/sparq-client/src/workspace.ts
@@ -1,0 +1,571 @@
+// [OPUS-4.8] sq-atb0 (epic sq-ixc3) — the persistent cross-session WORKSPACE model + the
+// persistence ABSTRACTION that lets a user's work survive an app restart.
+//
+// WHAT A WORKSPACE IS. A named, self-contained piece of GUI work:
+//   * its imported data sources — both local-file imports AND URL-loaded sources — captured
+//     as IMPORT METADATA (kind, label, url, format, byte size) so the dataset list re-hydrates
+//     and a URL source can be re-fetched;
+//   * a SNAPSHOT of the loaded dataset as N-Quads text (the engine's whole default+named-graph
+//     content), so re-opening a workspace restores the EXACT store it was saved with — a
+//     save/open snapshot cache, NOT a re-ingest-from-source-on-open (maintainer decision on
+//     sq-atb0 / #757, mirroring the engine's online-snapshot primitive sq-o5bi / #905);
+//   * the SPARQL editor state — the query text plus a small amount of editor UI state (the
+//     run mode, and whether endpoint mode was active with its endpoint config sans secrets).
+//
+// WHY HERE (framework-agnostic). This is pure data + a thin async persistence interface with
+// NO React, NO Next.js, and NO DOM beyond the two storage globals it FEATURE-DETECTS at
+// runtime. It transfers unchanged to any GUI host — the design's load-bearing "part (A)
+// transfers" property — exactly like the results / endpoint / highlight cores already in this
+// package. The site-specific glue (serialising the live wasm Store to a snapshot and back) is
+// a thin layer the site owns; this module is only "the shape of a workspace and where it is
+// stored".
+//
+// PERSISTENCE TIERS (one abstraction, runtime-selected — never assume Tauri exists):
+//   * Tauri desktop (`tauri` backend) — persists each workspace to a JSON file in the app's
+//     local data dir via the Tauri filesystem plugin, so it reloads on next launch. Selected
+//     ONLY when the Tauri filesystem plugin is actually present at runtime (feature-detected);
+//     the desktop shell must grant the `fs` capability for this path to activate.
+//   * Browser / GitHub Pages static export (`web` backend) — degrades gracefully to
+//     `localStorage`. Static-export-safe; works in any browser AND inside a Tauri webview that
+//     has not (yet) granted the fs capability.
+//   * No storage at all (SSR / Node build, or a locked-down webview) — an in-memory
+//     (`memory`) backend so the model still functions for one session and the build never
+//     hard-fails on a missing global.
+//
+// NO PERFORMANCE CLAIM is made anywhere here. NO secret (a bearer token) is ever persisted.
+
+// ---------------------------------------------------------------------------
+// The data model.
+// ---------------------------------------------------------------------------
+
+/**
+ * Where one imported data source came from. We persist enough METADATA to (a) re-draw the
+ * dataset list and (b) re-fetch a URL source on demand. We do NOT persist a file-system
+ * handle: browsers cannot silently re-read a previously chosen local file across sessions
+ * (no persistent handle without a fresh user gesture + the non-static File System Access
+ * API), so a `local` source re-hydrates from the workspace SNAPSHOT, not from the original
+ * file. This limitation is documented honestly in the UI, not papered over.
+ */
+export interface WorkspaceSourceMeta {
+  /** A `local` file import (re-hydrates from the snapshot only) or a `url` load (re-fetchable). */
+  kind: "local" | "url";
+  /** Display label — a filename for `local`, a short URL tail for `url`. */
+  label: string;
+  /** The fetch URL for a `url` source (absent for `local`). */
+  url?: string;
+  /** The RDF serialisation the source was parsed as (`turtle` / `nquads` / `trig` / …). */
+  format: string;
+  /** UTF-8 byte length of the imported document, for an honest "≈N bytes" note (best-effort). */
+  bytes?: number;
+  /** Epoch milliseconds the source was imported (for ordering / display). */
+  importedAt: number;
+}
+
+/** Which engine the editor was driving when the workspace was saved. */
+export type WorkspaceRunMode = "run" | "explain" | "analyze";
+
+/**
+ * The saved SPARQL editor state. `query` is the editor text; `mode` is the Run/EXPLAIN/ANALYZE
+ * selector; `endpointActive` + `endpointUrl` capture whether the editor was pointed at a
+ * running server (so the panel restores that view) — but the bearer TOKEN is NEVER persisted
+ * (a secret), so a restored endpoint session re-prompts for it.
+ */
+export interface WorkspaceEditorState {
+  query: string;
+  mode: WorkspaceRunMode;
+  endpointActive: boolean;
+  /** The endpoint URL (no token) when endpoint mode was active. */
+  endpointUrl?: string;
+}
+
+/**
+ * One named workspace. `dataSnapshot` is the N-Quads serialisation of the whole dataset
+ * (default graph + every named graph) at save time — the save/open cache. It MAY be absent
+ * for a freshly-created empty workspace.
+ */
+export interface Workspace {
+  /** Stable opaque id (also the storage key / filename stem). */
+  id: string;
+  /** User-facing name. */
+  name: string;
+  /** Epoch ms the workspace was created. */
+  createdAt: number;
+  /** Epoch ms of the last save. */
+  updatedAt: number;
+  /** The import metadata for every source the user loaded (local + url). */
+  sources: WorkspaceSourceMeta[];
+  /** The whole-dataset N-Quads snapshot at save time (the save/open cache); absent when empty. */
+  dataSnapshot?: string;
+  /** The saved SPARQL editor state. */
+  editor: WorkspaceEditorState;
+  /**
+   * The schema version of this persisted record. Bumped if the on-disk shape changes so a
+   * loader can migrate or discard an incompatible old record rather than crash.
+   */
+  schema: number;
+}
+
+/** The on-disk schema version. Bump + migrate (or drop) on a breaking shape change. */
+export const WORKSPACE_SCHEMA = 1;
+
+/** A workspace stripped to its identity, for a lightweight switcher list. */
+export interface WorkspaceSummary {
+  id: string;
+  name: string;
+  updatedAt: number;
+  /** Triple/quad lines in the snapshot, derived cheaply (newline count); 0 when empty. */
+  approxTriples: number;
+  sourceCount: number;
+}
+
+/** Reduce a full {@link Workspace} to its {@link WorkspaceSummary}. */
+export function workspaceSummary(ws: Workspace): WorkspaceSummary {
+  const snap = ws.dataSnapshot?.trim() ?? "";
+  return {
+    id: ws.id,
+    name: ws.name,
+    updatedAt: ws.updatedAt,
+    approxTriples: snap === "" ? 0 : snap.split("\n").length,
+    sourceCount: ws.sources.length,
+  };
+}
+
+/** Create a new, empty workspace with a fresh id and the given starting editor text. */
+export function newWorkspace(name: string, query: string): Workspace {
+  const now = Date.now();
+  return {
+    id: workspaceId(),
+    name,
+    createdAt: now,
+    updatedAt: now,
+    sources: [],
+    editor: { query, mode: "run", endpointActive: false },
+    schema: WORKSPACE_SCHEMA,
+  };
+}
+
+/**
+ * A short, collision-resistant workspace id. Uses `crypto.randomUUID()` when available
+ * (browsers, Tauri webview, modern Node), else a timestamp+random fallback so a build/SSR
+ * environment without `crypto` still works.
+ */
+export function workspaceId(): string {
+  const c = (globalThis as { crypto?: { randomUUID?: () => string } }).crypto;
+  if (c?.randomUUID) return `ws_${c.randomUUID()}`;
+  return `ws_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+/**
+ * Validate + normalise a parsed JSON value into a {@link Workspace}, or return `null` if it is
+ * not a recognisable, current-schema workspace. Used on load so a corrupt or stale record is
+ * dropped rather than crashing the GUI. Defensive about every field (a hand-edited file or a
+ * future-version record).
+ */
+export function parseWorkspace(value: unknown): Workspace | null {
+  if (typeof value !== "object" || value === null) return null;
+  const v = value as Record<string, unknown>;
+  if (v.schema !== WORKSPACE_SCHEMA) return null;
+  if (typeof v.id !== "string" || typeof v.name !== "string") return null;
+  const editor = v.editor as Record<string, unknown> | undefined;
+  if (!editor || typeof editor.query !== "string") return null;
+  const mode: WorkspaceRunMode =
+    editor.mode === "explain" || editor.mode === "analyze" ? editor.mode : "run";
+  const sources: WorkspaceSourceMeta[] = Array.isArray(v.sources)
+    ? v.sources.flatMap((s) => {
+        const src = parseSource(s);
+        return src ? [src] : [];
+      })
+    : [];
+  return {
+    id: v.id,
+    name: v.name,
+    createdAt: typeof v.createdAt === "number" ? v.createdAt : Date.now(),
+    updatedAt: typeof v.updatedAt === "number" ? v.updatedAt : Date.now(),
+    sources,
+    dataSnapshot:
+      typeof v.dataSnapshot === "string" ? v.dataSnapshot : undefined,
+    editor: {
+      query: editor.query,
+      mode,
+      endpointActive: editor.endpointActive === true,
+      endpointUrl:
+        typeof editor.endpointUrl === "string" ? editor.endpointUrl : undefined,
+    },
+    schema: WORKSPACE_SCHEMA,
+  };
+}
+
+function parseSource(value: unknown): WorkspaceSourceMeta | null {
+  if (typeof value !== "object" || value === null) return null;
+  const s = value as Record<string, unknown>;
+  if (s.kind !== "local" && s.kind !== "url") return null;
+  if (typeof s.label !== "string" || typeof s.format !== "string") return null;
+  return {
+    kind: s.kind,
+    label: s.label,
+    url: typeof s.url === "string" ? s.url : undefined,
+    format: s.format,
+    bytes: typeof s.bytes === "number" ? s.bytes : undefined,
+    importedAt: typeof s.importedAt === "number" ? s.importedAt : Date.now(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The persistence abstraction.
+// ---------------------------------------------------------------------------
+
+/**
+ * Which concrete backend a {@link WorkspaceStore} is using — surfaced so the UI can label the
+ * persistence honestly ("saved to disk" on Tauri, "saved in this browser" on the web, "this
+ * session only" for the in-memory fallback).
+ */
+export type WorkspaceBackend = "tauri" | "web" | "memory";
+
+/**
+ * The ONE persistence interface every backend implements. Async throughout so the Tauri
+ * filesystem path (which is async) and the web `localStorage` path (sync, trivially wrapped)
+ * share a signature. The set of stored workspaces plus a pointer to the LAST-OPENED one (for
+ * startup re-hydration).
+ */
+export interface WorkspaceStore {
+  /** Which concrete storage this resolved to. */
+  readonly backend: WorkspaceBackend;
+  /** Lightweight list of every stored workspace, for the switcher. */
+  list(): Promise<WorkspaceSummary[]>;
+  /** Load one workspace by id, or `null` if it is gone / unreadable. */
+  load(id: string): Promise<Workspace | null>;
+  /** Create or overwrite a workspace (keyed by `id`); bumps `updatedAt`. */
+  save(ws: Workspace): Promise<void>;
+  /** Delete a workspace by id (no-op if absent). */
+  remove(id: string): Promise<void>;
+  /** The id of the workspace to restore on startup, or `null` if none / it was deleted. */
+  lastOpenedId(): Promise<string | null>;
+  /** Record which workspace is open (so the next launch re-hydrates it). */
+  setLastOpenedId(id: string | null): Promise<void>;
+}
+
+// --- localStorage key scheme (web backend) ---------------------------------
+
+const WEB_PREFIX = "sparq.workspace.v1.";
+const WEB_INDEX_KEY = "sparq.workspace.v1.__index__";
+const WEB_LAST_KEY = "sparq.workspace.v1.__last__";
+
+/**
+ * Minimal synchronous key/value surface — exactly `localStorage`'s shape. Abstracted so the
+ * web backend can be unit-tested against an in-memory polyfill with no `jsdom`.
+ */
+export interface KeyValueStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+/**
+ * The web persistence backend: each workspace is one `localStorage` entry (`sparq.workspace.v1.<id>`),
+ * an `__index__` entry holds the id list, and `__last__` the last-opened id. Static-export-safe
+ * (no Tauri, no Node). Used in any browser and inside a Tauri webview lacking the fs capability.
+ */
+export class WebWorkspaceStore implements WorkspaceStore {
+  readonly backend: WorkspaceBackend;
+  private readonly kv: KeyValueStorage;
+
+  constructor(kv: KeyValueStorage, backend: WorkspaceBackend = "web") {
+    this.kv = kv;
+    this.backend = backend;
+  }
+
+  private ids(): string[] {
+    const raw = this.kv.getItem(WEB_INDEX_KEY);
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private writeIds(ids: string[]): void {
+    this.kv.setItem(WEB_INDEX_KEY, JSON.stringify(ids));
+  }
+
+  private readOne(id: string): Workspace | null {
+    const raw = this.kv.getItem(WEB_PREFIX + id);
+    if (!raw) return null;
+    try {
+      return parseWorkspace(JSON.parse(raw));
+    } catch {
+      return null;
+    }
+  }
+
+  async list(): Promise<WorkspaceSummary[]> {
+    return this.ids()
+      .flatMap((id) => {
+        const ws = this.readOne(id);
+        return ws ? [workspaceSummary(ws)] : [];
+      })
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+
+  async load(id: string): Promise<Workspace | null> {
+    return this.readOne(id);
+  }
+
+  async save(ws: Workspace): Promise<void> {
+    const record: Workspace = { ...ws, updatedAt: Date.now(), schema: WORKSPACE_SCHEMA };
+    this.kv.setItem(WEB_PREFIX + ws.id, JSON.stringify(record));
+    const ids = this.ids();
+    if (!ids.includes(ws.id)) this.writeIds([...ids, ws.id]);
+  }
+
+  async remove(id: string): Promise<void> {
+    this.kv.removeItem(WEB_PREFIX + id);
+    this.writeIds(this.ids().filter((x) => x !== id));
+    if (this.kv.getItem(WEB_LAST_KEY) === id) this.kv.removeItem(WEB_LAST_KEY);
+  }
+
+  async lastOpenedId(): Promise<string | null> {
+    const last = this.kv.getItem(WEB_LAST_KEY);
+    return last && this.ids().includes(last) ? last : null;
+  }
+
+  async setLastOpenedId(id: string | null): Promise<void> {
+    if (id === null) this.kv.removeItem(WEB_LAST_KEY);
+    else this.kv.setItem(WEB_LAST_KEY, id);
+  }
+}
+
+/**
+ * The in-memory fallback backend (`memory`): a `Map` that lives only for this session. Used
+ * when no persistent storage exists at all (SSR / Node build, or a webview that exposes
+ * neither `localStorage` nor the Tauri fs plugin). The model still works for one session; the
+ * UI labels it as non-persistent so the user is not misled.
+ */
+export class MemoryWorkspaceStore implements WorkspaceStore {
+  readonly backend: WorkspaceBackend = "memory";
+  private readonly map = new Map<string, Workspace>();
+  private last: string | null = null;
+
+  async list(): Promise<WorkspaceSummary[]> {
+    return [...this.map.values()]
+      .map(workspaceSummary)
+      .sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+  async load(id: string): Promise<Workspace | null> {
+    return this.map.get(id) ?? null;
+  }
+  async save(ws: Workspace): Promise<void> {
+    this.map.set(ws.id, { ...ws, updatedAt: Date.now(), schema: WORKSPACE_SCHEMA });
+  }
+  async remove(id: string): Promise<void> {
+    this.map.delete(id);
+    if (this.last === id) this.last = null;
+  }
+  async lastOpenedId(): Promise<string | null> {
+    return this.last && this.map.has(this.last) ? this.last : null;
+  }
+  async setLastOpenedId(id: string | null): Promise<void> {
+    this.last = id;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The Tauri filesystem backend (feature-detected at runtime).
+// ---------------------------------------------------------------------------
+
+/**
+ * The subset of the Tauri filesystem plugin (`@tauri-apps/plugin-fs`) this backend needs. We
+ * type it locally (rather than importing the plugin as a hard dependency) so the site bundle
+ * never depends on a Tauri package — the plugin is read off the runtime when present and the
+ * web build neither imports nor ships it.
+ */
+export interface TauriFsApi {
+  readonly baseDir: number;
+  readTextFile(path: string, opts?: { baseDir?: number }): Promise<string>;
+  writeTextFile(path: string, contents: string, opts?: { baseDir?: number }): Promise<void>;
+  remove(path: string, opts?: { baseDir?: number }): Promise<void>;
+  exists(path: string, opts?: { baseDir?: number }): Promise<boolean>;
+  mkdir(path: string, opts?: { baseDir?: number; recursive?: boolean }): Promise<void>;
+  readDir(path: string, opts?: { baseDir?: number }): Promise<{ name: string }[]>;
+}
+
+const TAURI_DIR = "workspaces";
+const TAURI_INDEX = "workspaces/__index__.json";
+const TAURI_LAST = "workspaces/__last__.json";
+
+/**
+ * The Tauri persistence backend: each workspace is a JSON file under
+ * `<app-local-data>/workspaces/<id>.json`, with sibling `__index__.json` / `__last__.json`
+ * pointers. Files are written through the injected {@link TauriFsApi} (the runtime
+ * `@tauri-apps/plugin-fs` surface) scoped to the app's local data dir, so workspaces survive
+ * an app restart. Selected by {@link createWorkspaceStore} ONLY when that plugin is actually
+ * present + the shell granted the fs capability.
+ */
+export class TauriWorkspaceStore implements WorkspaceStore {
+  readonly backend: WorkspaceBackend = "tauri";
+  private readonly fs: TauriFsApi;
+  private readonly opts: { baseDir: number };
+
+  constructor(fs: TauriFsApi) {
+    this.fs = fs;
+    this.opts = { baseDir: fs.baseDir };
+  }
+
+  /** Ensure the workspaces dir exists (idempotent). */
+  private async ensureDir(): Promise<void> {
+    if (!(await this.fs.exists(TAURI_DIR, this.opts))) {
+      await this.fs.mkdir(TAURI_DIR, { ...this.opts, recursive: true });
+    }
+  }
+
+  private path(id: string): string {
+    return `${TAURI_DIR}/${id}.json`;
+  }
+
+  private async readIds(): Promise<string[]> {
+    try {
+      const raw = await this.fs.readTextFile(TAURI_INDEX, this.opts);
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed.filter((x): x is string => typeof x === "string") : [];
+    } catch {
+      return [];
+    }
+  }
+
+  private async writeIds(ids: string[]): Promise<void> {
+    await this.ensureDir();
+    await this.fs.writeTextFile(TAURI_INDEX, JSON.stringify(ids), this.opts);
+  }
+
+  async list(): Promise<WorkspaceSummary[]> {
+    const ids = await this.readIds();
+    const summaries: WorkspaceSummary[] = [];
+    for (const id of ids) {
+      const ws = await this.load(id);
+      if (ws) summaries.push(workspaceSummary(ws));
+    }
+    return summaries.sort((a, b) => b.updatedAt - a.updatedAt);
+  }
+
+  async load(id: string): Promise<Workspace | null> {
+    try {
+      const raw = await this.fs.readTextFile(this.path(id), this.opts);
+      return parseWorkspace(JSON.parse(raw));
+    } catch {
+      return null;
+    }
+  }
+
+  async save(ws: Workspace): Promise<void> {
+    await this.ensureDir();
+    const record: Workspace = { ...ws, updatedAt: Date.now(), schema: WORKSPACE_SCHEMA };
+    await this.fs.writeTextFile(this.path(ws.id), JSON.stringify(record), this.opts);
+    const ids = await this.readIds();
+    if (!ids.includes(ws.id)) await this.writeIds([...ids, ws.id]);
+  }
+
+  async remove(id: string): Promise<void> {
+    try {
+      if (await this.fs.exists(this.path(id), this.opts)) {
+        await this.fs.remove(this.path(id), this.opts);
+      }
+    } catch {
+      // A missing file is fine — remove is best-effort idempotent.
+    }
+    await this.writeIds((await this.readIds()).filter((x) => x !== id));
+    if ((await this.lastOpenedId()) === id) await this.setLastOpenedId(null);
+  }
+
+  async lastOpenedId(): Promise<string | null> {
+    try {
+      const raw = await this.fs.readTextFile(TAURI_LAST, this.opts);
+      const id = JSON.parse(raw);
+      if (typeof id !== "string") return null;
+      return (await this.readIds()).includes(id) ? id : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async setLastOpenedId(id: string | null): Promise<void> {
+    await this.ensureDir();
+    await this.fs.writeTextFile(TAURI_LAST, JSON.stringify(id), this.opts);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Runtime backend selection (NEVER assume Tauri / localStorage exists).
+// ---------------------------------------------------------------------------
+
+/**
+ * True when running inside a Tauri webview. Feature-detection only — reads the Tauri runtime
+ * globals (`__TAURI_INTERNALS__` is set by Tauri 2; `__TAURI__` is the legacy/global-API
+ * marker) WITHOUT importing any Tauri package, so a browser build that never ships Tauri code
+ * simply sees `false`. Safe during SSR (guards `typeof window`).
+ */
+export function isTauriRuntime(): boolean {
+  if (typeof window === "undefined") return false;
+  const w = window as unknown as Record<string, unknown>;
+  return "__TAURI_INTERNALS__" in w || "__TAURI__" in w;
+}
+
+/**
+ * Resolve a usable {@link KeyValueStorage} (the browser `localStorage`) if present, else
+ * `null`. Guards the access in a `try` because some embedded webviews / privacy modes throw on
+ * `localStorage` access rather than simply omitting it.
+ */
+export function detectWebStorage(): KeyValueStorage | null {
+  try {
+    if (typeof localStorage === "undefined") return null;
+    // A probe write/remove confirms it is actually usable (not a throwing stub).
+    const probe = "sparq.workspace.v1.__probe__";
+    localStorage.setItem(probe, "1");
+    localStorage.removeItem(probe);
+    return localStorage;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * How a host injects the Tauri filesystem plugin (when it has one) into the store factory. The
+ * site does NOT depend on `@tauri-apps/plugin-fs`; a Tauri host can pass a loader that
+ * dynamically imports it, and {@link createWorkspaceStore} only calls the loader after
+ * {@link isTauriRuntime} confirms a Tauri webview. Returning `null` (e.g. the fs capability was
+ * not granted) cleanly degrades to the web backend.
+ */
+export interface WorkspaceStoreOptions {
+  /**
+   * Resolve the Tauri filesystem API + its app-local-data baseDir, or `null` to skip the Tauri
+   * backend. Only invoked inside a Tauri webview. The default is `null` (no Tauri fs), which is
+   * correct for the browser/static-export build — that path uses the web backend.
+   */
+  loadTauriFs?: () => Promise<TauriFsApi | null>;
+}
+
+/**
+ * Pick the best available persistence backend for the current runtime, in priority order:
+ *   1. Tauri filesystem (durable on-disk) — only inside a Tauri webview AND only if the host's
+ *      `loadTauriFs` resolves a usable fs API (the shell granted the `fs` capability);
+ *   2. browser `localStorage` (durable per-browser) — the static-export / GitHub Pages path,
+ *      and the Tauri-webview fallback when the fs capability is absent;
+ *   3. in-memory (this session only) — when neither exists, so the GUI still runs.
+ *
+ * Never throws on a missing global: each tier is feature-detected and falls through.
+ */
+export async function createWorkspaceStore(
+  options: WorkspaceStoreOptions = {},
+): Promise<WorkspaceStore> {
+  if (isTauriRuntime() && options.loadTauriFs) {
+    try {
+      const fs = await options.loadTauriFs();
+      if (fs) return new TauriWorkspaceStore(fs);
+    } catch {
+      // Fall through to the web/memory tiers if the plugin import / capability fails.
+    }
+  }
+  const kv = detectWebStorage();
+  if (kv) return new WebWorkspaceStore(kv);
+  return new MemoryWorkspaceStore();
+}

--- a/site/README.md
+++ b/site/README.md
@@ -16,6 +16,18 @@ Inter, `--radius 0.7rem`. Design record: `research/feature-showcase-site-design.
 - **Live SPARQL REPL** (`/try` and the landing marquee) — loads the lean sparq wasm
   bundle and runs **real SPARQL** against a sample graph via the actual Rust engine
   compiled to WebAssembly. Not a fixture; nothing is sent to a server.
+- **Persistent cross-session workspaces** (`sq-atb0`) — the REPL's workspace panel
+  saves a named workspace: a **snapshot** of the loaded dataset (the whole default+named-graph
+  content as N-Quads — a save/open cache, not a re-ingest-from-source), the imported-source
+  list (local + URL, with the URL kept so a remote source can be re-fetched), and the SPARQL
+  editor state (query text + run mode + endpoint URL — never a bearer token). The persistence
+  is **one abstraction, three runtime-selected backends** (`@sparq/client` `workspace.ts`):
+  Tauri local-disk on the desktop app (when the shell grants the `fs` capability), browser
+  `localStorage` on GitHub Pages (the static-export path), and an in-memory session fallback —
+  feature-detected, so the static export never depends on a Tauri API. The last workspace
+  re-hydrates on startup. **Honest limitation**: a previously chosen local file cannot be
+  silently re-read across sessions (the browser keeps no persistent handle), so the snapshot is
+  a local import's durable copy; the panel says so plainly.
 - **/about** — the honest "what runs where" matrix.
 
 The per-surface interactive demos and the three flagship demos (ZK car-hire, MPC £100k,

--- a/site/src/components/repl-datasets.tsx
+++ b/site/src/components/repl-datasets.tsx
@@ -58,12 +58,17 @@ export interface DatasetControlsProps {
   activeBuiltinId: string | null;
   /** Replace the store from a built-in dataset. */
   onSelectBuiltin: (id: string) => void;
-  /** Replace OR add a custom RDF document (text + format). */
+  /**
+   * Replace OR add a custom RDF document (text + format). [OPUS-4.8] sq-atb0 — the optional
+   * `origin` captures whether this came from a local file upload or a URL (with that URL), so
+   * the workspace model can record the import as source metadata (and re-fetch a URL source).
+   */
   onLoadText: (
     text: string,
     format: string,
     label: string,
     mode: "replace" | "add",
+    origin?: { kind: "local" | "url"; url?: string },
   ) => Promise<void>;
   /** Disable controls while the engine is still cold. */
   disabled?: boolean;
@@ -90,7 +95,11 @@ export function DatasetControls({
       e.target.value = "";
       if (!file) return;
       const text = await file.text();
-      await onLoadText(text, guessFormat(file.name), file.name, mode);
+      // [OPUS-4.8] sq-atb0 — a local file import: record the origin so the workspace lists it
+      // (it cannot be silently re-read across sessions — the snapshot is its durable copy).
+      await onLoadText(text, guessFormat(file.name), file.name, mode, {
+        kind: "local",
+      });
     },
     [onLoadText, mode],
   );
@@ -222,7 +231,11 @@ function UrlLoadDialog({
         format === "__auto__"
           ? (formatFromContentType(res.headers.get("content-type")) ?? guessFormat(target))
           : format;
-      await onLoadText(text, fmt, shortName(target), defaultMode);
+      // [OPUS-4.8] sq-atb0 — a URL import: record the origin URL so a workspace can re-fetch it.
+      await onLoadText(text, fmt, shortName(target), defaultMode, {
+        kind: "url",
+        url: target,
+      });
       onOpenChange(false);
       setUrl("");
     } catch (e) {

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -63,7 +63,21 @@ import { ConnectPanel } from "@/components/connect-panel";
 import { SubscriptionsView } from "@/components/subscriptions-view";
 // [OPUS-4.8] sq-he72 — endpoint mode: the server health / capabilities panel (metrics + VoID/SD).
 import { ServerHealthPanel } from "@/components/server-health-panel";
-import { type EndpointConfig, runEndpointQuery } from "@sparq/client";
+import {
+  type EndpointConfig,
+  type Workspace,
+  type WorkspaceSourceMeta,
+  newWorkspace,
+  runEndpointQuery,
+} from "@sparq/client";
+// [OPUS-4.8] sq-atb0 — the persistent cross-session workspace panel + its hook + the
+// site-side wasm-Store ⇄ snapshot bridge.
+import { WorkspacePanel } from "@/components/workspace-panel";
+import { useWorkspaces } from "@/lib/use-workspaces";
+import {
+  snapshotStore,
+  restoreStoreFromSnapshot,
+} from "@/lib/workspace-snapshot";
 
 // [OPUS-4.8] sq-vfbm — the REPL now dispatches across the whole lean-bundle query
 // surface, so the result state carries one variant per shape of answer: a solution
@@ -130,6 +144,21 @@ export function Repl() {
     url: "http://127.0.0.1:3030/sparql",
     token: "",
   });
+
+  // [OPUS-4.8] sq-atb0 — the persistent cross-session workspace state. `workspaces` owns the
+  // resolved persistence backend (Tauri disk / browser localStorage / in-memory) and the CRUD
+  // surface; `currentWorkspaceId` is the open workspace (null = an unsaved scratch session);
+  // `sources` accumulates the import metadata (local + url) of every source loaded this session
+  // so a saved workspace can re-draw its source list and re-fetch its URL sources. The dataset
+  // itself is persisted as an N-Quads SNAPSHOT (the save/open cache), not re-ingested on open.
+  const workspaces = useWorkspaces();
+  const [currentWorkspaceId, setCurrentWorkspaceId] = React.useState<string | null>(
+    null,
+  );
+  const [sources, setSources] = React.useState<WorkspaceSourceMeta[]>([]);
+  const [workspaceBusy, setWorkspaceBusy] = React.useState(false);
+  // Guards the one-shot startup re-hydration so it runs at most once per mount.
+  const rehydratedRef = React.useRef(false);
 
   // Build (or rebuild) the store from RDF text + format. Centralises error handling so
   // every load path (default, picker, upload, URL) reports failures the same way.
@@ -312,6 +341,9 @@ export function Repl() {
         await buildStore(ds.text, ds.format);
         setActiveBuiltinId(ds.id);
         setActive({ label: ds.label, description: ds.description });
+        // [OPUS-4.8] sq-atb0 — a built-in dataset REPLACES the store, so it resets the imported-
+        // source list: there are no user imports to re-list (the data lives in the snapshot).
+        setSources([]);
         setState({ kind: "idle" });
       } catch (e) {
         const message = e instanceof Error ? e.message : String(e);
@@ -329,6 +361,7 @@ export function Repl() {
       format: string,
       label: string,
       mode: "replace" | "add",
+      origin?: { kind: "local" | "url"; url?: string },
     ) => {
       try {
         const Store = await loadSparq();
@@ -356,6 +389,21 @@ export function Repl() {
           });
         }
         setActiveBuiltinId(null);
+        // [OPUS-4.8] sq-atb0 — record this import as workspace source metadata. A "replace"
+        // load starts a fresh source list; an "add" appends. `origin` defaults to a local file
+        // when the caller did not say (the only callers that omit it are programmatic loads).
+        const meta: WorkspaceSourceMeta = {
+          kind: origin?.kind ?? "local",
+          label,
+          url: origin?.kind === "url" ? origin.url : undefined,
+          format,
+          bytes:
+            typeof TextEncoder !== "undefined"
+              ? new TextEncoder().encode(text).length
+              : text.length,
+          importedAt: Date.now(),
+        };
+        setSources((prev) => (mode === "add" ? [...prev, meta] : [meta]));
         setState({ kind: "idle" });
         toast.success("Dataset loaded", {
           // Count the WHOLE dataset (default + named graphs), not just the default.
@@ -369,6 +417,206 @@ export function Repl() {
     },
     [buildStore, size],
   );
+
+  // [OPUS-4.8] sq-atb0 — apply a loaded workspace to the live REPL: re-hydrate the wasm store
+  // from the workspace's N-Quads SNAPSHOT (the save/open cache — no re-ingest from source),
+  // restore the editor state (query + run mode + endpoint view, never a bearer token), and
+  // re-draw the imported-source list. Becomes the open workspace.
+  const applyWorkspace = React.useCallback(
+    async (ws: Workspace) => {
+      const store = await restoreStoreFromSnapshot(ws.dataSnapshot);
+      storeRef.current = store;
+      setSize(datasetSize(store));
+      setDatasetVersion((v) => v + 1);
+      setActiveBuiltinId(null);
+      setActive({
+        label: ws.name,
+        description: `Restored from workspace "${ws.name}" (${ws.sources.length} source${
+          ws.sources.length === 1 ? "" : "s"
+        }).`,
+      });
+      setSources(ws.sources);
+      setSparql(ws.editor.query);
+      setMode(ws.editor.mode);
+      setEndpointActive(ws.editor.endpointActive);
+      if (ws.editor.endpointUrl) {
+        // Restore the endpoint URL but NEVER a token — a restored endpoint session re-prompts.
+        setEndpointConfig((c) => ({ url: ws.editor.endpointUrl ?? c.url, token: "" }));
+      }
+      setCurrentWorkspaceId(ws.id);
+      setState({ kind: "idle" });
+    },
+    [],
+  );
+
+  // [OPUS-4.8] sq-atb0 — assemble a Workspace record from the current REPL state: the
+  // whole-dataset N-Quads snapshot, the imported-source metadata, and the editor state (no
+  // token). Reused by both Save (overwrite) and Save-as (new id).
+  const buildWorkspaceRecord = React.useCallback(
+    (base: Workspace): Workspace => {
+      const store = storeRef.current;
+      return {
+        ...base,
+        sources,
+        dataSnapshot: store ? snapshotStore(store) : undefined,
+        editor: {
+          query: sparql,
+          mode,
+          endpointActive,
+          endpointUrl: endpointActive ? endpointConfig.url : undefined,
+        },
+      };
+    },
+    [sources, sparql, mode, endpointActive, endpointConfig.url],
+  );
+
+  // Open a stored workspace by id (from the switcher).
+  const openWorkspace = React.useCallback(
+    async (id: string) => {
+      setWorkspaceBusy(true);
+      try {
+        const ws = await workspaces.load(id);
+        if (!ws) {
+          toast.error("Workspace not found", {
+            description: "It may have been deleted in another tab.",
+          });
+          return;
+        }
+        await applyWorkspace(ws);
+        await workspaces.setLastOpened(ws.id);
+        toast.success("Workspace opened", { description: ws.name });
+      } catch (e) {
+        toast.error("Could not open workspace", {
+          description: e instanceof Error ? e.message : String(e),
+        });
+      } finally {
+        setWorkspaceBusy(false);
+      }
+    },
+    [workspaces, applyWorkspace],
+  );
+
+  // Overwrite the open workspace with the current state.
+  const saveWorkspace = React.useCallback(async () => {
+    if (currentWorkspaceId === null) return;
+    setWorkspaceBusy(true);
+    try {
+      const existing = await workspaces.load(currentWorkspaceId);
+      const base = existing ?? newWorkspace("Workspace", sparql);
+      await workspaces.save(buildWorkspaceRecord({ ...base, id: currentWorkspaceId }));
+      toast.success("Workspace saved");
+    } catch (e) {
+      toast.error("Could not save workspace", {
+        description: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      setWorkspaceBusy(false);
+    }
+  }, [currentWorkspaceId, workspaces, buildWorkspaceRecord, sparql]);
+
+  // Save the current state as a NEW named workspace (becomes the open one).
+  const saveWorkspaceAs = React.useCallback(
+    async (name: string) => {
+      setWorkspaceBusy(true);
+      try {
+        const record = buildWorkspaceRecord(newWorkspace(name, sparql));
+        await workspaces.save(record);
+        setCurrentWorkspaceId(record.id);
+        toast.success("Workspace created", { description: name });
+      } catch (e) {
+        toast.error("Could not save workspace", {
+          description: e instanceof Error ? e.message : String(e),
+        });
+      } finally {
+        setWorkspaceBusy(false);
+      }
+    },
+    [buildWorkspaceRecord, workspaces, sparql],
+  );
+
+  // Rename the open workspace.
+  const renameWorkspace = React.useCallback(
+    async (name: string) => {
+      if (currentWorkspaceId === null) return;
+      setWorkspaceBusy(true);
+      try {
+        const existing = await workspaces.load(currentWorkspaceId);
+        if (!existing) return;
+        await workspaces.save({ ...existing, name });
+        toast.success("Workspace renamed", { description: name });
+      } catch (e) {
+        toast.error("Could not rename workspace", {
+          description: e instanceof Error ? e.message : String(e),
+        });
+      } finally {
+        setWorkspaceBusy(false);
+      }
+    },
+    [currentWorkspaceId, workspaces],
+  );
+
+  // Delete a stored workspace; if it was the open one, drop back to a scratch session.
+  const deleteWorkspace = React.useCallback(
+    async (id: string) => {
+      setWorkspaceBusy(true);
+      try {
+        await workspaces.remove(id);
+        if (id === currentWorkspaceId) {
+          setCurrentWorkspaceId(null);
+          await workspaces.setLastOpened(null);
+        }
+        toast.success("Workspace deleted");
+      } catch (e) {
+        toast.error("Could not delete workspace", {
+          description: e instanceof Error ? e.message : String(e),
+        });
+      } finally {
+        setWorkspaceBusy(false);
+      }
+    },
+    [workspaces, currentWorkspaceId],
+  );
+
+  // Start a fresh scratch session: reload the default dataset, reset the editor + sources, and
+  // detach from any open workspace (nothing is deleted).
+  const newScratchSession = React.useCallback(async () => {
+    setCurrentWorkspaceId(null);
+    await workspaces.setLastOpened(null);
+    setSources([]);
+    setSparql(EXAMPLE_QUERIES[0].sparql);
+    setMode("run");
+    setActiveBuiltinId(DEFAULT_DATASET.id);
+    setActive({
+      label: DEFAULT_DATASET.label,
+      description: DEFAULT_DATASET.description,
+    });
+    try {
+      await buildStore(DEFAULT_DATASET.text, DEFAULT_DATASET.format);
+    } catch {
+      // The pre-warm effect / ensureStore will rebuild the default on the next run.
+    }
+    setState({ kind: "idle" });
+  }, [workspaces, buildStore]);
+
+  // [OPUS-4.8] sq-atb0 — startup re-hydration: once the persistence backend has resolved, if a
+  // last-opened workspace exists, restore it (its snapshot + editor state). Runs at most once
+  // per mount (the ref guard), and only after the engine pre-warm has built the default store,
+  // so applying the snapshot replaces a known-good store. A failure is non-fatal — the user
+  // keeps the default scratch session.
+  React.useEffect(() => {
+    if (rehydratedRef.current) return;
+    if (!workspaces.ready || workspaces.initialId === null) return;
+    if (engine !== "ready") return;
+    rehydratedRef.current = true;
+    void (async () => {
+      try {
+        const ws = await workspaces.load(workspaces.initialId as string);
+        if (ws) await applyWorkspace(ws);
+      } catch {
+        // Keep the scratch session if re-hydration fails.
+      }
+    })();
+  }, [workspaces.ready, workspaces.initialId, engine, workspaces, applyWorkspace]);
 
   const busy = state.kind === "running";
   const controlsDisabled = engine === "warming" || engine === "cold";
@@ -430,6 +678,24 @@ export function Repl() {
         </div>
       </CardHeader>
       <CardContent className="space-y-3">
+        {/* [OPUS-4.8] sq-atb0 — the persistent cross-session workspace panel: save / open the
+            loaded dataset (as a snapshot) + the imported-source list + the SPARQL editor state,
+            so a session survives an app/browser restart. Backend resolves to Tauri disk on the
+            desktop app, browser localStorage on GitHub Pages, or an in-memory session fallback. */}
+        <WorkspacePanel
+          ready={workspaces.ready}
+          backend={workspaces.backend}
+          list={workspaces.list}
+          currentId={currentWorkspaceId}
+          onOpen={(id) => void openWorkspace(id)}
+          onSave={() => void saveWorkspace()}
+          onSaveAs={(name) => void saveWorkspaceAs(name)}
+          onNew={() => void newScratchSession()}
+          onRename={(name) => void renameWorkspace(name)}
+          onDelete={(id) => void deleteWorkspace(id)}
+          busy={workspaceBusy}
+        />
+
         <ConnectPanel
           config={endpointConfig}
           onConfigChange={setEndpointConfig}

--- a/site/src/components/workspace-panel.tsx
+++ b/site/src/components/workspace-panel.tsx
@@ -1,0 +1,354 @@
+"use client";
+
+// [OPUS-4.8] sq-atb0 (epic sq-ixc3) — the WORKSPACE panel for the live SPARQL REPL.
+//
+// This is the React host for the persistent cross-session workspace model. It draws the
+// workspace switcher (a named-workspace picker), the Save / New / Rename / Delete actions, and
+// an HONEST backend label so the user knows whether their work is saved to disk (desktop),
+// saved in this browser (web), or only kept for this session (the in-memory fallback). All the
+// model + persistence logic lives in the framework-agnostic `@sparq/client` workspace module
+// and the `useWorkspaces` hook; this component is just the controls + honesty copy.
+//
+// The save/open mechanism is a SNAPSHOT CACHE (maintainer decision on sq-atb0): saving captures
+// the whole loaded dataset as an N-Quads snapshot plus the editor state plus source metadata;
+// opening restores that exact dataset (no re-ingest from the original sources). For URL sources
+// the metadata is kept so the source CAN be re-fetched; for local-file imports the original
+// file cannot be silently re-read across sessions — the snapshot is the durable copy. The panel
+// states this limitation plainly rather than implying a local file round-trips.
+
+import * as React from "react";
+import {
+  FolderOpen,
+  Save,
+  Plus,
+  Trash2,
+  HardDrive,
+  Database,
+  Globe,
+  Pencil,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  type WorkspaceBackend,
+  type WorkspaceSummary,
+} from "@sparq/client";
+
+export interface WorkspacePanelProps {
+  /** Whether the persistence backend has resolved (controls are disabled until then). */
+  ready: boolean;
+  /** Which storage resolved — drives the honest "saved to …" label. */
+  backend: WorkspaceBackend | null;
+  /** Every stored workspace, most-recent first. */
+  list: WorkspaceSummary[];
+  /** The currently-open workspace id (or null when on an unsaved scratch session). */
+  currentId: string | null;
+  /** Open a stored workspace by id (restores its dataset + editor state). */
+  onOpen: (id: string) => void;
+  /** Save the current REPL state into the open workspace (overwrites it). */
+  onSave: () => void;
+  /** Save the current REPL state into a NEW workspace with the given name. */
+  onSaveAs: (name: string) => void;
+  /** Start a fresh, empty scratch session (does not delete anything). */
+  onNew: () => void;
+  /** Rename the open workspace. */
+  onRename: (name: string) => void;
+  /** Delete a stored workspace by id. */
+  onDelete: (id: string) => void;
+  /** True while a save/open is in flight (disables the action buttons). */
+  busy?: boolean;
+}
+
+/**
+ * The workspace controls row. A picker to switch workspaces, Save / Save-as / New / Rename /
+ * Delete, and the backend-honesty badge. Mirrors the `DatasetControls` bar styling so the two
+ * read as one family.
+ */
+export function WorkspacePanel({
+  ready,
+  backend,
+  list,
+  currentId,
+  onOpen,
+  onSave,
+  onSaveAs,
+  onNew,
+  onRename,
+  onDelete,
+  busy,
+}: WorkspacePanelProps) {
+  const [saveAsOpen, setSaveAsOpen] = React.useState(false);
+  const [renameOpen, setRenameOpen] = React.useState(false);
+  const disabled = !ready || busy;
+  const current = list.find((w) => w.id === currentId) ?? null;
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex flex-wrap items-center gap-2 rounded-lg border bg-muted/30 p-2">
+        <span className="flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          <FolderOpen className="size-3.5" /> Workspace
+        </span>
+
+        <label htmlFor="repl-workspace" className="sr-only">
+          Open workspace
+        </label>
+        <select
+          id="repl-workspace"
+          value={currentId ?? "__scratch__"}
+          disabled={disabled}
+          onChange={(e) => {
+            const v = e.target.value;
+            if (v === "__scratch__") onNew();
+            else onOpen(v);
+          }}
+          className="h-7 min-w-40 rounded-md border bg-background px-2 text-xs outline-none focus-visible:ring-3 focus-visible:ring-ring/40 disabled:opacity-50"
+        >
+          <option value="__scratch__">
+            {currentId === null ? "Unsaved scratch session" : "New scratch session…"}
+          </option>
+          {list.length > 0 && (
+            <optgroup label="Saved workspaces">
+              {list.map((w) => (
+                <option key={w.id} value={w.id}>
+                  {w.name}
+                  {w.approxTriples > 0 ? ` · ${w.approxTriples} triples` : ""}
+                </option>
+              ))}
+            </optgroup>
+          )}
+        </select>
+
+        <span className="ml-auto flex flex-wrap items-center gap-1.5">
+          <BackendBadge ready={ready} backend={backend} />
+
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={disabled || currentId === null}
+            title="Overwrite the open workspace with the current dataset + editor state"
+            onClick={onSave}
+          >
+            <Save className="size-3.5" /> Save
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            disabled={disabled}
+            title="Save the current dataset + editor state as a new named workspace"
+            onClick={() => setSaveAsOpen(true)}
+          >
+            <Plus className="size-3.5" /> Save as
+          </Button>
+          {currentId !== null && (
+            <>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={disabled}
+                title="Rename the open workspace"
+                onClick={() => setRenameOpen(true)}
+              >
+                <Pencil className="size-3.5" /> Rename
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={disabled}
+                title="Delete the open workspace"
+                onClick={() => {
+                  onDelete(currentId);
+                }}
+              >
+                <Trash2 className="size-3.5" /> Delete
+              </Button>
+            </>
+          )}
+        </span>
+      </div>
+
+      {/* Honest, persistent note about what the snapshot cache does and does NOT round-trip. */}
+      <PersistenceNote backend={backend} sourceCount={current?.sourceCount ?? 0} />
+
+      <NameDialog
+        open={saveAsOpen}
+        onOpenChange={setSaveAsOpen}
+        title="Save as a new workspace"
+        description="Captures the loaded dataset (as a snapshot), the imported-source list, and the SPARQL editor state under a name. Re-opening restores that exact dataset — no re-ingest."
+        confirmLabel="Save workspace"
+        defaultValue={current ? `${current.name} copy` : "My workspace"}
+        onConfirm={(name) => {
+          onSaveAs(name);
+          setSaveAsOpen(false);
+        }}
+      />
+      <NameDialog
+        open={renameOpen}
+        onOpenChange={setRenameOpen}
+        title="Rename workspace"
+        description="Give this workspace a new name."
+        confirmLabel="Rename"
+        defaultValue={current?.name ?? ""}
+        onConfirm={(name) => {
+          onRename(name);
+          setRenameOpen(false);
+        }}
+      />
+    </div>
+  );
+}
+
+// [OPUS-4.8] sq-atb0 — the backend-honesty badge: tells the user exactly where their work is
+// stored, so "persistent" is never overclaimed for the session-only memory fallback.
+function BackendBadge({
+  ready,
+  backend,
+}: {
+  ready: boolean;
+  backend: WorkspaceBackend | null;
+}) {
+  if (!ready || backend === null) {
+    return (
+      <Badge variant="muted" aria-live="polite">
+        Resolving storage…
+      </Badge>
+    );
+  }
+  if (backend === "tauri") {
+    return (
+      <Badge variant="success" title="Saved to this device's local app-data on disk">
+        <HardDrive className="size-3" /> Saved on device
+      </Badge>
+    );
+  }
+  if (backend === "web") {
+    return (
+      <Badge
+        variant="default"
+        title="Saved in this browser's localStorage — persists on this browser/profile only, and can be cleared by browser data-clearing"
+      >
+        <Globe className="size-3" /> Saved in this browser
+      </Badge>
+    );
+  }
+  return (
+    <Badge
+      variant="warning"
+      title="No persistent storage available — workspaces are kept for this session only"
+    >
+      <Database className="size-3" /> This session only
+    </Badge>
+  );
+}
+
+// [OPUS-4.8] sq-atb0 — the standing honesty note. States what the snapshot cache restores and,
+// crucially, the local-file limitation (a previously chosen local file cannot be silently
+// re-read across sessions — the snapshot is the durable copy).
+function PersistenceNote({
+  backend,
+  sourceCount,
+}: {
+  backend: WorkspaceBackend | null;
+  sourceCount: number;
+}) {
+  const where =
+    backend === "tauri"
+      ? "to this device's local storage"
+      : backend === "web"
+        ? "in this browser"
+        : "for this session only";
+  return (
+    <p className="rounded-lg border bg-muted/20 px-2.5 py-1.5 text-[11px] leading-relaxed text-muted-foreground">
+      A workspace saves a <span className="font-medium">snapshot</span> of the loaded dataset,
+      the imported-source list{sourceCount > 0 ? ` (${sourceCount})` : ""}, and the SPARQL
+      editor state {where}. Re-opening restores that exact dataset — it does not re-ingest from
+      the original files. URL sources keep their address so they can be re-fetched;{" "}
+      <span className="font-medium">local file imports cannot be silently re-read</span> across
+      sessions (the browser has no persistent handle), so the snapshot is their durable copy.
+      Bearer tokens are never saved.
+    </p>
+  );
+}
+
+// [OPUS-4.8] sq-atb0 — a tiny name-entry dialog reused by Save-as + Rename. Reuses the shared
+// Dialog primitive + the editor's input styling.
+function NameDialog({
+  open,
+  onOpenChange,
+  title,
+  description,
+  confirmLabel,
+  defaultValue,
+  onConfirm,
+}: {
+  open: boolean;
+  onOpenChange: (o: boolean) => void;
+  title: string;
+  description: string;
+  confirmLabel: string;
+  defaultValue: string;
+  onConfirm: (name: string) => void;
+}) {
+  const [name, setName] = React.useState(defaultValue);
+  // Reset to the default whenever the dialog (re)opens, so a stale edit never leaks across opens.
+  React.useEffect(() => {
+    if (open) setName(defaultValue);
+  }, [open, defaultValue]);
+
+  const submit = React.useCallback(() => {
+    const trimmed = name.trim();
+    if (!trimmed) {
+      toast.error("Enter a workspace name");
+      return;
+    }
+    onConfirm(trimmed);
+  }, [name, onConfirm]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[min(28rem,calc(100vw-2rem))]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FolderOpen className="size-4 text-primary" /> {title}
+          </DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+        <div className="space-y-3">
+          <div className="space-y-1.5">
+            <label htmlFor="workspace-name" className="text-xs font-medium">
+              Workspace name
+            </label>
+            <input
+              id="workspace-name"
+              type="text"
+              value={name}
+              autoFocus
+              spellCheck={false}
+              onChange={(e) => setName(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") submit();
+              }}
+              className="w-full rounded-lg border bg-muted/40 px-3 py-2 text-[13px] outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+            />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button size="sm" disabled={!name.trim()} onClick={submit}>
+              {confirmLabel}
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/site/src/lib/tauri-fs.ts
+++ b/site/src/lib/tauri-fs.ts
@@ -1,0 +1,84 @@
+// [OPUS-4.8] sq-atb0 (epic sq-ixc3) — the OPTIONAL Tauri filesystem loader for workspace
+// persistence. The site is a static export that ALSO runs inside the Tauri 2 webview; this
+// module is the bridge that lets the desktop app persist workspaces to local disk WITHOUT the
+// browser/static build ever depending on a Tauri package.
+//
+// HOW IT STAYS STATIC-EXPORT-SAFE. `@tauri-apps/plugin-fs` is NOT a site dependency (not in
+// package.json). It is imported with a `webpackIgnore` dynamic `import()` of the plugin's
+// runtime ESM module path, evaluated ONLY when we are actually inside a Tauri webview
+// (feature-detected by `isTauriRuntime()` in `@sparq/client`). On the GitHub Pages build the
+// import line is never reached, the module is never bundled, and nothing Tauri-shaped ships.
+//
+// HONEST LIMITATION. The Tauri shell's current capability set (`gui/src-tauri/capabilities/
+// default.json`) grants only `core:default` + `dialog:allow-open` — it does NOT yet grant the
+// `fs` capability. Until the desktop shell adds the `fs:` permissions for the app-local-data
+// scope, this loader returns `null` at runtime and the GUI cleanly degrades to the web
+// (localStorage) backend even inside the Tauri webview. Wiring the `fs` capability + the
+// plugin into the Rust shell is tracked as follow-up bead sq-atb0-fs (a `gui/src-tauri`
+// change, out of the site lane).
+
+"use client";
+
+import { type TauriFsApi } from "@sparq/client";
+
+/**
+ * The shape of `@tauri-apps/plugin-fs` we read at runtime. Declared locally (not imported as a
+ * type from the absent package) so the site typechecks without the Tauri package installed.
+ * `BaseDirectory.AppLocalData` is the per-app local-data dir Tauri reserves for durable app
+ * state.
+ */
+interface TauriFsModule {
+  BaseDirectory: { AppLocalData: number };
+  readTextFile: TauriFsApi["readTextFile"];
+  writeTextFile: TauriFsApi["writeTextFile"];
+  remove: TauriFsApi["remove"];
+  exists: TauriFsApi["exists"];
+  mkdir: TauriFsApi["mkdir"];
+  readDir: TauriFsApi["readDir"];
+}
+
+/**
+ * Dynamically import `@tauri-apps/plugin-fs` at runtime. Isolated in its own one-line helper so
+ * the single `@ts-expect-error` for the intentionally-absent module specifier lands precisely
+ * on the import expression (it is NOT a site dependency — the static build must not bundle a
+ * Tauri package). `webpackIgnore` keeps it out of the bundle graph; it is fetched only inside
+ * the Tauri webview, never on the GitHub Pages build.
+ */
+function importTauriFsPlugin(): Promise<unknown> {
+  // @ts-expect-error — optional Tauri-only module, intentionally absent from the static build.
+  return import(/* webpackIgnore: true */ "@tauri-apps/plugin-fs");
+}
+
+/**
+ * Resolve the Tauri filesystem API scoped to the app's local-data dir, or `null` if the plugin
+ * is not importable / the fs capability was not granted. Passed to
+ * `createWorkspaceStore({ loadTauriFs })`, which only calls it inside a Tauri webview. A failed
+ * import (no plugin) or a permission error resolves to `null` so the store factory falls back
+ * to the web backend rather than throwing.
+ */
+export async function loadTauriFs(): Promise<TauriFsApi | null> {
+  try {
+    // webpackIgnore keeps the Tauri plugin out of the static bundle entirely: it is fetched as
+    // a plain ESM module from the Tauri runtime only when this code path actually runs (inside
+    // the desktop webview). On the GitHub Pages build this line is never reached.
+    //
+    // `@tauri-apps/plugin-fs` is deliberately NOT a site dependency (the static build must not
+    // depend on a Tauri package), so `tsc` cannot resolve the specifier — the import is a pure
+    // runtime concern guarded by `isTauriRuntime()`. The expect-error documents that the
+    // missing-module diagnostic is intentional; the cast pins the runtime shape we use.
+    const mod = (await importTauriFsPlugin()) as unknown as TauriFsModule;
+    if (typeof mod?.writeTextFile !== "function") return null;
+    return {
+      baseDir: mod.BaseDirectory.AppLocalData,
+      readTextFile: mod.readTextFile,
+      writeTextFile: mod.writeTextFile,
+      remove: mod.remove,
+      exists: mod.exists,
+      mkdir: mod.mkdir,
+      readDir: mod.readDir,
+    };
+  } catch {
+    // No plugin / capability not granted — the web (localStorage) backend takes over.
+    return null;
+  }
+}

--- a/site/src/lib/use-workspaces.ts
+++ b/site/src/lib/use-workspaces.ts
@@ -1,0 +1,123 @@
+// [OPUS-4.8] sq-atb0 (epic sq-ixc3) — the React hook that owns the persistent workspace
+// lifecycle for the REPL: it resolves the best persistence backend once, lists/loads/saves/
+// deletes workspaces through the framework-agnostic `WorkspaceStore`, and tracks the last-
+// opened id for startup re-hydration. The wasm-Store snapshotting is NOT here — the hook deals
+// only in the data model; the REPL composes it with `snapshotStore` / `restoreStoreFromSnapshot`
+// so this hook stays free of engine coupling.
+
+"use client";
+
+import * as React from "react";
+import {
+  type Workspace,
+  type WorkspaceBackend,
+  type WorkspaceStore,
+  type WorkspaceSummary,
+  createWorkspaceStore,
+} from "@sparq/client";
+import { loadTauriFs } from "@/lib/tauri-fs";
+
+/** The hook's public surface — what the REPL drives the workspace panel with. */
+export interface UseWorkspaces {
+  /** Whether the persistence backend has resolved yet (false during the initial async pick). */
+  ready: boolean;
+  /** Which concrete storage resolved: durable on Tauri/web, session-only in memory. */
+  backend: WorkspaceBackend | null;
+  /** Every stored workspace, most-recently-updated first. */
+  list: WorkspaceSummary[];
+  /** The id of the workspace last restored on startup, if any (for the REPL's initial open). */
+  initialId: string | null;
+  /** Load one workspace's full record by id. */
+  load(id: string): Promise<Workspace | null>;
+  /** Persist a workspace (create or overwrite); refreshes the list + records it as last-opened. */
+  save(ws: Workspace): Promise<void>;
+  /** Delete a workspace; refreshes the list. */
+  remove(id: string): Promise<void>;
+  /** Record which workspace is open so the next launch re-hydrates it. */
+  setLastOpened(id: string | null): Promise<void>;
+}
+
+/**
+ * Resolve + own the workspace persistence backend, exposing the CRUD surface the REPL needs.
+ * The backend is picked ONCE on mount (`createWorkspaceStore`, feature-detecting Tauri fs →
+ * localStorage → memory). All mutating calls go through the store and then refresh the cached
+ * list. `initialId` is read once on mount so the REPL can restore the last session.
+ */
+export function useWorkspaces(): UseWorkspaces {
+  const storeRef = React.useRef<WorkspaceStore | null>(null);
+  const [ready, setReady] = React.useState(false);
+  const [backend, setBackend] = React.useState<WorkspaceBackend | null>(null);
+  const [list, setList] = React.useState<WorkspaceSummary[]>([]);
+  const [initialId, setInitialId] = React.useState<string | null>(null);
+
+  // Resolve the backend once, then load the list + the last-opened pointer.
+  React.useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      // The Tauri fs loader is passed unconditionally; `createWorkspaceStore` only calls it
+      // INSIDE a Tauri webview (else it picks localStorage / memory), so the static export
+      // never imports the Tauri plugin.
+      const store = await createWorkspaceStore({ loadTauriFs });
+      if (cancelled) return;
+      storeRef.current = store;
+      setBackend(store.backend);
+      const [summaries, last] = await Promise.all([
+        store.list(),
+        store.lastOpenedId(),
+      ]);
+      if (cancelled) return;
+      setList(summaries);
+      setInitialId(last);
+      setReady(true);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const refresh = React.useCallback(async () => {
+    const store = storeRef.current;
+    if (!store) return;
+    setList(await store.list());
+  }, []);
+
+  const load = React.useCallback(async (id: string) => {
+    return (await storeRef.current?.load(id)) ?? null;
+  }, []);
+
+  const save = React.useCallback(
+    async (ws: Workspace) => {
+      const store = storeRef.current;
+      if (!store) return;
+      await store.save(ws);
+      await store.setLastOpenedId(ws.id);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const remove = React.useCallback(
+    async (id: string) => {
+      const store = storeRef.current;
+      if (!store) return;
+      await store.remove(id);
+      await refresh();
+    },
+    [refresh],
+  );
+
+  const setLastOpened = React.useCallback(async (id: string | null) => {
+    await storeRef.current?.setLastOpenedId(id);
+  }, []);
+
+  return {
+    ready,
+    backend,
+    list,
+    initialId,
+    load,
+    save,
+    remove,
+    setLastOpened,
+  };
+}

--- a/site/src/lib/workspace-snapshot.ts
+++ b/site/src/lib/workspace-snapshot.ts
@@ -1,0 +1,43 @@
+// [OPUS-4.8] sq-atb0 (epic sq-ixc3) — the site-side glue between the live wasm Store and the
+// framework-agnostic WORKSPACE model in `@sparq/client`.
+//
+// The workspace model is pure data + a persistence interface; it knows nothing about the wasm
+// engine. This thin module is the ONE place that bridges the two: it serialises the loaded
+// dataset to the workspace's N-Quads SNAPSHOT (the save/open cache) and re-hydrates a Store
+// from that snapshot on open. It stays in the site (NOT in `@sparq/client`) because it is
+// coupled to the site's dataset-format knowledge — exactly like `storeToNQuads` /
+// `loadIntoStore` in `@/lib/sparq-wasm`, which it reuses rather than re-implements.
+
+"use client";
+
+import {
+  loadSparq,
+  loadIntoStore,
+  storeToNQuads,
+  type WasmStore,
+} from "@/lib/sparq-wasm";
+
+/**
+ * Serialise the WHOLE dataset of a live wasm {@link WasmStore} (default graph + every named
+ * graph) to the N-Quads text a workspace stores as its `dataSnapshot` — the save/open cache.
+ * Reuses {@link storeToNQuads}, so it agrees with the "add to current" merge path exactly. An
+ * empty store yields `""`.
+ */
+export function snapshotStore(store: WasmStore): string {
+  return storeToNQuads(store);
+}
+
+/**
+ * Re-hydrate a fresh wasm {@link WasmStore} from a workspace's N-Quads `dataSnapshot`. The
+ * snapshot always carries named graphs (it is N-Quads), so it is loaded with the
+ * named-graph-preserving `loadDataset` path via {@link loadIntoStore}. An empty / whitespace
+ * snapshot yields an empty store. This is the save/open OPEN side: the restored store is
+ * byte-for-byte the dataset the workspace was saved with — no re-ingest from the original
+ * sources.
+ */
+export async function restoreStoreFromSnapshot(
+  snapshot: string | undefined,
+): Promise<WasmStore> {
+  const Store = await loadSparq();
+  return loadIntoStore(Store, snapshot?.trim() ?? "", "nquads");
+}

--- a/site/test/workspace.test.mjs
+++ b/site/test/workspace.test.mjs
@@ -1,0 +1,261 @@
+// [OPUS-4.8] sq-atb0 — unit tests for the persistent cross-session WORKSPACE model + the
+// persistence abstraction (`@sparq/client` `workspace.ts`): the data model + (de)serialisation
+// guards, the web (localStorage) backend over an in-memory polyfill, the in-memory backend, the
+// Tauri backend over an in-memory fake filesystem, and the runtime backend-selection factory.
+// These cover the pure, framework-free logic the REPL workspace panel relies on. Run via
+// `npm run test:unit`.
+//
+// Imported by RELATIVE path (not the `@sparq/client` alias) so the build-free ts-loader resolves
+// it. In Node there is no `window`/`localStorage`, so the tests inject the storage surfaces
+// explicitly — exactly the dependency-injection seams the abstraction is designed for.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  WORKSPACE_SCHEMA,
+  WebWorkspaceStore,
+  MemoryWorkspaceStore,
+  TauriWorkspaceStore,
+  createWorkspaceStore,
+  detectWebStorage,
+  isTauriRuntime,
+  newWorkspace,
+  parseWorkspace,
+  workspaceId,
+  workspaceSummary,
+} from "../../packages/sparq-client/src/workspace.ts";
+
+// A minimal in-memory localStorage polyfill (the `KeyValueStorage` shape).
+function fakeKv() {
+  const map = new Map();
+  return {
+    getItem: (k) => (map.has(k) ? map.get(k) : null),
+    setItem: (k, v) => map.set(k, String(v)),
+    removeItem: (k) => map.delete(k),
+    _map: map,
+  };
+}
+
+// A minimal in-memory TauriFsApi over a path→contents map.
+function fakeFs() {
+  const files = new Map();
+  return {
+    baseDir: 11, // AppLocalData placeholder
+    _files: files,
+    async readTextFile(path) {
+      if (!files.has(path)) throw new Error("ENOENT");
+      return files.get(path);
+    },
+    async writeTextFile(path, contents) {
+      files.set(path, contents);
+    },
+    async remove(path) {
+      files.delete(path);
+    },
+    async exists(path) {
+      // Treat the dir marker generously: any path that is a known dir prefix "exists".
+      if (files.has(path)) return true;
+      return [...files.keys()].some((k) => k.startsWith(path + "/"));
+    },
+    async mkdir() {},
+    async readDir() {
+      return [];
+    },
+  };
+}
+
+// --- the data model ---------------------------------------------------------
+
+test("newWorkspace seeds a current-schema record with a fresh id", () => {
+  const ws = newWorkspace("Demo", "SELECT * WHERE { ?s ?p ?o }");
+  assert.equal(ws.schema, WORKSPACE_SCHEMA);
+  assert.equal(ws.name, "Demo");
+  assert.equal(ws.editor.query, "SELECT * WHERE { ?s ?p ?o }");
+  assert.equal(ws.editor.mode, "run");
+  assert.equal(ws.editor.endpointActive, false);
+  assert.deepEqual(ws.sources, []);
+  assert.match(ws.id, /^ws_/);
+});
+
+test("workspaceId is unique across calls", () => {
+  const a = workspaceId();
+  const b = workspaceId();
+  assert.notEqual(a, b);
+});
+
+test("workspaceSummary derives an approx triple count from the snapshot", () => {
+  const ws = newWorkspace("S", "SELECT 1");
+  ws.dataSnapshot = "<a> <b> <c> .\n<d> <e> <f> .";
+  ws.sources = [{ kind: "url", label: "x", format: "turtle", importedAt: 1 }];
+  const s = workspaceSummary(ws);
+  assert.equal(s.approxTriples, 2);
+  assert.equal(s.sourceCount, 1);
+  assert.equal(workspaceSummary(newWorkspace("E", "")).approxTriples, 0);
+});
+
+test("parseWorkspace round-trips a valid record and rejects junk", () => {
+  const ws = newWorkspace("RT", "ASK {}");
+  ws.dataSnapshot = "<a> <b> <c> .";
+  ws.sources = [
+    { kind: "local", label: "f.ttl", format: "turtle", bytes: 12, importedAt: 5 },
+    { kind: "url", label: "remote", url: "https://x/y.ttl", format: "turtle", importedAt: 6 },
+  ];
+  const parsed = parseWorkspace(JSON.parse(JSON.stringify(ws)));
+  assert.ok(parsed);
+  assert.equal(parsed.name, "RT");
+  assert.equal(parsed.sources.length, 2);
+  assert.equal(parsed.sources[1].url, "https://x/y.ttl");
+  // junk / stale-schema / missing fields are rejected
+  assert.equal(parseWorkspace(null), null);
+  assert.equal(parseWorkspace({}), null);
+  assert.equal(parseWorkspace({ ...ws, schema: 999 }), null);
+  assert.equal(parseWorkspace({ ...ws, editor: undefined }), null);
+});
+
+test("parseWorkspace drops malformed sources but keeps valid ones", () => {
+  const ws = newWorkspace("M", "SELECT 1");
+  const raw = JSON.parse(JSON.stringify(ws));
+  raw.sources = [
+    { kind: "bogus" },
+    { kind: "url", label: "ok", format: "turtle", importedAt: 1 },
+    null,
+  ];
+  const parsed = parseWorkspace(raw);
+  assert.equal(parsed.sources.length, 1);
+  assert.equal(parsed.sources[0].label, "ok");
+});
+
+test("parseWorkspace never persists a token field (editor carries no secret)", () => {
+  const ws = newWorkspace("T", "SELECT 1");
+  ws.editor.endpointActive = true;
+  ws.editor.endpointUrl = "https://srv/sparql";
+  const parsed = parseWorkspace(JSON.parse(JSON.stringify(ws)));
+  assert.equal(parsed.editor.endpointUrl, "https://srv/sparql");
+  assert.ok(!("token" in parsed.editor));
+});
+
+// --- the web (localStorage) backend ----------------------------------------
+
+test("WebWorkspaceStore: save → list → load → setLast → remove", async () => {
+  const store = new WebWorkspaceStore(fakeKv());
+  assert.equal(store.backend, "web");
+  assert.deepEqual(await store.list(), []);
+
+  const a = newWorkspace("A", "SELECT 1");
+  const b = newWorkspace("B", "SELECT 2");
+  await store.save(a);
+  // A 2 ms gap so `b.updatedAt` is strictly later than `a.updatedAt` even on a coarse clock,
+  // making the most-recently-updated-first ordering deterministic for the assertion below.
+  await new Promise((r) => setTimeout(r, 2));
+  await store.save(b);
+
+  const list = await store.list();
+  assert.equal(list.length, 2);
+  // most-recently-updated first (b saved after a)
+  assert.equal(list[0].id, b.id);
+
+  const loaded = await store.load(a.id);
+  assert.equal(loaded.name, "A");
+
+  await store.setLastOpenedId(a.id);
+  assert.equal(await store.lastOpenedId(), a.id);
+
+  await store.remove(a.id);
+  assert.equal(await store.load(a.id), null);
+  assert.equal((await store.list()).length, 1);
+  // last-opened pointer is cleared when the workspace it pointed at is deleted
+  assert.equal(await store.lastOpenedId(), null);
+});
+
+test("WebWorkspaceStore: lastOpenedId is null when it points at a missing id", async () => {
+  const kv = fakeKv();
+  const store = new WebWorkspaceStore(kv);
+  await store.setLastOpenedId("ws_ghost");
+  assert.equal(await store.lastOpenedId(), null);
+});
+
+test("WebWorkspaceStore: a corrupt record is skipped, not thrown", async () => {
+  const kv = fakeKv();
+  const store = new WebWorkspaceStore(kv);
+  const a = newWorkspace("Good", "SELECT 1");
+  await store.save(a);
+  // Hand-corrupt a second indexed entry.
+  kv.setItem("sparq.workspace.v1.__index__", JSON.stringify([a.id, "ws_corrupt"]));
+  kv.setItem("sparq.workspace.v1.ws_corrupt", "{not json");
+  const list = await store.list();
+  assert.equal(list.length, 1);
+  assert.equal(list[0].name, "Good");
+  assert.equal(await store.load("ws_corrupt"), null);
+});
+
+// --- the in-memory backend --------------------------------------------------
+
+test("MemoryWorkspaceStore behaves like the web backend (session-only)", async () => {
+  const store = new MemoryWorkspaceStore();
+  assert.equal(store.backend, "memory");
+  const a = newWorkspace("A", "SELECT 1");
+  await store.save(a);
+  await store.setLastOpenedId(a.id);
+  assert.equal((await store.list()).length, 1);
+  assert.equal(await store.lastOpenedId(), a.id);
+  await store.remove(a.id);
+  assert.equal(await store.lastOpenedId(), null);
+});
+
+// --- the Tauri backend (over a fake fs) ------------------------------------
+
+test("TauriWorkspaceStore: save → list → load → remove over a fake fs", async () => {
+  const fs = fakeFs();
+  const store = new TauriWorkspaceStore(fs);
+  assert.equal(store.backend, "tauri");
+
+  const a = newWorkspace("Disk A", "SELECT 1");
+  a.dataSnapshot = "<a> <b> <c> .";
+  await store.save(a);
+  await store.setLastOpenedId(a.id);
+
+  // The record + index + last pointer are real files under workspaces/.
+  assert.ok(fs._files.has(`workspaces/${a.id}.json`));
+  assert.ok(fs._files.has("workspaces/__index__.json"));
+
+  const list = await store.list();
+  assert.equal(list.length, 1);
+  assert.equal(list[0].approxTriples, 1);
+
+  const loaded = await store.load(a.id);
+  assert.equal(loaded.name, "Disk A");
+  assert.equal(await store.lastOpenedId(), a.id);
+
+  await store.remove(a.id);
+  assert.equal(await store.load(a.id), null);
+  assert.equal(await store.lastOpenedId(), null);
+});
+
+// --- runtime backend selection ---------------------------------------------
+
+test("isTauriRuntime is false in a headless Node (no window)", () => {
+  assert.equal(isTauriRuntime(), false);
+});
+
+test("detectWebStorage returns null when localStorage is absent", () => {
+  // Node has no localStorage global → null (the memory fallback path).
+  assert.equal(detectWebStorage(), null);
+});
+
+test("createWorkspaceStore falls back to memory with no storage + no Tauri", async () => {
+  const store = await createWorkspaceStore();
+  assert.equal(store.backend, "memory");
+});
+
+test("createWorkspaceStore ignores a Tauri fs loader outside a Tauri runtime", async () => {
+  let called = false;
+  const store = await createWorkspaceStore({
+    loadTauriFs: async () => {
+      called = true;
+      return fakeFs();
+    },
+  });
+  // Not in a Tauri webview → the loader is never invoked, and it degrades to memory.
+  assert.equal(called, false);
+  assert.equal(store.backend, "memory");
+});


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am one of multiple agents @jeswr runs on this account. This PR was implemented autonomously by the SPARQ site agent (Opus 4.8, 1M context).

Implements **bead sq-atb0** (P1) under the GUI epic **sq-ixc3**: a **persistent, cross-session workspace model** for the GUI so a user's work survives an app/browser restart.

## What a workspace holds
A named workspace captures:
- a **snapshot** of the loaded dataset — the whole default + named-graph content as N-Quads. This is a **save/open cache** (the maintainer decision on #757: persistence is a save/open snapshot, **not** a re-ingest-from-source on open), mirroring the engine online-snapshot primitive (sq-o5bi / #905). Re-opening restores that exact dataset.
- the **imported-source metadata** — both local-file imports and URL-loaded sources. The URL is kept so a remote source **can** be re-fetched; a local import is listed but re-hydrates from the snapshot (see the limitation below).
- the **SPARQL editor state** — query text, run mode (Run/EXPLAIN/ANALYZE), and the endpoint URL when endpoint mode was active. **No bearer token is ever persisted** (a restored endpoint session re-prompts).

## The persistence abstraction (one interface, three runtime-selected backends)
`@sparq/client` `workspace.ts` defines the framework-agnostic model + a single `WorkspaceStore` interface with three backends, picked by `createWorkspaceStore()` via **feature detection** (never assumes Tauri / localStorage exists):

| Runtime | Backend | Durability |
|---|---|---|
| Tauri desktop app (fs capability granted) | `TauriWorkspaceStore` → app-local-data JSON files | on disk, survives restart |
| Browser / GitHub Pages static export | `WebWorkspaceStore` → `localStorage` | per browser/profile |
| No storage (SSR/build, locked-down webview) | `MemoryWorkspaceStore` | this session only |

The **static export never depends on a Tauri API**: `@tauri-apps/plugin-fs` is *not* a site dependency; it is a `webpackIgnore`'d runtime-only dynamic import (`site/src/lib/tauri-fs.ts`) reached only inside a Tauri webview (`isTauriRuntime()`). Verified the static `out/` bundle does **not** contain the plugin source — only the `import("@tauri-apps/plugin-fs")` specifier string survives as a runtime fetch target.

The last-opened workspace **re-hydrates on startup** (after the engine pre-warm, so the snapshot replaces a known-good store; a failure is non-fatal — the user keeps the scratch session).

## Honest re-hydration limitation (documented, not papered over)
A previously chosen **local file cannot be silently re-read across sessions** — the browser keeps no persistent handle (no fresh user gesture, and the File System Access API is non-static). So the **snapshot is a local import's durable copy**, and the panel + README state this plainly. URL sources keep their address and are re-fetchable.

The desktop **Tauri on-disk path is wired but dormant** until the shell grants the `fs` capability (the current `gui/src-tauri/capabilities/default.json` grants only `core:default` + `dialog:allow-open`) — that is a `gui/src-tauri` Rust change, **out of the site lane**, filed as a follow-up bead (below). Until then the Tauri webview cleanly degrades to the localStorage backend.

## Files / routes
- `packages/sparq-client/src/workspace.ts` (+ `index.ts` exports) — the model + `WorkspaceStore` + Web/Memory/Tauri backends + the selection factory
- `site/src/lib/{workspace-snapshot,use-workspaces,tauri-fs}.ts` — site-side glue (wasm-Store ⇄ snapshot bridge, the React lifecycle hook, the optional Tauri fs loader)
- `site/src/components/workspace-panel.tsx` — the workspace switcher + Save/Save-as/New/Rename/Delete + the backend-honesty badge
- `site/src/components/repl{,-datasets}.tsx` — wired into `/try` (source-metadata capture, the handlers, startup re-hydration)
- `site/test/workspace.test.mjs` — new unit suite
- `site/README.md` — honest feature note

## Gates
- **Static export GREEN end-to-end** in **both** build modes: `npm run build` (Pages, `basePath /sparq`) and `npm run build:tauri` (`basePath ""`). `/try` + all existing routes emitted into `out/`.
- **lint** clean (`next lint`).
- **tsc --noEmit** clean for both the **site** and **@sparq/client**. No `any`-escape hatch (one scoped `@ts-expect-error` for the intentionally-absent Tauri-only module specifier, isolated to a one-line helper).
- **unit suite** green — **248 tests** (model + (de)serialisation guards, all three backends over injected storage/fs polyfills, the selection factory).
- No new runtime dependency. No bundle-size impact on the static build (Tauri plugin not bundled). No bearer token persisted.

## Data honesty
No performance numbers added. No ZK/MPC copy touched. Workspace copy makes no benchmark claims — the only measured value the REPL shows remains the live per-query `performance.now()` latency (unchanged).

Auto-merge intentionally **OFF** — this is a GUI/UX change for review.

Refs epic **sq-ixc3**, closes bead **sq-atb0**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)