### PR TITLE
fix(ci/sbom): harden js-sbom lane against external dev-deps on a published member (sq-pl1p) [OPUS-4.8]

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -380,10 +380,20 @@ jobs:
       # which BOTH `npm ls --omit=dev` and the full `npm ls` exit 0, while the runtime (--omit=dev)
       # closure stays exactly the real runtime dep set (no dev-link leak into the published SBOM
       # surface). HARD job (no "advisory" token) — a regression reds the ci-summary gate.
-      - name: shellcheck gen-js-sbom.sh + the derive-lock self-test
-        run: shellcheck scripts/gen-js-sbom.sh scripts/tests/test_derive_workspace_member_lock.sh
+      - name: shellcheck gen-js-sbom.sh + the derive-lock self-tests
+        run: shellcheck scripts/gen-js-sbom.sh scripts/tests/test_derive_workspace_member_lock.sh scripts/tests/test_js_sbom_external_devdep.sh
       - name: "Self-test derive-workspace-member-lock.mjs (workspace-link materialization — sq-f04e)"
         run: bash scripts/tests/test_derive_workspace_member_lock.sh
+      # [OPUS-4.8] sq-pl1p (sq-f04e/#887 + #922 class): sq-f04e hardened only the workspace-LINK
+      # dep case. An EXTERNAL (registry) devDependency added to a PUBLISHED member (js/) projects its
+      # full transitive closure into the derived lock; a real dev-dep tree's unsatisfied peerDeps make
+      # cyclonedx-npm's FULL `npm ls` exit 254 (the #922 break). The fix keeps the runtime SBOM strict
+      # (--omit=dev prunes the dev tree) and passes --ignore-npm-errors on the DEV SBOM only (still
+      # enumerating the full set; superset honesty guard in gen-js-sbom.sh). This hermetic self-test
+      # (synthetic root lock, no network, node+npm only) pins the runtime-strict + dev-break-is-real +
+      # runtime-honesty teeth. HARD job (no "advisory" token) — a regression reds the ci-summary gate.
+      - name: "Self-test js-sbom lane vs external dev-deps on a published member (sq-pl1p)"
+        run: bash scripts/tests/test_js_sbom_external_devdep.sh
 
   # ----------------------------- ADVISORY -----------------------------
   markdownlint-advisory:

--- a/scripts/gen-js-sbom.sh
+++ b/scripts/gen-js-sbom.sh
@@ -111,13 +111,36 @@ echo "    -> runtime tree (--omit dev): $runtime_out"
     --mc-type library \
     --output-file "$runtime_out" )
 
-# Full build-time tree (incl. devDependencies) — parity with the Rust full-tree SBOM.
+# [OPUS-4.8] sq-pl1p (sq-f04e/#887 + #922 class): full build-time tree (incl. devDependencies)
+# — parity with the Rust full-tree SBOM. `--ignore-npm-errors` is REQUIRED here, and ONLY here.
+#
+# WHY (the exact #922 break mechanism): cyclonedx-npm shells out to
+# `npm ls --json --long --all --package-lock-only` (NO `--omit`) to enumerate the FULL tree, then
+# THROWS (exit 254) if that npm ls exits non-zero AND --ignore-npm-errors is unset (its default;
+# cyclonedx-npm builders.js fetchNpmLs). When a PUBLISHED member (js/ = @jeswr/sparq) declares an
+# EXTERNAL (registry) devDependency, derive-workspace-member-lock.mjs projects that dep's full
+# transitive closure into the standalone lock. A real dev-dep closure (e.g. @solid/acl-check ->
+# rdflib -> undici/cross-fetch, or n3) routinely carries UNSATISFIED `peerDependencies` and
+# version-overlap that `npm ls --package-lock-only` validates and flags as `missing`/`invalid`
+# (ELSPROBLEMS). That is INSTALL-FREE lock-VALIDATION noise — npm never actually installs here —
+# not a real defect, but the FULL view trips it (the runtime `--omit dev` view does NOT: it prunes
+# the entire dev subtree BEFORE validation, so it stays strict, see above). #922 worked around
+# this by relocating 3 test-only dev-deps to the repo-root package.json; this is the PROPER fix so
+# any future external dev-dep on a published member can't re-trip exit 254.
+#
+# HONESTY: --ignore-npm-errors only suppresses npm ls's NON-ZERO EXIT; cyclonedx still consumes
+# npm ls's STDOUT, so the FULL component set (every dev dep + its closure) is still enumerated —
+# nothing is dropped from the build-time SBOM. The runtime SBOM above keeps STRICT validation (NO
+# --ignore-npm-errors) so a genuine runtime-graph version conflict still reds the lane. And the
+# superset guard below asserts the dev SBOM still contains every runtime component, so this flag
+# can never silently hide a real runtime supply-chain surface.
 echo "    -> full build tree (incl. dev): $dev_out"
 ( cd "$JS_DIR" && npx --yes "$CDX_NPM" \
     --spec-version 1.5 \
     --output-format JSON \
     --package-lock-only \
     --no-workspaces \
+    --ignore-npm-errors \
     --mc-type library \
     --output-file "$dev_out" )
 
@@ -145,6 +168,27 @@ for f in "$runtime_out" "$dev_out"; do
     console.log("    OK", process.argv[1], "—", (d.components||[]).length, "component(s), specVersion", d.specVersion);
   ' "$f"
 done
+
+# [OPUS-4.8] sq-pl1p: HONESTY GUARD for the --ignore-npm-errors on the dev SBOM. Assert the dev
+# (full) SBOM is a SUPERSET of the runtime SBOM by purl — i.e. the relaxed dev pass can never
+# silently DROP a real runtime supply-chain component (which would understate the shipped surface).
+# If a runtime purl is missing from the dev tree, fail LOUDLY rather than emit a dishonest SBOM.
+echo "    -> honesty guard: dev SBOM must contain every runtime component"
+node -e '
+  const fs = require("fs");
+  const purls = (p) => new Set((JSON.parse(fs.readFileSync(p, "utf8")).components || [])
+    .map(c => c.purl).filter(Boolean));
+  const runtime = purls(process.argv[1]);
+  const dev = purls(process.argv[2]);
+  const missing = [...runtime].filter(p => !dev.has(p));
+  if (missing.length) {
+    console.error("ERROR: dev SBOM is NOT a superset of the runtime SBOM — runtime purl(s) absent");
+    console.error("       from the dev tree (the --ignore-npm-errors pass dropped a real runtime");
+    console.error("       component): " + JSON.stringify(missing));
+    process.exit(1);
+  }
+  console.log("    OK runtime SBOM (" + runtime.size + " purl) is a subset of the dev SBOM (" + dev.size + " purl)");
+' "$runtime_out" "$dev_out"
 
 echo "==> done. JS SBOMs in $OUT_DIR/:"
 for f in "$OUT_DIR"/sparq-js*.cdx.json; do

--- a/scripts/tests/test_js_sbom_external_devdep.sh
+++ b/scripts/tests/test_js_sbom_external_devdep.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] sq-pl1p — hermetic regression self-test guarding the js-sbom lane against EXTERNAL
+# (registry) devDependencies added to a PUBLISHED workspace member (e.g. js/ = @jeswr/sparq).
+# Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# WHY (the exact break this pins): gen-js-sbom.sh DERIVES a standalone per-member lock out of the
+# repo-root package-lock.json (derive-workspace-member-lock.mjs), then runs cyclonedx-npm twice:
+#   * RUNTIME SBOM — cyclonedx shells out to `npm ls ... --package-lock-only --omit=dev`.
+#   * DEV SBOM     — cyclonedx shells out to `npm ls ... --package-lock-only` (NO --omit).
+# cyclonedx-npm THROWS (exit 254) if its npm ls exits non-zero and --ignore-npm-errors is unset.
+# The sq-f04e hardening (#887) only covered workspace LINK deps. It did NOT cover EXTERNAL dev-deps:
+# when a published member declares one, the derive script projects that dep's FULL transitive
+# closure into the standalone lock; a real dev-dep closure (e.g. @solid/acl-check -> rdflib ->
+# undici, or n3) routinely carries UNSATISFIED peerDependencies / version-overlap that
+# `npm ls --package-lock-only` (the FULL view) flags as missing/invalid -> ELSPROBLEMS -> exit 254,
+# GATING the SBOM lane (the #922 class). #922's workaround relocated the test-only dev-deps to the
+# repo-root package.json; sq-pl1p is the proper fix:
+#   1. the RUNTIME (`--omit=dev`) view PRUNES the entire dev subtree BEFORE validation, so it stays
+#      green AND STRICT (no --ignore-npm-errors) — a real RUNTIME-graph conflict still reds the lane;
+#   2. the DEV (full) SBOM passes cyclonedx `--ignore-npm-errors`, which suppresses only npm ls's
+#      non-zero EXIT (install-free lock-VALIDATION noise) while STILL enumerating the full component
+#      set — nothing is dropped from the build-time SBOM.
+#
+# This pins THREE load-bearing behaviours over a tiny SYNTHETIC root lock (no real repo content),
+# matching the EXACT npm ls flags cyclonedx-npm@5.0.0 uses (builders.js fetchNpmLs):
+#   A. RUNTIME STRICT — a published member with an external dev-dep whose closure has an UNSATISFIED
+#      peer must still yield a derived lock on which `npm ls --omit=dev` exits 0 (the runtime SBOM
+#      keeps strict validation; the dev noise is pruned, never suppressed in the runtime view).
+#   B. DEV BREAK IS REAL — the FULL `npm ls` (no --omit) on that SAME lock exits NON-ZERO
+#      (ELSPROBLEMS) — proving the break mechanism is live and the --ignore-npm-errors on the dev
+#      SBOM is load-bearing, not decorative.
+#   C. RUNTIME HONESTY — the runtime (`--omit=dev`) closure still contains the member's REAL runtime
+#      dep (fzstd) and NOT the dev-only tree — the published runtime surface is unchanged + complete.
+#
+# HERMETIC: builds its own throwaway root package-lock.json under a mktemp dir; no repo content, no
+# network (`--package-lock-only`). Requires `node` + `npm`. If either is absent we SKIP with a clear
+# message rather than fail, so the harness never reds a box that simply lacks the toolchain.
+#
+# Run:  bash scripts/tests/test_js_sbom_external_devdep.sh   (exit 0 = pass, 1 = a case failed)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DERIVE="${ROOT}/scripts/derive-workspace-member-lock.mjs"
+
+[ -f "$DERIVE" ] || { echo "FATAL: derive script not found at ${DERIVE}"; exit 2; }
+
+if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+  echo "SKIP: 'node' and/or 'npm' not on PATH — both are needed to run this self-test."
+  exit 0
+fi
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+# --------------------------------------------------------------------------- #
+# Synthetic repo-root lock (lockfileVersion 3) mirroring the real npm-workspaces shape:
+#   * member "mbr"  — the "published" member (stands in for js/), runtime dep `fzstd`, EXTERNAL
+#                     (registry) dev dep `tooly`.
+#   * "tooly"       — an external dev-dep whose transitive closure carries an UNSATISFIED
+#                     peerDependency (`peerthing`), exactly the shape a real dev-dep tree
+#                     (rdflib/undici/n3 …) surfaces under `npm ls --package-lock-only`. `peerthing`
+#                     is intentionally NOT present in the lock — npm reports `missing: peerthing`.
+# derive-workspace-member-lock.mjs resolves the root lock RELATIVE TO ITS OWN LOCATION
+# (scripts/../package-lock.json), so we copy the script into the temp project so its `..` points at
+# the synthetic root, keeping the test fully hermetic.
+# --------------------------------------------------------------------------- #
+PROJ="${TMP}/proj"
+mkdir -p "${PROJ}/scripts" "${PROJ}/mbr"
+cp "$DERIVE" "${PROJ}/scripts/derive-workspace-member-lock.mjs"
+
+cat > "${PROJ}/package-lock.json" <<'JSON'
+{
+  "name": "synthetic-monorepo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": { "name": "synthetic-monorepo", "workspaces": ["mbr"] },
+    "mbr": {
+      "name": "@synthetic/mbr",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": { "fzstd": "^0.1.1" },
+      "devDependencies": { "tooly": "^1.0.0" }
+    },
+    "node_modules/fzstd": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/fzstd/-/fzstd-0.1.1.tgz",
+      "integrity": "sha512-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="
+    },
+    "node_modules/tooly": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/tooly/-/tooly-1.0.0.tgz",
+      "integrity": "sha512-BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB==",
+      "peerDependencies": { "peerthing": "^3.0.0" }
+    }
+  }
+}
+JSON
+
+# Member manifest co-located with the derived lock (npm reconciles it against the lock root).
+cat > "${PROJ}/mbr/package.json" <<'JSON'
+{
+  "name": "@synthetic/mbr",
+  "version": "0.1.0",
+  "dependencies": { "fzstd": "^0.1.1" },
+  "devDependencies": { "tooly": "^1.0.0" }
+}
+JSON
+
+OUT_LOCK="${PROJ}/mbr/package-lock.json"
+if ! node "${PROJ}/scripts/derive-workspace-member-lock.mjs" mbr "$OUT_LOCK" >/tmp/derive-extdev.log 2>&1; then
+  echo "FAIL: derive script exited non-zero on a member with an external dev dep:"
+  sed 's/^/    /' /tmp/derive-extdev.log
+  exit 1
+fi
+
+# Sanity: the external dev-dep WAS projected into the derived lock (the derive script does its job).
+node - "$OUT_LOCK" <<'NODE'
+const fs = require("fs");
+const p = JSON.parse(fs.readFileSync(process.argv[2], "utf8")).packages;
+const fail = (m) => { console.error("FAIL: " + m); process.exit(1); };
+if (!p["node_modules/fzstd"]) fail("the member's real runtime dep fzstd was not projected");
+if (!p["node_modules/tooly"]) fail("the member's external dev dep tooly was not projected into the lock");
+console.log("PASS: derive projected both the runtime dep (fzstd) and the external dev dep (tooly)");
+NODE
+
+# The EXACT npm ls flags cyclonedx-npm@5.0.0 emits (builders.js fetchNpmLs); gen-js-sbom.sh passes
+# --no-workspaces -> cyclonedx maps that to `--workspaces=false`.
+RUNTIME_LS=(npm ls --json --long --all --package-lock-only --omit=dev --workspaces=false)
+DEV_LS=(npm ls --json --long --all --package-lock-only --workspaces=false)
+
+# --------------------------------------------------------------------------- #
+# Case A (TEETH — RUNTIME STRICT): the runtime SBOM's npm ls (--omit=dev) must exit 0. The dev tree
+# (incl. the unsatisfied peer) is pruned BEFORE validation, so the runtime SBOM stays green WITHOUT
+# any --ignore-npm-errors — a genuine runtime conflict would still red this.
+# --------------------------------------------------------------------------- #
+if ( cd "${PROJ}/mbr" && "${RUNTIME_LS[@]}" ) >/tmp/extdev-omitdev.json 2>/tmp/extdev-omitdev.err; then
+  echo "PASS: runtime npm ls --omit=dev exits 0 on a derived lock carrying an external dev-dep tree"
+else
+  echo "FAIL: runtime npm ls --omit=dev errored on a derived lock with an external dev-dep (sq-pl1p regression):"
+  sed 's/^/    /' /tmp/extdev-omitdev.err
+  exit 1
+fi
+
+# --------------------------------------------------------------------------- #
+# Case B (the break is REAL): the FULL npm ls (no --omit) on the SAME derived lock MUST exit
+# non-zero (ELSPROBLEMS: missing peer). This proves the #922 break mechanism is live and that the
+# `--ignore-npm-errors` on the DEV SBOM in gen-js-sbom.sh is load-bearing, not decorative. If npm
+# ever stops flagging this (so the full view goes green on its own) the test SKIPS this assertion
+# loudly rather than failing — the hardening is then simply belt-and-braces.
+# --------------------------------------------------------------------------- #
+if ( cd "${PROJ}/mbr" && "${DEV_LS[@]}" ) >/tmp/extdev-full.json 2>/tmp/extdev-full.err; then
+  echo "NOTE: full npm ls (no --omit) unexpectedly exited 0 — this npm no longer flags the unsatisfied"
+  echo "      peer under --package-lock-only; the dev-SBOM --ignore-npm-errors is then belt-and-braces."
+else
+  echo "PASS: full npm ls (no --omit) exits NON-ZERO on the external-dev-dep lock — the #922 break is real,"
+  echo "      so the dev-SBOM cyclonedx --ignore-npm-errors in gen-js-sbom.sh is load-bearing."
+  # Confirm it is the expected lock-validation noise (ELSPROBLEMS), not an unrelated hard crash.
+  if ! grep -q "ELSPROBLEMS" /tmp/extdev-full.err; then
+    echo "FAIL: the full npm ls failed for a NON-ELSPROBLEMS reason (unexpected) — investigate:"
+    sed 's/^/    /' /tmp/extdev-full.err
+    exit 1
+  fi
+fi
+
+# --------------------------------------------------------------------------- #
+# Case C (RUNTIME HONESTY): the runtime (--omit=dev) closure must still contain the member's REAL
+# runtime dep fzstd and MUST NOT contain the dev-only `tooly` — the published runtime surface is
+# unchanged and complete (the fix never drops a real runtime dep to make the lane pass).
+# --------------------------------------------------------------------------- #
+node - /tmp/extdev-omitdev.json <<'NODE'
+const fs = require("fs");
+const tree = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const deps = Object.keys(tree.dependencies || {});
+const fail = (m) => { console.error("FAIL: " + m + " (runtime deps were: " + JSON.stringify(deps) + ")"); process.exit(1); };
+if (!deps.includes("fzstd")) fail("runtime (--omit=dev) tree is missing the real runtime dep fzstd");
+if (deps.includes("tooly")) fail("the external dev-only dep (tooly) leaked into the runtime (--omit=dev) tree");
+console.log("PASS: runtime (--omit=dev) closure is exactly the real runtime dep set (fzstd); no dev-dep leak");
+NODE
+
+echo "All js-sbom external-dev-dep self-tests passed."


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (Opus 4.8, 1M context) working on `jeswr/sparq` CI / supply-chain infrastructure. Flagging for human review; auto-merge intentionally OFF (supply-chain change).

Closes **sq-pl1p**. Systemic follow-up to the #887 (sq-f04e) / #922 class.

## The exact break mechanism

`scripts/gen-js-sbom.sh` derives a standalone per-member lock out of the repo-root `package-lock.json` (`scripts/derive-workspace-member-lock.mjs`), then runs `cyclonedx-npm@5.0.0` **twice**:
- **runtime** SBOM → cyclonedx shells out to `npm ls … --package-lock-only --omit=dev`
- **dev** (full) SBOM → cyclonedx shells out to `npm ls … --package-lock-only` (**no** `--omit`)

cyclonedx-npm **throws** (exit 254) if its `npm ls` exits non-zero **and** `--ignore-npm-errors` is unset (its default — confirmed in the tarball's `builders.js` `fetchNpmLs`).

The sq-f04e hardening (#887) only covered workspace **LINK** deps. It did **not** cover **external (registry) dev-deps**. When a *published* member (`js/` = `@jeswr/sparq`) declares one, the derive script projects that dep's **full transitive closure** into the standalone lock. A real dev-dep closure (e.g. `@solid/acl-check` → `rdflib` → `undici`, or `n3`) routinely carries **unsatisfied peerDependencies / version-overlap** that `npm ls --package-lock-only` (the **full** view) flags as `missing`/`invalid` → `ELSPROBLEMS` → cyclonedx exit 254 → **gates the SBOM lane** (the #922 class). #922's workaround relocated 3 test-only dev-deps to the repo-root `package.json`; this is the proper fix.

I reproduced this with the real tooling: a published member + an external dev-dep whose closure has an unsatisfied peer → `npm ls --omit=dev` exits **0** (runtime view prunes the dev tree), but the **full** `npm ls` exits non-zero (`missing: peer …`), which is exactly what cyclonedx surfaces as 254.

## The fix (and why it keeps the SBOM honest)

- **Runtime SBOM stays STRICT** (no `--ignore-npm-errors`): `--omit=dev` prunes the dev subtree **before** validation, so the consumer-facing/released SBOM keeps full validation **and** the full runtime surface (`fzstd`). A genuine *runtime*-graph conflict still reds the lane.
- **Dev (full) SBOM** passes cyclonedx `--ignore-npm-errors`, and **only** there: it suppresses solely npm ls's non-zero **exit** (install-free lock-**validation** noise — npm never installs here), while cyclonedx still consumes npm ls's stdout, so the **full component set is still enumerated** — nothing dropped from the build-time SBOM. Verified: cyclonedx with `--ignore-npm-errors` against a peer-broken lock still emits every component (`fzstd` + the dev dep).
- **Honesty guard** in `gen-js-sbom.sh`: asserts the dev SBOM is a **purl-superset** of the runtime SBOM, so the relaxed dev pass can never silently drop a real runtime supply-chain component.
- **Regression guard** `scripts/tests/test_js_sbom_external_devdep.sh` (hermetic, synthetic root lock, no network, node+npm only) pins three teeth: **runtime-strict** (`--omit=dev` exits 0), **dev-break-is-real** (full `npm ls` exits non-zero with `ELSPROBLEMS` — proving `--ignore-npm-errors` is load-bearing), and **runtime-honesty** (runtime closure is exactly `fzstd`, no dev leak). Wired into the **gating** `ci-scripts` job in `docs-quality.yml` (shellcheck + run).

## Validation
- `python3 -c "import yaml; …"` parses `docs-quality.yml` + `supply-chain.yml`: **OK**
- `actionlint .github/workflows/docs-quality.yml`: **0 issues**
- `shellcheck` on `gen-js-sbom.sh` + both self-tests: **OK**
- Real `gen-js-sbom.sh` on the current tree: both SBOMs emit, honesty guard passes (runtime ⊆ dev), transient `js/package-lock.json` cleaned up.
- New external-dev-dep test + existing link-dep test: **both green**.
- `typos` on changed content: clean. No hard-coded perf numbers. SHA-pinned actions untouched.
- **Gate aggregator**: this leg lives in the gating `ci-scripts` job (no `advisory`/`informational` token, no `continue-on-error`) → a regression reds `ci-summary / gate`. No required check added or removed.

Compliance gap closed: removes a recurring foot-gun in the JS CycloneDX SBOM lane (gap GS-3 surface) — the runtime SBOM stays a faithful, validated record of the published `@jeswr/sparq` runtime surface, and a future external dev-dep on a published member can no longer silently break SBOM derivation or the `js` gate.

Refs #887 (sq-f04e), #922.

🤖 Generated with [Claude Code](https://claude.com/claude-code)