### PR TITLE
fix(site): GUI SHACL validator __wbg_ptr crash (lost wasm receiver) + Playwright e2e (sq-800o)

### DIFF
--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -364,7 +364,13 @@ export async function sparqShaclValidate(
         "Rebuild sparq-wasm with --features shacl.",
     );
   }
-  return JSON.parse(validate(data, shapes, format)) as ShaclReport;
+  // [OPUS-4.8] sq-800o — LOST-RECEIVER fix. The line above only EXISTENCE-checks a detached
+  // method reference (so a lean, no-`shacl` bundle still yields the clear error above). It must
+  // NOT be the thing we CALL: wasm-bindgen's `Store.validate` body does
+  // `wasm.store_validate(this.__wbg_ptr, …)`, so invoking the detached `validate(…)` runs with
+  // `this === undefined` and throws `Cannot read properties of undefined (reading '__wbg_ptr')`.
+  // Invoke it BOUND to the `store` receiver so `this.__wbg_ptr` resolves to the live store.
+  return JSON.parse(store.validate(data, shapes, format)) as ShaclReport;
 }
 
 // ---------------------------------------------------------------------------

--- a/site/e2e/shacl-validator.spec.ts
+++ b/site/e2e/shacl-validator.spec.ts
@@ -1,0 +1,141 @@
+// [OPUS-4.8] sq-800o (epic sq-ixc3) — headless browser smoke test for the /surface/shacl
+// live SHACL validator. THIS IS THE REGRESSION GUARD.
+//
+// WHAT IT GUARDS. The validator (src/components/shacl-playground.tsx `run()`) calls
+// `sparqShaclValidate` (re-exported from `@sparq/client`) on the shacl-enabled wasm bundle and
+// renders a W3C validation report. The fixed bug (sq-800o): `sparqShaclValidate` extracted the
+// wasm `Store.validate` as a DETACHED method reference and invoked it bare — wasm-bindgen's
+// `validate` body does `wasm.store_validate(this.__wbg_ptr, …)`, so with `this === undefined`
+// it threw `Cannot read properties of undefined (reading '__wbg_ptr')`. The report never
+// rendered and the run landed in the error/toast path. The fix invokes `store.validate(…)` on
+// the live receiver. This spec drives a REAL headless Chromium: it runs the default example
+// (`ex:age "thirty"` — a datatype violation), asserts the report renders with
+// `sh:conforms = false` and at least one DatatypeConstraintComponent violation, and asserts
+// ZERO console errors across the interaction. Pre-fix, the `__wbg_ptr` throw both surfaces a
+// console error AND leaves the report panel absent — so this test fails red on the regression.
+//
+// DOM ANCHORS. Stable `data-testid` / `data-*` attributes added to the component (no copy
+// scraping): `[data-testid="shacl-report"]` (the result panel), `[data-conforms]` (the
+// conformance banner's boolean), `[data-testid="shacl-violation"]` + `[data-component]` (each
+// per-violation card and its constraint component). The "Compact syntax" path reuses the
+// pre-existing `[data-testid="scs-output"]` anchor.
+//
+// It is a CORRECTNESS smoke test, not a benchmark: it asserts the report's DOM, never a
+// wall-clock threshold (timings on a work-box / CI runner are non-canonical).
+//
+// WASM PREREQ. Like repl-results.spec.ts, the validator loads the wasm bundle from
+// `public/wasm/` (a gitignored build artifact synced from `js`'s `build:wasm`, which builds
+// `--features shacl,jsonld,…` so `validate` exists). The light site-e2e CI lane has no Rust
+// toolchain to build it, so this whole spec SKIPS when the bundle is absent and runs in full
+// when present. Run after `npm run sync-wasm`:
+//   npx playwright install chromium && npm run test:e2e
+import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Relative (no leading slash) so it resolves UNDER the baseURL's `/sparq/` basePath.
+const ROUTE = "surface/shacl/";
+
+// The shacl-enabled wasm bundle the validator loads at runtime. Synced into public/wasm/ by
+// `sync-wasm` from the `js` build; gitignored, so its presence gates this spec.
+const WASM_BUNDLE = fileURLToPath(
+  new URL("../public/wasm/sparq_wasm_bg.wasm", import.meta.url),
+);
+
+// Skip the whole file when the wasm bundle has not been built/synced — the light CI lane does
+// not produce it, and a validator that cannot load the engine is not the thing under test.
+test.skip(
+  !existsSync(WASM_BUNDLE),
+  "wasm bundle absent (public/wasm/sparq_wasm_bg.wasm) — run `npm run sync-wasm` after `(cd ../js && npm run build:wasm)`",
+);
+
+/** Collect every `console.error` the page emits, so the test can assert there were none. */
+function trackConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(String(err)));
+  return errors;
+}
+
+/** Navigate to /surface/shacl and wait for the wasm engine readiness pill to settle. */
+async function gotoReady(page: Page): Promise<void> {
+  await page.goto(ROUTE, { waitUntil: "domcontentloaded" });
+  // The playground pre-warms the engine on mount; the badge flips to "Engine ready".
+  await expect(page.getByText("Engine ready")).toBeVisible({ timeout: 90_000 });
+}
+
+test("the default example validates to a non-conformant report with a datatype violation", async ({
+  page,
+}) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoReady(page);
+
+  // Run the default example (the `ex:age "thirty"` datatype violation) via the Validate button.
+  await page.getByRole("button", { name: "Validate" }).click();
+
+  // The report panel renders. Pre-fix this never appears: the detached `validate(…)` threw
+  // `Cannot read properties of undefined (reading '__wbg_ptr')` and the run hit the error path.
+  const report = page.locator('[data-testid="shacl-report"]');
+  await expect(report).toBeVisible({ timeout: 30_000 });
+
+  // The conformance banner reports sh:conforms = false (a string datatype where the shape
+  // requires xsd:integer). Asserted via the stable data-conforms attr, not the banner copy.
+  await expect(report.locator("[data-conforms]")).toHaveAttribute(
+    "data-conforms",
+    "false",
+  );
+
+  // At least one violation, and the datatype one is present (DatatypeConstraintComponent).
+  const violations = report.locator('[data-testid="shacl-violation"]');
+  expect(await violations.count()).toBeGreaterThan(0);
+  await expect(
+    report.locator('[data-component="DatatypeConstraintComponent"]'),
+  ).toHaveCount(1);
+
+  // The whole interaction produced zero console errors — this is what catches the __wbg_ptr
+  // regression (pre-fix the detached call logged the TypeError to the console).
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});
+
+test("the conforming example validates to sh:conforms = true with no violations", async ({
+  page,
+}) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoReady(page);
+
+  // Switch to the "Conforming data" example (ex:age is a well-typed integer), then validate.
+  await page.getByRole("button", { name: "Conforming data" }).click();
+  await page.getByRole("button", { name: "Validate" }).click();
+
+  const report = page.locator('[data-testid="shacl-report"]');
+  await expect(report).toBeVisible({ timeout: 30_000 });
+  await expect(report.locator("[data-conforms]")).toHaveAttribute(
+    "data-conforms",
+    "true",
+  );
+  // A conforming report carries no per-violation cards.
+  await expect(report.locator('[data-testid="shacl-violation"]')).toHaveCount(0);
+
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});
+
+test("the Compact syntax button renders the shapes graph in SHACL Compact Syntax", async ({
+  page,
+}) => {
+  // A SEPARATE wasm path (loadIntoStore + matchQuads, not validate) — worth covering since the
+  // scs-output anchor already exists. Guards that the shapes graph round-trips to compact form.
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoReady(page);
+
+  await page.getByRole("button", { name: "Compact syntax" }).click();
+
+  const scs = page.locator('[data-testid="scs-output"]');
+  await expect(scs).toBeVisible({ timeout: 30_000 });
+  // The default PersonShape carries an ex:age property constraint; the compact rendering names
+  // the node shape. Assert a stable token of the compact grammar rather than the full text.
+  await expect(scs).toContainText("PersonShape");
+
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});

--- a/site/e2e/workspace-save-open.spec.ts
+++ b/site/e2e/workspace-save-open.spec.ts
@@ -1,0 +1,138 @@
+// [OPUS-4.8] sq-800o (epic sq-ixc3) — headless browser smoke test for the /try REPL
+// workspace SAVE / OPEN flow (the persistence model from sq-atb0 / #965).
+//
+// WHAT IT GUARDS. The workspace panel (src/components/workspace-panel.tsx, wired into
+// src/components/repl.tsx) lets a user save the current REPL state (dataset snapshot + editor
+// query) under a name and re-open it later. On GitHub-Pages / static hosting the backend is
+// localStorage ("Saved in this browser"). This test drives a REAL headless Chromium: it types a
+// DISTINCTIVE query into the editor, Save-as a named workspace, switches the picker to a fresh
+// scratch session (which resets the editor to the default example), then re-opens the saved
+// workspace from the picker and asserts the editor query is restored verbatim. It also asserts
+// ZERO console errors across the interaction.
+//
+// It is a CORRECTNESS smoke test, not a benchmark — it asserts restored DOM/editor state, never
+// a wall-clock threshold (timings on a work-box / CI runner are non-canonical).
+//
+// DOM ANCHORS. Reuses the component's own stable controls (no new test-ids needed): the
+// "SPARQL query" textbox (the controlled editor `<textarea>`), the `#repl-workspace` workspace
+// picker `<select>`, and the Save-as dialog's "Save as" button / "Workspace name" input /
+// "Save workspace" confirm — all by accessible role/label.
+//
+// DETERMINISM. localStorage is per-origin and persists across tests in the Playwright context,
+// so we `localStorage.clear()` right after the first navigation to start from a known-empty
+// store. The save/open path does not need the wasm engine for the EDITOR-state restore we
+// assert (the dataset snapshot is empty on a fresh session), but the REPL pre-warms the engine
+// on mount and the panel's controls enable once the persistence backend resolves; we wait on
+// the readiness pill so the run is stable. The spec still skips when the wasm bundle is absent
+// (the light CI lane), matching the sibling specs, so the whole suite has one consistent gate.
+import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Relative (no leading slash) so it resolves UNDER the baseURL's `/sparq/` basePath.
+const ROUTE = "try/";
+
+const WASM_BUNDLE = fileURLToPath(
+  new URL("../public/wasm/sparq_wasm_bg.wasm", import.meta.url),
+);
+
+test.skip(
+  !existsSync(WASM_BUNDLE),
+  "wasm bundle absent (public/wasm/sparq_wasm_bg.wasm) — run `npm run sync-wasm` after `(cd ../js && npm run build:wasm)`",
+);
+
+/** Collect every `console.error` the page emits, so the test can assert there were none. */
+function trackConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(String(err)));
+  return errors;
+}
+
+/** Navigate to /try, clear localStorage for determinism, and wait for the engine pill. */
+async function gotoReadyClean(page: Page): Promise<void> {
+  await page.goto(ROUTE, { waitUntil: "domcontentloaded" });
+  // Start from an empty per-origin workspace store so the picker has no stale saved entries.
+  await page.evaluate(() => localStorage.clear());
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page.getByText("Engine ready")).toBeVisible({ timeout: 90_000 });
+  // The picker enables once the persistence backend resolves (web/localStorage here).
+  await expect(page.locator("#repl-workspace")).toBeEnabled({ timeout: 30_000 });
+}
+
+test("a saved workspace restores the editor query when re-opened", async ({
+  page,
+}) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoReadyClean(page);
+
+  const editor = page.getByRole("textbox", { name: "SPARQL query" });
+  const picker = page.locator("#repl-workspace");
+
+  // A DISTINCTIVE query so the restore is unambiguous (and differs from the default example).
+  const distinctive = "SELECT ?marker WHERE { BIND(42 AS ?marker) }";
+  await editor.fill(distinctive);
+  await expect(editor).toHaveValue(distinctive);
+
+  // Save it as a new named workspace via the Save-as dialog.
+  await page.getByRole("button", { name: "Save as" }).click();
+  const nameInput = page.getByRole("textbox", { name: "Workspace name" });
+  await expect(nameInput).toBeVisible();
+  const wsName = "E2E restore probe";
+  await nameInput.fill(wsName);
+  await page.getByRole("button", { name: "Save workspace" }).click();
+
+  // The save makes it the OPEN workspace: the picker now lists the new option (its label is the
+  // name plus a ` · N triples` suffix, so we key off the stable option VALUE = the workspace id).
+  const savedOption = picker.locator("option", { hasText: wsName });
+  await expect(savedOption).toHaveCount(1);
+  const wsValue = (await savedOption.getAttribute("value")) ?? "";
+  expect(wsValue).not.toBe("");
+  await expect(picker).toHaveValue(wsValue);
+
+  // Switch to a fresh scratch session — this resets the editor to the default example query,
+  // so a successful re-open below cannot be a no-op (the editor genuinely changed away first).
+  await picker.selectOption("__scratch__");
+  await expect(editor).not.toHaveValue(distinctive);
+
+  // Re-open the saved workspace from the picker (by id) and assert the editor query is restored.
+  await picker.selectOption(wsValue);
+  await expect(editor).toHaveValue(distinctive, { timeout: 30_000 });
+
+  // The whole save/open round-trip produced zero console errors.
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});
+
+test("a saved workspace survives a full page reload (localStorage persistence)", async ({
+  page,
+}) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoReadyClean(page);
+
+  const editor = page.getByRole("textbox", { name: "SPARQL query" });
+  const picker = page.locator("#repl-workspace");
+
+  const distinctive = "ASK { ?persisted ?across ?reload }";
+  await editor.fill(distinctive);
+
+  await page.getByRole("button", { name: "Save as" }).click();
+  const wsName = "E2E persistence probe";
+  await page.getByRole("textbox", { name: "Workspace name" }).fill(wsName);
+  await page.getByRole("button", { name: "Save workspace" }).click();
+  await expect(picker.locator("option", { hasText: wsName })).toHaveCount(1);
+
+  // Reload WITHOUT clearing localStorage — the saved workspace must still be listed (web
+  // backend persists per-origin), and re-opening it restores the editor query.
+  await page.reload({ waitUntil: "domcontentloaded" });
+  await expect(page.getByText("Engine ready")).toBeVisible({ timeout: 90_000 });
+  await expect(picker).toBeEnabled({ timeout: 30_000 });
+
+  const reloadedOption = picker.locator("option", { hasText: wsName });
+  await expect(reloadedOption).toHaveCount(1);
+  await picker.selectOption((await reloadedOption.getAttribute("value")) ?? "");
+  await expect(editor).toHaveValue(distinctive, { timeout: 30_000 });
+
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});

--- a/site/src/components/connect-panel.tsx
+++ b/site/src/components/connect-panel.tsx
@@ -68,11 +68,25 @@ export function ConnectPanel({
 }: ConnectPanelProps) {
   const [test, setTest] = React.useState<TestState>({ kind: "idle" });
 
+  // [OPUS-4.8] sq-800o — defer the ORIGIN-dependent safety findings to after hydration.
+  // `connectionSafetyWarnings` reads `window.location.origin` (endpoint.ts): on the server it
+  // is undefined (so it emits the `service-allowlist` info), on the client the cross-origin
+  // default endpoint emits `cors-required` instead. Computing it during the first client render
+  // therefore disagreed with the server-rendered HTML → a React HYDRATION MISMATCH console
+  // error on /try (surfaced by the e2e "zero console errors" gate). Gating on a post-mount flag
+  // makes the FIRST client render match the server (no warnings list yet), then the effect
+  // flips `mounted` and the real, origin-aware findings render — no SSR/client divergence.
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => {
+    setMounted(true);
+  }, []);
+
   // The honest safety findings for the current config — recomputed as the user types.
-  // Pure + synchronous (no network), so it is cheap to run on every render.
+  // Pure + synchronous (no network), so it is cheap to run on every render. Empty until mount
+  // so server and first client render agree (see the hydration note above).
   const warnings = React.useMemo(
-    () => connectionSafetyWarnings(config),
-    [config],
+    () => (mounted ? connectionSafetyWarnings(config) : []),
+    [config, mounted],
   );
   const blocked = hasBlockingWarning(warnings);
   const urlValid = parseEndpointUrl(config.url) !== null;

--- a/site/src/components/shacl-playground.tsx
+++ b/site/src/components/shacl-playground.tsx
@@ -392,7 +392,11 @@ function ResultPanel({
   const { report } = state;
 
   return (
-    <div className="space-y-3">
+    // [OPUS-4.8] sq-800o — stable e2e anchor: the validation report panel. The Playwright
+    // SHACL spec waits on `[data-testid="shacl-report"]` (and reads `data-conforms` off the
+    // banner below) rather than scraping copy, so it catches a regression where the report
+    // never renders (e.g. the lost-receiver `__wbg_ptr` throw this bead fixes).
+    <div className="space-y-3" data-testid="shacl-report">
       <ConformanceBanner conforms={report.conforms} summary={reportSummary(report)} />
       {view === "turtle" ? (
         <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
@@ -469,6 +473,9 @@ function ConformanceBanner({
 }) {
   return (
     <div
+      // [OPUS-4.8] sq-800o — expose conformance as a stable `data-conforms` boolean attr so the
+      // e2e SHACL spec asserts `sh:conforms` without reading the localized banner copy.
+      data-conforms={conforms ? "true" : "false"}
       className={cn(
         "flex items-center gap-2 rounded-lg p-3 text-sm font-medium",
         conforms
@@ -502,6 +509,11 @@ function ResultList({ report }: { report: ShaclReport }) {
       {report.results.map((r, i) => (
         <li
           key={i}
+          // [OPUS-4.8] sq-800o — per-violation e2e anchor + the constraint component as a
+          // stable `data-component` attr (the DatatypeConstraintComponent the default example
+          // produces), so the spec asserts the violation without scraping the badge label.
+          data-testid="shacl-violation"
+          data-component={componentName(r.sourceConstraintComponent)}
           className="rounded-lg border bg-muted/30 p-3 text-sm"
         >
           <div className="mb-1.5 flex flex-wrap items-center gap-2">


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (Claude Opus 4.8, 1M context) working on @jeswr's sparq. This PR addresses bead **sq-800o** (P2 bug, epic **sq-ixc3**). @jeswr runs multiple agents on one account — this is an automated, for-review PR (auto-merge OFF).

## The bug — `Cannot read properties of undefined (reading '__wbg_ptr')`

The GUI live SHACL validator (`/surface/shacl`) threw on **Validate**. Root cause is a **lost wasm receiver** in `@sparq/client`'s `sparqShaclValidate` (`packages/sparq-client/src/index.ts`):

```ts
const validate = (store as { validate?: ... }).validate; // detached method reference
…
return JSON.parse(validate(data, shapes, format));        // called BARE → this === undefined
```

wasm-bindgen's generated `Store.validate` body is `wasm.store_validate(this.__wbg_ptr, …)`. Invoked detached, `this` is `undefined`, so `this.__wbg_ptr` throws exactly `Cannot read properties of undefined (reading '__wbg_ptr')`. The bundle **is** built `--features shacl,jsonld,…`, so `validate` exists — this was purely a lost-receiver bug, not a missing feature.

**Fix:** invoke `store.validate(data, shapes, format)` on the live receiver, while **keeping** the existence guard on the detached reference (so a lean, no-SHACL bundle still yields the clear "rebuild with `--features shacl`" error). Added an `[OPUS-4.8] sq-800o` comment documenting the lost-receiver mechanism so it doesn't regress. A full re-scan of `@sparq/client` + `site/` for the same `const m = (x as …).method; m(…)` pattern found **no other genuine detached-wasm-method site** (the `workspace.ts` `crypto.randomUUID` is already called bound to its receiver).

## Bonus fix — pre-existing `/try` hydration mismatch

While adding the workspace e2e (also on `/try`), the "zero console errors" gate caught a **pre-existing** React hydration mismatch in `connect-panel.tsx`: the origin-dependent `connectionSafetyWarnings` reads `window.location.origin`, so SSR emits `service-allowlist` but the client emits `cors-required` → divergent DOM. Gated the origin-aware warnings on a post-mount flag so the first client render matches the server. Local to the site lane.

## Playwright e2e (the bead asks for flow coverage)

Matches the established `repl-results.spec.ts` / `zk-prewarm.spec.ts` pattern: relative routes under the `/sparq/` basePath, `test.skip` when the wasm bundle is absent (light CI lane), stable `data-*`/role anchors (no copy-scraping), assert **zero console errors**, never a wall-clock threshold.

- **`e2e/shacl-validator.spec.ts`** — THE regression guard. The default `ex:age "thirty"` example renders `sh:conforms = false` + a `DatatypeConstraintComponent` violation with zero console errors (pre-fix this throws and the report never appears); a conforming example (`sh:conforms = true`, no violations); the **Compact syntax** path (a separate wasm code path).
- **`e2e/workspace-save-open.spec.ts`** — save-as a named workspace, switch to a scratch session, re-open, assert the editor query restored; plus the localStorage backend survives a full page reload.

`/try` query flow is already covered by `repl-results.spec.ts` — not duplicated.

Added minimal, styling-neutral anchors to `shacl-playground.tsx`: `data-testid="shacl-report"`, `data-conforms`, `data-testid="shacl-violation"` + `data-component`.

## Gates (all green locally)

- WASM prereq built (`js: npm run build:wasm` `--features shacl,jsonld,serialize-rdf,scs`) + synced; the bundle is a gitignored artifact, **not** committed.
- Static export **Pages** mode (`npm run build`) and **Tauri** mode (`npm run build:tauri`) both green; `out/surface/shacl/index.html` + `out/try/index.html` emitted; basePath `/sparq` correct in Pages, root-relative in Tauri.
- `npm run lint` clean. `tsc --noEmit` clean for **site** AND **packages/sparq-client**.
- `npm run test:e2e` — **11/11 pass, 0 skip** (3 new SHACL + 2 new workspace + 2 REPL + 4 ZK).
- No new dependencies. No `crates/` source changes. No hard-coded perf numbers; typos-gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)