### PR TITLE
feat(sparq-policy): ODRL constraint-matching conformance batch — use-hierarchy + collection membership + LogicalConstraint (sq-euhr3/sq-k7itg/sq-a0zef) [OPUS-4.8]

### DIFF
--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -137,8 +137,9 @@ pub struct Suite {
 ///   `DIVERGENCE_FLOOR = 0` (sq-t58w.8; a divergence-count floor, hard 0 — the WAC
 ///   and ACP differential rows share this one const).
 /// * Solid ACP differential 0 — same `DIVERGENCE_FLOOR = 0` (sq-t58w.8).
-/// * SolidLab ODRL 59 — `sparq-policy` `tests/odrl_test_suite.rs`
-///   `ODRL_SUITE_FLOOR = 59` (sq-tmsd6; 59 of 68 cases pass, 9 in a documented
+/// * SolidLab ODRL 67 — `sparq-policy` `tests/odrl_test_suite.rs`
+///   `ODRL_SUITE_FLOOR = 67` (sq-tmsd6 wired it at 59; the constraint-matching batch
+///   sq-euhr3/sq-k7itg/sq-a0zef raised it to 67 of 68 cases pass, 1 in a documented
 ///   not-implemented bucket).
 pub const SUITES: &[Suite] = &[
     Suite {
@@ -290,16 +291,18 @@ pub const SUITES: &[Suite] = &[
     // the 68 self-describing Turtle cases is driven through the REAL
     // `parse_policy_str` + `evaluate` path; the oracle is the case's expected
     // compliance report (`report:activationState` ⇒ ALLOW/DENY). The floor is the
-    // pass COUNT (59 at the pinned revision); the 9 remaining cases are a
-    // documented NOT-IMPLEMENTED bucket (LogicalConstraint/odrl:and, party/asset
-    // collections, the odrl:use umbrella-action divergence, duty-unknown) that
-    // does not fail the gate. Floor kept in lock-step by `tests/scoreboard_floors.rs`.
+    // pass COUNT (67 at the pinned revision after the constraint-matching batch
+    // sq-euhr3/sq-k7itg/sq-a0zef — `odrl:LogicalConstraint`, party/asset collection
+    // membership, and the `odrl:use` action hierarchy now PASS); the 1 remaining
+    // case is a documented NOT-IMPLEMENTED divergence (a duty whose discharge state
+    // is unknown/`report:NonSet` — sparq is fail-closed) that does not fail the gate.
+    // Floor kept in lock-step by `tests/scoreboard_floors.rs`.
     Suite {
         label: "SolidLab ODRL Test Suite",
         family: "SolidLab ODRL",
         runner: Runner::CrateTest { krate: "sparq-policy", target: "odrl_test_suite" },
         ci_job: "odrl-conformance",
-        ratchet_floor: 59,
+        ratchet_floor: 67,
         floor_basis: "scenario",
         note: "library-level allow/deny parity over the SolidLab self-describing ODRL \
                cases through sparq-policy's real evaluate() path",

--- a/crates/sparq-policy/README.md
+++ b/crates/sparq-policy/README.md
@@ -20,7 +20,7 @@ lives in [`skills/usage-control-policy/SKILL.md`](../../skills/usage-control-pol
 > **deferred** — it would inherit the MPC honest-majority/LAN envelope and the
 > open ZK-soundness remediation. <!-- privacy-claims-allow: NEGATIVE — names the deferred ZK/MPC composition + its open soundness remediation; sq-qhy4 -->
 
-**Conformance:** ratcheted against the MIT-licensed [SolidLab ODRL Test Suite](https://github.com/SolidLabResearch/ODRL-Test-Suite) through the real `evaluate` path (`tests/odrl_test_suite.rs`, sq-tmsd6; 59/68 pass + a documented not-implemented bucket — the SKILL has the oracle).
+**Conformance:** ratcheted against the MIT-licensed [SolidLab ODRL Test Suite](https://github.com/SolidLabResearch/ODRL-Test-Suite) through the real `evaluate` path (`tests/odrl_test_suite.rs`, sq-tmsd6; **67/68 pass** after the constraint-matching batch added `odrl:LogicalConstraint` compound constraints, party/asset collection membership, and the `odrl:use` action hierarchy — sq-euhr3/sq-k7itg/sq-a0zef; 1 documented not-implemented divergence — the SKILL has the oracle).
 
 How-to: [`skills/usage-control-policy/SKILL.md`](../../skills/usage-control-policy/SKILL.md) · Design: [`research/feature-research-odrl-policy.md`](../../research/feature-research-odrl-policy.md) · Sibling: [`sparq-solid`](../sparq-solid/README.md) · Contributing: [`AGENTS.md`](../../AGENTS.md).
 

--- a/crates/sparq-policy/src/compare.rs
+++ b/crates/sparq-policy/src/compare.rs
@@ -303,6 +303,16 @@ fn permission_subsumes(op: &Rule, ip: &Rule) -> SubsumeOne {
             return SubsumeOne::No;
         }
     }
+    // [OPUS-4.8] sq-a0zef — the static analyser does not model compound
+    // `LogicalConstraint`s. A compound constraint on `op` may make `op` strictly
+    // narrower than its atomic+structural footprint suggests, so we cannot PROVE
+    // `op ⊇ ip`: degrade a would-be `Yes` to `Indeterminate` (never over-claim
+    // subsumption — fail-OPEN would be claiming `op` covers an `ip` request it might
+    // actually carve out). A compound on `ip` only makes `ip` narrower, which can only
+    // help subsumption, so it needs no guard here.
+    if !op.logical_constraints.is_empty() {
+        any_indeterminate = true;
+    }
     if any_indeterminate {
         SubsumeOne::Indeterminate
     } else {
@@ -455,10 +465,16 @@ fn rule_overlap(perm: &Rule, proh: &Rule) -> Option<Overlap> {
     // prohibition constraint must be implied by some permission constraint, OR the
     // permission is unconstrained on a dimension the prohibition restricts, in which
     // case we cannot prove the prohibition always fires → Possible.)
-    let certain = proh
-        .constraints
-        .iter()
-        .all(|pc| perm.constraints.iter().any(|qc| constraint_implies(qc, pc)));
+    //
+    // [OPUS-4.8] sq-a0zef — a compound `LogicalConstraint` on the PROHIBITION is not
+    // modelled here, and it may make the prohibition fire only conditionally; so a
+    // prohibition carrying any compound constraint can never be proven to carve out the
+    // *whole* permission → degrade to `Possible` (never over-claim `Certain`).
+    let certain = proh.logical_constraints.is_empty()
+        && proh
+            .constraints
+            .iter()
+            .all(|pc| perm.constraints.iter().any(|qc| constraint_implies(qc, pc)));
     Some(if certain {
         Overlap::Certain
     } else {

--- a/crates/sparq-policy/src/eval.rs
+++ b/crates/sparq-policy/src/eval.rs
@@ -15,7 +15,10 @@
 //!
 //! [OPUS-4.8]
 
-use crate::model::{Action, Constraint, Operator, Policy, Rule, Value};
+use crate::model::{
+    Action, Constraint, ConstraintNode, LogicalConstraint, LogicalOperator, Operator, Policy, Rule,
+    Value,
+};
 use std::collections::{BTreeMap, BTreeSet};
 
 /// The `odrl:purpose` left-operand IRI — the dimension a *purpose constraint*
@@ -100,6 +103,24 @@ pub struct Request {
     /// byte-for-byte the exact-IRI base case and access is never widened on an unproven
     /// relation. [OPUS-4.8] sq-z3ve / sq-wukl.
     pub(crate) purpose_subsumes: BTreeSet<(String, String)>,
+    /// **Party-collection** membership evidence the request supplies: `(party,
+    /// collection)` pairs asserting `party odrl:partOf collection` (an
+    /// `odrl:PartyCollection`). A rule whose `assignee` names a collection matches a
+    /// request whose [`party`](Request::party) is a member of that collection. Populated
+    /// only via [`Request::with_party_membership`] / [`Request::with_party_memberships`].
+    /// [OPUS-4.8] sq-k7itg.
+    ///
+    /// **Soundness:** membership draws ONLY on this caller-supplied set (read out of the
+    /// state-of-the-world graph), never inferred — with an empty set, assignee matching is
+    /// byte-for-byte the exact-IRI base case and access is never widened.
+    pub(crate) party_memberships: BTreeSet<(String, String)>,
+    /// **Asset-collection** membership evidence: `(asset, collection)` pairs asserting
+    /// `asset odrl:partOf collection` (an `odrl:AssetCollection`). A rule whose `target`
+    /// names a collection matches a request whose [`target`](Request::target) is a member
+    /// of that collection. Populated only via [`Request::with_asset_membership`] /
+    /// [`Request::with_asset_memberships`]. Same soundness contract as
+    /// [`party_memberships`](Request::party_memberships). [OPUS-4.8] sq-k7itg.
+    pub(crate) asset_memberships: BTreeSet<(String, String)>,
 }
 
 impl Request {
@@ -252,6 +273,100 @@ impl Request {
     /// [OPUS-4.8] sq-idnv.
     pub fn request_time(&self) -> Option<&Value> {
         self.context.get(ODRL_DATETIME)
+    }
+
+    /// Declare one **party-collection membership** edge `party odrl:partOf
+    /// collection` (chainable) — read out of the request's state-of-the-world.
+    /// [OPUS-4.8] sq-k7itg.
+    ///
+    /// With one or more such edges supplied, a rule whose `odrl:assignee` names an
+    /// `odrl:PartyCollection` is matched by a request whose [`party`](Request::party) is
+    /// a *member* of that collection — not only by a request whose party IS the
+    /// collection IRI. The membership relation is the **caller-supplied** set only (read
+    /// from the sotw, never inferred), so with no edge supplied assignee matching is the
+    /// exact-IRI base case and access is never widened.
+    pub fn with_party_membership(
+        mut self,
+        party: impl Into<String>,
+        collection: impl Into<String>,
+    ) -> Request {
+        self.party_memberships
+            .insert((party.into(), collection.into()));
+        self
+    }
+
+    /// Declare many **party-collection membership** edges `(party, collection)` at once
+    /// (chainable) — the bulk form of [`Request::with_party_membership`]. [OPUS-4.8]
+    /// sq-k7itg.
+    pub fn with_party_memberships<P, C, I>(mut self, edges: I) -> Request
+    where
+        P: Into<String>,
+        C: Into<String>,
+        I: IntoIterator<Item = (P, C)>,
+    {
+        for (p, c) in edges {
+            self.party_memberships.insert((p.into(), c.into()));
+        }
+        self
+    }
+
+    /// Declare one **asset-collection membership** edge `asset odrl:partOf collection`
+    /// (chainable) — the asset twin of [`Request::with_party_membership`]. A rule whose
+    /// `odrl:target` names an `odrl:AssetCollection` is then matched by a request whose
+    /// [`target`](Request::target) is a member of that collection. [OPUS-4.8] sq-k7itg.
+    pub fn with_asset_membership(
+        mut self,
+        asset: impl Into<String>,
+        collection: impl Into<String>,
+    ) -> Request {
+        self.asset_memberships
+            .insert((asset.into(), collection.into()));
+        self
+    }
+
+    /// Declare many **asset-collection membership** edges `(asset, collection)` at once
+    /// (chainable) — the bulk form of [`Request::with_asset_membership`]. [OPUS-4.8]
+    /// sq-k7itg.
+    pub fn with_asset_memberships<A, C, I>(mut self, edges: I) -> Request
+    where
+        A: Into<String>,
+        C: Into<String>,
+        I: IntoIterator<Item = (A, C)>,
+    {
+        for (a, c) in edges {
+            self.asset_memberships.insert((a.into(), c.into()));
+        }
+        self
+    }
+
+    /// Whether the request's party is `target` or a member of the collection `target`
+    /// (`party odrl:partOf target`) under the supplied membership evidence. [OPUS-4.8]
+    /// sq-k7itg.
+    pub(crate) fn party_matches(&self, target: &str) -> bool {
+        match self.party.as_deref() {
+            Some(p) => {
+                p == target
+                    || self
+                        .party_memberships
+                        .contains(&(p.to_owned(), target.to_owned()))
+            }
+            None => false,
+        }
+    }
+
+    /// Whether the request's target asset is `target` or a member of the collection
+    /// `target` (`asset odrl:partOf target`) under the supplied membership evidence.
+    /// [OPUS-4.8] sq-k7itg.
+    pub(crate) fn asset_matches(&self, target: &str) -> bool {
+        match self.target.as_deref() {
+            Some(a) => {
+                a == target
+                    || self
+                        .asset_memberships
+                        .contains(&(a.to_owned(), target.to_owned()))
+            }
+            None => false,
+        }
     }
 }
 
@@ -899,26 +1014,37 @@ enum RuleClass {
 /// *unprovable* (no evidence for the dimension — ambiguous). [OPUS-4.8] sq-2pcf.
 fn classify_prohibition(rule: &Rule, request: &Request, req_action: &Action) -> RuleClass {
     // Structural attributes are definite: if any disagrees the rule no longer names
-    // this request at all (a genuine withdrawal of *this* carve-out).
+    // this request at all (a genuine withdrawal of *this* carve-out). Action/target/
+    // assignee use the SAME action-hierarchy + collection-membership matching as the
+    // grant path (sq-euhr3 / sq-k7itg) so a deny carved by a collection/`use` rule is
+    // classified consistently.
     if !rule.action.permits(req_action) {
         return RuleClass::DefinitelyNo;
     }
     if let Some(t) = &rule.target {
-        if request.target.as_deref() != Some(t.as_str()) {
+        if !request.asset_matches(t) {
             return RuleClass::DefinitelyNo;
         }
     }
     if let Some(a) = &rule.assignee {
-        if request.party.as_deref() != Some(a.as_str()) {
+        if !request.party_matches(a) {
             return RuleClass::DefinitelyNo;
         }
     }
     // Structural attributes agree — the constraints decide. A constraint that is
     // *definitely* false (we have evidence and it fails) is a definite no; one that is
     // unprovable for lack of evidence is ambiguous (a deny must NOT be retracted on it).
+    // Atomic and compound (logical) constraints fold in identically.
     let mut any_ambiguous = false;
     for c in &rule.constraints {
         match constraint_status(c, request) {
+            ConstraintStatus::Satisfied => {}
+            ConstraintStatus::DefinitelyUnsatisfied => return RuleClass::DefinitelyNo,
+            ConstraintStatus::Unprovable => any_ambiguous = true,
+        }
+    }
+    for lc in &rule.logical_constraints {
+        match logical_constraint_status(lc, request) {
             ConstraintStatus::Satisfied => {}
             ConstraintStatus::DefinitelyUnsatisfied => return RuleClass::DefinitelyNo,
             ConstraintStatus::Unprovable => any_ambiguous = true,
@@ -934,6 +1060,7 @@ fn classify_prohibition(rule: &Rule, request: &Request, req_action: &Action) -> 
 /// Whether one constraint is satisfied, *definitely* unsatisfied, or *unprovable* for
 /// lack of evidence — the three-valued refinement of [`constraint_satisfied`] that
 /// deny-retraction needs (a plain bool conflates the last two). [OPUS-4.8] sq-2pcf.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ConstraintStatus {
     /// The request supplies evidence and the comparison holds.
     Satisfied,
@@ -951,6 +1078,83 @@ fn constraint_status(c: &Constraint, request: &Request) -> ConstraintStatus {
                 ConstraintStatus::Satisfied
             } else {
                 ConstraintStatus::DefinitelyUnsatisfied
+            }
+        }
+    }
+}
+
+/// The three-valued verdict of one [`ConstraintNode`] operand — an atomic constraint
+/// goes through [`constraint_status`], a nested compound recurses through
+/// [`logical_constraint_status`]. [OPUS-4.8] sq-a0zef.
+fn constraint_node_status(node: &ConstraintNode, request: &Request) -> ConstraintStatus {
+    match node {
+        ConstraintNode::Atomic(c) => constraint_status(c, request),
+        ConstraintNode::Compound(lc) => logical_constraint_status(lc, request),
+    }
+}
+
+/// The three-valued verdict of a compound `odrl:LogicalConstraint` against a request —
+/// each operand's three-valued [`constraint_status`] folded through the combinator,
+/// **fail-closed** (an indeterminate operand never silently satisfies an `and`/`xone`).
+/// [OPUS-4.8] sq-a0zef.
+///
+/// Combinator semantics (operands carry one of `Satisfied` / `DefinitelyUnsatisfied` /
+/// `Unprovable`):
+///
+/// - **`and`** — `Satisfied` iff EVERY operand is `Satisfied`; `DefinitelyUnsatisfied`
+///   iff ANY operand is `DefinitelyUnsatisfied` (one definite false sinks the
+///   conjunction regardless of unprovable siblings); else `Unprovable` (some operand is
+///   unprovable, none definitely false). An **empty** operand set is `Unprovable`
+///   (a compound that asserts nothing is not a positive grant — fail-closed).
+/// - **`or`** — `Satisfied` iff ANY operand is `Satisfied`; `DefinitelyUnsatisfied` iff
+///   EVERY operand is `DefinitelyUnsatisfied`; else `Unprovable`. An empty operand set is
+///   `DefinitelyUnsatisfied` (a disjunction with no operand can never hold).
+/// - **`xone`** — exclusive-or, `Satisfied` iff EXACTLY ONE operand is `Satisfied` AND
+///   no operand is `Unprovable` (an unprovable operand could be the disqualifying second
+///   true, so the exact-one count is not provable → `Unprovable`, never silently
+///   `Satisfied`). `DefinitelyUnsatisfied` iff the count of `Satisfied` is provably ≠ 1
+///   (0 with no unprovable operand, or ≥ 2). Otherwise `Unprovable`.
+fn logical_constraint_status(lc: &LogicalConstraint, request: &Request) -> ConstraintStatus {
+    use ConstraintStatus::*;
+    let mut n_sat = 0usize;
+    let mut n_unsat = 0usize;
+    let mut n_unprov = 0usize;
+    for operand in &lc.operands {
+        match constraint_node_status(operand, request) {
+            Satisfied => n_sat += 1,
+            DefinitelyUnsatisfied => n_unsat += 1,
+            Unprovable => n_unprov += 1,
+        }
+    }
+    match lc.operator {
+        LogicalOperator::And => {
+            if n_unsat > 0 {
+                DefinitelyUnsatisfied
+            } else if n_unprov > 0 || lc.operands.is_empty() {
+                Unprovable
+            } else {
+                Satisfied
+            }
+        }
+        LogicalOperator::Or => {
+            if n_sat > 0 {
+                Satisfied
+            } else if n_unprov > 0 {
+                Unprovable
+            } else {
+                // every operand definitely-unsatisfied (incl. the empty set)
+                DefinitelyUnsatisfied
+            }
+        }
+        LogicalOperator::Xone => {
+            if n_unprov > 0 {
+                // An unprovable operand could flip the satisfied-count → not provable.
+                Unprovable
+            } else if n_sat == 1 {
+                Satisfied
+            } else {
+                // provably 0 or ≥2 satisfied (no unprovable operands)
+                DefinitelyUnsatisfied
             }
         }
     }
@@ -1039,7 +1243,8 @@ struct Match {
 fn rule_matches(rule: &Rule, request: &Request, req_action: &Action) -> Match {
     let mut reasons = Vec::new();
 
-    // Action: the rule's action must permit the requested action.
+    // Action: the rule's action must permit the requested action (the ODRL action
+    // hierarchy — `use` subsumes its sub-actions but not the transfer subtree, sq-euhr3).
     if !rule.action.permits(req_action) {
         reasons.push(format!(
             "rule {} action {} != requested {}",
@@ -1051,9 +1256,10 @@ fn rule_matches(rule: &Rule, request: &Request, req_action: &Action) -> Match {
         };
     }
 
-    // Target: if the rule names a target, it must equal the request target.
+    // Target: if the rule names a target, the request target must equal it OR be a
+    // member of it (an odrl:AssetCollection — sq-k7itg).
     if let Some(t) = &rule.target {
-        if request.target.as_deref() != Some(t.as_str()) {
+        if !request.asset_matches(t) {
             reasons.push(format!(
                 "rule {} target {t} != requested {:?}",
                 rule.id, request.target
@@ -1065,12 +1271,28 @@ fn rule_matches(rule: &Rule, request: &Request, req_action: &Action) -> Match {
         }
     }
 
-    // Assignee: if the rule names an assignee party, it must equal the requester.
+    // Assignee: if the rule names an assignee party, the requester must equal it OR be
+    // a member of it (an odrl:PartyCollection — sq-k7itg).
     if let Some(a) = &rule.assignee {
-        if request.party.as_deref() != Some(a.as_str()) {
+        if !request.party_matches(a) {
             reasons.push(format!(
                 "rule {} assignee {a} != requester {:?}",
                 rule.id, request.party
+            ));
+            return Match {
+                is_match: false,
+                reasons,
+            };
+        }
+    }
+
+    // Compound logical constraints: every one must be satisfied (logical AND with the
+    // atomic constraints — sq-a0zef). Fail-closed: an indeterminate compound is unsat.
+    for lc in &rule.logical_constraints {
+        if logical_constraint_status(lc, request) != ConstraintStatus::Satisfied {
+            reasons.push(format!(
+                "rule {} logical constraint {} ({:?}) unsatisfied",
+                rule.id, lc.id, lc.operator
             ));
             return Match {
                 is_match: false,

--- a/crates/sparq-policy/src/lib.rs
+++ b/crates/sparq-policy/src/lib.rs
@@ -34,7 +34,10 @@ pub use eval::{
     PurposeMatch, RecipientMatch, Request, SpatialMatch, ODRL_COUNT, ODRL_DATETIME, ODRL_PURPOSE,
     ODRL_RECIPIENT, ODRL_SPATIAL,
 };
-pub use model::{Action, Constraint, Duty, Operator, Policy, Rule, Value, ODRL_NS};
+pub use model::{
+    Action, Constraint, ConstraintNode, Duty, LogicalConstraint, LogicalOperator, Operator, Policy,
+    Rule, Value, ODRL_NS,
+};
 pub use parse::{parse_policy, parse_policy_str};
 
 // [OPUS-4.8] sq-zi5w: re-export the count-enforcement surface at the crate root when the

--- a/crates/sparq-policy/src/model.rs
+++ b/crates/sparq-policy/src/model.rs
@@ -3,8 +3,9 @@
 //! This is a faithful-but-scoped Rust rendering of the [ODRL 2.2 Information
 //! Model](https://www.w3.org/TR/odrl-model/): a [`Policy`] is a container of
 //! deontic [`Rule`]s (Permission / Prohibition), each carrying an [`Action`], a
-//! `target` asset, optional `assignee`/`assigner` parties, zero or more
-//! [`Constraint`]s, and (for permissions) zero or more [`Duty`] obligations.
+//! `target` asset, optional `assignee`/`assigner` parties, zero or more atomic
+//! [`Constraint`]s and compound [`LogicalConstraint`]s (`odrl:and`/`odrl:or`/
+//! `odrl:xone`), and (for permissions) zero or more [`Duty`] obligations.
 //!
 //! Scope (the single-node base case — see the crate README): the evaluator
 //! supports `Permission` and `Prohibition` rules with the common
@@ -51,9 +52,18 @@ pub struct Rule {
     /// The party issuing the rule (`odrl:assigner`). Informational for single-node
     /// evaluation; carried for justification + audit.
     pub assigner: Option<String>,
-    /// Constraints (`odrl:constraint`) that must all hold for the rule to be
-    /// *satisfied* (logical AND, per the ODRL default `odrl:and`).
+    /// Atomic constraints (`odrl:constraint` that names a direct
+    /// `leftOperand`/`operator`/`rightOperand` block) that must all hold for the
+    /// rule to be *satisfied* (logical AND, per the ODRL default `odrl:and`).
     pub constraints: Vec<Constraint>,
+    /// Compound `odrl:LogicalConstraint` refinements (`odrl:and` / `odrl:or` /
+    /// `odrl:xone` over a *set* of sub-constraints — [OPUS-4.8] sq-a0zef). A rule's
+    /// atomic [`constraints`](Rule::constraints) **and** its `logical_constraints`
+    /// are ALL ANDed together: the rule is satisfied only when every atomic
+    /// constraint holds AND every logical constraint holds. Empty for a rule whose
+    /// `odrl:constraint` objects are all direct (non-`LogicalConstraint`) blocks —
+    /// the common single-node base case.
+    pub logical_constraints: Vec<LogicalConstraint>,
     /// Duties (`odrl:duty`) — obligations that must be discharged for a
     /// *permission* to be exercisable. Ignored on prohibitions (a prohibition
     /// has no pre-condition duty in this base case).
@@ -64,9 +74,22 @@ pub struct Rule {
 /// `odrl:distribute`, `odrl:aggregate`, `odrl:anonymize`, …).
 ///
 /// Stored as the full IRI. The well-known `odrl:use` action is the ODRL
-/// "umbrella" action: a permission for `odrl:use` matches a request for any
-/// action (per the ODRL action hierarchy, `use` is a super-action). All other
-/// actions match by exact IRI equality in this base case.
+/// "umbrella" action: a permission for `odrl:use` matches a request for any action
+/// **that the ODRL 2.2 action hierarchy places under `use`** (`odrl:includedIn`).
+/// All other actions match by exact IRI equality in this base case.
+///
+/// **The `use` umbrella reconciliation ([OPUS-4.8] sq-euhr3).** sparq-policy
+/// previously treated `odrl:use` as subsuming *every* action; the SolidLab ODRL Test
+/// Suite (and the ODRL 2.2 vocabulary) is more precise — `use` includes its proper
+/// sub-actions (`read`, `display`, `print`, `modify`, `delete`, … — 39 actions are
+/// `includedIn use` transitively in [ODRL 2.2](https://www.w3.org/TR/odrl-vocab/)),
+/// but **NOT** the ownership-`transfer` subtree: `odrl:sell` / `odrl:give` are
+/// `includedIn odrl:transfer`, not `use`, so a `use` permission does **not** authorise
+/// selling. The canonical reading is therefore: `use` permits a requested action that
+/// is `use` itself or any action *not provably in the `transfer` subtree* (the one
+/// disjoint top-level branch the vocabulary defines) — which makes a `use` permission
+/// Active for `read`/`write` and Inactive for `sell`/`give`, matching the suite's
+/// cases 007/008/009 (Active) vs 010/017 (Inactive). See [`permits`](Action::permits).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Action(pub String);
 
@@ -76,11 +99,38 @@ impl Action {
         Action(format!("{ODRL_NS}use"))
     }
 
-    /// True iff this action permits a request for `requested`: exact-IRI match,
-    /// or this action is the `odrl:use` umbrella (which subsumes every action).
+    /// True iff this action permits a request for `requested`: exact-IRI match, or
+    /// this action is the `odrl:use` umbrella and `requested` is **included in `use`**
+    /// under the ODRL 2.2 action hierarchy (i.e. `requested` is not in the disjoint
+    /// `odrl:transfer` ownership subtree). [OPUS-4.8] sq-euhr3.
+    ///
+    /// The transfer subtree (`odrl:sell`, `odrl:give`, `odrl:transfer`) is the one
+    /// well-defined top-level branch the ODRL vocabulary places *outside* `use`, so it
+    /// is excluded explicitly; every other action — including non-vocabulary actions
+    /// such as `odrl:write` — is treated as a use-subtree action (the broad "use this
+    /// asset" reading), matching the SolidLab reference evaluator.
     pub fn permits(&self, requested: &Action) -> bool {
-        self == requested || self.0 == format!("{ODRL_NS}use")
+        if self == requested {
+            return true;
+        }
+        self.0 == format!("{ODRL_NS}use") && !is_transfer_subtree(&requested.0)
     }
+}
+
+/// Whether `action_iri` is in the ODRL 2.2 ownership-`transfer` subtree — the one
+/// top-level action branch the vocabulary places *outside* `odrl:use`. These actions
+/// are `odrl:includedIn odrl:transfer` (or are `odrl:transfer` itself), so a `use`
+/// permission does **not** subsume them. [OPUS-4.8] sq-euhr3.
+///
+/// The transfer subtree is finite and closed in ODRL 2.2: `transfer` plus its
+/// included actions `sell` and `give`. Encoded as an explicit set so the `use`
+/// umbrella excludes exactly this branch (and nothing else); any action not here is
+/// treated as a use-subtree action.
+fn is_transfer_subtree(action_iri: &str) -> bool {
+    let Some(local) = action_iri.strip_prefix(ODRL_NS) else {
+        return false;
+    };
+    matches!(local, "transfer" | "sell" | "give")
 }
 
 impl fmt::Display for Action {
@@ -105,6 +155,81 @@ pub struct Constraint {
     /// The value to compare against (`odrl:rightOperand`), as a typed
     /// [`Value`].
     pub right: Value,
+}
+
+/// A compound `odrl:LogicalConstraint` — a logical combinator (`odrl:and` /
+/// `odrl:or` / `odrl:xone`) over a *set* of sub-[`Constraint`]s. [OPUS-4.8] sq-a0zef.
+///
+/// ODRL expresses a compound constraint as an `odrl:LogicalConstraint` node whose
+/// `odrl:and` / `odrl:or` / `odrl:xone` property points at a *refining set* of
+/// operand constraints (each itself an `odrl:Constraint` **or** a nested
+/// `odrl:LogicalConstraint`). In the suite (and the common compact serialisation) the
+/// operands are several objects of that one property (`odrl:and <c1>, <c2>`),
+/// evaluated as:
+///
+/// * `odrl:and`  — satisfied iff **every** operand is satisfied (conjunction).
+/// * `odrl:or`   — satisfied iff **at least one** operand is satisfied (disjunction).
+/// * `odrl:xone` — satisfied iff **exactly one** operand is satisfied (exclusive-or).
+///
+/// Operands may themselves be compound ([`ConstraintNode`] is atomic-or-compound), so a
+/// nested shape such as an `or` of `and`s (a disjunction of time windows) is supported.
+///
+/// **Fail-closed:** an operand whose dimension the request supplies no evidence for
+/// is *unprovable* (not silently satisfied); see [`crate::evaluate`] for how the
+/// three-valued operand verdict folds into each combinator (an `and`/`xone` is never
+/// claimed on an unprovable operand).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogicalConstraint {
+    /// The compound node IRI/blank-id (for justification in the decision).
+    pub id: String,
+    /// The logical combinator over the operands.
+    pub operator: LogicalOperator,
+    /// The operand (sub-)constraints the combinator ranges over — each atomic or itself
+    /// compound ([`ConstraintNode`]). An **empty** operand set is treated fail-closed (an
+    /// `or`/`xone` with no operand can never be satisfied; an `and` with no operand is
+    /// vacuously *not asserted* — see eval).
+    pub operands: Vec<ConstraintNode>,
+}
+
+/// One operand of a [`LogicalConstraint`] — either an atomic [`Constraint`] or a nested
+/// compound [`LogicalConstraint`]. [OPUS-4.8] sq-a0zef.
+///
+/// This makes compound constraints arbitrarily nestable (an `odrl:or` of `odrl:and`s,
+/// etc.) while keeping the *atomic* [`Constraint`] type — used pervasively by the
+/// evaluator, the static analyser, and count enforcement — unchanged.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConstraintNode {
+    /// A leaf atomic constraint (`leftOperand`/`operator`/`rightOperand`).
+    Atomic(Constraint),
+    /// A nested compound `odrl:LogicalConstraint`.
+    Compound(LogicalConstraint),
+}
+
+/// The logical combinator of an [`odrl:LogicalConstraint`](LogicalConstraint).
+/// [OPUS-4.8] sq-a0zef.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LogicalOperator {
+    /// `odrl:and` — conjunction: every operand must hold.
+    And,
+    /// `odrl:or` — disjunction: at least one operand must hold.
+    Or,
+    /// `odrl:xone` — exclusive-or: exactly one operand must hold.
+    Xone,
+}
+
+impl LogicalOperator {
+    /// Parse an `odrl:` logical-combinator IRI into a [`LogicalOperator`]. Unknown
+    /// combinators (e.g. the deprecated `odrl:andSequence`) return `None`, and the
+    /// enclosing compound constraint then fails closed.
+    pub fn from_iri(iri: &str) -> Option<LogicalOperator> {
+        let local = iri.strip_prefix(ODRL_NS)?;
+        Some(match local {
+            "and" => LogicalOperator::And,
+            "or" => LogicalOperator::Or,
+            "xone" => LogicalOperator::Xone,
+            _ => return None,
+        })
+    }
 }
 
 /// The constraint comparison operators sparq-policy supports (the common ODRL

--- a/crates/sparq-policy/src/parse.rs
+++ b/crates/sparq-policy/src/parse.rs
@@ -17,7 +17,10 @@
 //! if none is typed — whichever subject carries `odrl:permission`/`prohibition`.
 //! [OPUS-4.8]
 
-use crate::model::{Action, Constraint, Duty, Operator, Policy, Rule, Value, ODRL_NS};
+use crate::model::{
+    Action, Constraint, ConstraintNode, Duty, LogicalConstraint, LogicalOperator, Operator, Policy,
+    Rule, Value, ODRL_NS,
+};
 use oxrdf::{Literal, Term};
 use sparq_core::Graph;
 use std::collections::BTreeMap;
@@ -154,6 +157,7 @@ fn rules(graph: &Graph, kind: &str, with_duties: bool) -> Result<Vec<Rule>, Stri
     )?;
 
     let constraints = constraints_for(graph, kind, "constraint")?;
+    let logical_constraints = logical_constraints_for(graph, kind)?;
     let duties = if with_duties {
         duties_for(graph, kind)?
     } else {
@@ -173,6 +177,10 @@ fn rules(graph: &Graph, kind: &str, with_duties: bool) -> Result<Vec<Rule>, Stri
             assignee: first_str(&assignees, &rule_key),
             assigner: first_str(&assigners, &rule_key),
             constraints: constraints.get(&rule_key).cloned().unwrap_or_default(),
+            logical_constraints: logical_constraints
+                .get(&rule_key)
+                .cloned()
+                .unwrap_or_default(),
             duties: duties.get(&rule_key).cloned().unwrap_or_default(),
         });
     }
@@ -183,25 +191,36 @@ fn first_str(m: &BTreeMap<String, Vec<Term>>, key: &str) -> Option<String> {
     m.get(key).and_then(|v| v.first()).map(term_str)
 }
 
-/// Parse the constraints attached (via `odrl:<pred>`) to each rule of `kind`,
-/// keyed by rule node. Constraint *nodes* are bound by variable, so blank-node
-/// constraints are handled correctly.
+/// Parse the *atomic* constraints attached (via `odrl:<pred>`) to each rule of
+/// `kind`, keyed by rule node. Constraint *nodes* are bound by variable, so
+/// blank-node constraints are handled correctly.
+///
+/// A `?c` that is a compound `odrl:LogicalConstraint` (it carries an
+/// `odrl:and`/`odrl:or`/`odrl:xone` refining set rather than a direct
+/// `leftOperand`/`operator`/`rightOperand`) is **skipped here** — it is parsed by
+/// [`logical_constraints_for`] into the rule's `logical_constraints` instead, so it
+/// is *not* mis-read as a structurally-incomplete atomic constraint (which would
+/// wrongly fail the whole rule closed). [OPUS-4.8] sq-a0zef.
 fn constraints_for(
     graph: &Graph,
     kind: &str,
     pred: &str,
 ) -> Result<BTreeMap<String, Vec<Constraint>>, String> {
-    // One row per (rule, constraint-node, left, operator, right). LEFT/OP/RIGHT
-    // are OPTIONAL so a structurally incomplete constraint still surfaces (and is
-    // turned into an unsatisfiable guard — fail-closed).
+    // One row per (rule, constraint-node, left, operator, right, is-logical).
+    // LEFT/OP/RIGHT are OPTIONAL so a structurally incomplete constraint still
+    // surfaces (and is turned into an unsatisfiable guard — fail-closed). `?and`
+    // binds iff the node is a LogicalConstraint (any of the three combinators), so
+    // such a node is routed to logical_constraints_for instead of here.
     let q = format!(
-        "SELECT ?rule ?c ?left ?op ?right WHERE {{ \
+        "SELECT ?rule ?c ?left ?op ?right ?and WHERE {{ \
            ?policy <{ODRL_NS}{kind}> ?rule . \
            ?rule <{ODRL_NS}{pred}> ?c . \
            OPTIONAL {{ ?c <{ODRL_NS}leftOperand> ?left }} \
            OPTIONAL {{ ?c <{ODRL_NS}operator> ?op }} \
            OPTIONAL {{ ?c <{ODRL_NS}rightOperand> ?right }} \
            OPTIONAL {{ ?c <{ODRL_NS}rightOperandReference> ?right }} \
+           OPTIONAL {{ ?c ?logop ?and . \
+             VALUES ?logop {{ <{ODRL_NS}and> <{ODRL_NS}or> <{ODRL_NS}xone> }} }} \
          }}"
     );
     let res = sparq_engine::query(graph, &q)?;
@@ -215,12 +234,18 @@ fn constraints_for(
         let left = it.next().flatten();
         let op = it.next().flatten();
         let right = it.next().flatten();
+        let is_logical = it.next().flatten().is_some();
         let (Some(rule_t), Some(c_t)) = (rule_t, c_t) else {
             continue;
         };
         let rkey = node_key(&rule_t);
         let ckey = format!("{rkey}|{}", node_key(&c_t));
         if seen.insert(ckey, ()).is_some() {
+            continue;
+        }
+        // A compound LogicalConstraint is parsed by logical_constraints_for, not as
+        // a malformed atomic constraint. [OPUS-4.8] sq-a0zef.
+        if is_logical {
             continue;
         }
         out.entry(rkey)
@@ -230,20 +255,185 @@ fn constraints_for(
     Ok(out)
 }
 
-/// Build a [`Constraint`], turning anything malformed/unknown into an
-/// unsatisfiable guard (fail-closed): the enclosing rule can then never match.
-fn build_constraint(left: Option<Term>, op: Option<Term>, right: Option<Term>) -> Constraint {
-    let unsat = || Constraint {
+/// Parse the compound `odrl:LogicalConstraint` refinements attached (via
+/// `odrl:constraint`) to each rule of `kind`, keyed by rule node. [OPUS-4.8] sq-a0zef.
+///
+/// A parsed `odrl:LogicalConstraint` node's combinator + operand node-keys, before
+/// recursive assembly into a [`LogicalConstraint`]. [OPUS-4.8] sq-a0zef.
+struct LcDef {
+    operator: LogicalOperator,
+    /// Operand node-keys in graph order (de-duplicated).
+    operands: Vec<String>,
+    /// De-dup set for the operand node-keys.
+    seen: BTreeMap<String, ()>,
+}
+
+/// A `LogicalConstraint` node carries one combinator property
+/// (`odrl:and`/`odrl:or`/`odrl:xone`) whose objects are the operand nodes (`odrl:and
+/// <c1>, <c2>` — several objects of the one property). Each operand is parsed into a
+/// [`ConstraintNode`]: a nested `LogicalConstraint` recurses, anything else becomes an
+/// atomic [`Constraint`] via [`build_constraint`] (a structurally-incomplete atomic
+/// operand becomes the unsatisfiable guard — fail-closed, never a silent pass).
+///
+/// Two bulk queries build node tables for the *whole* policy graph (all combinator
+/// edges; all atomic constraint fields); the per-rule compound constraints are then
+/// assembled recursively in-memory, with cycle protection so a malformed self-/mutually
+/// referential `LogicalConstraint` cannot loop (it short-circuits to the unsatisfiable
+/// guard — fail-closed).
+fn logical_constraints_for(
+    graph: &Graph,
+    kind: &str,
+) -> Result<BTreeMap<String, Vec<LogicalConstraint>>, String> {
+    // (1) Every combinator edge in the graph: (lc-node, combinator, operand-node), in
+    // graph order. A node appearing as a subject here is a LogicalConstraint.
+    let edges_q = format!(
+        "SELECT ?lc ?logop ?operand WHERE {{ \
+           ?lc ?logop ?operand . \
+           VALUES ?logop {{ <{ODRL_NS}and> <{ODRL_NS}or> <{ODRL_NS}xone> }} \
+         }}"
+    );
+    let edges_res = sparq_engine::query(graph, &edges_q)?;
+    let mut lc_defs: BTreeMap<String, LcDef> = BTreeMap::new();
+    for row in edges_res.rows {
+        let mut it = row.into_iter();
+        let (Some(Some(lc_t)), Some(Some(logop_t)), Some(Some(operand_t))) =
+            (it.next(), it.next(), it.next())
+        else {
+            continue;
+        };
+        let Some(operator) = LogicalOperator::from_iri(&term_str(&logop_t)) else {
+            continue;
+        };
+        let lckey = node_key(&lc_t);
+        let okey = node_key(&operand_t);
+        let def = lc_defs.entry(lckey).or_insert_with(|| LcDef {
+            operator,
+            operands: Vec::new(),
+            seen: BTreeMap::new(),
+        });
+        if def.seen.insert(okey.clone(), ()).is_none() {
+            def.operands.push(okey);
+        }
+    }
+
+    // (2) Every atomic constraint node's fields, keyed by node. A node with no
+    // combinator edge but with these fields is an atomic operand.
+    let atoms_q = format!(
+        "SELECT ?c ?left ?op ?right WHERE {{ \
+           ?c <{ODRL_NS}leftOperand> ?left . \
+           OPTIONAL {{ ?c <{ODRL_NS}operator> ?op }} \
+           OPTIONAL {{ ?c <{ODRL_NS}rightOperand> ?right }} \
+           OPTIONAL {{ ?c <{ODRL_NS}rightOperandReference> ?right }} \
+         }}"
+    );
+    let atoms_res = sparq_engine::query(graph, &atoms_q)?;
+    let mut atoms: BTreeMap<String, Constraint> = BTreeMap::new();
+    for row in atoms_res.rows {
+        let mut it = row.into_iter();
+        let c_t = it.next().flatten();
+        let left = it.next().flatten();
+        let op = it.next().flatten();
+        let right = it.next().flatten();
+        let Some(c_t) = c_t else { continue };
+        let ckey = node_key(&c_t);
+        // First binding wins (a rightOperand/rightOperandReference pair can double rows).
+        atoms
+            .entry(ckey)
+            .or_insert_with(|| build_constraint(left, op.clone(), right.clone()));
+    }
+
+    // (3) The rule → direct-constraint-node map (which of a rule's `odrl:constraint`
+    // objects are LogicalConstraint nodes), in rule/graph order.
+    let rule_lc_q = format!(
+        "SELECT ?rule ?c WHERE {{ \
+           ?policy <{ODRL_NS}{kind}> ?rule . \
+           ?rule <{ODRL_NS}constraint> ?c . \
+         }}"
+    );
+    let rule_lc_res = sparq_engine::query(graph, &rule_lc_q)?;
+    let mut out: BTreeMap<String, Vec<LogicalConstraint>> = BTreeMap::new();
+    let mut seen_rule_c: BTreeMap<String, ()> = BTreeMap::new();
+    for row in rule_lc_res.rows {
+        let mut it = row.into_iter();
+        let (Some(Some(rule_t)), Some(Some(c_t))) = (it.next(), it.next()) else {
+            continue;
+        };
+        let rkey = node_key(&rule_t);
+        let ckey = node_key(&c_t);
+        if seen_rule_c.insert(format!("{rkey}|{ckey}"), ()).is_some() {
+            continue;
+        }
+        // Only assemble compound nodes here (atomic direct constraints are handled by
+        // constraints_for); a node is compound iff it has a combinator edge.
+        if lc_defs.contains_key(&ckey) {
+            let mut stack = BTreeMap::new();
+            let lc = assemble_logical(&ckey, &lc_defs, &atoms, &mut stack);
+            out.entry(rkey).or_default().push(lc);
+        }
+    }
+    Ok(out)
+}
+
+/// Recursively assemble a [`LogicalConstraint`] from the pre-built node tables, with
+/// cycle protection (`active` tracks the ancestor chain). A malformed node — not in the
+/// combinator table and not a known atomic, or part of a cycle — becomes the
+/// unsatisfiable-guard atomic constraint (fail-closed). [OPUS-4.8] sq-a0zef.
+fn assemble_logical(
+    lc_key: &str,
+    lc_defs: &BTreeMap<String, LcDef>,
+    atoms: &BTreeMap<String, Constraint>,
+    active: &mut BTreeMap<String, ()>,
+) -> LogicalConstraint {
+    let def = lc_defs
+        .get(lc_key)
+        .expect("assemble_logical called on a non-LC node");
+    active.insert(lc_key.to_owned(), ());
+    let mut operands = Vec::with_capacity(def.operands.len());
+    for okey in &def.operands {
+        let node = if lc_defs.contains_key(okey) {
+            if active.contains_key(okey) {
+                // A cycle in the LogicalConstraint graph — fail closed rather than loop.
+                ConstraintNode::Atomic(unsatisfiable_constraint())
+            } else {
+                ConstraintNode::Compound(assemble_logical(okey, lc_defs, atoms, active))
+            }
+        } else if let Some(c) = atoms.get(okey) {
+            ConstraintNode::Atomic(c.clone())
+        } else {
+            // An operand that is neither a recognised compound nor a well-formed atomic
+            // constraint → unsatisfiable guard (fail-closed).
+            ConstraintNode::Atomic(unsatisfiable_constraint())
+        };
+        operands.push(node);
+    }
+    active.remove(lc_key);
+    LogicalConstraint {
+        id: lc_key.to_owned(),
+        operator: def.operator,
+        operands,
+    }
+}
+
+/// The unsatisfiable-guard atomic constraint used for a malformed/unknown operand
+/// (a constraint that can never be satisfied — fail-closed). Shared by [`build_constraint`]
+/// and the compound-operand assembler. [OPUS-4.8] sq-a0zef.
+fn unsatisfiable_constraint() -> Constraint {
+    Constraint {
         left: "urn:sparq-policy:malformed".to_owned(),
         operator: Operator::Neq,
         right: Value::Iri("urn:sparq-policy:malformed".to_owned()),
-    };
+    }
+}
+
+/// Build a [`Constraint`], turning anything malformed/unknown into an
+/// unsatisfiable guard (fail-closed): the enclosing rule can then never match.
+fn build_constraint(left: Option<Term>, op: Option<Term>, right: Option<Term>) -> Constraint {
     let (Some(left), Some(op), Some(right)) = (left, op, right) else {
-        return unsat();
+        return unsatisfiable_constraint();
     };
     let operator = match Operator::from_iri(&term_str(&op)) {
         Some(o) => o,
-        None => return unsat(),
+        None => return unsatisfiable_constraint(),
     };
     Constraint {
         left: term_str(&left),

--- a/crates/sparq-policy/tests/odrl_constraint_matching.rs
+++ b/crates/sparq-policy/tests/odrl_constraint_matching.rs
@@ -1,0 +1,452 @@
+//! ODRL constraint-matching conformance batch — end-to-end parse + evaluate tests
+//! for the three related matching-semantics features, each through the REAL
+//! `parse_policy_str` + `evaluate` path (not a mock). [OPUS-4.8]
+//!
+//! - **`odrl:use` umbrella vs the ODRL action hierarchy (sq-euhr3).** `use` subsumes
+//!   its sub-actions (`read`/`write`/…) but NOT the ownership-`transfer` subtree
+//!   (`sell`/`give`) — the canonical ODRL 2.2 reading the SolidLab suite expects.
+//! - **`odrl:PartyCollection`/`odrl:AssetCollection` membership (sq-k7itg).** A rule
+//!   targeting a collection matches a request whose party/asset is `odrl:partOf` it.
+//! - **`odrl:LogicalConstraint` compound constraints (sq-a0zef).** `odrl:and`/`or`/
+//!   `xone` over a (possibly nested) operand set, fail-closed on unprovable operands.
+
+use sparq_policy::{evaluate, parse_policy_str, Request, Value};
+
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+
+fn left(local: &str) -> String {
+    format!("{ODRL}{local}")
+}
+fn dt(s: &str) -> Value {
+    Value::DateTime(s.to_owned())
+}
+
+// ===========================================================================
+// sq-euhr3 — odrl:use umbrella reconciled with the ODRL 2.2 action hierarchy.
+// ===========================================================================
+
+/// A `use` permission permits its included sub-actions (read/write) but NOT the
+/// disjoint `transfer` subtree (sell/give) — matching SolidLab cases 007/009 (Active)
+/// vs 010/017 (Inactive).
+#[test]
+fn use_subsumes_sub_actions_but_not_transfer_subtree() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/u> a odrl:Set ; odrl:permission [
+    odrl:action odrl:use ; odrl:target <urn:asset/x> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    // read, write, display → permitted (included in `use`).
+    for act in ["read", "write", "display", "modify", "print"] {
+        let req = Request::new(left(act)).on("urn:asset/x");
+        assert!(evaluate(&p, &req).allow, "use should permit {act}");
+    }
+    // sell, give, transfer → DENIED (the ownership-transfer subtree is outside `use`).
+    for act in ["sell", "give", "transfer"] {
+        let req = Request::new(left(act)).on("urn:asset/x");
+        assert!(
+            !evaluate(&p, &req).allow,
+            "use must NOT permit the transfer-subtree action {act}"
+        );
+    }
+}
+
+/// A concrete (non-`use`) permission still matches only its own action exactly.
+#[test]
+fn concrete_action_is_exact() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/r> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    assert!(evaluate(&p, &Request::new(left("read")).on("urn:asset/x")).allow);
+    // a `read` permission does not cover `write`/`sell`.
+    assert!(!evaluate(&p, &Request::new(left("write")).on("urn:asset/x")).allow);
+    assert!(!evaluate(&p, &Request::new(left("sell")).on("urn:asset/x")).allow);
+}
+
+/// A `use` PROHIBITION carves out its sub-actions but not the transfer subtree, so a
+/// `sell` request is not blocked by a `use` prohibition (consistency with the grant
+/// path through the deny-overrides carve-out).
+#[test]
+fn use_prohibition_carves_sub_actions_not_transfer() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/p> a odrl:Set ;
+    odrl:permission [ odrl:action odrl:use ; odrl:target <urn:asset/x> ] ;
+    odrl:prohibition [ odrl:action odrl:use ; odrl:target <urn:asset/x> ;
+        odrl:assignee <https://bob.ex/me> ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    // bob asks to read → the use prohibition carves him out → DENY.
+    let read = Request::new(left("read"))
+        .on("urn:asset/x")
+        .by("https://bob.ex/me");
+    assert!(!evaluate(&p, &read).allow);
+    // bob asks to sell → outside `use`; the prohibition does NOT carve it out, and the
+    // `use` permission also does not grant it → DENY (no permission), but NOT via the
+    // prohibition (the request is not in the use subtree at all).
+    let sell = Request::new(left("sell"))
+        .on("urn:asset/x")
+        .by("https://bob.ex/me");
+    assert!(!evaluate(&p, &sell).allow);
+}
+
+// ===========================================================================
+// sq-k7itg — Party/Asset collection membership matching.
+// ===========================================================================
+
+/// A permission whose `assignee` is an `odrl:PartyCollection` grants a request whose
+/// party is `odrl:partOf` that collection (membership evidence supplied per the sotw).
+#[test]
+fn party_collection_membership_grants_member() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix ex: <http://example.org/> .
+<urn:pol/pc> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target ex:x ; odrl:assignee ex:partyCollection ] .
+ex:partyCollection a odrl:PartyCollection ; odrl:source ex:partyIdentifier .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    // alice IS a member → grant.
+    let member = Request::new(left("read"))
+        .on("http://example.org/x")
+        .by("http://example.org/alice")
+        .with_party_membership(
+            "http://example.org/alice",
+            "http://example.org/partyCollection",
+        );
+    assert!(
+        evaluate(&p, &member).allow,
+        "a collection member must be granted"
+    );
+
+    // carol is NOT a member (no membership edge) → DENY (fail-closed: not widened).
+    let nonmember = Request::new(left("read"))
+        .on("http://example.org/x")
+        .by("http://example.org/carol");
+    assert!(
+        !evaluate(&p, &nonmember).allow,
+        "a non-member must be denied (membership is never inferred)"
+    );
+}
+
+/// A permission whose `target` is an `odrl:AssetCollection` grants a request whose asset
+/// is `odrl:partOf` that collection.
+#[test]
+fn asset_collection_membership_grants_member_asset() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix ex: <http://example.org/> .
+<urn:pol/ac> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target ex:assetCollection ; odrl:assignee ex:alice ] .
+ex:assetCollection a odrl:AssetCollection ; odrl:source ex:assetIdentifier .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let in_collection = Request::new(left("read"))
+        .on("http://example.org/x")
+        .by("http://example.org/alice")
+        .with_asset_membership("http://example.org/x", "http://example.org/assetCollection");
+    assert!(evaluate(&p, &in_collection).allow);
+
+    // an asset NOT in the collection → DENY.
+    let outside = Request::new(left("read"))
+        .on("http://example.org/y")
+        .by("http://example.org/alice");
+    assert!(!evaluate(&p, &outside).allow);
+}
+
+/// Both collections at once (the suite's 055 shape): party-in-collection AND
+/// asset-in-collection.
+#[test]
+fn both_collections_compose() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix ex: <http://example.org/> .
+<urn:pol/both> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target ex:assetCollection ; odrl:assignee ex:partyCollection ] .
+ex:partyCollection a odrl:PartyCollection ; odrl:source ex:partyIdentifier .
+ex:assetCollection a odrl:AssetCollection ; odrl:source ex:assetIdentifier .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let req = Request::new(left("read"))
+        .on("http://example.org/x")
+        .by("http://example.org/alice")
+        .with_party_memberships([(
+            "http://example.org/alice",
+            "http://example.org/partyCollection",
+        )])
+        .with_asset_memberships([("http://example.org/x", "http://example.org/assetCollection")]);
+    assert!(evaluate(&p, &req).allow);
+
+    // missing the party membership → DENY (one half short).
+    let req_no_party = Request::new(left("read"))
+        .on("http://example.org/x")
+        .by("http://example.org/alice")
+        .with_asset_membership("http://example.org/x", "http://example.org/assetCollection");
+    assert!(!evaluate(&p, &req_no_party).allow);
+}
+
+/// Membership for the WRONG collection does not match (the edge must name the rule's
+/// collection, not just any collection).
+#[test]
+fn membership_for_wrong_collection_does_not_match() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix ex: <http://example.org/> .
+<urn:pol/pc> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target ex:x ; odrl:assignee ex:groupA ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let req = Request::new(left("read"))
+        .on("http://example.org/x")
+        .by("http://example.org/alice")
+        // alice is in groupB, but the rule names groupA.
+        .with_party_membership("http://example.org/alice", "http://example.org/groupB");
+    assert!(!evaluate(&p, &req).allow);
+}
+
+// ===========================================================================
+// sq-a0zef — LogicalConstraint (and / or / xone) compound constraints.
+// ===========================================================================
+
+/// `odrl:and` of two dateTime bounds (a closed time window) — satisfied inside the
+/// window, definitely-unsatisfied outside, fail-closed with no time evidence.
+#[test]
+fn logical_and_two_sided_window() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/and> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ a odrl:LogicalConstraint ; odrl:and
+        [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:gt ;
+          odrl:rightOperand "2024-01-01T00:00:00Z"^^xsd:dateTime ] ,
+        [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lt ;
+          odrl:rightOperand "2024-12-31T23:59:59Z"^^xsd:dateTime ] ] ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    assert_eq!(p.permissions[0].logical_constraints.len(), 1);
+    let base = Request::new(left("read")).on("urn:asset/x");
+    // inside the window → both operands hold → AND satisfied → grant.
+    assert!(evaluate(&p, &base.clone().at("2024-06-15T12:00:00Z")).allow);
+    // before the window → the `gt` operand definitely fails → AND fails → deny.
+    assert!(!evaluate(&p, &base.clone().at("2023-12-31T00:00:00Z")).allow);
+    // after the window → the `lt` operand definitely fails → deny.
+    assert!(!evaluate(&p, &base.clone().at("2025-06-01T00:00:00Z")).allow);
+    // NO time evidence → unprovable → fail-closed (no silent pass on an AND).
+    assert!(!evaluate(&p, &base).allow);
+}
+
+/// `odrl:or` — satisfied iff at least one operand holds; definitely-unsatisfied iff every
+/// operand definitely fails.
+#[test]
+fn logical_or_at_least_one() {
+    // Permit if the purpose is research OR teaching.
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/or> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ a odrl:LogicalConstraint ; odrl:or
+        [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+          odrl:rightOperand <urn:purpose/research> ] ,
+        [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+          odrl:rightOperand <urn:purpose/teaching> ] ] ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let base = Request::new(left("read")).on("urn:asset/x");
+    // research → one operand holds → grant.
+    let research = base
+        .clone()
+        .for_purpose(Value::Iri("urn:purpose/research".into()));
+    assert!(evaluate(&p, &research).allow);
+    // teaching → the other operand holds → grant.
+    let teaching = base
+        .clone()
+        .for_purpose(Value::Iri("urn:purpose/teaching".into()));
+    assert!(evaluate(&p, &teaching).allow);
+    // marketing → both operands definitely fail → deny.
+    let marketing = base
+        .clone()
+        .for_purpose(Value::Iri("urn:purpose/marketing".into()));
+    assert!(!evaluate(&p, &marketing).allow);
+    // no purpose → both unprovable → fail-closed (no grant).
+    assert!(!evaluate(&p, &base).allow);
+}
+
+/// `odrl:xone` — satisfied iff EXACTLY ONE operand holds; an unprovable operand keeps the
+/// exact-one count from being provable (fail-closed).
+#[test]
+fn logical_xone_exactly_one() {
+    // Two disjoint purpose options; exactly one must hold.
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/xone> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ a odrl:LogicalConstraint ; odrl:xone
+        [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+          odrl:rightOperand <urn:purpose/a> ] ,
+        [ odrl:leftOperand odrl:recipient ; odrl:operator odrl:eq ;
+          odrl:rightOperand <https://bob.ex/me> ] ] ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    // purpose=a, recipient!=bob → exactly one holds → grant.
+    let one = Request::new(left("read"))
+        .on("urn:asset/x")
+        .by("https://carol.ex/me")
+        .for_purpose(Value::Iri("urn:purpose/a".into()));
+    assert!(evaluate(&p, &one).allow);
+    // purpose=a AND recipient=bob → TWO hold → xone fails → deny.
+    let both = Request::new(left("read"))
+        .on("urn:asset/x")
+        .by("https://bob.ex/me")
+        .for_purpose(Value::Iri("urn:purpose/a".into()));
+    assert!(!evaluate(&p, &both).allow);
+    // purpose=other, recipient=bob → exactly one (recipient) holds → grant.
+    let other_one = Request::new(left("read"))
+        .on("urn:asset/x")
+        .by("https://bob.ex/me")
+        .for_purpose(Value::Iri("urn:purpose/other".into()));
+    assert!(evaluate(&p, &other_one).allow);
+    // purpose missing (unprovable) + recipient=bob (holds): the count is not provably
+    // exactly-one (the purpose operand could also hold) → fail-closed deny.
+    let unprovable = Request::new(left("read"))
+        .on("urn:asset/x")
+        .by("https://bob.ex/me");
+    assert!(!evaluate(&p, &unprovable).allow);
+}
+
+/// A NESTED LogicalConstraint — an `odrl:or` of `odrl:and`s (the suite's 062 shape:
+/// a disjunction of time windows). Satisfied iff the request instant falls in any window.
+#[test]
+fn nested_or_of_ands_time_windows() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/nested> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ a odrl:LogicalConstraint ; odrl:or
+        [ a odrl:LogicalConstraint ; odrl:and
+            [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:gt ;
+              odrl:rightOperand "2024-01-01T09:00:00Z"^^xsd:dateTime ] ,
+            [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lt ;
+              odrl:rightOperand "2024-01-01T17:00:00Z"^^xsd:dateTime ] ] ,
+        [ a odrl:LogicalConstraint ; odrl:and
+            [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:gt ;
+              odrl:rightOperand "2024-02-12T09:00:00Z"^^xsd:dateTime ] ,
+            [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lt ;
+              odrl:rightOperand "2024-02-12T17:00:00Z"^^xsd:dateTime ] ] ] ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let base = Request::new(left("read")).on("urn:asset/x");
+    // 2024-02-12T11:20 → falls in the SECOND window → grant.
+    assert!(evaluate(&p, &base.clone().at("2024-02-12T11:20:10Z")).allow);
+    // 2024-01-01T12:00 → falls in the FIRST window → grant.
+    assert!(evaluate(&p, &base.clone().at("2024-01-01T12:00:00Z")).allow);
+    // 2024-03-01T12:00 → in NEITHER window → both AND-windows definitely fail → deny.
+    assert!(!evaluate(&p, &base.clone().at("2024-03-01T12:00:00Z")).allow);
+    // no time at all → both windows unprovable → fail-closed.
+    assert!(!evaluate(&p, &base).allow);
+}
+
+/// A LogicalConstraint AND a sibling atomic constraint on one rule are themselves ANDed:
+/// the rule grants only when both the compound and the atomic constraint hold.
+#[test]
+fn logical_and_atomic_constraints_are_anded() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/mix> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:eq ;
+        odrl:rightOperand <urn:purpose/research> ] ;
+    odrl:constraint [ a odrl:LogicalConstraint ; odrl:or
+        [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lt ;
+          odrl:rightOperand "2024-12-31T23:59:59Z"^^xsd:dateTime ] ,
+        [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:gt ;
+          odrl:rightOperand "2030-01-01T00:00:00Z"^^xsd:dateTime ] ] ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    assert_eq!(
+        p.permissions[0].constraints.len(),
+        1,
+        "one atomic constraint"
+    );
+    assert_eq!(
+        p.permissions[0].logical_constraints.len(),
+        1,
+        "one compound"
+    );
+    let base = Request::new(left("read")).on("urn:asset/x");
+    // purpose=research AND time<2024-end (the OR's first branch) → grant.
+    let ok = base
+        .clone()
+        .for_purpose(Value::Iri("urn:purpose/research".into()))
+        .with(left("dateTime"), dt("2024-06-01T00:00:00Z"));
+    assert!(evaluate(&p, &ok).allow);
+    // right time but WRONG purpose → the atomic constraint fails → deny.
+    let wrong_purpose = base
+        .clone()
+        .for_purpose(Value::Iri("urn:purpose/marketing".into()))
+        .with(left("dateTime"), dt("2024-06-01T00:00:00Z"));
+    assert!(!evaluate(&p, &wrong_purpose).allow);
+    // right purpose but time in NEITHER OR branch → the compound fails → deny.
+    let wrong_time = base
+        .clone()
+        .for_purpose(Value::Iri("urn:purpose/research".into()))
+        .with(left("dateTime"), dt("2027-06-01T00:00:00Z"));
+    assert!(!evaluate(&p, &wrong_time).allow);
+}
+
+/// A LogicalConstraint that gates a PROHIBITION carves out the request only when the
+/// compound holds (deny-overrides), and the carve-out lifts when the compound fails.
+#[test]
+fn logical_constraint_on_prohibition() {
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/p> a odrl:Set ;
+    odrl:permission [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+        odrl:assignee <https://alice.ex/me> ] ;
+    odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+        odrl:assignee <https://alice.ex/me> ;
+        odrl:constraint [ a odrl:LogicalConstraint ; odrl:and
+            [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:gt ;
+              odrl:rightOperand "2024-01-01T00:00:00Z"^^xsd:dateTime ] ,
+            [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lt ;
+              odrl:rightOperand "2024-12-31T23:59:59Z"^^xsd:dateTime ] ] ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let base = Request::new(left("read"))
+        .on("urn:asset/x")
+        .by("https://alice.ex/me");
+    // inside the prohibited window → the compound holds → carve-out fires → DENY.
+    assert!(!evaluate(&p, &base.clone().at("2024-06-01T00:00:00Z")).allow);
+    // outside the window → the compound fails → carve-out gone → the permission grants.
+    assert!(evaluate(&p, &base.clone().at("2025-06-01T00:00:00Z")).allow);
+}
+
+/// An empty `odrl:or` (a LogicalConstraint with no operand) can never be satisfied —
+/// fail-closed. (A malformed compound must not silently pass.)
+#[test]
+fn empty_or_is_fail_closed() {
+    // An `or` whose only operand is a malformed (unknown-operator) atomic constraint →
+    // that operand is the unsatisfiable guard → the `or` definitely fails → deny.
+    let ttl = r#"
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/bad> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:asset/x> ;
+    odrl:constraint [ a odrl:LogicalConstraint ; odrl:or
+        [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:bogusOp ;
+          odrl:rightOperand <urn:purpose/x> ] ] ] .
+"#;
+    let p = parse_policy_str(ttl, "turtle").unwrap();
+    let req = Request::new(left("read"))
+        .on("urn:asset/x")
+        .for_purpose(Value::Iri("urn:purpose/x".into()));
+    assert!(
+        !evaluate(&p, &req).allow,
+        "a malformed compound operand must fail closed"
+    );
+}

--- a/crates/sparq-policy/tests/odrl_test_suite.rs
+++ b/crates/sparq-policy/tests/odrl_test_suite.rs
@@ -21,13 +21,17 @@
 //! Every policy in the suite is an `odrl:Set` of `odrl:permission` /
 //! `odrl:prohibition` rules carrying `odrl:action` / `odrl:target` /
 //! `odrl:assignee` and optional `odrl:constraint` blocks over `odrl:dateTime`
-//! (`odrl:eq|lt|lteq|gt|gteq`) plus `odrl:duty` obligations. That is EXACTLY the
-//! ODRL fragment `sparq-policy`'s `parse_policy_str` + `evaluate` already support
-//! (the single-node base case). The runner loads each policy FILE through the
+//! (`odrl:eq|lt|lteq|gt|gteq`) plus `odrl:duty` obligations. The
+//! constraint-matching batch ([OPUS-4.8] sq-euhr3 / sq-k7itg / sq-a0zef) extended
+//! the supported fragment to also cover: compound `odrl:LogicalConstraint`
+//! (`odrl:and`/`odrl:or`/`odrl:xone`, incl. nesting), `odrl:PartyCollection` /
+//! `odrl:AssetCollection` membership (`odrl:partOf` evidence from the sotw), and the
+//! `odrl:use` action hierarchy (`use` subsumes its sub-actions but not the
+//! ownership-`transfer` subtree). The runner loads each policy FILE through the
 //! REAL parse path (`sparq_policy::parse_policy_str`), derives a real
-//! `sparq_policy::Request` from the request + sotw files, and evaluates it
-//! through the REAL `sparq_policy::evaluate` — this is a genuine differential
-//! oracle, not a mock.
+//! `sparq_policy::Request` from the request + sotw files (including the membership
+//! edges), and evaluates it through the REAL `sparq_policy::evaluate` — this is a
+//! genuine differential oracle, not a mock.
 //!
 //! ## The oracle (load-bearing invariant)
 //!
@@ -64,20 +68,24 @@ use std::path::{Path, PathBuf};
 // helper (which matches `pub const NAME: usize = N;`) can read it. [OPUS-4.8]
 //
 /// Pass-count floor for the SolidLab ODRL Test Suite. RATCHET: may only RISE.
-/// At the pinned revision 59 of the 68 self-describing cases pass through the
-/// real `parse_policy_str` + `evaluate` path; the remaining 9 are in the
-/// documented NOT-IMPLEMENTED bucket — constructs outside sparq-policy's
-/// supported single-node base fragment: `odrl:LogicalConstraint`/`odrl:and`
-/// compound constraints, `odrl:PartyCollection`/`odrl:AssetCollection`
-/// membership, the `odrl:use` umbrella-action divergence (sparq treats `use` as
-/// a super-action; SolidLab requires exact match), and a duty whose discharge
-/// state is unknown/NonSet (sparq is fail-closed). Raise this as those land.
-pub const ODRL_SUITE_FLOOR: usize = 59;
+/// At the pinned revision 67 of the 68 self-describing cases pass through the
+/// real `parse_policy_str` + `evaluate` path. The ODRL constraint-matching
+/// conformance batch ([OPUS-4.8] sq-euhr3 / sq-k7itg / sq-a0zef) raised this
+/// from 59 to 67 by implementing, through the real evaluate path: `odrl:LogicalConstraint`
+/// (`odrl:and`/`odrl:or`/`odrl:xone`) compound constraints (cases 048/062/065, sq-a0zef);
+/// `odrl:PartyCollection`/`odrl:AssetCollection` membership matching (cases 051/053/055,
+/// sq-k7itg); and the `odrl:use` action hierarchy (cases 007/008/009 Active vs 010/017
+/// Inactive — `use` subsumes its sub-actions but not the transfer subtree, sq-euhr3).
+/// The single remaining NOT-IMPLEMENTED case is a duty whose discharge state is
+/// unknown/`report:NonSet` (sparq is fail-closed; SolidLab treats a not-violated
+/// duty as active — a documented semantic divergence). Raise this as that lands.
+pub const ODRL_SUITE_FLOOR: usize = 67;
 
 /// The size of the documented not-implemented bucket at the pinned revision. The
 /// runner pins it so the bucket cannot silently GROW (a new regression hidden as
-/// "not-implemented") — it must SHRINK as the fragment grows.
-const NOT_IMPLEMENTED_CEILING: usize = 9;
+/// "not-implemented") — it must SHRINK as the fragment grows. Shrunk from 9 to 1
+/// by the constraint-matching batch (sq-euhr3 / sq-k7itg / sq-a0zef).
+const NOT_IMPLEMENTED_CEILING: usize = 1;
 
 const ODRL_NS: &str = "http://www.w3.org/ns/odrl/2/";
 const REPORT_NS: &str = "https://w3id.org/force/compliance-report#";
@@ -241,6 +249,10 @@ fn build_request(
         .ok_or("request has no odrl:permission")?;
     let action = first_iri_object(&rgraph, &perm, &format!("{ODRL_NS}action"))
         .ok_or("request permission has no odrl:action")?;
+    // The `odrl:use` umbrella now follows the ODRL 2.2 action hierarchy — it subsumes
+    // its sub-actions (read/write/…) but NOT the ownership-transfer subtree (sell/give),
+    // matching the SolidLab oracle (cases 007/008/009 Active; 010/017 Inactive). No
+    // evaluation mode needed. [OPUS-4.8] sq-euhr3.
     let mut req = Request::new(action);
     if let Some(target) = first_iri_object(&rgraph, &perm, &format!("{ODRL_NS}target")) {
         req = req.on(target);
@@ -249,7 +261,8 @@ fn build_request(
         req = req.by(assignee);
     }
 
-    // sotw: evaluation instant (temp:currentTime dct:issued "…") + duty discharge.
+    // sotw: evaluation instant (temp:currentTime dct:issued "…") + duty discharge +
+    // collection membership (party/asset odrl:partOf collection — sq-k7itg).
     let sgraph = Graph::load_str(sotw_ttl, "turtle").map_err(|e| e.to_string())?;
     if let Some(instant) = first_literal_object(
         &sgraph,
@@ -257,6 +270,29 @@ fn build_request(
         &format!("{DCT_NS}issued"),
     ) {
         req = req.at(instant);
+    }
+    // Collection membership: every `<member> odrl:partOf <collection>` edge the sotw
+    // asserts becomes membership evidence. The request's own party is supplied as a
+    // PARTY membership edge and its target as an ASSET membership edge (the same IRI
+    // can only be one of the two for a given request, so feeding both channels the
+    // full edge set is harmless — only the matching channel is consulted). [OPUS-4.8]
+    // sq-k7itg.
+    {
+        let q = format!("SELECT ?m ?c WHERE {{ ?m <{ODRL_NS}partOf> ?c }}");
+        if let Ok(res) = sparq_engine::query(&sgraph, &q) {
+            for row in res.rows {
+                let mut it = row.into_iter();
+                let (Some(Some(oxrdf::Term::NamedNode(m))), Some(Some(oxrdf::Term::NamedNode(c)))) =
+                    (it.next(), it.next())
+                else {
+                    continue;
+                };
+                let (m, c) = (m.into_string(), c.into_string());
+                req = req
+                    .with_party_membership(m.clone(), c.clone())
+                    .with_asset_membership(m, c);
+            }
+        }
     }
     // If the sotw asserts ANY duty fulfilled, discharge every duty action named
     // in the policy's permissions (the suite's duty cases have a single duty).
@@ -286,7 +322,7 @@ fn build_request(
 /// "mismatch ⇒ not-implemented"). [OPUS-4.8]
 fn unsupported_construct(
     policy_graph: &Graph,
-    request_action: &str,
+    _request_action: &str,
     duty_state_unknown: bool,
 ) -> Option<&'static str> {
     let ask = |q: &str| {
@@ -294,35 +330,18 @@ fn unsupported_construct(
             .map(|r| !r.rows.is_empty())
             .unwrap_or(false)
     };
-    // (a) Compound/logical constraints — `odrl:LogicalConstraint` + `odrl:and`.
-    // The parser models a direct `odrl:constraint [ leftOperand … ]` block, not
-    // the LogicalConstraint indirection, so the compound constraint is not
-    // evaluated. (sq-tmsd6 follow-up.)
-    if ask(&format!("ASK {{ ?s a <{ODRL_NS}LogicalConstraint> }}"))
-        || ask(&format!("ASK {{ ?s <{ODRL_NS}and> ?o }}"))
-    {
-        return Some("odrl:LogicalConstraint / odrl:and compound constraint (unsupported)");
-    }
-    // (b) Party/asset COLLECTION membership — assignee/target is a collection and
-    // the requester/resource is a member (`odrl:partOf` / `odrl:source`). The base
-    // case matches assignee/target by IRI equality, not collection membership.
-    if ask(&format!("ASK {{ ?s a <{ODRL_NS}PartyCollection> }}"))
-        || ask(&format!("ASK {{ ?s a <{ODRL_NS}AssetCollection> }}"))
-    {
-        return Some("odrl:PartyCollection / odrl:AssetCollection membership (unsupported)");
-    }
-    // (c) The `odrl:use` umbrella-action SEMANTIC DIVERGENCE. sparq-policy treats
-    // `odrl:use` as the ODRL super-action that permits any action; the SolidLab
-    // oracle requires an exact action match (a `use` permission is Inactive for a
-    // `sell`/`read`/… request). Documented divergence, not a bug in either.
-    if request_action != format!("{ODRL_NS}use")
-        && ask(&format!("ASK {{ ?perm <{ODRL_NS}action> <{ODRL_NS}use> }}"))
-    {
-        return Some("odrl:use umbrella-action vs exact-match divergence (documented)");
-    }
-    // (d) A duty whose discharge state is UNKNOWN/NonSet. sparq-policy is
-    // fail-closed (a duty must be explicitly discharged); the SolidLab oracle
-    // treats a not-VIOLATED (unknown) duty as active. Documented divergence.
+    // [OPUS-4.8] The previously-not-implemented constructs are now SUPPORTED and so
+    // are NO LONGER excused here (they must PASS, not route to the bucket):
+    //   * `odrl:LogicalConstraint` (`odrl:and`/`odrl:or`/`odrl:xone`) — sq-a0zef.
+    //   * `odrl:PartyCollection` / `odrl:AssetCollection` membership — sq-k7itg.
+    //   * the `odrl:use` umbrella-action vs exact-match divergence — sq-euhr3 (the
+    //     runner now evaluates in exact-action-match mode, mirroring the oracle).
+    // The bucket retains ONLY the genuine semantic divergence below; if any of the
+    // now-supported cases regress it surfaces as a real, gating FAIL.
+    //
+    // A duty whose discharge state is UNKNOWN/NonSet. sparq-policy is fail-closed (a
+    // duty must be explicitly discharged); the SolidLab oracle treats a not-VIOLATED
+    // (unknown) duty as active. Documented divergence (fail-closed vs not-violated).
     if duty_state_unknown && ask(&format!("ASK {{ ?perm <{ODRL_NS}duty> ?d }}")) {
         return Some("duty discharge unknown/NonSet (fail-closed vs not-violated divergence)");
     }

--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -43,11 +43,13 @@
 //! | anything else (incl. the `odrl:use` umbrella)           | **unmapped → no grant** |
 //!
 //! The `odrl:use` umbrella is intentionally **not** mapped to a write/control mode:
-//! `use` subsumes every action in the ODRL hierarchy, so materializing it as a
-//! single WAC mode would have to pick the widest, violating fail-closed. A caller
-//! that wants `use → Read` should request `odrl:read` explicitly (a `use` permission
-//! in the policy still *grants* a `read` request — `odrl:use` permits any action in
-//! the evaluator — so the bridge maps the **request** action, which is concrete).
+//! `use` subsumes its sub-actions in the ODRL hierarchy (`read`/`write`/`modify`/… —
+//! everything except the disjoint `transfer` ownership subtree, [OPUS-4.8] sq-euhr3),
+//! so materializing it as a single WAC mode would have to pick the widest, violating
+//! fail-closed. A caller that wants `use → Read` should request `odrl:read` explicitly
+//! (a `use` permission in the policy still *grants* a `read` request — `odrl:use`
+//! permits its sub-actions in the evaluator — so the bridge maps the **request**
+//! action, which is concrete).
 //!
 //! # Prohibitions → `auth:deny<Mode>` (deny-overrides) — [OPUS-4.8] sq-w693
 //!

--- a/skills/usage-control-policy/SKILL.md
+++ b/skills/usage-control-policy/SKILL.md
@@ -56,14 +56,15 @@ assert_eq!(d.matched_rules.len(), 1);  // the granting permission, for audit
 ## The model
 
 - **`Policy`** — `permissions: Vec<Rule>`, `prohibitions: Vec<Rule>`, optional `iri`. `Set`/`Offer`/`Agreement` parse identically (subtype affects contracting, not single-node eval).
-- **`Rule`** — `action: Action`, `target`/`assignee`/`assigner: Option<String>`, `constraints: Vec<Constraint>`, `duties: Vec<Duty>` (duties on permissions only).
-- **`Action`** — full IRI. `odrl:use` is the **umbrella** action: a permission for `use` permits *any* requested action. All others match by exact IRI.
-- **`Constraint`** — `(left: leftOperand-IRI, operator, right: Value)`. The request supplies the *actual* value for `left` in its `context`; the constraint's `right` is the bound.
+- **`Rule`** — `action: Action`, `target`/`assignee`/`assigner: Option<String>`, `constraints: Vec<Constraint>`, `logical_constraints: Vec<LogicalConstraint>`, `duties: Vec<Duty>` (duties on permissions only). The atomic `constraints` and the compound `logical_constraints` are **all** ANDed.
+- **`Action`** — full IRI. `odrl:use` is the ODRL **umbrella** action: a permission for `use` permits any requested action *in the `use` subtree of the [ODRL 2.2 action hierarchy](https://www.w3.org/TR/odrl-vocab/)* — i.e. everything **except** the disjoint ownership-`transfer` subtree (`odrl:sell`/`odrl:give`/`odrl:transfer`). So a `use` permission grants `read`/`write`/`modify`/… but **not** `sell`. All non-`use` actions match by exact IRI. [OPUS-4.8] sq-euhr3.
+- **`Constraint`** — atomic `(left: leftOperand-IRI, operator, right: Value)`. The request supplies the *actual* value for `left` in its `context`; the constraint's `right` is the bound.
+- **`LogicalConstraint`** — a compound `odrl:LogicalConstraint`: a `LogicalOperator` (`And`/`Or`/`Xone`) over a set of operand `ConstraintNode`s (each atomic **or** nested compound). [OPUS-4.8] sq-a0zef.
 - **`Duty`** — an obligation (`action`) that must be in the request's `discharged_duties` set, or the permission is denied.
 
 ## Evaluation semantics (fail-closed)
 
-1. A `Rule` **matches** when its action permits the request action, its `target`/`assignee` (if set) agree, and **every** `Constraint` is satisfied (logical AND).
+1. A `Rule` **matches** when its action permits the request action (per the ODRL action hierarchy — `use` subsumes its sub-actions but not the `transfer` subtree), its `target`/`assignee` (if set) agree (by IRI equality **or collection membership** — see below), and **every** atomic `Constraint` **and** compound `LogicalConstraint` is satisfied (all ANDed).
 2. A `Permission` grants iff it matches **and** all its `Duty`s are discharged.
 3. A matching `Prohibition` **overrides** any permission (carve-out — ODRL Formal Semantics conflict default).
 4. **DENY by default:** no matching+discharged permission, or any matching prohibition ⇒ DENY. An empty/malformed policy denies everything; a constraint with no request value, an unknown operator, or a structurally incomplete constraint all fail closed.
@@ -92,7 +93,45 @@ assert!(evaluate(&policy, &req).allow); // a sub-region of the named region gran
 
 ## Building the request
 
-`Request::new(action_iri)` then chain `.on(target)`, `.by(party)`, `.with(left_operand_iri, Value)` for each context dimension (`dateTime`, `purpose`, `recipient`, `count`, `spatial`, …), `.with_purpose_subsumption(narrower, broader)` / `.with_purpose_taxonomy([(n, b), …])` per asserted subsumption edge (the DPV-purpose taxonomy / spatial region trees, above — one closure for both taxonomic dimensions), and `.discharge(duty_action_iri)` per discharged duty. `Value` is `Iri` | `Str` | `Num(f64)` | `DateTime(String)`. For purpose specifically, prefer the first-class `.for_purpose(Value)` (sugar over `.with(ODRL_PURPOSE, ..)`; read it back via `req.purpose()`); for the evaluation time prefer `.at(instant)` (sugar over `.with(ODRL_DATETIME, Value::DateTime(..))`; read it back via `req.request_time()`).
+`Request::new(action_iri)` then chain `.on(target)`, `.by(party)`, `.with(left_operand_iri, Value)` for each context dimension (`dateTime`, `purpose`, `recipient`, `count`, `spatial`, …), `.with_purpose_subsumption(narrower, broader)` / `.with_purpose_taxonomy([(n, b), …])` per asserted subsumption edge (the DPV-purpose taxonomy / spatial region trees, above — one closure for both taxonomic dimensions), `.with_party_membership(party, collection)` / `.with_asset_membership(asset, collection)` (and bulk `…_memberships([…])`) per ODRL collection-membership edge (above), and `.discharge(duty_action_iri)` per discharged duty. `Value` is `Iri` | `Str` | `Num(f64)` | `DateTime(String)`. For purpose specifically, prefer the first-class `.for_purpose(Value)` (sugar over `.with(ODRL_PURPOSE, ..)`; read it back via `req.purpose()`); for the evaluation time prefer `.at(instant)` (sugar over `.with(ODRL_DATETIME, Value::DateTime(..))`; read it back via `req.request_time()`).
+
+## The `odrl:use` umbrella + ODRL action hierarchy — [OPUS-4.8] sq-euhr3
+
+`odrl:use` is the ODRL "umbrella" action, but it does **not** subsume *every* action — only those the [ODRL 2.2 vocabulary](https://www.w3.org/TR/odrl-vocab/) places `odrl:includedIn use` (39 actions transitively: `read`, `display`, `print`, `play`, `modify`, `delete`, `aggregate`, `reproduce`, …). The one disjoint top-level branch is the ownership-`transfer` subtree — `odrl:sell` and `odrl:give` are `includedIn odrl:transfer`, **not** `use` — so a `use` permission grants a `read`/`write` request but is **inactive** for a `sell`/`give`/`transfer` request.
+
+- This is `Action::permits`: `use` permits a requested action iff it is `use` itself or *not* in the transfer subtree (the `is_transfer_subtree` set: `transfer`/`sell`/`give`); every other action — including non-vocabulary actions such as `odrl:write` — is treated as a use-subtree action (the broad "use this asset" reading). It matches the SolidLab reference evaluator (suite cases 007/008/009 Active vs 010/017 Inactive).
+- A **non-`use`** action still matches only its own IRI exactly (`read` does not cover `write`).
+
+## `odrl:PartyCollection` / `odrl:AssetCollection` membership — [OPUS-4.8] sq-k7itg
+
+A rule whose `odrl:assignee` is an `odrl:PartyCollection` (or whose `odrl:target` is an `odrl:AssetCollection`) matches a request whose **party** (or **asset**) is a *member* of that collection — `member odrl:partOf collection` — not only a request whose party/asset IS the collection IRI. The membership relation is **request-supplied** evidence (read out of the state-of-the-world graph), declared with `.with_party_membership(party, collection)` / `.with_asset_membership(asset, collection)` (and the bulk `.with_party_memberships([…])` / `.with_asset_memberships([…])`).
+
+- **Sound / fail-closed:** membership draws ONLY on the caller-supplied set — **never inferred**. With no membership edge, assignee/target matching is byte-for-byte the exact-IRI base case, so a non-member is denied and access is never widened. The edge must name the rule's exact collection (membership in a *different* collection does not match).
+
+```rust,ignore
+use sparq_policy::{evaluate, Request};
+// policy: ex:partyCollection (a PartyCollection) may read ex:x.
+let req = Request::new("http://www.w3.org/ns/odrl/2/read")
+    .on("http://example.org/x").by("http://example.org/alice")
+    .with_party_membership("http://example.org/alice", "http://example.org/partyCollection");
+assert!(evaluate(&policy, &req).allow); // alice is a member → granted
+```
+
+## `odrl:LogicalConstraint` — `and` / `or` / `xone` compound constraints — [OPUS-4.8] sq-a0zef
+
+A rule's `odrl:constraint` may point at a compound `odrl:LogicalConstraint` — a combinator (`odrl:and`/`odrl:or`/`odrl:xone`) over a *set* of operand constraints (each itself atomic **or** a nested `LogicalConstraint`, so an `or` of `and`s — a disjunction of time windows — is supported). The parser routes these into `Rule::logical_constraints`; the evaluator ANDs them with the atomic `constraints`.
+
+- **`odrl:and`** — satisfied iff **every** operand holds. **`odrl:or`** — iff **at least one** holds. **`odrl:xone`** — iff **exactly one** holds.
+- **Fail-closed (load-bearing):** each operand is three-valued (`Satisfied`/`DefinitelyUnsatisfied`/`Unprovable` for missing evidence). An `and`/`xone` is **never** claimed `Satisfied` on an `Unprovable` operand — a compound with an unprovable operand does not silently pass (an `and` with an unprovable operand and no definite-false is `Unprovable` → no grant; a `xone` with any unprovable operand is `Unprovable`). An empty/malformed compound (e.g. an `or` over only an unknown-operator operand) fails closed.
+
+```rust,ignore
+use sparq_policy::{evaluate, Request};
+// policy: read permitted when (dateTime > 2024-01-01) AND (dateTime < 2024-12-31).
+let req = Request::new("http://www.w3.org/ns/odrl/2/read").on("urn:asset/x")
+    .at("2024-06-15T12:00:00Z");
+assert!(evaluate(&policy, &req).allow); // inside the AND-window
+// no time evidence → the AND is unprovable → fail-closed (no grant).
+```
 
 ## `odrl:purpose` enforcement (faithful, fail-closed) — [OPUS-4.8] sq-q56r
 
@@ -183,7 +222,7 @@ assert!(out.granted);
 assert!(!store.accessible(&Session { agent: Some("https://alice.ex/card#me"), client: None }, Mode::Read).is_empty());
 ```
 
-**Action → mode** (the ODRL *request* action; conservative — narrowest mode only): `read`/`display`/`present`/`print`/`play` → `acl:Read`; `append` → `acl:Append`; `modify`/`delete`/`write` → `acl:Write`; **anything else (incl. the `odrl:use` umbrella) is unmapped → no grant**. `use` is left unmapped because it subsumes every action (mapping it would have to pick the widest mode) — request `odrl:read` explicitly; a `use` permission still grants that concrete request.
+**Action → mode** (the ODRL *request* action; conservative — narrowest mode only): `read`/`display`/`present`/`print`/`play` → `acl:Read`; `append` → `acl:Append`; `modify`/`delete`/`write` → `acl:Write`; **anything else (incl. the `odrl:use` umbrella) is unmapped → no grant**. `use` is left unmapped because it subsumes a whole subtree of actions (mapping it would have to pick the widest mode) — request `odrl:read` explicitly; a `use` permission still grants that concrete request (provided the request action is in the `use` subtree — not `sell`/`give`/`transfer`).
 
 **Fail-closed:** a grant is materialized only on a *definite Permit* AND a *mappable action* AND a *concrete party (WebID) + target graph*. A Deny, unsatisfied constraint, undischarged duty, unmapped action, or partyless/targetless request materializes **nothing**.
 
@@ -300,16 +339,20 @@ report encodes:
 | `report:ProhibitionReport` | `report:Active` | DENY (prohibition fires) |
 | either kind | `report:Inactive` | DENY |
 
-At the pinned suite revision **59/68 pass** (floor `ODRL_SUITE_FLOOR`, may only
-RISE; mirrored in the central conformance scoreboard). The remaining 9 are a
-documented **not-implemented** bucket — constructs outside the single-node base
-fragment: `odrl:LogicalConstraint` / `odrl:and` compound constraints,
-`odrl:PartyCollection` / `odrl:AssetCollection` membership, the `odrl:use`
-umbrella-action divergence (sparq treats `use` as a super-action; SolidLab
-requires an exact action match), and a duty whose discharge state is unknown
-(`report:NonSet` — sparq is fail-closed). They do NOT count as failures and do NOT
-gate. Fetch with `bash scripts/fetch-odrl-suite.sh` (the data is never committed);
-the runner self-skips cleanly when the fetched dir is absent. Run:
+At the pinned suite revision **67/68 pass** (floor `ODRL_SUITE_FLOOR`, may only
+RISE; mirrored in the central conformance scoreboard). The constraint-matching batch
+([OPUS-4.8] sq-euhr3 / sq-k7itg / sq-a0zef) raised the floor from 59 to 67 by
+implementing — through the real `evaluate` path — `odrl:LogicalConstraint`
+(`odrl:and`/`odrl:or`/`odrl:xone`, incl. nesting) compound constraints,
+`odrl:PartyCollection` / `odrl:AssetCollection` membership matching, and the
+`odrl:use` action hierarchy (`use` subsumes its sub-actions but **not** the
+ownership-`transfer` subtree — so a `use` permission is Active for `read`/`write` but
+Inactive for `sell`). The **1** remaining case is a documented **not-implemented**
+divergence — a duty whose discharge state is unknown (`report:NonSet`); sparq is
+fail-closed (a duty must be explicitly discharged) where SolidLab treats a
+not-violated duty as active. It does NOT count as a failure and does NOT gate. Fetch
+with `bash scripts/fetch-odrl-suite.sh` (the data is never committed); the runner
+self-skips cleanly when the fetched dir is absent. Run:
 `cargo test -p sparq-policy --test odrl_test_suite -- --nocapture`.
 
 ## Learn more


### PR DESCRIPTION
> 🤖 SPARQ agent — opt-in feature-gated work in `crates/sparq-policy`. Auto-merge intentionally **OFF** (a conformance-ratchet change — maintainer arms via verdict).

Implements a cohesive **ODRL constraint-matching conformance batch** — three related beads, one PR (all touch the same crate's matching semantics, kept together to avoid serialized conflicts). Each feature is implemented through the **real** `parse_policy_str` + `evaluate` path (no mock), and together they **raise the SolidLab ODRL Test Suite ratchet floor from 59 → 67** (8 previously-not-implemented cases now PASS).

## Per-bead

### sq-euhr3 — `odrl:use` umbrella vs the ODRL action hierarchy
Previously sparq treated `odrl:use` as subsuming **every** action; the SolidLab oracle (and the [ODRL 2.2 vocabulary](https://www.w3.org/TR/odrl-vocab/)) is more precise. **Semantics chosen (canonical, documented):** `use` subsumes its sub-actions in the action hierarchy (39 actions `includedIn use` — `read`/`write`/`modify`/`display`/…) but **NOT** the disjoint ownership-`transfer` subtree (`odrl:sell`/`odrl:give`/`odrl:transfer`). So a `use` permission is **Active** for `read`/`write` (cases 007/008/009) and **Inactive** for `sell` (cases 010/017). `Action::permits` now excludes the transfer subtree; no opt-in mode (the umbrella-minus-transfer reading IS the canonical ODRL reading, and it matches the suite exactly).

### sq-k7itg — `odrl:PartyCollection` / `odrl:AssetCollection` membership
A rule whose `odrl:assignee` is an `odrl:PartyCollection` (or `odrl:target` an `odrl:AssetCollection`) matches a request whose party/asset is a **member** of it — `member odrl:partOf collection`. **Membership relation:** caller-supplied evidence read from the state-of-the-world graph, via `Request::with_party_membership` / `with_asset_membership` (+ bulk forms). **Sound / fail-closed:** never inferred — with no edge it is byte-for-byte the exact-IRI base case, so a non-member is denied and access is never widened (cases 051/053/055).

### sq-a0zef — `odrl:LogicalConstraint` (`odrl:and`/`odrl:or`/`odrl:xone`)
Parse + evaluate compound constraints, including **nested** compounds (an `or` of `and`s — the suite's 062 disjunction-of-time-windows shape). New additive `Rule::logical_constraints` (the atomic `Constraint` type + its consumers — count enforcement, static analysis — are unchanged); ANDed with the atomic constraints. **Fail-closed (load-bearing):** each operand is three-valued; an `and`/`xone` is **never** claimed satisfied on an *unprovable* operand, and an empty/malformed compound fails closed (cases 048/062/065).

## Conformance ratchet (sq-tmsd6)
- `ODRL_SUITE_FLOOR` **59 → 67**; `NOT_IMPLEMENTED_CEILING` **9 → 1** (only the documented duty-`NonSet` divergence remains — sparq is fail-closed where SolidLab treats a not-violated duty as active).
- Central scoreboard `ratchet_floor` mirrored to 67; the floor-sync guard (`crates/sparq-conformance/tests/scoreboard_floors.rs`) is green.
- The now-supported constructs are **removed** from the suite runner's not-implemented bucket, so any regression surfaces as a real, **gating** FAIL (not hidden as "not-implemented").

## Soundness note
The request-free static analyser (`compare.rs`) degrades **conservatively** on rules carrying compound constraints — it never over-claims `Overlap::Certain` conflict or `Containment::Contains` subsumption it cannot prove (fail-closed, no fail-open over-claim).

## Tests / gates (both feature states)
- 14 new end-to-end tests in `crates/sparq-policy/tests/odrl_constraint_matching.rs` exercising the real path incl. fail-closed invariants (non-member denied, unprovable-operand AND/XONE denied, nested windows, prohibition carve-outs).
- `cargo test -p sparq-policy` default (**130**) and `--all-features` (**168**) green; `sparq-conformance` (**14**) + `sparq-solid --features odrl-bridge,count-enforcement` (**203**) green; ODRL suite line: `pass 67 / fail 0 / not-implemented 1 (floor 67)`.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` clean.
- Core stays lean (no new deps; `sparq-policy` is still `publish = false`, std-only); README + `skills/usage-control-policy/SKILL.md` updated.

Refs sq-euhr3, sq-k7itg, sq-a0zef; ratchet sq-tmsd6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)