### PR TITLE
feat(sparq-server): JSON-LD content negotiation — emit + accept application/ld+json on SPARQL/GSP (sq-oy1f.1) [OPUS-4.8]

### DIFF
--- a/crates/sparq-server/Cargo.toml
+++ b/crates/sparq-server/Cargo.toml
@@ -200,6 +200,21 @@ n3-patch = ["server"]
 # The default `server` build holds the ring/writer directly (byte-identical to pre-#941) and
 # never depends on arc-swap, so the default serving read path stays lean.
 backup = ["server", "dep:arc-swap", "sparq-serve/backup"]
+# [OPUS-4.8] (sq-oy1f.1, epic sq-oy1f) `jsonld` (default OFF) wires JSON-LD 1.1
+# (`application/ld+json`) into the server's RDF content negotiation, both directions:
+#   * EMIT — a SPARQL CONSTRUCT/DESCRIBE or a Graph-Store-Protocol GET with
+#     `Accept: application/ld+json` is served as JSON-LD (the engine's *flattened* form),
+#     participating in the existing q-value-aware Accept negotiation; and
+#   * ACCEPT — a GSP PUT/POST (or the SHACL shapes-body reader, which shares the same media-type
+#     matrix) with `Content-Type: application/ld+json` is parsed into the store via the engine's
+#     JSON-LD parser.
+# It turns on `sparq-core/jsonld` (the `oxjsonld` parser that `Graph::load_str` dispatches the
+# "jsonld" token to) and `sparq-engine/serialize-rdf` (the `write_jsonld` serialiser). Both are
+# native-pure (no wasm impact — sparq-wasm depends on sparq-core/-engine directly, never on
+# sparq-server). Without the feature the `GraphFormat::JsonLd` variant, its negotiation arm and
+# its write-body arm are `#[cfg]`-stripped, so an `application/ld+json` request gets the same
+# 406/415 it did before and the default build is byte-identical. Needs `server`.
+jsonld = ["server", "sparq-core/jsonld", "sparq-engine/serialize-rdf"]
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -37,7 +37,8 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
   dataset scoped to the addressed graph), and — behind the OPT-IN `n3-patch` feature + `--n3-patch`
   flag — a Solid-style `text/n3` **N3-Patch** (`solid:InsertDeletePatch`).
 - **Content negotiation** — q-value aware; SELECT/ASK in JSON/XML/CSV/TSV, CONSTRUCT/DESCRIBE and
-  GSP read in N-Triples / prefix-Turtle / RDF-XML; streamed SELECT bodies. Plus **EXPLAIN /
+  GSP read in N-Triples / prefix-Turtle / RDF-XML (plus **JSON-LD** behind the opt-in `jsonld`
+  feature, both emit and accept — see "Opt-in features"); streamed SELECT bodies. Plus **EXPLAIN /
   EXPLAIN ANALYZE**, Prometheus **`/metrics`**, and SEPA-style **WebSocket + SSE** live SELECT diffs.
 - **Durable persistence** — `--persist <DIR>` makes the on-disk index the source of truth (off by
   default, in-memory). See "Durable persistence".
@@ -52,6 +53,9 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
   **default-deny** SSRF guard), `federation-descriptors` (VoID + Service Description discovery),
   `tpf`/`brtpf` (Triple Pattern Fragments / bind-restricted LDF source), `shacl`
   (`POST /shacl/validate`), `n3-patch` (Solid `text/n3` N3-Patch on GSP `PATCH`),
+  `jsonld` (`application/ld+json` in content negotiation — EMIT a CONSTRUCT/DESCRIBE or GSP-read
+  graph as flattened JSON-LD on `Accept: application/ld+json`, and ACCEPT an `application/ld+json`
+  GSP write body; off by default, links `oxjsonld` + the engine's JSON-LD writer),
   `backup` (online snapshot `POST /admin/backup` + `/admin/restore`, no stop-the-world),
   `audit-log`/`access-audit` (access trails), `zlib-ng` (faster gzip).
 

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -63,19 +63,10 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
 
 By default: **no auth, loopback-only.** Hardening is opt-in but honest where it matters.
 
-- **Auth × bind matrix.** A non-loopback bind is refused unless `--allow-remote` is set, and a
-  write-token counts as "auth present" for that decision **only when reads are also gated**
-  (`--auth-token-read`) — a write-token alone still leaves reads open on a remote bind. The 401 is
-  byte-identical for a missing vs a wrong token. The Bearer gate is one shared secret with no
-  per-user identity — for real authz front it with a gateway or [`sparq-solid`](../sparq-solid), over TLS.
+- **Auth × bind matrix.** A non-loopback bind is refused unless `--allow-remote` is set, and a write-token counts as "auth present" for that decision **only when reads are also gated** (`--auth-token-read`) — a write-token alone still leaves reads open on a remote bind. The 401 is byte-identical for a missing vs a wrong token. The Bearer gate is one shared secret with no per-user identity — for real authz front it with a gateway or [`sparq-solid`](../sparq-solid), over TLS.
 - **Error responses do not leak internals** — every error is a generic `{"error":"…"}` class (never the caller's input, an RDF fragment, a path, or a token); detail to the log, class to the body (regression-guarded by `tests/hardening.rs`). An unmatched route is a categorised `404 {"error":"not found"}` (the message never echoes the requested path).
-- **Stable retry contract** — **transient** (`429`/`503`): retry; **permanent** (`4xx`): fix the
-  request — a `413` row/byte cap is a permanent honest refusal, **not** a silent truncation;
-  **defect** (`500`): surface, don't hot-retry. Versioned table in the `status_contract` crate doc.
-- **SERVICE federation** is OFF in the default build; with `--features service` it is
-  **default-DENY-all** (egress allowlist enforced before any socket, on the resolved IP —
-  DNS-rebinding-safe). DoS guards on by default (query timeout, body cap, concurrency shed, 20×
-  gzip-ratio cap, panic→`500`); **no rate limit** — add one in the gateway.
+- **Stable retry contract** — **transient** (`429`/`503`): retry; **permanent** (`4xx`): fix the request — a `413` row/byte cap is a permanent honest refusal, **not** a silent truncation; **defect** (`500`): surface, don't hot-retry. Versioned table in the `status_contract` crate doc.
+- **SERVICE federation** is OFF in the default build; with `--features service` it is **default-DENY-all** (egress allowlist enforced before any socket, on the resolved IP — DNS-rebinding-safe). DoS guards on by default (query timeout, body cap, concurrency shed, 20× gzip-ratio cap, panic→`500`); **no rate limit** — add one in the gateway.
 - **Request-log redaction (ON by default with `--verbose`)** — a `GET /sparql?query=…` URL can
   carry PII, so the query string becomes a length + non-reversible fingerprint
   (`--log-full-requests` opts out). **Honest boundary:** this is log-CONTENT redaction, **not**

--- a/crates/sparq-server/src/descriptors.rs
+++ b/crates/sparq-server/src/descriptors.rs
@@ -149,6 +149,10 @@ fn serialise(triples: &[Triple], fmt: GraphFormat) -> (&'static str, String) {
         GraphFormat::NTriples => crate::graph::triples_to_ntriples(triples),
         GraphFormat::Turtle => crate::graph::triples_to_turtle(triples),
         GraphFormat::RdfXml => crate::graph::triples_to_rdfxml(triples),
+        // [OPUS-4.8] sq-oy1f.1: a descriptor may be requested as JSON-LD too (only matchable
+        // when the `jsonld` feature is on; the variant does not exist otherwise).
+        #[cfg(feature = "jsonld")]
+        GraphFormat::JsonLd => crate::graph::triples_to_jsonld(triples),
     };
     (fmt.content_type(), body)
 }

--- a/crates/sparq-server/src/graph.rs
+++ b/crates/sparq-server/src/graph.rs
@@ -88,6 +88,33 @@ pub fn triples_to_rdfxml(triples: &[Triple]) -> String {
     serialize_with(ser.for_writer(Vec::new()), triples, |w, t| w.serialize_triple(t), |w| w.finish())
 }
 
+/// [OPUS-4.8] sq-oy1f.1: Serialises an RDF graph (triple list) as **JSON-LD 1.1**
+/// (`application/ld+json`) in the engine's *flattened* document form: a
+/// `{"@graph": [ … node objects … ]}` envelope with subjects merged into one node object
+/// each and a stable node ordering. We pick the flattened form (over expanded or compacted)
+/// as the negotiated default because it is the safest interop target — node-merged, no
+/// `@context` to negotiate against, and round-trips losslessly back to the same RDF graph
+/// (the JSON-LD `toRdf` of a `fromRdf`-flattened document reconstructs the source triples,
+/// asserted by the server-level round-trip test).
+///
+/// The result graph for a CONSTRUCT / DESCRIBE / GSP read is a flat list of default-graph
+/// triples (no named graphs — GSP scopes one graph per request, named by the URL), so we
+/// hand the engine writer a single default-graph view `[(None, triples)]`. The prefixes
+/// argument is only consulted by the compacted form, which we do not use here, so the
+/// engine's `default_prefixes` are inert.
+///
+/// OPT-IN: only compiled when the server's `jsonld` feature is on (it links the engine's
+/// `serialize-rdf` JSON-LD writer); without the feature this function does not exist and the
+/// `GraphFormat::JsonLd` variant it serves is never constructed.
+#[cfg(feature = "jsonld")]
+pub fn triples_to_jsonld(triples: &[Triple]) -> String {
+    use sparq_engine::serialize::{default_prefixes, write_jsonld, JsonLdForm, NamedGraph};
+    // One default-graph view over the triple list. `NamedGraph = (Option<&Term>, &[Triple])`;
+    // `None` is the default graph.
+    let view: [NamedGraph<'_>; 1] = [(None, triples)];
+    write_jsonld(&view, JsonLdForm::Flattened, &default_prefixes())
+}
+
 /// Shared driver for the `oxttl` / `oxrdfxml` writers, which share the
 /// `serialize_triple(TripleRef) -> io::Result<()>` + `finish() -> io::Result<W>` shape.
 /// Writing to an in-memory `Vec<u8>` is infallible, so an `io::Error` here is genuinely

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -2600,7 +2600,14 @@ fn negotiate_tpf(accept: Option<&str>) -> GraphFormat {
             let f = negotiate_graph(Some(a));
             // negotiate_graph defaults to N-Triples on an unrecognised header; for TPF a bare
             // `*/*` (or anything unmatched) should land on Turtle.
-            if a.contains("n-triples") || a.contains("turtle") || a.contains("rdf+xml") {
+            // [OPUS-4.8] sq-oy1f.1: an explicit JSON-LD request is honoured too (only matchable
+            // when the `jsonld` feature is on; `negotiate_graph` returns Turtle/N-Triples without
+            // it, so the substring is harmless when the feature is off).
+            if a.contains("n-triples")
+                || a.contains("turtle")
+                || a.contains("rdf+xml")
+                || a.contains("ld+json")
+            {
                 f
             } else {
                 GraphFormat::Turtle
@@ -2763,11 +2770,9 @@ async fn tpf_endpoint(
     );
 
     let fmt = negotiate_tpf(headers.get(header::ACCEPT).and_then(|v| v.to_str().ok()));
-    let body = match fmt {
-        GraphFormat::NTriples => crate::graph::triples_to_ntriples(&triples),
-        GraphFormat::Turtle => crate::graph::triples_to_turtle(&triples),
-        GraphFormat::RdfXml => crate::graph::triples_to_rdfxml(&triples),
-    };
+    // [OPUS-4.8] sq-oy1f.1: route through the shared graph serialiser so the JSON-LD arm is
+    // covered uniformly (and the match stays exhaustive when the `jsonld` feature is on).
+    let body = serialise_graph_triples(&triples, fmt);
     text_response(StatusCode::OK, fmt.content_type(), body, head_only)
 }
 
@@ -4707,6 +4712,12 @@ fn rdf_format_for(content_type: &str) -> Option<BodyFormat> {
         "application/n-triples" | "text/plain" => Some(BodyFormat::Core("ntriples")),
         "application/n-quads" => Some(BodyFormat::Core("nquads")),
         "application/trig" => Some(BodyFormat::Core("trig")),
+        // [OPUS-4.8] sq-oy1f.1: JSON-LD request body, OPT-IN behind the `jsonld` feature (which
+        // turns on `sparq-core/jsonld`, the `oxjsonld` parser `Graph::load_str` dispatches the
+        // "jsonld" token to). Without the feature this arm is compiled out, so an
+        // `application/ld+json` body is a plain `415` — byte-identical to before.
+        #[cfg(feature = "jsonld")]
+        "application/ld+json" => Some(BodyFormat::Core("jsonld")),
         // [OPUS-4.8] sq-rt6v: RDF/XML request body.
         "application/rdf+xml" => Some(BodyFormat::RdfXml),
         // No explicit Content-Type: default to Turtle (a superset of N-Triples), matching
@@ -4715,6 +4726,20 @@ fn rdf_format_for(content_type: &str) -> Option<BodyFormat> {
         _ => None,
     }
 }
+
+/// [OPUS-4.8] sq-oy1f.1: the `415` message for an unsupported GSP write-body media type. With
+/// the `jsonld` feature ON it names `application/ld+json` among the accepted dialects; OFF it
+/// names only the always-available RDF syntaxes (an `application/ld+json` body is then a plain
+/// `415`), so the advertised contract matches what the build actually parses.
+#[cfg(feature = "jsonld")]
+const GSP_WRITE_BODY_415: &str =
+    "GSP write body must be RDF: Content-Type 'text/turtle', 'application/n-triples', \
+     'application/n-quads', 'application/trig', 'application/rdf+xml' or 'application/ld+json'";
+/// [OPUS-4.8] sq-oy1f.1: the feature-OFF `415` message — JSON-LD is not parseable in this build.
+#[cfg(not(feature = "jsonld"))]
+const GSP_WRITE_BODY_415: &str =
+    "GSP write body must be RDF: Content-Type 'text/turtle', 'application/n-triples', \
+     'application/n-quads', 'application/trig' or 'application/rdf+xml'";
 
 /// Parses a GSP request body into canonical N-Triples (the term syntax accepted verbatim
 /// inside a SPARQL `INSERT DATA` block), validating the RDF in the process. The `sparq-core`
@@ -4735,7 +4760,7 @@ fn body_to_ntriples(
         None => {
             return Err(json_error(
                 StatusCode::UNSUPPORTED_MEDIA_TYPE,
-                "GSP write body must be RDF: Content-Type 'text/turtle', 'application/n-triples', 'application/n-quads', 'application/trig' or 'application/rdf+xml'",
+                GSP_WRITE_BODY_415,
             ))
         }
     };
@@ -5223,6 +5248,10 @@ fn serialise_graph_triples(triples: &[oxrdf::Triple], gfmt: GraphFormat) -> Stri
         GraphFormat::NTriples => crate::graph::triples_to_ntriples(triples),
         GraphFormat::Turtle => crate::graph::triples_to_turtle(triples),
         GraphFormat::RdfXml => crate::graph::triples_to_rdfxml(triples),
+        // [OPUS-4.8] sq-oy1f.1: JSON-LD (flattened) — only reachable when the `jsonld` feature
+        // is on (the variant does not exist otherwise, so the match stays exhaustive).
+        #[cfg(feature = "jsonld")]
+        GraphFormat::JsonLd => crate::graph::triples_to_jsonld(triples),
     }
 }
 

--- a/crates/sparq-server/src/negotiate.rs
+++ b/crates/sparq-server/src/negotiate.rs
@@ -48,6 +48,14 @@ pub enum GraphFormat {
     Turtle,
     /// `application/rdf+xml` — RDF/XML. [OPUS-4.8] sq-rt6v.
     RdfXml,
+    /// `application/ld+json` — JSON-LD 1.1 (the engine's flattened serialisation).
+    /// [OPUS-4.8] sq-oy1f.1. OPT-IN: only a participant in negotiation when the server is
+    /// built with the `jsonld` feature (which links the engine's `serialize-rdf` writer);
+    /// without it the variant does not exist, so `application/ld+json` is unrecognised and
+    /// negotiation never selects it (it falls through to the default, exactly like any other
+    /// unsupported media type).
+    #[cfg(feature = "jsonld")]
+    JsonLd,
 }
 
 impl GraphFormat {
@@ -58,6 +66,11 @@ impl GraphFormat {
             // [OPUS-4.8] sq-rt6v: RDF/XML registers `charset=utf-8` like the others; the
             // document's own XML declaration also pins UTF-8.
             GraphFormat::RdfXml => "application/rdf+xml; charset=utf-8",
+            // [OPUS-4.8] sq-oy1f.1: JSON-LD is UTF-8 JSON; the IANA `application/ld+json`
+            // registration carries no charset parameter (JSON is UTF-8 by RFC 8259), but we
+            // annotate it like the others so a strict client never mis-decodes.
+            #[cfg(feature = "jsonld")]
+            GraphFormat::JsonLd => "application/ld+json; charset=utf-8",
         }
     }
 }
@@ -79,6 +92,11 @@ pub fn negotiate_graph(accept: Option<&str>) -> GraphFormat {
             // some clients send for RDF/XML — kept lower-specificity so an exact match wins).
             "application/rdf+xml" => (Some(GraphFormat::RdfXml), 2),
             "application/xml" | "text/xml" => (Some(GraphFormat::RdfXml), 1),
+            // [OPUS-4.8] sq-oy1f.1: JSON-LD, OPT-IN behind the `jsonld` feature. When the
+            // feature is off this arm is compiled out, so `application/ld+json` matches no arm
+            // and falls through to the default (N-Triples) like any unsupported type.
+            #[cfg(feature = "jsonld")]
+            "application/ld+json" => (Some(GraphFormat::JsonLd), 2),
             "*/*" => (Some(GraphFormat::NTriples), 0),
             _ => (None, 0),
         };
@@ -219,5 +237,38 @@ mod tests {
         assert_eq!(negotiate_graph(Some("application/rdf+xml;q=0, text/turtle")), GraphFormat::Turtle);
         // An unsupported type still falls back to N-Triples.
         assert_eq!(negotiate_graph(Some("application/pdf")), GraphFormat::NTriples);
+    }
+
+    // [OPUS-4.8] sq-oy1f.1: JSON-LD negotiation is only compiled with the `jsonld` feature.
+    #[cfg(feature = "jsonld")]
+    #[test]
+    fn graph_format_jsonld() {
+        assert_eq!(negotiate_graph(Some("application/ld+json")), GraphFormat::JsonLd);
+        assert_eq!(GraphFormat::JsonLd.content_type(), "application/ld+json; charset=utf-8");
+        // q-values decide between JSON-LD and the other graph formats.
+        assert_eq!(
+            negotiate_graph(Some("text/turtle;q=0.5, application/ld+json;q=0.9")),
+            GraphFormat::JsonLd
+        );
+        // q=0 rejects JSON-LD, so Turtle wins.
+        assert_eq!(
+            negotiate_graph(Some("application/ld+json;q=0, text/turtle")),
+            GraphFormat::Turtle
+        );
+        // Exact JSON-LD beats a wildcard.
+        assert_eq!(negotiate_graph(Some("application/ld+json, */*")), GraphFormat::JsonLd);
+    }
+
+    // [OPUS-4.8] sq-oy1f.1: WITHOUT the feature, `application/ld+json` is just another
+    // unsupported type — negotiation must fall through to the default (N-Triples).
+    #[cfg(not(feature = "jsonld"))]
+    #[test]
+    fn graph_format_jsonld_unsupported_without_feature() {
+        assert_eq!(negotiate_graph(Some("application/ld+json")), GraphFormat::NTriples);
+        // Even alongside a supported type, the JSON-LD range is ignored and Turtle is picked.
+        assert_eq!(
+            negotiate_graph(Some("application/ld+json;q=0.9, text/turtle;q=0.5")),
+            GraphFormat::Turtle
+        );
     }
 }

--- a/crates/sparq-server/tests/jsonld_content_negotiation.rs
+++ b/crates/sparq-server/tests/jsonld_content_negotiation.rs
@@ -1,0 +1,293 @@
+//! [OPUS-4.8] sq-oy1f.1 — Server JSON-LD content negotiation integration tests.
+//!
+//! Spins the real axum server in-process and drives it over HTTP with `reqwest`, exercising
+//! BOTH directions of the `application/ld+json` wiring and the negotiation/contract corners:
+//!
+//!   * EMIT — a SPARQL `CONSTRUCT` with `Accept: application/ld+json` returns valid JSON-LD
+//!     whose `toRdf` round-trips back to the same triples (asserted by re-parsing the body
+//!     through the engine's JSON-LD loader and comparing the canonical triple set).
+//!   * ACCEPT — a Graph-Store-Protocol `PUT` of an `application/ld+json` body, then a `GET`,
+//!     returns exactly the triples that were loaded.
+//!   * the q-value-aware negotiation contract: a JSON-LD `Accept` beats a lower-q sibling, a
+//!     `q=0` rejects it, an unknown `Accept` does not 406 (the server has a default), and an
+//!     unsupported write `Content-Type` is a `415`.
+//!
+//! The positive tests compile only with the `jsonld` feature (`cargo test -p sparq-server
+//! --features jsonld`). A separate block under `#[cfg(not(feature = "jsonld"))]` asserts the
+//! feature-OFF contract: an `application/ld+json` write body is a plain `415`, and an
+//! `Accept: application/ld+json` query falls back to a supported graph format (NOT a 406) —
+//! so the default build is byte-identical to before.
+
+use sparq_core::Graph;
+use sparq_server::{router, AppState};
+use tokio::net::TcpListener;
+
+const DATA: &str = r#"
+    @prefix ex: <http://ex/> .
+    ex:alice ex:knows ex:bob ; ex:age 30 ; ex:name "Alice" .
+    ex:bob   ex:age 25 ; ex:name "Bob"@en .
+    ex:carol ex:age 35 .
+"#;
+
+/// Boots the server on a random local port over the loaded `DATA` graph; returns its base URL.
+async fn spawn() -> String {
+    let graph = Graph::load_str(DATA, "turtle").unwrap();
+    let app = router(AppState::new(graph));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+/// Boots an EMPTY server (no initial data) — for the GSP write-then-read round-trip.
+async fn spawn_empty() -> String {
+    let graph = Graph::load_str("", "turtle").unwrap();
+    let app = router(AppState::new(graph));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+// ===========================================================================
+// Feature ON: the real JSON-LD wiring.
+// ===========================================================================
+
+/// The canonical, order-independent triple set of an RDF document, for round-trip equality.
+/// We parse via the engine (the same parser the server uses) and compare N-Triples lines as a
+/// sorted set — JSON-LD specifies no node order, so a set comparison is the correct invariant.
+#[cfg(feature = "jsonld")]
+fn triple_set(text: &str, format: &str) -> std::collections::BTreeSet<String> {
+    let g = Graph::load_str(text, format).expect("parse RDF document");
+    let nt =
+        sparq_engine::construct_or_describe(&g, "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }").unwrap();
+    nt.iter()
+        .map(|t| format!("{} {} {} .", t.subject, t.predicate, t.object))
+        .collect()
+}
+
+/// EMIT: a `CONSTRUCT` with `Accept: application/ld+json` returns JSON-LD with the right
+/// `Content-Type`, and that JSON-LD `toRdf` round-trips back to the same triples as the
+/// equivalent N-Triples emission. This is the load-bearing result-equivalence invariant.
+#[cfg(feature = "jsonld")]
+#[tokio::test]
+async fn construct_accept_jsonld_roundtrips() {
+    let base = spawn().await;
+    let query = "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }";
+
+    // JSON-LD emission.
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", query)])
+        .header("accept", "application/ld+json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.headers()["content-type"], "application/ld+json; charset=utf-8");
+    let jsonld = resp.text().await.unwrap();
+    // Flattened form: a `@graph` envelope of node objects.
+    assert!(jsonld.contains("@graph"), "flattened JSON-LD carries an @graph envelope: {jsonld}");
+
+    // N-Triples emission of the same CONSTRUCT, as the reference triple set.
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", query)])
+        .header("accept", "application/n-triples")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let ntriples = resp.text().await.unwrap();
+
+    // toRdf(JSON-LD) == the N-Triples triple set. This proves the emitted JSON-LD is valid AND
+    // lossless — the real serialiser path, not a mock.
+    assert_eq!(
+        triple_set(&jsonld, "jsonld"),
+        triple_set(&ntriples, "ntriples"),
+        "JSON-LD CONSTRUCT output must round-trip to the same RDF graph as N-Triples"
+    );
+    // Sanity: the round-trip is non-trivial (the DATA is a multi-triple graph), so the
+    // equality above is a real assertion, not a trivially-empty-set match.
+    assert!(triple_set(&ntriples, "ntriples").len() >= 5);
+}
+
+/// ACCEPT: a GSP `PUT` of an `application/ld+json` body, then a `GET`, returns exactly the
+/// loaded triples — the parse path wired through the engine's JSON-LD loader.
+#[cfg(feature = "jsonld")]
+#[tokio::test]
+async fn gsp_put_jsonld_then_get_roundtrips() {
+    let base = spawn_empty().await;
+    // An expanded JSON-LD document: two triples on one subject.
+    let jsonld_body = r#"{
+        "@id": "http://ex/widget",
+        "http://ex/label": [{"@value": "Widget"}],
+        "http://ex/count": [{"@value": "7", "@type": "http://www.w3.org/2001/XMLSchema#integer"}]
+    }"#;
+
+    let put = client()
+        .put(format!("{base}/graphs/things"))
+        .header("content-type", "application/ld+json")
+        .body(jsonld_body)
+        .send()
+        .await
+        .unwrap();
+    assert!(
+        put.status().is_success(),
+        "GSP PUT of application/ld+json should succeed, got {}",
+        put.status()
+    );
+
+    // GET the graph back as N-Triples and compare the triple set to what we loaded.
+    let get = client()
+        .get(format!("{base}/graphs/things"))
+        .header("accept", "application/n-triples")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.status(), 200);
+    let back = get.text().await.unwrap();
+    let got = triple_set(&back, "ntriples");
+    let expected = triple_set(jsonld_body, "jsonld");
+    assert_eq!(got, expected, "GSP PUT(JSON-LD) -> GET must return the same triples");
+    assert_eq!(expected.len(), 2, "the body carries exactly two triples");
+}
+
+/// ACCEPT then re-EMIT as JSON-LD: a PUT of JSON-LD followed by a GET with
+/// `Accept: application/ld+json` round-trips through both wired directions at once.
+#[cfg(feature = "jsonld")]
+#[tokio::test]
+async fn gsp_put_jsonld_then_get_jsonld_roundtrips() {
+    let base = spawn_empty().await;
+    let jsonld_body = r#"[
+        {"@id": "http://ex/a", "http://ex/p": [{"@id": "http://ex/b"}]},
+        {"@id": "http://ex/b", "http://ex/q": [{"@value": "leaf"}]}
+    ]"#;
+    let put = client()
+        .put(format!("{base}/graphs/g"))
+        .header("content-type", "application/ld+json")
+        .body(jsonld_body)
+        .send()
+        .await
+        .unwrap();
+    assert!(put.status().is_success());
+
+    let get = client()
+        .get(format!("{base}/graphs/g"))
+        .header("accept", "application/ld+json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(get.status(), 200);
+    assert_eq!(get.headers()["content-type"], "application/ld+json; charset=utf-8");
+    let back = get.text().await.unwrap();
+    assert_eq!(
+        triple_set(&back, "jsonld"),
+        triple_set(jsonld_body, "jsonld"),
+        "PUT(JSON-LD) -> GET(JSON-LD) must round-trip the graph"
+    );
+}
+
+/// Negotiation contract: a higher-q JSON-LD wins over a lower-q Turtle; `q=0` rejects JSON-LD.
+#[cfg(feature = "jsonld")]
+#[tokio::test]
+async fn construct_jsonld_qvalue_contract() {
+    let base = spawn().await;
+    let query = "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }";
+
+    // JSON-LD q=0.9 beats Turtle q=0.5.
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", query)])
+        .header("accept", "text/turtle;q=0.5, application/ld+json;q=0.9")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.headers()["content-type"], "application/ld+json; charset=utf-8");
+
+    // q=0 rejects JSON-LD, so Turtle is served.
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", query)])
+        .header("accept", "application/ld+json;q=0, text/turtle")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.headers()["content-type"], "text/turtle; charset=utf-8");
+}
+
+/// A GSP write body of an UNSUPPORTED type is still a `415` even with the feature on, and its
+/// message advertises JSON-LD among the accepted dialects.
+#[cfg(feature = "jsonld")]
+#[tokio::test]
+async fn gsp_put_unsupported_type_is_415_with_jsonld_advertised() {
+    let base = spawn_empty().await;
+    let resp = client()
+        .put(format!("{base}/graphs/x"))
+        .header("content-type", "application/pdf")
+        .body("not rdf")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 415);
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.contains("application/ld+json"),
+        "feature-ON 415 message advertises JSON-LD: {body}"
+    );
+}
+
+// ===========================================================================
+// Feature OFF: the default build is byte-identical — JSON-LD is unsupported.
+// ===========================================================================
+
+/// Without the `jsonld` feature, an `application/ld+json` GSP write body is a plain `415`, and
+/// the message does NOT advertise JSON-LD (the build cannot parse it).
+#[cfg(not(feature = "jsonld"))]
+#[tokio::test]
+async fn gsp_put_jsonld_is_415_without_feature() {
+    let base = spawn_empty().await;
+    let resp = client()
+        .put(format!("{base}/graphs/x"))
+        .header("content-type", "application/ld+json")
+        .body(r#"{"@id":"http://ex/a"}"#)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 415);
+    let body = resp.text().await.unwrap();
+    assert!(
+        !body.contains("ld+json"),
+        "feature-OFF 415 message must not advertise JSON-LD: {body}"
+    );
+}
+
+/// Without the feature, an `Accept: application/ld+json` CONSTRUCT does NOT 406 — content
+/// negotiation falls back to a supported graph format (N-Triples, the default). The endpoint
+/// always has a representation, so it answers 200 with that fallback, never a 406.
+#[cfg(not(feature = "jsonld"))]
+#[tokio::test]
+async fn construct_accept_jsonld_falls_back_without_feature() {
+    let base = spawn().await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")])
+        .header("accept", "application/ld+json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let ct = resp.headers()["content-type"].to_str().unwrap().to_string();
+    assert!(
+        !ct.contains("ld+json"),
+        "feature-OFF build must not emit JSON-LD; fell back to {ct}"
+    );
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: http-server
-description: Run or point an agent at a sparq SPARQL 1.1 Protocol HTTP endpoint (sparq-server) — /sparql query+update over GET/POST, content negotiation (SELECT/ASK JSON/XML/CSV/TSV; CONSTRUCT/DESCRIBE + Graph Store N-Triples/prefix-Turtle/RDF-XML), Graph Store read AND write (PUT/POST/DELETE/PATCH on graph resources, RDF/XML bodies accepted, atomic SPARQL-Update + opt-in Solid N3-Patch on PATCH), EXPLAIN, Prometheus /metrics, WebSocket + SSE subscriptions, and opt-in time-travel ?generation pinning. Use when starting the server, querying/updating a running endpoint, choosing Accept/Content-Type, or embedding the axum router.
+description: Run or point an agent at a sparq SPARQL 1.1 Protocol HTTP endpoint (sparq-server) — /sparql query+update over GET/POST, content negotiation (SELECT/ASK JSON/XML/CSV/TSV; CONSTRUCT/DESCRIBE + Graph Store N-Triples/prefix-Turtle/RDF-XML, plus JSON-LD behind the opt-in jsonld feature), Graph Store read AND write (PUT/POST/DELETE/PATCH on graph resources, RDF/XML + opt-in JSON-LD bodies accepted, atomic SPARQL-Update + opt-in Solid N3-Patch on PATCH), EXPLAIN, Prometheus /metrics, WebSocket + SSE subscriptions, and opt-in time-travel ?generation pinning. Use when starting the server, querying/updating a running endpoint, choosing Accept/Content-Type, or embedding the axum router.
 ---
 
 # sparq-http-server
@@ -225,7 +225,7 @@ CONSTRUCT/DESCRIBE):
 | --- | --- | --- |
 | SELECT | `application/sparql-results+json` (default) / `+xml` / `text/csv` / `text/tab-separated-values` | matching results media |
 | ASK | json (default) / xml | `application/sparql-results+json` / `+xml` |
-| CONSTRUCT / DESCRIBE | `application/n-triples` (default) / `text/turtle` / `application/rdf+xml` | matching RDF media; N-Triples, prefix-compacting Turtle, or RDF/XML <!-- [OPUS-4.8] sq-rt6v --> |
+| CONSTRUCT / DESCRIBE | `application/n-triples` (default) / `text/turtle` / `application/rdf+xml` / `application/ld+json` (opt-in `jsonld` feature) | matching RDF media; N-Triples, prefix-compacting Turtle, RDF/XML, <!-- [OPUS-4.8] sq-rt6v --> or flattened JSON-LD <!-- [OPUS-4.8] sq-oy1f.1 --> |
 
 ```sh
 curl -G http://127.0.0.1:3030/sparql -H 'Accept: application/sparql-results+xml' \
@@ -236,7 +236,20 @@ curl -G http://127.0.0.1:3030/sparql -H 'Accept: text/turtle' \
 # RDF/XML:
 curl -G http://127.0.0.1:3030/sparql -H 'Accept: application/rdf+xml' \
      --data-urlencode 'query=CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'
+# JSON-LD (flattened) — requires a `--features jsonld` build: [OPUS-4.8] sq-oy1f.1
+curl -G http://127.0.0.1:3030/sparql -H 'Accept: application/ld+json' \
+     --data-urlencode 'query=CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'
 ```
+
+> **JSON-LD content negotiation (opt-in `jsonld` feature).** With the server built
+> `--features jsonld`, `application/ld+json` joins the q-value-aware RDF negotiation in BOTH
+> directions: a CONSTRUCT/DESCRIBE or a Graph-Store-Protocol read with `Accept:
+> application/ld+json` is served as the engine's *flattened* JSON-LD (a `{"@graph": […]}`
+> node-object document that `toRdf`-round-trips to the same graph), and a GSP `PUT`/`POST`
+> with `Content-Type: application/ld+json` is parsed into the store via the engine's JSON-LD
+> parser. Without the feature, `application/ld+json` is unrecognised: an `Accept` for it falls
+> back to N-Triples (never a 406 — the endpoint always has a representation), and a write body
+> in it is a plain `415`. The default build is byte-identical to before.
 
 **2. EXPLAIN a query plan (no execution) or analyze (execute + per-operator trace).**
 `text/plain` response. Use `explain` / `explain=plan` (or `Accept: text/x-sparq-explain`)
@@ -330,14 +343,17 @@ gauge count SSE streams and WS subscriptions together.
 
 ```sh
 # READ (GET/HEAD): serialises the addressed graph in the Accept-negotiated RDF syntax
-# (default N-Triples; also text/turtle = prefix-compacting Turtle, application/rdf+xml = RDF/XML)
+# (default N-Triples; also text/turtle = prefix-compacting Turtle, application/rdf+xml = RDF/XML,
+#  and application/ld+json = flattened JSON-LD with `--features jsonld` [OPUS-4.8] sq-oy1f.1)
 curl http://127.0.0.1:3030/sparql/graph?default                 # GSP indirect (default graph)
 curl 'http://127.0.0.1:3030/sparql/graph?graph=http://ex/g'     # GSP indirect (named graph)
 curl http://127.0.0.1:3030/graphs/whatever                      # GSP direct (request URI is the graph IRI)
 curl -H 'Accept: application/rdf+xml' http://127.0.0.1:3030/sparql/graph?default   # RDF/XML read [OPUS-4.8] sq-rt6v
+curl -H 'Accept: application/ld+json' http://127.0.0.1:3030/sparql/graph?default   # JSON-LD read (--features jsonld) [OPUS-4.8] sq-oy1f.1
 
 # WRITE (sq-gxsj): body is RDF, format by Content-Type
-#   (turtle | n-triples | n-quads | trig | application/rdf+xml [OPUS-4.8] sq-rt6v)
+#   (turtle | n-triples | n-quads | trig | application/rdf+xml [OPUS-4.8] sq-rt6v
+#    | application/ld+json with `--features jsonld` [OPUS-4.8] sq-oy1f.1)
 # PUT = REPLACE graph contents (201 if created, 204 if replaced):
 curl -X PUT 'http://127.0.0.1:3030/sparql/graph?graph=http://ex/g' \
      -H 'content-type: text/turtle' --data '<http://ex/s> <http://ex/p> <http://ex/o> .'


### PR DESCRIPTION
> 🤖 SPARQ agent — this PR was implemented by an autonomous SPARQ agent (Opus 4.8, 1M context). Tracking bead **sq-oy1f.1** under epic **sq-oy1f** (full W3C JSON-LD 1.1 support).

## What this does

Wires **JSON-LD 1.1** (`application/ld+json`) into the server's RDF content negotiation, **both directions**, behind a new **OPT-IN `jsonld` feature** (OFF by default — the default build is byte-identical to before).

### EMIT
A SPARQL `CONSTRUCT`/`DESCRIBE` or a Graph-Store-Protocol `GET` with `Accept: application/ld+json` is served as the engine's **flattened** JSON-LD (`{"@graph":[…]}` node-object document). It participates in the existing q-value-aware Accept negotiation exactly like the `text/turtle` / `application/rdf+xml` arms. Flattened (over expanded/compacted) is chosen as the negotiated default because it is node-merged, has a stable node ordering, and `toRdf`-round-trips losslessly to the source graph — the safest interop target.

### ACCEPT
A GSP `PUT`/`POST` (and the SHACL shapes-body reader, which shares the same media-type matrix) with `Content-Type: application/ld+json` is parsed into the store via the engine's JSON-LD parser (`Graph::load_str` `"jsonld"` token → `oxjsonld`).

## Wiring

- `negotiate.rs` — `GraphFormat::JsonLd` variant + its `content_type()` + a `negotiate_graph` arm (all `#[cfg(feature = "jsonld")]`).
- `graph.rs` — `triples_to_jsonld()` via the engine's `write_jsonld(.., JsonLdForm::Flattened, ..)`.
- `http.rs` — JSON-LD arm in the shared `serialise_graph_triples` dispatch (CONSTRUCT/DESCRIBE + GSP-read), the `rdf_format_for` write-body classifier, and a feature-aware GSP `415` message; the TPF body dispatch now routes through the shared serialiser so the match stays exhaustive.
- `descriptors.rs` — JSON-LD arm so a VoID/Service-Description (the `federation-descriptors` feature) can also be served as JSON-LD under `--all-features`.
- `Cargo.toml` — `jsonld = ["server", "sparq-core/jsonld", "sparq-engine/serialize-rdf"]`.

## Feature-OFF contract (strict-additive)

Without the feature, `GraphFormat::JsonLd`, its negotiation arm and its write-body arm are `#[cfg]`-stripped: an `Accept: application/ld+json` falls back to N-Triples (**never a 406** — the endpoint always has a representation), and an `application/ld+json` write body is a plain **415**. `sparq-wasm` depends on `sparq-core`/`-engine` directly (never on `sparq-server`), so the wasm bundle is untouched either way.

## Tests (`tests/jsonld_content_negotiation.rs`)

Real HTTP path (in-process axum + reqwest), not a mock:
- CONSTRUCT `Accept: application/ld+json` → valid JSON-LD whose `toRdf` equals the N-Triples emission's triple set (the load-bearing result-equivalence invariant).
- GSP `PUT(application/ld+json)` → `GET` returns the same triples; and `PUT(JSON-LD)` → `GET(JSON-LD)` round-trips through both wired directions.
- q-value contract (higher-q JSON-LD wins, `q=0` rejects) + `415` on an unsupported write type.
- `#[cfg(not(feature="jsonld"))]` block: feature-OFF `415` body, `Accept` fallback (no 406).

## Gates (both feature states)

- `cargo build` + `cargo test -p sparq-server` — green **default (feature OFF)** AND **`--features jsonld`**.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- No hard-coded perf numbers. `rustfmt`: matched the surrounding committed style (the workspace's reformat is intentionally deferred; clippy is the hard gate).

## Follow-up (bead)

A distinct **JSON-LD SPARQL *results* format** (`application/ld+json` for SELECT/ASK solution sets, vs the RDF-graph form here) is a separate surface — captured as a follow-up bead, see the agent report.

Refs sq-oy1f.1, epic sq-oy1f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)