### PR TITLE
fix(sparq-engine): three JSON-LD 1.1 Compaction strict-third-party faithfulness gaps (sq-oy1f.12/.13/.14) [OPUS-4.8]

### DIFF
--- a/crates/sparq-engine/README.md
+++ b/crates/sparq-engine/README.md
@@ -88,25 +88,20 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
   (or `&[oxrdf::Triple]`) back out as Turtle / TriG / N-Quads / JSON-LD 1.1
   (`serialize::{graph_to_turtle, graph_to_trig, graph_to_nquads, graph_to_jsonld, …}`; the
   `*_with` variants + `prefixes_from_pairs([(prefix, iri), …])` accept a caller's own prefix
-  policy). Plus a deterministic **pretty** Turtle / TriG variant
-  (`graph_to_turtle_pretty` / `graph_to_trig_pretty`, or `write_turtle_pretty` with
-  `PrettyOptions { indent, abbreviate }`): subject grouping, p-o/object lists, `a` for `rdf:type`,
-  used-only `@prefix`, *emission-order-independent* (sorted) — round-trip-correct. The JSON-LD
-  writers have a matching **pretty** (indented) variant (`graph_to_jsonld_pretty` /
-  `write_jsonld_pretty`, `JsonLdPrettyOptions { indent }`): a whitespace-only re-indent. For
-  true **W3C JSON-LD 1.1 Compaction** against a caller `@context`,
-  `graph_to_jsonld_compact(&g, &ctx)` / `write_jsonld_compact` (+ the `_pretty` variants) apply
-  the full algorithm — term definitions, `@vocab`, type/language/`@container`
-  (`@set`/`@list`/`@language`/`@index`) coercion, `@reverse`, `@id`/`@type` aliasing, value +
-  node + IRI compaction — still hand-rolled, dependency-free (`parse_context_json` builds it).
-  The emitted document is **faithful to a strict third-party processor** (differentially verified
-  against the pyld W3C reference): a `@reverse` edge is emitted as a forward member of the reverse
-  term (not an `@reverse` block, which would double-invert); non-string values never land in a
-  language map; multi-value `@language`/`@index` containers accumulate (no value lost); and a
-  literal under a `@type:@id` term stays a literal (sq-oy1f.12/.13/.14).
-  `JsonLdForm::Compacted` remains the lighter prefix-only `@context`. The N-Triples writer
-  (`triples_to_ntriples`) is always on; off, zero serializer code compiles, the default build is
-  byte-identical, **no new dependencies** added. See
+  policy). Plus a deterministic **pretty** Turtle / TriG variant (`graph_to_turtle_pretty` /
+  `graph_to_trig_pretty`, or `write_turtle_pretty` with `PrettyOptions { indent, abbreviate }`):
+  subject grouping, object lists, `a` for `rdf:type`, used-only `@prefix`, *order-independent*
+  (sorted) — round-trip-correct. The JSON-LD writers have a matching **pretty** (indented) variant
+  (`graph_to_jsonld_pretty` / `write_jsonld_pretty`, `JsonLdPrettyOptions { indent }`). For true
+  **W3C JSON-LD 1.1 Compaction** against a caller `@context`, `graph_to_jsonld_compact(&g, &ctx)` /
+  `write_jsonld_compact` (+ the `_pretty` variants) apply the full algorithm — term definitions,
+  `@vocab`, type/language/`@container` (`@set`/`@list`/`@language`/`@index`) coercion, `@reverse`,
+  `@id`/`@type` aliasing, value + node + IRI compaction — hand-rolled, dependency-free
+  (`parse_context_json` builds it). The output is **faithful to a strict third-party processor**
+  (differentially verified against pyld; the faithfulness fixes sq-oy1f.12/.13/.14 are detailed in
+  the `serialize::compact` rustdoc). `JsonLdForm::Compacted` remains the lighter prefix-only
+  `@context`. The N-Triples writer (`triples_to_ntriples`) is always on; off, zero serializer code
+  compiles, the default build is byte-identical, **no new dependencies** added. See
   [`skills/data-formats/SKILL.md`](../../skills/data-formats/SKILL.md) recipe 6.
 - **`forbid(unsafe_code)`** — the crate contains zero `unsafe`.
 

--- a/crates/sparq-engine/README.md
+++ b/crates/sparq-engine/README.md
@@ -99,6 +99,11 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
   the full algorithm — term definitions, `@vocab`, type/language/`@container`
   (`@set`/`@list`/`@language`/`@index`) coercion, `@reverse`, `@id`/`@type` aliasing, value +
   node + IRI compaction — still hand-rolled, dependency-free (`parse_context_json` builds it).
+  The emitted document is **faithful to a strict third-party processor** (differentially verified
+  against the pyld W3C reference): a `@reverse` edge is emitted as a forward member of the reverse
+  term (not an `@reverse` block, which would double-invert); non-string values never land in a
+  language map; multi-value `@language`/`@index` containers accumulate (no value lost); and a
+  literal under a `@type:@id` term stays a literal (sq-oy1f.12/.13/.14).
   `JsonLdForm::Compacted` remains the lighter prefix-only `@context`. The N-Triples writer
   (`triples_to_ntriples`) is always on; off, zero serializer code compiles, the default build is
   byte-identical, **no new dependencies** added. See

--- a/crates/sparq-engine/src/serialize.rs
+++ b/crates/sparq-engine/src/serialize.rs
@@ -3632,10 +3632,34 @@ ex:bob
                 }
                 let def = ctx.terms.get(k).cloned();
                 let pred = ctx.expand(k, true);
-                // @language container: { lang: value, … }. The reserved key `@none`
-                // ([OPUS-4.8] sq-oy1f.9) holds value(s) with NO language tag (a plain
-                // string, or a typed/native value object); those re-expand via the normal
-                // value path so they keep their datatype, not a bogus `@none` language tag.
+                // [OPUS-4.8] (sq-oy1f.12) A forward member whose term is a `@reverse` term
+                // INVERTS: `{subj: {children: O}}` (children is a @reverse term over
+                // `http://ex/parent`) means `O parent subj`, NOT `subj parent O`. The writer
+                // now emits relocated reverse edges as forward members keyed by the reverse
+                // term (never an `@reverse` block — that double-inverts for a strict
+                // processor), so the reader inverts here exactly once to recover the edge.
+                if def.as_ref().is_some_and(|d| d.reverse) {
+                    for o in as_array(v) {
+                        let mut aux = String::new();
+                        let obj = object_to_nt(o, def.as_ref(), ctx, graph, counter, &mut aux);
+                        let _ = writeln!(out, "{obj} <{pred}> {subj} {graph}.");
+                        out.push_str(&aux);
+                        if let Value::Object(om) = o {
+                            let has_id = om.iter().any(|(k, _)| ctx.keyword(k) == "@id");
+                            let has_value = om.iter().any(|(k, _)| ctx.keyword(k) == "@value");
+                            if has_id && om.len() > 1 && !has_value {
+                                node_to_nquads(om, graph, ctx, counter, out);
+                            }
+                        }
+                    }
+                    continue;
+                }
+                // @language container: { lang: value(s), … }. The reserved key `@none`
+                // ([OPUS-4.8] sq-oy1f.9) holds value(s) with NO language tag (a plain string,
+                // or a typed/native value object); those re-expand via the normal value path
+                // so they keep their datatype, not a bogus `@none` language tag. A language
+                // member's value may be an array ([OPUS-4.8] sq-oy1f.14 — several values share
+                // one language), so iterate strings via `as_array`.
                 if def.as_ref().and_then(|d| d.container.as_deref()) == Some("@language") {
                     if let Value::Object(langs) = v {
                         for (lang, lv) in langs {
@@ -3655,12 +3679,14 @@ ex:bob
                                 }
                                 continue;
                             }
-                            let lex = lv.as_str().expect("language map value");
-                            let _ = writeln!(
-                                out,
-                                "{subj} <{pred}> \"{}\"@{lang} {graph}.",
-                                escape(lex)
-                            );
+                            for sv in as_array(lv) {
+                                let lex = sv.as_str().expect("language map value");
+                                let _ = writeln!(
+                                    out,
+                                    "{subj} <{pred}> \"{}\"@{lang} {graph}.",
+                                    escape(lex)
+                                );
+                            }
                         }
                         continue;
                     }
@@ -4128,10 +4154,15 @@ ex:bob
         assert_compact_count_iso(&g, ctx);
     }
 
-    /// [OPUS-4.8] sq-oy1f.9 — an `@language`-container term must NOT drop a value lacking a
-    /// language tag (a plain string or a typed/numeric literal): per spec it falls under the
-    /// `@none` member (matching pyld), not into oblivion. The round-trip must preserve the
-    /// typed literal exactly.
+    /// [OPUS-4.8] sq-oy1f.9 (faithfulness-corrected by sq-oy1f.12) — an `@language`-container
+    /// term must NOT drop a value lacking a language tag. The ORIGINAL sq-oy1f.9 fix routed a
+    /// non-string value (the `xsd:integer` `42`) into the language map's `@none` member — but
+    /// that produces a document a STRICT third-party processor (pyld) REJECTS, because a
+    /// JSON-LD language map's values must be strings. sq-oy1f.12 corrects this: a non-string
+    /// value goes to a SEPARATE non-language key (the property IRI compacted without the
+    /// language term), which preserves the datatype on read-back. This test asserts the new
+    /// pyld-faithful shape. (A *plain string* with no language still correctly uses `@none`,
+    /// which IS valid — see `compact_language_none_plain_string`.)
     #[test]
     fn compact_language_container_keeps_nonlang_under_none() {
         let g = Graph::load_str(
@@ -4145,11 +4176,16 @@ ex:bob
         let doc = compact_doc(&g, ctx);
         // The language-tagged string keeps its language-map slot.
         assert!(doc.contains("\"en\":\"Hello\""), "language-map en slot:\n{doc}");
-        // The non-language-tagged integer is preserved under `@none` (pyld-faithful), as the
-        // native scalar — NOT dropped.
+        // The non-string integer is NOT placed in the language map (that would be invalid
+        // JSON-LD); it goes under the separate non-language key (the full IRI here), keeping
+        // its native form so the datatype survives.
         assert!(
-            doc.contains("\"@none\":42"),
-            "non-lang value preserved under @none:\n{doc}"
+            doc.contains("\"http://ex/labels\":42"),
+            "non-string value preserved under a separate non-language key:\n{doc}"
+        );
+        assert!(
+            !doc.contains("\"@none\":42"),
+            "a non-string value must NOT land in the language map (pyld rejects it):\n{doc}"
         );
         // Losslessness: both triples (incl. the xsd:integer 42) survive the round-trip.
         assert_compact_iso(&g, ctx);
@@ -4208,6 +4244,243 @@ ex:bob
             "full IRI must not be emitted for the predicate:\n{doc}"
         );
         // Lossless (this bug was output-quality only — confirm anyway).
+        assert_compact_iso(&g, ctx);
+    }
+
+    // =======================================================================
+    // [OPUS-4.8] sq-oy1f.12/.13/.14 — STRICT third-party (pyld) FAITHFULNESS
+    // regressions. The conformance suite's own oxjsonld self-reparse oracle
+    // MASKED these: the bytes below were each fed to the pyld W3C reference
+    // processor (expand + toRdf) and the reproduced N-Quads compared to the
+    // source. Each assertion pins the exact pyld-verified shape (NOT merely
+    // sparq's own round-trip) so a regression that re-introduces an
+    // invalid / inverted / lossy document is caught here. The
+    // `assert_compact_iso` guard additionally pins the sparq self-round-trip.
+    // =======================================================================
+
+    /// [OPUS-4.8] sq-oy1f.12 — a `@reverse`-term edge must be emitted as a FORWARD member
+    /// keyed by the reverse term, never inside an `@reverse` block. A reverse-term key inside
+    /// an `@reverse` block DOUBLE-INVERTS: pyld applies the block's inversion AND the term's
+    /// inversion, reading the edge backwards (`<alice> <parent> <bob>` instead of
+    /// `<bob> <parent> <alice>`). The forward-member shape inverts exactly once.
+    ///
+    /// pyld differential (verified): the doc below `toRdf`s to exactly the two source triples
+    /// `<bob> <parent> <alice>` + `<alice> <name> "Alice"`, NOT the inverted edge.
+    #[test]
+    fn compact_reverse_term_as_forward_member_not_block() {
+        let g = Graph::load_str(
+            r#"@prefix ex: <http://ex/> .
+               ex:bob ex:parent ex:alice .
+               ex:alice ex:name "Alice" ."#,
+            "turtle",
+        )
+        .unwrap();
+        // `children` is a @reverse term over ex:parent; the predicate has no plain @vocab
+        // spelling, so the ONLY way to express the edge is via the reverse term.
+        let ctx = r#"{"children":{"@reverse":"http://ex/parent","@type":"@id"},
+                      "name":"http://ex/name"}"#;
+        let doc = compact_doc(&g, ctx);
+        // Inspect the @graph body only (the @context legitimately mentions `@reverse` in the
+        // term definition; we are asserting on the emitted DATA, not the context).
+        let body = doc.split("\"@graph\":").nth(1).expect("doc has @graph");
+        // The reverse term appears as a FORWARD member of the object node (ex:alice), with
+        // the subject (ex:bob) as its value. The pyld-verified faithful shape.
+        assert!(
+            body.contains(r#""children":"http://ex/bob""#),
+            "reverse term emitted as forward member:\n{doc}"
+        );
+        // NO `@reverse` block is emitted in the data (that double-inverts for a strict
+        // processor); the only `@reverse` occurrence is the context term definition.
+        assert!(
+            !body.contains("@reverse"),
+            "no @reverse block in the @graph body (it would double-invert):\n{doc}"
+        );
+        // And the internal relocation sentinel never leaks into the document.
+        assert!(
+            !doc.contains("sparq-reverse"),
+            "internal sentinel must not appear:\n{doc}"
+        );
+        // Losslessness through sparq's own reader (the conformance oracle): exact-label match.
+        assert_compact_iso(&g, ctx);
+    }
+
+    /// [OPUS-4.8] sq-oy1f.12 — a non-string value (typed/numeric literal) must NOT be placed
+    /// in a `@language` container map (a strict processor rejects the whole document:
+    /// "language map values must be strings"). It goes to a SEPARATE non-language key, which
+    /// preserves its datatype on read-back.
+    ///
+    /// pyld differential (verified): with the integer under `@none` pyld THROWS
+    /// `invalid language map value`; with it under the separate key the doc `toRdf`s to
+    /// `"42"^^xsd:integer` (datatype preserved), not a `"42"` string.
+    #[test]
+    fn compact_language_nonstring_routes_to_separate_key() {
+        let g = Graph::load_str(
+            r#"@prefix ex: <http://ex/> .
+               ex:s ex:labels "Hello"@en .
+               ex:s ex:labels 42 ."#,
+            "turtle",
+        )
+        .unwrap();
+        let ctx = r#"{"labels":{"@id":"http://ex/labels","@container":"@language"}}"#;
+        let doc = compact_doc(&g, ctx);
+        // The language map holds ONLY the string-valued, language-tagged entry.
+        assert!(doc.contains(r#""labels":{"en":"Hello"}"#), "lang map en-only:\n{doc}");
+        // The integer is under the separate full-IRI key as a native scalar (datatype kept).
+        assert!(
+            doc.contains(r#""http://ex/labels":42"#),
+            "non-string under separate key:\n{doc}"
+        );
+        assert!(!doc.contains(r#""@none":42"#), "no invalid @none scalar:\n{doc}");
+        assert_compact_iso(&g, ctx);
+    }
+
+    /// [OPUS-4.8] sq-oy1f.12 — a PLAIN string (no language tag, xsd:string) under a
+    /// `@language` container IS validly placed in the `@none` member (a language map MAY hold
+    /// `@none` strings). This case must keep working — only NON-string values move out.
+    ///
+    /// pyld differential (verified): the `@none` plain string `toRdf`s to a plain `"plain"`
+    /// literal (xsd:string), round-tripping faithfully.
+    #[test]
+    fn compact_language_none_plain_string() {
+        let g = Graph::load_str(
+            r#"@prefix ex: <http://ex/> .
+               ex:s ex:labels "Hello"@en .
+               ex:s ex:labels "plain" ."#,
+            "turtle",
+        )
+        .unwrap();
+        let ctx = r#"{"labels":{"@id":"http://ex/labels","@container":"@language"}}"#;
+        let doc = compact_doc(&g, ctx);
+        assert!(doc.contains(r#""en":"Hello""#), "lang slot:\n{doc}");
+        // The plain string stays in the language map under `@none` (valid, pyld-faithful).
+        assert!(doc.contains(r#""@none":"plain""#), "plain string under @none:\n{doc}");
+        assert_compact_iso(&g, ctx);
+    }
+
+    /// [OPUS-4.8] sq-oy1f.13 — a plain literal value under a `@type:@id`-coerced term must be
+    /// emitted under a NON-coerced key, else a strict processor reads the literal string as a
+    /// node IRI (a string literal silently becomes a node — data corruption).
+    ///
+    /// pyld differential (verified): with `lit` (a `@type:@id` term) carrying the literal
+    /// `"http://ex/target"`, pyld `toRdf`s it to the IRI `<http://ex/target>` (corruption);
+    /// under the full-IRI key it `toRdf`s to the string literal `"http://ex/target"`. The
+    /// co-located node reference (`ref`) stays under the coerced term (its `{"@id"}` collapses
+    /// to a bare IRI — the point of the coercion).
+    #[test]
+    fn compact_typeid_literal_kept_off_coerced_term() {
+        let g = Graph::load_str(
+            r#"@prefix ex: <http://ex/> .
+               ex:s ex:ref ex:target .
+               ex:s ex:lit "http://ex/target" ."#,
+            "turtle",
+        )
+        .unwrap();
+        let ctx = r#"{"@vocab":"http://ex/",
+                      "ref":{"@id":"http://ex/ref","@type":"@id"},
+                      "lit":{"@id":"http://ex/lit","@type":"@id"}}"#;
+        let doc = compact_doc(&g, ctx);
+        // The literal goes under the full IRI key (a non-coerced spelling), staying a literal.
+        assert!(
+            doc.contains(r#""http://ex/lit":"http://ex/target""#),
+            "literal under non-coerced key:\n{doc}"
+        );
+        // The `lit` coerced term must NOT carry the literal string (that would read as an IRI).
+        assert!(
+            !doc.contains(r#""lit":"http://ex/target""#),
+            "literal must not use the @id-coerced term:\n{doc}"
+        );
+        // The genuine node reference still uses the coerced `ref` term (bare-IRI collapse).
+        assert!(
+            doc.contains(r#""ref":"http://ex/target""#),
+            "node ref keeps the @id-coerced term:\n{doc}"
+        );
+        assert_compact_iso(&g, ctx);
+    }
+
+    /// [OPUS-4.8] sq-oy1f.14 — several values sharing one language must each survive (an array
+    /// per language slot); the prior single-set clobbered all but the last.
+    ///
+    /// pyld differential (verified): the array-per-language doc `toRdf`s to all three triples
+    /// (`"Hi"@en`, `"Hello"@en`, `"Salut"@fr`); the clobbered single-value form lost `"Hi"@en`.
+    #[test]
+    fn compact_language_container_multivalue_per_language() {
+        let g = Graph::load_str(
+            r#"@prefix ex: <http://ex/> .
+               ex:s ex:labels "Hi"@en .
+               ex:s ex:labels "Hello"@en .
+               ex:s ex:labels "Salut"@fr ."#,
+            "turtle",
+        )
+        .unwrap();
+        let ctx = r#"{"labels":{"@id":"http://ex/labels","@container":"@language"}}"#;
+        let doc = compact_doc(&g, ctx);
+        // The `en` slot is an ARRAY of both English strings (order is first-seen).
+        assert!(
+            doc.contains(r#""en":["Hi","Hello"]"#),
+            "multi-value en array:\n{doc}"
+        );
+        assert!(doc.contains(r#""fr":"Salut""#), "single fr stays scalar:\n{doc}");
+        // Losslessness: all three triples survive the round-trip.
+        assert_compact_iso(&g, ctx);
+    }
+
+    /// [OPUS-4.8] sq-oy1f.14 — an `@id` / `@graph` container that fromRdf cannot losslessly
+    /// populate must FALL BACK to the default (no-container) framing, not emit a node ref
+    /// under the container term. Emitting `{"@id": …}` under a `@container:@id` term made a
+    /// strict processor reject the document (`illegal key … @id` on a value object).
+    ///
+    /// pyld differential (verified): the buggy container shape THROWS in pyld; the default
+    /// framing (node ref under the full IRI key) `toRdf`s to both source triples.
+    #[test]
+    fn compact_id_container_falls_back_to_default_framing() {
+        let g = Graph::load_str(
+            r#"@prefix ex: <http://ex/> .
+               ex:s ex:members ex:m1 .
+               ex:m1 ex:name "M1" ."#,
+            "turtle",
+        )
+        .unwrap();
+        let ctx = r#"{"@vocab":"http://ex/","id":"@id",
+                      "members":{"@id":"http://ex/members","@container":"@id"}}"#;
+        let doc = compact_doc(&g, ctx);
+        // Inspect the @graph body (the @context legitimately defines the `members` term).
+        let body = doc.split("\"@graph\":").nth(1).expect("doc has @graph");
+        // The edge is emitted under the full-IRI key (default framing), NOT the `members`
+        // container term, so the value is a plain node reference pyld can read.
+        assert!(
+            body.contains(r#""http://ex/members":{"id":"http://ex/m1"}"#),
+            "default framing under full IRI key:\n{doc}"
+        );
+        // The `members` container term is NOT used as a key in the data (that yields a broken
+        // @id map a strict processor rejects).
+        assert!(
+            !body.contains(r#""members":"#),
+            "the @id-container term must not be a key:\n{doc}"
+        );
+        assert_compact_iso(&g, ctx);
+    }
+
+    /// [OPUS-4.8] sq-oy1f.14 — a multi-value `@index` container groups all values (fromRdf has
+    /// no per-value `@index`, so they share the reserved `@none` index slot as an array). The
+    /// document stays valid and every value survives.
+    ///
+    /// pyld differential (verified): the `{"@none": [...]}` index map `toRdf`s to both values.
+    #[test]
+    fn compact_index_container_multivalue_under_none() {
+        let g = Graph::load_str(
+            r#"@prefix ex: <http://ex/> .
+               ex:s ex:p "x" .
+               ex:s ex:p "y" ."#,
+            "turtle",
+        )
+        .unwrap();
+        let ctx = r#"{"p":{"@id":"http://ex/p","@container":"@index"}}"#;
+        let doc = compact_doc(&g, ctx);
+        // Both values land under the reserved `@none` index slot as an array.
+        assert!(
+            doc.contains(r#""p":{"@none":["x","y"]}"#),
+            "multi-value @index under @none array:\n{doc}"
+        );
         assert_compact_iso(&g, ctx);
     }
 }

--- a/crates/sparq-engine/src/serialize/compact.rs
+++ b/crates/sparq-engine/src/serialize/compact.rs
@@ -43,6 +43,22 @@
 //! `@vocab`, type/language/`@container` (`@set`/`@list`/`@language`/`@index`), `@reverse`,
 //! keyword aliasing, value compaction, node compaction and IRI compaction are all
 //! covered. See the crate README + `skills/data-formats/SKILL.md` for the boundary.
+//!
+//! ## Faithful to a strict third-party processor (sq-oy1f.12/.13/.14)
+//!
+//! [OPUS-4.8] The emitted compacted document is differentially verified against the pyld
+//! W3C reference processor, so a strict third-party consumer re-expands it to the same
+//! graph. The four faithfulness fixes that close that gap:
+//!
+//! - **`@reverse` edges** are emitted as a *forward member of the reverse term*, not inside
+//!   an `@reverse` block — emitting the block on an already-reversed edge would double-invert
+//!   (see [`relocate_reverse`] / [`REVERSE_RELOC`] and `compact_node`).
+//! - **Non-string values never land in a `@language` map** — a language container only
+//!   accumulates language-tagged strings; other values fall through to the normal path.
+//! - **Multi-value `@language` / `@index` containers accumulate** every value rather than
+//!   overwriting, so no member is lost when several values share a key.
+//! - **A literal under a `@type: @id` term stays a literal** — type coercion to `@id` applies
+//!   only to node references, never to a value that is already a literal.
 
 use super::{
     coerce_native, detect_lists, json_escape, ListInfo, NamedGraph, RDF_LANG_STRING, RDF_TYPE, XSD,

--- a/crates/sparq-engine/src/serialize/compact.rs
+++ b/crates/sparq-engine/src/serialize/compact.rs
@@ -51,6 +51,15 @@ use oxrdf::{NamedOrBlankNode, Term, Triple};
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
 
+/// [OPUS-4.8] (sq-oy1f.12) Internal sentinel member key under which [`relocate_reverse`]
+/// stashes the edges it moves onto an object node. It is NOT a JSON-LD keyword (it does not
+/// start with `@` so it never collides with a real keyword, and the leading marker bytes make
+/// it impossible for it to be a real predicate IRI). [`ActiveContext::compact_node`] consumes
+/// it and emits each stashed edge through the matching `@reverse` *term as a forward member*
+/// (the spec-faithful, pyld-verified shape) rather than an `@reverse` block (which would
+/// double-invert). It never appears in the emitted document.
+const REVERSE_RELOC: &str = "\u{0}sparq-reverse";
+
 // ===========================================================================
 // A tiny, dependency-free JSON value model.
 //
@@ -441,31 +450,40 @@ impl ActiveContext {
     }
 
     /// [OPUS-4.8] (sq-oy1f.8) Compacts a property `iri` in vocab position while IGNORING any
-    /// term that carries a `@container` mapping — so a co-located non-list sibling of an
-    /// `@list`-container term gets a key the reader will NOT re-interpret as the ordered
-    /// list. It prefers a plain (container-free) term match for the IRI, then falls through
-    /// to the same `@vocab`-relative / prefix / full-IRI choices as [`compact_iri`]. This
-    /// mirrors pyld: with `@vocab` it yields the vocab-relative form, with a plain alternate
-    /// term that term, otherwise the full IRI.
+    /// term that carries a `@container` mapping OR an `@id`/`@vocab` `@type` coercion — so a
+    /// co-located sibling that must NOT be re-interpreted (an `@list` sibling, a non-string
+    /// language-map value, or a plain literal alongside a `@type:@id` node ref — [OPUS-4.8]
+    /// sq-oy1f.8/.12/.13) gets a "plain" key. It prefers a plain (container- and `@id`/`@vocab`-
+    /// coercion-free) term match for the IRI, then falls through to the `@vocab`-relative /
+    /// prefix / full-IRI choices. This mirrors pyld: with `@vocab` it yields the vocab-relative
+    /// form, with a plain alternate term that term, otherwise the full IRI.
     fn compact_iri_no_list(&self, iri: &str, reverse: bool) -> String {
+        // A term is "re-coercing" if it would change how the sibling reads back: an `@list` /
+        // `@language` / `@index` etc. container, or an `@id`/`@vocab` type coercion (which
+        // turns a string value into a node IRI). Such a term is skipped here.
+        let recoerces = |def: &TermDefinition| -> bool {
+            def.container.is_some()
+                || def
+                    .type_mapping
+                    .as_deref()
+                    .is_some_and(|t| t == "@id" || t == "@vocab")
+        };
         for (t, def) in &self.terms {
-            if def.iri == iri
-                && def.reverse == reverse
-                && def.container.is_none()
-                && !t.contains(':')
-            {
+            if def.iri == iri && def.reverse == reverse && !recoerces(def) && !t.contains(':') {
                 return t.to_string();
             }
         }
-        // No container-free exact term: reuse the @vocab-relative / prefix / full-IRI
-        // fallbacks. `compact_iri` only returns a *container-bearing* term via its step-1
-        // exact-match branch, which we have already shown has no container-free hit here;
-        // but a coerced (container) term could still win there, so strip the @vocab/prefix
-        // tail by hand rather than recursing.
+        // No plain exact term: reuse the @vocab-relative / prefix / full-IRI fallbacks. A term
+        // that re-coerces (container or @id/@vocab) could still win `compact_iri`'s step-1
+        // exact-match branch, so strip the @vocab/prefix tail by hand rather than recursing.
         if !reverse {
             if let Some(v) = &self.vocab {
                 if let Some(rest) = iri.strip_prefix(v.as_str()) {
-                    if !rest.is_empty() && !rest.contains(':') && self.term_def(rest).is_none() {
+                    // A @vocab-relative bare term `rest` is safe only if no term definition
+                    // shadows it with a re-coercion (an un-coerced shadow re-expands the same
+                    // way, so it is fine; a re-coercing shadow would change the read-back).
+                    let shadow_recoerces = self.term_def(rest).is_some_and(recoerces);
+                    if !rest.is_empty() && !rest.contains(':') && !shadow_recoerces {
                         return rest.to_string();
                     }
                 }
@@ -651,35 +669,44 @@ impl ActiveContext {
         // Ordinary forward properties.
         if let Json::Obj(members) = node {
             for (key, vals) in members {
+                if key == REVERSE_RELOC {
+                    continue; // the relocated-reverse sentinel — emitted via reverse terms below
+                }
                 if key.starts_with('@') {
-                    continue; // keywords handled above (incl. @reverse below)
+                    continue; // keywords handled above
                 }
                 self.compact_property(key, vals, false, &mut result);
             }
         }
-        // An `@reverse` member (placed by `relocate_reverse` on the object node): each member
-        // key is a forward-predicate IRI; compact it via the matching `@reverse` term and its
-        // object array via value/node compaction.
-        if let Some(Json::Obj(rev_members)) = node.get("@reverse") {
-            let mut rev = Json::obj();
+        // [OPUS-4.8] (sq-oy1f.12) Relocated reverse edges (placed by `relocate_reverse` on the
+        // object node under the `REVERSE_RELOC` sentinel): each member key is a forward-
+        // predicate IRI, and the matching `@reverse` term is emitted as a *forward member* of
+        // this node — NOT inside an `@reverse` block. A `@reverse` BLOCK whose key is itself a
+        // `@reverse` term double-inverts (a strict third-party processor like pyld reads the
+        // edge backwards: it applies the block's inversion AND the term's inversion). Emitting
+        // the reverse term as a forward member (`{"children": <subject>}`) applies the
+        // inversion exactly once, so pyld reconstructs the original edge direction.
+        if let Some(Json::Obj(rev_members)) = node.get(REVERSE_RELOC) {
             for (iri, vals) in rev_members {
-                self.compact_property(iri, vals, true, &mut rev);
-            }
-            if let Json::Obj(m) = &rev {
-                if !m.is_empty() {
-                    result.set(&self.compact_keyword("@reverse"), rev);
-                }
+                self.compact_property(iri, vals, true, &mut result);
             }
         }
         result
     }
 
-    /// Relocates forward edges into `@reverse` blocks per the active context's `@reverse`
-    /// term definitions. For every node `S` with a property `P` (where `P` is the IRI of a
-    /// `@reverse` term) whose objects are node references, the edge is *moved* onto each
-    /// object node `O` as an `@reverse` member `{ P: [{"@id": S}] }`, and removed from `S`.
-    /// This is the fromRdf-side preparation that lets node compaction express the edge
-    /// through the reverse term — keeping the round-trip exact (the reader re-inverts it).
+    /// Relocates forward edges that a `@reverse` term covers onto their object node, so node
+    /// compaction can express each through the reverse term. For every node `S` with a
+    /// property `P` (where `P` is the IRI of a `@reverse` term) whose objects are node
+    /// references, the edge is *moved* onto each object node `O` under the internal
+    /// [`REVERSE_RELOC`] sentinel as `{ P: [{"@id": S}] }`, and removed from `S`.
+    ///
+    /// [OPUS-4.8] (sq-oy1f.12) `compact_node` then emits each relocated edge as a **forward
+    /// member keyed by the reverse term** (e.g. `{"children": <S>}` on `O`) — NOT inside an
+    /// `@reverse` block. A reverse-term key *inside* an `@reverse` block double-inverts: a
+    /// strict third-party processor (pyld) applies the block's inversion AND the term's
+    /// inversion, reading the edge backwards. The forward-member shape inverts exactly once,
+    /// so the round-trip is faithful. (The sentinel — not `@reverse` — is used precisely so a
+    /// downstream `@reverse` block is never emitted.)
     ///
     /// Only applied within a single graph scope (the caller passes one graph's node array).
     fn relocate_reverse(&self, nodes: &mut [Json]) {
@@ -765,12 +792,14 @@ impl ActiveContext {
                 true
             });
         }
-        // Attach each edge onto the object node's `@reverse` member.
+        // Attach each edge onto the object node's `REVERSE_RELOC` sentinel member (consumed by
+        // `compact_node` and emitted via the reverse term as a forward member — never as an
+        // `@reverse` block, which would double-invert).
         for (pos, pred, subj) in moves {
             let node = &mut nodes[pos];
             let mut subj_ref = Json::obj();
             subj_ref.set("@id", Json::Str(subj));
-            let rev = match node.get("@reverse").cloned() {
+            let rev = match node.get(REVERSE_RELOC).cloned() {
                 Some(Json::Obj(mut m)) => {
                     if let Some(slot) = m.iter_mut().find(|(k, _)| *k == pred) {
                         if let Json::Arr(a) = &mut slot.1 {
@@ -787,16 +816,16 @@ impl ActiveContext {
                     o
                 }
             };
-            node.set("@reverse", rev);
+            node.set(REVERSE_RELOC, rev);
         }
     }
 
     /// Compacts one property `iri` with its expanded object array `vals` into `result`,
     /// applying the term's `@container` framing (`@set`/`@list`/`@language`/`@index`) and
     /// "compact arrays" (a single-element array collapses to a scalar unless `@container`
-    /// forces an array). When `reverse_only` is true, only a reverse term is emitted (used
-    /// for the `@reverse` block in [`ActiveContext::compact_node`]); when false, reverse
-    /// terms are skipped.
+    /// forces an array). When `reverse_only` is true, only a reverse term is emitted (the
+    /// relocated-reverse edges from [`ActiveContext::compact_node`], emitted as forward
+    /// members keyed by the reverse term); when false, reverse terms are skipped.
     fn compact_property(&self, iri: &str, vals: &Json, reverse_only: bool, result: &mut Json) {
         // Choose the active term for this IRI in vocab position.
         let term = self.compact_iri(iri, true, reverse_only);
@@ -883,44 +912,79 @@ impl ActiveContext {
             return;
         }
 
-        // @language container: { "<lang>": "<value>", … } grouping language-tagged strings.
+        // @language container: { "<lang>": "<value(s)>", … } grouping language-tagged strings.
         //
-        // [OPUS-4.8] (sq-oy1f.9) A value that lacks a usable `@language` (a plain string
-        // with no tag, or a typed/numeric literal whose `@value` is not a JSON string) must
-        // NOT be dropped: per the W3C Compaction Algorithm a value that does not fit the
-        // language map falls under the `@none` member (matching pyld), it is not discarded.
-        // The prior loop inserted ONLY items with BOTH a string `@value` AND a `@language`,
-        // so `ex:s ex:labels 42` (and any non-tagged string) vanished — silent data loss
-        // violating losslessness. We now route every non-language-tagged value into the
-        // `@none` bucket via `compact_value` (preserving native scalars / typed value
-        // objects), accumulating multiple into an array. The reader re-expands `@none`
-        // entries with no language tag, so the round-trip is lossless.
+        // [OPUS-4.8] (sq-oy1f.9) A value that lacks a usable `@language` (a plain string with
+        // no tag, or a typed/numeric literal) must NOT be dropped.
+        //
+        // [OPUS-4.8] (sq-oy1f.12) But a language map's VALUES must be STRINGS per the W3C
+        // JSON-LD 1.1 spec (and a strict third-party processor like pyld REJECTS the whole
+        // document — `language map values must be strings` — if a non-string lands under
+        // `@none`). The prior code put a native scalar (`42`) under `@none`, producing a
+        // document pyld throws on. So:
+        //   * a language-TAGGED string → its language-map slot;
+        //   * a PLAIN string (string `@value`, no tag) → the `@none` member (valid, faithful);
+        //   * a NON-string value (number/bool/typed literal) → a SEPARATE non-language key
+        //     (the IRI compacted ignoring the language term), which preserves the datatype on
+        //     read-back (pyld reads `42`^^xsd:integer, not a `"42"` string).
+        //
+        // [OPUS-4.8] (sq-oy1f.14) Several values may share one language (or `@none`); each
+        // language slot accumulates into an ARRAY of strings so none is overwritten/lost (the
+        // prior `map.set(lang, …)` silently clobbered an earlier same-language value).
         if container.as_deref() == Some("@language") {
             let mut map = Json::obj();
-            let mut none_bucket: Vec<Json> = Vec::new();
+            let mut nonstring: Vec<Json> = Vec::new();
+            // Accumulate string values per key (language tag or `@none`); a key with one
+            // string stays a scalar, a key with several becomes an array (spec + pyld).
+            let push_str = |map: &mut Json, key: &str, s: &str| match map.get(key).cloned() {
+                Some(Json::Arr(mut a)) => {
+                    a.push(Json::Str(s.to_string()));
+                    map.set(key, Json::Arr(a));
+                }
+                Some(existing) => map.set(key, Json::Arr(vec![existing, Json::Str(s.to_string())])),
+                None => map.set(key, Json::Str(s.to_string())),
+            };
             for v in &items {
                 match (
                     v.get("@value").and_then(Json::as_str),
                     v.get("@language").and_then(Json::as_str),
                 ) {
-                    (Some(val), Some(lang)) => map.set(lang, Json::Str(val.to_string())),
-                    _ => none_bucket.push(self.compact_value(Some(&term), v)),
+                    // A language-tagged string → its language slot.
+                    (Some(val), Some(lang)) => push_str(&mut map, lang, val),
+                    // A plain (untyped) string with no language → the `@none` slot. The
+                    // value is a JSON string AND the expanded model carries no `@type`
+                    // (untyped strings are emitted as a bare `@value` string by fromRdf).
+                    (Some(val), None) if v.get("@type").is_none() => {
+                        push_str(&mut map, "@none", val)
+                    }
+                    // Anything else (a native scalar `Json::Raw`, or a typed value object) is
+                    // NOT a valid language-map value — route it to a separate non-language key
+                    // so its datatype survives. `compact_value(None, …)` keeps the value
+                    // object as-is (no language-term coercion).
+                    _ => nonstring.push(self.compact_value(None, v)),
                 }
             }
-            if !none_bucket.is_empty() {
-                let none_val = if none_bucket.len() == 1 {
-                    none_bucket.into_iter().next().expect("len 1")
-                } else {
-                    Json::Arr(none_bucket)
-                };
-                map.set("@none", none_val);
+            if let Json::Obj(m) = &map {
+                if !m.is_empty() {
+                    result.set(&term, map);
+                }
             }
-            result.set(&term, map);
+            if !nonstring.is_empty() {
+                // The IRI compacted WITHOUT the language-container term (the full /
+                // `@vocab`-relative / prefix form), so the reader does not re-read these
+                // through the language map. Reuse `compact_iri_no_list` — it already skips any
+                // container-bearing term and yields exactly that fallback spelling.
+                let key = self.compact_iri_no_list(iri, reverse_only);
+                let value = self.compact_values_default(&key, &nonstring, false);
+                result.set(&key, value);
+            }
             return;
         }
 
-        // @index container: { "<index>": <value>, … }. fromRdf does not emit @index, but a
-        // context may declare it; group by the value's @index member if present.
+        // @index container: { "<index>": <value>, … }. fromRdf does not emit a per-value
+        // `@index`, so every value falls under the reserved `@none` member. [OPUS-4.8]
+        // (sq-oy1f.14) Several `@none` values accumulate into an array (the index-map value
+        // form pyld round-trips), never overwriting one another.
         if container.as_deref() == Some("@index") {
             let mut map = Json::obj();
             for v in &items {
@@ -936,6 +1000,61 @@ impl ActiveContext {
                 }
             }
             result.set(&term, map);
+            return;
+        }
+
+        // [OPUS-4.8] (sq-oy1f.14) `@id` / `@graph` containers: the fromRdf model has no
+        // per-value `@index`/`@id` map key and does not nest a named-graph under a property,
+        // so sparq cannot LOSSLESSLY populate these container maps. Emitting a node reference
+        // under an `@id`/`@graph` container produced a `{"@id": …}` map *value* that a strict
+        // processor (pyld) rejects (`illegal key … @id` on a value object) — an invalid
+        // document. Falling back to the DEFAULT (no-container) framing emits a plain node
+        // reference / value that round-trips faithfully through pyld. (`@id`/`@graph`
+        // container framing for an already-indexed input is out of scope — see the module
+        // "Honest scope" note; sparq's input is always a graph it produced.)
+        if matches!(container.as_deref(), Some("@id") | Some("@graph")) {
+            // Emit under a key that does NOT carry the `@id`/`@graph` container, so the reader
+            // (and pyld) does not try to read the value as a container map. `compact_iri_no_list`
+            // skips container-bearing terms, yielding the `@vocab`-relative / prefix / full-IRI
+            // spelling — exactly the plain key we need.
+            let key = self.compact_iri_no_list(iri, reverse_only);
+            let value = self.compact_values_default(&key, &items, false);
+            result.set(&key, value);
+            return;
+        }
+
+        // [OPUS-4.8] (sq-oy1f.13) `@type:@id` / `@type:@vocab` coercion vs a literal value.
+        // A term coerced to `@id`/`@vocab` makes a *bare string* value read back as a node
+        // IRI, not a literal. If the chosen term carries that coercion but this IRI also has a
+        // plain literal object (a `{"@value": …}` with no `@id`), emitting that literal under
+        // the coerced term CORRUPTS it on read-back (a strict processor like pyld reads
+        // `"http://ex/x"` as the IRI `<http://ex/x>` — a string literal silently becomes a
+        // node). Split: node references stay under the coerced term (their `{"@id"}` collapses
+        // to a bare IRI, the point of the coercion); literal values move to a NON-coerced key
+        // (the IRI compacted ignoring the coerced term), where they re-expand as literals.
+        let coerces_id = def
+            .as_ref()
+            .and_then(|d| d.type_mapping.as_deref())
+            .is_some_and(|t| t == "@id" || t == "@vocab");
+        if coerces_id {
+            let is_literal = |v: &Json| v.get("@value").is_some();
+            let (lits, refs): (Vec<Json>, Vec<Json>) =
+                items.into_iter().partition(|v| is_literal(v));
+            if !lits.is_empty() {
+                // Literals under a non-coerced key (full / @vocab-relative / prefix IRI).
+                let lit_key = self.compact_iri_no_list(iri, reverse_only);
+                // Guard: if the only available spelling for the IRI IS the coerced term
+                // (no alternate), `compact_iri_no_list` still returns the @vocab-relative /
+                // full IRI, which is distinct from the term — so the literal key never
+                // collides with the coerced term key.
+                let lit_val = self.compact_values_default(&lit_key, &lits, false);
+                result.set(&lit_key, lit_val);
+            }
+            if !refs.is_empty() {
+                let force_array = matches!(container.as_deref(), Some("@set"));
+                let ref_val = self.compact_values_default(&term, &refs, force_array);
+                result.set(&term, ref_val);
+            }
             return;
         }
 

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -276,30 +276,38 @@ reference to a bare IRI string), **language coercion** (a term `@language` or th
 `@language` drops a matching `@language`), **`@container`** — `@set` (always an array, no
 compact-arrays), `@list` (strips the `{"@list":…}` wrapper to a bare ordered array — but only the
 *pure* `{"@list":…}` value: any co-located non-list sibling stays under the property IRI, never
-dropped, sq-oy1f.8), `@language` (a `{lang: value}` map — a value with **no** language tag falls
-under the reserved `@none` member rather than being dropped, sq-oy1f.9) and `@index` (a
-`{index: value}` map), **`@reverse`** terms (forward edges whose predicate a reverse term maps
-relocate into an `@reverse` block on the object node — an edge whose object is *not* itself a
-subject is kept as a forward property, never stripped, sq-oy1f.10), **`@id`/`@type` keyword
-aliasing** (`{"id":"@id","type":"@type"}`), and **value + node + IRI compaction** against the
-active context (vocab-relative compaction emits the `@vocab`-stripped form even when the suffix
-contains `/` or `#` — only a `:` suffix is kept full, since it is ambiguous with a compact IRI on
-read-back, sq-oy1f.11). Build the context with `parse_context_json(r#"{…}"#)`
-(a string → `JsonLdValue`, returns `None` if not a JSON object) or construct the `JsonLdValue`
-directly; the parsed `ActiveContext` drives compaction. The output is a `{"@context":…,"@graph":[…]}`
-document and the compaction is **lossless** — every coercion is invertible against the same
-`@context`, so a JSON-LD-to-RDF round-trip reconstructs the original triples (verified by the
-crate's compaction round-trip tests). *Scope:* this is the fromRdf-then-compact (serialise) path —
-sparq always emits RDF, so the input is a `Graph`, not an arbitrary remote document; scoped/typed
-contexts, `@propagate`, remote `@context` fetching, `@import`, `@protected` and JSON-LD **Framing**
-are out of scope (Framing is a separate deferred bead). *Honest interop caveat:* the round-trip
-losslessness is verified against sparq's own JSON-LD→RDF reader. Two output shapes are **not**
-faithfully re-expandable by an external processor (e.g. pyld): a `@reverse`-term document emits the
-edge as both an `@reverse` block **and** a reverse-mapped term (a double inversion that a strict
-processor reads inverted — a tracked follow-up), and a non-string value placed under a language
-map's `@none` member is not a valid language-map value per the spec (language maps hold strings),
-though sparq preserves it. Prefer a non-`@reverse` context, and a non-`@language` container for
-typed values, when the document must be consumed by a third-party JSON-LD library.
+dropped, sq-oy1f.8), `@language` (a `{lang: value(s)}` map — a value with **no** language tag falls
+under the reserved `@none` member rather than being dropped, sq-oy1f.9; several values that share
+one language slot accumulate into an **array** so none is overwritten, and a **non-string** value —
+a typed/numeric literal — routes to a separate non-language key so a strict processor keeps its
+datatype rather than rejecting an invalid language-map value, sq-oy1f.12/.14) and `@index` (a
+`{index: value(s)}` map; fromRdf has no per-value index, so values share the reserved `@none`
+slot, accumulating into an array, sq-oy1f.14). `@id` / `@graph` containers — which the fromRdf
+model cannot losslessly populate — **fall back to the default (no-container) framing** rather than
+emit a container map a strict processor rejects (sq-oy1f.14). **`@reverse`** terms (forward edges
+whose predicate a reverse term maps relocate onto the object node and are emitted as a **forward
+member keyed by the reverse term**, NOT inside an `@reverse` block — a reverse-term key inside an
+`@reverse` block would double-invert and a strict processor reads the edge backwards, sq-oy1f.12;
+an edge whose object is *not* itself a subject is kept as a forward property, never stripped,
+sq-oy1f.10), **`@id`/`@type` keyword aliasing** (`{"id":"@id","type":"@type"}`), and **value + node
++ IRI compaction** against the active context (vocab-relative compaction emits the `@vocab`-stripped
+form even when the suffix contains `/` or `#` — only a `:` suffix is kept full, since it is ambiguous
+with a compact IRI on read-back, sq-oy1f.11; a plain **literal** value under a `@type:@id`-coerced
+term moves to a non-coerced key so it does not read back as a node IRI, sq-oy1f.13). Build the
+context with `parse_context_json(r#"{…}"#)` (a string → `JsonLdValue`, returns `None` if not a JSON
+object) or construct the `JsonLdValue` directly; the parsed `ActiveContext` drives compaction. The
+output is a `{"@context":…,"@graph":[…]}` document and the compaction is **lossless** — every
+coercion is invertible against the same `@context`, so a JSON-LD-to-RDF round-trip reconstructs the
+original triples. *Scope:* this is the fromRdf-then-compact (serialise) path — sparq always emits
+RDF, so the input is a `Graph`, not an arbitrary remote document; scoped/typed contexts,
+`@propagate`, remote `@context` fetching, `@import`, `@protected` and JSON-LD **Framing** are out of
+scope (Framing is a separate deferred bead). *Strict third-party faithfulness:* the compaction
+round-trip is verified both against sparq's own JSON-LD→RDF reader **and** differentially against the
+**pyld** W3C reference processor (`expand`/`toRdf`) for the `@reverse`, language-map, `@type:@id`,
+and multi-value-container shapes (sq-oy1f.12/.13/.14), so the emitted document re-expands to the
+original triples in a strict external processor, not only in sparq. (An `@id`/`@graph`-container
+*input* — i.e. compacting an already-indexed document, as distinct from the fromRdf graph sparq
+produces — remains out of scope and falls back to default framing as noted above.)
 
 ```rust
 use sparq_engine::serialize::{graph_to_jsonld_compact, parse_context_json};


### PR DESCRIPTION
> 🤖 SPARQ agent — opened by an automated SPARQ agent on @jeswr's behalf (multiple agents share this account).

Fixes three JSON-LD 1.1 **Compaction-writer faithfulness** gaps in `crates/sparq-engine/src/serialize/compact.rs` (the opt-in `serialize-rdf` writer landed by #963). These are real third-party-interop bugs that the conformance suite's own oxjsonld **self-reparse oracle MASKED** — they round-trip through sparq's own reader but a STRICT external processor reads them wrong. Each was found and fixed differentially against the **pyld** W3C reference processor (`expand`/`toRdf`), exactly as the original #963 work was. Closes sq-oy1f.12, sq-oy1f.13, sq-oy1f.14 (epic sq-oy1f).

## The three bugs + the faithful fix (each pyld-verified)

### sq-oy1f.12 — `@reverse` double-invert + non-string language-map value
- **`@reverse` double-invert.** A `@reverse`-term edge was relocated into an `@reverse` **block** keyed by the reverse term. A reverse-term key *inside* an `@reverse` block double-inverts: pyld applies the block's inversion AND the term's inversion and reads the edge **backwards**. For source `<bob> <parent> <alice>`, sparq emitted `{"@id":"alice","@reverse":{"children":"http://ex/bob"}}` and **pyld read `<alice> <parent> <bob>`** (inverted). **Fix:** emit the reverse term as a **forward member** of the object node (`{"@id":"alice","children":"http://ex/bob"}`) — the pyld-faithful shape that inverts exactly once. pyld now reads `<bob> <parent> <alice>`. No `@reverse` block is emitted; an internal sentinel (never serialized) carries the relocation.
- **Non-string language-map value.** A typed/numeric literal under a `@language` container was put in the `@none` member, but a language map's values **must be strings** — pyld **rejects the whole document** (`language map values must be strings`). **Fix:** route non-string values to a **separate non-language key** (the property IRI compacted without the language term). pyld now reads `"42"^^xsd:integer` with its datatype intact (under `@none:"42"` the datatype would have been lost even if accepted). A plain string under `@none` is valid and stays.

### sq-oy1f.13 — `@type:@id`-coerced key vs literal IRI
A plain string literal under a `@type:@id`/`@vocab`-coerced term read back as a **node IRI** — pyld turned the literal `"http://ex/target"` into the node `<http://ex/target>` (a literal silently becomes a node — data corruption). **Fix:** split literal values onto a non-coerced key; genuine node refs keep the coerced term (their `{"@id"}` still collapses to a bare IRI). pyld now reads the literal as a literal and the node ref as a node.

### sq-oy1f.14 — multi-value `@graph`/`@index`/`@id`/`@language` container round-trips
- **`@language`/`@index`:** several values sharing one slot clobbered all but the last (data loss). Each slot now accumulates into an **array**. pyld reads all values.
- **`@id`/`@graph` containers** (which the fromRdf model cannot losslessly populate) emitted a container map pyld **rejects** (`illegal key … @id` on a value object). They now **fall back to the default no-container framing**, which re-expands faithfully. (An already-indexed `@id`/`@graph` *input* — distinct from sparq's fromRdf graph — remains out of scope.)

## pyld differential result

Every fixed shape was fed to pyld (`expand` + `toRdf`) and the reproduced N-Quads compared to the source: all now reproduce the original triples (or no longer throw). The before/after table:

| case | before (pyld) | after (pyld) |
|---|---|---|
| `@reverse` edge | inverted (`alice parent bob`) | correct (`bob parent alice`) |
| non-string `@language` value | **document rejected** | `"42"^^xsd:integer` (datatype kept) |
| `@type:@id` literal | literal → IRI node | literal preserved |
| multi-value `@language` | one value (rest lost) | all values |
| `@id` container | **document rejected** | both triples |

## Conformance floor (measured)

I measured the W3C `compact` suite on the #969 (sq-3uos5) ratchet branch, which wires `COMPACT_FLOOR = 163`. **#969 is not yet merged to main**, so this PR leaves `crates/sparq-conformance` untouched (fixes only `sparq-engine` + its unit tests), per the coordination plan.

- **Before (on #969): `TOTAL compact 163 58 25`**
- **After my fix (cherry-picked onto #969): `TOTAL compact 186 35 25`** — **+23 W3C compact cases FAIL → PASS.**

**Follow-up:** once #969 lands, rebase and **raise `COMPACT_FLOOR` 163 → 186** (the honest measured count).

## Tests (the REAL path, pyld-shape-pinned)

Six permanent regression tests in `serialize.rs` assert the exact pyld-verified document shape (not merely sparq's own round-trip) plus the `assert_compact_iso` self-round-trip: `compact_reverse_term_as_forward_member_not_block`, `compact_language_nonstring_routes_to_separate_key`, `compact_language_none_plain_string`, `compact_typeid_literal_kept_off_coerced_term`, `compact_language_container_multivalue_per_language`, `compact_id_container_falls_back_to_default_framing`, `compact_index_container_multivalue_under_none`. The prior sq-oy1f.9 test (which asserted the now-fixed *invalid* `@none:42` shape) is corrected to the faithful separate-key shape. The test-module reader (the conformance reparse oracle) is updated to read the new shapes.

## Gates (both feature states)

- `cargo test -p sparq-engine --features serialize-rdf --lib`: **274 passed**; default (feature OFF): **199 passed** — both green.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`: clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features`: clean.
- `rustfmt`: my new code introduces **zero** new fmt diffs (the file's deferred-reformat debt is pre-existing #963 code; per the contract I did not run `cargo fmt` over untouched files).

Docs updated: `crates/sparq-engine/README.md` + `skills/data-formats/SKILL.md` (the prior "honest interop caveat" describing these as known gaps is replaced with the now-faithful behavior + the pyld-differential note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
