### PR TITLE
docs(research): reconcile stale JSON-LD Framing 'out of scope' note (framing landed sq-oy1f.17/#984) [OPUS-4.8]

### DIFF
--- a/research/jsonld-pretty-compaction-scope.md
+++ b/research/jsonld-pretty-compaction-scope.md
@@ -153,7 +153,10 @@ Turtle chain sq-ixc3.2 / sq-fe1s / sq-lxej):
    expose JSON-LD (incl. the new pretty option) through it so the site never
    hand-formats JSON-LD; depends on `sq-fe1s` + `sq-ixc3.3`.
 
-Framing is intentionally NOT a bead (no consumer; out of scope).
+JSON-LD 1.1 Framing was subsequently scoped and implemented (hand-rolled,
+`crates/sparq-engine/src/serialize/frame.rs`, `graph_to_jsonld_framed`) under
+bead `sq-oy1f.17` / PR #984 — so it is no longer out of scope here. (The earlier
+deferral decision lives in `sq-oy1f.6`.) [OPUS-4.8]
 
 ## Open questions for the maintainer
 


### PR DESCRIPTION
> 🤖 This PR is from a **SPARQ agent** (one of several @jeswr runs on this account).

## What

`research/jsonld-pretty-compaction-scope.md` asserted JSON-LD 1.1 Framing was "intentionally NOT a bead (no consumer; out of scope)". That is now stale.

**before:** `Framing is intentionally NOT a bead (no consumer; out of scope).`

**after:** points the note at the landed implementation (`crates/sparq-engine/src/serialize/frame.rs`, `graph_to_jsonld_framed`) under bead **sq-oy1f.17** / PR **#984**, and references the original deferral decision **sq-oy1f.6**.

## Why / evidence

- `bd show sq-oy1f.17` → CLOSED, "Implemented in PR (W3C JSON-LD 1.1 Framing in crates/sparq-engine/src/serialize/frame.rs, hand-rolled, pyld-differential-tested, 20 regression tests)".
- `git grep -l frame_match feat-sq-oy1f-jsonld-framing -- crates/sparq-engine` → `serialize/frame.rs` present on the #984 branch.
- Framing therefore both IS a bead and is implemented — the old note was wrong on both counts.

DOC-only; no `crates/` source touched. markdownlint-cli2: 0 errors. No ZK/MPC privacy claim introduced. Auto-merge intentionally left OFF.

Found during the recurring AGENTS.md maintenance sweep.