### PR TITLE
perf(site): lazy-load the wasm engine off the critical path — idle prewarm + code-split REPL (sq-4296) [OPUS-4.8]

### DIFF
--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -213,9 +213,100 @@ export async function loadSparq(opts: LoadSparqOptions = {}): Promise<WasmStoreC
  * {@link loadSparq} promise, so the cold start happens at most once. Returns a promise that
  * resolves when the engine is ready (or rejects on a load failure, which resets the cache
  * so a later call can retry).
+ *
+ * Note this kicks the fetch off IMMEDIATELY (synchronously from the call site). For the
+ * "load async AFTER the page paints" posture the maintainer asked for (#935 / #981 — keep
+ * the ~300 kB wasm off the critical path so the page is interactive FIRST), prefer
+ * {@link prewarmSparqWhenIdle}, which defers the fetch to the next browser-idle slot.
  */
 export function prewarmSparq(opts: LoadSparqOptions = {}): Promise<unknown> {
   return loadSparq(opts);
+}
+
+/** The handle {@link prewarmSparqWhenIdle} returns so a caller can cancel a not-yet-fired
+ * idle prewarm (e.g. a React effect cleanup on unmount). Calling it before the idle slot
+ * fires prevents the wasm fetch from being kicked off; calling it after is a no-op. */
+export interface IdlePrewarmHandle {
+  /** Cancel the pending idle prewarm if it has not fired yet. */
+  cancel(): void;
+}
+
+/**
+ * [OPUS-4.8] sq-4296 (#935 / #981) — pre-warm the wasm engine LAZILY, on the next
+ * browser-idle slot, so the ~300 kB engine wasm never competes with the initial page paint.
+ *
+ * This is the "load async after the page loads" mechanism: instead of firing the wasm fetch
+ * synchronously while a wasm-using component mounts (which the maintainer flagged as blocking
+ * page load), it schedules the fetch via `requestIdleCallback` — so the browser finishes
+ * layout / paint / first-input readiness FIRST, then fetches + instantiates the wasm in the
+ * background. The page is interactive before the wasm finishes loading; the (memoised)
+ * {@link loadSparq} promise is reused, so any later on-demand `await loadSparq()` (e.g. the
+ * first "Run query") simply joins the in-flight or already-resolved load — never a second
+ * cold start, never a call into an uninitialised wasm.
+ *
+ * `requestIdleCallback` is feature-detected: where it is unavailable (Safari < 16.4, the SSR
+ * pass, the static-export prerender) it falls back to a short `setTimeout(…, 1)`, which still
+ * yields to the paint before fetching. The optional `timeout` (default 2000 ms) caps how long
+ * the idle wait may stretch under sustained main-thread work, so the engine still warms on a
+ * busy page. Returns an {@link IdlePrewarmHandle} whose `cancel()` unschedules a not-yet-fired
+ * prewarm — pass it to a React effect cleanup so an unmount before the idle slot does no work.
+ *
+ * `onReady` / `onError` are optional readiness callbacks the (memoised) load resolves into, so
+ * a component can flip its engine pill to "ready" / "error" without re-importing `loadSparq`.
+ */
+export function prewarmSparqWhenIdle(
+  opts: LoadSparqOptions & {
+    timeout?: number;
+    onReady?: () => void;
+    onError?: (err: unknown) => void;
+  } = {},
+): IdlePrewarmHandle {
+  const { timeout = 2000, onReady, onError, ...loadOpts } = opts;
+  let cancelled = false;
+
+  const fire = (): void => {
+    if (cancelled) return;
+    loadSparq(loadOpts).then(
+      () => {
+        if (!cancelled) onReady?.();
+      },
+      (err) => {
+        if (!cancelled) onError?.(err);
+      },
+    );
+  };
+
+  // Schedule on the next idle slot so the page paints / becomes interactive first. Outside a
+  // browser (SSR / static prerender) `requestIdleCallback` is undefined; a short timeout
+  // there still yields to any paint before the fetch is kicked off.
+  type RIC = (cb: () => void, opts?: { timeout?: number }) => number;
+  type CIC = (handle: number) => void;
+  const ric =
+    typeof window !== "undefined"
+      ? (window as unknown as { requestIdleCallback?: RIC }).requestIdleCallback
+      : undefined;
+  const cic =
+    typeof window !== "undefined"
+      ? (window as unknown as { cancelIdleCallback?: CIC }).cancelIdleCallback
+      : undefined;
+
+  if (typeof ric === "function") {
+    const id = ric(fire, { timeout });
+    return {
+      cancel() {
+        cancelled = true;
+        if (typeof cic === "function") cic(id);
+      },
+    };
+  }
+
+  const id = setTimeout(fire, 1);
+  return {
+    cancel() {
+      cancelled = true;
+      clearTimeout(id);
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/site/README.md
+++ b/site/README.md
@@ -13,9 +13,10 @@ Inter, `--radius 0.7rem`. Design record: `research/feature-showcase-site-design.
 - **Landing / overview** — what sparq is, the live REPL, the three flagship cards, and
   the full surface grid (each card links to its page; unbuilt pages render an honest
   "coming soon" placeholder that states the planned execution tier).
-- **Live SPARQL REPL** (`/try` and the landing marquee) — loads the lean sparq wasm
-  bundle and runs **real SPARQL** against a sample graph via the actual Rust engine
-  compiled to WebAssembly. Not a fixture; nothing is sent to a server.
+- **Live SPARQL REPL** (`/try` and the landing marquee) — runs **real SPARQL** against a
+  sample graph via the actual Rust engine compiled to WebAssembly. Not a fixture; nothing is
+  sent to a server. The component is code-split and the wasm engine loads lazily on browser
+  idle, so it never blocks the initial page load (see *Lazy wasm loading* below — `sq-4296`).
 - **Persistent cross-session workspaces** (`sq-atb0`) — the REPL's workspace panel
   saves a named workspace: a **snapshot** of the loaded dataset (the whole default+named-graph
   content as N-Quads — a save/open cache, not a re-ingest-from-source), the imported-source
@@ -51,6 +52,44 @@ npm run test:e2e   # Playwright — headless browser smoke tests (see below)
 `public/wasm/` is generated (git-ignored): `scripts/sync-wasm.mjs` copies the
 wasm-pack `--target web` output from `js/wasm/`. The `prebuild` script runs it
 automatically before `next build`.
+
+### Lazy wasm loading — keeping the engine off the critical path — `sq-4296` (#935 / #981)
+
+The sparq engine wasm is heavy, so it is kept **out of the initial page load** in three
+layers — the page paints and becomes interactive before any of it has finished loading:
+
+1. **The wasm binary is never bundled into JS.** `@sparq/client`'s `loadSparq()`
+   dynamic-imports the wasm-pack glue with a `/* webpackIgnore: true */` hint, so the glue
+   (`public/wasm/sparq_wasm.js`) is fetched as a plain ESM module at runtime and the
+   `sparq_wasm_bg.wasm` binary is a static asset — neither enters a webpack chunk. (Verify:
+   no `_next` JS chunk embeds the `.wasm`; the loader chunk only holds the *URL string*.)
+2. **The REPL component is code-split.** `site/src/components/repl-lazy.tsx` wraps the heavy
+   `Repl` in `next/dynamic(..., { ssr: false })` with a skeleton fallback, so the home page
+   (`/`) and `/try` render their shell first and stream the REPL chunk in afterwards. The
+   server pages render `<ReplLazy />` rather than `<Repl />`.
+3. **The engine warm-up is deferred to browser idle.** Components call
+   `prewarmSparqWhenIdle()` (not the eager `prewarmSparq()`), which schedules the
+   fetch+instantiate via `requestIdleCallback` (with a `setTimeout` fallback) so the wasm
+   loads *after* first paint. The first interaction (`Run query` / `Validate`) still
+   `await`s the **memoised** `loadSparq()`, so it joins the in-flight load rather than
+   re-paying a cold start — and never calls into an uninitialised wasm.
+
+**ESM `<script type="module">` import (#981).** The wasm-pack `--target web` glue is a real
+ESM module, so it can be imported directly — instantiate it (its default `init`) before using
+`Store`, and the ~MB `.wasm` is fetched lazily by that init, not by the script tag:
+
+```html
+<script type="module">
+  // basePath-aware: '/sparq/...' on GitHub Pages, '/...' under the Tauri webview root.
+  import init, { Store } from "https://jeswr.github.io/sparq/wasm/sparq_wasm.js";
+  await init(); // lazily fetches + instantiates sparq_wasm_bg.wasm (off the critical path)
+  const store = Store.load("<a> <b> <c> .", "ntriples");
+  console.log(store.query("SELECT * WHERE { ?s ?p ?o }"));
+</script>
+```
+
+In an app, prefer `@sparq/client`'s `loadSparq()` (memoised, basePath-defaulted) over a
+hand-rolled `init()` so the cold start happens at most once across the whole page.
 
 ### Build modes — `basePath` (Pages vs Tauri) — `sq-9vw5`
 

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -1,7 +1,11 @@
 import Link from "next/link";
 import { ArrowRight, Cpu, ShieldCheck, Boxes } from "lucide-react";
 
-import { Repl } from "@/components/repl";
+// [OPUS-4.8] sq-4296 (#935 / #981) — the REPL is code-split into its own async chunk so it
+// does not sit in the home route's first-load JS bundle; the page shell renders + becomes
+// interactive first, then the REPL streams in (and only then does its idle-deferred wasm
+// engine warm up). See src/components/repl-lazy.tsx.
+import { ReplLazy } from "@/components/repl-lazy";
 import { Badge } from "@/components/ui/badge";
 import {
   Card,
@@ -45,7 +49,7 @@ export default function HomePage() {
 
       {/* Marquee live demo */}
       <section className="space-y-3">
-        <Repl />
+        <ReplLazy />
         <p className="text-xs text-muted-foreground">
           This REPL loads the lean sparq wasm bundle (~1.2 MB) and runs your
           SPARQL against the sample graph using the real Rust engine — the same

--- a/site/src/app/try/page.tsx
+++ b/site/src/app/try/page.tsx
@@ -1,6 +1,9 @@
 import type { Metadata } from "next";
 
-import { Repl } from "@/components/repl";
+// [OPUS-4.8] sq-4296 (#935 / #981) — code-split the REPL out of the /try route's first-load
+// bundle (see src/components/repl-lazy.tsx) so the page shell renders before the heavy REPL
+// chunk + its idle-deferred wasm engine load.
+import { ReplLazy } from "@/components/repl-lazy";
 
 export const metadata: Metadata = {
   title: "Live SPARQL REPL",
@@ -33,7 +36,7 @@ export default function TryPage() {
           SERVICE clause the server refuses by default) and never bypasses a server gate.
         </p>
       </header>
-      <Repl />
+      <ReplLazy />
     </div>
   );
 }

--- a/site/src/components/data-formats-demo.tsx
+++ b/site/src/components/data-formats-demo.tsx
@@ -27,7 +27,7 @@ import { cn } from "@/lib/utils";
 import {
   loadSparq,
   loadIntoStore,
-  prewarmSparq,
+  prewarmSparqWhenIdle,
   datasetSize,
   formatTerm,
   type SparqlResults,
@@ -78,20 +78,24 @@ export function DataFormatsDemo() {
   const [parse, setParse] = React.useState<ParseState>({ kind: "idle" });
   const [gzip, setGzip] = React.useState<GzipState>({ kind: "idle" });
 
-  // Pre-warm the wasm engine on mount so the first Parse pays no cold start. Shares the
-  // single loadSparq promise with the rest of the site.
+  // [OPUS-4.8] sq-4296 (#935 / #981) — pre-warm the wasm engine on the next browser-IDLE slot
+  // (not synchronously during mount) so the ~300 kB+ engine never blocks the initial page
+  // paint. Shares the single memoised loadSparq promise with the rest of the site, so the
+  // first Parse joins the in-flight load rather than re-paying a cold start.
   React.useEffect(() => {
     let cancelled = false;
     setEngine("warming");
-    prewarmSparq()
-      .then(() => {
+    const handle = prewarmSparqWhenIdle({
+      onReady: () => {
         if (!cancelled) setEngine("ready");
-      })
-      .catch(() => {
+      },
+      onError: () => {
         if (!cancelled) setEngine("error");
-      });
+      },
+    });
     return () => {
       cancelled = true;
+      handle.cancel();
     };
   }, []);
 

--- a/site/src/components/javascript-wasm-demo.tsx
+++ b/site/src/components/javascript-wasm-demo.tsx
@@ -39,7 +39,7 @@ import { cn } from "@/lib/utils";
 import {
   loadSparq,
   loadIntoStore,
-  prewarmSparq,
+  prewarmSparqWhenIdle,
   formatTerm,
   matchQuads,
   countQuads,
@@ -100,18 +100,24 @@ export function JavascriptWasmDemo() {
     setVersion((v) => v + 1);
   }, []);
 
+  // [OPUS-4.8] sq-4296 (#935 / #981) — pre-warm + seed on the next browser-IDLE slot (not
+  // synchronously during mount) so the ~300 kB+ engine never blocks the initial page paint.
+  // `rebuild` awaits the memoised loadSparq, so a user interaction before the idle warm-up
+  // completes joins the in-flight load rather than calling into an uninitialised wasm.
   React.useEffect(() => {
     let cancelled = false;
     setEngine("warming");
-    prewarmSparq()
-      .then(() => {
-        if (!cancelled) return rebuild();
-      })
-      .catch(() => {
+    const handle = prewarmSparqWhenIdle({
+      onReady: () => {
+        if (!cancelled) void rebuild();
+      },
+      onError: () => {
         if (!cancelled) setEngine("error");
-      });
+      },
+    });
     return () => {
       cancelled = true;
+      handle.cancel();
     };
   }, [rebuild]);
 

--- a/site/src/components/repl-lazy.tsx
+++ b/site/src/components/repl-lazy.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+// [OPUS-4.8] sq-4296 (#935 / #981) — the CODE-SPLIT boundary for the live REPL.
+//
+// The `Repl` is by far the heaviest client component on the site: it pulls in the SPARQL
+// editor, the results / dataset / workspace panels, the endpoint + subscriptions + health
+// views, and the `@sparq/client` query surface — and it is rendered on BOTH the home page
+// (`/`) and `/try`. Statically importing it put all of that JS into those routes' FIRST-LOAD
+// bundle, so the page could not become interactive until the whole REPL chunk had downloaded
+// and hydrated. That is the "don't bundle it into the main bundle" half of the maintainer's
+// website-load-time ask (#935): the heavy code should NOT sit on the critical path.
+//
+// `next/dynamic` with `ssr: false` moves the `Repl` into its OWN async chunk that the browser
+// fetches AFTER the route shell has rendered, so the page paints + becomes interactive first,
+// then the REPL streams in. A server component cannot call `dynamic(..., { ssr: false })`
+// directly in the Next.js App Router, so this thin `"use client"` wrapper owns the split; the
+// server pages render `<ReplLazy />` instead of `<Repl />` with no other change.
+//
+// This is the COMPONENT-level lazy load; the wasm ENGINE itself is loaded separately and even
+// later — `prewarmSparqWhenIdle` (in `@sparq/client`) defers the ~300 kB+ engine wasm fetch to
+// a browser-idle slot once the REPL has mounted. The two together keep the page interactive
+// before either the REPL chunk or the engine wasm has finished loading.
+
+import dynamic from "next/dynamic";
+
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+/**
+ * A layout-stable placeholder shown while the `Repl` chunk downloads. It mirrors the REPL's
+ * card shape (header row + editor block + a run-control row) so there is no layout shift when
+ * the real component swaps in. Purely presentational — no wasm, no client state.
+ */
+function ReplSkeleton() {
+  return (
+    <Card aria-busy="true" aria-label="Loading the live SPARQL REPL" data-repl-skeleton>
+      <CardHeader className="gap-3">
+        <div className="flex items-center justify-between gap-2">
+          <Skeleton className="h-5 w-40" />
+          <Skeleton className="h-6 w-28 rounded-full" />
+        </div>
+        <Skeleton className="h-9 w-full" />
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <Skeleton className="h-40 w-full rounded-md" />
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-9 w-28" />
+          <Skeleton className="h-9 w-24" />
+          <Skeleton className="ml-auto h-9 w-32" />
+        </div>
+        <Skeleton className="h-24 w-full rounded-md" />
+      </CardContent>
+    </Card>
+  );
+}
+
+// The split point. `ssr: false` keeps the REPL out of the static-export prerender (it is a
+// browser-only, wasm-backed component anyway), so it ships as a separate client chunk fetched
+// after the route shell renders. The skeleton is the loading state in the meantime.
+const Repl = dynamic(() => import("@/components/repl").then((m) => m.Repl), {
+  ssr: false,
+  loading: () => <ReplSkeleton />,
+});
+
+/** The code-split entry point the server pages render in place of the heavy `Repl`. */
+export function ReplLazy() {
+  return <Repl />;
+}

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -26,7 +26,7 @@ import { cn } from "@/lib/utils";
 import {
   loadSparq,
   loadIntoStore,
-  prewarmSparq,
+  prewarmSparqWhenIdle,
   storeToNQuads,
   datasetSize,
   extractTable,
@@ -184,29 +184,47 @@ export function Repl() {
     [],
   );
 
-  // Pre-warm the engine AND parse the default dataset eagerly on mount, off the render
-  // path. The first "Run query" then runs against an already-built store with no cold
-  // start. A failure resets the indicator so a later run can retry via ensureStore.
+  // [OPUS-4.8] sq-4296 (#935 / #981) — pre-warm the engine AND parse the default dataset on
+  // the next browser-IDLE slot, not synchronously during mount. The REPL renders on the home
+  // page and /try; firing the ~2.8 MB engine wasm fetch while the component mounts would
+  // compete with the initial paint / first-input readiness. `prewarmSparqWhenIdle` defers the
+  // fetch via `requestIdleCallback` (with a `setTimeout` fallback) so the page is interactive
+  // FIRST, then the wasm loads in the background. The first "Run query" still awaits the
+  // memoised `loadSparq()` via `ensureStore`, so an interaction before the idle warm-up
+  // completes joins the in-flight load — it never calls into an uninitialised wasm.
   React.useEffect(() => {
     let cancelled = false;
     setEngine("warming");
-    prewarmSparq()
-      .then(async () => {
-        if (cancelled || storeRef.current) return;
-        await buildStore(DEFAULT_DATASET.text, DEFAULT_DATASET.format);
-      })
-      .then(() => {
-        if (!cancelled) setEngine("ready");
-      })
-      .catch((e) => {
+    const handle = prewarmSparqWhenIdle({
+      onReady: () => {
+        if (cancelled || storeRef.current) {
+          if (!cancelled) setEngine("ready");
+          return;
+        }
+        // The engine is ready; build the default dataset off the render path, then mark ready.
+        buildStore(DEFAULT_DATASET.text, DEFAULT_DATASET.format)
+          .then(() => {
+            if (!cancelled) setEngine("ready");
+          })
+          .catch((e) => {
+            if (cancelled) return;
+            setEngine("error");
+            toast.error("Engine failed to load", {
+              description: e instanceof Error ? e.message : String(e),
+            });
+          });
+      },
+      onError: (e) => {
         if (cancelled) return;
         setEngine("error");
         toast.error("Engine failed to load", {
           description: e instanceof Error ? e.message : String(e),
         });
-      });
+      },
+    });
     return () => {
       cancelled = true;
+      handle.cancel();
     };
   }, [buildStore]);
 

--- a/site/src/components/shacl-playground.tsx
+++ b/site/src/components/shacl-playground.tsx
@@ -27,7 +27,7 @@ import {
 import { cn } from "@/lib/utils";
 import { RdfHighlight } from "@/components/rdf-highlight";
 import {
-  prewarmSparq,
+  prewarmSparqWhenIdle,
   loadSparq,
   loadIntoStore,
   matchQuads,
@@ -112,24 +112,29 @@ export function ShaclPlayground() {
   const [activeExample, setActiveExample] = React.useState<string>(DEFAULT.id);
   const [view, setView] = React.useState<View>("results");
 
-  // Pre-warm the wasm engine on mount (off the render path) so the first "Validate"
-  // pays no cold start. A failure resets the indicator; validate() retries the load.
+  // [OPUS-4.8] sq-4296 (#935 / #981) — pre-warm the wasm engine on the next browser-IDLE
+  // slot, not synchronously during mount, so the ~300 kB+ engine wasm never blocks the
+  // initial page paint. The first "Validate" still awaits the memoised `loadSparq()`, so an
+  // interaction before the idle warm-up completes joins the in-flight load (no cold-start
+  // double-load, no call into an uninitialised wasm). A failure resets the indicator.
   React.useEffect(() => {
     let cancelled = false;
     setEngine("warming");
-    prewarmSparq()
-      .then(() => {
+    const handle = prewarmSparqWhenIdle({
+      onReady: () => {
         if (!cancelled) setEngine("ready");
-      })
-      .catch((e) => {
+      },
+      onError: (e) => {
         if (cancelled) return;
         setEngine("error");
         toast.error("Engine failed to load", {
           description: e instanceof Error ? e.message : String(e),
         });
-      });
+      },
+    });
     return () => {
       cancelled = true;
+      handle.cancel();
     };
   }, []);
 

--- a/site/src/components/ui/skeleton.tsx
+++ b/site/src/components/ui/skeleton.tsx
@@ -1,0 +1,20 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+// [OPUS-4.8] sq-4296 — a minimal pulsing placeholder block (shadcn/ui convention), used as
+// the layout-stable loading state for code-split client components (e.g. the lazily-loaded
+// `Repl`, src/components/repl-lazy.tsx) so the page shell can render before the heavy chunk
+// arrives. Purely presentational; no client state, no wasm. `bg-muted` + `animate-pulse` are
+// both already in the design system's token set.
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/site/src/lib/sparq-wasm.ts
+++ b/site/src/lib/sparq-wasm.ts
@@ -50,6 +50,10 @@ export {
   loadSparq,
   matchQuads,
   prewarmSparq,
+  // [OPUS-4.8] sq-4296 (#935 / #981) — the IDLE-deferred pre-warm: schedule the wasm fetch on
+  // the next browser-idle slot so the ~300 kB+ engine never blocks the initial page paint.
+  prewarmSparqWhenIdle,
+  type IdlePrewarmHandle,
   sparqShaclValidate,
   streamQueryRows,
   // [OPUS-4.8] sq-x0kp — the framework-agnostic results-formatting core (table extraction,


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am one of several agents @jeswr runs on this account. This PR is the **site lane**. Auto-merge is intentionally **OFF**: this is a perf/page-load change for human review.

Implements **sq-4296** + the maintainer's paired asks: **#935** ("Improve Website load time — don't bundle the wasm directly, load it async after the page loads") and **#981** ("import the WASM via `<script type=module>` + lazy-load the ~300kb wasm so it doesn't block page load").

## What blocks page load today, and the fix

The engine wasm was already kept out of JS chunks (the `webpackIgnore` dynamic-import loader), **but**: (a) the heavy `Repl` component was statically imported into the home (`/`) and `/try` first-load bundles, and (b) every wasm component fired the engine fetch **synchronously on mount**, competing with the initial paint. This PR closes both gaps — keeping the engine off the critical path in three layers, so the page paints and is interactive before any of it finishes loading:

1. **Engine warm-up deferred to browser idle.** New `prewarmSparqWhenIdle()` in `@sparq/client` schedules the wasm fetch+instantiate via `requestIdleCallback` (with a `setTimeout` fallback for Safari/SSR) instead of firing during mount. The REPL, SHACL playground, data-formats demo and JS/WASM demo now use it. **Crucially**, the first interaction (`Run query` / `Validate`) still `await`s the **memoised** `loadSparq()`, so it joins the in-flight (or resolved) load rather than re-paying a cold start — and never calls into an uninitialised wasm (the `__wbg_ptr` class of bug the #970 fix guarded). Each component keeps its `cold→warming→ready→error` engine pill; an unmount before the idle slot fires `cancel()`s the pending prewarm.

2. **The REPL is code-split.** `repl-lazy.tsx` wraps the heavy `Repl` in `next/dynamic(..., { ssr: false })` with a layout-stable skeleton; the server pages render `<ReplLazy />`. The REPL's transitive JS (editor, panels, `@sparq/client` query surface) leaves the routes' first-load bundle.

3. **ESM `<script type=module>` import documented (#981).** The wasm-pack `--target web` glue is already a real ESM module — `import init, { Store } from ".../wasm/sparq_wasm.js"; await init()` — and `init()` lazily fetches the binary. `site/README.md` now documents that snippet + the three lazy-load layers. (The broader ask — a packaged ESM `Dataset` entry the issue imports by name — is split to follow-up **sq-lii76**.)

## Before → after (indicative — CI/work-box build, not canonical)

| Route | First-load JS before (main) | after |
|---|---|---|
| `/` (home) | 236 kB | 189 kB |
| `/try` | 171 kB | 113 kB |

The 2.8 MB wasm binary is served as a static asset and fetched only after idle; no `_next` JS chunk embeds it (the loader chunk holds only the URL string).

## Gates

- **Pages `npm run build`** + **Tauri `npm run build:tauri`** both green end-to-end (basePath `/sparq` ⇄ root-relative lockstep preserved; the `dynamic(ssr:false)` split is a client-side fetch, compatible with the Tauri webview).
- **`npm run lint`** clean; **`tsc --noEmit`** clean (no `any`-escape hatches).
- **Playwright e2e** all pass with the async load: REPL results panel + JSON-LD output mode (#976), SHACL validator + Compact Syntax (#970), workspace save/open. The existing "Engine ready" readiness anchors handle the idle-deferred load transparently.
- WASM prereq built first (`cd js && npm run build:wasm`). No hard-coded perf numbers in committed copy (the kB figures live only here in the PR, labelled indicative).

## New files / deps

- `site/src/components/repl-lazy.tsx`, `site/src/components/ui/skeleton.tsx` (shadcn convention, **dependency-free**). No new npm dependency.

Refs #935, #981. Follow-up: **sq-lii76** (packaged ESM `Dataset` entry). Closes sq-4296.