### PR TITLE
feat(site): regroup 16 surfaces into 5 capability themes + Cmd-K command palette (sq-vw3ax.1, sq-vw3ax.2) [OPUS-4.8]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5497,6 +5497,22 @@
         "node": ">=6"
       }
     },
+    "node_modules/cmdk": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cmdk/-/cmdk-1.1.1.tgz",
+      "integrity": "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "^1.1.1",
+        "@radix-ui/react-dialog": "^1.1.6",
+        "@radix-ui/react-id": "^1.1.0",
+        "@radix-ui/react-primitive": "^2.0.2"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^18 || ^19 || ^19.0.0-rc"
+      }
+    },
     "node_modules/color": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
@@ -13222,6 +13238,7 @@
         "@noir-lang/noir_js": "1.0.0-beta.21",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "cmdk": "^1.1.1",
         "lucide-react": "^0.460.0",
         "next": "^15.5.19",
         "next-themes": "^0.4.6",

--- a/site/e2e/command-palette.spec.ts
+++ b/site/e2e/command-palette.spec.ts
@@ -1,0 +1,100 @@
+// [OPUS-4.8] sq-vw3ax.1 — headless browser smoke test for the Cmd-K command palette.
+//
+// WHAT IT GUARDS. The redesign collapses a tripled navigation into one slim top bar, which is
+// only safe because the Cmd-K palette (src/components/command-palette.tsx) is the 0-click fast
+// path to every surface (research/website-redesign.md §2, §7). This test drives a REAL headless
+// Chromium and exercises the load-bearing flow end-to-end: OPEN (⌘/Ctrl-K and the header
+// trigger), SEARCH (fuzzy-filter to one surface), and NAVIGATE (Enter jumps to its route under
+// the /sparq basePath). It also asserts ESC closes the dialog.
+//
+// The palette is pure UI wired to the single GROUPS source — it needs no wasm bundle — so this
+// runs on the light site-e2e lane unconditionally (unlike the REPL/ZK specs that gate on wasm).
+//
+// DOM anchors: the cmdk dialog exposes its accessible name "Command palette"; items are real
+// listbox options reachable by role + accessible name. No copy-scraping of layout text.
+import { test, expect, type Page } from "@playwright/test";
+
+// Relative (no leading slash) so it resolves UNDER the baseURL's `/sparq/` basePath — a
+// leading slash would target the origin root and miss the basePath entirely. /papers is a
+// stable, wasm-free route, so the palette is available with no engine prerequisites.
+const ROUTE = "papers/";
+
+// On macOS the shortcut is ⌘K; everywhere else Ctrl-K. The headless Chromium reports a Linux
+// platform, so Control is the correct modifier here; the component binds both (metaKey||ctrlKey).
+const MOD = "Control";
+
+/** The open palette dialog, located by its accessible name (the sr-only DialogTitle). */
+function palette(page: Page) {
+  return page.getByRole("dialog", { name: "Command palette" });
+}
+
+// The site ships the coi-serviceworker shim (public/coi-serviceworker.js, registered in
+// app/layout.tsx): on a FRESH visit it registers and reloads the tab ONCE to take effect.
+// That reload tears down any open dialog and resets React state, so a test that opens the
+// palette before the reload settles would race it. Wait for the network to go idle (the
+// post-reload document) before interacting — the same one-time-reload absorption the
+// zk-prewarm spec performs via its readiness pill.
+async function gotoSettled(page: Page): Promise<void> {
+  await page.goto(ROUTE, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle").catch(() => {});
+  // A short beat lets the post-reload document hydrate so the global ⌘K listener is armed.
+  await page.waitForTimeout(500);
+}
+
+test.beforeEach(async ({ page }) => {
+  await gotoSettled(page);
+});
+
+test("opens with the keyboard shortcut, filters, and navigates on Enter", async ({ page }) => {
+  // The palette is not mounted/visible until opened.
+  await expect(palette(page)).toHaveCount(0);
+
+  // OPEN via the global keyboard shortcut.
+  await page.keyboard.press(`${MOD}+KeyK`);
+  const dialog = palette(page);
+  await expect(dialog).toBeVisible();
+
+  // The search input is focused on open.
+  const input = dialog.getByPlaceholder("Search surfaces, pages, actions…");
+  await expect(input).toBeFocused();
+
+  // SEARCH — fuzzy-filter down to the SHACL surface. cmdk filters every Item by its `value`,
+  // which includes the theme label + title + blurb, so "shacl" narrows to that row.
+  await input.fill("shacl");
+  const shaclOption = dialog.getByRole("option", { name: /SHACL/i });
+  await expect(shaclOption).toBeVisible();
+
+  // NAVIGATE — the highlighted result is the first match; Enter selects it and routes there.
+  await page.keyboard.press("Enter");
+  await page.waitForURL("**/surface/shacl/**", { timeout: 15_000 });
+  expect(new URL(page.url()).pathname).toContain("/surface/shacl");
+
+  // The palette closed on navigation.
+  await expect(palette(page)).toHaveCount(0);
+});
+
+test("the header trigger opens the palette and ESC closes it", async ({ page }) => {
+  // OPEN via the visible header trigger button (the discoverable affordance).
+  await page.getByRole("button", { name: /Search \(Command-K\)/i }).click();
+  await expect(palette(page)).toBeVisible();
+
+  // ESC closes it — a11y requirement; the route does not change.
+  await page.keyboard.press("Escape");
+  await expect(palette(page)).toHaveCount(0);
+  expect(new URL(page.url()).pathname).toContain("/papers");
+});
+
+test("clicking a result row navigates to its surface", async ({ page }) => {
+  await page.keyboard.press(`${MOD}+KeyK`);
+  const dialog = palette(page);
+  await expect(dialog).toBeVisible();
+
+  // Search a flagship by name and click its row — the mouse path, not the keyboard path.
+  await dialog.getByPlaceholder("Search surfaces, pages, actions…").fill("car-hire");
+  const flagship = dialog.getByRole("option", { name: /car-hire/i });
+  await expect(flagship).toBeVisible();
+  await flagship.click();
+
+  await page.waitForURL("**/showcase/zk-car-hire/**", { timeout: 15_000 });
+  expect(new URL(page.url()).pathname).toContain("/showcase/zk-car-hire");
+});

--- a/site/package.json
+++ b/site/package.json
@@ -23,6 +23,7 @@
     "@noir-lang/noir_js": "1.0.0-beta.21",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "cmdk": "^1.1.1",
     "lucide-react": "^0.460.0",
     "next": "^15.5.19",
     "next-themes": "^0.4.6",

--- a/site/src/app/about/page.tsx
+++ b/site/src/app/about/page.tsx
@@ -7,7 +7,11 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { ALL_SURFACES, TIER_LABEL, TIER_VARIANT } from "@/data/surfaces";
+import {
+  ALL_SURFACES_WITH_ABOUT,
+  TIER_LABEL,
+  TIER_VARIANT,
+} from "@/data/surfaces";
 
 export const metadata: Metadata = {
   title: "About",
@@ -50,7 +54,7 @@ export default function AboutPage() {
               </tr>
             </thead>
             <tbody>
-              {ALL_SURFACES.map((s) => (
+              {ALL_SURFACES_WITH_ABOUT.map((s) => (
                 <tr key={s.slug} className="border-t">
                   <td className="px-4 py-2.5 font-medium">{s.title}</td>
                   <td className="px-4 py-2.5">

--- a/site/src/components/command-palette.tsx
+++ b/site/src/components/command-palette.tsx
@@ -1,0 +1,368 @@
+"use client";
+
+// [OPUS-4.8] sq-vw3ax.1 — the Cmd-K command palette.
+//
+// WHY IT IS LOAD-BEARING (research/website-redesign.md §2, §7). The redesign collapses a
+// tripled navigation (full-tree sidebar + top-tab bar + 14-card landing grid) into one slim
+// top bar. That is only safe once there is a fast path to every surface that loses a visible
+// nav entry — a fuzzy command palette that jumps to any surface by name in 0 clicks. So this
+// ships FIRST (this bead), BEFORE the sidebar is removed (sq-vw3ax.7).
+//
+// SINGLE SOURCE. Everything it indexes derives from the one canonical IA source
+// `@/data/surfaces` — the 5 capability THEMES (`GROUPS`), the flagship showcases
+// (`FLAGSHIPS`), and the /about utility page (`ABOUT_SURFACE`) — plus the fixed top-level
+// pages and a small set of actions. Re-grouping in surfaces.ts restructures this palette in
+// one edit, exactly like the sidebar and the Home grid.
+//
+// ADDITIVE ONLY. This is a new overlay; it removes no existing nav. It is mounted once in the
+// AppShell so the ⌘K / Ctrl-K binding is global.
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Command } from "cmdk";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import {
+  Search,
+  Github,
+  Sun,
+  Moon,
+  CornerDownLeft,
+  type LucideIcon,
+} from "lucide-react";
+import { useTheme } from "next-themes";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import {
+  ABOUT_SURFACE,
+  FLAGSHIPS,
+  GROUPS,
+  TIER_LABEL,
+  TIER_VARIANT,
+  type Surface,
+} from "@/data/surfaces";
+
+const REPO_URL = "https://github.com/jeswr/sparq";
+
+// A tiny context so a header trigger button (or anything else in the shell) can open the
+// palette without prop-drilling — the palette owns the state, exposes setOpen via context.
+const CommandPaletteContext = React.createContext<{
+  open: boolean;
+  setOpen: (open: boolean) => void;
+} | null>(null);
+
+/** Open / toggle the global command palette from anywhere inside <CommandPalette>. */
+export function useCommandPalette() {
+  const ctx = React.useContext(CommandPaletteContext);
+  if (!ctx) {
+    throw new Error("useCommandPalette must be used within <CommandPalette>");
+  }
+  return ctx;
+}
+
+// The fixed top-level destinations that are NOT capability surfaces (so they are not in
+// GROUPS): the home overview, the benchmark dashboard, the papers index. /try and /about
+// already live in the surface data (try is the first Query & data surface; about is the
+// ABOUT_SURFACE utility page), so they are not repeated here.
+const TOP_PAGES: { href: string; title: string; blurb: string }[] = [
+  { href: "/", title: "Home", blurb: "Overview — what sparq is, the live REPL, the flagships." },
+  { href: "/benchmarks", title: "Benchmarks", blurb: "Per-commit, same-box benchmark dashboard." },
+  { href: "/papers", title: "Papers", blurb: "The research papers behind sparq." },
+];
+
+/** A tier badge a surface carries (flagship / surface rows render this in the right gutter). */
+function TierBadge({ surface }: { surface: Surface }) {
+  return (
+    <Badge
+      variant={TIER_VARIANT[surface.tier]}
+      className="h-4 shrink-0 px-1.5 text-[10px]"
+      title={TIER_LABEL[surface.tier]}
+    >
+      {TIER_LABEL[surface.tier]}
+    </Badge>
+  );
+}
+
+// [OPUS-4.8] sq-vw3ax.1 — a clean SUBSTRING/word scorer, used instead of cmdk's default
+// fuzzy-subsequence one. The default scores almost every row > 0 for a short query (because
+// each row's keyword soup contains the query's letters as a loose subsequence), and then DOM
+// order breaks the near-ties — so "shacl" would surface a flagship rather than the SHACL row.
+// This scorer only returns > 0 on a real substring hit, and weights a TITLE match far above a
+// keyword/blurb match, so the obvious row wins. Case-insensitive; whitespace-normalised.
+function scoreItem(value: string, search: string, keywords?: string[]): number {
+  const q = search.trim().toLowerCase();
+  if (!q) return 1; // empty query → show everything (cmdk renders all, DOM order)
+  const title = value.toLowerCase();
+  // Exact title, then title-prefix, then title-substring — the strongest signals.
+  if (title === q) return 1;
+  if (title.startsWith(q)) return 0.9;
+  if (title.includes(q)) return 0.7;
+  // Otherwise a keyword/blurb substring hit (theme label, blurb, action verbs).
+  const hay = (keywords ?? []).join(" ").toLowerCase();
+  if (hay.includes(q)) return 0.4;
+  return 0; // no substring match → hidden
+}
+
+/** A single selectable row. `value` is the title; cmdk scores it via our custom filter. */
+function PaletteItem({
+  icon: Icon,
+  title,
+  blurb,
+  keywords,
+  onSelect,
+  trailing,
+}: {
+  icon: LucideIcon;
+  title: string;
+  blurb?: string;
+  // Secondary match terms (theme label, blurb, action verbs). cmdk scores the `value`
+  // (the title) FIRST, then falls back to keywords — so "shacl" ranks the SHACL surface
+  // above an unrelated row whose blurb happens to fuzzy-match, rather than diluting the
+  // score by concatenating everything into one `value` string.
+  keywords?: string[];
+  onSelect: () => void;
+  trailing?: React.ReactNode;
+}) {
+  return (
+    <Command.Item
+      value={title}
+      keywords={keywords}
+      onSelect={onSelect}
+      className={cn(
+        "flex cursor-pointer items-center gap-3 rounded-md px-3 py-2 text-sm",
+        "text-foreground/90 data-[selected=true]:bg-sidebar-accent data-[selected=true]:text-sidebar-accent-foreground",
+      )}
+    >
+      <span className="flex size-7 shrink-0 items-center justify-center rounded-md bg-primary/10 text-primary">
+        <Icon className="size-4" />
+      </span>
+      <span className="flex min-w-0 flex-1 flex-col">
+        <span className="truncate font-medium">{title}</span>
+        {blurb && (
+          <span className="truncate text-xs text-muted-foreground">{blurb}</span>
+        )}
+      </span>
+      {trailing}
+    </Command.Item>
+  );
+}
+
+export function CommandPalette({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false);
+  const router = useRouter();
+  const { theme, setTheme, resolvedTheme } = useTheme();
+
+  const ctx = React.useMemo(() => ({ open, setOpen }), [open]);
+
+  // Global ⌘K (macOS) / Ctrl-K (Windows/Linux) toggles the palette. We also let the platform
+  // browser-search shortcut stay free: only K with the platform modifier is intercepted.
+  React.useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === "k" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        setOpen((v) => !v);
+      }
+    };
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, []);
+
+  // Navigate (or run an action), then close. next/navigation's router.push respects the
+  // configured basePath, so "/surface/zk" resolves under /sparq on Pages and at root under
+  // Tauri — no manual basePath juggling here.
+  const go = React.useCallback(
+    (href: string) => {
+      setOpen(false);
+      router.push(href);
+    },
+    [router],
+  );
+
+  const runAction = React.useCallback((fn: () => void) => {
+    setOpen(false);
+    fn();
+  }, []);
+
+  const isDark = (resolvedTheme ?? theme) === "dark";
+
+  return (
+    <CommandPaletteContext.Provider value={ctx}>
+      {children}
+      <DialogPrimitive.Root open={open} onOpenChange={setOpen}>
+        <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-black/40 backdrop-blur-sm",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          )}
+        />
+        <DialogPrimitive.Content
+          className={cn(
+            "bg-card text-card-foreground fixed left-1/2 top-[12vh] z-50 w-[min(38rem,calc(100vw-2rem))] -translate-x-1/2",
+            "overflow-hidden rounded-xl p-0 shadow-2xl ring-1 ring-foreground/10",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          )}
+        >
+          {/* The Title is the dialog's accessible name (radix links aria-labelledby to it). */}
+          <DialogPrimitive.Title className="sr-only">
+            Command palette
+          </DialogPrimitive.Title>
+          <DialogPrimitive.Description className="sr-only">
+            Type to fuzzy-search every sparq surface, page, and quick action, then press Enter
+            to jump to it.
+          </DialogPrimitive.Description>
+
+          <Command
+            label="Search surfaces, pages and actions"
+            className="flex flex-col"
+            filter={scoreItem}
+          >
+            <div className="flex items-center gap-2 border-b px-3">
+              <Search className="size-4 shrink-0 text-muted-foreground" aria-hidden />
+              <Command.Input
+                autoFocus
+                placeholder="Search surfaces, pages, actions…"
+                className="h-12 flex-1 bg-transparent text-sm outline-none placeholder:text-muted-foreground"
+              />
+              <kbd className="hidden rounded border px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground sm:inline-block">
+                ESC
+              </kbd>
+            </div>
+
+            <Command.List className="max-h-[min(60vh,28rem)] overflow-y-auto p-2">
+              <Command.Empty className="px-3 py-6 text-center text-sm text-muted-foreground">
+                No matches. Try a surface name, &ldquo;benchmarks&rdquo;, or &ldquo;theme&rdquo;.
+              </Command.Empty>
+
+              {/* Flagship showcases first — the strongest proof artifacts. */}
+              <Command.Group
+                heading="Flagship showcases"
+                className="px-1 pb-1 text-xs font-medium text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5"
+              >
+                {FLAGSHIPS.map((f) => (
+                  <PaletteItem
+                    key={f.href}
+                    icon={f.icon}
+                    title={f.title}
+                    blurb={f.blurb}
+                    keywords={["showcase", "flagship", f.blurb]}
+                    onSelect={() => go(f.href)}
+                    trailing={<TierBadge surface={f} />}
+                  />
+                ))}
+              </Command.Group>
+
+              {/* The 5 capability THEMES — every surface, derived from the single GROUPS source. */}
+              {GROUPS.map((group) => (
+                <Command.Group
+                  key={group.id}
+                  heading={group.label}
+                  className="px-1 pb-1 text-xs font-medium text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5"
+                >
+                  {group.surfaces.map((s) => (
+                    <PaletteItem
+                      key={s.href}
+                      icon={s.icon}
+                      title={s.title}
+                      blurb={s.blurb}
+                      // The theme label + blurb are keywords so a theme search surfaces its
+                      // members, without diluting the title-driven primary score.
+                      keywords={[group.label, s.blurb]}
+                      onSelect={() => go(s.href)}
+                      trailing={<TierBadge surface={s} />}
+                    />
+                  ))}
+                </Command.Group>
+              ))}
+
+              {/* Fixed top-level pages + the /about utility page. */}
+              <Command.Group
+                heading="Pages"
+                className="px-1 pb-1 text-xs font-medium text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5"
+              >
+                {TOP_PAGES.map((p) => (
+                  <PaletteItem
+                    key={p.href}
+                    icon={Search}
+                    title={p.title}
+                    blurb={p.blurb}
+                    keywords={["page", p.blurb]}
+                    onSelect={() => go(p.href)}
+                  />
+                ))}
+                <PaletteItem
+                  icon={ABOUT_SURFACE.icon}
+                  title={ABOUT_SURFACE.title}
+                  blurb={ABOUT_SURFACE.blurb}
+                  keywords={["page", ABOUT_SURFACE.blurb]}
+                  onSelect={() => go(ABOUT_SURFACE.href)}
+                />
+              </Command.Group>
+
+              {/* Quick actions. */}
+              <Command.Group
+                heading="Actions"
+                className="px-1 pb-1 text-xs font-medium text-muted-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5"
+              >
+                <PaletteItem
+                  icon={isDark ? Sun : Moon}
+                  title={isDark ? "Switch to light theme" : "Switch to dark theme"}
+                  keywords={["action", "toggle", "theme", "dark", "light", "mode"]}
+                  onSelect={() => runAction(() => setTheme(isDark ? "light" : "dark"))}
+                />
+                <PaletteItem
+                  icon={Github}
+                  title="Open sparq on GitHub"
+                  blurb={REPO_URL}
+                  keywords={["action", "github", "source", "repository", "code"]}
+                  onSelect={() =>
+                    runAction(() =>
+                      window.open(REPO_URL, "_blank", "noopener,noreferrer"),
+                    )
+                  }
+                />
+              </Command.Group>
+            </Command.List>
+
+            <div className="flex items-center justify-between gap-2 border-t px-3 py-2 text-[11px] text-muted-foreground">
+              <span className="inline-flex items-center gap-1">
+                <CornerDownLeft className="size-3" aria-hidden /> to open
+              </span>
+              <span>
+                Open with{" "}
+                <kbd className="rounded border px-1 py-0.5 font-medium">⌘K</kbd> /{" "}
+                <kbd className="rounded border px-1 py-0.5 font-medium">Ctrl K</kbd>
+              </span>
+            </div>
+          </Command>
+        </DialogPrimitive.Content>
+        </DialogPrimitive.Portal>
+      </DialogPrimitive.Root>
+    </CommandPaletteContext.Provider>
+  );
+}
+
+/**
+ * The header trigger — a slim "search" affordance showing the ⌘K hint, plus an icon-only
+ * variant for the mobile bar. Clicking it opens the same palette the keyboard shortcut does.
+ */
+export function CommandPaletteTrigger({ className }: { className?: string }) {
+  const { setOpen } = useCommandPalette();
+  return (
+    <button
+      type="button"
+      onClick={() => setOpen(true)}
+      aria-label="Search (Command-K)"
+      className={cn(
+        "inline-flex h-9 items-center gap-2 rounded-md border bg-background px-3 text-sm text-muted-foreground transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50",
+        className,
+      )}
+    >
+      <Search className="size-4" aria-hidden />
+      <span className="hidden sm:inline">Search…</span>
+      <kbd className="ml-1 hidden rounded border px-1.5 py-0.5 text-[10px] font-medium sm:inline-block">
+        ⌘K
+      </kbd>
+    </button>
+  );
+}

--- a/site/src/components/layout/app-shell.tsx
+++ b/site/src/components/layout/app-shell.tsx
@@ -16,6 +16,10 @@ import {
 import { Logo } from "@/components/logo";
 import { ThemeToggle } from "@/components/theme-toggle";
 import { SidebarNav } from "@/components/layout/sidebar-nav";
+import {
+  CommandPalette,
+  CommandPaletteTrigger,
+} from "@/components/command-palette";
 
 const REPO_URL = "https://github.com/jeswr/sparq";
 
@@ -42,6 +46,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   const [mobileOpen, setMobileOpen] = React.useState(false);
 
   return (
+    // [OPUS-4.8] sq-vw3ax.1 — the whole shell is wrapped in <CommandPalette> so the global
+    // ⌘K / Ctrl-K binding and the header trigger button share one palette instance, mounted
+    // once. This is purely additive: it removes nothing from the existing sidebar/top-tab nav
+    // (the redesign sequences sidebar-removal in sq-vw3ax.7, AFTER Cmd-K ships).
+    <CommandPalette>
     <div className="flex min-h-svh flex-col">
       <div className="flex flex-1">
         {/* Persistent desktop sidebar (w-64) */}
@@ -99,6 +108,8 @@ export function AppShell({ children }: { children: React.ReactNode }) {
             </nav>
 
             <div className="ml-auto flex items-center gap-1">
+              {/* [OPUS-4.8] sq-vw3ax.1 — the Cmd-K affordance in the utility cluster. */}
+              <CommandPaletteTrigger className="mr-1 hidden sm:inline-flex" />
               <Button variant="ghost" size="icon" asChild>
                 <a
                   href={REPO_URL}
@@ -121,5 +132,6 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         </div>
       </div>
     </div>
+    </CommandPalette>
   );
 }

--- a/site/src/components/layout/sidebar-nav.tsx
+++ b/site/src/components/layout/sidebar-nav.tsx
@@ -6,7 +6,13 @@ import { usePathname } from "next/navigation";
 
 import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
-import { FLAGSHIPS, GROUPS, TIER_LABEL, TIER_VARIANT } from "@/data/surfaces";
+import {
+  ABOUT_SURFACE,
+  FLAGSHIPS,
+  GROUPS,
+  TIER_LABEL,
+  TIER_VARIANT,
+} from "@/data/surfaces";
 
 // [OPUS-4.8] Hover/focus-intent prefetch of the in-browser ZK prover.
 //
@@ -110,8 +116,11 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
         ))}
       </Section>
 
+      {/* [OPUS-4.8] sq-vw3ax.2 — the 5 capability THEMES, derived from the single
+          GROUPS source. Re-grouping there restructures this sidebar (and the Home grid,
+          the future /capabilities, and Cmd-K) in one edit. */}
       {GROUPS.map((group) => (
-        <Section key={group.label} label={group.label}>
+        <Section key={group.id} label={group.label}>
           {group.surfaces.map((s) => (
             <NavLink
               key={s.href}
@@ -133,6 +142,16 @@ export function SidebarNav({ onNavigate }: { onNavigate?: () => void }) {
           ))}
         </Section>
       ))}
+
+      {/* [OPUS-4.8] sq-vw3ax.2 — /about is a utility destination, not a capability
+          theme, so it is kept out of GROUPS and rendered here so the link is retained. */}
+      <NavLink
+        href={ABOUT_SURFACE.href}
+        active={isActive(ABOUT_SURFACE.href)}
+        onNavigate={onNavigate}
+      >
+        {ABOUT_SURFACE.title}
+      </NavLink>
     </nav>
   );
 }

--- a/site/src/data/surfaces.ts
+++ b/site/src/data/surfaces.ts
@@ -1,6 +1,14 @@
 // [OPUS-4.8] sq-8thu — the canonical site IA, derived from the feature-showcase
 // design doc (research/feature-showcase-site-design.md §2). One source for the
 // sidebar nav AND the landing surface grid. `tier` drives the honesty badge.
+//
+// [OPUS-4.8] sq-vw3ax.2 — re-grouped ONCE here into the 5 capability THEMES from the
+// website-redesign record (research/website-redesign.md §2). Every consumer — the
+// sidebar nav, the Home theme grid, the future /capabilities gallery, and the Cmd-K
+// command palette — derives from this single GROUPS source, so one edit restructures
+// all of them. This commit is a STRUCTURAL regroup only: no surface, blurb, tier, or
+// route was added, removed, or reworded — only their grouping (and per-theme metadata)
+// changed.
 
 import type { LucideIcon } from "lucide-react";
 import {
@@ -44,7 +52,11 @@ export interface Surface {
 }
 
 export interface SurfaceGroup {
+  /** Stable anchor id — `/capabilities#<id>` + the Home theme grid + Cmd-K group key. */
+  id: string;
   label: string;
+  /** One-line theme description (the capability the surfaces under it deliver). */
+  description: string;
   surfaces: Surface[];
 }
 
@@ -104,9 +116,24 @@ export const FLAGSHIPS: Surface[] = [
   },
 ];
 
+// [OPUS-4.8] sq-vw3ax.2 — the 5 capability THEMES (research/website-redesign.md §2).
+// Surfaces are mapped to themes by what they DO, keeping every existing surface, route,
+// blurb and tier verbatim:
+//   1. Query & data      — the REPL + SPARQL + the data-format/JS-WASM/geo query surfaces
+//   2. Reason & validate — inference + SHACL
+//   3. Search & GenAI    — full-text BM25, vector, GenAI/NLQ
+//   4. Privacy (ZK / MPC)— ZK query proofs + MPC federation (the Solid flagship sits in
+//      /showcase; it is surfaced via FLAGSHIPS, not duplicated as a /surface row here)
+//   5. Serve & embed     — HTTP server, CLI, Python, streaming RSP-QL
+// The redesign's aspirational extra rows (structural-similarity, a federation surface
+// page) are NOT invented here — there is no such route today, and this regroup adds no
+// content. They become beads, not fabricated nav entries.
 export const GROUPS: SurfaceGroup[] = [
   {
-    label: "Core engine",
+    id: "query-data",
+    label: "Query & data",
+    description:
+      "Run SPARQL 1.1/1.2 over RDF — the live REPL, the query engine, and the formats it ingests.",
     surfaces: [
       {
         slug: "try",
@@ -144,10 +171,28 @@ export const GROUPS: SurfaceGroup[] = [
         icon: Boxes,
         built: true,
       },
+      {
+        slug: "geosparql",
+        href: "/surface/geosparql",
+        title: "GeoSPARQL",
+        blurb: "geof: functions + sf*/eh*/rcc8* + R-tree GeoIndex with a map overlay.",
+        // [OPUS-4.8] sq-ndaz: tier-e. sparq-geo is an opt-in native crate (the core engine
+        // + lean wasm bundle carry zero geometry code; the server exposes geof: only behind
+        // its non-default `geo` feature), and the static Pages site has no backend — so the
+        // honest surface is a captured-output walkthrough (the real London–Paris distance
+        // < 400 km query, within-polygon spatial join, topology-property rewrite, and R-tree
+        // GeoIndex metres, all answer-exact), not a live hosted endpoint.
+        tier: "walkthrough",
+        icon: MapPin,
+        built: true,
+      },
     ],
   },
   {
-    label: "Reasoning & validation",
+    id: "reason-validate",
+    label: "Reason & validate",
+    description:
+      "Derive new triples and check graphs against shapes — RDFS / OWL 2 RL / N3 closure and SHACL.",
     surfaces: [
       {
         slug: "inference",
@@ -170,7 +215,10 @@ export const GROUPS: SurfaceGroup[] = [
     ],
   },
   {
-    label: "Search & retrieval",
+    id: "search-genai",
+    label: "Search & GenAI",
+    description:
+      "Find and generate over RDF — BM25 full-text, vector k-NN, and a natural-language → SPARQL loop.",
     surfaces: [
       {
         slug: "full-text",
@@ -213,36 +261,10 @@ export const GROUPS: SurfaceGroup[] = [
     ],
   },
   {
-    label: "Spatial & streaming",
-    surfaces: [
-      {
-        slug: "geosparql",
-        href: "/surface/geosparql",
-        title: "GeoSPARQL",
-        blurb: "geof: functions + sf*/eh*/rcc8* + R-tree GeoIndex with a map overlay.",
-        // [OPUS-4.8] sq-ndaz: tier-e. sparq-geo is an opt-in native crate (the core engine
-        // + lean wasm bundle carry zero geometry code; the server exposes geof: only behind
-        // its non-default `geo` feature), and the static Pages site has no backend — so the
-        // honest surface is a captured-output walkthrough (the real London–Paris distance
-        // < 400 km query, within-polygon spatial join, topology-property rewrite, and R-tree
-        // GeoIndex metres, all answer-exact), not a live hosted endpoint.
-        tier: "walkthrough",
-        icon: MapPin,
-        built: true,
-      },
-      {
-        slug: "streaming-rsp",
-        href: "/surface/streaming-rsp",
-        title: "Streaming RSP",
-        blurb: "RSP-QL windows (sliding / tumbling, R/I/DSTREAM).",
-        tier: "live-new-wasm",
-        icon: Radio,
-        built: true,
-      },
-    ],
-  },
-  {
-    label: "Privacy (ZK + MPC)",
+    id: "privacy",
+    label: "Privacy (ZK / MPC)",
+    description:
+      "Answer queries without revealing the data — zero-knowledge query proofs and threshold MPC federation. Research-grade: the v1 verifier is not externally audited.",
     surfaces: [
       {
         slug: "zk",
@@ -265,7 +287,10 @@ export const GROUPS: SurfaceGroup[] = [
     ],
   },
   {
-    label: "Serving & hosts",
+    id: "serve-embed",
+    label: "Serve & embed",
+    description:
+      "Run sparq as a service or embed it — the HTTP endpoint, the CLI, Python bindings, and streaming RSP-QL.",
     surfaces: [
       {
         slug: "http-server",
@@ -277,6 +302,15 @@ export const GROUPS: SurfaceGroup[] = [
         // subscription firing on a committed UPDATE), not a live hosted endpoint.
         tier: "walkthrough",
         icon: Server,
+        built: true,
+      },
+      {
+        slug: "streaming-rsp",
+        href: "/surface/streaming-rsp",
+        title: "Streaming RSP",
+        blurb: "RSP-QL windows (sliding / tumbling, R/I/DSTREAM).",
+        tier: "live-new-wasm",
+        icon: Radio,
         built: true,
       },
       {
@@ -297,20 +331,24 @@ export const GROUPS: SurfaceGroup[] = [
       },
     ],
   },
-  {
-    label: "About",
-    surfaces: [
-      {
-        slug: "about",
-        href: "/about",
-        title: "About",
-        blurb: "Architecture and the honest \"what runs where\" matrix.",
-        tier: "live",
-        icon: Info,
-        built: true,
-      },
-    ],
-  },
 ];
 
+// [OPUS-4.8] sq-vw3ax.2 — /about is a UTILITY destination (the "what runs where" matrix),
+// not a capability theme, so it is kept OUT of GROUPS (which is now strictly the 5 themes)
+// and exported separately. Consumers that previously walked GROUPS for the About entry
+// (the sidebar, the About-page table) read this instead, so no route is lost.
+export const ABOUT_SURFACE: Surface = {
+  slug: "about",
+  href: "/about",
+  title: "About",
+  blurb: 'Architecture and the honest "what runs where" matrix.',
+  tier: "live",
+  icon: Info,
+  built: true,
+};
+
+/** Every capability surface across the 5 themes (excludes the /about utility page). */
 export const ALL_SURFACES: Surface[] = GROUPS.flatMap((g) => g.surfaces);
+
+/** Capability surfaces + the /about utility page — the complete navigable surface set. */
+export const ALL_SURFACES_WITH_ABOUT: Surface[] = [...ALL_SURFACES, ABOUT_SURFACE];


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (Claude Opus 4.8, 1M context). This PR is the **safe, additive foundation** of the website-redesign epic, opened for **maintainer review** — auto-merge is intentionally **OFF** (UX foundation).

## Why

The maintainer's verdict on the current site: **"there is too much text; it is overwhelming."** The audited root cause is **structural** — the same ~16 surfaces appear in up to three places at once (a full-tree sidebar **+** a top-tab bar **+** a 14-card landing grid). This PR lands the two **prerequisites** for fixing that, both of which **DELETE NO CONTENT yet** (sidebar removal / Home rewrite / `/capabilities` collapse are the HELD children **sq-vw3ax.3 / .5 / .7**, for maintainer review):

- **sq-vw3ax.2** — re-group the 16 surfaces into ~5 capability THEMES at the **single source**.
- **sq-vw3ax.1** — add the Cmd-K command palette (load-bearing: the only 0-click path to every surface once the sidebar is later removed; the design sequences sidebar-removal **after** Cmd-K exists).

Epic: **sq-vw3ax**. Design: `research/website-redesign.md` §2,§7 + the `frontend-design` skill (both now on `main`).

## sq-vw3ax.2 — single `GROUPS` source, 5 capability THEMES

Re-grouped **once** in `site/src/data/surfaces.ts` `GROUPS`; every consumer (sidebar nav, Home grid, the About "what runs where" matrix, and Cmd-K) derives from it, so one edit restructures all of them.

| Theme (`id`) | Surfaces |
|---|---|
| **Query & data** (`query-data`) | Live SPARQL REPL · SPARQL 1.1/1.2 · Data formats · JavaScript/WASM · GeoSPARQL |
| **Reason & validate** (`reason-validate`) | Inference (RDFS/OWL-RL/N3) · SHACL |
| **Search & GenAI** (`search-genai`) | Full-text (BM25) · Vector · GenAI/NLQ |
| **Privacy (ZK / MPC)** (`privacy`) | ZK query proofs · MPC federation |
| **Serve & embed** (`serve-embed`) | HTTP server · Streaming RSP · CLI · Python |

This is a **STRUCTURAL regroup only** — no surface, route, blurb, or tier was added, removed, or reworded; only the grouping (plus a per-theme `id` anchor + one-line `description`) changed. `/about` is a utility destination, not a capability theme, so it moves to a separate `ABOUT_SURFACE` export (kept in the sidebar + About matrix, so no route is lost). The redesign's **aspirational** extra rows (structural-similarity, a federation page) are **not fabricated** — there is no such route today; they stay as future beads.

**Privacy honesty preserved:** the Privacy theme `description` carries the not-externally-audited caveat ("Research-grade: the v1 verifier is not externally audited"); `scripts/check-privacy-claims.sh` passes.

## sq-vw3ax.1 — Cmd-K command palette

- New dep **`cmdk@^1.1.1`** (~124K source; its `@radix-ui/react-dialog`/`-primitive` deps were already in the tree via the site's `radix-ui` package, so the net runtime add is small).
- `CommandPalette` + `CommandPaletteTrigger` mounted **once** in `AppShell`; global **⌘K / Ctrl-K** toggles it, plus a visible header "Search… ⌘K" affordance.
- Indexes the **single `GROUPS` source** + flagships + `ABOUT_SURFACE` + top-level pages + quick actions (toggle theme, open GitHub).
- A small **substring/title-weighted custom `filter`** replaces cmdk's default fuzzy scorer, which mis-ranked short queries via keyword-soup ties (e.g. "shacl" surfaced a flagship). Now "shacl"→SHACL, "vector"→Vector, etc.
- basePath-correct navigation via `next/navigation` `router.push`; **ESC** closes; `sr-only` dialog title for a11y.
- **Purely additive** — it removes nothing from the existing sidebar/top-tab nav (sidebar-collapse is the HELD sq-vw3ax.7).

## Gates

- ✅ `npm run build` (Pages static export) green end-to-end, all 47 routes emitted to `out/`.
- ✅ `npm run build:tauri` (root-relative export) green.
- ✅ `npm run lint` clean · `tsc --noEmit` clean.
- ✅ New `e2e/command-palette.spec.ts` (open via ⌘K and via the header trigger, fuzzy-search, navigate on Enter and on click, ESC-close) — **3/3 pass**; **all 12 existing e2e** (REPL, SHACL, workspace, ZK pre-warm) still pass (**15/15** total).
- ✅ `scripts/check-privacy-claims.sh` + `scripts/check-terminology.py` pass.
- ✅ WASM prereq built (`cd js && npm run build:wasm`) — a build artifact only, no `crates/` changes.
- Rebased onto current `main` (includes the sibling **sq-4296** wasm-loading PR #987 — disjoint files, no conflicts; the wasm-loading code is untouched).

No hard-coded perf numbers; existing routes (`/`, `/benchmarks/*`, `/papers`, `/try`, `/surface/*`, `/showcase/*`, `/about`) all preserved.

Closes #sq-vw3ax.1 · Closes #sq-vw3ax.2 (tracked in `.beads/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)