### PR TITLE
test(sparq-shacl): correctness coverage — SHACL-AF func ops + SCS error paths + SHACL-SPARQL edges (sq-qcnn)

### DIFF
--- a/bench/coverage-floor.json
+++ b/bench/coverage-floor.json
@@ -96,7 +96,8 @@
       "note": "[OPUS-4.8] sq-4vao: behavioural tests for the lowest-covered modules (subscription reevaluate_step/subscribe_init diff + refusal classes, budget->SSE-status + RDF-1.2 triple-term encoding, the json_error/sanitized_error info-leak envelope, the GSP escape_iri/body-decode helpers, and the SPARQL-Protocol dataset-override rewrite) lifted measured line% 86.38 -> 88.14; floor = floor(measured) - 2 margin."
     },
     "sparq-shacl": {
-      "floor": 90
+      "floor": 93,
+      "note": "[OPUS-4.8] sq-qcnn: measured with DEFAULT features (the per-commit tier — no measure() case arm; the opt-in shacl-af/scs surfaces are compiled out of a default build, so func.rs/scs.rs do not count toward this default-feature number). Raised 90 -> 93 after tests/sparql_edge_cases.rs added SHACL-SPARQL §5.2/§6 dark-branch coverage (non-SELECT skip, ?value-unbound, ?path IRI-vs-literal mapping, SELECT-validator row-message + template substitution, LeftJoin pre-binding push-down, mismatched-validator skip) — measured default-feature line% 95.88 (3280/3421); floor = floor(measured) - 2 margin. The shacl-af func.rs (56% -> 94%) and scs.rs (85% -> 92%) gains from tests/node_expr_operators.rs + tests/scs_error_paths.rs are behind their opt-in features and so do NOT lift this default-feature floor. Conservative work-box seed; CI's --check-robust is the ratchet of record."
     },
     "sparq-shacl-wasm": {
       "floor": 0,

--- a/crates/sparq-shacl/tests/node_expr_operators.rs
+++ b/crates/sparq-shacl/tests/node_expr_operators.rs
@@ -1,0 +1,633 @@
+//! [OPUS-4.8] (sq-qcnn) Correctness coverage for the SHACL-AF node-expression
+//! **function operators** (`src/func.rs`) — fixture-independent unit tests that
+//! drive every built-in operator through the PUBLIC `eval_node_expression` seam
+//! and the `apply_rules` value-rule path, asserting hand-derived result node sets
+//! from the SHACL 1.2 node-expression algebra.
+//!
+//! Why a dedicated file: the W3C `node-expr` suite that exercises these operators
+//! is fetched into a gitignored `tests/shacl/` dir and SKIPS on a fresh checkout,
+//! so on the per-commit coverage gate `func.rs` ran dark for most operators
+//! (~56% lines). These tests cover the operators deterministically regardless of
+//! the fixtures, and pin the SEMANTICS (not just line-exercise): each assertion is
+//! the node set the SHACL-AF algebra specifies for that operator.
+//!
+//! Whole file is `#[cfg(feature = "shacl-af")]` — the node-expression public API
+//! it drives is itself feature-gated, so with the feature off this compiles to
+//! nothing (and the AGENTS.md "both feature states" standard is met: the file is a
+//! no-op in the default build).
+
+#![cfg(feature = "shacl-af")]
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_shacl::eval_node_expression;
+use sparq_shacl::view::GraphView;
+
+const PRELUDE: &str = "@prefix sh: <http://www.w3.org/ns/shacl#> .\n\
+    @prefix shnex: <http://www.w3.org/ns/shacl-node-expr#> .\n\
+    @prefix ex: <http://example.org/> .\n\
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .\n\
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n";
+
+fn g(ttl: &str) -> Graph {
+    Graph::load_str(&format!("{PRELUDE}{ttl}"), "turtle").unwrap()
+}
+
+fn iri(s: &str) -> Term {
+    Term::NamedNode(NamedNode::new_unchecked(format!("http://example.org/{s}")))
+}
+
+/// Evaluate the node expression bound to `ex:<decl_pred>` on `ex:Decl` over `data`.
+fn eval(data: &Graph, shapes: &Graph, decl_pred: &str, focus: &Term) -> Vec<Term> {
+    let view = GraphView::new(shapes);
+    let decl = iri("Decl");
+    let e = view
+        .object(&decl, &format!("http://example.org/{decl_pred}"))
+        .unwrap_or_else(|| panic!("node-expr bnode ex:{decl_pred} present"));
+    eval_node_expression(data, shapes, &e, focus)
+        .unwrap_or_else(|| panic!("ex:{decl_pred} must be a supported node expression"))
+}
+
+/// The lexical values of a result set, sorted (set-equality with dups collapsed
+/// by the caller's choice — most assertions use a multiset, so we keep dups).
+fn lexes(set: &[Term]) -> Vec<String> {
+    let mut v: Vec<String> = set
+        .iter()
+        .map(|t| match t {
+            Term::Literal(l) => l.value().to_string(),
+            Term::NamedNode(n) => n.as_str().to_string(),
+            Term::BlankNode(b) => b.as_str().to_string(),
+            other => other.to_string(),
+        })
+        .collect();
+    v.sort();
+    v
+}
+
+/// The datatype IRI of a single-literal result (panics if not a single literal).
+fn one_dt(set: &[Term]) -> String {
+    assert_eq!(set.len(), 1, "expected exactly one term: {set:?}");
+    match &set[0] {
+        Term::Literal(l) => l.datatype().as_str().to_string(),
+        other => panic!("expected a literal, got {other:?}"),
+    }
+}
+
+const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+
+// ───────────────────────── aggregate / numeric operators ─────────────────────────
+
+/// `sum` over mixed integer args stays `xsd:integer`; a decimal arg makes it
+/// `xsd:decimal`; non-numeric members are ignored; the empty set sums to 0.
+#[test]
+fn sum_integer_decimal_and_empty() {
+    let data = g("ex:a a ex:N .");
+    let shapes = g(r#"
+        ex:Decl
+          ex:allInt   [ shnex:sum ( 4 5 3 ) ] ;
+          ex:withDec  [ shnex:sum ( 1 2.5 ) ] ;
+          ex:withText [ shnex:sum ( 4 "not a number" 6 ) ] ;
+          ex:empty    [ shnex:sum [ sh:path ex:nope ] ] .
+    "#);
+    let f = iri("a");
+    assert_eq!(lexes(&eval(&data, &shapes, "allInt", &f)), vec!["12"]);
+    assert_eq!(
+        one_dt(&eval(&data, &shapes, "allInt", &f)),
+        format!("{XSD}integer")
+    );
+    assert_eq!(lexes(&eval(&data, &shapes, "withDec", &f)), vec!["3.5"]);
+    assert_eq!(
+        one_dt(&eval(&data, &shapes, "withDec", &f)),
+        format!("{XSD}decimal")
+    );
+    // Non-numeric members ignored: 4 + 6 = 10.
+    assert_eq!(lexes(&eval(&data, &shapes, "withText", &f)), vec!["10"]);
+    // Empty input sums to integer 0.
+    assert_eq!(lexes(&eval(&data, &shapes, "empty", &f)), vec!["0"]);
+}
+
+/// `min` / `max` pick the numerically least / greatest member; a set with no
+/// numeric member yields the empty set (NOT a zero).
+#[test]
+fn min_max_pick_extremes_and_empty_on_non_numeric() {
+    let data = g("ex:a a ex:N .");
+    let shapes = g(r#"
+        ex:Decl
+          ex:mn   [ shnex:min ( 7 2 9 4 ) ] ;
+          ex:mx   [ shnex:max ( 7 2 9 4 ) ] ;
+          ex:mnNN [ shnex:min ( "x" "y" ) ] .
+    "#);
+    let f = iri("a");
+    assert_eq!(lexes(&eval(&data, &shapes, "mn", &f)), vec!["2"]);
+    assert_eq!(lexes(&eval(&data, &shapes, "mx", &f)), vec!["9"]);
+    // No numeric member -> empty (min_max returns None).
+    assert!(eval(&data, &shapes, "mnNN", &f).is_empty());
+}
+
+/// `count` returns the cardinality of its argument set as an `xsd:integer`
+/// (duplicates counted; `count` does NOT dedup).
+#[test]
+fn count_counts_with_duplicates() {
+    let data = g("ex:a a ex:N .");
+    let shapes = g(r#"ex:Decl ex:c [ shnex:count ( 4 3 3 5 ) ] ."#);
+    let r = eval(&data, &shapes, "c", &iri("a"));
+    assert_eq!(lexes(&r), vec!["4"]);
+    assert_eq!(one_dt(&r), format!("{XSD}integer"));
+}
+
+/// `distinct` deduplicates by RDF term equality, preserving one of each.
+#[test]
+fn distinct_dedups_by_term() {
+    let data = g("ex:a a ex:N .");
+    let shapes = g(r#"ex:Decl ex:d [ shnex:distinct ( 4 2 4 2 9 ) ] ."#);
+    assert_eq!(
+        lexes(&eval(&data, &shapes, "d", &iri("a"))),
+        vec!["2", "4", "9"]
+    );
+}
+
+// ───────────────────────── boolean / conditional operators ─────────────────────────
+
+/// `exists` is `{ true }` when its argument set is non-empty, `{ false }` when
+/// empty — and the result is an `xsd:boolean`.
+#[test]
+fn exists_reflects_nonemptiness() {
+    let data = g("ex:a ex:has ex:x .");
+    let shapes = g(r#"
+        ex:Decl
+          ex:hasSome [ shnex:exists [ sh:path ex:has ] ] ;
+          ex:hasNone [ shnex:exists [ sh:path ex:missing ] ] .
+    "#);
+    let f = iri("a");
+    assert_eq!(lexes(&eval(&data, &shapes, "hasSome", &f)), vec!["true"]);
+    assert_eq!(
+        one_dt(&eval(&data, &shapes, "hasSome", &f)),
+        format!("{XSD}boolean")
+    );
+    assert_eq!(lexes(&eval(&data, &shapes, "hasNone", &f)), vec!["false"]);
+}
+
+/// `if … then … else?`: the `then` branch when the condition is `{ true }`, the
+/// `else` branch otherwise; with no `else` and a false condition the result is
+/// the empty set.
+#[test]
+fn if_then_else_branches() {
+    let data = g("ex:a a ex:N .");
+    let shapes = g(r#"
+        ex:Decl
+          ex:tBranch    [ shnex:if true  ; shnex:then 1 ; shnex:else 2 ] ;
+          ex:fBranch    [ shnex:if false ; shnex:then 1 ; shnex:else 2 ] ;
+          ex:fNoElse    [ shnex:if false ; shnex:then 1 ] ;
+          ex:nonBoolIsF [ shnex:if "yes" ; shnex:then 1 ; shnex:else 2 ] .
+    "#);
+    let f = iri("a");
+    assert_eq!(lexes(&eval(&data, &shapes, "tBranch", &f)), vec!["1"]);
+    assert_eq!(lexes(&eval(&data, &shapes, "fBranch", &f)), vec!["2"]);
+    // No else + false condition -> empty set.
+    assert!(eval(&data, &shapes, "fNoElse", &f).is_empty());
+    // A condition that is not exactly { true } takes the else branch.
+    assert_eq!(lexes(&eval(&data, &shapes, "nonBoolIsF", &f)), vec!["2"]);
+}
+
+// ───────────────────────── set / list operators ─────────────────────────
+
+/// `concat ( E1 E2 … )` concatenates members in order WITHOUT dedup (duplicates
+/// preserved across arguments).
+#[test]
+fn concat_preserves_order_and_duplicates() {
+    let data = g(r#"
+        ex:a ex:x ex:p1 ; ex:y ex:p1 , ex:p2 .
+    "#);
+    let shapes = g(r#"
+        ex:Decl ex:cat [ shnex:concat ( [ sh:path ex:x ] [ sh:path ex:y ] ) ] .
+    "#);
+    // ex:x = {p1}; ex:y = {p1, p2}. concat = [p1, p1, p2] (p1 appears twice).
+    let r = eval(&data, &shapes, "cat", &iri("a"));
+    assert_eq!(r.len(), 3, "concat keeps duplicates: {r:?}");
+    let mut vals = lexes(&r);
+    vals.sort();
+    assert_eq!(
+        vals,
+        vec![
+            "http://example.org/p1".to_string(),
+            "http://example.org/p1".to_string(),
+            "http://example.org/p2".to_string()
+        ]
+    );
+}
+
+/// `nodes N ; limit k` keeps the first `k`; `offset k` drops the first `k`; they
+/// compose as offset-then-limit. The input order is the data-graph order, which
+/// is deterministic for a single subject's objects here, so we assert as a set.
+#[test]
+fn limit_and_offset_slice() {
+    // Five distinct objects on a single predicate.
+    let data = g(r#"ex:a ex:p ex:n1 , ex:n2 , ex:n3 , ex:n4 , ex:n5 ."#);
+    let shapes = g(r#"
+        ex:Decl
+          ex:lim2 [ shnex:nodes [ sh:path ex:p ] ; shnex:limit 2 ] ;
+          ex:off3 [ shnex:nodes [ sh:path ex:p ] ; shnex:offset 3 ] .
+    "#);
+    let f = iri("a");
+    // limit 2 -> exactly 2 of the 5.
+    assert_eq!(eval(&data, &shapes, "lim2", &f).len(), 2);
+    // offset 3 -> the remaining 2 of the 5.
+    assert_eq!(eval(&data, &shapes, "off3", &f).len(), 2);
+}
+
+/// `nodes N ; remove R`: `Eval(N)` minus the members of `Eval(R)` (term
+/// equality), order-preserving.
+#[test]
+fn remove_subtracts_members() {
+    let data = g(r#"
+        ex:a ex:p ex:n1 , ex:n2 , ex:n3 .
+        ex:a ex:drop ex:n2 .
+    "#);
+    let shapes = g(r#"
+        ex:Decl ex:r [ shnex:nodes [ sh:path ex:p ] ; shnex:remove [ sh:path ex:drop ] ] .
+    "#);
+    // {n1,n2,n3} minus {n2} = {n1, n3}.
+    assert_eq!(
+        lexes(&eval(&data, &shapes, "r", &iri("a"))),
+        vec!["http://example.org/n1", "http://example.org/n3"]
+    );
+}
+
+/// `nodes N ; flatMap E`: for each member, evaluate `E` with the focus rebound,
+/// concatenated (no dedup). Here flatMap over each child collects each child's
+/// `ex:name`.
+#[test]
+fn flat_map_rebinds_focus_per_member() {
+    let data = g(r#"
+        ex:a ex:child ex:b , ex:c .
+        ex:b ex:name "Bob" .
+        ex:c ex:name "Carol" .
+    "#);
+    let shapes = g(r#"
+        ex:Decl ex:fm [ shnex:nodes [ sh:path ex:child ] ; shnex:flatMap [ sh:path ex:name ] ] .
+    "#);
+    assert_eq!(
+        lexes(&eval(&data, &shapes, "fm", &iri("a"))),
+        vec!["Bob", "Carol"]
+    );
+}
+
+/// `nodes N ; orderBy K` sorts by the least key value of each node, ascending by
+/// default and descending with `shnex:desc true`. A node with NO key sorts first
+/// (ascending).
+#[test]
+fn order_by_ascending_descending_and_missing_key() {
+    let data = g(r#"
+        ex:a ex:item ex:i1 , ex:i2 , ex:i3 .
+        ex:i1 ex:h 30 .
+        ex:i2 ex:h 10 .
+        ex:i3 ex:h 20 .
+    "#);
+    let shapes = g(r#"
+        ex:Decl
+          ex:asc  [ shnex:nodes [ sh:path ex:item ] ; shnex:orderBy [ sh:path ex:h ] ] ;
+          ex:desc [ shnex:nodes [ sh:path ex:item ] ; shnex:orderBy [ sh:path ex:h ] ; shnex:desc true ] .
+    "#);
+    let f = iri("a");
+    // ascending by height: i2(10), i3(20), i1(30) — order is observable here.
+    let asc: Vec<String> = eval(&data, &shapes, "asc", &f)
+        .iter()
+        .map(|t| t.to_string())
+        .collect();
+    assert_eq!(
+        asc,
+        vec![
+            "<http://example.org/i2>".to_string(),
+            "<http://example.org/i3>".to_string(),
+            "<http://example.org/i1>".to_string()
+        ]
+    );
+    let desc: Vec<String> = eval(&data, &shapes, "desc", &f)
+        .iter()
+        .map(|t| t.to_string())
+        .collect();
+    assert_eq!(
+        desc,
+        vec![
+            "<http://example.org/i1>".to_string(),
+            "<http://example.org/i3>".to_string(),
+            "<http://example.org/i2>".to_string()
+        ]
+    );
+}
+
+/// orderBy where one node has NO key sorts that node first (ascending).
+#[test]
+fn order_by_missing_key_sorts_first() {
+    let data = g(r#"
+        ex:a ex:item ex:i1 , ex:i2 .
+        ex:i1 ex:h 50 .
+        # ex:i2 has no ex:h key.
+    "#);
+    let shapes = g(r#"
+        ex:Decl ex:asc [ shnex:nodes [ sh:path ex:item ] ; shnex:orderBy [ sh:path ex:h ] ] .
+    "#);
+    let asc: Vec<String> = eval(&data, &shapes, "asc", &iri("a"))
+        .iter()
+        .map(|t| t.to_string())
+        .collect();
+    // i2 (no key) sorts before i1 (key 50).
+    assert_eq!(
+        asc,
+        vec![
+            "<http://example.org/i2>".to_string(),
+            "<http://example.org/i1>".to_string()
+        ]
+    );
+}
+
+// ───────────────────────── filter-shape operators ─────────────────────────
+
+/// `findFirst S ; nodes N` returns the first node of `Eval(N)` conforming to the
+/// inline filter shape `S` (empty if none conform).
+#[test]
+fn find_first_returns_first_conforming() {
+    let data = g(r#"
+        ex:a ex:item ex:i1 , ex:i2 , ex:i3 .
+        ex:i2 ex:tag "ok" .
+        ex:i3 ex:tag "ok" .
+    "#);
+    let shapes = g(r#"
+        ex:HasTag a sh:NodeShape ; sh:property [ sh:path ex:tag ; sh:minCount 1 ] .
+        ex:Decl ex:ff [
+          shnex:nodes [ sh:path ex:item ] ;
+          shnex:findFirst ex:HasTag
+        ] .
+    "#);
+    // i1 has no ex:tag (fails minCount 1). The first conforming is i2 OR i3 (the
+    // data-graph iteration order over the three objects is deterministic for a
+    // single run); assert it is exactly one of the conforming pair, never i1.
+    let r = eval(&data, &shapes, "ff", &iri("a"));
+    assert_eq!(r.len(), 1, "findFirst yields a single node: {r:?}");
+    let got = r[0].to_string();
+    assert!(
+        got == "<http://example.org/i2>" || got == "<http://example.org/i3>",
+        "must be a conforming node (i2 or i3), never the non-conforming i1: {got}"
+    );
+    assert_ne!(got, "<http://example.org/i1>");
+}
+
+/// `findFirst` over a set where NO node conforms yields the empty set.
+#[test]
+fn find_first_none_conforming_is_empty() {
+    let data = g(r#"ex:a ex:item ex:i1 , ex:i2 ."#);
+    let shapes = g(r#"
+        ex:HasTag a sh:NodeShape ; sh:property [ sh:path ex:tag ; sh:minCount 1 ] .
+        ex:Decl ex:ff [
+          shnex:nodes [ sh:path ex:item ] ;
+          shnex:findFirst ex:HasTag
+        ] .
+    "#);
+    assert!(eval(&data, &shapes, "ff", &iri("a")).is_empty());
+}
+
+/// `matchAll S ; nodes N` is `{ true }` iff EVERY node of `Eval(N)` conforms to
+/// `S` (empty input ⇒ `{ true }`), else `{ false }`.
+#[test]
+fn match_all_universal_quantifier() {
+    let data = g(r#"
+        ex:a ex:item ex:i1 , ex:i2 .
+        ex:i1 ex:tag "x" .
+        ex:i2 ex:tag "y" .
+        ex:b ex:item ex:j1 , ex:j2 .
+        ex:j1 ex:tag "x" .
+        # ex:j2 has no tag -> not all conform.
+    "#);
+    let shapes = g(r#"
+        ex:HasTag a sh:NodeShape ; sh:property [ sh:path ex:tag ; sh:minCount 1 ] .
+        ex:Decl ex:ma [
+          shnex:nodes [ sh:path ex:item ] ;
+          shnex:matchAll ex:HasTag
+        ] .
+    "#);
+    // All items of ex:a conform -> { true }.
+    assert_eq!(lexes(&eval(&data, &shapes, "ma", &iri("a"))), vec!["true"]);
+    // Not all items of ex:b conform -> { false }.
+    assert_eq!(lexes(&eval(&data, &shapes, "ma", &iri("b"))), vec!["false"]);
+}
+
+/// `matchAll` over an EMPTY input set is vacuously `{ true }`.
+#[test]
+fn match_all_empty_input_is_vacuously_true() {
+    let data = g(r#"ex:a a ex:N ."#);
+    let shapes = g(r#"
+        ex:HasTag a sh:NodeShape ; sh:property [ sh:path ex:tag ; sh:minCount 1 ] .
+        ex:Decl ex:ma [
+          shnex:nodes [ sh:path ex:nope ] ;
+          shnex:matchAll ex:HasTag
+        ] .
+    "#);
+    assert_eq!(lexes(&eval(&data, &shapes, "ma", &iri("a"))), vec!["true"]);
+}
+
+// ───────────────────────── class / shape membership ─────────────────────────
+
+/// `instancesOf C` yields the SHACL instances of class `C` including the subclass
+/// closure (an `rdfs:subClassOf` member is an instance of the superclass).
+#[test]
+fn instances_of_includes_subclass_closure() {
+    let data = g(r#"
+        ex:Animal a rdfs:Class .
+        ex:Dog rdfs:subClassOf ex:Animal .
+        ex:rex a ex:Dog .
+        ex:generic a ex:Animal .
+        ex:other a ex:Plant .
+    "#);
+    let shapes = g(r#"ex:Decl ex:io [ shnex:instancesOf ex:Animal ] ."#);
+    // rex (a Dog ⊑ Animal) and generic (a Animal) are instances; other is not.
+    assert_eq!(
+        lexes(&eval(&data, &shapes, "io", &iri("rex"))),
+        vec!["http://example.org/generic", "http://example.org/rex"]
+    );
+}
+
+/// `nodesMatching S` yields every node of the data graph conforming to shape `S`.
+#[test]
+fn nodes_matching_selects_conforming_nodes() {
+    let data = g(r#"
+        ex:p1 ex:tag "x" .
+        ex:p2 ex:tag "y" .
+        ex:p3 ex:other "z" .
+    "#);
+    let shapes = g(r#"
+        ex:Decl ex:nm [ shnex:nodesMatching ex:TagShape ] .
+        ex:TagShape a sh:NodeShape ; sh:property [ sh:path ex:tag ; sh:minCount 1 ] .
+    "#);
+    // p1 and p2 have an ex:tag; p3 does not. (Literal objects "x"/"y"/"z" are not
+    // candidate nodes; only subjects/non-literal objects are.)
+    assert_eq!(
+        lexes(&eval(&data, &shapes, "nm", &iri("p1"))),
+        vec!["http://example.org/p1", "http://example.org/p2"]
+    );
+}
+
+// ───────────────────────── var binding ─────────────────────────
+
+/// `var "focusNode"` is bound to the focus; any other variable name is unbound
+/// (the empty set), since there is no SPARQL variable scope at node-expr eval.
+#[test]
+fn var_focus_node_and_unbound() {
+    let data = g(r#"ex:a a ex:N ."#);
+    let shapes = g(r#"
+        ex:Decl
+          ex:vf [ shnex:var "focusNode" ] ;
+          ex:vx [ shnex:var "somethingElse" ] .
+    "#);
+    let f = iri("a");
+    assert_eq!(
+        eval(&data, &shapes, "vf", &f)[0].to_string(),
+        "<http://example.org/a>"
+    );
+    assert!(eval(&data, &shapes, "vx", &f).is_empty());
+}
+
+// ───────────────────────── custom sh:SPARQLFunction ─────────────────────────
+
+/// A declared `sh:SPARQLFunction` is dispatched through the SPARQL engine with the
+/// argument pre-bound; its `?result` column is the function output.
+#[test]
+fn custom_sparql_function_dispatches() {
+    let data = g(r#"ex:a ex:val 21 ."#);
+    let shapes = g(r#"
+        ex:double a sh:SPARQLFunction ;
+          sh:parameter [ sh:path ex:arg ] ;
+          sh:select "SELECT ((?arg * 2) AS ?result) WHERE { }" .
+        ex:Decl ex:dbl [ ex:double ( [ sh:path ex:val ] ) ] .
+    "#);
+    // ex:val = 21; double -> 42.
+    assert_eq!(lexes(&eval(&data, &shapes, "dbl", &iri("a"))), vec!["42"]);
+}
+
+/// A custom SPARQL function whose argument evaluates to MORE than one node (a
+/// non-scalar) is undefined ⇒ the empty set (fail-closed, no panic).
+#[test]
+fn custom_sparql_function_non_scalar_arg_is_empty() {
+    let data = g(r#"ex:a ex:val 1 , 2 , 3 ."#);
+    let shapes = g(r#"
+        ex:double a sh:SPARQLFunction ;
+          sh:parameter [ sh:path ex:arg ] ;
+          sh:select "SELECT ((?arg * 2) AS ?result) WHERE { }" .
+        ex:Decl ex:dbl [ ex:double ( [ sh:path ex:val ] ) ] .
+    "#);
+    // ex:val resolves to {1,2,3} (3 nodes) -> scalar binding fails -> empty.
+    assert!(eval(&data, &shapes, "dbl", &iri("a")).is_empty());
+}
+
+/// An undeclared function IRI (not a `sh:SPARQLFunction`) is NOT a node
+/// expression: `eval_node_expression` returns `None` (the lenient-drop contract).
+#[test]
+fn unknown_function_iri_is_not_a_node_expr() {
+    let data = g(r#"ex:a a ex:N ."#);
+    let shapes = g(r#"ex:Decl ex:f [ ex:notAFunction ( ex:a ) ] ."#);
+    let view = GraphView::new(&shapes);
+    let decl = iri("Decl");
+    let e = view.object(&decl, "http://example.org/f").unwrap();
+    assert!(
+        eval_node_expression(&data, &shapes, &e, &iri("a")).is_none(),
+        "an undeclared function IRI is not a supported node expression"
+    );
+}
+
+/// A custom SPARQL function whose argument evaluates to a BLANK NODE has no
+/// SPARQL ground form, so the VALUES row cannot be built ⇒ empty set (the
+/// `ground` blank-node arm + `build_function_query` `None` path).
+#[test]
+fn custom_sparql_function_blank_arg_is_empty() {
+    // ex:a's ex:ref points at a blank node; double() over a blank arg is undefined.
+    let data = g(r#"ex:a ex:ref [ ex:dummy 1 ] ."#);
+    let shapes = g(r#"
+        ex:double a sh:SPARQLFunction ;
+          sh:parameter [ sh:path ex:arg ] ;
+          sh:select "SELECT ((?arg * 2) AS ?result) WHERE { }" .
+        ex:Decl ex:dbl [ ex:double ( [ sh:path ex:ref ] ) ] .
+    "#);
+    assert!(eval(&data, &shapes, "dbl", &iri("a")).is_empty());
+}
+
+/// A custom SPARQL function whose SELECT body has NO `?result` column yields the
+/// empty set (the `position("result")` None arm) — fail-closed, no panic.
+#[test]
+fn custom_sparql_function_no_result_column_is_empty() {
+    let data = g(r#"ex:a ex:val 5 ."#);
+    let shapes = g(r#"
+        ex:noResult a sh:SPARQLFunction ;
+          sh:parameter [ sh:path ex:arg ] ;
+          sh:select "SELECT ((?arg * 2) AS ?other) WHERE { }" .
+        ex:Decl ex:nr [ ex:noResult ( [ sh:path ex:val ] ) ] .
+    "#);
+    assert!(eval(&data, &shapes, "nr", &iri("a")).is_empty());
+}
+
+/// `orderBy` over a STRING (non-numeric) sort key sorts lexically (the `cmp_term`
+/// lexical fallback + `lexical` literal arm), ascending by default.
+#[test]
+fn order_by_lexical_string_keys() {
+    let data = g(r#"
+        ex:a ex:item ex:i1 , ex:i2 , ex:i3 .
+        ex:i1 ex:name "charlie" .
+        ex:i2 ex:name "alice" .
+        ex:i3 ex:name "bob" .
+    "#);
+    let shapes = g(r#"
+        ex:Decl ex:ord [ shnex:nodes [ sh:path ex:item ] ; shnex:orderBy [ sh:path ex:name ] ] .
+    "#);
+    // Lexical ascending by name: alice(i2), bob(i3), charlie(i1).
+    let got: Vec<String> = eval(&data, &shapes, "ord", &iri("a"))
+        .iter()
+        .map(|t| t.to_string())
+        .collect();
+    assert_eq!(
+        got,
+        vec![
+            "<http://example.org/i2>".to_string(),
+            "<http://example.org/i3>".to_string(),
+            "<http://example.org/i1>".to_string()
+        ]
+    );
+}
+
+/// `concat` whose ANY argument is an unsupported sub-expression makes the whole
+/// `concat` parse fail ⇒ not a node expression (`None`), the lenient-drop contract
+/// at the operand level.
+#[test]
+fn concat_with_unsupported_operand_is_none() {
+    let data = g(r#"ex:a a ex:N ."#);
+    // ex:notAFn is not a declared function, so the inner expr is unsupported, so the
+    // whole concat list fails to parse.
+    let shapes = g(r#"ex:Decl ex:c [ shnex:concat ( [ ex:notAFn ( ex:a ) ] 3 ) ] ."#);
+    let view = GraphView::new(&shapes);
+    let decl = iri("Decl");
+    let e = view.object(&decl, "http://example.org/c").unwrap();
+    assert!(
+        eval_node_expression(&data, &shapes, &e, &iri("a")).is_none(),
+        "a concat over an unsupported operand must not parse"
+    );
+}
+
+/// A `sh:SPARQLFunction` applied with the WRONG argument count (more or fewer than
+/// the declared `sh:parameter` order) is not parsed as a function expression
+/// (`None`), matching the declared-arity contract.
+#[test]
+fn custom_sparql_function_arity_mismatch_is_none() {
+    let data = g(r#"ex:a ex:val 1 ."#);
+    let shapes = g(r#"
+        ex:double a sh:SPARQLFunction ;
+          sh:parameter [ sh:path ex:arg ] ;
+          sh:select "SELECT ((?arg * 2) AS ?result) WHERE { }" .
+        ex:Decl ex:dbl [ ex:double ( [ sh:path ex:val ] [ sh:path ex:val ] ) ] .
+    "#);
+    let view = GraphView::new(&shapes);
+    let decl = iri("Decl");
+    let e = view.object(&decl, "http://example.org/dbl").unwrap();
+    // Two args against a one-parameter declaration -> arity mismatch -> None.
+    assert!(
+        eval_node_expression(&data, &shapes, &e, &iri("a")).is_none(),
+        "arity mismatch must not parse as a function expression"
+    );
+}

--- a/crates/sparq-shacl/tests/node_expr_operators.rs
+++ b/crates/sparq-shacl/tests/node_expr_operators.rs
@@ -412,6 +412,35 @@ fn match_all_universal_quantifier() {
     assert_eq!(lexes(&eval(&data, &shapes, "ma", &iri("b"))), vec!["false"]);
 }
 
+/// `matchAll` must use the SPECIFIC named filter shape, not just "a" shape: with
+/// two distinct shapes registered, the discriminating one flips the boolean. (This
+/// pins `inline_or_named_shape` to the real `by_node` lookup — a constant shape-id
+/// would mis-route to the wrong shape and give the opposite answer.)
+#[test]
+fn match_all_uses_the_named_filter_shape_not_an_arbitrary_one() {
+    let data = g(r#"
+        ex:a ex:item ex:i1 , ex:i2 .
+        ex:i1 ex:tag "x" .
+        ex:i2 ex:tag "y" .
+        # Neither item carries ex:other, so the OtherShape filter fails for all.
+    "#);
+    let shapes = g(r#"
+        # Two distinct named shapes. HasTag conforms for both items; HasOther for
+        # neither. matchAll over the SAME nodes must give opposite booleans.
+        ex:HasTag   a sh:NodeShape ; sh:property [ sh:path ex:tag   ; sh:minCount 1 ] .
+        ex:HasOther a sh:NodeShape ; sh:property [ sh:path ex:other ; sh:minCount 1 ] .
+        ex:Decl
+          ex:maTag   [ shnex:nodes [ sh:path ex:item ] ; shnex:matchAll ex:HasTag ] ;
+          ex:maOther [ shnex:nodes [ sh:path ex:item ] ; shnex:matchAll ex:HasOther ] .
+    "#);
+    let f = iri("a");
+    // All items have a tag -> { true }; none have ex:other -> { false }. If the
+    // filter-shape id were a constant (the survivor), both would collapse to the
+    // SAME boolean — so the two assertions together kill that mutant.
+    assert_eq!(lexes(&eval(&data, &shapes, "maTag", &f)), vec!["true"]);
+    assert_eq!(lexes(&eval(&data, &shapes, "maOther", &f)), vec!["false"]);
+}
+
 /// `matchAll` over an EMPTY input set is vacuously `{ true }`.
 #[test]
 fn match_all_empty_input_is_vacuously_true() {

--- a/crates/sparq-shacl/tests/scs_error_paths.rs
+++ b/crates/sparq-shacl/tests/scs_error_paths.rs
@@ -1,0 +1,451 @@
+//! [OPUS-4.8] (sq-qcnn) Fail-closed + edge-construct correctness coverage for the
+//! SHACL Compact Syntax (SCS) PARSER (`src/scs.rs`).
+//!
+//! The W3C `shacl-compact-syntax` corpus that drives `scs.rs` is fetched into a
+//! gitignored `tests/shacl/` dir and SKIPS on a fresh checkout, so the parser's
+//! ERROR paths (the "any construct outside the supported surface returns a typed
+//! `ScsError` rather than silently mis-parsing" contract) ran dark on the
+//! per-commit gate. These tests pin that fail-closed contract directly — each
+//! malformed input MUST return an `Err`, never a wrong-but-`Ok` parse — plus the
+//! correct triple encoding of the valid edge constructs (escapes, paths,
+//! datatypes, arrays, disjunctions).
+//!
+//! SCS syntax reminder (NOT Turtle): directives are `BASE`/`IMPORTS`/`PREFIX p:`
+//! with no trailing `.`; a node shape is `shape ex:S -> ex:Class { … }` whose
+//! constraints live INSIDE the `{ }` body, each terminated by `.`. The four
+//! implicit prefixes `rdf`/`rdfs`/`sh`/`xsd` are predefined.
+//!
+//! Whole file is `#[cfg(feature = "scs")]` — the SCS parser public API is itself
+//! feature-gated, so with the feature off this compiles to nothing (the AGENTS.md
+//! "both feature states" standard is met).
+
+#![cfg(feature = "scs")]
+
+use sparq_shacl::{parse_scs, parse_scs_to_graph, DEFAULT_BASE};
+
+const SH: &str = "http://www.w3.org/ns/shacl#";
+const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+const PREFIX: &str = "PREFIX ex: <http://example.org/>\n";
+
+/// Parse with the default base; panics if the document is malformed.
+fn ok(text: &str) -> Vec<oxrdf::Triple> {
+    parse_scs(text, DEFAULT_BASE).unwrap_or_else(|e| panic!("expected OK, got: {e}"))
+}
+
+/// Parse expecting a fail-closed `ScsError`; returns its message for assertions.
+fn err(text: &str) -> String {
+    match parse_scs(text, DEFAULT_BASE) {
+        Ok(t) => panic!("expected an ScsError, but parsed {} triples OK", t.len()),
+        Err(e) => e.message,
+    }
+}
+
+/// True iff some emitted triple is `(_, <SH+pred>, …obj_lex…)`.
+fn has_pred_obj(triples: &[oxrdf::Triple], pred_local: &str, obj_lex: &str) -> bool {
+    triples.iter().any(|t| {
+        t.predicate.as_str() == format!("{SH}{pred_local}")
+            && t.object.to_string().contains(obj_lex)
+    })
+}
+
+fn has_pred(triples: &[oxrdf::Triple], pred_local: &str) -> bool {
+    triples
+        .iter()
+        .any(|t| t.predicate.as_str() == format!("{SH}{pred_local}"))
+}
+
+// ───────────────────────────── lexer fail-closed ─────────────────────────────
+
+#[test]
+fn unterminated_iri_is_error() {
+    assert!(err("shape <http://example.org/incomplete").contains("unterminated <IRI>"));
+}
+
+#[test]
+fn unterminated_string_is_error() {
+    let m = err(&format!("{PREFIX}shape ex:S {{ ex:p message=\"oops . }}"));
+    assert!(m.contains("unterminated string literal"), "got: {m}");
+}
+
+#[test]
+fn invalid_string_escape_is_error() {
+    let m = err(&format!(
+        "{PREFIX}shape ex:S {{ ex:p message=\"bad \\q escape\" . }}"
+    ));
+    assert!(m.contains("invalid string escape"), "got: {m}");
+}
+
+#[test]
+fn empty_language_tag_is_error() {
+    let m = err(&format!("{PREFIX}shape ex:S {{ ex:p message=\"hi\"@ . }}"));
+    assert!(m.contains("empty language tag"), "got: {m}");
+}
+
+#[test]
+fn at_without_prefixed_name_is_error() {
+    // `@` followed by neither `<iri>` nor a prefixed name (a digit run).
+    let m = err(&format!("{PREFIX}shape ex:S {{ ex:p @123 . }}"));
+    assert!(
+        !m.is_empty(),
+        "an `@` with no shape ref must fail closed: {m}"
+    );
+}
+
+// ───────────────────────────── parser fail-closed ─────────────────────────────
+
+#[test]
+fn undefined_prefix_is_error() {
+    let m = err("shape nope:S { }");
+    assert!(m.contains("undefined prefix"), "got: {m}");
+}
+
+#[test]
+fn prefix_decl_without_pname_is_error() {
+    let m = err("PREFIX <http://example.org/>");
+    assert!(m.contains("expected `prefix:` after PREFIX"), "got: {m}");
+}
+
+#[test]
+fn base_without_iri_is_error() {
+    let m = err("BASE notAniri");
+    assert!(m.contains("expected <BASE IRI"), "got: {m}");
+}
+
+#[test]
+fn imports_without_iri_is_error() {
+    let m = err("IMPORTS notAniri");
+    assert!(m.contains("expected <IMPORTS IRI"), "got: {m}");
+}
+
+#[test]
+fn stray_token_where_shape_expected_is_error() {
+    // After directives, only `shape`/`shapeClass`/EOF are valid.
+    let m = err(&format!("{PREFIX}ex:NotAKeyword"));
+    assert!(m.contains("expected `shape` or `shapeClass`"), "got: {m}");
+}
+
+#[test]
+fn target_class_arrow_with_no_iri_is_error() {
+    let m = err(&format!("{PREFIX}shape ex:S -> {{ }}"));
+    assert!(
+        m.contains("expected target class IRI after `->`"),
+        "got: {m}"
+    );
+}
+
+#[test]
+fn unterminated_brace_body_is_error() {
+    // `{` opens a node-shape body that never closes.
+    let m = err(&format!("{PREFIX}shape ex:S {{ "));
+    assert!(m.contains("unterminated `{ ... }` shape body"), "got: {m}");
+}
+
+#[test]
+fn min_count_non_integer_is_error() {
+    let m = err(&format!("{PREFIX}shape ex:S {{ ex:p [x..3] . }}"));
+    assert!(m.contains("expected min count integer"), "got: {m}");
+}
+
+#[test]
+fn max_count_garbage_is_error() {
+    let m = err(&format!("{PREFIX}shape ex:S {{ ex:p [0..x] . }}"));
+    assert!(m.contains("expected max count integer or `*`"), "got: {m}");
+}
+
+#[test]
+fn unterminated_array_is_error() {
+    let m = err(&format!("{PREFIX}shape ex:S {{ in=[ ex:a ex:b "));
+    assert!(m.contains("unterminated `[ ... ]` array"), "got: {m}");
+}
+
+#[test]
+fn missing_dot_after_node_constraint_is_error() {
+    // A node constraint inside the body must be terminated by `.`.
+    let m = err(&format!("{PREFIX}shape ex:S {{ closed=true }}"));
+    assert!(m.contains("expected `.`"), "got: {m}");
+}
+
+// ───────────────────────────── valid edge constructs ─────────────────────────────
+
+#[test]
+fn empty_doc_emits_only_ontology() {
+    // The empty document still emits the `?base rdf:type owl:Ontology` triple.
+    let t = ok("");
+    assert_eq!(t.len(), 1, "{t:?}");
+    assert!(
+        t[0].object.to_string().contains("owl#Ontology"),
+        "{:?}",
+        t[0]
+    );
+}
+
+#[test]
+fn imports_emits_owl_imports() {
+    let t = ok("IMPORTS <http://example.org/other>");
+    assert!(
+        t.iter().any(
+            |tr| tr.predicate.as_str() == "http://www.w3.org/2002/07/owl#imports"
+                && tr.object.to_string().contains("http://example.org/other")
+        ),
+        "{t:?}"
+    );
+}
+
+#[test]
+fn shape_class_adds_rdfs_class_type() {
+    let t = ok(&format!("{PREFIX}shapeClass ex:Animal {{ }}"));
+    let rdf_type = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+    assert!(
+        t.iter().any(|tr| tr.predicate.as_str() == rdf_type
+            && tr.object.to_string().contains("2000/01/rdf-schema#Class")),
+        "shapeClass must add the rdfs:Class type: {t:?}"
+    );
+    assert!(
+        t.iter().any(|tr| tr.predicate.as_str() == rdf_type
+            && tr.object.to_string().contains(&format!("{SH}NodeShape"))),
+        "shapeClass must also be a sh:NodeShape: {t:?}"
+    );
+}
+
+#[test]
+fn target_class_emits_sh_target_class() {
+    let t = ok(&format!("{PREFIX}shape ex:S -> ex:Person {{ }}"));
+    assert!(
+        has_pred_obj(&t, "targetClass", "http://example.org/Person"),
+        "`-> ex:Person` must emit sh:targetClass: {t:?}"
+    );
+}
+
+#[test]
+fn pn_local_escape_is_unescaped() {
+    // `ex:a\-b` is the local name `a-b` (PN_LOCAL_ESC).
+    let t = ok(&format!("{PREFIX}shape ex:a\\-b {{ }}"));
+    assert!(
+        t.iter()
+            .any(|tr| tr.subject.to_string().contains("http://example.org/a-b")),
+        "escaped local name must unescape to a-b: {t:?}"
+    );
+}
+
+#[test]
+fn bare_xsd_datatype_maps_to_sh_datatype_else_class() {
+    // `xsd:string` is a SPARQL datatype -> sh:datatype; a non-datatype IRI -> sh:class.
+    let t = ok(&format!(
+        "{PREFIX}shape ex:S {{ ex:p xsd:string . }}\nshape ex:T {{ ex:q ex:SomeClass . }}"
+    ));
+    assert!(
+        has_pred_obj(&t, "datatype", &format!("{XSD}string")),
+        "xsd:string must map to sh:datatype: {t:?}"
+    );
+    assert!(
+        has_pred_obj(&t, "class", "http://example.org/SomeClass"),
+        "a non-datatype IRI must map to sh:class: {t:?}"
+    );
+}
+
+#[test]
+fn node_kind_keyword_emits_sh_node_kind() {
+    let t = ok(&format!("{PREFIX}shape ex:S {{ ex:p IRI . }}"));
+    assert!(
+        has_pred_obj(&t, "nodeKind", &format!("{SH}IRI")),
+        "the IRI keyword must emit sh:nodeKind sh:IRI: {t:?}"
+    );
+}
+
+#[test]
+fn inverse_path_emits_inverse_path() {
+    let t = ok(&format!("{PREFIX}shape ex:S {{ ^ex:parent [0..1] . }}"));
+    assert!(
+        has_pred(&t, "inversePath"),
+        "`^ex:parent` must emit sh:inversePath: {t:?}"
+    );
+}
+
+#[test]
+fn zero_or_more_path_emits_modifier() {
+    let t = ok(&format!("{PREFIX}shape ex:S {{ ex:p* [0..1] . }}"));
+    assert!(
+        has_pred(&t, "zeroOrMorePath"),
+        "`ex:p*` must emit sh:zeroOrMorePath: {t:?}"
+    );
+}
+
+#[test]
+fn one_or_more_path_emits_modifier() {
+    let t = ok(&format!("{PREFIX}shape ex:S {{ ex:p+ . }}"));
+    assert!(
+        has_pred(&t, "oneOrMorePath"),
+        "`ex:p+` must emit sh:oneOrMorePath: {t:?}"
+    );
+}
+
+#[test]
+fn alternative_path_emits_alternative_path() {
+    let t = ok(&format!("{PREFIX}shape ex:S {{ (ex:a|ex:b) [0..1] . }}"));
+    assert!(
+        has_pred(&t, "alternativePath"),
+        "`(ex:a|ex:b)` must emit sh:alternativePath: {t:?}"
+    );
+}
+
+#[test]
+fn sequence_path_emits_rdf_list() {
+    // `ex:a/ex:b` is a sequence path (a plain RDF list).
+    let t = ok(&format!("{PREFIX}shape ex:S {{ ex:a/ex:b [0..1] . }}"));
+    let rdf_first = "http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
+    assert!(
+        t.iter().any(|tr| tr.predicate.as_str() == rdf_first),
+        "a sequence path must build an rdf:first/rdf:rest list: {t:?}"
+    );
+}
+
+#[test]
+fn typed_literal_datatype_resolves() {
+    // `"5"^^xsd:int` keeps its datatype.
+    let t = ok(&format!(
+        "{PREFIX}shape ex:S {{ hasValue=\"5\"^^xsd:int . }}"
+    ));
+    assert!(
+        t.iter()
+            .any(|tr| tr.object.to_string().contains(&format!("{XSD}int"))),
+        "typed-literal datatype must be carried through: {t:?}"
+    );
+}
+
+#[test]
+fn decimal_and_double_literals_get_right_datatype() {
+    let t = ok(&format!(
+        "{PREFIX}shape ex:S {{ minInclusive=2.5 . maxInclusive=1e3 . }}"
+    ));
+    assert!(
+        t.iter()
+            .any(|tr| tr.object.to_string().contains(&format!("{XSD}decimal"))),
+        "2.5 must be xsd:decimal: {t:?}"
+    );
+    assert!(
+        t.iter()
+            .any(|tr| tr.object.to_string().contains(&format!("{XSD}double"))),
+        "1e3 must be xsd:double: {t:?}"
+    );
+}
+
+#[test]
+fn lang_tagged_literal_carries_language() {
+    let t = ok(&format!(
+        "{PREFIX}shape ex:S {{ ex:p hasValue=\"bonjour\"@fr . }}"
+    ));
+    assert!(
+        t.iter().any(|tr| tr.object.to_string().contains("@fr")),
+        "a language-tagged literal must carry its @lang: {t:?}"
+    );
+}
+
+#[test]
+fn base_directive_resolves_relative_iri_via_graph() {
+    // A BASE directive plus a relative shape IRI resolves against the base; the
+    // graph form is what `validate` consumes, so build it end to end.
+    let g = parse_scs_to_graph(
+        "BASE <http://base.example/v1#>\nshape <Thing> { }",
+        DEFAULT_BASE,
+    )
+    .expect("valid SCS");
+    assert!(
+        g.len() >= 2,
+        "graph must carry the ontology + shape-type triples"
+    );
+}
+
+#[test]
+fn empty_array_value_emits_rdf_nil() {
+    // `in=[ ]` is the empty list -> rdf:nil.
+    let t = ok(&format!("{PREFIX}shape ex:S {{ in=[] . }}"));
+    assert!(
+        has_pred_obj(&t, "in", "1999/02/22-rdf-syntax-ns#nil"),
+        "empty array must encode as rdf:nil: {t:?}"
+    );
+}
+
+#[test]
+fn in_array_value_builds_rdf_list() {
+    let t = ok(&format!("{PREFIX}shape ex:S {{ in=[ex:a ex:b] . }}"));
+    let rdf_first = "http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
+    assert!(
+        t.iter().any(|tr| tr.predicate.as_str() == rdf_first),
+        "a non-empty `in` array must build an RDF list: {t:?}"
+    );
+}
+
+#[test]
+fn node_or_disjunction_emits_sh_or() {
+    // Two node disjuncts `datatype=xsd:string | class=ex:C` become an sh:or list
+    // (the W3C `node-or-3-not` fixture form).
+    let t = ok(&format!(
+        "{PREFIX}shape ex:S {{ datatype=xsd:string | class=ex:C . }}"
+    ));
+    assert!(
+        has_pred(&t, "or"),
+        "a 2-branch node disjunction must emit sh:or: {t:?}"
+    );
+}
+
+#[test]
+fn node_negation_emits_sh_not() {
+    // `!datatype=xsd:string` is a negated node constraint -> sh:not.
+    let t = ok(&format!("{PREFIX}shape ex:S {{ !datatype=xsd:string . }}"));
+    assert!(
+        has_pred(&t, "not"),
+        "a `!` node constraint must emit sh:not: {t:?}"
+    );
+}
+
+#[test]
+fn shape_ref_emits_sh_node() {
+    // `@ex:OtherShape` in property-atom position is a shape reference (sh:node).
+    let t = ok(&format!(
+        "{PREFIX}shape ex:Other {{ }}\nshape ex:S {{ ex:p @ex:Other . }}"
+    ));
+    assert!(
+        has_pred_obj(&t, "node", "http://example.org/Other"),
+        "`@ex:Other` must emit sh:node: {t:?}"
+    );
+}
+
+#[test]
+fn nested_brace_body_emits_sh_node() {
+    // A nested `{ ... }` after a path is an inline node shape (sh:node).
+    let t = ok(&format!(
+        "{PREFIX}shape ex:S {{ ex:p {{ ex:q [1..1] . }} . }}"
+    ));
+    assert!(
+        has_pred(&t, "node"),
+        "a nested `{{ }}` body must emit sh:node: {t:?}"
+    );
+}
+
+#[test]
+fn count_min_zero_omits_min_count() {
+    // `[0..3]` -> only sh:maxCount (min 0 is the SHACL default, so no sh:minCount).
+    let t = ok(&format!("{PREFIX}shape ex:S {{ ex:p [0..3] . }}"));
+    assert!(
+        !has_pred(&t, "minCount"),
+        "min 0 must NOT emit sh:minCount: {t:?}"
+    );
+    assert!(
+        has_pred_obj(&t, "maxCount", "3"),
+        "max 3 must emit sh:maxCount: {t:?}"
+    );
+}
+
+#[test]
+fn count_star_max_omits_max_count() {
+    // `[2..*]` -> only sh:minCount (unbounded max emits no sh:maxCount).
+    let t = ok(&format!("{PREFIX}shape ex:S {{ ex:p [2..*] . }}"));
+    assert!(
+        has_pred_obj(&t, "minCount", "2"),
+        "min 2 must emit sh:minCount: {t:?}"
+    );
+    assert!(
+        !has_pred(&t, "maxCount"),
+        "`*` max must NOT emit sh:maxCount: {t:?}"
+    );
+}

--- a/crates/sparq-shacl/tests/sparql_edge_cases.rs
+++ b/crates/sparq-shacl/tests/sparql_edge_cases.rs
@@ -1,0 +1,305 @@
+//! [OPUS-4.8] (sq-qcnn) SHACL-SPARQL (`src/sparql.rs`) edge-case correctness
+//! coverage — the genuinely-dark branches of the `sh:sparql` constraint path and
+//! the SHACL §6 SPARQL-based constraint-COMPONENT validator path that the
+//! fixture-gated W3C `sparql/` suites leave uncovered on a fresh checkout.
+//!
+//! Each test asserts the SHACL-spec-correct outcome (fail-closed skip of an
+//! ill-formed query; correct `?value`/`?path`/`?message` mapping; pre-binding
+//! pushed BELOW solution modifiers so `$value`/`$this` are in scope). All run
+//! through the public `validate` API over real Turtle shapes — the real path, no
+//! mocks.
+
+use sparq_core::Graph;
+use sparq_shacl::validate;
+
+fn run(data: &str, shapes: &str) -> sparq_shacl::ValidationReport {
+    let data = Graph::load_str(data, "turtle").unwrap();
+    let shapes = Graph::load_str(shapes, "turtle").unwrap();
+    validate(&data, &shapes)
+}
+
+const PREFIXES: &str = r#"
+    @prefix sh: <http://www.w3.org/ns/shacl#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix ex: <http://example.org/> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+"#;
+
+// ───────────────────────── sh:sparql fail-closed forms ─────────────────────────
+
+/// A `sh:sparql` whose `sh:select` is actually an ASK query is NOT a SELECT, so
+/// `PreparedSparql::build` rejects it (`!matches!(Query::Select)`) and the
+/// constraint is skipped — a parallel Core constraint still fires.
+#[test]
+fn non_select_sh_sparql_is_skipped() {
+    let shapes = format!(
+        r#"{PREFIXES}
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:thing ;
+          sh:sparql [ sh:select "ASK {{ ?s ?p ?o }}" ] ;
+          sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+    "#
+    );
+    let data = "@prefix ex: <http://example.org/> . ex:thing ex:other \"x\" .";
+    let r = run(data, &shapes);
+    // Only the minCount violation; the non-SELECT sh:sparql contributes nothing.
+    assert_eq!(r.results.len(), 1, "{}", r.to_text());
+    assert!(r.results[0]
+        .source_component
+        .ends_with("MinCountConstraintComponent"));
+}
+
+/// A `sh:sparql` constraint with NO `sh:message` and NO bound `?message` falls
+/// back to the default "Violates SPARQL-based constraint" message.
+#[test]
+fn sh_sparql_default_message_when_none_supplied() {
+    let shapes = format!(
+        r#"{PREFIXES}
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:bob ;
+          sh:sparql [ sh:select "SELECT $this WHERE {{ $this <http://example.org/bad> ?o }}" ] .
+    "#
+    );
+    let data = "@prefix ex: <http://example.org/> . ex:bob ex:bad \"y\" .";
+    let r = run(data, &shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(r.results.len(), 1, "{}", r.to_text());
+    assert!(
+        r.results[0].effective_messages()[0]
+            .to_string()
+            .contains("Violates SPARQL-based constraint"),
+        "default message expected: {}",
+        r.results[0].effective_messages()[0]
+    );
+}
+
+/// A `sh:sparql` SELECT that projects `?value` but leaves it UNBOUND on the
+/// solution row reports NO sh:value (None), not the focus node — distinguishing
+/// "value projected but unbound" from "value not projected".
+#[test]
+fn sh_sparql_value_projected_but_unbound_is_none() {
+    let shapes = format!(
+        r#"{PREFIXES}
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:bob ;
+          sh:sparql [
+            sh:select """
+              SELECT $this ?value WHERE {{
+                $this <http://example.org/flag> ?x .
+                OPTIONAL {{ $this <http://example.org/missing> ?value }}
+              }}
+            """ ;
+          ] .
+    "#
+    );
+    let data = "@prefix ex: <http://example.org/> . ex:bob ex:flag \"on\" .";
+    let r = run(data, &shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(r.results.len(), 1, "{}", r.to_text());
+    // ?value is projected but the OPTIONAL did not bind it -> no sh:value.
+    assert!(
+        r.results[0].value.is_none(),
+        "a projected-but-unbound ?value must yield None, got {:?}",
+        r.results[0].value
+    );
+}
+
+/// A `?path` binding that is an IRI maps to `sh:resultPath` (a predicate path); a
+/// `?path` binding that is NOT an IRI (a literal) maps to no path.
+#[test]
+fn sh_sparql_path_iri_maps_non_iri_does_not() {
+    let shapes_iri = format!(
+        r#"{PREFIXES}
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:bob ;
+          sh:sparql [
+            sh:select """
+              SELECT $this ?path WHERE {{
+                $this <http://example.org/bad> ?o .
+                BIND(<http://example.org/age> AS ?path)
+              }}
+            """ ;
+          ] .
+    "#
+    );
+    let data = "@prefix ex: <http://example.org/> . ex:bob ex:bad \"x\" .";
+    let r = run(data, &shapes_iri);
+    assert_eq!(r.results.len(), 1, "{}", r.to_text());
+    assert!(
+        r.results[0].path.is_some(),
+        "an IRI ?path must map to sh:resultPath: {}",
+        r.to_text()
+    );
+
+    // A literal ?path -> no resultPath.
+    let shapes_lit = format!(
+        r#"{PREFIXES}
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:bob ;
+          sh:sparql [
+            sh:select """
+              SELECT $this ?path WHERE {{
+                $this <http://example.org/bad> ?o .
+                BIND("not-an-iri" AS ?path)
+              }}
+            """ ;
+          ] .
+    "#
+    );
+    let r2 = run(data, &shapes_lit);
+    assert_eq!(r2.results.len(), 1, "{}", r2.to_text());
+    assert!(
+        r2.results[0].path.is_none(),
+        "a literal ?path must NOT map to sh:resultPath"
+    );
+}
+
+// ───────────────── SPARQL-based constraint COMPONENT validators ─────────────────
+
+const SUBCLASS: &str = "ex:MyCC rdfs:subClassOf sh:ConstraintComponent .\n";
+
+/// A SELECT validator component whose solution binds `?message` (and the
+/// component declares no `sh:message`) uses the row's `?message` as the result
+/// message (the `(None, Some(m))` precedence arm).
+#[test]
+fn select_validator_row_message_used_when_no_component_message() {
+    let shapes = format!(
+        r#"{PREFIXES}
+        {SUBCLASS}
+        ex:MsgComp a ex:MyCC ;
+          sh:parameter [ sh:path ex:tag ] ;
+          sh:validator [
+            a sh:SPARQLSelectValidator ;
+            sh:select """
+              SELECT $this ?message WHERE {{
+                $this <http://example.org/v> ?v .
+                BIND(CONCAT("bad value ", STR(?v)) AS ?message)
+              }}
+            """ ;
+          ] .
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:bob ;
+          ex:tag "anything" .
+    "#
+    );
+    let data = "@prefix ex: <http://example.org/> . ex:bob ex:v 7 .";
+    let r = run(data, &shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(r.results.len(), 1, "{}", r.to_text());
+    assert!(
+        r.results[0].effective_messages()[0]
+            .to_string()
+            .contains("bad value 7"),
+        "the row ?message must drive the result message: {}",
+        r.results[0].effective_messages()[0]
+    );
+}
+
+/// A SELECT validator component with a `sh:message` template substitutes the
+/// solution's `{?var}` (the `(Some(tpl), _)` precedence arm).
+#[test]
+fn select_validator_message_template_substitution() {
+    let shapes = format!(
+        r#"{PREFIXES}
+        {SUBCLASS}
+        ex:TplComp a ex:MyCC ;
+          sh:parameter [ sh:path ex:tag ] ;
+          sh:validator [
+            a sh:SPARQLSelectValidator ;
+            sh:message "value was {{?value}}" ;
+            sh:select """
+              SELECT $this ?value WHERE {{
+                $this <http://example.org/v> ?value .
+              }}
+            """ ;
+          ] .
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:bob ;
+          ex:tag "x" .
+    "#
+    );
+    let data = "@prefix ex: <http://example.org/> . ex:bob ex:v 42 .";
+    let r = run(data, &shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(r.results.len(), 1, "{}", r.to_text());
+    assert!(
+        r.results[0].effective_messages()[0]
+            .to_string()
+            .contains("value was 42"),
+        "the template must substitute ?value from the solution: {}",
+        r.results[0].effective_messages()[0]
+    );
+}
+
+/// An ASK validator whose WHERE has an `OPTIONAL` (a `LeftJoin` algebra node)
+/// over the FILTER must still pre-bind `$value`/`$this` on the REQUIRED (left)
+/// side, so the constraint evaluates correctly (`push_values_down` LeftJoin arm).
+/// The component flags a value outside the allowed numeric range.
+#[test]
+fn ask_validator_pre_binding_through_left_join() {
+    let shapes = format!(
+        r#"{PREFIXES}
+        {SUBCLASS}
+        ex:RangeComp a ex:MyCC ;
+          sh:parameter [ sh:path ex:maxV ] ;
+          sh:validator [
+            a sh:SPARQLAskValidator ;
+            sh:ask """
+              ASK {{
+                OPTIONAL {{ $this <http://example.org/note> ?n }}
+                FILTER (?value <= $maxV)
+              }}
+            """ ;
+          ] .
+        ex:S a sh:NodeShape ;
+          sh:targetNode 3, 9 ;
+          ex:maxV 5 .
+    "#
+    );
+    // value 9 > 5 -> ASK false -> violation; value 3 <= 5 -> conforms. The
+    // OPTIONAL is a LeftJoin; pre-binding must land on its required (left) side.
+    let data = "@prefix ex: <http://example.org/> . ex:x ex:y ex:z .";
+    let r = run(data, &shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(r.results.len(), 1, "{}", r.to_text());
+    assert!(
+        r.results[0]
+            .value
+            .as_ref()
+            .unwrap()
+            .to_string()
+            .starts_with("\"9\""),
+        "only value 9 violates the <= 5 range: {}",
+        r.to_text()
+    );
+}
+
+/// A component whose validator query is neither ASK nor SELECT in the slot it is
+/// declared for (`sh:ask` carrying a SELECT) is ill-formed and the validator is
+/// not built — the component contributes no violation (fail-closed skip).
+#[test]
+fn mismatched_validator_form_is_skipped() {
+    let shapes = format!(
+        r#"{PREFIXES}
+        {SUBCLASS}
+        ex:BadComp a ex:MyCC ;
+          sh:parameter [ sh:path ex:p ] ;
+          sh:validator [
+            a sh:SPARQLAskValidator ;
+            sh:ask "SELECT $this WHERE {{ $this ?p ?o }}" ;
+          ] .
+        ex:S a sh:NodeShape ;
+          sh:targetNode ex:bob ;
+          ex:p "x" ;
+          sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+    "#
+    );
+    let data = "@prefix ex: <http://example.org/> . ex:bob ex:other \"v\" .";
+    let r = run(data, &shapes);
+    // Only the minCount violation; the SELECT-in-sh:ask validator is not built.
+    assert_eq!(r.results.len(), 1, "{}", r.to_text());
+    assert!(r.results[0]
+        .source_component
+        .ends_with("MinCountConstraintComponent"));
+}

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -360,7 +360,16 @@ the conformance primitive `conforms(data, shapes, shape_node) -> ConformanceChec
 drives the `sht:EvalNodeExpr` suite — all evaluation entries pass; a companion
 harness (`tests/w3c_node_expr_constraints.rs`) drives the suite's two `sht:Validate`
 entries (`sh:expression` / `sh:nodeByExpression`) end-to-end (both self-skip when
-the suite is not fetched).
+the suite is not fetched). Because those W3C harnesses self-skip on a fresh
+checkout, the node-expression **function operators** are also pinned by a
+fixture-independent unit suite (`tests/node_expr_operators.rs`, sq-qcnn) that drives
+every built-in (`concat`/`count`/`sum`/`min`/`max`/`distinct`/`if`/`exists`/`limit`/
+`offset`/`flatMap`/`orderBy`/`findFirst`/`matchAll`/`remove`/`instancesOf`/
+`nodesMatching`/`var` + custom `sh:SPARQLFunction`) through the public
+`eval_node_expression` seam and asserts hand-derived result sets — so the operator
+semantics are gated even when the suite is absent. The SCS parser's fail-closed
+error paths and the SHACL-SPARQL §5.2/§6 edge cases get the same treatment
+(`tests/scs_error_paths.rs` under `scs`, `tests/sparql_edge_cases.rs`).
 
 ## Gotchas / feature flags / prerequisites
 


### PR DESCRIPTION
> 🤖 SPARQ agent — a concrete slice of the test-quality epic **sq-qcnn** (raise per-crate line-coverage toward ≥90% core-logic + kill surviving mutants). Hardening `sparq-shacl`, which is load-bearing for the trust-graph admission gate's shape scoping. **Test-only — no behaviour change.**

## What & why

The W3C suites that exercise `sparq-shacl`'s darkest modules (`func.rs` SHACL-AF function operators, `scs.rs` SCS parser, `sparql.rs` SHACL-SPARQL §5.2/§6) are fetched into a gitignored `tests/shacl/` dir and **self-skip on a fresh checkout** — so those modules ran dark on the per-commit coverage gate. Three **fixture-independent** unit suites now pin the *semantics* (hand-derived conforms/violations from the SHACL spec, not just line-exercise), via the public API, on the real `validate` / `apply_rules` / `eval_node_expression` paths (no mocks):

- **`tests/node_expr_operators.rs`** (`shacl-af`, 28 tests) — every built-in node-expression operator through the public `eval_node_expression` seam: `concat`/`count`/`sum`/`min`/`max`/`distinct`/`if-then-else`/`exists`/`limit`/`offset`/`flatMap`/`orderBy`/`findFirst`/`matchAll`/`remove`/`instancesOf`/`nodesMatching`/`var` + custom `sh:SPARQLFunction`, with the fail-closed paths (non-scalar/blank arg, no `?result` column, arity mismatch, unsupported operand). Includes a test that pins the filter-shape lookup to the real `by_node` id (kills a mutant — see below).
- **`tests/scs_error_paths.rs`** (`scs`, 40 tests) — the parser's fail-closed `ScsError` contract (unterminated IRI/string/array/brace, invalid escape, empty lang tag, undefined prefix, garbage count, stray token) + valid edge constructs (PN_LOCAL_ESC, paths `^`/`/`/`|`/`*+`, datatype-vs-class, typed/lang literals, `sh:or`/`sh:not`, nested bodies, count min-0/max-`*`).
- **`tests/sparql_edge_cases.rs`** (default, 8 tests) — non-SELECT skip, `?value` projected-but-unbound, `?path` IRI-vs-literal mapping, SELECT-validator row `?message` + `sh:message` template substitution, `LeftJoin` pre-binding push-down, mismatched-validator-form skip.

## Coverage (work-box `--all-features`, non-canonical)

| module | before → after (lines) |
|---|---|
| `func.rs` | **56.0% → 94.0%** |
| `scs.rs` | **84.5% → 92.4%** |
| `sparql.rs` | **74.7% → 79.4%** |
| crate TOTAL | **91.0% → 95.5%** |

The per-commit floor gate measures `sparq-shacl` with **default features** (the opt-in `shacl-af`/`scs` surfaces are compiled out), where line% rose **95.41 → 95.88** from the non-feature-gated `sparql_edge_cases.rs`. Floor raised **90 → 93** (`floor(measured) − 2`); the `func.rs`/`scs.rs` gains are behind their opt-in features and do not lift the default-feature floor.

## Mutants

Time-boxed `cargo mutants -p sparq-shacl -f src/func.rs --features shacl-af` (run bounded to save compute): **32 caught / 3 missed / 8 unviable / 0 timeout**. Of the 3 missed:
- 2× `inline_or_named_shape -> Some(0)/Some(1)` — **killed** by the new two-distinct-shape `matchAll` test (verified to fail under the manually-applied mutations, pass on real code).
- 1× `|| -> &&` in `parse_custom_function`'s namespace-skip guard — **left as provably-equivalent**: a `sh:`/`shnex:` predicate is never a declared `sh:SPARQLFunction`, so both branches yield `None`.

## Gates (all green)

- `cargo test -p sparq-shacl` — green across **default / `shacl-af` / `scs` / `--all-features`** legs.
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `cargo fmt` (new files only); `typos` clean; `check-readme-template.py` 0 deviations (README untouched).

No real bug was found (the early test-write failures were my own Turtle/SCS-grammar mistakes, corrected against the real validation path — not implementation defects). No hard-coded perf numbers.

Refs sq-qcnn. Auto-merge intentionally **OFF** (arm via verdict).