### PR TITLE
test(sparq-conformance): wire W3C JSON-LD 1.1 frame ratchet + raise COMPACT_FLOOR 163→186 (sq-oy1f.19/sq-oy1f.16) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -973,26 +973,28 @@ jobs:
             conformance-scoreboard.md
 
   jsonld-conformance:
-    # [OPUS-4.8] sq-oy1f.2 / sq-3uos5 — W3C JSON-LD 1.1 conformance RATCHET (toRdf +
-    # fromRdf + compact), a DEDICATED gating job alongside SPARQL / inference / SHACL
-    # / GeoSPARQL / Solid. The runner is crate-local
+    # [OPUS-4.8] sq-oy1f.2 / sq-3uos5 / sq-oy1f.19 — W3C JSON-LD 1.1 conformance
+    # RATCHET (toRdf + fromRdf + compact + frame), a DEDICATED gating job alongside
+    # SPARQL / inference / SHACL / GeoSPARQL / Solid. The runner is crate-local
     # (crates/sparq-conformance/tests/jsonld_suite.rs) but behind the OPT-IN
     # `jsonld-suite` feature (forwards to sparq-core/jsonld +
     # sparq-engine/serialize-rdf), so it runs ONLY here — the generic
     # `cargo test --workspace` shards build it feature-OFF (a single self-SKIP test,
     # zero oxjsonld/writer code linked: the lean-core posture). This job fetches the
-    # pinned w3c/json-ld-api suite (mirroring the SPARQL/SHACL fetch-then-run split),
-    # runs the runner with the feature ON + --nocapture, and re-checks the printed
-    # `TOTAL toRdf|fromRdf|compact <pass> …` lines as the same belt-and-braces
-    # `>= floor` gate. The runner's own `assert!(pass >= FLOOR)` is the primary gate.
-    # Honest baseline: NOT 100% conformant (remote-context / option / negative
-    # divergences are documented gaps; compact is RDF→compacted-JSON-LD via the native
-    # Compaction Algorithm, gated on a lossless round-trip, with its own honest
-    # below-floor divergence + skip buckets); expand/flatten/framing are reported as
-    # not-implemented buckets and never fail the gate. Never lower the ratchet (raise
-    # TORDF_FLOOR / FROMRDF_FLOOR / COMPACT_FLOOR as oxjsonld + the native
-    # writer/compactor improve).
-    name: W3C JSON-LD 1.1 conformance (ratchet — toRdf >= 413, fromRdf >= 51, compact >= 163)
+    # pinned w3c/json-ld-api suite (toRdf/fromRdf/compact) AND the SEPARATE pinned
+    # w3c/json-ld-framing suite (frame), runs the runner with the feature ON +
+    # --nocapture, and re-checks the printed `TOTAL toRdf|fromRdf|compact|frame
+    # <pass> …` lines as the same belt-and-braces `>= floor` gate. The runner's own
+    # `assert!(pass >= FLOOR)` is the primary gate. Honest baseline: NOT 100%
+    # conformant (remote-context / option / negative divergences are documented gaps;
+    # compact is RDF→compacted-JSON-LD via the native Compaction Algorithm gated on a
+    # lossless round-trip; frame is RDF→framed-JSON-LD via the native Framing
+    # Algorithm gated on RDF-equivalence to the normative expected output, each with
+    # its own honest below-floor divergence + skip buckets); expand/flatten are
+    # reported as not-implemented buckets and never fail the gate. Never lower the
+    # ratchet (raise TORDF_FLOOR / FROMRDF_FLOOR / COMPACT_FLOOR / FRAME_FLOOR as
+    # oxjsonld + the native writer/compactor/framer improve).
+    name: W3C JSON-LD 1.1 conformance (ratchet — toRdf >= 413, fromRdf >= 51, compact >= 186, frame >= 61)
     needs: changes
     if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
@@ -1000,9 +1002,12 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
-      - name: Fetch W3C JSON-LD 1.1 test suite (pinned)
+      - name: Fetch W3C JSON-LD 1.1 API test suite (toRdf/fromRdf/compact, pinned)
         run: ./scripts/fetch-jsonld-tests.sh
-      - name: Run JSON-LD toRdf + fromRdf + compact suites (jsonld-suite feature ON)
+      - name: Fetch W3C JSON-LD 1.1 Framing test suite (frame, pinned)
+        # [OPUS-4.8] sq-oy1f.19 — framing is a SEPARATE W3C repo (w3c/json-ld-framing).
+        run: ./scripts/fetch-jsonld-framing-tests.sh
+      - name: Run JSON-LD toRdf + fromRdf + compact + frame suites (jsonld-suite feature ON)
         # The runner asserts its own pinned floors; capture the scoreboard so the
         # grep gate below re-checks the pass counts.
         run: |
@@ -1012,17 +1017,23 @@ jobs:
         run: |
           TORDF_FLOOR=413
           FROMRDF_FLOOR=51
-          # [OPUS-4.8] sq-3uos5 — the compact ratchet (RDF → compacted JSON-LD,
-          # lossless round-trip). Mirror the toRdf/fromRdf belt-and-braces grep gate.
-          COMPACT_FLOOR=163
+          # [OPUS-4.8] sq-oy1f.16 — RAISED 163 → 186 after #978's compaction
+          # faithfulness fixes (re-measured: 186 pass). Mirror the toRdf/fromRdf
+          # belt-and-braces grep gate.
+          COMPACT_FLOOR=186
+          # [OPUS-4.8] sq-oy1f.19 — the frame ratchet (RDF → framed JSON-LD over the
+          # w3c/json-ld-framing suite; normative-answer-equivalence). Same grep shape.
+          FRAME_FLOOR=61
           # runner prints: "TOTAL toRdf <pass> <fail> <skip> (floor F)"
           TORDF_PASS=$(grep -E '^TOTAL toRdf ' jsonld-conformance.out | awk '{print $3}' | head -1)
           FROMRDF_PASS=$(grep -E '^TOTAL fromRdf ' jsonld-conformance.out | awk '{print $3}' | head -1)
           COMPACT_PASS=$(grep -E '^TOTAL compact ' jsonld-conformance.out | awk '{print $3}' | head -1)
-          echo "JSON-LD toRdf pass: ${TORDF_PASS:-unknown} (floor $TORDF_FLOOR); fromRdf pass: ${FROMRDF_PASS:-unknown} (floor $FROMRDF_FLOOR); compact pass: ${COMPACT_PASS:-unknown} (floor $COMPACT_FLOOR)"
+          FRAME_PASS=$(grep -E '^TOTAL frame ' jsonld-conformance.out | awk '{print $3}' | head -1)
+          echo "JSON-LD toRdf pass: ${TORDF_PASS:-unknown} (floor $TORDF_FLOOR); fromRdf pass: ${FROMRDF_PASS:-unknown} (floor $FROMRDF_FLOOR); compact pass: ${COMPACT_PASS:-unknown} (floor $COMPACT_FLOOR); frame pass: ${FRAME_PASS:-unknown} (floor $FRAME_FLOOR)"
           [ -n "$TORDF_PASS" ] && [ "$TORDF_PASS" -ge "$TORDF_FLOOR" ] || { echo "::error::JSON-LD toRdf regressed below the ratchet (${TORDF_PASS:-?} < $TORDF_FLOOR)"; exit 1; }
           [ -n "$FROMRDF_PASS" ] && [ "$FROMRDF_PASS" -ge "$FROMRDF_FLOOR" ] || { echo "::error::JSON-LD fromRdf regressed below the ratchet (${FROMRDF_PASS:-?} < $FROMRDF_FLOOR)"; exit 1; }
           [ -n "$COMPACT_PASS" ] && [ "$COMPACT_PASS" -ge "$COMPACT_FLOOR" ] || { echo "::error::JSON-LD compact regressed below the ratchet (${COMPACT_PASS:-?} < $COMPACT_FLOOR)"; exit 1; }
+          [ -n "$FRAME_PASS" ] && [ "$FRAME_PASS" -ge "$FRAME_FLOOR" ] || { echo "::error::JSON-LD frame regressed below the ratchet (${FRAME_PASS:-?} < $FRAME_FLOOR)"; exit 1; }
       - name: Emit consolidated conformance scoreboard
         # Render the ONE central scoreboard index (all suites + floors across crates)
         # into this job's step summary, so the JSON-LD job surfaces where it sits in

--- a/crates/sparq-conformance/README.md
+++ b/crates/sparq-conformance/README.md
@@ -8,18 +8,22 @@ result-comparison machinery: `sparq-conformance` (W3C SPARQL query/update/syntax
 `sparq-inference-conformance` (RDF Semantics, OWL 2 RL, N3, entailment regimes via
 `sparq-reason`), and `sparq-conformance-scoreboard` (consolidated index of every
 ratchet — SPARQL, inference, W3C SHACL, OGC GeoSPARQL, Solid WAC + ACP, **W3C
-JSON-LD 1.1 toRdf + fromRdf + compact**, **SolidLab ODRL Test Suite**).
+JSON-LD 1.1 toRdf + fromRdf + compact + frame**, **SolidLab ODRL Test Suite**).
 
 A crate-local `cargo test` ratchet behind the **opt-in `jsonld-suite`** feature
-drives the `w3c/json-ld-api` suite (toRdf + fromRdf + compact); honest divergences
-are reported, never inflated. The **compact** lane (sq-3uos5) parses each
-`jld:CompactTest` input to RDF, runs Compaction against the case `@context`, and
-requires lossless self-reparse (`reparse(compact(D, ctx)) ≡ D`). The ODRL Test
-Suite ratchet (sq-tmsd6) lives in `sparq-policy`; only its FLOOR is mirrored here.
+drives the `w3c/json-ld-api` suite (toRdf + fromRdf + **compact**, lossless
+self-reparse `reparse(compact(D,ctx)) ≡ D`; floor raised 163→186 by sq-oy1f.16) and
+the SEPARATE `w3c/json-ld-framing` suite (**frame**, sq-oy1f.19): each `jld:FrameTest`
+EXPANDED input is framed via the native Framing Algorithm and compared by
+RDF-equivalence to the suite's NORMATIVE expected output (framing is a SELECT+RESHAPE,
+so the oracle anchors on `expected`, not the input). Honest divergences are reported,
+never inflated. The ODRL ratchet (sq-tmsd6) lives in `sparq-policy`; only its FLOOR is
+mirrored here.
 
 > **Internal dev-only harness — not published** (`publish = false`). Test data is
 > fetched by `scripts/fetch-conformance.sh`, `fetch-jsonld-tests.sh`,
-> `fetch-odrl-suite.sh`. Contributing: [`AGENTS.md`](../../AGENTS.md).
+> `fetch-jsonld-framing-tests.sh`, `fetch-odrl-suite.sh`. Contributing:
+> [`AGENTS.md`](../../AGENTS.md).
 
 ## License
 

--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -133,9 +133,14 @@ pub struct Suite {
 ///   `TORDF_FLOOR = 413` (sq-oy1f.2; opt-in `jsonld-suite` feature).
 /// * JSON-LD fromRdf 51 — `sparq-conformance` `tests/jsonld_suite.rs`
 ///   `FROMRDF_FLOOR = 51` (sq-oy1f.2; opt-in `jsonld-suite` feature).
-/// * JSON-LD compact 163 — `sparq-conformance` `tests/jsonld_suite.rs`
-///   `COMPACT_FLOOR = 163` (sq-3uos5; opt-in `jsonld-suite` feature; RDF →
-///   compacted JSON-LD via the native Compaction Algorithm, lossless round-trip).
+/// * JSON-LD compact 186 — `sparq-conformance` `tests/jsonld_suite.rs`
+///   `COMPACT_FLOOR = 186` (sq-3uos5; RAISED 163→186 by sq-oy1f.16 after #978's
+///   faithfulness fixes; opt-in `jsonld-suite` feature; RDF → compacted JSON-LD via
+///   the native Compaction Algorithm, lossless round-trip).
+/// * JSON-LD frame 61 — `sparq-conformance` `tests/jsonld_suite.rs`
+///   `FRAME_FLOOR = 61` (sq-oy1f.19; opt-in `jsonld-suite` feature; RDF → framed
+///   JSON-LD via the native Framing Algorithm over the SEPARATE w3c/json-ld-framing
+///   suite, compared by re-parse RDF-equivalence to the normative expected output).
 /// * Solid WAC differential 0 — `sparq-solid` `tests/differential_oracle.rs`
 ///   `DIVERGENCE_FLOOR = 0` (sq-t58w.8; a divergence-count floor, hard 0 — the WAC
 ///   and ACP differential rows share this one const).
@@ -248,18 +253,21 @@ pub const SUITES: &[Suite] = &[
         note: "engine vs an independent reference evaluator vs the hand Expect table, \
                over the ACP parity corpus (zero divergence)",
     },
-    // [OPUS-4.8] sq-oy1f.2 — the W3C JSON-LD 1.1 API conformance ratchets. The
-    // runner is crate-local here (`tests/jsonld_suite.rs`) but behind the OPT-IN
-    // `jsonld-suite` feature (forwards to sparq-core/jsonld + sparq-engine/
+    // [OPUS-4.8] sq-oy1f.2 / sq-3uos5 / sq-oy1f.19 — the W3C JSON-LD 1.1 conformance
+    // ratchets. The runner is crate-local here (`tests/jsonld_suite.rs`) but behind
+    // the OPT-IN `jsonld-suite` feature (forwards to sparq-core/jsonld + sparq-engine/
     // serialize-rdf) so the default + `--workspace` builds neither link oxjsonld
-    // nor go red — the lean-core posture. Two gated categories: toRdf (JSON-LD →
-    // RDF through the real oxjsonld parse path) and fromRdf (RDF → JSON-LD through
-    // the native serialize-rdf writer, compared by a re-parse round-trip). The
-    // floors are the MEASURED pass counts at the pinned w3c/json-ld-api revision
-    // (NOT 100% — remote-context/option divergences are honest, recorded gaps);
-    // they may only RISE. Compaction/Framing/expand-out/flatten-out are the
-    // documented NOT-IMPLEMENTED buckets the runner reports separately (never
-    // failed). Floors kept in lock-step by `tests/scoreboard_floors.rs`.
+    // nor go red — the lean-core posture. Four gated categories: toRdf (JSON-LD →
+    // RDF through the real oxjsonld parse path), fromRdf (RDF → JSON-LD through the
+    // native serialize-rdf writer, re-parse round-trip), compact (RDF → compacted
+    // JSON-LD via the native Compaction Algorithm, lossless round-trip), and frame
+    // (RDF → framed JSON-LD via the native Framing Algorithm over the SEPARATE
+    // w3c/json-ld-framing suite, RDF-equivalence to the normative expected output).
+    // The floors are the MEASURED pass counts at the pinned suite revisions (NOT
+    // 100% — remote-context/option divergences are honest, recorded gaps); they may
+    // only RISE. expand-out/flatten-out remain the documented NOT-IMPLEMENTED
+    // buckets the runner reports separately (never failed). Floors kept in lock-step
+    // by `tests/scoreboard_floors.rs`.
     Suite {
         label: "W3C JSON-LD 1.1 toRdf",
         family: "W3C JSON-LD",
@@ -272,7 +280,7 @@ pub const SUITES: &[Suite] = &[
         ratchet_floor: 413,
         floor_basis: "pass",
         note: "JSON-LD → RDF through the real oxjsonld parse path (jsonld feature); \
-               framing is a documented not-implemented bucket (compact is now gated)",
+               compact + frame are now gated; expand/flatten remain not-implemented buckets",
     },
     Suite {
         label: "W3C JSON-LD 1.1 fromRdf",
@@ -308,11 +316,41 @@ pub const SUITES: &[Suite] = &[
             feature: "jsonld-suite",
         },
         ci_job: "jsonld-conformance",
-        ratchet_floor: 163,
+        // [OPUS-4.8] sq-oy1f.16 — RAISED 163 → 186 after the #978 compaction
+        // faithfulness fixes landed (re-measured on current main: 186 pass).
+        ratchet_floor: 186,
         floor_basis: "pass",
         note: "RDF → compacted JSON-LD through the native Compaction Algorithm \
                (serialize-rdf), compared by a re-parse RDF-dataset round-trip \
                (lossless-compaction invariant)",
+    },
+    // [OPUS-4.8] sq-oy1f.19 — the W3C JSON-LD 1.1 `frame` ratchet (epic sq-oy1f),
+    // over the SEPARATE w3c/json-ld-framing suite (fetch-jsonld-framing-tests.sh).
+    // Each `jld:FrameTest` input (an arbitrary EXPANDED JSON-LD document) is parsed
+    // to RDF (the real oxjsonld path), framed against the case frame document
+    // through the native hand-rolled Framing Algorithm (`graph_to_jsonld_framed`,
+    // serialize-rdf), then the framed output is re-parsed and required to
+    // reconstruct the SAME RDF dataset as the suite's NORMATIVE expected output
+    // (`reparse(frame(D, F)) ≡ reparse(expected)` — framing is a SELECT+RESHAPE, so
+    // the oracle anchors on the expected document, NOT the input). The floor is the
+    // MEASURED pass count; the remaining cases are honest framer divergences (below
+    // the floor, to RISE) or documented SKIP (the 3 frame-validation negatives
+    // sparq's TOTAL framer does not raise). Floor kept in lock-step by
+    // `tests/scoreboard_floors.rs`.
+    Suite {
+        label: "W3C JSON-LD 1.1 frame",
+        family: "W3C JSON-LD",
+        runner: Runner::FeatureGatedCrateTest {
+            krate: "sparq-conformance",
+            target: "jsonld_suite",
+            feature: "jsonld-suite",
+        },
+        ci_job: "jsonld-conformance",
+        ratchet_floor: 61,
+        floor_basis: "pass",
+        note: "RDF → framed JSON-LD through the native Framing Algorithm \
+               (serialize-rdf) over the w3c/json-ld-framing suite, compared by a \
+               re-parse RDF-equivalence to the normative expected output",
     },
     // [OPUS-4.8] sq-tmsd6 — the SolidLab ODRL Test Suite, wired as a crate-local
     // decision-parity ratchet in sparq-policy (mirrors the Solid WAC/ACP pattern:

--- a/crates/sparq-conformance/tests/jsonld_suite.rs
+++ b/crates/sparq-conformance/tests/jsonld_suite.rs
@@ -3,7 +3,8 @@
 //! conformance gate that mirrors the SPARQL / SHACL / GeoSPARQL / Solid ratchets
 //! in this crate (crate-local `cargo test` + a pinned pass-count FLOOR that may
 //! only RISE, registered in the central `scoreboard::SUITES` and guarded by
-//! `tests/jsonld_floors.rs`).
+//! `tests/scoreboard_floors.rs` — the textual floor-sync guard that pins each
+//! registry `ratchet_floor` to the `const … FLOOR` the runner asserts here).
 //!
 //! ## What is gated (v1) — only what sparq runs TODAY
 //!
@@ -44,18 +45,28 @@
 //! non-string-language shapes is NOT claimed by this ratchet and is tracked
 //! separately (a child of sq-oy1f).
 //!
+//! * **frame** (RDF → framed JSON-LD) — [OPUS-4.8] sq-oy1f.19: each
+//!   `jld:FrameTest` from the SEPARATE `w3c/json-ld-framing` suite (an arbitrary
+//!   EXPANDED JSON-LD input) is parsed to RDF (the real oxjsonld path), framed
+//!   against the case frame document through the native **Framing Algorithm** —
+//!   `sparq_engine::serialize::graph_to_jsonld_framed` (the `serialize-rdf`
+//!   feature) — then re-parsed and required to reconstruct the SAME RDF dataset as
+//!   the suite's NORMATIVE expected output: `reparse(frame(D, F)) ≡ reparse(expected)`.
+//!   Framing is a SELECT + RESHAPE (it prunes/fills/drops), so the oracle anchors on
+//!   the expected document, NOT the input. See `run_frame` for the SKIP buckets (the
+//!   3 frame-validation negatives sparq's TOTAL framer does not raise).
+//!
 //! ## Honest known-gap buckets (NOT failed, recorded as not-implemented)
 //!
-//! `expand`, `flatten`, `html`, `remote-doc`, and `frame` are the algorithm
-//! categories sparq does **not** yet ship as gateable surfaces: Framing is deferred
-//! (a separate W3C rec, sq-oy1f.6); expand/flatten as *output* algorithms are
-//! subsumed by the writer but have no W3C expected-document comparison here yet;
+//! `expand`, `flatten`, `html`, and `remote-doc` are the algorithm categories sparq
+//! does **not** yet ship as gateable surfaces: expand/flatten as *output* algorithms
+//! are subsumed by the writer but have no W3C expected-document comparison here yet;
 //! html/remote-doc need an HTML extractor / a remote `@context` loader. (`compact`
-//! GRADUATED out of this bucket under sq-3uos5 — it is now a gated category above.)
-//! These categories are reported in a separate **not-implemented** column of the
-//! scoreboard and DO NOT fail the gate, so the ratchet measures only what is
-//! shipped and GROWS as those land. The scoreboard prints them honestly as
-//! not-implemented — it does not inflate the pass count.
+//! GRADUATED out of this bucket under sq-3uos5, and `frame` under sq-oy1f.19 — both
+//! are now gated categories above.) These categories are reported in a separate
+//! **not-implemented** column of the scoreboard and DO NOT fail the gate, so the
+//! ratchet measures only what is shipped and GROWS as those land. The scoreboard
+//! prints them honestly as not-implemented — it does not inflate the pass count.
 //!
 //! ## Feature gating (both states)
 //!
@@ -64,9 +75,11 @@
 //! feature OFF this file compiles to a single self-SKIP `#[test]` (no oxjsonld /
 //! writer code links), so the default `cargo test -p sparq-conformance` and the
 //! `--workspace` shards stay green and lean. With it ON the runner executes and
-//! asserts the pinned floors. The suite fixtures are fetched by
-//! `scripts/fetch-jsonld-tests.sh` into the gitignored `tests/w3c/json-ld-api/`;
-//! when absent the runner SKIPS itself so a fresh offline checkout stays green.
+//! asserts the pinned floors. The toRdf/fromRdf/compact fixtures are fetched by
+//! `scripts/fetch-jsonld-tests.sh` into the gitignored `tests/w3c/json-ld-api/`,
+//! and the frame fixtures by `scripts/fetch-jsonld-framing-tests.sh` into
+//! `tests/w3c/json-ld-framing/`; when either is absent the runner SKIPS that lane
+//! so a fresh offline checkout stays green.
 //!
 //! Manifest-walking helpers are modelled on this crate's SPARQL machinery and on
 //! `sparq-shacl`'s W3C runner (copied, not shared). Comparison uses oxrdf's
@@ -94,13 +107,14 @@ mod gated {
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
 
-    // ---- Floors (the RATCHET). Calibrated against the pinned suite revision in
-    // scripts/fetch-jsonld-tests.sh; MIRRORED in the central scoreboard
+    // ---- Floors (the RATCHET). Calibrated against the pinned suite revisions in
+    // scripts/fetch-jsonld-tests.sh (toRdf/fromRdf/compact) + scripts/
+    // fetch-jsonld-framing-tests.sh (frame); MIRRORED in the central scoreboard
     // (scoreboard::SUITES) and read textually by the guard test
-    // tests/jsonld_floors.rs. They may only RISE — never lower them (raise as
+    // tests/scoreboard_floors.rs. They may only RISE — never lower them (raise as
     // oxjsonld coverage / the native writer improve). These are the ACTUAL
-    // current pass counts at the pinned revision, not aspirational targets.
-    // The `tests/jsonld_floors.rs` floor-sync guard reads these `const … : usize
+    // current pass counts at the pinned revisions, not aspirational targets.
+    // The `tests/scoreboard_floors.rs` floor-sync guard reads these `const … : usize
     // = N;` lines textually (the same shape as SHACL's `BASELINE_PASS`), so the
     // central scoreboard can never silently drift from what this runner asserts.
 
@@ -128,15 +142,71 @@ mod gated {
     /// redefinition errors, processing-mode error-raising), and those are SKIPPED
     /// (not failed) — see `run_compact` for the honest skip buckets.
     ///
-    /// Measured 163/246 at the pinned revision: 163 lossless round-trips, 58 honest
-    /// compaction divergences (the `@type:@id`-coerced-key-vs-plain-string IRI
-    /// confusion; `@graph`/`@index`/`@id`/`@language` container round-trips the
-    /// hand-rolled writer does not fully reproduce; scoped/typed-context shapes), and
-    /// 25 SKIP (negatives sparq does not raise, JSON-LD-1.0-only cases, non-inline /
-    /// remote / multi `@context`, and empty-RDF inputs). The 58 divergences are real
-    /// writer gaps below the floor, not harness artefacts — they are tracked for a
-    /// future floor RISE (a child of sq-oy1f).
-    pub const COMPACT_FLOOR: usize = 163;
+    /// [OPUS-4.8] sq-oy1f.16 — RAISED 163 → 186 after the compaction faithfulness
+    /// fixes (#978, sq-oy1f.12/.13/.14: `@reverse` double-invert, non-string
+    /// `@language`/`@none`, `@type:@id`-coerced-key-vs-plain-string IRI confusion,
+    /// container round-trips) landed on main. Re-MEASURED on current main at the
+    /// pinned revision: compact 186 pass / 35 fail / 25 skip (was 163/58/25). The
+    /// +23 FAIL→PASS are the cases those writer fixes made lossless. The 35
+    /// remaining failures are real writer gaps below the floor (scoped/typed
+    /// contexts, `@nest`, `@index`/`@id` map shapes the writer does not emit),
+    /// tracked for a future RISE; the 25 SKIP are unchanged (negatives sparq does
+    /// not raise, JSON-LD-1.0-only, non-inline/remote/multi `@context`, empty-RDF).
+    pub const COMPACT_FLOOR: usize = 186;
+
+    /// [OPUS-4.8] sq-oy1f.19 — `frame` (RDF → framed+compacted JSON-LD via the
+    /// native hand-rolled Framing Algorithm) pass floor over the SEPARATE
+    /// `w3c/json-ld-framing` suite (`scripts/fetch-jsonld-framing-tests.sh`).
+    /// RATCHET: may only RISE. This is the MEASURED pass count at the pinned
+    /// framing-suite revision — the number of `jld:FrameTest` cases for which
+    /// framing the input's RDF against the case frame document and re-parsing the
+    /// framed output reconstructs the SAME RDF dataset as re-parsing the suite's
+    /// NORMATIVE expected output (`reparse(frame(D, F)) ≡ reparse(expected)`).
+    ///
+    /// ## Why compare against `expect`, not the input
+    ///
+    /// Framing is a SELECT + RESHAPE, not a lossless transform: `@explicit` prunes
+    /// properties, an unmatched frame yields an empty `@graph`, `@default` fills a
+    /// value not in the input. So `reparse(frame(D)) ≡ D` is the WRONG oracle (the
+    /// framed RDF legitimately differs from the input). The normative answer is the
+    /// suite's `*-out.jsonld`; sparq must produce the SAME RDF as that expected
+    /// document. Comparing the two as canonical RDF datasets is envelope-insensitive
+    /// (both the bare-node `omitGraph` collapse and the `{"@graph":[…]}` envelope
+    /// re-parse to the same triples) and value-faithful, while NOT requiring sparq's
+    /// JSON layout to match pyld byte-for-byte (it does not — the same posture as
+    /// the toRdf/fromRdf/compact lanes).
+    ///
+    /// ## Honest SKIP buckets (recorded, not passed, not failed)
+    ///
+    /// * NegativeEvaluationTests (`expectErrorCode`) — sparq's framer is TOTAL; it
+    ///   never raises the spec's frame-validation errors (`invalid frame`, out-of-
+    ///   range `@embed`). A 1.1 framer that does not model those errors cannot
+    ///   honestly "pass" by rejecting, so these are SKIPPED (the compact-lane posture).
+    /// * A positive case with no `expect`, a non-object `frame`, an `input` the real
+    ///   oxjsonld path rejects, or a remote `input`/`frame` URL — out of the gated
+    ///   surface (SKIP, never a counted pass).
+    ///
+    /// Note: the `ordered` option (1 case) governs JSON-array element ORDER, a
+    /// concern the RDF-level oracle is blind to by design — such a case is still
+    /// gated on RDF equality and passes iff the framed RDF matches the expected RDF,
+    /// the honest verdict an RDF oracle can give.
+    ///
+    /// MEASURED 61/92 at the pinned framing-suite revision: 61 normative
+    /// RDF-equivalent frames, 28 honest framer divergences (value-pattern matching
+    /// over `@value` alternative arrays, `@explicit`/`@default` fill differences,
+    /// named-graph `@graph` framing shapes, `@list`/`@set` re-emit, blank-node
+    /// `@embed` table edge cases), and 3 SKIP (the suite's 3 NegativeEvaluationTests
+    /// — sparq's TOTAL framer does not raise the spec's frame-validation errors).
+    /// The 28 divergences are real framer gaps below the floor (tracked for a future
+    /// RISE — a child of sq-oy1f); SKIP is reserved for genuinely-unsupported cases,
+    /// never used to hide a divergence.
+    pub const FRAME_FLOOR: usize = 61;
+
+    /// [OPUS-4.8] sq-oy1f.19 — the framing suite's declared base (its
+    /// `baseIri`), used to resolve each frame test's input path into the document
+    /// IRI. Distinct from `SUITE_BASE` (the json-ld-api base) — framing is a
+    /// separate W3C repo.
+    const FRAME_SUITE_BASE: &str = "https://w3c.github.io/json-ld-framing/tests/";
 
     /// The suite's declared base for resolving each test's input path into the
     /// document IRI (the toRdf base when `option.base` is absent).
@@ -146,6 +216,14 @@ mod gated {
         // CARGO_MANIFEST_DIR = crates/sparq-conformance; the workspace root is two up.
         PathBuf::from(env!("CARGO_MANIFEST_DIR"))
             .join("../../tests/w3c/json-ld-api/tests")
+    }
+
+    /// [OPUS-4.8] sq-oy1f.19 — the SEPARATE `w3c/json-ld-framing` suite root
+    /// (`scripts/fetch-jsonld-framing-tests.sh`). Framing lives in its own W3C
+    /// repo, not under `json-ld-api`.
+    fn frame_suite_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tests/w3c/json-ld-framing/tests")
     }
 
     #[derive(Default)]
@@ -221,6 +299,17 @@ mod gated {
         /// model (it is not a faithful pass for a 1.1 processor to "reject" them).
         spec_version: Option<String>,
         processing_mode: Option<String>,
+        /// [OPUS-4.8] sq-oy1f.19 — the `frame` manifest's top-level `frame`
+        /// member: a path (relative to the suite root) to the sibling
+        /// `*-frame.jsonld` document (the frame pattern + its `@context`) to frame
+        /// the input against. `None` for the toRdf/fromRdf/compact manifests.
+        frame: Option<String>,
+        /// [OPUS-4.8] sq-oy1f.19 — a NegativeEvaluationTest's expected JSON-LD
+        /// error code (`invalid frame`, `invalid @embed value`, …). Recorded so the
+        /// frame runner can SKIP the error-raising negatives sparq's TOTAL framer
+        /// does not model (it never raises the spec's frame-validation errors), the
+        /// same honesty posture the compact lane takes toward its negatives.
+        expect_error_code: Option<String>,
     }
 
     /// Read `<cat>-manifest.jsonld` and return its `sequence` entries.
@@ -281,6 +370,15 @@ mod gated {
                 .and_then(|o| o.get("processingMode"))
                 .and_then(Value::as_str)
                 .map(str::to_string);
+            // [OPUS-4.8] sq-oy1f.19 — frame-only manifest members (None elsewhere).
+            let frame = e
+                .get("frame")
+                .and_then(Value::as_str)
+                .map(str::to_string);
+            let expect_error_code = e
+                .get("expectErrorCode")
+                .and_then(Value::as_str)
+                .map(str::to_string);
             out.push(Entry {
                 id,
                 is_negative,
@@ -291,6 +389,8 @@ mod gated {
                 context,
                 spec_version,
                 processing_mode,
+                frame,
+                expect_error_code,
             });
         }
         Ok(out)
@@ -686,14 +786,184 @@ mod gated {
         s
     }
 
+    /// [OPUS-4.8] sq-oy1f.19 — the base/document IRI for a `frame` test: the
+    /// `option.base` override if given, else the framing suite base joined with the
+    /// input path. (Distinct from `doc_base`, which uses the json-ld-api base.)
+    fn frame_doc_base(e: &Entry) -> String {
+        e.base_override
+            .clone()
+            .unwrap_or_else(|| format!("{}{}", FRAME_SUITE_BASE, e.input))
+    }
+
+    /// [OPUS-4.8] sq-oy1f.19 — run the SEPARATE W3C `w3c/json-ld-framing` suite
+    /// against sparq's hand-rolled Framing Algorithm (`sparq_engine::serialize::
+    /// graph_to_jsonld_framed`, the `serialize-rdf` feature).
+    ///
+    /// ## Pipeline (the REAL framing path)
+    ///
+    /// 1. Parse the case `input` (an arbitrary EXPANDED/`@graph` JSON-LD document) →
+    ///    RDF via the real oxjsonld ingest path (`parse_jsonld_dataset`). This is the
+    ///    expanded-document framing ENTRY PATH the bead asked for: the framer takes a
+    ///    `Graph`, not a JSON-LD doc, so the suite's expanded input is reduced to its
+    ///    RDF and loaded into a `Graph` — exactly the bridge `run_compact` uses.
+    /// 2. Read the case `frame` document (`*-frame.jsonld`: the frame pattern + its
+    ///    `@context`) with the writer's own JSON reader.
+    /// 3. Run `graph_to_jsonld_framed(&graph, &frame)`.
+    /// 4. **Invariant (normative answer-equivalence):** re-parse BOTH sparq's framed
+    ///    output AND the suite's NORMATIVE expected output (`*-out.jsonld`) to
+    ///    canonical [`Dataset`]s and require they are equal —
+    ///    `reparse(frame(D, F)) ≡ reparse(expected)`. Framing is a SELECT + RESHAPE
+    ///    (it legitimately prunes / fills / drops), so the oracle anchors on the
+    ///    W3C-expected framed document, NOT the input (see `FRAME_FLOOR`). This is
+    ///    envelope-insensitive and value-faithful while not requiring byte-identical
+    ///    JSON layout (the same oxjsonld self-reparse oracle the other lanes use).
+    ///
+    /// ## Honest SKIP buckets (recorded, not passed, not failed)
+    ///
+    /// * `requires` optional-feature cases — out of the gated surface.
+    /// * NegativeEvaluationTests (`expectErrorCode`) — sparq's framer is TOTAL and
+    ///   never raises the spec's frame-validation errors, so it cannot honestly
+    ///   "pass" by rejecting. SKIP (the compact-lane posture), never a counted pass.
+    /// * A positive case with no `expect` document, or whose `expect` the real
+    ///   oxjsonld path cannot re-parse (out of the gated surface) — SKIP.
+    /// * Remote `input`/`frame` URLs — none in the pinned suite, but guarded (SKIP).
+    fn run_frame(root: &Path) -> Score {
+        use sparq_engine::serialize::{graph_to_jsonld_framed, parse_context_json};
+        let mut s = Score::default();
+        let entries = match read_manifest(root, "frame") {
+            Ok(e) => e,
+            Err(why) => {
+                s.fail("frame-manifest", why);
+                return s;
+            }
+        };
+        for e in &entries {
+            if e.requires.is_some() {
+                s.skip();
+                continue;
+            }
+            // NegativeEvaluationTest: sparq's framer does not raise the spec's
+            // frame-validation errors, so a faithful 1.1 framer cannot "pass" by
+            // rejecting — SKIP (honest), never count as a pass.
+            if e.is_negative || e.expect_error_code.is_some() {
+                s.skip();
+                continue;
+            }
+            let Some(frame_rel) = &e.frame else {
+                s.skip();
+                continue;
+            };
+            let Some(expect_rel) = &e.expect else {
+                s.skip();
+                continue;
+            };
+            // Remote input/frame (no network) — none in the pinned suite; guard.
+            if e.input.starts_with("http://")
+                || e.input.starts_with("https://")
+                || frame_rel.starts_with("http://")
+                || frame_rel.starts_with("https://")
+            {
+                s.skip();
+                continue;
+            }
+
+            // 1. Parse the EXPANDED input document → RDF (the framing input).
+            let input_path = root.join(&e.input);
+            let in_text = match std::fs::read_to_string(&input_path) {
+                Ok(t) => t,
+                Err(why) => {
+                    s.fail(&e.id, format!("read input: {why}"));
+                    continue;
+                }
+            };
+            let base = frame_doc_base(e);
+            let input_ds = match parse_jsonld_dataset(&in_text, &base) {
+                Ok(ds) => ds,
+                // An input the real oxjsonld path rejects is out of scope for the
+                // framing round-trip (the toRdf lane gates ingest) — SKIP.
+                Err(_) => {
+                    s.skip();
+                    continue;
+                }
+            };
+
+            // 2. Read the frame document (the whole frame JSON: pattern + @context).
+            let frame_path = root.join(frame_rel);
+            let frame_text = match std::fs::read_to_string(&frame_path) {
+                Ok(t) => t,
+                Err(why) => {
+                    s.fail(&e.id, format!("read frame: {why}"));
+                    continue;
+                }
+            };
+            let Some(frame) = parse_context_json(&frame_text) else {
+                // A non-object frame (array/string) is not drivable through the
+                // single-object framer entry — SKIP.
+                s.skip();
+                continue;
+            };
+
+            // 3. Load the input RDF into a sparq Graph (named graphs preserved) and
+            //    run the REAL framing writer over the expanded-document-derived RDF.
+            let nq = dataset_to_nquads(&input_ds);
+            let graph = match Graph::load_dataset(&nq, "nquads") {
+                Ok(g) => g,
+                Err(why) => {
+                    s.fail(&e.id, format!("load input rdf into graph: {why}"));
+                    continue;
+                }
+            };
+            let framed = graph_to_jsonld_framed(&graph, &frame);
+
+            // 4. The normative answer-equivalence invariant: re-parse BOTH sparq's
+            //    framed output and the suite's expected output, require RDF equality.
+            let got = match jsonld_to_canonical_dataset(&framed, &base) {
+                Ok(ds) => ds,
+                Err(why) => {
+                    s.fail(&e.id, format!("re-parse framed output: {why}"));
+                    continue;
+                }
+            };
+            let expect_path = root.join(expect_rel);
+            let exp_text = match std::fs::read_to_string(&expect_path) {
+                Ok(t) => t,
+                Err(why) => {
+                    s.fail(&e.id, format!("read expect: {why}"));
+                    continue;
+                }
+            };
+            let want = match jsonld_to_canonical_dataset(&exp_text, &base) {
+                Ok(ds) => ds,
+                Err(why) => {
+                    s.fail(&e.id, format!("re-parse expected output: {why}"));
+                    continue;
+                }
+            };
+            if got == want {
+                s.pass();
+            } else {
+                s.fail(
+                    &e.id,
+                    format!(
+                        "framed RDF != expected RDF ({} vs {} quads)",
+                        got.len(),
+                        want.len()
+                    ),
+                );
+            }
+        }
+        s
+    }
+
     /// The known-gap categories: present in the W3C suite but NOT a sparq-shipped
     /// gateable surface yet. Reported as not-implemented (never failed). The size
     /// is read from each manifest so the scoreboard shows the real backlog and
     /// shrinks honestly as categories light up.
     ///
     /// [OPUS-4.8] sq-3uos5 — `compact` GRADUATED out of this bucket: it is now a
-    /// gated category (`run_compact`, `COMPACT_FLOOR`). `frame` stays deferred
-    /// (a separate W3C rec, sq-oy1f.6).
+    /// gated category (`run_compact`, `COMPACT_FLOOR`). [OPUS-4.8] sq-oy1f.19 —
+    /// `frame` likewise GRADUATED: it is now a gated category (`run_frame`,
+    /// `FRAME_FLOOR`) over the separate `w3c/json-ld-framing` suite.
     const NOT_IMPLEMENTED_CATS: &[(&str, &str)] = &[
         ("expand", "Expansion — output-vs-W3C-document comparison not wired (sq-oy1f)"),
         ("flatten", "Flattening — output-vs-W3C-document comparison not wired (sq-oy1f)"),
@@ -726,7 +996,16 @@ mod gated {
         let compact = run_compact(&root);
         let not_impl = not_implemented_counts(&root);
 
-        println!("\nW3C JSON-LD 1.1 conformance scoreboard (pinned w3c/json-ld-api)");
+        // [OPUS-4.8] sq-oy1f.19 — framing lives in the SEPARATE w3c/json-ld-framing
+        // suite (scripts/fetch-jsonld-framing-tests.sh), which a checkout may have
+        // independently of json-ld-api. Run it only when present; otherwise the
+        // `frame` line reports "suite absent" and the frame ratchet is not asserted
+        // (a fresh offline checkout stays green). When present, the FRAME_FLOOR
+        // ratchet is asserted below.
+        let frame_root = frame_suite_root();
+        let frame = frame_root.exists().then(|| run_frame(&frame_root));
+
+        println!("\nW3C JSON-LD 1.1 conformance scoreboard (pinned w3c/json-ld-api + json-ld-framing)");
         println!("{:<10} {:>5} {:>5} {:>5}", "category", "pass", "fail", "skip");
         // [OPUS-4.8] The CI ratchet greps these `TOTAL <cat>` lines.
         println!(
@@ -743,11 +1022,24 @@ mod gated {
             "TOTAL compact {} {} {} (floor {})",
             compact.pass, compact.fail, compact.skip, COMPACT_FLOOR
         );
+        // [OPUS-4.8] sq-oy1f.19 — the frame ratchet. The CI grep depends on this
+        // exact `^TOTAL frame ` prefix with the pass count in field $3 (same shape
+        // as the other lanes). Printed only when the framing suite is present.
+        if let Some(frame) = &frame {
+            println!(
+                "TOTAL frame {} {} {} (floor {})",
+                frame.pass, frame.fail, frame.skip, FRAME_FLOOR
+            );
+        } else {
+            println!(
+                "frame      (suite absent — run scripts/fetch-jsonld-framing-tests.sh; floor {})",
+                FRAME_FLOOR
+            );
+        }
         println!("\nknown-gap (NOT-IMPLEMENTED — not gated, grows the ratchet as they land):");
         for (cat, why) in NOT_IMPLEMENTED_CATS {
             println!("  {:<10} {:>4} tests — {}", cat, not_impl.get(cat).copied().unwrap_or(0), why);
         }
-        println!("  frame      (separate W3C rec — deferred, sq-oy1f.6)");
 
         if !tordf.failures.is_empty() {
             println!("\ntoRdf failures (first 40):");
@@ -765,6 +1057,14 @@ mod gated {
             println!("\ncompact failures (first 40):");
             for (id, why) in compact.failures.iter().take(40) {
                 println!("  {}: {}", id, why);
+            }
+        }
+        if let Some(frame) = &frame {
+            if !frame.failures.is_empty() {
+                println!("\nframe failures (first 40):");
+                for (id, why) in frame.failures.iter().take(40) {
+                    println!("  {}: {}", id, why);
+                }
             }
         }
 
@@ -789,5 +1089,15 @@ mod gated {
             compact.pass,
             COMPACT_FLOOR
         );
+        // [OPUS-4.8] sq-oy1f.19 — the frame ratchet (normative answer-equivalence
+        // floor), asserted only when the separate framing suite is present.
+        if let Some(frame) = &frame {
+            assert!(
+                frame.pass >= FRAME_FLOOR,
+                "JSON-LD frame pass count regressed: {} < floor {} — see failures above",
+                frame.pass,
+                FRAME_FLOOR
+            );
+        }
     }
 }

--- a/crates/sparq-conformance/tests/scoreboard_floors.rs
+++ b/crates/sparq-conformance/tests/scoreboard_floors.rs
@@ -127,6 +127,15 @@ const CRATE_LOCAL_FLOORS: &[(&str, &str, &str)] = &[
         "crates/sparq-conformance/tests/jsonld_suite.rs",
         "COMPACT_FLOOR",
     ),
+    // [OPUS-4.8] sq-oy1f.19 — the W3C JSON-LD 1.1 `frame` ratchet over the SEPARATE
+    // w3c/json-ld-framing suite. `pub const FRAME_FLOOR` lives in the same
+    // `tests/jsonld_suite.rs`; the guard reads it textually so the central
+    // scoreboard's `ratchet_floor` can never drift from what the runner asserts.
+    (
+        "W3C JSON-LD 1.1 frame",
+        "crates/sparq-conformance/tests/jsonld_suite.rs",
+        "FRAME_FLOOR",
+    ),
     // [OPUS-4.8] sq-tmsd6 — the SolidLab ODRL Test Suite decision-parity ratchet.
     // The floor const (`pub const ODRL_SUITE_FLOOR`) lives top-level in
     // `sparq-policy`'s `tests/odrl_test_suite.rs`; the guard reads it textually

--- a/scripts/fetch-jsonld-framing-tests.sh
+++ b/scripts/fetch-jsonld-framing-tests.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] sq-oy1f.19 — fetches the official W3C JSON-LD 1.1 Framing test suite
+# (github.com/w3c/json-ld-framing) at a PINNED commit into the gitignored
+# tests/w3c/json-ld-framing directory. Framing is a SEPARATE W3C repo from the
+# JSON-LD API suite (toRdf/fromRdf/compact live in w3c/json-ld-api, fetched by
+# scripts/fetch-jsonld-tests.sh); the frame manifest + fixtures live here.
+# Mirrors scripts/fetch-jsonld-tests.sh: test data is never committed — run this
+# before the JSON-LD `frame` conformance runner. The runner SKIPS itself when the
+# suite is absent, so a fresh checkout stays green offline.
+set -euo pipefail
+
+# Pinned w3c/json-ld-framing commit (main, 2026-06). Bump deliberately: the
+# JSON-LD framing pass-count floor (FRAME_FLOOR) in
+# crates/sparq-conformance/tests/jsonld_suite.rs is calibrated against THIS suite
+# revision — pass counts are only comparable across runs when the suite is fixed.
+PIN="3bf782ba9a40dd1b143435abe386d38df64f2b47"
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DEST="$ROOT/tests/w3c/json-ld-framing"
+
+if [ -d "$DEST/.git" ]; then
+    HAVE="$(git -C "$DEST" rev-parse HEAD)"
+    if [ "$HAVE" = "$PIN" ]; then
+        echo "json-ld-framing already at pinned commit $PIN — nothing to do."
+        exit 0
+    fi
+    echo "json-ld-framing present at $HAVE, re-pinning to $PIN…"
+    git -C "$DEST" fetch --depth 1 origin "$PIN"
+    git -C "$DEST" checkout --detach "$PIN"
+    exit 0
+fi
+
+mkdir -p "$(dirname "$DEST")"
+echo "Cloning w3c/json-ld-framing (shallow) into tests/w3c/json-ld-framing…"
+git clone --depth 1 https://github.com/w3c/json-ld-framing "$DEST"
+if [ "$(git -C "$DEST" rev-parse HEAD)" != "$PIN" ]; then
+    git -C "$DEST" fetch --depth 1 origin "$PIN"
+    git -C "$DEST" checkout --detach "$PIN"
+fi
+echo "json-ld-framing pinned at $PIN."

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -346,9 +346,13 @@ Output is a `{"@context":…,"@graph":[…]}` document, collapsing to the bare f
 `@context` for a single matched root (the `omitGraph` default). Each named graph in the dataset is
 framed against the same pattern (wrapped `{"@id":<graph>,"@graph":[…]}`). The framed shape is
 **differential-tested byte-for-byte against the pyld reference processor's `frame`** across the
-flag matrix (sq-oy1f.17). *Scope:* the serialise (fromRdf-then-frame) path — sparq supplies the
-graph + an inline frame; `@reverse` frames, scoped/typed frame contexts, and exact pyld
-`@graph`-frame semantics over an arbitrary expanded document are out of scope (follow-up beads).
+flag matrix (sq-oy1f.17), and **ratcheted against the official `w3c/json-ld-framing` suite**
+(sq-oy1f.19; see the conformance bullet below) — each `jld:FrameTest` expanded input is framed and
+compared by RDF-equivalence to the normative expected output, which quantifies the real gap. *Scope:*
+the serialise (fromRdf-then-frame) path — sparq supplies the graph + an inline frame. The W3C suite
+documents the current below-floor divergences honestly (value-pattern matching over `@value`
+alternative arrays, some `@explicit`/`@default` and named-graph `@graph`-frame shapes); `@reverse`
+frames and scoped/typed frame contexts remain follow-up beads (children of sq-oy1f).
 
 ```rust
 use sparq_engine::serialize::{graph_to_jsonld_framed, parse_context_json};
@@ -441,32 +445,41 @@ cargo build -p sparq-cli --features serialize-rdf
   in all in-memory paths; `into_compressed()` / `load_str_compressed()` trade a small
   per-scan decode for ~2.5× more triples per byte of RAM (browser target).
 - **JSON-LD W3C conformance is RATCHETED (honest baseline, not 100%).** A ratcheted W3C
-  JSON-LD 1.1 API conformance gate (sq-oy1f.2 + sq-3uos5) drives the official `w3c/json-ld-api`
-  suite through the real paths: **toRdf** through the `jsonld` parser (oxjsonld), **fromRdf**
-  through the `serialize-rdf` writer, and **compact** through the native Compaction Algorithm
-  (`graph_to_jsonld_compact`) — each compared by a re-parse RDF-dataset round-trip
-  (`reparse(out) ≡ in`, the same oxjsonld self-reparse oracle for all three). The floors only
-  RISE; they reflect ACTUAL current pass counts, not full conformance — the remaining toRdf
-  divergences are documented oxjsonld limits (remote/`@import` `@context` needs a
+  JSON-LD 1.1 conformance gate (sq-oy1f.2 + sq-3uos5 + sq-oy1f.19) drives the official
+  `w3c/json-ld-api` suite AND the SEPARATE `w3c/json-ld-framing` suite through the real paths:
+  **toRdf** through the `jsonld` parser (oxjsonld), **fromRdf** through the `serialize-rdf`
+  writer, **compact** through the native Compaction Algorithm (`graph_to_jsonld_compact`), and
+  **frame** through the native Framing Algorithm (`graph_to_jsonld_framed`). toRdf/fromRdf/compact
+  are compared by a re-parse RDF-dataset round-trip against the INPUT (`reparse(out) ≡ in`, the
+  oxjsonld self-reparse oracle); **frame** is compared by re-parse RDF-equivalence against the
+  suite's NORMATIVE expected output (`reparse(frame(D,F)) ≡ reparse(expected)`) — framing is a
+  SELECT+RESHAPE (it prunes/fills/drops), so the oracle anchors on the expected document, not the
+  input. The floors only RISE; they reflect ACTUAL current pass counts, not full conformance — the
+  remaining toRdf divergences are documented oxjsonld limits (remote/`@import` `@context` needs a
   `LoadDocumentCallback`; `expandContext`/`rdfDirection` options not applied; a few
   base-normalization edge cases + leniently-accepted negative tests), and fromRdf misses
   lists whose cells are shared across graphs. The **compact** lane gates on **lossless
   compaction** (parse input → RDF, compact against the case `@context`, require the
-  re-parse to reconstruct the SAME RDF); at the pinned revision a documented share of cases
-  is below the floor (the `@type:@id`-coerced-key-vs-plain-string IRI confusion; the
-  `@graph`/`@index`/`@id`/`@language` multi-value container round-trips the hand-rolled
-  writer does not yet reproduce) and several are SKIPPED (negatives sparq's TOTAL compaction
-  does not raise; JSON-LD-1.0-only; non-inline/remote `@context`; empty-RDF inputs). The
-  compact oracle is oxjsonld self-reparse, so the `@reverse` double-inversion /
-  non-string-language interop gap documented above (the compaction interop caveat) is NOT
-  caught by it and is tracked separately. **Framing, and expand/flatten output-document
-  comparison remain NOT-IMPLEMENTED buckets** the runner reports separately and never fails on
-  (they grow the ratchet as those land — Framing is sq-oy1f.6). The lane is the opt-in
+  re-parse to reconstruct the SAME RDF); the floor was raised by sq-oy1f.16 after the #978
+  faithfulness fixes (the `@type:@id`-coerced-key-vs-plain-string IRI confusion and several
+  container round-trips became lossless), with the rest still below the floor (scoped/typed
+  contexts, `@nest`, `@index`/`@id` map shapes the writer does not emit) and several SKIPPED
+  (negatives sparq's TOTAL compaction does not raise; JSON-LD-1.0-only; non-inline/remote
+  `@context`; empty-RDF inputs). The **frame** lane (over the separate framing suite) gates the
+  89 positive `jld:FrameTest` cases; below-floor cases are genuine framer divergences (value-pattern
+  matching over `@value` alternative arrays, `@explicit`/`@default` fill differences, named-graph
+  `@graph` framing shapes, `@list`/`@set` re-emit) tracked for a future RISE, and the 3
+  NegativeEvaluationTests are SKIPPED (sparq's framer is TOTAL — it never raises the spec's
+  frame-validation errors, so it cannot honestly "pass" by rejecting). The compact/frame oracle
+  is oxjsonld self-reparse, so the `@reverse` double-inversion / non-string-language interop gap
+  documented above (the compaction interop caveat) is NOT caught by it and is tracked separately.
+  **expand/flatten output-document comparison remain NOT-IMPLEMENTED buckets** the runner reports
+  separately and never fails on (they grow the ratchet as those land). The lane is the opt-in
   `jsonld-suite` feature on `sparq-conformance` (forwards to `sparq-core/jsonld` +
   `sparq-engine/serialize-rdf`); OFF it compiles to a self-skip. Reproduce with
-  `scripts/fetch-jsonld-tests.sh` then
+  `scripts/fetch-jsonld-tests.sh` + `scripts/fetch-jsonld-framing-tests.sh` then
   `cargo test -p sparq-conformance --features jsonld-suite --test jsonld_suite` (self-skips if
-  the gitignored suite is absent). It is registered in the central conformance scoreboard
+  the gitignored suites are absent). It is registered in the central conformance scoreboard
   (`sparq-conformance-scoreboard`).
 
 ## See also


### PR DESCRIPTION
> 🤖 SPARQ agent — two JSON-LD conformance-ratchet follow-ups under epic **sq-oy1f**, now unblocked since framing (#984) + compaction-faithfulness (#978) + the compact ratchet (#969) all merged.

## What this does

### sq-oy1f.19 — gate the W3C JSON-LD 1.1 **Framing** suite
Wires the **SEPARATE** `w3c/json-ld-framing` test suite (92 cases) as a ratcheted gate in `crates/sparq-conformance/tests/jsonld_suite.rs`, mirroring the toRdf/fromRdf/compact lanes (opt-in `jsonld-suite` feature + CI grep ratchet + `scoreboard_floors` guard):

- **New `scripts/fetch-jsonld-framing-tests.sh`** — pinned fetch (framing is its own W3C repo, not under `json-ld-api`).
- **`run_frame`** — the **expanded-document framing entry path** the bead asked for: each `jld:FrameTest` EXPANDED input is parsed to RDF via the real oxjsonld path, loaded into a `Graph`, framed through the native `graph_to_jsonld_framed`, then re-parsed and required to reconstruct the **SAME RDF dataset as re-parsing the suite's NORMATIVE expected output**: `reparse(frame(D, F)) ≡ reparse(expected)`.
- **Why compare against `expect`, not the input:** framing is a SELECT + RESHAPE (it prunes via `@explicit`, fills via `@default`, drops on no-match), so `reparse(frame(D)) ≡ D` is the WRONG oracle. The oracle anchors on the W3C-normative `*-out.jsonld` — envelope-insensitive and value-faithful, not requiring byte-identical JSON layout (the same posture as the other lanes).

**Honest measurement** at the pinned revision: **frame 61 pass / 28 fail / 3 skip**. All 89 positives are attempted (61 pass, 28 fail); the 3 `NegativeEvaluationTest`s are **SKIPPED** (sparq's framer is TOTAL — it never raises the spec's frame-validation errors, so it cannot honestly "pass" by rejecting). `FRAME_FLOOR = 61`. The 28 below-floor cases are **real framer divergences** (value-pattern matching over `@value` alternative arrays, `@explicit`/`@default` fill differences, named-graph `@graph` framing shapes, `@list`/`@set` re-emit) — tracked for a future RISE, never hidden as SKIP.

### sq-oy1f.16 — raise `COMPACT_FLOOR` 163 → 186
Re-measured the compact lane on current main after #978's faithfulness fixes landed: **compact 186 pass / 35 fail / 25 skip** (was 163/58/25; +23 FAIL→PASS). Raised `COMPACT_FLOOR = 186` (counted truthfully, not inflated).

## Wiring
Both floors are wired into the `tests/scoreboard_floors.rs` floor-sync guard (the new `W3C JSON-LD 1.1 frame` row + the compact 163→186 bump), the central `scoreboard::SUITES` registry, and the CI grep ratchet (`TOTAL frame` line `FRAME_FLOOR=61`; `COMPACT_FLOOR=186`). Fixed stale docs along the way: the doc-comments referenced a non-existent `tests/jsonld_floors.rs` guard (the real guard is `scoreboard_floors.rs`), and the "frame deferred (sq-oy1f.6) / not-implemented" notes are corrected to "gated".

## Genuinely-unsupported framing features deferred (to be beaded)
The 28 below-floor frame divergences group into: value-pattern matching over `@value` alternative arrays; some `@explicit`/`@default` fill shapes; named-graph `@graph`-frame semantics; `@list`/`@set` re-emit; `@reverse` frames and scoped/typed frame contexts. These are real framer gaps tracked for a floor RISE (children of sq-oy1f).

## Gates (both feature states)
- `cargo test -p sparq-conformance` (default, feature OFF) — green (self-skip).
- `cargo test -p sparq-conformance --features jsonld-suite` — green at the honest floors (toRdf 413, fromRdf 51, compact 186, frame 61).
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- readme-template + privacy-claims + typos — clean; `ci.yml` valid YAML.

No hard-coded perf numbers. Closes sq-oy1f.19 + sq-oy1f.16 (epic sq-oy1f).