### PR TITLE
feat(sparq-server): restore-into-live-durable-store (--persist write-through) (sq-ft7u)

### DIFF
--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -3061,23 +3061,66 @@ impl Graph {
     /// re-opened memory-mapped from the new base with a fresh, empty WAL.
     #[cfg(feature = "mmap")]
     fn persist_swap(&mut self, dir: &std::path::Path) -> Result<(), String> {
-        let new_dir = dir.with_extension("compact-new");
-        let old_dir = dir.with_extension("compact-old");
-        std::fs::remove_dir_all(&new_dir).ok();
-        std::fs::remove_dir_all(&old_dir).ok();
-        self.wal = None; // close the log before the directory swap
-        self.save(&new_dir).map_err(|e| e.to_string())?;
-        fsync_dir(&new_dir).map_err(|e| e.to_string())?;
-        let parent = dir.parent().unwrap_or_else(|| std::path::Path::new("."));
-        std::fs::rename(dir, &old_dir).map_err(|e| e.to_string())?;
-        fsync_dir(parent).map_err(|e| e.to_string())?;
-        std::fs::rename(&new_dir, dir).map_err(|e| e.to_string())?;
-        fsync_dir(parent).map_err(|e| e.to_string())?;
-        // Re-open memory-mapped from the new base (fresh, empty WAL); only then drop the old
-        // files (open mmaps keep unlinked files alive on unix).
-        *self = Graph::open(dir).map_err(|e| e.to_string())?;
-        std::fs::remove_dir_all(&old_dir).ok();
+        // Close THIS graph's WAL before the directory swap (its `wal.log` is about to be renamed
+        // away with `dir`), then run the shared crash-safe swap, writing `self`'s CURRENT image as
+        // the new base. Adopt the re-opened directory-backed graph in place. [OPUS-4.8] (sq-ft7u)
+        self.wal = None;
+        let reopened = swap_dir_to_new_base(dir, |new_dir| self.save(new_dir))
+            .map_err(|e| e.to_string())?;
+        *self = reopened;
         Ok(())
+    }
+
+    /// [OPUS-4.8] (sq-ft7u) PUBLIC crash-safe RESTORE-INTO-DURABLE seam. Atomically REPLACE the
+    /// durable contents of the directory-backed store at `dir` with `fresh`'s image, reusing the
+    /// EXACT same rollback-safe two-rename protocol as the internal compaction swap (the helper
+    /// `persist_swap` also calls — there is one crash-safe swap implementation, not two). Returns
+    /// the directory-backed [`Graph`] re-opened memory-mapped from the new base (a fresh, empty
+    /// WAL), so the caller's subsequent updates WAL-append to the restored store.
+    ///
+    /// This is the durable counterpart to the server's online in-memory restore: the caller imports
+    /// (and thus FULLY validates) the backup artifact into `fresh` BEFORE calling this, so the swap
+    /// only ever runs over a known-good image.
+    ///
+    /// CRASH-SAFETY + FAIL-CLOSED. The protocol is: write `fresh`'s image to `<dir>.compact-new`
+    /// and fsync that directory (durable before it can become canonical); rename `dir` ->
+    /// `<dir>.compact-old` (parent fsync); rename `<dir>.compact-new` -> `dir` (parent fsync);
+    /// re-open memory-mapped from the new base; drop `<dir>.compact-old`. There is a window where
+    /// the canonical `dir` does not exist (between the two renames); a crash there is HEALED
+    /// deterministically on the next `open` (which runs the compaction recovery from the surviving
+    /// `.compact-new` / `.compact-old` sibling), so `dir` ends up old-or-new — NEVER corrupt or
+    /// partially written. If anything fails BEFORE the first rename (e.g. writing the new base),
+    /// `dir` is untouched: the old durable store survives intact.
+    ///
+    /// PRECONDITION (caller's responsibility): NO other handle may be mutating `dir` (WAL-appending)
+    /// concurrently — the caller must quiesce the durable writer that owns `dir` before invoking
+    /// this, exactly as the in-process compaction swap runs only on the single writer thread.
+    #[cfg(feature = "mmap")]
+    pub fn restore_into_durable(
+        dir: &std::path::Path,
+        fresh: Graph,
+    ) -> std::io::Result<Graph> {
+        swap_dir_to_new_base(dir, |new_dir| fresh.save(new_dir))
+    }
+
+    /// [OPUS-4.8] (sq-ft7u) The directory this graph is durably backed by (its `--persist` dir),
+    /// or `None` for an in-memory graph. The companion to [`restore_into_durable`](Self::restore_into_durable):
+    /// a caller doing an in-place durable restore reads the backing dir, then closes the WAL
+    /// (see [`close_wal`](Self::close_wal)) before swapping the directory over to the new base.
+    #[cfg(feature = "mmap")]
+    pub fn persist_dir(&self) -> Option<std::path::PathBuf> {
+        self.wal.as_ref().map(|w| w.dir.clone())
+    }
+
+    /// [OPUS-4.8] (sq-ft7u) Close (drop) this graph's write-ahead-log handle, if any. Used right
+    /// before a directory swap that renames the backing dir away (the WAL's `wal.log` lives under
+    /// it), exactly as the internal compaction swap does — the swap then re-opens a fresh handle.
+    /// A no-op for an in-memory graph. Safe to call on a graph whose dir is about to be replaced
+    /// by [`restore_into_durable`](Self::restore_into_durable); the graph keeps serving reads from
+    /// its in-memory image, it simply stops appending to the (about-to-be-renamed) log.
+    #[cfg(feature = "mmap")]
+    pub fn close_wal(&mut self) {
+        self.wal = None;
     }
 
     /// [OPUS-4.8] (sq-x32t, epic sq-toze.33) ERASURE-GRADE VACUUM. Like [`compact`](Self::compact)
@@ -3178,6 +3221,49 @@ fn fsync_dir(dir: &std::path::Path) -> std::io::Result<()> {
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
         Err(e) => Err(e),
     }
+}
+
+/// [OPUS-4.8] (sq-ft7u) The ONE crash-safe directory-base swap, factored out of
+/// [`persist_swap`](Graph::persist_swap) so the public [`restore_into_durable`](Graph::restore_into_durable)
+/// reuses the IDENTICAL rollback-safe protocol rather than copy-pasting it. `write_new_base` is
+/// handed the (cleared) `<dir>.compact-new` sibling and must write the desired new durable image
+/// there (e.g. `graph.save(new_dir)`). On success the new base is canonical at `dir` and a graph
+/// re-opened memory-mapped from it (fresh, empty WAL) is returned.
+///
+/// The protocol (matching the design recorded on `persist_swap`):
+///   1. clear any stale siblings, then write the new base to `<dir>.compact-new` and fsync that
+///      DIRECTORY (so it is durable before it can become canonical);
+///   2. rename `dir` -> `<dir>.compact-old`, fsync the parent (the rename is durable);
+///   3. rename `<dir>.compact-new` -> `dir`, fsync the parent;
+///   4. re-open from the new base, THEN drop `<dir>.compact-old` (open mmaps keep unlinked files
+///      alive on unix, so the re-open must precede the cleanup).
+///
+/// FAIL-CLOSED: if `write_new_base` (or its fsync) fails — i.e. anything BEFORE the first rename —
+/// `dir` is never touched, so the old durable store survives intact. A crash DURING the two
+/// renames is healed by [`recover_compaction`] on the next [`open`](Graph::open), which promotes
+/// `compact-new` or rolls back to `compact-old` — `dir` is never lost.
+#[cfg(feature = "mmap")]
+fn swap_dir_to_new_base<F>(dir: &std::path::Path, write_new_base: F) -> std::io::Result<Graph>
+where
+    F: FnOnce(&std::path::Path) -> std::io::Result<()>,
+{
+    let new_dir = dir.with_extension("compact-new");
+    let old_dir = dir.with_extension("compact-old");
+    std::fs::remove_dir_all(&new_dir).ok();
+    std::fs::remove_dir_all(&old_dir).ok();
+    // Build + sync the new base FIRST. A failure here leaves `dir` untouched (fail-closed) —
+    // the two renames below have not started, so the old durable store is intact.
+    write_new_base(&new_dir)?;
+    fsync_dir(&new_dir)?;
+    let parent = dir.parent().unwrap_or_else(|| std::path::Path::new("."));
+    std::fs::rename(dir, &old_dir)?;
+    fsync_dir(parent)?;
+    std::fs::rename(&new_dir, dir)?;
+    fsync_dir(parent)?;
+    // Re-open memory-mapped from the new base (fresh, empty WAL); only then drop the old files.
+    let reopened = Graph::open(dir)?;
+    std::fs::remove_dir_all(&old_dir).ok();
+    Ok(reopened)
 }
 
 /// [OPUS-4.8] (review 1593) Recover an INTERRUPTED [`compact`](Graph::compact) directory swap
@@ -8911,6 +8997,65 @@ mod tests {
         assert!(!dir.with_extension("compact-old").exists());
 
         std::fs::remove_dir_all(&base).ok();
+    }
+
+    /// [OPUS-4.8] (sq-ft7u) The PUBLIC `restore_into_durable` seam: replacing a directory-backed
+    /// store's contents with a fresh image must (a) round-trip the fresh live triple set after the
+    /// swap AND after a reopen (the on-disk base IS the restored image), and (b) leave NO sibling
+    /// cruft. The restored graph must also be WAL-backed (a subsequent durable update survives a
+    /// reopen), proving the re-open carried a real WAL.
+    #[cfg(feature = "mmap")]
+    #[test]
+    fn restore_into_durable_round_trips_and_is_wal_backed() {
+        let dir = std::env::temp_dir().join(format!("sparq_restore_durable_{}", std::process::id()));
+        std::fs::remove_dir_all(&dir).ok();
+        // Establish an ORIGINAL durable store with one triple.
+        Graph::load_str("<http://ex/orig> <http://ex/p> <http://ex/o> .", "ntriples")
+            .unwrap()
+            .save(&dir)
+            .unwrap();
+        assert_eq!(Graph::open(&dir).unwrap().len(), 1);
+
+        // Restore a DIFFERENT, larger fresh image THROUGH to the durable dir.
+        let mut fresh = Graph::load_str(
+            "<http://ex/r1> <http://ex/p> <http://ex/o1> .\n\
+             <http://ex/r2> <http://ex/p> <http://ex/o2> .",
+            "ntriples",
+        )
+        .unwrap();
+        // A named graph too, to exercise the whole sub-tree write.
+        fresh
+            .apply_delta_nquads(
+                "<http://ex/n> <http://ex/q> <http://ex/w> <http://ex/g> .",
+                "",
+            )
+            .unwrap();
+        let restored = Graph::restore_into_durable(&dir, fresh).unwrap();
+        // The original triple is GONE; the restored set is present (round-trip of the live set).
+        let live = dump_terms(&restored);
+        assert!(!live.iter().any(|(s, _, _)| s.contains("/orig")), "original content replaced");
+        assert!(live.iter().any(|(s, _, _)| s.contains("/r1")), "restored content present");
+        assert_eq!(restored.len(), 2, "two default-graph triples after restore");
+        // No sibling leftovers from the swap.
+        assert!(!dir.with_extension("compact-new").exists());
+        assert!(!dir.with_extension("compact-old").exists());
+
+        // The restored graph is genuinely WAL-backed: a durable update + a fresh reopen sees it.
+        let mut g = restored;
+        g.apply_delta_nquads("<http://ex/post> <http://ex/p> <http://ex/v> .", "").unwrap();
+        drop(g);
+        let reopened = Graph::open(&dir).unwrap();
+        let live2 = dump_terms(&reopened);
+        assert!(live2.iter().any(|(s, _, _)| s.contains("/r1")), "restored content survives reopen");
+        assert!(live2.iter().any(|(s, _, _)| s.contains("/post")), "post-restore update is WAL-durable");
+        assert!(!live2.iter().any(|(s, _, _)| s.contains("/orig")), "original never resurrects");
+        let g_name = Term::NamedNode(NamedNode::new_unchecked("http://ex/g".to_string()));
+        let named = reopened
+            .named_graph(&g_name)
+            .expect("the restored named graph survives the reopen");
+        assert_eq!(named.len(), 1, "the named graph holds its one triple after reopen");
+
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     /// [OPUS-4.8] (review 1593) A durable CLEAR of a directory-backed graph must SURVIVE a

--- a/crates/sparq-serve/README.md
+++ b/crates/sparq-serve/README.md
@@ -46,7 +46,10 @@ cargo run -p sparq-server -- --format turtle data.ttl
   tens of nanoseconds and never block the writer; old generations are freed by
   ordinary `Arc` drop (no in-place reclaim, no reclaim-poll degradation).
 - **Single sequenced writer** — group-commit batching publishes each batch as
-  one new immutable generation; serialisability is by construction.
+  one new immutable generation; serialisability is by construction. Out-of-band
+  ops (`Writer::maintain` for durable WAL compaction; `Writer::restore` for a
+  crash-safe restore-into-durable) are sequenced through the same queue, so they
+  run strictly between batches — never racing a commit.
 - **Sync, runtime-agnostic, library-first** — no HTTP or async-runtime types;
   consumers wrap it. It must never enter `sparq-wasm`'s dependency graph.
 - **Online backup/restore** (opt-in `backup` feature, default OFF) — `backup::export`

--- a/crates/sparq-serve/src/writer.rs
+++ b/crates/sparq-serve/src/writer.rs
@@ -220,6 +220,25 @@ pub trait ApplyUpdates: Send + 'static {
     fn maintain(&mut self) -> Result<(), String> {
         Ok(())
     }
+
+    /// [OPUS-4.8] (sq-ft7u) RESTORE the applier's durable side from a freshly-built, already-
+    /// validated `fresh` snapshot, and return the new published snapshot the ring should serve.
+    /// Runs on the WRITER THREAD (the only thread that touches the durable store), sequenced
+    /// through the same queue as updates — so the durable swap never races a commit and the
+    /// served lineage is replaced atomically by the publish the caller does with the returned
+    /// snapshot. UNLIKE [`maintain`](Self::maintain), this CHANGES the live triple set (it
+    /// replaces the whole store), so the writer publishes a new generation from the return value.
+    ///
+    /// The default is a no-op error: an applier with no durable side (the in-memory server) has
+    /// no on-disk store to write through, so it uses the ring/writer-swap restore path instead.
+    /// An applier with a `--persist` durable mirror overrides this to perform the crash-safe
+    /// on-disk swap (e.g. via `Graph::restore_into_durable`) and adopt the re-opened store.
+    ///
+    /// `Err(msg)` is a restore failure that leaves the writer alive and the OLD durable store
+    /// intact (the durable swap is fail-closed); the caller is told and nothing is published.
+    fn restore_durable(&mut self, _fresh: Self::Snapshot) -> Result<Self::Snapshot, String> {
+        Err("restore_durable is not supported by this applier (no durable store)".to_string())
+    }
 }
 
 /// Why a submitted update did not land in a published generation.
@@ -271,13 +290,23 @@ struct Msg<U> {
 /// compaction). Maintenance is sequenced through the SAME single queue as updates, so it
 /// runs strictly between batches on the one thread that owns the durable store — no lock,
 /// no concurrent access to the durable graph, no reordering relative to in-flight writes.
-enum Cmd<U> {
+enum Cmd<U, S> {
     /// A normal update submission.
     Update(Msg<U>),
     /// Run [`ApplyUpdates::maintain`] on the writer thread; the result is sent back on the
     /// channel so the caller can block for completion. Publishes NO generation (maintenance
     /// preserves the live snapshot exactly).
     Maintain(SyncSender<Result<(), String>>),
+    /// [OPUS-4.8] (sq-ft7u) RESTORE the durable store from the freshly-built, already-validated
+    /// snapshot `fresh` on the writer thread, then PUBLISH the restored snapshot as a new
+    /// generation so the ring serves it. Sequenced through the same queue as updates, so the
+    /// durable swap runs strictly between batches — never concurrently with a commit. The ack
+    /// carries the published generation number (or the restore error). UNLIKE `Maintain`, this
+    /// CHANGES the live triple set (it replaces the whole store), so a generation IS published.
+    Restore {
+        fresh: Box<S>,
+        ack: SyncSender<Result<u64, String>>,
+    },
 }
 
 /// The single sequenced writer (§6.5): owns the one thread allowed to call
@@ -287,13 +316,19 @@ enum Cmd<U> {
 /// both submission methods take `&self`. Dropping the writer closes the queue,
 /// commits any in-flight batch (graceful drain — pending sync submitters still
 /// get their generation number), and joins the thread.
-pub struct Writer<U: Send + 'static> {
+///
+/// [OPUS-4.8] (sq-ft7u) The second type parameter `S` is the applier's SNAPSHOT type (e.g. the
+/// server's `Graph`): it is the payload of the out-of-band [`restore`](Self::restore) op, which
+/// installs a freshly-built snapshot as the new served lineage (the durable-restore primitive).
+/// It is inferred from the applier at [`spawn`](Self::spawn), so existing call sites that name
+/// only `Writer<U>` keep compiling via the `S = ()` default (no restore payload).
+pub struct Writer<U: Send + 'static, S: Send + Sync + 'static = ()> {
     /// `Some` until drop; dropping the sender is what tells the thread to drain.
-    tx: Option<mpsc::Sender<Cmd<U>>>,
+    tx: Option<mpsc::Sender<Cmd<U, S>>>,
     thread: Option<JoinHandle<()>>,
 }
 
-impl<U: Send + 'static> Writer<U> {
+impl<U: Send + 'static, S: Send + Sync + 'static> Writer<U, S> {
     /// Spawns the writer thread over `ring`, owning `applier` as its snapshot
     /// production strategy.
     pub fn spawn<A>(
@@ -302,9 +337,9 @@ impl<U: Send + 'static> Writer<U> {
         config: WriterConfig,
     ) -> Self
     where
-        A: ApplyUpdates<Update = U>,
+        A: ApplyUpdates<Update = U, Snapshot = S>,
     {
-        let (tx, rx) = mpsc::channel::<Cmd<U>>();
+        let (tx, rx) = mpsc::channel::<Cmd<U, S>>();
         let thread = thread::Builder::new()
             .name("sparq-serve-writer".into())
             .spawn(move || run(ring, applier, config, rx))
@@ -365,6 +400,29 @@ impl<U: Send + 'static> Writer<U> {
         done_rx.recv().map_err(|_| WriteError::Shutdown)
     }
 
+    /// [OPUS-4.8] (sq-ft7u) RESTORE the durable store from the freshly-built, already-validated
+    /// snapshot `fresh` ON THE WRITER THREAD, then PUBLISH the restored snapshot as a new
+    /// generation, and **block until it completes** — returning the published generation number
+    /// (or the restore error). Routed through the SAME queue as updates, so the durable swap
+    /// ([`ApplyUpdates::restore_durable`]) runs strictly between batches on the single thread that
+    /// owns the durable store — never concurrently with a commit, never reordered across an
+    /// in-flight write. UNLIKE [`maintain`](Self::maintain) it CHANGES the live triple set, so a
+    /// new generation IS published from the restored snapshot (the ring then serves it). A restore
+    /// failure leaves the writer alive and the OLD durable store intact (the underlying swap is
+    /// fail-closed): `Err(Shutdown)` if the writer is gone, else the inner `Result` is the outcome.
+    pub fn restore(&self, fresh: S) -> Result<Result<u64, String>, WriteError> {
+        let (ack_tx, ack_rx) = mpsc::sync_channel(1);
+        self.tx
+            .as_ref()
+            .expect("sender present until drop")
+            .send(Cmd::Restore {
+                fresh: Box::new(fresh),
+                ack: ack_tx,
+            })
+            .map_err(|_| WriteError::Shutdown)?;
+        ack_rx.recv().map_err(|_| WriteError::Shutdown)
+    }
+
     /// Fire-and-forget submission: queues the update and returns immediately.
     /// `Err(Shutdown)` if the writer is gone; otherwise the outcome (including a
     /// possible [`WriteError::Rejected`]) is not reported — callers that need
@@ -390,7 +448,7 @@ impl<U: Send + 'static> Writer<U> {
     }
 }
 
-impl<U: Send + 'static> Drop for Writer<U> {
+impl<U: Send + 'static, S: Send + Sync + 'static> Drop for Writer<U, S> {
     fn drop(&mut self) {
         // Closing the channel ends the thread's loop after it drains + commits
         // whatever batch is in flight (the disconnect also closes an open window
@@ -404,12 +462,19 @@ impl<U: Send + 'static> Drop for Writer<U> {
     }
 }
 
+/// [OPUS-4.8] (sq-ft7u) A restore request held until the in-flight batch commits: the
+/// freshly-built snapshot to install + the ack channel for the published generation number.
+type PendingRestore<A> = (
+    <A as ApplyUpdates>::Snapshot,
+    SyncSender<Result<u64, String>>,
+);
+
 /// The writer thread: collect a batch per group-commit window, commit, repeat.
 fn run<A: ApplyUpdates>(
     ring: Arc<GenerationRing<A::Snapshot>>,
     mut applier: A,
     config: WriterConfig,
-    rx: Receiver<Cmd<A::Update>>,
+    rx: Receiver<Cmd<A::Update, A::Snapshot>>,
 ) {
     let max_batch = config.max_batch.max(1);
     loop {
@@ -427,6 +492,11 @@ fn run<A: ApplyUpdates>(
                 let _ = done.send(applier.maintain());
                 continue;
             }
+            // [OPUS-4.8] (sq-ft7u) Restore arrived with no pending batch: run it now.
+            Cmd::Restore { fresh, ack } => {
+                run_restore(&ring, &mut applier, *fresh, ack);
+                continue;
+            }
         };
         let deadline = Instant::now() + config.window;
         let mut batch = vec![first];
@@ -437,6 +507,10 @@ fn run<A: ApplyUpdates>(
         // so a compaction observes exactly the writes that preceded it. The request is held
         // here and serviced once the batch is committed below.
         let mut pending_maintain: Option<SyncSender<Result<(), String>>> = None;
+        // [OPUS-4.8] (sq-ft7u) Likewise a RESTORE request that arrives mid-window closes the
+        // window: the in-flight batch is committed FIRST (strict FIFO), then the durable store is
+        // replaced — so a restore never races, or is reordered against, a concurrent update.
+        let mut pending_restore: Option<PendingRestore<A>> = None;
         while batch.len() < max_batch {
             let now = Instant::now();
             if now >= deadline {
@@ -447,6 +521,10 @@ fn run<A: ApplyUpdates>(
                 Ok(Cmd::Maintain(done)) => {
                     pending_maintain = Some(done);
                     break; // close the window; commit the batch, then run maintenance
+                }
+                Ok(Cmd::Restore { fresh, ack }) => {
+                    pending_restore = Some((*fresh, ack));
+                    break; // close the window; commit the batch, then run the restore
                 }
                 Err(RecvTimeoutError::Timeout) => break,
                 Err(RecvTimeoutError::Disconnected) => {
@@ -470,10 +548,36 @@ fn run<A: ApplyUpdates>(
         if let Some(done) = pending_maintain {
             let _ = done.send(applier.maintain());
         }
+        // [OPUS-4.8] (sq-ft7u) Run the restore AFTER the preceding batch is committed + published
+        // (strict FIFO — the restore observes every write that arrived before it, then replaces
+        // the store), then ack the caller. A restore failure leaves the writer alive (it is
+        // reported via the returned `Result`, not by tearing down the writer).
+        if let Some((fresh, ack)) = pending_restore {
+            run_restore(&ring, &mut applier, fresh, ack);
+        }
         if disconnected {
             return;
         }
     }
+}
+
+/// [OPUS-4.8] (sq-ft7u) Run a durable RESTORE on the writer thread and PUBLISH the restored
+/// snapshot as a new generation so the ring serves it. The applier's
+/// [`restore_durable`](ApplyUpdates::restore_durable) performs the crash-safe on-disk swap and
+/// returns the snapshot to publish; on its `Err` nothing is published and the OLD store is intact
+/// (the swap is fail-closed). The publish uses an empty epoch-touched set: a full-store restore
+/// invalidates everything, and the generation bump alone re-evaluates active subscriptions.
+fn run_restore<A: ApplyUpdates>(
+    ring: &GenerationRing<A::Snapshot>,
+    applier: &mut A,
+    fresh: A::Snapshot,
+    ack: SyncSender<Result<u64, String>>,
+) {
+    let result = match applier.restore_durable(fresh) {
+        Ok(snapshot) => Ok(ring.publish(snapshot, std::iter::empty::<PodId>()).number()),
+        Err(e) => Err(e),
+    };
+    let _ = ack.send(result);
 }
 
 /// Splits one window's batch into maximal runs of pairwise-commuting data

--- a/crates/sparq-serve/tests/writer.rs
+++ b/crates/sparq-serve/tests/writer.rs
@@ -41,6 +41,15 @@ struct MockApplier {
     /// The applier's own count of committed updates (advanced in `seal`), so `maintain`
     /// can record how many it observed.
     committed: usize,
+    /// [OPUS-4.8] (sq-ft7u) Restore control. When `restore_durable_supported` is true the mock
+    /// models a DURABLE applier: `restore_durable` records the committed-update count it observed
+    /// (proving FIFO sequencing) and returns the `fresh` snapshot to publish — unless
+    /// `restore_fails` > 0, in which case it fails once (consuming one), modelling a crash-safe
+    /// swap that left the old store intact. When false it is the IN-MEMORY applier and uses the
+    /// trait's default no-op-error `restore_durable`.
+    restore_durable_supported: bool,
+    restores: Arc<std::sync::Mutex<Vec<usize>>>,
+    restore_fails: Arc<AtomicUsize>,
 }
 
 impl MockApplier {
@@ -53,6 +62,32 @@ impl MockApplier {
             maintains: Arc::new(std::sync::Mutex::new(Vec::new())),
             maintain_fails: Arc::new(AtomicUsize::new(0)),
             committed: 0,
+            restore_durable_supported: false,
+            restores: Arc::new(std::sync::Mutex::new(Vec::new())),
+            restore_fails: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// [OPUS-4.8] (sq-ft7u) A mock modelling a DURABLE applier (one whose `--persist` store can be
+    /// restored through), sharing the restore observation/fault handles with the test so it can
+    /// verify the restore is sequenced after preceding updates, publishes a new generation, and
+    /// survives an injected restore failure.
+    fn with_restore_control(
+        forks: &Arc<AtomicUsize>,
+        restores: &Arc<std::sync::Mutex<Vec<usize>>>,
+        restore_fails: &Arc<AtomicUsize>,
+    ) -> Self {
+        MockApplier {
+            forks: forks.clone(),
+            fork_delay: Duration::ZERO,
+            seal_fails: Arc::new(AtomicUsize::new(0)),
+            seals: Arc::new(AtomicUsize::new(0)),
+            maintains: Arc::new(std::sync::Mutex::new(Vec::new())),
+            maintain_fails: Arc::new(AtomicUsize::new(0)),
+            committed: 0,
+            restore_durable_supported: true,
+            restores: restores.clone(),
+            restore_fails: restore_fails.clone(),
         }
     }
 
@@ -71,6 +106,9 @@ impl MockApplier {
             maintains: maintains.clone(),
             maintain_fails: maintain_fails.clone(),
             committed: 0,
+            restore_durable_supported: false,
+            restores: Arc::new(std::sync::Mutex::new(Vec::new())),
+            restore_fails: Arc::new(AtomicUsize::new(0)),
         }
     }
 
@@ -90,6 +128,9 @@ impl MockApplier {
             maintains: Arc::new(std::sync::Mutex::new(Vec::new())),
             maintain_fails: Arc::new(AtomicUsize::new(0)),
             committed: 0,
+            restore_durable_supported: false,
+            restores: Arc::new(std::sync::Mutex::new(Vec::new())),
+            restore_fails: Arc::new(AtomicUsize::new(0)),
         }
     }
 }
@@ -145,6 +186,47 @@ impl ApplyUpdates for MockApplier {
         }
         Ok(())
     }
+
+    /// [OPUS-4.8] (sq-ft7u) An IN-MEMORY applier delegates to the trait DEFAULT (no durable store
+    /// → an error). A DURABLE applier (built via `with_restore_control`) records the committed-
+    /// update count it observed — proving the restore ran AFTER the preceding batch (FIFO) — and
+    /// returns the `fresh` snapshot for the writer to publish, unless an injected failure is armed
+    /// (then it fails once, modelling a crash-safe swap that left the OLD store intact).
+    fn restore_durable(&mut self, fresh: Log) -> Result<Log, String> {
+        if !self.restore_durable_supported {
+            // Exercise the trait's default no-op-error impl explicitly.
+            return ApplyUpdates::restore_durable(
+                &mut DefaultRestoreApplier,
+                Vec::new(),
+            );
+        }
+        self.restores.lock().unwrap().push(self.committed);
+        if self.restore_fails.load(Ordering::SeqCst) > 0 {
+            self.restore_fails.fetch_sub(1, Ordering::SeqCst);
+            return Err("injected durable restore failure (old store intact)".into());
+        }
+        // The durable swap succeeded: the published snapshot is the restored image.
+        Ok(fresh)
+    }
+}
+
+/// [OPUS-4.8] (sq-ft7u) A trivial applier used ONLY to reach the trait's DEFAULT `restore_durable`
+/// (the in-memory-server path that errors because there is no durable store to write through).
+struct DefaultRestoreApplier;
+impl ApplyUpdates for DefaultRestoreApplier {
+    type Snapshot = Log;
+    type Working = Log;
+    type Update = String;
+    fn fork(&mut self, base: &Log) -> Result<Log, String> {
+        Ok(base.clone())
+    }
+    fn apply(&mut self, _working: &mut Log, _update: &String) -> Result<(), String> {
+        Ok(())
+    }
+    fn seal(&mut self, working: Log) -> Result<Log, String> {
+        Ok(working)
+    }
+    // restore_durable: uses the trait default (no-op error) — the path under test.
 }
 
 fn pods(ids: &[&str]) -> Vec<PodId> {
@@ -480,6 +562,9 @@ fn readers_never_stall_while_writer_commits() {
             maintains: Arc::new(std::sync::Mutex::new(Vec::new())),
             maintain_fails: Arc::new(AtomicUsize::new(0)),
             committed: 0,
+            restore_durable_supported: false,
+            restores: Arc::new(std::sync::Mutex::new(Vec::new())),
+            restore_fails: Arc::new(AtomicUsize::new(0)),
         },
         WriterConfig {
             window: Duration::from_millis(1),
@@ -826,5 +911,162 @@ fn maintain_failure_keeps_writer_alive() {
         maintains.lock().unwrap().len(),
         2,
         "both maintenance attempts ran"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-ft7u) Writer::restore — the out-of-band durable-restore op routed through the
+// single writer thread (the durable-write-through primitive sparq-server's /admin/restore?persist
+// and --restore-persist sit on top of). Behavioural coverage against the mock applier:
+//   - the IN-MEMORY applier (no durable store) reaches the trait DEFAULT restore_durable -> Err,
+//     and the writer survives;
+//   - a DURABLE applier's restore is sequenced AFTER the preceding batch (FIFO) and PUBLISHES the
+//     restored snapshot as a new generation the ring then serves;
+//   - a restore FAILURE is reported to the caller WITHOUT tearing down the writer (the old store
+//     is intact and later writes/restores still work).
+// ---------------------------------------------------------------------------
+
+/// An IN-MEMORY applier (no durable store) refuses a write-through restore via the trait DEFAULT
+/// `restore_durable` (inner `Err`), and the writer thread survives — a subsequent update commits.
+#[test]
+fn restore_on_in_memory_applier_errors_and_keeps_writer_alive() {
+    let forks = Arc::new(AtomicUsize::new(0));
+    let ring = Arc::new(GenerationRing::new(Log::new()));
+    let writer = Writer::spawn(
+        ring.clone(),
+        MockApplier::new(&forks), // restore_durable_supported = false → default no-op error
+        WriterConfig {
+            window: Duration::from_millis(5),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
+    );
+
+    let gen_before = ring.current().number();
+    // The restore is refused (no durable store): inner Err, nothing published.
+    let r = writer.restore(vec!["restored".to_string()]).unwrap();
+    assert!(
+        r.is_err(),
+        "an in-memory applier must refuse a write-through restore (inner Err), got {r:?}"
+    );
+    assert_eq!(
+        ring.current().number(),
+        gen_before,
+        "a refused restore publishes no generation"
+    );
+    // The writer survives — a later update still commits.
+    writer.submit("u0".to_string(), pods(&["pod:a"])).unwrap();
+    assert_eq!(
+        ring.current().snapshot(),
+        &vec!["u0".to_string()],
+        "writes still work after a refused restore"
+    );
+}
+
+/// A DURABLE applier's restore runs AFTER the preceding batch (strict FIFO — it observes every
+/// committed update) and PUBLISHES the restored snapshot as a NEW generation the ring serves; the
+/// returned generation number is that new generation.
+#[test]
+fn restore_publishes_new_generation_after_preceding_updates() {
+    let forks = Arc::new(AtomicUsize::new(0));
+    let restores = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let restore_fails = Arc::new(AtomicUsize::new(0));
+    let ring = Arc::new(GenerationRing::new(Log::new()));
+    let writer = Writer::spawn(
+        ring.clone(),
+        MockApplier::with_restore_control(&forks, &restores, &restore_fails),
+        WriterConfig {
+            window: Duration::from_millis(5),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
+    );
+
+    // Commit two updates first (the restore must observe them, then replace the whole store).
+    writer.submit("u0".to_string(), pods(&["pod:a"])).unwrap();
+    writer.submit("u1".to_string(), pods(&["pod:a"])).unwrap();
+    assert_eq!(ring.current().snapshot().len(), 2, "two updates committed");
+    let gen_before = ring.current().number();
+
+    // Restore: the durable swap succeeds, publishing the restored snapshot as a new generation.
+    let restored = vec!["alpha".to_string(), "beta".to_string(), "gamma".to_string()];
+    let published = writer.restore(restored.clone()).unwrap().expect("restore ok");
+    assert!(
+        published > gen_before,
+        "restore must publish a NEW generation ({published} > {gen_before})"
+    );
+    assert_eq!(
+        ring.current().number(),
+        published,
+        "the ring now serves the published restore generation"
+    );
+    // The live snapshot IS the restored image (the whole store was replaced).
+    assert_eq!(
+        ring.current().snapshot(),
+        &restored,
+        "the served snapshot is the restored image, not the prior log"
+    );
+    // It ran exactly once, after both updates committed (FIFO): it saw committed == 2.
+    assert_eq!(
+        *restores.lock().unwrap(),
+        vec![2],
+        "restore ran once, after the 2 preceding updates"
+    );
+}
+
+/// A restore FAILURE is reported to the caller (inner `Err`) WITHOUT tearing down the writer: the
+/// OLD live snapshot is untouched, and a subsequent update AND a later successful restore work.
+#[test]
+fn restore_failure_keeps_writer_alive_and_store_intact() {
+    let forks = Arc::new(AtomicUsize::new(0));
+    let restores = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let restore_fails = Arc::new(AtomicUsize::new(1)); // fail the first restore only
+    let ring = Arc::new(GenerationRing::new(Log::new()));
+    let writer = Writer::spawn(
+        ring.clone(),
+        MockApplier::with_restore_control(&forks, &restores, &restore_fails),
+        WriterConfig {
+            window: Duration::from_millis(5),
+            max_batch: 64,
+            ..WriterConfig::default()
+        },
+    );
+
+    writer.submit("keep".to_string(), pods(&["pod:a"])).unwrap();
+    let gen_before = ring.current().number();
+
+    // First restore fails (inner Err): nothing published, the OLD store is intact.
+    let r = writer.restore(vec!["discarded".to_string()]).unwrap();
+    assert!(r.is_err(), "armed restore failure must surface as Err, got {r:?}");
+    assert_eq!(
+        ring.current().number(),
+        gen_before,
+        "a failed restore publishes no generation"
+    );
+    assert_eq!(
+        ring.current().snapshot(),
+        &vec!["keep".to_string()],
+        "the old live snapshot survives a failed restore"
+    );
+
+    // The writer survives — a later update commits…
+    writer.submit("more".to_string(), pods(&["pod:a"])).unwrap();
+    assert_eq!(ring.current().snapshot().len(), 2, "writes work after a failed restore");
+
+    // …and a later restore now succeeds, replacing the store.
+    let ok = writer
+        .restore(vec!["final".to_string()])
+        .unwrap()
+        .expect("second restore ok");
+    assert_eq!(ring.current().number(), ok, "the successful restore is now served");
+    assert_eq!(
+        ring.current().snapshot(),
+        &vec!["final".to_string()],
+        "the second restore replaced the store"
+    );
+    assert_eq!(
+        restores.lock().unwrap().len(),
+        2,
+        "both restore attempts ran on the writer thread"
     );
 }

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -89,14 +89,12 @@ By default: **no auth, loopback-only.** Hardening is opt-in but honest where it 
 Readers pin the current immutable generation; writers commit batches as new generations
 ([`sparq-serve`](../sparq-serve/README.md)). **This single writer IS the write ceiling, by design**
 — a feature for the interactive single-resource-write workload, not a gap. An in-engine
-distributed/sharded writer is an **explicit Phase-2 non-goal**; the external-topology design (gh-52
-/ PSS ADR-0012, in [`research/`](../../research/adr-horizontal-scaling.md)) has **no engine code**.
+distributed/sharded writer is an **explicit Phase-2 non-goal** ([`research/`](../../research/adr-horizontal-scaling.md), gh-52 / PSS ADR-0012; no engine code).
 
 ## Durable persistence (`--persist DIR`)
 
 `--persist <DIR>` makes the on-disk index the durable source of truth (QLever's `--persist-updates`):
-every update is WAL-fsync'd **before the `204` ack** (restart replays the WAL, no rebuild); a rejected
-update is never persisted, a durable-write failure refuses with a **retryable `503`** (fail-closed), and WAL compaction (`POST /admin/compact` / `sparq-cli compact`) purges deleted bytes for erasure-completeness but **cannot** reach off-box copies (snapshots/backups) — see the SKILL.
+every update is WAL-fsync'd **before the `204` ack** (restart replays the WAL, no rebuild); a rejected update is never persisted, a durable-write failure refuses with a **retryable `503`** (fail-closed), and WAL compaction (`POST /admin/compact` / `sparq-cli compact`) purges deleted bytes for erasure-completeness but **cannot** reach off-box copies (snapshots/backups) — see the SKILL.
 
 **Restore into a live durable store** (`backup` feature): a `POST /admin/restore?persist=true` (or `--restore FILE --restore-persist` on start) REPLACES the durable store's contents with a backup artifact, written through to `DIR` so it survives a restart. The swap runs on the single writer thread, crash-safely (a two-rename directory swap healed deterministically on the next open), and is **fail-closed**: a corrupt artifact is rejected with the live store untouched. Without `?persist=true`, a `--persist` server refuses the restore (`409`) — an in-memory-only restore would be silently lost on restart.
 

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -54,15 +54,13 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
   **default-deny** SSRF guard), `federation-descriptors` (VoID + Service Description discovery),
   `tpf`/`brtpf` (Triple Pattern Fragments / bind-restricted LDF source), `shacl`
   (`POST /shacl/validate`), `n3-patch` (Solid `text/n3` N3-Patch on GSP `PATCH`),
-  `backup` (online snapshot `/admin/backup` + incremental PITR delta `/admin/backup/delta` + `/admin/restore`),
-  `audit-log`/`access-audit` (access trails), `zlib-ng` (faster gzip).
-- **Default-on JSON-LD** ([OPUS-4.8] sq-oy1f.4, user-prioritised epic sq-oy1f) — the `jsonld`
-  feature is in the server's **default** set (a maintainer-directed exception to opt-in-by-default):
-  `application/ld+json` joins the q-value-aware RDF content negotiation out of the box, **both
-  directions** — EMIT a CONSTRUCT/DESCRIBE or GSP-read graph as flattened JSON-LD, and ACCEPT an
-  `application/ld+json` GSP write body (`oxjsonld`). Toggleable off via `--no-default-features
-  --features server` (then `application/ld+json` → 406-fallback on read, 415 on write). Default-on
-  now: parse + serialise (flattened) + conneg; full conneg-conformance ratcheting is roadmap (sq-oy1f).
+  `backup` (no-stop-the-world `/admin/backup` snapshot + PITR delta `/admin/backup/delta` +
+  `/admin/restore`; on `--persist`, `?persist=true`/`--restore-persist` writes the restore through to
+  disk crash-safely so it survives a restart), `audit-log`/`access-audit`, `zlib-ng`.
+- **Default-on JSON-LD** ([OPUS-4.8] sq-oy1f.4, epic sq-oy1f) — the `jsonld` feature is in the
+  server's **default** set: `application/ld+json` joins q-value-aware RDF conneg out of the box, **both
+  directions** (flattened JSON-LD on CONSTRUCT/DESCRIBE/GSP-read; `oxjsonld` GSP write body). Off via
+  `--no-default-features --features server` (→ 406 read, 415 write). Full conneg ratcheting is roadmap.
 
 ## Security posture (essentials — full detail in the SKILL)
 
@@ -99,6 +97,8 @@ distributed/sharded writer is an **explicit Phase-2 non-goal**; the external-top
 `--persist <DIR>` makes the on-disk index the durable source of truth (QLever's `--persist-updates`):
 every update is WAL-fsync'd **before the `204` ack** (restart replays the WAL, no rebuild); a rejected
 update is never persisted, a durable-write failure refuses with a **retryable `503`** (fail-closed), and WAL compaction (`POST /admin/compact` / `sparq-cli compact`) purges deleted bytes for erasure-completeness but **cannot** reach off-box copies (snapshots/backups) — see the SKILL.
+
+**Restore into a live durable store** (`backup` feature): a `POST /admin/restore?persist=true` (or `--restore FILE --restore-persist` on start) REPLACES the durable store's contents with a backup artifact, written through to `DIR` so it survives a restart. The swap runs on the single writer thread, crash-safely (a two-rename directory swap healed deterministically on the next open), and is **fail-closed**: a corrupt artifact is rejected with the live store untouched. Without `?persist=true`, a `--persist` server refuses the restore (`409`) — an in-memory-only restore would be silently lost on restart.
 
 ## 📚 Learn more
 

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -543,6 +543,17 @@ pub struct ServerConfig {
     /// `SPARQ_RESTORE_DELTA` env (a path list).
     #[cfg(feature = "backup")]
     pub restore_delta: Vec<std::path::PathBuf>,
+    /// [OPUS-4.8] (sq-ft7u) RESTORE-INTO-DURABLE opt-in for the restore-on-start path. When
+    /// `true` AND both [`restore`](Self::restore) and [`persist_dir`](Self::persist_dir) are set,
+    /// the restore-on-start writes the artifact THROUGH to the durable `--persist` directory
+    /// crash-safely, so the restored dataset SURVIVES A RESTART (the on-disk base becomes the
+    /// restored image). `false` (the default) keeps the historical contract: `--restore` and
+    /// `--persist` are MUTUALLY EXCLUSIVE (the binary refuses the combination), because an
+    /// in-memory-only restore on a durable server would be silently lost on the next restart.
+    /// This field exists only with the `backup` cargo feature; a build without it compiles no
+    /// restore code. Set by the binary's `--restore-persist` flag / `SPARQ_RESTORE_PERSIST=1` env.
+    #[cfg(feature = "backup")]
+    pub restore_persist: bool,
     /// [OPUS-4.8] (sq-d3d8, epic sq-3183) OPT-IN federation discovery descriptors. When
     /// `true`, the server serves a W3C VoID dataset description at `GET /.well-known/void`
     /// and a SPARQL 1.1 Service Description for a `GET /sparql` with no `query` parameter
@@ -700,6 +711,10 @@ impl Default for ServerConfig {
             // [OPUS-4.8] sq-bu1a: no PITR delta chain by default (base-only restore).
             #[cfg(feature = "backup")]
             restore_delta: Vec::new(),
+            // [OPUS-4.8] sq-ft7u: restore-into-durable OFF by default — `--restore` + `--persist`
+            // stay mutually exclusive unless the operator opts in with `--restore-persist`.
+            #[cfg(feature = "backup")]
+            restore_persist: false,
             // [OPUS-4.8] sq-d3d8: safe default — federation discovery descriptors OFF even
             // when the feature is compiled in (the operator opts in deliberately).
             #[cfg(feature = "federation-descriptors")]
@@ -941,6 +956,14 @@ impl ServerConfig {
             cfg.restore_delta = std::env::split_paths(&v)
                 .filter(|p| !p.as_os_str().is_empty())
                 .collect();
+        }
+        // [OPUS-4.8] sq-ft7u: SPARQ_RESTORE_PERSIST truthy ("1"/"true"/"yes"/"on") makes the
+        // restore-on-start write THROUGH to the durable `--persist` dir (so it survives a restart)
+        // instead of the historical refusal of the --restore + --persist combination. Off by
+        // default. Only present with the `backup` feature; the binary's --restore-persist overrides.
+        #[cfg(feature = "backup")]
+        if let Ok(v) = std::env::var("SPARQ_RESTORE_PERSIST") {
+            cfg.restore_persist = env_truthy(&v);
         }
         // [OPUS-4.8] sq-d3d8: SPARQ_FEDERATION_DESCRIPTORS truthy ("1"/"true"/"yes"/"on")
         // serves the VoID + Service-Description discovery endpoints. Off by default. Only
@@ -1834,6 +1857,44 @@ impl ApplyUpdates for ServerApplier {
             None => Ok(()),
         }
     }
+
+    /// [OPUS-4.8] (sq-ft7u) RESTORE-INTO-DURABLE. Replace the `--persist` durable store's contents
+    /// with the freshly-imported (already-validated) `fresh` graph, crash-safely, and return the
+    /// snapshot the ring should publish so reads serve the restored data. Runs on the WRITER THREAD
+    /// (the only thread that mutates the durable store), so the on-disk swap never races a commit.
+    ///
+    /// Sequence: release the OLD durable graph's WAL handle (close its log), then
+    /// [`Graph::restore_into_durable`] writes `fresh`'s image to a sibling, two-rename-swaps it over
+    /// `dir` (parent fsync'd between the renames), re-opens the new base memory-mapped with a fresh
+    /// WAL, and drops the old base — the EXACT crash-safe protocol the in-process compaction uses,
+    /// healed by `recover_compaction` on the next open if a crash interrupts it. We adopt the
+    /// re-opened directory-backed graph as the new durable store (so subsequent updates WAL-append
+    /// to it), and return an independent in-memory snapshot of it for the ring to publish.
+    ///
+    /// FAIL-CLOSED: `fresh` is fully built before this runs; if the swap fails before the first
+    /// rename the OLD durable store is untouched, and a crash mid-swap heals to old-or-new. An
+    /// in-memory applier (no durable store) is a clean `Err` — there is no durable dir to write
+    /// through, so the in-memory restore path (the ring/writer swap) is used instead.
+    fn restore_durable(&mut self, fresh: Graph) -> Result<Graph, String> {
+        let durable = self.durable.as_mut().ok_or_else(|| {
+            "restore-into-durable requested on an applier with no --persist store".to_string()
+        })?;
+        // The directory the OLD durable graph is backed by; the swap targets it.
+        let dir = durable
+            .graph
+            .persist_dir()
+            .ok_or_else(|| "durable graph is not directory-backed".to_string())?;
+        // Release the OLD durable graph's WAL handle before the directory swap (its `wal.log` is
+        // about to be renamed away with `dir`); the crash-safe swap re-opens a fresh handle.
+        durable.graph.close_wal();
+        let restored = Graph::restore_into_durable(&dir, fresh)
+            .map_err(|e| format!("restore-into-durable swap failed: {e}"))?;
+        // Adopt the re-opened, directory-backed restored store; subsequent updates WAL-append to it.
+        // The published snapshot is an independent in-memory image of the restored content.
+        let published = restored.snapshot().into_graph();
+        durable.graph = restored;
+        Ok(published)
+    }
 }
 
 /// Shared server state: the dataset under query, served from a sparq-serve
@@ -1871,7 +1932,7 @@ struct ServingCore {
     /// The single sequenced writer (Wave A2): the sole publisher of generations.
     /// `submit` blocks for the group-commit window + batch application, so update
     /// handlers call it on the blocking pool.
-    writer: Arc<Writer<String>>,
+    writer: Arc<Writer<String, Graph>>,
 }
 
 /// [OPUS-4.8] (sq-o5bi) Builds the ring's retention config from the server config — the default
@@ -1909,7 +1970,7 @@ pub struct AppState {
     /// `submit` blocks for the group-commit window + batch application, so update
     /// handlers call it on the blocking pool.
     #[cfg(not(feature = "backup"))]
-    writer: Arc<Writer<String>>,
+    writer: Arc<Writer<String, Graph>>,
     /// [OPUS-4.8] (sq-o5bi, sq-0g6g) `backup`-only: the swappable serving core (ring + writer).
     /// See [`ServingCore`]. Loaded lock-free on every read/update; replaced atomically only by an
     /// online restore. This `ArcSwap` indirection exists solely to enable that atomic swap and is
@@ -2109,14 +2170,14 @@ impl AppState {
     /// [`ServingCore`] (one atomic refcount bump) so the handle outlives the load guard.
     #[cfg(not(feature = "backup"))]
     #[inline(always)]
-    fn writer(&self) -> &Writer<String> {
+    fn writer(&self) -> &Writer<String, Graph> {
         &self.writer
     }
 
     /// [OPUS-4.8] (sq-o5bi, sq-0g6g) `backup`-only writer accessor (see [`ring`](Self::ring)).
     #[cfg(feature = "backup")]
     #[inline(always)]
-    fn writer(&self) -> Arc<Writer<String>> {
+    fn writer(&self) -> Arc<Writer<String, Graph>> {
         self.core.load().writer.clone()
     }
 
@@ -2208,22 +2269,55 @@ impl AppState {
         sparq_serve::backup_export(&pin, out).map_err(|e| e.to_string())
     }
 
-    /// [OPUS-4.8] (sq-o5bi) ONLINE RESTORE: rehydrates the serving store from a backup artifact
-    /// and atomically installs the freshly-built ring+writer into the swappable serving core.
-    /// Readers in flight keep serving from the OLD core (its `Arc` survives until they release
-    /// their pin); every read/update issued AFTER the swap loads the new core. **Fail-closed**:
-    /// a corrupt/mismatched artifact returns `Err` and the live store is left UNTOUCHED (the new
-    /// core is built fully — import + ring + writer spawn — before the swap; if import fails
-    /// there is nothing to swap in).
+    /// [OPUS-4.8] (sq-o5bi, sq-ft7u) ONLINE RESTORE: rehydrates the serving store from a backup
+    /// artifact. **Fail-closed**: a corrupt/mismatched artifact returns `Err` and the live store is
+    /// left UNTOUCHED (the artifact is imported + validated fully BEFORE anything is swapped; if
+    /// import fails there is nothing to swap in).
     ///
-    /// **Scope (v1, honest):** in-memory restore only. A `--persist` durable server is refused
-    /// here (`Err`) — replacing a live WAL-backed durable directory needs its own crash-safe
-    /// swap and is a recorded follow-up; the in-memory restore is the bootstrap primitive the
-    /// horizontal-scaling stage-2 + PITR base want. Blocking (import parses + indexes the whole
-    /// dataset, then spawns a writer thread): call it on the blocking pool.
+    /// IN-MEMORY server (`persist_dir == None`): atomically installs a freshly-built ring+writer
+    /// into the swappable serving core. Readers in flight keep serving from the OLD core (its `Arc`
+    /// survives until they release their pin); every read/update after the swap loads the new core.
+    /// The restored content lives only in RAM — it does NOT survive a restart (the historical
+    /// in-memory restore).
+    ///
+    /// `--persist` DURABLE server (`persist_dir == Some(dir)`): only when `persist` is set (the
+    /// `--restore-persist` / `?persist=true` opt-in) does the restore write THROUGH to the durable
+    /// dir so it SURVIVES A RESTART — via the private `restore_into_durable_through` path.
+    /// WITHOUT the opt-in a durable server REFUSES the restore (an in-memory-only swap would be
+    /// silently lost on a restart — a footgun), surfaced as an `Err` the route maps to 409.
+    ///
+    /// `persist == true` on an IN-MEMORY server is an `Err` (there is no durable dir to write
+    /// through). Blocking (import parses + indexes the whole dataset): call it on the blocking pool.
     #[cfg(feature = "backup")]
-    pub fn restore_from<R: std::io::Read>(&self, input: R) -> Result<u64, String> {
-        self.guard_restore_supported()?;
+    pub fn restore_from<R: std::io::Read>(&self, input: R, persist: bool) -> Result<u64, String> {
+        match (self.config.persist_dir.is_some(), persist) {
+            // Durable server + persist opt-in: write the restore THROUGH to the durable store.
+            (true, true) => self.restore_into_durable_through(input),
+            // Durable server WITHOUT the opt-in: refuse (an in-memory swap would be lost on
+            // restart — a footgun). The route maps this `Err` to 409.
+            (true, false) => Err(
+                "this is a --persist (durable) server: a restore must opt in to write-through \
+                 (?persist=true / --restore-persist) so it survives a restart; an in-memory-only \
+                 restore would be silently lost on the next restart and is refused"
+                    .to_string(),
+            ),
+            // In-memory server + persist opt-in: there is no durable dir to write through.
+            (false, true) => Err(
+                "restore ?persist=true requires a --persist (durable) server; this server is \
+                 in-memory (no durable directory to write the restore through to)"
+                    .to_string(),
+            ),
+            // In-memory server, in-memory restore: the historical ring/writer core swap.
+            (false, false) => self.restore_in_memory(input),
+        }
+    }
+
+    /// [OPUS-4.8] (sq-o5bi) IN-MEMORY restore: build the entire new core BEFORE touching the live
+    /// one (fail-closed), then atomically swap it in. The restored content is RAM-only — it does
+    /// NOT survive a restart (the historical in-memory restore; `restore_from(.., persist=false)`
+    /// on an in-memory server). Returns the artifact's source generation for operator correlation.
+    #[cfg(feature = "backup")]
+    fn restore_in_memory<R: std::io::Read>(&self, input: R) -> Result<u64, String> {
         // Build the entire new core BEFORE touching the live one — fail-closed.
         let (graph, meta) = sparq_serve::backup_import(input).map_err(|e| e.to_string())?;
         self.install_restored_graph(graph);
@@ -2243,8 +2337,9 @@ impl AppState {
     /// the LIVE store is left untouched — there is no partial install. The chain must be
     /// same-lineage with the base (see `sparq_serve::backup_delta` for that boundary). Returns the
     /// recovered SOURCE generation/writer-seq (the last delta's `to`, or the base's generation for
-    /// an empty chain) for operator correlation. In-memory only (a `--persist` server is refused),
-    /// blocking: call on the blocking pool.
+    /// an empty chain) for operator correlation. In-memory only (a `--persist` server is refused —
+    /// the durable write-through opt-in applies to the base [`restore_from`](Self::restore_from)
+    /// only in v1), blocking: call on the blocking pool.
     #[cfg(feature = "backup")]
     pub fn restore_from_with_deltas(
         &self,
@@ -2265,14 +2360,15 @@ impl AppState {
         Ok(recovered.generation)
     }
 
-    /// [OPUS-4.8] (sq-bu1a) Shared restore precondition: in-memory-only in v1 (a `--persist`
-    /// durable directory needs its own crash-safe swap, a recorded follow-up).
+    /// [OPUS-4.8] (sq-bu1a) Shared restore precondition: the PITR delta path is in-memory-only in
+    /// v1 (replaying a delta chain into a `--persist` durable directory needs its own crash-safe
+    /// swap, a recorded follow-up; the base `restore_from` already has the write-through path).
     #[cfg(feature = "backup")]
     fn guard_restore_supported(&self) -> Result<(), String> {
         if self.config.persist_dir.is_some() {
             return Err(
-                "restore is not supported on a --persist (durable) server in v1; \
-                 it replaces the in-memory serving store only"
+                "point-in-time restore (--restore-delta) is not supported on a --persist (durable) \
+                 server in v1; it replaces the in-memory serving store only"
                     .to_string(),
             );
         }
@@ -2332,6 +2428,47 @@ impl AppState {
         sparq_serve::backup_export_delta(&from_gen, &to, out)
             .map(Some)
             .map_err(|e| e.to_string())
+    }
+
+    /// [OPUS-4.8] (sq-ft7u) RESTORE-INTO-LIVE-DURABLE-STORE (`--persist` write-through). Imports +
+    /// validates the artifact into a fresh `Graph` (fail-closed — done BEFORE the live store is
+    /// touched), then routes the durable swap THROUGH THE EXISTING WRITER THREAD
+    /// (`Writer::restore`): the writer commits any in-flight batch first, then replaces the durable
+    /// on-disk store with the imported image crash-safely (`Graph::restore_into_durable` — the same
+    /// two-rename swap the compaction uses, healed by `recover_compaction` on the next open) and
+    /// publishes the restored snapshot as a new generation. Because the swap runs on the single
+    /// writer thread it NEVER races a concurrent durable commit — no lock on the hot path, and no
+    /// ordering hazard: quiescing the durable writer is achieved by SEQUENCING the swap on that
+    /// very thread, not by tearing it down. After a restart (reopen `dir`) the restored triples are
+    /// present (the on-disk base IS the restored image).
+    ///
+    /// Fail-closed: a corrupt artifact fails the import → the writer is never asked to swap, the
+    /// durable store is untouched. A swap I/O error leaves the OLD durable store intact (the swap
+    /// is rollback-safe) and the writer alive; reads keep flowing from the last published snapshot.
+    /// Returns the artifact's source generation (for operator correlation), as the in-memory path.
+    #[cfg(feature = "backup")]
+    fn restore_into_durable_through<R: std::io::Read>(&self, input: R) -> Result<u64, String> {
+        // Import + FULLY validate the artifact first (fail-closed — nothing on disk is touched yet).
+        let (graph, meta) = sparq_serve::backup_import(input).map_err(|e| e.to_string())?;
+        // Route the crash-safe durable swap through the existing writer thread (sequenced with
+        // updates; no concurrent durable mutation possible). It publishes the restored snapshot.
+        match self.writer().restore(graph) {
+            Ok(Ok(number)) => {
+                // Re-evaluate active subscriptions against the restored (now-published) generation.
+                self.commits.send_if_modified(|g| {
+                    if number > *g {
+                        *g = number;
+                        true
+                    } else {
+                        false
+                    }
+                });
+                Ok(meta.generation)
+            }
+            // A durable-swap failure: the OLD store is intact, the writer is alive (fail-closed).
+            Ok(Err(e)) => Err(format!("restore-into-durable failed (store unchanged): {}", e)),
+            Err(e) => Err(format!("restore-into-durable: update writer unavailable: {}", e)),
+        }
     }
 
     /// A receiver of the committed generation number for a subscription connection (T23).
@@ -4112,37 +4249,58 @@ async fn admin_backup(State(state): State<AppState>, headers: HeaderMap) -> Resp
     }
 }
 
-/// [OPUS-4.8] (sq-o5bi) `POST /admin/restore` — ONLINE restore of the serving store from a
-/// backup artifact POSTed in the request body. On success it atomically installs a freshly
-/// rehydrated ring+writer into the swappable serving core; readers in flight keep serving from
-/// the old core until they release their pin, and every read/update after the swap sees the
-/// restored store.
+/// [OPUS-4.8] (sq-o5bi, sq-ft7u) `POST /admin/restore` — ONLINE restore of the serving store from
+/// a backup artifact POSTed in the request body.
 ///
-/// - **Fail-closed.** A corrupt/mismatched/non-artifact body is rejected (400) and the live
-///   store is left UNTOUCHED — the new core is built fully (import + ring + writer) before the
-///   swap, so a failed import swaps nothing in.
-/// - **Gated** behind the WRITE auth token (the existing admin gate); POST-only.
-/// - **In-memory only (v1).** A `--persist` durable server is refused (409) — replacing a live
-///   WAL-backed durable directory needs its own crash-safe swap (a recorded follow-up). The
-///   in-memory restore is the bootstrap primitive for horizontal-scaling stage-2 + PITR.
+/// - **In-memory server** (no `--persist`): atomically installs a freshly rehydrated ring+writer
+///   into the swappable serving core; readers in flight keep serving from the old core until they
+///   release their pin, and every read/update after the swap sees the restored store. RAM-only —
+///   the restored content does NOT survive a process restart.
+/// - **`--persist` durable server** with the write-through opt-in (`?persist=true`): writes the
+///   restore THROUGH to the durable dir so it SURVIVES A RESTART (sq-ft7u). The swap runs on the
+///   single writer thread, crash-safely (the two-rename `Graph::restore_into_durable`, healed by
+///   `recover_compaction`). WITHOUT `?persist=true` a durable server REFUSES the restore (409): an
+///   in-memory-only swap would be silently lost on the next restart, which is a footgun.
+/// - `?persist=true` on an in-memory server → 409 (no durable dir to write through).
+///
+/// **Fail-closed.** A corrupt/mismatched/non-artifact body is rejected (400) and the live store is
+/// left UNTOUCHED — the artifact is imported + validated fully before anything is swapped, and the
+/// durable swap itself is rollback-safe. **Gated** behind the WRITE auth token (the existing admin
+/// gate); POST-only.
 #[cfg(feature = "backup")]
 async fn admin_restore(
     State(state): State<AppState>,
     headers: HeaderMap,
+    Query(params): Query<std::collections::HashMap<String, String>>,
     body: Bytes,
 ) -> Response {
     if let Some(resp) = auth_gate(state.config(), &headers, Operation::Write) {
         return resp;
     }
-    if state.config().persist_dir.is_some() {
+    // [OPUS-4.8] (sq-ft7u) Opt in to writing the restore THROUGH to the durable `--persist` store
+    // (so it survives a restart) via `?persist=true` (truthy: "1"/"true"/"yes"/"on"). Default off:
+    // a restore is in-memory-only unless the operator explicitly asks for write-through.
+    let persist = params.get("persist").map(|v| env_truthy(v)).unwrap_or(false);
+    let durable = state.config().persist_dir.is_some();
+    // 409 cases (the request is incompatible with the server's durability posture) are decided
+    // HERE so any `Err` from `restore_from` below is unambiguously a corrupt/import problem (400).
+    if durable && !persist {
         return json_error(
             StatusCode::CONFLICT,
-            "restore is not supported on a --persist (durable) server in v1; \
-             it replaces the in-memory serving store only",
+            "this is a --persist (durable) server: pass ?persist=true to write the restore through \
+             to the durable store (so it survives a restart); an in-memory-only restore on a \
+             durable server would be silently lost on the next restart and is refused",
+        );
+    }
+    if !durable && persist {
+        return json_error(
+            StatusCode::CONFLICT,
+            "?persist=true requires a --persist (durable) server; this server is in-memory (there \
+             is no durable directory to write the restore through to)",
         );
     }
     let st = state.clone();
-    let task = tokio::task::spawn_blocking(move || st.restore_from(&body[..]));
+    let task = tokio::task::spawn_blocking(move || st.restore_from(&body[..], persist));
     match task.await {
         Ok(Ok(source_generation)) => text_response(
             StatusCode::OK,

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -359,6 +359,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 config.restore_delta.push(std::path::PathBuf::from(file));
             }
+            // [OPUS-4.8] sq-ft7u: RESTORE-INTO-DURABLE on start. Combined with --persist DIR +
+            // --restore FILE, write the artifact THROUGH to the durable dir crash-safely, so the
+            // restored dataset survives a restart (instead of refusing the --restore/--persist
+            // combination). Off by default (env SPARQ_RESTORE_PERSIST=1). See README.
+            #[cfg(feature = "backup")]
+            "--restore-persist" => config.restore_persist = true,
             // [OPUS-4.8] sq-o4qf: opt in to binding a non-loopback address. Without this (and
             // without SPARQ_ALLOW_REMOTE), a non-loopback --addr is refused unless the whole
             // surface is authenticated (--auth-token AND --auth-token-read) — see bind_posture.
@@ -464,6 +470,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 } else {
                     ""
                 };
+                // [OPUS-4.8] sq-o5bi / sq-ft7u: surface the OPT-IN restore flags (feature backup).
+                let backup = if cfg!(feature = "backup") {
+                    " [--restore FILE] [--restore-persist]"
+                } else {
+                    ""
+                };
                 eprintln!(
                     "usage: sparq-server [--addr HOST:PORT] [--allow-remote] [--persist DIR] \
                      [--auth-token TOKEN] [--auth-token-read] [--format FMT] \
@@ -471,7 +483,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                      [--max-body-bytes N] [--max-concurrent N] \
                      [--max-results N] [--max-query-rows N] [--max-query-bytes N] [--max-decompress-ratio N] \
                      [--max-subscriptions N] \
-                     [--max-subscriptions-per-conn N]{time_travel}{service}{brtpf}{shacl}{n3_patch} \
+                     [--max-subscriptions-per-conn N]{time_travel}{service}{brtpf}{shacl}{n3_patch}{backup} \
                      [--cors-allow-origin ORIGIN]... [--cors-allow-origin-file PATH] [--verbose] \
                      [--log-full-requests] [DATA_FILE]\n  \
                      or: sparq-server --health-probe [--health-probe-addr HOST:PORT]\n\n  \
@@ -500,6 +512,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                      SERVICE <iri> reaches NOTHING unless the host is allowlisted via \
                      --service-allow / --service-allow-file / SPARQ_SERVICE_ALLOW \
                      (exact host or *.suffix wildcard) — an SSRF guard.\n  \
+                     RESTORE (the `backup` build feature): --restore FILE (env SPARQ_RESTORE) \
+                     rehydrates the store from a backup artifact on start. Without --persist it is \
+                     in-memory only. With --persist DIR, ADD --restore-persist (env \
+                     SPARQ_RESTORE_PERSIST=1) to write the restore THROUGH to the durable dir \
+                     crash-safely so it survives a restart; without it the --restore/--persist \
+                     combination is refused. The online route POST /admin/restore mirrors this: \
+                     on a --persist server it needs ?persist=true (else 409).\n  \
                      CORS: NO CORS headers by default (a cross-origin browser fetch cannot read \
                      responses). For a FIRST-PARTY browser app on another origin, allowlist its \
                      exact origin(s) via --cors-allow-origin ORIGIN (repeatable) / \
@@ -602,20 +621,56 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             Graph::load_str("", "turtle").map_err(|e| format!("init: {e}"))?
         }
     };
-    // [OPUS-4.8] sq-o5bi: RESTORE-ON-START. When --restore <FILE> / SPARQ_RESTORE is set, the
-    // backup artifact REPLACES the seed graph (fail-closed: a corrupt/mismatched artifact aborts
-    // startup with a clean error). In-memory only in v1: the combination with --persist is
-    // refused (restoring into a live durable store needs its own crash-safe swap — a follow-up).
+    // [OPUS-4.8] sq-o5bi / sq-ft7u: RESTORE-ON-START. When --restore <FILE> / SPARQ_RESTORE is set,
+    // the backup artifact REPLACES the seed graph (fail-closed: a corrupt/mismatched artifact aborts
+    // startup with a clean error).
+    //
+    // WITHOUT --restore-persist (the historical default): in-memory only — the combination with
+    // --persist is REFUSED (an in-memory-only restore on a durable server would be silently lost on
+    // the next restart).
+    //
+    // WITH --restore-persist (sq-ft7u) AND --persist DIR: the artifact is written THROUGH to the
+    // durable dir crash-safely (`Graph::restore_into_durable`) BEFORE the store is opened, so the
+    // restored dataset survives a restart (the on-disk base IS the restored image). `try_with_config`
+    // then opens the already-restored durable dir.
     #[cfg(feature = "backup")]
-    let graph = match &config.restore {
-        Some(file) => {
-            if config.persist_dir.is_some() {
+    let graph = match (&config.restore, &config.persist_dir, config.restore_persist) {
+        // --restore + --persist + --restore-persist: write the artifact through to the durable dir.
+        (Some(file), Some(dir), true) => {
+            // [OPUS-4.8] sq-bu1a + sq-ft7u: PITR delta replay INTO a durable store is out of scope
+            // in v1 (the durable write-through swaps the base image only; replaying a delta chain
+            // into a --persist dir needs its own crash-safe path). Refuse the combination loudly
+            // rather than silently dropping the operator's --restore-delta chain.
+            if !config.restore_delta.is_empty() {
                 return Err(
-                    "--restore and --persist cannot be combined in v1 (restore replaces the \
-                     in-memory serving store only)"
+                    "--restore-delta (point-in-time recovery) cannot be combined with \
+                     --restore-persist in v1: replaying a delta chain into the durable store is \
+                     not yet supported; restore the base only, or use an in-memory --restore"
                         .into(),
                 );
             }
+            eprintln!(
+                "restoring durable store at {} from backup artifact {} (write-through) ...",
+                dir.display(),
+                file.display()
+            );
+            let f = std::fs::File::open(file)
+                .map_err(|e| format!("--restore: cannot open {}: {e}", file.display()))?;
+            let (fresh, meta) = sparq_serve::backup_import(std::io::BufReader::new(f))
+                .map_err(|e| format!("--restore: rejected {} ({e})", file.display()))?;
+            // Crash-safe two-rename swap of the durable dir to the restored image (fail-closed:
+            // a corrupt artifact already aborted above; an interrupted swap is healed on open).
+            Graph::restore_into_durable(dir, fresh)
+                .map_err(|e| format!("--restore-persist: durable restore into {} failed: {e}", dir.display()))?;
+            eprintln!(
+                "restored durable store from artifact taken at generation {} ({} triples) — survives restart",
+                meta.generation, meta.triples
+            );
+            // `try_with_config` opens the now-restored durable dir; the seed graph is ignored.
+            Graph::load_str("", "turtle").map_err(|e| format!("init: {e}"))?
+        }
+        // --restore WITHOUT --persist: the historical in-memory restore (RAM-only).
+        (Some(file), None, _) => {
             eprintln!("restoring in-memory store from backup artifact {} ...", file.display());
             let f = std::fs::File::open(file)
                 .map_err(|e| format!("--restore: cannot open {}: {e}", file.display()))?;
@@ -647,7 +702,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             g
         }
-        None => {
+        // --restore + --persist WITHOUT --restore-persist: refused (footgun, see above).
+        (Some(_), Some(_), false) => {
+            return Err(
+                "--restore and --persist cannot be combined unless --restore-persist is set \
+                 (an in-memory-only restore on a durable server would be silently lost on \
+                 restart; --restore-persist writes the restore through to the durable dir)"
+                    .into(),
+            );
+        }
+        // No --restore: the seed graph as built above.
+        (None, _, _) => {
             // [OPUS-4.8] sq-bu1a: --restore-delta is meaningless without a --restore base; refuse
             // it loudly rather than silently ignoring an operator's PITR intent.
             if !config.restore_delta.is_empty() {
@@ -714,11 +779,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         ),
         None => eprintln!("persistence: OFF — in-memory only (updates are LOST on restart; pass --persist DIR to enable)"),
     }
-    // [OPUS-4.8] sq-o5bi: surface the online backup/restore posture at startup.
+    // [OPUS-4.8] sq-o5bi / sq-ft7u: surface the online backup/restore posture at startup, including
+    // whether the restore (on-start or via /admin/restore?persist=true) writes THROUGH to the
+    // durable store so it survives a restart.
     #[cfg(feature = "backup")]
     eprintln!(
         "backup/restore: ON (admin routes POST /admin/backup + /admin/backup/delta + \
-         /admin/restore, write-gated; online snapshot, no stop-the-world){}{}",
+         /admin/restore, write-gated; online snapshot, no stop-the-world){}{}{}",
         match &config.restore {
             Some(f) => format!(" — restored on start from {}", f.display()),
             None => String::new(),
@@ -728,6 +795,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             String::new()
         } else {
             format!(" + {} delta(s) replayed (PITR)", config.restore_delta.len())
+        },
+        // [OPUS-4.8] sq-ft7u: surface the restore-into-durable posture (write-through vs refusal).
+        if config.persist_dir.is_some() {
+            if config.restore_persist {
+                " — restore-into-durable ENABLED (--restore-persist / ?persist=true writes through to the persist dir; survives restart)"
+            } else {
+                " — restore-into-durable OFF (a /admin/restore needs ?persist=true on this --persist server, else 409)"
+            }
+        } else {
+            ""
         }
     );
     // [OPUS-4.8] sq-4w18: surface the SERVICE egress posture at startup so an operator

--- a/crates/sparq-server/tests/backup.rs
+++ b/crates/sparq-server/tests/backup.rs
@@ -498,21 +498,57 @@ async fn delta_route_is_gated_and_validates_from() {
     );
 }
 
-/// PERSIST REFUSAL: a `--persist` durable server refuses restore (409) in v1.
-#[tokio::test]
-async fn restore_refuses_on_persist_server() {
-    static SEQ: AtomicU64 = AtomicU64::new(0);
-    let dir = std::env::temp_dir().join(format!(
-        "sparq-backup-persist-{}-{}",
-        std::process::id(),
-        SEQ.fetch_add(1, Ordering::Relaxed),
-    ));
-    let cl = reqwest::Client::new();
-    let config = ServerConfig {
-        persist_dir: Some(dir.clone()),
-        ..ServerConfig::default()
+/// A unique scratch persist directory removed on drop (the persist.rs hygiene pattern).
+struct ScratchDir(std::path::PathBuf);
+impl ScratchDir {
+    fn new() -> Self {
+        static SEQ: AtomicU64 = AtomicU64::new(0);
+        ScratchDir(std::env::temp_dir().join(format!(
+            "sparq-backup-persist-{}-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, Ordering::Relaxed),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos(),
+        )))
+    }
+    fn path(&self) -> &std::path::Path {
+        &self.0
+    }
+}
+impl Drop for ScratchDir {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn persist_config(dir: &std::path::Path) -> ServerConfig {
+    ServerConfig { persist_dir: Some(dir.to_path_buf()), ..ServerConfig::default() }
+}
+
+/// POSTs a restore artifact to `/admin/restore`, optionally with `?persist=true`, returning the
+/// status. `persist == true` is the write-through opt-in (sq-ft7u).
+async fn post_restore(cl: &reqwest::Client, base: &str, artifact: Vec<u8>, persist: bool) -> reqwest::StatusCode {
+    let url = if persist {
+        format!("{base}/admin/restore?persist=true")
+    } else {
+        format!("{base}/admin/restore")
     };
-    let base = spawn_with(Graph::load_str("", "turtle").unwrap(), config).await;
+    cl.post(url).body(artifact).send().await.unwrap().status()
+}
+
+/// PERSIST CONTRACT (sq-ft7u): a `--persist` durable server refuses an in-memory-only restore
+/// (no `?persist=true`) with 409, but ACCEPTS a restore that opts into write-through
+/// (`?persist=true`) with 200. (The 200 path's durability is proven by
+/// `restore_persist_survives_restart` below; this test pins the status contract.)
+#[tokio::test]
+async fn restore_refuses_on_persist_server_without_opt_in_accepts_with_it() {
+    let scratch = ScratchDir::new();
+    let cl = reqwest::Client::new();
+    let base = spawn_with(Graph::load_str("", "turtle").unwrap(), persist_config(scratch.path())).await;
+
+    // WITHOUT the persist opt-in → 409 (an in-memory-only restore would be lost on restart).
     let resp = cl
         .post(format!("{base}/admin/restore"))
         .body("anything")
@@ -522,7 +558,232 @@ async fn restore_refuses_on_persist_server() {
     assert_eq!(
         resp.status(),
         reqwest::StatusCode::CONFLICT,
-        "restore is refused on a --persist server in v1"
+        "an in-memory-only restore on a --persist server must be refused (409)"
     );
-    let _ = std::fs::remove_dir_all(&dir);
+
+    // WITH ?persist=true, a VALID artifact → 200 (write-through accepted).
+    let artifact = make_artifact(&cl).await;
+    assert_eq!(
+        post_restore(&cl, &base, artifact, true).await,
+        reqwest::StatusCode::OK,
+        "a write-through restore (?persist=true) on a --persist server must be accepted (200)"
+    );
+}
+
+/// Produces a valid backup artifact from a small populated in-memory source server.
+async fn make_artifact(cl: &reqwest::Client) -> Vec<u8> {
+    let src = spawn_with(
+        Graph::load_str("<http://ex/a> <http://ex/p> <http://ex/b> .", "turtle").unwrap(),
+        ServerConfig::default(),
+    )
+    .await;
+    post_update(cl, &src, "INSERT DATA { <http://ex/c> <http://ex/p> <http://ex/d> }").await;
+    post_update(
+        cl,
+        &src,
+        "INSERT DATA { GRAPH <http://ex/g> { <http://ex/n> <http://ex/q> <http://ex/w> } }",
+    )
+    .await;
+    backup(cl, &src).await
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] (sq-ft7u) RESTORE-INTO-LIVE-DURABLE-STORE (--persist write-through).
+//
+// The load-bearing proof: a restore opted into write-through (?persist=true) on a --persist
+// server is written THROUGH to the durable directory, so it SURVIVES A RESTART (reopen the same
+// dir → restored triples present). We reuse the persist.rs restart pattern: a Server we can DROP
+// (so its writer thread joins + every WAL handle releases), then REOPEN the same persist_dir.
+// We also pin: corrupt-artifact still fail-closes WITHOUT touching the durable store; the route
+// stays write-gated.
+// ---------------------------------------------------------------------------
+
+/// A running server we can SHUT DOWN cleanly (mirrors persist.rs): on `stop()` the serve task
+/// resolves, dropping the `AppState` so the writer thread joins and the durable dir's WAL handle
+/// releases — modelling a clean process restart.
+struct Server {
+    base: String,
+    shutdown: Option<tokio::sync::oneshot::Sender<()>>,
+    task: Option<tokio::task::JoinHandle<()>>,
+}
+
+impl Server {
+    async fn start(config: ServerConfig) -> Self {
+        // Empty seed; an existing persist dir is opened (seed ignored), an empty one created.
+        let graph = Graph::load_str("", "turtle").unwrap();
+        let state = AppState::try_with_config(graph, config).expect("durable open");
+        let app = router(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let (tx, rx) = tokio::sync::oneshot::channel::<()>();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .unwrap();
+        });
+        Server { base: format!("http://{addr}"), shutdown: Some(tx), task: Some(task) }
+    }
+
+    async fn stop(mut self) {
+        if let Some(tx) = self.shutdown.take() {
+            let _ = tx.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.await.expect("server serve task panicked / failed");
+        }
+    }
+}
+
+/// THE CORE PROOF (sq-ft7u). On a `--persist` server, a `?persist=true` restore is written through
+/// to the durable directory and SURVIVES A RESTART: after restoring an artifact captured from a
+/// SEPARATE in-memory source, the restored triples are present; after dropping the server and
+/// REOPENING the same persist_dir, they are STILL present (the on-disk base IS the restored image).
+#[tokio::test]
+async fn restore_persist_survives_restart() {
+    let scratch = ScratchDir::new();
+    let cl = reqwest::Client::new();
+
+    // An artifact captured from a SEPARATE source server (default-graph + a named graph).
+    let artifact = make_artifact(&cl).await;
+
+    // A fresh --persist server, initially with its OWN distinct data (proves the restore REPLACES).
+    let s1 = Server::start(persist_config(scratch.path())).await;
+    assert_eq!(
+        post_update(&cl, &s1.base, "INSERT DATA { <http://ex/preexisting> <http://ex/p> <http://ex/o> }").await,
+        reqwest::StatusCode::NO_CONTENT
+    );
+    assert_eq!(count_all(&cl, &s1.base).await, 1, "the durable server starts with its own one triple");
+
+    // Restore WITH write-through → 200, and the restored content replaces the pre-existing data.
+    assert_eq!(
+        post_restore(&cl, &s1.base, artifact.clone(), true).await,
+        reqwest::StatusCode::OK,
+        "write-through restore must be accepted on a --persist server"
+    );
+    // make_artifact's source = 1 seed + 1 default insert + 1 named insert = 3 quads.
+    assert_eq!(count_all(&cl, &s1.base).await, 3, "the restored quad set is live after restore");
+    assert_eq!(
+        count_rows(&cl, &s1.base, "SELECT * WHERE { <http://ex/preexisting> ?p ?o }").await,
+        0,
+        "the restore REPLACED the pre-existing durable content"
+    );
+    assert_eq!(
+        count_rows(&cl, &s1.base, "SELECT * WHERE { GRAPH <http://ex/g> { ?s ?p ?o } }").await,
+        1,
+        "the named graph from the artifact is live after the restore"
+    );
+
+    // The restored durable server is still WRITABLE (the writer survived; new WAL on the new base).
+    assert_eq!(
+        post_update(&cl, &s1.base, "INSERT DATA { <http://ex/postrestore> <http://ex/p> <http://ex/o> }").await,
+        reqwest::StatusCode::NO_CONTENT
+    );
+    assert_eq!(count_all(&cl, &s1.base).await, 4, "a post-restore update is visible");
+
+    // RESTART: drop the server (writer joins, WAL handle released), reopen the SAME dir.
+    s1.stop().await;
+    let s2 = Server::start(persist_config(scratch.path())).await;
+
+    // The restored triples — AND the post-restore update — survived the restart (durable).
+    assert_eq!(
+        count_all(&cl, &s2.base).await,
+        4,
+        "the restored dataset + the post-restore update must survive the restart (written through)"
+    );
+    assert_eq!(
+        count_rows(&cl, &s2.base, "SELECT * WHERE { GRAPH <http://ex/g> { ?s ?p ?o } }").await,
+        1,
+        "the restored named graph survives the restart"
+    );
+    assert_eq!(
+        count_rows(&cl, &s2.base, "SELECT * WHERE { <http://ex/preexisting> ?p ?o }").await,
+        0,
+        "the replaced pre-existing content must NOT resurrect after a restart"
+    );
+    s2.stop().await;
+}
+
+/// FAIL-CLOSED on a `--persist` server: a CORRUPT artifact restore (?persist=true) is rejected
+/// (400) and the durable store + dir are UNTOUCHED — reopening the dir shows the original data,
+/// with no `.compact-new`/`.compact-old` swap leftovers that would mis-heal on the next open.
+#[tokio::test]
+async fn restore_persist_corrupt_artifact_leaves_durable_store_untouched() {
+    let scratch = ScratchDir::new();
+    let cl = reqwest::Client::new();
+
+    let s1 = Server::start(persist_config(scratch.path())).await;
+    assert_eq!(
+        post_update(&cl, &s1.base, "INSERT DATA { <http://ex/keep> <http://ex/p> \"ORIGINAL\" }").await,
+        reqwest::StatusCode::NO_CONTENT
+    );
+    assert_eq!(count_all(&cl, &s1.base).await, 1);
+
+    // Corrupt a valid artifact (flip the last body byte) and restore it WITH write-through.
+    let mut artifact = make_artifact(&cl).await;
+    let last = artifact.len() - 1;
+    artifact[last] ^= 0xff;
+    assert_eq!(
+        post_restore(&cl, &s1.base, artifact, true).await,
+        reqwest::StatusCode::BAD_REQUEST,
+        "a corrupt write-through restore must fail closed (400)"
+    );
+    // The live durable store is unchanged (the import failed before any swap began).
+    assert_eq!(count_all(&cl, &s1.base).await, 1, "live durable store intact after a corrupt restore");
+
+    // No swap-sibling leftovers next to the persist dir (a stray .compact-new/-old could mis-heal).
+    let new_sib = scratch.path().with_extension("compact-new");
+    let old_sib = scratch.path().with_extension("compact-old");
+    assert!(!new_sib.exists(), "no .compact-new leftover after a failed restore");
+    assert!(!old_sib.exists(), "no .compact-old leftover after a failed restore");
+
+    // And the original survives a restart (the corrupt restore truly touched nothing on disk).
+    s1.stop().await;
+    let s2 = Server::start(persist_config(scratch.path())).await;
+    assert_eq!(count_all(&cl, &s2.base).await, 1, "original durable data survives a restart");
+    assert_eq!(
+        count_rows(&cl, &s2.base, "SELECT * WHERE { <http://ex/keep> ?p ?o }").await,
+        1,
+        "the original (un-restored-over) triple is still present after a restart"
+    );
+    s2.stop().await;
+}
+
+/// AUTH: the write-through restore route stays WRITE-gated — an unauthenticated ?persist=true
+/// restore is 401 (the auth gate runs before the persist-posture checks).
+#[tokio::test]
+async fn restore_persist_route_is_write_gated() {
+    let scratch = ScratchDir::new();
+    let cl = reqwest::Client::new();
+    let config = ServerConfig { auth_token: Some("s3cret".into()), ..persist_config(scratch.path()) };
+    let s = Server::start(config).await;
+
+    let resp = cl
+        .post(format!("{}/admin/restore?persist=true", s.base))
+        .body("anything")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::UNAUTHORIZED,
+        "an unauthenticated write-through restore must be 401"
+    );
+    s.stop().await;
+}
+
+/// An IN-MEMORY server (no --persist) refuses ?persist=true with 409 — there is no durable dir to
+/// write the restore through to. (The in-memory restore path stays available WITHOUT ?persist.)
+#[tokio::test]
+async fn restore_persist_on_in_memory_server_is_409() {
+    let cl = reqwest::Client::new();
+    let base = spawn_with(Graph::load_str("", "turtle").unwrap(), ServerConfig::default()).await;
+    let artifact = make_artifact(&cl).await;
+    assert_eq!(
+        post_restore(&cl, &base, artifact, true).await,
+        reqwest::StatusCode::CONFLICT,
+        "?persist=true on an in-memory server must be 409 (no durable dir to write through)"
+    );
 }

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -395,9 +395,12 @@ curl -X POST -H 'Authorization: Bearer <TOKEN>' http://127.0.0.1:3030/admin/comp
 # Online consistent-snapshot backup + restore (feature `backup`, default OFF). POST-only, WRITE-gated.
 # Backup streams a single self-describing artifact of the LIVE store WHILE SERVING (no stop-the-world):
 curl -X POST -H 'Authorization: Bearer <TOKEN>' http://127.0.0.1:3030/admin/backup -o snapshot.spqb
-# Restore atomically installs a store rehydrated from that artifact (in-memory server only; fail-closed):
+# Restore atomically installs a store rehydrated from that artifact (in-memory; fail-closed):
 curl -X POST -H 'Authorization: Bearer <TOKEN>' --data-binary @snapshot.spqb http://127.0.0.1:3030/admin/restore
+# On a --persist server, opt into write-through so the restore survives a restart (else 409):
+curl -X POST -H 'Authorization: Bearer <TOKEN>' --data-binary @snapshot.spqb 'http://127.0.0.1:3030/admin/restore?persist=true'
 # Restore on start (bootstrap a fresh node / PITR base):  sparq-server --restore snapshot.spqb
+#   …into a durable store (survives restart):             sparq-server --persist DIR --restore snapshot.spqb --restore-persist
 # Incremental change-stream / point-in-time recovery (PITR): a DELTA between a retained
 # generation N and the current generation (replayed forward onto the matching base):
 curl -X POST -H 'Authorization: Bearer <TOKEN>' 'http://127.0.0.1:3030/admin/backup/delta?from=0' -o d0.spqd
@@ -449,14 +452,26 @@ serving from the old store until they release their pin; every read/update after
 restored store. **Fail-closed:** a corrupt / truncated / version-mismatched / non-artifact body is
 rejected (`400`) and the live store is left **untouched** (the new core is built fully before the
 swap). Both routes are **POST-only** and gated by the **write** token (the admin gate). Responses:
-backup `200` (`application/octet-stream`); restore `200` on success, `400` on a rejected artifact,
-`409` on a `--persist` server (in-memory restore only in v1 — replacing a live durable directory is
-a recorded follow-up). **Restore-on-start:** `--restore <FILE>` / `SPARQ_RESTORE` seeds the
-in-memory store from an artifact before binding (the bootstrap primitive for horizontal-scaling
-stage-2 + the base of point-in-time recovery; refused together with `--persist`). **Honest scope:**
-**at-rest encryption of the artifact is out of scope** — the integrity digest detects accidental
-corruption, not tampering, and is not a confidentiality or authenticity guarantee; protect the
-artifact at the storage tier.
+backup `200` (`application/octet-stream`); restore `200` on success, `400` on a rejected artifact.
+
+**Restore into a live durable store (`sq-ft7u`).** On a `--persist` server, a plain
+`/admin/restore` (no opt-in) is **`409`** — an in-memory-only swap on a durable server would be
+silently lost on the next restart (a footgun). Add **`?persist=true`** to write the restore
+**THROUGH to the durable directory**, so it **survives a restart** (the on-disk base becomes the
+restored image). The durable swap runs **on the single writer thread** (sequenced with updates — no
+lock, no race with a concurrent durable commit) and is **crash-safe**: the imported image is written
+to a sibling and swapped in with a **two-rename directory swap** (parent dir fsync'd between renames)
+that an interrupted crash heals deterministically (`Graph::restore_into_durable` reuses the exact WAL
+compaction swap + `recover_compaction` healer). **Fail-closed throughout:** the artifact is imported
++ validated **before** any on-disk change, so a corrupt artifact is `400` with the durable store
+**untouched** and no swap-sibling leftovers; a swap I/O error leaves the OLD store intact and the
+writer alive. `?persist=true` on an **in-memory** server is `409` (no durable dir). **Restore-on-start:**
+`--restore <FILE>` / `SPARQ_RESTORE` seeds the in-memory store before binding (bootstrap for
+horizontal-scaling stage-2 + PITR base); with `--persist DIR` it is **refused unless** you add
+**`--restore-persist`** / `SPARQ_RESTORE_PERSIST=1`, which writes the artifact through to `DIR`
+crash-safely on start. **Honest scope:** **at-rest encryption of the artifact is out of scope** — the
+integrity digest detects accidental corruption, not tampering, and is not a confidentiality or
+authenticity guarantee; protect the artifact at the storage tier.
 
 **`POST /admin/backup/delta?from=N` + `--restore-delta` — incremental change-stream / PITR
 (same `backup` feature; `sq-bu1a`).** The Option-A backup above is the BASE half of a
@@ -1138,9 +1153,12 @@ identities and resource IRIs by design (see the privacy-boundary note above).
   `--features backup` to mount the WRITE-gated, POST-only `/admin/backup` (stream a
   self-describing snapshot artifact of the live store WITHOUT stopping the world) and
   `/admin/restore` (atomically install a store rehydrated from one, **fail-closed** on a
-  corrupt/mismatched artifact, in-memory server only in v1 — a `--persist` server gets `409`).
+  corrupt/mismatched artifact). On an in-memory server the restore is RAM-only; on a `--persist`
+  server it is `409` UNLESS you opt in with `?persist=true`, which writes the restore THROUGH to the
+  durable dir (crash-safe, fail-closed) so it survives a restart (`sq-ft7u`).
   `--restore <FILE>` / `SPARQ_RESTORE` runs the same restore on start (bootstrap a fresh
-  replica / PITR base; refused together with `--persist`). DISTINCT from the offline `sparq-cli
+  replica / PITR base); with `--persist` it is refused unless `--restore-persist` /
+  `SPARQ_RESTORE_PERSIST=1` is set (then it writes through to the durable dir on start). DISTINCT from the offline `sparq-cli
   save` and from the `--persist` WAL. **At-rest encryption of the artifact is out of scope** —
   the body digest detects accidental corruption, not tampering. Without the feature the routes +
   the `--restore` setting are compiled out AND the serving core stays the plain `ring`/`writer`


### PR DESCRIPTION
> 🤖 SPARQ agent

Implements **sq-ft7u** (P2) — extends the `backup` feature (PR #941, **sq-o5bi**) so an online restore can be written THROUGH to durable `--persist` storage, so a restore SURVIVES A PROCESS RESTART. Strict-additive, behind the EXISTING `backup` cargo feature; the default build is byte-identical.

## What this implements

**1. New PUBLIC crash-safe core seam** (`sparq-core`, `mmap`):
```rust
pub fn Graph::restore_into_durable(dir: &Path, fresh: Graph) -> std::io::Result<Graph>
```
Atomically replaces a directory-backed store's contents with a fresh, already-validated image, reusing the IDENTICAL rollback-safe two-rename swap as the compaction `persist_swap` — factored into ONE shared `swap_dir_to_new_base` helper (one crash-safe swap implementation, not two). Plus `Graph::persist_dir()` / `Graph::close_wal()` accessors for the in-place durable restore.

**2. Sequenced writer-thread restore** (`sparq-serve`): a new `Writer::restore` / `Cmd::Restore` / `ApplyUpdates::restore_durable`, parameterised by the snapshot type `S` (default `()`, so existing `Writer<U>` sites compile unchanged). The durable swap runs on the SINGLE writer thread, sequenced through the same queue as updates (like `maintain`). **This is the sound resolution of the quiesce-ordering hazard the bead flagged**: no concurrent durable commit can race the directory rename because the swap is SEQUENCED on the writer thread — not by tearing the writer down. (Deviation from the bead's "build a new core + drop the old writer" sketch: under the `ArcSwap` model an in-flight update transiently holds the old writer Arc, so a tear-down can't be made race-free without a hot-path lock; sequencing on the writer thread is race-free and lock-free.)

**3. The opt-in surface** (`sparq-server`):
- `POST /admin/restore?persist=true` — write-through on a `--persist` server; without the opt-in a durable server is **409** (an in-memory-only restore would be silently lost on restart — a footgun); `?persist=true` on an in-memory server is **409** (no durable dir).
- `--restore-persist` flag / `SPARQ_RESTORE_PERSIST=1` / `ServerConfig::restore_persist` — restore-on-start write-through; the `--restore`/`--persist` mutual-exclusion now only fires WITHOUT this opt-in.
- Updated usage/help + startup posture lines.

**Chosen semantics (explicit):** a `--persist` server REFUSES an in-memory-only restore (409) and only accepts a write-through restore — the least-surprising, contract-preserving choice. The existing `restore_refuses_on_persist_server` test is updated to the new contract (without-persist still 409; with-persist 200).

## Crash-safety / fail-closed (one paragraph)
The artifact is imported + FULLY validated into a fresh `Graph` BEFORE any on-disk change. The durable swap writes the image to `<dir>.compact-new`, fsyncs it, then two-renames `dir`→`.compact-old`→ promote `compact-new`→`dir` (parent dir fsync'd between renames), re-opens the new base memory-mapped with a fresh WAL, and drops the old base. A crash mid-swap is healed deterministically by the existing `recover_compaction` on the next `Graph::open` (promote `compact-new` or roll back to `compact-old`) — `dir` is NEVER corrupt or partially written. A corrupt artifact fails the import → nothing on disk is touched; a swap I/O error leaves the OLD store intact and the writer alive.

## Restart-durability test
`restore_persist_survives_restart` (in `crates/sparq-server/tests/backup.rs`): build a `--persist` server with its own data, restore an artifact captured from a SEPARATE source with `?persist=true`, assert the restored triples are live AND replaced the pre-existing content; then DROP the server and REOPEN the same `persist_dir` (the `persist.rs` drop+reopen pattern) → assert the restored dataset + a post-restore update are STILL present. Plus: `restore_persist_corrupt_artifact_leaves_durable_store_untouched` (fail-closed, no swap-sibling leftovers, survives a restart), `restore_persist_route_is_write_gated` (401), `restore_persist_on_in_memory_server_is_409`, and the sparq-core unit test `restore_into_durable_round_trips_and_is_wal_backed` (round-trip + WAL-backed + reopen).

## Feature flags
- `sparq-server`: **`backup`** (turns on `sparq-core/mmap` + `sparq-serve/backup`). Default build = feature OFF.
- `sparq-core`: **`mmap`** (the new seam + tests are `#[cfg(feature = "mmap")]`).

## Gates (run in BOTH feature states)
| Gate | Default (OFF) | `backup` ON / all-features |
|---|---|---|
| `cargo build` | ✅ workspace clean | ✅ `-p sparq-server --features backup` clean |
| `cargo test` | ✅ `-p sparq-server` green | ✅ `-p sparq-server --features backup` green (incl. 10 backup + new), `-p sparq-core --features mmap` 127 green, `-p sparq-server --test persist` 9 green |
| `cargo clippy -D warnings` | ✅ `-p sparq-server`/`-p sparq-serve` default; `-p sparq-core --features mmap` | ✅ `--workspace --all-targets --all-features` |
| `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --all-features` | — | ✅ clean (fixed one private-item doc-link → code span) |
| `check-readme-template.py --enforce` | ✅ 0 deviations (server README 119 lines, serve 105) | |
| typos gate | ✅ no new `DELETEd`/`DROPped`/`invokable`/`ANDed` introduced | |

## PERF
**Restore-only — the steady-state read/update path is byte-identical when no restore is in flight.** The `Cmd::Restore` arm is never sent on the hot path; no new hot-path atomic load. The default build never compiles any of this (it never depends on `arc-swap` and the swap code is `#[cfg]`-stripped). Flagging for the perf-reviewer gate (sq-0g6g); may be perf-held.

## Privacy / honesty
No ZK/MPC privacy claim. At-rest encryption of the artifact remains out of scope (documented honest boundary).

Refs **sq-ft7u**, **#941**.