### PR TITLE
feat(sparq-vectors): P0 structure-aware vectorisation — closure-before-vectorise + type-constrained negative sampling (sq-0wo9e.1) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3734,6 +3734,8 @@ dependencies = [
  "spargebra",
  "sparq-core",
  "sparq-engine",
+ "sparq-introspect",
+ "sparq-reason",
  "sparq-sim",
 ]
 

--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -27,6 +27,19 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
+# [OPUS-4.8] sq-0wo9e.1 (epic sq-0wo9e, design research/structure-aware-vectorisation.md §5.A/§2):
+# the P0 structure-aware-vectorisation PREPROCESSING + SAMPLING-LOGIC layer. OPT-IN and OFF by
+# default. It is the ONLY feature that pulls `sparq-reason` + `sparq-introspect` into this crate's
+# graph, so the default `sparq-vectors` build (and the core query path) carry ZERO structure-prep
+# code and gain no new required deps. Gates `structure.rs`: (a) closure-before-vectorise —
+# materialise the sparq-reason RDFS/OWL-RL closure BEFORE the vectoriser sees the graph, so
+# entailed type/subClassOf/domain/range triples are real facts the encoder reads; (b)
+# type-constrained negative sampling (Krompass et al. 2015) — a reusable `NegativeSampler` that
+# corrupts a positive triple only to domain/range-consistent entities (read from sparq-introspect),
+# with an `Unconstrained`/`TypeConstrained` ON/OFF ABLATION switch so adoption is measurement-gated.
+# It TRAINS NOTHING (sparq-vectors has no KGE training path — embeddings are out-of-process) and
+# serves no exact answer; the trainer that consumes these negatives is a tracked follow-up.
+structure = ["dep:sparq-reason", "dep:sparq-introspect"]
 # [OPUS-4.8] sq-1wc1: predicate-constrained (filtered) ANN — the RDF-native vector
 # differentiator. A SPARQL BGP carves out a candidate dict-id set (the "visit mask") and the
 # nearest-neighbour search returns only neighbours inside it. OPT-IN and OFF by default; it is a
@@ -108,6 +121,14 @@ spargebra = { workspace = true, optional = true }
 # async runtime into the tree) — mirrors sparq-nlq's `live` reqwest dependency exactly.
 # rustls-tls so there is no system-OpenSSL build dependency.
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"], optional = true }
+# [OPUS-4.8] sq-0wo9e.1: the closure-before-vectorise step + the type-constraint extractor for the
+# `structure` feature only. Both are OPTIONAL and ONLY pulled in by `structure`, so the default
+# build (and anything not opting in) never compiles them — `sparq-vectors` stays a pure
+# storage+ANN crate by default and the lean-core constraint holds. `sparq-reason` materialises the
+# RDFS/OWL-RL closure (already property-tested incremental == from-scratch); `sparq-introspect`
+# mines declared + observed domain/range. Neither pulls the engine.
+sparq-reason = { path = "../sparq-reason", version = "0.1.0", optional = true }
+sparq-introspect = { path = "../sparq-introspect", version = "0.1.0", optional = true }
 
 # [OPUS-4.8] sq-88c6: DEV-only. The `hybrid_search` example/tests fuse this crate's ANN
 # (`VectorIndex::nearest_term`) with `sparq-sim`'s structural similarity

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -53,46 +53,48 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   persistent on-disk `DiskAnnIndex` in the default build; the in-RAM HNSW `VectorIndex`
   behind the **opt-in `approx-ann`** feature, the **only** third-party-ANN dependency
   (`instant-distance`). **Approximate search has recall `< 1.0`** (measured against
-  `nearest_exact`) — only the exact path is answer-exact; the approximate path is never
-  claimed as exact.
+  `nearest_exact`) — only the exact path is answer-exact, never the approximate one.
 - **Predicate-constrained ANN (opt-in `filtered-ann`)** — restrict the search to the
   dict-ids a SPARQL BGP admits via an `IdMask` (lean, no new dependency). Composed with
-  `approx-ann`, filtered over-fetch fills `k` whenever `k` admitted vectors exist *and
-  the backend surfaces them* — **honest caveat:** over-fetch fixes *under-fill*, not the
-  approximate index's inherent misses (recall stays `< 1.0`, asserted in
-  `tests/overfetch.rs`).
+  `approx-ann`, filtered over-fetch fills `k` whenever `k` admitted vectors exist *and the
+  backend surfaces them* — **honest caveat:** over-fetch fixes *under-fill*, not the
+  approximate index's inherent misses (recall stays `< 1.0`, `tests/overfetch.rs`).
 - **k-NN inside SPARQL (opt-in `vec-predicate`)** — `vec:nearest` / `vec:search` magic
   predicates via a spargebra-algebra rewrite (the engine is unchanged). A constrained
   neighbour variable is searched as a *filtered* ANN over its join-connected sub-BGP,
   with the derived `IdMask` cached by sub-BGP + graph fingerprint (any graph change
-  misses the cache, so a stale mask is never served). A per-query cost model chooses
-  pre- vs post-filter; both return the **byte-identical** top-k.
+  misses the cache). A per-query cost model picks pre- vs post-filter; both return the
+  **byte-identical** top-k.
 - **Graph-staleness guard** — `.spqv`/`.spqg` headers embed a dictionary **fingerprint**
-  (thread-count-stable: re-loading the same RDF at a different `RAYON_NUM_THREADS`
-  fingerprints identically). The checked query paths reject a mismatch instead of serving
+  (thread-count-stable). The checked query paths reject a mismatch instead of serving
   wrong neighbours. **Id-keyed staleness contract (sq-wlzi):** a passing `check_graph` is
   **necessary but not sufficient** — to serve a persisted store, `Graph::save` its graph
   and reopen **that** (`Graph::open`, frozen id order); **never** re-parse the source RDF
   (pinned in `tests/staleness_contract.rs`).
 - **Incremental add / remove / update (opt-in `delta`)** — a `.spqv` is build-once-immutable; the
   `delta` feature adds a **delta sidecar** (`add`/`remove`/`update` → append map + tombstones) that
-  `get`/`iter`/search transparently union (honouring tombstones), generation-tied to the base
-  (sq-32i5); `compact` folds it into a from-scratch-equivalent base. `save_delta`/`open_with_delta`
-  persist+replay it to a crash-durable `.spqd` (tmp+fsync+rename, partial-write & mismatched-base detected) so mutations survive a restart without a compact. No new dep. See rustdoc/SKILL.
+  `get`/`iter`/search transparently union, generation-tied to the base (sq-32i5); `compact` folds it
+  into a from-scratch-equivalent base. `save_delta`/`open_with_delta` persist+replay it to a
+  crash-durable `.spqd` so mutations survive a restart. No new dep. See rustdoc/SKILL.
 - **Verbalization, quantization, hybrid fusion** — `verbalize` / `embed_entities` render
-  per-entity text (multilingual, char-budgeted, single named graph at a time);
-  `ScalarQuantizer` (4×) and `ProductQuantizer` for large stores; `fuse_rrf` /
-  `hybrid_search` combine vectors with another ranked signal (e.g.
-  [`sparq-sim`](../sparq-sim)).
+  per-entity text (multilingual, char-budgeted); `ScalarQuantizer` (4×) and
+  `ProductQuantizer` for large stores; `fuse_rrf` / `hybrid_search` combine vectors with
+  another ranked signal (e.g. [`sparq-sim`](../sparq-sim)).
 - **Bring-your-own embeddings** — `import_npy` / `import_numeric_dump` load an
   externally-computed matrix straight into a `.spqv` keyed by dict id (no model
   in-process, no new dependency). **Fail-closed**: any dtype / byte-order / shape /
-  length / non-finite-row mismatch is an `Err`, never a silent reinterpretation, and the
+  length / non-finite-row mismatch is an `Err`, never a silent reinterpretation; the
   declared `.npy` header is bounded before any body allocation.
 - **Live embeddings (opt-in)** — the default build is **socket-free**. The non-default
   `provider` feature carries the OpenAI-compatible `/v1/embeddings` shape with a
   caller-supplied `Transport`; `embeddings` adds a concrete reqwest client +
   `RemoteEmbedder::from_env(dim)`. Never enters the wasm bundle.
+- **Structure-aware preprocessing (opt-in `structure`)** — research-grade P0:
+  `close_for_vectorise` materialises the `sparq-reason` RDFS/OWL-RL closure **before**
+  vectorising (entailed type/`subClassOf`/domain/range become real facts); a `NegativeSampler`
+  emits type-constrained corruptions (Krompass 2015) from `sparq-introspect`, with an
+  `Unconstrained`/`TypeConstrained` **on/off ablation**. This crate has **no KGE trainer** —
+  reusable inputs a trainer consumes; **empirical benefit unproven (no accuracy claim)**.
 
 ## 📚 Learn more
 
@@ -101,18 +103,16 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   API surface and the `.spqv` / `.spqg` formats).
 - **API reference** — [docs.rs/sparq-vectors](https://docs.rs/sparq-vectors).
 - **Design** — [`research/genai-text-embedding-practices.md`](../../research/genai-text-embedding-practices.md).
-- **Accuracy & throughput** — not baked into docs; the recall / DiskANN / PQ /
-  throughput gates are `cargo test`s (`tests/recall.rs`, `tests/diskann.rs`,
-  `tests/quant.rs`, `tests/throughput.rs`), with live numbers on the
+- **Accuracy & throughput** — not baked into docs; the recall / DiskANN / PQ / throughput
+  gates are `cargo test`s (`tests/recall.rs`, `tests/diskann.rs`, `tests/quant.rs`,
+  `tests/throughput.rs`), with live numbers on the
   [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench).
 - **Verified against an established ANN library (sq-6te5)** — `tests/ref_lib_verify.rs`
-  anchors the approximate recall against **hnswlib** (the FAISS/hnswlib reference): it loads
-  a committed real-hnswlib capture (`tests/fixtures/hnswlib_ref.tsv`), checks that
-  `nearest_exact` reproduces the captured numpy exact-kNN oracle, and that DiskANN (and HNSW
-  under `approx-ann`) clears hnswlib's own recall on that shared oracle. Runs in CI with **no
-  native deps** — the corpus is regenerated deterministically on both sides. The **live**
-  hnswlib re-capture (`scripts/capture_hnswlib_ref.py`) is `#[ignore]`d and gather-only (needs
-  numpy + hnswlib). Recall figures are work-box NON-CANONICAL.
+  anchors recall against **hnswlib** (the FAISS/hnswlib reference) via a committed capture
+  (`tests/fixtures/hnswlib_ref.tsv`): `nearest_exact` reproduces the numpy exact-kNN oracle,
+  and DiskANN (and HNSW under `approx-ann`) clears hnswlib's recall on it. Runs in CI with **no
+  native deps** (corpus regenerated deterministically); the live re-capture
+  (`scripts/capture_hnswlib_ref.py`) is `#[ignore]`d. Recall figures are NON-CANONICAL.
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## License

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -27,6 +27,12 @@ pub mod quant;
 #[cfg(feature = "vec-predicate")]
 pub mod rewrite;
 pub mod store;
+// [OPUS-4.8] sq-0wo9e.1 (epic sq-0wo9e): the P0 structure-aware-vectorisation preprocessing +
+// sampling-logic layer — closure-before-vectorise + type-constrained negative sampling. `structure`
+// feature only; the only feature pulling sparq-reason + sparq-introspect, so the default build
+// carries zero structure-prep code.
+#[cfg(feature = "structure")]
+pub mod structure;
 pub mod verbalize;
 
 /// The `vec:` vocabulary — magic predicates recognised by `rewrite`
@@ -96,6 +102,14 @@ pub use sparq_engine::{query_prepared, PreparedQuery, QueryBudget, QueryResult};
 #[cfg(feature = "delta")]
 pub use delta::{VectorDelta, SPQD_MAGIC, SPQD_VERSION};
 pub use store::{StreamingWriter, VectorStore, SPQV_MAGIC, SPQV_VERSION};
+// [OPUS-4.8] sq-0wo9e.1 (epic sq-0wo9e): the structure-aware-vectorisation P0 surface — the
+// closure-before-vectorise step, the type-constraint extractor, and the type-constrained negative
+// sampler with its on/off ablation switch. `structure` feature only.
+#[cfg(feature = "structure")]
+pub use structure::{
+    close_for_vectorise, materialise_closure, ClosedGraph, Corrupt, NegativeSampler, SamplingMode,
+    TypeConstraints,
+};
 pub use verbalize::{
     description_predicates, embed_entities, label_predicates, verbalize, EntityTextConfig,
     ObjectKind, PropertyGroup,

--- a/crates/sparq-vectors/src/structure.rs
+++ b/crates/sparq-vectors/src/structure.rs
@@ -1,0 +1,622 @@
+//! Structure-aware vectorisation **preprocessing + sampling-logic** layer (P0).
+//!
+//! [OPUS-4.8] sq-0wo9e.1 (epic sq-0wo9e; design `research/structure-aware-vectorisation.md`
+//! §5.A + §2 row "domain/range"). This module is the **lowest-risk, additive** slice of the
+//! structure-aware-vectorisation epic. It is **opt-in** (the `structure` cargo feature, off by
+//! default) and changes **nothing** in the default `sparq-vectors` build or the core engine.
+//!
+//! # What this is — and, honestly, what it is NOT
+//!
+//! `sparq-vectors` is a vector-**search** + **import** surface: embeddings are produced
+//! **out-of-process** (see [`crate::embed`]) and the crate has **no KGE training path** — no
+//! TransE / ComplEx / RotatE, no triple-scoring, no learning loop, no negative-sampling consumer.
+//! P0 of the design ("restrict KGE *corruptions* to type-valid entities") therefore presupposes a
+//! trainer that does not exist in-tree. Rather than build a large new training subsystem blind
+//! (the design review #996 may reshape it), this module ships the two **buildable, additive**
+//! halves of P0 as reusable primitives an out-of-process trainer (or a future in-tree KGE block)
+//! consumes:
+//!
+//! 1. **closure-before-vectorise** ([`close_for_vectorise`] / [`materialise_closure`]) — run the
+//!    `sparq-reason` closure ([`Profile::Rdfs`] or [`Profile::OwlRl`]) over the graph **before** the
+//!    vectoriser sees it, so entailed type / `subClassOf` / domain / range triples are *materialised
+//!    facts* the encoder, the type extractor, and the negative sampler all read.
+//! 2. **type-constrained negative sampling** ([`TypeConstraints`] + [`NegativeSampler`]) — the
+//!    established Krompass et al. 2015 technique: corrupt a positive triple's head only to
+//!    entities whose type lies in the predicate's **domain**, its tail only to entities in the
+//!    predicate's **range**. The constraints are read from `sparq-introspect` (declared
+//!    `rdfs:domain`/`rdfs:range` **and** observed domain/range histograms) over the **closed**
+//!    graph.
+//!
+//! The KGE trainer that *consumes* these negatives is the deferred remainder (bead noted in the
+//! crate README / SKILL). This module trains nothing and serves no exact answer.
+//!
+//! # The on/off ablation hook (load-bearing, design §6.B)
+//!
+//! Every prior in this epic ships **behind an on/off ablation** and is adopted **only on measured
+//! lift** — no accuracy claim is made in advance. [`SamplingMode`] is that switch:
+//! [`SamplingMode::Unconstrained`] reproduces vanilla uniform corruption; [`SamplingMode::TypeConstrained`]
+//! applies the domain/range restriction. A harness runs the *same* sampler in both modes and
+//! compares Hits@k / MRR downstream. **No benchmark numbers exist; none are claimed here.**
+
+use rustc_hash::{FxHashMap, FxHashSet};
+use sparq_core::dict::{Id, TermParts};
+use sparq_core::Graph;
+use sparq_introspect::Introspection;
+use sparq_reason::Profile;
+
+/// `rdf:type` — the predicate whose objects are an entity's declared classes.
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+/// Outcome of [`materialise_closure`] / [`close_for_vectorise`]: the closed [`Graph`] plus a
+/// small, **non-canonical** report of how many triples the closure added. The counts exist so a
+/// caller can log / assert the closure ran (e.g. "every closed triple is visible to the encoder")
+/// — they are *not* a performance or quality metric and must never be baked into docs.
+pub struct ClosedGraph {
+    /// The graph after materialisation: asserted triples **plus** every entailed triple of the
+    /// chosen [`Profile`]. This is the graph the vectoriser, the type extractor, and the negative
+    /// sampler should read.
+    pub graph: Graph,
+    /// Triples present before materialisation.
+    pub asserted_triples: usize,
+    /// Triples added by the closure (`entailed_triples` ⩾ 0; `0` ⇒ the graph was already closed
+    /// under the profile, e.g. it has no schema axioms to fire on).
+    pub entailed_triples: usize,
+    /// The entailment regime that was materialised.
+    pub profile: Profile,
+}
+
+impl ClosedGraph {
+    /// Total triples after materialisation (`asserted_triples + entailed_triples`).
+    pub fn closed_triples(&self) -> usize {
+        self.asserted_triples + self.entailed_triples
+    }
+}
+
+/// Materialise the `profile` closure over an **already-parsed** `(dict, triples)` pair, then
+/// build the closed [`Graph`]. This is the closure-before-vectorise step (design §5.A): the
+/// reasoner is sound and complete for its profile, so after this call every entailed type /
+/// `subClassOf` / domain / range fact is a *real triple* the downstream vectorisation inputs see —
+/// not just the asserted subset.
+///
+/// `dict`/`triples` come from [`Graph::parse_to_triples`]. Ownership is taken because the closed
+/// graph is rebuilt from them via [`Graph::from_parts`].
+///
+/// ```
+/// use sparq_core::Graph;
+/// use sparq_reason::Profile;
+/// use sparq_vectors::structure::materialise_closure;
+///
+/// let ttl = "@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .\n\
+///            @prefix ex: <http://ex/> .\n\
+///            ex:Dog rdfs:subClassOf ex:Animal .\n\
+///            ex:rex a ex:Dog .";
+/// let (dict, triples) = Graph::parse_to_triples(ttl, "turtle").unwrap();
+/// let closed = materialise_closure(dict, triples, Profile::Rdfs);
+/// // `ex:rex a ex:Animal` is now an entailed, materialised triple.
+/// assert!(closed.entailed_triples >= 1);
+/// ```
+pub fn materialise_closure(
+    mut dict: sparq_core::dict::Dict,
+    mut triples: Vec<[Id; 3]>,
+    profile: Profile,
+) -> ClosedGraph {
+    let asserted_triples = triples.len();
+    let entailed_triples = sparq_reason::materialize(profile, &mut dict, &mut triples);
+    let graph = Graph::from_parts(dict, triples);
+    ClosedGraph { graph, asserted_triples, entailed_triples, profile }
+}
+
+/// Parse RDF `text` of the given `format`, then [`materialise_closure`] under `profile`
+/// ([`Profile::Rdfs`] or [`Profile::OwlRl`]) — the convenience entry point for the whole
+/// closure-before-vectorise step from a serialised source.
+///
+/// Returns `Err` with the parser's message on a parse failure (the closure step never fails:
+/// materialisation only *adds* triples).
+pub fn close_for_vectorise(
+    text: &str,
+    format: &str,
+    profile: Profile,
+) -> Result<ClosedGraph, String> {
+    let (dict, triples) = Graph::parse_to_triples(text, format)?;
+    Ok(materialise_closure(dict, triples, profile))
+}
+
+/// Per-predicate **type constraints** mined from a (closed) graph via `sparq-introspect`:
+/// the set of class IRIs admissible as a predicate's subject (domain) and object (range), and a
+/// per-entity type membership map. This is the input to [`NegativeSampler`].
+///
+/// "Admissible domain/range" unions the **declared** `rdfs:domain`/`rdfs:range` with the
+/// **observed** domain/range histograms `sparq-introspect` mines from usage — declared axioms are
+/// often absent or wrong in real data, so the observed classes broaden coverage. A predicate with
+/// *no* known domain (or range) classes is treated as **unconstrained** on that side (every
+/// entity is a valid corruption), so the sampler never deadlocks on a missing schema — it simply
+/// degrades to uniform corruption for that side, which is the honest fail-open behaviour.
+pub struct TypeConstraints {
+    /// `rdf:type` of each entity id, as the **interned class ids** that entity carries. Entities
+    /// with no `rdf:type` are absent (their lookup yields an empty set → unconstrained).
+    entity_types: FxHashMap<Id, FxHashSet<Id>>,
+    /// For each predicate id: the class ids admissible as its **subject** (domain). Empty ⇒
+    /// unconstrained domain.
+    predicate_domain: FxHashMap<Id, FxHashSet<Id>>,
+    /// For each predicate id: the class ids admissible as its **object** (range). Empty ⇒
+    /// unconstrained range.
+    predicate_range: FxHashMap<Id, FxHashSet<Id>>,
+}
+
+impl TypeConstraints {
+    /// Mine type constraints from `graph` (which should already be **closed** — call
+    /// [`materialise_closure`] first so entailed `subClassOf`/type/domain/range facts are present).
+    ///
+    /// Builds the `sparq-introspect` [`Introspection`] once and reads its declared + observed
+    /// domain/range histograms; the per-entity `rdf:type` map is read directly from the graph's
+    /// `rdf:type` triples (so it includes every entailed type, not just a sampled subset).
+    pub fn mine(graph: &Graph) -> TypeConstraints {
+        let introspection = Introspection::build(graph);
+        Self::from_introspection(graph, &introspection)
+    }
+
+    /// Mine type constraints from a graph and a **pre-built** [`Introspection`] (avoids a second
+    /// `Introspection::build` when the caller already has one). The introspection must have been
+    /// built from the *same* `graph` — class/predicate IRIs are resolved back to ids via the
+    /// graph's dictionary.
+    pub fn from_introspection(graph: &Graph, introspection: &Introspection) -> TypeConstraints {
+        let dict = &graph.dict;
+
+        // Resolve the rdf:type predicate id (NO_ID-equivalent if the graph never uses it → the
+        // entity_types map is simply empty and every entity is unconstrained).
+        let rdf_type_id = graph.id_of(&type_term());
+
+        // Per-entity rdf:type set, read from the (closed) graph's rdf:type triples directly so it
+        // reflects every entailed type. iter_ids is subject-sorted; we just scan once.
+        let mut entity_types: FxHashMap<Id, FxHashSet<Id>> = FxHashMap::default();
+        if let Some(type_pred) = rdf_type_id {
+            for [s, p, o] in graph.iter_ids() {
+                if p == type_pred {
+                    entity_types.entry(s).or_default().insert(o);
+                }
+            }
+        }
+
+        // Resolve a class IRI string to its interned id; classes absent from the dict are skipped
+        // (they can never be the type of any entity in this graph, so they cannot constrain).
+        let class_id = |iri: &str| -> Option<Id> {
+            let id = dict_iri_id(dict, iri);
+            id.filter(|&i| i != sparq_core::dict::NO_ID)
+        };
+
+        let mut predicate_domain: FxHashMap<Id, FxHashSet<Id>> = FxHashMap::default();
+        let mut predicate_range: FxHashMap<Id, FxHashSet<Id>> = FxHashMap::default();
+
+        for pred in &introspection.predicates {
+            let Some(pred_id) = class_id(&pred.predicate) else { continue };
+
+            let domain = predicate_domain.entry(pred_id).or_default();
+            for c in &pred.declared_domains {
+                if let Some(cid) = class_id(c) {
+                    domain.insert(cid);
+                }
+            }
+            for c in &pred.inferred_domains {
+                if let Some(cid) = class_id(&c.iri) {
+                    domain.insert(cid);
+                }
+            }
+
+            let range = predicate_range.entry(pred_id).or_default();
+            for c in &pred.declared_ranges {
+                if let Some(cid) = class_id(c) {
+                    range.insert(cid);
+                }
+            }
+            for c in &pred.inferred_ranges {
+                if let Some(cid) = class_id(&c.iri) {
+                    range.insert(cid);
+                }
+            }
+        }
+
+        TypeConstraints { entity_types, predicate_domain, predicate_range }
+    }
+
+    /// The interned `rdf:type` class ids of `entity` (empty if it has none).
+    pub fn types_of(&self, entity: Id) -> Option<&FxHashSet<Id>> {
+        self.entity_types.get(&entity)
+    }
+
+    /// Is `entity` admissible as the **subject** of `predicate`? `true` when the predicate has no
+    /// known domain (unconstrained), or `entity` carries at least one type in the domain.
+    pub fn admissible_subject(&self, predicate: Id, entity: Id) -> bool {
+        self.admissible(&self.predicate_domain, predicate, entity)
+    }
+
+    /// Is `entity` admissible as the **object** of `predicate`? `true` when the predicate has no
+    /// known range (unconstrained), or `entity` carries at least one type in the range.
+    pub fn admissible_object(&self, predicate: Id, entity: Id) -> bool {
+        self.admissible(&self.predicate_range, predicate, entity)
+    }
+
+    fn admissible(
+        &self,
+        side: &FxHashMap<Id, FxHashSet<Id>>,
+        predicate: Id,
+        entity: Id,
+    ) -> bool {
+        match side.get(&predicate) {
+            // Unconstrained side (no declared/observed classes) → every entity is admissible.
+            None => true,
+            Some(classes) if classes.is_empty() => true,
+            Some(classes) => match self.entity_types.get(&entity) {
+                // The entity has no type → cannot be proven admissible against a constrained
+                // side; treat it as inadmissible so type-constrained mode is strictly the
+                // restriction the literature describes (Unconstrained mode bypasses this).
+                None => false,
+                Some(types) => types.iter().any(|t| classes.contains(t)),
+            },
+        }
+    }
+}
+
+/// Which negative-sampling regime to apply — the **on/off ablation switch** (design §6.B). The
+/// sampler runs identically under both modes except for the admissibility filter, so a harness can
+/// measure type-constrained vs unconstrained on the *same* seed and positives.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SamplingMode {
+    /// Vanilla uniform corruption: any entity is a candidate (the ablation **off** baseline).
+    Unconstrained,
+    /// Krompass et al. 2015 type-constrained corruption: head corruptions restricted to the
+    /// predicate's domain types, tail corruptions to its range types (the ablation **on** arm).
+    TypeConstrained,
+}
+
+/// Which position of a positive triple a negative corrupts.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Corrupt {
+    /// Replace the head (subject), keeping `(?, r, t)`.
+    Head,
+    /// Replace the tail (object), keeping `(h, r, ?)`.
+    Tail,
+}
+
+/// A deterministic, type-aware **negative sampler** for KGE training. It does **not** train — it
+/// only *emits* corrupted triples a trainer scores. This is the reusable P0(b) primitive.
+///
+/// The entity pool is the graph's distinct subjects-and-objects of object-property triples (the
+/// nodes a KGE places in entity space). Corruptions are drawn deterministically from a SplitMix64
+/// stream seeded per call, so a fixed `(seed, mode)` is reproducible across runs and platforms —
+/// the on/off ablation compares like with like.
+pub struct NegativeSampler<'a> {
+    constraints: &'a TypeConstraints,
+    /// All candidate entity ids (sorted, deduplicated) — the corruption pool.
+    entities: Vec<Id>,
+    /// Positive `(h, r, t)` triples, used to reject a corruption that accidentally reproduces a
+    /// true triple (the standard "filtered" negative-sampling guard).
+    positives: FxHashSet<[Id; 3]>,
+    mode: SamplingMode,
+}
+
+impl<'a> NegativeSampler<'a> {
+    /// Build a sampler over `graph`'s object-property triples (literal objects are skipped — a KGE
+    /// places only entities in entity space; literals are handled by the typed-literal encoders of
+    /// design Phase 1, not here). `constraints` should be mined from the **same, closed** graph.
+    ///
+    /// `mode` is the ablation switch ([`SamplingMode`]).
+    pub fn new(
+        graph: &Graph,
+        constraints: &'a TypeConstraints,
+        mode: SamplingMode,
+    ) -> NegativeSampler<'a> {
+        let mut entity_set: FxHashSet<Id> = FxHashSet::default();
+        let mut positives: FxHashSet<[Id; 3]> = FxHashSet::default();
+
+        for [s, p, o] in graph.iter_ids() {
+            // Only object-property triples (object is an entity, not a literal/inline value).
+            if is_entity(graph, o) && is_entity(graph, s) {
+                entity_set.insert(s);
+                entity_set.insert(o);
+                positives.insert([s, p, o]);
+            }
+        }
+
+        // Deterministic order: sort the dedup'd entity ids ascending, independent of the
+        // FxHashSet iteration order, so the sampler is reproducible across runs.
+        let mut entities: Vec<Id> = entity_set.into_iter().collect();
+        entities.sort_unstable();
+
+        NegativeSampler { constraints, entities, positives, mode }
+    }
+
+    /// The number of candidate entities in the corruption pool.
+    pub fn entity_count(&self) -> usize {
+        self.entities.len()
+    }
+
+    /// Sample up to `n` negatives for the positive triple `(h, r, t)` corrupting `side`, using
+    /// `seed` to drive a deterministic stream. Returns fewer than `n` only when the admissible
+    /// pool is exhausted (e.g. a tightly-typed predicate with few range entities).
+    ///
+    /// A candidate is rejected when it (a) equals the original entity, (b) reproduces a true
+    /// positive triple (filtered guard), or (c) under [`SamplingMode::TypeConstrained`] is not
+    /// admissible for the corrupted side. Under [`SamplingMode::Unconstrained`] only (a) and (b)
+    /// apply — that is the ablation baseline.
+    pub fn sample(&self, triple: [Id; 3], side: Corrupt, n: usize, seed: u64) -> Vec<[Id; 3]> {
+        let [h, r, t] = triple;
+        if self.entities.is_empty() || n == 0 {
+            return Vec::new();
+        }
+        let mut out = Vec::with_capacity(n.min(self.entities.len()));
+        let mut emitted: FxHashSet<Id> = FxHashSet::default();
+        let mut state = seed ^ mix_triple(triple) ^ (side_salt(side));
+
+        // Bounded attempts: at most a small multiple of the pool, so a near-empty admissible set
+        // terminates instead of spinning. The cap is generous enough that a healthy pool fills `n`.
+        let max_attempts = self.entities.len().saturating_mul(8).max(64);
+        for _ in 0..max_attempts {
+            if out.len() >= n {
+                break;
+            }
+            let idx = (splitmix64(&mut state) as usize) % self.entities.len();
+            let candidate = self.entities[idx];
+
+            let (nh, nt) = match side {
+                Corrupt::Head => (candidate, t),
+                Corrupt::Tail => (h, candidate),
+            };
+            let original = match side {
+                Corrupt::Head => h,
+                Corrupt::Tail => t,
+            };
+
+            if candidate == original || emitted.contains(&candidate) {
+                continue;
+            }
+            // Filtered guard: never emit a corruption that is itself a true triple.
+            if self.positives.contains(&[nh, r, nt]) {
+                continue;
+            }
+            // Type-constraint filter — the only behavioural difference between the two modes.
+            if self.mode == SamplingMode::TypeConstrained {
+                let ok = match side {
+                    Corrupt::Head => self.constraints.admissible_subject(r, candidate),
+                    Corrupt::Tail => self.constraints.admissible_object(r, candidate),
+                };
+                if !ok {
+                    continue;
+                }
+            }
+
+            emitted.insert(candidate);
+            out.push([nh, r, nt]);
+        }
+        out
+    }
+}
+
+// ---- helpers ----------------------------------------------------------------------------------
+
+/// The `rdf:type` named-node term.
+fn type_term() -> oxrdf::Term {
+    oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked(RDF_TYPE))
+}
+
+/// Resolve an IRI string to its interned dictionary id, or `None` if absent.
+fn dict_iri_id(dict: &sparq_core::dict::Dict, iri: &str) -> Option<Id> {
+    let id = dict.lookup(&oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked(iri)));
+    (id != sparq_core::dict::NO_ID).then_some(id)
+}
+
+/// Is the term id an **entity** (a named node or blank node), as opposed to a literal / inline
+/// value? Only entities go in KGE entity space.
+fn is_entity(graph: &Graph, id: Id) -> bool {
+    matches!(
+        graph.dict.term_parts(id),
+        TermParts::Iri { .. } | TermParts::Blank(_)
+    )
+}
+
+/// Mix a triple into a 64-bit value so the per-triple stream differs for each positive (the
+/// sampler is otherwise deterministic for a fixed seed).
+fn mix_triple([s, p, o]: [Id; 3]) -> u64 {
+    let mut v = (s as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15);
+    v ^= (p as u64).rotate_left(21).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    v ^= (o as u64).rotate_left(42).wrapping_mul(0x94D0_49BB_1331_11EB);
+    v
+}
+
+/// A small per-side salt so head and tail streams of the same triple diverge.
+fn side_salt(side: Corrupt) -> u64 {
+    match side {
+        Corrupt::Head => 0x1111_2222_3333_4444,
+        Corrupt::Tail => 0x5555_6666_7777_8888,
+    }
+}
+
+/// SplitMix64 — a small, fast, well-distributed deterministic PRNG step. Reused (not imported)
+/// from the same algorithm `embed.rs` uses; kept local so `structure` carries no cross-module
+/// `pub(crate)` coupling beyond the feature gate.
+#[inline]
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // A small schema-rich graph: a subclass hierarchy + typed entities + an object property with a
+    // declared domain/range, plus a "wrong-typed" entity that type-constrained sampling must
+    // exclude as a corruption.
+    const TTL: &str = r#"
+@prefix rdf:  <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix ex:   <http://ex/> .
+
+ex:Dog   rdfs:subClassOf ex:Animal .
+ex:Cat   rdfs:subClassOf ex:Animal .
+ex:Owner rdfs:subClassOf ex:Person .
+
+ex:owns rdfs:domain ex:Person ; rdfs:range ex:Animal .
+
+ex:alice a ex:Owner .
+ex:bob   a ex:Owner .
+ex:rex   a ex:Dog .
+ex:tom   a ex:Cat .
+ex:car   a ex:Vehicle .
+
+ex:alice ex:owns ex:rex .
+ex:bob   ex:owns ex:tom .
+"#;
+
+    fn closed() -> ClosedGraph {
+        close_for_vectorise(TTL, "turtle", Profile::Rdfs).unwrap()
+    }
+
+    #[test]
+    fn closure_materialises_entailed_types() {
+        let c = closed();
+        // RDFS must add at least: rex a Animal, tom a Animal, alice a Person, bob a Person (rdfs9
+        // via subClassOf), and the domain/range entailments (rdfs2/rdfs3).
+        assert!(c.entailed_triples > 0, "closure added nothing: {}", c.entailed_triples);
+        assert_eq!(c.closed_triples(), c.asserted_triples + c.entailed_triples);
+
+        // The entailed `ex:rex a ex:Animal` must now be a real triple visible to the encoder.
+        let rex = c.graph.id_of(&iri("http://ex/rex")).unwrap();
+        let animal = c.graph.id_of(&iri("http://ex/Animal")).unwrap();
+        let type_p = c.graph.id_of(&type_term()).unwrap();
+        let has = c.graph.iter_ids().any(|[s, p, o]| s == rex && p == type_p && o == animal);
+        assert!(has, "closure-before-vectorise did not materialise ex:rex a ex:Animal");
+    }
+
+    #[test]
+    fn type_constraints_read_domain_and_range() {
+        let c = closed();
+        let tc = TypeConstraints::mine(&c.graph);
+        let owns = c.graph.id_of(&iri("http://ex/owns")).unwrap();
+
+        let alice = c.graph.id_of(&iri("http://ex/alice")).unwrap(); // Owner ⊑ Person
+        let rex = c.graph.id_of(&iri("http://ex/rex")).unwrap(); // Dog ⊑ Animal
+        let car = c.graph.id_of(&iri("http://ex/car")).unwrap(); // Vehicle — neither
+
+        // Subject (domain = Person): a Person is admissible; an Animal/Vehicle is not.
+        assert!(tc.admissible_subject(owns, alice), "Owner⊑Person must satisfy domain Person");
+        assert!(!tc.admissible_subject(owns, car), "Vehicle must not satisfy domain Person");
+
+        // Object (range = Animal): an Animal is admissible; a Person/Vehicle is not.
+        assert!(tc.admissible_object(owns, rex), "Dog⊑Animal must satisfy range Animal");
+        assert!(!tc.admissible_object(owns, car), "Vehicle must not satisfy range Animal");
+        assert!(!tc.admissible_object(owns, alice), "Person must not satisfy range Animal");
+    }
+
+    #[test]
+    fn type_constrained_sampler_excludes_wrong_types() {
+        let c = closed();
+        let tc = TypeConstraints::mine(&c.graph);
+        let owns = c.graph.id_of(&iri("http://ex/owns")).unwrap();
+        let alice = c.graph.id_of(&iri("http://ex/alice")).unwrap();
+        let rex = c.graph.id_of(&iri("http://ex/rex")).unwrap();
+        let car = c.graph.id_of(&iri("http://ex/car")).unwrap();
+
+        let sampler =
+            NegativeSampler::new(&c.graph, &tc, SamplingMode::TypeConstrained);
+
+        // Corrupt the TAIL of (alice owns rex): every emitted object must be range-admissible
+        // (an Animal), so `ex:car` (Vehicle) can NEVER appear.
+        let negs = sampler.sample([alice, owns, rex], Corrupt::Tail, 16, 42);
+        assert!(!negs.is_empty(), "expected some type-valid tail corruptions");
+        for [h, r, t] in &negs {
+            assert_eq!(*h, alice);
+            assert_eq!(*r, owns);
+            assert!(tc.admissible_object(owns, *t), "emitted non-range tail {t}");
+            assert_ne!(*t, car, "Vehicle must never be a type-constrained range corruption");
+            assert_ne!(*t, rex, "must not reproduce the original tail");
+        }
+    }
+
+    #[test]
+    fn ablation_off_admits_wrong_types() {
+        let c = closed();
+        let tc = TypeConstraints::mine(&c.graph);
+        let owns = c.graph.id_of(&iri("http://ex/owns")).unwrap();
+        let alice = c.graph.id_of(&iri("http://ex/alice")).unwrap();
+        let rex = c.graph.id_of(&iri("http://ex/rex")).unwrap();
+        let car = c.graph.id_of(&iri("http://ex/car")).unwrap();
+
+        // Unconstrained mode is the ablation OFF baseline: the type filter is bypassed, so the
+        // wrong-typed `ex:car` is reachable as a tail corruption (it would never be under ON).
+        let off = NegativeSampler::new(&c.graph, &tc, SamplingMode::Unconstrained);
+        let mut saw_car = false;
+        // Several seeds, since any single draw is random; the pool is tiny so this is reliable.
+        for seed in 0..32u64 {
+            let negs = off.sample([alice, owns, rex], Corrupt::Tail, 8, seed);
+            if negs.iter().any(|[_, _, t]| *t == car) {
+                saw_car = true;
+                break;
+            }
+        }
+        assert!(saw_car, "Unconstrained ablation arm must be able to emit the wrong-typed entity");
+        let _ = rex;
+    }
+
+    #[test]
+    fn sampler_is_deterministic_for_fixed_seed() {
+        let c = closed();
+        let tc = TypeConstraints::mine(&c.graph);
+        let owns = c.graph.id_of(&iri("http://ex/owns")).unwrap();
+        let alice = c.graph.id_of(&iri("http://ex/alice")).unwrap();
+        let rex = c.graph.id_of(&iri("http://ex/rex")).unwrap();
+        let s = NegativeSampler::new(&c.graph, &tc, SamplingMode::TypeConstrained);
+        let a = s.sample([alice, owns, rex], Corrupt::Tail, 4, 7);
+        let b = s.sample([alice, owns, rex], Corrupt::Tail, 4, 7);
+        assert_eq!(a, b, "fixed (seed, mode, triple) must reproduce identical negatives");
+    }
+
+    #[test]
+    fn sampler_never_reproduces_a_true_triple() {
+        let c = closed();
+        let tc = TypeConstraints::mine(&c.graph);
+        let owns = c.graph.id_of(&iri("http://ex/owns")).unwrap();
+        let alice = c.graph.id_of(&iri("http://ex/alice")).unwrap();
+        let bob = c.graph.id_of(&iri("http://ex/bob")).unwrap();
+        let rex = c.graph.id_of(&iri("http://ex/rex")).unwrap();
+        let tom = c.graph.id_of(&iri("http://ex/tom")).unwrap();
+        // (bob owns tom) is a true triple; corrupting (alice owns rex)'s head to `bob` together
+        // with tail `tom` is not what `sample` does (it fixes the tail), but corrupting the tail of
+        // (bob owns ?) must never re-emit `tom`.
+        let s = NegativeSampler::new(&c.graph, &tc, SamplingMode::TypeConstrained);
+        for seed in 0..32 {
+            let negs = s.sample([bob, owns, tom], Corrupt::Tail, 8, seed);
+            assert!(
+                !negs.contains(&[bob, owns, tom]),
+                "filtered guard must drop the true triple"
+            );
+        }
+        let _ = (alice, rex);
+    }
+
+    #[test]
+    fn unconstrained_predicate_is_fail_open() {
+        // A predicate with no declared/observed range still samples (degrades to uniform), so a
+        // missing schema never deadlocks the trainer.
+        let ttl = r#"
+@prefix ex: <http://ex/> .
+ex:a ex:rel ex:b .
+ex:b ex:rel ex:c .
+ex:c ex:rel ex:a .
+"#;
+        let c = close_for_vectorise(ttl, "turtle", Profile::Rdfs).unwrap();
+        let tc = TypeConstraints::mine(&c.graph);
+        let rel = c.graph.id_of(&iri("http://ex/rel")).unwrap();
+        let a = c.graph.id_of(&iri("http://ex/a")).unwrap();
+        let b = c.graph.id_of(&iri("http://ex/b")).unwrap();
+        let s = NegativeSampler::new(&c.graph, &tc, SamplingMode::TypeConstrained);
+        let negs = s.sample([a, rel, b], Corrupt::Tail, 4, 1);
+        assert!(!negs.is_empty(), "unconstrained predicate must still produce negatives");
+    }
+
+    fn iri(s: &str) -> oxrdf::Term {
+        oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked(s))
+    }
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -695,6 +695,43 @@ to a crash-durable `.spqd` (write-tmp + `fsync` + atomic rename) that `open_with
 detected (an exact-length check) and rejected, never read out of bounds. `put` is unchanged (still errors
 after `finalize`) — `add` is the additive path.
 
+### 13. Structure-aware preprocessing — closure + type-constrained negatives (opt-in, feature = `structure`)
+
+<!-- [OPUS-4.8] sq-0wo9e.1 (epic sq-0wo9e; design research/structure-aware-vectorisation.md §5.A/§2). -->
+Research-grade **P0** of the structure-aware-vectorisation epic. Two additive, buildable primitives an
+**out-of-process** KGE trainer consumes — this crate **trains nothing** (embeddings are produced
+outside it) and serves no exact answer.
+
+1. **Closure-before-vectorise** — run the `sparq-reason` RDFS/OWL-RL closure **before** the
+   vectoriser sees the graph, so entailed `rdf:type`/`subClassOf`/domain/range triples are *real
+   facts* the encoder, type extractor, and sampler read (design §5.A; the reasoner is sound+complete
+   for its profile, incremental closure property-tested == from-scratch).
+2. **Type-constrained negative sampling** (Krompass et al. 2015) — a `NegativeSampler` corrupts a
+   positive triple's head only to **domain**-consistent entities and its tail only to **range**-consistent
+   ones, reading declared+observed domain/range from `sparq-introspect`. The `SamplingMode`
+   (`Unconstrained` / `TypeConstrained`) is the **on/off ablation switch** (design §6.B) — a harness
+   measures Hits@k/MRR both ways on the same seed. **No benchmark numbers exist; none are claimed.**
+
+```rust,ignore
+# // cargo build -p sparq-vectors --features structure
+use sparq_reason::Profile;
+use sparq_vectors::{close_for_vectorise, Corrupt, NegativeSampler, SamplingMode, TypeConstraints};
+
+let closed = close_for_vectorise(turtle_src, "turtle", Profile::Rdfs)?;  // materialise entailed facts
+let constraints = TypeConstraints::mine(&closed.graph);                  // declared+observed domain/range
+let sampler = NegativeSampler::new(&closed.graph, &constraints, SamplingMode::TypeConstrained);
+let negatives = sampler.sample([h, r, t], Corrupt::Tail, 16, /*seed*/ 42);  // type-valid tail corruptions
+# Ok::<(), String>(())
+```
+
+**Fail-open by design.** A predicate with no known domain (or range) class degrades to uniform
+corruption for that side — a missing/wrong schema never deadlocks the sampler. The sampler is
+deterministic for a fixed `(seed, mode, triple)` and applies the standard "filtered" guard (never
+emits a corruption that is itself a true triple). **Honesty:** the empirical benefit of either prior is
+**unproven** — both ship behind the ablation precisely because the literal/type-aware KGE literature
+reports inconsistent gains; this slice is the buildable inputs, the trainer that consumes them is a
+tracked follow-up.
+
 ## Gotchas / feature flags / prerequisites
 
 - **Opt-in.** Nothing in the workspace depends on `sparq-vectors`; the default engine
@@ -711,6 +748,12 @@ after `finalize`) — `add` is the additive path.
   methods write a delta the read paths consult transparently (recipe 12). The delta lives in RAM on the
   handle; `save_delta` persists it to a crash-durable `.spqd` sidecar and `open_with_delta` replays it,
   so mutations survive a restart without a `compact` (the two durability paths).
+- **Structure-aware preprocessing is the non-default `structure` feature (sq-0wo9e.1).** It is the
+  ONLY feature pulling `sparq-reason` + `sparq-introspect` into this crate, both **optional**, so
+  with it OFF the default build compiles zero structure-prep code and gains no new required deps. With
+  it ON it exposes `close_for_vectorise` / `materialise_closure` / `ClosedGraph`, `TypeConstraints`,
+  and the `NegativeSampler` + `SamplingMode` (on/off ablation) of recipe 13. It TRAINS NOTHING and
+  serves no exact answer; benefit is **unproven** (research-grade, no accuracy claim, no numbers).
 - **`approx-ann` is the ONLY heavy ANN dependency, and it is OFF by default (sq-ip3a).** The HNSW
   index (`VectorIndex`/`HnswConfig`) and the `ApproxBackend` are gated behind it — it is the only
   thing pulling `instant-distance`. With it OFF the default build is lean: exact brute-force


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing **sq-0wo9e.1** (P0 of the structure-aware-vectorisation epic **sq-0wo9e**). Please review this **together with the design record in PR #996** (`research/structure-aware-vectorisation.md`); auto-merge is intentionally **left OFF** so the maintainer reviews the slice against the design.

## What this is

The lowest-risk, additive **P0** slice of the structure-aware-vectorisation epic — design §5.A (materialise-closure-before-vectorise) + §2 (the domain/range row → type-constrained negative sampling). New, **opt-in** behind a `structure` cargo feature, **OFF by default**.

It is the **only** feature pulling `sparq-reason` + `sparq-introspect` into `sparq-vectors`, both **optional**, so the default build (and the core query path) carry **zero** structure-prep code and gain **no new required deps** — the lean-core constraint holds.

### New `crates/sparq-vectors/src/structure.rs` — two reusable P0 primitives

1. **closure-before-vectorise** (`close_for_vectorise` / `materialise_closure` → `ClosedGraph`) — run the `sparq-reason` RDFS/OWL-RL closure **before** the vectoriser sees the graph, so entailed `rdf:type`/`subClassOf`/domain/range triples are *real facts* the encoder, type extractor, and sampler read. The reasoner is sound+complete for its profile; sparq-reason's incremental closure is already property-tested == from-scratch.
2. **type-constrained negative sampling** (`TypeConstraints` + `NegativeSampler`, Krompass et al. 2015) — corrupt a positive triple's **head** only to **domain**-consistent entities and its **tail** only to **range**-consistent ones, reading **declared + observed** domain/range from `sparq-introspect` over the *closed* graph. Fail-open (a predicate with no known domain/range degrades to uniform), filtered guard (never emits a corruption that is itself a true triple), deterministic for a fixed `(seed, mode, triple)`.

`SamplingMode::{Unconstrained,TypeConstrained}` is the **on/off ablation switch** (design §6.B) so adoption is measurement-gated.

## Scope finding (honest)

**`sparq-vectors` has NO KGE training path** — embeddings are produced **out-of-process**; there is no TransE/ComplEx/RotatE, no triple-scoring, no learning loop. Design P0 ("restrict KGE *corruptions*") therefore presupposes a trainer that does not exist in-tree. Rather than build a large new training subsystem blind (the guardrail in the brief), this PR ships the two **buildable, additive** halves of P0 as reusable primitives an out-of-process trainer (or a future in-tree KGE block) consumes. **It trains nothing and serves no exact answer.** The trainer that consumes these negatives is the **deferred remainder** (noted in the README/SKILL; I will file a follow-up bead under the epic).

**Empirical benefit is UNPROVEN.** Both priors ship behind the ablation precisely because the literal/type-aware KGE literature reports **inconsistent** gains (design §1, §9). **No accuracy claim, no benchmark numbers, no ZK/MPC claim.** Research-grade.

## Tests (the real path)

7 unit tests + 1 doctest exercise the **real** RDFS reasoner + introspect path: closure materialises entailed types (`ex:rex a ex:Animal`), domain/range mined from declared+observed, type-constrained sampler **excludes** wrong-typed entities, the ablation-OFF arm **admits** them, determinism, filtered guard, fail-open on an unconstrained predicate.

## Gates (both feature states)

| Gate | Result |
|---|---|
| `cargo build -p sparq-vectors` (feature **OFF**) | ✅ |
| `cargo build -p sparq-vectors --features structure` (**ON**) | ✅ |
| `cargo test -p sparq-vectors` (OFF) | ✅ |
| `cargo test -p sparq-vectors --features structure` (ON) | ✅ 52 lib + 7 doc |
| `cargo clippy --workspace --all-targets --all-features -- -D warnings` | ✅ clean |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` | ✅ clean |
| README ≤120-line template (`scripts/check-readme-template.py`) | ✅ 0 deviations |
| typos gate | ✅ clean |

**Feature flag:** `structure` (default OFF) — `structure = ["dep:sparq-reason", "dep:sparq-introspect"]`.

Docs: crate `README.md` ✨ bullet + `skills/vector-search/SKILL.md` recipe 13 + feature-flag note.

Refs **sq-0wo9e.1**, epic **sq-0wo9e**, design **#996**.