### PR TITLE
ci(release): mark hyphenated tags as pre-releases (sq-v286)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -289,6 +289,11 @@ jobs:
         with:
           files: assets/*
           generate_release_notes: true
+          # [OPUS-4.8] sq-v286: a hyphenated semver tag (v*-dev.N / v*-rc.N / v*-beta.N) is a
+          # pre-release; a bare vX.Y.Z is a full release. Lets us cut unsigned dev previews
+          # without flagging them "Latest". softprops/action-gh-release does NOT infer this from
+          # the tag, so it is set explicitly here.
+          prerelease: ${{ contains(github.ref_name, '-') }}
           # CHANGELOG.md is the curated source of truth; point readers at it.
           body: |
             See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/${{ github.ref_name }}/CHANGELOG.md) for the curated changelog.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change.

`softprops/action-gh-release` does not infer pre-release status from the tag name, so every `v*` tag currently produces a **full** release flagged *Latest*. This sets `prerelease: ${{ contains(github.ref_name, '-') }}` so:
- `v0.1.0-dev.1` / `v*-rc.N` / `v*-beta.N` → **pre-release** (not Latest)
- bare `vX.Y.Z` → full release (unchanged)

Unblocks cutting the first **unsigned dev preview** (`v0.1.0-dev.1`) for the `/download` page without mislabelling it as a stable Latest release. Refs sq-v286, sq-gl3cf.