### PR TITLE
feat(gui): distinct operational GUI frontend + app shell — stop wrapping the marketing site (sq-ixc3.8, sq-ixc3.9)

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -158,6 +158,69 @@ jobs:
         working-directory: site
         run: npm run build
 
+  # [OPUS-4.8] sq-ixc3.8 / sq-ixc3.9 — the DISTINCT operational GUI frontend (gui/app).
+  #
+  # This is the load-bearing deliverable of the GUI-foundation work: the workbench frontend is a
+  # SEPARATE Next.js app (NOT the marketing site), static-exported for BOTH the Tauri desktop
+  # webview (root-relative) AND a hosted "Try the GUI live" web target (sub-path). It runs the
+  # in-tab WASM engine, so the build embeds the lean shacl,jsonld bundle (built first). GATING
+  # (no `advisory` keyword): it is TS + a static export, fully reproducible on a Linux runner
+  # without any webview system libraries, so a break here is a real regression.
+  gui-app:
+    name: "operational GUI frontend (build + lint + typecheck, both targets)"
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # The GUI frontend embeds the in-tab engine, so the wasm bundle must be built first
+      # (the same shacl,jsonld bundle the site syncs).
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Cache cargo
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: gui-app-wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      - name: Build wasm bundle (shacl,jsonld)
+        working-directory: js
+        run: npm run build:wasm
+
+      - name: Install workspace dependencies
+        run: npm install
+
+      - name: GUI frontend lint
+        working-directory: gui/app
+        run: npm run lint
+
+      - name: GUI frontend typecheck
+        working-directory: gui/app
+        run: npm run typecheck
+
+      # The hosted "Try the GUI live" web target (sub-path basePath).
+      - name: GUI frontend static export (web target)
+        working-directory: gui/app
+        run: npm run build:web
+
+      # The Tauri desktop webview target (root-relative). Proves the SAME frontend exports for
+      # both hosts off the single NEXT_PUBLIC_BASE_PATH switch.
+      - name: GUI frontend static export (Tauri target)
+        working-directory: gui/app
+        run: npm run build:tauri
+
   # [OPUS-4.8] sq-bu69 — per-platform Tauri build + clippy matrix.
   #
   # ADVISORY (see the header): every matrix row's NAME carries the `advisory` keyword, so the
@@ -308,20 +371,23 @@ jobs:
         run: cargo install wasm-pack --locked
 
       # Build the frontend the Tauri webview embeds. The shell's `cargo build` embeds whatever
-      # is in `site/out` at COMPILE TIME, so the frontend MUST be built first. The site export
-      # is root-relative (NEXT_PUBLIC_BASE_PATH='') because a Tauri webview serves from the
-      # custom-protocol root, not GitHub Pages' /sparq basePath (gui/README.md).
-      - name: Build the lean WASM bundle (the in-tab engine)
+      # is in `gui/app/out` at COMPILE TIME (sq-ixc3.8 repointed `frontendDist` to the DISTINCT
+      # operational frontend, NOT the marketing site), so the frontend MUST be built first. The
+      # export is root-relative (build:tauri sets NEXT_PUBLIC_BASE_PATH='') because a Tauri
+      # webview serves from the custom-protocol root, not a /sparq basePath (gui/README.md).
+      #
+      # The GUI frontend embeds the in-tab engine, so it needs the shacl,jsonld bundle (its
+      # SHACL tool + JSON-LD ingest) — build the full bundle, not the lean one.
+      - name: Build the WASM bundle (shacl,jsonld; the in-tab engine)
         working-directory: js
         run: |
           npm install
-          npm run build:wasm:lean
+          npm run build:wasm
 
-      - name: Build the site static export (root-relative; embedded by the shell)
-        working-directory: site
+      - name: Build the GUI frontend static export (root-relative; embedded by the shell)
         run: |
           npm install
-          NEXT_PUBLIC_BASE_PATH='' npm run build
+          (cd gui/app && npm run build:tauri)
 
       # Build the desktop shell binary (debug). With site/out present, tauri_build embeds the
       # frontend into the `sparq-gui` binary tauri-driver will launch.

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,25 +1,40 @@
-# sparq GUI (Tauri 2 — MVP scaffold)
+# sparq GUI — operational workbench (Tauri 2 desktop + hosted web)
 
-A cross-platform desktop **scaffold** for the sparq RDF + SPARQL workbench, per the design
-record [`research/gui-design.md`](../research/gui-design.md) (bead `sq-2e93`). It follows the
-design's framework recommendation: **Tauri 2**, reusing the existing Next.js/React frontend
-(`site/`) in a native webview, with the engine linked **directly as native Rust**.
+A cross-platform **operational workbench** for the sparq RDF + SPARQL engine, per the design
+record [`research/gui-design.md`](../research/gui-design.md) §A (beads `sq-ixc3.8` / `sq-ixc3.9`,
+epic `sq-ixc3`). It is a **DISTINCT app, not the marketing site in a window**: a dense IDE-style
+workbench (left rail · thin top bar · IDE tab strip · status bar) over a live engine, where the
+showcase capabilities are TOOLS you run, not pages that describe them.
 
-> **This is a scaffold, not a shipped app.** It is structurally valid (`tauri.conf.json`
-> parses, `cargo metadata` resolves the full dependency graph) and the engine command layer
-> is unit-tested natively, but a full `cargo build` / `cargo tauri build` needs the webview
-> **system libraries** (webkit2gtk on Linux, WebView2 on Windows, WKWebView on macOS) that
-> are not present on every dev box. The full build/lint/typecheck is validated in the
-> path-scoped CI lane [`.github/workflows/gui.yml`](../.github/workflows/gui.yml), not
-> necessarily locally. Until that lane is green on a runner, treat this as **CI-validated /
-> locally-scaffolded**, not a working app.
+> **Foundation shell.** This PR stands up the distinct frontend + app shell with a working Query
+> tool over the live in-tab engine; the other TOOLS open as honest stubs the later phases fill
+> (Cmd-K palette `sq-ixc3.10`, the multi-view query workbench `sq-ixc3.12`, the import drawer
+> `sq-ixc3.13`, surfaces-as-tools `sq-ixc3.11`). The full per-platform desktop `cargo tauri build`
+> needs the webview **system libraries** (webkit2gtk on Linux, WebView2 on Windows, WKWebView on
+> macOS) validated in CI ([`.github/workflows/gui.yml`](../.github/workflows/gui.yml)), not
+> necessarily on every dev box.
+
+## Two builds, one frontend
+
+The operational frontend (`gui/app/`) static-exports (`output: export`, backend-free) for BOTH
+targets, selected by the single `NEXT_PUBLIC_BASE_PATH` switch (the same switch the site + the
+`@sparq/client` wasm loader key off, kept in lockstep):
+
+| Target | Command (`gui/app`) | `basePath` | Where it runs |
+|---|---|---|---|
+| **Tauri desktop** | `npm run build:tauri` | `""` (root-relative) | embedded in the desktop webview (serves from the `tauri://` root) |
+| **Hosted "Try the GUI live" web** | `npm run build:web` | `/sparq/gui` (default; overridable) | a static page so the site's "Try the GUI" link has a real target (bead `sq-wt4s3`; the hosting/Pages-root slot is `sq-svtt`) |
+
+The desktop bundle is wired via `gui/src-tauri/tauri.conf.json` — `frontendDist: "../app/out"`
+and `beforeBuildCommand: cd ../app && npm run build:tauri`. **`frontendDist` is no longer
+`site/out`** (the core of `sq-ixc3.8`): the GUI never embeds the marketing site.
 
 ## Why Tauri 2
 
 The design weighed Tauri 2 vs egui/iced vs Electron/PWA and chose **Tauri 2** because it (1)
-maximises reuse of the existing ~40-component React frontend, (2) unlocks the **full native
-engine** (rayon, mmap, `save`/`open`, no ~2 GiB tab ceiling — escaping every WASM limit), (3)
-closes the static-site live-backend gap, and (4) is the only credible mobile path here. See
+reuses the existing React/Tailwind stack + the WASM engine client, (2) unlocks the **full native
+engine** on desktop (rayon, mmap, `save`/`open`, no ~2 GiB tab ceiling) via a direct Rust link,
+(3) closes the static-site live-backend gap, and (4) is the only credible mobile path here. See
 `research/gui-design.md` §1 for the full comparison and honest caveats.
 
 ## Layout
@@ -27,56 +42,65 @@ closes the static-site live-backend gap, and (4) is the only credible mobile pat
 ```
 gui/
   README.md
+  app/                  # NEW: the DISTINCT operational frontend (Next.js, static-exported)
+    next.config.ts      #   env-switched basePath: build:tauri (root) / build:web (sub-path)
+    src/
+      app/              #   single route — the workbench shell (no /about, /benchmarks, …)
+      components/
+        workbench/      #   the shell: left-rail · top-bar · tab-strip · status-bar +
+                        #     query-workbench (the working Query tool) + tool-stub (honest stubs)
+        ui/             #   reused design-system primitives (button, badge) — sibling of the site
+      data/tools.ts     #   the TOOLS taxonomy (each a VERB with an honesty-tier dot)
+      lib/engine-context.tsx  # the ONE live wasm store + measured-latency query path
+  e2e/                  # tauri-driver (WebDriver) e2e — launches the shell, runs a query, asserts
   src-tauri/
     Cargo.toml          # standalone crate root (own [workspace]); links sparq-engine + sparq-core
-    tauri.conf.json     # window + bundle + frontendDist (= site/out)
+    tauri.conf.json     # window + bundle + frontendDist (= ../app/out)
     build.rs            # tauri_build::build()
     capabilities/       # least-privilege window capability (core + dialog:open)
-    icons/              # placeholder brand icons (PNG)
     src/
       main.rs           # desktop binary -> sparq_gui_lib::run()
       lib.rs            # Tauri builder: manages EngineState, registers the command handlers
       engine.rs         # the DIRECT native engine link: load/query/queryQuads/update/explain/count/ask
 ```
 
-## The direct native engine link
+## The app shell (sq-ixc3.9)
 
-`src/engine.rs` is the concrete proof of the design's embedding decision: a native
-`sparq_core::Graph` behind a `Mutex`, with Tauri commands that mirror the wasm `Store`
-surface exactly (`crates/sparq-wasm/src/lib.rs`) — `load`, `query`, `query_quads`,
-`update_in_place`, `explain`, `explain_analyze`, `count`, `ask`, `store_size` — but backed by
-the full native store rather than the WASM read-replica. Its `#[cfg(test)]` tests exercise the
-engine calls **directly** (no Tauri runtime), so they are the locally-runnable proof that the
-command layer is wired to the real engine, even when the full Tauri build is CI-only.
+`gui/app/src/components/workbench/` is the operational shell from `gui-design.md` §A.2:
 
-## Frontend reuse + the basePath switch (`sq-9vw5`)
+- **Left rail** (`w-56`): a workspace switcher (the persistent model is `sq-atb0`; foundation =
+  default), a **datasets tree of the live store** (default + named graphs with per-graph counts)
+  with an `+ Import` entry point, and the **TOOLS** list — each a VERB opened as a tab with an
+  honesty-tier dot, never a page describing the feature.
+- **Top bar** (`h-10`): a LOCAL⇄ENDPOINT target switch, the store size, a ⌘K hint, a theme toggle,
+  and an engine status LED.
+- **IDE tab strip** + a full-bleed work area (default = Query).
+- **Status bar** (`h-6`): the **measured `performance.now()` latency** of the last run, the row
+  count, the target, and the persistence backend.
 
-The webview loads the site's static export (`frontendDist: "../../site/out"`). The site
-defaults to `basePath: "/sparq"` for GitHub Pages, but a Tauri webview serves from the
-`tauri://` root, so the export the GUI consumes **must** be built root-relative
-(`basePath: ""`). `site/next.config.ts` now **env-switches** `basePath`/`assetPrefix` off
-`NEXT_PUBLIC_BASE_PATH`: the `beforeBuildCommand` runs the site's `build:tauri` script
-(`cross-env NEXT_PUBLIC_BASE_PATH= npm run build`), which sets the env var to an **empty
-string** cross-platform — `cross-env` is the portable shim so the same command works under a
-Unix shell and Windows `cmd.exe` (the bare `NEXT_PUBLIC_BASE_PATH='' npm run build` inline
-prefix is a Unix-shell idiom that `cmd.exe` does not parse, which broke the win-x64 installer
-row). So the GUI's export is root-relative with no extra step. Hand-written absolute asset hrefs (the
-favicon, the COOP/COEP service-worker `<Script src>`, the paper PDF links) read the **same**
-env var via `site/src/lib/base-path.ts`, so they move with the build mode too. See the
-"Build modes" table in [`site/README.md`](../site/README.md).
+## The direct native engine link (desktop)
+
+`src-tauri/src/engine.rs` is the concrete proof of the design's embedding decision: a native
+`sparq_core::Graph` behind a `Mutex`, with Tauri commands that mirror the wasm `Store` surface
+(`load` / `query` / `query_quads` / `update_in_place` / `explain` / `explain_analyze` / `count` /
+`ask` / `store_size`) but backed by the full native store. Its `#[cfg(test)]` tests exercise the
+engine calls directly. The foundation frontend runs the in-tab WASM engine in BOTH targets (the
+honest, working-today path); swapping the desktop target onto this IPC command layer is a later
+phase (`sq-ixc3.6`).
 
 ## Shared TS client
 
 The frontend consumes the framework-agnostic `@sparq/client`
-([`packages/sparq-client`](../packages/sparq-client)) for the `WasmStore` type surface and
-loaders — the same package the site uses — so the GUI is a **zero-new-copy** consumer rather
-than a third hand-redeclaration of the engine's TS surface (the drift liability the design
-flags). On desktop the GUI prefers the IPC command layer above over WASM, but the shared
-types remain the single source of truth for the result shapes both render.
+([`packages/sparq-client`](../packages/sparq-client)) for the wasm `Store` type surface, the
+loaders, and the result-shaping helpers — the **same package the site uses** — so the GUI is a
+**zero-new-copy** consumer, not a third hand-redeclaration of the engine's TS surface.
 
 ## Honesty
 
-No performance number is asserted. The ZK/MPC surfaces the reused frontend can drive are
-**research-grade and not externally audited**; that framing is inherited unchanged from the
-site. Mobile (Android/iOS), the native `save`/`open` persistence path, endpoint mode, and the
-editor uplift are later phases in the design, not in this scaffold.
+No performance number is baked in — the status bar shows the **measured** latency of the query you
+just ran, labelled as such (this work box / CI runner is non-canonical). The ZK/MPC tools are
+**research-grade and not externally audited** (the v1 ZK verifier is internally re-audited only,
+external accredited-cryptographer sign-off is pending; `sparq-mpc` is honest-majority semi-honest
+only, and the site's MPC demo is an in-tab JS simulation, not live MPC) — the tool stubs carry
+those caveats verbatim and never present either as a settled cryptographic guarantee. A
+`walkthrough`/`soon` tool is never silently dressed up as `live`.

--- a/gui/README.md
+++ b/gui/README.md
@@ -23,7 +23,7 @@ targets, selected by the single `NEXT_PUBLIC_BASE_PATH` switch (the same switch 
 | Target | Command (`gui/app`) | `basePath` | Where it runs |
 |---|---|---|---|
 | **Tauri desktop** | `npm run build:tauri` | `""` (root-relative) | embedded in the desktop webview (serves from the `tauri://` root) |
-| **Hosted "Try the GUI live" web** | `npm run build:web` | `/sparq/gui` (default; overridable) | a static page so the site's "Try the GUI" link has a real target (bead `sq-wt4s3`; the hosting/Pages-root slot is `sq-svtt`) |
+| **Hosted "Try the GUI live" web** | `npm run build:web` | `/sparq/app` (default; overridable) | a static page hosted at the site's **App** destination so the live-GUI link has a real target (beads `sq-wt4s3` + `sq-vnd0i`; `/try` stays the lightweight REPL) |
 
 The desktop bundle is wired via `gui/src-tauri/tauri.conf.json` — `frontendDist: "../app/out"`
 and `beforeBuildCommand: cd ../app && npm run build:tauri`. **`frontendDist` is no longer

--- a/gui/app/.gitignore
+++ b/gui/app/.gitignore
@@ -1,0 +1,9 @@
+# [OPUS-4.8] sq-ixc3.8 — build artifacts for the operational GUI frontend.
+/.next/
+/out/
+/node_modules/
+next-env.d.ts
+*.tsbuildinfo
+
+# The wasm bundle is synced in from js/wasm at build time (a build artifact, not source).
+/public/wasm/

--- a/gui/app/eslint.config.mjs
+++ b/gui/app/eslint.config.mjs
@@ -1,0 +1,17 @@
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import { FlatCompat } from "@eslint/eslintrc";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+const eslintConfig = [
+  ...compat.extends("next/core-web-vitals", "next/typescript"),
+  {
+    ignores: ["out/**", ".next/**", "public/wasm/**", "next-env.d.ts"],
+  },
+];
+
+export default eslintConfig;

--- a/gui/app/next.config.ts
+++ b/gui/app/next.config.ts
@@ -10,21 +10,21 @@ import type { NextConfig } from "next";
 //     EVERY asset must be ROOT-relative (a `/prefix` 404s there). `tauri.conf.json`'s
 //     `beforeBuildCommand` runs `build:tauri`, which sets NEXT_PUBLIC_BASE_PATH='' → basePath ''.
 //   * Hosted "Try the GUI live" web target ("build:web"): served under a sub-path on the same
-//     GitHub-Pages-style host. The website track owns the final hosted URL slot (bead sq-wt4s3 /
-//     the Pages-root decision sq-svtt); this app defaults the web build to the `/sparq/gui`
-//     sub-path so the site's "Try the GUI" nav slot has a real target, overridable via the env
-//     var if the maintainer chooses a different slot.
+//     GitHub-Pages-style host. The maintainer picked the URL slot (bead sq-vnd0i, Option B):
+//     the live GUI is hosted at the `/sparq/app` sub-path (the site's "App" nav destination;
+//     "/try" stays the lightweight REPL). This app defaults the web build to `/sparq/app`,
+//     overridable via the env var.
 //
-// An UNSET var keeps the web default (`/sparq/gui`); an explicit empty string selects the
+// An UNSET var keeps the web default (`/sparq/app`); an explicit empty string selects the
 // root-relative (Tauri) export. Next requires basePath to be empty or start with `/` (no
 // trailing slash), so we honour only `''` or a `/`-leading value and otherwise fall back.
 const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
 const basePath =
   rawBasePath === undefined
-    ? "/sparq/gui" // unset → hosted-web default ("Try the GUI live" sub-path)
+    ? "/sparq/app" // unset → hosted-web default (the live-GUI "/app" sub-path)
     : rawBasePath === "" || rawBasePath.startsWith("/")
       ? rawBasePath // '' (Tauri root-relative) or an explicit '/prefix'
-      : "/sparq/gui";
+      : "/sparq/app";
 
 const nextConfig: NextConfig = {
   output: "export",

--- a/gui/app/next.config.ts
+++ b/gui/app/next.config.ts
@@ -1,0 +1,58 @@
+import path from "node:path";
+import type { NextConfig } from "next";
+
+// [OPUS-4.8] sq-ixc3.8 / sq-ixc3.9 — static-export config for the DISTINCT operational GUI
+// frontend (NOT the marketing site). This app builds to a backend-free `out/` tree consumed by
+// BOTH targets, selected by NEXT_PUBLIC_BASE_PATH (the same single switch the site + the
+// @sparq/client wasm loader already key off, kept in lockstep):
+//
+//   * Tauri 2 desktop webview ("build:tauri"): serves the frontend from the `tauri://` root, so
+//     EVERY asset must be ROOT-relative (a `/prefix` 404s there). `tauri.conf.json`'s
+//     `beforeBuildCommand` runs `build:tauri`, which sets NEXT_PUBLIC_BASE_PATH='' → basePath ''.
+//   * Hosted "Try the GUI live" web target ("build:web"): served under a sub-path on the same
+//     GitHub-Pages-style host. The website track owns the final hosted URL slot (bead sq-wt4s3 /
+//     the Pages-root decision sq-svtt); this app defaults the web build to the `/sparq/gui`
+//     sub-path so the site's "Try the GUI" nav slot has a real target, overridable via the env
+//     var if the maintainer chooses a different slot.
+//
+// An UNSET var keeps the web default (`/sparq/gui`); an explicit empty string selects the
+// root-relative (Tauri) export. Next requires basePath to be empty or start with `/` (no
+// trailing slash), so we honour only `''` or a `/`-leading value and otherwise fall back.
+const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
+const basePath =
+  rawBasePath === undefined
+    ? "/sparq/gui" // unset → hosted-web default ("Try the GUI live" sub-path)
+    : rawBasePath === "" || rawBasePath.startsWith("/")
+      ? rawBasePath // '' (Tauri root-relative) or an explicit '/prefix'
+      : "/sparq/gui";
+
+const nextConfig: NextConfig = {
+  output: "export",
+  // Only emit basePath/assetPrefix when there IS a prefix. An empty basePath must not be set as
+  // `assetPrefix: ""` either — leaving both unset is exactly the root-relative behaviour the
+  // Tauri webview needs.
+  ...(basePath ? { basePath, assetPrefix: basePath } : {}),
+  trailingSlash: true,
+  // Static export cannot run the Next.js image optimiser.
+  images: { unoptimized: true },
+  // The @jeswr/sparq wrapper ships ESM with `.js` import specifiers that resolve to `.ts`/`.tsx`
+  // sources; mirror the site's webpack alias so the bundler follows them.
+  webpack: (config) => {
+    config.resolve.extensionAlias = {
+      ".js": [".ts", ".tsx", ".js", ".jsx"],
+    };
+    // Resolve the shared framework-agnostic client (`packages/sparq-client`) to its TS source —
+    // the SAME single-source-of-truth the site consumes, so the GUI is a zero-new-copy consumer
+    // of the engine TS surface (research/gui-design.md §4).
+    config.resolve.alias = {
+      ...config.resolve.alias,
+      "@sparq/client": path.resolve(
+        __dirname,
+        "../../packages/sparq-client/src/index.ts",
+      ),
+    };
+    return config;
+  },
+};
+
+export default nextConfig;

--- a/gui/app/package.json
+++ b/gui/app/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "sparq-gui-app",
+  "version": "0.1.0",
+  "private": true,
+  "description": "The sparq operational GUI frontend — a DISTINCT Next.js workbench app (NOT the marketing site) consumed by both the Tauri 2 desktop shell and a static-exported hosted 'Try the GUI live' web target. Reuses the @sparq/client wasm engine client + shared logic; renders its own operational shell (left rail · top bar · IDE tab strip · status bar), never the site's hero/Showcase/Benchmarks/About chrome.",
+  "type": "module",
+  "scripts": {
+    "presync-wasm": "node scripts/check-wasm-built.mjs",
+    "sync-wasm": "node scripts/sync-wasm.mjs",
+    "predev": "npm run sync-wasm",
+    "dev": "next dev -p 3001",
+    "prebuild": "npm run sync-wasm",
+    "build": "next build",
+    "build:tauri": "cross-env NEXT_PUBLIC_BASE_PATH= NEXT_PUBLIC_GUI_TARGET=tauri npm run build",
+    "build:web": "cross-env NEXT_PUBLIC_GUI_TARGET=web npm run build",
+    "start": "npx --yes serve out",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.460.0",
+    "next": "^15.5.19",
+    "next-themes": "^0.4.6",
+    "radix-ui": "^1.5.0",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "tailwind-merge": "^3.6.0"
+  },
+  "devDependencies": {
+    "@eslint/eslintrc": "^3.2.0",
+    "@tailwindcss/postcss": "^4.1.0",
+    "@types/node": "^22.10.0",
+    "@types/react": "^19.0.0",
+    "@types/react-dom": "^19.0.0",
+    "cross-env": "^7.0.3",
+    "eslint": "^9.18.0",
+    "eslint-config-next": "^15.5.19",
+    "tailwindcss": "^4.1.0",
+    "tw-animate-css": "^1.4.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/gui/app/postcss.config.mjs
+++ b/gui/app/postcss.config.mjs
@@ -1,0 +1,7 @@
+// Tailwind v4 — the PostCSS plugin is the whole build; the theme lives in CSS
+// (src/app/globals.css), there is no tailwind.config.ts (matches the site + solid-pod-manager).
+const config = {
+  plugins: ["@tailwindcss/postcss"],
+};
+
+export default config;

--- a/gui/app/scripts/check-wasm-built.mjs
+++ b/gui/app/scripts/check-wasm-built.mjs
@@ -1,0 +1,27 @@
+// [OPUS-4.8] sq-ixc3.8 — hard-fail the GUI frontend build if the wasm bundle is absent.
+//
+// The operational workbench runs the in-tab WASM engine, so the build embeds the lean
+// `--features shacl,jsonld` bundle (the same one the site syncs). That bundle is git-ignored
+// (`js/wasm/` is a build artifact), so a fresh checkout must build it FIRST:
+//
+//     (cd ../../js && npm ci && npm run build:wasm)
+//
+// This pre-sync check makes the failure mode explicit and actionable rather than letting the
+// engine 404 silently at runtime.
+import { access } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const wasm = join(here, "..", "..", "..", "js", "wasm", "sparq_wasm_bg.wasm");
+
+try {
+  await access(wasm);
+} catch {
+  console.error(
+    `[gui-app] WASM bundle not found at ${wasm}.\n` +
+      `The GUI frontend embeds the in-tab engine, so build the bundle first:\n` +
+      `    (cd ../../js && npm ci && npm run build:wasm)\n`,
+  );
+  process.exit(1);
+}

--- a/gui/app/scripts/sync-wasm.mjs
+++ b/gui/app/scripts/sync-wasm.mjs
@@ -1,0 +1,33 @@
+// [OPUS-4.8] sq-ixc3.8 — copy the lean sparq wasm bundle into public/wasm/ for the in-tab
+// engine the operational workbench runs. Source of truth is the wasm-pack `--target web`
+// output `js/`'s `build:wasm` produces (crates/sparq-wasm → js/wasm). Run after that build.
+//
+// The workbench loads these as plain static assets from /public at runtime (via the
+// @sparq/client loader, which keys its asset URLs off NEXT_PUBLIC_BASE_PATH), so they must live
+// in public/. The full satellite bundles (reason/rsp/text) the marketing site syncs are NOT
+// copied here — the foundation shell ships only the core SPARQL + SHACL engine; later GUI
+// phases (sq-ixc3.11/.12) add the tool tabs that would consume them.
+import { mkdir, copyFile, access } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = join(here, "..", "..", "..", "js", "wasm");
+const dest = join(here, "..", "public", "wasm");
+const files = ["sparq_wasm.js", "sparq_wasm_bg.wasm", "sparq_wasm.d.ts"];
+
+try {
+  await access(join(src, "sparq_wasm_bg.wasm"));
+} catch {
+  console.error(
+    `[sync-wasm] ${src}/sparq_wasm_bg.wasm not found.\n` +
+      `Build it first:  (cd ../../js && npm ci && npm run build:wasm)`,
+  );
+  process.exit(1);
+}
+
+await mkdir(dest, { recursive: true });
+for (const f of files) {
+  await copyFile(join(src, f), join(dest, f));
+}
+console.log(`[sync-wasm] copied ${files.length} files → public/wasm/`);

--- a/gui/app/src/app/globals.css
+++ b/gui/app/src/app/globals.css
@@ -1,0 +1,158 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+/* [OPUS-4.8] sq-ixc3.8 / sq-ixc3.9 — the OPERATIONAL WORKBENCH theme.
+   It shares the engine's privacy-first teal/cyan OKLCH palette with the marketing site so
+   the GUI reads as a sibling tool, but this is a DISTINCT app — a dense IDE-style workbench
+   (left rail · top bar · tab strip · status bar), NOT the marketing site's prose chrome.
+   Palette ported from the site's globals.css (which ported it from solid-pod-manager);
+   --radius is tightened (0.5rem vs the site's 0.7rem) for a denser operational feel. */
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+  --radius: 0.5rem;
+
+  --background: oklch(0.992 0.003 210);
+  --foreground: oklch(0.21 0.022 235);
+
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.21 0.022 235);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.21 0.022 235);
+
+  --primary: oklch(0.52 0.094 205);
+  --primary-foreground: oklch(0.99 0.005 200);
+
+  --secondary: oklch(0.965 0.008 215);
+  --secondary-foreground: oklch(0.24 0.024 235);
+
+  --muted: oklch(0.965 0.008 215);
+  --muted-foreground: oklch(0.5 0.02 230);
+
+  --accent: oklch(0.94 0.03 195);
+  --accent-foreground: oklch(0.24 0.05 215);
+
+  --destructive: oklch(0.55 0.2 27);
+  --destructive-foreground: oklch(0.99 0.005 200);
+
+  --success: oklch(0.55 0.11 155);
+  --warning: oklch(0.7 0.14 75);
+
+  --border: oklch(0.91 0.012 220);
+  --input: oklch(0.91 0.012 220);
+  --ring: oklch(0.52 0.094 205);
+
+  --sidebar: oklch(0.985 0.004 210);
+  --sidebar-foreground: oklch(0.21 0.022 235);
+  --sidebar-primary: oklch(0.52 0.094 205);
+  --sidebar-primary-foreground: oklch(0.99 0.005 200);
+  --sidebar-accent: oklch(0.94 0.03 195);
+  --sidebar-accent-foreground: oklch(0.24 0.05 215);
+  --sidebar-border: oklch(0.91 0.012 220);
+  --sidebar-ring: oklch(0.52 0.094 205);
+}
+
+.dark {
+  --background: oklch(0.17 0.018 235);
+  --foreground: oklch(0.96 0.006 210);
+
+  --card: oklch(0.21 0.02 233);
+  --card-foreground: oklch(0.96 0.006 210);
+  --popover: oklch(0.21 0.02 233);
+  --popover-foreground: oklch(0.96 0.006 210);
+
+  --primary: oklch(0.7 0.1 200);
+  --primary-foreground: oklch(0.17 0.03 235);
+
+  --secondary: oklch(0.26 0.02 232);
+  --secondary-foreground: oklch(0.96 0.006 210);
+
+  --muted: oklch(0.26 0.02 232);
+  --muted-foreground: oklch(0.7 0.02 220);
+
+  --accent: oklch(0.32 0.045 205);
+  --accent-foreground: oklch(0.96 0.006 210);
+
+  --destructive: oklch(0.7 0.18 22);
+  --destructive-foreground: oklch(0.96 0.006 210);
+
+  --success: oklch(0.72 0.12 155);
+  --warning: oklch(0.8 0.13 80);
+
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 12%);
+  --ring: oklch(0.7 0.1 200);
+
+  --sidebar: oklch(0.19 0.02 234);
+  --sidebar-foreground: oklch(0.96 0.006 210);
+  --sidebar-primary: oklch(0.7 0.1 200);
+  --sidebar-primary-foreground: oklch(0.17 0.03 235);
+  --sidebar-accent: oklch(0.32 0.045 205);
+  --sidebar-accent-foreground: oklch(0.96 0.006 210);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.7 0.1 200);
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
+  --color-success: var(--success);
+  --color-warning: var(--warning);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
+
+  --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+  --font-mono: ui-monospace, "SFMono-Regular", "Menlo", monospace;
+
+  --radius-sm: calc(var(--radius) * 0.6);
+  --radius-md: calc(var(--radius) * 0.8);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) * 1.4);
+}
+
+@layer base {
+  * {
+    border-color: var(--border);
+    outline-color: color-mix(in oklch, var(--ring) 50%, transparent);
+  }
+  html,
+  body {
+    height: 100%;
+  }
+  body {
+    background-color: var(--background);
+    color: var(--foreground);
+    font-feature-settings: "cv11", "ss01";
+    -webkit-font-smoothing: antialiased;
+    /* The workbench is a full-bleed app shell, never a scrolling document. */
+    overflow: hidden;
+  }
+}
+
+@utility tabular {
+  font-variant-numeric: tabular-nums;
+}

--- a/gui/app/src/app/layout.tsx
+++ b/gui/app/src/app/layout.tsx
@@ -1,0 +1,47 @@
+import type { Metadata, Viewport } from "next";
+import { Inter } from "next/font/google";
+
+import "./globals.css";
+import { ThemeProvider } from "@/components/theme-provider";
+import { EngineProvider } from "@/lib/engine-context";
+
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-inter",
+  display: "swap",
+});
+
+// [OPUS-4.8] sq-ixc3.8 / sq-ixc3.9 — the operational GUI is a DISTINCT app, not the marketing
+// site. Its metadata names the workbench, never the showcase.
+export const metadata: Metadata = {
+  title: "sparq workbench",
+  description:
+    "The sparq operational workbench — query, validate, and inspect RDF over a live in-tab engine. A distinct desktop + web tool, not the marketing site.",
+};
+
+export const viewport: Viewport = {
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#f7fbfc" },
+    { media: "(prefers-color-scheme: dark)", color: "#13181c" },
+  ],
+};
+
+export default function RootLayout({
+  children,
+}: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en" suppressHydrationWarning>
+      <body className={`${inter.variable} font-sans antialiased`}>
+        <ThemeProvider
+          attribute="class"
+          defaultTheme="dark"
+          enableSystem
+          disableTransitionOnChange
+        >
+          {/* The engine context provides the ONE live store the whole workbench shares. */}
+          <EngineProvider>{children}</EngineProvider>
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/gui/app/src/app/page.tsx
+++ b/gui/app/src/app/page.tsx
@@ -1,0 +1,8 @@
+import { Workbench } from "@/components/workbench/workbench";
+
+// [OPUS-4.8] sq-ixc3.9 — the single route: the operational workbench shell. The GUI has NO
+// route tree (no /about, /benchmarks, /showcase) — it is a workbench, not a site. Tools open
+// as TABS inside the shell, not as pages.
+export default function Page() {
+  return <Workbench />;
+}

--- a/gui/app/src/components/theme-provider.tsx
+++ b/gui/app/src/components/theme-provider.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import * as React from "react";
+import { ThemeProvider as NextThemesProvider } from "next-themes";
+
+export function ThemeProvider({
+  children,
+  ...props
+}: React.ComponentProps<typeof NextThemesProvider>) {
+  return <NextThemesProvider {...props}>{children}</NextThemesProvider>;
+}

--- a/gui/app/src/components/ui/badge.tsx
+++ b/gui/app/src/components/ui/badge.tsx
@@ -1,0 +1,41 @@
+import * as React from "react";
+import { Slot } from "radix-ui";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+// [OPUS-4.8] sq-ixc3.9 — operational Badge, ported from the site design system so the
+// honesty-tier dots + status pills read consistently with the rest of the engine's surfaces.
+const badgeVariants = cva(
+  "inline-flex items-center justify-center rounded-full h-5 px-2 text-xs font-medium w-fit whitespace-nowrap shrink-0 gap-1 [&>svg]:size-3",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary/10 text-primary",
+        secondary: "bg-secondary text-secondary-foreground",
+        outline: "text-foreground ring-1 ring-foreground/15",
+        success:
+          "bg-[color-mix(in_oklch,var(--success)_15%,transparent)] text-[var(--success)]",
+        warning:
+          "bg-[color-mix(in_oklch,var(--warning)_18%,transparent)] text-[color-mix(in_oklch,var(--warning)_80%,var(--foreground))]",
+        muted: "bg-muted text-muted-foreground",
+      },
+    },
+    defaultVariants: { variant: "default" },
+  },
+);
+
+function Badge({
+  className,
+  variant,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span";
+  return (
+    <Comp data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge, badgeVariants };

--- a/gui/app/src/components/ui/button.tsx
+++ b/gui/app/src/components/ui/button.tsx
@@ -1,0 +1,54 @@
+import * as React from "react";
+import { Slot } from "radix-ui";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+// [OPUS-4.8] sq-ixc3.9 — operational Button. Same variants as the site's design system
+// (reuse, don't reinvent) so the GUI reads as a sibling tool; sizes lean compact for the
+// dense workbench chrome.
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all outline-none focus-visible:ring-2 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        destructive:
+          "bg-destructive/10 text-destructive hover:bg-destructive/20",
+        outline:
+          "border bg-background hover:bg-accent hover:text-accent-foreground",
+        secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80",
+        ghost: "hover:bg-accent hover:text-accent-foreground",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-8 px-3 py-2 has-[>svg]:px-2.5",
+        sm: "h-7 rounded-md px-2.5 text-xs",
+        lg: "h-9 rounded-md px-5",
+        icon: "size-8",
+        "icon-sm": "size-7",
+      },
+    },
+    defaultVariants: { variant: "default", size: "default" },
+  },
+);
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "button";
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
+}
+
+export { Button, buttonVariants };

--- a/gui/app/src/components/workbench/left-rail.tsx
+++ b/gui/app/src/components/workbench/left-rail.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.9 — the LEFT RAIL (w-56, denser than the site's w-64;
+// research/gui-design.md §A.2):
+//   (1) workspace switcher — ●saved/○unsaved (the persistent-workspace model is sq-atb0; this
+//       foundation shows the default workspace; the picker is a later-phase stub);
+//   (2) datasets tree of the LIVE store — default + named graphs with per-graph counts, plus an
+//       Imports subgroup placeholder + "+ Import" entry point (the real import drawer is
+//       sq-ixc3.13);
+//   (3) TOOLS list — each a VERB opened as a tab with an honesty-tier dot (NOT a page).
+
+import * as React from "react";
+import { ChevronDown, Plus, Circle, Database, FolderTree } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useEngine } from "@/lib/engine-context";
+import { TIER_META, type ToolDef } from "@/data/tools";
+
+interface LeftRailProps {
+  tools: ToolDef[];
+  activeId: string;
+  onOpenTool: (toolId: string) => void;
+}
+
+function shortenGraph(iri: string | null): string {
+  if (iri === null) return "default graph";
+  // Show the last path/fragment segment for readability; full IRI on hover.
+  const m = iri.match(/[#/]([^#/]+)\/?$/);
+  return m ? m[1] : iri;
+}
+
+function DatasetsTree() {
+  const { graphs, status } = useEngine();
+  return (
+    <div className="px-1 pb-2">
+      {status.kind !== "ready" ? (
+        <p className="px-2 py-1 text-xs text-muted-foreground">
+          {status.kind === "error" ? "engine error" : "loading store…"}
+        </p>
+      ) : graphs.length === 0 ? (
+        <p className="px-2 py-1 text-xs text-muted-foreground">empty store</p>
+      ) : (
+        <ul className="space-y-0.5">
+          {graphs.map((g) => (
+            <li
+              key={g.graph ?? "__default__"}
+              className="flex items-center gap-1.5 rounded px-2 py-1 text-xs hover:bg-sidebar-accent/40"
+              title={g.graph ?? "the default graph"}
+            >
+              <Database className="size-3 shrink-0 text-muted-foreground" />
+              <span className="min-w-0 flex-1 truncate">{shortenGraph(g.graph)}</span>
+              <span className="tabular text-[11px] text-muted-foreground">
+                {g.count.toLocaleString()}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+      {/* Imports subgroup placeholder — the real WorkspaceSourceMeta list is sq-ixc3.13. */}
+      <button
+        className="mt-1 flex w-full cursor-not-allowed items-center gap-1.5 rounded px-2 py-1 text-xs text-muted-foreground"
+        title="Import RDF from disk / URL / paste — the import drawer is a later phase"
+        disabled
+      >
+        <Plus className="size-3" /> Import
+      </button>
+    </div>
+  );
+}
+
+function Section({
+  label,
+  icon,
+  children,
+}: {
+  label: string;
+  icon?: React.ReactNode;
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="py-1">
+      <h2 className="flex items-center gap-1.5 px-3 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        {icon}
+        {label}
+      </h2>
+      {children}
+    </section>
+  );
+}
+
+export function LeftRail({ tools, activeId, onOpenTool }: LeftRailProps) {
+  return (
+    <nav className="flex w-56 shrink-0 flex-col overflow-y-auto border-r bg-sidebar text-sidebar-foreground">
+      {/* (1) Workspace switcher — the persistent model is sq-atb0; foundation = default. */}
+      <div className="border-b px-2 py-2">
+        <button
+          className="flex w-full items-center gap-1.5 rounded-md border bg-background px-2 py-1.5 text-left text-xs hover:bg-sidebar-accent/40"
+          title="Workspace switcher — persistent workspaces are a later phase (sq-atb0)"
+        >
+          <Circle className="size-2.5 fill-[var(--success)] text-[var(--success)]" />
+          <span className="flex-1 truncate font-medium">default workspace</span>
+          <ChevronDown className="size-3 text-muted-foreground" />
+        </button>
+      </div>
+
+      {/* (2) Datasets tree of the LIVE store. */}
+      <Section label="Datasets" icon={<FolderTree className="size-3" />}>
+        <DatasetsTree />
+      </Section>
+
+      {/* (3) TOOLS — each a VERB opened as a tab with its honesty-tier dot. */}
+      <Section label="Tools">
+        <ul className="px-1 pb-2">
+          {tools.map((tool) => {
+            const Icon = tool.icon;
+            const tier = TIER_META[tool.tier];
+            const isActive = tool.id === activeId;
+            return (
+              <li key={tool.id}>
+                <button
+                  onClick={() => onOpenTool(tool.id)}
+                  className={cn(
+                    "group flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-sidebar-accent/50",
+                    isActive && "bg-sidebar-accent/70 font-medium",
+                  )}
+                  title={`${tool.blurb} — ${tier.label}`}
+                >
+                  <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+                  <span className="min-w-0 flex-1 truncate">{tool.label}</span>
+                  <span
+                    className={cn("size-2 shrink-0 rounded-full", tier.dot)}
+                    aria-hidden
+                  />
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </Section>
+    </nav>
+  );
+}

--- a/gui/app/src/components/workbench/query-workbench.tsx
+++ b/gui/app/src/components/workbench/query-workbench.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.9 — the WORKING Query tool: a full-height editor over the live store + a
+// co-resident results panel (Table | Raw JSON | N-Triples). This is the foundation slice of the
+// query workbench (sq-ixc3.12 adds the Graph view + streaming + the richer multi-view layout);
+// it runs SELECT/ASK/CONSTRUCT/DESCRIBE/UPDATE live in-tab and measures each run's latency.
+//
+// E2E CONTRACT (gui/e2e/run-e2e.mjs asserts these stable hooks, kept faithful so the harness
+// cannot silently drift): the editing <textarea id="repl-query">, a "Run query" button, the
+// "Engine ready" status copy (in the top bar), and the result container's
+// data-result-kind="select" + data-result-view="table" wrapping a <table> with the binding.
+
+import * as React from "react";
+import { Play, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useEngine, type QueryOutcome } from "@/lib/engine-context";
+import { extractTable, type SparqlResults } from "@sparq/client";
+import { DEFAULT_QUERY } from "@/data/sample-graph";
+
+type ResultView = "table" | "json" | "ntriples";
+
+function SelectTable({ results }: { results: SparqlResults }) {
+  const table = extractTable(results);
+  if (table.vars.length === 0) {
+    return <p className="p-3 text-sm text-muted-foreground">No projected variables.</p>;
+  }
+  return (
+    <div className="overflow-auto" data-result-view="table">
+      <table className="w-full border-collapse text-sm">
+        <thead className="sticky top-0 bg-card">
+          <tr>
+            {table.vars.map((v) => (
+              <th
+                key={v}
+                className="border-b px-3 py-1.5 text-left font-mono text-xs font-semibold"
+              >
+                ?{v}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.rows.length === 0 ? (
+            <tr>
+              <td
+                colSpan={table.vars.length}
+                className="px-3 py-3 text-center text-muted-foreground"
+              >
+                0 rows
+              </td>
+            </tr>
+          ) : (
+            table.rows.map((row, i) => (
+              <tr key={i} className="odd:bg-muted/30">
+                {row.map((cell, j) => (
+                  <td key={j} className="border-b px-3 py-1 font-mono text-xs">
+                    {cell}
+                  </td>
+                ))}
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ResultBody({
+  outcome,
+  view,
+}: {
+  outcome: QueryOutcome;
+  view: ResultView;
+}) {
+  if (outcome.kind === "error") {
+    return (
+      <pre
+        className="overflow-auto whitespace-pre-wrap p-3 font-mono text-xs text-destructive"
+        data-result-kind="error"
+      >
+        {outcome.message}
+      </pre>
+    );
+  }
+  if (outcome.kind === "ask") {
+    return (
+      <div className="p-3 text-sm" data-result-kind="ask">
+        {view === "json" ? (
+          <pre className="overflow-auto font-mono text-xs">{outcome.rawJson}</pre>
+        ) : (
+          <span className="font-mono">
+            ASK → <strong>{String(outcome.value)}</strong>
+          </span>
+        )}
+      </div>
+    );
+  }
+  if (outcome.kind === "graph") {
+    return (
+      <pre
+        className="overflow-auto whitespace-pre p-3 font-mono text-xs"
+        data-result-kind="graph"
+      >
+        {outcome.ntriples || "(empty graph)"}
+      </pre>
+    );
+  }
+  if (outcome.kind === "update") {
+    return (
+      <div className="p-3 text-sm" data-result-kind="update">
+        Update applied. Store now holds{" "}
+        <span className="tabular font-medium">{outcome.sizeAfter.toLocaleString()}</span> quads.
+      </div>
+    );
+  }
+  // select
+  return (
+    <div className="h-full" data-result-kind="select">
+      {view === "table" ? (
+        <SelectTable results={outcome.results} />
+      ) : view === "ntriples" ? (
+        <p className="p-3 text-sm text-muted-foreground">
+          N-Triples view applies to CONSTRUCT/DESCRIBE results.
+        </p>
+      ) : (
+        <pre className="overflow-auto p-3 font-mono text-xs" data-result-view="json">
+          {outcome.rawJson}
+        </pre>
+      )}
+    </div>
+  );
+}
+
+const VIEWS: { id: ResultView; label: string }[] = [
+  { id: "table", label: "Table" },
+  { id: "json", label: "Raw JSON" },
+  { id: "ntriples", label: "N-Triples" },
+];
+
+export function QueryWorkbench() {
+  const { run, status } = useEngine();
+  const [query, setQuery] = React.useState(DEFAULT_QUERY);
+  const [outcome, setOutcome] = React.useState<QueryOutcome | null>(null);
+  const [view, setView] = React.useState<ResultView>("table");
+  const [running, setRunning] = React.useState(false);
+
+  const onRun = React.useCallback(async () => {
+    setRunning(true);
+    try {
+      const result = await run(query);
+      setOutcome(result.outcome);
+      // A CONSTRUCT/DESCRIBE answer is graph-shaped → default its view to N-Triples.
+      if (result.outcome.kind === "graph") setView("ntriples");
+      else if (result.outcome.kind === "select" && view === "ntriples") setView("table");
+    } finally {
+      setRunning(false);
+    }
+  }, [run, query, view]);
+
+  // ⌘/Ctrl-Enter runs the query (the keyboard-first spine; the full Cmd-K palette is sq-ixc3.10).
+  const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+      e.preventDefault();
+      void onRun();
+    }
+  };
+
+  const ready = status.kind === "ready";
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Editor pane. */}
+      <div className="flex min-h-0 flex-[3] flex-col border-b">
+        <div className="flex items-center gap-2 border-b bg-card px-3 py-1.5">
+          <span className="text-xs font-medium text-muted-foreground">SPARQL</span>
+          <Button
+            size="sm"
+            onClick={() => void onRun()}
+            disabled={!ready || running}
+            className="ml-auto"
+          >
+            {running ? <Loader2 className="animate-spin" /> : <Play />}
+            Run query
+          </Button>
+          <span className="text-[11px] text-muted-foreground">⌘↵</span>
+        </div>
+        <textarea
+          id="repl-query"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onKeyDown={onKeyDown}
+          spellCheck={false}
+          className="min-h-0 flex-1 resize-none bg-background p-3 font-mono text-sm outline-none"
+          placeholder="Write a SPARQL query…"
+          aria-label="SPARQL query editor"
+        />
+      </div>
+
+      {/* Results pane. */}
+      <div className="flex min-h-0 flex-[2] flex-col">
+        <div className="flex items-center gap-1 border-b bg-card px-3 py-1">
+          {VIEWS.map((v) => (
+            <button
+              key={v.id}
+              onClick={() => setView(v.id)}
+              className={cn(
+                "rounded px-2 py-0.5 text-xs",
+                view === v.id
+                  ? "bg-primary/10 font-medium text-primary"
+                  : "text-muted-foreground hover:bg-accent/40",
+              )}
+            >
+              {v.label}
+            </button>
+          ))}
+        </div>
+        <div className="min-h-0 flex-1 overflow-auto">
+          {outcome === null ? (
+            <p className="p-3 text-sm text-muted-foreground">
+              {ready
+                ? "Run a query to see results."
+                : "Waiting for the engine to warm…"}
+            </p>
+          ) : (
+            <ResultBody outcome={outcome} view={view} />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/gui/app/src/components/workbench/status-bar.tsx
+++ b/gui/app/src/components/workbench/status-bar.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.9 — the bottom STATUS BAR (h-6, research/gui-design.md §A.2):
+// MEASURED performance.now() latency of the last run · row count · target · persistence backend.
+//
+// HONESTY: the latency is the wall-clock of the query the user JUST ran, measured with
+// performance.now() and LABELLED as a per-run latency — it is NOT a benchmark claim, and no
+// canonical number is baked in (this work box / CI runner is non-canonical).
+
+import { useEngine } from "@/lib/engine-context";
+
+/** Detect the desktop (Tauri) host so the bar reports the real persistence backend honestly. */
+function isTauri(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    // Tauri 2 injects a global the webview can detect.
+    ("__TAURI_INTERNALS__" in window || "__TAURI__" in window)
+  );
+}
+
+export function StatusBar() {
+  const { lastLatencyMs, lastRowCount, storeSize } = useEngine();
+  const desktop = isTauri();
+  return (
+    <footer className="flex h-6 shrink-0 items-center gap-4 border-t bg-card px-3 text-[11px] text-muted-foreground">
+      <span className="tabular" title="Wall-clock latency of the last query (performance.now)">
+        {lastLatencyMs === null ? "— ms" : `${lastLatencyMs.toFixed(1)} ms`}
+      </span>
+      <span className="tabular" title="Rows / triples returned by the last run">
+        {lastRowCount === null ? "— rows" : `${lastRowCount.toLocaleString()} rows`}
+      </span>
+      <span className="ml-auto tabular">{storeSize.toLocaleString()} quads</span>
+      <span title="Where queries run">target: local (in-tab WASM)</span>
+      <span title="Where the workspace persists">
+        backend: {desktop ? "desktop (Tauri)" : "browser (in-memory)"}
+      </span>
+    </footer>
+  );
+}

--- a/gui/app/src/components/workbench/tab-strip.tsx
+++ b/gui/app/src/components/workbench/tab-strip.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.9 — the IDE-style TAB STRIP (research/gui-design.md §A.2). Each open tool
+// is a tab; the active tab's panel fills the full-bleed work area below. The last tab is not
+// closable (the work area never empties).
+
+import { X } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { toolById, TIER_META } from "@/data/tools";
+import type { OpenTab } from "@/components/workbench/workbench";
+
+interface TabStripProps {
+  tabs: OpenTab[];
+  activeId: string;
+  onSelect: (id: string) => void;
+  onClose: (id: string) => void;
+}
+
+export function TabStrip({ tabs, activeId, onSelect, onClose }: TabStripProps) {
+  return (
+    <div
+      role="tablist"
+      className="flex h-9 shrink-0 items-stretch overflow-x-auto border-b bg-card"
+    >
+      {tabs.map((tab) => {
+        const tool = toolById(tab.id);
+        const tier = tool ? TIER_META[tool.tier] : null;
+        const isActive = tab.id === activeId;
+        const Icon = tool?.icon;
+        return (
+          <div
+            key={tab.id}
+            role="tab"
+            aria-selected={isActive}
+            className={cn(
+              "group flex cursor-pointer items-center gap-1.5 border-r px-3 text-xs",
+              isActive
+                ? "border-b-2 border-b-primary bg-background font-medium"
+                : "text-muted-foreground hover:bg-accent/40",
+            )}
+            onClick={() => onSelect(tab.id)}
+          >
+            {Icon ? <Icon className="size-3.5" /> : null}
+            <span>{tab.label}</span>
+            {tier ? (
+              <span className={cn("size-1.5 rounded-full", tier.dot)} aria-hidden />
+            ) : null}
+            {tabs.length > 1 ? (
+              <button
+                className="ml-1 rounded p-0.5 opacity-0 hover:bg-accent group-hover:opacity-100"
+                aria-label={`Close ${tab.label}`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onClose(tab.id);
+                }}
+              >
+                <X className="size-3" />
+              </button>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/gui/app/src/components/workbench/tool-panel.tsx
+++ b/gui/app/src/components/workbench/tool-panel.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.9 — dispatches a tab id to its tool panel. The Query tool is a WORKING
+// tab over the live store; every other tool is an honest STUB (ToolStub) that the later phases
+// fill (sq-ixc3.11 turns surfaces into live tools, sq-ixc3.12 the query workbench multi-view,
+// sq-ixc3.13 the import drawer). A stub never fabricates a result — it states the verb + tier.
+
+import { QueryWorkbench } from "@/components/workbench/query-workbench";
+import { ToolStub } from "@/components/workbench/tool-stub";
+import { toolById } from "@/data/tools";
+
+export function ToolPanel({ toolId }: { toolId: string }) {
+  if (toolId === "query") return <QueryWorkbench />;
+  const tool = toolById(toolId);
+  if (!tool) return <ToolStub toolId={toolId} />;
+  return <ToolStub toolId={toolId} />;
+}

--- a/gui/app/src/components/workbench/tool-stub.tsx
+++ b/gui/app/src/components/workbench/tool-stub.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.9 — an HONEST tool stub. The foundation shell registers every TOOL but
+// only the Query tool is wired; the rest open a panel that states plainly what the tool WILL do
+// over the live store, its honesty tier, and which bead lands it. It NEVER fabricates a result
+// or dresses a walkthrough/soon capability up as live.
+
+import { Badge } from "@/components/ui/badge";
+import { toolById, TIER_META } from "@/data/tools";
+
+/** Which bead lands each tool (so the stub is self-documenting, not a dead placeholder). */
+const TOOL_BEAD: Record<string, string> = {
+  "graph-view": "sq-lyp8",
+  shacl: "sq-ixc3.11",
+  inference: "sq-ixc3.11",
+  "full-text": "sq-ixc3.11",
+  vector: "sq-zeai",
+  geosparql: "sq-zeai",
+  streaming: "sq-ixc3.11",
+  zk: "sq-ixc3.11",
+  mpc: "sq-ixc3.11",
+  server: "sq-2mke",
+};
+
+/** Tier → the not-yet-audited / not-live caveat the privacy + honesty gates require. */
+const TIER_CAVEAT: Record<string, string> = {
+  "live-bbjs":
+    "In-tab UltraHonk proving is real, but the ZK estate is research-grade — the v1 verifier is internally re-audited only, external accredited-cryptographer sign-off is pending — so it is NOT an audited cryptographic guarantee.",
+  "live-sim":
+    "This will be a faithful in-tab JS illustration of the protocol shape, NOT the native sparq-mpc crate and NOT live MPC; sparq-mpc itself is honest-majority semi-honest only.",
+  walkthrough:
+    "This capability is a native-only crate not yet compiled to wasm, so it will start as a captured-I/O walkthrough until a portability spike or endpoint mode lands.",
+};
+
+export function ToolStub({ toolId }: { toolId: string }) {
+  const tool = toolById(toolId);
+  if (!tool) {
+    return (
+      <div className="flex h-full items-center justify-center p-8 text-sm text-muted-foreground">
+        Unknown tool: {toolId}
+      </div>
+    );
+  }
+  const Icon = tool.icon;
+  const tier = TIER_META[tool.tier];
+  const bead = TOOL_BEAD[toolId];
+  const caveat = TIER_CAVEAT[tool.tier];
+  return (
+    <div className="flex h-full items-center justify-center overflow-auto p-8">
+      <div className="max-w-md space-y-3 text-center">
+        <Icon className="mx-auto size-10 text-muted-foreground" />
+        <div className="flex items-center justify-center gap-2">
+          <h2 className="text-lg font-semibold">{tool.label}</h2>
+          <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+            <span className={`size-2 rounded-full ${tier.dot}`} aria-hidden />
+            {tier.label}
+          </span>
+        </div>
+        <p className="text-sm text-muted-foreground">{tool.blurb}</p>
+        {caveat ? (
+          <p className="rounded-md border border-[var(--warning)]/30 bg-[var(--warning)]/5 p-2 text-xs text-muted-foreground">
+            {caveat}
+          </p>
+        ) : null}
+        <div className="flex items-center justify-center gap-2 pt-1">
+          <Badge variant="muted">Not yet built</Badge>
+          {bead ? <Badge variant="outline">{bead}</Badge> : null}
+        </div>
+        <p className="text-xs text-muted-foreground">
+          This tool is registered in the workbench shell; the working panel is a later phase.
+          The Query tool runs live over the in-tab engine today.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/gui/app/src/components/workbench/top-bar.tsx
+++ b/gui/app/src/components/workbench/top-bar.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.9 — the thin TOP BAR (h-10, research/gui-design.md §A.2):
+// LOCAL⇄ENDPOINT target switch · store size · ⌘K hint · theme toggle · engine status LED.
+//
+// The target switch + Cmd-K are STUBS in this foundation shell (the endpoint/connect tool is
+// sq-ixc3.11/the Server tab; the command palette is sq-ixc3.10). They render and are honestly
+// labelled "soon" so the bar is complete chrome — they don't fabricate behaviour.
+
+import * as React from "react";
+import { useTheme } from "next-themes";
+import { Moon, Sun, Command, ExternalLink } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { useEngine } from "@/lib/engine-context";
+
+/** The honesty-website link target (the marketing site, opened in a NEW tab / system browser). */
+const WEBSITE_URL = "https://jeswr.github.io/sparq/";
+
+function StatusLed() {
+  const { status } = useEngine();
+  const color =
+    status.kind === "ready"
+      ? "bg-[var(--success)]"
+      : status.kind === "error"
+        ? "bg-destructive"
+        : "bg-[var(--warning)] animate-pulse";
+  const label =
+    status.kind === "ready"
+      ? "Engine ready"
+      : status.kind === "error"
+        ? "Engine error"
+        : "Warming…";
+  return (
+    <span className="flex items-center gap-1.5 text-xs text-muted-foreground" title={label}>
+      <span className={`size-2 rounded-full ${color}`} aria-hidden />
+      {/* The literal "Engine ready" copy is the deterministic hook the tauri-driver e2e waits on. */}
+      <span>{label}</span>
+    </span>
+  );
+}
+
+function ThemeToggle() {
+  const { resolvedTheme, setTheme } = useTheme();
+  const [mounted, setMounted] = React.useState(false);
+  React.useEffect(() => setMounted(true), []);
+  if (!mounted) {
+    return <Button variant="ghost" size="icon-sm" aria-label="Toggle theme" />;
+  }
+  const isDark = resolvedTheme === "dark";
+  return (
+    <Button
+      variant="ghost"
+      size="icon-sm"
+      aria-label="Toggle theme"
+      onClick={() => setTheme(isDark ? "light" : "dark")}
+    >
+      {isDark ? <Sun /> : <Moon />}
+    </Button>
+  );
+}
+
+export function TopBar() {
+  const { storeSize } = useEngine();
+  return (
+    <header className="flex h-10 shrink-0 items-center gap-3 border-b bg-card px-3">
+      <span className="font-mono text-sm font-semibold tracking-tight">sparq</span>
+      <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+        workbench
+      </span>
+
+      {/* LOCAL⇄ENDPOINT target switch — stub (the Server/endpoint tool is a later phase). */}
+      <div className="ml-2 flex items-center rounded-md border bg-background text-xs">
+        <button
+          className="rounded-l-md bg-primary px-2 py-1 font-medium text-primary-foreground"
+          title="Run queries against the in-tab engine (this build)"
+        >
+          LOCAL
+        </button>
+        <button
+          className="cursor-not-allowed rounded-r-md px-2 py-1 text-muted-foreground"
+          title="Endpoint mode (connect to a running sparq-server) — coming in a later phase"
+          disabled
+        >
+          ENDPOINT
+        </button>
+      </div>
+
+      <span className="tabular text-xs text-muted-foreground">
+        {storeSize.toLocaleString()} quads
+      </span>
+
+      <div className="ml-auto flex items-center gap-1.5">
+        {/* ⌘K hint — the command palette is sq-ixc3.10. */}
+        <span
+          className="hidden items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] text-muted-foreground sm:flex"
+          title="Command palette — coming in a later phase"
+        >
+          <Command className="size-3" />K
+        </span>
+        <StatusLed />
+        <ThemeToggle />
+        <Button
+          variant="ghost"
+          size="sm"
+          asChild
+          title="Open the sparq website (the marketing/docs site) in your browser"
+        >
+          <a href={WEBSITE_URL} target="_blank" rel="noreferrer noopener">
+            Help <ExternalLink className="size-3" />
+          </a>
+        </Button>
+      </div>
+    </header>
+  );
+}

--- a/gui/app/src/components/workbench/workbench.tsx
+++ b/gui/app/src/components/workbench/workbench.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.9 — the operational app SHELL (research/gui-design.md §A.2):
+//
+//   ┌──────────────────────────────────────────────────────────┐
+//   │ TOP BAR (h-10): target switch · store size · ⌘K · theme · LED │
+//   ├──────────┬───────────────────────────────────────────────┤
+//   │ LEFT     │ IDE TAB STRIP                                   │
+//   │ RAIL     ├───────────────────────────────────────────────┤
+//   │ (w-56)   │ WORK AREA (full-bleed, default = Query)         │
+//   │ workspace│                                                 │
+//   │ datasets ├───────────────────────────────────────────────┤
+//   │ TOOLS    │ STATUS BAR (h-6): latency · rows · target · backend │
+//   └──────────┴───────────────────────────────────────────────┘
+//
+// This is the workbench, NOT a route tree: no Showcase/Benchmarks/About marketing chrome. The
+// Query tab is a working tool over the live store; the other TOOLS open as honest stub tabs the
+// later phases (sq-ixc3.11/.12/.13) fill. A single Help link opens the marketing website in the
+// system browser (the design's rule: the GUI never renders the site, it links to it).
+
+import * as React from "react";
+
+import { LeftRail } from "@/components/workbench/left-rail";
+import { TopBar } from "@/components/workbench/top-bar";
+import { TabStrip } from "@/components/workbench/tab-strip";
+import { StatusBar } from "@/components/workbench/status-bar";
+import { ToolPanel } from "@/components/workbench/tool-panel";
+import { TOOLS, toolById } from "@/data/tools";
+
+/** An open tab in the IDE tab strip — keyed by tool id (a tool opens at most once). */
+export interface OpenTab {
+  id: string;
+  label: string;
+}
+
+const DEFAULT_TAB: OpenTab = { id: "query", label: "Query" };
+
+export function Workbench() {
+  // The Query tool is open by default (the design's default work area).
+  const [tabs, setTabs] = React.useState<OpenTab[]>([DEFAULT_TAB]);
+  const [activeId, setActiveId] = React.useState<string>(DEFAULT_TAB.id);
+
+  /** Open a tool as a tab (focus it if already open). */
+  const openTool = React.useCallback((toolId: string) => {
+    const tool = toolById(toolId);
+    if (!tool) return;
+    setTabs((prev) =>
+      prev.some((t) => t.id === toolId)
+        ? prev
+        : [...prev, { id: tool.id, label: tool.label }],
+    );
+    setActiveId(toolId);
+  }, []);
+
+  /** Close a tab; if it was active, focus the previous (never close the last one). */
+  const closeTab = React.useCallback(
+    (toolId: string) => {
+      setTabs((prev) => {
+        if (prev.length <= 1) return prev; // never empty the work area
+        const idx = prev.findIndex((t) => t.id === toolId);
+        const next = prev.filter((t) => t.id !== toolId);
+        if (toolId === activeId) {
+          const fallback = next[Math.max(0, idx - 1)] ?? next[0];
+          setActiveId(fallback.id);
+        }
+        return next;
+      });
+    },
+    [activeId],
+  );
+
+  return (
+    <div className="flex h-screen flex-col overflow-hidden bg-background text-foreground">
+      <TopBar />
+      <div className="flex min-h-0 flex-1">
+        <LeftRail tools={TOOLS} activeId={activeId} onOpenTool={openTool} />
+        <main className="flex min-w-0 flex-1 flex-col">
+          <TabStrip
+            tabs={tabs}
+            activeId={activeId}
+            onSelect={setActiveId}
+            onClose={closeTab}
+          />
+          <div className="min-h-0 flex-1 overflow-hidden">
+            {tabs.map((tab) => (
+              <div
+                key={tab.id}
+                hidden={tab.id !== activeId}
+                className="h-full"
+                data-tab={tab.id}
+              >
+                <ToolPanel toolId={tab.id} />
+              </div>
+            ))}
+          </div>
+          <StatusBar />
+        </main>
+      </div>
+    </div>
+  );
+}

--- a/gui/app/src/data/sample-graph.ts
+++ b/gui/app/src/data/sample-graph.ts
@@ -1,0 +1,42 @@
+// [OPUS-4.8] sq-ixc3.9 — a small, self-contained sample graph the workbench seeds the live
+// store with on first warm. Real Turtle; loaded into the wasm Store and queried for real (no
+// mocks). The foaf:name "Alice" binding is the deterministic fixture the tauri-driver e2e
+// (gui/e2e/run-e2e.mjs) asserts on, so keep it present.
+export const SAMPLE_TURTLE = `@prefix ex:   <http://example.org/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+ex:alice a foaf:Person ;
+  foaf:name "Alice" ;
+  foaf:age 30 ;
+  ex:city "London" ;
+  foaf:knows ex:bob, ex:carol .
+
+ex:bob a foaf:Person ;
+  foaf:name "Bob"@en ;
+  foaf:age 25 ;
+  ex:city "Bristol" ;
+  foaf:knows ex:alice .
+
+ex:carol a foaf:Person ;
+  foaf:name "Carol" ;
+  foaf:age 41 ;
+  ex:city "London" ;
+  foaf:knows ex:alice, ex:dan .
+
+ex:dan a foaf:Person ;
+  foaf:name "Dan" ;
+  foaf:age 19 ;
+  ex:city "Cardiff" .
+`;
+
+/** The engine format string the workbench loads the sample with (Turtle). */
+export const SAMPLE_FORMAT = "turtle";
+
+/** The default query the workbench opens with — a deterministic SELECT over the sample. */
+export const DEFAULT_QUERY = `PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+SELECT ?name ?age WHERE {
+  ?s foaf:name ?name ;
+     foaf:age ?age .
+}
+ORDER BY ?name`;

--- a/gui/app/src/data/tools.ts
+++ b/gui/app/src/data/tools.ts
@@ -1,0 +1,166 @@
+// [OPUS-4.8] sq-ixc3.9 — the operational TOOLS taxonomy for the left-rail TOOLS list.
+//
+// Per research/gui-design.md §A.2: each tool is a VERB the user opens as a tab to RUN over the
+// live store — NOT a marketing page that describes the feature. Each carries an honesty-TIER
+// dot inherited from the engine's existing tier taxonomy (site/src/data/surfaces.ts) so a
+// `walkthrough`/`soon` capability is never silently dressed up as `live`.
+//
+// The foundation shell (this PR) ships the Query tool as a working tab and registers the rest
+// as honest STUBS the later phases fill (sq-ixc3.11 turns surfaces into live tools;
+// sq-ixc3.12 the query workbench; sq-ixc3.13 the import drawer). A stub tab states plainly
+// what it will do and its current tier — it does not fabricate a result.
+
+import type { LucideIcon } from "lucide-react";
+import {
+  Database,
+  Network as GraphIcon,
+  ShieldCheck,
+  Brain,
+  Search,
+  Binary,
+  MapPin,
+  Radio,
+  Lock,
+  Users,
+  Server,
+} from "lucide-react";
+
+/**
+ * Live-execution tier — the honesty dot. Mirrors the engine's existing tier taxonomy
+ * (site/src/data/surfaces.ts) so the GUI inherits the same honest "what runs where" framing.
+ *   live           — shipped wasm, in-tab today
+ *   live-new-wasm  — a new wasm bundle (portability spike first)
+ *   live-bbjs      — 3rd-party WASM (bb.js UltraHonk proving); NOT externally audited
+ *   live-sim       — faithful in-tab JS simulation; NOT the native protocol
+ *   walkthrough    — captured-I/O replay (native-only / different host)
+ *   soon           — not yet built; honest placeholder
+ */
+export type Tier =
+  | "live"
+  | "live-new-wasm"
+  | "live-bbjs"
+  | "live-sim"
+  | "walkthrough"
+  | "soon";
+
+export interface ToolDef {
+  /** Stable id — the tab key + the Cmd-K (later) index key. */
+  id: string;
+  /** The VERB shown in the rail + the tab label. */
+  label: string;
+  /** One-line operational description (what running this tool DOES over the live store). */
+  blurb: string;
+  tier: Tier;
+  icon: LucideIcon;
+  /** Does a working tab exist yet, or is this an honest stub the later phases fill? */
+  built: boolean;
+}
+
+/** The TOOLS list, in the rail order from research/gui-design.md §A.2. */
+export const TOOLS: ToolDef[] = [
+  {
+    id: "query",
+    label: "Query",
+    blurb: "Run SPARQL 1.1/1.2 over the live store — SELECT/ASK/CONSTRUCT/DESCRIBE/UPDATE.",
+    tier: "live",
+    icon: Database,
+    built: true,
+  },
+  {
+    id: "graph-view",
+    label: "Graph view",
+    blurb: "Node-link visualisation of CONSTRUCT/DESCRIBE results over the live store.",
+    tier: "soon",
+    icon: GraphIcon,
+    built: false,
+  },
+  {
+    id: "shacl",
+    label: "SHACL",
+    blurb: "Validate the live store against SHACL shapes; W3C report with sh:detail.",
+    tier: "live",
+    icon: ShieldCheck,
+    built: false,
+  },
+  {
+    id: "inference",
+    label: "Inference",
+    blurb: "Materialise RDFS / OWL-RL / N3 closure over the live store + proof trees.",
+    tier: "live-new-wasm",
+    icon: Brain,
+    built: false,
+  },
+  {
+    id: "full-text",
+    label: "Full-text",
+    blurb: "BM25 full-text search via magic predicates over the live store.",
+    tier: "live-new-wasm",
+    icon: Search,
+    built: false,
+  },
+  {
+    id: "vector",
+    label: "Vector",
+    blurb: "kNN over embeddings (vec:nearest); native-only, not yet in the wasm bundle.",
+    tier: "walkthrough",
+    icon: Binary,
+    built: false,
+  },
+  {
+    id: "geosparql",
+    label: "GeoSPARQL",
+    blurb: "Spatial joins + topology (geof:); native-only, not yet in the wasm bundle.",
+    tier: "walkthrough",
+    icon: MapPin,
+    built: false,
+  },
+  {
+    id: "streaming",
+    label: "Streaming",
+    blurb: "RSP-QL windowed stream processing with R/I/DSTREAM tick view.",
+    tier: "live-new-wasm",
+    icon: Radio,
+    built: false,
+  },
+  {
+    id: "zk",
+    label: "ZK proofs",
+    blurb:
+      "Commit → prove → verify a query result in-tab (UltraHonk). Research-grade; NOT externally audited.",
+    tier: "live-bbjs",
+    icon: Lock,
+    built: false,
+  },
+  {
+    id: "mpc",
+    label: "MPC",
+    blurb:
+      "Multi-party threshold over additive shares. In-tab JS illustration; NOT the native protocol, NOT live MPC.",
+    tier: "live-sim",
+    icon: Users,
+    built: false,
+  },
+  {
+    id: "server",
+    label: "Server",
+    blurb:
+      "Connect to a running sparq-server (SPARQL 1.1 Protocol) — endpoint mode, subscriptions, health.",
+    tier: "walkthrough",
+    icon: Server,
+    built: false,
+  },
+];
+
+/** Tier → honesty-dot colour class + short label, for the rail dots and tab headers. */
+export const TIER_META: Record<Tier, { dot: string; label: string }> = {
+  live: { dot: "bg-[var(--success)]", label: "Live in-tab" },
+  "live-new-wasm": { dot: "bg-[var(--success)]", label: "Live (new wasm)" },
+  "live-bbjs": { dot: "bg-primary", label: "Live (bb.js); not audited" },
+  "live-sim": { dot: "bg-[var(--warning)]", label: "In-tab simulation" },
+  walkthrough: { dot: "bg-muted-foreground", label: "Walkthrough (native-only)" },
+  soon: { dot: "bg-muted-foreground", label: "Not yet built" },
+};
+
+export function toolById(id: string): ToolDef | undefined {
+  return TOOLS.find((t) => t.id === id);
+}

--- a/gui/app/src/lib/base-path.ts
+++ b/gui/app/src/lib/base-path.ts
@@ -2,7 +2,7 @@
 //
 // The operational GUI frontend is served under TWO targets (see gui/app/next.config.ts):
 //   * the Tauri 2 desktop webview — from the `tauri://` root, where a `/prefix` 404s (basePath '');
-//   * the hosted "Try the GUI live" web target — under a sub-path (default `/sparq/gui`).
+//   * the hosted "Try the GUI live" web target — under a sub-path (default `/sparq/app`).
 //
 // `next.config.ts` env-switches `basePath`/`assetPrefix` off `NEXT_PUBLIC_BASE_PATH`, so Next
 // rewrites `_next/*` chunk URLs and `<Link href>` routes automatically. A HARDCODED absolute
@@ -14,20 +14,20 @@
  * The configured base path, derived from `NEXT_PUBLIC_BASE_PATH` (the same switch
  * `next.config.ts` uses):
  *
- *   * **unset** → `"/sparq/gui"` (the hosted-web default);
+ *   * **unset** → `"/sparq/app"` (the hosted-web default);
  *   * **`""`** → `""` (the Tauri root-relative export);
  *   * a leading-`/` value → that value (an explicit deploy prefix);
- *   * any malformed value → falls back to `"/sparq/gui"`.
+ *   * any malformed value → falls back to `"/sparq/app"`.
  *
  * Returns `""` (not `"/"`) for the root, so {@link withBasePath} composes a clean
  * `${basePath}/foo` without a double slash.
  */
 export function basePath(): string {
   const raw = process.env.NEXT_PUBLIC_BASE_PATH;
-  if (raw === undefined) return "/sparq/gui";
+  if (raw === undefined) return "/sparq/app";
   if (raw === "") return "";
   if (raw.startsWith("/")) return raw.replace(/\/$/, ""); // strip any trailing slash
-  return "/sparq/gui";
+  return "/sparq/app";
 }
 
 /** Prefix a root-absolute asset path with the configured {@link basePath}. */

--- a/gui/app/src/lib/base-path.ts
+++ b/gui/app/src/lib/base-path.ts
@@ -1,0 +1,36 @@
+// [OPUS-4.8] sq-ixc3.8 — the ONE GUI-frontend base-path resolver.
+//
+// The operational GUI frontend is served under TWO targets (see gui/app/next.config.ts):
+//   * the Tauri 2 desktop webview — from the `tauri://` root, where a `/prefix` 404s (basePath '');
+//   * the hosted "Try the GUI live" web target — under a sub-path (default `/sparq/gui`).
+//
+// `next.config.ts` env-switches `basePath`/`assetPrefix` off `NEXT_PUBLIC_BASE_PATH`, so Next
+// rewrites `_next/*` chunk URLs and `<Link href>` routes automatically. A HARDCODED absolute
+// asset path written by hand (a favicon, a static link) is NOT rewritten by Next, so it must
+// read the same env var. This is also the value passed to the @sparq/client wasm loader so the
+// runtime engine-asset fetch prefix stays in lockstep with the build-time route prefix.
+
+/**
+ * The configured base path, derived from `NEXT_PUBLIC_BASE_PATH` (the same switch
+ * `next.config.ts` uses):
+ *
+ *   * **unset** → `"/sparq/gui"` (the hosted-web default);
+ *   * **`""`** → `""` (the Tauri root-relative export);
+ *   * a leading-`/` value → that value (an explicit deploy prefix);
+ *   * any malformed value → falls back to `"/sparq/gui"`.
+ *
+ * Returns `""` (not `"/"`) for the root, so {@link withBasePath} composes a clean
+ * `${basePath}/foo` without a double slash.
+ */
+export function basePath(): string {
+  const raw = process.env.NEXT_PUBLIC_BASE_PATH;
+  if (raw === undefined) return "/sparq/gui";
+  if (raw === "") return "";
+  if (raw.startsWith("/")) return raw.replace(/\/$/, ""); // strip any trailing slash
+  return "/sparq/gui";
+}
+
+/** Prefix a root-absolute asset path with the configured {@link basePath}. */
+export function withBasePath(path: string): string {
+  return `${basePath()}${path}`;
+}

--- a/gui/app/src/lib/engine-context.tsx
+++ b/gui/app/src/lib/engine-context.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.9 — the operational engine context: the ONE live wasm store the whole
+// workbench shares, plus warm status, the measured-latency query path, and the dataset
+// summary the left-rail datasets tree renders.
+//
+// HONESTY: no performance number is baked in. The bottom status bar shows the latency of the
+// query the user JUST ran, measured with `performance.now()` and labelled as such — never a
+// benchmark claim. On the desktop Tauri target the design's end state is the DIRECT native
+// engine link (gui/src-tauri/src/engine.rs); this foundation shell runs the same in-tab WASM
+// engine in both targets (the honest, working-today path) and the IPC swap is a later phase.
+
+import * as React from "react";
+import {
+  loadSparq,
+  prewarmSparq,
+  formatSparqlJson,
+  extractTable,
+  isAskResult,
+  askValue,
+  type SparqlResults,
+  type WasmStore,
+  type WasmStoreCtor,
+} from "@sparq/client";
+
+import { basePath } from "@/lib/base-path";
+import { SAMPLE_TURTLE, SAMPLE_FORMAT } from "@/data/sample-graph";
+
+/** The engine warm lifecycle. `error` carries a load/parse failure message. */
+export type EngineStatus =
+  | { kind: "cold" }
+  | { kind: "warming" }
+  | { kind: "ready" }
+  | { kind: "error"; message: string };
+
+/** A per-named-graph row for the datasets tree (default graph + named graphs). */
+export interface GraphSummary {
+  /** The graph IRI, or null for the default graph. */
+  graph: string | null;
+  /** Triple/quad count in this graph. */
+  count: number;
+}
+
+/** What a run produced — discriminated by SPARQL form so the results panel can branch. */
+export type QueryOutcome =
+  | { kind: "select"; results: SparqlResults; rawJson: string; rowCount: number }
+  | { kind: "ask"; value: boolean; rawJson: string }
+  | { kind: "graph"; ntriples: string; tripleCount: number }
+  | { kind: "update"; sizeAfter: number }
+  | { kind: "error"; message: string };
+
+/** A completed run + its MEASURED latency (performance.now delta, ms). */
+export interface RunResult {
+  outcome: QueryOutcome;
+  /** Wall-clock latency of THIS run, measured with performance.now() (ms). Labelled, not a benchmark. */
+  latencyMs: number;
+}
+
+export interface EngineContextValue {
+  status: EngineStatus;
+  /** Total quads in the live store (default + all named graphs). */
+  storeSize: number;
+  /** Per-graph counts for the datasets tree. */
+  graphs: GraphSummary[];
+  /** The latency (ms) of the most recent run, or null before any run. */
+  lastLatencyMs: number | null;
+  /** The row count of the most recent SELECT run, or null. */
+  lastRowCount: number | null;
+  /** Run a query/update against the live store; resolves with the outcome + measured latency. */
+  run: (query: string) => Promise<RunResult>;
+}
+
+const EngineContext = React.createContext<EngineContextValue | null>(null);
+
+/** Heuristic SPARQL form classifier (the WASM Store has separate verbs per form). */
+function classifyQuery(q: string): "select" | "ask" | "construct" | "describe" | "update" {
+  // Strip comments + leading PREFIX/BASE declarations to find the first significant keyword.
+  const body = q
+    .replace(/(^|\s)#[^\n]*/g, " ")
+    .replace(/\b(PREFIX\s+\S+\s+<[^>]*>|BASE\s+<[^>]*>)/gi, " ")
+    .trim();
+  const m = body.match(/\b(SELECT|ASK|CONSTRUCT|DESCRIBE|INSERT|DELETE|LOAD|CLEAR|CREATE|DROP|COPY|MOVE|ADD)\b/i);
+  const kw = m ? m[1].toUpperCase() : "SELECT";
+  if (kw === "ASK") return "ask";
+  if (kw === "CONSTRUCT") return "construct";
+  if (kw === "DESCRIBE") return "describe";
+  if (["INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP", "COPY", "MOVE", "ADD"].includes(kw))
+    return "update";
+  return "select";
+}
+
+/** Summarise the live store into per-graph counts via a single grouped query. */
+function summariseGraphs(store: WasmStore): { size: number; graphs: GraphSummary[] } {
+  const graphs: GraphSummary[] = [];
+  let size = 0;
+  // Default graph.
+  try {
+    const def = store.count("SELECT * WHERE { ?s ?p ?o }");
+    if (def > 0) {
+      graphs.push({ graph: null, count: def });
+      size += def;
+    }
+  } catch {
+    /* count over an empty store can be zero; ignore */
+  }
+  // Named graphs (group by graph).
+  try {
+    const json = store.query(
+      "SELECT ?g (COUNT(*) AS ?c) WHERE { GRAPH ?g { ?s ?p ?o } } GROUP BY ?g ORDER BY ?g",
+    );
+    const parsed = JSON.parse(json) as SparqlResults;
+    for (const b of parsed.results?.bindings ?? []) {
+      const g = b["g"]?.value ?? null;
+      const c = Number.parseInt(b["c"]?.value ?? "0", 10) || 0;
+      if (g) {
+        graphs.push({ graph: g, count: c });
+        size += c;
+      }
+    }
+  } catch {
+    /* a store with no named graphs yields no rows; ignore */
+  }
+  return { size, graphs };
+}
+
+export function EngineProvider({ children }: { children: React.ReactNode }) {
+  const [status, setStatus] = React.useState<EngineStatus>({ kind: "cold" });
+  const [storeSize, setStoreSize] = React.useState(0);
+  const [graphs, setGraphs] = React.useState<GraphSummary[]>([]);
+  const [lastLatencyMs, setLastLatencyMs] = React.useState<number | null>(null);
+  const [lastRowCount, setLastRowCount] = React.useState<number | null>(null);
+
+  const storeRef = React.useRef<WasmStore | null>(null);
+  const ctorRef = React.useRef<WasmStoreCtor | null>(null);
+
+  // Warm the engine once on mount: load wasm, seed the sample graph, compute the summary.
+  React.useEffect(() => {
+    let cancelled = false;
+    const opts = { basePath: basePath() };
+    setStatus({ kind: "warming" });
+    prewarmSparq(opts)
+      .then(() => loadSparq(opts))
+      .then((Store) => {
+        if (cancelled) return;
+        ctorRef.current = Store;
+        const store = Store.load(SAMPLE_TURTLE, SAMPLE_FORMAT);
+        storeRef.current = store;
+        const { size, graphs: gs } = summariseGraphs(store);
+        setStoreSize(size);
+        setGraphs(gs);
+        setStatus({ kind: "ready" });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setStatus({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const refreshSummary = React.useCallback(() => {
+    const store = storeRef.current;
+    if (!store) return;
+    const { size, graphs: gs } = summariseGraphs(store);
+    setStoreSize(size);
+    setGraphs(gs);
+  }, []);
+
+  const run = React.useCallback(
+    async (query: string): Promise<RunResult> => {
+      const store = storeRef.current;
+      if (!store) {
+        const outcome: QueryOutcome = {
+          kind: "error",
+          message: "The engine is not ready yet — wait for the store to warm.",
+        };
+        return { outcome, latencyMs: 0 };
+      }
+      const form = classifyQuery(query);
+      const t0 = performance.now();
+      let outcome: QueryOutcome;
+      try {
+        if (form === "ask") {
+          const json = store.query(query);
+          const parsed = JSON.parse(json) as SparqlResults;
+          outcome = isAskResult(parsed)
+            ? { kind: "ask", value: askValue(parsed) ?? false, rawJson: formatSparqlJson(parsed) }
+            : { kind: "error", message: "ASK query did not return a boolean result." };
+        } else if (form === "construct" || form === "describe") {
+          const ntriples = store.queryQuads(query);
+          const tripleCount = ntriples
+            .split("\n")
+            .filter((l) => l.trim().length > 0).length;
+          outcome = { kind: "graph", ntriples, tripleCount };
+        } else if (form === "update") {
+          store.updateInPlace(query);
+          // `size` reports the default graph only; recompute the full per-graph total below.
+          const { size } = summariseGraphs(store);
+          outcome = { kind: "update", sizeAfter: size };
+        } else {
+          const json = store.query(query);
+          const parsed = JSON.parse(json) as SparqlResults;
+          const table = extractTable(parsed);
+          outcome = {
+            kind: "select",
+            results: parsed,
+            rawJson: formatSparqlJson(parsed),
+            rowCount: table.rows.length,
+          };
+        }
+      } catch (err) {
+        outcome = {
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        };
+      }
+      const latencyMs = performance.now() - t0;
+      setLastLatencyMs(latencyMs);
+      setLastRowCount(
+        outcome.kind === "select"
+          ? outcome.rowCount
+          : outcome.kind === "graph"
+            ? outcome.tripleCount
+            : null,
+      );
+      // An UPDATE mutated the store; refresh the datasets tree.
+      if (outcome.kind === "update") refreshSummary();
+      return { outcome, latencyMs };
+    },
+    [refreshSummary],
+  );
+
+  const value = React.useMemo<EngineContextValue>(
+    () => ({ status, storeSize, graphs, lastLatencyMs, lastRowCount, run }),
+    [status, storeSize, graphs, lastLatencyMs, lastRowCount, run],
+  );
+
+  return <EngineContext.Provider value={value}>{children}</EngineContext.Provider>;
+}
+
+export function useEngine(): EngineContextValue {
+  const ctx = React.useContext(EngineContext);
+  if (!ctx) throw new Error("useEngine must be used within an <EngineProvider>");
+  return ctx;
+}

--- a/gui/app/src/lib/utils.ts
+++ b/gui/app/src/lib/utils.ts
@@ -1,0 +1,7 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+/** Merge Tailwind class lists with conflict resolution (the shadcn `cn` convention). */
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/gui/app/tsconfig.json
+++ b/gui/app/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [{ "name": "next" }],
+    "paths": {
+      "@/*": ["./src/*"],
+      "@sparq/client": ["../../packages/sparq-client/src/index.ts"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules", "out"]
+}

--- a/gui/e2e/README.md
+++ b/gui/e2e/README.md
@@ -4,9 +4,10 @@
 
 A **real** end-to-end test for the Tauri desktop shell: it launches the built shell binary
 through [`tauri-driver`](https://v2.tauri.app/develop/tests/webdriver/) (WebDriver), drives the
-reused Next.js frontend in the native webview, **runs a SPARQL query in the in-tab WASM REPL**,
-and asserts the result table renders. It replaces the earlier no-op harness smoke (`sq-bu69`),
-which only confirmed that `tauri-driver` / `WebKitWebDriver` / `xvfb` were on `PATH`.
+DISTINCT operational GUI frontend (`gui/app`, NOT the marketing site — `sq-ixc3.8`) in the
+native webview, **runs a SPARQL query in the in-tab WASM workbench**, and asserts the result
+table renders. It replaces the earlier no-op harness smoke (`sq-bu69`), which only confirmed
+that `tauri-driver` / `WebKitWebDriver` / `xvfb` were on `PATH`.
 
 ## What it does (`run-e2e.mjs`)
 
@@ -15,15 +16,16 @@ which only confirmed that `tauri-driver` / `WebKitWebDriver` / `xvfb` were on `P
    shell binary via the `tauri:options.application` capability.
 3. Waits for the SPARQL editor (`#repl-query`) to mount and the WASM engine to report
    **Engine ready**.
-4. **Enters** a deterministic `SELECT ?name` over the built-in sample graph (set through the
+4. **Enters** a deterministic `SELECT ?name` over the seeded sample graph (set through the
    native `<textarea>` value setter + a bubbling `input` event, so the React-controlled editor
    updates).
 5. Clicks **Run query**.
 6. **Asserts** a `data-result-kind="select"` table renders containing the binding `"Alice"`
    and at least one data row.
 
-The Tauri window loads the site's static-export **index** (`site/out/index.html`), which embeds
-`<Repl />`, so the REPL is present on load with no in-webview route navigation.
+The Tauri window loads the GUI frontend's static-export **index** (`gui/app/out/index.html`),
+which renders the workbench shell with the Query tool open by default, so the editor is present
+on load with no in-webview route navigation.
 
 ## Run it locally (Linux)
 
@@ -31,12 +33,13 @@ Requires the webview system libraries (`libwebkit2gtk-4.1-dev`, …), `webkit2gt
 (provides `WebKitWebDriver`), and `xvfb`. Then:
 
 ```bash
-# 1. Build the frontend the webview embeds (root-relative, as the GUI consumes it).
-cd js && npm install && npm run build:wasm:lean
-cd ../site && npm install && npm run build:tauri   # = cross-env NEXT_PUBLIC_BASE_PATH= npm run build (root-relative)
+# 1. Build the frontend the webview embeds (root-relative, as the GUI consumes it). The
+#    workbench needs the shacl,jsonld bundle (its SHACL tool + JSON-LD ingest).
+cd js && npm install && npm run build:wasm
+cd ../gui/app && npm install && npm run build:tauri   # = NEXT_PUBLIC_BASE_PATH= next build (root-relative)
 
-# 2. Build the shell binary (embeds site/out at compile time).
-cd ../gui/src-tauri && cargo build
+# 2. Build the shell binary (embeds gui/app/out at compile time).
+cd ../src-tauri && cargo build
 
 # 3. Install the e2e deps + the driver, then run under a virtual display.
 cd ../e2e && npm ci

--- a/gui/e2e/run-e2e.mjs
+++ b/gui/e2e/run-e2e.mjs
@@ -3,27 +3,31 @@
 // Replaces the no-op "harness scaffold OK" smoke (sq-bu69) with a real assertion:
 //   1. spawn tauri-driver (the WebDriver intermediary; on Linux it proxies WebKitWebDriver),
 //   2. connect a WebDriver client (webdriverio) and launch the BUILT Tauri shell binary,
-//   3. wait for the reused Next.js frontend (the in-tab WASM REPL) to mount + the engine to
-//      warm,
+//   3. wait for the DISTINCT operational GUI frontend (the in-tab WASM workbench) to mount +
+//      the engine to warm,
 //   4. ENTER a known SPARQL SELECT into the editor (the React-controlled `#repl-query`
 //      textarea — set via the native value setter + an `input` event so React's state
 //      updates, the standard controlled-input driving technique),
 //   5. click "Run query", and
 //   6. ASSERT the SELECT result table renders with the expected binding ("Alice", from the
-//      built-in sample graph).
+//      seeded sample graph).
 //
 // This proves the desktop shell actually loads, the WASM engine runs a query IN THE TAB, and
 // the result renders — i.e. the shell is a working app, not just a crate that compiles.
 //
-// HOW IT FINDS THINGS (kept faithful to the site so it cannot silently drift):
-//   * The Tauri window loads the site's static-export INDEX (site/out/index.html), which
-//     embeds <Repl /> (site/src/app/page.tsx) — so no in-webview route navigation is needed.
-//   * The editor is a controlled <textarea id="repl-query"> behind a highlight <pre>
-//     (site/src/components/sparql-editor.tsx).
-//   * The Run button carries the visible text "Run query" (site/src/components/repl.tsx).
+// HOW IT FINDS THINGS (kept faithful to the DISTINCT operational GUI frontend, gui/app, so it
+// cannot silently drift — sq-ixc3.8 repointed the shell off the marketing site onto gui/app):
+//   * The Tauri window loads the GUI frontend's static-export INDEX (gui/app/out/index.html),
+//     which renders the workbench shell with the Query tool open by default — so no in-webview
+//     route navigation is needed.
+//   * The editor is a controlled <textarea id="repl-query">
+//     (gui/app/src/components/workbench/query-workbench.tsx).
+//   * The Run button carries the visible text "Run query" (same file).
+//   * The top bar shows "Engine ready" once the in-tab WASM engine warms
+//     (gui/app/src/components/workbench/top-bar.tsx).
 //   * A SELECT result renders a container with data-result-kind="select" and, in table view,
-//     data-result-view="table" wrapping a <table> (same file). We assert on those stable
-//     data-* hooks + the literal "Alice".
+//     data-result-view="table" wrapping a <table> (query-workbench.tsx). We assert on those
+//     stable data-* hooks + the literal "Alice" (from the seeded sample graph).
 //
 // CONFIG via env (CI sets APP_BINARY): APP_BINARY is the absolute path to the built shell
 // binary tauri-driver launches (the gui crate's package name is `sparq-gui`, so the debug

--- a/gui/src-tauri/build.rs
+++ b/gui/src-tauri/build.rs
@@ -1,13 +1,13 @@
-// [OPUS-4.8] sq-2e93 — Tauri build script: generates the context (parses tauri.conf.json,
-// embeds the frontend dist + capabilities). Standard Tauri 2 scaffold.
+// [OPUS-4.8] sq-2e93 / sq-ixc3.8 — Tauri build script: generates the context (parses
+// tauri.conf.json, embeds the frontend dist + capabilities). Standard Tauri 2 scaffold.
 //
-// FRONTEND-DIST CAVEAT (recorded here, not in tauri.conf.json — the `build` table is
-// deserialized with deny_unknown_fields, so a JSON "//" comment key fails the build): the
-// GUI reuses the site's Next.js frontend. `beforeBuildCommand` builds the static export and
-// `frontendDist` (../../site/out) is that export tree. The site hardcodes basePath '/sparq'
-// for GitHub Pages, but a Tauri webview serves from the `tauri://` root, so the export
-// consumed here MUST be built with NEXT_PUBLIC_BASE_PATH='' / basePath '' (env-switched).
-// Wiring that env-switch into the site config is a follow-up bead.
+// FRONTEND-DIST (recorded here, not in tauri.conf.json — the `build` table is deserialized with
+// deny_unknown_fields, so a JSON "//" comment key fails the build): the GUI embeds the DISTINCT
+// operational frontend at `gui/app/` — NOT the marketing site (sq-ixc3.8). `beforeBuildCommand`
+// runs `gui/app`'s `build:tauri` (NEXT_PUBLIC_BASE_PATH='' → a root-relative static export,
+// since a Tauri webview serves from the `tauri://` root where a `/prefix` 404s) and
+// `frontendDist` (../app/out) is that export tree. The SAME frontend also builds as a hosted
+// "Try the GUI live" web target via `gui/app`'s `build:web`.
 fn main() {
     tauri_build::build();
 }

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -4,10 +4,10 @@
   "version": "0.1.0",
   "identifier": "io.github.jeswr.sparq",
   "build": {
-    "beforeDevCommand": "cd ../../site && npm run dev",
-    "beforeBuildCommand": "cd ../../site && npm run build:tauri",
-    "devUrl": "http://localhost:3000/sparq",
-    "frontendDist": "../../site/out"
+    "beforeDevCommand": "cd ../app && npm run dev",
+    "beforeBuildCommand": "cd ../app && npm run build:tauri",
+    "devUrl": "http://localhost:3001",
+    "frontendDist": "../app/out"
   },
   "app": {
     "windows": [
@@ -32,7 +32,7 @@
       "icons/icon.png"
     ],
     "category": "DeveloperTool",
-    "shortDescription": "RDF + SPARQL workbench (MVP scaffold)",
-    "longDescription": "A cross-platform desktop workbench for the sparq RDF + SPARQL engine. Reuses the sparq web frontend in a native webview and links the engine directly as native Rust (full native store, not the WASM read-replica). MVP scaffold."
+    "shortDescription": "RDF + SPARQL operational workbench",
+    "longDescription": "A cross-platform desktop workbench for the sparq RDF + SPARQL engine. A DISTINCT operational frontend (left rail · tab strip · status bar) — not the marketing site in a window — running a live in-tab engine. The same frontend also static-exports as a hosted 'Try the GUI live' web target."
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*",
         "js",
         "site",
+        "gui/app",
         "gui/e2e"
       ],
       "devDependencies": {
@@ -18,6 +19,65 @@
         "@solidlab/policy-engine": "^0.0.2",
         "n3": "^1.26.0"
       }
+    },
+    "gui/app": {
+      "name": "sparq-gui-app",
+      "version": "0.1.0",
+      "dependencies": {
+        "class-variance-authority": "^0.7.1",
+        "clsx": "^2.1.1",
+        "lucide-react": "^0.460.0",
+        "next": "^15.5.19",
+        "next-themes": "^0.4.6",
+        "radix-ui": "^1.5.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "tailwind-merge": "^3.6.0"
+      },
+      "devDependencies": {
+        "@eslint/eslintrc": "^3.2.0",
+        "@tailwindcss/postcss": "^4.1.0",
+        "@types/node": "^22.10.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "cross-env": "^7.0.3",
+        "eslint": "^9.18.0",
+        "eslint-config-next": "^15.5.19",
+        "tailwindcss": "^4.1.0",
+        "tw-animate-css": "^1.4.0",
+        "typescript": "^5.7.0"
+      }
+    },
+    "gui/app/node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "gui/app/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "gui/app/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "gui/e2e": {
       "name": "sparq-gui-e2e",
@@ -7214,13 +7274,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -11641,6 +11701,10 @@
         }
       ],
       "license": "Apache-2.0"
+    },
+    "node_modules/sparq-gui-app": {
+      "resolved": "gui/app",
+      "link": true
     },
     "node_modules/sparq-gui-e2e": {
       "resolved": "gui/e2e",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "sparq-monorepo",
   "version": "0.0.0",
   "private": true,
-  "description": "Repo-root npm workspaces for the sparq JS surfaces (the published @jeswr/sparq WASM client, the shared @sparq/client, the GitHub-Pages showcase site, and the Tauri GUI e2e harness). NOT a published package — it exists only to give CI a single root install + lockfile across the workspace members. Deliberately has NO \"type\" field so repo-root CommonJS scripts (scripts/*.js, bench/dashboard/*.js) keep resolving as CJS.",
+  "description": "Repo-root npm workspaces for the sparq JS surfaces (the published @jeswr/sparq WASM client, the shared @sparq/client, the GitHub-Pages showcase site, the DISTINCT operational GUI frontend, and the Tauri GUI e2e harness). NOT a published package — it exists only to give CI a single root install + lockfile across the workspace members. Deliberately has NO \"type\" field so repo-root CommonJS scripts (scripts/*.js, bench/dashboard/*.js) keep resolving as CJS.",
   "workspaces": [
     "packages/*",
     "js",
     "site",
+    "gui/app",
     "gui/e2e"
   ],
   "devDependencies": {


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

Foundation for the maintainer's flagged **"try the GUI live"** + downloads: stand up the GUI as a **distinct operational workbench**, not the marketing site in a window. Built using the **frontend-design** skill (§3 operational-GUI patterns) + `research/gui-design.md` §A.

Refs epic **sq-ixc3** · closes **sq-ixc3.8** + **sq-ixc3.9** · advances **sq-wt4s3** (hosted-web-GUI link).

## sq-ixc3.8 — stop wrapping the marketing site
- `gui/src-tauri/tauri.conf.json` `frontendDist` is **no longer `site/out`** — it now points at `../app/out`, the new **`gui/app/`** Next.js app, and `beforeBuildCommand` runs `cd ../app && npm run build:tauri`.
- The new app **reuses** the `@sparq/client` wasm engine client + shared result-shaping/highlighter logic (zero new copy of the engine TS surface) and the design-system primitives — but renders its **own** operational chrome, never the site's hero / Showcase / Benchmarks / About pages.
- It is a new repo-root npm-workspace member (`gui/app`).

## sq-ixc3.9 — the operational app shell (`gui-design.md` §A.2)
- **Left rail** (`w-56`): workspace switcher · **datasets tree of the LIVE store** (default + named graphs, per-graph counts) + `+ Import` · **TOOLS** list — each a VERB opened as a tab with an honesty-tier dot (not a page describing the feature).
- **Top bar** (`h-10`): LOCAL⇄ENDPOINT target switch · store size · ⌘K hint · theme · engine status LED.
- **IDE tab strip** + full-bleed work area (default = **Query**).
- **Status bar** (`h-6`): **measured `performance.now()`** last-run latency · rows · target · persistence backend.
- The **Query** tool runs SELECT/ASK/CONSTRUCT/DESCRIBE/UPDATE **live in-tab**; the other tools open as **honest stubs** (their tier + the not-yet-audited ZK/MPC caveats) that later phases fill. **No Showcase/Benchmarks/About chrome**; Help opens the website in the system browser.

## TRY LIVE (web-deployable) — sq-wt4s3
The **same** frontend static-exports for **both** targets off the single `NEXT_PUBLIC_BASE_PATH` switch:
- `npm run build:tauri` → root-relative (embedded by the desktop shell).
- `npm run build:web` → `/sparq/gui` sub-path — the hosted **"Try the GUI live"** target, so the site's planned "Try the GUI" nav slot has a real target.

Full hosting/deploy wiring (the Pages-root slot is `sq-svtt`) is **deferred to a follow-up bead**; the **web-buildable shell lands here**.

## Constraint honoured
- **`site/` is UNCHANGED** (no page/nav edits); the marketing site still builds green. Shared logic stays in `packages/sparq-client` — no site files touched.

## Gates
- `gui/app`: **build:web** ✅ · **build:tauri** ✅ · `next lint` clean ✅ · `tsc --noEmit` clean ✅.
- WASM prereq built (`cd js && npm run build:wasm`).
- **privacy-claims** gate clean ✅ · **typos** gate clean ✅ (ZK/MPC tool stubs carry the not-externally-audited caveat).
- **site** static export still green ✅; `@sparq/client` typecheck green ✅.
- Runtime **smoke** against the real wasm bundle runs the workbench's exact queries end-to-end (default/named-graph counts, the default SELECT, ASK, CONSTRUCT, UPDATE, the e2e "Alice" query) ✅.
- `gui.yml`: new **GATING** `gui-app` job (lint + typecheck + both export targets, Linux); `tauri-e2e` now builds `gui/app` (its `#repl-query` / "Run query" / "Engine ready" / `data-result-*` hooks preserved so the existing assertion stays valid).
- No hard-coded performance numbers; the status bar shows only **measured, labelled** per-run latency.

## Covered vs deferred
- **Covered:** distinct frontend (frontendDist ≠ site/out) · app shell · working Query tool over the live store · both static-export targets · honest tool stubs · CI wiring.
- **Deferred (beaded):** Cmd-K palette (sq-ixc3.10) · multi-view query workbench (sq-ixc3.12) · import drawer (sq-ixc3.13) · surfaces-as-live-tools (sq-ixc3.11) · the hosted web-GUI deploy/hosting step.

Auto-merge **OFF** — new GUI surface, for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)