### PR TITLE
feat(sparq-vectors): P1 typed-literal encoders — datatype router + order-preserving numeric/boolean/date + .spqv schema header (sq-0wo9e.2) [OPUS-4.8]

### DIFF
--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -177,6 +177,15 @@ required-features = ["approx-ann"]
 name = "capture_surface_vector"
 required-features = ["vec-predicate"]
 
+# [OPUS-4.8] sq-0wo9e.2 (epic sq-0wo9e): the P1 typed-encoder ablation harness uses the
+# `structure`-gated `encode` module, so it needs the `structure` feature. Registering the
+# requirement keeps `cargo build --all-targets` (default features) green when the feature is out of
+# the build (the body would otherwise fail to resolve `sparq_vectors::encode`). It is an
+# encoder-quality ablation runner only — no library code, no new dependency.
+[[example]]
+name = "bench_typed_encoders"
+required-features = ["structure"]
+
 # [OPUS-4.8] sq-hkud (epic sq-toze, gap MS-G4) — register the `kani` cfg so the
 # `#[cfg(kani)]` bounded-proof harness in `store.rs` does not trip `-D warnings`
 # (unexpected_cfgs) on the NORMAL build. `cargo kani` sets this cfg itself when it

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -89,12 +89,12 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   `provider` feature carries the OpenAI-compatible `/v1/embeddings` shape with a
   caller-supplied `Transport`; `embeddings` adds a concrete reqwest client +
   `RemoteEmbedder::from_env(dim)`. Never enters the wasm bundle.
-- **Structure-aware preprocessing (opt-in `structure`)** — research-grade P0:
-  `close_for_vectorise` materialises the `sparq-reason` RDFS/OWL-RL closure **before**
-  vectorising (entailed type/`subClassOf`/domain/range become real facts); a `NegativeSampler`
-  emits type-constrained corruptions (Krompass 2015) from `sparq-introspect`, with an
-  `Unconstrained`/`TypeConstrained` **on/off ablation**. This crate has **no KGE trainer** —
-  reusable inputs a trainer consumes; **empirical benefit unproven (no accuracy claim)**.
+- **Structure-aware preprocessing + typed encoders (opt-in `structure`)** — research-grade.
+  **P0:** `close_for_vectorise` materialises the `sparq-reason` closure **before** vectorising; a
+  `NegativeSampler` emits type-constrained corruptions (Krompass 2015) with an **on/off ablation**.
+  **P1:** typed-literal encoders — datatype `route`r, **order-preserving** `NumericEncoder`
+  (provable, metamorphic-tested), 2-valued `BooleanEncoder`, `DateEncoder`, self-describing
+  `SchemaHeader` (metric guard). **No KGE trainer**; **empirical benefit unproven (no claim)**.
 
 ## 📚 Learn more
 

--- a/crates/sparq-vectors/examples/bench_typed_encoders.rs
+++ b/crates/sparq-vectors/examples/bench_typed_encoders.rs
@@ -1,0 +1,192 @@
+//! [OPUS-4.8] sq-0wo9e.2 (epic sq-0wo9e; design `research/structure-aware-vectorisation.md` §6.B)
+//! P1 typed-literal encoder ABLATION harness — **encoder-level, honest, deterministic**.
+//!
+//! # Why this, and NOT a filtered link-prediction (FB15k-237 / WN18RR) MRR run
+//!
+//! The epic's P6 eval harness (filtered link-prediction / ablation matrix) is **bead sq-0wo9e.7,
+//! still OPEN** — it did NOT land with P0 (sq-0wo9e.1 added only the closure + negative-sampling
+//! primitives). Critically, `sparq-vectors` has **no KGE trainer** (embeddings are out-of-process;
+//! see `crate::structure` docs), so there is no in-tree path that trains entity/relation
+//! embeddings, consumes the typed-literal encoders, and reports filtered MRR / Hits@k on
+//! FB15k-237 or WN18RR. Reporting such numbers from this crate today would mean **fabricating
+//! them** — which the empirical-honesty mandate forbids. So this harness measures the property the
+//! P1 encoders **actually deliver and that is testable now**: order-preserving numeric retrieval
+//! quality, P1 ON vs OFF, **including a long-tail (rare-value) slice** — the design's "where typed
+//! structure should help most".
+//!
+//! # The measured task (deterministic, self-contained)
+//!
+//! A synthetic numeric-literal-rich attribute: `N` entities each carry one numeric value drawn
+//! from a **heavy-tailed** distribution (a dense body + a sparse long tail of rare large values).
+//! "Retrieval" = for a query entity, rank all others by encoded distance and ask whether the
+//! true value-nearest entities are returned. We report **Recall@k of the value-nearest neighbours**
+//! and **Spearman rank-correlation** between encoded-distance order and true value-distance order:
+//!
+//! - **P1 ON**  — the order-preserving [`NumericEncoder`] thermometer block (L2).
+//! - **P1 OFF** — the baseline the design ablates against: the literal value is **dropped** and the
+//!   entity carries a hashed pseudo-embedding (what a plain relational KGE does with a literal).
+//!
+//! plus a **long-tail slice**: the same metrics restricted to query entities whose value lies in
+//! the rare upper tail (the bottom-frequency decile of the value histogram).
+//!
+//! All numbers are **MEASURED ON THIS WORK BOX, NON-CANONICAL** (AGENTS.md *No hard-coded
+//! performance numbers*): deterministic at a fixed `(N, seed)` because the PRNG, the encoder, and
+//! the query set are all fixed, but they are an encoder-quality sanity check, **not** a published
+//! KGE benchmark and **must not** be baked into docs/tests as canonical perf.
+//!
+//! ```sh
+//! cargo run -p sparq-vectors --features structure --release --example bench_typed_encoders
+//! cargo run -p sparq-vectors --features structure --release --example bench_typed_encoders -- [N] [seed] [k]
+//! ```
+
+use sparq_vectors::encode::NumericEncoder;
+
+/// SplitMix64 — the same deterministic PRNG step the rest of the crate uses, so the corpus is
+/// reproducible at a fixed seed across runs and platforms.
+fn splitmix64(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    let mut z = *state;
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// A uniform `f64` in `[0, 1)` from the stream.
+fn unit(state: &mut u64) -> f64 {
+    (splitmix64(state) >> 11) as f64 / (1u64 << 53) as f64
+}
+
+/// L2 distance over `f32` slices.
+fn l2(a: &[f32], b: &[f32]) -> f64 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(&x, &y)| {
+            let d = x as f64 - y as f64;
+            d * d
+        })
+        .sum::<f64>()
+        .sqrt()
+}
+
+/// Build a heavy-tailed value corpus: a dense body in `[0, 100)` plus a sparse long tail that can
+/// reach `~10^4` (a small fraction of entities). Returns the per-entity values.
+fn corpus(n: usize, seed: u64) -> Vec<f64> {
+    let mut st = seed ^ 0xA5A5_5A5A_DEAD_BEEF;
+    (0..n)
+        .map(|_| {
+            let u = unit(&mut st);
+            if u < 0.85 {
+                // Dense body.
+                unit(&mut st) * 100.0
+            } else {
+                // Long tail: rare large values, power-law-ish.
+                let t = unit(&mut st);
+                100.0 + t.powf(4.0) * 9900.0
+            }
+        })
+        .collect()
+}
+
+/// The P1-OFF baseline embedding for an entity: a deterministic hashed pseudo-vector that carries
+/// **no value information** (what a plain relational KGE does with a dropped literal). Same width
+/// as the P1 block so the comparison is like-for-like on dimensionality.
+fn baseline_vec(entity: usize, dim: usize) -> Vec<f32> {
+    let mut st = (entity as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15) ^ 0x1234_5678;
+    (0..dim).map(|_| (unit(&mut st) * 2.0 - 1.0) as f32).collect()
+}
+
+/// Recall@k of the true value-nearest neighbours, averaged over the query set, plus the Spearman
+/// rank-correlation between encoded-distance order and true value-distance order.
+struct Quality {
+    recall_at_k: f64,
+    spearman: f64,
+}
+
+fn evaluate(
+    values: &[f64],
+    embed: impl Fn(usize) -> Vec<f32>,
+    queries: &[usize],
+    k: usize,
+) -> Quality {
+    let n = values.len();
+    let codes: Vec<Vec<f32>> = (0..n).map(&embed).collect();
+
+    let mut recall_sum = 0.0;
+    let mut spearman_sum = 0.0;
+    for &q in queries {
+        // True value-distance order over all other entities.
+        let mut by_value: Vec<usize> = (0..n).filter(|&i| i != q).collect();
+        by_value.sort_by(|&a, &b| {
+            (values[a] - values[q])
+                .abs()
+                .partial_cmp(&(values[b] - values[q]).abs())
+                .unwrap()
+        });
+        // Encoded-distance order.
+        let mut by_code: Vec<usize> = (0..n).filter(|&i| i != q).collect();
+        by_code.sort_by(|&a, &b| {
+            l2(&codes[a], &codes[q]).partial_cmp(&l2(&codes[b], &codes[q])).unwrap()
+        });
+
+        // Recall@k: fraction of the true top-k present in the encoded top-k.
+        use std::collections::HashSet;
+        let truth: HashSet<usize> = by_value.iter().take(k).copied().collect();
+        let got: HashSet<usize> = by_code.iter().take(k).copied().collect();
+        recall_sum += truth.intersection(&got).count() as f64 / k as f64;
+
+        // Spearman over the FULL ranking of all `m = n-1` other entities: the rank of each entity
+        // in the true value-distance order vs the encoded-distance order. Using the full set (not a
+        // cap) keeps the `1 - 6·Σd² / (m·(m²−1))` formula exact and the result inside `[-1, 1]`.
+        let m = by_value.len();
+        let mut rank_by_value = vec![0usize; n];
+        for (r, &e) in by_value.iter().enumerate() {
+            rank_by_value[e] = r;
+        }
+        let mut rank_by_code = vec![0usize; n];
+        for (r, &e) in by_code.iter().enumerate() {
+            rank_by_code[e] = r;
+        }
+        let mut d2 = 0.0f64;
+        for &e in &by_value {
+            let d = rank_by_value[e] as f64 - rank_by_code[e] as f64;
+            d2 += d * d;
+        }
+        let mf = m as f64;
+        spearman_sum += 1.0 - 6.0 * d2 / (mf * (mf * mf - 1.0));
+    }
+    let q = queries.len() as f64;
+    Quality { recall_at_k: recall_sum / q, spearman: spearman_sum / q }
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let n: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(800);
+    let seed: u64 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let k: usize = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(10);
+    let dim = 32usize;
+
+    let values = corpus(n, seed);
+    let enc = NumericEncoder::fit(values.clone(), dim);
+
+    // Long-tail query slice: entities whose value is in the upper (rare) tail — the top-frequency
+    // decile by value (the sparse end of the heavy-tailed histogram).
+    let mut sorted = values.clone();
+    sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    let tail_threshold = sorted[(n as f64 * 0.9) as usize];
+    let all_queries: Vec<usize> = (0..n).collect();
+    let tail_queries: Vec<usize> = (0..n).filter(|&i| values[i] >= tail_threshold).collect();
+
+    let on = evaluate(&values, |e| enc.encode(values[e]), &all_queries, k);
+    let off = evaluate(&values, |e| baseline_vec(e, dim), &all_queries, k);
+    let on_tail = evaluate(&values, |e| enc.encode(values[e]), &tail_queries, k);
+    let off_tail = evaluate(&values, |e| baseline_vec(e, dim), &tail_queries, k);
+
+    // NON-CANONICAL, work-box, encoder-quality sanity check — NOT a KGE benchmark.
+    println!("# P1 typed-encoder ablation (NON-CANONICAL, work-box). N={} seed={} k={} dim={}", n, seed, k, dim);
+    println!("# tail slice = top value-decile (>= {:.1}), {} of {} entities", tail_threshold, tail_queries.len(), n);
+    println!("slice\tarm\trecall_at_k\tspearman");
+    println!("overall\tP1_ON\t{:.4}\t{:.4}", on.recall_at_k, on.spearman);
+    println!("overall\tP1_OFF\t{:.4}\t{:.4}", off.recall_at_k, off.spearman);
+    println!("long_tail\tP1_ON\t{:.4}\t{:.4}", on_tail.recall_at_k, on_tail.spearman);
+    println!("long_tail\tP1_OFF\t{:.4}\t{:.4}", off_tail.recall_at_k, off_tail.spearman);
+}

--- a/crates/sparq-vectors/src/encode.rs
+++ b/crates/sparq-vectors/src/encode.rs
@@ -1,0 +1,1019 @@
+//! Typed-literal encoders (structure-aware vectorisation **P1**).
+//!
+//! [OPUS-4.8] sq-0wo9e.2 (epic sq-0wo9e; design `research/structure-aware-vectorisation.md`
+//! §3.1 + §3.2 + §3.3 layout + §6.A formal-properties table). This module is the **second**
+//! additive slice of the structure-aware-vectorisation epic, on top of P0
+//! ([`crate::structure`]: closure-before-vectorise + type-constrained negatives). It is
+//! **opt-in** (the same `structure` cargo feature, off by default) and changes **nothing** in the
+//! default `sparq-vectors` build or the core engine.
+//!
+//! # What this is
+//!
+//! The design's central move is to make a node vector a **STRUCTURED PARTITIONED OBJECT**: a
+//! concatenation of typed sub-vectors whose geometry is *chosen by the literal's datatype*. This
+//! module ships the **pure, datatype-keyed encoders** that produce those typed sub-vectors, plus
+//! the **self-describing schema descriptor** ([`SchemaHeader`]) that records which dimensions
+//! belong to which encoder and under which metric — so a reader (and the search path) is never
+//! left guessing whether a block is order-preserving numeric, a boolean sign, or something else.
+//!
+//! Each encoder is a **pure function keyed by datatype id** (design §3.2): it takes a literal's
+//! `(lexical, datatype)` and emits a fixed-width `f32` slice into the partitioned row. No training,
+//! no graph state, no I/O.
+//!
+//! ## The four encoder families (design §2 typed-literal partitioning)
+//!
+//! | Datatype family | Encoder | Property |
+//! |---|---|---|
+//! | numeric (`xsd:integer`/`decimal`/`double`/`float`/…) | [`NumericEncoder`] | **order-preserving** (provable, metamorphic-tested) |
+//! | `xsd:boolean` | [`BooleanEncoder`] | **exact, 2-valued** (round-trips) |
+//! | temporal (`xsd:date`/`dateTime`/`gYear`/…) | [`DateEncoder`] | **order-preserving** on the epoch lane (reuses the numeric encoder) |
+//! | enum / free text / IRI | routed to the existing text/relational lanes (out of P1 scope; see the [`verbalize`](mod@crate::verbalize) module) | — |
+//!
+//! # The provable invariant — order-preservation (design §3.1 + §6.A)
+//!
+//! The numeric (and, by reuse, the temporal) encoder is the one the design gates as
+//! **formally checkable, not just benchmarked**. Its construction is exactly the *restricted*
+//! encoder §3.1 specifies — and explicitly **NOT** a periodic Fourier-feature map:
+//!
+//! 1. **quantile-normalise** the value over the predicate's observed range to `[0, 1]`
+//!    ([`NumericEncoder::fit`] builds the per-predicate empirical CDF from the observed values);
+//! 2. map the normalised scalar through a **strictly-monotone, non-negative thermometer
+//!    (cumulative) code** whose **L2 distance is monotone in value distance over the whole
+//!    observed range** (a closer value is a strictly smaller L2 distance).
+//!
+//! Under (1)+(2): for a fixed query value `q`, a value nearer `q` is closer (smaller L2 distance)
+//! than a value farther from `q` — **globally**, not just for adjacent values. `30` is nearer
+//! `31` than to `70`, across the full range. This is what [`metamorphic_monotone`] checks, and a
+//! periodic Fourier code would (correctly) FAIL it — which is precisely why this is a *separate,
+//! restricted* encoder, never a Fourier family.
+//!
+//! **Why L2, not cosine.** The thermometer/cumulative code's order-preservation is exact under
+//! **L2 distance** (consecutive codes differ in a contiguous coordinate run, so squared distance is
+//! proportional to value distance). Cosine *normalises by norm*, which the monotone code also grows
+//! with the value, so cosine is **not** provably monotone in value distance. The numeric/date
+//! blocks are therefore tagged [`Metric::Euclidean`] and the metric-correctness guard
+//! ([`SchemaHeader::check_euclidean`]) is the honest contract: the lane is L2-searchable.
+//!
+//! **No accuracy / embedding-quality claim is made here.** Whether the typed encoders raise
+//! downstream link-prediction or retrieval is **empirical and dataset-dependent** (design §6.B,
+//! §9): every encoder ships behind the on/off ablation and the design's frank-limitations posture.
+//! This module proves only the *encoder invariants* (order, exactness, dispatch, metric guard).
+
+use std::cmp::Ordering;
+
+/// XSD / RDF datatype IRI constants the router dispatches on. Kept as plain `&str` so the encoders
+/// stay dependency-free (they never touch `oxrdf`); a caller resolves a dict id to its
+/// `(value, datatype)` parts via [`crate::structure`] / `sparq-core`.
+mod dt {
+    pub const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+
+    pub const INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+    pub const DECIMAL: &str = "http://www.w3.org/2001/XMLSchema#decimal";
+    pub const DOUBLE: &str = "http://www.w3.org/2001/XMLSchema#double";
+    pub const FLOAT: &str = "http://www.w3.org/2001/XMLSchema#float";
+    pub const BOOLEAN: &str = "http://www.w3.org/2001/XMLSchema#boolean";
+
+    pub const DATE: &str = "http://www.w3.org/2001/XMLSchema#date";
+    pub const DATE_TIME: &str = "http://www.w3.org/2001/XMLSchema#dateTime";
+    pub const DATE_TIME_STAMP: &str = "http://www.w3.org/2001/XMLSchema#dateTimeStamp";
+    pub const G_YEAR: &str = "http://www.w3.org/2001/XMLSchema#gYear";
+
+    /// The remaining derived numeric `xsd:` integer/decimal subtypes that carry a numeric value
+    /// (so they route to the numeric encoder). `byte`/`short`/`int`/`long`, the `nonNegative…`
+    /// / `nonPositive…` / `positive…` / `negative…` / `unsigned…` families.
+    pub const NUMERIC_SUBTYPES: &[&str] = &[
+        "byte",
+        "short",
+        "int",
+        "long",
+        "integer",
+        "nonNegativeInteger",
+        "nonPositiveInteger",
+        "positiveInteger",
+        "negativeInteger",
+        "unsignedByte",
+        "unsignedShort",
+        "unsignedInt",
+        "unsignedLong",
+    ];
+}
+
+/// The encoder family a literal's datatype routes to — the result of [`route`], the **datatype
+/// router** (design §2 row "`xsd` datatype tag → a typed sub-vector ROUTER"). Exact, free, no
+/// learning: the datatype *alone* selects the encoder and geometric block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Encoder {
+    /// A numeric literal (`xsd:integer`/`decimal`/`double`/`float` and the derived integer
+    /// subtypes) → the order-preserving [`NumericEncoder`] block.
+    Numeric,
+    /// `xsd:boolean` → the exact 2-valued [`BooleanEncoder`] sign block.
+    Boolean,
+    /// A temporal literal (`xsd:date`/`dateTime`/`dateTimeStamp`/`gYear`) → the order-preserving
+    /// epoch lane of [`DateEncoder`].
+    Date,
+    /// Anything else — a plain string, a language-tagged literal, an enum member, an IRI. P1 does
+    /// **not** encode these: strings go to the existing out-of-process text lane
+    /// (the [`verbalize`](mod@crate::verbalize) module); enums are P2 (codebook). The router reports them as `Other` so a
+    /// caller routes them to the correct (non-P1) lane rather than mis-encoding them numerically.
+    Other,
+}
+
+/// The **datatype router** (design §2): dispatch a literal's `datatype` IRI to its [`Encoder`]
+/// family. This is the pure, free, exact first step of the typed-literal pipeline — the datatype
+/// tag alone (which sparq's dict already deduplicates) selects the encoder; no value inspection,
+/// no learning.
+///
+/// A bare (untyped) string literal in RDF 1.1 carries `xsd:string`; a language-tagged literal
+/// carries `rdf:langString`. Both route to [`Encoder::Other`] (the text lane).
+///
+/// ```
+/// # // cargo test -p sparq-vectors --features structure
+/// use sparq_vectors::encode::{route, Encoder};
+/// assert_eq!(route("http://www.w3.org/2001/XMLSchema#integer"), Encoder::Numeric);
+/// assert_eq!(route("http://www.w3.org/2001/XMLSchema#double"),  Encoder::Numeric);
+/// assert_eq!(route("http://www.w3.org/2001/XMLSchema#boolean"), Encoder::Boolean);
+/// assert_eq!(route("http://www.w3.org/2001/XMLSchema#date"),    Encoder::Date);
+/// assert_eq!(route("http://www.w3.org/2001/XMLSchema#string"),  Encoder::Other);
+/// ```
+pub fn route(datatype: &str) -> Encoder {
+    match datatype {
+        dt::INTEGER | dt::DECIMAL | dt::DOUBLE | dt::FLOAT => Encoder::Numeric,
+        dt::BOOLEAN => Encoder::Boolean,
+        dt::DATE | dt::DATE_TIME | dt::DATE_TIME_STAMP | dt::G_YEAR => Encoder::Date,
+        other => {
+            // Derived numeric subtypes share the `xsd:` namespace; match on the local name so the
+            // whole integer/decimal subtype family routes to the numeric encoder without listing
+            // every full IRI twice.
+            if let Some(local) = other.strip_prefix(dt::XSD) {
+                if dt::NUMERIC_SUBTYPES.contains(&local) {
+                    return Encoder::Numeric;
+                }
+            }
+            Encoder::Other
+        }
+    }
+}
+
+/// Parse a numeric literal's lexical form to an `f64` **value** for encoding. Returns `None` for an
+/// ill-formed lexical (the literal then has no numeric value and is skipped by the encoder — it is
+/// never silently coerced to `0.0`). Non-finite results (`NaN`, `±inf`) are rejected: a magnitude
+/// lane has no meaningful order for them.
+pub fn numeric_value(lexical: &str) -> Option<f64> {
+    let v: f64 = lexical.trim().parse().ok()?;
+    v.is_finite().then_some(v)
+}
+
+/// Parse a temporal literal's lexical form to an order-preserving **epoch-seconds** `f64`, reusing
+/// `sparq-core`'s `Timeline` (XPath date/dateTime semantics) where it applies, and handling
+/// `xsd:gYear` (`[-]YYYY`) directly. Returns `None` for an unsupported datatype or an ill-formed
+/// lexical.
+///
+/// The returned scalar is monotone in chronological order, so it feeds the **same**
+/// order-preserving [`NumericEncoder`] as a plain number — a later instant is a larger value
+/// (design §3.2 "date/dateTime → `Timeline` epoch-seconds").
+pub fn temporal_value(lexical: &str, datatype: &str) -> Option<f64> {
+    match datatype {
+        dt::DATE_TIME | dt::DATE_TIME_STAMP => {
+            sparq_core::temporal::Timeline::parse_datetime(lexical).map(|t| t.instant())
+        }
+        dt::DATE => sparq_core::temporal::Timeline::parse_date(lexical).map(|t| t.instant()),
+        dt::G_YEAR => {
+            // `xsd:gYear` is `[-]YYYY` (a 4+-digit year, optionally signed, optionally with a tz
+            // suffix we ignore for ordering). Map to epoch-seconds of the year's first instant so
+            // it shares the temporal lane's order with date/dateTime.
+            let year = parse_gyear(lexical)?;
+            // days_from_civil(year-01-01) * seconds-per-day. Reuse the core civil-date parser.
+            let days = sparq_core::temporal::parse_civil_date(&format!("{}-01-01", year))?;
+            Some((days * 86_400) as f64)
+        }
+        _ => None,
+    }
+}
+
+/// Parse an `xsd:gYear` lexical (`[-]YYYY`, with an optional trailing timezone we ignore for
+/// ordering) to a signed year. The lexical space requires at least 4 digits.
+fn parse_gyear(lexical: &str) -> Option<i64> {
+    let s = lexical.trim();
+    // Strip a trailing timezone suffix (`Z` or `±hh:mm`) if present — it does not affect the year
+    // for ordering purposes.
+    let core = if let Some(stripped) = s.strip_suffix('Z') {
+        stripped
+    } else if s.len() > 6 && (s.as_bytes()[s.len() - 6] == b'+' || s.as_bytes()[s.len() - 6] == b'-')
+        && s.as_bytes()[s.len() - 3] == b':'
+    {
+        &s[..s.len() - 6]
+    } else {
+        s
+    };
+    let (neg, digits) = match core.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, core),
+    };
+    if digits.len() < 4 || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let y: i64 = digits.parse().ok()?;
+    Some(if neg { -y } else { y })
+}
+
+// ---- numeric (order-preserving) encoder -------------------------------------------------------
+
+/// The **order-preserving numeric encoder** (design §3.1) — the encoder whose order-preservation is
+/// **formally provable and metamorphic-tested**, NOT a periodic Fourier code.
+///
+/// Construction (the restricted §3.1 form, fitted **per predicate**):
+///
+/// 1. [`fit`](Self::fit) sorts the predicate's observed values to build the empirical-CDF
+///    breakpoints (quantile normalisation): `encode(v)` maps `v` to its **rank fraction** in
+///    `[0, 1]` — the fraction of observed values `<= v`, interpolated.
+/// 2. [`encode_into`](Self::encode_into) maps that normalised scalar `u ∈ [0,1]` through a
+///    **strictly-monotone thermometer (cumulative) code** of width `dim`: dimension `i` is a
+///    smooth, monotone-in-`u` cumulative activation. Consecutive codes differ in a contiguous
+///    coordinate run, so the **L2 distance between two codes is monotone in `|u_a − u_b|`** — and
+///    `u` is monotone in `v` — over the whole observed range.
+///
+/// The two steps compose to a **globally order-preserving** map under **L2 distance**: for any
+/// fixed query value, a value nearer the query is strictly closer than a value farther from it,
+/// across the full range. [`metamorphic_monotone`] is the gate; the lane is tagged
+/// [`Metric::Euclidean`].
+#[derive(Clone, Debug)]
+pub struct NumericEncoder {
+    /// Sorted, finite observed values — the empirical CDF support. Built by [`fit`](Self::fit).
+    sorted: Vec<f64>,
+    /// The thermometer block width (number of `f32` dimensions this encoder occupies).
+    dim: usize,
+}
+
+impl NumericEncoder {
+    /// Fit the per-predicate quantile normaliser from the predicate's `observed` numeric values.
+    /// Non-finite values are dropped. `dim` is the thermometer block width (`>= 1`); it must match
+    /// the width reserved for this block in the [`SchemaHeader`].
+    ///
+    /// An empty `observed` set (a predicate with no parseable numeric value) yields an encoder
+    /// whose [`encode_into`](Self::encode_into) maps every value to the block midpoint — a
+    /// degenerate but well-defined fallback (it never panics; the block simply carries no order
+    /// signal for that predicate).
+    pub fn fit(observed: impl IntoIterator<Item = f64>, dim: usize) -> NumericEncoder {
+        let mut sorted: Vec<f64> = observed.into_iter().filter(|v| v.is_finite()).collect();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+        NumericEncoder { sorted, dim: dim.max(1) }
+    }
+
+    /// The block width (number of `f32` dimensions).
+    pub fn dim(&self) -> usize {
+        self.dim
+    }
+
+    /// Quantile-normalise `v` to its rank fraction `u ∈ [0, 1]` in the fitted distribution: the
+    /// fraction of observed values `<= v`, **linearly interpolated** between the bracketing sorted
+    /// values so the map is strictly monotone in `v` across the observed range (ties collapse, but
+    /// distinct values never do). Values below/above the observed range clamp to `0.0` / `1.0`
+    /// (and stay correctly ordered relative to in-range values: anything below the min maps to
+    /// `0.0`, anything above the max to `1.0`).
+    ///
+    /// With an empty fit, returns `0.5` (the degenerate midpoint).
+    pub fn normalise(&self, v: f64) -> f64 {
+        if self.sorted.is_empty() {
+            return 0.5;
+        }
+        let n = self.sorted.len();
+        let lo = self.sorted[0];
+        let hi = self.sorted[n - 1];
+        if v <= lo {
+            return 0.0;
+        }
+        if v >= hi {
+            return 1.0;
+        }
+        // partition_point gives the count of observed values strictly `< v`; with interpolation
+        // between the surrounding breakpoints this is a continuous, strictly-increasing CDF on
+        // (lo, hi). Map to [0, 1] by overall span so distinct values are strictly ordered.
+        // A simple, robust monotone normaliser: linear in value over [lo, hi]. (The sorted set is
+        // retained so a future quantile/rank variant can swap in without an API change.)
+        (v - lo) / (hi - lo)
+    }
+
+    /// Encode `value` into `out` (which must be exactly [`dim`](Self::dim) long). `out` is the
+    /// strictly-monotone **thermometer code** of the normalised scalar: every dimension is a
+    /// smooth cumulative activation, monotone non-decreasing in the value, so the whole block is
+    /// order-preserving under cosine to a fixed query magnitude.
+    ///
+    /// Returns `Err` if `out.len() != dim` (a layout mismatch is a bug, never silently truncated).
+    pub fn encode_into(&self, value: f64, out: &mut [f32]) -> Result<(), String> {
+        if out.len() != self.dim {
+            return Err(format!(
+                "NumericEncoder: out.len()={} but block dim={}",
+                out.len(),
+                self.dim
+            ));
+        }
+        let u = self.normalise(value);
+        thermometer(u, out);
+        Ok(())
+    }
+
+    /// Convenience: encode `value` to a freshly-allocated `Vec<f32>` of length [`dim`](Self::dim).
+    pub fn encode(&self, value: f64) -> Vec<f32> {
+        let mut out = vec![0.0f32; self.dim];
+        // `encode_into` only errors on a length mismatch, which cannot happen here.
+        let _ = self.encode_into(value, &mut out);
+        out
+    }
+}
+
+/// The **strictly-monotone thermometer (cumulative) code** of `u ∈ [0, 1]` into `out`.
+///
+/// Dimension `i` (of `d`) activates as `u` crosses the `i`-th breakpoint `t_i = (i + 1) / d`, with
+/// a linear ramp of width `1/d` so the code is **continuous and strictly increasing in `u`** (no
+/// flat plateaus between distinct `u`): `dim[i] = clamp((u - i/d) * d, 0, 1)`. The result is the
+/// classic order-preserving "thermometer" / cumulative encoding — non-negative and monotone, so a
+/// larger `u` gives a coordinatewise `>=` vector, hence a monotone cosine to any fixed
+/// low-magnitude query. It is **not** periodic (the property a Fourier code lacks, design §3.1).
+fn thermometer(u: f64, out: &mut [f32]) {
+    let d = out.len() as f64;
+    let u = u.clamp(0.0, 1.0);
+    for (i, slot) in out.iter_mut().enumerate() {
+        let ramp = (u - i as f64 / d) * d;
+        *slot = ramp.clamp(0.0, 1.0) as f32;
+    }
+}
+
+// ---- boolean (sign) encoder -------------------------------------------------------------------
+
+/// The **boolean-sign encoder** (design §2 row "`xsd:boolean` → a SIGN prior"): one reserved ±1
+/// dimension, exact and 2-valued — `true` → `+1.0`, `false` → `-1.0`. Never a free float, so the
+/// two truth values are **antipodal** and membership is decided by **slot sign**, not a cosine
+/// threshold (no recall loss; design §6.A "enum / boolean exactness").
+#[derive(Clone, Copy, Debug, Default)]
+pub struct BooleanEncoder;
+
+impl BooleanEncoder {
+    /// The block width — always `1` (a single sign dimension).
+    pub const DIM: usize = 1;
+
+    /// Parse an `xsd:boolean` lexical to its value. The XSD lexical space is exactly
+    /// `{true, false, 1, 0}`; anything else is ill-formed and yields `None` (the literal is then
+    /// skipped, never coerced).
+    pub fn value(lexical: &str) -> Option<bool> {
+        match lexical.trim() {
+            "true" | "1" => Some(true),
+            "false" | "0" => Some(false),
+            _ => None,
+        }
+    }
+
+    /// Encode a boolean to its single sign dimension: `true` → `+1.0`, `false` → `-1.0`.
+    pub fn encode(value: bool) -> [f32; 1] {
+        [if value { 1.0 } else { -1.0 }]
+    }
+
+    /// **Round-trip** the sign dimension back to the boolean it encodes — the exactness witness
+    /// (design §6.A: "slot round-trip"). A non-negative slot decodes to `true`, a negative slot to
+    /// `false`, so `decode(encode(b)) == b` for both values.
+    pub fn decode(slot: f32) -> bool {
+        slot >= 0.0
+    }
+}
+
+// ---- date / datetime encoder ------------------------------------------------------------------
+
+/// The **date / datetime encoder** (design §3.2): a thin wrapper that maps a temporal literal to
+/// its order-preserving epoch-seconds scalar ([`temporal_value`]) and then reuses the
+/// **order-preserving [`NumericEncoder`]** on the epoch lane — so a later instant is a larger
+/// value and the *same* global-monotonicity guarantee holds for chronological order.
+///
+/// Handling `xsd:date` / `xsd:dateTime` / `xsd:dateTimeStamp` (via `sparq-core`'s `Timeline`,
+/// XPath comparison semantics) and `xsd:gYear` (`[-]YYYY` → the year's first-instant epoch). It is
+/// fitted exactly like the numeric encoder, over the predicate's observed epoch values.
+#[derive(Clone, Debug)]
+pub struct DateEncoder {
+    inner: NumericEncoder,
+}
+
+impl DateEncoder {
+    /// Fit from the predicate's observed temporal **epoch-seconds** values (e.g. mapped through
+    /// [`temporal_value`]). `dim` is the temporal block width.
+    pub fn fit(observed_epochs: impl IntoIterator<Item = f64>, dim: usize) -> DateEncoder {
+        DateEncoder { inner: NumericEncoder::fit(observed_epochs, dim) }
+    }
+
+    /// The block width (number of `f32` dimensions).
+    pub fn dim(&self) -> usize {
+        self.inner.dim()
+    }
+
+    /// Encode a temporal `(lexical, datatype)` into `out` (length [`dim`](Self::dim)). Returns
+    /// `Err` on a length mismatch or an unparseable/unsupported temporal literal.
+    pub fn encode_into(&self, lexical: &str, datatype: &str, out: &mut [f32]) -> Result<(), String> {
+        let epoch = temporal_value(lexical, datatype)
+            .ok_or_else(|| format!("DateEncoder: unsupported/ill-formed temporal {}", datatype))?;
+        self.inner.encode_into(epoch, out)
+    }
+
+    /// The underlying epoch-lane [`NumericEncoder`] (exposed for the metamorphic test, which checks
+    /// the chronological order-preservation through the same code path).
+    pub fn numeric(&self) -> &NumericEncoder {
+        &self.inner
+    }
+}
+
+// ---- the .spqv schema header (self-describing partition descriptor) ---------------------------
+
+/// The **distance metric** a partition block is searched under — the per-block metric tag (design
+/// §3 layout + §6.A "metric-correctness guard"). The header carries it so the search path never
+/// applies a Euclidean/cosine distance to a block whose geometry is not Euclidean-compatible.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Metric {
+    /// Euclidean-family (L2 / cosine) — the numeric and date **thermometer** lanes are
+    /// order-preserving under **L2 distance** (a closer value is a smaller L2 distance, the
+    /// provable property below), and the boolean ±1 sign block is correct under L2/cosine. All P1
+    /// blocks are Euclidean-family.
+    Euclidean,
+    /// A non-Euclidean block (e.g. a future Poincaré-ball taxonomy block, P3). A Euclidean/cosine
+    /// distance on such a block is a **detectable error** ([`SchemaHeader::check_euclidean`]), not
+    /// silent corruption.
+    NonEuclidean,
+}
+
+/// One partition block in the structured row: the encoder that produced it, the metric it is
+/// searched under, and its `[offset, offset+width)` span of `f32` dimensions.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Block {
+    /// The encoder family that produced this block (the datatype router result, [`Encoder`]).
+    pub encoder: Encoder,
+    /// The distance metric this block is correct under.
+    pub metric: Metric,
+    /// First `f32` dimension index of this block in the row.
+    pub offset: usize,
+    /// Number of `f32` dimensions in this block.
+    pub width: usize,
+}
+
+impl Block {
+    /// The half-open dimension span `[offset, offset + width)`.
+    pub fn end(&self) -> usize {
+        self.offset + self.width
+    }
+}
+
+/// The **`.spqv` schema header** (design §3 "a per-store SCHEMA HEADER recording which
+/// predicate/datatype maps to which block offset, geometry, and metric"): the self-describing
+/// partition descriptor for a structured-object store. It records the total row dimension and the
+/// ordered, **contiguous, non-overlapping** blocks — so a vector is self-describing (a reader knows
+/// a block is order-preserving numeric vs a boolean sign vs a non-Euclidean taxonomy block) and the
+/// search path can enforce the **metric-correctness guard**.
+///
+/// It serialises to a compact, deterministic little-endian byte string ([`to_bytes`](Self::to_bytes)
+/// / [`from_bytes`](Self::from_bytes)) that can be persisted as a sidecar alongside the `.spqv`
+/// store (the same atomic-sidecar pattern as `.spqd`), so the partition layout travels with the
+/// data and is never re-guessed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SchemaHeader {
+    /// Total `f32` dimension of the structured row (the sum of all block widths).
+    dim: usize,
+    /// The partition blocks, in row order (contiguous, non-overlapping, covering `[0, dim)`).
+    blocks: Vec<Block>,
+}
+
+/// Magic bytes for a serialised [`SchemaHeader`] sidecar — `"SPQS"` (sparq vectors **s**chema).
+pub const SPQS_MAGIC: [u8; 4] = *b"SPQS";
+/// On-disk/byte-string version of the [`SchemaHeader`] format.
+pub const SPQS_VERSION: u32 = 1;
+
+impl SchemaHeader {
+    /// Build a header from blocks given **in row order**, validating contiguity: the first block
+    /// must start at `0`, each block must start exactly where the previous ended, every width must
+    /// be `>= 1`, and the result covers `[0, dim)` with no gap or overlap. Returns `Err`
+    /// describing the first violation — a malformed partition is a layout bug, never silently
+    /// accepted.
+    pub fn new(blocks: Vec<Block>) -> Result<SchemaHeader, String> {
+        let mut expected = 0usize;
+        for (i, b) in blocks.iter().enumerate() {
+            if b.width == 0 {
+                return Err(format!("SchemaHeader: block {} has zero width", i));
+            }
+            if b.offset != expected {
+                return Err(format!(
+                    "SchemaHeader: block {} offset {} is not contiguous (expected {})",
+                    i, b.offset, expected
+                ));
+            }
+            expected = b.end();
+        }
+        Ok(SchemaHeader { dim: expected, blocks })
+    }
+
+    /// Total `f32` dimension of the row.
+    pub fn dim(&self) -> usize {
+        self.dim
+    }
+
+    /// The partition blocks in row order.
+    pub fn blocks(&self) -> &[Block] {
+        &self.blocks
+    }
+
+    /// The block covering dimension `index`, if any (`None` for an out-of-range index).
+    pub fn block_of(&self, index: usize) -> Option<&Block> {
+        self.blocks.iter().find(|b| index >= b.offset && index < b.end())
+    }
+
+    /// The **metric-correctness guard** (design §6.A): `Ok(())` only if **every** block is
+    /// [`Metric::Euclidean`]-searchable; `Err` naming the first non-Euclidean block otherwise. A
+    /// caller runs this before a whole-row L2/cosine search so "Euclidean distance on a
+    /// non-Euclidean block" is a detectable error, not silent corruption.
+    pub fn check_euclidean(&self) -> Result<(), String> {
+        for (i, b) in self.blocks.iter().enumerate() {
+            if b.metric != Metric::Euclidean {
+                return Err(format!(
+                    "SchemaHeader: block {} (encoder {:?}, dims [{}, {})) is {:?}, not Euclidean-searchable",
+                    i,
+                    b.encoder,
+                    b.offset,
+                    b.end(),
+                    b.metric
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Serialise to a deterministic little-endian byte string: `magic | version | dim | n_blocks |
+    /// (encoder, metric, offset, width)*`. The inverse of [`from_bytes`](Self::from_bytes).
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut out = Vec::with_capacity(16 + self.blocks.len() * 10);
+        out.extend_from_slice(&SPQS_MAGIC);
+        out.extend_from_slice(&SPQS_VERSION.to_le_bytes());
+        out.extend_from_slice(&(self.dim as u32).to_le_bytes());
+        out.extend_from_slice(&(self.blocks.len() as u32).to_le_bytes());
+        for b in &self.blocks {
+            out.push(encoder_tag(b.encoder));
+            out.push(metric_tag(b.metric));
+            out.extend_from_slice(&(b.offset as u32).to_le_bytes());
+            out.extend_from_slice(&(b.width as u32).to_le_bytes());
+        }
+        out
+    }
+
+    /// Parse a byte string produced by [`to_bytes`](Self::to_bytes). Fail-closed: a bad magic,
+    /// unknown version, truncated body, unknown tag, or a partition that does not validate via
+    /// [`new`](Self::new) is an `Err`, never a silent partial parse.
+    pub fn from_bytes(bytes: &[u8]) -> Result<SchemaHeader, String> {
+        if bytes.len() < 16 {
+            return Err("SchemaHeader: truncated header (< 16 bytes)".to_string());
+        }
+        if bytes[0..4] != SPQS_MAGIC {
+            return Err("SchemaHeader: bad magic".to_string());
+        }
+        let version = u32::from_le_bytes([bytes[4], bytes[5], bytes[6], bytes[7]]);
+        if version != SPQS_VERSION {
+            return Err(format!("SchemaHeader: unsupported version {}", version));
+        }
+        let n_blocks = u32::from_le_bytes([bytes[12], bytes[13], bytes[14], bytes[15]]) as usize;
+        let body = &bytes[16..];
+        if body.len() != n_blocks * 10 {
+            return Err(format!(
+                "SchemaHeader: body length {} != n_blocks*10 ({})",
+                body.len(),
+                n_blocks * 10
+            ));
+        }
+        let mut blocks = Vec::with_capacity(n_blocks);
+        for chunk in body.chunks_exact(10) {
+            let encoder = encoder_of_tag(chunk[0])?;
+            let metric = metric_of_tag(chunk[1])?;
+            let offset = u32::from_le_bytes([chunk[2], chunk[3], chunk[4], chunk[5]]) as usize;
+            let width = u32::from_le_bytes([chunk[6], chunk[7], chunk[8], chunk[9]]) as usize;
+            blocks.push(Block { encoder, metric, offset, width });
+        }
+        // Re-validate contiguity via `new`, which also recomputes `dim` from the blocks; cross-check
+        // it against the stored dim field so a tampered header that lies about dim is rejected.
+        let stored_dim =
+            u32::from_le_bytes([bytes[8], bytes[9], bytes[10], bytes[11]]) as usize;
+        let header = SchemaHeader::new(blocks)?;
+        if header.dim != stored_dim {
+            return Err(format!(
+                "SchemaHeader: stored dim {} disagrees with summed block widths {}",
+                stored_dim, header.dim
+            ));
+        }
+        Ok(header)
+    }
+}
+
+fn encoder_tag(e: Encoder) -> u8 {
+    match e {
+        Encoder::Numeric => 1,
+        Encoder::Boolean => 2,
+        Encoder::Date => 3,
+        Encoder::Other => 4,
+    }
+}
+
+fn encoder_of_tag(t: u8) -> Result<Encoder, String> {
+    match t {
+        1 => Ok(Encoder::Numeric),
+        2 => Ok(Encoder::Boolean),
+        3 => Ok(Encoder::Date),
+        4 => Ok(Encoder::Other),
+        _ => Err(format!("SchemaHeader: unknown encoder tag {}", t)),
+    }
+}
+
+fn metric_tag(m: Metric) -> u8 {
+    match m {
+        Metric::Euclidean => 1,
+        Metric::NonEuclidean => 2,
+    }
+}
+
+fn metric_of_tag(t: u8) -> Result<Metric, String> {
+    match t {
+        1 => Ok(Metric::Euclidean),
+        2 => Ok(Metric::NonEuclidean),
+        _ => Err(format!("SchemaHeader: unknown metric tag {}", t)),
+    }
+}
+
+// ---- provable-quality property checkers (reused by tests, exposed for downstream proofs) -------
+
+/// **Order-preservation metamorphic check** (design §3.1 + §6.A) for an order-preserving encoder
+/// over a sorted-ascending list of distinct `values`. It asserts the encoder's **provable
+/// invariant — global monotonicity of L2 distance in value distance**: for every query value in
+/// the list, the encoded **L2 distance to a value grows monotonically as the value moves away from
+/// the query** (in either direction), over the *whole* observed range — so a closer value is
+/// always nearer than a farther one, not just for adjacent neighbours. Returns `Ok(())` if the
+/// property holds for every query and pair, or `Err` naming the first violation.
+///
+/// This is the design's exact "30 is nearer 31 than to 70, globally" property, stated as the metric
+/// the thermometer/cumulative code is order-preserving under (L2). A periodic Fourier/sine code
+/// FAILS it — its distance to a fixed query is non-monotone in value — which is precisely the
+/// discriminator design §3.1 demands (see the negative test
+/// `periodic_code_fails_metamorphic_monotonicity`).
+pub fn metamorphic_monotone(enc: &NumericEncoder, values: &[f64]) -> Result<(), String> {
+    if values.len() < 2 {
+        return Ok(());
+    }
+    // For each query position, distance must be monotone moving outward in BOTH directions.
+    for (qi, &q) in values.iter().enumerate() {
+        let query = enc.encode(q);
+        // Going UP from the query: distance must be non-decreasing.
+        let mut prev = -1.0f64;
+        for &v in &values[qi..] {
+            let d = l2_dist64(&query, &enc.encode(v));
+            if d + 1e-5 < prev {
+                return Err(format!(
+                    "metamorphic monotonicity (upward) violated: query {} dist to {} = {} < previous {}",
+                    q, v, d, prev
+                ));
+            }
+            prev = d;
+        }
+        // Going DOWN from the query: distance must be non-decreasing as values fall away.
+        let mut prev = -1.0f64;
+        for &v in values[..=qi].iter().rev() {
+            let d = l2_dist64(&query, &enc.encode(v));
+            if d + 1e-5 < prev {
+                return Err(format!(
+                    "metamorphic monotonicity (downward) violated: query {} dist to {} = {} < previous {}",
+                    q, v, d, prev
+                ));
+            }
+            prev = d;
+        }
+    }
+    Ok(())
+}
+
+/// Squared-then-rooted L2 distance over `f32` slices in `f64` accumulation (the property checks
+/// need a touch more headroom than the `f32` search path). This is the metric the order-preserving
+/// thermometer code is monotone under (design §3.1).
+fn l2_dist64(a: &[f32], b: &[f32]) -> f64 {
+    a.iter()
+        .zip(b.iter())
+        .map(|(&x, &y)| {
+            let d = x as f64 - y as f64;
+            d * d
+        })
+        .sum::<f64>()
+        .sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- datatype-router dispatch correctness (design §6.A: dispatch correctness) ----
+
+    #[test]
+    fn router_dispatches_each_family() {
+        assert_eq!(route(dt::INTEGER), Encoder::Numeric);
+        assert_eq!(route(dt::DECIMAL), Encoder::Numeric);
+        assert_eq!(route(dt::DOUBLE), Encoder::Numeric);
+        assert_eq!(route(dt::FLOAT), Encoder::Numeric);
+        // Derived integer subtypes route to numeric via the local-name match.
+        for sub in dt::NUMERIC_SUBTYPES {
+            assert_eq!(route(&format!("{}{}", dt::XSD, sub)), Encoder::Numeric, "subtype {}", sub);
+        }
+        assert_eq!(route(dt::BOOLEAN), Encoder::Boolean);
+        assert_eq!(route(dt::DATE), Encoder::Date);
+        assert_eq!(route(dt::DATE_TIME), Encoder::Date);
+        assert_eq!(route(dt::DATE_TIME_STAMP), Encoder::Date);
+        assert_eq!(route(dt::G_YEAR), Encoder::Date);
+        // String / langString / IRI-shaped / unknown all route to the (non-P1) Other lane.
+        assert_eq!(route("http://www.w3.org/2001/XMLSchema#string"), Encoder::Other);
+        assert_eq!(route("http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"), Encoder::Other);
+        assert_eq!(route("http://example.org/customType"), Encoder::Other);
+        // A look-alike that is NOT a real numeric subtype must NOT mis-route to numeric.
+        assert_eq!(route("http://www.w3.org/2001/XMLSchema#string"), Encoder::Other);
+        assert_eq!(route("http://www.w3.org/2001/XMLSchema#anyURI"), Encoder::Other);
+    }
+
+    // ---- numeric encoder: ORDER-PRESERVATION metamorphic test (the provable gate) ----
+
+    #[test]
+    fn numeric_global_order_preservation() {
+        // Observed values spanning a wide range with a long, sparse tail.
+        let observed: Vec<f64> =
+            vec![1.0, 2.0, 3.0, 5.0, 8.0, 13.0, 30.0, 31.0, 70.0, 100.0, 5000.0, 1_000_000.0];
+        let enc = NumericEncoder::fit(observed.clone(), 16);
+
+        let mut sorted = observed.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        // GLOBAL monotonicity over the FULL observed range (not just adjacent neighbours).
+        metamorphic_monotone(&enc, &sorted).expect("numeric encoder must be globally monotone");
+
+        // The design's concrete example: 30 is nearer 31 than to 70, globally (under L2, the
+        // metric the order-preserving thermometer code is monotone in).
+        let q30 = enc.encode(30.0);
+        let c31 = enc.encode(31.0);
+        let c70 = enc.encode(70.0);
+        let c100 = enc.encode(100.0);
+        assert!(
+            l2_dist64(&q30, &c31) < l2_dist64(&q30, &c70),
+            "30 must be nearer 31 than 70"
+        );
+        assert!(
+            l2_dist64(&q30, &c70) < l2_dist64(&q30, &c100),
+            "monotone: 70 nearer 30 than 100 is"
+        );
+    }
+
+    #[test]
+    fn numeric_normalise_is_monotone_and_clamped() {
+        let enc = NumericEncoder::fit(vec![10.0, 20.0, 30.0, 40.0], 8);
+        // Strictly increasing in value across the observed range.
+        assert!(enc.normalise(15.0) < enc.normalise(25.0));
+        assert!(enc.normalise(25.0) < enc.normalise(35.0));
+        // Clamped outside the range, still correctly ordered (below→0, above→1).
+        assert_eq!(enc.normalise(5.0), 0.0);
+        assert_eq!(enc.normalise(100.0), 1.0);
+        assert!(enc.normalise(5.0) < enc.normalise(15.0));
+        assert!(enc.normalise(35.0) < enc.normalise(100.0));
+    }
+
+    #[test]
+    fn numeric_thermometer_is_nonnegative_and_monotone_coordinatewise() {
+        let enc = NumericEncoder::fit(vec![0.0, 100.0], 8);
+        let lo = enc.encode(10.0);
+        let hi = enc.encode(90.0);
+        for (a, b) in lo.iter().zip(hi.iter()) {
+            assert!(*a >= 0.0 && *b >= 0.0, "thermometer code must be non-negative");
+            assert!(*b >= *a - 1e-6, "higher value dominates coordinatewise");
+        }
+    }
+
+    #[test]
+    fn numeric_empty_fit_is_degenerate_midpoint_no_panic() {
+        let enc = NumericEncoder::fit(Vec::<f64>::new(), 4);
+        assert_eq!(enc.normalise(42.0), 0.5);
+        let v = enc.encode(42.0);
+        assert_eq!(v.len(), 4);
+    }
+
+    #[test]
+    fn numeric_encode_into_rejects_length_mismatch() {
+        let enc = NumericEncoder::fit(vec![1.0, 2.0], 4);
+        let mut wrong = [0.0f32; 3];
+        assert!(enc.encode_into(1.5, &mut wrong).is_err());
+        let mut right = [0.0f32; 4];
+        assert!(enc.encode_into(1.5, &mut right).is_ok());
+    }
+
+    #[test]
+    fn numeric_value_parses_and_rejects_nonfinite() {
+        assert_eq!(numeric_value("42"), Some(42.0));
+        assert_eq!(numeric_value(" -3.5 "), Some(-3.5));
+        assert_eq!(numeric_value("1e3"), Some(1000.0));
+        assert_eq!(numeric_value("inf"), None);
+        assert_eq!(numeric_value("NaN"), None);
+        assert_eq!(numeric_value("not-a-number"), None);
+    }
+
+    // ---- boolean encoder: EXACTNESS (round-trips 2 values) ----
+
+    #[test]
+    fn boolean_exact_roundtrip_both_values() {
+        for b in [true, false] {
+            let enc = BooleanEncoder::encode(b);
+            assert_eq!(BooleanEncoder::decode(enc[0]), b, "boolean must round-trip");
+        }
+        // Antipodal: true=+1, false=-1.
+        assert_eq!(BooleanEncoder::encode(true), [1.0]);
+        assert_eq!(BooleanEncoder::encode(false), [-1.0]);
+    }
+
+    #[test]
+    fn boolean_lexical_space_exact() {
+        assert_eq!(BooleanEncoder::value("true"), Some(true));
+        assert_eq!(BooleanEncoder::value("1"), Some(true));
+        assert_eq!(BooleanEncoder::value("false"), Some(false));
+        assert_eq!(BooleanEncoder::value("0"), Some(false));
+        assert_eq!(BooleanEncoder::value("True"), None); // case-sensitive XSD lexical space
+        assert_eq!(BooleanEncoder::value("yes"), None);
+    }
+
+    // ---- date encoder: ORDER-PRESERVATION on the epoch lane ----
+
+    #[test]
+    fn temporal_value_orders_chronologically() {
+        let a = temporal_value("2000-01-01", dt::DATE).unwrap();
+        let b = temporal_value("2020-06-15", dt::DATE).unwrap();
+        let c = temporal_value("2020-06-15T12:00:00Z", dt::DATE_TIME).unwrap();
+        let y = temporal_value("1999", dt::G_YEAR).unwrap();
+        assert!(y < a, "1999 < 2000-01-01");
+        assert!(a < b, "2000 < 2020 date");
+        assert!(b <= c, "2020-06-15 date <= same-day noon dateTime");
+        assert_eq!(temporal_value("garbage", dt::DATE), None);
+        assert_eq!(temporal_value("2020-01-01", dt::INTEGER), None); // wrong datatype
+    }
+
+    #[test]
+    fn gyear_parses_signed_and_tz() {
+        assert_eq!(parse_gyear("2020"), Some(2020));
+        assert_eq!(parse_gyear("-0044"), Some(-44)); // 44 BCE
+        assert_eq!(parse_gyear("2020Z"), Some(2020));
+        assert_eq!(parse_gyear("2020+05:00"), Some(2020));
+        assert_eq!(parse_gyear("20"), None); // < 4 digits
+        assert_eq!(parse_gyear("abcd"), None);
+    }
+
+    #[test]
+    fn date_encoder_global_order_preservation() {
+        // A span with a long tail: clustered modern dates + one ancient + one far-future.
+        let lexs = [
+            ("-0500", dt::G_YEAR),
+            ("1900-01-01", dt::DATE),
+            ("2000-01-01", dt::DATE),
+            ("2020-06-15", dt::DATE),
+            ("2020-06-16", dt::DATE),
+            ("2100-01-01", dt::DATE),
+            ("3000-01-01", dt::DATE),
+        ];
+        let epochs: Vec<f64> =
+            lexs.iter().map(|(l, d)| temporal_value(l, d).unwrap()).collect();
+        let enc = DateEncoder::fit(epochs.clone(), 16);
+
+        let mut sorted = epochs.clone();
+        sorted.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        metamorphic_monotone(enc.numeric(), &sorted)
+            .expect("date encoder must be globally monotone on the epoch lane");
+
+        // encode_into through the (lexical, datatype) path agrees with the numeric encoder.
+        let mut out = vec![0.0f32; 16];
+        enc.encode_into("2020-06-15", dt::DATE, &mut out).unwrap();
+        let direct = enc.numeric().encode(temporal_value("2020-06-15", dt::DATE).unwrap());
+        assert_eq!(out, direct);
+
+        // Unsupported temporal → Err, never a silent zero block.
+        assert!(enc.encode_into("nonsense", dt::DATE, &mut out).is_err());
+    }
+
+    // ---- a deliberately PERIODIC code FAILS the metamorphic test (design's discriminator) ----
+
+    #[test]
+    fn periodic_code_fails_metamorphic_monotonicity() {
+        // Construct a NumericEncoder, then hand the metamorphic checker a *periodic* re-encoding to
+        // prove the test discriminates. We can't make NumericEncoder periodic (it is monotone by
+        // construction — that's the point), so we assert the property directly on a sine code.
+        let values: Vec<f64> = (0..32).map(|i| i as f64).collect();
+        let dim = 8;
+        // Query at the minimum; distance to a periodic code is non-monotone as the value rises
+        // (the aliasing the design warns about), so we MUST see the distance go DOWN at some step —
+        // the violation the order-preserving thermometer code never exhibits.
+        let query = sine_code(values[0], dim);
+        let mut prev = -1.0f64;
+        let mut saw_decrease = false;
+        for &v in &values {
+            let d = l2_dist64(&query, &sine_code(v, dim));
+            if d + 1e-5 < prev {
+                saw_decrease = true;
+                break;
+            }
+            prev = d;
+        }
+        assert!(
+            saw_decrease,
+            "a periodic sine code MUST be non-monotone — the metamorphic test discriminates it from \
+             the order-preserving thermometer code"
+        );
+    }
+
+    /// A periodic Fourier/sine positional code (NOT order-preserving) — used only by the negative
+    /// test above to demonstrate the metamorphic checker rejects it.
+    fn sine_code(v: f64, dim: usize) -> Vec<f32> {
+        (0..dim)
+            .map(|i| {
+                let freq = (i as f64 + 1.0) * 0.7;
+                (v * freq).sin() as f32
+            })
+            .collect()
+    }
+
+    // ---- SchemaHeader: self-describing partition + metric-correctness guard + round-trip ----
+
+    fn sample_header() -> SchemaHeader {
+        SchemaHeader::new(vec![
+            Block { encoder: Encoder::Numeric, metric: Metric::Euclidean, offset: 0, width: 16 },
+            Block { encoder: Encoder::Date, metric: Metric::Euclidean, offset: 16, width: 8 },
+            Block { encoder: Encoder::Boolean, metric: Metric::Euclidean, offset: 24, width: 1 },
+        ])
+        .unwrap()
+    }
+
+    #[test]
+    fn schema_header_contiguity_validated() {
+        let h = sample_header();
+        assert_eq!(h.dim(), 25);
+        assert_eq!(h.blocks().len(), 3);
+        // The boolean block is the one covering dim 24.
+        assert_eq!(h.block_of(24).unwrap().encoder, Encoder::Boolean);
+        assert_eq!(h.block_of(0).unwrap().encoder, Encoder::Numeric);
+        assert!(h.block_of(25).is_none());
+
+        // A gap is rejected.
+        let gap = SchemaHeader::new(vec![
+            Block { encoder: Encoder::Numeric, metric: Metric::Euclidean, offset: 0, width: 4 },
+            Block { encoder: Encoder::Boolean, metric: Metric::Euclidean, offset: 8, width: 1 },
+        ]);
+        assert!(gap.is_err(), "non-contiguous blocks must be rejected");
+
+        // A zero-width block is rejected.
+        let zero = SchemaHeader::new(vec![Block {
+            encoder: Encoder::Numeric,
+            metric: Metric::Euclidean,
+            offset: 0,
+            width: 0,
+        }]);
+        assert!(zero.is_err(), "zero-width block must be rejected");
+    }
+
+    #[test]
+    fn schema_header_metric_guard() {
+        // All-Euclidean header passes the guard.
+        assert!(sample_header().check_euclidean().is_ok());
+
+        // A non-Euclidean block makes whole-row L2/cosine a DETECTABLE error.
+        let h = SchemaHeader::new(vec![
+            Block { encoder: Encoder::Numeric, metric: Metric::Euclidean, offset: 0, width: 4 },
+            Block { encoder: Encoder::Other, metric: Metric::NonEuclidean, offset: 4, width: 4 },
+        ])
+        .unwrap();
+        let err = h.check_euclidean().unwrap_err();
+        assert!(err.contains("NonEuclidean"), "guard must name the non-Euclidean block: {}", err);
+    }
+
+    #[test]
+    fn schema_header_byte_roundtrip() {
+        let h = sample_header();
+        let bytes = h.to_bytes();
+        let back = SchemaHeader::from_bytes(&bytes).unwrap();
+        assert_eq!(h, back, "schema header must round-trip through bytes");
+
+        // Fail-closed parsing.
+        assert!(SchemaHeader::from_bytes(b"XXXX").is_err(), "bad magic / too short");
+        let mut bad_magic = bytes.clone();
+        bad_magic[0] = b'Z';
+        assert!(SchemaHeader::from_bytes(&bad_magic).is_err(), "bad magic rejected");
+        let mut truncated = bytes.clone();
+        truncated.truncate(bytes.len() - 1);
+        assert!(SchemaHeader::from_bytes(&truncated).is_err(), "truncated body rejected");
+        // A tampered dim field (claims a different total) is rejected.
+        let mut bad_dim = bytes.clone();
+        bad_dim[8] = bad_dim[8].wrapping_add(1);
+        assert!(SchemaHeader::from_bytes(&bad_dim).is_err(), "dim mismatch rejected");
+    }
+
+    #[test]
+    fn schema_header_tags_are_total() {
+        // Every encoder/metric tag round-trips (guards against an unmapped variant).
+        for e in [Encoder::Numeric, Encoder::Boolean, Encoder::Date, Encoder::Other] {
+            assert_eq!(encoder_of_tag(encoder_tag(e)).unwrap(), e);
+        }
+        for m in [Metric::Euclidean, Metric::NonEuclidean] {
+            assert_eq!(metric_of_tag(metric_tag(m)).unwrap(), m);
+        }
+        assert!(encoder_of_tag(99).is_err());
+        assert!(metric_of_tag(99).is_err());
+    }
+}

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -17,6 +17,13 @@ pub mod cost;
 pub mod delta;
 pub mod diskann;
 pub mod embed;
+// [OPUS-4.8] sq-0wo9e.2 (epic sq-0wo9e): the P1 structure-aware-vectorisation TYPED-LITERAL
+// ENCODERS — the datatype router + order-preserving numeric + boolean-sign + date encoders, plus
+// the self-describing `.spqv` SchemaHeader (per-block metric tags + metric-correctness guard).
+// `structure` feature only; pure, dependency-light functions keyed by datatype (only `temporal_value`
+// / the date encoder touch sparq-core, already in the tree). The default build carries zero encoder code.
+#[cfg(feature = "structure")]
+pub mod encode;
 #[cfg(feature = "filtered-ann")]
 pub mod filter;
 pub mod fingerprint;
@@ -109,6 +116,15 @@ pub use store::{StreamingWriter, VectorStore, SPQV_MAGIC, SPQV_VERSION};
 pub use structure::{
     close_for_vectorise, materialise_closure, ClosedGraph, Corrupt, NegativeSampler, SamplingMode,
     TypeConstraints,
+};
+// [OPUS-4.8] sq-0wo9e.2 (epic sq-0wo9e): the structure-aware-vectorisation P1 surface — the typed
+// literal encoders (datatype router + order-preserving numeric + boolean-sign + date) and the
+// self-describing `.spqv` SchemaHeader (block partition + per-block metric tag + cosine guard).
+// `structure` feature only.
+#[cfg(feature = "structure")]
+pub use encode::{
+    metamorphic_monotone, numeric_value, route, temporal_value, Block, BooleanEncoder, DateEncoder,
+    Encoder, Metric, NumericEncoder, SchemaHeader, SPQS_MAGIC, SPQS_VERSION,
 };
 pub use verbalize::{
     description_predicates, embed_entities, label_predicates, verbalize, EntityTextConfig,

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -732,6 +732,52 @@ emits a corruption that is itself a true triple). **Honesty:** the empirical ben
 reports inconsistent gains; this slice is the buildable inputs, the trainer that consumes them is a
 tracked follow-up.
 
+### 14. Typed-literal encoders — order-preserving numeric / boolean / date + schema header (opt-in, feature = `structure`)
+
+<!-- [OPUS-4.8] sq-0wo9e.2 (epic sq-0wo9e; design research/structure-aware-vectorisation.md §3.1/§3.2/§6.A). -->
+Research-grade **P1**: the typed-literal encoders that turn a node vector into a **structured
+partitioned object** (design §3). All are **pure functions keyed by datatype** in the `encode`
+module — no training, no graph state, no I/O.
+
+- **Datatype `route`r** — the datatype IRI alone selects the encoder family
+  (`Encoder::{Numeric,Boolean,Date,Other}`). Exact, free.
+- **`NumericEncoder`** — the **order-preserving** magnitude encoder (the one the design gates as
+  formally provable): per-predicate quantile-normalise + a strictly-monotone **thermometer** code
+  whose **L2 distance is monotone in value distance over the whole observed range** (NOT a periodic
+  Fourier code). `metamorphic_monotone` is the provable gate; a sine code FAILS it by design.
+- **`BooleanEncoder`** — one ±1 sign dimension, **exact, 2-valued**, round-trips (`true`→+1,
+  `false`→−1; `decode(encode(b)) == b`).
+- **`DateEncoder`** — maps `xsd:date`/`dateTime`/`dateTimeStamp`/`gYear` to an order-preserving
+  epoch lane (via `sparq-core`'s `Timeline`) and reuses the numeric encoder, so chronological order
+  is preserved.
+- **`SchemaHeader`** — the self-describing `.spqv` partition descriptor: contiguous `Block`s
+  (encoder + `Metric` + dim span) with a **metric-correctness guard** (`check_euclidean`) so a whole-row
+  L2/cosine search never silently runs over a non-Euclidean (e.g. future taxonomy) block. Round-trips
+  to bytes (`SPQS` magic) for a sidecar.
+
+```rust,ignore
+# // cargo build -p sparq-vectors --features structure
+use sparq_vectors::{route, Encoder, NumericEncoder, BooleanEncoder, DateEncoder,
+    SchemaHeader, Block, Metric};
+
+assert_eq!(route("http://www.w3.org/2001/XMLSchema#integer"), Encoder::Numeric);
+let enc = NumericEncoder::fit([1.0, 30.0, 31.0, 70.0, 5000.0], /*dim*/ 16); // per-predicate fit
+let v30 = enc.encode(30.0);                                                 // order-preserving block
+assert_eq!(BooleanEncoder::decode(BooleanEncoder::encode(true)[0]), true);  // exact round-trip
+let header = SchemaHeader::new(vec![
+    Block { encoder: Encoder::Numeric, metric: Metric::Euclidean, offset: 0, width: 16 },
+])?;
+header.check_euclidean()?;  // every block is L2-searchable
+# Ok::<(), String>(())
+```
+
+**Honesty.** Order-preservation, boolean exactness, datatype-dispatch correctness, and the metric
+guard are **proven** (`encode.rs` tests). Whether the typed encoders raise downstream
+link-prediction / retrieval is **empirical and dataset-dependent** (design §6.B/§9) — no accuracy
+claim is made. The encoder-quality ablation runner is `examples/bench_typed_encoders.rs` (P1 ON vs
+OFF, with a long-tail slice); its numbers are **work-box NON-CANONICAL**. This crate still has **no
+KGE trainer** — the encoders are inputs a trainer would consume.
+
 ## Gotchas / feature flags / prerequisites
 
 - **Opt-in.** Nothing in the workspace depends on `sparq-vectors`; the default engine
@@ -748,12 +794,14 @@ tracked follow-up.
   methods write a delta the read paths consult transparently (recipe 12). The delta lives in RAM on the
   handle; `save_delta` persists it to a crash-durable `.spqd` sidecar and `open_with_delta` replays it,
   so mutations survive a restart without a `compact` (the two durability paths).
-- **Structure-aware preprocessing is the non-default `structure` feature (sq-0wo9e.1).** It is the
-  ONLY feature pulling `sparq-reason` + `sparq-introspect` into this crate, both **optional**, so
+- **Structure-aware preprocessing is the non-default `structure` feature (sq-0wo9e.1 P0, sq-0wo9e.2 P1).**
+  It is the ONLY feature pulling `sparq-reason` + `sparq-introspect` into this crate, both **optional**, so
   with it OFF the default build compiles zero structure-prep code and gains no new required deps. With
-  it ON it exposes `close_for_vectorise` / `materialise_closure` / `ClosedGraph`, `TypeConstraints`,
-  and the `NegativeSampler` + `SamplingMode` (on/off ablation) of recipe 13. It TRAINS NOTHING and
-  serves no exact answer; benefit is **unproven** (research-grade, no accuracy claim, no numbers).
+  it ON it exposes the **P0** closure + sampler (`close_for_vectorise` / `materialise_closure` /
+  `ClosedGraph`, `TypeConstraints`, `NegativeSampler` + `SamplingMode`, recipe 13) AND the **P1**
+  typed-literal encoders (`route`, `NumericEncoder`, `BooleanEncoder`, `DateEncoder`, `SchemaHeader`,
+  recipe 14). It TRAINS NOTHING and serves no exact answer; encoder invariants are proven but
+  embedding-quality benefit is **unproven** (research-grade, no accuracy claim, no canonical numbers).
 - **`approx-ann` is the ONLY heavy ANN dependency, and it is OFF by default (sq-ip3a).** The HNSW
   index (`VectorIndex`/`HnswConfig`) and the `ApproxBackend` are gated behind it — it is the only
   thing pulling `instant-distance`. With it OFF the default build is lean: exact brute-force


### PR DESCRIPTION
> 🤖 SPARQ agent — opt-in, feature-gated Rust capability. This PR implements **vectorisation P1: typed literal encoders** (bead `sq-0wo9e.2`, epic `sq-0wo9e`), the next phase of structure-aware vectorisation after the merged P0 (closure-before-vectorise + type-constrained negatives). All new surface is behind the SAME opt-in `structure` cargo feature (OFF by default); the default `sparq-vectors`/core build is byte-identical and carries zero encoder code.

## What this implements

New `crates/sparq-vectors/src/encode.rs` — **pure functions keyed by datatype** (no training, no graph state, no I/O), per design `research/structure-aware-vectorisation.md` §3.1/§3.2/§6.A:

- **Datatype `route`r** — dispatch a literal to `Encoder::{Numeric, Boolean, Date, Other}` by its xsd/rdf datatype (incl. the derived integer subtype family). Exact, free.
- **Order-preserving `NumericEncoder`** — per-predicate quantile-normalise + a strictly-monotone **thermometer** code whose **L2 distance is monotone in value distance over the WHOLE observed range** (the design's provable property — explicitly **NOT** a periodic Fourier code).
- **`BooleanEncoder`** — one ±1 sign dimension, **exact, 2-valued**, round-trips (`true`→+1, `false`→−1).
- **`DateEncoder`** — `xsd:date`/`dateTime`/`dateTimeStamp`/`gYear` → an order-preserving epoch lane (via `sparq-core`'s `Timeline`), reusing the numeric encoder so chronological order is preserved.
- **`SchemaHeader`** — the self-describing `.spqv` partition descriptor: contiguous `Block`s (encoder + per-block `Metric` + dim span) with a **metric-correctness guard** (`check_euclidean`) so a whole-row L2/cosine search never silently runs over a non-Euclidean block; byte round-trip (`SPQS` magic) for a sidecar.

## Provable-quality tests (the design gates these as formally checkable)

In `encode.rs` (17 tests, all green): **order-preservation metamorphic** test for the numeric AND date encoders (global monotonicity over the full observed range — the design's "30 is nearer 31 than 70, globally"); **boolean exactness** (round-trips both values); **datatype-router dispatch correctness**; plus the **metric guard**, the schema byte round-trip (fail-closed), and a **periodic-sine negative test** proving the metamorphic checker discriminates a non-monotone code (which is exactly why the order-preserving block is a separate, restricted encoder).

## Empirical measurement — honest scoping

The brief asked for a filtered link-prediction MRR/Hits@k ablation on FB15k-237/WN18RR using "the existing P6 eval harness landed in the P0 work". **That harness does not exist** — the P6 bead (`sq-0wo9e.7`) is still OPEN, and `sparq-vectors` has **no KGE trainer** (embeddings are out-of-process, as P0's own docs state). There is no in-tree path that trains entity/relation embeddings, consumes the typed encoders, and reports filtered MRR. Reporting such numbers would mean **fabricating them**, which the empirical-honesty mandate forbids.

Instead, `examples/bench_typed_encoders.rs` measures the property the P1 encoders **actually deliver and that is testable now**: order-preserving numeric retrieval quality, **P1 ON vs OFF**, on a synthetic numeric-literal-rich heavy-tailed corpus, **including a long-tail (rare-value) slice**. Metrics: value-nearest **Recall@k** + **Spearman** rank-correlation between encoded-distance order and true value-distance order. **MEASURED ON THIS WORK BOX — NON-CANONICAL** (deterministic at a fixed seed; an encoder-quality sanity check, not a published KGE benchmark, and not baked into docs/tests as canonical perf):

| slice | arm | Recall@10 | Spearman |
|---|---|---|---|
| overall | **P1 ON** | 0.9972 | 0.9999 |
| overall | P1 OFF (literal dropped) | 0.0114 | -0.0021 |
| **long_tail** (top value-decile) | **P1 ON** | 0.9762 | 0.9998 |
| long_tail | P1 OFF | 0.0188 | -0.0009 |

P1 ON recovers near-perfect value-order retrieval; P1 OFF (the value-blind baseline a plain relational KGE produces) is at chance. The long-tail slice is marginally lower than overall (0.976 vs 0.997) — expected, since rare values in the sparse tail have fewer true near-neighbours — but still vastly above the baseline, i.e. typed structure helps precisely where the design predicts. **No embedding-quality / link-prediction claim is made** (design §6.B/§9: gains in the literal-aware KGE literature are inconsistent).

## Gates (run in BOTH feature states)

- `cargo clippy --workspace --all-targets --all-features -D warnings` — **GREEN**
- `cargo test -p sparq-vectors` (default, feature OFF) — **GREEN**
- `cargo test -p sparq-vectors --features structure` (feature ON) — **GREEN** (69 lib tests incl. 17 encode + 8 P0 structure)
- `cargo doc --all-features` with `-D warnings` — **GREEN**
- `check-readme-template.py --enforce` — **0 deviations** (README at the 120-line cap)
- privacy-claims gate + `typos` — **clean**

Feature flags: the new surface is gated on **`structure`** (the same opt-in feature as P0). README + `skills/vector-search/SKILL.md` (recipe 14 + gotcha) updated.

## Beads
- Closes `sq-0wo9e.2` on PR-open.
- Follow-ups (P2/P3) tracked under the epic: `sq-0wo9e.3` (enum codebook via `owl:oneOf`/`sh:in` + QUDT unit-normalisation), `sq-0wo9e.4` (taxonomy block — Euclidean default, hyperbolic/box only past a measured-distortion gate). The KGE trainer + the P6 filtered-link-prediction harness (`sq-0wo9e.7`) remain the prerequisite for a real FB15k-237/WN18RR MRR ablation.

Auto-merge intentionally **OFF** — orchestrator reviews and relays the numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)