### PR TITLE
feat(site): scan-first surface-content deep-page template + rebuild the 5 live-tier pages (sq-vw3ax.4) [OPUS-4.8]

### DIFF
--- a/site/src/app/surface/data-formats/page.tsx
+++ b/site/src/app/surface/data-formats/page.tsx
@@ -10,100 +10,59 @@ export const metadata: Metadata = {
     "Parse and load RDF into a sparq Graph — Turtle, N-Triples, N-Quads, TriG, JSON-LD, compressed dumps, and the binary HDT archive format.",
 };
 
+// [OPUS-4.8] sq-vw3ax.4 — scan-first deep page: statement + the format-picker demo
+// first, then a tight capabilities list, a one-sentence "how this runs", caveats
+// closed.
 export default function DataFormatsSurfacePage() {
   return (
     <SurfaceContent
       icon={Database}
       title="Data formats"
-      statement="Getting RDF into a sparq Graph: the four text formats, compressed ingest, and HDT."
+      statement="Getting RDF into a sparq Graph — the four text formats plus JSON-LD parse live in your tab; compressed ingest and HDT load natively."
       tier="live"
-      intro={
-        <>
-          <p>
-            sparq parses the four standard RDF text formats —{" "}
-            <strong className="text-foreground">Turtle, N-Triples, N-Quads</strong>{" "}
-            and <strong className="text-foreground">TriG</strong> — in{" "}
-            <code className="font-mono text-foreground">sparq-core</code>, with
-            in-memory, streaming, parallel and external-memory loaders for large
-            dumps. The binary{" "}
-            <strong className="text-foreground">HDT</strong> archive format (and its
-            content-sniffed <code className="font-mono">.hdt.gz</code> /{" "}
-            <code className="font-mono">.hdt.zst</code> /{" "}
-            <code className="font-mono">.hdt.bz2</code> variants) lives in the
-            opt-in <code className="font-mono text-foreground">sparq-hdt</code>{" "}
-            crate.
-          </p>
-          <p>
-            <strong className="text-foreground">JSON-LD 1.1</strong> (JSON for
-            linked data) parses through the opt-in{" "}
-            <code className="font-mono text-foreground">jsonld</code> feature
-            (oxjsonld) — which the site&apos;s wasm bundle enables, so the picker
-            below reads it too.
-          </p>
-          <p>
-            These crates parse RDF <em>in</em>; to write RDF <em>out</em>, the
-            engine ships a writer matrix (Turtle / TriG / N-Quads / JSON-LD 1.1)
-            behind its <code className="font-mono">serialize-rdf</code> feature,
-            with the N-Triples writer always on.
-          </p>
-        </>
-      }
       capabilities={[
         {
-          title: "Turtle / N-Triples / N-Quads / TriG",
+          term: "Turtle / N-Triples / N-Quads / TriG",
           body: "All four text formats, with named-graph preservation for the quad formats.",
         },
         {
-          title: "JSON-LD 1.1",
+          term: "JSON-LD 1.1",
           body: "JSON for linked data — parsed via the opt-in jsonld feature (oxjsonld), which the site bundle enables.",
         },
         {
-          title: "Compressed ingest",
-          body: "gzip / zstd / bzip2 RDF dumps decode-and-load natively (fused decompress + parallel parse); gzip also decodes live in the browser.",
+          term: "Compressed ingest",
+          body: "gzip / zstd / bzip2 dumps decode-and-load natively (fused decompress + parallel parse); gzip also decodes live in the browser.",
         },
         {
-          title: "Streaming & parallel loaders",
-          body: "Chunk-parallel parsing for large N-Triples dumps; external-memory ingest (native).",
+          term: "HDT archives",
+          body: "Load .hdt and content-sniffed .hdt.gz/.zst/.bz2 via the opt-in sparq-hdt crate (native).",
         },
         {
-          title: "HDT archives",
-          body: "Load .hdt and content-sniffed .hdt.gz/.zst/.bz2 via the opt-in sparq-hdt crate.",
-        },
-        {
-          title: "Copy-on-write snapshots",
-          body: "Cheap immutable Graph snapshots for concurrent serving.",
-        },
-        {
-          title: "RDF writer matrix",
-          body: "Serialize back out to Turtle / TriG / N-Quads / JSON-LD (engine serialize-rdf feature).",
+          term: "RDF writer matrix",
+          body: "Serialize back out to Turtle / TriG / N-Quads / JSON-LD (engine serialize-rdf feature; the N-Triples writer is always on).",
         },
       ]}
       runsNote={
         <>
-          <p>
-            <strong className="text-foreground">Live in your tab</strong> for the
-            four text formats and JSON-LD — the demo above runs the same{" "}
-            <code className="font-mono">Store.load</code> /{" "}
-            <code className="font-mono">loadDataset</code> loaders that ship in{" "}
-            <code className="font-mono">@jeswr/sparq</code>, compiled to wasm. The
-            gzip-ingest panel decodes with the browser&apos;s native{" "}
-            <code className="font-mono">DecompressionStream</code> before parsing —
-            no codec library, no server.
-          </p>
+          Runs live in your tab for the four text formats and JSON-LD — the demo calls
+          the same <code className="font-mono">Store.load</code> /{" "}
+          <code className="font-mono">loadDataset</code> loaders that ship in{" "}
+          <code className="font-mono">@jeswr/sparq</code>, and gzip decodes with the
+          browser&apos;s native <code className="font-mono">DecompressionStream</code>,
+          with no network round-trip. Reproduce:{" "}
+          <code className="font-mono">cargo test -p sparq-core</code>.
         </>
       }
       caveat={
-        <>
-          <p>
-            Only <strong className="text-foreground">gzip</strong> decodes in the
-            browser (via <code className="font-mono">DecompressionStream</code>);{" "}
-            <strong className="text-foreground">zstd</strong> and{" "}
-            <strong className="text-foreground">bzip2</strong> ingest, HDT loading,
-            the mmap / external-memory path, and the fully-parallel fast loaders are{" "}
-            <strong className="text-foreground">native-only</strong> — in the
-            browser the in-memory streaming loader is used.
-          </p>
-        </>
+        <p>
+          Only <strong className="text-foreground">gzip</strong> decodes in the browser
+          (via <code className="font-mono">DecompressionStream</code>);{" "}
+          <strong className="text-foreground">zstd</strong> and{" "}
+          <strong className="text-foreground">bzip2</strong> ingest, HDT loading, the
+          mmap / external-memory path, and the fully-parallel fast loaders are{" "}
+          <strong className="text-foreground">native-only</strong> — in the browser the
+          in-memory streaming loader is used.
+        </p>
       }
       links={[{ href: "/try", label: "Open the full SPARQL REPL" }]}
     >

--- a/site/src/app/surface/full-text/page.tsx
+++ b/site/src/app/surface/full-text/page.tsx
@@ -50,27 +50,27 @@ export default function FullTextSurfacePage() {
       }
       capabilities={[
         {
-          title: "text:matches (AND) + BM25 score",
+          term: "text:matches (AND) + BM25 score",
           body: "Keyword search: literals containing every token, ranked by BM25 relevance bound with text:score.",
         },
         {
-          title: "text:matchesAny (OR)",
+          term: "text:matchesAny (OR)",
           body: "Literals containing at least one token — the inclusive variant, also BM25-ranked.",
         },
         {
-          title: "Prefix tokens (foo*)",
+          term: "Prefix tokens (foo*)",
           body: "A token ending in '*' is a prefix query: 'fox*' matches 'fox' and 'foxes' — autocomplete-style.",
         },
         {
-          title: "text:phrase (adjacent, in order)",
+          term: "text:phrase (adjacent, in order)",
           body: "Exact phrase match over the positions-enabled index this bundle always builds; order is significant.",
         },
         {
-          title: "text:near + text:slop (proximity)",
+          term: "text:near + text:slop (proximity)",
           body: "Bounded-gap, in-order proximity match, ranked tightest-first (score = 1/(1+gap)); slop sets the gap budget.",
         },
         {
-          title: "Index footprint reported",
+          term: "Index footprint reported",
           body: "Indexed-literal and distinct-token counts plus an in-memory heap estimate — the index-build-memory surface, shown per run.",
         },
       ]}

--- a/site/src/app/surface/genai/page.tsx
+++ b/site/src/app/surface/genai/page.tsx
@@ -64,27 +64,27 @@ export default function GenaiSurfacePage() {
       }
       capabilities={[
         {
-          title: "Schema-card grounding (real introspection)",
+          term: "Schema-card grounding (real introspection)",
           body: "sparq-introspect's to_text_summary builds a token-budgeted deck — exact class/predicate counts, datatype ranges, characteristic sets — from the store's indexes, not guesses.",
         },
         {
-          title: "Validate before execute",
+          term: "Validate before execute",
           body: "The extracted query is parsed with the real spargebra parser before the engine sees it, so a malformed query becomes a concrete repair signal rather than a silent failure.",
         },
         {
-          title: "Bounded repair loop",
+          term: "Bounded repair loop",
           body: "Parse and execution errors (unsupported forms, budget trips) are fed back with the failed query; a capped number of rounds, then the loop gives up honestly.",
         },
         {
-          title: "Budgeted execution",
+          term: "Budgeted execution",
           body: "LLM-generated queries are untrusted input — every query runs under a QueryBudget (default 10 s wall clock, 1M materialised rows); opting out is explicit.",
         },
         {
-          title: "Record / replay — offline CI",
+          term: "Record / replay — offline CI",
           body: "The Llm trait records (prompt, completion) pairs to a fixture and replays them by exact-prompt match, so the whole loop is deterministic and network-free in tests.",
         },
         {
-          title: "Index-grounded entity linking (opt-in)",
+          term: "Index-grounded entity linking (opt-in)",
           body: "Optionally resolve a question's proper nouns to concrete IRIs in this store (label index + sparq-sim structural siblings) and surface them in the prompt — off by default.",
         },
       ]}

--- a/site/src/app/surface/geosparql/page.tsx
+++ b/site/src/app/surface/geosparql/page.tsx
@@ -74,27 +74,27 @@ export default function GeosparqlSurfacePage() {
       }
       capabilities={[
         {
-          title: "WKT + GML geometry literals",
+          term: "WKT + GML geometry literals",
           body: "Parses geo:wktLiteral and geo:gmlLiteral (GML Simple-Features: Point / LineString / Polygon with rings / Multi*), an optional leading CRS IRI, EPSG:4326 axis-swap, and the OGC R9 geo: metadata properties (dimension / isEmpty / isSimple / …).",
         },
         {
-          title: "geof: inside plain SPARQL",
+          term: "geof: inside plain SPARQL",
           body: "geof_registry() packages the functions as a sparq-engine FunctionRegistry, so distance / the relation families / envelope / buffer / set ops run inside real FILTER / BIND / SELECT expressions — and chain (geof:buffer feeds straight into geof:sfWithin).",
         },
         {
-          title: "Three DE-9IM relation families",
+          term: "Three DE-9IM relation families",
           body: "sf* (Simple Features), eh* (Egenhofer) and rcc8* (RCC8) topology predicates, plus a generic 9-char DE-9IM relate(). Relations are planar (coordinate-space), not geodesic.",
         },
         {
-          title: "Topology-property query rewrite",
+          term: "Topology-property query rewrite",
           body: "geosparql_rewrite expands ?a geo:sfWithin ?b triple patterns into (hasDefaultGeometry|hasGeometry)/asWKT resolution joins + the matching geof: FILTER — opt-in, so W3C conformance of the default entry points is unaffected.",
         },
         {
-          title: "R-tree GeoIndex (nearest / radius / intersects)",
+          term: "R-tree GeoIndex (nearest / radius / intersects)",
           body: "GeoIndex::build scans geo:asWKT / geo:asGML into an rstar R-tree; nearest (k-NN), within_distance (radius) and intersects answer great-circle metre queries, with incremental apply_delta to stay in sync with graph updates.",
         },
         {
-          title: "Opt-in everywhere",
+          term: "Opt-in everywhere",
           body: "A separate crate (the core engine + lean wasm carry no geometry code); the server installs geof: only behind its non-default `geo` feature; the `reproject` module (a small curated EPSG table → CRS84) is itself opt-in.",
         },
       ]}

--- a/site/src/app/surface/http-server/page.tsx
+++ b/site/src/app/surface/http-server/page.tsx
@@ -60,27 +60,27 @@ export default function HttpServerSurfacePage() {
       }
       capabilities={[
         {
-          title: "SPARQL 1.1 Protocol query + update",
+          term: "SPARQL 1.1 Protocol query + update",
           body: "GET (URL param) or POST (direct body / url-encoded form) at /sparql; updates are atomic — failure → 400 with no partial effect, success → 204.",
         },
         {
-          title: "Accept-driven content negotiation",
+          term: "Accept-driven content negotiation",
           body: "SELECT/ASK as JSON / XML / CSV / TSV; CONSTRUCT/DESCRIBE + Graph-Store reads as N-Triples / prefix-compacting Turtle / RDF/XML — q-value aware.",
         },
         {
-          title: "Graph Store HTTP Protocol (read + write)",
+          term: "Graph Store HTTP Protocol (read + write)",
           body: "GET/HEAD read a graph; PUT replaces (201/204), POST merges, DELETE drops — bodies parsed by Content-Type, routed through the same atomic writer as UPDATE.",
         },
         {
-          title: "Live WebSocket + SSE subscriptions",
+          term: "Live WebSocket + SSE subscriptions",
           body: "Subscribe to a SELECT; get a sequence-0 snapshot then per-commit added/removed diffs. Both transports share one registry; close the stream to unsubscribe.",
         },
         {
-          title: "EXPLAIN + Prometheus /metrics",
+          term: "EXPLAIN + Prometheus /metrics",
           body: "?explain=true returns the join plan with cardinality estimates (no execution); /metrics exposes triple count, applied-update counter and active-subscription gauge.",
         },
         {
-          title: "Hardened by default",
+          term: "Hardened by default",
           body: "Loopback-only bind, optional Bearer write/read gate, per-request timeouts, body / concurrency / decompress caps, slow-loris guards, and a fixed security-header set on every response.",
         },
       ]}

--- a/site/src/app/surface/inference/page.tsx
+++ b/site/src/app/surface/inference/page.tsx
@@ -10,96 +10,57 @@ export const metadata: Metadata = {
     "Forward-chaining RDFS / OWL 2 RL / Notation3 reasoning with the sparq reasoner — base vs entailed triple counts and a why() derivation proof tree, live in your tab via the W-reason wasm bundle.",
 };
 
+// [OPUS-4.8] sq-vw3ax.4 — scan-first deep page: statement + the inference
+// playground first (lazy-loads the W-reason bundle on interaction), then a tight
+// capabilities list, a one-sentence "how this runs", caveats closed.
 export default function InferenceSurfacePage() {
   return (
     <SurfaceContent
       icon={Brain}
       title="Inference"
-      statement="Forward-chain the RDFS / OWL 2 RL / N3 closure — see what reasoning adds, then ask why."
+      statement="Forward-chain the RDFS / OWL 2 RL / N3 closure — see what reasoning adds, then ask why, in your tab."
       tier="live-new-wasm"
-      intro={
-        <>
-          <p>
-            <code className="font-mono text-foreground">sparq-reason</code> is a
-            forward-chaining reasoner over a{" "}
-            <code className="font-mono">sparq_core::Graph</code>: it materializes
-            the deductive closure of an ontology + facts under{" "}
-            <strong className="text-foreground">RDFS</strong> or{" "}
-            <strong className="text-foreground">OWL 2 RL</strong>, runs{" "}
-            <strong className="text-foreground">Notation3 rules</strong> (
-            <code className="font-mono">{"{ … } => { … }"}</code>), and — uniquely —
-            reconstructs a <code className="font-mono">why()</code>{" "}
-            <strong className="text-foreground">derivation proof tree</strong> for
-            any entailed triple: the chain of inference rules and asserted facts that
-            justify it.
-          </p>
-          <p>
-            Because it is pure Rust over <code className="font-mono">sparq-engine</code>
-            , it compiles to wasm. The playground below loads the tier-b{" "}
-            <strong className="text-foreground">&ldquo;W-reason&rdquo; bundle</strong>{" "}
-            on demand — a separate, lazily-loaded bundle from the lean SPARQL REPL — and
-            runs the reasoner in this tab: paste an ontology, see the base vs entailed
-            triple counts, then click an entailed triple to render its proof. The
-            default is the classic Socrates syllogism.
-          </p>
-        </>
-      }
       capabilities={[
         {
-          title: "RDFS closure",
+          term: "RDFS closure",
           body: "subClassOf / subPropertyOf / domain / range entailments, forward-chained to fixpoint.",
         },
         {
-          title: "OWL 2 RL closure",
-          body: "Property axioms (inverseOf, symmetric/transitive), class axioms, restrictions — the RL profile (includes RDFS).",
+          term: "OWL 2 RL closure",
+          body: "Property axioms (inverseOf, symmetric/transitive), class axioms and restrictions — the rule-based RL profile (includes RDFS).",
         },
         {
-          title: "Notation3 rules",
+          term: "Notation3 rules",
           body: "{ … } => { … } rule documents over facts — the Socrates example, run in-tab.",
         },
         {
-          title: "Base vs entailed counts",
-          body: "Distinct asserted triples, the closure size, and exactly how many triples reasoning added.",
+          term: "Base vs entailed counts",
+          body: "Distinct asserted triples, the closure size, and exactly how many triples reasoning added (the entailed-only delta).",
         },
         {
-          title: "why() proof trees",
+          term: "why() proof trees",
           body: "Click an entailed triple for one derivation: a premises-before-conclusion DAG bottoming out in asserted facts.",
-        },
-        {
-          title: "Entailed-only delta",
-          body: "Just the triples reasoning ADDED — the closure minus the asserted base — not the whole closure.",
         },
       ]}
       runsNote={
         <>
-          <p>
-            <strong className="text-foreground">Live in your browser tab.</strong>{" "}
-            The reasoner is pure Rust over the engine, compiled to wasm in the
-            separate W-reason bundle (
-            <code className="font-mono">sparq-reason-wasm</code>, built with the{" "}
-            <code className="font-mono">explain</code> feature for{" "}
-            <code className="font-mono">why()</code>). The page lazy-loads it on first
-            interaction so the landing page never pays for it, then calls the bundle&rsquo;s{" "}
-            <code className="font-mono text-foreground">Reasoner.materializeStats</code>,{" "}
-            <code className="font-mono">Reasoner.entailed</code> /{" "}
-            <code className="font-mono">Reasoner.reasonN3</code>, and{" "}
-            <code className="font-mono">Reasoner.why</code> bindings — nothing is sent
-            to a server.
-          </p>
+          Runs live in your tab via the separately lazy-loaded W-reason bundle (
+          <code className="font-mono">sparq-reason-wasm</code>, built with the{" "}
+          <code className="font-mono">explain</code> feature) — loaded only on first
+          interaction so the landing page never pays for it, with no network round-trip.
+          Reproduce: <code className="font-mono">cargo test -p sparq-reason</code>.
         </>
       }
       caveat={
-        <>
-          <p>
-            The reasoner is a forward-chaining materializer sized for the
-            illustrative documents here (tens of triples); it is not a tableau OWL DL
-            reasoner, and the OWL 2 RL profile is the rule-based RL fragment, not full
-            OWL. The N3 mode reasons over the rule document directly, so the{" "}
-            <code className="font-mono">why?</code> proof-tree button is shown for the
-            RDFS / OWL profiles only. Materialize large graphs server-side via{" "}
-            <code className="font-mono">sparq-cli reason</code>.
-          </p>
-        </>
+        <p>
+          The reasoner is a forward-chaining materializer sized for the illustrative
+          documents here (tens of triples); it is not a tableau OWL DL reasoner, and the
+          OWL 2 RL profile is the rule-based RL fragment, not full OWL. The N3 mode
+          reasons over the rule document directly, so the{" "}
+          <code className="font-mono">why?</code> proof-tree button shows for the RDFS /
+          OWL profiles only. Materialize large graphs server-side via{" "}
+          <code className="font-mono">sparq-cli reason</code>.
+        </p>
       }
     >
       <InferencePlayground />

--- a/site/src/app/surface/javascript-wasm/page.tsx
+++ b/site/src/app/surface/javascript-wasm/page.tsx
@@ -10,94 +10,58 @@ export const metadata: Metadata = {
     "Use the sparq engine from JavaScript/TypeScript via @jeswr/sparq — an idiomatic RDF/JS surface over the ~886 KB WebAssembly build, in Node or the browser.",
 };
 
+// [OPUS-4.8] sq-vw3ax.4 — scan-first deep page: statement + the RDF/JS API demo
+// first, then a tight capabilities list, a one-sentence "how this runs", caveats
+// closed.
 export default function JavascriptWasmSurfacePage() {
   return (
     <SurfaceContent
       icon={Boxes}
       title="JavaScript / WASM"
-      statement="The @jeswr/sparq RDF/JS API — the Rust engine compiled to a single ~886 KB wasm artifact."
+      statement="The @jeswr/sparq RDF/JS API — the Rust engine compiled to a single ~886 KB wasm artifact, running unchanged in Node and the browser."
       tier="live"
-      intro={
-        <>
-          <p>
-            sparq is a Rust RDF triplestore + SPARQL engine compiled to a single{" "}
-            <strong className="text-foreground">~886 KB</strong> (≈314 KB gzipped)
-            WebAssembly artifact. The npm package{" "}
-            <code className="font-mono text-foreground">@jeswr/sparq</code> wraps it
-            in an idiomatic <a className="text-primary underline-offset-4 hover:underline" href="https://rdf.js.org/" target="_blank" rel="noopener noreferrer">RDF/JS</a>{" "}
-            surface — <code className="font-mono">SparqStore</code>, Map-like{" "}
-            <code className="font-mono">Bindings</code>, spec terms via{" "}
-            <code className="font-mono">@rdfjs/types</code> — and runs unchanged in
-            Node &ge; 18 and the browser.
-          </p>
-          <p>
-            This very site uses it: the live REPL constructs a{" "}
-            <code className="font-mono">Store</code>, loads Turtle, and runs your
-            SPARQL — all in the tab. A thin raw <code className="font-mono">Store</code>{" "}
-            class is available if you want SPARQL-JSON strings with no JS-side term
-            materialisation. The panels below call the API directly against one seeded
-            store, in your tab.
-          </p>
-        </>
-      }
       capabilities={[
         {
-          title: "SparqStore (RDF/JS)",
-          body: "fromString / fromCompressed, query() yielding Map-like Bindings, idiomatic terms.",
+          term: "SparqStore (RDF/JS)",
+          body: "fromString / fromCompressed, query() yielding Map-like Bindings, idiomatic spec terms via @rdfjs/types.",
         },
         {
-          title: "Streaming cursors",
-          body: "Iterate large SELECT results in batches without materialising the whole table.",
+          term: "Streaming cursors + count()",
+          body: "Iterate large SELECT results in batches without materialising the whole table; count() reads from the index without building bindings.",
         },
         {
-          title: "count() without materialising",
-          body: "Get a solution count, read from the index, without building every binding.",
-        },
-        {
-          title: "RDF/JS match() / countQuads()",
+          term: "RDF/JS match() / countQuads()",
           body: "The standard Source interface for triple-pattern matching over the store.",
         },
         {
-          title: "applyDelta / SPARQL Update",
+          term: "applyDelta / SPARQL Update",
           body: "Apply quad-level deltas or SPARQL Update to mutate the store in place.",
         },
         {
-          title: "Raw Store class",
-          body: "SPARQL-JSON strings + CONSTRUCT / DESCRIBE, skipping JS term materialisation.",
+          term: "Raw Store class",
+          body: "SPARQL-JSON strings + CONSTRUCT / DESCRIBE, skipping JS-side term materialisation.",
         },
       ]}
       runsNote={
         <>
-          <p>
-            <strong className="text-foreground">This is the engine.</strong> Every
-            live demo on this site calls this API. In Node it loads the same wasm
-            binary; in the browser it streams it on first use.
-          </p>
-          <p>
-            The demo below seeds a six-person Turtle graph, then exercises{" "}
-            <code className="font-mono">queryCursor()</code>,{" "}
-            <code className="font-mono">match()</code>/
-            <code className="font-mono">countQuads()</code>,{" "}
-            <code className="font-mono">count()</code> and{" "}
-            <code className="font-mono">applyDelta()</code> against it — all in your tab.
-          </p>
+          This is the engine — every live demo on this site calls this API. In Node it
+          loads the same wasm binary; in the browser it streams it on first use, with no
+          network round-trip beyond fetching the artifact. Reproduce:{" "}
+          <code className="font-mono">npm install @jeswr/sparq</code>.
         </>
       }
       caveat={
-        <>
-          <p>
-            The <code className="font-mono">SparqStore</code> wrapper&apos;s{" "}
-            <code className="font-mono">query()</code> covers SELECT/ASK; CONSTRUCT /
-            DESCRIBE are on the wrapper via{" "}
-            <code className="font-mono">queryQuads()</code> (RDF/JS quads),{" "}
-            <code className="font-mono">queryQuadsString()</code> (N-Triples), and{" "}
-            <code className="font-mono">queryQuadsStream()</code>; drop to the raw{" "}
-            <code className="font-mono">Store</code> only to skip term
-            materialisation. The lean bundle omits REGEX/REPLACE and the
-            wall-clock query budget (see the SPARQL surface), trading a smaller
-            download for those native-only features.
-          </p>
-        </>
+        <p>
+          The <code className="font-mono">SparqStore</code> wrapper&apos;s{" "}
+          <code className="font-mono">query()</code> covers SELECT / ASK; CONSTRUCT /
+          DESCRIBE are on the wrapper via{" "}
+          <code className="font-mono">queryQuads()</code> (RDF/JS quads),{" "}
+          <code className="font-mono">queryQuadsString()</code> (N-Triples) and{" "}
+          <code className="font-mono">queryQuadsStream()</code> — drop to the raw{" "}
+          <code className="font-mono">Store</code> only to skip term materialisation. The
+          lean bundle omits REGEX / REPLACE and the wall-clock query budget (see the
+          SPARQL surface), trading a smaller download for those native-only features.
+        </p>
       }
       links={[
         { href: "/try", label: "Open the live REPL" },

--- a/site/src/app/surface/mpc/page.tsx
+++ b/site/src/app/surface/mpc/page.tsx
@@ -42,27 +42,27 @@ export default function MpcSurfacePage() {
       }
       capabilities={[
         {
-          title: "Per-holder local evaluation",
+          term: "Per-holder local evaluation",
           body: "Each holder runs its own SELECT fragment over its own graph; the raw graph never leaves.",
         },
         {
-          title: "Disclosed-key global join",
+          term: "Disclosed-key global join",
           body: "Crypto-free inner join on shared global IRIs, equal to union-store evaluation.",
         },
         {
-          title: "Secure cumulative aggregate",
+          term: "Secure cumulative aggregate",
           body: "Sum private integers over Shamir shares (free local addition), reveal only the total.",
         },
         {
-          title: "Secure threshold verdict",
+          term: "Secure threshold verdict",
           body: "Open only the bit `sum ≥ threshold` — the £100k flatmates example — never the operands.",
         },
         {
-          title: "Hidden-value join",
+          term: "Hidden-value join",
           body: "Join on a private key via secret-shared equality; only matched payload columns disclosed.",
         },
         {
-          title: "Fail-closed backend selection",
+          term: "Fail-closed backend selection",
           body: "A federation states its security floor up front; an over-strong request is truthfully refused.",
         },
       ]}

--- a/site/src/app/surface/shacl/page.tsx
+++ b/site/src/app/surface/shacl/page.tsx
@@ -10,103 +10,67 @@ export const metadata: Metadata = {
     "Validate RDF against SHACL shapes with the sparq engine — SHACL Core constraints, SHACL-SPARQL, custom constraint components, the W3C validation report, and a SHACL Compact Syntax view, live in your tab.",
 };
 
+// [OPUS-4.8] sq-vw3ax.4 — scan-first deep page: statement + the SHACL playground
+// first, then a tight capabilities list, a one-sentence "how this runs", caveats
+// closed.
 export default function ShaclSurfacePage() {
   return (
     <SurfaceContent
       icon={ShieldCheck}
       title="SHACL"
-      statement="Validate RDF data against shapes — SHACL Core, SHACL-SPARQL, the W3C validation report, and a live SHACL Compact Syntax view."
+      statement="Validate RDF against shapes — SHACL Core, SHACL-SPARQL, the W3C validation report and a live SHACL Compact Syntax view, in your tab."
       tier="live"
-      intro={
-        <>
-          <p>
-            <code className="font-mono text-foreground">sparq-shacl</code> validates
-            a <code className="font-mono">sparq_core::Graph</code> against SHACL
-            shapes and produces a{" "}
-            <strong className="text-foreground">W3C validation report</strong>{" "}
-            (conformance plus per-violation results) as Turtle or human-readable
-            text. It implements SHACL Core constraints, SHACL-SPARQL{" "}
-            <code className="font-mono">sh:sparql</code> constraints, and custom
-            SPARQL-based constraint components.
-          </p>
-          <p>
-            Because it is pure Rust over <code className="font-mono">sparq-engine</code>
-            , it is wasm-portable. The SHACL-enabled wasm bundle — the same one the
-            published <code className="font-mono text-foreground">@jeswr/sparq</code>{" "}
-            ships — runs the validator in this tab: paste data + shapes below and the
-            conformance flag and per-violation report come back with no network
-            round-trip.
-          </p>
-        </>
-      }
       capabilities={[
         {
-          title: "SHACL Core constraints",
-          body: "class, datatype, cardinality, value ranges, node/property shapes, paths.",
+          term: "SHACL Core constraints",
+          body: "class, datatype, cardinality, value ranges, node/property shapes, paths, plus and / or / not / xone, qualified value shapes, closed shapes, in / hasValue.",
         },
         {
-          title: "Logical & qualified shapes",
-          body: "and / or / not / xone, qualified value shapes, closed shapes, in / hasValue.",
-        },
-        {
-          title: "SHACL-SPARQL (§5.2)",
+          term: "SHACL-SPARQL (§5.2)",
           body: "sh:sparql constraints expressed as SPARQL SELECT over the engine.",
         },
         {
-          title: "Custom constraint components (§6)",
+          term: "Custom constraint components (§6)",
           body: "Define new sh:ConstraintComponent backed by SPARQL.",
         },
         {
-          title: "W3C validation report",
-          body: "Conformance boolean + sh:result violations, as Turtle or human text.",
+          term: "W3C validation report",
+          body: "Conformance boolean + sh:result violations, rendered as Turtle or human text.",
         },
         {
-          title: "Path expressions",
-          body: "Property paths in shape targets and constraints, reusing the engine's path evaluator.",
-        },
-        {
-          title: "SHACL Compact Syntax (display)",
-          body: "Render the shapes graph in the W3C compact notation — node/property shapes, paths, counts and value constraints — beside the W3C report.",
+          term: "SHACL Compact Syntax (display)",
+          body: "Render the shapes graph in the W3C compact notation — node/property shapes, paths, counts and value constraints — beside the report.",
         },
       ]}
       runsNote={
         <>
-          <p>
-            <strong className="text-foreground">Live in your browser tab.</strong>{" "}
-            The validator is pure Rust over the engine, compiled to wasm in the
-            SHACL-enabled bundle (the published{" "}
-            <code className="font-mono">@jeswr/sparq</code> ships it). The playground
-            calls the bundle&rsquo;s{" "}
-            <code className="font-mono text-foreground">Store.validate(data, shapes)</code>{" "}
-            binding, parses the two graphs, and renders the conformance flag plus the
-            per-violation W3C report — nothing is sent to a server.
-          </p>
+          Runs live in your tab via the SHACL-enabled wasm bundle (the published{" "}
+          <code className="font-mono">@jeswr/sparq</code>) — it calls{" "}
+          <code className="font-mono">Store.validate(data, shapes)</code> and renders the
+          conformance flag plus the W3C report, with no network round-trip. Reproduce:{" "}
+          <code className="font-mono">cargo test -p sparq-shacl</code>.
         </>
       }
       caveat={
         <>
           <p>
-            SHACL-SPARQL constraints rely on the engine&rsquo;s REGEX. The lean SPARQL
-            REPL bundle compiles REGEX out, but the SHACL bundle keeps it, so{" "}
-            <code className="font-mono">sh:sparql</code> constraints validate in-tab
-            too. The in-tab validator is sized for small documents (~10–100 triples);
+            The in-tab validator is sized for small documents (~10–100 triples);
             validate large graphs server-side via the{" "}
             <code className="font-mono">sparq-server</code> HTTP{" "}
             <code className="font-mono">validate</code> path.
           </p>
           <p>
-            The <strong className="text-foreground">Compact syntax</strong> view is
-            the <em>display</em> direction only (shapes &rarr; compact). It is
-            best-effort: SHACL Compact Syntax has no form for logical constraints
-            (<code className="font-mono">sh:and</code> /{" "}
+            The <strong className="text-foreground">Compact syntax</strong> view is the{" "}
+            <em>display</em> direction only (shapes &rarr; compact) and best-effort:
+            SHACL Compact Syntax has no form for logical constraints (
+            <code className="font-mono">sh:and</code> /{" "}
             <code className="font-mono">sh:or</code> /{" "}
             <code className="font-mono">sh:xone</code> /{" "}
-            <code className="font-mono">sh:not</code>) or shape references{" "}
-            (<code className="font-mono">sh:node</code>), which the view lists
-            explicitly rather than dropping. The <em>parse</em> direction (compact
-            text &rarr; shapes) is a full grammar that belongs in the{" "}
-            <code className="font-mono">sparq-shacl</code> engine and is tracked
-            separately.
+            <code className="font-mono">sh:not</code>) or shape references (
+            <code className="font-mono">sh:node</code>), which the view lists explicitly
+            rather than dropping. The <em>parse</em> direction (compact text &rarr;
+            shapes) belongs in the <code className="font-mono">sparq-shacl</code> engine
+            and is tracked separately.
           </p>
         </>
       }

--- a/site/src/app/surface/sparql/page.tsx
+++ b/site/src/app/surface/sparql/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { FileCode2 } from "lucide-react";
 
 import { SurfaceContent } from "@/components/surface-content";
+import { ReplLazy } from "@/components/repl-lazy";
 
 export const metadata: Metadata = {
   title: "SPARQL 1.1 / 1.2",
@@ -9,91 +10,57 @@ export const metadata: Metadata = {
     "SELECT / ASK / CONSTRUCT / UPDATE, property paths, RDF 1.2 triple terms, aggregates, subqueries — the sparq SPARQL engine, live in your tab.",
 };
 
+// [OPUS-4.8] sq-vw3ax.4 — scan-first deep page: statement + the live REPL demo
+// first, then a tight capabilities list, a one-sentence "how this runs", caveats
+// closed. The REPL mounts via ReplLazy so the heavy chunk loads after the shell.
 export default function SparqlSurfacePage() {
   return (
     <SurfaceContent
       icon={FileCode2}
       title="SPARQL 1.1 / 1.2"
-      statement="The full query language — SELECT, ASK, CONSTRUCT, UPDATE — over the sparq engine."
+      statement="The full query language — SELECT, ASK, CONSTRUCT, UPDATE — over a worst-case-optimal-join engine, live in your tab."
       tier="live"
-      intro={
-        <>
-          <p>
-            sparq evaluates SPARQL 1.1/1.2 over a{" "}
-            <code className="font-mono text-foreground">sparq_core::Graph</code>{" "}
-            using a worst-case-optimal join (WCOJ) engine. The same engine that
-            powers the native crate is compiled to WebAssembly and ships as{" "}
-            <code className="font-mono text-foreground">@jeswr/sparq</code>, so you
-            can run real queries in this tab — nothing is sent to a server.
-          </p>
-          <p>
-            The query surface covers the algebra you would expect — basic graph
-            patterns, FILTER, OPTIONAL, UNION, MINUS, BIND, VALUES, aggregates and
-            GROUP BY, sub-SELECT, and property paths — plus RDF 1.2 triple terms
-            and named-graph dataset views.
-          </p>
-        </>
-      }
       capabilities={[
         {
-          title: "SELECT / ASK / CONSTRUCT / DESCRIBE",
-          body: "All four query forms, returning bindings, a boolean, or a constructed graph.",
+          term: "All four query forms",
+          body: "SELECT / ASK / CONSTRUCT / DESCRIBE, plus SPARQL Update (INSERT / DELETE / DELETE…WHERE) that mutates the in-tab store.",
         },
         {
-          title: "SPARQL Update",
-          body: "INSERT / DELETE / DELETE…WHERE and graph management, mutating the store in place.",
+          term: "The algebra you expect",
+          body: "BGPs, FILTER, OPTIONAL, UNION, MINUS, BIND, VALUES, aggregates + GROUP BY / HAVING, and sub-SELECT.",
         },
         {
-          title: "Property paths",
+          term: "Property paths",
           body: "Sequence, alternative, inverse, and the transitive *, +, ? operators.",
         },
         {
-          title: "RDF 1.2 triple terms",
-          body: "Triple terms in object position, written <<( s p o )>> and queried with the triple-term functions.",
+          term: "RDF 1.2 triple terms",
+          body: "Triple terms in object position, written <<( s p o )>>, queried with the triple-term functions.",
         },
         {
-          title: "Aggregates & subqueries",
-          body: "COUNT / SUM / AVG / MIN / MAX / GROUP_CONCAT, GROUP BY / HAVING, and nested SELECT.",
-        },
-        {
-          title: "Extension functions",
-          body: "Register custom SPARQL functions via the engine's FunctionRegistry (native).",
+          term: "EXPLAIN / EXPLAIN ANALYZE",
+          body: "Inspect the planner's join order and cardinality estimates; ANALYZE also runs and appends a per-operator row-count trace.",
         },
       ]}
       runsNote={
         <>
-          <p>
-            <strong className="text-foreground">Live in your browser tab.</strong>{" "}
-            The lean wasm bundle carries the parser, triplestore and SPARQL engine.
-            The live REPL runs your queries against the sample graph with no network
-            round-trip — SELECT and ASK render a table / boolean, CONSTRUCT and
-            DESCRIBE render the constructed N-Triples, and SPARQL Update
-            (INSERT / DELETE) mutates the in-tab store.
-          </p>
-          <p>
-            The same REPL has an{" "}
-            <code className="font-mono text-foreground">EXPLAIN</code> /{" "}
-            <code className="font-mono text-foreground">EXPLAIN ANALYZE</code> mode:
-            EXPLAIN shows the planner&apos;s join order and cardinality estimates
-            without executing, ANALYZE also runs the query and appends a per-operator
-            row-count trace.
-          </p>
+          Runs live in your tab via the lean wasm bundle — the same WCOJ engine the
+          native crate ships, with no network round-trip. Reproduce:{" "}
+          <code className="font-mono">cargo test -p sparq-engine</code>.
         </>
       }
       caveat={
-        <>
-          <p>
-            REGEX / REPLACE are compiled out of the lean wasm bundle to keep it
-            small; they are available in the native build. The query-budget
-            deadline (wall-clock timeout) is native-only — the wasm bundle enforces
-            a row cap instead. In the wasm build,{" "}
-            <code className="font-mono">EXPLAIN ANALYZE</code> reports exact
-            per-operator row counts but zero wall-times (no monotonic clock under
-            wasm32).
-          </p>
-        </>
+        <p>
+          REGEX / REPLACE are compiled out of the lean wasm bundle to keep it small
+          (native-only). The wall-clock query-budget deadline is native-only too — the
+          wasm build enforces a row cap instead, and{" "}
+          <code className="font-mono">EXPLAIN ANALYZE</code> reports exact per-operator
+          row counts but zero wall-times (no monotonic clock under wasm32).
+        </p>
       }
-      links={[{ href: "/try", label: "Open the live REPL" }]}
-    />
+      links={[{ href: "/try", label: "Open the full REPL" }]}
+    >
+      <ReplLazy />
+    </SurfaceContent>
   );
 }

--- a/site/src/app/surface/streaming-rsp/page.tsx
+++ b/site/src/app/surface/streaming-rsp/page.tsx
@@ -52,27 +52,27 @@ export default function StreamingRspSurfacePage() {
       }
       capabilities={[
         {
-          title: "Tumbling & sliding time windows",
+          term: "Tumbling & sliding time windows",
           body: "RANGE / STEP in your own logical time unit — step == range tumbles, step < range slides with overlap.",
         },
         {
-          title: "Per-window aggregates",
+          term: "Per-window aggregates",
           body: "AVG / COUNT / SUM / MIN / MAX over each window's triples; integer AVG comes back as xsd:decimal per SPARQL typing.",
         },
         {
-          title: "RSTREAM / ISTREAM / DSTREAM",
+          term: "RSTREAM / ISTREAM / DSTREAM",
           body: "Full result per window, only rows that newly appeared (ISTREAM), or only rows that disappeared (DSTREAM).",
         },
         {
-          title: "Watermark + out-of-order tolerance",
+          term: "Watermark + out-of-order tolerance",
           body: "A window closes when max_ts − maxDelay reaches its end; late arrivals past every covering window are counted, not silently dropped.",
         },
         {
-          title: "Empty windows reported",
+          term: "Empty windows reported",
           body: "When the watermark jumps a gap, the window still fires (with no rows) — so DSTREAM can observe results disappear.",
         },
         {
-          title: "Flush at end-of-stream",
+          term: "Flush at end-of-stream",
           body: "Flush closes every remaining open window up to the last timestamp seen, ignoring maxDelay.",
         },
       ]}

--- a/site/src/app/surface/vector/page.tsx
+++ b/site/src/app/surface/vector/page.tsx
@@ -69,27 +69,27 @@ export default function VectorSurfacePage() {
       }
       capabilities={[
         {
-          title: "Memory-mapped per-term-id store (.spqv)",
+          term: "Memory-mapped per-term-id store (.spqv)",
           body: "One f32 vector per dictionary id; get is one binary search + a contiguous slice. Sparse by design, corrupt files rejected up front, build bigger than RAM with StreamingWriter.",
         },
         {
-          title: "Exact + approximate search",
+          term: "Exact + approximate search",
           body: "nearest_exact is the answer-exact ground truth; the on-disk DiskANN/Vamana graph (build once, reopen with no rebuild) and the opt-in in-RAM HNSW trade recall (< 1.0) for speed at scale.",
         },
         {
-          title: "k-NN inside plain SPARQL (opt-in vec-predicate)",
+          term: "k-NN inside plain SPARQL (opt-in vec-predicate)",
           body: "vec:nearest / vec:search run vector k-NN via a spargebra-algebra rewrite that inlines the hits as a VALUES table — the engine, planner and wasm bundle are unchanged.",
         },
         {
-          title: "Predicate-constrained (filtered) ANN (opt-in filtered-ann)",
+          term: "Predicate-constrained (filtered) ANN (opt-in filtered-ann)",
           body: "Restrict the search to the graph nodes a SPARQL BGP admits — the join-connected sub-BGP of the neighbour variable derives the candidate mask; a cost model picks pre- vs post-filter, both byte-identical.",
         },
         {
-          title: "Hybrid fusion + quantization",
+          term: "Hybrid fusion + quantization",
           body: "fuse_rrf / fuse_scores combine text vectors with another ranked signal (e.g. structural similarity); ScalarQuantizer (4×) and ProductQuantizer (8–32×) shrink large stores.",
         },
         {
-          title: "Bring-your-own embeddings",
+          term: "Bring-your-own embeddings",
           body: "Embeddings are out-of-process: import a matrix computed elsewhere (NumPy .npy / flat f32 dump) keyed by dict id, or wire a real OpenAI-compatible endpoint behind the opt-in embeddings feature. The default build opens no sockets.",
         },
       ]}

--- a/site/src/app/surface/zk/page.tsx
+++ b/site/src/app/surface/zk/page.tsx
@@ -41,27 +41,27 @@ export default function ZkSurfacePage() {
       }
       capabilities={[
         {
-          title: "Per-graph Poseidon2 commitments",
+          term: "Per-graph Poseidon2 commitments",
           body: "Commit a credential graph to a single field element the proof binds against.",
         },
         {
-          title: "BGP scan + integer FILTER",
+          term: "BGP scan + integer FILTER",
           body: "Prove a basic graph pattern matched and a numeric predicate (e.g. age ≥ 25) held.",
         },
         {
-          title: "Issuer attestation",
+          term: "Issuer attestation",
           body: "Schnorr signatures, incl. hidden-key set membership (prove a trusted issuer without naming it).",
         },
         {
-          title: "Revocation",
+          term: "Revocation",
           body: "Status-list non-revocation at a clear or hidden index.",
         },
         {
-          title: "Equality join",
+          term: "Equality join",
           body: "Prove two credentials share a holder term without disclosing it.",
         },
         {
-          title: "Replay defence",
+          term: "Replay defence",
           body: "Verifier-supplied nonces make each presentation single-use.",
         },
       ]}

--- a/site/src/components/surface-content.tsx
+++ b/site/src/components/surface-content.tsx
@@ -1,43 +1,70 @@
 // [OPUS-4.8] sq-3hrc — shared layout for a real (non-placeholder) surface page.
-// Renders a consistent structure per research/feature-showcase-site-design.md §2:
-// capability statement → tier badge → capability list → "how this works" →
-// honest caveat → CTAs. Content is grounded in each surface's skills/*/SKILL.md.
+//
+// [OPUS-4.8] sq-vw3ax.4 — rebuilt SCAN-FIRST per research/website-redesign.md §4
+// ("CAPABILITY DEEP PAGE"). The old template was a rigid sequence of always-open
+// cards (intro prose → 6-card capability grid → "How this runs" card → "Honest
+// caveats" card) that could not shrink — the density root cause the redesign
+// answers. The new order leads with the demo and makes every content block an
+// OPTIONAL prop, so a simple surface renders just statement + demo + one-line note:
+//
+//   (1) title + tier badge + ONE-sentence statement
+//   (2) the interactive demo IMMEDIATELY (`children`)
+//   (3) a tight Capabilities list (bolded lead term + short clause, max ~5)
+//   (4) "How this runs" as a SINGLE sentence whose authority is the tier badge
+//   (5) caveats as a CLOSED <details>
+//
+// Content is grounded in each surface's skills/*/SKILL.md. Honesty discipline:
+// the tier badge (TIER_LABEL / TIER_VARIANT) is the load-bearing claim — the
+// runsNote sentence only restates it, it must not over-claim past the badge.
 
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { ArrowLeft, Check, Info, TriangleAlert } from "lucide-react";
+import { ArrowLeft } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { type Tier, TIER_LABEL, TIER_VARIANT } from "@/data/surfaces";
 
 export interface SurfaceContentProps {
   icon: LucideIcon;
   title: string;
-  /** One-line capability statement. */
+  /** One-line capability statement — always shown under the title. */
   statement: string;
   tier: Tier;
   /** Optional extra badge label (e.g. "Native-only", "Research-grade"). */
   extraBadge?: string;
-  /** Lead paragraphs of prose. */
-  intro: ReactNode;
-  /** The concrete capabilities this surface offers (bullet list). */
-  capabilities: { title: string; body: string }[];
-  /** "How this runs" honest note. */
-  runsNote: ReactNode;
-  /** Honest caveat / what is NOT covered. */
-  caveat: ReactNode;
+  /**
+   * The interactive demo. Rendered IMMEDIATELY after the header so the proof is
+   * the first thing a visitor scans. Optional — a surface with no in-tab demo
+   * simply omits it.
+   */
+  children?: ReactNode;
+  /**
+   * Optional lead prose. Most deep pages no longer need this — the demo plus the
+   * capabilities list carry the page. Kept for surfaces that genuinely need a
+   * sentence of framing before the list.
+   */
+  intro?: ReactNode;
+  /**
+   * The concrete capabilities this surface offers, as a tight scan-list. Each
+   * entry is a bolded lead term + a short clause. Keep it to ~5 — long lists are
+   * the density the redesign cuts. Optional: omit for a bare statement+demo page.
+   */
+  capabilities?: { term: string; body: string }[];
+  /**
+   * "How this runs" — a SINGLE sentence whose authority is the tier badge above
+   * (e.g. "Runs live in your tab via the lean wasm bundle"). Optional. Renders as
+   * one muted line, NOT a card.
+   */
+  runsNote?: ReactNode;
+  /**
+   * Honest caveat / what is NOT covered. Rendered inside a CLOSED <details> so it
+   * is available without dominating the page. Optional.
+   */
+  caveat?: ReactNode;
   /** Optional CTA links beyond the source link. */
   links?: { href: string; label: string; external?: boolean }[];
-  /** Anything extra (e.g. an embedded REPL or table). */
-  children?: ReactNode;
 }
 
 export function SurfaceContent({
@@ -46,15 +73,20 @@ export function SurfaceContent({
   statement,
   tier,
   extraBadge,
+  children,
   intro,
   capabilities,
   runsNote,
   caveat,
   links,
-  children,
 }: SurfaceContentProps) {
   return (
-    <div className="space-y-10">
+    <div className="space-y-8">
+      {/*
+        Back-link targets the overview. The redesign's /capabilities gallery
+        (sq-vw3ax.3) is the intended parent once it lands on main; until then this
+        points to "/" so the link never resolves to a 404 on the static export.
+      */}
       <Button variant="ghost" size="sm" asChild className="-ml-2">
         <Link href="/">
           <ArrowLeft className="size-4" aria-hidden="true" />
@@ -62,72 +94,77 @@ export function SurfaceContent({
         </Link>
       </Button>
 
+      {/* (1) title + tier badge + ONE-sentence statement */}
       <header className="space-y-3">
-        <div className="flex items-center gap-3">
-          <span className="flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+        <div className="flex items-start gap-3">
+          <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
             <Icon className="size-5" aria-hidden="true" />
           </span>
-          <div>
-            <h1 className="text-2xl font-semibold">{title}</h1>
-            <p className="text-sm text-muted-foreground">{statement}</p>
+          <div className="space-y-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <h1 className="text-2xl font-semibold">{title}</h1>
+              <Badge variant={TIER_VARIANT[tier]}>{TIER_LABEL[tier]}</Badge>
+              {extraBadge && <Badge variant="muted">{extraBadge}</Badge>}
+            </div>
+            <p className="text-muted-foreground">{statement}</p>
           </div>
-        </div>
-        <div className="flex flex-wrap gap-2">
-          <Badge variant={TIER_VARIANT[tier]}>{TIER_LABEL[tier]}</Badge>
-          {extraBadge && <Badge variant="muted">{extraBadge}</Badge>}
         </div>
       </header>
 
-      <section className="measure space-y-3 text-muted-foreground">{intro}</section>
+      {/* Optional one-sentence framing, before the demo. */}
+      {intro && (
+        <section className="measure space-y-3 text-sm text-muted-foreground">
+          {intro}
+        </section>
+      )}
 
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold">Capabilities</h2>
-        <div className="grid gap-3 sm:grid-cols-2">
-          {capabilities.map((c) => (
-            <div
-              key={c.title}
-              className="flex gap-3 rounded-xl bg-muted/40 p-4 ring-1 ring-foreground/10"
-            >
-              <Check
-                className="mt-0.5 size-4 shrink-0 text-[var(--success)]"
-                aria-hidden="true"
-              />
-              <div>
-                <div className="text-sm font-semibold">{c.title}</div>
-                <div className="text-sm text-muted-foreground">{c.body}</div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </section>
-
+      {/* (2) the interactive demo IMMEDIATELY */}
       {children}
 
-      <section className="grid gap-4 md:grid-cols-2">
-        <Card>
-          <CardHeader className="flex-row items-center gap-2 space-y-0">
-            <Info className="size-5 text-primary" aria-hidden="true" />
-            <CardTitle className="text-base">How this runs</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2 text-sm text-muted-foreground">
-            {runsNote}
-          </CardContent>
-        </Card>
-        <Card className="ring-[var(--warning)]/30">
-          <CardHeader className="flex-row items-center gap-2 space-y-0">
-            <TriangleAlert
-              className="size-5 text-[var(--warning)]"
-              aria-hidden="true"
-            />
-            <CardTitle className="text-base">Honest caveats</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2 text-sm text-muted-foreground">
-            {caveat}
-          </CardContent>
-        </Card>
-      </section>
+      {/* (3) a tight Capabilities list — bolded lead term + short clause, max ~5 */}
+      {capabilities && capabilities.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            Capabilities
+          </h2>
+          <ul className="measure space-y-2 text-sm">
+            {capabilities.map((c) => (
+              <li key={c.term} className="flex gap-2">
+                <span
+                  className="mt-2 size-1.5 shrink-0 rounded-full bg-primary/60"
+                  aria-hidden="true"
+                />
+                <span className="text-muted-foreground">
+                  <strong className="font-semibold text-foreground">
+                    {c.term}
+                  </strong>{" "}
+                  — {c.body}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
 
-      <section className="flex flex-wrap gap-2">
+      {/* (4) "How this runs" as a SINGLE sentence — authority is the badge above */}
+      {runsNote && (
+        <section className="measure text-sm text-muted-foreground">
+          <span className="font-medium text-foreground">How this runs: </span>
+          {runsNote}
+        </section>
+      )}
+
+      {/* (5) caveats as a CLOSED <details> */}
+      {caveat && (
+        <details className="measure rounded-lg border bg-muted/20 p-3 text-sm text-muted-foreground">
+          <summary className="cursor-pointer select-none font-medium text-foreground">
+            Caveats &amp; what is not covered
+          </summary>
+          <div className="mt-3 space-y-2">{caveat}</div>
+        </details>
+      )}
+
+      <section className="flex flex-wrap gap-2 pt-2">
         {links?.map((l) =>
           l.external ? (
             <Button key={l.href} asChild variant="outline" size="sm">


### PR DESCRIPTION
> 🤖 Filed by a **SPARQ agent** (site lane) working bead **sq-vw3ax.4** under the website-redesign epic **sq-vw3ax**. @jeswr runs several agents on one account — this is one of them.

## What & why

Rebuilds `surface-content.tsx` as a **scan-first, disclosure-based** template with **all content blocks OPTIONAL props**, per `research/website-redesign.md` §4 ("CAPABILITY DEEP PAGE"). The old template was a rigid sequence of always-open cards (intro prose → 6-card capability grid → "How this runs" card → "Honest caveats" card) that **could not shrink** — the density root cause the redesign answers.

### New order (was: header → intro → 6 ring-cards → demo → 2 always-open cards → CTAs)
1. title + tier badge + **ONE-sentence** statement
2. the interactive demo **IMMEDIATELY** (`children`)
3. a tight **Capabilities** list — bolded lead term + short clause, **max ~5** (was a 6-card ring grid)
4. **"How this runs"** as a **single sentence** whose authority is the tier badge
5. caveats as a **closed `<details>`**

`intro` / `capabilities` / `runsNote` / `caveat` are now **all optional**, so a simple surface renders just *statement + demo + one-line note*.

### The 5 retained live-tier deep pages, rebuilt on it
`/surface/{sparql,shacl,inference,data-formats,javascript-wasm}` — capabilities trimmed to 5 each, single-sentence `runsNote`, caveats moved into the closed `<details>`. The **SPARQL** page now leads with the live REPL via `ReplLazy`, so the heavy REPL chunk stays off the route's first-load bundle (**141 B** page-specific JS).

## Compatibility
The capability field was renamed `title` → `term` (the lead term). The 8 other `SurfaceContent` callers (full-text, streaming-rsp, geosparql, vector, zk, genai, mpc, http-server) were updated to the new field so they keep compiling and rendering — `runsNote`/`caveat` bodies are untouched (incl. the ZK/MPC privacy caveats).

**Back-link** points to `/` (overview). The `/capabilities` gallery this would ideally link to ships in **sq-vw3ax.3 / #1004**, which is **not yet on `main`** — linking there now would 404 on the static export. Repoint once #1004 lands.

## Gates (all green)
- `npm run lint` — clean (no ESLint warnings/errors)
- `npm run build` (static export) — **green end-to-end**; all `/surface/*` routes emitted into `out/`. WASM prereq built first (`cd js && npm run build:wasm` + `build:reason-wasm`).
- typecheck (Next build) — passes, no `any`-escape hatches
- `typos` — clean; `check-privacy-claims.sh` — OK (384 files); `no-perf-numbers` — 0 findings
- `basePath` (`/sparq`) correct on all links/assets; no existing route broken

## Data honesty
No benchmark numbers added. The `~886 KB` on the JS/WASM page is the published-artifact **size** (not a perf/benchmark claim). Generated `benchmarks.generated.json` (a prebuild artifact) was reverted — not part of this change.

## Covered vs deferred
- **Covered:** the `surface-content.tsx` rebuild + the 5 deep pages + keeping all 13 callers compiling.
- **Deferred:** repointing the back-link to `/capabilities` once #1004 merges.