### PR TITLE
docs(trust): trust: vocabulary (machine-readable TTL) + two-stratum semantics note (sq-pfae.2) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3727,6 +3727,7 @@ name = "sparq-trust"
 version = "0.1.0"
 dependencies = [
  "oxrdf 0.3.3",
+ "oxttl 0.2.3",
  "sparq-canon",
  "sparq-core",
  "sparq-reason",

--- a/crates/sparq-trust/Cargo.toml
+++ b/crates/sparq-trust/Cargo.toml
@@ -38,3 +38,9 @@ sparq-zk = { path = "../sparq-zk" }
 # The `forShape` statement-type primitive (forPredicate desugars to it; step 3).
 sparq-shacl = { path = "../sparq-shacl", default-features = false }
 oxrdf.workspace = true
+
+# Test-only: parse-validate the published machine-readable vocabulary
+# `ontologies/trust/trust.ttl` so the Turtle a working group reads stays valid
+# Turtle (sq-pfae.2). Not a runtime dependency — the lean default build is unaffected.
+[dev-dependencies]
+oxttl.workspace = true

--- a/crates/sparq-trust/README.md
+++ b/crates/sparq-trust/README.md
@@ -56,6 +56,12 @@ unchanged WAC/ACP view.
 - **The 10-term minimal ontology** (`vocab`) — `trust:TrustPolicy`, `TrustRule`,
   `trustsSourceFor`, `source`, `forShape`, `Source`, `issuerKey`, `scope`, `freshWithin`,
   `admitted` — plus the one `forPredicate → forShape` desugaring (sugar, not a primitive).
+  Published in machine-readable Turtle as
+  [`ontologies/trust/trust.ttl`](ontologies/trust/trust.ttl) (with the two-stratum
+  semantics, degenerate-`.acl` equivalence, and strict-additivity property pinned in
+  [`ontologies/trust/SEMANTICS.md`](ontologies/trust/SEMANTICS.md)); a sync test keeps
+  the Turtle and the Rust constants from drifting. **All `trust:` IRIs are NON-STANDARD,
+  invented for this proposal** — a WG would rename/rehome them.
 - **Fail-closed policy parsing** (`policy`) — a trust policy not presented through the
   Control-gated channel admits nothing (a type-level `ControlGate`).
 - **The admission gate** (`admit`) — canonicalise (`sparq-canon` RDFC-1.0), verify the issuer
@@ -86,6 +92,9 @@ unchanged WAC/ACP view.
 
 ## 📚 Learn more
 
+- The machine-readable vocabulary [`ontologies/trust/trust.ttl`](ontologies/trust/trust.ttl)
+  and its [`ontologies/trust/SEMANTICS.md`](ontologies/trust/SEMANTICS.md) normative
+  two-stratum semantics note (the `sq-pfae.2` doc + vocab artifact).
 - The design record `research/solid-trust-graph-authz-design.md` (§6.0 is the PoC spec; §7 the
   honest limitations) — tracked in [issue #940](https://github.com/jeswr/sparq/issues/940) and
   landing via design PR <https://github.com/jeswr/sparq/pull/951>.

--- a/crates/sparq-trust/ontologies/trust/SEMANTICS.md
+++ b/crates/sparq-trust/ontologies/trust/SEMANTICS.md
@@ -1,0 +1,201 @@
+<!-- [OPUS-4.8] sq-pfae.2 (issue #940 / gh-940). 🤖 SPARQ agent — trust-graph
+authorisation. Written while Fable unavailable; flag for re-review when Fable returns. -->
+# Trust-graph two-stratum semantics note (normative reference)
+
+> **Status — DESIGN-FOR-REVIEW, NOT a shipped guarantee.** This is the *normative
+> semantics reference* for the `trust:` vocabulary (`trust.ttl` in this directory). It
+> pins the two-stratum (admission / derivation) semantics, the degenerate-`.acl`
+> equivalence, and the strict-additivity property so the prototype phases (epic
+> `sq-pfae`) have one place to point at. It is a **proposal** to take to the LWS and
+> Solid working groups, not a security guarantee. The full motivation, soundness
+> argument, and honest limitations live in `research/solid-trust-graph-authz-design.md`
+> (this note is a focused, normatively-worded extract of §2.1, §2.3, §3, §5.2 and §7
+> G6 — the design record remains authoritative where they differ).
+>
+> Model: Opus 4.8 (Fable unavailable — flag for re-review when Fable returns).
+
+## 0. Scope and references
+
+This note defines the **meaning** of a trust graph: what it admits, what it derives,
+and the two structural properties a reviewer should be able to check by reading the
+definitions alone (degenerate-`.acl` equivalence and strict additivity). It is
+deliberately **doc + vocab only** (bead `sq-pfae.2`) — no new runtime capability. The
+admission *gate* that realises stratum 1 is the opt-in `sparq-trust` crate
+(`src/admit.rs`, PoC bead `sq-pfae.10`); the derivation *materialiser* that realises
+stratum 2 is the shipped `sparq-solid` WAC/ACP reasoner.
+
+| Concept here | Vocabulary term (`trust.ttl`) | Realised by |
+|---|---|---|
+| Admission gate | `trust:trustsSourceFor`, `trust:source`, `trust:forShape`, `trust:issuerKey`, `trust:scope`, `trust:freshWithin` | `sparq-trust::admit` (opt-in) |
+| Stratum-boundary marker | `trust:admitted` | the gate tags admitted facts |
+| Policy container / rule | `trust:TrustPolicy`, `trust:TrustRule`, `trust:Source` | `sparq-trust::policy` |
+| Derivation | the local `.acl`/`.acr` + ABAC N3 rules | shipped `sparq-solid` materialiser |
+
+## 1. The two strata
+
+The access decision is a **two-stage, stratified** reasoning pipeline. The strata are
+ordered: every relevant admission decision completes before any derivation rule reads
+its output. The boundary between them is the marker `trust:admitted`.
+
+```text
+   attested statements (VC claims, signed graphs)
+                 │
+                 ▼
+   ┌───────────────────────────────────────────────┐
+   │  STRATUM 1 — ADMISSION  (NEW, opt-in)          │
+   │  "is this fact from a source I trust for this  │
+   │   statement-type?"                             │
+   │  gate = matching trust rule (source × shape ×  │
+   │  scope) ∧ CHECKED issuer signature ∧ freshness │
+   │  ∧ not-revoked ∧ holder binding                │
+   └───────────────────────────────────────────────┘
+                 │  trust:admitted facts (issuer-tagged)
+                 ▼
+   ┌───────────────────────────────────────────────┐
+   │  STRATUM 2 — DERIVATION  (EXISTING, shipped)   │
+   │  the sparq-solid WAC/ACP N3 rules + any ABAC   │
+   │  rule (age>18 ⇒ canAccess) over admitted facts │
+   └───────────────────────────────────────────────┘
+                 │
+                 ▼
+        <urn:sparq:auth>  (allow-list, fail-closed)
+```
+
+### 1.1 Stratum 1 — Admission (the new contribution)
+
+A fact `S P O` carried by a presented, signed credential graph *G* is **admitted** —
+i.e. enters stratum 2 tagged `trust:admitted` and bound to its issuer — **iff ALL** of
+the following hold. (This is the conjunction worked through in design §3.1; the
+soundness of each conjunct is §3.3.)
+
+1. **A matching trust rule exists.** There is a `trust:TrustRule` whose `trust:source`
+   names a `trust:Source` *S′*, whose statement-type (`trust:forShape`, or the
+   `trust:forPredicate` sugar desugared to a single-predicate shape) the fact
+   *satisfies* under the shipped `sparq-shacl` validator, and whose `trust:scope`
+   covers the target resource.
+2. **The issuer signature is CHECKED, never self-asserted.** *G* is verified to be
+   signed by the key `trust:issuerKey` names for *S′*, over *G*'s RDFC-1.0 commitment.
+   A graph merely *claiming* `trust:issuerKey …` proves nothing. *(Caveat: the
+   `issuerKey → verifying-key` binding is operator-asserted until a DID resolver lands —
+   `sq-pfae.3`; this is the live forgery vector D′, design §3.3.)*
+3. **Freshness and revocation pass.** The credential is within `trust:freshWithin` of
+   `Session.now` and is not revoked. Both are **per-request side-conditions** —
+   freshness is a Rust check (time is not a reasoner fact); a `not-revoked` guard, if
+   used, must be NAF over an **input-only** `revoked` predicate (the shipped reasoner
+   rejects NAF over *derived* predicates). See §3 and `sq-tu4e`.
+4. **Holder binding.** The credential subject binds to the authenticated requester
+   (v1: `credentialSubject == Session.agent`, the clear-WebID degraded path — `sq-wvne`
+   / `sq-xc4y`). Presenting a third party's credential without holder binding does
+   **not** admit the fact.
+
+**Statement-type scoping is enforced HERE, at admission, not at derivation.** A source
+trusted for `schema:age` cannot launder an `acl:agent` or `solidx:` triple in: those
+predicates are not in its shape, so the admission test fails for them, and the
+reserved-derivation-predicate guard additionally forbids any source from asserting
+`solidx:`/`trust:admitted` internal vocabulary (design §3.3 item 2).
+
+**v1 admits only DIRECTLY-attested facts of a trusted type** — no entailment
+laundering (deriving `age` from an untrusted `birthDate` and inheriting trust). Trust
+propagation through the closure is explicitly out of v1 scope (design §3.3, G3).
+
+### 1.2 Stratum 2 — Derivation (the shipped substrate, unchanged)
+
+The shipped `sparq-solid` materialiser runs the local `.acl`/`.acr` WAC/ACP N3 rules —
+plus any ABAC rule such as `{ ?x schema:age ?y . ?y math:greaterThan 18 } => { ?x
+auth:read R }` — over **the union of the existing trusted inputs and the
+`trust:admitted` facts**, and materialises `<urn:sparq:auth>` exactly as today. Nothing
+in this stratum changes: it consumes the admitted facts as if they had always been
+trusted inputs, because stratum 1 has already vouched for them.
+
+### 1.3 Why the ordering is load-bearing
+
+The shipped reasoner is **no-retraction, stratified negation-as-failure**. Admission
+must be stratified strictly ahead of derivation so scoped-NAF stays sound: a derivation
+rule must never observe a fact mid-admission. **Open soundness question (`sq-xc4y`):**
+the shipped auth view is materialised once, session-independently, whereas holder
+binding and freshness are per-request — so a per-request, identity-bound admission
+decision cannot simply sit frozen ahead of a materialise-once view. v1 must either
+re-run admission per request for credential-gated resources, or split static admission
+(signature / type-scope, materialise-time) from dynamic admission (holder / freshness,
+query-time). This note records the constraint; it does **not** declare it solved.
+
+## 2. The degenerate-`.acl` equivalence
+
+> **Property (degenerate case).** A trust graph whose *only* statement trusts the
+> `.acl`/`.acr` document for all access-control predicates **reproduces WAC/ACP exactly**
+> (design §2.2, §5.2).
+
+Concretely: let the trust policy contain a single `trust:TrustRule` whose `trust:source`
+is the resource's own control document, whose statement-type covers the access-control
+predicates, and whose `trust:scope` is the resource/container. Then stratum 1 admits
+**exactly** the `.acl`/`.acr` rules the shipped loader already trusts (the control
+document is, by construction, signed/authoritative for its own resource), and stratum 2
+runs the identical WAC/ACP derivation over the identical input set. No external fact is
+admitted (there is no other trust rule), so the materialised `<urn:sparq:auth>` is
+identical to today's.
+
+Two named special cases fall out:
+
+- **WAC/ACP** is the degenerate case above: `.acl`/`.acr` as the one trusted source.
+- **Solid-OIDC** is the *n = 1* case: one issuer, one statement-type (the identity
+  assertion that the requester controls a WebID).
+
+This is the precise sense in which the trust graph is a **conservative
+generalisation**: today's single-trusted-source model is the one-rule instance of the
+many-rule model. RBAC/ABAC then appear by *adding* rules (a role-assignment predicate
+from HR; `schema:age` from a government) — never by changing how `.acl` is evaluated.
+
+## 3. The strict-additivity property (G6)
+
+> **Property (strict additivity, G6).** A pod with **no** trust graph behaves
+> **exactly** as WAC/ACP do today (design §2.2 G6, §7).
+
+This is stronger than the degenerate-`.acl` equivalence and is what makes the whole
+proposal safe to adopt incrementally. It holds at **two** levels:
+
+1. **Semantic additivity.** With an empty trust policy, stratum 1 admits **nothing**
+   (no trust rule ⇒ no external fact passes the gate ⇒ fail-closed). Stratum 2 then
+   runs over exactly the inputs it has today, so the access decision is **byte-identical**
+   to current WAC/ACP. Adding a trust rule can only **admit more** facts for the reasoner
+   to consider; it can never suppress an existing `.acl`/`.acr` grant or deny path — the
+   admission stratum is **monotone-add** with respect to the derivation inputs. (Conflict
+   between two *trusted* external attestations is a separate question with its own honest
+   caveats — design §3.5, `sq-tu4e` — and does not affect additivity over the *empty*
+   trust graph.)
+
+2. **Build / dependency additivity (opt-in by construction).** Nothing in the
+   workspace's default build depends on `sparq-trust`. `sparq-solid` pulls it in **only**
+   behind its default-OFF `trust-graph` cargo feature, so the lean core
+   (`sparq-core` / `sparq-engine` / `sparq-reason`) and the default `sparq-solid` build
+   are byte-identical with or without the trust-graph work. A pod that never enables the
+   feature pays nothing — no code, no dependency, no behaviour change. This is the
+   feature-gating discipline of `AGENTS.md` (new capability ⇒ opt-in crate/feature; core
+   stays lean) made concrete for this surface.
+
+**Why a reviewer can trust this from the definitions alone:** strict additivity is not
+an empirical claim about a running system; it is a structural consequence of (a)
+fail-closed admission over an empty rule set and (b) the derivation stratum being the
+*unmodified* shipped materialiser. Both are checkable by reading §1 above and the
+`sparq-trust` Cargo manifest (`default = []`, the feature wiring in `sparq-solid`).
+
+## 4. Honest limitations (do not over-read this note)
+
+This note pins **semantics and additivity**, nothing about privacy. In particular:
+
+- **No privacy / unlinkability / anonymity.** Admission verifies a CHECKED signature but
+  the credential is admitted **in the clear** — the verifier learns the exact value
+  (`age 25`, not "≥ 18"). This is **not** ZKAPs-grade unlinkable presentation.
+- **Holder binding is the clear-WebID, non-anonymous degraded path** (`sq-wvne` /
+  `sq-xc4y`).
+- **Issuer keys are operator-asserted** until a DID resolver lands (`sq-pfae.3`) — the
+  live forgery vector D′.
+- The ZK estate this design *could* compose with (`sparq-zk` / `sparq-zk-compose`) is
+  research-grade and **externally unaudited** — external accredited-cryptographer
+  sign-off is **pending** (`sq-qhy4`); `sparq-mpc` is honest-majority semi-honest only.
+- Open problems respected as documented limitations, never silently solved: `sq-xc4y`
+  (admission vs materialise-once), `sq-tu4e` (no in-reasoner NAF over derived facts;
+  no deny-on-disagreement), `sq-l5og` (delegation invocation binding), `sq-wvne` (ZK
+  privacy).
+
+See `research/solid-trust-graph-authz-design.md` §7 for the full, audited limitations
+list, and `crates/sparq-trust/README.md` for the PoC's honest scope.

--- a/crates/sparq-trust/ontologies/trust/trust.ttl
+++ b/crates/sparq-trust/ontologies/trust/trust.ttl
@@ -1,0 +1,143 @@
+# trust.ttl — the `trust:` vocabulary (machine-readable, normative form)
+#
+# [OPUS-4.8] sq-pfae.2 (issue #940 / gh-940). 🤖 SPARQ agent — trust-graph
+# authorisation. Written while Fable unavailable; flag for re-review when Fable
+# returns.
+#
+# This is the canonical, machine-readable rendering of the ten-term minimal
+# orthogonal ontology of `research/solid-trust-graph-authz-design.md` §2.3.1, plus
+# the ONE convenience (`trust:forPredicate`) that the design admits as SUGAR, not a
+# primitive (§2.3.3). It is byte-pinned against the Rust constants in
+# `crates/sparq-trust/src/vocab.rs` by the `ttl_term_iris_match_rust_constants`
+# sync test in that module — the two MUST NOT drift.
+#
+# *** ALL `trust:` IRIs ARE NON-STANDARD, INVENTED FOR THIS PROPOSAL. ***
+# `https://sparq.dev/ns/trust#` is a PLACEHOLDER namespace to make the semantics
+# concrete; it is NOT minted, NOT resolvable, and NOT a claim of standardisation. A
+# working group taking this design forward would rename/rehome every term. See the
+# `owl:Ontology` note below and the two-stratum semantics note `SEMANTICS.md` in this
+# directory.
+
+@prefix trust: <https://sparq.dev/ns/trust#> .
+@prefix sh:    <http://www.w3.org/ns/shacl#> .
+@prefix rdf:   <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:  <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:   <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:   <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+
+# --- ontology metadata -------------------------------------------------------
+
+trust: a owl:Ontology ;
+  rdfs:label "Trust-graph authorisation vocabulary (NON-STANDARD, proposal)"@en ;
+  dcterms:description """The minimal orthogonal vocabulary for trust-graph
+authorisation over Solid/LWS: per-(source, statement-type) trust over issuer-attested
+statements that an N3 reasoner merges with the local .acl/.acr rules to derive access.
+EVERY term here is NON-STANDARD and invented for this proposal; the namespace is a
+placeholder. Companion: SEMANTICS.md (two-stratum semantics, degenerate-.acl
+equivalence, strict additivity) and research/solid-trust-graph-authz-design.md."""@en ;
+  rdfs:seeAlso <https://github.com/jeswr/sparq/issues/940> ;
+  rdfs:comment "Placeholder namespace; a WG would rename/rehome every term."@en .
+
+# =============================================================================
+# The ten-term irreducible core (design §2.3.1 / §2.3.2)
+# =============================================================================
+# Each term occupies a distinct, non-overlapping role; none can be derived from a
+# combination of the others (the irreducibility argument, §2.3.2). The
+# domain/range below are DESCRIPTIVE of the intended use, not RDFS-entailment
+# directives the admission engine relies on — admission soundness rests on the
+# CHECKED issuer signature + SHACL statement-type scoping (§3.3), never on
+# RDFS/OWL inference over attacker-supplied input.
+
+# --- classes -----------------------------------------------------------------
+
+trust:TrustPolicy a rdfs:Class, owl:Class ;
+  rdfs:label "Trust policy"@en ;
+  rdfs:comment "The policy container: a set of admission rules scoping a resource or server. The administrable unit; authored in the same Control-gated channel as .acl/.acr (§3.2)."@en ;
+  rdfs:isDefinedBy trust: .
+
+trust:TrustRule a rdfs:Class, owl:Class ;
+  rdfs:label "Trust rule"@en ;
+  rdfs:comment "One reified admission rule, grouping a source + statement-type + scope + freshness condition under a single node. Reification is what makes a rule the unit of conflict, override, and audit (§2.3.2 item 2)."@en ;
+  rdfs:isDefinedBy trust: .
+
+trust:Source a rdfs:Class, owl:Class ;
+  rdfs:label "Attesting source"@en ;
+  rdfs:comment "An attesting authority, identified by an issuer key / DID. Simultaneously the object of trust:source and the subject of trust:issuerKey (§2.3.2 item 6)."@en ;
+  rdfs:isDefinedBy trust: .
+
+# --- properties: the core relation ------------------------------------------
+
+trust:trustsSourceFor a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "trusts source for"@en ;
+  rdfs:comment "THE core relation: admit statements of this type (shape) from this source — i.e. 'trust source S for statement-type T'. The only term that expresses per-(source, statement-type) scoping; every other term names a participant in, or constrains, this relation (§2.3.2 item 3). Renders RT/PERMIS-style typed-issuer trust as RDF a Solid reasoner can merge with local rules (§2.2)."@en ;
+  rdfs:domain trust:Source ;
+  rdfs:range sh:NodeShape ;
+  rdfs:isDefinedBy trust: .
+
+# --- properties: rule participants ------------------------------------------
+
+trust:source a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "source"@en ;
+  rdfs:comment "The attesting source a trust rule names. Connects a rule to a NAMED trust:Source so one source can be referenced across many rules without key duplication (§2.3.2 item 4)."@en ;
+  rdfs:domain trust:TrustRule ;
+  rdfs:range trust:Source ;
+  rdfs:isDefinedBy trust: .
+
+trust:forShape a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "for shape"@en ;
+  rdfs:comment "Statement-type as a SHACL shape: THE one statement-type primitive (§2.3.2 item 5). A SHACL shape is the most general type constraint in the set — predicate-only, cardinality, value-range, and conjunctive constraints are all shapes. Evaluated by the shipped sparq-shacl validator as the admission side-condition; cannot be reduced backward to anything coarser. trust:forPredicate is sugar that desugars INTO this (never the reverse)."@en ;
+  rdfs:domain trust:TrustRule ;
+  rdfs:range sh:NodeShape ;
+  rdfs:isDefinedBy trust: .
+
+trust:issuerKey a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "issuer key"@en ;
+  rdfs:comment "The cryptographic binding 'source S's verification key is K' — the load-bearing gate for signature verification at admission (§3.3 item 1). Aligns with zk:issuerKey on the existing sparq-zk estate. NB sparq has no DID resolver yet (sq-pfae.3): until then the binding is operator-asserted, the live forgery vector D' (§3.3)."@en ;
+  rdfs:domain trust:Source ;
+  rdfs:range rdfs:Resource ;
+  rdfs:isDefinedBy trust: .
+
+trust:scope a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "scope"@en ;
+  rdfs:comment "Where the trust rule applies (server-wide vs per-.acr / per-resource). Orthogonal to source and statement-type — the same (source, type) pair may be trusted for resource A but not B — so it cannot be derived from them (§2.3.2 item 8). Per-.acr rules narrow, never broaden, a server default (§3.2)."@en ;
+  rdfs:domain trust:TrustRule ;
+  rdfs:range rdfs:Resource ;
+  rdfs:isDefinedBy trust: .
+
+trust:freshWithin a rdf:Property, owl:DatatypeProperty ;
+  rdfs:label "fresh within"@en ;
+  rdfs:comment "Maximum staleness admitted, as an xsd:duration consulted against Session.now. The temporal gate, orthogonal to source/type/scope (§2.3.2 item 9). It MUST be enforced as a per-request Rust side-condition, NOT an in-reasoner predicate (§3.3) — time is not a reasoner fact."@en ;
+  rdfs:domain trust:TrustRule ;
+  rdfs:range xsd:duration ;
+  rdfs:isDefinedBy trust: .
+
+trust:admitted a rdf:Property ;
+  rdfs:label "admitted"@en ;
+  rdfs:comment "INTERNAL stratum-boundary marker: tags a fact that PASSED admission, enabling the stratified separation of admission from derivation (§2.1, §2.3.2 item 10). Analogous to the solidx: internal vocab; reserved — an external source may NOT assert it (the reserved-derivation-predicate guard, §3.3 item 2). Without it the two-stratum architecture collapses and the §3.3 soundness argument has nothing to hang on."@en ;
+  rdfs:isDefinedBy trust: .
+
+# =============================================================================
+# The ONE convenience — SUGAR, not a primitive (design §2.3.3)
+# =============================================================================
+# The SOLE purely-syntactic redundancy the de-dup pass found. Kept for ergonomics
+# but DEFINED WHOLLY BY ITS DESUGARING, so a WG standardises only trust:forShape.
+# `trust:forPredicate P` desugars (at load time) to a single-predicate forShape:
+#
+#   [] a sh:NodeShape ;
+#      sh:targetSubjectsOf P ;
+#      sh:property [ sh:path P ; sh:minCount 1 ] .
+#
+# The rewrite is lossless in the predicate-only direction and runs the genuine,
+# shipped sparq-shacl target/path mechanism (there is no sh:targetPredicate in
+# SHACL). Implemented by `sparq_trust::vocab::desugar_for_predicate`. v1 ships
+# `forPredicate` as the default surface syntax and `forShape` as the expressive
+# upgrade — but the NORMATIVE vocabulary is `forShape` alone.
+
+trust:forPredicate a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "for predicate (SUGAR)"@en ;
+  rdfs:comment "SUGAR — NOT a primitive. Shorthand for a single-predicate trust:forShape: 'admit a source for all triples on predicate P'. Defined wholly by its desugaring (§2.3.3); adds no expressivity forShape lacks. Standardise trust:forShape, not this."@en ;
+  rdfs:domain trust:TrustRule ;
+  rdfs:range rdfs:Resource ;
+  rdfs:subPropertyOf trust:forShape ;
+  rdfs:isDefinedBy trust: .

--- a/crates/sparq-trust/src/vocab.rs
+++ b/crates/sparq-trust/src/vocab.rs
@@ -9,8 +9,16 @@
 //! All `trust:` IRIs are **NON-STANDARD, invented for this proposal** (a placeholder
 //! namespace to make the semantics concrete); a WG would rename/rehome them.
 //!
-//! [OPUS-4.8] sq-pfae PoC (issue #940). Flag for re-review when Fable returns.
-//! 🤖 SPARQ agent — trust-graph authorisation PoC.
+//! The canonical, machine-readable form of this vocabulary is
+//! [`ontologies/trust/trust.ttl`](https://github.com/jeswr/sparq/blob/main/crates/sparq-trust/ontologies/trust/trust.ttl)
+//! (Turtle, with `rdfs:label`/`rdfs:comment`/`rdfs:domain`/`rdfs:range`), and its
+//! two-stratum semantics — admission/derivation, the degenerate-`.acl` equivalence,
+//! and the strict-additivity property (G6) — are pinned in the companion
+//! `ontologies/trust/SEMANTICS.md`. The `ttl_pins_match_rust_constants` test below
+//! keeps the published Turtle and these Rust constants from drifting.
+//!
+//! [OPUS-4.8] sq-pfae PoC (issue #940); vocab/semantics note pinned in sq-pfae.2.
+//! Flag for re-review when Fable returns. 🤖 SPARQ agent — trust-graph authorisation.
 
 use oxrdf::{BlankNode, Literal, NamedNode, NamedOrBlankNode, Term, Triple};
 
@@ -169,5 +177,79 @@ mod tests {
         let (a, _) = desugar_for_predicate(&p);
         let (b, _) = desugar_for_predicate(&p);
         assert_ne!(a, b, "fresh blank nodes — desugarings never collide");
+    }
+
+    /// No-drift guard for sq-pfae.2: every `trust:` IRI these Rust constants name
+    /// MUST appear (as a subject) in the published machine-readable vocabulary
+    /// `ontologies/trust/trust.ttl`, and vice-versa. If a term is renamed/added in
+    /// one and not the other this test fails — the published Turtle a working group
+    /// reads and the constants the admission gate uses cannot silently diverge.
+    #[test]
+    fn ttl_pins_match_rust_constants() {
+        // The published Turtle vocabulary (Doc + vocab artifact of sq-pfae.2).
+        const TTL: &str = include_str!("../ontologies/trust/trust.ttl");
+
+        // The full set of `trust:` IRIs the Rust core + the one sugar name.
+        let constants: &[&str] = &[
+            TRUST_POLICY,
+            TRUST_RULE,
+            TRUSTS_SOURCE_FOR,
+            SOURCE,
+            FOR_SHAPE,
+            SOURCE_CLASS,
+            ISSUER_KEY,
+            SCOPE,
+            FRESH_WITHIN,
+            ADMITTED,
+            FOR_PREDICATE,
+        ];
+
+        // Every constant must be declared in the Turtle (as `trust:LocalName a …`).
+        for &iri in constants {
+            let local = iri
+                .strip_prefix(TRUST_NS)
+                .expect("every constant is in the trust: namespace");
+            let decl = format!("trust:{local} a ");
+            assert!(
+                TTL.contains(&decl),
+                "trust.ttl is missing a declaration for `trust:{local}` ({iri}) — \
+                 the published vocabulary drifted from the Rust constants (sq-pfae.2)",
+            );
+        }
+
+        // And every `trust:LocalName a` declaration in the Turtle must be backed by a
+        // Rust constant — no published term without a constant. Scan declaration lines.
+        let declared_locals: Vec<&str> = TTL
+            .lines()
+            .filter_map(|line| {
+                let t = line.trim_start();
+                let rest = t.strip_prefix("trust:")?;
+                // `trust: a owl:Ontology` is the ontology-node line (bare namespace IRI):
+                // the char right after the colon is whitespace, so it has no local name —
+                // it is metadata, not a term. Skip it.
+                if rest.starts_with(char::is_whitespace) {
+                    return None;
+                }
+                // A term declaration line looks like `trust:Foo a …`.
+                let name = rest.split_whitespace().next()?;
+                if rest[name.len()..].trim_start().starts_with("a ") {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert!(
+            !declared_locals.is_empty(),
+            "no trust: term declarations found in trust.ttl — parser/format drift",
+        );
+        for local in declared_locals {
+            let full = format!("{TRUST_NS}{local}");
+            assert!(
+                constants.contains(&full.as_str()),
+                "trust.ttl declares `trust:{local}` but no Rust constant names it — \
+                 add the constant or remove the term (sq-pfae.2)",
+            );
+        }
     }
 }

--- a/crates/sparq-trust/tests/vocab_ttl.rs
+++ b/crates/sparq-trust/tests/vocab_ttl.rs
@@ -1,0 +1,66 @@
+//! Parse-validation of the published machine-readable vocabulary
+//! `ontologies/trust/trust.ttl` (sq-pfae.2). The Turtle a working group reads MUST
+//! stay valid Turtle and MUST declare exactly the ten core terms + the one sugar
+//! term. The `vocab::tests::ttl_pins_match_rust_constants` unit test additionally
+//! pins the IRIs against the Rust constants; this test is the *syntactic* guard.
+//!
+//! [OPUS-4.8] sq-pfae.2 (issue #940). 🤖 SPARQ agent — trust-graph authorisation.
+
+use oxttl::TurtleParser;
+
+const TTL: &str = include_str!("../ontologies/trust/trust.ttl");
+
+/// The published vocabulary is valid Turtle (it parses without error) and is
+/// non-empty.
+#[test]
+fn trust_ttl_is_valid_turtle() {
+    let mut triples = 0usize;
+    for result in TurtleParser::new().for_reader(TTL.as_bytes()) {
+        result.expect("trust.ttl must be valid Turtle");
+        triples += 1;
+    }
+    assert!(
+        triples > 0,
+        "trust.ttl parsed to zero triples — the published vocabulary is empty",
+    );
+}
+
+/// Every one of the eleven term IRIs (ten core + the one sugar) is declared in the
+/// Turtle as a subject. This is a coarse presence check independent of the unit-test
+/// constant pinning, so a refactor of `vocab.rs` cannot silently drop a published
+/// term from the gate.
+#[test]
+fn trust_ttl_declares_all_eleven_terms() {
+    use oxrdf::NamedOrBlankNode;
+
+    const NS: &str = "https://sparq.dev/ns/trust#";
+    let expected = [
+        "TrustPolicy",
+        "TrustRule",
+        "Source",
+        "trustsSourceFor",
+        "source",
+        "forShape",
+        "issuerKey",
+        "scope",
+        "freshWithin",
+        "admitted",
+        "forPredicate",
+    ];
+
+    let mut subjects = std::collections::HashSet::new();
+    for result in TurtleParser::new().for_reader(TTL.as_bytes()) {
+        let t = result.expect("valid Turtle");
+        if let NamedOrBlankNode::NamedNode(s) = t.subject {
+            subjects.insert(s.into_string());
+        }
+    }
+
+    for local in expected {
+        let iri = format!("{NS}{local}");
+        assert!(
+            subjects.contains(&iri),
+            "trust.ttl does not declare `trust:{local}` ({iri}) as a subject",
+        );
+    }
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — opened by an automated agent working on the sparq engine (model: Opus 4.8 [1m]; @jeswr runs several agents on one account). Flag for re-review when Fable returns.

## What

Implements **sq-pfae.2** (`P1: trust-graph vocabulary + two-stratum semantics note`, surface P1; gh-940) — the **doc + vocab only** foundational artifact that **blocks all the trust-graph prototype phases** under epic `sq-pfae`. It pins, in canonical and machine-readable form, what the design record `research/solid-trust-graph-authz-design.md` §2–§3 specifies in prose.

### Deliverables

- **`crates/sparq-trust/ontologies/trust/trust.ttl`** — the canonical machine-readable rendering of the **ten-term minimal orthogonal ontology** (design §2.3.1) plus the **one** `trust:forPredicate → trust:forShape` convenience that the design admits as **sugar, not a primitive** (§2.3.3). Each term carries `rdfs:label`/`rdfs:comment` and (where applicable) `rdfs:domain`/`rdfs:range`; an `owl:Ontology` header flags **every `trust:` IRI as NON-STANDARD, invented for this proposal** (the `https://sparq.dev/ns/trust#` namespace is a placeholder a WG would rename/rehome).
- **`crates/sparq-trust/ontologies/trust/SEMANTICS.md`** — the **normative two-stratum semantics note**:
  - the **admission / derivation** strata and the `trust:admitted` stratum boundary (the four admission conjuncts; statement-type scoping enforced at admission, not derivation; v1 admits only directly-attested facts — no entailment laundering);
  - the **degenerate-`.acl` equivalence** (WAC/ACP as the one-rule case; Solid-OIDC as the *n = 1* case);
  - the **strict-additivity property (G6)** at *two* levels — semantic (empty trust graph ⇒ byte-identical to today's WAC/ACP, fail-closed, monotone-add) and build/dependency (opt-in by construction; `sparq-trust` pulled in only behind `sparq-solid`'s default-OFF `trust-graph` feature, lean core unchanged);
  - an **honest-limitations** section pinning the open problems (`sq-xc4y`, `sq-tu4e`, `sq-l5og`, `sq-wvne`) as documented limitations, never silently "solved" — no privacy/unlinkability, clear-WebID holder binding, operator-asserted issuer keys until `sq-pfae.3`, unaudited ZK estate (`sq-qhy4`).
- **`vocab.rs`** — `ttl_pins_match_rust_constants` no-drift guard (the published Turtle and the Rust `vocab` constants cannot diverge in either direction) + a docs pointer to the TTL/SEMANTICS files.
- **`tests/vocab_ttl.rs`** (test-only `oxttl` dev-dependency) — the published Turtle stays **valid Turtle** and declares **exactly the eleven** terms.

## Best-judgment decisions (documented per the standing rule)

The bead is doc + vocab; it underspecified *where* the artifacts live and *how strongly* to bind them. Decisions made (steerable later):

1. **Location** — vocab + semantics live under `crates/sparq-trust/ontologies/trust/`, mirroring the existing vendored `ontologies/zkp-sparql/` convention, so the vocabulary ships with the crate that realises its admission stratum (rather than `research/`, which already holds the *design record*).
2. **Bind, don't just describe** — added two test-only guards (constant↔TTL sync; TTL validity/completeness) so the published vocabulary cannot silently drift from the Rust constants the PoC gate uses. These are test-only (dev-dep), so they respect "doc + vocab only; no [runtime] code" and the strict-additivity / lean-core posture.
3. **`rdfs:domain`/`range` are descriptive, not entailment directives** — stated explicitly in `trust.ttl`; admission soundness rests on the checked signature + SHACL scoping (§3.3), never on RDFS/OWL inference over attacker input.

A short GitHub issue will flag these for the maintainer to steer.

## Gates (all green, both feature states)

- `cargo clippy -p sparq-trust --all-targets --all-features -D warnings` ✅ (sparq-trust has no own features; default == all-features)
- `cargo fmt -p sparq-trust --check` ✅
- `RUSTDOCFLAGS=-D warnings cargo doc -p sparq-trust --all-features` ✅
- `scripts/check-readme-template.py` ✅ (0 deviations / 37 READMEs)
- `scripts/check-privacy-claims.sh` ✅ (clean)
- `markdownlint-cli2` ✅ (0 errors / 228 files) · `typos` ✅
- `cargo test -p sparq-trust` ✅ · `cargo build -p sparq-solid --features trust-graph` ✅

Closes sq-pfae.2. Auto-merge intentionally **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)