### PR TITLE
feat(sparq-trust): static/dynamic admission split — per-request holder/freshness vs the materialize-once auth view (sq-xc4y) [OPUS-4.8]

### DIFF
--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -48,9 +48,10 @@ pub use odrl_bridge::{
 };
 #[cfg(feature = "odrl-bridge")]
 pub use odrl_bridge::{BridgeEntry, BridgeKind, BridgeLedger};
-// [OPUS-4.8] sq-pfae PoC: the trust-graph admission outcome type (feature-gated).
+// [OPUS-4.8] sq-pfae PoC: the trust-graph admission outcome types (feature-gated).
+// `TrustStaticOutcome` is the materialise-time (static/dynamic split, sq-xc4y) result.
 #[cfg(feature = "trust-graph")]
-pub use trust_wire::TrustAdmissionOutcome;
+pub use trust_wire::{TrustAdmissionOutcome, TrustStaticOutcome};
 pub use rewrite::{rewrite_for, wrap_for_view};
 
 use oxrdf::{NamedNode, Term};

--- a/crates/sparq-solid/src/trust_wire.rs
+++ b/crates/sparq-solid/src/trust_wire.rs
@@ -14,24 +14,45 @@
 //! ODRL-bridge grant-injection precedent. Everything downstream (the session-scoped
 //! `∪ allow ∖ ∪ deny` enforcement, the query rewrite) is the existing shipped code.
 //!
+//! ## Two install paths — the `sq-xc4y` static / dynamic split (read first)
+//!
+//! Admission has a session-INDEPENDENT (STATIC) class and a per-request (DYNAMIC)
+//! class. There are TWO install methods, and choosing the wrong one is a soundness bug:
+//!
+//! - [`PodStore::admit_trust_credential_static`] is the **materialise-time** path. It
+//!   runs ONLY the static class (`sparq_trust::admit_static`) and installs each derived
+//!   grant as a **conditional grant** (`auth:ConditionalGrant`) whose holder
+//!   (`auth:agent`) and freshness (`auth:notAfter`) are re-checked **per request** by
+//!   the shipped sq-0q7n `AuthIndex::cond_applies` path. This composes with the
+//!   materialise-once epoch cache: the static decision is frozen, the DYNAMIC
+//!   holder/freshness verdict is NOT — a stale or wrong-holder credential is denied at
+//!   query time without a re-materialise. **Use this for the materialise-once view.**
+//! - [`PodStore::admit_trust_credential_and_materialize`] (and `_with_rule`) is the
+//!   **single-request snapshot** path. It runs the COMBINED gate against one live
+//!   `Session` and installs an UNCONDITIONAL grant valid for *that* request only.
+//!   Calling it once freezes a per-request decision into the view — so it MUST be
+//!   re-run per request, or used only for an ephemeral, request-scoped view. **Do NOT
+//!   use it to populate a long-lived materialise-once view.**
+//!
 //! ## Honest scope (load-bearing — RESEARCH, NOT a security guarantee)
 //!
 //! The gate verifies a CHECKED issuer signature, but it does **NOT** deliver privacy,
 //! unlinkability, or anonymity: the credential is admitted in the clear and the holder
 //! binding authenticates the WebID in the clear (the non-anonymous degraded path,
 //! `sq-wvne` / `sq-xc4y`). The ZK estate it composes with is externally **UNAUDITED**
-//! (`sq-qhy4`). Admission MUST be re-run per request for credential-gated resources
-//! (`sq-xc4y`) — calling this once does not freeze a per-request decision into the
-//! materialise-once view. Full scope: the `sparq-trust` crate docs + README.
+//! (`sq-qhy4`). Full scope: the `sparq-trust` crate docs + README.
 //!
 //! [OPUS-4.8] sq-pfae PoC. 🤖 SPARQ agent — trust-graph authorisation PoC.
 
-use crate::{PodStore, AUTH_GRAPH};
-use oxrdf::{NamedNode, Term, Triple};
+use crate::authindex::{ANY_CLIENT, ANY_ISSUER};
+use crate::{PodStore, AUTH_GRAPH, AUTH_NS};
+use oxrdf::{Literal, NamedNode, Term, Triple};
 use sparq_core::Graph;
-use sparq_trust::admit::{admit, AdmittedFact, PresentedCredential, Session as TrustSession};
+use sparq_trust::admit::{
+    admit, admit_static, AdmittedFact, PresentedCredential, Session as TrustSession,
+};
 use sparq_trust::policy::TrustRule;
-use sparq_trust::wire::derive_grants;
+use sparq_trust::wire::{derive_conditional_grants, derive_grants, ConditionalGrant};
 
 /// What the trust-graph admission pass decided and installed.
 #[derive(Debug, Clone, Default)]
@@ -42,6 +63,20 @@ pub struct TrustAdmissionOutcome {
     /// The `auth:*` grant triples derived by merging the admitted facts with the
     /// `.acr` ABAC rule and installed into `<urn:sparq:auth>` (possibly empty).
     pub installed_grants: Vec<Triple>,
+}
+
+/// What the **static** (materialise-time) trust-graph admission pass decided and
+/// installed (the `sq-xc4y` static/dynamic split — see
+/// [`PodStore::admit_trust_credential_static`]).
+#[derive(Debug, Clone, Default)]
+pub struct TrustStaticOutcome {
+    /// The conditional grants derived from the statically-admitted facts. Each carries
+    /// the bound holder + the freshness deadline as DYNAMIC conditions re-checked per
+    /// request (NOT a frozen unconditional allow).
+    pub conditional_grants: Vec<ConditionalGrant>,
+    /// The number of distinct `auth:ConditionalGrant` head-triple sets installed into
+    /// `<urn:sparq:auth>` (one per derived conditional grant).
+    pub installed_count: usize,
 }
 
 impl PodStore {
@@ -96,6 +131,11 @@ impl PodStore {
     /// `{ ?x schema:age ?y . ?y math:greaterThan 18 } => { ?x auth:read <r> }`),
     /// rather than reading it from the store. This is the v1 PoC entry point: the rule
     /// is the trusted root carried in the Control-gated `.acr` channel.
+    ///
+    /// **Snapshot path (`sq-xc4y`).** Like `admit_trust_credential_and_materialize`,
+    /// this installs an UNCONDITIONAL grant valid for the supplied `session` only. To
+    /// populate a long-lived materialise-once view, use
+    /// [`PodStore::admit_trust_credential_static`] instead.
     pub fn admit_trust_credential_with_rule(
         &mut self,
         credential: &PresentedCredential,
@@ -113,6 +153,61 @@ impl PodStore {
         Ok(TrustAdmissionOutcome {
             admitted,
             installed_grants: grants,
+        })
+    }
+
+    /// Run the **STATIC** trust-graph admission pass (the materialise-time half of the
+    /// `sq-xc4y` split) over a presented `credential`, derive the `auth:*` grants by
+    /// merging the statically-admitted facts with the controller-authored `.acr`
+    /// `abac_rule_n3`, and install each as a **conditional grant**
+    /// (`auth:ConditionalGrant`) into `<urn:sparq:auth>`.
+    ///
+    /// Unlike [`PodStore::admit_trust_credential_with_rule`], this takes **no
+    /// `Session`**: it decides only the session-INDEPENDENT class (signature,
+    /// statement-type scope, reserved-predicate guard, `trust:scope`) and DEFERS the
+    /// per-request holder binding + freshness to the installed conditional grant. The
+    /// grant's `auth:agent` is the credential subject (re-checked against
+    /// `Session.agent` per request) and its `auth:notAfter` is `issued_at + freshWithin`
+    /// rendered as an `xsd:dateTime` (re-checked against `Session.now` per request) — the
+    /// shipped sq-0q7n path. So a request as the wrong holder, or after the credential
+    /// lapses, is denied at **query time** without a re-materialise, and the dynamic
+    /// decision is **never frozen** into the materialise-once view. This is the install
+    /// path to use for a long-lived view.
+    ///
+    /// The grants are **appended** on top of the current (WAC/ACP) view — a trust-graph
+    /// grant can never drop a WAC/ACP grant.
+    ///
+    /// # Honest scope
+    ///
+    /// RESEARCH prototype, NOT a security guarantee. No privacy / unlinkability /
+    /// anonymity; the holder binding is clear-WebID (`sq-wvne`); the ZK estate is
+    /// externally unaudited (`sq-qhy4`). See the module + `sparq-trust` docs.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err` only if the N3 merge of the statically-admitted facts with
+    /// `abac_rule_n3` fails to reason (a malformed rule). Admission itself never errors:
+    /// a credential that fails any static gate simply admits nothing (fail-closed).
+    pub fn admit_trust_credential_static(
+        &mut self,
+        credential: &PresentedCredential,
+        rules: &[TrustRule],
+        target: &NamedNode,
+        abac_rule_n3: &str,
+    ) -> Result<TrustStaticOutcome, String> {
+        let statics = admit_static(credential, rules, target);
+        let conditional_grants = derive_conditional_grants(&statics, abac_rule_n3)?;
+        let mut installed_count = 0usize;
+        for cg in &conditional_grants {
+            install_conditional_grant(&mut self.graph, target, cg);
+            installed_count += 1;
+        }
+        if installed_count > 0 {
+            self.reindex();
+        }
+        Ok(TrustStaticOutcome {
+            conditional_grants,
+            installed_count,
         })
     }
 }
@@ -145,16 +240,156 @@ fn install_auth_grants(graph: &mut Graph, grants: &[Triple]) {
             terms.push(triple);
         }
     }
-    // Re-intern into a fresh sub-graph dictionary (mirrors install_auth_view).
+    write_back_auth_terms(graph, &g_name, terms);
+}
+
+/// Install one `auth:ConditionalGrant` for a derived trust-graph grant, with its DYNAMIC
+/// conditions (holder + freshness) carried as data the shipped sq-0q7n
+/// `AuthIndex::cond_applies` path re-checks **per request** — the materialise-time half
+/// of the `sq-xc4y` split. The head is the SAME shape the ODRL bridge emits
+/// (`append_conditional_grants`), so it is honoured by the unchanged session-scoped
+/// evaluator:
+///
+/// - `auth:effect auth:Allow` — a conditional allow;
+/// - `auth:agent <holder>` — the bound holder, re-checked against `Session.agent`
+///   per request (the deferred DYNAMIC holder binding; a different requester never
+///   matches);
+/// - `auth:client auth:AnyClient` / `auth:issuer auth:AnyIssuer` — a trust-graph grant
+///   carries no client/issuer constraint (it spans those dimensions' tops, stated
+///   explicitly so the fail-closed head convention applies);
+/// - `auth:mode <acl#…>` + `auth:graph <target>` — the access this grant confers;
+/// - `auth:notAfter "<issued_at+freshWithin>"^^xsd:dateTime` — the freshness deadline,
+///   re-checked against `Session.now` per request (the deferred DYNAMIC freshness check;
+///   a lapsed credential denies *that request* without a re-materialise).
+fn install_conditional_grant(graph: &mut Graph, target: &NamedNode, cg: &ConditionalGrant) {
+    let Some(mode_iri) = mode_iri_for_auth_pred(cg.grant.predicate.as_str()) else {
+        return; // not an auth:read|write|append|control grant → nothing to install
+    };
+    let g_name = Term::NamedNode(NamedNode::new_unchecked(AUTH_GRAPH));
+    let mut terms: Vec<[Term; 3]> = match graph.named.iter().find(|(n, _)| *n == g_name) {
+        Some((_, sub)) => crate::loader::graph_triples(sub),
+        None => Vec::new(),
+    };
+
+    let not_after = unix_to_xsd_datetime(cg.not_after_unix_secs);
+    // A deterministic grant IRI keyed on (holder, mode, graph, notAfter) so re-running
+    // static admission for the same credential is idempotent (no duplicate heads) and a
+    // different freshness deadline does not silently overwrite an earlier one.
+    let grant_iri = format!(
+        "urn:sparq:trust-cond?agent={}&mode={}&graph={}&notAfter={}",
+        sparq_reason::n3::encode_for_uri(cg.holder.as_str()),
+        sparq_reason::n3::encode_for_uri(mode_iri),
+        sparq_reason::n3::encode_for_uri(target.as_str()),
+        sparq_reason::n3::encode_for_uri(&not_after),
+    );
+    let g = Term::NamedNode(NamedNode::new_unchecked(&grant_iri));
+    let xsd_datetime = NamedNode::new_unchecked("http://www.w3.org/2001/XMLSchema#dateTime");
+    let head: Vec<[Term; 3]> = vec![
+        [
+            g.clone(),
+            Term::NamedNode(NamedNode::new_unchecked(
+                "http://www.w3.org/1999/02/22-rdf-syntax-ns#type",
+            )),
+            Term::NamedNode(NamedNode::new_unchecked(format!(
+                "{AUTH_NS}ConditionalGrant"
+            ))),
+        ],
+        [
+            g.clone(),
+            Term::NamedNode(NamedNode::new_unchecked(format!("{AUTH_NS}effect"))),
+            Term::NamedNode(NamedNode::new_unchecked(format!("{AUTH_NS}Allow"))),
+        ],
+        [
+            g.clone(),
+            Term::NamedNode(NamedNode::new_unchecked(format!("{AUTH_NS}agent"))),
+            Term::NamedNode(cg.holder.clone()),
+        ],
+        [
+            g.clone(),
+            Term::NamedNode(NamedNode::new_unchecked(format!("{AUTH_NS}client"))),
+            Term::NamedNode(NamedNode::new_unchecked(ANY_CLIENT)),
+        ],
+        [
+            g.clone(),
+            Term::NamedNode(NamedNode::new_unchecked(format!("{AUTH_NS}issuer"))),
+            Term::NamedNode(NamedNode::new_unchecked(ANY_ISSUER)),
+        ],
+        [
+            g.clone(),
+            Term::NamedNode(NamedNode::new_unchecked(format!("{AUTH_NS}mode"))),
+            Term::NamedNode(NamedNode::new_unchecked(mode_iri)),
+        ],
+        [
+            g.clone(),
+            Term::NamedNode(NamedNode::new_unchecked(format!("{AUTH_NS}graph"))),
+            Term::NamedNode(target.clone()),
+        ],
+        [
+            g,
+            Term::NamedNode(NamedNode::new_unchecked(format!("{AUTH_NS}notAfter"))),
+            Term::Literal(Literal::new_typed_literal(not_after, xsd_datetime)),
+        ],
+    ];
+    for t in head {
+        if !terms.contains(&t) {
+            terms.push(t);
+        }
+    }
+    write_back_auth_terms(graph, &g_name, terms);
+}
+
+/// Re-intern the `<urn:sparq:auth>` sub-graph from a flat term list and write it back
+/// (mirrors `install_auth_view`). Shared by the unconditional + conditional installers.
+fn write_back_auth_terms(graph: &mut Graph, g_name: &Term, terms: Vec<[Term; 3]>) {
     let mut dict = sparq_core::dict::Dict::new();
     let ids: Vec<[sparq_core::dict::Id; 3]> = terms
         .iter()
         .map(|t| [dict.intern(&t[0]), dict.intern(&t[1]), dict.intern(&t[2])])
         .collect();
     let sub = Graph::from_parts(dict, ids);
-    if let Some(slot) = graph.named.iter_mut().find(|(n, _)| *n == g_name) {
+    if let Some(slot) = graph.named.iter_mut().find(|(n, _)| n == g_name) {
         slot.1 = sub;
     } else {
-        graph.named.push((g_name, sub));
+        graph.named.push((g_name.clone(), sub));
     }
+}
+
+/// Map a derived `auth:read|write|append|control` predicate IRI to its `acl:` mode IRI
+/// (the `auth:mode` object on a conditional grant). Returns `None` for any non-mode
+/// `auth:` predicate (fail-closed: nothing installed).
+fn mode_iri_for_auth_pred(pred: &str) -> Option<&'static str> {
+    match pred.strip_prefix(AUTH_NS)? {
+        "read" => Some("http://www.w3.org/ns/auth/acl#Read"),
+        "write" => Some("http://www.w3.org/ns/auth/acl#Write"),
+        "append" => Some("http://www.w3.org/ns/auth/acl#Append"),
+        "control" => Some("http://www.w3.org/ns/auth/acl#Control"),
+        _ => None,
+    }
+}
+
+/// Epoch seconds (UTC) → an `xsd:dateTime` lexical `YYYY-MM-DDTHH:MM:SSZ`, dependency-
+/// free (the workspace carries no `chrono`/`time`). The civil-date conversion is Howard
+/// Hinnant's algorithm (the inverse of `days_from_civil`, the same one the sq-0q7n
+/// `AuthIndex` `xsd:dateTime` parser uses), so a formatted lexical parses back to the
+/// same instant the `cond_applies` window compares against. [OPUS-4.8] sq-xc4y.
+fn unix_to_xsd_datetime(epoch_secs: i64) -> String {
+    let days = epoch_secs.div_euclid(86_400);
+    let tod = epoch_secs.rem_euclid(86_400); // 0..86400, always non-negative
+    let (h, mi, s) = (tod / 3600, (tod % 3600) / 60, tod % 60);
+    let (y, m, d) = civil_from_days(days);
+    format!("{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z", y, m, d, h, mi, s)
+}
+
+/// Days-from-epoch (1970-01-01 = 0) → `(year, month, day)` (Howard Hinnant).
+fn civil_from_days(z: i64) -> (i64, u32, u32) {
+    let z = z + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 }.div_euclid(146_097);
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32; // [1, 31]
+    let m = (if mp < 10 { mp + 3 } else { mp - 9 }) as u32; // [1, 12]
+    (if m <= 2 { y + 1 } else { y }, m, d)
 }

--- a/crates/sparq-solid/tests/trust_graph.rs
+++ b/crates/sparq-solid/tests/trust_graph.rs
@@ -229,6 +229,98 @@ fn age_16_admitted_but_no_grant_through_podstore() {
     );
 }
 
+// --- the static/dynamic admission split (sq-xc4y) ---------------------------
+
+/// `now` as an `xsd:dateTime` lexical, for a per-request `Session.now`.
+fn at(secs: i64) -> String {
+    let days = secs.div_euclid(86_400);
+    let tod = secs.rem_euclid(86_400);
+    let (h, mi, s) = (tod / 3600, (tod % 3600) / 60, tod % 60);
+    // Hinnant civil_from_days, inline for the test (matches trust_wire's formatter).
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let (yy, mm) = if m <= 2 { (y + 1, m) } else { (y, m) };
+    format!("{yy:04}-{mm:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+}
+
+fn read_at(store: &mut PodStore, agent: &str, now: &str) -> bool {
+    let s = Session {
+        agent: Some(agent),
+        client: None,
+        issuer: None,
+        now: Some(now),
+    };
+    store
+        .accessible(&s, Mode::Read)
+        .iter()
+        .any(|n| n.as_str() == RESOURCE_X)
+}
+
+/// THE LOAD-BEARING sq-xc4y SOUNDNESS TEST. Static admission installs a CONDITIONAL
+/// grant whose holder + freshness are re-checked PER REQUEST — so the per-request
+/// decision is NOT frozen into the materialise-once view:
+/// 1. as Jesse, before the deadline → GRANTED;
+/// 2. as Jesse, AFTER the freshness deadline → DENIED (the freshness lapsed at query
+///    time, without any re-materialise);
+/// 3. as a DIFFERENT requester (Mallory), before the deadline → DENIED (the holder
+///    binding is re-checked against Session.agent, not frozen as Jesse's allow).
+#[test]
+fn static_admission_defers_holder_and_freshness_to_query_time() {
+    let (sk, pk) = gov_key();
+    let mut store = PodStore::new(Graph::load_dataset(&pod_nquads(), "nquads").unwrap());
+    store.materialize_wac().unwrap();
+
+    // Credential issued at NOW-1day, P30D window ⇒ deadline = NOW - 1day + 30days.
+    let cred = signed_cred(&sk, "25");
+    let rules = gov_age_rules(GOV_ISSUER, &pk);
+    let outcome = store
+        .admit_trust_credential_static(&cred, &rules, &iri(RESOURCE_X), ACR_ABAC_RULE)
+        .unwrap();
+    assert_eq!(
+        outcome.installed_count, 1,
+        "one conditional grant installed for the age fact"
+    );
+    let deadline = cred.issued_at_unix_secs + 30 * 86_400;
+
+    // (1) Jesse, well before the deadline → GRANTED.
+    let before = at(NOW);
+    assert!(
+        read_at(&mut store, JESSE, &before),
+        "static admission ⇒ Jesse is granted read while the credential is fresh"
+    );
+
+    // (2) Jesse, AFTER the freshness deadline → DENIED, without a re-materialise. This
+    // is the proof the freshness is NOT frozen into the view.
+    let after = at(deadline + 86_400);
+    assert!(
+        !read_at(&mut store, JESSE, &after),
+        "a request past trust:freshWithin is denied at QUERY TIME — the freshness was \
+         deferred to the per-request conditional check, not frozen into the view (sq-xc4y)"
+    );
+
+    // (3) Mallory (a different requester), before the deadline → DENIED. The holder
+    // binding is re-checked against Session.agent; the grant is pinned to Jesse.
+    let mallory = "https://mallory.ex/card#me";
+    assert!(
+        !read_at(&mut store, mallory, &before),
+        "a different requester (Mallory) is denied — the holder binding is re-checked \
+         per request against Session.agent, never frozen as a bare allow (sq-xc4y)"
+    );
+
+    // (4) And the fresh-Jesse request still works (idempotent, repeatable check).
+    assert!(
+        read_at(&mut store, JESSE, &before),
+        "still granted for fresh Jesse"
+    );
+}
+
 /// STRICT ADDITIVITY (G6): with the `trust-graph` feature compiled in but NO admission
 /// call made, the store's auth view is IDENTICAL to a plain WAC materialise — the
 /// feature is additive, never a behaviour change to the WAC/ACP path. (The byte-level

--- a/crates/sparq-trust/README.md
+++ b/crates/sparq-trust/README.md
@@ -65,22 +65,31 @@ unchanged WAC/ACP view.
 - **N3 merge** (`wire`) — feed the admitted facts into the shipped `sparq-reason` reasoner ahead
   of the materialiser; the `.acr` ABAC rule `{ ?x age ?y . ?y math:greaterThan 18 } => { ?x
   auth:read R }` derives the grant. The age>18 worked example runs end-to-end (see the tests).
+- **Static / dynamic admission split** (`admit_static` + `derive_conditional_grants`, `sq-xc4y`)
+  — the materialise-time half. `admit_static` decides the **session-independent** class
+  (signature, type-scope, scope) once and carries the **per-request** class (holder + freshness)
+  as conditions; `sparq-solid`'s `admit_trust_credential_static` installs them as an
+  `auth:ConditionalGrant` re-checked per request via the shipped sq-0q7n
+  `auth:agent` / `auth:notAfter` path — so holder/freshness are never frozen into the
+  materialise-once view (a stale or wrong-holder request is denied at query time).
 
 ## Honest scope — what this does and does NOT do
 
 - **No privacy / unlinkability / anonymity.** The credential is admitted **in the clear**; the
   verifier learns the exact value (`age 25`, not "≥ 18"). This does **not** match ZKAPs-grade
   unlinkable presentation.
-- **Holder binding is the clear-WebID, non-anonymous degraded path** (`sq-wvne` / `sq-xc4y`):
+- **Holder binding is the clear-WebID, non-anonymous degraded path** (`sq-wvne`):
   `credentialSubject == Session.agent` authenticates the WebID in the clear — documented, not
-  silently "solved". Presentations stay linkable by requester identity.
+  silently "solved". Presentations stay linkable by requester identity. (Its materialise-time
+  composition — `sq-xc4y` — is RESOLVED by the static/dynamic split above; the *clear-WebID*
+  privacy limitation is separate and remains, `sq-wvne`.)
 - **Issuer keys are operator-asserted** — sparq has no DID resolver yet (`sq-pfae.3`), so the
   `trust:issuerKey → verifying-key` binding is the live forgery vector D′ (§3.3), not an
   end-to-end trust path.
-- **Open problems respected as documented limitations, never solved:** `sq-xc4y` (per-request
-  admission vs materialise-once), `sq-tu4e` (no in-reasoner NAF over derived facts; `revoked` is
-  input-only; no deny-on-disagreement), `sq-l5og` (delegation) and `sq-wvne` (ZK privacy) are
-  **out of PoC scope**.
+- **Open problems respected as documented limitations, never solved:** `sq-tu4e` (no in-reasoner
+  NAF over derived facts; `revoked` is input-only; no deny-on-disagreement), `sq-l5og`
+  (delegation) and `sq-wvne` (ZK privacy) are **out of PoC scope**. (`sq-xc4y`, per-request
+  admission vs materialise-once, is RESOLVED — see the static/dynamic split above.)
 - **Strict additivity (G6):** with `sparq-solid`'s `trust-graph` feature OFF, the crate is not
   compiled and `sparq-solid` behaves exactly as WAC/ACP do today.
 

--- a/crates/sparq-trust/src/admit.rs
+++ b/crates/sparq-trust/src/admit.rs
@@ -24,12 +24,40 @@
 //! (per-request, NOT in-reasoner — §3.3 B′); `shape_admits` runs the shipped,
 //! terminating `sparq-shacl` validator; `scope_covers` is a containment check.
 //!
+//! ## The static / dynamic admission split (the `sq-xc4y` resolution)
+//!
+//! Admission has TWO classes of condition with DIFFERENT lifetimes (design §3.3
+//! ADMISSION-VS-MATERIALIZE-ONCE GAP):
+//!
+//! - **STATIC** — the issuer signature over the RDFC-1.0 commitment, the
+//!   statement-type scope (SHACL shape), the reserved-predicate guard, and the
+//!   `trust:scope` containment. These depend ONLY on the credential + the policy, NOT
+//!   on the request. They are session-independent and can be decided **once, at
+//!   materialise-time**, exactly like the WAC/ACP derivation stratum.
+//! - **DYNAMIC** — the holder binding (`credentialSubject == Session.agent`) and
+//!   freshness (`Session.now - issued_at ≤ freshWithin`). These are **per-request**
+//!   facts. They MUST be re-evaluated on every request and must NOT be frozen into the
+//!   session-independent materialise-once view.
+//!
+//! [`admit`] runs BOTH classes against a single live [`Session`] (the snapshot path:
+//! the decision is valid for *that* request only). [`admit_static`] runs ONLY the
+//! static class and returns each fact carrying the dynamic conditions it still owes
+//! ([`StaticAdmittedFact::holder`] and [`StaticAdmittedFact::not_after_unix_secs`]) so
+//! the caller can install a **conditional grant** whose holder/freshness are re-checked
+//! per request at query time — the shipped sq-0q7n `auth:notBefore`/`auth:notAfter`
+//! conditional-grant precedent (`sparq-solid` `AuthIndex::cond_applies`). This is the
+//! `sq-xc4y` decision **(a) split static-admission from dynamic-admission**, NOT
+//! **(b) per-request re-materialise**: the static stratum composes with the epoch
+//! cache, the dynamic conditions ride the existing per-request conditional-grant path.
+//!
 //! ## Open-problem hooks this gate RESPECTS (does not silently solve)
 //!
-//! - **`sq-xc4y`** (holder-binding/freshness are per-request) — this gate IS the
-//!   per-request admission decision: it takes the live [`Session`] and must be run
-//!   per request for a credential-gated resource, NOT frozen into the
-//!   materialise-once view. [`crate::wire`] re-runs it per request.
+//! - **`sq-xc4y`** (holder-binding/freshness are per-request) — RESOLVED by the
+//!   static/dynamic split above: [`admit_static`] emits the static decision once and
+//!   defers holder/freshness to the per-request conditional-grant check, so a stale or
+//!   wrong-holder credential is denied at query time WITHOUT a re-materialise and is
+//!   never frozen into the materialise-once view. The combined [`admit`] remains the
+//!   per-request snapshot path for a single request.
 //! - **`sq-wvne` / `sq-xc4y` (holder binding)** — the holder binding is the
 //!   **clear-WebID v1 path** (`credentialSubject == Session.agent`), the
 //!   **non-anonymous degraded path**. It authenticates the requester's WebID in the
@@ -111,6 +139,33 @@ pub struct AdmittedFact {
     pub issuer: NamedNode,
 }
 
+/// A fact that passed the **STATIC** admission class (signature + statement-type scope +
+/// reserved-predicate guard + `trust:scope`), carrying the **DYNAMIC** conditions it
+/// still owes so the caller can defer them to a per-request check (`sq-xc4y`).
+///
+/// The static decision is session-independent — it depends only on the credential and
+/// the policy — so it can be made **once, at materialise-time**. The dynamic conditions
+/// ([`holder`](Self::holder) and [`not_after_unix_secs`](Self::not_after_unix_secs))
+/// MUST NOT be frozen into the materialise-once view; they ride the shipped sq-0q7n
+/// conditional-grant path (`auth:agent` re-checked against `Session.agent`,
+/// `auth:notAfter` re-checked against `Session.now`) and are re-evaluated per request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StaticAdmittedFact {
+    /// The admitted triple (e.g. `<Jesse> schema:age 25`).
+    pub triple: Triple,
+    /// `trust:source` — the issuer this fact is tagged with.
+    pub issuer: NamedNode,
+    /// The bound holder: the credential subject the fact may only be used on behalf of.
+    /// The per-request holder binding is `holder == Session.agent`, deferred to query
+    /// time (NEVER frozen into the view — `sq-xc4y` / `sq-wvne` clear-WebID path).
+    pub holder: NamedNode,
+    /// The freshness deadline as a Unix timestamp (seconds): `issued_at + freshWithin`.
+    /// The per-request freshness check is `Session.now ≤ not_after_unix_secs`, deferred
+    /// to query time so a credential that lapses denies *that request* without a
+    /// re-materialise (`sq-xc4y`; the sq-0q7n `auth:notAfter` precedent).
+    pub not_after_unix_secs: i64,
+}
+
 /// Run the admission gate over a presented credential. Returns the admitted facts
 /// (possibly empty — default-deny). NEVER panics on adversarial input: a malformed
 /// signature, an uncanonicalisable graph, or a bad shape all fail closed (no admit).
@@ -185,6 +240,96 @@ pub fn admit(
             let fact = AdmittedFact {
                 triple: t.clone(),
                 issuer: r.source.clone(),
+            };
+            if !admitted.contains(&fact) {
+                admitted.push(fact);
+            }
+        }
+    }
+    admitted
+}
+
+/// Run ONLY the **static** admission class over a presented credential, returning the
+/// statically-admitted facts each tagged with the **dynamic** conditions it still owes
+/// (the bound holder + the freshness deadline). This is the materialise-time half of
+/// the `sq-xc4y` static/dynamic split: it decides everything that is session-
+/// independent (signature, statement-type scope, reserved-predicate guard, `trust:scope`)
+/// and DEFERS holder-binding + freshness to a per-request conditional-grant check.
+///
+/// Unlike [`admit`], this takes **no `Session`**: a static decision must not depend on
+/// the request. The credential subject becomes the [`StaticAdmittedFact::holder`] the
+/// grant is pinned to; the freshness deadline becomes
+/// [`StaticAdmittedFact::not_after_unix_secs`]. The caller installs a conditional grant
+/// that re-checks both per request — so a stale or wrong-holder credential is denied at
+/// query time WITHOUT a re-materialise and is never frozen into the materialise-once
+/// view.
+///
+/// Returns the statically-admitted facts (possibly empty — default-deny). NEVER panics
+/// on adversarial input: a malformed signature, an uncanonicalisable graph, or a bad
+/// shape all fail closed (no admit). The static class fails closed exactly as [`admit`]
+/// does; only the holder/freshness checks move to query time.
+pub fn admit_static(
+    cred: &PresentedCredential,
+    rules: &[TrustRule],
+    target: &NamedNode,
+) -> Vec<StaticAdmittedFact> {
+    let mut admitted: Vec<StaticAdmittedFact> = Vec::new();
+
+    // Step 1: canonicalise + commit G (the same canonical unit the ZK estate commits
+    // over). A graph that cannot be committed admits nothing.
+    let salt = salt_from_bytes(&cred.salt);
+    let Ok(commitment) = commit_triples(&cred.graph, salt) else {
+        return admitted; // fail closed
+    };
+    let commitment_fr: Fr = commitment.commitment;
+
+    let Some(signature) = signature_from_hex(&cred.issuer_signature_hex) else {
+        return admitted;
+    };
+
+    for r in rules {
+        // §3.2 scope (STATIC: policy + credential only).
+        if !scope_covers(&r.scope, target) {
+            continue;
+        }
+        // §3.3 (1) CHECKED issuer signature (STATIC).
+        let msg = commitment_message(&commitment_fr);
+        if !verify(&r.issuer_key, &msg, &signature) {
+            continue;
+        }
+        // §3.3 input-stratified revocation guard. Revocation is a per-credential input
+        // fact (not request-dependent), so a credential KNOWN revoked at materialise is
+        // dropped here too; a credential revoked LATER is handled by re-materialise
+        // (epoch bump on trust-graph/status change — design §3.3 / G5).
+        if cred.revoked {
+            continue;
+        }
+        // The freshness deadline this rule imposes: issued_at + freshWithin. Carried as
+        // a per-request DYNAMIC condition (NOT checked here against any `now`).
+        let not_after_unix_secs = cred.issued_at_unix_secs.saturating_add(r.fresh_within_secs);
+
+        for t in &cred.graph {
+            // The reserved-predicate guard stays in force UNDER admission (STATIC).
+            if is_reserved_predicate(&t.predicate) {
+                continue;
+            }
+            // §2.3.2 statement-type scoping via the SHACL shape (STATIC).
+            if !shape_admits(&r.shape, t, &cred.graph) {
+                continue;
+            }
+            // The bound holder is the credential subject — pinned into the grant's
+            // `auth:agent` head, re-checked against `Session.agent` per request (the
+            // DYNAMIC holder binding, deferred — §3.4 / sq-xc4y). A triple whose subject
+            // is a blank node cannot be holder-bound (no stable WebID), so it is not
+            // statically admissible for a credential-gated grant: fail closed.
+            let NamedOrBlankNode::NamedNode(holder) = &t.subject else {
+                continue;
+            };
+            let fact = StaticAdmittedFact {
+                triple: t.clone(),
+                issuer: r.source.clone(),
+                holder: holder.clone(),
+                not_after_unix_secs,
             };
             if !admitted.contains(&fact) {
                 admitted.push(fact);

--- a/crates/sparq-trust/src/lib.rs
+++ b/crates/sparq-trust/src/lib.rs
@@ -30,9 +30,12 @@
 //!   (fail-closed: a policy not Control-gated admits nothing).
 //! - [`mod@admit`] — the admission gate: canonicalise (RDFC-1.0), verify the issuer
 //!   signature, enforce statement-type scoping (SHACL shape), freshness, and holder
-//!   binding; output [`admit::AdmittedFact`]s.
+//!   binding; output [`admit::AdmittedFact`]s. [`admit::admit_static`] runs only the
+//!   session-independent (STATIC) class and defers holder/freshness to a per-request
+//!   conditional-grant check — the `sq-xc4y` static/dynamic split.
 //! - [`wire`] — feed admitted facts into the N3 reasoner ahead of the materialiser;
-//!   read off the derived `auth:*` grants.
+//!   read off the derived `auth:*` grants ([`wire::derive_grants`]) OR the per-grant
+//!   DYNAMIC conditions for a conditional grant ([`wire::derive_conditional_grants`]).
 //!
 //! ## Opt-in by construction (strict additivity — design §2.2 G6)
 //!
@@ -72,9 +75,15 @@
 //! ## Open problems this PoC RESPECTS as documented limitations (never silently solved)
 //!
 //! - **`sq-xc4y`** — per-request holder-binding / freshness vs the
-//!   session-independent materialise-once auth view: admission MUST be re-run per
-//!   request for credential-gated resources (this gate takes the live `Session`), it
-//!   cannot sit frozen ahead of a materialise-once view.
+//!   session-independent materialise-once auth view: RESOLVED by the **static/dynamic
+//!   admission split** (decision (a)). The static class (signature, statement-type
+//!   scope, reserved-predicate guard, `trust:scope`) is session-independent and runs
+//!   ONCE at materialise-time ([`admit::admit_static`]); the dynamic class (holder
+//!   binding + freshness) is deferred to a **per-request conditional grant** re-checked
+//!   at query time via the shipped sq-0q7n `auth:agent` / `auth:notAfter` path — so a
+//!   stale or wrong-holder credential is denied per request WITHOUT a re-materialise
+//!   and is never frozen into the view. (The combined [`admit::admit`] remains the
+//!   single-request snapshot path.)
 //! - **`sq-l5og`** — delegation invocation-binding: **out of PoC scope** (no
 //!   delegation substrate exists; §4 of the design is design-only).
 //! - **`sq-tu4e`** — no in-reasoner NAF over derived facts: `revoked` is an
@@ -93,6 +102,8 @@ pub mod policy;
 pub mod vocab;
 pub mod wire;
 
-pub use admit::{admit, AdmittedFact, PresentedCredential, Session};
+pub use admit::{
+    admit, admit_static, AdmittedFact, PresentedCredential, Session, StaticAdmittedFact,
+};
 pub use policy::{parse_policy, ControlGate, PolicyError, ShapeRef, TrustRule};
-pub use wire::derive_grants;
+pub use wire::{derive_conditional_grants, derive_grants, ConditionalGrant};

--- a/crates/sparq-trust/src/wire.rs
+++ b/crates/sparq-trust/src/wire.rs
@@ -25,8 +25,8 @@
 //!
 //! [OPUS-4.8] sq-pfae PoC (issue #940). 🤖 SPARQ agent — trust-graph authorisation PoC.
 
-use crate::admit::AdmittedFact;
-use oxrdf::{NamedNode, Term, Triple};
+use crate::admit::{AdmittedFact, StaticAdmittedFact};
+use oxrdf::{NamedNode, NamedOrBlankNode, Term, Triple};
 use sparq_core::dict::Dict;
 use sparq_reason::reason_n3;
 use std::fmt::Write as _;
@@ -34,6 +34,30 @@ use std::fmt::Write as _;
 /// The `auth:` view namespace (`auth:read|write|append|control` — the SAME predicates
 /// the shipped WAC/ACP rules emit and `sparq_solid::AuthIndex` reads).
 pub const AUTH_NS: &str = "https://sparq.dev/ns/auth#";
+
+/// A derived `auth:*` grant carrying the **DYNAMIC** conditions it still owes — the
+/// output of [`derive_conditional_grants`], the materialise-time half of the `sq-xc4y`
+/// split. The `sparq-solid` `trust-graph` layer installs each as a **conditional grant**
+/// (`auth:ConditionalGrant`) whose `auth:agent` is re-checked against `Session.agent`
+/// and whose `auth:notAfter` (`= not_after_unix_secs` rendered as `xsd:dateTime`) is
+/// re-checked against `Session.now` PER REQUEST — the shipped sq-0q7n path. The grant is
+/// therefore NOT a frozen unconditional allow: a stale or wrong-holder credential is
+/// denied at query time without a re-materialise.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConditionalGrant {
+    /// The derived `auth:*` grant triple (e.g. `<Jesse> auth:read <resourceX>`). Its
+    /// subject is always the bound [`holder`](Self::holder) (the credential subject the
+    /// `.acr` rule fired on).
+    pub grant: Triple,
+    /// The bound holder (credential subject). Becomes the conditional grant's
+    /// `auth:agent` head — re-checked against `Session.agent` per request (the deferred
+    /// DYNAMIC holder binding; never frozen). A different requester never matches.
+    pub holder: NamedNode,
+    /// The freshness deadline (Unix seconds): `issued_at + freshWithin`. Becomes the
+    /// conditional grant's `auth:notAfter` (`xsd:dateTime`) — re-checked against
+    /// `Session.now` per request (the deferred DYNAMIC freshness check; never frozen).
+    pub not_after_unix_secs: i64,
+}
 
 /// Run the N3 merge: the admitted facts + the controller-authored ABAC `rule_n3`
 /// (from the `.acr`) → the derived `auth:*` grant triples.
@@ -95,6 +119,58 @@ pub fn derive_grants(admitted: &[AdmittedFact], rule_n3: &str) -> Result<Vec<Tri
         }
     }
     Ok(grants)
+}
+
+/// Run the N3 merge over **statically-admitted** facts and return each derived
+/// `auth:*` grant tagged with the DYNAMIC conditions it still owes (the bound holder +
+/// freshness deadline) — the materialise-time half of the `sq-xc4y` static/dynamic
+/// split. Use this (not [`derive_grants`]) when feeding the **session-independent**
+/// materialise-once view: the returned [`ConditionalGrant`]s carry the per-request
+/// holder/freshness so the caller installs a CONDITIONAL grant re-checked at query time,
+/// rather than an unconditional allow that would freeze a per-request decision.
+///
+/// The merge runs **per static fact** so each derived grant keeps its holder/expiry
+/// association: a fact only fires `.acr` rules whose head subject is the fact's holder
+/// (the credential subject), so the grant's `auth:agent` and its `not_after` stay
+/// consistent. A grant whose derived subject is NOT the bound holder is dropped
+/// (fail-closed: the credential cannot grant on behalf of a third party — §3.4).
+///
+/// `rule_n3` is the trusted ABAC rule(s) from the Control-gated `.acr` channel (see
+/// [`derive_grants`]). NEVER panics — a malformed rule yields an `Err` the caller fails
+/// closed on; an empty input derives nothing (default-deny).
+pub fn derive_conditional_grants(
+    admitted: &[StaticAdmittedFact],
+    rule_n3: &str,
+) -> Result<Vec<ConditionalGrant>, String> {
+    let mut out: Vec<ConditionalGrant> = Vec::new();
+    for f in admitted {
+        // The plain AdmittedFact the N3 merge consumes (issuer-tagged).
+        let af = AdmittedFact {
+            triple: f.triple.clone(),
+            issuer: f.issuer.clone(),
+        };
+        for grant in derive_grants(std::slice::from_ref(&af), rule_n3)? {
+            // Fail-closed holder consistency: the derived grant's subject MUST be the
+            // bound holder (the credential subject). A rule that derived a grant for a
+            // different subject must not ride this credential's holder binding.
+            let subj_is_holder = matches!(
+                &grant.subject,
+                NamedOrBlankNode::NamedNode(n) if n.as_str() == f.holder.as_str()
+            );
+            if !subj_is_holder {
+                continue;
+            }
+            let cg = ConditionalGrant {
+                grant,
+                holder: f.holder.clone(),
+                not_after_unix_secs: f.not_after_unix_secs,
+            };
+            if !out.contains(&cg) {
+                out.push(cg);
+            }
+        }
+    }
+    Ok(out)
 }
 
 fn to_triple(s: Term, p: NamedNode, o: Term) -> Option<Triple> {
@@ -168,6 +244,63 @@ mod tests {
         assert!(
             grants.is_empty(),
             "default-deny: empty admission ⇒ empty derivation"
+        );
+    }
+
+    fn static_age(value: &str, not_after: i64) -> Vec<StaticAdmittedFact> {
+        vec![StaticAdmittedFact {
+            triple: Triple::new(
+                oxrdf::NamedOrBlankNode::NamedNode(iri("https://jesse.ex/card#me")),
+                iri("http://schema.org/age"),
+                Term::Literal(Literal::new_typed_literal(
+                    value,
+                    iri("http://www.w3.org/2001/XMLSchema#integer"),
+                )),
+            ),
+            issuer: iri("https://gov.example/issuer"),
+            holder: iri("https://jesse.ex/card#me"),
+            not_after_unix_secs: not_after,
+        }]
+    }
+
+    #[test]
+    fn conditional_grant_carries_holder_and_expiry() {
+        // age 25 > 18 → one conditional read grant, tagged with the holder + deadline.
+        let cgs = derive_conditional_grants(&static_age("25", 1_700_086_400), RULE).unwrap();
+        assert_eq!(cgs.len(), 1, "age 25 > 18 derives one conditional grant");
+        let cg = &cgs[0];
+        assert_eq!(
+            cg.grant.predicate.as_str(),
+            "https://sparq.dev/ns/auth#read"
+        );
+        assert_eq!(cg.holder.as_str(), "https://jesse.ex/card#me");
+        assert_eq!(
+            cg.not_after_unix_secs, 1_700_086_400,
+            "the freshness deadline rides the grant as a DYNAMIC condition"
+        );
+    }
+
+    #[test]
+    fn conditional_grant_age_16_denies() {
+        // age 16 is statically admitted but the > 18 rule does not fire → no grant.
+        let cgs = derive_conditional_grants(&static_age("16", 1_700_086_400), RULE).unwrap();
+        assert!(cgs.is_empty(), "age 16: rule denies ⇒ no conditional grant");
+    }
+
+    #[test]
+    fn conditional_grant_drops_third_party_subject() {
+        // A rule that grants a DIFFERENT subject than the holder must not ride this
+        // credential's holder binding (fail-closed §3.4).
+        const THIRD_PARTY_RULE: &str = r#"@prefix schema: <http://schema.org/> .
+@prefix math:   <http://www.w3.org/2000/10/swap/math#> .
+@prefix auth:   <https://sparq.dev/ns/auth#> .
+{ ?x schema:age ?y . ?y math:greaterThan 18 } => { <https://mallory.ex/card#me> auth:read <https://pod.ex/resourceX> } .
+"#;
+        let cgs =
+            derive_conditional_grants(&static_age("25", 1_700_086_400), THIRD_PARTY_RULE).unwrap();
+        assert!(
+            cgs.is_empty(),
+            "a grant whose subject is not the bound holder is dropped"
         );
     }
 }

--- a/crates/sparq-trust/tests/age_over_18_e2e.rs
+++ b/crates/sparq-trust/tests/age_over_18_e2e.rs
@@ -21,10 +21,10 @@
 //! [OPUS-4.8] sq-pfae PoC. 🤖 SPARQ agent — trust-graph authorisation PoC.
 
 use oxrdf::{Literal, NamedNode, NamedOrBlankNode, Term, Triple};
-use sparq_trust::admit::{admit, PresentedCredential, Session};
+use sparq_trust::admit::{admit, admit_static, PresentedCredential, Session};
 use sparq_trust::policy::{parse_policy, ControlGate, ShapeRef, TrustRule};
 use sparq_trust::vocab::{self, desugar_for_predicate};
-use sparq_trust::wire::derive_grants;
+use sparq_trust::wire::{derive_conditional_grants, derive_grants};
 use sparq_zk::commit::commit_triples;
 use sparq_zk::encode::salt_from_bytes;
 use sparq_zk::sig::{public_key_to_hex, PublicKey, SecretKey};
@@ -356,6 +356,117 @@ fn out_of_scope_resource_is_not_covered() {
     assert!(
         admitted.is_empty(),
         "a rule scoped to resourceX does not cover a request for resourceY (§3.2 scope)"
+    );
+}
+
+// --- the static/dynamic admission split (sq-xc4y) ---------------------------
+
+#[test]
+fn static_admission_is_session_independent_and_carries_dynamic_conditions() {
+    // admit_static() takes NO session: it decides only the STATIC class (signature,
+    // type-scope, reserved-predicate guard, scope) and carries the DYNAMIC conditions
+    // (the bound holder + the freshness deadline) for a per-request check.
+    let (sk, pk) = gov_key();
+    let rules = gov_age_policy(GOV_ISSUER, &pk, RESOURCE_X);
+    let cred = fresh_cred(&sk, age_credential_graph(JESSE, "25"));
+    let statics = admit_static(&cred, &rules, &iri(RESOURCE_X));
+    assert_eq!(statics.len(), 1, "the age fact passes static admission");
+    let f = &statics[0];
+    assert_eq!(
+        f.holder.as_str(),
+        JESSE,
+        "the bound holder is the credential subject"
+    );
+    assert_eq!(
+        f.not_after_unix_secs,
+        ISSUED_FRESH + 30 * 86_400,
+        "the freshness deadline is issued_at + freshWithin (P30D), carried for the \
+         per-request check — NOT evaluated at static-admission time"
+    );
+}
+
+#[test]
+fn static_admission_admits_a_stale_credential_but_defers_the_freshness_check() {
+    // A credential past freshWithin is STILL statically admitted (freshness is a
+    // DYNAMIC, per-request condition, not a static one) — but the carried deadline is
+    // in the past, so the per-request conditional check would deny it. The point of the
+    // split: the static decision is session-independent; the freshness verdict is
+    // re-evaluated per request, never frozen.
+    let (sk, pk) = gov_key();
+    let rules = gov_age_policy(GOV_ISSUER, &pk, RESOURCE_X);
+    let graph = age_credential_graph(JESSE, "25");
+    let sig = sign_graph(&sk, &graph);
+    let issued = NOW - 60 * 86_400; // 60 days ago — past P30D
+    let cred = PresentedCredential {
+        graph,
+        issuer_signature_hex: sig,
+        salt: SALT_BYTES,
+        issued_at_unix_secs: issued,
+        revoked: false,
+    };
+    let statics = admit_static(&cred, &rules, &iri(RESOURCE_X));
+    assert_eq!(
+        statics.len(),
+        1,
+        "a stale credential STILL passes static admission (signature + type-scope hold)"
+    );
+    let deadline = statics[0].not_after_unix_secs;
+    assert!(
+        deadline < NOW,
+        "but the carried freshness deadline ({deadline}) is in the past, so the \
+         per-request check denies it at query time — NOT frozen into the view"
+    );
+}
+
+#[test]
+fn static_admission_then_conditional_grant_carries_holder_and_deadline() {
+    // The materialise-time half end-to-end: static admission → derive_conditional_grants
+    // → a conditional grant tagged with the holder + deadline for the per-request check.
+    let (sk, pk) = gov_key();
+    let rules = gov_age_policy(GOV_ISSUER, &pk, RESOURCE_X);
+    let cred = fresh_cred(&sk, age_credential_graph(JESSE, "25"));
+    let statics = admit_static(&cred, &rules, &iri(RESOURCE_X));
+    let cgs = derive_conditional_grants(&statics, ACR_ABAC_RULE).expect("derivation runs");
+    assert_eq!(
+        cgs.len(),
+        1,
+        "age 25 > 18 derives one conditional read grant"
+    );
+    let cg = &cgs[0];
+    assert_eq!(
+        cg.grant.predicate.as_str(),
+        "https://sparq.dev/ns/auth#read"
+    );
+    assert_eq!(cg.holder.as_str(), JESSE);
+    assert_eq!(cg.not_after_unix_secs, ISSUED_FRESH + 30 * 86_400);
+}
+
+#[test]
+fn static_admission_drops_a_blank_node_subject() {
+    // A credential triple whose subject is a blank node has no stable WebID to bind the
+    // holder to, so it cannot be holder-bound for a credential-gated grant: fail closed.
+    let (sk, pk) = gov_key();
+    let rules = gov_age_policy(GOV_ISSUER, &pk, RESOURCE_X);
+    let graph = vec![Triple::new(
+        NamedOrBlankNode::BlankNode(oxrdf::BlankNode::new("b0").unwrap()),
+        iri(SCHEMA_AGE),
+        Term::Literal(Literal::new_typed_literal(
+            "25",
+            iri("http://www.w3.org/2001/XMLSchema#integer"),
+        )),
+    )];
+    let sig = sign_graph(&sk, &graph);
+    let cred = PresentedCredential {
+        graph,
+        issuer_signature_hex: sig,
+        salt: SALT_BYTES,
+        issued_at_unix_secs: ISSUED_FRESH,
+        revoked: false,
+    };
+    let statics = admit_static(&cred, &rules, &iri(RESOURCE_X));
+    assert!(
+        statics.is_empty(),
+        "a blank-node-subject triple cannot be holder-bound ⇒ not statically admitted"
     );
 }
 

--- a/research/solid-trust-graph-authz-design.md
+++ b/research/solid-trust-graph-authz-design.md
@@ -429,21 +429,36 @@ is gated correctly. The design's safety argument:
 negation-as-failure** (sparq-reason; the AC design's stratification discipline). Several
 consequences the design must honour — and one architectural gap the prior draft glossed:
 
-- **ADMISSION-VS-MATERIALIZE-ONCE GAP (open; top-priority — `sq-xc4y`).** The prior draft
+- **ADMISSION-VS-MATERIALIZE-ONCE GAP — RESOLVED: decision (a), the static/dynamic split
+  (`sq-xc4y`, shipped in `sparq-trust` + `sparq-solid` `trust_wire`).** The prior draft
   presented admission as a clean stratum *ahead of* derivation. But the shipped `sparq-solid`
   auth view is materialised **once, session-independently** (`PodStore`, `lib.rs`) and then
   queried **per-session** by principal expansion — whereas admission gates on
   `credentialSubject == Session.agent` (holder binding, §3.4) and `trust:freshWithin` vs
   `Session.now`, which are **per-request** facts. A per-request, identity-bound admission
   decision **cannot** simply sit ahead of derivation inside a session-independent
-  materialise-once view: either admission **re-runs per request** (negating the P4 epoch-cache
-  composition) **or** holder binding **degrades to a query-time principal match**. (A partial
-  precedent exists: per-request `now` *is* already consulted for time-windowed conditional
-  grants — `authindex.rs`, `sq-0q7n` — re-checked per request rather than frozen at
-  materialise; but per-request *identity*-bound admission ahead of derivation is unspecified.)
-  This is an **open soundness question**, not settled stratification: split static-admission
-  (signature / type-scope, materialise-time) from dynamic-admission (holder-binding /
-  freshness, query-time), or per-request re-materialise for credential-gated resources.
+  materialise-once view: either admission re-runs per request (negating the P4 epoch-cache
+  composition) **or** holder binding degrades to a query-time principal match. **The decision
+  taken is (a):** SPLIT admission into a **STATIC** class (issuer signature, statement-type
+  scope, reserved-predicate guard, `trust:scope`) decided **once at materialise-time**
+  (`sparq_trust::admit_static`), and a **DYNAMIC** class (holder binding + freshness) **deferred
+  to a per-request conditional grant**. The static decision emits an `auth:ConditionalGrant`
+  whose `auth:agent` is the credential subject and whose `auth:notAfter` is
+  `issued_at + freshWithin`; both are re-checked **per request** by the shipped sq-0q7n
+  `AuthIndex::cond_applies` path (`auth:agent` against `Session.agent`, `auth:notAfter` against
+  `Session.now`). So holder binding does NOT degrade to a static principal match — it is a live
+  per-request check — and freshness lapses at query time **without** a re-materialise; the
+  dynamic verdict is never frozen into the view, while the static stratum composes with the
+  epoch cache. (This generalises the sq-0q7n precedent — which already does this for time
+  windows — to the identity dimension. Option (b) per-request re-materialise was rejected: it
+  negates the epoch cache and the existing conditional-grant machinery already gives the
+  per-request semantics for free.) The load-bearing soundness test
+  (`sparq-solid/tests/trust_graph.rs::static_admission_defers_holder_and_freshness_to_query_time`)
+  drives this through the REAL `PodStore`: a stale `now` and a wrong-holder request are each
+  denied at query time. **Honest residue:** revocation that occurs AFTER materialise is still a
+  re-materialise event (epoch bump, G5/§8) — only holder + freshness are deferred, because they
+  are pure functions of the per-request `Session`; revocation is an external-state change, not a
+  request fact.
 - Admission rules must be **stratified ahead of** derivation: all *static* admission decisions
   for a predicate complete before any derivation rule reads it, so scoped-NAF stays sound.
 - **Freshness/revocation are NOT in the reasoner; the §2.1 diagram is reworded accordingly.**
@@ -1005,8 +1020,10 @@ not in-reasoner — §3.3 B′); `shape_admits` runs the shipped, terminating `s
 `scope_covers` is a containment check. The emitted facts then enter the **unchanged** `sparq-solid`
 materialiser, which runs the `.acl` rule via `sparq-reason` `reason_n3`. **Open-problem hooks the
 PoC must respect** (do not silently "solve" them — wire them as the documented degraded path):
-`sq-xc4y` (holder-binding/freshness are per-request → run admission **per request** for
-credential-gated resources, not in the materialise-once view); `sq-tu4e` (no in-reasoner NAF over
+`sq-xc4y` (holder-binding/freshness are per-request → **RESOLVED** by the static/dynamic split:
+`admit_static` decides the session-independent class once and defers holder/freshness to a
+per-request conditional grant, §3.3 A′ — never frozen into the materialise-once view);
+`sq-tu4e` (no in-reasoner NAF over
 derived facts → `revoked` is an **input-only** seeded predicate; no deny-on-disagreement rule);
 `sq-l5og` / `sq-wvne` are **out of PoC scope** (no delegation, no ZK/privacy).
 
@@ -1155,15 +1172,19 @@ prior draft phrased as settled are open problems.
 
 ### 7.3 Evaluation soundness (the trust-scoping / reasoner half)
 
-- **A′ — ADMISSION-VS-MATERIALIZE-ONCE GAP (new; top priority — `sq-xc4y`).** Holder binding +
-  freshness are **per-request**, but the shipped auth view is materialised **once,
-  session-independently** (`PodStore`, `lib.rs`) and queried per-session. v1 has **NOT
-  specified** how per-request identity-bound admission composes with the materialise-once /
-  epoch-cache model: either admission **re-runs per request** (negating P4) **or** holder
-  binding **degrades to a query-time principal match**. This is an **open soundness question**,
-  not the clean pre-derivation stratification the prior draft implied. (Partial precedent:
-  per-request `now` is already consulted for time-windowed conditional grants, `authindex.rs`
-  `sq-0q7n`; but identity-bound admission ahead of derivation is unspecified.)
+- **A′ — ADMISSION-VS-MATERIALIZE-ONCE GAP — RESOLVED (decision (a); `sq-xc4y`, shipped).**
+  Holder binding + freshness are **per-request**, but the shipped auth view is materialised
+  **once, session-independently** (`PodStore`, `lib.rs`) and queried per-session. The decision:
+  **split static admission (signature / type-scope / scope, materialise-time) from dynamic
+  admission (holder-binding / freshness, query-time)**, with the dynamic class deferred to a
+  **conditional grant** re-checked per request by the shipped sq-0q7n `cond_applies` path
+  (`auth:agent`↔`Session.agent`, `auth:notAfter`↔`Session.now`). Holder binding does NOT degrade
+  to a frozen static match — it is a live per-request check — and freshness lapses at query time
+  without a re-materialise. This generalises the sq-0q7n time-window precedent to the identity
+  dimension; option (b) per-request re-materialise was rejected (negates P4, redundant with the
+  conditional-grant machinery). See §3.3 for the full rationale and the soundness test. Residue:
+  post-materialise *revocation* is still a re-materialise event (external-state change, not a
+  request fact) — only the two pure-`Session` conditions are deferred.
 - **B′ — Freshness/revocation are NOT in the reasoner.** Time is a per-request Rust check
   (`authindex.rs`); the shipped reasoner permits NAF **only over input-only predicates** and
   rejects NAF over **derived** predicates. Any `not-revoked` guard must be **input-stratified**
@@ -1245,7 +1266,9 @@ The genuine **design gaps** (not mere caveats) surfaced above are tracked as bea
 `gh-940`, to be sequenced by the orchestrator:
 
 - `sq-xc4y` — per-request holder-binding/freshness admission vs session-independent
-  materialise-once auth view (top-priority soundness question).
+  materialise-once auth view: **RESOLVED** — decision (a), the static/dynamic split, shipped in
+  `sparq-trust` (`admit_static` / `derive_conditional_grants`) + `sparq-solid`
+  (`admit_trust_credential_static`, conditional-grant install on the sq-0q7n path); §3.3 A′.
 - `sq-l5og` — delegation invocation-binding gate (invoker == terminal delegate, key-proven);
   admitted delegation is replayable without it; ambient-authority + intersection-snapshot +
   stale-window sub-problems.
@@ -1262,7 +1285,8 @@ The genuine **design gaps** (not mere caveats) surfaced above are tracked as bea
 own prior draft's overclaims. The *primary* load-bearing claims a reviewer should attack are the
 **concessions of §7.1–7.4**, audited for *adequacy* — i.e. is each gap conceded honestly and
 fully, or does residual overclaim survive? Those concessions are specific and falsifiable, and
-are framed as **open problems, not settled claims**: admission-vs-materialise-once (`sq-xc4y`),
+are framed as **open problems, not settled claims** (with the exception of
+admission-vs-materialise-once `sq-xc4y`, now RESOLVED by the static/dynamic split, §3.3 A′):
 delegation invocation-binding (`sq-l5og`), conflict / deny-on-disagreement reachability and the
 in-reasoner-NAF / freshness / issuer-key limits (`sq-tu4e`), and the ZK-presentation composite +
 §3.4-holder-binding architecture blocker (`sq-wvne`). The document makes **no claim** to

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -356,12 +356,24 @@ worked example (a trusted-government VC `<Jesse> age 25` + a trust policy + the 
 
 It is wired into `sparq-solid` behind the **default-OFF `trust-graph` cargo feature**. With the
 feature off, `sparq-solid` is byte-identical to WAC/ACP today (**strict additivity**); with it
-on, `PodStore` gains one method — `admit_trust_credential_with_rule(credential, rules, session,
-target, abac_rule_n3)` — that runs the gate and installs the derived `auth:*` grants on top of
-the unchanged auth view (the ODRL-bridge precedent). The admission gate is the §6.0 algorithm:
+on, `PodStore` gains two install methods. The admission gate is the §6.0 algorithm:
 RDFC-1.0 canonicalise (`sparq-canon`) → a **checked** issuer signature over the commitment
 (`sparq-zk`, never a self-asserted triple) → statement-type scoping via a real SHACL shape
-(`sparq-shacl`) → freshness (a per-request Rust check) → the clear-WebID holder binding. The
+(`sparq-shacl`) → freshness (a per-request check) → the clear-WebID holder binding.
+
+- **`admit_trust_credential_static(credential, rules, target, abac_rule_n3)`** — the
+  **materialise-time** path (the `sq-xc4y` static/dynamic split). It runs only the
+  session-INDEPENDENT class (signature, type-scope, scope) and installs each derived grant as an
+  `auth:ConditionalGrant` whose holder (`auth:agent`) and freshness (`auth:notAfter`) are
+  re-checked **per request** by the shipped sq-0q7n `cond_applies` path — so holder/freshness are
+  never frozen into the materialise-once view (a stale or wrong-holder request is denied at query
+  time). **Use this for a long-lived view.**
+- **`admit_trust_credential_with_rule(credential, rules, session, target, abac_rule_n3)`** — the
+  single-request **snapshot** path: it runs the COMBINED gate against one live `Session` and
+  installs an UNCONDITIONAL grant valid for that request only (do not use it to populate a
+  long-lived view).
+
+Both install on top of the unchanged auth view (the ODRL-bridge precedent). The
 public surface is `sparq_trust::{vocab, policy, admit, wire}` — see
 [`crates/sparq-trust/README.md`](../../crates/sparq-trust/README.md) and the design record
 `research/solid-trust-graph-authz-design.md` §6.0 (tracked in
@@ -371,12 +383,14 @@ public surface is `sparq_trust::{vocab, policy, admit, wire}` — see
 **Honest scope (read first).** This is a RESEARCH prototype, **NOT a security guarantee**. It
 does **not** provide privacy, unlinkability, or anonymity: the credential is admitted in the
 clear and the holder binding authenticates the WebID in the clear (the non-anonymous degraded
-path, `sq-wvne` / `sq-xc4y`). The ZK estate it composes with is externally **unaudited**
+path, `sq-wvne`). The ZK estate it composes with is externally **unaudited**
 (`sq-qhy4`, pending external accredited-cryptographer sign-off). Issuer keys are
 operator-asserted (no DID resolver yet — `sq-pfae.3`, the live forgery vector D′). Open problems
-are respected as documented limitations, never solved: `sq-xc4y` (per-request admission vs
-materialise-once), `sq-tu4e` (no in-reasoner NAF over derived facts; `revoked` is input-only; no
-deny-on-disagreement), `sq-l5og` (delegation) and `sq-wvne` (ZK privacy) are out of PoC scope.
+are respected as documented limitations, never solved: `sq-tu4e` (no in-reasoner NAF over
+derived facts; `revoked` is input-only; no deny-on-disagreement), `sq-l5og` (delegation) and
+`sq-wvne` (ZK privacy) are out of PoC scope. (`sq-xc4y` — per-request holder/freshness admission
+vs the materialise-once view — is **RESOLVED** by the static/dynamic split: see
+`admit_trust_credential_static` above and design §3.3 A′.)
 
 ## Related skills
 


### PR DESCRIPTION
> 🤖 SPARQ agent — trust-graph authorisation PoC. Opt-in / feature-gated; RESEARCH prototype, not a security guarantee.

## What this resolves

The top-priority trust-graph soundness open problem **`sq-xc4y`** (gh-940): the shipped `sparq-solid` auth view is materialised **once, session-independently** (`PodStore`), but trust-graph admission gates on **holder-binding** (`credentialSubject == Session.agent`) and **freshness** (`Session.now` vs `trust:freshWithin`) — **per-request** facts that cannot sit frozen ahead of a materialise-once view. Before this PR, the PoC's `admit_trust_credential_and_materialize` baked a per-request, holder-bound grant into the shared `<urn:sparq:auth>` view as an **unconditional** `auth:read` — so once admitted it would grant access to any session as that holder, forever, ignoring freshness.

## The decision — (a) split static-admission from dynamic-admission

Option **(a)** was chosen; option **(b)** (per-request re-materialise) was **rejected** — it negates the P4 epoch cache and the shipped sq-0q7n conditional-grant machinery already gives per-request semantics for free.

- **STATIC** (signature, statement-type scope, reserved-predicate guard, `trust:scope`) — session-independent → decided **once at materialise-time** (`sparq_trust::admit_static`).
- **DYNAMIC** (holder binding + freshness) — per-request → deferred to a **conditional grant** re-checked at query time via the shipped sq-0q7n `AuthIndex::cond_applies` path (`auth:agent` ↔ `Session.agent`, `auth:notAfter` ↔ `Session.now`). This **generalises the sq-0q7n time-window precedent to the identity dimension**: holder binding stays a live per-request check (never a frozen static match), and freshness lapses at query time **without** a re-materialise.

## Surface (opt-in, default-OFF `trust-graph`)

- `sparq-trust`: `admit_static()` → `Vec<StaticAdmittedFact>` (each carries `holder` + `not_after_unix_secs`); `derive_conditional_grants()` → `Vec<ConditionalGrant>` (fail-closed: a derived grant whose subject is not the bound holder is dropped, §3.4).
- `sparq-solid` (`--features trust-graph`): `PodStore::admit_trust_credential_static(credential, rules, target, abac_rule_n3)` installs each as an `auth:ConditionalGrant` (the same wire shape the ODRL bridge emits). The combined `admit_trust_credential_{and_materialize,with_rule}` are documented as the single-request **snapshot** path.

## Load-bearing soundness test (REAL `PodStore`)

`trust_graph.rs::static_admission_defers_holder_and_freshness_to_query_time`: after static admission, (1) fresh Jesse is granted; (2) Jesse **after the freshness deadline** is **denied at query time** without a re-materialise; (3) a **different requester** (Mallory) is **denied** — proving the dynamic conditions are not frozen. Plus unit + e2e coverage for `admit_static` / `derive_conditional_grants` (session-independence, stale-but-statically-admitted, blank-node-subject drop, holder/deadline carry).

## Gates (both feature states)

- `cargo clippy --all-targets -D warnings` — GREEN default (OFF) **and** `--features trust-graph` (ON).
- `cargo test` — GREEN both states (trust_graph: 5 passed with feature on).
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean (no private-item doc-links).
- `rustfmt` clean on touched files; `check-readme-template.py --enforce` → 0 deviations; `check-privacy-claims.sh` clean; no hard-coded perf numbers.

## Honest scope / residue

RESEARCH prototype, not a security guarantee. Clear-WebID holder binding stays the non-anonymous path (`sq-wvne`); the ZK estate it composes with is externally **unaudited** (`sq-qhy4`, pending external accredited-cryptographer sign-off). **Residue:** post-materialise *revocation* remains a re-materialise event (external-state change, not a request fact, G5) — only the two pure-`Session` conditions are deferred.

Design record updated: §3.3 A′ / §7.2 A′ / §7.5 / §7.6 marked **RESOLVED**; sparq-trust README + access-control SKILL updated. `sq-xc4y` closed on PR-open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)