### PR TITLE
feat(sparq-serve): backup change-stream / PITR companion — incremental delta artifacts on the Option-A base (sq-bu1a) [OPUS-4.8]

### DIFF
--- a/crates/sparq-serve/README.md
+++ b/crates/sparq-serve/README.md
@@ -55,6 +55,12 @@ cargo run -p sparq-server -- --format turtle data.ttl
   `backup::import` re-hydrates a `Graph` from one, **fail-closed** on a corrupt/mismatched
   artifact. Distinct from the offline `sparq-cli save` and the `--persist` WAL. At-rest
   encryption is out of scope. `sparq-server` mounts `/admin/backup` + `/admin/restore` on it.
+- **Incremental change-stream / PITR** (same `backup` feature) — `backup_delta::export_delta`
+  captures the quad-set change between two **same-lineage** generations as a self-describing
+  delta artifact keyed off the generation/writer-seq range; `backup_delta::replay` applies an
+  ordered chain forward onto a restored base to reach a chosen recovery point (fail-closed on a
+  corrupt or discontinuous chain). `sparq-server` adds `/admin/backup/delta?from=N` +
+  `--restore-delta` for point-in-time recovery.
 - **Response-bytes result cache** *(opt-in: `--features result-cache`, OFF by
   default)* — see below.
 

--- a/crates/sparq-serve/src/backup.rs
+++ b/crates/sparq-serve/src/backup.rs
@@ -111,7 +111,9 @@ impl From<io::Error> for BackupError {
 /// Total quad count of a [`Graph`] = the default-graph triples ([`Graph::len`], which counts
 /// ONLY the default graph) plus every named graph's triples. This is the count the N-Quads
 /// body has one line for, so it is what `triples` records and cross-checks on restore.
-fn total_quads(graph: &Graph) -> u64 {
+/// `pub(crate)` so the delta companion (`backup_delta`) cross-checks a replayed graph's quad
+/// count the same way.
+pub(crate) fn total_quads(graph: &Graph) -> u64 {
     let mut n = graph.len() as u64;
     for (_name, g) in &graph.named {
         n += g.len() as u64;
@@ -125,7 +127,10 @@ fn total_quads(graph: &Graph) -> u64 {
 /// two separate processes needs. NOT cryptographic: it detects accidental
 /// corruption/truncation, not tampering (at-rest authenticity is out of scope — see the
 /// module docs).
-fn body_digest(bytes: &[u8]) -> u64 {
+///
+/// `pub(crate)` so the delta-stream companion (`backup_delta`) digests its insert / delete
+/// bodies with the SAME function — one integrity scheme across the whole backup family.
+pub(crate) fn body_digest(bytes: &[u8]) -> u64 {
     const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
     const PRIME: u64 = 0x0000_0100_0000_01b3;
     let mut h = OFFSET;
@@ -311,8 +316,9 @@ pub fn import<R: Read>(input: R) -> Result<(Graph, BackupMeta), BackupError> {
 }
 
 /// Reads one trimmed line (without the trailing newline). An EOF mid-header is a format
-/// error (the header must be blank-line terminated).
-fn read_line<R: BufRead>(reader: &mut R) -> Result<String, BackupError> {
+/// error (the header must be blank-line terminated). `pub(crate)` so the delta companion
+/// (`backup_delta`) parses its header with the exact same line discipline.
+pub(crate) fn read_line<R: BufRead>(reader: &mut R) -> Result<String, BackupError> {
     let mut s = String::new();
     let n = reader.read_line(&mut s)?;
     if n == 0 {
@@ -327,7 +333,10 @@ fn read_line<R: BufRead>(reader: &mut R) -> Result<String, BackupError> {
     Ok(s)
 }
 
-fn parse_u64(val: &str, field: &str) -> Result<u64, BackupError> {
+/// Parses a `u64` header value, mapping a parse failure to a [`BackupError::Format`].
+/// `pub(crate)` so the delta companion (`backup_delta`) parses its numeric header fields
+/// with identical error reporting.
+pub(crate) fn parse_u64(val: &str, field: &str) -> Result<u64, BackupError> {
     val.parse()
         .map_err(|_| BackupError::Format(format!("invalid `{}` header value {:?}", field, val)))
 }

--- a/crates/sparq-serve/src/backup_delta.rs
+++ b/crates/sparq-serve/src/backup_delta.rs
@@ -1,0 +1,749 @@
+//! [OPUS-4.8] (sq-bu1a) The INCREMENTAL DELTA-STREAM companion to the Option-A base backup
+//! ([`crate::backup`]) — the change-stream / point-in-time-recovery (PITR) other half.
+//!
+//! ## What this is
+//!
+//! [`backup::export`](crate::backup::export) captures a single consistent generation as a
+//! self-describing BASE artifact. This module captures the **change** between two generations
+//! of the SAME ring lineage as a self-describing DELTA artifact, keyed off the recorded
+//! generation/writer-seq (`from-generation` → `to-generation`). A restore then **replays
+//! forward**: load the base, apply an ordered chain of deltas, and arrive at any later point in
+//! the writer history that the chain covers — PITR.
+//!
+//! ```text
+//!   base@G0 ──(delta G0→G3)──▶ G3 ──(delta G3→G7)──▶ G7   (= a chosen recovery point)
+//! ```
+//!
+//! ## Artifact format — delta (a distinct kind, deliberately)
+//!
+//! A delta is its OWN artifact kind with its own magic ([`DELTA_MAGIC`]) and version, so it can
+//! never be confused with a base ([`backup`](crate::backup) keeps `SPARQ-BACKUP` v1) and so an
+//! `import_base`/`import_delta` mismatch fails closed at the magic line. The layout mirrors the
+//! base's line-oriented textual header (trivially inspectable, version-stable), followed by TWO
+//! N-Quads bodies — the quads INSERTED and the quads DELETED between `from` and `to`:
+//!
+//! ```text
+//!   SPARQ-BACKUP-DELTA 1
+//!   from-generation <u64>          ← the base/predecessor seq this delta applies onto
+//!   to-generation   <u64>          ← the seq this delta advances to
+//!   inserts <count>                ← quad lines in the inserts body
+//!   deletes <count>                ← quad lines in the deletes body
+//!   inserts-bytes <len> ; inserts-fnv1a64 <16hex>
+//!   deletes-bytes <len> ; deletes-fnv1a64 <16hex>
+//!   epoch <n> ; epoch-entry <epoch> <pod-iri> …   ← the per-pod vector AT `to`
+//!   <blank line>
+//!   <inserts N-Quads body><deletes N-Quads body>   ← inserts first, then deletes
+//! ```
+//!
+//! The delta is computed as the **quad-set difference** of the two generations' N-Quads
+//! serialisations: a quad in `to` but not in `from` is an insert; a quad in `from` but not in
+//! `to` is a delete. This stays inside the Option-A spirit — self-describing, lossless,
+//! format-stable RDF that round-trips through [`Graph::apply_delta_nquads`](sparq_core::Graph::apply_delta_nquads).
+//!
+//! ## Load-bearing boundary: SAME-LINEAGE deltas only (honest scope)
+//!
+//! A quad-set diff of two N-Quads serialisations is correct **only when blank-node labels are
+//! stable between the two snapshots** — i.e. the two generations come from the **same ring
+//! lineage** (the writer forks a generation and applies updates, preserving every surviving
+//! term's identity, blank nodes included). That is exactly the PITR use case: a delta is always
+//! taken between two points of one writer history, and replayed onto the base from THAT history.
+//! Diffing snapshots from two unrelated load paths (where the same logical blank node may carry
+//! different labels) is NOT supported and is not what the change stream does.
+//! [`replay`](crate::backup_delta::replay) enforces the *generation*-continuity half of this
+//! (each delta's `from` must equal the running seq); the lineage assumption itself is a
+//! documented operator contract, not a runtime check.
+//!
+//! ## Fail-closed, same as the base
+//!
+//! [`import_delta`](crate::backup_delta::import_delta) rejects — never partially applies — a delta
+//! whose magic, version, header shape, body lengths or body digests do not check out;
+//! [`replay`](crate::backup_delta::replay) additionally rejects a
+//! gapped/overlapping/out-of-order chain. A corrupt or discontinuous stream yields a
+//! [`BackupError`] and the in-progress graph is discarded, so a PITR that fails leaves a clean
+//! error rather than a silently-wrong store.
+//!
+//! **Out of scope (a separate concern), same as the base:** at-rest encryption + cryptographic
+//! authenticity. The digests are the SAME non-cryptographic FNV-1a checksum the base uses — they
+//! detect truncation/corruption/version-mismatch, not tampering.
+
+use std::collections::BTreeSet;
+use std::io::{self, Read, Write};
+
+use sparq_core::Graph;
+use sparq_engine::serialize::graph_to_nquads;
+
+use crate::backup::{body_digest, parse_u64, read_line, total_quads, BackupError, BackupMeta};
+use crate::epoch::{Epoch, PodEpochs, PodId};
+use crate::ring::Generation;
+
+/// Magic line that opens every sparq DELTA artifact — distinct from the base's `SPARQ-BACKUP`
+/// so the two kinds can never be confused (an `import_delta` of a base, or vice-versa, fails
+/// closed at this line).
+pub const DELTA_MAGIC: &str = "SPARQ-BACKUP-DELTA";
+
+/// Delta artifact format version. Bumped independently of the base's version; [`import_delta`]
+/// rejects an unknown version (fail-closed) rather than mis-reading a newer layout.
+const DELTA_FORMAT_VERSION: u32 = 1;
+
+/// The point-in-time metadata captured ALONGSIDE the change-set in a delta artifact: the
+/// `from`/`to` generation/writer-seq range it bridges, the per-pod epoch vector AT `to`, and the
+/// insert / delete quad counts. Replayed in order, the `to` of one delta is the `from` of the
+/// next, so a chain reconstructs the writer history between a base and a chosen recovery point.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DeltaMeta {
+    /// The generation/writer-seq this delta applies ONTO — the base (or predecessor delta's
+    /// `to`). [`replay`] checks this equals the running generation before applying, so a gap or
+    /// an out-of-order delta fails closed.
+    pub from_generation: u64,
+    /// The generation/writer-seq this delta advances the store TO. Strictly greater than
+    /// `from_generation` (a delta always moves forward; equal/backward is rejected on import).
+    pub to_generation: u64,
+    /// The per-pod epoch vector as of `to_generation`. Restored verbatim so cache-invalidation
+    /// epochs stay continuous across a replayed restore (a pod's epoch never goes backwards).
+    pub epochs: PodEpochs,
+    /// Number of quads inserted between `from` and `to` (lines in the inserts body).
+    pub inserts: u64,
+    /// Number of quads deleted between `from` and `to` (lines in the deletes body).
+    pub deletes: u64,
+}
+
+/// The N-Quads line sets of a graph's full dataset (default + named graphs), one `String` per
+/// quad, in a `BTreeSet` so set-difference is deterministic and the result is stably ordered.
+/// Blank-node labels are rendered verbatim by the serialiser, so this is a faithful per-quad set
+/// WITHIN a lineage (see the module's same-lineage boundary).
+fn quad_lines(graph: &Graph) -> BTreeSet<String> {
+    graph_to_nquads(graph)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .map(String::from)
+        .collect()
+}
+
+/// Computes the change-set between `from` and `to` (both same-lineage generations) and writes a
+/// single self-describing DELTA artifact to `out`. `to` must be strictly later than `from`
+/// (`to.number() > from.number()`); a non-increasing range is a caller error
+/// ([`BackupError::Format`]).
+///
+/// Both generations are already immutable (held by their `Arc`s), so this runs **while serving**:
+/// nothing here touches the ring or the writer. The delta's epoch vector is taken from `to`.
+pub fn export_delta<W: Write>(
+    from: &Generation<Graph>,
+    to: &Generation<Graph>,
+    out: &mut W,
+) -> Result<DeltaMeta, BackupError> {
+    if to.number() <= from.number() {
+        return Err(BackupError::Format(format!(
+            "delta range must move forward: from-generation {} >= to-generation {}",
+            from.number(),
+            to.number()
+        )));
+    }
+    let from_lines = quad_lines(from.snapshot());
+    let to_lines = quad_lines(to.snapshot());
+
+    // Inserts = in `to` but not `from`; deletes = in `from` but not `to`. BTreeSet difference is
+    // sorted+deterministic, so the bodies (and thus the digests) are reproducible.
+    let mut inserts = String::new();
+    let mut n_inserts: u64 = 0;
+    for line in to_lines.difference(&from_lines) {
+        inserts.push_str(line);
+        inserts.push('\n');
+        n_inserts += 1;
+    }
+    let mut deletes = String::new();
+    let mut n_deletes: u64 = 0;
+    for line in from_lines.difference(&to_lines) {
+        deletes.push_str(line);
+        deletes.push('\n');
+        n_deletes += 1;
+    }
+
+    let ins_bytes = inserts.as_bytes();
+    let del_bytes = deletes.as_bytes();
+    let ins_digest = body_digest(ins_bytes);
+    let del_digest = body_digest(del_bytes);
+
+    writeln!(out, "{} {}", DELTA_MAGIC, DELTA_FORMAT_VERSION)?;
+    writeln!(out, "from-generation {}", from.number())?;
+    writeln!(out, "to-generation {}", to.number())?;
+    writeln!(out, "inserts {}", n_inserts)?;
+    writeln!(out, "deletes {}", n_deletes)?;
+    writeln!(out, "inserts-bytes {}", ins_bytes.len())?;
+    writeln!(out, "inserts-fnv1a64 {:016x}", ins_digest)?;
+    writeln!(out, "deletes-bytes {}", del_bytes.len())?;
+    writeln!(out, "deletes-fnv1a64 {:016x}", del_digest)?;
+    // Epoch vector AT `to` — same line shape as the base header.
+    let epochs = to.epochs();
+    writeln!(out, "epoch {}", epochs.len())?;
+    for (pod, epoch) in epochs.iter() {
+        writeln!(out, "epoch-entry {} {}", epoch, pod.as_str())?;
+    }
+    writeln!(out)?; // blank line: end of header
+    out.write_all(ins_bytes)?;
+    out.write_all(del_bytes)?;
+    out.flush()?;
+
+    Ok(DeltaMeta {
+        from_generation: from.number(),
+        to_generation: to.number(),
+        epochs: epochs.clone(),
+        inserts: n_inserts,
+        deletes: n_deletes,
+    })
+}
+
+/// A decoded delta artifact: the insert / delete N-Quads bodies (ready for
+/// [`Graph::apply_delta_nquads`]) and the [`DeltaMeta`] describing the seq range + epoch vector.
+/// Kept separate from application so a caller can inspect / chain / validate a stream before any
+/// graph is mutated.
+#[derive(Clone, Debug)]
+pub struct Delta {
+    /// The change-stream metadata (seq range, epoch vector, counts).
+    pub meta: DeltaMeta,
+    /// The N-Quads of the quads to INSERT (default + named graphs).
+    pub inserts: String,
+    /// The N-Quads of the quads to DELETE (default + named graphs).
+    pub deletes: String,
+}
+
+/// Imports one delta artifact from `input`, returning the decoded [`Delta`] WITHOUT applying it.
+/// **Fail-closed**: a bad/absent magic, an unknown version, a malformed header, a non-forward
+/// range, or a body whose declared length / count / digest does not match all yield a
+/// [`BackupError`]. Applying a chain of these is [`replay`].
+pub fn import_delta<R: Read>(input: R) -> Result<Delta, BackupError> {
+    let mut reader = io::BufReader::new(input);
+
+    // --- Magic + version ---
+    let first = read_line(&mut reader)?;
+    let mut parts = first.splitn(2, ' ');
+    let magic = parts.next().unwrap_or("");
+    if magic != DELTA_MAGIC {
+        return Err(BackupError::Format(format!(
+            "not a sparq delta artifact (expected magic {:?})",
+            DELTA_MAGIC
+        )));
+    }
+    let version: u32 = parts
+        .next()
+        .and_then(|v| v.trim().parse().ok())
+        .ok_or_else(|| BackupError::Format("missing/invalid delta format version".into()))?;
+    if version != DELTA_FORMAT_VERSION {
+        return Err(BackupError::Format(format!(
+            "unsupported delta format version {} (this build reads/writes {})",
+            version, DELTA_FORMAT_VERSION
+        )));
+    }
+
+    // --- Header ---
+    let mut from_generation: Option<u64> = None;
+    let mut to_generation: Option<u64> = None;
+    let mut inserts: Option<u64> = None;
+    let mut deletes: Option<u64> = None;
+    let mut inserts_bytes: Option<usize> = None;
+    let mut deletes_bytes: Option<usize> = None;
+    let mut inserts_digest_hdr: Option<u64> = None;
+    let mut deletes_digest_hdr: Option<u64> = None;
+    let mut epoch_count: Option<usize> = None;
+    let mut epochs = PodEpochs::default();
+    let mut epoch_entries: usize = 0;
+
+    loop {
+        let line = read_line(&mut reader)?;
+        if line.is_empty() {
+            break; // blank line: end of header
+        }
+        let mut kv = line.splitn(2, ' ');
+        let key = kv.next().unwrap_or("");
+        let val = kv.next().unwrap_or("").trim();
+        match key {
+            "from-generation" => from_generation = Some(parse_u64(val, "from-generation")?),
+            "to-generation" => to_generation = Some(parse_u64(val, "to-generation")?),
+            "inserts" => inserts = Some(parse_u64(val, "inserts")?),
+            "deletes" => deletes = Some(parse_u64(val, "deletes")?),
+            "inserts-bytes" => {
+                inserts_bytes = Some(usize::try_from(parse_u64(val, "inserts-bytes")?).map_err(
+                    |_| BackupError::Format("inserts-bytes exceeds platform usize".into()),
+                )?)
+            }
+            "deletes-bytes" => {
+                deletes_bytes = Some(usize::try_from(parse_u64(val, "deletes-bytes")?).map_err(
+                    |_| BackupError::Format("deletes-bytes exceeds platform usize".into()),
+                )?)
+            }
+            "inserts-fnv1a64" => {
+                inserts_digest_hdr = Some(u64::from_str_radix(val, 16).map_err(|_| {
+                    BackupError::Format("invalid inserts-fnv1a64 digest (not 16-hex)".into())
+                })?)
+            }
+            "deletes-fnv1a64" => {
+                deletes_digest_hdr = Some(u64::from_str_radix(val, 16).map_err(|_| {
+                    BackupError::Format("invalid deletes-fnv1a64 digest (not 16-hex)".into())
+                })?)
+            }
+            "epoch" => {
+                epoch_count = Some(usize::try_from(parse_u64(val, "epoch")?).map_err(|_| {
+                    BackupError::Format("epoch count exceeds platform usize".into())
+                })?)
+            }
+            "epoch-entry" => {
+                let mut ev = val.splitn(2, ' ');
+                let e: Epoch = ev
+                    .next()
+                    .and_then(|s| s.parse().ok())
+                    .ok_or_else(|| BackupError::Format("invalid epoch-entry epoch".into()))?;
+                let pod = ev
+                    .next()
+                    .filter(|s| !s.is_empty())
+                    .ok_or_else(|| BackupError::Format("missing epoch-entry pod IRI".into()))?;
+                epochs.set(PodId::new(pod), e);
+                epoch_entries += 1;
+            }
+            // Unknown header keys are rejected (fail-closed), same as the base importer.
+            other => {
+                return Err(BackupError::Format(format!(
+                    "unknown delta header key {:?}",
+                    other
+                )))
+            }
+        }
+    }
+
+    let from_generation = from_generation
+        .ok_or_else(|| BackupError::Format("missing `from-generation` header".into()))?;
+    let to_generation = to_generation
+        .ok_or_else(|| BackupError::Format("missing `to-generation` header".into()))?;
+    if to_generation <= from_generation {
+        return Err(BackupError::Format(format!(
+            "delta range must move forward: from-generation {} >= to-generation {}",
+            from_generation, to_generation
+        )));
+    }
+    let inserts = inserts.ok_or_else(|| BackupError::Format("missing `inserts` header".into()))?;
+    let deletes = deletes.ok_or_else(|| BackupError::Format("missing `deletes` header".into()))?;
+    let inserts_bytes = inserts_bytes
+        .ok_or_else(|| BackupError::Format("missing `inserts-bytes` header".into()))?;
+    let deletes_bytes = deletes_bytes
+        .ok_or_else(|| BackupError::Format("missing `deletes-bytes` header".into()))?;
+    let inserts_digest_hdr = inserts_digest_hdr
+        .ok_or_else(|| BackupError::Format("missing `inserts-fnv1a64` header".into()))?;
+    let deletes_digest_hdr = deletes_digest_hdr
+        .ok_or_else(|| BackupError::Format("missing `deletes-fnv1a64` header".into()))?;
+    if let Some(n) = epoch_count {
+        if n != epoch_entries {
+            return Err(BackupError::Format(format!(
+                "epoch count {} != {} epoch-entry lines",
+                n, epoch_entries
+            )));
+        }
+    }
+
+    // --- Bodies (inserts first, then deletes; each exactly its declared byte length) ---
+    let inserts_body = read_body(&mut reader, inserts_bytes, inserts_digest_hdr, "inserts")?;
+    let deletes_body = read_body(&mut reader, deletes_bytes, deletes_digest_hdr, "deletes")?;
+    // Cross-check the declared quad counts against the actual non-empty line counts.
+    check_line_count(&inserts_body, inserts, "inserts")?;
+    check_line_count(&deletes_body, deletes, "deletes")?;
+
+    Ok(Delta {
+        meta: DeltaMeta {
+            from_generation,
+            to_generation,
+            epochs,
+            inserts,
+            deletes,
+        },
+        inserts: inserts_body,
+        deletes: deletes_body,
+    })
+}
+
+/// Reads exactly `len` bytes, verifies the digest, and decodes UTF-8 — the shared body reader for
+/// both the inserts and the deletes sections. Fail-closed on a short read, a digest mismatch, or
+/// invalid UTF-8.
+fn read_body<R: Read>(
+    reader: &mut R,
+    len: usize,
+    digest_hdr: u64,
+    which: &str,
+) -> Result<String, BackupError> {
+    let mut body = vec![0u8; len];
+    reader.read_exact(&mut body).map_err(|_| {
+        BackupError::Corrupt(format!("{} body shorter than declared byte length", which))
+    })?;
+    let actual = body_digest(&body);
+    if actual != digest_hdr {
+        return Err(BackupError::Corrupt(format!(
+            "{} body digest mismatch (header {:016x}, computed {:016x})",
+            which, digest_hdr, actual
+        )));
+    }
+    String::from_utf8(body)
+        .map_err(|_| BackupError::Corrupt(format!("{} body is not valid UTF-8", which)))
+}
+
+/// Cross-checks the number of non-empty quad lines in `body` against the declared `count`.
+fn check_line_count(body: &str, count: u64, which: &str) -> Result<(), BackupError> {
+    let actual = body.lines().filter(|l| !l.trim().is_empty()).count() as u64;
+    if actual != count {
+        return Err(BackupError::Corrupt(format!(
+            "{} line count mismatch (header {}, decoded {})",
+            which, count, actual
+        )));
+    }
+    Ok(())
+}
+
+/// Replays an ordered chain of delta artifacts forward onto a restored BASE graph, in place,
+/// reconstructing the store as of the LAST delta's `to_generation` — point-in-time recovery.
+///
+/// `base_meta` is the [`BackupMeta`] the base was imported with ([`backup::import`](crate::backup::import));
+/// its `generation` is the seq the chain must start from. Each delta `d` in `deltas` is applied
+/// only if `d.meta.from_generation` equals the running generation (the base's generation, then
+/// the previous delta's `to_generation`); a gap, an overlap, or an out-of-order delta is rejected
+/// **fail-closed** ([`BackupError::Corrupt`]) and `graph` is left as it was at the last good step
+/// — the caller discards a partially-replayed graph rather than serving a wrong store. Returns
+/// the [`BackupMeta`] of the recovered point (the last delta's epoch vector + `to_generation`, or
+/// the unchanged `base_meta` for an empty chain).
+///
+/// The chain must be **same-lineage** with the base (see the module boundary): the deltas are the
+/// writer history of that base, replayed onto it.
+pub fn replay<'a, I>(
+    graph: &mut Graph,
+    base_meta: &BackupMeta,
+    deltas: I,
+) -> Result<BackupMeta, BackupError>
+where
+    I: IntoIterator<Item = &'a Delta>,
+{
+    let mut current = base_meta.generation;
+    let mut epochs = base_meta.epochs.clone();
+    for d in deltas {
+        if d.meta.from_generation != current {
+            return Err(BackupError::Corrupt(format!(
+                "delta chain discontinuity: expected a delta from generation {}, got one from {} (to {})",
+                current, d.meta.from_generation, d.meta.to_generation
+            )));
+        }
+        graph
+            .apply_delta_nquads(&d.inserts, &d.deletes)
+            .map_err(|e| BackupError::Corrupt(format!("delta replay failed: {}", e)))?;
+        current = d.meta.to_generation;
+        epochs = d.meta.epochs.clone();
+    }
+    Ok(BackupMeta {
+        generation: current,
+        epochs,
+        triples: total_quads(graph),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::backup::{export as export_base, import as import_base};
+    use crate::ring::GenerationRing;
+
+    fn graph_with(nq: &str) -> Graph {
+        Graph::load_dataset(nq, "nquads").expect("seed parses")
+    }
+
+    /// Sorted N-Quads line set of a graph — the equality oracle for "same dataset".
+    fn lines_sorted(g: &Graph) -> Vec<String> {
+        let mut v: Vec<String> = graph_to_nquads(g)
+            .lines()
+            .filter(|l| !l.trim().is_empty())
+            .map(String::from)
+            .collect();
+        v.sort();
+        v
+    }
+
+    /// `Graph` is not `Debug`, so a `Result<Delta, _>::unwrap_err` is fine but a
+    /// `Result<(Graph, _), _>` is not — extract the error without Debug-formatting Ok.
+    fn err_of<T>(res: Result<T, BackupError>) -> BackupError {
+        match res {
+            Ok(_) => panic!("expected a fail-closed error, but it succeeded"),
+            Err(e) => e,
+        }
+    }
+
+    /// The load-bearing invariant: base + replayed delta chain == the live generation it was
+    /// taken at (RESULT-EQUIVALENCE). Build a ring, publish a few generations with real
+    /// inserts/deletes across default + named graphs, back up the base at G0, export deltas, and
+    /// replay them — the recovered graph must equal the live target generation quad-for-quad.
+    #[test]
+    fn pitr_replay_equals_live_target() {
+        let pod_a = PodId::new("http://ex/g");
+        let ring: GenerationRing<Graph> = GenerationRing::new(graph_with(
+            "<http://ex/s0> <http://ex/p> <http://ex/o0> .\n",
+        ));
+        let base = ring.current();
+
+        // G1: add a default + a named-graph triple.
+        let g1 = ring.publish(
+            graph_with(
+                "<http://ex/s0> <http://ex/p> <http://ex/o0> .\n\
+                 <http://ex/s1> <http://ex/p> <http://ex/o1> .\n\
+                 <http://ex/s1> <http://ex/p> \"in-g\" <http://ex/g> .\n",
+            ),
+            [pod_a.clone()],
+        );
+        // G2: delete the original default triple, add another named-graph triple.
+        let g2 = ring.publish(
+            graph_with(
+                "<http://ex/s1> <http://ex/p> <http://ex/o1> .\n\
+                 <http://ex/s1> <http://ex/p> \"in-g\" <http://ex/g> .\n\
+                 <http://ex/s2> <http://ex/p> \"in-g\" <http://ex/g> .\n",
+            ),
+            [pod_a.clone()],
+        );
+
+        // Base artifact @G0.
+        let mut base_buf = Vec::new();
+        export_base(&base, &mut base_buf).expect("export base");
+        // Two deltas: G0→G1 and G1→G2.
+        let mut d01 = Vec::new();
+        let m01 = export_delta(&base, &g1, &mut d01).expect("export delta 0->1");
+        assert_eq!(m01.from_generation, 0);
+        assert_eq!(m01.to_generation, 1);
+        let mut d12 = Vec::new();
+        export_delta(&g1, &g2, &mut d12).expect("export delta 1->2");
+
+        // Restore: import base, decode the chain, replay.
+        let (mut restored, base_meta) = import_base(&base_buf[..]).expect("import base");
+        let dec01 = import_delta(&d01[..]).expect("import delta 0->1");
+        let dec12 = import_delta(&d12[..]).expect("import delta 1->2");
+        let recovered = replay(&mut restored, &base_meta, [&dec01, &dec12]).expect("replay chain");
+
+        // The recovered point is generation 2 with the named-pod epoch from g2.
+        assert_eq!(recovered.generation, 2);
+        assert_eq!(recovered.epochs.epoch(&pod_a), g2.epochs().epoch(&pod_a));
+        // Quad-for-quad equality with the live G2 snapshot.
+        assert_eq!(
+            lines_sorted(&restored),
+            lines_sorted(g2.snapshot()),
+            "PITR replay must equal the live target generation"
+        );
+    }
+
+    /// Replaying PART of the chain recovers the INTERMEDIATE point (a chosen earlier PITR target).
+    #[test]
+    fn partial_replay_recovers_intermediate_point() {
+        let ring: GenerationRing<Graph> = GenerationRing::new(graph_with(
+            "<http://ex/s0> <http://ex/p> <http://ex/o0> .\n",
+        ));
+        let base = ring.current();
+        let g1 = ring.publish(
+            graph_with(
+                "<http://ex/s0> <http://ex/p> <http://ex/o0> .\n\
+                 <http://ex/s1> <http://ex/p> <http://ex/o1> .\n",
+            ),
+            [],
+        );
+        let g2 = ring.publish(
+            graph_with("<http://ex/s9> <http://ex/p> <http://ex/o9> .\n"),
+            [],
+        );
+        let _ = g2;
+
+        let mut base_buf = Vec::new();
+        export_base(&base, &mut base_buf).expect("export base");
+        let mut d01 = Vec::new();
+        export_delta(&base, &g1, &mut d01).expect("export 0->1");
+
+        let (mut restored, base_meta) = import_base(&base_buf[..]).expect("import base");
+        let dec01 = import_delta(&d01[..]).expect("import 0->1");
+        let recovered = replay(&mut restored, &base_meta, [&dec01]).expect("replay 0->1");
+        assert_eq!(recovered.generation, 1);
+        assert_eq!(lines_sorted(&restored), lines_sorted(g1.snapshot()));
+    }
+
+    /// An EMPTY chain is the base itself (PITR target == the base point).
+    #[test]
+    fn empty_chain_is_the_base() {
+        let ring: GenerationRing<Graph> =
+            GenerationRing::new(graph_with("<http://ex/s> <http://ex/p> <http://ex/o> .\n"));
+        let base = ring.current();
+        let mut base_buf = Vec::new();
+        export_base(&base, &mut base_buf).expect("export base");
+        let (mut restored, base_meta) = import_base(&base_buf[..]).expect("import base");
+        let recovered =
+            replay(&mut restored, &base_meta, std::iter::empty()).expect("empty replay");
+        assert_eq!(recovered.generation, base_meta.generation);
+        assert_eq!(recovered.triples, base_meta.triples);
+    }
+
+    /// A round-tripped delta preserves its metadata (seq range + epoch vector + counts).
+    #[test]
+    fn delta_roundtrip_preserves_meta() {
+        let pod = PodId::new("http://ex/g");
+        let ring: GenerationRing<Graph> = GenerationRing::new(graph_with(""));
+        let base = ring.current();
+        let g3 = {
+            ring.publish(
+                graph_with("<http://ex/a> <http://ex/p> <http://ex/b> .\n"),
+                [pod.clone()],
+            );
+            ring.publish(
+                graph_with("<http://ex/a> <http://ex/p> <http://ex/b> .\n"),
+                [pod.clone()],
+            );
+            ring.publish(
+                graph_with(
+                    "<http://ex/a> <http://ex/p> <http://ex/b> .\n\
+                     <http://ex/c> <http://ex/p> \"x\" <http://ex/g> .\n",
+                ),
+                [pod.clone()],
+            )
+        };
+        assert_eq!(g3.number(), 3);
+        let mut buf = Vec::new();
+        let exported = export_delta(&base, &g3, &mut buf).expect("export");
+        let decoded = import_delta(&buf[..]).expect("import");
+        assert_eq!(decoded.meta, exported);
+        assert_eq!(decoded.meta.from_generation, 0);
+        assert_eq!(decoded.meta.to_generation, 3);
+        assert_eq!(decoded.meta.epochs.epoch(&pod), 3);
+        // 2 quads added (one default, one named), nothing deleted.
+        assert_eq!(decoded.meta.inserts, 2);
+        assert_eq!(decoded.meta.deletes, 0);
+    }
+
+    /// A non-forward range is rejected on export AND on import (fail-closed).
+    #[test]
+    fn rejects_non_forward_range() {
+        let ring: GenerationRing<Graph> = GenerationRing::new(graph_with(""));
+        let base = ring.current();
+        let g1 = ring.publish(
+            graph_with("<http://ex/a> <http://ex/p> <http://ex/b> .\n"),
+            [],
+        );
+        // Export with from=g1, to=base (backwards) is rejected.
+        let mut buf = Vec::new();
+        let err = err_of(export_delta(&g1, &base, &mut buf));
+        assert!(matches!(err, BackupError::Format(_)), "{:?}", err);
+        // A hand-crafted backwards artifact is rejected on import too.
+        let art = "SPARQ-BACKUP-DELTA 1\nfrom-generation 5\nto-generation 5\ninserts 0\n\
+                   deletes 0\ninserts-bytes 0\ninserts-fnv1a64 cbf29ce484222325\n\
+                   deletes-bytes 0\ndeletes-fnv1a64 cbf29ce484222325\nepoch 0\n\n";
+        let err = err_of(import_delta(art.as_bytes()));
+        assert!(matches!(err, BackupError::Format(_)), "{:?}", err);
+    }
+
+    /// A delta is NOT a base and vice-versa: import_delta of a base, and import (base) of a
+    /// delta, both fail closed at the magic line.
+    #[test]
+    fn delta_and_base_are_distinct_kinds() {
+        let ring: GenerationRing<Graph> =
+            GenerationRing::new(graph_with("<http://ex/s> <http://ex/p> <http://ex/o> .\n"));
+        let base = ring.current();
+        let g1 = ring.publish(
+            graph_with("<http://ex/s> <http://ex/p> <http://ex/o2> .\n"),
+            [],
+        );
+        let mut base_buf = Vec::new();
+        export_base(&base, &mut base_buf).expect("export base");
+        let mut delta_buf = Vec::new();
+        export_delta(&base, &g1, &mut delta_buf).expect("export delta");
+        // import_delta of a base artifact -> Format error (wrong magic).
+        let err = err_of(import_delta(&base_buf[..]));
+        assert!(matches!(err, BackupError::Format(_)), "{:?}", err);
+        // import (base) of a delta artifact -> Format error (wrong magic).
+        let err = err_of(import_base(&delta_buf[..]));
+        assert!(matches!(err, BackupError::Format(_)), "{:?}", err);
+    }
+
+    /// A gapped chain is rejected fail-closed on replay (the base is G0 but the chain starts at G5).
+    #[test]
+    fn replay_rejects_chain_gap() {
+        let ring: GenerationRing<Graph> = GenerationRing::new(graph_with(""));
+        let base = ring.current();
+        let g1 = ring.publish(
+            graph_with("<http://ex/a> <http://ex/p> <http://ex/b> .\n"),
+            [],
+        );
+        let mut base_buf = Vec::new();
+        export_base(&base, &mut base_buf).expect("export base");
+        let mut d = Vec::new();
+        export_delta(&base, &g1, &mut d).expect("export 0->1");
+        let mut dec = import_delta(&d[..]).expect("import 0->1");
+        // Forge a gap: claim this delta applies from generation 5, not 0.
+        dec.meta.from_generation = 5;
+        let (mut restored, base_meta) = import_base(&base_buf[..]).expect("import base");
+        let err = err_of(replay(&mut restored, &base_meta, [&dec]));
+        assert!(matches!(err, BackupError::Corrupt(_)), "{:?}", err);
+    }
+
+    /// An out-of-order chain (correct individually, wrong sequence) is rejected fail-closed.
+    #[test]
+    fn replay_rejects_out_of_order() {
+        let ring: GenerationRing<Graph> = GenerationRing::new(graph_with(""));
+        let base = ring.current();
+        let g1 = ring.publish(
+            graph_with("<http://ex/a> <http://ex/p> <http://ex/b> .\n"),
+            [],
+        );
+        let g2 = ring.publish(
+            graph_with("<http://ex/c> <http://ex/p> <http://ex/d> .\n"),
+            [],
+        );
+        let mut base_buf = Vec::new();
+        export_base(&base, &mut base_buf).expect("export base");
+        let mut d01 = Vec::new();
+        export_delta(&base, &g1, &mut d01).expect("0->1");
+        let mut d12 = Vec::new();
+        export_delta(&g1, &g2, &mut d12).expect("1->2");
+        let dec01 = import_delta(&d01[..]).expect("import 0->1");
+        let dec12 = import_delta(&d12[..]).expect("import 1->2");
+        let (mut restored, base_meta) = import_base(&base_buf[..]).expect("import base");
+        // 1->2 before 0->1: the first applied delta's from-generation (1) != base generation (0).
+        let err = err_of(replay(&mut restored, &base_meta, [&dec12, &dec01]));
+        assert!(matches!(err, BackupError::Corrupt(_)), "{:?}", err);
+    }
+
+    /// A corrupt body (digest mismatch) is rejected fail-closed on import.
+    #[test]
+    fn import_rejects_corrupt_body() {
+        let ring: GenerationRing<Graph> = GenerationRing::new(graph_with(""));
+        let base = ring.current();
+        let g1 = ring.publish(
+            graph_with("<http://ex/a> <http://ex/p> <http://ex/b> .\n"),
+            [],
+        );
+        let mut buf = Vec::new();
+        export_delta(&base, &g1, &mut buf).expect("export");
+        // Flip a byte inside the bodies (after the blank-line header terminator).
+        let header_end = buf
+            .windows(2)
+            .position(|w| w == b"\n\n")
+            .expect("blank-line terminator")
+            + 2;
+        buf[header_end + 1] ^= 0xff;
+        let err = err_of(import_delta(&buf[..]));
+        assert!(matches!(err, BackupError::Corrupt(_)), "{:?}", err);
+    }
+
+    /// A truncated delta (body shorter than declared) is rejected fail-closed.
+    #[test]
+    fn import_rejects_truncated() {
+        let ring: GenerationRing<Graph> = GenerationRing::new(graph_with(""));
+        let base = ring.current();
+        let g1 = ring.publish(
+            graph_with("<http://ex/a> <http://ex/p> <http://ex/b> .\n"),
+            [],
+        );
+        let mut buf = Vec::new();
+        export_delta(&base, &g1, &mut buf).expect("export");
+        buf.truncate(buf.len() - 3);
+        let err = err_of(import_delta(&buf[..]));
+        assert!(matches!(err, BackupError::Corrupt(_)), "{:?}", err);
+    }
+
+    /// An unknown delta format version is rejected fail-closed.
+    #[test]
+    fn import_rejects_unknown_version() {
+        let art = "SPARQ-BACKUP-DELTA 999\nfrom-generation 0\nto-generation 1\ninserts 0\n\n";
+        let err = err_of(import_delta(art.as_bytes()));
+        assert!(matches!(err, BackupError::Format(_)), "{:?}", err);
+    }
+}

--- a/crates/sparq-serve/src/lib.rs
+++ b/crates/sparq-serve/src/lib.rs
@@ -15,6 +15,14 @@ mod applier;
 /// for the Option-A artifact format and the at-rest-encryption out-of-scope boundary.
 #[cfg(feature = "backup")]
 pub mod backup;
+/// [OPUS-4.8] (sq-bu1a) The INCREMENTAL DELTA-STREAM / point-in-time-recovery companion to the
+/// Option-A base backup ([`backup`]): export the change between two same-lineage generations as a
+/// self-describing delta artifact keyed off generation/writer-seq, and replay an ordered chain of
+/// deltas forward onto a restored base to reach a chosen recovery point (fail-closed on a corrupt
+/// or discontinuous stream). Compiled only behind the opt-in `backup` feature (default OFF). See
+/// the module docs for the delta artifact format and the same-lineage boundary.
+#[cfg(feature = "backup")]
+pub mod backup_delta;
 mod epoch;
 mod footprint;
 mod ring;
@@ -43,6 +51,15 @@ mod canon;
 
 #[cfg(feature = "backup")]
 pub use backup::{export as backup_export, import as backup_import, BackupError, BackupMeta};
+// [OPUS-4.8] (sq-bu1a) The change-stream / PITR delta companion (feature `backup`):
+// `export_delta` between two same-lineage generations, `import_delta` to decode one (fail-closed),
+// and `replay` to apply an ordered chain forward onto a restored base. `DELTA_MAGIC` is the
+// artifact's distinguishing magic line; `Delta`/`DeltaMeta` are the decoded forms.
+#[cfg(feature = "backup")]
+pub use backup_delta::{
+    export_delta as backup_export_delta, import_delta as backup_import_delta,
+    replay as backup_replay, Delta, DeltaMeta, DELTA_MAGIC,
+};
 pub use applier::{GraphApplier, DEFAULT_COMPACT_THRESHOLD};
 pub use epoch::{Epoch, PodEpochs, PodId};
 pub use footprint::{Footprint, TargetGraph};

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -54,7 +54,7 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
   **default-deny** SSRF guard), `federation-descriptors` (VoID + Service Description discovery),
   `tpf`/`brtpf` (Triple Pattern Fragments / bind-restricted LDF source), `shacl`
   (`POST /shacl/validate`), `n3-patch` (Solid `text/n3` N3-Patch on GSP `PATCH`),
-  `backup` (online snapshot `POST /admin/backup` + `/admin/restore`, no stop-the-world),
+  `backup` (online snapshot `/admin/backup` + incremental PITR delta `/admin/backup/delta` + `/admin/restore`),
   `audit-log`/`access-audit` (access trails), `zlib-ng` (faster gzip).
 - **Default-on JSON-LD** ([OPUS-4.8] sq-oy1f.4, user-prioritised epic sq-oy1f) — the `jsonld`
   feature is in the server's **default** set (a maintainer-directed exception to opt-in-by-default):

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -531,6 +531,18 @@ pub struct ServerConfig {
     /// Set by the binary's `--restore <FILE>` flag / `SPARQ_RESTORE` env.
     #[cfg(feature = "backup")]
     pub restore: Option<std::path::PathBuf>,
+    /// [OPUS-4.8] (sq-bu1a) POINT-IN-TIME-RECOVERY delta chain replayed forward onto the
+    /// `restore` base on start. When non-empty (and `restore` is `Some`), the binary imports the
+    /// base, then replays these incremental delta artifacts in order BEFORE binding, so the
+    /// in-memory store starts at the chain's last `to-generation` — a chosen recovery point.
+    /// Fail-closed: a corrupt / version-mismatched / out-of-order / gapped delta aborts startup
+    /// with a clean error (the same discipline as the base restore). Each path is one
+    /// `sparq_serve::backup_export_delta` output, oldest first. Empty (the default) = restore the
+    /// base only. Ignored unless `restore` is also set. This field exists only with the `backup`
+    /// cargo feature. Set by the binary's repeatable `--restore-delta <FILE>` flag /
+    /// `SPARQ_RESTORE_DELTA` env (a path list).
+    #[cfg(feature = "backup")]
+    pub restore_delta: Vec<std::path::PathBuf>,
     /// [OPUS-4.8] (sq-d3d8, epic sq-3183) OPT-IN federation discovery descriptors. When
     /// `true`, the server serves a W3C VoID dataset description at `GET /.well-known/void`
     /// and a SPARQL 1.1 Service Description for a `GET /sparql` with no `query` parameter
@@ -685,6 +697,9 @@ impl Default for ServerConfig {
             // [OPUS-4.8] sq-o5bi: no restore-on-start by default (seed from data file / empty).
             #[cfg(feature = "backup")]
             restore: None,
+            // [OPUS-4.8] sq-bu1a: no PITR delta chain by default (base-only restore).
+            #[cfg(feature = "backup")]
+            restore_delta: Vec::new(),
             // [OPUS-4.8] sq-d3d8: safe default — federation discovery descriptors OFF even
             // when the feature is compiled in (the operator opts in deliberately).
             #[cfg(feature = "federation-descriptors")]
@@ -917,6 +932,15 @@ impl ServerConfig {
         #[cfg(feature = "backup")]
         if let Ok(v) = std::env::var("SPARQ_RESTORE") {
             cfg.restore = (!v.is_empty()).then(|| std::path::PathBuf::from(v));
+        }
+        // [OPUS-4.8] sq-bu1a: SPARQ_RESTORE_DELTA is a platform-path-separator-delimited list of
+        // incremental delta artifacts replayed forward onto the --restore base (PITR), oldest
+        // first. Repeated --restore-delta flags override it. Only present with the `backup` feature.
+        #[cfg(feature = "backup")]
+        if let Ok(v) = std::env::var("SPARQ_RESTORE_DELTA") {
+            cfg.restore_delta = std::env::split_paths(&v)
+                .filter(|p| !p.as_os_str().is_empty())
+                .collect();
         }
         // [OPUS-4.8] sq-d3d8: SPARQ_FEDERATION_DESCRIPTORS truthy ("1"/"true"/"yes"/"on")
         // serves the VoID + Service-Description discovery endpoints. Off by default. Only
@@ -2199,6 +2223,52 @@ impl AppState {
     /// dataset, then spawns a writer thread): call it on the blocking pool.
     #[cfg(feature = "backup")]
     pub fn restore_from<R: std::io::Read>(&self, input: R) -> Result<u64, String> {
+        self.guard_restore_supported()?;
+        // Build the entire new core BEFORE touching the live one — fail-closed.
+        let (graph, meta) = sparq_serve::backup_import(input).map_err(|e| e.to_string())?;
+        self.install_restored_graph(graph);
+        Ok(meta.generation)
+    }
+
+    /// [OPUS-4.8] (sq-bu1a) ONLINE point-in-time RESTORE: rehydrates from a BASE artifact, then
+    /// REPLAYS an ordered chain of incremental DELTA artifacts forward onto it to reach a chosen
+    /// recovery point, and atomically installs the result — the change-stream / PITR companion to
+    /// [`restore_from`](Self::restore_from). `base` is the base artifact; `deltas` is the ordered
+    /// sequence of delta artifact byte-blobs (each [`sparq_serve::backup_export_delta`] output),
+    /// oldest first.
+    ///
+    /// **Fail-closed, same discipline as the base restore:** the base is imported, every delta is
+    /// decoded and the whole chain is replayed onto a private graph BEFORE any swap. A corrupt /
+    /// version-mismatched / out-of-order / gapped artifact aborts the whole operation (`Err`) and
+    /// the LIVE store is left untouched — there is no partial install. The chain must be
+    /// same-lineage with the base (see `sparq_serve::backup_delta` for that boundary). Returns the
+    /// recovered SOURCE generation/writer-seq (the last delta's `to`, or the base's generation for
+    /// an empty chain) for operator correlation. In-memory only (a `--persist` server is refused),
+    /// blocking: call on the blocking pool.
+    #[cfg(feature = "backup")]
+    pub fn restore_from_with_deltas(
+        &self,
+        base: &[u8],
+        deltas: &[Vec<u8>],
+    ) -> Result<u64, String> {
+        self.guard_restore_supported()?;
+        // Import + replay onto a PRIVATE graph first — fail-closed before any swap.
+        let (mut graph, base_meta) = sparq_serve::backup_import(base).map_err(|e| e.to_string())?;
+        let decoded: Vec<sparq_serve::Delta> = deltas
+            .iter()
+            .map(|d| sparq_serve::backup_import_delta(&d[..]))
+            .collect::<Result<_, _>>()
+            .map_err(|e| e.to_string())?;
+        let recovered = sparq_serve::backup_replay(&mut graph, &base_meta, decoded.iter())
+            .map_err(|e| e.to_string())?;
+        self.install_restored_graph(graph);
+        Ok(recovered.generation)
+    }
+
+    /// [OPUS-4.8] (sq-bu1a) Shared restore precondition: in-memory-only in v1 (a `--persist`
+    /// durable directory needs its own crash-safe swap, a recorded follow-up).
+    #[cfg(feature = "backup")]
+    fn guard_restore_supported(&self) -> Result<(), String> {
         if self.config.persist_dir.is_some() {
             return Err(
                 "restore is not supported on a --persist (durable) server in v1; \
@@ -2206,8 +2276,16 @@ impl AppState {
                     .to_string(),
             );
         }
-        // Build the entire new core BEFORE touching the live one — fail-closed.
-        let (graph, meta) = sparq_serve::backup_import(input).map_err(|e| e.to_string())?;
+        Ok(())
+    }
+
+    /// [OPUS-4.8] (sq-bu1a) Shared restore install: builds a fresh ring+writer around the
+    /// rehydrated `graph` and atomically swaps it in. Readers in flight keep serving from the OLD
+    /// core (its `Arc` survives until they release their pin); every read/update after the swap
+    /// loads the new core. The restored ring restarts at generation 0; the recorded source
+    /// generation is returned by the callers for operator correlation.
+    #[cfg(feature = "backup")]
+    fn install_restored_graph(&self, graph: Graph) {
         let ring_config = build_ring_config(&self.config);
         let ring = Arc::new(GenerationRing::with_config(graph, ring_config));
         let applier = ServerApplier::new(self.config.clone());
@@ -2215,12 +2293,45 @@ impl AppState {
         // Atomic swap: subsequent loads see the new ring+writer; the old core's writer thread
         // joins once its last in-flight reader/Arc drops (Writer's Drop drains + joins).
         self.core.store(Arc::new(ServingCore { ring, writer }));
-        // Advance the commit watch so active subscriptions re-evaluate against the restored
-        // store. The restored ring restarts at generation 0; the recorded source generation
-        // (the writer seq the artifact was taken at) is returned for operator correlation.
+        // Advance the commit watch so active subscriptions re-evaluate against the restored store.
         let restored_gen = self.current().number();
         self.commits.send_replace(restored_gen);
-        Ok(meta.generation)
+    }
+
+    /// [OPUS-4.8] (sq-bu1a) Exports an INCREMENTAL DELTA between a RETAINED generation `from` and
+    /// the CURRENT generation to `out` (sparq-serve's self-describing delta format) — the
+    /// change-stream / PITR producer. Pins both generations lock-free (so it runs **while
+    /// serving**) and serialises the quad-set difference off those immutable `Arc`s.
+    ///
+    /// `from` must still be RETAINED by the ring: with `time-travel` OFF only the last K
+    /// generations are retained (the concurrency window), so practical incremental backup wants
+    /// the `time-travel` feature to widen the retention window. `Ok(None)` means `from` is no
+    /// longer retained (aged out, or never published) — the caller maps that to a 410/404, exactly
+    /// like `?generation=N`. `Ok(Some(meta))` is the exported delta's metadata. CPU/IO-bound
+    /// (serialises both generations): call on the blocking pool.
+    #[cfg(feature = "backup")]
+    pub fn export_delta_from<W: std::io::Write>(
+        &self,
+        from: u64,
+        out: &mut W,
+    ) -> Result<Option<sparq_serve::DeltaMeta>, String> {
+        let to = self.pin_for_backup();
+        // The current generation is always retained; `from` must be too. `ring().at` needs the
+        // retention window — without `time-travel` only the K-generation concurrency floor is kept.
+        let from_gen = match self.ring().at(from) {
+            Some(g) => g,
+            None => return Ok(None),
+        };
+        if from >= to.number() {
+            return Err(format!(
+                "delta `from` generation {} must be earlier than the current generation {}",
+                from,
+                to.number()
+            ));
+        }
+        sparq_serve::backup_export_delta(&from_gen, &to, out)
+            .map(Some)
+            .map_err(|e| e.to_string())
     }
 
     /// A receiver of the committed generation number for a subscription connection (T23).
@@ -2283,7 +2394,11 @@ pub fn router(state: AppState) -> Router {
     #[cfg(feature = "backup")]
     let routes = routes
         .route("/admin/backup", post(admin_backup))
-        .route("/admin/restore", post(admin_restore));
+        .route("/admin/restore", post(admin_restore))
+        // [OPUS-4.8] sq-bu1a: the INCREMENTAL change-stream / PITR producer. `?from=N` streams the
+        // delta between RETAINED generation N and the current generation; restore-forward replay is
+        // driven by the binary's `--restore` + `--restore-delta` (see main.rs), not a route.
+        .route("/admin/backup/delta", post(admin_backup_delta));
     // [OPUS-4.8] sq-d3d8 (epic sq-3183): OPT-IN federation discovery — the VoID dataset
     // description at /.well-known/void. Compiled only with the `federation-descriptors`
     // feature; even then the handler refuses (404) unless the config flag is set. The SD is
@@ -4035,6 +4150,86 @@ async fn admin_restore(
             &e,
         ),
         Err(_) => json_error(StatusCode::INTERNAL_SERVER_ERROR, "restore worker panicked"),
+    }
+}
+
+/// [OPUS-4.8] (sq-bu1a) `POST /admin/backup/delta?from=N` — the INCREMENTAL change-stream / PITR
+/// producer. Streams a single self-describing DELTA artifact (sparq-serve's delta format: a header
+/// keying the `from-generation` N → the current `to-generation`, plus the per-pod epoch vector at
+/// `to` and the inserted/deleted quad bodies as N-Quads) as `application/octet-stream`. Replayed
+/// forward onto the matching base artifact, the delta advances a restore to a later point in the
+/// writer history — point-in-time recovery.
+///
+/// - **Online — no stop-the-world.** Both generations are pinned lock-free and the diff is
+///   serialised off those immutable `Arc`s on the blocking pool.
+/// - **`from` must be a RETAINED generation.** Without the `time-travel` feature only the last few
+///   generations (the concurrency window) are retained, so a `from` older than that yields 410 Gone
+///   (aged out) — exactly like `?generation=N` on `/sparql`. The `time-travel` feature widens the
+///   retention window so further-back deltas are available.
+/// - **Gated** behind the WRITE admin token (it reads the whole dataset); POST-only.
+///
+/// At-rest ENCRYPTION of the artifact is a separate concern, out of scope (same as the base).
+#[cfg(feature = "backup")]
+async fn admin_backup_delta(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> Response {
+    if let Some(resp) = auth_gate(state.config(), &headers, Operation::Write) {
+        return resp;
+    }
+    let from = match params.get("from").map(|s| s.trim().parse::<u64>()) {
+        Some(Ok(n)) => n,
+        Some(Err(_)) => {
+            return json_error(
+                StatusCode::BAD_REQUEST,
+                "delta backup requires a numeric `from` generation",
+            )
+        }
+        None => {
+            return json_error(
+                StatusCode::BAD_REQUEST,
+                "delta backup requires a `from` generation query parameter (?from=N)",
+            )
+        }
+    };
+    let st = state.clone();
+    let task = tokio::task::spawn_blocking(move || {
+        let mut buf = Vec::new();
+        st.export_delta_from(from, &mut buf).map(|meta| (meta, buf))
+    });
+    match task.await {
+        // `from` is no longer retained (aged out / never published): 410 Gone, mirroring time-travel.
+        Ok(Ok((None, _))) => json_error(
+            StatusCode::GONE,
+            "the `from` generation is no longer retained (aged out of the retention window); \
+             enable the time-travel feature to widen retention",
+        ),
+        Ok(Ok((Some(meta), bytes))) => Response::builder()
+            .status(StatusCode::OK)
+            .header(header::CONTENT_TYPE, "application/octet-stream")
+            .header(header::CONTENT_LENGTH, bytes.len())
+            // [OPUS-4.8] positional format args (CodeQL rust/unused-variable false-positive).
+            .header(
+                header::CONTENT_DISPOSITION,
+                format!(
+                    "attachment; filename=\"sparq-delta-{}-{}.spqd\"",
+                    meta.from_generation, meta.to_generation
+                ),
+            )
+            .body(axum::body::Body::from(bytes))
+            .unwrap(),
+        // A range/serialisation error (e.g. `from` >= current): the store is untouched (read-only).
+        Ok(Err(e)) => sanitized_error(
+            StatusCode::BAD_REQUEST,
+            "backup-delta",
+            "delta backup rejected",
+            &e,
+        ),
+        Err(_) => json_error(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "backup-delta worker panicked",
+        ),
     }
 }
 

--- a/crates/sparq-server/src/main.rs
+++ b/crates/sparq-server/src/main.rs
@@ -189,6 +189,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // the CLI only ever widens what env granted (never silently narrows it).
     let mut service_allow_cli: Vec<String> = Vec::new();
     let mut service_allow_file: Option<String> = None;
+    // [OPUS-4.8] sq-bu1a: track whether --restore-delta was given on the CLI so the FIRST flag
+    // OVERRIDES any SPARQ_RESTORE_DELTA env list (matching --restore's flag-overrides-env contract)
+    // rather than appending to it.
+    #[cfg(feature = "backup")]
+    let mut restore_delta_from_cli = false;
     // [OPUS-4.8] sq-o7o0: collect first-party CORS origin allowlist entries from the CLI;
     // UNIONed with the SPARQ_CORS_ALLOW_ORIGIN env baseline + an optional
     // --cors-allow-origin-file, after the arg loop (additive — CLI only widens).
@@ -336,6 +341,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     return Err("--restore must not be empty".into());
                 }
                 config.restore = Some(std::path::PathBuf::from(file));
+            }
+            // [OPUS-4.8] sq-bu1a: POINT-IN-TIME-RECOVERY — replay an incremental DELTA artifact
+            // forward onto the --restore base. Repeatable (oldest first); each must be a
+            // sparq delta artifact. Requires --restore. Fail-closed: a corrupt / out-of-order /
+            // gapped delta aborts startup. Off by default (env SPARQ_RESTORE_DELTA=<files>).
+            #[cfg(feature = "backup")]
+            "--restore-delta" => {
+                let file = args.next().ok_or("--restore-delta requires an artifact file path")?;
+                if file.is_empty() {
+                    return Err("--restore-delta must not be empty".into());
+                }
+                // First CLI flag clears any env-provided list (flag overrides env).
+                if !restore_delta_from_cli {
+                    config.restore_delta.clear();
+                    restore_delta_from_cli = true;
+                }
+                config.restore_delta.push(std::path::PathBuf::from(file));
             }
             // [OPUS-4.8] sq-o4qf: opt in to binding a non-loopback address. Without this (and
             // without SPARQ_ALLOW_REMOTE), a non-loopback --addr is refused unless the whole
@@ -597,15 +619,42 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             eprintln!("restoring in-memory store from backup artifact {} ...", file.display());
             let f = std::fs::File::open(file)
                 .map_err(|e| format!("--restore: cannot open {}: {e}", file.display()))?;
-            let (g, meta) = sparq_serve::backup_import(std::io::BufReader::new(f))
+            let (mut g, meta) = sparq_serve::backup_import(std::io::BufReader::new(f))
                 .map_err(|e| format!("--restore: rejected {} ({e})", file.display()))?;
             eprintln!(
                 "restored from artifact taken at generation {} ({} triples)",
                 meta.generation, meta.triples
             );
+            // [OPUS-4.8] sq-bu1a: POINT-IN-TIME RECOVERY — replay the --restore-delta chain forward
+            // onto the base. Fail-closed: a corrupt / out-of-order / gapped delta aborts startup.
+            if !config.restore_delta.is_empty() {
+                let mut decoded = Vec::with_capacity(config.restore_delta.len());
+                for d in &config.restore_delta {
+                    let df = std::fs::File::open(d)
+                        .map_err(|e| format!("--restore-delta: cannot open {}: {e}", d.display()))?;
+                    let delta = sparq_serve::backup_import_delta(std::io::BufReader::new(df))
+                        .map_err(|e| format!("--restore-delta: rejected {} ({e})", d.display()))?;
+                    decoded.push(delta);
+                }
+                let recovered = sparq_serve::backup_replay(&mut g, &meta, decoded.iter())
+                    .map_err(|e| format!("--restore-delta: replay failed ({e})"))?;
+                eprintln!(
+                    "replayed {} delta artifact(s) — recovered to generation {} ({} triples)",
+                    config.restore_delta.len(),
+                    recovered.generation,
+                    recovered.triples
+                );
+            }
             g
         }
-        None => graph,
+        None => {
+            // [OPUS-4.8] sq-bu1a: --restore-delta is meaningless without a --restore base; refuse
+            // it loudly rather than silently ignoring an operator's PITR intent.
+            if !config.restore_delta.is_empty() {
+                return Err("--restore-delta requires --restore (a base artifact to replay onto)".into());
+            }
+            graph
+        }
     };
     eprintln!("loaded {} triples", graph.len());
     eprintln!(
@@ -668,11 +717,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // [OPUS-4.8] sq-o5bi: surface the online backup/restore posture at startup.
     #[cfg(feature = "backup")]
     eprintln!(
-        "backup/restore: ON (admin routes POST /admin/backup + /admin/restore, write-gated; \
-         online snapshot, no stop-the-world){}",
+        "backup/restore: ON (admin routes POST /admin/backup + /admin/backup/delta + \
+         /admin/restore, write-gated; online snapshot, no stop-the-world){}{}",
         match &config.restore {
             Some(f) => format!(" — restored on start from {}", f.display()),
             None => String::new(),
+        },
+        // [OPUS-4.8] sq-bu1a: surface a replayed PITR delta chain in the posture line.
+        if config.restore_delta.is_empty() {
+            String::new()
+        } else {
+            format!(" + {} delta(s) replayed (PITR)", config.restore_delta.len())
         }
     );
     // [OPUS-4.8] sq-4w18: surface the SERVICE egress posture at startup so an operator

--- a/crates/sparq-server/tests/backup.rs
+++ b/crates/sparq-server/tests/backup.rs
@@ -301,6 +301,203 @@ async fn admin_routes_are_write_gated() {
     assert_eq!(resp.status(), reqwest::StatusCode::OK);
 }
 
+/// Downloads a DELTA artifact from `POST /admin/backup/delta?from=N`, returning (status, bytes).
+async fn backup_delta(
+    cl: &reqwest::Client,
+    base: &str,
+    from: u64,
+) -> (reqwest::StatusCode, Vec<u8>) {
+    let resp = cl
+        .post(format!("{base}/admin/backup/delta"))
+        .query(&[("from", from.to_string())])
+        .send()
+        .await
+        .unwrap();
+    let status = resp.status();
+    (status, resp.bytes().await.unwrap().to_vec())
+}
+
+/// [OPUS-4.8] (sq-bu1a) PITR ROUND TRIP via the real HTTP delta route: take a BASE backup at
+/// generation 0, move the store forward, export a DELTA(0→current) over HTTP, then restore the
+/// base + replay the delta — the recovered store equals the moved-on source.
+#[tokio::test]
+async fn pitr_base_plus_http_delta_recovers_the_moved_on_store() {
+    let cl = reqwest::Client::new();
+    let src = spawn_with(
+        Graph::load_str("<http://ex/s0> <http://ex/p> <http://ex/o0> .", "turtle").unwrap(),
+        ServerConfig::default(),
+    )
+    .await;
+    // BASE @ generation 0 (before any update).
+    let base_artifact = backup(&cl, &src).await;
+
+    // Move forward: a default insert + a named-graph insert + a delete of the seed.
+    post_update(
+        &cl,
+        &src,
+        "INSERT DATA { <http://ex/s1> <http://ex/p> <http://ex/o1> }",
+    )
+    .await;
+    post_update(
+        &cl,
+        &src,
+        "INSERT DATA { GRAPH <http://ex/g> { <http://ex/s2> <http://ex/p> <http://ex/o2> } }",
+    )
+    .await;
+    post_update(
+        &cl,
+        &src,
+        "DELETE DATA { <http://ex/s0> <http://ex/p> <http://ex/o0> }",
+    )
+    .await;
+    let src_total = count_all(&cl, &src).await;
+    assert_eq!(src_total, 2, "seed deleted, 2 inserts remain");
+
+    // DELTA(0 -> current) over HTTP.
+    let (status, delta_artifact) = backup_delta(&cl, &src, 0).await;
+    assert_eq!(status, reqwest::StatusCode::OK, "delta export must be 200");
+    assert!(
+        delta_artifact.starts_with(b"SPARQ-BACKUP-DELTA "),
+        "delta is the distinct self-describing kind"
+    );
+
+    // RESTORE base + replay delta into a fresh server (via the AppState PITR primitive the
+    // binary's --restore + --restore-delta uses).
+    let state = AppState::with_config(Graph::load_str("", "turtle").unwrap(), ServerConfig::default());
+    let recovered_gen = state
+        .restore_from_with_deltas(&base_artifact, &[delta_artifact])
+        .expect("base + delta restore");
+    assert_eq!(recovered_gen, 3, "recovered to the source's writer-seq (3)");
+    let app = sparq_server::router(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let dst = format!("http://{addr}");
+
+    assert_eq!(
+        count_all(&cl, &dst).await,
+        src_total,
+        "PITR-recovered quad count equals the moved-on source"
+    );
+    assert_eq!(
+        count_rows(&cl, &dst, "SELECT * WHERE { GRAPH <http://ex/g> { ?s ?p ?o } }").await,
+        1,
+        "the named-graph insert was replayed"
+    );
+    // The deleted seed triple is absent after replay (counted as a SELECT, not an ASK).
+    assert_eq!(
+        count_rows(
+            &cl,
+            &dst,
+            "SELECT * WHERE { <http://ex/s0> <http://ex/p> <http://ex/o0> }"
+        )
+        .await,
+        0,
+        "the deleted seed triple is absent after replay"
+    );
+}
+
+/// [OPUS-4.8] (sq-bu1a) FAIL-CLOSED: `restore_from_with_deltas` rejects a corrupt delta and the
+/// base install never happens (the whole op is atomic — import + replay before any swap).
+#[tokio::test]
+async fn pitr_rejects_corrupt_delta_in_chain() {
+    let cl = reqwest::Client::new();
+    let src = spawn_with(
+        Graph::load_str("<http://ex/s0> <http://ex/p> <http://ex/o0> .", "turtle").unwrap(),
+        ServerConfig::default(),
+    )
+    .await;
+    let base_artifact = backup(&cl, &src).await;
+    post_update(
+        &cl,
+        &src,
+        "INSERT DATA { <http://ex/s1> <http://ex/p> <http://ex/o1> }",
+    )
+    .await;
+    let (status, mut delta_artifact) = backup_delta(&cl, &src, 0).await;
+    assert_eq!(status, reqwest::StatusCode::OK);
+    // Corrupt the delta body (flip the last byte).
+    let last = delta_artifact.len() - 1;
+    delta_artifact[last] ^= 0xff;
+
+    let state = AppState::with_config(Graph::load_str("", "turtle").unwrap(), ServerConfig::default());
+    let res = state.restore_from_with_deltas(&base_artifact, &[delta_artifact]);
+    assert!(res.is_err(), "a corrupt delta must fail the whole restore closed");
+}
+
+/// [OPUS-4.8] (sq-bu1a) The delta route is WRITE-gated, POST-only, and 400s a missing/invalid
+/// `from`; an aged-out `from` is 410 Gone (mirroring time-travel).
+#[tokio::test]
+async fn delta_route_is_gated_and_validates_from() {
+    let cl = reqwest::Client::new();
+    // Auth-gated server: unauthenticated delta -> 401.
+    let gated = spawn_with(
+        Graph::load_str("<http://ex/s> <http://ex/p> <http://ex/o> .", "turtle").unwrap(),
+        ServerConfig {
+            auth_token: Some("s3cret".into()),
+            ..ServerConfig::default()
+        },
+    )
+    .await;
+    let resp = cl
+        .post(format!("{gated}/admin/backup/delta"))
+        .query(&[("from", "0")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::UNAUTHORIZED);
+
+    // Open server: missing `from` -> 400.
+    let open = spawn_with(
+        Graph::load_str("<http://ex/s> <http://ex/p> <http://ex/o> .", "turtle").unwrap(),
+        ServerConfig::default(),
+    )
+    .await;
+    let resp = cl
+        .post(format!("{open}/admin/backup/delta"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        reqwest::StatusCode::BAD_REQUEST,
+        "a missing `from` is a 400"
+    );
+    // Non-numeric `from` -> 400.
+    let resp = cl
+        .post(format!("{open}/admin/backup/delta"))
+        .query(&[("from", "abc")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), reqwest::StatusCode::BAD_REQUEST);
+
+    // `from` >= current (no movement yet, current is 0): from=0 is not earlier than current=0,
+    // so the range check rejects with 400.
+    let (status, _b) = backup_delta(&cl, &open, 0).await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::BAD_REQUEST,
+        "from must be earlier than the current generation"
+    );
+
+    // An aged-out `from` (never retained without time-travel; far beyond current) -> 410 Gone.
+    post_update(
+        &cl,
+        &open,
+        "INSERT DATA { <http://ex/a> <http://ex/p> <http://ex/b> }",
+    )
+    .await;
+    let (status, _b) = backup_delta(&cl, &open, 999).await;
+    assert_eq!(
+        status,
+        reqwest::StatusCode::GONE,
+        "a `from` generation that is not retained is 410 Gone"
+    );
+}
+
 /// PERSIST REFUSAL: a `--persist` durable server refuses restore (409) in v1.
 #[tokio::test]
 async fn restore_refuses_on_persist_server() {

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -398,6 +398,11 @@ curl -X POST -H 'Authorization: Bearer <TOKEN>' http://127.0.0.1:3030/admin/back
 # Restore atomically installs a store rehydrated from that artifact (in-memory server only; fail-closed):
 curl -X POST -H 'Authorization: Bearer <TOKEN>' --data-binary @snapshot.spqb http://127.0.0.1:3030/admin/restore
 # Restore on start (bootstrap a fresh node / PITR base):  sparq-server --restore snapshot.spqb
+# Incremental change-stream / point-in-time recovery (PITR): a DELTA between a retained
+# generation N and the current generation (replayed forward onto the matching base):
+curl -X POST -H 'Authorization: Bearer <TOKEN>' 'http://127.0.0.1:3030/admin/backup/delta?from=0' -o d0.spqd
+# Recover to the chosen point: restore the base, then replay the delta chain (oldest first):
+sparq-server --restore snapshot.spqb --restore-delta d0.spqd --restore-delta d1.spqd
 ```
 
 `/metrics` is hand-rolled Prometheus text exposition (no metrics dependency); the
@@ -452,6 +457,24 @@ stage-2 + the base of point-in-time recovery; refused together with `--persist`)
 **at-rest encryption of the artifact is out of scope** — the integrity digest detects accidental
 corruption, not tampering, and is not a confidentiality or authenticity guarantee; protect the
 artifact at the storage tier.
+
+**`POST /admin/backup/delta?from=N` + `--restore-delta` — incremental change-stream / PITR
+(same `backup` feature; `sq-bu1a`).** The Option-A backup above is the BASE half of a
+point-in-time-recovery story; this is the incremental companion. **`/admin/backup/delta`** streams
+a single self-describing **delta artifact** (distinct magic `SPARQ-BACKUP-DELTA`) keyed off the
+generation/writer-seq: a header recording the `from-generation` N → the current `to-generation`
+plus the per-pod epoch vector at `to`, then the **quad-set change** (inserted + deleted quads, each
+as N-Quads) between those two generations. `from` must still be **retained** by the ring — without
+the `time-travel` feature only the last few generations (the concurrency window) are retained, so a
+`from` older than that is `410 Gone` (widen retention with `time-travel`); a missing/invalid `from`
+is `400`. To recover to a chosen point, restore the base then **replay the delta chain forward**:
+`sparq-server --restore base.spqb --restore-delta d0.spqd --restore-delta d1.spqd …` (oldest
+first; or `SPARQ_RESTORE_DELTA`). **Fail-closed:** a corrupt / version-mismatched / out-of-order /
+gapped delta aborts the whole recovery and the live store is untouched (import + full replay happen
+before any swap). **Honest scope:** deltas are **same-lineage** only — the chain must be the writer
+history of that base (blank-node labels are stable within a lineage, which is what the quad-set diff
+relies on); cross-lineage diffing is unsupported. At-rest encryption is out of scope, same as the
+base.
 
 GSP **writes** translate into a server-minted SPARQL Update (`DROP`/`CLEAR` + `INSERT
 DATA`) and submit through the SAME sequenced group-commit writer the
@@ -1112,6 +1135,16 @@ identities and resource IRIs by design (see the privacy-boundary note above).
   pair — the `ArcSwap<ServingCore>` that backs the atomic online restore is `backup`-gated, so the
   DEFAULT read path is byte-identical to before #941 (no extra atomic load when `backup` is OFF;
   sq-0g6g resolved in the lean direction). (sq-o5bi.)
+- **Incremental change-stream / PITR — same `backup` feature (sq-bu1a).** The base backup above
+  is the BASE half of point-in-time recovery; `/admin/backup/delta?from=N` streams an incremental
+  **delta artifact** (distinct `SPARQ-BACKUP-DELTA` kind) — the quad-set change between a *retained*
+  generation N and the current one, keyed off the generation/writer-seq range + the epoch vector at
+  `to`. Recover to a chosen point by restoring the base then replaying the chain forward:
+  `--restore base --restore-delta d0 --restore-delta d1 …` (oldest first; or `SPARQ_RESTORE_DELTA`).
+  **Fail-closed** on a corrupt / out-of-order / gapped chain (import + full replay before any swap);
+  `from` not retained is `410` (widen retention with `time-travel`). **Same-lineage only** — the
+  chain must be the writer history of that base (the diff relies on lineage-stable blank-node
+  labels). At-rest encryption out of scope, same as the base.
 - **Time-travel memory cost is real.** Each retained generation is a *full* `Graph` today
   (~780 MB/generation at 1M triples); size `--time-travel-generations` accordingly.
 - **Error bodies.** Every error is structured JSON `{"error": "..."}` with


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead `sq-bu1a` (surface: sparq-serve). Self-identifying per the sub-agent shared contract.

## What this implements

The v1 backup artifact (`sq-o5bi`, #941) — Option A, a single self-describing file (header with generation/writer-seq + per-pod epoch vectors + triple count + body digest, then full-dataset N-Quads) — is the **BASE half** of a change-stream / point-in-time-recovery (PITR) story. This adds the **incremental companion**: a delta-artifact stream keyed off the recorded generation/writer-seq so a restore can **replay forward** from a base backup to a chosen point in time.

```
base@G0 ──(delta G0→G3)──▶ G3 ──(delta G3→G7)──▶ G7   (= a chosen recovery point)
```

### `sparq-serve` (feature `backup`, default OFF) — new `backup_delta` module
- **`export_delta(from, to)`** captures the **quad-set change** between two same-lineage generations as a self-describing **DELTA artifact** — its own magic `SPARQ-BACKUP-DELTA` + its own version (so it can never be confused with a base), a header keying the `from-generation → to-generation` range + the per-pod epoch vector at `to`, then the inserted / deleted quads as N-Quads.
- **`import_delta`** decodes one fail-closed; **`replay`** applies an ordered chain forward onto a restored base, rejecting a gapped / overlapping / out-of-order chain.
- Reuses the base's FNV-1a digest, line discipline, quad-count cross-check and fail-closed posture (promoted to `pub(crate)` — one integrity scheme across the backup family).

### `sparq-server` (feature `backup`)
- **`POST /admin/backup/delta?from=N`** streams a delta between retained generation N and the current generation (online, no stop-the-world; WRITE-gated; POST-only). `410 Gone` when `from` is no longer retained (widen retention with the `time-travel` feature, mirroring `?generation=N`); `400` on a missing/invalid/non-forward `from`.
- **`--restore-delta <FILE>`** / `SPARQ_RESTORE_DELTA` replays a delta chain forward onto the `--restore` base on start (PITR); fail-closed, in-memory only (refused with `--persist`, same as the base restore). `AppState::restore_from_with_deltas` / `export_delta_from` are the helpers; the binary's posture line surfaces the replayed chain.

## Best-judgment design decisions (documented here + in a one-line bead note)
- **Delta is computed as a quad-set diff of the two generations' N-Quads serialisations.** Self-describing, lossless, format-stable RDF that round-trips through `Graph::apply_delta_nquads` — staying inside the Option-A spirit rather than coupling to the WAL layout.
- **Load-bearing honest boundary: SAME-LINEAGE deltas only.** A quad-set diff is correct only when blank-node labels are stable between the two snapshots — i.e. the two generations come from the same ring lineage (the writer forks a generation and applies updates, preserving every surviving term's identity, blank nodes included). That is exactly the PITR use case. `replay` enforces the generation-continuity half (each delta's `from` must equal the running seq) at runtime; the lineage assumption itself is a documented operator contract. Cross-lineage diffing is unsupported.
- **Distinct artifact KIND** (separate magic + version) so an `import_base`/`import_delta` mismatch fails closed at the magic line.

## Feature flags
`backup` (default OFF) on both `sparq-serve` and `sparq-server`. The default build carries **zero** delta code (cfg-stripped; no `arc-swap`), and `sparq-serve` stays out of the `sparq-wasm` dependency graph (verified).

## Gates run (both feature states)
- `cargo build` / `cargo clippy --all-targets -D warnings` / `cargo test` — GREEN in **default (feature OFF)** AND with **`backup` ON** (also checked `backup,time-travel`).
- `cargo doc --workspace-scope --no-deps --all-features` with `RUSTDOCFLAGS="-D warnings"` — clean (fixed two feature-gated module-doc intra-links that only surface here).
- `rustfmt` clean on the new module (siblings are rustfmt-clean, so matched).
- `check-readme-template.py --enforce` → **0 deviations**; both crate READMEs within the ≤120-line cap.
- `check-privacy-claims.sh` → clean. No hard-coded perf numbers.

### Load-bearing tests
- **Result-equivalence (PITR):** base + replayed delta chain == the live target generation, quad-for-quad — as a `sparq-serve` unit test AND over the **real HTTP delta route** (`/admin/backup/delta` → `restore_from_with_deltas`), across default + named graphs with inserts and deletes.
- **Fail-closed:** corrupt body, truncation, unknown version, non-forward range, chain gap, out-of-order chain, base/delta kind confusion — all rejected; a corrupt delta in a chain aborts the whole recovery (live store untouched). Delta route is WRITE-gated + validates `from`.

## Honest boundary
At-rest **encryption** of the artifact remains **out of scope** (a separate concern), same as the base — the integrity digest is a non-cryptographic checksum (detects corruption, not tampering).

Bead `sq-bu1a` closed on PR-open. `.beads/` is not staged into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
