### PR TITLE
feat(sparq-vectors): P2 SHACL/OWL prior reader (enum/datatype/cardinality) + QUDT unit-normalisation (sq-0wo9e.3) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3751,6 +3751,7 @@ dependencies = [
  "sparq-engine",
  "sparq-introspect",
  "sparq-reason",
+ "sparq-shacl",
  "sparq-sim",
 ]
 

--- a/crates/sparq-vectors/Cargo.toml
+++ b/crates/sparq-vectors/Cargo.toml
@@ -51,6 +51,16 @@ structure = ["dep:sparq-reason", "dep:sparq-introspect"]
 # carry ZERO trainer/eval code and gain no new deps. It TRAINS a research-grade model only to
 # MEASURE the priors — it makes no accuracy claim and serves no exact answer.
 kge = ["structure"]
+# [OPUS-4.8] sq-0wo9e.3 (epic sq-0wo9e, design research/structure-aware-vectorisation.md §2 + §7):
+# P2 — the SHACL/OWL PRIOR EXTRACTOR (`shacl_priors.rs`). Reads enum (`sh:in`) / datatype
+# (`sh:datatype`) / cardinality (`sh:min,maxCount`, `owl:FunctionalProperty`) priors out of a parsed
+# `sparq-shacl` shapes model (read-only — no SHACL changes) into the codebook + pooling layout the
+# structure-aware encoders consume. OPT-IN and OFF by default; it IMPLIES `structure` and is the ONLY
+# feature that pulls `sparq-shacl` (and, transitively, the engine on native) into this crate's graph,
+# so neither the default build nor the lean `structure` feature gains a SHACL/engine dependency. The
+# enum CODEBOOK encoder and the QUDT UNIT normaliser themselves ship under `structure` (pure, no
+# SHACL dep); only the *reader* that mines them from shapes needs sparq-shacl.
+structure-shacl = ["structure", "dep:sparq-shacl"]
 # [OPUS-4.8] sq-1wc1: predicate-constrained (filtered) ANN — the RDF-native vector
 # differentiator. A SPARQL BGP carves out a candidate dict-id set (the "visit mask") and the
 # nearest-neighbour search returns only neighbours inside it. OPT-IN and OFF by default; it is a
@@ -140,6 +150,11 @@ reqwest = { version = "0.12", default-features = false, features = ["blocking", 
 # mines declared + observed domain/range. Neither pulls the engine.
 sparq-reason = { path = "../sparq-reason", version = "0.1.0", optional = true }
 sparq-introspect = { path = "../sparq-introspect", version = "0.1.0", optional = true }
+# [OPUS-4.8] sq-0wo9e.3: the P2 SHACL/OWL prior extractor reads a parsed shapes model. OPTIONAL and
+# ONLY pulled in by `structure-shacl`, so the default build (and the lean `structure` feature) never
+# compile it — `sparq-vectors` stays free of any SHACL/engine dependency unless this reader is opted
+# in. sparq-shacl is itself an opt-in crate that nothing in the workspace depends on by default.
+sparq-shacl = { path = "../sparq-shacl", version = "0.1.0", optional = true }
 
 # [OPUS-4.8] sq-88c6: DEV-only. The `hybrid_search` example/tests fuse this crate's ANN
 # (`VectorIndex::nearest_term`) with `sparq-sim`'s structural similarity

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -89,11 +89,12 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
   `provider` feature carries the OpenAI-compatible `/v1/embeddings` shape with a
   caller-supplied `Transport`; `embeddings` adds a concrete reqwest client +
   `RemoteEmbedder::from_env(dim)`. Never enters the wasm bundle.
-- **Structure-aware vectorisation (opt-in `structure`; measurement behind `kge`)** — research-grade.
+- **Structure-aware vectorisation (opt-in `structure` / `structure-shacl`; measurement behind `kge`)** — research-grade.
   **P0:** `close_for_vectorise` materialises the `sparq-reason` closure **before** vectorising; a
   `NegativeSampler` emits type-constrained corruptions (Krompass 2015) with an **on/off ablation**.
-  **P1:** typed-literal encoders — `route`r, **order-preserving** `NumericEncoder`, `BooleanEncoder`,
-  `DateEncoder`, self-describing `SchemaHeader` (metric guard).
+  **P1/P2:** typed-literal encoders — `route`r, **order-preserving** `NumericEncoder`, `BooleanEncoder`,
+  `DateEncoder`, enum `Codebook`, `SchemaHeader` (metric guard); QUDT unit-`normalise` (`1000 m` ≡ `1 km`);
+  **`structure-shacl`** adds the `ShaclPriors` reader (enum/datatype/cardinality from `sparq-shacl`).
   **`kge`** (implies `structure`, no new dep — hand-rolled SGD): a thin CPU-only trainer (symmetric
   **DistMult** / asymmetric **ComplEx**) + a **filtered link-prediction** `{closure}×{type-neg}`
   ablation (`run_ablation*`). **No accuracy claim**; INDICATIVE only — read deltas off ComplEx (DistMult is symmetric → near-random on directional data).

--- a/crates/sparq-vectors/src/codebook.rs
+++ b/crates/sparq-vectors/src/codebook.rs
@@ -1,0 +1,219 @@
+//! Categorical **codebook** encoder for enumeration members (structure-aware vectorisation **P2**).
+//!
+//! [OPUS-4.8] sq-0wo9e.3 (epic sq-0wo9e; design `research/structure-aware-vectorisation.md`
+//! §2 row "`owl:oneOf` / `sh:in` enum → a CATEGORICAL CODEBOOK" + §6.A "enum / boolean exactness").
+//! The encoder for [`crate::encode::Encoder::Enum`]. It is **opt-in** (the `structure` cargo
+//! feature, off by default — pure, no new dependency) and changes **nothing** in the default
+//! `sparq-vectors` build or the core engine.
+//!
+//! # The provable invariant — enum equality is a SLOT MATCH, not a cosine threshold
+//!
+//! An enumeration declared by `sh:in (…)` or `owl:oneOf (…)` is a **closed set** of members. The
+//! codebook reserves **one dimension per member** plus a **single reserved dimension for the
+//! out-of-enum / invalid code** (slot `0`). Encoding sets exactly one slot to `1.0`:
+//!
+//! - a member sets its own member slot → membership is decided by **which slot is hot**, an exact
+//!   equality, **never a cosine threshold** (design §2: "no recall loss");
+//! - a value **not in the enum** sets the reserved invalid slot (`0`) → it is a *distinct, reserved
+//!   code* a closed-world SHACL `sh:in` shape rejects (design §2: "out-of-enum → reserved invalid
+//!   code SHACL rejects"), never silently collapsed onto a member.
+//!
+//! [`Codebook::encode`] / [`Codebook::decode`] **round-trip** every member and the invalid code
+//! (the `encode_decode_roundtrip` test is the gate). The block is one-hot non-negative, so it is correct
+//! under L2/cosine and tagged [`Metric::Euclidean`](crate::encode::Metric::Euclidean).
+//!
+//! # What is NOT claimed
+//!
+//! No embedding-quality claim. A learned codebook (rather than one-hot) is a future variant; the
+//! one-hot form is the *provable* baseline (exact membership), and whether a learned codebook lifts
+//! downstream retrieval is empirical and ablation-gated (design §6.B). The width grows with the
+//! enum size, so this is intended for **small, closed** enumerations (the common `sh:in` case).
+
+use oxrdf::Term;
+use rustc_hash::FxHashMap;
+
+/// A one-hot categorical codebook over a **closed** set of enumeration members (the `sh:in` /
+/// `owl:oneOf` members). Width is `members + 1`: slot `0` is the reserved out-of-enum / invalid
+/// code, slots `1..=members` are the members in declaration order.
+#[derive(Clone, Debug)]
+pub struct Codebook {
+    /// Member term → its 1-based slot index (slot `0` is reserved for the invalid code).
+    slot_of: FxHashMap<Term, usize>,
+    /// Members in declaration order (index `i` ↦ slot `i + 1`) — for [`decode`](Self::decode) and
+    /// [`members`](Self::members).
+    members: Vec<Term>,
+}
+
+/// The reserved slot index for the **out-of-enum / invalid** code (design §2). A value not in the
+/// enum encodes here, distinct from every member slot.
+pub const INVALID_SLOT: usize = 0;
+
+impl Codebook {
+    /// Build a codebook over `members` (the `sh:in` / `owl:oneOf` members, in declaration order).
+    /// Duplicate members collapse to their first slot (a malformed enum with repeats does not widen
+    /// the block); the order of first appearance is preserved.
+    pub fn new(members: impl IntoIterator<Item = Term>) -> Codebook {
+        let mut slot_of: FxHashMap<Term, usize> = FxHashMap::default();
+        let mut ordered: Vec<Term> = Vec::new();
+        for m in members {
+            if !slot_of.contains_key(&m) {
+                slot_of.insert(m.clone(), ordered.len() + 1); // 1-based; slot 0 is reserved
+                ordered.push(m);
+            }
+        }
+        Codebook { slot_of, members: ordered }
+    }
+
+    /// The number of **distinct** enum members (excludes the reserved invalid slot).
+    pub fn member_count(&self) -> usize {
+        self.members.len()
+    }
+
+    /// The codebook block width — `member_count + 1` (the members plus the reserved invalid slot).
+    pub fn dim(&self) -> usize {
+        self.members.len() + 1
+    }
+
+    /// The members in declaration order (slot `i + 1` is `members()[i]`).
+    pub fn members(&self) -> &[Term] {
+        &self.members
+    }
+
+    /// The 1-based slot of `term`, or [`INVALID_SLOT`] (`0`) if `term` is **not** an enum member —
+    /// the reserved out-of-enum code. This is the exact membership decision (a slot match).
+    pub fn slot(&self, term: &Term) -> usize {
+        self.slot_of.get(term).copied().unwrap_or(INVALID_SLOT)
+    }
+
+    /// Is `term` a member of this enumeration? (`slot(term) != INVALID_SLOT`.)
+    pub fn is_member(&self, term: &Term) -> bool {
+        self.slot_of.contains_key(term)
+    }
+
+    /// One-hot-encode `term` into `out` (length [`dim`](Self::dim)). Exactly one slot is `1.0`: the
+    /// member's slot for a member, or the reserved [`INVALID_SLOT`] for an out-of-enum value.
+    /// Returns `Err` on a length mismatch (a layout bug, never silently truncated).
+    pub fn encode_into(&self, term: &Term, out: &mut [f32]) -> Result<(), String> {
+        if out.len() != self.dim() {
+            return Err(format!(
+                "Codebook: out.len()={} but block dim={}",
+                out.len(),
+                self.dim()
+            ));
+        }
+        out.iter_mut().for_each(|s| *s = 0.0);
+        out[self.slot(term)] = 1.0;
+        Ok(())
+    }
+
+    /// Convenience: one-hot-encode `term` to a freshly-allocated `Vec<f32>` of length
+    /// [`dim`](Self::dim).
+    pub fn encode(&self, term: &Term) -> Vec<f32> {
+        let mut out = vec![0.0f32; self.dim()];
+        let _ = self.encode_into(term, &mut out); // only errors on length mismatch, impossible here
+        out
+    }
+
+    /// **Decode** a codebook block back to the member it encodes — the exactness witness (design
+    /// §6.A "slot round-trip"). Returns `Some(member)` for a member slot, `None` for the reserved
+    /// invalid slot (the out-of-enum code) — so `decode(encode(member)) == Some(member)` and
+    /// `decode(encode(non_member)) == None`. The hot slot is the **argmax** (the block is one-hot,
+    /// so this is unambiguous for a well-formed block); `None` is also returned for an all-zero
+    /// block.
+    pub fn decode(&self, block: &[f32]) -> Option<Term> {
+        let (hot, &val) = block
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))?;
+        if val <= 0.0 || hot == INVALID_SLOT {
+            return None; // all-zero, or the reserved invalid slot
+        }
+        // slot `hot` (1-based) ↦ member index `hot - 1`.
+        self.members.get(hot - 1).cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxrdf::NamedNode;
+
+    fn iri(s: &str) -> Term {
+        Term::NamedNode(NamedNode::new_unchecked(s))
+    }
+
+    fn sample() -> Codebook {
+        Codebook::new(vec![
+            iri("http://ex/Red"),
+            iri("http://ex/Green"),
+            iri("http://ex/Blue"),
+        ])
+    }
+
+    #[test]
+    fn dim_is_members_plus_invalid_slot() {
+        let cb = sample();
+        assert_eq!(cb.member_count(), 3);
+        assert_eq!(cb.dim(), 4, "3 members + 1 reserved invalid slot");
+    }
+
+    #[test]
+    fn encode_decode_roundtrip() {
+        let cb = sample();
+        // Every member round-trips through encode→decode (exactness, design §6.A).
+        for m in cb.members() {
+            let block = cb.encode(m);
+            assert_eq!(cb.decode(&block).as_ref(), Some(m), "member must round-trip: {m}");
+            // One-hot: exactly one slot is 1.0, and it is NOT the invalid slot.
+            let hot: Vec<usize> = block.iter().enumerate().filter(|(_, &v)| v == 1.0).map(|(i, _)| i).collect();
+            assert_eq!(hot.len(), 1, "exactly one hot slot");
+            assert_ne!(hot[0], INVALID_SLOT, "a member must not use the invalid slot");
+        }
+    }
+
+    #[test]
+    fn out_of_enum_uses_reserved_invalid_code() {
+        let cb = sample();
+        let outsider = iri("http://ex/Purple"); // NOT in the enum
+        assert!(!cb.is_member(&outsider));
+        assert_eq!(cb.slot(&outsider), INVALID_SLOT);
+        let block = cb.encode(&outsider);
+        // The invalid slot is hot, and decode reports None (not a member) — the reserved code a
+        // closed-world SHACL `sh:in` shape rejects, never silently a member.
+        assert_eq!(block[INVALID_SLOT], 1.0);
+        assert!(cb.decode(&block).is_none(), "out-of-enum decodes to None, not a member");
+    }
+
+    #[test]
+    fn slot_match_not_cosine_threshold() {
+        // Two distinct members are ORTHOGONAL one-hot codes (cosine 0) — equality is the slot, not a
+        // distance threshold; no near-member ever aliases onto another member.
+        let cb = sample();
+        let red = cb.encode(&iri("http://ex/Red"));
+        let green = cb.encode(&iri("http://ex/Green"));
+        let dot: f32 = red.iter().zip(green.iter()).map(|(a, b)| a * b).sum();
+        assert_eq!(dot, 0.0, "distinct members are orthogonal — membership is exact, not fuzzy");
+    }
+
+    #[test]
+    fn duplicate_members_collapse() {
+        let cb = Codebook::new(vec![iri("http://ex/A"), iri("http://ex/A"), iri("http://ex/B")]);
+        assert_eq!(cb.member_count(), 2, "a repeated member does not widen the block");
+        assert_eq!(cb.dim(), 3);
+    }
+
+    #[test]
+    fn encode_into_rejects_length_mismatch() {
+        let cb = sample();
+        let mut wrong = [0.0f32; 3];
+        assert!(cb.encode_into(&iri("http://ex/Red"), &mut wrong).is_err());
+        let mut right = [0.0f32; 4];
+        assert!(cb.encode_into(&iri("http://ex/Red"), &mut right).is_ok());
+    }
+
+    #[test]
+    fn all_zero_block_decodes_to_none() {
+        let cb = sample();
+        assert!(cb.decode(&[0.0; 4]).is_none(), "an all-zero block is not a member");
+    }
+}

--- a/crates/sparq-vectors/src/encode.rs
+++ b/crates/sparq-vectors/src/encode.rs
@@ -111,10 +111,15 @@ pub enum Encoder {
     /// A temporal literal (`xsd:date`/`dateTime`/`dateTimeStamp`/`gYear`) → the order-preserving
     /// epoch lane of [`DateEncoder`].
     Date,
-    /// Anything else — a plain string, a language-tagged literal, an enum member, an IRI. P1 does
-    /// **not** encode these: strings go to the existing out-of-process text lane
-    /// (the [`verbalize`](mod@crate::verbalize) module); enums are P2 (codebook). The router reports them as `Other` so a
-    /// caller routes them to the correct (non-P1) lane rather than mis-encoding them numerically.
+    /// An **enumeration member** — a value drawn from a closed set declared by `sh:in` / `owl:oneOf`
+    /// → the [`Codebook`](crate::codebook::Codebook) block (P2, the `structure-shacl` reader).
+    /// Encoded by **slot match**, not a cosine threshold: membership is exact and out-of-enum is a
+    /// reserved invalid code (design §2 "enum equality is a slot match … no recall loss").
+    Enum,
+    /// Anything else — a plain string, a language-tagged literal, a free IRI. The router does
+    /// **not** encode these: strings go to the existing out-of-process text lane (the
+    /// [`verbalize`](mod@crate::verbalize) module). The router reports them as `Other` so a caller
+    /// routes them to the correct lane rather than mis-encoding them numerically.
     Other,
 }
 
@@ -607,6 +612,9 @@ fn encoder_tag(e: Encoder) -> u8 {
         Encoder::Boolean => 2,
         Encoder::Date => 3,
         Encoder::Other => 4,
+        // [OPUS-4.8] sq-0wo9e.3 (P2): tag 5 is additive — a header written by P1 never used it, so
+        // older serialised headers still parse and new ones round-trip the enum (codebook) block.
+        Encoder::Enum => 5,
     }
 }
 
@@ -616,6 +624,7 @@ fn encoder_of_tag(t: u8) -> Result<Encoder, String> {
         2 => Ok(Encoder::Boolean),
         3 => Ok(Encoder::Date),
         4 => Ok(Encoder::Other),
+        5 => Ok(Encoder::Enum),
         _ => Err(format!("SchemaHeader: unknown encoder tag {}", t)),
     }
 }
@@ -1007,7 +1016,7 @@ mod tests {
     #[test]
     fn schema_header_tags_are_total() {
         // Every encoder/metric tag round-trips (guards against an unmapped variant).
-        for e in [Encoder::Numeric, Encoder::Boolean, Encoder::Date, Encoder::Other] {
+        for e in [Encoder::Numeric, Encoder::Boolean, Encoder::Date, Encoder::Other, Encoder::Enum] {
             assert_eq!(encoder_of_tag(encoder_tag(e)).unwrap(), e);
         }
         for m in [Metric::Euclidean, Metric::NonEuclidean] {

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -24,6 +24,22 @@ pub mod embed;
 // / the date encoder touch sparq-core, already in the tree). The default build carries zero encoder code.
 #[cfg(feature = "structure")]
 pub mod encode;
+// [OPUS-4.8] sq-0wo9e.3 (epic sq-0wo9e): P2 — the categorical CODEBOOK encoder for `sh:in`/`owl:oneOf`
+// enum members (slot-match exactness, reserved out-of-enum invalid code) and the QUDT UNIT
+// normaliser (`1000 m` and `1 km` share a code before the order-preserving numeric encoder).
+// `structure` feature only; pure, dependency-light (no SHACL/engine dep — the SHACL *reader* below
+// is the only thing that pulls sparq-shacl). The default build carries zero P2 code.
+#[cfg(feature = "structure")]
+pub mod codebook;
+#[cfg(feature = "structure")]
+pub mod units;
+// [OPUS-4.8] sq-0wo9e.3 (epic sq-0wo9e): P2 — the SHACL/OWL PRIOR EXTRACTOR. Reads enum (`sh:in`) /
+// datatype (`sh:datatype`) / cardinality (`sh:min,maxCount`, `owl:FunctionalProperty`) priors out of
+// a parsed `sparq-shacl` shapes model (no SHACL changes — a read-only reader). `structure-shacl`
+// feature only: it is the ONLY feature pulling `sparq-shacl` into this crate's graph, so neither the
+// default build nor the lean `structure` feature gains a SHACL/engine dependency.
+#[cfg(feature = "structure-shacl")]
+pub mod shacl_priors;
 #[cfg(feature = "filtered-ann")]
 pub mod filter;
 pub mod fingerprint;
@@ -146,6 +162,19 @@ pub use encode::{
     metamorphic_monotone, numeric_value, route, temporal_value, Block, BooleanEncoder, DateEncoder,
     Encoder, Metric, NumericEncoder, SchemaHeader, SPQS_MAGIC, SPQS_VERSION,
 };
+// [OPUS-4.8] sq-0wo9e.3 (epic sq-0wo9e): the P2 enum codebook + QUDT unit-normaliser surface —
+// `structure` feature only (pure, no SHACL dep).
+#[cfg(feature = "structure")]
+pub use codebook::{Codebook, INVALID_SLOT};
+#[cfg(feature = "structure")]
+pub use units::{
+    is_known, normalise, normalise_lexical, quantity_kind, same_quantity, Normalised, QuantityKind,
+    QUDT_UNIT_NS,
+};
+// [OPUS-4.8] sq-0wo9e.3 (epic sq-0wo9e): the P2 SHACL/OWL prior-extractor surface —
+// `structure-shacl` feature only (the only feature pulling sparq-shacl).
+#[cfg(feature = "structure-shacl")]
+pub use shacl_priors::{Cardinality, PredicatePrior, ShaclPriors};
 pub use verbalize::{
     description_predicates, embed_entities, label_predicates, verbalize, EntityTextConfig,
     ObjectKind, PropertyGroup,

--- a/crates/sparq-vectors/src/shacl_priors.rs
+++ b/crates/sparq-vectors/src/shacl_priors.rs
@@ -1,0 +1,375 @@
+//! SHACL / OWL **prior extractor** — read enum / datatype / cardinality priors out of a parsed
+//! SHACL shapes model (and `owl:FunctionalProperty` from the data graph) into the layout the
+//! structure-aware encoders consume (structure-aware vectorisation **P2**).
+//!
+//! [OPUS-4.8] sq-0wo9e.3 (epic sq-0wo9e; design `research/structure-aware-vectorisation.md`
+//! §2 + §7 "sparq-shacl already evaluates `sh:datatype`, `sh:in`, `sh:not`, `min/maxCount` — the
+//! prior extractor reads these from `model.rs` (no SHACL changes; a new reader in the opt-in
+//! crate)"). It is **opt-in** behind the `structure-shacl` cargo feature (off by default) — the
+//! ONLY feature that pulls `sparq-shacl` into this crate's graph, so the default build (and the
+//! `structure` feature) carry zero SHACL code and gain no new required dep.
+//!
+//! # What it extracts (per predicate)
+//!
+//! For each **property shape** whose `sh:path` is a single predicate, the reader maps the SHACL
+//! constraints to the structure-aware priors of design §2:
+//!
+//! | SHACL / OWL fact | Prior |
+//! |---|---|
+//! | `sh:in (m1 m2 …)` | a **[`Codebook`]** over the enum members — encoded by slot match, out-of-enum is the reserved invalid code (design §2 "enum equality is a slot match"). |
+//! | `sh:datatype dt` | the **router-confirm** [`Encoder`] for `dt` (cross-checks the datatype router against the declared datatype — a *declared* type the encoder can trust over a guessed one). |
+//! | `sh:maxCount 1` **or** `owl:FunctionalProperty` | [`Cardinality::Functional`] → a **single deterministic slot** (one value per subject). |
+//! | otherwise (multi-valued) | [`Cardinality::Multi`] → a **permutation-invariant pooled** block (design §2 "multi-valued → a permutation-invariant pooled block"). |
+//! | `sh:minCount` / `sh:maxCount` | recorded on [`PredicatePrior`] so a caller knows the declared multiplicity. |
+//!
+//! `owl:FunctionalProperty` is an **OWL** axiom, not a SHACL constraint, so it is read from the
+//! **data/ontology graph** (a `rdf:type owl:FunctionalProperty` triple), not the shapes model —
+//! exactly the split design §2/§7 describes. The shapes model is read **read-only**; no SHACL
+//! behaviour changes.
+//!
+//! # Honesty
+//!
+//! Enum/boolean exactness and the datatype-confirm are **provable** (slot match, exact dispatch).
+//! Whether these priors lift downstream retrieval is **empirical and ablation-gated** (design §6.B)
+//! — no accuracy claim is made here. A predicate with **no** declared shape simply has **no** prior
+//! (the caller falls back to the datatype router on the literal alone) — fail-open, never a guess.
+
+use crate::codebook::Codebook;
+use crate::encode::{route, Encoder};
+use oxrdf::Term;
+use rustc_hash::FxHashMap;
+use sparq_shacl::model::{Component, ShapesModel};
+use sparq_shacl::Path;
+
+/// `rdf:type` and `owl:FunctionalProperty` IRIs (the OWL functional-property axiom is read from the
+/// data graph, not the shapes model).
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const OWL_FUNCTIONAL_PROPERTY: &str = "http://www.w3.org/2002/07/owl#FunctionalProperty";
+
+/// The **pooling rule** a predicate's cardinality dictates (design §2 "Cardinality → a POOLING
+/// RULE"). It tells the structured-object builder whether the predicate occupies one deterministic
+/// slot or a permutation-invariant pooled block.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Cardinality {
+    /// At most one value per subject (`sh:maxCount 1` or `owl:FunctionalProperty`) → a **single
+    /// deterministic slot**.
+    Functional,
+    /// Possibly many values per subject → a **permutation-invariant pooled** block (the order of
+    /// the values must not change the encoding).
+    Multi,
+}
+
+/// The structure-aware priors mined for one predicate from the SHACL shapes (and OWL axioms).
+/// Every field is `Option`/best-effort: a missing constraint means "no prior", never a guess.
+#[derive(Clone, Debug)]
+pub struct PredicatePrior {
+    /// The predicate IRI these priors are for.
+    pub predicate: String,
+    /// `Some(codebook)` when the predicate declares an `sh:in` enumeration → encode by slot match
+    /// ([`Codebook`]); `None` otherwise.
+    pub enum_codebook: Option<Codebook>,
+    /// `Some(encoder)` when the predicate declares an `sh:datatype` — the **router-confirmed**
+    /// encoder family for that *declared* datatype (a declared type the encoder can trust). `None`
+    /// when no `sh:datatype` is declared. A `sh:datatype` list with mixed encoder families resolves
+    /// to `Encoder::Other` (no single trusted lane).
+    pub datatype_encoder: Option<Encoder>,
+    /// The pooling rule from the predicate's cardinality (functional vs multi-valued).
+    pub cardinality: Cardinality,
+    /// The declared `sh:minCount`, if any.
+    pub min_count: Option<u64>,
+    /// The declared `sh:maxCount`, if any.
+    pub max_count: Option<u64>,
+}
+
+impl PredicatePrior {
+    /// Is this predicate functional (one value per subject) — `sh:maxCount 1` or
+    /// `owl:FunctionalProperty`? Convenience over [`cardinality`](Self::cardinality).
+    pub fn is_functional(&self) -> bool {
+        self.cardinality == Cardinality::Functional
+    }
+}
+
+/// All per-predicate priors mined from a shapes model + the functional-property axioms of a data
+/// graph. Keyed by predicate IRI.
+#[derive(Clone, Debug, Default)]
+pub struct ShaclPriors {
+    by_predicate: FxHashMap<String, PredicatePrior>,
+}
+
+impl ShaclPriors {
+    /// Mine priors from a parsed [`ShapesModel`] **only** (no OWL functional-property axioms — a
+    /// predicate is functional iff it declares `sh:maxCount 1`). Use
+    /// [`from_model_and_data`](Self::from_model_and_data) to also honour `owl:FunctionalProperty`
+    /// from a data graph.
+    pub fn from_model(model: &ShapesModel) -> ShaclPriors {
+        Self::extract(model, &Default::default())
+    }
+
+    /// Mine priors from a parsed [`ShapesModel`] **and** the `owl:FunctionalProperty` axioms of a
+    /// data/ontology [`Graph`](sparq_core::Graph). A predicate is [`Cardinality::Functional`] when
+    /// it declares `sh:maxCount 1` **or** is typed `owl:FunctionalProperty` in `data` (the OWL/SHACL
+    /// split of design §2/§7 — the OWL axiom comes from the data graph, the SHACL constraints from
+    /// the model).
+    pub fn from_model_and_data(model: &ShapesModel, data: &sparq_core::Graph) -> ShaclPriors {
+        let functional = functional_properties(data);
+        Self::extract(model, &functional)
+    }
+
+    /// The mined prior for `predicate`, if any (`None` when the predicate has no declared shape).
+    pub fn get(&self, predicate: &str) -> Option<&PredicatePrior> {
+        self.by_predicate.get(predicate)
+    }
+
+    /// Every mined predicate prior.
+    pub fn priors(&self) -> impl Iterator<Item = &PredicatePrior> {
+        self.by_predicate.values()
+    }
+
+    /// The number of predicates with at least one mined prior.
+    pub fn len(&self) -> usize {
+        self.by_predicate.len()
+    }
+
+    /// Is the prior set empty (no predicate had a usable shape)?
+    pub fn is_empty(&self) -> bool {
+        self.by_predicate.is_empty()
+    }
+
+    fn extract(
+        model: &ShapesModel,
+        functional_axioms: &rustc_hash::FxHashSet<String>,
+    ) -> ShaclPriors {
+        let mut by_predicate: FxHashMap<String, PredicatePrior> = FxHashMap::default();
+
+        for shape in &model.shapes {
+            // Only property shapes whose path is a single predicate carry per-predicate priors. A
+            // complex path (inverse / sequence / alternative) has no single predicate to key on.
+            let Some(Path::Predicate(pred)) = shape.path.as_ref() else { continue };
+
+            let mut enum_members: Option<Vec<Term>> = None;
+            let mut datatype_set: Option<Vec<String>> = None;
+            let mut min_count: Option<u64> = None;
+            let mut max_count: Option<u64> = None;
+
+            for comp in &shape.components {
+                match comp {
+                    Component::In(members) => {
+                        // Last `sh:in` on a shape wins if (malformedly) repeated; clone the members.
+                        enum_members = Some(members.clone());
+                    }
+                    Component::Datatype(dts) => datatype_set = Some(dts.clone()),
+                    Component::MinCount(n) => min_count = Some(*n),
+                    Component::MaxCount(n) => max_count = Some(*n),
+                    _ => {}
+                }
+            }
+
+            let functional =
+                max_count == Some(1) || functional_axioms.contains(pred.as_str());
+            let cardinality =
+                if functional { Cardinality::Functional } else { Cardinality::Multi };
+
+            let enum_codebook = enum_members.map(Codebook::new);
+            let datatype_encoder = datatype_set.as_deref().map(resolve_datatype_encoder);
+
+            // Merge into any existing prior for the same predicate (two property shapes may target
+            // the same predicate): a more specific (Some) value wins; functional is sticky (once a
+            // shape declares maxCount 1 the predicate is functional).
+            match by_predicate.get_mut(pred) {
+                Some(existing) => {
+                    if existing.enum_codebook.is_none() {
+                        existing.enum_codebook = enum_codebook;
+                    }
+                    if existing.datatype_encoder.is_none() {
+                        existing.datatype_encoder = datatype_encoder;
+                    }
+                    if existing.min_count.is_none() {
+                        existing.min_count = min_count;
+                    }
+                    if existing.max_count.is_none() {
+                        existing.max_count = max_count;
+                    }
+                    if cardinality == Cardinality::Functional {
+                        existing.cardinality = Cardinality::Functional;
+                    }
+                }
+                None => {
+                    by_predicate.insert(
+                        pred.clone(),
+                        PredicatePrior {
+                            predicate: pred.clone(),
+                            enum_codebook,
+                            datatype_encoder,
+                            cardinality,
+                            min_count,
+                            max_count,
+                        },
+                    );
+                }
+            }
+        }
+
+        ShaclPriors { by_predicate }
+    }
+}
+
+/// Resolve a declared `sh:datatype` set to a **single** router-confirmed [`Encoder`]: if every
+/// declared datatype routes to the same encoder family, that family is the confirmed lane; a
+/// mixed-family list (e.g. `( xsd:string xsd:integer )`) has no single trusted lane and resolves to
+/// [`Encoder::Other`]. An empty set also resolves to `Other`.
+fn resolve_datatype_encoder(datatypes: &[String]) -> Encoder {
+    let mut encoders = datatypes.iter().map(|dt| route(dt));
+    match encoders.next() {
+        None => Encoder::Other,
+        Some(first) => {
+            if encoders.all(|e| e == first) {
+                first
+            } else {
+                Encoder::Other
+            }
+        }
+    }
+}
+
+/// The set of predicate IRIs typed `owl:FunctionalProperty` in `data` (an OWL axiom read from the
+/// data/ontology graph — not the shapes model).
+fn functional_properties(data: &sparq_core::Graph) -> rustc_hash::FxHashSet<String> {
+    use oxrdf::NamedNode;
+    let type_id = data.id_of(&Term::NamedNode(NamedNode::new_unchecked(RDF_TYPE)));
+    let fp_id = data.id_of(&Term::NamedNode(NamedNode::new_unchecked(OWL_FUNCTIONAL_PROPERTY)));
+    let (Some(type_id), Some(fp_id)) = (type_id, fp_id) else {
+        return rustc_hash::FxHashSet::default();
+    };
+    let mut out = rustc_hash::FxHashSet::default();
+    for [s, p, o] in data.iter_ids() {
+        if p == type_id && o == fp_id {
+            // Resolve the subject id back to its IRI string (a non-IRI subject of an
+            // owl:FunctionalProperty axiom is malformed and simply ignored).
+            if let Term::NamedNode(n) = data.dict.term(s) {
+                out.insert(n.into_string());
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sparq_core::Graph;
+
+    fn shapes(ttl: &str) -> ShapesModel {
+        let g = Graph::load_str(ttl, "turtle").expect("parse shapes");
+        ShapesModel::parse(&g)
+    }
+
+    const SHAPES: &str = r#"
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <http://ex/> .
+
+ex:PersonShape a sh:NodeShape ;
+  sh:targetClass ex:Person ;
+  sh:property [ sh:path ex:age ;     sh:datatype xsd:integer ; sh:maxCount 1 ; sh:minCount 1 ] ;
+  sh:property [ sh:path ex:status ;  sh:in ( ex:Active ex:Suspended ex:Closed ) ; sh:maxCount 1 ] ;
+  sh:property [ sh:path ex:nickname ; sh:datatype xsd:string ] .
+"#;
+
+    #[test]
+    fn extracts_enum_codebook_with_slot_match() {
+        let m = shapes(SHAPES);
+        let priors = ShaclPriors::from_model(&m);
+        let status = priors.get("http://ex/status").expect("status prior");
+        let cb = status.enum_codebook.as_ref().expect("status declares sh:in → codebook");
+        assert_eq!(cb.member_count(), 3, "3 enum members");
+        // Slot match, not a cosine threshold: a member is hot at its own slot; an outsider is the
+        // reserved invalid code.
+        let active = oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked("http://ex/Active"));
+        assert!(cb.is_member(&active));
+        let outsider = oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked("http://ex/Other"));
+        assert!(!cb.is_member(&outsider));
+        assert_eq!(cb.slot(&outsider), crate::codebook::INVALID_SLOT);
+    }
+
+    #[test]
+    fn datatype_confirm_routes_declared_type() {
+        let m = shapes(SHAPES);
+        let priors = ShaclPriors::from_model(&m);
+        // The declared sh:datatype confirms the encoder family the router would pick.
+        assert_eq!(priors.get("http://ex/age").unwrap().datatype_encoder, Some(Encoder::Numeric));
+        assert_eq!(
+            priors.get("http://ex/nickname").unwrap().datatype_encoder,
+            Some(Encoder::Other),
+            "xsd:string routes to the text (Other) lane"
+        );
+    }
+
+    #[test]
+    fn cardinality_pooling_rule_from_maxcount() {
+        let m = shapes(SHAPES);
+        let priors = ShaclPriors::from_model(&m);
+        // sh:maxCount 1 → Functional (one deterministic slot).
+        let age = priors.get("http://ex/age").unwrap();
+        assert!(age.is_functional(), "maxCount 1 → functional");
+        assert_eq!(age.cardinality, Cardinality::Functional);
+        assert_eq!(age.min_count, Some(1));
+        assert_eq!(age.max_count, Some(1));
+        // No maxCount on nickname → Multi (permutation-invariant pooled block).
+        assert_eq!(priors.get("http://ex/nickname").unwrap().cardinality, Cardinality::Multi);
+    }
+
+    #[test]
+    fn owl_functional_property_from_data_graph() {
+        // `ex:ssn` is functional via the OWL axiom, NOT a SHACL maxCount.
+        let shapes_ttl = r#"
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix ex:  <http://ex/> .
+ex:S a sh:NodeShape ; sh:property [ sh:path ex:ssn ] .
+"#;
+        let data_ttl = r#"
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix ex:  <http://ex/> .
+ex:ssn a owl:FunctionalProperty .
+"#;
+        let m = shapes(shapes_ttl);
+        let data = Graph::load_str(data_ttl, "turtle").unwrap();
+
+        // Without the data graph, ssn has no maxCount → Multi.
+        assert_eq!(
+            ShaclPriors::from_model(&m).get("http://ex/ssn").unwrap().cardinality,
+            Cardinality::Multi
+        );
+        // With the data graph, the OWL axiom makes it Functional.
+        let with_owl = ShaclPriors::from_model_and_data(&m, &data);
+        assert!(
+            with_owl.get("http://ex/ssn").unwrap().is_functional(),
+            "owl:FunctionalProperty makes ex:ssn functional"
+        );
+    }
+
+    #[test]
+    fn predicate_with_no_shape_has_no_prior_fail_open() {
+        let m = shapes(SHAPES);
+        let priors = ShaclPriors::from_model(&m);
+        assert!(priors.get("http://ex/undeclared").is_none(), "no shape → no prior (fail-open)");
+    }
+
+    #[test]
+    fn mixed_datatype_list_has_no_single_lane() {
+        let m = shapes(
+            r#"
+@prefix sh:  <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:  <http://ex/> .
+ex:S a sh:NodeShape ;
+  sh:property [ sh:path ex:mixed ; sh:datatype ( xsd:integer xsd:string ) ] .
+"#,
+        );
+        let priors = ShaclPriors::from_model(&m);
+        // numeric + string → no single trusted lane → Other.
+        assert_eq!(
+            priors.get("http://ex/mixed").unwrap().datatype_encoder,
+            Some(Encoder::Other)
+        );
+    }
+}

--- a/crates/sparq-vectors/src/units.rs
+++ b/crates/sparq-vectors/src/units.rs
@@ -1,0 +1,328 @@
+//! QUDT unit-normalisation — convert a unit-annotated magnitude to its **canonical SI value**
+//! *before* the order-preserving numeric encoder, so `1000 m` and `1 km` share a code
+//! (structure-aware vectorisation **P2**).
+//!
+//! [OPUS-4.8] sq-0wo9e.3 (epic sq-0wo9e; design `research/structure-aware-vectorisation.md`
+//! §2 row "QUDT / unit annotations → UNIT-NORMALISE-BEFORE-MAGNITUDE" + §3.1 numeric encoder).
+//! Part of the **second** structure-aware slice (P2), on top of P1
+//! ([`crate::encode`]: the typed-literal encoders). It is **opt-in** (the same `structure` cargo
+//! feature, off by default — no new dependency) and changes **nothing** in the default
+//! `sparq-vectors` build or the core engine.
+//!
+//! # The problem this solves
+//!
+//! A magnitude is only meaningful *with* its unit. Two literals `"1000"^^…` annotated `qudt:unit
+//! unit:M` (metre) and `"1"^^…` annotated `unit:KiloM` (kilometre) denote the **same** physical
+//! length, but the raw numbers `1000` and `1` would land at opposite ends of the
+//! order-preserving numeric block ([`crate::encode::NumericEncoder`]) — the order-preservation
+//! guarantee is then over *lexical* magnitudes, not *physical* ones, which is wrong.
+//!
+//! The fix (design §2): **normalise to the canonical SI base unit of the quantity kind first**,
+//! then feed the canonical value to the numeric encoder. After normalisation both literals are
+//! `1000` metres, so they encode identically and order-preservation holds over physical magnitude.
+//!
+//! # What is, and is NOT, claimed
+//!
+//! - **Provable (and tested):** the conversion is an **affine map** `canonical = lexical * factor
+//!   + offset` with a constant `(factor, offset)` per unit; two unit/value pairs that denote the
+//!   same physical quantity map to the **same** canonical value (exactly for affine-exact units,
+//!   within f64 rounding otherwise). [`same_quantity_normalises_equal`] is the gate.
+//! - **Fail-closed / SHACL-detectable mismatch (design §2 "unit mismatch is SHACL-detectable,
+//!   not silent noise"):** [`normalise`] returns the **quantity kind** alongside the value, so a
+//!   caller routes each quantity kind to its **own** numeric block (a length is never compared to a
+//!   mass). An **unknown** unit IRI yields `None` — the magnitude is then skipped, never silently
+//!   treated as dimensionless; and mixing two different [`QuantityKind`]s in one block is a
+//!   caller-detectable error, exactly as a `sh:datatype`/unit mismatch is for SHACL.
+//! - **NOT claimed:** completeness of the bundled table. This is a **curated, deliberately small**
+//!   subset of QUDT (the common SI + a few customary units), not the full QUDT ontology. An
+//!   absent unit fails closed (`None`); extending the table is additive. No accuracy/embedding
+//!   claim is made — this only makes the *input* to the numeric encoder physically comparable.
+
+/// The QUDT `unit:` vocabulary namespace (the curated subset below uses these IRIs). The full
+/// vocabulary is much larger; this crate bundles only the common units (see the module docs).
+pub const QUDT_UNIT_NS: &str = "http://qudt.org/vocab/unit/";
+
+/// The physical **quantity kind** a unit measures — the *routing slot* of design §2 ("quantity-kind
+/// is a routing slot"). Two values are only physically comparable (and may share a numeric block)
+/// when their [`QuantityKind`] matches; the canonical SI base unit is fixed per kind.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum QuantityKind {
+    /// Length — canonical base **metre** (`m`).
+    Length,
+    /// Mass — canonical base **kilogram** (`kg`).
+    Mass,
+    /// Time / duration — canonical base **second** (`s`).
+    Time,
+    /// Thermodynamic temperature — canonical base **kelvin** (`K`) (affine for °C/°F).
+    Temperature,
+    /// Plane angle — canonical base **radian** (`rad`).
+    Angle,
+    /// Data / information size — canonical base **byte** (`B`).
+    DataSize,
+}
+
+impl QuantityKind {
+    /// The canonical SI base unit's QUDT local name (the unit a value is normalised *to*).
+    pub fn canonical_unit(self) -> &'static str {
+        match self {
+            QuantityKind::Length => "M",
+            QuantityKind::Mass => "KiloGM",
+            QuantityKind::Time => "SEC",
+            QuantityKind::Temperature => "K",
+            QuantityKind::Angle => "RAD",
+            QuantityKind::DataSize => "BYTE",
+        }
+    }
+}
+
+/// A normalised magnitude: the value expressed in the canonical SI base unit of its
+/// [`QuantityKind`], plus that kind (the routing slot). Produced by [`normalise`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Normalised {
+    /// The value in the canonical SI base unit (`canonical = lexical * factor + offset`).
+    pub canonical_value: f64,
+    /// The physical quantity kind — the routing slot. Two `Normalised` values may share a numeric
+    /// block only when this matches.
+    pub kind: QuantityKind,
+}
+
+/// One unit's affine conversion **to** its quantity kind's canonical SI base unit:
+/// `canonical = lexical * factor + offset`. For a pure scaling unit (km → m) `offset` is `0.0`;
+/// affine units (°C → K) carry a non-zero `offset`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct UnitConv {
+    kind: QuantityKind,
+    factor: f64,
+    offset: f64,
+}
+
+/// Resolve a unit IRI (or bare QUDT local name) to its conversion, or `None` if the unit is not in
+/// the bundled table. Accepts a full `http://qudt.org/vocab/unit/<Local>` IRI or just `<Local>`
+/// (so a caller that has already stripped the namespace, or uses a different serialisation, still
+/// resolves). The match is on the **local name** exactly as QUDT spells it (case-sensitive).
+fn lookup(unit_iri: &str) -> Option<UnitConv> {
+    let local = unit_iri.strip_prefix(QUDT_UNIT_NS).unwrap_or(unit_iri);
+    // The bundled table: (local-name, kind, factor-to-canonical, offset-to-canonical).
+    // Curated, deliberately small subset of QUDT. Extending it is purely additive.
+    let conv = |kind, factor, offset| UnitConv { kind, factor, offset };
+    use QuantityKind::*;
+    Some(match local {
+        // ---- length (canonical: metre) ----
+        "M" | "Meter" | "Metre" => conv(Length, 1.0, 0.0),
+        "KiloM" => conv(Length, 1_000.0, 0.0),
+        "CentiM" => conv(Length, 0.01, 0.0),
+        "MilliM" => conv(Length, 0.001, 0.0),
+        "MicroM" => conv(Length, 1e-6, 0.0),
+        "NanoM" => conv(Length, 1e-9, 0.0),
+        "MI" | "MI_International" => conv(Length, 1_609.344, 0.0), // statute mile
+        "YD" => conv(Length, 0.9144, 0.0),                        // yard
+        "FT" => conv(Length, 0.3048, 0.0),                        // foot
+        "IN" => conv(Length, 0.0254, 0.0),                        // inch
+        // ---- mass (canonical: kilogram) ----
+        "KiloGM" => conv(Mass, 1.0, 0.0),
+        "GM" => conv(Mass, 0.001, 0.0),
+        "MilliGM" => conv(Mass, 1e-6, 0.0),
+        "MicroGM" => conv(Mass, 1e-9, 0.0),
+        "TONNE" | "TON_Metric" => conv(Mass, 1_000.0, 0.0),
+        "LB" => conv(Mass, 0.453_592_37, 0.0), // avoirdupois pound
+        "OZ" => conv(Mass, 0.028_349_523_125, 0.0),
+        // ---- time (canonical: second) ----
+        "SEC" => conv(Time, 1.0, 0.0),
+        "MilliSEC" => conv(Time, 0.001, 0.0),
+        "MicroSEC" => conv(Time, 1e-6, 0.0),
+        "MIN" => conv(Time, 60.0, 0.0),
+        "HR" => conv(Time, 3_600.0, 0.0),
+        "DAY" => conv(Time, 86_400.0, 0.0),
+        "WK" => conv(Time, 604_800.0, 0.0),
+        "YR" | "YR_Common" => conv(Time, 31_536_000.0, 0.0), // 365-day common year
+        // ---- temperature (canonical: kelvin; AFFINE for °C/°F) ----
+        "K" => conv(Temperature, 1.0, 0.0),
+        "DEG_C" => conv(Temperature, 1.0, 273.15),
+        "DEG_F" => conv(Temperature, 5.0 / 9.0, 459.67 * 5.0 / 9.0),
+        // ---- plane angle (canonical: radian) ----
+        "RAD" => conv(Angle, 1.0, 0.0),
+        "DEG" => conv(Angle, core::f64::consts::PI / 180.0, 0.0),
+        "GRAD" => conv(Angle, core::f64::consts::PI / 200.0, 0.0),
+        // ---- data size (canonical: byte; decimal SI prefixes) ----
+        "BYTE" => conv(DataSize, 1.0, 0.0),
+        "KiloBYTE" => conv(DataSize, 1_000.0, 0.0),
+        "MegaBYTE" => conv(DataSize, 1_000_000.0, 0.0),
+        "GigaBYTE" => conv(DataSize, 1_000_000_000.0, 0.0),
+        "KibiBYTE" => conv(DataSize, 1_024.0, 0.0),
+        "MebiBYTE" => conv(DataSize, 1_048_576.0, 0.0),
+        "GibiBYTE" => conv(DataSize, 1_073_741_824.0, 0.0),
+        _ => return None,
+    })
+}
+
+/// Is `unit_iri` a unit the bundled table knows? (`true` ⇒ [`normalise`] succeeds for any finite
+/// value.)
+pub fn is_known(unit_iri: &str) -> bool {
+    lookup(unit_iri).is_some()
+}
+
+/// The [`QuantityKind`] a known unit measures, or `None` for an unknown unit. The routing slot
+/// without converting a value (e.g. to check two units are comparable before encoding).
+pub fn quantity_kind(unit_iri: &str) -> Option<QuantityKind> {
+    lookup(unit_iri).map(|c| c.kind)
+}
+
+/// Do two unit IRIs measure the **same** physical quantity kind (so their normalised values may
+/// share a numeric block)? `false` if either is unknown or they differ — the caller treats a
+/// `false` as the **unit-mismatch error** design §2 calls "SHACL-detectable".
+pub fn same_quantity(a: &str, b: &str) -> bool {
+    match (quantity_kind(a), quantity_kind(b)) {
+        (Some(ka), Some(kb)) => ka == kb,
+        _ => false,
+    }
+}
+
+/// Normalise a `(value, unit_iri)` pair to its canonical SI value + quantity kind — the
+/// **UNIT-NORMALISE-BEFORE-MAGNITUDE** step (design §2). Returns `None` (fail-closed) when:
+///
+/// - the unit is **not** in the bundled table (the magnitude is then skipped, never silently
+///   treated as dimensionless), or
+/// - the lexical `value` is non-finite (`NaN`/`±inf` — a magnitude lane has no order for them), or
+/// - the normalised result is non-finite (an overflow under a huge factor).
+///
+/// On `Some`, feed [`Normalised::canonical_value`] to [`crate::encode::NumericEncoder`] **fitted
+/// over canonical values of the same [`Normalised::kind`]**, so `1000 m` and `1 km` land at the
+/// identical code and order-preservation holds over *physical* magnitude.
+pub fn normalise(value: f64, unit_iri: &str) -> Option<Normalised> {
+    if !value.is_finite() {
+        return None;
+    }
+    let conv = lookup(unit_iri)?;
+    let canonical = value * conv.factor + conv.offset;
+    canonical
+        .is_finite()
+        .then_some(Normalised { canonical_value: canonical, kind: conv.kind })
+}
+
+/// Parse a numeric `lexical` (via [`crate::encode::numeric_value`]) **and** normalise it by
+/// `unit_iri` in one call — the convenience entry point from a unit-annotated RDF literal's
+/// `(lexical, unit)`. `None` if the lexical is not a finite number or the unit is unknown.
+pub fn normalise_lexical(lexical: &str, unit_iri: &str) -> Option<Normalised> {
+    let v = crate::encode::numeric_value(lexical)?;
+    normalise(v, unit_iri)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- the load-bearing property: same physical quantity → same canonical value ----
+
+    #[test]
+    fn same_quantity_normalises_equal() {
+        // 1000 m and 1 km are the SAME length → identical canonical value (the design's example).
+        let m = normalise(1000.0, "http://qudt.org/vocab/unit/M").unwrap();
+        let km = normalise(1.0, "http://qudt.org/vocab/unit/KiloM").unwrap();
+        assert_eq!(m.kind, QuantityKind::Length);
+        assert_eq!(km.kind, QuantityKind::Length);
+        assert!((m.canonical_value - km.canonical_value).abs() < 1e-9, "1000 m == 1 km");
+        assert_eq!(m.canonical_value, 1000.0);
+
+        // 1 cm == 10 mm; 2.54 cm == 1 inch (within f64 rounding).
+        let cm = normalise(1.0, "CentiM").unwrap();
+        let mm = normalise(10.0, "MilliM").unwrap();
+        assert!((cm.canonical_value - mm.canonical_value).abs() < 1e-12);
+        let inch = normalise(1.0, "IN").unwrap();
+        let cm254 = normalise(2.54, "CentiM").unwrap();
+        assert!((inch.canonical_value - cm254.canonical_value).abs() < 1e-12, "1 in == 2.54 cm");
+
+        // 1 kg == 1000 g; 1 hour == 3600 s.
+        let kg = normalise(1.0, "KiloGM").unwrap();
+        let g = normalise(1000.0, "GM").unwrap();
+        assert!((kg.canonical_value - g.canonical_value).abs() < 1e-12);
+        let hr = normalise(1.0, "HR").unwrap();
+        let s = normalise(3600.0, "SEC").unwrap();
+        assert_eq!(hr.canonical_value, s.canonical_value);
+    }
+
+    #[test]
+    fn affine_temperature_units_normalise() {
+        // 0 °C == 273.15 K; 100 °C == 373.15 K (affine, offset 273.15).
+        let c0 = normalise(0.0, "DEG_C").unwrap();
+        assert_eq!(c0.kind, QuantityKind::Temperature);
+        assert!((c0.canonical_value - 273.15).abs() < 1e-9);
+        let c100 = normalise(100.0, "DEG_C").unwrap();
+        assert!((c100.canonical_value - 373.15).abs() < 1e-9);
+        // 32 °F == 273.15 K == 0 °C (the freezing point) — affine slope 5/9.
+        let f32deg = normalise(32.0, "DEG_F").unwrap();
+        assert!((f32deg.canonical_value - 273.15).abs() < 1e-6, "32 F == 273.15 K: {f32deg:?}");
+        // 212 °F == 373.15 K == 100 °C (the boiling point).
+        let f212 = normalise(212.0, "DEG_F").unwrap();
+        assert!((f212.canonical_value - 373.15).abs() < 1e-6, "212 F == 373.15 K: {f212:?}");
+    }
+
+    #[test]
+    fn angle_and_datasize_units() {
+        // 180 degrees == pi radians.
+        let deg180 = normalise(180.0, "DEG").unwrap();
+        assert!((deg180.canonical_value - core::f64::consts::PI).abs() < 1e-12);
+        // 1 KiB == 1024 B; 1 KB (decimal) == 1000 B (SI vs binary prefix kept distinct).
+        let kib = normalise(1.0, "KibiBYTE").unwrap();
+        assert_eq!(kib.canonical_value, 1024.0);
+        let kb = normalise(1.0, "KiloBYTE").unwrap();
+        assert_eq!(kb.canonical_value, 1000.0);
+        assert_ne!(kib.canonical_value, kb.canonical_value, "KiB != KB by design");
+    }
+
+    // ---- fail-closed: unknown unit, non-finite, and the SHACL-detectable mismatch ----
+
+    #[test]
+    fn unknown_unit_fails_closed() {
+        assert!(normalise(1.0, "http://qudt.org/vocab/unit/NotARealUnit").is_none());
+        assert!(normalise(1.0, "http://example.org/myUnit").is_none());
+        assert!(!is_known("FOO"));
+        assert!(quantity_kind("FOO").is_none());
+        // A magnitude with an unknown unit is SKIPPED, never silently dimensionless.
+        assert!(normalise_lexical("42", "FOO").is_none());
+    }
+
+    #[test]
+    fn nonfinite_value_rejected() {
+        assert!(normalise(f64::NAN, "M").is_none());
+        assert!(normalise(f64::INFINITY, "M").is_none());
+        assert!(normalise_lexical("inf", "M").is_none());
+        assert!(normalise_lexical("not-a-number", "M").is_none());
+    }
+
+    #[test]
+    fn unit_mismatch_is_detectable() {
+        // A length and a mass are NOT the same quantity — the caller treats this as the
+        // unit-mismatch error design §2 calls "SHACL-detectable" (a length is never compared to a
+        // mass in one numeric block).
+        assert!(!same_quantity("M", "KiloGM"), "length vs mass must be a detectable mismatch");
+        assert!(!same_quantity("M", "SEC"), "length vs time must be a detectable mismatch");
+        // Same kind, different scale → comparable (the legitimate case).
+        assert!(same_quantity("M", "KiloM"));
+        assert!(same_quantity("KiloGM", "GM"));
+        // Unknown unit on either side → mismatch (fail-closed).
+        assert!(!same_quantity("M", "FOO"));
+    }
+
+    #[test]
+    fn full_iri_and_bare_local_both_resolve() {
+        let full = normalise(1.0, "http://qudt.org/vocab/unit/KiloM").unwrap();
+        let bare = normalise(1.0, "KiloM").unwrap();
+        assert_eq!(full, bare, "full IRI and bare local name must resolve identically");
+    }
+
+    #[test]
+    fn canonical_unit_is_self_normalising() {
+        // Normalising a value already in the canonical unit is the identity (factor 1, offset 0).
+        for kind in [
+            QuantityKind::Length,
+            QuantityKind::Mass,
+            QuantityKind::Time,
+            QuantityKind::Angle,
+            QuantityKind::DataSize,
+        ] {
+            let n = normalise(7.0, kind.canonical_unit()).unwrap();
+            assert_eq!(n.kind, kind);
+            assert_eq!(n.canonical_value, 7.0, "canonical unit of {kind:?} must be identity");
+        }
+    }
+}

--- a/crates/sparq-vectors/tests/structure_shacl.rs
+++ b/crates/sparq-vectors/tests/structure_shacl.rs
@@ -1,0 +1,123 @@
+//! End-to-end tests for the structure-aware-vectorisation **P2** surface (sq-0wo9e.3): the SHACL/OWL
+//! prior extractor + the QUDT unit-normaliser, exercised through the REAL cross-module path — a
+//! parsed `sparq-shacl` shapes model feeds the codebook + cardinality priors, and unit-normalised
+//! magnitudes feed the P1 order-preserving numeric encoder. [OPUS-4.8]
+#![cfg(feature = "structure-shacl")]
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_vectors::{
+    normalise, route, Cardinality, Codebook, Encoder, NumericEncoder, QuantityKind, ShaclPriors,
+    INVALID_SLOT,
+};
+use sparq_shacl::model::ShapesModel;
+
+fn iri(s: &str) -> Term {
+    Term::NamedNode(NamedNode::new_unchecked(s))
+}
+
+const SHAPES: &str = r#"
+@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex:   <http://ex/> .
+
+ex:SensorShape a sh:NodeShape ;
+  sh:targetClass ex:Sensor ;
+  sh:property [ sh:path ex:status ; sh:in ( ex:Active ex:Idle ex:Fault ) ; sh:maxCount 1 ] ;
+  sh:property [ sh:path ex:reading ; sh:datatype xsd:decimal ] ;
+  sh:property [ sh:path ex:tag ; sh:datatype xsd:string ] .
+"#;
+
+/// The whole P2 SHACL path: parse shapes → mine priors → build a codebook from the mined enum →
+/// a member encodes to its slot, a NON-member to the reserved invalid code a closed-world SHACL
+/// `sh:in` shape rejects. This exercises the real `ShapesModel::parse` → `ShaclPriors` → `Codebook`
+/// chain, not a hand-built codebook.
+#[test]
+fn shacl_enum_prior_drives_slot_match_codebook() {
+    let shapes_graph = Graph::load_str(SHAPES, "turtle").unwrap();
+    let model = ShapesModel::parse(&shapes_graph);
+    let priors = ShaclPriors::from_model(&model);
+
+    let status = priors.get("http://ex/status").expect("status prior mined from sh:in");
+    let cb: &Codebook = status.enum_codebook.as_ref().expect("sh:in → codebook");
+    assert_eq!(cb.member_count(), 3);
+
+    // A declared member encodes to its own slot (exact, not a cosine threshold).
+    let active_block = cb.encode(&iri("http://ex/Active"));
+    assert_eq!(cb.decode(&active_block).as_ref(), Some(&iri("http://ex/Active")));
+
+    // A value NOT in the enum lands on the reserved invalid slot — the code a SHACL `sh:in` shape
+    // rejects (out-of-enum, never silently a member). This is the design's answer-safety property.
+    let outsider = iri("http://ex/Booting");
+    assert!(!cb.is_member(&outsider));
+    let bad = cb.encode(&outsider);
+    assert_eq!(bad[INVALID_SLOT], 1.0);
+    assert!(cb.decode(&bad).is_none());
+}
+
+/// The cardinality pooling rule + datatype-confirm flow through the real shapes model: `sh:maxCount
+/// 1` → Functional (one slot); a declared `sh:datatype` confirms the router-chosen encoder lane.
+#[test]
+fn shacl_cardinality_and_datatype_confirm() {
+    let shapes_graph = Graph::load_str(SHAPES, "turtle").unwrap();
+    let model = ShapesModel::parse(&shapes_graph);
+    let priors = ShaclPriors::from_model(&model);
+
+    // status: maxCount 1 → functional (single deterministic slot).
+    assert_eq!(priors.get("http://ex/status").unwrap().cardinality, Cardinality::Functional);
+    // reading: xsd:decimal, no maxCount → Multi, and the datatype confirms the numeric lane.
+    let reading = priors.get("http://ex/reading").unwrap();
+    assert_eq!(reading.cardinality, Cardinality::Multi);
+    assert_eq!(reading.datatype_encoder, Some(Encoder::Numeric));
+    // The declared datatype agrees with what the standalone router would pick (router-confirm).
+    assert_eq!(
+        reading.datatype_encoder,
+        Some(route("http://www.w3.org/2001/XMLSchema#decimal"))
+    );
+    // tag: xsd:string → the text (Other) lane.
+    assert_eq!(priors.get("http://ex/tag").unwrap().datatype_encoder, Some(Encoder::Other));
+}
+
+/// The load-bearing P2 numeric invariant: unit-normalise BEFORE the order-preserving numeric encoder
+/// so two literals denoting the SAME physical length encode to the IDENTICAL code. `1000 m` and
+/// `1 km` must produce byte-identical P1 numeric blocks; a genuinely different length (`2 km`) must
+/// not. This is the real `units::normalise` → `encode::NumericEncoder` chain.
+#[test]
+fn unit_normalised_magnitudes_share_a_code() {
+    // Observed canonical (metre) values for the predicate — fit the P1 numeric encoder over them.
+    let observed_m = [
+        normalise(500.0, "M").unwrap().canonical_value,    // 500 m
+        normalise(1000.0, "M").unwrap().canonical_value,   // 1000 m == 1 km
+        normalise(2.0, "KiloM").unwrap().canonical_value,  // 2 km == 2000 m
+    ];
+    for n in &observed_m {
+        assert!(n.is_finite());
+    }
+    let enc = NumericEncoder::fit(observed_m, 16);
+
+    // 1000 m and 1 km are the same length → identical canonical value → identical encoded block.
+    let m1000 = normalise(1000.0, "M").unwrap();
+    let km1 = normalise(1.0, "KiloM").unwrap();
+    assert_eq!(m1000.kind, QuantityKind::Length);
+    assert_eq!(km1.kind, QuantityKind::Length);
+    assert_eq!(m1000.canonical_value, km1.canonical_value, "1000 m == 1 km canonically");
+    assert_eq!(
+        enc.encode(m1000.canonical_value),
+        enc.encode(km1.canonical_value),
+        "same physical length must encode to the identical numeric block"
+    );
+
+    // A different length (2 km == 2000 m) must encode DIFFERENTLY — normalisation did not flatten
+    // genuine differences, only spurious unit ones.
+    let km2 = normalise(2.0, "KiloM").unwrap();
+    assert_ne!(
+        enc.encode(m1000.canonical_value),
+        enc.encode(km2.canonical_value),
+        "2 km is a genuinely different length and must encode differently"
+    );
+
+    // A mass annotated where a length is expected is a SHACL-detectable mismatch: its kind differs,
+    // so a caller must not feed it into THIS (length) numeric block.
+    let mass = normalise(1000.0, "KiloGM").unwrap();
+    assert_ne!(mass.kind, m1000.kind, "a mass must not silently share the length block");
+}

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -841,6 +841,58 @@ OFF, with a long-tail slice); its numbers are **work-box NON-CANONICAL**. The en
 trainer would consume — the thin KGE trainer that consumes them now exists behind the `kge` feature
 (recipe 14). <!-- [OPUS-4.8] sq-0wo9e.8 -->
 
+### 16. SHACL/OWL priors + QUDT unit-normalisation — enum codebook / cardinality pooling / SI magnitudes (opt-in, `structure` + `structure-shacl`)
+
+<!-- [OPUS-4.8] sq-0wo9e.3 (epic sq-0wo9e; design research/structure-aware-vectorisation.md §2 + §7). -->
+Research-grade **P2**: read the schema sparq already holds — `sh:in` enums, `sh:datatype`,
+`sh:min/maxCount`, `owl:FunctionalProperty`, and QUDT units — as **priors over the encoder layout**,
+not post-hoc filters. Two slices:
+
+- **QUDT unit-normalisation (`structure`, pure — no SHACL dep)** — `units::normalise(value, unit_iri)`
+  converts a unit-annotated magnitude to its **canonical SI value + `QuantityKind`** via a bundled
+  affine table, **before** the order-preserving `NumericEncoder`, so `1000 m` and `1 km` map to the
+  **identical** code (design §2 "unit-normalise-before-magnitude"). `same_quantity(a, b)` makes a
+  length-vs-mass mismatch a **detectable error** (a length never shares a numeric block with a mass).
+  Unknown unit / non-finite value → `None` (**fail-closed**, never silently dimensionless).
+- **Enum `Codebook` (`structure`, pure)** — a one-hot block over a closed enum: slot `0` is the
+  reserved **out-of-enum / invalid** code, slots `1..=n` the members. **Enum equality is a slot match,
+  not a cosine threshold** (design §2 "no recall loss"); a non-member encodes to the invalid slot a
+  closed-world `sh:in` shape rejects. `encode`/`decode` round-trip every member.
+- **`ShaclPriors` reader (`structure-shacl`, pulls `sparq-shacl`)** — `ShaclPriors::from_model` /
+  `from_model_and_data` mine, **per predicate** from a parsed `ShapesModel` (read-only — no SHACL
+  changes): the enum `Codebook` (`sh:in`), the router-confirmed `Encoder` (`sh:datatype`), and the
+  **pooling rule** `Cardinality::{Functional,Multi}` (`sh:maxCount 1` or `owl:FunctionalProperty` from
+  the data graph → one deterministic slot; else a permutation-invariant pooled block).
+
+```rust,ignore
+# // cargo build -p sparq-vectors --features structure-shacl
+use sparq_vectors::{normalise, QuantityKind, NumericEncoder, ShaclPriors, Cardinality};
+use sparq_shacl::model::ShapesModel;
+
+// unit-normalise before the magnitude encoder: 1000 m == 1 km share a code.
+let m = normalise(1000.0, "http://qudt.org/vocab/unit/M").unwrap();
+let km = normalise(1.0, "http://qudt.org/vocab/unit/KiloM").unwrap();
+assert_eq!(m.canonical_value, km.canonical_value);          // same physical length
+let enc = NumericEncoder::fit([m.canonical_value], 16);
+assert_eq!(enc.encode(m.canonical_value), enc.encode(km.canonical_value));
+
+// SHACL priors: sh:in → codebook (slot match), sh:maxCount 1 → functional pooling.
+let model = ShapesModel::parse(&shapes_graph);
+let priors = ShaclPriors::from_model(&model);
+if let Some(p) = priors.get("http://ex/status") {
+    let cb = p.enum_codebook.as_ref().unwrap();             // out-of-enum → reserved invalid slot
+    assert!(matches!(p.cardinality, Cardinality::Functional | Cardinality::Multi));
+    let _ = cb.member_count();
+}
+```
+
+**Honesty.** Enum/boolean exactness (slot match), the affine unit conversion, and the
+SHACL-detectable mismatch are **proven** (`codebook.rs` / `units.rs` / `shacl_priors.rs` tests +
+`tests/structure_shacl.rs`). The QUDT table is a **curated, deliberately small** subset (common SI +
+a few customary units); an absent unit fails closed — extending it is additive. Whether these priors
+raise downstream retrieval is **empirical, ablation-gated** — no accuracy claim. A predicate with no
+declared shape simply gets **no** prior (fail-open, the encoder falls back to the datatype router).
+
 ## Gotchas / feature flags / prerequisites
 
 - **Opt-in.** Nothing in the workspace depends on `sparq-vectors`; the default engine
@@ -857,14 +909,22 @@ trainer would consume — the thin KGE trainer that consumes them now exists beh
   methods write a delta the read paths consult transparently (recipe 12). The delta lives in RAM on the
   handle; `save_delta` persists it to a crash-durable `.spqd` sidecar and `open_with_delta` replays it,
   so mutations survive a restart without a `compact` (the two durability paths).
-- **Structure-aware preprocessing is the non-default `structure` feature (sq-0wo9e.1 P0, sq-0wo9e.2 P1).**
+- **Structure-aware preprocessing is the non-default `structure` feature (sq-0wo9e.1 P0, sq-0wo9e.2 P1, sq-0wo9e.3 P2).**
   It is the ONLY feature pulling `sparq-reason` + `sparq-introspect` into this crate, both **optional**, so
   with it OFF the default build compiles zero structure-prep code and gains no new required deps. With
   it ON it exposes the **P0** closure + sampler (`close_for_vectorise` / `materialise_closure` /
-  `ClosedGraph`, `TypeConstraints`, `NegativeSampler` + `SamplingMode`, recipe 13) AND the **P1**
+  `ClosedGraph`, `TypeConstraints`, `NegativeSampler` + `SamplingMode`, recipe 13), the **P1**
   typed-literal encoders (`route`, `NumericEncoder`, `BooleanEncoder`, `DateEncoder`, `SchemaHeader`,
-  recipe 15). `structure` itself serves no exact answer; encoder invariants are proven but
-  embedding-quality benefit is **unproven** (research-grade, no accuracy claim, no canonical numbers).
+  recipe 15), AND the **P2** enum `Codebook` + QUDT unit-`normalise` (recipe 16). `structure` itself
+  serves no exact answer; encoder invariants are proven but embedding-quality benefit is **unproven**
+  (research-grade, no accuracy claim, no canonical numbers).
+- **The SHACL/OWL prior reader is the non-default `structure-shacl` feature (sq-0wo9e.3 P2).** It
+  **implies `structure`** and is the ONLY feature pulling `sparq-shacl` (and transitively, on native,
+  the engine) into this crate's graph — so neither the default build nor the lean `structure` feature
+  gains a SHACL/engine dependency. With it ON it exposes `ShaclPriors` / `PredicatePrior` /
+  `Cardinality` (recipe 16): a **read-only** reader that mines enum/datatype/cardinality priors out of
+  a parsed `ShapesModel` (no SHACL behaviour change). The enum codebook + QUDT normaliser themselves
+  ship under plain `structure` (pure, no SHACL dep) — only the *reader* needs `structure-shacl`.
 - **The KGE measurement foundation is the non-default `kge` feature (sq-0wo9e.8 / P6).** It **implies
   `structure`** and adds **no new dependency** (a hand-rolled CPU-only trainer — no ML crate). With it
   OFF the default build compiles zero trainer/eval code; with it ON it exposes `train` / `TrainConfig`


### PR DESCRIPTION
> 🤖 SPARQ agent — automated implementation of bead **sq-0wo9e.3** (P2 of epic sq-0wo9e, structure-aware vectorisation). Self-identifying per the sub-agent shared contract; @jeswr runs several agents on one account.

## What this implements

**P2** of the structure-aware-vectorisation epic (design `research/structure-aware-vectorisation.md` §2 + §7) — additive on top of P1's typed-literal encoders (`encode.rs`). Reads the schema sparq already holds (`sh:in` enums, `sh:datatype`, `sh:min/maxCount`, `owl:FunctionalProperty`, QUDT units) as **priors over the encoder layout**, not post-hoc filters. Everything is opt-in; the default `sparq-vectors` build and the core engine are byte-identical.

### New surface — behind the existing `structure` feature (pure, no new dependency)
- **`units.rs` — QUDT unit-normalisation.** `normalise(value, unit_iri)` converts a unit-annotated magnitude to its **canonical SI value + `QuantityKind`** via a bundled affine `(factor, offset)` table **before** the order-preserving `NumericEncoder`, so `1000 m` and `1 km` share a code (design §2 "unit-normalise-before-magnitude"). `same_quantity(a, b)` makes a length-vs-mass mismatch a **detectable error**; an unknown unit or non-finite value fails closed (`None`, never silently dimensionless).
- **`codebook.rs` — enum `Codebook`.** A one-hot block over a closed `sh:in`/`owl:oneOf` set: slot 0 is the reserved out-of-enum/invalid code, slots `1..=n` the members. **Enum equality is a slot match, not a cosine threshold** (design §2 "no recall loss"); a non-member encodes to the invalid code a closed-world `sh:in` shape rejects. `encode`/`decode` round-trip every member.
- **`encode.rs`** — adds `Encoder::Enum` (additive `SchemaHeader` byte tag 5 — old headers still parse).

### New surface — behind a NEW `structure-shacl` feature (`= structure + dep:sparq-shacl`)
- **`shacl_priors.rs` — `ShaclPriors` reader.** Mines per-predicate **enum** (`sh:in` → `Codebook`), **datatype** (`sh:datatype` → router-confirmed `Encoder`), and **cardinality** (`sh:maxCount 1` or `owl:FunctionalProperty` → `Cardinality::Functional` one slot; else `Multi` pooled block) out of a parsed `sparq-shacl` `ShapesModel` — **read-only, no SHACL behaviour change**. `owl:FunctionalProperty` is read from the data graph (OWL axiom), not the shapes model. Fail-open: a predicate with no declared shape gets **no** prior.

`structure-shacl` is the **only** feature that pulls `sparq-shacl` (and, on native, the engine) into this crate's graph — so neither the default build nor the lean `structure` feature gains a SHACL/engine dependency (lean-core constraint held).

## Feature flags
- `structure` (existing) — gates `units.rs` + `codebook.rs` (pure; no new dep).
- `structure-shacl` (new) — `= ["structure", "dep:sparq-shacl"]` — gates `shacl_priors.rs`.

## Provable invariants (tested, not benchmarked)
Enum slot-match exactness + out-of-enum reserved invalid code; affine unit conversion (incl. °C/°F affine offset); SHACL-detectable length-vs-mass mismatch; `1000 m` ≡ `1 km` encode identically through `units::normalise → NumericEncoder`. `tests/structure_shacl.rs` exercises the **real** cross-module path (`ShapesModel::parse → ShaclPriors → Codebook`, and the unit→numeric identity), not a mock.

## Honesty
Encoder/enum/unit invariants are formally checkable. **Embedding-quality benefit is empirical, dataset-dependent, and ablation-gated — no accuracy claim, no benchmark numbers.** The QUDT table is a curated, deliberately small subset (common SI + a few customary units); an absent unit fails closed (extending it is additive). No ZK/MPC claim.

## Gates run (sparq-vectors)
- `cargo build` / `clippy --all-targets -D warnings` / `test` — GREEN in **default**, **`structure`**, and **`structure-shacl`** (default lib 45 tests; `structure-shacl` lib 90 + 3 integration + 8 doctests).
- `cargo doc --workspace --no-deps --all-features` + `RUSTDOCFLAGS=-D warnings` — clean (fixed two intra-doc links before opening, the bundled rustdoc gate).
- `check-readme-template.py --enforce` — 0 deviations (README ≤120 lines); `check-privacy-claims.sh` — clean; `typos` — clean.

## Bead
Closes **sq-0wo9e.3**. Auto-merge intentionally **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
