### PR TITLE
chore(orchestration): frontier agent excludes beads with an open PR (sq-7mwun) [OPUS-4.8]

### DIFF
--- a/.claude/workflows/autonomous-scheduler.js
+++ b/.claude/workflows/autonomous-scheduler.js
@@ -119,6 +119,14 @@ while (opened.length < MAX_BEADS && dry < 2) {
     'Read the launchable-bead frontier: `export PATH=$PATH:/home/ubuntu/.local/bin && cd /home/ubuntu/sparq && bash scripts/push-frontier.sh` (READ-ONLY; do NOT git-checkout). ' +
     'Each line is `bead-id  surface  title`. Return up to 6 DISPATCHABLE ready beads as {beads:[{id,surface,title}]}. ' +
     'EXCLUDE: epics; anything needs-user / requiring a maintainer decision; in-progress; and these already-handled ids: ' + JSON.stringify([...seen]) + '. ' +
+    // [OPUS-4.8] sq-7mwun: belt-and-suspenders open-PR exclusion. push-frontier.sh already
+    // subtracts in-flight beads, but it matches a bead id as a SUBSTRING of an open-PR
+    // branch/title, which over/under-matches dotted CHILD ids (sq-ixc3.11 vs sq-ixc3.12) and
+    // misses worktree-named branches (worktree-wf_...) whose PR title omits the exact id token.
+    // Those leaks let already-in-flight beads (and already-merged-but-bd-still-open ones) get
+    // re-picked + re-skipped every wave, wasting agent slots. So the frontier agent ALSO does an
+    // explicit, EXACT per-candidate open-PR check before returning each bead.
+    'For EACH candidate bead the frontier script emitted, run `gh pr list --search "<bead-id>" --state open --json number,title,headRefName` and DROP the bead if any returned PR matches it (its EXACT id token appears in a PR title or head-branch name) — that work is already in flight, so re-dispatching it would re-implement in-flight work. Only return beads with NO matching open PR. ' +
     (ONLY ? 'RESTRICT to only these bead ids if present on the frontier: ' + JSON.stringify(ONLY) + '. ' : '') +
     'Prefer well-scoped feature/task/bug beads an implementation agent can finish autonomously. If the frontier has no dispatchable beads, return {beads:[]}.',
     { label: 'frontier', phase: 'Frontier', schema: FRONTIER_SCHEMA, agentType: 'general-purpose' }


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous-scheduler surface. Filed and implemented by an automated SPARQ coding agent (Opus 4.8). @jeswr runs multiple agents on one account.

## What

Makes the autonomous-scheduler's **frontier agent** exclude any bead that already has an **open PR**, so in-flight work is never re-dispatched.

Closes bead **sq-7mwun**.

## Why

Observed in scheduler waves: beads with an open PR (e.g. `sq-ixc3.11`/`.12`) and already-merged-but-bd-still-open beads (`sq-jluc`) got **re-picked each wave and then re-skipped** at implementation time, wasting agent slots.

`scripts/push-frontier.sh` already subtracts in-flight beads — but it matches a bead id as a **substring** of an open-PR branch/title. That:

- **over/under-matches dotted CHILD ids** — a substring test for `sq-ixc3.1` matches both `sq-ixc3.11` and `sq-ixc3.12`; `sq-ixc3.11` does not substring-match a PR titled with `sq-ixc3.12`, so a sibling child can leak through; and
- **misses worktree-named branches** (`worktree-wf_...`) whose PR title omits the exact id token.

## Change

A single, surgical addition to the **frontier-agent prompt** in `.claude/workflows/autonomous-scheduler.js` (the location and approach the bead prescribes): for **each** candidate bead the frontier script emitted, the agent runs

```
gh pr list --search "<bead-id>" --state open --json number,title,headRefName
```

and **drops** the bead if any returned PR matches it by **exact** id token (in the PR title or head-branch). Only beads with no matching open PR are returned for dispatch. This is a belt-and-suspenders defense layered on top of the script's existing in-flight subtraction.

Scope kept tight to the bead: it does **not** touch `push-frontier.sh`'s tested in-flight core (owned by sq-8rpq / sq-6ip4 / sq-751l), and it does **not** alter the surrounding skip-vs-proceed-on-decision text (that durable edit is tracked by **sq-6psmk**), to avoid a conflict with that in-flight change.

## Gates

- `node --check .claude/workflows/autonomous-scheduler.js` — OK (prompt-string-only change; no Rust crate, README, perf numbers, or privacy/soundness claims touched).
- `scripts/check-privacy-claims.sh` — OK (no unqualified ZK/MPC claim).

Relates sq-sgu1 (autonomous-scheduler epic); folds into the sq-6psmk durable-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
