### PR TITLE
fix(ci): retry conformance suite-fetch clones so a transient reset doesn't red-gate (sq-nj0pd) [OPUS-4.8]

### DIFF
--- a/scripts/fetch-conformance.sh
+++ b/scripts/fetch-conformance.sh
@@ -4,30 +4,20 @@
 # committed to this repo — run this script before `cargo run -p sparq-conformance`.
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# [OPUS-4.8] sq-nj0pd: retry the shallow clone/fetch — a transient GitHub reset on
+# this (the FIRST network op the SPARQL + inference conformance lanes run) used to
+# red-gate the required check in ~18s with no real conformance error, stalling
+# --auto merges on unrelated PRs. The pin check below is unchanged, so a retry can
+# never substitute drifted test data.
+# shellcheck source=scripts/lib/fetch-retry.sh
+. "$ROOT/scripts/lib/fetch-retry.sh"
+
 # Pinned w3c/rdf-tests commit (main, 2026-06). Bump deliberately: pass-rates are
 # only comparable across runs when the suite revision is fixed.
 PIN="f25dbc092c654d792974848e81bb519d7328f0e8"
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/tests/w3c/rdf-tests"
 
-if [ -d "$DEST/.git" ]; then
-    HAVE="$(git -C "$DEST" rev-parse HEAD)"
-    if [ "$HAVE" = "$PIN" ]; then
-        echo "rdf-tests already at pinned commit $PIN — nothing to do."
-        exit 0
-    fi
-    echo "rdf-tests present at $HAVE, re-pinning to $PIN…"
-    git -C "$DEST" fetch --depth 1 origin "$PIN"
-    git -C "$DEST" checkout --detach "$PIN"
-    exit 0
-fi
-
-mkdir -p "$(dirname "$DEST")"
-echo "Cloning w3c/rdf-tests (shallow) into tests/w3c/rdf-tests…"
-git clone --depth 1 https://github.com/w3c/rdf-tests "$DEST"
-if [ "$(git -C "$DEST" rev-parse HEAD)" != "$PIN" ]; then
-    git -C "$DEST" fetch --depth 1 origin "$PIN"
-    git -C "$DEST" checkout --detach "$PIN"
-fi
+retry_git_clone_pinned "https://github.com/w3c/rdf-tests" "$DEST" "$PIN"
 echo "rdf-tests pinned at $PIN."

--- a/scripts/fetch-inference-suites.sh
+++ b/scripts/fetch-inference-suites.sh
@@ -19,21 +19,14 @@ set -euo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 
-# [OPUS-4.8] Retry a flaky network command (git clone/fetch) a few times with a
-# short backoff. GitHub and the Internet Archive both reset CI transfers
-# occasionally; one blip should not red-gate every engine PR (sq-y5dz).
-retry() {
-    local n=0 max=5
-    until "$@"; do
-        n=$((n + 1))
-        if [ "$n" -ge "$max" ]; then
-            echo "ERROR: '$*' failed after $max attempts." >&2
-            return 1
-        fi
-        echo "  attempt $n/$max failed; retrying in 5s…" >&2
-        sleep 5
-    done
-}
+# [OPUS-4.8] sq-nj0pd: `retry` + the pinned-clone idiom now live in the shared
+# lib so every conformance suite-fetch retries identically (sq-y5dz seeded this
+# resilience here; centralising it also covers the delegated fetch-conformance.sh
+# in step 1 below — the w3c/rdf-tests clone that was the remaining un-retried
+# network op in the inference lane). GitHub and the Internet Archive both reset CI
+# transfers occasionally; one blip should not red-gate every engine PR.
+# shellcheck source=scripts/lib/fetch-retry.sh
+. "$ROOT/scripts/lib/fetch-retry.sh"
 
 # --- 1. w3c/rdf-tests (shared pin with the SPARQL conformance harness) -------
 "$ROOT/scripts/fetch-conformance.sh"
@@ -43,24 +36,7 @@ retry() {
 N3_PIN="23ccf3d56b25cb60a68878a04aae0d52493080f0"
 N3_DEST="$ROOT/tests/w3c/n3"
 
-if [ -d "$N3_DEST/.git" ]; then
-    HAVE="$(git -C "$N3_DEST" rev-parse HEAD)"
-    if [ "$HAVE" != "$N3_PIN" ]; then
-        echo "w3c/N3 present at $HAVE, re-pinning to $N3_PIN…"
-        retry git -C "$N3_DEST" fetch --depth 1 origin "$N3_PIN"
-        git -C "$N3_DEST" checkout --detach "$N3_PIN"
-    else
-        echo "w3c/N3 already at pinned commit $N3_PIN — nothing to do."
-    fi
-else
-    mkdir -p "$(dirname "$N3_DEST")"
-    echo "Cloning w3c/N3 (shallow) into tests/w3c/n3…"
-    retry git clone --depth 1 https://github.com/w3c/N3 "$N3_DEST"
-    if [ "$(git -C "$N3_DEST" rev-parse HEAD)" != "$N3_PIN" ]; then
-        retry git -C "$N3_DEST" fetch --depth 1 origin "$N3_PIN"
-        git -C "$N3_DEST" checkout --detach "$N3_PIN"
-    fi
-fi
+retry_git_clone_pinned "https://github.com/w3c/N3" "$N3_DEST" "$N3_PIN"
 echo "w3c/N3 pinned at $N3_PIN."
 
 # --- 3. OWL 2 test cases (W3C OWL WG export, archived) -------------------------

--- a/scripts/fetch-jsonld-framing-tests.sh
+++ b/scripts/fetch-jsonld-framing-tests.sh
@@ -9,32 +9,19 @@
 # suite is absent, so a fresh checkout stays green offline.
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# [OPUS-4.8] sq-nj0pd: retry the shallow clone/fetch (shared helper) so a transient
+# GitHub reset doesn't red-gate the JSON-LD frame conformance lane. Pin unchanged.
+# shellcheck source=scripts/lib/fetch-retry.sh
+. "$ROOT/scripts/lib/fetch-retry.sh"
+
 # Pinned w3c/json-ld-framing commit (main, 2026-06). Bump deliberately: the
 # JSON-LD framing pass-count floor (FRAME_FLOOR) in
 # crates/sparq-conformance/tests/jsonld_suite.rs is calibrated against THIS suite
 # revision — pass counts are only comparable across runs when the suite is fixed.
 PIN="3bf782ba9a40dd1b143435abe386d38df64f2b47"
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/tests/w3c/json-ld-framing"
 
-if [ -d "$DEST/.git" ]; then
-    HAVE="$(git -C "$DEST" rev-parse HEAD)"
-    if [ "$HAVE" = "$PIN" ]; then
-        echo "json-ld-framing already at pinned commit $PIN — nothing to do."
-        exit 0
-    fi
-    echo "json-ld-framing present at $HAVE, re-pinning to $PIN…"
-    git -C "$DEST" fetch --depth 1 origin "$PIN"
-    git -C "$DEST" checkout --detach "$PIN"
-    exit 0
-fi
-
-mkdir -p "$(dirname "$DEST")"
-echo "Cloning w3c/json-ld-framing (shallow) into tests/w3c/json-ld-framing…"
-git clone --depth 1 https://github.com/w3c/json-ld-framing "$DEST"
-if [ "$(git -C "$DEST" rev-parse HEAD)" != "$PIN" ]; then
-    git -C "$DEST" fetch --depth 1 origin "$PIN"
-    git -C "$DEST" checkout --detach "$PIN"
-fi
+retry_git_clone_pinned "https://github.com/w3c/json-ld-framing" "$DEST" "$PIN"
 echo "json-ld-framing pinned at $PIN."

--- a/scripts/fetch-jsonld-tests.sh
+++ b/scripts/fetch-jsonld-tests.sh
@@ -7,32 +7,19 @@
 # is absent, so a fresh checkout stays green offline.
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# [OPUS-4.8] sq-nj0pd: retry the shallow clone/fetch (shared helper) so a transient
+# GitHub reset doesn't red-gate the JSON-LD conformance lane. Pin check unchanged.
+# shellcheck source=scripts/lib/fetch-retry.sh
+. "$ROOT/scripts/lib/fetch-retry.sh"
+
 # Pinned w3c/json-ld-api commit (main, 2026-06). Bump deliberately: the
 # JSON-LD conformance pass-count floors (toRdf / fromRdf) in
 # crates/sparq-conformance/tests/jsonld_floors.rs are calibrated against THIS
 # suite revision — they are only comparable across runs when the suite is fixed.
 PIN="8654ac22b6cf4f441d2fee915ae634d36b5a8067"
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/tests/w3c/json-ld-api"
 
-if [ -d "$DEST/.git" ]; then
-    HAVE="$(git -C "$DEST" rev-parse HEAD)"
-    if [ "$HAVE" = "$PIN" ]; then
-        echo "json-ld-api already at pinned commit $PIN — nothing to do."
-        exit 0
-    fi
-    echo "json-ld-api present at $HAVE, re-pinning to $PIN…"
-    git -C "$DEST" fetch --depth 1 origin "$PIN"
-    git -C "$DEST" checkout --detach "$PIN"
-    exit 0
-fi
-
-mkdir -p "$(dirname "$DEST")"
-echo "Cloning w3c/json-ld-api (shallow) into tests/w3c/json-ld-api…"
-git clone --depth 1 https://github.com/w3c/json-ld-api "$DEST"
-if [ "$(git -C "$DEST" rev-parse HEAD)" != "$PIN" ]; then
-    git -C "$DEST" fetch --depth 1 origin "$PIN"
-    git -C "$DEST" checkout --detach "$PIN"
-fi
+retry_git_clone_pinned "https://github.com/w3c/json-ld-api" "$DEST" "$PIN"
 echo "json-ld-api pinned at $PIN."

--- a/scripts/fetch-odrl-suite.sh
+++ b/scripts/fetch-odrl-suite.sh
@@ -9,31 +9,18 @@
 # crate-local runner evaluates through sparq-policy's real evaluate() path.
 set -euo pipefail
 
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# [OPUS-4.8] sq-nj0pd: retry the shallow clone/fetch (shared helper) so a transient
+# GitHub reset doesn't red-gate the ODRL conformance lane. Pin check unchanged.
+# shellcheck source=scripts/lib/fetch-retry.sh
+. "$ROOT/scripts/lib/fetch-retry.sh"
+
 # Pinned SolidLabResearch/ODRL-Test-Suite commit (main, 2025-10-15). Bump
 # deliberately: pass-rates are only comparable across runs when the suite
 # revision is fixed (same discipline as the W3C suite pin).
 PIN="7958238e72511059478e43ec9e57b053504cfd2c"
 
-ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 DEST="$ROOT/tests/odrl-test-suite"
 
-if [ -d "$DEST/.git" ]; then
-    HAVE="$(git -C "$DEST" rev-parse HEAD)"
-    if [ "$HAVE" = "$PIN" ]; then
-        echo "ODRL-Test-Suite already at pinned commit $PIN — nothing to do."
-        exit 0
-    fi
-    echo "ODRL-Test-Suite present at $HAVE, re-pinning to $PIN…"
-    git -C "$DEST" fetch --depth 1 origin "$PIN"
-    git -C "$DEST" checkout --detach "$PIN"
-    exit 0
-fi
-
-mkdir -p "$(dirname "$DEST")"
-echo "Cloning SolidLabResearch/ODRL-Test-Suite (shallow) into tests/odrl-test-suite…"
-git clone --depth 1 https://github.com/SolidLabResearch/ODRL-Test-Suite "$DEST"
-if [ "$(git -C "$DEST" rev-parse HEAD)" != "$PIN" ]; then
-    git -C "$DEST" fetch --depth 1 origin "$PIN"
-    git -C "$DEST" checkout --detach "$PIN"
-fi
+retry_git_clone_pinned "https://github.com/SolidLabResearch/ODRL-Test-Suite" "$DEST" "$PIN"
 echo "ODRL-Test-Suite pinned at $PIN."

--- a/scripts/lib/fetch-retry.sh
+++ b/scripts/lib/fetch-retry.sh
@@ -1,0 +1,73 @@
+# shellcheck shell=bash
+# [OPUS-4.8] sq-nj0pd — shared network-retry helpers for the W3C / community
+# conformance suite-fetch scripts. Source (do NOT execute) this file:
+#
+#   . "$(dirname "$0")/lib/fetch-retry.sh"
+#
+# Background: the conformance jobs (W3C SPARQL, inference, JSON-LD, ODRL) each
+# `git clone`/`git fetch` a PINNED test suite at the START of the lane. A single
+# transient reset on that clone — GitHub occasionally drops large transfers from
+# CI runner IP ranges — exits the script non-zero under `set -euo pipefail`,
+# which red-gates the lane in ~18s with no real conformance error. Because every
+# one of these is a REQUIRED check feeding the ci-summary aggregator, one network
+# blip stalls --auto merges on PRs that never touched the reasoner. sq-y5dz (#864)
+# hardened the N3 clone + OWL curl inside fetch-inference-suites.sh but the
+# DELEGATED first step (fetch-conformance.sh, the w3c/rdf-tests clone) plus the
+# JSON-LD / ODRL fetchers were still bare git ops — this centralises the retry so
+# every suite fetch is resilient and consistent.
+#
+# Pin discipline is UNCHANGED: every caller still verifies the cloned/fetched
+# HEAD equals the pinned commit (or, for the OWL payload, its sha256) AFTER the
+# retried transfer, so a retry can never silently substitute drifted test data.
+
+# retry CMD [ARGS...]
+#   Runs CMD until it succeeds or FETCH_RETRY_MAX (default 5) attempts elapse,
+#   sleeping FETCH_RETRY_DELAY (default 5) seconds between tries. Returns the
+#   command's last exit status on persistent failure. Safe to call under
+#   `set -e` (the `until` loop consumes the non-zero status of each attempt).
+retry() {
+    local n=0
+    local max="${FETCH_RETRY_MAX:-5}"
+    local delay="${FETCH_RETRY_DELAY:-5}"
+    local rc=0
+    until "$@"; do
+        rc=$?
+        n=$((n + 1))
+        if [ "$n" -ge "$max" ]; then
+            echo "ERROR: '$*' failed after $max attempts (last exit $rc)." >&2
+            return "$rc"
+        fi
+        echo "  attempt $n/$max failed (exit $rc); retrying in ${delay}s…" >&2
+        sleep "$delay"
+    done
+}
+
+# retry_git_clone_pinned URL DEST PIN
+#   Resilient "clone (shallow) at, or re-pin to, PIN" idiom shared by the
+#   git-based suite fetchers. If DEST already holds a checkout: no-op when it is
+#   already at PIN, else retried `fetch` + detached checkout. Otherwise: retried
+#   shallow clone, then a retried `fetch` + detached checkout when the default
+#   branch HEAD is not PIN. Echos progress; relies on the caller having set
+#   `set -euo pipefail`.
+retry_git_clone_pinned() {
+    local url="$1" dest="$2" pin="$3"
+    if [ -d "$dest/.git" ]; then
+        local have
+        have="$(git -C "$dest" rev-parse HEAD)"
+        if [ "$have" = "$pin" ]; then
+            echo "$(basename "$dest") already at pinned commit $pin — nothing to do."
+            return 0
+        fi
+        echo "$(basename "$dest") present at $have, re-pinning to $pin…"
+        retry git -C "$dest" fetch --depth 1 origin "$pin"
+        git -C "$dest" checkout --detach "$pin"
+        return 0
+    fi
+    mkdir -p "$(dirname "$dest")"
+    echo "Cloning $url (shallow) into $dest…"
+    retry git clone --depth 1 "$url" "$dest"
+    if [ "$(git -C "$dest" rev-parse HEAD)" != "$pin" ]; then
+        retry git -C "$dest" fetch --depth 1 origin "$pin"
+        git -C "$dest" checkout --detach "$pin"
+    fi
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated CI/supply-chain change on @jeswr's account (multiple agents share this login). Self-identifying per the SPARQ agent contract.

## What & why (sq-nj0pd)

The `Inference conformance (ratchet >= 1967 pass+divergence)` check — a **REQUIRED** gate feeding the `ci-summary / gate` aggregator — intermittently FAILS in ~18s with **no error in the log** on PRs that don't touch the reasoner (blocked #1006, #1015 `--auto`), while staying green on main. 18s is far too short for a release build + suite run, which points the finger at the **suite fetch**, not the ratchet.

Root cause: the conformance lanes each `git clone` / `git fetch` a **pinned** W3C / community test suite at the start of the job. A single transient GitHub reset on that clone exits the fetch script non-zero under `set -euo pipefail`, red-gating the lane. `sq-y5dz` (#864) hardened the N3 clone + the OWL `curl` *inside* `fetch-inference-suites.sh`, **but** its delegated step 1 — `fetch-conformance.sh`, the `w3c/rdf-tests` clone — plus the JSON-LD / ODRL fetchers were still **bare git ops**. That `fetch-conformance.sh` clone is the remaining un-retried network op in the inference lane (and the first one it runs), so it is the most likely source of the ~18s flake. The SPARQL, JSON-LD-API, JSON-LD-framing and ODRL conformance lanes share the same vulnerability.

## Fix

Centralise the retry into a new sourced library and apply it everywhere:

- **`scripts/lib/fetch-retry.sh`** (new) — `retry CMD…` (configurable `FETCH_RETRY_MAX`/`FETCH_RETRY_DELAY`, returns the command's real exit code on persistent failure) and `retry_git_clone_pinned URL DEST PIN` (the shared "shallow clone, or re-pin to PIN" idiom, with every git op retried).
- **`scripts/fetch-conformance.sh`**, **`fetch-inference-suites.sh`** (N3 clone; OWL `curl` already had `--retry-all-errors` from #864 and is unchanged), **`fetch-jsonld-tests.sh`**, **`fetch-jsonld-framing-tests.sh`**, **`fetch-odrl-suite.sh`** — all now source the helper.

**Pin discipline UNCHANGED:** every caller still verifies the cloned/fetched HEAD equals the pinned commit *after* the retried transfer, so a retry can never substitute drifted test data and the ratchet counts stay comparable. No gate is weakened — a genuine ratchet miss still fails; only transient transport blips are retried.

## Gate aggregator / path-filter

No workflow YAML changed. Job **names**, the `ci-summary / gate` aggregator, and the `needs.changes.outputs.rust_changed` path-filter are all untouched — non-Rust PRs still skip these heavy jobs.

## Local reproduction

- `bash -n` + `shellcheck -x` clean across all six scripts.
- `retry` unit-exercised: succeeds after N transient failures; on persistent failure returns the command's **real** exit code (not a flattened 1).
- `retry_git_clone_pinned` exercised end-to-end against a local repo: shallow-clones, fetches + detaches the pinned commit when HEAD differs, and no-ops when already at the pin.
- A **real** `./scripts/fetch-conformance.sh` run cloned `w3c/rdf-tests` and checked out the exact pinned commit `f25dbc0`, producing `tests/w3c/rdf-tests` (gitignored — not staged).

## Compliance / honesty note

This is a **CI reliability** fix (flaky-gate elimination), not a new supply-chain attestation. It does not change SLSA / SBOM / SSDF posture. It is the best-judgment hypothesis for the ~18s flake given the symptom (fast fail, no conformance error, green on main): the un-retried fetch is the only remaining transient-network op on the inference path. If a future occurrence shows the flake is elsewhere (e.g. cache restore or toolchain setup), that's a separate finding — I've left a steer for the maintainer in the tracking issue. The bead's secondary suggestion (the autonomous-scheduler should auto-rerun a flaky required check) is a scheduler concern, out of scope here and noted on the bead.

Closes sq-nj0pd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)