### PR TITLE
feat(infra): per-tick disk guard — df-check + prune merged worktrees + gated main-target reclaim (sq-4vo9m) [OPUS-4.8]

### DIFF
--- a/.claude/workflows/autonomous-scheduler.js
+++ b/.claude/workflows/autonomous-scheduler.js
@@ -33,6 +33,12 @@ const FRONTIER_SCHEMA = {
   type: 'object',
   additionalProperties: false,
   properties: {
+    // [OPUS-4.8] sq-4vo9m: per-tick disk guard. The frontier agent runs
+    // `scripts/disk-guard.sh --apply` BEFORE reading the frontier (its safe worktree prune
+    // is harmless when disk is fine and frees the most when it is not) and reports the
+    // resulting disk state so the scheduler can back off dispatch under disk pressure.
+    disk_state: { type: 'string', enum: ['OK', 'WARN', 'CRITICAL', 'UNKNOWN'] },
+    disk_free_gb: { type: 'number' },
     beads: {
       type: 'array',
       items: {
@@ -116,7 +122,17 @@ while (opened.length < MAX_BEADS && dry < 2) {
   }
   phase('Frontier')
   const fr = await agent(
-    'Read the launchable-bead frontier: `export PATH=$PATH:/home/ubuntu/.local/bin && cd /home/ubuntu/sparq && bash scripts/push-frontier.sh` (READ-ONLY; do NOT git-checkout). ' +
+    // [OPUS-4.8] sq-4vo9m: DISK GUARD each tick — run BEFORE reading the frontier so we prune
+    // merged worktrees and measure free space every wave (the autonomous loop's per-agent
+    // target/ dirs re-fill the disk; an unguarded loop hit 99%/ENOSPC and crashed a verify
+    // build). The guard's worktree prune is SAFE (it keeps anything unmerged/dirty), so --apply
+    // it unconditionally; the main-checkout target/ reclaim is opt-in + CRITICAL-only + gated on
+    // no live build, so passing --reclaim-main-target is safe (it only fires when truly starved).
+    'FIRST run the per-tick disk guard (READ-ONLY repo; do NOT git-checkout): ' +
+    '`cd /home/ubuntu/sparq && bash scripts/disk-guard.sh --apply --reclaim-main-target`. ' +
+    'Capture its final `[disk-guard] done (state=..., advisory exit=N)` line: report disk_state ' +
+    '(OK/WARN/CRITICAL/UNKNOWN) and disk_free_gb (the "Xg free" it printed, as a number). ' +
+    'Then read the launchable-bead frontier: `export PATH=$PATH:/home/ubuntu/.local/bin && cd /home/ubuntu/sparq && bash scripts/push-frontier.sh` (READ-ONLY; do NOT git-checkout). ' +
     'Each line is `bead-id  surface  title`. Return up to 6 DISPATCHABLE ready beads as {beads:[{id,surface,title}]}. ' +
     'EXCLUDE: epics; anything needs-user / requiring a maintainer decision; in-progress; and these already-handled ids: ' + JSON.stringify([...seen]) + '. ' +
     // [OPUS-4.8] sq-7mwun: belt-and-suspenders open-PR exclusion. push-frontier.sh already
@@ -131,9 +147,24 @@ while (opened.length < MAX_BEADS && dry < 2) {
     'Prefer well-scoped feature/task/bug beads an implementation agent can finish autonomously. If the frontier has no dispatchable beads, return {beads:[]}.',
     { label: 'frontier', phase: 'Frontier', schema: FRONTIER_SCHEMA, agentType: 'general-purpose' }
   )
+  // [OPUS-4.8] sq-4vo9m: disk-pressure backoff. The guard already pruned + (if CRITICAL)
+  // reclaimed before this point; we still THROTTLE new dispatch under pressure because each
+  // dispatched impl agent allocates a fresh multi-GB target/. WARN → cap the wave to 1 new
+  // agent; CRITICAL → dispatch NOTHING this wave (let the just-run prune/reclaim take effect
+  // and re-measure next tick) rather than pour more target/ dirs onto a near-full disk.
+  const diskState = (fr && fr.disk_state) || 'UNKNOWN'
+  if (typeof fr === 'object' && fr) {
+    log('disk: state=' + diskState + (fr.disk_free_gb != null ? ' (~' + fr.disk_free_gb + 'G free)' : ''))
+  }
+  if (diskState === 'CRITICAL') {
+    log('disk CRITICAL — skipping dispatch this wave (guard pruned/reclaimed; re-measuring next tick)')
+    dry++
+    continue
+  }
+  const diskCap = diskState === 'WARN' ? 1 : 6
   const beads = ((fr && fr.beads) || [])
     .filter(b => b && b.id && !seen.has(b.id))
-    .slice(0, Math.min(6, MAX_BEADS - opened.length))
+    .slice(0, Math.min(diskCap, MAX_BEADS - opened.length))
   if (!beads.length) { dry++; log('frontier dry (round ' + dry + ')'); continue }
   dry = 0
   beads.forEach(b => seen.add(b.id))

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -276,6 +276,20 @@ jobs:
         run: shellcheck scripts/ci-free-disk.sh scripts/tests/test_ci_free_disk.sh
       - name: Self-test ci-free-disk.sh (set -u safety + existence guards + #462 fold)
         run: bash scripts/tests/test_ci_free_disk.sh
+      # [OPUS-4.8] sq-4vo9m: the per-tick disk guard (df-check + merged-worktree prune +
+      # gated main-target reclaim) that stops the autonomous loop from filling the work box
+      # to ENOSPC. Validated HERE (hermetic: the harness PATH-shadows df/pgrep and sandboxes
+      # the main checkout / worktree-gc, so it touches no real disk/worktree) — it has no
+      # runtime in CI itself, but a regression in its gated-escalation / busy-build-guard /
+      # state→exit / non-fatal-delegation logic must be caught before it is trusted to broom
+      # the work box. Both the script's own pure-predicate self-test AND the end-to-end
+      # harness run; HARD (no "advisory"/"informational") so ci-summary gates on it.
+      - name: shellcheck disk-guard.sh + its self-test
+        run: shellcheck scripts/disk-guard.sh scripts/tests/test_disk_guard.sh
+      - name: Self-test disk-guard.sh (threshold math + state→exit-code, hermetic)
+        run: bash scripts/disk-guard.sh --dry-run-self-test
+      - name: Self-test disk-guard.sh (gated escalation + busy-build guard, end-to-end)
+        run: bash scripts/tests/test_disk_guard.sh
       # [OPUS-4.8] sq-neq8: hermetic self-test of the coverage-ratchet gate's PURE logic
       # (max-remeasure aggregation sq-x4jy + floor-monotonicity sq-neq8) so a regression in
       # the gate ITSELF is caught here, before the gate is trusted to guard real coverage.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -347,6 +347,7 @@ This is the standing orchestration loop that ties the sections above together. R
 > To stay event-driven, **keep a CI watcher armed on every in-flight PR** (`gh run watch <run-id> --exit-status` in the background) so its completion notifies you and you can act immediately — do not let a green PR sit undiscovered until the next sweep. If you ever find yourself thinking "the next loop tick will merge this," that's the bug: merge it now. When a sweep does fire, it should usually find little to do because the event-driven path already handled it.
 
 0. **Reconcile first (cheap, every pass).** `git worktree list` + `gh pr list`; reap finished-but-unnotified worktree agents (a committed branch + no live `cargo` process = done → open its PR); merge any PR that is `ci-summary`-green **and** has all review threads resolved (squash, delete branch, then watch main CI); rebase any PR gone stale/red. (See *Orchestration cadence* + *Contribution workflow*.)
+   - **Disk guard (run EVERY tick — `scripts/disk-guard.sh --apply`).** <!-- [OPUS-4.8] sq-4vo9m per-tick disk guard --> The autonomous loop spawns one worktree-isolated agent per bead, each accumulating a multi-GB `target/`, so disk re-fills every wave — left unguarded the work box hit 99% / ENOSPC and crashed a `--workspace` verify build mid-run. So each tick run `scripts/disk-guard.sh --apply`: it `df`-checks `/` (warns when **< 20 G** free, escalates **< 10 G**), then **delegates the merged-worktree prune to `worktree-gc.sh`** (which only ever removes a worktree whose HEAD is in `origin/main` or whose branch is gone-on-origin, with no dirty/unpushed work — **never an active one**, never the main checkout). When the disk is genuinely **CRITICAL** (< 10 G) and you opt in (`--reclaim-main-target`), it also drops the **orchestrator main checkout's `target/`** — regenerable, because impl agents build in their OWN worktrees — but only after confirming no live `cargo`/`rustc` build references the main checkout (so it can never abort an in-flight build). It is **non-fatal** (a guard tick never aborts the sweep) and **dry-run by default** (it only mutates with `--apply`); its advisory exit code encodes the disk state (0 OK / 10 WARN / 20 CRITICAL). The `autonomous-scheduler` runs this same guard before each wave and **backs off dispatch under pressure** (WARN → ≤ 1 new agent; CRITICAL → dispatch nothing that wave, let the prune/reclaim take effect, re-measure next tick). (See the script catalog below; supersedes the bare "run `worktree-gc.sh --apply` at idle" advice — the guard wraps it and adds the per-tick `df` check + escalation.)
 1. **Charter cross-pollination.** *Pull:* fetch each sibling charter (`gh api repos/<sibling>/contents/AGENTS.md --jq .content | base64 -d`) + the open cross-pollination issues on this repo; fold genuinely-portable conventions into THIS file — **adapted to sparq** (cargo/clippy `-D warnings` + the W3C-conformance + best-ever-perf ratchets as the gate; roborev/codex as the reviewer; beads; the crate/wasm/CLI/HTTP/Py/JS surfaces) — via a PR, conservatively; then close/comment the issue. *Push:* for any convention this charter gains that a sibling lacks, file an issue (or PR) on the sibling repo. *Watch:* poll the cross-repo threads YOU opened/commented on (the sibling's issues + PRs) for follow-up replies and answer them, self-identifying as the SPARQ agent. No-op when there is no charter drift and no open thread awaits a reply. (See *Cross-pollinate the charter with sibling repos*.)
 2. **Screen + triage inbound work — open issues, code-scanning alerts, deps, roborev.**
    - **Open issues** (`gh issue list`): screen every one. Many are filed by the **PSS agent** — the agent developing the private sibling `jeswr/prod-solid-server`, which consumes sparq as its triplestore/server; **"PSS" anywhere in an issue refers to that codebase.** For each actionable issue: capture it as a bead (`bd create` with the issue as `--external-ref`, priority by the issue's stated severity — a "SHOWSTOPPER" → P0/P1) and drive it through the loop; comment on the issue with the bead id + status; close it when the work lands (referencing the merged PR). If an issue is **unclear, do not guess — post a clarifying reply on the issue** (the PSS agent monitors and responds), and leave it open.
@@ -456,6 +457,10 @@ no network); the Python close-script carries a `--self-test`.
   takes `only: ["sq-…", …]`). It **codifies** loop steps 3–4 (drive `bd ready` → land each
   PR) so the orchestrator stays out of the per-agent dispatch loop; it is bounded by
   `maxBeads` so it cannot flood, and impl agents never branch-switch the shared checkout.
+  **Before each wave it runs `scripts/disk-guard.sh --apply --reclaim-main-target`** (sq-4vo9m)
+  and **backs off dispatch under disk pressure** — WARN caps the wave to ≤ 1 new agent,
+  CRITICAL skips dispatch entirely that wave (the guard already pruned/reclaimed; it
+  re-measures next tick) — so the loop's own per-agent `target/` dirs cannot ENOSPC the box.
 - **`scripts/worktree-gc.sh [--dry-run | --apply]`** (sq-6xdr) — a **manual / idle-time**
   broom for the harness's `.claude/worktrees/` dirs. The harness creates one git worktree
   per agent but never auto-removes a finished one, so they pile up (366+ this session) and
@@ -472,6 +477,24 @@ no network); the Python close-script carries a `--self-test`.
   the safe set then `git worktree prune`. Run `--apply` **at idle, not while sibling agents
   are building** (the predicate cannot misclassify a busy worktree, but removing one
   mid-build aborts that build). When in doubt it KEEPS.
+- **`scripts/disk-guard.sh [--dry-run | --apply] [--reclaim-main-target]`** (sq-4vo9m) — the
+  **per-tick disk guard**: the floor that stops the autonomous loop from filling the work box
+  (one worktree-isolated agent per bead, each a multi-GB `target/`, re-fills disk every wave;
+  unguarded it hit 99% / ENOSPC and crashed a verify build). Each invocation (1) reads
+  `df -BG /` and classifies **OK / WARN (< 20 G) / CRITICAL (< 10 G)**; (2) **delegates** the
+  merged-worktree prune to `worktree-gc.sh` — it does **not** reimplement that safe predicate,
+  so the "never an active/unmerged/dirty worktree, never the main checkout" guarantees are the
+  same; and (3) only when **CRITICAL** *and* you pass `--reclaim-main-target` *and* no live
+  `cargo`/`rustc` build references the main checkout, drops the orchestrator main checkout's
+  regenerable `target/`. **Default is dry-run** (measures + dry-run-prunes + prints the plan);
+  `--apply` performs the prune (and, gated as above, the reclaim). It is **non-fatal** (runs
+  `set -uo pipefail`, never `-e`-aborts its caller — an absent `df`/`worktree-gc.sh` or a busy
+  main `target/` degrades to a logged skip); its **advisory exit code encodes the disk state**
+  (0 OK / 10 WARN / 20 CRITICAL) for a scheduler to read. Carries a hermetic
+  `--dry-run-self-test`; the end-to-end behaviour (gated escalation, the busy-build guard, the
+  state→exit mapping, non-fatal delegation) is pinned by `scripts/tests/test_disk_guard.sh`.
+  The maintenance loop runs `--apply` each tick (step 0) and the `autonomous-scheduler` runs it
+  before every wave (`--apply --reclaim-main-target`) and backs off dispatch under pressure.
 
 See `research/orchestration-automation-design.md` §1.3 (the five judgment behaviours that
 must stay with the orchestrator), §6 (failure modes + the guardrail behind each), and §5

--- a/scripts/disk-guard.sh
+++ b/scripts/disk-guard.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Disk guard — the per-tick disk-pressure broom (bead sq-4vo9m).
+# Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# disk-guard.sh [--dry-run | --apply] [--warn-gb N] [--critical-gb N]
+#               [--mount PATH] [--main PATH] [--root DIR] [--base REF]
+#               [--no-worktree-gc] [--reclaim-main-target] [--dry-run-self-test]
+#
+# WHY: 2026-06-21 the work box filled to 99% (286/290G) and a wave-4 verify agent hit
+# ENOSPC mid-build (could not run `--workspace` clippy). The autonomous loop spawns one
+# worktree-isolated agent per bead, each accumulating a multi-GB `target/`, so disk
+# re-fills every wave. The existing `worktree-gc.sh` (sq-6xdr) is the SAFE broom for
+# finished worktrees, but it was a MANUAL / idle-time tool — nothing ran a `df` check or
+# the prune ON EACH MAINTENANCE TICK. This script is that per-tick GUARD: it
+#   (1) measures free space on the disk and classifies OK / WARN (<20G) / CRITICAL (<10G);
+#   (2) prunes provably-merged worktrees by DELEGATING to worktree-gc.sh (it does NOT
+#       reimplement the safe predicate — composition, not duplication); and
+#   (3) only when CRITICAL, and only when NO live cargo/rustc build is touching the
+#       orchestrator main checkout's `target/`, reclaims that `target/` (regenerable:
+#       agents build in their OWN worktrees, so the orchestrator's `target/` is not load-
+#       bearing for in-flight work).
+#
+# DESIGN — same discipline as worktree-gc.sh / ci-free-disk.sh:
+#   • DEFAULT IS --dry-run: it MEASURES + REPORTS + delegates a DRY-RUN prune, and prints
+#     what it WOULD reclaim. It mutates NOTHING without --apply.
+#   • --apply: runs `worktree-gc.sh --apply` (safe-set removal + prune) and, if CRITICAL
+#     and `--reclaim-main-target` is set AND no live build is detected, deletes the main
+#     checkout's `target/`. Even with --apply, the main-`target/` reclaim is GATED behind
+#     CRITICAL + an explicit opt-in flag + a live-build check — it never fires casually.
+#   • The main checkout is a HARD never-touch for worktree removal (worktree-gc.sh asserts
+#     this); the ONLY thing this guard may remove from the main checkout is the regenerable
+#     `target/` build dir, and only under the gates above.
+#   • NON-FATAL by contract: a guard tick must never abort the caller. A failed `df`, an
+#     absent worktree-gc.sh, or a busy main `target/` all degrade to a logged skip, not a
+#     non-zero crash of the whole maintenance sweep. The EXIT CODE encodes the disk STATE
+#     so a caller can act (0 = OK, 10 = WARN, 20 = CRITICAL), but those are advisory signals
+#     a scheduler reads, NOT hard failures (see the scheduler/AGENTS.md wiring).
+#
+# Run:
+#   scripts/disk-guard.sh                       # dry-run (default): df + dry-run prune + plan
+#   scripts/disk-guard.sh --apply               # prune the safe worktree set, then report
+#   scripts/disk-guard.sh --apply --reclaim-main-target   # also drop main target/ IF critical
+#   scripts/disk-guard.sh --warn-gb 30          # warn earlier
+#   scripts/disk-guard.sh --dry-run-self-test   # hermetic self-test (no fs/git mutation)
+set -uo pipefail   # NOT -e: a guard tick is best-effort and must not abort its caller.
+
+PROG="disk-guard"
+log()  { printf '[%s] %s\n' "$PROG" "$*" >&2; }
+die()  { printf '[%s] ERROR: %s\n' "$PROG" "$*" >&2; exit 1; }
+
+# --- configuration (overridable by flags) -----------------------------------------------
+DEFAULT_MOUNT="/"
+DEFAULT_MAIN="/home/ubuntu/sparq"
+DEFAULT_ROOT="/home/ubuntu/sparq/.claude/worktrees"
+DEFAULT_BASE="origin/main"
+DEFAULT_WARN_GB=20       # bead: "warn if <20G free"
+DEFAULT_CRITICAL_GB=10   # below this, escalate to the gated main-target reclaim
+
+# --- pure, testable helpers -------------------------------------------------------------
+# free_gb_from_df_line <df-line>: extract the "Available" column (4th field, in GiB from
+# `df -BG`) as a bare integer. Pure string parse — no fs access — so it is unit-testable.
+# Accepts a value with or without a trailing 'G'. Prints the integer, or empty on a line we
+# cannot parse (caller treats empty as "unknown" → skip, never crash).
+free_gb_from_df_line() {
+  local line="$1" avail
+  # df -BG row: "Filesystem 1G-blocks Used Available Use% Mounted" → field 4 is Available.
+  avail="$(printf '%s\n' "$line" | awk 'NR==1{print $4}')"
+  avail="${avail%G}"
+  case "$avail" in
+    ''|*[!0-9]*) printf '' ;;     # non-numeric ⇒ unknown
+    *)           printf '%s' "$avail" ;;
+  esac
+}
+
+# classify_state <free_gb> <warn_gb> <critical_gb>: echo OK | WARN | CRITICAL | UNKNOWN.
+# Pure arithmetic; the single source of the threshold decision so it is testable in one
+# place and the exit-code mapping below cannot drift from it.
+classify_state() {
+  local free="$1" warn="$2" crit="$3"
+  case "$free" in ''|*[!0-9]*) echo "UNKNOWN"; return 0 ;; esac
+  if [ "$free" -lt "$crit" ]; then echo "CRITICAL"; return 0; fi
+  if [ "$free" -lt "$warn" ]; then echo "WARN";     return 0; fi
+  echo "OK"
+}
+
+# state_exit_code <state>: 0 OK/UNKNOWN, 10 WARN, 20 CRITICAL. UNKNOWN maps to 0 (a df we
+# could not parse must not, by itself, look like a crisis — we already logged it).
+state_exit_code() {
+  case "$1" in
+    CRITICAL) echo 20 ;;
+    WARN)     echo 10 ;;
+    *)        echo 0  ;;
+  esac
+}
+
+# --- hermetic self-test (no fs/git mutation; exercises the pure predicates) --------------
+self_test() {
+  local fails=0
+  _ok()   { printf '  ok   %s\n' "$1"; }
+  _fail() { printf '  FAIL %s\n       %s\n' "$1" "$2"; fails=$((fails + 1)); }
+  _eq()   { if [ "$2" = "$3" ]; then _ok "$1"; else _fail "$1" "expected '$3', got '$2'"; fi; }
+  log "running --dry-run self-test (hermetic; no fs/git mutation)"
+
+  # free_gb_from_df_line: parse the Available column from a df -BG data row.
+  _eq "parse plain integer avail"        "$(free_gb_from_df_line '/dev/root 290G 141G 149G 49% /')" "149"
+  _eq "parse 0G avail"                   "$(free_gb_from_df_line 'fs 290G 290G 0G 100% /')"          "0"
+  _eq "short line (no \$4) ⇒ empty"      "$(free_gb_from_df_line 'total garbage')"                   ""
+  _eq "non-numeric avail ⇒ empty"        "$(free_gb_from_df_line 'a b c notanumber d e')"            ""
+
+  # classify_state: the threshold decision (warn=20, critical=10).
+  _eq "200G free ⇒ OK"                   "$(classify_state 200 20 10)" "OK"
+  _eq "exactly 20G ⇒ OK (>=warn)"        "$(classify_state 20 20 10)"  "OK"
+  _eq "19G ⇒ WARN"                       "$(classify_state 19 20 10)"  "WARN"
+  _eq "exactly 10G ⇒ WARN (>=crit)"      "$(classify_state 10 20 10)"  "WARN"
+  _eq "9G ⇒ CRITICAL"                    "$(classify_state 9 20 10)"   "CRITICAL"
+  _eq "0G ⇒ CRITICAL"                    "$(classify_state 0 20 10)"   "CRITICAL"
+  _eq "empty free ⇒ UNKNOWN"            "$(classify_state '' 20 10)"  "UNKNOWN"
+
+  # state_exit_code: the advisory exit-code mapping.
+  _eq "OK ⇒ exit 0"                      "$(state_exit_code OK)"       "0"
+  _eq "UNKNOWN ⇒ exit 0"                 "$(state_exit_code UNKNOWN)"  "0"
+  _eq "WARN ⇒ exit 10"                   "$(state_exit_code WARN)"     "10"
+  _eq "CRITICAL ⇒ exit 20"               "$(state_exit_code CRITICAL)" "20"
+
+  # main_target_build_busy: a real `pgrep`-backed probe; just assert it is callable and
+  # returns a clean 0/1 (we cannot deterministically assert a system state here).
+  if main_target_build_busy "/nonexistent/main"; then _ok "busy-probe returns (busy)"; else _ok "busy-probe returns (idle)"; fi
+
+  echo
+  if [ "$fails" -eq 0 ]; then log "self-test PASSED"; return 0; fi
+  die "self-test FAILED ($fails check(s))"
+}
+
+# main_target_build_busy <main>: 0 (busy) iff a live cargo/rustc process appears to be
+# building under <main>/target. Best-effort heuristic — when in doubt, report BUSY (1's
+# inverse) so we KEEP the dir. We look for cargo/rustc processes whose cwd or args mention
+# the main checkout path; a false "busy" only means we skip a reclaim (safe), whereas a
+# false "idle" could abort a build, so the probe is deliberately conservative.
+main_target_build_busy() {
+  local main="${1%/}"
+  command -v pgrep >/dev/null 2>&1 || return 0   # cannot tell ⇒ assume busy ⇒ keep
+  # Any cargo/rustc/rustdoc process at all, whose command line references the main path.
+  if pgrep -af 'cargo|rustc|rustdoc' 2>/dev/null | grep -qF -- "$main"; then
+    return 0   # busy
+  fi
+  return 1     # idle
+}
+
+# --- arg parsing -------------------------------------------------------------------------
+APPLY=0
+MOUNT="$DEFAULT_MOUNT"
+MAIN="$DEFAULT_MAIN"
+ROOT="$DEFAULT_ROOT"
+BASE="$DEFAULT_BASE"
+WARN_GB="$DEFAULT_WARN_GB"
+CRITICAL_GB="$DEFAULT_CRITICAL_GB"
+RUN_WT_GC=1
+RECLAIM_MAIN_TARGET=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --dry-run-self-test)   self_test; exit 0 ;;
+    --apply)               APPLY=1 ;;
+    --dry-run)             APPLY=0 ;;
+    --warn-gb)             shift; [ "$#" -gt 0 ] || die "--warn-gb needs a value"; WARN_GB="$1" ;;
+    --warn-gb=*)           WARN_GB="${1#--warn-gb=}" ;;
+    --critical-gb)         shift; [ "$#" -gt 0 ] || die "--critical-gb needs a value"; CRITICAL_GB="$1" ;;
+    --critical-gb=*)       CRITICAL_GB="${1#--critical-gb=}" ;;
+    --mount)               shift; [ "$#" -gt 0 ] || die "--mount needs a value"; MOUNT="$1" ;;
+    --mount=*)             MOUNT="${1#--mount=}" ;;
+    --main)                shift; [ "$#" -gt 0 ] || die "--main needs a value"; MAIN="$1" ;;
+    --main=*)              MAIN="${1#--main=}" ;;
+    --root)                shift; [ "$#" -gt 0 ] || die "--root needs a value"; ROOT="$1" ;;
+    --root=*)              ROOT="${1#--root=}" ;;
+    --base)                shift; [ "$#" -gt 0 ] || die "--base needs a value"; BASE="$1" ;;
+    --base=*)              BASE="${1#--base=}" ;;
+    --no-worktree-gc)      RUN_WT_GC=0 ;;
+    --reclaim-main-target) RECLAIM_MAIN_TARGET=1 ;;
+    -h|--help)             sed -n '2,60p' "$0"; exit 0 ;;
+    *)                     die "unknown argument: $1 (try --apply, --warn-gb, --critical-gb, --reclaim-main-target, --dry-run-self-test, --help)" ;;
+  esac
+  shift
+done
+
+case "$WARN_GB" in     ''|*[!0-9]*) die "--warn-gb must be a non-negative integer (got '$WARN_GB')" ;; esac
+case "$CRITICAL_GB" in ''|*[!0-9]*) die "--critical-gb must be a non-negative integer (got '$CRITICAL_GB')" ;; esac
+[ "$CRITICAL_GB" -le "$WARN_GB" ] || die "--critical-gb ($CRITICAL_GB) must be <= --warn-gb ($WARN_GB)"
+MAIN="${MAIN%/}"
+ROOT="${ROOT%/}"
+
+# --- 1. measure free space ---------------------------------------------------------------
+log "mode=$([ "$APPLY" -eq 1 ] && echo APPLY || echo dry-run)  mount=$MOUNT  warn=<${WARN_GB}G  critical=<${CRITICAL_GB}G"
+
+DF_LINE="$(df -BG "$MOUNT" 2>/dev/null | awk 'NR==2{print}')" || DF_LINE=""
+if [ -z "$DF_LINE" ]; then
+  log "WARNING: could not read 'df -BG $MOUNT' — skipping disk measurement (non-fatal)."
+  FREE_GB=""
+else
+  FREE_GB="$(free_gb_from_df_line "$DF_LINE")"
+fi
+
+STATE="$(classify_state "${FREE_GB:-}" "$WARN_GB" "$CRITICAL_GB")"
+case "$STATE" in
+  OK)       log "disk OK: ${FREE_GB}G free on $MOUNT (>= ${WARN_GB}G warn threshold)." ;;
+  WARN)     log "DISK WARN: only ${FREE_GB}G free on $MOUNT (< ${WARN_GB}G) — pruning merged worktrees." ;;
+  CRITICAL) log "DISK CRITICAL: only ${FREE_GB}G free on $MOUNT (< ${CRITICAL_GB}G) — pruning + escalating." ;;
+  UNKNOWN)  log "disk state UNKNOWN (df unparsed) — running the safe prune anyway, skipping escalation." ;;
+esac
+
+# --- 2. prune provably-merged worktrees (delegate to worktree-gc.sh) ---------------------
+# We ALWAYS run the worktree prune (its safe predicate KEEPS anything unmerged/dirty, so it
+# is harmless when disk is fine and frees the most when it is not) — this is the per-tick
+# "prune merged worktrees" the bead asks for. We do not reimplement the predicate.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WT_GC="${SCRIPT_DIR}/worktree-gc.sh"
+
+if [ "$RUN_WT_GC" -eq 1 ]; then
+  if [ -x "$WT_GC" ] || [ -f "$WT_GC" ]; then
+    log "delegating worktree prune to worktree-gc.sh ($([ "$APPLY" -eq 1 ] && echo --apply || echo --dry-run)):"
+    if [ "$APPLY" -eq 1 ]; then
+      bash "$WT_GC" --apply --root "$ROOT" --main "$MAIN" --base "$BASE" || \
+        log "WARNING: worktree-gc.sh --apply returned non-zero (some worktrees kept) — non-fatal."
+    else
+      bash "$WT_GC" --dry-run --root "$ROOT" --main "$MAIN" --base "$BASE" || \
+        log "WARNING: worktree-gc.sh --dry-run returned non-zero — non-fatal."
+    fi
+  else
+    log "WARNING: worktree-gc.sh not found at $WT_GC — skipping worktree prune (non-fatal)."
+  fi
+else
+  log "worktree prune skipped (--no-worktree-gc)."
+fi
+
+# --- 3. CRITICAL escalation: reclaim the orchestrator main checkout's target/ ------------
+# Regenerable (agents build in their OWN worktrees). GATED behind ALL of:
+#   • STATE == CRITICAL, AND
+#   • --reclaim-main-target opt-in, AND
+#   • no live cargo/rustc build referencing the main checkout, AND
+#   • --apply (otherwise we only PLAN it).
+MAIN_TARGET="${MAIN}/target"
+if [ "$STATE" = "CRITICAL" ]; then
+  if [ "$RECLAIM_MAIN_TARGET" -eq 1 ]; then
+    if [ -d "$MAIN_TARGET" ]; then
+      if main_target_build_busy "$MAIN"; then
+        log "CRITICAL but a live cargo/rustc build references $MAIN — KEEPING $MAIN_TARGET (a reclaim would abort it)."
+      else
+        local_size="$(du -sh "$MAIN_TARGET" 2>/dev/null | cut -f1)"
+        if [ "$APPLY" -eq 1 ]; then
+          log "reclaiming main checkout build dir: rm -rf $MAIN_TARGET (was ${local_size:-?}; regenerable)."
+          rm -rf "$MAIN_TARGET" || log "WARNING: failed to remove $MAIN_TARGET — non-fatal."
+        else
+          log "PLAN (dry-run): would rm -rf $MAIN_TARGET (${local_size:-?} reclaimable) — re-run with --apply --reclaim-main-target."
+        fi
+      fi
+    else
+      log "CRITICAL: no $MAIN_TARGET to reclaim."
+    fi
+  else
+    log "CRITICAL: main-target reclaim available but NOT opted in (pass --reclaim-main-target to enable)."
+  fi
+fi
+
+# --- final df + advisory exit code -------------------------------------------------------
+if [ "$APPLY" -eq 1 ] && [ -n "$DF_LINE" ]; then
+  AFTER_LINE="$(df -BG "$MOUNT" 2>/dev/null | awk 'NR==2{print}')" || AFTER_LINE=""
+  if [ -n "$AFTER_LINE" ]; then
+    AFTER_GB="$(free_gb_from_df_line "$AFTER_LINE")"
+    log "after sweep: ${AFTER_GB:-?}G free on $MOUNT."
+  fi
+fi
+
+EXIT_CODE="$(state_exit_code "$STATE")"
+log "done (state=$STATE, advisory exit=$EXIT_CODE)."
+exit "$EXIT_CODE"

--- a/scripts/tests/test_disk_guard.sh
+++ b/scripts/tests/test_disk_guard.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Hermetic self-tests for scripts/disk-guard.sh (bead sq-4vo9m —
+# the per-tick disk guard: df-check + merged-worktree prune + gated main-target
+# reclaim). Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable
+# returns).
+#
+# WHY: the guard's correctness rests on a few load-bearing invariants that a future
+# refactor must not silently break, so we pin them with a hermetic harness (the
+# pure-predicate self-test inside the script covers the threshold math; THIS harness
+# covers the END-TO-END behaviour under stubbed df/pgrep, where the dangerous mutation
+# — deleting the main checkout's target/ — actually lives):
+#   1. ESCALATION IS GATED — when disk is CRITICAL, the main-checkout target/ is removed
+#      ONLY with --apply AND --reclaim-main-target. CRITICAL alone, or --apply without the
+#      opt-in flag, must KEEP it.
+#   2. BUSY-BUILD GUARD — even CRITICAL + --apply + --reclaim-main-target must KEEP target/
+#      if a live cargo/rustc process references the main checkout (removing it mid-build
+#      would abort that build — the exact ENOSPC-adjacent failure mode the bead is about).
+#   3. STATE → EXIT-CODE — OK⇒0, WARN⇒10, CRITICAL⇒20 (advisory signals a scheduler reads).
+#   4. NON-FATAL DELEGATION — disk-guard always invokes the worktree prune and never aborts
+#      its caller; an absent/erroring worktree-gc.sh degrades to a logged skip, not a crash.
+#
+# HERMETIC w.r.t. the real system: `df` and `pgrep` are PATH-shadowed by stubs, the main
+# checkout + worktree root are scratch dirs under a mktemp sandbox, and worktree-gc.sh is
+# replaced by a no-op stub next to the script copy. The harness never reads real disk free
+# space, never touches a real worktree, and never deletes anything outside the sandbox.
+#
+# Run:  bash scripts/tests/test_disk_guard.sh   (exit 0 = all pass, 1 = a failure)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SRC="${ROOT}/scripts/disk-guard.sh"
+WT_GC_SRC="${ROOT}/scripts/worktree-gc.sh"
+
+[ -f "$SRC" ] || { echo "FATAL: script not found at ${SRC}"; exit 2; }
+
+pass=0
+fail=0
+note_pass() { pass=$((pass + 1)); }
+note_fail() { fail=$((fail + 1)); printf 'CASE FAILED: %s\n' "$1"; }
+check_rc() {  # check_rc <description> <expected-rc> <actual-rc>
+  if [ "$3" = "$2" ]; then note_pass; else note_fail "$1 (wanted rc=$2, got rc=$3)"; fi
+}
+
+# --------------------------------------------------------------------------- #
+# Sandbox: a scratch dir with a stub `df` + `pgrep` on PATH, a no-op worktree-gc
+# stub sitting beside a COPY of disk-guard.sh (so its `dirname $0/worktree-gc.sh`
+# resolves to the stub, not the real broom), and a scratch main checkout + target/.
+# --------------------------------------------------------------------------- #
+SANDBOX="$(mktemp -d)"
+trap 'rm -rf "$SANDBOX"' EXIT
+BIN="${SANDBOX}/bin"
+SCRIPTS="${SANDBOX}/scripts"
+MAIN="${SANDBOX}/main"
+WTROOT="${SANDBOX}/wtroot"
+mkdir -p "$BIN" "$SCRIPTS" "$MAIN" "$WTROOT"
+
+cp "$SRC" "${SCRIPTS}/disk-guard.sh"
+GUARD="${SCRIPTS}/disk-guard.sh"
+
+# No-op worktree-gc stub beside the copied guard — records that it was invoked.
+WT_GC_LOG="${SANDBOX}/wtgc.log"
+: >"$WT_GC_LOG"
+cat >"${SCRIPTS}/worktree-gc.sh" <<EOF
+#!/usr/bin/env bash
+echo "INVOKED \$*" >>"${WT_GC_LOG}"
+exit 0
+EOF
+chmod +x "${SCRIPTS}/worktree-gc.sh"
+
+# Stub pgrep that reports NO matching build by default (idle box).
+write_idle_pgrep() {
+  cat >"${BIN}/pgrep" <<'EOF'
+#!/usr/bin/env bash
+exit 1   # no processes matched
+EOF
+  chmod +x "${BIN}/pgrep"
+}
+# Stub pgrep that reports a live cargo build referencing the sandbox main checkout.
+write_busy_pgrep() {
+  cat >"${BIN}/pgrep" <<EOF
+#!/usr/bin/env bash
+echo "4242 cargo build --manifest-path ${MAIN}/Cargo.toml"
+exit 0
+EOF
+  chmod +x "${BIN}/pgrep"
+}
+# Stub df that reports a given GiB-free value (CRITICAL/WARN/OK as chosen by caller).
+write_df_free() {  # write_df_free <free_gb>
+  cat >"${BIN}/df" <<EOF
+#!/usr/bin/env bash
+echo "Filesystem 1G-blocks Used Available Use% Mounted on"
+echo "stub 290G \$((290 - $1))G ${1}G $(( (290-$1)*100/290 ))% /"
+EOF
+  chmod +x "${BIN}/df"
+}
+
+mk_target() { rm -rf "${MAIN}/target"; mkdir -p "${MAIN}/target/debug"; : >"${MAIN}/target/debug/blob"; }
+target_present() { [ -d "${MAIN}/target" ]; }
+
+run_guard() {  # run_guard <expected-rc> <args...>; sets last_rc. (expected-rc is consumed by
+               # the caller's check_rc; we drop it here so it is not passed to the guard.)
+  shift
+  set +e
+  PATH="${BIN}:${PATH}" bash "$GUARD" --main "$MAIN" --root "$WTROOT" "$@" >/dev/null 2>&1
+  last_rc=$?
+  set -e
+}
+
+# --------------------------------------------------------------------------- #
+# 1. CRITICAL + --apply but NO --reclaim-main-target ⇒ KEEP target/, exit 20.
+# --------------------------------------------------------------------------- #
+write_idle_pgrep; write_df_free 5; mk_target
+run_guard 20 --apply
+check_rc "CRITICAL + apply, no opt-in: exit 20" 20 "$last_rc"
+if target_present; then note_pass; else note_fail "CRITICAL + apply, no opt-in: target/ wrongly removed"; fi
+
+# --------------------------------------------------------------------------- #
+# 2. CRITICAL + --apply + --reclaim-main-target + idle ⇒ REMOVE target/, exit 20.
+# --------------------------------------------------------------------------- #
+write_idle_pgrep; write_df_free 5; mk_target
+run_guard 20 --apply --reclaim-main-target
+check_rc "CRITICAL + apply + opt-in (idle): exit 20" 20 "$last_rc"
+if target_present; then note_fail "CRITICAL + apply + opt-in (idle): target/ NOT reclaimed"; else note_pass; fi
+
+# --------------------------------------------------------------------------- #
+# 3. CRITICAL + --apply + --reclaim-main-target BUT a live build ⇒ KEEP target/.
+#    (the busy-build guard — must never abort an in-flight build.)
+# --------------------------------------------------------------------------- #
+write_busy_pgrep; write_df_free 5; mk_target
+run_guard 20 --apply --reclaim-main-target
+check_rc "CRITICAL + apply + opt-in (BUSY): exit 20" 20 "$last_rc"
+if target_present; then note_pass; else note_fail "CRITICAL + apply + opt-in (BUSY): target/ removed mid-build!"; fi
+
+# --------------------------------------------------------------------------- #
+# 4. CRITICAL DRY-RUN + opt-in ⇒ PLAN only, KEEP target/, exit 20.
+# --------------------------------------------------------------------------- #
+write_idle_pgrep; write_df_free 5; mk_target
+run_guard 20 --reclaim-main-target
+check_rc "CRITICAL dry-run + opt-in: exit 20" 20 "$last_rc"
+if target_present; then note_pass; else note_fail "CRITICAL dry-run: target/ removed (must only PLAN)"; fi
+
+# --------------------------------------------------------------------------- #
+# 5. WARN (15G) ⇒ prune only, no escalation, exit 10, target/ untouched even with opt-in.
+# --------------------------------------------------------------------------- #
+write_idle_pgrep; write_df_free 15; mk_target
+run_guard 10 --apply --reclaim-main-target
+check_rc "WARN: exit 10" 10 "$last_rc"
+if target_present; then note_pass; else note_fail "WARN: target/ removed (escalation must be CRITICAL-only)"; fi
+
+# --------------------------------------------------------------------------- #
+# 6. OK (200G) ⇒ exit 0, target/ untouched.
+# --------------------------------------------------------------------------- #
+write_idle_pgrep; write_df_free 200; mk_target
+run_guard 0 --apply --reclaim-main-target
+check_rc "OK: exit 0" 0 "$last_rc"
+if target_present; then note_pass; else note_fail "OK: target/ removed (must only act when CRITICAL)"; fi
+
+# --------------------------------------------------------------------------- #
+# 7. NON-FATAL DELEGATION — the worktree prune is ALWAYS invoked (every tick), and
+#    a worktree-gc that EXITS NON-ZERO does not crash the guard.
+# --------------------------------------------------------------------------- #
+: >"$WT_GC_LOG"
+write_idle_pgrep; write_df_free 200; mk_target
+run_guard 0 --dry-run
+if grep -q '^INVOKED' "$WT_GC_LOG"; then note_pass; else note_fail "worktree prune was NOT invoked on an OK tick"; fi
+
+# erroring worktree-gc ⇒ guard still exits on the disk-state code (non-fatal delegation)
+cat >"${SCRIPTS}/worktree-gc.sh" <<'EOF'
+#!/usr/bin/env bash
+echo "boom" >&2
+exit 3
+EOF
+chmod +x "${SCRIPTS}/worktree-gc.sh"
+write_idle_pgrep; write_df_free 200
+run_guard 0 --apply
+check_rc "erroring worktree-gc is non-fatal (exit on disk state)" 0 "$last_rc"
+# restore the no-op stub
+cat >"${SCRIPTS}/worktree-gc.sh" <<EOF
+#!/usr/bin/env bash
+echo "INVOKED \$*" >>"${WT_GC_LOG}"
+exit 0
+EOF
+chmod +x "${SCRIPTS}/worktree-gc.sh"
+
+# --------------------------------------------------------------------------- #
+# 8. UNKNOWN df (unparseable) ⇒ exit 0 (a df we cannot read is NOT, by itself, a crisis),
+#    no escalation, target/ untouched even with --apply --reclaim-main-target.
+# --------------------------------------------------------------------------- #
+cat >"${BIN}/df" <<'EOF'
+#!/usr/bin/env bash
+echo "Filesystem 1G-blocks Used Available Use% Mounted on"
+echo "totally unparseable"
+EOF
+chmod +x "${BIN}/df"
+write_idle_pgrep; mk_target
+run_guard 0 --apply --reclaim-main-target
+check_rc "UNKNOWN df: exit 0" 0 "$last_rc"
+if target_present; then note_pass; else note_fail "UNKNOWN df: target/ removed (must not escalate)"; fi
+
+# --------------------------------------------------------------------------- #
+# 9. STATIC: bead invariants present in the source (a refactor cannot silently drop them).
+# --------------------------------------------------------------------------- #
+if grep -q 'main_target_build_busy' "$SRC"; then note_pass; else note_fail "busy-build guard removed from source"; fi
+if grep -q 'RECLAIM_MAIN_TARGET' "$SRC";    then note_pass; else note_fail "main-target reclaim opt-in removed from source"; fi
+if grep -q 'worktree-gc.sh' "$SRC";         then note_pass; else note_fail "worktree-gc delegation removed from source"; fi
+# the guard must DELEGATE the safe predicate, not reimplement a worktree-removal predicate:
+if grep -q 'merge-base --is-ancestor' "$SRC"; then
+  note_fail "disk-guard reimplements the worktree safe predicate — it must DELEGATE to worktree-gc.sh"
+else
+  note_pass
+fi
+
+# 10. The real worktree-gc.sh still passes its OWN self-test (composition integrity).
+if [ -f "$WT_GC_SRC" ]; then
+  if bash "$WT_GC_SRC" --dry-run-self-test >/dev/null 2>&1; then note_pass; else note_fail "real worktree-gc.sh self-test failed"; fi
+else
+  note_fail "real worktree-gc.sh missing — disk-guard delegates to it"
+fi
+
+# --------------------------------------------------------------------------- #
+echo ""
+echo "test_disk_guard: ${pass} passed, ${fail} failed."
+[ "$fail" -eq 0 ] || exit 1
+echo "test_disk_guard: OK — gated escalation + busy-build guard + state→exit + non-fatal delegation hold."


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated infra contribution. I am one of several agents @jeswr runs on this account; this PR self-identifies per the AGENTS.md self-ID rule.

Closes **sq-4vo9m** (infra, P1).

## Problem
2026-06-21 the work box filled to 99% (286/290G) and a wave-4 verify agent hit **ENOSPC** mid-build (could not run `--workspace` clippy). The autonomous loop spawns one worktree-isolated agent per bead, each accumulating a multi-GB `target/`, so disk re-fills every wave. `worktree-gc.sh` (sq-6xdr) was the SAFE broom but was **manual / idle-time only** — nothing ran a `df` check or the prune **on each maintenance tick**, and nothing reclaimed the orchestrator main checkout's `target/` when critically low.

## What this wires (and where)
- **`scripts/disk-guard.sh`** (new) — the per-tick guard. Each invocation:
  1. `df -BG /` → classify **OK / WARN (< 20 G) / CRITICAL (< 10 G)**;
  2. **delegates** the merged-worktree prune to `worktree-gc.sh` — it does **not** reimplement the safe predicate, so "never an active/unmerged/dirty worktree, never the main checkout" is unchanged (a static test asserts the guard does not re-implement `merge-base --is-ancestor`);
  3. only when **CRITICAL** *and* `--reclaim-main-target` opt-in *and* **no live `cargo`/`rustc` build references the main checkout**, drops the orchestrator main checkout's regenerable `target/` (impl agents build in their OWN worktrees).
  Non-fatal (`set -uo pipefail`, never `-e`-aborts its caller); **dry-run by default**, mutation behind `--apply`; advisory exit code encodes disk state (**0 OK / 10 WARN / 20 CRITICAL**).
- **`.claude/workflows/autonomous-scheduler.js`** — runs the guard (`--apply --reclaim-main-target`) **before each wave** and **backs off dispatch under pressure**: WARN → ≤ 1 new agent, CRITICAL → dispatch nothing that wave (re-measure next tick), so the loop's own per-agent `target/` dirs cannot ENOSPC the box.
- **`AGENTS.md`** — maintenance loop **step 0** now runs `disk-guard.sh --apply` every tick; the orchestration-automation script catalog documents it (supersedes the bare "run `worktree-gc.sh --apply` at idle" advice — the guard wraps it and adds the per-tick `df` check + escalation).
- **`.github/workflows/docs-quality.yml`** — the `ci-scripts` job (HARD gate → feeds `ci-summary`) now shellchecks the script + harness and runs both self-tests.

## Design decisions (best-judgment, per the STANDING RULE — flagged for the maintainer to steer)
- **The main-checkout `target/` reclaim is opt-in (`--reclaim-main-target`) + CRITICAL-only + gated on no live build**, not automatic. Rationale: deleting `target/` mid-build aborts that build (the exact ENOSPC-adjacent failure the bead is about), so the conservative default is to KEEP unless genuinely starved. The scheduler opts in; the bare maintenance-loop step does not (it only prunes worktrees). If you'd prefer it always-on at WARN, that's a one-flag change.
- **Thresholds 20 G warn / 10 G critical** (the bead names "< 20 G"); both overridable via `--warn-gb` / `--critical-gb`.

## Gates
- `bash -n` OK; **shellcheck CLEAN** on both new scripts; **`typos` exits 0** (repo `_typos.toml`); **privacy-claims OK** (422 files); **no-perf-numbers 0 findings**.
- **YAML valid + actionlint CLEAN** on `docs-quality.yml`; the `ci-scripts` job name has no `advisory`/`informational`, so **`ci-summary / gate` gates on it**.
- **Local reproduction:** ran `disk-guard.sh --dry-run` against the live work box — it measured free space, delegated the prune to `worktree-gc.sh` (correctly KEPT all 23 worktrees, none safe), exit 0. Stubbed-`df` runs confirmed CRITICAL→reclaim (opt-in only), busy-build→KEEP, WARN→prune-only, UNKNOWN→exit 0.
- **Self-tests:** `disk-guard.sh --dry-run-self-test` (threshold math + state→exit) and `scripts/tests/test_disk_guard.sh` (**21/21** — gated escalation, busy-build guard, state→exit, non-fatal delegation; hermetic, PATH-shadows `df`/`pgrep`, sandboxes the main checkout / worktree-gc). Regression-checked: `worktree-gc.sh` + `ci-free-disk` self-tests still pass.

## Compliance gap closed
Operational disk-exhaustion / availability guard for the autonomous build loop — not a supply-chain framework claim. Closes the concrete ENOSPC-crash failure mode in sq-4vo9m.

Auto-merge: **OFF**.

Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).