### PR TITLE
feat(site): load gzip/zip RDF datasets by upload OR URL, decompressed client-side (sq-spita) [OPUS-4.8]

### DIFF
--- a/site/src/components/repl-datasets.tsx
+++ b/site/src/components/repl-datasets.tsx
@@ -37,7 +37,60 @@ import {
   guessFormat,
   formatFromContentType,
 } from "@/lib/repl-dataset";
+// [OPUS-4.8] sq-spita — client-side gzip/zip decompression so a compressed dataset
+// (e.g. a 10M-triple UMBC `.nt.gz` redirect, a TIB watdiv `.zip`) loads by upload OR URL.
+import {
+  sniffArchive,
+  archiveCodecFromName,
+  archiveCodecFromContentType,
+  decompressArchive,
+} from "@/lib/dataset-archive";
 import { BUILTIN_DATASETS } from "@/data/sample-graph";
+
+/**
+ * Turns the raw bytes of an uploaded file / fetched URL into RDF text + the format to
+ * parse it as, transparently decompressing a gzip (`.gz`) or zip (`.zip`) container in
+ * the browser tab first. [OPUS-4.8] sq-spita.
+ *
+ * Detection order: an archive `Content-Type` / extension, else the payload's magic
+ * number. Plain (uncompressed) RDF is decoded as UTF-8 directly. The RDF format is
+ * derived from the inner (decompressed) member name, with the supplied `explicitFormat`
+ * (an explicit picker choice) / `contentType` taking precedence when present.
+ */
+async function bytesToRdf(
+  bytes: Uint8Array,
+  sourceName: string,
+  opts: { explicitFormat?: string; contentType?: string | null } = {},
+): Promise<{ text: string; format: string }> {
+  const { explicitFormat, contentType } = opts;
+  const archiveCodec =
+    archiveCodecFromContentType(contentType ?? null) ??
+    archiveCodecFromName(sourceName) ??
+    sniffArchive(bytes);
+
+  if (archiveCodec) {
+    const { text, innerName } = await decompressArchive(
+      bytes,
+      sourceName,
+      archiveCodec,
+    );
+    // An explicit picker choice always wins; otherwise the INNER member name decides
+    // (the archive's Content-Type only names the container, not the RDF format).
+    const format =
+      explicitFormat && explicitFormat !== "__auto__"
+        ? explicitFormat
+        : guessFormat(innerName ?? sourceName);
+    return { text, format };
+  }
+
+  // Not compressed: decode the bytes as UTF-8 and detect the RDF format normally.
+  const text = new TextDecoder().decode(bytes);
+  const format =
+    explicitFormat && explicitFormat !== "__auto__"
+      ? explicitFormat
+      : (formatFromContentType(contentType ?? null) ?? guessFormat(sourceName));
+  return { text, format };
+}
 
 /** What's currently loaded into the REPL store, for the viewer's heading. */
 export interface ActiveDataset {
@@ -86,6 +139,7 @@ export function DatasetControls({
 }: DatasetControlsProps) {
   const [mode, setMode] = React.useState<"replace" | "add">("replace");
   const [urlOpen, setUrlOpen] = React.useState(false);
+  const [fileError, setFileError] = React.useState<string | null>(null);
   const fileRef = React.useRef<HTMLInputElement | null>(null);
 
   const onFile = React.useCallback(
@@ -94,12 +148,18 @@ export function DatasetControls({
       // Reset the input so re-selecting the same file fires onChange again.
       e.target.value = "";
       if (!file) return;
-      const text = await file.text();
-      // [OPUS-4.8] sq-atb0 — a local file import: record the origin so the workspace lists it
-      // (it cannot be silently re-read across sessions — the snapshot is its durable copy).
-      await onLoadText(text, guessFormat(file.name), file.name, mode, {
-        kind: "local",
-      });
+      setFileError(null);
+      try {
+        // [OPUS-4.8] sq-spita — read the file as BYTES (not text) so a gzip/zip archive
+        // can be detected by magic number and decompressed in-tab before parsing.
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const { text, format } = await bytesToRdf(bytes, file.name);
+        // [OPUS-4.8] sq-atb0 — a local file import: record the origin so the workspace lists it
+        // (it cannot be silently re-read across sessions — the snapshot is its durable copy).
+        await onLoadText(text, format, file.name, mode, { kind: "local" });
+      } catch (err) {
+        setFileError(err instanceof Error ? err.message : String(err));
+      }
     },
     [onLoadText, mode],
   );
@@ -151,7 +211,9 @@ export function DatasetControls({
         <input
           ref={fileRef}
           type="file"
-          accept=".ttl,.turtle,.nt,.ntriples,.nq,.nquads,.trig,.jsonld,text/turtle,application/n-triples,application/n-quads,application/trig,application/ld+json"
+          // [OPUS-4.8] sq-spita — also accept gzip/zip archives (incl. compound suffixes
+          // such as .ttl.gz / .nt.gz); they decompress in-tab before parsing.
+          accept=".ttl,.turtle,.nt,.ntriples,.nq,.nquads,.trig,.jsonld,.gz,.zip,.ttl.gz,.nt.gz,.nq.gz,.trig.gz,text/turtle,application/n-triples,application/n-quads,application/trig,application/ld+json,application/gzip,application/zip"
           className="hidden"
           onChange={onFile}
         />
@@ -172,6 +234,14 @@ export function DatasetControls({
           <Link2 className="size-3.5" /> From URL
         </Button>
       </span>
+
+      {/* [OPUS-4.8] sq-spita — a failed upload (e.g. an unsupported zip member, or a
+          parse error in the decompressed RDF) surfaces inline rather than silently. */}
+      {fileError && (
+        <p className="w-full rounded-lg border border-destructive/30 bg-destructive/5 p-2 text-xs text-destructive">
+          {fileError}
+        </p>
+      )}
 
       <UrlLoadDialog
         open={urlOpen}
@@ -199,7 +269,10 @@ function UrlLoadDialog({
   onLoadText: DatasetControlsProps["onLoadText"];
 }) {
   const [url, setUrl] = React.useState("");
-  const [format, setFormat] = React.useState("turtle");
+  // [OPUS-4.8] sq-spita — default to Auto-detect so a compressed URL (e.g. a UMBC
+  // `.nt.gz` redirect or a TIB watdiv `.zip`) detects its container + inner RDF format
+  // out of the box (served media type → URL extension → magic number).
+  const [format, setFormat] = React.useState("__auto__");
   const [busy, setBusy] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
 
@@ -224,13 +297,14 @@ function UrlLoadDialog({
       if (!res.ok) {
         throw new Error(`Fetch failed: HTTP ${res.status} ${res.statusText}`);
       }
-      const text = await res.text();
-      // Auto-detect prefers the served media type (reliable for extension-less URLs),
-      // then the URL extension. An explicit picker choice always wins.
-      const fmt =
-        format === "__auto__"
-          ? (formatFromContentType(res.headers.get("content-type")) ?? guessFormat(target))
-          : format;
+      // [OPUS-4.8] sq-spita — fetch as BYTES so a gzipped (`.nt.gz`) or zipped (`.zip`)
+      // dataset is decompressed in-tab; `bytesToRdf` also handles the auto-detect (served
+      // media type → URL extension → magic number). An explicit picker choice still wins.
+      const bytes = new Uint8Array(await res.arrayBuffer());
+      const { text, format: fmt } = await bytesToRdf(bytes, target, {
+        explicitFormat: format,
+        contentType: res.headers.get("content-type"),
+      });
       // [OPUS-4.8] sq-atb0 — a URL import: record the origin URL so a workspace can re-fetch it.
       await onLoadText(text, fmt, shortName(target), defaultMode, {
         kind: "url",
@@ -253,8 +327,9 @@ function UrlLoadDialog({
             <Link2 className="size-4 text-primary" /> Load RDF from a URL
           </DialogTitle>
           <DialogDescription>
-            Fetched and parsed entirely in your browser tab. The host must allow
-            cross-origin reads (CORS).
+            Fetched and parsed entirely in your browser tab. Gzip (.gz) and zip
+            (.zip) archives decompress in-tab. The host must allow cross-origin
+            reads (CORS).
           </DialogDescription>
         </DialogHeader>
 
@@ -286,7 +361,9 @@ function UrlLoadDialog({
               onChange={(e) => setFormat(e.target.value)}
               className="h-8 w-full rounded-lg border bg-background px-2 text-sm outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
             >
-              <option value="__auto__">Auto-detect (content type / extension)</option>
+              <option value="__auto__">
+                Auto-detect (content type / extension; .gz/.zip ok)
+              </option>
               {FORMAT_OPTIONS.map((f) => (
                 <option key={f.value} value={f.value}>
                   {f.label}

--- a/site/src/lib/dataset-archive.ts
+++ b/site/src/lib/dataset-archive.ts
@@ -1,0 +1,339 @@
+// [OPUS-4.8] sq-spita — client-side decompression of zipped / gzipped RDF datasets so
+// the live SPARQL REPL (and, when it reuses these controls, the GUI) can load a
+// compressed resource by file upload OR by URL — e.g. a 10M-triple UMBC `.nt.gz`
+// redirect or a TIB watdiv `.zip` — entirely in the browser tab, no server.
+//
+// These helpers are pure + framework-free (no React, no DOM beyond the standard
+// `DecompressionStream` Web API, no wasm), so they unit-test directly under
+// `node --test` (Node ≥18 ships `DecompressionStream`). The actual RDF parse still
+// happens in the wasm Store — this layer only turns archive BYTES into RDF TEXT.
+//
+// Codec choice (deliberately dependency-free):
+//   • gzip (`.gz`, magic 1f 8b) — decoded by the native `DecompressionStream("gzip")`.
+//     Single-member only: browsers silently truncate multi-member gzip to the first
+//     member (measured in research/custom-parsers-D4 §3). Real-world RDF `.gz` dumps
+//     (DBpedia/UMBC/LOD) are single-member, so this is the right trade vs. shipping a
+//     JS gzip codec.
+//   • zip (`.zip`, magic 50 4b) — a minimal central-directory reader that inflates the
+//     first RDF-looking member with the native `DecompressionStream("deflate-raw")`
+//     (DEFLATE, ZIP method 8) or copies a STORED member (method 0). No JSZip / pako
+//     dependency (would add ~95 kB / ~45 kB to the bundle for a feature served by a
+//     browser-native API). Encrypted, ZIP64, and other compression methods are
+//     rejected with a clear message rather than silently mis-decoding.
+//
+// zstd/bzip2 are intentionally out of scope for this surface (the bead names gzip/zip);
+// the JS package's `decompress.ts` covers zstd for the engine ingest path.
+
+/** A recognised dataset-archive container codec. */
+export type ArchiveCodec = "gzip" | "zip";
+
+/** The result of decompressing an archive: the decoded RDF text plus the inner
+ *  member name (used to guess the RDF format — `data.nt.gz` → `data.nt`). */
+export interface DecompressedArchive {
+  /** The decoded RDF document text. */
+  text: string;
+  /** The inner file name (archive suffix stripped / zip member name), or `null`
+   *  when it cannot be determined — the caller then falls back to its own guess. */
+  innerName: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Detection
+// ---------------------------------------------------------------------------
+
+/** The container codec a payload's magic number announces, or `undefined`. */
+export function sniffArchive(bytes: Uint8Array): ArchiveCodec | undefined {
+  // gzip: 1f 8b (RFC 1952 §2.3.1).
+  if (bytes.length >= 2 && bytes[0] === 0x1f && bytes[1] === 0x8b) return "gzip";
+  // zip: "PK\x03\x04" (local file header) or "PK\x05\x06" (empty-archive EOCD).
+  if (
+    bytes.length >= 4 &&
+    bytes[0] === 0x50 &&
+    bytes[1] === 0x4b &&
+    (bytes[2] === 0x03 || bytes[2] === 0x05 || bytes[2] === 0x07) &&
+    (bytes[3] === 0x04 || bytes[3] === 0x06 || bytes[3] === 0x08)
+  ) {
+    return "zip";
+  }
+  return undefined;
+}
+
+// Extensions / media types that name an archive container (vs. the inner RDF format).
+const GZIP_EXTS = new Set(["gz", "gzip", "tgz"]);
+const ZIP_EXTS = new Set(["zip"]);
+
+const ARCHIVE_CONTENT_TYPES: Record<string, ArchiveCodec> = {
+  "application/gzip": "gzip",
+  "application/x-gzip": "gzip",
+  "application/zip": "zip",
+  "application/x-zip-compressed": "zip",
+};
+
+/** The container codec a filename/URL extension names, or `undefined`. */
+export function archiveCodecFromName(name: string): ArchiveCodec | undefined {
+  const ext = name.split(/[?#]/)[0].split(".").pop()?.toLowerCase() ?? "";
+  if (GZIP_EXTS.has(ext)) return "gzip";
+  if (ZIP_EXTS.has(ext)) return "zip";
+  return undefined;
+}
+
+/** The container codec a response `Content-Type` names, or `undefined`. */
+export function archiveCodecFromContentType(
+  contentType: string | null,
+): ArchiveCodec | undefined {
+  if (!contentType) return undefined;
+  const mime = contentType.split(";")[0].trim().toLowerCase();
+  return ARCHIVE_CONTENT_TYPES[mime];
+}
+
+/**
+ * The inner file name for an archive name: strips a trailing `.gz`/`.gzip`/`.zip`
+ * so `dataset.nt.gz` → `dataset.nt` (a name the format guesser understands). `.tgz`
+ * maps to `.tar`, which is not an RDF format, so it returns `null` to force a fallback.
+ * Returns the input unchanged when it has no recognised archive suffix.
+ */
+export function innerNameForArchive(name: string): string | null {
+  const base = name.split(/[?#]/)[0];
+  const lower = base.toLowerCase();
+  if (lower.endsWith(".tgz")) return null; // tar inside — no single inner RDF name
+  for (const suffix of [".gz", ".gzip", ".zip"]) {
+    if (lower.endsWith(suffix)) {
+      const inner = base.slice(0, base.length - suffix.length);
+      return inner.length > 0 ? inner : null;
+    }
+  }
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// Decompression
+// ---------------------------------------------------------------------------
+
+/** Collects a byte stream into one buffer. */
+async function collectStream(
+  stream: ReadableStream<Uint8Array>,
+): Promise<Uint8Array> {
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  const reader = stream.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      chunks.push(value);
+      total += value.length;
+    }
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.length;
+  }
+  return out;
+}
+
+/** Runs raw bytes through a native `DecompressionStream` of the given format. */
+async function inflate(
+  bytes: Uint8Array,
+  format: "gzip" | "deflate-raw" | "deflate",
+): Promise<Uint8Array> {
+  const ds = new DecompressionStream(format);
+  // `Blob` is available in both the browser and Node ≥18; using it (rather than a
+  // hand-rolled ReadableStream) keeps this portable across both test + runtime.
+  const stream = new Blob([bytes as BlobPart])
+    .stream()
+    .pipeThrough(ds) as unknown as ReadableStream<Uint8Array>;
+  return collectStream(stream);
+}
+
+const utf8 = new TextDecoder();
+
+/**
+ * Decompresses a recognised dataset archive (`gzip` or `zip`) to RDF text plus the
+ * inner member name. `codec` defaults to sniffing the magic number; `name` (the
+ * file/URL name) is used to break gzip's "no inner name" ambiguity (a zip carries its
+ * own member name). Throws a clear, actionable error for an unrecognised / unsupported
+ * payload rather than mis-decoding.
+ */
+export async function decompressArchive(
+  bytes: Uint8Array,
+  name: string,
+  codec?: ArchiveCodec,
+): Promise<DecompressedArchive> {
+  const resolved = codec ?? sniffArchive(bytes);
+  switch (resolved) {
+    case "gzip": {
+      const out = await inflate(bytes, "gzip");
+      return { text: utf8.decode(out), innerName: innerNameForArchive(name) };
+    }
+    case "zip":
+      return unzipFirstRdfMember(bytes);
+    default:
+      throw new Error(
+        "Unrecognised compressed payload: expected a gzip (.gz) or zip (.zip) magic number.",
+      );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Minimal ZIP reader (central-directory based, DEFLATE + STORED only)
+// ---------------------------------------------------------------------------
+
+// ZIP signatures (PKZIP APPNOTE.TXT).
+const EOCD_SIG = 0x06054b50; // End of central directory
+const CDH_SIG = 0x02014b50; // Central directory file header
+const LFH_SIG = 0x04034b50; // Local file header
+const ZIP64_EOCD_LOCATOR_SIG = 0x07064b50;
+
+// RDF file extensions we prefer when an archive holds several members. Ordered by how
+// commonly compressed RDF dumps ship; the FIRST matching member wins.
+const RDF_EXTS = [
+  "nt",
+  "ntriples",
+  "ttl",
+  "turtle",
+  "nq",
+  "nquads",
+  "trig",
+  "jsonld",
+  "json-ld",
+  "rdf",
+  "n3",
+];
+
+interface ZipEntry {
+  name: string;
+  method: number; // 0 = stored, 8 = deflate
+  flags: number;
+  localHeaderOffset: number;
+  compressedSize: number;
+  uncompressedSize: number;
+}
+
+function extOf(name: string): string {
+  return name.split(".").pop()?.toLowerCase() ?? "";
+}
+
+/** A member is a plausible RDF document (by extension), excluding directory entries. */
+function isRdfMember(name: string): boolean {
+  if (name.endsWith("/")) return false; // directory entry
+  return RDF_EXTS.includes(extOf(name));
+}
+
+/** Finds the End Of Central Directory record by scanning backwards for its signature
+ *  (it sits at the very end, after an optional ≤64 kB comment). */
+function findEocd(view: DataView): number {
+  // Minimum EOCD size is 22 bytes; comment can be up to 65535 bytes.
+  const min = 22;
+  const maxBack = Math.min(view.byteLength, min + 0xffff);
+  for (let i = view.byteLength - min; i >= view.byteLength - maxBack; i--) {
+    if (i < 0) break;
+    if (view.getUint32(i, true) === EOCD_SIG) return i;
+  }
+  return -1;
+}
+
+/** Parses the central directory into the list of stored entries. */
+function readCentralDirectory(bytes: Uint8Array): ZipEntry[] {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const eocd = findEocd(view);
+  if (eocd < 0) {
+    throw new Error("Invalid zip: no End Of Central Directory record found.");
+  }
+  // ZIP64 archives put a real CD offset behind a locator; we don't support them.
+  if (eocd >= 20 && view.getUint32(eocd - 20, true) === ZIP64_EOCD_LOCATOR_SIG) {
+    throw new Error("ZIP64 archives are not supported — re-zip without ZIP64.");
+  }
+  const entryCount = view.getUint16(eocd + 10, true);
+  let offset = view.getUint32(eocd + 16, true);
+  const entries: ZipEntry[] = [];
+  for (let i = 0; i < entryCount; i++) {
+    if (
+      offset + 46 > bytes.byteLength ||
+      view.getUint32(offset, true) !== CDH_SIG
+    ) {
+      break; // truncated / malformed central directory — stop with what we have
+    }
+    const flags = view.getUint16(offset + 8, true);
+    const method = view.getUint16(offset + 10, true);
+    const compressedSize = view.getUint32(offset + 20, true);
+    const uncompressedSize = view.getUint32(offset + 24, true);
+    const nameLen = view.getUint16(offset + 28, true);
+    const extraLen = view.getUint16(offset + 30, true);
+    const commentLen = view.getUint16(offset + 32, true);
+    const localHeaderOffset = view.getUint32(offset + 42, true);
+    const nameBytes = bytes.subarray(offset + 46, offset + 46 + nameLen);
+    // ZIP names are CP437 historically but UTF-8 in practice for modern tools; the
+    // language-encoding flag (bit 11) marks UTF-8. We decode UTF-8 either way — RDF
+    // dump member names are ASCII in practice, so this is safe.
+    const name = utf8.decode(nameBytes);
+    entries.push({
+      name,
+      method,
+      flags,
+      localHeaderOffset,
+      compressedSize,
+      uncompressedSize,
+    });
+    offset += 46 + nameLen + extraLen + commentLen;
+  }
+  if (entries.length === 0) {
+    throw new Error("Invalid or empty zip: no entries in the central directory.");
+  }
+  return entries;
+}
+
+/** Reads + decompresses one entry's bytes via its local file header. */
+async function readEntryBytes(
+  bytes: Uint8Array,
+  entry: ZipEntry,
+): Promise<Uint8Array> {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const lfo = entry.localHeaderOffset;
+  if (lfo + 30 > bytes.byteLength || view.getUint32(lfo, true) !== LFH_SIG) {
+    throw new Error(`Invalid zip: bad local header for "${entry.name}".`);
+  }
+  // bit 0 of the general-purpose flag = encrypted.
+  if ((entry.flags & 0x0001) !== 0) {
+    throw new Error(
+      `Encrypted zip member "${entry.name}" is not supported — provide an unencrypted archive.`,
+    );
+  }
+  const nameLen = view.getUint16(lfo + 26, true);
+  const extraLen = view.getUint16(lfo + 28, true);
+  const dataStart = lfo + 30 + nameLen + extraLen;
+  const dataEnd = dataStart + entry.compressedSize;
+  if (dataEnd > bytes.byteLength) {
+    throw new Error(`Invalid zip: member "${entry.name}" data is truncated.`);
+  }
+  const compressed = bytes.subarray(dataStart, dataEnd);
+  switch (entry.method) {
+    case 0: // STORED — copy as-is
+      return compressed.slice();
+    case 8: // DEFLATE — raw deflate stream (no zlib header)
+      return inflate(compressed, "deflate-raw");
+    default:
+      throw new Error(
+        `Unsupported zip compression method ${entry.method} for "${entry.name}" — ` +
+          "only STORED and DEFLATE are supported.",
+      );
+  }
+}
+
+/** Decompresses the first RDF-looking member of a zip archive (or, failing that, the
+ *  single member / first member) to RDF text + that member's name. */
+async function unzipFirstRdfMember(
+  bytes: Uint8Array,
+): Promise<DecompressedArchive> {
+  const entries = readCentralDirectory(bytes);
+  const files = entries.filter((e) => !e.name.endsWith("/"));
+  if (files.length === 0) {
+    throw new Error("Zip contains only directories, no files.");
+  }
+  // Prefer the first RDF-typed member; otherwise fall back to the single/first file
+  // (lets an extensionless dump still load, with the caller guessing the format).
+  const chosen = files.find((e) => isRdfMember(e.name)) ?? files[0];
+  const out = await readEntryBytes(bytes, chosen);
+  return { text: utf8.decode(out), innerName: chosen.name };
+}

--- a/site/test/dataset-archive.test.mjs
+++ b/site/test/dataset-archive.test.mjs
@@ -1,0 +1,256 @@
+// [OPUS-4.8] sq-spita — unit tests for the client-side dataset-archive helpers that let
+// the live SPARQL REPL (and the GUI, when it reuses the controls) load a gzip/zip RDF
+// dataset by upload OR URL, decompressing entirely in the browser tab. These cover the
+// pure, framework-free detection + decompression logic. Fixtures are REAL archives built
+// here from the native CompressionStream / a hand-assembled ZIP — no canned blobs and no
+// extra dependency. Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  sniffArchive,
+  archiveCodecFromName,
+  archiveCodecFromContentType,
+  innerNameForArchive,
+  decompressArchive,
+} from "../src/lib/dataset-archive.ts";
+
+const SAMPLE_NT =
+  '<http://example.org/s> <http://example.org/p> "object value" .\n' +
+  '<http://example.org/s> <http://example.org/q> <http://example.org/o2> .\n';
+
+// --- helpers to build real archive fixtures ---------------------------------
+
+async function collect(stream) {
+  const chunks = [];
+  const reader = stream.getReader();
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) chunks.push(value);
+  }
+  let total = 0;
+  for (const c of chunks) total += c.length;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) {
+    out.set(c, off);
+    off += c.length;
+  }
+  return out;
+}
+
+/** Real gzip bytes for a string via the native CompressionStream. */
+async function gzipBytes(text) {
+  const cs = new CompressionStream("gzip");
+  const stream = new Blob([text]).stream().pipeThrough(cs);
+  return collect(stream);
+}
+
+/** Real raw-deflate bytes (ZIP method 8) for a string. */
+async function deflateRawBytes(text) {
+  const cs = new CompressionStream("deflate-raw");
+  const stream = new Blob([text]).stream().pipeThrough(cs);
+  return collect(stream);
+}
+
+// Minimal single-member ZIP writer (DEFLATE or STORED). Enough to exercise the reader;
+// the real-world archives we load are produced by `zip`/`7z`, which this mirrors.
+import { deflateRawSync } from "node:zlib";
+
+function crc32(buf) {
+  // Standard CRC-32 (poly 0xEDB88320), no node crc32 dependency for portability.
+  let crc = ~0;
+  for (let i = 0; i < buf.length; i++) {
+    crc ^= buf[i];
+    for (let k = 0; k < 8; k++) crc = (crc >>> 1) ^ (0xedb88320 & -(crc & 1));
+  }
+  return (~crc) >>> 0;
+}
+
+function makeZip(members) {
+  // members: [{ name, text, method }]  method 0 = stored, 8 = deflate
+  const enc = new TextEncoder();
+  const localParts = [];
+  const central = [];
+  let offset = 0;
+  for (const m of members) {
+    const nameBytes = enc.encode(m.name);
+    const raw = enc.encode(m.text);
+    const compressed =
+      m.method === 8 ? new Uint8Array(deflateRawSync(raw)) : raw;
+    const crc = crc32(raw);
+    const lfh = new DataView(new ArrayBuffer(30));
+    lfh.setUint32(0, 0x04034b50, true);
+    lfh.setUint16(4, 20, true); // version needed
+    lfh.setUint16(6, 0, true); // flags
+    lfh.setUint16(8, m.method, true);
+    lfh.setUint16(10, 0, true); // time
+    lfh.setUint16(12, 0, true); // date
+    lfh.setUint32(14, crc, true);
+    lfh.setUint32(18, compressed.length, true);
+    lfh.setUint32(22, raw.length, true);
+    lfh.setUint16(26, nameBytes.length, true);
+    lfh.setUint16(28, 0, true); // extra len
+    const localHeaderOffset = offset;
+    localParts.push(new Uint8Array(lfh.buffer), nameBytes, compressed);
+    offset += 30 + nameBytes.length + compressed.length;
+
+    const cdh = new DataView(new ArrayBuffer(46));
+    cdh.setUint32(0, 0x02014b50, true);
+    cdh.setUint16(4, 20, true);
+    cdh.setUint16(6, 20, true);
+    cdh.setUint16(8, 0, true);
+    cdh.setUint16(10, m.method, true);
+    cdh.setUint16(12, 0, true);
+    cdh.setUint16(14, 0, true);
+    cdh.setUint32(16, crc, true);
+    cdh.setUint32(20, compressed.length, true);
+    cdh.setUint32(24, raw.length, true);
+    cdh.setUint16(28, nameBytes.length, true);
+    cdh.setUint16(30, 0, true);
+    cdh.setUint16(32, 0, true);
+    cdh.setUint16(34, 0, true);
+    cdh.setUint16(36, 0, true);
+    cdh.setUint32(38, 0, true);
+    cdh.setUint32(42, localHeaderOffset, true);
+    central.push({ header: new Uint8Array(cdh.buffer), name: nameBytes });
+  }
+  const localBytes = concat(localParts);
+  const cdParts = [];
+  for (const c of central) cdParts.push(c.header, c.name);
+  const cdBytes = concat(cdParts);
+  const eocd = new DataView(new ArrayBuffer(22));
+  eocd.setUint32(0, 0x06054b50, true);
+  eocd.setUint16(8, members.length, true);
+  eocd.setUint16(10, members.length, true);
+  eocd.setUint32(12, cdBytes.length, true);
+  eocd.setUint32(16, localBytes.length, true);
+  eocd.setUint16(20, 0, true);
+  return concat([localBytes, cdBytes, new Uint8Array(eocd.buffer)]);
+}
+
+function concat(arrs) {
+  let total = 0;
+  for (const a of arrs) total += a.length;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const a of arrs) {
+    out.set(a, off);
+    off += a.length;
+  }
+  return out;
+}
+
+// --- detection tests --------------------------------------------------------
+
+test("sniffArchive recognises gzip and zip magic numbers", async () => {
+  const gz = await gzipBytes("x");
+  assert.equal(sniffArchive(gz), "gzip");
+  const zip = makeZip([{ name: "a.nt", text: "x", method: 0 }]);
+  assert.equal(sniffArchive(zip), "zip");
+  // Plain text is not an archive.
+  assert.equal(sniffArchive(new TextEncoder().encode("plain")), undefined);
+  assert.equal(sniffArchive(new Uint8Array([])), undefined);
+});
+
+test("archiveCodecFromName maps archive extensions (incl. query/hash strip)", () => {
+  assert.equal(archiveCodecFromName("dataset.nt.gz"), "gzip");
+  assert.equal(archiveCodecFromName("dump.zip"), "zip");
+  assert.equal(archiveCodecFromName("dump.zip?x=1#frag"), "zip");
+  assert.equal(archiveCodecFromName("data.ttl"), undefined);
+  assert.equal(archiveCodecFromName("data"), undefined);
+});
+
+test("archiveCodecFromContentType handles common server media types", () => {
+  assert.equal(archiveCodecFromContentType("application/gzip"), "gzip");
+  assert.equal(archiveCodecFromContentType("application/x-gzip; charset=x"), "gzip");
+  assert.equal(archiveCodecFromContentType("application/zip"), "zip");
+  assert.equal(archiveCodecFromContentType("text/turtle"), undefined);
+  assert.equal(archiveCodecFromContentType(null), undefined);
+});
+
+test("innerNameForArchive strips the archive suffix for format guessing", () => {
+  assert.equal(innerNameForArchive("dataset.nt.gz"), "dataset.nt");
+  assert.equal(innerNameForArchive("watdiv.ttl.GZ"), "watdiv.ttl");
+  assert.equal(innerNameForArchive("dump.zip"), "dump");
+  assert.equal(innerNameForArchive("dump.zip?download=1"), "dump");
+  // A .tgz holds a tar with no single inner RDF name -> null (force fallback).
+  assert.equal(innerNameForArchive("dump.tgz"), null);
+  // No recognised archive suffix: returned unchanged.
+  assert.equal(innerNameForArchive("data.ttl"), "data.ttl");
+});
+
+// --- decompression tests ----------------------------------------------------
+
+test("decompressArchive round-trips a real gzip payload to text + inner name", async () => {
+  const gz = await gzipBytes(SAMPLE_NT);
+  const { text, innerName } = await decompressArchive(gz, "umbc.nt.gz", "gzip");
+  assert.equal(text, SAMPLE_NT);
+  assert.equal(innerName, "umbc.nt");
+});
+
+test("decompressArchive sniffs the codec when none is passed", async () => {
+  const gz = await gzipBytes(SAMPLE_NT);
+  const { text } = await decompressArchive(gz, "umbc.nt.gz");
+  assert.equal(text, SAMPLE_NT);
+});
+
+test("decompressArchive inflates a DEFLATE zip member and reports its name", async () => {
+  const zip = makeZip([{ name: "watdiv.nt", text: SAMPLE_NT, method: 8 }]);
+  const { text, innerName } = await decompressArchive(zip, "watdiv.zip");
+  assert.equal(text, SAMPLE_NT);
+  assert.equal(innerName, "watdiv.nt");
+});
+
+test("decompressArchive copies a STORED (method 0) zip member", async () => {
+  const zip = makeZip([{ name: "data.ttl", text: SAMPLE_NT, method: 0 }]);
+  const { text, innerName } = await decompressArchive(zip, "data.zip");
+  assert.equal(text, SAMPLE_NT);
+  assert.equal(innerName, "data.ttl");
+});
+
+test("decompressArchive picks the first RDF member from a multi-file zip", async () => {
+  const zip = makeZip([
+    { name: "README.txt", text: "not rdf", method: 8 },
+    { name: "graph.nt", text: SAMPLE_NT, method: 8 },
+  ]);
+  const { text, innerName } = await decompressArchive(zip, "bundle.zip");
+  assert.equal(text, SAMPLE_NT);
+  assert.equal(innerName, "graph.nt");
+});
+
+test("decompressArchive falls back to the first file when no member looks like RDF", async () => {
+  const zip = makeZip([{ name: "dump.dat", text: SAMPLE_NT, method: 0 }]);
+  const { text, innerName } = await decompressArchive(zip, "dump.zip");
+  assert.equal(text, SAMPLE_NT);
+  assert.equal(innerName, "dump.dat");
+});
+
+test("decompressArchive rejects an unrecognised payload with a clear error", async () => {
+  await assert.rejects(
+    () => decompressArchive(new TextEncoder().encode("not compressed"), "x.bin"),
+    /Unrecognised compressed payload/,
+  );
+});
+
+test("decompressArchive rejects an unsupported zip compression method", async () => {
+  // method 12 = bzip2 (not supported by the native DecompressionStream path).
+  const zip = makeZip([{ name: "a.nt", text: SAMPLE_NT, method: 0 }]);
+  // Patch the central-directory + local method bytes to 12 to simulate bzip2.
+  // Local header method @ offset 8; central header is later — patch both occurrences.
+  const patched = zip.slice();
+  const dv = new DataView(patched.buffer);
+  dv.setUint16(8, 12, true); // local file header method
+  // find central dir header signature and patch its method (offset +10)
+  for (let i = 0; i + 4 <= patched.length; i++) {
+    if (dv.getUint32(i, true) === 0x02014b50) {
+      dv.setUint16(i + 10, 12, true);
+      break;
+    }
+  }
+  await assert.rejects(
+    () => decompressArchive(patched, "a.zip"),
+    /Unsupported zip compression method 12/,
+  );
+});


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** working the **site lane**. This PR is for bead **sq-spita** (epic sq-ixc3). Self-identifying per the SPARQ agent contract — @jeswr runs multiple agents on one account.

## What & why

The live SPARQL REPL (`/try`) could only ingest **uncompressed** RDF — both the **Upload** and **From URL** paths read the payload as text. Real-world dataset distributions ship compressed (e.g. a **10M-triple UMBC `.nt.gz` redirect**, a **TIB watdiv `.zip`** — the exact examples in the bead / maintainer #983), so they could not be loaded without a separate manual decompress step.

This adds **client-side gzip/zip decompression** so a compressed dataset loads transparently by **upload OR URL**, entirely in the browser tab (no server — keeps the static-export model intact).

## Changes

- **`site/src/lib/dataset-archive.ts`** (new) — a pure, framework-free, **dependency-free** decompressor:
  - **gzip** (`.gz`) via the **native `DecompressionStream("gzip")`**. Single-member only (browsers truncate multi-member gzip — documented), which is what real RDF `.gz` dumps are.
  - **zip** (`.zip`) via a minimal **central-directory reader** that inflates the first RDF-looking member with the native **`DecompressionStream("deflate-raw")`** (DEFLATE, method 8) or copies a STORED member (method 0). **No JSZip / pako** dependency (would add ~45–95 kB for a feature a browser-native API already serves).
  - magic-number + extension + `Content-Type` detection; **ZIP64 / encrypted / unsupported-method** archives are rejected with a clear, actionable message rather than mis-decoded.
- **`site/src/components/repl-datasets.tsx`** — wire **both** the Upload and From-URL paths to read **bytes**, transparently decompress an archive, then derive the RDF format from the **inner (decompressed) member name** (`data.nt.gz` → `nt`; a zip member's own name). The URL dialog now defaults to **Auto-detect** (so a compressed URL works out of the box) and a failed upload surfaces inline. `accept=` updated for `.gz`/`.zip` (incl. compound `.ttl.gz`).
- **`site/test/dataset-archive.test.mjs`** (new) — 12 unit tests over **real** gzip/zip fixtures (native `CompressionStream` + a hand-assembled ZIP), covering detection, gzip round-trip, DEFLATE + STORED members, multi-member RDF selection, and the rejection paths.

`DatasetControls` is the GUI's import surface too (the Tauri GUI reuses the site components), so this covers **both the web UI and the GUI**.

### Decision (documented per the standing rule)
- **Scope**: gzip + zip only. zstd/bzip2 are deliberately out of scope (the bead names gzip/zip); the JS package's `decompress.ts` already covers zstd for the engine ingest path. Flagged in a tracking issue for the maintainer to steer if broader codec coverage is wanted.
- **No new dependency** — native Compression Streams API. Bundle-size impact: ~0 (the `/try` route's first-load JS is unchanged in the build report; the new lib is a small dynamic part of that route's chunk).

## Gates (green)
- WASM prereq built first: `cd js && npm run build:wasm` (build artifact only, no `crates/` changes).
- `cd site && npm install && npm run build` — static export green **end-to-end**, all 50 routes emitted (incl. `/try`); existing routes (`/`, `/benchmarks/*`, `/papers`, `/showcase/*`, `/surface/*`) unaffected; `basePath` (`/sparq`) preserved.
- `npm run lint` clean; build typecheck passes (no `any`-escape hatches).
- `npm run test:unit` — **272/272** pass (incl. the 12 new archive tests).
- `check-privacy-claims.sh` OK; no ZK/MPC copy touched; no hard-coded perf numbers; typos gate clean.
- Did **not** stage the build-regenerated `benchmarks.generated.json` (work-box / non-canonical) — only the three real source files.

## Not covered / deferred
- zstd / bzip2 archives (see decision above).
- Streaming decompress of multi-GB archives (current path buffers in memory — fine for the cited UMBC/watdiv sizes; a streamed-into-wasm ingest is a separate engine concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)