### PR TITLE
feat(site/js): packaged `Dataset` RDF/JS DatasetCore ESM entry, lazily wasm-init (sq-lii76) [OPUS-4.8]

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -159,6 +159,51 @@ for (const r of report.results) {
 store.free(); // release wasm memory (also `using store = …` via Symbol.dispose)
 ```
 
+### `Dataset` — the RDF/JS `DatasetCore` entry, importable from a `<script type="module">`
+
+For an RDF/JS-`DatasetCore`-shaped surface (rather than the SPARQL-first
+`SparqStore`), import the named **`Dataset`** export. It is a thin wrapper over
+`SparqStore` exposing the four `DatasetCore` members (`add` / `delete` / `has` /
+`match`) plus `size` and `[Symbol.iterator]`, with the **full SPARQL surface one
+accessor away** (`dataset.store`). Because `DatasetCore`'s instance methods are
+synchronous, you obtain an instance through an **async factory** —
+`Dataset.create()` / `Dataset.fromString()` / `Dataset.fromQuads()` — each of
+which `await`s the wasm engine first. That is the lazy-load point: the
+~MB `.wasm` is fetched on the first `await Dataset.…`, never on import, and the
+cold start is paid at most once per page.
+
+This is what makes the GitHub-issue ESM snippet (#981) work — you can import the
+name directly in a browser `<script type="module">` from any ESM CDN, and the
+engine streams in only when you first build a dataset:
+
+```html
+<script type="module">
+  // From an ESM CDN (or a bundler import) — the ~MB wasm is lazily fetched by
+  // the first `Dataset.fromString(...)`, not by the import below.
+  import { Dataset, DataFactory as DF } from "https://esm.sh/@jeswr/sparq";
+
+  const ds = await Dataset.fromString(
+    "<http://ex/a> <http://ex/name> \"Alice\" .",
+    "ntriples",
+  );
+  console.log(ds.size); // 1
+
+  ds.add(DF.quad(DF.namedNode("http://ex/b"), DF.namedNode("http://ex/name"), DF.literal("Bob")));
+  for (const q of ds.match(null, DF.namedNode("http://ex/name"), null)) {
+    console.log(q.subject.value, q.object.value);
+  }
+
+  // Drop to the SPARQL engine when DatasetCore is not enough:
+  console.log(ds.store.queryBoolean("ASK { ?s ?p ?o }")); // true
+  ds.free();
+</script>
+```
+
+If you only need the low-level engine handle, the wasm-pack `--target web` glue
+is itself a real ESM module — `import init, { Store } from ".../wasm/sparq_wasm.js";
+await init();` — but `Dataset` (and `SparqStore`) is the ergonomic, memoised-init
+entry to prefer in an app.
+
 ### Talking to a sparq server: dictionary-fetch protocol
 
 Sparq servers compress small SPARQL responses with shared zstd *vocabulary

--- a/js/src/dataset.ts
+++ b/js/src/dataset.ts
@@ -1,0 +1,165 @@
+/**
+ * [OPUS-4.8] sq-lii76 (#981) — `Dataset`: a small RDF/JS **`DatasetCore`** surface over the
+ * sparq wasm engine, so the import the issue's `<script type="module">` snippet uses by name —
+ *
+ *     import { Dataset } from "https://esm.sh/@jeswr/sparq"
+ *
+ * — resolves to a real, spec-shaped entry, not just the low-level `Store` class. It is a thin
+ * wrapper over {@link SparqStore} (which already wraps the engine), adding nothing the engine
+ * does not already do: it exposes the four RDF/JS `DatasetCore` members (`add` / `delete` /
+ * `has` / `match`), the `size` getter and `[Symbol.iterator]`, each mapped onto the store's
+ * existing quad-level delta / `match` / count bindings.
+ *
+ * LAZY WASM INIT (the #981 posture). `DatasetCore`'s instance methods are SYNCHRONOUS by the
+ * RDF/JS spec, so the wasm must already be instantiated by the time an instance exists. The
+ * `Dataset` constructor is therefore PRIVATE; you obtain one through the async factories
+ * {@link Dataset.create} / {@link Dataset.fromString} / {@link Dataset.fromQuads}, each of
+ * which `await`s the engine's (memoised) `init()` FIRST. Until you call one of them the
+ * ~MB wasm binary is never fetched — so a `<script type="module">` that merely imports the
+ * name pays nothing, and the engine streams in only on the first `await Dataset.create(...)`.
+ * The cold start is paid at most once across the whole page (the underlying `init()` is
+ * memoised), so two datasets created in the same tab share one engine instance.
+ *
+ * This is a SUPERSET-by-reference, not a fork: a `Dataset` exposes its backing
+ * {@link Dataset.store} so the full SPARQL surface (`queryBindings`, `update`,
+ * `queryQuads`, SHACL `validate`, streaming cursors, …) stays one accessor away — `Dataset`
+ * is the RDF/JS-`DatasetCore` ergonomic entry, `SparqStore` is the SPARQL engine handle.
+ */
+import type * as RDF from '@rdfjs/types';
+import { SparqStore, type RdfFormat, type SparqStoreOptions } from './store.js';
+
+/** RDF/JS `match()` term position: a concrete term, or `null`/`undefined` for a wildcard. */
+type MatchTerm = RDF.Term | null | undefined;
+
+/**
+ * An RDF/JS **`DatasetCore`** backed by the sparq wasm engine. Construct via the async
+ * factories ({@link Dataset.create} / {@link Dataset.fromString} / {@link Dataset.fromQuads}),
+ * which lazily instantiate the wasm engine on first use; thereafter the `DatasetCore` members
+ * are synchronous per the spec. Mutations (`add` / `delete`) go through the engine's O(batch)
+ * delta overlay — no index rebuild.
+ */
+export class Dataset implements RDF.DatasetCore {
+  readonly #store: SparqStore;
+
+  private constructor(store: SparqStore) {
+    this.#store = store;
+  }
+
+  /**
+   * An EMPTY dataset. Awaits the (memoised) wasm `init()` first — this is the lazy-load
+   * point: the engine binary is fetched here, not when the module is imported. `options`
+   * are forwarded to {@link SparqStore.fromString} (e.g. `{ dataset: true }` to keep named
+   * graphs addressable; the default folds them into the default graph).
+   */
+  static async create(options: SparqStoreOptions = {}): Promise<Dataset> {
+    return new Dataset(await SparqStore.fromString('', 'ntriples', options));
+  }
+
+  /**
+   * Parses an RDF document into a dataset (lazily instantiating the wasm engine first).
+   * `format` and `options` mirror {@link SparqStore.fromString} — pass `{ dataset: true }`
+   * to preserve named graphs from N-Quads / TriG / a JSON-LD `@graph`.
+   */
+  static async fromString(
+    data: string,
+    format: RdfFormat = 'turtle',
+    options: SparqStoreOptions = {},
+  ): Promise<Dataset> {
+    return new Dataset(await SparqStore.fromString(data, format, options));
+  }
+
+  /**
+   * Builds a dataset from RDF/JS quads (lazily instantiating the wasm engine first). With
+   * `{ dataset: true }` each quad's graph is preserved; otherwise all quads land in the
+   * default graph.
+   */
+  static async fromQuads(
+    quads: Iterable<RDF.Quad>,
+    options: SparqStoreOptions = {},
+  ): Promise<Dataset> {
+    return new Dataset(await SparqStore.fromQuads(quads, options));
+  }
+
+  /**
+   * The backing {@link SparqStore} — the full SPARQL engine surface (`queryBindings`,
+   * `update`, `queryQuads`, SHACL `validate`, streaming cursors, …) for when `DatasetCore`'s
+   * four members are not enough. The `Dataset` and its store share one wasm handle.
+   */
+  get store(): SparqStore {
+    return this.#store;
+  }
+
+  /**
+   * The number of quads across the default graph AND every named graph (RDF/JS
+   * `DatasetCore.size` spans the whole dataset). Computed via a `COUNT(*)` over a
+   * graph-spanning pattern so a dataset loaded with `{ dataset: true }` reports its named
+   * graphs too (the store's plain `size` counts the default graph only).
+   */
+  get size(): number {
+    return this.#store.countQuads(null, null, null, null);
+  }
+
+  /**
+   * Adds a quad through the engine's O(batch) delta overlay (idempotent — the store is a
+   * set, so re-adding an existing quad is a no-op). Returns `this` per the RDF/JS spec.
+   */
+  add(quad: RDF.Quad): this {
+    this.#store.addQuads([quad]);
+    return this;
+  }
+
+  /**
+   * Removes a quad through the engine's O(batch) delta overlay (a no-op if absent). Returns
+   * `this` per the RDF/JS spec.
+   */
+  delete(quad: RDF.Quad): this {
+    this.#store.removeQuads([quad]);
+    return this;
+  }
+
+  /** Whether the dataset contains `quad` (graph-aware). */
+  has(quad: RDF.Quad): boolean {
+    return (
+      this.#store.countQuads(quad.subject, quad.predicate, quad.object, quad.graph) > 0
+    );
+  }
+
+  /**
+   * Returns a NEW {@link Dataset} with the quads matching the given term pattern
+   * (`null`/`undefined` positions are wildcards; the graph wildcard spans the default graph
+   * and every named graph), per RDF/JS `DatasetCore.match`. The result is an independent
+   * dataset (its own engine handle); mutating it does not affect this one. Always preserves
+   * named graphs so a graph-spanning match round-trips faithfully.
+   */
+  match(
+    subject?: MatchTerm,
+    predicate?: MatchTerm,
+    object?: MatchTerm,
+    graph?: MatchTerm,
+  ): Dataset {
+    const quads = this.#store.match(subject, predicate, object, graph);
+    // `match()` is synchronous per the RDF/JS spec, and the wasm engine is already
+    // initialised by the time any Dataset instance exists (the async factories awaited
+    // `init()`), so the SYNC `fromQuadsSync` is safe here — it never re-fetches the engine.
+    return new Dataset(SparqStore.fromQuadsSync(quads, { dataset: true }));
+  }
+
+  /**
+   * Iterates every quad across the default graph and all named graphs. The materialised
+   * array is built once via the store's graph-spanning `match()`; for a very large dataset
+   * prefer the backing {@link store}'s streaming surface (`queryQuadsStream` /
+   * `queryBindingsStream`) instead.
+   */
+  [Symbol.iterator](): Iterator<RDF.Quad> {
+    return this.#store.match(null, null, null, null)[Symbol.iterator]();
+  }
+
+  /** Releases the wasm-side memory. The dataset must not be used afterwards. */
+  free(): void {
+    this.#store.free();
+  }
+
+  [Symbol.dispose](): void {
+    this.free();
+  }
+}

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -5,6 +5,9 @@ export {
   type ValidationReport,
   type ValidationResult,
 } from './store.js';
+// [OPUS-4.8] sq-lii76 (#981) — the RDF/JS `DatasetCore` entry the ESM `<script type=module>`
+// snippet imports by name (`import { Dataset } from "..."`), lazily instantiating the wasm.
+export { Dataset } from './dataset.js';
 export { Bindings } from './bindings.js';
 export { DataFactory, NamedNode, BlankNode, Literal, Variable, DefaultGraph, Quad } from './terms.js';
 export {

--- a/js/src/store.ts
+++ b/js/src/store.ts
@@ -122,6 +122,34 @@ export class SparqStore {
     return new SparqStore(inner);
   }
 
+  /**
+   * [OPUS-4.8] sq-lii76: parses an RDF document into a store SYNCHRONOUSLY — the same as
+   * {@link fromString} but WITHOUT the `await init()`. The wasm engine must ALREADY be
+   * initialised (a prior `await init()` / `await SparqStore.fromString(...)` has resolved),
+   * otherwise the wasm binding throws. This is the building block for the synchronous RDF/JS
+   * `DatasetCore` members ({@link Dataset.match}), where the engine is guaranteed already up;
+   * prefer the async {@link fromString} for first construction.
+   */
+  static fromStringSync(data: string, format: RdfFormat = 'turtle', options: SparqStoreOptions = {}): SparqStore {
+    if (options.dataset && options.compressed) {
+      throw new Error('options.dataset cannot be combined with options.compressed (no compressed dataset loader yet)');
+    }
+    const inner = options.dataset
+      ? WasmStore.loadDataset(data, format)
+      : options.compressed
+        ? WasmStore.loadCompressed(data, format)
+        : WasmStore.load(data, format);
+    return new SparqStore(inner);
+  }
+
+  /**
+   * [OPUS-4.8] sq-lii76: builds a store from RDF/JS quads SYNCHRONOUSLY (see
+   * {@link fromStringSync} — the wasm engine must already be initialised).
+   */
+  static fromQuadsSync(quads: Iterable<RDF.Quad>, options: SparqStoreOptions = {}): SparqStore {
+    return SparqStore.fromStringSync(quadsToNQuads(quads), 'nquads', options);
+  }
+
   /** Builds a store from RDF/JS quads (serialised internally to N-Quads). */
   static async fromQuads(quads: Iterable<RDF.Quad>, options: SparqStoreOptions = {}): Promise<SparqStore> {
     return SparqStore.fromString(quadsToNQuads(quads), 'nquads', options);

--- a/js/test/dataset.test.mjs
+++ b/js/test/dataset.test.mjs
@@ -1,0 +1,83 @@
+// [OPUS-4.8] sq-lii76 (#981) — the `Dataset` RDF/JS `DatasetCore` surface (the named ESM
+// entry the `<script type="module">` snippet imports), exercised against the built dist/.
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { Dataset, DataFactory as DF } from '../dist/index.js';
+
+const TTL = `@prefix ex: <http://ex/> .
+ex:alice ex:name "Alice" ; ex:knows ex:bob .
+ex:bob ex:name "Bob" .`;
+
+test('Dataset.fromString loads quads; size spans the graph', async () => {
+  const ds = await Dataset.fromString(TTL, 'turtle');
+  assert.equal(ds.size, 3);
+  ds.free();
+});
+
+test('Dataset.create is empty and accepts add/delete (DatasetCore)', async () => {
+  const ds = await Dataset.create();
+  assert.equal(ds.size, 0);
+  const q = DF.quad(DF.namedNode('http://ex/s'), DF.namedNode('http://ex/p'), DF.literal('o'));
+  const ret = ds.add(q);
+  assert.equal(ret, ds, 'add() returns this');
+  assert.equal(ds.size, 1);
+  assert.ok(ds.has(q));
+  ds.add(q); // idempotent — store is a set
+  assert.equal(ds.size, 1);
+  ds.delete(q);
+  assert.equal(ds.size, 0);
+  assert.ok(!ds.has(q));
+  ds.free();
+});
+
+test('Dataset.match returns a new, independent DatasetCore', async () => {
+  const ds = await Dataset.fromString(TTL, 'turtle');
+  const names = ds.match(null, DF.namedNode('http://ex/name'), null);
+  assert.equal(names.size, 2);
+  // The original is untouched; the match result is a distinct dataset.
+  assert.equal(ds.size, 3);
+  assert.notEqual(names, ds);
+  // Mutating the match result does not affect the source.
+  names.delete(
+    DF.quad(DF.namedNode('http://ex/alice'), DF.namedNode('http://ex/name'), DF.literal('Alice')),
+  );
+  assert.equal(names.size, 1);
+  assert.equal(ds.size, 3);
+  ds.free();
+  names.free();
+});
+
+test('Dataset is iterable (Symbol.iterator yields every quad)', async () => {
+  const ds = await Dataset.fromString(TTL, 'turtle');
+  const quads = [...ds];
+  assert.equal(quads.length, 3);
+  for (const q of quads) {
+    assert.ok(q.subject && q.predicate && q.object, 'each is a quad');
+  }
+  ds.free();
+});
+
+test('Dataset.fromQuads round-trips RDF/JS quads', async () => {
+  const q = DF.quad(DF.namedNode('http://ex/s'), DF.namedNode('http://ex/p'), DF.namedNode('http://ex/o'));
+  const ds = await Dataset.fromQuads([q]);
+  assert.equal(ds.size, 1);
+  assert.ok(ds.has(q));
+  ds.free();
+});
+
+test('Dataset.store exposes the full SPARQL surface', async () => {
+  const ds = await Dataset.fromString(TTL, 'turtle');
+  const rows = ds.store.queryBindings('PREFIX ex: <http://ex/> SELECT ?n WHERE { ?s ex:name ?n }');
+  assert.equal(rows.length, 2);
+  ds.free();
+});
+
+test('Dataset preserves named graphs with { dataset: true }', async () => {
+  const nq = '<http://ex/s> <http://ex/p> <http://ex/o> <http://ex/g> .';
+  const ds = await Dataset.fromString(nq, 'nquads', { dataset: true });
+  assert.equal(ds.size, 1);
+  const inG = ds.match(null, null, null, DF.namedNode('http://ex/g'));
+  assert.equal(inG.size, 1);
+  ds.free();
+  inG.free();
+});

--- a/site/src/app/surface/javascript-wasm/esm-import-snippet.tsx
+++ b/site/src/app/surface/javascript-wasm/esm-import-snippet.tsx
@@ -1,0 +1,85 @@
+// [OPUS-4.8] sq-lii76 (#981) — the `<script type="module">` ESM-import recipe for the named
+// `Dataset` entry. A static (server-rendered) doc card: it shows that the same RDF/JS surface
+// the live demo above exercises can be imported by NAME into a bare HTML page from an ESM CDN,
+// with the ~MB wasm fetched LAZILY by the first `await Dataset.…` (not by the import line).
+// This is the literal snippet shape the maintainer's issue asked for.
+
+import { FileCode2 } from "lucide-react";
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+const SNIPPET = `<script type="module">
+  // From any ESM CDN (or a bundler import). The ~MB engine wasm is fetched
+  // LAZILY by the first \`await Dataset.fromString(...)\` below — NOT by this
+  // import — so it never blocks the page paint.
+  import { Dataset, DataFactory as DF } from "https://esm.sh/@jeswr/sparq";
+
+  const ds = await Dataset.fromString(
+    '<http://ex/a> <http://ex/name> "Alice" .',
+    "ntriples",
+  );
+  console.log(ds.size); // 1  (DatasetCore: size, add, delete, has, match, iterate)
+
+  ds.add(DF.quad(
+    DF.namedNode("http://ex/b"), DF.namedNode("http://ex/name"), DF.literal("Bob"),
+  ));
+  for (const q of ds.match(null, DF.namedNode("http://ex/name"), null)) {
+    console.log(q.subject.value, "→", q.object.value);
+  }
+
+  // Drop to the full SPARQL engine when DatasetCore is not enough:
+  console.log(ds.store.queryBoolean("ASK { ?s ?p ?o }")); // true
+  ds.free();
+</script>`;
+
+const GLUE_SNIPPET = `<script type="module">
+  // Low-level: the wasm-pack \`--target web\` glue is itself a real ESM module.
+  import init, { Store } from "https://jeswr.github.io/sparq/wasm/sparq_wasm.js";
+  await init(); // lazily fetches + instantiates sparq_wasm_bg.wasm
+  const store = Store.load("<a> <b> <c> .", "ntriples");
+</script>`;
+
+export function EsmImportSnippet() {
+  return (
+    <Card>
+      <CardHeader className="flex-row items-start gap-2 space-y-0">
+        <FileCode2 className="mt-0.5 size-5 text-primary" aria-hidden="true" />
+        <div>
+          <CardTitle className="text-base">
+            Import <code className="font-mono">Dataset</code> from a{" "}
+            <code className="font-mono">&lt;script type=&quot;module&quot;&gt;</code>
+          </CardTitle>
+          <CardDescription>
+            The named <code className="font-mono">Dataset</code> export is an RDF/JS{" "}
+            <code className="font-mono">DatasetCore</code> over the engine — importable
+            directly in a browser module script from any ESM CDN. The async factories
+            (<code className="font-mono">Dataset.fromString</code> /{" "}
+            <code className="font-mono">.create</code> /{" "}
+            <code className="font-mono">.fromQuads</code>) instantiate the wasm engine on
+            first use, so the ~MB binary loads lazily — never on import.
+          </CardDescription>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
+          {SNIPPET}
+        </pre>
+        <p className="text-sm text-muted-foreground">
+          Prefer <code className="font-mono">Dataset</code> (or{" "}
+          <code className="font-mono">SparqStore</code>) in an app — the cold start is
+          memoised, so it is paid at most once per page. The lower-level engine handle is
+          also importable: the wasm-pack glue is itself an ESM module.
+        </p>
+        <pre className="overflow-x-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
+          {GLUE_SNIPPET}
+        </pre>
+      </CardContent>
+    </Card>
+  );
+}

--- a/site/src/app/surface/javascript-wasm/page.tsx
+++ b/site/src/app/surface/javascript-wasm/page.tsx
@@ -3,11 +3,12 @@ import { Boxes } from "lucide-react";
 
 import { SurfaceContent } from "@/components/surface-content";
 import { JavascriptWasmDemo } from "@/components/javascript-wasm-demo";
+import { EsmImportSnippet } from "./esm-import-snippet";
 
 export const metadata: Metadata = {
   title: "JavaScript / WASM",
   description:
-    "Use the sparq engine from JavaScript/TypeScript via @jeswr/sparq — an idiomatic RDF/JS surface over the ~886 KB WebAssembly build, in Node or the browser.",
+    "Use the sparq engine from JavaScript/TypeScript via @jeswr/sparq — an idiomatic RDF/JS surface (SparqStore + a named Dataset DatasetCore entry, importable from a <script type=module>) over the ~886 KB WebAssembly build, in Node or the browser.",
 };
 
 export default function JavascriptWasmSurfacePage() {
@@ -38,12 +39,31 @@ export default function JavascriptWasmSurfacePage() {
             materialisation. The panels below call the API directly against one seeded
             store, in your tab.
           </p>
+          <p>
+            For an RDF/JS{" "}
+            <a className="text-primary underline-offset-4 hover:underline" href="https://rdf.js.org/dataset-spec/" target="_blank" rel="noopener noreferrer">
+              <code className="font-mono">DatasetCore</code>
+            </a>{" "}
+            surface, the package exports a named{" "}
+            <code className="font-mono">Dataset</code> — importable directly in a{" "}
+            <code className="font-mono">&lt;script type=&quot;module&quot;&gt;</code> from
+            any ESM CDN. Its async factories (
+            <code className="font-mono">Dataset.fromString</code> /{" "}
+            <code className="font-mono">.create</code> /{" "}
+            <code className="font-mono">.fromQuads</code>) instantiate the wasm engine on
+            first use, so the ~MB binary loads lazily — never on import (see the snippet
+            below).
+          </p>
         </>
       }
       capabilities={[
         {
           title: "SparqStore (RDF/JS)",
           body: "fromString / fromCompressed, query() yielding Map-like Bindings, idiomatic terms.",
+        },
+        {
+          title: "Dataset — RDF/JS DatasetCore",
+          body: "Named ESM entry: add / delete / has / match / size / iterate, lazily wasm-initialised; .store drops to the full SPARQL surface.",
         },
         {
           title: "Streaming cursors",
@@ -109,6 +129,7 @@ export default function JavascriptWasmSurfacePage() {
       ]}
     >
       <JavascriptWasmDemo />
+      <EsmImportSnippet />
     </SurfaceContent>
   );
 }


### PR DESCRIPTION
> 🤖 **SPARQ agent** — site lane. Self-identifying: this PR was prepared by an automated SPARQ agent on @jeswr's account.

Closes the remaining half of **#981** (split out of sq-4296 as **sq-lii76**): make the issue's snippet `import { Dataset } from "..."` resolve to a real, stable, **named** ESM entry — not just the low-level `Store` glue — while keeping the ~MB wasm off the critical path (lazy on first use).

## What changed

**`@jeswr/sparq` — new `Dataset` export** (`js/src/dataset.ts`)
- A thin RDF/JS **`DatasetCore`** over the existing `SparqStore`: the four spec members (`add` / `delete` / `has` / `match`) plus `size` and `[Symbol.iterator]`, each mapped onto the engine's existing quad-level delta / `match` / count bindings. No engine re-implementation — `dataset.store` exposes the full SPARQL surface (`queryBindings`, `update`, `queryQuads`, SHACL `validate`, streaming cursors) one accessor away.
- **Lazy-init posture preserved (#981).** `DatasetCore`'s instance methods are synchronous per spec, so the constructor is private and instances come from **async factories** — `Dataset.create()` / `Dataset.fromString()` / `Dataset.fromQuads()` — each of which `await`s the engine's **memoised** `init()` first. The wasm binary is fetched on the first `await Dataset.…`, **never on import**; the cold start is paid at most once per page (two datasets share one engine instance).
- `SparqStore.fromStringSync` / `fromQuadsSync` added (used by the synchronous `Dataset.match()`; documented to require an already-initialised engine).

**Site `/surface/javascript-wasm`**
- Documents the named `Dataset` entry (intro paragraph + a "Dataset — RDF/JS DatasetCore" capability), and adds a static, server-rendered `<script type="module">` recipe card (`esm-import-snippet.tsx`) that shows importing `{ Dataset }` from an ESM CDN with the lazy wasm load, plus the lower-level `Store`-glue form.

**`js/README.md`** — a new ESM `<script type=module>` section for `Dataset`.

## Design decision (documented per the standing rule)

The bead offered "a thin `@jeswr/sparq` ESM wrapper **or** a documented re-export". I implemented the wrapper because it gives the issue's snippet a literal, importable `Dataset` name with a spec-shaped surface, and the package is the natural home for an RDF/JS surface. I scoped it as a **DatasetCore** (not the full mutating-`Dataset` algebra) to stay thin over the engine; the full SPARQL surface remains reachable via `dataset.store`. A short issue flagging this for the maintainer to steer is referenced in the bead note.

> Note: this touches `js/` (the JS/WASM binding package) in addition to `site/`. `js/` is the JS package that owns the RDF/JS surface the issue imports — no `crates/` engine source is touched.

## Gates (green)

- WASM prereq built: `cd js && npm run build:wasm` (build artifact only — no `crates/` source change).
- `cd site && npm install && npm run build` — static export succeeds end-to-end; `/surface/javascript-wasm` emits to `out/` with the snippet in the HTML and the wasm bundle in `out/wasm/`. `basePath` `/sparq` preserved.
- `npm run lint` clean; `tsc --noEmit` clean (no `any`-escape hatches).
- `js`: `tsc` + conformance typecheck clean; `node --test test/dataset.test.mjs` → **7/7 pass**; `check:package` (publishable + git-pin-installable) and `@sparq/client` `check:wasm-types` (generated `Store` surface unchanged) pass. (Pre-existing `solid-differential.test.mjs` failure is environment-only — it imports `n3`/`rdflib`/`@solid/*` which are not in the workspace deps; unrelated to this change.)
- `check-privacy-claims.sh` clean; no flagged typos; `check-readme-template.py` clean.
- **No new dependencies**; bundle-size impact: `Dataset` is a small TS wrapper (the `/surface/javascript-wasm` route grew slightly for the static snippet card; no JS shipped to the client for it).

## Covered vs deferred
- Covered: named `Dataset` ESM entry, lazy wasm init, `<script type=module>` docs (README + site), DatasetCore tests.
- Deferred: the full RDF/JS `Dataset` algebra (`union`/`intersection`/`map`/`filter`/`forEach`/`import`/`toStream`/…) beyond `DatasetCore` — reachable today via `dataset.store`'s SPARQL surface; can follow up if the maintainer wants the full interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)