### PR TITLE
feat(gui): Import drawer — real disk/URL/paste ingest via the native loader (sq-ixc3.13) [OPUS-4.8]

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -6,10 +6,11 @@ epic `sq-ixc3`). It is a **DISTINCT app, not the marketing site in a window**: a
 workbench (left rail · thin top bar · IDE tab strip · status bar) over a live engine, where the
 showcase capabilities are TOOLS you run, not pages that describe them.
 
-> **Foundation shell.** This PR stands up the distinct frontend + app shell with a working Query
-> tool over the live in-tab engine; the other TOOLS open as honest stubs the later phases fill
-> (Cmd-K palette `sq-ixc3.10`, the multi-view query workbench `sq-ixc3.12`, the import drawer
-> `sq-ixc3.13`, surfaces-as-tools `sq-ixc3.11`). The full per-platform desktop `cargo tauri build`
+> **Foundation shell.** The distinct frontend + app shell stands up a working Query tool over the
+> live in-tab engine, the Cmd-K palette (`sq-ixc3.10`), the multi-view query workbench
+> (`sq-ixc3.12`), surfaces-as-tools (`sq-ixc3.11`), and the **Import drawer** (`sq-ixc3.13` — real
+> disk/URL/paste ingest via the native loader); the remaining TOOLS open as honest stubs the later
+> phases fill. The full per-platform desktop `cargo tauri build`
 > needs the webview **system libraries** (webkit2gtk on Linux, WebView2 on Windows, WKWebView on
 > macOS) validated in CI ([`.github/workflows/gui.yml`](../.github/workflows/gui.yml)), not
 > necessarily on every dev box.
@@ -61,7 +62,8 @@ gui/
     src/
       main.rs           # desktop binary -> sparq_gui_lib::run()
       lib.rs            # Tauri builder: manages EngineState, registers the command handlers
-      engine.rs         # the DIRECT native engine link: load/query/queryQuads/update/explain/count/ask
+      engine.rs         # the DIRECT native engine link: load/query/.../ask + the Import drawer's
+                        #   native loader (load_path/load_text: compressed + native-only HDT)
 ```
 
 ## The app shell (sq-ixc3.9)
@@ -70,8 +72,9 @@ gui/
 
 - **Left rail** (`w-56`): a workspace switcher (the persistent model is `sq-atb0`; foundation =
   default), a **datasets tree of the live store** (default + named graphs with per-graph counts)
-  with an `+ Import` entry point, and the **TOOLS** list — each a VERB opened as a tab with an
-  honesty-tier dot, never a page describing the feature.
+  with an **Imports** subgroup (the active workspace's `WorkspaceSourceMeta` — file + re-fetchable
+  URL sources) and a working `+ Import` entry point (opens the Import drawer), and the **TOOLS**
+  list — each a VERB opened as a tab with an honesty-tier dot, never a page describing the feature.
 - **Top bar** (`h-10`): a LOCAL⇄ENDPOINT target switch, the store size, a ⌘K hint, a theme toggle,
   and an engine status LED.
 - **IDE tab strip** + a full-bleed work area (default = Query).
@@ -84,9 +87,18 @@ gui/
 `sparq_core::Graph` behind a `Mutex`, with Tauri commands that mirror the wasm `Store` surface
 (`load` / `query` / `query_quads` / `update_in_place` / `explain` / `explain_analyze` / `count` /
 `ask` / `store_size`) but backed by the full native store. Its `#[cfg(test)]` tests exercise the
-engine calls directly. The foundation frontend runs the in-tab WASM engine in BOTH targets (the
-honest, working-today path); swapping the desktop target onto this IPC command layer is a later
-phase (`sq-ixc3.6`).
+engine calls directly. The foundation frontend runs the in-tab WASM engine in BOTH targets for
+**query** (the honest, working-today path).
+
+For **ingest**, the Import drawer (`sq-ixc3.13`) calls the engine's **native loader** IPC
+(`load_path` / `load_text`) when running in the desktop shell: a disk file — including
+**compressed** (`.gz` / `.bz2` / `.zst`) streams and **native-only HDT** (`.hdt` / `.hdt.gz`,
+behind the crate's opt-in `hdt` feature) — is decoded by the native engine (threads, no ~2 GiB
+wasm-tab ceiling) and handed back as N-Quads for the in-tab store to merge (named-graph-
+preserving). On the hosted web target, the drawer's paste/URL tabs parse in the in-tab WASM
+engine instead (no compressed-file / HDT path — the drawer says so). A successful import records a
+`WorkspaceSourceMeta` + a workspace snapshot (the `sq-atb0` save/open cache). The full on-disk
+workspace persistence path activates once the shell grants the `fs` capability (`sq-ixc3.6`).
 
 ## Shared TS client
 

--- a/gui/app/src/app/layout.tsx
+++ b/gui/app/src/app/layout.tsx
@@ -4,6 +4,7 @@ import { Inter } from "next/font/google";
 import "./globals.css";
 import { ThemeProvider } from "@/components/theme-provider";
 import { EngineProvider } from "@/lib/engine-context";
+import { WorkspaceProvider } from "@/lib/workspace-context";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -38,8 +39,12 @@ export default function RootLayout({
           enableSystem
           disableTransitionOnChange
         >
-          {/* The engine context provides the ONE live store the whole workbench shares. */}
-          <EngineProvider>{children}</EngineProvider>
+          {/* The engine context provides the ONE live store the whole workbench shares; the
+              workspace context tracks the active workspace's imported sources + persists the
+              save/open snapshot (sq-atb0) the Import drawer (sq-ixc3.13) writes on each import. */}
+          <EngineProvider>
+            <WorkspaceProvider>{children}</WorkspaceProvider>
+          </EngineProvider>
         </ThemeProvider>
       </body>
     </html>

--- a/gui/app/src/components/workbench/import-drawer.tsx
+++ b/gui/app/src/components/workbench/import-drawer.tsx
@@ -1,0 +1,603 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.13 (epic sq-ixc3) — the IMPORT DRAWER: real disk / URL / paste ingest into
+// the active workspace's live store via the NATIVE loader (research/gui-design.md §A.4).
+//
+// This is the operational counterpart to the site's /try dataset picker: NOT a demo dataset
+// chooser, but the way a user gets THEIR OWN data into the workspace. Three tabs:
+//   * FILE  — a native file-open dialog → the native loader (`load_path`): every format incl.
+//             COMPRESSED (.gz/.bz2/.zst) + NATIVE-ONLY HDT, off the main thread, no wasm ceiling.
+//             Desktop only (a browser cannot read an arbitrary disk path).
+//   * URL   — fetch a remote document, then load it (native `load_text` on desktop, in-tab WASM
+//             on the web). Recorded as a re-fetchable WorkspaceSourceMeta.
+//   * PASTE — load a typed/pasted document (native `load_text` on desktop, in-tab WASM on web).
+// Plus a format auto-detect (overridable), a named-graph-preserving toggle (the `preserve_graphs`
+// loader arg), and a replace/add-to-current mode. On success it updates the datasets tree (via
+// the engine context) AND records the import + a workspace snapshot (sq-atb0) via the workspace
+// context. It is mounted ONCE in the workbench; the rail's "+ Import", the top bar, and Cmd-K all
+// open it through `useImportDrawer`.
+//
+// HONESTY. The drawer states plainly when the native loader is unavailable (the web target): on
+// the web, File import is disabled and paste/URL run in the in-tab WASM engine (no compressed-
+// file / HDT path). No performance number is shown.
+
+import * as React from "react";
+import { Dialog as DialogPrimitive } from "radix-ui";
+import {
+  Upload,
+  FileUp,
+  Link2,
+  ClipboardPaste,
+  X,
+  Loader2,
+  FolderOpen,
+  CheckCircle2,
+  AlertTriangle,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { useEngine, type ImportKind, type ImportMode } from "@/lib/engine-context";
+import { useWorkspace } from "@/lib/workspace-context";
+import {
+  FORMAT_OPTIONS,
+  fileLabel,
+  formatFromContentType,
+  guessFormat,
+  isCompressed,
+  isHdt,
+  urlLabel,
+} from "@/lib/rdf-format";
+import { hasNativeLoader, pickRdfFile } from "@/lib/tauri-ipc";
+import type { WorkspaceSourceMeta } from "@sparq/client";
+
+// ── Open-state context (so the rail / top bar / Cmd-K can open the drawer) ─────────────────────
+
+const ImportDrawerContext = React.createContext<{
+  open: boolean;
+  setOpen: (open: boolean) => void;
+} | null>(null);
+
+/** Open / close the Import drawer from anywhere inside <ImportDrawerProvider>. */
+export function useImportDrawer() {
+  const ctx = React.useContext(ImportDrawerContext);
+  if (!ctx) throw new Error("useImportDrawer must be used within <ImportDrawerProvider>");
+  return ctx;
+}
+
+export function ImportDrawerProvider({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false);
+  const value = React.useMemo(() => ({ open, setOpen }), [open]);
+  return (
+    <ImportDrawerContext.Provider value={value}>
+      {children}
+      <ImportDrawer open={open} onOpenChange={setOpen} />
+    </ImportDrawerContext.Provider>
+  );
+}
+
+// ── The drawer body ────────────────────────────────────────────────────────────────────────────
+
+type Tab = "file" | "url" | "paste";
+
+interface FeedbackOk {
+  kind: "ok";
+  message: string;
+}
+interface FeedbackErr {
+  kind: "error";
+  message: string;
+}
+type Feedback = FeedbackOk | FeedbackErr | null;
+
+function ImportDrawer({
+  open,
+  onOpenChange,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { importRdf, snapshotStore } = useEngine();
+  const { recordImport } = useWorkspace();
+  const native = hasNativeLoader();
+
+  const [tab, setTab] = React.useState<Tab>(native ? "file" : "paste");
+  const [busy, setBusy] = React.useState(false);
+  const [feedback, setFeedback] = React.useState<Feedback>(null);
+
+  // Shared controls.
+  const [mode, setMode] = React.useState<ImportMode>("add");
+  const [preserveGraphs, setPreserveGraphs] = React.useState(true);
+
+  // File tab.
+  const [filePath, setFilePath] = React.useState<string>("");
+  // URL tab.
+  const [url, setUrl] = React.useState<string>("");
+  // Paste tab.
+  const [pasteText, setPasteText] = React.useState<string>("");
+  const [pasteFormat, setPasteFormat] = React.useState<string>("turtle");
+
+  // Reset transient state whenever the drawer is (re)opened.
+  React.useEffect(() => {
+    if (open) {
+      setFeedback(null);
+      setBusy(false);
+      setTab(native ? "file" : "paste");
+    }
+  }, [open, native]);
+
+  const finishImport = React.useCallback(
+    async (
+      sourceKind: ImportKind,
+      run: () => Promise<{ source: WorkspaceSourceMeta; storeSize: number; added: number }>,
+    ) => {
+      setBusy(true);
+      setFeedback(null);
+      try {
+        const { source, storeSize, added } = await run();
+        // Record the source + persist a fresh snapshot of the now-updated live store.
+        await recordImport(source, snapshotStore());
+        setFeedback({
+          kind: "ok",
+          message: `Imported ${added.toLocaleString()} quad${added === 1 ? "" : "s"} (${sourceKind}). Store now holds ${storeSize.toLocaleString()}.`,
+        });
+      } catch (err) {
+        setFeedback({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      } finally {
+        setBusy(false);
+      }
+    },
+    [recordImport, snapshotStore],
+  );
+
+  // FILE — pick via the native dialog, then load via the native loader.
+  const onPickFile = React.useCallback(async () => {
+    const picked = await pickRdfFile();
+    if (picked) setFilePath(picked);
+  }, []);
+
+  const onImportFile = React.useCallback(() => {
+    if (!filePath) return;
+    void finishImport("file", async () => {
+      const label = fileLabel(filePath);
+      const format = guessFormat(filePath);
+      const result = await importRdf({
+        kind: "file",
+        mode,
+        preserveGraphs,
+        label,
+        format,
+        path: filePath,
+      });
+      const source: WorkspaceSourceMeta = {
+        kind: "local",
+        label,
+        format: result.format,
+        bytes: result.bytes,
+        importedAt: Date.now(),
+      };
+      return { source, storeSize: result.storeSize, added: result.added };
+    });
+  }, [filePath, finishImport, importRdf, mode, preserveGraphs]);
+
+  // URL — fetch the document, prefer the served Content-Type for the format, then load.
+  const onImportUrl = React.useCallback(() => {
+    const target = url.trim();
+    if (!target) return;
+    void finishImport("url", async () => {
+      const res = await fetch(target);
+      if (!res.ok) throw new Error(`Fetch failed: HTTP ${res.status} ${res.statusText}`);
+      const body = await res.text();
+      const format =
+        formatFromContentType(res.headers.get("content-type")) ?? guessFormat(target);
+      const result = await importRdf({
+        kind: "url",
+        mode,
+        preserveGraphs,
+        label: urlLabel(target),
+        format,
+        text: body,
+        url: target,
+      });
+      const source: WorkspaceSourceMeta = {
+        kind: "url",
+        label: urlLabel(target),
+        url: target,
+        format: result.format,
+        bytes: result.bytes,
+        importedAt: Date.now(),
+      };
+      return { source, storeSize: result.storeSize, added: result.added };
+    });
+  }, [url, finishImport, importRdf, mode, preserveGraphs]);
+
+  // PASTE — load the typed document with the chosen format.
+  const onImportPaste = React.useCallback(() => {
+    const text = pasteText.trim();
+    if (!text) return;
+    void finishImport("paste", async () => {
+      const result = await importRdf({
+        kind: "paste",
+        mode,
+        preserveGraphs,
+        label: "pasted document",
+        format: pasteFormat,
+        text,
+      });
+      const source: WorkspaceSourceMeta = {
+        kind: "local",
+        label: "pasted document",
+        format: result.format,
+        bytes: result.bytes,
+        importedAt: Date.now(),
+      };
+      return { source, storeSize: result.storeSize, added: result.added };
+    });
+  }, [pasteText, pasteFormat, finishImport, importRdf, mode, preserveGraphs]);
+
+  return (
+    <DialogPrimitive.Root open={open} onOpenChange={onOpenChange}>
+      <DialogPrimitive.Portal>
+        <DialogPrimitive.Overlay
+          className={cn(
+            "fixed inset-0 z-50 bg-black/40 backdrop-blur-sm",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+          )}
+        />
+        <DialogPrimitive.Content
+          data-import-drawer
+          className={cn(
+            "bg-card text-card-foreground fixed right-0 top-0 z-50 flex h-full w-[min(28rem,calc(100vw-2rem))] flex-col",
+            "border-l shadow-2xl",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right",
+          )}
+        >
+          <div className="flex items-center gap-2 border-b px-4 py-3">
+            <Upload className="size-4 text-primary" aria-hidden />
+            <DialogPrimitive.Title className="flex-1 text-sm font-semibold">
+              Import RDF into the workspace
+            </DialogPrimitive.Title>
+            <DialogPrimitive.Close asChild>
+              <Button variant="ghost" size="icon-sm" aria-label="Close import drawer">
+                <X className="size-4" />
+              </Button>
+            </DialogPrimitive.Close>
+          </div>
+          <DialogPrimitive.Description className="sr-only">
+            Load RDF from a disk file (compressed and HDT supported on the desktop app), from a
+            URL, or by pasting a document, into the active workspace&rsquo;s live store.
+          </DialogPrimitive.Description>
+
+          {/* Tab strip. */}
+          <div className="flex border-b text-xs" role="tablist">
+            <DrawerTab id="file" current={tab} onSelect={setTab} icon={FileUp} label="File" />
+            <DrawerTab id="url" current={tab} onSelect={setTab} icon={Link2} label="URL" />
+            <DrawerTab id="paste" current={tab} onSelect={setTab} icon={ClipboardPaste} label="Paste" />
+          </div>
+
+          <div className="flex-1 overflow-y-auto p-4">
+            {tab === "file" && (
+              <FilePane
+                native={native}
+                filePath={filePath}
+                onPickFile={onPickFile}
+                onClear={() => setFilePath("")}
+              />
+            )}
+            {tab === "url" && <UrlPane url={url} onUrl={setUrl} />}
+            {tab === "paste" && (
+              <PastePane
+                text={pasteText}
+                onText={setPasteText}
+                format={pasteFormat}
+                onFormat={setPasteFormat}
+              />
+            )}
+          </div>
+
+          {/* Shared options + actions. */}
+          <div className="space-y-3 border-t p-4">
+            <OptionsRow
+              mode={mode}
+              onMode={setMode}
+              preserveGraphs={preserveGraphs}
+              onPreserveGraphs={setPreserveGraphs}
+            />
+
+            {feedback && (
+              <p
+                role="status"
+                data-import-feedback={feedback.kind}
+                className={cn(
+                  "flex items-start gap-2 rounded-md border px-3 py-2 text-xs",
+                  feedback.kind === "ok"
+                    ? "border-[var(--success)]/40 text-[var(--success)]"
+                    : "border-destructive/40 text-destructive",
+                )}
+              >
+                {feedback.kind === "ok" ? (
+                  <CheckCircle2 className="mt-0.5 size-3.5 shrink-0" />
+                ) : (
+                  <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+                )}
+                <span>{feedback.message}</span>
+              </p>
+            )}
+
+            <Button
+              className="w-full"
+              disabled={
+                busy ||
+                (tab === "file" && (!native || !filePath)) ||
+                (tab === "url" && !url.trim()) ||
+                (tab === "paste" && !pasteText.trim())
+              }
+              onClick={
+                tab === "file" ? onImportFile : tab === "url" ? onImportUrl : onImportPaste
+              }
+            >
+              {busy ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" /> Importing…
+                </>
+              ) : (
+                <>
+                  <Upload className="size-4" /> Import {mode === "add" ? "(add to store)" : "(replace store)"}
+                </>
+              )}
+            </Button>
+          </div>
+        </DialogPrimitive.Content>
+      </DialogPrimitive.Portal>
+    </DialogPrimitive.Root>
+  );
+}
+
+// ── Panes ────────────────────────────────────────────────────────────────────────────────────
+
+function DrawerTab({
+  id,
+  current,
+  onSelect,
+  icon: Icon,
+  label,
+}: {
+  id: Tab;
+  current: Tab;
+  onSelect: (t: Tab) => void;
+  icon: typeof FileUp;
+  label: string;
+}) {
+  const active = id === current;
+  return (
+    <button
+      role="tab"
+      aria-selected={active}
+      data-import-tab={id}
+      onClick={() => onSelect(id)}
+      className={cn(
+        "flex flex-1 items-center justify-center gap-1.5 border-b-2 px-3 py-2 font-medium",
+        active
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground",
+      )}
+    >
+      <Icon className="size-3.5" /> {label}
+    </button>
+  );
+}
+
+function FilePane({
+  native,
+  filePath,
+  onPickFile,
+  onClear,
+}: {
+  native: boolean;
+  filePath: string;
+  onPickFile: () => void;
+  onClear: () => void;
+}) {
+  if (!native) {
+    return (
+      <div className="rounded-md border border-[var(--warning)]/40 bg-[var(--warning)]/5 p-3 text-xs text-muted-foreground">
+        <p className="mb-1 flex items-center gap-1.5 font-medium text-foreground">
+          <AlertTriangle className="size-3.5 text-[var(--warning)]" /> Desktop app only
+        </p>
+        Reading a file from disk — including <strong>compressed</strong> (.gz / .bz2 / .zst) and{" "}
+        <strong>native-only HDT</strong> archives — needs the desktop app&rsquo;s native loader (no
+        ~2&nbsp;GiB browser-tab ceiling). In this web build, use the <strong>URL</strong> or{" "}
+        <strong>Paste</strong> tab instead.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">
+        Load an RDF file through the native engine — Turtle / N-Triples / N-Quads / TriG / JSON-LD,
+        including <strong>compressed</strong> (.gz / .bz2 / .zst) streams and{" "}
+        <strong>native-only HDT</strong> (.hdt / .hdt.gz) archives. Named graphs are preserved.
+      </p>
+      <Button variant="outline" className="w-full" onClick={onPickFile}>
+        <FolderOpen className="size-4" /> Choose a file…
+      </Button>
+      {filePath && (
+        <div className="flex items-start gap-2 rounded-md border bg-background px-3 py-2 text-xs">
+          <FileUp className="mt-0.5 size-3.5 shrink-0 text-muted-foreground" />
+          <span className="min-w-0 flex-1 break-all font-mono">{filePath}</span>
+          <button
+            onClick={onClear}
+            aria-label="Clear selected file"
+            className="shrink-0 text-muted-foreground hover:text-foreground"
+          >
+            <X className="size-3.5" />
+          </button>
+        </div>
+      )}
+      {filePath && (
+        <FormatNote
+          label={fileLabel(filePath)}
+          format={guessFormat(filePath)}
+          compressed={isCompressed(filePath)}
+          hdt={isHdt(filePath)}
+        />
+      )}
+    </div>
+  );
+}
+
+function UrlPane({ url, onUrl }: { url: string; onUrl: (v: string) => void }) {
+  return (
+    <div className="space-y-3">
+      <p className="text-xs text-muted-foreground">
+        Fetch an RDF document from a URL and load it into the store. The source is recorded as a
+        re-fetchable workspace source. The format is auto-detected from the served{" "}
+        <code>Content-Type</code> (or the URL extension).
+      </p>
+      <input
+        type="url"
+        inputMode="url"
+        placeholder="https://example.org/data.ttl"
+        value={url}
+        onChange={(e) => onUrl(e.target.value)}
+        className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      />
+      {url.trim() && (
+        <FormatNote
+          label={urlLabel(url)}
+          format={guessFormat(url)}
+          compressed={isCompressed(url)}
+          hdt={isHdt(url)}
+        />
+      )}
+    </div>
+  );
+}
+
+function PastePane({
+  text,
+  onText,
+  format,
+  onFormat,
+}: {
+  text: string;
+  onText: (v: string) => void;
+  format: string;
+  onFormat: (v: string) => void;
+}) {
+  // HDT is a BINARY archive format — it cannot be pasted as text, so it is never a paste option
+  // (it is offered only on the File tab, where the native loader reads the binary off disk).
+  const options = FORMAT_OPTIONS.filter((f) => f.value !== "hdt");
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2">
+        <label htmlFor="import-paste-format" className="text-xs font-medium text-muted-foreground">
+          Format
+        </label>
+        <select
+          id="import-paste-format"
+          value={format}
+          onChange={(e) => onFormat(e.target.value)}
+          className="rounded-md border bg-background px-2 py-1 text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        >
+          {options.map((f) => (
+            <option key={f.value} value={f.value}>
+              {f.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <textarea
+        value={text}
+        onChange={(e) => onText(e.target.value)}
+        placeholder={"<http://example.org/a> <http://example.org/p> <http://example.org/b> ."}
+        spellCheck={false}
+        className="h-48 w-full resize-y rounded-md border bg-background px-3 py-2 font-mono text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      />
+    </div>
+  );
+}
+
+function FormatNote({
+  label,
+  format,
+  compressed,
+  hdt,
+}: {
+  label: string;
+  format: string;
+  compressed: boolean;
+  hdt: boolean;
+}) {
+  return (
+    <p className="text-[11px] text-muted-foreground">
+      <span className="font-mono">{label}</span> → parsed as{" "}
+      <span className="font-medium text-foreground">{format}</span>
+      {compressed && !hdt && " (decompressed natively)"}
+      {hdt && " (native-only HDT)"}.
+    </p>
+  );
+}
+
+function OptionsRow({
+  mode,
+  onMode,
+  preserveGraphs,
+  onPreserveGraphs,
+}: {
+  mode: ImportMode;
+  onMode: (m: ImportMode) => void;
+  preserveGraphs: boolean;
+  onPreserveGraphs: (v: boolean) => void;
+}) {
+  return (
+    <div className="space-y-2 text-xs">
+      <div className="flex items-center gap-2">
+        <span className="font-medium text-muted-foreground">Mode</span>
+        <div className="inline-flex overflow-hidden rounded-md border">
+          <ModeButton current={mode} value="add" label="Add to store" onSelect={onMode} />
+          <ModeButton current={mode} value="replace" label="Replace store" onSelect={onMode} />
+        </div>
+      </div>
+      <label className="flex cursor-pointer items-center gap-2">
+        <input
+          type="checkbox"
+          checked={preserveGraphs}
+          onChange={(e) => onPreserveGraphs(e.target.checked)}
+          className="size-3.5 accent-[var(--primary)]"
+        />
+        <span className="text-muted-foreground">
+          Preserve named graphs (route quad formats through the dataset loader)
+        </span>
+      </label>
+    </div>
+  );
+}
+
+function ModeButton({
+  current,
+  value,
+  label,
+  onSelect,
+}: {
+  current: ImportMode;
+  value: ImportMode;
+  label: string;
+  onSelect: (m: ImportMode) => void;
+}) {
+  const active = current === value;
+  return (
+    <button
+      onClick={() => onSelect(value)}
+      className={cn(
+        "px-2.5 py-1",
+        active ? "bg-primary text-primary-foreground" : "bg-background hover:bg-accent",
+      )}
+    >
+      {label}
+    </button>
+  );
+}

--- a/gui/app/src/components/workbench/left-rail.tsx
+++ b/gui/app/src/components/workbench/left-rail.tsx
@@ -10,10 +10,12 @@
 //   (3) TOOLS list — each a VERB opened as a tab with an honesty-tier dot (NOT a page).
 
 import * as React from "react";
-import { ChevronDown, Plus, Circle, Database, FolderTree } from "lucide-react";
+import { ChevronDown, Plus, Circle, Database, FolderTree, FileUp, Link2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useEngine } from "@/lib/engine-context";
+import { useWorkspace } from "@/lib/workspace-context";
+import { useImportDrawer } from "@/components/workbench/import-drawer";
 import { TIER_META, type ToolDef } from "@/data/tools";
 
 interface LeftRailProps {
@@ -31,6 +33,10 @@ function shortenGraph(iri: string | null): string {
 
 function DatasetsTree() {
   const { graphs, status } = useEngine();
+  // [OPUS-4.8] sq-ixc3.13 — the live Imports subgroup (WorkspaceSourceMeta) + the working
+  // "+ Import" entry point that opens the Import drawer.
+  const { sources } = useWorkspace();
+  const { setOpen } = useImportDrawer();
   return (
     <div className="px-1 pb-2">
       {status.kind !== "ready" ? (
@@ -56,11 +62,48 @@ function DatasetsTree() {
           ))}
         </ul>
       )}
-      {/* Imports subgroup placeholder — the real WorkspaceSourceMeta list is sq-ixc3.13. */}
+
+      {/* [OPUS-4.8] sq-ixc3.13 — the Imports subgroup: the active workspace's WorkspaceSourceMeta
+          list (local files + re-fetchable URL sources), most recent first. */}
+      {sources.length > 0 && (
+        <div className="mt-2">
+          <h3 className="px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            Imports
+          </h3>
+          <ul className="space-y-0.5">
+            {[...sources]
+              .sort((a, b) => b.importedAt - a.importedAt)
+              .map((s) => (
+                <li
+                  key={`${s.kind}-${s.label}-${s.importedAt}`}
+                  className="flex items-center gap-1.5 rounded px-2 py-1 text-xs hover:bg-sidebar-accent/40"
+                  title={
+                    s.kind === "url" && s.url
+                      ? `${s.url} · ${s.format}`
+                      : `${s.label} · ${s.format} (re-hydrated from the workspace snapshot)`
+                  }
+                >
+                  {s.kind === "url" ? (
+                    <Link2 className="size-3 shrink-0 text-muted-foreground" />
+                  ) : (
+                    <FileUp className="size-3 shrink-0 text-muted-foreground" />
+                  )}
+                  <span className="min-w-0 flex-1 truncate">{s.label}</span>
+                  <span className="tabular text-[10px] uppercase text-muted-foreground">
+                    {s.format}
+                  </span>
+                </li>
+              ))}
+          </ul>
+        </div>
+      )}
+
+      {/* [OPUS-4.8] sq-ixc3.13 — the working "+ Import" entry point (opens the Import drawer). */}
       <button
-        className="mt-1 flex w-full cursor-not-allowed items-center gap-1.5 rounded px-2 py-1 text-xs text-muted-foreground"
-        title="Import RDF from disk / URL / paste — the import drawer is a later phase"
-        disabled
+        onClick={() => setOpen(true)}
+        className="mt-1 flex w-full items-center gap-1.5 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-sidebar-accent/40 hover:text-foreground"
+        title="Import RDF from a disk file (compressed / HDT), a URL, or pasted text"
+        data-import-trigger="rail"
       >
         <Plus className="size-3" /> Import
       </button>

--- a/gui/app/src/components/workbench/status-bar.tsx
+++ b/gui/app/src/components/workbench/status-bar.tsx
@@ -8,19 +8,23 @@
 // canonical number is baked in (this work box / CI runner is non-canonical).
 
 import { useEngine } from "@/lib/engine-context";
+import { useWorkspace } from "@/lib/workspace-context";
 
-/** Detect the desktop (Tauri) host so the bar reports the real persistence backend honestly. */
-function isTauri(): boolean {
-  return (
-    typeof window !== "undefined" &&
-    // Tauri 2 injects a global the webview can detect.
-    ("__TAURI_INTERNALS__" in window || "__TAURI__" in window)
-  );
+/**
+ * [OPUS-4.8] sq-ixc3.13 — an honest persistence-backend label from the workspace store's
+ * RESOLVED backend (not just a Tauri-presence guess): on-device disk (Tauri fs capability
+ * granted), this browser (localStorage), or this session only (in-memory fallback).
+ */
+function backendLabel(backend: "tauri" | "web" | "memory" | null): string {
+  if (backend === "tauri") return "saved on device";
+  if (backend === "web") return "saved in this browser";
+  if (backend === "memory") return "this session only";
+  return "resolving…";
 }
 
 export function StatusBar() {
-  const { lastLatencyMs, lastRowCount, storeSize } = useEngine();
-  const desktop = isTauri();
+  const { lastLatencyMs, lastRowCount, storeSize, nativeLoaderAvailable } = useEngine();
+  const { backend } = useWorkspace();
   return (
     <footer className="flex h-6 shrink-0 items-center gap-4 border-t bg-card px-3 text-[11px] text-muted-foreground">
       <span className="tabular" title="Wall-clock latency of the last query (performance.now)">
@@ -31,9 +35,16 @@ export function StatusBar() {
       </span>
       <span className="ml-auto tabular">{storeSize.toLocaleString()} quads</span>
       <span title="Where queries run">target: local (in-tab WASM)</span>
-      <span title="Where the workspace persists">
-        backend: {desktop ? "desktop (Tauri)" : "browser (in-memory)"}
+      <span
+        title={
+          nativeLoaderAvailable
+            ? "Imports decode through the native engine (compressed + native-only HDT)"
+            : "Imports parse in the in-tab WASM engine (no compressed-file / HDT path)"
+        }
+      >
+        loader: {nativeLoaderAvailable ? "native" : "in-tab"}
       </span>
+      <span title="Where the workspace persists">backend: {backendLabel(backend)}</span>
     </footer>
   );
 }

--- a/gui/app/src/components/workbench/top-bar.tsx
+++ b/gui/app/src/components/workbench/top-bar.tsx
@@ -9,11 +9,12 @@
 
 import * as React from "react";
 import { useTheme } from "next-themes";
-import { Moon, Sun, Command, ExternalLink } from "lucide-react";
+import { Moon, Sun, Command, ExternalLink, Upload } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { useEngine } from "@/lib/engine-context";
 import { useCommandPalette } from "@/components/workbench/command-palette";
+import { useImportDrawer } from "@/components/workbench/import-drawer";
 
 /** The honesty-website link target (the marketing site, opened in a NEW tab / system browser). */
 const WEBSITE_URL = "https://jeswr.github.io/sparq/";
@@ -64,6 +65,8 @@ function ThemeToggle() {
 export function TopBar() {
   const { storeSize } = useEngine();
   const { setOpen } = useCommandPalette();
+  // [OPUS-4.8] sq-ixc3.13 — the top-bar "+ Import" affordance (opens the Import drawer).
+  const { setOpen: setImportOpen } = useImportDrawer();
   return (
     <header className="flex h-10 shrink-0 items-center gap-3 border-b bg-card px-3">
       <span className="font-mono text-sm font-semibold tracking-tight">sparq</span>
@@ -91,6 +94,18 @@ export function TopBar() {
       <span className="tabular text-xs text-muted-foreground">
         {storeSize.toLocaleString()} quads
       </span>
+
+      {/* [OPUS-4.8] sq-ixc3.13 — "+ Import": real disk/URL/paste ingest via the native loader. */}
+      <Button
+        variant="outline"
+        size="sm"
+        className="ml-1"
+        onClick={() => setImportOpen(true)}
+        title="Import RDF from a disk file (compressed / HDT), a URL, or pasted text"
+        data-import-trigger="topbar"
+      >
+        <Upload className="size-3.5" /> Import
+      </Button>
 
       <div className="ml-auto flex items-center gap-1.5">
         {/* ⌘K — opens the keyboard-first command palette (the spine). */}

--- a/gui/app/src/components/workbench/workbench.tsx
+++ b/gui/app/src/components/workbench/workbench.tsx
@@ -19,7 +19,7 @@
 // system browser (the design's rule: the GUI never renders the site, it links to it).
 
 import * as React from "react";
-import { PanelsTopLeft, X, Layers } from "lucide-react";
+import { PanelsTopLeft, X, Layers, Upload } from "lucide-react";
 
 import { LeftRail } from "@/components/workbench/left-rail";
 import { TopBar } from "@/components/workbench/top-bar";
@@ -37,6 +37,12 @@ import {
 } from "@/components/workbench/command-palette";
 import { WorkbenchProvider, type WorkbenchActions } from "@/components/workbench/workbench-context";
 import { graphLabel, type PaletteCommand } from "@/lib/palette-commands";
+// [OPUS-4.8] sq-ixc3.13 — the Import drawer (real disk/URL/paste ingest via the native loader)
+// is mounted once here and opened from the rail's "+ Import", the top bar, and Cmd-K.
+import {
+  ImportDrawerProvider,
+  useImportDrawer,
+} from "@/components/workbench/import-drawer";
 
 /** An open tab in the IDE tab strip — keyed by tool id (a tool opens at most once). */
 export interface OpenTab {
@@ -87,6 +93,7 @@ export function Workbench() {
     // keyboard-first spine) + the shell-actions provider, both mounted ONCE here.
     <CommandPaletteProvider>
       <WorkbenchProvider actions={actions}>
+        <ImportDrawerProvider>
         <ShellPaletteCommands
           tabs={tabs}
           activeId={activeId}
@@ -121,6 +128,7 @@ export function Workbench() {
             </main>
           </div>
         </div>
+        </ImportDrawerProvider>
       </WorkbenchProvider>
     </CommandPaletteProvider>
   );
@@ -144,9 +152,22 @@ function ShellPaletteCommands({
   onCloseTab: (toolId: string) => void;
 }) {
   const { graphs } = useEngine();
+  // [OPUS-4.8] sq-ixc3.13 — the Cmd-K entry point for the Import drawer.
+  const { setOpen: setImportOpen } = useImportDrawer();
 
   const commands = React.useMemo<PaletteCommand[]>(() => {
     const cmds: PaletteCommand[] = [];
+
+    // [OPUS-4.8] sq-ixc3.13 — the lead ACTION: open the Import drawer (real disk/URL/paste ingest).
+    cmds.push({
+      id: "action.import",
+      group: "Actions",
+      title: "Import data…",
+      blurb: "Load RDF from a file (compressed / HDT), a URL, or pasted text into the store.",
+      keywords: ["import", "load", "data", "file", "url", "paste", "rdf", "hdt", "open dataset"],
+      icon: Upload,
+      run: () => setImportOpen(true),
+    });
 
     // Every TOOL as an "open …" command. A `built` tool opens its working tab; a stub still opens
     // (the panel states its tier + what it will do honestly — no fabricated result).
@@ -202,7 +223,7 @@ function ShellPaletteCommands({
     }
 
     return cmds;
-  }, [tabs, activeId, graphs, onOpenTool, onSelectTab, onCloseTab]);
+  }, [tabs, activeId, graphs, onOpenTool, onSelectTab, onCloseTab, setImportOpen]);
 
   useRegisterPaletteCommands("shell", commands);
   return null;

--- a/gui/app/src/lib/engine-context.tsx
+++ b/gui/app/src/lib/engine-context.tsx
@@ -20,12 +20,19 @@ import {
   streamQueryRows,
   type SparqlBinding,
   type SparqlResults,
+  type SparqlTerm,
   type WasmStore,
   type WasmStoreCtor,
 } from "@sparq/client";
 
 import { basePath } from "@/lib/base-path";
 import { SAMPLE_TURTLE, SAMPLE_FORMAT } from "@/data/sample-graph";
+import {
+  hasNativeLoader,
+  nativeLoadPath,
+  nativeLoadText,
+  type LoadedDocument,
+} from "@/lib/tauri-ipc";
 
 /**
  * Internal sentinel thrown out of the streaming loop when the caller's {@link AbortSignal} fires,
@@ -115,6 +122,51 @@ export const DEFAULT_ROW_CAP = 5_000;
 /** The batch size {@link streamQueryRows} pulls per cursor step (one batch held at a time). */
 const STREAM_BATCH_SIZE = 1_000;
 
+/** Where an import came from — drives the source kind recorded in the workspace metadata. */
+export type ImportKind = "file" | "url" | "paste";
+
+/** Whether an import REPLACES the live store or ADDS (merges) into it. */
+export type ImportMode = "replace" | "add";
+
+/** A request to bring RDF into the live store via the Import drawer. */
+export interface ImportRequest {
+  kind: ImportKind;
+  /** REPLACE the store, or merge into it. */
+  mode: ImportMode;
+  /** Preserve named graphs (route quad-bearing formats through the dataset loader). */
+  preserveGraphs: boolean;
+  /** A human label for the source (filename / URL tail / "pasted document"). */
+  label: string;
+  /** The RDF serialisation to parse the document as (e.g. `turtle` / `nquads` / `hdt`). */
+  format: string;
+  /**
+   * For `kind: "file"` — the disk path (the native loader reads + decodes it, incl. compressed
+   * + native-only HDT). Mutually exclusive with `text`.
+   */
+  path?: string;
+  /**
+   * For `kind: "paste"` / `"url"` — the document body. Mutually exclusive with `path`. (The URL
+   * fetch happens in the drawer; the fetched body is passed here.)
+   */
+  text?: string;
+  /** For `kind: "url"` — the source URL, recorded so the workspace source is re-fetchable. */
+  url?: string;
+}
+
+/** The outcome of a successful import — what the drawer reports + records as workspace metadata. */
+export interface ImportResult {
+  /** Quads ADDED by this import (the parsed document's whole-dataset count). */
+  added: number;
+  /** Total quads in the live store after the import. */
+  storeSize: number;
+  /** Whether the native (Tauri) loader handled it, or the in-tab WASM fallback did. */
+  loadedNatively: boolean;
+  /** The format the document was actually parsed as. */
+  format: string;
+  /** UTF-8 byte length of the imported document body (best-effort; for an "≈N bytes" note). */
+  bytes: number;
+}
+
 export interface EngineContextValue {
   status: EngineStatus;
   /** Total quads in the live store (default + all named graphs). */
@@ -142,6 +194,26 @@ export interface EngineContextValue {
    * bundle lacks the serialise binding. The serialise-rdf binding is in the GUI's wasm bundle.
    */
   serializeStore: () => string | null;
+  /**
+   * [OPUS-4.8] sq-ixc3.13 — bring RDF into the live store via the Import drawer. A `file` import
+   * (a disk path) goes through the NATIVE loader (`load_path`: threads, no wasm-tab ceiling,
+   * compressed streams, native-only HDT) when running inside the Tauri desktop shell; `paste` /
+   * `url` documents go through the native `load_text` there too, so named graphs are preserved by
+   * the SAME engine path. On the hosted web target (no native loader) `paste` / `url` parse in
+   * the in-tab WASM engine (no disk / compressed-file / HDT path — the drawer says so honestly).
+   * `mode: "add"` MERGES into the current store (named-graph-preserving) instead of replacing it.
+   * Resolves with the import outcome; rejects with the loader's error message on a parse failure.
+   */
+  importRdf: (req: ImportRequest) => Promise<ImportResult>;
+  /** True when the native loader IPC is available (inside the Tauri desktop shell). */
+  nativeLoaderAvailable: boolean;
+  /**
+   * [OPUS-4.8] sq-ixc3.13 — the whole-dataset N-QUADS snapshot of the live store (default graph +
+   * every named graph), the save/open cache a workspace persists as its `dataSnapshot` (sq-atb0).
+   * N-Quads (not the TriG `serializeStore` emits) because that is the workspace snapshot format,
+   * and it agrees byte-for-byte with the "add to current" merge path. `null` before warm.
+   */
+  snapshotStore: () => string | null;
 }
 
 const EngineContext = React.createContext<EngineContextValue | null>(null);
@@ -161,6 +233,69 @@ function classifyQuery(q: string): "select" | "ask" | "construct" | "describe" |
   if (["INSERT", "DELETE", "LOAD", "CLEAR", "CREATE", "DROP", "COPY", "MOVE", "ADD"].includes(kw))
     return "update";
   return "select";
+}
+
+// [OPUS-4.8] sq-ixc3.13 — the all-quads N-Quads (de)serialisation the Import drawer's MERGE
+// path uses. The wasm `Store.serialize` binding does NOT emit N-Triples/N-Quads (only
+// turtle/trig/jsonld — see `serializeStore` below), and the framework-agnostic `@sparq/client`
+// deliberately leaves the dataset-format opinion (which formats carry named graphs) to the
+// host. So this small, well-understood serialiser lives here: SELECT every quad over the live
+// store and emit one N-Quads line per solution, exactly the shape the site's `storeToNQuads`
+// (site/src/lib/repl-dataset.ts) produces. The merge then concatenates this with the incoming
+// document's N-Quads and re-loads with `loadDataset(_, "nquads")`, so BOTH stores' named graphs
+// survive the round-trip.
+
+/** SELECT every quad (default graph as the unbound `?g`, plus every named graph). */
+const ALL_QUADS_QUERY =
+  "SELECT ?s ?p ?o ?g WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }";
+
+const XSD_STRING = "http://www.w3.org/2001/XMLSchema#string";
+
+/** Escape a literal lexical form for an N-Triples/N-Quads double-quoted string. */
+function escapeNTLiteral(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t");
+}
+
+/**
+ * Emit a single canonical N-Triples/N-Quads TERM (IRI / blank node / literal) from a SPARQL-JSON
+ * term. Unlike `formatTerm` (a DISPLAY helper that abbreviates the datatype to `xsd:…`, which is
+ * NOT valid N-Triples), this writes the FULL datatype IRI and escapes the lexical form, so the
+ * re-load of the merged N-Quads parses losslessly.
+ */
+function termToNT(t: SparqlTerm): string {
+  if (t.type === "uri") return `<${t.value}>`;
+  if (t.type === "bnode") return `_:${t.value}`;
+  // Literal.
+  const lex = `"${escapeNTLiteral(t.value)}"`;
+  if (t["xml:lang"]) return `${lex}@${t["xml:lang"]}`;
+  if (t.datatype && t.datatype !== XSD_STRING) return `${lex}^^<${t.datatype}>`;
+  return lex;
+}
+
+/**
+ * Serialise the WHOLE dataset of the live store (default graph + every named graph) to N-Quads,
+ * one line per quad. Used as the LEFT side of the "add to current" merge. An empty store yields
+ * `""`.
+ */
+function storeToNQuads(store: WasmStore): string {
+  const json = store.query(ALL_QUADS_QUERY);
+  const parsed = JSON.parse(json) as SparqlResults;
+  const lines: string[] = [];
+  for (const b of parsed.results?.bindings ?? []) {
+    const s = b["s"];
+    const p = b["p"];
+    const o = b["o"];
+    if (!s || !p || !o) continue;
+    const g = b["g"];
+    const tail = g ? ` ${termToNT(g)}` : "";
+    lines.push(`${termToNT(s)} ${termToNT(p)} ${termToNT(o)}${tail} .`);
+  }
+  return lines.join("\n");
 }
 
 /** Summarise the live store into per-graph counts via a single grouped query. */
@@ -243,6 +378,83 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     setStoreSize(size);
     setGraphs(gs);
   }, []);
+
+  // [OPUS-4.8] sq-ixc3.13 — the Import drawer's ingest. A `file` import (a disk path) goes
+  // through the NATIVE loader IPC (`load_path`: compressed + native-only HDT, no wasm-tab
+  // ceiling) inside the Tauri shell; `paste`/`url` documents go through native `load_text` there
+  // too. Either way the loader hands back the document as N-QUADS (named-graph-preserving), which
+  // we MERGE (concatenate with the live store's N-Quads) or REPLACE, then re-load with
+  // `loadDataset(_, "nquads")` so every named graph of both sides survives. On the hosted web
+  // target (no native loader), `paste`/`url` parse directly in the in-tab WASM engine; a `file`
+  // import is rejected there with a clear message (browsers cannot read an arbitrary disk path).
+  const importRdf = React.useCallback(
+    async (req: ImportRequest): Promise<ImportResult> => {
+      const Store = ctorRef.current;
+      if (!Store) {
+        throw new Error("The engine is not ready yet — wait for the store to warm.");
+      }
+
+      // 1. Decode the incoming document to N-Quads (native loader when available, else in-tab).
+      let incomingNQuads: string;
+      let added: number;
+      let format = req.format;
+      let loadedNatively = false;
+      let bytes = req.text ? new Blob([req.text]).size : 0;
+
+      const native = hasNativeLoader();
+      if (req.kind === "file") {
+        if (!native || !req.path) {
+          throw new Error(
+            "Importing a file from disk needs the desktop app (the native loader). On the web " +
+              "target, paste the document or load it by URL instead.",
+          );
+        }
+        const doc = await nativeLoadPath(req.path, req.format, req.preserveGraphs);
+        if (!doc) throw new Error("The native loader is unavailable.");
+        incomingNQuads = doc.nquads;
+        added = doc.count;
+        format = doc.format;
+        loadedNatively = true;
+        bytes = new Blob([incomingNQuads]).size;
+      } else {
+        // paste / url — a document body in `req.text`.
+        const text = req.text ?? "";
+        const doc: LoadedDocument | null = native
+          ? await nativeLoadText(text, req.format, req.preserveGraphs)
+          : null;
+        if (doc) {
+          incomingNQuads = doc.nquads;
+          added = doc.count;
+          format = doc.format;
+          loadedNatively = true;
+        } else {
+          // In-tab WASM parse: build a store from the incoming doc, then serialise to N-Quads.
+          const incomingStore = req.preserveGraphs
+            ? Store.loadDataset(text, req.format)
+            : Store.load(text, req.format);
+          incomingNQuads = storeToNQuads(incomingStore);
+          added = incomingNQuads === "" ? 0 : incomingNQuads.split("\n").length;
+        }
+      }
+
+      // 2. Merge (add) or replace, then re-load the whole dataset as N-Quads.
+      let combined = incomingNQuads;
+      if (req.mode === "add" && storeRef.current) {
+        const current = storeToNQuads(storeRef.current);
+        combined = current === "" ? incomingNQuads : `${current}\n${incomingNQuads}`;
+      }
+      const merged = Store.loadDataset(combined, "nquads");
+      storeRef.current = merged;
+
+      // 3. Refresh the datasets tree + store size from the new store.
+      const { size, graphs: gs } = summariseGraphs(merged);
+      setStoreSize(size);
+      setGraphs(gs);
+
+      return { added, storeSize: size, loadedNatively, format, bytes };
+    },
+    [],
+  );
 
   const run = React.useCallback(
     async (query: string, opts: RunOptions = {}): Promise<RunResult> => {
@@ -370,9 +582,46 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     return store.serialize("trig", false, null, false, null);
   }, []);
 
+  // [OPUS-4.8] sq-ixc3.13 — the N-Quads whole-dataset snapshot the workspace persists (sq-atb0).
+  const snapshotStore = React.useCallback((): string | null => {
+    const store = storeRef.current;
+    if (!store) return null;
+    return storeToNQuads(store);
+  }, []);
+
+  // [OPUS-4.8] sq-ixc3.13 — whether the native loader IPC is reachable (inside the Tauri shell).
+  // Computed once on mount (the runtime never changes mid-session) so the status bar / drawer can
+  // label the loader honestly without re-detecting on every render.
+  const [nativeLoaderAvailable, setNativeLoaderAvailable] = React.useState(false);
+  React.useEffect(() => {
+    setNativeLoaderAvailable(hasNativeLoader());
+  }, []);
+
   const value = React.useMemo<EngineContextValue>(
-    () => ({ status, storeSize, graphs, lastLatencyMs, lastRowCount, run, serializeStore }),
-    [status, storeSize, graphs, lastLatencyMs, lastRowCount, run, serializeStore],
+    () => ({
+      status,
+      storeSize,
+      graphs,
+      lastLatencyMs,
+      lastRowCount,
+      run,
+      serializeStore,
+      importRdf,
+      nativeLoaderAvailable,
+      snapshotStore,
+    }),
+    [
+      status,
+      storeSize,
+      graphs,
+      lastLatencyMs,
+      lastRowCount,
+      run,
+      serializeStore,
+      importRdf,
+      nativeLoaderAvailable,
+      snapshotStore,
+    ],
   );
 
   return <EngineContext.Provider value={value}>{children}</EngineContext.Provider>;

--- a/gui/app/src/lib/rdf-format.ts
+++ b/gui/app/src/lib/rdf-format.ts
@@ -1,0 +1,95 @@
+// [OPUS-4.8] sq-ixc3.13 (epic sq-ixc3) — RDF format auto-detection for the Import drawer.
+//
+// A small, pure, dependency-free helper (testable with no DOM): guess the engine format from a
+// filename/URL, map a `Content-Type` to a format, and — load-bearing for the NATIVE loader —
+// strip a compression suffix so a `data.ttl.gz` is parsed as `turtle` (the native loader decodes
+// the `.gz` itself). Mirrors the site's `repl-dataset.ts` opinion on which extensions carry which
+// format (site-local there; the GUI cannot import from `site/`, so this is the GUI's own copy of
+// that tiny, stable table).
+
+/** A selectable RDF serialisation in the drawer's format dropdown. */
+export interface FormatOption {
+  value: string;
+  label: string;
+  exts: string[];
+}
+
+/** The formats the engine ingests, with their file extensions. `hdt` is native-only (see drawer). */
+export const FORMAT_OPTIONS: FormatOption[] = [
+  { value: "turtle", label: "Turtle (.ttl)", exts: ["ttl", "turtle"] },
+  { value: "ntriples", label: "N-Triples (.nt)", exts: ["nt", "ntriples"] },
+  { value: "nquads", label: "N-Quads (.nq)", exts: ["nq", "nquads"] },
+  { value: "trig", label: "TriG (.trig)", exts: ["trig"] },
+  { value: "jsonld", label: "JSON-LD (.jsonld)", exts: ["jsonld", "json-ld", "json"] },
+  { value: "hdt", label: "HDT (.hdt) — native only", exts: ["hdt"] },
+];
+
+/** The compression suffixes the native loader streams; stripped before the format guess. */
+const COMPRESSION_EXTS = new Set(["gz", "bz2", "zst", "zstd"]);
+
+/**
+ * Strip the path/query off a name and the compression suffix (`.gz` / `.bz2` / `.zst[d]`) so the
+ * INNER extension drives the format guess. `data.ttl.gz` → `data.ttl`; `x.hdt.gz` → `x.hdt`.
+ */
+export function stripCompression(name: string): string {
+  const bare = name.split(/[?#]/)[0];
+  const ext = bare.split(".").pop()?.toLowerCase() ?? "";
+  return COMPRESSION_EXTS.has(ext) ? bare.slice(0, bare.length - ext.length - 1) : bare;
+}
+
+/** True when the name has a compression suffix the native loader will decode. */
+export function isCompressed(name: string): boolean {
+  const ext = name.split(/[?#]/)[0].split(".").pop()?.toLowerCase() ?? "";
+  return COMPRESSION_EXTS.has(ext);
+}
+
+/** True when the name is an HDT archive (`.hdt` or `.hdt.gz`) — native-only ingest. */
+export function isHdt(name: string): boolean {
+  const inner = stripCompression(name).toLowerCase();
+  return inner.endsWith(".hdt");
+}
+
+/**
+ * Best-effort engine format guess from a filename / URL, decompression-aware. An `.hdt[.gz]`
+ * reports `hdt`; otherwise the inner extension is matched against {@link FORMAT_OPTIONS},
+ * falling back to Turtle.
+ */
+export function guessFormat(name: string): string {
+  if (isHdt(name)) return "hdt";
+  const inner = stripCompression(name);
+  const ext = inner.split(".").pop()?.toLowerCase() ?? "";
+  const hit = FORMAT_OPTIONS.find((f) => f.exts.includes(ext));
+  return hit?.value ?? "turtle";
+}
+
+const CONTENT_TYPE_FORMATS: Record<string, string> = {
+  "text/turtle": "turtle",
+  "application/n-triples": "ntriples",
+  "application/n-quads": "nquads",
+  "application/trig": "trig",
+  "application/ld+json": "jsonld",
+};
+
+/** Engine format for a response `Content-Type`, or `undefined` if unrecognised / absent. */
+export function formatFromContentType(contentType: string | null): string | undefined {
+  if (!contentType) return undefined;
+  const mime = contentType.split(";")[0].trim().toLowerCase();
+  return CONTENT_TYPE_FORMATS[mime];
+}
+
+/** A short display label for a URL: the last non-empty path segment, or the host. */
+export function urlLabel(url: string): string {
+  try {
+    const u = new URL(url);
+    const tail = u.pathname.split("/").filter(Boolean).pop();
+    return tail || u.host;
+  } catch {
+    return url.length > 40 ? `${url.slice(0, 39)}…` : url;
+  }
+}
+
+/** A short display label for a disk path: the final path segment (filename). */
+export function fileLabel(path: string): string {
+  const seg = path.split(/[\\/]/).filter(Boolean).pop();
+  return seg || path;
+}

--- a/gui/app/src/lib/tauri-fs.ts
+++ b/gui/app/src/lib/tauri-fs.ts
@@ -1,0 +1,61 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.13 (epic sq-ixc3) — the OPTIONAL Tauri filesystem loader for workspace
+// persistence in the operational GUI. A sibling of site/src/lib/tauri-fs.ts (same discipline):
+// it bridges the framework-agnostic `@sparq/client` workspace store (sq-atb0) to the Tauri 2
+// `@tauri-apps/plugin-fs` plugin WITHOUT the static (web) build ever depending on a Tauri
+// package.
+//
+// HOW IT STAYS STATIC-EXPORT-SAFE. `@tauri-apps/plugin-fs` is imported with a `webpackIgnore`
+// dynamic `import()` evaluated only inside a Tauri webview (feature-detected by `isTauriRuntime`).
+// On the hosted "Try the GUI live" web build the import is never reached, never bundled.
+//
+// HONEST LIMITATION. The on-disk path activates only when the Tauri shell grants the `fs`
+// capability scoped to AppLocalData (follow-up bead sq-ixc3.6). Until then this loader returns
+// `null` and the GUI cleanly degrades to the browser localStorage backend — even inside Tauri.
+
+import { type TauriFsApi } from "@sparq/client";
+
+/**
+ * The shape of `@tauri-apps/plugin-fs` we read at runtime. Declared locally (not imported from
+ * the intentionally-absent package) so the web build typechecks without the Tauri package.
+ */
+interface TauriFsModule {
+  BaseDirectory: { AppLocalData: number };
+  readTextFile: TauriFsApi["readTextFile"];
+  writeTextFile: TauriFsApi["writeTextFile"];
+  remove: TauriFsApi["remove"];
+  exists: TauriFsApi["exists"];
+  mkdir: TauriFsApi["mkdir"];
+  readDir: TauriFsApi["readDir"];
+}
+
+/** Dynamically import the Tauri fs plugin (webpackIgnore keeps it out of the web bundle). */
+function importTauriFsPlugin(): Promise<unknown> {
+  // @ts-expect-error — optional Tauri-only module, intentionally absent from the static build.
+  return import(/* webpackIgnore: true */ "@tauri-apps/plugin-fs");
+}
+
+/**
+ * Resolve the Tauri filesystem API scoped to the app's local-data dir, or `null` if the plugin
+ * is not importable / the fs capability was not granted. Passed to
+ * `createWorkspaceStore({ loadTauriFs })`, which only calls it inside a Tauri webview.
+ */
+export async function loadTauriFs(): Promise<TauriFsApi | null> {
+  try {
+    const mod = (await importTauriFsPlugin()) as unknown as TauriFsModule;
+    if (typeof mod?.writeTextFile !== "function") return null;
+    return {
+      baseDir: mod.BaseDirectory.AppLocalData,
+      readTextFile: mod.readTextFile,
+      writeTextFile: mod.writeTextFile,
+      remove: mod.remove,
+      exists: mod.exists,
+      mkdir: mod.mkdir,
+      readDir: mod.readDir,
+    };
+  } catch {
+    // No plugin / capability not granted — the web (localStorage) backend takes over.
+    return null;
+  }
+}

--- a/gui/app/src/lib/tauri-ipc.ts
+++ b/gui/app/src/lib/tauri-ipc.ts
@@ -1,0 +1,146 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.13 (epic sq-ixc3) — the OPTIONAL Tauri IPC bridge for the Import drawer's
+// NATIVE loader.
+//
+// The desktop target links the engine directly (gui/src-tauri/src/engine.rs) and exposes the
+// native loader over Tauri IPC: `load_path` (decode a disk file — incl. compressed + native-only
+// HDT) and `load_text` (decode a pasted / fetched document), both returning the whole dataset as
+// N-Quads for the in-tab store to merge. This module is the thin frontend bridge to those
+// commands plus the native file-open dialog.
+//
+// HOW IT STAYS STATIC-EXPORT-SAFE + DEPENDENCY-FREE. The Tauri shell sets `withGlobalTauri: true`
+// (gui/src-tauri/tauri.conf.json), which injects `window.__TAURI__` with `core.invoke` and the
+// registered plugins' globals (`dialog.open`). We read those off the runtime window — so the GUI
+// needs NO `@tauri-apps/*` npm dependency at all, and the hosted web build (where the global is
+// absent) simply sees `null` and uses the in-tab WASM loader instead. Feature-detected via
+// `isTauriRuntime()` from `@sparq/client`.
+//
+// NO performance claim is made here. The native loader's advantage (threads, no ~2 GiB wasm-tab
+// ceiling, native-only HDT) is a capability statement, not a benchmarked number.
+
+import { isTauriRuntime } from "@sparq/client";
+
+/**
+ * What the native loader (`load_text` / `load_path`) hands back — byte-for-byte the Rust
+ * `LoadedDocument` (gui/src-tauri/src/engine.rs): the whole dataset as N-Quads (the named-graph-
+ * preserving merge wire format), the whole-dataset quad count, and the format it parsed as.
+ */
+export interface LoadedDocument {
+  /** The whole dataset serialised to N-Quads (default graph + every named graph). */
+  nquads: string;
+  /** Total triples/quads parsed (default graph + every named graph). */
+  count: number;
+  /** The RDF serialisation the native loader actually parsed the document as. */
+  format: string;
+}
+
+/** Re-export the runtime detector so callers need only one import. */
+export { isTauriRuntime };
+
+/** The IPC invoker shape `window.__TAURI__.core.invoke` exposes. */
+type TauriInvoke = <T>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+
+/** The subset of the injected `window.__TAURI__` global this module reads. */
+interface TauriGlobal {
+  core?: { invoke?: TauriInvoke };
+}
+
+/** Read the injected Tauri global (present only inside the desktop webview), or `null`. */
+function tauriGlobal(): TauriGlobal | null {
+  if (!isTauriRuntime() || typeof window === "undefined") return null;
+  const g = (window as unknown as { __TAURI__?: TauriGlobal }).__TAURI__;
+  return g ?? null;
+}
+
+/** Resolve the Tauri `invoke`, or `null` outside the desktop webview / if it is absent. */
+function tauriInvoke(): TauriInvoke | null {
+  const g = tauriGlobal();
+  return typeof g?.core?.invoke === "function" ? g.core.invoke : null;
+}
+
+/**
+ * The RDF file extensions the native open dialog offers as a filter group. Includes the
+ * compression suffixes the native loader streams (`.gz` / `.bz2` / `.zst`) and the native-only
+ * HDT archive extensions — capabilities the web target fundamentally lacks.
+ */
+export const RDF_FILE_EXTENSIONS = [
+  "ttl",
+  "nt",
+  "nq",
+  "trig",
+  "jsonld",
+  "json",
+  "hdt",
+  "gz",
+  "bz2",
+  "zst",
+  "zstd",
+] as const;
+
+/**
+ * Open the native file picker for an RDF document, returning the chosen absolute path or `null`
+ * (cancelled / not in a Tauri webview). Implemented by invoking the dialog plugin's `open`
+ * COMMAND directly (`plugin:dialog|open`) over IPC — so the GUI needs no `@tauri-apps/plugin-
+ * dialog` npm package, only the Rust-side plugin (`tauri_plugin_dialog::init()`) + the granted
+ * `dialog:allow-open` capability. The native loader (`load_path`) then decodes the chosen file.
+ */
+export async function pickRdfFile(): Promise<string | null> {
+  const invoke = tauriInvoke();
+  if (!invoke) return null;
+  try {
+    // The dialog plugin's `open` command returns the selected path (string), or null on cancel.
+    const selected = await invoke<string | string[] | null>("plugin:dialog|open", {
+      options: {
+        multiple: false,
+        directory: false,
+        title: "Import an RDF file into the workspace",
+        filters: [
+          { name: "RDF (incl. compressed + HDT)", extensions: [...RDF_FILE_EXTENSIONS] },
+          { name: "All files", extensions: ["*"] },
+        ],
+      },
+    });
+    return typeof selected === "string" ? selected : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decode a disk file through the NATIVE loader (`load_path`): compressed streams + native-only
+ * HDT + named-graph-preserving, off the main thread in the Rust engine. Returns the whole
+ * dataset as N-Quads for the in-tab store to merge, or `null` if not in a Tauri webview. Throws
+ * the native error string on a decode/parse failure (e.g. an HDT import in a lean build).
+ */
+export async function nativeLoadPath(
+  path: string,
+  format: string,
+  preserveGraphs: boolean,
+): Promise<LoadedDocument | null> {
+  const invoke = tauriInvoke();
+  if (!invoke) return null;
+  return invoke<LoadedDocument>("load_path", { path, format, preserveGraphs });
+}
+
+/**
+ * Decode an in-memory document (paste / a fetched URL body) through the NATIVE loader
+ * (`load_text`) so its named graphs are preserved by the SAME engine path a disk file takes.
+ * Returns the whole dataset as N-Quads, or `null` if not in a Tauri webview (the web target
+ * parses paste/URL in the in-tab WASM engine instead). Throws the native error string on a
+ * parse failure.
+ */
+export async function nativeLoadText(
+  text: string,
+  format: string,
+  preserveGraphs: boolean,
+): Promise<LoadedDocument | null> {
+  const invoke = tauriInvoke();
+  if (!invoke) return null;
+  return invoke<LoadedDocument>("load_text", { text, format, preserveGraphs });
+}
+
+/** True when the native loader IPC path is available (we are inside a Tauri webview). */
+export function hasNativeLoader(): boolean {
+  return isTauriRuntime();
+}

--- a/gui/app/src/lib/workspace-context.tsx
+++ b/gui/app/src/lib/workspace-context.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+// [OPUS-4.8] sq-ixc3.13 (epic sq-ixc3) — the active-WORKSPACE context for the operational GUI.
+//
+// The persistent-workspace MODEL + persistence abstraction is the framework-agnostic
+// `@sparq/client` `workspace.ts` (sq-atb0): one `WorkspaceStore` interface with three runtime-
+// selected backends (Tauri on-disk when the fs capability is granted, browser localStorage on
+// the web target, in-memory fallback). This context is the GUI's thin host glue around it for
+// the IMPORT path: it holds the active workspace's imported-source list (drives the left rail's
+// Imports subgroup) and persists a workspace SNAPSHOT (the save/open cache) after each import.
+//
+// SCOPE (this bead). A SINGLE auto-created/restored workspace — the full switcher/create/delete
+// UI is a separate phase (sq-atb0 model exists; the rail switcher button is still a stub). What
+// this bead needs and lights up: record `WorkspaceSourceMeta` for each import + write the
+// dataset snapshot so a re-open restores the imported store. NO secret is ever persisted.
+
+import * as React from "react";
+import {
+  createWorkspaceStore,
+  newWorkspace,
+  type Workspace,
+  type WorkspaceBackend,
+  type WorkspaceSourceMeta,
+  type WorkspaceStore,
+} from "@sparq/client";
+
+import { loadTauriFs } from "@/lib/tauri-fs";
+
+/** The starting editor query a freshly-created workspace carries (kept in lockstep with the Query tool default). */
+const STARTER_QUERY = "SELECT * WHERE { ?s ?p ?o } LIMIT 25";
+
+export interface WorkspaceContextValue {
+  /** The active workspace, or `null` until the store + workspace are restored on mount. */
+  workspace: Workspace | null;
+  /** Which concrete persistence backend resolved (for an honest "saved on device / in browser" label). */
+  backend: WorkspaceBackend | null;
+  /** The imported-source metadata list for the active workspace (drives the rail's Imports subgroup). */
+  sources: WorkspaceSourceMeta[];
+  /**
+   * Record an imported source + persist a fresh dataset SNAPSHOT of the live store. Called by the
+   * Import drawer on a successful ingest. `snapshot` is the live store's whole-dataset N-Quads
+   * (the engine context's `snapshotStore()`), the save/open cache. Best-effort persistence: a
+   * write failure does not throw (the import itself already succeeded in-memory).
+   */
+  recordImport: (source: WorkspaceSourceMeta, snapshot: string | null) => Promise<void>;
+}
+
+const WorkspaceContext = React.createContext<WorkspaceContextValue | null>(null);
+
+export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
+  const [workspace, setWorkspace] = React.useState<Workspace | null>(null);
+  const [backend, setBackend] = React.useState<WorkspaceBackend | null>(null);
+  const storeRef = React.useRef<WorkspaceStore | null>(null);
+
+  // Resolve the persistence backend + restore (or create) the active workspace once on mount.
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      const store = await createWorkspaceStore({ loadTauriFs });
+      if (cancelled) return;
+      storeRef.current = store;
+      setBackend(store.backend);
+      // Restore the last-opened workspace if there is one, else create a fresh default.
+      let ws: Workspace | null = null;
+      try {
+        const lastId = await store.lastOpenedId();
+        if (lastId) ws = await store.load(lastId);
+      } catch {
+        /* unreadable index — fall through to a fresh workspace */
+      }
+      if (!ws) {
+        ws = newWorkspace("default workspace", STARTER_QUERY);
+        try {
+          await store.save(ws);
+          await store.setLastOpenedId(ws.id);
+        } catch {
+          /* in-memory / locked-down backend — keep the workspace for this session anyway */
+        }
+      }
+      if (!cancelled) setWorkspace(ws);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const recordImport = React.useCallback(
+    async (source: WorkspaceSourceMeta, snapshot: string | null): Promise<void> => {
+      setWorkspace((prev) => {
+        const base = prev ?? newWorkspace("default workspace", STARTER_QUERY);
+        const next: Workspace = {
+          ...base,
+          sources: [...base.sources, source],
+          dataSnapshot: snapshot ?? base.dataSnapshot,
+          updatedAt: Date.now(),
+        };
+        // Persist the updated record (best-effort; the import already succeeded in-memory).
+        const store = storeRef.current;
+        if (store) {
+          store
+            .save(next)
+            .then(() => store.setLastOpenedId(next.id))
+            .catch(() => {
+              /* a write failure must not break the in-memory import */
+            });
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const value = React.useMemo<WorkspaceContextValue>(
+    () => ({
+      workspace,
+      backend,
+      sources: workspace?.sources ?? [],
+      recordImport,
+    }),
+    [workspace, backend, recordImport],
+  );
+
+  return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;
+}
+
+export function useWorkspace(): WorkspaceContextValue {
+  const ctx = React.useContext(WorkspaceContext);
+  if (!ctx) throw new Error("useWorkspace must be used within a <WorkspaceProvider>");
+  return ctx;
+}

--- a/gui/e2e/run-e2e.mjs
+++ b/gui/e2e/run-e2e.mjs
@@ -16,6 +16,9 @@
 //   8. [OPUS-4.8] sq-ixc3.11 — open the SHACL tool (left-rail data-tool="shacl"), click
 //      "Validate live store", and ASSERT a W3C validation report renders over the serialised
 //      live store (proving the SHACL surface is a working TOOL, not a stub).
+//   9. [OPUS-4.8] sq-ixc3.13 — open the Import drawer (left-rail data-import-trigger="rail"),
+//      switch to the Paste tab, enter a triple, click Import, and ASSERT a success feedback
+//      (data-import-feedback="ok") — proving the native loader ingest path merges into the store.
 //
 // This proves the desktop shell actually loads, the WASM engine runs a query IN THE TAB, and
 // the result renders — i.e. the shell is a working app, not just a crate that compiles.
@@ -274,6 +277,50 @@ async function main() {
       },
     );
     log("PASS — the SHACL tool validated the live store and rendered a W3C report.");
+
+    // 9. [OPUS-4.8] sq-ixc3.13 — IMPORT DRAWER smoke: open the drawer from the left rail's
+    //    "+ Import" (data-import-trigger="rail"), switch to the Paste tab, enter a triple, and
+    //    click Import — then assert a SUCCESS feedback renders (data-import-feedback="ok"). This
+    //    exercises the real ingest path end-to-end inside the desktop shell: the native loader
+    //    (`load_text`) decodes the document → N-Quads → the in-tab store merges it. The seeded
+    //    triple uses a fresh subject so it adds at least one quad regardless of the sample graph.
+    log("opening the Import drawer from the left rail…");
+    const importTrigger = await browser.$('[data-import-trigger="rail"]');
+    await importTrigger.waitForClickable({ timeout: 10_000 });
+    await importTrigger.click();
+
+    log("switching to the Paste tab…");
+    const pasteTab = await browser.$('[data-import-tab="paste"]');
+    await pasteTab.waitForClickable({ timeout: 10_000 });
+    await pasteTab.click();
+
+    log("entering a triple into the paste textarea…");
+    const IMPORT_DOC =
+      "<http://example.org/imported> <http://example.org/p> <http://example.org/o> .";
+    await browser.execute((value) => {
+      const el = document.querySelector("[data-import-drawer] textarea");
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      ).set;
+      setter.call(el, value);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    }, IMPORT_DOC);
+
+    log("clicking the Import button…");
+    // The Import button label carries the mode suffix ("Import (add to store)"); match the lead.
+    const importButton = await browser.$('[data-import-drawer] button*=Import');
+    await importButton.waitForClickable({ timeout: 10_000 });
+    await importButton.click();
+
+    log("waiting for the import success feedback…");
+    const importOk = await browser.$('[data-import-feedback="ok"]');
+    await importOk.waitForExist({ timeout: 30_000 });
+    const okText = await importOk.getText();
+    if (!/Imported/i.test(okText)) {
+      throw new Error(`import feedback rendered but was not a success: ${JSON.stringify(okText)}`);
+    }
+    log("PASS — the Import drawer ingested a pasted document into the live store.");
 
     await browser.deleteSession();
   } catch (err) {

--- a/gui/src-tauri/Cargo.lock
+++ b/gui/src-tauri/Cargo.lock
@@ -215,6 +215,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytesize"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e78e506b9d7633710dab98996f22f95f3d0f488e8f1aa162830556ed9fc14d"
+
+[[package]]
+name = "bzip2"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3a53fac24f34a81bc9954b5d6cfce0c21e18ec6959f44f56e8e90e4bb7c346c"
+dependencies = [
+ "libbz2-rs-sys",
+]
+
+[[package]]
 name = "cairo-rs"
 version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -288,6 +303,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -421,6 +438,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -501,7 +533,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -539,7 +571,7 @@ checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
  "ident_case",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "strsim",
  "syn 2.0.118",
 ]
@@ -551,7 +583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -591,7 +623,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "rustc_version",
  "syn 2.0.118",
 ]
@@ -657,7 +689,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -680,7 +712,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fbbb781877580993a8707ec48672673ec7b81eeba04cfd2310bd28c08e47c8f"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -863,7 +895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -921,7 +953,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -1161,7 +1193,7 @@ dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro-error",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -1240,7 +1272,7 @@ dependencies = [
  "proc-macro-crate 1.3.1",
  "proc-macro-error",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -1259,6 +1291,21 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "hdt"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70928a2e9d31dcdb05b1b2b3546ba271376baa1f19f1e3af2faa2ac440ebac73"
+dependencies = [
+ "bytesize",
+ "crc",
+ "log",
+ "mownstr",
+ "ntriple",
+ "sucds",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1630,8 +1677,18 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -1707,6 +1764,12 @@ dependencies = [
  "libloading",
  "once_cell",
 ]
+
+[[package]]
+name = "libbz2-rs-sys"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b357333733e8260735ba5894eb928c02ecc69c78715f01a8019e7fa7f2db4c"
 
 [[package]]
 name = "libc"
@@ -1827,6 +1890,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "mownstr"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b33dce847b8623c1f2e473ed3a05e43d0c395e3b93fab62378b6ae94b0a1c42c"
+
+[[package]]
 name = "muda"
 version = "0.19.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1878,6 +1947,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
+name = "ntriple"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "020fb7cf74ddf131e4ba84e13221d2493ae4d17cad3982a9158771442d6b0730"
+dependencies = [
+ "peg 0.5.7",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1910,7 +1988,7 @@ checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
  "proc-macro-crate 3.5.0",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -2225,6 +2303,15 @@ dependencies = [
 
 [[package]]
 name = "peg"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40df12dde1d836ed2a4c3bfc2799797e3abaf807d97520d28d6e3f3bf41a5f85"
+dependencies = [
+ "quote 0.3.15",
+]
+
+[[package]]
+name = "peg"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0aad070be5b63aa72103f2fcdd70a83adbd5e90112ce5b574171ff1c65501773"
@@ -2241,7 +2328,7 @@ checksum = "ddd8ef6825cae95355031ae26a99b616a2a21f22ba2de0197c43dfb05acbe7ee"
 dependencies = [
  "peg-runtime",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
 ]
 
 [[package]]
@@ -2296,7 +2383,7 @@ dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -2427,7 +2514,7 @@ checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
 dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 1.0.109",
  "version_check",
 ]
@@ -2439,7 +2526,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "version_check",
 ]
 
@@ -2460,6 +2547,12 @@ checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 
 [[package]]
 name = "quote"
@@ -2573,7 +2666,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -2746,7 +2839,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "serde_derive_internals",
  "syn 2.0.118",
 ]
@@ -2824,7 +2917,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -2835,7 +2928,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -2859,7 +2952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -2909,7 +3002,7 @@ checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
  "darling",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -2931,7 +3024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "772ee033c0916d670af7860b6e1ef7d658a4629a6d0b4c8c3e67f09b3765b75d"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -3074,7 +3167,7 @@ dependencies = [
  "oxilangtag",
  "oxiri",
  "oxrdf",
- "peg",
+ "peg 0.8.6",
  "rand",
  "thiserror 2.0.18",
 ]
@@ -3114,13 +3207,30 @@ dependencies = [
 name = "sparq-gui"
 version = "0.1.0"
 dependencies = [
+ "bzip2",
+ "flate2",
  "serde",
  "serde_json",
  "sparq-core",
  "sparq-engine",
+ "sparq-hdt",
  "tauri",
  "tauri-build",
  "tauri-plugin-dialog",
+ "zstd",
+]
+
+[[package]]
+name = "sparq-hdt"
+version = "0.1.0"
+dependencies = [
+ "bzip2",
+ "crc",
+ "flate2",
+ "hdt",
+ "rayon",
+ "sparq-core",
+ "zstd",
 ]
 
 [[package]]
@@ -3150,7 +3260,7 @@ dependencies = [
  "phf_generator",
  "phf_shared",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
 ]
 
 [[package]]
@@ -3158,6 +3268,16 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "sucds"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd324eaa05be64f105ea5269bb8aabd70e5dd57fa5c673b167f451b07d6c0dcd"
+dependencies = [
+ "anyhow",
+ "num-traits",
+]
 
 [[package]]
 name = "swift-rs"
@@ -3187,7 +3307,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "unicode-ident",
 ]
 
@@ -3207,7 +3327,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -3271,7 +3391,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4e16beb8b2ac17db28eab8bca40e62dbfbb34c0fcdc6d9826b11b7b5d047dfd"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -3366,7 +3486,7 @@ dependencies = [
  "plist",
  "png 0.17.16",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "semver",
  "serde",
  "serde_json",
@@ -3388,7 +3508,7 @@ checksum = "e8b394794f399a421811d06966343e7933fcae92d59f5180b9388d1174497a45"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
  "tauri-codegen",
  "tauri-utils",
@@ -3524,7 +3644,7 @@ dependencies = [
  "phf",
  "plist",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "regex",
  "schemars 0.8.22",
  "semver",
@@ -3587,7 +3707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -3598,7 +3718,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -4105,7 +4225,7 @@ version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e21a184b13fb19e157296e2c46056aec9092264fab83e4ba59e68c61b323c3d"
 dependencies = [
- "quote",
+ "quote 1.0.45",
  "wasm-bindgen-macro-support",
 ]
 
@@ -4117,7 +4237,7 @@ checksum = "fecefd9c35bd935a20fc3fc344b5f29138961e4f47fb03297d88f2587afb5ebd"
 dependencies = [
  "bumpalo",
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
@@ -4231,7 +4351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67a921c1b6914c367b2b823cd4cde6f96beec77d30a939c8199bb377cf9b9b54"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -4358,7 +4478,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -4369,7 +4489,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -4800,7 +4920,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
  "synstructure",
 ]
@@ -4821,7 +4941,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -4841,7 +4961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
  "synstructure",
 ]
@@ -4875,7 +4995,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
- "quote",
+ "quote 1.0.45",
  "syn 2.0.118",
 ]
 
@@ -4884,3 +5004,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -45,6 +45,16 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 [build-dependencies]
 tauri-build = { version = "2", features = [] }
 
+[features]
+# [OPUS-4.8] sq-ixc3.13 — native-only HDT (Header-Dictionary-Triples) ingest via the opt-in
+# sparq-hdt crate. OFF by default for the SAME reasons the CLI keeps it opt-in (crates/
+# sparq-cli/Cargo.toml): sparq-hdt's MSRV (1.87, the wrapped `hdt` crate) and the dead-weight
+# decode stack. The desktop release build turns it ON (`cargo build --features hdt`) so the
+# Import drawer can ingest `.hdt` / `.hdt.gz` archives the wasm read-replica fundamentally
+# cannot. The webview-target build (Pages "Try the GUI live") never links this crate at all.
+default = []
+hdt = ["dep:sparq-hdt"]
+
 [dependencies]
 tauri = { version = "2", features = [] }
 tauri-plugin-dialog = "2"
@@ -55,8 +65,23 @@ serde_json = "1"
 # shell (research/gui-design.md §1). The desktop app IS a Rust binary, so it depends on the
 # engine library crates by path and runs the FULL native store (threads, no wasm ceiling),
 # not the WASM read-replica. `jsonld` matches the formats the site's wasm bundle ingests.
+# [OPUS-4.8] sq-ixc3.13 — `serialize-rdf` turns on the engine's N-Quads writer
+# (`graph_to_nquads`), the named-graph-preserving wire format the Import drawer's native
+# loader hands a parsed disk/URL/HDT document back to the in-tab store as.
 sparq-core = { path = "../../crates/sparq-core", features = ["jsonld"] }
-sparq-engine = { path = "../../crates/sparq-engine" }
+sparq-engine = { path = "../../crates/sparq-engine", features = ["serialize-rdf"] }
+
+# [OPUS-4.8] sq-ixc3.13 — opt-in native-only HDT reader (loads .hdt[.gz] straight into a
+# sparq Graph; the wasm read-replica cannot). Pulled in only under this crate's `hdt` feature.
+sparq-hdt = { path = "../../crates/sparq-hdt", optional = true }
+
+# [OPUS-4.8] sq-ixc3.13 — streaming decompression for the native disk loader: gzip + bzip2 +
+# zstd, the SAME codec matrix the CLI's `open_reader` handles (crates/sparq-cli/src/main.rs).
+# This is the "compressed" half of the bead — a `.nt.gz` / `.ttl.bz2` / `.nq.zst` file is
+# decoded by the native engine (no ~2 GiB wasm-tab ceiling) before it is parsed.
+flate2 = "1"
+bzip2 = "0.6"
+zstd = "0.13"
 
 # Inherit the workspace memory-safety posture (the unsafe-rust-attestation skill): this
 # crate writes no `unsafe`.

--- a/gui/src-tauri/src/engine.rs
+++ b/gui/src-tauri/src/engine.rs
@@ -67,14 +67,161 @@ pub fn load(
     format: String,
     preserve_graphs: bool,
 ) -> Result<usize, String> {
-    let graph = if preserve_graphs {
-        Graph::load_dataset(&text, &format)?
-    } else {
-        Graph::load_str(&text, &format)?
-    };
+    let graph = parse_graph(&text, &format, preserve_graphs)?;
     let size = graph.len();
     *lock(&state)? = graph;
     Ok(size)
+}
+
+/// Parse an in-memory RDF document into a `Graph`, honouring the named-graph-preserving
+/// toggle. The ONE parse helper [`load`] / [`load_text`] share so the `preserve_graphs`
+/// routing (`load_dataset` for the quad-bearing formats vs the cheaper `load_str`) is decided
+/// in exactly one place.
+fn parse_graph(text: &str, format: &str, preserve_graphs: bool) -> Result<Graph, String> {
+    if preserve_graphs {
+        Graph::load_dataset(text, format)
+    } else {
+        Graph::load_str(text, format)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-ixc3.13 — the Import drawer's NATIVE loader.
+//
+// The whole point of the desktop target (research/gui-design.md §A.4): real disk/URL ingest
+// through the NATIVE engine — threads, no ~2 GiB wasm-tab ceiling, COMPRESSED streams, and
+// NATIVE-ONLY HDT — capabilities the browser read-replica fundamentally cannot offer. The
+// native loader decodes the document into a `sparq_core::Graph` and hands it back to the
+// frontend as N-QUADS text (the named-graph-preserving wire format), which the in-tab store
+// MERGES (or replaces) into the live workspace. Keeping the in-tab store the single query
+// surface — rather than splitting queries across two engines — is the honest, smallest design:
+// the native side owns the heavy *ingest*, the in-tab side owns *query* (where the GUI already
+// runs today). No performance number is asserted anywhere.
+// ---------------------------------------------------------------------------
+
+/// What the native loader hands the frontend after decoding a document: the whole dataset as
+/// N-Quads (default graph + every named graph), the triple/quad count, and the format the
+/// loader actually parsed it as (so a `.ttl.gz` file reports `turtle`, an `.hdt` reports `hdt`).
+#[derive(Debug, serde::Serialize)]
+pub struct LoadedDocument {
+    /// The whole dataset serialised to N-Quads — the named-graph-preserving merge wire format.
+    pub nquads: String,
+    /// Total triples/quads parsed (default graph + every named graph).
+    pub count: usize,
+    /// The RDF serialisation the loader actually parsed the document as.
+    pub format: String,
+}
+
+/// Serialise a decoded `Graph` into a [`LoadedDocument`]. Counts the WHOLE dataset (default
+/// graph + every named graph) — NOT `Graph::len()`, which reports the default graph only and so
+/// UNDER-counts a dataset with named graphs. The count is the non-empty N-Quads line count
+/// (one line per quad), the same whole-dataset count the site derives from its N-Quads dump.
+fn to_loaded_document(graph: &Graph, format: String) -> LoadedDocument {
+    let nquads = sparq_engine::serialize::graph_to_nquads(graph);
+    let count = nquads.lines().filter(|l| !l.trim().is_empty()).count();
+    LoadedDocument {
+        nquads,
+        count,
+        format,
+    }
+}
+
+/// Decode an in-memory RDF document and return it as N-Quads for the in-tab store to merge.
+/// The PASTE path: a document typed/pasted into the drawer. Mirrors [`load_path`]'s output so
+/// the frontend's merge logic is one branch. Returns the whole dataset as N-Quads, the count,
+/// and the (echoed) format.
+#[tauri::command]
+pub fn load_text(
+    text: String,
+    format: String,
+    preserve_graphs: bool,
+) -> Result<LoadedDocument, String> {
+    let graph = parse_graph(&text, &format, preserve_graphs)?;
+    Ok(to_loaded_document(&graph, format))
+}
+
+/// Decode an RDF document FROM DISK and return it as N-Quads for the in-tab store to merge —
+/// the FILE tab of the Import drawer. This is the native loader's headline capability:
+///
+///   * **Compressed** streams (`.gz` / `.bz2` / `.zst[d]`) are decompressed natively (the SAME
+///     codec matrix as the CLI's `open_reader`) — the browser cannot stream a multi-GiB
+///     compressed file without buffering the whole decoded copy in the tab.
+///   * **Native-only HDT** (`.hdt` / `.hdt.gz`, or `format == "hdt"`) routes through the opt-in
+///     `sparq-hdt` crate (gated behind this crate's `hdt` feature). The wasm read-replica
+///     cannot load HDT at all.
+///   * Everything else parses as the given `format` (auto-detected by the frontend from the
+///     extension), with `preserve_graphs` choosing the named-graph-preserving dataset path.
+///
+/// `format` is the frontend's extension-derived guess (it strips a compression suffix first);
+/// the loader trusts it for the parse but routes HDT by extension regardless.
+#[tauri::command]
+pub fn load_path(
+    path: String,
+    format: String,
+    preserve_graphs: bool,
+) -> Result<LoadedDocument, String> {
+    let lower = path.to_ascii_lowercase();
+
+    // HDT archives route through sparq-hdt by extension OR an explicit `hdt` format. Opt-in:
+    // a build without the `hdt` feature reports the actionable rebuild hint rather than
+    // silently mis-parsing the binary as Turtle.
+    if format == "hdt" || lower.ends_with(".hdt") || lower.ends_with(".hdt.gz") {
+        return load_hdt(&path);
+    }
+
+    let graph = decode_file_to_graph(&path, &format, preserve_graphs)?;
+    Ok(to_loaded_document(&graph, format))
+}
+
+/// Open a (possibly compressed) file as a streaming reader. Mirrors the CLI's `open_reader`
+/// codec matrix (crates/sparq-cli/src/main.rs): a `.gz` is MultiGzDecoder, a `.bz2` is
+/// MultiBzDecoder, a `.zst`/`.zstd` is the zstd stream decoder, anything else is the raw file.
+fn open_reader(path: &str) -> std::io::Result<Box<dyn std::io::Read + Send>> {
+    let file = std::fs::File::open(path)?;
+    let lower = path.to_ascii_lowercase();
+    Ok(if lower.ends_with(".gz") {
+        Box::new(flate2::read::MultiGzDecoder::new(file))
+    } else if lower.ends_with(".bz2") {
+        Box::new(bzip2::read::MultiBzDecoder::new(file))
+    } else if lower.ends_with(".zst") || lower.ends_with(".zstd") {
+        Box::new(zstd::stream::read::Decoder::new(file)?)
+    } else {
+        Box::new(file)
+    })
+}
+
+/// Decode a non-HDT file into a `Graph`. N-Triples streams block-by-block through the parallel
+/// pipelined parser (no whole-decompressed copy held in RAM); the other formats need the whole
+/// document buffered for the statement splitter. This mirrors the CLI's `load_quiet` shape.
+fn decode_file_to_graph(path: &str, format: &str, preserve_graphs: bool) -> Result<Graph, String> {
+    if matches!(format, "ntriples" | "n-triples") && !preserve_graphs {
+        let reader = open_reader(path).map_err(|e| format!("cannot open {path}: {e}"))?;
+        return Graph::load_reader_parallel(reader, format);
+    }
+    use std::io::Read;
+    let mut text = String::new();
+    open_reader(path)
+        .and_then(|mut r| r.read_to_string(&mut text))
+        .map_err(|e| format!("cannot read {path}: {e}"))?;
+    parse_graph(&text, format, preserve_graphs)
+}
+
+/// Load an HDT archive via the opt-in `sparq-hdt` crate. Compiled out when the `hdt` feature
+/// is off (the default build), returning an actionable rebuild hint so an HDT import in a
+/// lean build fails LOUDLY rather than mis-parsing the binary — honest about the gate.
+#[cfg(feature = "hdt")]
+fn load_hdt(path: &str) -> Result<LoadedDocument, String> {
+    let graph = sparq_hdt::load(path).map_err(|e| e.to_string())?;
+    Ok(to_loaded_document(&graph, "hdt".to_string()))
+}
+
+#[cfg(not(feature = "hdt"))]
+fn load_hdt(_path: &str) -> Result<LoadedDocument, String> {
+    Err(
+        "HDT support is not compiled into this build — rebuild the desktop app with \
+         `cargo build --features hdt` to import .hdt archives."
+            .to_string(),
+    )
 }
 
 /// Run a SELECT/ASK query, returning the SPARQL 1.1 JSON results document — the exact shape
@@ -88,10 +235,7 @@ pub fn query(state: tauri::State<'_, EngineState>, sparql: String) -> Result<Str
 /// Run a CONSTRUCT/DESCRIBE query, returning the constructed graph as an N-Triples document
 /// (mirrors the wasm `queryQuads`).
 #[tauri::command]
-pub fn query_quads(
-    state: tauri::State<'_, EngineState>,
-    sparql: String,
-) -> Result<String, String> {
+pub fn query_quads(state: tauri::State<'_, EngineState>, sparql: String) -> Result<String, String> {
     let graph = lock(&state)?;
     sparq_engine::construct_ntriples(&graph, &sparql)
 }
@@ -160,8 +304,8 @@ mod tests {
     fn load_then_query_round_trips_through_the_native_engine() {
         let graph = Graph::load_str(TTL, "turtle").expect("turtle parses");
         assert_eq!(graph.len(), 1);
-        let json = sparq_engine::query_json(&graph, "SELECT * WHERE { ?s ?p ?o }")
-            .expect("select runs");
+        let json =
+            sparq_engine::query_json(&graph, "SELECT * WHERE { ?s ?p ?o }").expect("select runs");
         assert!(json.contains("http://example.org/a"));
         assert!(json.contains("\"bindings\""));
     }
@@ -174,5 +318,95 @@ mod tests {
             sparq_engine::count(&graph, "SELECT * WHERE { ?s ?p ?o }").expect("count runs"),
             1
         );
+    }
+
+    // ── [OPUS-4.8] sq-ixc3.13 — the native loader (paste / disk / compressed / named graphs) ──
+
+    const NQUADS: &str = "<http://example.org/a> <http://example.org/p> <http://example.org/b> <http://example.org/g> .\n<http://example.org/c> <http://example.org/p> <http://example.org/d> .";
+
+    #[test]
+    fn load_text_returns_nquads_count_and_format() {
+        // The PASTE path: a single triple round-trips back as one N-Quads line.
+        let doc = load_text(TTL.to_string(), "turtle".to_string(), false).expect("paste loads");
+        assert_eq!(doc.count, 1);
+        assert_eq!(doc.format, "turtle");
+        assert!(doc.nquads.contains("http://example.org/a"));
+    }
+
+    #[test]
+    fn load_text_preserves_named_graphs_when_toggled() {
+        // preserve_graphs routes through load_dataset, so the named graph survives into the
+        // returned N-Quads (a 4-term line); without it the quad-bearing parse path is not taken.
+        let doc = load_text(NQUADS.to_string(), "nquads".to_string(), true).expect("nquads loads");
+        assert_eq!(doc.count, 2);
+        assert!(
+            doc.nquads.contains("http://example.org/g"),
+            "named graph must survive into the merged N-Quads: {}",
+            doc.nquads
+        );
+    }
+
+    #[test]
+    fn load_path_decodes_a_plain_ntriples_file() {
+        let dir = std::env::temp_dir().join(format!("sparq-gui-import-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mk tmp dir");
+        let path = dir.join("data.nt");
+        std::fs::write(&path, TTL).expect("write nt file");
+        let doc = load_path(
+            path.to_string_lossy().into_owned(),
+            "ntriples".to_string(),
+            false,
+        )
+        .expect("ntriples file loads");
+        assert_eq!(doc.count, 1);
+        assert!(doc.nquads.contains("http://example.org/a"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_path_decodes_a_gzip_compressed_file_natively() {
+        use std::io::Write;
+        let dir = std::env::temp_dir().join(format!("sparq-gui-import-gz-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mk tmp dir");
+        let path = dir.join("data.nt.gz");
+        // Write a gzip-compressed N-Triples document, the COMPRESSED half of the bead.
+        let file = std::fs::File::create(&path).expect("create gz file");
+        let mut enc = flate2::write::GzEncoder::new(file, flate2::Compression::default());
+        enc.write_all(TTL.as_bytes()).expect("gz write");
+        enc.finish().expect("gz finish");
+        // The frontend strips the .gz suffix to derive the format; the loader sniffs .gz itself.
+        let doc = load_path(
+            path.to_string_lossy().into_owned(),
+            "ntriples".to_string(),
+            false,
+        )
+        .expect("gzip file decodes + parses natively");
+        assert_eq!(doc.count, 1);
+        assert!(doc.nquads.contains("http://example.org/b"));
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn load_path_reports_missing_file_as_an_error_not_a_panic() {
+        let err = load_path(
+            "/definitely/not/a/real/path/data.nt".to_string(),
+            "ntriples".to_string(),
+            false,
+        )
+        .expect_err("a missing file is an Err");
+        assert!(
+            err.contains("cannot open") || err.contains("cannot read"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    #[cfg(not(feature = "hdt"))]
+    fn hdt_import_in_a_lean_build_fails_loudly_with_a_rebuild_hint() {
+        // Without the `hdt` feature, an .hdt path must NOT be mis-parsed as Turtle — it must
+        // return the actionable rebuild hint.
+        let err = load_path("/tmp/whatever.hdt".to_string(), "hdt".to_string(), false)
+            .expect_err("HDT in a lean build is an Err");
+        assert!(err.contains("--features hdt"), "got: {err}");
     }
 }

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -27,6 +27,11 @@ pub fn run() {
         .manage(EngineState::new())
         .invoke_handler(tauri::generate_handler![
             engine::load,
+            // [OPUS-4.8] sq-ixc3.13 — the Import drawer's native loader: decode a pasted
+            // document (`load_text`) or a disk file (`load_path`, incl. compressed + native-
+            // only HDT) into N-Quads for the in-tab store to merge.
+            engine::load_text,
+            engine::load_path,
             engine::query,
             engine::query_quads,
             engine::update_in_place,

--- a/gui/src-tauri/tauri.conf.json
+++ b/gui/src-tauri/tauri.conf.json
@@ -10,6 +10,7 @@
     "frontendDist": "../app/out"
   },
   "app": {
+    "withGlobalTauri": true,
     "windows": [
       {
         "title": "sparq — RDF + SPARQL workbench",
@@ -22,7 +23,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'"
+      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self' https: http: ipc: http://ipc.localhost"
     }
   },
   "bundle": {


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (site/GUI lane), running on Claude Opus 4.8 (1M context). @jeswr runs several agents on this account — this is automated work. Flagging the design judgment below for you to steer.

Implements **sq-ixc3.13** (epic sq-ixc3) — the GUI **Import drawer**: real disk/URL/paste ingest into the active workspace's live store via the **native loader**, compressed + native-only HDT, named-graph-preserving, persisted. Ref `research/gui-design.md` §A.4 IMPORT spec.

## What it does

A right-side drawer opened from the rail's **+ Import**, the **top bar**, and **Cmd-K** ("Import data…"). Three tabs:

- **File** — native file-open dialog → the engine's **native loader IPC** (`load_path`): Turtle/N-Triples/N-Quads/TriG/JSON-LD, including **compressed** (`.gz`/`.bz2`/`.zst`) streams and **native-only HDT** (`.hdt`/`.hdt.gz`). Off the main thread in the Rust engine (no ~2 GiB wasm-tab ceiling). Desktop only.
- **URL** — fetch a remote document, load it (native `load_text` on desktop, in-tab WASM on web); recorded as a **re-fetchable** `WorkspaceSourceMeta`.
- **Paste** — load a typed/pasted document (native `load_text` on desktop, in-tab on web).

Plus a decompression-aware **format auto-detect** (overridable), a **named-graph-preserving toggle** (the `preserve_graphs` loader arg), and a **replace / add-to-current** merge mode. On success: the **datasets tree** updates (+ an **Imports** subgroup listing the sources) and the import is recorded as a `WorkspaceSourceMeta` + a **workspace snapshot** (the sq-atb0 save/open cache).

## Design decisions (flagging for steer)

1. **Native loader for ingest, in-tab WASM for query.** The GUI runs the in-tab WASM engine for *query* today (engine-context). Rather than splitting queries across two stores, the native loader (engine.rs `load_path`/`load_text`) decodes the document and hands it back as **N-Quads** (named-graph-preserving), which the in-tab store merges. The native side owns the heavy *ingest* (threads, compressed, HDT); the in-tab side owns *query*. This is the smallest honest design — happy to wire the desktop query path onto native IPC later (paired with sq-ixc3.6).
2. **HDT behind an opt-in `hdt` feature** on the gui crate (mirrors the CLI), OFF by default; the desktop release turns it on. A lean build returns an actionable rebuild hint rather than mis-parsing the binary.
3. **Dependency-free frontend bridge.** Set `withGlobalTauri: true` and read `window.__TAURI__.core.invoke` + the `plugin:dialog|open` command — so the GUI needs **no `@tauri-apps/*` npm package** and the web build ships nothing Tauri-shaped. Widened the Tauri CSP `connect-src` to allow the URL-tab fetch.
4. **Minimal workspace context** (active workspace + sources + snapshot persistence) reusing the framework-agnostic `@sparq/client` `createWorkspaceStore` (sq-atb0). The full switcher/create/delete UI + on-disk activation stay with sq-ixc3.6.

I'll open a short issue flagging (1) + (3) for you to confirm.

## Honesty
No performance number anywhere. The web target's lack of a native disk/compressed/HDT path is stated **in the drawer + the status bar** (`loader: native | in-tab`). Local-file imports re-hydrate from the snapshot (no silent cross-session re-read) — the documented sq-atb0 limitation. privacy-claims gate clean (no ZK/MPC copy touched).

## Files / routes
Native: `gui/src-tauri/src/engine.rs` (`load_path`/`load_text`/`to_loaded_document`/`open_reader`/HDT), `lib.rs` (register), `Cargo.toml` (`hdt` feature + flate2/bzip2/zstd/serialize-rdf), `tauri.conf.json` (`withGlobalTauri` + CSP). Frontend: new `import-drawer.tsx`, `tauri-ipc.ts`, `tauri-fs.ts`, `workspace-context.tsx`, `rdf-format.ts`; engine-context import path; rail/top-bar/status-bar/workbench wiring. e2e step 9. The single route `/` is unchanged.

## Gates (green)
- `cargo test --lib engine::` — **8 pass** (default); **7 pass** with `--features hdt` (the lean-build HDT test is `cfg(not(hdt))`).
- `cargo clippy --lib --all-targets -- -D warnings` clean in **both** feature states; `cargo doc -D warnings` (all features) clean; `cargo fmt --check` clean.
- `gui/app`: `tsc --noEmit` clean, `next lint` clean.
- **Static export green end-to-end for BOTH targets** (`build:tauri` + `build:web`) after building the WASM prereq (`js && npm run build:wasm`). No `@tauri-apps` module bundled into the web build.

## Covered vs deferred
Covered: disk (compressed + HDT) / URL / paste ingest, format auto-detect, named-graph toggle, replace/add merge, datasets-tree + Imports-subgroup update, source-meta + snapshot persistence, Cmd-K + rail + top-bar entry points, native unit tests + e2e step. Deferred (other beads): on-disk fs-capability activation (sq-ixc3.6), zipped-archive (.zip) ingest (sq-spita), the full workspace switcher UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)