### PR TITLE
feat(site): add /examples gallery + rebuild /showcase/* demo-first (sq-vw3ax.6) [OPUS-4.8]

### DIFF
--- a/site/src/app/examples/page.tsx
+++ b/site/src/app/examples/page.tsx
@@ -1,0 +1,96 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+
+// [OPUS-4.8] sq-vw3ax.6 — /examples: the curated "show me it working" gallery.
+//
+// A one-line lede + a 2-col grid of LARGE demo cards = the 3 flagships (zk-car-hire,
+// mpc-100k, solid-pairs) + a "Live REPL" card (research/website-redesign.md §4). Each card:
+// title, one-line OUTCOME, tier badge, a decorative still, [Open demo]. No prose walls — the
+// /showcase/* pages (rebuilt demo-first) and /try are the detail targets the cards open.
+//
+// Design judgment (no thumbnail image assets exist in site/public): the "still/thumbnail" is a
+// dependency-free, theme-token CSS panel (the surface icon over a soft gradient), not a raster
+// screenshot. This keeps the static export light and avoids stale/heavy PNGs that would drift
+// from the live demos; a real captured still can drop in later behind the same slot. Flagged in
+// the PR body + a bead note for the maintainer to steer.
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { EXAMPLE_CARDS, type ExampleCard } from "@/data/examples";
+import { TIER_LABEL, TIER_VARIANT } from "@/data/surfaces";
+
+export const metadata: Metadata = {
+  title: "Examples",
+  description:
+    "The curated 'show me it working' gallery — three end-to-end flagship demos (ZK car-hire, MPC £100k threshold, Solid per-pair result sets) plus the live SPARQL REPL, each runnable in your browser tab.",
+};
+
+export default function ExamplesPage() {
+  return (
+    <div className="space-y-8">
+      <header className="space-y-3">
+        <h1 className="text-3xl font-semibold tracking-tight">Examples</h1>
+        <p className="measure text-muted-foreground">
+          See sparq working — four runnable demos. Three end-to-end privacy flagships
+          and the live SPARQL REPL, each opening into a hands-on page.
+        </p>
+      </header>
+
+      <div className="grid gap-5 md:grid-cols-2">
+        {EXAMPLE_CARDS.map((card) => (
+          <ExampleCardItem key={card.href} card={card} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/** A large demo card: a decorative still over title · outcome · tier badge · [Open demo]. */
+function ExampleCardItem({ card }: { card: ExampleCard }) {
+  const Icon = card.icon;
+  return (
+    <Link
+      href={card.href}
+      className="group block focus-visible:outline-none"
+      aria-label={`Open demo: ${card.title}`}
+    >
+      <Card className="h-full overflow-hidden pt-0 transition-colors group-hover:ring-primary/40 group-focus-visible:ring-3 group-focus-visible:ring-ring/50">
+        {/* The "still" — a dependency-free token gradient with the surface icon. */}
+        <div
+          className="relative flex h-32 items-center justify-center bg-gradient-to-br from-primary/15 via-primary/5 to-transparent"
+          aria-hidden
+        >
+          <span className="flex size-14 items-center justify-center rounded-2xl bg-background/70 text-primary shadow-sm ring-1 ring-foreground/10 backdrop-blur">
+            <Icon className="size-7" />
+          </span>
+          <span className="absolute right-3 top-3">
+            <Badge variant={TIER_VARIANT[card.tier]}>{TIER_LABEL[card.tier]}</Badge>
+          </span>
+        </div>
+        <CardHeader className="gap-2">
+          <CardTitle className="flex items-center gap-1.5 text-lg">
+            {card.flagship && (
+              <span className="text-[var(--warning)]" aria-hidden>
+                ★
+              </span>
+            )}
+            {card.title}
+          </CardTitle>
+          <CardDescription className="leading-relaxed">{card.outcome}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <span className="inline-flex items-center gap-1 text-sm font-medium text-primary">
+            Open demo
+            <ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+          </span>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -97,7 +97,14 @@ export default function HomePage() {
         <div>
           <h2 className="text-2xl font-semibold">See it work</h2>
           <p className="text-sm text-muted-foreground">
-            Three end-to-end privacy demonstrations, each runnable.
+            Three end-to-end privacy demonstrations, each runnable —{" "}
+            <Link
+              href="/examples"
+              className="text-primary underline-offset-4 hover:underline"
+            >
+              browse the examples gallery
+            </Link>
+            .
           </p>
         </div>
         <div className="grid gap-4 md:grid-cols-3">

--- a/site/src/app/showcase/mpc-100k/page.tsx
+++ b/site/src/app/showcase/mpc-100k/page.tsx
@@ -1,275 +1,135 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import {
-  ArrowLeft,
-  Lock,
-  Network,
-  Split,
-  Sigma,
-  Eye,
-  Info,
-  TriangleAlert,
-} from "lucide-react";
+import { ArrowLeft, ExternalLink, Info } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { MpcDemo } from "@/components/mpc-demo";
 import { TIER_LABEL, TIER_VARIANT } from "@/data/surfaces";
 
+// [OPUS-4.8] sq-13rg / sq-4r4b — the MPC £100k secure-threshold flagship.
+// [OPUS-4.8] sq-vw3ax.6 — rebuilt DEMO-FIRST (research/website-redesign.md §4): minimal header
+// → the demo immediately → one-line caption → the protocol explanation + the FULL security
+// caveat behind a closed <details>. The privacy qualifiers (faithful SIMULATION, not the
+// hardened crate, NOT a proof of correctness — the correctness layer is a stub, NOT externally
+// audited, semi-honest / honest-majority only) are PRESERVED verbatim inside the disclosure and
+// summarised in the visible header badge (privacy-claims gate).
 export const metadata: Metadata = {
   title: "MPC £100k secure threshold",
   description:
-    "Four flatmates learn only whether their combined income clears a £100k threshold — no salary, and not even the exact total, is revealed. A faithful in-tab illustration of the sparq-mpc secure-threshold protocol.",
+    "Four flatmates learn only whether their combined income clears a £100k threshold — no salary, and not even the exact total, is revealed. A faithful in-tab illustration of the sparq-mpc secure-threshold protocol — not the hardened crate, and not a proof of correctness.",
 };
+
+const REPO_URL = "https://github.com/jeswr/sparq";
 
 export default function MpcFlagshipPage() {
   return (
-    <div className="space-y-10">
+    <div className="space-y-6">
       <Button variant="ghost" size="sm" asChild className="-ml-2">
-        <Link href="/">
+        <Link href="/examples">
           <ArrowLeft className="size-4" aria-hidden="true" />
-          Back to overview
+          Back to examples
         </Link>
       </Button>
 
-      {/* Hero */}
-      <header className="space-y-3">
-        <div className="flex items-center gap-3">
-          <span className="flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
-            <Lock className="size-5" aria-hidden="true" />
+      {/* Minimal header: title + tier + the "faithful illustration" qualifier badge. */}
+      <header className="space-y-2">
+        <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+          <span className="text-[var(--warning)]" aria-hidden="true">
+            ★
           </span>
-          <div>
-            <h1 className="flex items-center gap-2 text-2xl font-semibold">
-              <span className="text-[var(--warning)]" aria-hidden="true">
-                ★
-              </span>
-              MPC £100k secure threshold
-            </h1>
-            <p className="text-sm text-muted-foreground">
-              Can a group collectively afford it — without anyone revealing their
-              salary?
-            </p>
-          </div>
-        </div>
+          MPC £100k secure threshold
+        </h1>
         <div className="flex flex-wrap gap-2">
           <Badge variant={TIER_VARIANT["live-sim"]}>{TIER_LABEL["live-sim"]}</Badge>
-          <Badge variant="muted">Faithful illustration — not live MPC</Badge>
+          <Badge variant="warning">
+            Faithful illustration · not live MPC · not externally audited
+          </Badge>
         </div>
       </header>
 
-      {/* Narrative */}
-      <section className="measure space-y-3 text-muted-foreground">
-        <p>
-          Four flatmates want to apply for a £100k mortgage together. The lender
-          only needs to know one thing:{" "}
-          <strong className="text-foreground">
-            does their combined income clear £100,000?
-          </strong>{" "}
-          Nobody wants to disclose their salary to the others, and the group does
-          not even want to reveal the exact total — only the yes/no answer.
-        </p>
-        <p>
-          Secure multi-party computation (MPC) lets the parties jointly compute
-          that single bit. Each party&rsquo;s income stays on their own device;
-          what crosses the wire is a set of <em>random shares</em> that, on their
-          own, reveal nothing. This mirrors the path tested in the native{" "}
-          <code className="font-mono text-foreground">sparq-mpc</code> crate
-          (30k + 28k + 26k + 24k = 108k → <strong className="text-foreground">true</strong>).
-        </p>
-      </section>
+      {/* The demo, immediately. */}
+      <MpcDemo />
 
-      {/* The interactive demo */}
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold">Try it</h2>
-        <p className="text-sm text-muted-foreground">
-          Set each party&rsquo;s private income and run the secure threshold. The
-          page reveals only the verdict bit — watch the share matrix to see exactly
-          what is exchanged.
-        </p>
-        <MpcDemo />
-      </section>
+      {/* One-line caption. */}
+      <p className="measure text-sm text-muted-foreground">
+        Set each party&rsquo;s private income and run the secure threshold: the page reveals
+        only the yes/no verdict bit — not any salary, and not even the exact total — and the
+        share matrix shows exactly what crosses the wire.
+      </p>
 
-      {/* How the protocol works */}
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold">How the protocol works</h2>
-        <div className="grid gap-4 md:grid-cols-3">
-          <FlowStep
-            icon={Split}
-            n={1}
-            title="Secret-share"
-            body="Each party splits its private value into N random shares whose sum equals the value. Any single share is a uniform random number — it leaks nothing. Each party keeps one share and sends the rest to its peers."
-          />
-          <FlowStep
-            icon={Sigma}
-            n={2}
-            title="Add over shares"
-            body="Addition is free on secret shares: every party locally sums the shares it holds. Combining those local sums yields a sharing of the grand total, without anyone ever seeing another party's value."
-          />
-          <FlowStep
-            icon={Eye}
-            n={3}
-            title="Reveal one bit"
-            body="A secure comparison opens only the boolean total ≥ £100k. The exact total is never reconstructed as an output — the lender learns one bit, and nothing else."
-          />
+      {/* The protocol explanation + the FULL security caveat — behind a closed disclosure. */}
+      <details className="rounded-xl border bg-card px-4 py-3 text-sm">
+        <summary className="cursor-pointer select-none font-medium">
+          How it works &amp; full security caveat
+        </summary>
+        <div className="mt-3 space-y-3 text-muted-foreground">
+          <p>
+            Four flatmates want a £100k mortgage together. The lender needs only one bit:{" "}
+            <strong className="text-foreground">
+              does their combined income clear £100,000?
+            </strong>{" "}
+            Secure multi-party computation lets them jointly compute that bit without anyone
+            disclosing a salary. Each party splits its value into{" "}
+            <strong className="text-foreground">random shares</strong> (any single share is a
+            uniform random number that leaks nothing), addition is free over shares, and a
+            secure comparison opens only the boolean total ≥ £100k — never the total itself.
+            This mirrors the native <code className="font-mono">sparq-mpc</code> crate
+            (30k + 28k + 26k + 24k = 108k →{" "}
+            <strong className="text-foreground">true</strong>).
+          </p>
+          <p>
+            <strong className="text-foreground">What this demo is, and is not.</strong> This
+            page is a{" "}
+            <strong className="text-foreground">
+              client-side illustration of the protocol shape
+            </strong>
+            , not the hardened crate running in your browser — the{" "}
+            <code className="font-mono">sparq-mpc</code> crate is deliberately native-only and
+            absent from the wasm bundle, so nothing cryptographic runs here. The in-tab code
+            uses simple additive (n-of-n) secret sharing with{" "}
+            <code className="font-mono">Math.random</code> to make the &ldquo;shares reveal
+            nothing&rdquo; / &ldquo;addition is free&rdquo; properties visible; the real crate
+            uses honest-majority{" "}
+            <strong className="text-foreground">Shamir t-of-n</strong> sharing and a
+            bit-decomposition secure comparison.
+          </p>
+          <p>
+            Even the native crate makes{" "}
+            <strong className="text-foreground">no production security claim</strong>. It is
+            honest-majority <strong className="text-foreground">semi-honest</strong> only —
+            confidentiality holds against parties that follow the protocol but try to learn
+            more, <strong className="text-foreground">not</strong> against actively-cheating
+            (malicious) parties, and assumes an honest majority. The collaborative
+            zero-knowledge <em>proof of correctness and source-attestation</em> layer is a{" "}
+            <strong className="text-foreground">stub</strong> that returns{" "}
+            <code className="font-mono">NotYetImplemented</code> (beads{" "}
+            <code className="font-mono">sq-9hrn</code> / <code className="font-mono">sq-qhy4</code>),
+            so this demo does <strong className="text-foreground">not</strong> prove the result
+            is correct — there is no soundness guarantee, only that the disclosure pattern is
+            minimal under the semi-honest, honest-majority assumption. No external
+            cryptographer has reviewed sparq&rsquo;s bespoke MPC; treat it as a research /
+            explainer artifact, not a certified secure-computation system.
+          </p>
+          <p className="flex flex-wrap gap-4">
+            <Link
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href="/capabilities#privacy"
+            >
+              <Info className="size-3.5" aria-hidden="true" />
+              The MPC surface in depth
+            </Link>
+            <a
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href={`${REPO_URL}/tree/main/crates/sparq-mpc`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              sparq-mpc on GitHub <ExternalLink className="size-3.5" />
+            </a>
+          </p>
         </div>
-      </section>
-
-      {/* What is shared vs private */}
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold">What is shared vs. what stays private</h2>
-        <div className="grid gap-4 md:grid-cols-2">
-          <Card>
-            <CardHeader className="flex-row items-center gap-2 space-y-0">
-              <Lock className="size-5 text-primary" aria-hidden="true" />
-              <CardTitle className="text-base">Stays private</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2 text-sm text-muted-foreground">
-              <p>
-                <strong className="text-foreground">Each party&rsquo;s income.</strong>{" "}
-                It never leaves the device in the clear; only random shares are
-                sent, and no party can see another&rsquo;s value.
-              </p>
-              <p>
-                <strong className="text-foreground">The exact total.</strong> It is
-                only ever held as a secret sharing and is never opened — only the
-                threshold comparison&rsquo;s result is.
-              </p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader className="flex-row items-center gap-2 space-y-0">
-              <Network className="size-5 text-[var(--success)]" aria-hidden="true" />
-              <CardTitle className="text-base">Shared / revealed</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2 text-sm text-muted-foreground">
-              <p>
-                <strong className="text-foreground">Random shares between peers.</strong>{" "}
-                These cross the wire but are uniformly random — fewer than the
-                reconstruction threshold of them reveal nothing.
-              </p>
-              <p>
-                <strong className="text-foreground">The verdict bit.</strong> The
-                single output: whether the combined income meets £100k. The public
-                threshold itself is, of course, public.
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-      </section>
-
-      {/* HONESTY — mandatory framing */}
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold">Honesty: what this demo is, and is not</h2>
-        <Card className="ring-[var(--warning)]/30">
-          <CardHeader className="flex-row items-center gap-2 space-y-0">
-            <TriangleAlert
-              className="size-5 text-[var(--warning)]"
-              aria-hidden="true"
-            />
-            <CardTitle className="text-base">
-              A faithful illustration — not live MPC, and not a security claim
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm text-muted-foreground">
-            <p>
-              This page is a{" "}
-              <strong className="text-foreground">
-                client-side illustration of the protocol shape
-              </strong>
-              , not the hardened crate running in your browser. The{" "}
-              <code className="font-mono">sparq-mpc</code> crate is deliberately
-              native-only and is absent from the wasm bundle, so nothing
-              cryptographic runs here. The in-tab code uses simple additive
-              (n-of-n) secret sharing with <code className="font-mono">Math.random</code>{" "}
-              to make the &ldquo;shares reveal nothing&rdquo; and &ldquo;addition
-              is free&rdquo; properties visible; the real crate uses honest-majority{" "}
-              <strong className="text-foreground">Shamir t-of-n</strong> sharing and
-              a bit-decomposition secure comparison.
-            </p>
-            <p>
-              Even the native crate makes{" "}
-              <strong className="text-foreground">no production security claim</strong>.
-              It is honest-majority <strong className="text-foreground">semi-honest</strong>{" "}
-              only — confidentiality holds against parties that follow the protocol
-              but try to learn more, <strong className="text-foreground">not</strong> against
-              actively-cheating (malicious) parties, and the confidentiality argument
-              assumes an honest majority. The collaborative zero-knowledge{" "}
-              <em>proof of correctness and source-attestation</em> layer is a{" "}
-              <strong className="text-foreground">stub</strong> that returns{" "}
-              <code className="font-mono">NotYetImplemented</code> (tracked as beads{" "}
-              <code className="font-mono">sq-9hrn</code> /{" "}
-              <code className="font-mono">sq-qhy4</code>). So this demo does{" "}
-              <strong className="text-foreground">not</strong> prove the result is
-              correct — there is no soundness guarantee — only that the disclosure
-              pattern is minimal under the semi-honest, honest-majority assumption.
-            </p>
-            <p>
-              No external cryptographer has reviewed sparq&rsquo;s bespoke MPC. Per
-              the project&rsquo;s published <code className="font-mono">SECURITY.md</code>{" "}
-              posture, treat this as a research / explainer artifact, not a
-              certified secure-computation system. The crypto-review readiness doc
-              (<code className="font-mono">compliance/cryptoreview/</code>, gap{" "}
-              <code className="font-mono">CR-G1</code>) states it plainly:{" "}
-              <code className="font-mono">sparq-mpc</code> carries no confidentiality,
-              correctness, attestation, or malicious-security guarantee today.
-            </p>
-          </CardContent>
-        </Card>
-      </section>
-
-      <section className="flex flex-wrap gap-2">
-        <Button asChild variant="outline" size="sm">
-          <Link href="/surface/mpc">
-            <Info className="size-4" aria-hidden="true" />
-            The MPC surface in depth
-          </Link>
-        </Button>
-        <Button asChild variant="outline" size="sm">
-          <a
-            href="https://github.com/jeswr/sparq/tree/main/crates/sparq-mpc"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            sparq-mpc source on GitHub
-          </a>
-        </Button>
-      </section>
+      </details>
     </div>
-  );
-}
-
-function FlowStep({
-  icon: Icon,
-  n,
-  title,
-  body,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  n: number;
-  title: string;
-  body: string;
-}) {
-  return (
-    <Card className="h-full">
-      <CardHeader className="gap-2">
-        <div className="flex items-center gap-2">
-          <span className="flex size-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
-            <Icon className="size-4.5" aria-hidden="true" />
-          </span>
-          <Badge variant="muted">Step {n}</Badge>
-        </div>
-        <CardTitle className="text-base">{title}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <CardDescription className="leading-relaxed">{body}</CardDescription>
-      </CardContent>
-    </Card>
   );
 }

--- a/site/src/app/showcase/solid-pairs/page.tsx
+++ b/site/src/app/showcase/solid-pairs/page.tsx
@@ -1,26 +1,15 @@
 // [OPUS-4.8] sq-4r4b — the Solid (user, app)-pair flagship page (3rd flagship).
+// [OPUS-4.8] sq-vw3ax.6 — rebuilt DEMO-FIRST (research/website-redesign.md §4): minimal header
+// → the demo immediately → one-line caption → the enforcement explanation + the full caveat
+// behind a closed <details>. The honesty (the restriction is REAL but the access-control
+// DECISION is precomputed; sparq-solid is a research track / authorization oracle, never the
+// sole gate) is preserved inside the disclosure.
 import type { Metadata } from "next";
 import Link from "next/link";
-import {
-  ArrowLeft,
-  Network,
-  Layers,
-  KeyRound,
-  ShieldOff,
-  Eye,
-  Info,
-  TriangleAlert,
-} from "lucide-react";
+import { ArrowLeft, ExternalLink, Info } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { SolidPairsDemo } from "@/components/solid-pairs-demo";
 import { TIER_LABEL, TIER_VARIANT } from "@/data/surfaces";
 
@@ -30,35 +19,26 @@ export const metadata: Metadata = {
     "The same SPARQL query over the same Solid Pod returns different result sets per (user, application) pair — because WAC/ACP access control filters which named graphs each requester may read. A faithful, live-in-tab illustration of sparq-solid's graph-level, fail-closed enforcement.",
 };
 
+const REPO_URL = "https://github.com/jeswr/sparq";
+
 export default function SolidFlagshipPage() {
   return (
-    <div className="space-y-10">
+    <div className="space-y-6">
       <Button variant="ghost" size="sm" asChild className="-ml-2">
-        <Link href="/">
+        <Link href="/examples">
           <ArrowLeft className="size-4" aria-hidden="true" />
-          Back to overview
+          Back to examples
         </Link>
       </Button>
 
-      {/* Hero */}
-      <header className="space-y-3">
-        <div className="flex items-center gap-3">
-          <span className="flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
-            <Network className="size-5" aria-hidden="true" />
+      {/* Minimal header: title + tier + the "decision precomputed, restriction live" qualifier. */}
+      <header className="space-y-2">
+        <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
+          <span className="text-[var(--warning)]" aria-hidden="true">
+            ★
           </span>
-          <div>
-            <h1 className="flex items-center gap-2 text-2xl font-semibold">
-              <span className="text-[var(--warning)]" aria-hidden="true">
-                ★
-              </span>
-              Solid (user, app)-pair result sets
-            </h1>
-            <p className="text-sm text-muted-foreground">
-              The same query over the same Pod — different answers for different
-              requesters.
-            </p>
-          </div>
-        </div>
+          Solid (user, app)-pair result sets
+        </h1>
         <div className="flex flex-wrap gap-2">
           <Badge variant={TIER_VARIANT["live"]}>{TIER_LABEL["live"]}</Badge>
           <Badge variant="muted">
@@ -67,235 +47,86 @@ export default function SolidFlagshipPage() {
         </div>
       </header>
 
-      {/* Narrative */}
-      <section className="measure space-y-3 text-muted-foreground">
-        <p>
-          In Solid, your data lives in <strong className="text-foreground">your Pod</strong>,
-          and you decide who may read what. The same resource can be public,
-          shared with a named friend, or locked to you alone — and the rules can
-          depend not just on <em>who</em> is asking but on{" "}
-          <strong className="text-foreground">which application</strong> they are
-          asking from.
-        </p>
-        <p>
-          So here is the headline insight:{" "}
-          <strong className="text-foreground">
-            run the SAME SPARQL query over the SAME Pod, and the result set you get
-            back depends on the (user, application) pair
-          </strong>{" "}
-          — because WAC/ACP access control filters which documents each requester
-          may see. sparq models a Pod as{" "}
-          <strong className="text-foreground">one named graph per document</strong>{" "}
-          and reduces enforcement to a dataset restriction: a query only ever runs
-          over the named graphs that pair is authorized to read.
-        </p>
-        <p>
-          This page demonstrates that with a small fixed Pod — a public profile,
-          private health data, a shared calendar, and private notes — and a
-          selector for (user, app) pairs. Pick two pairs, run a query (the demo
-          one, or your own), and watch the answers diverge, with the WAC/ACP grant
-          that produced each result shown alongside it.
-        </p>
-      </section>
+      {/* The demo, immediately. */}
+      <SolidPairsDemo />
 
-      {/* The interactive demo */}
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold">Try it</h2>
-        <p className="text-sm text-muted-foreground">
-          The query is the same for both pairs on a given run &mdash; and you can{" "}
-          <strong className="text-foreground">edit it and re-run</strong>. What differs
-          is the authorized named-graph set the engine restricts to: the materialized
-          access-control decision for that (agent, client), injected as a{" "}
-          <code className="font-mono">FROM NAMED</code> clause around whatever you type.
-        </p>
-        <SolidPairsDemo />
-      </section>
+      {/* One-line caption. */}
+      <p className="measure text-sm text-muted-foreground">
+        Run the same SPARQL over the same Pod for two different (user, app) pairs and watch the
+        answers diverge — the engine restricts each query to exactly the named graphs that pair
+        is authorized to read, with the WAC/ACP grant that produced each result shown alongside.
+      </p>
 
-      {/* How enforcement works */}
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold">How the enforcement works</h2>
-        <div className="grid gap-4 md:grid-cols-3">
-          <FlowStep
-            icon={Layers}
-            n={1}
-            title="One named graph per document"
-            body="A Pod loads as a dataset where each document is a named graph whose name is the resource IRI. WAC .acl / ACP .acr documents are themselves queryable graphs. Access control lives at the graph level."
-          />
-          <FlowStep
-            icon={KeyRound}
-            n={2}
-            title="Materialize the authorized set"
-            body="For a Session { agent, client }, sparq-solid runs N3 rules over the WAC/ACP rules to compute exactly the named graphs that pair may read. The session key is the (agent, client) pair — the same agent from a different app can get a different set."
-          />
-          <FlowStep
-            icon={Eye}
-            n={3}
-            title="Restrict the query (FROM NAMED)"
-            body="The same query is evaluated only over that authorized set, via a FROM NAMED dataset restriction (sparq-solid's rewrite_for). Graphs outside the set are simply absent from the query's dataset — so the rows that come back differ per requester."
-          />
+      {/* The enforcement explanation + the full caveat — behind a closed disclosure. */}
+      <details className="rounded-xl border bg-card px-4 py-3 text-sm">
+        <summary className="cursor-pointer select-none font-medium">
+          How enforcement works &amp; full caveat
+        </summary>
+        <div className="mt-3 space-y-3 text-muted-foreground">
+          <p>
+            In Solid your data lives in <strong className="text-foreground">your Pod</strong>,
+            and the rules for who may read what can depend not just on <em>who</em> is asking
+            but on <strong className="text-foreground">which application</strong> they ask
+            from. sparq models a Pod as{" "}
+            <strong className="text-foreground">one named graph per document</strong> and
+            reduces enforcement to a dataset restriction: for a Session {`{ agent, client }`},
+            sparq-solid materializes exactly the named graphs that pair may read, then evaluates
+            the query only over that authorized set via a{" "}
+            <code className="font-mono">FROM NAMED</code> clause (its{" "}
+            <code className="font-mono">rewrite_for</code> path). The default is fail-closed:
+            absence of a grant is denial, and a non-authorized graph is indistinguishable from
+            absent — an ungranted requester gets the empty set, so the Pod looks empty to it.
+          </p>
+          <p>
+            <strong className="text-foreground">What is real, and what is precomputed.</strong>{" "}
+            The <strong className="text-foreground">restriction you see is real</strong>: the
+            Pod is loaded into the sparq wasm engine in your tab with its named graphs
+            preserved, and the same query is rewritten per pair — the differing result sets are
+            the real engine doing the real graph-level restriction. What is{" "}
+            <strong className="text-foreground">precomputed</strong> is the access-control{" "}
+            <em>decision</em> (which named graphs each pair may read): the WAC/ACP
+            materialization runs natively / at build time, not in the browser, and ships here as
+            fixtures (the rules behind each are shown in the &ldquo;why these graphs?&rdquo;
+            panels, so nothing is hidden).
+          </p>
+          <p>
+            Most importantly, <code className="font-mono">sparq-solid</code> is a{" "}
+            <strong className="text-foreground">research track, not a Solid-server
+            cutover</strong>. Per the project house rule (issue #55), security-critical paths
+            run through vetted TypeScript in the production Solid server; sparq-solid is at most
+            an authorization <strong className="text-foreground">oracle</strong>, never the sole
+            gate. It does not authenticate — it answers a graph-set question for an
+            already-resolved (WebID, client) Session. This demo shows the graph-level
+            access-control <em>capability and semantics</em>, not a certified production Solid
+            deployment.
+          </p>
+          <p className="flex flex-wrap gap-4">
+            <Link
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href="/try"
+            >
+              <Info className="size-3.5" aria-hidden="true" />
+              The live SPARQL REPL
+            </Link>
+            <a
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href={`${REPO_URL}/tree/main/crates/sparq-solid`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              sparq-solid on GitHub <ExternalLink className="size-3.5" />
+            </a>
+            <a
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href={`${REPO_URL}/issues/55`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Issue #55 — scope &amp; house rule <ExternalLink className="size-3.5" />
+            </a>
+          </p>
         </div>
-      </section>
-
-      {/* What differs vs what stays */}
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold">
-          Fail-closed: no grant means no data
-        </h2>
-        <div className="grid gap-4 md:grid-cols-2">
-          <Card>
-            <CardHeader className="flex-row items-center gap-2 space-y-0">
-              <KeyRound className="size-5 text-primary" aria-hidden="true" />
-              <CardTitle className="text-base">What a pair can see</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2 text-sm text-muted-foreground">
-              <p>
-                <strong className="text-foreground">Only graphs with a matching grant.</strong>{" "}
-                The authorized set is an allow-list: a document is visible only if
-                some WAC/ACP rule grants this (agent, client) pair read access to it.
-              </p>
-              <p>
-                <strong className="text-foreground">App-scoped grants are honoured.</strong>{" "}
-                A grant scoped to one application (WAC <code className="font-mono">acl:origin</code>,
-                ACP <code className="font-mono">acp:client</code>) is minted as a
-                pair principal — so the owner from her trusted health app sees data
-                the owner from a different app does not.
-              </p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardHeader className="flex-row items-center gap-2 space-y-0">
-              <ShieldOff className="size-5 text-[var(--warning)]" aria-hidden="true" />
-              <CardTitle className="text-base">What stays invisible</CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-2 text-sm text-muted-foreground">
-              <p>
-                <strong className="text-foreground">Anything with no applicable grant.</strong>{" "}
-                Absence of a grant is denial — the default is fail-closed (design
-                decision D4). A non-authorized graph is{" "}
-                <strong className="text-foreground">indistinguishable from absent</strong>:
-                the requester cannot even tell it exists.
-              </p>
-              <p>
-                <strong className="text-foreground">An empty authorized set ⇒ zero rows.</strong>{" "}
-                An anonymous or ungranted (agent, client) gets the empty set, so the
-                query is restricted to a guaranteed-absent graph and returns nothing
-                — the Pod looks empty to it.
-              </p>
-            </CardContent>
-          </Card>
-        </div>
-      </section>
-
-      {/* HONESTY — mandatory framing */}
-      <section className="space-y-3">
-        <h2 className="text-xl font-semibold">Honesty: what this demo is, and is not</h2>
-        <Card className="ring-[var(--warning)]/30">
-          <CardHeader className="flex-row items-center gap-2 space-y-0">
-            <TriangleAlert
-              className="size-5 text-[var(--warning)]"
-              aria-hidden="true"
-            />
-            <CardTitle className="text-base">
-              A capability illustration — not a production Solid server
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-3 text-sm text-muted-foreground">
-            <p>
-              The <strong className="text-foreground">restriction you see is real</strong>:
-              the Pod is loaded into the sparq wasm engine in your tab with its named
-              graphs preserved, and the same query is rewritten per pair with a{" "}
-              <code className="font-mono">FROM NAMED</code> dataset clause — exactly
-              sparq-solid&rsquo;s <code className="font-mono">rewrite_for</code> /{" "}
-              <code className="font-mono">query_as_rewrite</code> path. The differing
-              result sets are the real engine doing the real graph-level restriction.
-            </p>
-            <p>
-              What is <strong className="text-foreground">precomputed</strong> is the
-              access-control <em>decision</em> — which named graphs each (agent,
-              client) pair is authorized to read. In the real system the WAC/ACP
-              materialization (the <code className="font-mono">sparq-solid</code>{" "}
-              crate&rsquo;s N3 reasoner running over the <code className="font-mono">.acl</code>/
-              <code className="font-mono">.acr</code> rules) runs natively / at build
-              time, not in the browser. This page ships those authorized sets as
-              fixtures and applies them live; the WAC/ACP rules behind each one are
-              shown in the &ldquo;why these graphs?&rdquo; panels so nothing is hidden.
-            </p>
-            <p>
-              Most importantly, <code className="font-mono">sparq-solid</code> is a{" "}
-              <strong className="text-foreground">research track, not a Solid-server
-              cutover</strong>. Per the project&rsquo;s house rule (issue #55):{" "}
-              <em>
-                security-critical paths run through vetted TypeScript in the
-                production Solid server; sparq-solid is at most an authorization{" "}
-                <strong className="text-foreground">oracle</strong>, never the sole
-                gate
-              </em>
-              . It does not authenticate — it takes an already-resolved (WebID,
-              client) Session and answers a graph-set question. HTTP status semantics
-              (401 vs 403, <code className="font-mono">WAC-Allow</code>), Solid-OIDC /
-              DPoP, and the request lifecycle all stay in the vetted server. This demo
-              shows sparq&rsquo;s graph-level access-control <em>capability and
-              semantics</em>, not a certified production Solid deployment.
-            </p>
-          </CardContent>
-        </Card>
-      </section>
-
-      <section className="flex flex-wrap gap-2">
-        <Button asChild variant="outline" size="sm">
-          <Link href="/try">
-            <Info className="size-4" aria-hidden="true" />
-            The live SPARQL REPL
-          </Link>
-        </Button>
-        <Button asChild variant="outline" size="sm">
-          <a
-            href="https://github.com/jeswr/sparq/tree/main/crates/sparq-solid"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            sparq-solid source on GitHub
-          </a>
-        </Button>
-        <Button asChild variant="outline" size="sm">
-          <a
-            href="https://github.com/jeswr/sparq/issues/55"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Issue #55 — scope &amp; house rule
-          </a>
-        </Button>
-      </section>
+      </details>
     </div>
-  );
-}
-
-function FlowStep({
-  icon: Icon,
-  n,
-  title,
-  body,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  n: number;
-  title: string;
-  body: string;
-}) {
-  return (
-    <Card className="h-full">
-      <CardHeader className="gap-2">
-        <div className="flex items-center gap-2">
-          <span className="flex size-9 items-center justify-center rounded-lg bg-primary/10 text-primary">
-            <Icon className="size-4.5" aria-hidden="true" />
-          </span>
-          <Badge variant="muted">Step {n}</Badge>
-        </div>
-        <CardTitle className="text-base">{title}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <CardDescription className="leading-relaxed">{body}</CardDescription>
-      </CardContent>
-    </Card>
   );
 }

--- a/site/src/app/showcase/zk-car-hire/page.tsx
+++ b/site/src/app/showcase/zk-car-hire/page.tsx
@@ -1,52 +1,107 @@
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, ExternalLink } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { ZkCarHire } from "@/components/zk-car-hire";
 
 // [OPUS-4.8] sq-13rg / sq-4r4b — the ZK cross-credential car-hire flagship.
+// [OPUS-4.8] sq-vw3ax.6 — rebuilt DEMO-FIRST (research/website-redesign.md §4): minimal header
+// → the live demo immediately → one-line caption → the full security caveat behind a closed
+// <details>. The research-grade / NOT-externally-audited qualifier stays VISIBLE in the header
+// badge (privacy-claims gate); the soundness/linkability detail relocates into the disclosure.
 export const metadata: Metadata = {
   title: "ZK car-hire — prove eligibility, reveal nothing",
   description:
     "Research-grade (not externally audited): a real zero-knowledge proof — age ≥ 25 over hidden credential data — generated in your browser via Noir + Barretenberg UltraHonk. The exact age is never disclosed in-circuit; the v1 verifier carries no production soundness guarantee.",
 };
 
+const REPO_URL = "https://github.com/jeswr/sparq";
+
 export default function ZkCarHirePage() {
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       <Button variant="ghost" size="sm" asChild className="-ml-2">
-        <Link href="/">
-          <ArrowLeft className="size-4" />
-          Back to overview
+        <Link href="/examples">
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Back to examples
         </Link>
       </Button>
 
-      <header className="space-y-3">
-        <div className="flex items-center gap-2">
-          <Badge variant="success">Live via bb.js — real proof in your tab</Badge>
-          <Badge variant="warning">Research-grade · not externally audited</Badge>
-        </div>
+      {/* Minimal header: title + the tier + research-grade badges (the privacy qualifier stays
+          visible up top; the full hedge moves into the caveat disclosure below). */}
+      <header className="space-y-2">
         <h1 className="flex items-center gap-2 text-2xl font-semibold tracking-tight">
           <span className="text-[var(--warning)]" aria-hidden>
             ★
           </span>
           Prove you may hire a car — reveal nothing
         </h1>
-        <p className="measure text-muted-foreground">
-          A renter holds two W3C Verifiable Credentials — a gov-ID and a DVLA
-          driving licence. The car-hire desk must learn only that the renter is{" "}
-          <strong>≥ 25</strong>, holds a <strong>valid licence</strong>, and that
-          both credentials belong to the <strong>same person</strong> — and nothing
-          else: not the date of birth, not the licence number, not the identity.
-          The age-gate below proves <em>age ≥ 25</em> over a hidden age with a real
-          UltraHonk zero-knowledge proof, generated and verified entirely in your
-          browser.
-        </p>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="success">Live via bb.js — real proof in your tab</Badge>
+          <Badge variant="warning">Research-grade · not externally audited</Badge>
+        </div>
       </header>
 
+      {/* The demo, immediately. */}
       <ZkCarHire />
+
+      {/* One-line caption. */}
+      <p className="measure text-sm text-muted-foreground">
+        The age-gate proves <em>age ≥ 25</em> over a hidden date of birth with a real
+        UltraHonk zero-knowledge proof, generated and verified entirely in your browser —
+        the exact age, the licence number, and the holder&rsquo;s identity are never revealed.
+      </p>
+
+      {/* The full security caveat — behind a closed disclosure. */}
+      <details className="rounded-xl border bg-card px-4 py-3 text-sm">
+        <summary className="cursor-pointer select-none font-medium">
+          Details &amp; full security caveat
+        </summary>
+        <div className="mt-3 space-y-3 text-muted-foreground">
+          <p>
+            A renter holds two W3C Verifiable Credentials — a gov-ID and a DVLA driving
+            licence. The car-hire desk must learn only that the renter is{" "}
+            <strong className="text-foreground">≥ 25</strong>, holds a{" "}
+            <strong className="text-foreground">valid, non-revoked licence</strong>, and that
+            both credentials belong to the{" "}
+            <strong className="text-foreground">same person</strong> — and nothing else: not
+            the date of birth, not the licence number, not the identity.
+          </p>
+          <p>
+            The proof runs in-tab via the third-party{" "}
+            <code className="font-mono">bb.js</code> UltraHonk prover over a Noir circuit; the
+            ~MB prover chunk loads only when you run the demo. The v1 verifier is{" "}
+            <strong className="text-foreground">research-grade</strong>: sound as landed under
+            its stated threat model, but{" "}
+            <strong className="text-foreground">not externally audited</strong> and pending
+            re-review — treat the timings and gate counts as indicative engineering numbers,{" "}
+            <strong className="text-foreground">not</strong> an audited cryptographic
+            guarantee. Reproduction commands, the full circuit/public-input contract, and the
+            soundness/linkability discussion live in the crate README and{" "}
+            <code className="font-mono">SKILL.md</code>.
+          </p>
+          <p className="flex flex-wrap gap-4">
+            <a
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href={`${REPO_URL}/tree/main/crates/sparq-zk`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              sparq-zk on GitHub <ExternalLink className="size-3.5" />
+            </a>
+            <a
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href={`${REPO_URL}/blob/main/skills/zk/SKILL.md`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ZK SKILL.md <ExternalLink className="size-3.5" />
+            </a>
+          </p>
+        </div>
+      </details>
     </div>
   );
 }

--- a/site/src/components/command-palette.tsx
+++ b/site/src/components/command-palette.tsx
@@ -96,6 +96,9 @@ export function useCommandPalette() {
 // /download + /app are the discovery gaps the maintainer flagged.
 const TOP_PAGES: { href: string; title: string; blurb: string }[] = [
   { href: "/", title: "Home", blurb: "Overview — what sparq is, the live REPL, the flagships." },
+  // [OPUS-4.8] sq-vw3ax.6 — the curated "show me it working" gallery (3 flagships + Live REPL).
+  // Discoverable here in Cmd-K (0 clicks) without bloating the slim top bar — the bar stays at 6.
+  { href: "/examples", title: "Examples", blurb: "The curated 'show me it working' demo gallery." },
   { href: "/capabilities", title: "Capabilities", blurb: "Every surface in one gallery, by theme." },
   { href: "/app", title: "App", blurb: "The live operational GUI (hosted web app coming soon)." },
   { href: "/benchmarks", title: "Benchmarks", blurb: "Per-commit, same-box benchmark dashboard." },

--- a/site/src/data/examples.ts
+++ b/site/src/data/examples.ts
@@ -1,0 +1,63 @@
+// [OPUS-4.8] sq-vw3ax.6 — the /examples gallery model: the curated "show me it working"
+// set, derived from the single FLAGSHIPS source (data/surfaces.ts) plus the live REPL.
+//
+// /examples is the curated "show me it working" gallery (research/website-redesign.md §4):
+// a 2-col grid of LARGE demo cards = the 3 flagships (zk-car-hire, mpc-100k, solid-pairs) +
+// a "Live REPL" card. Each card carries a one-line OUTCOME (what you walk away having proven),
+// a tier badge, and an [Open demo] CTA. The /showcase/<slug> pages are the detail targets
+// (rebuilt demo-first); the REPL card targets /try.
+//
+// Keeping the three flagship items derived from FLAGSHIPS (rather than re-listed) means a
+// re-word of a flagship's title/blurb/tier in surfaces.ts flows straight into this gallery, the
+// Home "See it work" row, and Cmd-K together — no second source to drift.
+
+import { PlayCircle, type LucideIcon } from "lucide-react";
+
+import { FLAGSHIPS, type Tier } from "@/data/surfaces";
+
+export interface ExampleCard {
+  /** Stable key + the demo route the card opens. */
+  href: string;
+  title: string;
+  /** One-line OUTCOME — what you walk away having seen proven (not a feature list). */
+  outcome: string;
+  tier: Tier;
+  icon: LucideIcon;
+  /** Flagships carry the ★ marker; the REPL card does not. */
+  flagship: boolean;
+}
+
+// A per-flagship one-line OUTCOME (the "you walk away having proven X" line), keyed by slug.
+// The flagship `blurb` in surfaces.ts is the longer descriptive sentence used elsewhere; the
+// gallery wants the terse outcome, so it lives here, next to the gallery that consumes it.
+const FLAGSHIP_OUTCOME: Record<string, string> = {
+  "zk-car-hire": "Prove you may hire a car without revealing your documents.",
+  "mpc-100k":
+    "Learn only whether four incomes clear £100k — no salary, not even the total, revealed.",
+  "solid-pairs":
+    "One query, one Pod — a different result set per (user, app) pair, enforced live.",
+};
+
+const FLAGSHIP_CARDS: ExampleCard[] = FLAGSHIPS.map((f) => ({
+  href: f.href,
+  title: f.title,
+  outcome: FLAGSHIP_OUTCOME[f.slug] ?? f.blurb,
+  tier: f.tier,
+  icon: f.icon,
+  flagship: true,
+}));
+
+// The live REPL card — the single best proof artifact (the killer demo), opened as a large
+// card alongside the flagships, targeting its own /try route.
+const REPL_CARD: ExampleCard = {
+  href: "/try",
+  title: "Live SPARQL REPL",
+  outcome:
+    "Run real SPARQL against a sample graph — the Rust engine compiled to wasm, in your tab.",
+  tier: "live",
+  icon: PlayCircle,
+  flagship: false,
+};
+
+/** The curated example gallery: the 3 flagships + the live REPL, in display order. */
+export const EXAMPLE_CARDS: ExampleCard[] = [...FLAGSHIP_CARDS, REPL_CARD];


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** working the site lane. This PR is automated work on bead **sq-vw3ax.6** (website-redesign epic sq-vw3ax). Flagged `[OPUS-4.8]` for later re-review.

## What this does

Implements **sq-vw3ax.6** (research/website-redesign.md §4): a new **/examples** gallery + a **demo-first rebuild of /showcase/***.

### NEW `/examples`
The curated "show me it working" gallery: a one-line lede + a **2-col grid of large demo cards** = the **3 flagships** (zk-car-hire, mpc-100k, solid-pairs) + a **Live REPL** card. Each card: title, one-line **outcome**, tier badge, a still, **[Open demo]**. No prose walls.
- Cards are **derived from the single `FLAGSHIPS` source** (`data/surfaces.ts`) via a new `data/examples.ts`, so the gallery, Home's "See it work" row, and Cmd-K never drift.
- Discoverable in **0 clicks via Cmd-K** (added to `TOP_PAGES`) and linked from Home's "See it work" — **without bloating the slim 6-item top bar** (the maintainer's Option-B decision in sq-vw3ax.7 deliberately kept the bar slim; Papers already lives in Cmd-K overflow, so /examples follows the same pattern).

### Rebuilt `/showcase/{zk-car-hire,mpc-100k,solid-pairs}` demo-first
Each page now reads: minimal header (back-to-examples + title + tier badges) → **the live demo immediately** → one-line caption → the full explanation + security caveat **behind a closed `<details>`**. Replaces the prose-walls / always-open "How it works" + "Honesty" sections.

## Privacy-claims honesty (LIVE gate)
Every ZK/MPC qualifier is **preserved**, just relocated behind the disclosure and summarised in the visible header badge:
- **ZK**: "Research-grade · not externally audited" badge stays up top; the soundness/linkability hedge moves into the caveat.
- **MPC**: "Faithful illustration · not live MPC · not externally audited" badge; the full hedge (faithful **simulation**, not the hardened crate, **not a proof of correctness** — the correctness layer is a **stub**, semi-honest/honest-majority only, no production security claim) preserved verbatim.
- **Solid**: "decision precomputed · restriction is live" badge; the research-track / authorization-**oracle**-never-sole-gate caveat preserved.

`scripts/check-privacy-claims.sh` passes (425 files scanned, no unqualified claim).

## Design judgment (for maintainer steer)
No thumbnail image assets exist in `site/public/`. The card "still" is a **dependency-free theme-token CSS panel** (the surface icon over a soft gradient), not a raster screenshot — keeps the static export light and avoids stale PNGs drifting from the live demos. A real captured still can drop into the same slot later. Documented here + in the bead note.

## Gates (all green)
- `cd site && npm install && npm run build` — static export succeeds end-to-end; `/examples` + `/showcase/*` emitted into `out/` with `basePath: /sparq` on every asset and cross-link.
- `npm run lint` clean · `tsc --noEmit` clean (no `any`-escapes).
- `scripts/check-privacy-claims.sh` + `scripts/check-terminology.py` clean.
- **WASM prereq**: lean `sparq_wasm` bundle built first (`cd js && npm run build:wasm`) — build artifact only, no `crates/` source changes.
- No new dependencies. No hard-coded perf numbers.

## Scope / not in scope
- Covered: /examples gallery, demo-first /showcase rebuild, Cmd-K + Home discoverability.
- Deferred (other beads): the deep-page rebuild (sq-vw3ax.4), captured raster stills.

Closes the bead on PR-open. Auto-merge **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)