### PR TITLE
feat(site): condense the 5 capability deep pages to the scan-first template (sq-vw3ax.8) [OPUS-4.8]

### DIFF
--- a/site/src/app/surface/data-formats/page.tsx
+++ b/site/src/app/surface/data-formats/page.tsx
@@ -10,6 +10,9 @@ export const metadata: Metadata = {
     "Parse and load RDF into a sparq Graph — Turtle, N-Triples, N-Quads, TriG, JSON-LD, compressed dumps, and the binary HDT archive format.",
 };
 
+// [OPUS-4.8] sq-vw3ax.8 — condensed to the scan-first template: demo first, one-line lead,
+// ≤5 capabilities, single-sentence runs note + reproduce, caveats behind <details>, plus the
+// universal README + SKILL.md links. The full loader/writer matrix lives in the SKILL.
 export default function DataFormatsSurfacePage() {
   return (
     <SurfaceContent
@@ -18,35 +21,13 @@ export default function DataFormatsSurfacePage() {
       statement="Getting RDF into a sparq Graph: the four text formats, compressed ingest, and HDT."
       tier="live"
       intro={
-        <>
-          <p>
-            sparq parses the four standard RDF text formats —{" "}
-            <strong className="text-foreground">Turtle, N-Triples, N-Quads</strong>{" "}
-            and <strong className="text-foreground">TriG</strong> — in{" "}
-            <code className="font-mono text-foreground">sparq-core</code>, with
-            in-memory, streaming, parallel and external-memory loaders for large
-            dumps. The binary{" "}
-            <strong className="text-foreground">HDT</strong> archive format (and its
-            content-sniffed <code className="font-mono">.hdt.gz</code> /{" "}
-            <code className="font-mono">.hdt.zst</code> /{" "}
-            <code className="font-mono">.hdt.bz2</code> variants) lives in the
-            opt-in <code className="font-mono text-foreground">sparq-hdt</code>{" "}
-            crate.
-          </p>
-          <p>
-            <strong className="text-foreground">JSON-LD 1.1</strong> (JSON for
-            linked data) parses through the opt-in{" "}
-            <code className="font-mono text-foreground">jsonld</code> feature
-            (oxjsonld) — which the site&apos;s wasm bundle enables, so the picker
-            below reads it too.
-          </p>
-          <p>
-            These crates parse RDF <em>in</em>; to write RDF <em>out</em>, the
-            engine ships a writer matrix (Turtle / TriG / N-Quads / JSON-LD 1.1)
-            behind its <code className="font-mono">serialize-rdf</code> feature,
-            with the N-Triples writer always on.
-          </p>
-        </>
+        <p>
+          sparq parses the four standard RDF text formats (Turtle / N-Triples / N-Quads /
+          TriG) and JSON-LD 1.1 in <code className="font-mono text-foreground">sparq-core</code>,
+          with the binary HDT archive format in the opt-in{" "}
+          <code className="font-mono text-foreground">sparq-hdt</code> crate; the picker
+          above runs the same loaders the published wasm bundle ships.
+        </p>
       }
       capabilities={[
         {
@@ -58,53 +39,32 @@ export default function DataFormatsSurfacePage() {
           body: "JSON for linked data — parsed via the opt-in jsonld feature (oxjsonld), which the site bundle enables.",
         },
         {
-          title: "Compressed ingest",
-          body: "gzip / zstd / bzip2 RDF dumps decode-and-load natively (fused decompress + parallel parse); gzip also decodes live in the browser.",
-        },
-        {
-          title: "Streaming & parallel loaders",
-          body: "Chunk-parallel parsing for large N-Triples dumps; external-memory ingest (native).",
+          title: "Compressed & streaming ingest",
+          body: "gzip / zstd / bzip2 dumps decode-and-load natively (fused decompress + parallel parse); gzip also decodes live in the browser.",
         },
         {
           title: "HDT archives",
           body: "Load .hdt and content-sniffed .hdt.gz/.zst/.bz2 via the opt-in sparq-hdt crate.",
         },
         {
-          title: "Copy-on-write snapshots",
-          body: "Cheap immutable Graph snapshots for concurrent serving.",
-        },
-        {
           title: "RDF writer matrix",
-          body: "Serialize back out to Turtle / TriG / N-Quads / JSON-LD (engine serialize-rdf feature).",
+          body: "Serialize back out to Turtle / TriG / N-Quads / JSON-LD (engine serialize-rdf feature; N-Triples always on).",
         },
       ]}
-      runsNote={
-        <>
-          <p>
-            <strong className="text-foreground">Live in your tab</strong> for the
-            four text formats and JSON-LD — the demo above runs the same{" "}
-            <code className="font-mono">Store.load</code> /{" "}
-            <code className="font-mono">loadDataset</code> loaders that ship in{" "}
-            <code className="font-mono">@jeswr/sparq</code>, compiled to wasm. The
-            gzip-ingest panel decodes with the browser&apos;s native{" "}
-            <code className="font-mono">DecompressionStream</code> before parsing —
-            no codec library, no server.
-          </p>
-        </>
-      }
+      runsNote="Live in your tab for the four text formats and JSON-LD — the demo runs the same loaders that ship in @jeswr/sparq, and the gzip panel decodes with the browser's native DecompressionStream before parsing, with no codec library and no server."
+      reproduce="cargo test -p sparq-core"
       caveat={
-        <>
-          <p>
-            Only <strong className="text-foreground">gzip</strong> decodes in the
-            browser (via <code className="font-mono">DecompressionStream</code>);{" "}
-            <strong className="text-foreground">zstd</strong> and{" "}
-            <strong className="text-foreground">bzip2</strong> ingest, HDT loading,
-            the mmap / external-memory path, and the fully-parallel fast loaders are{" "}
-            <strong className="text-foreground">native-only</strong> — in the
-            browser the in-memory streaming loader is used.
-          </p>
-        </>
+        <p>
+          Only <strong className="text-foreground">gzip</strong> decodes in the browser
+          (via <code className="font-mono">DecompressionStream</code>);{" "}
+          <strong className="text-foreground">zstd</strong> and{" "}
+          <strong className="text-foreground">bzip2</strong> ingest, HDT loading, the
+          mmap / external-memory path, and the fully-parallel fast loaders are
+          native-only — in the browser the in-memory streaming loader is used.
+        </p>
       }
+      readmeHref="https://github.com/jeswr/sparq/tree/main/crates/sparq-core"
+      skillHref="https://github.com/jeswr/sparq/blob/main/skills/data-formats/SKILL.md"
       links={[{ href: "/try", label: "Open the full SPARQL REPL" }]}
     >
       <DataFormatsDemo />

--- a/site/src/app/surface/inference/page.tsx
+++ b/site/src/app/surface/inference/page.tsx
@@ -10,6 +10,9 @@ export const metadata: Metadata = {
     "Forward-chaining RDFS / OWL 2 RL / Notation3 reasoning with the sparq reasoner — base vs entailed triple counts and a why() derivation proof tree, live in your tab via the W-reason wasm bundle.",
 };
 
+// [OPUS-4.8] sq-vw3ax.8 — condensed to the scan-first template: demo first, one-line lead,
+// ≤5 capabilities, single-sentence runs note + reproduce, caveats behind <details>, plus the
+// universal README + SKILL.md links. The bundle-mechanics detail moves to the SKILL.
 export default function InferenceSurfacePage() {
   return (
     <SurfaceContent
@@ -18,40 +21,18 @@ export default function InferenceSurfacePage() {
       statement="Forward-chain the RDFS / OWL 2 RL / N3 closure — see what reasoning adds, then ask why."
       tier="live-new-wasm"
       intro={
-        <>
-          <p>
-            <code className="font-mono text-foreground">sparq-reason</code> is a
-            forward-chaining reasoner over a{" "}
-            <code className="font-mono">sparq_core::Graph</code>: it materializes
-            the deductive closure of an ontology + facts under{" "}
-            <strong className="text-foreground">RDFS</strong> or{" "}
-            <strong className="text-foreground">OWL 2 RL</strong>, runs{" "}
-            <strong className="text-foreground">Notation3 rules</strong> (
-            <code className="font-mono">{"{ … } => { … }"}</code>), and — uniquely —
-            reconstructs a <code className="font-mono">why()</code>{" "}
-            <strong className="text-foreground">derivation proof tree</strong> for
-            any entailed triple: the chain of inference rules and asserted facts that
-            justify it.
-          </p>
-          <p>
-            Because it is pure Rust over <code className="font-mono">sparq-engine</code>
-            , it compiles to wasm. The playground below loads the tier-b{" "}
-            <strong className="text-foreground">&ldquo;W-reason&rdquo; bundle</strong>{" "}
-            on demand — a separate, lazily-loaded bundle from the lean SPARQL REPL — and
-            runs the reasoner in this tab: paste an ontology, see the base vs entailed
-            triple counts, then click an entailed triple to render its proof. The
-            default is the classic Socrates syllogism.
-          </p>
-        </>
+        <p>
+          <code className="font-mono text-foreground">sparq-reason</code> materializes
+          the deductive closure under RDFS, OWL 2 RL or Notation3 rules and — uniquely —
+          reconstructs a <code className="font-mono">why()</code> derivation proof tree
+          for any entailed triple; the playground above runs it in your tab on the
+          lazily-loaded W-reason wasm bundle.
+        </p>
       }
       capabilities={[
         {
-          title: "RDFS closure",
-          body: "subClassOf / subPropertyOf / domain / range entailments, forward-chained to fixpoint.",
-        },
-        {
-          title: "OWL 2 RL closure",
-          body: "Property axioms (inverseOf, symmetric/transitive), class axioms, restrictions — the RL profile (includes RDFS).",
+          title: "RDFS & OWL 2 RL closure",
+          body: "subClassOf / subPropertyOf / domain / range plus the RL property & class axioms, forward-chained to fixpoint.",
         },
         {
           title: "Notation3 rules",
@@ -70,37 +51,20 @@ export default function InferenceSurfacePage() {
           body: "Just the triples reasoning ADDED — the closure minus the asserted base — not the whole closure.",
         },
       ]}
-      runsNote={
-        <>
-          <p>
-            <strong className="text-foreground">Live in your browser tab.</strong>{" "}
-            The reasoner is pure Rust over the engine, compiled to wasm in the
-            separate W-reason bundle (
-            <code className="font-mono">sparq-reason-wasm</code>, built with the{" "}
-            <code className="font-mono">explain</code> feature for{" "}
-            <code className="font-mono">why()</code>). The page lazy-loads it on first
-            interaction so the landing page never pays for it, then calls the bundle&rsquo;s{" "}
-            <code className="font-mono text-foreground">Reasoner.materializeStats</code>,{" "}
-            <code className="font-mono">Reasoner.entailed</code> /{" "}
-            <code className="font-mono">Reasoner.reasonN3</code>, and{" "}
-            <code className="font-mono">Reasoner.why</code> bindings — nothing is sent
-            to a server.
-          </p>
-        </>
-      }
+      runsNote="Live in your browser tab — the reasoner is pure Rust over the engine, compiled to the separate W-reason wasm bundle that the page lazy-loads on first interaction, so nothing is sent to a server."
+      reproduce="cargo test -p sparq-reason"
       caveat={
-        <>
-          <p>
-            The reasoner is a forward-chaining materializer sized for the
-            illustrative documents here (tens of triples); it is not a tableau OWL DL
-            reasoner, and the OWL 2 RL profile is the rule-based RL fragment, not full
-            OWL. The N3 mode reasons over the rule document directly, so the{" "}
-            <code className="font-mono">why?</code> proof-tree button is shown for the
-            RDFS / OWL profiles only. Materialize large graphs server-side via{" "}
-            <code className="font-mono">sparq-cli reason</code>.
-          </p>
-        </>
+        <p>
+          This is a forward-chaining materializer sized for the illustrative documents
+          here (tens of triples), not a tableau OWL DL reasoner; the OWL 2 RL profile is
+          the rule-based RL fragment, not full OWL. The N3 mode reasons over the rule
+          document directly, so the <code className="font-mono">why?</code> proof-tree
+          button shows for the RDFS / OWL profiles only. Materialize large graphs
+          server-side via <code className="font-mono">sparq-cli reason</code>.
+        </p>
       }
+      readmeHref="https://github.com/jeswr/sparq/tree/main/crates/sparq-reason"
+      skillHref="https://github.com/jeswr/sparq/blob/main/skills/inference/SKILL.md"
     >
       <InferencePlayground />
     </SurfaceContent>

--- a/site/src/app/surface/javascript-wasm/page.tsx
+++ b/site/src/app/surface/javascript-wasm/page.tsx
@@ -11,6 +11,10 @@ export const metadata: Metadata = {
     "Use the sparq engine from JavaScript/TypeScript via @jeswr/sparq — an idiomatic RDF/JS surface (SparqStore + a named Dataset DatasetCore entry, importable from a <script type=module>) over the ~886 KB WebAssembly build, in Node or the browser.",
 };
 
+// [OPUS-4.8] sq-vw3ax.8 — condensed to the scan-first template: demo first, one-line lead,
+// ≤5 capabilities, single-sentence runs note + reproduce, caveats behind <details>, plus the
+// universal README + SKILL.md links. The full API tour lives in the SKILL. The ~886 KB figure
+// is a build-output artifact size (not a benchmark) and is kept.
 export default function JavascriptWasmSurfacePage() {
   return (
     <SurfaceContent
@@ -19,47 +23,27 @@ export default function JavascriptWasmSurfacePage() {
       statement="The @jeswr/sparq RDF/JS API — the Rust engine compiled to a single ~886 KB wasm artifact."
       tier="live"
       intro={
-        <>
-          <p>
-            sparq is a Rust RDF triplestore + SPARQL engine compiled to a single{" "}
-            <strong className="text-foreground">~886 KB</strong> (≈314 KB gzipped)
-            WebAssembly artifact. The npm package{" "}
-            <code className="font-mono text-foreground">@jeswr/sparq</code> wraps it
-            in an idiomatic <a className="text-primary underline-offset-4 hover:underline" href="https://rdf.js.org/" target="_blank" rel="noopener noreferrer">RDF/JS</a>{" "}
-            surface — <code className="font-mono">SparqStore</code>, Map-like{" "}
-            <code className="font-mono">Bindings</code>, spec terms via{" "}
-            <code className="font-mono">@rdfjs/types</code> — and runs unchanged in
-            Node &ge; 18 and the browser.
-          </p>
-          <p>
-            This very site uses it: the live REPL constructs a{" "}
-            <code className="font-mono">Store</code>, loads Turtle, and runs your
-            SPARQL — all in the tab. A thin raw <code className="font-mono">Store</code>{" "}
-            class is available if you want SPARQL-JSON strings with no JS-side term
-            materialisation. The panels below call the API directly against one seeded
-            store, in your tab.
-          </p>
-          <p>
-            For an RDF/JS{" "}
-            <a className="text-primary underline-offset-4 hover:underline" href="https://rdf.js.org/dataset-spec/" target="_blank" rel="noopener noreferrer">
-              <code className="font-mono">DatasetCore</code>
-            </a>{" "}
-            surface, the package exports a named{" "}
-            <code className="font-mono">Dataset</code> — importable directly in a{" "}
-            <code className="font-mono">&lt;script type=&quot;module&quot;&gt;</code> from
-            any ESM CDN. Its async factories (
-            <code className="font-mono">Dataset.fromString</code> /{" "}
-            <code className="font-mono">.create</code> /{" "}
-            <code className="font-mono">.fromQuads</code>) instantiate the wasm engine on
-            first use, so the ~MB binary loads lazily — never on import (see the snippet
-            below).
-          </p>
-        </>
+        <p>
+          <code className="font-mono text-foreground">@jeswr/sparq</code> wraps the Rust
+          triplestore + SPARQL engine — compiled to a single ~886 KB (≈314 KB gzipped)
+          wasm artifact — in an idiomatic{" "}
+          <a
+            className="text-primary underline-offset-4 hover:underline"
+            href="https://rdf.js.org/"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            RDF/JS
+          </a>{" "}
+          surface that runs unchanged in Node &ge; 18 and the browser; this very site
+          uses it for every live demo, and the panels below run against one seeded store
+          in your tab.
+        </p>
       }
       capabilities={[
         {
           title: "SparqStore (RDF/JS)",
-          body: "fromString / fromCompressed, query() yielding Map-like Bindings, idiomatic terms.",
+          body: "fromString / fromCompressed, query() yielding Map-like Bindings, idiomatic terms, plus the raw Store class for SPARQL-JSON strings.",
         },
         {
           title: "Dataset — RDF/JS DatasetCore",
@@ -70,55 +54,30 @@ export default function JavascriptWasmSurfacePage() {
           body: "Iterate large SELECT results in batches without materialising the whole table.",
         },
         {
-          title: "count() without materialising",
-          body: "Get a solution count, read from the index, without building every binding.",
-        },
-        {
-          title: "RDF/JS match() / countQuads()",
-          body: "The standard Source interface for triple-pattern matching over the store.",
+          title: "RDF/JS match() / countQuads() / count()",
+          body: "The standard Source interface, plus a solution count read from the index without building every binding.",
         },
         {
           title: "applyDelta / SPARQL Update",
           body: "Apply quad-level deltas or SPARQL Update to mutate the store in place.",
         },
-        {
-          title: "Raw Store class",
-          body: "SPARQL-JSON strings + CONSTRUCT / DESCRIBE, skipping JS term materialisation.",
-        },
       ]}
-      runsNote={
-        <>
-          <p>
-            <strong className="text-foreground">This is the engine.</strong> Every
-            live demo on this site calls this API. In Node it loads the same wasm
-            binary; in the browser it streams it on first use.
-          </p>
-          <p>
-            The demo below seeds a six-person Turtle graph, then exercises{" "}
-            <code className="font-mono">queryCursor()</code>,{" "}
-            <code className="font-mono">match()</code>/
-            <code className="font-mono">countQuads()</code>,{" "}
-            <code className="font-mono">count()</code> and{" "}
-            <code className="font-mono">applyDelta()</code> against it — all in your tab.
-          </p>
-        </>
-      }
+      runsNote="This is the engine — every live demo on this site calls this API; in Node it loads the same wasm binary, and in the browser it streams it on first use, never on import."
+      reproduce="npm i @jeswr/sparq"
       caveat={
-        <>
-          <p>
-            The <code className="font-mono">SparqStore</code> wrapper&apos;s{" "}
-            <code className="font-mono">query()</code> covers SELECT/ASK; CONSTRUCT /
-            DESCRIBE are on the wrapper via{" "}
-            <code className="font-mono">queryQuads()</code> (RDF/JS quads),{" "}
-            <code className="font-mono">queryQuadsString()</code> (N-Triples), and{" "}
-            <code className="font-mono">queryQuadsStream()</code>; drop to the raw{" "}
-            <code className="font-mono">Store</code> only to skip term
-            materialisation. The lean bundle omits REGEX/REPLACE and the
-            wall-clock query budget (see the SPARQL surface), trading a smaller
-            download for those native-only features.
-          </p>
-        </>
+        <p>
+          The <code className="font-mono">SparqStore.query()</code> wrapper covers
+          SELECT/ASK; CONSTRUCT / DESCRIBE come via{" "}
+          <code className="font-mono">queryQuads()</code> (RDF/JS quads),{" "}
+          <code className="font-mono">queryQuadsString()</code> (N-Triples) and{" "}
+          <code className="font-mono">queryQuadsStream()</code> — drop to the raw{" "}
+          <code className="font-mono">Store</code> only to skip term materialisation. The
+          lean bundle omits REGEX/REPLACE and the wall-clock query budget (see the SPARQL
+          surface), trading a smaller download for those native-only features.
+        </p>
       }
+      readmeHref="https://github.com/jeswr/sparq/tree/main/crates/sparq-wasm"
+      skillHref="https://github.com/jeswr/sparq/blob/main/skills/javascript-wasm/SKILL.md"
       links={[
         { href: "/try", label: "Open the live REPL" },
         {

--- a/site/src/app/surface/shacl/page.tsx
+++ b/site/src/app/surface/shacl/page.tsx
@@ -10,6 +10,9 @@ export const metadata: Metadata = {
     "Validate RDF against SHACL shapes with the sparq engine — SHACL Core constraints, SHACL-SPARQL, custom constraint components, the W3C validation report, and a SHACL Compact Syntax view, live in your tab.",
 };
 
+// [OPUS-4.8] sq-vw3ax.8 — condensed to the scan-first template: demo first, one-line lead,
+// ≤5 capabilities, single-sentence runs note + reproduce, caveats behind <details>, plus the
+// universal README + SKILL.md links. The compact-syntax boundary detail moves to the SKILL.
 export default function ShaclSurfacePage() {
   return (
     <SurfaceContent
@@ -18,35 +21,18 @@ export default function ShaclSurfacePage() {
       statement="Validate RDF data against shapes — SHACL Core, SHACL-SPARQL, the W3C validation report, and a live SHACL Compact Syntax view."
       tier="live"
       intro={
-        <>
-          <p>
-            <code className="font-mono text-foreground">sparq-shacl</code> validates
-            a <code className="font-mono">sparq_core::Graph</code> against SHACL
-            shapes and produces a{" "}
-            <strong className="text-foreground">W3C validation report</strong>{" "}
-            (conformance plus per-violation results) as Turtle or human-readable
-            text. It implements SHACL Core constraints, SHACL-SPARQL{" "}
-            <code className="font-mono">sh:sparql</code> constraints, and custom
-            SPARQL-based constraint components.
-          </p>
-          <p>
-            Because it is pure Rust over <code className="font-mono">sparq-engine</code>
-            , it is wasm-portable. The SHACL-enabled wasm bundle — the same one the
-            published <code className="font-mono text-foreground">@jeswr/sparq</code>{" "}
-            ships — runs the validator in this tab: paste data + shapes below and the
-            conformance flag and per-violation report come back with no network
-            round-trip.
-          </p>
-        </>
+        <p>
+          <code className="font-mono text-foreground">sparq-shacl</code> validates a
+          graph against SHACL Core + SHACL-SPARQL constraints and returns a W3C
+          validation report (conformance plus per-violation results); the playground
+          above runs the validator in your tab via the SHACL-enabled wasm bundle that{" "}
+          <code className="font-mono text-foreground">@jeswr/sparq</code> ships.
+        </p>
       }
       capabilities={[
         {
           title: "SHACL Core constraints",
-          body: "class, datatype, cardinality, value ranges, node/property shapes, paths.",
-        },
-        {
-          title: "Logical & qualified shapes",
-          body: "and / or / not / xone, qualified value shapes, closed shapes, in / hasValue.",
+          body: "class, datatype, cardinality, value ranges, node/property shapes, paths, plus and / or / not / xone, qualified & closed shapes.",
         },
         {
           title: "SHACL-SPARQL (§5.2)",
@@ -61,55 +47,34 @@ export default function ShaclSurfacePage() {
           body: "Conformance boolean + sh:result violations, as Turtle or human text.",
         },
         {
-          title: "Path expressions",
-          body: "Property paths in shape targets and constraints, reusing the engine's path evaluator.",
-        },
-        {
           title: "SHACL Compact Syntax (display)",
-          body: "Render the shapes graph in the W3C compact notation — node/property shapes, paths, counts and value constraints — beside the W3C report.",
+          body: "Render the shapes graph in the W3C compact notation beside the validation report.",
         },
       ]}
-      runsNote={
-        <>
-          <p>
-            <strong className="text-foreground">Live in your browser tab.</strong>{" "}
-            The validator is pure Rust over the engine, compiled to wasm in the
-            SHACL-enabled bundle (the published{" "}
-            <code className="font-mono">@jeswr/sparq</code> ships it). The playground
-            calls the bundle&rsquo;s{" "}
-            <code className="font-mono text-foreground">Store.validate(data, shapes)</code>{" "}
-            binding, parses the two graphs, and renders the conformance flag plus the
-            per-violation W3C report — nothing is sent to a server.
-          </p>
-        </>
-      }
+      runsNote="Live in your browser tab — the validator is pure Rust over the engine compiled to the SHACL-enabled wasm bundle, so the conformance flag and per-violation report come back with no network round-trip."
+      reproduce="cargo test -p sparq-shacl"
       caveat={
         <>
           <p>
-            SHACL-SPARQL constraints rely on the engine&rsquo;s REGEX. The lean SPARQL
-            REPL bundle compiles REGEX out, but the SHACL bundle keeps it, so{" "}
-            <code className="font-mono">sh:sparql</code> constraints validate in-tab
-            too. The in-tab validator is sized for small documents (~10–100 triples);
-            validate large graphs server-side via the{" "}
-            <code className="font-mono">sparq-server</code> HTTP{" "}
-            <code className="font-mono">validate</code> path.
+            SHACL-SPARQL constraints rely on the engine&rsquo;s REGEX, which the SHACL
+            bundle keeps (the lean SPARQL REPL bundle compiles it out), so{" "}
+            <code className="font-mono">sh:sparql</code> validates in-tab too. The in-tab
+            validator is sized for small documents (~10–100 triples); validate large
+            graphs server-side via the <code className="font-mono">sparq-server</code>{" "}
+            HTTP <code className="font-mono">validate</code> path.
           </p>
           <p>
-            The <strong className="text-foreground">Compact syntax</strong> view is
-            the <em>display</em> direction only (shapes &rarr; compact). It is
-            best-effort: SHACL Compact Syntax has no form for logical constraints
-            (<code className="font-mono">sh:and</code> /{" "}
-            <code className="font-mono">sh:or</code> /{" "}
-            <code className="font-mono">sh:xone</code> /{" "}
-            <code className="font-mono">sh:not</code>) or shape references{" "}
-            (<code className="font-mono">sh:node</code>), which the view lists
-            explicitly rather than dropping. The <em>parse</em> direction (compact
-            text &rarr; shapes) is a full grammar that belongs in the{" "}
-            <code className="font-mono">sparq-shacl</code> engine and is tracked
-            separately.
+            The <strong className="text-foreground">Compact syntax</strong> view is the
+            display direction only (shapes &rarr; compact) and best-effort: the notation
+            has no form for logical constraints or shape references, which the view lists
+            explicitly rather than dropping. The parse direction (compact text &rarr;
+            shapes) belongs in the <code className="font-mono">sparq-shacl</code> engine
+            and is tracked separately.
           </p>
         </>
       }
+      readmeHref="https://github.com/jeswr/sparq/tree/main/crates/sparq-shacl"
+      skillHref="https://github.com/jeswr/sparq/blob/main/skills/shacl-validation/SKILL.md"
     >
       <ShaclPlayground />
     </SurfaceContent>

--- a/site/src/app/surface/sparql/page.tsx
+++ b/site/src/app/surface/sparql/page.tsx
@@ -9,6 +9,9 @@ export const metadata: Metadata = {
     "SELECT / ASK / CONSTRUCT / UPDATE, property paths, RDF 1.2 triple terms, aggregates, subqueries — the sparq SPARQL engine, live in your tab.",
 };
 
+// [OPUS-4.8] sq-vw3ax.8 — condensed to the scan-first template: one-line lead, ≤5
+// capabilities, single-sentence runs note + reproduce, caveats behind <details>, and the
+// universal README + SKILL.md links. The long-form algebra walk-through lives in the SKILL.
 export default function SparqlSurfacePage() {
   return (
     <SurfaceContent
@@ -17,27 +20,17 @@ export default function SparqlSurfacePage() {
       statement="The full query language — SELECT, ASK, CONSTRUCT, UPDATE — over the sparq engine."
       tier="live"
       intro={
-        <>
-          <p>
-            sparq evaluates SPARQL 1.1/1.2 over a{" "}
-            <code className="font-mono text-foreground">sparq_core::Graph</code>{" "}
-            using a worst-case-optimal join (WCOJ) engine. The same engine that
-            powers the native crate is compiled to WebAssembly and ships as{" "}
-            <code className="font-mono text-foreground">@jeswr/sparq</code>, so you
-            can run real queries in this tab — nothing is sent to a server.
-          </p>
-          <p>
-            The query surface covers the algebra you would expect — basic graph
-            patterns, FILTER, OPTIONAL, UNION, MINUS, BIND, VALUES, aggregates and
-            GROUP BY, sub-SELECT, and property paths — plus RDF 1.2 triple terms
-            and named-graph dataset views.
-          </p>
-        </>
+        <p>
+          sparq evaluates SPARQL 1.1/1.2 over an in-memory graph with a
+          worst-case-optimal join engine; the same engine compiled to wasm ships as{" "}
+          <code className="font-mono text-foreground">@jeswr/sparq</code>, so the live
+          REPL runs real queries in your tab with no server round-trip.
+        </p>
       }
       capabilities={[
         {
-          title: "SELECT / ASK / CONSTRUCT / DESCRIBE",
-          body: "All four query forms, returning bindings, a boolean, or a constructed graph.",
+          title: "All four query forms",
+          body: "SELECT / ASK / CONSTRUCT / DESCRIBE, returning bindings, a boolean, or a constructed graph.",
         },
         {
           title: "SPARQL Update",
@@ -49,50 +42,26 @@ export default function SparqlSurfacePage() {
         },
         {
           title: "RDF 1.2 triple terms",
-          body: "Triple terms in object position, written <<( s p o )>> and queried with the triple-term functions.",
+          body: "Triple terms in object position, written <<( s p o )>>, with the triple-term functions.",
         },
         {
           title: "Aggregates & subqueries",
-          body: "COUNT / SUM / AVG / MIN / MAX / GROUP_CONCAT, GROUP BY / HAVING, and nested SELECT.",
-        },
-        {
-          title: "Extension functions",
-          body: "Register custom SPARQL functions via the engine's FunctionRegistry (native).",
+          body: "COUNT / SUM / AVG / MIN / MAX / GROUP_CONCAT, GROUP BY / HAVING, nested SELECT, plus EXPLAIN / EXPLAIN ANALYZE.",
         },
       ]}
-      runsNote={
-        <>
-          <p>
-            <strong className="text-foreground">Live in your browser tab.</strong>{" "}
-            The lean wasm bundle carries the parser, triplestore and SPARQL engine.
-            The live REPL runs your queries against the sample graph with no network
-            round-trip — SELECT and ASK render a table / boolean, CONSTRUCT and
-            DESCRIBE render the constructed N-Triples, and SPARQL Update
-            (INSERT / DELETE) mutates the in-tab store.
-          </p>
-          <p>
-            The same REPL has an{" "}
-            <code className="font-mono text-foreground">EXPLAIN</code> /{" "}
-            <code className="font-mono text-foreground">EXPLAIN ANALYZE</code> mode:
-            EXPLAIN shows the planner&apos;s join order and cardinality estimates
-            without executing, ANALYZE also runs the query and appends a per-operator
-            row-count trace.
-          </p>
-        </>
-      }
+      runsNote="Live in your browser tab — the lean wasm bundle carries the parser, triplestore and SPARQL engine, so queries run against the sample graph with no network round-trip."
+      reproduce="cargo test -p sparq-engine"
       caveat={
-        <>
-          <p>
-            REGEX / REPLACE are compiled out of the lean wasm bundle to keep it
-            small; they are available in the native build. The query-budget
-            deadline (wall-clock timeout) is native-only — the wasm bundle enforces
-            a row cap instead. In the wasm build,{" "}
-            <code className="font-mono">EXPLAIN ANALYZE</code> reports exact
-            per-operator row counts but zero wall-times (no monotonic clock under
-            wasm32).
-          </p>
-        </>
+        <p>
+          REGEX / REPLACE are compiled out of the lean wasm bundle to keep it small
+          (available in the native build). The query-budget deadline (wall-clock
+          timeout) is native-only — the wasm bundle enforces a row cap instead — and{" "}
+          <code className="font-mono">EXPLAIN ANALYZE</code> reports exact per-operator
+          row counts but zero wall-times under wasm32 (no monotonic clock).
+        </p>
       }
+      readmeHref="https://github.com/jeswr/sparq/tree/main/crates/sparq-engine"
+      skillHref="https://github.com/jeswr/sparq/blob/main/skills/sparql-query/SKILL.md"
       links={[{ href: "/try", label: "Open the live REPL" }]}
     />
   );

--- a/site/src/components/surface-content.tsx
+++ b/site/src/components/surface-content.tsx
@@ -1,21 +1,34 @@
 // [OPUS-4.8] sq-3hrc — shared layout for a real (non-placeholder) surface page.
-// Renders a consistent structure per research/feature-showcase-site-design.md §2:
-// capability statement → tier badge → capability list → "how this works" →
-// honest caveat → CTAs. Content is grounded in each surface's skills/*/SKILL.md.
+//
+// [OPUS-4.8] sq-vw3ax.8 — REBUILT to the scan-first, disclosure-based template from the
+// website-redesign record (research/website-redesign.md §4 "CAPABILITY DEEP PAGE"):
+//
+//   1. title + tier badge + ONE-sentence statement (the badge carries the per-page truth,
+//      so prose does not have to repeat it);
+//   2. the interactive demo IMMEDIATELY (children) — show-don't-tell, before any prose;
+//   3. an OPTIONAL one-line lead (`intro`) — deep pages trim their old multi-paragraph
+//      intros to a single sentence; the long form moves to the crate README / SKILL.md;
+//   4. a TIGHT capabilities list (bolded lead term + short clause, max ~5) — NOT the old
+//      always-open 6 ring-cards;
+//   5. "How this runs" as a SINGLE sentence whose authority is the badge, with an optional
+//      reproduce-it line — NOT an always-open co-equal card;
+//   6. caveats behind a CLOSED <details> ("Caveats & limitations") — the qualifier is
+//      preserved (scripts/check-privacy-claims.sh stays green), just relocated off the
+//      first screen;
+//   7. UNIVERSAL depth links — every deep page links its crate README + SKILL.md (the
+//      reference material moved off-site lives there), alongside any page-specific CTAs.
+//
+// Every content block is an OPTIONAL prop: a simple surface renders just statement + demo +
+// a one-line note. Reference-grade detail (full capability matrices, edge-case boundaries,
+// feature-gating minutiae) belongs in the README / SKILL.md / research, NOT here.
 
 import type { ReactNode } from "react";
 import Link from "next/link";
-import { ArrowLeft, Check, Info, TriangleAlert } from "lucide-react";
+import { ArrowLeft, BookOpen, Check, ExternalLink, FileText } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import { type Tier, TIER_LABEL, TIER_VARIANT } from "@/data/surfaces";
 
 export interface SurfaceContentProps {
@@ -26,17 +39,31 @@ export interface SurfaceContentProps {
   tier: Tier;
   /** Optional extra badge label (e.g. "Native-only", "Research-grade"). */
   extraBadge?: string;
-  /** Lead paragraphs of prose. */
-  intro: ReactNode;
-  /** The concrete capabilities this surface offers (bullet list). */
-  capabilities: { title: string; body: string }[];
-  /** "How this runs" honest note. */
-  runsNote: ReactNode;
-  /** Honest caveat / what is NOT covered. */
-  caveat: ReactNode;
-  /** Optional CTA links beyond the source link. */
+  /**
+   * Optional one-line (1–2 sentence) lead. Keep it short — the long-form intro,
+   * full matrices and edge-case boundaries move to the crate README / SKILL.md.
+   */
+  intro?: ReactNode;
+  /** The concrete capabilities this surface offers — keep to ≤5, bolded lead term. */
+  capabilities?: { title: string; body: string }[];
+  /** "How this runs" — a SINGLE sentence; its authority is the tier badge. */
+  runsNote?: ReactNode;
+  /** Optional reproduce-it line shown beside the runs note (e.g. a cargo command). */
+  reproduce?: string;
+  /**
+   * Honest caveat / what is NOT covered — rendered behind a CLOSED <details>.
+   * The qualifier is preserved (privacy-claims gate), just off the first screen.
+   */
+  caveat?: ReactNode;
+  /** Label for the caveat disclosure (default "Caveats & limitations"). */
+  caveatLabel?: string;
+  /** Crate README link — the moved-off-site reference material lives here. */
+  readmeHref?: string;
+  /** SKILL.md link — the usage guide for this surface. */
+  skillHref?: string;
+  /** Optional CTA links beyond the README / SKILL / source links. */
   links?: { href: string; label: string; external?: boolean }[];
-  /** Anything extra (e.g. an embedded REPL or table). */
+  /** Anything extra (e.g. an embedded REPL or table) — shown IMMEDIATELY after the header. */
   children?: ReactNode;
 }
 
@@ -49,16 +76,20 @@ export function SurfaceContent({
   intro,
   capabilities,
   runsNote,
+  reproduce,
   caveat,
+  caveatLabel = "Caveats & limitations",
+  readmeHref,
+  skillHref,
   links,
   children,
 }: SurfaceContentProps) {
   return (
-    <div className="space-y-10">
+    <div className="space-y-8">
       <Button variant="ghost" size="sm" asChild className="-ml-2">
-        <Link href="/">
+        <Link href="/capabilities">
           <ArrowLeft className="size-4" aria-hidden="true" />
-          Back to overview
+          Back to Capabilities
         </Link>
       </Button>
 
@@ -78,54 +109,56 @@ export function SurfaceContent({
         </div>
       </header>
 
-      <section className="measure space-y-3 text-muted-foreground">{intro}</section>
-
-      <section className="space-y-4">
-        <h2 className="text-xl font-semibold">Capabilities</h2>
-        <div className="grid gap-3 sm:grid-cols-2">
-          {capabilities.map((c) => (
-            <div
-              key={c.title}
-              className="flex gap-3 rounded-xl bg-muted/40 p-4 ring-1 ring-foreground/10"
-            >
-              <Check
-                className="mt-0.5 size-4 shrink-0 text-[var(--success)]"
-                aria-hidden="true"
-              />
-              <div>
-                <div className="text-sm font-semibold">{c.title}</div>
-                <div className="text-sm text-muted-foreground">{c.body}</div>
-              </div>
-            </div>
-          ))}
-        </div>
-      </section>
-
+      {/* Show, then tell: the interactive demo comes IMMEDIATELY after the header. */}
       {children}
 
-      <section className="grid gap-4 md:grid-cols-2">
-        <Card>
-          <CardHeader className="flex-row items-center gap-2 space-y-0">
-            <Info className="size-5 text-primary" aria-hidden="true" />
-            <CardTitle className="text-base">How this runs</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2 text-sm text-muted-foreground">
-            {runsNote}
-          </CardContent>
-        </Card>
-        <Card className="ring-[var(--warning)]/30">
-          <CardHeader className="flex-row items-center gap-2 space-y-0">
-            <TriangleAlert
-              className="size-5 text-[var(--warning)]"
-              aria-hidden="true"
-            />
-            <CardTitle className="text-base">Honest caveats</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2 text-sm text-muted-foreground">
-            {caveat}
-          </CardContent>
-        </Card>
-      </section>
+      {intro && (
+        <section className="measure space-y-3 text-muted-foreground">{intro}</section>
+      )}
+
+      {capabilities && capabilities.length > 0 && (
+        <section className="space-y-3">
+          <h2 className="text-lg font-semibold">What it does</h2>
+          <ul className="space-y-2">
+            {capabilities.map((c) => (
+              <li key={c.title} className="flex gap-2.5 text-sm">
+                <Check
+                  className="mt-0.5 size-4 shrink-0 text-[var(--success)]"
+                  aria-hidden="true"
+                />
+                <span className="text-muted-foreground">
+                  <span className="font-semibold text-foreground">{c.title}</span>
+                  {" — "}
+                  {c.body}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {(runsNote || reproduce) && (
+        <section className="space-y-2 text-sm text-muted-foreground">
+          {runsNote && <p>{runsNote}</p>}
+          {reproduce && (
+            <p>
+              Reproduce:{" "}
+              <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[12px] text-foreground">
+                {reproduce}
+              </code>
+            </p>
+          )}
+        </section>
+      )}
+
+      {caveat && (
+        <details className="group rounded-xl border bg-muted/30 px-4 py-3 text-sm">
+          <summary className="cursor-pointer select-none font-medium text-foreground/90">
+            {caveatLabel}
+          </summary>
+          <div className="mt-3 space-y-2 text-muted-foreground">{caveat}</div>
+        </details>
+      )}
 
       <section className="flex flex-wrap gap-2">
         {links?.map((l) =>
@@ -140,6 +173,24 @@ export function SurfaceContent({
               <Link href={l.href}>{l.label}</Link>
             </Button>
           ),
+        )}
+        {readmeHref && (
+          <Button asChild variant="outline" size="sm">
+            <a href={readmeHref} target="_blank" rel="noopener noreferrer">
+              <FileText className="size-4" aria-hidden="true" />
+              Crate README
+              <ExternalLink className="size-3.5 opacity-60" aria-hidden="true" />
+            </a>
+          </Button>
+        )}
+        {skillHref && (
+          <Button asChild variant="outline" size="sm">
+            <a href={skillHref} target="_blank" rel="noopener noreferrer">
+              <BookOpen className="size-4" aria-hidden="true" />
+              SKILL.md
+              <ExternalLink className="size-3.5 opacity-60" aria-hidden="true" />
+            </a>
+          </Button>
         )}
         <Button asChild variant="outline" size="sm">
           <a


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change on @jeswr's behalf (the site lane). Self-identifying per the shared contract. Authored by Claude Opus 4.8 (1M context) while Fable is unavailable — flagged `[OPUS-4.8]` for later re-review.

Implements **sq-vw3ax.8** — *"condense the dense walkthrough/caveat content — one-line blurbs, caveats behind `<details>`, and MOVE reference material out to README/SKILL/research"* (epic **sq-vw3ax**, website redesign). Steered by `research/website-redesign.md` §3 (content-reduction) + §4 (CAPABILITY DEEP PAGE).

## What changed
Rebuilt the deep-page template `site/src/components/surface-content.tsx` to the **scan-first, disclosure-based** shape and condensed the **5 retained live deep pages** that still used it:
- `site/src/app/surface/sparql/page.tsx`
- `site/src/app/surface/data-formats/page.tsx`
- `site/src/app/surface/javascript-wasm/page.tsx`
- `site/src/app/surface/shacl/page.tsx`
- `site/src/app/surface/inference/page.tsx`

**Template changes (per §4):**
1. The interactive demo (`children`) now renders **immediately** after the header — show-don't-tell.
2. **Every content block is an optional prop** — a simple surface renders just statement + demo + a one-line note.
3. Multi-paragraph `intro` → **one 1–2 sentence lead**; the long form / full matrices / edge-case boundaries move to the crate README + SKILL.md.
4. The always-open **6 capability ring-cards** → a tight **≤5-item list** with a bolded lead term.
5. The always-open co-equal **"How this runs" + "Honest caveats"** cards → a **single-sentence** runs note (+ optional `reproduce:` line) and a **CLOSED `<details>`** for the caveat. The qualifier is **preserved**, just relocated off the first screen.
6. **Universal depth links** — every deep page now links its **crate README + SKILL.md** alongside its page CTAs.

**On the dense ZK/MPC caveats called out in the bead:** the 8 walkthrough surfaces (geosparql, full-text, vector, genai, http-server, streaming-rsp, **zk**, **mpc**) and their dense intros/caveats already collapsed into one-line `/capabilities` rows under **sq-vw3ax.3** — each row carries the one-line "Research-grade — not externally audited" caveat + README/SKILL links behind a `Details & caveats` `<details>`. So the ZK 5-clause / MPC "stub" caveat is already a one-line flagged summary + disclosure; this PR finishes the job on the remaining live deep pages.

## Decision (best-judgment, flagged for steering)
The redesign §4 says "rebuild `surface-content.tsx`". I rebuilt it as a **superset** of the old API (back-compatible-ish: required props relaxed to optional; added `reproduce`, `readmeHref`, `skillHref`, `caveatLabel`) rather than a parallel component, so the 5 deep pages migrate in place and the diff stays reviewable. The "Back to overview → /" link became **"Back to Capabilities → /capabilities"** (the gallery is the new parent in the redesigned IA). No new dependency added.

## Gates (all green)
- **WASM prereq built** (build artifact only, no `crates/` source change): `cd js && npm run build:wasm` (lean bundle) + `npm run build:reason-wasm` (W-reason for `/surface/inference`).
- `cd site && npm install && npm run build` — **static export green end-to-end**; all 5 deep routes emitted into `out/` (`/surface/{sparql,data-formats,javascript-wasm,shacl,inference}/index.html`), the 8 collapsed surfaces remain ~636 B redirect stubs.
- `npm run lint` — clean. `tsc --noEmit` — passes.
- `scripts/check-privacy-claims.sh` — **clean** (425 files scanned; qualifiers preserved, just relocated).
- Terminology/typos gate — no `DELETEd`/`DROPped`/`invokable`/`ANDed`.
- `basePath: /sparq` preserved (verified `/sparq/capabilities/`, `/sparq/try/` in exported HTML; README/SKILL render as absolute GitHub links).
- No hard-coded perf numbers added; the `~886 KB` wasm figure is a build-output artifact size (allowed per §0), kept.

## Data honesty
No benchmark numbers touched. The `sync-benchmarks.mjs` prebuild regenerated `site/src/data/benchmarks.generated.json` as a side effect of building locally on this non-canonical work box — that generated file was **reverted and is NOT in this PR**.

## Covered vs deferred
- **Covered:** the 5 deep pages + the shared template; universal README/SKILL links on the deep pages.
- **Already done elsewhere (not this PR):** the 8 walkthrough rows' one-line caveats + README/SKILL links (sq-vw3ax.3); the Home preamble/grid cut + nav collapse (other sq-vw3ax.* beads).
- **Deferred (separate beads):** `/examples` gallery (sq-vw3ax.6), main-bundle-wasm-free perf (sq-vw3ax.9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)