### PR TITLE
fix(bench): KGE result-capture — build-first + file-capture + compact-table-only emit for 64KB serial console (sq-6tley) [OPUS-4.8]

### DIFF
--- a/bench/CATALOG.md
+++ b/bench/CATALOG.md
@@ -58,7 +58,7 @@ conventions first, then a per-category map that points at the registry, then a
 
 | category | what it covers | registry ids |
 |---|---|---|
-| **query** | engine compute + differential correctness; aux-index harnesses; well-known suites | `sparq-bench-compare`, `sparq-bench-fuzz`, `sparq-bench-diff`, `cli-bench-suite`, `cli-bench-mmap`, `operator-coverage`, `sp2b`, `dbpsb`, `watdiv`, `bsbm`, `lubm`, `shacl-validate-bench`, `geo-bench`, `selective-bindjoin`, `u64-valueids`, `qlever-olympics`, `qlever-synthetic-10m`, `qlever-synthetic-100m`, `text-index-bench`, `vector-ann-bench`, `geo-index-bench`, `rsp-throughput`, `rsp-ql`, `vectors-throughput`, `gpu-bench`, `sim-olympics-eval`, `introspect-olympics` |
+| **query** | engine compute + differential correctness; aux-index harnesses; well-known suites | `sparq-bench-compare`, `sparq-bench-fuzz`, `sparq-bench-diff`, `cli-bench-suite`, `cli-bench-mmap`, `operator-coverage`, `sp2b`, `dbpsb`, `watdiv`, `bsbm`, `lubm`, `shacl-validate-bench`, `geo-bench`, `selective-bindjoin`, `u64-valueids`, `qlever-olympics`, `qlever-synthetic-10m`, `qlever-synthetic-100m`, `text-index-bench`, `vector-ann-bench`, `geo-index-bench`, `rsp-throughput`, `rsp-ql`, `vectors-throughput`, `kge-ablation`, `gpu-bench`, `sim-olympics-eval`, `introspect-olympics` |
 | **parse** | text-format parse throughput (MB/s) | `parse-baseline` |
 | **ingest** | load + dict + external-memory build throughput | `cli-ingest`, `cli-save-build`, `cli-bench-remap`, `dict-baseline`, `hdt-load-bench`, `hdt-stage-split`, `hdt-suite`, `wikidata-8b` |
 | **compression** | index / result-serialization footprint tradeoffs | `cli-probe-compress`, `cli-compare-compress`, `compress-bench` |

--- a/bench/benchmarks.toml
+++ b/bench/benchmarks.toml
@@ -787,6 +787,31 @@ pinning     = "N=50000, DIM=32, K=10, QUERIES=200 consts in the test; seeds fixe
 records_to  = "stderr (--nocapture); source of the sparq-vectors README numbers"
 status      = "ok"
 
+# [OPUS-4.8] sq-6tley (relates sq-0wo9e.8/sq-0wo9e.9): the KGE P0 ablation on EC2.
+# RESULT-CAPTURE is the whole point of this entry. A prior run (i-09e73) trained all three
+# datasets fine but the results were LOST: `cargo run` streams hundreds of "Compiling <dep>"
+# lines through ec2-bench's line-by-line console emitter, which overflows the 64KB serial
+# buffer that `get-console-output` retains, pushing the final MRR/Hits@k tables out. So this
+# invoke (a) BUILDS the example first (compile noise off the result path), (b) runs the
+# PREBUILT binary to a file per dataset, (c) emits ONLY the compact final ablation table for
+# each dataset between `=== SPARQ_BENCH_RESULT <ds> ===` / `=== END SPARQ_BENCH_RESULT <ds> ===`
+# sub-markers via grep, so the bytes that reach the console fit the buffer with room to spare.
+# Datasets: synthetic always; optionally a colon-separated SPARQ_KGE_DATASETS list of real KG
+# files (e.g. WN18RR / FB15k-237 N-Triples), each run via the example's SPARQ_KGE_DATASET arm.
+[[benchmark]]
+id          = "kge-ablation"
+name        = "Structure-aware KGE — P0 closure x type-constrained-negatives link-prediction ablation (sq-0wo9e)"
+category    = "query"
+measures    = "filtered link-prediction MRR / Hits@1 / Hits@3 / Hits@10 (mean +/- std over 5 seeds) across the 2x2 P0 ablation matrix {closure on/off} x {uniform, type-constrained negatives}, under both DistMult (symmetric) and ComplEx (asymmetric — read deltas here), with a head-vs-tail breakdown, per dataset"
+invoke      = "cargo build -p sparq-vectors --release --features kge --example kge_ablation 2>&1 | tail -3\nKGEBIN=target/release/examples/kge_ablation\nrun_kge() { ds=$1; tag=$(basename $ds); out=/root/kge-$tag.out; echo === SPARQ_BENCH_RESULT kge $tag ===; if [ $ds = synthetic ]; then $KGEBIN >$out 2>&1; else SPARQ_KGE_DATASET=$ds $KGEBIN >$out 2>&1; fi; grep -E '^(#|==|closure=|    head |  [(]ablation failed)' $out || tail -40 $out; echo === END SPARQ_BENCH_RESULT $tag ===; }\nrun_kge synthetic\nIFS=: ; for d in ${SPARQ_KGE_DATASETS:-}; do case $d in ?*) run_kge $d;; esac; done"
+source      = "crates/sparq-vectors/examples/kge_ablation.rs (the runnable P0 ablation); crates/sparq-vectors/src/{train,eval}.rs (DistMult/ComplEx trainer + filtered link-prediction harness); feature = kge (implies structure); design research/structure-aware-vectorisation.md (P0/P6)"
+dataset     = "SYNTHETIC always (in-process: a WN18RR-style structured-relational slice + a gUFO slice from seeded PRNGs, no download). REAL datasets are OPT-IN via SPARQ_KGE_DATASETS=/path/a.nt:/path/b.nt (e.g. WN18RR + FB15k-237 N-Triples); absent it, only the synthetic arm runs"
+quiet_box_sensitive = true  # MRR/Hits@k are INDICATIVE on a non-canonical box; no figure is baked into a committed doc (per the example's own header). Re-measure on a canonical machine, on a REAL dataset, under ComplEx, multi-seed, before adopting any prior.
+pinning     = "5 seeds from seed0=20260620 (args: [entities] [people] [seed0]); EvalConfig::small with epochs=150 dim=64 negatives_per_positive=16 (set in the example); read inter-cell deltas off the ASYMMETRIC ComplEx run only (DistMult is near-random on these ~100%-directional slices)"
+records_to  = "serial console only (no SSH key / no S3 on pss): the FULL per-dataset run goes to /root/kge-<ds>.out on the box; ONLY the compact final ablation table per dataset is echoed between '=== SPARQ_BENCH_RESULT <ds> ===' / '=== END SPARQ_BENCH_RESULT <ds> ===' so it fits the 64KB get-console-output buffer (the fix for sq-6tley). NOT a perf-gate input"
+featured    = false  # research measurement harness for epic sq-0wo9e (INDICATIVE, non-canonical, no baked figure) — intentionally NOT a capability dashboard card (G3 escape hatch, design §2.1)
+status      = "ok"
+
 [[benchmark]]
 id          = "gpu-bench"
 name        = "CPU vs GPU hot-path kernels (T24d experiment)"

--- a/bench/ec2-bench.sh
+++ b/bench/ec2-bench.sh
@@ -9,6 +9,16 @@
 # between `=== SPARQ_BENCH_RESULT === ... === END SPARQ_BENCH_RESULT ===` markers to
 # /dev/console, and we pull them with `aws ec2 get-console-output`. NO inbound rules.
 #
+# 64KB-BUFFER DISCIPLINE (sq-6tley): get-console-output retains only the LAST ~64KB of the
+# serial buffer. An invoke that streams a lot of output (notably `cargo run`, which emits a
+# "Compiling <dep>" line for every dependency before the program even starts) will push its
+# OWN result lines out of that window and the results are LOST even though the run succeeded.
+# So a chatty benchmark MUST: (1) BUILD first with a tiny tail (`cargo build ... | tail -3`),
+# (2) run the PREBUILT binary to a FILE, and (3) echo back ONLY the compact final table. Use
+# per-dataset sub-markers `=== SPARQ_BENCH_RESULT <ds> ===` / `=== END SPARQ_BENCH_RESULT <ds> ===`
+# (NOTE the trailing `<ds> ===`, not a bare `===`, so they do NOT close the outer harness range
+# below). See the `kge-ablation` entry in benchmarks.toml for the canonical pattern.
+#
 # ORPHAN-SAFETY (paramount — a prior session orphaned a billing instance), BOTH ways:
 #   (a) every instance launches with --instance-initiated-shutdown-behavior terminate;
 #   (b) user-data's FIRST action backgrounds a hard watchdog `( sleep WATCHDOG; shutdown -h now ) &`


### PR DESCRIPTION
> 🤖 This PR was opened by an autonomous agent (a SPARQ agent) operating on @jeswr's behalf.
> NOT yet ready for maintainer review — pending @jeswr's own review first. @jeswr please steer.

## Why

A prior EC2 KGE run (`i-09e73`, now terminated) trained all three datasets fine but the **results were lost**: `aws ec2 get-console-output` retains only the **last ~64KB** of the serial buffer, and `cargo run` streams a `Compiling <dep>` line for *every* dependency through `ec2-bench`'s line-by-line console emitter. That compile noise overflowed the buffer and pushed the final MRR/Hits@k ablation tables out of the window before the snapshot was taken (and `/tmp/kge-results` was empty — `pss` has no SSH key / no S3, so the serial console is the only channel). Bead **sq-6tley** (relates sq-0wo9e.8/sq-0wo9e.9).

Investigation finding worth flagging: the bead hypothesised "verbose per-seed training logs" as the cause, but `kge_ablation.rs` and `sparq_vectors::{eval,train}` emit **no** training logs — the example's entire stdout is already the compact tables (~3.7KB/dataset). The real overflow source is purely the `cargo run` compile-line stream. The fix addresses that directly.

## What / How

Adds a `kge-ablation` benchmark id to `bench/benchmarks.toml` whose `invoke`:
1. **Builds the example first** with a tiny tail — `cargo build … --example kge_ablation 2>&1 | tail -3` — so the compile output never reaches the result path.
2. Runs the **prebuilt binary to a file** per dataset: `/root/kge-<ds>.out`.
3. Echoes back **only** the compact final ablation table per dataset, between per-dataset sub-markers `=== SPARQ_BENCH_RESULT kge <ds> ===` / `=== END SPARQ_BENCH_RESULT <ds> ===`, via `grep -E '^(#|==|closure=|    head |  [(]ablation failed)'` (keeps header / section / cell / head+tail lines; drops blanks). Falls back to `tail -40` if grep finds nothing.

Datasets: **synthetic always** (in-process WN18RR-style + gUFO slices, no download); **real datasets opt-in** via `SPARQ_KGE_DATASETS=/path/a.nt:/path/b.nt` (e.g. WN18RR + FB15k-237), each run through the example's `SPARQ_KGE_DATASET` arm.

Also documents the **64KB-buffer discipline** in `bench/ec2-bench.sh`'s header (build-first + file-capture + compact-echo, and the sub-marker naming rule) and registers the id in the `bench/CATALOG.md` query-category row.

## Best-judgment decisions (no greenlight needed — flagged here for steering)

- **`featured = false`** (G3 escape hatch, `check-new-bench-registered.py` / design §2.1): this is a research *measurement harness* for epic sq-0wo9e producing INDICATIVE, non-canonical numbers (no figure baked into any committed doc), not a capability dashboard card.
- **Sub-marker `=== END SPARQ_BENCH_RESULT <ds> ===`** (not a bare `=== END ===`): verified it does **not** collide with the outer harness's bare `=== END SPARQ_BENCH_RESULT ===` `sed` range in `cmd_result`/`cmd_wait_result`, so multi-dataset runs are captured intact.
- **`basename()`** sanitizes a full dataset path into the output filename + marker label (a raw path would produce an invalid `/root/kge-/abs/path.nt.out`).

## Verification (local, work-box — NON-canonical)

- `bench/benchmarks.toml` parses under `tomllib`; 66 benchmarks; `kge-ablation` has expected keys.
- Extracted the invoke via the real `extract_invoke` awk+sed in `ec2-bench.sh`, embedded as the harness does, and **executed it** against the committed toml: clean balanced markers, compact ~3.7KB synthetic table, and the outer `sed` range captures the full body.
- Caught + fixed two bugs during testing: a broken grep (`\\(` → `[(]` for the literal paren) and full-path filenames (→ `basename`).
- Gates green: `check-new-bench-registered.py` (G3) PASS, `check-no-perf-numbers.py` 0 findings, `check-privacy-claims.sh` OK, `drift-scan.py` no drift, `shellcheck bench/ec2-bench.sh` (only pre-existing info notes, none in the edited lines).

No Rust code touched (bench config + a shell-script header comment), so the clippy/rustdoc/fmt/test gates do not apply.