### PR TITLE
chore(scheduler): proceed-on-decision in autonomous-scheduler (sq-6psmk) [OPUS-4.8]

### DIFF
--- a/.claude/workflows/autonomous-scheduler.js
+++ b/.claude/workflows/autonomous-scheduler.js
@@ -92,7 +92,7 @@ function pickAgent(surface) {
 function implPrompt(b) {
   return 'Implement bead ' + b.id + ' ("' + b.title + '", surface: ' + b.surface + '). ' +
     '`export PATH=$PATH:/home/ubuntu/.local/bin && bd show ' + b.id + '`. You are in an ISOLATED git worktree — work there; NEVER git-checkout/branch-switch the shared /home/ubuntu/sparq checkout. ' +
-    'FIRST decide if this is genuinely implementable autonomously: if it is an EPIC, needs a MAINTAINER DECISION, is underspecified, or is already done on main, do NOT implement — return {bead, skipped:true, reason}. ' +
+    'FIRST decide if this is genuinely implementable autonomously: if it is an EPIC, is already done on main, or needs an EXTERNAL credential/access you cannot obtain (OS signing certs, npm/PyPI tokens, an external auditor), do NOT implement — return {bead, skipped:true, reason}. If it merely needs a DESIGN/JUDGMENT decision or is somewhat underspecified, PROCEED anyway (STANDING RULE — do not block on the maintainer greenlight): make the best-judgment choice, DOCUMENT it in the PR body + a one-line bead note, and open a short GitHub issue (🤖 SPARQ self-id) flagging the decision for the maintainer to steer later. ' +
     'Otherwise implement per the bead + AGENTS.md conventions: new capability => opt-in/feature-gated (keep sparq-core/engine lean); gate BOTH feature states (clippy --all-targets --all-features -D warnings + tests in default AND feature-on), rustdoc --all-features -D warnings, cargo fmt, check-readme-template.py if you touch a crate README, check-privacy-claims.sh clean, no hard-coded perf numbers. Tag [OPUS-4.8] + Opus trailer. ' +
     'Close the bead on PR-open; do NOT stage .beads/ into the PR. Open ONE PR vs main, auto-merge OFF, with the 🤖 SPARQ-agent self-id blockquote. ' +
     'Return {bead, pr_url, gates_green, skipped:false}. If you hit a weekly limit, STOP and return {bead, skipped:true, reason:"weekly limit"}.'
@@ -134,7 +134,8 @@ while (opened.length < MAX_BEADS && dry < 2) {
     '(OK/WARN/CRITICAL/UNKNOWN) and disk_free_gb (the "Xg free" it printed, as a number). ' +
     'Then read the launchable-bead frontier: `export PATH=$PATH:/home/ubuntu/.local/bin && cd /home/ubuntu/sparq && bash scripts/push-frontier.sh` (READ-ONLY; do NOT git-checkout). ' +
     'Each line is `bead-id  surface  title`. Return up to 6 DISPATCHABLE ready beads as {beads:[{id,surface,title}]}. ' +
-    'EXCLUDE: epics; anything needs-user / requiring a maintainer decision; in-progress; and these already-handled ids: ' + JSON.stringify([...seen]) + '. ' +
+    'EXCLUDE: epics; in-progress; and beads needing an EXTERNAL credential/access an agent cannot obtain (OS signing certs, npm/PyPI publish tokens, the external cryptographer audit); and these already-handled ids: ' + JSON.stringify([...seen]) + '. ' +
+    'INCLUDE beads that merely need a DESIGN/JUDGMENT decision — the impl agent decides with best judgment + documents it (STANDING RULE: proceed without the maintainer greenlight, steer post-hoc). ' +
     // [OPUS-4.8] sq-7mwun: belt-and-suspenders open-PR exclusion. push-frontier.sh already
     // subtracts in-flight beads, but it matches a bead id as a SUBSTRING of an open-PR
     // branch/title, which over/under-matches dotted CHILD ids (sq-ixc3.11 vs sq-ixc3.12) and


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated maintenance commit.

Durably commits the **proceed-on-decision** (STANDING RULE, 2026-06-21) behavior into the autonomous-scheduler so the self-driving loop no longer parks design/judgment-blocked beads for the maintainer — it proceeds with best judgment, documents the choice, and opens a steer-issue.

**Key point:** applied *surgically on top of `origin/main`*, NOT by overwriting with my older working copy. origin/main already had the disk-guard (sq-4vo9m) and the exact open-PR exclusion (sq-7mwun); a blind overwrite would have regressed both. This commit preserves them and adds only the two proceed-on-decision changes (impl skip-clause + frontier EXCLUDE→INCLUDE).

Closes sq-6psmk.