### PR TITLE
feat(sparq-kb): query-the-PKG skill PoC — introspect → ground → ask (sq-2m6zm.3) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3488,7 +3488,10 @@ dependencies = [
  "oxttl 0.2.3",
  "sparq-core",
  "sparq-engine",
+ "sparq-introspect",
+ "sparq-reason",
  "sparq-shacl",
+ "sparq-vectors",
 ]
 
 [[package]]

--- a/crates/sparq-kb/Cargo.toml
+++ b/crates/sparq-kb/Cargo.toml
@@ -33,6 +33,16 @@ validate = ["dep:sparq-core", "dep:sparq-shacl", "dep:oxttl", "dep:oxrdf"]
 # (sq-2m6zm.2): the example-lookup answers (`Graph::load_str` + `sparq_engine::query`).
 # Pulls in the SPARQL engine; keep it off the lean default build.
 query = ["validate", "dep:sparq-engine"]
+# [OPUS-4.8] sq-2m6zm.3 (epic sq-2m6zm). OPT-IN (default-OFF). Enables the
+# `skill` module — the Phase-1 "query-the-PKG" recipe (introspect → ground → ask):
+# load the ingested PKG, ALWAYS `close_for_vectorise(RDFS|OWL-RL)` first, mine a
+# token-budgeted schema card, run a §4.1-class verified-expressible SPARQL query, and
+# return the minimal answer rows + the ABSTAT-style minimal subgraphs that ground each
+# bound IRI, with the executed SPARQL surfaced for verification. IMPLIES `query`; the
+# only thing that pulls `sparq-vectors` (structure feature → grounding +
+# closure-before-vectorise), `sparq-introspect`, and `sparq-reason` into this crate.
+# With it OFF the default build is unchanged (pure data + constants).
+skill = ["query", "dep:sparq-vectors", "dep:sparq-introspect", "dep:sparq-reason"]
 
 [dependencies]
 # Engine graph type (only behind `validate`). default-features=false keeps it lean.
@@ -43,6 +53,14 @@ sparq-core = { path = "../sparq-core", default-features = false, optional = true
 sparq-shacl = { path = "../sparq-shacl", default-features = false, optional = true }
 # The SPARQL query/update engine (only behind `query`, for the example-lookup proof).
 sparq-engine = { path = "../sparq-engine", default-features = false, optional = true }
+# [OPUS-4.8] sq-2m6zm.3: the flexible grounding selector + closure-before-vectorise
+# (`structure` feature gates `grounding` + `structure::close_for_vectorise`). Only
+# behind `skill`. default-features=false keeps it lean.
+sparq-vectors = { path = "../sparq-vectors", default-features = false, features = ["structure"], optional = true }
+# [OPUS-4.8] sq-2m6zm.3: the token-budgeted schema-card miner. Only behind `skill`.
+sparq-introspect = { path = "../sparq-introspect", default-features = false, optional = true }
+# [OPUS-4.8] sq-2m6zm.3: the entailment `Profile` (RDFS / OWL-RL). Only behind `skill`.
+sparq-reason = { path = "../sparq-reason", default-features = false, optional = true }
 # Turtle parser + term model (only behind `validate`, to build the data graph).
 oxttl = { workspace = true, optional = true }
 oxrdf = { workspace = true, optional = true }

--- a/crates/sparq-kb/README.md
+++ b/crates/sparq-kb/README.md
@@ -63,6 +63,21 @@ one. The example lookups (`--features query --test ingest_query`) answer real
 questions — *"merge discipline for a ZK PR?"*, *"standing rules for sub-agents?"*,
 the §4.1 ready-frontier — returning the minimal triples computed by the engine.
 
+## 🔎 Query-the-PKG skill (`sq-2m6zm.3`, opt-in `skill` feature)
+
+`skill::query_the_pkg` is the thin **introspect → ground → ask** recipe an agent
+calls to query the PKG instead of re-reading the prose corpus: it ALWAYS
+`close_for_vectorise(RDFS|OWL-RL)` first (so the `owl:inverseOf` + subclass edges
+materialise), mines a token-budgeted schema card (`sparq-introspect`), runs a
+**§4.1-class verified-expressible** SPARQL query (the `skill::recipes` catalogue),
+and returns the minimal answer rows + the ABSTAT-style **minimal subgraph**
+(`sparq-vectors` grounding) for each bound IRI — with the **executed SPARQL
+surfaced** for verification. The §4.2/§4.3 N3 rules are explicitly Phase-2/3.
+
+```text
+cargo test -p sparq-kb --features skill --test skill_recipe -- --nocapture
+```
+
 ## ✨ Features
 
 - **Reuse-first ontology** — generalises the vendored `zkp-sparql`
@@ -76,8 +91,9 @@ the §4.1 ready-frontier — returning the minimal triples computed by the engin
 - **SHACL guardrails** — `pkg.shapes.ttl` makes a source + a confidence value + an
   assurance basis + non-filler content **mandatory** on every `pkg:Finding`, and
   enforces a valid status / bounded priority / no-stale-edge on every `pkg:Task`.
-- **Opt-in by construction** — default build is data + constants only; the
-  `validate` feature is the only thing that pulls in `sparq-core` + `sparq-shacl`.
+- **Opt-in by construction** — default build is data + constants only; `validate`
+  adds `sparq-core` + `sparq-shacl`, `query` adds the engine, and `skill` adds the
+  grounding + introspect surface. None of it is in the default build.
 - **No-drift guard** — `vocab.rs` is byte-pinned against `pkg.ttl` by a sync test.
 
 ## 📚 Learn more
@@ -89,9 +105,9 @@ the §4.1 ready-frontier — returning the minimal triples computed by the engin
   verification of every `skos:closeMatch` alignment against the live ontology.
 - The precedent it follows: `crates/sparq-trust/ontologies/zkp-sparql/` and
   `crates/sparq-trust/src/vocab.rs` (the ship-an-ontology + Rust-constants pattern).
-- Epic `sq-2m6zm`: the ontology/shapes are `sq-2m6zm.1`; the ingestion PoC above is
-  `sq-2m6zm.2`. Next: the query-the-PKG skill (`sq-2m6zm.3`) + the token-A/B harness
-  (`sq-2m6zm.4`).
+- Epic `sq-2m6zm`: the ontology/shapes are `sq-2m6zm.1`; the ingestion PoC is
+  `sq-2m6zm.2`; the query-the-PKG skill above is `sq-2m6zm.3`. Next: the token-A/B
+  harness (`sq-2m6zm.4`) that measures whether this beats re-reading the corpus.
 
 ## License
 

--- a/crates/sparq-kb/src/lib.rs
+++ b/crates/sparq-kb/src/lib.rs
@@ -112,3 +112,12 @@ pub mod query {
         query(graph, sparql)
     }
 }
+
+/// The Phase-1 **"query-the-PKG"** recipe (introspect → ground → ask). OPT-IN behind
+/// the default-OFF `skill` cargo feature (pulls in `sparq-vectors`'s grounding +
+/// closure-before-vectorise, `sparq-introspect`, and `sparq-reason`): the thin
+/// in-process recipe an agent calls to query the ingested PKG and get back minimal
+/// subgraphs + the executed SPARQL, instead of re-reading the prose corpus
+/// (sq-2m6zm.3). See [`skill`] for the full design notes.
+#[cfg(feature = "skill")]
+pub mod skill;

--- a/crates/sparq-kb/src/skill.rs
+++ b/crates/sparq-kb/src/skill.rs
@@ -1,0 +1,326 @@
+//! # `skill` — the Phase-1 "query-the-PKG" recipe (introspect → ground → ask)
+//!
+//! [OPUS-4.8] sq-2m6zm.3 (epic sq-2m6zm); design record
+//! `research/dogfooding-sparq-knowledge-graph.md` §4.1 + §6 Phase-1 deliverable 3.
+//! 🤖 SPARQ agent — dogfooding sparq as a project knowledge graph. Written while
+//! Fable unavailable; flag for re-review when Fable returns.
+//!
+//! This is the thin **in-process Rust** recipe an agent calls to query the ingested
+//! PKG ([`crate::PKG_INSTANCES`]) instead of re-reading the prose corpus. It wires the
+//! three steps the design prescribes, using only **production-ready** sparq surfaces:
+//!
+//! 1. **introspect** — mine a token-budgeted schema card of the loaded graph
+//!    ([`sparq_introspect::Introspection::to_text_summary`]). "Mine once, summarise
+//!    forever": the card is the cheap, re-usable grounding context for query
+//!    construction (design §1.2).
+//! 2. **ground** — ALWAYS [`close_for_vectorise`](sparq_vectors::structure::close_for_vectorise)
+//!    `(RDFS|OWL-RL)` **first** (design §3.1: completeness is profile-relative; the
+//!    `pkg:dependsOn owl:inverseOf pkg:blockedBy` axiom and the SKOS/RDFS subclass
+//!    edges only materialise after closure), then return the ABSTAT-style **minimal
+//!    subgraph** ([`sparq_vectors::grounding::Grounding::Subgraph`]) for each IRI the
+//!    answer binds — the verifiable facts, `O(answer)` tokens, not `O(corpus)`.
+//! 3. **ask** — run a **§4.1-class verified-expressible SPARQL** query (the
+//!    [`recipes`](crate::skill::recipes) catalogue, or any caller-supplied
+//!    `SELECT`/`ASK`) over the closed graph and **surface the executed SPARQL** (the
+//!    [`PkgAnswer`](crate::skill::PkgAnswer) `sparql` field) so the answer is
+//!    independently re-checkable.
+//!
+//! **Scope (honest):** Phase-1 relies *only* on the §4.1-class frontier queries that
+//! are verified-expressible in SPARQL today. The §4.2/§4.3 N3 trigger / research↔bead
+//! rules are explicitly Phase-2/3 and are **not** wired here. NL→SPARQL
+//! ([`sparq_nlq`](https://docs.rs/sparq-nlq)) is also out of scope: this recipe takes
+//! the SPARQL it runs from the verified catalogue (or the caller), it does not
+//! generate it from natural language. The store bounds the answer set, so within the
+//! store the answer cannot be fabricated; query-construction + verbalisation
+//! hallucination is *reduced*, not removed (design honesty summary).
+
+use oxrdf::Term;
+use sparq_core::Graph;
+use sparq_engine::{query, QueryResult};
+use sparq_introspect::Introspection;
+use sparq_reason::Profile;
+use sparq_vectors::grounding::{ground, GroundFact, Grounding, GroundingConfig, Modality};
+use sparq_vectors::structure::close_for_vectorise;
+
+/// The entailment profile to materialise before grounding/asking. Re-exports the two
+/// regimes [`close_for_vectorise`] supports; the design mandates closing under one of
+/// them so completeness is profile-relative.
+///
+/// Default [`Closure::OwlRl`] — the PKG ontology declares `pkg:dependsOn owl:inverseOf
+/// pkg:blockedBy` and `pkg:couldBeMergedWith a owl:SymmetricProperty`, which only
+/// materialise under OWL-RL; RDFS alone would leave those edges un-closed.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+pub enum Closure {
+    /// RDFS only (subclass / subproperty / domain / range).
+    Rdfs,
+    /// OWL 2 RL (includes RDFS; adds `inverseOf`, `SymmetricProperty`, `sameAs`, …).
+    /// The PKG default — see [`Closure`].
+    #[default]
+    OwlRl,
+}
+
+impl Closure {
+    fn profile(self) -> Profile {
+        match self {
+            Closure::Rdfs => Profile::Rdfs,
+            Closure::OwlRl => Profile::OwlRl,
+        }
+    }
+}
+
+/// Configuration for the [`query_the_pkg`] recipe.
+#[derive(Clone, Debug)]
+pub struct SkillConfig {
+    /// Which entailment closure to materialise before grounding/asking. Default
+    /// [`Closure::OwlRl`].
+    pub closure: Closure,
+    /// Character (token-proxy) budget for the introspection schema card. `0` skips the
+    /// card (no introspect step). Default 4096.
+    pub schema_card_chars: usize,
+    /// Cap on the number of facts in each grounded minimal subgraph (the `k`-budget
+    /// passed to [`GroundingConfig::max_facts`]). Default 32.
+    pub max_facts_per_subgraph: usize,
+    /// Cap on the number of distinct bound IRIs to ground into minimal subgraphs (an
+    /// answer can bind many entities; grounding every one defeats the `O(answer)`
+    /// token goal). `0` = ground none (rows only). Default 8.
+    pub max_grounded_nodes: usize,
+}
+
+impl Default for SkillConfig {
+    fn default() -> Self {
+        SkillConfig {
+            closure: Closure::default(),
+            schema_card_chars: 4096,
+            max_facts_per_subgraph: 32,
+            max_grounded_nodes: 8,
+        }
+    }
+}
+
+/// One bound IRI plus the ABSTAT-style **minimal subgraph** that grounds it — the
+/// verifiable facts the answer rests on. The subject is the IRI; each fact is a
+/// `(predicate, object)` pair present in the closed graph.
+#[derive(Clone, Debug)]
+pub struct GroundedNode {
+    /// The IRI (rendered bare) that the answer bound.
+    pub iri: String,
+    /// The minimal subgraph: the predicates the node's effective (minimal) type
+    /// carries, each with its object, bounded by [`SkillConfig::max_facts_per_subgraph`].
+    pub facts: Vec<GroundFact>,
+}
+
+/// The result of [`query_the_pkg`]: the executed SPARQL (surfaced for verification),
+/// the schema card, the answer rows, and the grounded minimal subgraphs.
+#[derive(Clone, Debug)]
+pub struct PkgAnswer {
+    /// The **executed** SPARQL — exactly what ran, surfaced so the answer is
+    /// independently re-checkable (design §6: "surface the executed SPARQL").
+    pub sparql: String,
+    /// The entailment closure that was materialised before the query ran.
+    pub closure: Closure,
+    /// Triples added by the closure (non-canonical; proves the closure ran). Never a
+    /// performance metric.
+    pub entailed_triples: usize,
+    /// The token-budgeted introspection schema card (empty when the card budget is 0).
+    pub schema_card: String,
+    /// The answer variable names, in projection order.
+    pub vars: Vec<String>,
+    /// The answer rows (the minimal binding set the engine computed — `O(answer)`).
+    /// Each cell is the rendered term, or `None` for an unbound variable.
+    pub rows: Vec<Vec<Option<String>>>,
+    /// The grounded minimal subgraphs for the distinct IRIs the answer bound (bounded
+    /// by [`SkillConfig::max_grounded_nodes`]).
+    pub grounded: Vec<GroundedNode>,
+}
+
+impl PkgAnswer {
+    /// The number of answer rows.
+    pub fn row_count(&self) -> usize {
+        self.rows.len()
+    }
+}
+
+/// Load the PKG ontology + ingested instances into one graph and materialise the
+/// `closure`. This is the "ground" step's prerequisite: every entailed
+/// `subClassOf`/`subPropertyOf`/`inverseOf`/`domain`/`range`/type fact becomes a real
+/// triple before any query or grounding reads the graph.
+///
+/// Returns the closed [`Graph`] and the number of triples the closure added.
+pub fn load_closed_pkg(closure: Closure) -> Result<(Graph, usize), String> {
+    let combined = format!("{}\n{}", crate::PKG_ONTOLOGY, crate::PKG_INSTANCES);
+    let closed = close_for_vectorise(&combined, "turtle", closure.profile())?;
+    Ok((closed.graph, closed.entailed_triples))
+}
+
+/// Mine a token-budgeted schema card of `graph` — the cheap, re-usable grounding
+/// context (design §1.2 "mine once, summarise forever"). `budget_chars == 0` returns
+/// an empty card.
+pub fn introspect(graph: &Graph, budget_chars: usize) -> String {
+    if budget_chars == 0 {
+        return String::new();
+    }
+    Introspection::build(graph).to_text_summary(budget_chars)
+}
+
+/// Render a result term to text: an IRI bare, a literal as its lexical value, a blank
+/// node as its label. Mirrors the rendering [`GroundFact`] uses so a row cell and a
+/// grounded fact line up.
+fn render_term(t: &Term) -> String {
+    match t {
+        Term::NamedNode(n) => n.as_str().to_string(),
+        Term::Literal(l) => l.value().to_string(),
+        Term::BlankNode(b) => format!("_:{}", b.as_str()),
+        // RDF-1.2 triple terms render via Display; they never appear as PKG IRIs.
+        other => other.to_string(),
+    }
+}
+
+/// Run a SPARQL `SELECT`/`ASK` query over the **already-closed** `graph`, returning the
+/// rows plus the minimal subgraph grounding for each distinct bound IRI (bounded by
+/// `cfg`). The caller is responsible for having closed the graph (use
+/// [`load_closed_pkg`] / [`query_the_pkg`]).
+///
+/// Only the IRIs the answer binds are grounded — the answer set already bounds the
+/// token cost, and the grounding adds *only* each entity's effective-type minimal
+/// predicate set, keeping the whole result `O(answer)` rather than `O(corpus)`.
+pub fn ask(graph: &Graph, sparql: &str, cfg: &SkillConfig) -> Result<PkgAnswer, String> {
+    let result: QueryResult = query(graph, sparql)?;
+
+    let vars: Vec<String> = result.vars.iter().map(|v| v.as_str().to_string()).collect();
+    let rows: Vec<Vec<Option<String>>> = result
+        .rows
+        .iter()
+        .map(|row| row.iter().map(|c| c.as_ref().map(render_term)).collect())
+        .collect();
+
+    // Ground the distinct bound IRIs into minimal subgraphs (in first-seen order, so
+    // the output is deterministic). Build the introspection once for minimalisation.
+    let mut grounded = Vec::new();
+    if cfg.max_grounded_nodes > 0 {
+        let introspection = Introspection::build(graph);
+        let gcfg = GroundingConfig {
+            minimal_type_pattern: true,
+            max_facts: cfg.max_facts_per_subgraph,
+            ..Default::default()
+        };
+        let mut seen = std::collections::HashSet::new();
+        'outer: for row in &result.rows {
+            for cell in row {
+                if let Some(Term::NamedNode(n)) = cell {
+                    let iri = n.as_str().to_string();
+                    if !seen.insert(iri.clone()) {
+                        continue;
+                    }
+                    let node = Term::NamedNode(n.clone());
+                    if let Some(Grounding::Subgraph(facts)) = ground(
+                        graph,
+                        &node,
+                        Modality::Subgraph,
+                        &gcfg,
+                        Some(&introspection),
+                        None,
+                    ) {
+                        grounded.push(GroundedNode { iri, facts });
+                    }
+                    if grounded.len() >= cfg.max_grounded_nodes {
+                        break 'outer;
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(PkgAnswer {
+        sparql: sparql.to_string(),
+        closure: cfg.closure,
+        entailed_triples: 0, // filled by query_the_pkg, which owns the closure step
+        schema_card: String::new(),
+        vars,
+        rows,
+        grounded,
+    })
+}
+
+/// The full **introspect → ground → ask** recipe: load + close the PKG, mine the schema
+/// card, run `sparql` (a [`recipes`] query or any caller-supplied `SELECT`/`ASK`), and
+/// ground the bound IRIs into minimal subgraphs. The executed SPARQL is surfaced on
+/// the returned [`PkgAnswer`].
+///
+/// ```no_run
+/// use sparq_kb::skill::{query_the_pkg, recipes, SkillConfig};
+///
+/// let ans = query_the_pkg(recipes::READY_FRONTIER_COUNT, &SkillConfig::default())
+///     .expect("recipe runs");
+/// println!("executed:\n{}", ans.sparql);     // surfaced for verification
+/// println!("schema card:\n{}", ans.schema_card);
+/// for row in &ans.rows {
+///     println!("{row:?}");
+/// }
+/// ```
+pub fn query_the_pkg(sparql: &str, cfg: &SkillConfig) -> Result<PkgAnswer, String> {
+    let (graph, entailed) = load_closed_pkg(cfg.closure)?;
+    let card = introspect(&graph, cfg.schema_card_chars);
+    let mut answer = ask(&graph, sparql, cfg)?;
+    answer.entailed_triples = entailed;
+    answer.schema_card = card;
+    Ok(answer)
+}
+
+/// The **§4.1-class verified-expressible** SPARQL catalogue — the only queries Phase-1
+/// relies on. Each is a `SELECT`/`ASK` proven to run over the ingested PKG graph (the
+/// `ingest_query` proof + the [`super::skill`] tests). The §4.2/§4.3 N3 rules are
+/// explicitly Phase-2/3 and are NOT here.
+pub mod recipes {
+    /// §4.1 ready-frontier (the dependency half) — **count** of open/in-progress tasks
+    /// with no OPEN blocking dependency, not human-gated (`needs:` label), and not an
+    /// umbrella (parent of another task). The conflict-partition / CPU-cap /
+    /// in-flight-by-git layers are NOT expressible without the (Phase-2) live-state
+    /// named graph — see design §4.
+    pub const READY_FRONTIER_COUNT: &str = r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+SELECT (COUNT(DISTINCT ?t) AS ?ready) WHERE {
+  ?t a pkg:Task ; pkg:status ?s ; pkg:priority ?prio .
+  FILTER(?s IN (pkg:Open, pkg:InProgress))
+  FILTER NOT EXISTS { ?t pkg:dependsOn ?b . ?b pkg:status ?bs . FILTER(?bs != pkg:Closed) }
+  FILTER NOT EXISTS { ?t pkg:label ?l . FILTER(STRSTARTS(STR(?l), "needs:")) }
+  FILTER NOT EXISTS { ?child dcterms:isPartOf ?t }
+}"#;
+
+    /// §4.1 ready-frontier — the **task IRIs** themselves (same predicate as
+    /// [`READY_FRONTIER_COUNT`] but projecting the tasks + priority, ordered), so the
+    /// caller can ground each into its minimal subgraph.
+    pub const READY_FRONTIER: &str = r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+SELECT ?t ?prio WHERE {
+  ?t a pkg:Task ; pkg:status ?s ; pkg:priority ?prio .
+  FILTER(?s IN (pkg:Open, pkg:InProgress))
+  FILTER NOT EXISTS { ?t pkg:dependsOn ?b . ?b pkg:status ?bs . FILTER(?bs != pkg:Closed) }
+  FILTER NOT EXISTS { ?t pkg:label ?l . FILTER(STRSTARTS(STR(?l), "needs:")) }
+  FILTER NOT EXISTS { ?child dcterms:isPartOf ?t }
+} ORDER BY ?prio ?t LIMIT 50"#;
+
+    /// "Which Findings are about a topic?" — the sourced, confidence-ordered Findings
+    /// for a topic IRI. The query is parameterless; substitute the topic with
+    /// [`findings_about`].
+    pub const FINDINGS_ABOUT_TEMPLATE: &str = r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?f ?label ?section ?conf WHERE {
+  ?f a pkg:Finding ;
+     pkg:about <TOPIC> ;
+     rdfs:label ?label ;
+     dcterms:source ?section ;
+     pkg:confidence ?conf .
+} ORDER BY DESC(?conf)"#;
+
+    /// Build a "Findings about `<topic_iri>`" query from [`FINDINGS_ABOUT_TEMPLATE`] by
+    /// substituting the topic IRI. The IRI is wrapped in `<>`; callers pass a bare IRI
+    /// (e.g. a `kb:topic-…` URL). No general string interpolation into SPARQL is done
+    /// elsewhere — only this single, IRI-shaped slot — so injection surface is nil.
+    pub fn findings_about(topic_iri: &str) -> String {
+        FINDINGS_ABOUT_TEMPLATE.replace("<TOPIC>", &format!("<{topic_iri}>"))
+    }
+}

--- a/crates/sparq-kb/tests/dogfood_shacl.rs
+++ b/crates/sparq-kb/tests/dogfood_shacl.rs
@@ -37,7 +37,10 @@ fn ontology_and_shapes_parse_and_load() {
     // Both .ttl files must parse (load in sparq) — the first gate.
     let report = validate_instances(&[PKG_EXAMPLE]).expect("ontology + shapes + example load");
     // The report rendering is captured into the PR description as proof the guardrails fire.
-    eprintln!("=== sparq-shacl PKG guardrail report ===\n{}", report.to_text());
+    eprintln!(
+        "=== sparq-shacl PKG guardrail report ===\n{}",
+        report.to_text()
+    );
 }
 
 #[test]
@@ -52,12 +55,12 @@ fn valid_nodes_pass_and_invalid_nodes_are_reported() {
 
     // --- VALID nodes must NOT be reported -----------------------------------
     for ok in [
-        "find-cs-dual-use",      // sourced + confident + assured + non-filler
-        "find-kge-neutral",      // sourced refuting-edge finding
+        "find-cs-dual-use",           // sourced + confident + assured + non-filler
+        "find-kge-neutral",           // sourced refuting-edge finding
         "src-neumann-moerkotte-2011", // explored-status + title
         "tech-characteristic-sets",   // supersedes an existing Technique
-        "task-sq-2m6zm",         // open epic, sound dep edge
-        "task-sq-2m6zm-1",       // in-progress, bounded priority
+        "task-sq-2m6zm",              // open epic, sound dep edge
+        "task-sq-2m6zm-1",            // in-progress, bounded priority
     ] {
         assert!(
             !reported(&report, ok),

--- a/crates/sparq-kb/tests/ingest_query.rs
+++ b/crates/sparq-kb/tests/ingest_query.rs
@@ -11,8 +11,8 @@
 #![cfg(feature = "query")]
 
 use oxrdf::Term;
-use sparq_kb::query::{ask_pkg, load_pkg};
 use sparq_engine::QueryResult;
+use sparq_kb::query::{ask_pkg, load_pkg};
 
 /// Pretty-print a result set so the proof appears in the PR description.
 fn dump(label: &str, q: &str, r: &QueryResult) {
@@ -21,10 +21,19 @@ fn dump(label: &str, q: &str, r: &QueryResult) {
         let cells: Vec<String> = row
             .iter()
             .map(|c| match c {
-                Some(Term::NamedNode(n)) => n.as_str().rsplit(['#', '/']).next().unwrap_or("").to_string(),
+                Some(Term::NamedNode(n)) => n
+                    .as_str()
+                    .rsplit(['#', '/'])
+                    .next()
+                    .unwrap_or("")
+                    .to_string(),
                 Some(Term::Literal(l)) => {
                     let s = l.value();
-                    if s.len() > 110 { format!("{}…", &s[..110]) } else { s.to_string() }
+                    if s.len() > 110 {
+                        format!("{}…", &s[..110])
+                    } else {
+                        s.to_string()
+                    }
                 }
                 Some(t) => t.to_string(),
                 None => "(unbound)".into(),
@@ -73,17 +82,23 @@ SELECT ?label ?section ?conf WHERE {
         "Q1 must surface the ci-summary gate; got {labels:?}"
     );
     assert!(
-        labels.iter().any(|l| l.contains("circuit") || l.contains("gate-count")),
+        labels
+            .iter()
+            .any(|l| l.contains("circuit") || l.contains("gate-count")),
         "Q1 must surface the ZK-circuit gate; got {labels:?}"
     );
     assert!(
-        labels.iter().any(|l| l.contains("privacy") || l.contains("soundness")),
+        labels
+            .iter()
+            .any(|l| l.contains("privacy") || l.contains("soundness")),
         "Q1 must surface the privacy-claims gate; got {labels:?}"
     );
     // Every returned Finding carries a section anchor (its provenance) — that is the
     // citation half of the guardrail, queryable.
     assert!(
-        r.rows.iter().all(|row| matches!(&row[1], Some(Term::Literal(_)))),
+        r.rows
+            .iter()
+            .all(|row| matches!(&row[1], Some(Term::Literal(_)))),
         "every Q1 Finding must carry its dcterms:source section anchor"
     );
 }
@@ -117,7 +132,10 @@ SELECT ?label ?section ?conf WHERE {
             _ => None,
         })
         .collect();
-    assert!(labels.len() >= 5, "Q2 should surface the sub-agent rule set; got {labels:?}");
+    assert!(
+        labels.len() >= 5,
+        "Q2 should surface the sub-agent rule set; got {labels:?}"
+    );
     assert!(
         labels.iter().any(|l| l.contains("shared contract")),
         "Q2 must surface the shared contract; got {labels:?}"
@@ -152,10 +170,18 @@ SELECT (COUNT(DISTINCT ?t) AS ?ready) WHERE {
     let r = ask_pkg(&g, q).expect("frontier query runs");
     dump("Q3: §4.1 ready-frontier (dependency half)", q, &r);
     // The frontier is non-empty over a real backlog of 1255 tasks.
-    let n = match &r.rows.first().and_then(|row| row.first()).and_then(|c| c.clone()) {
+    let n = match &r
+        .rows
+        .first()
+        .and_then(|row| row.first())
+        .and_then(|c| c.clone())
+    {
         Some(Term::Literal(l)) => l.value().parse::<i64>().unwrap_or(0),
         _ => 0,
     };
-    assert!(n > 0, "the ready-frontier must be non-empty over the bd backlog; got {n}");
+    assert!(
+        n > 0,
+        "the ready-frontier must be non-empty over the bd backlog; got {n}"
+    );
     eprintln!("\nQ3 ready-frontier count = {n}");
 }

--- a/crates/sparq-kb/tests/skill_recipe.rs
+++ b/crates/sparq-kb/tests/skill_recipe.rs
@@ -1,0 +1,210 @@
+//! End-to-end proof of the Phase-1 "query-the-PKG" recipe (introspect → ground → ask).
+//!
+//! [OPUS-4.8] sq-2m6zm.3 (epic sq-2m6zm). 🤖 SPARQ agent — query-the-PKG skill PoC.
+//! These run the recipe against the ingested PKG and assert the three steps actually
+//! fire: the closure materialises entailed triples, the introspection card is a real
+//! token-budgeted schema card, the §4.1-class queries return the minimal answer, the
+//! bound IRIs are grounded into ABSTAT-style minimal subgraphs, and the executed
+//! SPARQL is surfaced for verification. The answers are computed by sparq's own engine
+//! over the closed graph — within the store the answer cannot be fabricated.
+//!
+//! Run: `cargo test -p sparq-kb --features skill --test skill_recipe -- --nocapture`
+#![cfg(feature = "skill")]
+
+use sparq_kb::skill::{
+    ask, introspect, load_closed_pkg, query_the_pkg, recipes, Closure, SkillConfig,
+};
+
+/// The closure step must run and (for the PKG, which declares `owl:inverseOf` +
+/// `owl:SymmetricProperty` + RDFS subclass edges) add entailed triples under OWL-RL.
+#[test]
+fn closure_materialises_entailed_triples() {
+    let (_g, entailed) = load_closed_pkg(Closure::OwlRl).expect("PKG loads + closes");
+    eprintln!("OWL-RL closure added {entailed} entailed triples");
+    assert!(
+        entailed > 0,
+        "OWL-RL closure must materialise entailed triples over the PKG ontology"
+    );
+}
+
+/// The introspect step must produce a non-empty, budget-bounded schema card that
+/// actually mentions the PKG classes (the grounding context for query construction).
+#[test]
+fn introspect_yields_schema_card() {
+    let (g, _) = load_closed_pkg(Closure::OwlRl).expect("PKG loads");
+    let budget = 4096;
+    let card = introspect(&g, budget);
+    eprintln!("=== schema card ({} chars) ===\n{card}", card.len());
+    assert!(!card.is_empty(), "schema card must be non-empty");
+    assert!(
+        card.chars().count() <= budget,
+        "schema card must respect its char budget"
+    );
+    assert!(
+        card.contains("Task") || card.contains("Finding") || card.contains("Class"),
+        "schema card must surface the PKG schema; got: {card}"
+    );
+    // budget 0 disables the introspect step.
+    assert!(introspect(&g, 0).is_empty(), "budget 0 must skip the card");
+}
+
+/// The §4.1 ready-frontier count must be non-empty over the real bd backlog, and the
+/// recipe must surface the executed SPARQL + the closure report.
+#[test]
+fn ready_frontier_count() {
+    let ans = query_the_pkg(recipes::READY_FRONTIER_COUNT, &SkillConfig::default())
+        .expect("frontier recipe runs");
+    eprintln!("\n=== executed SPARQL ===\n{}", ans.sparql);
+    eprintln!(
+        "closure={:?} entailed={}",
+        ans.closure, ans.entailed_triples
+    );
+    assert_eq!(
+        ans.sparql,
+        recipes::READY_FRONTIER_COUNT,
+        "executed SPARQL must be surfaced verbatim"
+    );
+    assert!(
+        ans.entailed_triples > 0,
+        "the recipe must close the graph before asking"
+    );
+    assert!(
+        !ans.schema_card.is_empty(),
+        "the recipe must mine the schema card"
+    );
+    assert_eq!(ans.row_count(), 1, "COUNT returns exactly one row");
+    let count: i64 = ans.rows[0][0]
+        .as_ref()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
+    eprintln!("ready-frontier count = {count}");
+    assert!(
+        count > 0,
+        "the ready-frontier must be non-empty over the bd backlog; got {count}"
+    );
+}
+
+/// The ready-frontier IRI projection must bind task IRIs AND ground each into a minimal
+/// subgraph (the "ground" half of the recipe) — verifiable facts, not prose.
+#[test]
+fn ready_frontier_grounds_tasks() {
+    let cfg = SkillConfig {
+        max_grounded_nodes: 5,
+        ..Default::default()
+    };
+    let ans = query_the_pkg(recipes::READY_FRONTIER, &cfg).expect("frontier recipe runs");
+    eprintln!("\n=== ready-frontier ({} rows) ===", ans.row_count());
+    assert!(
+        ans.row_count() > 0,
+        "the ready-frontier must bind at least one task"
+    );
+    assert_eq!(ans.vars, vec!["t".to_string(), "prio".to_string()]);
+
+    // Each grounded node is a real PKG Task IRI with a non-empty minimal subgraph.
+    assert!(
+        !ans.grounded.is_empty(),
+        "the recipe must ground the bound task IRIs"
+    );
+    assert!(
+        ans.grounded.len() <= cfg.max_grounded_nodes,
+        "grounding must respect max_grounded_nodes"
+    );
+    for gn in &ans.grounded {
+        eprintln!("\n{} — {} fact(s)", gn.iri, gn.facts.len());
+        for f in &gn.facts {
+            eprintln!("  {} -> {}", f.predicate, f.object);
+        }
+        assert!(gn.iri.starts_with("http"), "grounded node must be an IRI");
+        assert!(
+            !gn.facts.is_empty(),
+            "a grounded task must carry a minimal subgraph"
+        );
+        // Minimal subgraph respects the per-node fact budget.
+        assert!(
+            gn.facts.len() <= cfg.max_facts_per_subgraph,
+            "subgraph must respect max_facts_per_subgraph"
+        );
+        // The grounded facts include the task's status (the load-bearing predicate the
+        // frontier selected on) — proof the subgraph is the relevant minimal pattern.
+        assert!(
+            gn.facts
+                .iter()
+                .any(|f| f.predicate.ends_with("#status") || f.predicate.ends_with("#priority")),
+            "a grounded Task's minimal subgraph must carry its status/priority; got {:?}",
+            gn.facts
+        );
+    }
+}
+
+/// A "Findings about a topic" lookup (built from the verified template) must return the
+/// sourced, confidence-bearing Findings for a real PKG topic — the citation half of the
+/// guardrail, queryable.
+#[test]
+fn findings_about_a_topic() {
+    let topic = "https://sparq.dev/ns/pkg/kb#topic-merge-discipline";
+    let sparql = recipes::findings_about(topic);
+    let ans = query_the_pkg(&sparql, &SkillConfig::default()).expect("findings recipe runs");
+    eprintln!(
+        "\n=== findings about {topic} ({} rows) ===",
+        ans.row_count()
+    );
+    for row in &ans.rows {
+        eprintln!("  {row:?}");
+    }
+    assert!(
+        ans.sparql.contains(topic),
+        "the executed SPARQL must bind the requested topic"
+    );
+    assert!(
+        ans.row_count() > 0,
+        "merge-discipline topic must have Findings"
+    );
+    // Projection is ?f ?label ?section ?conf — every Finding carries a source section
+    // (the citation) and a confidence.
+    assert_eq!(ans.vars, vec!["f", "label", "section", "conf"]);
+    for row in &ans.rows {
+        assert!(
+            row[2].is_some(),
+            "every Finding must carry its dcterms:source section"
+        );
+        assert!(
+            row[3].is_some(),
+            "every Finding must carry its pkg:confidence"
+        );
+    }
+    // The Finding IRIs (?f) are grounded into minimal subgraphs.
+    assert!(
+        !ans.grounded.is_empty(),
+        "the recipe must ground the Finding IRIs"
+    );
+}
+
+/// RDFS-only closure is also a valid grounding profile; the recipe must run under it
+/// (completeness is then RDFS-profile-relative, per the design).
+#[test]
+fn rdfs_closure_also_runs() {
+    let cfg = SkillConfig {
+        closure: Closure::Rdfs,
+        ..Default::default()
+    };
+    let ans = query_the_pkg(recipes::READY_FRONTIER_COUNT, &cfg).expect("recipe runs under RDFS");
+    assert_eq!(ans.closure, Closure::Rdfs);
+    assert_eq!(ans.row_count(), 1);
+}
+
+/// The low-level `ask` over a caller-closed graph surfaces the executed SPARQL and
+/// grounds bound IRIs without re-closing (the composable building block).
+#[test]
+fn ask_over_caller_closed_graph() {
+    let (g, _) = load_closed_pkg(Closure::OwlRl).expect("PKG loads");
+    let q = r#"
+PREFIX pkg: <https://sparq.dev/ns/pkg#>
+SELECT ?f WHERE { ?f a pkg:Finding } LIMIT 3"#;
+    let ans = ask(&g, q, &SkillConfig::default()).expect("ask runs");
+    assert_eq!(ans.sparql, q, "ask must surface the executed SPARQL");
+    assert!(ans.row_count() > 0 && ans.row_count() <= 3);
+    assert!(
+        !ans.grounded.is_empty(),
+        "ask must ground the bound Finding IRIs"
+    );
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** [OPUS-4.8] — query-the-PKG skill PoC (`sq-2m6zm.3`), Phase-1 deliverable 3 of the PKG dogfooding design. Dogfooding sparq as a project knowledge graph. Written while Fable unavailable; flag for re-review when Fable returns.

## What

Implements `sq-2m6zm.3` — the **"query-the-PKG" skill PoC** from
`research/dogfooding-sparq-knowledge-graph.md` §4.1 + §6 (Phase-1 deliverable 3): the
thin in-process Rust recipe an agent calls to **query** the ingested PKG (landed in
#1069) instead of re-reading the prose corpus.

New default-OFF **`skill`** feature on `sparq-kb` adds `skill::query_the_pkg`, which
wires three production-ready surfaces:

1. **introspect** — a token-budgeted schema card (`sparq-introspect`).
2. **ground** — ALWAYS `close_for_vectorise(RDFS|OWL-RL)` **first** (`sparq-vectors`
   `structure`), so the `pkg:dependsOn owl:inverseOf pkg:blockedBy` axiom + RDFS/SKOS
   subclass edges materialise, then the ABSTAT-style **minimal subgraph**
   (`grounding::Grounding::Subgraph`) for each bound IRI — verifiable facts,
   `O(answer)` tokens, not `O(corpus)`.
3. **ask** — a **§4.1-class verified-expressible** SPARQL query (the `skill::recipes`
   catalogue: ready-frontier count/IRIs + findings-about-a-topic) over the closed
   graph, with **the executed SPARQL surfaced** for verification.

## Scope / honesty

- Relies **only** on the §4.1 verified-expressible frontier. The §4.2/§4.3 N3
  trigger / research↔bead rules are explicitly **Phase-2/3 and NOT wired**.
- **NL→SPARQL is out of scope** — the SPARQL comes from the verified catalogue or the
  caller, never generated. The store bounds the answer set (no in-store fabrication);
  query-construction + verbalisation hallucination is *reduced*, not removed.

## Best-judgment decisions (steer post-hoc)

The bead specifies the *shape* but not the exact API, so per the standing
proceed-without-greenlight rule I chose (flagged in a follow-up issue):

- **In-process Rust, not raw-SPARQL-over-HTTP.** In-process is the only one available
  today — the §3.2 wiring gap means nlq/introspect/grounding are not exposed over
  `sparq-server`. HTTP exposure is its own tracked gap, not this PoC.
- **Default closure = OWL-RL** (the PKG declares `owl:inverseOf` +
  `owl:SymmetricProperty`; RDFS alone leaves those edges un-closed). RDFS is selectable.
- **A small verified `recipes` catalogue** (ready-frontier + findings-about-a-topic)
  rather than free-form query generation — keeps Phase-1 on the verified frontier.

## Note

Also folds in the `cargo fmt` fixes that #1069's test files (`dogfood_shacl.rs`,
`ingest_query.rs`) needed, so the crate is fmt-clean against `main`.

## Gates

All green in **both** feature states:
- `cargo clippy -p sparq-kb --all-targets --all-features -D warnings` + default + full-workspace clippy
- `cargo test -p sparq-kb --features skill` (lib 1, dogfood_shacl 3, ingest_query 3, ingest_shacl 2, **skill_recipe 7**, doctest 1)
- `cargo doc --workspace --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`
- `cargo fmt -p sparq-kb --check`, `check-readme-template.py` (114 lines), `check-privacy-claims.sh`, `typos`
- No hard-coded perf numbers (the entailed-triple / count assertions are correctness checks in test code, not docs/metrics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
