### PR TITLE
feat(sparq-kb): query-the-PKG skill PoC — introspect → ground → ask (sq-2m6zm.3) [OPUS-4.8]

### DIFF
--- a/.claude/skills/query-pkg/SKILL.md
+++ b/.claude/skills/query-pkg/SKILL.md
@@ -1,0 +1,197 @@
+---
+name: query-pkg
+description: Answer a "what does the repo say about X, where was Y decided, what is the status or provenance of Z, which sources are still unexplored, what depends on bead W" question by running a SPARQL query over the ingested Project-Knowledge-Graph (PKG) instead of reading whole documents. Use when an agent working on sparq needs a sourced, answer-sized fact from AGENTS.md, the skills, or the bd backlog and would otherwise Read or Grep a large doc. The mechanism is introspect then ground then ask via the pkg-query helper in crates/sparq-kb. NOTE this is the MECHANISM; whether it actually cuts agent tokens is measured by bead sq-2m6zm.4, not claimed here.
+---
+
+# Query the PKG — introspect → ground → ask
+
+[OPUS-4.8] Bead **sq-2m6zm.3** (epic sq-2m6zm). Design record:
+`research/dogfooding-sparq-knowledge-graph.md` (§4.1 frontier queries, §6 worked
+questions). 🤖 SPARQ agent — dogfooding sparq as a project knowledge graph.
+
+The PKG is sparq's own knowledge stored as RDF triples: `pkg:Finding`s (sourced,
+confidence-tagged discoveries from AGENTS.md), `pkg:Source`s (skills / docs with an
+explored-status), `pkg:Technique`s (the surfaces), and `pkg:Task`s (the bd backlog
+projected to RDF with `pkg:dependsOn` edges). Instead of `Read`-ing a whole document to
+find one fact, run a SPARQL query and read the **answer-sized** result. The answer is
+computed by sparq's own engine over the ingested graph — within the store the agent
+cannot fabricate a fact the data does not contain (the engine bounds the result set), and
+an empty result is the honest "I don't know / none outstanding" answer.
+
+> **Honesty.** This skill is the *mechanism*. **Whether querying the PKG actually cuts an
+> agent's token spend versus reading the source document is MEASURED by bead sq-2m6zm.4,
+> not claimed here.** This file contains NO unmeasured token-saving number. The PKG is a
+> Phase-1 *head slice* (the AGENTS.md finding set + a mechanical bd→Task projection + the
+> heaviest skills' front-matter), not the whole corpus — a miss means "not in the head
+> slice yet", so fall back to Read/Grep.
+
+## The helper
+
+One command, in `crates/sparq-kb`, behind the default-OFF `query` feature (keeps the lean
+default build a pure data crate):
+
+```bash
+cargo run -p sparq-kb --features query --bin pkg-query -- <args>
+```
+
+It loads `pkg.ttl` (the ontology) + `pkg-instances.ttl` (the ingested data) into a sparq
+store, runs a **named canned query** or a **raw SPARQL string**, prints the executed
+SPARQL (always — for verification) and the result rows. Add `--features close` and
+`--close owl-rl` to materialise the RDFS/OWL-RL closure first (entails the `pkg:dependsOn
+owl:inverseOf pkg:blockedBy` pair and `pkg:couldBeMergedWith` symmetry — the design's
+"always close first" step).
+
+## (a) INTROSPECT — what can I ask about?
+
+Before grounding a question, learn the dataset's effective schema so you know which
+classes and predicates exist (cheaper than scanning sample data). The `schema-classes`
+query lists every `pkg:` class actually instantiated, with a count:
+
+```bash
+cargo run -p sparq-kb --features query --bin pkg-query -- --query schema-classes
+```
+
+```text
+class  |  instances
+Task  |  1255
+Finding  |  11
+Source  |  6
+Document  |  6
+Technique  |  5
+```
+
+`--query schema-properties` lists the predicates in use (label, type, title, identifier,
+priority, status, issueType, isPartOf, **dependsOn**, subject, source, …). List every
+canned query with:
+
+```bash
+cargo run -p sparq-kb --features query --bin pkg-query -- --list
+```
+
+## (b) GROUND — translate the question to SPARQL over those terms
+
+The canned queries are the §4.1-class, verified-expressible SPARQL frontier queries
+(plain SELECT / `FILTER NOT EXISTS` / `GROUP BY`; the §4.2/§4.3 N3 rules are explicitly
+Phase-2/3 and NOT used here). Pick the template that matches the question shape; some take
+an argument via `--arg`.
+
+| Question shape | canned `--query` | `--arg` |
+|---|---|---|
+| "What does the repo say about TOPIC?" | `findings-about` | a topic IRI |
+| "Where was this decided / what is its provenance + confidence?" | `finding-provenance` | — |
+| "Which sources are still UNEXPLORED (target follow-up)?" | `unexplored-sources` | — |
+| "What is the explored-status of the source catalog?" | `source-status` | — |
+| "What does bead W depend on, and is each dependency done?" | `task-depends-on` | a bd id |
+| "What is blocked by bead W (downstream impact)?" | `task-blocks` | a bd id |
+| "Which sources should I read next (priority order)?" | `high-followup-priority` | — |
+| "How many beads are ready (§4.1 dependency frontier)?" | `ready-frontier` | — |
+
+The topic IRIs in the current head slice are
+`https://sparq.dev/ns/pkg/kb#topic-merge-discipline`,
+`…#topic-subagent-rules`, and `…#topic-zk-discipline`.
+
+To go beyond the templates, write a raw SPARQL SELECT/ASK against the `pkg:` terms and
+pass it with `--sparql '<query>'`. Use `--sparql-only` to print the SPARQL without running
+it (verify before executing).
+
+## (c) ASK — run the helper and read the answer
+
+Run the chosen query; read the small result table instead of the source doc. Each finding
+row carries its `dcterms:source` section anchor and `pkg:confidence`, so the answer is
+**sourced and confidence-tagged**, not bare prose.
+
+---
+
+## End-to-end examples (real questions, real returned answers)
+
+### Example A — "What is the merge discipline?" (a findings-about GROUND query)
+
+Instead of reading the whole `AGENTS.md` contribution-workflow + gate-matrix sections:
+
+```bash
+cargo run -p sparq-kb --features query --bin pkg-query -- \
+  --query findings-about --arg https://sparq.dev/ns/pkg/kb#topic-merge-discipline
+```
+
+Returned answer (sourced + confidence-tagged):
+
+```text
+label  |  section  |  conf
+A PR merges only when ci-summary is green and every review thread is resolved
+    |  AGENTS.md#contribution-workflow--prs-reviews-resolved-the-ci-summary-gate  |  0.98
+A verified-clean non-perf PR auto-arms; never arm auto-merge on a stacked PR whose base is not main
+    |  AGENTS.md#contribution-workflow--prs-reviews-resolved-the-ci-summary-gate  |  0.93
+2 row(s).
+```
+
+(Swap the topic to `…#topic-zk-discipline` for "what's the merge discipline for a ZK PR?"
+— it adds the forge_gates + gate-count snapshot row and the HARD privacy-claims gate row.)
+
+### Example B — "Which sources are still unexplored?" (an honest empty answer)
+
+```bash
+cargo run -p sparq-kb --features query --bin pkg-query -- --query unexplored-sources
+```
+
+Returned answer:
+
+```text
+source  |  title  |  status  |  prio
+0 row(s).
+```
+
+Over the Phase-1 ingest every source is `pkg:Explored`, so the targeted-follow-up list is
+**empty** — the honest "none outstanding" answer, computed by the engine rather than
+guessed. (As `Unexplored`/`Exploring` sources are ingested in later phases they appear
+here automatically.)
+
+### Example C — "What is blocked by bead sq-8thu?" (a task-blocks GROUND query)
+
+Instead of running `bd dep tree` or grepping `.beads/issues.jsonl`, ask the read-model:
+
+```bash
+cargo run -p sparq-kb --features query --bin pkg-query -- --query task-blocks --arg sq-8thu
+```
+
+Returned answer (downstream dependents + each one's status; truncated):
+
+```text
+downstreamId  |  downstreamStatus  |  downstreamTitle
+sq-0po6  |  Closed  |  page: /surface/inference (tier-b live)
+sq-11zy  |  Closed  |  page: /surface/streaming-rsp (tier-b live)
+sq-13rg  |  Closed  |  ZK: bb.js in-browser UltraHonk proving wiring (WZK)
+…
+22 row(s).
+```
+
+The inverse direction (`?b pkg:blockedBy sq-8thu`) is never asserted in the data; under
+OWL-RL closure it is entailed, so this is equivalent — verify with:
+
+```bash
+cargo run -p sparq-kb --features close --bin pkg-query -- --close owl-rl \
+  --sparql 'PREFIX pkg: <https://sparq.dev/ns/pkg#> PREFIX dcterms: <http://purl.org/dc/terms/>
+            SELECT (COUNT(*) AS ?n) WHERE { ?b dcterms:identifier "sq-8thu" . ?b pkg:blockedBy ?d }'
+```
+
+## When NOT to use this
+
+- The fact is **not in the head slice** (PKG is a Phase-1 subset) → an empty/partial
+  result means fall back to `Read`/`Grep`. An empty result is honest, not a failure.
+- The document is **small** and you would read it once → loading it directly is fewer
+  tokens and fewer round-trips (the design's §1.1 honest boundary).
+- For the **live** ready-frontier (git/gh/nproc-aware) use `scripts/push-frontier.sh`;
+  `ready-frontier` here is only the §4.1 dependency half over the projected backlog.
+- bd remains the **source-of-record** for tasks; the PKG `pkg:Task`s are a read-model
+  mirror, not a place to write task state.
+
+## Where this lives
+
+- Helper binary: `crates/sparq-kb/src/bin/pkg_query.rs` (`--bin pkg-query`).
+- Canned queries (the library the binary + the test share):
+  `crates/sparq-kb/src/query/canned.rs`.
+- Loader + optional closure: `crates/sparq-kb/src/lib.rs` (`query` / `query::close` modules).
+- Rot-guard test: `crates/sparq-kb/tests/query_canned.rs`
+  (`cargo test -p sparq-kb --features query --test query_canned`; add `--features close`
+  for the closure test).
+- Ontology + data: `crates/sparq-kb/ontology/pkg/pkg.ttl`,
+  `crates/sparq-kb/ingest/pkg-instances.ttl`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3488,6 +3488,7 @@ dependencies = [
  "oxttl 0.2.3",
  "sparq-core",
  "sparq-engine",
+ "sparq-reason",
  "sparq-shacl",
 ]
 

--- a/crates/sparq-kb/Cargo.toml
+++ b/crates/sparq-kb/Cargo.toml
@@ -30,9 +30,18 @@ default = []
 # Enables the `validate` module (load PKG ontology + instances, run the SHACL shapes).
 validate = ["dep:sparq-core", "dep:sparq-shacl", "dep:oxttl", "dep:oxrdf"]
 # OPT-IN (default-OFF). Enables the SPARQL-query proof over the ingested PKG graph
-# (sq-2m6zm.2): the example-lookup answers (`Graph::load_str` + `sparq_engine::query`).
-# Pulls in the SPARQL engine; keep it off the lean default build.
+# (sq-2m6zm.2): the example-lookup answers (`Graph::load_str` + `sparq_engine::query`),
+# the introspect→ground→ask `query` module, the named canned queries, and the
+# `pkg-query` binary (sq-2m6zm.3). Pulls in the SPARQL engine; keep it off the lean
+# default build.
 query = ["validate", "dep:sparq-engine"]
+# OPT-IN (default-OFF). Adds the optional RDFS/OWL-RL closure step the design record
+# (§3.1) calls for before querying — materialise the `pkg:dependsOn owl:inverseOf
+# pkg:blockedBy` and `pkg:couldBeMergedWith` symmetry so a query over the inverse /
+# symmetric direction sees the entailed edges. Pulls in only `sparq-reason` (which
+# itself depends solely on `sparq-core`, already in the `query` build), so it stays
+# light. `close` implies `query`. [OPUS-4.8] sq-2m6zm.3
+close = ["query", "dep:sparq-reason"]
 
 [dependencies]
 # Engine graph type (only behind `validate`). default-features=false keeps it lean.
@@ -43,6 +52,19 @@ sparq-core = { path = "../sparq-core", default-features = false, optional = true
 sparq-shacl = { path = "../sparq-shacl", default-features = false, optional = true }
 # The SPARQL query/update engine (only behind `query`, for the example-lookup proof).
 sparq-engine = { path = "../sparq-engine", default-features = false, optional = true }
+# Forward-chaining RDFS/OWL-RL closure (only behind `close`). Depends solely on
+# sparq-core (already in the `query` build), so it adds no new third-party weight.
+sparq-reason = { path = "../sparq-reason", default-features = false, optional = true }
 # Turtle parser + term model (only behind `validate`, to build the data graph).
 oxttl = { workspace = true, optional = true }
 oxrdf = { workspace = true, optional = true }
+
+# The `pkg-query` helper binary (sq-2m6zm.3): one command to introspect → ground →
+# ask over the ingested PKG. It needs the `query` module (engine), so it is only
+# built when the default-OFF `query` feature is on — `required-features` keeps the
+# default `cargo build` lean (pure data + constants crate) and excludes the binary.
+# [OPUS-4.8]
+[[bin]]
+name = "pkg-query"
+path = "src/bin/pkg_query.rs"
+required-features = ["query"]

--- a/crates/sparq-kb/README.md
+++ b/crates/sparq-kb/README.md
@@ -90,8 +90,10 @@ the §4.1 ready-frontier — returning the minimal triples computed by the engin
 - The precedent it follows: `crates/sparq-trust/ontologies/zkp-sparql/` and
   `crates/sparq-trust/src/vocab.rs` (the ship-an-ontology + Rust-constants pattern).
 - Epic `sq-2m6zm`: the ontology/shapes are `sq-2m6zm.1`; the ingestion PoC above is
-  `sq-2m6zm.2`. Next: the query-the-PKG skill (`sq-2m6zm.3`) + the token-A/B harness
-  (`sq-2m6zm.4`).
+  `sq-2m6zm.2`; the **query-the-PKG** helper + skill is `sq-2m6zm.3` —
+  `cargo run -p sparq-kb --features query --bin pkg-query -- --list` runs the
+  introspect→ground→ask canned queries (`.claude/skills/query-pkg/SKILL.md`). Next:
+  the token-A/B harness (`sq-2m6zm.4`).
 
 ## License
 

--- a/crates/sparq-kb/src/bin/pkg_query.rs
+++ b/crates/sparq-kb/src/bin/pkg_query.rs
@@ -1,0 +1,221 @@
+//! `pkg-query` — one command to **introspect → ground → ask** over the ingested PKG.
+//!
+//! [OPUS-4.8] sq-2m6zm.3 (epic sq-2m6zm); design record
+//! `research/dogfooding-sparq-knowledge-graph.md` §6 (PR #1063). 🤖 SPARQ agent —
+//! dogfooding sparq as a project knowledge graph. Written while Fable unavailable; flag
+//! for re-review when Fable returns.
+//!
+//! Loads the PKG ontology (`pkg.ttl`) + the ingested instances (`pkg-instances.ttl`)
+//! into a sparq store and runs either a **named canned query** (`--query <name>`) or a
+//! **raw SPARQL string** (`--sparql '<select …>'`), printing the engine's exact result
+//! rows. The point of the tool is to let an agent pay tokens proportional to the
+//! *answer*, not to the source document. Whether that actually saves tokens is
+//! **measured by sq-2m6zm.4**, not claimed here.
+//!
+//! ## Usage
+//!
+//! ```text
+//! # list the canned introspect/ground queries:
+//! cargo run -p sparq-kb --features query --bin pkg-query -- --list
+//!
+//! # INTROSPECT — what classes/properties can I ask about?
+//! cargo run -p sparq-kb --features query --bin pkg-query -- --query schema-classes
+//!
+//! # GROUND+ASK — a canned query (some take an argument):
+//! cargo run -p sparq-kb --features query --bin pkg-query -- \
+//!     --query findings-about --arg https://sparq.dev/ns/pkg/kb#topic-merge-discipline
+//!
+//! # ASK — a raw SPARQL SELECT:
+//! cargo run -p sparq-kb --features query --bin pkg-query -- \
+//!     --sparql 'PREFIX pkg: <https://sparq.dev/ns/pkg#> SELECT (COUNT(*) AS ?n) WHERE { ?s a pkg:Task }'
+//!
+//! # optionally materialise the RDFS/OWL-RL closure first (needs --features close):
+//! cargo run -p sparq-kb --features close --bin pkg-query -- --close owl-rl --query task-blocks --arg sq-8thu
+//! ```
+
+use oxrdf::Term;
+use sparq_engine::QueryResult;
+use sparq_kb::query::{ask_pkg, canned, load_pkg};
+
+fn usage() -> &'static str {
+    "\
+pkg-query — introspect → ground → ask over the ingested PKG (sq-2m6zm.3)
+
+USAGE:
+  pkg-query --list
+  pkg-query --query <name> [--arg <value>] [--close rdfs|owl-rl] [--sparql-only]
+  pkg-query --sparql '<SPARQL SELECT/ASK>' [--close rdfs|owl-rl]
+
+OPTIONS:
+  --list             list the canned introspect/ground queries and exit
+  --query <name>     run a canned query by name (see --list)
+  --arg <value>      argument for a parameterised canned query ({ARG} substitution)
+  --sparql <query>   run a raw SPARQL SELECT/ASK string
+  --close <profile>  materialise RDFS or OWL-RL closure first (needs --features close)
+  --sparql-only      print the executed SPARQL but do not run it (for verification)
+  -h, --help         show this help
+"
+}
+
+fn main() -> std::process::ExitCode {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    match run(&args) {
+        Ok(()) => std::process::ExitCode::SUCCESS,
+        Err(msg) => {
+            eprintln!("pkg-query: {msg}\n\n{}", usage());
+            std::process::ExitCode::FAILURE
+        }
+    }
+}
+
+/// Consume the value following a flag at `args[*i]`, advancing `i` past it.
+fn next<'a>(args: &'a [String], i: &mut usize, flag: &str) -> Result<&'a str, String> {
+    *i += 1;
+    args.get(*i)
+        .map(String::as_str)
+        .ok_or_else(|| format!("{flag} needs a value"))
+}
+
+fn run(args: &[String]) -> Result<(), String> {
+    let mut query_name: Option<&str> = None;
+    let mut raw_sparql: Option<&str> = None;
+    let mut arg: Option<&str> = None;
+    let mut close: Option<&str> = None;
+    let mut sparql_only = false;
+
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-h" | "--help" => {
+                print!("{}", usage());
+                return Ok(());
+            }
+            "--list" => {
+                list_canned();
+                return Ok(());
+            }
+            "--query" => {
+                query_name = Some(next(args, &mut i, "--query")?);
+            }
+            "--sparql" => {
+                raw_sparql = Some(next(args, &mut i, "--sparql")?);
+            }
+            "--arg" => {
+                arg = Some(next(args, &mut i, "--arg")?);
+            }
+            "--close" => {
+                close = Some(next(args, &mut i, "--close")?);
+            }
+            "--sparql-only" => sparql_only = true,
+            other => return Err(format!("unknown argument `{other}`")),
+        }
+        i += 1;
+    }
+
+    // Resolve the SPARQL to run.
+    let sparql: String = match (query_name, raw_sparql) {
+        (Some(_), Some(_)) => return Err("pass either --query or --sparql, not both".into()),
+        (None, None) => {
+            return Err("nothing to run — pass --query <name>, --sparql '<…>' or --list".into())
+        }
+        (Some(name), None) => {
+            let q = canned::by_name(name)
+                .ok_or_else(|| format!("no canned query named `{name}` (try --list)"))?;
+            q.render(arg)
+        }
+        (None, Some(s)) => s.to_string(),
+    };
+
+    // Surface the executed SPARQL (the design's "surface the executed SPARQL" rule).
+    eprintln!(
+        "--- executed SPARQL ---\n{}\n-----------------------",
+        sparql.trim()
+    );
+    if sparql_only {
+        return Ok(());
+    }
+
+    // Load the store (optionally closed), then run.
+    let result = run_query(&sparql, close)?;
+    print_table(&result);
+    eprintln!("\n{} row(s).", result.rows.len());
+    Ok(())
+}
+
+/// Run `sparql` over the PKG, optionally under an RDFS/OWL-RL closure. The closure path
+/// is only available when the crate is built with `--features close`.
+fn run_query(sparql: &str, close: Option<&str>) -> Result<QueryResult, String> {
+    match close {
+        None => {
+            let g = load_pkg()?;
+            ask_pkg(&g, sparql)
+        }
+        Some(profile) => run_closed(sparql, profile),
+    }
+}
+
+#[cfg(feature = "close")]
+fn run_closed(sparql: &str, profile: &str) -> Result<QueryResult, String> {
+    use sparq_kb::query::close::{load_pkg_closed, Profile};
+    let profile = Profile::parse(profile)
+        .ok_or_else(|| format!("unknown closure profile `{profile}` (use rdfs|owl-rl)"))?;
+    let (g, entailed) = load_pkg_closed(profile)?;
+    eprintln!("--- closure: {entailed} entailed triple(s) materialised ---");
+    ask_pkg(&g, sparql)
+}
+
+#[cfg(not(feature = "close"))]
+fn run_closed(_sparql: &str, _profile: &str) -> Result<QueryResult, String> {
+    Err("--close needs the `close` feature: rebuild with --features close".into())
+}
+
+/// List every canned query (name + description + whether it takes an argument).
+fn list_canned() {
+    println!("Canned PKG queries (introspect → ground → ask):\n");
+    for q in canned::ALL {
+        let param = match q.param {
+            Some((label, default)) => format!("  [--arg <{label}>; default: {default}]"),
+            None => String::new(),
+        };
+        println!("  {:<24}{}", q.name, q.about);
+        if !param.is_empty() {
+            println!("  {:<24}{param}", "");
+        }
+    }
+    println!("\nRun one with:  pkg-query --query <name> [--arg <value>]");
+}
+
+/// Pretty-print a result set as a header + rows (short-IRI local names; truncated long
+/// literals) so the answer is human- and agent-readable.
+fn print_table(r: &QueryResult) {
+    let header: Vec<String> = r.vars.iter().map(|v| v.as_str().to_string()).collect();
+    println!("{}", header.join("  |  "));
+    println!("{}", "-".repeat(header.join("  |  ").len().max(3)));
+    for row in &r.rows {
+        let cells: Vec<String> = row.iter().map(cell).collect();
+        println!("{}", cells.join("  |  "));
+    }
+}
+
+/// Render one result cell: short local name for an IRI, truncated value for a literal.
+fn cell(c: &Option<Term>) -> String {
+    match c {
+        Some(Term::NamedNode(n)) => n
+            .as_str()
+            .rsplit(['#', '/'])
+            .next()
+            .unwrap_or("")
+            .to_string(),
+        Some(Term::Literal(l)) => {
+            let s = l.value();
+            if s.chars().count() > 110 {
+                let cut: String = s.chars().take(110).collect();
+                format!("{cut}…")
+            } else {
+                s.to_string()
+            }
+        }
+        Some(t) => t.to_string(),
+        None => "(unbound)".into(),
+    }
+}

--- a/crates/sparq-kb/src/lib.rs
+++ b/crates/sparq-kb/src/lib.rs
@@ -91,14 +91,24 @@ pub mod validate {
     }
 }
 
-/// SPARQL-query helpers over the ingested PKG graph. OPT-IN behind the default-OFF
-/// `query` cargo feature (pulls in the SPARQL engine), used for the sq-2m6zm.2
-/// example-lookup proof — the answers are computed deterministically by the engine,
-/// not generated.
+/// SPARQL-query helpers over the ingested PKG graph — the **introspect → ground →
+/// ask** mechanism of the dogfooding epic (sq-2m6zm.3). OPT-IN behind the default-OFF
+/// `query` cargo feature (pulls in the SPARQL engine); the optional [`close`](query::close)
+/// step is gated behind the further default-OFF `close` feature (pulls in
+/// `sparq-reason`). The answers are computed deterministically by the engine, not
+/// generated, so within the store the agent cannot fabricate a fact the data does not
+/// contain.
+///
+/// > **Honesty (per the design record §1).** This module is the *mechanism*. Whether
+/// > querying the PKG actually cuts an agent's token spend versus reading the source
+/// > document is **measured by sq-2m6zm.4**, not claimed here — this code carries no
+/// > token-saving number.
 #[cfg(feature = "query")]
 pub mod query {
     use sparq_core::Graph;
     use sparq_engine::{query, QueryResult};
+
+    pub mod canned;
 
     /// Load the PKG ontology + the ingested instances into one queryable [`Graph`].
     /// The `kb:` instances use absolute IRIs, so no base is needed.
@@ -110,5 +120,36 @@ pub mod query {
     /// Run a SPARQL `SELECT` over the ingested PKG graph and return the result set.
     pub fn ask_pkg(graph: &Graph, sparql: &str) -> Result<QueryResult, String> {
         query(graph, sparql)
+    }
+
+    /// The optional RDFS / OWL-RL **closure-before-query** step the design record
+    /// (§3.1: "always close first") calls for. Materialising the OWL-RL closure makes
+    /// the `pkg:dependsOn owl:inverseOf pkg:blockedBy` pair and the
+    /// `pkg:couldBeMergedWith` symmetry *entailed*, so a query written over the inverse
+    /// / symmetric direction sees edges that were only asserted the other way round.
+    /// OPT-IN behind the default-OFF `close` feature (pulls in `sparq-reason`).
+    ///
+    /// [OPUS-4.8] sq-2m6zm.3
+    #[cfg(feature = "close")]
+    pub mod close {
+        use sparq_core::Graph;
+        pub use sparq_reason::Profile;
+
+        /// Load the PKG (ontology + instances), materialise the `profile` closure
+        /// ([`Profile::Rdfs`] or [`Profile::OwlRl`]) in place, and return the closed
+        /// [`Graph`] together with the number of entailed triples added.
+        ///
+        /// The closure step never fails (materialisation only *adds* triples); the
+        /// only error path is the Turtle parse.
+        pub fn load_pkg_closed(profile: Profile) -> Result<(Graph, usize), String> {
+            let combined = format!(
+                "{}\n{}",
+                super::super::PKG_ONTOLOGY,
+                super::super::PKG_INSTANCES
+            );
+            let (mut dict, mut triples) = Graph::parse_to_triples(&combined, "turtle")?;
+            let entailed = sparq_reason::materialize(profile, &mut dict, &mut triples);
+            Ok((Graph::from_parts(dict, triples), entailed))
+        }
     }
 }

--- a/crates/sparq-kb/src/query/canned.rs
+++ b/crates/sparq-kb/src/query/canned.rs
@@ -1,0 +1,258 @@
+//! Canned SPARQL queries over the ingested PKG — the **introspect → ground → ask**
+//! library used by the `pkg-query` helper binary (sq-2m6zm.3) and by the
+//! `query_canned` test.
+//!
+//! [OPUS-4.8] sq-2m6zm.3 (epic sq-2m6zm); design record
+//! `research/dogfooding-sparq-knowledge-graph.md` §4.1 / §6 (PR #1063). 🤖 SPARQ agent
+//! — dogfooding sparq as a project knowledge graph. Written while Fable unavailable;
+//! flag for re-review when Fable returns.
+//!
+//! Each query is one of the **§4.1-class, verified-expressible** SPARQL frontier
+//! queries (plain SELECT / `FILTER NOT EXISTS` / `GROUP BY` over the PKG terms). The
+//! §4.2/§4.3 N3 rules are explicitly Phase-2/3 and are NOT used here.
+//!
+//! **Honesty.** These return exactly the binding rows the data contains — an
+//! `answer`-sized result, not the source document. Whether that actually cuts an
+//! agent's tokens is **measured by sq-2m6zm.4**, not claimed here.
+
+/// A named, documented canned query. Queries whose `param` is `Some` accept one
+/// argument substituted for the literal `{ARG}` token in [`sparql`](CannedQuery::sparql).
+pub struct CannedQuery {
+    /// The CLI / lookup name (`--query <name>`).
+    pub name: &'static str,
+    /// One-line description of what the query answers.
+    pub about: &'static str,
+    /// The SPARQL text. If [`param`](CannedQuery::param) is `Some`, it contains the
+    /// `{ARG}` placeholder, replaced by the caller-supplied argument before execution.
+    pub sparql: &'static str,
+    /// `Some((label, default))` when the query is parameterised: the human label of the
+    /// argument and the default substituted when none is given.
+    pub param: Option<(&'static str, &'static str)>,
+}
+
+impl CannedQuery {
+    /// The query text with `{ARG}` substituted: `arg` when given, else the registered
+    /// default; for a non-parameterised query the text is returned unchanged.
+    pub fn render(&self, arg: Option<&str>) -> String {
+        match self.param {
+            Some((_, default)) => self.sparql.replace("{ARG}", arg.unwrap_or(default)),
+            None => self.sparql.to_string(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (a) INTROSPECT — the "schema" query: what classes + properties can I ask about?
+// ---------------------------------------------------------------------------
+
+/// INTROSPECT — list the PKG classes actually instantiated in the graph, each with a
+/// count, so the agent learns what it can ask about without scanning the data.
+pub const SCHEMA_CLASSES: CannedQuery = CannedQuery {
+    name: "schema-classes",
+    about: "INTROSPECT: the pkg: classes present in the graph + an instance count each",
+    sparql: r#"
+PREFIX pkg: <https://sparq.dev/ns/pkg#>
+SELECT ?class (COUNT(?s) AS ?instances) WHERE {
+  ?s a ?class .
+  FILTER(STRSTARTS(STR(?class), STR(pkg:)))
+} GROUP BY ?class ORDER BY DESC(?instances)"#,
+    param: None,
+};
+
+/// INTROSPECT — list the predicates actually used in the graph, each with a use count,
+/// so the agent learns the queryable property vocabulary (pkg: terms + the reused
+/// PROV-O / SKOS / DC / CiTO predicates).
+pub const SCHEMA_PROPERTIES: CannedQuery = CannedQuery {
+    name: "schema-properties",
+    about: "INTROSPECT: the predicates used in the graph + a use count each",
+    sparql: r#"
+SELECT ?p (COUNT(*) AS ?uses) WHERE { ?s ?p ?o }
+GROUP BY ?p ORDER BY DESC(?uses)"#,
+    param: None,
+};
+
+// ---------------------------------------------------------------------------
+// (b) GROUND — NL question → SPARQL over the introspected terms (worked templates)
+// ---------------------------------------------------------------------------
+
+/// GROUND — "what does the repo say about TOPIC?" The Findings about a topic, each with
+/// its label + source section anchor + confidence, ordered by confidence. `{ARG}` is the
+/// topic IRI (e.g. `https://sparq.dev/ns/pkg/kb#topic-zk-discipline`).
+pub const FINDINGS_ABOUT: CannedQuery = CannedQuery {
+    name: "findings-about",
+    about: "GROUND: Findings about a topic IRI (label + source section + confidence)",
+    sparql: r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?label ?section ?conf WHERE {
+  ?f a pkg:Finding ;
+     pkg:about <{ARG}> ;
+     rdfs:label ?label ;
+     dcterms:source ?section ;
+     pkg:confidence ?conf .
+} ORDER BY DESC(?conf)"#,
+    param: Some((
+        "topic IRI",
+        "https://sparq.dev/ns/pkg/kb#topic-zk-discipline",
+    )),
+};
+
+/// GROUND — "where was this decided / what is its provenance + confidence?" For every
+/// Finding: its label, the source it was derived from, its assurance basis, and its
+/// numeric confidence. The provenance + confidence are the citation half of the
+/// guardrail, queryable.
+pub const FINDING_PROVENANCE: CannedQuery = CannedQuery {
+    name: "finding-provenance",
+    about: "GROUND: provenance (source + assurance) + confidence of every Finding",
+    sparql: r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX prov:    <http://www.w3.org/ns/prov#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
+SELECT ?label ?source ?section ?assurance ?conf WHERE {
+  ?f a pkg:Finding ;
+     rdfs:label ?label ;
+     prov:wasDerivedFrom ?source ;
+     pkg:assurance ?assurance ;
+     pkg:confidence ?conf .
+  OPTIONAL { ?f dcterms:source ?section }
+} ORDER BY DESC(?conf)"#,
+    param: None,
+};
+
+/// GROUND — "which sources are still UNEXPLORED, so follow-up can be targeted?" Sources
+/// whose `pkg:exploredStatus` is anything other than `pkg:Explored`, ordered by
+/// follow-up priority. (Over the current Phase-1 ingest every source is `Explored`, so
+/// this returns zero rows — the honest "none outstanding" answer, computed by the engine
+/// rather than guessed.)
+pub const UNEXPLORED_SOURCES: CannedQuery = CannedQuery {
+    name: "unexplored-sources",
+    about: "GROUND: sources NOT yet pkg:Explored (the targeted-follow-up list)",
+    sparql: r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+SELECT ?source ?title ?status ?prio WHERE {
+  ?source a pkg:Source ;
+          dcterms:title ?title ;
+          pkg:exploredStatus ?status .
+  FILTER(?status != pkg:Explored)
+  OPTIONAL { ?source pkg:followUpPriority ?prio }
+} ORDER BY ?prio"#,
+    param: None,
+};
+
+/// GROUND — "what is the status / provenance of a source, by its explored-status?" The
+/// full source catalog with its explored-status, follow-up priority and confidence —
+/// the read-model of "what have I already looked at".
+pub const SOURCE_STATUS: CannedQuery = CannedQuery {
+    name: "source-status",
+    about: "GROUND: the source catalog with explored-status + follow-up priority + confidence",
+    sparql: r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+SELECT ?title ?status ?prio ?conf WHERE {
+  ?source a pkg:Source ;
+          dcterms:title ?title ;
+          pkg:exploredStatus ?status .
+  OPTIONAL { ?source pkg:followUpPriority ?prio }
+  OPTIONAL { ?source pkg:confidence ?conf }
+} ORDER BY ?prio DESC(?conf)"#,
+    param: None,
+};
+
+/// GROUND — "what does task `{ARG}` depend on, and what is the status of each
+/// dependency?" The dependency edges of a task (`pkg:dependsOn`), each dependency's
+/// title + status — answers "is X unblocked / what is blocking it". `{ARG}` is the bd id
+/// (e.g. `sq-0po6`). bd's dotted child ids are projected with `_` (e.g. `sq-toze.1` →
+/// `sq-toze_1`); pass the `dcterms:identifier` exactly as it appears in the data.
+pub const TASK_DEPENDS_ON: CannedQuery = CannedQuery {
+    name: "task-depends-on",
+    about: "GROUND: what a task (bd id) depends on, with each dependency's status",
+    sparql: r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+SELECT ?depId ?depTitle ?depStatus WHERE {
+  ?t a pkg:Task ; dcterms:identifier "{ARG}" ; pkg:dependsOn ?dep .
+  ?dep dcterms:identifier ?depId ; pkg:status ?depStatus .
+  OPTIONAL { ?dep dcterms:title ?depTitle }
+} ORDER BY ?depId"#,
+    param: Some(("bd task id", "sq-0po6")),
+};
+
+/// GROUND — "what is blocked-by task `{ARG}` (the downstream impact of finishing it)?"
+/// The tasks that wait on a given task — the inverse direction. Written over
+/// `pkg:dependsOn` (the §2.2 predicate; under OWL-RL closure this is equivalent to a
+/// `?downstream pkg:blockedBy {ARG}` query). `{ARG}` is the bd id.
+pub const TASK_BLOCKS: CannedQuery = CannedQuery {
+    name: "task-blocks",
+    about: "GROUND: the tasks that depend on (are blocked by) a given task (bd id)",
+    sparql: r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+SELECT ?downstreamId ?downstreamStatus ?downstreamTitle WHERE {
+  ?blocker a pkg:Task ; dcterms:identifier "{ARG}" .
+  ?downstream pkg:dependsOn ?blocker ;
+              dcterms:identifier ?downstreamId ;
+              pkg:status ?downstreamStatus .
+  OPTIONAL { ?downstream dcterms:title ?downstreamTitle }
+} ORDER BY ?downstreamId"#,
+    param: Some(("bd task id", "sq-8thu")),
+};
+
+/// GROUND — "what are the high-follow-up-priority sources to read next?" The source
+/// catalog ordered by `pkg:followUpPriority` ascending (lower = sooner) — the
+/// targeted-reading queue, independent of explored-status.
+pub const HIGH_FOLLOWUP_PRIORITY: CannedQuery = CannedQuery {
+    name: "high-followup-priority",
+    about: "GROUND: sources ordered by follow-up priority (lower = read sooner)",
+    sparql: r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+SELECT ?title ?prio ?status WHERE {
+  ?source a pkg:Source ;
+          dcterms:title ?title ;
+          pkg:followUpPriority ?prio ;
+          pkg:exploredStatus ?status .
+} ORDER BY ?prio"#,
+    param: None,
+};
+
+/// GROUND — the §4.1 ready-frontier (dependency half, verified-expressible TODAY): a
+/// COUNT of open/in-progress tasks with no OPEN dependency, not human-gated, not an
+/// umbrella. Proves the bd → Task projection is queryable as a read-model.
+pub const READY_FRONTIER: CannedQuery = CannedQuery {
+    name: "ready-frontier",
+    about: "GROUND: §4.1 ready-frontier count (open, no open dep, not gated, not umbrella)",
+    sparql: r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+SELECT (COUNT(DISTINCT ?t) AS ?ready) WHERE {
+  ?t a pkg:Task ; pkg:status ?s ; pkg:priority ?prio .
+  FILTER(?s IN (pkg:Open, pkg:InProgress))
+  FILTER NOT EXISTS { ?t pkg:dependsOn ?b . ?b pkg:status ?bs . FILTER(?bs != pkg:Closed) }
+  FILTER NOT EXISTS { ?t pkg:label ?l . FILTER(STRSTARTS(STR(?l), "needs:")) }
+  FILTER NOT EXISTS { ?child dcterms:isPartOf ?t }
+}"#,
+    param: None,
+};
+
+/// Every canned query, in INTROSPECT → GROUND order — the registry the binary lists and
+/// looks up by name.
+pub const ALL: &[&CannedQuery] = &[
+    &SCHEMA_CLASSES,
+    &SCHEMA_PROPERTIES,
+    &FINDINGS_ABOUT,
+    &FINDING_PROVENANCE,
+    &UNEXPLORED_SOURCES,
+    &SOURCE_STATUS,
+    &TASK_DEPENDS_ON,
+    &TASK_BLOCKS,
+    &HIGH_FOLLOWUP_PRIORITY,
+    &READY_FRONTIER,
+];
+
+/// Look up a canned query by its `--query <name>` name.
+pub fn by_name(name: &str) -> Option<&'static CannedQuery> {
+    ALL.iter().copied().find(|q| q.name == name)
+}

--- a/crates/sparq-kb/tests/dogfood_shacl.rs
+++ b/crates/sparq-kb/tests/dogfood_shacl.rs
@@ -37,7 +37,10 @@ fn ontology_and_shapes_parse_and_load() {
     // Both .ttl files must parse (load in sparq) — the first gate.
     let report = validate_instances(&[PKG_EXAMPLE]).expect("ontology + shapes + example load");
     // The report rendering is captured into the PR description as proof the guardrails fire.
-    eprintln!("=== sparq-shacl PKG guardrail report ===\n{}", report.to_text());
+    eprintln!(
+        "=== sparq-shacl PKG guardrail report ===\n{}",
+        report.to_text()
+    );
 }
 
 #[test]
@@ -52,12 +55,12 @@ fn valid_nodes_pass_and_invalid_nodes_are_reported() {
 
     // --- VALID nodes must NOT be reported -----------------------------------
     for ok in [
-        "find-cs-dual-use",      // sourced + confident + assured + non-filler
-        "find-kge-neutral",      // sourced refuting-edge finding
+        "find-cs-dual-use",           // sourced + confident + assured + non-filler
+        "find-kge-neutral",           // sourced refuting-edge finding
         "src-neumann-moerkotte-2011", // explored-status + title
         "tech-characteristic-sets",   // supersedes an existing Technique
-        "task-sq-2m6zm",         // open epic, sound dep edge
-        "task-sq-2m6zm-1",       // in-progress, bounded priority
+        "task-sq-2m6zm",              // open epic, sound dep edge
+        "task-sq-2m6zm-1",            // in-progress, bounded priority
     ] {
         assert!(
             !reported(&report, ok),

--- a/crates/sparq-kb/tests/ingest_query.rs
+++ b/crates/sparq-kb/tests/ingest_query.rs
@@ -11,8 +11,8 @@
 #![cfg(feature = "query")]
 
 use oxrdf::Term;
-use sparq_kb::query::{ask_pkg, load_pkg};
 use sparq_engine::QueryResult;
+use sparq_kb::query::{ask_pkg, load_pkg};
 
 /// Pretty-print a result set so the proof appears in the PR description.
 fn dump(label: &str, q: &str, r: &QueryResult) {
@@ -21,10 +21,19 @@ fn dump(label: &str, q: &str, r: &QueryResult) {
         let cells: Vec<String> = row
             .iter()
             .map(|c| match c {
-                Some(Term::NamedNode(n)) => n.as_str().rsplit(['#', '/']).next().unwrap_or("").to_string(),
+                Some(Term::NamedNode(n)) => n
+                    .as_str()
+                    .rsplit(['#', '/'])
+                    .next()
+                    .unwrap_or("")
+                    .to_string(),
                 Some(Term::Literal(l)) => {
                     let s = l.value();
-                    if s.len() > 110 { format!("{}…", &s[..110]) } else { s.to_string() }
+                    if s.len() > 110 {
+                        format!("{}…", &s[..110])
+                    } else {
+                        s.to_string()
+                    }
                 }
                 Some(t) => t.to_string(),
                 None => "(unbound)".into(),
@@ -73,17 +82,23 @@ SELECT ?label ?section ?conf WHERE {
         "Q1 must surface the ci-summary gate; got {labels:?}"
     );
     assert!(
-        labels.iter().any(|l| l.contains("circuit") || l.contains("gate-count")),
+        labels
+            .iter()
+            .any(|l| l.contains("circuit") || l.contains("gate-count")),
         "Q1 must surface the ZK-circuit gate; got {labels:?}"
     );
     assert!(
-        labels.iter().any(|l| l.contains("privacy") || l.contains("soundness")),
+        labels
+            .iter()
+            .any(|l| l.contains("privacy") || l.contains("soundness")),
         "Q1 must surface the privacy-claims gate; got {labels:?}"
     );
     // Every returned Finding carries a section anchor (its provenance) — that is the
     // citation half of the guardrail, queryable.
     assert!(
-        r.rows.iter().all(|row| matches!(&row[1], Some(Term::Literal(_)))),
+        r.rows
+            .iter()
+            .all(|row| matches!(&row[1], Some(Term::Literal(_)))),
         "every Q1 Finding must carry its dcterms:source section anchor"
     );
 }
@@ -117,7 +132,10 @@ SELECT ?label ?section ?conf WHERE {
             _ => None,
         })
         .collect();
-    assert!(labels.len() >= 5, "Q2 should surface the sub-agent rule set; got {labels:?}");
+    assert!(
+        labels.len() >= 5,
+        "Q2 should surface the sub-agent rule set; got {labels:?}"
+    );
     assert!(
         labels.iter().any(|l| l.contains("shared contract")),
         "Q2 must surface the shared contract; got {labels:?}"
@@ -152,10 +170,18 @@ SELECT (COUNT(DISTINCT ?t) AS ?ready) WHERE {
     let r = ask_pkg(&g, q).expect("frontier query runs");
     dump("Q3: §4.1 ready-frontier (dependency half)", q, &r);
     // The frontier is non-empty over a real backlog of 1255 tasks.
-    let n = match &r.rows.first().and_then(|row| row.first()).and_then(|c| c.clone()) {
+    let n = match &r
+        .rows
+        .first()
+        .and_then(|row| row.first())
+        .and_then(|c| c.clone())
+    {
         Some(Term::Literal(l)) => l.value().parse::<i64>().unwrap_or(0),
         _ => 0,
     };
-    assert!(n > 0, "the ready-frontier must be non-empty over the bd backlog; got {n}");
+    assert!(
+        n > 0,
+        "the ready-frontier must be non-empty over the bd backlog; got {n}"
+    );
     eprintln!("\nQ3 ready-frontier count = {n}");
 }

--- a/crates/sparq-kb/tests/query_canned.rs
+++ b/crates/sparq-kb/tests/query_canned.rs
@@ -1,0 +1,237 @@
+//! The canned-query helper must keep loading the PKG and returning the expected rows —
+//! a rot-guard for the `pkg-query` skill (sq-2m6zm.3). The answers are computed by
+//! sparq's own SPARQL engine over the ingested graph; the engine bounds the result set,
+//! so within the store the answer cannot be fabricated.
+//!
+//! [OPUS-4.8] sq-2m6zm.3 (epic sq-2m6zm). 🤖 SPARQ agent — query-the-PKG skill PoC.
+//!
+//! Run: `cargo test -p sparq-kb --features query --test query_canned -- --nocapture`
+//! (and, to exercise the optional closure path:
+//!  `cargo test -p sparq-kb --features close --test query_canned -- --nocapture`).
+#![cfg(feature = "query")]
+
+use oxrdf::Term;
+use sparq_engine::QueryResult;
+use sparq_kb::query::canned::{self, CannedQuery};
+use sparq_kb::query::{ask_pkg, load_pkg};
+
+/// Render + run a canned query (with an optional argument) over the loaded PKG.
+fn run(q: &CannedQuery, arg: Option<&str>) -> QueryResult {
+    let g = load_pkg().expect("PKG loads");
+    let sparql = q.render(arg);
+    ask_pkg(&g, &sparql).unwrap_or_else(|e| panic!("`{}` query runs: {e}", q.name))
+}
+
+/// The literal string value of cell `col` in `row`, lower-cased (empty if unbound/IRI).
+fn lit(r: &QueryResult, row: usize, col: usize) -> String {
+    match r.rows.get(row).and_then(|x| x.get(col)) {
+        Some(Some(Term::Literal(l))) => l.value().to_lowercase(),
+        _ => String::new(),
+    }
+}
+
+/// The local name of an IRI cell, or the literal value, lower-cased.
+fn term_str(t: &Option<Term>) -> String {
+    match t {
+        Some(Term::NamedNode(n)) => n
+            .as_str()
+            .rsplit(['#', '/'])
+            .next()
+            .unwrap_or("")
+            .to_lowercase(),
+        Some(Term::Literal(l)) => l.value().to_lowercase(),
+        _ => String::new(),
+    }
+}
+
+#[test]
+fn registry_is_complete_and_named() {
+    // Every canned query is reachable by name, and the parameterised ones have a
+    // working default that round-trips through `render`.
+    assert!(
+        !canned::ALL.is_empty(),
+        "the canned registry must not be empty"
+    );
+    for q in canned::ALL {
+        assert_eq!(canned::by_name(q.name).map(|x| x.name), Some(q.name));
+        let rendered = q.render(None);
+        assert!(
+            !rendered.contains("{ARG}"),
+            "`{}` still has an unsubstituted {{ARG}} after rendering its default",
+            q.name
+        );
+    }
+    // The §6 worked queries the skill documents must all be present.
+    for name in [
+        "schema-classes",
+        "schema-properties",
+        "findings-about",
+        "finding-provenance",
+        "unexplored-sources",
+        "task-depends-on",
+        "task-blocks",
+        "high-followup-priority",
+        "ready-frontier",
+    ] {
+        assert!(
+            canned::by_name(name).is_some(),
+            "canned query `{name}` is missing"
+        );
+    }
+}
+
+#[test]
+fn introspect_schema_classes() {
+    // The schema card must surface the PKG classes actually present, with Task the
+    // largest (the bd projection dominates the ingest).
+    let r = run(&canned::SCHEMA_CLASSES, None);
+    let classes: Vec<String> = r.rows.iter().map(|row| term_str(&row[0])).collect();
+    for expect in ["task", "finding", "source", "technique"] {
+        assert!(
+            classes.contains(&expect.to_string()),
+            "schema card missing pkg:{expect}; got {classes:?}"
+        );
+    }
+    assert_eq!(
+        classes.first().map(String::as_str),
+        Some("task"),
+        "Task must be the largest class"
+    );
+}
+
+#[test]
+fn ground_findings_about_merge_discipline() {
+    // The merge-discipline topic must surface the ci-summary base gate, each with a
+    // section anchor (provenance) and a confidence.
+    let topic = "https://sparq.dev/ns/pkg/kb#topic-merge-discipline";
+    let r = run(&canned::FINDINGS_ABOUT, Some(topic));
+    assert!(
+        !r.rows.is_empty(),
+        "findings-about returned no rows for the merge-discipline topic"
+    );
+    let labels: Vec<String> = (0..r.rows.len()).map(|i| lit(&r, i, 0)).collect();
+    assert!(
+        labels.iter().any(|l| l.contains("ci-summary")),
+        "merge-discipline findings must surface the ci-summary gate; got {labels:?}"
+    );
+    // Every row carries a source section anchor (col 1) — the queryable citation.
+    assert!(
+        r.rows
+            .iter()
+            .all(|row| matches!(&row[1], Some(Term::Literal(_)))),
+        "every finding must carry its dcterms:source section anchor"
+    );
+}
+
+#[test]
+fn ground_finding_provenance_is_sourced_and_confident() {
+    // Every Finding has a derived-from source, an assurance basis, and a confidence.
+    let r = run(&canned::FINDING_PROVENANCE, None);
+    assert!(
+        r.rows.len() >= 6,
+        "expected the AGENTS.md finding slice; got {} rows",
+        r.rows.len()
+    );
+    for (i, row) in r.rows.iter().enumerate() {
+        assert!(
+            matches!(&row[1], Some(Term::NamedNode(_))),
+            "row {i}: provenance source must be an IRI"
+        );
+        let assurance = term_str(&row[3]);
+        assert!(
+            matches!(assurance.as_str(), "proven" | "claimed" | "conjectured"),
+            "row {i}: assurance must be a secx: basis; got `{assurance}`"
+        );
+        let conf = lit(&r, i, 4).parse::<f64>().unwrap_or(-1.0);
+        assert!(
+            (0.0..=1.0).contains(&conf),
+            "row {i}: confidence must be in 0..1; got {conf}"
+        );
+    }
+}
+
+#[test]
+fn ground_unexplored_sources_is_the_honest_none_answer() {
+    // Over the Phase-1 ingest every source is pkg:Explored, so the targeted-follow-up
+    // list is EMPTY — the honest "none outstanding" answer, computed by the engine. This
+    // is the negative/out-of-KG-existence stratum the design wants represented.
+    let r = run(&canned::UNEXPLORED_SOURCES, None);
+    assert!(
+        r.rows.is_empty(),
+        "every ingested source is pkg:Explored, so unexplored-sources must be empty; got {} rows",
+        r.rows.len()
+    );
+}
+
+#[test]
+fn ground_task_blocks_returns_downstream_dependents() {
+    // sq-8thu is the most-depended-on blocker in the ingest; finishing it unblocks many.
+    let r = run(&canned::TASK_BLOCKS, Some("sq-8thu"));
+    assert!(
+        r.rows.len() >= 10,
+        "sq-8thu should have many downstream dependents; got {} rows",
+        r.rows.len()
+    );
+}
+
+#[test]
+fn ground_task_depends_on_returns_dependencies() {
+    // The default arg (sq-0po6) depends on two tasks; each comes back with a status.
+    let r = run(&canned::TASK_DEPENDS_ON, None);
+    assert!(
+        !r.rows.is_empty(),
+        "task-depends-on default (sq-0po6) should have dependencies"
+    );
+    let dep_ids: Vec<String> = r.rows.iter().map(|row| term_str(&row[0])).collect();
+    assert!(
+        dep_ids.iter().any(|d| d == "sq-8thu"),
+        "sq-0po6 must depend on sq-8thu; got {dep_ids:?}"
+    );
+}
+
+#[test]
+fn ground_ready_frontier_is_non_empty() {
+    // The §4.1 ready-frontier (dependency half) over the real backlog is non-empty.
+    let r = run(&canned::READY_FRONTIER, None);
+    let n = match r.rows.first().and_then(|row| row.first()) {
+        Some(Some(Term::Literal(l))) => l.value().parse::<i64>().unwrap_or(0),
+        _ => 0,
+    };
+    assert!(
+        n > 0,
+        "the §4.1 ready-frontier must be non-empty over the bd backlog; got {n}"
+    );
+}
+
+/// The optional closure step must materialise the `pkg:dependsOn owl:inverseOf
+/// pkg:blockedBy` pair, so a `pkg:blockedBy` query (the inverse direction, never
+/// asserted in the data) returns the same downstream set as the `pkg:dependsOn` query.
+/// Only built with `--features close`.
+#[cfg(feature = "close")]
+#[test]
+fn closure_materialises_the_blockedby_inverse() {
+    use sparq_kb::query::close::{load_pkg_closed, Profile};
+
+    let (g, entailed) = load_pkg_closed(Profile::OwlRl).expect("closed PKG loads");
+    assert!(entailed > 0, "OWL-RL closure must add entailed triples");
+
+    // The inverse direction, asked only via pkg:blockedBy (never asserted as such):
+    let inverse = r#"
+PREFIX pkg:     <https://sparq.dev/ns/pkg#>
+PREFIX dcterms: <http://purl.org/dc/terms/>
+SELECT (COUNT(*) AS ?n) WHERE {
+  ?blocker dcterms:identifier "sq-8thu" . ?blocker pkg:blockedBy ?d
+}"#;
+    let r = ask_pkg(&g, inverse).expect("inverse query runs");
+    let n = match r.rows.first().and_then(|row| row.first()) {
+        Some(Some(Term::Literal(l))) => l.value().parse::<i64>().unwrap_or(0),
+        _ => 0,
+    };
+    // Must match the asserted forward (dependsOn) count for the same blocker.
+    let forward = run(&canned::TASK_BLOCKS, Some("sq-8thu")).rows.len() as i64;
+    assert_eq!(
+        n, forward,
+        "blockedBy (entailed inverse) must match dependsOn (asserted) count"
+    );
+    assert!(n > 0, "the entailed inverse must be non-empty for sq-8thu");
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** [OPUS-4.8] — dogfooding sparq as a project knowledge graph. Written while Fable unavailable; flag for re-review when Fable returns. (auto-merge intentionally OFF.)

Implements bead **sq-2m6zm.3** — the **query-the-PKG skill PoC**, the core token-saving mechanism of the dogfooding epic **sq-2m6zm**. Design record: `research/dogfooding-sparq-knowledge-graph.md` (§4.1 verified-expressible frontier queries, §6 worked questions).

## What

Let an agent ANSWER a *"what does the repo say about X / where was Y decided / status+provenance of Z / which sources are unexplored / what depends on bead W"* question by running a SPARQL query over the ingested PKG (`pkg.ttl` + `pkg-instances.ttl`) instead of reading whole documents — paying tokens proportional to the **answer**, not the corpus.

## Deliverables

1. **Query helper** — `pkg-query` binary (`crates/sparq-kb/src/bin/pkg_query.rs`, `--bin pkg-query`, `required-features = ["query"]`). Loads the ontology + ingested instances into a sparq store, runs a **named canned query** or a **raw SPARQL string**, surfaces the executed SPARQL (always) and an answer-sized result table. Opt-in / feature-gated per AGENTS.md — the default `cargo build` stays a pure data crate. An optional default-OFF **`close`** feature (pulls in only `sparq-reason`) adds the RDFS/OWL-RL closure-before-query the design calls for, materialising `pkg:dependsOn owl:inverseOf pkg:blockedBy` so an inverse-direction query is entailed-equivalent.
2. **Canned queries** (`src/query/canned.rs`, shared by the binary + the test) — 2 INTROSPECT schema queries + 8 §4.1-class GROUND templates (findings-about, finding-provenance, unexplored-sources, source-status, task-depends-on, task-blocks, high-followup-priority, ready-frontier).
3. **Skill** `.claude/skills/query-pkg/SKILL.md` — documents **introspect → ground → ask** with full command invocation in every example, the query→answer for each template, and three real end-to-end examples (merge-discipline findings; the honest *empty* unexplored-sources answer; task-blocks over the real backlog).
4. **Rot-guard test** `tests/query_canned.rs` — loads the PKG and asserts each canned query returns the expected rows (9 tests with `close`, 8 without).

## Honesty

The skill + module state explicitly: **this is the MECHANISM; whether it actually cuts agent tokens is MEASURED by sq-2m6zm.4, not claimed here.** No unmeasured token-saving number anywhere. `unexplored-sources` returns 0 rows (every ingested source is `pkg:Explored`) — the honest engine-computed "none outstanding" answer.

## Three real end-to-end answers

```text
$ pkg-query --query findings-about --arg …#topic-merge-discipline
A PR merges only when ci-summary is green and every review thread is resolved | AGENTS.md#…ci-summary-gate | 0.98
A verified-clean non-perf PR auto-arms; never arm auto-merge on a stacked PR… | AGENTS.md#…ci-summary-gate | 0.93

$ pkg-query --query unexplored-sources
0 row(s).   # honest: every source is pkg:Explored

$ pkg-query --query task-blocks --arg sq-8thu
sq-0po6 | Closed | page: /surface/inference (tier-b live)
…                  (22 downstream dependents)
```

## Gate

clippy `--all-targets -D warnings` clean in **default**, **`query`**, and **`--all-features`** states; `cargo fmt` clean; rustdoc clean; tests pass in both feature states; `check-readme-template.py`, `check-skill-frontmatter.py`, `check-no-perf-numbers.py`, `check-privacy-claims.sh`, and `gate-api-skill.py` all pass; workspace `cargo check` clean.

Closes sq-2m6zm.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)