### PR TITLE
ci(feature-matrix): gate sparq-kb validate/query feature tests (sq-u6nmt) [OPUS-4.8]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -377,6 +377,47 @@ jobs:
             crate: sparq-fedclient
             features: fedclient
             test: true
+          # [OPUS-4.8] sq-u6nmt: the sparq-kb Project-Knowledge-Graph dogfooding crate
+          # (added by PR #1069). The DEFAULT build is a pure data + Rust-vocab crate; its
+          # SHACL-dogfood + ingest suites are entirely behind default-OFF features:
+          #   • tests/dogfood_shacl.rs + tests/ingest_shacl.rs are `#![cfg(feature =
+          #     "validate")]` (load the PKG ontology/instances, run the SHACL shapes); and
+          #   • tests/ingest_query.rs is `#![cfg(feature = "query")]` (the SPARQL proof
+          #     over the ingested PKG graph).
+          # ci.yml's `cargo nextest archive --workspace --all-targets` passes NO
+          # `--features validate`/`query`, so it compiled all of those test bodies EMPTY and
+          # ran ZERO of them — the silent-skip gap this lane exists to close — and sparq-kb
+          # had NO leg here at all. TWO legs cover every suite + every documented opt-in
+          # state of the crate:
+          #   (1) `validate` runs dogfood_shacl + ingest_shacl (the suites gated on
+          #       `validate` but NOT `query`); and
+          #   (2) `query` IMPLIES `validate` (Cargo.toml: `query = ["validate", …]`) and is
+          #       the crate's MAXIMAL feature set, so this leg is equivalent to
+          #       `--all-features` for sparq-kb today: it runs ingest_query AND re-runs the
+          #       validate suites, and its `clippy --all-targets -D warnings` gates the full
+          #       feature surface. (The crate's `--all-features` clippy/build is ALSO already
+          #       covered workspace-wide by ci.yml's `cargo clippy --workspace --all-targets
+          #       --all-features` + `cargo doc --workspace --all-features`; what was missing
+          #       — and what these legs add — is the all-features TEST execution.)
+          # No `not(feature = …)` divergence in the crate, so two isolated legs (matching the
+          # per-feature convention above) suffice. Cheap: sparq-kb is tiny; `validate` pulls
+          # sparq-core + sparq-shacl (+ oxttl/oxrdf), `query` additionally sparq-engine, all
+          # already compiled by sibling legs / the warm cache. Verified locally on origin/main:
+          # `cargo test -p sparq-kb --features validate` runs 3 dogfood_shacl + 2 ingest_shacl
+          # (+1 vocab unit) tests, `--features query` adds the 3 ingest_query tests, and
+          # `clippy --all-targets -D warnings` is clean in every state.
+          # NOTE: the optional `close` feature (pulls sparq-reason) + the `query_canned`
+          # suite are NOT on main yet (they arrive with PR #1075, still open) — adding a
+          # `close` leg now would ENOENT (`does not have feature 'close'`), so it is
+          # deliberately omitted; extend with a `close` leg when #1075 lands.
+          - name: sparq-kb (validate)
+            crate: sparq-kb
+            features: validate
+            test: true
+          - name: sparq-kb (query, implies validate — maximal feature set)
+            crate: sparq-kb
+            features: query
+            test: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Rust (stable)


### PR DESCRIPTION
> 🤖 **SPARQ agent** (sparq-ci-infra, Opus 4.8). Account runs multiple agents — flagging the author.

Closes **sq-u6nmt**.

## Problem

PR #1069 added `crates/sparq-kb` (the Project-Knowledge-Graph dogfooding crate). Its SHACL-dogfood + ingest suites live entirely behind default-OFF cargo features:

- `tests/dogfood_shacl.rs` + `tests/ingest_shacl.rs` → `#![cfg(feature = "validate")]`
- `tests/ingest_query.rs` → `#![cfg(feature = "query")]`

`ci.yml`'s `cargo nextest archive --workspace --all-targets` passes **no** `--features validate`/`query`, so those test bodies compiled **empty** and **zero** of the suites ran. They were silently skipping and would rot — and `sparq-kb` had **no leg** in `feature-matrix.yml` at all. This is the same silent-skip class the feature-matrix lane exists to close.

## Fix

Two **gating** legs added to the `opt-in-features` matrix in `.github/workflows/feature-matrix.yml`:

| leg | exercises |
|---|---|
| `opt-in sparq-kb (validate)` | `dogfood_shacl` + `ingest_shacl` |
| `opt-in sparq-kb (query, implies validate — maximal feature set)` | `ingest_query` (+ re-runs the validate suites; `query = ["validate", …]`) |

Each leg runs **build → test → `clippy --all-targets -- -D warnings`** on the stable toolchain, reusing the lane's existing fetch/build retry + per-leg cache scaffolding.

`query` is the crate's **maximal** feature set, so the `query` leg is equivalent to `--all-features` for `sparq-kb` today. The crate's `--all-features` *clippy/build* is additionally already covered workspace-wide by `ci.yml`'s `cargo clippy --workspace --all-targets --all-features` + `cargo doc --workspace --all-features`; what these legs add is the all-features **test execution** that the archive lane was skipping.

## Gating

Both leg names are free of the words `advisory`/`informational`, so the single required `ci-summary / gate` aggregator auto-discovers `feature-matrix / opt-in sparq-kb (validate)` and `feature-matrix / opt-in sparq-kb (query, …)` as **REQUIRED** checks — a broken `sparq-kb` opt-in build/test/clippy now **blocks the merge**. No edit to `ci-summary.yml` (it polls by name). Confirmed against the aggregator's `\b(advisory|informational)\b` regex: both **GATE**.

## Verification (local, on origin/main)

Reproduced the exact step commands for both legs:

- `cargo build -p sparq-kb --features {validate,query}` → OK
- `cargo test -p sparq-kb --features validate` → 3 `dogfood_shacl` + 2 `ingest_shacl` (+1 vocab unit) pass
- `cargo test -p sparq-kb --features query` → adds the 3 `ingest_query` tests, all pass
- `cargo clippy -p sparq-kb --features {default,validate,query,--all-features} --all-targets -- -D warnings` → clean in every state
- `actionlint .github/workflows/feature-matrix.yml` → clean; YAML parses

## Honest notes

- The optional `close` feature (pulls `sparq-reason`) and the `query_canned` suite are **not on `main` yet** — they arrive with PR #1075, still open. Adding a `close` leg now would ENOENT (`sparq-kb does not have feature 'close'`) and exit-1 in CI, so it is deliberately omitted. A code comment marks where to extend the matrix once #1075 lands.
- Path-filter preserved: these legs sit under the existing `needs.changes`/`if: rust_changed` guard, so a doc-only PR still skips them (and the gate resolves on the `skipped` conclusion).

**Compliance gap closed:** removes a silent test-skip (the CDMC "code CI never compiles rots" finding, sq-kzfi class) for `sparq-kb`'s `validate`/`query` opt-in features.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>