### PR TITLE
fix(site,ci): resolve fzstd in the ESM bundle + run gui.yml on its real inputs [OPUS-4.8]

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -44,15 +44,27 @@ name: gui
 
 on:
   pull_request:
+    # [OPUS-4.8] The `site build + typecheck` job here consumes `site/` (its static export +
+    # the bundle-wasm-esm script) and `js/` (the @jeswr/sparq source it bundles), and resolves
+    # workspace deps from the root lockfile — so changes to ANY of those can break it. They were
+    # previously omitted, so a `site/`+lockfile regression (an unresolved `fzstd` in the ESM
+    # bundle) slipped onto `main` undetected and only surfaced on a PR whose `gate` re-scans the
+    # merge ref. List every input the jobs read.
     paths:
       - "gui/**"
       - "packages/sparq-client/**"
+      - "site/**"
+      - "js/**"
+      - "package-lock.json"
       - ".github/workflows/gui.yml"
   push:
     branches: [main]
     paths:
       - "gui/**"
       - "packages/sparq-client/**"
+      - "site/**"
+      - "js/**"
+      - "package-lock.json"
       - ".github/workflows/gui.yml"
 
 # Least-privilege default (Scorecard TokenPermissions): read-only; this lane never writes.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13808,6 +13808,7 @@
         "esbuild": "^0.25.12",
         "eslint": "^9.18.0",
         "eslint-config-next": "^15.5.19",
+        "fzstd": "^0.1.1",
         "tailwindcss": "^4.1.0",
         "tw-animate-css": "^1.4.0",
         "typescript": "^5.7.0"

--- a/site/package.json
+++ b/site/package.json
@@ -48,6 +48,7 @@
     "esbuild": "^0.25.12",
     "eslint": "^9.18.0",
     "eslint-config-next": "^15.5.19",
+    "fzstd": "^0.1.1",
     "tailwindcss": "^4.1.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.7.0"


### PR DESCRIPTION
> 🤖 SPARQ agent

## What

Declare `fzstd` as a `site` devDependency so the self-hosted ESM bundle build resolves it.

## Why (a main-side gate regression)

The **`site build + typecheck (consuming @sparq/client)`** gate (gui.yml) fails its static-export step with:

```
✘ [ERROR] Could not resolve "fzstd"
  ../js/src/decompress.ts:58:59: ERROR: Could not resolve "fzstd"
```

`site/scripts/bundle-wasm-esm.mjs` (sq-55w5a, #1056) esbuild-bundles `js/src/index.ts` and is explicitly designed to **inline** `fzstd` (~8 kB, pure JS) so the published `wasm/sparq.js` artifact carries no CDN runtime dependency. But the gui.yml lane runs `npm install` only with `working-directory: packages/sparq-client` and `working-directory: site` — never from `js` or the repo root — so the `js` workspace member's `fzstd` dependency is never installed into a place esbuild can resolve from `js/src/decompress.ts`. The bundle then hard-fails at build time.

`fzstd` is the **site's** build-time (bundle) consumer here, so it is declared as a `site` devDependency. `npm install` from `site/` then hoists it to the root `node_modules`, where esbuild resolves and inlines it. The lockfile already carries the `node_modules/fzstd` resolution (pulled in by `js`); this PR only adds `site` as a declared consumer — a 2-line change.

## Verified locally

Built `js/src/index.ts` through the exact esbuild config the real script uses (browser/esm, glue externalised): bundle succeeds (~25 KB) and leaves **no** bare `import('fzstd')` — i.e. `fzstd` is inlined, the script's intended behaviour.

## Why it surfaced now

The lane last ran green on `main` at `fe93a625` (before the bundle script + lockfile changes landed). Every later `main` commit was path-filtered out of gui.yml, so the regression only surfaced on a PR whose `gate` re-scans the merge ref (it is blocking PR #1048). This fix on `main` unblocks that PR (and any other open PR) once re-triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
