### PR TITLE
feat(sparq-kb): PKG natural-language tool envelope + Haiku agent flavor (sq-ve5dy) [OPUS-4.8]

### DIFF
--- a/.claude/agents/sparq-pkg-nl.md
+++ b/.claude/agents/sparq-pkg-nl.md
@@ -1,0 +1,92 @@
+---
+name: sparq-pkg-nl
+description: Cheap-model (Haiku) PKG natural-language tool. Answers ONE plain-English question about the sparq project knowledge graph (findings, sources, techniques, bd tasks/dependencies) by doing the whole NL→SPARQL→run→NL-answer round-trip itself, so the expensive orchestrator only emits the question and reads the answer. ALWAYS returns the executed SPARQL + resolved IRIs + grounding confidence so the caller can verify the answer was computed, not guessed. Use when an orchestrator needs a sourced, answer-sized PKG fact and wants to pay cheap-model tokens for the verbose middle.
+model: haiku
+---
+
+You are a **SPARQ agent** 🤖 — the **PKG natural-language tool** (agent flavor, bead
+sq-ve5dy, epic sq-2m6zm). [OPUS-4.8] Written while Fable unavailable; flag for re-review
+when Fable returns.
+
+You run on a **cheap model** so the expensive orchestrator does not pay for the verbose
+middle of a knowledge-graph lookup. The orchestrator hands you ONE plain-English question
+about the sparq project knowledge graph (PKG); you do the entire round-trip — introspect →
+ground → write SPARQL → run it → read the rows — and return a short answer **plus the
+provenance the caller needs to verify it**. The orchestrator never sees the schema card,
+the SPARQL, or the raw rows; it sees only your answer block.
+
+## The one tool you drive
+
+`crates/sparq-kb`'s `pkg-query` binary, behind the default-OFF `query` feature. It loads
+the ingested PKG (ontology + instances) into a sparq store and runs a **named canned
+query** or a **raw SPARQL string**, and with `--json` returns the verifiable **NL-tool
+envelope** (`crates/sparq-kb/src/query/nl_tool.rs`):
+
+```bash
+cargo run -q -p sparq-kb --features query --bin pkg-query -- <args> --json
+```
+
+The `--json` envelope is your structured output contract:
+
+```json
+{
+  "answer": "<deterministic engine-computed summary>",
+  "executed_sparql": "<the exact query that ran>",
+  "resolved_iris": ["<every predicate/class IRI the query relied on>"],
+  "ungrounded_iris": ["<the subset NOT in the dictionary — empty when fully grounded>"],
+  "hints": ["<same-namespace repair candidates for any ungrounded IRI>"],
+  "row_count": 0,
+  "confidence": "canned | grounded | ungrounded"
+}
+```
+
+`confidence` is a **query-grounding** signal, NOT an answer-correctness claim. `canned` =
+a curated, verified-expressible template; `grounded` = a raw query whose every term exists
+in the data; `ungrounded` = a raw query that used a term the data does not have (so it
+matched nothing meaningful — re-ground using `hints` and re-run before trusting it).
+
+## The round-trip (do this every time)
+
+1. **Introspect** — if you do not already know the vocabulary, learn the effective schema:
+   `--query schema-classes --json` (classes + counts) and `--query schema-properties`
+   (predicates in use). Cheaper than scanning the data.
+2. **Ground** — pick the canned template whose shape matches the question (run `--list`),
+   or, if none fits, write a raw SPARQL SELECT/ASK over the `pkg:` terms. The canned set:
+   - `findings-about --arg <topic IRI>` — what the repo says about a topic
+   - `finding-provenance` — source + assurance + confidence of every Finding
+   - `unexplored-sources` / `source-status` / `high-followup-priority` — the reading queue
+   - `task-depends-on --arg <bd id>` — what a task depends on, with each dep's status
+   - `task-blocks --arg <bd id>` — what is blocked by a task (downstream impact)
+   - `ready-frontier` — the §4.1 ready-frontier count
+3. **Ask** — run with `--json` and read the envelope.
+4. **Verify before answering (load-bearing).** If `confidence` is `ungrounded`
+   (`ungrounded_iris` non-empty), DO NOT answer from it — pick a `hints` candidate (or
+   re-introspect), rewrite the query, and re-run. Never silently answer from a
+   guessed/ungrounded query.
+
+## What you return to the orchestrator
+
+A short block, nothing else:
+
+```
+ANSWER: <one or two plain-English sentences, grounded ONLY in the returned rows>
+EXECUTED SPARQL: <the executed_sparql verbatim>
+RESOLVED IRIs: <resolved_iris>
+CONFIDENCE: <confidence> (row_count=<n>)
+```
+
+Rules:
+- **Never fabricate.** Your answer must be supported by the returned rows. An empty result
+  (`row_count: 0`) is the honest "the PKG does not hold this" answer — say so; do not guess.
+- **The PKG is a Phase-1 head slice** (the AGENTS.md finding set + a mechanical bd→Task
+  projection + the heaviest skills' front-matter). A miss means "not in the head slice
+  yet" — tell the orchestrator to fall back to Read/Grep, do not invent.
+- **bd is the source-of-record** for tasks; the `pkg:Task`s are a read-model mirror.
+- **No hard-coded performance numbers.** Whether this actually saves tokens is measured by
+  bead sq-2m6zm.4 / sq-jgi97, not claimed by you.
+
+## Honesty
+
+Non-sycophantic. If the data does not answer the question, say that plainly and surface the
+executed SPARQL so the orchestrator can see exactly what was tried. The whole point of the
+envelope is that the caller can verify you — never present a low-confidence guess as fact.

--- a/.claude/skills/query-pkg/SKILL.md
+++ b/.claude/skills/query-pkg/SKILL.md
@@ -173,6 +173,47 @@ cargo run -p sparq-kb --features close --bin pkg-query -- --close owl-rl \
             SELECT (COUNT(*) AS ?n) WHERE { ?b dcterms:identifier "sq-8thu" . ?b pkg:blockedBy ?d }'
 ```
 
+## The natural-language tool (agent flavor) — `sq-ve5dy`
+
+Instead of writing the SPARQL yourself, you can delegate the whole round-trip to a
+**cheap-model (Haiku) sub-agent** so the expensive orchestrator only emits a plain-English
+question and reads a short answer. The sub-agent (`.claude/agents/sparq-pkg-nl.md`,
+`model: haiku`) does NL → introspect → ground → SPARQL → run → NL answer itself.
+
+**Soundness guardrail (load-bearing):** the tool ALWAYS returns the **executed SPARQL +
+resolved IRIs + grounding confidence** so the caller can verify the answer was *computed*,
+not guessed — it never silently answers from a guessed query. `pkg-query --json` emits this
+**NL-tool envelope** (`crates/sparq-kb/src/query/nl_tool.rs`):
+
+```bash
+cargo run -q -p sparq-kb --features query --bin pkg-query -- --query schema-classes --json
+```
+
+```json
+{
+  "answer": "5 row(s). Columns: class, instances.\n- Task | 1255\n- Finding | 11 …",
+  "executed_sparql": "PREFIX pkg: <https://sparq.dev/ns/pkg#> SELECT ?class …",
+  "resolved_iris": ["http://www.w3.org/1999/02/22-rdf-syntax-ns#type"],
+  "ungrounded_iris": [],
+  "hints": [],
+  "row_count": 5,
+  "confidence": "canned"
+}
+```
+
+`confidence` is a **query-grounding** signal (NOT an answer-correctness claim): `canned` =
+a curated template; `grounded` = a raw query whose every term exists in the data;
+`ungrounded` = a raw query that used a term the data lacks (so it matched nothing — the
+`hints` give same-namespace repair candidates; re-ground and re-run before trusting it). The
+deterministic `answer` is the engine's computed rows; the cheap model rephrases it. The
+**PRODUCT flavor** (sparq calling a configurable cheap-model endpoint as a real GenAI
+integration) needs sparq's own API key (an external-credential dependency) and is a
+follow-up — only the **agent flavor** (no API key) ships here.
+
+> **Honesty.** Whether routing PKG access through a cheap-model sub-agent actually cuts the
+> orchestrator's *model-price-weighted* cost is **measured by sq-2m6zm.4 / sq-jgi97**, not
+> claimed here.
+
 ## When NOT to use this
 
 - The fact is **not in the head slice** (PKG is a Phase-1 subset) → an empty/partial
@@ -186,12 +227,16 @@ cargo run -p sparq-kb --features close --bin pkg-query -- --close owl-rl \
 
 ## Where this lives
 
-- Helper binary: `crates/sparq-kb/src/bin/pkg_query.rs` (`--bin pkg-query`).
+- Helper binary: `crates/sparq-kb/src/bin/pkg_query.rs` (`--bin pkg-query`; `--json`
+  emits the NL-tool envelope).
 - Canned queries (the library the binary + the test share):
   `crates/sparq-kb/src/query/canned.rs`.
+- NL-tool envelope (`sq-ve5dy`): `crates/sparq-kb/src/query/nl_tool.rs`
+  (`run_canned` / `run_raw` → `NlToolResult`).
+- Agent-flavor sub-agent (`model: haiku`): `.claude/agents/sparq-pkg-nl.md`.
 - Loader + optional closure: `crates/sparq-kb/src/lib.rs` (`query` / `query::close` modules).
-- Rot-guard test: `crates/sparq-kb/tests/query_canned.rs`
-  (`cargo test -p sparq-kb --features query --test query_canned`; add `--features close`
-  for the closure test).
+- Rot-guard tests: `crates/sparq-kb/tests/query_canned.rs` and
+  `crates/sparq-kb/tests/nl_tool.rs`
+  (`cargo test -p sparq-kb --features query`; add `--features close` for the closure test).
 - Ontology + data: `crates/sparq-kb/ontology/pkg/pkg.ttl`,
   `crates/sparq-kb/ingest/pkg-instances.ttl`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3486,6 +3486,9 @@ version = "0.1.0"
 dependencies = [
  "oxrdf 0.3.3",
  "oxttl 0.2.3",
+ "serde",
+ "serde_json",
+ "spargebra",
  "sparq-core",
  "sparq-engine",
  "sparq-reason",

--- a/crates/sparq-kb/Cargo.toml
+++ b/crates/sparq-kb/Cargo.toml
@@ -31,10 +31,13 @@ default = []
 validate = ["dep:sparq-core", "dep:sparq-shacl", "dep:oxttl", "dep:oxrdf"]
 # OPT-IN (default-OFF). Enables the SPARQL-query proof over the ingested PKG graph
 # (sq-2m6zm.2): the example-lookup answers (`Graph::load_str` + `sparq_engine::query`),
-# the introspect→ground→ask `query` module, the named canned queries, and the
-# `pkg-query` binary (sq-2m6zm.3). Pulls in the SPARQL engine; keep it off the lean
-# default build.
-query = ["validate", "dep:sparq-engine"]
+# the introspect→ground→ask `query` module, the named canned queries, the
+# `pkg-query` binary (sq-2m6zm.3) and the natural-language tool envelope (sq-ve5dy:
+# `query::nl_tool` — run a query and return the executed SPARQL + resolved IRIs +
+# confidence so the caller can verify the answer was not fabricated). Pulls in the
+# SPARQL engine + spargebra (algebra walk for the resolved-IRI provenance) + serde
+# (JSON envelope); keep it off the lean default build. [OPUS-4.8] sq-ve5dy
+query = ["validate", "dep:sparq-engine", "dep:spargebra", "dep:serde", "dep:serde_json"]
 # OPT-IN (default-OFF). Adds the optional RDFS/OWL-RL closure step the design record
 # (§3.1) calls for before querying — materialise the `pkg:dependsOn owl:inverseOf
 # pkg:blockedBy` and `pkg:couldBeMergedWith` symmetry so a query over the inverse /
@@ -58,6 +61,16 @@ sparq-reason = { path = "../sparq-reason", default-features = false, optional = 
 # Turtle parser + term model (only behind `validate`, to build the data graph).
 oxttl = { workspace = true, optional = true }
 oxrdf = { workspace = true, optional = true }
+# SPARQL algebra parser (only behind `query`): the NL-tool envelope (sq-ve5dy) walks
+# the parsed query to collect the predicate/class IRIs the answer actually relied on,
+# so the returned `resolved_iris` provenance is exact, not a string scrape. Workspace-
+# pinned to the same vendored spargebra the engine uses. [OPUS-4.8] sq-ve5dy
+spargebra = { workspace = true, optional = true }
+# JSON envelope for the NL tool (only behind `query`): the `--json` output mode of
+# `pkg-query` and the serde-derived `NlToolResult` the agent-flavor sub-agent returns.
+# [OPUS-4.8] sq-ve5dy
+serde = { version = "1", features = ["derive"], optional = true }
+serde_json = { version = "1", optional = true }
 
 # The `pkg-query` helper binary (sq-2m6zm.3): one command to introspect → ground →
 # ask over the ingested PKG. It needs the `query` module (engine), so it is only

--- a/crates/sparq-kb/README.md
+++ b/crates/sparq-kb/README.md
@@ -79,6 +79,11 @@ the §4.1 ready-frontier — returning the minimal triples computed by the engin
 - **Opt-in by construction** — default build is data + constants only; the
   `validate` feature is the only thing that pulls in `sparq-core` + `sparq-shacl`.
 - **No-drift guard** — `vocab.rs` is byte-pinned against `pkg.ttl` by a sync test.
+- **NL-tool envelope** (`query` feature, `sq-ve5dy`) — `query::nl_tool` runs a query
+  and returns the **executed SPARQL + resolved IRIs + grounding confidence** so the
+  caller can verify the answer was computed, not guessed; `pkg-query --json` emits it.
+  The `model: haiku` agent-flavor sub-agent (`.claude/agents/sparq-pkg-nl.md`) drives
+  it so the orchestrator pays cheap-model tokens for the verbose middle.
 
 ## 📚 Learn more
 

--- a/crates/sparq-kb/src/bin/pkg_query.rs
+++ b/crates/sparq-kb/src/bin/pkg_query.rs
@@ -34,17 +34,18 @@
 //! ```
 
 use oxrdf::Term;
+use sparq_core::Graph;
 use sparq_engine::QueryResult;
-use sparq_kb::query::{ask_pkg, canned, load_pkg};
+use sparq_kb::query::{ask_pkg, canned, load_pkg, nl_tool};
 
 fn usage() -> &'static str {
     "\
-pkg-query — introspect → ground → ask over the ingested PKG (sq-2m6zm.3)
+pkg-query — introspect → ground → ask over the ingested PKG (sq-2m6zm.3, sq-ve5dy)
 
 USAGE:
   pkg-query --list
-  pkg-query --query <name> [--arg <value>] [--close rdfs|owl-rl] [--sparql-only]
-  pkg-query --sparql '<SPARQL SELECT/ASK>' [--close rdfs|owl-rl]
+  pkg-query --query <name> [--arg <value>] [--close rdfs|owl-rl] [--sparql-only] [--json]
+  pkg-query --sparql '<SPARQL SELECT/ASK>' [--close rdfs|owl-rl] [--json]
 
 OPTIONS:
   --list             list the canned introspect/ground queries and exit
@@ -53,6 +54,9 @@ OPTIONS:
   --sparql <query>   run a raw SPARQL SELECT/ASK string
   --close <profile>  materialise RDFS or OWL-RL closure first (needs --features close)
   --sparql-only      print the executed SPARQL but do not run it (for verification)
+  --json             emit the NL-tool envelope as JSON (answer + executed SPARQL +
+                     resolved IRIs + grounding confidence) — the agent-flavor tool
+                     output (sq-ve5dy)
   -h, --help         show this help
 "
 }
@@ -82,6 +86,7 @@ fn run(args: &[String]) -> Result<(), String> {
     let mut arg: Option<&str> = None;
     let mut close: Option<&str> = None;
     let mut sparql_only = false;
+    let mut json = false;
 
     let mut i = 0;
     while i < args.len() {
@@ -107,6 +112,7 @@ fn run(args: &[String]) -> Result<(), String> {
                 close = Some(next(args, &mut i, "--close")?);
             }
             "--sparql-only" => sparql_only = true,
+            "--json" => json = true,
             other => return Err(format!("unknown argument `{other}`")),
         }
         i += 1;
@@ -135,37 +141,52 @@ fn run(args: &[String]) -> Result<(), String> {
         return Ok(());
     }
 
-    // Load the store (optionally closed), then run.
-    let result = run_query(&sparql, close)?;
+    // Load the store (optionally closed).
+    let graph = load_graph(close)?;
+
+    // --json: emit the NL-tool envelope (sq-ve5dy) — answer + executed SPARQL +
+    // resolved IRIs + grounding confidence — the agent-flavor tool output. Canned
+    // queries carry `Confidence::Canned`; a raw query's confidence is derived from its
+    // dictionary grounding.
+    if json {
+        let envelope = match query_name {
+            Some(name) => nl_tool::run_canned(&graph, name, arg)?,
+            None => nl_tool::run_raw(&graph, &sparql)?,
+        };
+        println!("{}", envelope.to_json());
+        return Ok(());
+    }
+
+    // Default human/table output.
+    let result = ask_pkg(&graph, &sparql)?;
     print_table(&result);
     eprintln!("\n{} row(s).", result.rows.len());
     Ok(())
 }
 
-/// Run `sparql` over the PKG, optionally under an RDFS/OWL-RL closure. The closure path
-/// is only available when the crate is built with `--features close`.
-fn run_query(sparql: &str, close: Option<&str>) -> Result<QueryResult, String> {
+/// Load the PKG store, optionally under an RDFS/OWL-RL closure. The closure path is only
+/// available when the crate is built with `--features close`. Shared by both the table
+/// output and the `--json` NL-tool envelope so the two cannot diverge on what data they
+/// answer over.
+fn load_graph(close: Option<&str>) -> Result<Graph, String> {
     match close {
-        None => {
-            let g = load_pkg()?;
-            ask_pkg(&g, sparql)
-        }
-        Some(profile) => run_closed(sparql, profile),
+        None => load_pkg(),
+        Some(profile) => load_closed(profile),
     }
 }
 
 #[cfg(feature = "close")]
-fn run_closed(sparql: &str, profile: &str) -> Result<QueryResult, String> {
+fn load_closed(profile: &str) -> Result<Graph, String> {
     use sparq_kb::query::close::{load_pkg_closed, Profile};
     let profile = Profile::parse(profile)
         .ok_or_else(|| format!("unknown closure profile `{profile}` (use rdfs|owl-rl)"))?;
     let (g, entailed) = load_pkg_closed(profile)?;
     eprintln!("--- closure: {entailed} entailed triple(s) materialised ---");
-    ask_pkg(&g, sparql)
+    Ok(g)
 }
 
 #[cfg(not(feature = "close"))]
-fn run_closed(_sparql: &str, _profile: &str) -> Result<QueryResult, String> {
+fn load_closed(_profile: &str) -> Result<Graph, String> {
     Err("--close needs the `close` feature: rebuild with --features close".into())
 }
 

--- a/crates/sparq-kb/src/lib.rs
+++ b/crates/sparq-kb/src/lib.rs
@@ -109,6 +109,10 @@ pub mod query {
     use sparq_engine::{query, QueryResult};
 
     pub mod canned;
+    /// The PKG **natural-language tool** envelope (agent flavor, sq-ve5dy): run a query
+    /// and return the executed SPARQL + resolved IRIs + grounding confidence so the
+    /// caller can verify the answer was computed, not guessed. [OPUS-4.8] sq-ve5dy
+    pub mod nl_tool;
 
     /// Load the PKG ontology + the ingested instances into one queryable [`Graph`].
     /// The `kb:` instances use absolute IRIs, so no base is needed.

--- a/crates/sparq-kb/src/query/nl_tool.rs
+++ b/crates/sparq-kb/src/query/nl_tool.rs
@@ -1,0 +1,653 @@
+//! The PKG **natural-language tool** envelope (agent flavor) — sq-ve5dy.
+//!
+//! [OPUS-4.8] sq-ve5dy (epic sq-2m6zm); reframes PKG access (sq-2m6zm.3) as a
+//! *natural-language tool call* the cheap-model sub-agent makes on the expensive
+//! orchestrator's behalf. 🤖 SPARQ agent — dogfooding sparq as a project knowledge
+//! graph. Written while Fable unavailable; flag for re-review when Fable returns.
+//!
+//! # Why this module exists
+//!
+//! The maintainer reframe (2026-06-21) is: a cheap model (Haiku/Sonnet) does the whole
+//! round-trip — NL question → introspect/ground → SPARQL → run via `ask_pkg` →
+//! result rows → concise NL answer — so the expensive orchestrator only emits the
+//! question and reads the answer. The orchestrator never sees the schema card, the
+//! SPARQL, or the raw rows.
+//!
+//! The **AGENT flavor** (this slice, sq-ve5dy) needs no API key: the cheap model is a
+//! `model: haiku` Claude-Code sub-agent (definition in
+//! `.claude/agents/sparq-pkg-nl.md`) that drives the `pkg-query` binary. The PRODUCT
+//! flavor — `sparq-nlq` calling a configurable cheap-model endpoint as a real GenAI
+//! integration — needs sparq's own Anthropic key (an external-credential dependency)
+//! and is left to a follow-up (see the README + the bead note).
+//!
+//! # The soundness guardrail (load-bearing)
+//!
+//! A cheap model translating NL → SPARQL can guess a *plausible-but-wrong* query and
+//! return a confident answer the data never supported. So the tool must **never
+//! silently answer from a guessed query**: every answer is returned together with the
+//! `NlToolResult` envelope — the **executed SPARQL**, the **resolved IRIs** the query
+//! actually relied on, the **row count**, and a **grounding confidence** — so the
+//! caller can verify the answer was computed, not fabricated. The rows are computed by
+//! sparq's own engine over the ingested graph; within the store the model cannot invent
+//! a fact the data does not contain, and an empty result is the honest "none" answer.
+//!
+//! `Confidence` is a **query-grounding** signal (was the query canned / fully
+//! dictionary-grounded / partially ungrounded), explicitly *not* an answer-correctness
+//! claim — we have no gold answer to score against, and this module makes no such
+//! claim.
+
+use serde::{Deserialize, Serialize};
+use sparq_core::dict::TermParts;
+use sparq_core::Graph;
+use sparq_engine::QueryResult;
+
+use oxrdf::{NamedNode, Term};
+use spargebra::algebra::{Expression, GraphPattern, PropertyPathExpression};
+use spargebra::term::{NamedNodePattern, TermPattern, TriplePattern};
+use spargebra::Query;
+
+/// `rdf:type` — the predicate whose object is a class IRI (the one object position we
+/// treat as schema vocabulary).
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+/// How many sample answer rows the deterministic NL summary renders before eliding.
+const SUMMARY_SAMPLE_ROWS: usize = 5;
+
+/// Grounding confidence of the executed query. A **structural** signal about how
+/// grounded the query was — NOT a claim about whether the answer is *correct* (no gold
+/// answer is scored here).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Confidence {
+    /// The query is one of the curated, verified-expressible `canned::` templates
+    /// (introspect → ground → ask). Highest structural confidence.
+    Canned,
+    /// A raw query whose every predicate / `rdf:type` class IRI is present in the live
+    /// PKG dictionary, so each vocabulary term it relies on actually exists in the data.
+    Grounded,
+    /// A raw query that parses but uses one or more predicate / class IRIs **absent**
+    /// from the dictionary — it matched no triples for those terms, so the answer may be
+    /// partial or empty for the wrong reason. The caller should re-check the
+    /// `ungrounded_iris` before trusting the answer.
+    Ungrounded,
+}
+
+impl Confidence {
+    /// A stable one-word label for prompts / logs.
+    pub fn label(self) -> &'static str {
+        match self {
+            Confidence::Canned => "canned",
+            Confidence::Grounded => "grounded",
+            Confidence::Ungrounded => "ungrounded",
+        }
+    }
+}
+
+/// The verifiable result envelope the NL tool returns — the soundness guardrail. Carries
+/// everything the caller needs to confirm the answer was *computed* from the data, not
+/// guessed: the executed SPARQL, the IRIs the query relied on (and which of them were
+/// ungrounded), the row count, and the grounding confidence. Serialisable to JSON for
+/// the `pkg-query --json` output mode the agent-flavor sub-agent consumes.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct NlToolResult {
+    /// A concise, **deterministic** NL summary of the answer (header + a few sample
+    /// rows, computed by the engine). The cheap-model sub-agent may rephrase this into
+    /// fluent prose, but even with no model the envelope already carries a sound answer.
+    pub answer: String,
+    /// The SPARQL that was executed (post-substitution for a canned query). Always
+    /// present — the caller can re-run it to verify.
+    pub executed_sparql: String,
+    /// Every predicate / `rdf:type` class IRI the query relied on, de-duplicated, in
+    /// first-appearance order — the schema vocabulary the answer depends on.
+    pub resolved_iris: Vec<String>,
+    /// The subset of `resolved_iris` that is **absent from the live dictionary** (so it
+    /// matched no triples). Empty for a fully grounded query; non-empty downgrades the
+    /// confidence to [`Confidence::Ungrounded`].
+    pub ungrounded_iris: Vec<String>,
+    /// **Advisory** same-namespace repair hints for each ungrounded IRI (empty when the
+    /// query is fully grounded) — so the agent-flavor sub-agent can re-ground its next
+    /// query. Advisory only: NOT part of the soundness guarantee.
+    pub hints: Vec<String>,
+    /// How many solution rows the query returned (0 is the honest "none" answer).
+    pub row_count: usize,
+    /// The grounding confidence (see [`Confidence`]).
+    pub confidence: Confidence,
+}
+
+impl NlToolResult {
+    /// Serialise the envelope to pretty JSON (the `pkg-query --json` payload). Infallible:
+    /// every field is a plain string / number / enum.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).expect("NlToolResult serialises to JSON")
+    }
+}
+
+/// Run a **canned** PKG query (by name, with an optional `--arg` substitution) as a
+/// natural-language tool call, returning the verifiable [`NlToolResult`] envelope.
+/// Confidence is [`Confidence::Canned`] (the template is curated + verified-expressible).
+///
+/// `graph` is the loaded PKG ([`super::load_pkg`] or [`super::close::load_pkg_closed`]).
+pub fn run_canned(graph: &Graph, name: &str, arg: Option<&str>) -> Result<NlToolResult, String> {
+    let q = super::canned::by_name(name)
+        .ok_or_else(|| format!("no canned query named `{name}` (try the canned registry)"))?;
+    let sparql = q.render(arg);
+    run_sparql_with_confidence(graph, &sparql, Confidence::Canned)
+}
+
+/// Run a **raw** SPARQL string as a natural-language tool call, returning the verifiable
+/// [`NlToolResult`] envelope. Confidence is derived from the query's grounding against
+/// the live dictionary: [`Confidence::Grounded`] when every predicate / class IRI exists
+/// in the data, else [`Confidence::Ungrounded`] (with the offending IRIs surfaced in
+/// `ungrounded_iris`).
+pub fn run_raw(graph: &Graph, sparql: &str) -> Result<NlToolResult, String> {
+    // Parse once to drive both grounding and (re-)execution; the engine re-parses but
+    // the algebra walk needs the parsed form for exact IRI provenance.
+    let parsed = spargebra::SparqlParser::new()
+        .parse_query(sparql)
+        .map_err(|e| format!("the question's SPARQL did not parse: {e}"))?;
+    let resolved = resolved_iris(&parsed);
+    let ungrounded: Vec<String> = resolved
+        .iter()
+        .filter(|iri| !iri_in_dictionary(graph, iri))
+        .cloned()
+        .collect();
+    let confidence = if ungrounded.is_empty() {
+        Confidence::Grounded
+    } else {
+        Confidence::Ungrounded
+    };
+    finish(graph, sparql, resolved, ungrounded, confidence)
+}
+
+/// Shared path for a query whose confidence is fixed by the caller (the canned case):
+/// still computes the resolved/ungrounded IRIs (provenance), but does not let the
+/// grounding override the supplied confidence.
+fn run_sparql_with_confidence(
+    graph: &Graph,
+    sparql: &str,
+    confidence: Confidence,
+) -> Result<NlToolResult, String> {
+    let parsed = spargebra::SparqlParser::new()
+        .parse_query(sparql)
+        .map_err(|e| format!("the canned query did not parse: {e}"))?;
+    let resolved = resolved_iris(&parsed);
+    let ungrounded: Vec<String> = resolved
+        .iter()
+        .filter(|iri| !iri_in_dictionary(graph, iri))
+        .cloned()
+        .collect();
+    finish(graph, sparql, resolved, ungrounded, confidence)
+}
+
+/// Execute the query and assemble the envelope from the already-computed provenance.
+fn finish(
+    graph: &Graph,
+    sparql: &str,
+    resolved_iris: Vec<String>,
+    ungrounded_iris: Vec<String>,
+    confidence: Confidence,
+) -> Result<NlToolResult, String> {
+    let result = super::ask_pkg(graph, sparql)?;
+    let answer = summarise(&result);
+    // Advisory same-namespace hints for any ungrounded term, de-duplicated.
+    let mut hints: Vec<String> = Vec::new();
+    for iri in &ungrounded_iris {
+        for h in nearest_known(graph, iri) {
+            if !hints.contains(&h) {
+                hints.push(h);
+            }
+        }
+    }
+    Ok(NlToolResult {
+        answer,
+        executed_sparql: sparql.trim().to_string(),
+        resolved_iris,
+        ungrounded_iris,
+        hints,
+        row_count: result.len(),
+        confidence,
+    })
+}
+
+/// A concise, deterministic NL summary of a result set: a one-line shape, the variable
+/// header, and up to [`SUMMARY_SAMPLE_ROWS`] sample rows with the rest elided. This is
+/// the *answer-sized* payload the cheap model rephrases; it is sound on its own.
+fn summarise(r: &QueryResult) -> String {
+    let n = r.len();
+    if n == 0 {
+        return "No rows matched — the data holds no answer to this question (the honest \
+                \"none\" result)."
+            .to_string();
+    }
+    let header: Vec<&str> = r.vars.iter().map(|v| v.as_str()).collect();
+    let mut s = format!(
+        "{n} row(s). Columns: {}.\n",
+        if header.is_empty() {
+            "(none — ASK/unit result)".to_string()
+        } else {
+            header.join(", ")
+        }
+    );
+    for row in r.rows.iter().take(SUMMARY_SAMPLE_ROWS) {
+        let cells: Vec<String> = row.iter().map(cell).collect();
+        s.push_str(&format!("- {}\n", cells.join(" | ")));
+    }
+    if n > SUMMARY_SAMPLE_ROWS {
+        s.push_str(&format!("… and {} more row(s).\n", n - SUMMARY_SAMPLE_ROWS));
+    }
+    s.trim_end().to_string()
+}
+
+/// Render one result cell: short local name for an IRI, truncated value for a literal —
+/// the same human/agent-readable rendering the `pkg-query` table uses.
+fn cell(c: &Option<Term>) -> String {
+    match c {
+        Some(Term::NamedNode(n)) => n
+            .as_str()
+            .rsplit(['#', '/'])
+            .next()
+            .unwrap_or("")
+            .to_string(),
+        Some(Term::Literal(l)) => {
+            let v = l.value();
+            if v.chars().count() > 110 {
+                let cut: String = v.chars().take(110).collect();
+                format!("{cut}…")
+            } else {
+                v.to_string()
+            }
+        }
+        Some(t) => t.to_string(),
+        None => "(unbound)".to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Resolved-IRI provenance (algebra walk) + dictionary grounding
+// ---------------------------------------------------------------------------
+
+/// Collect every predicate / `rdf:type` class IRI the parsed `query` relies on,
+/// de-duplicated in first-appearance order — the schema vocabulary the answer depends
+/// on. This is the *resolved IRIs* half of the soundness envelope: the caller can see
+/// exactly which terms the answer was computed over.
+///
+/// Scope mirrors `sparq_nlq::constrain` (predicate + class position): those are the
+/// vocabulary terms a grounded query must get right. Specific entity IRIs in
+/// subject/object data position are left out (they are values, not schema).
+pub fn resolved_iris(query: &Query) -> Vec<String> {
+    let mut found: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut push = |iri: &str| {
+        if seen.insert(iri.to_string()) {
+            found.push(iri.to_string());
+        }
+    };
+    match query {
+        Query::Select { pattern, .. }
+        | Query::Ask { pattern, .. }
+        | Query::Describe { pattern, .. } => walk_pattern(pattern, &mut push),
+        Query::Construct {
+            pattern, template, ..
+        } => {
+            walk_pattern(pattern, &mut push);
+            for tp in template {
+                walk_triple(tp, &mut push);
+            }
+        }
+    }
+    found
+}
+
+/// Is `iri` a term in the live dictionary? An absent IRI matches no triple.
+fn iri_in_dictionary(graph: &Graph, iri: &str) -> bool {
+    match NamedNode::new(iri) {
+        Ok(node) => graph.id_of(&Term::NamedNode(node)).is_some(),
+        Err(_) => false,
+    }
+}
+
+// --- algebra walk (predicate + class position) ---------------------------------------
+
+fn walk_pattern<F: FnMut(&str)>(p: &GraphPattern, f: &mut F) {
+    match p {
+        GraphPattern::Bgp { patterns } => {
+            for tp in patterns {
+                walk_triple(tp, f);
+            }
+        }
+        GraphPattern::Path { path, .. } => walk_path(path, f),
+        GraphPattern::Join { left, right }
+        | GraphPattern::Union { left, right }
+        | GraphPattern::Minus { left, right }
+        | GraphPattern::Lateral { left, right } => {
+            walk_pattern(left, f);
+            walk_pattern(right, f);
+        }
+        GraphPattern::LeftJoin {
+            left,
+            right,
+            expression,
+        } => {
+            walk_pattern(left, f);
+            walk_pattern(right, f);
+            if let Some(e) = expression {
+                walk_expr(e, f);
+            }
+        }
+        GraphPattern::Filter { expr, inner } => {
+            walk_expr(expr, f);
+            walk_pattern(inner, f);
+        }
+        GraphPattern::Graph { inner, .. }
+        | GraphPattern::Distinct { inner }
+        | GraphPattern::Reduced { inner }
+        | GraphPattern::Slice { inner, .. }
+        | GraphPattern::OrderBy { inner, .. }
+        | GraphPattern::Project { inner, .. }
+        | GraphPattern::Group { inner, .. } => walk_pattern(inner, f),
+        GraphPattern::Extend {
+            inner, expression, ..
+        } => {
+            walk_pattern(inner, f);
+            walk_expr(expression, f);
+        }
+        // A SERVICE block's vocabulary belongs to a remote dictionary; out of scope.
+        GraphPattern::Service { .. } => {}
+        GraphPattern::Values { .. } => {}
+    }
+}
+
+fn walk_triple<F: FnMut(&str)>(tp: &TriplePattern, f: &mut F) {
+    if let NamedNodePattern::NamedNode(p) = &tp.predicate {
+        let p = p.as_str();
+        f(p);
+        if p == RDF_TYPE {
+            if let TermPattern::NamedNode(o) = &tp.object {
+                f(o.as_str());
+            }
+        }
+    }
+    if let TermPattern::Triple(inner) = &tp.subject {
+        walk_triple(inner, f);
+    }
+    if let TermPattern::Triple(inner) = &tp.object {
+        walk_triple(inner, f);
+    }
+}
+
+fn walk_path<F: FnMut(&str)>(path: &PropertyPathExpression, f: &mut F) {
+    match path {
+        PropertyPathExpression::NamedNode(n) => f(n.as_str()),
+        PropertyPathExpression::Reverse(p)
+        | PropertyPathExpression::ZeroOrMore(p)
+        | PropertyPathExpression::OneOrMore(p)
+        | PropertyPathExpression::ZeroOrOne(p) => walk_path(p, f),
+        PropertyPathExpression::Sequence(a, b) | PropertyPathExpression::Alternative(a, b) => {
+            walk_path(a, f);
+            walk_path(b, f);
+        }
+        PropertyPathExpression::NegatedPropertySet(ns) => {
+            for n in ns {
+                f(n.as_str());
+            }
+        }
+    }
+}
+
+fn walk_expr<F: FnMut(&str)>(e: &Expression, f: &mut F) {
+    match e {
+        Expression::Exists(p) => walk_pattern(p, f),
+        Expression::Or(a, b)
+        | Expression::And(a, b)
+        | Expression::Equal(a, b)
+        | Expression::SameTerm(a, b)
+        | Expression::Greater(a, b)
+        | Expression::GreaterOrEqual(a, b)
+        | Expression::Less(a, b)
+        | Expression::LessOrEqual(a, b)
+        | Expression::Add(a, b)
+        | Expression::Subtract(a, b)
+        | Expression::Multiply(a, b)
+        | Expression::Divide(a, b) => {
+            walk_expr(a, f);
+            walk_expr(b, f);
+        }
+        Expression::In(a, list) => {
+            walk_expr(a, f);
+            for e in list {
+                walk_expr(e, f);
+            }
+        }
+        Expression::UnaryPlus(a) | Expression::UnaryMinus(a) | Expression::Not(a) => {
+            walk_expr(a, f)
+        }
+        Expression::FunctionCall(_, args) => {
+            for a in args {
+                walk_expr(a, f);
+            }
+        }
+        Expression::If(a, b, c) => {
+            walk_expr(a, f);
+            walk_expr(b, f);
+            walk_expr(c, f);
+        }
+        Expression::Coalesce(list) => {
+            for e in list {
+                walk_expr(e, f);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// How many advisory repair hints to surface per ungrounded IRI.
+const MAX_HINTS: usize = 4;
+
+/// Same-namespace dictionary IRIs **nearest** (smallest local-name edit distance) to
+/// `iri` — an **advisory** repair hint surfaced alongside an ungrounded term so the
+/// agent-flavor sub-agent can re-ground its next query without a full re-introspection.
+/// Advisory only: it is NOT part of the soundness guarantee (the guarantee is the
+/// executed SPARQL + the grounding flag). Ranked by edit distance so the closest
+/// candidates lead, capped at `MAX_HINTS`.
+pub fn nearest_known(graph: &Graph, iri: &str) -> Vec<String> {
+    let Some(split) = iri.rfind(['#', '/']) else {
+        return Vec::new();
+    };
+    let prefix = &iri[..=split];
+    let suffix = &iri[split + 1..];
+    let mut scored: Vec<(usize, String)> = Vec::new();
+    for (_, parts) in graph.dict.iter() {
+        if let TermParts::Iri {
+            prefix: p,
+            suffix: s,
+        } = parts
+        {
+            if p == prefix && s != suffix {
+                let full = format!("{p}{s}");
+                if !scored.iter().any(|(_, h)| h == &full) {
+                    scored.push((edit_distance(suffix, s), full));
+                }
+            }
+        }
+    }
+    scored.sort_by(|a, b| a.0.cmp(&b.0).then_with(|| a.1.cmp(&b.1)));
+    scored.truncate(MAX_HINTS);
+    scored.into_iter().map(|(_, iri)| iri).collect()
+}
+
+/// Levenshtein edit distance (two rolling rows) over the chars of `a` and `b`. Local
+/// names are short, so the quadratic cost is trivial.
+fn edit_distance(a: &str, b: &str) -> usize {
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
+    if a.is_empty() {
+        return b.len();
+    }
+    if b.is_empty() {
+        return a.len();
+    }
+    let mut prev: Vec<usize> = (0..=b.len()).collect();
+    let mut cur = vec![0usize; b.len() + 1];
+    for (i, &ca) in a.iter().enumerate() {
+        cur[0] = i + 1;
+        for (j, &cb) in b.iter().enumerate() {
+            let cost = usize::from(ca != cb);
+            cur[j + 1] = (prev[j + 1] + 1).min(cur[j] + 1).min(prev[j] + cost);
+        }
+        std::mem::swap(&mut prev, &mut cur);
+    }
+    prev[b.len()]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sparq_core::Graph;
+
+    /// A tiny PKG-shaped graph so the tests exercise the REAL engine path without
+    /// depending on the full ingested instances file (which is large + churny). The
+    /// `pkg:` prefix and predicate IRIs match the ontology so grounding is meaningful.
+    fn tiny_pkg() -> Graph {
+        let ttl = r#"
+            @prefix pkg:     <https://sparq.dev/ns/pkg#> .
+            @prefix dcterms: <http://purl.org/dc/terms/> .
+            @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+            pkg:t1 a pkg:Task ; dcterms:identifier "sq-aaaa" ; pkg:status pkg:Open ;
+                   dcterms:title "first task" .
+            pkg:t2 a pkg:Task ; dcterms:identifier "sq-bbbb" ; pkg:status pkg:Closed ;
+                   dcterms:title "second task" .
+            pkg:f1 a pkg:Finding ; rdfs:label "a sourced finding" ; pkg:confidence "0.9" .
+        "#;
+        Graph::load_str(ttl, "turtle").expect("tiny PKG parses")
+    }
+
+    #[test]
+    fn run_raw_grounded_query_returns_sound_envelope() {
+        let g = tiny_pkg();
+        let q = "PREFIX pkg: <https://sparq.dev/ns/pkg#>\n\
+                 SELECT (COUNT(?t) AS ?n) WHERE { ?t a pkg:Task }";
+        let r = run_raw(&g, q).expect("runs");
+        assert_eq!(r.confidence, Confidence::Grounded);
+        assert!(r.ungrounded_iris.is_empty(), "{:?}", r.ungrounded_iris);
+        assert!(
+            r.hints.is_empty(),
+            "a grounded query needs no hints: {:?}",
+            r.hints
+        );
+        // The resolved IRIs include rdf:type (the predicate) and pkg:Task (the class).
+        assert!(r.resolved_iris.contains(&RDF_TYPE.to_string()));
+        assert!(r
+            .resolved_iris
+            .contains(&"https://sparq.dev/ns/pkg#Task".to_string()));
+        // The executed SPARQL is echoed back verbatim for verification.
+        assert!(r.executed_sparql.contains("COUNT(?t)"));
+        assert_eq!(r.row_count, 1);
+        assert!(r.answer.contains("row(s)"));
+    }
+
+    #[test]
+    fn run_raw_ungrounded_predicate_lowers_confidence_and_is_surfaced() {
+        let g = tiny_pkg();
+        // `pkg:nope` is a perfectly valid IRI absent from this graph's dictionary.
+        let q = "PREFIX pkg: <https://sparq.dev/ns/pkg#>\n\
+                 SELECT ?s WHERE { ?s pkg:nope ?o }";
+        let r = run_raw(&g, q).expect("runs (the query is valid, just ungrounded)");
+        assert_eq!(r.confidence, Confidence::Ungrounded);
+        assert_eq!(
+            r.ungrounded_iris,
+            vec!["https://sparq.dev/ns/pkg#nope".to_string()]
+        );
+        // Advisory same-namespace hints help the agent re-ground: every hint is a real
+        // term from the same `pkg:` namespace (and never the ungrounded term itself).
+        assert!(
+            !r.hints.is_empty(),
+            "expected same-namespace hints, got none"
+        );
+        assert!(
+            r.hints
+                .iter()
+                .all(|h| h.starts_with("https://sparq.dev/ns/pkg#")
+                    && h != "https://sparq.dev/ns/pkg#nope"),
+            "hints must be same-namespace, non-self terms, got {:?}",
+            r.hints
+        );
+        // The honest "no rows" answer, computed not guessed.
+        assert_eq!(r.row_count, 0);
+        assert!(r.answer.contains("No rows matched"));
+    }
+
+    #[test]
+    fn run_canned_uses_canned_confidence_even_when_arg_matches_nothing() {
+        let g = tiny_pkg();
+        // `task-depends-on` is a curated template; over this tiny graph it returns 0
+        // rows, but the confidence stays `Canned` (the template is verified-expressible
+        // — the empty answer is honest, not a low-confidence guess).
+        let r = run_canned(&g, "task-depends-on", Some("sq-aaaa")).expect("runs");
+        assert_eq!(r.confidence, Confidence::Canned);
+        assert_eq!(r.row_count, 0);
+        // The substituted argument is visible in the echoed SPARQL.
+        assert!(r.executed_sparql.contains("sq-aaaa"));
+    }
+
+    #[test]
+    fn run_canned_unknown_name_is_an_error_not_a_guess() {
+        let g = tiny_pkg();
+        let err = run_canned(&g, "no-such-query", None).unwrap_err();
+        assert!(err.contains("no canned query named"));
+    }
+
+    #[test]
+    fn syntactically_invalid_sparql_is_an_error_not_a_silent_answer() {
+        let g = tiny_pkg();
+        let err = run_raw(&g, "SELECT ?s WHERE { ?s ?p").unwrap_err();
+        assert!(err.contains("did not parse"), "{err}");
+    }
+
+    #[test]
+    fn envelope_round_trips_through_json() {
+        let g = tiny_pkg();
+        let q = "PREFIX pkg: <https://sparq.dev/ns/pkg#>\n\
+                 SELECT ?id WHERE { ?t a pkg:Task ; \
+                 <http://purl.org/dc/terms/identifier> ?id } ORDER BY ?id";
+        let r = run_raw(&g, q).expect("runs");
+        let json = r.to_json();
+        let back: NlToolResult = serde_json::from_str(&json).expect("round-trips");
+        assert_eq!(back, r);
+        // The two task identifiers are in the deterministic sample.
+        assert!(r.answer.contains("sq-aaaa"));
+        assert!(r.answer.contains("sq-bbbb"));
+        assert_eq!(r.row_count, 2);
+    }
+
+    #[test]
+    fn confidence_labels_are_stable() {
+        assert_eq!(Confidence::Canned.label(), "canned");
+        assert_eq!(Confidence::Grounded.label(), "grounded");
+        assert_eq!(Confidence::Ungrounded.label(), "ungrounded");
+    }
+
+    #[test]
+    fn nearest_known_ranks_the_closest_sibling_first() {
+        let g = tiny_pkg();
+        // `pkg:Tas` (typo) — edit distance 1 from `pkg:Task`, which must therefore LEAD
+        // the (distance-ranked) same-namespace hint list, ahead of farther terms.
+        let hints = nearest_known(&g, "https://sparq.dev/ns/pkg#Tas");
+        assert_eq!(
+            hints.first().map(String::as_str),
+            Some("https://sparq.dev/ns/pkg#Task"),
+            "the distance-1 sibling pkg:Task must rank first, got {hints:?}"
+        );
+        assert!(
+            hints.len() <= MAX_HINTS,
+            "capped at MAX_HINTS, got {hints:?}"
+        );
+    }
+
+    #[test]
+    fn edit_distance_basics() {
+        assert_eq!(edit_distance("Task", "Tas"), 1);
+        assert_eq!(edit_distance("abc", "abc"), 0);
+        assert_eq!(edit_distance("", "abc"), 3);
+        assert_eq!(edit_distance("kitten", "sitting"), 3);
+    }
+}

--- a/crates/sparq-kb/tests/nl_tool.rs
+++ b/crates/sparq-kb/tests/nl_tool.rs
@@ -1,0 +1,127 @@
+//! Integration test for the PKG **natural-language tool** envelope (agent flavor) over
+//! the REAL ingested PKG — sq-ve5dy. The soundness guarantee (every answer is returned
+//! with the executed SPARQL + resolved IRIs + grounding confidence, so the caller can
+//! verify it was computed, not guessed) must hold against the actual data, not just a
+//! tiny fixture.
+//!
+//! [OPUS-4.8] sq-ve5dy (epic sq-2m6zm). 🤖 SPARQ agent — dogfooding sparq as a project
+//! knowledge graph. Written while Fable unavailable; flag for re-review when Fable returns.
+//!
+//! Run: `cargo test -p sparq-kb --features query --test nl_tool -- --nocapture`.
+#![cfg(feature = "query")]
+
+use sparq_kb::query::load_pkg;
+use sparq_kb::query::nl_tool::{self, Confidence};
+
+#[test]
+fn canned_query_over_real_pkg_is_a_canned_confidence_envelope() {
+    // The introspect "schema-classes" canned query over the real ingest: the answer is
+    // computed (Task dominates the projection), the executed SPARQL is echoed for
+    // verification, and the confidence is `Canned` (curated template).
+    let g = load_pkg().expect("PKG loads");
+    let r = nl_tool::run_canned(&g, "schema-classes", None).expect("runs");
+    assert_eq!(r.confidence, Confidence::Canned);
+    assert!(
+        r.row_count >= 4,
+        "expected the PKG class card; got {}",
+        r.row_count
+    );
+    // The executed SPARQL is the real canned text, verifiable by re-running.
+    assert!(r.executed_sparql.contains("GROUP BY ?class"));
+    // The answer is the engine's computed rows (Task is the largest class).
+    assert!(
+        r.answer.to_lowercase().contains("task"),
+        "answer should mention the Task class; got: {}",
+        r.answer
+    );
+    // rdf:type is the predicate the query relied on — surfaced as a resolved IRI.
+    assert!(r
+        .resolved_iris
+        .contains(&"http://www.w3.org/1999/02/22-rdf-syntax-ns#type".to_string()));
+    assert!(r.ungrounded_iris.is_empty(), "{:?}", r.ungrounded_iris);
+}
+
+#[test]
+fn parameterised_canned_query_substitutes_and_runs() {
+    // `task-blocks` for sq-8thu (the most-depended-on blocker) returns many downstream
+    // dependents; the substituted arg is visible in the echoed SPARQL.
+    let g = load_pkg().expect("PKG loads");
+    let r = nl_tool::run_canned(&g, "task-blocks", Some("sq-8thu")).expect("runs");
+    assert_eq!(r.confidence, Confidence::Canned);
+    assert!(
+        r.row_count >= 10,
+        "sq-8thu should have many downstream dependents; got {}",
+        r.row_count
+    );
+    assert!(r.executed_sparql.contains("sq-8thu"));
+}
+
+#[test]
+fn raw_grounded_query_over_real_pkg_is_grounded_with_no_hints() {
+    // A raw count over the real Task class: every term grounds, confidence `Grounded`.
+    let g = load_pkg().expect("PKG loads");
+    let r = nl_tool::run_raw(
+        &g,
+        "PREFIX pkg: <https://sparq.dev/ns/pkg#>\n\
+         SELECT (COUNT(?t) AS ?n) WHERE { ?t a pkg:Task }",
+    )
+    .expect("runs");
+    assert_eq!(r.confidence, Confidence::Grounded);
+    assert!(r.ungrounded_iris.is_empty());
+    assert!(r.hints.is_empty());
+    assert_eq!(r.row_count, 1);
+}
+
+#[test]
+fn raw_ungrounded_query_lowers_confidence_and_surfaces_provenance() {
+    // A plausible-but-wrong predicate (`pkg:dependsUpon`, not the real `pkg:dependsOn`):
+    // the tool does NOT silently answer — it flags the ungrounded term, lowers the
+    // confidence, and surfaces same-namespace hints so the agent can re-ground.
+    let g = load_pkg().expect("PKG loads");
+    let r = nl_tool::run_raw(
+        &g,
+        "PREFIX pkg: <https://sparq.dev/ns/pkg#>\n\
+         SELECT ?a ?b WHERE { ?a pkg:dependsUpon ?b }",
+    )
+    .expect("the query is valid, just ungrounded");
+    assert_eq!(r.confidence, Confidence::Ungrounded);
+    assert_eq!(
+        r.ungrounded_iris,
+        vec!["https://sparq.dev/ns/pkg#dependsUpon".to_string()]
+    );
+    // The real `pkg:dependsOn` predicate is in the same namespace, so it surfaces as a
+    // repair hint.
+    assert!(
+        r.hints
+            .iter()
+            .any(|h| h == "https://sparq.dev/ns/pkg#dependsOn"),
+        "expected pkg:dependsOn hint; got {:?}",
+        r.hints
+    );
+    // Honest "none" answer, computed not guessed.
+    assert_eq!(r.row_count, 0);
+}
+
+#[test]
+fn json_envelope_round_trips_over_real_pkg() {
+    // The JSON the agent-flavor sub-agent emits must parse back identical (the wire
+    // contract between the cheap-model sub-agent and the orchestrator).
+    let g = load_pkg().expect("PKG loads");
+    let r = nl_tool::run_canned(&g, "finding-provenance", None).expect("runs");
+    let json = r.to_json();
+    let back: nl_tool::NlToolResult = serde_json::from_str(&json).expect("round-trips");
+    assert_eq!(back, r);
+    // Findings exist in the ingest, so the answer is non-empty + sourced.
+    assert!(
+        r.row_count >= 6,
+        "expected the AGENTS.md finding slice; got {}",
+        r.row_count
+    );
+}
+
+#[test]
+fn unknown_canned_name_is_an_error_not_a_silent_guess() {
+    let g = load_pkg().expect("PKG loads");
+    let err = nl_tool::run_canned(&g, "no-such-canned-query", None).unwrap_err();
+    assert!(err.contains("no canned query named"), "{err}");
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bead **sq-ve5dy** (epic sq-2m6zm), surface **sparq-nlq/PKG**. Written while Fable unavailable; flag for re-review when Fable returns. [OPUS-4.8]

## What this implements

The maintainer reframe (2026-06-21) of PKG access as a **natural-language tool call**: a cheap model (Haiku/Sonnet) does the whole round-trip — NL question → introspect/ground → SPARQL → run via `pkg-query` → result rows → concise NL answer — so the expensive orchestrator only emits the question and reads the NL answer. It never sees the schema card, the SPARQL, or the raw rows.

This ships the **AGENT flavor** (immediate, no API key), as the bead directs ("build the agent flavor first").

### The sound core (opt-in, behind the existing default-OFF `query` feature)

`crates/sparq-kb/src/query/nl_tool.rs` — `run_canned` / `run_raw` → `NlToolResult`, which **always** carries the soundness guardrail the bead requires:

| field | meaning |
|---|---|
| `answer` | deterministic engine-computed summary (the cheap model rephrases it) |
| `executed_sparql` | the exact query that ran — re-runnable to verify |
| `resolved_iris` | every predicate / `rdf:type` class IRI the query relied on (algebra walk) |
| `ungrounded_iris` | the subset absent from the live dictionary (matched no triples) |
| `hints` | edit-distance-ranked same-namespace repair candidates for each ungrounded IRI |
| `row_count` | rows returned (0 = the honest "none" answer) |
| `confidence` | `canned` / `grounded` / `ungrounded` |

The tool **never silently answers from a guessed query**: the envelope lets the caller verify the answer was computed by the engine, not fabricated. An ungrounded term lowers confidence and is surfaced (with hints) rather than swallowed.

### The agent flavor (no API key)

- `pkg-query --json` emits the `NlToolResult` envelope (the structured-output contract).
- `.claude/agents/sparq-pkg-nl.md` is the **`model: haiku`** sub-agent that drives `pkg-query`, does the round-trip, and returns the answer + provenance block.

## Design/judgment decisions (STANDING RULE — proceeded without greenlight; steer post-hoc)

1. **`confidence` is a query-GROUNDING signal, not an answer-correctness claim.** We have no gold answer to score against in the agent flavor, so claiming answer-correctness would be dishonest. `canned` = curated/verified-expressible template; `grounded` = every term exists in the data; `ungrounded` = a term the data lacks. This is the most honest signal derivable without a gold set.
2. **Agent flavor only; PRODUCT flavor deferred.** The product flavor (sparq calling a configurable cheap-model endpoint as a real GenAI integration) needs sparq's own Anthropic API key — an external-credential dependency this autonomous slice cannot satisfy. Designed on `sparq-nlq` + the `V()` surface, left to a follow-up bead.
3. **Lives in `sparq-kb` behind the existing `query` feature**, not a new crate: it builds directly on the committed `pkg-query` infrastructure (sq-2m6zm.3) and reuses the `sparq-nlq::constrain`-style algebra walk. `sparq-core`/`sparq-engine` stay lean.

A short GitHub issue will be opened flagging decisions (1)/(2) for the maintainer to steer.

## Feature flags + gates (run in-worktree)

Opt-in: all new surface is behind the default-OFF **`query`** feature (and the `--close`/`close` feature for the closure path). Default `cargo build` of sparq-kb stays a pure data + constants crate.

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — **green in BOTH states**: default (feature OFF) AND `--features query` and `--features close`.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — **clean** (fixed module-doc intra-links to plain code spans).
- Tests exercise the **REAL ingested PKG** (`crates/sparq-kb/tests/nl_tool.rs`), including the load-bearing invariant: the envelope is sound, an ungrounded query is flagged not answered, the JSON wire contract round-trips.
- `typos`, `check-privacy-claims.sh`, `check-no-perf-numbers.py`, `check-readme-template.py --enforce` (README 105 lines, 0 deviations) — all clean.
- No hard-coded perf numbers; whether this cuts model-price-weighted cost is **measured by sq-2m6zm.4 / sq-jgi97**, not claimed here.

## Files

- `crates/sparq-kb/src/query/nl_tool.rs` (new) · `crates/sparq-kb/tests/nl_tool.rs` (new)
- `crates/sparq-kb/src/bin/pkg_query.rs` (`--json`) · `crates/sparq-kb/src/lib.rs` (module wiring) · `crates/sparq-kb/Cargo.toml`
- `.claude/agents/sparq-pkg-nl.md` (new, `model: haiku`)
- `.claude/skills/query-pkg/SKILL.md` · `crates/sparq-kb/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)