### PR TITLE
feat(site): import & query Verifiable Credentials in-tab (sq-3p0z, #822) [OPUS-4.8]

### DIFF
--- a/site/src/app/showcase/verifiable-credentials/page.tsx
+++ b/site/src/app/showcase/verifiable-credentials/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowLeft, ExternalLink } from "lucide-react";
+
+// [OPUS-4.8] sq-3p0z (#822) — the Verifiable-Credentials import-and-query surface.
+//
+// Built DEMO-FIRST (research/website-redesign.md §4): a minimal header → the live import +
+// query workbench immediately → a one-line caption → the import-vs-verify honesty behind a
+// closed <details>. The "live · in your tab" tier and the "imported, not verified" qualifier
+// stay VISIBLE in the header badges (privacy-claims gate); the full detail relocates into the
+// disclosure. The realised proposal lives in research/gui-design.md §2b.
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { VerifiableCredentials } from "@/components/verifiable-credentials";
+
+export const metadata: Metadata = {
+  title: "Import & query Verifiable Credentials",
+  description:
+    "Drag-drop, paste or fetch a W3C Verifiable Credential and run SPARQL over its claims — the sparq engine compiled to WebAssembly, entirely in your browser tab. Importing and querying is live; cryptographic verification and zero-knowledge proofs are the separate research-grade ZK estate (not externally audited).",
+};
+
+const REPO_URL = "https://github.com/jeswr/sparq";
+
+export default function VerifiableCredentialsPage() {
+  return (
+    <div className="space-y-6">
+      <Button variant="ghost" size="sm" asChild className="-ml-2">
+        <Link href="/examples">
+          <ArrowLeft className="size-4" aria-hidden="true" />
+          Back to examples
+        </Link>
+      </Button>
+
+      {/* Minimal header: title + the live tier + the import-vs-verify qualifier (the full
+          honesty hedge moves into the caveat disclosure below). */}
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold tracking-tight">
+          Import &amp; query your Verifiable Credentials
+        </h1>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="success">Live in your tab — real SPARQL over your VCs</Badge>
+          <Badge variant="warning">Imported &amp; queried — not cryptographically verified</Badge>
+        </div>
+      </header>
+
+      {/* The workbench, immediately. */}
+      <VerifiableCredentials />
+
+      {/* One-line caption. */}
+      <p className="measure text-sm text-muted-foreground">
+        Drag in a credential (JSON-LD VC, Turtle, N-Quads), or paste / fetch one, and run real
+        SPARQL over its claims — joins across multiple credentials included — entirely in your
+        browser, with nothing sent to a server.
+      </p>
+
+      {/* The import-vs-verify honesty — behind a closed disclosure. */}
+      <details className="rounded-xl border bg-card px-4 py-3 text-sm">
+        <summary className="cursor-pointer select-none font-medium">
+          Details &amp; honest limits
+        </summary>
+        <div className="mt-3 space-y-3 text-muted-foreground">
+          <p>
+            A W3C Verifiable Credential is an RDF document — a JSON-LD document that maps to RDF
+            (parsed in-tab by the engine&rsquo;s JSON-LD reader), or one already serialised as
+            Turtle / N-Quads. So &ldquo;load it into a graph and query it&rdquo; is just the
+            existing ingest path, and runs live in your browser via the sparq engine compiled to
+            WebAssembly. Every imported credential is queried together, so you can join across
+            them (e.g. &ldquo;is the holder of this licence the same subject as this degree?&rdquo;).
+          </p>
+          <p>
+            <strong className="text-foreground">In-tab JSON-LD limit.</strong> The lean
+            browser bundle does not fetch a remote{" "}
+            <code className="font-mono">@context</code> — a JSON-LD credential that references the
+            W3C VC context only by URL must carry that context inline, be pre-expanded, or be
+            imported as Turtle / N-Quads. The desktop / server engine has no such limit.
+          </p>
+          <p>
+            <strong className="text-foreground">Querying is not verifying.</strong> This surface
+            does <strong className="text-foreground">not</strong> check a credential&rsquo;s
+            signature, its issuer, or its revocation status, and it produces no zero-knowledge
+            proof. SD-JWT-VC / JWT-VC envelopes are recognised but not decoded (they are not plain
+            RDF). VC <em>verification</em> and zero-knowledge proofs over credentials are the
+            separate sparq ZK estate, which is <strong className="text-foreground">research-grade
+            and not externally audited</strong> — an external accredited-cryptographer audit is
+            required before any ZK security, privacy or attestation claim may be relied upon
+            (tracked as <code className="font-mono">sq-qhy4</code>). Treat any future
+            &ldquo;verified&rdquo; affordance as a research demonstration, not a production
+            guarantee.
+          </p>
+          <p className="flex flex-wrap gap-4">
+            <a
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href={`${REPO_URL}/tree/main/crates/sparq-zk`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              sparq-zk on GitHub <ExternalLink className="size-3.5" />
+            </a>
+            <a
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href={`${REPO_URL}/blob/main/SECURITY.md`}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              SECURITY.md <ExternalLink className="size-3.5" />
+            </a>
+          </p>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/site/src/components/verifiable-credentials.tsx
+++ b/site/src/components/verifiable-credentials.tsx
@@ -1,0 +1,872 @@
+"use client";
+
+// [OPUS-4.8] sq-3p0z (#822) — the Verifiable-Credentials import-and-query workbench.
+//
+// The maintainer's ask (#822, research/gui-design.md §2b): "import VCs (drag-drop or URL) and
+// run SPARQL queries over them." A W3C Verifiable Credential is an RDF document (a JSON-LD doc
+// that maps to RDF, or already Turtle / N-Quads), so the base capability — load it into a graph
+// and query it — is JUST the existing in-tab WASM ingest path, and is `live` today. This
+// component is the IMPORT SURFACE: a drag-drop zone, a file picker, a paste box, and a URL
+// fetch, plus a credentials list showing each imported VC's recognised envelope, issuer and
+// subject — then the shared SPARQL editor + result table running over the union of every
+// imported credential, entirely in your browser tab.
+//
+// HONESTY (the load-bearing distinction). *Querying* over VC triples is `live`. This surface
+// does NOT cryptographically verify a VC's signature, nor produce any zero-knowledge proof —
+// that is the separate research-grade ZK estate (sparq-zk), which is internally re-audited and
+// NOT externally audited (sq-qhy4). SD-JWT-VC / JWT-VC envelopes are RECOGNISED (so the user
+// is told they are JWT-wrapped and need decoding/verification first), never silently mis-parsed.
+// The page never presents "verified" or any ZK property as a guarantee.
+
+import * as React from "react";
+import {
+  FileLock2,
+  Upload,
+  Link2,
+  ClipboardPaste,
+  Play,
+  Loader2,
+  X,
+  CheckCircle2,
+  AlertTriangle,
+  ShieldQuestion,
+  Trash2,
+  FilePlus2,
+} from "lucide-react";
+import { toast } from "sonner";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { withBasePath } from "@/lib/base-path";
+import { SparqlEditor } from "@/components/sparql-editor";
+import {
+  loadSparq,
+  loadIntoStore,
+  storeToNQuads,
+  datasetSize,
+  extractTable,
+  type SparqlResults,
+  type WasmStore,
+} from "@/lib/sparq-wasm";
+import { classifyQueryForm } from "@/lib/repl-dataset";
+import {
+  SAMPLE_CREDENTIALS,
+  SAMPLE_QUERIES,
+  VC_FORMAT_OPTIONS,
+  vcFormatFromName,
+  looksLikeJwtVc,
+  type VcFormat,
+} from "@/data/verifiable-credentials";
+
+// ── Model ───────────────────────────────────────────────────────────────────────────────────
+
+/** One imported credential: its source, the format it parsed as, and a few derived facts. */
+interface ImportedCredential {
+  /** Unique key (timestamp + counter) so React lists are stable across re-imports. */
+  key: string;
+  label: string;
+  source: string;
+  format: VcFormat;
+  /** How it arrived (drives the small origin tag). */
+  origin: "sample" | "file" | "paste" | "url";
+  /** Triples this credential contributes (counted at parse time). */
+  triples: number;
+  /** Issuer IRI, if the credential states one (cred:issuer). */
+  issuer: string | null;
+  /** Subject id (credentialSubject id / a Person identifier), if present. */
+  subject: string | null;
+}
+
+type QueryState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "select"; results: SparqlResults; ms: number }
+  | { kind: "boolean"; value: boolean; ms: number }
+  | { kind: "graph"; ntriples: string; triples: number; ms: number }
+  | { kind: "error"; message: string };
+
+// Lightweight introspection queries to surface a credential's issuer + subject in the list.
+// Run against an EPHEMERAL store holding only that one credential, so the facts are per-VC.
+const ISSUER_QUERY =
+  "PREFIX cred: <https://www.w3.org/2018/credentials#> SELECT ?i WHERE { ?c cred:issuer ?i } LIMIT 1";
+// The W3C VC 2.0 (v2 context) subject predicate expands to the credentials/v2 IRI; the older
+// 2018 vocabulary uses cred:credentialSubject. We also fall back to a schema.org identifier.
+const SUBJECT_QUERY = `PREFIX cred: <https://www.w3.org/2018/credentials#>
+PREFIX cred2: <https://www.w3.org/ns/credentials/issuer-dependent#>
+PREFIX sch: <https://schema.org/>
+SELECT ?s WHERE {
+  { ?c <https://www.w3.org/2018/credentials#credentialSubject> ?s }
+  UNION { ?c <https://www.w3.org/ns/credentials#credentialSubject> ?s }
+  UNION { ?subject sch:identifier ?s }
+} LIMIT 1`;
+
+/** First binding's single value, or null — for the per-credential introspection queries. */
+function firstValue(store: WasmStore, query: string): string | null {
+  try {
+    const parsed = JSON.parse(store.query(query)) as SparqlResults;
+    const row = parsed.results?.bindings?.[0];
+    if (!row) return null;
+    const term = Object.values(row)[0];
+    return term?.value ?? null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Component ───────────────────────────────────────────────────────────────────────────────
+
+let importCounter = 0;
+function nextKey(): string {
+  importCounter += 1;
+  return `vc-${Date.now()}-${importCounter}`;
+}
+
+export function VerifiableCredentials() {
+  const [creds, setCreds] = React.useState<ImportedCredential[]>([]);
+  const [query, setQuery] = React.useState<string>(SAMPLE_QUERIES[0].sparql);
+  const [state, setState] = React.useState<QueryState>({ kind: "idle" });
+  const [seeded, setSeeded] = React.useState(false);
+
+  // Parse one RDF/JSON-LD document into an ephemeral store and derive its per-VC facts. Throws
+  // a clear Error on a parse failure so the caller can surface it (and abort the import).
+  const describe = React.useCallback(
+    async (
+      label: string,
+      source: string,
+      format: VcFormat,
+      origin: ImportedCredential["origin"],
+    ): Promise<ImportedCredential> => {
+      const Store = await loadSparq();
+      const store = loadIntoStore(Store, source, format);
+      return {
+        key: nextKey(),
+        label,
+        source,
+        format,
+        origin,
+        triples: datasetSize(store),
+        issuer: firstValue(store, ISSUER_QUERY),
+        subject: firstValue(store, SUBJECT_QUERY),
+      };
+    },
+    [],
+  );
+
+  // Seed the two sample credentials on first mount so the surface shows it working before the
+  // user imports their own. Best-effort: a wasm load hiccup leaves the list empty (the import
+  // affordances still work), it never throws into render.
+  React.useEffect(() => {
+    if (seeded) return;
+    let cancelled = false;
+    setSeeded(true);
+    (async () => {
+      const out: ImportedCredential[] = [];
+      for (const s of SAMPLE_CREDENTIALS) {
+        try {
+          out.push(await describe(s.label, s.source, s.format, "sample"));
+        } catch {
+          // Skip a sample that fails to parse; the rest still seed.
+        }
+      }
+      if (!cancelled) setCreds(out);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [seeded, describe]);
+
+  // Add a document to the credentials list (parsing + introspection happen here). Rejects a
+  // JWT-shaped envelope with an explanation rather than mis-parsing it as RDF.
+  const addDocument = React.useCallback(
+    async (
+      label: string,
+      source: string,
+      format: VcFormat,
+      origin: ImportedCredential["origin"],
+    ) => {
+      const trimmed = source.trim();
+      if (!trimmed) return;
+      if ((format === "jsonld" || origin === "paste") && looksLikeJwtVc(trimmed)) {
+        toast.error("That looks like a JWT-wrapped VC", {
+          description:
+            "SD-JWT-VC / JWT-VC envelopes are not plain RDF — they must be decoded (and their proof verified) before their claims can be queried as triples. That is the separate, not-externally-audited crypto estate.",
+        });
+        return;
+      }
+      try {
+        const cred = await describe(label, trimmed, format, origin);
+        setCreds((prev) => [...prev, cred]);
+        toast.success(`Imported ${label}`, {
+          description: `${cred.triples.toLocaleString()} triple${cred.triples === 1 ? "" : "s"} added — query it below.`,
+        });
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        // The lean in-tab bundle has no remote-context loader, so a JSON-LD VC that references
+        // its @context only by URL fails here. Explain the fix rather than leak the raw error.
+        const remoteContext = /remote context|LoadDocumentCallback/i.test(message);
+        toast.error("Could not parse the credential", {
+          description: remoteContext
+            ? "This JSON-LD credential references a remote @context by URL, which the in-tab engine does not fetch. Inline the @context terms, pre-expand the document, or import it as Turtle / N-Quads."
+            : message,
+        });
+      }
+    },
+    [describe],
+  );
+
+  const removeCredential = React.useCallback((key: string) => {
+    setCreds((prev) => prev.filter((c) => c.key !== key));
+  }, []);
+
+  const clearAll = React.useCallback(() => {
+    setCreds([]);
+    setState({ kind: "idle" });
+  }, []);
+
+  // Run the SPARQL query over the UNION of every imported credential. Each credential's RDF is
+  // re-serialised to N-Quads and concatenated, then loaded once via loadDataset — so named
+  // graphs survive and the query sees all credentials together, exactly like the REPL's merge.
+  const runQuery = React.useCallback(async () => {
+    if (creds.length === 0) {
+      toast.error("No credentials imported", {
+        description: "Import a VC (drag-drop, paste or URL) before querying.",
+      });
+      return;
+    }
+    setState({ kind: "running" });
+    try {
+      const Store = await loadSparq();
+      // Build the combined store from every credential's N-Quads.
+      let combined = "";
+      for (const c of creds) {
+        const one = loadIntoStore(Store, c.source, c.format);
+        combined += storeToNQuads(one) + "\n";
+      }
+      const store = loadIntoStore(Store, combined, "nquads");
+
+      const form = classifyQueryForm(query);
+      const t0 = performance.now();
+      if (form === "construct" || form === "describe") {
+        const ntriples = store.queryQuads(query).trim();
+        const triples = ntriples === "" ? 0 : ntriples.split("\n").length;
+        setState({ kind: "graph", ntriples, triples, ms: performance.now() - t0 });
+        return;
+      }
+      if (form === "update") {
+        throw new Error(
+          "This surface is read-only over imported credentials — SPARQL Update is not supported here. Use SELECT / ASK / CONSTRUCT / DESCRIBE.",
+        );
+      }
+      const json = store.query(query);
+      const ms = performance.now() - t0;
+      const parsed = JSON.parse(json) as SparqlResults;
+      if (typeof parsed.boolean === "boolean") {
+        setState({ kind: "boolean", value: parsed.boolean, ms });
+      } else {
+        setState({ kind: "select", results: parsed, ms });
+      }
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setState({ kind: "error", message });
+      toast.error("Query failed", { description: message });
+    }
+  }, [creds, query]);
+
+  const totalTriples = creds.reduce((n, c) => n + c.triples, 0);
+
+  return (
+    <div className="space-y-6">
+      <div className="grid gap-6 lg:grid-cols-2">
+        <ImportPanel onAdd={addDocument} />
+        <CredentialsList
+          creds={creds}
+          totalTriples={totalTriples}
+          onRemove={removeCredential}
+          onClear={clearAll}
+        />
+      </div>
+
+      <QueryPanel
+        query={query}
+        onQuery={setQuery}
+        onRun={runQuery}
+        running={state.kind === "running"}
+        disabled={creds.length === 0}
+      />
+
+      <ResultPanel state={state} />
+
+      <HonestyNote />
+    </div>
+  );
+}
+
+// ── Import panel: drag-drop + file + paste + URL ──────────────────────────────────────────────
+
+type ImportTab = "drop" | "paste" | "url";
+
+function ImportPanel({
+  onAdd,
+}: {
+  onAdd: (
+    label: string,
+    source: string,
+    format: VcFormat,
+    origin: ImportedCredential["origin"],
+  ) => void;
+}) {
+  const [tab, setTab] = React.useState<ImportTab>("drop");
+  const [dragOver, setDragOver] = React.useState(false);
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  // Paste tab.
+  const [pasteText, setPasteText] = React.useState("");
+  const [pasteFormat, setPasteFormat] = React.useState<VcFormat>("jsonld");
+  // URL tab.
+  const [url, setUrl] = React.useState("");
+  const [fetching, setFetching] = React.useState(false);
+
+  const ingestFiles = React.useCallback(
+    async (files: FileList | File[]) => {
+      for (const file of Array.from(files)) {
+        try {
+          const text = await file.text();
+          onAdd(file.name, text, vcFormatFromName(file.name), "file");
+        } catch (e) {
+          toast.error(`Could not read ${file.name}`, {
+            description: e instanceof Error ? e.message : String(e),
+          });
+        }
+      }
+    },
+    [onAdd],
+  );
+
+  const onDrop = React.useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragOver(false);
+      const dt = e.dataTransfer;
+      if (dt.files && dt.files.length > 0) {
+        void ingestFiles(dt.files);
+        return;
+      }
+      // A drag of selected text (not a file) — treat it as a pasted document.
+      const text = dt.getData("text/plain");
+      if (text.trim()) {
+        onAdd("dropped text", text, looksLikeJwtVc(text) ? "jsonld" : "turtle", "paste");
+      }
+    },
+    [ingestFiles, onAdd],
+  );
+
+  const importUrl = React.useCallback(async () => {
+    const target = url.trim();
+    if (!target) return;
+    setFetching(true);
+    try {
+      const res = await fetch(target);
+      if (!res.ok) throw new Error(`HTTP ${res.status} ${res.statusText}`);
+      const body = await res.text();
+      const fmt = formatFromContentType(res.headers.get("content-type")) ?? vcFormatFromName(target);
+      onAdd(urlLabel(target), body, fmt, "url");
+      setUrl("");
+    } catch (e) {
+      toast.error("Fetch failed", {
+        description: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      setFetching(false);
+    }
+  }, [url, onAdd]);
+
+  return (
+    <Card>
+      <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Upload className="size-4 text-primary" />
+          Import a Verifiable Credential
+        </CardTitle>
+        <Badge variant="success">Live · in your tab</Badge>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <div className="flex border-b text-xs" role="tablist" aria-label="Import method">
+          <ImportTabButton id="drop" current={tab} onSelect={setTab} icon={FilePlus2} label="Drag-drop / file" />
+          <ImportTabButton id="paste" current={tab} onSelect={setTab} icon={ClipboardPaste} label="Paste" />
+          <ImportTabButton id="url" current={tab} onSelect={setTab} icon={Link2} label="URL" />
+        </div>
+
+        {tab === "drop" && (
+          <div className="space-y-2">
+            <div
+              data-vc-dropzone
+              onDragOver={(e) => {
+                e.preventDefault();
+                setDragOver(true);
+              }}
+              onDragLeave={() => setDragOver(false)}
+              onDrop={onDrop}
+              onClick={() => fileInputRef.current?.click()}
+              role="button"
+              tabIndex={0}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  fileInputRef.current?.click();
+                }
+              }}
+              aria-label="Drop a credential file here or click to choose one"
+              className={cn(
+                "flex cursor-pointer flex-col items-center justify-center gap-2 rounded-lg border-2 border-dashed p-8 text-center transition-colors",
+                dragOver
+                  ? "border-primary bg-primary/5 text-foreground"
+                  : "border-foreground/15 text-muted-foreground hover:border-primary/50 hover:text-foreground",
+              )}
+            >
+              <Upload className="size-6" aria-hidden />
+              <p className="text-sm font-medium">
+                Drop a VC file here, or click to choose
+              </p>
+              <p className="text-xs">
+                JSON-LD VC, Turtle, N-Quads, TriG or N-Triples — parsed in your browser.
+              </p>
+              <p className="text-[11px] text-muted-foreground/80">
+                In-tab JSON-LD needs an inline <code className="font-mono">@context</code> (no
+                remote context fetch); or import the VC as Turtle / N-Quads.
+              </p>
+            </div>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".jsonld,.json,.ttl,.turtle,.nq,.nquads,.trig,.nt,.ntriples,application/ld+json,text/turtle"
+              multiple
+              className="sr-only"
+              onChange={(e) => {
+                if (e.target.files) void ingestFiles(e.target.files);
+                e.target.value = "";
+              }}
+            />
+          </div>
+        )}
+
+        {tab === "paste" && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-2">
+              <label htmlFor="vc-paste-format" className="text-xs font-medium text-muted-foreground">
+                Format
+              </label>
+              <select
+                id="vc-paste-format"
+                value={pasteFormat}
+                onChange={(e) => setPasteFormat(e.target.value as VcFormat)}
+                className="rounded-md border bg-background px-2 py-1 text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              >
+                {VC_FORMAT_OPTIONS.map((f) => (
+                  <option key={f.value} value={f.value}>
+                    {f.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <textarea
+              value={pasteText}
+              onChange={(e) => setPasteText(e.target.value)}
+              placeholder={'{ "@context": "https://www.w3.org/ns/credentials/v2", "type": ["VerifiableCredential"], … }'}
+              spellCheck={false}
+              className="h-40 w-full resize-y rounded-md border bg-background px-3 py-2 font-mono text-xs outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+            />
+            <Button
+              size="sm"
+              disabled={!pasteText.trim()}
+              onClick={() => {
+                onAdd("pasted credential", pasteText, pasteFormat, "paste");
+                setPasteText("");
+              }}
+            >
+              <FilePlus2 className="size-4" /> Add pasted credential
+            </Button>
+          </div>
+        )}
+
+        {tab === "url" && (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground">
+              Fetch a credential document from a URL (the format is auto-detected from the
+              served <code className="font-mono">Content-Type</code> or the extension). The
+              host must allow the cross-origin request.
+            </p>
+            <div className="flex gap-2">
+              <input
+                type="url"
+                inputMode="url"
+                placeholder="https://example.org/credential.jsonld"
+                value={url}
+                onChange={(e) => setUrl(e.target.value)}
+                className="w-full rounded-md border bg-background px-3 py-2 text-sm outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+              />
+              <Button size="sm" disabled={!url.trim() || fetching} onClick={importUrl}>
+                {fetching ? <Loader2 className="size-4 animate-spin" /> : <Link2 className="size-4" />}
+                Fetch
+              </Button>
+            </div>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function ImportTabButton({
+  id,
+  current,
+  onSelect,
+  icon: Icon,
+  label,
+}: {
+  id: ImportTab;
+  current: ImportTab;
+  onSelect: (t: ImportTab) => void;
+  icon: typeof FilePlus2;
+  label: string;
+}) {
+  const active = id === current;
+  return (
+    <button
+      role="tab"
+      aria-selected={active}
+      data-vc-import-tab={id}
+      onClick={() => onSelect(id)}
+      className={cn(
+        "flex flex-1 items-center justify-center gap-1.5 border-b-2 px-3 py-2 font-medium",
+        active
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:text-foreground",
+      )}
+    >
+      <Icon className="size-3.5" /> {label}
+    </button>
+  );
+}
+
+// Map a response Content-Type to the engine format (kept local — small + VC-specific).
+function formatFromContentType(contentType: string | null): VcFormat | undefined {
+  if (!contentType) return undefined;
+  const mime = contentType.split(";")[0].trim().toLowerCase();
+  const map: Record<string, VcFormat> = {
+    "application/ld+json": "jsonld",
+    "application/json": "jsonld",
+    "text/turtle": "turtle",
+    "application/n-quads": "nquads",
+    "application/trig": "trig",
+    "application/n-triples": "ntriples",
+  };
+  return map[mime];
+}
+
+/** A short, readable label for a URL (last path segment, or the host). */
+function urlLabel(url: string): string {
+  try {
+    const u = new URL(url);
+    const last = u.pathname.split("/").filter(Boolean).pop();
+    return last || u.host;
+  } catch {
+    return url;
+  }
+}
+
+// ── Credentials list ──────────────────────────────────────────────────────────────────────────
+
+function CredentialsList({
+  creds,
+  totalTriples,
+  onRemove,
+  onClear,
+}: {
+  creds: ImportedCredential[];
+  totalTriples: number;
+  onRemove: (key: string) => void;
+  onClear: () => void;
+}) {
+  return (
+    <Card data-vc-list>
+      <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <FileLock2 className="size-4 text-primary" />
+          Imported credentials
+        </CardTitle>
+        <div className="flex items-center gap-2">
+          <Badge variant="muted" className="tabular" data-vc-count>
+            {creds.length} · {totalTriples.toLocaleString()} triples
+          </Badge>
+          {creds.length > 0 && (
+            <Button variant="ghost" size="icon" aria-label="Clear all credentials" onClick={onClear}>
+              <Trash2 className="size-4" />
+            </Button>
+          )}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-2">
+        {creds.length === 0 ? (
+          <p className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+            No credentials imported yet. Drag-drop a VC file, paste one, or fetch it from a URL —
+            then query it below.
+          </p>
+        ) : (
+          <ul className="space-y-2">
+            {creds.map((c) => (
+              <li
+                key={c.key}
+                data-vc-cred
+                className="flex items-start gap-3 rounded-lg border bg-card p-3"
+              >
+                <FileLock2 className="mt-0.5 size-4 shrink-0 text-muted-foreground" />
+                <div className="min-w-0 flex-1 space-y-1">
+                  <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                    <span className="truncate text-sm font-medium">{c.label}</span>
+                    <Badge variant="outline" className="h-4 px-1.5 text-[10px] uppercase">
+                      {c.format}
+                    </Badge>
+                    <span className="text-[11px] text-muted-foreground">
+                      {c.origin} · {c.triples.toLocaleString()} triples
+                    </span>
+                  </div>
+                  {c.issuer && (
+                    <p className="truncate font-mono text-[11px] text-muted-foreground">
+                      issuer: {c.issuer}
+                    </p>
+                  )}
+                  {c.subject && (
+                    <p className="truncate font-mono text-[11px] text-muted-foreground">
+                      subject: {c.subject}
+                    </p>
+                  )}
+                </div>
+                <button
+                  onClick={() => onRemove(c.key)}
+                  aria-label={`Remove ${c.label}`}
+                  className="shrink-0 text-muted-foreground hover:text-foreground"
+                >
+                  <X className="size-4" />
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Query panel ─────────────────────────────────────────────────────────────────────────────
+
+function QueryPanel({
+  query,
+  onQuery,
+  onRun,
+  running,
+  disabled,
+}: {
+  query: string;
+  onQuery: (q: string) => void;
+  onRun: () => void;
+  running: boolean;
+  disabled: boolean;
+}) {
+  return (
+    <Card>
+      <CardHeader className="space-y-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Play className="size-4 text-primary" />
+          Query the imported credentials
+        </CardTitle>
+        <div className="flex flex-wrap gap-1.5" role="group" aria-label="Example queries">
+          {SAMPLE_QUERIES.map((q) => (
+            <Button
+              key={q.id}
+              variant="outline"
+              size="sm"
+              title={q.blurb}
+              onClick={() => onQuery(q.sparql)}
+            >
+              {q.label}
+            </Button>
+          ))}
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <SparqlEditor value={query} onChange={onQuery} rows={9} ariaLabel="SPARQL query over imported credentials" />
+        <div className="flex items-center gap-3">
+          <Button onClick={onRun} disabled={running || disabled} data-vc-run>
+            {running ? <Loader2 className="size-4 animate-spin" /> : <Play className="size-4" />}
+            Run query
+          </Button>
+          <p className="text-xs text-muted-foreground">
+            SELECT / ASK / CONSTRUCT / DESCRIBE over the union of every imported credential,
+            executed in your browser tab.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ── Result panel ────────────────────────────────────────────────────────────────────────────
+
+function ResultPanel({ state }: { state: QueryState }) {
+  if (state.kind === "idle") return null;
+  if (state.kind === "running") {
+    return (
+      <Card>
+        <CardContent className="flex items-center gap-2 pt-5 text-sm text-muted-foreground">
+          <Loader2 className="size-4 animate-spin" /> Running the query in your tab…
+        </CardContent>
+      </Card>
+    );
+  }
+  if (state.kind === "error") {
+    return (
+      <Card className="ring-destructive/30">
+        <CardContent className="pt-5">
+          <pre
+            data-vc-result="error"
+            className="overflow-x-auto rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive"
+          >
+            {state.message}
+          </pre>
+        </CardContent>
+      </Card>
+    );
+  }
+  return (
+    <Card data-vc-result={state.kind}>
+      <CardHeader className="flex-row items-center justify-between gap-2 space-y-0">
+        <CardTitle className="text-base">Result</CardTitle>
+        <Badge variant="muted" className="tabular">
+          {state.ms.toFixed(1)} ms · in your tab
+        </Badge>
+      </CardHeader>
+      <CardContent>
+        {state.kind === "boolean" ? (
+          <div
+            className={cn(
+              "rounded-lg p-4 text-center text-2xl font-semibold",
+              state.value
+                ? "bg-[color-mix(in_oklch,var(--success)_14%,transparent)] text-[var(--success)]"
+                : "bg-muted text-muted-foreground",
+            )}
+          >
+            {state.value ? "true" : "false"}
+          </div>
+        ) : state.kind === "graph" ? (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground">
+              {state.triples.toLocaleString()} triple{state.triples === 1 ? "" : "s"} constructed.
+            </p>
+            <pre className="max-h-96 overflow-auto rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed">
+              {state.ntriples || "(empty graph)"}
+            </pre>
+          </div>
+        ) : (
+          <SelectTable results={state.results} />
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+function SelectTable({ results }: { results: SparqlResults }) {
+  const table = React.useMemo(() => extractTable(results), [results]);
+  if (table.rows.length === 0) {
+    return (
+      <p className="rounded-lg border bg-muted/30 p-3 text-sm text-muted-foreground">
+        No solutions.
+      </p>
+    );
+  }
+  return (
+    <div className="max-h-96 overflow-auto rounded-lg border">
+      <table className="w-full text-left text-sm">
+        <thead className="sticky top-0 bg-muted/80 backdrop-blur">
+          <tr>
+            {table.vars.map((v) => (
+              <th key={v} className="px-3 py-2 font-medium">
+                ?{v}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.rows.map((row, i) => (
+            <tr key={i} className="border-t">
+              {row.map((cell, j) => (
+                <td key={table.vars[j]} className="px-3 py-1.5 font-mono text-[12.5px]">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ── Honesty: import + query is live; verification / ZK is the separate, unaudited estate ───────
+
+function HonestyNote() {
+  return (
+    <Card className="ring-[var(--warning)]/30">
+      <CardHeader className="flex-row items-center gap-2 space-y-0">
+        <ShieldQuestion className="size-5 text-[var(--warning)]" />
+        <CardTitle className="text-base">Imported &amp; queryable — not verified</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3 text-sm text-muted-foreground">
+        <p className="flex items-start gap-2">
+          <CheckCircle2 className="mt-0.5 size-4 shrink-0 text-[var(--success)]" />
+          <span>
+            <strong className="text-foreground">What is live.</strong> Importing a Verifiable
+            Credential and running SPARQL over its claims is the real sparq engine, compiled to
+            WebAssembly and running entirely in your browser tab — a VC is RDF (JSON-LD that maps
+            to RDF, or already Turtle / N-Quads), so this is just the existing ingest path.
+            Nothing is sent to a server.
+          </span>
+        </p>
+        <p className="flex items-start gap-2">
+          <AlertTriangle className="mt-0.5 size-4 shrink-0 text-[var(--warning)]" />
+          <span>
+            <strong className="text-foreground">What is NOT done here.</strong> This surface does{" "}
+            <strong className="text-foreground">not</strong> cryptographically verify a
+            credential&rsquo;s signature, check its issuer or revocation status, nor produce any
+            zero-knowledge proof about it. Querying a claim is distinct from{" "}
+            <em>verifying</em> it. JWT-wrapped envelopes (SD-JWT-VC / JWT-VC) are recognised but
+            not parsed — they must be decoded and their proof verified first.
+          </span>
+        </p>
+        <p>
+          VC <em>verification</em> and zero-knowledge proofs over credentials are the separate
+          sparq ZK estate (<code className="font-mono">sparq-zk</code>). That estate is{" "}
+          <strong className="text-foreground">research-grade</strong>: internally re-audited but{" "}
+          <strong className="text-foreground">not externally audited</strong> — any timing or
+          gate count there is an indicative engineering number, not an audited cryptographic
+          guarantee, and external accredited-cryptographer sign-off is pending (
+          <code className="font-mono">sq-qhy4</code>). Treat any future &ldquo;verified&rdquo;
+          affordance accordingly. See the{" "}
+          <a
+            className="text-primary underline-offset-4 hover:underline"
+            href={withBasePath("/showcase/zk-car-hire")}
+          >
+            ZK car-hire demo
+          </a>{" "}
+          for a real (research-grade) zero-knowledge proof over credential data.
+        </p>
+      </CardContent>
+    </Card>
+  );
+}

--- a/site/src/data/examples.ts
+++ b/site/src/data/examples.ts
@@ -11,7 +11,7 @@
 // re-word of a flagship's title/blurb/tier in surfaces.ts flows straight into this gallery, the
 // Home "See it work" row, and Cmd-K together — no second source to drift.
 
-import { PlayCircle, type LucideIcon } from "lucide-react";
+import { PlayCircle, FileLock2, type LucideIcon } from "lucide-react";
 
 import { FLAGSHIPS, type Tier } from "@/data/surfaces";
 
@@ -59,5 +59,19 @@ const REPL_CARD: ExampleCard = {
   flagship: false,
 };
 
-/** The curated example gallery: the 3 flagships + the live REPL, in display order. */
-export const EXAMPLE_CARDS: ExampleCard[] = [...FLAGSHIP_CARDS, REPL_CARD];
+// [OPUS-4.8] sq-3p0z (#822) — the Verifiable-Credentials import-and-query demo. A `live`
+// data/query capability (not a privacy flagship — it does no crypto), so it sits beside the
+// REPL rather than in FLAGSHIPS: drag-drop / paste / fetch a VC and run SPARQL over its claims,
+// in-tab. The import-vs-verify honesty lives on the page itself (and in the page's caveat).
+const VC_CARD: ExampleCard = {
+  href: "/showcase/verifiable-credentials",
+  title: "Import & query Verifiable Credentials",
+  outcome:
+    "Drag in a W3C VC (JSON-LD / Turtle) and run real SPARQL over its claims — imported & queried in your tab (not verified).",
+  tier: "live",
+  icon: FileLock2,
+  flagship: false,
+};
+
+/** The curated example gallery: the 3 flagships + the live REPL + the VC import demo. */
+export const EXAMPLE_CARDS: ExampleCard[] = [...FLAGSHIP_CARDS, REPL_CARD, VC_CARD];

--- a/site/src/data/verifiable-credentials.ts
+++ b/site/src/data/verifiable-credentials.ts
@@ -1,0 +1,173 @@
+// [OPUS-4.8] sq-3p0z (#822) — fixture data for the Verifiable-Credentials import-and-query
+// surface (research/gui-design.md §2b "Verifiable-Credentials workspace").
+//
+// A W3C Verifiable Credential is an RDF document (a JSON-LD doc that maps to RDF, or already
+// Turtle / N-Quads), so "load it into a graph and query it" is JUST the existing in-tab WASM
+// ingest path — `live` today. These samples seed the surface so a reader sees it working
+// before importing their own; the import surface (drag-drop / paste / URL) loads ANY VC.
+//
+// HONESTY. These credentials are *imported and queried* — NOT cryptographically verified.
+// Recognising / querying a VC's claims is distinct from verifying its proof or producing a
+// zero-knowledge proof about it; that is the separate research-grade ZK estate (sparq-zk),
+// which is internally re-audited and NOT externally audited (sq-qhy4). The surface copy says
+// so, and the privacy-claims gate enforces it.
+
+/** The engine format string each sample / import parses as (the wasm `load`/`loadDataset`). */
+export type VcFormat = "jsonld" | "turtle" | "nquads" | "trig" | "ntriples";
+
+export interface SampleCredential {
+  /** Stable id + dropdown key. */
+  id: string;
+  /** Human label shown in the credentials list. */
+  label: string;
+  /** One-line description of what the credential asserts. */
+  blurb: string;
+  /** The RDF/JSON-LD source as the holder would receive it. */
+  source: string;
+  /** The engine format the source parses as. */
+  format: VcFormat;
+}
+
+// A W3C VC JSON-LD university-degree credential. JSON-LD maps to RDF via the engine's oxjsonld
+// parser (the lean wasm bundle ships the `jsonld` feature), so this is queryable as triples
+// with no pre-processing. IMPORTANT: the lean in-tab bundle has NO remote-context loader, so
+// the `@context` is fully INLINE here (a credential that references the W3C VC context only by
+// URL would need that context inlined or be supplied as Turtle/N-Quads — see the page caveat).
+// The inline terms expand to the standard cred:/schema: IRIs the example queries match on.
+const DEGREE_JSONLD = `{
+  "@context": {
+    "id": "@id",
+    "type": "@type",
+    "VerifiableCredential": "https://www.w3.org/2018/credentials#VerifiableCredential",
+    "UniversityDegreeCredential": "https://example.org/vc#UniversityDegreeCredential",
+    "issuer": { "@id": "https://www.w3.org/2018/credentials#issuer", "@type": "@id" },
+    "credentialSubject": { "@id": "https://www.w3.org/2018/credentials#credentialSubject", "@type": "@id" },
+    "degree": "https://example.org/vc#degree",
+    "name": "https://schema.org/name",
+    "alumniOf": "https://schema.org/alumniOf"
+  },
+  "id": "https://example.org/credentials/3732",
+  "type": ["VerifiableCredential", "UniversityDegreeCredential"],
+  "issuer": "https://university.example/issuers/565049",
+  "credentialSubject": {
+    "id": "did:example:ebfeb1f712ebc6f1c276e12ec21",
+    "name": "Ada Lovelace",
+    "degree": "BSc Computer Science",
+    "alumniOf": "Example University"
+  }
+}`;
+
+// A driving-licence VC as Turtle (the holder may receive a VC already serialised as RDF).
+// It shares the same subject DID as the degree credential, so a join across the two
+// imported credentials is queryable.
+const LICENCE_TURTLE = `@prefix cred: <https://www.w3.org/2018/credentials#> .
+@prefix sch:  <https://schema.org/> .
+@prefix ex:   <https://example.org/vc#> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+<https://example.org/credentials/dl-9981> a cred:VerifiableCredential , ex:DrivingLicenceCredential ;
+    cred:issuer    <https://dvla.example/issuers/1> ;
+    cred:validFrom "2023-01-01T00:00:00Z"^^xsd:dateTime ;
+    cred:credentialSubject [
+        a sch:Person ;
+        sch:identifier   "did:example:ebfeb1f712ebc6f1c276e12ec21" ;
+        ex:licenceClass  "B" ;
+        ex:validUntil    "2033-01-01"^^xsd:date ;
+        ex:revoked       false
+    ] .`;
+
+/** The seeded sample credentials a reader sees before importing their own. */
+export const SAMPLE_CREDENTIALS: SampleCredential[] = [
+  {
+    id: "degree",
+    label: "University degree (JSON-LD VC)",
+    blurb: "A W3C VC 2.0 university-degree credential, as the holder receives it (JSON-LD).",
+    source: DEGREE_JSONLD,
+    format: "jsonld",
+  },
+  {
+    id: "licence",
+    label: "Driving licence (Turtle VC)",
+    blurb: "A driving-licence credential serialised as Turtle, for the same subject DID.",
+    source: LICENCE_TURTLE,
+    format: "turtle",
+  },
+];
+
+export interface SampleQuery {
+  id: string;
+  label: string;
+  /** One-line description of what the query asks of the imported credentials. */
+  blurb: string;
+  sparql: string;
+}
+
+/** Starter SPARQL queries over the seeded credentials. The user can edit or replace them. */
+export const SAMPLE_QUERIES: SampleQuery[] = [
+  {
+    id: "list",
+    label: "List every imported credential",
+    blurb: "Every subject typed as a VerifiableCredential, with its issuer.",
+    sparql: `PREFIX cred: <https://www.w3.org/2018/credentials#>
+SELECT ?credential ?issuer WHERE {
+  ?credential a cred:VerifiableCredential ;
+              cred:issuer ?issuer .
+}`,
+  },
+  {
+    id: "claims",
+    label: "Read the degree credential's claims",
+    blurb: "The subject's name, degree and alma mater from the JSON-LD credential.",
+    sparql: `PREFIX sch: <https://schema.org/>
+PREFIX ex:  <https://example.org/vc#>
+SELECT ?name ?degree ?alumniOf WHERE {
+  ?subject sch:name ?name ;
+           ex:degree ?degree ;
+           sch:alumniOf ?alumniOf .
+}`,
+  },
+  {
+    id: "join",
+    label: "Same holder across two credentials (ASK)",
+    blurb: "Do the degree (JSON-LD) and the licence (Turtle) describe the same subject DID?",
+    sparql: `PREFIX sch: <https://schema.org/>
+ASK {
+  # the degree credential's subject DID
+  ?degreeSubject sch:name "Ada Lovelace" .
+  BIND("did:example:ebfeb1f712ebc6f1c276e12ec21" AS ?did)
+  FILTER(STR(?degreeSubject) = ?did)
+  # the licence credential's subject, identified by the same DID
+  ?licSubject sch:identifier ?did .
+}`,
+  },
+];
+
+// A subset of the in-tab WASM engine's loadable RDF/JSON-LD formats, for the import format
+// dropdown. JSON-LD is first because it is the canonical VC serialisation. (Kept here, beside
+// the surface that consumes it, rather than re-deriving the REPL's full list.)
+export const VC_FORMAT_OPTIONS: { value: VcFormat; label: string; exts: string[] }[] = [
+  { value: "jsonld", label: "JSON-LD VC (.jsonld / .json)", exts: ["jsonld", "json-ld", "json"] },
+  { value: "turtle", label: "Turtle (.ttl)", exts: ["ttl", "turtle"] },
+  { value: "nquads", label: "N-Quads (.nq)", exts: ["nq", "nquads"] },
+  { value: "trig", label: "TriG (.trig)", exts: ["trig"] },
+  { value: "ntriples", label: "N-Triples (.nt)", exts: ["nt", "ntriples"] },
+];
+
+/** Best-effort engine format from a filename, defaulting to JSON-LD (the VC default). */
+export function vcFormatFromName(name: string): VcFormat {
+  const ext = name.split(/[?#]/)[0].split(".").pop()?.toLowerCase() ?? "";
+  const hit = VC_FORMAT_OPTIONS.find((f) => f.exts.includes(ext));
+  return hit?.value ?? "jsonld";
+}
+
+/**
+ * Recognise a JWT-shaped VC envelope (`SD-JWT-VC` / `JWT-VC`): three base64url segments
+ * separated by dots, optionally with SD-JWT disclosures appended after a `~`. These envelopes
+ * are NOT plain RDF — the surface recognises them and explains they need decoding/verification
+ * (the separate ZK/crypto estate) before their claims can be queried as triples. It never
+ * pretends to parse or verify them.
+ */
+export function looksLikeJwtVc(text: string): boolean {
+  const head = text.trim().split("~")[0];
+  return /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/.test(head);
+}

--- a/site/test/verifiable-credentials.test.mjs
+++ b/site/test/verifiable-credentials.test.mjs
@@ -1,0 +1,71 @@
+// [OPUS-4.8] sq-3p0z (#822) — unit tests for the pure helpers behind the Verifiable-
+// Credentials import-and-query surface. These cover the framework-free decision logic
+// (format-from-filename + JWT-envelope recognition) and the integrity of the seeded
+// fixtures; the engine-level JSON-LD/Turtle parsing + SPARQL is already proven by the
+// Rust tests and js/test/store.test.mjs. Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  SAMPLE_CREDENTIALS,
+  SAMPLE_QUERIES,
+  VC_FORMAT_OPTIONS,
+  vcFormatFromName,
+  looksLikeJwtVc,
+} from "../src/data/verifiable-credentials.ts";
+
+test("vcFormatFromName maps filenames to the engine format, defaulting to JSON-LD", () => {
+  // JSON-LD is the canonical VC serialisation, so it is the default for unknown / .json.
+  assert.equal(vcFormatFromName("credential.jsonld"), "jsonld");
+  assert.equal(vcFormatFromName("credential.json"), "jsonld");
+  assert.equal(vcFormatFromName("credential.json-ld"), "jsonld");
+  assert.equal(vcFormatFromName("licence.ttl"), "turtle");
+  assert.equal(vcFormatFromName("data.nq"), "nquads");
+  assert.equal(vcFormatFromName("data.trig"), "trig");
+  assert.equal(vcFormatFromName("data.nt"), "ntriples");
+  // A query string / fragment must not defeat the extension sniff.
+  assert.equal(vcFormatFromName("https://ex.org/c.ttl?v=2#frag"), "turtle");
+  // Unknown extension → the JSON-LD default (a VC is most often JSON-LD).
+  assert.equal(vcFormatFromName("credential"), "jsonld");
+  assert.equal(vcFormatFromName("credential.bin"), "jsonld");
+});
+
+test("looksLikeJwtVc recognises JWT / SD-JWT-VC envelopes but not RDF/JSON-LD", () => {
+  // A bare three-segment JWT.
+  assert.equal(looksLikeJwtVc("eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIxMjMifQ.c2lnbmF0dXJl"), true);
+  // An SD-JWT-VC: a JWT followed by `~`-separated disclosures (+ optional trailing `~`).
+  assert.equal(
+    looksLikeJwtVc("eyJhbGciOiJFUzI1NiJ9.eyJ2YyI6e319.sig~WyJzYWx0IiwibmFtZSIsIkFkYSJd~"),
+    true,
+  );
+  // JSON-LD and Turtle are NOT JWT-shaped.
+  assert.equal(looksLikeJwtVc('{ "@context": "x", "type": "VerifiableCredential" }'), false);
+  assert.equal(looksLikeJwtVc("@prefix ex: <http://ex/> . ex:a ex:b ex:c ."), false);
+  assert.equal(looksLikeJwtVc(""), false);
+  // A two-segment token (not a full JWT) is not recognised as one.
+  assert.equal(looksLikeJwtVc("eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiIxMjMifQ"), false);
+});
+
+test("the seeded fixtures are internally consistent", () => {
+  // Two seeded sample credentials, each in a format the engine can load.
+  assert.equal(SAMPLE_CREDENTIALS.length, 2);
+  const formats = new Set(VC_FORMAT_OPTIONS.map((f) => f.value));
+  for (const c of SAMPLE_CREDENTIALS) {
+    assert.ok(c.source.trim().length > 0, `${c.id} has a non-empty source`);
+    assert.ok(formats.has(c.format), `${c.id} format ${c.format} is a known engine format`);
+  }
+  // The JSON-LD sample must inline its @context (the lean in-tab bundle fetches no remote
+  // context) — i.e. it must NOT reference the W3C VC context only by URL.
+  const jsonld = SAMPLE_CREDENTIALS.find((c) => c.format === "jsonld");
+  assert.ok(jsonld, "a JSON-LD sample exists");
+  assert.ok(
+    !/"@context"\s*:\s*\[?\s*"https?:\/\//.test(jsonld.source),
+    "the JSON-LD sample does not start its @context with a remote URL",
+  );
+
+  // Every sample query carries non-empty SPARQL.
+  assert.ok(SAMPLE_QUERIES.length >= 1);
+  for (const q of SAMPLE_QUERIES) {
+    assert.ok(q.sparql.trim().length > 0, `${q.id} has non-empty SPARQL`);
+  }
+});


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (site lane), running on Claude Opus 4.8. @jeswr runs several agents on one account — this PR is one of them.

Closes #822 · bead `sq-3p0z` (parent epic `sq-ixc3`).

## What & why
A new **`/showcase/verifiable-credentials`** surface that does exactly what maintainer #822 asked: let a user **import their own W3C Verifiable Credentials (drag-drop / file-pick / paste / URL) and run SPARQL over them** — entirely in the browser tab via the sparq engine compiled to WebAssembly. This realises the `research/gui-design.md` §2b VC-workspace proposal in the **site lane**.

A VC is RDF (a JSON-LD doc that maps to RDF, or already Turtle / N-Quads), so "load it into a graph and query it" is just the existing in-tab ingest path — `live` today. Every imported credential is queried **together**, so joins across credentials work (e.g. *"same holder across the degree and the licence?"*).

## Honesty (the load-bearing distinction)
- **Import + query is `live`.** Real engine, in your tab, nothing sent to a server.
- **Verification is NOT done here.** No signature check, no issuer/revocation check, no zero-knowledge proof. Those are the separate **research-grade, NOT-externally-audited** ZK estate (`sparq-zk`); external accredited-cryptographer sign-off is pending (`sq-qhy4`). The page header badge, the in-component honesty card, and the page caveat all say so — the LIVE `check-privacy-claims.sh` gate passes.
- **JWT envelopes** (SD-JWT-VC / JWT-VC) are *recognised* (the user is told they need decoding/verification first), never silently mis-parsed as RDF.

## Design / judgment decisions (STANDING RULE — documented, not blocked on greenlight)
1. **Lane.** The bead is `area:gui`; I own the **site lane**, so I shipped the VC import+query capability as a **site showcase** (the site already runs SPARQL over WASM and the design record explicitly recommends shipping VC *import + query* first as `live`). The Tauri `gui/app` already has a generic import drawer; a VC-specific GUI workspace remains future GUI-lane work.
2. **In-tab JSON-LD limit (honest gap).** The lean WASM bundle has **no remote-`@context` loader** (verified: a remote-context VC raises *"No LoadDocumentCallback…"*). So the sample uses an **inline `@context`**, the UI states the limit, and a remote-context parse failure surfaces a friendly fix-it message ("inline the context, pre-expand, or import as Turtle / N-Quads"). The desktop/server engine has no such limit. Flagging for the maintainer to steer (a future bead could add a fetch-backed context loader to the wasm surface).
3. **Placement.** Registered in `/examples` as a `live` card (not a `FLAGSHIPS` privacy flagship — it does no crypto).

## Changes
- `site/src/app/showcase/verifiable-credentials/page.tsx` — demo-first route (header badges → workbench → caption → `<details>` caveat), `metadata` for SEO.
- `site/src/components/verifiable-credentials.tsx` — the import-and-query workbench (drag-drop zone + file/paste/URL, credentials list with per-VC issuer/subject/triple-count, shared `SparqlEditor`, results table/boolean/graph, honesty card).
- `site/src/data/verifiable-credentials.ts` — seeded sample VCs (inline-context JSON-LD degree + Turtle licence, same DID) + starter queries + pure helpers.
- `site/src/data/examples.ts` — register the VC demo card.
- `site/test/verifiable-credentials.test.mjs` — unit tests for the pure helpers + fixture integrity.

## Gates (all green)
- **WASM prereq built** (`js`'s `build:wasm`, `--features shacl,jsonld,serialize-rdf,scs`) — a build artifact only, no `crates/` changes.
- `cd site && npm install && npm run build` ✅ end-to-end static export; `/showcase/verifiable-credentials` emitted into `out/` (9.6 kB route). Existing routes intact.
- `npm run lint` ✅ clean · `tsc --noEmit` ✅ exit 0 (no `any`-escapes).
- `npm run test:unit` ✅ 277 pass (+3 new).
- `scripts/check-privacy-claims.sh` ✅ OK · typos gate ✅ clean.
- **No new npm dependency** (reuses existing components + `@sparq/client` WASM helpers + design-system). `basePath` (`/sparq`) preserved (uses `withBasePath`).

## Verified behaviour (real WASM, not asserted)
The three seeded queries run against the merged store: LIST returns both VCs + issuers; CLAIMS returns the degree's name/degree/alma-mater; the same-holder JOIN `ASK` returns `true`.

## Covered vs deferred
- **Covered:** drag-drop / file / paste / URL import; JSON-LD + Turtle/N-Quads/TriG/N-Triples; multi-credential query + joins; per-VC introspection; full honesty framing.
- **Deferred (future beads):** VC signature/ZK *verification* (rides the `sq-1s2.5` audited-crypto phase); a fetch-backed remote-`@context` loader for the wasm bundle; housing this as a first-class VC *workspace type* in the Tauri GUI lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)