### PR TITLE
test(sparq-vectors): firm up gUFO closure-prior — PAIRED multi-seed delta + denser schema-bearing slice (sq-4891y)

### DIFF
--- a/crates/sparq-vectors/examples/kge_ablation.rs
+++ b/crates/sparq-vectors/examples/kge_ablation.rs
@@ -15,6 +15,17 @@
 //! ComplEx run, and each cell is reported as a **mean ± std over several seeds** so a single-seed
 //! delta is not mistaken for signal.
 //!
+//! **Firm-up (sq-4891y).** The headline closure-prior claim is not read off the *unpaired* cell
+//! means (means ± stds, eyeballed). It is read off the **PAIRED** per-seed closure delta
+//! ([`run_ablation_multiseed_paired`]): within each seed the four cells share the split / init /
+//! negatives, so the paired difference cancels the shared noise and its spread is far smaller. The
+//! run prints the paired closure delta as `mean ± se` with a significance flag at 1·se and 2·se, on
+//! a **denser, schema-bearing** gUFO slice (the rigid `Person` kind is asserted on nobody, so the
+//! RDFS closure must materialise it — the closure axis genuinely bites), over MANY seeds and more
+//! epochs. It also runs an **LR sweep** so the maintainer can tune the step size on a canonical
+//! machine. A prior is adopted only when the paired delta is significant on a schema-bearing KG
+//! under ComplEx — never on these INDICATIVE work-box figures.
+//!
 //! ```sh
 //! # Default: the synthetic slices, sized for this NON-CANONICAL work-box (runs in minutes).
 //! cargo run -p sparq-vectors --release --features kge --example kge_ablation
@@ -33,8 +44,8 @@
 #[cfg(feature = "kge")]
 fn main() {
     use sparq_vectors::eval::{
-        run_ablation_multiseed, synthetic_gufo_ttl, synthetic_relational_ttl, EvalConfig,
-        MultiSeedCell,
+        run_ablation_multiseed, run_ablation_multiseed_paired, synthetic_gufo_ttl,
+        synthetic_gufo_ttl_sized, synthetic_relational_ttl, EvalConfig, MultiSeedCell,
     };
     use sparq_vectors::ModelKind;
 
@@ -116,6 +127,95 @@ fn main() {
         "synthetic gUFO slice",
         &synthetic_gufo_ttl(people, seed0 ^ 0x9),
     );
+
+    // ---- Firm-up: PAIRED closure-delta on a denser schema-bearing gUFO slice (sq-4891y) --------
+    // The headline closure claim, read off the variance-reduced PAIRED delta over MANY seeds, with
+    // more epochs and a denser slice, under the asymmetric model. INDICATIVE only.
+    {
+        println!(
+            "== FIRM-UP: paired closure delta on dense schema-bearing gUFO slice (ComplEx) =="
+        );
+        let n_seeds = 12usize;
+        let seeds: Vec<u64> = (0..n_seeds as u64)
+            .map(|i| seed0.wrapping_add(0x500 + i))
+            .collect();
+        let dense_ttl = synthetic_gufo_ttl_sized(people.max(400), 3, seed0 ^ 0x9);
+        let mut cfg = EvalConfig::small(seed0);
+        cfg.train.model = ModelKind::ComplEx;
+        cfg.train.epochs = 250;
+        cfg.train.dim = 64;
+        cfg.train.negatives_per_positive = 16;
+        match run_ablation_multiseed_paired(&dense_ttl, "turtle", cfg, &seeds) {
+            Ok(r) => {
+                let off = &r.cells[0].metrics.mrr; // C off, N unif (reference cell)
+                let on = &r.cells[2].metrics.mrr; // C on,  N unif
+                let unpaired = r.cells[0].metrics.mrr.std + r.cells[2].metrics.mrr.std;
+                println!(
+                    "  UNPAIRED view  : MRR(C off)={:.4}+/-{:.4}  MRR(C on)={:.4}+/-{:.4}  (sum-of-std={:.4})",
+                    off.mean, off.std, on.mean, on.std, unpaired
+                );
+                let d = &r.closure_mrr;
+                println!(
+                    "  PAIRED closure : delta={:.4}  std={:.4}  se={:.4}  n={}  [sig@1se={}  sig@2se={}]",
+                    d.mean,
+                    d.std,
+                    d.se,
+                    d.n,
+                    d.significant_at(1.0),
+                    d.significant_at(2.0),
+                );
+                let dt = &r.closure_mrr_tail;
+                println!(
+                    "  PAIRED tail    : delta={:.4}  std={:.4}  se={:.4}  [sig@1se={}]",
+                    dt.mean,
+                    dt.std,
+                    dt.se,
+                    dt.significant_at(1.0),
+                );
+                let dn = &r.type_neg_mrr;
+                println!(
+                    "  PAIRED type-neg: delta={:.4}  std={:.4}  se={:.4}  [sig@1se={}]",
+                    dn.mean,
+                    dn.std,
+                    dn.se,
+                    dn.significant_at(1.0),
+                );
+                println!(
+                    "  (read: a positive PAIRED delta clearing 2*se is the firm-up bar; the paired \
+                     std should be << the unpaired sum-of-std.)"
+                );
+            }
+            Err(e) => println!("  (paired ablation failed: {})", e),
+        }
+        println!();
+
+        // LR sweep: the bead asks for an LR tune. Report the paired closure delta + se per LR so the
+        // step size can be chosen on a canonical machine.
+        println!("== FIRM-UP: LR sweep (paired closure delta per learning rate, ComplEx) ==");
+        let lr_seeds: Vec<u64> = (0..6u64).map(|i| seed0.wrapping_add(0x900 + i)).collect();
+        for &lr in &[0.03f32, 0.05, 0.1, 0.2, 0.3] {
+            let mut cfg = EvalConfig::small(seed0);
+            cfg.train.model = ModelKind::ComplEx;
+            cfg.train.epochs = 200;
+            cfg.train.dim = 64;
+            cfg.train.negatives_per_positive = 16;
+            cfg.train.lr = lr;
+            match run_ablation_multiseed_paired(&dense_ttl, "turtle", cfg, &lr_seeds) {
+                Ok(r) => {
+                    let d = &r.closure_mrr;
+                    println!(
+                        "  lr={:<5} closure delta={:.4}+/-se{:.4}  [sig@2se={}]",
+                        lr,
+                        d.mean,
+                        d.se,
+                        d.significant_at(2.0)
+                    );
+                }
+                Err(e) => println!("  lr={:<5} (failed: {})", lr, e),
+            }
+        }
+        println!();
+    }
 
     // DATASET-GATED full run.
     if let Ok(path) = std::env::var("SPARQ_KGE_DATASET") {

--- a/crates/sparq-vectors/src/eval.rs
+++ b/crates/sparq-vectors/src/eval.rs
@@ -54,6 +54,22 @@
 //! [`run_ablation_multiseed`] to report each cell's metric as a **mean ± std over several seeds**
 //! before treating any delta as real; a delta smaller than the combined spread is not yet evidence.
 //!
+//! # Paired deltas: the variance-reduction that lets a real effect clear the spread (sq-4891y)
+//!
+//! Reporting two cells as `mean ± std` and eyeballing whether the *means* differ by more than the
+//! *spreads* is the **unpaired** comparison — and it is needlessly noisy here. The four cells of one
+//! seed are trained on the **same split with the same negatives draw and the same init stream**
+//! (common random numbers): the bulk of the per-seed variance is *shared* between the closure-ON and
+//! closure-OFF cells and **cancels in their difference**. The correct statistic is therefore the
+//! **paired** per-seed delta `Δ_s = MRR(closure ON) − MRR(closure OFF)`, aggregated as a mean ± std
+//! over seeds. Its standard error `std(Δ)/√n` shrinks with `n`, and because the shared noise
+//! cancels, `std(Δ)` is typically **far smaller** than `std(cellA) + std(cellB)` — so a real effect
+//! that the unpaired view cannot distinguish from noise can clear the *paired* spread. [`run_ablation_multiseed_paired`]
+//! returns the per-axis [`PairedDelta`]s alongside the per-cell aggregates, with a
+//! [`PairedDelta::significant_at`] gate (mean − k·SE > 0). **The honesty posture is unchanged:** a
+//! prior is adopted only when the paired delta is significant *on a schema-bearing KG under the
+//! asymmetric model*, never on a single seed and never on a schema-free slice the prior cannot bite.
+//!
 //! # Honesty
 //!
 //! **No numbers live in this file or any committed doc.** The harness *computes* them at run time
@@ -589,6 +605,78 @@ pub struct MultiSeedCell {
     pub head: CellStats,
 }
 
+/// A **paired** per-seed delta of one metric between two cells, aggregated over seeds (sq-4891y).
+///
+/// Because the four ablation cells of a single seed share the split, init stream, and negative draws
+/// (common random numbers), the per-seed difference `Δ_s = metric(on) − metric(off)` cancels the
+/// shared noise. The mean of `Δ` estimates the true effect; `std(Δ)` is the *paired* spread — almost
+/// always much smaller than the sum of the two cells' unpaired stds — and `se = std(Δ)/√n` is the
+/// standard error of the mean. This is the statistic the firm-up gate ([`significant_at`]) reads:
+/// the effect is evidence only when its mean clears a multiple of its **paired** spread, not the
+/// inflated unpaired one. **No threshold is hard-coded** — the caller chooses `k`.
+///
+/// [`significant_at`]: PairedDelta::significant_at
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PairedDelta {
+    /// Mean of the per-seed paired delta `metric(on) − metric(off)` (the effect estimate).
+    pub mean: f64,
+    /// Population standard deviation of the per-seed paired delta (the **paired** spread).
+    pub std: f64,
+    /// Standard error of the mean: `std / √n` (0 for a single seed — undefined spread).
+    pub se: f64,
+    /// Number of seeds (paired samples).
+    pub n: usize,
+}
+
+impl PairedDelta {
+    /// Aggregate per-seed paired deltas `xs[s] = metric(on)_s − metric(off)_s` into mean/std/se.
+    fn of(xs: &[f64]) -> PairedDelta {
+        let ms = MeanStd::of(xs);
+        let se = if ms.n > 0 {
+            ms.std / (ms.n as f64).sqrt()
+        } else {
+            0.0
+        };
+        PairedDelta {
+            mean: ms.mean,
+            std: ms.std,
+            se,
+            n: ms.n,
+        }
+    }
+
+    /// Is the (positive) effect significant at `k` standard errors — i.e. `mean − k·se > 0`?
+    ///
+    /// This is the firm-up gate the bead (sq-4891y) requires before adopting the closure prior: the
+    /// *paired* effect must clear `k` standard errors of its own (variance-reduced) spread. With a
+    /// single seed `se == 0`, so any strictly-positive mean is trivially "significant" — which is
+    /// exactly why the gate is meaningful **only** for `n ≥ 2` (assert it in the caller). `k = 1` is
+    /// a one-SE screen; `k = 2` is the conventional ≈95% one-sided bar. The threshold is the
+    /// caller's policy, never baked in.
+    pub fn significant_at(&self, k: f64) -> bool {
+        self.n >= 2 && self.mean - k * self.se > 0.0
+    }
+}
+
+/// The full result of a paired multi-seed ablation (sq-4891y): the per-cell aggregates **plus** the
+/// variance-reduced paired deltas for each prior axis, so a caller can apply a significance gate
+/// without re-deriving the pairing.
+#[derive(Clone, Debug)]
+pub struct PairedAblation {
+    /// The four per-cell aggregates, in the fixed [`run_ablation`] order.
+    pub cells: Vec<MultiSeedCell>,
+    /// Paired MRR delta of the **closure** axis, averaged over the two negative-sampling settings:
+    /// per seed, `½[(MRR(C=on,N=unif) − MRR(C=off,N=unif)) + (MRR(C=on,N=type) − MRR(C=off,N=type))]`.
+    /// This is the headline "closure-prior lift" the firm-up test gates on.
+    pub closure_mrr: PairedDelta,
+    /// Paired MRR delta of the closure axis on the **long-tail** (rare-answer) bucket — where the
+    /// closure-materialised types most plausibly help cold/rare entities.
+    pub closure_mrr_tail: PairedDelta,
+    /// Paired MRR delta of the **type-constrained-negatives** axis, averaged over the two closure
+    /// settings (the other P0 prior, reported for completeness).
+    pub type_neg_mrr: PairedDelta,
+}
+
 /// Run the 2×2 ablation once per seed in `seeds` and aggregate each cell's metrics to a mean ± std.
 ///
 /// This is the **adversarial-review answer to single-seed noise**: the harness is deterministic per
@@ -640,6 +728,79 @@ pub fn run_ablation_multiseed(
             }
         })
         .collect())
+}
+
+/// Run the 2×2 ablation per seed and return BOTH the per-cell aggregates and the **paired**
+/// per-axis MRR deltas (sq-4891y) — the variance-reduced statistic the firm-up gate reads.
+///
+/// For each seed the four cells are produced by a single [`run_ablation`] call, so they share the
+/// split / init / negative draws (common random numbers). We therefore form, **per seed**, the
+/// paired closure delta (closure ON − OFF, averaged over the two negative settings) and the paired
+/// type-negative delta, then aggregate each over seeds with its own (small) paired spread. The
+/// cell order is the fixed `[(C=F,N=F), (F,T), (T,F), (T,T)]` of [`run_ablation`].
+///
+/// Use `template.train.model = ModelKind::ComplEx` (the asymmetric model — DistMult is near-random
+/// on directional slices). Pass several seeds; [`PairedDelta::significant_at`] is meaningful only
+/// for `n ≥ 2`.
+pub fn run_ablation_multiseed_paired(
+    text: &str,
+    format: &str,
+    template: EvalConfig,
+    seeds: &[u64],
+) -> Result<PairedAblation, String> {
+    assert!(!seeds.is_empty(), "need at least one seed");
+    let mut samples: Vec<CellSamples> = (0..4).map(|_| CellSamples::default()).collect();
+    let mut shape: Vec<(bool, bool)> = Vec::with_capacity(4);
+
+    // Per-seed paired deltas (one value per seed).
+    let mut closure_overall: Vec<f64> = Vec::with_capacity(seeds.len());
+    let mut closure_tail: Vec<f64> = Vec::with_capacity(seeds.len());
+    let mut type_neg_overall: Vec<f64> = Vec::with_capacity(seeds.len());
+
+    for (si, &seed) in seeds.iter().enumerate() {
+        let mut cfg = template;
+        cfg.split_seed = seed ^ 0xF00D;
+        cfg.train.seed = seed;
+        let cells = run_ablation(text, format, cfg)?;
+        if cells.len() != 4 {
+            return Err(format!("expected 4 cells, got {}", cells.len()));
+        }
+        // Fixed order: 0=(C off,N unif) 1=(C off,N type) 2=(C on,N unif) 3=(C on,N type).
+        let m = |i: usize| cells[i].metrics.mrr;
+        let mt = |i: usize| cells[i].long_tail.tail.mrr;
+        // Closure axis = on − off, averaged over the two negative settings (paired within seed).
+        closure_overall.push(0.5 * ((m(2) - m(0)) + (m(3) - m(1))));
+        closure_tail.push(0.5 * ((mt(2) - mt(0)) + (mt(3) - mt(1))));
+        // Type-negative axis = type − unif, averaged over the two closure settings.
+        type_neg_overall.push(0.5 * ((m(1) - m(0)) + (m(3) - m(2))));
+
+        for (ci, cell) in cells.iter().enumerate() {
+            if si == 0 {
+                shape.push((cell.closure, cell.type_constrained));
+            }
+            samples[ci].push(cell);
+        }
+    }
+
+    let cells = (0..4)
+        .map(|ci| {
+            let (closure, type_constrained) = shape[ci];
+            MultiSeedCell {
+                closure,
+                type_constrained,
+                metrics: samples[ci].overall.finish(),
+                tail: samples[ci].tail.finish(),
+                head: samples[ci].head.finish(),
+            }
+        })
+        .collect();
+
+    Ok(PairedAblation {
+        cells,
+        closure_mrr: PairedDelta::of(&closure_overall),
+        closure_mrr_tail: PairedDelta::of(&closure_tail),
+        type_neg_mrr: PairedDelta::of(&type_neg_overall),
+    })
 }
 
 /// Per-cell accumulator of one metric sample per seed, for the overall/head/tail buckets.
@@ -733,7 +894,27 @@ fn restrict_to_train(graph: &Graph, splits: &Splits) -> Graph {
 /// Returns the serialised Turtle. The vocabulary is namespaced under `http://ex/gufo#` for the gUFO
 /// meta-classes and `http://ex/` for individuals. The generator is deterministic in `seed` and sized
 /// by `n_people` (a few hundred is a good non-trivial work-box size).
+///
+/// This is the default-density slice. For the firm-up test (sq-4891y) use
+/// [`synthetic_gufo_ttl_sized`], which adds a **density** multiplier: a larger, denser test set
+/// shrinks per-seed sampling variance (more held-out triples ⇒ a tighter MRR estimate per seed) and,
+/// importantly, keeps the slice **schema-bearing but less FB237-overfit-prone** — the closure must
+/// still derive the rigid `Person` kind, so the closure axis genuinely bites.
 pub fn synthetic_gufo_ttl(n_people: usize, seed: u64) -> String {
+    synthetic_gufo_ttl_sized(n_people, 1, seed)
+}
+
+/// Density-parameterised [`synthetic_gufo_ttl`] (sq-4891y).
+///
+/// `density` (clamped to `≥ 1`) multiplies the per-person edge propensity and the course/org pools so
+/// the slice carries **more learnable, schema-bearing signal per held-out triple**. The aim is the
+/// firm-up bead's two requirements at once: a *larger/denser* test set (lower per-seed variance, the
+/// (a) ask) on a graph that is *still schema-bearing and not trivially separable* — the rigid
+/// `Person` kind is asserted on **nobody** and must be materialised by the RDFS closure, so closure
+/// genuinely changes the type-constrained negatives (the (b) ask). `density = 1` reproduces
+/// [`synthetic_gufo_ttl`] exactly. Deterministic in `seed`.
+pub fn synthetic_gufo_ttl_sized(n_people: usize, density: usize, seed: u64) -> String {
+    let density = density.max(1);
     let mut state = seed ^ 0x6757_F0F0;
     let mut next = |m: usize| -> usize { (splitmix64(&mut state) as usize) % m.max(1) };
 
@@ -764,8 +945,10 @@ pub fn synthetic_gufo_ttl(n_people: usize, seed: u64) -> String {
     out.push_str("ex:enrolledIn rdfs:domain ex:Student ; rdfs:range ex:Course .\n");
     out.push_str("ex:employedBy rdfs:domain ex:Employee ; rdfs:range ex:Organisation .\n\n");
 
-    let n_org = (n_people / 20).max(2);
-    let n_course = (n_people / 10).max(3);
+    // A denser slice gets a proportionally larger course/org pool so the candidate set per query
+    // still dwarfs the answer set (non-triviality preserved as density grows).
+    let n_org = (n_people / 20).max(2) * density;
+    let n_course = (n_people / 10).max(3) * density;
     for i in 0..n_org {
         out.push_str(&format!("ex:org{} a ex:Organisation .\n", i));
     }
@@ -820,16 +1003,35 @@ pub fn synthetic_gufo_ttl(n_people: usize, seed: u64) -> String {
         }
         // Contingent edges only when the role is held, and only for SOME holders (decoys: a Student
         // not enrolled in anything). The target course/org is community-correlated (community → a
-        // preferred course/org band) so enrolment is learnable.
-        if is_student && next(10) < 7 {
-            let band = comm(i) % n_course;
-            let course = if next(10) < 7 { band } else { next(n_course) };
-            out.push_str(&format!("ex:p{} ex:enrolledIn ex:course{} .\n", i, course));
+        // preferred course/org band) so enrolment is learnable. A `density>1` slice draws up to
+        // `density` DISTINCT such edges per holder (a person can enrol in several courses), which
+        // multiplies the held-out test triples per seed — shrinking the per-seed MRR variance the
+        // firm-up bead targets — while the per-edge ~70% propensity and community bands keep the
+        // decoy set (and thus non-triviality) intact.
+        let n_comm_band = 5usize;
+        if is_student {
+            let mut emitted = std::collections::BTreeSet::new();
+            for d in 0..density {
+                if next(10) < 7 {
+                    let band = (comm(i) + d) % n_comm_band % n_course;
+                    let course = if next(10) < 7 { band } else { next(n_course) };
+                    if emitted.insert(course) {
+                        out.push_str(&format!("ex:p{} ex:enrolledIn ex:course{} .\n", i, course));
+                    }
+                }
+            }
         }
-        if is_employee && next(10) < 7 {
-            let band = comm(i) % n_org;
-            let org = if next(10) < 7 { band } else { next(n_org) };
-            out.push_str(&format!("ex:p{} ex:employedBy ex:org{} .\n", i, org));
+        if is_employee {
+            let mut emitted = std::collections::BTreeSet::new();
+            for d in 0..density {
+                if next(10) < 7 {
+                    let band = (comm(i) + d) % n_comm_band % n_org;
+                    let org = if next(10) < 7 { band } else { next(n_org) };
+                    if emitted.insert(org) {
+                        out.push_str(&format!("ex:p{} ex:employedBy ex:org{} .\n", i, org));
+                    }
+                }
+            }
         }
     }
     out
@@ -1119,6 +1321,121 @@ ex:c ex:rel ex:y .
         assert!(
             any_variance,
             "across 5 seeds at least one cell's MRR must show variance (single-seed deltas are noisy)"
+        );
+    }
+
+    #[test]
+    fn paired_delta_reduces_variance_vs_unpaired() {
+        // The firm-up bead (sq-4891y) rests on this property: the PAIRED closure delta (computed
+        // within each seed, where the four cells share the split/init/negatives) has a SMALLER spread
+        // than the UNPAIRED comparison (the sum of the two cells' independent stds), because the
+        // shared per-seed noise cancels in the difference. We verify the variance reduction directly
+        // on the schema-bearing gUFO slice under the asymmetric model, over enough seeds to estimate
+        // both spreads.
+        use crate::train::ModelKind;
+        let ttl = synthetic_gufo_ttl_sized(200, 3, 0xBEEF);
+        let mut template = EvalConfig::small(0);
+        template.train.model = ModelKind::ComplEx;
+        template.train.epochs = 80;
+        template.train.dim = 48;
+        template.train.negatives_per_positive = 12;
+        let seeds: Vec<u64> = (0..8).map(|i| 100 + i).collect();
+        let r = run_ablation_multiseed_paired(&ttl, "turtle", template, &seeds).unwrap();
+
+        // The unpaired spread proxy: sum of the closure-OFF and closure-ON cells' MRR stds, averaged
+        // over the two negative settings (mirrors how `closure_mrr` averages the two settings).
+        let unpaired = 0.5
+            * ((r.cells[0].metrics.mrr.std + r.cells[2].metrics.mrr.std)
+                + (r.cells[1].metrics.mrr.std + r.cells[3].metrics.mrr.std));
+        assert_eq!(
+            r.closure_mrr.n,
+            seeds.len(),
+            "all seeds contribute to the paired delta"
+        );
+        assert!(
+            r.closure_mrr.std > 0.0 && unpaired > 0.0,
+            "both spreads must be observable (paired std={}, unpaired proxy={})",
+            r.closure_mrr.std,
+            unpaired
+        );
+        // The whole point of pairing: the paired spread is strictly smaller than the unpaired sum.
+        assert!(
+            r.closure_mrr.std < unpaired,
+            "paired delta std ({}) must be smaller than the unpaired sum-of-stds ({}) — common \
+             random numbers cancel the shared per-seed noise",
+            r.closure_mrr.std,
+            unpaired
+        );
+        // The standard error must shrink as std/√n (the variance-reduction mechanism the gate uses).
+        let expected_se = r.closure_mrr.std / (seeds.len() as f64).sqrt();
+        assert!(
+            (r.closure_mrr.se - expected_se).abs() < 1e-9,
+            "se must equal std/√n"
+        );
+    }
+
+    #[test]
+    fn paired_delta_significance_gate_is_honest() {
+        // `significant_at` must be a genuine gate, not a rubber stamp: it requires n>=2 (a single
+        // seed has undefined spread, so the gate must REFUSE to certify), and a larger k must be a
+        // STRICTLY stronger bar (monotone). We use a deterministic synthetic PairedDelta so the
+        // assertion is about the gate logic, not a noisy run.
+        // Single seed: se is 0 and the gate must refuse regardless of a positive mean.
+        let one = PairedDelta {
+            mean: 0.05,
+            std: 0.0,
+            se: 0.0,
+            n: 1,
+        };
+        assert!(!one.significant_at(0.0), "n<2 must never be certified");
+        assert!(!one.significant_at(2.0));
+        // A real multi-seed delta: mean 0.02, se 0.005 → clears 1·se and 2·se, not 5·se.
+        let d = PairedDelta {
+            mean: 0.02,
+            std: 0.005 * 4.0,
+            se: 0.005,
+            n: 16,
+        };
+        assert!(d.significant_at(1.0), "0.02 > 1·0.005");
+        assert!(d.significant_at(2.0), "0.02 > 2·0.005");
+        assert!(!d.significant_at(5.0), "0.02 < 5·0.005 — must NOT certify");
+        // A negative effect is never significant.
+        let neg = PairedDelta {
+            mean: -0.01,
+            std: 0.02,
+            se: 0.005,
+            n: 16,
+        };
+        assert!(
+            !neg.significant_at(0.0),
+            "a negative effect is never a positive win"
+        );
+    }
+
+    #[test]
+    fn denser_gufo_slice_has_more_test_triples_and_still_bites() {
+        // Density must (a) increase the number of held-out test triples per seed (the variance lever)
+        // and (b) keep the closure axis live (the rigid Person kind is still asserted on nobody, so
+        // closure must derive entailed triples). Both are load-bearing for the firm-up.
+        let cfg = EvalConfig::small(7);
+        let sparse = run_ablation(&synthetic_gufo_ttl_sized(200, 1, 9), "turtle", cfg).unwrap();
+        let dense = run_ablation(&synthetic_gufo_ttl_sized(200, 4, 9), "turtle", cfg).unwrap();
+        assert!(
+            dense[0].metrics.queries > sparse[0].metrics.queries,
+            "a denser slice must yield more scorable test queries: dense={} sparse={}",
+            dense[0].metrics.queries,
+            sparse[0].metrics.queries
+        );
+        // Closure still bites on the dense slice (entailed Person memberships derived).
+        let c = close_for_vectorise(
+            &synthetic_gufo_ttl_sized(200, 4, 9),
+            "turtle",
+            Profile::Rdfs,
+        )
+        .unwrap();
+        assert!(
+            c.entailed_triples > 0,
+            "dense gUFO slice closure must still derive entailed triples"
         );
     }
 

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -161,8 +161,9 @@ pub use structure::{
 // harness surface — `kge` feature only.
 #[cfg(feature = "kge")]
 pub use eval::{
-    run_ablation, run_ablation_multiseed, synthetic_gufo_ttl, synthetic_relational_ttl,
-    AblationCell, CellStats, EvalConfig, LongTail, MeanStd, Metrics, MultiSeedCell, Splits,
+    run_ablation, run_ablation_multiseed, run_ablation_multiseed_paired, synthetic_gufo_ttl,
+    synthetic_gufo_ttl_sized, synthetic_relational_ttl, AblationCell, CellStats, EvalConfig,
+    LongTail, MeanStd, Metrics, MultiSeedCell, PairedAblation, PairedDelta, Splits,
     SCHEMA_PREDICATES,
 };
 #[cfg(feature = "kge")]

--- a/skills/vector-search/SKILL.md
+++ b/skills/vector-search/SKILL.md
@@ -781,6 +781,31 @@ for c in &cells {
 // A delta smaller than the combined spread of the two cells is NOT yet evidence.
 ```
 
+**Read the effect off the PAIRED delta, not the unpaired means (sq-4891y).** Comparing two cells'
+`mean ± std` and eyeballing the gap is the *unpaired* view — needlessly noisy, because the four cells
+of one seed share the split / init / negatives, so most per-seed variance is *shared* and cancels in
+their difference. `run_ablation_multiseed_paired` returns the **paired** per-seed closure delta (and
+type-negative delta) as a `PairedDelta { mean, std, se, n }` whose paired `std` is far smaller than
+the unpaired sum-of-stds, with a `significant_at(k)` gate (`mean − k·se > 0`, requires `n ≥ 2`):
+
+```rust,ignore
+# // cargo build -p sparq-vectors --features kge
+use sparq_vectors::{run_ablation_multiseed_paired, synthetic_gufo_ttl_sized, EvalConfig};
+let ttl = synthetic_gufo_ttl_sized(400, /*density*/ 3, 9); // denser → more held-out triples/seed
+let template = EvalConfig::small(13);                       // ComplEx; bump epochs for a tighter run
+let r = run_ablation_multiseed_paired(&ttl, "turtle", template, &(0..12).collect::<Vec<_>>())?;
+let d = r.closure_mrr; // headline closure-prior lift, variance-reduced
+println!("closure delta={:.4} se={:.4} sig@2se={}", d.mean, d.se, d.significant_at(2.0));
+# Ok::<(), String>(())
+// Firm-up bar: a positive PAIRED delta clearing 2·se on a SCHEMA-BEARING slice under ComplEx.
+```
+
+`synthetic_gufo_ttl_sized(n, density, seed)` is the **schema-bearing** firm-up slice: the rigid
+`Person` kind is asserted on **nobody**, so the RDFS closure must materialise it (the closure axis
+genuinely bites — unlike schema-free WN18RR/FB237). A higher `density` adds more learnable held-out
+triples per seed, shrinking the per-seed MRR variance, while keeping the decoy set (non-triviality)
+intact. `examples/kge_ablation.rs` prints the paired delta + an LR sweep.
+
 **Filtered protocol (load-bearing).** Each ranking removes **every** known-true triple (train + valid +
 test) before scoring the held-out one — the established Bordes 2013 protocol; getting it wrong
 invalidates every number. Train/valid/test are a leakage-free partition (a triple is in exactly one


### PR DESCRIPTION
> 🤖 **SPARQ agent** — opened by an autonomous SPARQ agent on @jeswr's account.

Closes the firm-up gap on the gUFO closure-prior claim (bead **sq-4891y**, epic sq-0wo9e P0).

## The problem

The canonical gUFO ablation was inadequate: **per-seed variance ≥ the closure effect** (std ≥ mean), so the ~2× MRR delta could not be told apart from noise. Separately, the real WN18RR/FB237 benchmarks are **schema-free** and cannot exercise the closure/type-neg priors at all.

## What changed

**(a) Variance reduction — PAIRED delta.** The unpaired comparison (two cells' `mean ± std`, eyeballed) is needlessly noisy: the four ablation cells of one seed share the split / init / negative draws (common random numbers), so most per-seed variance is *shared* and **cancels in their difference**. The correct statistic is the paired per-seed delta `Δ_s = MRR(closure ON) − MRR(closure OFF)`, whose spread is far smaller than the sum of the two cells' unpaired stds.

- `PairedDelta { mean, std, se, n }` + `significant_at(k)` gate (`mean − k·se > 0`; refuses `n < 2`). **No threshold hard-coded** — the caller picks `k`.
- `run_ablation_multiseed_paired` returns the per-axis paired closure / closure-tail / type-negative deltas alongside the per-cell aggregates.
- Test `paired_delta_reduces_variance_vs_unpaired` **measures** (ComplEx, 8 seeds) that the paired std is strictly smaller than the unpaired sum-of-stds and `se == std/√n` — the mechanism that lets a real effect clear the spread.
- The example now reports the paired delta + `sig@1se`/`@2se` over **12 seeds at 250 epochs**, plus an **LR sweep** (the bead's "LR tune" ask).

**(b) Schema-bearing slice.** The synthetic gUFO slice already IS schema-bearing — the rigid `Person` kind is asserted on **nobody**, so the RDFS closure must materialise it (closure axis genuinely bites, unlike schema-free WN18RR/FB237). `synthetic_gufo_ttl_sized(n, density, seed)` adds a **density** knob: a denser slice yields more held-out triples per seed (lower per-seed variance) while keeping the decoy set (non-triviality, **anti-overfit**) intact. The `SPARQ_KGE_DATASET` env-gated arm remains for a real typed KG on a canonical machine.

## Judgment decision flagged for the maintainer

The bead suggested a "typed DBpedia/YAGO subset". I did **not** vendor a multi-GB external corpus (would need an external download and bloat the repo). Instead I satisfied the schema-bearing requirement via the **denser synthetic gUFO slice** (closure genuinely materialises types) plus the existing `SPARQ_KGE_DATASET` hook for a real typed KG. Filed as a follow-up issue for the maintainer to steer if a vendored real benchmark is wanted.

## Honesty posture (unchanged)

No benchmark numbers in any committed doc; figures are INDICATIVE on a non-canonical work-box. A prior is adopted only when the **paired** delta is significant on a **schema-bearing** KG under the **asymmetric** model. Opt-in behind the existing `kge` feature; **default build and core engine untouched**.

## Gates

- `cargo clippy -p sparq-vectors --all-targets -D warnings` — default **and** `--features kge` ✅
- `cargo doc --all-features` with `RUSTDOCFLAGS=-D warnings` ✅
- `kge` tests (10 `eval::tests` pass, incl. the 3 new tests) ✅
- `check-privacy-claims.sh` ✅ · `check-readme-template.py` ✅ · no hard-coded perf numbers ✅

[OPUS-4.8]

🤖 Generated with [Claude Code](https://claude.com/claude-code)