### PR TITLE
docs: reconcile NL-tool measured-cost honesty + cross-link ast-grep A/B homes (w661z5rbm cleanup) [OPUS-4.8]

### DIFF
--- a/.claude/agents/sparq-pkg-nl.md
+++ b/.claude/agents/sparq-pkg-nl.md
@@ -82,8 +82,10 @@ Rules:
   projection + the heaviest skills' front-matter). A miss means "not in the head slice
   yet" — tell the orchestrator to fall back to Read/Grep, do not invent.
 - **bd is the source-of-record** for tasks; the `pkg:Task`s are a read-model mirror.
-- **No hard-coded performance numbers.** Whether this actually saves tokens is measured by
-  bead sq-2m6zm.4 / sq-jgi97, not claimed by you.
+- **No hard-coded performance numbers, no cost claims in your answer.** The cost win of this
+  NL-tool was measured separately (beads sq-zbyo7 / sq-jgi97; see `bench/pkg-dogfood/RESULTS.md`)
+  — it is NOT your job to assert it. Answer the question from the rows; never editorialise
+  about tokens or cost.
 
 ## Honesty
 

--- a/.claude/skills/query-pkg/SKILL.md
+++ b/.claude/skills/query-pkg/SKILL.md
@@ -270,8 +270,12 @@ integration) needs sparq's own API key (an external-credential dependency) and i
 follow-up — only the **agent flavor** (no API key) ships here.
 
 > **Honesty.** Whether routing PKG access through a cheap-model sub-agent actually cuts the
-> orchestrator's *model-price-weighted* cost is **measured by sq-2m6zm.4 / sq-jgi97**, not
-> claimed here.
+> orchestrator's *model-price-weighted* cost is now **MEASURED** (beads sq-zbyo7 / sq-jgi97,
+> the real-transcript N=30 3-arm A/B that superseded the sq-2m6zm.4 #1078 proxy): the Haiku
+> NL-tool was ≈ 30× cheaper in $ than read-docs at equal quality. The full table, method,
+> and caveats live in `bench/pkg-dogfood/RESULTS.md` (the sanctioned record); this file
+> only points at it. The win is scoped to **PKG-answerable** questions by construction —
+> a miss is an honest abstain, not a fabricated answer.
 
 ## When NOT to use this
 

--- a/scripts/agent-telemetry/ast-grep-outline/README.md
+++ b/scripts/agent-telemetry/ast-grep-outline/README.md
@@ -1,6 +1,19 @@
 <!-- [OPUS-4.8] sq-lhwo.4 (epic sq-lhwo). 🤖 SPARQ agent. -->
 # ast-grep + outline token A/B harness (sq-lhwo.4)
 
+> 🤖 **SPARQ agent — verdict already SETTLED; this is the runnable proxy harness, not the
+> canonical answer.** The load-bearing decision ("does outline/`ast-grep`-first save agent
+> tokens?") was settled by the **real-transcript** A/B, whose CONCLUSION is:
+> **ast-grep + outline are PRECISION / completeness tools, measured NOT to save tokens**
+> (slightly more expensive end-to-end). The **canonical record** is
+> [`bench/pkg-dogfood/RESULTS-astgrep.md`](../../../bench/pkg-dogfood/RESULTS-astgrep.md)
+> (cited qualitatively by `AGENTS.md` §2 and the `ast-grep` SKILL §5). This directory is the
+> **lower-fidelity read-payload PROXY** harness (the runnable code + the frozen PREREG/tasks);
+> by construction it **cannot** reach `recommend_adopt` (see below), and its predecessor
+> byte-proxy in fact **overstated** the saving — the real measurement corrected it. Keep this
+> harness for reproducible proxy runs and as the pre-registration of record; for the *verdict*,
+> read `RESULTS-astgrep.md`.
+
 The FIRM, runnable A/B for the **ast-grep + outline-before-read** intervention vs the
 competent `grep -rn` + full-`Read` baseline — deferred from `sq-lhwo.2` (where the
 skill shipped and a directional, advisory byte-cost pilot ran). It applies the SHARED


### PR DESCRIPTION
> 🤖 **SPARQ agent.** Cleanup after a stale autonomous-scheduler run (`w661z5rbm`) that merged duplicate/overlapping work alongside the manual track, leaving two **honesty contradictions** on `main`. This PR reconciles them; it is doc/skill-only (no code).

## 1. NL-tool cost win — kill the contradictory "not yet measured" fragments (honesty-critical)

`bench/pkg-dogfood/RESULTS.md` + beads **sq-zbyo7 / sq-jgi97** (both **CLOSED**) record the real-transcript N=30 3-arm A/B: the Haiku NL-tool is **≈ 30× cheaper in $** than read-docs at **equal quality**. The `query-pkg` SKILL.md already documents the cheap-model Haiku NL-tool as the **DEFAULT** (delegate to `sparq-pkg-nl` / `nl_tool.rs`), the **abstain → fall-back** rule, **tier-escalation**, and cites `RESULTS.md` — that guidance is intact on main and is **not** lost.

What was wrong: two **trailing stale notes** still said the saving was *"measured by sq-2m6zm.4 / sq-jgi97, **not claimed here**"* — directly contradicting the measured headline at the top of the same file/agent. Fixed:
- `.claude/skills/query-pkg/SKILL.md` — the trailing honesty note now states the win **is MEASURED** (sq-zbyo7 / sq-jgi97 superseded the sq-2m6zm.4 #1078 proxy) and points to `RESULTS.md`.
- `.claude/agents/sparq-pkg-nl.md` — the stale *"not claimed by you"* rule is rephrased to the durable discipline (the Haiku agent must never editorialise about tokens/cost) without the stale to-be-measured framing.

`crates/sparq-kb/src/query/nl_tool.rs` and the `sparq-pkg-nl` agent are **unchanged** (kept from #1085) and coherent with the skill — verified `cargo check -p sparq-kb --all-features` clean.

## 2. ast-grep A/B homes — make the two records cross-consistent

Two records exist on main and **already agree** ("ast-grep/outline are **precision/completeness** tools, **NOT token-savers**"):
- `bench/pkg-dogfood/RESULTS-astgrep.md` (#1095) — the **canonical real-transcript** verdict; cited by AGENTS.md §2 + the ast-grep SKILL §5.
- `scripts/agent-telemetry/ast-grep-outline/` (#1079) — the **read-payload PROXY** harness; its PREREG honestly states the proxy **cannot reach `recommend_adopt`** and its predecessor byte-proxy **overstated** the saving.

No verdict contradiction — but the proxy directory lacked a pointer to the real measurement that superseded it, so a reader landing there could mistake the proxy verdict for the answer. Fix: added a clear cross-link at the top of the proxy `README.md` to `bench/pkg-dogfood/RESULTS-astgrep.md` as the canonical home. AGENTS.md already points only to the canonical record (correct).

## Gates
All 3 edited docs pass `check-no-perf-numbers.py` (0 findings) and `lychee --offline` (3/3 links OK). No code touched.

[OPUS-4.8] Written while Fable unavailable; flag for re-review when Fable returns.