### PR TITLE
feat(sparq-vectors): paired variance-reduction firm-verdict for the gUFO closure prior (sq-4891y) [OPUS-4.8]

### DIFF
--- a/crates/sparq-vectors/examples/kge_ablation.rs
+++ b/crates/sparq-vectors/examples/kge_ablation.rs
@@ -25,16 +25,33 @@
 //! SPARQ_KGE_DATASET=/path/to/wn18rr.nt cargo run -p sparq-vectors --release --features kge --example kge_ablation
 //! ```
 //!
+//! ## Variance reduction (sq-4891y) — the PAIRED closure verdict + tuning knobs
+//!
+//! [OPUS-4.8] The earlier canonical run was *inadequate*: on the gUFO slice the per-seed std was on
+//! the order of the cell mean, so the ~2× MRR lift could not be called firm. That per-cell std is
+//! dominated by **common-mode** seed noise (which split/init a seed draws); subtracting closure-on −
+//! closure-off **within a seed** cancels it. This example now prints the
+//! [`ClosureVerdict`](sparq_vectors::eval::ClosureVerdict): the *paired* delta, its (far smaller)
+//! paired std + standard error, and a **`firm`** flag (`|delta| ≥ t·std_error` at the small-sample
+//! 95 % t threshold AND a unanimous per-seed sign). To shrink the spread further, raise the
+//! variance-reduction levers from the environment — `SPARQ_KGE_SEEDS` (more seeds ⇒ std_error ∝
+//! 1/√n), `SPARQ_KGE_EPOCHS` (steadier per-seed signal), `SPARQ_KGE_LR` (learning-rate tune):
+//!
+//! ```sh
+//! SPARQ_KGE_SEEDS=12 SPARQ_KGE_EPOCHS=200 SPARQ_KGE_LR=0.05 \
+//!   cargo run -p sparq-vectors --release --features kge --example kge_ablation
+//! ```
+//!
 //! All numbers printed here are **INDICATIVE only** — the work-box is non-canonical, the model is a
 //! tiny research-grade shallow KGE, and no figure is baked into any committed doc. The harness is the
 //! instrument; the numbers must be re-measured on a canonical machine, on a REAL dataset, under the
-//! asymmetric model, with multi-seed reporting, before any prior is adopted.
+//! asymmetric model, with multi-seed PAIRED reporting, before any prior is adopted.
 
 #[cfg(feature = "kge")]
 fn main() {
     use sparq_vectors::eval::{
-        run_ablation_multiseed, synthetic_gufo_ttl, synthetic_relational_ttl, EvalConfig,
-        MultiSeedCell,
+        run_ablation_multiseed_full, synthetic_gufo_ttl, synthetic_relational_ttl, Bucket,
+        ClosureVerdict, EvalConfig, Metric, MultiSeedCell, PairedContrast,
     };
     use sparq_vectors::ModelKind;
 
@@ -43,14 +60,38 @@ fn main() {
     let people: usize = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(600);
     let seed0: u64 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(20260620);
 
-    // Five seeds: the mean ± std over them is what should be read, NOT a single run.
-    let seeds: Vec<u64> = (0..5).map(|i| seed0.wrapping_add(i)).collect();
+    // Variance-reduction tuning knobs (sq-4891y), read from the environment so a default run is
+    // unchanged but a firm-up run can crank seeds / epochs / LR without recompiling.
+    let env_usize = |k: &str, d: usize| {
+        std::env::var(k)
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(d)
+    };
+    let n_seeds: usize = env_usize("SPARQ_KGE_SEEDS", 5).max(2);
+    let epochs: usize = env_usize("SPARQ_KGE_EPOCHS", 150);
+    let lr: f32 = std::env::var("SPARQ_KGE_LR")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0.1);
 
-    println!("# sq-0wo9e P0 ablation — INDICATIVE numbers on a NON-CANONICAL work-box");
+    // The seeds: the mean ± std (and the PAIRED contrast) over them is what should be read, NOT a
+    // single run. More seeds shrink the paired delta's standard error as 1/√n.
+    let seeds: Vec<u64> = (0..n_seeds as u64).map(|i| seed0.wrapping_add(i)).collect();
+
+    println!("# sq-0wo9e / sq-4891y P0 ablation — INDICATIVE numbers on a NON-CANONICAL work-box");
     println!("# filtered link-prediction: MRR / Hits@1 / Hits@3 / Hits@10 (higher is better)");
     println!("# matrix: closure {{off,on}} x negatives {{uniform,type-constrained}}");
-    println!("# reported as MEAN +/- STD over {} seeds; read the ASYMMETRIC ComplEx run for any", seeds.len());
-    println!("# inter-cell delta (DistMult is near-random on these 100%-directional slices).");
+    println!(
+        "# {} seeds, {} epochs, lr={}; read the ASYMMETRIC ComplEx run for any inter-cell delta",
+        seeds.len(),
+        epochs,
+        lr,
+    );
+    println!("# (DistMult is near-random on these 100%-directional slices).");
+    println!(
+        "# sq-4891y: the PAIRED closure verdict cancels common-mode seed noise — read 'firm'."
+    );
     println!();
 
     let print_cell = |c: &MultiSeedCell| {
@@ -82,6 +123,20 @@ fn main() {
         );
     };
 
+    // Print a paired contrast (variance-reduced) line with its firm verdict.
+    let print_paired = |label: &str, p: &PairedContrast| {
+        println!(
+            "    PAIRED {:<14} delta={:+.4} +/-{:.4} (se={:.4}, t*se={:.4}) sign={:.0}% -> {}",
+            label,
+            p.delta,
+            p.delta_std,
+            p.std_error,
+            p.firm_z * p.std_error,
+            p.sign_agreement * 100.0,
+            if p.firm { "FIRM" } else { "not firm" },
+        );
+    };
+
     let run_slice = |name: &str, ttl: &str| {
         // The work-box can afford a longer, slightly larger run than the test preset, for less
         // noisy indicative numbers (still NON-CANONICAL).
@@ -93,13 +148,25 @@ fn main() {
             println!("== {} :: {} ==", name, tag);
             let mut cfg = EvalConfig::small(seed0);
             cfg.train.model = model;
-            cfg.train.epochs = 150;
+            cfg.train.epochs = epochs;
+            cfg.train.lr = lr;
             cfg.train.dim = 64;
             cfg.train.negatives_per_positive = 16;
-            match run_ablation_multiseed(ttl, "turtle", cfg, &seeds) {
-                Ok(cells) => {
-                    for c in &cells {
+            match run_ablation_multiseed_full(ttl, "turtle", cfg, &seeds) {
+                Ok(res) => {
+                    for c in &res.cells {
                         print_cell(c);
+                    }
+                    // sq-4891y: the PAIRED closure verdict — closure-on − closure-off, per seed, with
+                    // a firm flag. This is the figure the bead's acceptance turns on.
+                    let v = ClosureVerdict::compute(&res, Metric::Mrr, Bucket::Overall);
+                    println!("  -- closure prior (paired, variance-reduced) --");
+                    print_paired("closure@unif", &v.at_uniform);
+                    print_paired("closure@type", &v.at_type);
+                    if v.any_firm_positive() {
+                        println!("  => closure prior shows a FIRM positive lift on this slice.");
+                    } else {
+                        println!("  => closure lift NOT firm at these seeds/epochs (raise SPARQ_KGE_SEEDS/_EPOCHS).");
                     }
                 }
                 Err(e) => println!("  (ablation failed: {})", e),

--- a/crates/sparq-vectors/src/eval.rs
+++ b/crates/sparq-vectors/src/eval.rs
@@ -54,6 +54,21 @@
 //! [`run_ablation_multiseed`] to report each cell's metric as a **mean ± std over several seeds**
 //! before treating any delta as real; a delta smaller than the combined spread is not yet evidence.
 //!
+//! # Variance reduction: the PAIRED closure contrast (sq-4891y)
+//!
+//! [OPUS-4.8] The per-cell std reported above is dominated by **common-mode** seed noise: which
+//! train/test split and which init a seed happens to draw moves *every* cell of that seed together,
+//! so on the gUFO slice a cell's std can be ≈ its mean (the bead's `std ≥ mean` finding) even though
+//! the closure prior has a real, repeatable effect. Because each seed produces all four cells from
+//! the *same* draw, subtracting closure-on − closure-off **within a seed** cancels that common-mode
+//! term — the textbook paired-difference variance reduction. [`run_ablation_multiseed_full`] returns
+//! the raw per-seed cell matrix and [`PairedContrast`] / [`ClosureVerdict`] compute the paired delta,
+//! its (much smaller) paired std, the standard error, and a **`firm` verdict**: the prior is adopted
+//! only when `|delta| ≥ firm_z·std_error` (a small-sample Student-t threshold, [`firm_z_for`]) **and**
+//! the per-seed differences are unanimous in sign. This is the bead's variance-reduction lever: more
+//! seeds shrink the std error as `1/√n`, and the paired contrast removes the noise that previously
+//! swamped the lift. The verdict is still computed at run time — no figure is frozen into any doc.
+//!
 //! # Honesty
 //!
 //! **No numbers live in this file or any committed doc.** The harness *computes* them at run time
@@ -553,7 +568,11 @@ impl MeanStd {
         }
         let mean = xs.iter().sum::<f64>() / n as f64;
         let var = xs.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>() / n as f64;
-        MeanStd { mean, std: var.sqrt(), n }
+        MeanStd {
+            mean,
+            std: var.sqrt(),
+            n,
+        }
     }
 }
 
@@ -605,10 +624,43 @@ pub fn run_ablation_multiseed(
     template: EvalConfig,
     seeds: &[u64],
 ) -> Result<Vec<MultiSeedCell>, String> {
+    Ok(run_ablation_multiseed_full(text, format, template, seeds)?.cells)
+}
+
+/// The full per-seed result of a multi-seed ablation: the aggregated [`MultiSeedCell`]s **and** the
+/// raw per-seed cell matrix the [`PairedContrast`] machinery needs.
+///
+/// [OPUS-4.8] sq-4891y. The aggregated cells carry each cell's metric as an *independent* mean ± std
+/// over seeds; that per-cell spread is dominated by **common-mode** seed noise (which split/init a
+/// seed happens to draw). The raw `per_seed` matrix preserves the alignment — `per_seed[i]` is the
+/// four cells from seed `seeds[i]` — so a **paired** contrast can subtract two cells *within the same
+/// seed*, cancelling that common-mode term. That is the variance-reduction lever this bead needs:
+/// the per-cell std can be ≈ the cell mean while the *paired delta's* std is far smaller.
+#[derive(Clone, Debug)]
+pub struct MultiSeedResult {
+    /// The four aggregated cells (fixed `run_ablation` order), each metric as a mean ± std.
+    pub cells: Vec<MultiSeedCell>,
+    /// `per_seed[i]` is the four [`AblationCell`]s produced by `seeds[i]` (same order as `cells`).
+    /// Aligned so a paired contrast can index the *same seed's* two cells.
+    pub per_seed: Vec<[AblationCell; 4]>,
+    /// The seeds, in the order `per_seed` rows correspond to.
+    pub seeds: Vec<u64>,
+}
+
+/// Run the 2×2 ablation once per seed and return BOTH the aggregated cells and the raw per-seed
+/// matrix (the input the [`PairedContrast`] machinery consumes). [`run_ablation_multiseed`] is the
+/// thin wrapper that keeps only the aggregated cells. [OPUS-4.8] sq-4891y.
+pub fn run_ablation_multiseed_full(
+    text: &str,
+    format: &str,
+    template: EvalConfig,
+    seeds: &[u64],
+) -> Result<MultiSeedResult, String> {
     assert!(!seeds.is_empty(), "need at least one seed");
     // Per-cell samples: 4 cells, each accumulating one value per seed for every metric/bucket.
     let mut samples: Vec<CellSamples> = (0..4).map(|_| CellSamples::default()).collect();
     let mut shape: Vec<(bool, bool)> = Vec::with_capacity(4);
+    let mut per_seed: Vec<[AblationCell; 4]> = Vec::with_capacity(seeds.len());
 
     for (si, &seed) in seeds.iter().enumerate() {
         let mut cfg = template;
@@ -626,9 +678,14 @@ pub fn run_ablation_multiseed(
             }
             samples[ci].push(cell);
         }
+        // Preserve the per-seed alignment for the paired contrast (fixed 4-cell order).
+        let arr: [AblationCell; 4] = cells
+            .try_into()
+            .map_err(|_| "ablation did not yield exactly 4 cells".to_string())?;
+        per_seed.push(arr);
     }
 
-    Ok((0..4)
+    let cells = (0..4)
         .map(|ci| {
             let (closure, type_constrained) = shape[ci];
             MultiSeedCell {
@@ -639,7 +696,220 @@ pub fn run_ablation_multiseed(
                 head: samples[ci].head.finish(),
             }
         })
-        .collect())
+        .collect();
+
+    Ok(MultiSeedResult {
+        cells,
+        per_seed,
+        seeds: seeds.to_vec(),
+    })
+}
+
+/// Which metric a [`PairedContrast`] is taken over (read off the per-cell [`Metrics`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Metric {
+    /// Filtered mean reciprocal rank (the headline figure for the closure prior).
+    Mrr,
+    /// Filtered Hits@1.
+    Hits1,
+    /// Filtered Hits@3.
+    Hits3,
+    /// Filtered Hits@10.
+    Hits10,
+}
+
+impl Metric {
+    /// Read this metric off a [`Metrics`] row.
+    fn of(self, m: &Metrics) -> f64 {
+        match self {
+            Metric::Mrr => m.mrr,
+            Metric::Hits1 => m.hits1,
+            Metric::Hits3 => m.hits3,
+            Metric::Hits10 => m.hits10,
+        }
+    }
+}
+
+/// Which test bucket a [`PairedContrast`] is read over.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Bucket {
+    /// All scorable test queries.
+    Overall,
+    /// Head (frequent-answer) queries only.
+    Head,
+    /// Long-tail (rare-answer) queries only.
+    Tail,
+}
+
+impl Bucket {
+    fn metrics_of(self, cell: &AblationCell) -> &Metrics {
+        match self {
+            Bucket::Overall => &cell.metrics,
+            Bucket::Head => &cell.long_tail.head,
+            Bucket::Tail => &cell.long_tail.tail,
+        }
+    }
+}
+
+/// A **paired** between-cell contrast on one metric, computed per seed and aggregated.
+///
+/// [OPUS-4.8] sq-4891y — the variance-reduction answer. Each seed produces all four cells from the
+/// *same* split + init draw, so the difference `metric(cell_b) − metric(cell_a)` taken **within a
+/// seed** cancels the common-mode "lucky seed" term that dominates the per-cell std. The contrast
+/// reports:
+/// - `delta` — the mean of the per-seed paired differences (the effect size);
+/// - `delta_std` — the population std of those per-seed differences (the *paired* spread, typically
+///   far below the per-cell std the bead flagged as `std ≥ mean`);
+/// - `std_error` — `delta_std / √n`, the standard error of the mean difference;
+/// - `firm` — `true` iff `|delta| ≥ firm_z · std_error` AND the effect is unanimous in sign (every
+///   seed's paired difference agrees with the mean's sign). Unanimity is a deliberately conservative
+///   extra guard: a mean that is "significant" only because a couple of seeds swing hugely is not the
+///   kind of *stable* lift the bead requires before adopting a prior.
+///
+/// The per-seed differences are kept (`per_seed`) so a caller can run its own test or print them.
+#[derive(Clone, Debug)]
+pub struct PairedContrast {
+    /// Mean of the per-seed paired differences `metric(b) − metric(a)` (the effect size).
+    pub delta: f64,
+    /// Population std of the per-seed paired differences (the variance-reduced spread).
+    pub delta_std: f64,
+    /// Standard error of the mean difference: `delta_std / √n`.
+    pub std_error: f64,
+    /// Number of seeds (paired samples).
+    pub n: usize,
+    /// `|delta| ≥ firm_z · std_error` AND every seed agrees on the sign of the effect.
+    pub firm: bool,
+    /// The `firm_z` threshold (in standard errors) the verdict used.
+    pub firm_z: f64,
+    /// The per-seed paired differences, in seed order (for a caller's own test / printout).
+    pub per_seed: Vec<f64>,
+    /// Fraction of seeds whose paired difference agrees in sign with `delta` (1.0 = unanimous).
+    pub sign_agreement: f64,
+}
+
+impl PairedContrast {
+    /// Compute the paired contrast `metric(b) − metric(a)` over the seeds of `res`, on `bucket`.
+    ///
+    /// `cell_a` / `cell_b` are cell indices into the fixed `run_ablation` order
+    /// `[(closure=F,tc=F), (F,T), (T,F), (T,T)]`. `firm_z` is the significance threshold in standard
+    /// errors (≈1.96 for a two-sided 95 % normal interval; the small-sample harness here is honest
+    /// about `n` being a handful of seeds — see [`firm_z_for`]).
+    pub fn compute(
+        res: &MultiSeedResult,
+        cell_a: usize,
+        cell_b: usize,
+        metric: Metric,
+        bucket: Bucket,
+        firm_z: f64,
+    ) -> PairedContrast {
+        assert!(cell_a < 4 && cell_b < 4, "cell indices must be in 0..4");
+        let diffs: Vec<f64> = res
+            .per_seed
+            .iter()
+            .map(|cells| {
+                let a = metric.of(bucket.metrics_of(&cells[cell_a]));
+                let b = metric.of(bucket.metrics_of(&cells[cell_b]));
+                b - a
+            })
+            .collect();
+        let ms = MeanStd::of(&diffs);
+        let n = diffs.len();
+        let std_error = if n > 0 {
+            ms.std / (n as f64).sqrt()
+        } else {
+            0.0
+        };
+        // Sign unanimity: every nonzero difference must agree with the mean's sign. (A zero
+        // difference is treated as agreeing — it does not contradict the effect.)
+        let sign = ms.mean.signum();
+        let agree = diffs
+            .iter()
+            .filter(|d| **d != 0.0 && d.signum() == sign)
+            .count();
+        let nonzero = diffs.iter().filter(|d| **d != 0.0).count();
+        let sign_agreement = if nonzero == 0 {
+            0.0
+        } else {
+            (agree + (n - nonzero)) as f64 / n as f64
+        };
+        let firm = n >= 2
+            && std_error > 0.0
+            && ms.mean.abs() >= firm_z * std_error
+            && (sign_agreement - 1.0).abs() < 1e-9;
+        PairedContrast {
+            delta: ms.mean,
+            delta_std: ms.std,
+            std_error,
+            n,
+            firm,
+            firm_z,
+            per_seed: diffs,
+            sign_agreement,
+        }
+    }
+}
+
+/// A small-sample-honest `firm_z` for `n` seeds: the two-sided 95 % Student-t quantile (df = n−1),
+/// falling back to the normal `1.96` once `n` is large. Using `t` not `z` is the honest choice for
+/// the handful of seeds this work-box harness runs — with only 5 seeds the `t` critical value (2.78)
+/// is materially stricter than `z` (1.96), so a "firm" verdict is not an artefact of pretending the
+/// sample is large. [OPUS-4.8] sq-4891y.
+pub fn firm_z_for(n: usize) -> f64 {
+    // Two-sided 95 % t critical values by df = n-1 (df 1..=10), then the normal limit.
+    const T95: [f64; 11] = [
+        0.0,    // df 0 (n=1) — unusable; PairedContrast::firm guards n>=2 anyway.
+        12.706, // df 1 (n=2)
+        4.303,  // df 2 (n=3)
+        3.182,  // df 3 (n=4)
+        2.776,  // df 4 (n=5)
+        2.571,  // df 5 (n=6)
+        2.447,  // df 6 (n=7)
+        2.365,  // df 7 (n=8)
+        2.306,  // df 8 (n=9)
+        2.262,  // df 9 (n=10)
+        2.228,  // df 10 (n=11)
+    ];
+    if n < 2 {
+        return f64::INFINITY; // cannot be firm with <2 paired samples.
+    }
+    let df = n - 1;
+    if df < T95.len() {
+        T95[df]
+    } else {
+        1.96 // large-sample normal limit.
+    }
+}
+
+/// The two **closure** contrasts of an ablation: closure-on − closure-off at each negative-sampling
+/// mode, computed paired over seeds on a chosen metric+bucket. This is the bead's headline object —
+/// the closure prior is `firm` iff the paired delta clears [`firm_z_for`] standard errors with a
+/// unanimous sign. [OPUS-4.8] sq-4891y.
+#[derive(Clone, Debug)]
+pub struct ClosureVerdict {
+    /// closure ON − OFF at **uniform** negatives (cells 0 → 2).
+    pub at_uniform: PairedContrast,
+    /// closure ON − OFF at **type-constrained** negatives (cells 1 → 3).
+    pub at_type: PairedContrast,
+}
+
+impl ClosureVerdict {
+    /// Compute both closure contrasts over `res` on `(metric, bucket)`, using the small-sample
+    /// `firm_z` for the seed count. The cell indices follow the fixed `run_ablation` order.
+    pub fn compute(res: &MultiSeedResult, metric: Metric, bucket: Bucket) -> ClosureVerdict {
+        let z = firm_z_for(res.seeds.len());
+        ClosureVerdict {
+            at_uniform: PairedContrast::compute(res, 0, 2, metric, bucket, z),
+            at_type: PairedContrast::compute(res, 1, 3, metric, bucket, z),
+        }
+    }
+
+    /// Is the closure prior firm under EITHER negative-sampling mode? (Adoption needs only one
+    /// firm, sign-positive lift; the bead separately RECORDS that type-constrained negatives depress
+    /// the result, so the uniform-negative contrast is the one expected to fire.)
+    pub fn any_firm_positive(&self) -> bool {
+        (self.at_uniform.firm && self.at_uniform.delta > 0.0)
+            || (self.at_type.firm && self.at_type.delta > 0.0)
+    }
 }
 
 /// Per-cell accumulator of one metric sample per seed, for the overall/head/tail buckets.
@@ -1135,6 +1405,320 @@ ex:c ex:rel ex:y .
         assert_eq!(cells.len(), 4);
         for c in &cells {
             assert_eq!(c.metrics.mrr.n, 2);
+        }
+    }
+
+    #[test]
+    fn full_result_preserves_per_seed_alignment() {
+        // run_ablation_multiseed_full must return one aligned 4-cell row per seed, in seed order,
+        // and the aggregated cells must equal the wrapper's. [OPUS-4.8] sq-4891y
+        let ttl = synthetic_gufo_ttl(80, 11);
+        let template = EvalConfig::small(0);
+        let seeds = [1u64, 2, 3, 4];
+        let res = run_ablation_multiseed_full(&ttl, "turtle", template, &seeds).unwrap();
+        assert_eq!(res.per_seed.len(), seeds.len(), "one row per seed");
+        assert_eq!(res.seeds, seeds, "seed order preserved");
+        for row in &res.per_seed {
+            // Each row carries the fixed cell order.
+            assert!(!row[0].closure && !row[0].type_constrained);
+            assert!(!row[1].closure && row[1].type_constrained);
+            assert!(row[2].closure && !row[2].type_constrained);
+            assert!(row[3].closure && row[3].type_constrained);
+        }
+        // The aggregated cell means must equal the mean of the per-seed values (the wrapper is just
+        // an aggregation of the same per-seed matrix).
+        for ci in 0..4 {
+            let mean =
+                res.per_seed.iter().map(|r| r[ci].metrics.mrr).sum::<f64>() / seeds.len() as f64;
+            assert!(
+                (res.cells[ci].metrics.mrr.mean - mean).abs() < 1e-12,
+                "cell {} aggregate mean must match per-seed mean",
+                ci
+            );
+        }
+    }
+
+    #[test]
+    fn paired_contrast_decomposition_and_variance_reduction() {
+        // sq-4891y variance reduction. Because every seed draws all four cells from the SAME
+        // split+init, the per-seed PAIRED closure delta cancels the COMMON-MODE part of the noise.
+        // The EXACT identity (always true) is Var(b−a) = Var(a) + Var(b) − 2·Cov(a,b); pairing
+        // *reduces* variance below the independent sum EXACTLY WHEN the cross-seed covariance is
+        // positive (the common-mode "lucky seed" term). We verify (1) the decomposition holds to
+        // float precision, and (2) that the variance reduction `2·Cov` is captured — i.e. the paired
+        // variance equals `Var(a)+Var(b)−2·Cov(a,b)`, NOT `Var(a)+Var(b)`. We do NOT assert an
+        // unconditional inequality, because at small n the sample covariance can be slightly negative
+        // (an honest small-sample effect; the bead's point is the MECHANISM, not a guarantee that
+        // every tiny run reduces variance). [OPUS-4.8] sq-4891y
+        let ttl = synthetic_gufo_ttl(70, 21);
+        let mut template = EvalConfig::small(0);
+        template.train.epochs = 40; // small: the identity is algebraic, it does not need a big run.
+        let seeds = [10u64, 11, 12, 13, 14];
+        let res = run_ablation_multiseed_full(&ttl, "turtle", template, &seeds).unwrap();
+
+        // Per-cell samples for the closure axis at uniform negatives (cells 0 and 2).
+        let off: Vec<f64> = res.per_seed.iter().map(|r| r[0].metrics.mrr).collect();
+        let on: Vec<f64> = res.per_seed.iter().map(|r| r[2].metrics.mrr).collect();
+        let n = seeds.len() as f64;
+        let mean_off = MeanStd::of(&off).mean;
+        let mean_on = MeanStd::of(&on).mean;
+        let var_off = MeanStd::of(&off).std.powi(2);
+        let var_on = MeanStd::of(&on).std.powi(2);
+        // Population covariance across the SAME seeds (the common-mode term pairing cancels).
+        let cov = off
+            .iter()
+            .zip(&on)
+            .map(|(a, b)| (a - mean_off) * (b - mean_on))
+            .sum::<f64>()
+            / n;
+
+        let c = PairedContrast::compute(
+            &res,
+            0,
+            2,
+            Metric::Mrr,
+            Bucket::Overall,
+            firm_z_for(seeds.len()),
+        );
+        let paired_var = c.delta_std.powi(2);
+        assert_eq!(
+            c.n,
+            seeds.len(),
+            "all seeds contribute to the paired contrast"
+        );
+        assert_eq!(c.per_seed.len(), seeds.len());
+        // (1) The paired delta equals the difference of cell means.
+        assert!(
+            (c.delta - (mean_on - mean_off)).abs() < 1e-12,
+            "paired delta must equal the difference of cell means"
+        );
+        // (2) The variance decomposition holds EXACTLY: Var(b−a) = Var(a)+Var(b)−2·Cov(a,b).
+        let decomposed = var_on + var_off - 2.0 * cov;
+        assert!(
+            (paired_var - decomposed).abs() < 1e-9,
+            "paired variance {} must equal Var(a)+Var(b)-2*Cov(a,b)={} (the variance-reduction \
+             identity: pairing subtracts 2*Cov, the common-mode term)",
+            paired_var,
+            decomposed,
+        );
+    }
+
+    #[test]
+    fn closure_axis_moves_mrr_on_schema_bearing_slice() {
+        // On a SCHEMA-BEARING KG (the gUFO slice — RDFS-typed, where the closure actually
+        // materialises rdf:type/subClassOf so the prior CAN bite, unlike a plain .nt where it is a
+        // proven no-op), the closure axis must MEASURABLY move the MRR. We assert the WEAK, robust
+        // property the harness can guarantee — that the paired closure delta is non-trivially nonzero
+        // (the prior is not a no-op here) and that the verdict machinery produces a coherent result —
+        // NOT a fixed sign. The sign of the lift is itself unstable across generator slices (see
+        // `closure_lift_sign_is_unstable_across_generator_seeds`), which is the bead's honest finding.
+        // [OPUS-4.8] sq-4891y
+        let ttl = synthetic_gufo_ttl(70, 3);
+        let mut template = EvalConfig::small(0);
+        template.train.epochs = 40;
+        let seeds: Vec<u64> = (0..4).map(|i| 4242u64 + i).collect();
+        let res = run_ablation_multiseed_full(&ttl, "turtle", template, &seeds).unwrap();
+
+        let verdict = ClosureVerdict::compute(&res, Metric::Mrr, Bucket::Overall);
+        // The prior is NOT a no-op on schema-bearing data: the paired closure delta moves the metric
+        // by a non-trivial amount under at least one negative-sampling mode.
+        assert!(
+            verdict.at_uniform.delta.abs() > 0.01 || verdict.at_type.delta.abs() > 0.01,
+            "closure must measurably move MRR on a schema-bearing slice (not a no-op): \
+             unif={} type={}",
+            verdict.at_uniform.delta,
+            verdict.at_type.delta,
+        );
+        // The verdict is internally coherent: standard error == delta_std/√n; firm implies the
+        // significance bound AND unanimity hold.
+        for c in [&verdict.at_uniform, &verdict.at_type] {
+            let expect_se = c.delta_std / (c.n as f64).sqrt();
+            assert!(
+                (c.std_error - expect_se).abs() < 1e-12,
+                "std_error == delta_std/√n"
+            );
+            if c.firm {
+                assert!(c.delta.abs() >= c.firm_z * c.std_error - 1e-12);
+                assert!(
+                    (c.sign_agreement - 1.0).abs() < 1e-9,
+                    "firm ⇒ unanimous sign"
+                );
+            }
+        }
+    }
+
+    #[test]
+    #[ignore = "heavy empirical characterization (96 trainings, ~2 min); run on demand: \
+                cargo test -p sparq-vectors --features kge -- --ignored closure_lift_sign"]
+    fn closure_lift_sign_is_unstable_across_generator_seeds() {
+        // The bead's HONEST finding (empirical-honesty mandate): the gUFO closure-prior lift is NOT
+        // robust — its SIGN flips across generator slices. We build several gUFO slices (different
+        // generator seeds), compute the paired closure@unif MRR delta on each (a handful of prior
+        // seeds, modest epochs — enough to expose the instability without a long run), and assert
+        // that the sign is NOT consistent across slices. If a future change ever makes the lift
+        // robustly one-signed across generator seeds, THIS test fails loudly and the verdict in
+        // `research/structure-aware-vectorisation.md` must be revisited — that is the intent.
+        // [OPUS-4.8] sq-4891y
+        let mut template = EvalConfig::small(0);
+        template.train.epochs = 80;
+        template.train.dim = 32;
+        template.train.negatives_per_positive = 8;
+        let prior_seeds: Vec<u64> = (0..4).map(|i| 100u64 + i).collect();
+
+        let mut signs: Vec<i32> = Vec::new();
+        for gen_seed in [1u64, 2, 3, 7, 11, 23] {
+            let ttl = synthetic_gufo_ttl(140, gen_seed);
+            let res = run_ablation_multiseed_full(&ttl, "turtle", template, &prior_seeds).unwrap();
+            let d = PairedContrast::compute(
+                &res,
+                0,
+                2,
+                Metric::Mrr,
+                Bucket::Overall,
+                firm_z_for(prior_seeds.len()),
+            )
+            .delta;
+            // Record only non-trivial signs (a delta within float noise of zero is uninformative).
+            if d.abs() > 1e-3 {
+                signs.push(if d > 0.0 { 1 } else { -1 });
+            }
+        }
+        assert!(
+            signs.len() >= 3,
+            "need several informative slices to judge stability: {:?}",
+            signs
+        );
+        let positives = signs.iter().filter(|s| **s > 0).count();
+        let negatives = signs.len() - positives;
+        // Instability == both signs occur. This documents the bead's verdict as an executable fact:
+        // the synthetic gUFO closure lift is direction-unstable, so it is NOT firmly adoptable here.
+        assert!(
+            positives > 0 && negatives > 0,
+            "closure lift sign should be UNSTABLE across generator slices (the bead's honest finding); \
+             got signs={:?} (positives={}, negatives={}). If this is now stable, revisit the verdict.",
+            signs,
+            positives,
+            negatives,
+        );
+    }
+
+    #[test]
+    fn firm_z_is_small_sample_honest() {
+        // firm_z must be the (stricter) small-sample Student-t value for few seeds and relax toward
+        // the normal 1.96 as n grows; <2 samples cannot be firm. [OPUS-4.8] sq-4891y
+        assert_eq!(
+            firm_z_for(1),
+            f64::INFINITY,
+            "cannot be firm with <2 samples"
+        );
+        assert!((firm_z_for(5) - 2.776).abs() < 1e-9, "n=5 ⇒ t(df=4)=2.776");
+        assert!(
+            firm_z_for(5) > firm_z_for(11),
+            "t shrinks toward z as n grows"
+        );
+        assert!(
+            (firm_z_for(50) - 1.96).abs() < 1e-9,
+            "large n ⇒ normal limit 1.96"
+        );
+    }
+
+    #[test]
+    fn firm_verdict_requires_sign_unanimity() {
+        // A contrast whose mean is large but whose per-seed signs disagree must NOT be firm — the
+        // unanimity guard is what stops a couple of huge-swing seeds masquerading as a stable lift.
+        // We build a synthetic MultiSeedResult by hand so the test owns the per-seed differences.
+        // [OPUS-4.8] sq-4891y
+        let res = synthetic_result_with_cell0_cell2_mrr(&[
+            // (cell0 mrr, cell2 mrr): cell2-cell0 = +0.5, +0.5, +0.5, -0.9 (one seed flips sign)
+            (0.1, 0.6),
+            (0.1, 0.6),
+            (0.1, 0.6),
+            (1.0, 0.1),
+        ]);
+        let c = PairedContrast::compute(&res, 0, 2, Metric::Mrr, Bucket::Overall, 1.0);
+        assert!(c.delta > 0.0, "mean diff is positive");
+        assert!(c.sign_agreement < 1.0, "signs are NOT unanimous");
+        assert!(
+            !c.firm,
+            "must not be firm without sign unanimity even if |delta| clears z*se"
+        );
+
+        // A unanimous, low-variance positive contrast IS firm.
+        let res2 = synthetic_result_with_cell0_cell2_mrr(&[
+            (0.10, 0.50),
+            (0.12, 0.52),
+            (0.11, 0.49),
+            (0.13, 0.51),
+        ]);
+        let c2 = PairedContrast::compute(&res2, 0, 2, Metric::Mrr, Bucket::Overall, firm_z_for(4));
+        assert!((c2.sign_agreement - 1.0).abs() < 1e-9, "signs unanimous");
+        assert!(
+            c2.firm,
+            "unanimous, tight, large lift must be firm: {:?}",
+            c2
+        );
+    }
+
+    /// Build a [`MultiSeedResult`] whose per-seed rows have the given (cell0 MRR, cell2 MRR) and
+    /// trivial values elsewhere — a test fixture for the paired-contrast logic that does not depend
+    /// on training. [OPUS-4.8] sq-4891y
+    fn synthetic_result_with_cell0_cell2_mrr(pairs: &[(f64, f64)]) -> MultiSeedResult {
+        let mk_cell = |closure: bool, tc: bool, mrr: f64| AblationCell {
+            closure,
+            type_constrained: tc,
+            gufo_prior: false,
+            metrics: Metrics {
+                queries: 10,
+                mrr,
+                hits1: 0.0,
+                hits3: 0.0,
+                hits10: 0.0,
+            },
+            long_tail: LongTail {
+                threshold: 2,
+                head: Metrics::default(),
+                tail: Metrics::default(),
+            },
+            report: TrainReport {
+                epoch_loss: vec![1.0, 0.5],
+                positives: 10,
+                entities: 10,
+                relations: 1,
+            },
+        };
+        let per_seed: Vec<[AblationCell; 4]> = pairs
+            .iter()
+            .map(|&(c0, c2)| {
+                [
+                    mk_cell(false, false, c0),
+                    mk_cell(false, true, 0.0),
+                    mk_cell(true, false, c2),
+                    mk_cell(true, true, 0.0),
+                ]
+            })
+            .collect();
+        let seeds: Vec<u64> = (0..pairs.len() as u64).collect();
+        // Aggregated cells are not used by these tests; build them from the per-seed matrix.
+        let mut samples: Vec<CellSamples> = (0..4).map(|_| CellSamples::default()).collect();
+        for row in &per_seed {
+            for (ci, cell) in row.iter().enumerate() {
+                samples[ci].push(cell);
+            }
+        }
+        let shape = [(false, false), (false, true), (true, false), (true, true)];
+        let cells = (0..4)
+            .map(|ci| MultiSeedCell {
+                closure: shape[ci].0,
+                type_constrained: shape[ci].1,
+                metrics: samples[ci].overall.finish(),
+                tail: samples[ci].tail.finish(),
+                head: samples[ci].head.finish(),
+            })
+            .collect();
+        MultiSeedResult {
+            cells,
+            per_seed,
+            seeds,
         }
     }
 

--- a/crates/sparq-vectors/src/lib.rs
+++ b/crates/sparq-vectors/src/lib.rs
@@ -161,10 +161,14 @@ pub use structure::{
 // harness surface — `kge` feature only.
 #[cfg(feature = "kge")]
 pub use eval::{
-    run_ablation, run_ablation_multiseed, synthetic_gufo_ttl, synthetic_relational_ttl,
-    AblationCell, CellStats, EvalConfig, LongTail, MeanStd, Metrics, MultiSeedCell, Splits,
+    firm_z_for, run_ablation, run_ablation_multiseed, run_ablation_multiseed_full,
+    synthetic_gufo_ttl, synthetic_relational_ttl, AblationCell, Bucket, CellStats, ClosureVerdict,
+    EvalConfig, LongTail, MeanStd, Metrics, MultiSeedCell, MultiSeedResult, PairedContrast, Splits,
     SCHEMA_PREDICATES,
 };
+// NOTE: `eval::Metric` (which ablation metric — MRR/Hits@k) is intentionally NOT re-exported at the
+// crate root: the name collides with the existing `encode::Metric` (a vector distance metric). It is
+// reachable via the full path `sparq_vectors::eval::Metric`. [OPUS-4.8] sq-4891y
 #[cfg(feature = "kge")]
 pub use train::{train, ModelKind, TrainConfig, TrainReport, TrainedModel};
 // [OPUS-4.8] sq-0wo9e.2 (epic sq-0wo9e): the structure-aware-vectorisation P1 surface — the typed

--- a/research/structure-aware-vectorisation.md
+++ b/research/structure-aware-vectorisation.md
@@ -338,6 +338,27 @@ seeds; per-prior on/off matrix; the formal properties (6.A) as unit/property/met
 that run in CI; the empirical numbers (6.B) as a separate, dataset-gated bench that publishes to
 the dashboard (never baked into markdown — AGENTS.md *No hard-coded performance numbers*).
 
+**Variance reduction & the firm-verdict gate (sq-4891y).** The per-cell mean ± std over seeds is
+*not* the figure to gate on: it is dominated by **common-mode** seed noise (which train/test split
+and init a seed draws moves every cell together), so on a schema-bearing slice a cell's std can be
+≈ its mean even when a prior has a real effect. Each seed draws all four ablation cells from the
+*same* split+init, so the **paired** contrast — closure-on − closure-off computed *within a seed*
+and aggregated — cancels that common-mode term (the textbook paired-difference variance reduction,
+`Var(b−a) = Var(a)+Var(b)−2·Cov(a,b)`). The harness (`crates/sparq-vectors/src/eval.rs`:
+`run_ablation_multiseed_full` → `PairedContrast` / `ClosureVerdict`) reports the paired delta, its
+paired std, the standard error (`∝ 1/√n` — more seeds shrink it), and a **`firm`** flag:
+`|delta| ≥ t·std_error` at a *small-sample Student-t* threshold (`firm_z_for`, honest about the
+handful of seeds a work-box runs) **AND** a unanimous per-seed sign. A prior is adopted only on a
+firm, sign-positive lift. **Measured (NON-CANONICAL, work-box, INDICATIVE — re-measure on a
+canonical machine + real schema-bearing KG):** on the synthetic gUFO slice the closure lift is
+**real but direction-UNSTABLE** — its *sign flips across generator slices* (asserted by the
+`closure_lift_sign_is_unstable_across_generator_seeds` characterisation test), and even where it is
+large and unanimous-in-sign the paired standard error at a handful of seeds does not clear the
+firm-verdict bar. So variance reduction **did not firm up** the synthetic gUFO closure claim: the
+instrument now *exists and is honest*, and the verdict on synthetic data is "not firmly adoptable —
+needs a real schema-bearing KG to settle". The firm-verdict gate is the mechanism that would let a
+real-dataset run on a canonical machine settle it.
+
 ---
 
 ## 7. sparq integration — opt-in crate over sparq-vectors + sparq-shacl + sparq-reason


### PR DESCRIPTION
> 🤖 This PR was prepared by a **SPARQ agent** (Claude Opus 4.8) on behalf of @jeswr.

Closes bead **sq-4891y** — *"Firm up the gUFO closure-prior claim: variance reduction (more seeds/epochs, LR tune) so the ~2x MRR delta exceeds the per-seed spread (currently std≥mean)."*

## What the bead asked
The canonical KGE ablation was inadequate: on the gUFO slice the per-seed std was on the order of the cell mean, so the ~2× MRR closure lift could not be called firm. The bead asked for variance reduction (more seeds/epochs, LR tune) so the lift exceeds the per-seed spread, on a **schema-bearing** KG (the gUFO slice — RDFS-typed, where the closure actually materialises `rdf:type`/`subClassOf`, unlike a plain `.nt`).

## What this does (all `kge` feature — opt-in, off by default; core/engine untouched)
The per-cell std is dominated by **common-mode** seed noise (which split/init a seed draws moves every cell together). Because each seed produces all four ablation cells from the **same** draw, the **paired** contrast (closure-on − closure-off *within a seed*) cancels that common-mode term — textbook paired-difference variance reduction `Var(b−a)=Var(a)+Var(b)−2·Cov(a,b)`.

In `crates/sparq-vectors/src/eval.rs`:
- `run_ablation_multiseed_full` → `MultiSeedResult` (raw per-seed cell matrix; `run_ablation_multiseed` becomes a thin wrapper);
- `PairedContrast` / `ClosureVerdict`: the paired delta, its (far smaller) paired std, the standard error (`∝ 1/√n` — more seeds shrink it), and a **`firm`** flag = `|delta| ≥ t·std_error` at a **small-sample Student-t** threshold (`firm_z_for`, honest about a handful of seeds) **AND** a unanimous per-seed sign;
- `SPARQ_KGE_SEEDS` / `SPARQ_KGE_EPOCHS` / `SPARQ_KGE_LR` tuning knobs on the `kge_ablation` example, which now prints the paired closure verdict.

## Honest finding (best-judgment decision — empirical-honesty mandate)
**Variance reduction did NOT firm up the synthetic gUFO closure claim.** The lift is *real but direction-UNSTABLE* — its **sign flips across generator slices** (asserted by the `#[ignore]`'d `closure_lift_sign_is_unstable_across_generator_seeds` characterization test), and the paired standard error at a handful of seeds does not clear the firm bar even when 100% of seeds agree on sign. So the instrument now **exists and is honest**, and the verdict on *synthetic* data is: **"not firmly adoptable — needs a real schema-bearing KG (`SPARQ_KGE_DATASET`) on a canonical machine to settle."** The `firm`-verdict gate is exactly the mechanism a real-dataset run would use to settle it.

This is a deliberate, documented judgment call (per the standing "proceed without greenlight" rule): rather than rig a test to assert a positive lift that isn't robust, the PR ships the measurement instrument + the honest negative result. `research/structure-aware-vectorisation.md` §6.B updated accordingly. **No performance numbers are committed.**

## Gates
- `cargo clippy -p sparq-vectors --all-targets` for `{default, kge, --all-features}` with `-D warnings` — green
- `RUSTDOCFLAGS=-D warnings cargo doc --all-features` — green
- `cargo fmt` — my edit regions clean (pre-existing repo-wide drift in `lib.rs` is unrelated; the CI fmt gate is informational/`continue-on-error` pending the deferred workspace reformat)
- `scripts/check-no-perf-numbers.py`, `scripts/check-privacy-claims.sh` — green
- `cargo test -p sparq-vectors --features kge --lib` — 124 pass, 1 heavy characterization test `#[ignore]`'d; default-feature build compiles the eval code out (45 pass)

No crate README touched. Auto-merge intentionally OFF.