### PR TITLE
ci(feature-matrix): add the sparq-kb `close` opt-in feature leg (sq-8cuf8) [OPUS-4.8]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -406,17 +406,41 @@ jobs:
           # `cargo test -p sparq-kb --features validate` runs 3 dogfood_shacl + 2 ingest_shacl
           # (+1 vocab unit) tests, `--features query` adds the 3 ingest_query tests, and
           # `clippy --all-targets -D warnings` is clean in every state.
-          # NOTE: the optional `close` feature (pulls sparq-reason) + the `query_canned`
-          # suite are NOT on main yet (they arrive with PR #1075, still open) — adding a
-          # `close` leg now would ENOENT (`does not have feature 'close'`), so it is
-          # deliberately omitted; extend with a `close` leg when #1075 lands.
+          # [OPUS-4.8] sq-8cuf8: the optional `close` feature (Cargo.toml: `close =
+          # ["query", "dep:sparq-reason"]`) landed on main with PR #1075, so the leg the
+          # NOTE above deferred is now wired below. `close` is a TRUE `not(feature=…)`
+          # divergence — NOT just an additive superset of `query` — so it gets its OWN
+          # isolated leg per rule (b) of the GUARD above, for two reasons:
+          #   (1) `tests/query_canned.rs` is `#![cfg(feature = "query")]` AND contains
+          #       `closure_materialises_the_blockedby_inverse`, an extra
+          #       `#[cfg(feature = "close")]` test. The `query` leg above COMPILES that
+          #       test body EMPTY (it passes `--features query`, not `close`), so the
+          #       inverse-/symmetric-edge closure proof ran ZERO times — the silent gap
+          #       this leg closes; and
+          #   (2) `src/bin/pkg_query.rs` has divergent `#[cfg(feature = "close")]` vs
+          #       `#[cfg(not(feature = "close"))]` arms of `load_closed` (real OWL-RL
+          #       closure vs the "--close needs the `close` feature" error). The `query`
+          #       leg exercises the `not(close)` arm; THIS leg compiles + clippies the
+          #       `close` arm (the one that actually pulls sparq-reason and materialises
+          #       the closure), so neither code path rots.
+          # `close` implies `query` (⊃ `validate`), so it is the crate's MAXIMAL feature
+          # set today and equivalent to `--all-features` for sparq-kb. It adds only the
+          # already-built sparq-reason dep (sparq-reason depends solely on sparq-core, in
+          # the `query` build), so the leg is cheap. Verified locally on this branch:
+          # `cargo test -p sparq-kb --features close` runs all of `query`'s suites PLUS
+          # the previously-skipped close test (query_canned: 9 vs 8 under `query`), and
+          # `clippy --all-targets -D warnings` is clean with the feature ON.
           - name: sparq-kb (validate)
             crate: sparq-kb
             features: validate
             test: true
-          - name: sparq-kb (query, implies validate — maximal feature set)
+          - name: sparq-kb (query, implies validate)
             crate: sparq-kb
             features: query
+            test: true
+          - name: sparq-kb (close, implies query — maximal feature set)
+            crate: sparq-kb
+            features: close
             test: true
           # [OPUS-4.8] sq-leg8n: the sparq-terse opt-in LLM-ergonomic SPARQL surface
           # (epic sq-2m6zm, design research/llm-ergonomic-sparql-surface.md). Only the


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** working on `jeswr/sparq` CI/supply-chain infrastructure. This PR is automated. @jeswr runs multiple agents on this account.

## What this wires + where

`.github/workflows/feature-matrix.yml` — adds one new opt-in matrix leg:

```yaml
- name: sparq-kb (close, implies query — maximal feature set)
  crate: sparq-kb
  features: close
  test: true
```

It also (a) replaces the stale `NOTE:` block that deferred this leg until PR #1075 landed, with the rationale for why `close` is its own leg, and (b) drops the "— maximal feature set" tail from the `query` leg name (the `close` leg is now the maximal set for sparq-kb).

## Why — closes bead sq-8cuf8 (unblocked by #1075)

PR #1075 (sq-2m6zm.3) merged the optional `close` feature into sparq-kb (`close = ["query", "dep:sparq-reason"]`), which the prior code-comment marked as the place to extend once it landed. `close` is a **true `not(feature=…)` divergence**, not just an additive superset of `query`, so per the workflow's own GUARD (rule (b)) it gets its **own isolated leg**:

1. `crates/sparq-kb/tests/query_canned.rs` is `#![cfg(feature = "query")]` and contains an extra `#[cfg(feature = "close")]` test `closure_materialises_the_blockedby_inverse` (the OWL-RL inverse/symmetric-edge closure proof). The `query` leg passes `--features query` (not `close`), so it compiled that test body **EMPTY** — it ran ZERO times. Verified: `query_canned` lists **9** tests under `--features close` vs **8** under `--features query`.
2. `crates/sparq-kb/src/bin/pkg_query.rs::load_closed` has divergent `#[cfg(feature = "close")]` (real closure, pulls `sparq-reason`) vs `#[cfg(not(feature = "close"))]` (error) arms. The `query` leg only exercises the `not(close)` arm; this leg compiles + clippies the `close` arm.

`close` implies `query` (⊃ `validate`), so it is sparq-kb's maximal feature set today and equivalent to `--all-features` for the crate. It adds only the already-built `sparq-reason` dep (which depends solely on `sparq-core`), so the leg is cheap.

## Exact commands (the leg's steps), reproduced locally on this branch — all green

```
cargo build  -p sparq-kb --features close
cargo test   -p sparq-kb --features close      # close-only test runs; 33 tests pass total
cargo clippy -p sparq-kb --features close --all-targets -- -D warnings
```

## Gate validity

- YAML valid: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/feature-matrix.yml'))"` → OK.
- `actionlint .github/workflows/feature-matrix.yml` → no findings.
- `scripts/check-privacy-claims.sh` → OK (no unqualified ZK/MPC claim).
- No typos-gate words (`DELETEd`/`DROPped`/`invokable`/`ANDed`) in the diff.
- No hard-coded performance numbers — the "9 vs 8" figures are deterministic test counts (the exact silent-skip gap this leg closes), not timings.

## Gate aggregator

The new leg name `opt-in sparq-kb (close, implies query — maximal feature set)` contains **no** `advisory`/`informational` token, so the single required `ci-summary / gate` aggregator auto-discovers it as a **REQUIRED gating** check (no edit to `ci-summary.yml` — it polls by name). The leg sits under the path-filtered `opt-in-features` job (`needs.changes` / `rust_changed`), so a purely non-Rust PR reports `skipped` (non-failing) and the gate still resolves.

## Compliance gap closed

Restores the rot-protection contract for the `close` opt-in (CDMC cert finding sq-kzfi class): a default-feature change can no longer silently break the `close` build/clippy or skip the closure-correctness test. Honest level: this gates the **build + clippy `-D warnings` + the previously-skipped `close`-gated test** of the sparq-kb `close` feature; it does not assert anything about the (unmeasured) token saving from closure-before-query (that is bead sq-2m6zm.4).

Closes sq-8cuf8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)