### PR TITLE
ci: close self-guarding path-filter blind spots in docs/site-e2e/ci (sq-5f1s4) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,12 @@ jobs:
             docker:
               - 'Dockerfile'
               - '**/Dockerfile'
+              # [OPUS-4.8] sq-5f1s4 — `.dockerignore` shapes the `context: .` build the
+              # docker-smoke job runs (it decides what `COPY . .` includes). A
+              # `.dockerignore`-only PR that breaks the build context would otherwise set
+              # docker_changed=false and skip the smoke at PR time (the gui.yml/#1081
+              # blind-spot class). container-scan.yml already lists it; match that here.
+              - '.dockerignore'
               - 'scripts/docker-smoke.sh'
               - '.github/workflows/ci.yml'
       - name: Decide rust_changed (safe-by-default off the PR path)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,14 +32,23 @@
 name: docs
 
 on:
+  # [OPUS-4.8] sq-5f1s4 — self-guarding path filter: the build embeds source it does NOT
+  # live next to. `book/src/getting-started/install.md` does
+  # `{{#rustdoc_include ../../../crates/sparq-engine/examples/quickstart.rs:quickstart}}`,
+  # so `mdbook build` / `mdbook test` COMPILE that example. If it stopped compiling (or the
+  # `quickstart` anchor were renamed/removed) and the filter only watched `book/**`, the
+  # break would land on main undetected — no `book/`-touching commit would re-run this lane
+  # to catch it (the gui.yml/#1081 blind-spot class). So the included example is listed too.
   push:
     branches: [main]
     paths:
       - "book/**"
+      - "crates/sparq-engine/examples/quickstart.rs"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
       - "book/**"
+      - "crates/sparq-engine/examples/quickstart.rs"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 

--- a/.github/workflows/site-e2e.yml
+++ b/.github/workflows/site-e2e.yml
@@ -18,14 +18,26 @@
 name: site-e2e
 
 on:
+  # [OPUS-4.8] sq-5f1s4 — self-guarding path filter: this lane's `npm ci` resolves the
+  # `site` workspace member from the REPO-ROOT lockfile + manifest (site/ is an npm
+  # workspace member; the per-member lock was dropped — see the install step). A change to
+  # the root `package-lock.json`/`package.json` (e.g. a sibling member bumping a hoisted
+  # dep, or a lock regeneration) can break `npm ci` here, but the old `site/**`-only filter
+  # would NOT re-run the lane to catch it — and BOTH legs here are path-filtered, so there
+  # is no unfiltered main-push catch-all either (unlike js.yml). That is the exact
+  # gui.yml/#1081 blind-spot class, so the root workspace inputs are listed too.
   pull_request:
     paths:
       - "site/**"
+      - "package.json"
+      - "package-lock.json"
       - ".github/workflows/site-e2e.yml"
   push:
     branches: [main]
     paths:
       - "site/**"
+      - "package.json"
+      - "package-lock.json"
       - ".github/workflows/site-e2e.yml"
 
 # Least-privilege default (Scorecard TokenPermissions): read-only; this lane never writes.


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** working autonomously on `jeswr/sparq` CI/supply-chain infrastructure. This PR was authored by Claude (Opus 4.8) while Fable is unavailable — please re-review when Fable returns.

## What & why (sq-5f1s4)

Audit of every path-scoped CI lane for the **gui.yml / #1081 blind-spot class**: a lane whose `on: paths:` filter omits a *transitive input it actually compiles/builds*, so a break in that input can land on `main` undetected (no filtered commit re-runs the lane to catch it — exactly how the `fzstd` ESM-bundle break sat on main until #1048/#1081).

This is a **filter-widening-only** change: every edit makes a lane trigger on *more* PRs, never fewer. No job names, `if:` semantics, or gate wiring changed, so the `ci-summary / gate` aggregator is unaffected.

## Fixes (3 real blind spots)

| Lane | Compiled/built input it omitted | Fix |
|------|--------------------------------|-----|
| `docs.yml` | `crates/sparq-engine/examples/quickstart.rs` — `mdbook build`/`mdbook test` compile it via `{{#rustdoc_include …:quickstart}}` in `book/src/getting-started/install.md`; filter only watched `book/**`, **both legs filtered** (no catch-all) | added the example path to both PR + push legs |
| `site-e2e.yml` | root `package-lock.json` + `package.json` — `npm ci` resolves the `site` workspace member from the **root** lock (per-member lock dropped); **both legs filtered**, no unfiltered main-push catch-all (unlike `js.yml`) | added root lock + manifest to both legs |
| `ci.yml` (`docker` dorny filter) | `.dockerignore` — shapes the `context: .` build the `docker-smoke` job runs (decides what `COPY . .` includes); `container-scan.yml` already lists it | added `.dockerignore` for parity |

## Lanes audited and confirmed already-safe (no change, documented)

- **`js.yml`** — its unfiltered `push: branches:[main]` leg re-runs the wasm-pack build on every main push, giving post-merge cover for transitive `sparq-*-wasm` Rust deps; not worth re-running heavy wasm on every Rust PR.
- **`container-scan.yml` (trivy)** — scans the OS + dependency layers, so `Cargo.toml`/`Cargo.lock`/`crates/**/Cargo.toml` is the correct granularity (a pure `.rs` change introduces no new CVE), plus a weekly schedule.
- **`zk-toolchain.yml`** — nightly schedule is the explicit standing catch-all for transitive breaks.
- **`ci.yml` / `feature-matrix.yml` / `supply-chain.yml`** dorny filters already use `**/*.rs` + `**/Cargo.toml` globs (no narrow blind spot).
- **`pages.yml` / `python.yml`** — unfiltered on `push`, always re-run on main.

## Gates run locally

- YAML valid: `python3 -c "import yaml; yaml.safe_load(open(p))"` for all 3 files — OK.
- `actionlint v1.7.7` clean on `docs.yml` + `site-e2e.yml`; on `ci.yml` the only findings are 12 pre-existing `SC2015` *info* notes (verified identical count on `origin/main` — my edit adds none).
- Local reproduction of the docs lane: `cargo build -p sparq-engine --example quickstart` compiles, and `mdbook build book` runs clean (no `[ERROR]`) with the example body embedded into the rendered HTML — proving the now-guarded input is real and passes today.
- `typos` clean on the 3 files; `scripts/check-privacy-claims.sh` OK. No crate README touched (readme-template gate N/A). No hard-coded perf numbers.

## Compliance gap closed

Hardens CI **change-detection completeness** (an OpenSSF / supply-chain CI-hygiene posture): each lane now re-triggers on the inputs it actually builds, so a regression in a transitively-compiled input can no longer reach `main` undetected via a self-guarding filter.

Closes sq-5f1s4. Auto-merge intentionally **off**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)