### PR TITLE
fix(sparq-shacl): sh:pattern with an uncompilable regex skips + diagnoses, not fail-closed (sq-lz99x) [OPUS-4.8]

### DIFF
--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -109,7 +109,10 @@ The remaining out-of-scope item is the full `sparql/pre-binding` semantics (reje
 variable re-binding, `$shapesGraph`) — see `bd list -l area:sparq-shacl`. Validation
 results are **not deduplicated** across traversal routes (matching the test suite: a
 nested shape reached through two parents reports twice), and re-entrant recursion on the
-same focus/shape pair counts as conforming (SHACL leaves recursion undefined).
+same focus/shape pair counts as conforming (SHACL leaves recursion undefined). An
+**uncompilable `sh:pattern`** (e.g. a `(?!…)` lookahead — unsupported by Rust `regex`
+*and* by XML Schema regex) is **skipped**, surfaced in `report.diagnostics`, never
+fail-closed onto every value.
 
 ## License
 

--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -5,7 +5,7 @@ use crate::model::{
     sh, Component, ComponentDef, PreparedComponentValidator, Shape, ShapesModel, Target,
 };
 use crate::path::Path;
-use crate::report::ValidationResult;
+use crate::report::{ShapeDiagnostic, ValidationResult};
 use crate::sparql::{ComponentResultFields, PreparedValidator};
 use crate::view::GraphView;
 use oxrdf::{Literal, Term};
@@ -21,7 +21,10 @@ const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 /// OCCURRENCE (e.g. two sh:class violations on one value) and per traversal route
 /// (a nested shape reached through two parents reports twice). Duplicate focus
 /// nodes from overlapping targets ARE collapsed (in `focus_nodes`).
-pub(crate) fn validate_graph(data: &Graph, shapes: &ShapesModel) -> Vec<ValidationResult> {
+pub(crate) fn validate_graph(
+    data: &Graph,
+    shapes: &ShapesModel,
+) -> (Vec<ValidationResult>, Vec<ShapeDiagnostic>) {
     let mut v = Validator {
         data: GraphView::new(data),
         shapes,
@@ -30,6 +33,7 @@ pub(crate) fn validate_graph(data: &Graph, shapes: &ShapesModel) -> Vec<Validati
         min_reentry: usize::MAX,
         regexes: FxHashMap::default(),
         uvf_targets: FxHashMap::default(),
+        diagnostics: Vec::new(),
     };
     let mut out = Vec::new();
     for &sid in &shapes.targeted {
@@ -37,7 +41,7 @@ pub(crate) fn validate_graph(data: &Graph, shapes: &ShapesModel) -> Vec<Validati
             v.validate_shape(sid, &focus, &mut out);
         }
     }
-    out
+    (out, v.diagnostics)
 }
 
 /// [OPUS-4.8] (sq-d1dw, `shacl-af`) True iff `node` conforms to the shape `sid`
@@ -57,6 +61,7 @@ pub(crate) fn conforms_node(data: &Graph, shapes: &ShapesModel, sid: usize, node
         min_reentry: usize::MAX,
         regexes: FxHashMap::default(),
         uvf_targets: FxHashMap::default(),
+        diagnostics: Vec::new(),
     };
     v.conforms(node, sid)
 }
@@ -80,6 +85,11 @@ struct Validator<'a> {
     /// (the constraint needs every target node of the shape, but is evaluated once
     /// per focus node — compute the target scan once).
     uvf_targets: FxHashMap<usize, Vec<Term>>,
+    /// [OPUS-4.8] (sq-lz99x) Non-fatal author-time diagnostics for constraints
+    /// that were SKIPPED because they could not be evaluated (currently: an
+    /// uncompilable `sh:pattern` regex). De-duplicated per (shape, pattern, flags)
+    /// so a skip is reported once, not once per value/focus node.
+    diagnostics: Vec<ShapeDiagnostic>,
 }
 
 impl<'a> Validator<'a> {
@@ -346,20 +356,31 @@ impl<'a> Validator<'a> {
                 }
             }
             Component::Pattern { source, flags } => {
-                let re = self.regex_for(source, flags.as_deref());
-                for v in values {
-                    let ok = match (&re, string_repr(v)) {
-                        (Some(re), Some(s)) => re.is_match(&s),
-                        _ => false,
-                    };
-                    if !ok {
-                        out.push(self.result(
-                            sid,
-                            focus,
-                            Some(v.clone()),
-                            "PatternConstraintComponent",
-                            format!("Value does not match pattern \"{source}\""),
-                        ));
+                // [OPUS-4.8] (sq-lz99x) An uncompilable `sh:pattern` (e.g. an
+                // unbalanced bracket, or a `(?!...)` lookahead the Rust `regex`
+                // crate does not support — neither does the XML Schema regex
+                // flavour the W3C spec ties `sh:pattern` to) yields no regex.
+                // SKIP the constraint (the crate's lenient ill-formed-shape
+                // policy) and record a diagnostic, instead of fail-closed
+                // flagging EVERY value as a violation.
+                match self.regex_for(source, flags.as_deref()) {
+                    None => self.note_pattern_skipped(sid, source, flags.as_deref()),
+                    Some(re) => {
+                        for v in values {
+                            let ok = match string_repr(v) {
+                                Some(s) => re.is_match(&s),
+                                None => false,
+                            };
+                            if !ok {
+                                out.push(self.result(
+                                    sid,
+                                    focus,
+                                    Some(v.clone()),
+                                    "PatternConstraintComponent",
+                                    format!("Value does not match pattern \"{source}\""),
+                                ));
+                            }
+                        }
                     }
                 }
             }
@@ -1167,21 +1188,67 @@ impl<'a> Validator<'a> {
         let key = format!("{}\u{0}{}", source, flags.unwrap_or(""));
         self.regexes
             .entry(key)
-            .or_insert_with(|| {
-                let mut inline = String::new();
-                for f in flags.unwrap_or("").chars() {
-                    if matches!(f, 'i' | 'm' | 's' | 'x' | 'U') {
-                        inline.push(f);
-                    }
-                }
-                let pat = if inline.is_empty() {
-                    source.to_string()
-                } else {
-                    format!("(?{inline}){source}")
-                };
-                regex::Regex::new(&pat).ok()
-            })
+            .or_insert_with(|| regex::Regex::new(&compose_pattern(source, flags)).ok())
             .clone()
+    }
+
+    /// [OPUS-4.8] (sq-lz99x) Records a diagnostic for an uncompilable
+    /// `sh:pattern` that was SKIPPED, de-duplicated per (shape, pattern, flags) so
+    /// it is reported once regardless of how many focus nodes / values the shape
+    /// has. The recorded message carries the `regex` crate's own compile error
+    /// (recomputed here — only on the rare skip path), which names the unsupported
+    /// construct (e.g. look-around).
+    fn note_pattern_skipped(&mut self, sid: usize, source: &str, flags: Option<&str>) {
+        let shape = self.shapes.shapes[sid].node.clone();
+        let component = sh("PatternConstraintComponent");
+        let needle = format!("\"{source}\"");
+        let already = self.diagnostics.iter().any(|d| {
+            d.source_shape == shape
+                && d.source_component == component
+                && d.message.contains(&needle)
+        });
+        if already {
+            return;
+        }
+        let detail = match regex::Regex::new(&compose_pattern(source, flags)) {
+            Err(e) => e.to_string(),
+            // Unreachable: this is only called when `regex_for` returned None, but
+            // be defensive rather than panic.
+            Ok(_) => "the pattern did not compile".to_string(),
+        };
+        let flag_note = match flags {
+            Some(f) if !f.is_empty() => format!(" (flags \"{f}\")"),
+            _ => String::new(),
+        };
+        self.diagnostics.push(ShapeDiagnostic {
+            source_shape: shape,
+            source_component: component,
+            message: format!(
+                "sh:pattern \"{source}\"{flag_note} did not compile and was SKIPPED \
+                 (the constraint reports no violations); the Rust regex engine has no \
+                 lookahead/lookbehind, matching the XML Schema regex flavour the SHACL \
+                 spec ties sh:pattern to. regex error: {detail}"
+            ),
+        });
+    }
+}
+
+/// [OPUS-4.8] (sq-lz99x) Builds the final regex source for a `sh:pattern` /
+/// `sh:flags` pair: the supported XPath-regex flags (`i`/`m`/`s`/`x`/`U`) are
+/// turned into a leading inline `(?...)` group. Shared by [`Validator::regex_for`]
+/// (compile + match) and [`Validator::note_pattern_skipped`] (recompute the error)
+/// so both see byte-identical input.
+fn compose_pattern(source: &str, flags: Option<&str>) -> String {
+    let mut inline = String::new();
+    for f in flags.unwrap_or("").chars() {
+        if matches!(f, 'i' | 'm' | 's' | 'x' | 'U') {
+            inline.push(f);
+        }
+    }
+    if inline.is_empty() {
+        source.to_string()
+    } else {
+        format!("(?{inline}){source}")
     }
 }
 

--- a/crates/sparq-shacl/src/lib.rs
+++ b/crates/sparq-shacl/src/lib.rs
@@ -22,7 +22,9 @@ pub mod view;
 
 pub use model::{Component, Shape, ShapesModel, Target};
 pub use path::Path;
-pub use report::{ValidationReport, ValidationResult};
+// [OPUS-4.8] (sq-lz99x) `ShapeDiagnostic` surfaces a constraint the validator
+// SKIPPED because it could not be evaluated (e.g. an uncompilable `sh:pattern`).
+pub use report::{ShapeDiagnostic, ValidationReport, ValidationResult};
 
 // [OPUS-4.8] (sq-v0b8) SHACL Compact Syntax parser public surface (feature `scs`).
 #[cfg(feature = "scs")]
@@ -49,7 +51,8 @@ pub fn validate(data: &Graph, shapes: &Graph) -> ValidationReport {
 /// [`validate`] against an already-parsed shapes model (amortises shape
 /// parsing across many data graphs).
 pub fn validate_with_model(data: &Graph, model: &ShapesModel) -> ValidationReport {
-    ValidationReport::new(eval::validate_graph(data, model))
+    let (results, diagnostics) = eval::validate_graph(data, model);
+    ValidationReport::with_diagnostics(results, diagnostics)
 }
 
 /// Builds a queryable [`Graph`] from already-parsed triples. The seam for

--- a/crates/sparq-shacl/src/report.rs
+++ b/crates/sparq-shacl/src/report.rs
@@ -36,19 +36,59 @@ pub struct ValidationResult {
     pub details: Vec<ValidationResult>,
 }
 
+/// [OPUS-4.8] (sq-lz99x) A non-fatal author-time diagnostic: a constraint the
+/// validator could not evaluate and therefore SKIPPED (the crate's lenient
+/// ill-formed-shape policy), surfaced so the skip is not silent. Currently the
+/// only producer is an uncompilable `sh:pattern` regex — the Rust `regex` crate
+/// has no lookahead/lookbehind (neither does XML Schema regex, which the W3C SHACL
+/// spec ties `sh:pattern` to), so a `(?!...)` pattern fails to compile. A
+/// diagnostic never affects `conforms`: a skipped constraint reports no
+/// violations.
+#[derive(Debug, Clone)]
+pub struct ShapeDiagnostic {
+    /// The shape whose constraint was skipped (`sh:sourceShape`).
+    pub source_shape: Term,
+    /// The constraint-component IRI of the skipped constraint (e.g.
+    /// `sh:PatternConstraintComponent`).
+    pub source_component: String,
+    /// A human-readable explanation of why the constraint was skipped.
+    pub message: String,
+}
+
 /// The outcome of validating a data graph against a shapes graph.
 #[derive(Debug)]
 pub struct ValidationReport {
     /// True iff there are no validation results.
     pub conforms: bool,
     pub results: Vec<ValidationResult>,
+    /// [OPUS-4.8] (sq-lz99x) Non-fatal author-time diagnostics for constraints
+    /// that could not be evaluated and were therefore SKIPPED (e.g. an
+    /// uncompilable `sh:pattern` regex). These never affect `conforms` — a
+    /// skipped constraint contributes no results — but surface the skip so it is
+    /// not silent. Empty in the common (well-formed) case.
+    pub diagnostics: Vec<ShapeDiagnostic>,
 }
 
 impl ValidationReport {
+    // [OPUS-4.8] (sq-lz99x) Test-only convenience: the report tests below build
+    // reports from hand-rolled results (no diagnostics). Production code calls
+    // `with_diagnostics`, so gate this to `test` to avoid a dead-code warning in
+    // the plain lib build.
+    #[cfg(test)]
     pub(crate) fn new(results: Vec<ValidationResult>) -> Self {
+        Self::with_diagnostics(results, Vec::new())
+    }
+
+    /// [OPUS-4.8] (sq-lz99x) Build a report carrying both validation results and
+    /// skipped-constraint diagnostics (e.g. an uncompilable `sh:pattern`).
+    pub(crate) fn with_diagnostics(
+        results: Vec<ValidationResult>,
+        diagnostics: Vec<ShapeDiagnostic>,
+    ) -> Self {
         ValidationReport {
             conforms: results.is_empty(),
             results,
+            diagnostics,
         }
     }
 
@@ -92,10 +132,11 @@ impl ValidationReport {
 
     /// A human-readable rendering of the report.
     pub fn to_text(&self) -> String {
-        if self.conforms {
-            return "Conforms: data graph satisfies all shapes.\n".into();
-        }
-        let mut out = format!("Does not conform: {} result(s)\n", self.results.len());
+        let mut out = if self.conforms {
+            "Conforms: data graph satisfies all shapes.\n".to_string()
+        } else {
+            format!("Does not conform: {} result(s)\n", self.results.len())
+        };
         for r in &self.results {
             let sev = r.severity.rsplit(['#', '/']).next().unwrap_or(&r.severity);
             let comp = r
@@ -128,6 +169,17 @@ impl ValidationReport {
                 }
                 let _ = writeln!(out);
             }
+        }
+        // [OPUS-4.8] (sq-lz99x) Surface skipped-constraint diagnostics so the
+        // lenient skip is not silent. They never affect `conforms`.
+        for d in &self.diagnostics {
+            let comp = d
+                .source_component
+                .rsplit(['#', '/'])
+                .next()
+                .unwrap_or(&d.source_component);
+            let _ = writeln!(out, "! [diagnostic] shape {} | {comp}", d.source_shape);
+            let _ = writeln!(out, "    {}", d.message);
         }
         out
     }

--- a/crates/sparq-shacl/tests/constraints.rs
+++ b/crates/sparq-shacl/tests/constraints.rs
@@ -935,8 +935,9 @@ fn unique_values_for_no_values_conforms() {
 // The sq-qap0 datatype/pattern tests exercised only WELL-FORMED literals and a
 // VALID regex. These pin the still-dark conjuncts: the `&& well_formed(l)` FALSE
 // branch in `Component::Datatype` (right datatype IRI, ill-formed lexical value)
-// and the `regex_for(..) == None` branch in `Component::Pattern` (an invalid
-// pattern compiles to no regex, so every value violates — fail-closed/lenient).
+// and the `regex_for(..) == None` branch in `Component::Pattern` (an uncompilable
+// pattern yields no regex — the constraint is SKIPPED with a diagnostic, sq-lz99x,
+// NOT fail-closed flagging every value).
 
 /// `sh:datatype` is NOT satisfied by a literal that carries the right datatype IRI
 /// but whose lexical value is ill-formed for it — the `well_formed(l)` conjunct.
@@ -995,23 +996,109 @@ fn datatype_rejects_out_of_range_bounded_integer() {
     );
 }
 
-/// An invalid `sh:pattern` (a regex that fails to compile) yields NO compiled
-/// regex, so `Component::Pattern` flags EVERY value (fail-closed). This pins the
-/// `regex_for(..) == None` branch, never reached by a valid pattern. The unbalanced
-/// `[` is a lexical regex error.
+/// [OPUS-4.8] (sq-lz99x) An uncompilable `sh:pattern` (a regex that fails to
+/// compile) yields NO regex, so the `Component::Pattern` `regex_for(..) == None`
+/// branch SKIPS the constraint (the crate's lenient ill-formed-shape policy) and
+/// records a diagnostic — it does NOT fail-closed by flagging every value. The
+/// unbalanced `[` is a lexical regex error. Before sq-lz99x both values here were
+/// (wrongly) reported as violations.
 #[test]
-fn pattern_with_invalid_regex_flags_all_values() {
+fn pattern_with_invalid_regex_is_skipped_with_diagnostic() {
     let shapes = r#"
         ex:S a sh:NodeShape ; sh:targetNode ex:n ;
           sh:property [ sh:path ex:code ; sh:pattern "[" ] .
     "#;
-    // Two values; both are flagged because the pattern never compiles.
+    // Two values; the (only) constraint is uncompilable, so NEITHER is flagged.
     let r = run(r#"ex:n ex:code "ab" , "cd" ."#, shapes);
-    assert!(!r.conforms, "{}", r.to_text());
+    assert!(
+        r.conforms,
+        "a skipped uncompilable pattern reports no violations: {}",
+        r.to_text()
+    );
     assert_eq!(
         count_component(&r, "PatternConstraintComponent"),
-        2,
-        "an uncompilable pattern fails every value: {}",
+        0,
+        "{}",
+        r.to_text()
+    );
+    // The skip is surfaced, once, as a diagnostic naming the component.
+    assert_eq!(r.diagnostics.len(), 1, "{}", r.to_text());
+    let d = &r.diagnostics[0];
+    assert!(
+        d.source_component.ends_with("PatternConstraintComponent"),
+        "{}",
+        d.source_component
+    );
+    assert!(d.message.contains("SKIPPED"), "{}", d.message);
+    // to_text surfaces the diagnostic even though the report conforms.
+    assert!(r.to_text().contains("diagnostic"), "{}", r.to_text());
+}
+
+/// [OPUS-4.8] (sq-lz99x) The bead's exact repro: a negative-lookahead pattern
+/// `^(?!(TODO|TBD)).*` with `sh:flags "i"`. The Rust `regex` crate (like the XML
+/// Schema regex flavour the SHACL spec ties `sh:pattern` to) has NO lookahead, so
+/// the pattern does not compile. Pre-fix this flagged EVERY conformant string as a
+/// violation; now the constraint is SKIPPED with a diagnostic and a conformant
+/// value passes. (Express such a check as a POSITIVE-match `sh:sparql` REGEX
+/// constraint instead — see the bead.)
+#[test]
+fn pattern_lookahead_is_skipped_not_fail_closed() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+          sh:property [ sh:path ex:title ; sh:pattern "^(?!(TODO|TBD)).*" ; sh:flags "i" ] .
+    "#;
+    let r = run(r#"ex:n ex:title "A real title" ."#, shapes);
+    assert!(
+        r.conforms,
+        "an unsupported-lookahead pattern must not fail-close a conformant value: {}",
+        r.to_text()
+    );
+    assert_eq!(count_component(&r, "PatternConstraintComponent"), 0);
+    assert_eq!(r.diagnostics.len(), 1, "{}", r.to_text());
+    // The diagnostic carries the regex crate's own error (names look-around) and
+    // notes the flags it was compiled with.
+    let m = &r.diagnostics[0].message;
+    assert!(m.contains("flags \"i\""), "{m}");
+    assert!(m.to_lowercase().contains("look"), "{m}");
+}
+
+/// [OPUS-4.8] (sq-lz99x) A WELL-FORMED `sh:pattern` is unaffected by the
+/// skip-on-uncompilable change: real violations are still reported and no spurious
+/// diagnostic is recorded.
+#[test]
+fn pattern_valid_still_reports_violations_and_no_diagnostic() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+          sh:property [ sh:path ex:code ; sh:pattern "^ab" ] .
+    "#;
+    let r = run(r#"ex:n ex:code "abc" , "xyz" ."#, shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(count_component(&r, "PatternConstraintComponent"), 1);
+    assert_eq!(flagged_values(&r), vec!["\"xyz\"".to_string()]);
+    assert!(r.diagnostics.is_empty(), "{}", r.to_text());
+}
+
+/// [OPUS-4.8] (sq-lz99x) A diagnostic is recorded ONCE per (shape, pattern), not
+/// once per focus node or value — so a shape with many targets does not flood the
+/// report.
+#[test]
+fn pattern_skip_diagnostic_is_deduplicated() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetClass ex:T ;
+          sh:property [ sh:path ex:code ; sh:pattern "[" ] .
+    "#;
+    // Three focus nodes, each with two values: 6 (focus, value) pairs total.
+    let data = r#"
+        ex:a a ex:T ; ex:code "x" , "y" .
+        ex:b a ex:T ; ex:code "p" , "q" .
+        ex:c a ex:T ; ex:code "m" , "n" .
+    "#;
+    let r = run(data, shapes);
+    assert!(r.conforms, "{}", r.to_text());
+    assert_eq!(
+        r.diagnostics.len(),
+        1,
+        "the skip is reported once, not per focus/value: {}",
         r.to_text()
     );
 }

--- a/crates/sparq-shacl/tests/diff_fuzz.rs
+++ b/crates/sparq-shacl/tests/diff_fuzz.rs
@@ -712,6 +712,9 @@ fn key_normalisation_is_consistent() {
             default_message: String::new(),
             details: vec![],
         }],
+        // [OPUS-4.8] (sq-lz99x) report now carries skipped-constraint diagnostics;
+        // none here (this fixture is a hand-built result, not a real validation).
+        diagnostics: vec![],
     };
     let sk = sparq_keys(&report);
     let rr = RefReport {

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -124,6 +124,7 @@ pub fn ShapesModel::parse(shapes_graph: &Graph) -> ShapesModel;   // parse once,
 ```rust
 pub conforms: bool;                         // true iff results is empty (spec sh:conforms — counts EVERY result)
 pub results: Vec<ValidationResult>;
+pub diagnostics: Vec<ShapeDiagnostic>;      // skipped-constraint diagnostics (e.g. uncompilable sh:pattern); never affect `conforms`
 pub fn conforms_violations_only(&self) -> bool;                       // ignore sh:Warning / sh:Info
 pub fn results_with_severity<'a>(&'a self, severity: &'a str)         // full IRI, e.g. ".../shacl#Warning"
     -> impl Iterator<Item = &'a ValidationResult>;
@@ -413,6 +414,14 @@ conforms/violations).
   contributes no results; the rest of validation still runs. `validate` never returns
   a `Result`/panics on bad shapes — so a silently-empty report can mean "no targets"
   rather than "conforms".
+- **An uncompilable `sh:pattern` is SKIPPED, not fail-closed (sq-lz99x).** The Rust
+  `regex` crate has no lookahead/lookbehind — neither does the XML Schema regex flavour
+  the SHACL spec ties `sh:pattern` to — so e.g. `^(?!(TODO|TBD)).*` does not compile.
+  That constraint is skipped (it reports no violations) and surfaced once in
+  `report.diagnostics` (a `ShapeDiagnostic` carrying the shape, component, and the
+  `regex` crate's error), so the skip is not silent. Earlier this wrongly flagged
+  EVERY value. To express a "must NOT start with X" check, use a POSITIVE-match
+  `sh:sparql` `REGEX(?str, "^\\s*(TODO|...)")` constraint (flag when it matches) instead.
 - **Results are NOT deduplicated** across traversal routes / component occurrences — a
   nested shape reached via two parents reports twice (intentional, matches the suite).
 - **Recursion is treated as conforming.** Re-entering the same (focus, shape) pair


### PR DESCRIPTION
> 🤖 SPARQ agent — automated implementation of bead `sq-lz99x`. I am one of several agents @jeswr runs on this account.

## What & why

`sparq-shacl` evaluated `sh:pattern` via the Rust `regex` crate. When the pattern did **not compile** (an unbalanced bracket, or a `(?!...)` lookahead — which the Rust `regex` crate does not support, and *neither does the XML Schema regex flavour the W3C SHACL spec ties `sh:pattern` to*), `regex_for` returned `None`, and the `Component::Pattern` match arm `_ => false` then flagged **every** value as a violation (silent fail-closed). The bead's repro `^(?!(TODO|TBD)).*` with `sh:flags "i"` thus reported every conformant string as failing.

This is the **one** place the crate violated its otherwise-consistent **lenient policy** — an ill-formed constraint (unparsable path, unparsable `sh:select`, …) is everywhere else *skipped*, not fail-closed.

## Fix (option (a) in the bead — judgment call, documented below)

When the pattern does not compile, **skip the constraint** (report no violations) and record a `ShapeDiagnostic` so the skip is not silent. Decision rationale: option (a) over (b) (reject author-time) because it matches the crate's documented lenient ill-formed-shape policy and keeps `validate` non-fallible (no `Result`/panic on bad shapes), which the wasm + W3C-suite consumers rely on.

- `ValidationReport` gains `diagnostics: Vec<ShapeDiagnostic>` (shape + component + the `regex` crate's own compile error, which names the unsupported construct). It **never affects `conforms`** — a skipped constraint contributes no results.
- De-duplicated per `(shape, pattern)` so a many-target shape reports the skip once, not once per focus/value.
- `to_text` surfaces diagnostics even on a conforming report; `to_turtle` is **unchanged** (W3C report vocabulary stays spec-faithful + round-trippable — the wasm round-trip test still passes).
- Well-formed patterns are entirely unaffected (still match/violate, no diagnostic).
- **Workaround for authors** (documented in README + SKILL): express a "must NOT start with X" check as a POSITIVE-match `sh:sparql` `REGEX(?str, "^\\s*(TODO|...)")` constraint (flag when it matches) — there is no portable lookahead in either regex flavour.

## Feature flags

This is a bug fix to the **base** validation path — no new cargo feature. The crate's existing opt-in features are `shacl-af` and `scs`.

## Gates (run in-worktree, BOTH states)

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — GREEN with the feature **OFF (default)** and with **`--all-features`** (`shacl-af` + `scs`).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations (README 119 lines, under the 120 cap).
- `scripts/check-privacy-claims.sh` — OK. `typos` — clean. New code carries `[OPUS-4.8]` markers.

## Tests

The old fail-closed test (`pattern_with_invalid_regex_flags_all_values`) is rewritten to assert **skip + diagnose**; added the bead's exact **lookahead** repro, a **well-formed-still-works** guard, and a **per-(shape,pattern) de-dup** test. The full crate suite (incl. the W3C core 98/98 + SHACL-SPARQL + SHACL-1.2 suites) stays green in both states.

Closes bead `sq-lz99x`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
