### PR TITLE
docs: WASM API + Oxigraph migration + sparq-solid wasm/WAC-Allow docs [OPUS-4.8]

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -7,26 +7,24 @@
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
 </p>
 
-**Solid Pod access control** over the [sparq](../../README.md) engine. Pods are stored as **named
-graph per document**; their WAC (`.acl`) / ACP (`.acr`) access-control documents stay as plain,
-queryable triples, and their semantics are encoded as **N3 rules** (run by `sparq-reason`) that
-materialize a queryable authorization view in `<urn:sparq:auth>`. Every SPARQL query is then filtered
-per `(WebID, client)` session to the authorized graph set — **fail-closed**, with zero Solid-specific
-code in the engine (this crate is depended on by nothing else in the workspace).
+**Solid Pod access control** over the [sparq](../../README.md) engine. Pods are stored as **named graph
+per document**; their WAC (`.acl`) / ACP (`.acr`) docs stay as plain, queryable triples, and their
+semantics are encoded as **N3 rules** (run by `sparq-reason`) that materialize a queryable authorization
+view in `<urn:sparq:auth>`. Every SPARQL query is then filtered per `(WebID, client)` session to the
+authorized graph set — **fail-closed**, with zero Solid-specific code in the engine (this crate is
+depended on by nothing else in the workspace).
 
 ## 🚀 Quickstart
 
 ```rust
-# // [OPUS-4.8] hidden main returns Result<(), String>: engine API errors are `String` (no Error impl, so `?` can't widen to Box<dyn Error>).
+# // [OPUS-4.8] hidden main returns Result<(), String>: engine API errors are `String` (no Error impl).
 # fn main() -> Result<(), String> {
 use sparq_core::Graph;
 use sparq_solid::{Mode, PodStore, Session};
-
 // A pod is a dataset, one named graph per document (here the bundled fixture).
 let graph = Graph::load_dataset(&sparq_solid::wac_fixture(), "nquads")?;
 let mut store = PodStore::new(graph);
 store.materialize_wac()?; // run the N3 rules → install <urn:sparq:auth>
-
 // The SAME query, different sessions, different results — fail-closed.
 let q = "SELECT ?title WHERE { ?s <https://ex.dev/ns#title> ?title }";
 let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None, now: None };
@@ -39,81 +37,82 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
 
 - **WAC + ACP** — Web Access Control (`.acl`) and Access Control Policy (`.acr`): inheritance, agent
   classes, groups, `allOf`/`anyOf`/`noneOf`, the ACP `(agent, client, issuer)` principal,
-  `acp:CreatorAgent`/`acp:OwnerAgent`, normative deny-overrides (matrix in the design doc).
+  `acp:CreatorAgent`/`acp:OwnerAgent`, normative deny-overrides.
 - **Trusted creator/owner provenance** — `acp:CreatorAgent`/`acp:OwnerAgent` resolve only against
-  per-resource WebIDs the storage layer supplies through the trusted `AccessProvenance` channel,
-  **never** graph content. The loader hard-rejects any control-document triple in the derivation-internal
-  `solidx:` namespace, so a writer cannot self-grant; with no provenance, no such matcher grants.
-- **Triples-native + zero-copy enforcement** — pods, ACL/ACR docs, and the auth view are all
-  ordinary named graphs ("who can read G?" is one SPARQL pattern); the default path evaluates
-  through the engine's zero-copy dataset view, with a v1 `FROM NAMED` rewrite kept as a portability
-  path for standard SPARQL 1.1 engines.
-- **Write-path gating** — `update_as` / `update_as_acp` check every graph an update could mutate
-  before applying, and auto-re-materialize on `.acl`/`.acr` writes.
+  per-resource WebIDs the storage layer supplies through the trusted `AccessProvenance` channel, **never**
+  graph content (the loader hard-rejects `solidx:` triples, so a writer cannot self-grant).
+- **Triples-native + zero-copy enforcement** — pods, ACL/ACR docs, and the auth view are all ordinary
+  named graphs ("who can read G?" is one SPARQL pattern); the default path evaluates through the engine's
+  zero-copy dataset view, with a v1 `FROM NAMED` rewrite as a standard-SPARQL portability path.
+- **Write-path gating** — `update_as` / `update_as_acp` check every graph an update could mutate before
+  applying, and auto-re-materialize on `.acl`/`.acr` writes.
 - **ODRL bridge (opt-in `odrl-bridge`, research-track — not a production cutover)** — runs the
-  [`sparq-policy`](../sparq-policy) ODRL evaluator and materializes the equivalent WAC/ACP grant (or
-  dual `auth:deny*`) into the auth view, no new enforcement engine (zero ODRL code by default). See below.
-- **Trust-graph admission PoC (opt-in `trust-graph`, research — NOT a security guarantee)** — an admission
-  stratum ([`sparq-trust`](../sparq-trust)) admits an issuer-signed, trusted-source-scoped credential fact
-  ahead of the materialiser; OFF = byte-identical WAC/ACP. No privacy/ZK (`sq-qhy4` unaudited).
+  [`sparq-policy`](../sparq-policy) ODRL evaluator and materializes the equivalent WAC/ACP grant (or dual
+  `auth:deny*`) into the auth view — no new enforcement engine (zero ODRL code by default; see below).
+- **Trust-graph admission PoC (opt-in `trust-graph`, research — NOT a security guarantee)** — a
+  [`sparq-trust`](../sparq-trust) admission stratum injects an issuer-signed, trusted-source-scoped
+  credential fact ahead of the materialiser; OFF = byte-identical WAC/ACP. No privacy/ZK (`sq-qhy4` unaudited).
 
 ## ODRL → AUTH_GRAPH bridge (opt-in `odrl-bridge`)
 
 A matched ODRL `Permission` becomes a concrete `principal auth:<mode> graph` triple **appended** to
 `<urn:sparq:auth>`; the *request* action maps conservatively to the narrowest WAC mode (`odrl:use`
-deliberately **unmapped → no grant**), and a Prohibition maps to the dual `auth:deny*`.
-**Fail-closed:** a grant materializes **only** on a definite Permit + a mappable action + a concrete
-party + target (a deny **only** on a genuine prohibition match) — a Deny, unsatisfied constraint,
-undischarged duty, unmapped action, or partyless/targetless request materializes **nothing**.
+deliberately **unmapped → no grant**), and a Prohibition maps to the dual `auth:deny*`. **Fail-closed:**
+a grant materializes **only** on a definite Permit + mappable action + concrete party + target (a deny
+**only** on a genuine prohibition match); a Deny, unsatisfied constraint, undischarged duty, unmapped
+action, or partyless/targetless request materializes **nothing**.
 
-**Re-checked conditions vs frozen one-shots.** `materialize_odrl_permission_conditional` persists a
-*faithfully-mappable* constraint as an ACP `auth:ConditionalGrant` re-checked per session (the
-`recipient`/`assignee` matchers, incl. `neq` "everyone EXCEPT X", and an `odrl:dateTime` inclusive
-window re-checked against `Session::now`, **fail-closed with no clock**). `purpose`/`count`/strict
-bounds have **no** stateless analogue, so they stay **one-shot** (checked once via
-`sparq_policy::evaluate` — a missing value is *unprovable* → fail-closed, **no DPV purpose-hierarchy
-subsumption**; a lapsed bound is caught on the next `refresh_odrl_grant`). A mixed rule with any
-unmappable constraint falls back **entirely** to one-shot (never drop a bound and over-grant).
-**`odrl:count` is stateful, ACP is stateless** — it stays one-shot; real stateful enforcement is the opt-in `count-enforcement` feature. Full mapping detail in the SKILL.
+**Conditions, refresh & revocation.** A *faithfully-mappable* constraint
+(`materialize_odrl_permission_conditional`) persists as a per-session-rechecked ACP `auth:ConditionalGrant`
+(recipient/assignee matchers; an inclusive `odrl:dateTime` window vs `Session::now`, **fail-closed with no
+clock**); `purpose`/`count`/strict bounds have no stateless analogue and stay **one-shot** (any unmappable
+constraint falls the whole rule back to one-shot). Bridged grants are ledger-tracked; `refresh_odrl_grant(s)`
+rebuilds the view (static baseline + replay of valid entries), retracting lapsed ones. **Deny retraction is
+asymmetric (fail-OPEN risk):** an `auth:deny*` is retracted **only** on a *definite* `Withdrawn` verdict
+(kept on `Applies`/`Ambiguous`); static grants are never in the ledger. Full mapping/replay detail in the SKILL.
 
-**Refresh / revocation.** Bridged grants are tracked in a ledger; `refresh_odrl_grant(s)` rebuilds
-the view from the static baseline plus a replay of still-valid entries, retracting any that no longer
-hold. **Deny retraction is asymmetric (fail-OPEN risk):** a bridged `auth:deny*` is retracted **only**
-on a *definite* `Withdrawn` verdict (`sparq_policy::prohibition_status`) — kept on `Applies`/`Ambiguous`,
-since reusing the grant rule would re-admit a carved-out party. Static grants are never in the ledger,
-so refresh can't widen or drop them.
+## WASM support
+
+`sparq-solid` (with its `sparq-reason` dep, `default-features = false`) **compiles for
+`wasm32-unknown-unknown`** (trial-build verified; no native-only deps — rayon off, `sparq-reason`'s
+parallel path gated). Its transitive `oxrdf 0.3.3 → rand → getrandom` needs the host bundle to select a
+wasm RNG backend as `sparq-wasm` does (`getrandom`'s `wasm_js` feature + the `getrandom_backend` cfg; see
+the [migration guide](../../docs/migrating-from-oxigraph.md#wasm-compilation)). **Runtime caveat:**
+`materialize_wac`/`materialize_acp` call `std::time::Instant::now()` (`stats.millis`), which **panics on
+wasm32** (no monotonic clock) — materialize traps until that call is `cfg`-gated (follow-up bead). So
+Deno-wasm / Cloudflare Workers are *compile-feasible now, run-feasible once the clock call is gated*.
 
 ## Conformance, security & containment
 
 - **WAC + ACP conformance harnesses** (`sparq_solid::wac_conformance` / `conformance`) assert the
   engine against the [WAC](https://solidproject.org/TR/wac) / [ACP](https://solidproject.org/TR/acp)
-  specs at the *library* level (data-declared `(agent, client, mode, resource) → allow|deny`
-  scenarios). **Scope (honest):** the realistic library-level oracle, **not** the Solid
-  CTH-over-HTTP (no HTTP surface here) — see `research/sparq-solid-scope.md` §4.
-- **In-repo differential oracle** (`tests/differential_oracle.rs`) runs the shared corpus through
-  THREE deciders — the engine (N3 rules), an **independent procedural reference evaluator**
-  (`tests/reference/`, a *different paradigm*, no shared code) and the hand `Expect` table — and
-  asserts **zero divergence** (fail-closed). A correctness oracle, **not** a security audit.
-- **Security posture — fail-closed.** Absence of a grant makes a graph **invisible**. The reasoner
-  is fed only ACL/ACR + structural facts — **never pod content** — so no writable document can
-  grant itself access; the reserved `urn:sparq:` namespace is rejected on input and forged
-  `<urn:sparq:auth>` graphs are stripped at load.
-- **`ldp:contains` is PSS-written, not sparq-derived** — stored as opaque content, **never** derived
-  from IRI structure, mutated on a write, or read into the reasoner. Containment *ancestry* is derived
-  structurally only to drive ACL inheritance (pinned by `tests/containment_view_ownership.rs`).
+  specs at the *library* level (data-declared `(agent, client, mode, resource) → allow|deny`). **Scope
+  (honest):** the realistic library-level oracle, **not** the Solid CTH-over-HTTP (no HTTP surface here)
+  — see `research/sparq-solid-scope.md` §4.
+- **In-repo differential oracle** (`tests/differential_oracle.rs`) runs the shared corpus through THREE
+  deciders — the engine (N3 rules), an **independent procedural reference evaluator** (`tests/reference/`,
+  no shared code) and the hand `Expect` table — asserting **zero divergence**. A correctness oracle,
+  **not** a security audit.
+- **Security posture — fail-closed.** Absence of a grant makes a graph **invisible**. The reasoner is fed
+  only ACL/ACR + structural facts — **never pod content** — so no writable document can grant itself
+  access; the reserved `urn:sparq:` namespace is rejected on input and forged `<urn:sparq:auth>` graphs
+  are stripped at load. `ldp:contains` is PSS-written opaque content, **never** derived from IRI structure
+  or read into the reasoner; containment *ancestry* drives ACL inheritance only (pinned by
+  `tests/containment_view_ownership.rs`).
 
 ## 📚 Learn more
 
-- **How-to** — [`skills/access-control/SKILL.md`](../../skills/access-control/SKILL.md) (public
-  API, WAC/ACP notes, conformance harnesses + the differential oracle, ODRL-bridge mapping detail).
+- **How-to** — [`skills/access-control/SKILL.md`](../../skills/access-control/SKILL.md) (public API,
+  WAC/ACP notes, conformance harnesses + the differential oracle, the **request-pipeline / WAC-Allow
+  example**, ODRL-bridge mapping detail).
 - **Design + threat model** —
   [`research/solid-access-control-design.md`](../../research/solid-access-control-design.md) (model,
   matrix, strata, boundaries) + [scope](../../research/sparq-solid-scope.md).
-- **API reference** — [docs.rs/sparq-solid](https://docs.rs/sparq-solid); walk-through
-  `cargo run -p sparq-solid --example quickstart --release`.
-- **Performance** — not baked into docs; measured via `cargo run -p sparq-solid --example bench
-  --release` + the [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench).
-- **Contribute** — [`AGENTS.md`](../../AGENTS.md), [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
+- **API reference** — [docs.rs/sparq-solid](https://docs.rs/sparq-solid); walk-through `cargo run -p
+  sparq-solid --example quickstart --release`. Migrating from Oxigraph?
+  [`docs/migrating-from-oxigraph.md`](../../docs/migrating-from-oxigraph.md).
+- **Performance / Contribute** — [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench)
+  (`--example bench`); [`AGENTS.md`](../../AGENTS.md), [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## License
 

--- a/docs/migrating-from-oxigraph.md
+++ b/docs/migrating-from-oxigraph.md
@@ -1,0 +1,250 @@
+<!-- [OPUS-4.8] sq-d1axm: migration guide (#1128); folds the oxrdf-version matrix (#1124) and links the result-shape diff (#1123). -->
+# Migrating from Oxigraph to sparq
+
+sparq and [Oxigraph](https://github.com/oxigraph/oxigraph) share the same RDF
+term foundation — the **`oxrdf`** crate — so the *data model* (IRIs, blank nodes,
+literals, named graphs) is byte-for-byte interoperable. What differs is the
+**store API surface** and the **query-result shape**. This guide maps the common
+Oxigraph operations to their sparq equivalents so a port is mechanical rather
+than trial-and-error.
+
+It targets the **Rust API** (`sparq-core` + `sparq-engine`). The JavaScript/WASM
+surface is covered separately in [`js/README.md`](../js/README.md) and the
+[`javascript-wasm`](../skills/javascript-wasm/SKILL.md) skill; the WASM-build
+differences are in [§ WASM](#wasm-compilation).
+
+> sparq is an **in-memory, immutable-index** engine optimised for load-once /
+> query-many over a fixed graph, with an append-only delta overlay for
+> incremental mutation. Oxigraph is a **persistent, transactional** store
+> (RocksDB or in-memory) with full SPARQL 1.1 Update transactions. They are not
+> drop-in replacements: if you need durable on-disk storage or MVCC
+> transactions, sparq does not (yet) provide them — see
+> [§ What sparq does NOT replace](#what-sparq-does-not-replace).
+
+## oxrdf version compatibility (#1124)
+
+sparq's workspace pins `oxrdf = { version = "0.3", … }`, which **resolves to
+`oxrdf 0.3.3`** — *exactly* the version Oxigraph 0.5 depends on. So `oxrdf::Term`
+/ `NamedNode` / `Literal` / `Quad` values flow between an Oxigraph 0.5 store and
+sparq without conversion: there is **no type-incompatibility gap to bridge**, and
+no version bump is required on either side.
+
+Verify the resolved version in any checkout with:
+
+```sh
+cargo tree -p sparq-core -i oxrdf
+# oxrdf v0.3.3
+```
+
+| Crate            | oxrdf line | Resolves to | Notes |
+| ---------------- | ---------- | ----------- | ----- |
+| sparq (workspace) | `0.3`      | **0.3.3**   | `features = ["rdf-12"]` (RDF 1.2 / triple terms) |
+| Oxigraph 0.5      | `0.3`      | **0.3.3**   | same minor, same patch |
+| sparq-canon (only) | `0.2.4`   | 0.2.4       | a *separate, isolated* dep — the URDNA2015 bridge speaks `oxrdf 0.2`; it is internal to canonicalisation and does not touch the public term model |
+
+The lone `oxrdf 0.2.4` in the tree (`sparq-canon`'s RDFC-1.0 bridge) is
+deliberate and quarantined; it never appears in `sparq-core` / `sparq-engine`
+public signatures. Your migration only ever sees `oxrdf 0.3.3` types.
+
+## Store initialisation
+
+Oxigraph builds a mutable `Store` you insert into; sparq parses a document (or a
+batch of quads) into an immutable, fully-indexed `Graph` in one shot.
+
+```rust
+// Oxigraph
+use oxigraph::store::Store;
+let store = Store::new()?;                       // empty, mutable
+store.load_from_reader(RdfFormat::Turtle, turtle.as_bytes())?;
+
+// sparq
+use sparq_core::Graph;
+let graph = Graph::load_str(turtle, "turtle")?;  // parse + index in one call
+// named graphs preserved (N-Quads / TriG / JSON-LD @graph):
+let dataset = Graph::load_dataset(nquads, "nquads")?;
+```
+
+`Graph::load_str` folds named graphs into the default graph;
+`Graph::load_dataset` preserves them as queryable named graphs (the input must be
+a quad-bearing format). An **unrecognised `format` is an `Err`** — it is not
+silently parsed as Turtle. Accepted format strings and their aliases match the
+JS/WASM surface; see [§ Format strings](#format-strings).
+
+## Quad insert / delete
+
+Oxigraph mutates per-quad through a transaction. sparq applies a **batch delta**
+through its overlay (`apply_delta`) — deletes first, then inserts, O(batch), no
+index rebuild — or rebuilds via SPARQL Update.
+
+```rust
+// Oxigraph
+store.insert(&quad)?;
+store.remove(&quad)?;
+
+// sparq — batch delta over the overlay (oxrdf Terms, same types)
+use oxrdf::{NamedNode, Term};
+let s = Term::NamedNode(NamedNode::new("http://ex/s")?);
+let p = NamedNode::new("http://ex/p")?;            // predicate
+let o = Term::Literal("o".into());
+graph.apply_delta(&[[s, Term::NamedNode(p), o]], &[])?; // inserts, no deletes
+
+// or via SPARQL 1.1 Update (rebuilds the immutable index, returns a new Graph)
+let updated = sparq_engine::update(&graph, "INSERT DATA { <http://ex/s> <http://ex/p> \"o\" }")?;
+// in place (delta overlay; no rebuild):
+sparq_engine::update_in_place(&mut graph, "DELETE DATA { <http://ex/s> <http://ex/p> \"o\" }")?;
+```
+
+The overlay is append-only: the dictionary only grows and deletes are tombstones
+until the graph is reloaded. This is the right shape for ingest-then-query and
+incremental top-ups, **not** for a high-churn transactional workload — that is an
+Oxigraph strength sparq does not match.
+
+## Query result processing (#1123)
+
+This is the **biggest porting difference**. Oxigraph yields an iterator of
+per-solution maps; sparq returns a single columnar `QueryResult { vars, rows }`.
+
+```rust
+// Oxigraph — iterator of QuerySolution, lookup by Variable/name
+if let QueryResults::Solutions(solutions) = store.query("SELECT ?s ?o WHERE { ?s ?p ?o }")? {
+    for sol in solutions {
+        let sol = sol?;
+        let s = sol.get("s");       // Option<&Term>, keyed by variable
+        let o = sol.get("o");
+    }
+}
+
+// sparq — columnar: a vars header + rows of positional Option<Term>
+use sparq_engine::query;
+let res = query(&graph, "SELECT ?s ?o WHERE { ?s ?p ?o }")?;
+// res.vars : Vec<Variable>            — column order
+// res.rows : Vec<Vec<Option<Term>>>   — one row per solution; None = unbound
+let s_col = res.vars.iter().position(|v| v.as_str() == "s").unwrap();
+for row in &res.rows {
+    let s: Option<&Term> = row[s_col].as_ref();
+}
+```
+
+The sparq shape is:
+
+```rust
+pub struct QueryResult {
+    pub vars: Vec<oxrdf::Variable>,            // column header (order matters)
+    pub rows: Vec<Vec<Option<oxrdf::Term>>>,   // None == unbound in that position
+}
+```
+
+`ASK` is a separate entry point returning a `bool`
+(`sparq_engine::ask(&graph, sparql)`), and `CONSTRUCT` / `DESCRIBE` return
+triples (`sparq_engine::construct(&graph, sparql) -> Vec<oxrdf::Triple>`, or
+`construct_ntriples` for a serialised string) rather than going through
+`QueryResult`.
+
+To recover an Oxigraph-style "lookup by variable name" per row, build a
+name→index map once from `vars` and index `row[idx]` — a few lines, applied at
+the one call site, instead of the per-row `HashMap` Oxigraph materialises. A
+first-class iterator-of-bindings adapter is tracked as a follow-up (linked to
+issue #1123); the columnar shape is intentional (it avoids a per-row map
+allocation on the hot path), so the adapter will be an *additional* accessor,
+not a replacement.
+
+## Named graphs
+
+Both stores model named graphs as a fourth quad position over the same `oxrdf`
+terms. The difference is loading and querying:
+
+```rust
+// sparq — preserve named graphs at load, then GRAPH-aware SPARQL
+let ds = Graph::load_dataset(nquads, "nquads")?;     // or "trig"
+let res = query(&ds, "SELECT ?g ?s WHERE { GRAPH ?g { ?s ?p ?o } }")?;
+```
+
+`GRAPH <iri>` / `GRAPH ?g`, `FROM` / `FROM NAMED`, and `GRAPH` blocks in Update
+all work over a dataset-loaded `Graph`. Note `Graph::len()` reports the
+**default graph** only; count a dataset with a `GRAPH ?g` query. The
+default-graph fold of `load_str` matches Oxigraph's behaviour when you load
+quads into the default graph explicitly.
+
+## Serialization
+
+Oxigraph's `store.dump_to_writer(format, …)` maps to the `sparq_engine::serialize`
+functions, which take a `&Graph` and return a `String`:
+
+| Output | sparq function |
+| ------ | -------------- |
+| Turtle (default graph) | `serialize::graph_to_turtle(&g)` / `graph_to_turtle_pretty(&g)` |
+| N-Triples | `construct::construct_ntriples` (result graph) or the Turtle writer |
+| N-Quads (whole dataset) | `serialize::graph_to_nquads(&g)` |
+| TriG (whole dataset) | the pretty-TriG writer (`graph_to_turtle_pretty_with` family) |
+| JSON-LD 1.1 (expanded / flattened / compacted) | `serialize::graph_to_jsonld(&g, form)` / `graph_to_jsonld_compact(&g, ctx)` |
+
+The JSON-LD writers are dependency-free (they reuse the existing oxrdf term
+infrastructure). The same writer matrix is what the CLI, the HTTP server, and the
+WASM `Store.serialize` binding all call, so output is consistent across surfaces.
+
+## WASM compilation
+
+sparq's `oxrdf 0.3.3` (and therefore Oxigraph 0.5's) pulls `rand` → `getrandom`
+for blank-node id generation. On `wasm32-unknown-unknown` there is **no default
+OS RNG**, so a wasm build of *any* crate in this family must select getrandom's
+browser backend, exactly as Oxigraph's own wasm guidance requires. sparq's
+`sparq-wasm` bundle does this with:
+
+```toml
+# the final bundle crate's Cargo.toml
+getrandom = { version = "0.3", features = ["wasm_js"] }
+```
+
+```toml
+# .cargo/config.toml (workspace root), for target wasm32-unknown-unknown
+[target.wasm32-unknown-unknown]
+rustflags = ['--cfg', 'getrandom_backend="wasm_js"']
+```
+
+With that in place the engine compiles to wasm32 cleanly. The published
+`@jeswr/sparq` npm package ships this prebuilt — for a JS migration you do not
+touch the toolchain at all; see [`js/README.md`](../js/README.md). For
+`sparq-solid` specifically, the wasm status (compiles; one runtime caveat) is
+documented in [its README](../crates/sparq-solid/README.md#wasm-support).
+
+### Format strings
+
+`Graph::load_str` / `load_dataset` (and the WASM `Store.load`) accept these
+case-sensitive format strings and aliases (an unrecognised value errors):
+
+| Format | Accepted strings |
+| ------ | ---------------- |
+| Turtle | `turtle`, `ttl`, `text/turtle`, `application/turtle` |
+| N-Triples | `ntriples`, `n-triples`, `nt`, `application/n-triples` |
+| N-Quads | `nquads`, `n-quads`, `nq`, `application/n-quads` |
+| TriG | `trig`, `application/trig` |
+| JSON-LD | `jsonld`, `json-ld`, `application/ld+json` (opt-in `jsonld` feature) |
+
+## What sparq does NOT replace
+
+Being honest about the boundary so a migration does not hit a wall:
+
+- **No durable on-disk store / transactions.** sparq's `Graph` is in-memory with
+  an append-only overlay; there is no RocksDB-style persistence layer or
+  MVCC/ACID transaction API. Oxigraph keeps that.
+- **No `REGEX` / `REPLACE` in the default build** (the engine's non-default
+  `regex` cargo feature is off, and it is off in the lean wasm bundle to keep the
+  binary small). Use `CONTAINS` / `STRSTARTS` / `STRENDS` or a `--features regex`
+  build.
+- **Federated `SERVICE`** is native-only and not exposed at the JS/WASM wrapper
+  layer.
+- The **delta overlay is not a transaction manager** — it is an append-only
+  optimisation for incremental load, not concurrent multi-writer isolation.
+
+If those are load-bearing for your project, keep Oxigraph for the storage layer
+and use sparq for the load-once / query-many analytical path — the shared
+`oxrdf 0.3.3` term model means quads cross the boundary for free.
+
+## See also
+
+- [`js/README.md`](../js/README.md) — the JavaScript/WASM API surface.
+- [`skills/javascript-wasm/SKILL.md`](../skills/javascript-wasm/SKILL.md) — the
+  WASM `Store` / `SparqStore` reference (init, format strings, errors, `.free()`).
+- [`crates/sparq-solid/README.md`](../crates/sparq-solid/README.md) — Solid Pod
+  access control (WAC/ACP), incl. its wasm-support status.
+- #1123 (result-shape adapter), #1124 (oxrdf alignment), this guide (#1128).

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -181,6 +181,56 @@ Materialize the authorization view from the access-control documents, then enfor
 The materialized view is itself just triples — *"who can read G?"* is one SPARQL
 pattern: `GRAPH <urn:sparq:auth> { ?who <https://sparq.dev/ns/auth#read> ?doc }`.
 
+## Request-pipeline integration for a Solid server (incl. WAC-Allow headers) — issue #1126
+
+`examples/quickstart.rs` shows the load → `materialize_wac` → `query_as`/`accessible`
+loop. A Solid **request handler** wraps that with three steps: (1) build a `Session`
+from the authenticated request, (2) gate the request with `accessible(...)` /
+`query_as(...)`, (3) emit a [`WAC-Allow`](https://solidproject.org/TR/wac#wac-allow)
+response header advertising the modes the agent (and the public) hold on the target
+resource. There is **no public `WAC-Allow` helper in the crate yet** (tracked as a
+follow-up); it is a few lines over the existing `accessible` API, shown here so a
+server can drop it in. The header lists the modes available to `user` (the
+authenticated agent) and to `public` (an anonymous `Session::default()`):
+
+```rust
+use sparq_solid::{Mode, PodStore, Session};
+use oxrdf::NamedNode;
+
+// One `Session` per request; `client`/`issuer` come from the auth layer (None = any).
+fn session_from_request<'a>(webid: Option<&'a str>, origin: Option<&'a str>) -> Session<'a> {
+    Session { agent: webid, client: origin, issuer: None, now: None }
+}
+
+// Does this session have `mode` on the graph backing `resource`? (fail-closed)
+fn may(store: &mut PodStore, s: &Session, mode: Mode, resource: &NamedNode) -> bool {
+    store.accessible(s, mode).iter().any(|g| g == resource)
+}
+
+// RFC-style WAC-Allow: `user="read write",public="read"` — only the modes actually held.
+fn wac_allow(store: &mut PodStore, s: &Session, resource: &NamedNode) -> String {
+    let modes = [(Mode::Read, "read"), (Mode::Write, "write"),
+                 (Mode::Append, "append"), (Mode::Control, "control")];
+    let held = |sess: &Session| -> String {
+        modes.iter()
+            .filter(|(m, _)| may(store, sess, *m, resource))
+            .map(|(_, name)| *name).collect::<Vec<_>>().join(" ")
+    };
+    let anon = Session::default();
+    format!(r#"user="{}",public="{}""#, held(s), held(&anon))
+}
+```
+
+Per request: `session_from_request(...)` → `may(&mut store, &s, Mode::Read, &resource)`
+to allow/deny (a deny is `403`/`404` per your fail-closed policy) → set the response's
+`WAC-Allow` header to `wac_allow(&mut store, &s, &resource)`. `accessible` is an O(1)
+hash check over the materialized index (it caches per session), so the four-mode sweep
+is cheap. **Scope caveat:** sparq-solid is a *library-level* authoriser — there is no
+HTTP surface here (no `Link`/`acl:` resource discovery, no `.well-known`), so mapping a
+**request path to its named graph** (`resource`) and authenticating the WebID are the
+server's job (see `research/sparq-solid-scope.md` §4). The header builder above is
+illustrative, not a conformance-tested helper.
+
 ## Capability notes (WAC + ACP)
 
 - **WAC** (`.acl`) — `acl:agent` (WebID), `acl:agentClass foaf:Agent` (public) /

--- a/skills/javascript-wasm/SKILL.md
+++ b/skills/javascript-wasm/SKILL.md
@@ -200,6 +200,27 @@ const violations = report.results.filter(
 
 The raw `Store.validate(data, shapes, format)` returns the same report as a JSON **string** (`JSON.parse` it yourself). `focusNode`/`value`/`sourceShape` are N-Triples term strings; `path` is a SHACL Turtle path expression; `severity`/`sourceConstraintComponent` are full IRIs; `message` is the first `sh:message` text (or a generated default). `path`/`value`/`message` are `null` when absent. Only a graph parse failure throws; malformed shapes are skipped, not surfaced. For large data graphs validate server-side via the `sparq-server` HTTP `validate` endpoint instead (the other half of the #162 decision). See the `shacl-validation` skill for the engine's SHACL coverage.
 
+**Raw wasm `Store`: init (`initSync` vs async default), errors, and `.free()` (#1127).** The wasm-pack `--target web` glue (`../wasm/sparq_wasm.js`) is a real ESM module that exports a **default async `init`** plus a synchronous **`initSync`** — one of the two MUST run before any `Store.*` static (`SparqStore`/`Dataset` do this for you via the package's memoised `init()`; you only call these when using the raw `Store` directly).
+
+```js
+import init, { initSync, Store } from '@jeswr/sparq/wasm/sparq_wasm.js';
+
+// (a) async default — the normal path. In the browser/Deno it fetches the .wasm
+// relative to the module; pass explicit bytes/URL to override.
+await init();                                   // or: await init({ module_or_path: bytes })
+// (b) initSync — when you ALREADY hold the compiled module/bytes (no top-level await,
+// e.g. a bundler that inlines the wasm, or a Cloudflare-Worker WebAssembly.Module import).
+initSync({ module_or_path: wasmModuleOrBytes });
+
+const store = Store.load('<a> <b> <c> .', 'ntriples');
+```
+
+- **When to use which.** Prefer the high-level `@jeswr/sparq` entry (`SparqStore`/`Dataset`), whose `init()` picks the right path per environment (Node reads the bytes off disk; browser/Deno `fetch`es) and memoises it — so the ~MB `.wasm` is paid at most once. Drop to `init`/`initSync` only when you import the raw `Store` glue directly: async `init()` for the common fetch-relative case, `initSync(...)` only when you have the module/bytes in hand and want no `await`.
+- **`init()`/`initSync()` not called first → `Store.*` throws** a wasm-bindgen "must call init" error. Calling `init()` again is idempotent.
+- **Format strings** for `Store.load`/`loadDataset`/`loadCompressed` are the same case-sensitive set the engine accepts: `turtle` (`ttl`/`text/turtle`), `ntriples` (`n-triples`/`nt`), `nquads` (`n-quads`/`nq`), `trig`, and `jsonld` (`json-ld`/`application/ld+json`, opt-in `jsonld` bundle). An **unrecognised format is an `Err`/throw** — it is NOT silently parsed as Turtle (so a `'jsonld'` load on the lean bundle throws rather than mis-parsing).
+- **Errors are JS exceptions.** Every fallible `Store` method (`load*`, `query`, `ask`, `update`, `applyDelta`, `validate`, …) maps a Rust `Err(String)` to a thrown `Error` (wasm-bindgen `JsError`) carrying the engine message (parse error with position, malformed SPARQL, an unrecognised format, a query form routed to the wrong method — e.g. CONSTRUCT through `query`). Wrap calls in `try/catch`; there are no silent failures.
+- **`.free()` — when and on what.** wasm linear memory is NOT GC'd: call `.free()` on every `Store` you create, AND on each cursor object (`QueryChunks` / the `queryCursor` / `queryQuadsChunks` handles) once drained or abandoned. After `.free()` the handle (and any cursor it spawned) must not be touched. In the high-level wrapper use `store.free()` or `using store = await SparqStore.from…()` (`Symbol.dispose`); for the raw `Store`, `break`ing out of a streaming `for…of` over a cursor still requires freeing that cursor. Leaking handles grows the 4 GB wasm heap until the tab/process OOMs.
+
 ## Gotchas / feature flags / prerequisites
 
 - **ESM only, Node >= 18.** The package is `"type": "module"`; `init()` is idempotent and runs automatically on the first `SparqStore.from*` call (in Node it reads the wasm bytes from disk; in the browser/Deno it `fetch`es relative to the module). One runtime dep: `fzstd` (~8 KB, dynamically imported only when decoding zstd).


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (Claude Opus 4.8, 1M context) maintaining sparq's docs. This PR addresses the external **KamiQuasi** documentation cluster (WASM/JS API + Oxigraph migration). DOC-ONLY — no `crates/` source changes. Every factual claim was verified against current code / `Cargo.lock`.

## What this reconciles

| Issue | Resolution |
| ----- | ---------- |
| **#1128** Migration guide from Oxigraph | New `docs/migrating-from-oxigraph.md`: store init, quad insert/delete, **result-shape diff** (links #1123), named graphs, serialization, wasm getrandom backend, and an honest "what sparq does NOT replace" section. |
| **#1124** oxrdf version alignment | Folded into the migration guide as a compatibility matrix. **Verified:** sparq's `oxrdf 0.3` resolves to **0.3.3** — exactly Oxigraph 0.5's version (`cargo tree -p sparq-core -i oxrdf` → `oxrdf v0.3.3`). No bump needed; the lone `oxrdf 0.2.4` is `sparq-canon`'s isolated URDNA2015 bridge, never in the public term model. |
| **#1127** WASM API documentation | `skills/javascript-wasm/SKILL.md` gains a raw-`Store` lifecycle recipe: **`initSync` vs async default `init`** (when to use which), **format-string aliases** (`ntriples`/`n-triples`/`nt`; unrecognised ⇒ throw, not silent-Turtle), **error-as-exception** semantics, and **`.free()`** on the `Store` + every cursor. |
| **#1125** sparq-solid WASM compatibility | `crates/sparq-solid/README.md` new **WASM support** section. **Determined by trial build:** sparq-solid (+ `sparq-reason`, `default-features=false`) **compiles for `wasm32-unknown-unknown`** — the only blocker is the shared `oxrdf → rand → getrandom` backend (solved exactly as `sparq-wasm` does). **Runtime caveat documented:** `materialize_wac`/`materialize_acp` call `std::time::Instant::now()`, which panics on wasm32 (no monotonic clock). |
| **#1126** WAC enforcement examples | `skills/access-control/SKILL.md` gains a request-pipeline integration recipe with a **WAC-Allow header builder** over the existing `accessible()` / `query_as()` API. No public helper exists yet (illustrative, not conformance-tested). |

## Verification evidence
- `cargo tree -p sparq-core -i oxrdf` → `oxrdf v0.3.3` (#1124).
- Trial wasm32 build of a scratch crate depending on `sparq-solid` + `getrandom/wasm_js` → **compiles clean** (#1125); without the backend it fails with getrandom's `wasm_js`-required error — the documented blocker.
- `sparq-solid/src/materialize.rs` calls `Instant::now()`/`elapsed()` unconditionally → runtime panic on wasm32 (documented; `sq-7agop`).
- Doc gates: markdownlint (HARD) **0**, `check-readme-template.py --enforce` **0** (README 119 ≤ 120), lychee `--offline --include-fragments` **0**, `check-no-perf-numbers.py --enforce` **0**, typos clean. `cargo test -p sparq-solid --doc` **24/24 pass**.

## Honesty notes
- **No unqualified ZK/MPC claim introduced.** The one ZK mention I touched (sparq-solid trust-graph bullet) **preserves** its "No privacy/ZK (`sq-qhy4` unaudited)" caveat verbatim. The migration guide adds no privacy/soundness claims.
- The #1125 verdict is **honest, not laundered**: compiles ≠ runs. wasm32 is *compile-feasible today, run-feasible once the `Instant` call is `cfg`-gated*.

## Follow-ups captured as beads (not in this PR)
- `sq-7agop` (P1, bug): cfg-gate `std::time::Instant` in sparq-solid materialize for wasm32.
- `sq-2k9yx` (P2): Oxigraph-shaped iterator-of-bindings result accessor (folds #1123).
- `sq-d1axm` (P2): the umbrella doc record for this cluster.

Closes #1124
Closes #1125
Closes #1126
Closes #1127
Closes #1128

🤖 Generated with [Claude Code](https://claude.com/claude-code)