### PR TITLE
fix(sparq-core): lowercase language tags in the byte N-Triples/N-Quads parser (#1119) [OPUS-4.8]

### DIFF
--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -6273,11 +6273,16 @@ mod tests {
 
         // 4. Literals with datatypes, language tags (incl. `--dir`), escapes, and a `.`-bearing
         //    IRI/literal — the byte parser's literal/IRI grammar must agree with oxttl's per graph.
+        //    [OPUS-4.8] (sq-langcase / #1119) The MIXED-CASE tags (`en-US`, `en-GB--ltr`) pin the
+        //    casing-normalisation parity: the byte parser must lowercase the tag to the SAME slot
+        //    oxttl produces, or this differential check fails on the language column.
         let mut lits = String::new();
         for i in 0..400 {
             let g = if i % 3 == 0 { String::new() } else { format!(" <http://g.x/{}.n>", i % 3) };
             lits.push_str(&format!(
                 "<http://ex/s{i}> <http://ex/p> \"val.{i} \\\"q\\\" x\"@en-us{g} .\n\
+                 <http://ex/s{i}> <http://ex/m> \"mixed.{i}\"@en-US{g} .\n\
+                 <http://ex/s{i}> <http://ex/d> \"dir.{i}\"@en-GB--ltr{g} .\n\
                  <http://ex/s{i}> <http://ex/n> \"{i}\"^^<http://www.w3.org/2001/XMLSchema#integer>{g} .\n"
             ));
         }
@@ -9411,6 +9416,30 @@ mod dir_roundtrip_test {
         let scan = g.store.scan(&[None, None, None]);
         let t = scan.to_spo(&scan.rows.as_ref()[0]);
         assert_eq!(g.dict.term(t[2]).to_string(), "\"abc\"@en--ltr");
+    }
+
+    /// [OPUS-4.8] (sq-langcase / KamiQuasi #1119) Cross-format CONSISTENCY: loading the SAME
+    /// language-tagged triple as N-Triples, N-Quads, and Turtle must yield the SAME stored term —
+    /// a lowercased tag (`en-us`), not the format-dependent `en-US` (N-Triples) / `en-us` (Turtle)
+    /// split that existed before the byte parser was taught to normalise the tag. This is the
+    /// public-API regression for the reported bug: pick the literal object back out via the store
+    /// scan and compare its serialised form across all three load paths.
+    #[test]
+    fn language_tag_casing_consistent_across_formats() {
+        let only_obj = |g: &crate::Graph| -> String {
+            let scan = g.store.scan(&[None, None, None]);
+            let t = scan.to_spo(&scan.rows.as_ref()[0]);
+            g.dict.term(t[2]).to_string()
+        };
+        let nt = crate::Graph::load_str("<http://ex/s> <http://ex/p> \"hi\"@en-US .\n", "ntriples").unwrap();
+        let ttl = crate::Graph::load_str("<http://ex/s> <http://ex/p> \"hi\"@en-US .\n", "turtle").unwrap();
+        let nq = crate::Graph::load_str("<http://ex/s> <http://ex/p> \"hi\"@en-US .\n", "nquads").unwrap();
+        assert_eq!(only_obj(&nt), "\"hi\"@en-us", "N-Triples must lowercase the language tag");
+        assert_eq!(only_obj(&ttl), "\"hi\"@en-us", "Turtle must lowercase the language tag");
+        assert_eq!(only_obj(&nq), "\"hi\"@en-us", "N-Quads must lowercase the language tag");
+        // The three load paths agree (the format-dependent split is gone).
+        assert_eq!(only_obj(&nt), only_obj(&ttl));
+        assert_eq!(only_obj(&nt), only_obj(&nq));
     }
 
     /// Fork-after-compact must stay O(delta): compaction folds the numeric/temporal

--- a/crates/sparq-core/src/nt.rs
+++ b/crates/sparq-core/src/nt.rs
@@ -451,6 +451,20 @@ const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
 const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
 const RDF_DIR_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#dirLangString";
 
+/// [OPUS-4.8] (sq-langcase / #1119) ASCII-lowercases a parsed language tag, BORROWING the input
+/// when it is already all-lowercase (the common case) so the no-uppercase fast path stays
+/// allocation-free. RDF language tags are ASCII (`(PN_CHARS_BASE)('-' alnum*)*` plus the RDF 1.2
+/// `--ltr`/`--rtl` direction), so `make_ascii_lowercase` is the correct, locale-independent fold —
+/// the SAME normalisation `oxrdf`/`oxttl` apply, keeping the byte parser's stored language slot
+/// byte-identical to the oxttl paths' for the same tag.
+fn lowercase_lang(raw: &str) -> Cow<'_, str> {
+    if raw.bytes().any(|c| c.is_ascii_uppercase()) {
+        Cow::Owned(raw.to_ascii_lowercase())
+    } else {
+        Cow::Borrowed(raw)
+    }
+}
+
 fn literal(b: &[u8], i: usize, dict: &mut Dict) -> Result<(Id, usize), String> {
     let (vstart, vend, vesc, after) = scan_delim(b, i, b'"')?;
     let value = decode(&b[vstart..vend], vesc)?;
@@ -474,9 +488,23 @@ fn literal(b: &[u8], i: usize, dict: &mut Dict) -> Result<(Id, usize), String> {
             }
             // RDF 1.2 `@lang--dir` keeps the combined slot (the dict's stored encoding)
             // but is typed rdf:dirLangString.
-            let lang = str_of(&b[lstart..j])?;
-            let dt = if lang.contains("--") { RDF_DIR_LANG_STRING } else { RDF_LANG_STRING };
-            Ok((dict.intern_lit(&value, dt, Some(lang)), j))
+            let raw = str_of(&b[lstart..j])?;
+            let dt = if raw.contains("--") { RDF_DIR_LANG_STRING } else { RDF_LANG_STRING };
+            // [OPUS-4.8] (sq-langcase / KamiQuasi #1119) NORMALISE the language tag to ASCII
+            // lowercase, matching the oxttl/oxrdf paths (`Literal::new_language_tagged_literal`
+            // lowercases via `make_ascii_lowercase`; oxttl's Turtle/N-Quads/TriG recognisers call
+            // `language.to_ascii_lowercase()` before interning). RDF 1.1/1.2 language tags are
+            // case-INSENSITIVE, so `"x"@en-US` and `"x"@en-us` are the SAME RDF term and must
+            // intern to the SAME dict id (term identity is byte-equality of the stored slot).
+            // Without this the byte-level N-Triples/N-Quads fast path preserved the written case
+            // while every oxttl path lowercased it — a format-dependent inconsistency (a Turtle
+            // doc lowercased, the same triple in N-Triples did not) AND a latent term-identity
+            // bug (case-variant tags interned as two distinct terms). The `--dir` suffix is only
+            // ever `ltr`/`rtl` (already lowercase) so lowercasing the whole slot is equivalent to
+            // lowercasing just the BCP47 language part. The all-lowercase case (the overwhelming
+            // majority) borrows with no allocation; only a tag carrying uppercase pays one alloc.
+            let lang = lowercase_lang(raw);
+            Ok((dict.intern_lit(&value, dt, Some(&lang)), j))
         }
         // simple literal -> xsd:string
         _ => Ok((dict.intern_lit(&value, XSD_STRING, None), after)),
@@ -579,6 +607,81 @@ mod tests {
         assert_eq!(t.len(), 2);
         assert_eq!(d.term(t[0][2]), iri("http://ex/o"));
         assert_eq!(d.term(t[1][2]), Term::Literal(Literal::new_simple_literal("v")));
+    }
+
+    // [OPUS-4.8] (sq-langcase / KamiQuasi #1119) The byte-level N-Triples/N-Quads parser
+    // NORMALISES language tags to ASCII lowercase, matching every oxttl path (the Turtle /
+    // N-Quads / TriG recognisers + `oxrdf::Literal::new_language_tagged_literal`). Previously the
+    // byte path PRESERVED the written case (`en-US`) while oxttl lowercased it (`en-us`), giving a
+    // format-dependent result for the SAME triple. RDF 1.1/1.2 language tags are case-insensitive,
+    // so the lowercased slot is the canonical RDF term — and the regression target is twofold:
+    // (a) cross-format consistency, (b) `"x"@en-US` and `"x"@en-us` interning to the SAME id.
+    #[test]
+    fn language_tag_lowercased_to_match_oxttl() {
+        let nt = b"<http://ex/s> <http://ex/p> \"hi\"@en-US .\n";
+        let mut d = Dict::new();
+        let t = parse_chunk(nt, &mut d).unwrap();
+        assert_eq!(t.len(), 1);
+        // The stored term carries the lowercased tag — byte-identical to what oxttl produces.
+        let want = Term::Literal(Literal::new_language_tagged_literal_unchecked("hi", "en-us"));
+        assert_eq!(d.term(t[0][2]), want);
+        // And it equals what the checked oxrdf constructor (which lowercases) yields from the
+        // mixed-case tag, i.e. the byte parser and the oxttl/oxrdf paths agree.
+        let oxttl_like =
+            Term::Literal(Literal::new_language_tagged_literal("hi", "en-US").unwrap());
+        assert_eq!(d.term(t[0][2]), oxttl_like);
+    }
+
+    #[test]
+    fn case_variant_language_tags_intern_to_same_id() {
+        // Two lines whose ONLY difference is the language-tag case must content-address to one id
+        // (term identity is case-insensitive on the tag) — they did NOT before this fix.
+        let nt = b"<http://ex/s> <http://ex/p> \"hi\"@en-US .\n<http://ex/s2> <http://ex/p> \"hi\"@en-us .\n";
+        let mut d = Dict::new();
+        let t = parse_chunk(nt, &mut d).unwrap();
+        assert_eq!(t.len(), 2);
+        assert_eq!(t[0][2], t[1][2], "case-variant language tags must share one dict id");
+    }
+
+    #[test]
+    fn directional_language_tag_lowercases_lang_part_only() {
+        // RDF 1.2 `@lang--dir`: the BCP47 language part lowercases; the direction (`ltr`/`rtl`,
+        // already lowercase) is unchanged. The stored slot must match the oxttl encoding exactly.
+        let nt = b"<http://ex/s> <http://ex/p> \"hi\"@en-US--ltr .\n";
+        let mut d = Dict::new();
+        let t = parse_chunk(nt, &mut d).unwrap();
+        assert_eq!(t.len(), 1);
+        let want = Term::Literal(
+            Literal::new_directional_language_tagged_literal_unchecked(
+                "hi",
+                "en-us",
+                oxrdf::BaseDirection::Ltr,
+            ),
+        );
+        assert_eq!(d.term(t[0][2]), want);
+    }
+
+    // The N-Quads byte fast path interns S/P/O through the SAME `literal` path, so it lowercases
+    // too — guarding against a future divergence between the two byte loaders.
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn nquads_language_tag_lowercased() {
+        let nq = b"<http://ex/s> <http://ex/p> \"hi\"@en-US <http://ex/g> .\n";
+        let buckets = parse_quads_chunk(nq).unwrap();
+        assert_eq!(buckets.len(), 1);
+        let (_g, dict, triples) = &buckets[0];
+        let want = Term::Literal(Literal::new_language_tagged_literal_unchecked("hi", "en-us"));
+        assert_eq!(dict.term(triples[0][2]), want);
+    }
+
+    #[test]
+    fn already_lowercase_language_tag_unchanged() {
+        // The common all-lowercase tag is untouched (and the fast borrow path is exercised).
+        let nt = b"<http://ex/s> <http://ex/p> \"hi\"@fr .\n";
+        let mut d = Dict::new();
+        let t = parse_chunk(nt, &mut d).unwrap();
+        let want = Term::Literal(Literal::new_language_tagged_literal_unchecked("hi", "fr"));
+        assert_eq!(d.term(t[0][2]), want);
     }
 
     #[test]

--- a/crates/sparq-core/tests/parallel_serial_load_differential.rs
+++ b/crates/sparq-core/tests/parallel_serial_load_differential.rs
@@ -211,6 +211,11 @@ fn synthetic_nt() -> (String, Vec<[Term; 3]>) {
     // Every remaining record shape, plus an exact-duplicate line and a shared-term crosser.
     nt.push_str("<http://ex/s0> <http://ex/label> \"caf\\u00e9 \\\"q\\\"\"@fr .\n");
     reference.push([iri("http://ex/s0"), iri("http://ex/label"), lang("café \"q\"", "fr")]);
+    // [OPUS-4.8] (sq-langcase / #1119) A MIXED-CASE language tag: the byte parser must lowercase
+    // it (`en-US` -> `en-us`) to agree with the oxttl streaming/serial paths AND this reference
+    // (whose tag is the canonical lowercase form). Pins the casing-normalisation parity here too.
+    nt.push_str("<http://ex/s0> <http://ex/label> \"hello\"@en-US .\n");
+    reference.push([iri("http://ex/s0"), iri("http://ex/label"), lang("hello", "en-us")]);
     nt.push_str("<http://ex/s1> <http://ex/note> \"a plain string\" .\n");
     reference.push([iri("http://ex/s1"), iri("http://ex/note"), lit("a plain string")]);
     nt.push_str("_:b0 <http://ex/about> <http://ex/s2> .\n");

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -422,6 +422,14 @@ cargo build -p sparq-cli --features serialize-rdf
   is a heap-stack pushdown automaton and cannot recurse the native stack. The SPARQL parser has
   the matching `MAX_RECURSION_DEPTH = 128` cap (groups/expressions/paths/collections/triple
   terms). 128 is far deeper than any real data/query nests.
+- **Language tags are normalised to lowercase on ingest.** A `@lang` tag is stored ASCII-lowercased
+  across **every** format and path — Turtle/TriG/N-Quads via `oxttl`, and the byte-level
+  N-Triples/N-Quads fast parser (`sparq-core::nt`). RDF 1.1/1.2 language tags are case-insensitive,
+  so `"x"@en-US` and `"x"@en-us` are the **same** RDF term and intern to one dict id (matching
+  `oxrdf::Literal::new_language_tagged_literal`). This makes ingest format-INDEPENDENT: the same
+  triple written as N-Triples or as Turtle yields the identical stored term (it did **not** before —
+  the byte path used to preserve the written case while every `oxttl` path lowercased it; KamiQuasi
+  #1119 / sq-langcase). The RDF 1.2 `--ltr`/`--rtl` direction is unaffected (already lowercase).
 - **`build_external` / `open` / `save` require the `mmap` feature** (native only). The
   N-Triples external path also honors `SPARQ_SHARDED_DICT` (default on with ≥2 threads)
   and, with the `dict-spill` feature + `SPARQ_DICT_SPILL` env, bounds peak build RSS by


### PR DESCRIPTION
> 🤖 SPARQ agent — addressing EXTERNAL issue #1119 (reported by @KamiQuasi), cluster *Language-tag casing consistency in the parse path*.

## The bug (verified)

Language-tag casing was **format-dependent**. sparq's own byte-level N-Triples/N-Quads fast parser (`crates/sparq-core/src/nt.rs`) **preserved** the written case (`en-US`), while every `oxttl` path (Turtle / TriG / N-Quads, serial + streaming) **lowercased** it to `en-us`. So the same triple loaded as N-Triples vs Turtle produced a different stored term:

```text
N-Triples  "hi"@en-US  ->  "hi"@en-US   (byte parser, preserved)
Turtle     "hi"@en-US  ->  "hi"@en-us   (oxttl, lowercased)
```

RDF 1.1/1.2 language tags are **case-insensitive**, so this was two problems at once:
1. a cross-format **inconsistency**, and
2. a latent **term-identity bug** — `"x"@en-US` and `"x"@en-us` are the *same* RDF term but interned to **distinct dict ids** on the byte path (so they would not match in a BGP / collapse under DISTINCT).

## The decision: normalise to lowercase (not preserve)

The cluster's `needs_decision` flagged a preserve-vs-normalize policy call. I went with **normalise to lowercase**, and the brief's literal suggestion (*"rebuild the literal via the unchecked lang constructor after oxttl yields it"*) turns out to be **infeasible**: `oxttl` lowercases the tag *internally* (`terse.rs` calls `language.to_ascii_lowercase()`) **before** it ever yields the `Term` — the original case is already gone, so the only way to "preserve" through the Turtle path would be to fork `oxttl` or hand-roll Turtle lang re-extraction, both against the lean-core constraint.

Lowercasing is also the **established sparq convention**, so `nt.rs` was the outlier:
- the **sparq-reason** N3 parser already lowercases (`@EN-US` → `en-us`, asserted in its tests), and
- the **engine** already folds the tag to lowercase for `RDFterm-equal` (`exec.rs` `lit_kind`).

Normalising makes term identity **spec-correct** and ingest **format-independent** across every path — and matches `oxrdf::Literal::new_language_tagged_literal` (`make_ascii_lowercase`).

## The fix

`nt::literal` lowercases the parsed `@lang` slot via a small `lowercase_lang` helper that **borrows** when the tag is already lowercase (keeps the module's zero-alloc fast path; only a tag carrying uppercase pays one allocation). Applies to the N-Triples and N-Quads byte paths. The RDF 1.2 `--ltr`/`--rtl` direction is unaffected (already lowercase).

No new dependency, **no feature flag** — this is a conformance fix to an existing parse surface, not a new opt-in capability, so `sparq-core` stays lean.

## Tests (real path, both feature states)

- `nt.rs` units: match-oxttl, case-variant-→-same-id, directional (`@en-US--ltr`), N-Quads byte path, already-lowercase (borrow path).
- `lib.rs` public-API cross-format test `language_tag_casing_consistent_across_formats` (N-Triples == Turtle == N-Quads).
- Mixed-case fixtures (`@en-US`, `@en-GB--ltr`) added to **both** differential oracles (`parallel_nquads_matches_serial` and the `parallel_serial_load_differential` integration test) so byte-vs-oxttl parity now pins casing.

## Gates run (GREEN in both states)

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — `-p sparq-core` **default (`parallel`)** AND **`--no-default-features`**.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- Downstream `sparq-engine`, `sparq-shacl`, `sparq-reason`, `sparq-conformance` test suites — green (no fixture relied on the old preserved case).

Doc: a gotcha bullet in `skills/data-formats/SKILL.md`. README untouched (the detail belongs in the SKILL).

Closes #1119.

---
Auto-merge intentionally **left off**: this changes observable parse output across formats, so it warrants a maintainer eyeball even though it is low-risk. A follow-up bead (`sq-vkuv8`) was filed for an unrelated stale line in the same SKILL (says unknown formats parse as Turtle; `sq-m2pc` made them reject).