### PR TITLE
fix(sparq-solid): cfg-gate std::time::Instant in materialize for wasm32 (sq-7agop) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -419,7 +419,7 @@ jobs:
           done
 
   wasm:
-    name: wasm build (sparq-wasm + sparq-reason-wasm + sparq-rsp-wasm + sparq-text-wasm + sparq-shacl-wasm)
+    name: wasm build (sparq-wasm + sparq-reason-wasm + sparq-rsp-wasm + sparq-text-wasm + sparq-shacl-wasm + sparq-solid)
     needs: changes
     if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
@@ -594,6 +594,21 @@ jobs:
       # job summary so a future bloat is visible in the log.
       - name: Measure sparq-introspect wasm bundle size (informational)
         run: ./scripts/introspect-wasm-size.sh | tee -a "$GITHUB_STEP_SUMMARY"
+      # [OPUS-4.8] sq-7agop: the opt-in Solid access-control layer compiles to wasm32 AND
+      # now RUNS there. `materialize_wac`/`materialize_acp` previously called
+      # `std::time::Instant::now()` unconditionally (for the informational `stats.millis`),
+      # which PANICS on wasm32-unknown-unknown (no monotonic clock) — the crate compiled
+      # but TRAPPED at runtime. The timing is now cfg-gated off on wasm32 (reports `0.0`).
+      # clippy on the wasm32 target first (the native lint job compiles for the HOST triple
+      # and never sees wasm32-cfg'd paths), then the headless `wasm-pack test --node` smoke
+      # (crates/sparq-solid/tests/wasm_materialize.rs) drives the REAL materialize path in a
+      # genuine wasm runtime so the trap can never silently regress — `cargo build --target
+      # wasm32` alone never RUNS materialize. The crate's transitive oxrdf→rand→getrandom
+      # uses the wasm_js backend selected by .cargo/config.toml.
+      - name: clippy (wasm32 target, sparq-solid, deny warnings)
+        run: cargo clippy -p sparq-solid --target wasm32-unknown-unknown --all-targets -- -D warnings
+      - name: Headless wasm tests (sparq-solid materialize, wasm-pack test --node)
+        run: wasm-pack test --node crates/sparq-solid
 
   # NOTE: sparq-py's pytest suite (incl. the new test_parity.py result-parity +
   # panic-surface tests) is run by the dedicated `python.yml` workflow ("Python

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3699,6 +3699,7 @@ dependencies = [
 name = "sparq-solid"
 version = "0.1.0"
 dependencies = [
+ "getrandom 0.3.4",
  "oxrdf 0.3.3",
  "rustc-hash 2.1.2",
  "spargebra",
@@ -3708,6 +3709,7 @@ dependencies = [
  "sparq-reason",
  "sparq-trust",
  "sparq-zk",
+ "wasm-bindgen-test",
 ]
 
 [[package]]

--- a/crates/sparq-solid/Cargo.toml
+++ b/crates/sparq-solid/Cargo.toml
@@ -70,9 +70,28 @@ count-enforcement = ["odrl-bridge", "sparq-policy/count-enforcement"]
 # SKILL for the honest scope.
 trust-graph = ["dep:sparq-trust"]
 
-[dev-dependencies]
 # [OPUS-4.8] sq-pfae PoC: the trust-graph end-to-end test (tests/trust_graph.rs, fully
 # `#![cfg(feature = "trust-graph")]`) drives the admission gate through the real
-# PodStore. These are dev-only — they do not touch the default build or publish.
+# PodStore. These are dev-only — they do not touch the default build or publish. Scoped
+# to NON-wasm32 [OPUS-4.8 sq-7agop]: the `trust-graph` ZK estate (the arkworks stack →
+# `rand 0.8 → getrandom 0.2`) is native-only and not wasm-portable, so excluding it from
+# the wasm32 dev-graph lets `tests/wasm_materialize.rs` build under `wasm-pack test`
+# without dragging a wasm-incompatible getrandom into the test graph.
+[target.'cfg(not(target_arch = "wasm32"))'.dev-dependencies]
 sparq-trust = { path = "../sparq-trust" }
 sparq-zk = { path = "../sparq-zk" }
+
+# [OPUS-4.8] sq-7agop: wasm32 build+smoke check (regression guard for the cfg-gated
+# `std::time::Instant` in `materialize_*`). `tests/wasm_materialize.rs` runs the REAL
+# materialize path in a genuine wasm32 runtime via `wasm-pack test --node`, asserting it
+# no longer traps (it panicked on `Instant::now()` before the fix). These are DEV-ONLY
+# wasm32-target deps — they do NOT enter the runtime/published graph and native builds
+# link none of them:
+#  - getrandom/wasm_js: the crate's transitive `oxrdf → rand → getrandom` needs a wasm
+#    RNG backend selected before it compiles for wasm32 (the workspace `.cargo/config.toml`
+#    sets the matching `--cfg getrandom_backend="wasm_js"`). A downstream host bundle
+#    selects the backend itself at runtime (see README §WASM support), as `sparq-wasm` does.
+#  - wasm-bindgen-test: the headless test harness (pairs with the 0.2.x wasm-bindgen line).
+[target.'cfg(target_arch = "wasm32")'.dev-dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
+wasm-bindgen-test = "0.3"

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -73,14 +73,15 @@ asymmetric (fail-OPEN risk):** an `auth:deny*` is retracted **only** on a *defin
 
 ## WASM support
 
-`sparq-solid` (with its `sparq-reason` dep, `default-features = false`) **compiles for
-`wasm32-unknown-unknown`** (trial-build verified; no native-only deps — rayon off, `sparq-reason`'s
-parallel path gated). Its transitive `oxrdf 0.3.3 → rand → getrandom` needs the host bundle to select a
-wasm RNG backend as `sparq-wasm` does (`getrandom`'s `wasm_js` feature + the `getrandom_backend` cfg; see
-the [migration guide](../../docs/migrating-from-oxigraph.md#wasm-compilation)). **Runtime caveat:**
-`materialize_wac`/`materialize_acp` call `std::time::Instant::now()` (`stats.millis`), which **panics on
-wasm32** (no monotonic clock) — materialize traps until that call is `cfg`-gated (follow-up bead). So
-Deno-wasm / Cloudflare Workers are *compile-feasible now, run-feasible once the clock call is gated*.
+`sparq-solid` (with its `sparq-reason` dep, `default-features = false`) **compiles for AND runs on
+`wasm32-unknown-unknown`** (no native-only deps — rayon off, `sparq-reason`'s parallel path gated). Its
+transitive `oxrdf 0.3.3 → rand → getrandom` needs the host bundle to select a wasm RNG backend as
+`sparq-wasm` does (`getrandom`'s `wasm_js` feature + the `getrandom_backend` cfg; see the
+[migration guide](../../docs/migrating-from-oxigraph.md#wasm-compilation)). **Timing on wasm32:**
+`std::time::Instant` is unavailable there (no monotonic clock — `Instant::now()` panics), so
+`materialize_wac`/`materialize_acp` `cfg`-gate the wall-clock plumbing off and report `stats.millis == 0.0`
+rather than trapping (rest of `MaterializeStats` unchanged); a wasm32 runtime smoke test
+(`tests/wasm_materialize.rs`, `wasm-pack test --node`) guards it. Deno-wasm / Workers are run-feasible.
 
 ## Conformance, security & containment
 

--- a/crates/sparq-solid/src/materialize.rs
+++ b/crates/sparq-solid/src/materialize.rs
@@ -14,6 +14,11 @@ use sparq_core::dict::Dict;
 use sparq_core::Graph;
 use sparq_reason::reason_n3;
 use std::fmt::Write as _;
+// `std::time::Instant` is unusable on `wasm32-unknown-unknown` — `Instant::now()`
+// panics there (no monotonic clock). The wall-clock plumbing for `stats.millis` is
+// purely informational, so it is `cfg`-gated off and reported as `0.0` on wasm32
+// rather than trapping at runtime (sq-7agop). [OPUS-4.8]
+#[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
 
 const COMMON_RULES: &str = include_str!("../rules/common.n3");
@@ -96,6 +101,7 @@ pub struct MaterializeStats {
 /// # Ok::<(), String>(())
 /// ```
 pub fn materialize_wac(graph: &mut Graph) -> Result<MaterializeStats, String> {
+    #[cfg(not(target_arch = "wasm32"))]
     let t0 = Instant::now();
     strip_reserved_graphs(graph);
     // WAC has no creator/owner vocabulary; provenance is ignored (the loader skips it).
@@ -105,7 +111,10 @@ pub fn materialize_wac(graph: &mut Graph) -> Result<MaterializeStats, String> {
     let closure = reason_n3(&mut dict, &src)?;
     let mut stats = install_auth_view(graph, &dict, &closure);
     stats.strata_facts = vec![closure.len()];
-    stats.millis = t0.elapsed().as_secs_f64() * 1e3;
+    stats.millis = elapsed_millis(
+        #[cfg(not(target_arch = "wasm32"))]
+        t0,
+    );
     Ok(stats)
 }
 
@@ -170,6 +179,7 @@ pub fn materialize_acp_with(
     graph: &mut Graph,
     provenance: &AccessProvenance,
 ) -> Result<MaterializeStats, String> {
+    #[cfg(not(target_arch = "wasm32"))]
     let t0 = Instant::now();
     strip_reserved_graphs(graph);
     let input = assemble_input(graph, System::Acp, provenance)?;
@@ -191,8 +201,25 @@ pub fn materialize_acp_with(
 
     let mut stats = install_auth_view(graph, &d3, &c3);
     stats.strata_facts = strata_facts;
-    stats.millis = t0.elapsed().as_secs_f64() * 1e3;
+    stats.millis = elapsed_millis(
+        #[cfg(not(target_arch = "wasm32"))]
+        t0,
+    );
     Ok(stats)
+}
+
+/// Wall-clock milliseconds since `t0`, or `0.0` on `wasm32-unknown-unknown` where
+/// `std::time::Instant` is unavailable (sq-7agop). `stats.millis` is purely
+/// informational (logging / benchmarking), so wasm32 simply reports no timing
+/// rather than trapping. [OPUS-4.8]
+#[cfg(not(target_arch = "wasm32"))]
+fn elapsed_millis(t0: Instant) -> f64 {
+    t0.elapsed().as_secs_f64() * 1e3
+}
+
+#[cfg(target_arch = "wasm32")]
+fn elapsed_millis() -> f64 {
+    0.0
 }
 
 /// Re-serialize a stratum's ground closure as facts for the next stratum.

--- a/crates/sparq-solid/tests/wasm_materialize.rs
+++ b/crates/sparq-solid/tests/wasm_materialize.rs
@@ -1,0 +1,72 @@
+// [OPUS-4.8] sq-7agop — headless wasm32 smoke test of the materializer.
+//
+// `materialize_wac` / `materialize_acp` used to call `std::time::Instant::now()`
+// unconditionally for `stats.millis`. `Instant` is unusable on
+// `wasm32-unknown-unknown` (no monotonic clock — `Instant::now()` PANICS), so the
+// crate compiled to wasm32 but TRAPPED at runtime the moment either function ran.
+//
+// The timing is now `cfg`-gated off on wasm32 (`stats.millis == 0.0` there). This
+// module is the regression guard: it drives the REAL materialize path in a genuine
+// wasm32 runtime via `wasm-pack test --node` and asserts it returns instead of
+// trapping. The native `#[cfg(test)]` suite never catches this — `Instant` is fine
+// natively — so the bug is only observable in an actual wasm runtime.
+//
+// Run with: `wasm-pack test --node -p sparq-solid`. Node is the default executor, so
+// no `wasm_bindgen_test_configure!(run_in_browser)` directive is needed.
+
+#![cfg(target_arch = "wasm32")]
+
+use sparq_solid::{materialize_acp, materialize_wac, AUTH_GRAPH};
+use wasm_bindgen_test::*;
+
+// A single .acl that grants alice Read on the pod root (mirrors the `materialize_wac`
+// doctest fixture).
+const WAC_NQUADS: &str = r#"
+<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hello" <https://pod.ex/notes/n1> .
+<https://pod.ex/.acl#owner> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/.acl> .
+<https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> <https://pod.ex/.acl> .
+<https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#agent> <https://alice.ex/card#me> <https://pod.ex/.acl> .
+<https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/.acl> .
+"#;
+
+// One ACR granting alice Read on all members of the pod root (mirrors the
+// `materialize_acp` doctest fixture).
+const ACP_NQUADS: &str = r#"
+<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hello" <https://pod.ex/notes/n1> .
+<https://pod.ex/.acr> <http://www.w3.org/ns/solid/acp#memberAccessControl> <https://pod.ex/.acr#c> <https://pod.ex/.acr> .
+<https://pod.ex/.acr#c> <http://www.w3.org/ns/solid/acp#apply> <https://pod.ex/.acr#pol> <https://pod.ex/.acr> .
+<https://pod.ex/.acr#pol> <http://www.w3.org/ns/solid/acp#allow> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/.acr> .
+<https://pod.ex/.acr#pol> <http://www.w3.org/ns/solid/acp#allOf> <https://pod.ex/.acr#m> <https://pod.ex/.acr> .
+<https://pod.ex/.acr#m> <http://www.w3.org/ns/solid/acp#agent> <https://alice.ex/card#me> <https://pod.ex/.acr> .
+"#;
+
+/// WAC materialize runs to completion in wasm32 (it used to trap on `Instant::now()`),
+/// installs the auth view, and reports `millis == 0.0` (timing is cfg-gated off here).
+#[wasm_bindgen_test]
+fn wac_materialize_does_not_trap_on_wasm32() {
+    let mut graph =
+        sparq_core::Graph::load_dataset(WAC_NQUADS, "nquads").expect("nquads must load in wasm");
+    let stats = materialize_wac(&mut graph).expect("materialize_wac must not trap on wasm32");
+    assert!(stats.auth_triples > 0, "auth view must be non-empty");
+    assert_eq!(stats.strata_facts.len(), 1, "WAC is a single stratum");
+    // Timing is unavailable on wasm32 (Instant cfg-gated off) — reported as 0.0.
+    assert_eq!(stats.millis, 0.0, "wasm32 reports no wall-clock timing");
+    // The view is installed as an ordinary named graph.
+    assert!(
+        graph.named.iter().any(|(name, _)| matches!(
+            name, oxrdf::Term::NamedNode(n) if n.as_str() == AUTH_GRAPH)),
+        "auth graph must be installed"
+    );
+}
+
+/// ACP materialize (three stratified reasoning calls) also runs to completion in wasm32
+/// and reports `millis == 0.0`.
+#[wasm_bindgen_test]
+fn acp_materialize_does_not_trap_on_wasm32() {
+    let mut graph =
+        sparq_core::Graph::load_dataset(ACP_NQUADS, "nquads").expect("nquads must load in wasm");
+    let stats = materialize_acp(&mut graph).expect("materialize_acp must not trap on wasm32");
+    assert!(stats.auth_triples > 0, "auth view must be non-empty");
+    assert_eq!(stats.strata_facts.len(), 3, "ACP runs three strata");
+    assert_eq!(stats.millis, 0.0, "wasm32 reports no wall-clock timing");
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -88,7 +88,9 @@ Materialize the authorization view from the access-control documents, then enfor
 - `PodStore::new(graph) -> PodStore` — wrap a loaded dataset. Before the first
   `materialize_*` call **every** session (including the owner) sees nothing.
 - `store.materialize_wac()` / `store.materialize_acp() -> Result<MaterializeStats, _>` —
-  run the N3 rules to (re)install `<urn:sparq:auth>`.
+  run the N3 rules to (re)install `<urn:sparq:auth>`. On `wasm32-unknown-unknown` the
+  informational `MaterializeStats::millis` is reported as `0.0` (no `std::time::Instant`);
+  the auth view is identical ([OPUS-4.8] sq-7agop).
 - `store.materialize_acp_with(&AccessProvenance) -> Result<MaterializeStats, _>` —
   ([OPUS-4.8] sq-3jtd.5) ACP materialization that ALSO resolves `acp:CreatorAgent` /
   `acp:OwnerAgent` matchers against per-resource creator/owner WebIDs supplied by the


### PR DESCRIPTION
> 🤖 SPARQ agent — automated change. I identify as a SPARQ agent (one of several @jeswr runs on this account).

## What & why (sq-7agop)

`materialize_wac` / `materialize_acp_with` called `std::time::Instant::now()` unconditionally (for the informational `MaterializeStats::millis`). `Instant` is **unusable on `wasm32-unknown-unknown`** — `Instant::now()` **panics** (no monotonic clock) — so the crate *compiled* to wasm32 but **trapped at runtime** the moment either materialize function ran. Surfaced documenting #1125.

## Fix

- Route the wall-clock through an `elapsed_millis()` helper: `#[cfg(not(target_arch = "wasm32"))]` does the real `t0.elapsed()` timing; `#[cfg(target_arch = "wasm32")]` returns `0.0`. The `Instant` import and the two `t0` bindings are cfg-gated to match.
- The produced auth view and the rest of `MaterializeStats` are **byte-identical across targets** — only the informational timing is dropped on wasm32.

## Regression guard (real path, not a mock)

- New `crates/sparq-solid/tests/wasm_materialize.rs` (`#![cfg(target_arch = "wasm32")]`) drives the **real** WAC + ACP materialize path in a genuine wasm32 runtime via `wasm-pack test --node`, asserting it returns (`millis == 0.0`, auth view non-empty, correct strata count) instead of trapping. The native `#[cfg(test)]` suite never catches this — `Instant` is fine natively, so the bug is only observable in an actual wasm runtime.
- Wired a wasm32 **build + clippy + headless smoke** for `sparq-solid` into the `ci.yml` `wasm` job so the trap can never silently regress.

## Dependency scoping (keeps the lean default build)

- wasm32-target **dev**-deps: `getrandom`/`wasm_js` (the crate's transitive `oxrdf → rand → getrandom` needs a wasm RNG backend; the workspace `.cargo/config.toml` already sets the matching `--cfg getrandom_backend="wasm_js"`) + `wasm-bindgen-test`. Native builds and the published runtime graph link **none** of it.
- Existing `sparq-trust`/`sparq-zk` dev-deps moved to **NON-wasm32** scope: their `arkworks → rand 0.8 → getrandom 0.2` stack is native-only / not wasm-portable, and `tests/trust_graph.rs` is `#![cfg(feature = "trust-graph")]` (native-only research feature). Verified `cargo test -p sparq-solid --features trust-graph --no-run` still compiles.

## Judgment call (flagged for steering)

Used a small `elapsed_millis()` helper rather than the engine's inline two-`#[cfg]`-binding pattern (`exec.rs` / `explain.rs`), to avoid duplicating the `0.0` at two call sites. Documented here + in the bead note; easy to inline if a different convention is preferred.

## Gates (both feature states)

- `cargo build` / `cargo clippy --all-targets [--all-features] -- -D warnings` / `cargo test`: GREEN on native in **default** (feature OFF) AND **all-features** (feature ON).
- `cargo clippy -p sparq-solid --target wasm32-unknown-unknown --all-targets -- -D warnings`: GREEN.
- `wasm-pack test --node crates/sparq-solid`: 2/2 wasm32 smoke tests pass (were trapping before the fix).
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features`: clean.
- `check-readme-template.py --enforce`: 0 deviations (README at the 120-line cap).
- `check-privacy-claims.sh`: clean. `typos`: clean.

Docs updated: `crates/sparq-solid/README.md` (WASM support section) + `skills/access-control/SKILL.md`.

Closes sq-7agop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)