### PR TITLE
feat(site): SHACL playground Compact→shapes (SCS) input mode onto Store.parseShaclCompact (sq-pyn7)

### DIFF
--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -464,6 +464,50 @@ export async function sparqShaclValidate(
   return JSON.parse(store.validate(data, shapes, format)) as ShaclReport;
 }
 
+/**
+ * [OPUS-4.8] sq-pyn7 (#796) — parse a **SHACL Compact Syntax** (SCS) document into a SHACL
+ * **shapes graph**, returned as pretty Turtle, entirely in-tab via the `scs`-enabled wasm
+ * bundle. This is the SCS *input* counterpart of the playground's serialiser
+ * (`shapesToCompact`, the Turtle → SCS *display* direction): it takes compact text and gives
+ * back the Turtle shapes graph that {@link sparqShaclValidate} then consumes — so a user can
+ * author shapes in the terser compact notation and validate data against them unchanged.
+ *
+ * Like {@link sparqShaclValidate} this is a stateless one-shot exposed as an instance method
+ * on the wasm `Store`, so it needs any receiver — an empty store is the cheapest. The optional
+ * `base` resolves relative IRIs in the SCS document; `loadOpts` is forwarded to
+ * {@link loadSparq} so a GUI host can pass its own `basePath`.
+ *
+ * A clear error is thrown if the loaded bundle was built without the `scs` feature (no
+ * `parseShaclCompact` binding) — the lean SPARQL REPL bundle omits it — so a caller can
+ * distinguish "no SCS in this bundle" from an SCS *parse* error (the latter is a `JsError`
+ * carrying the parser's message + 1-based line).
+ */
+export async function sparqParseShaclCompact(
+  text: string,
+  base?: string,
+  loadOpts: LoadSparqOptions = {},
+): Promise<string> {
+  const Store = await loadSparq(loadOpts);
+  // Stateless one-shot, but exposed as an instance method — the empty store is just the
+  // receiver (the binding does not consult its triples).
+  const store = Store.load("", "turtle");
+  // Defensive lean-bundle check: the tracked generated d.ts is the site's `scs`-enabled
+  // bundle, so `parseShaclCompact` is type-declared as present, but the bundle actually LOADED
+  // at runtime is decided by the asset URL. A lean bundle omits the binding, so probe a
+  // possibly-undefined view first to yield a clear error rather than a "not a function" crash.
+  const parse = (store as { parseShaclCompact?: WasmStore["parseShaclCompact"] })
+    .parseShaclCompact;
+  if (typeof parse !== "function") {
+    throw new Error(
+      "This wasm bundle was built without the SHACL Compact Syntax feature (no " +
+        "parseShaclCompact binding). Rebuild sparq-wasm with --features scs.",
+    );
+  }
+  // Invoke BOUND to the `store` receiver (the same lost-receiver fix as `validate` above:
+  // a detached `parse(…)` would run with `this === undefined` and throw on `this.__wbg_ptr`).
+  return store.parseShaclCompact(text, base ?? null);
+}
+
 // ---------------------------------------------------------------------------
 // [OPUS-4.8] sq-n5aw — the framework-agnostic SPARQL EDITOR core (highlighting + prefixes).
 // Re-exported so the site (and the Tauri webview) consume the same dependency-free tokenizer

--- a/site/e2e/shacl-validator.spec.ts
+++ b/site/e2e/shacl-validator.spec.ts
@@ -139,3 +139,38 @@ test("the Compact syntax button renders the shapes graph in SHACL Compact Syntax
 
   expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
 });
+
+test("the SCS-input example parses compact shapes and validates the data against them", async ({
+  page,
+}) => {
+  // [OPUS-4.8] sq-pyn7 (#796) — the SCS *input* path: the shapes editor switches to Compact
+  // mode and its SHACL Compact Syntax text is parsed to a Turtle shapes graph via the wasm
+  // `Store.parseShaclCompact` binding BEFORE validation. This guards that the compact-authored
+  // Person shape flags `ex:carol`'s string age exactly as the equivalent Turtle shape would.
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoReady(page);
+
+  // Select the "Compact-syntax shapes (SCS input)" example — it flips the shapes-input toggle
+  // to Compact and loads SCS into the shapes editor.
+  await page.getByRole("button", { name: "Compact-syntax shapes (SCS input)" }).click();
+  // The shapes-input radiogroup now reports Compact as the checked option.
+  await expect(
+    page.getByRole("radio", { name: "Compact" }),
+  ).toHaveAttribute("aria-checked", "true");
+
+  await page.getByRole("button", { name: "Validate" }).click();
+
+  // The SCS is parsed to a shapes graph and the data validated against it: a non-conformant
+  // report with the datatype violation (a string ex:age where the SCS requires xsd:integer).
+  const report = page.locator('[data-testid="shacl-report"]');
+  await expect(report).toBeVisible({ timeout: 30_000 });
+  await expect(report.locator("[data-conforms]")).toHaveAttribute(
+    "data-conforms",
+    "false",
+  );
+  await expect(
+    report.locator('[data-component="DatatypeConstraintComponent"]'),
+  ).toHaveCount(1);
+
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});

--- a/site/src/app/surface/shacl/page.tsx
+++ b/site/src/app/surface/shacl/page.tsx
@@ -47,8 +47,8 @@ export default function ShaclSurfacePage() {
           body: "Conformance boolean + sh:result violations, as Turtle or human text.",
         },
         {
-          title: "SHACL Compact Syntax (display)",
-          body: "Render the shapes graph in the W3C compact notation beside the validation report.",
+          title: "SHACL Compact Syntax (in + out)",
+          body: "Author shapes in the W3C compact notation (parsed in-tab to a shapes graph) and render any shapes graph back to compact form.",
         },
       ]}
       runsNote="Live in your browser tab — the validator is pure Rust over the engine compiled to the SHACL-enabled wasm bundle, so the conformance flag and per-violation report come back with no network round-trip."
@@ -64,12 +64,14 @@ export default function ShaclSurfacePage() {
             HTTP <code className="font-mono">validate</code> path.
           </p>
           <p>
-            The <strong className="text-foreground">Compact syntax</strong> view is the
-            display direction only (shapes &rarr; compact) and best-effort: the notation
+            <strong className="text-foreground">SHACL Compact Syntax</strong> works both
+            ways. The <em>input</em> direction (compact text &rarr; shapes) parses in-tab
+            via the engine&rsquo;s <code className="font-mono">parseShaclCompact</code>{" "}
+            binding &mdash; switch the shapes editor to <em>Compact</em> to author shapes
+            in the terser notation and validate against them unchanged. The{" "}
+            <em>display</em> direction (shapes &rarr; compact) is best-effort: the notation
             has no form for logical constraints or shape references, which the view lists
-            explicitly rather than dropping. The parse direction (compact text &rarr;
-            shapes) belongs in the <code className="font-mono">sparq-shacl</code> engine
-            and is tracked separately.
+            explicitly rather than dropping.
           </p>
         </>
       }

--- a/site/src/components/shacl-playground.tsx
+++ b/site/src/components/shacl-playground.tsx
@@ -32,6 +32,7 @@ import {
   loadIntoStore,
   matchQuads,
   sparqShaclValidate,
+  sparqParseShaclCompact,
   type ShaclReport,
   type SparqlBinding,
   type SparqlTerm,
@@ -68,6 +69,13 @@ type CompactState =
 
 type EngineState = "cold" | "warming" | "ready" | "error";
 type View = "results" | "turtle" | "compact";
+
+// [OPUS-4.8] sq-pyn7 (#796) — the SHAPES-input syntax. "turtle" feeds the textarea text to
+// the validator unchanged; "compact" reads it as SHACL Compact Syntax (SCS) and parses it to
+// a Turtle shapes graph via the wasm `Store.parseShaclCompact` binding FIRST, so the user can
+// author shapes in the terser compact notation and still validate / round-trip them. This is
+// the SCS *input* direction, the counterpart of the `shapesToCompact` Turtle→SCS serialiser.
+type ShapesMode = "turtle" | "compact";
 
 // Turtle `@prefix p: <iri> .` OR SPARQL-style `PREFIX p: <iri>` declarations. The
 // shared `declaredPrefixBindings` only matches the SPARQL form; the SHACL Turtle
@@ -106,11 +114,21 @@ const DEFAULT = SHACL_EXAMPLES[0];
 export function ShaclPlayground() {
   const [data, setData] = React.useState(DEFAULT.data);
   const [shapes, setShapes] = React.useState(DEFAULT.shapes);
+  const [shapesMode, setShapesMode] = React.useState<ShapesMode>("turtle");
   const [state, setState] = React.useState<RunState>({ kind: "idle" });
   const [compact, setCompact] = React.useState<CompactState>({ kind: "idle" });
   const [engine, setEngine] = React.useState<EngineState>("cold");
   const [activeExample, setActiveExample] = React.useState<string>(DEFAULT.id);
   const [view, setView] = React.useState<View>("results");
+
+  // [OPUS-4.8] sq-pyn7 (#796) — resolve the SHAPES textarea to a Turtle shapes graph: in
+  // "turtle" mode it is the text unchanged; in "compact" mode it is SCS, parsed to Turtle via
+  // the wasm `Store.parseShaclCompact` binding (a clear error is surfaced if the loaded bundle
+  // lacks the `scs` feature, or if the SCS fails to parse). Memoised on `shapes`/`shapesMode`.
+  const resolveShapesTurtle = React.useCallback(async (): Promise<string> => {
+    if (shapesMode === "turtle") return shapes;
+    return sparqParseShaclCompact(shapes);
+  }, [shapes, shapesMode]);
 
   // [OPUS-4.8] sq-4296 (#935 / #981) — pre-warm the wasm engine on the next browser-IDLE
   // slot, not synchronously during mount, so the ~300 kB+ engine wasm never blocks the
@@ -142,7 +160,12 @@ export function ShaclPlayground() {
     setState({ kind: "running" });
     try {
       const t0 = performance.now();
-      const report = await sparqShaclValidate(data, shapes, "turtle");
+      // [OPUS-4.8] sq-pyn7 (#796) — when the shapes editor is in Compact mode the SCS text is
+      // parsed to a Turtle shapes graph FIRST (via the wasm binding), then validated exactly
+      // as a hand-written Turtle shapes graph would be — the SCS input round-trips losslessly
+      // through the same `validate` path.
+      const shapesTurtle = await resolveShapesTurtle();
+      const report = await sparqShaclValidate(data, shapesTurtle, "turtle");
       const ms = performance.now() - t0;
       setEngine("ready");
       setState({ kind: "report", report, ms });
@@ -151,7 +174,7 @@ export function ShaclPlayground() {
       setState({ kind: "error", message });
       toast.error("Validation failed", { description: message });
     }
-  }, [data, shapes]);
+  }, [data, resolveShapesTurtle]);
 
   // [OPUS-4.8] sq-pvg2 (#796) — render the SHAPES graph in SHACL Compact Syntax.
   // Parses the shapes Turtle with the same wasm engine, pulls every triple out via
@@ -161,8 +184,12 @@ export function ShaclPlayground() {
     setView("compact");
     setCompact({ kind: "running" });
     try {
+      // [OPUS-4.8] sq-pyn7 (#796) — resolve to Turtle first so the compact render works in
+      // BOTH input modes: in Compact mode this parses SCS → Turtle, then re-serialises Turtle
+      // → SCS, exercising the full round-trip; in Turtle mode it serialises the text directly.
+      const shapesTurtle = await resolveShapesTurtle();
       const Store = await loadSparq();
-      const store = loadIntoStore(Store, shapes, "turtle");
+      const store = loadIntoStore(Store, shapesTurtle, "turtle");
       const rows: SparqlBinding[] = matchQuads(store);
       const triples: ScsTriple[] = rows.flatMap((row) => {
         const { s, p, o } = row;
@@ -171,7 +198,9 @@ export function ShaclPlayground() {
           { subject: toScsTerm(s), predicate: toScsTerm(p), object: toScsTerm(o) },
         ];
       });
-      const { text, unsupported } = shapesToCompact(triples, extractPrefixes(shapes));
+      // Recover the prefix labels from the resolved Turtle (it carries the `@prefix`/PREFIX
+      // declarations in both modes — the wasm parser emits them for the SCS-derived graph too).
+      const { text, unsupported } = shapesToCompact(triples, extractPrefixes(shapesTurtle));
       setEngine("ready");
       setCompact({ kind: "done", text, unsupported });
     } catch (e) {
@@ -179,13 +208,16 @@ export function ShaclPlayground() {
       setCompact({ kind: "error", message });
       toast.error("Could not render compact syntax", { description: message });
     }
-  }, [shapes]);
+  }, [resolveShapesTurtle]);
 
   const selectExample = React.useCallback((id: string) => {
     const ex = SHACL_EXAMPLES.find((e) => e.id === id);
     if (!ex) return;
     setData(ex.data);
     setShapes(ex.shapes);
+    // [OPUS-4.8] sq-pyn7 (#796) — an example may carry its shapes as SCS (`shapesMode:
+    // "compact"`); switch the shapes-input toggle to match so it parses, not validates raw.
+    setShapesMode(ex.shapesMode ?? "turtle");
     setActiveExample(id);
     setState({ kind: "idle" });
     setCompact({ kind: "idle" });
@@ -236,12 +268,15 @@ export function ShaclPlayground() {
             />
           </div>
           <div className="space-y-1.5">
-            <label
-              htmlFor="shacl-shapes"
-              className="text-xs font-medium text-muted-foreground"
-            >
-              Shapes graph (Turtle)
-            </label>
+            <div className="flex items-center justify-between gap-2">
+              <label
+                htmlFor="shacl-shapes"
+                className="text-xs font-medium text-muted-foreground"
+              >
+                Shapes graph ({shapesMode === "compact" ? "Compact syntax" : "Turtle"})
+              </label>
+              <ShapesModeToggle mode={shapesMode} onChange={setShapesMode} />
+            </div>
             <textarea
               id="shacl-shapes"
               value={shapes}
@@ -249,7 +284,18 @@ export function ShaclPlayground() {
               onChange={(e) => setShapes(e.target.value)}
               rows={12}
               className="w-full resize-y rounded-lg border bg-muted/40 p-3 font-mono text-[12.5px] leading-relaxed outline-none focus-visible:ring-3 focus-visible:ring-ring/40"
+              aria-describedby={shapesMode === "compact" ? "shacl-shapes-scs-hint" : undefined}
             />
+            {shapesMode === "compact" && (
+              <p
+                id="shacl-shapes-scs-hint"
+                className="text-[11px] text-muted-foreground"
+              >
+                SHACL Compact Syntax — parsed to a shapes graph via the wasm{" "}
+                <code className="font-mono">Store.parseShaclCompact</code> binding before
+                validation.
+              </p>
+            )}
           </div>
         </div>
 
@@ -320,6 +366,47 @@ function EngineIndicator({ engine }: { engine: EngineState }) {
     <Badge variant="muted" aria-live="polite">
       <Loader2 className="size-3 animate-spin" /> Engine loading…
     </Badge>
+  );
+}
+
+// [OPUS-4.8] sq-pyn7 (#796) — the shapes-input syntax toggle: Turtle (the default; the text
+// is fed to the validator unchanged) vs Compact (the text is SHACL Compact Syntax, parsed to
+// a Turtle shapes graph via the wasm `Store.parseShaclCompact` binding before validation).
+function ShapesModeToggle({
+  mode,
+  onChange,
+}: {
+  mode: ShapesMode;
+  onChange: (m: ShapesMode) => void;
+}) {
+  const options: { value: ShapesMode; label: string }[] = [
+    { value: "turtle", label: "Turtle" },
+    { value: "compact", label: "Compact" },
+  ];
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Shapes input syntax"
+      className="inline-flex rounded-lg border bg-muted/40 p-0.5"
+    >
+      {options.map((o) => (
+        <button
+          key={o.value}
+          type="button"
+          role="radio"
+          aria-checked={mode === o.value}
+          onClick={() => onChange(o.value)}
+          className={cn(
+            "rounded-md px-2 py-0.5 text-[11px] font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40",
+            mode === o.value
+              ? "bg-background text-foreground shadow-sm"
+              : "text-muted-foreground hover:text-foreground",
+          )}
+        >
+          {o.label}
+        </button>
+      ))}
+    </div>
   );
 }
 

--- a/site/src/data/shacl-examples.ts
+++ b/site/src/data/shacl-examples.ts
@@ -10,6 +10,12 @@ export interface ShaclExample {
   conforms: boolean;
   data: string;
   shapes: string;
+  /**
+   * [OPUS-4.8] sq-pyn7 (#796) — the syntax of `shapes`. Defaults to "turtle"; an example with
+   * "compact" carries its shapes graph as SHACL Compact Syntax, which the playground parses to
+   * Turtle via the wasm `Store.parseShaclCompact` binding before validating.
+   */
+  shapesMode?: "turtle" | "compact";
 }
 
 const PERSON_SHAPE = `@prefix sh:  <http://www.w3.org/ns/shacl#> .
@@ -73,5 +79,33 @@ ex:bob a ex:Person ;
   ex:age 41 .
 `,
     shapes: PERSON_SHAPE,
+  },
+  {
+    // [OPUS-4.8] sq-pyn7 (#796) — the SCS *input* example: the same Person shape authored in
+    // the terser SHACL Compact Syntax. The playground parses it to a Turtle shapes graph via
+    // the wasm `Store.parseShaclCompact` binding before validating, so `ex:age "thirty"` (a
+    // string) still fails the xsd:integer datatype constraint. `shapeClass` makes the shape
+    // its own target class — the data's `ex:carol a ex:Person` is targeted.
+    id: "compact-input",
+    label: "Compact-syntax shapes (SCS input)",
+    description:
+      "The Person shape written in SHACL Compact Syntax, parsed to a shapes graph via Store.parseShaclCompact before validating. ex:carol's string age violates xsd:integer — the same report as the equivalent Turtle shapes.",
+    conforms: false,
+    shapesMode: "compact",
+    data: `@prefix ex: <http://example.org/> .
+
+# age is a string literal, not an integer — fails sh:datatype xsd:integer.
+ex:carol a ex:Person ;
+  ex:name "Carol" ;
+  ex:age "thirty" .
+`,
+    shapes: `PREFIX ex: <http://example.org/>
+PREFIX xsd: <http://www.w3.org/2001/XMLSchema#>
+
+shapeClass ex:Person {
+\tex:name xsd:string [1..1] .
+\tex:age xsd:integer [1..1] .
+}
+`,
   },
 ];

--- a/site/src/lib/sparq-wasm.ts
+++ b/site/src/lib/sparq-wasm.ts
@@ -55,6 +55,10 @@ export {
   prewarmSparqWhenIdle,
   type IdlePrewarmHandle,
   sparqShaclValidate,
+  // [OPUS-4.8] sq-pyn7 (#796) — the SCS *input* helper: parse a SHACL Compact Syntax document
+  // into a Turtle shapes graph via the `scs`-enabled wasm `Store.parseShaclCompact`, the
+  // counterpart of the `shapesToCompact` Turtle→SCS serialiser.
+  sparqParseShaclCompact,
   streamQueryRows,
   // [OPUS-4.8] sq-x0kp — the framework-agnostic results-formatting core (table extraction,
   // CSV/TSV export, raw-JSON pretty-print, ASK discrimination) the REPL result panel draws.


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (sparq-site lane) working on behalf of @jeswr. This PR was prepared autonomously.

## What & why

Closes **sq-pyn7** — wires the **SHACL Compact Syntax (SCS) _input_ mode** ("Compact → shapes") into the #796 SHACL playground, the deferred front-end follow-up to **sq-quly** (which landed the opt-in wasm `Store.parseShaclCompact(text, base?)` binding behind the `scs` feature; the published `@jeswr/sparq` bundle is built with `--features shacl,jsonld,serialize-rdf,scs`).

The playground already had the **display** direction (Turtle shapes → SCS, via the dependency-free `shapesToCompact` serialiser). This adds the **input** direction: author shapes in the terser compact notation, parse them in-tab to a Turtle shapes graph, and validate data against them unchanged.

## Changes

- **`packages/sparq-client/src/index.ts`** — new `sparqParseShaclCompact(text, base?, loadOpts?)`: parses an SCS document to a Turtle shapes graph via the wasm `Store.parseShaclCompact` binding. Mirrors `sparqShaclValidate`'s defensive pattern — a **clear error on a lean bundle** that omits the binding (distinct from an SCS parse error), and the same lost-receiver fix (invoked **bound** to a throwaway store so `this.__wbg_ptr` resolves). Re-exported from the site's `@/lib/sparq-wasm`.
- **`site/src/components/shacl-playground.tsx`** — a Turtle / Compact **shapes-input toggle** (`role="radiogroup"`). In Compact mode the shapes textarea is resolved to Turtle **first** (`resolveShapesTurtle`), then fed to the existing `validate` and compact-render paths unchanged — so SCS input validates identically to hand-written Turtle, and the round-trip (SCS → Turtle → SCS) is exercised by the Compact-syntax button.
- **`site/src/data/shacl-examples.ts`** — new "Compact-syntax shapes (SCS input)" example carrying a verified-parseable SCS document (`shapeClass ex:Person { … }`) + a `shapesMode` field; `ex:carol`'s string age violates the SCS `xsd:integer` datatype constraint, producing the same report as the equivalent Turtle shape.
- **`site/e2e/shacl-validator.spec.ts`** — Playwright test for the parse→validate path (selects the SCS example, asserts the Compact radio is checked, validates, asserts a non-conformant report with one `DatatypeConstraintComponent` + zero console errors). Skips when the wasm bundle is absent, like the sibling tests.
- **`site/src/app/surface/shacl/page.tsx`** — capability + caveat copy updated to describe the now-**bidirectional** compact support (the stale "parse direction … tracked separately" note is replaced).

## Design decisions (best-judgment, per the standing rule — steer post-hoc)

1. **Surfaced via the existing `ShaclPlayground`** (rendered on `/surface/shacl`), which **is** the #796 SHACL playground component. The bead title says "/try", but `/try` is the SPARQL REPL — the SHACL playground has always lived at `/surface/shacl`. Wired the SCS mode where the SHACL UI actually is.
2. **No new typed `SparqStore.parseShaclCompact` wrapper.** The bead asked whether to add one (as a separate bead). The site consumes the raw wasm `Store` binding through a small framework-agnostic helper (`sparqParseShaclCompact`) that matches the existing `sparqShaclValidate` shape — no new public-API surface, no separate bead needed. A typed RDF/JS wrapper can be added later for the npm package if desired.
3. **Lean-bundle absence** yields an explicit "built without the SHACL Compact Syntax feature (… `--features scs`)" error rather than a `not a function` crash.

A short tracking issue flags decisions 1 & 2 for the maintainer to steer.

## Gates (all green)

- `cd site && npm install && npm run build` — **static export succeeds end-to-end**; `out/surface/shacl/`, `out/try/`, `out/`, `out/papers/` emitted; `basePath` `/sparq/` correct on assets.
- `npm run lint` — clean. `tsc --noEmit` — clean. `npm run test:unit` — **277/277 pass**.
- `scripts/check-privacy-claims.sh` — clean (no ZK/MPC copy added). Typos gate — none of the flagged terms in the diff.
- **WASM prereq rebuilt**: `js` `build:wasm` (`--features shacl,jsonld,serialize-rdf,scs`) + `build:reason-wasm` — a build artifact only, **no `crates/` source changed**.

Benchmark/`benchmarks.generated.json` churn from the prebuild step was reverted — it is unrelated CI-runner data regeneration, kept out of this PR.

## Covered vs deferred

Covered: SCS input parse → validate, the example, the e2e guard, the round-trip via Compact-syntax, and the lean-bundle error path. Deferred: a typed `SparqStore.parseShaclCompact` wrapper for the npm package (decision 2 above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)