### PR TITLE
feat(sparq-core): guarantee Graph is Send+Sync + opt-in SharedGraph server handle (sq-yj76l)

### DIFF
--- a/crates/sparq-core/Cargo.toml
+++ b/crates/sparq-core/Cargo.toml
@@ -45,6 +45,13 @@ jsonld = ["dep:oxjsonld"]
 # sharded in-RAM consolidation. See research/external-dictionary.md. Rides the
 # parallel parse pipeline and the mmap on-disk store, hence the feature deps.
 dict-spill = ["mmap", "parallel", "dep:libc"]
+# [OPUS-4.8] sq-yj76l (gh #1121): the ergonomic `shared::SharedGraph` handle — an
+# `Arc<RwLock<Graph>>` packaging the recommended read-heavy serving pattern for sharing one
+# store across the async handlers of an axum/actix/tower server. `Graph` is ALREADY Send+Sync
+# (a compile-time assertion in the crate root guarantees it stays so), so this adds NO new
+# dependency — it is `std::sync` only — and is OFF by default so the lean default / wasm build
+# pays nothing. See the `shared` module docs.
+shared = []
 
 [dependencies]
 oxrdf.workspace = true

--- a/crates/sparq-core/README.md
+++ b/crates/sparq-core/README.md
@@ -41,6 +41,8 @@ assert_eq!(count, 1);
   with optional block compression and near-zero resident heap.
 - **Named graphs & RDF 1.2** — full quad storage and
   [triple terms](https://www.w3.org/TR/rdf12-concepts/).
+- **Thread-safe sharing** — `Graph` is `Send + Sync`, so one store serves many server threads;
+  the opt-in `shared` feature adds an ergonomic `SharedGraph` handle for axum/actix state.
 
 ## 📚 Learn more
 

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -10,6 +10,11 @@ pub mod dictspill;
 #[cfg(feature = "mmap")]
 pub mod extsort;
 mod nt;
+// [OPUS-4.8] sq-yj76l (gh #1121): the opt-in `SharedGraph` server-sharing handle. OFF by
+// default so the lean default / wasm build never links it (it is `std::sync` only — no new
+// dep — but the surface stays out of the default API).
+#[cfg(feature = "shared")]
+pub mod shared;
 pub mod store;
 pub mod temporal;
 
@@ -130,6 +135,19 @@ impl std::ops::Deref for GraphSnapshot {
         &self.graph
     }
 }
+
+// [OPUS-4.8] (sq-yj76l, gh #1121) GUARANTEE — for all feature states — that a `Graph` and its
+// read-only `GraphSnapshot` stay `Send` + `Sync`, so they can be shared across the threads of a
+// multi-threaded server (axum/actix) directly or via [`shared::SharedGraph`]. This is a
+// zero-cost compile-time check: adding a future non-`Send`/non-`Sync` field (e.g. an `Rc` or a
+// bare interior-mutable cell) to `Graph` would fail the build HERE rather than silently breaking
+// downstream multi-threaded users. The `mmap`/`dict-spill`-gated fields (`File`, `Mmap`,
+// `TxnJournal`) are themselves `Send + Sync`, so this holds with every feature on too.
+const _: fn() = || {
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<Graph>();
+    assert_send_sync::<GraphSnapshot>();
+};
 
 /// Backing storage for the numeric-value cache (`numerics[id-1]` = f64 value of term
 /// `id`, NaN for non-numeric): owned dense in RAM, mmap'd from disk (out-of-core), or

--- a/crates/sparq-core/src/shared.rs
+++ b/crates/sparq-core/src/shared.rs
@@ -1,0 +1,226 @@
+//! [OPUS-4.8] (sq-yj76l, gh #1121) Ergonomic thread-safe sharing of a [`Graph`] across the
+//! async handlers of a web server (axum / actix / tower) — opt-in behind the `shared`
+//! feature so the lean default / wasm build never pays for it.
+//!
+//! # Why this exists
+//!
+//! A [`Graph`] is already [`Send`] + [`Sync`] (guaranteed by a compile-time assertion in the
+//! crate root), so it *can* be shared with the standard library — `Arc<RwLock<Graph>>`. The
+//! external request behind this module ([gh #1121]) is not about *whether* that works but
+//! about the boilerplate: every axum/actix `State` ends up re-deriving the same
+//! `Arc<RwLock<…>>` plumbing and the same lock-discipline decisions. [`SharedGraph`] packages
+//! the recommended pattern once, with the read-heavy default baked in.
+//!
+//! [gh #1121]: https://github.com/jeswr/sparq/issues/1121
+//!
+//! # Which pattern to use
+//!
+//! sparq gives you two complementary ways to serve one store from many threads. Pick by your
+//! read/write ratio:
+//!
+//! * **Snapshot-per-read (recommended for read-heavy serving).** Take a cheap, immutable
+//!   [`GraphSnapshot`] with [`SharedGraph::snapshot`] and query *that* with no lock held for
+//!   the duration of the request. Snapshotting is O(pending delta) (see [`Graph::snapshot`]),
+//!   the write lock is held only for that O(overlay) clone, and readers never block each
+//!   other or a writer once they hold their snapshot. This is the production serving shape:
+//!   one mutable master + a cheap immutable snapshot per request / per commit.
+//! * **Direct shared access.** [`SharedGraph::read`] / [`SharedGraph::write`] hand out RAII
+//!   [`std::sync::RwLock`] guards for ad-hoc access when a snapshot would be overkill
+//!   (e.g. a one-off `len()` or a quick in-place `apply_delta`). Many readers proceed
+//!   concurrently; a writer is exclusive.
+//!
+//! # Example (axum-style state)
+//!
+//! ```
+//! # #[cfg(feature = "shared")] {
+//! use sparq_core::shared::SharedGraph;
+//! use sparq_core::Graph;
+//!
+//! // Build once, share the handle into every handler (clone is an `Arc` bump).
+//! let g = Graph::load_str("<http://ex/a> <http://ex/p> <http://ex/b> .", "ntriples").unwrap();
+//! let shared = SharedGraph::new(g);
+//!
+//! // A read-heavy handler: snapshot, then query lock-free.
+//! let handler_state = shared.clone();
+//! let snap = handler_state.snapshot();
+//! assert_eq!(snap.len(), 1);
+//!
+//! // A write handler: take the write lock only for the mutation.
+//! shared
+//!     .write()
+//!     .apply_delta(&[], &[])
+//!     .unwrap();
+//! # }
+//! ```
+//!
+//! # Poisoning
+//!
+//! [`SharedGraph`] wraps a [`std::sync::RwLock`]. If a thread panics while holding the write
+//! lock the lock is *poisoned*; the accessors here recover the guard with
+//! `unwrap_or_else(PoisonError::into_inner)` rather than propagating the poison, because a
+//! `Graph` mutation that panics part-way still leaves the store in a structurally valid state
+//! (the delta-overlay and dictionary are append-only and a failed `apply_delta` is reported
+//! as an `Err` *before* any mmap/WAL write — see [`Graph::apply_delta`]). Reads are always
+//! safe; a torn write surfaces as a normal `Err` from the mutating method, not as a poisoned
+//! lock you must special-case in every handler.
+
+use std::sync::{Arc, PoisonError, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+use crate::{Graph, GraphSnapshot};
+
+/// A cheaply-cloneable, thread-safe handle to one shared [`Graph`], ready to drop into an
+/// axum / actix / tower `State`.
+///
+/// Cloning is an [`Arc`] bump — every clone refers to the *same* underlying graph, so an
+/// `apply_delta` through one handle is visible through all of them. See the [module
+/// docs](crate::shared) for when to prefer [`snapshot`](Self::snapshot) (lock-free reads)
+/// over [`read`](Self::read) / [`write`](Self::write) (direct locked access).
+#[derive(Clone)]
+pub struct SharedGraph {
+    inner: Arc<RwLock<Graph>>,
+}
+
+impl SharedGraph {
+    /// Wraps an owned [`Graph`] in a shareable handle.
+    #[inline]
+    pub fn new(graph: Graph) -> Self {
+        Self { inner: Arc::new(RwLock::new(graph)) }
+    }
+
+    /// A cheap, immutable, point-in-time [`GraphSnapshot`] of the current state — the
+    /// recommended read path for a request handler.
+    ///
+    /// Holds the write lock only for the duration of [`Graph::snapshot`] (O(pending delta),
+    /// never O(triples)); the returned snapshot is itself [`Send`] + [`Sync`] and can then be
+    /// queried with no lock held, so concurrent readers never block one another or a later
+    /// writer. The write lock (not the read lock) is taken because `snapshot` populates an
+    /// interior cache the first time a flat graph is frozen; subsequent snapshots are O(overlay).
+    #[inline]
+    pub fn snapshot(&self) -> GraphSnapshot {
+        self.inner.write().unwrap_or_else(PoisonError::into_inner).snapshot()
+    }
+
+    /// A shared (many-reader) RAII guard for ad-hoc read access. Prefer
+    /// [`snapshot`](Self::snapshot) for anything beyond a one-off read — a held read guard
+    /// blocks a concurrent writer for as long as the guard lives.
+    #[inline]
+    pub fn read(&self) -> RwLockReadGuard<'_, Graph> {
+        self.inner.read().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// An exclusive (single-writer) RAII guard for in-place mutation, e.g.
+    /// [`Graph::apply_delta`] / [`Graph::compact`]. Held exclusively, so keep the critical
+    /// section short.
+    #[inline]
+    pub fn write(&self) -> RwLockWriteGuard<'_, Graph> {
+        self.inner.write().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// The number of handles (this one included) sharing the underlying graph — the
+    /// [`Arc::strong_count`] of the inner handle. Diagnostic only.
+    #[inline]
+    pub fn handle_count(&self) -> usize {
+        Arc::strong_count(&self.inner)
+    }
+}
+
+impl From<Graph> for SharedGraph {
+    #[inline]
+    fn from(graph: Graph) -> Self {
+        Self::new(graph)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc as StdArc;
+    use std::thread;
+
+    fn sample() -> Graph {
+        Graph::load_str(
+            "<http://ex/a> <http://ex/p> <http://ex/b> .\n\
+             <http://ex/a> <http://ex/p> <http://ex/c> .",
+            "ntriples",
+        )
+        .expect("load")
+    }
+
+    #[test]
+    fn snapshot_is_consistent_under_concurrent_reads() {
+        let shared = SharedGraph::new(sample());
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let s = shared.clone();
+            handles.push(thread::spawn(move || {
+                // Each thread snapshots and queries lock-free; the real read path runs.
+                let snap = s.snapshot();
+                assert_eq!(snap.len(), 2);
+                snap.len()
+            }));
+        }
+        let total: usize = handles.into_iter().map(|h| h.join().unwrap()).sum();
+        assert_eq!(total, 16);
+    }
+
+    #[test]
+    fn snapshot_is_isolated_from_a_concurrent_write() {
+        // Load-bearing invariant: a snapshot taken before a write reflects the OLD state,
+        // and a snapshot taken after reflects the NEW state — the real apply_delta path.
+        let shared = SharedGraph::new(sample());
+        let before = shared.snapshot();
+        assert_eq!(before.len(), 2);
+
+        shared
+            .write()
+            .apply_delta(
+                &[[
+                    oxrdf::NamedNode::new("http://ex/a").unwrap().into(),
+                    oxrdf::NamedNode::new("http://ex/p").unwrap().into(),
+                    oxrdf::NamedNode::new("http://ex/d").unwrap().into(),
+                ]],
+                &[],
+            )
+            .expect("apply_delta");
+
+        // The earlier snapshot is unaffected by the later mutation.
+        assert_eq!(before.len(), 2);
+        // A fresh snapshot sees the insert.
+        assert_eq!(shared.snapshot().len(), 3);
+        // And the shared base now reports 3 through a direct read guard too.
+        assert_eq!(shared.read().len(), 3);
+    }
+
+    #[test]
+    fn clones_share_one_underlying_graph() {
+        let a = SharedGraph::new(sample());
+        let b = a.clone();
+        assert_eq!(a.handle_count(), 2);
+        b.write()
+            .apply_delta(
+                &[[
+                    oxrdf::NamedNode::new("http://ex/a").unwrap().into(),
+                    oxrdf::NamedNode::new("http://ex/p").unwrap().into(),
+                    oxrdf::NamedNode::new("http://ex/e").unwrap().into(),
+                ]],
+                &[],
+            )
+            .expect("apply_delta");
+        // Mutation through `b` is visible through `a` — same store.
+        assert_eq!(a.read().len(), 3);
+    }
+
+    #[test]
+    fn shared_graph_is_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<SharedGraph>();
+        // It is usable as `Arc<SharedGraph>` state too (axum wraps state in an Arc).
+        let _: StdArc<SharedGraph> = StdArc::new(SharedGraph::new(sample()));
+    }
+
+    #[test]
+    fn from_graph_builds_a_handle() {
+        let shared: SharedGraph = sample().into();
+        assert_eq!(shared.snapshot().len(), 2);
+    }
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -415,6 +415,26 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   let r3 = cache.get_or_eval(&graph, &q, version, &QueryBudget::unlimited())?; // miss (fresh)
   # Ok::<(), String>(())
   ```
+- **Sharing one `Graph` across server threads** — a `sparq_core::Graph` (and its read-only
+  `GraphSnapshot`) is **`Send + Sync`** (guaranteed by a compile-time assertion in `sparq-core`), so
+  it can be shared across the async handlers of an axum/actix/tower server directly with
+  `Arc<RwLock<Graph>>`. To skip that boilerplate, enable the non-default **`shared` cargo feature**
+  on `sparq-core` (bead `sq-yj76l`, gh #1121) for `shared::SharedGraph` — a cheaply-cloneable handle
+  (`SharedGraph::new(graph)` / `.clone()` is an `Arc` bump) with three access paths: `.snapshot()`
+  hands out a cheap immutable point-in-time `GraphSnapshot` you query **lock-free** for the request
+  (the recommended read-heavy path — the write lock is held only for the O(overlay) snapshot clone),
+  while `.read()` / `.write()` give RAII `RwLock` guards for ad-hoc locked access. It is `std::sync`
+  only (no new dependency) and off by default, so the lean default / wasm build pays nothing.
+
+  ```rust
+  // Cargo.toml: sparq-core = { version = "0.1", features = ["shared"] }
+  use sparq_core::shared::SharedGraph;
+  let shared = SharedGraph::new(graph);          // drop into axum `State`, clone per handler
+  let snap = shared.snapshot();                  // cheap immutable view; query it lock-free
+  let _n = snap.len();
+  shared.write().apply_delta(&[], &[])?;          // exclusive write lock only for the mutation
+  # Ok::<(), String>(())
+  ```
 - **MVCC / ACID transaction isolation** is the non-default `txn` cargo feature (bead `sq-it1x`):
   `txn::TransactionManager::new(graph)` owns one logical graph and hands out **snapshot-isolation**
   read transactions (`begin_read()` → a cheap point-in-time view that derefs to `&Graph`, immune to


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead `sq-yj76l` (gh #1121), surface `sparq-core`. Self-identifying per the sub-agent shared contract.

## What & why

External request from @KamiQuasi ([gh #1121](https://github.com/jeswr/sparq/issues/1121)): sharing one `Graph` across the async handlers of an axum/actix/tower server required hand-rolled `Arc<Mutex<Graph>>` boilerplate. The bead offered two options — make `Graph` directly `Send + Sync`, or provide an `Arc`-based `SharedGraph` wrapper.

**Finding:** `Graph` (and its read-only `GraphSnapshot`) is **already structurally `Send + Sync` in every feature state** (verified by building default / `--all-features` / `--no-default-features` / `mmap`-only with a temporary assertion — all the `mmap`/`dict-spill`-gated fields `File` / `Mmap` / `TxnJournal` are themselves `Send + Sync`). Nothing *guaranteed* it, though, so a future non-`Send` field would silently break multi-threaded users. So this PR does **both**, the durable way:

1. **Compile-time guarantee.** A zero-cost `const _: fn() = …` assertion in the crate root pins `Graph: Send + Sync` and `GraphSnapshot: Send + Sync` for all feature states. Adding a future `Rc` / bare interior-mutable cell would fail the build *here* rather than downstream.

2. **Opt-in `shared` cargo feature** (OFF by default) → `shared::SharedGraph`: a cheaply-cloneable `Arc<RwLock<Graph>>` handle for axum/actix `State` with three access paths:
   - `.snapshot()` — a cheap immutable point-in-time `GraphSnapshot` queried **lock-free** for the request duration (the recommended read-heavy path; the write lock is held only for the O(overlay) snapshot clone). Built on the existing `Graph::snapshot` structural fork.
   - `.read()` / `.write()` — RAII `RwLock` guards for ad-hoc locked access.
   - Poison-tolerant: a failed `apply_delta` returns `Err` *before* any mmap/WAL write, so the lock is recovered (`PoisonError::into_inner`) rather than forcing every handler to special-case poisoning.

## Design decisions (STANDING RULE — proceeding without greenlight, flagged for the maintainer)

- **`RwLock` not `Mutex`** — the request workload is read-heavy; many readers proceed concurrently. The lock-free snapshot path is steered as the default in the docs.
- **`std::sync` only, no new dependency** — keeps `sparq-core` lean. The feature is OFF by default so the tracked wasm bundle / lean native build link nothing new.
- A short GitHub issue is being opened to let the maintainer steer the `SharedGraph` API surface (e.g. whether to also expose a `Mutex`-backed variant or an axum extractor) later.

## Architecture / leanness

New capability is **opt-in** behind the `shared` feature; default `sparq-core` / wasm builds are byte-unaffected (no new dep, no new default surface).

## Tests (real path, load-bearing invariants)

- `snapshot_is_consistent_under_concurrent_reads` — 8 threads snapshot + query concurrently.
- `snapshot_is_isolated_from_a_concurrent_write` — a snapshot taken before a real `apply_delta` still reads the OLD state; a fresh one reads the NEW state.
- `clones_share_one_underlying_graph` — mutation through one clone is visible through another.
- `shared_graph_is_send_and_sync` + `from_graph_builds_a_handle`.

## Gates (both feature states)

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — GREEN in **default (feature OFF)** AND with **`shared` ON** (feature flag: `sparq-core/shared`). Workspace `cargo clippy --workspace --all-targets --all-features -- -D warnings` green.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `check-readme-template.py --enforce` — 0 deviations (README 60 lines, ≤120).
- `typos` + `check-privacy-claims.sh` — clean.

## Docs

- `crates/sparq-core/README.md` — thread-safe-sharing feature bullet.
- `skills/sparql-query/SKILL.md` — `SharedGraph` recipe + the `Send + Sync` guarantee.

Closes #1121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>