### PR TITLE
feat(sparq-solid): public WAC-Allow header helper PodStore::wac_allow (sq-i7k08) [OPUS-4.8]

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -44,8 +44,8 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
 - **Triples-native + zero-copy enforcement** — pods, ACL/ACR docs, and the auth view are all ordinary
   named graphs ("who can read G?" is one SPARQL pattern); the default path evaluates through the engine's
   zero-copy dataset view, with a v1 `FROM NAMED` rewrite as a standard-SPARQL portability path.
-- **Write-path gating** — `update_as` / `update_as_acp` check every graph an update could mutate before
-  applying, and auto-re-materialize on `.acl`/`.acr` writes.
+- **Write-path gating + WAC-Allow** — `update_as` / `update_as_acp` check every graph an update could
+  mutate before applying; `wac_allow` builds the fail-closed `user="…",public="…"` header a server returns.
 - **ODRL bridge (opt-in `odrl-bridge`, research-track — not a production cutover)** — runs the
   [`sparq-policy`](../sparq-policy) ODRL evaluator and materializes the equivalent WAC/ACP grant (or dual
   `auth:deny*`) into the auth view — no new enforcement engine (zero ODRL code by default; see below).

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -357,6 +357,86 @@ impl PodStore {
         Arc::clone(&self.session_sets(s, mode).set)
     }
 
+    /// Build the value of a [`WAC-Allow`](https://solidproject.org/TR/wac#wac-allow)
+    /// response header for `resource` as seen by `session` — the RFC-style
+    /// `user="…",public="…"` permission advertisement a Solid server returns on a
+    /// `GET`/`HEAD`. [OPUS-4.8] sq-i7k08.
+    ///
+    /// `user` lists the modes the **authenticated** agent (`session`) holds on the
+    /// named graph backing `resource`; `public` lists the modes an **anonymous**
+    /// caller ([`Session::default`]) holds — so an unauthenticated request still learns
+    /// what the public can do. Each list is the space-separated lower-case mode names
+    /// (`read write append control`, in that fixed order), containing **only** the modes
+    /// actually granted, and empty (`user=""`) when none are. The four
+    /// [`PodStore::accessible`] sweeps share the per-session cache, so this is an O(1)
+    /// hash check per mode over the materialized index.
+    ///
+    /// **Fail-closed**, exactly like [`PodStore::accessible`]: before the first
+    /// `materialize_*` call, for a grant-less session, or for a `resource` outside the
+    /// session's accessible set, the corresponding list is empty — never a wider one.
+    ///
+    /// **Scope (honest):** `sparq-solid` is a *library-level* authoriser with **no HTTP
+    /// surface** — mapping a request **path to its named graph** (`resource`) and
+    /// authenticating the WebID into a `Session` are the **server's** job (see
+    /// `research/sparq-solid-scope.md` §4). This builds the header *value* from the
+    /// authorization verdict; it does not parse requests, discover ACLs, or set headers.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sparq_solid::{Mode, PodStore, Session};
+    /// use oxrdf::NamedNode;
+    ///
+    /// let nquads = r#"
+    /// <https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hello" <https://pod.ex/notes/n1> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#agent> <https://alice.ex/card#me> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Write> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#pub> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#pub> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#pub> <http://www.w3.org/ns/auth/acl#agentClass> <http://xmlns.com/foaf/0.1/Agent> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#pub> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/.acl> .
+    /// "#;
+    /// let mut store = PodStore::new(sparq_core::Graph::load_dataset(nquads, "nquads")?);
+    /// store.materialize_wac()?;
+    ///
+    /// let resource = NamedNode::new("https://pod.ex/notes/n1").map_err(|e| e.to_string())?;
+    /// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None, now: None };
+    /// // alice holds read+write; everyone (public) holds read.
+    /// assert_eq!(store.wac_allow(&alice, &resource), r#"user="read write",public="read""#);
+    /// // an anonymous request still learns the public modes (user == public here).
+    /// assert_eq!(store.wac_allow(&Session::default(), &resource), r#"user="read",public="read""#);
+    /// # Ok::<(), String>(())
+    /// ```
+    pub fn wac_allow(&mut self, session: &Session, resource: &NamedNode) -> String {
+        let user = self.modes_held(session, resource);
+        // The `public` field is what an anonymous caller (no WebID) holds — `acl:Read`
+        // granted to `foaf:Agent` etc. — independent of the authenticated session.
+        let public = self.modes_held(&Session::default(), resource);
+        format!(r#"user="{}",public="{}""#, user, public)
+    }
+
+    /// The space-separated WAC mode names `session` holds on `resource`'s graph, in the
+    /// fixed `read write append control` order — the per-field body of [`Self::wac_allow`].
+    /// Empty string when no mode is held (fail-closed). [OPUS-4.8] sq-i7k08.
+    fn modes_held(&mut self, session: &Session, resource: &NamedNode) -> String {
+        const MODES: [(Mode, &str); 4] = [
+            (Mode::Read, "read"),
+            (Mode::Write, "write"),
+            (Mode::Append, "append"),
+            (Mode::Control, "control"),
+        ];
+        let mut held = Vec::with_capacity(MODES.len());
+        for (mode, name) in MODES {
+            if self.accessible(session, mode).iter().any(|g| g == resource) {
+                held.push(name);
+            }
+        }
+        held.join(" ")
+    }
+
     fn session_sets(&mut self, s: &Session, mode: Mode) -> &SessionSets {
         let key = (
             s.agent.map(str::to_owned),

--- a/crates/sparq-solid/tests/wac.rs
+++ b/crates/sparq-solid/tests/wac.rs
@@ -1,6 +1,7 @@
 //! WAC correctness: hand-computed expected access for the fixture pod
 //! (crates/sparq-solid/src/fixture.rs — see the subtree semantics table there).
 
+use oxrdf::NamedNode;
 use sparq_core::Graph;
 use sparq_solid::{wac_fixture, Mode, PodStore, Session};
 
@@ -122,4 +123,45 @@ fn wac_write_enforcement_matches_grants() {
     assert!(can(&mut s, Some(ALICE), None, Mode::Write, acl)); // via Control->write
     assert!(!can(&mut s, Some(BOB), None, Mode::Write, acl));
     assert!(s.update_as(&Session { agent: Some(BOB), client: None, issuer: None, now: None }, &ins(acl)).is_err());
+}
+
+/// [OPUS-4.8] sq-i7k08 — the public `WAC-Allow` header builder ([`PodStore::wac_allow`])
+/// advertises exactly the modes each principal holds on the resource's graph, and is
+/// fail-closed. Exercises the REAL `accessible()` path (not a mock) and pins the
+/// `user="…",public="…"` format against the hand-computed fixture access matrix above.
+#[test]
+fn wac_allow_header_advertises_held_modes() {
+    let mut s = store();
+    let sess = |agent: Option<&'static str>| Session { agent, client: None, issuer: None, now: None };
+    let res = |g: &str| NamedNode::new(g).expect("valid IRI");
+
+    // 1. Private resource: ALICE owns Read+Write+Control via the root acl:default (matrix
+    //    #1); public holds nothing — so the public field is empty, never widened.
+    let priv0 = res("https://pod.ex/priv0/c4/g0/d0.ttl");
+    assert_eq!(s.wac_allow(&sess(Some(ALICE)), &priv0), r#"user="read write control",public="""#);
+    // 2. …and a non-owner (BOB) holds nothing on it — fully fail-closed (matrix #2).
+    assert_eq!(s.wac_allow(&sess(Some(BOB)), &priv0), r#"user="",public="""#);
+    assert_eq!(s.wac_allow(&Session::default(), &priv0), r#"user="",public="""#);
+
+    // 3. Public subtree (matrix #3): everyone — incl. an anonymous request — learns the
+    //    public Read grant; the owner additionally sees their own Write/Control.
+    let pub1 = res("https://pod.ex/pub1/c0/g0/d0.ttl");
+    assert_eq!(s.wac_allow(&sess(Some(ALICE)), &pub1), r#"user="read write control",public="read""#);
+    assert_eq!(s.wac_allow(&sess(Some(BOB)), &pub1), r#"user="read",public="read""#);
+    assert_eq!(s.wac_allow(&Session::default(), &pub1), r#"user="read",public="read""#);
+
+    // 4. Group resource with NEAREST-ACL shadowing (matrix #4/#5): the team group
+    //    (BOB, CAROL) holds Read+Write; ALICE is shadowed out → empty; public empty.
+    let team2 = res("https://pod.ex/team2/c3/g0/d0.ttl");
+    assert_eq!(s.wac_allow(&sess(Some(BOB)), &team2), r#"user="read write",public="""#);
+    assert_eq!(s.wac_allow(&sess(Some(CAROL)), &team2), r#"user="read write",public="""#);
+    assert_eq!(s.wac_allow(&sess(Some(ALICE)), &team2), r#"user="",public="""#);
+
+    // 5. A resource OUTSIDE every grant set → both fields empty (fail-closed).
+    let unknown = res("https://pod.ex/no/such/doc.ttl");
+    assert_eq!(s.wac_allow(&sess(Some(ALICE)), &unknown), r#"user="",public="""#);
+
+    // 6. Fail-closed before materialization: an un-materialized store grants nothing.
+    let mut bare = PodStore::new(Graph::load_dataset(&wac_fixture(), "nquads").expect("fixture loads"));
+    assert_eq!(bare.wac_allow(&sess(Some(ALICE)), &pub1), r#"user="",public="""#);
 }

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -119,6 +119,11 @@ Materialize the authorization view from the access-control documents, then enfor
   `store.accessible_set(...)` / `store.view_for(...) -> DatasetView` /
   `store.auth() -> &AuthIndex` — inspect the authorized graph set or the materialized
   index directly.
+- `store.wac_allow(&Session, &NamedNode) -> String` — build the public
+  [`WAC-Allow`](https://solidproject.org/TR/wac#wac-allow) response-header value
+  (`user="…",public="…"`) advertising the modes the session (and the public) hold on a
+  resource ([OPUS-4.8] sq-i7k08); fail-closed, only the modes actually held. See the
+  request-pipeline section below.
 - `store.materialize_odrl_permission(&Policy, &Request) -> BridgeOutcome` — **opt-in**
   (`odrl-bridge` feature, OFF by default; [OPUS-4.8] sq-h3uk): run the `sparq-policy` ODRL
   evaluator and, on a *definite Permit*, materialize the equivalent `principal auth:<mode>
@@ -190,10 +195,12 @@ loop. A Solid **request handler** wraps that with three steps: (1) build a `Sess
 from the authenticated request, (2) gate the request with `accessible(...)` /
 `query_as(...)`, (3) emit a [`WAC-Allow`](https://solidproject.org/TR/wac#wac-allow)
 response header advertising the modes the agent (and the public) hold on the target
-resource. There is **no public `WAC-Allow` helper in the crate yet** (tracked as a
-follow-up); it is a few lines over the existing `accessible` API, shown here so a
-server can drop it in. The header lists the modes available to `user` (the
-authenticated agent) and to `public` (an anonymous `Session::default()`):
+resource. Step (3) is the public helper
+[`PodStore::wac_allow(&Session, &NamedNode) -> String`](https://docs.rs/sparq-solid)
+([OPUS-4.8] sq-i7k08) — it builds the RFC-style `user="…",public="…"` value over the
+existing `accessible` API (the `user` list is the authenticated session's modes; the
+`public` list is an anonymous `Session::default()`'s), fail-closed and with only the
+modes actually held:
 
 ```rust
 use sparq_solid::{Mode, PodStore, Session};
@@ -209,29 +216,22 @@ fn may(store: &mut PodStore, s: &Session, mode: Mode, resource: &NamedNode) -> b
     store.accessible(s, mode).iter().any(|g| g == resource)
 }
 
-// RFC-style WAC-Allow: `user="read write",public="read"` — only the modes actually held.
-fn wac_allow(store: &mut PodStore, s: &Session, resource: &NamedNode) -> String {
-    let modes = [(Mode::Read, "read"), (Mode::Write, "write"),
-                 (Mode::Append, "append"), (Mode::Control, "control")];
-    let held = |sess: &Session| -> String {
-        modes.iter()
-            .filter(|(m, _)| may(store, sess, *m, resource))
-            .map(|(_, name)| *name).collect::<Vec<_>>().join(" ")
-    };
-    let anon = Session::default();
-    format!(r#"user="{}",public="{}""#, held(s), held(&anon))
+// Build the WAC-Allow header value for the request, e.g. `user="read write",public="read"`.
+fn wac_allow_header(store: &mut PodStore, s: &Session, resource: &NamedNode) -> String {
+    store.wac_allow(s, resource)
 }
 ```
 
 Per request: `session_from_request(...)` → `may(&mut store, &s, Mode::Read, &resource)`
 to allow/deny (a deny is `403`/`404` per your fail-closed policy) → set the response's
-`WAC-Allow` header to `wac_allow(&mut store, &s, &resource)`. `accessible` is an O(1)
-hash check over the materialized index (it caches per session), so the four-mode sweep
-is cheap. **Scope caveat:** sparq-solid is a *library-level* authoriser — there is no
-HTTP surface here (no `Link`/`acl:` resource discovery, no `.well-known`), so mapping a
-**request path to its named graph** (`resource`) and authenticating the WebID are the
-server's job (see `research/sparq-solid-scope.md` §4). The header builder above is
-illustrative, not a conformance-tested helper.
+`WAC-Allow` header to `store.wac_allow(&s, &resource)`. `wac_allow` runs four
+`accessible` sweeps that share the per-session cache (each an O(1) hash check over the
+materialized index), so it is cheap. **Scope caveat:** sparq-solid is a *library-level*
+authoriser — there is no HTTP surface here (no `Link`/`acl:` resource discovery, no
+`.well-known`), so mapping a **request path to its named graph** (`resource`) and
+authenticating the WebID are the server's job (see `research/sparq-solid-scope.md` §4).
+`wac_allow` builds the header *value* from the authorization verdict; it is not itself a
+conformance-tested HTTP layer.
 
 ## Capability notes (WAC + ACP)
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. @jeswr runs several agents on one account; this PR is from a sub-agent implementing bead **sq-i7k08**.

## What

Promotes the inline `WAC-Allow` header builder documented in the access-control SKILL into a small **public** helper on the always-present `accessible()` API:

```rust
PodStore::wac_allow(&Session, &NamedNode) -> String
```

It builds the RFC-style [`WAC-Allow`](https://solidproject.org/TR/wac#wac-allow) response-header value a Solid server returns:

- **`user`** = the modes the authenticated session holds on the resource's graph;
- **`public`** = the modes an anonymous `Session::default()` holds — so an unauthenticated request still learns the public modes;
- only the modes **actually held**, in the fixed `read write append control` order;
- **fail-closed**: empty before the first `materialize_*`, for a grant-less session, or for a resource outside the accessible set.

Four cached `accessible()` sweeps, one O(1) hash check per mode.

## Design note (best-judgment, standing rule — not blocked on greenlight)

This is a **zero-new-dependency additive method over an already-public API**, so it stays in the crate's always-present surface (next to `accessible()` / `query_as()`) rather than behind a cargo feature. The opt-in/feature-gate constraint exists to keep `sparq-core`/`sparq-engine` lean and free of heavy deps — both are **untouched** here, and the helper pulls in nothing. Gating a four-line string builder behind a feature would fragment the public API for no architectural benefit. Flagged for the maintainer to steer in a short issue (linked below).

`sparq-solid` stays a **library-level** authoriser: mapping a request **path → named graph** and authenticating the WebID into a `Session` remain the **server's** job (no HTTP surface here; `research/sparq-solid-scope.md` §4). `wac_allow` builds the header *value* from the authorization verdict only.

## Changes

- `crates/sparq-solid/src/lib.rs` — `wac_allow` + a private `modes_held` helper, with a worked doctest.
- `crates/sparq-solid/tests/wac.rs` — `wac_allow_header_advertises_held_modes` exercises the **real** `accessible()` path over the WAC fixture (authenticated / public / nearest-ACL-shadowed / outside-grant / un-materialized fail-closed cases).
- `skills/access-control/SKILL.md` — request-pipeline section + public-API list now point at the public helper.
- `crates/sparq-solid/README.md` — Features bullet mentions it (kept ≤120 lines).

## Gates (green in BOTH feature states)

Feature flags: default (OFF) and `--all-features` (`odrl-bridge`, `count-enforcement`, `trust-graph`). The helper is feature-independent.

- `cargo build -p sparq-solid` ✓
- `cargo clippy -p sparq-solid --all-targets -- -D warnings` ✓ (default) and `--all-features` ✓
- `cargo test -p sparq-solid` ✓ (default, 25 doc/unit) and `--all-features` ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` ✓
- `scripts/check-readme-template.py --enforce` → 0 deviations (README at the 120-line cap) ✓
- `scripts/check-privacy-claims.sh` ✓ · `typos` ✓ · no `DELETEd`/`DROPped`/`invokable`/`ANDed`

No hard-coded performance numbers; work-box timings are non-canonical and not baked in.

Closes sq-i7k08.

🤖 Generated with [Claude Code](https://claude.com/claude-code)