### PR TITLE
feat(sparq-trust): DID resolution + issuer-key binding (did:key/did:web) (sq-pfae.3) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3756,6 +3756,7 @@ version = "0.1.0"
 dependencies = [
  "oxrdf 0.3.3",
  "oxttl 0.2.3",
+ "serde_json",
  "sparq-canon",
  "sparq-core",
  "sparq-reason",

--- a/crates/sparq-solid/Cargo.toml
+++ b/crates/sparq-solid/Cargo.toml
@@ -70,6 +70,15 @@ count-enforcement = ["odrl-bridge", "sparq-policy/count-enforcement"]
 # SKILL for the honest scope.
 trust-graph = ["dep:sparq-trust"]
 
+# [OPUS-4.8] sq-pfae.3 (issue #940): forward `sparq-trust`'s OPT-IN `did` feature so a
+# sparq-solid integrator can bind a trust rule's issuer key from a `trust:issuerDid`
+# (`did:key` offline self-cert / pluggable `did:web`) via `sparq_trust::resolve_rule_keys`,
+# narrowing the operator-asserted-key forgery vector D′. Default-OFF and additive over
+# `trust-graph` — it adds only the resolver surface; no new runtime method. See the
+# `sparq-trust` `did` rustdoc for the honest scope (self-cert ≠ trust anchor; did:web is
+# only as strong as host/TLS control; no privacy).
+trust-graph-did = ["trust-graph", "sparq-trust/did"]
+
 # [OPUS-4.8] sq-pfae PoC: the trust-graph end-to-end test (tests/trust_graph.rs, fully
 # `#![cfg(feature = "trust-graph")]`) drives the admission gate through the real
 # PodStore. These are dev-only — they do not touch the default build or publish. Scoped

--- a/crates/sparq-trust/Cargo.toml
+++ b/crates/sparq-trust/Cargo.toml
@@ -27,6 +27,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 # property G6 of research/solid-trust-graph-authz-design.md §2.2). It depends only on
 # what the admission gate needs — RDFC-1.0 canon, the issuer-sig primitive, the SHACL
 # validator, the N3 reasoner, and the shipped sparq-solid materialiser.
+# DEFAULT-OFF features. The crate stays lean by default; `did` pulls the only extra
+# dependency (`serde_json`, used solely to parse a fetched `did:web` DID document) and
+# is OFF unless a caller explicitly opts in (sq-pfae.3). The `did:key`/`did:web` self-
+# certifying decode (multibase/multicodec/base58/varint) is dependency-free hand-rolled,
+# so the feature's whole cost is the JSON parser for the optional `did:web` path.
+[features]
+default = []
+# DID resolution + issuer-key binding (`did:key` offline self-cert + pluggable `did:web`).
+did = ["dep:serde_json"]
+
 [dependencies]
 sparq-core = { path = "../sparq-core", default-features = false }
 sparq-reason = { path = "../sparq-reason", default-features = false }
@@ -38,6 +48,9 @@ sparq-zk = { path = "../sparq-zk" }
 # The `forShape` statement-type primitive (forPredicate desugars to it; step 3).
 sparq-shacl = { path = "../sparq-shacl", default-features = false }
 oxrdf.workspace = true
+# OPTIONAL — `did` feature only. Parses a fetched `did:web` DID document (JSON). The
+# `did:key` path needs no JSON; the default build pulls neither.
+serde_json = { version = "1", optional = true }
 
 # Test-only: parse-validate the published machine-readable vocabulary
 # `ontologies/trust/trust.ttl` so the Turtle a working group reads stays valid

--- a/crates/sparq-trust/README.md
+++ b/crates/sparq-trust/README.md
@@ -45,39 +45,40 @@ let admitted = admit(cred, &rules, &session, &target);
 # }
 ```
 
-From `sparq-solid` (with `--features trust-graph`), `PodStore::admit_trust_credential_with_rule`
-runs the gate and installs the derived `auth:*` grants into `<urn:sparq:auth>` on top of the
-unchanged WAC/ACP view. See the `delegation` rustdoc for the invocation-binding path.
+From `sparq-solid` (`--features trust-graph`), `PodStore::admit_trust_credential_with_rule` runs the
+gate and installs the derived `auth:*` grants into `<urn:sparq:auth>` on top of the unchanged WAC/ACP
+view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae.3`).
 
 ## ✨ Features
 
-- **The 10-term minimal ontology** (`vocab`) — `trust:TrustPolicy`, `TrustRule`,
+- **The minimal `trust:` ontology** (`vocab`) — the 10-term core (`TrustPolicy`, `TrustRule`,
   `trustsSourceFor`, `source`, `forShape`, `Source`, `issuerKey`, `scope`, `freshWithin`,
-  `admitted`, plus the one `forPredicate → forShape` desugaring. Published as machine-readable
-  Turtle ([`ontologies/trust/trust.ttl`](ontologies/trust/trust.ttl), semantics in
-  [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md)); a sync test keeps it and the Rust constants
-  aligned. **All `trust:` IRIs are NON-STANDARD, invented for this proposal** — a WG would rehome them.
+  `admitted`) + `issuerDid` + the one `forPredicate → forShape` desugaring. Published as Turtle
+  ([`trust.ttl`](ontologies/trust/trust.ttl), semantics in [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md));
+  a sync test pins it to the Rust constants. **All `trust:` IRIs are NON-STANDARD** — a WG would rehome them.
 - **Fail-closed policy parsing** (`policy`) — a trust policy not presented through the
   Control-gated channel admits nothing (a type-level `ControlGate`).
 - **The admission gate** (`admit`) — canonicalise (`sparq-canon` RDFC-1.0), verify the **checked**
   issuer signature over the commitment (`sparq-zk`, never a self-asserted triple), enforce
   statement-type scoping via a real SHACL shape (`sparq-shacl`), freshness, and the clear-WebID
   holder binding. Default-deny, short-circuit.
-- **N3 merge** (`wire`) — feed the admitted facts into the shipped `sparq-reason` reasoner ahead
-  of the materialiser; the `.acr` ABAC rule derives the grant (the age>18 worked example runs
-  end-to-end — see the tests).
-- **Static / dynamic admission split** (`admit_static` + `derive_conditional_grants`, `sq-xc4y`)
-  — `admit_static` decides the **session-independent** class (signature, type-scope, scope) once
-  at materialise-time and defers the **per-request** class (holder + freshness) to an
+- **N3 merge** (`wire`) — feed the admitted facts into the shipped `sparq-reason` reasoner ahead of
+  the materialiser; the `.acr` ABAC rule derives the grant (the age>18 worked example runs end-to-end).
+- **Static / dynamic admission split** (`admit_static` + `derive_conditional_grants`, `sq-xc4y`) —
+  `admit_static` decides the **session-independent** class (signature, type-scope, scope) once at
+  materialise-time and defers the **per-request** class (holder + freshness) to an
   `auth:ConditionalGrant` re-checked per request (shipped sq-0q7n path) — never frozen into the view.
 - **The invocation-binding gate** (`delegation`, `sq-l5og`) — verify a carried ZCAP/UCAN-style
   delegation chain (each hop a CHECKED delegator signature over delegator/delegate **keys** +
   capability + expiry), enforce monotone attenuation (`child ⊆ parent`), and bind
   **authenticated invoker == the chain's terminal delegate, key-proven per request** via a
-  fresh-challenge proof-of-possession. Folding each hop's `delegate_key` into the signed preimage
-  is the load-bearing soundness step: it defeats the key-substitution stolen-chain replay an
-  adversarial review proved against an earlier revision (see *Honest scope* + rustdoc). The
-  delegation-replay forgery matrix (incl. key-substitution) runs end-to-end.
+  fresh-challenge PoP. Folding each hop's `delegate_key` into the signed preimage defeats the
+  key-substitution stolen-chain replay; the forgery matrix runs end-to-end.
+- **DID issuer-key binding** (`did`, **opt-in `did` feature**, `sq-pfae.3`) — a rule may name its
+  issuer by `trust:issuerDid` instead of `trust:issuerKey` hex. `DidKeyResolver` decodes a
+  self-certifying `did:key` offline; `DidWebResolver` reads the key from a `did:web` document via a
+  **pluggable** fetcher (no HTTP client on the default build); `resolve_rule_keys` feeds the resolved
+  key into the unchanged signature check. **Narrows** D′ (`did:key` self-cert; `did:web` host/TLS-rooted).
 
 ## Honest scope — what this does and does NOT do
 
@@ -89,31 +90,30 @@ unchanged WAC/ACP view. See the `delegation` rustdoc for the invocation-binding 
   silently "solved". Presentations stay linkable by requester identity. (Its materialise-time
   composition, `sq-xc4y`, is RESOLVED by the static/dynamic split; the *clear-WebID* privacy
   limitation is separate and remains.)
-- **Issuer keys are operator-asserted** — sparq has no DID resolver yet (`sq-pfae.3`), so the
-  `trust:issuerKey → verifying-key` binding is the live forgery vector D′ (§3.3), not an
-  end-to-end trust path.
+- **Issuer keys: operator-asserted by default; DID-bindable (opt-in, `sq-pfae.3`).** The default
+  `trust:issuerKey` hex binding is the live forgery vector D′ (§3.3); the `did` feature binds it from
+  a `trust:issuerDid` instead, which **narrows** D′ but is no absolute trust anchor (`did:key` is
+  self-cert; `did:web` only as strong as host/TLS).
 - **Delegation invocation is the clear-WebID, non-anonymous path too** (`sq-l5og`): the gate
   authenticates the invoker AS the terminal delegate's WebID in the clear — **not**
-  anonymous/unlinkable. The `delegate_key` binding defeats the key-substitution stolen-chain
-  replay, but **not** full non-replayability: the delegate key is only as trustworthy as the
-  operator-asserted delegator key that attests it (no DID resolver yet, `sq-pfae.3`, forgery
-  vector D′). Also open: deep-chain *incremental* revocation. Full reasoning in the rustdoc.
+  anonymous/unlinkable. The `delegate_key` binding defeats the key-substitution stolen-chain replay,
+  but **not** full non-replayability: the delegate key is only as trustworthy as the delegator key
+  that attests it (DID-bindable now via the `did` feature, `sq-pfae.3`; deep-chain *incremental*
+  revocation stays open). Full reasoning in the rustdoc.
 - **Open problems respected as documented limitations:** `sq-tu4e` (no in-reasoner NAF;
-  `revoked` is input-only) and `sq-wvne` (ZK privacy) are **out of PoC scope**. `sq-xc4y`
-  (per-request vs materialise-once) is RESOLVED by the static/dynamic split; `sq-l5og`
-  (delegation invocation-binding) is now **specified, enforced, and tested** (see *Features*).
+  `revoked` is input-only) and `sq-wvne` (ZK privacy) are **out of PoC scope**; `sq-xc4y` is
+  RESOLVED by the static/dynamic split; `sq-l5og` is **specified, enforced, and tested**.
 - **Strict additivity (G6):** with `sparq-solid`'s `trust-graph` feature OFF, the crate is not
   compiled and `sparq-solid` behaves exactly as WAC/ACP do today.
 
 ## 📚 Learn more
 
-- The machine-readable vocabulary [`ontologies/trust/trust.ttl`](ontologies/trust/trust.ttl)
-  and its [`ontologies/trust/SEMANTICS.md`](ontologies/trust/SEMANTICS.md) normative
-  two-stratum semantics note (the `sq-pfae.2` doc + vocab artifact).
+- The machine-readable vocabulary [`trust.ttl`](ontologies/trust/trust.ttl) and its
+  [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md) normative two-stratum semantics note (`sq-pfae.2`).
 - The design record `research/solid-trust-graph-authz-design.md` (§6.0 the PoC spec; §7 the
   honest limitations) — [issue #940](https://github.com/jeswr/sparq/issues/940).
-- The host crate: [`sparq-solid`](../sparq-solid/README.md) (the WAC/ACP substrate this extends).
-- `cargo doc -p sparq-trust` for the full module-level docs.
+- The host crate: [`sparq-solid`](../sparq-solid/README.md) (the WAC/ACP substrate this extends);
+  `cargo doc -p sparq-trust --all-features` for the full module-level docs (incl. the `did` module).
 
 ## License
 

--- a/crates/sparq-trust/ontologies/trust/SEMANTICS.md
+++ b/crates/sparq-trust/ontologies/trust/SEMANTICS.md
@@ -76,8 +76,9 @@ soundness of each conjunct is §3.3.)
 2. **The issuer signature is CHECKED, never self-asserted.** *G* is verified to be
    signed by the key `trust:issuerKey` names for *S′*, over *G*'s RDFC-1.0 commitment.
    A graph merely *claiming* `trust:issuerKey …` proves nothing. *(Caveat: the
-   `issuerKey → verifying-key` binding is operator-asserted until a DID resolver lands —
-   `sq-pfae.3`; this is the live forgery vector D′, design §3.3.)*
+   `issuerKey → verifying-key` binding is operator-asserted by default — the live forgery
+   vector D′, design §3.3. The opt-in `did` resolver (`sq-pfae.3`) binds it from a
+   `trust:issuerDid` instead, narrowing — not eliminating — D′.)*
 3. **Freshness and revocation pass.** The credential is within `trust:freshWithin` of
    `Session.now` and is not revoked. Both are **per-request side-conditions** —
    freshness is a Rust check (time is not a reasoner fact); a `not-revoked` guard, if
@@ -187,8 +188,9 @@ This note pins **semantics and additivity**, nothing about privacy. In particula
   (`age 25`, not "≥ 18"). This is **not** ZKAPs-grade unlinkable presentation.
 - **Holder binding is the clear-WebID, non-anonymous degraded path** (`sq-wvne` /
   `sq-xc4y`).
-- **Issuer keys are operator-asserted** until a DID resolver lands (`sq-pfae.3`) — the
-  live forgery vector D′.
+- **Issuer keys are operator-asserted by default** — the live forgery vector D′. The
+  opt-in `did` resolver (`sq-pfae.3`) binds the key from a `trust:issuerDid`
+  (`did:key`/`did:web`), narrowing — not eliminating — D′.
 - The ZK estate this design *could* compose with (`sparq-zk` / `sparq-zk-compose`) is
   research-grade and **externally unaudited** — external accredited-cryptographer
   sign-off is **pending** (`sq-qhy4`); `sparq-mpc` is honest-majority semi-honest only.

--- a/crates/sparq-trust/ontologies/trust/trust.ttl
+++ b/crates/sparq-trust/ontologies/trust/trust.ttl
@@ -93,7 +93,14 @@ trust:forShape a rdf:Property, owl:ObjectProperty ;
 
 trust:issuerKey a rdf:Property, owl:ObjectProperty ;
   rdfs:label "issuer key"@en ;
-  rdfs:comment "The cryptographic binding 'source S's verification key is K' — the load-bearing gate for signature verification at admission (§3.3 item 1). Aligns with zk:issuerKey on the existing sparq-zk estate. NB sparq has no DID resolver yet (sq-pfae.3): until then the binding is operator-asserted, the live forgery vector D' (§3.3)."@en ;
+  rdfs:comment "The cryptographic binding 'source S's verification key is K' — the load-bearing gate for signature verification at admission (§3.3 item 1). Aligns with zk:issuerKey on the existing sparq-zk estate. This OPERATOR-ASSERTED form is the live forgery vector D' (§3.3): the operator pastes the key directly. Prefer trust:issuerDid (sq-pfae.3) where a resolver can bind the key, which narrows D'."@en ;
+  rdfs:domain trust:Source ;
+  rdfs:range rdfs:Resource ;
+  rdfs:isDefinedBy trust: .
+
+trust:issuerDid a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "issuer DID"@en ;
+  rdfs:comment "The source's Decentralised Identifier (DID), resolved to its verifying key by a pluggable DID resolver (did:key offline self-cert / pluggable did:web). A rule may name its issuer by trust:issuerDid INSTEAD of the operator-asserted trust:issuerKey hex — the sq-pfae.3 issuer-key-binding term that narrows forgery vector D'. did:key is self-certifying (not a trust anchor); did:web is only as strong as host/TLS control. Resolution is opt-in (sparq-trust `did` cargo feature)."@en ;
   rdfs:domain trust:Source ;
   rdfs:range rdfs:Resource ;
   rdfs:isDefinedBy trust: .

--- a/crates/sparq-trust/src/admit.rs
+++ b/crates/sparq-trust/src/admit.rs
@@ -71,9 +71,10 @@
 //!
 //! This gate verifies a CHECKED issuer signature; it does **NOT** provide privacy,
 //! unlinkability, anonymity, or any cryptographic guarantee. The ZK estate it
-//! composes with is research-grade and **externally UNAUDITED** (`sq-qhy4`). The
-//! issuer key is operator-asserted (no DID resolver — `sq-pfae.3`), so the
-//! `issuerKey → verifying-key` binding is the live forgery vector D′ of §3.3.
+//! composes with is research-grade and **externally UNAUDITED** (`sq-qhy4`). The issuer
+//! key is operator-asserted by default (the `issuerKey → verifying-key` binding is the
+//! live forgery vector D′ of §3.3); the opt-in `did` feature (`sq-pfae.3`, the `did`
+//! module) can bind it from a `trust:issuerDid` instead, narrowing — not eliminating — D′.
 //!
 //! [OPUS-4.8] sq-pfae PoC (issue #940). 🤖 SPARQ agent — trust-graph authorisation PoC.
 

--- a/crates/sparq-trust/src/delegation.rs
+++ b/crates/sparq-trust/src/delegation.rs
@@ -155,7 +155,8 @@ pub struct DelegationHop {
     pub delegator: NamedNode,
     /// The delegator's verification key — the hop signature must verify under it. For
     /// the ROOT hop this is the trust-anchored root key (`anchor` step). Operator-/
-    /// chain-asserted (no DID resolver yet — `sq-pfae.3`, the live forgery vector D′).
+    /// chain-asserted by default (the live forgery vector D′); the root anchor is
+    /// DID-bindable via the opt-in `did` feature (`sq-pfae.3`), narrowing D′.
     pub delegator_key: PublicKey,
     /// The delegate's WebID/DID (the principal receiving authority on this hop). For
     /// the *next* hop this becomes the delegator; for the TERMINAL hop this must equal

--- a/crates/sparq-trust/src/did.rs
+++ b/crates/sparq-trust/src/did.rs
@@ -1,0 +1,648 @@
+//! # `did.rs` — pluggable DID resolution + issuer-key binding (`did:key` / `did:web`)
+//!
+//! Closes the **operator-asserted issuer-key** gap (`sq-pfae.3`, the live forgery
+//! vector D′ of the design's §3.3): until now a trust rule named its issuer's
+//! verifying key as raw `trust:issuerKey` hex supplied DIRECTLY by the pod operator,
+//! so a wrong/forged key in the policy graph silently admitted forged credentials.
+//! This module lets a rule instead name its issuer by **DID** (`trust:issuerDid`) and
+//! resolves that DID to the SAME [`PublicKey`] the admission gate's signature check
+//! already consumes ([`mod@crate::admit`]), via a **pluggable** [`DidResolver`].
+//!
+//! It is **OPT-IN**: the whole module sits behind the default-OFF `did` cargo feature,
+//! so the lean default `sparq-trust` build (and the byte-identical default `sparq-solid`
+//! build) gain nothing — strict additivity (design §2.2 G6) is preserved.
+//!
+//! ## Two methods, two trust models (be precise about which you get)
+//!
+//! - **`did:key`** ([`DidKeyResolver`]) — **self-certifying, offline, no network.** The
+//!   key material is encoded IN the DID identifier (multibase `z`-base58btc over a
+//!   multicodec-prefixed compressed point), so "resolving" is a local decode: the DID
+//!   *is* the key. There is no document to fetch and nothing to trust beyond the DID
+//!   string itself. What it buys over raw `trust:issuerKey` hex is a **stable,
+//!   round-trippable, method-tagged identifier** that the same string everywhere refers
+//!   to one key — NOT a stronger root of trust (whoever could put a forged hex key in the
+//!   policy could equally put a forged `did:key`).
+//! - **`did:web`** ([`DidWebResolver`]) — **document-fetched, network/host-rooted.** The
+//!   DID maps to an `https://` URL (per the W3C `did:web` method) serving a DID document;
+//!   the issuer key is read from that document's verification method. The root of trust is
+//!   **whoever controls the host + its TLS** — a genuine improvement over an operator
+//!   pasting hex, but only as strong as that host's control. The HTTP fetch is **not**
+//!   performed by this crate (keeping the default build dependency-light): the caller
+//!   supplies a [`DidDocumentFetcher`], so the resolver itself is offline-testable and the
+//!   crate forces no HTTP client onto anyone. Wiring a real fetcher is the integration
+//!   seam (see the module tests for an in-memory fetcher).
+//!
+//! ## Honest scope — what DID resolution does and does NOT fix (`sq-pfae.3`)
+//!
+//! Resolving the issuer key from a DID **narrows** forgery vector D′; it does not close
+//! it, and it adds **no** privacy:
+//!
+//! - **`did:key` is not a trust anchor.** It is self-certifying — it proves the DID and
+//!   the key agree, nothing about WHO holds the key. Trust still flows from whoever
+//!   authored the (Control-gated) policy that names the DID.
+//! - **`did:web` is only as strong as host/TLS control.** A host takeover or a
+//!   mis-issued certificate substitutes the issuer key. There is no key-history /
+//!   `did:web` deactivation handling here, and revocation stays the input-only
+//!   `sq-tu4e` guard.
+//! - **No privacy / unlinkability.** This binds an issuer key; it changes nothing about
+//!   the in-the-clear admission of the credential value (the verifier still learns
+//!   `age 25`, not "≥ 18"). The ZK estate remains research-grade and externally
+//!   **UNAUDITED** (`sq-qhy4`); `sparq-mpc` is honest-majority semi-honest only.
+//! - **Curve caveat — sparq's keys are Baby-JubJub, not Ed25519.** The shipped issuer
+//!   signature is Poseidon2-Schnorr over Baby-JubJub ([`sparq_zk::sig`]), so the standard
+//!   `did:key` Ed25519 multicodec (`0xed01`, the `z6Mk…` form) does **not** apply. This
+//!   module uses an explicit **sparq-private** multicodec ([`MULTICODEC_BABYJUBJUB_PUB`])
+//!   for the compressed Baby-JubJub point, and `did:web` documents must carry the sparq
+//!   cryptosuite key. A DID minted for a different curve fails closed. This is an honest
+//!   non-interop point with the wider `did:key` ecosystem, recorded so a working group can
+//!   register a real codec.
+//!
+//! [OPUS-4.8] sq-pfae.3 (issue #940 / gh-940). Written while Fable unavailable — flag for
+//! re-review when Fable returns. 🤖 SPARQ agent — trust-graph authorisation PoC.
+
+use sparq_zk::sig::{public_key_from_hex, public_key_to_hex, PublicKey};
+
+/// The multibase prefix for **base58btc** (`z`), the encoding `did:key` mandates for
+/// its multicodec-prefixed key material (W3C `did:key` method §3.1).
+pub const MULTIBASE_BASE58BTC: char = 'z';
+
+/// A **sparq-private** multicodec code for a compressed Baby-JubJub public key, as an
+/// unsigned-varint prefix on the 32-byte compressed point. The standard multicodec
+/// table has no Baby-JubJub entry (sparq's curve is non-standard for `did:key`), so this
+/// uses a value in the private-use space. It is documented as **non-interoperable**
+/// with the wider `did:key` ecosystem and is the explicit curve-tag a working group would
+/// replace with a registered code.
+pub const MULTICODEC_BABYJUBJUB_PUB: u64 = 0x30_0100;
+
+/// A parsed Decentralised Identifier: the method name and the method-specific id. Only
+/// the syntactic shape is parsed here; method semantics live in the resolvers. Parsing
+/// is fail-closed — a string that is not a syntactically valid `did:<method>:<id>`
+/// yields `None`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Did {
+    /// The DID method (e.g. `"key"`, `"web"`), lowercased per the spec's method-name rule.
+    pub method: String,
+    /// The method-specific identifier (everything after `did:<method>:`).
+    pub method_specific_id: String,
+}
+
+impl Did {
+    /// Parse a `did:<method>:<method-specific-id>` string. Fail-closed: returns `None`
+    /// for anything not matching the generic DID syntax (missing `did:` scheme, empty
+    /// method, empty id). The method name must be lowercase-or-digit (method names are
+    /// case-insensitive per the DID-Core ABNF; an uppercase method is rejected here).
+    pub fn parse(s: &str) -> Option<Did> {
+        let rest = s.strip_prefix("did:")?;
+        let (method, id) = rest.split_once(':')?;
+        if method.is_empty() || id.is_empty() {
+            return None;
+        }
+        // Method name is `1*method-char` of lowercase-or-digit; reject anything else so a
+        // malformed method can never reach a resolver.
+        if !method
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        {
+            return None;
+        }
+        Some(Did {
+            method: method.to_string(),
+            method_specific_id: id.to_string(),
+        })
+    }
+
+    /// Render the DID back to its canonical `did:<method>:<id>` string.
+    pub fn to_did_string(&self) -> String {
+        format!("did:{}:{}", self.method, self.method_specific_id)
+    }
+}
+
+/// Why a DID could not be resolved to an issuer key. Every variant is a **fail-closed**
+/// outcome: the admission gate admits nothing for a rule whose issuer DID does not
+/// resolve.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DidError {
+    /// The string was not a syntactically valid DID.
+    Malformed(String),
+    /// The DID method is not supported by this resolver (only `key` / `web` are).
+    UnsupportedMethod(String),
+    /// A `did:key` identifier did not decode to a valid sparq issuer key (bad multibase,
+    /// wrong multicodec, or not a valid compressed Baby-JubJub point).
+    BadKeyMaterial(String),
+    /// A `did:web` DID document could not be fetched (the fetcher returned an error).
+    FetchFailed(String),
+    /// A fetched `did:web` document had no usable sparq issuer verification method.
+    NoIssuerKey(String),
+}
+
+impl std::fmt::Display for DidError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            // Positional `format!` args (CodeQL rust/unused-variable false-positive avoidance).
+            DidError::Malformed(s) => write!(f, "malformed DID: {}", s),
+            DidError::UnsupportedMethod(m) => write!(f, "unsupported DID method: {}", m),
+            DidError::BadKeyMaterial(s) => write!(f, "did:key material did not decode: {}", s),
+            DidError::FetchFailed(s) => write!(f, "did:web document fetch failed: {}", s),
+            DidError::NoIssuerKey(s) => {
+                write!(f, "did:web document has no sparq issuer key: {}", s)
+            }
+        }
+    }
+}
+
+impl std::error::Error for DidError {}
+
+/// A pluggable DID resolver: map a DID to the issuer [`PublicKey`] the admission gate
+/// verifies signatures against. Implementations MUST be fail-closed (return
+/// `Err(DidError::…)` rather than a wrong key) so an unresolvable DID admits nothing.
+pub trait DidResolver {
+    /// Resolve a parsed DID to its issuer verifying key.
+    fn resolve(&self, did: &Did) -> Result<PublicKey, DidError>;
+
+    /// Convenience: parse `s` then [`resolve`](DidResolver::resolve). Returns
+    /// [`DidError::Malformed`] if `s` is not a syntactically valid DID.
+    fn resolve_str(&self, s: &str) -> Result<PublicKey, DidError> {
+        let did = Did::parse(s).ok_or_else(|| DidError::Malformed(s.to_string()))?;
+        self.resolve(&did)
+    }
+}
+
+// --- did:key (offline, self-certifying) -----------------------------------
+
+/// The offline `did:key` resolver: decode the multibase/multicodec key material in the
+/// DID identifier to a [`PublicKey`]. No network, no document — the DID *is* the key.
+///
+/// Only the sparq Baby-JubJub multicodec ([`MULTICODEC_BABYJUBJUB_PUB`]) is accepted;
+/// any other codec (e.g. the standard Ed25519 `z6Mk…`) fails closed with
+/// [`DidError::BadKeyMaterial`], because sparq's issuer signature is Baby-JubJub.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct DidKeyResolver;
+
+impl DidResolver for DidKeyResolver {
+    fn resolve(&self, did: &Did) -> Result<PublicKey, DidError> {
+        if did.method != "key" {
+            return Err(DidError::UnsupportedMethod(did.method.clone()));
+        }
+        decode_did_key_id(&did.method_specific_id)
+    }
+}
+
+/// Mint the canonical `did:key` string for a sparq issuer [`PublicKey`]: multibase
+/// (`z`-base58btc) over the multicodec-prefixed compressed Baby-JubJub point. Round-trips
+/// with [`DidKeyResolver`]: `resolve(parse(did_key_for(pk))) == pk`.
+pub fn did_key_for(pk: &PublicKey) -> String {
+    // Compressed point bytes (the same 32-byte image `public_key_to_hex` encodes).
+    let point = from_hex(&public_key_to_hex(pk)).expect("hex from public_key_to_hex is valid");
+    let mut payload = encode_varint(MULTICODEC_BABYJUBJUB_PUB);
+    payload.extend_from_slice(&point);
+    let mb = base58btc_encode(&payload);
+    format!("did:key:{}{}", MULTIBASE_BASE58BTC, mb)
+}
+
+/// Decode a `did:key` method-specific id to a [`PublicKey`]. Fail-closed on a wrong
+/// multibase prefix, bad base58, the wrong multicodec, or a non-Baby-JubJub point.
+fn decode_did_key_id(id: &str) -> Result<PublicKey, DidError> {
+    let prefix = id
+        .chars()
+        .next()
+        .ok_or_else(|| DidError::BadKeyMaterial("empty did:key id".to_string()))?;
+    if prefix != MULTIBASE_BASE58BTC {
+        return Err(DidError::BadKeyMaterial(format!(
+            "unsupported multibase prefix `{}` (only `z`-base58btc)",
+            prefix
+        )));
+    }
+    let b58 = &id[prefix.len_utf8()..];
+    let payload = base58btc_decode(b58)
+        .ok_or_else(|| DidError::BadKeyMaterial(format!("bad base58: {}", id)))?;
+    let (codec, rest) = decode_varint(&payload)
+        .ok_or_else(|| DidError::BadKeyMaterial("truncated multicodec varint".to_string()))?;
+    if codec != MULTICODEC_BABYJUBJUB_PUB {
+        return Err(DidError::BadKeyMaterial(format!(
+            "unsupported multicodec 0x{:x} (sparq uses Baby-JubJub 0x{:x})",
+            codec, MULTICODEC_BABYJUBJUB_PUB
+        )));
+    }
+    // The compressed point is the remaining bytes; `public_key_from_hex` re-checks it is
+    // a valid (non-identity) Baby-JubJub point and fails closed otherwise.
+    let hex = to_hex(rest);
+    public_key_from_hex(&hex)
+        .ok_or_else(|| DidError::BadKeyMaterial(format!("not a valid Baby-JubJub point: {}", id)))
+}
+
+// --- did:web (document-fetched, pluggable fetcher) ------------------------
+
+/// A pluggable fetcher for a `did:web` DID document. The resolver hands it the resolved
+/// `https://…/did.json` URL; the implementation returns the document bytes (UTF-8 JSON)
+/// or an error. This is the **network seam** — the crate ships no HTTP client of its own,
+/// so the default build forces no `reqwest`/`ureq` onto anyone, and the resolver stays
+/// offline-testable (an in-memory map is a perfectly valid fetcher for tests / a
+/// pre-cached registry).
+pub trait DidDocumentFetcher {
+    /// Fetch the DID document at `url` (always an `https://` URL ending in `did.json`).
+    /// Return the raw UTF-8 JSON, or a human-readable error string (mapped to
+    /// [`DidError::FetchFailed`]).
+    fn fetch(&self, url: &str) -> Result<String, String>;
+}
+
+/// The `did:web` resolver over a pluggable [`DidDocumentFetcher`]. Maps the DID to its
+/// `https://` document URL (W3C `did:web` §3.2), fetches it, and extracts the sparq
+/// issuer key from the document's verification method.
+pub struct DidWebResolver<F: DidDocumentFetcher> {
+    fetcher: F,
+}
+
+impl<F: DidDocumentFetcher> DidWebResolver<F> {
+    /// Build a `did:web` resolver over the given fetcher.
+    pub fn new(fetcher: F) -> Self {
+        DidWebResolver { fetcher }
+    }
+
+    /// Map a `did:web` method-specific id to its document URL per the method spec:
+    /// the authority (with an optional `%3A`-encoded port) and `:`-separated path
+    /// segments become a `/`-separated path. A bare-host DID (`did:web:example.com`)
+    /// resolves to `https://example.com/.well-known/did.json`; a pathful DID
+    /// (`did:web:example.com:user:alice`) resolves to
+    /// `https://example.com/user/alice/did.json`. Returns `None` for an empty/invalid id.
+    pub fn document_url(id: &str) -> Option<String> {
+        if id.is_empty() {
+            return None;
+        }
+        let mut parts = id.split(':');
+        let authority = parts.next()?;
+        if authority.is_empty() {
+            return None;
+        }
+        // `%3A` in the authority is a port separator per the spec.
+        let authority = authority.replace("%3A", ":");
+        let path_segments: Vec<&str> = parts.collect();
+        if path_segments.iter().any(|s| s.is_empty()) {
+            return None; // a `::` empty path segment is malformed
+        }
+        if path_segments.is_empty() {
+            Some(format!("https://{}/.well-known/did.json", authority))
+        } else {
+            Some(format!(
+                "https://{}/{}/did.json",
+                authority,
+                path_segments.join("/")
+            ))
+        }
+    }
+}
+
+impl<F: DidDocumentFetcher> DidResolver for DidWebResolver<F> {
+    fn resolve(&self, did: &Did) -> Result<PublicKey, DidError> {
+        if did.method != "web" {
+            return Err(DidError::UnsupportedMethod(did.method.clone()));
+        }
+        let url = Self::document_url(&did.method_specific_id)
+            .ok_or_else(|| DidError::Malformed(did.to_did_string()))?;
+        let doc = self.fetcher.fetch(&url).map_err(DidError::FetchFailed)?;
+        extract_issuer_key_from_doc(&doc, &did.to_did_string())
+    }
+}
+
+/// Extract the sparq issuer [`PublicKey`] from a `did:web` DID document (JSON).
+///
+/// The document must carry a verification method whose `publicKeyMultibase` is the SAME
+/// multibase/multicodec encoding `did:key` uses (so a `did:web` document and a `did:key`
+/// agree on the curve tag), OR a `publicKeyHex` carrying the raw compressed point hex.
+/// The first verification method that decodes to a valid sparq key wins; if none do, this
+/// fails closed with [`DidError::NoIssuerKey`].
+fn extract_issuer_key_from_doc(doc: &str, did: &str) -> Result<PublicKey, DidError> {
+    let value: serde_json::Value =
+        serde_json::from_str(doc).map_err(|e| DidError::NoIssuerKey(format!("{}: {}", did, e)))?;
+    let methods = collect_verification_methods(&value);
+    for m in methods {
+        // `publicKeyMultibase` (preferred — same encoding as did:key).
+        if let Some(mb) = m.get("publicKeyMultibase").and_then(|v| v.as_str()) {
+            if let Ok(pk) = decode_did_key_id(mb) {
+                return Ok(pk);
+            }
+        }
+        // `publicKeyHex` (raw compressed Baby-JubJub point hex — sparq-zk's native form).
+        if let Some(hex) = m.get("publicKeyHex").and_then(|v| v.as_str()) {
+            if let Some(pk) = public_key_from_hex(hex) {
+                return Ok(pk);
+            }
+        }
+    }
+    Err(DidError::NoIssuerKey(did.to_string()))
+}
+
+/// Collect candidate verification-method JSON objects from a DID document: the
+/// embedded objects under `verificationMethod` plus any embedded under `assertionMethod`.
+/// (A production resolver would also honour bare relationship references; the PoC scans
+/// the embedded methods, which is sufficient for the issuer-key binding.)
+fn collect_verification_methods(doc: &serde_json::Value) -> Vec<&serde_json::Value> {
+    let mut out = Vec::new();
+    for key in ["verificationMethod", "assertionMethod"] {
+        if let Some(arr) = doc.get(key).and_then(|v| v.as_array()) {
+            for m in arr {
+                if m.is_object() {
+                    out.push(m);
+                }
+            }
+        }
+    }
+    out
+}
+
+// --- minimal multibase / multicodec / hex (no extra deps — lean-core rule) -----
+
+/// The base58btc alphabet (Bitcoin/IPFS ordering), as used by multibase `z`.
+const B58_ALPHABET: &[u8; 58] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+/// Encode bytes as base58btc (no multibase prefix). Big-endian, leading-zero preserving.
+fn base58btc_encode(input: &[u8]) -> String {
+    // Count leading zero bytes (each → a leading '1').
+    let zeros = input.iter().take_while(|&&b| b == 0).count();
+    let mut digits: Vec<u8> = Vec::new();
+    for &byte in input {
+        let mut carry = byte as u32;
+        for d in digits.iter_mut() {
+            carry += (*d as u32) << 8;
+            *d = (carry % 58) as u8;
+            carry /= 58;
+        }
+        while carry > 0 {
+            digits.push((carry % 58) as u8);
+            carry /= 58;
+        }
+    }
+    let mut out = String::with_capacity(zeros + digits.len());
+    for _ in 0..zeros {
+        out.push('1');
+    }
+    for &d in digits.iter().rev() {
+        out.push(B58_ALPHABET[d as usize] as char);
+    }
+    if out.is_empty() {
+        out.push('1');
+    }
+    out
+}
+
+/// Decode a base58btc string (no multibase prefix). `None` on any non-alphabet char.
+fn base58btc_decode(input: &str) -> Option<Vec<u8>> {
+    if input.is_empty() {
+        return None;
+    }
+    let mut bytes: Vec<u8> = Vec::new();
+    for ch in input.chars() {
+        let val = B58_ALPHABET.iter().position(|&c| c as char == ch)? as u32;
+        let mut carry = val;
+        for b in bytes.iter_mut() {
+            carry += (*b as u32) * 58;
+            *b = (carry & 0xff) as u8;
+            carry >>= 8;
+        }
+        while carry > 0 {
+            bytes.push((carry & 0xff) as u8);
+            carry >>= 8;
+        }
+    }
+    // Restore leading zero bytes (each leading '1' → a 0x00).
+    let zeros = input.chars().take_while(|&c| c == '1').count();
+    bytes.extend(std::iter::repeat_n(0u8, zeros));
+    bytes.reverse();
+    Some(bytes)
+}
+
+/// Encode an unsigned-LEB128 varint (the multicodec encoding).
+fn encode_varint(mut v: u64) -> Vec<u8> {
+    let mut out = Vec::new();
+    loop {
+        let mut byte = (v & 0x7f) as u8;
+        v >>= 7;
+        if v != 0 {
+            byte |= 0x80;
+        }
+        out.push(byte);
+        if v == 0 {
+            break;
+        }
+    }
+    out
+}
+
+/// Decode an unsigned-LEB128 varint from the front of `bytes`; returns `(value, rest)`.
+/// `None` on a truncated or over-long (> 64-bit) varint (fail-closed).
+fn decode_varint(bytes: &[u8]) -> Option<(u64, &[u8])> {
+    let mut value: u64 = 0;
+    let mut shift = 0u32;
+    for (i, &b) in bytes.iter().enumerate() {
+        if shift >= 64 {
+            return None; // over-long
+        }
+        value |= ((b & 0x7f) as u64) << shift;
+        if b & 0x80 == 0 {
+            return Some((value, &bytes[i + 1..]));
+        }
+        shift += 7;
+    }
+    None // truncated
+}
+
+/// Lowercase-hex encode.
+fn to_hex(bytes: &[u8]) -> String {
+    let mut s = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        // Positional args (CodeQL rust/unused-variable false-positive avoidance).
+        s.push_str(&format!("{:02x}", b));
+    }
+    s
+}
+
+/// Decode lowercase/uppercase hex (optional `0x`), `None` on odd length / bad nibble.
+fn from_hex(s: &str) -> Option<Vec<u8>> {
+    let s = s.strip_prefix("0x").unwrap_or(s);
+    if !s.len().is_multiple_of(2) {
+        return None;
+    }
+    let mut out = Vec::with_capacity(s.len() / 2);
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let hi = (bytes[i] as char).to_digit(16)?;
+        let lo = (bytes[i + 1] as char).to_digit(16)?;
+        out.push((hi * 16 + lo) as u8);
+        i += 2;
+    }
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sparq_zk::sig::SecretKey;
+
+    fn test_pk() -> PublicKey {
+        // A deterministic non-identity issuer key for the round-trip tests.
+        SecretKey::from_seed(0x1234_5678_9abc_def0).public_key()
+    }
+
+    #[test]
+    fn did_parse_round_trips() {
+        let d = Did::parse("did:key:zABC").unwrap();
+        assert_eq!(d.method, "key");
+        assert_eq!(d.method_specific_id, "zABC");
+        assert_eq!(d.to_did_string(), "did:key:zABC");
+        // Fail-closed shapes.
+        assert!(Did::parse("did:key:").is_none());
+        assert!(Did::parse("did::id").is_none());
+        assert!(Did::parse("notadid").is_none());
+        assert!(Did::parse("did:KEY:x").is_none()); // uppercase method rejected
+    }
+
+    #[test]
+    fn base58_round_trips() {
+        let cases: Vec<Vec<u8>> = vec![
+            vec![0u8],
+            vec![0, 0, 1, 2, 3],
+            vec![255, 254, 0, 7],
+            (0u8..40).collect(),
+        ];
+        for v in cases {
+            let enc = base58btc_encode(&v);
+            let dec = base58btc_decode(&enc).unwrap();
+            assert_eq!(dec, v, "base58 round-trip for {:?}", v);
+        }
+        assert!(base58btc_decode("0OIl").is_none()); // chars not in the alphabet
+    }
+
+    #[test]
+    fn varint_round_trips() {
+        for v in [0u64, 1, 127, 128, 300, MULTICODEC_BABYJUBJUB_PUB, u64::MAX] {
+            let enc = encode_varint(v);
+            let (dec, rest) = decode_varint(&enc).unwrap();
+            assert_eq!(dec, v);
+            assert!(rest.is_empty());
+        }
+        assert!(decode_varint(&[0x80]).is_none()); // truncated
+    }
+
+    #[test]
+    fn did_key_round_trips_to_the_same_public_key() {
+        let pk = test_pk();
+        let did_str = did_key_for(&pk);
+        assert!(did_str.starts_with("did:key:z"));
+        let resolver = DidKeyResolver;
+        let resolved = resolver.resolve_str(&did_str).unwrap();
+        assert_eq!(resolved, pk, "did:key resolves to the SAME issuer key");
+    }
+
+    #[test]
+    fn did_key_fails_closed_on_wrong_method_and_bad_material() {
+        let resolver = DidKeyResolver;
+        // Wrong method.
+        let web = Did::parse("did:web:example.com").unwrap();
+        assert!(matches!(
+            resolver.resolve(&web),
+            Err(DidError::UnsupportedMethod(_))
+        ));
+        // Bad multibase prefix.
+        assert!(matches!(
+            resolver.resolve_str("did:key:QABC"),
+            Err(DidError::BadKeyMaterial(_))
+        ));
+        // A valid base58 string but the wrong multicodec (Ed25519 0xed01 → not sparq).
+        let mut payload = encode_varint(0xed01);
+        payload.extend_from_slice(&[0u8; 32]);
+        let wrong = format!("did:key:z{}", base58btc_encode(&payload));
+        assert!(matches!(
+            resolver.resolve_str(&wrong),
+            Err(DidError::BadKeyMaterial(_))
+        ));
+    }
+
+    #[test]
+    fn did_web_document_url_mapping() {
+        type R = DidWebResolver<NullFetcher>;
+        assert_eq!(
+            R::document_url("example.com"),
+            Some("https://example.com/.well-known/did.json".to_string())
+        );
+        assert_eq!(
+            R::document_url("example.com:user:alice"),
+            Some("https://example.com/user/alice/did.json".to_string())
+        );
+        assert_eq!(
+            R::document_url("example.com%3A3000:u"),
+            Some("https://example.com:3000/u/did.json".to_string())
+        );
+        assert_eq!(R::document_url(""), None);
+        assert_eq!(R::document_url("example.com::x"), None); // empty segment
+    }
+
+    /// A fetcher that always errors (for the URL-mapping type alias only).
+    struct NullFetcher;
+    impl DidDocumentFetcher for NullFetcher {
+        fn fetch(&self, _url: &str) -> Result<String, String> {
+            Err("null".to_string())
+        }
+    }
+
+    #[cfg(feature = "did")]
+    #[test]
+    fn did_web_resolves_from_an_in_memory_document() {
+        use std::collections::HashMap;
+
+        let pk = test_pk();
+        // Same multibase/multicodec encoding as did:key (strip the `did:key:` head).
+        let mb = did_key_for(&pk)
+            .strip_prefix("did:key:")
+            .unwrap()
+            .to_string();
+        let did = "did:web:issuer.example:gov";
+        let url = DidWebResolver::<MapFetcher>::document_url("issuer.example:gov").unwrap();
+        let doc = format!(
+            r#"{{
+              "id": "{did}",
+              "verificationMethod": [
+                {{ "id": "{did}#k1", "type": "Multikey", "publicKeyMultibase": "{mb}" }}
+              ],
+              "assertionMethod": ["{did}#k1"]
+            }}"#
+        );
+        let mut map = HashMap::new();
+        map.insert(url, doc);
+        let resolver = DidWebResolver::new(MapFetcher(map));
+        let resolved = resolver.resolve_str(did).unwrap();
+        assert_eq!(resolved, pk, "did:web resolves the document's issuer key");
+    }
+
+    #[cfg(feature = "did")]
+    #[test]
+    fn did_web_fails_closed_on_missing_or_keyless_document() {
+        use std::collections::HashMap;
+        // Empty registry → fetch fails → FetchFailed.
+        let resolver = DidWebResolver::new(MapFetcher(HashMap::new()));
+        assert!(matches!(
+            resolver.resolve_str("did:web:issuer.example"),
+            Err(DidError::FetchFailed(_))
+        ));
+        // Present but keyless document → NoIssuerKey.
+        let url = DidWebResolver::<MapFetcher>::document_url("issuer.example").unwrap();
+        let mut map = HashMap::new();
+        map.insert(url, r#"{"id":"did:web:issuer.example"}"#.to_string());
+        let resolver = DidWebResolver::new(MapFetcher(map));
+        assert!(matches!(
+            resolver.resolve_str("did:web:issuer.example"),
+            Err(DidError::NoIssuerKey(_))
+        ));
+    }
+
+    #[cfg(feature = "did")]
+    struct MapFetcher(std::collections::HashMap<String, String>);
+    #[cfg(feature = "did")]
+    impl DidDocumentFetcher for MapFetcher {
+        fn fetch(&self, url: &str) -> Result<String, String> {
+            self.0
+                .get(url)
+                .cloned()
+                .ok_or_else(|| format!("no document at {}", url))
+        }
+    }
+}

--- a/crates/sparq-trust/src/lib.rs
+++ b/crates/sparq-trust/src/lib.rs
@@ -41,6 +41,12 @@
 //! - [`wire`] — feed admitted facts into the N3 reasoner ahead of the materialiser;
 //!   read off the derived `auth:*` grants ([`wire::derive_grants`]) OR the per-grant
 //!   DYNAMIC conditions for a conditional grant ([`wire::derive_conditional_grants`]).
+//! - `did` (OPT-IN, default-OFF `did` feature) — pluggable DID resolution
+//!   (`did:key` offline self-cert + a pluggable `did:web` fetcher) that binds a
+//!   `trust:issuerDid` to the issuer verifying key the gate already checks, narrowing
+//!   the operator-asserted-key forgery vector D′ (`sq-pfae.3`). A plain code-span here
+//!   (not an intra-doc link) so the default-feature doc build does not reference a
+//!   feature-gated item.
 //!
 //! ## Opt-in by construction (strict additivity — design §2.2 G6)
 //!
@@ -72,10 +78,13 @@
 //!   by requester identity. A ZKAPs-equivalent presentation would have to REPLACE
 //!   clear-WebID holder binding with an in-ZK holder-PoP plus a nullifier — an
 //!   architecture change, not a composition step.
-//! - **Issuer keys are operator-asserted.** sparq has no DID resolver yet
-//!   (`sq-pfae.3`), so the `trust:issuerKey → verifying-key` binding is supplied
-//!   directly rather than resolver-verified — the live forgery vector D′ (§3.3). This
-//!   is honest, but **not** an end-to-end trust path.
+//! - **Issuer keys are operator-asserted by default; DID-bindable opt-in (`sq-pfae.3`).**
+//!   The default `trust:issuerKey → verifying-key` binding is supplied directly — the live
+//!   forgery vector D′ (§3.3). The **opt-in `did` feature** lets a rule bind its key from a
+//!   `trust:issuerDid` instead (the `did` module: `did:key` offline self-cert + a pluggable
+//!   `did:web` fetcher), which **narrows** D′ but is no absolute anchor (`did:key` is
+//!   self-certifying; `did:web` only as strong as host/TLS) — still not a fully end-to-end
+//!   trust path.
 //!
 //! ## Open problems this PoC RESPECTS as documented limitations (never silently solved)
 //!
@@ -98,7 +107,8 @@
 //!   and intersects against the **current** delegator grant (never a delegation-time
 //!   snapshot). What stays open and is documented, not silently solved: deep-chain
 //!   *incremental* revocation (full re-materialisation only — the §4.4 stale-authority
-//!   window is bounded, not closed) and DID-resolver key binding (`sq-pfae.3`).
+//!   window is bounded, not closed). DID-resolver key binding (`sq-pfae.3`) is now
+//!   addressed by the opt-in `did` module (narrows, does not eliminate, forgery vector D′).
 //! - **`sq-tu4e`** — no in-reasoner NAF over derived facts: `revoked` is an
 //!   **input-only** per-request guard; there is **no deny-on-disagreement** rule.
 //! - **`sq-wvne`** — ZKAPs-grade unlinkable presentation needs a 3-part ZK composite:
@@ -112,6 +122,9 @@
 
 pub mod admit;
 pub mod delegation;
+#[cfg(feature = "did")]
+#[cfg_attr(docsrs, doc(cfg(feature = "did")))]
+pub mod did;
 pub mod policy;
 pub mod vocab;
 pub mod wire;
@@ -123,5 +136,11 @@ pub use delegation::{
     effective_against_current, hop_message, invoke, Capability, DelegationChain, DelegationHop,
     EffectiveCapability, Invocation, InvocationDenied,
 };
+#[cfg(feature = "did")]
+pub use did::{
+    did_key_for, Did, DidDocumentFetcher, DidError, DidKeyResolver, DidResolver, DidWebResolver,
+};
 pub use policy::{parse_policy, ControlGate, PolicyError, ShapeRef, TrustRule};
+#[cfg(feature = "did")]
+pub use policy::{resolve_rule_keys, IssuerBinding};
 pub use wire::{derive_conditional_grants, derive_grants, ConditionalGrant};

--- a/crates/sparq-trust/src/policy.rs
+++ b/crates/sparq-trust/src/policy.rs
@@ -55,9 +55,13 @@ impl ControlGate {
 pub struct TrustRule {
     /// `trust:source` — the named attesting authority IRI.
     pub source: NamedNode,
-    /// `trust:issuerKey` — the verification key the source signs with (parsed from
-    /// the `zk:`-aligned hex key material; v1 supplies the key DIRECTLY because there
-    /// is no DID resolver yet — P2 / `sq-pfae.3`, the live forgery vector D′ of §3.3).
+    /// The verification key the source signs with. Bound either from operator-asserted
+    /// `trust:issuerKey` hex (the default [`parse_policy`] path — the live forgery vector
+    /// D′ of §3.3) OR from a `trust:issuerDid` resolved by a `did::DidResolver` via
+    /// `resolve_rule_keys` (the opt-in `did` feature, `sq-pfae.3` — narrows D′; plain
+    /// code-spans, not intra-doc links, so the default-feature doc build does not reference
+    /// feature-gated items). The admission gate consumes this concrete key identically
+    /// regardless of how it was bound.
     pub issuer_key: PublicKey,
     /// `trust:forShape` — the statement-type SHACL node-shape (a `forPredicate P`
     /// rule is desugared into this at load; see [`crate::vocab::desugar_for_predicate`]).
@@ -94,6 +98,10 @@ pub enum PolicyError {
     IncompleteRule { rule: String, missing: &'static str },
     /// The `trust:issuerKey` literal/IRI did not parse as a verification key.
     BadIssuerKey(String),
+    /// The `trust:issuerDid` (or its resolved key) failed to resolve (`sq-pfae.3`). Carries
+    /// the DID and the resolver's reason. Fail-closed: a rule whose DID does not resolve
+    /// admits nothing.
+    BadIssuerDid { did: String, reason: String },
     /// The `trust:freshWithin` literal was not a parseable `xsd:duration`.
     BadDuration(String),
 }
@@ -109,6 +117,9 @@ impl std::fmt::Display for PolicyError {
                 write!(f, "trust rule <{}> is missing {}", rule, missing)
             }
             PolicyError::BadIssuerKey(k) => write!(f, "trust:issuerKey did not parse: {}", k),
+            PolicyError::BadIssuerDid { did, reason } => {
+                write!(f, "trust:issuerDid <{}> did not resolve: {}", did, reason)
+            }
             PolicyError::BadDuration(d) => {
                 write!(f, "trust:freshWithin is not xsd:duration: {}", d)
             }
@@ -128,7 +139,7 @@ impl std::error::Error for PolicyError {}
 /// hard [`PolicyError::IncompleteRule`] — a partially-specified rule never silently
 /// admits.
 pub fn parse_policy(policy: &[Triple], _gate: ControlGate) -> Result<Vec<TrustRule>, PolicyError> {
-    parse_rules(policy)
+    parse_rules(policy, &operator_asserted_key)
 }
 
 /// The fail-closed analogue used in tests: parse WITHOUT a [`ControlGate`]. Always
@@ -138,7 +149,83 @@ pub fn try_parse_ungated(_policy: &[Triple]) -> Result<Vec<TrustRule>, PolicyErr
     Err(PolicyError::NotControlGated)
 }
 
-fn parse_rules(policy: &[Triple]) -> Result<Vec<TrustRule>, PolicyError> {
+/// Resolve a rule node's issuer key. A strategy fn so the operator-asserted-hex path
+/// ([`parse_policy`]) and the DID-resolving path ([`resolve_rule_keys`]) share ALL other
+/// per-rule parsing (scope / freshness / shape) — only the key binding differs.
+type KeyResolver<'a> = dyn Fn(&Term, &[Triple]) -> Result<PublicKey, PolicyError> + 'a;
+
+/// The operator-asserted key binding (today's behaviour): the rule's `trust:issuerKey`
+/// hex is parsed directly. This is the live forgery vector D′ — the operator pastes the
+/// key — kept as the default so the lean build needs no DID resolver.
+fn operator_asserted_key(node: &Term, policy: &[Triple]) -> Result<PublicKey, PolicyError> {
+    let key_term =
+        object_of(node, vocab::ISSUER_KEY, policy).ok_or_else(|| PolicyError::IncompleteRule {
+            rule: node_label(node),
+            missing: "trust:issuerKey",
+        })?;
+    let key_hex = term_lexical(&key_term);
+    public_key_from_hex(&key_hex).ok_or_else(|| PolicyError::BadIssuerKey(key_hex.clone()))
+}
+
+/// How a trust rule binds its issuer's verifying key. Either the operator pastes the
+/// key directly (`trust:issuerKey` hex — the live forgery vector D′), or the rule names
+/// the issuer by `trust:issuerDid` and a resolver binds the key (`sq-pfae.3`). The DID
+/// form **narrows** D′ — it does not eliminate it (a `did:key` is self-certifying, a
+/// `did:web` is only as strong as host/TLS control; see [`crate::did`]).
+#[cfg(feature = "did")]
+#[cfg_attr(docsrs, doc(cfg(feature = "did")))]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IssuerBinding {
+    /// `trust:issuerKey` — operator-asserted verifying-key hex (the default path).
+    OperatorAssertedKey,
+    /// `trust:issuerDid` — the DID string a resolver binds to a verifying key.
+    Did(String),
+}
+
+/// Parse a Control-gated trust policy whose rules may name their issuer by
+/// **`trust:issuerDid`** (resolved via `resolver`) as an alternative to the
+/// operator-asserted `trust:issuerKey` hex, producing the same `Vec<TrustRule>` the
+/// admission gate consumes (`sq-pfae.3`).
+///
+/// For each `trust:TrustRule`: if it carries `trust:issuerDid`, the DID is resolved to a
+/// verifying key via `resolver` (`did:key` offline / `did:web` via the resolver's
+/// fetcher); otherwise it falls back to `trust:issuerKey` hex. A rule carrying **neither**
+/// is a [`PolicyError::IncompleteRule`]; a DID that fails to resolve is a
+/// [`PolicyError::BadIssuerDid`] — **fail-closed**, so an unresolvable issuer admits
+/// nothing. Everything else (scope, freshness, shape) parses exactly as [`parse_policy`].
+///
+/// Possession of a [`ControlGate`] is still required (§3.2): the issuer-key BINDING is
+/// strengthened, but the policy itself must still arrive through the trusted channel —
+/// DID resolution narrows forgery vector D′, it does not relax the Control-gating root.
+#[cfg(feature = "did")]
+#[cfg_attr(docsrs, doc(cfg(feature = "did")))]
+pub fn resolve_rule_keys(
+    policy: &[Triple],
+    resolver: &dyn crate::did::DidResolver,
+    _gate: ControlGate,
+) -> Result<Vec<TrustRule>, PolicyError> {
+    let key_for = move |node: &Term, policy: &[Triple]| -> Result<PublicKey, PolicyError> {
+        // Prefer trust:issuerDid (the resolver-bound, D′-narrowing path).
+        if let Some(did_term) = object_of(node, vocab::ISSUER_DID, policy) {
+            let did_str = term_lexical(&did_term);
+            return resolver.resolve_str(&did_str).map_err(|e| PolicyError::BadIssuerDid {
+                did: did_str,
+                reason: e.to_string(),
+            });
+        }
+        // Fall back to the operator-asserted hex key.
+        if object_of(node, vocab::ISSUER_KEY, policy).is_some() {
+            return operator_asserted_key(node, policy);
+        }
+        Err(PolicyError::IncompleteRule {
+            rule: node_label(node),
+            missing: "trust:issuerDid or trust:issuerKey",
+        })
+    };
+    parse_rules(policy, &key_for)
+}
+
+fn parse_rules(policy: &[Triple], key_for: &KeyResolver) -> Result<Vec<TrustRule>, PolicyError> {
     // Collect every node typed `trust:TrustRule`.
     let mut rule_nodes: Vec<Term> = Vec::new();
     for t in policy {
@@ -153,12 +240,16 @@ fn parse_rules(policy: &[Triple]) -> Result<Vec<TrustRule>, PolicyError> {
 
     let mut out = Vec::with_capacity(rule_nodes.len());
     for node in rule_nodes {
-        out.push(parse_one_rule(&node, policy)?);
+        out.push(parse_one_rule(&node, policy, key_for)?);
     }
     Ok(out)
 }
 
-fn parse_one_rule(node: &Term, policy: &[Triple]) -> Result<TrustRule, PolicyError> {
+fn parse_one_rule(
+    node: &Term,
+    policy: &[Triple],
+    key_for: &KeyResolver,
+) -> Result<TrustRule, PolicyError> {
     let rule_id = || node_label(node);
 
     // trust:source — a named attesting authority.
@@ -168,15 +259,9 @@ fn parse_one_rule(node: &Term, policy: &[Triple]) -> Result<TrustRule, PolicyErr
             missing: "trust:source",
         })?;
 
-    // trust:issuerKey — hex key material (operator-asserted; no DID resolver — §3.3 D′).
-    let key_term =
-        object_of(node, vocab::ISSUER_KEY, policy).ok_or_else(|| PolicyError::IncompleteRule {
-            rule: rule_id(),
-            missing: "trust:issuerKey",
-        })?;
-    let key_hex = term_lexical(&key_term);
-    let issuer_key =
-        public_key_from_hex(&key_hex).ok_or_else(|| PolicyError::BadIssuerKey(key_hex.clone()))?;
+    // The issuer verifying key — operator-asserted hex (`trust:issuerKey`) or
+    // DID-resolved (`trust:issuerDid`), depending on the supplied strategy.
+    let issuer_key = key_for(node, policy)?;
 
     // trust:scope — exact-or-ancestor resource/container IRI.
     let scope =

--- a/crates/sparq-trust/src/vocab.rs
+++ b/crates/sparq-trust/src/vocab.rs
@@ -54,6 +54,12 @@ pub const SOURCE_CLASS: &str = "https://sparq.dev/ns/trust#Source";
 /// `trust:issuerKey` — verification key the source signs with (aligns with
 /// `zk:issuerKey`).
 pub const ISSUER_KEY: &str = "https://sparq.dev/ns/trust#issuerKey";
+/// `trust:issuerDid` — the source's DID, resolved to its verifying key by a pluggable
+/// DID resolver (`did:key` / `did:web`; the `crate::did` module, opt-in `did` feature).
+/// A rule may name its issuer by `trust:issuerDid` INSTEAD of the operator-asserted
+/// `trust:issuerKey` hex — the `sq-pfae.3` issuer-key-binding term that narrows forgery
+/// vector D′.
+pub const ISSUER_DID: &str = "https://sparq.dev/ns/trust#issuerDid";
 /// `trust:scope` — where the trust rule applies (server-wide vs per-`.acr`).
 pub const SCOPE: &str = "https://sparq.dev/ns/trust#scope";
 /// `trust:freshWithin` — maximum staleness admitted (consulted against
@@ -198,6 +204,7 @@ mod tests {
             FOR_SHAPE,
             SOURCE_CLASS,
             ISSUER_KEY,
+            ISSUER_DID,
             SCOPE,
             FRESH_WITHIN,
             ADMITTED,

--- a/crates/sparq-trust/tests/did_issuer_binding_e2e.rs
+++ b/crates/sparq-trust/tests/did_issuer_binding_e2e.rs
@@ -1,0 +1,292 @@
+//! End-to-end: DID-bound issuer key (`trust:issuerDid`) drives the SAME admission gate
+//! as the operator-asserted `trust:issuerKey` hex — the `sq-pfae.3` issuer-key binding.
+//!
+//! It exercises the REAL path: a Control-gated trust policy whose rule names its issuer
+//! by `trust:issuerDid` (a `did:key` minted from the gov issuer's verifying key), is
+//! resolved via [`resolve_rule_keys`] + a [`DidKeyResolver`] into a concrete `TrustRule`,
+//! then run through the unchanged admission gate (RDFC-1.0 commit → CHECKED issuer
+//! signature → SHACL statement-type scope → freshness → holder binding) and the N3 merge
+//! with the `.acr` ABAC rule. The load-bearing invariant: **result-equivalence** — the
+//! DID-bound policy admits and grants EXACTLY what the operator-asserted policy does.
+//!
+//! Fail-closed negatives (each MUST deny): a DID that resolves to the WRONG key, an
+//! unresolvable / unsupported-method DID, and a `did:web` document with no usable key.
+//! A `did:web` positive runs through an in-memory fetcher (no network).
+//!
+//! Only compiled with the opt-in `did` feature.
+//!
+//! [OPUS-4.8] sq-pfae.3 (issue #940 / gh-940). 🤖 SPARQ agent — trust-graph authz PoC.
+#![cfg(feature = "did")]
+
+use std::collections::HashMap;
+
+use oxrdf::{Literal, NamedNode, NamedOrBlankNode, Term, Triple};
+use sparq_trust::admit::{admit, PresentedCredential, Session};
+use sparq_trust::did::{did_key_for, DidDocumentFetcher, DidKeyResolver, DidWebResolver};
+use sparq_trust::policy::{parse_policy, resolve_rule_keys, ControlGate, TrustRule};
+use sparq_trust::vocab;
+use sparq_trust::wire::derive_grants;
+use sparq_zk::commit::commit_triples;
+use sparq_zk::encode::salt_from_bytes;
+use sparq_zk::sig::{public_key_to_hex, PublicKey, SecretKey};
+
+const JESSE: &str = "https://jesse.ex/card#me";
+const GOV_ISSUER: &str = "https://gov.example/issuer";
+const SCHEMA_AGE: &str = "http://schema.org/age";
+const RESOURCE_X: &str = "https://pod.ex/resourceX";
+const SALT_BYTES: [u8; 32] = [7u8; 32];
+const NOW: i64 = 1_700_000_000;
+const ISSUED_FRESH: i64 = NOW - 86_400;
+
+const ACR_ABAC_RULE: &str = r#"@prefix schema: <http://schema.org/> .
+@prefix math:   <http://www.w3.org/2000/10/swap/math#> .
+@prefix auth:   <https://sparq.dev/ns/auth#> .
+{ ?x schema:age ?y . ?y math:greaterThan 18 } => { ?x auth:read <https://pod.ex/resourceX> } .
+"#;
+
+fn iri(s: &str) -> NamedNode {
+    NamedNode::new(s).unwrap()
+}
+
+fn age_credential_graph(subject: &str, value: &str) -> Vec<Triple> {
+    vec![Triple::new(
+        NamedOrBlankNode::NamedNode(iri(subject)),
+        iri(SCHEMA_AGE),
+        Term::Literal(Literal::new_typed_literal(
+            value,
+            iri("http://www.w3.org/2001/XMLSchema#integer"),
+        )),
+    )]
+}
+
+fn gov_key() -> (SecretKey, PublicKey) {
+    let sk = SecretKey::from_seed(0xC0FFEE);
+    let pk = sk.public_key();
+    (sk, pk)
+}
+
+fn sign_graph(sk: &SecretKey, graph: &[Triple]) -> String {
+    let salt = salt_from_bytes(&SALT_BYTES);
+    let commitment = commit_triples(graph, salt).expect("credential graph commits");
+    sk.sign_commitment(&commitment.commitment)
+}
+
+fn fresh_cred(sk: &SecretKey, graph: Vec<Triple>) -> PresentedCredential {
+    let sig = sign_graph(sk, &graph);
+    PresentedCredential {
+        graph,
+        issuer_signature_hex: sig,
+        salt: SALT_BYTES,
+        issued_at_unix_secs: ISSUED_FRESH,
+        revoked: false,
+    }
+}
+
+fn session(agent: &str, now: i64) -> Session {
+    Session {
+        agent: iri(agent),
+        now_unix_secs: now,
+    }
+}
+
+/// Build a gov-trusts-age policy GRAPH whose rule binds the issuer via `binding`
+/// (either a `trust:issuerKey` hex literal or a `trust:issuerDid` string literal).
+fn gov_age_policy_graph(issuer: &str, binding: (&str, &str), scope: &str) -> Vec<Triple> {
+    let (key_pred, key_lex) = binding;
+    let rule = NamedNode::new("https://pod.ex/.acr#trustrule").unwrap();
+    vec![
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule.clone()),
+            iri(vocab::RDF_TYPE),
+            Term::NamedNode(iri(vocab::TRUST_RULE)),
+        ),
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule.clone()),
+            iri(vocab::SOURCE),
+            Term::NamedNode(iri(issuer)),
+        ),
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule.clone()),
+            iri(key_pred),
+            Term::Literal(Literal::new_simple_literal(key_lex)),
+        ),
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule.clone()),
+            iri(vocab::FOR_PREDICATE),
+            Term::NamedNode(iri(SCHEMA_AGE)),
+        ),
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule.clone()),
+            iri(vocab::SCOPE),
+            Term::NamedNode(iri(scope)),
+        ),
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule),
+            iri(vocab::FRESH_WITHIN),
+            Term::Literal(Literal::new_typed_literal(
+                "P30D",
+                iri("http://www.w3.org/2001/XMLSchema#duration"),
+            )),
+        ),
+    ]
+}
+
+fn read_granted(grants: &[Triple], subject: &str) -> bool {
+    grants.iter().any(|t| {
+        t.predicate.as_str() == "https://sparq.dev/ns/auth#read"
+            && matches!(&t.subject, NamedOrBlankNode::NamedNode(n) if n.as_str() == subject)
+            && matches!(&t.object, Term::NamedNode(o) if o.as_str() == RESOURCE_X)
+    })
+}
+
+fn run(rules: &[TrustRule]) -> Vec<Triple> {
+    let (sk, _) = gov_key();
+    let cred = fresh_cred(&sk, age_credential_graph(JESSE, "25"));
+    let admitted = admit(&cred, rules, &session(JESSE, NOW), &iri(RESOURCE_X));
+    derive_grants(&admitted, ACR_ABAC_RULE).expect("derivation runs")
+}
+
+// --- the load-bearing invariant: result-equivalence -------------------------
+
+#[test]
+fn did_key_bound_issuer_grants_read_identically_to_operator_asserted_key() {
+    let (_sk, pk) = gov_key();
+
+    // Path A: operator-asserted hex key (today's path).
+    let policy_key = gov_age_policy_graph(
+        GOV_ISSUER,
+        (vocab::ISSUER_KEY, &public_key_to_hex(&pk)),
+        RESOURCE_X,
+    );
+    let rules_key = parse_policy(&policy_key, ControlGate::assert_control_gated()).unwrap();
+
+    // Path B: a did:key minted from the SAME key, resolved by the offline DidKeyResolver.
+    let did = did_key_for(&pk);
+    let policy_did = gov_age_policy_graph(GOV_ISSUER, (vocab::ISSUER_DID, &did), RESOURCE_X);
+    let rules_did = resolve_rule_keys(
+        &policy_did,
+        &DidKeyResolver,
+        ControlGate::assert_control_gated(),
+    )
+    .unwrap();
+
+    // The resolved key MUST equal the operator-asserted key (binding correctness).
+    assert_eq!(
+        rules_did[0].issuer_key, rules_key[0].issuer_key,
+        "the did:key resolves to the SAME issuer verifying key the operator would paste"
+    );
+
+    // And the end-to-end grant is IDENTICAL (result-equivalence).
+    let grants_key = run(&rules_key);
+    let grants_did = run(&rules_did);
+    assert!(read_granted(&grants_key, JESSE), "operator-asserted path grants read");
+    assert!(
+        read_granted(&grants_did, JESSE),
+        "did:key-bound path grants read end-to-end — identical to the operator path"
+    );
+}
+
+// --- fail-closed negatives --------------------------------------------------
+
+#[test]
+fn did_key_bound_to_the_wrong_key_does_not_admit() {
+    // The policy's DID resolves to a DIFFERENT key than the one that signed the
+    // credential ⇒ the CHECKED signature fails ⇒ no admission ⇒ no access.
+    let wrong = SecretKey::from_seed(0xDECAF).public_key();
+    let did = did_key_for(&wrong);
+    let policy = gov_age_policy_graph(GOV_ISSUER, (vocab::ISSUER_DID, &did), RESOURCE_X);
+    let rules =
+        resolve_rule_keys(&policy, &DidKeyResolver, ControlGate::assert_control_gated()).unwrap();
+    let grants = run(&rules);
+    assert!(
+        !read_granted(&grants, JESSE),
+        "a did:key bound to the wrong issuer key fails the signature check ⇒ no access"
+    );
+}
+
+#[test]
+fn unresolvable_did_rejects_the_policy_fail_closed() {
+    // A syntactically valid but undecodable did:key id ⇒ resolve_rule_keys errors
+    // (fail-closed): the policy is rejected, nothing is admitted.
+    let policy =
+        gov_age_policy_graph(GOV_ISSUER, (vocab::ISSUER_DID, "did:key:zNOTAKEY"), RESOURCE_X);
+    let err = resolve_rule_keys(&policy, &DidKeyResolver, ControlGate::assert_control_gated());
+    assert!(
+        matches!(err, Err(sparq_trust::policy::PolicyError::BadIssuerDid { .. })),
+        "an unresolvable issuer DID is a fail-closed BadIssuerDid, not a silent admit: {err:?}"
+    );
+}
+
+#[test]
+fn unsupported_did_method_rejects_the_policy() {
+    // did:web through the did:key resolver is an unsupported method ⇒ fail-closed.
+    let policy = gov_age_policy_graph(
+        GOV_ISSUER,
+        (vocab::ISSUER_DID, "did:web:gov.example"),
+        RESOURCE_X,
+    );
+    let err = resolve_rule_keys(&policy, &DidKeyResolver, ControlGate::assert_control_gated());
+    assert!(
+        matches!(err, Err(sparq_trust::policy::PolicyError::BadIssuerDid { .. })),
+        "an unsupported DID method is rejected fail-closed: {err:?}"
+    );
+}
+
+// --- did:web through an in-memory fetcher (no network) ----------------------
+
+struct MapFetcher(HashMap<String, String>);
+impl DidDocumentFetcher for MapFetcher {
+    fn fetch(&self, url: &str) -> Result<String, String> {
+        self.0
+            .get(url)
+            .cloned()
+            .ok_or_else(|| format!("no document at {}", url))
+    }
+}
+
+#[test]
+fn did_web_bound_issuer_grants_read_through_an_in_memory_document() {
+    let (_sk, pk) = gov_key();
+    // The DID document carries the SAME key as publicKeyMultibase (the did:key encoding).
+    let mb = did_key_for(&pk).strip_prefix("did:key:").unwrap().to_string();
+    let did = "did:web:gov.example";
+    let url = DidWebResolver::<MapFetcher>::document_url("gov.example").unwrap();
+    let doc = format!(
+        r#"{{
+          "id": "{did}",
+          "verificationMethod": [
+            {{ "id": "{did}#k1", "type": "Multikey", "publicKeyMultibase": "{mb}" }}
+          ]
+        }}"#
+    );
+    let mut map = HashMap::new();
+    map.insert(url, doc);
+    let resolver = DidWebResolver::new(MapFetcher(map));
+
+    let policy = gov_age_policy_graph(GOV_ISSUER, (vocab::ISSUER_DID, did), RESOURCE_X);
+    let rules = resolve_rule_keys(&policy, &resolver, ControlGate::assert_control_gated()).unwrap();
+    assert_eq!(
+        rules[0].issuer_key, pk,
+        "the did:web document's verification method binds the gov issuer key"
+    );
+    let grants = run(&rules);
+    assert!(
+        read_granted(&grants, JESSE),
+        "a did:web-bound issuer grants read end-to-end (in-memory document; no network)"
+    );
+}
+
+#[test]
+fn did_web_with_no_usable_key_rejects_the_policy() {
+    let did = "did:web:gov.example";
+    let url = DidWebResolver::<MapFetcher>::document_url("gov.example").unwrap();
+    let mut map = HashMap::new();
+    map.insert(url, format!(r#"{{"id":"{did}"}}"#)); // keyless document
+    let resolver = DidWebResolver::new(MapFetcher(map));
+    let policy = gov_age_policy_graph(GOV_ISSUER, (vocab::ISSUER_DID, did), RESOURCE_X);
+    let err = resolve_rule_keys(&policy, &resolver, ControlGate::assert_control_gated());
+    assert!(
+        matches!(err, Err(sparq_trust::policy::PolicyError::BadIssuerDid { .. })),
+        "a did:web document with no usable issuer key rejects the policy fail-closed: {err:?}"
+    );
+}

--- a/crates/sparq-trust/tests/vocab_ttl.rs
+++ b/crates/sparq-trust/tests/vocab_ttl.rs
@@ -1,8 +1,9 @@
 //! Parse-validation of the published machine-readable vocabulary
-//! `ontologies/trust/trust.ttl` (sq-pfae.2). The Turtle a working group reads MUST
-//! stay valid Turtle and MUST declare exactly the ten core terms + the one sugar
-//! term. The `vocab::tests::ttl_pins_match_rust_constants` unit test additionally
-//! pins the IRIs against the Rust constants; this test is the *syntactic* guard.
+//! `ontologies/trust/trust.ttl` (sq-pfae.2, extended for the `trust:issuerDid`
+//! issuer-key-binding term in sq-pfae.3). The Turtle a working group reads MUST
+//! stay valid Turtle and MUST declare the core terms + the one sugar term. The
+//! `vocab::tests::ttl_pins_match_rust_constants` unit test additionally pins the IRIs
+//! against the Rust constants; this test is the *syntactic* guard.
 //!
 //! [OPUS-4.8] sq-pfae.2 (issue #940). 🤖 SPARQ agent — trust-graph authorisation.
 
@@ -25,12 +26,12 @@ fn trust_ttl_is_valid_turtle() {
     );
 }
 
-/// Every one of the eleven term IRIs (ten core + the one sugar) is declared in the
-/// Turtle as a subject. This is a coarse presence check independent of the unit-test
-/// constant pinning, so a refactor of `vocab.rs` cannot silently drop a published
-/// term from the gate.
+/// Every term IRI (ten core + the `trust:issuerDid` binding term + the one sugar) is
+/// declared in the Turtle as a subject. This is a coarse presence check independent of
+/// the unit-test constant pinning, so a refactor of `vocab.rs` cannot silently drop a
+/// published term from the gate.
 #[test]
-fn trust_ttl_declares_all_eleven_terms() {
+fn trust_ttl_declares_all_core_terms() {
     use oxrdf::NamedOrBlankNode;
 
     const NS: &str = "https://sparq.dev/ns/trust#";
@@ -42,6 +43,7 @@ fn trust_ttl_declares_all_eleven_terms() {
         "source",
         "forShape",
         "issuerKey",
+        "issuerDid",
         "scope",
         "freshWithin",
         "admitted",

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -437,8 +437,12 @@ does **not** provide privacy, unlinkability, or anonymity: the credential is adm
 clear and the holder binding authenticates the WebID in the clear (the non-anonymous degraded
 path, `sq-wvne`). The ZK estate it composes with is externally **unaudited**
 (`sq-qhy4`, pending external accredited-cryptographer sign-off). Issuer keys are
-operator-asserted (no DID resolver yet — `sq-pfae.3`, the live forgery vector D′). Open problems
-are respected as documented limitations, never solved: `sq-tu4e` (no in-reasoner NAF over
+operator-asserted by default (`trust:issuerKey` hex, the live forgery vector D′); the **opt-in
+`did` feature** (`sq-pfae.3`) lets a rule bind its key from a `trust:issuerDid` instead —
+`sparq_trust::{DidKeyResolver, DidWebResolver, resolve_rule_keys}`, `did:key` offline self-cert +
+a pluggable `did:web` fetcher (no HTTP client forced on the default build). This **narrows** D′ but
+is no absolute anchor: `did:key` is self-certifying, `did:web` only as strong as host/TLS. Open
+problems are respected as documented limitations, never solved: `sq-tu4e` (no in-reasoner NAF over
 derived facts; `revoked` is input-only; no deny-on-disagreement) and `sq-wvne` (ZK privacy) are
 out of PoC scope. `sq-xc4y` (per-request holder/freshness admission vs the materialise-once view)
 is **RESOLVED** by the static/dynamic split: see `admit_trust_credential_static` above and design


### PR DESCRIPTION
> 🤖 SPARQ agent — trust-graph authorisation PoC. Written while Fable is unavailable; flag for re-review when Fable returns.

Closes **sq-pfae.3** (gh-940 epic `sq-pfae` — Trust-graph authorisation for Solid/LWS). Implements pluggable **DID resolution + issuer-key binding (`did:key` / `did:web`)** feeding the existing `sparq-zk` signature check.

## What this implements

Until now a trust rule named its issuer's verifying key as operator-asserted `trust:issuerKey` hex — the live forgery vector **D′** (design §3.3): paste a forged key in the policy and forged credentials are admitted. This PR lets a rule instead name its issuer by **`trust:issuerDid`** and resolves that DID to the **same** `PublicKey` the admission gate already consumes, via a pluggable resolver. It **narrows** D′; it does not eliminate it (see *Honest scope*).

- **`did` module** (feature-gated): a `Did` parser, a pluggable `DidResolver` trait, an offline self-certifying `DidKeyResolver` (multibase / multicodec / base58btc / unsigned-varint decoded **dependency-free**, hand-rolled to keep the crate lean), and a `DidWebResolver` over a pluggable `DidDocumentFetcher` (the crate ships **no HTTP client**, so the default build forces no `reqwest`/`ureq` on anyone, and the resolver is offline-testable).
- **`trust:issuerDid` vocab term** + **`resolve_rule_keys(policy, resolver, gate)`** in `policy`: parses a Control-gated policy whose rules bind their key from a DID (falling back to `trust:issuerKey` hex), resolves it, and produces the **unchanged** `Vec<TrustRule>` the gate runs. **Fail-closed**: an unresolvable / wrong-key / unsupported-method DID is a `PolicyError::BadIssuerDid` and admits nothing.
- **`sparq-solid`** gains a forwarding **`trust-graph-did`** feature (`= ["trust-graph", "sparq-trust/did"]`).

## Opt-in by construction

Everything sits behind the **default-OFF `did` cargo feature** (`did = ["dep:serde_json"]` — `serde_json` is the *only* extra dep, used solely to parse a fetched `did:web` document; the `did:key` path needs no JSON). The lean default `sparq-trust` / `sparq-solid` builds are byte-identical — strict additivity (design §2.2 G6) preserved.

## Honest scope / best-judgment decisions (steering welcome — STANDING RULE)

This is underspecified at the crypto-encoding level, so I made these documented best-judgment calls (flagged in a GitHub issue for the maintainer to steer later):

- **`did:key` is self-certifying — NOT a trust anchor.** It proves DID↔key agreement, nothing about *who* holds the key; trust still flows from the Control-gated policy that names it.
- **`did:web` is only as strong as host/TLS control.** No key-history / deactivation handling; revocation stays the input-only `sq-tu4e` guard.
- **Curve caveat — sparq keys are Baby-JubJub, not Ed25519.** The issuer signature is Poseidon2-Schnorr over Baby-JubJub, so the standard `did:key` Ed25519 multicodec (`z6Mk…`) does **not** apply. I use an explicit **sparq-private** multicodec for the compressed point and document the **non-interop** with the wider `did:key` ecosystem so a WG can register a real codec.
- **No privacy / unlinkability.** This binds an issuer key only; the credential value is still admitted in the clear. The ZK estate remains research-grade and **externally UNAUDITED** (`sq-qhy4`); `sparq-mpc` is honest-majority semi-honest only.

## Tests (REAL path, not a mock that bypasses the logic)

`tests/did_issuer_binding_e2e.rs` (feature-gated) drives the actual admission gate:
- **Load-bearing invariant — result-equivalence**: a `did:key` minted from the gov issuer key admits and grants **identically** to the operator-asserted hex path.
- `did:web` resolves through an **in-memory fetcher** (no network) and grants end-to-end.
- Fail-closed matrix: wrong-key DID (signature fails), unresolvable DID, unsupported method, keyless `did:web` document — each denies. Plus offline `did:key`/base58/varint/url-mapping unit tests in the module.

## Gates (run in BOTH feature states)

| Gate | default (feature OFF) | `--features did` |
|---|---|---|
| `cargo build` | green | green |
| `cargo clippy --all-targets -D warnings` | green | green |
| `cargo test` | green | green (6 e2e + module units) |
| `rustdoc --no-deps -D warnings` | green | green (`--all-features`) |

Also: workspace `cargo doc --workspace --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`) clean; `check-readme-template.py --enforce` → **0 deviations** (README 120 lines); `check-privacy-claims.sh` clean; `typos` clean. No hard-coded perf numbers.

**Feature flags:** `sparq-trust/did` (and the `sparq-solid/trust-graph-did` forwarder).

Auto-merge intentionally **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
