### PR TITLE
fix(ci): disk-guard reclaims COMPLETED-but-unmerged workflow worktrees (sq-h34dc) [OPUS-4.8]

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -290,6 +290,20 @@ jobs:
         run: bash scripts/disk-guard.sh --dry-run-self-test
       - name: Self-test disk-guard.sh (gated escalation + busy-build guard, end-to-end)
         run: bash scripts/tests/test_disk_guard.sh
+      # [OPUS-4.8] sq-h34dc: worktree-gc.sh's COMPLETED-but-unmerged reclaim (--reclaim-completed)
+      # removes clean+pushed wf_/agent- worktrees with no live owning task — strictly more
+      # aggressive than the default MERGED-or-GONE broom, so its safety (opt-in, workflow-named
+      # only, KEEP-if-dirty/unpushed/in-use) is pinned by a hermetic harness that builds real git
+      # repos + worktrees and spawns a live in-use process. The script's own pure self-test (the
+      # is_workflow_branch predicate + in-use probe callability) runs too. HARD (no
+      # "advisory"/"informational") so ci-summary gates on it. (shellcheck of worktree-gc.sh is
+      # new here — it now carries the load-bearing in-use guard.)
+      - name: shellcheck worktree-gc.sh + its completed-reclaim self-test
+        run: shellcheck scripts/worktree-gc.sh scripts/tests/test_worktree_gc_completed.sh
+      - name: Self-test worktree-gc.sh (pure predicates incl. is_workflow_branch, hermetic)
+        run: bash scripts/worktree-gc.sh --dry-run-self-test
+      - name: Self-test worktree-gc.sh (completed-reclaim opt-in + workflow-only + in-use guard, end-to-end)
+        run: bash scripts/tests/test_worktree_gc_completed.sh
       # [OPUS-4.8] sq-13uyp: the per-tick merged-bead reconcile sweep — closes bd-OPEN beads
       # whose fix already MERGED so they stop wasting frontier dispatches (it COMPLEMENTS
       # push-frontier's open-PR exclusion, sq-7mwun). Its correctness rests on a conservative

--- a/scripts/disk-guard.sh
+++ b/scripts/disk-guard.sh
@@ -4,7 +4,8 @@
 #
 # disk-guard.sh [--dry-run | --apply] [--warn-gb N] [--critical-gb N]
 #               [--mount PATH] [--main PATH] [--root DIR] [--base REF]
-#               [--no-worktree-gc] [--reclaim-main-target] [--dry-run-self-test]
+#               [--no-worktree-gc] [--no-reclaim-completed] [--reclaim-main-target]
+#               [--dry-run-self-test]
 #
 # WHY: 2026-06-21 the work box filled to 99% (286/290G) and a wave-4 verify agent hit
 # ENOSPC mid-build (could not run `--workspace` clippy). The autonomous loop spawns one
@@ -13,8 +14,14 @@
 # finished worktrees, but it was a MANUAL / idle-time tool — nothing ran a `df` check or
 # the prune ON EACH MAINTENANCE TICK. This script is that per-tick GUARD: it
 #   (1) measures free space on the disk and classifies OK / WARN (<20G) / CRITICAL (<10G);
-#   (2) prunes provably-merged worktrees by DELEGATING to worktree-gc.sh (it does NOT
-#       reimplement the safe predicate — composition, not duplication); and
+#   (2) prunes finished worktrees by DELEGATING to worktree-gc.sh (it does NOT reimplement
+#       the safe predicate — composition, not duplication). It runs the broom with
+#       --reclaim-completed (default ON, --no-reclaim-completed to disable) so it ALSO
+#       reclaims COMPLETED-but-unmerged workflow worktrees — clean trees whose PR branch is
+#       pushed but not yet merged, with no live owning task. Without this they linger forever
+#       and starve the disk (observed 2026-06-22: ~229G of these, one 33G — bead sq-h34dc).
+#       The in-use guard inside worktree-gc.sh KEEPS any tree a live process is using, so a
+#       per-tick reclaim never touches an in-flight agent; and
 #   (3) only when CRITICAL, and only when NO live cargo/rustc build is touching the
 #       orchestrator main checkout's `target/`, reclaims that `target/` (regenerable:
 #       agents build in their OWN worktrees, so the orchestrator's `target/` is not load-
@@ -40,6 +47,7 @@
 #   scripts/disk-guard.sh                       # dry-run (default): df + dry-run prune + plan
 #   scripts/disk-guard.sh --apply               # prune the safe worktree set, then report
 #   scripts/disk-guard.sh --apply --reclaim-main-target   # also drop main target/ IF critical
+#   scripts/disk-guard.sh --no-reclaim-completed --apply  # MERGED/GONE-only prune (old behaviour)
 #   scripts/disk-guard.sh --warn-gb 30          # warn earlier
 #   scripts/disk-guard.sh --dry-run-self-test   # hermetic self-test (no fs/git mutation)
 set -uo pipefail   # NOT -e: a guard tick is best-effort and must not abort its caller.
@@ -156,28 +164,32 @@ WARN_GB="$DEFAULT_WARN_GB"
 CRITICAL_GB="$DEFAULT_CRITICAL_GB"
 RUN_WT_GC=1
 RECLAIM_MAIN_TARGET=0
+RECLAIM_COMPLETED=1   # default ON: the per-tick guard reclaims completed-but-unmerged workflow
+                     # worktrees too (sq-h34dc). worktree-gc.sh's in-use guard keeps live trees.
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --dry-run-self-test)   self_test; exit 0 ;;
-    --apply)               APPLY=1 ;;
-    --dry-run)             APPLY=0 ;;
-    --warn-gb)             shift; [ "$#" -gt 0 ] || die "--warn-gb needs a value"; WARN_GB="$1" ;;
-    --warn-gb=*)           WARN_GB="${1#--warn-gb=}" ;;
-    --critical-gb)         shift; [ "$#" -gt 0 ] || die "--critical-gb needs a value"; CRITICAL_GB="$1" ;;
-    --critical-gb=*)       CRITICAL_GB="${1#--critical-gb=}" ;;
-    --mount)               shift; [ "$#" -gt 0 ] || die "--mount needs a value"; MOUNT="$1" ;;
-    --mount=*)             MOUNT="${1#--mount=}" ;;
-    --main)                shift; [ "$#" -gt 0 ] || die "--main needs a value"; MAIN="$1" ;;
-    --main=*)              MAIN="${1#--main=}" ;;
-    --root)                shift; [ "$#" -gt 0 ] || die "--root needs a value"; ROOT="$1" ;;
-    --root=*)              ROOT="${1#--root=}" ;;
-    --base)                shift; [ "$#" -gt 0 ] || die "--base needs a value"; BASE="$1" ;;
-    --base=*)              BASE="${1#--base=}" ;;
-    --no-worktree-gc)      RUN_WT_GC=0 ;;
-    --reclaim-main-target) RECLAIM_MAIN_TARGET=1 ;;
-    -h|--help)             sed -n '2,60p' "$0"; exit 0 ;;
-    *)                     die "unknown argument: $1 (try --apply, --warn-gb, --critical-gb, --reclaim-main-target, --dry-run-self-test, --help)" ;;
+    --dry-run-self-test)     self_test; exit 0 ;;
+    --apply)                 APPLY=1 ;;
+    --dry-run)               APPLY=0 ;;
+    --warn-gb)               shift; [ "$#" -gt 0 ] || die "--warn-gb needs a value"; WARN_GB="$1" ;;
+    --warn-gb=*)             WARN_GB="${1#--warn-gb=}" ;;
+    --critical-gb)           shift; [ "$#" -gt 0 ] || die "--critical-gb needs a value"; CRITICAL_GB="$1" ;;
+    --critical-gb=*)         CRITICAL_GB="${1#--critical-gb=}" ;;
+    --mount)                 shift; [ "$#" -gt 0 ] || die "--mount needs a value"; MOUNT="$1" ;;
+    --mount=*)               MOUNT="${1#--mount=}" ;;
+    --main)                  shift; [ "$#" -gt 0 ] || die "--main needs a value"; MAIN="$1" ;;
+    --main=*)                MAIN="${1#--main=}" ;;
+    --root)                  shift; [ "$#" -gt 0 ] || die "--root needs a value"; ROOT="$1" ;;
+    --root=*)                ROOT="${1#--root=}" ;;
+    --base)                  shift; [ "$#" -gt 0 ] || die "--base needs a value"; BASE="$1" ;;
+    --base=*)                BASE="${1#--base=}" ;;
+    --no-worktree-gc)        RUN_WT_GC=0 ;;
+    --reclaim-completed)     RECLAIM_COMPLETED=1 ;;   # accepted for symmetry (already the default)
+    --no-reclaim-completed)  RECLAIM_COMPLETED=0 ;;
+    --reclaim-main-target)   RECLAIM_MAIN_TARGET=1 ;;
+    -h|--help)               sed -n '2,60p' "$0"; exit 0 ;;
+    *)                       die "unknown argument: $1 (try --apply, --warn-gb, --critical-gb, --no-reclaim-completed, --reclaim-main-target, --dry-run-self-test, --help)" ;;
   esac
   shift
 done
@@ -207,21 +219,26 @@ case "$STATE" in
   UNKNOWN)  log "disk state UNKNOWN (df unparsed) — running the safe prune anyway, skipping escalation." ;;
 esac
 
-# --- 2. prune provably-merged worktrees (delegate to worktree-gc.sh) ---------------------
-# We ALWAYS run the worktree prune (its safe predicate KEEPS anything unmerged/dirty, so it
-# is harmless when disk is fine and frees the most when it is not) — this is the per-tick
-# "prune merged worktrees" the bead asks for. We do not reimplement the predicate.
+# --- 2. prune finished worktrees (delegate to worktree-gc.sh) ----------------------------
+# We ALWAYS run the worktree prune (its safe predicate KEEPS anything unmerged/dirty/in-use, so
+# it is harmless when disk is fine and frees the most when it is not) — this is the per-tick
+# worktree prune the bead asks for. We do not reimplement the predicate. By default we pass
+# --reclaim-completed so the broom ALSO reclaims clean+pushed completed-but-unmerged workflow
+# worktrees with no live owning task (sq-h34dc) — the in-use guard inside worktree-gc.sh keeps
+# any tree a live process is using, so this never touches an in-flight agent.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 WT_GC="${SCRIPT_DIR}/worktree-gc.sh"
 
 if [ "$RUN_WT_GC" -eq 1 ]; then
   if [ -x "$WT_GC" ] || [ -f "$WT_GC" ]; then
-    log "delegating worktree prune to worktree-gc.sh ($([ "$APPLY" -eq 1 ] && echo --apply || echo --dry-run)):"
+    WT_GC_EXTRA=()
+    [ "$RECLAIM_COMPLETED" -eq 1 ] && WT_GC_EXTRA+=(--reclaim-completed)
+    log "delegating worktree prune to worktree-gc.sh ($([ "$APPLY" -eq 1 ] && echo --apply || echo --dry-run)$([ "$RECLAIM_COMPLETED" -eq 1 ] && echo ' --reclaim-completed')):"
     if [ "$APPLY" -eq 1 ]; then
-      bash "$WT_GC" --apply --root "$ROOT" --main "$MAIN" --base "$BASE" || \
+      bash "$WT_GC" --apply --root "$ROOT" --main "$MAIN" --base "$BASE" "${WT_GC_EXTRA[@]+"${WT_GC_EXTRA[@]}"}" || \
         log "WARNING: worktree-gc.sh --apply returned non-zero (some worktrees kept) — non-fatal."
     else
-      bash "$WT_GC" --dry-run --root "$ROOT" --main "$MAIN" --base "$BASE" || \
+      bash "$WT_GC" --dry-run --root "$ROOT" --main "$MAIN" --base "$BASE" "${WT_GC_EXTRA[@]+"${WT_GC_EXTRA[@]}"}" || \
         log "WARNING: worktree-gc.sh --dry-run returned non-zero — non-fatal."
     fi
   else

--- a/scripts/tests/test_disk_guard.sh
+++ b/scripts/tests/test_disk_guard.sh
@@ -164,6 +164,23 @@ write_idle_pgrep; write_df_free 200; mk_target
 run_guard 0 --dry-run
 if grep -q '^INVOKED' "$WT_GC_LOG"; then note_pass; else note_fail "worktree prune was NOT invoked on an OK tick"; fi
 
+# --------------------------------------------------------------------------- #
+# 7b. COMPLETED-RECLAIM PASS-THROUGH (sq-h34dc) — by default disk-guard delegates with
+#     --reclaim-completed (so the per-tick sweep also reclaims completed-but-unmerged workflow
+#     worktrees); --no-reclaim-completed omits it (old MERGED/GONE-only behaviour).
+# --------------------------------------------------------------------------- #
+: >"$WT_GC_LOG"
+write_idle_pgrep; write_df_free 200; mk_target
+run_guard 0 --dry-run
+if grep -q 'INVOKED.*--reclaim-completed' "$WT_GC_LOG"; then note_pass; else
+  note_fail "default tick did NOT pass --reclaim-completed to worktree-gc.sh"; fi
+
+: >"$WT_GC_LOG"
+write_idle_pgrep; write_df_free 200; mk_target
+run_guard 0 --dry-run --no-reclaim-completed
+if grep -q '^INVOKED' "$WT_GC_LOG" && ! grep -q -- '--reclaim-completed' "$WT_GC_LOG"; then note_pass; else
+  note_fail "--no-reclaim-completed still passed --reclaim-completed (or skipped the prune)"; fi
+
 # erroring worktree-gc ⇒ guard still exits on the disk-state code (non-fatal delegation)
 cat >"${SCRIPTS}/worktree-gc.sh" <<'EOF'
 #!/usr/bin/env bash

--- a/scripts/tests/test_worktree_gc_completed.sh
+++ b/scripts/tests/test_worktree_gc_completed.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# [OPUS-4.8] Hermetic end-to-end self-test for scripts/worktree-gc.sh's COMPLETED-but-unmerged
+# workflow-worktree reclaim (--reclaim-completed — bead sq-h34dc). Authored by Opus 4.8 (Fable
+# unavailable; flag for re-review when Fable returns).
+#
+# WHY: the completed-reclaim path removes a worktree whose PR branch is PUSHED but NOT yet merged
+# — strictly more aggressive than the default MERGED-or-GONE broom. Its safety rests on three
+# load-bearing invariants that a refactor must never silently break, so we pin them with a
+# hermetic harness that builds REAL git repos (a bare "origin" + a clone with worktrees) and
+# drives the actual `worktree-gc.sh`:
+#   1. OPT-IN — without --reclaim-completed a completed-but-unmerged workflow worktree is KEPT
+#      (default behaviour is unchanged: MERGED-or-GONE only).
+#   2. WORKFLOW-NAMED ONLY — with --reclaim-completed a clean+pushed wf_/agent- worktree is
+#      reclaimed, but a clean+pushed *human-named* (feat/…) worktree is KEPT — only the harness
+#      naming pattern is eligible.
+#   3. KEEP-IF-UNSAFE — dirty, unpushed, and (the new guard) IN-USE worktrees are KEPT even with
+#      --reclaim-completed. The in-use case is exercised by spawning a live process whose cwd is
+#      inside the worktree and asserting --apply does NOT remove it.
+#   Plus: MERGED still classifies as MERGED regardless of the flag, and --apply actually removes
+#   the reclaimed set (so the disk is genuinely freed).
+#
+# HERMETIC w.r.t. the real system: everything lives under a mktemp sandbox; the harness creates
+# its own bare origin + clone + worktrees and never reads or touches the real repo, the real
+# `.claude/worktrees/`, or any real process. It removes nothing outside the sandbox.
+#
+# Run:  bash scripts/tests/test_worktree_gc_completed.sh   (exit 0 = all pass, 1 = a failure)
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+GC="${ROOT}/scripts/worktree-gc.sh"
+[ -f "$GC" ] || { echo "FATAL: script not found at ${GC}"; exit 2; }
+
+pass=0
+fail=0
+note_pass() { pass=$((pass + 1)); }
+note_fail() { fail=$((fail + 1)); printf 'CASE FAILED: %s\n' "$1"; }
+
+SANDBOX="$(mktemp -d)"
+cleanup() {
+  # kill any lingering in-use stub process, then drop the sandbox.
+  if [ -n "${INUSE_PID:-}" ]; then kill "$INUSE_PID" 2>/dev/null || true; fi
+  rm -rf "$SANDBOX"
+}
+trap cleanup EXIT
+
+ORIGIN="${SANDBOX}/origin.git"
+CLONE="${SANDBOX}/clone"
+WTROOT="${CLONE}/.claude/worktrees"   # mimic the real layout: worktrees under the clone
+
+export GIT_AUTHOR_NAME=t GIT_AUTHOR_EMAIL=t@t GIT_COMMITTER_NAME=t GIT_COMMITTER_EMAIL=t@t
+
+# --- build a bare origin with a `main`, then a clone tracking it --------------------------
+git init -q --bare "$ORIGIN"
+git clone -q "$ORIGIN" "$CLONE" 2>/dev/null   # ignore the benign "empty repository" notice
+( cd "$CLONE"
+  git checkout -q -b main 2>/dev/null || git checkout -q main
+  echo seed > seed.txt; git add seed.txt; git commit -qm seed
+  git push -q origin main
+)
+mkdir -p "$WTROOT"
+
+# add_wt <name> <branch> : create a worktree on a NEW branch off main.
+add_wt() { git -C "$CLONE" worktree add -q -b "$2" "${WTROOT}/$1" main; }
+
+# commit_in <name> <msg> : add a commit inside a worktree.
+commit_in() { ( cd "${WTROOT}/$1" && echo "$2" >> file.txt && git add file.txt && git commit -qm "$2" ); }
+
+# push_wt <name> <branch> : push the worktree branch to origin (so it has NO unpushed commits).
+push_wt() { git -C "${WTROOT}/$1" push -q -u origin "$2"; }
+
+# run the broom; capture combined output into a global (rc is not asserted here).
+run_gc() {  # run_gc <args...>
+  set +e
+  GC_OUT="$(bash "$GC" --main "$CLONE" --root "$WTROOT" --base origin/main "$@" 2>&1)"
+  set -e
+}
+# helper assertions over the last run's output
+out_has()    { printf '%s\n' "$GC_OUT" | grep -qF "$1"; }
+wt_exists()  { [ -d "${WTROOT}/$1" ]; }
+
+# --------------------------------------------------------------------------- #
+# Fixtures (each on its own NEW branch off main):
+#   completed-wf   : wf_-named, 1 pushed commit, clean        → COMPLETED-PUSHED (eligible)
+#   completed-human: feat/-named, 1 pushed commit, clean      → not-merged-not-workflow (KEEP)
+#   dirty-wf       : wf_-named, pushed commit + untracked file → dirty (KEEP)
+#   unpushed-wf    : wf_-named, 1 LOCAL-only commit            → unpushed=1 (KEEP)
+#   merged-wf      : wf_-named, commit merged into origin/main → MERGED (always safe)
+# --------------------------------------------------------------------------- #
+add_wt completed-wf    wf_completed-001
+commit_in completed-wf "work"; push_wt completed-wf wf_completed-001
+
+add_wt completed-human feat/human-feature
+commit_in completed-human "work"; push_wt completed-human feat/human-feature
+
+add_wt dirty-wf        wf_dirty-002
+commit_in dirty-wf "work"; push_wt dirty-wf wf_dirty-002
+echo scratch > "${WTROOT}/dirty-wf/untracked.tmp"      # make it dirty (untracked)
+
+add_wt unpushed-wf     wf_unpushed-003
+commit_in unpushed-wf "local-only"                      # committed but NEVER pushed
+
+add_wt merged-wf       wf_merged-004
+commit_in merged-wf "to-merge"; push_wt merged-wf wf_merged-004
+# merge that branch into origin/main so its HEAD becomes an ancestor of the base ref. The clone's
+# own `main` worktree is at $CLONE; merge there (fast-forward) and push, then refresh the
+# remote-tracking origin/main so the broom's `HEAD is-ancestor origin/main` test sees the merge.
+git -C "$CLONE" checkout -q main
+git -C "$CLONE" merge -q --no-edit wf_merged-004
+git -C "$CLONE" push -q origin main
+git -C "$CLONE" fetch -q origin
+
+# --------------------------------------------------------------------------- #
+# 1. WITHOUT --reclaim-completed: completed-wf is KEPT (not-merged-not-gone); default unchanged.
+# --------------------------------------------------------------------------- #
+run_gc --dry-run
+if out_has "not-merged-not-gone" && out_has "$WTROOT/completed-wf"; then note_pass; else
+  note_fail "default (no flag): completed-wf should be KEPT as not-merged-not-gone"; fi
+# and it must NOT appear as a safe COMPLETED-PUSHED removal.
+if printf '%s\n' "$GC_OUT" | grep -q 'COMPLETED-PUSHED'; then
+  note_fail "default (no flag): COMPLETED-PUSHED leaked without --reclaim-completed"; else note_pass; fi
+
+# --------------------------------------------------------------------------- #
+# 2. WITH --reclaim-completed (dry-run): completed-wf is COMPLETED-PUSHED (safe to remove)…
+# --------------------------------------------------------------------------- #
+run_gc --dry-run --reclaim-completed
+if printf '%s\n' "$GC_OUT" | grep -F "$WTROOT/completed-wf" | grep -q 'COMPLETED-PUSHED'; then note_pass; else
+  note_fail "reclaim-completed: completed-wf should be COMPLETED-PUSHED"; fi
+# …the human-named completed worktree is NOT (workflow-named only)…
+if out_has "not-merged-not-workflow" && out_has "$WTROOT/completed-human"; then note_pass; else
+  note_fail "reclaim-completed: feat/-named completed worktree should be not-merged-not-workflow (KEEP)"; fi
+# …dirty-wf is KEPT (dirty)…
+if printf '%s\n' "$GC_OUT" | grep -F "$WTROOT/dirty-wf" | grep -q 'dirty'; then note_pass; else
+  note_fail "reclaim-completed: dirty-wf should be KEPT (dirty)"; fi
+# …unpushed-wf is KEPT (unpushed)…
+if printf '%s\n' "$GC_OUT" | grep -F "$WTROOT/unpushed-wf" | grep -q 'unpushed='; then note_pass; else
+  note_fail "reclaim-completed: unpushed-wf should be KEPT (unpushed=…)"; fi
+# …merged-wf is MERGED (always safe, flag-independent).
+if printf '%s\n' "$GC_OUT" | grep -F "$WTROOT/merged-wf" | grep -q 'MERGED'; then note_pass; else
+  note_fail "reclaim-completed: merged-wf should be MERGED"; fi
+
+# --------------------------------------------------------------------------- #
+# 3. IN-USE guard: spawn a live process whose cwd is inside completed-wf, then --apply with
+#    --reclaim-completed. The tree MUST be KEPT (in use), and dirty/unpushed/human also kept.
+# --------------------------------------------------------------------------- #
+( cd "${WTROOT}/completed-wf" && exec sleep 30 ) &
+INUSE_PID=$!
+# give the kernel a moment to publish the child's cwd in /proc (poll, no fixed sleep).
+for _ in 1 2 3 4 5 6 7 8 9 10; do
+  cwd="$(readlink "/proc/${INUSE_PID}/cwd" 2>/dev/null || true)"
+  case "$cwd" in *"/completed-wf") break ;; esac
+done
+run_gc --apply --reclaim-completed
+# completed-wf still exists (kept: in use) …
+if wt_exists completed-wf; then note_pass; else note_fail "IN-USE: completed-wf removed despite a live process inside it"; fi
+# … and the broom logged it as in-use somewhere (SKIP or in-use keep).
+if printf '%s\n' "$GC_OUT" | grep -qiE 'in.?use'; then note_pass; else
+  note_fail "IN-USE: broom did not report completed-wf as in-use"; fi
+kill "$INUSE_PID" 2>/dev/null || true; wait "$INUSE_PID" 2>/dev/null || true; INUSE_PID=""
+
+# the human / dirty / unpushed trees must also have survived the --apply.
+if wt_exists completed-human; then note_pass; else note_fail "--apply: human-named worktree wrongly removed"; fi
+if wt_exists dirty-wf;        then note_pass; else note_fail "--apply: dirty worktree wrongly removed"; fi
+if wt_exists unpushed-wf;     then note_pass; else note_fail "--apply: unpushed worktree wrongly removed"; fi
+# the MERGED worktree IS removed by --apply (it was always safe).
+if wt_exists merged-wf; then note_fail "--apply: MERGED worktree was NOT removed"; else note_pass; fi
+
+# --------------------------------------------------------------------------- #
+# 4. APPLY actually reclaims the now-idle completed worktree (disk genuinely freed).
+# --------------------------------------------------------------------------- #
+run_gc --apply --reclaim-completed
+if wt_exists completed-wf; then note_fail "--apply (idle): completed-wf was NOT reclaimed"; else note_pass; fi
+
+# --------------------------------------------------------------------------- #
+# 5. STATIC: the load-bearing predicates are present in source (a refactor can't silently drop).
+# --------------------------------------------------------------------------- #
+if grep -q 'is_workflow_branch' "$GC"; then note_pass; else note_fail "is_workflow_branch removed from source"; fi
+if grep -q 'wt_in_use'          "$GC"; then note_pass; else note_fail "wt_in_use guard removed from source"; fi
+if grep -q 'COMPLETED-PUSHED'   "$GC"; then note_pass; else note_fail "COMPLETED-PUSHED token removed from source"; fi
+# the main checkout must never be a candidate — its self-test still passes.
+if bash "$GC" --dry-run-self-test >/dev/null 2>&1; then note_pass; else note_fail "worktree-gc.sh pure self-test failed"; fi
+
+# --------------------------------------------------------------------------- #
+echo ""
+echo "test_worktree_gc_completed: ${pass} passed, ${fail} failed."
+[ "$fail" -eq 0 ] || exit 1
+echo "test_worktree_gc_completed: OK — opt-in + workflow-named-only + keep-if-dirty/unpushed/in-use hold."

--- a/scripts/worktree-gc.sh
+++ b/scripts/worktree-gc.sh
@@ -3,6 +3,7 @@
 # Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
 #
 # worktree-gc.sh [--dry-run | --apply] [--root <dir>] [--main <path>] [--base <ref>]
+#                [--reclaim-completed]
 #
 # WHY: the Claude Code harness creates a fresh git worktree per agent under
 # `.claude/worktrees/` but NEVER auto-removes a finished agent's worktree. They pile up
@@ -28,9 +29,28 @@
 #       by the self-test. We also only ever consider worktrees physically under <root>
 #       (default the harness `.claude/worktrees/` dir): allow-list by location, not deny-list.
 #
+# COMPLETED-BUT-UNMERGED RECLAIM (--reclaim-completed; OFF by default — bead sq-h34dc):
+#   A *completed* workflow worktree is one whose agent finished and PUSHED its PR branch, but
+#   whose PR is not yet merged (and the branch not yet deleted on origin). Such a worktree is
+#   CLEAN and has NO unpushed commits, yet it fails (a) MERGED-or-GONE — so the default broom
+#   KEEPS it forever and it starves the disk (observed 2026-06-22: ~229G of these piled up,
+#   one 33G, until a manual prune). With --reclaim-completed the broom ALSO reclaims a worktree
+#   when ALL of:
+#     (b) CLEAN and (c) NO UNPUSHED COMMITS  — its work is already on origin, nothing to lose;
+#     (e) WORKFLOW-NAMED: its branch matches the harness pattern (wf_* / agent-* / the
+#         `worktree-wf_*` / `worktree-agent-*` synthetic-branch forms) — a human-named branch
+#         is NEVER swept by this path; AND
+#     (f) NOT IN USE: no live process has its cwd or an open file handle inside the worktree
+#         (the load-bearing new guard — an in-flight agent that is momentarily clean+pushed
+#         between commits is KEPT). When the in-use probe cannot tell, it reports IN USE → KEEP.
+#   This path is OPT-IN precisely because it removes a tree whose PR may still be OPEN; the
+#   default predicate (MERGED-or-GONE) is unchanged, so a plain `worktree-gc.sh` is as
+#   conservative as before. `disk-guard.sh` passes --reclaim-completed through on its sweep.
+#
 # Any worktree that is locked, prunable (its dir is already gone), bare, detached with
-# unreachable HEAD, dirty, has unpushed commits, or whose branch is neither merged nor gone
-# is KEPT and reported with the reason it was kept. When in doubt, KEEP.
+# unreachable HEAD, dirty, has unpushed commits, is in use, or whose branch is neither merged
+# nor gone (and not an eligible completed-workflow tree) is KEPT and reported with the reason
+# it was kept. When in doubt, KEEP.
 #
 # DEFAULT IS --dry-run: prints the safe-to-remove set with a per-worktree reason and a
 #   reclaimable-size estimate (du -sh of each safe dir + a total). Touches nothing.
@@ -50,6 +70,9 @@
 #   scripts/worktree-gc.sh                      # dry-run (default): list safe-to-remove + size
 #   scripts/worktree-gc.sh --apply              # actually remove the safe set, then prune
 #   scripts/worktree-gc.sh --base origin/main   # change the "merged" base ref (default)
+#   scripts/worktree-gc.sh --reclaim-completed  # ALSO reclaim completed-but-unmerged workflow
+#                                               #   worktrees (clean+pushed+not-in-use); dry-run
+#   scripts/worktree-gc.sh --apply --reclaim-completed   # ... and actually remove them
 #   scripts/worktree-gc.sh --dry-run-self-test  # hermetic self-test (no git mutation)
 set -euo pipefail
 
@@ -86,6 +109,23 @@ under_root() {
   case "$p/" in
     "$root"/*) return 0 ;;
     *)         return 1 ;;
+  esac
+}
+
+# is_workflow_branch <branch>
+#   True (0) iff <branch> is a harness-created workflow/agent branch — the only branches the
+#   completed-but-unmerged reclaim (--reclaim-completed) may sweep. Pure string match (no git,
+#   no fs) so it is unit-testable. Covers the live shapes the harness produces:
+#     wf_<id> / agent-<id>                       (a real PR branch named for the workflow)
+#     worktree-wf_<id> / worktree-agent-<id>     (the synthetic per-worktree branch git creates
+#                                                  when the harness does not name one itself)
+#   A human-authored branch (feat/…, fix/…, ci/…, or a bare bead-id branch) is NOT matched and
+#   is therefore NEVER eligible for the completed-reclaim path — only MERGED-or-GONE removes it.
+is_workflow_branch() {
+  local b="$1"
+  case "$b" in
+    wf_*|agent-*|worktree-wf_*|worktree-agent-*) return 0 ;;
+    *)                                           return 1 ;;
   esac
 }
 
@@ -155,12 +195,56 @@ wt_head_reachable_from_remote() {
     | grep -q .
 }
 
-# classify_reason <wt> <base> : echo a single token describing the SAFE basis, or a KEEP
-# reason. Exit 0 ⇒ safe to remove; exit 1 ⇒ keep. This is the predicate in one place.
-#   safe tokens : MERGED  | BRANCH-GONE
-#   keep  tokens: dirty | unpushed=<n> | detached-unreachable | not-merged-not-gone | unreadable
+# wt_in_use <wt> : 0 (IN USE) iff a live process appears to be using the worktree. This is the
+# load-bearing guard for the completed-reclaim path: an in-flight agent that is momentarily
+# CLEAN and fully PUSHED (between commits) must not be reclaimed out from under it.
+#
+# Primary mechanism: a `/proc/<pid>/cwd` scan — portable (no external tool), and the cwd of a
+# running agent shell is the single most reliable "this tree is live" signal (the harness runs
+# each agent WITH its worktree as cwd). We resolve <wt> to its real path and report IN USE if
+# any process's cwd resolves to <wt> or a path strictly beneath it.
+# Fallback: if /proc is unavailable but `lsof` is, use `lsof +D <wt>` — broader still, it
+# catches any OPEN FILE HANDLE under the tree, not just a cwd. If NEITHER is available we cannot
+# tell ⇒ report IN USE (return 0) so we KEEP — a false "in use" only forgoes a reclaim (safe);
+# a false "idle" could delete a live tree, so the probe errs toward IN USE.
+wt_in_use() {
+  local wt="$1" real pid cwd creal
+  real="$(cd "$wt" 2>/dev/null && pwd -P)" || real="${wt%/}"
+  real="${real%/}"
+
+  if [ -d /proc ]; then
+    for pid in /proc/[0-9]*; do
+      cwd="$(readlink "$pid/cwd" 2>/dev/null)" || continue
+      [ -n "$cwd" ] || continue
+      cwd="${cwd%/}"
+      # exact match or strictly beneath the worktree (prefix-safe via the trailing slash).
+      if [ "$cwd" = "$real" ]; then return 0; fi
+      case "$cwd/" in "$real"/*) return 0 ;; esac
+      # also catch a process whose cwd is the symlinky <wt> form rather than its realpath.
+      creal="${wt%/}"
+      if [ "$cwd" = "$creal" ]; then return 0; fi
+      case "$cwd/" in "$creal"/*) return 0 ;; esac
+    done
+    return 1   # /proc scanned, no live cwd inside the tree ⇒ NOT in use
+  fi
+
+  # No /proc: fall back to lsof if present; else we cannot tell ⇒ conservatively IN USE.
+  if command -v lsof >/dev/null 2>&1; then
+    lsof +D "$real" >/dev/null 2>&1 && return 0
+    return 1
+  fi
+  return 0   # cannot determine ⇒ assume IN USE ⇒ KEEP
+}
+
+# classify_reason <wt> <base> <reclaim_completed> : echo a single token describing the SAFE
+# basis, or a KEEP reason. Exit 0 ⇒ safe to remove; exit 1 ⇒ keep. The predicate in one place.
+# <reclaim_completed> (0/1, default 0) enables the completed-but-unmerged workflow-worktree
+# path — when off, behaviour is identical to before (MERGED-or-GONE only).
+#   safe tokens : MERGED  | BRANCH-GONE | COMPLETED-PUSHED
+#   keep  tokens: dirty | unpushed=<n> | gone-but-head-local-only | in-use
+#                 | not-merged-not-gone | not-merged-not-workflow
 classify_reason() {
-  local wt="$1" base="$2" branch unpushed
+  local wt="$1" base="$2" reclaim_completed="${3:-0}" branch unpushed
   # (b) CLEAN — independent of everything else; a dirty tree is always KEEP.
   if ! wt_is_clean "$wt"; then echo "dirty"; return 1; fi
 
@@ -177,6 +261,18 @@ classify_reason() {
   if wt_branch_gone "$wt" "$branch"; then
     if wt_head_reachable_from_remote "$wt"; then echo "BRANCH-GONE"; return 0; fi
     echo "gone-but-head-local-only"; return 1
+  fi
+
+  # (e)+(f) COMPLETED-BUT-UNMERGED reclaim (opt-in): we reach here only when the tree is CLEAN
+  # and has NO unpushed commits (its work is safely on origin) but is neither merged nor gone —
+  # i.e. a finished agent whose PR is still open. Reclaim it iff explicitly enabled AND it is a
+  # harness workflow branch AND no live process is using it; otherwise KEEP as before.
+  if [ "$reclaim_completed" = "1" ]; then
+    if is_workflow_branch "$branch"; then
+      if wt_in_use "$wt"; then echo "in-use"; return 1; fi
+      echo "COMPLETED-PUSHED"; return 0
+    fi
+    echo "not-merged-not-workflow"; return 1
   fi
 
   echo "not-merged-not-gone"; return 1
@@ -213,6 +309,27 @@ self_test() {
   LBL="a path that merely shares a prefix is rejected"
   _expect_false under_root "${R}-evil/agent-x" "$R"
 
+  # is_workflow_branch: only harness wf_/agent- branches are eligible for completed-reclaim.
+  LBL="wf_ branch is a workflow branch"
+  _expect_true  is_workflow_branch "wf_d3d8da8f-85c-1"
+  LBL="agent- branch is a workflow branch"
+  _expect_true  is_workflow_branch "agent-foo"
+  LBL="synthetic worktree-wf_ branch is a workflow branch"
+  _expect_true  is_workflow_branch "worktree-wf_d3d8da8f-85c-1"
+  LBL="synthetic worktree-agent- branch is a workflow branch"
+  _expect_true  is_workflow_branch "worktree-agent-foo"
+  LBL="a feat/ branch is NOT a workflow branch (never completed-reclaimed)"
+  _expect_false is_workflow_branch "feat/sq-evb1-reason-el"
+  LBL="a bare bead-id branch is NOT a workflow branch"
+  _expect_false is_workflow_branch "sq-m3sm-mpc-routing"
+  LBL="an empty (detached) branch is NOT a workflow branch"
+  _expect_false is_workflow_branch ""
+
+  # wt_in_use: a real probe; assert it is callable and returns a clean 0/1 (we cannot
+  # deterministically assert the live-process state of an arbitrary path here). A nonexistent
+  # path has no process with a cwd inside it ⇒ NOT in use (return 1) on a box with /proc.
+  if wt_in_use "/nonexistent/worktree/path"; then _ok "in-use probe returns (in-use)"; else _ok "in-use probe returns (idle)"; fi
+
   echo
   if [ "$fails" -eq 0 ]; then log "self-test PASSED"; return 0; fi
   die "self-test FAILED ($fails check(s))"
@@ -223,11 +340,13 @@ APPLY=0
 ROOT="$DEFAULT_ROOT"
 MAIN="$DEFAULT_MAIN"
 BASE="$DEFAULT_BASE"
+RECLAIM_COMPLETED=0
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --dry-run-self-test) self_test; exit 0 ;;
     --apply)             APPLY=1 ;;
     --dry-run)           APPLY=0 ;;
+    --reclaim-completed) RECLAIM_COMPLETED=1 ;;
     --root)              shift; [ "$#" -gt 0 ] || die "--root needs a value"; ROOT="$1" ;;
     --root=*)            ROOT="${1#--root=}" ;;
     --main)              shift; [ "$#" -gt 0 ] || die "--main needs a value"; MAIN="$1" ;;
@@ -235,7 +354,7 @@ while [ "$#" -gt 0 ]; do
     --base)              shift; [ "$#" -gt 0 ] || die "--base needs a value"; BASE="$1" ;;
     --base=*)            BASE="${1#--base=}" ;;
     -h|--help)           sed -n '2,60p' "$0"; exit 0 ;;
-    *)                   die "unknown argument: $1 (try --apply, --root, --main, --base, --dry-run-self-test, --help)" ;;
+    *)                   die "unknown argument: $1 (try --apply, --reclaim-completed, --root, --main, --base, --dry-run-self-test, --help)" ;;
   esac
   shift
 done
@@ -252,7 +371,7 @@ if ! git -C "$GIT_CTX" rev-parse --git-dir >/dev/null 2>&1; then
     || die "no git repository found (tried --main='$MAIN' and CWD)"
 fi
 log "enumerating worktrees from git context: $GIT_CTX"
-log "root=$ROOT  main(protected)=$MAIN  base(merged-ref)=$BASE  mode=$([ "$APPLY" -eq 1 ] && echo APPLY || echo dry-run)"
+log "root=$ROOT  main(protected)=$MAIN  base(merged-ref)=$BASE  mode=$([ "$APPLY" -eq 1 ] && echo APPLY || echo dry-run)  reclaim-completed=$([ "$RECLAIM_COMPLETED" -eq 1 ] && echo on || echo off)"
 
 # Confirm the base ref resolves (a typo'd --base would make NOTHING look merged → silent
 # under-removal, which is safe, but warn so the operator knows).
@@ -288,7 +407,7 @@ process_record() {
   if [ ! -d "$cur_path" ];     then log "KEEP  $cur_path  (path missing on disk)";       kept=$((kept+1)); return 0; fi
 
   local reason
-  if reason="$(classify_reason "$cur_path" "$BASE")"; then
+  if reason="$(classify_reason "$cur_path" "$BASE" "$RECLAIM_COMPLETED")"; then
     SAFE_DIRS+=("$cur_path")
     SAFE_REASON+=("$reason")
     SEEN_REASON_COUNT["$reason"]=$(( ${SEEN_REASON_COUNT["$reason"]:-0} + 1 ))
@@ -347,20 +466,35 @@ fi
 
 # --- --apply: remove the safe set, then prune --------------------------------------------
 log "--apply: removing ${#SAFE_DIRS[@]} safe worktree(s)..."
-removed=0; failed=0
-for wt in "${SAFE_DIRS[@]}"; do
+removed=0; failed=0; skipped_busy=0
+for i in "${!SAFE_DIRS[@]}"; do
+  wt="${SAFE_DIRS[$i]}"
+  reason="${SAFE_REASON[$i]}"
   # Re-assert the hard exclusion at the point of mutation (defence in depth — this can never
   # fire because main is dropped during enumeration, but if it ever did we abort, not delete).
   if is_protected_path "$wt" "$MAIN"; then
     die "refusing to remove protected main checkout: $wt"
   fi
+  # TOCTOU re-verify the completed-but-unmerged path: a tree that was clean+pushed+idle when we
+  # classified it could have been re-entered by a freshly-spawned agent between the scan and now.
+  # MERGED/BRANCH-GONE entries are immune (their work is already on origin), so we only re-check
+  # the COMPLETED-PUSHED set — KEEPing it if it has since gone dirty or in-use. Cheap insurance.
+  if [ "$reason" = "COMPLETED-PUSHED" ]; then
+    if ! wt_is_clean "$wt"; then
+      log "  SKIP (now dirty since scan, kept): $wt"; skipped_busy=$((skipped_busy+1)); continue
+    fi
+    if wt_in_use "$wt"; then
+      log "  SKIP (now in use since scan, kept): $wt"; skipped_busy=$((skipped_busy+1)); continue
+    fi
+  fi
   if git -C "$GIT_CTX" worktree remove --force "$wt" 2>/dev/null; then
-    log "  removed: $wt"; removed=$((removed+1))
+    log "  removed ($reason): $wt"; removed=$((removed+1))
   else
     log "  FAILED to remove (kept): $wt"; failed=$((failed+1))
   fi
 done
+[ "$skipped_busy" -eq 0 ] || log "skipped $skipped_busy completed-worktree(s) that became dirty/in-use after the scan (kept)."
 log "pruning stale worktree administrative entries..."
 git -C "$GIT_CTX" worktree prune -v 2>&1 | sed 's/^/  /' >&2 || true
-log "done: removed $removed, failed $failed, of ${#SAFE_DIRS[@]} safe candidate(s)."
+log "done: removed $removed, failed $failed, skipped-busy $skipped_busy, of ${#SAFE_DIRS[@]} safe candidate(s)."
 [ "$failed" -eq 0 ]


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** working on `jeswr/sparq`'s CI / scripts infrastructure. This PR was authored autonomously (Opus 4.8; flag for re-review when Fable returns). @jeswr runs multiple agents on one account.

## What & why (bead sq-h34dc)

`scripts/worktree-gc.sh`'s safe broom only removed **MERGED-or-GONE** worktrees. A *completed* workflow worktree — CLEAN, PR branch **pushed**, but the PR not yet merged and the branch not yet deleted on origin — fails that predicate, so the broom KEPT it forever. These lingered and starved disk (observed 2026-06-22: **~229G** of them piled up, one **33G**, until a manual full prune). `disk-guard.sh` delegates to the broom, so the per-tick guard inherited the gap.

## What I wired (where)

- **`scripts/worktree-gc.sh`** — new OPT-IN `--reclaim-completed` path. A worktree is reclaimed iff ALL of:
  - **CLEAN** + **NO unpushed commits** (its work is already on origin — nothing to lose);
  - **WORKFLOW-NAMED**: branch matches `wf_*` / `agent-*` / `worktree-wf_*` / `worktree-agent-*` (new pure `is_workflow_branch`). A human-named `feat/…`/`fix/…`/`ci/…`/bare-bead-id branch is **never** swept by this path;
  - **NOT IN USE**: new load-bearing `wt_in_use` probe — a `/proc/<pid>/cwd` scan (portable; `lsof +D` fallback) that reports IN USE if any live process's cwd (or open handle, via lsof) is inside the tree, and reports **IN USE when it cannot tell** (conservative: a false "in use" only forgoes a reclaim; a false "idle" could delete a live tree).
  - The default predicate (MERGED-or-GONE) is **unchanged** — a plain `worktree-gc.sh` is exactly as conservative as before.
  - `--apply` **re-verifies** clean + not-in-use at the point of mutation (TOCTOU insurance against an agent re-entering a tree between the scan and the removal).
- **`scripts/disk-guard.sh`** — passes `--reclaim-completed` through **by default** (`--no-reclaim-completed` to disable). Live worktrees are **doubly protected**: the harness `LOCK`s active worktrees (structural KEEP, before any predicate runs) **and** the in-use probe.
- **`scripts/tests/test_worktree_gc_completed.sh`** (new) — hermetic harness; builds **real** git repos + worktrees, spawns a **live in-use process** inside a candidate, and pins: opt-in, workflow-named-only, KEEP-if-dirty/unpushed/**in-use**, MERGED-still-removed, and that `--apply` genuinely reclaims an idle completed tree. 18 cases.
- **`scripts/tests/test_disk_guard.sh`** — +2 cases pinning the `--reclaim-completed` pass-through (default-on; `--no-reclaim-completed` omits it). 23 cases.
- **`.github/workflows/docs-quality.yml`** — wired `shellcheck worktree-gc.sh` + both new self-tests into the existing **`ci-scripts` GATING job** (name has no `advisory`/`informational` token → `ci-summary / gate` gates on it).

## Design decision (proceeded per standing rule; flagged for you to steer)

Completed-reclaim is **opt-in** in the library script (`worktree-gc.sh`) but **on by default** in `disk-guard.sh`'s per-tick delegation. Rationale: the bead's whole point is that the per-tick sweep MUST reclaim these or disk starves; the in-use guard + harness lock make a default-on per-tick reclaim safe. `--no-reclaim-completed` restores the old MERGED/GONE-only behaviour. If you'd prefer it opt-in at the disk-guard layer too, that's a one-line flip.

## Gates (local reproduction)

- `bash -n` + **shellcheck 0.9.0** clean on all 4 shell files; **actionlint 1.7.12** clean on `docs-quality.yml`; YAML `yaml.safe_load` valid.
- `worktree-gc.sh --dry-run-self-test` PASS; `disk-guard.sh --dry-run-self-test` PASS.
- `test_worktree_gc_completed.sh` **18/18** (stable over 5 runs — the in-use `/proc` race is polled, not slept); `test_disk_guard.sh` **23/23**.
- **Real end-to-end** dry-run against this box: the broom KEEPS the two live (`locked`) worktrees and the `feat/`-named completed tree (`not-merged-not-workflow`); reclaims nothing live.
- `check-privacy-claims.sh` OK; `check-no-perf-numbers.py` 0 findings (the 229G/33G are disk-capacity facts, not perf numbers).

**Gate aggregator:** new legs run inside the existing GATING `ci-scripts` job — they gate, and nothing is `if:`-skipped. The path-filter / heavy-Rust matrix is untouched (this is a CI/scripts-only PR).

Closes sq-h34dc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)