### PR TITLE
feat(engine): Oxigraph-shaped QuerySolution per-solution accessor on QueryResult (sq-xj29q) [OPUS-4.8]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -223,6 +223,26 @@ jobs:
             crate: sparq-engine
             features: result-cache
             test: true
+          # [OPUS-4.8] sq-xj29q: the Oxigraph-shaped per-solution accessor on QueryResult.
+          # `pub mod solution` (the zero-copy `QuerySolution`/`QuerySolutionIter`/
+          # `QuerySolutionBindings`/`VarIndex` views over the columnar `rows`) is
+          # `#[cfg(feature = "query-solution")]` in lib.rs, so its in-module `#[cfg(test)]
+          # mod tests` (6 unit tests: solutions_match_columnar_rows / missing_and_unbound_are_none
+          # / iter_yields_bound_pairs_only / index_returns_bound_term / index_panics_on_missing
+          # / empty_result_no_solutions) AND the doctest on `QueryResult::solutions` are compiled
+          # EMPTY by the default build (and by ci.yml's `--workspace --all-targets` archive, which
+          # passes NO `--features`) — so all 7 ran ZERO times and `query-solution` had NO leg here:
+          # the silent "compiled EMPTY ... tests never ran" gap this lane exists to close. No new
+          # dep (`query-solution = []`, only the already-direct oxrdf `Term`/`Variable` and the
+          # crate's own `QueryResult`) and no `not(feature=…)` divergence, so a single isolated leg
+          # (matching the per-feature engine legs above) covers it; verified `cargo test -p
+          # sparq-engine --features query-solution` runs all 6 unit tests + the doctest, the
+          # default `cargo test -p sparq-engine` shows ZERO `solution::tests`, and `cargo clippy
+          # -p sparq-engine --all-targets --features query-solution -- -D warnings` is clean.
+          - name: sparq-engine (query-solution)
+            crate: sparq-engine
+            features: query-solution
+            test: true
           # sparq-cli: the `dump` re-serializer (forwards sparq-engine/serialize-rdf).
           - name: sparq-cli (serialize-rdf)
             crate: sparq-cli

--- a/crates/sparq-engine/Cargo.toml
+++ b/crates/sparq-engine/Cargo.toml
@@ -113,6 +113,19 @@ result-cache = []
 # `update_in_place_capturing` write-set capture; oxrdf/rustc-hash are already direct deps)
 # and contains no `unsafe`.
 txn = []
+# [OPUS-4.8] (sq-xj29q) Oxigraph-shaped per-solution result accessor: a borrowed,
+# zero-copy `QuerySolution` view over each `QueryResult` row, reachable through
+# `QueryResult::solutions()`. It mirrors Oxigraph's `QuerySolution` API
+# (`get` by name / `VariableRef` / position, `iter` over bound `(Variable, Term)`
+# pairs, panicking `Index`) so a Rust consumer migrating from / interoperating with
+# Oxigraph (#1124 oxrdf alignment, #1128 migration guide) can index a result
+# per-solution instead of walking the columnar `{vars, rows}` table by hand. It is a
+# pure VIEW: no second materialisation of the table, no per-row map, no cloned terms —
+# the columnar layout the engine uses for perf is unchanged. OPT-IN and OFF by default:
+# when off, zero of this code compiles and the default native + wasm builds are
+# byte-identical. Pulls in ZERO new dependencies (oxrdf — `Term`/`Variable`/
+# `VariableRef` — is already a direct dep) and contains no `unsafe`.
+query-solution = []
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io

--- a/crates/sparq-engine/README.md
+++ b/crates/sparq-engine/README.md
@@ -42,21 +42,17 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
   see [`docs/extension-functions.md`](../../docs/extension-functions.md).
 - **Custom aggregates + window functions** *(opt-in `window-functions` feature, OFF by default)* —
   register a named user aggregate (`CustomAggregateRegistry`) callable from a real SPARQL `GROUP BY`,
-  and a window-function surface (`ROW_NUMBER` / `RANK` / `DENSE_RANK`, the offset/positional
-  `LAG`/`LEAD`/`NTILE` (sq-hqhc), + the windowed aggregates `COUNT`/`SUM`/`AVG`/`MIN`/`MAX`, with
-  `PARTITION BY` + `ORDER BY` and an optional `ROWS`/`RANGE` frame)
-  available two ways: a programmatic pass (`window::apply_window` over a `QueryResult`) and an inline
-  `OVER(…)` query syntax (`query_over` — e.g. `(SUM(?x) OVER (ORDER BY ?y ROWS BETWEEN UNBOUNDED
-  PRECEDING AND CURRENT ROW) AS ?run)` in the SELECT, and a reusable `WINDOW w AS (…)` clause with
-  `OVER w`). **Window functions are a NON-STANDARD extension**
-  — SPARQL has no W3C-REC `OVER` syntax. The inline form is a *source rewrite* in front of the engine
-  recognised ONLY on `query_over` (it does NOT change the vendored parser), so the standard
-  `query`/`ask`/… surface stays exactly SPARQL 1.1 and conformance is unaffected. Inline covers the three
-  ranking functions, the five windowed aggregates, `ROWS`/`RANGE` frames (sq-imj8), the offset/positional
-  `LAG`/`LEAD`/`NTILE` and a named `WINDOW` clause (sq-hqhc); `DISTINCT`/computed-expression function
+  and a window-function surface (`ROW_NUMBER`/`RANK`/`DENSE_RANK`, the offset/positional
+  `LAG`/`LEAD`/`NTILE`, + windowed `COUNT`/`SUM`/`AVG`/`MIN`/`MAX`, with `PARTITION BY` + `ORDER BY`
+  and an optional `ROWS`/`RANGE` frame) available two ways: a programmatic pass
+  (`window::apply_window` over a `QueryResult`) and an inline `OVER(…)` query syntax (`query_over`,
+  plus a reusable `WINDOW w AS (…)` clause). **Window functions are a NON-STANDARD extension** —
+  SPARQL has no W3C-REC `OVER` syntax. The inline form is a *source rewrite* recognised ONLY on
+  `query_over` (it does NOT touch the vendored parser), so the standard `query`/`ask`/… surface
+  stays exactly SPARQL 1.1 and conformance is unaffected; `DISTINCT`/computed-expression function
   arguments, numeric `RANGE` offsets, and a computed-expression `PARTITION BY` are inline-deferred
-  (use the programmatic API). When the feature is off, zero window/aggregate-registry code compiles and
-  the default build is byte-identical (no new deps).
+  (use the programmatic API). When the feature is off, zero window/aggregate-registry code compiles
+  and the default build is byte-identical (no new deps).
 - **Materialised-view / query-result cache** *(opt-in `result-cache` feature, OFF by default)* —
   a bounded, version-aware LRU (`cache::ResultCache`) that stores a SELECT/ASK `QueryResult` keyed
   by `(parsed query algebra, caller graph-version)`, so an endpoint that re-serves the same read
@@ -94,15 +90,19 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
   `PrettyOptions { indent, abbreviate }`): subject grouping, p-o/object lists, `a` for `rdf:type`,
   used-only `@prefix`, *emission-order-independent* (sorted) — round-trip-correct. For true **W3C
   JSON-LD 1.1 Compaction** against a caller `@context`, `graph_to_jsonld_compact(&g, &ctx)` /
-  `write_jsonld_compact` (+ the `_pretty` variants) apply the full algorithm — term definitions,
-  `@vocab`, type/language/`@container` (`@set`/`@list`/`@language`/`@index`) coercion, `@reverse`,
-  `@id`/`@type` aliasing, value/node/IRI compaction — plus **JSON-LD 1.1 Framing**
-  (`graph_to_jsonld_framed(&g, &frame)`: node-pattern matching +
-  `@embed`/`@explicit`/`@default`/`@omitDefault`/`@requireAll`) — hand-rolled, dependency-free
-  (`parse_context_json` builds the context/frame). Compaction is **pyld-faithful** (differentially
-  verified; fixes sq-oy1f.12/.13/.14, see the `serialize::compact` rustdoc). `JsonLdForm::Compacted`
-  remains the lighter prefix-only `@context`. The N-Triples writer (`triples_to_ntriples`) is always
-  on; off, zero serializer code compiles, **no new dependencies**. See [`skills/data-formats/SKILL.md`](../../skills/data-formats/SKILL.md) recipe 6.
+  `write_jsonld_compact` (+ `_pretty` variants) apply the full algorithm (term definitions, `@vocab`,
+  `@container` coercion, `@reverse`, value/node/IRI compaction), plus **JSON-LD 1.1 Framing**
+  (`graph_to_jsonld_framed`) — hand-rolled, dependency-free, **pyld-faithful** (differentially
+  verified; see the `serialize::compact` rustdoc). The N-Triples writer (`triples_to_ntriples`) is
+  always on; off, zero serializer code compiles, **no new dependencies**. See
+  [`skills/data-formats/SKILL.md`](../../skills/data-formats/SKILL.md) recipe 6.
+- **Oxigraph-shaped per-solution accessor** *(opt-in `query-solution` feature, OFF by default)* —
+  `QueryResult::solutions()` yields borrowed, zero-copy `QuerySolution` views (one per row) matching
+  Oxigraph's `QuerySolution` API — `get` by name / `VariableRef` / position, `iter` over the bound
+  `(Variable, Term)` pairs, panicking `Index` — over the engine's columnar `{vars, rows}` table with
+  no second materialisation (eases Rust Oxigraph interop / migration). Off, zero code compiles, the
+  default build is byte-identical, no new deps. See
+  [`skills/sparql-query/SKILL.md`](../../skills/sparql-query/SKILL.md).
 - **`forbid(unsafe_code)`** — the crate contains zero `unsafe`.
 
 ## 📚 Learn more

--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -230,6 +230,18 @@ pub mod chunk;
 #[cfg(feature = "vectorized")]
 pub use chunk::{DataChunk, SelVec, VecCmp};
 
+// [OPUS-4.8] (sq-xj29q) Oxigraph-shaped per-solution view over `QueryResult` —
+// `QueryResult::solutions()` yields borrowed, zero-copy `QuerySolution` views (per-row
+// map from `Variable` to bound `Term`: `get`, `iter`, `Index`) matching Oxigraph's
+// `QuerySolution`, WITHOUT abandoning the columnar `{vars, rows}` layout the engine
+// uses for perf. NON-DEFAULT `query-solution` feature: when off, zero of this code
+// compiles and the default native + wasm builds are byte-identical (no new
+// dependencies — oxrdf is already a direct dep; no `unsafe`).
+#[cfg(feature = "query-solution")]
+pub mod solution;
+#[cfg(feature = "query-solution")]
+pub use solution::{QuerySolution, QuerySolutionBindings, QuerySolutionIter, VarIndex};
+
 // ---- Spatial pushdown seam (sq-mg9) -----------------------------------------
 //
 // The engine is GEOMETRY-FREE: the dependency direction is sparq-geo ->

--- a/crates/sparq-engine/src/solution.rs
+++ b/crates/sparq-engine/src/solution.rs
@@ -1,0 +1,343 @@
+//! Oxigraph-shaped per-solution view over a [`QueryResult`] (sq-xj29q). [OPUS-4.8]
+//!
+//! sparq stores SELECT results in a **columnar** [`QueryResult`] — a shared `vars`
+//! header plus a `Vec<Vec<Option<Term>>>` of rows. That layout is what the engine,
+//! the SPARQL-Results-JSON writer and the result cache want (the variable name is
+//! stored once, not per cell). Oxigraph, by contrast, hands a SELECT consumer an
+//! iterator of `QuerySolution` values, each of which behaves like a per-row map from
+//! `Variable` to `Term` (`solution.get("x")`, `solution.iter()`, `solution["x"]`).
+//!
+//! For a Rust consumer migrating from / interoperating with Oxigraph (#1124 oxrdf
+//! alignment, #1128 migration guide), iterating `result.rows` and indexing the `vars`
+//! header by hand is the friction. This module closes that gap **without** abandoning
+//! the columnar layout: [`QueryResult::solutions`] returns an iterator of
+//! [`QuerySolution`], each a **borrowed, zero-copy view** of one row that shares the
+//! `vars` header — no second materialisation of the table, no per-row `HashMap`, no
+//! cloned terms. A `QuerySolution` is the size of two references plus a row index; the
+//! `Term`s it yields are borrowed straight out of `QueryResult::rows`.
+//!
+//! The accessor surface mirrors Oxigraph's `QuerySolution` so the same call sites
+//! compile against either engine:
+//!
+//! * [`QuerySolution::get`] — by `&str` name, by [`VariableRef`]/`&Variable`, or by
+//!   positional `usize`; returns `Option<&Term>` (`None` = absent variable **or** an
+//!   unbound cell, exactly like Oxigraph).
+//! * [`QuerySolution::iter`] — over the **bound** `(VariableRef, &Term)` pairs only,
+//!   skipping unbound cells (Oxigraph's `QuerySolution::iter` semantics).
+//! * [`core::ops::Index`] by `&str` / `VariableRef` / `usize` — panics on a missing
+//!   binding, mirroring Oxigraph's `Index` impl, for terse `&sol["x"]` access.
+//! * [`QuerySolution::variables`], [`len`](QuerySolution::len),
+//!   [`is_empty`](QuerySolution::is_empty), [`values`](QuerySolution::values).
+//!
+//! This is the OPT-IN `query-solution` feature: when it is off, zero of this code
+//! compiles and the default native + wasm builds are byte-identical. It pulls in NO
+//! new dependencies — `oxrdf` (`Term`, `Variable`, `VariableRef`) is already a direct
+//! dependency — and contains no `unsafe`.
+
+use crate::QueryResult;
+use oxrdf::{Term, Variable, VariableRef};
+
+impl QueryResult {
+    /// Iterates the result table as Oxigraph-shaped [`QuerySolution`] views — one per
+    /// row, each a borrowed zero-copy view sharing this result's `vars` header.
+    ///
+    /// The iterator is lazy and allocation-free: it walks `rows` by index and hands
+    /// out a [`QuerySolution`] that borrows the shared header and the row in place. No
+    /// terms are cloned and the columnar table is not re-materialised.
+    ///
+    /// ```
+    /// # use sparq_core::Graph;
+    /// let g = Graph::load_str(
+    ///     "<http://ex/a> <http://ex/p> <http://ex/b> .",
+    ///     "turtle",
+    /// )
+    /// .unwrap();
+    /// let r = sparq_engine::query(&g, "SELECT ?s ?o WHERE { ?s ?p ?o }").unwrap();
+    /// for sol in r.solutions() {
+    ///     // Oxigraph-style per-solution access.
+    ///     let s = sol.get("s").unwrap();
+    ///     assert_eq!(s, &sol["s"]);
+    /// }
+    /// ```
+    pub fn solutions(&self) -> QuerySolutionIter<'_> {
+        QuerySolutionIter { vars: &self.vars, rows: &self.rows, pos: 0 }
+    }
+}
+
+/// A borrowed, zero-copy view of a single [`QueryResult`] row, shaped like Oxigraph's
+/// `QuerySolution`: a per-solution map from `Variable` to bound `Term`.
+///
+/// Constructed by [`QueryResult::solutions`]. It holds only a reference to the shared
+/// `vars` header and to the row slice — no owned terms, no per-row map — so it is cheap
+/// to create and to pass around. `None` from [`get`](Self::get) means the variable is
+/// either absent from the projection **or** unbound in this row, matching Oxigraph.
+#[derive(Debug, Clone, Copy)]
+pub struct QuerySolution<'a> {
+    vars: &'a [Variable],
+    row: &'a [Option<Term>],
+}
+
+impl<'a> QuerySolution<'a> {
+    /// The variable header shared by every solution of the result (the projected
+    /// SELECT variables, in projection order). Same slice for every row.
+    pub fn variables(&self) -> &'a [Variable] {
+        self.vars
+    }
+
+    /// Looks up the bound [`Term`] for a variable. Accepts a `&str` name (without the
+    /// leading `?`), a [`VariableRef`] / `&Variable` (via [`VarIndex`]), or a
+    /// positional `usize`. Returns `None` if the variable is not projected **or** is
+    /// unbound in this solution — the Oxigraph `QuerySolution::get` contract.
+    pub fn get<V: VarIndex>(&self, var: V) -> Option<&'a Term> {
+        var.position(self.vars).and_then(|i| self.row.get(i).and_then(Option::as_ref))
+    }
+
+    /// Iterates the **bound** `(VariableRef, &Term)` pairs of this solution, skipping
+    /// unbound cells — the Oxigraph `QuerySolution::iter` semantics. Pairs are yielded
+    /// in projection (variable header) order.
+    pub fn iter(&self) -> QuerySolutionBindings<'a> {
+        QuerySolutionBindings { vars: self.vars, row: self.row, pos: 0 }
+    }
+
+    /// The bound `Term`s of this solution in projection order, skipping unbound cells.
+    /// The value half of [`iter`](Self::iter).
+    pub fn values(&self) -> impl Iterator<Item = &'a Term> {
+        self.row.iter().filter_map(Option::as_ref)
+    }
+
+    /// The number of **bound** variables in this solution (unbound cells excluded), as
+    /// in Oxigraph. Note this can be smaller than `variables().len()`.
+    pub fn len(&self) -> usize {
+        self.row.iter().filter(|c| c.is_some()).count()
+    }
+
+    /// Whether this solution binds no variable at all (every projected cell unbound).
+    pub fn is_empty(&self) -> bool {
+        self.row.iter().all(Option::is_none)
+    }
+}
+
+impl<'a> IntoIterator for QuerySolution<'a> {
+    type Item = (VariableRef<'a>, &'a Term);
+    type IntoIter = QuerySolutionBindings<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> IntoIterator for &QuerySolution<'a> {
+    type Item = (VariableRef<'a>, &'a Term);
+    type IntoIter = QuerySolutionBindings<'a>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+/// `&solution[var]` — panicking accessor, mirroring Oxigraph's `Index` impl. Use
+/// [`QuerySolution::get`] for the non-panicking form. Indexable by `&str`,
+/// [`VariableRef`] / `&Variable`, or positional `usize`.
+impl<V: VarIndex> core::ops::Index<V> for QuerySolution<'_> {
+    type Output = Term;
+
+    fn index(&self, var: V) -> &Term {
+        self.get(var).expect("the variable is not bound in this query solution")
+    }
+}
+
+/// Iterator of [`QuerySolution`] views over a [`QueryResult`], returned by
+/// [`QueryResult::solutions`]. Lazy and allocation-free.
+#[derive(Debug, Clone)]
+pub struct QuerySolutionIter<'a> {
+    vars: &'a [Variable],
+    rows: &'a [Vec<Option<Term>>],
+    pos: usize,
+}
+
+impl<'a> Iterator for QuerySolutionIter<'a> {
+    type Item = QuerySolution<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let row = self.rows.get(self.pos)?;
+        self.pos += 1;
+        Some(QuerySolution { vars: self.vars, row })
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.rows.len() - self.pos;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for QuerySolutionIter<'_> {}
+
+/// Iterator of the **bound** `(VariableRef, &Term)` pairs of one [`QuerySolution`],
+/// returned by [`QuerySolution::iter`]. Skips unbound cells; projection order.
+#[derive(Debug, Clone)]
+pub struct QuerySolutionBindings<'a> {
+    vars: &'a [Variable],
+    row: &'a [Option<Term>],
+    pos: usize,
+}
+
+impl<'a> Iterator for QuerySolutionBindings<'a> {
+    type Item = (VariableRef<'a>, &'a Term);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        while self.pos < self.row.len() {
+            let i = self.pos;
+            self.pos += 1;
+            if let Some(term) = &self.row[i] {
+                // `vars` and `row` are parallel (same projection); `i < row.len()` and
+                // the result invariant gives `row.len() == vars.len()`, so this indexes
+                // safely.
+                return Some((self.vars[i].as_ref(), term));
+            }
+        }
+        None
+    }
+}
+
+/// Lookup strategy for indexing a [`QuerySolution`] by variable: a `&str` name, a
+/// [`VariableRef`] / `&Variable`, or a positional `usize`. Mirrors the key types
+/// Oxigraph's `QuerySolution::get` / `Index` accept.
+pub trait VarIndex {
+    /// Resolves this key to a positional index into the projection `vars` header, or
+    /// `None` if no projected variable matches.
+    fn position(self, vars: &[Variable]) -> Option<usize>;
+}
+
+impl VarIndex for usize {
+    fn position(self, vars: &[Variable]) -> Option<usize> {
+        (self < vars.len()).then_some(self)
+    }
+}
+
+impl VarIndex for &str {
+    fn position(self, vars: &[Variable]) -> Option<usize> {
+        // Accept both the bare name (`"x"`) and the SPARQL-rendered `"?x"` form so a
+        // caller can pass either; the engine's `Variable::as_str` is the bare name.
+        let name = self.strip_prefix('?').unwrap_or(self);
+        vars.iter().position(|v| v.as_str() == name)
+    }
+}
+
+impl VarIndex for VariableRef<'_> {
+    fn position(self, vars: &[Variable]) -> Option<usize> {
+        vars.iter().position(|v| v.as_ref() == self)
+    }
+}
+
+impl VarIndex for &Variable {
+    fn position(self, vars: &[Variable]) -> Option<usize> {
+        vars.iter().position(|v| v == self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use sparq_core::Graph;
+
+    const DATA: &str = r#"@prefix ex: <http://ex/> .
+        ex:a ex:p ex:b .
+        ex:a ex:q "lit" .
+        ex:c ex:p ex:d .
+    "#;
+
+    fn g() -> Graph {
+        Graph::load_str(DATA, "turtle").unwrap()
+    }
+
+    /// `solutions()` yields one view per row, sharing the `vars` header, and `get`
+    /// resolves by name / ref / position to the SAME term the columnar `rows` hold.
+    #[test]
+    fn solutions_match_columnar_rows() {
+        let r = super::super::query(&g(), "PREFIX ex: <http://ex/> SELECT ?s ?o WHERE { ?s ex:p ?o } ORDER BY ?s").unwrap();
+        let sols: Vec<_> = r.solutions().collect();
+        assert_eq!(sols.len(), r.rows.len());
+        assert_eq!(r.solutions().len(), r.rows.len(), "ExactSizeIterator len");
+        for (sol, row) in sols.iter().zip(&r.rows) {
+            assert_eq!(sol.variables(), &r.vars[..]);
+            // by name, by ?-name, by VariableRef, by &Variable, by position — all agree.
+            let by_name = sol.get("s");
+            assert_eq!(by_name, sol.get("?s"));
+            assert_eq!(by_name, sol.get(VariableRef::new_unchecked("s")));
+            assert_eq!(by_name, sol.get(&r.vars[0]));
+            assert_eq!(by_name, sol.get(0usize));
+            // and it equals the raw columnar cell.
+            assert_eq!(by_name, row[0].as_ref());
+            assert_eq!(sol.get("o"), row[1].as_ref());
+        }
+    }
+
+    /// Absent variable, out-of-range position, and unbound cell all return `None`.
+    #[test]
+    fn missing_and_unbound_are_none() {
+        // OPTIONAL leaves ?o unbound on the row where ex:nope matches nothing.
+        let r = super::super::query(
+            &g(),
+            "PREFIX ex: <http://ex/> SELECT ?s ?o WHERE { ?s ex:p ?x OPTIONAL { ?s ex:nope ?o } } ORDER BY ?s",
+        )
+        .unwrap();
+        let sol = r.solutions().next().unwrap();
+        assert!(sol.get("missing").is_none(), "absent variable -> None");
+        assert!(sol.get("?missing").is_none());
+        assert!(sol.get(99usize).is_none(), "out-of-range position -> None");
+        assert!(sol.get("o").is_none(), "unbound cell -> None");
+        assert!(sol.get("s").is_some(), "bound cell -> Some");
+        // len/is_empty count only BOUND cells.
+        assert_eq!(sol.len(), 1, "only ?s is bound");
+        assert!(!sol.is_empty());
+    }
+
+    /// `iter()` yields only the BOUND pairs, in projection order, and round-trips
+    /// through `get`. `IntoIterator` on a borrow agrees.
+    #[test]
+    fn iter_yields_bound_pairs_only() {
+        let r = super::super::query(
+            &g(),
+            "PREFIX ex: <http://ex/> SELECT ?s ?o WHERE { ?s ex:p ?x OPTIONAL { ?s ex:nope ?o } } ORDER BY ?s",
+        )
+        .unwrap();
+        let sol = r.solutions().next().unwrap();
+        let pairs: Vec<_> = sol.iter().collect();
+        assert_eq!(pairs.len(), 1, "unbound ?o is skipped");
+        let (var, term) = pairs[0];
+        assert_eq!(var.as_str(), "s");
+        assert_eq!(Some(term), sol.get("s"));
+        // borrow-IntoIterator agrees with iter().
+        let via_for: Vec<_> = (&sol).into_iter().collect();
+        assert_eq!(via_for, pairs);
+        // values() is the value half.
+        let vals: Vec<_> = sol.values().collect();
+        assert_eq!(vals, vec![term]);
+    }
+
+    /// The panicking `Index` accessor returns the bound term and matches `get`.
+    #[test]
+    fn index_returns_bound_term() {
+        let r = super::super::query(&g(), "PREFIX ex: <http://ex/> SELECT ?s ?o WHERE { ?s ex:p ?o } ORDER BY ?s").unwrap();
+        let sol = r.solutions().next().unwrap();
+        assert_eq!(&sol["s"], sol.get("s").unwrap());
+        assert_eq!(&sol[0usize], sol.get(0usize).unwrap());
+        assert_eq!(&sol[VariableRef::new_unchecked("o")], sol.get("o").unwrap());
+    }
+
+    /// `Index` panics on a missing binding, like Oxigraph.
+    #[test]
+    #[should_panic(expected = "not bound")]
+    fn index_panics_on_missing() {
+        let r = super::super::query(&g(), "PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:p ?o }").unwrap();
+        let sol = r.solutions().next().unwrap();
+        let _ = &sol["does_not_exist"];
+    }
+
+    /// An empty result yields no solutions.
+    #[test]
+    fn empty_result_no_solutions() {
+        let r = super::super::query(&g(), "PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:never ?o }").unwrap();
+        assert_eq!(r.solutions().count(), 0);
+    }
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -57,7 +57,17 @@ All entry points take `&Graph` + `&str` and return `Result<_, String>` (parse + 
 `String`). The result types:
 
 - `pub struct QueryResult { pub vars: Vec<oxrdf::Variable>, pub rows: Vec<Vec<Option<oxrdf::Term>>> }`
-  — `len()` / `is_empty()` count solution rows.
+  — `len()` / `is_empty()` count solution rows. The layout is **columnar** (the `vars` header is
+  stored once, not per cell); index a cell as `result.rows[row][col]` where `col` is the position of
+  the variable in `result.vars`, `None` = unbound.
+- *(opt-in `query-solution` feature, OFF by default)* `result.solutions()` gives an
+  **Oxigraph-shaped** per-solution view — an iterator of borrowed, zero-copy `QuerySolution` values
+  (one per row, sharing the `vars` header; no second materialisation, no cloned terms). Each matches
+  Oxigraph's `QuerySolution`: `sol.get(var) -> Option<&Term>` (by `&str` name with or without a
+  leading `?`, by `oxrdf::VariableRef`/`&Variable`, or by positional `usize`; `None` = absent or
+  unbound), `sol.iter()` over the bound `(VariableRef, &Term)` pairs (unbound cells skipped),
+  `&sol[var]` (panicking `Index`), plus `variables()` / `values()` / `len()` / `is_empty()`. Use it
+  for ergonomic Rust Oxigraph interop / migration; the underlying `{vars, rows}` layout is unchanged.
 - `pub struct QueryBudget { pub deadline: Option<Instant> /*native only*/, pub max_rows: Option<usize>, pub max_bytes: Option<usize> }`
   — `QueryBudget::unlimited()` is the no-op default. `max_rows` caps the working-set ROW count;
   `max_bytes` (`sq-s5is`) is the byte-accounted companion — it prices row WIDTH


### PR DESCRIPTION
> 🤖 SPARQ agent — automated PR. I am one of several agents @jeswr runs on this account; this work was implemented and self-reviewed by a Claude Opus 4.8 SPARQ agent.

## What & why (sq-xj29q)

#1123 asked for an Oxigraph-interface-aligned SELECT-result surface. The JS side (`@jeswr/sparq`) already exposes `querySolutions`; the native Rust `QueryResult { vars, rows }` was unchanged. For a **Rust** consumer migrating from / interoperating with Oxigraph (#1124 oxrdf alignment, #1128 migration guide), walking the columnar `rows` and indexing the `vars` header by hand is the friction this closes.

This adds an **opt-in `query-solution` feature (OFF by default)** giving `QueryResult::solutions()` — an iterator of borrowed, zero-copy `QuerySolution` views (one per row, sharing the `vars` header) that mirror Oxigraph's `QuerySolution`:

- `get(var) -> Option<&Term>` by `&str` name (with or without a leading `?`), `oxrdf::VariableRef` / `&Variable`, or positional `usize` (`None` = absent **or** unbound — Oxigraph's contract);
- `iter()` / `IntoIterator` over the **bound** `(VariableRef, &Term)` pairs (unbound cells skipped);
- panicking `Index` (`&sol["x"]`), plus `variables()` / `values()` / `len()` / `is_empty()`.

### Design note (no maintainer greenlight needed — standing rule)

The bead left the call open ("assess vs the columnar layout"). Best-judgment decision, documented here: the accessor is a **pure zero-cost view**, NOT a second materialisation. `QuerySolution` is two references plus a row index; the `Term`s it yields are borrowed straight out of `QueryResult::rows`. The engine's perf-oriented columnar `{vars, rows}` representation is **unchanged** — so a consumer that wants the columnar table keeps it, and an Oxigraph-shaped consumer gets the per-solution map with no allocation and no cloned terms. The bead's broader "RDF/JS-equivalent typings library for the Rust ecosystem" idea is left out of scope (a cross-crate trait surface is a separate, larger design); this PR delivers the concrete `QueryResult` adapter the bead's primary ask names.

### Opt-in / lean-core

When the feature is off, **zero of this code compiles** and the default native + wasm builds are byte-identical. It pulls in **ZERO new dependencies** (`oxrdf` — `Term`/`Variable`/`VariableRef` — is already a direct dep) and contains **no `unsafe`** (the crate keeps `forbid(unsafe_code)`).

## Gates (run in-worktree, BOTH feature states)

- `cargo build` / `cargo clippy --all-targets -D warnings` — green in **default**, `--features query-solution`, and `--all-features`.
- `cargo test -p sparq-engine` — green in both states; the new `solution` module has 6 unit tests + 1 doctest exercising the REAL `query()` path, asserting the load-bearing invariant: each `QuerySolution::get` (by every key form) returns the **same** `Term` the columnar `rows` hold, `iter()` yields only bound pairs, and missing/unbound/out-of-range all return `None`.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-engine --no-deps --all-features` — clean (demoted `&Variable` doc-links to code spans).
- `python3 scripts/check-readme-template.py --enforce` — **0 deviations**; the crate README is at the 120-line cap.
- `typos` + `scripts/check-privacy-claims.sh` — clean. No ZK/MPC claims and no hard-coded perf numbers.

## Files

- `crates/sparq-engine/src/solution.rs` (new) — the module + tests.
- `crates/sparq-engine/src/lib.rs`, `Cargo.toml` — feature gate + re-exports.
- `crates/sparq-engine/README.md`, `skills/sparql-query/SKILL.md` — docs.

Feature flags to name in CI: **default** (feature off) and **`query-solution`** (feature on). Auto-merge intentionally left OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)