### PR TITLE
feat(sparq-trust): claim-level trustsSourceFor admission form — closes the acp:vc gap (sq-pfae.4)

### DIFF
--- a/crates/sparq-trust/README.md
+++ b/crates/sparq-trust/README.md
@@ -53,11 +53,13 @@ view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
 
 - **The minimal `trust:` ontology** (`vocab`) — the 10-term core (`TrustPolicy`, `TrustRule`,
   `trustsSourceFor`, `source`, `forShape`, `Source`, `issuerKey`, `scope`, `freshWithin`,
-  `admitted`) + `issuerDid` + the one `forPredicate → forShape` desugaring. Published as Turtle
+  `admitted`) + `issuerDid` + the `forPredicate → forShape` desugaring. Published as Turtle
   ([`trust.ttl`](ontologies/trust/trust.ttl), semantics in [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md));
   a sync test pins it to the Rust constants. **All `trust:` IRIs are NON-STANDARD** — a WG would rehome them.
 - **Fail-closed policy parsing** (`policy`) — a trust policy not presented through the
-  Control-gated channel admits nothing (a type-level `ControlGate`).
+  Control-gated channel admits nothing (a type-level `ControlGate`). Accepts the reified
+  `trust:TrustRule` form AND the claim-level `trust:trustsSourceFor` relational form (per-(source,
+  statement-type) trust — the compact replacement for ACP's type-only `acp:vc`, `sq-pfae.4`).
 - **The admission gate** (`admit`) — canonicalise (`sparq-canon` RDFC-1.0), verify the **checked**
   issuer signature over the commitment (`sparq-zk`, never a self-asserted triple), enforce
   statement-type scoping via a real SHACL shape (`sparq-shacl`), freshness, and the clear-WebID
@@ -70,10 +72,10 @@ view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
   `auth:ConditionalGrant` re-checked per request (shipped sq-0q7n path) — never frozen into the view.
 - **The invocation-binding gate** (`delegation`, `sq-l5og`) — verify a carried ZCAP/UCAN-style
   delegation chain (each hop a CHECKED delegator signature over delegator/delegate **keys** +
-  capability + expiry), enforce monotone attenuation (`child ⊆ parent`), and bind
-  **authenticated invoker == the chain's terminal delegate, key-proven per request** via a
-  fresh-challenge PoP. Folding each hop's `delegate_key` into the signed preimage defeats the
-  key-substitution stolen-chain replay; the forgery matrix runs end-to-end.
+  capability + expiry), enforce monotone attenuation (`child ⊆ parent`), and bind **authenticated
+  invoker == the chain's terminal delegate, key-proven per request** via a fresh-challenge PoP.
+  Folding each hop's `delegate_key` into the signed preimage defeats the key-substitution
+  stolen-chain replay; the forgery matrix runs end-to-end.
 - **DID issuer-key binding** (`did`, **opt-in `did` feature**, `sq-pfae.3`) — a rule may name its
   issuer by `trust:issuerDid` instead of `trust:issuerKey` hex. `DidKeyResolver` decodes a
   self-certifying `did:key` offline; `DidWebResolver` reads the key from a `did:web` document via a
@@ -88,32 +90,30 @@ view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
 - **Holder binding is the clear-WebID, non-anonymous degraded path** (`sq-wvne`):
   `credentialSubject == Session.agent` authenticates the WebID in the clear — documented, not
   silently "solved". Presentations stay linkable by requester identity. (Its materialise-time
-  composition, `sq-xc4y`, is RESOLVED by the static/dynamic split; the *clear-WebID* privacy
-  limitation is separate and remains.)
+  composition, `sq-xc4y`, is RESOLVED by the static/dynamic split; the *clear-WebID* limitation remains.)
 - **Issuer keys: operator-asserted by default; DID-bindable (opt-in, `sq-pfae.3`).** The default
   `trust:issuerKey` hex binding is the live forgery vector D′ (§3.3); the `did` feature binds it from
-  a `trust:issuerDid` instead, which **narrows** D′ but is no absolute trust anchor (`did:key` is
-  self-cert; `did:web` only as strong as host/TLS).
+  a `trust:issuerDid` instead, which **narrows** D′ but is no absolute anchor (`did:key` self-cert;
+  `did:web` only as strong as host/TLS).
 - **Delegation invocation is the clear-WebID, non-anonymous path too** (`sq-l5og`): the gate
   authenticates the invoker AS the terminal delegate's WebID in the clear — **not**
-  anonymous/unlinkable. The `delegate_key` binding defeats the key-substitution stolen-chain replay,
-  but **not** full non-replayability: the delegate key is only as trustworthy as the delegator key
-  that attests it (DID-bindable now via the `did` feature, `sq-pfae.3`; deep-chain *incremental*
-  revocation stays open). Full reasoning in the rustdoc.
+  anonymous/unlinkable. The `delegate_key` binding defeats the key-substitution stolen-chain replay
+  but **not** full non-replayability (the delegate key is only as trustworthy as the delegator key
+  that attests it; DID-bindable via the `did` feature; deep-chain *incremental* revocation stays
+  open — rustdoc has the full reasoning).
 - **Open problems respected as documented limitations:** `sq-tu4e` (no in-reasoner NAF;
   `revoked` is input-only) and `sq-wvne` (ZK privacy) are **out of PoC scope**; `sq-xc4y` is
   RESOLVED by the static/dynamic split; `sq-l5og` is **specified, enforced, and tested**.
 - **Strict additivity (G6):** with `sparq-solid`'s `trust-graph` feature OFF, the crate is not
-  compiled and `sparq-solid` behaves exactly as WAC/ACP do today.
+  compiled and `sparq-solid` behaves exactly as WAC/ACP do today (byte-identical).
 
 ## 📚 Learn more
 
 - The machine-readable vocabulary [`trust.ttl`](ontologies/trust/trust.ttl) and its
   [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md) normative two-stratum semantics note (`sq-pfae.2`).
-- The design record `research/solid-trust-graph-authz-design.md` (§6.0 the PoC spec; §7 the
-  honest limitations) — [issue #940](https://github.com/jeswr/sparq/issues/940).
-- The host crate: [`sparq-solid`](../sparq-solid/README.md) (the WAC/ACP substrate this extends);
-  `cargo doc -p sparq-trust --all-features` for the full module-level docs (incl. the `did` module).
+- The design record `research/solid-trust-graph-authz-design.md` (§6.0 PoC spec; §7 honest limits) —
+  [issue #940](https://github.com/jeswr/sparq/issues/940); the host crate
+  [`sparq-solid`](../sparq-solid/README.md). `cargo doc -p sparq-trust --all-features` for full docs.
 
 ## License
 

--- a/crates/sparq-trust/src/policy.rs
+++ b/crates/sparq-trust/src/policy.rs
@@ -2,8 +2,28 @@
 //!
 //! Parses a trust-policy RDF graph (authored in the **Control-gated channel**, the
 //! same trusted channel as `.acl`/`.acr` — design §3.2) into a `Vec<TrustRule>`.
-//! Each rule reifies one admission condition: `source` + `issuer_key` + `shape` +
+//! Each rule carries one admission condition: `source` + `issuer_key` + `shape` +
 //! `scope` + `fresh_within`.
+//!
+//! ## Two equivalent authoring forms (both → the SAME `Vec<TrustRule>`)
+//!
+//! - **Reified** (`trust:TrustRule`) — a rule node groups `trust:source` +
+//!   `trust:forShape`/`trust:forPredicate` + `trust:scope` + `trust:freshWithin` (+ key).
+//!   This keeps `trust:scope`/`trust:freshWithin` **per-rule**, so one source may be
+//!   trusted with different windows on different resources.
+//! - **Claim-level relational** (`trust:trustsSourceFor`) — the foundational primitive
+//!   (design §2.3.1): a `trust:Source` node carries
+//!   `trust:trustsSourceFor <shape-or-predicate>` directly, alongside its key +
+//!   `trust:scope` + `trust:freshWithin`. EACH `trustsSourceFor` statement is one rule;
+//!   the source's key/scope/freshness are **shared** across its statement-types. This is
+//!   the compact form that maps onto — and replaces — ACP's type-only, unimplemented
+//!   `acp:vc` matcher with *per-(source, statement-type)* trust (the `sq-pfae.4` gap).
+//!   The `trustsSourceFor` object is a `sh:NodeShape` node (carried like `forShape`) or a
+//!   predicate IRI (desugared like `forPredicate`).
+//!
+//! Both forms produce the identical `TrustRule` the admission gate consumes, so the gate,
+//! the DID-resolved key binding, and every soundness side-condition are unchanged: only
+//! the surface syntax differs. A graph may mix both.
 //!
 //! ## Fail-closed Control-gating (design §3.2 / §3.3 item 3)
 //!
@@ -133,11 +153,14 @@ impl std::error::Error for PolicyError {}
 /// [`ControlGate`] is required: a policy that did not arrive through the trusted
 /// channel cannot reach this function (§3.2, fail-closed).
 ///
-/// Each `trust:TrustRule` node must carry: `trust:source`, `trust:issuerKey`,
-/// exactly one of `trust:forShape` / `trust:forPredicate` (the latter desugared
-/// here), `trust:scope`, and `trust:freshWithin`. A rule missing any property is a
-/// hard [`PolicyError::IncompleteRule`] — a partially-specified rule never silently
-/// admits.
+/// Accepts BOTH authoring forms (see the module docs): each `trust:TrustRule` node must
+/// carry `trust:source`, `trust:issuerKey`, exactly one of `trust:forShape` /
+/// `trust:forPredicate` (the latter desugared here), `trust:scope`, and
+/// `trust:freshWithin`; and each `trust:Source` node bearing a
+/// `trust:trustsSourceFor <shape-or-predicate>` statement must carry `trust:issuerKey`,
+/// `trust:scope`, and `trust:freshWithin` (one rule per `trustsSourceFor` statement). A
+/// rule missing any required property is a hard [`PolicyError::IncompleteRule`] — a
+/// partially-specified rule never silently admits.
 pub fn parse_policy(policy: &[Triple], _gate: ControlGate) -> Result<Vec<TrustRule>, PolicyError> {
     parse_rules(policy, &operator_asserted_key)
 }
@@ -226,23 +249,139 @@ pub fn resolve_rule_keys(
 }
 
 fn parse_rules(policy: &[Triple], key_for: &KeyResolver) -> Result<Vec<TrustRule>, PolicyError> {
-    // Collect every node typed `trust:TrustRule`.
-    let mut rule_nodes: Vec<Term> = Vec::new();
+    let mut out: Vec<TrustRule> = Vec::new();
+
+    // Form A — the **reified** rule: a node typed `trust:TrustRule` grouping
+    // `source` + `forShape`/`forPredicate` + `scope` + `freshWithin` (+ key).
     for t in policy {
         if t.predicate.as_str() == vocab::RDF_TYPE {
             if let Term::NamedNode(o) = &t.object {
                 if o.as_str() == vocab::TRUST_RULE {
-                    rule_nodes.push(subject_term(&t.subject));
+                    out.push(parse_one_rule(&subject_term(&t.subject), policy, key_for)?);
                 }
             }
         }
     }
 
-    let mut out = Vec::with_capacity(rule_nodes.len());
-    for node in rule_nodes {
-        out.push(parse_one_rule(&node, policy, key_for)?);
+    // Form B — the **claim-level relational** form (the foundational `trustsSourceFor`
+    // primitive, design §2.3.1; the direct replacement for ACP's type-only `acp:vc`):
+    // a `trust:Source` node carries `trust:trustsSourceFor <shape-or-predicate>`
+    // alongside its key + `trust:scope` + `trust:freshWithin`. EACH `trustsSourceFor`
+    // statement on that source node is ONE admission rule (a source trusted for two
+    // statement-types yields two rules), all over the source's shared key/scope/freshness.
+    // The source node is BOTH the `trust:source` (the named attesting authority) and the
+    // qualifier-bearing subject — collapsing the rule reification into the source itself
+    // (design §2.3.2, the "fold `trust:source` into `trustsSourceFor`" compaction made
+    // concrete). A reified `trust:TrustRule` node is not a `trust:Source`, so the two
+    // forms never double-count the same rule.
+    for (source_node, shape_obj) in trusts_source_for_statements(policy) {
+        out.push(parse_claim_rule(&source_node, &shape_obj, policy, key_for)?);
     }
+
     Ok(out)
+}
+
+/// Collect every `(source, shape-object)` pair asserted by a `trust:trustsSourceFor`
+/// triple, in policy order — the claim-level statements (Form B). One rule is parsed per
+/// pair, so a source trusted for several statement-types produces several rules.
+fn trusts_source_for_statements(policy: &[Triple]) -> Vec<(Term, Term)> {
+    policy
+        .iter()
+        .filter(|t| t.predicate.as_str() == vocab::TRUSTS_SOURCE_FOR)
+        .map(|t| (subject_term(&t.subject), t.object.clone()))
+        .collect()
+}
+
+/// Parse one claim-level statement (Form B): a `source trust:trustsSourceFor shape_obj`
+/// pair, over the source node's shared key + `trust:scope` + `trust:freshWithin`. The
+/// source node's own IRI is the rule's `trust:source` (a blank-node source is rejected —
+/// a named attesting authority must have a stable identity to tag admitted facts with).
+/// `shape_obj` is the statement-type: a `sh:NodeShape` node (carry its closure, like
+/// `forShape`) OR a predicate IRI (desugar, like `forPredicate`). Fails closed exactly as
+/// [`parse_one_rule`]: any missing qualifier is a [`PolicyError::IncompleteRule`].
+fn parse_claim_rule(
+    source_node: &Term,
+    shape_obj: &Term,
+    policy: &[Triple],
+    key_for: &KeyResolver,
+) -> Result<TrustRule, PolicyError> {
+    let rule_id = || node_label(source_node);
+
+    // The source node IS the named attesting authority — it must be an IRI.
+    let Term::NamedNode(source) = source_node else {
+        return Err(PolicyError::IncompleteRule {
+            rule: rule_id(),
+            missing: "a named trust:Source (trustsSourceFor on a blank node is rejected)",
+        });
+    };
+
+    // The issuer key is read off the SAME source node (`trust:issuerKey` hex or
+    // `trust:issuerDid`), shared across every shape this source is trusted for.
+    let issuer_key = key_for(source_node, policy)?;
+
+    // `trust:scope` + `trust:freshWithin` qualify the source's trust (per-source here;
+    // the reified form keeps them per-rule). Both are mandatory — fail closed.
+    let scope = object_iri(source_node, vocab::SCOPE, policy).ok_or_else(|| {
+        PolicyError::IncompleteRule {
+            rule: rule_id(),
+            missing: "trust:scope",
+        }
+    })?;
+    let fresh_term = object_of(source_node, vocab::FRESH_WITHIN, policy).ok_or_else(|| {
+        PolicyError::IncompleteRule {
+            rule: rule_id(),
+            missing: "trust:freshWithin",
+        }
+    })?;
+    let fresh_lex = term_lexical(&fresh_term);
+    let fresh_within_secs =
+        parse_xsd_duration_secs(&fresh_lex).ok_or(PolicyError::BadDuration(fresh_lex))?;
+
+    let shape = shape_from_trusts_object(shape_obj, policy);
+
+    Ok(TrustRule {
+        source: source.clone(),
+        issuer_key,
+        shape,
+        scope,
+        fresh_within_secs,
+    })
+}
+
+/// Resolve a `trust:trustsSourceFor` object into a [`ShapeRef`]: a predicate IRI is
+/// desugared to the normative single-predicate node-shape (exactly the `forPredicate`
+/// rewrite — design §2.3.3), while a node naming a `sh:NodeShape` carries its closure of
+/// defining triples (exactly the `forShape` primitive). A bare IRI is treated as a
+/// predicate UNLESS the policy types it `sh:NodeShape`, in which case its shape closure is
+/// carried — so `trustsSourceFor <ageShape>` (with `<ageShape> a sh:NodeShape`) and
+/// `trustsSourceFor schema:age` both work.
+fn shape_from_trusts_object(obj: &Term, policy: &[Triple]) -> ShapeRef {
+    // A node explicitly typed `sh:NodeShape` is a shape: carry its closure (forShape path).
+    let is_node_shape = policy.iter().any(|t| {
+        subject_term(&t.subject) == *obj
+            && t.predicate.as_str() == vocab::RDF_TYPE
+            && matches!(&t.object, Term::NamedNode(n) if n.as_str() == vocab::SH_NODE_SHAPE)
+    });
+    if is_node_shape {
+        return ShapeRef {
+            root: obj.clone(),
+            triples: shape_closure(obj, policy),
+        };
+    }
+    // Otherwise an IRI object is a predicate: desugar it (forPredicate path).
+    if let Term::NamedNode(p) = obj {
+        let (root, triples) = vocab::desugar_for_predicate(p);
+        return ShapeRef {
+            root: shape_root_to_term(root),
+            triples,
+        };
+    }
+    // A blank-node object that is not typed sh:NodeShape: carry its closure anyway (an
+    // inline shape with no explicit type) so an inline `[ sh:targetSubjectsOf … ]` works.
+    ShapeRef {
+        root: obj.clone(),
+        triples: shape_closure(obj, policy),
+    }
 }
 
 fn parse_one_rule(
@@ -461,5 +600,196 @@ mod tests {
         assert_eq!(parse_xsd_duration_secs("garbage"), None);
         assert_eq!(parse_xsd_duration_secs("P"), None);
         assert_eq!(parse_xsd_duration_secs("P30"), None);
+    }
+
+    // --- the claim-level `trust:trustsSourceFor` relational form (Form B, sq-pfae.4) ---
+
+    use oxrdf::{Literal, NamedOrBlankNode};
+    use sparq_zk::sig::{public_key_to_hex, SecretKey};
+
+    const GOV: &str = "https://gov.example/issuer";
+    const SCHEMA_AGE: &str = "http://schema.org/age";
+    const SCHEMA_NAME: &str = "http://schema.org/name";
+    const RES: &str = "https://pod.ex/resourceX";
+
+    fn nn(s: &str) -> NamedNode {
+        NamedNode::new(s).unwrap()
+    }
+
+    fn key_hex() -> String {
+        public_key_to_hex(&SecretKey::from_seed(0xC0FFEE).public_key())
+    }
+
+    /// A `trust:Source` node carrying `n_shapes` `trustsSourceFor predicate` statements
+    /// plus a shared `issuerKey` + `scope` + `freshWithin` — the claim-level form.
+    fn source_trusts(source: &str, predicates: &[&str], with_key: bool) -> Vec<Triple> {
+        let s = || NamedOrBlankNode::NamedNode(nn(source));
+        let mut g = vec![Triple::new(
+            s(),
+            nn(vocab::RDF_TYPE),
+            Term::NamedNode(nn(vocab::SOURCE_CLASS)),
+        )];
+        for p in predicates {
+            g.push(Triple::new(
+                s(),
+                nn(vocab::TRUSTS_SOURCE_FOR),
+                Term::NamedNode(nn(p)),
+            ));
+        }
+        if with_key {
+            g.push(Triple::new(
+                s(),
+                nn(vocab::ISSUER_KEY),
+                Term::Literal(Literal::new_simple_literal(key_hex())),
+            ));
+        }
+        g.push(Triple::new(s(), nn(vocab::SCOPE), Term::NamedNode(nn(RES))));
+        g.push(Triple::new(
+            s(),
+            nn(vocab::FRESH_WITHIN),
+            Term::Literal(Literal::new_typed_literal(
+                "P30D",
+                nn("http://www.w3.org/2001/XMLSchema#duration"),
+            )),
+        ));
+        g
+    }
+
+    #[test]
+    fn trusts_source_for_predicate_parses_to_one_rule() {
+        let g = source_trusts(GOV, &[SCHEMA_AGE], true);
+        let rules = parse_policy(&g, ControlGate::assert_control_gated()).unwrap();
+        assert_eq!(rules.len(), 1, "one trustsSourceFor statement ⇒ one rule");
+        let r = &rules[0];
+        assert_eq!(
+            r.source.as_str(),
+            GOV,
+            "the source node IS the named source"
+        );
+        assert_eq!(r.scope.as_str(), RES);
+        assert_eq!(r.fresh_within_secs, 30 * 86_400);
+        // The predicate desugars to the normative single-predicate shape (forPredicate path).
+        assert!(
+            r.shape
+                .triples
+                .iter()
+                .any(|t| t.predicate.as_str() == vocab::SH_TARGET_SUBJECTS_OF
+                    && matches!(&t.object, Term::NamedNode(o) if o.as_str() == SCHEMA_AGE)),
+            "the trustsSourceFor predicate desugared to a sh:targetSubjectsOf shape"
+        );
+    }
+
+    #[test]
+    fn trusts_source_for_fans_out_one_rule_per_statement_type() {
+        // A source trusted for TWO statement-types yields TWO rules, sharing the key/scope.
+        let g = source_trusts(GOV, &[SCHEMA_AGE, SCHEMA_NAME], true);
+        let rules = parse_policy(&g, ControlGate::assert_control_gated()).unwrap();
+        assert_eq!(rules.len(), 2, "two trustsSourceFor statements ⇒ two rules");
+        assert!(rules.iter().all(|r| r.source.as_str() == GOV));
+        // Both desugared shapes are present (age and name), one per rule.
+        let targets: Vec<String> = rules
+            .iter()
+            .flat_map(|r| r.shape.triples.iter())
+            .filter(|t| t.predicate.as_str() == vocab::SH_TARGET_SUBJECTS_OF)
+            .filter_map(|t| match &t.object {
+                Term::NamedNode(o) => Some(o.as_str().to_string()),
+                _ => None,
+            })
+            .collect();
+        assert!(targets.contains(&SCHEMA_AGE.to_string()));
+        assert!(targets.contains(&SCHEMA_NAME.to_string()));
+    }
+
+    #[test]
+    fn trusts_source_for_node_shape_carries_its_closure() {
+        // trustsSourceFor a node EXPLICITLY typed sh:NodeShape carries the shape closure
+        // (the forShape path), not the desugaring.
+        let shape = "https://pod.ex/.acr#ageShape";
+        let s = || NamedOrBlankNode::NamedNode(nn(GOV));
+        let mut g = source_trusts(GOV, &[], true);
+        g.push(Triple::new(
+            s(),
+            nn(vocab::TRUSTS_SOURCE_FOR),
+            Term::NamedNode(nn(shape)),
+        ));
+        // Define the shape: a sh:NodeShape targeting subjects-of schema:age.
+        g.push(Triple::new(
+            NamedOrBlankNode::NamedNode(nn(shape)),
+            nn(vocab::RDF_TYPE),
+            Term::NamedNode(nn(vocab::SH_NODE_SHAPE)),
+        ));
+        g.push(Triple::new(
+            NamedOrBlankNode::NamedNode(nn(shape)),
+            nn(vocab::SH_TARGET_SUBJECTS_OF),
+            Term::NamedNode(nn(SCHEMA_AGE)),
+        ));
+        let rules = parse_policy(&g, ControlGate::assert_control_gated()).unwrap();
+        assert_eq!(rules.len(), 1);
+        assert!(
+            matches!(&rules[0].shape.root, Term::NamedNode(n) if n.as_str() == shape),
+            "the shape root is the named sh:NodeShape (forShape path), not a fresh blank node"
+        );
+        assert!(
+            rules[0]
+                .shape
+                .triples
+                .iter()
+                .any(|t| t.predicate.as_str() == vocab::SH_TARGET_SUBJECTS_OF),
+            "the node-shape closure is carried"
+        );
+    }
+
+    #[test]
+    fn trusts_source_for_missing_scope_is_incomplete_fail_closed() {
+        // Drop the scope triple → fail-closed IncompleteRule (never a silent admit).
+        let mut g = source_trusts(GOV, &[SCHEMA_AGE], true);
+        g.retain(|t| t.predicate.as_str() != vocab::SCOPE);
+        let err = parse_policy(&g, ControlGate::assert_control_gated());
+        assert!(
+            matches!(err, Err(PolicyError::IncompleteRule { missing, .. }) if missing.contains("scope")),
+            "a trustsSourceFor source with no scope is rejected fail-closed: {err:?}"
+        );
+    }
+
+    #[test]
+    fn trusts_source_for_missing_key_is_incomplete_fail_closed() {
+        let g = source_trusts(GOV, &[SCHEMA_AGE], false); // no issuerKey
+        let err = parse_policy(&g, ControlGate::assert_control_gated());
+        assert!(
+            matches!(err, Err(PolicyError::IncompleteRule { .. })),
+            "a trustsSourceFor source with no issuer key is rejected fail-closed: {err:?}"
+        );
+    }
+
+    #[test]
+    fn trusts_source_for_on_a_blank_node_is_rejected() {
+        // A blank-node source has no stable identity to tag admitted facts with.
+        let b = NamedOrBlankNode::BlankNode(oxrdf::BlankNode::new("src").unwrap());
+        let g = vec![
+            Triple::new(
+                b.clone(),
+                nn(vocab::TRUSTS_SOURCE_FOR),
+                Term::NamedNode(nn(SCHEMA_AGE)),
+            ),
+            Triple::new(
+                b.clone(),
+                nn(vocab::ISSUER_KEY),
+                Term::Literal(Literal::new_simple_literal(key_hex())),
+            ),
+            Triple::new(b.clone(), nn(vocab::SCOPE), Term::NamedNode(nn(RES))),
+            Triple::new(
+                b,
+                nn(vocab::FRESH_WITHIN),
+                Term::Literal(Literal::new_typed_literal(
+                    "P30D",
+                    nn("http://www.w3.org/2001/XMLSchema#duration"),
+                )),
+            ),
+        ];
+        let err = parse_policy(&g, ControlGate::assert_control_gated());
+        assert!(
+            matches!(err, Err(PolicyError::IncompleteRule { missing, .. }) if missing.contains("named")),
+            "trustsSourceFor on a blank-node source is rejected fail-closed: {err:?}"
+        );
     }
 }

--- a/crates/sparq-trust/tests/did_issuer_binding_e2e.rs
+++ b/crates/sparq-trust/tests/did_issuer_binding_e2e.rs
@@ -277,6 +277,59 @@ fn did_web_bound_issuer_grants_read_through_an_in_memory_document() {
 }
 
 #[test]
+fn claim_level_trusts_source_for_composes_with_a_did_key_bound_issuer() {
+    // The `sq-pfae.4` claim-level relational form (`<gov> trust:trustsSourceFor schema:age`)
+    // names its issuer by `trust:issuerDid` on the SAME source node — so the foundational
+    // primitive and the DID-resolved key binding (`sq-pfae.3`) compose: resolve_rule_keys
+    // binds the key, and the unchanged gate grants read end-to-end.
+    let (_sk, pk) = gov_key();
+    let did = did_key_for(&pk);
+    let s = || NamedOrBlankNode::NamedNode(iri(GOV_ISSUER));
+    let policy = vec![
+        Triple::new(
+            s(),
+            iri(vocab::RDF_TYPE),
+            Term::NamedNode(iri(vocab::SOURCE_CLASS)),
+        ),
+        Triple::new(
+            s(),
+            iri(vocab::TRUSTS_SOURCE_FOR),
+            Term::NamedNode(iri(SCHEMA_AGE)),
+        ),
+        Triple::new(
+            s(),
+            iri(vocab::ISSUER_DID),
+            Term::Literal(Literal::new_simple_literal(&did)),
+        ),
+        Triple::new(s(), iri(vocab::SCOPE), Term::NamedNode(iri(RESOURCE_X))),
+        Triple::new(
+            s(),
+            iri(vocab::FRESH_WITHIN),
+            Term::Literal(Literal::new_typed_literal(
+                "P30D",
+                iri("http://www.w3.org/2001/XMLSchema#duration"),
+            )),
+        ),
+    ];
+    let rules = resolve_rule_keys(
+        &policy,
+        &DidKeyResolver,
+        ControlGate::assert_control_gated(),
+    )
+    .unwrap();
+    assert_eq!(rules.len(), 1, "one trustsSourceFor statement ⇒ one rule");
+    assert_eq!(
+        rules[0].issuer_key, pk,
+        "the source's trust:issuerDid resolves to the gov verifying key"
+    );
+    let grants = run(&rules);
+    assert!(
+        read_granted(&grants, JESSE),
+        "the claim-level trustsSourceFor form + a did:key-bound issuer grants read end-to-end"
+    );
+}
+
+#[test]
 fn did_web_with_no_usable_key_rejects_the_policy() {
     let did = "did:web:gov.example";
     let url = DidWebResolver::<MapFetcher>::document_url("gov.example").unwrap();

--- a/crates/sparq-trust/tests/trusts_source_for_e2e.rs
+++ b/crates/sparq-trust/tests/trusts_source_for_e2e.rs
@@ -1,0 +1,292 @@
+//! End-to-end: the claim-level `trust:trustsSourceFor` relational policy form drives the
+//! SAME admission gate as the reified `trust:TrustRule` form — the `sq-pfae.4` core
+//! deliverable that closes the `acp:vc` gap (per-(source, statement-type) trust replacing
+//! ACP's type-only, unimplemented `acp:vc` matcher).
+//!
+//! It exercises the REAL admission path through a policy authored with the foundational
+//! relation (`<gov> trust:trustsSourceFor schema:age`): RDFC-1.0 commit → CHECKED issuer
+//! signature → SHACL statement-type scope → freshness → clear-WebID holder binding → N3
+//! merge with the `.acr` ABAC rule. The load-bearing invariant: **result-equivalence** —
+//! the `trustsSourceFor` policy admits and grants EXACTLY what the reified policy does.
+//!
+//! Adversarial forgery negatives (each MUST deny, mirroring sparq-solid's
+//! `acp_forged_*_in_acr_document_does_not_grant`): an UNTRUSTED issuer key, a tampered
+//! signature, a third-party (wrong-holder) credential, and an out-of-type laundered
+//! `acl:agent` triple under a source trusted only for `schema:age`. The claim-level form
+//! is NOT a weaker admission path: every soundness side-condition holds identically.
+//!
+//! [OPUS-4.8] sq-pfae.4 (issue #940 / gh-940). 🤖 SPARQ agent — trust-graph authz PoC.
+
+use oxrdf::{Literal, NamedNode, NamedOrBlankNode, Term, Triple};
+use sparq_trust::admit::{admit, PresentedCredential, Session};
+use sparq_trust::policy::{parse_policy, ControlGate, TrustRule};
+use sparq_trust::vocab;
+use sparq_trust::wire::derive_grants;
+use sparq_zk::commit::commit_triples;
+use sparq_zk::encode::salt_from_bytes;
+use sparq_zk::sig::{public_key_to_hex, PublicKey, SecretKey};
+
+const JESSE: &str = "https://jesse.ex/card#me";
+const MALLORY: &str = "https://mallory.ex/card#me";
+const GOV_ISSUER: &str = "https://gov.example/issuer";
+const SCHEMA_AGE: &str = "http://schema.org/age";
+const ACL_AGENT: &str = "http://www.w3.org/ns/auth/acl#agent";
+const RESOURCE_X: &str = "https://pod.ex/resourceX";
+const SALT_BYTES: [u8; 32] = [7u8; 32];
+const NOW: i64 = 1_700_000_000;
+const ISSUED_FRESH: i64 = NOW - 86_400;
+
+const ACR_ABAC_RULE: &str = r#"@prefix schema: <http://schema.org/> .
+@prefix math:   <http://www.w3.org/2000/10/swap/math#> .
+@prefix auth:   <https://sparq.dev/ns/auth#> .
+{ ?x schema:age ?y . ?y math:greaterThan 18 } => { ?x auth:read <https://pod.ex/resourceX> } .
+"#;
+
+fn iri(s: &str) -> NamedNode {
+    NamedNode::new(s).unwrap()
+}
+
+fn age_credential_graph(subject: &str, value: &str) -> Vec<Triple> {
+    vec![Triple::new(
+        NamedOrBlankNode::NamedNode(iri(subject)),
+        iri(SCHEMA_AGE),
+        Term::Literal(Literal::new_typed_literal(
+            value,
+            iri("http://www.w3.org/2001/XMLSchema#integer"),
+        )),
+    )]
+}
+
+fn gov_key() -> (SecretKey, PublicKey) {
+    let sk = SecretKey::from_seed(0xC0FFEE);
+    let pk = sk.public_key();
+    (sk, pk)
+}
+
+fn sign_graph(sk: &SecretKey, graph: &[Triple]) -> String {
+    let salt = salt_from_bytes(&SALT_BYTES);
+    let commitment = commit_triples(graph, salt).expect("credential graph commits");
+    sk.sign_commitment(&commitment.commitment)
+}
+
+fn fresh_cred(sk: &SecretKey, graph: Vec<Triple>) -> PresentedCredential {
+    let sig = sign_graph(sk, &graph);
+    PresentedCredential {
+        graph,
+        issuer_signature_hex: sig,
+        salt: SALT_BYTES,
+        issued_at_unix_secs: ISSUED_FRESH,
+        revoked: false,
+    }
+}
+
+fn session(agent: &str, now: i64) -> Session {
+    Session {
+        agent: iri(agent),
+        now_unix_secs: now,
+    }
+}
+
+/// The REIFIED form: a `trust:TrustRule` node grouping source/key/forPredicate/scope/fresh.
+fn reified_policy(issuer: &str, key: &PublicKey) -> Vec<Triple> {
+    let rule = iri("https://pod.ex/.acr#trustrule");
+    let s = || NamedOrBlankNode::NamedNode(rule.clone());
+    vec![
+        Triple::new(
+            s(),
+            iri(vocab::RDF_TYPE),
+            Term::NamedNode(iri(vocab::TRUST_RULE)),
+        ),
+        Triple::new(s(), iri(vocab::SOURCE), Term::NamedNode(iri(issuer))),
+        Triple::new(
+            s(),
+            iri(vocab::ISSUER_KEY),
+            Term::Literal(Literal::new_simple_literal(public_key_to_hex(key))),
+        ),
+        Triple::new(
+            s(),
+            iri(vocab::FOR_PREDICATE),
+            Term::NamedNode(iri(SCHEMA_AGE)),
+        ),
+        Triple::new(s(), iri(vocab::SCOPE), Term::NamedNode(iri(RESOURCE_X))),
+        Triple::new(
+            s(),
+            iri(vocab::FRESH_WITHIN),
+            Term::Literal(Literal::new_typed_literal(
+                "P30D",
+                iri("http://www.w3.org/2001/XMLSchema#duration"),
+            )),
+        ),
+    ]
+}
+
+/// The CLAIM-LEVEL form: the source node carries `trust:trustsSourceFor schema:age`
+/// directly, alongside its key + scope + freshWithin. The source IRI is `issuer`.
+fn claim_level_policy(issuer: &str, key: &PublicKey) -> Vec<Triple> {
+    let s = || NamedOrBlankNode::NamedNode(iri(issuer));
+    vec![
+        Triple::new(
+            s(),
+            iri(vocab::RDF_TYPE),
+            Term::NamedNode(iri(vocab::SOURCE_CLASS)),
+        ),
+        Triple::new(
+            s(),
+            iri(vocab::TRUSTS_SOURCE_FOR),
+            Term::NamedNode(iri(SCHEMA_AGE)),
+        ),
+        Triple::new(
+            s(),
+            iri(vocab::ISSUER_KEY),
+            Term::Literal(Literal::new_simple_literal(public_key_to_hex(key))),
+        ),
+        Triple::new(s(), iri(vocab::SCOPE), Term::NamedNode(iri(RESOURCE_X))),
+        Triple::new(
+            s(),
+            iri(vocab::FRESH_WITHIN),
+            Term::Literal(Literal::new_typed_literal(
+                "P30D",
+                iri("http://www.w3.org/2001/XMLSchema#duration"),
+            )),
+        ),
+    ]
+}
+
+fn parse(policy: &[Triple]) -> Vec<TrustRule> {
+    parse_policy(policy, ControlGate::assert_control_gated()).expect("policy parses")
+}
+
+fn read_granted(grants: &[Triple], subject: &str) -> bool {
+    grants.iter().any(|t| {
+        t.predicate.as_str() == "https://sparq.dev/ns/auth#read"
+            && matches!(&t.subject, NamedOrBlankNode::NamedNode(n) if n.as_str() == subject)
+            && matches!(&t.object, Term::NamedNode(o) if o.as_str() == RESOURCE_X)
+    })
+}
+
+fn run(cred: &PresentedCredential, rules: &[TrustRule], sess: &Session) -> Vec<Triple> {
+    let admitted = admit(cred, rules, sess, &iri(RESOURCE_X));
+    derive_grants(&admitted, ACR_ABAC_RULE).expect("derivation runs")
+}
+
+// --- the load-bearing invariant: result-equivalence with the reified form ----
+
+#[test]
+fn claim_level_form_grants_read_identically_to_the_reified_form() {
+    let (sk, pk) = gov_key();
+    let cred = fresh_cred(&sk, age_credential_graph(JESSE, "25"));
+
+    let reified = parse(&reified_policy(GOV_ISSUER, &pk));
+    let claim = parse(&claim_level_policy(GOV_ISSUER, &pk));
+
+    // Both forms produce ONE rule with the SAME source/scope/freshness.
+    assert_eq!(reified.len(), 1);
+    assert_eq!(claim.len(), 1);
+    assert_eq!(reified[0].source, claim[0].source);
+    assert_eq!(reified[0].scope, claim[0].scope);
+    assert_eq!(reified[0].fresh_within_secs, claim[0].fresh_within_secs);
+    assert_eq!(reified[0].issuer_key, claim[0].issuer_key);
+
+    // And the end-to-end grant is IDENTICAL (result-equivalence).
+    assert!(
+        read_granted(&run(&cred, &reified, &session(JESSE, NOW)), JESSE),
+        "reified form grants read"
+    );
+    assert!(
+        read_granted(&run(&cred, &claim, &session(JESSE, NOW)), JESSE),
+        "claim-level trustsSourceFor form grants read — identical to the reified form"
+    );
+}
+
+// --- adversarial forgery negatives (each MUST deny) --------------------------
+
+#[test]
+fn claim_level_untrusted_issuer_key_does_not_grant() {
+    // The policy trusts the GOV key; the credential is signed by a DIFFERENT key whose
+    // signature does not verify ⇒ no admission ⇒ no access.
+    let (_gov_sk, gov_pk) = gov_key();
+    let forge_sk = SecretKey::from_seed(0xBADBAD);
+    let rules = parse(&claim_level_policy(GOV_ISSUER, &gov_pk));
+    let cred = fresh_cred(&forge_sk, age_credential_graph(JESSE, "25"));
+    assert!(
+        !read_granted(&run(&cred, &rules, &session(JESSE, NOW)), JESSE),
+        "a credential signed by an untrusted key fails the CHECKED signature ⇒ no access"
+    );
+}
+
+#[test]
+fn claim_level_tampered_signature_does_not_grant() {
+    let (sk, pk) = gov_key();
+    let rules = parse(&claim_level_policy(GOV_ISSUER, &pk));
+    let mut cred = fresh_cred(&sk, age_credential_graph(JESSE, "25"));
+    let mut sig: Vec<char> = cred.issuer_signature_hex.chars().collect();
+    let last = sig.len() - 1;
+    sig[last] = if sig[last] == '0' { '1' } else { '0' };
+    cred.issuer_signature_hex = sig.into_iter().collect();
+    assert!(
+        !read_granted(&run(&cred, &rules, &session(JESSE, NOW)), JESSE),
+        "a tampered issuer signature is rejected fail-closed ⇒ no access"
+    );
+}
+
+#[test]
+fn claim_level_wrong_holder_third_party_does_not_grant() {
+    // Mallory presents Jesse's validly-signed credential: credentialSubject (Jesse) !=
+    // Session.agent (Mallory) ⇒ holder binding fails ⇒ not admitted.
+    let (sk, pk) = gov_key();
+    let rules = parse(&claim_level_policy(GOV_ISSUER, &pk));
+    let cred = fresh_cred(&sk, age_credential_graph(JESSE, "25"));
+    let grants = run(&cred, &rules, &session(MALLORY, NOW));
+    assert!(
+        !read_granted(&grants, MALLORY),
+        "wrong-holder presentation denies"
+    );
+    assert!(
+        !read_granted(&grants, JESSE),
+        "and does not silently grant Jesse"
+    );
+}
+
+#[test]
+fn claim_level_out_of_type_laundered_predicate_is_not_admitted() {
+    // The source is trusted (trustsSourceFor) ONLY for schema:age. It signs a graph that
+    // also smuggles an `acl:agent` triple. Statement-type scoping + the reserved-predicate
+    // guard reject the smuggled triple — and it does not poison the legit age admission.
+    let (sk, pk) = gov_key();
+    let rules = parse(&claim_level_policy(GOV_ISSUER, &pk));
+    let mut graph = age_credential_graph(JESSE, "25");
+    graph.push(Triple::new(
+        NamedOrBlankNode::NamedNode(iri(JESSE)),
+        iri(ACL_AGENT),
+        Term::NamedNode(iri(JESSE)),
+    ));
+    let cred = fresh_cred(&sk, graph);
+    let admitted = admit(&cred, &rules, &session(JESSE, NOW), &iri(RESOURCE_X));
+    assert!(
+        admitted
+            .iter()
+            .all(|f| f.triple.predicate.as_str() == SCHEMA_AGE),
+        "a source trusted only for schema:age cannot launder an acl:agent triple in"
+    );
+    assert!(
+        read_granted(&derive_grants(&admitted, ACR_ABAC_RULE).unwrap(), JESSE),
+        "the smuggled predicate does not block the legitimate age admission"
+    );
+}
+
+#[test]
+fn claim_level_out_of_scope_resource_is_not_covered() {
+    let (sk, pk) = gov_key();
+    let rules = parse(&claim_level_policy(GOV_ISSUER, &pk));
+    let cred = fresh_cred(&sk, age_credential_graph(JESSE, "25"));
+    let admitted = admit(
+        &cred,
+        &rules,
+        &session(JESSE, NOW),
+        &iri("https://pod.ex/resourceY"),
+    );
+    assert!(
+        admitted.is_empty(),
+        "a source scoped to resourceX does not cover a request for resourceY"
+    );
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -413,6 +413,22 @@ RDFC-1.0 canonicalise (`sparq-canon`) → a **checked** issuer signature over th
 (`sparq-zk`, never a self-asserted triple) → statement-type scoping via a real SHACL shape
 (`sparq-shacl`) → freshness (a per-request check) → the clear-WebID holder binding.
 
+**Two equivalent policy-authoring forms (`parse_policy` / `resolve_rule_keys` accept both;
+`sq-pfae.4`).** A Control-gated trust policy may name a rule either way, and both desugar to the
+SAME `Vec<TrustRule>` the gate consumes:
+- **Reified** — a `trust:TrustRule` node grouping `trust:source` + `trust:forShape`/`forPredicate`
+  + `trust:scope` + `trust:freshWithin` (+ key). Keeps scope/freshness **per-rule**.
+- **Claim-level relational** (`trust:trustsSourceFor`, the foundational primitive, design §2.3.1)
+  — a `trust:Source` node carries `trust:trustsSourceFor <shape-or-predicate>` directly, alongside
+  its shared key + `trust:scope` + `trust:freshWithin`; EACH `trustsSourceFor` statement is one
+  rule. This is the compact *per-(source, statement-type)* form that **replaces ACP's type-only,
+  unimplemented `acp:vc` matcher** with claim-level trust. The object is a `sh:NodeShape` node
+  (carried like `forShape`) or a predicate IRI (desugared like `forPredicate`); a blank-node source
+  is rejected fail-closed. It composes with the opt-in `did` key binding (`trust:issuerDid` on the
+  source node). Every soundness side-condition (checked signature, type-scope, holder binding,
+  reserved-predicate guard) is identical to the reified form — the claim-level form is NOT a weaker
+  admission path.
+
 - **`admit_trust_credential_static(credential, rules, target, abac_rule_n3)`** — the
   **materialise-time** path (the `sq-xc4y` static/dynamic split). It runs only the
   session-INDEPENDENT class (signature, type-scope, scope) and installs each derived grant as an


### PR DESCRIPTION
> 🤖 SPARQ agent — trust-graph authorisation PoC. This PR was prepared by an automated SPARQ agent (Opus 4.8; Fable unavailable — flag for re-review when Fable returns).

## What this implements (`sq-pfae.4`, surface `sparq-trust`)

The P3 **claim-level admission stratum**, the core deliverable that **closes the `acp:vc` gap**, building directly on the just-merged DID resolution (`sq-pfae.3` / #1164).

It teaches the Control-gated policy parser the foundational `trust:trustsSourceFor` relational primitive (design §2.3.1) as a **second authoring form** alongside the reified `trust:TrustRule`:

- A `trust:Source` node carries `trust:trustsSourceFor <shape-or-predicate>` **directly**, alongside its shared issuer key (`trust:issuerKey` / `trust:issuerDid`) + `trust:scope` + `trust:freshWithin`.
- **Each** `trustsSourceFor` statement is one rule (a source trusted for two statement-types yields two rules), sharing the source's key/scope/freshness.
- This is the compact **per-(source, statement-type)** form that replaces ACP's *type-only, unimplemented* `acp:vc` matcher with **claim-level** trust.

Both forms desugar to the **same** `Vec<TrustRule>` the admission gate already consumes, so the gate, the DID-resolved key binding, and **every soundness side-condition are unchanged** — only the surface syntax differs. The `trustsSourceFor` object is a `sh:NodeShape` node (carried like `forShape`) or a predicate IRI (desugared like `forPredicate`). Fail-closed: a blank-node source is rejected (no stable identity); missing key/scope/freshness is an `IncompleteRule`.

## Soundness (`never admit on a self-asserted trust triple`)

The claim-level form is **NOT a weaker admission path**. It runs the identical gate: RDFC-1.0 commit → **CHECKED** issuer signature over the commitment → SHACL statement-type scope → reserved-predicate guard → freshness → clear-WebID holder binding. Adversarial forgery negatives (mirroring `acp_forged_*_in_acr_document_does_not_grant`) each DENY: untrusted key, tampered signature, wrong-holder third party, out-of-type laundered `acl:agent`, out-of-scope resource.

## Files

- `crates/sparq-trust/src/policy.rs` — `trusts_source_for_statements` / `parse_claim_rule` / `shape_from_trusts_object`; module + `parse_policy` docs; 6 new unit tests.
- `crates/sparq-trust/tests/trusts_source_for_e2e.rs` (NEW) — result-equivalence with the reified form + the adversarial forgery matrix.
- `crates/sparq-trust/tests/did_issuer_binding_e2e.rs` — claim-level form composes with a `trust:issuerDid`-bound issuer.
- `crates/sparq-trust/README.md`, `skills/access-control/SKILL.md` — document the two authoring forms.

## Gates (GREEN in BOTH feature states)

Feature flags: default (feature OFF) and `--features did` (the only sparq-trust feature). The new surface is **opt-in by construction** — `sparq-trust` is default-OFF in `sparq-solid`; the lean core is untouched.

- `cargo clippy -p sparq-trust --all-targets -- -D warnings` ✅ (default)
- `cargo clippy -p sparq-trust --all-targets --all-features -- -D warnings` ✅ (`did` ON)
- `cargo test -p sparq-trust` ✅ (default) and `--all-features` ✅
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-trust --no-deps --all-features` ✅
- `sparq-solid --features trust-graph-did` clippy + tests ✅ (strict additivity G6 intact)
- `check-readme-template.py --enforce` → 0 deviations (README 120 lines); `check-privacy-claims.sh` clean; typos clean on changed files.

## Honest scope

RESEARCH PoC, **NOT a security guarantee**. Admits in the clear (no privacy/unlinkability); issuer keys operator-asserted by default (DID-bindable opt-in — narrows but does not close forgery vector D′); the ZK estate it composes with is externally **UNAUDITED** (`sq-qhy4`, pending accredited-cryptographer sign-off), `sparq-mpc` semi-honest only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)