### PR TITLE
fix(supply-chain): bump memmap2 0.9.10 -> 0.9.11 for RUSTSEC-2026-0186 [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,9 +1738,9 @@ checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+checksum = "d1219ed1b7f229ee7104d281dd01d6802fe28bb6e95d292942c4daacdeb798c0"
 dependencies = [
  "libc",
 ]

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -586,7 +586,7 @@ version = "2.8.2"
 criteria = "safe-to-deploy"
 
 [[exemptions.memmap2]]
-version = "0.9.10"
+version = "0.9.11"
 criteria = "safe-to-deploy"
 
 [[exemptions.mimalloc]]


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (CI-infra / supply-chain). This PR was prepared autonomously.

## Why (queue unblocker)

The newly-published advisory **[RUSTSEC-2026-0186](https://rustsec.org/advisories/RUSTSEC-2026-0186)** (`memmap2 0.9.10`, severity *unsound*) makes the **GATING** `cargo deny check advisories` leg of `supply-chain.yml` fail on `main` **and every open PR** (sparq-trust #1172, sparq-kb-DQV #1176, V()-exposure #1177, …), stalling the entire merge queue.

The advisory: `memmap2 < 0.9.11` performs insufficient validation of the `offset`/`len` args to `Mmap::[unchecked_]advise_range()`, `MmapMut::[unchecked_]advise_range()` and `MmapMut::flush[_async]_range()`. An out-of-bounds range yields an out-of-bounds pointer (via `pointer::offset()` / `pointer::add()`) that is then handed to the `madvise`/`msync` syscalls (and their Windows equivalents) — undefined behaviour. The pointer is not dereferenced in-process, but the syscall arguments are unsound.

## What pulls memmap2 in

`memmap2` is a **direct** dependency of three workspace crates:

- `sparq-core` — behind the **opt-in `mmap` feature** (`mmap = ["dep:memmap2"]`)
- `sparq-cli` — unconditional
- `sparq-vectors` — unconditional

(`deny.toml` sets `all-features = true`, so the gate evaluates the advisory across all features regardless.)

## Remediation — patch bump (preferred path)

The flaw is fixed in **`0.9.11`** (commit `cee7cf0`), and the advisory's own documented solution is `cargo update -p memmap2`. The workspace spec is `memmap2 = "0.9"` (caret), so `0.9.11` is **semver-compatible** and resolves automatically — **no `deny.toml` ignore is needed.** This is the cleanest possible fix: a single-package `Cargo.lock` bump, no other dependency churn, no API change.

```
 [[package]]
 name = "memmap2"
-version = "0.9.10"
+version = "0.9.11"
```

## Verification (run locally)

- `cargo update -p memmap2` → `Updating memmap2 v0.9.10 -> v0.9.11` (single package, no other churn)
- `cargo deny check` → **`advisories ok, bans ok, licenses ok, sources ok`** (all four GATING checks green; was `advisories FAILED` before)
- `cargo build -p sparq-core --features mmap -p sparq-vectors -p sparq-cli` → builds clean (`memmap2 v0.9.11` is API-compatible)

## Compliance gap closed

Restores the `cargo deny check advisories` GATING leg to green — i.e. the RustSec-advisory control of the supply-chain attestation posture, no longer carrying a known-unsound `memmap2`.

## Follow-up (for the other open PRs)

After this merges to `main`, the other open PRs must **merge `main` into their branches** to pick up this `Cargo.lock` bump before their `cargo deny check advisories` re-runs green.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>