### PR TITLE
feat(reason-el): RBox / property-chain + transitive-role saturation (CR10/CR11) — opt-in `rbox` (sq-xetf7) [OPUS-4.8]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -58,9 +58,10 @@
 #     opt-in (the spike's preferred shape, keeping sparq-reason lean). Its whole surface
 #     (lib unit tests + the tests/differential.rs ELK-calculus oracle + clippy + rustdoc)
 #     is therefore built/tested by ci.yml's `cargo {build,nextest,clippy,doc} --workspace`
-#     lanes already — there is no default-OFF feature to toggle, so a feature-matrix leg
-#     (whose template is `--features <X>`) does not apply. WHEN Phase E2 (bead sq-xetf7)
-#     adds an RBox/property-chain feature, add a leg here for it.
+#     lanes already — for the E1 default surface there is no default-OFF feature to toggle.
+#     [OPUS-4.8] sq-xetf7: Phase E2 ADDED the default-OFF `rbox` feature (RBox / property
+#     chain + transitive-role saturation, CR10/CR11), so the leg this NOTE anticipated now
+#     exists below as the `sparq-reason-el (rbox …)` matrix entry.
 
 name: feature-matrix
 
@@ -341,6 +342,22 @@ jobs:
           - name: sparq-reason (explain)
             crate: sparq-reason
             features: explain
+            test: true
+          # [OPUS-4.8] sq-xetf7 (Phase E2): sparq-reason-el's `rbox` feature — RBox / property
+          # chain + transitive-role saturation (CR10 role inclusion + CR11 role composition).
+          # The NOTE at the head of this file (sq-evb1) anticipated this leg: E1 ships the
+          # crate with NO intra-crate feature, but E2 adds the default-OFF `rbox` feature, so
+          # without a leg here the whole RBox surface goes UNGATED in CI. tests/rbox_differential.rs
+          # is `#![cfg(feature = "rbox")]` (8 CR10/CR11 closure-oracle tests) and the rbox.rs +
+          # extract.rs/classify.rs role-automaton arms are all `#[cfg(feature = "rbox")]`, so the
+          # default build (and ci.yml's `--workspace --all-targets` archive, which passes NO
+          # `--features`) compiled them EMPTY and ran ZERO of them — the silent gap this leg
+          # closes. No new dep (`rbox = []`, reuses oxrdf + rustc-hash). Verified locally: `cargo
+          # nextest list -p sparq-reason-el --features rbox` shows the 8 rbox_differential tests +
+          # the 4 in-src rbox::tests, and `clippy --all-targets -D warnings` is clean with it on.
+          - name: sparq-reason-el (rbox — CR10/CR11 RBox saturation)
+            crate: sparq-reason-el
+            features: rbox
             test: true
           # sparq-mpc: the deterministic/seedable masking RNG seam (insecure-by-name).
           - name: sparq-mpc (insecure-test-rng)

--- a/crates/sparq-reason-el/Cargo.toml
+++ b/crates/sparq-reason-el/Cargo.toml
@@ -36,6 +36,15 @@ rustdoc-args = ["--cfg", "docsrs"]
 # the crate is itself the opt-in surface (depending on it is the opt-in).
 default = []
 
+# [OPUS-4.8] sq-xetf7 (Phase E2): RBox / property-chain + transitive-role saturation
+# (CR10 role inclusion + CR11 role composition, the EL+ role automaton — the SNOMED-critical
+# right-identity/transitive role reasoning). OFF by default so the E1 classifier (and the lean
+# wasm port) carry zero role-automaton code: without `rbox` every `rdfs:subPropertyOf`,
+# `owl:propertyChainAxiom` and `owl:TransitiveProperty` axiom is left unapplied (roles are
+# compared for equality only, exactly the E1 behaviour). No new dependency — reuses oxrdf +
+# rustc-hash. Spike: research/owl2-el-ql-reasoning-spike.md §5 (EL-track E2).
+rbox = []
+
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io
 # (required to publish — crates.io strips `path`).

--- a/crates/sparq-reason-el/README.md
+++ b/crates/sparq-reason-el/README.md
@@ -45,12 +45,17 @@ For a typed view (super-classes, subsumption test, unsatisfiable classes) use
 - **Same dict/Graph seam as RL** — emits the lattice as `rdfs:subClassOf` triples queryable by
   plain BGP eval; no store changes.
 - **Unsatisfiable-class detection** — `owl:disjointWith` clashes surface `C ⊑ owl:Nothing`.
-- **Honest fragment reporting** — axioms outside EL+⊥ (unionOf / cardinality / RBox / …) are
-  counted in `Report::skipped_axioms`, never silently misapplied.
+- **RBox role automaton** *(opt-in `rbox` feature, Phase E2)* — `rdfs:subPropertyOf` role
+  inclusions (**CR10**), `owl:propertyChainAxiom` + `owl:TransitiveProperty` compositions
+  (**CR11**), incl. the SNOMED-critical right-identity `r ∘ s ⊑ s`. OFF by default: zero
+  role-automaton code without it, and RBox axioms are then left unapplied (roles compared for
+  equality only).
+- **Honest fragment reporting** — class axioms outside the active fragment (unionOf /
+  cardinality / …) are counted in `Report::skipped_axioms`, never silently misapplied.
 
-**Scope (MVP, Phase E1):** EL+⊥ minus RBox. RBox / property chains / transitive roles (CR10/
-CR11) are **Phase E2**; transitive reduction + scale **E3**; concurrency **E4**; nominals +
-concrete domains are deferred. The classifier is **single-threaded**.
+**Scope:** EL+⊥ (E1, default) and — with `rbox` — EL+ role reasoning (E2). Transitive reduction
++ scale are **E3**; concurrency **E4**; nominals + concrete domains are deferred. The classifier
+is **single-threaded**. Enable RBox with `sparq-reason-el = { version = "0.1", features = ["rbox"] }`.
 
 ## 📚 Learn more
 

--- a/crates/sparq-reason-el/src/classify.rs
+++ b/crates/sparq-reason-el/src/classify.rs
@@ -17,6 +17,8 @@
 // derived membership is processed once. Single-threaded (Phase E1; concurrency is E4).
 
 use crate::normal::{Concept, Names, Normal, Role, BOTTOM, TOP};
+#[cfg(feature = "rbox")]
+use crate::rbox::RoleBox;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 /// Indexes the normal-form axioms by the premise shape each completion rule matches on, so a
@@ -64,9 +66,29 @@ pub struct Saturation {
     pub r_succ: FxHashMap<Role, FxHashMap<Concept, FxHashSet<Concept>>>,
 }
 
-/// Runs CR1–CR5 to a fixpoint over `axioms` for `n` concepts (the dense count from [`Names`]).
-/// Returns the saturated [`Saturation`]; `S[c]` then holds every concept subsuming `c`.
+/// Runs CR1–CR5 (and, under the `rbox` feature, CR10/CR11 role saturation) to a fixpoint over
+/// `axioms` for `n` concepts (the dense count from [`Names`]). Returns the saturated
+/// [`Saturation`]; `S[c]` then holds every concept subsuming `c`.
+#[cfg(feature = "rbox")]
+pub fn saturate(axioms: &[Normal], n: usize, role_box: &RoleBox) -> Saturation {
+    saturate_inner(axioms, n, role_box)
+}
+
+/// Runs CR1–CR5 to a fixpoint (no role hierarchy — roles are compared for equality only). The
+/// E1 entry point; the `rbox` build uses the [`RoleBox`]-aware overload above.
+#[cfg(not(feature = "rbox"))]
 pub fn saturate(axioms: &[Normal], n: usize) -> Saturation {
+    saturate_inner(axioms, n)
+}
+
+/// The shared CR1–CR5 (+CR10/CR11 under `rbox`) fixpoint. The `role_box` argument exists only
+/// in the `rbox` build; CR3 link insertion routes through it so every asserted existential link
+/// is closed under role inclusion + composition before CR4/CR5 fire.
+fn saturate_inner(
+    axioms: &[Normal],
+    n: usize,
+    #[cfg(feature = "rbox")] role_box: &RoleBox,
+) -> Saturation {
     let ix = AxiomIndex::build(axioms);
     let mut sat = Saturation {
         s: vec![FxHashSet::default(); n],
@@ -101,9 +123,13 @@ pub fn saturate(axioms: &[Normal], n: usize) -> Saturation {
                 }
             }
         }
-        // CR3: every `D ⊑ ∃r.F` axiom adds the link (X, F) to R(r).
+        // CR3: every `D ⊑ ∃r.F` axiom adds the link (X, F) to R(r). Under `rbox` the link is
+        // closed under CR10 (role inclusion) + CR11 (composition) before CR4/CR5 fire.
         if let Some(links) = ix.exists.get(&d) {
             for &(r, f) in links {
+                #[cfg(feature = "rbox")]
+                add_link_rbox(&mut sat, r, x, f, &ix, role_box, &mut queue);
+                #[cfg(not(feature = "rbox"))]
                 add_link(&mut sat, r, x, f, &ix, &mut queue);
             }
         }
@@ -148,7 +174,8 @@ fn add(set: &mut FxHashSet<Concept>, x: Concept, e: Concept, queue: &mut Vec<(Co
 
 /// Adds the existential link `(x, f) ∈ R(r)` and fires the link-triggered half of CR4/CR5:
 /// for the NEW link, every `D ∈ S(f)` with an axiom `∃r.D ⊑ E` yields `E ∈ S(x)`, and a
-/// pre-existing `⊥ ∈ S(f)` yields `⊥ ∈ S(x)` (CR5).
+/// pre-existing `⊥ ∈ S(f)` yields `⊥ ∈ S(x)` (CR5). Returns `true` iff the link was new (so the
+/// `rbox` caller can decide whether to close it under CR10/CR11).
 fn add_link(
     sat: &mut Saturation,
     r: Role,
@@ -156,10 +183,10 @@ fn add_link(
     f: Concept,
     ix: &AxiomIndex,
     queue: &mut Vec<(Concept, Concept)>,
-) {
+) -> bool {
     let succ = sat.r_succ.entry(r).or_default().entry(x).or_default();
     if !succ.insert(f) {
-        return; // link already present.
+        return false; // link already present.
     }
     sat.r_pred
         .entry(r)
@@ -179,6 +206,65 @@ fn add_link(
         // CR5 for the new link.
         if d == BOTTOM {
             add(&mut sat.s[x as usize], x, BOTTOM, queue);
+        }
+    }
+    true
+}
+
+/// Adds the asserted existential link `(x, f) ∈ R(r)` (CR3) and closes it under the RBox role
+/// rules to a fixpoint via a link worklist, calling [`add_link`] (which fires CR4/CR5) for every
+/// derived link:
+///
+///   CR10  r ⊑* s          ⇒  (x, f) ∈ R(s)                      for each super-role s of r
+///   CR11  r ∘ r2 ⊑ s, (f, z) ∈ R(r2)  ⇒  (x, z) ∈ R(s)         (new link is the FIRST component)
+///         r1 ∘ r ⊑ s, (w, x) ∈ R(r1)  ⇒  (w, f) ∈ R(s)         (new link is the SECOND component)
+///
+/// Newly-derived links are pushed back onto the worklist, so composed links compose again and
+/// super-roles of derived roles also propagate — the standard RBox link-saturation. The worklist
+/// is bounded by the number of distinct `(role, x, f)` triples (each is stored at most once in
+/// `r_succ`), so the fixpoint terminates.
+#[cfg(feature = "rbox")]
+fn add_link_rbox(
+    sat: &mut Saturation,
+    r: Role,
+    x: Concept,
+    f: Concept,
+    ix: &AxiomIndex,
+    role_box: &RoleBox,
+    queue: &mut Vec<(Concept, Concept)>,
+) {
+    // Each work item is a link to STORE (already at its exact role). Seed with the CR3 link.
+    let mut links: Vec<(Role, Concept, Concept)> = vec![(r, x, f)];
+    while let Some((lr, lx, lf)) = links.pop() {
+        if !add_link(sat, lr, lx, lf, ix, queue) {
+            continue; // link already present — its consequences were already enqueued.
+        }
+        // CR10: propagate to every strict super-role of `lr` (super_roles includes lr itself).
+        for &sup in role_box.super_roles(lr) {
+            if sup != lr {
+                links.push((sup, lx, lf));
+            }
+        }
+        // CR11 (only when the TBox has any composition axiom — a pure role hierarchy skips
+        // every probe). New link as the FIRST component: lr ∘ r2 ⊑ s with (lf, z) ∈ R(r2)
+        // ⇒ (lx, z) ∈ R(s); and as the SECOND: r1 ∘ lr ⊑ s with (w, lx) ∈ R(r1) ⇒ (w, lf) ∈ R(s).
+        if role_box.has_compositions() {
+            for &(r2, s) in role_box.compositions_first(lr) {
+                if let Some(z_set) = sat.r_succ.get(&r2).and_then(|m| m.get(&lf)) {
+                    let zs: Vec<Concept> = z_set.iter().copied().collect();
+                    for z in zs {
+                        links.push((s, lx, z));
+                    }
+                }
+            }
+            for &(r1, s) in role_box.compositions_second(lr) {
+                if let Some(w_set) = sat.r_pred.get(&r1).and_then(|m| m.get(&lx)) {
+                    let ws: Vec<Concept> = w_set.iter().copied().collect();
+                    for w in ws {
+                        links.push((s, w, lf));
+                    }
+                }
+            }
         }
     }
 }

--- a/crates/sparq-reason-el/src/extract.rs
+++ b/crates/sparq-reason-el/src/extract.rs
@@ -16,9 +16,24 @@
 // non-EL ontology gets an honest "n axioms outside the EL fragment were ignored" count.
 
 use crate::normal::{Expr, Names, Normal, Normalizer, BOTTOM, TOP};
+#[cfg(feature = "rbox")]
+use crate::normal::{Role, RoleAxiom};
 use crate::Report;
 use rustc_hash::{FxHashMap, FxHashSet};
 use sparq_core::dict::{Dict, Id};
+
+/// Everything the extractor reads out of the RDF substrate: the normalized concept axioms, the
+/// name table, the [`Report`], and — only under the `rbox` feature — the normalized RBox role
+/// axioms (E2). Keeping the role axioms in a feature-gated field means the default build's
+/// extraction is byte-for-byte the E1 path.
+pub struct Extracted {
+    pub axioms: Vec<Normal>,
+    pub names: Names,
+    pub report: Report,
+    /// Normalized RBox axioms (role inclusions + compositions). Empty/absent without `rbox`.
+    #[cfg(feature = "rbox")]
+    pub role_axioms: Vec<RoleAxiom>,
+}
 
 const OWL: &str = "http://www.w3.org/2002/07/owl#";
 const RDF: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
@@ -60,6 +75,13 @@ struct Vocab {
     nothing: Id,
     /// Predicate ids whose presence on a class node makes it non-EL (see [`NON_EL_MARKERS`]).
     non_el: FxHashSet<Id>,
+    /// RBox vocabulary — only consulted under the `rbox` feature (E2).
+    #[cfg(feature = "rbox")]
+    sub_property_of: Id,
+    #[cfg(feature = "rbox")]
+    property_chain_axiom: Id,
+    #[cfg(feature = "rbox")]
+    transitive_property: Id,
 }
 
 impl Vocab {
@@ -84,6 +106,12 @@ impl Vocab {
                 .iter()
                 .map(|m| look(format!("{}{}", OWL, m)))
                 .collect(),
+            #[cfg(feature = "rbox")]
+            sub_property_of: look(format!("{}subPropertyOf", RDFS)),
+            #[cfg(feature = "rbox")]
+            property_chain_axiom: look(format!("{}propertyChainAxiom", OWL)),
+            #[cfg(feature = "rbox")]
+            transitive_property: look(format!("{}TransitiveProperty", OWL)),
         }
     }
 }
@@ -102,11 +130,18 @@ struct Idx {
     rest: FxHashMap<Id, Id>,       // rdf:rest edges
     is_restriction: FxHashSet<Id>, // nodes typed owl:Restriction
     non_el_node: FxHashSet<Id>,    // nodes carrying a non-EL marker predicate
+    #[cfg(feature = "rbox")]
+    sub_property: Vec<(Id, Id)>, // (r, s) from rdfs:subPropertyOf — a role inclusion r ⊑ s
+    #[cfg(feature = "rbox")]
+    chain_head: FxHashMap<Id, Id>, // super-property -> owl:propertyChainAxiom list head
+    #[cfg(feature = "rbox")]
+    transitive: Vec<Id>, // properties typed owl:TransitiveProperty
 }
 
-/// Extracts and normalizes the EL+⊥ TBox from `triples`, returning the normal-form axioms,
-/// the name table, and a fresh [`Report`] tallying skipped (non-EL) axioms. Single-threaded.
-pub fn extract(dict: &Dict, triples: &[[Id; 3]]) -> (Vec<Normal>, Names, Report) {
+/// Extracts and normalizes the EL+⊥ TBox from `triples`, returning the [`Extracted`] bundle
+/// (normal-form concept axioms, the name table, the [`Report`], and — under `rbox` — the
+/// normalized RBox role axioms). Single-threaded.
+pub fn extract(dict: &Dict, triples: &[[Id; 3]]) -> Extracted {
     let v = Vocab::intern(dict);
     let mut idx = Idx::default();
     for &[s, p, o] in triples {
@@ -130,6 +165,9 @@ pub fn extract(dict: &Dict, triples: &[[Id; 3]]) -> (Vec<Normal>, Names, Report)
             idx.is_restriction.insert(s);
         } else if v.non_el.contains(&p) {
             idx.non_el_node.insert(s);
+        } else {
+            #[cfg(feature = "rbox")]
+            extract_rbox_triple(&mut idx, &v, s, p, o);
         }
     }
 
@@ -174,8 +212,87 @@ pub fn extract(dict: &Dict, triples: &[[Id; 3]]) -> (Vec<Normal>, Names, Report)
     }
 
     let axioms = norm.finish();
+
+    // RBox normalization (E2): role inclusions + property chains + transitive roles into
+    // [`RoleAxiom`] forms. Done here while `names` is still borrowable so role ids agree with
+    // the existential links minted during concept decoding. No-op without the `rbox` feature.
+    #[cfg(feature = "rbox")]
+    let role_axioms = normalize_rbox(&idx, &v, &mut names);
+
     report.named_classes = names.concept_count();
-    (axioms, names, report)
+    Extracted {
+        axioms,
+        names,
+        report,
+        #[cfg(feature = "rbox")]
+        role_axioms,
+    }
+}
+
+/// Routes one RBox triple into the structural index: `rdfs:subPropertyOf` (role inclusion),
+/// `owl:propertyChainAxiom` (the super-property is the SUBJECT, the chain list is the object),
+/// or an `owl:TransitiveProperty` type assertion. Bare datatype-property `subPropertyOf`s are
+/// captured too but never fire — they cannot appear in an `∃r.C` link, so a spurious inclusion
+/// among data properties is inert (kept simple rather than requiring property-type declarations).
+#[cfg(feature = "rbox")]
+fn extract_rbox_triple(idx: &mut Idx, v: &Vocab, s: Id, p: Id, o: Id) {
+    if p == v.sub_property_of {
+        idx.sub_property.push((s, o));
+    } else if p == v.property_chain_axiom {
+        idx.chain_head.insert(s, o);
+    } else if p == v.ty && o == v.transitive_property {
+        idx.transitive.push(s);
+    }
+}
+
+/// Builds the normalized [`RoleAxiom`] list from the RBox structural index, minting role ids
+/// through the shared [`Names`] table. A property chain of length `n` is left-folded into `n-1`
+/// binary compositions over fresh intermediate roles; a transitive property `r` becomes the
+/// composition `r ∘ r ⊑ r`. A degenerate chain (length 0/1) is treated as a plain inclusion.
+#[cfg(feature = "rbox")]
+fn normalize_rbox(idx: &Idx, v: &Vocab, names: &mut Names) -> Vec<RoleAxiom> {
+    let mut out: Vec<RoleAxiom> = Vec::new();
+    // r ⊑ s.
+    for &(r, s) in &idx.sub_property {
+        let (ri, si) = (names.role(r), names.role(s));
+        out.push(RoleAxiom::Sub(ri, si));
+    }
+    // owl:propertyChainAxiom: r1 ∘ … ∘ rn ⊑ super.
+    for (&super_prop, &head) in &idx.chain_head {
+        let members = decode_list(head, idx, v);
+        let chain: Vec<Role> = members.iter().map(|&m| names.role(m)).collect();
+        let sup = names.role(super_prop);
+        fold_chain(&chain, sup, names, &mut out);
+    }
+    // owl:TransitiveProperty(r) ≡ r ∘ r ⊑ r.
+    for &r in &idx.transitive {
+        let ri = names.role(r);
+        out.push(RoleAxiom::Chain(ri, ri, ri));
+    }
+    out
+}
+
+/// Left-folds a property chain `r1 ∘ … ∘ rn ⊑ sup` into binary [`RoleAxiom::Chain`]s:
+/// `r1 ∘ r2 ⊑ f1`, `f1 ∘ r3 ⊑ f2`, …, `f_{n-2} ∘ rn ⊑ sup`. Length-1 chains degenerate to an
+/// inclusion `r1 ⊑ sup`; a length-0 chain (malformed) is dropped.
+#[cfg(feature = "rbox")]
+fn fold_chain(chain: &[Role], sup: Role, names: &mut Names, out: &mut Vec<RoleAxiom>) {
+    match chain {
+        [] => {}
+        [r1] => out.push(RoleAxiom::Sub(*r1, sup)),
+        [r1, r2] => out.push(RoleAxiom::Chain(*r1, *r2, sup)),
+        [first, rest @ ..] => {
+            let mut acc = *first;
+            // rest has len ≥ 2 here; compose all but the last over fresh roles, last lands on sup.
+            for &next in &rest[..rest.len() - 1] {
+                let f = names.fresh_role();
+                out.push(RoleAxiom::Chain(acc, next, f));
+                acc = f;
+            }
+            let last = rest[rest.len() - 1];
+            out.push(RoleAxiom::Chain(acc, last, sup));
+        }
+    }
 }
 
 /// Resolves a class node (named class, ⊤, ⊥, an `owl:Restriction` node, or an

--- a/crates/sparq-reason-el/src/lib.rs
+++ b/crates/sparq-reason-el/src/lib.rs
@@ -13,6 +13,8 @@ use sparq_core::dict::{Dict, Id};
 mod classify;
 mod extract;
 mod normal;
+#[cfg(feature = "rbox")]
+mod rbox;
 
 const RDFS_SUB_CLASS_OF: &str = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
 const OWL_NOTHING: &str = "http://www.w3.org/2002/07/owl#Nothing";
@@ -20,13 +22,14 @@ const OWL_NOTHING: &str = "http://www.w3.org/2002/07/owl#Nothing";
 /// A tally of what the extractor read and what it could not (so an honest
 /// "n axioms outside the EL fragment were ignored" can be surfaced).
 ///
-/// The classifier is SOUND but only COMPLETE for the EL+⊥-minus-RBox fragment it recognises
-/// (the MVP, Phase E1). Axioms using constructs outside that fragment — `owl:unionOf`,
-/// `owl:complementOf`, `owl:allValuesFrom`, cardinality, `owl:hasValue`, nominals
-/// (`owl:oneOf`), data properties, and RBox axioms (`owl:propertyChainAxiom`,
-/// `owl:TransitiveProperty`, `rdfs:subPropertyOf` between object properties) — are NOT applied
-/// and are counted in [`Report::skipped_axioms`]. RBox / property-chain saturation is Phase E2
-/// (bead sq-xetf7); nominals + concrete domains are deferred further still.
+/// The classifier is SOUND but only COMPLETE for the fragment it recognises. By default that is
+/// EL+⊥-minus-RBox (the E1 MVP); with the `rbox` feature it is EL+ (E1 + the RBox role automaton:
+/// `rdfs:subPropertyOf` role inclusions, `owl:propertyChainAxiom` chains, `owl:TransitiveProperty`
+/// — completion rules CR10/CR11). Axioms using constructs outside the active fragment —
+/// `owl:unionOf`, `owl:complementOf`, `owl:allValuesFrom`, cardinality, `owl:hasValue`, nominals
+/// (`owl:oneOf`), data properties — are NOT applied and class-axiom occurrences are counted in
+/// [`Report::skipped_axioms`]. Without `rbox`, RBox axioms are simply left unapplied (roles are
+/// compared for equality only); nominals + concrete domains are deferred further still.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct Report {
     /// Distinct named classes (and ⊤/⊥ if they occur) seen by the extractor.
@@ -112,7 +115,21 @@ impl Classifier {
     /// subsumption [`ClassHierarchy`]. Does NOT mutate the graph; use [`classify_graph`] to
     /// materialize the lattice as triples. Single-threaded.
     pub fn classify(dict: &Dict, triples: &[[Id; 3]]) -> ClassHierarchy {
-        let (axioms, names, mut report) = extract::extract(dict, triples);
+        let extract::Extracted {
+            axioms,
+            names,
+            mut report,
+            #[cfg(feature = "rbox")]
+            role_axioms,
+        } = extract::extract(dict, triples);
+        // The role box (CR10/CR11 saturation) is built only under `rbox`; without it the
+        // saturator runs the E1 calculus (roles compared for equality only). Building it here
+        // before `names` is borrowed by `saturate` keeps role ids consistent.
+        #[cfg(feature = "rbox")]
+        let role_box = rbox::RoleBox::build(&role_axioms, names.role_count());
+        #[cfg(feature = "rbox")]
+        let sat = classify::saturate(&axioms, names.concept_count(), &role_box);
+        #[cfg(not(feature = "rbox"))]
         let sat = classify::saturate(&axioms, names.concept_count());
         let cls = classify::classify(&sat, &names);
         // Re-key the named-concept lattice onto dict ids for the public view.

--- a/crates/sparq-reason-el/src/normal.rs
+++ b/crates/sparq-reason-el/src/normal.rs
@@ -16,9 +16,25 @@ use sparq_core::dict::Id;
 pub type Concept = u32;
 
 /// A role (object property) in the internal index space. Like [`Concept`] this is a dense
-/// `u32` separate from dict ids; the EL MVP does not reason over the role hierarchy (Phase
-/// E2), so a role is only ever compared for equality.
+/// `u32` separate from dict ids. Without the `rbox` feature a role is only ever compared for
+/// equality (no role hierarchy). With `rbox` (Phase E2, bead sq-xetf7) the saturator reasons
+/// over role inclusions and compositions via the [`RoleBox`] role automaton.
 pub type Role = u32;
+
+/// An RBox (role-box) axiom in normal form — the two EL+ role forms the Baader–Brandt–Lutz
+/// calculus adds on top of the four concept forms (spike §5, CR10/CR11). Only built when the
+/// `rbox` feature is on; the MVP (E1) drops every role axiom into [`crate::Report::skipped_axioms`].
+#[cfg(feature = "rbox")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum RoleAxiom {
+    /// `r ⊑ s` — a simple role inclusion (`rdfs:subPropertyOf` between object properties).
+    /// `owl:TransitiveProperty(r)` is normalized to the composition `r ∘ r ⊑ r`, NOT this form.
+    Sub(Role, Role),
+    /// `r1 ∘ r2 ⊑ s` — a (binary) role composition. An `owl:propertyChainAxiom` of length `n`
+    /// is left-folded into `n-1` of these over fresh intermediate roles; a transitive role is
+    /// the special case `r ∘ r ⊑ r`; SNOMED right-identity is `r ∘ s ⊑ s`.
+    Chain(Role, Role, Role),
+}
 
 /// The internal name table: a bijection between the dense classification index space and the
 /// source dict ids, plus a counter that mints fresh (anonymous) concepts for normalization.
@@ -76,6 +92,24 @@ impl Names {
         self.role_to_dict.push(dict_id);
         self.role_by_dict.insert(dict_id, r);
         r
+    }
+
+    /// Mints a fresh anonymous role (no dict id) — used to left-fold an `owl:propertyChainAxiom`
+    /// of length `n` into `n-1` binary [`RoleAxiom::Chain`] forms over intermediate roles. The
+    /// fresh role uses a sentinel dict id (`Id::MAX`) that no real property interns to; it never
+    /// appears in an emitted link because chain heads are always named roles.
+    #[cfg(feature = "rbox")]
+    pub fn fresh_role(&mut self) -> Role {
+        let r = self.role_to_dict.len() as Role;
+        self.role_to_dict.push(Id::MAX);
+        r
+    }
+
+    /// The number of roles minted so far (the dense role-index upper bound). Used to size the
+    /// role-saturation tables in [`RoleBox`].
+    #[cfg(feature = "rbox")]
+    pub fn role_count(&self) -> usize {
+        self.role_to_dict.len()
     }
 
     /// Mints a fresh anonymous concept (a normalization name with no dict id).

--- a/crates/sparq-reason-el/src/rbox.rs
+++ b/crates/sparq-reason-el/src/rbox.rs
@@ -1,0 +1,170 @@
+// [OPUS-4.8] sq-xetf7: RBox (role-box) saturation — CR10 (role inclusion) + CR11 (role
+// composition), the EL+ role automaton the spike's Phase E2 adds on top of the E1 CR1-CR5
+// concept calculus (research/owl2-el-ql-reasoning-spike.md §5).
+//
+// EL+ role reasoning is a finite, fully-specified calculus (spike §"Hard parts" (2)). The two
+// role completion rules are:
+//
+//   CR10  r ⊑ s ∈ R,      (X, Y) ∈ R(r)                    ⇒  (X, Y) ∈ R(s)
+//   CR11  r1 ∘ r2 ⊑ s ∈ R,  (X, Y) ∈ R(r1),  (Y, Z) ∈ R(r2) ⇒  (X, Z) ∈ R(s)
+//
+// Transitive roles (`r ∘ r ⊑ r`) and SNOMED right-identity (`r ∘ s ⊑ s`) are special cases of
+// CR11, so a single composition table handles all three. CR10 alone is a reachability problem
+// over the told-inclusion graph; we precompute its REFLEXIVE-TRANSITIVE CLOSURE once (`r ⊑* s`)
+// so the hot saturation loop in `classify` answers "every super-role of r" by a table lookup,
+// never a fixpoint over inclusions.
+//
+// This whole module is `#[cfg(feature = "rbox")]`: the default build (and the lean wasm port)
+// carry zero role-automaton code, and every RBox axiom stays in `Report::skipped_axioms`.
+
+use crate::normal::{Role, RoleAxiom};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+/// The saturated role box: the reflexive-transitive closure of told role inclusions (CR10) plus
+/// the indexed binary composition axioms (CR11). Built once from the extracted [`RoleAxiom`]s,
+/// then consulted read-only by the concept saturator.
+pub struct RoleBox {
+    /// `super_of[r]` = every role `s` with `r ⊑* s` under the told inclusions, INCLUDING `r`
+    /// itself (reflexive). So a link `(X, Y) ∈ R(r)` immediately holds for each `s ∈ super_of[r]`.
+    super_of: Vec<Vec<Role>>,
+    /// Composition axioms keyed by the FIRST component: `comp_by_first[r1]` = `(r2, s)` pairs
+    /// with `r1 ∘ r2 ⊑ s`. The keying matches CR11's firing shape — a new link `(X, Y) ∈ R(r1)`
+    /// looks for a `(Y, Z) ∈ R(r2)` to compose with.
+    comp_by_first: FxHashMap<Role, Vec<(Role, Role)>>,
+    /// Composition axioms keyed by the SECOND component: `comp_by_second[r2]` = `(r1, s)` pairs
+    /// with `r1 ∘ r2 ⊑ s`. CR11 also fires when the `(Y, Z) ∈ R(r2)` link is the new trigger and
+    /// the `(X, Y) ∈ R(r1)` predecessor already exists.
+    comp_by_second: FxHashMap<Role, Vec<(Role, Role)>>,
+    /// Whether ANY composition axiom exists. When false the box degenerates to a pure role
+    /// hierarchy and the saturator can skip every composition probe.
+    has_compositions: bool,
+}
+
+impl RoleBox {
+    /// Builds the saturated role box for `role_count` roles from the told [`RoleAxiom`]s.
+    /// Computes the reflexive-transitive inclusion closure (CR10) with a per-role BFS over the
+    /// told-inclusion adjacency, and indexes compositions (CR11) on both components. Roles that
+    /// have no inclusion/composition axiom still get a singleton reflexive `super_of` row.
+    pub fn build(axioms: &[RoleAxiom], role_count: usize) -> RoleBox {
+        // Told inclusion adjacency: incl_adj[r] = roles s with `r ⊑ s` asserted (excluding the
+        // reflexive self-edge, which the closure adds unconditionally).
+        let mut incl_adj: Vec<Vec<Role>> = vec![Vec::new(); role_count];
+        let mut comp_by_first: FxHashMap<Role, Vec<(Role, Role)>> = FxHashMap::default();
+        let mut comp_by_second: FxHashMap<Role, Vec<(Role, Role)>> = FxHashMap::default();
+        let mut has_compositions = false;
+        for &ax in axioms {
+            match ax {
+                RoleAxiom::Sub(r, s) => {
+                    if r != s {
+                        incl_adj[r as usize].push(s);
+                    }
+                }
+                RoleAxiom::Chain(r1, r2, s) => {
+                    has_compositions = true;
+                    comp_by_first.entry(r1).or_default().push((r2, s));
+                    comp_by_second.entry(r2).or_default().push((r1, s));
+                }
+            }
+        }
+
+        // Reflexive-transitive closure of the inclusion graph, one BFS per role. role_count is
+        // the number of object properties in the TBox (tiny vs the concept space), so the
+        // quadratic-worst-case closure is cheap and never the bottleneck.
+        let mut super_of: Vec<Vec<Role>> = Vec::with_capacity(role_count);
+        for r in 0..role_count as Role {
+            let mut seen: FxHashSet<Role> = FxHashSet::default();
+            let mut stack = vec![r];
+            seen.insert(r);
+            while let Some(cur) = stack.pop() {
+                for &nxt in &incl_adj[cur as usize] {
+                    if seen.insert(nxt) {
+                        stack.push(nxt);
+                    }
+                }
+            }
+            let mut row: Vec<Role> = seen.into_iter().collect();
+            row.sort_unstable(); // deterministic emission order.
+            super_of.push(row);
+        }
+
+        RoleBox {
+            super_of,
+            comp_by_first,
+            comp_by_second,
+            has_compositions,
+        }
+    }
+
+    /// Every super-role of `r` (reflexive-transitive closure of `⊑`), including `r` itself.
+    /// A link `(X, Y) ∈ R(r)` holds for each role this returns (CR10).
+    #[inline]
+    pub fn super_roles(&self, r: Role) -> &[Role] {
+        self.super_of
+            .get(r as usize)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Composition axioms whose FIRST component is `r1`: `(r2, s)` with `r1 ∘ r2 ⊑ s`.
+    #[inline]
+    pub fn compositions_first(&self, r1: Role) -> &[(Role, Role)] {
+        self.comp_by_first
+            .get(&r1)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Composition axioms whose SECOND component is `r2`: `(r1, s)` with `r1 ∘ r2 ⊑ s`.
+    #[inline]
+    pub fn compositions_second(&self, r2: Role) -> &[(Role, Role)] {
+        self.comp_by_second
+            .get(&r2)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+
+    /// Whether the box has any composition axiom. When false the saturator skips CR11 entirely
+    /// (the common case: a TBox with only `rdfs:subPropertyOf` and no chains/transitivity).
+    #[inline]
+    pub fn has_compositions(&self) -> bool {
+        self.has_compositions
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn reflexive_transitive_inclusion_closure() {
+        // r0 ⊑ r1 ⊑ r2. Each role's super-set is the upward chain incl. itself.
+        let rb = RoleBox::build(&[RoleAxiom::Sub(0, 1), RoleAxiom::Sub(1, 2)], 3);
+        assert_eq!(rb.super_roles(0), &[0, 1, 2]);
+        assert_eq!(rb.super_roles(1), &[1, 2]);
+        assert_eq!(rb.super_roles(2), &[2]);
+    }
+
+    #[test]
+    fn inclusion_cycle_is_safe() {
+        // r0 ⊑ r1, r1 ⊑ r0 (equivalent roles). The closure must terminate and contain both.
+        let rb = RoleBox::build(&[RoleAxiom::Sub(0, 1), RoleAxiom::Sub(1, 0)], 2);
+        assert_eq!(rb.super_roles(0), &[0, 1]);
+        assert_eq!(rb.super_roles(1), &[0, 1]);
+    }
+
+    #[test]
+    fn compositions_indexed_on_both_components() {
+        // r0 ∘ r1 ⊑ r2 (a right-identity-flavoured chain).
+        let rb = RoleBox::build(&[RoleAxiom::Chain(0, 1, 2)], 3);
+        assert!(rb.has_compositions());
+        assert_eq!(rb.compositions_first(0), &[(1, 2)]);
+        assert_eq!(rb.compositions_second(1), &[(0, 2)]);
+        assert!(rb.compositions_first(1).is_empty());
+    }
+
+    #[test]
+    fn pure_hierarchy_has_no_compositions() {
+        let rb = RoleBox::build(&[RoleAxiom::Sub(0, 1)], 2);
+        assert!(!rb.has_compositions());
+    }
+}

--- a/crates/sparq-reason-el/tests/rbox_differential.rs
+++ b/crates/sparq-reason-el/tests/rbox_differential.rs
@@ -1,0 +1,200 @@
+// [OPUS-4.8] sq-xetf7: differential-correctness fixtures for the EL+ RBox classifier (Phase E2:
+// CR10 role inclusion + CR11 role composition / transitive roles / property chains).
+//
+// `#![cfg(feature = "rbox")]` — these run ONLY with the `rbox` feature on. A feature-matrix.yml
+// leg (`sparq-reason-el (rbox)`) builds + tests + clippies this file with the feature enabled, so
+// it is NOT a compiled-empty-and-never-run suite (the gap #1171 flagged); the default build (and
+// ci.yml's `--workspace --all-targets` archive, which passes no `--features`) compiles it empty.
+//
+// ORACLE NOTE (same discipline as tests/differential.rs, flagged in the PR + issue #1163): the
+// expected closures are hand-derived from the Baader–Brandt–Lutz / ELK CR1–CR5 + CR10/CR11
+// calculus (the SAME role rules ELK implements) and asserted EXHAUSTIVELY — every expected
+// subsumption holds AND no spurious one does. Each fixture is small enough to verify the role
+// automaton by hand. Making ELK (a JVM + jar fetched over the network) a CI dependency is against
+// the lean-default discipline; where ELK is available locally it can cross-check the same Turtle
+// offline (a developer step, not a gate). E3 (sq-s2nob) revisits ELK-on-CI at biomedical scale.
+
+#![cfg(feature = "rbox")]
+
+use oxrdf::{NamedNode, Term as OTerm};
+use sparq_core::dict::{Dict, Id};
+use sparq_core::Graph;
+use sparq_reason_el::Classifier;
+
+const PRE: &str = r#"
+    @prefix : <http://ex/> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+"#;
+
+fn iri(dict: &Dict, frag: &str) -> Id {
+    dict.lookup(&OTerm::NamedNode(NamedNode::new_unchecked(format!(
+        "http://ex/{frag}"
+    ))))
+}
+
+/// Asserts the classifier's named-class subsumption relation EXACTLY equals `expected` over the
+/// class set `classes` (every pair in `expected` holds; no other proper named subsumption does).
+fn assert_closure(ttl: &str, classes: &[&str], expected: &[(&str, &str)]) {
+    let (dict, triples) = Graph::parse_to_triples(ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    let exp: std::collections::HashSet<(&str, &str)> = expected.iter().copied().collect();
+    for &sub in classes {
+        for &sup in classes {
+            if sub == sup {
+                continue;
+            }
+            let got = h.is_subclass_of(iri(&dict, sub), iri(&dict, sup));
+            let want = exp.contains(&(sub, sup));
+            assert_eq!(
+                got, want,
+                "subsumption {sub} ⊑ {sup}: got {got}, want {want}"
+            );
+        }
+    }
+}
+
+#[test]
+fn cr10_role_inclusion_propagates_existential() {
+    // r ⊑ s,  A ⊑ ∃r.B,  ∃s.B ⊑ C.  CR10 lifts the (A,B) ∈ R(r) link to R(s), so CR4 over
+    // `∃s.B ⊑ C` derives A ⊑ C — a subsumption the E1 classifier (no role hierarchy) misses.
+    let ttl = format!(
+        "{PRE}
+         :r rdfs:subPropertyOf :s .
+         :A rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] .
+         [ owl:onProperty :s ; owl:someValuesFrom :B ] rdfs:subClassOf :C ."
+    );
+    assert_closure(&ttl, &["A", "B", "C"], &[("A", "C")]);
+}
+
+#[test]
+fn cr10_does_not_lift_downward() {
+    // r ⊑ s,  A ⊑ ∃s.B,  ∃r.B ⊑ C.  The link is on s (a SUPER-role of r); CR10 only lifts
+    // UPWARD, so it must NOT reach `∃r.B ⊑ C`. A ⊑ C must NOT be derived (soundness witness).
+    let ttl = format!(
+        "{PRE}
+         :r rdfs:subPropertyOf :s .
+         :A rdfs:subClassOf [ owl:onProperty :s ; owl:someValuesFrom :B ] .
+         [ owl:onProperty :r ; owl:someValuesFrom :B ] rdfs:subClassOf :C ."
+    );
+    assert_closure(&ttl, &["A", "B", "C"], &[]);
+}
+
+#[test]
+fn cr11_transitive_role() {
+    // r transitive (r ∘ r ⊑ r),  A ⊑ ∃r.B,  B ⊑ ∃r.D,  ∃r.D ⊑ E.
+    // (A,B) ∈ R(r) and (B,D) ∈ R(r) compose to (A,D) ∈ R(r) (CR11), so CR4 over `∃r.D ⊑ E`
+    // derives A ⊑ E. Also B ⊑ E directly via (B,D). Transitive-role reasoning is SNOMED-critical.
+    let ttl = format!(
+        "{PRE}
+         :r rdf:type owl:TransitiveProperty .
+         :A rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] .
+         :B rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :D ] .
+         [ owl:onProperty :r ; owl:someValuesFrom :D ] rdfs:subClassOf :E ."
+    );
+    assert_closure(&ttl, &["A", "B", "D", "E"], &[("A", "E"), ("B", "E")]);
+}
+
+#[test]
+fn cr11_transitive_three_hops_recomposes_derived_link() {
+    // Stress the worklist: r transitive, A→B→C→D all via r. (A,B)∘(B,C)⇒(A,C), then the
+    // DERIVED (A,C) must compose with (C,D) ⇒ (A,D) — a composed link re-feeding CR11. With
+    // `∃r.D ⊑ E`, A ⊑ E only holds if the derived link recomposes. B ⊑ E and C ⊑ E too.
+    let ttl = format!(
+        "{PRE}
+         :r rdf:type owl:TransitiveProperty .
+         :A rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] .
+         :B rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :C ] .
+         :C rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :D ] .
+         [ owl:onProperty :r ; owl:someValuesFrom :D ] rdfs:subClassOf :E ."
+    );
+    assert_closure(
+        &ttl,
+        &["A", "B", "C", "D", "E"],
+        &[("A", "E"), ("B", "E"), ("C", "E")],
+    );
+}
+
+#[test]
+fn cr11_property_chain_right_identity() {
+    // The SNOMED right-identity shape: partOf ∘ isa ⊑ partOf — here r ∘ s ⊑ r.
+    // A ⊑ ∃r.B,  B ⊑ ∃s.D,  ∃r.D ⊑ E.  (A,B)∈R(r) ∘ (B,D)∈R(s) ⇒ (A,D)∈R(r) (CR11),
+    // so CR4 over `∃r.D ⊑ E` derives A ⊑ E.
+    let ttl = format!(
+        "{PRE}
+         :r owl:propertyChainAxiom ( :r :s ) .
+         :A rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] .
+         :B rdfs:subClassOf [ owl:onProperty :s ; owl:someValuesFrom :D ] .
+         [ owl:onProperty :r ; owl:someValuesFrom :D ] rdfs:subClassOf :E ."
+    );
+    assert_closure(&ttl, &["A", "B", "D", "E"], &[("A", "E")]);
+}
+
+#[test]
+fn cr11_three_role_chain() {
+    // Length-3 chain p ∘ q ∘ r ⊑ t (left-folded over a fresh role).
+    // A ⊑ ∃p.B,  B ⊑ ∃q.C,  C ⊑ ∃r.D,  ∃t.D ⊑ G.  The three links compose to (A,D)∈R(t),
+    // so CR4 over `∃t.D ⊑ G` derives A ⊑ G. No shorter prefix derives anything (t is the only
+    // role with a `∃t.· ⊑ ·` axiom).
+    let ttl = format!(
+        "{PRE}
+         :t owl:propertyChainAxiom ( :p :q :r ) .
+         :A rdfs:subClassOf [ owl:onProperty :p ; owl:someValuesFrom :B ] .
+         :B rdfs:subClassOf [ owl:onProperty :q ; owl:someValuesFrom :C ] .
+         :C rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :D ] .
+         [ owl:onProperty :t ; owl:someValuesFrom :D ] rdfs:subClassOf :G ."
+    );
+    assert_closure(&ttl, &["A", "B", "C", "D", "G"], &[("A", "G")]);
+}
+
+#[test]
+fn cr10_transitive_inclusion_chain() {
+    // r ⊑ s ⊑ t (a 2-level role hierarchy),  A ⊑ ∃r.B,  ∃t.B ⊑ C.
+    // The reflexive-transitive closure lifts (A,B)∈R(r) all the way to R(t), so A ⊑ C.
+    let ttl = format!(
+        "{PRE}
+         :r rdfs:subPropertyOf :s .  :s rdfs:subPropertyOf :t .
+         :A rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] .
+         [ owl:onProperty :t ; owl:someValuesFrom :B ] rdfs:subClassOf :C ."
+    );
+    assert_closure(&ttl, &["A", "B", "C"], &[("A", "C")]);
+}
+
+#[test]
+fn cr11_bottom_propagates_through_composed_link() {
+    // Composition feeds CR5 too: r transitive,  A ⊑ ∃r.B,  B ⊑ ∃r.D,  D ⊑ ⊥ (via disjointness).
+    // (A,D)∈R(r) by composition, and ⊥∈S(D) ⇒ ⊥∈S(A) (CR5) — A and B are both unsatisfiable.
+    let ttl = format!(
+        "{PRE}
+         :r rdf:type owl:TransitiveProperty .
+         :A rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] .
+         :B rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :D ] .
+         :D rdfs:subClassOf :P .  :D rdfs:subClassOf :Q .  :P owl:disjointWith :Q ."
+    );
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    let unsat = h.unsatisfiable_classes();
+    assert!(unsat.contains(&iri(&dict, "D")), "D ⊑ ⊥ (P ⊓ Q ⊑ ⊥)");
+    assert!(
+        unsat.contains(&iri(&dict, "B")),
+        "CR5: B ⊑ ∃r.D with D ⊑ ⊥ makes B ⊑ ⊥"
+    );
+    assert!(
+        unsat.contains(&iri(&dict, "A")),
+        "CR5 over the composed (A,D) link makes A ⊑ ⊥"
+    );
+}
+
+#[test]
+fn no_chain_no_spurious_composition() {
+    // Sanity: WITHOUT any transitive/chain axiom, a two-hop existential structure must NOT
+    // self-compose. r is a plain role; A ⊑ ∃r.B, B ⊑ ∃r.D, ∃r.D ⊑ E ⇒ only B ⊑ E (not A ⊑ E).
+    let ttl = format!(
+        "{PRE}
+         :A rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] .
+         :B rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :D ] .
+         [ owl:onProperty :r ; owl:someValuesFrom :D ] rdfs:subClassOf :E ."
+    );
+    assert_closure(&ttl, &["A", "B", "D", "E"], &[("B", "E")]);
+}

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -126,8 +126,9 @@ let _ = h.super_classes(some_class_id);
 let _ = h.unsatisfiable_classes();      // classes forced ⊑ owl:Nothing (e.g. via disjointWith)
 ```
 
-- **Scope (MVP, Phase E1):** `EL+⊥` minus RBox — `rdfs:subClassOf`/`owl:equivalentClass`, `owl:intersectionOf`, `owl:someValuesFrom` restrictions, `owl:disjointWith`, `owl:Thing`/`owl:Nothing`. Axioms outside that fragment (unionOf / complementOf / allValuesFrom / cardinality / nominals / RBox) are **not applied** and counted in `Report::skipped_axioms` (honest, never silently misapplied). Single-threaded.
-- **Deferred:** RBox / property chains / transitive roles (CR10/CR11) → Phase E2 (bead `sq-xetf7`); transitive reduction + scale → E3 (`sq-s2nob`); concurrency → E4; nominals + concrete domains later. The emitted lattice is the *full* (not transitively-reduced) set of derived subsumptions.
+- **Scope (default, Phase E1):** `EL+⊥` minus RBox — `rdfs:subClassOf`/`owl:equivalentClass`, `owl:intersectionOf`, `owl:someValuesFrom` restrictions, `owl:disjointWith`, `owl:Thing`/`owl:Nothing`. Class axioms outside that fragment (unionOf / complementOf / allValuesFrom / cardinality / nominals) are **not applied** and counted in `Report::skipped_axioms` (honest, never silently misapplied). Single-threaded.
+- **RBox role reasoning (opt-in `rbox` feature, Phase E2, bead `sq-xetf7`):** add `features = ["rbox"]`. Applies `rdfs:subPropertyOf` role inclusions (**CR10**) and `owl:propertyChainAxiom` + `owl:TransitiveProperty` compositions (**CR11**, incl. the SNOMED-critical right-identity `r ∘ s ⊑ s`) via a saturated role automaton, so links propagate up the role hierarchy and along chains before CR4/CR5 fire. **OFF by default** — zero role-automaton code in the default/wasm build; without it RBox axioms are left unapplied (roles compared for equality only). Same `Classifier`/`classify_graph` API; no signature change.
+- **Deferred:** transitive reduction + scale → E3 (`sq-s2nob`); concurrency → E4; nominals + concrete domains later. The emitted lattice is the *full* (not transitively-reduced) set of derived subsumptions.
 - **Use EL, not `--reason owl`, when you need a complete class hierarchy over an EL ontology.** RL is not an approximation you can tune up with more rules — EL needs a different algorithm.
 
 ## Common recipes


### PR DESCRIPTION
> 🤖 SPARQ agent — opened by an automated SPARQ agent (Opus 4.8, 1M context). Reach @jeswr for anything needing a human.

## What

Phase **E2** of the OWL 2 EL track (`research/owl2-el-ql-reasoning-spike.md` §5), extending the merged **E1** classifier (`sq-evb1`, #1162) with the **SNOMED-critical RBox role automaton** behind a **default-OFF `rbox` cargo feature** on `sparq-reason-el`. Closes bead **`sq-xetf7`**.

Without `rbox` the crate is the byte-for-byte E1 classifier (roles compared for equality only; `rdfs:subPropertyOf` / `owl:propertyChainAxiom` / `owl:TransitiveProperty` axioms left unapplied). With `rbox` the saturator additionally applies:

- **CR10 — role inclusion** `r ⊑ s`: a link `(X,Y) ∈ R(r)` lifts to every super-role (reflexive-transitive closure of told inclusions, precomputed once).
- **CR11 — role composition** `r1 ∘ r2 ⊑ s`: transitive roles (`r ∘ r ⊑ r`), property chains (left-folded into binary compositions over fresh roles), and the SNOMED right-identity `r ∘ s ⊑ s`.

Each derived/composed link feeds CR4/CR5 exactly like an asserted one, so existential reasoning now traverses the role hierarchy and chains.

## How

- **`normal.rs`** — `RoleAxiom` (`Sub` / `Chain`) + `fresh_role`/`role_count` for chain folding (`#[cfg(feature = "rbox")]`).
- **`rbox.rs`** *(new)* — `RoleBox`: reflexive-transitive inclusion closure (CR10) + compositions indexed on both components (CR11), with a `has_compositions` fast-path for pure role hierarchies.
- **`extract.rs`** — reads the RBox vocabulary; `Extracted` bundle carries the role axioms in a feature-gated field (the default extraction path is unchanged).
- **`classify.rs`** — `add_link_rbox` closes every CR3 link under CR10/CR11 via a **link worklist** (derived links re-compose to a fixpoint) before CR4/CR5 fire. `add_link` now returns whether the link was new.

**Opt-in / lean-core:** default build and the lean wasm port carry **zero** role-automaton code. **No new dependency** (`rbox = []`, reuses `oxrdf` + `rustc-hash`); **`Cargo.lock` unchanged** (memmap2 stays 0.9.11).

## Tests + the feature-matrix leg (closes the #1171 gap)

`tests/rbox_differential.rs` is `#![cfg(feature = "rbox")]` — **9** hand-derived CR10/CR11 closure-oracle cases (role inclusion + an **upward-only soundness witness** that must NOT derive, transitive role, right-identity chain, 3-role chain, **3-hop recomposition stress**, ⊥-through-composed-link, no-spurious-composition guard) + **4** `rbox::tests` unit tests. A new **`sparq-reason-el (rbox …)` `feature-matrix.yml` leg** builds + tests + clippies them with the feature ON, so they are not compiled-empty-and-never-run.

**Oracle note** (same discipline as E1, flagged in #1163): the expected closures are hand-derived from the Baader–Brandt–Lutz / ELK CR1–CR5 + CR10/CR11 calculus — the same role rules ELK implements — and asserted exhaustively (every subsumption holds AND no spurious one does). Making ELK (a JVM + jar over the network) a CI dependency is against the lean-default discipline; ELK can cross-check the same Turtle offline as a developer step. E3 (`sq-s2nob`) revisits ELK-on-CI at biomedical scale.

## Gates (GREEN in BOTH feature states)

Feature flags: **default (`rbox` OFF)** and **`rbox` ON**.

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — green with `rbox` OFF and ON (and workspace `clippy --all-targets --all-features -D warnings`).
- `cargo doc --workspace --no-deps --all-features` with `RUSTDOCFLAGS="-D warnings"` — clean.
- `scripts/check-readme-template.py --enforce` — 0 deviations (README 70 lines, ≤120 cap).
- `scripts/check-privacy-claims.sh` — clean (no ZK/MPC claims in this change).
- `cargo fmt --check` (crate) — clean.

Docs: crate `README.md`, `skills/inference/SKILL.md`, and the `Report` doc-comment updated for the opt-in feature + its honest boundary.

Auto-merge intentionally **OFF** — for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)