### PR TITLE
feat(sparq-trust): trust-document storage/authoring model (opt-in `store`) (sq-pfae.5) [OPUS-4.8]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -347,6 +347,21 @@ jobs:
             crate: sparq-mpc
             features: insecure-test-rng
             test: true
+          # [OPUS-4.8] sq-pfae.5: the trust-document STORAGE/AUTHORING model. The whole
+          # `store` module + the `tests/trust_store_cache_key.rs` integration suite are
+          # `#[cfg(feature = "store")]` behind `default = []`, so the default build/clippy/
+          # test (and ci.yml's archive) compile them EMPTY and run ZERO of the store unit
+          # tests + the 3 cache-key/narrowing integration tests. This leg compiles the module,
+          # runs `clippy --all-targets -D warnings` with the feature ON (the real gate), and
+          # runs `cargo test`, which drives the REAL TrustStore + admit path (cache-key
+          # invalidation on policy edit/revoke, per-`.acr` freshness narrowing, distinct
+          # evidence hashes). `store` is std-only (no new dep — it reuses the sparq-zk
+          # commitment + std hashing), so this is a fast leg. Verified: `cargo nextest list -p
+          # sparq-trust --features store` lists the 7 store unit tests + 3 integration tests.
+          - name: sparq-trust (store)
+            crate: sparq-trust
+            features: store
+            test: true
           # [OPUS-4.8] sq-h3uk: the ODRL->AUTH_GRAPH bridge (pulls the optional
           # sparq-policy ODRL evaluator) — keeps the opt-in ON path from rotting.
           - name: sparq-solid (odrl-bridge)

--- a/crates/sparq-trust/Cargo.toml
+++ b/crates/sparq-trust/Cargo.toml
@@ -36,6 +36,13 @@ rustdoc-args = ["--cfg", "docsrs"]
 default = []
 # DID resolution + issuer-key binding (`did:key` offline self-cert + pluggable `did:web`).
 did = ["dep:serde_json"]
+# [OPUS-4.8] sq-pfae.5 — the trust-document STORAGE/AUTHORING model: server-wide vs
+# per-`.acr` documents (per-`.acr` NARROWS, never broadens), monotone document
+# versioning + revocation, and the admission cache key (evidence hash + policy version)
+# that composes with the sparq-solid epoch cache. Pure-Rust over the deps already
+# present (sparq-zk commitment for the evidence hash, std hashing) — NO new dependency,
+# so the lean default build is byte-identical with it OFF.
+store = []
 
 [dependencies]
 sparq-core = { path = "../sparq-core", default-features = false }

--- a/crates/sparq-trust/README.md
+++ b/crates/sparq-trust/README.md
@@ -54,8 +54,8 @@ view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
 - **The minimal `trust:` ontology** (`vocab`) — the 10-term core (`TrustPolicy`, `TrustRule`,
   `trustsSourceFor`, `source`, `forShape`, `Source`, `issuerKey`, `scope`, `freshWithin`,
   `admitted`) + `issuerDid` + the `forPredicate → forShape` desugaring. Published as Turtle
-  ([`trust.ttl`](ontologies/trust/trust.ttl), semantics in [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md));
-  a sync test pins it to the Rust constants. **All `trust:` IRIs are NON-STANDARD** — a WG would rehome them.
+  ([`trust.ttl`](ontologies/trust/trust.ttl), [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md)); a sync
+  test pins it to the Rust constants. **All `trust:` IRIs are NON-STANDARD** — a WG would rehome them.
 - **Fail-closed policy parsing** (`policy`) — a trust policy not presented through the
   Control-gated channel admits nothing (a type-level `ControlGate`). Accepts the reified
   `trust:TrustRule` form AND the claim-level `trust:trustsSourceFor` relational form (per-(source,
@@ -64,12 +64,16 @@ view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
   issuer signature over the commitment (`sparq-zk`, never a self-asserted triple), enforce
   statement-type scoping via a real SHACL shape (`sparq-shacl`), freshness, and the clear-WebID
   holder binding. Default-deny, short-circuit.
-- **N3 merge** (`wire`) — feed the admitted facts into the shipped `sparq-reason` reasoner ahead of
-  the materialiser; the `.acr` ABAC rule derives the grant (the age>18 worked example runs end-to-end).
+- **N3 merge** (`wire`) — feed admitted facts into `sparq-reason`; the `.acr` ABAC rule derives the grant (age>18 e2e).
+- **Storage / authoring model** (`store`, **opt-in `store` feature**, `sq-pfae.5`) — where trust
+  rules live: a server-wide default + per-`.acr` documents, where a per-`.acr` document **NARROWS,
+  never broadens** the server ceiling (`effective_rules`). Monotone versioning (stale rejected) +
+  revocation. The `AdmissionCacheKey` (evidence hash + policy version) composes with the sparq-solid
+  epoch cache: a policy edit/revoke bumps the version + invalidates the cached verdict. No new dep.
 - **Static / dynamic admission split** (`admit_static` + `derive_conditional_grants`, `sq-xc4y`) —
-  `admit_static` decides the **session-independent** class (signature, type-scope, scope) once at
-  materialise-time and defers the **per-request** class (holder + freshness) to an
-  `auth:ConditionalGrant` re-checked per request (shipped sq-0q7n path) — never frozen into the view.
+  decides the **session-independent** class (signature, type-scope, scope) once at materialise-time
+  and defers the **per-request** class (holder + freshness) to an `auth:ConditionalGrant` re-checked
+  per request (shipped sq-0q7n path) — never frozen into the view.
 - **The invocation-binding gate** (`delegation`, `sq-l5og`) — verify a carried ZCAP/UCAN-style
   delegation chain (each hop a CHECKED delegator signature over delegator/delegate **keys** +
   capability + expiry), enforce monotone attenuation (`child ⊆ parent`), and bind **authenticated
@@ -77,10 +81,9 @@ view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
   Folding each hop's `delegate_key` into the signed preimage defeats the key-substitution
   stolen-chain replay; the forgery matrix runs end-to-end.
 - **DID issuer-key binding** (`did`, **opt-in `did` feature**, `sq-pfae.3`) — a rule may name its
-  issuer by `trust:issuerDid` instead of `trust:issuerKey` hex. `DidKeyResolver` decodes a
-  self-certifying `did:key` offline; `DidWebResolver` reads the key from a `did:web` document via a
-  **pluggable** fetcher (no HTTP client on the default build); `resolve_rule_keys` feeds the resolved
-  key into the unchanged signature check. **Narrows** D′ (`did:key` self-cert; `did:web` host/TLS-rooted).
+  issuer by `trust:issuerDid` instead of `trust:issuerKey` hex. `DidKeyResolver` decodes a `did:key`
+  offline; `DidWebResolver` reads a `did:web` document via a **pluggable** fetcher (no HTTP client on
+  the default build). **Narrows** the operator-asserted-key forgery vector D′ (not an absolute anchor).
 
 ## Honest scope — what this does and does NOT do
 
@@ -89,30 +92,27 @@ view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
   unlinkable presentation.
 - **Holder binding is the clear-WebID, non-anonymous degraded path** (`sq-wvne`):
   `credentialSubject == Session.agent` authenticates the WebID in the clear — documented, not
-  silently "solved". Presentations stay linkable by requester identity. (Its materialise-time
-  composition, `sq-xc4y`, is RESOLVED by the static/dynamic split; the *clear-WebID* limitation remains.)
+  silently "solved". Presentations stay linkable by requester identity.
 - **Issuer keys: operator-asserted by default; DID-bindable (opt-in, `sq-pfae.3`).** The default
   `trust:issuerKey` hex binding is the live forgery vector D′ (§3.3); the `did` feature binds it from
   a `trust:issuerDid` instead, which **narrows** D′ but is no absolute anchor (`did:key` self-cert;
   `did:web` only as strong as host/TLS).
 - **Delegation invocation is the clear-WebID, non-anonymous path too** (`sq-l5og`): the gate
-  authenticates the invoker AS the terminal delegate's WebID in the clear — **not**
-  anonymous/unlinkable. The `delegate_key` binding defeats the key-substitution stolen-chain replay
-  but **not** full non-replayability (the delegate key is only as trustworthy as the delegator key
-  that attests it; DID-bindable via the `did` feature; deep-chain *incremental* revocation stays
-  open — rustdoc has the full reasoning).
+  authenticates the invoker AS the terminal delegate's WebID in the clear. The `delegate_key` binding
+  defeats the key-substitution stolen-chain replay but **not** full non-replayability; deep-chain
+  *incremental* revocation stays open (rustdoc has the full reasoning).
 - **Open problems respected as documented limitations:** `sq-tu4e` (no in-reasoner NAF;
-  `revoked` is input-only) and `sq-wvne` (ZK privacy) are **out of PoC scope**; `sq-xc4y` is
-  RESOLVED by the static/dynamic split; `sq-l5og` is **specified, enforced, and tested**.
-- **Strict additivity (G6):** with `sparq-solid`'s `trust-graph` feature OFF, the crate is not
+  `revoked` is input-only) and `sq-wvne` (ZK privacy) are **out of PoC scope**; `sq-xc4y` is RESOLVED
+  by the static/dynamic split; `sq-l5og` is **specified, enforced, and tested**.
+- **Strict additivity (G6):** with `sparq-solid`'s `trust-graph` feature OFF the crate is not
   compiled and `sparq-solid` behaves exactly as WAC/ACP do today (byte-identical).
 
 ## 📚 Learn more
 
-- The machine-readable vocabulary [`trust.ttl`](ontologies/trust/trust.ttl) and its
-  [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md) normative two-stratum semantics note (`sq-pfae.2`).
-- The design record `research/solid-trust-graph-authz-design.md` (§6.0 PoC spec; §7 honest limits) —
-  [issue #940](https://github.com/jeswr/sparq/issues/940); the host crate
+- The machine-readable vocabulary [`trust.ttl`](ontologies/trust/trust.ttl) +
+  [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md) two-stratum semantics note (`sq-pfae.2`), and the
+  design record `research/solid-trust-graph-authz-design.md` (§3.2 storage model; §6.0 PoC spec; §7
+  honest limits) — [issue #940](https://github.com/jeswr/sparq/issues/940). The host crate
   [`sparq-solid`](../sparq-solid/README.md). `cargo doc -p sparq-trust --all-features` for full docs.
 
 ## License

--- a/crates/sparq-trust/src/lib.rs
+++ b/crates/sparq-trust/src/lib.rs
@@ -126,6 +126,13 @@ pub mod delegation;
 #[cfg_attr(docsrs, doc(cfg(feature = "did")))]
 pub mod did;
 pub mod policy;
+/// The trust-document storage / authoring model — server-wide vs per-`.acr` documents,
+/// versioning, revocation, and the admission cache key that composes with the
+/// sparq-solid epoch cache (the P4 model, `sq-pfae.5`). Behind the default-OFF `store`
+/// feature: nothing in the lean default build depends on it.
+#[cfg(feature = "store")]
+#[cfg_attr(docsrs, doc(cfg(feature = "store")))]
+pub mod store;
 pub mod vocab;
 pub mod wire;
 
@@ -143,4 +150,8 @@ pub use did::{
 pub use policy::{parse_policy, ControlGate, PolicyError, ShapeRef, TrustRule};
 #[cfg(feature = "did")]
 pub use policy::{resolve_rule_keys, IssuerBinding};
+#[cfg(feature = "store")]
+pub use store::{
+    AdmissionCacheKey, PolicyVersion, StoreError, TrustDocument, TrustLayer, TrustStore,
+};
 pub use wire::{derive_conditional_grants, derive_grants, ConditionalGrant};

--- a/crates/sparq-trust/src/store.rs
+++ b/crates/sparq-trust/src/store.rs
@@ -1,0 +1,793 @@
+//! # `store.rs` — trust-document storage / authoring model (`store` feature, opt-in)
+//!
+//! Where trust rules LIVE, how they are versioned + revoked, and how a server-wide
+//! default composes with per-`.acr` documents — the P4 storage/authoring model of the
+//! design record (`research/solid-trust-graph-authz-design.md` §3.2 / §8 Q1; epic
+//! `sq-pfae`, bead `sq-pfae.5`). `policy.rs` answers *"what is one admission rule"*;
+//! this module answers *"where does the policy come from, which version is in force, and
+//! how do a server default and a per-`.acr` document combine"*.
+//!
+//! ## Two layers, one composition — BOTH, with per-`.acr` NARROWING (design §3.2)
+//!
+//! The §8 Q1 maintainer decision is **both** scopes, with the monotone discipline
+//! ACP inheritance already uses:
+//!
+//! - [`TrustLayer::ServerWide`] — the server-wide default trust policy (one per
+//!   server). It establishes the **ceiling**: a `(source, statement-type)` pair the
+//!   server default does NOT trust can never be admitted, no matter what a deeper
+//!   document says.
+//! - [`TrustLayer::Container`] — a per-`.acr` trust document anchored at a container /
+//!   resource path. It may only **NARROW** the server default: tighten the freshness
+//!   window, restrict the scope to a sub-tree, or drop a source — it can **NEVER**
+//!   introduce a new trusted `(source, statement-type)` the server default did not
+//!   already grant. Broadening fails closed (the rule is simply not in the effective
+//!   set). This is the load-bearing soundness property of the storage model
+//!   ([`TrustStore::effective_rules`]): a writer who controls one container's `.acr`
+//!   cannot widen trust beyond the server administrator's ceiling.
+//!
+//! ## Control-gating, versioning, revocation
+//!
+//! - **Control-gated.** A [`TrustDocument`] can only be built behind a
+//!   [`ControlGate`](crate::policy::ControlGate) — the SAME fail-closed channel as
+//!   `.acl`/`.acr` (§3.2). A document that did not arrive through Control cannot enter
+//!   the store; there is no un-gated constructor.
+//! - **Versioned.** Each document carries a monotone [`TrustDocument::version`]. An
+//!   author bumps it on every edit; the store rejects a stale (≤ current) version on
+//!   update ([`TrustStore::put`] returns [`StoreError::StaleVersion`]) so a replayed
+//!   old document can never silently roll trust back.
+//! - **Revoked.** Revocation is **document removal** ([`TrustStore::revoke`]): the
+//!   document leaves the store and the [`PolicyVersion`] for every affected target
+//!   bumps, so the composed admission decision is invalidated. (This matches the
+//!   epoch-bump-on-rematerialise discipline — revocation propagates by re-materialise,
+//!   §3.3 / G5; there is no in-place retraction inside a single reasoner run.)
+//!
+//! ## The admission cache key (composes with the sparq-solid epoch cache)
+//!
+//! [`AdmissionCacheKey`] `= (evidence_hash, policy_version)` is the design's §9.1
+//! cache-key recipe made concrete:
+//!
+//! - `evidence_hash` — a stable hash of the presented credential's RDFC-1.0 commitment
+//!   + bound holder (the per-credential evidence). Two requests presenting the SAME
+//!   credential for the SAME holder share it.
+//! - `policy_version` — the [`PolicyVersion`] for the target: the aggregate of the
+//!   server-wide document version and every per-`.acr` document in force on the path to
+//!   the target. ANY contributing document edit / revocation bumps it.
+//!
+//! It composes with the sparq-solid **epoch cache**: the host caches an admission
+//! verdict under `(epoch, AdmissionCacheKey)`. A re-materialise bumps the epoch (drops
+//! everything); a trust-document edit/revoke bumps the `policy_version` (drops only the
+//! entries for affected targets); a different credential changes the `evidence_hash`.
+//! So a stale verdict is NEVER served after either the auth view OR the trust policy
+//! changed — the load-bearing invalidation property this module exists to provide.
+//!
+//! ## Honest scope
+//!
+//! This is the STORAGE / AUTHORING model, not a new admission primitive: it decides
+//! *which* [`TrustRule`]s are in force for a target and a cache key over them. It adds
+//! NO cryptographic guarantee; the admission gate ([`mod@crate::admit`]) and its honest
+//! caveats (no privacy/unlinkability; operator-asserted issuer keys; externally
+//! UNAUDITED ZK estate — `sq-qhy4`) are unchanged.
+//!
+//! [OPUS-4.8] sq-pfae.5 P4 storage/authoring model (issue #940). Written while Fable
+//! unavailable — flag for re-review when Fable returns. 🤖 SPARQ agent — trust-graph
+//! authorisation PoC.
+
+use crate::admit::{scope_covers, PresentedCredential};
+use crate::policy::{ControlGate, TrustRule};
+use oxrdf::NamedNode;
+use sparq_zk::commit::commit_triples;
+use sparq_zk::encode::salt_from_bytes;
+use sparq_zk::field::field_to_be_bytes_32;
+use std::collections::hash_map::DefaultHasher;
+use std::collections::BTreeMap;
+use std::hash::{Hash, Hasher};
+
+/// Where a trust document lives (§3.2 / §8 Q1 — the storage layer). The model is
+/// **both** server-wide and per-`.acr`, with [`TrustLayer::Container`] narrowing the
+/// [`TrustLayer::ServerWide`] default.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum TrustLayer {
+    /// The server-wide default trust policy (one per server). It establishes the
+    /// ceiling on what any deeper document may admit.
+    ServerWide,
+    /// A per-`.acr` trust document anchored at a container / resource path (the IRI of
+    /// the container or resource the `.acr` governs). It may only narrow the ceiling.
+    Container(NamedNode),
+}
+
+impl TrustLayer {
+    /// The anchor IRI of a [`TrustLayer::Container`], or `None` for the server-wide
+    /// layer. Used to order layers by path-specificity (a deeper anchor is more
+    /// specific).
+    pub fn anchor(&self) -> Option<&NamedNode> {
+        match self {
+            TrustLayer::ServerWide => None,
+            TrustLayer::Container(a) => Some(a),
+        }
+    }
+
+    /// Whether this layer's anchor covers `target` (so the layer's rules are CANDIDATES
+    /// for the target). The server-wide layer covers every target; a container layer
+    /// covers a target iff the target is the anchor or a descendant of it (Solid
+    /// slash-semantics, the same containment [`scope_covers`] uses).
+    pub fn covers(&self, target: &NamedNode) -> bool {
+        match self {
+            TrustLayer::ServerWide => true,
+            TrustLayer::Container(anchor) => scope_covers(anchor, target),
+        }
+    }
+}
+
+/// A Control-gated, versioned trust document at a [`TrustLayer`]. Holds the
+/// already-parsed [`TrustRule`]s (parse them with [`crate::parse_policy`], which itself
+/// requires a [`ControlGate`]).
+///
+/// A document can only be built with [`TrustDocument::new`], which REQUIRES a
+/// [`ControlGate`]: a document that did not arrive through the trusted `.acl`/`.acr`
+/// channel cannot enter the store (fail-closed, §3.2).
+#[derive(Debug, Clone)]
+pub struct TrustDocument {
+    /// Where the document lives (server-wide vs a per-`.acr` container).
+    layer: TrustLayer,
+    /// The monotone version the author stamps. Bumped on every edit; a stale version is
+    /// rejected on update ([`StoreError::StaleVersion`]).
+    version: u64,
+    /// The parsed admission rules this document carries.
+    rules: Vec<TrustRule>,
+}
+
+impl TrustDocument {
+    /// Build a Control-gated trust document. Possession of a [`ControlGate`] asserts the
+    /// document arrived through the `.acl`/`.acr` channel (§3.2) — there is no un-gated
+    /// constructor, so an untrusted writer's document can never enter the store.
+    pub fn new(
+        layer: TrustLayer,
+        version: u64,
+        rules: Vec<TrustRule>,
+        _gate: ControlGate,
+    ) -> TrustDocument {
+        TrustDocument {
+            layer,
+            version,
+            rules,
+        }
+    }
+
+    /// The layer this document lives at.
+    pub fn layer(&self) -> &TrustLayer {
+        &self.layer
+    }
+
+    /// The monotone document version.
+    pub fn version(&self) -> u64 {
+        self.version
+    }
+
+    /// The admission rules this document carries.
+    pub fn rules(&self) -> &[TrustRule] {
+        &self.rules
+    }
+}
+
+/// The aggregate policy version in force for a target: the combination of the
+/// server-wide document version and every per-`.acr` document on the path to the
+/// target. Any contributing document edit / revocation changes it, so it is a stable
+/// cache-invalidation token. Composes with the sparq-solid epoch cache (§9.1).
+///
+/// It is an opaque 64-bit token — callers compare it for equality / use it as a cache
+/// key, never interpret its value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct PolicyVersion(pub u64);
+
+/// A composed admission cache key: `(evidence_hash, policy_version)` (design §9.1). Two
+/// admission requests share a key iff they present the SAME credential evidence for the
+/// SAME holder AND the trust policy in force for the target is at the SAME version. It
+/// composes with the sparq-solid epoch cache: cache an admission verdict under
+/// `(epoch, AdmissionCacheKey)`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AdmissionCacheKey {
+    /// A stable hash of the presented credential's RDFC-1.0 commitment + bound holder
+    /// (the per-credential evidence). `0` is reserved for a credential whose graph
+    /// could not be committed (fail-closed: such a credential admits nothing anyway, so
+    /// the key never serves a real verdict).
+    pub evidence_hash: u64,
+    /// The [`PolicyVersion`] for the target.
+    pub policy_version: PolicyVersion,
+}
+
+/// Why a trust-store update was rejected (fail-closed: a rejected update leaves the
+/// store unchanged).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StoreError {
+    /// A [`TrustStore::put`] presented a version `≤` the version already stored at that
+    /// layer — a stale or replayed document. The existing document is kept.
+    StaleVersion {
+        /// The version already in the store.
+        current: u64,
+        /// The (rejected) version that was presented.
+        presented: u64,
+    },
+}
+
+impl std::fmt::Display for StoreError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            StoreError::StaleVersion { current, presented } => write!(
+                f,
+                "stale trust-document version {} (store is at {}): rejected fail-closed",
+                presented, current
+            ),
+        }
+    }
+}
+
+impl std::error::Error for StoreError {}
+
+/// The trust-document store: a server-wide default plus zero-or-more per-`.acr`
+/// documents, composed with per-`.acr` NARROWING (§3.2). It owns the
+/// version/revocation bookkeeping and produces the [`PolicyVersion`] +
+/// [`AdmissionCacheKey`] that compose with the sparq-solid epoch cache.
+#[derive(Debug, Clone, Default)]
+pub struct TrustStore {
+    /// The server-wide default (`None` until one is installed — fail-closed: with no
+    /// server default, NOTHING is admissible, because a per-`.acr` document can only
+    /// narrow a ceiling that does not exist).
+    server_wide: Option<TrustDocument>,
+    /// The per-`.acr` documents, keyed by their anchor IRI. `BTreeMap` for a
+    /// deterministic, anchor-ordered iteration (so the composed result is stable).
+    containers: BTreeMap<String, TrustDocument>,
+}
+
+impl TrustStore {
+    /// An empty store (no server default, no per-`.acr` documents). Fail-closed:
+    /// admits nothing until a server-wide default is installed.
+    pub fn new() -> TrustStore {
+        TrustStore::default()
+    }
+
+    /// Install or update a trust document. The version MUST be strictly greater than the
+    /// version currently stored at the same layer — a stale/replayed document is rejected
+    /// with [`StoreError::StaleVersion`] and the store is left unchanged (monotone
+    /// versioning, §3.2). A brand-new layer accepts any version.
+    pub fn put(&mut self, doc: TrustDocument) -> Result<(), StoreError> {
+        match doc.layer.clone() {
+            TrustLayer::ServerWide => {
+                if let Some(existing) = &self.server_wide {
+                    if doc.version <= existing.version {
+                        return Err(StoreError::StaleVersion {
+                            current: existing.version,
+                            presented: doc.version,
+                        });
+                    }
+                }
+                self.server_wide = Some(doc);
+            }
+            TrustLayer::Container(anchor) => {
+                let key = anchor.as_str().to_string();
+                if let Some(existing) = self.containers.get(&key) {
+                    if doc.version <= existing.version {
+                        return Err(StoreError::StaleVersion {
+                            current: existing.version,
+                            presented: doc.version,
+                        });
+                    }
+                }
+                self.containers.insert(key, doc);
+            }
+        }
+        Ok(())
+    }
+
+    /// Revoke (remove) the document at a layer. Returns `true` if a document was present
+    /// and removed. Revocation is document removal: after it, [`TrustStore::policy_version`]
+    /// for every affected target changes, invalidating any cached admission verdict
+    /// (§3.3 / G5 — revocation propagates by re-materialise, not in-place retraction).
+    pub fn revoke(&mut self, layer: &TrustLayer) -> bool {
+        match layer {
+            TrustLayer::ServerWide => self.server_wide.take().is_some(),
+            TrustLayer::Container(anchor) => self.containers.remove(anchor.as_str()).is_some(),
+        }
+    }
+
+    /// The effective trust rules in force for `target`: the server-wide default,
+    /// NARROWED by every per-`.acr` document on the path to the target.
+    ///
+    /// The composition is **monotone narrowing** (§3.2): a per-`.acr` rule enters the
+    /// effective set ONLY if it is covered by (a narrowing of) some server-default rule
+    /// for the SAME `(source, statement-type-shape)` — i.e. the per-`.acr` document may
+    /// restrict scope / freshness, but may NOT trust a `(source, type)` the server
+    /// default did not. A per-`.acr` rule with no matching server-default rule is
+    /// DROPPED (broadening is fail-closed).
+    ///
+    /// Concretely, the effective rule for a `(source, shape-key)` the server trusts is
+    /// the **tightest** of the server default and any covering per-`.acr` narrowing:
+    /// the smaller freshness window and the more-specific scope. A target with no
+    /// server default admits nothing (empty result).
+    pub fn effective_rules(&self, target: &NamedNode) -> Vec<TrustRule> {
+        let Some(server) = &self.server_wide else {
+            return Vec::new(); // fail-closed: no ceiling ⇒ nothing admissible
+        };
+
+        // The per-`.acr` documents whose anchor covers the target, from least specific
+        // (shallowest container) to most specific (deepest). A deeper document narrows
+        // a shallower one — but ALL are still bounded by the server ceiling.
+        let mut covering: Vec<&TrustDocument> = self
+            .containers
+            .values()
+            .filter(|d| d.layer.covers(target))
+            .collect();
+        covering.sort_by_key(|d| d.layer.anchor().map(|a| a.as_str().len()).unwrap_or(0));
+
+        let mut out: Vec<TrustRule> = Vec::new();
+        // Start from the server ceiling: every server rule that itself covers the
+        // target is a candidate.
+        for srule in server.rules() {
+            if !scope_covers(&srule.scope, target) {
+                continue;
+            }
+            // Narrow this server rule by every covering per-`.acr` rule that matches its
+            // (source, statement-type) AND is itself a narrowing (covered scope). A
+            // per-`.acr` rule that does NOT match any server rule is broadening — never
+            // applied here, so it is dropped (fail-closed).
+            let mut eff = srule.clone();
+            for doc in &covering {
+                for crule in doc.rules() {
+                    if narrows(srule, crule, target) {
+                        eff = tighten(&eff, crule);
+                    }
+                }
+            }
+            out.push(eff);
+        }
+        out
+    }
+
+    /// The [`PolicyVersion`] in force for `target`: a stable aggregate of the
+    /// server-wide document version and every per-`.acr` document covering the target.
+    /// Any contributing document edit (version bump) or revocation (removal) changes it,
+    /// so it is a sound cache-invalidation token.
+    pub fn policy_version(&self, target: &NamedNode) -> PolicyVersion {
+        let mut hasher = DefaultHasher::new();
+        // Domain tag so a server-wide-version `N` never collides with a container
+        // version `N`.
+        "trust-policy-version:v1".hash(&mut hasher);
+        match &self.server_wide {
+            Some(d) => {
+                0u8.hash(&mut hasher); // present
+                d.version.hash(&mut hasher);
+            }
+            None => 1u8.hash(&mut hasher), // absent — still a distinct, stable state
+        }
+        // Containers covering the target, in deterministic anchor order (BTreeMap is
+        // already sorted by the String key). Both the anchor IRI AND the version are
+        // folded in, so adding/removing a covering document changes the result.
+        for (anchor, doc) in &self.containers {
+            if doc.layer.covers(target) {
+                anchor.hash(&mut hasher);
+                doc.version.hash(&mut hasher);
+            }
+        }
+        PolicyVersion(hasher.finish())
+    }
+
+    /// The composed [`AdmissionCacheKey`] for presenting `cred` (bound to `holder`) at
+    /// `target`: `(evidence_hash, policy_version)`. Composes with the sparq-solid epoch
+    /// cache — see the module docs.
+    pub fn admission_cache_key(
+        &self,
+        cred: &PresentedCredential,
+        holder: &NamedNode,
+        target: &NamedNode,
+    ) -> AdmissionCacheKey {
+        AdmissionCacheKey {
+            evidence_hash: evidence_hash(cred, holder),
+            policy_version: self.policy_version(target),
+        }
+    }
+}
+
+/// A stable per-credential evidence hash: the RDFC-1.0 commitment over the credential
+/// graph (the same canonical unit the admission gate and the ZK estate commit over)
+/// folded with the bound holder WebID. `0` for a credential whose graph cannot be
+/// committed (fail-closed — such a credential admits nothing).
+fn evidence_hash(cred: &PresentedCredential, holder: &NamedNode) -> u64 {
+    let salt = salt_from_bytes(&cred.salt);
+    let Ok(commitment) = commit_triples(&cred.graph, salt) else {
+        return 0; // uncommittable ⇒ reserved sentinel; never serves a real verdict
+    };
+    let mut hasher = DefaultHasher::new();
+    "trust-evidence:v1".hash(&mut hasher);
+    field_to_be_bytes_32(&commitment.commitment).hash(&mut hasher);
+    holder.as_str().hash(&mut hasher);
+    // The signature binds the credential to its issuer; fold it so two graphs with the
+    // same commitment but different issuer signatures never share an evidence key.
+    cred.issuer_signature_hex.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Whether a per-`.acr` rule `crule` is a NARROWING of a server-default rule `srule`
+/// for the target — i.e. it trusts the SAME source for the SAME statement-type-shape
+/// and its scope is covered by (within) the server rule's scope. A per-`.acr` rule that
+/// trusts a different source / type, or whose scope is NOT within the server rule's, is
+/// NOT a narrowing (it would broaden) and is rejected.
+fn narrows(srule: &TrustRule, crule: &TrustRule, target: &NamedNode) -> bool {
+    // Same trusted source.
+    if srule.source.as_str() != crule.source.as_str() {
+        return false;
+    }
+    // Same statement-type: the issuer key the source signs with AND the shape must
+    // match (a per-`.acr` document cannot swap the key or widen the shape).
+    if srule.issuer_key != crule.issuer_key {
+        return false;
+    }
+    if shape_key(srule) != shape_key(crule) {
+        return false;
+    }
+    // The per-`.acr` rule must itself cover the target (it is in force here) AND its
+    // scope must be WITHIN the server rule's scope (narrowing, never broadening).
+    scope_covers(&crule.scope, target) && scope_covers(&srule.scope, &crule.scope)
+}
+
+/// Tighten an effective rule by a narrowing per-`.acr` rule: take the smaller freshness
+/// window and the more-specific (descendant) scope. Never widens either dimension.
+fn tighten(eff: &TrustRule, crule: &TrustRule) -> TrustRule {
+    let fresh_within_secs = eff.fresh_within_secs.min(crule.fresh_within_secs);
+    // The more-specific scope is the one the OTHER covers (a descendant string is
+    // longer and is covered by its ancestor). `narrows` already proved
+    // `scope_covers(eff.scope, crule.scope)`, so `crule.scope` is the descendant.
+    let scope = crule.scope.clone();
+    TrustRule {
+        source: eff.source.clone(),
+        issuer_key: eff.issuer_key,
+        shape: eff.shape.clone(),
+        scope,
+        fresh_within_secs,
+    }
+}
+
+/// A coarse, stable identity for a rule's statement-type shape: the sorted set of the
+/// shape's `sh:targetSubjectsOf` predicate IRIs. Two rules with the same target
+/// predicates are "the same statement-type" for the narrowing check. (The PoC's shapes
+/// are single-predicate desugarings or `targetSubjectsOf`-anchored node-shapes, so this
+/// is exact for the supported fragment; an inline property-shape difference that does
+/// not change the target predicates is treated as the same type — a conservative,
+/// fail-closed-leaning choice for the narrowing direction.)
+fn shape_key(rule: &TrustRule) -> Vec<String> {
+    use crate::vocab::SH_TARGET_SUBJECTS_OF;
+    let mut preds: Vec<String> = rule
+        .shape
+        .triples
+        .iter()
+        .filter(|t| t.predicate.as_str() == SH_TARGET_SUBJECTS_OF)
+        .filter_map(|t| match &t.object {
+            oxrdf::Term::NamedNode(n) => Some(n.as_str().to_string()),
+            _ => None,
+        })
+        .collect();
+    preds.sort();
+    preds.dedup();
+    preds
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::policy::{parse_policy, ControlGate};
+    use oxrdf::{Literal, NamedNode, NamedOrBlankNode, Term, Triple};
+    use sparq_zk::sig::SecretKey;
+
+    fn iri(s: &str) -> NamedNode {
+        NamedNode::new(s).unwrap()
+    }
+
+    /// Build a one-rule Control-gated policy graph (source / issuerKey / forPredicate /
+    /// scope / freshWithin) and parse it into `Vec<TrustRule>`.
+    fn policy_rules(
+        rule_iri: &str,
+        source: &str,
+        key_hex: &str,
+        predicate: &str,
+        scope: &str,
+        fresh: &str,
+    ) -> Vec<TrustRule> {
+        use crate::vocab::{
+            FOR_PREDICATE, FRESH_WITHIN, ISSUER_KEY, RDF_TYPE, SCOPE, SOURCE, TRUST_RULE,
+        };
+        let s = NamedOrBlankNode::NamedNode(iri(rule_iri));
+        let xsd_dur = iri("http://www.w3.org/2001/XMLSchema#duration");
+        let triples = vec![
+            Triple::new(s.clone(), iri(RDF_TYPE), Term::NamedNode(iri(TRUST_RULE))),
+            Triple::new(s.clone(), iri(SOURCE), Term::NamedNode(iri(source))),
+            Triple::new(
+                s.clone(),
+                iri(ISSUER_KEY),
+                Term::Literal(Literal::new_simple_literal(key_hex)),
+            ),
+            Triple::new(
+                s.clone(),
+                iri(FOR_PREDICATE),
+                Term::NamedNode(iri(predicate)),
+            ),
+            Triple::new(s.clone(), iri(SCOPE), Term::NamedNode(iri(scope))),
+            Triple::new(
+                s,
+                iri(FRESH_WITHIN),
+                Term::Literal(Literal::new_typed_literal(fresh, xsd_dur)),
+            ),
+        ];
+        parse_policy(&triples, ControlGate::assert_control_gated()).unwrap()
+    }
+
+    /// A deterministic verifying-key hex (the value is irrelevant to the storage tests —
+    /// they never verify a signature — but it must PARSE as a key).
+    fn a_key_hex() -> String {
+        let sk = SecretKey::from_seed(0xA11CE);
+        sparq_zk::sig::public_key_to_hex(&sk.public_key())
+    }
+
+    fn gate() -> ControlGate {
+        ControlGate::assert_control_gated()
+    }
+
+    #[test]
+    fn empty_store_admits_nothing_fail_closed() {
+        let store = TrustStore::new();
+        let eff = store.effective_rules(&iri("https://pod.ex/docs/x"));
+        assert!(eff.is_empty(), "no server default ⇒ nothing admissible");
+    }
+
+    #[test]
+    fn server_wide_default_is_the_ceiling() {
+        let key = a_key_hex();
+        let server = policy_rules(
+            "https://pod.ex/trust#r",
+            "https://gov.example/issuer",
+            &key,
+            "http://schema.org/age",
+            "https://pod.ex/", // server-wide container scope
+            "P30D",
+        );
+        let mut store = TrustStore::new();
+        store
+            .put(TrustDocument::new(TrustLayer::ServerWide, 1, server, gate()))
+            .unwrap();
+        let eff = store.effective_rules(&iri("https://pod.ex/docs/x"));
+        assert_eq!(eff.len(), 1, "the server rule covers the target");
+        assert_eq!(eff[0].fresh_within_secs, 30 * 86_400);
+    }
+
+    #[test]
+    fn per_acr_narrows_freshness_and_scope_never_broadens() {
+        let key = a_key_hex();
+        let server = policy_rules(
+            "https://pod.ex/trust#r",
+            "https://gov.example/issuer",
+            &key,
+            "http://schema.org/age",
+            "https://pod.ex/",
+            "P30D",
+        );
+        // Per-.acr on /docs/ narrows to P7D and scope /docs/.
+        let acr = policy_rules(
+            "https://pod.ex/docs/.acr#r",
+            "https://gov.example/issuer",
+            &key,
+            "http://schema.org/age",
+            "https://pod.ex/docs/",
+            "P7D",
+        );
+        let mut store = TrustStore::new();
+        store
+            .put(TrustDocument::new(TrustLayer::ServerWide, 1, server, gate()))
+            .unwrap();
+        store
+            .put(TrustDocument::new(
+                TrustLayer::Container(iri("https://pod.ex/docs/")),
+                1,
+                acr,
+                gate(),
+            ))
+            .unwrap();
+
+        // Inside /docs/: the tighter P7D + the more-specific /docs/ scope win.
+        let eff = store.effective_rules(&iri("https://pod.ex/docs/x"));
+        assert_eq!(eff.len(), 1);
+        assert_eq!(eff[0].fresh_within_secs, 7 * 86_400, "narrowed to P7D");
+        assert_eq!(eff[0].scope.as_str(), "https://pod.ex/docs/");
+
+        // Outside /docs/ (e.g. /photos/x): the per-.acr does NOT cover it, so the
+        // server ceiling P30D applies unchanged.
+        let eff_out = store.effective_rules(&iri("https://pod.ex/photos/x"));
+        assert_eq!(eff_out.len(), 1);
+        assert_eq!(eff_out[0].fresh_within_secs, 30 * 86_400);
+    }
+
+    #[test]
+    fn per_acr_cannot_broaden_a_new_source_is_dropped() {
+        let key = a_key_hex();
+        // Server trusts ONLY gov for age.
+        let server = policy_rules(
+            "https://pod.ex/trust#r",
+            "https://gov.example/issuer",
+            &key,
+            "http://schema.org/age",
+            "https://pod.ex/",
+            "P30D",
+        );
+        // A per-.acr tries to ALSO trust a different issuer for age — broadening.
+        let rogue = policy_rules(
+            "https://pod.ex/docs/.acr#r",
+            "https://rogue.example/issuer",
+            &key,
+            "http://schema.org/age",
+            "https://pod.ex/docs/",
+            "P30D",
+        );
+        let mut store = TrustStore::new();
+        store
+            .put(TrustDocument::new(TrustLayer::ServerWide, 1, server, gate()))
+            .unwrap();
+        store
+            .put(TrustDocument::new(
+                TrustLayer::Container(iri("https://pod.ex/docs/")),
+                1,
+                rogue,
+                gate(),
+            ))
+            .unwrap();
+        let eff = store.effective_rules(&iri("https://pod.ex/docs/x"));
+        // The rogue source is NOT in the effective set — only the server-trusted gov.
+        assert_eq!(eff.len(), 1, "broadening per-.acr source is dropped");
+        assert_eq!(eff[0].source.as_str(), "https://gov.example/issuer");
+    }
+
+    #[test]
+    fn stale_version_is_rejected() {
+        let key = a_key_hex();
+        let mk = |v: &str| {
+            policy_rules(
+                "https://pod.ex/trust#r",
+                "https://gov.example/issuer",
+                &key,
+                "http://schema.org/age",
+                "https://pod.ex/",
+                v,
+            )
+        };
+        let mut store = TrustStore::new();
+        store
+            .put(TrustDocument::new(
+                TrustLayer::ServerWide,
+                5,
+                mk("P30D"),
+                gate(),
+            ))
+            .unwrap();
+        // A replayed v3 (≤ 5) is rejected; the store is unchanged.
+        let err = store
+            .put(TrustDocument::new(
+                TrustLayer::ServerWide,
+                3,
+                mk("P7D"),
+                gate(),
+            ))
+            .unwrap_err();
+        assert_eq!(
+            err,
+            StoreError::StaleVersion {
+                current: 5,
+                presented: 3
+            }
+        );
+        // Equal version is also rejected (strictly-greater required).
+        assert!(store
+            .put(TrustDocument::new(
+                TrustLayer::ServerWide,
+                5,
+                mk("P7D"),
+                gate()
+            ))
+            .is_err());
+        // A newer version is accepted.
+        store
+            .put(TrustDocument::new(
+                TrustLayer::ServerWide,
+                6,
+                mk("P7D"),
+                gate(),
+            ))
+            .unwrap();
+    }
+
+    #[test]
+    fn policy_version_bumps_on_edit_and_revoke() {
+        let key = a_key_hex();
+        let mk = |scope: &str| {
+            policy_rules(
+                "https://pod.ex/trust#r",
+                "https://gov.example/issuer",
+                &key,
+                "http://schema.org/age",
+                scope,
+                "P30D",
+            )
+        };
+        let target = iri("https://pod.ex/docs/x");
+        let mut store = TrustStore::new();
+        store
+            .put(TrustDocument::new(
+                TrustLayer::ServerWide,
+                1,
+                mk("https://pod.ex/"),
+                gate(),
+            ))
+            .unwrap();
+        let v1 = store.policy_version(&target);
+
+        // Adding a covering per-.acr document changes the version.
+        store
+            .put(TrustDocument::new(
+                TrustLayer::Container(iri("https://pod.ex/docs/")),
+                1,
+                mk("https://pod.ex/docs/"),
+                gate(),
+            ))
+            .unwrap();
+        let v2 = store.policy_version(&target);
+        assert_ne!(v1, v2, "adding a covering document bumps the policy version");
+
+        // Editing it (version bump) changes the version again.
+        store
+            .put(TrustDocument::new(
+                TrustLayer::Container(iri("https://pod.ex/docs/")),
+                2,
+                mk("https://pod.ex/docs/"),
+                gate(),
+            ))
+            .unwrap();
+        let v3 = store.policy_version(&target);
+        assert_ne!(v2, v3, "editing a document bumps the policy version");
+
+        // Revoking it changes the version again (back toward the server-only state).
+        assert!(store.revoke(&TrustLayer::Container(iri("https://pod.ex/docs/"))));
+        let v4 = store.policy_version(&target);
+        assert_ne!(v3, v4, "revoking a document bumps the policy version");
+
+        // A target NOT covered by the per-.acr is unaffected by its lifecycle.
+        let other = iri("https://pod.ex/photos/y");
+        let o1 = store.policy_version(&other);
+        store
+            .put(TrustDocument::new(
+                TrustLayer::Container(iri("https://pod.ex/docs/")),
+                3,
+                mk("https://pod.ex/docs/"),
+                gate(),
+            ))
+            .unwrap();
+        let o2 = store.policy_version(&other);
+        assert_eq!(
+            o1, o2,
+            "an unrelated container's edits don't affect this target"
+        );
+    }
+
+    #[test]
+    fn revoke_reports_presence() {
+        let mut store = TrustStore::new();
+        assert!(!store.revoke(&TrustLayer::ServerWide), "nothing to revoke");
+        let key = a_key_hex();
+        let rules = policy_rules(
+            "https://pod.ex/trust#r",
+            "https://gov.example/issuer",
+            &key,
+            "http://schema.org/age",
+            "https://pod.ex/",
+            "P30D",
+        );
+        store
+            .put(TrustDocument::new(TrustLayer::ServerWide, 1, rules, gate()))
+            .unwrap();
+        assert!(store.revoke(&TrustLayer::ServerWide), "removed");
+        assert!(!store.revoke(&TrustLayer::ServerWide), "already gone");
+    }
+}

--- a/crates/sparq-trust/tests/trust_store_cache_key.rs
+++ b/crates/sparq-trust/tests/trust_store_cache_key.rs
@@ -1,0 +1,258 @@
+//! End-to-end test of the trust-document storage/authoring model (`sq-pfae.5`, P4):
+//! the admission cache key composes with the sparq-solid epoch cache, and the
+//! per-`.acr` NARROWING composition is monotone. Drives the REAL [`TrustStore`] +
+//! [`admit`] path (no mock): a verdict cached under `(epoch, AdmissionCacheKey)` is
+//! served only while BOTH the epoch AND the trust policy are unchanged, and the
+//! narrowing actually changes which credentials admit.
+//!
+//! Gated on the `store` feature (the whole file). Executed by a dedicated
+//! `feature-matrix.yml` leg (`sparq-trust (store)`) — see that workflow.
+//!
+//! [OPUS-4.8] sq-pfae.5. 🤖 SPARQ agent — trust-graph authorisation PoC.
+#![cfg(feature = "store")]
+
+use oxrdf::{Literal, NamedNode, NamedOrBlankNode, Term, Triple};
+use sparq_trust::admit::{admit, PresentedCredential, Session};
+use sparq_trust::policy::{parse_policy, ControlGate, TrustRule};
+use sparq_trust::store::{AdmissionCacheKey, TrustDocument, TrustLayer, TrustStore};
+use sparq_zk::sig::{public_key_to_hex, SecretKey};
+use std::collections::HashMap;
+
+const SCHEMA_AGE: &str = "http://schema.org/age";
+const GOV: &str = "https://gov.example/issuer";
+
+fn iri(s: &str) -> NamedNode {
+    NamedNode::new(s).unwrap()
+}
+
+/// A Control-gated single-rule policy (gov trusts `schema:age` over `scope`, within
+/// `fresh`).
+fn policy(rule_iri: &str, key_hex: &str, scope: &str, fresh: &str) -> Vec<TrustRule> {
+    let s = NamedOrBlankNode::NamedNode(iri(rule_iri));
+    let t = "https://sparq.dev/ns/trust#";
+    let triples = vec![
+        Triple::new(
+            s.clone(),
+            iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+            Term::NamedNode(iri(&format!("{t}TrustRule"))),
+        ),
+        Triple::new(s.clone(), iri(&format!("{t}source")), Term::NamedNode(iri(GOV))),
+        Triple::new(
+            s.clone(),
+            iri(&format!("{t}issuerKey")),
+            Term::Literal(Literal::new_simple_literal(key_hex)),
+        ),
+        Triple::new(
+            s.clone(),
+            iri(&format!("{t}forPredicate")),
+            Term::NamedNode(iri(SCHEMA_AGE)),
+        ),
+        Triple::new(s.clone(), iri(&format!("{t}scope")), Term::NamedNode(iri(scope))),
+        Triple::new(
+            s,
+            iri(&format!("{t}freshWithin")),
+            Term::Literal(Literal::new_typed_literal(
+                fresh,
+                iri("http://www.w3.org/2001/XMLSchema#duration"),
+            )),
+        ),
+    ];
+    parse_policy(&triples, ControlGate::assert_control_gated()).unwrap()
+}
+
+/// A gov-signed `<holder> schema:age <age>` credential, issued at `issued_at`.
+fn credential(holder: &str, age: i64, issued_at: i64) -> PresentedCredential {
+    let sk = SecretKey::from_seed(0xC0FFEE);
+    let salt = [3u8; 32];
+    let graph = vec![Triple::new(
+        NamedOrBlankNode::NamedNode(iri(holder)),
+        iri(SCHEMA_AGE),
+        Term::Literal(Literal::new_typed_literal(
+            age.to_string(),
+            iri("http://www.w3.org/2001/XMLSchema#integer"),
+        )),
+    )];
+    // Sign over the RDFC-1.0 commitment, exactly as the issuance side does
+    // (`sign_commitment` returns the hex-encoded signature directly).
+    let salt_fr = sparq_zk::encode::salt_from_bytes(&salt);
+    let commitment = sparq_zk::commit::commit_triples(&graph, salt_fr).unwrap();
+    let issuer_signature_hex = sk.sign_commitment(&commitment.commitment);
+    PresentedCredential {
+        graph,
+        issuer_signature_hex,
+        salt,
+        issued_at_unix_secs: issued_at,
+        revoked: false,
+    }
+}
+
+fn gov_key_hex() -> String {
+    public_key_to_hex(&SecretKey::from_seed(0xC0FFEE).public_key())
+}
+
+/// A tiny admission cache keyed by `(epoch, AdmissionCacheKey)`, mirroring how
+/// sparq-solid would cache an admission verdict on top of its epoch cache. The verdict
+/// is the count of admitted facts.
+#[derive(Default)]
+struct AdmissionCache {
+    inner: HashMap<(u64, AdmissionCacheKey), usize>,
+    misses: usize,
+}
+
+impl AdmissionCache {
+    /// Look up or compute-and-store the admission verdict. Counts a miss whenever the
+    /// real gate had to run (so a test can assert a stale verdict was NOT served).
+    fn verdict(
+        &mut self,
+        epoch: u64,
+        store: &TrustStore,
+        cred: &PresentedCredential,
+        session: &Session,
+        target: &NamedNode,
+    ) -> usize {
+        let key = store.admission_cache_key(cred, &session.agent, target);
+        if let Some(v) = self.inner.get(&(epoch, key)) {
+            return *v;
+        }
+        self.misses += 1;
+        // The REAL admission gate over the effective (narrowed) rules.
+        let rules = store.effective_rules(target);
+        let admitted = admit(cred, &rules, session, target).len();
+        self.inner.insert((epoch, key), admitted);
+        admitted
+    }
+}
+
+/// The load-bearing invariant: a cached admission verdict is reused while epoch AND
+/// policy version are unchanged, but a trust-document edit/revoke bumps the policy
+/// version → the cache key changes → the gate re-runs (no stale verdict).
+#[test]
+fn cache_key_invalidates_on_policy_change_but_reuses_when_unchanged() {
+    let key = gov_key_hex();
+    let target = iri("https://pod.ex/docs/x");
+    let session = Session {
+        agent: iri("https://jesse.ex/card#me"),
+        now_unix_secs: 1_000_000,
+    };
+    let cred = credential("https://jesse.ex/card#me", 25, 1_000_000 - 86_400); // 1 day old
+
+    let mut store = TrustStore::new();
+    store
+        .put(TrustDocument::new(
+            TrustLayer::ServerWide,
+            1,
+            policy("https://pod.ex/trust#r", &key, "https://pod.ex/", "P30D"),
+            ControlGate::assert_control_gated(),
+        ))
+        .unwrap();
+
+    let mut cache = AdmissionCache::default();
+    let epoch = 7;
+
+    // First call: a miss, admits the age fact.
+    assert_eq!(cache.verdict(epoch, &store, &cred, &session, &target), 1);
+    assert_eq!(cache.misses, 1);
+
+    // Same epoch + same policy + same credential: served from cache, NO new miss.
+    assert_eq!(cache.verdict(epoch, &store, &cred, &session, &target), 1);
+    assert_eq!(cache.misses, 1, "unchanged inputs reuse the cached verdict");
+
+    // Edit the server-wide policy (a version bump). The policy version changes, so the
+    // cache key changes and the gate re-runs (a new miss) — the stale verdict is NOT
+    // served.
+    store
+        .put(TrustDocument::new(
+            TrustLayer::ServerWide,
+            2,
+            policy("https://pod.ex/trust#r", &key, "https://pod.ex/", "P30D"),
+            ControlGate::assert_control_gated(),
+        ))
+        .unwrap();
+    assert_eq!(cache.verdict(epoch, &store, &cred, &session, &target), 1);
+    assert_eq!(cache.misses, 2, "a policy edit invalidates the cached verdict");
+}
+
+/// The narrowing composition is REAL: a per-`.acr` document tightening freshness to P1D
+/// turns a 5-day-old credential that the server-wide P30D would admit into a denial
+/// inside that container — and the same credential still admits OUTSIDE the container.
+#[test]
+fn per_acr_freshness_narrowing_changes_admission() {
+    let key = gov_key_hex();
+    let session = Session {
+        agent: iri("https://jesse.ex/card#me"),
+        now_unix_secs: 1_000_000,
+    };
+    // 5-day-old credential.
+    let cred = credential("https://jesse.ex/card#me", 25, 1_000_000 - 5 * 86_400);
+
+    let mut store = TrustStore::new();
+    store
+        .put(TrustDocument::new(
+            TrustLayer::ServerWide,
+            1,
+            policy("https://pod.ex/trust#r", &key, "https://pod.ex/", "P30D"),
+            ControlGate::assert_control_gated(),
+        ))
+        .unwrap();
+    // Per-.acr on /private/ narrows freshness to P1D.
+    store
+        .put(TrustDocument::new(
+            TrustLayer::Container(iri("https://pod.ex/private/")),
+            1,
+            policy(
+                "https://pod.ex/private/.acr#r",
+                &key,
+                "https://pod.ex/private/",
+                "P1D",
+            ),
+            ControlGate::assert_control_gated(),
+        ))
+        .unwrap();
+
+    // Inside /private/: the narrowed P1D denies the 5-day-old credential.
+    let inside = iri("https://pod.ex/private/secret");
+    let rules_inside = store.effective_rules(&inside);
+    assert_eq!(
+        admit(&cred, &rules_inside, &session, &inside).len(),
+        0,
+        "P1D narrowing denies the stale credential inside the container"
+    );
+
+    // Outside /private/ (e.g. /docs/x): the server-wide P30D still admits it.
+    let outside = iri("https://pod.ex/docs/x");
+    let rules_outside = store.effective_rules(&outside);
+    assert_eq!(
+        admit(&cred, &rules_outside, &session, &outside).len(),
+        1,
+        "the server-wide P30D admits it outside the narrowed container"
+    );
+}
+
+/// A different credential (different holder) gets a different evidence hash → a
+/// different cache key → its own verdict (no cross-credential cache collision).
+#[test]
+fn distinct_credentials_have_distinct_cache_keys() {
+    let key = gov_key_hex();
+    let target = iri("https://pod.ex/docs/x");
+    let mut store = TrustStore::new();
+    store
+        .put(TrustDocument::new(
+            TrustLayer::ServerWide,
+            1,
+            policy("https://pod.ex/trust#r", &key, "https://pod.ex/", "P30D"),
+            ControlGate::assert_control_gated(),
+        ))
+        .unwrap();
+
+    let jesse = iri("https://jesse.ex/card#me");
+    let alice = iri("https://alice.ex/card#me");
+    let cred_j = credential(jesse.as_str(), 25, 990_000);
+    let cred_a = credential(alice.as_str(), 25, 990_000);
+
+    let k_j = store.admission_cache_key(&cred_j, &jesse, &target);
+    let k_a = store.admission_cache_key(&cred_a, &alice, &target);
+    assert_ne!(
+        k_j, k_a,
+        "different holders/credentials must not share a cache key"
+    );
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -448,6 +448,20 @@ public surface is `sparq_trust::{vocab, policy, admit, wire}` — see
 [issue #940](https://github.com/jeswr/sparq/issues/940); landing via design PR
 <https://github.com/jeswr/sparq/pull/951>).
 
+**Trust-document storage / authoring model** (the **opt-in `store` feature**, `sq-pfae.5`,
+design §3.2). `sparq_trust::store::TrustStore` decides *where* trust rules live and *which
+version* is in force: a **server-wide default** (the ceiling) plus zero-or-more **per-`.acr`
+documents** (`TrustLayer::{ServerWide, Container}`), where a per-`.acr` document may only
+**NARROW, never broaden** the server default — it can tighten a freshness window or restrict
+scope, but can NOT trust a `(source, statement-type)` the server default did not
+(`TrustStore::effective_rules`, the load-bearing soundness property). Documents are
+Control-gated (same `TrustDocument::new`-requires-`ControlGate` channel as `.acl`/`.acr`),
+**monotonically versioned** (a stale `put` is rejected), and revoked by removal. The
+`AdmissionCacheKey` = (evidence hash + policy version) composes with the sparq-solid epoch
+cache: a re-materialise bumps the epoch, a trust-document edit/revoke bumps the
+`policy_version` for affected targets — so a cached admission verdict is never served stale.
+Pure-Rust, no new dependency; OFF in the default build.
+
 **Honest scope (read first).** This is a RESEARCH prototype, **NOT a security guarantee**. It
 does **not** provide privacy, unlinkability, or anonymity: the credential is admitted in the
 clear and the holder binding authenticates the WebID in the clear (the non-anonymous degraded


### PR DESCRIPTION
> 🤖 SPARQ agent — trust-graph authorisation PoC. Implements bead **sq-pfae.5** (P4 of epic sq-pfae, issue #940). Written while Fable unavailable — flag for re-review when Fable returns.

## What

P4 of the trust-graph authorisation epic: **where trust rules live, how they are versioned + revoked, and how a server-wide default composes with per-`.acr` documents** (design record `research/solid-trust-graph-authz-design.md` §3.2 / §8 Q1). New **default-OFF `store` feature** on `sparq-trust`.

### `store::TrustStore`
- **Two layers, one composition (BOTH, the §8 Q1 decision):** a server-wide default (the *ceiling*) + per-`.acr` documents (`TrustLayer::{ServerWide, Container}`), where a per-`.acr` document may only **NARROW, never broaden** the server default — it can tighten a freshness window or restrict scope, but can **NOT** trust a `(source, statement-type)` the server default did not. `effective_rules` drops a broadening per-`.acr` rule **fail-closed** (the load-bearing soundness property).
- **Control-gated** (`TrustDocument::new` requires a `ControlGate`, the same channel as `.acl`/`.acr`), **monotonically versioned** (a stale `put` → `StoreError::StaleVersion`, store unchanged), **revoked** by document removal.
- **`AdmissionCacheKey` = (evidence hash + policy version)** composes with the sparq-solid epoch cache: a re-materialise bumps the epoch; a trust-document edit/revoke bumps the per-target `policy_version` — so a cached admission verdict is never served stale.

## Opt-in / architecture
`store = []` — pure-Rust over deps already present (sparq-zk commitment for the evidence hash + std hashing). **NO new dependency**; the lean default build is byte-identical with the feature OFF (strict additivity G6). `sparq-core`/`sparq-engine` untouched.

## Tests (REAL path, no mock)
- 7 in-crate unit tests: per-`.acr` narrowing, broadening-source-dropped, stale-version-rejected, version-bump-on-edit/revoke, fail-closed empty store.
- **Net-new cfg-gated integration suite** `tests/trust_store_cache_key.rs` (3 tests, drives the real `TrustStore` + `admit`): cache-key invalidation on a policy edit, per-`.acr` freshness narrowing **flipping admission inside a container**, distinct evidence hashes per credential.
- Wired a **`sparq-trust (store)` feature-matrix.yml leg** that actually EXECUTES the cfg-gated suite (avoids the compiled-empty-under-default coverage gap, #1171).

## Gates (GREEN both states)
- `cargo build` / `clippy --all-targets -D warnings` / `cargo test`: feature **OFF** (default) AND **ON** (`--features store` / `--all-features`).
- rustdoc `--workspace --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings`: clean (fixed an ambiguous `crate::admit` intra-doc link → `mod@crate::admit`).
- `readme-template`: 0 deviations (README 120 lines). `check-privacy-claims.sh`: clean. `typos`: clean. **Cargo.lock unchanged** (no memmap2 regression).

Feature flags: **`store`** (sparq-trust).

## Honest scope
This is the **storage / authoring model**, not a new admission primitive or a cryptographic guarantee. The admission gate's caveats are unchanged: no privacy / unlinkability / anonymity; issuer keys are operator-asserted by default; the ZK estate it composes with is research-grade and **externally UNAUDITED** (`sq-qhy4`, pending accredited-cryptographer sign-off); `sparq-mpc` is semi-honest only.

## Discovered work
- **sq-pfae.12** (created): wire `TrustStore` into sparq-solid's `trust-graph` (PodStore consults `effective_rules` + caches the admission verdict under `(epoch, AdmissionCacheKey)`).

Closes sq-pfae.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)