### PR TITLE
fix(sparq-server): feature-gate server-only integration tests under #![cfg(feature="server")] (sq-1b390)

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -559,6 +559,56 @@ jobs:
       - name: Clippy (--all-targets -D warnings)
         run: cargo clippy -p ${{ matrix.crate }} --features ${{ matrix.features }} --all-targets -- -D warnings
 
+  # [OPUS-4.8] sq-1b390: THE pure-serialiser-library build of sparq-server — i.e. the crate
+  # with `--no-default-features` (the `server` async HTTP stack OFF), the contract a consumer
+  # relies on when it wants only the XML/CSV/TSV/graph serialisers without dragging in
+  # axum/hyper/tokio. ci.yml only ever clippies the DEFAULT (server-ON) set and the
+  # opt-in-features matrix above only ADDS features, so NOTHING gated this config and it had
+  # rotted: the integration-test files (`tests/{hardening,subscriptions,protocol,…}.rs`)
+  # referenced the `server`-gated `sparq_server::router`/`AppState`/axum API unconditionally,
+  # so `cargo clippy -p sparq-server --no-default-features --all-targets` failed on unresolved
+  # imports (the bug sq-1b390 fixes by `#![cfg(feature = "server")]`-gating each server-only
+  # suite). This job locks the pure-library build green: build + `clippy --all-targets -D
+  # warnings` + `cargo test` of the suites that STAY compiled with the feature off (the two
+  # serialiser-oracle tests). The job NAME is free of "advisory"/"informational", so the
+  # required `ci-summary / gate` aggregator auto-discovers it as REQUIRED (no edit to
+  # ci-summary.yml).
+  server-no-default-features:
+    needs: changes
+    if: needs.changes.outputs.rust_changed == 'true'
+    name: sparq-server pure-serialiser (--no-default-features)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: feature-matrix-sparq-server-no-default-features
+      - name: Fetch dependencies (retry transient crates.io fetch)
+        run: |
+          set -euo pipefail
+          n=0
+          until cargo fetch --locked; do
+            n=$((n+1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::cargo fetch failed after $n attempts (registry outage?)" >&2
+              exit 1
+            fi
+            echo "cargo fetch attempt $n failed; retrying in 10s..." >&2
+            sleep 10
+          done
+      - name: Build (-p sparq-server --no-default-features)
+        run: cargo build -p sparq-server --no-default-features
+      - name: Test (-p sparq-server --no-default-features) — the still-compiled pure-serialiser suites
+        run: cargo test -p sparq-server --no-default-features
+      - name: Clippy (--no-default-features --all-targets -D warnings)
+        run: cargo clippy -p sparq-server --no-default-features --all-targets -- -D warnings
+
   # [OPUS-4.8] sq-s1uy (epic sq-dnko): THE load-bearing Phase-0 deliverable. Assert the
   # lean core (sparq-core + sparq-engine) has NO dependency edge to the OPT-IN federation
   # client sparq-fedclient — in BOTH feature states (the guard resolves --all-features, so

--- a/crates/sparq-server/tests/auth.rs
+++ b/crates/sparq-server/tests/auth.rs
@@ -14,6 +14,13 @@
 //!     the query path (POST `application/sparql-query` body that is an update) is gated too.
 //!
 //! Mirrors QLever's `-a <token>` write gate.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use sparq_core::Graph;
 use sparq_server::{router, AppState, ServerConfig};

--- a/crates/sparq-server/tests/cors.rs
+++ b/crates/sparq-server/tests/cors.rs
@@ -9,6 +9,13 @@
 //!   * the `OPTIONS` preflight is answered (`204` + methods/headers/max-age) for an
 //!     allowlisted origin only;
 //!   * allowlisting an origin does NOT relax the existing auth gate.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use sparq_core::Graph;
 use sparq_server::{router, AppState, CorsAllowlist, ServerConfig};

--- a/crates/sparq-server/tests/explain_metrics.rs
+++ b/crates/sparq-server/tests/explain_metrics.rs
@@ -1,5 +1,12 @@
 //! Integration tests for T22: the `/sparql` EXPLAIN surface (query parameter and
 //! `Accept: text/x-sparq-explain`) and the `/metrics` Prometheus endpoint.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use sparq_core::Graph;
 use sparq_server::{router, AppState};

--- a/crates/sparq-server/tests/gsp_patch.rs
+++ b/crates/sparq-server/tests/gsp_patch.rs
@@ -9,6 +9,13 @@
 //!     test asserts the feature-OFF behaviour (a `text/n3` PATCH body is a plain `415`).
 //!
 //! The server runs on an ephemeral port in-process and is driven over real HTTP with `reqwest`.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use sparq_core::Graph;
 use sparq_server::{router, AppState, ServerConfig};

--- a/crates/sparq-server/tests/hardening.rs
+++ b/crates/sparq-server/tests/hardening.rs
@@ -2,6 +2,13 @@
 //! concurrency shedding, panic recovery and the SELECT row cap. Each test boots the real
 //! hardened router on an ephemeral port and drives it over HTTP, asserting both the HTTP
 //! status semantics and the structured JSON error bodies.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use std::time::Duration;
 

--- a/crates/sparq-server/tests/health_probe.rs
+++ b/crates/sparq-server/tests/health_probe.rs
@@ -4,6 +4,13 @@
 //! the REAL server on an ephemeral port and drives `health_probe::run_probe` against it
 //! (healthy), then against a closed port (unhealthy) — the two outcomes the container
 //! runtime maps to healthy/unhealthy.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use sparq_core::Graph;
 use sparq_server::health_probe::run_probe;

--- a/crates/sparq-server/tests/jsonld_content_negotiation.rs
+++ b/crates/sparq-server/tests/jsonld_content_negotiation.rs
@@ -18,6 +18,13 @@
 //! "jsonld"))]` asserts the feature-OFF contract (`--no-default-features --features server`): an
 //! `application/ld+json` write body is a plain `415`, and an `Accept: application/ld+json` query
 //! falls back to a supported graph format (NOT a 406) — so a JSON-LD-disabled build is unchanged.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use sparq_core::Graph;
 use sparq_server::{router, AppState};

--- a/crates/sparq-server/tests/log_redaction.rs
+++ b/crates/sparq-server/tests/log_redaction.rs
@@ -12,6 +12,13 @@
 //!
 //! Only one global subscriber may be installed per process, so BOTH cases run against ONE
 //! subscriber in a single `#[tokio::test]`; the capture buffer is cleared between cases.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use std::sync::{Arc, Mutex};
 

--- a/crates/sparq-server/tests/named_graphs.rs
+++ b/crates/sparq-server/tests/named_graphs.rs
@@ -44,6 +44,13 @@
 //! stable oracle; the field-level assertions are what a differential check against QLever
 //! would compare (term kind / lexical value / datatype IRI), here pinned to the spec's
 //! canonical projection.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use sparq_core::Graph;
 use sparq_server::{router, AppState};

--- a/crates/sparq-server/tests/persist.rs
+++ b/crates/sparq-server/tests/persist.rs
@@ -14,6 +14,13 @@
 //! sends AFTER `ServerApplier::seal` has WAL-fsync'd the batch to the durable graph (see
 //! `src/http.rs`). So by the time a 204 returns, the update is already on disk — the restart
 //! merely re-opens it.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/crates/sparq-server/tests/protocol.rs
+++ b/crates/sparq-server/tests/protocol.rs
@@ -5,6 +5,13 @@
 //! media types, payload shapes, ASK booleans and HTTP status semantics. This is structured
 //! so the official W3C SPARQL Protocol test suite could be pointed at the running endpoint
 //! (see the crate README for how to run conformance).
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use sparq_core::Graph;
 use sparq_server::{router, AppState};

--- a/crates/sparq-server/tests/subscriptions.rs
+++ b/crates/sparq-server/tests/subscriptions.rs
@@ -5,6 +5,13 @@
 //! JSON protocol end to end: subscribe → initial notification, committed SPARQL Update
 //! via POST /sparql → added/removed diff, non-matching update → silence, unsubscribe,
 //! the per-connection / global limits, and slot cleanup after a socket drop.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use std::time::Duration;
 

--- a/crates/sparq-server/tests/subscriptions_auth.rs
+++ b/crates/sparq-server/tests/subscriptions_auth.rs
@@ -15,6 +15,13 @@
 //!
 //! Reuses the WS harness shape from `subscriptions.rs` (tokio-tungstenite) and the SSE shape
 //! from `subscriptions_sse.rs` (reqwest reads the `text/event-stream` body).
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use sparq_core::Graph;
 use sparq_server::{router, AppState, ServerConfig};

--- a/crates/sparq-server/tests/subscriptions_sse.rs
+++ b/crates/sparq-server/tests/subscriptions_sse.rs
@@ -13,6 +13,13 @@
 //! (4) dropping the stream releases the global slot (no leak); (5) bad-query refusals
 //! surface as real HTTP error statuses BEFORE the stream opens; (6) [OPUS-4.8] sq-bxog
 //! (Copilot #120) an initial result over the row cap is a 413 (matching `/sparql`), NOT a 503.
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use std::time::Duration;
 

--- a/crates/sparq-server/tests/time_travel.rs
+++ b/crates/sparq-server/tests/time_travel.rs
@@ -16,6 +16,13 @@
 //! window), never by wall-clock `max_age` — the clock-sensitive age semantics
 //! are unit-tested in sparq-serve with an injected clock (the recorded
 //! determinism concern).
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use sparq_core::Graph;
 use sparq_server::{router, AppState, ServerConfig};

--- a/crates/sparq-server/tests/updates.rs
+++ b/crates/sparq-server/tests/updates.rs
@@ -16,6 +16,13 @@
 //! The `#[ignore]`d benchmark at the bottom is the honest update-cost measurement on a
 //! 1M-triple graph under the ring (per-batch O(graph) fork — the recorded A2 trade):
 //!   cargo test -p sparq-server --release --test updates -- --ignored --nocapture
+//!
+//! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
+//! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
+//! `--no-default-features --all-targets` (the pure-serialiser-library build) this file must
+//! compile OUT — otherwise `clippy --no-default-features --all-targets` breaks on the
+//! unresolved axum / serde_json / router imports. 🤖 SPARQ agent.
+#![cfg(feature = "server")]
 
 use std::time::{Duration, Instant};
 


### PR DESCRIPTION
> 🤖 SPARQ agent — automated fix for bead `sq-1b390`.

## Problem

The **pure-serialiser-library** build of `sparq-server` — i.e. `cargo clippy -p sparq-server --no-default-features --all-targets` (the contract a consumer relies on when it wants only the XML/CSV/TSV/graph serialisers, **without** dragging in axum/hyper/tokio) — was **broken**. 16 integration-test files reference the `server`-gated `sparq_server::router` / `AppState` / `axum` / `serde_json` API **unconditionally** at file scope, so with the `server` feature OFF they fail to compile with unresolved-import errors (`E0432`/`E0433`).

Nothing in CI exercised that config (`ci.yml` only clippies the **default**, server-ON set; the opt-in `feature-matrix.yml` only **adds** features), so it had rotted silently. The bead named `hardening.rs`/`subscriptions.rs`; the real failing set is broader.

## Fix

Gate each **server-only** suite with a top-level `#![cfg(feature = "server")]` so it compiles OUT when `server` is off:

`auth`, `cors`, `explain_metrics`, `gsp_patch`, `hardening`, `health_probe`, `jsonld_content_negotiation`, `log_redaction`, `named_graphs`, `persist`, `protocol`, `subscriptions`, `subscriptions_auth`, `subscriptions_sse`, `time_travel`, `updates`.

The two **pure-serialiser** oracle suites (`serializer_oracle`, `graph_serializer_oracle`) use only the always-on `sparq_server::graph` / `results` API and are deliberately **left UNGATED** — they correctly compile and run under `--no-default-features` (2 + 6 tests), preserving coverage of the pure-library build. The inner `jsonld` / `time-travel` per-fn cfg gates in the affected files are unchanged: once `server` is on, they select the right test bodies exactly as before.

## Regression protection (caught on #1171)

Added a `feature-matrix.yml` job — **"sparq-server pure-serialiser (--no-default-features)"** — that builds + tests + clippies `-p sparq-server --no-default-features --all-targets -D warnings`. Its name is free of "advisory"/"informational", so the required `ci-summary / gate` aggregator auto-discovers it as **REQUIRED** and this config can't rot again.

## Gates run (in-worktree, both feature states)

- `clippy -p sparq-server --no-default-features --all-targets -D warnings` — **PASS** (was the bug)
- `clippy -p sparq-server --all-targets -D warnings` — **PASS**
- `clippy -p sparq-server --all-features --all-targets -D warnings` — **PASS**
- `test -p sparq-server` (default) / `--all-features` / `--no-default-features` — **PASS**
- `RUSTDOCFLAGS="-D warnings" doc -p sparq-server --no-deps --all-features` — **PASS**
- `check-privacy-claims.sh` — **PASS** (no claims touched)

No public API change, no behavioural change, no new dependency. No crate `README.md` touched (so the `readme-template` gate is not engaged). Test-gating + CI hygiene only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)