### PR TITLE
docs(book): single-source guide pages via mdBook {{#include}} anchors (sq-im8u) [OPUS-4.8]

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,23 +32,33 @@
 name: docs
 
 on:
-  # [OPUS-4.8] sq-5f1s4 — self-guarding path filter: the build embeds source it does NOT
-  # live next to. `book/src/getting-started/install.md` does
-  # `{{#rustdoc_include ../../../crates/sparq-engine/examples/quickstart.rs:quickstart}}`,
-  # so `mdbook build` / `mdbook test` COMPILE that example. If it stopped compiling (or the
-  # `quickstart` anchor were renamed/removed) and the filter only watched `book/**`, the
-  # break would land on main undetected — no `book/`-touching commit would re-run this lane
-  # to catch it (the gui.yml/#1081 blind-spot class). So the included example is listed too.
+  # [OPUS-4.8] sq-5f1s4 / sq-im8u — self-guarding path filter: the build embeds source it does
+  # NOT live next to. `book/src/getting-started/install.md` does
+  # `{{#rustdoc_include ../../../crates/sparq-engine/examples/quickstart.rs:quickstart}}`, and
+  # (as of sq-im8u) the guide pages `{{#include}}` canonical prose from `README.md`
+  # (`lead`/`quickstart-cli` anchors) and `skills/{zk-query-proofs,mpc}/SKILL.md`
+  # (`scaffold-caveat` anchors). `mdbook build`/`mdbook test` resolve those anchors, so if an
+  # anchor were renamed/removed (or the included example stopped compiling) and the filter only
+  # watched `book/**`, the break would land on main undetected — no `book/`-touching commit
+  # would re-run this lane to catch it (the gui.yml/#1081 blind-spot class). So every embedded
+  # source is listed too. (mdBook EXITs 0 on a broken include — the build step greps the log
+  # for `[ERROR]` — so re-running THIS lane on a source edit is the only thing that catches it.)
   push:
     branches: [main]
     paths:
       - "book/**"
       - "crates/sparq-engine/examples/quickstart.rs"
+      - "README.md"
+      - "skills/zk-query-proofs/SKILL.md"
+      - "skills/mpc/SKILL.md"
       - ".github/workflows/docs.yml"
   pull_request:
     paths:
       - "book/**"
       - "crates/sparq-engine/examples/quickstart.rs"
+      - "README.md"
+      - "skills/zk-query-proofs/SKILL.md"
+      - "skills/mpc/SKILL.md"
       - ".github/workflows/docs.yml"
   workflow_dispatch:
 

--- a/README.md
+++ b/README.md
@@ -10,10 +10,17 @@
   <img src="https://img.shields.io/badge/status-experimental-yellow.svg" alt="Status: experimental">
 </p>
 
+<!-- sq-im8u: the `lead` anchor below is single-sourced into book/src/introduction.md via
+     mdBook {{#include}}. Keep the anchored paragraph link-portable (ABSOLUTE URLs only — no
+     repo-relative links) so it renders correctly both here and under the mdBook mount. The
+     ANCHOR/ANCHOR_END markers MUST stay one-per-line: mdBook excludes only the exact marker
+     line, so any prose on the marker line leaks into the include. [OPUS-4.8] -->
+<!-- ANCHOR: lead -->
 **sparq** is a lightning-fast [RDF](https://www.w3.org/TR/rdf12-concepts/) triplestore and
 [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) / [1.2](https://www.w3.org/TR/sparql12-query/)
 engine, written in Rust — usable as a library, CLI, HTTP server, and from Python and
 JavaScript/WASM.
+<!-- ANCHOR_END: lead -->
 
 > **Status: experimental research engine.** The API is unstable and pre-1.0. Conformance against
 > the W3C SPARQL, SHACL, and inference suites is tracked by CI ratchets that only ever go up —
@@ -26,6 +33,10 @@ JavaScript/WASM.
 
 ## 🚀 Quickstart
 
+<!-- sq-im8u: the `quickstart-cli` anchor is single-sourced into
+     book/src/getting-started/install.md. Shell only, no links, so it is fully portable across
+     the README and mdBook mounts. Keep the ANCHOR markers one-per-line. [OPUS-4.8] -->
+<!-- ANCHOR: quickstart-cli -->
 ```sh
 cargo build --release
 
@@ -40,6 +51,7 @@ cargo run --release -p sparq-cli -- query-mmap ./idx 'SELECT (COUNT(*) AS ?n) WH
 # W3C SPARQL Protocol HTTP server on :3030
 cargo run --release -p sparq-server -- --addr 127.0.0.1:3030 --format turtle data.ttl
 ```
+<!-- ANCHOR_END: quickstart-cli -->
 
 As a library:
 

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,11 +1,13 @@
-# [OPUS-4.8] sq-h0tr — mdBook guide scaffold for the sparq docs site.
+# [OPUS-4.8] sq-h0tr / sq-im8u — mdBook guide scaffold for the sparq docs site.
 #
-# This is the SCAFFOLD only (book.toml + SUMMARY.md + a few real content pages).
-# Single-source {{#include}} wiring of guide pages from README/SKILL.md is a
-# FOLLOW-UP bead (sq-im8u); tested-example {{#rustdoc_include}} embedding is
-# sq-384j. The pages here are intentionally short, hand-written prose distilled
-# from the existing AGENTS.md/README/SKILL content (not lorem), so the tree is
-# real and renders, and the include-wiring bead can replace the prose in place.
+# Scaffold (book.toml + SUMMARY.md + the content pages) from sq-h0tr; as of sq-im8u
+# the content pages are thin {{#include}} wrappers that single-source their prose
+# (build-time content injection) from the canonical README.md / skills/<surface>/SKILL.md
+# `ANCHOR` regions, so the guide cannot drift from the source of truth. Tested-example
+# {{#rustdoc_include}} embedding (the library snippet) is sq-384j. The only original
+# prose left in book/src is SUMMARY.md + one-line section intros; the capability
+# link-TABLE keeps mount-portable absolute URLs (see capabilities.md header for why it
+# is not included from the README's repo-relative Features list).
 #
 # Reproducible build (CI pins the exact mdbook version — see .github/workflows/docs.yml):
 #   mdbook build book      # → book/book/ (the rendered site)

--- a/book/src/SUMMARY.md
+++ b/book/src/SUMMARY.md
@@ -1,11 +1,14 @@
-<!-- [OPUS-4.8] sq-h0tr — mdBook table of contents.
+<!-- [OPUS-4.8] sq-h0tr / sq-im8u — mdBook table of contents.
 
 This SUMMARY mirrors the structure of the usage-skills router (skills/SKILL.md):
-an introduction, then a "Getting started" section. Under the follow-up
-include-wiring bead (sq-im8u) each capability page will {{#include}} from its
-skills/<surface>/SKILL.md instead of carrying its own prose. For now only the
-scaffold pages that exist are listed — the full per-surface page set is part of
-the content-migration beads, not this scaffold. Keep this in sync with src/. -->
+an introduction, then a "Getting started" section. As of sq-im8u the existing
+content pages are thin {{#include}} wrappers — they single-source their prose
+(build-time content injection) from the canonical README.md / skills/<surface>/SKILL.md
+anchors rather than carrying their own copy, so the guide cannot drift from the
+source of truth. This SUMMARY and the per-surface page set are the only places
+original prose may live (a one-line section heading / intro). The full per-surface
+page set is part of the content-migration beads, not this scaffold. Keep this in
+sync with src/. -->
 
 # Summary
 

--- a/book/src/getting-started/capabilities.md
+++ b/book/src/getting-started/capabilities.md
@@ -1,11 +1,22 @@
-<!-- [OPUS-4.8] sq-h0tr — scaffold page. Distilled from the README "Features" list
-(no lorem). The ZK / MPC entries KEEP the research-scaffold / not-externally-audited
-caveats from the source — do not relabel them as sound or maliciously secure (privacy-claims-allow: meta-instruction WARNING against relabeling as sound/maliciously-secure, not an achieved-property claim; sq-toze.35)
-(privacy-claims gate). The include-wiring bead (sq-im8u) will single-source each
-capability description from its skills/<surface>/SKILL.md.
-[OPUS-4.8] sq-tfpq / issue #813 — Update row now links SPARQL 1.2 Update alongside 1.1
-and a short note documents the 1.2 triple-term delta (no new ops); honest scoping kept
-(engine write tests, not a formal conformance run). -->
+<!-- [OPUS-4.8] sq-im8u — single-source include wiring. The two research-scaffold
+maturity caveats are {{#include}}d verbatim from their canonical skills/*/SKILL.md
+`scaffold-caveat` anchors (build-time content injection), so they cannot drift and
+their not-yet-audited / not-yet-hardened hedges stay intact at the source (privacy-claims
+gate; sq-toze.35 / sq-qhy4). Do not weaken the included hedges or restate the guarantees
+inline here.
+
+The capability link-TABLE below and the SPARQL-Update note are deliberately NOT included
+from the README's Features list: the README links per-surface guides with REPO-RELATIVE
+paths (`skills/<x>/SKILL.md`) — required there by the lychee internal-links gate — and
+mdBook rewrites a relative link relative to THIS page's mount, so an included copy would
+resolve to a non-existent `getting-started/skills/...` and 404 under GitHub Pages. The
+table therefore uses mount-portable ABSOLUTE GitHub URLs; it is a navigation matrix
+(mount-point-specific link targets), not duplicated prose. Single-sourcing the table
+itself is tracked as a follow-up (would require a README-side portable-link form the
+lychee gate does not currently permit).
+[OPUS-4.8] sq-tfpq / issue #813 — Update row links SPARQL 1.2 Update alongside 1.1 and a
+short note documents the 1.2 triple-term delta (no new ops); honest scoping kept (engine
+write tests, not a formal conformance run). -->
 
 # Capabilities at a glance
 
@@ -50,18 +61,20 @@ against a formal SPARQL 1.2 conformance suite.
 
 Two capabilities are **research scaffolds**. They are honest models of the protocols, but they do
 **not** yet provide the cryptographic guarantee a relying party would need. Treat any engineering
-numbers as indicative, not as an audited cryptographic guarantee.
+numbers as indicative, not as an audited cryptographic guarantee. The two maturity caveats below
+are single-sourced verbatim (build-time `{{#include}}`) from their canonical guides, so they
+cannot drift from the source of truth — see the
+[zk-query-proofs guide](https://github.com/jeswr/sparq/blob/main/skills/zk-query-proofs/SKILL.md),
+the [mpc guide](https://github.com/jeswr/sparq/blob/main/skills/mpc/SKILL.md), and
+[SECURITY.md](https://github.com/jeswr/sparq/blob/main/SECURITY.md) for the full scope.
 
-- **Zero-knowledge query proofs** — models proving a query result is correct without revealing the
-  data. The v1 verifier is **research-grade and not externally audited**; it provides **no**
-  soundness guarantee to a relying party pending external audit. See the
-  [security caveat](https://github.com/jeswr/sparq/blob/main/SECURITY.md) and the
-  [zk-query-proofs guide](https://github.com/jeswr/sparq/blob/main/skills/zk-query-proofs/SKILL.md).
-- **Federated MPC** — models evaluating SPARQL across parties with multi-party computation. It is
-  honest-majority semi-honest, **not** maliciously secure. <!-- privacy-claims-allow: NEGATIVE caveat — explicitly denies malicious security (semi-honest only); sq-qhy4 -->
-  See
-  [SECURITY.md](https://github.com/jeswr/sparq/blob/main/SECURITY.md) and the
-  [mpc guide](https://github.com/jeswr/sparq/blob/main/skills/mpc/SKILL.md).
+**Zero-knowledge query proofs** —
+
+{{#include ../../../skills/zk-query-proofs/SKILL.md:scaffold-caveat}}
+
+**Federated MPC** —
+
+{{#include ../../../skills/mpc/SKILL.md:scaffold-caveat}}
 
 ## Interfaces
 

--- a/book/src/getting-started/install.md
+++ b/book/src/getting-started/install.md
@@ -1,42 +1,16 @@
-<!-- [OPUS-4.8] sq-h0tr — scaffold page. Prose distilled from README.md
-"Quickstart" + CONTRIBUTING.md "The gate" (no lorem, no hard-coded perf numbers).
-The include-wiring bead (sq-im8u) may later single-source the command blocks from
-the canonical files. -->
+<!-- [OPUS-4.8] sq-im8u — single-source include wrapper. The quickstart command block is
+{{#include}}d verbatim from the canonical README.md `quickstart-cli` anchor, and the library
+example is {{#rustdoc_include}}d from the tested examples/quickstart.rs (sq-384j) — so neither
+can drift. Only one-line intros and the contributor-gate block (whose canonical prose lives in
+CONTRIBUTING.md) are written here; no prose is duplicated from the README. -->
 
 # Install & build from source
 
 sparq is a Rust workspace. The minimum supported Rust version (MSRV) is tracked in CI; a recent
-stable toolchain works.
+stable toolchain works. Build the release binaries, then query a file, build a persistent on-disk
+store, or run the HTTP server:
 
-## Build
-
-```sh
-cargo build --release
-```
-
-## Query a file
-
-Turtle, N-Triples, N-Quads, or TriG — optionally `.gz` / `.bz2` / `.zst` compressed:
-
-```sh
-cargo run --release -p sparq-cli -- query data.ttl turtle \
-  'SELECT ?s ?o WHERE { ?s <http://schema.org/name> ?o } LIMIT 10'
-```
-
-## Build a persistent on-disk store once, then query it without loading into RAM
-
-```sh
-cargo run --release -p sparq-cli -- build data.nt ntriples ./idx
-cargo run --release -p sparq-cli -- query-mmap ./idx 'SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?o }'
-```
-
-## Run the HTTP server
-
-A W3C SPARQL 1.1 Protocol server on `:3030`:
-
-```sh
-cargo run --release -p sparq-server -- --addr 127.0.0.1:3030 --format turtle data.ttl
-```
+{{#include ../../../README.md:quickstart-cli}}
 
 ## Use it as a library
 
@@ -69,4 +43,5 @@ cargo fmt --check
 ```
 
 See [`CONTRIBUTING.md`](https://github.com/jeswr/sparq/blob/main/CONTRIBUTING.md) for the full
-contributor workflow and the conformance ratchet details.
+contributor workflow and the conformance ratchet details — that file is the canonical source for
+the gate.

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -1,18 +1,14 @@
-<!-- [OPUS-4.8] sq-h0tr — scaffold page. Hand-written prose distilled from
-README.md + AGENTS.md (no lorem, no hard-coded performance numbers). The
-include-wiring bead (sq-im8u) will replace this prose with a single-source
-{{#include}} from the canonical file once anchors are added there. -->
+<!-- [OPUS-4.8] sq-im8u — single-source include wrapper. The lead paragraph is
+{{#include}}d verbatim from the canonical README.md `lead` anchor (build-time content
+injection), so it cannot drift from the README. The only non-included content below is
+the load-bearing experimental-status caveat (a required honesty caveat — see AGENTS.md)
+and the one-line "next" navigation, whose link targets are mount-point-specific (absolute
+GitHub URLs that resolve under the Pages mount, unlike the README's repo-relative links).
+No prose is duplicated from the README. -->
 
 # Introduction
 
-**sparq** is a lightning-fast [RDF](https://www.w3.org/TR/rdf12-concepts/) triplestore and
-[SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) / [1.2](https://www.w3.org/TR/sparql12-query/)
-engine, written in Rust — usable as a library, a CLI, an HTTP server, and from Python and
-JavaScript/WASM.
-
-It is a from-scratch engine: dictionary-encoded terms, six sorted permutation indexes, parallel
-and streaming execution, RDFS / OWL-RL / N3 inference, an out-of-core (mmap) mode with a
-compressed on-disk format, a WebAssembly build, and a W3C-conformant HTTP server.
+{{#include ../../README.md:lead}}
 
 > **Status: experimental research engine.** The API is unstable and pre-1.0. Conformance against
 > the W3C SPARQL, SHACL, and inference suites is tracked by CI ratchets that only ever go up.
@@ -20,16 +16,6 @@ compressed on-disk format, a WebAssembly build, and a W3C-conformant HTTP server
 > default build); when built in it is default-DENY-all egress, allowlisted per host as an SSRF
 > guard (see
 > [`research/roadmap.md`](https://github.com/jeswr/sparq/blob/main/research/roadmap.md)).
-
-## How it is published
-
-The engine core is always built; every other capability is an opt-in crate that the core does not
-depend on, so it stays lean (enforced in CI). The same query surface is mirrored across:
-
-- **Rust crates** (crates.io): `sparq-core`, `sparq-engine`, `sparq-cli`, `sparq-server`, plus the
-  opt-in capability crates.
-- **npm**: `@jeswr/sparq` — an RDF/JS-typed API over the wasm build, with zero runtime deps.
-- **PyPI**: `sparq` — pyo3 / maturin bindings (`import sparq`).
 
 ## Where to go next
 

--- a/skills/mpc/SKILL.md
+++ b/skills/mpc/SKILL.md
@@ -7,7 +7,16 @@ description: Run a SPARQL query across multiple mutually-distrusting RDF data ho
 
 `sparq-mpc` lets a set of mutually-distrusting **holders**, each owning private RDF named graphs, jointly answer ONE SPARQL query over the *union* of their data while minimising what each holder reveals. Today it delivers a real per-holder local evaluator, a crypto-free join on disclosed global IRIs, and an honest-majority Shamir secret-sharing backend that powers secure cumulative aggregates and a hidden-value (private-key) join. The reconstruction path is **honest-majority with tamper DETECTION + abort** — and **robust correction where the `(n, t)` redundancy allows** — over RS-consistency-checked opens; the degree-`2t` equality open is **detection-only above `n = 2t + 1`**, and semi-honest is the floor when a given configuration carries no redundancy. It is **not** dishonest-majority and **not** full malicious security; each backend reports its exact level via `BackendInfo.malicious_security`.
 
+<!-- sq-im8u: the `scaffold-caveat` anchor is single-sourced into
+     book/src/getting-started/capabilities.md via mdBook {{#include}}. Load-bearing honesty
+     caveat; keep the anchored line link-portable (inline code + bead refs only, no
+     repo-relative links) so it renders under both mounts. Keep the ANCHOR markers
+     one-per-line — mdBook excludes only the exact marker line.
+     privacy-claims-allow: NEGATIVE caveat block (explicitly "not full malicious security",
+     semi-honest floor, ZK proof not implemented) — not an achieved-property claim; sq-qhy4. [OPUS-4.8] -->
+<!-- ANCHOR: scaffold-caveat -->
 > **Maturity (read first).** EARLY / RESEARCH, **native-only** (deliberately not in the wasm build). The Shamir layer's reconstruction is **RS-consistency-checked**: it detects (and, with enough redundancy, robustly corrects) actively-tampered shares and reports the exact guarantee via `BackendInfo.malicious_security` — but the degree-`2t` equality open in the hidden-value join is **not** hardened at `n = 2t+1` (see *Gotchas*). The primitives run as an **in-process simulation** (one process plays all parties) for correctness/cost counting, AND over a **REAL multi-process loopback transport** (`transport` module — each party its own process over `127.0.0.1`; all four `QueryClass` cells incl. the multi-round oblivious shuffle/sort run on the wire) for MEASURED wall-clock + bytes-on-wire. The **collaborative ZK proof** of correctness + issuer-attestation is **not implemented**: those methods return `MpcError::NotYetImplemented` naming their gate. No fake crypto anywhere. See *Gotchas* for the full envelope.
+<!-- ANCHOR_END: scaffold-caveat -->
 
 ## Quickstart
 

--- a/skills/zk-query-proofs/SKILL.md
+++ b/skills/zk-query-proofs/SKILL.md
@@ -7,7 +7,14 @@ description: Prove and verify a SPARQL query result over committed RDF Verifiabl
 
 Zero-knowledge proofs that a SPARQL query result is correct over RDF held in named-graph Verifiable Credentials. **`sparq-zk`** (stage 1) canonicalizes (RDFC10) and commits each named graph to a Poseidon2-BN254 commitment `C(G)`, encodes terms, and signs commitments with a Schnorr-over-Baby-JubJub issuer key. **`sparq-zk-compose`** (stage 2) builds per-property Noir circuit inputs (BGP **scan** + hidden-operand integer **FILTER**), drives `nargo`/`bb` to produce/verify proofs, and bundles everything into a serializable `ProofManifest` that a relying party verifies against its own trust anchors (issuer key-set, status list, fresh nonce).
 
+<!-- sq-im8u: the `scaffold-caveat` anchor is single-sourced into
+     book/src/getting-started/capabilities.md via mdBook {{#include}}. Load-bearing honesty
+     caveat; keep the anchored line link-portable (bead refs + inline code only, no
+     repo-relative links) so it renders under both mounts. Keep the ANCHOR markers
+     one-per-line — mdBook excludes only the exact marker line. [OPUS-4.8] -->
+<!-- ANCHOR: scaffold-caveat -->
 > **Research-stage / experimental — NOT-yet-sound.** The composition verifier's soundness is the subject of an open audit (sq-qhy4 / sq-9hrn; remediation epic sq-1s2): a passing proof is NOT a guarantee the SPARQL statement holds under an adversarial prover. Read the "Honest scope" section before relying on a guarantee — only `Simple` entailment is proved; circuit members are fixed buckets. The query fragment covers BGP scans, integer FILTER (and the integer-valued `xsd:double` fragment), and a single-prover hidden cross-credential JOIN.
+<!-- ANCHOR_END: scaffold-caveat -->
 
 ## Prerequisites
 


### PR DESCRIPTION
> 🤖 **SPARQ agent (Claude Opus 4.8, 1M context).** @jeswr runs several agents on one account — this is one of them. DOC-ONLY change (no `crates/` source).

Implements **sq-im8u** — *single-source include wiring of the docs-site guide pages so no prose is duplicated in `book/`; build-time content injection from the canonical sources*.

## What changed (before → after)

The three existing `book/src` content pages were hand-written prose distilled from the README/SKILLs (the sq-h0tr scaffold, which explicitly deferred include-wiring to this bead). They are now **thin `{{#include}}` wrappers** that inject their prose at build time from the canonical source, so the guide cannot drift:

| Page | Was | Now single-sources |
| --- | --- | --- |
| `introduction.md` | hand-written lead + "how it is published" prose | README `lead` anchor (`{{#include}}`) |
| `getting-started/install.md` | duplicated quickstart command blocks | README `quickstart-cli` anchor (+ the existing sq-384j `{{#rustdoc_include}}` of the tested example) |
| `getting-started/capabilities.md` | hand-written ZK/MPC research-scaffold caveats | the `scaffold-caveat` anchors in `skills/zk-query-proofs/SKILL.md` + `skills/mpc/SKILL.md` |

Added one-per-line `ANCHOR`/`ANCHOR_END` markers to `README.md` (invisible HTML comments — the rendered README prose is unchanged) and both SKILL.md files. A multi-line marker leaks the comment's continuation lines into the include — caught here by `mdbook test` and fixed by keeping each marker on its own line.

Extended the **`docs.yml` path filter** to watch the newly-embedded `README.md` + the two `SKILL.md` so a future anchor rename/removal re-triggers the docs lane (self-guarding-filter class, sq-5f1s4; mdBook EXITs 0 on a broken include, so re-running the lane is the only thing that catches it).

## Honesty / privacy-claims

The load-bearing **ZK/MPC research-scaffold caveats are now single-sourced** from their canonical SKILL.md guides, so the "not-yet-sound / not externally audited (sq-qhy4)" and "semi-honest only / not full malicious security" hedges cannot drift out of the guide. No unqualified ZK/MPC claim is introduced; `check-privacy-claims.sh` is clean over all 457 files.

## Design judgment (standing-rule, no greenlight)

The capabilities **link-TABLE** is deliberately **not** single-sourced from the README Features list. The README links per-surface guides with **repo-relative** paths (`skills/<x>/SKILL.md`) — required there by the lychee internal-links gate — and mdBook rewrites a relative link relative to *the including page's* mount, so an included copy resolves to a non-existent `getting-started/skills/...` and 404s under Pages (verified: mdBook rewrites `skills/cli/SKILL.md` → `skills/cli/SKILL.html` relative to the page). The table therefore keeps mount-portable **absolute** GitHub URLs as a navigation matrix (mount-point-specific link targets, not duplicated prose). Fully single-sourcing the table is tracked as follow-up **sq-g4h0c** (needs an mdbook link-rewriting preprocessor, a lychee-accepted portable-link convention, or a shared capability manifest).

## Gates (run locally)

- `mdbook 0.4.40 build book` — clean, no `[ERROR]` lines; all 4 includes inject; no anchor/comment leakage in rendered HTML.
- `mdbook test book` — all chapters pass (compiles the embedded example).
- `scripts/check-privacy-claims.sh` — OK (457 files, 0 unqualified claims).
- `markdownlint-cli2` (repo HARD config) — 0 errors over changed files incl. the book pages.
- No crate README touched (root README is not a crate README); no `crates/` source changed.

Closes sq-im8u. Follow-up: sq-g4h0c.

🤖 Generated with [Claude Code](https://claude.com/claude-code)