### PR TITLE
feat(sparq-trust): secprop ontology vocab — sec-prop: extension (Turtle + Rust constants), opt-in `secprop-vocab` (sq-5oru9) [OPUS-4.8]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -502,6 +502,21 @@ jobs:
             crate: sparq-kb
             features: close
             test: true
+          # [OPUS-4.8] sq-5oru9 (epic sq-0dksu): the sparq sec-prop: EXTENSION vocab.
+          # The `secprop` module (Rust constants) + the `secprop_ttl.rs` integration
+          # suite (`#![cfg(feature = "secprop-vocab")]`) + the `secprop::tests` unit
+          # tests are ALL behind the default-OFF `secprop-vocab` feature, so ci.yml's
+          # default-feature `nextest archive` compiles them EMPTY and runs ZERO of
+          # them — the silent-skip gap (#1171) this leg closes. The feature is
+          # dependency-free (`const &str` data + a TTL drift test, strictly additive),
+          # so this leg is cheap and reaches every secprop-vocab test. Verified
+          # locally: `cargo test -p sparq-trust --features secprop-vocab` runs the 5
+          # `secprop::tests` unit drift-checks + the 3 `secprop_ttl.rs` integration
+          # tests; `clippy --all-targets -D warnings` is clean in every state.
+          - name: sparq-trust (secprop-vocab)
+            crate: sparq-trust
+            features: secprop-vocab
+            test: true
           # [OPUS-4.8] sq-leg8n: the sparq-terse opt-in LLM-ergonomic SPARQL surface
           # (epic sq-2m6zm, design research/llm-ergonomic-sparql-surface.md). Only the
           # `vectors` leg lives here: it pulls sparq-core/sparq-nlq/sparq-vectors and runs the

--- a/crates/sparq-trust/Cargo.toml
+++ b/crates/sparq-trust/Cargo.toml
@@ -43,6 +43,12 @@ did = ["dep:serde_json"]
 # present (sparq-zk commitment for the evidence hash, std hashing) — NO new dependency,
 # so the lean default build is byte-identical with it OFF.
 store = []
+# The sparq sec-prop: EXTENSION vocabulary (`secprop` module + `secprop-ext.ttl`):
+# the orthogonal proof-system dimensions + the assurance/audit-status axis the
+# vendored `sec-prop:` ontology lacks (sq-5oru9; design §4.2). Dependency-free — it
+# is `const &str` data + a TTL drift test, strictly additive (no new dep, no new edge
+# onto the lean default build).
+secprop-vocab = []
 
 [dependencies]
 sparq-core = { path = "../sparq-core", default-features = false }

--- a/crates/sparq-trust/README.md
+++ b/crates/sparq-trust/README.md
@@ -84,36 +84,36 @@ view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
   issuer by `trust:issuerDid` instead of `trust:issuerKey` hex. `DidKeyResolver` decodes a `did:key`
   offline; `DidWebResolver` reads a `did:web` document via a **pluggable** fetcher (no HTTP client on
   the default build). **Narrows** the operator-asserted-key forgery vector D′ (not an absolute anchor).
+- **Security-properties vocabulary** (`secprop`, **opt-in `secprop-vocab`**, `sq-5oru9`) — the sparq
+  **`sec-prop:` extension** (constants + [`secprop-ext.ttl`](ontologies/zkp-sparql/secprop-ext.ttl)): the
+  orthogonal proof-system dimensions + the **assurance / audit-status axis** the vendored `sec-prop:` lacks,
+  same namespace (extend, not fork). Records a claim + its epistemic basis — NOT a proof; default assurance
+  `Claimed` (#1001), no sparq ZK method `Proven` while the audit (`sq-qhy4`) is open.
 
 ## Honest scope — what this does and does NOT do
 
 - **No privacy / unlinkability / anonymity.** The credential is admitted **in the clear**; the
-  verifier learns the exact value (`age 25`, not "≥ 18"). This does **not** match ZKAPs-grade
-  unlinkable presentation.
+  verifier learns the exact value (`age 25`, not "≥ 18"). This does **not** match ZKAPs-grade unlinkable presentation.
 - **Holder binding is the clear-WebID, non-anonymous degraded path** (`sq-wvne`):
-  `credentialSubject == Session.agent` authenticates the WebID in the clear — documented, not
-  silently "solved". Presentations stay linkable by requester identity.
+  `credentialSubject == Session.agent` authenticates the WebID in the clear — not silently "solved"; presentations stay linkable by requester identity.
 - **Issuer keys: operator-asserted by default; DID-bindable (opt-in, `sq-pfae.3`).** The default
-  `trust:issuerKey` hex binding is the live forgery vector D′ (§3.3); the `did` feature binds it from
-  a `trust:issuerDid` instead, which **narrows** D′ but is no absolute anchor (`did:key` self-cert;
-  `did:web` only as strong as host/TLS).
+  `trust:issuerKey` hex binding is the live forgery vector D′ (§3.3); the `did` feature binds from a
+  `trust:issuerDid` instead — **narrows** D′ but no absolute anchor (`did:key` self-cert; `did:web` host/TLS).
 - **Delegation invocation is the clear-WebID, non-anonymous path too** (`sq-l5og`): the gate
   authenticates the invoker AS the terminal delegate's WebID in the clear. The `delegate_key` binding
   defeats the key-substitution stolen-chain replay but **not** full non-replayability; deep-chain
   *incremental* revocation stays open (rustdoc has the full reasoning).
-- **Open problems respected as documented limitations:** `sq-tu4e` (no in-reasoner NAF;
-  `revoked` is input-only) and `sq-wvne` (ZK privacy) are **out of PoC scope**; `sq-xc4y` is RESOLVED
-  by the static/dynamic split; `sq-l5og` is **specified, enforced, and tested**.
-- **Strict additivity (G6):** with `sparq-solid`'s `trust-graph` feature OFF the crate is not
-  compiled and `sparq-solid` behaves exactly as WAC/ACP do today (byte-identical).
+- **Open problems respected as documented limitations:** `sq-tu4e` (no in-reasoner NAF; `revoked`
+  input-only) + `sq-wvne` (ZK privacy) are **out of PoC scope**; `sq-xc4y` RESOLVED (static/dynamic split); `sq-l5og` **specified + enforced + tested**.
+- **Strict additivity (G6):** with `sparq-solid`'s `trust-graph` feature OFF the crate is not compiled — `sparq-solid` behaves exactly as WAC/ACP do today (byte-identical).
 
 ## 📚 Learn more
 
-- The machine-readable vocabulary [`trust.ttl`](ontologies/trust/trust.ttl) +
-  [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md) two-stratum semantics note (`sq-pfae.2`), and the
-  design record `research/solid-trust-graph-authz-design.md` (§3.2 storage model; §6.0 PoC spec; §7
-  honest limits) — [issue #940](https://github.com/jeswr/sparq/issues/940). The host crate
-  [`sparq-solid`](../sparq-solid/README.md). `cargo doc -p sparq-trust --all-features` for full docs.
+- The machine-readable [`trust.ttl`](ontologies/trust/trust.ttl) +
+  [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md) (`sq-pfae.2`) + the
+  [`secprop-ext.ttl`](ontologies/zkp-sparql/secprop-ext.ttl) sec-prop: extension; design records
+  `research/solid-trust-graph-authz-design.md` (§3.2 storage; §6.0 PoC) + `…/security-properties-ontology-design.md`
+  (secprop §4.2) — [#940](https://github.com/jeswr/sparq/issues/940). `cargo doc -p sparq-trust --all-features`.
 
 ## License
 

--- a/crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl
+++ b/crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl
@@ -1,0 +1,310 @@
+# secprop-ext.ttl — the sparq EXTENSION of the vendored `sec-prop:` ontology.
+#
+# [OPUS-4.8] sq-5oru9 (epic sq-0dksu; design record
+# research/security-properties-ontology-design.md §4.2). 🤖 SPARQ agent —
+# security-properties ontology. Written while Fable unavailable; flag for re-review
+# when Fable returns.
+#
+# WHAT THIS IS. The vendored `sec-prop:` vocabulary (vocab/sec-prop.yaml.ld) carries
+# the eight security properties of paper §7.7 as boolean concepts. This file EXTENDS
+# that same namespace (https://w3id.org/zkp-sparql/sec-prop#) — it does NOT fork it
+# (design §4.1) — with the orthogonal proof-system dimensions it lacks (§3.3 delta)
+# and the assurance / audit-status axis (§4.2.2). Reused terms keep his IRIs; new
+# terms are minted under the `secx:` ("sec-prop extension") sub-prefix of the SAME
+# namespace so it is visible which are his vs new while both resolve under his
+# w3id.org base.
+#
+# IRREDUCIBILITY (design §4.4). Each dimension is non-derivable from the others
+# (Unlinkability ≠ Anonymity; ZeroKnowledgeType ≠ Soundness; Hiding ≠ Binding;
+# SingleUse ≠ Unlinkability; assurance ≠ any property). The assurance axis is ONE
+# axis orthogonal to every property — stated once, not multiplied across dimensions.
+#
+# HONESTY — assurance default + the sq-qhy4 audit gate. The default assurance for a
+# sparq-asserted ZK property is `secx:Claimed` (issue #1001 Option A) and the live
+# audit status is `secx:ExternalSignOffPending`: sparq's ZK estate is research-grade
+# and NOT externally audited (bead sq-qhy4). NO sparq ZK method may be labelled
+# `secx:Proven` while sq-qhy4 is open. This vocabulary RECORDS claims + their
+# epistemic basis; it is NOT itself a proof of any property.
+#
+# DPV ALIGNMENT — Light (issue #1002 Option 2). New property classes carry
+# `skos:closeMatch`/`rdfs:seeAlso` to W3C DPV CryptographicMethods IRIs where a
+# near-match exists; the full regulation→requirement chain is deliberately NOT built
+# here (that is the deeper, reversible-later option).
+#
+# SCOPE OF THIS FILE (bead sq-5oru9 — the VOCAB head of the chain). This file +
+# `crates/sparq-trust/src/secprop.rs` (the Rust constants, byte-pinned to this file
+# by the `secprop_ext_iris_match_rust_constants` test) are the vocabulary. The ODRL
+# leftOperand profile (Phase 4, sq-uor3g), the N3 admissibility ruleset (Phase 2,
+# sq-ufsi9), and the per-method annotation graph (Phase 3, sq-bevd3) are downstream
+# beads and are NOT in this file.
+
+@prefix sec-prop: <https://w3id.org/zkp-sparql/sec-prop#> .
+@prefix secx:    <https://w3id.org/zkp-sparql/sec-prop#> .   # SAME namespace; prose-only distinction
+@prefix sig-impl: <https://w3id.org/zkp-sparql/sig-impl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix skos:    <http://www.w3.org/2004/02/skos/core#> .
+@prefix dpv:     <https://w3id.org/dpv#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+# --- ontology metadata -------------------------------------------------------
+
+<https://w3id.org/zkp-sparql/sec-prop-ext> a owl:Ontology ;
+  rdfs:label "sparq sec-prop: extension — orthogonal proof-system dimensions + assurance axis"@en-GB ;
+  dcterms:description """A sparq extension of the vendored ZKP-SPARQL `sec-prop:`
+ontology. It adds the orthogonal proof-system-theoretic dimensions (ZK-type,
+soundness, completeness, hiding/binding, anonymity, setup, interactivity, selective
+disclosure, single-use) and the machine-reasonable assurance / audit-status axis that
+`sec-prop:`'s boolean properties lack, under the SAME w3id.org/zkp-sparql/sec-prop#
+namespace (extend, not fork). It records claims and their epistemic basis; it is NOT
+a proof of any property. The default assurance for a sparq ZK property is `Claimed`
+and the audit status is `ExternalSignOffPending` (the ZK estate is unaudited,
+sq-qhy4); no sparq ZK method may be labelled `Proven` while that audit is open."""@en-GB ;
+  owl:imports <https://w3id.org/zkp-sparql/sec-prop> ;
+  rdfs:seeAlso <https://github.com/jeswr/sparq/issues/972> ;
+  rdfs:comment "sparq extension; reused terms keep the vendored IRIs (design §4.1)."@en-GB .
+
+# ─────────────────────── annotation shape (§4.2.2) ───────────────────────────
+# Generalises his sig-impl:Assertion reified pattern from "(sig-impl, property) →
+# verdict" to "(any method IRI, property) → (level, assurance, audit-status,
+# assumption, evidence)".
+
+secx:PropertyAssertion a owl:Class, rdfs:Class ;
+  rdfs:subClassOf sig-impl:Assertion ;
+  rdfs:label "Property assertion"@en-GB ;
+  rdfs:comment "A reified (method, property) → (level, assurance, audit-status, assumption, evidence) claim."@en-GB .
+
+secx:hasProperty a owl:ObjectProperty ;
+  rdfs:label "has property"@en-GB ;
+  rdfs:comment "Attaches a secx:PropertyAssertion to a method IRI (a zk:scheme, cryptosuite, circuit family, or mpc: protocol)."@en-GB ;
+  rdfs:range secx:PropertyAssertion .
+
+secx:property a owl:ObjectProperty ;
+  rdfs:label "property"@en-GB ;
+  rdfs:comment "The dimension the assertion is about (e.g. secx:UnlinkabilityScope)."@en-GB ;
+  rdfs:domain secx:PropertyAssertion ;
+  rdfs:range sec-prop:SecurityProperty .
+
+secx:level a owl:ObjectProperty ;
+  rdfs:label "level"@en-GB ;
+  rdfs:comment "The level/class held within the asserted dimension (e.g. secx:CrossPresentation)."@en-GB ;
+  rdfs:domain secx:PropertyAssertion .
+
+secx:parameter a owl:DatatypeProperty ;
+  rdfs:label "parameter"@en-GB ;
+  rdfs:comment "Optional numeric parameter for a parameterised dimension (secx:nistLevel, secx:anonymitySet)."@en-GB ;
+  rdfs:domain secx:PropertyAssertion .
+
+secx:assurance a owl:ObjectProperty ;
+  rdfs:label "assurance"@en-GB ;
+  rdfs:comment "The epistemic basis of the claim: secx:Proven ⊐ secx:Claimed ⊐ secx:Conjectured. ONE axis, orthogonal to every property (§4.2.2). Default for a sparq ZK property is secx:Claimed (#1001 Option A)."@en-GB ;
+  rdfs:domain secx:PropertyAssertion ;
+  rdfs:range secx:AssuranceLevel .
+
+secx:auditStatus a owl:ObjectProperty ;
+  rdfs:label "audit status"@en-GB ;
+  rdfs:comment "secx:ExternallyAudited ⊐ secx:InternallyReviewed ⊐ secx:Unreviewed; plus secx:ExternalSignOffPending for the live sq-qhy4 state."@en-GB ;
+  rdfs:domain secx:PropertyAssertion ;
+  rdfs:range secx:AuditStatus .
+
+secx:assumption a owl:ObjectProperty ;
+  rdfs:label "assumption"@en-GB ;
+  rdfs:comment "The assumption the claim rests on (secx:IssuerHonesty, secx:DiscreteLog, secx:RandomOracle, secx:HonestMajority, secx:SemiHonest). A precondition of a property's validity, not a property of the proof (§4.2.3)."@en-GB ;
+  rdfs:domain secx:PropertyAssertion ;
+  rdfs:range secx:Assumption .
+
+secx:auditEvidence a owl:AnnotationProperty ;
+  rdfs:subPropertyOf rdfs:seeAlso ;
+  rdfs:label "audit evidence"@en-GB ;
+  rdfs:comment "Points at the audit doc / gap-register row backing the audit-status (e.g. the sq-qhy4 audit)."@en-GB ;
+  rdfs:domain secx:PropertyAssertion .
+
+# ─────────────── the assurance axis individuals (§4.2.2) ─────────────────────
+# Proven ⊐ Claimed ⊐ Conjectured. The SAME discharge machinery as a property
+# dimension: `requiresAssurance gteq Proven` mechanically removes every unaudited
+# sparq method. NO sparq ZK method is Proven while sq-qhy4 is open.
+
+secx:AssuranceLevel a owl:Class, rdfs:Class ;
+  rdfs:label "Assurance level"@en-GB ;
+  rdfs:comment "The epistemic basis of a property assertion (orthogonal to every property)."@en-GB .
+
+secx:Proven a secx:AssuranceLevel ;
+  rdfs:label "Proven"@en-GB ;
+  rdfs:comment "Backed by a formal proof or an external audit (including a provable NEGATIVE result, e.g. 'not post-quantum secure'). NOT applicable to a sparq ZK property while sq-qhy4 is open (#1001)."@en-GB .
+secx:Claimed a secx:AssuranceLevel ;
+  rdfs:label "Claimed"@en-GB ;
+  rdfs:comment "Asserted by the implementer, NOT independently verified. The DEFAULT for a sparq ZK property (#1001 Option A)."@en-GB .
+secx:Conjectured a secx:AssuranceLevel ;
+  rdfs:label "Conjectured"@en-GB ;
+  rdfs:comment "Believed plausible but not yet established to the Claimed bar."@en-GB .
+
+secx:AuditStatus a owl:Class, rdfs:Class ;
+  rdfs:label "Audit status"@en-GB ;
+  rdfs:comment "Independent-review state of a property assertion."@en-GB .
+
+secx:ExternallyAudited a secx:AuditStatus ;
+  rdfs:label "Externally audited"@en-GB ;
+  rdfs:comment "Reviewed by an external accredited party."@en-GB .
+secx:InternallyReviewed a secx:AuditStatus ;
+  rdfs:label "Internally reviewed"@en-GB ;
+  rdfs:comment "Reviewed internally only (no external sign-off)."@en-GB .
+secx:Unreviewed a secx:AuditStatus ;
+  rdfs:label "Unreviewed"@en-GB ;
+  rdfs:comment "Not reviewed."@en-GB .
+secx:ExternalSignOffPending a secx:AuditStatus ;
+  rdfs:label "External sign-off pending"@en-GB ;
+  rdfs:comment "External audit is underway / pending. The live state of the sparq ZK estate (sq-qhy4)."@en-GB .
+
+# ─────────────────────── assumptions (§4.2.3) ────────────────────────────────
+
+secx:Assumption a owl:Class, rdfs:Class ;
+  rdfs:label "Assumption"@en-GB ;
+  rdfs:comment "A precondition under which an asserted property holds."@en-GB .
+
+secx:IssuerHonesty a secx:Assumption ; rdfs:label "Issuer honesty"@en-GB .
+secx:DiscreteLog a secx:Assumption ; rdfs:label "Discrete-log hardness"@en-GB .
+secx:RandomOracle a secx:Assumption ; rdfs:label "Random-oracle model"@en-GB .
+secx:HonestMajority a secx:Assumption ; rdfs:label "Honest majority (MPC)"@en-GB .
+secx:SemiHonest a secx:Assumption ; rdfs:label "Semi-honest adversary (MPC)"@en-GB .
+
+# ════════════════════ property dimensions + levels (§4.2.1) ══════════════════
+# [his] = reused from the vendored sec-prop: (the IRI is preserved; where his term
+# was boolean we ADD ordered levels). [new] = an orthogonal dimension this design
+# mints under the same namespace. `⊐` (in comments) = "stronger than".
+
+# ─── [his] Unlinkability: refined into two ordered sub-axes (strength × scope) ──
+# Both rdfs:subPropertyOf his sec-prop:Unlinkability so the original IRI is kept.
+# Honesty: the everlasting/computational and per/cross-presentation taxonomy is the
+# ACADEMIC one (Pfitzmann–Hansen), NOT lifted from the IRTF CFRG BBS draft.
+
+secx:UnlinkabilityStrength a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:subPropertyOf sec-prop:Unlinkability ;
+  rdfs:label "Unlinkability strength"@en-GB ;
+  skos:closeMatch dpv:Pseudonymisation ;
+  rdfs:comment "EverlastingUnlinkable ⊐ ComputationalUnlinkable (Pfitzmann–Hansen)."@en-GB .
+secx:EverlastingUnlinkable a skos:Concept ; rdfs:label "Everlasting unlinkable"@en-GB .
+secx:ComputationalUnlinkable a skos:Concept ; rdfs:label "Computational unlinkable"@en-GB .
+
+secx:UnlinkabilityScope a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:subPropertyOf sec-prop:Unlinkability ;
+  rdfs:label "Unlinkability scope"@en-GB ;
+  skos:closeMatch dpv:Pseudonymisation ;
+  rdfs:comment "CrossPresentation ⊐ PerPresentation ⊐ Linkable (multi-show scope)."@en-GB .
+secx:CrossPresentation a skos:Concept ; rdfs:label "Cross-presentation"@en-GB .
+secx:PerPresentation a skos:Concept ; rdfs:label "Per-presentation"@en-GB .
+secx:Linkable a skos:Concept ; rdfs:label "Linkable"@en-GB .
+
+# ─── [his] PostQuantumForgery: keep IRI, add the nistLevel parameter ──────────
+secx:PQForgeryResistant a skos:Concept ; rdfs:label "PQ forgery-resistant"@en-GB .
+secx:PQForgeable a skos:Concept ; rdfs:label "PQ forgeable"@en-GB .
+secx:nistLevel a owl:DatatypeProperty ;
+  rdfs:label "NIST security category"@en-GB ;
+  rdfs:comment "FIPS 203/204/205 security category 1–5 (a secx:parameter value)."@en-GB ;
+  rdfs:range xsd:integer .
+
+# ─── [his] PostQuantumSnooping ────────────────────────────────────────────────
+secx:PQHiding a skos:Concept ; rdfs:label "PQ hiding"@en-GB .
+secx:PQRevealable a skos:Concept ; rdfs:label "PQ revealable"@en-GB .
+
+# ─── [his] SourceCredentialDisclosure: refined into ordered levels ────────────
+secx:NoIssuerDisclosure a skos:Concept ; rdfs:label "No issuer disclosure"@en-GB .
+secx:IssuerSetDisclosure a skos:Concept ; rdfs:label "Issuer-set disclosure"@en-GB .
+secx:FullSourceDisclosure a skos:Concept ; rdfs:label "Full source disclosure"@en-GB .
+
+# ─── [his] SignatureTypeLeakage ───────────────────────────────────────────────
+secx:SchemeHidden a skos:Concept ; rdfs:label "Scheme hidden"@en-GB .
+secx:SchemeRevealed a skos:Concept ; rdfs:label "Scheme revealed"@en-GB .
+
+# ─── [his] ProofSizeLeakage ───────────────────────────────────────────────────
+secx:FixedSize a skos:Concept ; rdfs:label "Fixed size"@en-GB .
+secx:StructureLeaking a skos:Concept ; rdfs:label "Structure leaking"@en-GB .
+
+# ─── [his] CircuitAudit: keep IRI; DISTINCT from the new Soundness dimension ───
+secx:MechanisedProof a skos:Concept ; rdfs:label "Mechanised proof"@en-GB .
+secx:ManualAudit a skos:Concept ; rdfs:label "Manual audit"@en-GB .
+secx:Unaudited a skos:Concept ; rdfs:label "Unaudited"@en-GB .
+
+# ─── [his] ValidityPeriodLeakage ──────────────────────────────────────────────
+secx:ValidityHidden a skos:Concept ; rdfs:label "Validity hidden"@en-GB .
+secx:ValidityRevealed a skos:Concept ; rdfs:label "Validity revealed"@en-GB .
+
+# ════════════════════ [new] orthogonal proof-system dimensions ═══════════════
+
+secx:ZeroKnowledgeType a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:label "Zero-knowledge type"@en-GB ;
+  skos:closeMatch dpv:ZeroKnowledgeAuthentication ;
+  rdfs:comment "PerfectZK ⊐ StatisticalZK ⊐ ComputationalZK ⊐ NotZK. His set assumed ZK but did not type it."@en-GB .
+secx:PerfectZK a skos:Concept ; rdfs:label "Perfect ZK"@en-GB .
+secx:StatisticalZK a skos:Concept ; rdfs:label "Statistical ZK"@en-GB .
+secx:ComputationalZK a skos:Concept ; rdfs:label "Computational ZK"@en-GB .
+secx:NotZK a skos:Concept ; rdfs:label "Not ZK"@en-GB .
+
+secx:Soundness a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:label "Soundness"@en-GB ;
+  rdfs:comment "KnowledgeSound ⊐ Sound ⊐ Unsound; orthogonally StatisticalSoundness ⊐ ComputationalSoundness. Distinct from his CircuitAudit (generator correctness)."@en-GB .
+secx:KnowledgeSound a skos:Concept ; rdfs:label "Knowledge-sound"@en-GB .
+secx:Sound a skos:Concept ; rdfs:label "Sound"@en-GB .
+secx:Unsound a skos:Concept ; rdfs:label "Unsound"@en-GB .
+secx:StatisticalSoundness a skos:Concept ; rdfs:label "Statistical soundness"@en-GB .
+secx:ComputationalSoundness a skos:Concept ; rdfs:label "Computational soundness"@en-GB .
+
+secx:Completeness a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:label "Completeness"@en-GB ;
+  rdfs:comment "Complete / Incomplete (ZKProof reference)."@en-GB .
+secx:Complete a skos:Concept ; rdfs:label "Complete"@en-GB .
+secx:Incomplete a skos:Concept ; rdfs:label "Incomplete"@en-GB .
+
+secx:Hiding a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:label "Hiding (commitments)"@en-GB ;
+  rdfs:comment "PerfectHiding ⊐ StatisticalHiding ⊐ ComputationalHiding ⊐ NotHiding. General-time hiding axis (his PostQuantumSnooping is its PQ-time slice)."@en-GB .
+secx:PerfectHiding a skos:Concept ; rdfs:label "Perfect hiding"@en-GB .
+secx:StatisticalHiding a skos:Concept ; rdfs:label "Statistical hiding"@en-GB .
+secx:ComputationalHiding a skos:Concept ; rdfs:label "Computational hiding"@en-GB .
+secx:NotHiding a skos:Concept ; rdfs:label "Not hiding"@en-GB .
+
+secx:Binding a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:label "Binding (commitments)"@en-GB ;
+  rdfs:comment "PerfectBinding ⊐ StatisticalBinding ⊐ ComputationalBinding ⊐ NotBinding. Dual of Hiding; the perfectly-hiding-XOR-perfectly-binding impossibility is why both are needed."@en-GB .
+secx:PerfectBinding a skos:Concept ; rdfs:label "Perfect binding"@en-GB .
+secx:StatisticalBinding a skos:Concept ; rdfs:label "Statistical binding"@en-GB .
+secx:ComputationalBinding a skos:Concept ; rdfs:label "Computational binding"@en-GB .
+secx:NotBinding a skos:Concept ; rdfs:label "Not binding"@en-GB .
+
+secx:Anonymity a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:label "Anonymity"@en-GB ;
+  skos:closeMatch dpv:Anonymisation ;
+  rdfs:comment "Anonymous ⊐ Pseudonymous ⊐ Identified, with an anonymitySet parameter. The trust-graph §3.4 clear-WebID path is Identified."@en-GB .
+secx:Anonymous a skos:Concept ; rdfs:label "Anonymous"@en-GB .
+secx:Pseudonymous a skos:Concept ; rdfs:label "Pseudonymous"@en-GB .
+secx:Identified a skos:Concept ; rdfs:label "Identified"@en-GB .
+secx:anonymitySet a owl:DatatypeProperty ;
+  rdfs:label "Anonymity set size"@en-GB ;
+  rdfs:comment "Size of the anonymity set (a secx:parameter value)."@en-GB ;
+  rdfs:range xsd:integer .
+
+secx:Setup a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:label "Setup"@en-GB ;
+  rdfs:comment "Transparent ⊐ UniversalTrustedSetup ⊐ PerCircuitTrustedSetup (STARK/Bulletproofs vs PLONK/KZG vs Groth16)."@en-GB .
+secx:Transparent a skos:Concept ; rdfs:label "Transparent setup"@en-GB .
+secx:UniversalTrustedSetup a skos:Concept ; rdfs:label "Universal trusted setup"@en-GB .
+secx:PerCircuitTrustedSetup a skos:Concept ; rdfs:label "Per-circuit trusted setup"@en-GB .
+
+secx:Interactivity a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:label "Interactivity"@en-GB ;
+  rdfs:comment "NonInteractive / Interactive (NI via Fiat–Shamir; load-bearing for credential-presentability)."@en-GB .
+secx:NonInteractive a skos:Concept ; rdfs:label "Non-interactive"@en-GB .
+secx:Interactive a skos:Concept ; rdfs:label "Interactive"@en-GB .
+
+secx:SelectiveDisclosure a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:label "Selective disclosure"@en-GB ;
+  rdfs:comment "SelectivelyDisclosable / AllOrNothing (BBS / ecdsa-sd vs plain suites)."@en-GB .
+secx:SelectivelyDisclosable a skos:Concept ; rdfs:label "Selectively disclosable"@en-GB .
+secx:AllOrNothing a skos:Concept ; rdfs:label "All-or-nothing"@en-GB .
+
+secx:SingleUse a owl:ObjectProperty, sec-prop:SecurityProperty ;
+  rdfs:label "Single use"@en-GB ;
+  rdfs:comment "SingleUse (nullifier-enforced) / Replayable. The anti-replay primitive his work flagged but did not put in the vocabulary; every current sparq method is Replayable today (honest)."@en-GB .
+secx:SingleUseEnforced a skos:Concept ; rdfs:label "Single-use (nullifier-enforced)"@en-GB .
+secx:Replayable a skos:Concept ; rdfs:label "Replayable"@en-GB .

--- a/crates/sparq-trust/src/lib.rs
+++ b/crates/sparq-trust/src/lib.rs
@@ -126,6 +126,9 @@ pub mod delegation;
 #[cfg_attr(docsrs, doc(cfg(feature = "did")))]
 pub mod did;
 pub mod policy;
+#[cfg(feature = "secprop-vocab")]
+#[cfg_attr(docsrs, doc(cfg(feature = "secprop-vocab")))]
+pub mod secprop;
 /// The trust-document storage / authoring model — server-wide vs per-`.acr` documents,
 /// versioning, revocation, and the admission cache key that composes with the
 /// sparq-solid epoch cache (the P4 model, `sq-pfae.5`). Behind the default-OFF `store`

--- a/crates/sparq-trust/src/secprop.rs
+++ b/crates/sparq-trust/src/secprop.rs
@@ -1,0 +1,559 @@
+//! # `secprop` — the sparq `sec-prop:` extension vocabulary (Rust constants)
+//!
+//! The IRIs of the sparq **security-properties ontology** as Rust constants. This
+//! module **extends** the vendored `sec-prop:` ontology
+//! (`ontologies/zkp-sparql/`) — the companion to the ISWC 2025 ZKP-SPARQL paper —
+//! with the orthogonal proof-system dimensions and the **assurance / audit-status
+//! axis** it lacks, *under the same namespace* (`https://w3id.org/zkp-sparql/sec-prop#`):
+//! it does **not** fork it (design record `research/security-properties-ontology-design.md`
+//! §4.1).
+//!
+//! Reused terms keep the vendored IRIs (`sec-prop:Unlinkability`, …); new terms are
+//! minted under the **same** namespace and named with a `SECX_` constant prefix so
+//! the his-vs-new split is visible in the Rust as it is in the prose (`secx:` is a
+//! prose-only sub-prefix of `sec-prop:`, not a distinct namespace).
+//!
+//! ## What this vocabulary is — and is NOT
+//!
+//! It **records** a (method, property) → (level, assurance, audit-status, assumption)
+//! claim and its **epistemic basis**; it is **NOT** a proof of any property. The
+//! **assurance axis** ([`SECX_PROVEN`] ⊐ [`SECX_CLAIMED`] ⊐ [`SECX_CONJECTURED`]) is
+//! the honesty mechanism: it is **one** axis, orthogonal to every property (stated
+//! once, not multiplied across dimensions). The **default** assurance for a
+//! sparq-asserted ZK property is [`SECX_CLAIMED`] (issue #1001 Option A) and the live
+//! audit status is [`SECX_EXTERNAL_SIGN_OFF_PENDING`] — sparq's ZK estate is
+//! research-grade and **externally UNAUDITED** (`sq-qhy4`, pending an external
+//! accredited-cryptographer sign-off). **No sparq ZK method may be labelled
+//! [`SECX_PROVEN`] while `sq-qhy4` is open.**
+//!
+//! ## DPV alignment — Light (issue #1002 Option 2)
+//!
+//! New property classes cross-reference W3C DPV `CryptographicMethods` IRIs with
+//! `skos:closeMatch` where a near-match exists (in the Turtle); the full
+//! regulation→requirement chain is deliberately not modelled here.
+//!
+//! ## Opt-in by construction
+//!
+//! This whole module (and the `secprop-ext.ttl` it pins) is behind the **default-OFF
+//! `secprop-vocab`** cargo feature, so it adds **nothing** to the lean default build
+//! — it is plain `const &str` data plus a test, no new dependency, strictly additive.
+//!
+//! The canonical machine-readable form is
+//! `ontologies/zkp-sparql/secprop-ext.ttl`; the
+//! `secprop_ext_iris_match_rust_constants` test below keeps the published Turtle and
+//! these constants from drifting (the same discipline as [`crate::vocab`]).
+//!
+//! [OPUS-4.8] sq-5oru9 (epic sq-0dksu; design PR #972). 🤖 SPARQ agent —
+//! security-properties ontology. Flag for re-review when Fable returns.
+
+/// The `sec-prop:` namespace base (the vendored ZKP-SPARQL namespace this extends —
+/// a real `w3id.org` permanent identifier, NOT a placeholder).
+pub const SEC_PROP_NS: &str = "https://w3id.org/zkp-sparql/sec-prop#";
+
+// ── reused [his] property classes (the vendored eight; IRIs preserved) ───────
+
+/// `sec-prop:Unlinkability` — the vendored unlinkability property (refined below
+/// into the [`SECX_UNLINKABILITY_STRENGTH`] × [`SECX_UNLINKABILITY_SCOPE`] sub-axes,
+/// both `rdfs:subPropertyOf` this IRI).
+pub const SEC_PROP_UNLINKABILITY: &str = "https://w3id.org/zkp-sparql/sec-prop#Unlinkability";
+/// `sec-prop:SecurityProperty` — the vendored superclass every dimension instantiates.
+pub const SEC_PROP_SECURITY_PROPERTY: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#SecurityProperty";
+
+// ── the annotation shape (§4.2.2) ────────────────────────────────────────────
+
+/// `secx:PropertyAssertion` — the reified (method, property)→(level, assurance,
+/// audit-status, assumption, evidence) node (`rdfs:subClassOf sig-impl:Assertion`).
+pub const SECX_PROPERTY_ASSERTION: &str = "https://w3id.org/zkp-sparql/sec-prop#PropertyAssertion";
+/// `secx:hasProperty` — attaches a [`SECX_PROPERTY_ASSERTION`] to a method IRI.
+pub const SECX_HAS_PROPERTY: &str = "https://w3id.org/zkp-sparql/sec-prop#hasProperty";
+/// `secx:property` — the dimension the assertion is about.
+pub const SECX_PROPERTY: &str = "https://w3id.org/zkp-sparql/sec-prop#property";
+/// `secx:level` — the level/class held within the asserted dimension.
+pub const SECX_LEVEL: &str = "https://w3id.org/zkp-sparql/sec-prop#level";
+/// `secx:parameter` — an optional numeric parameter (`nistLevel`, `anonymitySet`).
+pub const SECX_PARAMETER: &str = "https://w3id.org/zkp-sparql/sec-prop#parameter";
+/// `secx:assurance` — the epistemic-basis axis of the claim.
+pub const SECX_ASSURANCE: &str = "https://w3id.org/zkp-sparql/sec-prop#assurance";
+/// `secx:auditStatus` — the independent-review state of the claim.
+pub const SECX_AUDIT_STATUS: &str = "https://w3id.org/zkp-sparql/sec-prop#auditStatus";
+/// `secx:assumption` — the assumption the claim rests on.
+pub const SECX_ASSUMPTION: &str = "https://w3id.org/zkp-sparql/sec-prop#assumption";
+/// `secx:auditEvidence` — `rdfs:seeAlso` to the audit doc / gap-register row.
+pub const SECX_AUDIT_EVIDENCE: &str = "https://w3id.org/zkp-sparql/sec-prop#auditEvidence";
+
+// ── the assurance axis (§4.2.2): Proven ⊐ Claimed ⊐ Conjectured ──────────────
+
+/// `secx:AssuranceLevel` — the assurance-axis class.
+pub const SECX_ASSURANCE_LEVEL: &str = "https://w3id.org/zkp-sparql/sec-prop#AssuranceLevel";
+/// `secx:Proven` — backed by a formal proof or an external audit (incl. a provable
+/// NEGATIVE result). **NOT applicable to a sparq ZK property while `sq-qhy4` is open.**
+pub const SECX_PROVEN: &str = "https://w3id.org/zkp-sparql/sec-prop#Proven";
+/// `secx:Claimed` — asserted, not independently verified. **The DEFAULT** for a
+/// sparq ZK property (#1001 Option A).
+pub const SECX_CLAIMED: &str = "https://w3id.org/zkp-sparql/sec-prop#Claimed";
+/// `secx:Conjectured` — believed plausible but not established to the `Claimed` bar.
+pub const SECX_CONJECTURED: &str = "https://w3id.org/zkp-sparql/sec-prop#Conjectured";
+
+/// `secx:AuditStatus` — the audit-status class.
+pub const SECX_AUDIT_STATUS_CLASS: &str = "https://w3id.org/zkp-sparql/sec-prop#AuditStatus";
+/// `secx:ExternallyAudited` — reviewed by an external accredited party.
+pub const SECX_EXTERNALLY_AUDITED: &str = "https://w3id.org/zkp-sparql/sec-prop#ExternallyAudited";
+/// `secx:InternallyReviewed` — reviewed internally only.
+pub const SECX_INTERNALLY_REVIEWED: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#InternallyReviewed";
+/// `secx:Unreviewed` — not reviewed.
+pub const SECX_UNREVIEWED: &str = "https://w3id.org/zkp-sparql/sec-prop#Unreviewed";
+/// `secx:ExternalSignOffPending` — external audit underway/pending. **The live state
+/// of the sparq ZK estate (`sq-qhy4`).**
+pub const SECX_EXTERNAL_SIGN_OFF_PENDING: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#ExternalSignOffPending";
+
+// ── assumptions (§4.2.3) ─────────────────────────────────────────────────────
+
+/// `secx:Assumption` — the assumption class.
+pub const SECX_ASSUMPTION_CLASS: &str = "https://w3id.org/zkp-sparql/sec-prop#Assumption";
+/// `secx:IssuerHonesty` — the issuer-honesty precondition (the dual-leaf INV-VL case).
+pub const SECX_ISSUER_HONESTY: &str = "https://w3id.org/zkp-sparql/sec-prop#IssuerHonesty";
+/// `secx:DiscreteLog` — discrete-log hardness.
+pub const SECX_DISCRETE_LOG: &str = "https://w3id.org/zkp-sparql/sec-prop#DiscreteLog";
+/// `secx:RandomOracle` — the random-oracle model.
+pub const SECX_RANDOM_ORACLE: &str = "https://w3id.org/zkp-sparql/sec-prop#RandomOracle";
+/// `secx:HonestMajority` — the MPC honest-majority assumption.
+pub const SECX_HONEST_MAJORITY: &str = "https://w3id.org/zkp-sparql/sec-prop#HonestMajority";
+/// `secx:SemiHonest` — the MPC semi-honest-adversary assumption (sparq-mpc's model).
+pub const SECX_SEMI_HONEST: &str = "https://w3id.org/zkp-sparql/sec-prop#SemiHonest";
+
+// ── [his] Unlinkability refinement (strength × scope) ─────────────────────────
+
+/// `secx:UnlinkabilityStrength` — `rdfs:subPropertyOf sec-prop:Unlinkability`.
+pub const SECX_UNLINKABILITY_STRENGTH: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#UnlinkabilityStrength";
+/// `secx:EverlastingUnlinkable` — the stronger strength level.
+pub const SECX_EVERLASTING_UNLINKABLE: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#EverlastingUnlinkable";
+/// `secx:ComputationalUnlinkable` — the weaker strength level.
+pub const SECX_COMPUTATIONAL_UNLINKABLE: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#ComputationalUnlinkable";
+/// `secx:UnlinkabilityScope` — `rdfs:subPropertyOf sec-prop:Unlinkability`.
+pub const SECX_UNLINKABILITY_SCOPE: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#UnlinkabilityScope";
+/// `secx:CrossPresentation` — multi-show scope (strongest).
+pub const SECX_CROSS_PRESENTATION: &str = "https://w3id.org/zkp-sparql/sec-prop#CrossPresentation";
+/// `secx:PerPresentation` — single-show scope.
+pub const SECX_PER_PRESENTATION: &str = "https://w3id.org/zkp-sparql/sec-prop#PerPresentation";
+/// `secx:Linkable` — no unlinkability scope (weakest).
+pub const SECX_LINKABLE: &str = "https://w3id.org/zkp-sparql/sec-prop#Linkable";
+
+// ── [his] PostQuantumForgery levels + the nistLevel parameter ─────────────────
+
+/// `secx:PQForgeryResistant`.
+pub const SECX_PQ_FORGERY_RESISTANT: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#PQForgeryResistant";
+/// `secx:PQForgeable`.
+pub const SECX_PQ_FORGEABLE: &str = "https://w3id.org/zkp-sparql/sec-prop#PQForgeable";
+/// `secx:nistLevel` — the FIPS 203/204/205 security category 1–5 (a parameter value).
+pub const SECX_NIST_LEVEL: &str = "https://w3id.org/zkp-sparql/sec-prop#nistLevel";
+
+// ── [his] PostQuantumSnooping levels ──────────────────────────────────────────
+
+/// `secx:PQHiding`.
+pub const SECX_PQ_HIDING: &str = "https://w3id.org/zkp-sparql/sec-prop#PQHiding";
+/// `secx:PQRevealable`.
+pub const SECX_PQ_REVEALABLE: &str = "https://w3id.org/zkp-sparql/sec-prop#PQRevealable";
+
+// ── [his] SourceCredentialDisclosure levels ───────────────────────────────────
+
+/// `secx:NoIssuerDisclosure` (strongest).
+pub const SECX_NO_ISSUER_DISCLOSURE: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#NoIssuerDisclosure";
+/// `secx:IssuerSetDisclosure` (his Merkle-over-dataset default).
+pub const SECX_ISSUER_SET_DISCLOSURE: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#IssuerSetDisclosure";
+/// `secx:FullSourceDisclosure` (weakest).
+pub const SECX_FULL_SOURCE_DISCLOSURE: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#FullSourceDisclosure";
+
+// ── [his] SignatureTypeLeakage levels ─────────────────────────────────────────
+
+/// `secx:SchemeHidden`.
+pub const SECX_SCHEME_HIDDEN: &str = "https://w3id.org/zkp-sparql/sec-prop#SchemeHidden";
+/// `secx:SchemeRevealed`.
+pub const SECX_SCHEME_REVEALED: &str = "https://w3id.org/zkp-sparql/sec-prop#SchemeRevealed";
+
+// ── [his] ProofSizeLeakage levels ─────────────────────────────────────────────
+
+/// `secx:FixedSize`.
+pub const SECX_FIXED_SIZE: &str = "https://w3id.org/zkp-sparql/sec-prop#FixedSize";
+/// `secx:StructureLeaking`.
+pub const SECX_STRUCTURE_LEAKING: &str = "https://w3id.org/zkp-sparql/sec-prop#StructureLeaking";
+
+// ── [his] CircuitAudit levels (distinct from the new Soundness dimension) ─────
+
+/// `secx:MechanisedProof` (strongest).
+pub const SECX_MECHANISED_PROOF: &str = "https://w3id.org/zkp-sparql/sec-prop#MechanisedProof";
+/// `secx:ManualAudit`.
+pub const SECX_MANUAL_AUDIT: &str = "https://w3id.org/zkp-sparql/sec-prop#ManualAudit";
+/// `secx:Unaudited` (weakest).
+pub const SECX_UNAUDITED: &str = "https://w3id.org/zkp-sparql/sec-prop#Unaudited";
+
+// ── [his] ValidityPeriodLeakage levels ────────────────────────────────────────
+
+/// `secx:ValidityHidden`.
+pub const SECX_VALIDITY_HIDDEN: &str = "https://w3id.org/zkp-sparql/sec-prop#ValidityHidden";
+/// `secx:ValidityRevealed`.
+pub const SECX_VALIDITY_REVEALED: &str = "https://w3id.org/zkp-sparql/sec-prop#ValidityRevealed";
+
+// ── [new] orthogonal proof-system dimensions (§3.3 delta) ─────────────────────
+
+/// `secx:ZeroKnowledgeType` dimension.
+pub const SECX_ZERO_KNOWLEDGE_TYPE: &str = "https://w3id.org/zkp-sparql/sec-prop#ZeroKnowledgeType";
+/// `secx:PerfectZK`.
+pub const SECX_PERFECT_ZK: &str = "https://w3id.org/zkp-sparql/sec-prop#PerfectZK";
+/// `secx:StatisticalZK`.
+pub const SECX_STATISTICAL_ZK: &str = "https://w3id.org/zkp-sparql/sec-prop#StatisticalZK";
+/// `secx:ComputationalZK`.
+pub const SECX_COMPUTATIONAL_ZK: &str = "https://w3id.org/zkp-sparql/sec-prop#ComputationalZK";
+/// `secx:NotZK`.
+pub const SECX_NOT_ZK: &str = "https://w3id.org/zkp-sparql/sec-prop#NotZK";
+
+/// `secx:Soundness` dimension (distinct from his `CircuitAudit`).
+pub const SECX_SOUNDNESS: &str = "https://w3id.org/zkp-sparql/sec-prop#Soundness";
+/// `secx:KnowledgeSound`.
+pub const SECX_KNOWLEDGE_SOUND: &str = "https://w3id.org/zkp-sparql/sec-prop#KnowledgeSound";
+/// `secx:Sound`.
+pub const SECX_SOUND: &str = "https://w3id.org/zkp-sparql/sec-prop#Sound";
+/// `secx:Unsound`.
+pub const SECX_UNSOUND: &str = "https://w3id.org/zkp-sparql/sec-prop#Unsound";
+/// `secx:StatisticalSoundness`.
+pub const SECX_STATISTICAL_SOUNDNESS: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#StatisticalSoundness";
+/// `secx:ComputationalSoundness`.
+pub const SECX_COMPUTATIONAL_SOUNDNESS: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#ComputationalSoundness";
+
+/// `secx:Completeness` dimension.
+pub const SECX_COMPLETENESS: &str = "https://w3id.org/zkp-sparql/sec-prop#Completeness";
+/// `secx:Complete`.
+pub const SECX_COMPLETE: &str = "https://w3id.org/zkp-sparql/sec-prop#Complete";
+/// `secx:Incomplete`.
+pub const SECX_INCOMPLETE: &str = "https://w3id.org/zkp-sparql/sec-prop#Incomplete";
+
+/// `secx:Hiding` (commitments) dimension.
+pub const SECX_HIDING: &str = "https://w3id.org/zkp-sparql/sec-prop#Hiding";
+/// `secx:PerfectHiding`.
+pub const SECX_PERFECT_HIDING: &str = "https://w3id.org/zkp-sparql/sec-prop#PerfectHiding";
+/// `secx:StatisticalHiding`.
+pub const SECX_STATISTICAL_HIDING: &str = "https://w3id.org/zkp-sparql/sec-prop#StatisticalHiding";
+/// `secx:ComputationalHiding`.
+pub const SECX_COMPUTATIONAL_HIDING: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#ComputationalHiding";
+/// `secx:NotHiding`.
+pub const SECX_NOT_HIDING: &str = "https://w3id.org/zkp-sparql/sec-prop#NotHiding";
+
+/// `secx:Binding` (commitments) dimension (dual of [`SECX_HIDING`]).
+pub const SECX_BINDING: &str = "https://w3id.org/zkp-sparql/sec-prop#Binding";
+/// `secx:PerfectBinding`.
+pub const SECX_PERFECT_BINDING: &str = "https://w3id.org/zkp-sparql/sec-prop#PerfectBinding";
+/// `secx:StatisticalBinding`.
+pub const SECX_STATISTICAL_BINDING: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#StatisticalBinding";
+/// `secx:ComputationalBinding`.
+pub const SECX_COMPUTATIONAL_BINDING: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#ComputationalBinding";
+/// `secx:NotBinding`.
+pub const SECX_NOT_BINDING: &str = "https://w3id.org/zkp-sparql/sec-prop#NotBinding";
+
+/// `secx:Anonymity` dimension.
+pub const SECX_ANONYMITY: &str = "https://w3id.org/zkp-sparql/sec-prop#Anonymity";
+/// `secx:Anonymous`.
+pub const SECX_ANONYMOUS: &str = "https://w3id.org/zkp-sparql/sec-prop#Anonymous";
+/// `secx:Pseudonymous`.
+pub const SECX_PSEUDONYMOUS: &str = "https://w3id.org/zkp-sparql/sec-prop#Pseudonymous";
+/// `secx:Identified` — the trust-graph §3.4 clear-WebID path level.
+pub const SECX_IDENTIFIED: &str = "https://w3id.org/zkp-sparql/sec-prop#Identified";
+/// `secx:anonymitySet` — the anonymity-set-size parameter.
+pub const SECX_ANONYMITY_SET: &str = "https://w3id.org/zkp-sparql/sec-prop#anonymitySet";
+
+/// `secx:Setup` dimension.
+pub const SECX_SETUP: &str = "https://w3id.org/zkp-sparql/sec-prop#Setup";
+/// `secx:Transparent`.
+pub const SECX_TRANSPARENT: &str = "https://w3id.org/zkp-sparql/sec-prop#Transparent";
+/// `secx:UniversalTrustedSetup`.
+pub const SECX_UNIVERSAL_TRUSTED_SETUP: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#UniversalTrustedSetup";
+/// `secx:PerCircuitTrustedSetup`.
+pub const SECX_PER_CIRCUIT_TRUSTED_SETUP: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#PerCircuitTrustedSetup";
+
+/// `secx:Interactivity` dimension.
+pub const SECX_INTERACTIVITY: &str = "https://w3id.org/zkp-sparql/sec-prop#Interactivity";
+/// `secx:NonInteractive`.
+pub const SECX_NON_INTERACTIVE: &str = "https://w3id.org/zkp-sparql/sec-prop#NonInteractive";
+/// `secx:Interactive`.
+pub const SECX_INTERACTIVE: &str = "https://w3id.org/zkp-sparql/sec-prop#Interactive";
+
+/// `secx:SelectiveDisclosure` dimension.
+pub const SECX_SELECTIVE_DISCLOSURE: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#SelectiveDisclosure";
+/// `secx:SelectivelyDisclosable`.
+pub const SECX_SELECTIVELY_DISCLOSABLE: &str =
+    "https://w3id.org/zkp-sparql/sec-prop#SelectivelyDisclosable";
+/// `secx:AllOrNothing`.
+pub const SECX_ALL_OR_NOTHING: &str = "https://w3id.org/zkp-sparql/sec-prop#AllOrNothing";
+
+/// `secx:SingleUse` dimension (the anti-replay primitive; every sparq method is
+/// [`SECX_REPLAYABLE`] today — honest).
+pub const SECX_SINGLE_USE: &str = "https://w3id.org/zkp-sparql/sec-prop#SingleUse";
+/// `secx:SingleUseEnforced` (nullifier-enforced).
+pub const SECX_SINGLE_USE_ENFORCED: &str = "https://w3id.org/zkp-sparql/sec-prop#SingleUseEnforced";
+/// `secx:Replayable`.
+pub const SECX_REPLAYABLE: &str = "https://w3id.org/zkp-sparql/sec-prop#Replayable";
+
+/// Every `secx:`/`sec-prop:` IRI this module declares, in declaration order. The
+/// single source of truth the `tests` drift-check iterates — keeping the published
+/// `secprop-ext.ttl` and these constants from diverging (the [`crate::vocab`]
+/// discipline).
+pub const ALL_SECPROP_IRIS: &[&str] = &[
+    // reused [his] classes
+    SEC_PROP_UNLINKABILITY,
+    SEC_PROP_SECURITY_PROPERTY,
+    // annotation shape
+    SECX_PROPERTY_ASSERTION,
+    SECX_HAS_PROPERTY,
+    SECX_PROPERTY,
+    SECX_LEVEL,
+    SECX_PARAMETER,
+    SECX_ASSURANCE,
+    SECX_AUDIT_STATUS,
+    SECX_ASSUMPTION,
+    SECX_AUDIT_EVIDENCE,
+    // assurance axis
+    SECX_ASSURANCE_LEVEL,
+    SECX_PROVEN,
+    SECX_CLAIMED,
+    SECX_CONJECTURED,
+    SECX_AUDIT_STATUS_CLASS,
+    SECX_EXTERNALLY_AUDITED,
+    SECX_INTERNALLY_REVIEWED,
+    SECX_UNREVIEWED,
+    SECX_EXTERNAL_SIGN_OFF_PENDING,
+    // assumptions
+    SECX_ASSUMPTION_CLASS,
+    SECX_ISSUER_HONESTY,
+    SECX_DISCRETE_LOG,
+    SECX_RANDOM_ORACLE,
+    SECX_HONEST_MAJORITY,
+    SECX_SEMI_HONEST,
+    // [his] Unlinkability refinement
+    SECX_UNLINKABILITY_STRENGTH,
+    SECX_EVERLASTING_UNLINKABLE,
+    SECX_COMPUTATIONAL_UNLINKABLE,
+    SECX_UNLINKABILITY_SCOPE,
+    SECX_CROSS_PRESENTATION,
+    SECX_PER_PRESENTATION,
+    SECX_LINKABLE,
+    // [his] PostQuantumForgery
+    SECX_PQ_FORGERY_RESISTANT,
+    SECX_PQ_FORGEABLE,
+    SECX_NIST_LEVEL,
+    // [his] PostQuantumSnooping
+    SECX_PQ_HIDING,
+    SECX_PQ_REVEALABLE,
+    // [his] SourceCredentialDisclosure
+    SECX_NO_ISSUER_DISCLOSURE,
+    SECX_ISSUER_SET_DISCLOSURE,
+    SECX_FULL_SOURCE_DISCLOSURE,
+    // [his] SignatureTypeLeakage
+    SECX_SCHEME_HIDDEN,
+    SECX_SCHEME_REVEALED,
+    // [his] ProofSizeLeakage
+    SECX_FIXED_SIZE,
+    SECX_STRUCTURE_LEAKING,
+    // [his] CircuitAudit
+    SECX_MECHANISED_PROOF,
+    SECX_MANUAL_AUDIT,
+    SECX_UNAUDITED,
+    // [his] ValidityPeriodLeakage
+    SECX_VALIDITY_HIDDEN,
+    SECX_VALIDITY_REVEALED,
+    // [new] ZeroKnowledgeType
+    SECX_ZERO_KNOWLEDGE_TYPE,
+    SECX_PERFECT_ZK,
+    SECX_STATISTICAL_ZK,
+    SECX_COMPUTATIONAL_ZK,
+    SECX_NOT_ZK,
+    // [new] Soundness
+    SECX_SOUNDNESS,
+    SECX_KNOWLEDGE_SOUND,
+    SECX_SOUND,
+    SECX_UNSOUND,
+    SECX_STATISTICAL_SOUNDNESS,
+    SECX_COMPUTATIONAL_SOUNDNESS,
+    // [new] Completeness
+    SECX_COMPLETENESS,
+    SECX_COMPLETE,
+    SECX_INCOMPLETE,
+    // [new] Hiding
+    SECX_HIDING,
+    SECX_PERFECT_HIDING,
+    SECX_STATISTICAL_HIDING,
+    SECX_COMPUTATIONAL_HIDING,
+    SECX_NOT_HIDING,
+    // [new] Binding
+    SECX_BINDING,
+    SECX_PERFECT_BINDING,
+    SECX_STATISTICAL_BINDING,
+    SECX_COMPUTATIONAL_BINDING,
+    SECX_NOT_BINDING,
+    // [new] Anonymity
+    SECX_ANONYMITY,
+    SECX_ANONYMOUS,
+    SECX_PSEUDONYMOUS,
+    SECX_IDENTIFIED,
+    SECX_ANONYMITY_SET,
+    // [new] Setup
+    SECX_SETUP,
+    SECX_TRANSPARENT,
+    SECX_UNIVERSAL_TRUSTED_SETUP,
+    SECX_PER_CIRCUIT_TRUSTED_SETUP,
+    // [new] Interactivity
+    SECX_INTERACTIVITY,
+    SECX_NON_INTERACTIVE,
+    SECX_INTERACTIVE,
+    // [new] SelectiveDisclosure
+    SECX_SELECTIVE_DISCLOSURE,
+    SECX_SELECTIVELY_DISCLOSABLE,
+    SECX_ALL_OR_NOTHING,
+    // [new] SingleUse
+    SECX_SINGLE_USE,
+    SECX_SINGLE_USE_ENFORCED,
+    SECX_REPLAYABLE,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The machine-readable `secprop-ext.ttl` is the canonical form; keep it pinned
+    /// to these constants so the two cannot drift (the [`crate::vocab`] discipline).
+    const TTL: &str = include_str!("../ontologies/zkp-sparql/secprop-ext.ttl");
+
+    /// Every constant is in the `sec-prop:` namespace.
+    #[test]
+    fn all_constants_share_the_sec_prop_namespace() {
+        for &iri in ALL_SECPROP_IRIS {
+            assert!(
+                iri.starts_with(SEC_PROP_NS),
+                "constant `{}` is not in the sec-prop: namespace",
+                iri,
+            );
+        }
+    }
+
+    /// No duplicate IRI in the registry (a copy-paste guard).
+    #[test]
+    fn no_duplicate_iris() {
+        let mut seen = std::collections::HashSet::new();
+        for &iri in ALL_SECPROP_IRIS {
+            assert!(
+                seen.insert(iri),
+                "duplicate IRI in ALL_SECPROP_IRIS: {}",
+                iri
+            );
+        }
+    }
+
+    /// Every Rust constant is declared in `secprop-ext.ttl` as a `secx:LocalName`
+    /// subject. The reused `sec-prop:` superclasses are referenced (range/import),
+    /// not subjects of a fresh declaration here, so they are exempt from the
+    /// declared-subject check.
+    #[test]
+    fn secprop_ext_iris_match_rust_constants() {
+        // The two reused vendored class IRIs are referenced (owl:imports /
+        // rdfs:range), not re-declared as subjects in the extension file.
+        let reused_only = [SEC_PROP_UNLINKABILITY, SEC_PROP_SECURITY_PROPERTY];
+
+        for &iri in ALL_SECPROP_IRIS {
+            if reused_only.contains(&iri) {
+                continue;
+            }
+            let local = iri
+                .strip_prefix(SEC_PROP_NS)
+                .expect("every constant is in the sec-prop: namespace");
+            let decl = format!("secx:{} ", local);
+            assert!(
+                TTL.contains(&decl),
+                "secprop-ext.ttl is missing a declaration for `secx:{}` ({}) — the \
+                 published vocabulary drifted from the Rust constants (sq-5oru9)",
+                local,
+                iri,
+            );
+        }
+    }
+
+    /// And every `secx:LocalName a` declaration in the Turtle is backed by a Rust
+    /// constant — no published term without a constant. Scans declaration lines (a
+    /// `secx:Foo a …` start-of-line subject), the inverse of the [`crate::vocab`]
+    /// sync test.
+    #[test]
+    fn every_ttl_term_has_a_rust_constant() {
+        let declared_locals: Vec<&str> = TTL
+            .lines()
+            .filter_map(|line| {
+                let t = line.trim_start();
+                let rest = t.strip_prefix("secx:")?;
+                // Skip the bare-namespace metadata line (no local name) if present.
+                if rest.starts_with(char::is_whitespace) {
+                    return None;
+                }
+                let name = rest.split_whitespace().next()?;
+                // A term declaration line looks like `secx:Foo a …`.
+                if rest[name.len()..].trim_start().starts_with("a ") {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert!(
+            !declared_locals.is_empty(),
+            "no secx: term declarations found in secprop-ext.ttl — parser/format drift",
+        );
+
+        let constant_locals: std::collections::HashSet<&str> = ALL_SECPROP_IRIS
+            .iter()
+            .filter_map(|iri| iri.strip_prefix(SEC_PROP_NS))
+            .collect();
+
+        for local in declared_locals {
+            assert!(
+                constant_locals.contains(local),
+                "secprop-ext.ttl declares `secx:{}` but no Rust constant names it — \
+                 add the constant or remove the term (sq-5oru9)",
+                local,
+            );
+        }
+    }
+
+    /// The assurance default + the sq-qhy4 audit gate are documented in the Turtle —
+    /// a load-bearing honesty invariant of the vocabulary (the default is `Claimed`,
+    /// not `Proven`, and `Proven` is barred while the audit is open).
+    #[test]
+    fn assurance_default_and_audit_gate_are_documented() {
+        assert!(
+            TTL.contains("sq-qhy4"),
+            "secprop-ext.ttl must reference the open external-audit gate (sq-qhy4)",
+        );
+        assert!(
+            TTL.contains("DEFAULT for a sparq ZK property"),
+            "secprop-ext.ttl must document Claimed as the default assurance (#1001 Option A)",
+        );
+        assert!(
+            TTL.contains("NO sparq ZK method may be labelled\n# `secx:Proven`")
+                || TTL.contains("no sparq ZK method may be labelled `Proven`"),
+            "secprop-ext.ttl must document that Proven is barred while sq-qhy4 is open",
+        );
+    }
+}

--- a/crates/sparq-trust/tests/secprop_ttl.rs
+++ b/crates/sparq-trust/tests/secprop_ttl.rs
@@ -1,0 +1,109 @@
+//! Parse-validation of the published `sec-prop:` extension vocabulary
+//! `ontologies/zkp-sparql/secprop-ext.ttl` (sq-5oru9). The Turtle a working group /
+//! reasoner reads MUST stay valid Turtle and MUST declare exactly the term set the
+//! Rust constants name. The `secprop::tests::secprop_ext_iris_match_rust_constants`
+//! unit test pins the IRIs against the constants; this test is the *syntactic* guard
+//! (the `vocab_ttl.rs` discipline applied to the extension).
+//!
+//! Behind the default-OFF `secprop-vocab` feature — exercised by the matching
+//! feature-matrix.yml leg (the silent-skip guard, #1171).
+//!
+//! [OPUS-4.8] sq-5oru9 (epic sq-0dksu; design PR #972). 🤖 SPARQ agent —
+//! security-properties ontology.
+#![cfg(feature = "secprop-vocab")]
+
+use oxttl::TurtleParser;
+
+const TTL: &str = include_str!("../ontologies/zkp-sparql/secprop-ext.ttl");
+
+/// The published extension vocabulary is valid Turtle and non-empty.
+#[test]
+fn secprop_ext_ttl_is_valid_turtle() {
+    let mut triples = 0usize;
+    for result in TurtleParser::new().for_reader(TTL.as_bytes()) {
+        result.expect("secprop-ext.ttl must be valid Turtle");
+        triples += 1;
+    }
+    assert!(
+        triples > 0,
+        "secprop-ext.ttl parsed to zero triples — the published vocabulary is empty",
+    );
+}
+
+/// Every constant in `secprop::ALL_SECPROP_IRIS` appears as a SUBJECT in the parsed
+/// Turtle (a coarse presence check independent of the unit-test constant pinning, so
+/// a refactor of `secprop.rs` cannot silently drop a published term). The two reused
+/// vendored class IRIs (`sec-prop:Unlinkability`, `sec-prop:SecurityProperty`) are
+/// referenced (range / owl:imports) but not re-declared as subjects in the extension
+/// file, so they are exempt — exactly the split the unit test makes.
+#[test]
+fn secprop_ext_ttl_declares_every_minted_term() {
+    use oxrdf::NamedOrBlankNode;
+    use sparq_trust::secprop::{
+        ALL_SECPROP_IRIS, SEC_PROP_SECURITY_PROPERTY, SEC_PROP_UNLINKABILITY,
+    };
+
+    let reused_only = [SEC_PROP_UNLINKABILITY, SEC_PROP_SECURITY_PROPERTY];
+
+    let mut subjects = std::collections::HashSet::new();
+    for result in TurtleParser::new().for_reader(TTL.as_bytes()) {
+        let t = result.expect("valid Turtle");
+        if let NamedOrBlankNode::NamedNode(s) = t.subject {
+            subjects.insert(s.into_string());
+        }
+    }
+
+    for &iri in ALL_SECPROP_IRIS {
+        if reused_only.contains(&iri) {
+            continue;
+        }
+        assert!(
+            subjects.contains(iri),
+            "secprop-ext.ttl does not declare `{}` as a subject",
+            iri,
+        );
+    }
+}
+
+/// The assurance axis carries exactly the three ordered levels, the audit-status set
+/// includes the live `ExternalSignOffPending` state, and the file references the open
+/// `sq-qhy4` audit gate — the load-bearing honesty invariants of the vocabulary.
+#[test]
+fn secprop_ext_ttl_carries_the_assurance_axis_and_audit_gate() {
+    use oxrdf::{NamedNode, NamedOrBlankNode, Term};
+    use sparq_trust::secprop::{
+        SECX_ASSURANCE_LEVEL, SECX_AUDIT_STATUS_CLASS, SECX_CLAIMED, SECX_CONJECTURED,
+        SECX_EXTERNAL_SIGN_OFF_PENDING, SECX_PROVEN,
+    };
+
+    const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+    // Collect (subject, type) pairs.
+    let mut typed: Vec<(String, String)> = Vec::new();
+    for result in TurtleParser::new().for_reader(TTL.as_bytes()) {
+        let t = result.expect("valid Turtle");
+        if t.predicate == NamedNode::new(RDF_TYPE).unwrap() {
+            if let (NamedOrBlankNode::NamedNode(s), Term::NamedNode(o)) = (t.subject, t.object) {
+                typed.push((s.into_string(), o.into_string()));
+            }
+        }
+    }
+    let is_a = |s: &str, class: &str| typed.iter().any(|(sub, ty)| sub == s && ty == class);
+
+    for level in [SECX_PROVEN, SECX_CLAIMED, SECX_CONJECTURED] {
+        assert!(
+            is_a(level, SECX_ASSURANCE_LEVEL),
+            "`{}` must be a secx:AssuranceLevel",
+            level,
+        );
+    }
+    assert!(
+        is_a(SECX_EXTERNAL_SIGN_OFF_PENDING, SECX_AUDIT_STATUS_CLASS),
+        "the live sq-qhy4 state ExternalSignOffPending must be a secx:AuditStatus",
+    );
+
+    assert!(
+        TTL.contains("sq-qhy4"),
+        "secprop-ext.ttl must reference the open external-audit gate (sq-qhy4)",
+    );
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -481,6 +481,28 @@ implemented: it binds each hop's `delegate_key` into the delegator-signed preima
 key-substitution stolen-chain replay — but it does **not** claim full non-replayability, because
 the delegator's own key is still operator-asserted (`sq-pfae.3`); see the crate README *Honest scope*.
 
+### Security-properties vocabulary — opt-in `secprop-vocab` ([OPUS-4.8] sq-5oru9, epic sq-0dksu)
+
+The `sparq_trust::secprop` module (behind the **default-OFF `secprop-vocab`** cargo feature) is the
+sparq **`sec-prop:` extension** vocabulary: the orthogonal proof-system dimensions (ZK-type,
+soundness, completeness, hiding/binding, anonymity, setup, interactivity, selective disclosure,
+single-use) plus the machine-reasonable **assurance / audit-status axis** that the vendored
+`sec-prop:` ontology (the ISWC 2025 ZKP-SPARQL paper's vocabulary,
+`crates/sparq-trust/ontologies/zkp-sparql/`) lacks — **under the same
+`https://w3id.org/zkp-sparql/sec-prop#` namespace** (extend, do not fork; design
+`research/security-properties-ontology-design.md` §4.1). It is **data + Rust constants only** (a
+`const &str` registry + the canonical [`secprop-ext.ttl`](../../crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl),
+pinned together by a drift test) — it is **not** a reasoner, an ODRL profile, or a per-method
+annotation graph (those are the downstream Phase 2/3/4 beads `sq-ufsi9`/`sq-bevd3`/`sq-uor3g`).
+
+The **assurance axis is the honesty mechanism**: `Proven ⊐ Claimed ⊐ Conjectured`, one axis
+orthogonal to every property. The **default** assurance for a sparq-asserted ZK property is
+`secx:Claimed` (decision #1001 Option A) with audit status `secx:ExternalSignOffPending` — and **no
+sparq ZK method may be labelled `secx:Proven` while the external accredited-cryptographer audit
+(`sq-qhy4`) is open.** The vocabulary **records** a claim and its epistemic basis; it is **NOT** a
+proof of any property. DPV alignment is *Light* (#1002 Option 2): `skos:closeMatch` cross-refs to
+W3C DPV `CryptographicMethods` where a near-match exists, not a full regulation→requirement chain.
+
 ## Related skills
 
 - [`http-server`](../http-server/SKILL.md) — the sparq SPARQL HTTP server has **no**


### PR DESCRIPTION
> 🤖 **SPARQ agent** — security-properties ontology. This PR is the **head of the secprop ontology Phase chain** (epic `sq-0dksu`, bead `sq-5oru9`). Written while Fable is unavailable; flag for re-review when Fable returns.

## What this implements

The sparq **`sec-prop:` extension vocabulary** — the *vocab head* of the secprop chain — as a **Turtle file + Rust constants**, behind a new **default-OFF `secprop-vocab`** cargo feature on `sparq-trust`. It **extends** the vendored ZKP-SPARQL `sec-prop:` ontology (the ISWC 2025 paper's vocabulary, `crates/sparq-trust/ontologies/zkp-sparql/`) — **under the same `https://w3id.org/zkp-sparql/sec-prop#` namespace** (extend, not fork; design `research/security-properties-ontology-design.md` §4.1) — with:

- the **orthogonal proof-system dimensions** his boolean properties lack: ZK-type, soundness, completeness, hiding/binding, anonymity, setup, interactivity, selective-disclosure, single-use (§3.3 delta);
- the **assurance / audit-status axis** (§4.2.2) — `secx:Proven ⊐ Claimed ⊐ Conjectured` + `ExternallyAudited ⊐ InternallyReviewed ⊐ Unreviewed` (+ `ExternalSignOffPending`) — **one** axis orthogonal to every property;
- the **annotation shape** (`secx:hasProperty`/`property`/`level`/`assurance`/`auditStatus`/`assumption`/`auditEvidence`) generalising his `sig-impl:Assertion` reified pattern;
- the **assumptions** (`IssuerHonesty`, `DiscreteLog`, `RandomOracle`, `HonestMajority`, `SemiHonest`).

### Documented design decisions (standing rule — proceeded with defaults)

- **Assurance default = `Claimed`** (issue #1001 Option A) — and **no sparq ZK method is `Proven` while the external audit (`sq-qhy4`) is open**.
- **DPV alignment = Light** (issue #1002 Option 2) — `skos:closeMatch` cross-refs to W3C DPV `CryptographicMethods` where a near-match exists; **not** a full regulation→requirement chain.

### Honest scope (privacy-claims compliant)

The vocabulary **records** a (method, property) → (level, assurance, audit-status, assumption) claim and its **epistemic basis**; it is **NOT** a proof of any property. sparq's ZK estate is research-grade and **externally UNAUDITED** (`sq-qhy4`, pending accredited-cryptographer sign-off); `sparq-mpc` is honest-majority semi-honest only. No `Proven` labels are minted for sparq methods.

### Out of scope (downstream Phase beads — NOT in this PR)

The ODRL leftOperand profile (Phase 4, `sq-uor3g`), the N3 admissibility ruleset (Phase 2, `sq-ufsi9`), and the per-method annotation graph (Phase 3, `sq-bevd3`). This PR is the **vocab head** they build on.

## Files

- `crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl` — the canonical machine-readable vocab (valid Turtle; `owl:imports` the vendored `sec-prop:`).
- `crates/sparq-trust/src/secprop.rs` — the Rust constants (the `secprop` module), behind the new default-OFF `secprop-vocab` feature. **Dependency-free** `const &str` data + a TTL drift test — strictly additive, the lean default build is byte-identical.
- `crates/sparq-trust/tests/secprop_ttl.rs` — feature-gated syntactic guard (valid Turtle + every minted term is a subject + the assurance-axis/audit-gate invariants).
- `Cargo.toml` / `lib.rs` — the feature + the feature-gated `pub mod secprop`.
- `.github/workflows/feature-matrix.yml` — a new **`sparq-trust (secprop-vocab)`** leg that EXECUTES the cfg-gated suite (the #1171 silent-skip guard).
- README + `skills/access-control/SKILL.md` — document the feature, its semantics, and the honest boundary (README kept ≤120 lines).

## Opt-in by construction

`secprop-vocab` is **default-OFF**; with it off, `sparq-trust` is byte-identical and nothing in the lean core/default build changes. No new dependency, no new edge.

## Gates run — GREEN in BOTH feature states

| Gate | default (feature OFF) | `--features secprop-vocab` |
|---|---|---|
| `cargo build -p sparq-trust` | ✅ | ✅ |
| `cargo test -p sparq-trust …` | ✅ | ✅ (5 unit drift-checks + 3 TTL integration tests) |
| `cargo clippy --all-targets -D warnings` | ✅ | ✅ |

Also green: `cargo clippy -p sparq-trust --no-default-features --all-targets -D warnings`, `--all-features` clippy, `RUSTDOCFLAGS=-D warnings cargo doc --all-features` (crate + workspace), `cargo fmt` (new `secprop.rs` is rustfmt-clean; untouched files not reformatted), `scripts/check-readme-template.py --enforce` (0 deviations, README = 120 lines), `scripts/check-privacy-claims.sh` (clean), markdownlint (0 errors), typos (clean). The load-bearing **TTL↔Rust drift test** (`secprop_ext_iris_match_rust_constants` + `every_ttl_term_has_a_rust_constant`) exercises the real pinning in both directions.

Feature flag to enable: **`secprop-vocab`** (on `sparq-trust`). Rebased on `origin/main` (incl. #1182's opt-in `store`); Cargo.lock unchanged (memmap2 0.9.11 preserved). Auto-merge intentionally **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)