### PR TITLE
docs(data-formats): loaders REJECT unknown formats, not parse-as-Turtle (sq-vkuv8) [OPUS-4.8]

### DIFF
--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -414,10 +414,18 @@ cargo build -p sparq-cli --features serialize-rdf
 
 ## Gotchas / feature flags / prerequisites
 
-- **Format strings are matched literally.** Accepted: `"turtle"`/`"ttl"`,
-  `"ntriples"`/`"n-triples"`, `"nquads"`/`"n-quads"`, `"trig"`/`"application/trig"`.
-  `parse_to_triples` (and the `_with_base` variants) treat any **unknown** format as
-  Turtle (the `_ =>` arm) — pass the exact string.
+- **Format strings are matched literally — an unknown format is REJECTED, not
+  guessed.** Accepted aliases:
+  `"turtle"`/`"ttl"`/`"text/turtle"`/`"application/turtle"`,
+  `"ntriples"`/`"n-triples"`/`"nt"`/`"application/n-triples"`,
+  `"nquads"`/`"n-quads"`/`"nq"`/`"application/n-quads"`, `"trig"`/`"application/trig"`
+  (and the `"jsonld"`/`"json-ld"`/`"application/ld+json"` set when the `jsonld` feature is
+  on). `parse_to_triples` (and the `_with_base` variants), `load_dataset`/`load_dataset_serial`
+  gate on these explicit alias sets: any unknown/typo'd string returns
+  `Err("unknown RDF format \"…\" (known: …)")` naming the bad format — it does **not**
+  silently fall back to Turtle/TriG (the old `_ =>` catch-all was removed in sq-m2pc /
+  sq-01yr; verify: `cargo test -p sparq-core parse_to_triples_rejects_unknown_format
+  load_dataset_rejects_unknown_format`). Pass the exact string.
 - **Parallel paths need the `parallel` feature** (on by default natively). The parallel
   fast path applies to N-Triples and Turtle in `load_str`; `load_reader_parallel`'s
   pipelined parser is **N-Triples only** (other formats silently fall back to serial


### PR DESCRIPTION
> 🤖 **SPARQ agent** — DOC-ONLY honesty-reconciliation pass.

## What this fixes (bead sq-vkuv8)

`skills/data-formats/SKILL.md` "Gotchas" bullet still claimed:

> `parse_to_triples` (and the `_with_base` variants) treat any **unknown** format as Turtle (the `_ =>` arm)

That has been **STALE** since **sq-m2pc** (`parse_to_triples` / `_with_base`) and **sq-01yr** (`load_dataset_serial`): the loaders now gate on explicit alias sets and **reject** unknown/typo'd formats with an error that names the bad format — they no longer silently fall back to Turtle/TriG.

### Before → after (status wording)

| | text |
|---|---|
| **before** | "treat any **unknown** format as Turtle (the `_ =>` arm)" |
| **after** | "an unknown format is **REJECTED, not guessed** … any unknown/typo'd string returns `Err(\"unknown RDF format \"…\" (known: …)\")` naming the bad format — it does **not** silently fall back to Turtle/TriG" |

Also corrected the accepted-alias list to the verified code (it was missing the media-type aliases, the `nt`/`nq` extension aliases, and the feature-gated `jsonld` set).

## Verification (reproducible)

- `crates/sparq-core/src/lib.rs` — `parse_to_triples` / `parse_to_triples_with_base` / `load_dataset_serial` now end in `_ => return Err(unknown_format_err(format))`; `is_turtle_format` / `is_trig_format` / `is_nquads_format` / `is_jsonld_format` are the alias authorities; `unknown_format_err` returns `unknown RDF format {format:?} (known: …)`.
- `cargo test -p sparq-core parse_to_triples_rejects_unknown_format load_dataset_rejects_unknown_format` → **both pass** (default features).

## Gates

- `markdownlint-cli2 skills/data-formats/SKILL.md` → 0 errors
- `python3 scripts/check-readme-template.py --enforce` → 0 deviations (SKILL is not a README)
- `bash scripts/check-privacy-claims.sh` → OK; **no unqualified ZK/MPC claim introduced** (this change touches no privacy/soundness wording)
- typos gate: no `DELETEd`/`DROPped`/`invokable`/`ANDed`-class tokens added

DOC-ONLY — no `crates/` source change. Auto-merge **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
