### PR TITLE
feat(sparq-trust): PROV-O delegation audit for human + AI agents (sq-pfae.6) [OPUS-4.8]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -379,6 +379,24 @@ jobs:
             crate: sparq-trust
             features: store
             test: true
+          # [OPUS-4.8] sq-pfae.6: the delegation stratum's PROV-O AUDIT half. The whole
+          # `delegation_prov` module + the `tests/delegation_prov_audit.rs` integration suite
+          # are `#[cfg(feature = "delegation-prov")]` / `#![cfg(feature = "delegation-prov")]`
+          # behind `default = []`, so the default build/clippy/test (and ci.yml's
+          # `--workspace --all-targets` archive, which passes NO `--features`) compile them
+          # EMPTY and run ZERO of the 7 module unit tests + the 4 audit integration tests. This
+          # leg compiles the module, runs `clippy --all-targets -D warnings` with the feature
+          # ON (the real gate), and runs `cargo test` — which drives the REAL invoke() →
+          # effective_against_current() → audit_invocation() path (on-behalf-of lineage, the
+          # human/AI principal attestation, and the load-bearing SAFETY invariant: the audit
+          # never renders a grant broader than the gate conferred). `delegation-prov` is
+          # std-only over oxrdf (NO new dep, NO sparq-prov edge), so this is a fast leg.
+          # Verified: `cargo nextest list -p sparq-trust --features delegation-prov` lists the
+          # 7 delegation_prov unit tests + the 4 delegation_prov_audit integration tests.
+          - name: sparq-trust (delegation-prov)
+            crate: sparq-trust
+            features: delegation-prov
+            test: true
           # [OPUS-4.8] sq-h3uk: the ODRL->AUTH_GRAPH bridge (pulls the optional
           # sparq-policy ODRL evaluator) — keeps the opt-in ON path from rotting.
           - name: sparq-solid (odrl-bridge)

--- a/crates/sparq-trust/Cargo.toml
+++ b/crates/sparq-trust/Cargo.toml
@@ -49,6 +49,15 @@ store = []
 # is `const &str` data + a TTL drift test, strictly additive (no new dep, no new edge
 # onto the lean default build).
 secprop-vocab = []
+# [OPUS-4.8] sq-pfae.6 — the delegation stratum's AUDIT half: render an invocation-bound
+# delegation chain + effective capability as a minimal W3C PROV-O audit graph
+# (`prov:actedOnBehalfOf` lineage + the effective grant as `auth:*` RDF), with the
+# human/AI principal classification §4.2 names as an attested attribute on the delegate.
+# Pure-Rust over `oxrdf` (already a dep) + the `delegation` module — NO new dependency and,
+# deliberately, NO `sparq-prov` edge (that would drag `sparq-engine` onto this crate's dep
+# graph; the audit is a small fixed triple set emitted directly). Strictly additive: the
+# lean default build is byte-identical with it OFF.
+delegation-prov = []
 
 [dependencies]
 sparq-core = { path = "../sparq-core", default-features = false }

--- a/crates/sparq-trust/README.md
+++ b/crates/sparq-trust/README.md
@@ -24,8 +24,7 @@ the issuer-tagged fact so the existing N3 reasoner merges it with the `.acr` rul
 
 ## 🚀 Quickstart
 
-`sparq-trust` is **opt-in**: nothing in the default build depends on it; the gate is wired into
-`sparq-solid` behind its default-OFF `trust-graph` cargo feature.
+`sparq-trust` is **opt-in**: nothing in the default build depends on it; the gate is wired into `sparq-solid` behind its default-OFF `trust-graph` cargo feature.
 
 ```rust
 use sparq_trust::admit::{admit, PresentedCredential, Session};
@@ -47,29 +46,27 @@ let admitted = admit(cred, &rules, &session, &target);
 
 From `sparq-solid` (`--features trust-graph`), `PodStore::admit_trust_credential_with_rule` runs the
 gate and installs the derived `auth:*` grants into `<urn:sparq:auth>` on top of the unchanged WAC/ACP
-view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae.3`).
+view; `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae.3`).
 
 ## ✨ Features
 
 - **The minimal `trust:` ontology** (`vocab`) — the 10-term core (`TrustPolicy`, `TrustRule`,
   `trustsSourceFor`, `source`, `forShape`, `Source`, `issuerKey`, `scope`, `freshWithin`,
   `admitted`) + `issuerDid` + the `forPredicate → forShape` desugaring. Published as Turtle
-  ([`trust.ttl`](ontologies/trust/trust.ttl), [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md)); a sync
-  test pins it to the Rust constants. **All `trust:` IRIs are NON-STANDARD** — a WG would rehome them.
+  ([`trust.ttl`](ontologies/trust/trust.ttl), [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md)), pinned to the
+  Rust constants by a sync test. **All `trust:` IRIs are NON-STANDARD** — a WG would rehome them.
 - **Fail-closed policy parsing** (`policy`) — a trust policy not presented through the
   Control-gated channel admits nothing (a type-level `ControlGate`). Accepts the reified
   `trust:TrustRule` form AND the claim-level `trust:trustsSourceFor` relational form (per-(source,
   statement-type) trust — the compact replacement for ACP's type-only `acp:vc`, `sq-pfae.4`).
-- **The admission gate** (`admit`) — canonicalise (`sparq-canon` RDFC-1.0), verify the **checked**
-  issuer signature over the commitment (`sparq-zk`, never a self-asserted triple), enforce
-  statement-type scoping via a real SHACL shape (`sparq-shacl`), freshness, and the clear-WebID
-  holder binding. Default-deny, short-circuit.
+- **The admission gate** (`admit`) — canonicalise (`sparq-canon` RDFC-1.0), verify the **checked** issuer
+  signature over the commitment (`sparq-zk`, never a self-asserted triple), enforce statement-type scoping
+  via a real SHACL shape (`sparq-shacl`), freshness, and the clear-WebID holder binding. Default-deny.
 - **N3 merge** (`wire`) — feed admitted facts into `sparq-reason`; the `.acr` ABAC rule derives the grant (age>18 e2e).
-- **Storage / authoring model** (`store`, **opt-in `store` feature**, `sq-pfae.5`) — where trust
-  rules live: a server-wide default + per-`.acr` documents, where a per-`.acr` document **NARROWS,
-  never broadens** the server ceiling (`effective_rules`). Monotone versioning (stale rejected) +
-  revocation. The `AdmissionCacheKey` (evidence hash + policy version) composes with the sparq-solid
-  epoch cache: a policy edit/revoke bumps the version + invalidates the cached verdict. No new dep.
+- **Storage / authoring model** (`store`, **opt-in `store` feature**, `sq-pfae.5`) — a server-wide
+  default + per-`.acr` documents that **NARROW, never broaden** the server ceiling (`effective_rules`);
+  monotone versioning (stale rejected) + revocation; the `AdmissionCacheKey` (evidence hash + policy
+  version) composes with the sparq-solid epoch cache (edit/revoke invalidates the verdict). No new dep.
 - **Static / dynamic admission split** (`admit_static` + `derive_conditional_grants`, `sq-xc4y`) —
   decides the **session-independent** class (signature, type-scope, scope) once at materialise-time
   and defers the **per-request** class (holder + freshness) to an `auth:ConditionalGrant` re-checked
@@ -80,15 +77,19 @@ view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
   invoker == the chain's terminal delegate, key-proven per request** via a fresh-challenge PoP.
   Folding each hop's `delegate_key` into the signed preimage defeats the key-substitution
   stolen-chain replay; the forgery matrix runs end-to-end.
-- **DID issuer-key binding** (`did`, **opt-in `did` feature**, `sq-pfae.3`) — a rule may name its
-  issuer by `trust:issuerDid` instead of `trust:issuerKey` hex. `DidKeyResolver` decodes a `did:key`
-  offline; `DidWebResolver` reads a `did:web` document via a **pluggable** fetcher (no HTTP client on
-  the default build). **Narrows** the operator-asserted-key forgery vector D′ (not an absolute anchor).
+- **Delegation PROV-O audit** (`delegation_prov`, **opt-in `delegation-prov`**, `sq-pfae.6`) — render an
+  invocation-bound chain as a minimal W3C PROV-O graph: `prov:actedOnBehalfOf` per hop, the human/AI
+  principal as an attested attribute (`trust:HumanPrincipal`/`AiAgent`, §4.2), the effective grant as
+  `auth:*` RDF. Pure `oxrdf`, NO `sparq-prov` edge. A record, never authority: emitted *after* the gate,
+  it only describes authority already conferred (never broader).
+- **DID issuer-key binding** (`did`, **opt-in `did` feature**, `sq-pfae.3`) — a rule may name its issuer
+  by `trust:issuerDid` instead of `trust:issuerKey` hex. `DidKeyResolver` decodes a `did:key` offline;
+  `DidWebResolver` reads a `did:web` document via a **pluggable** fetcher (no HTTP client on the default
+  build). **Narrows** the operator-asserted-key forgery vector D′ (not an absolute anchor).
 - **Security-properties vocabulary** (`secprop`, **opt-in `secprop-vocab`**, `sq-5oru9`) — the sparq
   **`sec-prop:` extension** (constants + [`secprop-ext.ttl`](ontologies/zkp-sparql/secprop-ext.ttl)): the
-  orthogonal proof-system dimensions + the **assurance / audit-status axis** the vendored `sec-prop:` lacks,
-  same namespace (extend, not fork). Records a claim + its epistemic basis — NOT a proof; default assurance
-  `Claimed` (#1001), no sparq ZK method `Proven` while the audit (`sq-qhy4`) is open.
+  orthogonal proof-system dimensions + the **assurance / audit-status axis** the vendored `sec-prop:` lacks
+  (extend, not fork). Records a claim + basis, NOT a proof; default `Claimed`, no `Proven` while `sq-qhy4` open.
 
 ## Honest scope — what this does and does NOT do
 
@@ -101,19 +102,18 @@ view. `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
   `trust:issuerDid` instead — **narrows** D′ but no absolute anchor (`did:key` self-cert; `did:web` host/TLS).
 - **Delegation invocation is the clear-WebID, non-anonymous path too** (`sq-l5og`): the gate
   authenticates the invoker AS the terminal delegate's WebID in the clear. The `delegate_key` binding
-  defeats the key-substitution stolen-chain replay but **not** full non-replayability; deep-chain
-  *incremental* revocation stays open (rustdoc has the full reasoning).
-- **Open problems respected as documented limitations:** `sq-tu4e` (no in-reasoner NAF; `revoked`
-  input-only) + `sq-wvne` (ZK privacy) are **out of PoC scope**; `sq-xc4y` RESOLVED (static/dynamic split); `sq-l5og` **specified + enforced + tested**.
+  defeats key-substitution stolen-chain replay but **not** full non-replayability; deep-chain
+  *incremental* revocation stays open. The `delegation-prov` PROV-O audit adds NO security property —
+  it records *who acted on whose behalf* (a record, not an authority; rustdoc has the full reasoning).
+- **Open problems respected as documented limitations:** `sq-tu4e` (no in-reasoner NAF; `revoked` input-only) + `sq-wvne` (ZK privacy) are **out of PoC scope**; `sq-xc4y` RESOLVED; `sq-l5og` **specified + enforced + tested**.
 - **Strict additivity (G6):** with `sparq-solid`'s `trust-graph` feature OFF the crate is not compiled — `sparq-solid` behaves exactly as WAC/ACP do today (byte-identical).
 
 ## 📚 Learn more
 
-- The machine-readable [`trust.ttl`](ontologies/trust/trust.ttl) +
-  [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md) (`sq-pfae.2`) + the
-  [`secprop-ext.ttl`](ontologies/zkp-sparql/secprop-ext.ttl) sec-prop: extension; design records
-  `research/solid-trust-graph-authz-design.md` (§3.2 storage; §6.0 PoC) + `…/security-properties-ontology-design.md`
-  (secprop §4.2) — [#940](https://github.com/jeswr/sparq/issues/940). `cargo doc -p sparq-trust --all-features`.
+- Machine-readable [`trust.ttl`](ontologies/trust/trust.ttl) + [`SEMANTICS.md`](ontologies/trust/SEMANTICS.md)
+  (`sq-pfae.2`) + [`secprop-ext.ttl`](ontologies/zkp-sparql/secprop-ext.ttl); design record
+  `research/solid-trust-graph-authz-design.md` (§3.2 storage; §4 delegation; §6.0 PoC) —
+  [#940](https://github.com/jeswr/sparq/issues/940). `cargo doc -p sparq-trust --all-features`.
 
 ## License
 

--- a/crates/sparq-trust/src/delegation_prov.rs
+++ b/crates/sparq-trust/src/delegation_prov.rs
@@ -1,0 +1,616 @@
+//! # `delegation_prov.rs` — PROV-O delegation audit for human + AI agents (`sq-pfae.6`)
+//!
+//! The **delegation stratum's audit half**: render an invocation-bound delegation chain
+//! (the [`crate::delegation`] gate) as a **minimal W3C PROV-O audit graph**, modelling the
+//! human-and-AI-agent *on-behalf-of* relationship the design names in §4.2 — *"an AI agent
+//! is a distinct principal (its own DID/key) holding an attenuated child of its human
+//! principal's authority"* — and rendering the surviving effective capability as `auth:*`
+//! RDF that reasons with the SAME `.acl`/`.acr` rules the rest of the estate uses (the §4.3
+//! delegation value-add). Behind the **default-OFF `delegation-prov` feature**.
+//!
+//! ## Why this module exists (the gap it closes)
+//!
+//! The design record §4.3 / §7.4(K) flags the audit + on-behalf-of story as **proposed,
+//! zero substrate**: `sparq-prov` records only a **single-agent** `prov:wasAssociatedWith`
+//! per reasoner-derivation activity and has **no `prov:actedOnBehalfOf` / delegation-chain
+//! modelling**, and "Human vs AI agent" is named as *an attested attribute on the delegate*
+//! but never rendered. The [`crate::delegation`] gate (`sq-l5og`, merged) verifies the
+//! chain and binds the invoker per request; this module records **who acted on whose
+//! behalf**, as a standard PROV-O graph an auditor can replay.
+//!
+//! ## What the audit graph says (PROV-O, minimal)
+//!
+//! For an [`crate::delegation::EffectiveCapability`] that survived [`crate::delegation::invoke`]
+//! over a chain `root → … → terminal`:
+//!
+//! - each principal `P` is a `prov:Agent`; the human root and any human delegate are also
+//!   `trust:HumanPrincipal`, an AI delegate also `trust:AiAgent` (the attested attribute);
+//! - for every hop `delegator → delegate`, `delegate` `prov:actedOnBehalfOf` `delegator`
+//!   (the delegation chain rendered as PROV-O **on-behalf-of** edges — this is exactly the
+//!   modelling `sparq-prov` lacks);
+//! - the invocation is a `prov:Activity` the terminal delegate `prov:wasAssociatedWith`,
+//!   the **whole chain** is recorded as a sequence of `actedOnBehalfOf` edges the activity
+//!   `prov:used`, and (when supplied) the activity is time-stamped `prov:atTime`;
+//! - the **effective grant** is a `prov:Entity` `prov:wasGeneratedBy` the invocation and
+//!   `prov:wasAttributedTo` the terminal delegate, carrying the `auth:*` action triples the
+//!   capability confers over its target — the grant rendered as RDF (the §4.3 value-add).
+//!
+//! ## Honest boundaries (this module adds NO security property)
+//!
+//! - **An audit record, never an authority source.** The graph is produced *after* a
+//!   successful [`crate::delegation::invoke`] — it can only ever describe authority that
+//!   already passed the gate. It is the OPTIONAL §4.1 audit record the obj-cap discipline
+//!   demotes: `invoke()` still gates on the carried chain + the live PoP, never on graph
+//!   presence. Feeding this graph back as input grants **nothing** (there is no admission
+//!   rule that trusts a `prov:actedOnBehalfOf` triple — the §2.4 reserved-predicate guard
+//!   and §3.3 "verified signature only" discipline are unchanged).
+//! - **`trust:HumanPrincipal` / `trust:AiAgent` are NON-STANDARD**, invented for this
+//!   proposal (the same posture as the rest of the `trust:` vocab); a WG would rehome them.
+//!   They are an **attested attribute** on the delegate, not an authority — the AI agent's
+//!   authority is the attenuated capability the signed chain carries.
+//! - **No `sparq-prov` dependency.** The audit is a small fixed triple set, emitted directly
+//!   via `oxrdf` (a handful of `prov:` IRI constants), NOT by pulling `sparq-prov` — which
+//!   would drag `sparq-engine` onto this crate's dep graph and break lean-core. The PROV-O
+//!   IRIs are the standard ones, so the graph round-trips through any PROV-O consumer.
+//! - **No privacy / unlinkability.** Like the rest of this crate, the principals are named in
+//!   the **clear**; the audit graph is the opposite of anonymous. The ZK estate is
+//!   research-grade and externally UNAUDITED (`sq-qhy4`).
+//!
+//! [OPUS-4.8] sq-pfae.6: PROV-O delegation audit for human + AI agents (issue #940, #1190,
+//! epic sq-pfae P5). Written while Fable unavailable — flag for re-review when Fable returns.
+//! 🤖 SPARQ agent — trust-graph delegation PROV-O audit.
+
+use crate::delegation::{Capability, DelegationChain, EffectiveCapability};
+use oxrdf::vocab::{rdf, xsd};
+use oxrdf::{Literal, NamedNode, NamedOrBlankNode, Term, Triple};
+
+/// The W3C PROV-O namespace base.
+const PROV_NS: &str = "http://www.w3.org/ns/prov#";
+
+/// `prov:` term IRI (`http://www.w3.org/ns/prov#{local}`). Every `local` here is a
+/// syntactically valid IRI suffix, so `new_unchecked` is safe.
+fn prov(local: &str) -> NamedNode {
+    NamedNode::new_unchecked(format!("{}{}", PROV_NS, local))
+}
+
+/// `trust:` term IRI for a vocab constant (already a full IRI — wrap it).
+fn trust_node(full_iri: &str) -> NamedNode {
+    NamedNode::new_unchecked(full_iri.to_owned())
+}
+
+/// Whether a delegation principal is a human or an AI agent — an **attested attribute**
+/// on the delegate (design §4.2: *"Human vs AI is just an attested attribute / caveat on
+/// the delegate"*). It confers NO authority; the AI agent's authority is the attenuated
+/// capability the signed chain carries. The audit records it as a `trust:HumanPrincipal`
+/// / `trust:AiAgent` type so an auditor can tell a human acting from an AI agent acting on
+/// a human's behalf.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PrincipalKind {
+    /// A human principal (the human root, or any human delegate).
+    Human,
+    /// An AI agent: a distinct principal (its own DID/key) holding an attenuated child of
+    /// its human principal's authority (§4.2).
+    AiAgent,
+}
+
+impl PrincipalKind {
+    /// The `trust:` class IRI this kind classifies a principal as.
+    fn type_iri(self) -> NamedNode {
+        match self {
+            PrincipalKind::Human => trust_node(crate::vocab::HUMAN_PRINCIPAL),
+            PrincipalKind::AiAgent => trust_node(crate::vocab::AI_AGENT),
+        }
+    }
+}
+
+/// How the principals of a chain are classified (human vs AI agent) for the audit.
+///
+/// The classification is an **attested attribute** supplied by the caller (it is NOT
+/// derivable from the chain's cryptography — a key does not say whether its holder is a
+/// human or an AI agent). A principal NOT named here is recorded as a plain `prov:Agent`
+/// with no human/AI type (honest: an unclassified principal is not silently assumed human).
+#[derive(Debug, Clone, Default)]
+pub struct PrincipalClassification {
+    /// `(principal-WebID/DID, kind)` pairs. The canonical use is the §4.2 shape: the human
+    /// root is [`PrincipalKind::Human`] and the terminal AI agent is
+    /// [`PrincipalKind::AiAgent`], but any mix is allowed (a human may delegate to a human).
+    classes: Vec<(NamedNode, PrincipalKind)>,
+}
+
+impl PrincipalClassification {
+    /// An empty classification (every principal recorded as a plain `prov:Agent`).
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Classify `principal` as `kind`. The last classification for a principal wins.
+    pub fn with(mut self, principal: NamedNode, kind: PrincipalKind) -> Self {
+        self.classes.push((principal, kind));
+        self
+    }
+
+    /// The classification recorded for `principal`, if any (`None` ⇒ plain `prov:Agent`).
+    fn kind_of(&self, principal: &NamedNode) -> Option<PrincipalKind> {
+        self.classes
+            .iter()
+            .rev()
+            .find(|(p, _)| p.as_str() == principal.as_str())
+            .map(|(_, k)| *k)
+    }
+}
+
+/// A completed PROV-O delegation audit: the audit RDF graph for one invocation-bound
+/// chain + effective capability. Produced by [`audit_invocation`]; obtain the triples
+/// with [`DelegationAudit::graph`].
+#[derive(Debug, Clone)]
+pub struct DelegationAudit {
+    triples: Vec<Triple>,
+    activity: NamedNode,
+    grant_entity: NamedNode,
+}
+
+impl DelegationAudit {
+    /// The PROV-O audit graph as RDF triples (standard `prov:` IRIs — round-trips through
+    /// any PROV-O consumer). The graph is self-contained: every node IRI is absolute.
+    pub fn graph(&self) -> &[Triple] {
+        &self.triples
+    }
+
+    /// The minted `prov:Activity` IRI naming the invocation.
+    pub fn activity(&self) -> &NamedNode {
+        &self.activity
+    }
+
+    /// The minted `prov:Entity` IRI naming the effective grant.
+    pub fn grant_entity(&self) -> &NamedNode {
+        &self.grant_entity
+    }
+}
+
+/// IRI prefix the audit mints its `prov:Activity` / `prov:Entity` nodes under when not
+/// supplied — stable + self-describing-shaped, distinct from the `urn:sparq:auth:`
+/// allow-list and the `urn:sparq:prov:` derivation namespace.
+pub const SPARQ_DELEGATION_PROV_NS: &str = "urn:sparq:delegation-prov:";
+
+/// Optional knobs for the audit (IRIs to use, the wall-clock instant). Defaults mint fresh
+/// `urn:sparq:delegation-prov:` nodes and omit the timestamp.
+#[derive(Debug, Clone, Default)]
+pub struct AuditConfig {
+    /// IRI naming the `prov:Activity` (the invocation). `None` ⇒ mint a fresh one keyed on
+    /// the terminal delegate (so two invocations by the same delegate share an activity IRI
+    /// — deterministic, replayable). Supply one to integrate with an external audit store.
+    pub activity: Option<NamedNode>,
+    /// IRI naming the `prov:Entity` (the effective grant). `None` ⇒ mint a fresh one keyed
+    /// on the delegate + target.
+    pub entity: Option<NamedNode>,
+    /// Wall-clock instant of the invocation as a Unix timestamp (seconds). `Some` ⇒ recorded
+    /// as `prov:atTime "…"^^xsd:dateTime` on the activity; `None` ⇒ omitted (honest: we do
+    /// not fabricate a timestamp).
+    pub at_time_unix_secs: Option<i64>,
+    /// How the chain's principals are classified human/AI (§4.2). Default: all unclassified
+    /// (plain `prov:Agent`).
+    pub principals: PrincipalClassification,
+}
+
+/// Render a PROV-O delegation audit for an invocation-bound chain + effective capability.
+///
+/// `chain` is the carried delegation chain that passed [`crate::delegation::invoke`];
+/// `effective` is the surviving capability (the terminal capability, optionally already
+/// intersected with the current delegator grant via
+/// [`crate::delegation::effective_against_current`]). The audit records the on-behalf-of
+/// lineage of the **whole** chain plus the effective grant the terminal delegate exercised.
+///
+/// This is an **audit record only** — it adds no security property and is never an
+/// authority source (see the module docs). It is the caller's responsibility to call this
+/// only on a chain that actually passed the gate; the function does not re-verify the chain
+/// (that is [`crate::delegation::invoke`]'s job, and re-doing it here would invite the
+/// caller to treat the audit as the gate). It NEVER panics.
+pub fn audit_invocation(
+    chain: &DelegationChain,
+    effective: &EffectiveCapability,
+    config: &AuditConfig,
+) -> DelegationAudit {
+    let mut out: Vec<Triple> = Vec::new();
+
+    let terminal_delegate = effective.delegate.clone();
+    let target = effective.capability.target.clone();
+
+    // Mint (or take) the activity + grant-entity IRIs deterministically.
+    let activity = config.activity.clone().unwrap_or_else(|| {
+        NamedNode::new_unchecked(format!(
+            "{}invocation:{}",
+            SPARQ_DELEGATION_PROV_NS,
+            slug(terminal_delegate.as_str())
+        ))
+    });
+    let grant_entity = config.entity.clone().unwrap_or_else(|| {
+        NamedNode::new_unchecked(format!(
+            "{}grant:{}:{}",
+            SPARQ_DELEGATION_PROV_NS,
+            slug(terminal_delegate.as_str()),
+            slug(target.as_str())
+        ))
+    });
+
+    // 1. Every principal in the chain is a prov:Agent, optionally typed human/AI.
+    //    Collect principals in chain order (delegators then the terminal delegate), de-duped.
+    let mut principals: Vec<NamedNode> = Vec::new();
+    for hop in &chain.hops {
+        for p in [&hop.delegator, &hop.delegate] {
+            if !principals.iter().any(|q| q.as_str() == p.as_str()) {
+                principals.push(p.clone());
+            }
+        }
+    }
+    for p in &principals {
+        out.push(Triple {
+            subject: NamedOrBlankNode::NamedNode(p.clone()),
+            predicate: rdf::TYPE.into_owned(),
+            object: Term::NamedNode(prov("Agent")),
+        });
+        if let Some(kind) = config.principals.kind_of(p) {
+            out.push(Triple {
+                subject: NamedOrBlankNode::NamedNode(p.clone()),
+                predicate: rdf::TYPE.into_owned(),
+                object: Term::NamedNode(kind.type_iri()),
+            });
+        }
+    }
+
+    // 2. The on-behalf-of lineage: for each hop, delegate prov:actedOnBehalfOf delegator.
+    //    This is the modelling sparq-prov lacks — the delegation chain as PROV-O.
+    for hop in &chain.hops {
+        out.push(Triple {
+            subject: NamedOrBlankNode::NamedNode(hop.delegate.clone()),
+            predicate: prov("actedOnBehalfOf"),
+            object: Term::NamedNode(hop.delegator.clone()),
+        });
+    }
+
+    // 3. The invocation activity: typed, associated with the terminal delegate, using the
+    //    chain principals, optionally timestamped.
+    out.push(Triple {
+        subject: NamedOrBlankNode::NamedNode(activity.clone()),
+        predicate: rdf::TYPE.into_owned(),
+        object: Term::NamedNode(prov("Activity")),
+    });
+    out.push(Triple {
+        subject: NamedOrBlankNode::NamedNode(activity.clone()),
+        predicate: prov("wasAssociatedWith"),
+        object: Term::NamedNode(terminal_delegate.clone()),
+    });
+    for p in &principals {
+        out.push(Triple {
+            subject: NamedOrBlankNode::NamedNode(activity.clone()),
+            predicate: prov("used"),
+            object: Term::NamedNode(p.clone()),
+        });
+    }
+    if let Some(secs) = config.at_time_unix_secs {
+        out.push(Triple {
+            subject: NamedOrBlankNode::NamedNode(activity.clone()),
+            predicate: prov("atTime"),
+            object: Term::Literal(Literal::new_typed_literal(
+                unix_to_xsd_datetime(secs),
+                xsd::DATE_TIME.into_owned(),
+            )),
+        });
+    }
+
+    // 4. The effective grant entity: generated by + attributed to the terminal delegate,
+    //    carrying the auth:* action triples (the grant rendered as RDF — §4.3 value-add).
+    out.push(Triple {
+        subject: NamedOrBlankNode::NamedNode(grant_entity.clone()),
+        predicate: rdf::TYPE.into_owned(),
+        object: Term::NamedNode(prov("Entity")),
+    });
+    out.push(Triple {
+        subject: NamedOrBlankNode::NamedNode(grant_entity.clone()),
+        predicate: prov("wasGeneratedBy"),
+        object: Term::NamedNode(activity.clone()),
+    });
+    out.push(Triple {
+        subject: NamedOrBlankNode::NamedNode(grant_entity.clone()),
+        predicate: prov("wasAttributedTo"),
+        object: Term::NamedNode(terminal_delegate.clone()),
+    });
+    for grant in render_capability_grants(&effective.capability, &terminal_delegate) {
+        out.push(grant);
+    }
+
+    DelegationAudit {
+        triples: out,
+        activity,
+        grant_entity,
+    }
+}
+
+/// The `auth:*` view namespace (the SAME predicates the shipped WAC/ACP rules emit and
+/// `sparq_solid::AuthIndex` reads — see [`crate::wire::AUTH_NS`]). Re-declared here so the
+/// audit module does not depend on the N3-merge module's wiring.
+const AUTH_NS: &str = "https://sparq.dev/ns/auth#";
+
+/// Render the effective [`Capability`] as `auth:*` grant triples over its target, subject =
+/// the terminal delegate (the principal the grant is *for*). This is the §4.3 value-add: the
+/// surviving delegated authority expressed as RDF that reasons with the SAME `.acl`/`.acr`
+/// rules the rest of the estate uses — `<delegate> auth:read <target>`, etc.
+///
+/// Only actions in the `auth:` namespace are rendered (the gate's capability lattice is the
+/// `auth:read|write|append|control` action set the WAC/ACP view uses); a non-`auth:` action
+/// is recorded too (it is still a granted action), so the audit is faithful to the chain.
+fn render_capability_grants(cap: &Capability, delegate: &NamedNode) -> Vec<Triple> {
+    cap.actions
+        .iter()
+        .map(|action| Triple {
+            subject: NamedOrBlankNode::NamedNode(delegate.clone()),
+            predicate: action.clone(),
+            object: Term::NamedNode(cap.target.clone()),
+        })
+        .collect()
+}
+
+/// Whether `action` is an `auth:` view predicate (exposed so a consumer can filter the
+/// audit's grant triples to the WAC/ACP action lattice if it wants only those).
+pub fn is_auth_action(action: &NamedNode) -> bool {
+    action.as_str().starts_with(AUTH_NS)
+}
+
+/// Slugify an IRI into a node-name-safe suffix (non-alphanumeric → `_`), so a minted
+/// `prov:` IRI is a valid, stable, collision-resistant-enough node name for the audit.
+fn slug(iri: &str) -> String {
+    iri.chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '_' })
+        .collect()
+}
+
+/// Render a Unix timestamp (seconds, UTC) as an `xsd:dateTime` lexical (`YYYY-MM-DDThh:mm:ssZ`).
+/// A self-contained civil-from-days conversion (Howard Hinnant's algorithm) — no chrono dep,
+/// matching the lean-core posture. Negative (pre-epoch) instants are handled.
+fn unix_to_xsd_datetime(secs: i64) -> String {
+    // days since 1970-01-01 and seconds-of-day, floor-divided so a negative instant lands
+    // in the previous civil day rather than rounding toward zero.
+    let days = secs.div_euclid(86_400);
+    let sod = secs.rem_euclid(86_400);
+    let (h, m, s) = (sod / 3600, (sod % 3600) / 60, sod % 60);
+
+    // civil_from_days (Hinnant): days is offset to a 0000-03-01 era origin.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = z - era * 146_097; // [0, 146096]
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365; // [0, 399]
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+    let mp = (5 * doy + 2) / 153; // [0, 11]
+    let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+    let month = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+    let year = if month <= 2 { y + 1 } else { y };
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}Z",
+        year, month, d, h, m, s
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::delegation::Capability;
+
+    fn iri(s: &str) -> NamedNode {
+        NamedNode::new(s).unwrap()
+    }
+    fn read() -> NamedNode {
+        iri("https://sparq.dev/ns/auth#read")
+    }
+    fn write() -> NamedNode {
+        iri("https://sparq.dev/ns/auth#write")
+    }
+
+    /// A human → AI-agent chain over /docs/ (human root grants read+write, the AI agent
+    /// child attenuates to read over /docs/x). Mirrors the §4.2 on-behalf-of shape.
+    fn human_to_ai_chain() -> (DelegationChain, EffectiveCapability) {
+        use crate::delegation::DelegationHop;
+        use sparq_zk::sig::SecretKey;
+        let human = iri("https://alice.ex/card#me");
+        let ai = iri("https://alice-bot.ex/card#me");
+        let (hk, hpk) = {
+            let sk = SecretKey::from_seed(1);
+            let pk = sk.public_key();
+            (sk, pk)
+        };
+        let (ak, apk) = {
+            let sk = SecretKey::from_seed(2);
+            let pk = sk.public_key();
+            (sk, pk)
+        };
+        let _ = (&hk, &ak); // keys not re-verified here — this is the audit, not the gate
+        let hop = DelegationHop {
+            delegator: human.clone(),
+            delegator_key: hpk,
+            delegate: ai.clone(),
+            delegate_key: apk,
+            capability: Capability {
+                actions: vec![read()],
+                target: iri("https://pod.ex/docs/x"),
+            },
+            expires_at_unix_secs: 2_000_000_000,
+            signature_hex: String::new(),
+        };
+        let chain = DelegationChain { hops: vec![hop] };
+        let effective = EffectiveCapability {
+            capability: Capability {
+                actions: vec![read()],
+                target: iri("https://pod.ex/docs/x"),
+            },
+            delegate: ai,
+        };
+        (chain, effective)
+    }
+
+    #[test]
+    fn audit_records_acted_on_behalf_of_and_principal_kinds() {
+        let (chain, eff) = human_to_ai_chain();
+        let human = iri("https://alice.ex/card#me");
+        let ai = iri("https://alice-bot.ex/card#me");
+        let cfg = AuditConfig {
+            principals: PrincipalClassification::new()
+                .with(human.clone(), PrincipalKind::Human)
+                .with(ai.clone(), PrincipalKind::AiAgent),
+            ..Default::default()
+        };
+        let audit = audit_invocation(&chain, &eff, &cfg);
+        let g = audit.graph();
+
+        // The on-behalf-of edge: the AI agent acted on behalf of the human.
+        let acted = Triple {
+            subject: NamedOrBlankNode::NamedNode(ai.clone()),
+            predicate: prov("actedOnBehalfOf"),
+            object: Term::NamedNode(human.clone()),
+        };
+        assert!(
+            g.contains(&acted),
+            "AI agent prov:actedOnBehalfOf the human delegator"
+        );
+
+        // The principal-kind attestations.
+        let ai_is_agent = Triple {
+            subject: NamedOrBlankNode::NamedNode(ai.clone()),
+            predicate: rdf::TYPE.into_owned(),
+            object: Term::NamedNode(trust_node(crate::vocab::AI_AGENT)),
+        };
+        let human_is_human = Triple {
+            subject: NamedOrBlankNode::NamedNode(human.clone()),
+            predicate: rdf::TYPE.into_owned(),
+            object: Term::NamedNode(trust_node(crate::vocab::HUMAN_PRINCIPAL)),
+        };
+        assert!(g.contains(&ai_is_agent), "AI delegate typed trust:AiAgent");
+        assert!(
+            g.contains(&human_is_human),
+            "human root typed trust:HumanPrincipal"
+        );
+
+        // Both principals are prov:Agent.
+        for p in [&human, &ai] {
+            let is_agent = Triple {
+                subject: NamedOrBlankNode::NamedNode(p.clone()),
+                predicate: rdf::TYPE.into_owned(),
+                object: Term::NamedNode(prov("Agent")),
+            };
+            assert!(g.contains(&is_agent), "principal is a prov:Agent");
+        }
+    }
+
+    #[test]
+    fn audit_renders_the_effective_grant_as_auth_rdf() {
+        let (chain, eff) = human_to_ai_chain();
+        let ai = iri("https://alice-bot.ex/card#me");
+        let audit = audit_invocation(&chain, &eff, &AuditConfig::default());
+        let g = audit.graph();
+
+        // The grant is rendered as <ai-agent> auth:read <target>.
+        let grant = Triple {
+            subject: NamedOrBlankNode::NamedNode(ai.clone()),
+            predicate: read(),
+            object: Term::NamedNode(iri("https://pod.ex/docs/x")),
+        };
+        assert!(
+            g.contains(&grant),
+            "effective grant rendered as auth:* RDF for the delegate"
+        );
+
+        // The grant entity is generated by + attributed to the terminal delegate.
+        let gen = Triple {
+            subject: NamedOrBlankNode::NamedNode(audit.grant_entity().clone()),
+            predicate: prov("wasGeneratedBy"),
+            object: Term::NamedNode(audit.activity().clone()),
+        };
+        let attr = Triple {
+            subject: NamedOrBlankNode::NamedNode(audit.grant_entity().clone()),
+            predicate: prov("wasAttributedTo"),
+            object: Term::NamedNode(ai),
+        };
+        assert!(g.contains(&gen), "grant wasGeneratedBy the invocation");
+        assert!(g.contains(&attr), "grant wasAttributedTo the delegate");
+    }
+
+    #[test]
+    fn audit_records_only_an_auth_action_that_the_capability_grants() {
+        // The capability grants read only — write must NOT appear in the rendered grant.
+        let (chain, eff) = human_to_ai_chain();
+        let ai = iri("https://alice-bot.ex/card#me");
+        let audit = audit_invocation(&chain, &eff, &AuditConfig::default());
+        let g = audit.graph();
+        let write_grant = Triple {
+            subject: NamedOrBlankNode::NamedNode(ai),
+            predicate: write(),
+            object: Term::NamedNode(iri("https://pod.ex/docs/x")),
+        };
+        assert!(
+            !g.contains(&write_grant),
+            "an action the capability does NOT grant is never rendered"
+        );
+    }
+
+    #[test]
+    fn timestamp_recorded_only_when_supplied() {
+        let (chain, eff) = human_to_ai_chain();
+        // Without a timestamp: no prov:atTime.
+        let audit = audit_invocation(&chain, &eff, &AuditConfig::default());
+        assert!(
+            !audit
+                .graph()
+                .iter()
+                .any(|t| t.predicate.as_str() == format!("{}atTime", PROV_NS)),
+            "no fabricated timestamp when none is supplied"
+        );
+        // With a timestamp: a prov:atTime xsd:dateTime literal.
+        let cfg = AuditConfig {
+            at_time_unix_secs: Some(1_700_000_000),
+            ..Default::default()
+        };
+        let audit = audit_invocation(&chain, &eff, &cfg);
+        let at = audit
+            .graph()
+            .iter()
+            .find(|t| t.predicate.as_str() == format!("{}atTime", PROV_NS))
+            .expect("prov:atTime present when supplied");
+        match &at.object {
+            Term::Literal(l) => {
+                assert_eq!(l.datatype().as_str(), xsd::DATE_TIME.as_str());
+                assert_eq!(l.value(), "2023-11-14T22:13:20Z", "correct xsd:dateTime");
+            }
+            _ => panic!("prov:atTime must be a typed literal"),
+        }
+    }
+
+    #[test]
+    fn unclassified_principal_is_plain_agent_not_assumed_human() {
+        // No classification supplied → no human/AI type, only prov:Agent (honest).
+        let (chain, eff) = human_to_ai_chain();
+        let ai = iri("https://alice-bot.ex/card#me");
+        let audit = audit_invocation(&chain, &eff, &AuditConfig::default());
+        let g = audit.graph();
+        let typed_human = Triple {
+            subject: NamedOrBlankNode::NamedNode(ai),
+            predicate: rdf::TYPE.into_owned(),
+            object: Term::NamedNode(trust_node(crate::vocab::HUMAN_PRINCIPAL)),
+        };
+        assert!(
+            !g.contains(&typed_human),
+            "an unclassified principal is NOT silently assumed human"
+        );
+    }
+
+    #[test]
+    fn datetime_conversion_handles_epoch_and_pre_epoch() {
+        assert_eq!(unix_to_xsd_datetime(0), "1970-01-01T00:00:00Z");
+        assert_eq!(unix_to_xsd_datetime(-1), "1969-12-31T23:59:59Z");
+        assert_eq!(unix_to_xsd_datetime(1_700_000_000), "2023-11-14T22:13:20Z");
+    }
+
+    #[test]
+    fn is_auth_action_classifies_the_lattice() {
+        assert!(is_auth_action(&read()));
+        assert!(!is_auth_action(&iri("https://example.org/other#act")));
+    }
+}

--- a/crates/sparq-trust/src/lib.rs
+++ b/crates/sparq-trust/src/lib.rs
@@ -122,6 +122,15 @@
 
 pub mod admit;
 pub mod delegation;
+/// PROV-O delegation audit for human + AI agents (the P5 audit half, `sq-pfae.6`): render
+/// an invocation-bound delegation chain + effective capability as a minimal W3C PROV-O
+/// graph (`prov:actedOnBehalfOf` lineage + the effective grant as `auth:*` RDF), with the
+/// human/AI principal classification the design §4.2 names as an attested attribute on the
+/// delegate. Behind the default-OFF `delegation-prov` feature: nothing in the lean default
+/// build depends on it (no new dependency — pure `oxrdf`, no `sparq-prov` edge).
+#[cfg(feature = "delegation-prov")]
+#[cfg_attr(docsrs, doc(cfg(feature = "delegation-prov")))]
+pub mod delegation_prov;
 #[cfg(feature = "did")]
 #[cfg_attr(docsrs, doc(cfg(feature = "did")))]
 pub mod did;
@@ -145,6 +154,11 @@ pub use admit::{
 pub use delegation::{
     effective_against_current, hop_message, invoke, Capability, DelegationChain, DelegationHop,
     EffectiveCapability, Invocation, InvocationDenied,
+};
+#[cfg(feature = "delegation-prov")]
+pub use delegation_prov::{
+    audit_invocation, is_auth_action, AuditConfig, DelegationAudit, PrincipalClassification,
+    PrincipalKind,
 };
 #[cfg(feature = "did")]
 pub use did::{

--- a/crates/sparq-trust/src/vocab.rs
+++ b/crates/sparq-trust/src/vocab.rs
@@ -69,6 +69,25 @@ pub const FRESH_WITHIN: &str = "https://sparq.dev/ns/trust#freshWithin";
 /// `solidx:` internal vocab; the stratum-boundary marker).
 pub const ADMITTED: &str = "https://sparq.dev/ns/trust#admitted";
 
+// --- delegation principal kinds (§4.2 on-behalf-of; sq-pfae.6) -------------
+//
+// "Human vs AI is just an attested attribute / caveat on the delegate" (design §4.2).
+// These classify a delegation principal in the PROV-O audit the `delegation_prov`
+// module emits (opt-in `delegation-prov` feature). They are an ATTESTED ATTRIBUTE on
+// the delegate — they confer NO authority of their own (authority is the attenuated
+// capability the signed chain carries); they only let a policy / audit reader tell a
+// human principal from an AI agent acting on a human's behalf.
+
+/// `trust:HumanPrincipal` — a delegation principal that is a human (the human root /
+/// any human delegate). An attested attribute on the principal, not an authority.
+pub const HUMAN_PRINCIPAL: &str = "https://sparq.dev/ns/trust#HumanPrincipal";
+/// `trust:AiAgent` — a delegation principal that is an AI agent: a **distinct
+/// principal** (its own DID/key) holding an **attenuated child** of its human
+/// principal's authority (§4.2). An attested attribute on the delegate, not an
+/// authority — the AI agent's authority is the attenuated capability the signed chain
+/// carries, never this type.
+pub const AI_AGENT: &str = "https://sparq.dev/ns/trust#AiAgent";
+
 // --- the one convenience (sugar, NOT a primitive — §2.3.3) -----------------
 
 /// `trust:forPredicate` — **SUGAR** for a single-predicate `trust:forShape`. It is

--- a/crates/sparq-trust/tests/delegation_prov_audit.rs
+++ b/crates/sparq-trust/tests/delegation_prov_audit.rs
@@ -1,0 +1,281 @@
+//! End-to-end PROV-O delegation-audit tests (design §4.2/§4.3, `sq-pfae.6`).
+//!
+//! These exercise the **REAL** path — a genuinely signed human → AI-agent delegation
+//! chain, the shipped [`invoke`] gate, the [`effective_against_current`] intersection, and
+//! then [`audit_invocation`] over the surviving capability — so the audit is proved over an
+//! authority that ACTUALLY passed the gate, not a hand-built [`EffectiveCapability`].
+//!
+//! The load-bearing safety invariant: the audit graph can never record a grant BROADER than
+//! the capability the gate conferred. When the current delegator grant has been narrowed
+//! (item N), `effective_against_current` intersects it down, and the audit renders only the
+//! intersected `auth:*` actions — never the (now-stale) chain-time capability.
+//!
+//! [OPUS-4.8] sq-pfae.6: PROV-O delegation audit for human + AI agents (issue #940, #1190,
+//! epic sq-pfae P5). 🤖 SPARQ agent — trust-graph delegation PROV-O audit.
+//!
+//! This whole suite is gated on the `delegation-prov` feature (the module is feature-gated),
+//! so a feature-matrix leg must enable it — see `.github/workflows/feature-matrix.yml`.
+#![cfg(feature = "delegation-prov")]
+
+use oxrdf::{NamedNode, NamedOrBlankNode, Term, Triple};
+use sparq_trust::delegation::{
+    effective_against_current, hop_message, invoke, Capability, DelegationChain, DelegationHop,
+    Invocation,
+};
+use sparq_trust::delegation_prov::{
+    audit_invocation, AuditConfig, PrincipalClassification, PrincipalKind,
+};
+use sparq_zk::field::{field_from_hash_bytes, Fr};
+use sparq_zk::sig::{PublicKey, SecretKey};
+
+// --- fixtures: a human principal delegating to an AI agent -------------------
+
+const HUMAN: &str = "https://alice.ex/card#me"; // human root (trust-anchored)
+const AI_AGENT: &str = "https://alice-bot.ex/card#me"; // AI agent (terminal delegate)
+const DOCS: &str = "https://pod.ex/docs/";
+const DOC_X: &str = "https://pod.ex/docs/x";
+
+const NOW: i64 = 1_700_000_000;
+const FAR_FUTURE: i64 = NOW + 365 * 86_400;
+const CHALLENGE: [u8; 32] = [0x42u8; 32];
+
+const PROV_NS: &str = "http://www.w3.org/ns/prov#";
+const TRUST_NS: &str = "https://sparq.dev/ns/trust#";
+
+fn iri(s: &str) -> NamedNode {
+    NamedNode::new(s).unwrap()
+}
+fn read() -> NamedNode {
+    iri("https://sparq.dev/ns/auth#read")
+}
+fn write() -> NamedNode {
+    iri("https://sparq.dev/ns/auth#write")
+}
+fn prov(local: &str) -> NamedNode {
+    iri(&format!("{}{}", PROV_NS, local))
+}
+fn cap(actions: Vec<NamedNode>, target: &str) -> Capability {
+    Capability {
+        actions,
+        target: iri(target),
+    }
+}
+fn key(seed: u64) -> (SecretKey, PublicKey) {
+    let sk = SecretKey::from_seed(seed);
+    let pk = sk.public_key();
+    (sk, pk)
+}
+
+fn signed_hop(
+    delegator: &str,
+    delegator_sk: &SecretKey,
+    delegator_pk: &PublicKey,
+    delegate: &str,
+    delegate_pk: &PublicKey,
+    capability: Capability,
+    expires_at_unix_secs: i64,
+) -> DelegationHop {
+    let mut hop = DelegationHop {
+        delegator: iri(delegator),
+        delegator_key: *delegator_pk,
+        delegate: iri(delegate),
+        delegate_key: *delegate_pk,
+        capability,
+        expires_at_unix_secs,
+        signature_hex: String::new(),
+    };
+    let msg = hop_message(&hop);
+    hop.signature_hex = delegator_sk.sign_commitment(&msg);
+    hop
+}
+
+/// A genuinely signed single-hop chain: the human grants read+write over /docs/ to its AI
+/// agent (the AI attenuates is enforced by the gate; here the hop confers read+write so we
+/// can later watch the *current grant* narrow it). Returns (chain, roots, ai_sk).
+fn human_to_ai_chain() -> (DelegationChain, Vec<PublicKey>, SecretKey) {
+    let (human_sk, human_pk) = key(0x2001);
+    let (ai_sk, ai_pk) = key(0x2002);
+    let hop = signed_hop(
+        HUMAN,
+        &human_sk,
+        &human_pk,
+        AI_AGENT,
+        &ai_pk,
+        cap(vec![read(), write()], DOCS),
+        FAR_FUTURE,
+    );
+    (DelegationChain { hops: vec![hop] }, vec![human_pk], ai_sk)
+}
+
+fn invocation(ai_sk: &SecretKey) -> Invocation {
+    let challenge_fr: Fr = field_from_hash_bytes(&CHALLENGE);
+    Invocation {
+        agent: iri(AI_AGENT),
+        challenge: CHALLENGE,
+        pop_hex: ai_sk.sign_holder_pop(&challenge_fr),
+        now_unix_secs: NOW,
+    }
+}
+
+fn classification() -> PrincipalClassification {
+    PrincipalClassification::new()
+        .with(iri(HUMAN), PrincipalKind::Human)
+        .with(iri(AI_AGENT), PrincipalKind::AiAgent)
+}
+
+fn has(graph: &[Triple], s: &str, p: NamedNode, o: Term) -> bool {
+    graph.contains(&Triple {
+        subject: NamedOrBlankNode::NamedNode(iri(s)),
+        predicate: p,
+        object: o,
+    })
+}
+
+// --- the real-path positive case --------------------------------------------
+
+#[test]
+fn real_invoke_then_audit_records_on_behalf_of_and_the_conferred_grant() {
+    let (chain, roots, ai_sk) = human_to_ai_chain();
+    let inv = invocation(&ai_sk);
+
+    // REAL gate: invoke verifies the genuine signature + binds the live PoP.
+    let eff = invoke(&chain, &roots, &inv, &iri(DOC_X)).expect("the gate confers the capability");
+    assert_eq!(eff.delegate.as_str(), AI_AGENT);
+
+    let cfg = AuditConfig {
+        principals: classification(),
+        at_time_unix_secs: Some(NOW),
+        ..Default::default()
+    };
+    let audit = audit_invocation(&chain, &eff, &cfg);
+    let g = audit.graph();
+
+    // on-behalf-of: the AI agent acted on behalf of the human.
+    assert!(
+        has(
+            g,
+            AI_AGENT,
+            prov("actedOnBehalfOf"),
+            Term::NamedNode(iri(HUMAN))
+        ),
+        "AI agent prov:actedOnBehalfOf the human"
+    );
+    // the §4.2 attested attribute: the delegate is an AI agent, the root is human.
+    assert!(
+        has(
+            g,
+            AI_AGENT,
+            iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+            Term::NamedNode(iri(&format!("{}AiAgent", TRUST_NS)))
+        ),
+        "terminal delegate typed trust:AiAgent"
+    );
+    assert!(
+        has(
+            g,
+            HUMAN,
+            iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#type"),
+            Term::NamedNode(iri(&format!("{}HumanPrincipal", TRUST_NS)))
+        ),
+        "human root typed trust:HumanPrincipal"
+    );
+    // the grant rendered as auth:* RDF for the agent, over the CAPABILITY's target (the
+    // granted scope /docs/, which covers the requested /docs/x). read+write conferred here.
+    assert_eq!(
+        eff.capability.target.as_str(),
+        DOCS,
+        "the conferred scope is /docs/"
+    );
+    assert!(
+        has(g, AI_AGENT, read(), Term::NamedNode(iri(DOCS))),
+        "read grant rendered for the AI agent over the granted scope"
+    );
+    assert!(
+        has(g, AI_AGENT, write(), Term::NamedNode(iri(DOCS))),
+        "write grant rendered (the chain confers it here)"
+    );
+    // the activity is associated with the AI agent and timestamped.
+    assert!(g
+        .iter()
+        .any(|t| t.predicate.as_str() == format!("{}atTime", PROV_NS)));
+}
+
+// --- the load-bearing safety invariant: audit never exceeds the gate --------
+
+#[test]
+fn audit_of_intersected_grant_never_exceeds_the_current_delegator_grant() {
+    // The chain confers read+write, but the CURRENT delegator grant has been narrowed to
+    // read-only (item N: the human's own grant was revoked down). The intersection must
+    // drop write, and the audit must render read ONLY — never the stale chain-time write.
+    let (chain, roots, ai_sk) = human_to_ai_chain();
+    let inv = invocation(&ai_sk);
+    let eff = invoke(&chain, &roots, &inv, &iri(DOC_X)).expect("gate confers");
+    assert_eq!(
+        eff.capability.actions,
+        vec![read(), write()],
+        "chain confers both"
+    );
+
+    // The current delegator grant: read only over /docs/.
+    let current = cap(vec![read()], DOCS);
+    let narrowed =
+        effective_against_current(&eff, &current).expect("non-empty intersection (read survives)");
+    assert_eq!(
+        narrowed.capability.actions,
+        vec![read()],
+        "write dropped by the current-grant intersection"
+    );
+
+    let audit = audit_invocation(&chain, &narrowed, &AuditConfig::default());
+    let g = audit.graph();
+    // The grant renders over the intersected target /docs/ (read only).
+    assert!(
+        has(g, AI_AGENT, read(), Term::NamedNode(iri(DOCS))),
+        "the surviving read is audited"
+    );
+    assert!(
+        !g.iter().any(|t| t.predicate.as_str() == write().as_str()),
+        "SAFETY: the revoked write is NOT in the audit — the audit never exceeds the gate"
+    );
+}
+
+#[test]
+fn audit_is_not_an_authority_source_feeding_it_back_grants_nothing() {
+    // The audit graph contains `<ai> auth:read <docX>` triples. But re-admitting that graph
+    // through the trust gate must grant nothing: there is no admission rule that trusts a
+    // prov:actedOnBehalfOf or a rendered auth:* triple — they carry no issuer signature.
+    // We assert the structural fact the design relies on: the audit's grant triples are
+    // plain `auth:*` assertions with NO `trust:admitted` marker and NO issuer attribution,
+    // so they cannot re-enter the admission stratum (which admits only signed facts).
+    let (chain, roots, ai_sk) = human_to_ai_chain();
+    let inv = invocation(&ai_sk);
+    let eff = invoke(&chain, &roots, &inv, &iri(DOC_X)).expect("gate confers");
+    let audit = audit_invocation(&chain, &eff, &AuditConfig::default());
+    let g = audit.graph();
+    let admitted_marker = format!("{}admitted", TRUST_NS);
+    assert!(
+        !g.iter().any(|t| t.predicate.as_str() == admitted_marker),
+        "the audit never marks anything trust:admitted — it is a record, not an admission"
+    );
+}
+
+#[test]
+fn deterministic_node_iris_for_replayability() {
+    // Two audits of the same invocation mint the SAME activity/grant IRIs (deterministic),
+    // so an auditor can correlate records across runs.
+    let (chain, roots, ai_sk) = human_to_ai_chain();
+    let inv = invocation(&ai_sk);
+    let eff = invoke(&chain, &roots, &inv, &iri(DOC_X)).expect("gate confers");
+    let a1 = audit_invocation(&chain, &eff, &AuditConfig::default());
+    let a2 = audit_invocation(&chain, &eff, &AuditConfig::default());
+    assert_eq!(
+        a1.activity(),
+        a2.activity(),
+        "activity IRI is deterministic"
+    );
+    assert_eq!(
+        a1.grant_entity(),
+        a2.grant_entity(),
+        "grant-entity IRI is deterministic"
+    );
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -442,7 +442,8 @@ SAME `Vec<TrustRule>` the gate consumes:
   long-lived view).
 
 Both install on top of the unchanged auth view (the ODRL-bridge precedent). The
-public surface is `sparq_trust::{vocab, policy, admit, wire}` — see
+public surface is `sparq_trust::{vocab, policy, admit, wire, delegation}` (+ the opt-in
+`delegation_prov` / `did` / `store` / `secprop` modules) — see
 [`crates/sparq-trust/README.md`](../../crates/sparq-trust/README.md) and the design record
 `research/solid-trust-graph-authz-design.md` §6.0 (tracked in
 [issue #940](https://github.com/jeswr/sparq/issues/940); landing via design PR
@@ -480,6 +481,23 @@ is **RESOLVED** by the static/dynamic split: see `admit_trust_credential_static`
 implemented: it binds each hop's `delegate_key` into the delegator-signed preimage, defeating the
 key-substitution stolen-chain replay — but it does **not** claim full non-replayability, because
 the delegator's own key is still operator-asserted (`sq-pfae.3`); see the crate README *Honest scope*.
+
+**Delegation PROV-O audit for human + AI agents** (the **opt-in `delegation-prov` feature**,
+`sq-pfae.6`, design §4.2/§4.3). `sparq_trust::delegation_prov::audit_invocation(chain, effective,
+config)` renders an invocation-bound delegation chain + its surviving `EffectiveCapability` as a
+minimal **W3C PROV-O** audit graph: each hop's `delegate prov:actedOnBehalfOf delegator` (the
+on-behalf-of lineage `sparq-prov` lacks), the invocation as a `prov:Activity` the terminal delegate
+`prov:wasAssociatedWith`, and the effective grant as a `prov:Entity` `wasGeneratedBy`/`wasAttributedTo`
+the delegate carrying the `auth:*` actions over its target — the §4.3 value-add of rendering the
+delegated authority as RDF that reasons with the SAME `.acl` rules. **Human vs AI** is an **attested
+attribute** on the delegate (§4.2: an AI agent is a distinct principal holding an attenuated child of
+its human's authority) — recorded `trust:HumanPrincipal` / `trust:AiAgent` via `PrincipalClassification`.
+Two honesty boundaries: (i) it is an **audit record, never an authority source** — produced *after* a
+successful `invoke`, it can only ever describe authority that already passed the gate, and it never
+renders a grant broader than the gate conferred (when `effective_against_current` narrows the chain to
+the CURRENT delegator grant, the audit drops the revoked actions); (ii) it adds **no security property**
+and no privacy — principals are named in the clear. Pure `oxrdf` (**no `sparq-prov` dependency** — that
+would drag `sparq-engine` onto the crate's dep graph); OFF in the default build.
 
 ### Security-properties vocabulary — opt-in `secprop-vocab` ([OPUS-4.8] sq-5oru9, epic sq-0dksu)
 


### PR DESCRIPTION
> 🤖 SPARQ agent — trust-graph authorisation PoC (epic sq-pfae, P5). Written while Fable unavailable; flag for re-review when Fable returns.

Implements **sq-pfae.6** ("delegation stratum for human + AI agents"). The invocation-binding gate it builds on — ZCAP/UCAN chain verification, monotone attenuation, the `agent ⊆ delegator` intersection per request, confused-deputy resistance (authority carried with the invocation + key-proof binding) — **already landed** under `sq-l5og` (#1026, `crates/sparq-trust/src/delegation.rs`). This PR delivers the **two deliverables the design record §4.3 / §7.4(K) flagged as "proposed, zero substrate"**:

1. **PROV-O delegation audit.** `sparq-prov` records only a single-agent `prov:wasAssociatedWith` and has **no `prov:actedOnBehalfOf` / delegation-chain modelling**. The new `delegation_prov` module renders an invocation-bound chain + its surviving `EffectiveCapability` as a minimal **W3C PROV-O** audit graph: `delegate prov:actedOnBehalfOf delegator` per hop, the invocation as a `prov:Activity` the terminal delegate `prov:wasAssociatedWith`, and the effective grant as a `prov:Entity` `wasGeneratedBy`/`wasAttributedTo` the delegate carrying the `auth:*` actions — the §4.3 value-add: delegated authority rendered as RDF that reasons with the SAME `.acl` rules.
2. **Human vs AI principal as an attested attribute on the delegate** (§4.2: *"an AI agent is a distinct principal holding an attenuated child of its human principal's authority"*) — recorded `trust:HumanPrincipal` / `trust:AiAgent` via `PrincipalClassification`.

## Opt-in / lean-core

New **default-OFF `delegation-prov` cargo feature**. Pure-Rust over `oxrdf` (already a dep) + the `delegation` module — **NO new dependency** and, deliberately, **NO `sparq-prov` edge** (that would drag `sparq-engine` onto this crate's dep graph; the audit is a small fixed triple set emitted directly). Strictly additive (G6): the lean default build is byte-identical with it OFF.

## Honest scope (unchanged)

Research prototype, **NOT a security guarantee**. The audit is a **record, never an authority source** — produced *after* a successful `invoke`, it can only ever describe authority that already passed the gate, and it **never renders a grant broader than the gate conferred** (the load-bearing safety invariant, tested: when `effective_against_current` narrows the chain to the CURRENT delegator grant, the audit drops the revoked actions). It adds **no security property** and no privacy — principals are named in the clear. The ZK estate it composes with is externally **unaudited** (`sq-qhy4`). Design judgment calls (no `sparq-prov` dep; audit-not-authority; NON-STANDARD `trust:` IRIs) are documented in #1190.

## Gates (both feature states)

- `cargo clippy -p sparq-trust --all-targets -- -D warnings` (feature OFF) **and** `--all-features` — clean.
- `cargo test -p sparq-trust` (OFF) **and** `--all-features` — green. **7** `delegation_prov` unit tests + **4** real-path integration tests (`tests/delegation_prov_audit.rs`: genuine signed human→AI chain → `invoke` → `effective_against_current` → `audit_invocation`, asserting on-behalf-of lineage, the human/AI attestation, and the safety invariant).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean (caught + fixed `[prov:X]` broken intra-doc links → code spans).
- `scripts/check-readme-template.py --enforce` → **0 deviations**; crate README **= 120 lines**.
- `scripts/check-privacy-claims.sh` — clean. markdownlint on changed files — clean.
- **feature-matrix.yml leg** added (`sparq-trust (delegation-prov)`) so the cfg-gated suite actually EXECUTES (ci.yml's no-features archive compiles it empty otherwise).

## Files

`crates/sparq-trust/src/delegation_prov.rs` (new), `tests/delegation_prov_audit.rs` (new), `src/vocab.rs` (`trust:HumanPrincipal`/`AiAgent`), `src/lib.rs` (feature-gated module + re-exports), `Cargo.toml` (feature), `README.md`, `skills/access-control/SKILL.md`, `.github/workflows/feature-matrix.yml`.

Closes the audit + on-behalf-of half of `sq-pfae.6`. Auto-merge intentionally OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)