### PR TITLE
feat(sparq-solid): per-resource WAC decision layer — decide/decide_batch + typed fail-closed status + ACL walk (sq-snopa.1/.2/.3, #992)

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -44,8 +44,8 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
 - **Triples-native + zero-copy enforcement** — pods, ACL/ACR docs, and the auth view are all ordinary
   named graphs ("who can read G?" is one SPARQL pattern); the default path evaluates through the engine's
   zero-copy dataset view, with a v1 `FROM NAMED` rewrite as a standard-SPARQL portability path.
-- **Write-path gating + WAC-Allow** — `update_as` / `update_as_acp` check every graph an update could
-  mutate before applying; `wac_allow` builds the fail-closed `user="…",public="…"` header a server returns.
+- **Write-path gating, WAC-Allow + per-resource decision (#992 FR-1/6/7)** — `update_as` gates writes, `wac_allow` builds the header, and `decide`/`decide_batch`/`resolve_acl` answer the per-request *"may X do M on R?"* with the
+  governing-ACL + `accessTo`/`default` scope and a typed fail-closed `AclStatus` (absent/unloaded/transient ⇒ deny, never open — for a server's 401/403-vs-503 mapping).
 - **ODRL bridge (opt-in `odrl-bridge`, research-track — not a production cutover)** — runs the
   [`sparq-policy`](../sparq-policy) ODRL evaluator and materializes the equivalent WAC/ACP grant (or dual
   `auth:deny*`) into the auth view — no new enforcement engine (zero ODRL code by default; see below).

--- a/crates/sparq-solid/src/decide.rs
+++ b/crates/sparq-solid/src/decide.rs
@@ -1,0 +1,423 @@
+//! [OPUS-4.8] issue #992 Phase-1 — the per-resource WAC **decision** layer
+//! (beads sq-snopa.1 / .2 / .3). Where the rest of this crate filters *graphs* (the
+//! authorization *oracle*: `accessible` / `query_as` / `update_as`), this module answers
+//! the one question an LDP resource server asks per request: **"may principal X do mode M
+//! on resource R?"** — as a typed [`WacDecision`], with the governing ACL + scope and a
+//! fail-closed load/error [`AclStatus`].
+//!
+//! It builds ENTIRELY on the existing machinery — [`crate::AuthIndex::accessible`] for the
+//! verdict, the loader's container-chain walk (`loader::parent_iri`) for ACL discovery —
+//! and adds no dependency, so it is an always-present public API (no cargo gate), mirroring
+//! [`crate::PodStore::wac_allow`].
+//!
+//! # Security posture — fail-CLOSED, never fail-OPEN (FR-6, sq-snopa.2)
+//!
+//! This is authorization decision logic; the cardinal rule is **any uncertainty ⇒ deny**.
+//! Every error/absence path resolves to `allow == false`, with a typed [`AclStatus`] the
+//! server maps to an HTTP status — but the deny is independent of the status, so a caller
+//! that ignores the status STILL fails closed. The grant verdict reuses
+//! [`crate::AuthIndex::accessible`], which is itself fail-closed (an un-materialized view,
+//! a grant-less session, or a reserved-encoding session value all degrade to the empty
+//! set), so a `decide` allow can never be wider than the oracle would grant.
+
+use crate::authindex::Mode;
+use crate::loader::{parent_iri, ACL_SUFFIX, ACR_SUFFIX};
+use crate::{AuthIndex, Session, AUTH_GRAPH};
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+
+/// Where a governing ACL grant applies relative to the resource it governs — the WAC
+/// `acl:accessTo` / `acl:default` distinction (FR-7, sq-snopa.3), surfaced for
+/// debuggability and the `Link: rel="acl"` surface (FR-5 will build on it).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AclScope {
+    /// The resource has its **own** access-control document (`<R> + ".acl"`/`".acr"`),
+    /// and authorizations there target it directly (WAC `acl:accessTo <R>`).
+    AccessTo,
+    /// No own ACL; the governing document is the **nearest ancestor container's** ACL,
+    /// inherited via WAC `acl:default` (Solid container-`default` inheritance).
+    Default,
+}
+
+/// The typed fail-closed load/error contract for a decision (FR-6, sq-snopa.2).
+///
+/// Carries over the hard-won fail-OPEN lessons: it lets a resource server distinguish a
+/// *definitive* deny (map to **401/403**) from a *retryable* one (map to **503**) —
+/// **without ever failing open**. The [`WacDecision::allow`] flag is `false` for every
+/// status except [`AclStatus::Resolved`], and `Resolved` only ever carries the verdict
+/// the materialized auth view actually supports. A server that ignores `status` entirely
+/// still gets the correct allow/deny; `status` only refines the *HTTP code*.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum AclStatus {
+    /// A governing ACL was discovered and the auth view is loaded: the decision is
+    /// **authoritative**. `allow` is the real verdict. (An authoritative *deny* — the
+    /// principal simply lacks the mode — is also `Resolved`; map it to **403**.)
+    Resolved,
+    /// No governing ACL exists anywhere up the container chain (the resource is
+    /// **un-protected by any discoverable ACL**). Fail-closed ⇒ `allow == false`. A
+    /// Solid server treats this as a definitive deny — map to **403** (or **401** for an
+    /// anonymous principal that might succeed once authenticated).
+    NoAcl,
+    /// A governing ACL was discovered, but the authorization view is **not loaded**
+    /// (`materialize_wac` / `materialize_acp` has not been run, so no verdict can be
+    /// computed). Fail-closed ⇒ `allow == false`. This is a *transient/operational*
+    /// condition, not a permission denial — map to a **retryable 503**.
+    Unloaded,
+    /// A **typed transient error** occurred while deciding (e.g. a malformed resource
+    /// IRI the server passed in). Fail-closed ⇒ `allow == false`. Map to a **retryable
+    /// 503** — the request is not necessarily forbidden, the decision just could not be
+    /// computed *this time*.
+    Transient,
+}
+
+impl AclStatus {
+    /// Whether this status denotes a **retryable** (operational/transient) condition a
+    /// server should map to **503**, rather than a definitive permission outcome
+    /// (401/403). Convenience for the resource-server status mapping; `Unloaded` and
+    /// `Transient` are retryable, `Resolved` and `NoAcl` are definitive. Fail-closed is
+    /// orthogonal — every non-`Resolved` status still carries `allow == false`.
+    pub fn is_retryable(self) -> bool {
+        matches!(self, AclStatus::Unloaded | AclStatus::Transient)
+    }
+}
+
+/// The effective governing ACL for a resource: the discovered ACL document IRI plus the
+/// scope by which it governs (FR-7, sq-snopa.3). Produced by
+/// [`crate::PodStore::resolve_acl`] in ONE indexed pass over the dataset's named graphs —
+/// no per-ancestor round-trips.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct EffectiveAcl {
+    /// The discovered access-control document IRI (`<R>.acl` for an own ACL, or the
+    /// nearest ancestor container's `<C>.acl` for an inherited one).
+    pub acl: NamedNode,
+    /// Whether the ACL governs `R` directly (`acl:accessTo`) or by container inheritance
+    /// (`acl:default`).
+    pub scope: AclScope,
+}
+
+/// A per-request access-control decision for one `(principal, resource, mode)` (FR-1,
+/// sq-snopa.1).
+///
+/// The point-query analogue of the graph-filtering oracle: a Solid resource server hands
+/// this straight to its request pipeline. It is **fail-closed by construction** — see the
+/// module docs and [`AclStatus`]. The grant verdict reuses
+/// [`crate::AuthIndex::accessible`] (the same `∪ allow ∖ ∪ deny` per-mode set), so a
+/// `decide` allow is never wider than what `accessible` / `query_as` would grant.
+///
+/// # Examples
+///
+/// ```
+/// use sparq_solid::{AclScope, AclStatus, Mode, PodStore, Session};
+///
+/// let nquads = r#"
+/// <https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hello" <https://pod.ex/notes/n1> .
+/// <https://pod.ex/.acl#owner> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/.acl> .
+/// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> <https://pod.ex/.acl> .
+/// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#agent> <https://alice.ex/card#me> <https://pod.ex/.acl> .
+/// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/.acl> .
+/// "#;
+/// let mut store = PodStore::new(sparq_core::Graph::load_dataset(nquads, "nquads")?);
+/// store.materialize_wac()?;
+///
+/// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None, now: None };
+/// let d = store.decide(&alice, "https://pod.ex/notes/n1", Mode::Read);
+/// assert!(d.allow);
+/// assert_eq!(d.status, AclStatus::Resolved);
+/// assert_eq!(d.scope, Some(AclScope::Default)); // inherited from the root `.acl`
+/// assert!(d.granted_modes.contains(&Mode::Read));
+/// // alice has only Read — Write is an authoritative deny, NOT a transient one.
+/// let dw = store.decide(&alice, "https://pod.ex/notes/n1", Mode::Write);
+/// assert!(!dw.allow);
+/// assert_eq!(dw.status, AclStatus::Resolved);
+/// # Ok::<(), String>(())
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WacDecision {
+    /// The verdict for the requested mode. **Fail-closed**: `false` for every non-`Resolved`
+    /// status, and `false` whenever the principal lacks the mode.
+    pub allow: bool,
+    /// Every mode the principal holds on the resource (sorted, deduped) — so the server can
+    /// build a `WAC-Allow` advertisement or a 403 body from one decision. Empty unless
+    /// `status == Resolved`.
+    pub granted_modes: Vec<Mode>,
+    /// The governing ACL document IRI, when one was discovered (FR-7). `None` when
+    /// `status == NoAcl` (no ACL anywhere in the chain), or on a `Transient` error.
+    pub governing_acl: Option<NamedNode>,
+    /// How the governing ACL applies — `AccessTo` (own ACL) or `Default` (inherited).
+    /// `Some` exactly when `governing_acl` is `Some`.
+    pub scope: Option<AclScope>,
+    /// The typed fail-closed load/error status (FR-6). Drives the server's HTTP mapping;
+    /// the allow/deny itself is already correct regardless of it.
+    pub status: AclStatus,
+}
+
+impl WacDecision {
+    /// A fail-closed deny with the given status and no governing ACL — the single
+    /// constructor for every uncertainty path, so deny-by-default is impossible to forget.
+    fn deny(status: AclStatus) -> WacDecision {
+        WacDecision { allow: false, granted_modes: Vec::new(), governing_acl: None, scope: None, status }
+    }
+}
+
+/// A read-only structural index of a dataset's named graphs: which IRIs are control
+/// documents (`.acl`/`.acr`), and whether the auth view is loaded. Built ONCE per
+/// `decide_batch` / `resolve_acl` call so a batch of N decisions is N point lookups, not
+/// N full scans (FR-7's "one indexed call, not N round-trips"). [OPUS-4.8]
+pub(crate) struct AclIndex {
+    /// Every control-document IRI present (both `.acl` and `.acr` — a pod is one system,
+    /// but we don't assume which, and an own-ACL lookup is just a set membership test).
+    control: rustc_hash::FxHashSet<String>,
+    /// Whether the materialized auth view (`<urn:sparq:auth>`) is present in the dataset.
+    materialized: bool,
+}
+
+impl AclIndex {
+    /// Index the dataset's named-graph names in one pass.
+    pub(crate) fn build(graph: &Graph) -> AclIndex {
+        let mut control = rustc_hash::FxHashSet::default();
+        let mut materialized = false;
+        for (name, _) in &graph.named {
+            let Term::NamedNode(n) = name else { continue };
+            let iri = n.as_str();
+            if iri == AUTH_GRAPH {
+                materialized = true;
+            } else if iri.ends_with(ACL_SUFFIX) || iri.ends_with(ACR_SUFFIX) {
+                control.insert(iri.to_owned());
+            }
+        }
+        AclIndex { control, materialized }
+    }
+
+    /// The control-document IRI governing `resource`, if one exists in the dataset
+    /// (`<resource>.acl` / `<resource>.acr`).
+    fn own_acl(&self, resource: &str) -> Option<String> {
+        for suffix in [ACL_SUFFIX, ACR_SUFFIX] {
+            let candidate = format!("{}{}", resource, suffix);
+            if self.control.contains(&candidate) {
+                return Some(candidate);
+            }
+        }
+        None
+    }
+
+    /// FR-7 (sq-snopa.3) — resolve the EFFECTIVE governing ACL for `resource` in ONE
+    /// indexed call: the up-the-container-chain `.acl`/`.acr` discovery + `acl:default`
+    /// inheritance, returning the governing ACL IRI + `accessTo`-vs-`default` scope.
+    ///
+    /// Mirrors the materialize-time nearest-ancestor walk in `rules/wac.n3` /
+    /// `rules/common.n3`: the resource's own ACL (`acl:accessTo`) wins; otherwise the
+    /// nearest ancestor container that HAS an ACL governs by `acl:default`. `None` when no
+    /// ACL exists anywhere up to the pod root (the resource is un-protected ⇒ the caller
+    /// fails closed). The container-prefix walk is exactly the loader's `parent_iri`
+    /// slash-semantics walk, so discovery and materialization can never disagree.
+    pub(crate) fn resolve_acl(&self, resource: &str) -> Option<EffectiveAcl> {
+        // Own ACL → accessTo scope.
+        if let Some(acl) = self.own_acl(resource) {
+            return Some(EffectiveAcl { acl: NamedNode::new_unchecked(acl), scope: AclScope::AccessTo });
+        }
+        // Walk up the container chain; the nearest ancestor with an ACL governs by default.
+        let mut cur = resource;
+        while let Some(parent) = parent_iri(cur) {
+            if let Some(acl) = self.own_acl(parent) {
+                return Some(EffectiveAcl { acl: NamedNode::new_unchecked(acl), scope: AclScope::Default });
+            }
+            cur = parent;
+        }
+        None
+    }
+}
+
+/// Compute the decision for one `(session, resource, mode)` against a prebuilt index +
+/// auth index. Shared by [`crate::PodStore::decide`] and `decide_batch` (the batch path
+/// builds the [`AclIndex`] once). [OPUS-4.8]
+pub(crate) fn decide_one(
+    index: &AclIndex,
+    auth: &AuthIndex,
+    session: &Session,
+    resource: &str,
+    mode: Mode,
+) -> WacDecision {
+    // A malformed resource IRI is a typed transient error — fail closed, retryable.
+    let Ok(res_node) = NamedNode::new(resource) else {
+        return WacDecision::deny(AclStatus::Transient);
+    };
+
+    // FR-7: discover the governing ACL up the container chain in one indexed pass.
+    let Some(effective) = index.resolve_acl(resource) else {
+        // No ACL anywhere ⇒ the resource is un-protected by any discoverable ACL ⇒ deny.
+        return WacDecision::deny(AclStatus::NoAcl);
+    };
+
+    // FR-6: a governing ACL exists but the view is not loaded ⇒ retryable deny.
+    if !index.materialized {
+        return WacDecision {
+            allow: false,
+            granted_modes: Vec::new(),
+            governing_acl: Some(effective.acl),
+            scope: Some(effective.scope),
+            status: AclStatus::Unloaded,
+        };
+    }
+
+    // Authoritative: ask the (fail-closed) oracle for every mode the session holds on R.
+    let granted_modes = held_modes(auth, session, &res_node);
+    let allow = granted_modes.contains(&mode);
+    WacDecision {
+        allow,
+        granted_modes,
+        governing_acl: Some(effective.acl),
+        scope: Some(effective.scope),
+        status: AclStatus::Resolved,
+    }
+}
+
+/// The sorted set of modes `session` holds on `resource`, via the fail-closed oracle
+/// ([`AuthIndex::accessible`]). The point-query analogue of `PodStore::modes_held`, over
+/// the index directly (no per-session cache here — `decide` is a single index walk).
+fn held_modes(auth: &AuthIndex, session: &Session, resource: &NamedNode) -> Vec<Mode> {
+    const MODES: [Mode; 4] = [Mode::Read, Mode::Write, Mode::Append, Mode::Control];
+    MODES
+        .into_iter()
+        .filter(|&m| auth.accessible(session, m).iter().any(|g| g == resource))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn graph(nquads: &str) -> Graph {
+        Graph::load_dataset(nquads, "nquads").expect("loads")
+    }
+
+    // A root `.acl` granting alice Read by `acl:default`, plus a doc under /notes/.
+    const ROOT_ACL: &str = r#"
+<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hello" <https://pod.ex/notes/n1> .
+<https://pod.ex/.acl#owner> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/.acl> .
+<https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> <https://pod.ex/.acl> .
+<https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#agent> <https://alice.ex/card#me> <https://pod.ex/.acl> .
+<https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/.acl> .
+"#;
+
+    #[test]
+    fn resolve_inherited_default_scope() {
+        let g = graph(ROOT_ACL);
+        let ix = AclIndex::build(&g);
+        let eff = ix
+            .resolve_acl("https://pod.ex/notes/n1")
+            .expect("inherited acl");
+        assert_eq!(eff.acl.as_str(), "https://pod.ex/.acl");
+        assert_eq!(eff.scope, AclScope::Default);
+    }
+
+    #[test]
+    fn resolve_own_acl_access_to_scope() {
+        // A doc with its OWN .acl → accessTo scope, even though the root also has one.
+        let nquads = format!(
+            "{ROOT_ACL}\
+             <https://pod.ex/notes/n1.acl#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/notes/n1.acl> .\n"
+        );
+        let g = graph(&nquads);
+        let ix = AclIndex::build(&g);
+        let eff = ix.resolve_acl("https://pod.ex/notes/n1").expect("own acl");
+        assert_eq!(eff.acl.as_str(), "https://pod.ex/notes/n1.acl");
+        assert_eq!(eff.scope, AclScope::AccessTo);
+    }
+
+    #[test]
+    fn resolve_no_acl_is_none() {
+        // A pod with NO control document anywhere.
+        let nquads = "<https://pod.ex/d#it> <https://ex.dev/ns#k> \"v\" <https://pod.ex/d> .\n";
+        let g = graph(nquads);
+        let ix = AclIndex::build(&g);
+        assert!(ix.resolve_acl("https://pod.ex/d").is_none());
+    }
+
+    #[test]
+    fn resolve_walks_nearest_ancestor_not_root() {
+        // Both a deep container AND the root have ACLs → the NEAREST (deep) one governs.
+        let nquads = format!(
+            "{ROOT_ACL}\
+             <https://pod.ex/notes/.acl#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/notes/.acl> .\n"
+        );
+        let g = graph(&nquads);
+        let ix = AclIndex::build(&g);
+        let eff = ix
+            .resolve_acl("https://pod.ex/notes/n1")
+            .expect("nearest acl");
+        assert_eq!(
+            eff.acl.as_str(),
+            "https://pod.ex/notes/.acl",
+            "nearest ancestor, not root"
+        );
+        assert_eq!(eff.scope, AclScope::Default);
+    }
+
+    #[test]
+    fn unmaterialized_with_acl_is_unloaded_deny() {
+        // The view was never materialized: governing ACL is discovered, but we cannot
+        // decide → Unloaded, deny, retryable. FR-6 present-but-unloaded path.
+        let g = graph(ROOT_ACL);
+        let ix = AclIndex::build(&g);
+        let empty_auth = AuthIndex::default();
+        let alice = Session {
+            agent: Some("https://alice.ex/card#me"),
+            client: None,
+            issuer: None,
+            now: None,
+        };
+        let d = decide_one(
+            &ix,
+            &empty_auth,
+            &alice,
+            "https://pod.ex/notes/n1",
+            Mode::Read,
+        );
+        assert!(!d.allow, "fail-closed");
+        assert_eq!(d.status, AclStatus::Unloaded);
+        assert!(d.status.is_retryable());
+        assert!(
+            d.governing_acl.is_some(),
+            "ACL still discovered for the Link: rel=acl surface"
+        );
+    }
+
+    #[test]
+    fn malformed_resource_iri_is_transient_deny() {
+        let g = graph(ROOT_ACL);
+        let ix = AclIndex::build(&g);
+        let auth = AuthIndex::default();
+        let alice = Session {
+            agent: Some("https://alice.ex/card#me"),
+            client: None,
+            issuer: None,
+            now: None,
+        };
+        let d = decide_one(&ix, &auth, &alice, "not a valid iri", Mode::Read);
+        assert!(!d.allow);
+        assert_eq!(d.status, AclStatus::Transient);
+        assert!(d.status.is_retryable());
+        assert!(d.governing_acl.is_none());
+    }
+
+    #[test]
+    fn no_acl_is_definitive_deny_not_retryable() {
+        let nquads = "<https://pod.ex/d#it> <https://ex.dev/ns#k> \"v\" <https://pod.ex/d> .\n";
+        let g = graph(nquads);
+        let ix = AclIndex::build(&g);
+        let auth = AuthIndex::default();
+        let alice = Session {
+            agent: Some("https://alice.ex/card#me"),
+            client: None,
+            issuer: None,
+            now: None,
+        };
+        let d = decide_one(&ix, &auth, &alice, "https://pod.ex/d", Mode::Read);
+        assert!(!d.allow);
+        assert_eq!(d.status, AclStatus::NoAcl);
+        assert!(
+            !d.status.is_retryable(),
+            "absent ACL is a definitive (403) deny, not a retry"
+        );
+    }
+}

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -8,6 +8,12 @@ mod authindex;
 // gate): it depends only on the always-present ACP path. The corpus lives in
 // tests/conformance_acp.rs.
 pub mod conformance;
+// [OPUS-4.8] issue #992 Phase-1 (sq-snopa.1/.2/.3): the per-resource WAC DECISION layer —
+// `PodStore::decide`/`decide_batch`/`resolve_acl`, the typed fail-closed `AclStatus`, and
+// the `accessTo`-vs-`default` `AclScope`. Always compiled (no feature gate): it adds no
+// dependency, reusing only `AuthIndex::accessible` + the loader's container-chain walk —
+// so it mirrors `wac_allow`'s always-present public-API placement (#1154).
+mod decide;
 pub mod fixture;
 mod loader;
 mod materialize;
@@ -35,6 +41,8 @@ pub mod wac_conformance;
 pub use authindex::{pair_principal, triple_principal, AuthIndex, Mode, Session};
 // [OPUS-4.8] sq-3jtd.9: the ACP conformance harness entry types.
 pub use conformance::{AcpScenario, AcrBuilder, Decision, Expect, ScenarioReport};
+// [OPUS-4.8] issue #992 Phase-1 (sq-snopa.1/.2/.3): the per-resource WAC decision types.
+pub use decide::{AclScope, AclStatus, EffectiveAcl, WacDecision};
 // [OPUS-4.8] sq-3jtd.8: the WAC conformance harness entry types (the decision/expectation
 // /report vocabulary is the shared `conformance::{Decision, Expect, ScenarioReport}`).
 pub use wac_conformance::{AclBuilder, AuthBuilder, WacScenario};
@@ -435,6 +443,109 @@ impl PodStore {
             }
         }
         held.join(" ")
+    }
+
+    /// [OPUS-4.8] issue #992 FR-1 (sq-snopa.1) — the per-REQUEST access-control decision:
+    /// **may `principal` do `mode` on `resource`?** Returns a typed [`WacDecision`]
+    /// (`allow`, `granted_modes`, `governing_acl`, `scope`, fail-closed `status`).
+    ///
+    /// This is the point-query an LDP resource server asks per request, NOT graph
+    /// filtering. Where [`PodStore::query_as`] / [`PodStore::accessible`] return the *set*
+    /// of authorized graphs, `decide` answers the single `(principal, resource, mode)`
+    /// question and pairs the verdict with the governing-ACL provenance the server needs
+    /// for its `Link: rel="acl"` / `WAC-Allow` surfaces.
+    ///
+    /// It reuses the SAME machinery — the verdict is the fail-closed
+    /// [`AuthIndex::accessible`] oracle (the `∪ allow ∖ ∪ deny` per-mode set), the ACL
+    /// discovery is the loader's container-chain walk ([`PodStore::resolve_acl`]) — so a
+    /// `decide` allow can never be wider than `query_as` would grant.
+    ///
+    /// # Fail-closed (FR-6, sq-snopa.2 — never fail OPEN)
+    ///
+    /// Every uncertainty path denies. The typed [`WacDecision::status`] lets a server map
+    /// the deny to the right HTTP code — **401/403** for a definitive deny
+    /// ([`AclStatus::Resolved`] without the mode, or [`AclStatus::NoAcl`]); a **retryable
+    /// 503** for an operational one ([`AclStatus::Unloaded`] — the view was never
+    /// materialized; [`AclStatus::Transient`] — e.g. a malformed resource IRI) — but the
+    /// `allow == false` is already correct regardless of the status. See [`AclStatus`].
+    ///
+    /// `resource` is the named-graph IRI backing the LDP resource (mapping the request
+    /// PATH to it is the server's job — `sparq-solid` is a library-level authoriser with
+    /// no HTTP surface; see `research/sparq-solid-scope.md` §4).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sparq_solid::{AclScope, AclStatus, Mode, PodStore, Session};
+    ///
+    /// let nquads = r#"
+    /// <https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hi" <https://pod.ex/notes/n1> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#agent> <https://alice.ex/card#me> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/.acl> .
+    /// "#;
+    /// let mut store = PodStore::new(sparq_core::Graph::load_dataset(nquads, "nquads")?);
+    /// store.materialize_wac()?;
+    ///
+    /// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None, now: None };
+    /// let d = store.decide(&alice, "https://pod.ex/notes/n1", Mode::Read);
+    /// assert!(d.allow && d.status == AclStatus::Resolved);
+    /// assert_eq!(d.scope, Some(AclScope::Default)); // inherited from the root .acl
+    /// // anonymous has no grant → an authoritative deny (403), not a transient one.
+    /// let anon = store.decide(&Session::default(), "https://pod.ex/notes/n1", Mode::Read);
+    /// assert!(!anon.allow && anon.status == AclStatus::Resolved);
+    /// # Ok::<(), String>(())
+    /// ```
+    pub fn decide(&self, session: &Session, resource: &str, mode: Mode) -> WacDecision {
+        let index = decide::AclIndex::build(&self.graph);
+        decide::decide_one(&index, &self.auth, session, resource, mode)
+    }
+
+    /// [OPUS-4.8] issue #992 FR-1 (sq-snopa.1) — [`PodStore::decide`] for a BATCH of
+    /// `(resource, mode)` requests as one `principal`, building the structural ACL index
+    /// ONCE and reusing it for every request (the LDP server's "decide a page of
+    /// resources" call). Each element's [`WacDecision`] is independent and fail-closed
+    /// exactly as [`PodStore::decide`]; the result vector is parallel to the input.
+    pub fn decide_batch(&self, session: &Session, requests: &[(&str, Mode)]) -> Vec<WacDecision> {
+        let index = decide::AclIndex::build(&self.graph);
+        requests
+            .iter()
+            .map(|(resource, mode)| decide::decide_one(&index, &self.auth, session, resource, *mode))
+            .collect()
+    }
+
+    /// [OPUS-4.8] issue #992 FR-7 (sq-snopa.3) — resolve the EFFECTIVE governing ACL for a
+    /// resource in ONE indexed call: the up-the-container-chain `.acl`/`.acr` discovery +
+    /// `acl:default` inheritance, returning the governing ACL IRI + `accessTo`-vs-`default`
+    /// scope ([`EffectiveAcl`]) — instead of N HTTP round-trips up the chain.
+    ///
+    /// The resource's OWN ACL (`<resource>.acl`/`.acr`) wins with [`AclScope::AccessTo`];
+    /// otherwise the NEAREST ancestor container that has an ACL governs by
+    /// [`AclScope::Default`] (Solid container-`default` inheritance). `None` when no ACL
+    /// exists anywhere up to the pod root (an un-protected resource — the caller should
+    /// fail closed). The walk is exactly the loader's slash-semantics `parent_iri` chain,
+    /// so this per-resource discovery and the materialize-time inheritance can never
+    /// disagree. Feeds [`PodStore::decide`]'s `governing_acl`/`scope` (and FR-5 later).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sparq_solid::{AclScope, PodStore};
+    ///
+    /// let nquads = r#"
+    /// <https://pod.ex/notes/n1#it> <https://ex.dev/ns#k> "v" <https://pod.ex/notes/n1> .
+    /// <https://pod.ex/.acl#a> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/.acl> .
+    /// "#;
+    /// let store = PodStore::new(sparq_core::Graph::load_dataset(nquads, "nquads")?);
+    /// let eff = store.resolve_acl("https://pod.ex/notes/n1").expect("inherited acl");
+    /// assert_eq!(eff.acl.as_str(), "https://pod.ex/.acl");
+    /// assert_eq!(eff.scope, AclScope::Default);
+    /// assert!(store.resolve_acl("https://other.ex/x").is_none()); // no ACL anywhere
+    /// # Ok::<(), String>(())
+    /// ```
+    pub fn resolve_acl(&self, resource: &str) -> Option<EffectiveAcl> {
+        decide::AclIndex::build(&self.graph).resolve_acl(resource)
     }
 
     fn session_sets(&mut self, s: &Session, mode: Mode) -> &SessionSets {

--- a/crates/sparq-solid/tests/decide.rs
+++ b/crates/sparq-solid/tests/decide.rs
@@ -1,0 +1,278 @@
+//! [OPUS-4.8] issue #992 Phase-1 (sq-snopa.1/.2/.3) — soundness of the per-resource WAC
+//! DECISION layer (`PodStore::decide` / `decide_batch` / `resolve_acl`), exercised through
+//! the REAL materialize → AuthIndex::accessible path (no mock bypasses the verdict). This
+//! is security-critical authz logic, so the suite pins the soundness cases the issue calls
+//! out: allow/deny per mode, agent vs agentGroup vs public vs authenticated, accessTo vs
+//! default scope, and the fail-closed contract (ABSENT acl ⇒ deny+NoAcl; present-but-
+//! UNLOADED ⇒ deny+Unloaded; transient ⇒ deny+Transient — never allow).
+
+use oxrdf::NamedNode;
+use sparq_core::Graph;
+use sparq_solid::wac_conformance::AclBuilder;
+use sparq_solid::{AclScope, AclStatus, Mode, PodStore, Session};
+
+const ALICE: &str = "https://alice.ex/card#me";
+const BOB: &str = "https://bob.ex/card#me";
+const CAROL: &str = "https://carol.ex/card#me";
+const DAVE: &str = "https://dave.ex/card#me";
+const TEAM: &str = "https://pod.ex/groups/team#g";
+
+fn session(agent: Option<&str>) -> Session<'_> {
+    Session { agent, client: None, issuer: None, now: None }
+}
+
+/// Build a materialized WAC store from an ACL corpus.
+fn store(acl: AclBuilder) -> PodStore {
+    let g = Graph::load_dataset(&acl.into_nquads(), "nquads").expect("loads");
+    let mut s = PodStore::new(g);
+    s.materialize_wac().expect("materializes");
+    s
+}
+
+/// `decide(...).allow` — the per-request verdict, the most-checked field.
+fn allow(s: &PodStore, agent: Option<&str>, resource: &str, mode: Mode) -> bool {
+    s.decide(&session(agent), resource, mode).allow
+}
+
+// ─── FR-1: allow / deny per mode (Read/Write/Append/Control) ──────────────────────────
+
+#[test]
+fn decide_allow_deny_per_mode() {
+    // alice: Read+Write on her own doc; bob: nothing. The doc has its OWN .acl.
+    let mut acl = AclBuilder::new();
+    acl.document("https://pod.ex/d.ttl");
+    acl.access_to("https://pod.ex/d.ttl", |a| a.agent(ALICE).mode(Mode::Read).mode(Mode::Write));
+    let store = store(acl);
+
+    let r = store.decide(&session(Some(ALICE)), "https://pod.ex/d.ttl", Mode::Read);
+    assert!(r.allow, "alice has Read");
+    assert_eq!(r.status, AclStatus::Resolved);
+    assert_eq!(r.scope, Some(AclScope::AccessTo), "own .acl ⇒ accessTo");
+    assert_eq!(r.governing_acl, Some(NamedNode::new_unchecked("https://pod.ex/d.ttl.acl")));
+    // granted_modes carries the full set in one decision.
+    assert!(r.granted_modes.contains(&Mode::Read) && r.granted_modes.contains(&Mode::Write));
+    assert!(!r.granted_modes.contains(&Mode::Append) && !r.granted_modes.contains(&Mode::Control));
+
+    assert!(allow(&store, Some(ALICE), "https://pod.ex/d.ttl", Mode::Write));
+    // alice was NOT granted Append/Control → authoritative deny (Resolved), not transient.
+    let app = store.decide(&session(Some(ALICE)), "https://pod.ex/d.ttl", Mode::Append);
+    assert!(!app.allow && app.status == AclStatus::Resolved);
+    let ctl = store.decide(&session(Some(ALICE)), "https://pod.ex/d.ttl", Mode::Control);
+    assert!(!ctl.allow && ctl.status == AclStatus::Resolved);
+
+    // bob: no grant at all → deny on every mode, but still Resolved (the ACL governs him).
+    for m in [Mode::Read, Mode::Write, Mode::Append, Mode::Control] {
+        let d = store.decide(&session(Some(BOB)), "https://pod.ex/d.ttl", m);
+        assert!(!d.allow, "bob denied {m:?}");
+        assert_eq!(d.status, AclStatus::Resolved);
+        assert!(d.granted_modes.is_empty());
+    }
+}
+
+// ─── FR-1: agent vs agentGroup vs public vs authenticated ─────────────────────────────
+
+#[test]
+fn decide_subject_kinds() {
+    let mut acl = AclBuilder::new();
+    // public Read on /pub/d.ttl; group Read on /team/d.ttl; authenticated-only Read on
+    // /auth/d.ttl; alice-only Read on /priv/d.ttl — each its own ACL.
+    acl.document("https://pod.ex/pub/d.ttl");
+    acl.access_to("https://pod.ex/pub/d.ttl", |a| a.public().mode(Mode::Read));
+    acl.document("https://pod.ex/team/d.ttl");
+    acl.access_to("https://pod.ex/team/d.ttl", |a| a.agent_group(TEAM, &[CAROL, BOB]).mode(Mode::Read));
+    acl.document("https://pod.ex/auth/d.ttl");
+    acl.access_to("https://pod.ex/auth/d.ttl", |a| a.authenticated().mode(Mode::Read));
+    acl.document("https://pod.ex/priv/d.ttl");
+    acl.access_to("https://pod.ex/priv/d.ttl", |a| a.agent(ALICE).mode(Mode::Read));
+    let store = store(acl);
+
+    let r = Mode::Read;
+    // PUBLIC: anonymous + any agent.
+    assert!(allow(&store, None, "https://pod.ex/pub/d.ttl", r));
+    assert!(allow(&store, Some(DAVE), "https://pod.ex/pub/d.ttl", r));
+    // GROUP: carol + bob yes; dave (non-member) no.
+    assert!(allow(&store, Some(CAROL), "https://pod.ex/team/d.ttl", r));
+    assert!(allow(&store, Some(BOB), "https://pod.ex/team/d.ttl", r));
+    assert!(!allow(&store, Some(DAVE), "https://pod.ex/team/d.ttl", r));
+    // AUTHENTICATED: any logged-in agent yes; anonymous no.
+    assert!(allow(&store, Some(DAVE), "https://pod.ex/auth/d.ttl", r));
+    assert!(!allow(&store, None, "https://pod.ex/auth/d.ttl", r));
+    // AGENT: alice yes; bob no.
+    assert!(allow(&store, Some(ALICE), "https://pod.ex/priv/d.ttl", r));
+    assert!(!allow(&store, Some(BOB), "https://pod.ex/priv/d.ttl", r));
+}
+
+// ─── FR-7: accessTo vs default scope; nearest-ancestor discovery ──────────────────────
+
+#[test]
+fn decide_scope_access_to_vs_default() {
+    // Root .acl grants alice Read by acl:default (members inherit). A deep doc n1 has NO
+    // own ACL → inherits with Default scope. A sibling doc WITH its own ACL → AccessTo.
+    let mut acl = AclBuilder::new();
+    acl.document("https://pod.ex/notes/n1.ttl");
+    acl.document("https://pod.ex/notes/own.ttl");
+    acl.default_for("https://pod.ex/", |a| a.agent(ALICE).mode(Mode::Read));
+    acl.access_to("https://pod.ex/notes/own.ttl", |a| a.agent(BOB).mode(Mode::Read));
+    let store = store(acl);
+
+    // n1: inherited from the root .acl → Default scope.
+    let n1 = store.decide(&session(Some(ALICE)), "https://pod.ex/notes/n1.ttl", Mode::Read);
+    assert!(n1.allow);
+    assert_eq!(n1.scope, Some(AclScope::Default));
+    assert_eq!(n1.governing_acl, Some(NamedNode::new_unchecked("https://pod.ex/.acl")));
+
+    // own.ttl: its OWN .acl governs → AccessTo scope, and only bob (alice's default does
+    // NOT leak in — nearest-ACL semantics shadow the ancestor grant).
+    let eff = store.resolve_acl("https://pod.ex/notes/own.ttl").expect("own acl");
+    assert_eq!(eff.scope, AclScope::AccessTo);
+    assert_eq!(eff.acl.as_str(), "https://pod.ex/notes/own.ttl.acl");
+    assert!(allow(&store, Some(BOB), "https://pod.ex/notes/own.ttl", Mode::Read));
+    let alice_on_own = store.decide(&session(Some(ALICE)), "https://pod.ex/notes/own.ttl", Mode::Read);
+    assert!(!alice_on_own.allow, "nearest-ACL shadows the root acl:default grant");
+    assert_eq!(alice_on_own.status, AclStatus::Resolved);
+
+    // The /notes/ container is a MEMBER of / , so the root's acl:default <pod.ex/> DOES
+    // grant it (inherited) — Default scope, governed by the root .acl. The ROOT container
+    // itself is NOT a member of itself, so acl:default does not grant accessTo on it →
+    // deny, while its own .acl is still surfaced (AccessTo discovery scope).
+    let notes = store.decide(&session(Some(ALICE)), "https://pod.ex/notes/", Mode::Read);
+    assert!(notes.allow, "/notes/ is a member of / → inherited grant");
+    assert_eq!(notes.scope, Some(AclScope::Default));
+    let root = store.decide(&session(Some(ALICE)), "https://pod.ex/", Mode::Read);
+    assert!(!root.allow, "acl:default does not grant accessTo on the container it targets");
+    assert_eq!(root.scope, Some(AclScope::AccessTo), "root's own .acl governs it directly");
+}
+
+#[test]
+fn resolve_acl_nearest_ancestor_one_call() {
+    // doc → /a/b/ → /a/ → / : only /a/ has an ACL → /a/.acl governs by default.
+    let mut acl = AclBuilder::new();
+    acl.document("https://pod.ex/a/b/doc.ttl");
+    acl.default_for("https://pod.ex/a/", |a| a.public().mode(Mode::Read));
+    let store = store(acl);
+    let eff = store.resolve_acl("https://pod.ex/a/b/doc.ttl").expect("inherited");
+    assert_eq!(eff.acl.as_str(), "https://pod.ex/a/.acl");
+    assert_eq!(eff.scope, AclScope::Default);
+}
+
+// ─── FR-6: the fail-closed load/error contract (the security core) ────────────────────
+
+#[test]
+fn fail_closed_absent_acl_is_denied_noacl() {
+    // A resource with NO ACL anywhere in its chain: deny + NoAcl (definitive 403), and
+    // CRUCIALLY not an allow. The auth view IS materialized — the absence is structural.
+    let mut acl = AclBuilder::new();
+    acl.document("https://pod.ex/open.ttl"); // a doc, but zero authorizations anywhere
+    let store = store(acl);
+    let d = store.decide(&session(Some(ALICE)), "https://pod.ex/open.ttl", Mode::Read);
+    assert!(!d.allow, "ABSENT acl ⇒ DENIED, never allowed");
+    assert_eq!(d.status, AclStatus::NoAcl);
+    assert!(!d.status.is_retryable(), "absent acl is a definitive deny");
+    assert!(d.governing_acl.is_none());
+    assert!(store.resolve_acl("https://pod.ex/open.ttl").is_none());
+}
+
+#[test]
+fn fail_closed_present_but_unloaded_is_denied_unloaded() {
+    // The ACL document is PRESENT in the dataset, but materialize_* was NEVER run, so no
+    // verdict can be computed → deny + Unloaded (retryable 503), never allow.
+    let mut acl = AclBuilder::new();
+    acl.document("https://pod.ex/d.ttl");
+    acl.access_to("https://pod.ex/d.ttl", |a| a.agent(ALICE).mode(Mode::Read));
+    let g = Graph::load_dataset(&acl.into_nquads(), "nquads").expect("loads");
+    let store = PodStore::new(g); // NOTE: no materialize_wac()
+    let d = store.decide(&session(Some(ALICE)), "https://pod.ex/d.ttl", Mode::Read);
+    assert!(!d.allow, "present-but-UNLOADED ⇒ DENIED, never allowed");
+    assert_eq!(d.status, AclStatus::Unloaded);
+    assert!(d.status.is_retryable(), "unloaded is a retryable 503, not a permission denial");
+    // The governing ACL is still discovered (for the Link: rel=acl surface / a 503 body).
+    assert_eq!(d.governing_acl, Some(NamedNode::new_unchecked("https://pod.ex/d.ttl.acl")));
+}
+
+#[test]
+fn fail_closed_transient_on_malformed_resource_iri() {
+    let mut acl = AclBuilder::new();
+    acl.document("https://pod.ex/d.ttl");
+    acl.access_to("https://pod.ex/d.ttl", |a| a.public().mode(Mode::Read));
+    let store = store(acl);
+    let d = store.decide(&session(Some(ALICE)), "this is not an iri", Mode::Read);
+    assert!(!d.allow, "malformed resource IRI ⇒ DENIED, never allowed");
+    assert_eq!(d.status, AclStatus::Transient);
+    assert!(d.status.is_retryable());
+    assert!(d.governing_acl.is_none());
+}
+
+#[test]
+fn fail_closed_reserved_encoding_session_value() {
+    // A session whose "WebID" is itself in the reserved minted-principal space must never
+    // match a grant (it could otherwise impersonate a minted pair). decide must fail closed
+    // even when the ACL/material view exists — the reserved value invalidates the WHOLE
+    // session (accessible returns empty), so even Public is not reachable for it.
+    let mut acl = AclBuilder::new();
+    acl.document("https://pod.ex/d.ttl");
+    acl.access_to("https://pod.ex/d.ttl", |a| a.public().mode(Mode::Read));
+    let store = store(acl);
+    let forged = Session {
+        agent: Some("urn:sparq:pair?agent=x&client=y"),
+        client: None,
+        issuer: None,
+        now: None,
+    };
+    let d = store.decide(&forged, "https://pod.ex/d.ttl", Mode::Read);
+    assert!(!d.allow, "reserved-encoding session value ⇒ fail-closed deny");
+}
+
+// ─── FR-1: decide_batch is a per-element independent, fail-closed decision ────────────
+
+#[test]
+fn decide_batch_independent_decisions() {
+    let mut acl = AclBuilder::new();
+    acl.document("https://pod.ex/pub.ttl");
+    acl.access_to("https://pod.ex/pub.ttl", |a| a.public().mode(Mode::Read));
+    acl.document("https://pod.ex/priv.ttl");
+    acl.access_to("https://pod.ex/priv.ttl", |a| a.agent(ALICE).mode(Mode::Read));
+    let store = store(acl);
+
+    let bob = session(Some(BOB));
+    let reqs: &[(&str, Mode)] = &[
+        ("https://pod.ex/pub.ttl", Mode::Read),     // public → allow
+        ("https://pod.ex/priv.ttl", Mode::Read),    // alice-only, bob → deny (Resolved)
+        ("https://pod.ex/missing.ttl", Mode::Read), // no ACL → deny (NoAcl)
+        ("https://pod.ex/pub.ttl", Mode::Write),    // public has only Read → deny
+    ];
+    let out = store.decide_batch(&bob, reqs);
+    assert_eq!(out.len(), 4, "result is parallel to input");
+    assert!(out[0].allow && out[0].status == AclStatus::Resolved);
+    assert!(!out[1].allow && out[1].status == AclStatus::Resolved);
+    assert!(!out[2].allow && out[2].status == AclStatus::NoAcl);
+    assert!(!out[3].allow && out[3].status == AclStatus::Resolved);
+
+    // The batch result must equal calling decide() one-by-one (no cross-talk).
+    for (i, (res, mode)) in reqs.iter().enumerate() {
+        assert_eq!(store.decide(&bob, res, *mode), out[i], "batch == singletons at {i}");
+    }
+}
+
+// ─── Equivalence: decide's verdict matches the accessible() oracle (no widening) ──────
+
+#[test]
+fn decide_verdict_matches_accessible_oracle() {
+    // decide() must never grant more than accessible()/query_as would. Cross-check the
+    // verdict against the graph-filtering oracle for every (session, mode) on a resource
+    // the oracle CAN see.
+    let mut acl = AclBuilder::new();
+    acl.document("https://pod.ex/notes/n1.ttl");
+    acl.default_for("https://pod.ex/", |a| a.agent(ALICE).mode(Mode::Read).mode(Mode::Write));
+    let mut s = store(acl);
+
+    let resource = "https://pod.ex/notes/n1.ttl";
+    let res_node = NamedNode::new_unchecked(resource);
+    for agent in [Some(ALICE), Some(BOB), None] {
+        for mode in [Mode::Read, Mode::Write, Mode::Append, Mode::Control] {
+            let sess = session(agent);
+            let oracle = s.accessible(&sess, mode).contains(&res_node);
+            let decided = s.decide(&sess, resource, mode).allow;
+            assert_eq!(decided, oracle, "decide != accessible for {agent:?}/{mode:?}");
+        }
+    }
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -124,6 +124,37 @@ Materialize the authorization view from the access-control documents, then enfor
   (`user="…",public="…"`) advertising the modes the session (and the public) hold on a
   resource ([OPUS-4.8] sq-i7k08); fail-closed, only the modes actually held. See the
   request-pipeline section below.
+- `store.decide(&Session, resource: &str, Mode) -> WacDecision` /
+  `decide_batch(&Session, &[(&str, Mode)]) -> Vec<WacDecision>` — **per-REQUEST WAC
+  decision** ([OPUS-4.8] issue #992 FR-1, sq-snopa.1): the point-query *"may principal X do
+  mode M on resource R?"* an LDP resource server asks (NOT graph filtering). Returns
+  `WacDecision { allow, granted_modes: Vec<Mode>, governing_acl: Option<NamedNode>, scope:
+  Option<AclScope>, status: AclStatus }`. The verdict reuses the SAME fail-closed
+  `AuthIndex::accessible` oracle, so a `decide` allow is never wider than `query_as` would
+  grant; `granted_modes` carries the full mode set in one decision (build a `WAC-Allow`
+  body without four sweeps). `decide_batch` builds the structural ACL index ONCE for a page
+  of resources. Always-present API (no cargo gate; mirrors `wac_allow`).
+- `AclStatus` — the **typed fail-closed load/error contract** (FR-6, sq-snopa.2): a server
+  maps `Resolved` (authoritative — `allow` is the real verdict; a deny is **403**), `NoAcl`
+  (no governing ACL anywhere up the chain — definitive **403/401**), `Unloaded` (a governing
+  ACL exists but `materialize_*` was never run — a **retryable 503**), and `Transient`
+  (a typed transient error, e.g. a malformed resource IRI — a **retryable 503**).
+  `AclStatus::is_retryable()` separates the 503s from the definitive denies. **It never
+  fails OPEN:** `allow == false` for every non-`Resolved` status, independent of whether the
+  caller inspects `status` — absent ⇒ deny, present-but-unloaded ⇒ deny, transient ⇒ deny.
+- `store.resolve_acl(resource: &str) -> Option<EffectiveAcl>` — **ACL-discovery walk in ONE
+  indexed call** (FR-7, sq-snopa.3): the up-the-container-chain `.acl`/`.acr` discovery +
+  `acl:default` inheritance, returning `EffectiveAcl { acl: NamedNode, scope: AclScope }` —
+  `AccessTo` when the resource has its OWN ACL, `Default` when it inherits from the nearest
+  ancestor container — instead of N round-trips. The walk is exactly the loader's
+  slash-semantics `parent_iri` chain, so per-resource discovery and the materialize-time
+  inheritance can never disagree; `None` ⇒ un-protected ⇒ fail closed. Feeds `decide`'s
+  `governing_acl`/`scope` (and FR-5 provenance later). **Honest scope:** Phase-1 implements
+  the WAC `accessTo` + container-`default` subset of [issue #992](https://github.com/jeswr/sparq/issues/992)
+  (FR-1/6/7) — the per-resource decision + fail-closed contract + ACL walk; it is NOT the
+  full WAC HTTP surface (FR-4's `POST /authz/*` on `sparq-server` is the separate sq-snopa.6
+  architecture call), and the `decide` `scope` is the ACL-*document* discovery scope, while
+  whether a grant within that ACL applies is the verdict the oracle computes.
 - `store.materialize_odrl_permission(&Policy, &Request) -> BridgeOutcome` — **opt-in**
   (`odrl-bridge` feature, OFF by default; [OPUS-4.8] sq-h3uk): run the `sparq-policy` ODRL
   evaluator and, on a *definite Permit*, materialize the equivalent `principal auth:<mode>


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Opus 4.8). Implementing issue #992 Phase-1 (FR-1/6/7) for the experimental Rust Solid server (jeswr/solid-server-rs): the SPARQ-native per-resource WAC **decision** layer. Beads sq-snopa.1/.2/.3, implemented together as one cohesive PR (they are interdependent).

## What this implements

Where `sparq-solid` today filters *graphs* (the authorization oracle: `accessible` / `query_as` / `update_as`), an LDP resource server needs a per-REQUEST decision. This adds it, building ON the existing machinery (no new dependency):

- **FR-1 (sq-snopa.1)** — `PodStore::decide(principal, resource_iri, mode) -> WacDecision` + `decide_batch(...)`. `WacDecision { allow, granted_modes, governing_acl, scope, status }` answers *"may agent X do mode M on resource R?"* — NOT graph filtering. The verdict **reuses the existing fail-closed `AuthIndex::accessible` oracle** (the same `∪ allow ∖ ∪ deny` per-mode set), so a `decide` allow can never be wider than `query_as` grants. `granted_modes` carries the full set in one decision; `decide_batch` builds the structural index once for a page of resources.
- **FR-6 (sq-snopa.2)** — the typed fail-closed load/error contract `AclStatus`: `Resolved` (authoritative; a deny here is a definitive 403), `NoAcl` (absent ⇒ definitive 401/403), `Unloaded` (governing ACL present but `materialize_*` never run ⇒ retryable 503), `Transient` (typed transient error, e.g. malformed resource IRI ⇒ retryable 503). `is_retryable()` separates the 503s. **It never fails OPEN:** `allow == false` for every non-`Resolved` status, independent of whether the caller inspects `status` — carrying over PSS's hard-won fail-open lessons (default-deny on every error path).
- **FR-7 (sq-snopa.3)** — `PodStore::resolve_acl(resource_iri) -> Option<EffectiveAcl>` does the up-the-container-chain `.acl`/`.acr` discovery + `acl:default` inheritance in **ONE indexed call** (not N round-trips), returning the governing ACL IRI + `accessTo`-vs-`default` scope. The walk is exactly the loader's slash-semantics `parent_iri` chain, so per-resource discovery and the materialize-time inheritance can never disagree. Feeds FR-1's `governing_acl`/`scope` (and FR-5 later).

## Placement (architecture)

Mirrors `wac_allow` — an **always-present public API with NO cargo gate** (per #1154): it adds **zero dependencies** (reuses `AuthIndex` + the loader's container walk + `oxrdf` only), so sparq-core/engine stay lean and **no `sparq-server` dep is introduced** (FR-4's HTTP `POST /authz/*` surface is the separate **sq-snopa.6** maintainer architecture call — out of scope here).

## Tests (security-critical authz — REAL path, no mock bypass)

`crates/sparq-solid/tests/decide.rs` + in-module unit tests drive the soundness cases through the **real materialize → `AuthIndex::accessible` path**:
- allow/deny per mode (Read/Write/Append/Control);
- agent vs agentGroup vs public vs authenticated;
- `accessTo` vs `default` scope + nearest-ancestor discovery (deep container shadows the root);
- the fail-closed paths: **ABSENT** acl ⇒ deny+`NoAcl` (not allowed); **present-but-UNLOADED** ⇒ deny+`Unloaded`; **transient** (malformed IRI) ⇒ deny+`Transient`; reserved-encoding session value ⇒ deny;
- `decide` == `accessible` equivalence (no widening); `decide_batch` == singletons.

## Honest scope (no overclaim)

Phase-1 is the WAC `accessTo` + container-`default` **subset** of #992 (FR-1/6/7) — the decision + fail-closed contract + ACL walk. It is **NOT** the full WAC HTTP surface (no HTTP/LDP here), and `decide`'s `scope` is the ACL-*document* discovery scope, while whether a grant within that ACL applies is the verdict the oracle computes.

## Gates (GREEN in BOTH feature states)

Feature flags: **default (all new code OFF-cargo-gate, always present)** AND the opt-in **`odrl-bridge`** / **`count-enforcement`** ON.
- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo test` — green in default + `odrl-bridge` + `count-enforcement` (+ `trust-graph` build).
- `cargo doc --workspace --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` — clean (public doc-comments link no private/`pub(crate)` item).
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations (README ≤120 lines); `scripts/check-privacy-claims.sh` — clean; no hard-coded perf numbers.
- New tests are NOT cfg-gated (always-present API), so ci.yml's default-feature archive runs them — no new `feature-matrix.yml` leg needed.

Closes sq-snopa.1, sq-snopa.2, sq-snopa.3. Refs #992 (FR-1/6/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)