### PR TITLE
docs(book): single-source the capabilities link-list from README via a link-rewriting preprocessor (sq-g4h0c) [OPUS-4.8]

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -32,21 +32,26 @@
 name: docs
 
 on:
-  # [OPUS-4.8] sq-5f1s4 / sq-im8u — self-guarding path filter: the build embeds source it does
-  # NOT live next to. `book/src/getting-started/install.md` does
-  # `{{#rustdoc_include ../../../crates/sparq-engine/examples/quickstart.rs:quickstart}}`, and
+  # [OPUS-4.8] sq-5f1s4 / sq-im8u / sq-g4h0c — self-guarding path filter: the build embeds
+  # source it does NOT live next to. `book/src/getting-started/install.md` does
+  # `{{#rustdoc_include ../../../crates/sparq-engine/examples/quickstart.rs:quickstart}}`;
   # (as of sq-im8u) the guide pages `{{#include}}` canonical prose from `README.md`
   # (`lead`/`quickstart-cli` anchors) and `skills/{zk-query-proofs,mpc}/SKILL.md`
-  # (`scaffold-caveat` anchors). `mdbook build`/`mdbook test` resolve those anchors, so if an
-  # anchor were renamed/removed (or the included example stopped compiling) and the filter only
-  # watched `book/**`, the break would land on main undetected — no `book/`-touching commit
-  # would re-run this lane to catch it (the gui.yml/#1081 blind-spot class). So every embedded
-  # source is listed too. (mdBook EXITs 0 on a broken include — the build step greps the log
-  # for `[ERROR]` — so re-running THIS lane on a source edit is the only thing that catches it.)
+  # (`scaffold-caveat` anchors); and (as of sq-g4h0c) `capabilities.md` `{{#include}}`s the
+  # README `features-core`/`interfaces` anchors, whose repo-relative links are then rewritten by
+  # the `link-fixup` preprocessor `scripts/mdbook-rewrite-links.py` (wired in book.toml).
+  # `mdbook build`/`mdbook test` resolve every anchor AND run the preprocessor, so if an anchor
+  # were renamed/removed (or the example stopped compiling, or the preprocessor regressed) and
+  # the filter only watched `book/**`, the break would land on main undetected — no
+  # `book/`-touching commit would re-run this lane to catch it (the gui.yml/#1081 blind-spot
+  # class). So every embedded source AND the preprocessor are listed too. (mdBook EXITs 0 on a
+  # broken include — the build step greps the log for `[ERROR]` — so re-running THIS lane on a
+  # source/preprocessor edit is the only thing that catches it.)
   push:
     branches: [main]
     paths:
       - "book/**"
+      - "scripts/mdbook-rewrite-links.py"
       - "crates/sparq-engine/examples/quickstart.rs"
       - "README.md"
       - "skills/zk-query-proofs/SKILL.md"
@@ -55,6 +60,7 @@ on:
   pull_request:
     paths:
       - "book/**"
+      - "scripts/mdbook-rewrite-links.py"
       - "crates/sparq-engine/examples/quickstart.rs"
       - "README.md"
       - "skills/zk-query-proofs/SKILL.md"

--- a/README.md
+++ b/README.md
@@ -77,6 +77,17 @@ The engine **core** is always built; every other capability is an opt-in crate t
 does not depend on (so it stays lean — enforced in CI). Each capability links its how-to and the
 standard it implements.
 
+<!-- sq-g4h0c: the `features-core` anchor below is the SINGLE SOURCE for the docs guide's
+     "Capabilities at a glance" list — it is {{#include}}d into
+     book/src/getting-started/capabilities.md. Keep the per-surface `skills/<x>/SKILL.md`
+     links REPO-RELATIVE (the lychee internal-links gate requires that); the book's
+     `link-fixup` preprocessor (scripts/mdbook-rewrite-links.py) rewrites them to portable
+     github.com/jeswr/sparq/blob/main URLs at build time. The two research-scaffold bullets
+     (ZK / MPC) and the Interfaces bullet are intentionally OUTSIDE this anchor: the book
+     expands them from their own canonical anchors (the SKILL.md `scaffold-caveat` includes
+     for the load-bearing honesty caveats, and the `interfaces` anchor below). Keep the
+     ANCHOR/ANCHOR_END markers one-per-line. [OPUS-4.8] -->
+<!-- ANCHOR: features-core -->
 - **SPARQL query** — run [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) and
   [1.2](https://www.w3.org/TR/sparql12-query/) over your data
   ([guide](skills/sparql-query/SKILL.md)).
@@ -112,6 +123,7 @@ standard it implements.
 - **RDF Dataset Canonicalization** — deterministic, blank-node-relabelled canonical form for
   hashing/signing/diffing with [RDFC-1.0](https://www.w3.org/TR/rdf-canon/)
   ([guide](skills/rdf-canon/SKILL.md)).
+<!-- ANCHOR_END: features-core -->
 - **Zero-knowledge query proofs** *(research scaffold — NOT yet sound)* — model proving a query
   result is correct without revealing the data ([guide](skills/zk-query-proofs/SKILL.md)). The v1
   verifier provides **no** soundness guarantee to a relying party pending external audit — see the
@@ -119,12 +131,19 @@ standard it implements.
 - **Federated MPC** *(research scaffold — no security guarantee yet)* — model evaluating SPARQL
   across parties with multi-party computation ([guide](skills/mpc/SKILL.md)); honest-majority
   semi-honest, **not** maliciously secure ([SECURITY.md](SECURITY.md)). <!-- privacy-claims-allow: negative caveat ("not maliciously secure"); sq-toze.35 -->
+<!-- sq-g4h0c: the `interfaces` anchor is the SINGLE SOURCE for the docs guide's
+     "Interfaces" line (book/src/getting-started/capabilities.md {{#include}}s it). Repo-
+     relative `skills/<x>/SKILL.md` links are kept for the lychee gate and rewritten to
+     portable URLs by the book's `link-fixup` preprocessor. Keep the markers one-per-line.
+     [OPUS-4.8] -->
+<!-- ANCHOR: interfaces -->
 - **Interfaces** — a [CLI](skills/cli/SKILL.md), a
   [SPARQL 1.1 Protocol](https://www.w3.org/TR/sparql11-protocol/) +
   [Graph Store HTTP Protocol](https://www.w3.org/TR/sparql11-http-rdf-update/)
   [HTTP server](skills/http-server/SKILL.md), a WebAssembly /
   [JavaScript build](skills/javascript-wasm/SKILL.md), and a
   [Python package](skills/python/SKILL.md).
+<!-- ANCHOR_END: interfaces -->
 
 > Agent skills — how to use sparq from Claude Code and other AI agents — are
 > in the [usage-skills router](skills/SKILL.md).

--- a/book/book.toml
+++ b/book/book.toml
@@ -1,13 +1,14 @@
-# [OPUS-4.8] sq-h0tr / sq-im8u — mdBook guide scaffold for the sparq docs site.
+# [OPUS-4.8] sq-h0tr / sq-im8u / sq-g4h0c — mdBook guide scaffold for the sparq docs site.
 #
 # Scaffold (book.toml + SUMMARY.md + the content pages) from sq-h0tr; as of sq-im8u
 # the content pages are thin {{#include}} wrappers that single-source their prose
 # (build-time content injection) from the canonical README.md / skills/<surface>/SKILL.md
 # `ANCHOR` regions, so the guide cannot drift from the source of truth. Tested-example
 # {{#rustdoc_include}} embedding (the library snippet) is sq-384j. The only original
-# prose left in book/src is SUMMARY.md + one-line section intros; the capability
-# link-TABLE keeps mount-portable absolute URLs (see capabilities.md header for why it
-# is not included from the README's repo-relative Features list).
+# prose left in book/src is SUMMARY.md + one-line section intros; as of sq-g4h0c even the
+# capability link-list + interfaces line are {{#include}}d from the README's Features
+# anchors — see the `link-fixup` preprocessor below for how their repo-relative links
+# (kept that way for the lychee gate) are made mount-portable at build time.
 #
 # Reproducible build (CI pins the exact mdbook version — see .github/workflows/docs.yml):
 #   mdbook build book      # → book/book/ (the rendered site)
@@ -25,6 +26,18 @@ build-dir = "book"
 # mdBook EXITS 0 even on a broken {{#include}}/anchor (rust-lang/mdBook#1094), so
 # the CI workflow greps the build log for "[ERROR]" in addition to this flag.
 create-missing = false
+
+# [OPUS-4.8] sq-g4h0c — repo-relative → mount-portable link rewriting at build time.
+# The canonical README.md / SKILL.md keep REPO-RELATIVE per-surface guide links
+# (required by the lychee internal-links gate); when those are {{#include}}d into a
+# chapter, mdBook would resolve them against the page mount and 404 under Pages. This
+# preprocessor rewrites such links to https://github.com/jeswr/sparq/blob/main/... so
+# the single-sourced content renders correctly under the mdBook mount. The command is
+# resolved relative to the dir `mdbook` runs in (the repo root: `mdbook build book`).
+# Run after the built-in `links` preprocessor so it sees the post-{{#include}} text.
+[preprocessor.link-fixup]
+command = "python3 scripts/mdbook-rewrite-links.py"
+after = ["links"]
 
 [output.html]
 # Pages will eventually serve this under /sparq/... (a sub-path of the GitHub

--- a/book/src/getting-started/capabilities.md
+++ b/book/src/getting-started/capabilities.md
@@ -1,22 +1,21 @@
-<!-- [OPUS-4.8] sq-im8u — single-source include wiring. The two research-scaffold
-maturity caveats are {{#include}}d verbatim from their canonical skills/*/SKILL.md
-`scaffold-caveat` anchors (build-time content injection), so they cannot drift and
-their not-yet-audited / not-yet-hardened hedges stay intact at the source (privacy-claims
-gate; sq-toze.35 / sq-qhy4). Do not weaken the included hedges or restate the guarantees
-inline here.
+<!-- [OPUS-4.8] sq-g4h0c — capability link-LIST single-sourced (build-time content
+injection). The list below is {{#include}}d from the README's `features-core` ANCHOR
+and the Interfaces line from the README's `interfaces` ANCHOR — so the docs guide can no
+longer drift from the README. The README keeps those per-surface guides as REPO-RELATIVE
+`skills/<x>/SKILL.md` links (required by the lychee internal-links gate); the book's
+`link-fixup` preprocessor (scripts/mdbook-rewrite-links.py, wired in book.toml) rewrites
+them to mount-portable github.com/jeswr/sparq/blob/main URLs at build time, which is what
+resolves the relative-vs-portable conflict that previously forced a hand-maintained table
+of absolute URLs here.
 
-The capability link-TABLE below and the SPARQL-Update note are deliberately NOT included
-from the README's Features list: the README links per-surface guides with REPO-RELATIVE
-paths (`skills/<x>/SKILL.md`) — required there by the lychee internal-links gate — and
-mdBook rewrites a relative link relative to THIS page's mount, so an included copy would
-resolve to a non-existent `getting-started/skills/...` and 404 under GitHub Pages. The
-table therefore uses mount-portable ABSOLUTE GitHub URLs; it is a navigation matrix
-(mount-point-specific link targets), not duplicated prose. Single-sourcing the table
-itself is tracked as a follow-up (would require a README-side portable-link form the
-lychee gate does not currently permit).
-[OPUS-4.8] sq-tfpq / issue #813 — Update row links SPARQL 1.2 Update alongside 1.1 and a
-short note documents the 1.2 triple-term delta (no new ops); honest scoping kept (engine
-write tests, not a formal conformance run). -->
+[OPUS-4.8] sq-im8u — the two research-scaffold maturity caveats below are {{#include}}d
+verbatim from their canonical skills/*/SKILL.md `scaffold-caveat` anchors, so their
+not-yet-audited / not-yet-hardened hedges stay intact at the source (privacy-claims gate;
+sq-toze.35 / sq-qhy4). Do not weaken the included hedges or restate the guarantees inline.
+
+[OPUS-4.8] sq-tfpq / issue #813 — the SPARQL-Update note documents the 1.2 triple-term
+delta (no new ops); honest scoping kept (engine write tests, not a formal conformance
+run). It is book-only prose (no README counterpart to single-source from). -->
 
 # Capabilities at a glance
 
@@ -24,22 +23,7 @@ The engine core is always built; every capability below is an **opt-in** crate o
 core does not depend on, so the core stays lean. Each links the standard it implements and its
 usage guide.
 
-| Capability | Standard | Guide |
-| --- | --- | --- |
-| SPARQL query | [SPARQL 1.1](https://www.w3.org/TR/sparql11-query/) / [1.2](https://www.w3.org/TR/sparql12-query/) | [sparql-query](https://github.com/jeswr/sparq/blob/main/skills/sparql-query/SKILL.md) |
-| SPARQL Update | [SPARQL 1.1 Update](https://www.w3.org/TR/sparql11-update/) / [1.2](https://www.w3.org/TR/sparql12-update/) | [sparql-query](https://github.com/jeswr/sparq/blob/main/skills/sparql-query/SKILL.md) |
-| RDF parsing & ingest | Turtle / N-Triples / N-Quads / TriG (+ `.gz` / `.bz2` / `.zst`) | [data-formats](https://github.com/jeswr/sparq/blob/main/skills/data-formats/SKILL.md) |
-| RDF 1.2 triple terms | [RDF 1.2 Concepts](https://www.w3.org/TR/rdf12-concepts/) | [sparql-query](https://github.com/jeswr/sparq/blob/main/skills/sparql-query/SKILL.md) |
-| RDFS / OWL-RL / N3 reasoning | [RDFS](https://www.w3.org/TR/rdf-schema/), [OWL 2 RL](https://www.w3.org/TR/owl2-profiles/#OWL_2_RL), [N3](https://w3c.github.io/N3/spec/) | [inference](https://github.com/jeswr/sparq/blob/main/skills/inference/SKILL.md) |
-| SHACL validation | [SHACL](https://www.w3.org/TR/shacl/) | [shacl-validation](https://github.com/jeswr/sparq/blob/main/skills/shacl-validation/SKILL.md) |
-| Full-text search | BM25 over RDF literals | [full-text-search](https://github.com/jeswr/sparq/blob/main/skills/full-text-search/SKILL.md) |
-| GeoSPARQL | [OGC GeoSPARQL](https://www.ogc.org/standard/geosparql/) | [geosparql](https://github.com/jeswr/sparq/blob/main/skills/geosparql/SKILL.md) |
-| Vector & similarity search | embedding nearest-neighbour | [vector-search](https://github.com/jeswr/sparq/blob/main/skills/vector-search/SKILL.md) |
-| GenAI / NL retrieval | schema introspection + grounded NL→SPARQL | [genai-retrieval](https://github.com/jeswr/sparq/blob/main/skills/genai-retrieval/SKILL.md) |
-| HDT archives | [HDT](https://www.w3.org/submissions/HDT/) | [hdt crate](https://github.com/jeswr/sparq/tree/main/crates/sparq-hdt) |
-| RDF stream processing | [RSP-QL](https://www.w3.org/community/rsp/) | [streaming-rsp](https://github.com/jeswr/sparq/blob/main/skills/streaming-rsp/SKILL.md) |
-| Solid access control | [Solid WAC](https://solidproject.org/TR/wac) / [ACP](https://solidproject.org/TR/acp) | [solid crate](https://github.com/jeswr/sparq/tree/main/crates/sparq-solid) |
-| Dataset canonicalization | [RDFC-1.0](https://www.w3.org/TR/rdf-canon/) | [rdf-canon](https://github.com/jeswr/sparq/blob/main/skills/rdf-canon/SKILL.md) |
+{{#include ../../../README.md:features-core}}
 
 ## A note on SPARQL Update 1.1 vs 1.2
 
@@ -78,8 +62,4 @@ the [mpc guide](https://github.com/jeswr/sparq/blob/main/skills/mpc/SKILL.md), a
 
 ## Interfaces
 
-A [CLI](https://github.com/jeswr/sparq/blob/main/skills/cli/SKILL.md), a
-[SPARQL 1.1 Protocol](https://www.w3.org/TR/sparql11-protocol/) + Graph Store Protocol
-[HTTP server](https://github.com/jeswr/sparq/blob/main/skills/http-server/SKILL.md), a
-[JavaScript / WASM build](https://github.com/jeswr/sparq/blob/main/skills/javascript-wasm/SKILL.md),
-and a [Python package](https://github.com/jeswr/sparq/blob/main/skills/python/SKILL.md).
+{{#include ../../../README.md:interfaces}}

--- a/scripts/mdbook-rewrite-links.py
+++ b/scripts/mdbook-rewrite-links.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] mdBook link-rewriting preprocessor (bead sq-g4h0c).
+#
+# WHY THIS EXISTS — the relative-vs-portable link conflict
+# --------------------------------------------------------
+# The docs guide single-sources its prose from the canonical files (README.md and
+# skills/<surface>/SKILL.md) via mdBook `{{#include}}` (bead sq-im8u). Those source
+# files link the per-surface guides with REPO-RELATIVE paths (e.g. skills/cli/SKILL.md)
+# because the lychee internal-links gate (docs-quality.yml) requires every relative
+# link to resolve on disk. But when mdBook pulls that content into a chapter, it
+# rewrites a relative link RELATIVE TO THE INCLUDING PAGE'S MOUNT — so a copy included
+# into book/src/getting-started/capabilities.md resolves `skills/cli/SKILL.md` to the
+# non-existent `getting-started/skills/cli/SKILL.html` and 404s under GitHub Pages.
+#
+# This preprocessor closes that gap: at book-build time it rewrites repo-relative
+# markdown links in the (already-assembled, post-`{{#include}}`) chapter text to the
+# mount-portable canonical form
+#     https://github.com/jeswr/sparq/blob/main/<path>
+# so the SAME content renders correctly under BOTH mounts (raw GitHub view of the
+# source file AND the mdBook site) WITHOUT the source files having to carry absolute
+# URLs that the lychee gate cannot offline-resolve. Single source of truth stays in
+# README.md / SKILL.md with their lychee-friendly relative links; the book gets
+# portable links for free. Resolves bead sq-g4h0c, option (a).
+#
+# CONTRACT (mdBook preprocessor protocol — https://rust-lang.github.io/mdBook/):
+#   * `mdbook-rewrite-links.py supports <renderer>` — exit 0 (we support every
+#     renderer; we only touch chapter markdown, never renderer internals).
+#   * otherwise: read a JSON `[context, book]` array on stdin, walk every Chapter's
+#     `content`, rewrite links, and write the mutated `book` object to stdout.
+#
+# SCOPE OF THE REWRITE (deliberately narrow — leave everything else untouched):
+#   * ONLY inline-markdown link targets `[text](target)` and `[ref]: target`
+#     reference definitions whose target is a REPO-RELATIVE path (no scheme, not
+#     starting with `/`, `#`, `mailto:`, etc.) that points at a tracked repo file —
+#     i.e. begins with one of the allow-listed top-level prefixes below, or is a
+#     bare root-level `*.md` (README.md, AGENTS.md, SECURITY.md, ...).
+#   * Anchor-only (`#frag`), absolute-URL (`http(s)://`, `//`), root-absolute (`/x`),
+#     and `mailto:`/`tel:` targets are left exactly as-is.
+#   * A trailing `#fragment` on a rewritten path is preserved.
+#   * Links INSIDE fenced/indented code blocks and inline-code spans are NOT rewritten
+#     (a `[x](y)` printed inside ``` ``` ``` is code, not a link).
+#
+# Idempotent (re-running over already-absolute links is a no-op) and dependency-free
+# (stdlib only — runs in CI with the same python3 the other docs gates use).
+
+import json
+import re
+import sys
+
+GITHUB_BLOB_BASE = "https://github.com/jeswr/sparq/blob/main/"
+
+# Repo-relative targets we rewrite: a path under one of these tracked top-level dirs,
+# or a bare root-level *.md file. Kept explicit (not "any relative path") so we never
+# rewrite an intra-book chapter link like `./getting-started/install.md`.
+_DIR_PREFIXES = ("skills/", "crates/", "docs/", "research/", "bench/", "vendor/", "compliance/", "assets/")
+_ROOT_MD = re.compile(r"[A-Z][A-Za-z0-9_.-]*\.md\Z")  # README.md, AGENTS.md, ... (root-level)
+
+# An mdBook chapter is plain markdown. Match the link TARGET inside:
+#   inline:    [text](TARGET)            and [text](TARGET "title")
+#   reference: [label]: TARGET           (at line start, optional title)
+# We only capture the target run (no spaces, no `)` ) and rewrite it in place.
+_INLINE = re.compile(r"(\]\()([^)\s]+)([)\s])")
+_REFDEF = re.compile(r"(?m)^(\s*\[[^\]]+\]:\s+)(\S+)(.*)$")
+
+
+def _is_repo_relative(target: str) -> bool:
+    # Strip a trailing #fragment for the prefix test; fragments are re-attached later.
+    path = target.split("#", 1)[0]
+    if not path:
+        return False  # pure `#anchor`
+    # Reject anything that already has a scheme / is protocol-relative / root-absolute.
+    if "://" in target or target.startswith(("/", "#", "mailto:", "tel:", "//")):
+        return False
+    if path.startswith("./") or path.startswith("../"):
+        # Intra-book navigation between chapters — mdBook resolves these correctly.
+        return False
+    if path.startswith(_DIR_PREFIXES):
+        return True
+    return bool(_ROOT_MD.match(path))
+
+
+def _rewrite_target(target: str) -> str:
+    if not _is_repo_relative(target):
+        return target
+    if "#" in target:
+        path, frag = target.split("#", 1)
+        return f"{GITHUB_BLOB_BASE}{path}#{frag}"
+    return f"{GITHUB_BLOB_BASE}{target}"
+
+
+# Mask fenced code blocks (```...``` / ~~~...~~~) and inline code spans (`...`) so we
+# never rewrite a link that is actually printed as code, then restore them verbatim.
+_FENCE = re.compile(r"(?ms)^(`{3,}|~{3,}).*?^\1[ \t]*$")
+_INLINE_CODE = re.compile(r"`[^`\n]*`")
+
+
+def _mask(text: str):
+    store = []
+
+    def stash(m):
+        store.append(m.group(0))
+        return f"\x00{len(store) - 1}\x00"
+
+    masked = _FENCE.sub(stash, text)
+    masked = _INLINE_CODE.sub(stash, masked)
+    return masked, store
+
+
+def _unmask(text: str, store) -> str:
+    return re.sub(r"\x00(\d+)\x00", lambda m: store[int(m.group(1))], text)
+
+
+def rewrite_content(content: str) -> str:
+    masked, store = _mask(content)
+    masked = _INLINE.sub(lambda m: m.group(1) + _rewrite_target(m.group(2)) + m.group(3), masked)
+    masked = _REFDEF.sub(lambda m: m.group(1) + _rewrite_target(m.group(2)) + m.group(3), masked)
+    return _unmask(masked, store)
+
+
+def _walk(section) -> None:
+    # A book item is either {"Chapter": {...}} or {"Separator": ...} / {"PartTitle": ...}.
+    chapter = section.get("Chapter") if isinstance(section, dict) else None
+    if chapter is None:
+        return
+    if isinstance(chapter.get("content"), str):
+        chapter["content"] = rewrite_content(chapter["content"])
+    for sub in chapter.get("sub_items", []) or []:
+        _walk(sub)
+
+
+def main() -> int:
+    # `supports <renderer>` handshake: we support all renderers.
+    if len(sys.argv) > 1 and sys.argv[1] == "supports":
+        return 0
+
+    context_and_book = json.load(sys.stdin)
+    # stdin is the 2-element array [context, book]; we mutate and emit `book`.
+    book = context_and_book[1]
+    for section in book.get("sections", []):
+        _walk(section)
+    json.dump(book, sys.stdout)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> 🤖 **SPARQ agent (Opus 4.8).** I am an automated agent working on the docs site. This PR is opened on @jeswr's behalf; I self-identify here per the sub-agent contract.

## What & why (bead sq-g4h0c)

Follow-up to **sq-im8u**, which single-sourced the book's prose but had to **defer** the capability link-TABLE because of a concrete conflict:

- `README.md` links the per-surface guides with **repo-relative** paths (`skills/<x>/SKILL.md`) — **required** by the lychee `internal-links` gate (it offline-resolves every relative link on disk).
- mdBook rewrites a relative link **relative to the including page's mount**, so a `{{#include}}`d copy resolved to a non-existent `getting-started/skills/...` and 404'd under GitHub Pages.

So `capabilities.md` kept a **hand-maintained table of absolute URLs** that could silently drift from the README Features list.

This PR resolves the conflict via the bead's **option (a): a small mdBook link-rewriting preprocessor**, then single-sources the list.

## Changes

| File | Change |
| --- | --- |
| `scripts/mdbook-rewrite-links.py` | **New** mdBook preprocessor. Rewrites repo-relative markdown links (`skills/`, `crates/`, `docs/`, `research/`, root `*.md`, …) in book chapters to mount-portable `https://github.com/jeswr/sparq/blob/main/…` URLs **at build time**. Stdlib-only, idempotent, masks fenced/inline code, leaves intra-book (`./`) and already-absolute links untouched. |
| `book/book.toml` | Wire it as `[preprocessor.link-fixup]`, `after = ["links"]` (so it sees post-`{{#include}}` text). |
| `README.md` | Wrap the Features capability list in a `features-core` ANCHOR and the Interfaces bullet in an `interfaces` ANCHOR. **No link target or prose changed** — links stay repo-relative for lychee; the preprocessor makes them portable on book build. |
| `book/src/getting-started/capabilities.md` | Replace the duplicated hand-built table + interfaces prose with `{{#include}}` of those README anchors. The book can no longer drift from the README. |
| `.github/workflows/docs.yml` | Extend the self-guarding path filter (sq-5f1s4 class) to watch the preprocessor — a preprocessor regression must re-run the docs lane. |

## Honesty (privacy-claims)

The **ZK/MPC research-scaffold caveats stay single-sourced** from their `skills/{zk-query-proofs,mpc}/SKILL.md` `scaffold-caveat` anchors (the sq-im8u mechanism) — the load-bearing not-externally-audited / honest-majority-not-malicious hedges are **untouched** and cannot drift. `check-privacy-claims.sh` clean.

## Design decision (standing rule — no greenlight needed; documented for steer)

The README Features list is a **bulleted list**, not a 3-column table; single-sourcing means the README is the source of truth, so the book now renders the same list (with portable links) instead of a separate table. I picked **option (a)** over (b) a README-side allowlisted-absolute-link form (would weaken the lychee gate) and (c) a shared capability manifest (heavier; the README list is already the canonical human-readable list). The preprocessor generalises to **all** future per-surface guide pages, so the "per-surface guide pages from `skills/SKILL.md`" half of the bead inherits a working link story. Steer issue filed for post-hoc review.

## Gates (all green, run locally)

- `mdbook build book` (0.4.40) — clean, **no `[ERROR]`**; preprocessor verified to rewrite the included links in the rendered HTML (no `getting-started/skills/...` 404s).
- `mdbook test book` — pass.
- `lychee --offline --include-fragments` over README + skills + docs + crates — **0 errors**.
- `check-privacy-claims.sh` — clean (457 files). `markdownlint-cli2` HARD config — **0 errors**. `check-terminology.py`, `check-no-perf-numbers.py` — clean.
- Preprocessor has an inline unit-test matrix (rewrite, skip-absolute, skip-`./`, fenced/inline-code masking, fragment preservation, idempotency) — all pass.

DOC-ONLY. Auto-merge intentionally **OFF**.
