### PR TITLE
fix(sparq-nlq): exact full-prefLabel match precedes token-overlap so a verbatim label never goes ambiguous (sq-26fdp) [OPUS-4.8]

### DIFF
--- a/bench/terse/RESULTS.md
+++ b/bench/terse/RESULTS.md
@@ -73,15 +73,18 @@ arms, so it does not differentiate the levers.)
    behind the cache breakpoint. **Caveat:** the saving sits right at the 20% bar and is
    a **proxy on the input side only**; the verdict is **CONDITIONAL** and must be
    upgraded by the full-session transcript fan-out before unconditional adoption.
-2. **Lever 3 (`V()`) does NOT clear the quality bar** — and this is the load-bearing
-   honest result. `V()` resolves clean prefLabels perfectly (`V("merge discipline")` →
-   the right topic, score 1.0), but on the punctuation-heavy prefLabel
-   `"ZK/MPC claim + circuit discipline"` the lexical linker scores two topics equally
-   on the shared token "discipline" and the soundness envelope **loud-fails as
-   ambiguous** rather than guess. That is the envelope *working* (loud-fail beats
-   silent-wrong), but it means the lever drops `parses`/F1/`resolution_correctness`
-   below arm A on the frozen set, so `recommend_adopt = false`. **`V()` is a
-   convenience for clean-label phrases, not a drop-in replacement for an explicit IRI.**
+2. **Lever 3 (`V()`) resolves verbatim prefLabels; still measure-gated on the rest.**
+   `V()` resolves clean prefLabels perfectly (`V("merge discipline")` → the right topic,
+   score 1.0). The original run loud-failed on the punctuation-heavy prefLabel
+   `"ZK/MPC claim + circuit discipline"`: the lexical linker scored two topics equally on
+   the shared token "discipline" and the soundness envelope **loud-failed as ambiguous**
+   rather than guess. `sq-26fdp` fixed that — the linker now exact-matches a full
+   prefLabel (case/whitespace-normalised, punctuation preserved) **before** token overlap,
+   so a verbatim prefLabel binds at score 1.0 and `resolution_correctness` recovers to 1.0
+   on re-run. The envelope is **unchanged** for genuinely fuzzy phrases (a non-label phrase
+   that merely shares tokens with several concepts still loud-fails — envelope *working*,
+   loud-fail beats silent-wrong). **`V()` is still a convenience that must be checked
+   (echoed IRI + score + confidence), not a blind drop-in for an explicit IRI.**
 3. **The negative stratum behaved correctly in every arm** — absent statuses/topics
    returned the empty answer-set (no manufactured rows), and `V()` over a phrase absent
    from the PKG (`V("Quantum supremacy")`) **loud-failed** rather than mis-binding
@@ -93,10 +96,11 @@ arms, so it does not differentiate the levers.)
   upgrades fidelity from `input-authoring-proxy` to `full-session-transcript`; only then
   can lever 1's CONDITIONAL recommend become unconditional. Tracked as bead `sq-bmpzd`
   (the fidelity design call is GH issue #1173).
-- Lever 3 would need a tightened lexical linker that exact-matches a full prefLabel
-  **before** falling to token overlap (so a verbatim prefLabel never goes ambiguous) — or
-  the vector fallback enabled. Tracked as bead `sq-26fdp`. Until then, lever 3 stays
-  **measure-gated / not-adopted**.
+- Lever 3's verbatim-prefLabel gap is **fixed** (`sq-26fdp`): the lexical linker now
+  exact-matches a full prefLabel **before** falling to token overlap, so a verbatim
+  prefLabel never goes ambiguous; the re-run restores lever-3 `resolution_correctness` to
+  1.0. The vector fallback (for genuinely fuzzy, non-verbatim phrases) remains the separate,
+  opt-in path. Broad lever-3 adoption still rides the full quality/token A/B verdict.
 
 ## Honest caveats (read before citing)
 

--- a/crates/sparq-nlq/src/link.rs
+++ b/crates/sparq-nlq/src/link.rs
@@ -15,7 +15,11 @@
 //!    the common label predicates (`rdfs:label`, `skos:prefLabel`, `schema:name`,
 //!    `foaf:name`, `dc:title`, `dcterms:title`) resolves a mention to candidate
 //!    entities; exact label equality outranks containment, and rarer (higher-IDF) label
-//!    predicates outrank `rdfs:label`.
+//!    predicates outrank `rdfs:label`. **A verbatim full-label hit short-circuits first**
+//!    (`sq-26fdp`): when the WHOLE input is itself an entire label — case/whitespace
+//!    normalised, punctuation preserved — it binds that one entity exactly *before* the
+//!    token n-gram path can split it into shared tokens, so a phrase that IS a `prefLabel`
+//!    (e.g. `"ZK/MPC claim + circuit discipline"`) never goes ambiguous.
 //! 3. **Structural expansion (sparq-sim)** — each linked entity is expanded with its
 //!    top structurally-similar siblings via [`sparq_sim::Sim::most_similar`] (the wiring
 //!    `sq-uw40` calls for), so the model sees a few worked examples of the entity's
@@ -143,6 +147,14 @@ pub struct EntityLinker<'g> {
     sim: Sim<'g>,
     /// lowercased label -> the best (entity, original-label, score) for it.
     labels: BTreeMap<String, (NamedNode, String, f64)>,
+    /// **Whitespace-collapsed**, lowercased full label -> the best (entity, original-label,
+    /// score) for it. Used by the verbatim-phrase exact match (`sq-26fdp`) so a phrase that
+    /// IS an entire label — punctuation and all, e.g. `"ZK/MPC claim + circuit discipline"` —
+    /// resolves at the strongest signal BEFORE the token n-gram path can split it into
+    /// shared tokens and (correctly) loud-fail as ambiguous. A separate index keeps the
+    /// per-mention `labels.get` lookups untouched; this one only normalises interior
+    /// whitespace (it preserves punctuation, so distinct labels never collapse together).
+    norm_labels: BTreeMap<String, (NamedNode, String, f64)>,
     /// lowercased predicate local-name -> (predicate IRI, triple count).
     predicates: BTreeMap<String, (NamedNode, u64)>,
     /// How many similar siblings to attach per linked entity.
@@ -157,10 +169,12 @@ impl<'g> EntityLinker<'g> {
     /// `max_links` bounds the entities and relations rendered into the prompt.
     pub fn build(graph: &'g Graph, expand_k: usize, max_links: usize) -> Self {
         let labels = build_label_index(graph);
+        let norm_labels = build_norm_label_index(&labels);
         let predicates = build_predicate_index(graph);
         EntityLinker {
             sim: Sim::new(graph),
             labels,
+            norm_labels,
             predicates,
             expand_k,
             max_links,
@@ -169,6 +183,18 @@ impl<'g> EntityLinker<'g> {
 
     /// Links `question` to entities and relations in the graph.
     pub fn link(&self, question: &str) -> Linking {
+        // ---- Verbatim-phrase exact match FIRST (sq-26fdp). ----
+        // When the WHOLE input is itself an entire entity label — e.g. a `V("phrase")`
+        // resolution where the phrase is a verbatim `skos:prefLabel` such as
+        // `"ZK/MPC claim + circuit discipline"` — that single entity is the unambiguous
+        // answer at the strongest lexical signal. Otherwise the token n-gram path below
+        // would split the label into shared tokens (`discipline`) and (correctly) loud-fail
+        // as ambiguous, so a phrase that IS an exact label never resolves. This only fires
+        // on a full normalised-label hit, so a genuine multi-concept question (whose whole
+        // text is not a single label) is unaffected and still flows to the token path. The
+        // matched entity still gets the usual structural expansion below.
+        let exact_phrase = self.exact_phrase_entity(question);
+
         let mentions = mentions(question);
 
         // ---- Entity linking: best candidate per mention, exact beats substring. ----
@@ -209,6 +235,13 @@ impl<'g> EntityLinker<'g> {
                 .then(ea.iri.as_str().cmp(eb.iri.as_str()))
         });
         let mut entities: Vec<LinkedEntity> = ranked.into_iter().map(|(e, _)| e).collect();
+        // A verbatim full-label hit (sq-26fdp) is the unambiguous answer: it becomes the
+        // SOLE entity, so a downstream resolver sees no runner-up and binds at full
+        // confidence instead of stalling on the shared-token ambiguity. The matched entity
+        // is still expanded structurally below.
+        if let Some(e) = exact_phrase {
+            entities = vec![e];
+        }
         entities.truncate(self.max_links);
 
         // ---- Structural expansion via sparq-sim (the sq-uw40 wiring). ----
@@ -253,6 +286,28 @@ impl<'g> EntityLinker<'g> {
             entities,
             relations,
         }
+    }
+
+    /// The verbatim-phrase exact match (`sq-26fdp`): if the WHOLE `phrase`, after the same
+    /// case-fold + interior-whitespace collapse applied to every indexed label, equals an
+    /// entire entity label, return that entity as a fully `exact` [`LinkedEntity`] (no
+    /// siblings yet — the caller expands it). `None` when the phrase is not itself a complete
+    /// label, in which case the regular token n-gram path runs. The normalisation preserves
+    /// punctuation, so it tolerates only spacing/case drift and never collapses two distinct
+    /// labels into one.
+    fn exact_phrase_entity(&self, phrase: &str) -> Option<LinkedEntity> {
+        let key = normalise_label(phrase);
+        if key.is_empty() {
+            return None;
+        }
+        let (iri, label, _score) = self.norm_labels.get(&key)?;
+        Some(LinkedEntity {
+            mention: phrase.trim().to_lowercase(),
+            iri: iri.clone(),
+            label: label.clone(),
+            exact: true,
+            similar: Vec::new(),
+        })
     }
 
     /// The best entity for one mention: exact label match wins over substring; among
@@ -344,6 +399,42 @@ fn build_label_index(graph: &Graph) -> BTreeMap<String, (NamedNode, String, f64)
                 _ => {
                     idx.insert(key, candidate);
                 }
+            }
+        }
+    }
+    idx
+}
+
+/// Case/space-normalised form of a label or candidate phrase used for the verbatim-phrase
+/// exact match (`sq-26fdp`): lower-cased, with every maximal run of Unicode whitespace
+/// collapsed to a single ASCII space and the ends trimmed. Punctuation is preserved, so
+/// `"ZK/MPC claim + circuit discipline"` and `" zk/mpc   claim + circuit discipline "`
+/// share a key while two genuinely distinct labels never collapse together.
+fn normalise_label(s: &str) -> String {
+    s.split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// Derives the whitespace-collapsed label index from the per-mention `labels` index. Each
+/// label's [`normalise_label`] key maps to the same best `(entity, original-label, score)`;
+/// on a collision (two distinct labels normalising equal) the higher score wins, else the
+/// lexicographically smaller IRI, keeping it deterministic and order-independent.
+fn build_norm_label_index(
+    labels: &BTreeMap<String, (NamedNode, String, f64)>,
+) -> BTreeMap<String, (NamedNode, String, f64)> {
+    let mut idx: BTreeMap<String, (NamedNode, String, f64)> = BTreeMap::new();
+    for (iri, orig, score) in labels.values() {
+        let key = normalise_label(orig);
+        if key.is_empty() {
+            continue;
+        }
+        match idx.get(&key) {
+            Some((existing_iri, _, existing_score))
+                if (*existing_score, existing_iri.as_str()) >= (*score, iri.as_str()) => {}
+            _ => {
+                idx.insert(key, (iri.clone(), orig.clone(), *score));
             }
         }
     }
@@ -515,6 +606,112 @@ mod tests {
                 .map(|r| r.iri.as_str())
                 .collect::<Vec<_>>()
         );
+    }
+
+    /// The `sq-26fdp` regression graph: two SKOS concepts whose prefLabels share the token
+    /// "discipline"; one prefLabel contains punctuation (`/`, `+`).
+    fn discipline_graph() -> Graph {
+        let ttl = r#"
+            @prefix kb: <https://sparq.dev/ns/pkg/kb#> .
+            @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+            kb:topic-merge-discipline a skos:Concept ; skos:prefLabel "Merge discipline" .
+            kb:topic-zk-discipline a skos:Concept ;
+                skos:prefLabel "ZK/MPC claim + circuit discipline" .
+        "#;
+        Graph::load_str(ttl, "turtle").expect("graph parses")
+    }
+
+    #[test]
+    fn verbatim_preflabel_with_punctuation_resolves_unambiguously() {
+        // Bug sq-26fdp: V("ZK/MPC claim + circuit discipline") is a VERBATIM prefLabel, yet
+        // the token n-gram path scored both discipline topics equally on the shared token
+        // and the phrase went ambiguous. The verbatim-phrase exact match must bind it to the
+        // single right concept, as the SOLE entity (no runner-up to stall on).
+        let g = discipline_graph();
+        let linker = EntityLinker::build(&g, 0, 16);
+        let l = linker.link("ZK/MPC claim + circuit discipline");
+        assert_eq!(
+            l.entities.len(),
+            1,
+            "a verbatim full prefLabel must resolve to exactly one entity, got {:?}",
+            l.entities
+                .iter()
+                .map(|e| e.iri.as_str())
+                .collect::<Vec<_>>()
+        );
+        let e = &l.entities[0];
+        assert_eq!(
+            e.iri.as_str(),
+            "https://sparq.dev/ns/pkg/kb#topic-zk-discipline"
+        );
+        assert!(e.exact, "a full-label hit is exact");
+        assert_eq!(e.label, "ZK/MPC claim + circuit discipline");
+    }
+
+    #[test]
+    fn verbatim_preflabel_match_is_case_and_whitespace_tolerant() {
+        let g = discipline_graph();
+        let linker = EntityLinker::build(&g, 0, 16);
+        // Lower-cased, padded, and with collapsed interior whitespace — still the same label.
+        let l = linker.link("  zk/mpc   claim + circuit DISCIPLINE  ");
+        assert_eq!(
+            l.entities.len(),
+            1,
+            "normalised verbatim label still resolves"
+        );
+        assert_eq!(
+            l.entities[0].iri.as_str(),
+            "https://sparq.dev/ns/pkg/kb#topic-zk-discipline"
+        );
+        assert!(l.entities[0].exact);
+    }
+
+    #[test]
+    fn other_verbatim_preflabel_still_resolves_to_its_own_concept() {
+        // The sibling label "Merge discipline" must still bind to ITS topic, not be dragged
+        // to the zk concept by the shared "discipline" token.
+        let g = discipline_graph();
+        let linker = EntityLinker::build(&g, 0, 16);
+        let l = linker.link("Merge discipline");
+        assert_eq!(l.entities.len(), 1);
+        assert_eq!(
+            l.entities[0].iri.as_str(),
+            "https://sparq.dev/ns/pkg/kb#topic-merge-discipline"
+        );
+        assert!(l.entities[0].exact);
+    }
+
+    #[test]
+    fn non_label_question_is_unaffected_by_verbatim_path() {
+        // A real question whose WHOLE text is not a single label must NOT hit the verbatim
+        // path — it still flows through the token n-gram linker. Here the shared "discipline"
+        // token only substring-matches (never an exact full-label hit), so whatever entity it
+        // surfaces is non-exact: the verbatim short-circuit did not fire.
+        let g = discipline_graph();
+        let linker = EntityLinker::build(&g, 0, 16);
+        let l = linker.link("Which findings are about discipline in general?");
+        assert!(
+            !l.entities.is_empty(),
+            "the token path still links the shared token"
+        );
+        assert!(
+            l.entities.iter().all(|e| !e.exact),
+            "a non-label question must produce only substring (non-exact) links, got {:?}",
+            l.entities
+                .iter()
+                .map(|e| (e.iri.as_str(), e.exact))
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn normalise_label_collapses_whitespace_and_case_keeps_punctuation() {
+        assert_eq!(
+            normalise_label("  ZK/MPC   claim + circuit Discipline "),
+            "zk/mpc claim + circuit discipline"
+        );
+        assert_eq!(normalise_label("Merge\tdiscipline"), "merge discipline");
+        assert_eq!(normalise_label("   "), "");
     }
 
     #[test]

--- a/crates/sparq-terse/src/resolve.rs
+++ b/crates/sparq-terse/src/resolve.rs
@@ -379,4 +379,74 @@ mod tests {
         assert_eq!(r.method, Method::Lexical);
         assert_eq!(r.iri, "http://ex/cat");
     }
+
+    /// End-to-end `V()` resolution (`sq-26fdp`): a verbatim `skos:prefLabel` that shares a
+    /// token with a sibling concept must bind unambiguously at the strongest lexical signal,
+    /// not loud-fail as ambiguous. Exercises the REAL `ResolveCtx::resolve` lexical path.
+    #[cfg(feature = "vectors")]
+    mod verbatim_preflabel {
+        use crate::{Method, ResolveCtx};
+        use sparq_core::Graph;
+
+        fn graph() -> Graph {
+            // Two SKOS concepts sharing the token "discipline"; one prefLabel carries
+            // punctuation (`/`, `+`) — the exact bug-report shape. Two extra concepts
+            // (`alpha thing` / `beta gadget`) give a phrase that substring-matches two
+            // DIFFERENT concepts via two different tokens, i.e. a genuinely ambiguous fuzzy
+            // phrase the gate must still loud-fail on.
+            let ttl = r#"
+                @prefix kb: <https://sparq.dev/ns/pkg/kb#> .
+                @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+                kb:topic-merge-discipline a skos:Concept ; skos:prefLabel "Merge discipline" .
+                kb:topic-zk-discipline a skos:Concept ;
+                    skos:prefLabel "ZK/MPC claim + circuit discipline" .
+                kb:topic-alpha a skos:Concept ; skos:prefLabel "alpha thing" .
+                kb:topic-beta a skos:Concept ; skos:prefLabel "beta gadget" .
+            "#;
+            Graph::load_str(ttl, "turtle").expect("graph parses")
+        }
+
+        #[test]
+        fn verbatim_punctuated_preflabel_binds_at_full_confidence() {
+            let g = graph();
+            let ctx = ResolveCtx::lexical(&g);
+            // Before the fix this loud-failed AMBIGUOUS on the shared "discipline" token.
+            let res = ctx
+                .resolve("ZK/MPC claim + circuit discipline", None)
+                .expect("a verbatim prefLabel must resolve, not loud-fail");
+            assert_eq!(res.iri, "https://sparq.dev/ns/pkg/kb#topic-zk-discipline");
+            assert_eq!(res.method, Method::Lexical);
+            assert_eq!(res.score, 1.0, "an exact full-label hit is the strongest signal");
+            assert!(res.runner_up.is_none(), "the verbatim hit is the sole candidate");
+            assert_eq!(res.confidence, 1.0, "no runner-up => full confidence");
+        }
+
+        #[test]
+        fn sibling_verbatim_preflabel_still_resolves_to_its_own_concept() {
+            // The pre-existing working case stays working: "Merge discipline" -> its topic.
+            let g = graph();
+            let ctx = ResolveCtx::lexical(&g);
+            let res = ctx.resolve("Merge discipline", None).expect("resolves");
+            assert_eq!(res.iri, "https://sparq.dev/ns/pkg/kb#topic-merge-discipline");
+            assert_eq!(res.score, 1.0);
+            assert!(res.runner_up.is_none());
+        }
+
+        #[test]
+        fn genuinely_ambiguous_fuzzy_phrase_still_loud_fails() {
+            // The fix must NOT weaken the loud-fail: a phrase that is not a whole label and
+            // substring-matches two DIFFERENT concepts at the same score is still ambiguous.
+            // "alpha beta" is not a label; "alpha" -> topic-alpha, "beta" -> topic-beta, both
+            // non-exact (0.6) => a tie the gate must refuse rather than guess.
+            let g = graph();
+            let ctx = ResolveCtx::lexical(&g);
+            let err = ctx
+                .resolve("alpha beta", None)
+                .expect_err("a tie across two concepts must loud-fail, never guess");
+            assert!(
+                matches!(err, crate::TerseError::Unresolved { .. }),
+                "expected Unresolved, got {err:?}"
+            );
+        }
+    }
 }

--- a/crates/sparq-terse/tests/v_resolution.rs
+++ b/crates/sparq-terse/tests/v_resolution.rs
@@ -17,11 +17,16 @@ fn graph() -> Graph {
     let ttl = r#"
         @prefix ex: <http://example.org/> .
         @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+        @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
         ex:cardEst   a ex:Topic ; rdfs:label "cardinality estimation" .
         ex:joinOrder a ex:Topic ; rdfs:label "join order optimisation" .
         ex:cat       a ex:Animal ; rdfs:label "Cat" .
         ex:catalog   a ex:Thing ; rdfs:label "Catalogue" .
         ex:finding1  ex:about ex:cardEst .
+        # sq-26fdp regression: two concepts share the token "discipline"; one prefLabel is
+        # punctuated. A V() of the verbatim punctuated label must resolve unambiguously.
+        ex:mergeDisc a ex:Topic ; skos:prefLabel "Merge discipline" .
+        ex:zkDisc    a ex:Topic ; skos:prefLabel "ZK/MPC claim + circuit discipline" .
     "#;
     Graph::load_str(ttl, "turtle").expect("graph parses")
 }
@@ -52,6 +57,36 @@ fn lexical_exact_match_resolves_and_splices_canonical_iri() {
     assert_eq!(r.iri, "http://example.org/cardEst");
     assert_eq!(r.method, Method::Lexical);
     assert!(r.confidence > 0.0);
+}
+
+#[test]
+fn verbatim_punctuated_preflabel_resolves_through_the_public_surface() {
+    // sq-26fdp: V("ZK/MPC claim + circuit discipline") is a VERBATIM prefLabel that shares
+    // the token "discipline" with a sibling concept. Before the fix the token path scored
+    // both equally and the §6 envelope loud-failed AMBIGUOUS on a phrase that IS an exact
+    // label. The exact-prefLabel-first match must now splice the right IRI, unambiguously.
+    let g = graph();
+    let ctx = ResolveCtx::lexical(&g);
+    let exp = terse_to_sparql_with(
+        "SELECT ?f WHERE { ?f <http://example.org/about> V(\"ZK/MPC claim + circuit discipline\") }",
+        &ctx,
+        |_p| None,
+    )
+    .expect("a verbatim prefLabel must resolve, not loud-fail as ambiguous");
+
+    assert!(
+        exp.canonical_sparql.contains("<http://example.org/zkDisc>"),
+        "expected the zk-discipline IRI, got: {}",
+        exp.canonical_sparql
+    );
+    assert!(!exp.canonical_sparql.contains("V("), "no V() must remain");
+    assert_eq!(exp.resolutions.len(), 1);
+    let r = &exp.resolutions[0];
+    assert_eq!(r.iri, "http://example.org/zkDisc");
+    assert_eq!(r.method, Method::Lexical);
+    assert_eq!(r.score, 1.0);
+    assert!(r.runner_up.is_none(), "the verbatim label is the sole candidate");
+    assert_eq!(r.confidence, 1.0);
 }
 
 #[test]

--- a/skills/genai-retrieval/SKILL.md
+++ b/skills/genai-retrieval/SKILL.md
@@ -144,6 +144,9 @@ Nlq::repair_prompt_for(&self, question, failed_sparql, error) -> String
 // the grounding prompt. Usable standalone:
 sparq_nlq::link::EntityLinker::build(graph: &Graph, expand_k: usize, max_links: usize)
 EntityLinker::link(&self, question: &str) -> Linking
+// link() tries a verbatim FULL-LABEL match first (case/whitespace-normalised, punctuation
+// preserved): when the whole input IS an entire label it binds that one entity exactly
+// (sq-26fdp), so a verbatim prefLabel never goes ambiguous; otherwise the token n-gram path runs.
 // Linking { entities: Vec<LinkedEntity>, relations: Vec<LinkedRelation> }
 //   LinkedEntity { mention, iri: NamedNode, label, exact: bool, similar: Vec<NamedNode> }
 //   LinkedRelation { mention, iri: NamedNode, triples: u64 }
@@ -462,12 +465,18 @@ numbers are work-box / NON-CANONICAL) gives a **per-lever** result, NOT a blanke
 - **Lever 1 (`K:<name>` keywords): conditional adopt.** Clears the cache-discounted token bar
   *and* ties plain SPARQL on quality. Conditional only because the headline win is a *caching*
   property, pending a full-session real-transcript fan-out (`sq-bmpzd`).
-- **Lever 3 (`V("phrase")`): do NOT adopt on quality.** `V()` is **not** a drop-in for an
-  explicit IRI — in the A/B it (correctly, by design) **loud-fails** on a punctuation-heavy
-  verbatim `prefLabel`, dropping resolution-correctness below 1.0. That is the soundness envelope
-  working as specified (loud-fail beats silent-wrong), but it means `V()` is a convenience that
-  must be checked, not trusted blind; the resolver-coverage fix is tracked in `sq-26fdp`. Prefer
-  `K:` + explicit `<iri>` for anything load-bearing.
+- **Lever 3 (`V("phrase")`): verbatim labels now resolve; still check, not trust.** The
+  original A/B loud-failed on a punctuation-heavy verbatim `prefLabel`
+  (`"ZK/MPC claim + circuit discipline"`) because the token-overlap linker split it on the
+  shared token `discipline` and (correctly, by the envelope) refused to guess between two
+  equally-scored topics. `sq-26fdp` fixes that: the linker now tries an **exact, case- and
+  whitespace-normalised, punctuation-preserving full-label match FIRST**, so a phrase that IS
+  an entire label binds unambiguously at score 1.0 before token-overlap runs; re-running the
+  A/B restores lever-3 `resolution_correctness` to **1.0**. The soundness envelope is
+  unchanged for genuinely fuzzy phrases (a phrase that is *not* a whole label and merely
+  shares tokens with several concepts still loud-fails). `V()` remains a convenience that must
+  be checked (echoed IRI + score + confidence), not trusted blind; prefer `K:` + explicit
+  `<iri>` for anything load-bearing.
 
 ## Gotchas / feature flags / prerequisites
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** [OPUS-4.8] — bug fix for `sq-26fdp` (surface: sparq-terse / sparq-nlq lexical linker).

## The bug

`sparq-terse`'s `V("phrase")` lexical resolver routes the whole phrase through `sparq-nlq`'s `EntityLinker::link`, which only ever matched n-gram **mentions** against the label index — it **never tried the whole input as a complete label**. So a phrase that IS a verbatim `skos:prefLabel` containing punctuation, e.g. `"ZK/MPC claim + circuit discipline"` (the verbatim `prefLabel` of `kb:topic-zk-discipline`), got split into tokens; the shared token `discipline` matched both `topic-zk-discipline` and `topic-merge-discipline` equally and the §6 soundness envelope **loud-failed AMBIGUOUS** — on a phrase that is itself an exact label. `V("Merge discipline")` worked only because its bigram coincidentally re-formed the whole (space-only) label.

Found by the `sq-bzign` Phase-5 A/B (`bench/terse/`, task t16): lever-3 `resolution_correctness` dropped below 1.0 (DO-NOT-ADOPT on quality).

## The fix

`EntityLinker::link` now tries an **exact, case/whitespace-normalised, punctuation-PRESERVING full-label match FIRST** (`sq-26fdp`). When the whole input is itself an entire label it binds that one entity exactly — the SOLE candidate, the strongest lexical signal (score 1.0) — so a downstream resolver sees no runner-up and binds at full confidence instead of stalling on the shared-token tie. Only when the input is **not** a whole label does the token n-gram path run, so the loud-fail for genuinely fuzzy phrases (a non-label phrase that merely shares tokens with several concepts) is **unchanged** — loud-fail still beats silent-wrong.

A new `norm_labels` index keys each label by a whitespace-collapsed, lower-cased form with **punctuation preserved**, so two genuinely distinct labels never collapse together.

## Design note (best-judgment, per the standing proceed-without-greenlight rule)

The bead specified "case/space-normalised, **punctuation-tolerant**". I implemented punctuation-**preserving** normalisation (collapse interior whitespace + case-fold; keep `/`, `+`, etc. verbatim) rather than punctuation-**stripping**. Rationale: stripping punctuation risks collapsing distinct labels (e.g. `"a/b"` vs `"a b"`) and weakening the unambiguity guarantee the bead asks for. This binds verbatim labels (incl. punctuation) at 1.0 while tolerating only spacing/case drift. Flagged for the maintainer to steer in the tracking issue below.

## Tests (REAL path, both surfaces)

- `sparq-nlq` unit tests in `link.rs`: verbatim punctuated label resolves to exactly one entity; case/whitespace tolerance; the sibling label `"Merge discipline"` still binds to its own concept; a non-label question still flows the token path (only non-exact links); `normalise_label` behaviour.
- `sparq-terse` end-to-end tests (`ResolveCtx::resolve` + the public `terse_to_sparql_with`): verbatim label binds at score/confidence 1.0 with the right IRI spliced into canonical SPARQL; a genuine 2-concept tie still loud-fails `Unresolved`.
- Bench re-run (`bench/terse/run.sh`): lever-3 `resolution_correctness` back to **1.0** (work-box / NON-CANONICAL).

## Gates (both feature states — named flags)

- `sparq-nlq` (default): `cargo build` / `clippy --all-targets -D warnings` / `test` GREEN.
- `sparq-terse` **default (feature OFF)** AND **`--features vectors` (ON)**: `build` / `clippy --all-targets -D warnings` / `test` GREEN.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` clean.
- `scripts/check-privacy-claims.sh` clean; no banned typos; no hard-coded perf numbers (bench artifacts stay gitignored / NON-CANONICAL).
- `rustfmt`: applied only to my own additions; the workspace's intentionally-deferred reformat of untouched files was reverted.

Auto-merge intentionally **OFF**. Closes `sq-26fdp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)