### PR TITLE
feat(gui): paginate SELECT results + bounded read-ahead page cache (sq-9w4t, #817) [OPUS-4.8]

### DIFF
--- a/gui/app/src/components/workbench/query-workbench.tsx
+++ b/gui/app/src/components/workbench/query-workbench.tsx
@@ -20,7 +20,20 @@
 // data-result-view="table" wrapping a <table> with the binding.
 
 import * as React from "react";
-import { Play, Loader2, Square, Network, Activity, Telescope, Gauge, History } from "lucide-react";
+import {
+  Play,
+  Loader2,
+  Square,
+  Network,
+  Activity,
+  Telescope,
+  Gauge,
+  History,
+  ChevronFirst,
+  ChevronLast,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -34,6 +47,7 @@ import {
 } from "@/lib/engine-context";
 import {
   extractTable,
+  createPageCache,
   resultsToCsv,
   resultsToTsv,
   formatSparqlJson,
@@ -70,49 +84,152 @@ const VIEWS: { id: ResultView; label: string }[] = [
 // View bodies.
 // ---------------------------------------------------------------------------
 
+/** The page-size choices the results table offers (rows rendered per page). */
+const PAGE_SIZES = [50, 100, 250, 500] as const;
+const DEFAULT_PAGE_SIZE = 100;
+
+// [OPUS-4.8] sq-9w4t (#817) — paginated SELECT table. Only the VISIBLE page of rows is shaped
+// into <td> cells (serialising/rendering the whole kept result is the per-render cost #817
+// calls out), and a bounded read-ahead PAGE CACHE (createPageCache, ~2 pages ahead) warms the
+// next page so ⏭ is instant. The cache is rebuilt only when the underlying result or page size
+// changes — paging itself never re-extracts the table. NOTE this paginates over the rows the
+// engine ALREADY streamed into JS; demand-driven query EVALUATION up to the current page needs
+// a pull-iterator exec model the engine lacks today (gated — see results.ts / gui-design.md).
 function SelectTable({ results }: { results: SparqlResults }) {
-  const table = extractTable(results);
+  const table = React.useMemo(() => extractTable(results), [results]);
+  const [pageSize, setPageSize] = React.useState<number>(DEFAULT_PAGE_SIZE);
+  const [page, setPage] = React.useState(0);
+
+  // One cache per (result, pageSize). Reset to the first page whenever either changes so a new
+  // run / resize never strands the view on an out-of-range page.
+  const cache = React.useMemo(
+    () => createPageCache(table, pageSize, 2),
+    [table, pageSize],
+  );
+  React.useEffect(() => {
+    setPage(0);
+  }, [cache]);
+
   if (table.vars.length === 0) {
     return <p className="p-3 text-sm text-muted-foreground">No projected variables.</p>;
   }
+
+  // `cache.get` clamps + warms the read-ahead window; render only its returned slice.
+  const current = cache.get(page);
+  const { rows, totalRows, totalPages, startRow } = current;
+  const firstRow = totalRows === 0 ? 0 : startRow + 1;
+  const lastRow = startRow + rows.length;
+  const atFirst = current.page <= 0;
+  const atLast = current.page >= totalPages - 1;
+
   return (
-    <div className="overflow-auto" data-result-view="table">
-      <table className="w-full border-collapse text-sm">
-        <thead className="sticky top-0 bg-card">
-          <tr>
-            {table.vars.map((v) => (
-              <th
-                key={v}
-                className="border-b px-3 py-1.5 text-left font-mono text-xs font-semibold"
-              >
-                ?{v}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {table.rows.length === 0 ? (
+    <div className="flex h-full flex-col" data-result-view="table">
+      <div className="min-h-0 flex-1 overflow-auto">
+        <table className="w-full border-collapse text-sm">
+          <thead className="sticky top-0 bg-card">
             <tr>
-              <td
-                colSpan={table.vars.length}
-                className="px-3 py-3 text-center text-muted-foreground"
-              >
-                0 rows
-              </td>
+              {table.vars.map((v) => (
+                <th
+                  key={v}
+                  className="border-b px-3 py-1.5 text-left font-mono text-xs font-semibold"
+                >
+                  ?{v}
+                </th>
+              ))}
             </tr>
-          ) : (
-            table.rows.map((row, i) => (
-              <tr key={i} className="odd:bg-muted/30">
-                {row.map((cell, j) => (
-                  <td key={j} className="border-b px-3 py-1 font-mono text-xs">
-                    {cell}
-                  </td>
-                ))}
+          </thead>
+          <tbody>
+            {rows.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={table.vars.length}
+                  className="px-3 py-3 text-center text-muted-foreground"
+                >
+                  0 rows
+                </td>
               </tr>
-            ))
-          )}
-        </tbody>
-      </table>
+            ) : (
+              rows.map((row, i) => (
+                <tr key={startRow + i} className="odd:bg-muted/30">
+                  {row.map((cell, j) => (
+                    <td key={j} className="border-b px-3 py-1 font-mono text-xs">
+                      {cell}
+                    </td>
+                  ))}
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      {/* Pager: only shown when there is more than one page of kept rows. */}
+      {totalRows > 0 && (
+        <div
+          className="flex items-center gap-2 border-t bg-card px-3 py-1 text-[11px] text-muted-foreground"
+          data-result-pager
+        >
+          <span className="tabular" data-pager-range>
+            {firstRow.toLocaleString()}–{lastRow.toLocaleString()} of{" "}
+            {totalRows.toLocaleString()}
+          </span>
+          <div className="ml-auto flex items-center gap-1">
+            <label className="flex items-center gap-1">
+              <span>Rows / page</span>
+              <select
+                className="rounded border bg-background px-1 py-0.5 text-[11px]"
+                value={pageSize}
+                onChange={(e) => setPageSize(Number(e.target.value))}
+                aria-label="Rows per page"
+              >
+                {PAGE_SIZES.map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button
+              className="rounded p-0.5 hover:bg-accent/40 disabled:opacity-30"
+              onClick={() => setPage(0)}
+              disabled={atFirst}
+              title="First page"
+              aria-label="First page"
+            >
+              <ChevronFirst className="size-3.5" />
+            </button>
+            <button
+              className="rounded p-0.5 hover:bg-accent/40 disabled:opacity-30"
+              onClick={() => setPage((p) => p - 1)}
+              disabled={atFirst}
+              title="Previous page"
+              aria-label="Previous page"
+            >
+              <ChevronLeft className="size-3.5" />
+            </button>
+            <span className="tabular px-1" data-pager-page>
+              Page {(current.page + 1).toLocaleString()} / {totalPages.toLocaleString()}
+            </span>
+            <button
+              className="rounded p-0.5 hover:bg-accent/40 disabled:opacity-30"
+              onClick={() => setPage((p) => p + 1)}
+              disabled={atLast}
+              title="Next page"
+              aria-label="Next page"
+            >
+              <ChevronRight className="size-3.5" />
+            </button>
+            <button
+              className="rounded p-0.5 hover:bg-accent/40 disabled:opacity-30"
+              onClick={() => setPage(totalPages - 1)}
+              disabled={atLast}
+              title="Last page"
+              aria-label="Last page"
+            >
+              <ChevronLast className="size-3.5" />
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -584,6 +584,20 @@ export {
   formatSparqlJson,
 } from "./results.js";
 
+// [OPUS-4.8] sq-9w4t (#817) — paginated result rendering + a bounded read-ahead page cache:
+// slice ONE display-page of a kept SELECT result, warming ~2 pages ahead so the next page is
+// instant, while holding at most a bounded window of shaped slices. Pure shaping over the rows
+// already streamed into JS (the engine result path is still materialised — the demand-driven
+// EVALUATION half is gated on a pull/iterator exec model; see results.ts + gui-design.md §A.4).
+export {
+  type ResultPage,
+  type PageCache,
+  pageCount,
+  clampPage,
+  paginateTable,
+  createPageCache,
+} from "./results.js";
+
 // ---------------------------------------------------------------------------
 // [OPUS-4.8] sq-2mke — endpoint mode: the SPARQL 1.1 Protocol HTTP client.
 // The companion to the in-tab WASM `Store` above — run the SAME editor against any

--- a/packages/sparq-client/src/results.ts
+++ b/packages/sparq-client/src/results.ts
@@ -163,3 +163,168 @@ export function resultsToTsv(results: SparqlResults): string {
 export function formatSparqlJson(results: SparqlResults): string {
   return JSON.stringify(results, null, 2);
 }
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-9w4t (#817) — PAGINATED result rendering + a bounded read-ahead page cache.
+//
+// WHY. Maintainer #817: serialising/rendering the WHOLE kept result is the main per-render
+// overhead, but the user only ever LOOKS at one screenful. So the panel should render (and
+// shape into display cells) only the VISIBLE slice, advancing on a page change, materialising
+// a couple of pages ahead so the next ⏭ is instant. This is the RENDERING half of the bead —
+// pure data shaping over the rows already streamed into JS, with no DOM and no framework, so
+// it lives here in `@sparq/client` and the React panel just draws what it returns.
+//
+// SCOPE — what this is NOT. The bead's note is correct: the engine result path is currently
+// MATERIALISED (the wasm `SolutionCursor` slices an already-evaluated `result.rows` —
+// crates/sparq-wasm/src/lib.rs), so there is no PULL iterator to drive *demand-driven query
+// EVALUATION* (computing the engine work only up to the current page). That LAZY-EVAL half is
+// gated on a pull/iterator exec model in `sparq-engine` and is tracked separately (a follow-up
+// bead + research/gui-design.md §A.4); this module paginates over the rows already in hand and
+// makes no performance claim.
+// ---------------------------------------------------------------------------
+
+/** A single page of a paginated {@link ResultTable}: the slice plus where it sits. */
+export interface ResultPage {
+  /** The column headers (the whole result's `vars`, unchanged across pages). */
+  vars: string[];
+  /** The display-shaped rows for THIS page only (≤ `pageSize`). */
+  rows: string[][];
+  /** 0-based index of this page. */
+  page: number;
+  /** Rows per page this page was sliced at. */
+  pageSize: number;
+  /** 0-based index of the first row of this page within the whole result. */
+  startRow: number;
+  /** Total rows across the whole (kept) result — the denominator for "x–y of N". */
+  totalRows: number;
+  /** Total number of pages at this `pageSize` (≥ 1, even for an empty result). */
+  totalPages: number;
+}
+
+/** Total number of pages `totalRows` rows split into, at `pageSize` rows per page (≥ 1). */
+export function pageCount(totalRows: number, pageSize: number): number {
+  if (pageSize <= 0) return 1;
+  if (totalRows <= 0) return 1;
+  return Math.ceil(totalRows / pageSize);
+}
+
+/** Clamp a (possibly out-of-range) 0-based page index into `[0, pageCount-1]`. */
+export function clampPage(page: number, totalRows: number, pageSize: number): number {
+  const last = pageCount(totalRows, pageSize) - 1;
+  if (!Number.isFinite(page) || page < 0) return 0;
+  return page > last ? last : Math.floor(page);
+}
+
+/**
+ * [OPUS-4.8] sq-9w4t — slice ONE page of display-shaped cells out of a {@link ResultTable}.
+ * The `page` is clamped into range (an out-of-range page yields the nearest valid page, never
+ * an empty slice on a non-empty result). `pageSize ≤ 0` is treated as "one page of everything".
+ * Only the `pageSize` rows of the requested page are shaped — the whole-table `table.rows` is
+ * already display-shaped by {@link extractTable}, so this is a bounded slice, not a re-render of
+ * every row.
+ */
+export function paginateTable(
+  table: ResultTable,
+  page: number,
+  pageSize: number,
+): ResultPage {
+  const totalRows = table.rows.length;
+  const effectiveSize = pageSize > 0 ? pageSize : Math.max(totalRows, 1);
+  const totalPages = pageCount(totalRows, effectiveSize);
+  const clamped = clampPage(page, totalRows, effectiveSize);
+  const startRow = clamped * effectiveSize;
+  return {
+    vars: table.vars,
+    rows: table.rows.slice(startRow, startRow + effectiveSize),
+    page: clamped,
+    pageSize: effectiveSize,
+    startRow,
+    totalRows,
+    totalPages,
+  };
+}
+
+/**
+ * A bounded read-ahead cache over a paginated {@link ResultTable}. {@link PageCache.get} returns
+ * the requested page (computing + memoising its slice on first access) and, as a side effect,
+ * WARMS the next `readAhead` pages so a forward ⏭ is already materialised. The cache keeps at
+ * most `1 + 2·readAhead` page slices live (the current page, `readAhead` ahead, `readAhead`
+ * behind) and evicts the page furthest from the last-requested one — so paging through a large
+ * result never holds more than that bounded window of shaped slices in memory at once.
+ */
+export interface PageCache {
+  /** The page at `page` (clamped), warming the read-ahead window as a side effect. */
+  get(page: number): ResultPage;
+  /** How many page slices are currently materialised (for tests / introspection). */
+  readonly size: number;
+  /** Rows per page this cache paginates at. */
+  readonly pageSize: number;
+  /** Total pages at this page size (≥ 1). */
+  readonly totalPages: number;
+}
+
+/**
+ * [OPUS-4.8] sq-9w4t — build a {@link PageCache} over `table`. `pageSize` is the rows-per-page;
+ * `readAhead` (default 2 — the maintainer's "~2 pages ahead") is how many pages forward to warm
+ * on each `get`, and also bounds the retained window. The slices are computed lazily by
+ * {@link paginateTable}, so constructing the cache shapes NOTHING — only the pages actually
+ * visited (and their read-ahead) are ever materialised.
+ */
+export function createPageCache(
+  table: ResultTable,
+  pageSize: number,
+  readAhead = 2,
+): PageCache {
+  const ahead = Math.max(0, Math.floor(readAhead));
+  const total = pageCount(table.rows.length, pageSize > 0 ? pageSize : table.rows.length || 1);
+  // Map page-index -> shaped slice, plus a parallel "last touched" tick for LRU-by-distance
+  // eviction. `Map` preserves insertion order, but we evict by DISTANCE from the focus page
+  // (not insertion order) so a back-and-forth around the focus keeps the hot window.
+  const slices = new Map<number, ResultPage>();
+  const cap = 1 + 2 * ahead;
+  let focus = 0;
+
+  const materialise = (p: number): ResultPage => {
+    const existing = slices.get(p);
+    if (existing) return existing;
+    const slice = paginateTable(table, p, pageSize);
+    // `paginateTable` clamps, so key by the CLAMPED page to avoid duplicate entries for the
+    // same physical page (e.g. warming past the last page).
+    const keyed = slices.get(slice.page);
+    if (keyed) return keyed;
+    slices.set(slice.page, slice);
+    return slice;
+  };
+
+  const evictBeyondWindow = () => {
+    if (slices.size <= cap) return;
+    // Drop the entries furthest from the focus page until we are back within the window.
+    const byDistance = [...slices.keys()].sort(
+      (a, b) => Math.abs(b - focus) - Math.abs(a - focus),
+    );
+    for (const k of byDistance) {
+      if (slices.size <= cap) break;
+      slices.delete(k);
+    }
+  };
+
+  return {
+    get(page: number): ResultPage {
+      const current = materialise(page);
+      focus = current.page;
+      // Warm the read-ahead window (forward, where a ⏭ goes next) AND one behind, so a ⏮ after
+      // a ⏭ is also warm — all bounded by `cap` via the eviction below.
+      for (let d = 1; d <= ahead; d += 1) {
+        if (current.page + d < total) materialise(current.page + d);
+        if (current.page - d >= 0) materialise(current.page - d);
+      }
+      evictBeyondWindow();
+      return current;
+    },
+    get size() {
+      return slices.size;
+    },
+    pageSize: pageSize > 0 ? pageSize : table.rows.length || 1,
+    totalPages: total,
+  };
+}

--- a/research/gui-design.md
+++ b/research/gui-design.md
@@ -167,6 +167,36 @@ REPL's built-in-dataset picker and explanatory captions (datasets live in the le
 and runs full-height with multiple co-resident result views (Table | Graph | Raw JSON |
 N-Triples/Turtle) against the persistent store rather than a sample graph.
 
+#### A.5.1 Paginated results + the lazy-evaluation gate (`sq-9w4t`, #817)
+
+[OPUS-4.8] Maintainer #817 observed that **serialising / rendering the whole kept result is
+the dominant per-render cost**, while the user only ever looks at one screenful. The SELECT
+**Table** view is therefore **paginated**: only the visible page of rows is shaped into DOM
+cells, and a **bounded read-ahead page cache** (`@sparq/client`'s `createPageCache`, default
+~2 pages ahead) warms the next page so a ⏭ is instant while never holding more than
+`1 + 2·readAhead` shaped slices live. The pure page-math (`paginateTable` / `pageCount` /
+`clampPage` / `createPageCache`) lives in `@sparq/client/results.ts` (host-agnostic, unit-
+tested in `site/test/results-pagination.test.mjs`); the React pager is in `query-workbench.tsx`.
+
+This is the **rendering** half. The bead's other half — **demand-driven query *evaluation***
+that computes the engine work only up to the current page and advances on a page change — is
+**deliberately NOT shipped** and is gated on a design pre-condition that does not hold today:
+
+- The engine result path is **materialised**, not pull-based. The wasm `SolutionCursor`
+  (`crates/sparq-wasm/src/lib.rs`) slices an already-fully-evaluated `result.rows`; `next()`
+  hands out `result.rows[pos..end]`. There is no pull/iterator that can stop after page *k*'s
+  worth of solutions, so "page-wise evaluation" would today still evaluate the whole query and
+  only **chunk the already-computed rows** — exactly what `streamQueryRows` already does.
+- Real lazy page-wise evaluation needs **one** of: (a) a **pull/Volcano iterator execution
+  model** in `sparq-engine` whose top operator can be driven `n` rows at a time and paused; or
+  (b) a **query-rewrite** strategy (`… ORDER BY … LIMIT pageSize OFFSET k·pageSize`) re-run per
+  page — which is only correct under a **stable total order** (an `ORDER BY` the user did not
+  necessarily write) and re-pays the scan each page, so it is a trade, not a clear win.
+
+Until that exec-model decision is made and measured, pagination over the streamed-in-hand rows
+is the honest, shippable surface; the evaluation half is tracked as a separate follow-up bead
+(no performance number is claimed for either half).
+
 ## 0. Ground truth — what exists today
 
 <!-- [OPUS-4.8] sq-uau8 — CORRECTED. The earlier draft said "Nothing is built yet /

--- a/site/test/results-pagination.test.mjs
+++ b/site/test/results-pagination.test.mjs
@@ -1,0 +1,137 @@
+// [OPUS-4.8] sq-9w4t (#817) — unit tests for the PAGINATED result rendering + bounded
+// read-ahead page cache (packages/sparq-client/src/results.ts). These cover the PURE shaping
+// the GUI Query workbench's SELECT table draws: slicing one display-page out of an extracted
+// `ResultTable`, page-count / clamp arithmetic, and the read-ahead cache's lazy materialisation
+// + bounded-window eviction. The query SEMANTICS are proven by the Rust engine tests; here we
+// only test the JS page-math over the rows already streamed into JS. Run via `npm run test:unit`.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  extractTable,
+  pageCount,
+  clampPage,
+  paginateTable,
+  createPageCache,
+} from "../../packages/sparq-client/src/results.ts";
+
+/** Build a SELECT-results doc with `n` single-column rows (?i = "row-0".."row-(n-1)"). */
+function makeResults(n) {
+  return {
+    head: { vars: ["i"] },
+    results: {
+      bindings: Array.from({ length: n }, (_, k) => ({
+        i: { type: "literal", value: `row-${k}` },
+      })),
+    },
+  };
+}
+
+// --- pageCount / clampPage arithmetic -------------------------------------------------------
+
+test("pageCount: ceil division, and ≥1 even for an empty/zero result", () => {
+  assert.equal(pageCount(0, 50), 1);
+  assert.equal(pageCount(1, 50), 1);
+  assert.equal(pageCount(50, 50), 1);
+  assert.equal(pageCount(51, 50), 2);
+  assert.equal(pageCount(250, 100), 3);
+  // pageSize ≤ 0 collapses to a single page.
+  assert.equal(pageCount(999, 0), 1);
+});
+
+test("clampPage: negatives → 0, past-the-end → last page, floors fractions", () => {
+  // 250 rows @ 100/pp → pages 0,1,2.
+  assert.equal(clampPage(-5, 250, 100), 0);
+  assert.equal(clampPage(0, 250, 100), 0);
+  assert.equal(clampPage(2, 250, 100), 2);
+  assert.equal(clampPage(99, 250, 100), 2);
+  assert.equal(clampPage(1.9, 250, 100), 1);
+  assert.equal(clampPage(NaN, 250, 100), 0);
+});
+
+// --- paginateTable: only the visible slice is shaped ----------------------------------------
+
+test("paginateTable: slices exactly the requested page, with correct metadata", () => {
+  const table = extractTable(makeResults(250));
+  const p0 = paginateTable(table, 0, 100);
+  assert.equal(p0.rows.length, 100);
+  assert.deepEqual(p0.rows[0], ['"row-0"']);
+  assert.deepEqual(p0.rows[99], ['"row-99"']);
+  assert.equal(p0.page, 0);
+  assert.equal(p0.startRow, 0);
+  assert.equal(p0.totalRows, 250);
+  assert.equal(p0.totalPages, 3);
+  assert.deepEqual(p0.vars, ["i"]);
+
+  // The last (short) page holds the remainder only.
+  const p2 = paginateTable(table, 2, 100);
+  assert.equal(p2.rows.length, 50);
+  assert.deepEqual(p2.rows[0], ['"row-200"']);
+  assert.equal(p2.startRow, 200);
+});
+
+test("paginateTable: an out-of-range page clamps to the last (never an empty slice)", () => {
+  const table = extractTable(makeResults(250));
+  const p = paginateTable(table, 99, 100);
+  assert.equal(p.page, 2);
+  assert.equal(p.rows.length, 50);
+});
+
+test("paginateTable: pageSize ≤ 0 yields one page of everything", () => {
+  const table = extractTable(makeResults(7));
+  const p = paginateTable(table, 0, 0);
+  assert.equal(p.totalPages, 1);
+  assert.equal(p.rows.length, 7);
+});
+
+test("paginateTable: an empty result is one empty page, not a crash", () => {
+  const table = extractTable(makeResults(0));
+  const p = paginateTable(table, 0, 100);
+  assert.equal(p.totalPages, 1);
+  assert.equal(p.totalRows, 0);
+  assert.equal(p.rows.length, 0);
+});
+
+// --- createPageCache: lazy materialisation + bounded read-ahead window ----------------------
+
+test("createPageCache: constructing it shapes NOTHING until a page is visited", () => {
+  const table = extractTable(makeResults(1000)); // 10 pages @ 100
+  const cache = createPageCache(table, 100, 2);
+  assert.equal(cache.size, 0);
+  assert.equal(cache.totalPages, 10);
+  assert.equal(cache.pageSize, 100);
+});
+
+test("createPageCache: get warms ~readAhead pages ahead (and behind), bounded", () => {
+  const table = extractTable(makeResults(1000)); // 10 pages @ 100
+  const cache = createPageCache(table, 100, 2);
+  const p = cache.get(0);
+  assert.equal(p.page, 0);
+  assert.deepEqual(p.rows[0], ['"row-0"']);
+  // Page 0 + 2 ahead warmed (no pages behind 0). The bounded window cap is 1 + 2·readAhead = 5.
+  assert.equal(cache.size, 3);
+  assert.ok(cache.size <= 1 + 2 * 2);
+});
+
+test("createPageCache: paging across the result never exceeds the bounded window", () => {
+  const table = extractTable(makeResults(10_000)); // 100 pages @ 100
+  const cache = createPageCache(table, 100, 2);
+  const cap = 1 + 2 * 2;
+  for (let pg = 0; pg < 100; pg += 1) {
+    const got = cache.get(pg);
+    assert.equal(got.page, pg);
+    assert.ok(
+      cache.size <= cap,
+      `cache held ${cache.size} slices at page ${pg}, exceeding the ${cap} window`,
+    );
+  }
+});
+
+test("createPageCache: the slice is the right rows for the requested page", () => {
+  const table = extractTable(makeResults(1000));
+  const cache = createPageCache(table, 100, 2);
+  const p5 = cache.get(5);
+  assert.equal(p5.startRow, 500);
+  assert.deepEqual(p5.rows[0], ['"row-500"']);
+  assert.deepEqual(p5.rows[99], ['"row-599"']);
+});


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Opus 4.8). Implements bead **sq-9w4t** — maintainer #817.

## What

Maintainer #817 observed that **serialising / rendering the whole kept SELECT result is the dominant per-render cost**, while the user only ever looks at one screenful. So the Query workbench's **Table** view is now **paginated**:

- **Only the visible page of rows is shaped into DOM cells** (not the whole kept result).
- A **bounded read-ahead page cache** (`createPageCache`, default ~2 pages ahead) warms the next page so a ⏭ is instant, while holding at most `1 + 2·readAhead` shaped slices live — so paging through a large result never grows JS memory unbounded.
- A pager (first / prev / next / last + a **rows-per-page** selector: 50 / 100 / 250 / 500) and an "x–y of N · Page p / P" readout.

The pure page-math is host-agnostic and lives in `@sparq/client`:
`paginateTable` · `pageCount` · `clampPage` · `createPageCache` (`packages/sparq-client/src/results.ts`), unit-tested in `site/test/results-pagination.test.mjs` (**10 tests**, incl. lazy materialisation + bounded-window eviction). The React pager is in `gui/app/src/components/workbench/query-workbench.tsx`. The **e2e stable hooks are preserved** (`data-result-view="table"` wrapping a `<table>` with `tbody` rows; the seeded sample result fits on page 1, so the "Alice" assertion still holds).

## What is deliberately NOT shipped (design / judgment call — proceeded per STANDING RULE)

The bead's **other** half — demand-driven page-wise *query EVALUATION* (compute engine work only up to the current page, advance on page change) — is **gated** and tracked separately. The engine result path is **materialised**: the wasm `SolutionCursor` (`crates/sparq-wasm/src/lib.rs`) slices an already-fully-evaluated `result.rows`, so there is no pull/iterator that can stop after page *k*. Real lazy evaluation needs **either** a pull/Volcano exec model in `sparq-engine` whose top operator can be driven *n* rows at a time and paused, **or** a per-page `ORDER BY … LIMIT pageSize OFFSET k·pageSize` rewrite — correct only under a stable total order and re-paying the scan per page. That is a decision to make and **measure** first.

- Documented in `research/gui-design.md` **§A.5.1**.
- Tracked as follow-up bead **sq-f4pmk** (depends-on sq-9w4t).

**No performance number is claimed for either half.**

## Gates

- `@sparq/client` typecheck: green.
- GUI app lint + typecheck + static export (web + tauri targets): green.
- `site` `test:unit`: **287 pass / 0 fail** (incl. the 10 new pagination tests); existing `results-panel` suite unchanged.
- `check-privacy-claims.sh`: OK (no ZK/MPC claim touched). No crate README changed (readme-template N/A).
- Pure TS change (no Rust cfg-gate) → covered by `gui.yml` + `site-e2e.yml`; **no `feature-matrix.yml` leg needed** (avoids the recurring conflict).
- `Cargo.lock` `memmap2` kept at 0.9.11.

Closes #817 on merge. Auto-merge OFF.

🤖 Generated with [Claude Code](https://claude.com/claude-code)