### PR TITLE
feat(sparq-solid): authoritative ACL write-through put_acl/delete_acl + atomic re-materialize (sq-snopa.5) [OPUS-4.8]

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -44,7 +44,7 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
 - **Triples-native + zero-copy enforcement** — pods, ACL/ACR docs, and the auth view are all ordinary
   named graphs ("who can read G?" is one SPARQL pattern); the default path evaluates through the engine's
   zero-copy dataset view, with a v1 `FROM NAMED` rewrite as a standard-SPARQL portability path.
-- **Write-path gating, WAC-Allow + per-resource decision (#992 FR-1/6/7)** — `update_as` gates writes, `wac_allow` builds the header, and `decide`/`decide_batch`/`resolve_acl` answer the per-request *"may X do M on R?"* with the
+- **Write-path gating, WAC-Allow, per-resource decision + ACL write-through (#992 FR-1/3/6/7)** — `update_as` gates writes; `put_acl`/`delete_acl` are the authoritative LDP-`PUT`/`DELETE`-on-`.acl` write-through (atomic graph replace + re-materialize, fail-closed rollback); `wac_allow` builds the header; `decide`/`decide_batch`/`resolve_acl` answer the per-request *"may X do M on R?"* with the
   governing-ACL + `accessTo`/`default` scope and a typed fail-closed `AclStatus` (absent/unloaded/transient ⇒ deny, never open — for a server's 401/403-vs-503 mapping).
 - **ODRL bridge (opt-in `odrl-bridge`, research-track — not a production cutover)** — runs the
   [`sparq-policy`](../sparq-policy) ODRL evaluator and materializes the equivalent WAC/ACP grant (or dual

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -31,6 +31,12 @@ pub mod odrl_bridge;
 pub mod trust_wire;
 mod rewrite;
 mod update; // [OPUS-4.8] sq-xor3: write/update-path enforcement
+// [OPUS-4.8] issue #992 FR-3 (sq-snopa.5): the AUTHORITATIVE ACL write-through —
+// `PodStore::put_acl`/`delete_acl` replace (or remove) a `.acl`/`.acr` graph AND
+// re-materialize `<urn:sparq:auth>` as ONE atomic, fail-closed unit, keeping SPARQ the
+// source of truth. Always compiled (no feature gate): it adds no dependency, reusing only
+// the always-present materialize + named-graph machinery — mirroring `update_as`/`decide`.
+mod write_through;
 // [OPUS-4.8] sq-3jtd.8: library-level WAC conformance harness — the table-driven
 // scenario sibling of `conformance` (ACP), over the WAC engine (materialize_wac +
 // AuthIndex::accessible). Shares the decision/expectation/report vocabulary with
@@ -61,6 +67,9 @@ pub use odrl_bridge::{BridgeEntry, BridgeKind, BridgeLedger};
 #[cfg(feature = "trust-graph")]
 pub use trust_wire::{TrustAdmissionOutcome, TrustStaticOutcome};
 pub use rewrite::{rewrite_for, wrap_for_view};
+// [OPUS-4.8] issue #992 FR-3 (sq-snopa.5): the authoritative ACL write-through outcome type
+// (the `put_acl`/`delete_acl` methods live on `PodStore` in `write_through`).
+pub use write_through::AclWriteOutcome;
 
 use oxrdf::{NamedNode, Term};
 use rustc_hash::FxHashMap;

--- a/crates/sparq-solid/src/write_through.rs
+++ b/crates/sparq-solid/src/write_through.rs
@@ -1,0 +1,319 @@
+//! [OPUS-4.8] issue #992 FR-3 (sq-snopa.5) — the AUTHORITATIVE ACL write-through.
+//!
+//! A Solid LDP server treats a `PUT`/`DELETE` to a `.acl`/`.acr` document as a change to
+//! the access-control rules: the new rule text becomes the storage of record, and the
+//! materialized authorization view (`<urn:sparq:auth>`) must be rebuilt so the change
+//! takes effect immediately. This module is the storage-layer primitive for that:
+//! [`crate::PodStore::put_acl`] / [`crate::PodStore::delete_acl`] update the access-control
+//! GRAPH and re-materialize the auth view as ONE fail-closed, ATOMIC unit — keeping SPARQ
+//! the source of truth (the auth view is always a pure function of the current `.acl`/`.acr`
+//! graphs, never a stale snapshot).
+//!
+//! # Where this sits relative to [`crate::PodStore::update_as`]
+//!
+//! [`crate::PodStore::update_as`] is the SESSION-authorized write path: it checks the
+//! actor's `acl:Control` (via the same auth view) before applying a SPARQL Update that
+//! happens to touch an `.acl`/`.acr` graph, then re-materializes. `put_acl`/`delete_acl`
+//! are the lower-level STORAGE primitive the server calls AFTER it has authorized the
+//! request through its own pipeline (e.g. [`crate::PodStore::decide`] with
+//! [`crate::Mode::Control`]): they take the new document content directly and replace the
+//! whole control graph, rather than expressing the edit as a SPARQL `DELETE/INSERT`. They
+//! perform NO session authorization themselves — authorization is the caller's job and
+//! `update_as` remains the session-checked path. Use `put_acl`/`delete_acl` when the server
+//! has the new `.acl` body in hand (the LDP `PUT` shape) and wants an authoritative,
+//! atomic replace + re-materialize.
+//!
+//! # Atomicity (all-or-nothing)
+//!
+//! The two steps — swap the control graph, rebuild the auth view — succeed together or
+//! leave the store byte-for-byte as it was:
+//!
+//! 1. the supplied content is PARSED first (a malformed document is rejected before
+//!    anything is mutated);
+//! 2. the prior control-graph slot is captured, then the new content is swapped in (or the
+//!    slot removed, for `delete_acl`);
+//! 3. the auth view is re-materialized. On success the store reflects the new rules.
+//! 4. **on any re-materialization error** (e.g. the new ACL names a reserved-encoding
+//!    principal) the captured prior slot is RESTORED and the auth view rebuilt from it, so
+//!    the call leaves the store exactly as it found it and returns `Err` — never a control
+//!    graph updated without its matching auth view, and never a partial write.
+//!
+//! # Fail-closed
+//!
+//! Every error path leaves the PRIOR (already-validated) authorization in force, never a
+//! wider one: a rejected content parse, a reserved-encoding principal, or a non-control
+//! target IRI all return `Err` with the previous auth view intact. A successful `delete_acl`
+//! REMOVES grants (it can only narrow access — the deleted rules no longer grant anything),
+//! and a successful `put_acl` replaces the old rules wholesale with the new ones.
+
+use crate::loader::{ACL_SUFFIX, ACR_SUFFIX};
+use crate::PodStore;
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+
+/// What a successful [`crate::PodStore::put_acl`] / [`crate::PodStore::delete_acl`] did, for
+/// the server's audit log / response. The auth view has already been re-materialized when
+/// this is returned. [OPUS-4.8] sq-snopa.5.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AclWriteOutcome {
+    /// The control-document IRI that was written (`put_acl`) or removed (`delete_acl`).
+    pub acl: NamedNode,
+    /// Whether a control graph of that IRI already existed before the call (a `PUT` that
+    /// CREATED a new `.acl` vs one that REPLACED an existing one; a `delete_acl` of an
+    /// absent graph is a no-op success with `existed == false`).
+    pub existed: bool,
+    /// Triples in the control graph AFTER the write (0 for `delete_acl`).
+    pub triples: usize,
+}
+
+/// Whether `iri` is an access-control document (`.acl`/`.acr`) by naming convention — the
+/// only graphs `put_acl`/`delete_acl` accept (writing a content graph is the data path,
+/// not the access-control path).
+fn is_control_graph(iri: &str) -> bool {
+    iri.ends_with(ACL_SUFFIX) || iri.ends_with(ACR_SUFFIX)
+}
+
+/// The number of triples a sub-graph currently holds.
+fn graph_len(g: &Graph) -> usize {
+    let pat: sparq_core::store::Pattern = [None, None, None];
+    g.store.scan(&pat).rows.len()
+}
+
+impl PodStore {
+    /// [OPUS-4.8] issue #992 FR-3 (sq-snopa.5) — authoritatively write an access-control
+    /// document and re-materialize the auth view, ATOMICALLY (WAC pods).
+    ///
+    /// Replaces the `<acl_iri>` control graph with the parsed `content` and rebuilds
+    /// `<urn:sparq:auth>` from the updated `.acl` graphs in ONE fail-closed unit — the LDP
+    /// `PUT /resource.acl` storage primitive. `acl_iri` MUST be an `.acl`/`.acr` document
+    /// IRI (writing a content graph is the data path — [`PodStore::update_as`] — not this
+    /// one). `content` is parsed in `format` (`"turtle"`, `"ntriples"`, …) as the FULL new
+    /// body of the document: the old rules are replaced wholesale, exactly as an LDP `PUT`
+    /// replaces a resource.
+    ///
+    /// This is the AUTHORITATIVE write-through: the auth view becomes a pure function of the
+    /// new `.acl` content, so SPARQ stays the source of truth — no stale grant survives a
+    /// rule change. It performs NO session authorization (the server authorizes the request
+    /// through its own pipeline, e.g. [`PodStore::decide`] with [`Mode::Control`](crate::Mode);
+    /// the session-checked write path is [`PodStore::update_as`]).
+    ///
+    /// # Atomicity & fail-closed
+    ///
+    /// All-or-nothing: the content is parsed FIRST (a malformed document is rejected before
+    /// anything mutates), then the graph is swapped and the view rebuilt. If
+    /// re-materialization fails (e.g. the new ACL names a reserved-encoding principal) the
+    /// PRIOR control graph + auth view are RESTORED and `Err` is returned — the store is left
+    /// exactly as it was, and the previous (already-validated) authorization stays in force.
+    ///
+    /// For an **ACP** pod (`.acr` documents, three-stratum view) use
+    /// [`PodStore::put_acl_acp`] so the re-materialization runs the ACP rules.
+    ///
+    /// # Errors
+    ///
+    /// `Err` if `acl_iri` is not an `.acl`/`.acr` document IRI, if `content` does not parse
+    /// in `format`, or if re-materializing the resulting view fails (the store is rolled back
+    /// to its prior state first).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sparq_solid::{Mode, PodStore, Session};
+    ///
+    /// // Start with an empty pod (no ACL anywhere) — every session fails closed.
+    /// let nquads = "<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> \"hi\" <https://pod.ex/notes/n1> .\n";
+    /// let mut store = PodStore::new(sparq_core::Graph::load_dataset(nquads, "nquads")?);
+    /// store.materialize_wac()?;
+    /// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None, now: None };
+    /// assert_eq!(store.accessible(&alice, Mode::Read).len(), 0); // no grant yet
+    ///
+    /// // PUT a root .acl granting alice Read by default — and re-materialize atomically.
+    /// let acl = r#"
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#agent> <https://alice.ex/card#me> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .
+    /// "#;
+    /// let out = store.put_acl("https://pod.ex/.acl", acl, "ntriples")?;
+    /// assert!(!out.existed); // created
+    /// // the change took effect immediately — no separate materialize_wac() call.
+    /// assert_eq!(store.accessible(&alice, Mode::Read).len(), 2); // n1 + notes/ container
+    /// # Ok::<(), String>(())
+    /// ```
+    pub fn put_acl(
+        &mut self,
+        acl_iri: &str,
+        content: &str,
+        format: &str,
+    ) -> Result<AclWriteOutcome, String> {
+        self.put_acl_inner(acl_iri, content, format, false)
+    }
+
+    /// [`PodStore::put_acl`] for **ACP** pods: identical atomic replace + re-materialize, but
+    /// the view is rebuilt by the ACP rules ([`PodStore::materialize_acp`]) over the `.acr`
+    /// graphs instead of the WAC ones. [OPUS-4.8] sq-snopa.5.
+    pub fn put_acl_acp(
+        &mut self,
+        acl_iri: &str,
+        content: &str,
+        format: &str,
+    ) -> Result<AclWriteOutcome, String> {
+        self.put_acl_inner(acl_iri, content, format, true)
+    }
+
+    /// [OPUS-4.8] issue #992 FR-3 (sq-snopa.5) — authoritatively REMOVE an access-control
+    /// document and re-materialize the auth view, ATOMICALLY (WAC pods).
+    ///
+    /// Removes the `<acl_iri>` control graph entirely and rebuilds `<urn:sparq:auth>` from the
+    /// remaining `.acl` graphs — the LDP `DELETE /resource.acl` storage primitive. Deleting an
+    /// ACL can only NARROW access: the removed rules no longer grant anything, so a resource
+    /// that relied on this ACL falls back to its nearest ancestor container's ACL (or becomes
+    /// un-protected, and every session fails closed on it). `acl_iri` MUST be an `.acl`/`.acr`
+    /// document IRI. Deleting an ACL that does not exist is a no-op success
+    /// (`existed == false`), still re-materializing so the caller need not branch.
+    ///
+    /// Like [`PodStore::put_acl`] this is the AUTHORITATIVE write-through (the auth view stays
+    /// a pure function of the present `.acl` graphs) and performs NO session authorization. For
+    /// an **ACP** pod use [`PodStore::delete_acl_acp`].
+    ///
+    /// # Atomicity & fail-closed
+    ///
+    /// All-or-nothing, exactly as [`PodStore::put_acl`]: the prior slot is captured, removed,
+    /// then the view is rebuilt; on a re-materialization error the slot is restored and the
+    /// prior auth view rebuilt, leaving the store untouched and returning `Err`. (Removing an
+    /// ACL can only narrow grants, so a re-materialization error here is unusual — but the
+    /// rollback keeps the contract uniform with `put_acl`.)
+    ///
+    /// # Errors
+    ///
+    /// `Err` if `acl_iri` is not an `.acl`/`.acr` document IRI, or if re-materializing after
+    /// the removal fails (the store is rolled back first).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use sparq_solid::{Mode, PodStore, Session};
+    ///
+    /// let nquads = r#"
+    /// <https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> "hi" <https://pod.ex/notes/n1> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#agent> <https://alice.ex/card#me> <https://pod.ex/.acl> .
+    /// <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/.acl> .
+    /// "#;
+    /// let mut store = PodStore::new(sparq_core::Graph::load_dataset(nquads, "nquads")?);
+    /// store.materialize_wac()?;
+    /// let alice = Session { agent: Some("https://alice.ex/card#me"), client: None, issuer: None, now: None };
+    /// assert_eq!(store.accessible(&alice, Mode::Read).len(), 2); // granted by the root .acl
+    ///
+    /// // DELETE the root .acl — alice's grant disappears, the view is rebuilt atomically.
+    /// let out = store.delete_acl("https://pod.ex/.acl")?;
+    /// assert!(out.existed);
+    /// assert_eq!(store.accessible(&alice, Mode::Read).len(), 0); // un-protected ⇒ fail closed
+    /// # Ok::<(), String>(())
+    /// ```
+    pub fn delete_acl(&mut self, acl_iri: &str) -> Result<AclWriteOutcome, String> {
+        self.delete_acl_inner(acl_iri, false)
+    }
+
+    /// [`PodStore::delete_acl`] for **ACP** pods: identical atomic removal + re-materialize,
+    /// rebuilding the view with the ACP rules. [OPUS-4.8] sq-snopa.5.
+    pub fn delete_acl_acp(&mut self, acl_iri: &str) -> Result<AclWriteOutcome, String> {
+        self.delete_acl_inner(acl_iri, true)
+    }
+
+    /// Shared `put_acl` body — parse, swap, re-materialize, rollback-on-error.
+    fn put_acl_inner(
+        &mut self,
+        acl_iri: &str,
+        content: &str,
+        format: &str,
+        acp: bool,
+    ) -> Result<AclWriteOutcome, String> {
+        if !is_control_graph(acl_iri) {
+            return Err(format!(
+                "put_acl denied: <{}> is not an access-control document (must end in \
+                 `{}` or `{}`) — write content graphs through `update_as`",
+                acl_iri, ACL_SUFFIX, ACR_SUFFIX
+            ));
+        }
+        let name = NamedNode::new(acl_iri)
+            .map_err(|e| format!("put_acl denied: malformed ACL IRI <{}>: {}", acl_iri, e))?;
+        // PARSE FIRST — a malformed document is rejected before anything mutates.
+        let new_graph = Graph::load_str(content, format).map_err(|e| {
+            format!("put_acl denied: ACL content for <{}> did not parse as {}: {}", acl_iri, format, e)
+        })?;
+        let new_len = graph_len(&new_graph);
+
+        // Capture the prior slot (for rollback) and swap the new content in.
+        let term = Term::NamedNode(name.clone());
+        let prior = self.take_named_slot(&term);
+        let existed = prior.is_some();
+        self.graph.named.push((term.clone(), new_graph));
+
+        // Re-materialize; roll back to the prior content on any error.
+        if let Err(e) = self.rematerialize(acp) {
+            self.restore_named_slot(&term, prior, acp);
+            return Err(e);
+        }
+        Ok(AclWriteOutcome { acl: name, existed, triples: new_len })
+    }
+
+    /// Shared `delete_acl` body — capture, remove, re-materialize, rollback-on-error.
+    fn delete_acl_inner(&mut self, acl_iri: &str, acp: bool) -> Result<AclWriteOutcome, String> {
+        if !is_control_graph(acl_iri) {
+            return Err(format!(
+                "delete_acl denied: <{}> is not an access-control document (must end in \
+                 `{}` or `{}`)",
+                acl_iri, ACL_SUFFIX, ACR_SUFFIX
+            ));
+        }
+        let name = NamedNode::new(acl_iri)
+            .map_err(|e| format!("delete_acl denied: malformed ACL IRI <{}>: {}", acl_iri, e))?;
+        let term = Term::NamedNode(name.clone());
+        let prior = self.take_named_slot(&term);
+        let existed = prior.is_some();
+
+        if let Err(e) = self.rematerialize(acp) {
+            self.restore_named_slot(&term, prior, acp);
+            return Err(e);
+        }
+        Ok(AclWriteOutcome { acl: name, existed, triples: 0 })
+    }
+
+    /// Remove and return the sub-graph currently stored under `name`, if any (so it can be
+    /// swapped or restored). The reserved auth view is never a target here — these methods
+    /// reject non-control IRIs up front.
+    fn take_named_slot(&mut self, name: &Term) -> Option<Graph> {
+        let pos = self.graph.named.iter().position(|(n, _)| n == name)?;
+        Some(self.graph.named.swap_remove(pos).1)
+    }
+
+    /// Restore a captured prior slot after a failed re-materialization, then rebuild the
+    /// auth view from the restored content so the store is left consistent with the PRIOR
+    /// rules (the rollback path). The earlier swap already removed the new content; here we
+    /// re-insert the old content (or leave the slot absent if there was none) and
+    /// re-materialize from it.
+    fn restore_named_slot(&mut self, name: &Term, prior: Option<Graph>, acp: bool) {
+        // Drop whatever is currently in the slot (the new content that failed) and put the
+        // prior content back.
+        let _ = self.take_named_slot(name);
+        if let Some(g) = prior {
+            self.graph.named.push((name.clone(), g));
+        }
+        // Rebuild the auth view from the restored (prior) rules. This re-runs the SAME
+        // materialization that previously succeeded for this content, so it is expected to
+        // succeed; if it somehow fails the prior auth view left in place by the failed run
+        // still stands (materialize leaves the previous view untouched on error) and the
+        // index is rebuilt from it — fail-closed either way.
+        let _ = self.rematerialize(acp);
+    }
+
+    /// Re-materialize the WAC or ACP view (the shared step both write paths end on).
+    fn rematerialize(&mut self, acp: bool) -> Result<(), String> {
+        if acp {
+            self.materialize_acp().map(|_| ())
+        } else {
+            self.materialize_wac().map(|_| ())
+        }
+    }
+}

--- a/crates/sparq-solid/tests/write_through.rs
+++ b/crates/sparq-solid/tests/write_through.rs
@@ -1,0 +1,280 @@
+//! [OPUS-4.8] issue #992 FR-3 (sq-snopa.5): the AUTHORITATIVE ACL write-through.
+//!
+//! Exercises the REAL path — `PodStore::put_acl`/`delete_acl` (WAC) and
+//! `put_acl_acp`/`delete_acl_acp` (ACP) over the live materializer + session oracle — for
+//! the load-bearing invariants:
+//!
+//! - **write-through takes effect immediately**: a `put_acl` granting access makes the
+//!   grant visible through the SAME enforcement path (`accessible`) with no separate
+//!   `materialize_*` call — the auth view is rebuilt atomically by the call;
+//! - **delete narrows**: a `delete_acl` removing the governing ACL revokes the grant;
+//! - **source-of-truth / pure-function**: after a put-then-delete the auth view equals what
+//!   a fresh load + materialize of the SAME final `.acl` graphs produces (no stale grant
+//!   survives a rule change);
+//! - **atomic rollback / fail-closed**: a `put_acl` whose new ACL is rejected at
+//!   materialization (a reserved-encoding principal) leaves the store EXACTLY as it was —
+//!   the prior content and the prior auth view both intact, and `Err` returned;
+//! - **input validation**: a non-`.acl`/`.acr` target IRI and malformed content are both
+//!   rejected before any mutation.
+
+use sparq_core::Graph;
+use sparq_solid::{Mode, PodStore, Session};
+
+fn sess(agent: &str) -> Session<'_> {
+    Session { agent: Some(agent), client: None, issuer: None, now: None }
+}
+
+const ALICE: &str = "https://alice.ex/card#me";
+const BOB: &str = "https://bob.ex/card#me";
+
+/// A root `.acl` (N-Triples body, no graph column — `put_acl` parses the document body)
+/// granting `agent` `Read` on the whole pod by `acl:default`.
+fn root_acl_read(agent: &str) -> String {
+    format!(
+        "<https://pod.ex/.acl#owner> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> .\n\
+         <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> .\n\
+         <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#agent> <{agent}> .\n\
+         <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n"
+    )
+}
+
+/// One content document under /notes/, no ACL — every session fails closed until one is PUT.
+fn empty_pod() -> PodStore {
+    let nq = "<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> \"hi\" <https://pod.ex/notes/n1> .\n";
+    let mut store = PodStore::new(Graph::load_dataset(nq, "nquads").expect("loads"));
+    store.materialize_wac().expect("materializes");
+    store
+}
+
+/// How many triples the named graph `name` holds in the store (0 if absent).
+fn graph_len(store: &PodStore, name: &str) -> usize {
+    let term = oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked(name));
+    store
+        .graph
+        .named
+        .iter()
+        .find(|(n, _)| *n == term)
+        .map(|(_, g)| {
+            let pat: sparq_core::store::Pattern = [None, None, None];
+            g.store.scan(&pat).rows.len()
+        })
+        .unwrap_or(0)
+}
+
+// --- put_acl: create + immediate effect ------------------------------------------------
+
+#[test]
+fn put_acl_creates_and_takes_effect_immediately() {
+    let mut store = empty_pod();
+    let alice = sess(ALICE);
+    assert_eq!(store.accessible(&alice, Mode::Read).len(), 0, "no grant before PUT");
+
+    let out = store
+        .put_acl("https://pod.ex/.acl", &root_acl_read(ALICE), "ntriples")
+        .expect("put_acl succeeds");
+    assert!(!out.existed, "a fresh .acl is CREATED, not replaced");
+    assert_eq!(out.acl.as_str(), "https://pod.ex/.acl");
+    assert!(out.triples >= 4, "the four authorization triples are stored");
+
+    // No separate materialize_wac() — the write-through rebuilt the view atomically.
+    assert_eq!(
+        store.accessible(&alice, Mode::Read).len(),
+        2,
+        "alice now reads n1 + the notes/ container"
+    );
+}
+
+// --- put_acl: replace swaps the grant wholesale ----------------------------------------
+
+#[test]
+fn put_acl_replaces_rules_wholesale() {
+    let mut store = empty_pod();
+    store
+        .put_acl("https://pod.ex/.acl", &root_acl_read(ALICE), "ntriples")
+        .expect("first put");
+    assert_eq!(store.accessible(&sess(ALICE), Mode::Read).len(), 2);
+    assert_eq!(store.accessible(&sess(BOB), Mode::Read).len(), 0);
+
+    // PUT a NEW body that grants BOB instead of alice — the old rules are gone.
+    let out = store
+        .put_acl("https://pod.ex/.acl", &root_acl_read(BOB), "ntriples")
+        .expect("replace");
+    assert!(out.existed, "the .acl already existed → replaced");
+    assert_eq!(store.accessible(&sess(BOB), Mode::Read).len(), 2, "bob now reads");
+    assert_eq!(
+        store.accessible(&sess(ALICE), Mode::Read).len(),
+        0,
+        "alice's grant was REPLACED, not merged"
+    );
+}
+
+// --- delete_acl: narrows access --------------------------------------------------------
+
+#[test]
+fn delete_acl_revokes_and_rebuilds_atomically() {
+    let mut store = empty_pod();
+    store
+        .put_acl("https://pod.ex/.acl", &root_acl_read(ALICE), "ntriples")
+        .expect("put");
+    assert_eq!(store.accessible(&sess(ALICE), Mode::Read).len(), 2);
+
+    let out = store.delete_acl("https://pod.ex/.acl").expect("delete");
+    assert!(out.existed);
+    assert_eq!(out.triples, 0);
+    assert_eq!(graph_len(&store, "https://pod.ex/.acl"), 0, "the .acl graph is gone");
+    assert_eq!(
+        store.accessible(&sess(ALICE), Mode::Read).len(),
+        0,
+        "un-protected ⇒ every session fails closed"
+    );
+}
+
+#[test]
+fn delete_absent_acl_is_noop_success() {
+    let mut store = empty_pod();
+    let out = store
+        .delete_acl("https://pod.ex/missing.acl")
+        .expect("deleting an absent ACL is a no-op success");
+    assert!(!out.existed, "nothing was there");
+}
+
+// --- source-of-truth: the auth view is a PURE FUNCTION of the present .acl graphs -------
+
+#[test]
+fn auth_view_is_pure_function_of_final_acl_state() {
+    // Path A: empty pod → PUT alice's ACL → PUT bob's ACL → DELETE → PUT alice again.
+    let mut a = empty_pod();
+    a.put_acl("https://pod.ex/.acl", &root_acl_read(ALICE), "ntriples").unwrap();
+    a.put_acl("https://pod.ex/.acl", &root_acl_read(BOB), "ntriples").unwrap();
+    a.delete_acl("https://pod.ex/.acl").unwrap();
+    a.put_acl("https://pod.ex/.acl", &root_acl_read(ALICE), "ntriples").unwrap();
+
+    // Path B: load the SAME final dataset (n1 content + alice's .acl) from scratch.
+    let final_nq = format!(
+        "<https://pod.ex/notes/n1#it> <https://ex.dev/ns#title> \"hi\" <https://pod.ex/notes/n1> .\n\
+         <https://pod.ex/.acl#owner> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://pod.ex/.acl> .\n\
+         <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> <https://pod.ex/.acl> .\n\
+         <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#agent> <{ALICE}> <https://pod.ex/.acl> .\n\
+         <https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://pod.ex/.acl> .\n"
+    );
+    let mut b = PodStore::new(Graph::load_dataset(&final_nq, "nquads").unwrap());
+    b.materialize_wac().unwrap();
+
+    // The two stores authorize IDENTICALLY — no stale grant survived the put/delete churn.
+    for s in [sess(ALICE), sess(BOB), Session::default()] {
+        for mode in [Mode::Read, Mode::Write, Mode::Append, Mode::Control] {
+            assert_eq!(
+                a.accessible(&s, mode).len(),
+                b.accessible(&s, mode).len(),
+                "write-through churn must converge to the same auth view as a fresh load ({:?}, {:?})",
+                s.agent,
+                mode
+            );
+        }
+    }
+}
+
+// --- atomic rollback: a rejected new ACL leaves the store EXACTLY as it was -------------
+
+#[test]
+fn put_acl_rolls_back_on_reserved_principal() {
+    let mut store = empty_pod();
+    // Establish a known-good grant first.
+    store
+        .put_acl("https://pod.ex/.acl", &root_acl_read(ALICE), "ntriples")
+        .expect("good put");
+    assert_eq!(store.accessible(&sess(ALICE), Mode::Read).len(), 2);
+    let prior_acl_len = graph_len(&store, "https://pod.ex/.acl");
+
+    // Now PUT a body naming a RESERVED-encoding agent — materialization REJECTS it.
+    let bad = "<https://pod.ex/.acl#owner> <http://www.w3.org/ns/auth/acl#agent> <urn:sparq:evil> .\n";
+    let err = store
+        .put_acl("https://pod.ex/.acl", bad, "ntriples")
+        .expect_err("reserved-encoding principal must be rejected");
+    assert!(err.contains("urn:sparq:") || err.to_lowercase().contains("reserved"), "{err}");
+
+    // Atomic: the PRIOR content and the PRIOR auth view are both intact.
+    assert_eq!(
+        graph_len(&store, "https://pod.ex/.acl"),
+        prior_acl_len,
+        "the rejected content was rolled back — prior .acl restored"
+    );
+    assert_eq!(
+        store.accessible(&sess(ALICE), Mode::Read).len(),
+        2,
+        "alice's prior grant still stands after the failed put (no partial write)"
+    );
+}
+
+// --- input validation ------------------------------------------------------------------
+
+#[test]
+fn put_acl_rejects_non_control_iri() {
+    let mut store = empty_pod();
+    let err = store
+        .put_acl("https://pod.ex/notes/n1", "", "ntriples")
+        .expect_err("a content graph IRI is not an ACL target");
+    assert!(err.contains("access-control document"), "{err}");
+    // The content graph was NOT touched.
+    assert_eq!(graph_len(&store, "https://pod.ex/notes/n1"), 1);
+}
+
+#[test]
+fn delete_acl_rejects_non_control_iri() {
+    let mut store = empty_pod();
+    let err = store
+        .delete_acl("https://pod.ex/notes/n1")
+        .expect_err("a content graph IRI is not an ACL target");
+    assert!(err.contains("access-control document"), "{err}");
+    assert_eq!(graph_len(&store, "https://pod.ex/notes/n1"), 1, "content graph untouched");
+}
+
+#[test]
+fn put_acl_rejects_malformed_content() {
+    let mut store = empty_pod();
+    let err = store
+        .put_acl("https://pod.ex/.acl", "this is not RDF <<<", "ntriples")
+        .expect_err("malformed content must be rejected");
+    assert!(err.contains("did not parse"), "{err}");
+    // Nothing was created.
+    assert_eq!(graph_len(&store, "https://pod.ex/.acl"), 0);
+}
+
+// --- ACP variant -----------------------------------------------------------------------
+
+#[test]
+fn put_acl_acp_creates_and_takes_effect() {
+    // An empty ACP pod: one content doc under /docs/, no .acr yet.
+    let nq = "<https://pod.ex/docs/d0#it> <https://ex.dev/ns#k> \"v\" <https://pod.ex/docs/d0> .\n";
+    let mut store = PodStore::new(Graph::load_dataset(nq, "nquads").unwrap());
+    store.materialize_acp().unwrap();
+    let alice = sess(ALICE);
+    assert_eq!(store.accessible(&alice, Mode::Read).len(), 0, "no grant yet");
+
+    // A root .acr granting alice Read on all member resources (memberAccessControl).
+    let acp = "http://www.w3.org/ns/solid/acp#";
+    let acr = format!(
+        "<https://pod.ex/.acr> <{acp}memberAccessControl> <https://pod.ex/.acr#c> .\n\
+         <https://pod.ex/.acr#c> <{acp}apply> <https://pod.ex/.acr#pol> .\n\
+         <https://pod.ex/.acr#pol> <{acp}allow> <http://www.w3.org/ns/auth/acl#Read> .\n\
+         <https://pod.ex/.acr#pol> <{acp}allOf> <https://pod.ex/.acr#m> .\n\
+         <https://pod.ex/.acr#m> <{acp}agent> <{ALICE}> .\n"
+    );
+    let out = store
+        .put_acl_acp("https://pod.ex/.acr", &acr, "ntriples")
+        .expect("put_acl_acp succeeds");
+    assert!(!out.existed);
+    assert!(
+        !store.accessible(&alice, Mode::Read).is_empty(),
+        "the ACP grant is materialized and visible immediately"
+    );
+
+    // DELETE the .acr → grant gone, atomically.
+    let out = store.delete_acl_acp("https://pod.ex/.acr").expect("delete_acl_acp");
+    assert!(out.existed);
+    assert_eq!(
+        store.accessible(&alice, Mode::Read).len(),
+        0,
+        "removing the .acr revokes the grant"
+    );
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -115,6 +115,19 @@ Materialize the authorization view from the access-control documents, then enfor
 - `store.update_as(&Session, sparql)` / `store.update_as_acp(...)` — **write-path
   gating**: check every graph an update could mutate *before* applying, and
   auto-re-materialize on `.acl`/`.acr` writes.
+- `store.put_acl(acl_iri, content, format) -> AclWriteOutcome` /
+  `store.delete_acl(acl_iri)` (+ `…_acp` variants) — **authoritative ACL write-through**
+  ([OPUS-4.8] issue #992 FR-3, sq-snopa.5): the LDP `PUT`/`DELETE /resource.acl` STORAGE
+  primitive. Replaces (or removes) the `.acl`/`.acr` GRAPH and re-materializes
+  `<urn:sparq:auth>` as ONE **atomic, fail-closed** unit, so SPARQ stays the source of
+  truth (the auth view is always a pure function of the present `.acl` graphs — no stale
+  grant survives a rule change). `content` is parsed FIRST (malformed ⇒ `Err`, nothing
+  mutated); a re-materialization failure (e.g. a reserved-encoding principal) ROLLS BACK to
+  the prior content + prior auth view (all-or-nothing). A non-`.acl`/`.acr` target IRI is
+  rejected (write content graphs through `update_as`). It performs **NO session
+  authorization** — the server authorizes the request itself (e.g. `decide(.., Mode::Control)`)
+  and `update_as` remains the session-checked write path. Always-present API (no cargo gate;
+  mirrors `update_as`/`decide` — adds no dependency).
 - `store.accessible(&Session, Mode) -> Arc<Vec<NamedNode>>` /
   `store.accessible_set(...)` / `store.view_for(...) -> DatasetView` /
   `store.auth() -> &AuthIndex` — inspect the authorized graph set or the materialized


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus 4.8). Implements issue #992 **FR-3** (bead `sq-snopa.5`), building on the merged FR-1 decide layer (#1193).

## What

A `PUT`/`DELETE` to a `.acl`/`.acr` document now updates the access-control **graph** AND re-materializes `<urn:sparq:auth>` as **one atomic, fail-closed unit** — keeping SPARQ the source of truth (the auth view is always a *pure function* of the present `.acl` graphs; no stale grant survives a rule change).

New public surface on `PodStore` (`crates/sparq-solid/src/write_through.rs`):

- `put_acl(acl_iri, content, format) -> AclWriteOutcome` / `put_acl_acp(…)` — LDP-`PUT`-on-`.acl` storage primitive: replace the control graph + re-materialize.
- `delete_acl(acl_iri)` / `delete_acl_acp(…)` — LDP-`DELETE`-on-`.acl`: remove the control graph + re-materialize (narrows access).
- `AclWriteOutcome { acl, existed, triples }`.

## Atomicity & fail-closed (the load-bearing invariant)

All-or-nothing:
1. `content` is **parsed first** — a malformed document is rejected before anything mutates;
2. the prior control-graph slot is captured, the new content swapped in (or the slot removed);
3. the auth view is re-materialized;
4. on **any** re-materialization error (e.g. the new ACL names a reserved-encoding principal) the **prior content + prior auth view are restored** and `Err` is returned — never a control graph updated without its matching auth view, never a partial write.

A non-`.acl`/`.acr` target IRI is rejected (write content graphs through `update_as`).

## Scope (honest)

These are the **storage primitive** the server calls *after* it has authorized the request through its own pipeline (e.g. `decide(.., Mode::Control)`); they perform **NO session authorization**. `update_as` remains the session-checked write path. Documented in the rustdoc + the access-control SKILL.

## Design / judgment call (proceed-and-document)

Implemented **always-compiled (no cargo feature gate)**, mirroring `update_as`/`decide`/`resolve_acl` — it adds **zero new dependency** and reuses only the always-present materialize + named-graph machinery, so the lean-core constraint is already satisfied and a feature gate would only diverge from the crate's established pattern. Rationale + an offer to move it behind a default-OFF feature if preferred: **#1210**.

No net-new **cfg-gated** test, so no `feature-matrix.yml` leg is needed — `tests/write_through.rs` runs under default features and is covered by the standard test lane.

## Gates (run in-worktree, BOTH feature states)

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — green **default (feature OFF)** AND **`--all-features` (ON)**. Exact flags: default (none) and `--all-features` (= `odrl-bridge,count-enforcement,trust-graph,trust-graph-did`).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean (intra-doc links to `Mode::Control`/`PodStore::put_acl` resolve).
- `scripts/check-readme-template.py --enforce` — 0 deviations; README still **120 lines** (≤120).
- `scripts/check-privacy-claims.sh` — clean.
- `tests/write_through.rs` (10 tests, real path): immediate effect, wholesale replace, delete-narrows, the **source-of-truth pure-function invariant** (put/delete churn converges to a fresh-load auth view), **atomic rollback** on a reserved-encoding principal, non-control-IRI + malformed-content rejection, ACP variant. + 2 new doc-tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)