### PR TITLE
feat(sparq-trust): live status/revocation over a W3C Bitstring Status List + minimal denial justification (sq-pfae.7) [OPUS-4.8]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -646,6 +646,27 @@ jobs:
             crate: sparq-vectors
             features: kge
             test: true
+          # [OPUS-4.8] sq-pfae.7 (epic sq-pfae P6): the live-status / revocation stratum. The
+          # whole `status_list` module + the `admit::admit_with_status` wiring + the
+          # `tests/live_status_e2e.rs` integration suite (`#![cfg(feature = "status-list")]`)
+          # are behind the default-OFF `status-list` feature, so ci.yml's default-feature
+          # `nextest archive --workspace --all-targets` (which passes NO `--features`) compiles
+          # them EMPTY and runs ZERO of the 18 module unit tests + the 5 e2e fail-closed tests —
+          # the silent-skip gap (#1171) this leg closes. The `status-list-flate2` SUPERSET
+          # feature additionally compiles the built-in `flate2` GZIP decoder + its real-gzip
+          # round-trip test, so a single leg with that feature reaches EVERY status-list cfg
+          # (the leg's `--features` set is a superset of both `status-list` and
+          # `status-list-flate2`). The leg runs `clippy --all-targets -D warnings` with the
+          # feature ON (the real gate) + `cargo test`, which drives the REAL gate path
+          # (admit_with_status → derive_grants over a decoded Bitstring Status List) and the
+          # load-bearing SAFETY invariant: fail-closed on set/unknown/stale + a minimal denial
+          # justification. Verified: `cargo nextest list -p sparq-trust --features
+          # status-list-flate2` lists the status_list::tests unit suite + the live_status_e2e
+          # integration tests.
+          - name: sparq-trust (status-list-flate2 — live status/revocation + denial justification)
+            crate: sparq-trust
+            features: status-list-flate2
+            test: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Install Rust (stable)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3763,6 +3763,7 @@ dependencies = [
 name = "sparq-trust"
 version = "0.1.0"
 dependencies = [
+ "flate2",
  "oxrdf 0.3.3",
  "oxttl 0.2.3",
  "serde_json",

--- a/crates/sparq-trust/Cargo.toml
+++ b/crates/sparq-trust/Cargo.toml
@@ -65,6 +65,20 @@ secprop-admissibility = ["secprop-vocab"]
 # graph; the audit is a small fixed triple set emitted directly). Strictly additive: the
 # lean default build is byte-identical with it OFF.
 delegation-prov = []
+# [OPUS-4.8] sq-pfae.7 — live credential status / revocation over a W3C Bitstring Status
+# List + a minimal PROV-O denial justification (the P6 status stratum). Fetch (pluggable
+# `StatusListResolver`) + decode (hand-rolled multibase base64url/base58btc over a pluggable
+# `GzipDecoder` seam) a status list, gate derivations **fail-closed on set/unknown/stale**,
+# and render a minimal `prov:`/`trust:` justification per allow OR deny. The base layer is
+# DEPENDENCY-FREE (the multibase decode + the PROV-O render are pure `oxrdf` over a
+# caller-supplied decoder) — NO new dependency on the lean default build, strictly additive
+# (byte-identical with it OFF).
+status-list = []
+# The built-in `flate2` GZIP decoder (`Flate2GzipDecoder`) for the spec-mandated GZIP
+# `encodedList` payload. Nested under `status-list`: it pulls `flate2` ONLY when a caller
+# opts into the convenience codec; the plain `status-list` feature stays dependency-free and
+# decodes over a caller-supplied `GzipDecoder`.
+status-list-flate2 = ["status-list", "dep:flate2"]
 
 [dependencies]
 sparq-core = { path = "../sparq-core", default-features = false }
@@ -80,6 +94,10 @@ oxrdf.workspace = true
 # OPTIONAL — `did` feature only. Parses a fetched `did:web` DID document (JSON). The
 # `did:key` path needs no JSON; the default build pulls neither.
 serde_json = { version = "1", optional = true }
+# OPTIONAL — `status-list-flate2` feature only. The built-in GZIP decoder for the
+# spec-mandated GZIP `encodedList` payload (`sq-pfae.7`). The plain `status-list` feature is
+# dependency-free over a caller-supplied decoder; the default build pulls neither.
+flate2 = { version = "1", optional = true }
 
 # Test-only: parse-validate the published machine-readable vocabulary
 # `ontologies/trust/trust.ttl` so the Turtle a working group reads stays valid

--- a/crates/sparq-trust/README.md
+++ b/crates/sparq-trust/README.md
@@ -63,49 +63,49 @@ view; `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
   signature over the commitment (`sparq-zk`, never a self-asserted triple), enforce statement-type scoping
   via a real SHACL shape (`sparq-shacl`), freshness, and the clear-WebID holder binding. Default-deny.
 - **N3 merge** (`wire`) — feed admitted facts into `sparq-reason`; the `.acr` ABAC rule derives the grant (age>18 e2e).
-- **Storage / authoring model** (`store`, **opt-in `store` feature**, `sq-pfae.5`) — a server-wide
-  default + per-`.acr` documents that **NARROW, never broaden** the server ceiling (`effective_rules`);
-  monotone versioning (stale rejected) + revocation; the `AdmissionCacheKey` (evidence hash + policy
-  version) composes with the sparq-solid epoch cache (edit/revoke invalidates the verdict). No new dep.
-- **Static / dynamic admission split** (`admit_static` + `derive_conditional_grants`, `sq-xc4y`) —
-  decides the **session-independent** class (signature, type-scope, scope) once at materialise-time and
-  defers the **per-request** class (holder + freshness) to an `auth:ConditionalGrant` re-checked per request.
-- **The invocation-binding gate** (`delegation`, `sq-l5og`) — verify a carried ZCAP/UCAN-style delegation
-  chain (each hop a CHECKED delegator signature over delegator/delegate **keys** + capability + expiry),
-  enforce monotone attenuation (`child ⊆ parent`), and bind **authenticated invoker == the chain's terminal
-  delegate, key-proven per request** via a fresh-challenge PoP. Folding each hop's `delegate_key` into the
-  signed preimage defeats the key-substitution stolen-chain replay; the forgery matrix runs end-to-end.
+- **Storage / authoring model** (`store`, **opt-in `store` feature**, `sq-pfae.5`) — a server-wide default +
+  per-`.acr` documents that **NARROW, never broaden** the server ceiling (`effective_rules`); monotone versioning
+  (stale rejected) + revocation; the `AdmissionCacheKey` (evidence hash + policy version) composes with the
+  sparq-solid epoch cache (edit/revoke invalidates the verdict). No new dep.
+- **Static / dynamic admission split** (`admit_static` + `derive_conditional_grants`, `sq-xc4y`) — decides the
+  **session-independent** class once at materialise-time and defers the **per-request** class (holder + freshness)
+  to an `auth:ConditionalGrant` re-checked per request.
+- **The invocation-binding gate** (`delegation`, `sq-l5og`) — verify a carried ZCAP/UCAN-style delegation chain
+  (each hop a CHECKED delegator signature over delegator/delegate **keys** + capability + expiry), enforce monotone
+  attenuation (`child ⊆ parent`), and bind **authenticated invoker == the chain's terminal delegate, key-proven per
+  request** via a fresh-challenge PoP — folding `delegate_key` into the preimage defeats the stolen-chain replay.
 - **Delegation PROV-O audit** (`delegation_prov`, **opt-in `delegation-prov`**, `sq-pfae.6`) — render an
-  invocation-bound chain as a minimal W3C PROV-O graph: `prov:actedOnBehalfOf` per hop, the human/AI
-  principal as an attested attribute (`trust:HumanPrincipal`/`AiAgent`, §4.2), the effective grant as `auth:*`
-  RDF. Pure `oxrdf`, NO `sparq-prov` edge. A record, never authority: emitted *after* the gate (never broader).
+  invocation-bound chain as a minimal W3C PROV-O graph (`prov:actedOnBehalfOf` per hop, human/AI principal as an
+  attested attribute, the effective grant as `auth:*` RDF). Pure `oxrdf`, NO `sparq-prov` edge; a record, never authority.
 - **DID issuer-key binding** (`did`, **opt-in `did` feature**, `sq-pfae.3`) — a rule may name its issuer by
-  `trust:issuerDid` instead of `trust:issuerKey` hex. `DidKeyResolver` decodes a `did:key` offline;
-  `DidWebResolver` reads `did:web` via a **pluggable** fetcher (no default HTTP client). **Narrows** D′ (no absolute anchor).
-- **Security-properties vocabulary** (`secprop`, **opt-in `secprop-vocab`**, `sq-5oru9`) — the sparq
-  **`sec-prop:` extension** (constants + [`secprop-ext.ttl`](ontologies/zkp-sparql/secprop-ext.ttl)): orthogonal
-  proof-system dimensions + the **assurance / audit-status axis** the vendored `sec-prop:` lacks (extend, not
-  fork). Records a claim + basis, NOT a proof; default `Claimed`, no `Proven` while `sq-qhy4` open.
-- **N3 proof-admissibility** (`admissibility`, **opt-in `secprop-admissibility`**, `sq-ufsi9`) — the §4.3 ODRL →
-  admissible-proof-set reduction (`strongerThan`-closure / `atLeast` / `overDimension` / `satisfies`) as a
-  RUNNABLE N3 ruleset on `sparq-reason`, with the Rust **default-deny** universal (`admissible`). Reasons over
+  `trust:issuerDid` instead of `trust:issuerKey` hex (`DidKeyResolver` decodes `did:key` offline; `DidWebResolver`
+  reads `did:web` via a **pluggable** fetcher). **Narrows** the forgery vector D′ (no absolute anchor).
+- **Security properties** (`secprop` / `admissibility`, **opt-in `secprop-vocab` / `secprop-admissibility`**,
+  `sq-5oru9` / `sq-ufsi9`) — the sparq **`sec-prop:` extension** ([`secprop-ext.ttl`](ontologies/zkp-sparql/secprop-ext.ttl);
+  orthogonal proof-system dimensions + the **assurance / audit-status axis** the vendored ontology lacks) and the §4.3
+  ODRL → admissible-proof-set reduction as a RUNNABLE N3 ruleset on `sparq-reason` (Rust **default-deny**). Reasons over
   ANNOTATIONS, not crypto: `requiresAssurance gteq Proven` empties the admissible set today (`sq-qhy4`).
+- **Live status / revocation** (`status_list`, **opt-in `status-list`**, `sq-pfae.7`) — gate derivations on a **live
+  W3C Bitstring Status List** instead of the `revoked: bool` flag: fetch (pluggable `StatusListResolver`) + decode
+  (hand-rolled multibase over a pluggable `GzipDecoder`; built-in `Flate2GzipDecoder` behind `status-list-flate2`),
+  then `admit_with_status` admits ONLY a `LiveStatus::Live` credential — **fail-closed on set/unknown/stale** — and
+  emits a minimal `prov:`/`trust:` denial justification. No new default dep; the list VC's own signature is not yet
+  verified (resolver is the trust seam; follow-up bead captured).
 
 ## Honest scope — what this does and does NOT do
 
 - **No privacy / unlinkability / anonymity.** The credential is admitted **in the clear**; the
   verifier learns the exact value (`age 25`, not "≥ 18"). This does **not** match ZKAPs-grade unlinkable presentation.
-- **Holder binding is the clear-WebID, non-anonymous degraded path** (`sq-wvne`):
-  `credentialSubject == Session.agent` authenticates the WebID in the clear — not silently "solved"; presentations stay linkable by requester identity.
-- **Issuer keys: operator-asserted by default; DID-bindable (opt-in, `sq-pfae.3`).** The default
-  `trust:issuerKey` hex binding is the live forgery vector D′ (§3.3); the `did` feature binds from a
-  `trust:issuerDid` instead — **narrows** D′ but no absolute anchor (`did:key` self-cert; `did:web` host/TLS).
-- **Delegation invocation is the clear-WebID, non-anonymous path too** (`sq-l5og`): the gate
-  authenticates the invoker AS the terminal delegate's WebID in the clear. The `delegate_key` binding
-  defeats key-substitution stolen-chain replay but **not** full non-replayability; deep-chain
-  *incremental* revocation stays open. The `delegation-prov` PROV-O audit adds NO security property —
-  it records *who acted on whose behalf* (a record, not an authority; rustdoc has the full reasoning).
-- **Open problems respected as documented limitations:** `sq-tu4e` (no in-reasoner NAF; `revoked` input-only) + `sq-wvne` (ZK privacy) are **out of PoC scope**; `sq-xc4y` RESOLVED; `sq-l5og` **specified + enforced + tested**.
+- **Holder binding + delegation invocation are the clear-WebID, non-anonymous paths** (`sq-wvne` / `sq-l5og`):
+  `credentialSubject == Session.agent` (and the invoker == terminal delegate) authenticate the WebID in the clear —
+  not silently "solved"; presentations stay linkable by requester identity. The `delegate_key` binding defeats the
+  key-substitution stolen-chain replay but not full non-replayability. The `delegation-prov` / `status_list` PROV-O
+  records add NO security property — an audit fact, not authority.
+- **Issuer keys: operator-asserted by default; DID-bindable (opt-in, `sq-pfae.3`).** The default `trust:issuerKey`
+  hex binding is the live forgery vector D′ (§3.3); the `did` feature binds from a `trust:issuerDid` instead —
+  **narrows** D′ but no absolute anchor (`did:key` self-cert; `did:web` host/TLS).
+- **Open problems respected:** `sq-wvne` (ZK privacy) is **out of PoC scope**; `sq-xc4y` RESOLVED; `sq-l5og`
+  **specified + enforced + tested**; `sq-tu4e` (live status) is now the opt-in `status-list` gate (`sq-pfae.7`).
 - **Strict additivity (G6):** with `sparq-solid`'s `trust-graph` feature OFF the crate is not compiled — `sparq-solid` behaves exactly as WAC/ACP do today (byte-identical).
 
 ## 📚 Learn more

--- a/crates/sparq-trust/src/admit.rs
+++ b/crates/sparq-trust/src/admit.rs
@@ -340,6 +340,52 @@ pub fn admit_static(
     admitted
 }
 
+/// Run the admission gate over a presented credential, gating on a **live** credential
+/// status (the P6 status stratum, `sq-pfae.7`) instead of the PoC's per-credential
+/// `revoked: bool` flag. This is the OPT-IN (`status-list` feature) wiring of the
+/// [`crate::status_list`] gate into the REAL admission path.
+///
+/// The credential's [`crate::status_list::StatusListEntry`] is checked against the live
+/// W3C Bitstring Status List via the caller's [`crate::status_list::LiveStatusCheck`] at
+/// `session.now_unix_secs`. The credential is admitted ONLY when the status
+/// [`crate::status_list::LiveStatus::admits`] (i.e. the bit is unset, the list resolved +
+/// decoded, the index is in range, and the snapshot is fresh) — **fail-closed on
+/// set/unknown/stale** exactly as the bead requires. On a non-admitting status the WHOLE
+/// credential is denied (empty result), mirroring where the `cred.revoked` flag dropped it.
+///
+/// When the status admits, this delegates to the unchanged [`admit`] — every other gate
+/// (signature, statement-type scope, freshness, holder binding) is untouched, so this is
+/// strictly additive: it can only NARROW, never broaden, what [`admit`] admits.
+///
+/// Returns `(admitted, status)`: the admitted facts and the [`crate::status_list::LiveStatus`]
+/// the decision rested on, so the caller can render a [`crate::status_list::justify_status_decision`]
+/// justification for the allow OR the deny.
+#[cfg(feature = "status-list")]
+#[cfg_attr(docsrs, doc(cfg(feature = "status-list")))]
+pub fn admit_with_status<R, D>(
+    cred: &PresentedCredential,
+    rules: &[TrustRule],
+    session: &Session,
+    target: &NamedNode,
+    status_entry: &crate::status_list::StatusListEntry,
+    status_check: &crate::status_list::LiveStatusCheck<R, D>,
+) -> (Vec<AdmittedFact>, crate::status_list::LiveStatus)
+where
+    R: crate::status_list::StatusListResolver,
+    D: crate::status_list::GzipDecoder,
+{
+    // The live status gate runs FIRST (fail-closed): a set/unknown/stale status denies the
+    // whole credential before any fact is admitted. This replaces the `cred.revoked` flag
+    // with a check against the live list — the bead's "gate derivations on validity".
+    let status = status_check.check(status_entry, session.now_unix_secs);
+    if !status.admits() {
+        return (Vec::new(), status);
+    }
+    // Status admits ⇒ run the unchanged gate. (The `cred.revoked` boolean still applies as
+    // the PoC's belt-and-braces input guard; a caller using the live path sets it `false`.)
+    (admit(cred, rules, session, target), status)
+}
+
 /// `scope_covers(scope, target)` — exact-IRI or ancestor-container containment
 /// (Solid slash-semantics). v1 is exact-or-prefix: a rule scoped to a container
 /// covers its members; a rule scoped to a resource covers exactly that resource. A

--- a/crates/sparq-trust/src/lib.rs
+++ b/crates/sparq-trust/src/lib.rs
@@ -154,6 +154,16 @@ pub mod secprop;
 #[cfg(feature = "store")]
 #[cfg_attr(docsrs, doc(cfg(feature = "store")))]
 pub mod store;
+/// Live credential status / revocation over a W3C Bitstring Status List + a minimal PROV-O
+/// denial justification (the P6 status stratum, `sq-pfae.7`): fetch (pluggable resolver) +
+/// decode (multibase + a pluggable GZIP seam) a status list, gate derivations **fail-closed
+/// on set/unknown/stale** status, and render a minimal `prov:`/`trust:` justification per
+/// allow OR deny. Behind the default-OFF `status-list` feature (dependency-free; the nested
+/// `status-list-flate2` feature adds the built-in `flate2` GZIP decoder): nothing in the lean
+/// default build depends on it.
+#[cfg(feature = "status-list")]
+#[cfg_attr(docsrs, doc(cfg(feature = "status-list")))]
+pub mod status_list;
 pub mod vocab;
 pub mod wire;
 
@@ -162,6 +172,8 @@ pub use admissibility::{admissible, ruleset, Admissibility};
 pub use admit::{
     admit, admit_static, AdmittedFact, PresentedCredential, Session, StaticAdmittedFact,
 };
+#[cfg(feature = "status-list")]
+pub use admit::admit_with_status;
 pub use delegation::{
     effective_against_current, hop_message, invoke, Capability, DelegationChain, DelegationHop,
     EffectiveCapability, Invocation, InvocationDenied,
@@ -181,5 +193,11 @@ pub use policy::{resolve_rule_keys, IssuerBinding};
 #[cfg(feature = "store")]
 pub use store::{
     AdmissionCacheKey, PolicyVersion, StoreError, TrustDocument, TrustLayer, TrustStore,
+};
+#[cfg(feature = "status-list")]
+pub use status_list::{
+    decode_encoded_list, justify_status_decision, GzipDecoder, IdentityGzipDecoder, LiveStatus,
+    LiveStatusCheck, StatusBitstring, StatusJustification, StatusListEntry, StatusListResolver,
+    StatusPurpose,
 };
 pub use wire::{derive_conditional_grants, derive_grants, ConditionalGrant};

--- a/crates/sparq-trust/src/status_list.rs
+++ b/crates/sparq-trust/src/status_list.rs
@@ -1,0 +1,847 @@
+//! # `status_list.rs` — live credential status / revocation + a minimal denial justification (`sq-pfae.7`)
+//!
+//! The **P6 status stratum** (design `research/solid-trust-graph-authz-design.md` §6.1
+//! item 6; issue #940 / gh-940): replace the PoC's per-request `revoked: bool` input flag
+//! (the `sq-tu4e` input-only guard) with a check against a **live W3C Bitstring Status
+//! List** ([VC-BITSTRING-STATUS-LIST](https://www.w3.org/TR/vc-bitstring-status-list/)),
+//! and render a **minimal PROV-O justification** for the resulting allow OR deny.
+//!
+//! It is **OPT-IN**: the whole module sits behind the default-OFF `status-list` cargo
+//! feature, so the lean default `sparq-trust` build (and the byte-identical default
+//! `sparq-solid` build) gain nothing — strict additivity (design §2.2 G6) is preserved.
+//!
+//! ## What a credential's status entry says
+//!
+//! A `BitstringStatusListEntry` (the credential's `credentialStatus`) names:
+//! - a `statusListCredential` IRI (where the published list lives),
+//! - a `statusListIndex` (this credential's slot in that list), and
+//! - a `statusPurpose` (`revocation` / `suspension`).
+//!
+//! The published list is itself a Verifiable Credential whose `credentialSubject` carries
+//! an `encodedList`: a **multibase** string (`u` = base64url-no-pad per the current spec,
+//! or the legacy `z`-base58btc StatusList2021 form) over the **GZIP-compressed** status
+//! bitstring. Bit `i` is `bits[i >> 3] & (0x80 >> (i & 7))` — **MSB-first within each byte**,
+//! the Bitstring-Status-List §3.2 "leftmost bit is index 0" convention (this is the
+//! *opposite* of the legacy StatusList2021 LSB-first layout the ZK
+//! `sparq-zk-compose::StatusListSnapshot` mirror uses; that mirror is for the hidden-index
+//! ZK proof, NOT this clear-index gate — see *Why a separate decoder*).
+//!
+//! ## Fail-closed by construction (`sq-pfae.7`: "fail-closed on unknown/stale")
+//!
+//! The check returns a [`LiveStatus`] that is **`Live` only** when EVERY condition holds:
+//! the list resolved, decoded, the index is in range, the bit is **unset**, and the
+//! snapshot is **fresh** (its `as_of_unix_secs` is within the caller's `max_age_secs`).
+//! Every other outcome **denies**:
+//! - [`LiveStatus::Set`] — the status bit is set (revoked/suspended): deny.
+//! - [`LiveStatus::Unknown`] — no resolver wired, the list did not resolve, did not
+//!   decode, or the index is out of range: deny (**fail-closed on unknown**, NOT
+//!   fail-open). An out-of-range index is treated as not-covered (Unknown), never Live.
+//! - [`LiveStatus::Stale`] — the snapshot is older than `max_age_secs`: deny
+//!   (**fail-closed on stale**).
+//!
+//! [`LiveStatus::admits`] is the single fail-closed predicate: `true` for `Live` ONLY.
+//! Wire it into [`crate::admit::admit`] by mapping `!status.admits()` onto the existing
+//! `cred.revoked` guard — a revoked / unknown / stale credential is dropped exactly where
+//! the `revoked` flag dropped it, with NO change to the rest of the gate.
+//!
+//! ## Re-materialise on change — full re-run, not incremental (design §3.3 / G5)
+//!
+//! v1 is **full re-materialisation**: a status change (or a snapshot ageing past
+//! `max_age_secs`) invalidates the admission verdict and the caller re-runs the gate; there
+//! is **no** in-reasoner incremental retraction (the §4.4 stale-authority window is
+//! *bounded* by `max_age_secs`, not closed). This is the SAME discipline the `store` module
+//! documents for trust-document revocation: revocation propagates by re-materialise.
+//!
+//! ## Why a separate decoder (NOT the ZK `StatusListSnapshot`)
+//!
+//! `sparq-zk-compose::StatusListSnapshot` is the **host-side mirror for the hidden-index
+//! revocation ZK proof** — it is LSB-first (legacy StatusList2021), lives in the heavy ZK
+//! estate, and exists to commit a Merkle root the circuit binds. Pulling it here would drag
+//! `sparq-zk-compose` (Noir/circuit tooling) onto this crate and break lean-core. This
+//! module is the **clear-index** gate: a dependency-light, MSB-first Bitstring-Status-List
+//! decoder. The two are deliberately distinct (clear-index gate vs hidden-index proof).
+//!
+//! ## Network + GZIP are seams — the default build pulls NEITHER
+//!
+//! Like the `did:web` fetcher, the network fetch is a **pluggable** [`StatusListResolver`]
+//! (the crate ships no HTTP client). GZIP decompression is likewise a pluggable
+//! [`GzipDecoder`]: the base64url/base58btc multibase decode is hand-rolled and
+//! dependency-free, but inflate needs a codec. A built-in `Flate2GzipDecoder` is offered
+//! ONLY behind the nested default-OFF `status-list-flate2` feature (it pulls `flate2`); the
+//! plain `status-list` feature is dependency-free and decode-only over a caller-supplied
+//! decoder. An [`IdentityGzipDecoder`] (no compression) is always available for
+//! already-inflated lists and tests.
+//!
+//! ## Honest scope — what this does and does NOT do
+//!
+//! - **No privacy / unlinkability.** The status check is over the **clear** index and the
+//!   **clear** list; the resolver learns which credential is being checked. It does NOT
+//!   deliver the hidden-index ZK revocation proof (`sq-3e5`/`sq-h2v`, the ZK estate — still
+//!   externally **UNAUDITED**, `sq-qhy4`). This is the in-the-clear, fail-closed gate.
+//! - **The list itself is trusted as fetched.** v1 does NOT verify the status-list
+//!   credential's OWN issuer signature (the resolver is the trust seam — a TLS-fetched or
+//!   pre-validated list). Verifying the list VC's signature against a trusted status
+//!   authority is a documented follow-up (a captured bead), not silently solved.
+//! - **The justification is an AUDIT record, never an authority.** Like
+//!   [`crate::delegation_prov`], the PROV-O graph is emitted *after* the verdict — feeding
+//!   it back as input grants nothing (no admission rule trusts a `prov:` triple; the §2.4
+//!   reserved-predicate guard is unchanged).
+//!
+//! [OPUS-4.8] sq-pfae.7 (issue #940 / gh-940, epic sq-pfae P6). Written while Fable
+//! unavailable — flag for re-review when Fable returns. 🤖 SPARQ agent — trust-graph
+//! live-status / revocation gate.
+
+use oxrdf::vocab::{rdf, xsd};
+use oxrdf::{Literal, NamedNode, NamedOrBlankNode, Term, Triple};
+
+/// The W3C PROV-O namespace base (the justification uses the standard terms so the graph
+/// round-trips through any PROV-O consumer — same posture as [`crate::delegation_prov`]).
+const PROV_NS: &str = "http://www.w3.org/ns/prov#";
+
+/// The W3C Bitstring-Status-List vocabulary namespace (the status-entry terms).
+const STATUS_NS: &str = "https://www.w3.org/ns/credentials/status#";
+
+/// The `trust:` justification terms reuse the crate vocab namespace.
+const TRUST_NS: &str = crate::vocab::TRUST_NS;
+
+/// `prov:` term IRI. Every `local` here is a valid IRI suffix, so `new_unchecked` is safe.
+fn prov(local: &str) -> NamedNode {
+    NamedNode::new_unchecked(format!("{}{}", PROV_NS, local))
+}
+
+/// `trust:` term IRI for a justification predicate (constructed from the crate namespace).
+fn trust(local: &str) -> NamedNode {
+    NamedNode::new_unchecked(format!("{}{}", TRUST_NS, local))
+}
+
+/// `status:` term IRI (the W3C Bitstring-Status-List vocabulary).
+fn status(local: &str) -> NamedNode {
+    NamedNode::new_unchecked(format!("{}{}", STATUS_NS, local))
+}
+
+/// The status purpose a list serves — the W3C `statusPurpose` (a list slot is purpose-
+/// specific; a "revocation" list and a "suspension" list are distinct bitstrings).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StatusPurpose {
+    /// `revocation` — a permanent, irreversible status change.
+    Revocation,
+    /// `suspension` — a reversible status change.
+    Suspension,
+}
+
+impl StatusPurpose {
+    /// The spec string for this purpose (`"revocation"` / `"suspension"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            StatusPurpose::Revocation => "revocation",
+            StatusPurpose::Suspension => "suspension",
+        }
+    }
+}
+
+/// A credential's `BitstringStatusListEntry` — the `credentialStatus` that points at the
+/// credential's slot in a published status list (W3C Bitstring-Status-List §2).
+///
+/// This is the per-credential input the gate consults; it carries NO bit of its own (the
+/// authoritative status lives in the resolved list, never in a credential-asserted flag —
+/// the `sq-tu4e` "input-only, never self-asserted" discipline, now over a LIVE list).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusListEntry {
+    /// `statusListCredential` — the IRI of the published list VC to resolve.
+    pub status_list_credential: NamedNode,
+    /// `statusListIndex` — this credential's slot (bit index) in that list.
+    pub status_list_index: u64,
+    /// `statusPurpose` — the status this slot encodes.
+    pub purpose: StatusPurpose,
+}
+
+/// A decoded status bitstring: the inflated bytes + a freshness timestamp.
+///
+/// Bit `i` is **MSB-first within each byte** (Bitstring-Status-List §3.2: the leftmost bit
+/// of the first byte is index 0). An index past the end of the bytes reads as **set**
+/// (fail-closed padding — an out-of-range slot is treated as revoked at the bit level; the
+/// higher-level [`LiveStatusCheck`] reports such an index as `Unknown`, never `Live`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatusBitstring {
+    /// The inflated status bits (MSB-first within each byte).
+    bits: Vec<u8>,
+    /// When this snapshot was produced/observed (Unix seconds) — the freshness anchor the
+    /// staleness check compares against `now - max_age_secs`.
+    as_of_unix_secs: i64,
+}
+
+impl StatusBitstring {
+    /// Build a snapshot from already-inflated MSB-first bytes observed at `as_of_unix_secs`.
+    pub fn from_bits(bits: Vec<u8>, as_of_unix_secs: i64) -> Self {
+        StatusBitstring {
+            bits,
+            as_of_unix_secs,
+        }
+    }
+
+    /// The bit at `index` (MSB-first within each byte). An out-of-range index reads as
+    /// **set** (`true`) — fail-closed padding, an unknown slot is treated as revoked.
+    pub fn is_set(&self, index: u64) -> bool {
+        let byte = (index >> 3) as usize;
+        let bit_in_byte = (index & 7) as u8; // 0 = MSB
+        match self.bits.get(byte) {
+            // MSB-first: leftmost bit is index 0 within the byte.
+            Some(b) => (b >> (7 - bit_in_byte)) & 1 == 1,
+            None => true, // out of range ⇒ fail-closed (treated as set/revoked)
+        }
+    }
+
+    /// When this snapshot was observed (Unix seconds).
+    pub fn as_of_unix_secs(&self) -> i64 {
+        self.as_of_unix_secs
+    }
+
+    /// The number of bytes in the bitstring.
+    pub fn len_bytes(&self) -> usize {
+        self.bits.len()
+    }
+}
+
+/// A pluggable GZIP decoder for the `encodedList`'s compressed payload. The multibase
+/// decode (base64url / base58btc) is hand-rolled and dependency-free, but inflate needs a
+/// codec — this is the **compression seam** that keeps the default build dependency-free.
+pub trait GzipDecoder {
+    /// Inflate `gzipped` (RFC 1952 GZIP) to the raw status bytes, or a human-readable error.
+    fn inflate(&self, gzipped: &[u8]) -> Result<Vec<u8>, String>;
+}
+
+/// A no-compression decoder: returns the input unchanged. For already-inflated lists and
+/// tests. Always available (the spec mandates GZIP, so this is NOT spec-conformant on a
+/// real `encodedList` — it is the test/seam fallback).
+#[derive(Debug, Clone, Copy, Default)]
+pub struct IdentityGzipDecoder;
+
+impl GzipDecoder for IdentityGzipDecoder {
+    fn inflate(&self, gzipped: &[u8]) -> Result<Vec<u8>, String> {
+        Ok(gzipped.to_vec())
+    }
+}
+
+/// The built-in GZIP decoder over `flate2` — ONLY behind the nested default-OFF
+/// `status-list-flate2` feature (it pulls the `flate2` dependency). The plain `status-list`
+/// feature is dependency-free and uses a caller-supplied [`GzipDecoder`].
+#[cfg(feature = "status-list-flate2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "status-list-flate2")))]
+#[derive(Debug, Clone, Copy, Default)]
+pub struct Flate2GzipDecoder;
+
+#[cfg(feature = "status-list-flate2")]
+impl GzipDecoder for Flate2GzipDecoder {
+    fn inflate(&self, gzipped: &[u8]) -> Result<Vec<u8>, String> {
+        use std::io::Read as _;
+        let mut decoder = flate2::read::GzDecoder::new(gzipped);
+        let mut out = Vec::new();
+        decoder
+            .read_to_end(&mut out)
+            .map_err(|e| format!("gzip inflate failed: {}", e))?;
+        Ok(out)
+    }
+}
+
+/// The multibase prefix for base64url-no-pad (`u`), the current Bitstring-Status-List form.
+const MULTIBASE_BASE64URL: char = 'u';
+/// The multibase prefix for base58btc (`z`), the legacy StatusList2021 form.
+const MULTIBASE_BASE58BTC: char = 'z';
+
+/// Decode a multibase `encodedList` string + inflate it into a [`StatusBitstring`].
+///
+/// Accepts the current base64url-no-pad (`u`) form and the legacy base58btc (`z`) form.
+/// Fails closed (returns `None`) on an unknown multibase prefix, malformed base, or a
+/// decoder inflate error. `as_of_unix_secs` stamps the resulting snapshot's freshness.
+pub fn decode_encoded_list<D: GzipDecoder>(
+    encoded_list: &str,
+    decoder: &D,
+    as_of_unix_secs: i64,
+) -> Option<StatusBitstring> {
+    let prefix = encoded_list.chars().next()?;
+    let body = &encoded_list[prefix.len_utf8()..];
+    let compressed = match prefix {
+        MULTIBASE_BASE64URL => base64url_decode(body)?,
+        MULTIBASE_BASE58BTC => base58btc_decode(body)?,
+        _ => return None, // unknown multibase prefix ⇒ fail closed
+    };
+    let bits = decoder.inflate(&compressed).ok()?;
+    Some(StatusBitstring::from_bits(bits, as_of_unix_secs))
+}
+
+/// A pluggable resolver for a published status-list credential. Hands the gate the
+/// `encodedList` string + the snapshot's `as_of` timestamp, or signals the list could not
+/// be obtained (mapped to a fail-closed [`LiveStatus::Unknown`]).
+///
+/// This is the **network seam** — the crate ships no HTTP client, so the default build
+/// forces no `reqwest`/`ureq` onto anyone and the resolver stays offline-testable (an
+/// in-memory map is a perfectly valid resolver for tests / a pre-fetched registry).
+pub trait StatusListResolver {
+    /// Resolve the list at `status_list_credential`. Return `(encoded_list, as_of_unix_secs)`
+    /// — the multibase `encodedList` string and when the snapshot was observed — or `None`
+    /// if the list could not be obtained (⇒ fail-closed `Unknown`).
+    fn resolve(&self, status_list_credential: &NamedNode) -> Option<(String, i64)>;
+}
+
+/// The verdict of a live status check — fail-closed by construction: ONLY [`LiveStatus::Live`]
+/// admits ([`LiveStatus::admits`]). Every other variant denies.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LiveStatus {
+    /// The list resolved + decoded, the index is in range, the bit is **unset**, and the
+    /// snapshot is **fresh**. The ONLY variant that admits.
+    Live,
+    /// The status bit is **set** (revoked / suspended): deny.
+    Set,
+    /// The list did not resolve / decode, no resolver is wired, or the index is out of
+    /// range (not covered by the list): deny (**fail-closed on unknown**, never fail-open).
+    Unknown,
+    /// The resolved snapshot is older than the caller's `max_age_secs` (or from the
+    /// future): deny (**fail-closed on stale**).
+    Stale,
+}
+
+impl LiveStatus {
+    /// The single fail-closed admission predicate: `true` for [`LiveStatus::Live`] ONLY.
+    pub fn admits(self) -> bool {
+        matches!(self, LiveStatus::Live)
+    }
+
+    /// A short machine-readable reason token for the denial justification (or `"live"`).
+    pub fn reason(self) -> &'static str {
+        match self {
+            LiveStatus::Live => "live",
+            LiveStatus::Set => "status-set",
+            LiveStatus::Unknown => "status-unknown",
+            LiveStatus::Stale => "status-stale",
+        }
+    }
+}
+
+/// A live status check: a pluggable [`StatusListResolver`] + a [`GzipDecoder`] + a freshness
+/// budget. Consult it with [`Self::check`] for a credential's [`StatusListEntry`] at `now`.
+///
+/// Fail-closed by construction: a missing resolver, an unresolvable / undecodable list, an
+/// out-of-range index, a set bit, or a snapshot older than `max_age_secs` ALL deny.
+pub struct LiveStatusCheck<R: StatusListResolver, D: GzipDecoder> {
+    resolver: R,
+    decoder: D,
+    /// The maximum age (seconds) a resolved snapshot may have before it is treated as
+    /// stale (fail-closed). Bounds the §4.4 stale-authority window.
+    max_age_secs: i64,
+}
+
+impl<R: StatusListResolver, D: GzipDecoder> LiveStatusCheck<R, D> {
+    /// Build a check over the given resolver + decoder with a `max_age_secs` freshness
+    /// budget. A non-positive `max_age_secs` means "no snapshot is ever fresh enough" —
+    /// every check is `Stale` (the maximally fail-closed setting).
+    pub fn new(resolver: R, decoder: D, max_age_secs: i64) -> Self {
+        LiveStatusCheck {
+            resolver,
+            decoder,
+            max_age_secs,
+        }
+    }
+
+    /// Check a credential's status entry against the live list at instant `now_unix_secs`.
+    /// Returns the fail-closed [`LiveStatus`].
+    pub fn check(&self, entry: &StatusListEntry, now_unix_secs: i64) -> LiveStatus {
+        // Resolve the published list (network seam). No list ⇒ fail-closed Unknown.
+        let Some((encoded, as_of)) = self.resolver.resolve(&entry.status_list_credential) else {
+            return LiveStatus::Unknown;
+        };
+        // Decode + inflate. A bad multibase / inflate error ⇒ fail-closed Unknown.
+        let Some(snapshot) = decode_encoded_list(&encoded, &self.decoder, as_of) else {
+            return LiveStatus::Unknown;
+        };
+        // Freshness: a snapshot older than max_age_secs (or from the future) is stale.
+        let age = now_unix_secs.saturating_sub(snapshot.as_of_unix_secs());
+        if self.max_age_secs <= 0 || age < 0 || age > self.max_age_secs {
+            return LiveStatus::Stale;
+        }
+        // The bit. We distinguish a genuine in-range set bit from an out-of-range read so
+        // the justification is honest: an out-of-range index is `Unknown` (the slot is not
+        // covered by the list), NOT a positive revocation — but still fail-closed (deny).
+        let byte = (entry.status_list_index >> 3) as usize;
+        if byte >= snapshot.len_bytes() {
+            return LiveStatus::Unknown; // index not covered by the list ⇒ fail-closed Unknown
+        }
+        if snapshot.is_set(entry.status_list_index) {
+            LiveStatus::Set
+        } else {
+            LiveStatus::Live
+        }
+    }
+}
+
+// --- minimal PROV-O justification (the "minimal justification" half of sq-pfae.7) --------
+
+/// A minimal PROV-O justification for a status DECISION over a single grant — an **audit
+/// record, never an authority** (same posture as [`crate::delegation_prov`]: emitted AFTER
+/// the verdict; feeding it back grants nothing).
+///
+/// For an allow it records the grant as live; for a deny (the bead's *minimal denial
+/// justification*) it records WHY — the [`LiveStatus::reason`] token + the status entry that
+/// was checked — so an auditor can replay the decision without re-fetching the list.
+#[derive(Debug, Clone)]
+pub struct StatusJustification {
+    triples: Vec<Triple>,
+}
+
+impl StatusJustification {
+    /// The justification triples (a small fixed set, like the delegation audit).
+    pub fn triples(&self) -> &[Triple] {
+        &self.triples
+    }
+
+    /// Consume the justification, returning the owned triples.
+    pub fn into_triples(self) -> Vec<Triple> {
+        self.triples
+    }
+}
+
+/// Render a **minimal PROV-O justification** for a status decision over `grant`.
+///
+/// The activity (a fresh blank node) is a `prov:Activity` (also `trust:StatusCheck`) that
+/// `prov:generated` the grant entity; the activity `prov:used` the named
+/// `statusListCredential` entity and carries the checked index, the purpose, the decision
+/// (`trust:statusDecision` = `live` / the deny reason), and (when supplied) `prov:atTime`.
+/// For a DENY the decision token is the [`LiveStatus::reason`] — the *minimal denial
+/// justification* the bead names.
+///
+/// `grant` is the `auth:*` (or any) grant triple the decision gates; its subject is recorded
+/// as `trust:aboutSubject` and its predicate as `trust:grantPredicate`. The activity is the
+/// SAME PROV-O shape the delegation audit uses, so the two compose in one audit graph.
+pub fn justify_status_decision(
+    grant: &Triple,
+    entry: &StatusListEntry,
+    decision: LiveStatus,
+    at_time_unix_secs: Option<i64>,
+) -> StatusJustification {
+    let mut triples = Vec::new();
+    let activity = NamedOrBlankNode::BlankNode(oxrdf::BlankNode::default());
+    let grant_entity = NamedOrBlankNode::BlankNode(oxrdf::BlankNode::default());
+
+    // The activity is a prov:Activity, typed trust:StatusCheck so an auditor can find it.
+    triples.push(Triple::new(
+        activity.clone(),
+        NamedNode::from(rdf::TYPE),
+        Term::NamedNode(prov("Activity")),
+    ));
+    triples.push(Triple::new(
+        activity.clone(),
+        NamedNode::from(rdf::TYPE),
+        Term::NamedNode(trust("StatusCheck")),
+    ));
+    // It used the named status list credential (a prov:Entity input).
+    let list_entity = entry.status_list_credential.clone();
+    triples.push(Triple::new(
+        activity.clone(),
+        prov("used"),
+        Term::NamedNode(list_entity.clone()),
+    ));
+    triples.push(Triple::new(
+        NamedOrBlankNode::NamedNode(list_entity),
+        NamedNode::from(rdf::TYPE),
+        Term::NamedNode(prov("Entity")),
+    ));
+    // The checked index + purpose (so the audit binds the exact slot).
+    triples.push(Triple::new(
+        activity.clone(),
+        status("statusListIndex"),
+        Term::Literal(Literal::new_typed_literal(
+            entry.status_list_index.to_string(),
+            xsd::NON_NEGATIVE_INTEGER,
+        )),
+    ));
+    triples.push(Triple::new(
+        activity.clone(),
+        status("statusPurpose"),
+        Term::Literal(Literal::new_simple_literal(entry.purpose.as_str())),
+    ));
+    // The decision token (live / the deny reason — the minimal justification).
+    triples.push(Triple::new(
+        activity.clone(),
+        trust("statusDecision"),
+        Term::Literal(Literal::new_simple_literal(decision.reason())),
+    ));
+    // Whether the decision admits (a boolean an auditor can act on directly).
+    triples.push(Triple::new(
+        activity.clone(),
+        trust("statusAdmits"),
+        Term::Literal(Literal::new_typed_literal(
+            if decision.admits() { "true" } else { "false" },
+            xsd::BOOLEAN,
+        )),
+    ));
+    // The grant entity the activity generated, and the grant triple it is about.
+    triples.push(Triple::new(
+        activity.clone(),
+        prov("generated"),
+        Term::from(grant_entity.clone()),
+    ));
+    triples.push(Triple::new(
+        grant_entity.clone(),
+        NamedNode::from(rdf::TYPE),
+        Term::NamedNode(prov("Entity")),
+    ));
+    triples.push(Triple::new(
+        grant_entity.clone(),
+        trust("aboutSubject"),
+        subject_term(&grant.subject),
+    ));
+    triples.push(Triple::new(
+        grant_entity,
+        trust("grantPredicate"),
+        Term::NamedNode(grant.predicate.clone()),
+    ));
+    // Optional activity timestamp.
+    if let Some(t) = at_time_unix_secs {
+        triples.push(Triple::new(
+            activity,
+            prov("atTime"),
+            Term::Literal(Literal::new_typed_literal(t.to_string(), xsd::INTEGER)),
+        ));
+    }
+    StatusJustification { triples }
+}
+
+/// Lift a triple subject into an object term (named node or blank node).
+fn subject_term(s: &NamedOrBlankNode) -> Term {
+    match s {
+        NamedOrBlankNode::NamedNode(n) => Term::NamedNode(n.clone()),
+        NamedOrBlankNode::BlankNode(b) => Term::BlankNode(b.clone()),
+    }
+}
+
+// --- dependency-free base decoders (hand-rolled, like did.rs's base58btc) ----------------
+
+/// Decode base64url-no-pad (RFC 4648 §5, no `=` padding) — the current Bitstring-Status-List
+/// multibase `u` form. Returns `None` on any non-alphabet character or a non-canonical
+/// (non-zero) final-sextet remainder.
+fn base64url_decode(input: &str) -> Option<Vec<u8>> {
+    fn val(b: u8) -> Option<u8> {
+        match b {
+            b'A'..=b'Z' => Some(b - b'A'),
+            b'a'..=b'z' => Some(b - b'a' + 26),
+            b'0'..=b'9' => Some(b - b'0' + 52),
+            b'-' => Some(62),
+            b'_' => Some(63),
+            _ => None, // including '=' (no-pad form) and base64-std '+'/'/'
+        }
+    }
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len() * 3 / 4);
+    let mut acc: u32 = 0;
+    let mut nbits: u32 = 0;
+    for &b in bytes {
+        let v = val(b)? as u32;
+        acc = (acc << 6) | v;
+        nbits += 6;
+        if nbits >= 8 {
+            nbits -= 8;
+            out.push((acc >> nbits) as u8);
+        }
+    }
+    // Any leftover bits beyond a partial final sextet must be zero (canonical no-pad).
+    if nbits > 0 && (acc & ((1u32 << nbits) - 1)) != 0 {
+        return None;
+    }
+    Some(out)
+}
+
+/// Decode base58btc (Bitcoin alphabet) — the legacy StatusList2021 multibase `z` form.
+/// Hand-rolled (dependency-free), matching the `did.rs` base58 decoder's semantics.
+fn base58btc_decode(input: &str) -> Option<Vec<u8>> {
+    const ALPHABET: &[u8; 58] = b"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+    // Leading '1's encode leading zero bytes.
+    let mut leading_zeros = 0usize;
+    for &c in input.as_bytes() {
+        if c == b'1' {
+            leading_zeros += 1;
+        } else {
+            break;
+        }
+    }
+    let mut bytes: Vec<u8> = Vec::new();
+    for &c in input.as_bytes() {
+        let digit = ALPHABET.iter().position(|&a| a == c)? as u32;
+        let mut carry = digit;
+        for byte in bytes.iter_mut() {
+            carry += (*byte as u32) * 58;
+            *byte = (carry & 0xff) as u8;
+            carry >>= 8;
+        }
+        while carry > 0 {
+            bytes.push((carry & 0xff) as u8);
+            carry >>= 8;
+        }
+    }
+    // `bytes` is little-endian; reverse and prepend the leading zeros.
+    let mut out = vec![0u8; leading_zeros];
+    out.extend(bytes.iter().rev());
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(index: u64) -> StatusListEntry {
+        StatusListEntry {
+            status_list_credential: NamedNode::new_unchecked("https://issuer.ex/status/list#list"),
+            status_list_index: index,
+            purpose: StatusPurpose::Revocation,
+        }
+    }
+
+    /// Encode bytes as base64url-no-pad (test helper — the encoder side of the decoder).
+    fn base64url_encode(input: &[u8]) -> String {
+        const ALPHA: &[u8; 64] =
+            b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+        let mut out = String::new();
+        let mut acc: u32 = 0;
+        let mut nbits: u32 = 0;
+        for &b in input {
+            acc = (acc << 8) | b as u32;
+            nbits += 8;
+            while nbits >= 6 {
+                nbits -= 6;
+                out.push(ALPHA[((acc >> nbits) & 0x3f) as usize] as char);
+            }
+        }
+        if nbits > 0 {
+            out.push(ALPHA[((acc << (6 - nbits)) & 0x3f) as usize] as char);
+        }
+        out
+    }
+
+    #[test]
+    fn base64url_round_trips() {
+        for case in [
+            &b""[..],
+            &b"f"[..],
+            &b"fo"[..],
+            &b"foo"[..],
+            &b"foob"[..],
+            &b"fooba"[..],
+            &b"foobar"[..],
+            &[0u8, 1, 2, 3, 0xff, 0x80][..],
+        ] {
+            let enc = base64url_encode(case);
+            let dec = base64url_decode(&enc).expect("decodes");
+            assert_eq!(dec, case, "round-trip for {:?}", case);
+        }
+    }
+
+    #[test]
+    fn base64url_rejects_non_alphabet_and_padding() {
+        assert!(base64url_decode("ab=c").is_none(), "'=' padding rejected");
+        assert!(base64url_decode("ab cd").is_none(), "space rejected");
+        assert!(
+            base64url_decode("ab+cd").is_none(),
+            "'+' (base64 std) rejected"
+        );
+    }
+
+    #[test]
+    fn bitstring_is_msb_first_and_fail_closed_past_end() {
+        // 0b1000_0000 → index 0 set (MSB-first), indices 1..=7 unset.
+        let bs = StatusBitstring::from_bits(vec![0x80], 1000);
+        assert!(bs.is_set(0), "MSB is index 0");
+        for i in 1..8 {
+            assert!(!bs.is_set(i), "index {} unset", i);
+        }
+        // Out of range ⇒ fail-closed set (at the bit level).
+        assert!(bs.is_set(8), "out-of-range index reads as set");
+        assert!(bs.is_set(1_000_000), "far out-of-range reads as set");
+    }
+
+    #[test]
+    fn decode_encoded_list_u_prefix_identity() {
+        // 0x80 = index-0-set; base64url-no-pad with the 'u' multibase prefix; identity codec.
+        let encoded = format!("{}{}", MULTIBASE_BASE64URL, base64url_encode(&[0x80]));
+        let bs = decode_encoded_list(&encoded, &IdentityGzipDecoder, 500).expect("decodes");
+        assert!(bs.is_set(0));
+        assert!(!bs.is_set(1));
+        assert_eq!(bs.as_of_unix_secs(), 500);
+    }
+
+    #[test]
+    fn decode_encoded_list_rejects_unknown_multibase() {
+        // 'm' is base64-standard multibase, which this decoder does not accept.
+        assert!(decode_encoded_list("mgA", &IdentityGzipDecoder, 0).is_none());
+        assert!(decode_encoded_list("", &IdentityGzipDecoder, 0).is_none());
+    }
+
+    /// An in-memory resolver mapping the one list IRI to an encoded list + as_of.
+    struct MapResolver {
+        encoded: Option<(String, i64)>,
+    }
+    impl StatusListResolver for MapResolver {
+        fn resolve(&self, _iri: &NamedNode) -> Option<(String, i64)> {
+            self.encoded.clone()
+        }
+    }
+
+    fn check_with(bits: &[u8], as_of: i64, max_age: i64, now: i64, index: u64) -> LiveStatus {
+        let encoded = format!("{}{}", MULTIBASE_BASE64URL, base64url_encode(bits));
+        let resolver = MapResolver {
+            encoded: Some((encoded, as_of)),
+        };
+        let check = LiveStatusCheck::new(resolver, IdentityGzipDecoder, max_age);
+        check.check(&entry(index), now)
+    }
+
+    #[test]
+    fn live_when_unset_fresh_in_range() {
+        // index 1 unset (byte 0x80 = only index 0 set), fresh snapshot.
+        assert_eq!(check_with(&[0x80], 1000, 3600, 1500, 1), LiveStatus::Live);
+    }
+
+    #[test]
+    fn set_bit_denies() {
+        // index 0 set ⇒ Set (deny).
+        let s = check_with(&[0x80], 1000, 3600, 1500, 0);
+        assert_eq!(s, LiveStatus::Set);
+        assert!(!s.admits());
+    }
+
+    #[test]
+    fn stale_snapshot_denies_fail_closed() {
+        // snapshot at 1000, now 99999, max_age 3600 ⇒ Stale.
+        let s = check_with(&[0x00], 1000, 3600, 99999, 1);
+        assert_eq!(s, LiveStatus::Stale);
+        assert!(!s.admits());
+    }
+
+    #[test]
+    fn future_snapshot_denies_fail_closed() {
+        // snapshot timestamped in the future (now < as_of) ⇒ Stale (negative age).
+        let s = check_with(&[0x00], 5000, 3600, 1000, 1);
+        assert_eq!(s, LiveStatus::Stale);
+    }
+
+    #[test]
+    fn non_positive_max_age_is_maximally_fail_closed() {
+        // max_age 0 ⇒ nothing is ever fresh enough ⇒ Stale even at as_of == now.
+        let s = check_with(&[0x00], 1000, 0, 1000, 1);
+        assert_eq!(s, LiveStatus::Stale);
+    }
+
+    #[test]
+    fn unresolvable_list_is_unknown_fail_closed() {
+        let resolver = MapResolver { encoded: None };
+        let check = LiveStatusCheck::new(resolver, IdentityGzipDecoder, 3600);
+        let s = check.check(&entry(0), 1000);
+        assert_eq!(s, LiveStatus::Unknown);
+        assert!(!s.admits());
+    }
+
+    #[test]
+    fn out_of_range_index_is_unknown_not_set() {
+        // 1-byte list covers indices 0..=7; index 8 is not covered ⇒ Unknown, not Set.
+        let s = check_with(&[0x00], 1000, 3600, 1500, 8);
+        assert_eq!(s, LiveStatus::Unknown);
+        assert!(!s.admits());
+    }
+
+    #[test]
+    fn undecodable_list_is_unknown_fail_closed() {
+        // A bad multibase prefix ('m') ⇒ the decoder returns None ⇒ Unknown.
+        let resolver = MapResolver {
+            encoded: Some(("mZZZ".to_string(), 1000)),
+        };
+        let check = LiveStatusCheck::new(resolver, IdentityGzipDecoder, 3600);
+        assert_eq!(check.check(&entry(0), 1500), LiveStatus::Unknown);
+    }
+
+    #[test]
+    fn only_live_admits() {
+        assert!(LiveStatus::Live.admits());
+        assert!(!LiveStatus::Set.admits());
+        assert!(!LiveStatus::Unknown.admits());
+        assert!(!LiveStatus::Stale.admits());
+    }
+
+    #[test]
+    fn justification_records_the_decision_and_reason() {
+        let grant = Triple::new(
+            NamedNode::new_unchecked("https://jesse.ex/card#me"),
+            NamedNode::new_unchecked("https://sparq.dev/ns/auth#read"),
+            Term::NamedNode(NamedNode::new_unchecked("https://pod.ex/resourceX")),
+        );
+        // Deny case: a revoked status ⇒ the minimal denial justification.
+        let j = justify_status_decision(&grant, &entry(7), LiveStatus::Set, Some(1500));
+        let joined: String = j
+            .triples()
+            .iter()
+            .map(|t| format!("{} {} {}\n", t.subject, t.predicate, t.object))
+            .collect();
+        // The decision token is the deny reason (minimal justification).
+        assert!(
+            joined.contains("statusDecision") && joined.contains("status-set"),
+            "records the deny reason:\n{}",
+            joined
+        );
+        // It records statusAdmits=false.
+        assert!(
+            joined.contains("statusAdmits") && joined.contains("false"),
+            "records admits=false:\n{}",
+            joined
+        );
+        // It binds the checked index (7) + purpose.
+        assert!(joined.contains("statusListIndex"), "binds the index");
+        assert!(joined.contains("revocation"), "binds the purpose");
+        // PROV-O shape: a prov:Activity that generated a grant entity.
+        assert!(joined.contains("prov#Activity"), "is a prov:Activity");
+        assert!(joined.contains("prov#generated"), "generated the grant");
+    }
+
+    #[test]
+    fn justification_allow_records_live() {
+        let grant = Triple::new(
+            NamedNode::new_unchecked("https://jesse.ex/card#me"),
+            NamedNode::new_unchecked("https://sparq.dev/ns/auth#read"),
+            Term::NamedNode(NamedNode::new_unchecked("https://pod.ex/resourceX")),
+        );
+        let j = justify_status_decision(&grant, &entry(1), LiveStatus::Live, None);
+        let joined: String = j
+            .triples()
+            .iter()
+            .map(|t| format!("{} {} {}\n", t.subject, t.predicate, t.object))
+            .collect();
+        assert!(!joined.contains("status-set"), "not a deny token");
+        assert!(joined.contains("statusDecision"));
+        assert!(joined.contains("statusAdmits") && joined.contains("true"));
+    }
+
+    #[test]
+    fn base58btc_decodes_leading_zero() {
+        // A single '1' decodes to one zero byte (leading-zero convention).
+        let decoded = base58btc_decode("1").expect("single '1' decodes to one zero byte");
+        assert_eq!(decoded, vec![0u8]);
+    }
+
+    /// The built-in `flate2` GZIP decoder inflates a REAL gzip-compressed `encodedList`
+    /// (the spec-mandated codec) — exercised ONLY under the `status-list-flate2` feature.
+    #[cfg(feature = "status-list-flate2")]
+    #[test]
+    fn flate2_decoder_inflates_a_real_gzip_encoded_list() {
+        use flate2::{write::GzEncoder, Compression};
+        use std::io::Write as _;
+
+        // 0x80 = index-0-set, 0x00 = indices 8..=15 unset.
+        let raw = [0x80u8, 0x00];
+        let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+        enc.write_all(&raw).unwrap();
+        let gzipped = enc.finish().unwrap();
+        // Multibase `u` (base64url) over the GZIP bytes — the real `encodedList` shape.
+        let encoded = format!("{}{}", MULTIBASE_BASE64URL, base64url_encode(&gzipped));
+        let bs = decode_encoded_list(&encoded, &Flate2GzipDecoder, 1000)
+            .expect("decodes + inflates the real gzip list");
+        assert!(bs.is_set(0), "MSB of byte 0 is index 0 (set)");
+        assert!(!bs.is_set(1));
+        assert!(!bs.is_set(8), "byte 1 is 0x00 ⇒ index 8 unset");
+        assert_eq!(bs.len_bytes(), 2);
+    }
+}

--- a/crates/sparq-trust/tests/live_status_e2e.rs
+++ b/crates/sparq-trust/tests/live_status_e2e.rs
@@ -1,0 +1,355 @@
+//! End-to-end P6 status stratum (`sq-pfae.7`): the REAL admission → derivation pipeline
+//! gated on a **live W3C Bitstring Status List**, plus the minimal PROV-O denial
+//! justification.
+//!
+//! It exercises the REAL path — a CHECKED issuer Schnorr signature over the RDFC-1.0
+//! commitment (sparq-zk), statement-type scoping via a real SHACL shape (sparq-shacl),
+//! freshness, the clear-WebID holder binding, AND the new live-status gate
+//! ([`sparq_trust::admit_with_status`]) over a decoded Bitstring Status List — then the N3
+//! merge of the admitted fact with the `.acr` ABAC rule (sparq-reason) to derive the
+//! `auth:read` grant. The load-bearing INVARIANT under test: the live-status gate is
+//! **fail-closed** — only an unset-bit, in-range, fresh, resolvable status admits; a set
+//! bit, an unknown/undecodable list, or a stale snapshot ALL deny the whole credential, and
+//! the deny carries a minimal justification recording WHY.
+//!
+//! This suite is `#![cfg(feature = "status-list")]`, so it ONLY compiles/runs with the
+//! feature ON (wired as the trailing `sparq-trust (status-list)` leg in feature-matrix.yml).
+//!
+//! [OPUS-4.8] sq-pfae.7 (issue #940 / gh-940). 🤖 SPARQ agent — trust-graph live-status gate.
+#![cfg(feature = "status-list")]
+
+use oxrdf::{Literal, NamedNode, NamedOrBlankNode, Term, Triple};
+use sparq_trust::admit::{admit_with_status, PresentedCredential, Session};
+use sparq_trust::policy::{parse_policy, ControlGate, TrustRule};
+use sparq_trust::status_list::{
+    justify_status_decision, IdentityGzipDecoder, LiveStatus, LiveStatusCheck, StatusListEntry,
+    StatusListResolver, StatusPurpose,
+};
+use sparq_trust::vocab;
+use sparq_trust::wire::derive_grants;
+use sparq_zk::commit::commit_triples;
+use sparq_zk::encode::salt_from_bytes;
+use sparq_zk::sig::{public_key_to_hex, PublicKey, SecretKey};
+
+const JESSE: &str = "https://jesse.ex/card#me";
+const GOV_ISSUER: &str = "https://gov.example/issuer";
+const SCHEMA_AGE: &str = "http://schema.org/age";
+const RESOURCE_X: &str = "https://pod.ex/resourceX";
+const STATUS_LIST: &str = "https://gov.example/status/3#list";
+const SALT_BYTES: [u8; 32] = [7u8; 32];
+const NOW: i64 = 1_700_000_000;
+const ISSUED_FRESH: i64 = NOW - 86_400; // 1 day ago
+
+const ACR_ABAC_RULE: &str = r#"@prefix schema: <http://schema.org/> .
+@prefix math:   <http://www.w3.org/2000/10/swap/math#> .
+@prefix auth:   <https://sparq.dev/ns/auth#> .
+{ ?x schema:age ?y . ?y math:greaterThan 18 } => { ?x auth:read <https://pod.ex/resourceX> } .
+"#;
+
+fn iri(s: &str) -> NamedNode {
+    NamedNode::new(s).unwrap()
+}
+
+fn gov_key() -> (SecretKey, PublicKey) {
+    let sk = SecretKey::from_seed(0xC0FFEE);
+    let pk = sk.public_key();
+    (sk, pk)
+}
+
+fn age_graph(subject: &str, value: &str) -> Vec<Triple> {
+    vec![Triple::new(
+        NamedOrBlankNode::NamedNode(iri(subject)),
+        iri(SCHEMA_AGE),
+        Term::Literal(Literal::new_typed_literal(
+            value,
+            iri("http://www.w3.org/2001/XMLSchema#integer"),
+        )),
+    )]
+}
+
+fn sign_graph(sk: &SecretKey, graph: &[Triple]) -> String {
+    let salt = salt_from_bytes(&SALT_BYTES);
+    let commitment = commit_triples(graph, salt).expect("commits");
+    sk.sign_commitment(&commitment.commitment)
+}
+
+fn fresh_cred(sk: &SecretKey, graph: Vec<Triple>) -> PresentedCredential {
+    let sig = sign_graph(sk, &graph);
+    PresentedCredential {
+        graph,
+        issuer_signature_hex: sig,
+        salt: SALT_BYTES,
+        issued_at_unix_secs: ISSUED_FRESH,
+        revoked: false,
+    }
+}
+
+fn gov_age_policy(key: &PublicKey) -> Vec<TrustRule> {
+    let rule = NamedNode::new("https://pod.ex/.acr#trustrule").unwrap();
+    let policy: Vec<Triple> = vec![
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule.clone()),
+            iri(vocab::RDF_TYPE),
+            Term::NamedNode(iri(vocab::TRUST_RULE)),
+        ),
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule.clone()),
+            iri(vocab::SOURCE),
+            Term::NamedNode(iri(GOV_ISSUER)),
+        ),
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule.clone()),
+            iri(vocab::ISSUER_KEY),
+            Term::Literal(Literal::new_simple_literal(public_key_to_hex(key))),
+        ),
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule.clone()),
+            iri(vocab::FOR_PREDICATE),
+            Term::NamedNode(iri(SCHEMA_AGE)),
+        ),
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule.clone()),
+            iri(vocab::SCOPE),
+            Term::NamedNode(iri(RESOURCE_X)),
+        ),
+        Triple::new(
+            NamedOrBlankNode::NamedNode(rule),
+            iri(vocab::FRESH_WITHIN),
+            Term::Literal(Literal::new_typed_literal(
+                "P30D",
+                iri("http://www.w3.org/2001/XMLSchema#duration"),
+            )),
+        ),
+    ];
+    parse_policy(&policy, ControlGate::assert_control_gated()).expect("policy parses")
+}
+
+fn session(now: i64) -> Session {
+    Session {
+        agent: iri(JESSE),
+        now_unix_secs: now,
+    }
+}
+
+fn status_entry(index: u64) -> StatusListEntry {
+    StatusListEntry {
+        status_list_credential: iri(STATUS_LIST),
+        status_list_index: index,
+        purpose: StatusPurpose::Revocation,
+    }
+}
+
+/// base64url-no-pad encode (the encoder side of the crate's decoder).
+fn base64url_encode(input: &[u8]) -> String {
+    const ALPHA: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    let mut out = String::new();
+    let mut acc: u32 = 0;
+    let mut nbits: u32 = 0;
+    for &b in input {
+        acc = (acc << 8) | b as u32;
+        nbits += 8;
+        while nbits >= 6 {
+            nbits -= 6;
+            out.push(ALPHA[((acc >> nbits) & 0x3f) as usize] as char);
+        }
+    }
+    if nbits > 0 {
+        out.push(ALPHA[((acc << (6 - nbits)) & 0x3f) as usize] as char);
+    }
+    out
+}
+
+/// An in-memory status-list resolver: maps the one list IRI to its encoded bytes + as_of.
+struct MapResolver {
+    encoded: Option<(String, i64)>,
+}
+impl StatusListResolver for MapResolver {
+    fn resolve(&self, _iri: &NamedNode) -> Option<(String, i64)> {
+        self.encoded.clone()
+    }
+}
+
+/// A status list (multibase `u` + identity codec) with `set_indices` marked revoked.
+fn status_list(set_indices: &[u64], n_bytes: usize, as_of: i64) -> MapResolver {
+    let mut bits = vec![0u8; n_bytes];
+    for &i in set_indices {
+        let byte = (i >> 3) as usize;
+        let bit = (i & 7) as u8;
+        bits[byte] |= 0x80 >> bit; // MSB-first
+    }
+    let encoded = format!("u{}", base64url_encode(&bits));
+    MapResolver {
+        encoded: Some((encoded, as_of)),
+    }
+}
+
+fn read_granted(grants: &[Triple]) -> bool {
+    grants.iter().any(|t| {
+        t.predicate.as_str() == "https://sparq.dev/ns/auth#read"
+            && matches!(&t.subject, NamedOrBlankNode::NamedNode(n) if n.as_str() == JESSE)
+            && matches!(&t.object, Term::NamedNode(o) if o.as_str() == RESOURCE_X)
+    })
+}
+
+#[test]
+fn live_unset_status_grants_read_end_to_end() {
+    let (sk, pk) = gov_key();
+    let rules = gov_age_policy(&pk);
+    let cred = fresh_cred(&sk, age_graph(JESSE, "25"));
+    // The credential is at index 5; only index 9 is revoked ⇒ index 5 is LIVE.
+    let resolver = status_list(&[9], 4, NOW - 60); // fresh snapshot (1 min old)
+    let check = LiveStatusCheck::new(resolver, IdentityGzipDecoder, 3600);
+
+    let (admitted, status) = admit_with_status(
+        &cred,
+        &rules,
+        &session(NOW),
+        &iri(RESOURCE_X),
+        &status_entry(5),
+        &check,
+    );
+    assert_eq!(status, LiveStatus::Live, "unset, fresh, in-range ⇒ Live");
+    assert!(status.admits());
+    let grants = derive_grants(&admitted, ACR_ABAC_RULE).expect("derivation runs");
+    assert!(
+        read_granted(&grants),
+        "a LIVE credential ⇒ the age>18 rule derives <Jesse> auth:read <resourceX>"
+    );
+}
+
+#[test]
+fn revoked_status_denies_with_minimal_justification() {
+    let (sk, pk) = gov_key();
+    let rules = gov_age_policy(&pk);
+    let cred = fresh_cred(&sk, age_graph(JESSE, "25"));
+    // The credential is at index 5 AND index 5 is revoked ⇒ DENY.
+    let resolver = status_list(&[5], 4, NOW - 60);
+    let check = LiveStatusCheck::new(resolver, IdentityGzipDecoder, 3600);
+
+    let (admitted, status) = admit_with_status(
+        &cred,
+        &rules,
+        &session(NOW),
+        &iri(RESOURCE_X),
+        &status_entry(5),
+        &check,
+    );
+    assert_eq!(status, LiveStatus::Set, "the bit is set ⇒ revoked");
+    assert!(!status.admits(), "fail-closed: a set bit denies");
+    assert!(admitted.is_empty(), "a revoked credential admits NOTHING");
+    let grants = derive_grants(&admitted, ACR_ABAC_RULE).expect("derivation runs");
+    assert!(
+        !read_granted(&grants),
+        "no admitted fact ⇒ no grant derived"
+    );
+
+    // The minimal DENIAL justification records WHY (the bead's "minimal denial justification").
+    let would_be_grant = Triple::new(
+        NamedOrBlankNode::NamedNode(iri(JESSE)),
+        iri("https://sparq.dev/ns/auth#read"),
+        Term::NamedNode(iri(RESOURCE_X)),
+    );
+    let j = justify_status_decision(&would_be_grant, &status_entry(5), status, Some(NOW));
+    let joined: String = j
+        .triples()
+        .iter()
+        .map(|t| format!("{} {} {}\n", t.subject, t.predicate, t.object))
+        .collect();
+    assert!(
+        joined.contains("status-set"),
+        "deny reason is recorded:\n{}",
+        joined
+    );
+    assert!(joined.contains("statusAdmits") && joined.contains("false"));
+    assert!(
+        joined.contains("statusListIndex"),
+        "binds the checked index"
+    );
+}
+
+#[test]
+fn stale_status_denies_fail_closed() {
+    let (sk, pk) = gov_key();
+    let rules = gov_age_policy(&pk);
+    let cred = fresh_cred(&sk, age_graph(JESSE, "25"));
+    // The snapshot is 2 days old; max_age is 1 hour ⇒ STALE (deny even though unset).
+    let resolver = status_list(&[], 4, NOW - 2 * 86_400);
+    let check = LiveStatusCheck::new(resolver, IdentityGzipDecoder, 3600);
+
+    let (admitted, status) = admit_with_status(
+        &cred,
+        &rules,
+        &session(NOW),
+        &iri(RESOURCE_X),
+        &status_entry(5),
+        &check,
+    );
+    assert_eq!(
+        status,
+        LiveStatus::Stale,
+        "stale snapshot ⇒ fail-closed deny"
+    );
+    assert!(!status.admits());
+    assert!(
+        admitted.is_empty(),
+        "a stale-status credential admits NOTHING"
+    );
+    let grants = derive_grants(&admitted, ACR_ABAC_RULE).unwrap();
+    assert!(!read_granted(&grants));
+}
+
+#[test]
+fn unknown_status_denies_fail_closed() {
+    let (sk, pk) = gov_key();
+    let rules = gov_age_policy(&pk);
+    let cred = fresh_cred(&sk, age_graph(JESSE, "25"));
+    // The list does not resolve ⇒ UNKNOWN (deny — fail-closed, never fail-open).
+    let resolver = MapResolver { encoded: None };
+    let check = LiveStatusCheck::new(resolver, IdentityGzipDecoder, 3600);
+
+    let (admitted, status) = admit_with_status(
+        &cred,
+        &rules,
+        &session(NOW),
+        &iri(RESOURCE_X),
+        &status_entry(5),
+        &check,
+    );
+    assert_eq!(
+        status,
+        LiveStatus::Unknown,
+        "unresolvable list ⇒ fail-closed deny"
+    );
+    assert!(!status.admits());
+    assert!(
+        admitted.is_empty(),
+        "an unknown-status credential admits NOTHING"
+    );
+    let grants = derive_grants(&admitted, ACR_ABAC_RULE).unwrap();
+    assert!(!read_granted(&grants));
+}
+
+#[test]
+fn out_of_range_index_denies_fail_closed() {
+    let (sk, pk) = gov_key();
+    let rules = gov_age_policy(&pk);
+    let cred = fresh_cred(&sk, age_graph(JESSE, "25"));
+    // The list is 1 byte (indices 0..=7); the credential claims index 100 ⇒ not covered.
+    let resolver = status_list(&[], 1, NOW - 60);
+    let check = LiveStatusCheck::new(resolver, IdentityGzipDecoder, 3600);
+
+    let (admitted, status) = admit_with_status(
+        &cred,
+        &rules,
+        &session(NOW),
+        &iri(RESOURCE_X),
+        &status_entry(100),
+        &check,
+    );
+    assert_eq!(
+        status,
+        LiveStatus::Unknown,
+        "out-of-range index ⇒ fail-closed Unknown"
+    );
+    assert!(admitted.is_empty());
+}

--- a/research/solid-trust-graph-authz-design.md
+++ b/research/solid-trust-graph-authz-design.md
@@ -1114,7 +1114,13 @@ core spine; **P5, P6, P7** depend on P3/P4; **P7 (privacy) is hard-gated on `sq-
 6. **P6 — Live status/revocation + minimal justification (prototype, G5/G6).** Fetch+decode a
    W3C Bitstring Status List; gate derivations on validity; emit a *minimal* PROV-O
    justification subset for each grant (sparq has PROV-O lineage but not minimal proof trees).
-   *Blocked-on: P3.*
+   *Blocked-on: P3.* **PROTOTYPED** (`sq-pfae.7`, opt-in `status-list` feature): the
+   `sparq_trust::status_list` module decodes a Bitstring Status List (pluggable resolver +
+   GZIP seam, MSB-first clear-index — distinct from the LSB-first ZK `StatusListSnapshot`
+   mirror), `admit_with_status` gates the REAL admission path **fail-closed on
+   set/unknown/stale**, and `justify_status_decision` renders the minimal PROV-O allow/deny
+   justification. Open residue (captured beads): verifying the status-list VC's own issuer
+   signature; incremental (non-re-materialise) revocation. [OPUS-4.8]
 7. **P7 — Privacy/ZK admission feasibility (design + caveated prototype, G4).** Show the
    trust-graph derivation can run under sparq's ZK estate to give ZKAP-equivalent unlinkable
    predicate access. ZKAPs-grade unlinkability needs the **three-part composite** (§5.3): the

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -582,6 +582,33 @@ open), and `requiresPostQuantumForgery gteq …` removes the DL-signature method
 **principled refusal** ("no admissible proof") over silently serving a non-conforming one. The §4.3.3
 worked example is the golden test: empty under Alice's strict preference, non-empty under the relaxed one.
 
+### Live status / revocation + minimal denial justification — opt-in `status-list` ([OPUS-4.8] sq-pfae.7, design §6.1 P6)
+
+The `sparq_trust::status_list` module (behind the **default-OFF `status-list`** cargo feature) gates
+admission on a **live W3C Bitstring Status List** instead of the PoC's per-credential `revoked: bool`
+flag. A credential's `StatusListEntry` (`{ status_list_credential, status_list_index, purpose }`) is
+checked by a `LiveStatusCheck::new(resolver, decoder, max_age_secs)` — a **pluggable**
+`StatusListResolver` (the network seam; the crate ships no HTTP client) + a **pluggable** `GzipDecoder`
+(the compression seam; the multibase base64url/base58btc decode is hand-rolled and dependency-free, the
+built-in `Flate2GzipDecoder` lives behind the nested `status-list-flate2` feature that pulls `flate2`).
+`LiveStatusCheck::check(&entry, now)` returns a `LiveStatus`, and `LiveStatus::admits()` is `true` for
+`LiveStatus::Live` **only** — **fail-closed on `Set` (revoked), `Unknown` (unresolvable / undecodable /
+out-of-range), and `Stale` (snapshot older than `max_age_secs`)**, exactly as the bead requires. The
+bitstring is MSB-first per the spec (`StatusBitstring`), distinct from the LSB-first
+`sparq-zk-compose::StatusListSnapshot` ZK mirror — this is the **clear-index** gate, not the hidden-index
+ZK proof. `sparq_trust::admit_with_status(cred, rules, session, target, &entry, &check)` wires the gate
+into the REAL admission path: it runs the live-status check FIRST (deny the whole credential on a
+non-admitting status) and otherwise delegates to the unchanged `admit` — strictly additive (it can only
+NARROW). `justify_status_decision(grant, &entry, status, at_time)` renders a **minimal PROV-O
+justification** for the allow OR the deny (a `prov:Activity` typed `trust:StatusCheck`, `prov:generated`
+the grant, with `trust:statusDecision` = the reason token + the checked index/purpose) — the bead's
+*minimal denial justification*. Two honesty boundaries: (i) it adds **no privacy** (the index + list are
+clear; the resolver learns which credential is checked); (ii) v1 does **not** verify the status-list
+credential's OWN issuer signature (the resolver is the trust seam — a captured follow-up bead).
+Revocation propagates by **full re-materialise** (the §4.4 stale window is *bounded* by `max_age_secs`,
+not closed — no in-reasoner incremental retraction). Pure-Rust base layer (no new default dep); OFF in
+the default build.
+
 ## Related skills
 
 - [`http-server`](../http-server/SKILL.md) — the sparq SPARQL HTTP server has **no**


### PR DESCRIPTION
> 🤖 SPARQ agent — the P6 live-status/revocation stratum for the trust-graph authorisation PoC: gate admission on a LIVE W3C Bitstring Status List (fail-closed on set/unknown/stale) + a minimal PROV-O denial justification. Opt-in, lean-core preserved.

Implements bead **sq-pfae.7** (epic `sq-pfae`, issue #940 / gh-940), the **P6 status stratum** of `research/solid-trust-graph-authz-design.md` §6.1. Behind the **default-OFF `status-list` cargo feature** — strictly additive (the lean default `sparq-trust` / `sparq-solid` build is byte-identical with it OFF; property G6).

## What this adds

Replaces the PoC's per-credential `revoked: bool` flag (the `sq-tu4e` input-only guard) with a check against a **live W3C Bitstring Status List**, and renders a **minimal PROV-O justification** for the allow OR the deny.

- **`sparq_trust::status_list`** — decode a multibase (`u` base64url-no-pad / legacy `z` base58btc) GZIP `encodedList` into an **MSB-first** `StatusBitstring` (the Bitstring-Status-List §3.2 convention). The multibase decode is **hand-rolled and dependency-free** (like `did.rs`'s base58btc); the **network fetch** (`StatusListResolver`) and the **GZIP inflate** (`GzipDecoder`) are **pluggable seams**. The built-in `Flate2GzipDecoder` sits behind the nested `status-list-flate2` feature — the ONLY thing that pulls `flate2`; the plain `status-list` feature and the default build pull **neither** `flate2` nor `serde_json`.
- **`LiveStatusCheck::check -> LiveStatus`** — `LiveStatus::admits()` is `true` for `Live` **only**; **fail-closed** on `Set` (revoked), `Unknown` (unresolvable / undecodable / out-of-range), and `Stale` (snapshot older than `max_age_secs`). Deliberately distinct from the LSB-first ZK `sparq-zk-compose::StatusListSnapshot` mirror — this is the **clear-index gate**, not the hidden-index ZK proof (pulling that crate would break lean-core).
- **`admit::admit_with_status`** — wires the gate into the **REAL** admission path: the live status is checked first (deny the whole credential on a non-admitting status), otherwise it delegates to the unchanged `admit`. It can only **NARROW**, never broaden.
- **`justify_status_decision`** — a `prov:Activity` typed `trust:StatusCheck` that `prov:generated` the grant, carrying `trust:statusDecision` (the deny reason token) + the checked index/purpose — the bead's *minimal denial justification*. An audit record, never an authority (same posture as `delegation_prov`).

## Tests (the REAL path, fail-closed invariant)

- 18 `status_list` unit tests (MSB-first bit layout + fail-closed padding, base64url/base58btc decode + rejection, every `LiveStatus` outcome, the justification shape) + a real-gzip round-trip through `Flate2GzipDecoder`.
- A 5-case `live_status_e2e` integration suite (`#![cfg(feature = "status-list")]`) driving `admit_with_status -> derive_grants`: a live credential derives `auth:read`; revoked / stale / unknown / out-of-range all **deny** the whole credential and carry a denial justification.

## Gates (both feature states)

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — green **default (feature OFF)** AND **`--all-features`** (140 tests pass all-features; 18 status_list + 5 e2e).
- Feature flags: `status-list` (dependency-free) and `status-list-flate2` (adds `flate2`).
- `rustdoc --workspace --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` — clean (no intra-doc link to a cfg-gated item; `Flate2GzipDecoder` is a plain code-span in shared docs).
- `check-readme-template.py --enforce` — 0 deviations, README 120 lines.
- `check-privacy-claims.sh` — clean.
- New `sparq-trust (status-list-flate2)` leg **appended at the END** of the feature-matrix.yml legs list (the `status-list-flate2` set is a superset reaching every `status-list` cfg).

## Decisions (proceed-and-document → issue #1214)

- **The status-list VC's OWN issuer signature is not verified in v1** (the resolver is the trust seam). Chose this to keep the slice self-contained vs coupling to the in-flight Data Integrity verify (sq-ylbrq). Reversible follow-up: **sq-pfae.13**.
- **Revocation propagates by full re-materialise only** (no incremental retraction; consistent with `sq-tu4e`). The §4.4 stale window is *bounded* by `max_age_secs`, not closed. Follow-up: **sq-pfae.14**.

## Honest scope

Research-grade, fail-closed, **no privacy / unlinkability** (clear-index gate; the resolver learns which credential is checked). The ZK estate it composes with is research-grade and externally **UNAUDITED** (`sq-qhy4`, pending external accredited-cryptographer sign-off). Written while Fable unavailable — flag for re-review when Fable returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)