### PR TITLE
test(sparq-shacl): correctness coverage (sq-bif)

### DIFF
--- a/crates/sparq-shacl/src/lib.rs
+++ b/crates/sparq-shacl/src/lib.rs
@@ -209,6 +209,40 @@ mod tests {
         assert_eq!(count_focus_nodes(&empty, &model), 0);
     }
 
+    /// [OPUS-4.8] (sq-bif) `count_focus_nodes` unions EVERY target kind — node,
+    /// subjects-of, objects-of — deduplicated. A node selected by two distinct
+    /// targets is counted once.
+    #[test]
+    fn focus_node_count_unions_all_target_kinds() {
+        let data = Graph::load_str(
+            r#"
+            @prefix ex: <http://example.org/> .
+            ex:alice ex:knows ex:bob .
+            ex:carol ex:knows ex:alice .
+        "#,
+            "turtle",
+        )
+        .unwrap();
+        // sh:targetNode ex:alice, sh:targetSubjectsOf ex:knows (= {alice, carol}),
+        // sh:targetObjectsOf ex:knows (= {bob, alice}). The deduplicated union is
+        // {alice, bob, carol} = 3 (alice appears via all three but counts once).
+        let shapes = Graph::load_str(
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:S a sh:NodeShape ;
+              sh:targetNode ex:alice ;
+              sh:targetSubjectsOf ex:knows ;
+              sh:targetObjectsOf ex:knows ;
+              sh:property [ sh:path ex:name ; sh:minCount 1 ] .
+        "#,
+            "turtle",
+        )
+        .unwrap();
+        let model = ShapesModel::parse(&shapes);
+        assert_eq!(count_focus_nodes(&data, &model), 3);
+    }
+
     /// The Turtle rendering must itself be valid Turtle.
     #[test]
     fn report_turtle_parses() {
@@ -412,6 +446,78 @@ mod tests {
             .results
             .iter()
             .any(|x| x.source_component.ends_with("MinCountConstraintComponent")));
+    }
+
+    // [OPUS-4.8] (sq-bif) `load_turtle_with_base` resolves relative IRIs against
+    // the supplied base (the seam `Graph::load_str` does not expose, used by the
+    // W3C manifest loaders) and surfaces a parse error as an `Err(String)`.
+    #[test]
+    fn load_turtle_with_base_resolves_relatives_and_reports_errors() {
+        // `<rel>` and `<#frag>` resolve against the base.
+        let g = load_turtle_with_base(
+            "<rel> <http://example.org/p> <#frag> .",
+            "http://base.example/dir/",
+        )
+        .unwrap();
+        let v = view::GraphView::new(&g);
+        // The relative subject resolved to base + "rel".
+        assert!(v.contains(
+            &oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked(
+                "http://base.example/dir/rel"
+            )),
+            "http://example.org/p",
+            &oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked(
+                "http://base.example/dir/#frag"
+            )),
+        ));
+        // A malformed Turtle document is an Err, not a panic (Graph has no Debug,
+        // so map to the error string before asserting).
+        let err = load_turtle_with_base("this is not turtle @@@", "http://base.example/").err();
+        assert!(err.is_some(), "malformed Turtle must Err");
+        // An invalid base IRI is also a (different) Err.
+        assert!(load_turtle_with_base("", "not a valid base").is_err());
+    }
+
+    // [OPUS-4.8] (sq-bif) `graph_from_triples` interns oxrdf triples — including
+    // a BLANK-NODE subject (the subject match arm `Graph::load_str` round-trips
+    // but the helper handles explicitly) — into a queryable Graph.
+    #[test]
+    fn graph_from_triples_interns_iri_and_blank_subjects() {
+        use oxrdf::{BlankNode, NamedNode, NamedOrBlankNode, Term, Triple};
+        let p = NamedNode::new_unchecked("http://example.org/p");
+        let bnode = BlankNode::default();
+        let triples = vec![
+            // IRI subject.
+            Triple::new(
+                NamedOrBlankNode::NamedNode(NamedNode::new_unchecked("http://example.org/s")),
+                p.clone(),
+                Term::NamedNode(NamedNode::new_unchecked("http://example.org/o")),
+            ),
+            // Blank-node subject (the BlankNode arm of the subject match).
+            Triple::new(
+                NamedOrBlankNode::BlankNode(bnode.clone()),
+                p.clone(),
+                Term::Literal(oxrdf::Literal::new_simple_literal("x")),
+            ),
+        ];
+        let g = graph_from_triples(triples);
+        let v = view::GraphView::new(&g);
+        // Both triples are present and queryable.
+        assert!(v.contains(
+            &Term::NamedNode(NamedNode::new_unchecked("http://example.org/s")),
+            "http://example.org/p",
+            &Term::NamedNode(NamedNode::new_unchecked("http://example.org/o")),
+        ));
+        assert!(v.contains(
+            &Term::BlankNode(bnode),
+            "http://example.org/p",
+            &Term::Literal(oxrdf::Literal::new_simple_literal("x")),
+        ));
+        // An empty iterator yields an empty graph.
+        let empty = graph_from_triples(std::iter::empty());
+        assert!(view::GraphView::new(&empty)
+            .triples(None, Some("http://example.org/p"), None)
+            .is_empty());
     }
 
     #[test]

--- a/crates/sparq-shacl/src/view.rs
+++ b/crates/sparq-shacl/src/view.rs
@@ -262,3 +262,384 @@ pub(crate) fn dedup(items: impl IntoIterator<Item = Term>) -> Vec<Term> {
     }
     out
 }
+
+// [OPUS-4.8] (sq-bif) Direct unit coverage for the public `GraphView` read-view.
+// The W3C-suite harness drives `view.object`/`view.list` indirectly, but the
+// edge-case branches of this term-level API — the invalid-IRI guards, the
+// cycle-safe lenient `list` vs the strict `list_strict` (which must REJECT a
+// malformed/duplicated/cyclic list rather than silently truncate), and the
+// `rdfs:subClassOf` closure walk in `instances_of`/`is_instance_of` — are
+// load-bearing and were previously unexercised at the assertion level. Graphs are
+// built term-exactly via `crate::graph_from_triples` so malformed lists, cycles
+// and subclass hierarchies can be constructed precisely.
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxrdf::{BlankNode, Literal, NamedNode, NamedOrBlankNode, Triple};
+
+    const EX: &str = "http://example.org/";
+
+    fn nn(s: &str) -> NamedNode {
+        NamedNode::new_unchecked(s.to_string())
+    }
+    fn iri(s: &str) -> Term {
+        Term::NamedNode(nn(s))
+    }
+    fn ex(local: &str) -> Term {
+        iri(&format!("{EX}{local}"))
+    }
+    fn lit(s: &str) -> Term {
+        Term::Literal(Literal::new_simple_literal(s))
+    }
+
+    /// Build a graph from `(subject, predicate, object)` term triples. A literal
+    /// subject is illegal in RDF and is skipped (no such triple in our fixtures).
+    fn graph(triples: &[(Term, &str, Term)]) -> Graph {
+        let ts: Vec<Triple> = triples
+            .iter()
+            .filter_map(|(s, p, o)| {
+                let subj = match s {
+                    Term::NamedNode(n) => NamedOrBlankNode::NamedNode(n.clone()),
+                    Term::BlankNode(b) => NamedOrBlankNode::BlankNode(b.clone()),
+                    // A literal (or RDF-star quoted-triple) subject is illegal in
+                    // RDF 1.1 and never appears in our fixtures — skip it.
+                    _ => return None,
+                };
+                Some(Triple::new(subj, nn(p), o.clone()))
+            })
+            .collect();
+        crate::graph_from_triples(ts)
+    }
+
+    // ---- pattern scans + invalid-IRI guards ----
+
+    #[test]
+    fn triples_invalid_predicate_iri_matches_nothing() {
+        let g = graph(&[(ex("s"), &format!("{EX}p"), ex("o"))]);
+        let v = GraphView::new(&g);
+        // A syntactically invalid predicate IRI (contains a space) cannot name a
+        // term, so the scan returns nothing rather than erroring.
+        assert!(v.triples(None, Some("not a valid iri"), None).is_empty());
+        // A well-formed but ABSENT predicate also matches nothing (dict miss).
+        assert!(v
+            .triples(None, Some(&format!("{EX}absent")), None)
+            .is_empty());
+        // The real predicate matches the one triple.
+        assert_eq!(v.triples(None, Some(&format!("{EX}p")), None).len(), 1);
+    }
+
+    #[test]
+    fn contains_respects_ground_terms_and_invalid_iri() {
+        let g = graph(&[(ex("s"), &format!("{EX}p"), ex("o"))]);
+        let v = GraphView::new(&g);
+        assert!(v.contains(&ex("s"), &format!("{EX}p"), &ex("o")));
+        // Wrong object — not present.
+        assert!(!v.contains(&ex("s"), &format!("{EX}p"), &ex("other")));
+        // A subject term absent from the dictionary — not present.
+        assert!(!v.contains(&ex("ghost"), &format!("{EX}p"), &ex("o")));
+        // An invalid predicate IRI — false, not a panic.
+        assert!(!v.contains(&ex("s"), "bad iri", &ex("o")));
+    }
+
+    // ---- objects / subjects / dedup projections ----
+
+    #[test]
+    fn object_objects_subjects_and_str_object() {
+        let g = graph(&[
+            (ex("s"), &format!("{EX}p"), ex("a")),
+            (ex("s"), &format!("{EX}p"), ex("b")),
+            (ex("s"), &format!("{EX}label"), lit("hi")),
+            (ex("t"), &format!("{EX}p"), ex("a")),
+        ]);
+        let v = GraphView::new(&g);
+        // objects: both a and b (order not guaranteed → compare as a set).
+        let mut objs: Vec<String> = v
+            .objects(&ex("s"), &format!("{EX}p"))
+            .iter()
+            .map(|t| t.to_string())
+            .collect();
+        objs.sort();
+        assert_eq!(objs, vec![ex("a").to_string(), ex("b").to_string()]);
+        // object: the first (some) value of p; absent predicate → None.
+        assert!(v.object(&ex("s"), &format!("{EX}p")).is_some());
+        assert!(v.object(&ex("s"), &format!("{EX}absent")).is_none());
+        // subjects of (p, a): both s and t.
+        let mut subs: Vec<String> = v
+            .subjects(&format!("{EX}p"), &ex("a"))
+            .iter()
+            .map(|t| t.to_string())
+            .collect();
+        subs.sort();
+        assert_eq!(subs, vec![ex("s").to_string(), ex("t").to_string()]);
+        // str_object: the lexical form of a literal object; None for an IRI object.
+        assert_eq!(
+            v.str_object(&ex("s"), &format!("{EX}label")),
+            Some("hi".to_string())
+        );
+        assert_eq!(v.str_object(&ex("s"), &format!("{EX}p")), None);
+    }
+
+    #[test]
+    fn subjects_of_and_objects_of_dedup() {
+        // Two subjects each with the predicate twice over distinct objects: the
+        // DISTINCT subjects of p is {s, t}; the DISTINCT objects is {a, b, c}.
+        let g = graph(&[
+            (ex("s"), &format!("{EX}p"), ex("a")),
+            (ex("s"), &format!("{EX}p"), ex("b")),
+            (ex("t"), &format!("{EX}p"), ex("b")),
+            (ex("t"), &format!("{EX}p"), ex("c")),
+        ]);
+        let v = GraphView::new(&g);
+        assert_eq!(v.subjects_of(&format!("{EX}p")).len(), 2);
+        assert_eq!(v.objects_of(&format!("{EX}p")).len(), 3);
+    }
+
+    #[test]
+    fn predicate_objects_lists_every_pair() {
+        let g = graph(&[
+            (ex("s"), &format!("{EX}p"), ex("a")),
+            (ex("s"), &format!("{EX}q"), lit("x")),
+        ]);
+        let v = GraphView::new(&g);
+        let mut pairs: Vec<(String, String)> = v
+            .predicate_objects(&ex("s"))
+            .into_iter()
+            .map(|(p, o)| (p.to_string(), o.to_string()))
+            .collect();
+        pairs.sort();
+        assert_eq!(pairs.len(), 2);
+        assert!(pairs.iter().any(|(p, _)| p.ends_with("q>")));
+    }
+
+    // ---- has_type / instances_of / subclass closure ----
+
+    #[test]
+    fn has_type_direct_only_and_invalid_class() {
+        let g = graph(&[(ex("alice"), RDF_TYPE, ex("Person"))]);
+        let v = GraphView::new(&g);
+        assert!(v.has_type(&ex("alice"), &format!("{EX}Person")));
+        // has_type is direct (no subclass walk); a superclass is NOT a direct type.
+        assert!(!v.has_type(&ex("alice"), &format!("{EX}Agent")));
+        // An invalid class IRI → false, not a panic.
+        assert!(!v.has_type(&ex("alice"), "not an iri"));
+    }
+
+    #[test]
+    fn instances_of_walks_subclass_closure() {
+        // Worker ⊑ Employee ⊑ Person. An instance of the most-derived class is an
+        // instance of every ancestor.
+        let g = graph(&[
+            (ex("Employee"), RDFS_SUBCLASS_OF, ex("Person")),
+            (ex("Worker"), RDFS_SUBCLASS_OF, ex("Employee")),
+            (ex("alice"), RDF_TYPE, ex("Worker")),
+            (ex("bob"), RDF_TYPE, ex("Employee")),
+            (ex("carol"), RDF_TYPE, ex("Person")),
+        ]);
+        let v = GraphView::new(&g);
+        // instances_of(Person) = closure {Person, Employee, Worker} typed nodes.
+        let mut insts: Vec<String> = v
+            .instances_of(&ex("Person"))
+            .iter()
+            .map(|t| t.to_string())
+            .collect();
+        insts.sort();
+        assert_eq!(
+            insts,
+            vec![
+                ex("alice").to_string(),
+                ex("bob").to_string(),
+                ex("carol").to_string()
+            ]
+        );
+        // instances_of(Employee) excludes the Person-only carol.
+        let mut insts: Vec<String> = v
+            .instances_of(&ex("Employee"))
+            .iter()
+            .map(|t| t.to_string())
+            .collect();
+        insts.sort();
+        assert_eq!(insts, vec![ex("alice").to_string(), ex("bob").to_string()]);
+    }
+
+    #[test]
+    fn instances_of_dedupes_across_subclass_routes() {
+        // A node typed BOTH as the class and a subclass must appear once.
+        let g = graph(&[
+            (ex("Sub"), RDFS_SUBCLASS_OF, ex("Super")),
+            (ex("x"), RDF_TYPE, ex("Super")),
+            (ex("x"), RDF_TYPE, ex("Sub")),
+        ]);
+        let v = GraphView::new(&g);
+        assert_eq!(v.instances_of(&ex("Super")).len(), 1);
+    }
+
+    #[test]
+    fn subclass_closure_is_cycle_safe_and_reflexive() {
+        // A subclass CYCLE (A ⊑ B ⊑ A) must not loop forever; the closure is the
+        // reflexive set {A, B}.
+        let g = graph(&[
+            (ex("A"), RDFS_SUBCLASS_OF, ex("B")),
+            (ex("B"), RDFS_SUBCLASS_OF, ex("A")),
+        ]);
+        let v = GraphView::new(&g);
+        let mut clo: Vec<String> = v
+            .subclass_closure(&ex("A"))
+            .iter()
+            .map(|t| t.to_string())
+            .collect();
+        clo.sort();
+        assert_eq!(clo, vec![ex("A").to_string(), ex("B").to_string()]);
+        // A class with no declared subclasses → just itself (reflexive).
+        assert_eq!(v.subclass_closure(&ex("Lonely")).len(), 1);
+    }
+
+    #[test]
+    fn is_instance_of_walks_superclasses_and_rejects_literals() {
+        let g = graph(&[
+            (ex("Employee"), RDFS_SUBCLASS_OF, ex("Person")),
+            (ex("alice"), RDF_TYPE, ex("Employee")),
+        ]);
+        let v = GraphView::new(&g);
+        // Direct type.
+        assert!(v.is_instance_of(&ex("alice"), &ex("Employee")));
+        // Via the rdfs:subClassOf walk (Employee ⊑ Person).
+        assert!(v.is_instance_of(&ex("alice"), &ex("Person")));
+        // Not an instance of an unrelated class.
+        assert!(!v.is_instance_of(&ex("alice"), &ex("Robot")));
+        // A literal is never a SHACL instance of any class (early return).
+        assert!(!v.is_instance_of(&lit("x"), &ex("Person")));
+    }
+
+    #[test]
+    fn is_instance_of_handles_superclass_cycle() {
+        // A ⊑ B ⊑ A with x typed A: the superclass walk must terminate.
+        let g = graph(&[
+            (ex("A"), RDFS_SUBCLASS_OF, ex("B")),
+            (ex("B"), RDFS_SUBCLASS_OF, ex("A")),
+            (ex("x"), RDF_TYPE, ex("A")),
+        ]);
+        let v = GraphView::new(&g);
+        assert!(v.is_instance_of(&ex("x"), &ex("A")));
+        assert!(v.is_instance_of(&ex("x"), &ex("B")));
+        assert!(!v.is_instance_of(&ex("x"), &ex("Unrelated")));
+    }
+
+    // ---- list (lenient) vs list_strict (well-formed only) ----
+
+    /// Build an `rdf:first`/`rdf:rest` chain over the given members rooted at a
+    /// fresh blank node; the tail is `rdf:nil`. Returns (head, triples).
+    fn well_formed_list(members: &[Term]) -> (Term, Vec<(Term, &'static str, Term)>) {
+        let nil = iri(RDF_NIL);
+        let mut triples: Vec<(Term, &'static str, Term)> = Vec::new();
+        let mut next = nil.clone();
+        // Build right-to-left so each cons cell points at the previously-built tail.
+        for m in members.iter().rev() {
+            let cell = Term::BlankNode(BlankNode::default());
+            triples.push((cell.clone(), RDF_FIRST, m.clone()));
+            triples.push((cell.clone(), RDF_REST, next.clone()));
+            next = cell;
+        }
+        (next, triples)
+    }
+
+    #[test]
+    fn list_and_list_strict_well_formed() {
+        let (head, ts) = well_formed_list(&[ex("a"), ex("b"), ex("c")]);
+        let g = graph(&ts);
+        let v = GraphView::new(&g);
+        let want = vec![ex("a"), ex("b"), ex("c")];
+        assert_eq!(v.list(&head), want);
+        assert_eq!(v.list_strict(&head), Some(want));
+        // The empty list: rdf:nil with nothing attached.
+        let empty = graph(&[(ex("s"), &format!("{EX}p"), ex("o"))]);
+        let ev = GraphView::new(&empty);
+        assert!(ev.list(&iri(RDF_NIL)).is_empty());
+        assert_eq!(ev.list_strict(&iri(RDF_NIL)), Some(vec![]));
+    }
+
+    #[test]
+    fn list_strict_rejects_literal_head() {
+        let g = graph(&[(ex("s"), &format!("{EX}p"), ex("o"))]);
+        let v = GraphView::new(&g);
+        // A literal is never a SHACL list.
+        assert_eq!(v.list_strict(&lit("x")), None);
+        // The lenient walk also yields nothing for a literal head (no rdf:first).
+        assert!(v.list(&lit("x")).is_empty());
+    }
+
+    #[test]
+    fn list_strict_rejects_nil_with_extra_triples() {
+        // rdf:nil carrying an rdf:first is NOT the empty list under the strict check.
+        let g = graph(&[(iri(RDF_NIL), RDF_FIRST, ex("a"))]);
+        let v = GraphView::new(&g);
+        assert_eq!(v.list_strict(&iri(RDF_NIL)), None);
+    }
+
+    #[test]
+    fn list_strict_rejects_duplicate_first_or_rest() {
+        // A cons cell with TWO rdf:first values is malformed → rejected.
+        let cell = Term::BlankNode(BlankNode::default());
+        let g = graph(&[
+            (cell.clone(), RDF_FIRST, ex("a")),
+            (cell.clone(), RDF_FIRST, ex("b")),
+            (cell.clone(), RDF_REST, iri(RDF_NIL)),
+        ]);
+        let v = GraphView::new(&g);
+        assert_eq!(v.list_strict(&cell), None);
+        // But the lenient `list` still extracts ONE member (it tolerates the
+        // malformation) — exactly the silent-truncation `list_strict` guards against.
+        assert_eq!(v.list(&cell).len(), 1);
+    }
+
+    #[test]
+    fn list_strict_rejects_missing_first() {
+        // A cell with only rdf:rest (no rdf:first) is not a well-formed list node.
+        let cell = Term::BlankNode(BlankNode::default());
+        let g = graph(&[(cell.clone(), RDF_REST, iri(RDF_NIL))]);
+        let v = GraphView::new(&g);
+        assert_eq!(v.list_strict(&cell), None);
+        // Lenient `list` breaks at the missing rdf:first → empty.
+        assert!(v.list(&cell).is_empty());
+    }
+
+    #[test]
+    fn list_and_list_strict_reject_cycle() {
+        // A cell whose rdf:rest points back at itself: a cycle via rdf:rest+.
+        let cell = Term::BlankNode(BlankNode::default());
+        let g = graph(&[
+            (cell.clone(), RDF_FIRST, ex("a")),
+            (cell.clone(), RDF_REST, cell.clone()),
+        ]);
+        let v = GraphView::new(&g);
+        // list_strict rejects a cycle outright.
+        assert_eq!(v.list_strict(&cell), None);
+        // The lenient `list` is cycle-SAFE: it terminates, yielding the members
+        // seen before re-entry (here the single 'a') rather than looping forever.
+        assert_eq!(v.list(&cell), vec![ex("a")]);
+    }
+
+    #[test]
+    fn list_lenient_truncates_malformed_tail() {
+        // head -> a -> (cell with no rdf:rest): lenient `list` returns [a, b] then
+        // stops; list_strict rejects because the second cell has no rdf:rest.
+        let c1 = Term::BlankNode(BlankNode::default());
+        let c2 = Term::BlankNode(BlankNode::default());
+        let g = graph(&[
+            (c1.clone(), RDF_FIRST, ex("a")),
+            (c1.clone(), RDF_REST, c2.clone()),
+            (c2.clone(), RDF_FIRST, ex("b")),
+            // c2 has NO rdf:rest → malformed tail.
+        ]);
+        let v = GraphView::new(&g);
+        assert_eq!(v.list(&c1), vec![ex("a"), ex("b")]);
+        assert_eq!(v.list_strict(&c1), None);
+    }
+
+    #[test]
+    fn graph_accessor_returns_underlying() {
+        let g = graph(&[(ex("s"), &format!("{EX}p"), ex("o"))]);
+        let v = GraphView::new(&g);
+        // The seam SHACL-SPARQL uses: the accessor hands back the same graph.
+        assert!(std::ptr::eq(v.graph(), &g));
+    }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — automated correctness-test coverage for `sparq-shacl` (advances P1 umbrella `sq-bif`). No production code changed; tests only.

## What

Fills genuine correctness-test gaps in the **default (non-feature-gated) surface** of `sparq-shacl`, found with `cargo llvm-cov -p sparq-shacl`. `view.rs` was the lowest line-covered file (~87% line) with **no direct unit tests**, and the `lib.rs` public helpers were untested (~78% region). Every new test asserts **specific correct behaviour** (rejection / exact membership / distinct counts), so it would catch a real regression — not a "does not panic" pad.

### `view.rs` — new unit-test module for the public `view::GraphView` read-view
- invalid / absent predicate-IRI guards on `triples()` / `contains()` / `has_type()`
- `objects` / `subjects` / `predicate_objects` / `str_object` projections; distinct dedup in `subjects_of` / `objects_of`
- the `rdfs:subClassOf` closure walk in `instances_of` / `is_instance_of`: multi-level hierarchy, dedup across subclass routes, **reflexive + cycle-safe** `subclass_closure`
- the load-bearing **lenient `list()`** (cycle-safe, truncates a malformed tail) vs the **strict `list_strict()`**, which must REJECT: a literal head, `rdf:nil` carrying extra triples, a duplicated `rdf:first`/`rdf:rest`, a missing `rdf:first`, and an `rdf:rest+` cycle — the silent-truncation hazard `list_strict` exists to guard against

### `lib.rs` — public helpers
- `graph_from_triples`: IRI **and blank-node** subject arms, empty input
- `load_turtle_with_base`: relative-IRI resolution against the base, plus the malformed-Turtle and invalid-base `Err` paths
- `count_focus_nodes` over `sh:targetNode` / `sh:targetSubjectsOf` / `sh:targetObjectsOf` with the distinct-union semantics across mixed target kinds

## Coverage (default surface)
- TOTAL: **93.38% → 95.18%** region, **95.29% → 96.77%** line
- `view.rs`: 89.43% → **99.91%** region, 87.36% → **99.77%** line
- `lib.rs`: 77.78% → **92.83%** region, 88.58% → **98.81%** line

The coverage ratchet rises; nothing regresses.

## Gates (run in-worktree)
- `cargo test -p sparq-shacl` — green (default: 102 lib tests)
- `cargo test -p sparq-shacl --all-features` — green (139 lib tests)
- `cargo clippy -p sparq-shacl --all-targets -- -D warnings` — clean (default **and** `--all-features`)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-shacl --no-deps --all-features` — clean
- `rustfmt`: new code is fmt-clean; the pre-existing deferred-reformat backlog left untouched (no `cargo fmt` over unrelated files)

## Scope
Test-only, default surface — **no new cargo feature or cfg-gate** (so no feature-matrix fragment needed), no README / SKILL change (no public-API change). Umbrella `sq-bif` is **not** closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)