### PR TITLE
test(sparq-engine): correctness coverage (sq-bif)

### DIFF
--- a/crates/sparq-engine/src/json.rs
+++ b/crates/sparq-engine/src/json.rs
@@ -285,3 +285,154 @@ mod escape_tests {
         assert_eq!(esc("\u{7f}"), "\u{7f}");
     }
 }
+
+/// [OPUS-4.8] (sq-bif) The materialised `term_to_json` writer through the public
+/// `to_sparql_json_rows` — the SPARQL-1.1/1.2-results-JSON binding object for EACH
+/// term shape. The existing `rows_tests` only exercise the `uri` shape; these pin
+/// the `bnode`, plain/typed/language/directional literal and RDF-1.2 triple-term
+/// encodings so a regression in any branch of `term_to_json` is caught (e.g. the
+/// `its:dir` split or the recursive triple-term writer, which had no public
+/// assertion before).
+#[cfg(test)]
+mod term_shape_tests {
+    use super::to_sparql_json_rows;
+    use oxrdf::vocab::xsd;
+    use oxrdf::{BaseDirection, BlankNode, Literal, NamedNode, Term, Triple, Variable};
+
+    /// Wrap one term as a single `?v` binding and return JUST its binding object
+    /// (the depth-matched object after `"v":` in the one-row document), so each
+    /// assertion reads as the exact SPARQL-results-JSON for that term.
+    fn binding(t: Term) -> String {
+        let vars = vec![Variable::new("v").unwrap()];
+        let doc = to_sparql_json_rows(&vars, &[vec![Some(t)]]);
+        let needle = "\"v\":";
+        let start = doc.find(needle).expect("binding present") + needle.len();
+        let rest = &doc[start..];
+        // The object runs from its opening `{` to the matching `}`.
+        let bytes = rest.as_bytes();
+        let mut depth = 0usize;
+        let mut end = None;
+        for (i, &b) in bytes.iter().enumerate() {
+            match b {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = Some(i + 1);
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        rest[..end.expect("object closes")].to_string()
+    }
+
+    #[test]
+    fn iri_and_bnode_shapes() {
+        assert_eq!(
+            binding(Term::NamedNode(NamedNode::new("http://ex/o").unwrap())),
+            r#"{"type":"uri","value":"http://ex/o"}"#
+        );
+        assert_eq!(
+            binding(Term::BlankNode(BlankNode::new("b0").unwrap())),
+            r#"{"type":"bnode","value":"b0"}"#
+        );
+    }
+
+    #[test]
+    fn plain_and_typed_literal_shapes() {
+        // A plain (xsd:string) literal omits the datatype key entirely.
+        assert_eq!(
+            binding(Term::Literal(Literal::new_simple_literal("hi"))),
+            r#"{"type":"literal","value":"hi"}"#
+        );
+        // xsd:string is the default and is STILL omitted even when explicit.
+        assert_eq!(
+            binding(Term::Literal(Literal::new_typed_literal("hi", xsd::STRING))),
+            r#"{"type":"literal","value":"hi"}"#
+        );
+        // A non-string datatype is emitted.
+        let int42 = Term::Literal(Literal::new_typed_literal("42", xsd::INTEGER));
+        assert_eq!(
+            binding(int42),
+            r#"{"type":"literal","value":"42","datatype":"http://www.w3.org/2001/XMLSchema#integer"}"#
+        );
+        // The value is JSON-escaped (a quote and a newline in the lexical form).
+        assert_eq!(
+            binding(Term::Literal(Literal::new_simple_literal("a\"b\nc"))),
+            r#"{"type":"literal","value":"a\"b\nc"}"#
+        );
+    }
+
+    #[test]
+    fn language_and_directional_literal_shapes() {
+        // Directional-literal builder, kept short so the assertions fit.
+        let dir = |v: &str, tag: &str, d: BaseDirection| {
+            Term::Literal(Literal::new_directional_language_tagged_literal(v, tag, d).unwrap())
+        };
+        let lang = |v: &str, tag: &str| {
+            Term::Literal(Literal::new_language_tagged_literal(v, tag).unwrap())
+        };
+
+        // A language-tagged literal: `xml:lang`, no datatype.
+        assert_eq!(
+            binding(lang("hello", "en")),
+            r#"{"type":"literal","value":"hello","xml:lang":"en"}"#
+        );
+        // RDF 1.2 directional literal: `xml:lang` is the BARE tag and `its:dir`
+        // carries the base direction — the two are kept apart (SPARQL 1.2 JSON),
+        // never folded into one `xml:lang:"en--ltr"`.
+        assert_eq!(
+            binding(dir("hello", "en", BaseDirection::Ltr)),
+            r#"{"type":"literal","value":"hello","xml:lang":"en","its:dir":"ltr"}"#
+        );
+        assert_eq!(
+            binding(dir("مرحبا", "ar", BaseDirection::Rtl)),
+            r#"{"type":"literal","value":"مرحبا","xml:lang":"ar","its:dir":"rtl"}"#
+        );
+    }
+
+    #[test]
+    fn rdf_star_triple_term_shape_recurses() {
+        // An RDF 1.2 quoted triple `<< :a :p 7 >>` in object position:
+        // `{"type":"triple","value":{"subject":…,"predicate":…,"object":…}}`, each
+        // component recursively encoded by the SAME writer (so the integer object
+        // carries its datatype and the predicate is a `uri`).
+        let t = Triple::new(
+            NamedNode::new("http://ex/a").unwrap(),
+            NamedNode::new("http://ex/p").unwrap(),
+            Literal::new_typed_literal("7", xsd::INTEGER),
+        );
+        assert_eq!(
+            binding(Term::Triple(Box::new(t))),
+            concat!(
+                r#"{"type":"triple","value":{"#,
+                r#""subject":{"type":"uri","value":"http://ex/a"},"#,
+                r#""predicate":{"type":"uri","value":"http://ex/p"},"#,
+                r#""object":{"type":"literal","value":"7","datatype":"http://www.w3.org/2001/XMLSchema#integer"}}}"#,
+            )
+        );
+
+        // A triple nested in the OBJECT of another triple recurses one more level
+        // (subject-position quoted triples are not representable in oxrdf's term
+        // model, so object nesting is the reachable nested case).
+        let inner = Triple::new(
+            NamedNode::new("http://ex/a").unwrap(),
+            NamedNode::new("http://ex/p").unwrap(),
+            Term::NamedNode(NamedNode::new("http://ex/b").unwrap()),
+        );
+        let outer = Triple::new(
+            NamedNode::new("http://ex/c").unwrap(),
+            NamedNode::new("http://ex/says").unwrap(),
+            Term::Triple(Box::new(inner)),
+        );
+        let json = binding(Term::Triple(Box::new(outer)));
+        let has = |needle: &str| assert!(json.contains(needle), "{json}");
+        has(r#""object":{"type":"triple","value":{"#);
+        has(r#""object":{"type":"uri","value":"http://ex/b"}"#);
+        let want_prefix =
+            r#"{"type":"triple","value":{"subject":{"type":"uri","value":"http://ex/c"}"#;
+        assert!(json.starts_with(want_prefix), "{json}");
+    }
+}

--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -2311,4 +2311,166 @@ mod tests {
         assert_eq!(r.len(), n as usize);
         assert!(r.rows.iter().all(|row| row[0].is_some()));
     }
+
+    // [OPUS-4.8] (sq-bif) The public `count` / `count_prepared` entry points — the
+    // id-level solution counter that the server's budgeted ASK path leans on. The
+    // local `count` helper above routes through `query().len()`; these exercise the
+    // REAL `crate::count` (no result materialisation) and pin its agreement with the
+    // materialised count plus its form-rejection error path.
+
+    /// `count` must agree with `query(..).len()` across the modifier shapes that
+    /// change the cardinality (DISTINCT collapses duplicates, LIMIT caps, the
+    /// projection of a constant). A divergence here means the count fast path and
+    /// the materialising path disagree — a real correctness bug.
+    #[test]
+    fn count_agrees_with_materialized_len() {
+        let g = g();
+        let cases = [
+            "PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:age ?a }",
+            "PREFIX ex: <http://ex/> SELECT DISTINCT ?a WHERE { ?s ex:knows ?b ; ex:age ?a }",
+            "PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:age ?a } LIMIT 2",
+            "PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:age ?a } ORDER BY ?a LIMIT 1",
+            // Empty result: an unsatisfiable pattern.
+            "PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:nope ?a }",
+            // A cross/star join.
+            "PREFIX ex: <http://ex/> SELECT ?a ?b WHERE { ?a ex:knows ?b . ?b ex:age ?x }",
+        ];
+        for q in cases {
+            assert_eq!(
+                crate::count(&g, q).unwrap(),
+                query(&g, q).unwrap().len(),
+                "count disagrees with materialised len for {q:?}"
+            );
+        }
+    }
+
+    /// An ASK counts its single unit row: 1 when satisfiable, 0 otherwise — the
+    /// `usize::from(bool)` arm of `count_prepared_with_budget`.
+    #[test]
+    fn count_of_ask_is_zero_or_one() {
+        let g = g();
+        let cnt = |q: &str| crate::count(&g, q).unwrap();
+        assert_eq!(cnt("PREFIX ex: <http://ex/> ASK { ?s ex:age ?a }"), 1);
+        assert_eq!(cnt("PREFIX ex: <http://ex/> ASK { ?s ex:nope ?a }"), 0);
+    }
+
+    /// `count` (and `query_json`) only support SELECT / ASK; the graph-valued
+    /// forms (CONSTRUCT / DESCRIBE) are an explicit error, not a panic or a wrong
+    /// number. This guards the `_ => Err(...)` arms that have no other coverage.
+    #[test]
+    fn count_and_query_json_reject_graph_forms() {
+        let g = g();
+        let construct = "PREFIX ex: <http://ex/> CONSTRUCT { ?s ex:a ?a } WHERE { ?s ex:age ?a }";
+        let describe = "DESCRIBE <http://ex/alice>";
+        let rejects = |e: String, q: &str| assert!(e.contains("only SELECT and ASK"), "{q:?}: {e}");
+        for q in [construct, describe] {
+            rejects(crate::count(&g, q).unwrap_err(), q);
+            rejects(query_json(&g, q).unwrap_err(), q);
+        }
+        // count_prepared takes the same path over a pre-parsed query.
+        let prepared = PreparedQuery::parse(construct).unwrap();
+        assert!(count_prepared(&g, &prepared).is_err());
+    }
+
+    /// `query_json` of an ASK emits the SPARQL-results-JSON boolean document
+    /// (`{"head":{},"boolean":…}`), distinct from the SELECT `bindings` document.
+    #[test]
+    fn query_json_ask_emits_boolean_document() {
+        let g = g();
+        assert_eq!(
+            query_json(&g, "PREFIX ex: <http://ex/> ASK { ?s ex:age ?a }").unwrap(),
+            r#"{"head":{},"boolean":true}"#
+        );
+        assert_eq!(
+            query_json(&g, "PREFIX ex: <http://ex/> ASK { ?s ex:nope ?a }").unwrap(),
+            r#"{"head":{},"boolean":false}"#
+        );
+    }
+
+    /// The `PreparedQuery` round-trips: parse / `From<Query>` / `FromStr` /
+    /// `into_query` all produce the SAME execution. A query built programmatically
+    /// from algebra (the sparq-rsp / rewrite seam) must evaluate identically to the
+    /// parsed string form.
+    #[test]
+    fn prepared_query_construction_round_trips() {
+        let g = g();
+        let q = "PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:age ?a } ORDER BY ?s";
+
+        let from_parse = PreparedQuery::parse(q).unwrap();
+        // FromStr is the same as parse.
+        let from_str: PreparedQuery = q.parse().unwrap();
+        // From<Query> wraps already-parsed algebra; into_query unwraps it back.
+        let algebra = from_parse.clone().into_query();
+        let from_algebra = PreparedQuery::from(algebra);
+
+        let want = query_prepared(&g, &from_parse).unwrap();
+        for p in [&from_str, &from_algebra] {
+            let got = query_prepared(&g, p).unwrap();
+            assert_eq!(got.vars, want.vars);
+            assert_eq!(got.rows, want.rows);
+        }
+        // `query()` exposes the wrapped algebra without consuming it.
+        assert!(matches!(from_parse.query(), Query::Select { .. }));
+        // A malformed query is a parse error, not a panic.
+        assert!(PreparedQuery::parse("SELECT ?s WHERE { ?s ?p").is_err());
+        assert!("not a query".parse::<PreparedQuery>().is_err());
+    }
+
+    /// `QueryResult::len` / `is_empty` track the row count exactly — including the
+    /// degenerate one-unbound-row case a no-match aggregate produces (NOT empty),
+    /// which is a classic off-by-one trap.
+    #[test]
+    fn query_result_len_and_is_empty() {
+        let g = g();
+        let run = |q: &str| query(&g, q).unwrap();
+
+        let some = run("PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:age ?a }");
+        assert_eq!(some.len(), 3);
+        assert!(!some.is_empty());
+
+        let none = run("PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:nope ?a }");
+        assert_eq!(none.len(), 0);
+        assert!(none.is_empty());
+
+        // A whole-dataset aggregate over an empty match is ONE row (the unbound
+        // group), so the result is NOT empty even though the pattern matched nothing.
+        let agg = run("PREFIX ex: <http://ex/> SELECT (COUNT(*) AS ?c) WHERE { ?s ex:nope ?a }");
+        assert_eq!(agg.len(), 1);
+        assert!(!agg.is_empty());
+    }
+
+    /// [OPUS-4.8] (sq-bif) The `FunctionRegistry` introspection accessors
+    /// (`new`/`is_empty`/`len`/`get`/`iris`) that the Service-Description path
+    /// advertises from, plus the documented "register REPLACES a duplicate IRI"
+    /// behaviour — none of which had a direct assertion.
+    #[test]
+    fn function_registry_accessors_and_replace() {
+        let mut reg = FunctionRegistry::new();
+        assert!(reg.is_empty());
+        assert_eq!(reg.len(), 0);
+        assert!(reg.get("http://ex/fn#id").is_none());
+        assert_eq!(reg.iris().count(), 0);
+
+        reg.register("http://ex/fn#a", |args: &[Term]| Ok(args[0].clone()));
+        reg.register("http://ex/fn#b", |args: &[Term]| Ok(args[0].clone()));
+        assert!(!reg.is_empty());
+        assert_eq!(reg.len(), 2);
+        assert!(reg.get("http://ex/fn#a").is_some());
+        let mut iris: Vec<&str> = reg.iris().collect();
+        iris.sort_unstable();
+        assert_eq!(iris, ["http://ex/fn#a", "http://ex/fn#b"]);
+
+        // Re-registering the SAME IRI replaces the closure (and never grows len).
+        let replaced = Term::NamedNode(oxrdf::NamedNode::new("http://ex/replaced").unwrap());
+        let r2 = replaced.clone();
+        reg.register("http://ex/fn#a", move |_: &[Term]| Ok(r2.clone()));
+        assert_eq!(reg.len(), 2, "duplicate IRI must replace, not add");
+        let q = "SELECT ?r WHERE { BIND(<http://ex/fn#a>(<http://ex/x>) AS ?r) }";
+        let r = query_with_functions(&g(), q, &reg).unwrap();
+        assert_eq!(
+            r.rows[0][0].as_ref().unwrap(),
+            &replaced,
+            "the replacement closure, not the original, must run"
+        );
+    }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — correctness-test coverage for `sparq-engine` (advances the P1 umbrella bead **sq-bif**). Tests-only; no library/API change.

## What this adds

Meaningful, regression-catching tests on `sparq-engine`'s **DEFAULT (non-feature-gated)** public surface, added to the EXISTING `lib.rs` / `json.rs` test modules. **No new cargo feature or cfg-gate** — so no feature-matrix fragment is needed. I read the crate first; its existing coverage is genuinely strong (exec.rs scalar-builtin matrix, temporal-cache differentials, dataset/construct/explain), so these target the few real gaps where a regression would currently slip through:

- **`json::term_to_json` (the materialised SPARQL-results-JSON writer)** through the public `to_sparql_json_rows`: the `bnode` / plain / typed (`xsd:string` elided) / language-tagged / **RDF-1.2 directional** (`its:dir` kept apart from `xml:lang`, never folded to `lang--dir`) / **RDF-1.2 quoted-triple** (`{"type":"triple",...}`, recursive through each component) binding objects. Before this, only the `uri` shape had a public assertion — the directional-literal and triple-term branches were unasserted.
- **`count` / `count_prepared`**: agreement with the materialised `query().len()` across DISTINCT / LIMIT / ORDER-BY-LIMIT / empty / join shapes (the id-level count fast path vs the row-materialising path); ASK → 0/1; and the explicit `"only SELECT and ASK"` rejection of CONSTRUCT/DESCRIBE — the previously-untested `_ => Err(...)` arms (also covered for `query_json`).
- **`query_json` ASK** boolean document (`{"head":{},"boolean":...}`).
- **`PreparedQuery`** `parse` / `FromStr` / `From<Query>` / `into_query` round-trip evaluate identically (the sparq-rsp / rewrite seam); a malformed query is a parse error, not a panic.
- **`QueryResult::len` / `is_empty`**, including the one-unbound-row no-match aggregate (the classic off-by-one trap — NOT empty).
- **`FunctionRegistry`** introspection accessors (`new`/`is_empty`/`len`/`get`/`iris`) + the documented register-REPLACES-duplicate-IRI behaviour.

All tests assert SPECIFIC correct behaviour (exact JSON strings, exact counts) and exercise the real code path — not "does not panic".

## Gates (run in-worktree, both feature states)

- `cargo test -p sparq-engine` — green (default).
- `cargo test -p sparq-engine --all-features` — green (448 lib + all integration targets; 0 failed).
- `cargo clippy -p sparq-engine --all-targets -- -D warnings` — clean, default **and** `--all-features`.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-engine --no-deps --all-features` — clean.
- New code is rustfmt-clean; no reformat of untouched lines (the workspace's deferred reformat is left alone).

Coverage rises (11 new tests). **sq-bif is NOT closed** — it is an umbrella; this is one slice.

Auto-merge intentionally **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)