### PR TITLE
test(sparq-fedplan): correctness coverage (sq-bif)

### DIFF
--- a/crates/sparq-fedplan/src/plan.rs
+++ b/crates/sparq-fedplan/src/plan.rs
@@ -928,4 +928,42 @@ mod tests {
             "the disconnected (Cartesian) arm is deferred to last"
         );
     }
+
+    // ---- [OPUS-4.8] sq-bif: a DISCONNECTED candidate evaluated AFTER a connected best has
+    //      already been chosen in the same selection round must NOT displace it — the
+    //      `(connected=false, best_conn=true) => false` arm of the next-arm comparison. This is
+    //      the symmetric guard to `connected_arm_preferred_over_smaller_disconnected`: there the
+    //      connected arm wins by *appearing*; here we make the connected candidate the LOWER index
+    //      (so it is `best` first) and the disconnected candidate the higher index AND strictly
+    //      smaller, so only the `false`-arm can keep the Cartesian arm out — a regression that
+    //      let a smaller disconnected leaf overtake a connected best would reorder this plan.
+    #[test]
+    fn smaller_disconnected_later_candidate_never_overtakes_connected_best() {
+        // Seed ?s :p ?o (idx 0). Remaining iterate in index order: idx 1 = connected :q
+        // (shares ?o), idx 2 = disconnected :iso (smaller leaf, no shared var).
+        let bgp = Bgp::new(vec![
+            TriplePattern::new(var("s"), iri("http://ex/p"), var("o")),
+            TriplePattern::new(var("o"), iri("http://ex/q"), var("z")), // connected (lower idx).
+            TriplePattern::new(var("a"), iri("http://ex/iso"), var("b")), // disconnected, smaller.
+        ]);
+        let src = SourceDescriptor::builder(SourceId::new("S"))
+            .total_triples(100_000)
+            .predicate(pred("http://ex/p", 1, 1, 1)) // global-min ⇒ seed.
+            .predicate(pred("http://ex/q", 800, 800, 800)) // connected, LARGE.
+            .predicate(pred("http://ex/iso", 2, 2, 2)) // disconnected, TINY (< :q).
+            .build();
+        let srcs = [src];
+        let sel = select_sources(&bgp, &srcs);
+        let order = plan_bgp(&bgp, &sel, &srcs, &PlanOptions::default())
+            .unwrap()
+            .join_order();
+        // :q (connected, idx 1) is picked as the second arm despite the disconnected :iso (idx 2)
+        // being far smaller — the disconnected candidate's `false` arm refuses to overtake.
+        assert_eq!(order[0], 0, ":p seeds (global-min leaf)");
+        assert_eq!(
+            order[1], 1,
+            "the connected :q stays the chosen next arm; the smaller disconnected :iso cannot overtake it"
+        );
+        assert_eq!(order[2], 2, "the Cartesian :iso is deferred to last");
+    }
 }

--- a/crates/sparq-fedplan/src/stream.rs
+++ b/crates/sparq-fedplan/src/stream.rs
@@ -724,4 +724,157 @@ mod tests {
         );
         assert!(multiset_eq(&got, &oracle));
     }
+
+    // ============================================================================
+    // [OPUS-4.8] sq-bif — correctness suite: the public `Tuple` value type's documented
+    // invariants (canonical variable-sorted bindings, duplicate-variable-keeps-first,
+    // `get` lookup incl. the missing-var `None`), the `encode`/`decode` spill round-trip
+    // (incl. the previously-uncovered empty-tuple line), and the load-bearing arrival-order
+    // independence of `merge_ordered`. These drive the REAL operator code and each asserts a
+    // specific documented behaviour a regression would break — not a "does not panic".
+    // ============================================================================
+
+    // ---- `Tuple::bindings` is in canonical *variable-sorted* order regardless of the input
+    //      order. This is load-bearing: equal tuples must be byte-identical so spill/compare
+    //      and the `PartialEq` used by the multiset oracle agree. Two tuples built from the
+    //      same pairs in different orders MUST be equal.
+    #[test]
+    fn tuple_bindings_are_canonical_and_order_independent() {
+        // Built object-first then subject-first — the canonical form sorts by variable name.
+        let a = Tuple::new([
+            (Var::new("z"), "26".to_string()),
+            (Var::new("a"), "1".to_string()),
+            (Var::new("m"), "13".to_string()),
+        ]);
+        // Bindings come back ascending by variable name (a, m, z), values carried along.
+        assert_eq!(
+            a.bindings(),
+            &[
+                (Var::new("a"), "1".to_string()),
+                (Var::new("m"), "13".to_string()),
+                (Var::new("z"), "26".to_string()),
+            ]
+        );
+        // A different *insertion* order yields an EQUAL tuple (canonicalisation is total).
+        let b = Tuple::new([
+            (Var::new("m"), "13".to_string()),
+            (Var::new("z"), "26".to_string()),
+            (Var::new("a"), "1".to_string()),
+        ]);
+        assert_eq!(
+            a, b,
+            "tuple equality is insertion-order-independent (canonical)"
+        );
+        // …and they encode to byte-identical lines (the property the spill path relies on).
+        assert_eq!(a.encode(), b.encode());
+    }
+
+    // ---- `Tuple::new` keeps the FIRST value on a duplicate variable (documented). A regression
+    //      to last-wins would silently change join results, so assert the exact retained value.
+    #[test]
+    fn tuple_new_duplicate_variable_keeps_first_value() {
+        let dup = Tuple::new([
+            (Var::new("s"), "first".to_string()),
+            (Var::new("s"), "second".to_string()), // dropped — first wins.
+            (Var::new("o"), "x".to_string()),
+        ]);
+        assert_eq!(dup.get(&Var::new("s")), Some("first"));
+        // Exactly one binding survives for the duplicated variable (plus the unique `o`).
+        assert_eq!(dup.bindings().len(), 2);
+    }
+
+    // ---- `Tuple::get` returns the bound value for a present variable and `None` for an absent
+    //      one (the key/merge logic depends on this distinction).
+    #[test]
+    fn tuple_get_present_and_absent() {
+        let tup = t(&[("s", "alice"), ("o", "bob")]);
+        assert_eq!(tup.get(&Var::new("s")), Some("alice"));
+        assert_eq!(tup.get(&Var::new("o")), Some("bob"));
+        assert_eq!(
+            tup.get(&Var::new("missing")),
+            None,
+            "an unbound variable looks up to None"
+        );
+    }
+
+    // ---- `encode` → `decode` is a round-trip for a non-trivial multi-binding tuple (the spill
+    //      backing store serialises with `encode` and rehydrates with `decode`, so a regression
+    //      here would corrupt spilled partitions and break the spill correctness invariant).
+    #[test]
+    fn tuple_encode_decode_round_trip() {
+        let original = t(&[("s", "http://ex/a"), ("p", "1"), ("o", "literal value")]);
+        let line = original.encode();
+        let back = Tuple::decode(&line);
+        assert_eq!(back, original, "encode∘decode is the identity on a tuple");
+        // The decoded tuple is itself canonical (decode re-canonicalises defensively).
+        assert_eq!(back.bindings(), original.bindings());
+    }
+
+    // ---- `decode("")` yields the EMPTY tuple (previously-uncovered empty-line branch). An empty
+    //      tuple — zero bindings — is what a key-less / projected-away row encodes to, and it must
+    //      round-trip through the spill store rather than mis-parsing into a phantom binding.
+    #[test]
+    fn tuple_decode_empty_line_is_empty_tuple() {
+        let empty = Tuple::new(std::iter::empty::<(Var, String)>());
+        assert!(empty.bindings().is_empty());
+        assert_eq!(
+            empty.encode(),
+            "",
+            "an empty tuple encodes to the empty string"
+        );
+        let decoded = Tuple::decode("");
+        assert!(
+            decoded.bindings().is_empty(),
+            "decoding the empty line yields a binding-less tuple, not a phantom one"
+        );
+        assert_eq!(decoded, empty);
+    }
+
+    // ---- Arrival-order independence (the documented `merge_ordered` invariant): the SAME pair
+    //      of matching tuples must produce the SAME merged binding set whether the left or the
+    //      right arrives first. The discriminating case is a NON-join variable bound by BOTH sides
+    //      to DIFFERENT values: `merge` keeps the LEFT side's value on a conflict, so the canonical
+    //      `merge_ordered` must pick the left value regardless of which side arrived last. A
+    //      regression that merged in arrival order would still pass the multiset COUNT tests but
+    //      flip this shared variable's value when the right arrives last — this pins it.
+    #[test]
+    fn merge_result_is_independent_of_arrival_order() {
+        // Join on `s`; both sides ALSO bind `c` (a non-join var) to different values. The
+        // canonical merge keeps the LEFT side's `c = leftc`.
+        let l = t(&[("s", "k"), ("c", "leftc"), ("o", "leftval")]);
+        let r = t(&[("s", "k"), ("c", "rightc"), ("n", "rightval")]);
+
+        // Schedule 1: left arrives first, then right completes the match.
+        let mut j1 = StreamJoin::new(jv(&["s"]), StreamJoinOptions::default());
+        assert!(j1.push_left(l.clone()).is_empty());
+        let out_lr = j1.push_right(r.clone());
+
+        // Schedule 2: right arrives first, then left completes the match.
+        let mut j2 = StreamJoin::new(jv(&["s"]), StreamJoinOptions::default());
+        assert!(j2.push_right(r.clone()).is_empty());
+        let out_rl = j2.push_left(l.clone());
+
+        assert_eq!(out_lr.len(), 1);
+        assert_eq!(out_rl.len(), 1);
+        // The single merged row is byte-identical across the two arrival orders.
+        let merged = &out_lr[0];
+        assert_eq!(
+            merged, &out_rl[0],
+            "merge result is independent of which side arrives last"
+        );
+        assert_eq!(merged.get(&Var::new("s")), Some("k"));
+        assert_eq!(merged.get(&Var::new("o")), Some("leftval"));
+        assert_eq!(merged.get(&Var::new("n")), Some("rightval"));
+        // The discriminating assertion: the LEFT side's value of the conflicting non-join var
+        // wins in BOTH arrival orders (an arrival-order merge would yield `rightc` for j2).
+        assert_eq!(
+            merged.get(&Var::new("c")),
+            Some("leftc"),
+            "the left side's value wins a non-join-variable conflict, regardless of arrival order"
+        );
+        // It also equals the blocking oracle's merge of the same pair (left.merge(right)).
+        let oracle = blocking_hash_join(&[l], &[r], &jv(&["s"]));
+        assert_eq!(oracle.len(), 1);
+        assert_eq!(merged, &oracle[0]);
+    }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus 4.8). Advances the P1 correctness-coverage umbrella **sq-bif** for the opt-in `sparq-fedplan` planning crate. Umbrella left OPEN.

## What this adds

`sparq-fedplan` was already strongly covered (98.3% region via the prior sq-bif.3 suite), so rather than pad coverage this targets the **genuine remaining gaps** with 7 tests, each pinning a specific documented behaviour and each **mutation-validated** (confirmed to FAIL under a targeted source mutation, so none is a tautology or a "does not panic").

**`stream.rs` — the public `Tuple` value type's documented invariants** (previously exercised only indirectly):
- canonical variable-sorted `bindings()` + insertion-order-independent equality/`encode` — load-bearing so equal tuples are byte-identical for spill compare;
- `Tuple::new` keeps the **first** value on a duplicate variable (a regression to last-wins would silently change join results — asserts the exact retained value);
- `get` present/absent (the `None`-on-missing distinction the key/merge logic relies on);
- `encode`∘`decode` round-trip, including the **previously-uncovered empty-line → empty-tuple** branch (an empty/projected-away row must round-trip through the spill store, not mis-parse into a phantom binding);
- **`merge_ordered` arrival-order independence** — a non-join variable bound by *both* sides resolves to the **left** value regardless of which side arrives last. This is the discriminating case the existing count-based multiset tests miss (they pass even if merge corrupts a shared variable's provenance).

**`plan.rs` — the symmetric next-arm guard**: a smaller **disconnected** candidate evaluated *after* a connected best has been chosen in the same round must not overtake it (the `(connected=false, best_conn=true) => false` arm; the prior test only covered the case where the connected arm *appears* and wins).

## Coverage (strictly improved, no regression)

| file | line cov before → after |
|---|---|
| stream.rs | 98.00% → **98.86%** |
| plan.rs | 98.33% → **98.40%** |
| crate total | 98.01% → **98.16%** line (98.30% → 98.39% region) |

## Constraints honoured
- **No new cargo feature / cfg-gate** — tests live in the existing `tests` modules of the `#[cfg(feature = "fedplan")]` modules, whose CI feature legs already run them. No feature-matrix fragment needed.
- Test-only change; the default (feature OFF) surface is an empty gated crate and is untouched.

## Gates (green in BOTH feature states)
- `cargo build` / `cargo test -p sparq-fedplan` — default OFF (empty crate) **and** `--all-features` (**103** tests pass).
- `cargo clippy -p sparq-fedplan --all-targets -- -D warnings` — clean, default **and** `--all-features`.
- `cargo doc --workspace --no-deps --all-features` with `RUSTDOCFLAGS="-D warnings"` — clean.
- `rustfmt`: `stream.rs` reformatted clean (it was fmt-clean at origin, so the diff is additions-only); `plan.rs` additions match the surrounding committed style (the file already carries the workspace's intentionally-deferred reformat — not reflowed here).

Auto-merge intentionally **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)