### PR TITLE
test(sparq-core): correctness coverage (sq-bif)

### DIFF
--- a/crates/sparq-core/src/compress.rs
+++ b/crates/sparq-core/src/compress.rs
@@ -604,6 +604,57 @@ mod tests {
         }
     }
 
+    /// [OPUS-4.8] sq-bif — `count_range` is the planner's cheap cardinality estimate and must
+    /// return EXACTLY `range(lo, hi).len()` without materialising the range. It only decodes
+    /// the two boundary blocks and adds `BLOCK` for each full interior block
+    /// (`first_count + (last - first - 1) * BLOCK + last_count`), so an off-by-one in that
+    /// arithmetic — or a wrong interior-block count — yields a count that disagrees with the
+    /// materialised range. This was previously only reached transitively through the planner;
+    /// here we pin the invariant directly, across single-block, two-block and many-interior-
+    /// block ranges, the empty / inverted range, and the exact boundary keys.
+    #[test]
+    fn count_range_equals_materialised_range_len() {
+        let rows = sample(5000);
+        let c = CompressedPerm::encode(&rows);
+        assert!(rows.len() > 3 * BLOCK, "need several blocks to exercise the interior arithmetic");
+
+        // Reference count: the length of the materialised range (itself proven correct above).
+        let want = |lo: [Id; 3], hi: [Id; 3]| -> usize { c.range(lo, hi).len() };
+
+        let cases: &[([Id; 3], [Id; 3])] = &[
+            // Whole permutation: spans every block (first + many interior + last).
+            ([Id::MIN; 3], [Id::MAX; 3]),
+            // A bound-subject prefix and a bound subject+predicate prefix.
+            ([100, Id::MIN, Id::MIN], [100, Id::MAX, Id::MAX]),
+            ([200, 5, Id::MIN], [200, 5, Id::MAX]),
+            // A subject that does not exist → empty count.
+            ([99999999, Id::MIN, Id::MIN], [99999999, Id::MAX, Id::MAX]),
+            // Exact single-row ranges at the start, middle, and end.
+            (rows[0], rows[0]),
+            (rows[rows.len() / 2], rows[rows.len() / 2]),
+            (rows[rows.len() - 1], rows[rows.len() - 1]),
+            // A wide interior span that crosses many full blocks (lo/hi land partway into
+            // their boundary blocks, so first_count and last_count are both partial).
+            (rows[BLOCK / 3], rows[rows.len() - BLOCK / 3]),
+            // Two adjacent rows that straddle a block boundary.
+            (rows[BLOCK - 1], rows[BLOCK]),
+        ];
+        for &(lo, hi) in cases {
+            assert_eq!(c.count_range(lo, hi), want(lo, hi), "count_range != range().len() for {lo:?}..={hi:?}");
+        }
+
+        // An inverted range (lo > hi) and an empty permutation both count 0.
+        assert_eq!(c.count_range([10, 0, 0], [1, 0, 0]), 0, "inverted range counts 0");
+        let empty = CompressedPerm::encode(&[]);
+        assert_eq!(empty.count_range([Id::MIN; 3], [Id::MAX; 3]), 0, "empty perm counts 0");
+
+        // Every single-row range over the whole permutation counts exactly 1 (each row is
+        // present once), which independently pins the boundary-block partition_point logic.
+        for &r in &rows {
+            assert_eq!(c.count_range(r, r), 1, "each present row counts exactly once: {r:?}");
+        }
+    }
+
     /// [OPUS-4.8] sq-vkz7 — for a NON-EMPTY perm the STREAMING [`CompressedPermWriter`] must
     /// produce a file BYTE-IDENTICAL to the in-RAM `encode(rows).write_to(..)`. Covers block
     /// boundaries (127/128/129), a partial last block, and a large run. The EMPTY case must

--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -3268,4 +3268,47 @@ mod tests {
         assert!(!is_inline(id));
         assert_eq!(d.term(id), iri);
     }
+
+    /// [OPUS-4.8] sq-bif — `inline_id_of_int` is the engine's fast path for resolving a
+    /// COMPUTED integer (BIND / aggregate result) directly to its inline id, with no term or
+    /// lexical built. Previously it had no test. The id it returns MUST be the very id the
+    /// canonical `xsd:integer` literal of that value interns to (so a computed value and a
+    /// parsed literal collide on one id), and the in-range/out-of-range boundary must match
+    /// `is_inline`. Values below 0 or above `INLINE_MAX` fall back to the dictionary (`None`).
+    #[test]
+    fn inline_id_of_int_matches_intern_and_respects_boundaries() {
+        let mut d = Dict::new();
+        // In-range values: the fast-path id equals interning the canonical integer literal,
+        // and decodes back to that value via the inline partition.
+        for v in [0i64, 1, 2, 42, 1_000_000, INLINE_MAX as i64 - 1, INLINE_MAX as i64] {
+            let id = inline_id_of_int(v).unwrap_or_else(|| panic!("{v} is in range"));
+            assert!(is_inline(id), "{v} maps to an inline id");
+            assert_eq!(id, INLINE_BASE + v as u32, "exact inline encoding for {v}");
+            assert_eq!(id, d.intern(&int(&v.to_string())), "fast-path id == canonical literal's id for {v}");
+        }
+        // Out-of-range: negative and just past INLINE_MAX both fall back to the dictionary.
+        assert_eq!(inline_id_of_int(-1), None, "negative integers are not inline");
+        assert_eq!(inline_id_of_int(i64::MIN), None);
+        assert_eq!(inline_id_of_int(INLINE_MAX as i64 + 1), None, "one past the inline ceiling is not inline");
+        assert_eq!(inline_id_of_int(i64::MAX), None);
+        // The dictionary stayed empty: no inline value was ever stored as a term.
+        assert_eq!(d.len(), 0);
+    }
+
+    /// [OPUS-4.8] sq-bif — `is_inline` must classify the id partition EXACTLY at its
+    /// boundaries: `NO_ID`(0) and every dictionary id are NOT inline; `INLINE_BASE` (value 0)
+    /// up to `INLINE_BASE + INLINE_MAX` (the inline ceiling) ARE; the first id ABOVE the
+    /// inline range (the engine's local-vocab space) is NOT. A drift here would silently
+    /// misread a local-vocab id as an integer value.
+    #[test]
+    fn is_inline_partition_boundaries() {
+        assert!(!is_inline(NO_ID), "0 / NO_ID is not inline");
+        assert!(!is_inline(1), "the first dictionary id is not inline");
+        assert!(!is_inline(INLINE_BASE - 1), "the last dictionary id is not inline");
+        assert!(is_inline(INLINE_BASE), "INLINE_BASE (value 0) is inline");
+        assert!(is_inline(INLINE_BASE + INLINE_MAX), "the inline ceiling is inline");
+        // One past the inline range is the engine's local-vocab space, NOT an inline integer.
+        assert!(!is_inline(INLINE_BASE + INLINE_MAX + 1), "above the inline range is not inline");
+        assert!(!is_inline(u32::MAX), "the very top of the id space is not inline");
+    }
 }

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -8467,6 +8467,104 @@ mod tests {
         assert_eq!(scan.rows.len(), 2);
     }
 
+    /// [OPUS-4.8] sq-bif — `is_integer_datatype` decides whether a datatype's values are
+    /// exact integers (an `xsd:integer` subtype), which gates the exact-lexical disambiguation
+    /// path. It must accept `xsd:integer` and every derived integer subtype, but REJECT the
+    /// other numeric datatypes (`decimal` is exact but not an integer; `double`/`float` ARE
+    /// their f64) and every non-numeric datatype. Previously it had no direct test, so a typo
+    /// dropping a subtype — or accidentally admitting `decimal` — would go unnoticed.
+    #[test]
+    fn is_integer_datatype_accepts_integer_subtypes_only() {
+        // Every integer family member is accepted.
+        for dt in [
+            xsd::INTEGER,
+            xsd::LONG,
+            xsd::INT,
+            xsd::SHORT,
+            xsd::BYTE,
+            xsd::NON_NEGATIVE_INTEGER,
+            xsd::POSITIVE_INTEGER,
+            xsd::NON_POSITIVE_INTEGER,
+            xsd::NEGATIVE_INTEGER,
+            xsd::UNSIGNED_INT,
+            xsd::UNSIGNED_LONG,
+            xsd::UNSIGNED_SHORT,
+            xsd::UNSIGNED_BYTE,
+        ] {
+            assert!(is_integer_datatype(dt.as_str()), "{} must be an integer datatype", dt.as_str());
+        }
+        // Numeric-but-not-integer and non-numeric datatypes are rejected.
+        for dt in [xsd::DECIMAL, xsd::DOUBLE, xsd::FLOAT, xsd::STRING, xsd::BOOLEAN, xsd::DATE_TIME] {
+            assert!(!is_integer_datatype(dt.as_str()), "{} must NOT be an integer datatype", dt.as_str());
+        }
+        assert!(!is_integer_datatype("http://ex/custom"), "an unknown IRI is not an integer datatype");
+        assert!(!is_integer_datatype(""), "the empty datatype is not an integer datatype");
+    }
+
+    /// [OPUS-4.8] sq-bif — `exact_numeric_lexical` is the disambiguator the engine reaches for
+    /// only when two operands' f64 values compare EQUAL: it returns the EXACT lexical of an
+    /// integer-subtype or `xsd:decimal` literal (so `9007199254740993` ≠ `9007199254740992`
+    /// survives the f64 collapse at 2^53) and `None` for everything whose value already IS its
+    /// f64 (float/double) or is non-numeric. It had no test. We pin: the inline-integer path,
+    /// the dictionary integer path (including a value beyond f64's exact range), the decimal
+    /// path, and every `None` case.
+    #[test]
+    fn exact_numeric_lexical_returns_exact_form_or_none() {
+        // A big integer past 2^53 (where f64 cannot represent consecutive integers) and its
+        // neighbour: both are dictionary terms (out of the inline range), and their EXACT
+        // lexicals must survive even though their f64s are equal.
+        let big = "9007199254740993"; // 2^53 + 1
+        let big_neighbour = "9007199254740992"; // 2^53 — same f64 as `big`
+        let nt = format!(
+            "<http://ex/s> <http://ex/i> \"42\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n\
+             <http://ex/s> <http://ex/big> \"{big}\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n\
+             <http://ex/s> <http://ex/big2> \"{big_neighbour}\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n\
+             <http://ex/s> <http://ex/long> \"-5\"^^<http://www.w3.org/2001/XMLSchema#long> .\n\
+             <http://ex/s> <http://ex/dec> \"1.50\"^^<http://www.w3.org/2001/XMLSchema#decimal> .\n\
+             <http://ex/s> <http://ex/dbl> \"1.5\"^^<http://www.w3.org/2001/XMLSchema#double> .\n\
+             <http://ex/s> <http://ex/flt> \"1.5\"^^<http://www.w3.org/2001/XMLSchema#float> .\n\
+             <http://ex/s> <http://ex/str> \"hello\" .\n\
+             <http://ex/s> <http://ex/lang> \"bonjour\"@fr .\n"
+        );
+        let g = Graph::load_str(&nt, "ntriples").unwrap();
+
+        let lexical = |value: &str, dt: oxrdf::NamedNodeRef| -> Option<String> {
+            let lit = Term::Literal(Literal::new_typed_literal(value, dt));
+            g.exact_numeric_lexical(g.id_of(&lit).unwrap_or_else(|| panic!("{value} not interned")))
+        };
+
+        // Inline integer (small, in range): the inline id formats its value directly.
+        let small_id = g.id_of(&Term::Literal(Literal::new_typed_literal("42", xsd::INTEGER))).unwrap();
+        assert!(dict::is_inline(small_id), "42 is an inline integer");
+        assert_eq!(g.exact_numeric_lexical(small_id).as_deref(), Some("42"));
+
+        // Big dictionary integers: the EXACT lexical is preserved, disambiguating the f64 tie.
+        assert_eq!(lexical(big, xsd::INTEGER).as_deref(), Some(big));
+        assert_eq!(lexical(big_neighbour, xsd::INTEGER).as_deref(), Some(big_neighbour));
+        // The two lexicals differ even though they are the same f64 (the whole point).
+        assert_eq!(g.numeric_value(g.id_of(&Term::Literal(Literal::new_typed_literal(big, xsd::INTEGER))).unwrap()),
+                   g.numeric_value(g.id_of(&Term::Literal(Literal::new_typed_literal(big_neighbour, xsd::INTEGER))).unwrap()),
+                   "the two big integers collapse to the same f64");
+        assert_ne!(lexical(big, xsd::INTEGER), lexical(big_neighbour, xsd::INTEGER));
+
+        // An integer SUBTYPE (long) is also exact.
+        assert_eq!(lexical("-5", xsd::LONG).as_deref(), Some("-5"));
+        // `xsd:decimal` is exact (the trailing zero of "1.50" is preserved verbatim).
+        assert_eq!(lexical("1.50", xsd::DECIMAL).as_deref(), Some("1.50"));
+
+        // None: double / float values ARE their f64 (no exact-lexical disambiguation needed).
+        assert_eq!(lexical("1.5", xsd::DOUBLE), None);
+        assert_eq!(lexical("1.5", xsd::FLOAT), None);
+        // None: a plain string and a language-tagged literal are not numeric.
+        assert_eq!(g.exact_numeric_lexical(g.id_of(&Term::Literal(Literal::new_simple_literal("hello"))).unwrap()), None);
+        assert_eq!(
+            g.exact_numeric_lexical(g.id_of(&Term::Literal(Literal::new_language_tagged_literal_unchecked("bonjour", "fr"))).unwrap()),
+            None
+        );
+        // None: an IRI is not numeric.
+        assert_eq!(g.exact_numeric_lexical(g.id_of(&Term::NamedNode(NamedNode::new_unchecked("http://ex/s"))).unwrap()), None);
+    }
+
     /// The full sorted term-triple set of a graph (overlay merged), for state comparison.
     fn dump_terms(g: &Graph) -> Vec<(String, String, String)> {
         let scan = g.store.scan(&[None, None, None]);

--- a/crates/sparq-core/src/temporal.rs
+++ b/crates/sparq-core/src/temporal.rs
@@ -238,4 +238,141 @@ mod tests {
         assert!(Temporal::of_lit("13:00:00", "http://www.w3.org/2001/XMLSchema#time").is_none());
         assert!(Temporal::of_lit("42", "http://www.w3.org/2001/XMLSchema#integer").is_none());
     }
+
+    // [OPUS-4.8] sq-bif — the tests below close real gaps in this module's default surface:
+    // `Timeline::cmp_tl` (the direct timeline-comparison API — previously only `Temporal::cmp_t`
+    // was exercised), `parse_date`'s timezone-OFFSET branch (only the `Z` branch was covered),
+    // the `parse_tz` / `parse_civil_date` parsers' boundary + rejection behaviour, the
+    // dateTime/dateTimeStamp shared family, and `instant()`'s timezone normalisation.
+
+    /// `Timeline::cmp_tl` is the public timeline comparison the engine calls before a cache
+    /// cell exists; it must follow the SAME XPath rules as the cached `Temporal::cmp_t` —
+    /// both-zoned/both-floating compare directly, mixed presence is indeterminate inside the
+    /// ±14h window and decidable outside it. Previously untested.
+    #[test]
+    fn cmp_tl_matches_xpath_and_temporal_cmp() {
+        let p = |s: &str| Timeline::parse_datetime(s).unwrap();
+        // Equal instants across timezones compare Equal.
+        assert_eq!(
+            Timeline::cmp_tl(p("2024-03-15T13:00:00Z"), p("2024-03-15T14:00:00+01:00")),
+            Some(Equal),
+        );
+        // Both floating (no tz): a direct compare.
+        assert_eq!(Timeline::cmp_tl(p("2024-03-15T12:00:00"), p("2024-03-15T13:00:00")), Some(Less));
+        // Mixed presence inside the ±14h window: indeterminate (a SPARQL type error).
+        assert_eq!(Timeline::cmp_tl(p("2024-03-15T13:00:00Z"), p("2024-03-15T13:00:00")), None);
+        // Mixed presence OUTSIDE the window: decidable.
+        assert_eq!(Timeline::cmp_tl(p("2024-03-15T13:00:00Z"), p("2024-03-17T13:00:00")), Some(Less));
+
+        // And `cmp_tl` agrees with the cached `Temporal::cmp_t` on the same lexicals.
+        for (a, b) in [
+            ("2024-03-15T13:00:00Z", "2024-03-15T14:00:00+01:00"),
+            ("2024-03-15T13:00:00Z", "2024-03-15T13:00:00"),
+            ("2024-03-15T13:00:00Z", "2024-03-17T13:00:00"),
+            ("2024-03-15T12:00:00", "2024-03-15T13:00:00"),
+        ] {
+            assert_eq!(Timeline::cmp_tl(p(a), p(b)), Temporal::cmp_t(dt(a), dt(b)), "cmp_tl/cmp_t disagree on {a} vs {b}");
+        }
+    }
+
+    /// `parse_date` must accept a timezone OFFSET suffix (`+hh:mm` / `-hh:mm`), not only `Z`,
+    /// and must NOT mistake a bare date's own hyphens for an offset sign. The offset branch
+    /// (the `len > 10 && sign && ':'` path) was previously uncovered.
+    #[test]
+    fn parse_date_handles_timezone_offset_and_bare_date() {
+        // Bare date: no timezone, midnight UTC, day 0 == 1970-01-01.
+        let epoch = Timeline::parse_date("1970-01-01").unwrap();
+        assert_eq!(epoch.secs, 0);
+        assert!(epoch.tz.is_none());
+
+        // `Z` suffix: tz present and 0.
+        let z = Timeline::parse_date("2024-03-15Z").unwrap();
+        assert_eq!(z.tz, Some(0));
+
+        // Positive and negative OFFSET suffixes are parsed (the previously-untested branch).
+        let plus = Timeline::parse_date("2024-03-15+05:00").unwrap();
+        assert_eq!(plus.tz, Some(5 * 3600));
+        let minus = Timeline::parse_date("2024-03-15-09:30").unwrap();
+        assert_eq!(minus.tz, Some(-(9 * 3600 + 30 * 60)));
+        // The civil date is the same regardless of the offset suffix.
+        assert_eq!(plus.secs, minus.secs);
+        assert_eq!(plus.secs, Timeline::parse_date("2024-03-15").unwrap().secs);
+
+        // A NEGATIVE-YEAR bare date must not be read as having a trailing offset (its leading
+        // `-` is the year sign, and there is no `:` six chars from the end).
+        let bce = Timeline::parse_date("-0044-03-15").unwrap();
+        assert!(bce.tz.is_none(), "a BCE year sign must not be parsed as a timezone offset");
+        assert!(bce.secs < 0, "44 BCE is before the epoch");
+    }
+
+    /// `parse_tz` directly: `Z` is +0, signed `±hh:mm` offsets resolve to seconds, and a
+    /// malformed offset is rejected.
+    #[test]
+    fn parse_tz_parses_offsets_and_rejects_malformed() {
+        assert_eq!(parse_tz("Z"), Some(0));
+        assert_eq!(parse_tz("+00:00"), Some(0));
+        assert_eq!(parse_tz("+05:30"), Some(5 * 3600 + 30 * 60));
+        assert_eq!(parse_tz("-08:00"), Some(-8 * 3600));
+        // Missing the `:hh` minute field is malformed.
+        assert_eq!(parse_tz("+05"), None);
+        assert_eq!(parse_tz("garbage"), None);
+    }
+
+    /// `parse_civil_date` (Howard Hinnant's days_from_civil): the epoch is day 0, ordering is
+    /// monotonic, negative (BCE) years parse, and out-of-range month/day or extra components
+    /// are rejected.
+    #[test]
+    fn parse_civil_date_epoch_ordering_and_validation() {
+        assert_eq!(parse_civil_date("1970-01-01"), Some(0), "epoch is day 0");
+        assert_eq!(parse_civil_date("1970-01-02"), Some(1));
+        assert_eq!(parse_civil_date("1969-12-31"), Some(-1));
+        // A whole non-leap year later is +365 days.
+        assert_eq!(parse_civil_date("1971-01-01"), Some(365));
+        // 2000 is a leap year (divisible by 400): Feb 29 is valid and day-of-year ordered.
+        assert!(parse_civil_date("2000-02-29").is_some());
+        assert!(parse_civil_date("2000-02-29") < parse_civil_date("2000-03-01"));
+        // BCE years parse to large-negative day counts.
+        assert!(parse_civil_date("-0001-12-31").unwrap() < 0);
+
+        // Rejections: month/day out of the 1..=12 / 1..=31 ranges, and an extra component.
+        assert!(parse_civil_date("2024-13-01").is_none(), "month 13 rejected");
+        assert!(parse_civil_date("2024-00-01").is_none(), "month 0 rejected");
+        assert!(parse_civil_date("2024-01-32").is_none(), "day 32 rejected");
+        assert!(parse_civil_date("2024-01-00").is_none(), "day 0 rejected");
+        assert!(parse_civil_date("2024-01-01-01").is_none(), "extra component rejected");
+        assert!(parse_civil_date("notanumber").is_none());
+    }
+
+    /// `xsd:dateTime` and `xsd:dateTimeStamp` share ONE temporal family (they compare on the
+    /// timeline together), while `xsd:date` is disjoint. Only the dateTime path was exercised
+    /// before; this pins dateTimeStamp's family membership and cross-family indeterminacy.
+    #[test]
+    fn datetime_and_datetimestamp_share_a_family_date_is_disjoint() {
+        let stamp = Temporal::of_lit("2024-03-15T13:00:00Z", XSD_DATE_TIME_STAMP).unwrap();
+        assert_eq!(stamp.kind, TemporalKind::DateTime, "dateTimeStamp caches as the DateTime family");
+        let dttime = dt("2024-03-15T13:00:00Z");
+        // Same instant, both in the DateTime family: comparable and Equal.
+        assert_eq!(Temporal::cmp_t(stamp, dttime), Some(Equal));
+        // A date is a disjoint family: comparing across families is a type error (None).
+        let date = Temporal::of_lit("2024-03-15", XSD_DATE).unwrap();
+        assert_eq!(date.kind, TemporalKind::Date);
+        assert_eq!(Temporal::cmp_t(stamp, date), None);
+    }
+
+    /// `Timeline::instant()` normalises a zoned time to UTC (subtracting the offset) and treats
+    /// an absent timezone as UTC, so two lexicals naming the same absolute instant share one
+    /// `instant`, and the fractional second is carried.
+    #[test]
+    fn instant_normalises_timezone_to_utc() {
+        let utc = Timeline::parse_datetime("2024-03-15T13:00:00Z").unwrap();
+        let off = Timeline::parse_datetime("2024-03-15T14:00:00+01:00").unwrap();
+        // Same absolute instant despite different wall clock + offset.
+        assert_eq!(utc.instant().to_bits(), off.instant().to_bits());
+        // A floating (no-tz) time is treated as UTC, so it equals the same wall time zoned `Z`.
+        let floating = Timeline::parse_datetime("2024-03-15T13:00:00").unwrap();
+        assert_eq!(floating.instant(), utc.instant());
+        // The fractional second survives into the instant.
+        let frac = Timeline::parse_datetime("2024-03-15T13:00:00.25Z").unwrap();
+        assert_eq!(frac.instant() - utc.instant(), 0.25);
+    }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — automated correctness-test coverage for `sparq-core` (advances umbrella bead **sq-bif**).

## What

Adds 11 meaningful correctness tests for previously-untested **public functions** on `sparq-core`'s **default surface**. Each asserts SPECIFIC correct behaviour against an independent reference — none is a "does not panic" tautology or a coverage pad.

| Function | Module | Gap closed |
|---|---|---|
| `CompressedPerm::count_range` | `compress.rs` | Public planner cardinality estimate, only reached transitively. Pinned `== range(lo,hi).len()` across single/two/many-interior-block ranges, empty/inverted range, exact boundary keys — catches an off-by-one in `first_count + (last-first-1)*BLOCK + last_count`. |
| `dict::inline_id_of_int` | `dict.rs` | Public computed-integer fast path, no test + no in-crate caller. Pinned `== ` interning the canonical `xsd:integer` literal, plus the negative / `INLINE_MAX` / `INLINE_MAX+1` boundaries. |
| `dict::is_inline` | `dict.rs` | Exact id-partition boundaries (`NO_ID`, last dict id, `INLINE_BASE`, the inline ceiling, the first local-vocab id, `u32::MAX`). |
| `Timeline::cmp_tl` | `temporal.rs` | The direct timeline comparison (only the cached `Temporal::cmp_t` was tested). |
| `parse_date` offset branch, `parse_tz`, `parse_civil_date` | `temporal.rs` | `parse_date`'s `±hh:mm` timezone branch (only `Z` was covered, incl. the BCE-year-sign-is-not-an-offset case), `parse_tz` offsets/rejection, `parse_civil_date` epoch/ordering/leap-year/out-of-range validation, the dateTime/dateTimeStamp shared family vs disjoint date, `instant()` tz→UTC normalisation. |
| `is_integer_datatype` | `lib.rs` | Accept every integer subtype; reject decimal/double/float + non-numeric. |
| `Graph::exact_numeric_lexical` | `lib.rs` | The equal-f64 disambiguator: exact lexical for inline + dictionary integers (incl. a `2^53+1` value that **ties on f64** but must stay distinct) and `xsd:decimal`; `None` for double/float/string/lang/IRI. |

## Constraints honoured

- Tests added to **existing test targets / the default surface only** — **no new cargo feature or cfg-gate**, so no feature-matrix fragment is needed. No production code touched (329 insertions, all in `mod tests`).
- Coverage can only increase (test-only additions over previously-untested public items).
- No README change → `readme-template` gate unaffected. No ZK/MPC/privacy claims, no hard-coded perf numbers.

## Gates (both feature states)

- `cargo test -p sparq-core` — green (default: 92 lib tests; `--all-features`: 175 lib tests + all integration suites).
- `cargo clippy -p sparq-core --all-targets -- -D warnings` and `--all-features` — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-core --no-deps --all-features` — clean.
- `rustfmt`: new code matches the surrounding committed wide-line style (the workspace's intentionally-deferred reformat; `origin/main` already trips default rustfmt on these files). `cargo fmt` was NOT run over untouched files.

Umbrella **sq-bif** is advanced, **not closed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)