### PR TITLE
test(sparq-fedplan-mpc): correctness coverage (sq-bif)

### DIFF
--- a/crates/sparq-fedplan-mpc/src/combination.rs
+++ b/crates/sparq-fedplan-mpc/src/combination.rs
@@ -718,6 +718,87 @@ mod tests {
         assert_eq!(a, b);
     }
 
+    /// A longer shared-variable chain (0-1-2-3-4) must still collapse to ONE component with all
+    /// five patterns — the union-find path-compression over a transitive chain produces a single
+    /// connected component, exercising the multi-level `find` walk. A regression in the component
+    /// merge (e.g. losing transitivity) would split the chain. [OPUS-4.8] sq-bif.
+    #[test]
+    fn long_shared_variable_chain_is_one_component() {
+        // ?a p ?b . ?b p ?c . ?c p ?d . ?d p ?e . ?e p ?f  — a five-pattern chain, each joining
+        // the next on the shared variable.
+        let bgp = Bgp::new(vec![
+            TriplePattern::new(var("a"), iri(SHARES_HOUSE), var("b")),
+            TriplePattern::new(var("b"), iri(NAME), var("c")),
+            TriplePattern::new(var("c"), iri(OWES), var("d")),
+            TriplePattern::new(var("d"), iri(MEMBER_OF), var("e")),
+            TriplePattern::new(var("e"), iri(SHARES_HOUSE), var("f")),
+        ]);
+        let sources = vec![source("http://a/", &[SHARES_HOUSE, NAME, OWES, MEMBER_OF])];
+        let sel = select_private_sources(&bgp, &sources, &[]).unwrap();
+        let out = prune_source_combinations(&bgp, &sources, &sel).unwrap();
+        assert!(out.bgp_satisfiable);
+        // Exactly one component covering the whole transitive chain, ascending.
+        assert_eq!(out.components.len(), 1);
+        assert_eq!(out.components[0].patterns, vec![0, 1, 2, 3, 4]);
+        assert!(out.components[0].satisfiable);
+    }
+
+    /// `BgpComponent::satisfiable` is per-component: in a disconnected BGP with one empty and one
+    /// non-empty component, the non-empty component reports `satisfiable == true` while the empty
+    /// one reports `false` — even though the WHOLE-BGP verdict is unsatisfiable. This pins the
+    /// distinction between the per-component flag and the global `bgp_satisfiable`. [OPUS-4.8]
+    /// sq-bif.
+    #[test]
+    fn per_component_satisfiability_is_independent_of_the_global_verdict() {
+        // Comp A: 0-1 chained on ?p, both non-empty (satisfiable). Comp B: 2 alone, empty.
+        let bgp = Bgp::new(vec![
+            TriplePattern::new(var("p"), iri(SHARES_HOUSE), var("h")), // 0 comp A
+            TriplePattern::new(var("p"), iri(NAME), var("n")),         // 1 comp A
+            TriplePattern::new(var("z"), iri(ABSENT), var("w")),       // 2 comp B (empty)
+        ]);
+        let sources = vec![source("http://a/", &[SHARES_HOUSE, NAME])];
+        let sel = select_private_sources(&bgp, &sources, &[]).unwrap();
+        let out = prune_source_combinations(&bgp, &sources, &sel).unwrap();
+
+        // Global verdict: unsatisfiable (an empty conjunct kills the whole BGP).
+        assert!(!out.bgp_satisfiable);
+        assert_eq!(out.empty_patterns, vec![2]);
+
+        // But the per-component flag distinguishes the live component from the dead one.
+        assert_eq!(out.components.len(), 2);
+        let comp_a = out
+            .components
+            .iter()
+            .find(|c| c.patterns == vec![0, 1])
+            .expect("the {0,1} component exists");
+        assert!(
+            comp_a.satisfiable,
+            "the non-empty component is itself satisfiable"
+        );
+        let comp_b = out
+            .components
+            .iter()
+            .find(|c| c.patterns == vec![2])
+            .expect("the {2} component exists");
+        assert!(!comp_b.satisfiable, "the empty component is unsatisfiable");
+    }
+
+    /// `CombinationPruneReason::label` names the witnessing pattern explicitly (a regression that
+    /// blanked it or dropped the witness index would lose the audit-trail diagnostic). [OPUS-4.8]
+    /// sq-bif.
+    #[test]
+    fn combination_prune_reason_label_names_the_witness_pattern() {
+        let label = CombinationPruneReason::UnsatisfiableBgp { witness: 7 }.label();
+        assert!(
+            label.contains("unsatisfiable"),
+            "label names the cause: {label}"
+        );
+        assert!(
+            label.contains("pattern 7"),
+            "label names the witness pattern: {label}"
+        );
+    }
+
     /// A selection whose pattern count does not match the BGP is a fail-closed
     /// DescriptorMismatch (phase SourceCombination) — never guess the alignment.
     #[test]

--- a/crates/sparq-fedplan-mpc/src/envelope.rs
+++ b/crates/sparq-fedplan-mpc/src/envelope.rs
@@ -643,6 +643,151 @@ mod tests {
         assert!(outcome.is_ratified(), "four-flatmates plan must ratify");
     }
 
+    // ── Empty global-IRI operand: the disclosed-by-convention path (envelope label + C-B skip) ──
+
+    // A single-operator plan that discloses one global IRI binding NO specific predicate, plus the
+    // routing that matches it (so `assemble_leakage_envelope` accepts the pair). Returns
+    // (routing, ops). [OPUS-4.8] sq-bif.
+    fn disclosed_empty_global_iri_plan() -> (PrivateRouting, Vec<QueryOperator>) {
+        let ops = vec![QueryOperator::new(
+            "membership-join (anonymous global IRI)",
+            OperatorClass::EqualityJoin,
+            vec![Operand::GlobalIri {
+                // Empty predicate ⇒ a global IRI binding no specific predicate.
+                predicate: String::new(),
+            }],
+        )];
+        // No contributing privacy descriptor at all ⇒ the default policy discloses the global IRI.
+        let routing = route_operators(
+            &SelectedPrivateSources::default(),
+            &[],
+            &ops,
+            RoutingPolicy::Default,
+        )
+        .unwrap();
+        assert_eq!(routing.routing[0].routing, Routing::Disclosed);
+        (routing, ops)
+    }
+
+    /// An empty-predicate global-IRI operand, when disclosed, is recorded HONESTLY in the envelope
+    /// as the `<global-iri>` placeholder (not silently dropped, not a panic) — the disclosure of
+    /// *a* global IRI is enumerated even though it binds no named predicate. [OPUS-4.8] sq-bif.
+    #[test]
+    fn empty_global_iri_operand_is_recorded_as_the_placeholder() {
+        let (routing, ops) = disclosed_empty_global_iri_plan();
+        let env =
+            assemble_leakage_envelope(&routing, &ops, &SelectedPrivateSources::default()).unwrap();
+        assert_eq!(env.operators.len(), 1);
+        assert!(env.operators[0].disclosed);
+        assert_eq!(env.operators[0].disclosed_operands, vec!["<global-iri>"]);
+        // It counts as one distinct disclosed operand across the plan (a real, declared leak).
+        assert_eq!(
+            env.distinct_disclosed_operands(),
+            vec!["<global-iri>".to_string()]
+        );
+    }
+
+    /// The load-bearing C-B soundness boundary for the placeholder: a `<global-iri>` disclosure is
+    /// disclosed BY CONVENTION (it binds no holder's named predicate), so a holder's fail-closed
+    /// re-check must NOT spuriously reject it — even a deny-all holder ratifies. A regression that
+    /// dropped the `<global-iri>` skip would falsely reject every plan that discloses an anonymous
+    /// global IRI. [OPUS-4.8] sq-bif.
+    #[test]
+    fn placeholder_global_iri_is_not_held_against_a_deny_all_holder() {
+        let (routing, ops) = disclosed_empty_global_iri_plan();
+        let env =
+            assemble_leakage_envelope(&routing, &ops, &SelectedPrivateSources::default()).unwrap();
+        // A maximally-private holder discloses NOTHING — yet it must still ratify the placeholder,
+        // because the placeholder is not over any named predicate it could object to.
+        let deny_all = SourcePrivacyDescriptor::deny_all(SourceId::new("http://a/"));
+        assert_eq!(
+            ratify_envelope(&env, &[deny_all], None),
+            RatificationOutcome::Ratified,
+            "an anonymous global IRI is disclosed by convention; no holder can veto it"
+        );
+    }
+
+    /// The placeholder is skipped by the HOLDER check but still COUNTS against the VERIFIER budget:
+    /// it is a real disclosure (the verifier bounds total operand disclosure), so a budget of 0
+    /// rejects it on the verifier side even though every holder accepted. This pins the precise
+    /// asymmetry — holder-exempt, verifier-counted. [OPUS-4.8] sq-bif.
+    #[test]
+    fn placeholder_global_iri_counts_against_the_verifier_budget() {
+        let (routing, ops) = disclosed_empty_global_iri_plan();
+        let env =
+            assemble_leakage_envelope(&routing, &ops, &SelectedPrivateSources::default()).unwrap();
+        let holders = [SourcePrivacyDescriptor::deny_all(SourceId::new(
+            "http://a/",
+        ))];
+        // Budget 0: one distinct disclosed operand (`<global-iri>`) exceeds it ⇒ verifier rejects.
+        match ratify_envelope(&env, &holders, Some(0)) {
+            RatificationOutcome::VerifierRejected {
+                disclosed, budget, ..
+            } => {
+                assert_eq!(disclosed, 1);
+                assert_eq!(budget, 0);
+            }
+            other => panic!(
+                "expected a verifier rejection on a 0 budget, got {:?}",
+                other
+            ),
+        }
+        // Budget 1: it fits ⇒ ratified.
+        assert_eq!(
+            ratify_envelope(&env, &holders, Some(1)),
+            RatificationOutcome::Ratified
+        );
+    }
+
+    /// Phase-2 prune narrows the Phase-3 disclosure gating: a private holder that is PRUNED (it
+    /// declared non-participation) no longer gates a predicate's disclosability, so a predicate the
+    /// *remaining* sources all mark public becomes Disclosed — and the assembled envelope honestly
+    /// records that disclosure. This is the cross-phase interaction (selection → routing →
+    /// envelope) over the REAL path. [OPUS-4.8] sq-bif.
+    #[test]
+    fn pruned_private_holder_does_not_gate_disclosure_downstream() {
+        // Source A marks memberOf public and participates; source B marks it PRIVATE but declares
+        // non-participation, so Phase 2 prunes B. With only A contributing, memberOf is disclosable.
+        let a_pub = SourcePrivacyDescriptor::builder(SourceId::new("http://a/"))
+            .public_predicate(MEMBER_OF)
+            .participates(true)
+            .build();
+        let b_private_refuses = SourcePrivacyDescriptor::builder(SourceId::new("http://b/"))
+            .private_predicate(MEMBER_OF)
+            .participates(false)
+            .build();
+        let sources = vec![source("http://a/"), source("http://b/")];
+        let privacy = vec![a_pub.clone(), b_private_refuses];
+        let bgp = Bgp::new(vec![TriplePattern::new(
+            Term::Var(Var::new("h")),
+            Term::Iri(MEMBER_OF.to_string()),
+            Term::Iri(FLAT_IRI.to_string()),
+        )]);
+        let selected = select_private_sources(&bgp, &sources, &privacy).unwrap();
+        // B was pruned (non-participating) ⇒ only A participates.
+        assert_eq!(
+            selected.participating_sources(),
+            vec![&SourceId::new("http://a/")]
+        );
+
+        let ops = vec![QueryOperator::new(
+            "membership-join",
+            OperatorClass::EqualityJoin,
+            vec![Operand::Predicate(MEMBER_OF.to_string())],
+        )];
+        // Routed over the REAL selection: only A gates memberOf, and A marks it public ⇒ Disclosed.
+        let routing = route_operators(&selected, &privacy, &ops, RoutingPolicy::Default).unwrap();
+        assert_eq!(routing.routing[0].routing, Routing::Disclosed);
+
+        let env = assemble_leakage_envelope(&routing, &ops, &selected).unwrap();
+        assert_eq!(env.operators[0].disclosed_operands, vec![MEMBER_OF]);
+        // Only A is declared participating, and only A ratifies (B is no longer a holder of record).
+        assert_eq!(
+            ratify_envelope(&env, &[a_pub], Some(4)),
+            RatificationOutcome::Ratified
+        );
+    }
+
     /// Determinism: same plan ⇒ identical envelope + identical outcome, twice.
     #[test]
     fn determinism_same_plan_same_envelope_and_outcome() {

--- a/crates/sparq-fedplan-mpc/src/selection.rs
+++ b/crates/sparq-fedplan-mpc/src/selection.rs
@@ -511,4 +511,119 @@ mod tests {
         let b = select_private_sources(&bgp, &sources, &privacy).unwrap();
         assert_eq!(a, b);
     }
+
+    // A two-pattern BGP `?s p1 ?o . ?s p2 ?o2` (joins on ?s) so a source can appear in BOTH
+    // patterns and a per-pattern cardinality sum is non-trivial. [OPUS-4.8] sq-bif.
+    fn bgp_two_preds(p1: &str, p2: &str) -> Bgp {
+        Bgp::new(vec![
+            TriplePattern::new(
+                Term::Var(sparq_fedplan::Var::new("s")),
+                Term::Iri(p1.to_string()),
+                Term::Var(sparq_fedplan::Var::new("o")),
+            ),
+            TriplePattern::new(
+                Term::Var(sparq_fedplan::Var::new("s")),
+                Term::Iri(p2.to_string()),
+                Term::Var(sparq_fedplan::Var::new("o2")),
+            ),
+        ])
+    }
+
+    /// `total_cardinality` sums ONLY the surviving candidates, and it excludes a pruned one — a
+    /// regression that summed pruned candidates (or the wrong field) would change the number. The
+    /// surviving sum must equal the upstream per-pattern total minus the pruned source's estimate.
+    /// [OPUS-4.8] sq-bif.
+    #[test]
+    fn total_cardinality_sums_only_surviving_candidates() {
+        let pred = "http://ex/p";
+        let bgp = bgp_pred(pred);
+        let sources = vec![
+            source_with_pred("http://a/", pred),
+            source_with_pred("http://b/", pred),
+        ];
+        // Source B is non-participating ⇒ pruned; only A's estimate should remain in the total.
+        let privacy = vec![SourcePrivacyDescriptor::builder(SourceId::new("http://b/"))
+            .participates(false)
+            .build()];
+
+        let upstream = select_sources(&bgp, &sources);
+        let upstream_total = upstream[0].total_cardinality();
+        // The pruned source's upstream estimate (B is index 1).
+        let pruned_estimate = upstream[0]
+            .candidates
+            .iter()
+            .find(|c| c.source == 1)
+            .map(|c| c.estimated_cardinality)
+            .expect("upstream retained B before the prune");
+
+        let sel = select_private_sources(&bgp, &sources, &privacy).unwrap();
+        let surviving_total = sel.per_pattern[0].total_cardinality();
+
+        // The surviving total is the kept candidate's estimate — A only.
+        assert_eq!(sel.per_pattern[0].candidates.len(), 1);
+        assert_eq!(
+            surviving_total,
+            sel.per_pattern[0].candidates[0].estimated_cardinality
+        );
+        // …and it is strictly the upstream total minus the pruned source's contribution (so a
+        // regression that left B in the sum would be caught).
+        assert_eq!(surviving_total, upstream_total - pruned_estimate);
+        assert!(
+            surviving_total < upstream_total,
+            "pruning a contributing source must lower the per-pattern total"
+        );
+    }
+
+    /// `participating_sources` deduplicates a source that contributes to MULTIPLE patterns — it
+    /// returns each distinct id once, ascending. A regression that concatenated per-pattern ids
+    /// without the dedup would report the source twice.  [OPUS-4.8] sq-bif.
+    #[test]
+    fn participating_sources_dedups_a_source_across_patterns() {
+        let p1 = "http://ex/p1";
+        let p2 = "http://ex/p2";
+        let bgp = bgp_two_preds(p1, p2);
+        // One source holding BOTH predicates ⇒ it is a candidate for pattern 0 AND pattern 1.
+        let sources = vec![SourceDescriptor::builder(SourceId::new("http://a/"))
+            .total_triples(100)
+            .predicate(PredPartition {
+                predicate: p1.to_string(),
+                triples: 100,
+                distinct_subjects: 10,
+                distinct_objects: 10,
+            })
+            .predicate(PredPartition {
+                predicate: p2.to_string(),
+                triples: 100,
+                distinct_subjects: 10,
+                distinct_objects: 10,
+            })
+            .authorities_complete()
+            .build()];
+        let sel = select_private_sources(&bgp, &sources, &[]).unwrap();
+        // The source survives in both patterns…
+        assert_eq!(sel.per_pattern.len(), 2);
+        assert_eq!(sel.per_pattern[0].candidates.len(), 1);
+        assert_eq!(sel.per_pattern[1].candidates.len(), 1);
+        // …but participating_sources reports it exactly ONCE (deduped), not twice.
+        assert_eq!(
+            sel.participating_sources(),
+            vec![&SourceId::new("http://a/")]
+        );
+    }
+
+    /// The audit-trail `PruneReason::label` is the human-readable diagnostic surfaced to a relying
+    /// party. Pin its content (a regression that blanked or reworded it past the load-bearing
+    /// `participates=false` token would be caught). [OPUS-4.8] sq-bif.
+    #[test]
+    fn prune_reason_label_names_the_non_participation_cause() {
+        let label = PruneReason::NonParticipating.label();
+        assert!(
+            label.contains("non-participating"),
+            "label must name the cause: {label}"
+        );
+        assert!(
+            label.contains("participates=false"),
+            "label must name the load-bearing flag: {label}"
+        );
+    }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — automated correctness-coverage pass on `sparq-fedplan-mpc` (advances P1 bead sq-bif). Self-identifying: this PR was opened by an autonomous SPARQ agent (Opus 4.8).

## What this adds

10 mutation-verified correctness tests, added to the **existing** test modules of `sparq-fedplan-mpc` (no new cargo feature / cfg-gate — no new feature-matrix fragment). Each asserts specific behaviour, not "no panic"/tautology. Found by reading the crate + an `llvm-cov` gap analysis, then keeping only the tests that pin a genuine behaviour or soundness invariant.

### `selection.rs` (Phase 2 adapter)
- `total_cardinality` sums **only the surviving** candidates — asserted to equal the upstream per-pattern total minus the pruned source's estimate (and strictly lower). A regression that summed pruned candidates is caught.
- `participating_sources` **deduplicates** a source that contributes to multiple patterns (mutation-verified: removing the dedup fails the test).
- `PruneReason::label` pins the load-bearing `participates=false` diagnostic token.

### `envelope.rs` (Phase 4 leakage-envelope + dual ratification — the MPC soundness boundary)
- An **empty-predicate `GlobalIri`** operand is honestly recorded as the `<global-iri>` placeholder when disclosed (not dropped, not a panic).
- **C-B fail-closed invariant**: a `<global-iri>` placeholder is disclosed *by convention*, so a deny-all holder must **not** spuriously reject it. Mutation-verified — removing the `<global-iri>` skip fails 2 tests.
- The **holder-exempt / verifier-counted asymmetry**: the placeholder is skipped by the holder C-B check yet still counts against the verifier budget (budget 0 rejects, budget 1 ratifies).
- **Cross-phase interaction over the REAL path**: a private holder **pruned** at Phase 2 (non-participating) no longer gates disclosability at Phase 3, so a predicate the remaining sources mark public becomes `Disclosed` and the envelope records it (select → route → assemble → ratify, no mock).

### `combination.rs` (Phase 6 result-aware combination prune)
- A 5-pattern shared-variable chain collapses to **one** connected component.
- Per-component `satisfiable` is **independent** of the global `bgp_satisfiable` verdict (a live component reports `true` while an empty one reports `false`).
- `CombinationPruneReason::label` names the witness pattern.

## Coverage (feature `fedplan-mpc` ON)
- line **98.46% → 99.29%**, region **98.59% → 99.26%**, **missed functions 2 → 0**.
- Remaining uncovered lines are a deliberately-unreachable defensive out-of-range guard, union-find path-halving (internal optimisation), and test-internal `panic!` arms — **not** untested behaviour. No padding to hit them.

## Gates (run in-worktree, BOTH feature states)
Feature flag: **`fedplan-mpc`** (OFF by default).
- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — green with the feature **OFF** (empty crate) **and ON** (64 tests pass; was 54).
- `cargo test -p sparq-fedplan-mpc --all-features` — 64 pass.
- `rustfmt --check` on the 3 changed files — clean (matched committed style; untouched files not reformatted).
- `cargo doc --no-deps --all-features` with `RUSTDOCFLAGS=-D warnings` — clean.
- `typos` — clean.

No public API change (test-only), so the crate `README.md` (already at the 120-line cap) and `skills/mpc/SKILL.md` are unchanged.

## Honesty boundary
This crate performs **no** MPC and makes **no** soundness/privacy claim; the C-B / fail-closed behaviours tested here are **plan-time policy gates**, not cryptographic enforcement. The MPC estate is research-grade, honest-majority semi-honest only, and is **not externally audited** — the accredited-cryptographer sign-off (sq-qhy4) and the coZK re-audit (sq-9hrn) are pending.

Advances **sq-bif** (kept open). Auto-merge intentionally **OFF** — the orchestrator merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)