### PR TITLE
test(sparq-reason-el): correctness coverage (sq-bif)

### DIFF
--- a/crates/sparq-reason-el/tests/differential.rs
+++ b/crates/sparq-reason-el/tests/differential.rs
@@ -17,7 +17,7 @@
 use oxrdf::{NamedNode, Term as OTerm};
 use sparq_core::dict::{Dict, Id};
 use sparq_core::Graph;
-use sparq_reason_el::Classifier;
+use sparq_reason_el::{classify_graph, Classifier};
 
 const PRE: &str = r#"
     @prefix : <http://ex/> .
@@ -170,4 +170,331 @@ fn rl_incompleteness_witness_is_complete_under_el() {
          [ owl:onProperty :r ; owl:someValuesFrom :C ] rdfs:subClassOf :D ."
     );
     assert_closure(&ttl, &["A", "B", "C", "D"], &[("B", "C"), ("A", "D")]);
+}
+
+// ---------------------------------------------------------------------------------------------
+// [OPUS-4.8] sq-bif: correctness-coverage additions. The fixtures above pin the CR1-CR5 closure
+// via the `is_subclass_of` / `unsatisfiable_classes` oracles; the tests below close GENUINE gaps
+// in the *public surface* and the *extractor's fragment recogniser* — paths the existing suite
+// never asserts: the `super_classes` accessor contract, the `Report` field semantics, the RHS /
+// degenerate / non-EL `decode` branches, the 3-way conjunction left-fold, the `classify_graph`
+// `rdfs:subClassOf`-interning path, and the malformed-blank-node guards. Each asserts an EXACT
+// expected value (not "no panic"); flipping the corresponding logic flips a named assertion.
+
+#[test]
+fn super_classes_accessor_excludes_self_thing_nothing_and_is_sorted() {
+    // super_classes(A) for A ⊑ B ⊑ C must be EXACTLY {B, C} (the full transitive closure), sorted
+    // by dict id, and must NOT contain A itself, owl:Thing, or owl:Nothing. This is the documented
+    // contract of `super_classes` — the differential suite only ever calls `is_subclass_of`, so the
+    // slice CONTENTS (and the self/⊤/⊥ exclusion) are otherwise unasserted.
+    let ttl = format!("{PRE} :A rdfs:subClassOf :B . :B rdfs:subClassOf :C .");
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    let (a, b, c) = (iri(&dict, "A"), iri(&dict, "B"), iri(&dict, "C"));
+    let mut want = vec![b, c];
+    want.sort_unstable();
+    assert_eq!(
+        h.super_classes(a),
+        want.as_slice(),
+        "A's supers are exactly {{B,C}}, sorted"
+    );
+    assert!(
+        !h.super_classes(a).contains(&a),
+        "super_classes must exclude the class itself"
+    );
+    let thing = dict.lookup(&OTerm::NamedNode(NamedNode::new_unchecked(
+        "http://www.w3.org/2002/07/owl#Thing".to_string(),
+    )));
+    assert!(
+        !h.super_classes(a).contains(&thing),
+        "super_classes must exclude owl:Thing"
+    );
+    // A top class (C) has no proper super-class: empty slice, not a missing-key panic.
+    assert!(h.super_classes(c).is_empty(), "C has no proper super-class");
+    // An unknown dict id returns the empty slice (the documented not-a-classified-class fallback).
+    let absent = dict.lookup(&OTerm::NamedNode(NamedNode::new_unchecked(
+        "http://ex/absent".to_string(),
+    )));
+    assert!(h.super_classes(absent).is_empty(), "unknown class → empty");
+}
+
+#[test]
+fn report_counts_named_classes_and_emitted_subsumptions() {
+    // The `Report` field semantics are load-bearing for the "n axioms outside EL were ignored"
+    // honesty surface but never directly asserted. `named_classes` is the dense concept count —
+    // the named classes (A,B,C = 3) PLUS the always-seeded ⊤ and ⊥ = 5. `emitted_subsumptions` is
+    // 0 on the borrow-only `Classifier::classify` path and only set by `classify_graph`.
+    let ttl = format!("{PRE} :A rdfs:subClassOf :B . :B rdfs:subClassOf :C .");
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    let rep = h.report();
+    assert_eq!(
+        rep.named_classes, 5,
+        "3 named classes (A,B,C) + ⊤ + ⊥ in the dense concept space"
+    );
+    assert_eq!(
+        rep.emitted_subsumptions, 0,
+        "classify (borrow-only) never materializes triples"
+    );
+    assert_eq!(rep.unsatisfiable_classes, 0, "no clash in this TBox");
+    assert_eq!(rep.skipped_axioms, 0, "every axiom is in-fragment");
+}
+
+#[test]
+fn rhs_intersection_splits_into_separate_subsumptions() {
+    // A ⊑ (B ⊓ C) — the conjunction is on the SUPER-class (RHS) side. The normalizer's RHS split
+    // must turn this into A ⊑ B AND A ⊑ C (a subclass of a conjunction is a subclass of each
+    // conjunct). The existing suite only exercises a conjunction via `owl:equivalentClass`; the
+    // plain one-directional RHS-And `rhs_concept` branch is otherwise untested.
+    let ttl = format!("{PRE} :A rdfs:subClassOf [ owl:intersectionOf ( :B :C ) ] .");
+    assert_closure(&ttl, &["A", "B", "C"], &[("A", "B"), ("A", "C")]);
+}
+
+#[test]
+fn single_element_intersection_reduces_to_its_member() {
+    // owl:intersectionOf ( :B ) — a DEGENERATE one-element conjunction. EL semantics: ⊓{B} ≡ B, so
+    // `[intersectionOf (B)] ⊑ A` must behave as `B ⊑ A` (NOT be skipped as non-EL, and NOT panic on
+    // the <2 conjuncts path). With X ⊑ B that yields X ⊑ A. Pins the `parts.len() == 1` decode arm.
+    let ttl = format!(
+        "{PRE}
+         [ owl:intersectionOf ( :B ) ] rdfs:subClassOf :A .
+         :X rdfs:subClassOf :B ."
+    );
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    assert!(
+        h.is_subclass_of(iri(&dict, "X"), iri(&dict, "A")),
+        "⊓{{B}} ≡ B: B ⊑ A and X ⊑ B ⊨ X ⊑ A"
+    );
+    assert_eq!(
+        h.report().skipped_axioms,
+        0,
+        "a single-element intersection is in-fragment, not skipped"
+    );
+}
+
+#[test]
+fn explicit_owl_nothing_superclass_makes_class_unsatisfiable() {
+    // A ⊑ owl:Nothing directly (⊥ as a NAMED superclass node, not via a disjointness clash). The
+    // extractor must route owl:Nothing to BOTTOM so A is reported unsatisfiable. The existing
+    // bottom test reaches ⊥ only through P ⊓ Q ⊑ ⊥; the direct ⊑ owl:Nothing path is distinct.
+    let ttl = format!("{PRE} :A rdfs:subClassOf owl:Nothing .");
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    assert!(
+        h.unsatisfiable_classes().contains(&iri(&dict, "A")),
+        "A ⊑ owl:Nothing makes A unsatisfiable"
+    );
+    assert_eq!(
+        h.report().unsatisfiable_classes,
+        1,
+        "exactly A is unsatisfiable"
+    );
+}
+
+#[test]
+fn explicit_owl_thing_superclass_is_trivial_not_a_derived_subsumption() {
+    // A ⊑ owl:Thing is a tautology: it must NOT appear as a *derived named* subsumption (⊤ is
+    // excluded from `super_classes`), and B ⊑ A must still classify. Guards the ⊤ recogniser + the
+    // projection's `d != TOP` filter — a regression here would emit owl:Thing as a spurious super.
+    let ttl = format!("{PRE} :A rdfs:subClassOf owl:Thing . :B rdfs:subClassOf :A .");
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    let thing = dict.lookup(&OTerm::NamedNode(NamedNode::new_unchecked(
+        "http://www.w3.org/2002/07/owl#Thing".to_string(),
+    )));
+    assert!(
+        !h.super_classes(iri(&dict, "A")).contains(&thing),
+        "owl:Thing is never a derived named super-class"
+    );
+    assert!(
+        h.is_subclass_of(iri(&dict, "B"), iri(&dict, "A")),
+        "the real B ⊑ A subsumption still holds"
+    );
+}
+
+#[test]
+fn allvaluesfrom_restriction_is_skipped_but_el_part_survives() {
+    // A restriction node with onProperty + allValuesFrom (universal) is OUTSIDE EL+⊥. The existing
+    // skip test uses owl:unionOf (a class-expression marker caught by NON_EL_MARKERS); allValuesFrom
+    // exercises a DIFFERENT branch — a well-formed owl:Restriction whose body is not someValuesFrom,
+    // caught by decode's `_ => None` restriction arm. It must be counted as a skip, not misapplied,
+    // and the in-fragment A ⊑ Z axiom must still classify.
+    let ttl = format!(
+        "{PRE}
+         :A rdfs:subClassOf [ owl:onProperty :r ; owl:allValuesFrom :B ] .
+         :A rdfs:subClassOf :Z ."
+    );
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    assert!(
+        h.report().skipped_axioms >= 1,
+        "the allValuesFrom axiom must be recorded as skipped"
+    );
+    assert!(
+        h.is_subclass_of(iri(&dict, "A"), iri(&dict, "Z")),
+        "the in-fragment A ⊑ Z must still classify"
+    );
+    // Soundness: allValuesFrom must NOT be misread as someValuesFrom — no link to B is created, so
+    // nothing about an r-successor of A is derivable. B is unrelated to A.
+    assert!(
+        !h.is_subclass_of(iri(&dict, "A"), iri(&dict, "B")),
+        "a skipped universal restriction derives nothing about B"
+    );
+}
+
+#[test]
+fn three_way_conjunction_left_fold_requires_all_conjuncts() {
+    // (A ⊓ B ⊓ C) ⊑ D left-folds through TWO binary AndSub axioms over a fresh name. The existing
+    // CR2 test is 2-way only; this pins the multi-conjunct `and_lhs` fold AND its completeness:
+    //   X with A,B,C ⊨ X ⊑ D, but Y with only A,B does NOT (the partial conjunction must not fire).
+    let ttl = format!(
+        "{PRE}
+         [ owl:intersectionOf ( :A :B :C ) ] rdfs:subClassOf :D .
+         :X rdfs:subClassOf :A . :X rdfs:subClassOf :B . :X rdfs:subClassOf :C .
+         :Y rdfs:subClassOf :A . :Y rdfs:subClassOf :B ."
+    );
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    assert!(
+        h.is_subclass_of(iri(&dict, "X"), iri(&dict, "D")),
+        "X has all three conjuncts ⇒ X ⊑ D"
+    );
+    assert!(
+        !h.is_subclass_of(iri(&dict, "Y"), iri(&dict, "D")),
+        "Y has only two of three conjuncts ⇒ Y ⊑ D must NOT fire"
+    );
+}
+
+#[test]
+fn classify_graph_interns_subclassof_when_absent_from_dict() {
+    // A graph asserted with `owl:equivalentClass` ONLY has no `rdfs:subClassOf` term in the dict.
+    // `classify_graph` must INTERN the predicate before emitting (the `dict.intern_iri` path) and
+    // materialize both directions of A ≡ B as subClassOf triples. Pins the intern branch the
+    // in-module test never hits (its fixtures always carry subClassOf already).
+    let ttl = format!("{PRE} :A owl:equivalentClass :B .");
+    let (mut dict, mut triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let sub_class_of_iri = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
+    assert_eq!(
+        dict.lookup(&OTerm::NamedNode(NamedNode::new_unchecked(
+            sub_class_of_iri.to_string()
+        ))),
+        sparq_core::dict::NO_ID,
+        "rdfs:subClassOf is absent from an equivalentClass-only graph"
+    );
+    let report = classify_graph(&mut dict, &mut triples);
+    // A ≡ B ⊨ A ⊑ B and B ⊑ A — two NEW subsumption triples.
+    assert_eq!(
+        report.emitted_subsumptions, 2,
+        "both directions of A ≡ B emitted"
+    );
+    let sc = dict.lookup(&OTerm::NamedNode(NamedNode::new_unchecked(
+        sub_class_of_iri.to_string(),
+    )));
+    assert_ne!(sc, sparq_core::dict::NO_ID, "subClassOf was interned");
+    let (a, b) = (iri(&dict, "A"), iri(&dict, "B"));
+    assert!(triples.contains(&[a, sc, b]), "A ⊑ B materialized");
+    assert!(triples.contains(&[b, sc, a]), "B ⊑ A materialized");
+}
+
+#[test]
+fn malformed_self_referential_list_terminates_safely() {
+    // A hand-built intersectionOf whose `rdf:rest` points at its own cell (a cyclic list). The
+    // bounded `decode_list` walk (guarded by the `seen` set) must TERMINATE and treat the list as
+    // its single reachable member A, so `[⊓ {A,…cycle}] ⊑ D` behaves as `A ⊑ D`. A regression to an
+    // unbounded walk would hang the test — this asserts both termination and the A ⊑ D result.
+    let mut dict = Dict::new();
+    let sc = dict.intern_iri("http://www.w3.org/2000/01/rdf-schema#subClassOf");
+    let inter = dict.intern_iri("http://www.w3.org/2002/07/owl#intersectionOf");
+    let first = dict.intern_iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#first");
+    let rest = dict.intern_iri("http://www.w3.org/1999/02/22-rdf-syntax-ns#rest");
+    let node = dict.intern_iri("http://ex/node");
+    let cell = dict.intern_iri("http://ex/cell");
+    let a = dict.intern_iri("http://ex/A");
+    let d = dict.intern_iri("http://ex/D");
+    let triples = vec![
+        [node, inter, cell],
+        [cell, first, a],
+        [cell, rest, cell], // self-referential rdf:rest — must not loop forever.
+        [node, sc, d],
+    ];
+    let h = Classifier::classify(&dict, &triples);
+    assert!(
+        h.is_subclass_of(a, d),
+        "a single-member cyclic list reduces to A; A ⊑ D"
+    );
+}
+
+#[test]
+fn classify_graph_emits_full_closure_not_just_told_edges() {
+    // classify_graph must materialize the COMPLETE closure (every derived edge), not only the
+    // direct/told ones — this is the contrast with the `hasse` transitive-reduction emitter. For
+    // A ⊑ B ⊑ C ⊑ D the told edges are 3 and the closure adds A⊑C, A⊑D, B⊑D = 3 NEW edges.
+    let ttl =
+        format!("{PRE} :A rdfs:subClassOf :B . :B rdfs:subClassOf :C . :C rdfs:subClassOf :D .");
+    let (mut dict, mut triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let report = classify_graph(&mut dict, &mut triples);
+    assert_eq!(
+        report.emitted_subsumptions, 3,
+        "the 3 transitive closure edges A⊑C, A⊑D, B⊑D are emitted"
+    );
+    let sc = dict.lookup(&OTerm::NamedNode(NamedNode::new_unchecked(
+        "http://www.w3.org/2000/01/rdf-schema#subClassOf".to_string(),
+    )));
+    let (a, c, d) = (iri(&dict, "A"), iri(&dict, "C"), iri(&dict, "D"));
+    assert!(
+        triples.contains(&[a, sc, c]),
+        "transitive A⊑C is materialized"
+    );
+    assert!(
+        triples.contains(&[a, sc, d]),
+        "transitive A⊑D is materialized"
+    );
+}
+
+#[test]
+fn disjoint_with_non_el_side_is_skipped_via_the_disjoint_branch() {
+    // owl:disjointWith has its OWN extract branch (`C ⊓ D ⊑ ⊥`), separate from the subClassOf /
+    // equivalentClass decode. When one side is a non-EL node (owl:unionOf), that disjointness axiom
+    // must be recorded as a skip on the DISJOINT path — not silently turned into a ⊥ clash that
+    // would wrongly make classes unsatisfiable. The in-fragment A ⊑ D must still classify.
+    let ttl = format!(
+        "{PRE}
+         [ owl:unionOf ( :A :B ) ] owl:disjointWith :C .
+         :A rdfs:subClassOf :D ."
+    );
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    assert!(
+        h.report().skipped_axioms >= 1,
+        "the non-EL disjointWith axiom is recorded as skipped"
+    );
+    assert!(
+        h.is_subclass_of(iri(&dict, "A"), iri(&dict, "D")),
+        "the in-fragment A ⊑ D still classifies"
+    );
+    // Soundness: a SKIPPED disjointness must not fabricate an unsatisfiable class.
+    assert!(
+        h.unsatisfiable_classes().is_empty(),
+        "a skipped disjointWith creates no ⊥ clash"
+    );
+}
+
+#[test]
+fn equivalent_class_to_existential_applies_both_directions() {
+    // A ≡ ∃r.B is two inclusions: A ⊑ ∃r.B AND ∃r.B ⊑ A. The second direction is the load-bearing
+    // one — it is an `∃r.B ⊑ A` (NF4 / `ExistsSub`) axiom minted from an EQUIVALENCE, a path the
+    // existing equivalence fixture (A ≡ B ⊓ C, conjunction only) never produces. With C ⊑ ∃r.B,
+    // CR4 over the `∃r.B ⊑ A` direction must derive C ⊑ A.
+    let ttl = format!(
+        "{PRE}
+         :A owl:equivalentClass [ owl:onProperty :r ; owl:someValuesFrom :B ] .
+         :C rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] ."
+    );
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    assert!(
+        h.is_subclass_of(iri(&dict, "C"), iri(&dict, "A")),
+        "the ∃r.B ⊑ A direction of the equivalence derives C ⊑ A"
+    );
 }

--- a/crates/sparq-reason-el/tests/hasse_reduction.rs
+++ b/crates/sparq-reason-el/tests/hasse_reduction.rs
@@ -345,3 +345,83 @@ fn empty_graph_is_safe() {
     assert_eq!(direct.direct_edge_count(), 0);
     assert_eq!(direct.equivalence_class_count(), 0);
 }
+
+// ---------------------------------------------------------------------------------------------
+// [OPUS-4.8] sq-bif: Hasse public-accessor edge-case coverage. The fixtures above assert the
+// reduction over REPRESENTATIVE rows + the count metrics; the additions below pin the documented
+// fallbacks of the three lookup accessors on inputs the existing suite never passes them: a class
+// equivalent to nothing, an unknown dict id, and a NON-representative clique member (whose row and
+// equivalents must be derived through its representative, not its own absent entry).
+
+#[test]
+fn accessor_fallbacks_for_non_equivalent_unknown_and_clique_member() {
+    // A ⊑ B, plus an equivalence clique X ≡ Y, all under nothing else. Exercises every accessor's
+    // documented fallback in one fixture.
+    let ttl = format!(
+        "{PRE}
+         :A rdfs:subClassOf :B .
+         :X rdfs:subClassOf :Y . :Y rdfs:subClassOf :X . :X rdfs:subClassOf :B ."
+    );
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let closure = Classifier::classify(&dict, &triples);
+    let direct = DirectHierarchy::from_closure(&closure);
+    let (a, b, x, y) = (
+        iri(&dict, "A"),
+        iri(&dict, "B"),
+        iri(&dict, "X"),
+        iri(&dict, "Y"),
+    );
+
+    // (1) A class equivalent to nothing is its OWN representative and has an EMPTY equivalents set.
+    assert_eq!(direct.representative(a), a, "A is its own representative");
+    assert!(
+        direct.equivalent_classes(a).is_empty(),
+        "A has no equivalents"
+    );
+
+    // (2) An unknown dict id falls back to itself as representative, with empty direct supers /
+    // equivalents — no panic, no spurious membership.
+    let absent = dict.lookup(&OTerm::NamedNode(NamedNode::new_unchecked(
+        "http://ex/absent".to_string(),
+    )));
+    assert_eq!(
+        direct.representative(absent),
+        absent,
+        "unknown id maps to itself"
+    );
+    assert!(
+        direct.direct_super_classes(absent).is_empty(),
+        "unknown id has no direct supers"
+    );
+    assert!(
+        direct.equivalent_classes(absent).is_empty(),
+        "unknown id has no equivalents"
+    );
+
+    // (3) X and Y form one clique. WHICHEVER is the non-representative member must still report the
+    // SAME representative, the SAME direct supers (the clique's shared parent B, looked up via the
+    // rep), and the OTHER member as its equivalent (rep-relative, minus itself).
+    let rep = direct.representative(x);
+    assert_eq!(
+        direct.representative(y),
+        rep,
+        "X and Y share a representative"
+    );
+    assert!(rep == x || rep == y, "the rep is one of the clique members");
+    let non_rep = if rep == x { y } else { x };
+    assert_eq!(
+        direct.direct_super_classes(non_rep),
+        &[b][..],
+        "the non-representative member sees the clique's direct super B"
+    );
+    assert_eq!(
+        direct.equivalent_classes(non_rep),
+        vec![rep],
+        "the non-representative member's only equivalent is the representative"
+    );
+    assert_eq!(
+        direct.equivalent_classes(rep),
+        vec![non_rep],
+        "the representative's only equivalent is the other member"
+    );
+}

--- a/crates/sparq-reason-el/tests/rbox_differential.rs
+++ b/crates/sparq-reason-el/tests/rbox_differential.rs
@@ -198,3 +198,69 @@ fn no_chain_no_spurious_composition() {
     );
     assert_closure(&ttl, &["A", "B", "D", "E"], &[("B", "E")]);
 }
+
+// ---------------------------------------------------------------------------------------------
+// [OPUS-4.8] sq-bif: RBox correctness-coverage additions. The fixtures above all use the LEFT
+// (`r ∘ s ⊑ r`) right-identity and the transitive special case; the additions below close the
+// distinct RIGHT-identity `r ∘ s ⊑ s` direction (the super-role is the SECOND chain component —
+// indexed in `comp_by_second` not `comp_by_first`), a chain that fires through a SUPER-role of a
+// composed link (CR10 over a CR11 result), and the honest-report invariant that an RBox axiom is
+// NOT double-counted as a skipped non-EL class axiom under the active fragment.
+
+#[test]
+fn cr11_right_identity_super_is_second_component() {
+    // r ∘ s ⊑ s — the OTHER right-identity (the existing `cr11_property_chain_right_identity` uses
+    // r ∘ s ⊑ r, where the super-role is the FIRST component). Here the super-role `s` is the
+    // SECOND chain component, so the link must compose onto R(s), not R(r). A ⊑ ∃r.B, B ⊑ ∃s.D,
+    // ∃s.D ⊑ E: (A,B)∈R(r) ∘ (B,D)∈R(s) ⇒ (A,D)∈R(s), and CR4 over `∃s.D ⊑ E` derives A ⊑ E. B ⊑ E
+    // holds directly via (B,D)∈R(s); no other named subsumption.
+    let ttl = format!(
+        "{PRE}
+         :s owl:propertyChainAxiom ( :r :s ) .
+         :A rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] .
+         :B rdfs:subClassOf [ owl:onProperty :s ; owl:someValuesFrom :D ] .
+         [ owl:onProperty :s ; owl:someValuesFrom :D ] rdfs:subClassOf :E ."
+    );
+    assert_closure(&ttl, &["A", "B", "D", "E"], &[("A", "E"), ("B", "E")]);
+}
+
+#[test]
+fn cr10_lifts_a_cr11_composed_link_to_a_super_role() {
+    // Compose THEN lift: t is transitive (t ∘ t ⊑ t) and t ⊑ u (a super-role). A ⊑ ∃t.B, B ⊑ ∃t.D
+    // compose to (A,D) ∈ R(t) (CR11), which CR10 then lifts to (A,D) ∈ R(u). With `∃u.D ⊑ G` only
+    // the lifted link reaches the axiom, so A ⊑ G holds ONLY if CR10 fires over the CR11 result. A
+    // soundness+completeness witness for the interaction of the two role rules on a derived link.
+    let ttl = format!(
+        "{PRE}
+         :t rdf:type owl:TransitiveProperty .  :t rdfs:subPropertyOf :u .
+         :A rdfs:subClassOf [ owl:onProperty :t ; owl:someValuesFrom :B ] .
+         :B rdfs:subClassOf [ owl:onProperty :t ; owl:someValuesFrom :D ] .
+         [ owl:onProperty :u ; owl:someValuesFrom :D ] rdfs:subClassOf :G ."
+    );
+    assert_closure(&ttl, &["A", "B", "D", "G"], &[("A", "G"), ("B", "G")]);
+}
+
+#[test]
+fn rbox_axioms_are_not_counted_as_skipped_class_axioms() {
+    // With `rbox` ON, a role inclusion + a property chain are APPLIED, not skipped — so they must
+    // NOT inflate `Report::skipped_axioms` (which counts only out-of-fragment CLASS axioms). The
+    // sole class axiom here (A ⊑ B) is in-fragment, so the count must be exactly 0. Guards against a
+    // regression that routed RBox triples through the class-axiom skip path.
+    let ttl = format!(
+        "{PRE}
+         :r rdfs:subPropertyOf :s .
+         :t owl:propertyChainAxiom ( :r :s ) .
+         :A rdfs:subClassOf :B ."
+    );
+    let (dict, triples) = Graph::parse_to_triples(&ttl, "turtle").expect("parse");
+    let h = Classifier::classify(&dict, &triples);
+    assert_eq!(
+        h.report().skipped_axioms,
+        0,
+        "RBox axioms are applied under `rbox`, never counted as skipped class axioms"
+    );
+    assert!(
+        h.is_subclass_of(iri(&dict, "A"), iri(&dict, "B")),
+        "the in-fragment class axiom still classifies"
+    );
+}


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus 4.8): correctness-test coverage for the opt-in OWL 2 EL classifier `sparq-reason-el`. Advances P1 umbrella bead `sq-bif` (left OPEN).

## What

16 regression-catching correctness tests added to the **three existing test targets** — **no new cargo feature or `cfg`-gate** (per the brief's constraint). The crate was already well-covered for the core CR1–CR5 / CR10–CR11 closure; these close **genuine gaps** the differential suite never asserted: the public **accessor contracts**, the **`Report` field semantics**, and the **extractor's fragment-recogniser branches**. Every test asserts an **exact expected value** (not "no panic"/tautology) and was **fault-injection-verified** to fail when the corresponding logic is broken and pass after revert.

### `tests/differential.rs` (default feature, +13)
- `super_classes` accessor: exact closure slice, **self / `owl:Thing` / `owl:Nothing` exclusion**, sorted order, empty-on-top-class and empty-on-unknown-id fallbacks
- `Report` semantics: `named_classes` = dense concept count (named **+ ⊤ + ⊥**); `emitted_subsumptions` = 0 on the borrow-only `classify` path; `skipped`/`unsatisfiable`
- **RHS** `owl:intersectionOf` split (`A ⊑ B ⊓ C ⊨ A⊑B, A⊑C`)
- degenerate **single-element** `owl:intersectionOf` reduces to its member (not skipped, not a panic on the `< 2` path)
- explicit **`owl:Nothing` superclass → unsatisfiable**; `owl:Thing` superclass is trivial (never a derived named super)
- **`allValuesFrom`** restriction skipped via `decode`'s restriction fall-through arm (a *distinct* branch from the `unionOf` `NON_EL_MARKERS` path the existing skip test uses); EL part survives; not misread as `someValuesFrom`
- **3-way conjunction** left-fold requires **all** conjuncts (completeness + no spurious fire on a partial match)
- `classify_graph` **interns `rdfs:subClassOf` when absent** (equivalentClass-only graph) and emits the **full closure**, not just told edges
- non-EL **`disjointWith` skipped** via its dedicated branch (no fabricated ⊥ clash)
- **`equivalentClass`-to-existential** applies both directions (the `∃r.B ⊑ A` path)
- **malformed self-referential `rdf:rest`** list terminates safely

### `tests/rbox_differential.rs` (`rbox` feature, +3)
- CR11 **right-identity where the super-role is the SECOND chain component** (`r ∘ s ⊑ s`) — distinct from the existing `r ∘ s ⊑ r` fixture
- **CR10 lifting a CR11-composed link** to a super-role (compose-then-lift on a *derived* link)
- RBox axioms are **applied, not double-counted** as skipped class axioms

### `tests/hasse_reduction.rs` (`hasse` feature, +1)
- `DirectHierarchy` accessor fallbacks: a class equivalent to nothing, an unknown dict id, and a **non-representative clique member** (row + equivalents derived through the representative)

## Gates (run in-worktree, both feature states)
- `cargo build -p sparq-reason-el` — green
- `cargo test -p sparq-reason-el` (default: 7 in-module + 20 differential + 2 doctests) **and** `--all-features` (adds `hasse` 10 + `rbox` 12) — all green
- `cargo clippy -p sparq-reason-el --all-targets -- -D warnings` **and** `--all-features` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-reason-el --no-deps --all-features` — clean
- `cargo fmt -p sparq-reason-el -- --check` — clean (diff confined to the 3 changed test files)

**Source files untouched** — test-only (474 insertions). Coverage not regressed. Auto-merge left **OFF**.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
