### PR TITLE
ci(shacl-conformance): self-heal transient crates.io flake + honest failure messaging (sq-shacl-flake) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,15 @@ concurrency:
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
+  # [OPUS-4.8] sq-shacl-flake: harden EVERY job against transient crates.io
+  # registry download hiccups. A `curl failed` mid-download of a single crate
+  # (observed: `download of al/lo/allocator-api2 failed`) aborts the build and,
+  # in the SHACL conformance job, then mis-reported as a phantom "conformance
+  # regressed below the ratchet" that jammed the merge queue. Raising cargo's
+  # network retry well above the default (3) lets these transients self-heal at
+  # the cargo layer before they ever sink a job. A genuine fetch failure (crate
+  # truly absent) still exhausts the retries and fails honestly.
+  CARGO_NET_RETRY: "10"
 
 jobs:
   # [OPUS-4.8] merge-throughput: path-filtered gate. Compute whether THIS change
@@ -814,13 +823,57 @@ jobs:
       - name: Run SHACL core + SHACL-SPARQL suites
         # The runners assert their own pinned floors; capture the scoreboards so
         # the grep gate below can re-check the pass counts.
+        # [OPUS-4.8] sq-shacl-flake: STEP-LEVEL transient self-heal (mirrors the
+        # sq-c76x retry idiom on the main nextest job). A transient crates.io
+        # download hiccup (`curl failed` mid-fetch) aborts `cargo test` BEFORE
+        # any test runs, leaving shacl-conformance.out empty; the previous
+        # single-shot invocation then let the ratchet step below mis-report that
+        # empty scoreboard as a phantom "conformance regressed below the ratchet"
+        # (`? < 98`) that jammed the merge queue across unrelated PRs. Re-running
+        # the whole invocation lets such a transient self-heal. A GENUINE
+        # conformance regression fails the runner's own `assert!(pass >= floor)`
+        # on every attempt and still correctly reds the job — the floor is never
+        # weakened. `rc` is captured explicitly (set -e-safe) so a real failure
+        # surfaces rather than silently exiting 0.
         run: |
-          cargo test -p sparq-shacl --test w3c_core --test w3c_sparql -- --nocapture \
-            | tee shacl-conformance.out
+          set -uo pipefail
+          MAX_ATTEMPTS=2
+          attempt=1
+          while true; do
+            echo "::group::SHACL conformance — attempt $attempt/$MAX_ATTEMPTS"
+            rc=0
+            # `tee` would mask cargo's exit code via the pipe, so capture it from
+            # PIPESTATUS[0] (cargo), not the pipeline's last command (tee).
+            cargo test -p sparq-shacl --test w3c_core --test w3c_sparql -- --nocapture \
+              | tee shacl-conformance.out
+            rc=${PIPESTATUS[0]}
+            echo "::endgroup::"
+            if [ "$rc" -eq 0 ]; then
+              echo "SHACL conformance suites passed on attempt $attempt"
+              break
+            fi
+            if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
+              echo "::error::SHACL conformance run failed after $attempt attempt(s) (exit $rc) — genuine failure, not a single transient. Inspect the cargo/test output above (a real conformance regression trips the runner's own assert!(pass >= floor); a 'curl failed'/download error is an infra flake, not a conformance change)."
+              exit "$rc"
+            fi
+            echo "::warning::SHACL conformance attempt $attempt failed (exit $rc) — retrying once (sq-shacl-flake transient self-heal: most often a transient crates.io download hiccup before any test ran)."
+            attempt=$((attempt + 1))
+          done
       - name: Enforce ratchet (pass counts must not regress)
         run: |
           CORE_FLOOR=98
           SPARQL_FLOOR=5
+          # [OPUS-4.8] sq-shacl-flake: distinguish "scoreboard never produced"
+          # (the test step did not emit a TOTAL line — e.g. an infra/compile
+          # flake) from a GENUINE pass-count regression, so an empty scoreboard
+          # is never mis-reported as "conformance regressed below the ratchet"
+          # (the phantom `? < 98` that jammed the queue). With the step-level
+          # retry above this should not happen, but if it does we fail with an
+          # HONEST, distinct diagnostic instead of a false regression claim.
+          if ! grep -qE '^TOTAL ' shacl-conformance.out; then
+            echo "::error::SHACL conformance scoreboard is missing/empty — the test step produced no 'TOTAL' line. This is an INFRA/build failure (e.g. a transient crates.io download), NOT a conformance regression. Re-run the job; inspect the 'Run SHACL core + SHACL-SPARQL suites' step output above."
+            exit 1
+          fi
           # core runner prints: "TOTAL  <pass> <fail> <skip>"
           CORE_PASS=$(grep -E '^TOTAL ' shacl-conformance.out | awk '{print $2}' | head -1)
           # sparql runner prints: "pass <n> / fail <m> / skip <k>"


### PR DESCRIPTION
> 🤖 I am a **SPARQ agent** (CI-infra fixer, Opus 4.8). This is a CI-correctness fix that unblocks the merge queue.

## Why (queue unblocker)

The single gating check **`W3C SHACL conformance (ratchet — core >= 98, sparql >= 5)`** was **failing on OPEN PRs that don't touch SHACL at all** (e.g. #1231 test-cov-policy), jamming the merge queue. I diagnosed the real failure — it is **NOT a conformance regression**, **NOT a harness path bug**, and **NOT our code**. It is a **transient crates.io download flake**:

```
error: failed to get `allocator-api2` as a dependency of package `hashbrown v0.17.1`
  failed to load source for dependency `allocator-api2`
  download of al/lo/allocator-api2 failed
  curl failed
```

`cargo test` aborted at the **compile/fetch** step *before any test ran*, leaving `shacl-conformance.out` empty. The separate "Enforce ratchet" step then ran anyway, parsed nothing (`CORE_PASS=unknown`), and emitted the **misleading** `::error::SHACL core regressed below the ratchet (? < 98)` — masking an infra flake as a phantom conformance regression. (#1232, with the same code, **passed** in CI — confirming a flake, not a deterministic break.)

## Actual conformance numbers (now vs floor) — NOT regressed

Verified locally on a clean `origin/main` checkout (`./crates/sparq-shacl/fetch-shacl-tests.sh` then `cargo test -p sparq-shacl --test w3c_core --test w3c_sparql`):

| Suite | Pass | Fail | Floor | Status |
|---|---|---|---|---|
| SHACL core | **98** | 0 | 98 | ✅ at floor |
| SHACL-SPARQL | **5** | 0 | 5 | ✅ at floor |

The floors are **correct** and are **NOT lowered** — conformance is healthy. The runners assert their own floors (`assert!(pass >= 98)` / `>= 5`), and the belt-and-braces grep gate parses `98`/`5` correctly from real output.

## Fix (CI-correctness only — no `crates/` source change)

1. **`CARGO_NET_RETRY: "10"`** at top-level `env` — hardens **every** job against this class of transient crates.io download hiccup (cargo's default retry is 3).
2. **Step-level transient self-heal** on the SHACL run, mirroring the established **sq-c76x** retry idiom on the main nextest job: re-runs the whole invocation once. A **genuine** regression trips the runner's own `assert!(pass >= floor)` on every attempt and still correctly reds the job — **the floor is never weakened.** cargo's exit code is captured from `PIPESTATUS[0]` so `tee` cannot mask a real failure.
3. The **ratchet step now distinguishes** "scoreboard missing/empty" (infra/build failure) from a genuine pass-count regression, with an **honest, distinct** diagnostic — so an empty scoreboard is never again reported as a phantom "conformance regressed below the ratchet".

## Gates

- **YAML valid** (`python3 -c "import yaml; yaml.safe_load(...)"`), **actionlint clean** — the 12 `SC2015:info` notes are **pre-existing** on the established ratchet idiom and **unchanged** by this diff (count is 12 on both original and patched).
- **Locally reproduced** the full new step logic end-to-end: passes on attempt 1, ratchet reads core 98 / sparql 5 → PASS; the empty-scoreboard branch correctly fires the honest "INFRA failure, NOT a conformance regression" error; `PIPESTATUS` capture verified to propagate a non-zero exit through `tee`.
- **Gate aggregator intact**: job **name** (no `advisory`/`informational` token) and **`rust_changed` path-filter** are untouched, so this leg still **GATES** and non-Rust PRs still **skip** it.
- `memmap2` stays at `0.9.11` (no Cargo change). Only `.github/workflows/ci.yml` changed.

## Compliance gap closed

Restores **merge-queue correctness / conformance-gate honesty** — a transient infra flake no longer masquerades as a conformance regression and no longer blocks unrelated PRs.

> ⚠️ After this merges, the other open PRs (#1231, #1232, …) need an `update-branch` to pick up this fix.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)