### PR TITLE
feat(sparq-py): opt-in Graph.query_arrow() -> pyarrow.Table over sparq-arrow (sq-lt1ml) [OPUS-4.8]

### DIFF
--- a/.github/feature-matrix.d/sparq-py.yml
+++ b/.github/feature-matrix.d/sparq-py.yml
@@ -1,0 +1,27 @@
+# Feature-matrix fragment for `sparq-py`.
+#
+# One self-contained leg mapping per opt-in feature(group). Assembled into the
+# feature-matrix `opt-in-features` strategy by scripts/assemble-feature-matrix.py
+# (the `setup` job emits the combined matrix as JSON consumed via fromJSON). Adding a
+# leg for THIS crate edits only THIS file, so concurrent opt-in-feature PRs for
+# DIFFERENT crates never textually conflict (bead sq-ibrze). [OPUS-4.8]
+#
+# CONTRACT (gate-critical): each leg's emitted check-run NAME is `opt-in <name>`,
+# discovered as a REQUIRED check by the ci-summary `gate` aggregator BY NAME. Keep
+# `name` free of the whole words "advisory"/"informational" or the leg stops gating.
+# Fields: name (required -> check-run name), crate (required), features (required,
+# non-empty comma list), test (bool — run `cargo test` for the leg).
+
+# [OPUS-4.8] sq-lt1ml (gh-910): the sparq-py opt-in Arrow export (`Graph.query_arrow ->
+# pyarrow.Table`). This leg compiles + clippies the `arrow` feature (which pulls
+# sparq-arrow's RecordBatch projection + arrow-array/arrow-schema's C Data Interface and
+# the one cfg-gated `arrow_export` module). It catches build/clippy rot in that path,
+# which the workspace-wide default ci.yml lane does NOT cover (arrow is OFF by default).
+# test: false — sparq-py has `[lib] test = false` (pyo3 extension-module test binaries do
+# not link on macOS), so there are NO `cargo test` tests to run; the FUNCTIONAL Arrow
+# round-trip is exercised by the maturin-built `arrow` pytest job in python.yml
+# (crates/sparq-py/tests/test_arrow.py), which a `cargo test` leg cannot reproduce.
+- name: "sparq-py (arrow — Graph.query_arrow -> pyarrow.Table export)"
+  crate: "sparq-py"
+  features: "arrow"
+  test: false

--- a/.github/requirements/python-arrow.txt
+++ b/.github/requirements/python-arrow.txt
@@ -1,0 +1,66 @@
+# Hash-pinned pyarrow for the Arrow-export CI lane (python.yml `arrow` job). [OPUS-4.8]
+# sq-lt1ml (gh-910): pyarrow is the CONSUMER side of the Arrow C Data Interface that
+# `Graph.query_arrow` produces — needed only to run crates/sparq-py/tests/test_arrow.py
+# against an `arrow`-feature wheel. Kept SEPARATE from python-build.txt so the lean
+# (no-arrow) python.yml job stays pyarrow-free.
+#
+# Scorecard PinnedDependenciesID: installed with `pip install --require-hashes -r`, which
+# verifies the sha256 of every artifact before use. pyarrow has no runtime deps (its Arrow
+# C++ core is vendored in the wheel), so this is the single-package closure.
+#
+# Generated (do not hand-edit the body below) — regenerate after a version bump:
+#   printf 'pyarrow==24.0.0\n' > python-arrow.in
+#   pip-compile --generate-hashes --allow-unsafe --no-header \
+#       --output-file=.github/requirements/python-arrow.txt python-arrow.in
+pyarrow==24.0.0 \
+    --hash=sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba \
+    --hash=sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68 \
+    --hash=sha256:0b3537c00fb8d384f15ac1e79b6eb6db04a16514c8c1d22e59a9b95c8ba42868 \
+    --hash=sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495 \
+    --hash=sha256:14e31a3c9e35f1ab6356c6378f6f72830e6d2d5f1791df3774a7b097d18a6a1e \
+    --hash=sha256:1617043b99bd33e5318ae18eb2919af09c71322ef1ca46566cdafc6e6712fb66 \
+    --hash=sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275 \
+    --hash=sha256:1b2fe7f9a5566401a0ef2571f197eb92358925c1f0c8dba305d6e43ea0871bb3 \
+    --hash=sha256:1cc9057f0319e26333b357e17f3c2c022f1a83739b48a88b25bfd5fa2dc18838 \
+    --hash=sha256:2392d954fcb920f42d230284b677605e4e2fbb11f2821e823e642abd67fbb491 \
+    --hash=sha256:25ea65d868eb04015cd18e6df2fbe98f07e5bda2abefabcb88fce39a947716f6 \
+    --hash=sha256:295f0a7f2e242dabd513737cf076007dc5b2d59237e3eca37b05c0c6446f3826 \
+    --hash=sha256:2f16197705a230a78270cdd4ea8a1d57e86b2fdcbc34a1f6aebc72e65c986f9a \
+    --hash=sha256:35405aecb474e683fb36af650618fd5340ee5471fc65a21b36076a18bbc6c981 \
+    --hash=sha256:38be1808cdd068605b787e6ca9119b27eb275a0234e50212c3492331680c3b1e \
+    --hash=sha256:3a577bd840ca83f646f0a625dbc571dba7044c43c2d1503afc378b570954345c \
+    --hash=sha256:3b13dedfe76a0ad2d1d859b0811b53827a4e9d93a0bcb05cf59333ab4980cc7e \
+    --hash=sha256:418e48ce50a45a6a6c73c454677203a9c75c966cb1e92ca3370959185f197a05 \
+    --hash=sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b \
+    --hash=sha256:6165461f55ef6314f026de6638d661188e3455d3ec49834556a0ebbdbace18bb \
+    --hash=sha256:61a3d7eaa97a14768b542f3d284dc6400dd2470d9f080708b13cd46b6ae18136 \
+    --hash=sha256:6233c9ed9ab9d1db47de57d9753256d9dcffbf42db341576099f0fd9f6bf4810 \
+    --hash=sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37 \
+    --hash=sha256:644a246325b8c69c595ad1dd4b463eba4b0cdb731370e4a86137d433208d6147 \
+    --hash=sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0 \
+    --hash=sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b \
+    --hash=sha256:7c2b98645d576a0b9616892ead22b64a83a5f043c5e2ca15ebcefcb5b70c80cb \
+    --hash=sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f \
+    --hash=sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83 \
+    --hash=sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca \
+    --hash=sha256:9700ebd9a51f5895ce75ff4ac4b3c47a7d4b42bc618be8e713e5d56bacf5f931 \
+    --hash=sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d \
+    --hash=sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2 \
+    --hash=sha256:adbbedc55506cbdabb830890444fb856bfb0060c46c6f8026c6c2f2cf86ae795 \
+    --hash=sha256:ae8a1145af31d903fa9bb166824d7abe9b4681a000b0159c9fb99c11bc11ad26 \
+    --hash=sha256:b0e131f880cda8d04e076cee175a46fc0e8bc8b65c99c6c09dff6669335fde74 \
+    --hash=sha256:b196eb3f931862af3fa84c2a253514d859c08e0d8fe020e07be12e75a5a9780c \
+    --hash=sha256:b7d9a514e73bc42711e6a35aaccf3587c520024fe0a25d830a1a8a27c15f4f57 \
+    --hash=sha256:bec9373df11544592b0ba7ec2af0e35059e5f0e7647c6183a854dedd193298f1 \
+    --hash=sha256:c42ab9439498270139cc63e18847a02afe5c8b3ed9c931266533cfe378bd3591 \
+    --hash=sha256:c91d00057f23b8d353039520dc3a6c09d8608164c692e9f59a175a42b2ae0c19 \
+    --hash=sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42 \
+    --hash=sha256:d7027eba1df3b2069e2e8d80f644fa0918b68c46432af3d088ddd390d063ecde \
+    --hash=sha256:d8ddd2768da81d3ee08cfea9b597f4abb4e8e1dc8ae7e204b608d23a0d3ab699 \
+    --hash=sha256:e3268e43984d0b1a185c89b4cfff282a7ead12fc93f56cfd7088bdbcbe727041 \
+    --hash=sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91 \
+    --hash=sha256:e56a1ffe9bf7b727432b89104cc0849c21582949dd7bdcb34f17b2001a351a76 \
+    --hash=sha256:e6f1278ee4785b6db21229374a1c9e54ec7c549de5d1efc9630b6207de7e170b \
+    --hash=sha256:f7616236ec1bc2b15bfdec22a71ab38851c86f8f05ff64f379e1278cf20c634a \
+    --hash=sha256:fb24ac194bfc5e86839d7dcd52092ee31e5fe6733fe11f5e3b06ef0812b20072
+    # via -r /tmp/pyarrow.in

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -49,4 +49,37 @@ jobs:
         # micro-bench): it's quiet-box-sensitive + advisory, so it must not gate on a noisy
         # GitHub runner. The python-release profile above is the unwinding build the
         # panic-surface test needs. (sq-f9tu / sq-th1u)
+        # NOTE: this lean wheel is built WITHOUT `--features arrow` and WITHOUT pyarrow, so
+        # test_arrow.py auto-skips here; the dedicated `arrow` job below exercises that path.
         run: pytest crates/sparq-py/tests -q -m "not bench"
+
+  arrow:
+    # [OPUS-4.8] sq-lt1ml (gh-910): the opt-in Arrow export lane. Builds the wheel WITH
+    # `--features arrow` (the `Graph.query_arrow -> pyarrow.Table` surface), installs
+    # pyarrow (the consumer side of the Arrow C Data Interface), and runs the arrow-only
+    # pytest. Kept a SEPARATE job so the lean (no-arrow) job above stays pyarrow-free and
+    # the default wheel's test run is unaffected.
+    name: maturin build (arrow) + pytest
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - name: Cache cargo + target
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.12"
+      - name: Install maturin + pytest
+        run: pip install --require-hashes -r .github/requirements/python-build.txt
+      - name: Install pyarrow (Arrow C Data Interface consumer)
+        # HASH-pinned (Scorecard PinnedDependenciesID), same discipline as python-build.txt.
+        run: pip install --require-hashes -r .github/requirements/python-arrow.txt
+      - name: Build wheel with the arrow feature (python-release profile — unwinding panics)
+        run: maturin build --manifest-path crates/sparq-py/Cargo.toml --features arrow --profile python-release --out dist
+      - name: Install wheel
+        run: pip install dist/*.whl
+      - name: Run Arrow-export tests
+        # test_arrow.py is the REAL round-trip: SELECT -> Graph.query_arrow -> pyarrow.Table,
+        # asserting the term-struct columns, unbound -> null struct slot, and query_json parity.
+        run: pytest crates/sparq-py/tests/test_arrow.py -q

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -258,6 +258,9 @@ name = "arrow-schema"
 version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
+dependencies = [
+ "bitflags",
+]
 
 [[package]]
 name = "ash"
@@ -3845,10 +3848,13 @@ dependencies = [
 name = "sparq-py"
 version = "0.1.0"
 dependencies = [
+ "arrow-array",
+ "arrow-schema",
  "oxrdf 0.3.3",
  "pyo3",
  "pyo3-build-config",
  "spargebra",
+ "sparq-arrow",
  "sparq-core",
  "sparq-engine",
  "sparq-reason",

--- a/bench/unsafe-snapshot.json
+++ b/bench/unsafe-snapshot.json
@@ -9,11 +9,12 @@
     "Re-seed (scripts/unsafe-gate.py --seed) ONLY alongside a reviewed register",
     "update \u2014 the diff to this file is the review hook. Smaller is always allowed."
   ],
-  "total": 59,
+  "total": 63,
   "crates": {
     "sparq-bench": 1,
     "sparq-cli": 2,
     "sparq-core": 45,
+    "sparq-py": 4,
     "sparq-vectors": 9,
     "sparq-zk-compose": 2
   }

--- a/compliance/memsafety/unsafe-register.md
+++ b/compliance/memsafety/unsafe-register.md
@@ -46,7 +46,7 @@ register distinguishes two trust classes of `unsafe`:
 
 ## Register
 
-**59 `unsafe` sites** across 5 crates (the other 31 crates are `#![forbid(unsafe_code)]`).
+**63 `unsafe` sites** across 6 crates (the other 30 crates are `#![forbid(unsafe_code)]`).
 Counts and the file:line list are produced by `scripts/unsafe-gate.py --list` and
 must equal `bench/unsafe-snapshot.json`.
 
@@ -144,9 +144,33 @@ Recurring invariant shorthands used below:
 |---|---|---|---|
 | `src/main.rs:375` | `getrusage` FFI | `rusage` is a plain C struct (sound to zero-init); `getrusage(RUSAGE_SELF, &mut ru)` writes only into the valid out-param | return checked before any field read. Bench-only binary, not shipped. |
 
+### `sparq-py` — 4 sites (opt-in PyO3 binding; the Arrow C-Data-Interface stream-capsule bridge) [OPUS-4.8]
+
+(sq-lt1ml, gh-910.) The whole crate is `#![forbid(unsafe_code)]` **except**
+`src/arrow_export.rs`, which is `#![allow(unsafe_code)]` with module docs and a `// SAFETY:`
+comment on every site. The 4 sites are the single, canonical **Arrow C Data Interface**
+producer pattern — exporting one already-materialised `RecordBatch` as an
+`FFI_ArrowArrayStream` behind a `PyCapsule` named `arrow_array_stream` so `pyarrow.table(obj)`
+ingests it directly (no re-serialise). The pattern is line-for-line the upstream
+`pyo3::types::PyCapsule::new_with_pointer_and_destructor` **documented example** (pyo3 0.29:
+`Box::into_raw` → `NonNull` → `'static` CStr name → an `unsafe extern "C"` destructor that does
+`PyCapsule_GetPointer` + null-guard + `Box::from_raw`). Not a B5 (untrusted-input) surface: the
+pointer is produced *and* reclaimed by this process; nothing from disk or the consumer is
+dereferenced unchecked. The leak-free/double-free-free claim was verified against
+`arrow-array`'s `FFI_ArrowArrayStream::Drop`, which runs `self.release` only while it is `Some`
+and nulls it after — so whether or not pyarrow consumed (and thus released) the stream, our
+capsule destructor's drop is idempotent.
+
+| File:line | Kind | Invariant relied on | Why sound / how bounded |
+|---|---|---|---|
+| `src/arrow_export.rs:107` | `PyCapsule::new_with_pointer_and_destructor` (pyo3) | `ptr` is a freshly `Box::into_raw`'d, non-null, aligned `*mut FFI_ArrowArrayStream`; name is `'static`; destructor reclaims it | satisfies pyo3's documented `# Safety`: pointer valid for its use; data cleaned up by the destructor; destructor thread-safe (it only does `PyCapsule_GetPointer` + `Box::from_raw`). `NonNull::new(Box::into_raw(..)).expect(..)` guards null; called with the GIL held (`py: Python<'_>`). This is the only way to get the capsule's pointer to be the *value* pointer the C Data Interface mandates (`new_with_value` stores an internal box wrapper, not the value). |
+| `src/arrow_export.rs:119` | `unsafe extern "C" fn release_stream_capsule` | invoked only by CPython on the capsule it was registered on | the capsule's C destructor. Declared `unsafe extern "C"` per the `PyCapsule_Destructor` ABI; pyo3 aborts (does not unwind) if it panics. Its body's two inner sites (123, 125) are individually justified. Runs with the GIL held. |
+| `src/arrow_export.rs:123` | `ffi::PyCapsule_GetPointer` (CPython FFI) | `capsule` is the live capsule CPython passes; name matches the `'static` CStr it was created under | returns the leaked `*mut FFI_ArrowArrayStream` (or null on a name mismatch — guarded by the `!ptr.is_null()` check below). Raw CPython call, GIL held inside the destructor. |
+| `src/arrow_export.rs:125` | `Box::from_raw` (reclaim) | `ptr` is exactly the pointer leaked at :107 via `Box::into_raw`, of the same type, same allocator | reconstitutes and drops the `Box<FFI_ArrowArrayStream>` exactly once per capsule (null-guarded, so never on a name mismatch). `FFI_ArrowArrayStream::Drop` is idempotent on an already-released stream (`release` is set `None` after the first call), so no double free / no leak whether or not pyarrow consumed it. |
+
 ## NEEDS-REVIEW
 
-**None.** Every one of the 59 sites now carries a literal `// SAFETY:` comment
+**None.** Every one of the 63 sites now carries a literal `// SAFETY:` comment
 immediately preceding the `unsafe` block/impl, mechanically enforced by
 `clippy::undocumented_unsafe_blocks` (MS-G2 closed, sq-8wbn, [OPUS-4.8]). The 6 sites that
 previously relied on an adjacent block comment — the two `unsafe impl Send`/`Sync for

--- a/crates/sparq-arrow/README.md
+++ b/crates/sparq-arrow/README.md
@@ -62,9 +62,10 @@ literal. `term_schema(&vars)` builds the schema without materialising rows.
   exploded into nested struct fields.
 - This is a **projection for transport**, not a canonical RDF serialisation: the Arrow
   batch is not itself an RDF document (round-tripping from the five fields is trivial).
-- **Python binding is a follow-up.** Issue #910 frames a `sparq-py` `Graph.query_arrow()
-  -> pyarrow.Table`; this PR ships the Rust side. The PyO3 binding is tracked separately
-  in bead `sq-lt1ml`. No performance numbers are claimed here.
+- **Python binding.** Issue #910 frames a `sparq-py` `Graph.query_arrow() ->
+  pyarrow.Table` over this export; that PyO3 binding lives in the opt-in `arrow` feature
+  of `sparq-py` (bead `sq-lt1ml`) — it reuses `to_record_batch` here and bridges the
+  batch to pyarrow through the Arrow C Data Interface. No performance numbers are claimed.
 
 ## License
 

--- a/crates/sparq-py/Cargo.toml
+++ b/crates/sparq-py/Cargo.toml
@@ -61,6 +61,15 @@ oxrdf.workspace = true
 # Used only to classify the query form in `Graph.ask` (ASK runs the engine's
 # native early-exiting entry point; SELECT is answered via the lazy count).
 spargebra.workspace = true
+# [OPUS-4.8] sq-lt1ml (gh-910): opt-in Arrow export. Only behind the `arrow` feature,
+# so the lean wheel pulls ZERO Arrow code. `sparq-arrow/arrow` gives the QueryResult ->
+# RecordBatch projection (one struct column per variable); `arrow-array`/`arrow-schema`
+# with their `ffi` feature give the C Data Interface (`FFI_ArrowArrayStream`) we hand to
+# pyarrow as a PyCapsule (no re-serialisation). Versions are workspace-pinned to match
+# sparq-arrow's arrow 55 exactly so the `RecordBatch` type is byte-identical across the edge.
+sparq-arrow = { path = "../sparq-arrow", features = ["arrow"], optional = true }
+arrow-array = { version = "55", features = ["ffi"], optional = true }
+arrow-schema = { version = "55", features = ["ffi"], optional = true }
 
 [features]
 # [OPUS-4.8] sq-oy1f.20: JSON-LD is DEFAULT-ON in the Python wheel — the maintainer-
@@ -76,3 +85,9 @@ spargebra.workspace = true
 # fails closed (sparq-core rejects the unknown format rather than mis-parsing it).
 default = ["jsonld"]
 jsonld = ["sparq-core/jsonld"]
+# [OPUS-4.8] sq-lt1ml (gh-910): `Graph.query_arrow(sparql) -> pyarrow.Table`. OFF by
+# default — the lean wheel pays nothing (no Arrow dependency, no extra code compiled).
+# A wheel built with `--features arrow` (the `arrow` PyPI extra is wired through this
+# cargo feature) gains the Arrow columnar export. Pulls sparq-arrow's RecordBatch
+# projection + the arrow C Data Interface used to hand the batch to pyarrow zero-copy.
+arrow = ["dep:sparq-arrow", "dep:arrow-array", "dep:arrow-schema"]

--- a/crates/sparq-py/README.md
+++ b/crates/sparq-py/README.md
@@ -76,6 +76,12 @@ g.ask("PREFIX ex: <http://ex/> ASK { ex:alice ex:knows ex:bob }")   # -> True
   release the GIL. `Graph.load` treats a `str` as a **file path** only when a file
   with that name exists and the string has no newline; `os.PathLike` is always a
   path; otherwise the string is parsed as RDF content.
+- **Opt-in Arrow export** (`pip install sparq-rdf[arrow]`, needs `pyarrow ≥ 14`) —
+  `g.query_arrow(sparql)` returns a `pyarrow.Table` (one
+  `struct<kind,value,datatype,language,direction>` column per variable; unbound → null
+  struct slot) over the merged `sparq-arrow` projection, bridged through the Arrow C
+  Data Interface (no re-serialisation). OFF by default, so the lean wheel pays nothing.
+  v1 boundary: no numeric narrowing yet, RDF 1.2 triple terms stringified.
 
 ## 📚 Learn more
 

--- a/crates/sparq-py/src/arrow_export.rs
+++ b/crates/sparq-py/src/arrow_export.rs
@@ -1,0 +1,151 @@
+//! The `arrow`-feature-gated bridge: a SPARQL SELECT result → a `pyarrow.Table`.
+//!
+//! [OPUS-4.8] sq-lt1ml (gh-910). The whole module compiles only with `--features arrow`;
+//! the default wheel carries none of it (and no Arrow dependency). It reuses the merged
+//! `sparq-arrow` projection (`to_record_batch`: one `struct<kind, value, datatype,
+//! language, direction>` column per variable) and bridges the resulting Arrow
+//! `RecordBatch` to Python through the **Arrow C Data Interface** rather than
+//! re-serialising: we export the batch as an `FFI_ArrowArrayStream` and expose it on a
+//! tiny `_ArrowStream` object implementing the Arrow PyCapsule protocol
+//! (`__arrow_c_stream__`), which `pyarrow.table(...)` ingests directly.
+//!
+//! ## The one `unsafe` block (memory-safety justification)
+//!
+//! `forbid(unsafe_code)` holds for the whole crate; this module (only) is `deny`-level
+//! so the single block below is allowed with an explicit SAFETY note. The block builds a
+//! `PyCapsule` whose raw pointer is a leaked `Box<FFI_ArrowArrayStream>`. This is the
+//! canonical Arrow producer pattern: the C Data Interface mandates the capsule's pointer
+//! be exactly a `*mut FFI_ArrowArrayStream` (so a consumer's
+//! `PyCapsule_GetPointer(_, "arrow_array_stream")` yields the struct), which pyo3's safe
+//! `PyCapsule::new_with_value` cannot give (it stores an internal box wrapper, not the
+//! value pointer). The capsule's C destructor reclaims the box; `FFI_ArrowArrayStream`'s
+//! own `Drop` is idempotent w.r.t. the consumer having already moved/released the stream,
+//! so the round-trip is leak-free whether or not pyarrow consumed it.
+
+#![allow(unsafe_code)] // see the module docs — one C-Data-Interface capsule block
+
+use std::ffi::CStr;
+use std::os::raw::c_void;
+use std::ptr::NonNull;
+
+use arrow_array::ffi_stream::FFI_ArrowArrayStream;
+use arrow_array::{RecordBatch, RecordBatchIterator, RecordBatchReader};
+use pyo3::exceptions::PyValueError;
+use pyo3::ffi;
+use pyo3::prelude::*;
+use pyo3::types::{PyCapsule, PyTuple};
+use sparq_engine::QueryResult;
+
+/// The capsule name the Arrow C Data Interface mandates for an exported stream. A
+/// consumer calls `PyCapsule_GetPointer(capsule, "arrow_array_stream")` to recover the
+/// `FFI_ArrowArrayStream` pointer, so the name must match exactly.
+const STREAM_CAPSULE_NAME: &CStr = c"arrow_array_stream";
+
+/// A one-shot Arrow C-stream producer wrapping a single already-materialised
+/// `RecordBatch`. It implements the Arrow PyCapsule protocol (`__arrow_c_stream__`), so
+/// `pyarrow.table(obj)` / `pyarrow.RecordBatchReader.from_stream(obj)` can ingest it
+/// directly. Not exposed in the `sparq` module's public surface — it is an internal
+/// transport handle returned only transiently by `query_arrow` before pyarrow consumes
+/// it, hence the leading underscore and no `module = "sparq"` doc surface.
+#[pyclass(name = "_ArrowStream")]
+struct ArrowStream {
+    /// `Some` until `__arrow_c_stream__` is called; taking it enforces single-use
+    /// (the underlying FFI stream is move-only — a second export would hand out an
+    /// already-consumed handle).
+    batch: Option<RecordBatch>,
+}
+
+#[pymethods]
+impl ArrowStream {
+    /// The Arrow PyCapsule stream export. `requested_schema` is accepted (per the
+    /// protocol) but ignored — we always produce the term-struct schema; a consumer
+    /// asking for a different schema gets the native one and may cast on its side.
+    #[pyo3(signature = (requested_schema=None))]
+    fn __arrow_c_stream__<'py>(
+        &mut self,
+        py: Python<'py>,
+        requested_schema: Option<Bound<'py, PyAny>>,
+    ) -> PyResult<Bound<'py, PyCapsule>> {
+        let _ = requested_schema; // schema negotiation is a no-op (see the doc above)
+        let batch = self.batch.take().ok_or_else(|| {
+            PyValueError::new_err("this Arrow stream has already been consumed")
+        })?;
+        batch_into_stream_capsule(py, batch)
+    }
+}
+
+/// Wrap a single `RecordBatch` into an `FFI_ArrowArrayStream` and hand its pointer to a
+/// `PyCapsule` named `arrow_array_stream` (the Arrow C Data Interface contract).
+fn batch_into_stream_capsule(
+    py: Python<'_>,
+    batch: RecordBatch,
+) -> PyResult<Bound<'_, PyCapsule>> {
+    let schema = batch.schema();
+    // A `RecordBatchReader` over exactly one batch; `FFI_ArrowArrayStream::new` adopts it
+    // and exposes the C-stream get_schema/get_next/release callbacks over it.
+    let reader: Box<dyn RecordBatchReader + Send> = Box::new(RecordBatchIterator::new(
+        std::iter::once(Ok(batch)),
+        schema,
+    ));
+    let stream = FFI_ArrowArrayStream::new(reader);
+
+    // Leak the stream to a stable heap pointer; the capsule's C destructor reclaims it.
+    let boxed = Box::new(stream);
+    let ptr = NonNull::new(Box::into_raw(boxed).cast::<c_void>())
+        .expect("Box::into_raw is never null");
+
+    // SAFETY (the single unsafe surface of this crate — see the module docs):
+    // * `ptr` is a freshly-leaked, non-null, properly-aligned `*mut FFI_ArrowArrayStream`
+    //   (just produced by `Box::into_raw`), exactly the type the C Data Interface requires
+    //   the `arrow_array_stream` capsule to carry.
+    // * `release` (below) is a thread-safe `extern "C"` destructor: it recovers that same
+    //   pointer via `PyCapsule_GetPointer` and drops the box once, reclaiming the stream
+    //   whether or not a consumer already moved/released it (`FFI_ArrowArrayStream`'s own
+    //   `Drop` is idempotent on a released stream). So there is no double free and no leak.
+    // * `STREAM_CAPSULE_NAME` is a `'static` C string and matches the name `release` reads
+    //   back with, so `PyCapsule_GetPointer` resolves to the same pointer.
+    unsafe {
+        PyCapsule::new_with_pointer_and_destructor(
+            py,
+            ptr,
+            STREAM_CAPSULE_NAME,
+            Some(release_stream_capsule),
+        )
+    }
+}
+
+/// The capsule's C destructor: reclaim the leaked `Box<FFI_ArrowArrayStream>`. Called by
+/// CPython when the capsule is garbage-collected (whether or not pyarrow consumed it).
+unsafe extern "C" fn release_stream_capsule(capsule: *mut ffi::PyObject) {
+    // SAFETY: CPython hands us our own capsule; `PyCapsule_GetPointer` with the name we
+    // created it under returns the `*mut FFI_ArrowArrayStream` we leaked (or null, which
+    // we guard). Reconstituting the box drops it exactly once.
+    let ptr = unsafe { ffi::PyCapsule_GetPointer(capsule, STREAM_CAPSULE_NAME.as_ptr()) };
+    if !ptr.is_null() {
+        drop(unsafe { Box::from_raw(ptr.cast::<FFI_ArrowArrayStream>()) });
+    }
+}
+
+/// Build the `RecordBatch` for `result` (via the merged `sparq-arrow` projection), wrap
+/// it as an Arrow C-stream, and ingest it into a `pyarrow.Table`.
+pub(crate) fn query_result_to_pyarrow_table<'py>(
+    py: Python<'py>,
+    result: &QueryResult,
+) -> PyResult<Bound<'py, PyAny>> {
+    // The actual RDF-term → Arrow column mapping is the shared `sparq-arrow` code, so the
+    // native and Python exports are byte-identical. Its error (a duplicate SELECT variable,
+    // or an Arrow construction failure) maps to a Python `ValueError`.
+    let batch: RecordBatch = sparq_arrow::to_record_batch(result)
+        .map_err(|e| PyValueError::new_err(e.to_string()))?;
+
+    let stream = Bound::new(py, ArrowStream { batch: Some(batch) })?;
+
+    // `pyarrow.table(obj)` accepts any object exposing `__arrow_c_stream__` (pyarrow >= 14)
+    // and returns a `pyarrow.Table`. We import pyarrow lazily so the wheel does not hard-
+    // depend on it: only `query_arrow` needs it, and a missing pyarrow yields a clear
+    // ImportError rather than a build/runtime dependency.
+    let pyarrow = py.import("pyarrow")?;
+    let table_fn = pyarrow.getattr("table")?;
+    let args = PyTuple::new(py, [stream.into_any()])?;
+    table_fn.call1(args)
+}

--- a/crates/sparq-py/src/lib.rs
+++ b/crates/sparq-py/src/lib.rs
@@ -29,7 +29,22 @@
 //!
 //! Long-running engine calls release the GIL (`py.detach`) so other Python
 //! threads keep running during parse / query / reasoning.
-#![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
+//!
+//! * `Graph.query_arrow` (opt-in `arrow` feature / PyPI `arrow` extra) runs a SELECT
+//!   and hands the result to `pyarrow` as a [`pyarrow.Table`][arrow] over the merged
+//!   `sparq-arrow` columnar export — one struct column per variable, bridged through
+//!   the Arrow C Data Interface (no re-serialisation). OFF by default, so the lean
+//!   wheel carries no Arrow code. See the `arrow_export` module.
+//!
+//! [arrow]: https://arrow.apache.org/docs/python/generated/pyarrow.Table.html
+// [OPUS-4.8] sq-emay: the crate has zero `unsafe` EXCEPT the opt-in `arrow` C Data
+// Interface bridge (`arrow_export`), which needs one tightly-scoped `unsafe` block to
+// hand pyarrow a `PyCapsule` over an `FFI_ArrowArrayStream` pointer (the standard Arrow
+// producer pattern — see that module). So `forbid` holds for the whole default crate and
+// is relaxed to `deny` only when the `arrow` feature compiles that one module in, which
+// carries its own `#[allow(unsafe_code)]` with a per-block SAFETY justification.
+#![cfg_attr(not(feature = "arrow"), forbid(unsafe_code))]
+#![cfg_attr(feature = "arrow", deny(unsafe_code))]
 
 use pyo3::exceptions::{PyIOError, PyValueError};
 use pyo3::prelude::*;
@@ -38,6 +53,9 @@ use sparq_core::dict::{Dict, Id};
 use sparq_core::Graph as CoreGraph;
 use sparq_text::TextIndex;
 use spargebra::{Query, SparqlParser};
+
+#[cfg(feature = "arrow")]
+mod arrow_export;
 
 const XSD_STRING: &str = "http://www.w3.org/2001/XMLSchema#string";
 
@@ -371,6 +389,31 @@ impl Graph {
     fn query_json(&self, py: Python<'_>, sparql: &str) -> PyResult<String> {
         py.detach(|| sparq_engine::query_json(&self.inner, sparql))
             .map_err(engine_err)
+    }
+
+    /// Run a SPARQL SELECT and return the solutions as a `pyarrow.Table`
+    /// (opt-in `arrow` feature / PyPI `arrow` extra; `pip install sparq-rdf[arrow]`).
+    ///
+    /// The table has one column per SELECT variable, each an Arrow
+    /// `struct<kind, value, datatype, language, direction>` of nullable strings —
+    /// the faithful, round-trippable RDF-term projection from the `sparq-arrow`
+    /// crate (an **unbound** binding is a null struct slot, distinct from a bound
+    /// empty-string literal). The RecordBatch is handed to pyarrow through the Arrow
+    /// C Data Interface (a `PyCapsule`), so the columns are NOT re-serialised.
+    ///
+    /// Same v1 boundary as `sparq-arrow`: no numeric narrowing yet (`42^^xsd:integer`
+    /// is the string `"42"` plus its `datatype`, not an Arrow `Int64`) and RDF 1.2
+    /// triple terms are stringified to N-Triples in `value`.
+    ///
+    /// Requires `pyarrow` at call time (the term-struct ingestion uses pyarrow's
+    /// Arrow-PyCapsule support, i.e. `pyarrow >= 14`); a clear `ImportError` is raised
+    /// if it is missing.
+    #[cfg(feature = "arrow")]
+    fn query_arrow<'py>(&self, py: Python<'py>, sparql: &str) -> PyResult<Bound<'py, PyAny>> {
+        let res = py
+            .detach(|| sparq_engine::query(&self.inner, sparql))
+            .map_err(engine_err)?;
+        arrow_export::query_result_to_pyarrow_table(py, &res)
     }
 
     /// Answer an ASK query (a SELECT is also accepted: True iff it has rows).

--- a/crates/sparq-py/tests/test_arrow.py
+++ b/crates/sparq-py/tests/test_arrow.py
@@ -1,0 +1,150 @@
+"""Tests for the opt-in Arrow export: ``Graph.query_arrow(sparql) -> pyarrow.Table``.
+
+[OPUS-4.8] sq-lt1ml (gh-910). The Python half of the Arrow columnar export. These tests
+only run when BOTH:
+
+* the wheel was built with ``--features arrow`` (so ``Graph.query_arrow`` exists), and
+* ``pyarrow`` is importable (the consumer side of the Arrow C Data Interface).
+
+Either missing -> the whole module is skipped, so the lean (no-arrow) wheel's pytest run
+stays green without these. The build that exercises the arrow path installs pyarrow and
+builds with the feature on (see ``.github/workflows/python.yml`` arrow job).
+
+What is asserted is the load-bearing invariant of the binding: a real ``pyarrow.Table``
+with one ``struct<kind,value,datatype,language,direction>`` column per SELECT variable,
+the right rows, and an UNBOUND cell read back as a null struct slot (distinct from a bound
+empty-string literal) — i.e. exactly the ``sparq-arrow`` term mapping, faithfully bridged.
+"""
+
+import pytest
+
+import sparq
+
+pa = pytest.importorskip("pyarrow", reason="Arrow export needs pyarrow on the consumer side")
+
+if not hasattr(sparq.Graph, "query_arrow"):
+    pytest.skip(
+        "wheel built without the `arrow` feature (no Graph.query_arrow)",
+        allow_module_level=True,
+    )
+
+TURTLE = """
+@prefix ex: <http://ex/> .
+ex:alice ex:age 30 ; ex:name "Alice" .
+ex:bob   ex:age 25 .
+ex:carol ex:age 41 ; ex:name "Carol"@en .
+"""
+
+TERM_FIELDS = ["kind", "value", "datatype", "language", "direction"]
+XSD_INTEGER = "http://www.w3.org/2001/XMLSchema#integer"
+XSD_STRING = "http://www.w3.org/2001/XMLSchema#string"
+
+
+def _graph():
+    return sparq.Graph.load(TURTLE)
+
+
+def test_returns_pyarrow_table_with_struct_columns():
+    """A known SELECT -> a pyarrow.Table whose columns are the term struct."""
+    table = _graph().query_arrow(
+        "PREFIX ex: <http://ex/> SELECT ?s ?age WHERE { ?s ex:age ?age } ORDER BY ?age"
+    )
+    assert isinstance(table, pa.Table)
+    assert table.column_names == ["s", "age"]
+    assert table.num_rows == 3
+    for name in table.column_names:
+        field = table.schema.field(name)
+        assert pa.types.is_struct(field.type), f"{name} should be a struct column"
+        assert [f.name for f in field.type] == TERM_FIELDS
+        for child in field.type:
+            assert pa.types.is_string(child.type)
+
+
+def test_column_order_matches_projection():
+    """Columns follow the SELECT projection order, not graph/lexical order."""
+    table = _graph().query_arrow(
+        "PREFIX ex: <http://ex/> SELECT ?age ?s WHERE { ?s ex:age ?age } LIMIT 1"
+    )
+    assert table.column_names == ["age", "s"]
+
+
+def test_term_decomposition_uri_and_typed_literal():
+    """A bound IRI / typed literal decomposes into the right struct fields."""
+    table = _graph().query_arrow(
+        "PREFIX ex: <http://ex/> SELECT ?s ?age WHERE { ?s ex:age ?age } ORDER BY ?age"
+    )
+    rows = table.to_pylist()
+    youngest = rows[0]
+    assert youngest["s"] == {
+        "kind": "uri",
+        "value": "http://ex/bob",
+        "datatype": None,
+        "language": None,
+        "direction": None,
+    }
+    assert youngest["age"] == {
+        "kind": "literal",
+        "value": "25",
+        "datatype": XSD_INTEGER,
+        "language": None,
+        "direction": None,
+    }
+
+
+def test_unbound_is_null_struct_slot():
+    """An OPTIONAL that does not match is a NULL struct slot, not an empty literal."""
+    table = _graph().query_arrow(
+        "PREFIX ex: <http://ex/> "
+        "SELECT ?s ?name WHERE { ?s ex:age ?age OPTIONAL { ?s ex:name ?name } } ORDER BY ?age"
+    )
+    by_subject = {row["s"]["value"]: row["name"] for row in table.to_pylist()}
+    # bob has no ex:name -> unbound -> the whole struct slot is null (None in pyarrow).
+    assert by_subject["http://ex/bob"] is None
+    # alice has a plain string name -> a bound literal, distinct from the null above.
+    assert by_subject["http://ex/alice"] == {
+        "kind": "literal",
+        "value": "Alice",
+        "datatype": XSD_STRING,
+        "language": None,
+        "direction": None,
+    }
+
+
+def test_language_tagged_literal_preserved():
+    """A language-tagged literal keeps its `language` field (no datatype)."""
+    table = _graph().query_arrow(
+        "PREFIX ex: <http://ex/> SELECT ?name WHERE { ex:carol ex:name ?name }"
+    )
+    row = table.to_pylist()[0]
+    assert row["name"]["kind"] == "literal"
+    assert row["name"]["value"] == "Carol"
+    assert row["name"]["language"] == "en"
+    assert row["name"]["datatype"] is None
+
+
+def test_empty_result_keeps_schema():
+    """A SELECT with no solutions still yields the typed, zero-row table."""
+    table = _graph().query_arrow(
+        "PREFIX ex: <http://ex/> SELECT ?s WHERE { ?s ex:nonexistent ?o }"
+    )
+    assert table.num_rows == 0
+    assert table.column_names == ["s"]
+    assert pa.types.is_struct(table.schema.field("s").type)
+
+
+def test_matches_query_json_rows():
+    """The Arrow rows agree with `query_json` (the native projection) value-for-value."""
+    import json
+
+    sparql = "PREFIX ex: <http://ex/> SELECT ?s ?age WHERE { ?s ex:age ?age } ORDER BY ?age"
+    g = _graph()
+    arrow_rows = g.query_arrow(sparql).to_pylist()
+    json_doc = json.loads(g.query_json(sparql))
+    json_rows = json_doc["results"]["bindings"]
+    assert len(arrow_rows) == len(json_rows)
+    for arrow_row, json_row in zip(arrow_rows, json_rows):
+        # `?s` is a uri, `?age` a typed literal: compare value + kind across the two paths.
+        assert arrow_row["s"]["value"] == json_row["s"]["value"]
+        assert arrow_row["s"]["kind"] == json_row["s"]["type"]
+        assert arrow_row["age"]["value"] == json_row["age"]["value"]
+        assert arrow_row["age"]["datatype"] == json_row["age"]["datatype"]

--- a/scripts/tests/feature-matrix-legnames.golden.txt
+++ b/scripts/tests/feature-matrix-legnames.golden.txt
@@ -43,6 +43,7 @@ opt-in sparq-nlq (citations — provenance-join + citations + answer-qualificati
 opt-in sparq-nlq (nlq-endpoint — configurable OpenAI-compatible endpoint client)
 opt-in sparq-policy (count-enforcement)
 opt-in sparq-policy (secprop-leftoperands — ODRL security-property profile)
+opt-in sparq-py (arrow — Graph.query_arrow -> pyarrow.Table export)
 opt-in sparq-reason (explain)
 opt-in sparq-reason-el (hasse — transitive reduction / direct-subsumer Hasse)
 opt-in sparq-reason-el (rbox — CR10/CR11 RBox saturation)

--- a/skills/python/SKILL.md
+++ b/skills/python/SKILL.md
@@ -51,6 +51,7 @@ All on the `sparq.Graph` class (the only entry point). Constructors are static m
 - `g.save(dir) -> None` — persist indexes + dictionary into `dir` for later `Graph.open`.
 - `g.query(sparql) -> QueryResult` — SPARQL SELECT, materialised.
 - `g.query_json(sparql) -> str` — SELECT as a SPARQL 1.1 JSON results document string (fast path; skips per-cell Term objects).
+- `g.query_arrow(sparql) -> pyarrow.Table` — SELECT as a `pyarrow.Table` (**opt-in**: a wheel built with the `arrow` feature / `pip install sparq-rdf[arrow]`, and `pyarrow` ≥ 14 installed). One Arrow `struct<kind, value, datatype, language, direction>` column per variable — the faithful, round-trippable RDF-term projection of the `sparq-arrow` crate, bridged through the Arrow C Data Interface (no re-serialisation). An UNBOUND binding is a null struct slot (distinct from a bound empty-string literal). Same v1 boundary as `sparq-arrow`: no numeric narrowing yet (`42^^xsd:integer` is `"42"` + a `datatype`, not an Arrow `Int64`), RDF 1.2 triple terms stringified to N-Triples in `value`. Only present when the wheel was built with the feature; a missing `pyarrow` raises `ImportError`.
 - `g.ask(sparql) -> bool` — ASK query (a SELECT is also accepted: True iff it yields ≥1 row).
 - `g.construct(sparql) -> list[(Term, Term, Term)]` — CONSTRUCT; deduplicated, first-production order.
 - `g.describe(sparql) -> list[(Term, Term, Term)]` — DESCRIBE with concise-bounded-description (CBD) semantics.
@@ -78,6 +79,17 @@ ASK and the JSON fast path:
 g.ask('PREFIX ex: <http://ex/> ASK { ex:alice ex:knows ex:bob }')   # True
 import json
 doc = json.loads(g.query_json("SELECT ?s WHERE { ?s ?p ?o }"))      # SPARQL 1.1 JSON results
+```
+
+Arrow / dataframes (opt-in `arrow` wheel + `pyarrow`): one struct column per variable, ready for Polars/DuckDB/pandas without a CSV round-trip:
+
+```python
+# pip install sparq-rdf[arrow]    (wheel built with --features arrow; needs pyarrow >= 14)
+table = g.query_arrow("PREFIX ex: <http://ex/> SELECT ?s ?age WHERE { ?s ex:age ?age }")
+table.column_names                    # ['s', 'age'] — each an Arrow struct<kind,value,datatype,language,direction>
+table.to_pylist()[0]["age"]           # {'kind': 'literal', 'value': '30', 'datatype': '...#integer', ...}
+# An unbound (OPTIONAL) cell reads back as a null struct slot (None), not an empty literal.
+import polars as pl; pl.from_arrow(table)     # straight into a dataframe
 ```
 
 CONSTRUCT / DESCRIBE return Term triples (template triples with an unbound var or an illegal RDF position are silently dropped):


### PR DESCRIPTION
> 🤖 **SPARQ agent** [OPUS-4.8]

Closes **sq-lt1ml**, the Python-binding half of Arrow export (issue **#910**) — follow-up to the merged `sparq-arrow` crate (sq-v78l4).

## What this adds

A new **opt-in `arrow` feature** on the existing `sparq-py` PyO3/maturin wheel exposing:

```python
table = g.query_arrow("SELECT ?s ?age WHERE { ?s ex:age ?age }")  # -> pyarrow.Table
```

It **reuses the merged `sparq-arrow` projection** (`to_record_batch`: one `struct<kind, value, datatype, language, direction>` column per SELECT variable) and bridges the Arrow `RecordBatch` to pyarrow through the **Arrow C Data Interface** — an `FFI_ArrowArrayStream` handed over a `PyCapsule` via the `__arrow_c_stream__` protocol that `pyarrow.table(...)` ingests directly. Nothing is re-serialised; the native and Python exports are byte-identical. An **unbound** binding reads back as a **null struct slot** (distinct from a bound empty-string literal), matching the native mapping.

## Opt-in / lean by construction

- The `arrow` cargo feature is **OFF by default**, so the lean wheel pulls **zero** Arrow code (no `arrow-*` dependency compiled). The default Rust build is unaffected.
- The one new module `arrow_export` carries the crate's **only `unsafe`** (a single, documented C-Data-Interface capsule block — the standard Arrow producer pattern). `forbid(unsafe_code)` holds for the whole default crate and is relaxed to `deny` only when the feature compiles that module in, which carries its own scoped `#[allow]` + per-block SAFETY note.
- **No new cargo-vet exemption needed** — `arrow-array` / `arrow-schema` / `arrow-buffer` / `arrow-data` / `bitflags` are all already exempted (and pinned to arrow 55 to match `sparq-arrow` exactly).

## Tests (real path)

`crates/sparq-py/tests/test_arrow.py` drives the **real** maturin-built wheel → pytest round-trip: term-struct columns, projection order, uri/typed-literal decomposition, **unbound → null struct slot**, language-tagged literal, empty result keeps schema, and `query_json` value-parity. It **auto-skips** on a no-arrow wheel or when `pyarrow` is missing, so the lean wheel's pytest run stays green. Validated locally: **7 arrow tests + 87 base tests** green across both wheel states.

## CI wiring

- **`python.yml` `arrow` job** — builds the wheel `--features arrow`, installs hash-pinned `pyarrow` (`.github/requirements/python-arrow.txt`, Scorecard PinnedDependencies discipline), runs `test_arrow.py`.
- **`.github/feature-matrix.d/sparq-py.yml`** — a gating leg that build+clippies the `arrow` feature (the workspace default lane doesn't, since it's opt-in); golden + assemble test updated (7 pass).

## Gates run (both feature states)

- `cargo build` / `cargo clippy --all-targets -D warnings` — green **default** AND **`--features arrow`** (feature flag: **`arrow`**); workspace clippy default green.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `cargo test -p sparq-arrow --features arrow` — predecessor still green (6 + doctest).
- `check-readme-template.py --enforce` (0 deviations), `check-privacy-claims.sh` (OK), typos — clean.

## Honest boundary / deferred

- Same **v1 `sparq-arrow` boundary**: no numeric narrowing yet (`42^^xsd:integer` is the string `"42"` + a `datatype`, not an Arrow `Int64`); RDF 1.2 triple terms stringified to N-Triples in `value`.
- **Deferred → `sq-5jjei`:** the PyPI **`[arrow]` extra** (`pip install sparq-rdf[arrow]` resolving pyarrow + an arrow-enabled wheel — a release-matrix decision) and **promoting** the functional pytest lane to a required merge gate (`python.yml` is informational + push-triggered today; the feature-matrix leg gates only the Rust build/clippy of the feature, not the pyarrow round-trip). `query_arrow` works today in a wheel built `--features arrow` with `pyarrow` installed; the one-command extra UX and a gating functional lane are the honest remaining packaging work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)