### PR TITLE
test(sparq-nlq): correctness coverage (sq-bif)

### DIFF
--- a/crates/sparq-nlq/src/cite.rs
+++ b/crates/sparq-nlq/src/cite.rs
@@ -302,4 +302,82 @@ ex:bare a pkg:Finding ;
         assert!(block.contains("no source recorded"));
         assert!(block.contains("<http://ex/bare>"));
     }
+
+    /// A subject derived from TWO sources must cite BOTH, with the numbering continuing
+    /// across the two citations (not reset per subject) — the `render` contract: "one
+    /// `Citation` per distinct source link" / "a Finding derived from two sources cites
+    /// both". This is the multi-source branch of the `for link in &rec.sources` loop, which
+    /// no single-source fixture exercises. [OPUS-4.8]
+    #[test]
+    fn subject_with_two_sources_cites_both_with_continuing_numbers() {
+        let g = Graph::load_str(
+            r#"@prefix pkg:  <https://sparq.dev/ns/pkg#> .
+               @prefix prov: <http://www.w3.org/ns/prov#> .
+               @prefix ex:   <http://ex/> .
+               ex:multi a pkg:Finding ;
+                 prov:wasDerivedFrom ex:src-a , ex:src-b ;
+                 pkg:confidence "0.8" .
+               ex:src-a a pkg:Source .
+               ex:src-b a pkg:Source ."#,
+            "turtle",
+        )
+        .unwrap();
+        // Bind ONLY the multi-source finding so the citation count is exactly its sources.
+        let result = query_with_budget(
+            &g,
+            "PREFIX pkg: <https://sparq.dev/ns/pkg#> \
+             SELECT ?f WHERE { VALUES ?f { <http://ex/multi> } ?f a pkg:Finding }",
+            &QueryBudget::unlimited(),
+        )
+        .unwrap();
+        let cited = cite_result(&g, &result);
+
+        // Two citations, BOTH for the same subject, BOTH to a real distinct source.
+        assert_eq!(cited.citations.len(), 2, "both sources must be cited");
+        assert!(cited
+            .citations
+            .iter()
+            .all(|c| c.subject == nn("http://ex/multi")));
+        let mut srcs: Vec<&str> = cited.citations.iter().map(|c| c.source.as_str()).collect();
+        srcs.sort_unstable();
+        assert_eq!(srcs, vec!["http://ex/src-a", "http://ex/src-b"]);
+        // Numbering continues 1,2 across the sources — it does NOT reset to 1 per source.
+        let mut nums: Vec<usize> = cited.citations.iter().map(|c| c.number).collect();
+        nums.sort_unstable();
+        assert_eq!(nums, vec![1, 2]);
+        // The subject's shared confidence is carried onto each per-source citation.
+        assert!(cited
+            .citations
+            .iter()
+            .all(|c| c.confidence.as_deref() == Some("0.8")));
+        // The multi-source path keeps the resolution guarantee.
+        assert_eq!(cited.resolution_rate(&g), 1.0);
+    }
+
+    /// Citation numbering is a stable, document-wide index across distinct subjects — the
+    /// property a downstream `[n]` marker relies on. Asserts the markers render `[1]`/`[2]`
+    /// and each footnote leads with its own marker. [OPUS-4.8]
+    #[test]
+    fn numbering_is_document_wide_and_marker_leads_footnote() {
+        let g = graph();
+        let cited = cite_result(&g, &all_findings(&g));
+        assert_eq!(cited.citations.len(), 2);
+        assert_eq!(cited.citations[0].marker(), "[1]");
+        assert_eq!(cited.citations[1].marker(), "[2]");
+        assert!(cited.citations[0].footnote().starts_with("[1] "));
+        assert!(cited.citations[1].footnote().starts_with("[2] "));
+    }
+
+    /// `render` over an EMPTY record list yields a citation-free answer with an empty
+    /// footnote block and a vacuous resolution rate of 1.0 — the degenerate input that
+    /// `cite_result` over an empty result table produces. [OPUS-4.8]
+    #[test]
+    fn render_of_no_records_is_empty_and_vacuously_resolved() {
+        let g = graph();
+        let cited = render(&[]);
+        assert!(!cited.has_citations());
+        assert!(cited.no_source_recorded.is_empty());
+        assert_eq!(cited.footnotes(), "");
+        assert_eq!(cited.resolution_rate(&g), 1.0);
+    }
 }

--- a/crates/sparq-nlq/src/endpoint.rs
+++ b/crates/sparq-nlq/src/endpoint.rs
@@ -205,3 +205,65 @@ impl Llm for EndpointLlm {
         Ok(text)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The `EndpointConfig` builder chain sets each field and leaves the others at their
+    /// defaults — the config invariant the loopback-stub integration tests assume but never
+    /// assert on `with_max_tokens` / `with_timeout`. [OPUS-4.8]
+    #[test]
+    fn config_builder_chain_sets_each_field() {
+        let cfg = EndpointConfig::new("http://h/v1", "m")
+            .with_api_key("sk-xyz")
+            .with_max_tokens(64)
+            .with_timeout(std::time::Duration::from_secs(7));
+        assert_eq!(cfg.base_url, "http://h/v1");
+        assert_eq!(cfg.model, "m");
+        assert_eq!(cfg.api_key.as_deref(), Some("sk-xyz"));
+        assert_eq!(cfg.max_tokens, 64);
+        assert_eq!(cfg.timeout, std::time::Duration::from_secs(7));
+
+        // A bare `new` leaves the documented defaults in place.
+        let bare = EndpointConfig::new("http://h", "m");
+        assert!(bare.api_key.is_none());
+        assert_eq!(bare.max_tokens, DEFAULT_MAX_TOKENS);
+        assert_eq!(bare.timeout, DEFAULT_TIMEOUT);
+    }
+
+    /// The request URL is `{base_url}/chat/completions` with at most one separating slash —
+    /// a trailing slash on the base is trimmed (no doubled `//chat`), an absent one is
+    /// added. Guards the `trim_end_matches('/')` join. [OPUS-4.8]
+    #[test]
+    fn request_url_join_normalises_trailing_slash() {
+        let no_slash = EndpointLlm::new(EndpointConfig::new("http://h/v1", "m")).unwrap();
+        assert_eq!(no_slash.request_url, "http://h/v1/chat/completions");
+        assert_eq!(no_slash.model(), "m");
+
+        let with_slash = EndpointLlm::new(EndpointConfig::new("http://h/v1/", "m")).unwrap();
+        assert_eq!(with_slash.request_url, "http://h/v1/chat/completions");
+
+        // Multiple trailing slashes are all trimmed (trim_end_matches strips the run).
+        let many = EndpointLlm::new(EndpointConfig::new("http://h/v1///", "m")).unwrap();
+        assert_eq!(many.request_url, "http://h/v1/chat/completions");
+    }
+
+    /// `non_empty_env` distinguishes "unset" and "empty" from a real value, mapping both
+    /// failure modes to the same actionable error naming the variable. Uses a unique
+    /// variable name so it does not race the integration-suite env tests. [OPUS-4.8]
+    #[test]
+    fn non_empty_env_rejects_unset_and_empty() {
+        const VAR: &str = "SPARQ_NLQ_TEST_NON_EMPTY_ENV_PROBE";
+        std::env::remove_var(VAR);
+        let err = non_empty_env(VAR).unwrap_err();
+        assert!(err.contains(VAR), "error names the variable: {err}");
+
+        std::env::set_var(VAR, "");
+        assert!(non_empty_env(VAR).is_err(), "empty value is rejected");
+
+        std::env::set_var(VAR, "value");
+        assert_eq!(non_empty_env(VAR).unwrap(), "value");
+        std::env::remove_var(VAR);
+    }
+}

--- a/crates/sparq-nlq/src/endpoint.rs
+++ b/crates/sparq-nlq/src/endpoint.rs
@@ -254,6 +254,15 @@ mod tests {
     /// variable name so it does not race the integration-suite env tests. [OPUS-4.8]
     #[test]
     fn non_empty_env_rejects_unset_and_empty() {
+        // Serialize every env-mutating test in this binary against ONE process-wide lock:
+        // `set_var` / `remove_var` are NOT thread-safe (they mutate process-global state
+        // and race any concurrent `getenv`/`setenv` from another thread — UB even though
+        // the probe key below is unique to this test), and cargo runs this binary's unit
+        // tests on a thread pool. Mirrors the `ENV_LOCK` guard in `tests/endpoint_stub.rs`.
+        // [OPUS-4.8]
+        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+
         const VAR: &str = "SPARQ_NLQ_TEST_NON_EMPTY_ENV_PROBE";
         std::env::remove_var(VAR);
         let err = non_empty_env(VAR).unwrap_err();

--- a/crates/sparq-nlq/src/eval.rs
+++ b/crates/sparq-nlq/src/eval.rs
@@ -521,6 +521,67 @@ mod tests {
         assert!(f1.is_exact());
     }
 
+    /// The ASYMMETRIC empty cases — only one of the two sides is empty — which the
+    /// perfect/partial/disjoint and empty-vs-empty tests never reach. An empty PREDICTED
+    /// against a non-empty gold is a total miss (recall 0); a non-empty predicted against
+    /// an empty gold is a total false-positive (precision 0). Both score F1 0 and are NOT
+    /// exact. This is the `p == 0` / `g == 0` ratio guard in `F1::score`. [OPUS-4.8]
+    #[test]
+    fn f1_one_side_empty_scores_zero_and_is_not_exact() {
+        let g = tiny_graph();
+        let people =
+            AnswerSet::from_result(&query_with_budget(&g, PEOPLE, &oracle_budget()).unwrap());
+        let empty = AnswerSet::default();
+        assert!(!people.is_empty());
+
+        // Predicted nothing, gold has rows → recall 0, precision 0 (no intersection).
+        let miss = F1::score(&empty, &people);
+        assert_eq!(miss.precision, 0.0);
+        assert_eq!(miss.recall, 0.0);
+        assert_eq!(miss.f1, 0.0);
+        assert_eq!(miss.intersection, 0);
+        assert_eq!(miss.predicted, 0);
+        assert_eq!(miss.gold, people.len());
+        assert!(!miss.is_exact());
+
+        // Predicted rows, gold is empty → over-answered: precision 0, recall 0.
+        let over = F1::score(&people, &empty);
+        assert_eq!(over.precision, 0.0);
+        assert_eq!(over.recall, 0.0);
+        assert_eq!(over.f1, 0.0);
+        assert_eq!(over.predicted, people.len());
+        assert_eq!(over.gold, 0);
+        assert!(!over.is_exact());
+    }
+
+    /// Answer-set comparison is a MULTISET — duplicate rows are preserved, so a query that
+    /// returns a row twice does NOT collapse it. Guards the `intersection_count` greedy
+    /// merge over duplicates and the `from_result` dup-keeping. [OPUS-4.8]
+    #[test]
+    fn answer_set_is_a_multiset_over_duplicate_rows() {
+        let g = tiny_graph();
+        // UNION of the same person twice yields two identical rows (no DISTINCT).
+        let dup_q = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n\
+             PREFIX ex: <http://example.org/>\n\
+             SELECT ?p WHERE { { ?p rdf:type ex:Person FILTER(?p = ex:alice) } \
+             UNION { ?p rdf:type ex:Person FILTER(?p = ex:alice) } }";
+        let dup = AnswerSet::from_result(&query_with_budget(&g, dup_q, &oracle_budget()).unwrap());
+        assert_eq!(dup.len(), 2, "the duplicate row is kept, not collapsed");
+
+        // The single-row version (alice once) intersects the multiset in exactly one row,
+        // so precision against the 2-row predicted set is 1/2.
+        let single_q = "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n\
+             PREFIX ex: <http://example.org/>\n\
+             SELECT ?p WHERE { ?p rdf:type ex:Person FILTER(?p = ex:alice) }";
+        let single =
+            AnswerSet::from_result(&query_with_budget(&g, single_q, &oracle_budget()).unwrap());
+        assert_eq!(single.len(), 1);
+        let f1 = F1::score(&dup, &single);
+        assert_eq!(f1.intersection, 1, "one of the two duplicate rows matches");
+        assert_eq!(f1.precision, 0.5);
+        assert_eq!(f1.recall, 1.0);
+    }
+
     #[test]
     fn oracle_linking_scores_perfect_without_the_llm() {
         let g = tiny_graph();

--- a/crates/sparq-nlq/src/lib.rs
+++ b/crates/sparq-nlq/src/lib.rs
@@ -749,6 +749,97 @@ mod tests {
         assert_eq!(extract_sparql("I cannot answer that."), None);
     }
 
+    /// An EMPTY fenced block yields `None` (the `(!q.is_empty())` guard in `extract_fenced`),
+    /// not an empty string the loop would then mis-report as `NoSparql`-via-parse. An
+    /// UNCLOSED fence (opener, no closing ```` ``` ````) likewise yields `None` — the
+    /// `body_end` search fails. Neither path is exercised by the happy-path tests. [OPUS-4.8]
+    #[test]
+    fn extract_returns_none_for_empty_or_unclosed_fence() {
+        // Empty `sparql` fence body → None (not Some("")).
+        assert_eq!(extract_sparql("```sparql\n```"), None);
+        // Whitespace-only fence body trims to empty → None.
+        assert_eq!(extract_sparql("```sparql\n   \n```"), None);
+        // Opener present but no closing fence → None (no body_end).
+        assert_eq!(
+            extract_sparql("```sparql\nSELECT * WHERE { ?s ?p ?o }"),
+            None
+        );
+        // Anonymous empty fence → None as well.
+        assert_eq!(extract_sparql("```\n```"), None);
+    }
+
+    /// Bare-text extraction is case-insensitive on the leading keyword and accepts `ASK`,
+    /// `SELECT`, and `PREFIX` starts — but rejects other leading words. Guards the
+    /// `to_ascii_uppercase().starts_with(...)` branch. [OPUS-4.8]
+    #[test]
+    fn extract_bare_text_is_case_insensitive_and_keyword_gated() {
+        assert_eq!(
+            extract_sparql("ask { ?s ?p ?o }").unwrap(),
+            "ask { ?s ?p ?o }"
+        );
+        assert_eq!(
+            extract_sparql("prefix ex: <http://e/> select ?s {}").unwrap(),
+            "prefix ex: <http://e/> select ?s {}"
+        );
+        // A non-SPARQL leading keyword is NOT picked up as a bare query.
+        assert_eq!(extract_sparql("DESCRIBE is unsupported here"), None);
+        assert_eq!(extract_sparql("construct your own"), None);
+    }
+
+    /// `RecordingLlm` records ONLY successful calls — the documented invariant ("Failed
+    /// calls are not recorded; a fixture replays the happy path"). A failing inner call
+    /// propagates the error and leaves the recording empty, so a saved fixture never carries
+    /// a recorded failure. [OPUS-4.8]
+    #[test]
+    fn recording_llm_does_not_record_failed_calls() {
+        let rec = RecordingLlm::new(FnLlm(|p: &str| {
+            if p.contains("boom") {
+                Err("inner failure".into())
+            } else {
+                Ok("ok-completion".into())
+            }
+        }));
+        // A failing call propagates the error and records nothing.
+        assert_eq!(rec.complete("boom"), Err("inner failure".into()));
+        assert!(
+            rec.exchanges().is_empty(),
+            "failed call must not be recorded"
+        );
+        // A successful call IS recorded.
+        assert_eq!(rec.complete("fine").unwrap(), "ok-completion");
+        assert_eq!(rec.exchanges().len(), 1);
+        assert_eq!(rec.exchanges()[0].prompt, "fine");
+        assert_eq!(rec.exchanges()[0].completion, "ok-completion");
+        // A second failure still does not grow the recording past the one success.
+        assert!(rec.complete("boom again? boom").is_err());
+        assert_eq!(rec.exchanges().len(), 1);
+    }
+
+    /// `ReplayLlm::from_json` over the empty fixture `[]` is `is_empty()`, `len()==0`, and
+    /// every lookup misses with the diagnosable re-record error. Also: a malformed fixture
+    /// surfaces an `invalid replay fixture` error rather than panicking. [OPUS-4.8]
+    #[test]
+    fn replay_llm_empty_and_malformed_fixtures() {
+        let empty = ReplayLlm::from_json("[]").expect("empty array is a valid fixture");
+        assert!(empty.is_empty());
+        assert_eq!(empty.len(), 0);
+        let err = empty
+            .complete("Question: anything")
+            .expect_err("an empty fixture always misses");
+        assert!(err.contains("replay miss"), "{err}");
+        assert!(err.contains("0 recorded exchanges"), "{err}");
+
+        // A malformed fixture is an error, never a panic. (`ReplayLlm` is not `Debug`, so
+        // match on the result rather than `unwrap_err`.)
+        match ReplayLlm::from_json("{not json") {
+            Err(e) => assert!(
+                e.contains("invalid replay fixture"),
+                "malformed fixture must surface a descriptive error, got {e}"
+            ),
+            Ok(_) => panic!("malformed JSON must not parse as a fixture"),
+        }
+    }
+
     #[test]
     fn prompt_contains_grounding_examples_and_question() {
         let g = tiny_graph();

--- a/crates/sparq-nlq/src/provenance.rs
+++ b/crates/sparq-nlq/src/provenance.rs
@@ -368,6 +368,54 @@ ex:bare a pkg:Finding ;
         assert!(!r.has_provenance());
     }
 
+    /// A subject with TWO `prov:wasDerivedFrom` sources resolves to TWO distinct
+    /// [`SourceLink`]s — the multi-source fold (`records_from` dedup of the OPTIONAL
+    /// cross-product into one link per distinct `(source, anchor)`). No existing fixture
+    /// has a subject with more than one source. [OPUS-4.8]
+    #[test]
+    fn provenance_for_subject_with_two_sources() {
+        let g = Graph::load_str(
+            r#"@prefix prov: <http://www.w3.org/ns/prov#> .
+               @prefix pkg:  <https://sparq.dev/ns/pkg#> .
+               @prefix ex:   <http://ex/> .
+               ex:m a pkg:Finding ;
+                 prov:wasDerivedFrom ex:s1 , ex:s2 ;
+                 pkg:assurance <https://sparq.dev/ns/secx#Claimed> ;
+                 pkg:confidence "0.6" ."#,
+            "turtle",
+        )
+        .unwrap();
+        let r = provenance_for(&g, &nn("http://ex/m"));
+        assert!(r.has_provenance());
+        // Both sources present, de-duplicated and order-independent.
+        let mut sources: Vec<&str> = r.sources.iter().map(|l| l.source.as_str()).collect();
+        sources.sort_unstable();
+        assert_eq!(sources, vec!["http://ex/s1", "http://ex/s2"]);
+        // The single-valued quality axes are read once, not duplicated per source row.
+        assert_eq!(r.confidence.as_deref(), Some("0.6"));
+        assert_eq!(
+            r.assurance.as_deref(),
+            Some("https://sparq.dev/ns/secx#Claimed")
+        );
+    }
+
+    /// `lookup_query` is deterministic and embeds the subject in EVERY axis clause — the
+    /// shape a caller inspecting "exactly what is executed" depends on. [OPUS-4.8]
+    #[test]
+    fn lookup_query_embeds_subject_in_every_axis() {
+        let q = lookup_query("http://ex/s").expect("embeddable");
+        // The subject appears once per OPTIONAL axis (5 axes).
+        assert_eq!(q.matches("<http://ex/s>").count(), 5);
+        // All five provenance predicates are present.
+        assert!(q.contains("prov:wasDerivedFrom"));
+        assert!(q.contains("dcterms:source"));
+        assert!(q.contains("pkg:confidence"));
+        assert!(q.contains("pkg:assurance"));
+        assert!(q.contains("cito:citesAsEvidence"));
+        // Determinism: same input → byte-identical query.
+        assert_eq!(lookup_query("http://ex/s").unwrap(), q);
+    }
+
     #[test]
     fn join_resolves_every_bound_iri() {
         let g = graph();

--- a/crates/sparq-nlq/src/qualify.rs
+++ b/crates/sparq-nlq/src/qualify.rs
@@ -429,6 +429,58 @@ ex:bare a pkg:Finding ;
         assert_eq!(cfg.band_for(1.0 / 3.0), ConfidenceBand::Medium);
     }
 
+    /// The DOCUMENTED degenerate-config invariant: an out-of-order `low_band > high_band`
+    /// does not panic but COLLAPSES the `Medium` band to empty — every confidence is then
+    /// `High` (>= high_band) or `Low` (< low_band), and `High` wins the `>=` check first.
+    /// Asserts that no value maps to `Medium` under the inverted thresholds. [OPUS-4.8]
+    #[test]
+    fn band_for_inverted_thresholds_collapses_medium() {
+        let cfg = QualifyConfig {
+            low_band: 0.8,
+            high_band: 0.2,
+            ..QualifyConfig::default()
+        };
+        // 0.5 is >= high_band(0.2) → High (the `>=` branch is checked first).
+        assert_eq!(cfg.band_for(0.5), ConfidenceBand::High);
+        // 0.1 is < low_band(0.8) and < high_band → still hits the High `>=`? No: 0.1 < 0.2.
+        assert_eq!(cfg.band_for(0.1), ConfidenceBand::Low);
+        // Sweep a range: nothing lands in Medium under the inverted split.
+        for i in 0..=10 {
+            let c = i as f64 / 10.0;
+            assert_ne!(
+                cfg.band_for(c),
+                ConfidenceBand::Medium,
+                "inverted thresholds must collapse Medium, but {c} mapped to Medium"
+            );
+        }
+    }
+
+    /// `min_confidence` floor at the EXACT boundary: confidence == floor does NOT abstain
+    /// (the floor is "strictly below"); a hair under it does. Locks the `< floor` predicate
+    /// against an accidental `<=`. [OPUS-4.8]
+    #[test]
+    fn abstention_floor_is_strict_less_than() {
+        let g = graph();
+        let exactly = qualify_records(
+            &[provenance::provenance_for(&g, &nn("http://ex/claimed-mid"))],
+            &QualifyConfig {
+                min_confidence: Some(0.5), // claimed-mid is exactly 0.5
+                ..QualifyConfig::default()
+            },
+        );
+        assert_eq!(exactly.min_confidence, Some(0.5));
+        assert!(!exactly.abstain, "0.5 == floor must NOT abstain (strict <)");
+
+        let under = qualify_records(
+            &[provenance::provenance_for(&g, &nn("http://ex/claimed-mid"))],
+            &QualifyConfig {
+                min_confidence: Some(0.5001),
+                ..QualifyConfig::default()
+            },
+        );
+        assert!(under.abstain, "0.5 < 0.5001 floor must abstain");
+    }
+
     #[test]
     fn weakest_link_min_confidence_drives_band() {
         // Answer over the Proven-high (0.9) AND Claimed-mid (0.5) findings: the WEAKEST


### PR DESCRIPTION
> 🤖 SPARQ agent [OPUS-4.8]

Advances P1 bead **sq-bif** (workspace correctness-coverage sweep) for crate **`sparq-nlq`** — the opt-in natural-language-to-SPARQL surface.

`sparq-nlq` was already exceptionally well-covered (the loop, the dictionary constraint, entity/relation linking, the exec-accuracy harness, provenance/citations/qualification, and the endpoint client all have real, end-to-end suites). Rather than pad, I found the GENUINE remaining gaps — documented-but-untested branches, asymmetric error/Result paths, and degenerate-config invariants — and added MEANINGFUL tests that each assert a SPECIFIC behaviour and would catch a real regression. All additions go into EXISTING test targets / EXISTING features; **no new cargo feature or cfg-gate** (no new feature-matrix fragment).

## Gaps filled (each pins a previously-unexercised branch)

- **`cite.rs`** (`citations`): **multi-source render** — a subject with two `prov:wasDerivedFrom` sources cites BOTH, with **document-wide continuing numbering** (the documented "a Finding derived from two sources cites both" branch of the per-source loop, which no single-source fixture reached); empty-records render (vacuous resolution `1.0`); marker-leads-footnote.
- **`provenance.rs`** (`citations`): `provenance_for` over a **2-source subject** (the OPTIONAL cross-product deduped into two distinct `SourceLink`s; single-valued quality axes read once, not duplicated per row); `lookup_query` embeds the subject in **every** axis + determinism.
- **`lib.rs`**: `extract_sparql` **empty/unclosed** fenced block → `None` (the `!q.is_empty()` and missing-`body_end` guards); case-insensitive bare-keyword gating; **`RecordingLlm` does NOT record failed calls** (documented invariant); `ReplayLlm` empty-fixture miss + malformed-fixture error path.
- **`eval.rs`**: `F1::score` **asymmetric one-side-empty** (predicted-empty vs non-empty gold, and vice versa → F1 `0`, not exact — the `p==0`/`g==0` ratio guards); `AnswerSet` **multiset** duplicate-row preservation + the greedy intersection merge over duplicates.
- **`qualify.rs`** (`citations`): `band_for` **inverted-thresholds collapse-Medium** (the documented degenerate-config invariant); abstention floor is **strict `<`** (confidence `== floor` does NOT abstain — locks against an accidental `<=`).
- **`endpoint.rs`** (`nlq-endpoint`): the `EndpointConfig` builder chain (`with_max_tokens`/`with_timeout`/`with_api_key`); `request_url` trailing-slash normalisation; `non_empty_env` unset-vs-empty.

## Gates (run in-worktree, BOTH feature states)

- `cargo build` / `cargo test` — green **default** AND **`--all-features`** (also verified **`--features citations`** alone and **`--features nlq-endpoint`** alone). 118 individual tests pass under `--all-features`.
- `cargo clippy -p sparq-nlq --all-targets -- -D warnings` — clean (default + `--all-features`).
- Workspace rustdoc gate: `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `rustfmt --check` clean on every changed file.
- Test-only (392 insertions; no public API / README / SKILL change). Coverage not regressed — net-new assertions on previously-untested branches.

Auto-merge intentionally **OFF**. Umbrella **sq-bif** left **OPEN**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)