### PR TITLE
feat(serve): in-process embedding seam — embed facade + GenerationRing front door (sq-xa15c, #1248 items 1+2) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3925,6 +3925,7 @@ name = "sparq-serve"
 version = "0.1.0"
 dependencies = [
  "arc-swap",
+ "oxrdf 0.3.3",
  "rustc-hash 2.1.2",
  "spargebra",
  "sparq-core",

--- a/crates/sparq-serve/Cargo.toml
+++ b/crates/sparq-serve/Cargo.toml
@@ -69,6 +69,12 @@ result-cache = []
 # a workspace dependency) — no other crate should reach for it casually; the
 # generation ring is the one sanctioned place for arc-swap in the tree.
 arc-swap = "1"
+# [OPUS-4.8] sq-xa15c (#1248): the embedding seam's named-graph existence probe
+# (`embed::named_graph_exists`) names `oxrdf::Term` — the type `Graph::named_graph`
+# already takes. Workspace dep (same version sparq-core/sparq-engine already pull
+# in transitively); already vetted at the workspace level, so NO new cargo-vet
+# exemption. No HTTP/async — does not break the library-first §6.1 guard.
+oxrdf.workspace = true
 rustc-hash.workspace = true
 # Promoted from dev-dependencies by Wave A2 (as the A1 comment anticipated): the
 # sequenced writer's production `ApplyUpdates` strategy (`GraphApplier`) applies

--- a/crates/sparq-serve/README.md
+++ b/crates/sparq-serve/README.md
@@ -21,14 +21,25 @@ The crate is **sync, runtime-agnostic, and library-first**: it exposes no HTTP
 or async-runtime types (consumers such as `sparq-server` wrap it), and it must
 never enter `sparq-wasm`'s dependency graph.
 
-> **Library-internal core, not a standalone surface.** It is wrapped by
-> `sparq-server` and has no public API of its own — the [surface map in
-> `AGENTS.md`](../../AGENTS.md) does not list it as a usage entry point. It is
-> nonetheless a *publishable* crate (its `Cargo.toml` does **not** set
-> `publish = false`), and it must stay that way: the published `sparq-server`
-> depends on it, and a crates.io crate cannot depend on a `publish = false`
-> crate. So it ships to crates.io as plumbing for `sparq-server`, not as an
-> independently useful library.
+> **Mostly library-internal plumbing — with one deliberate public surface** (the
+> `embed` seam below). It is wrapped by `sparq-server` and otherwise has no
+> standalone API. It is a *publishable* crate (its `Cargo.toml` does **not** set
+> `publish = false`) and must stay that way: the published `sparq-server` depends
+> on it, and a crates.io crate cannot depend on a `publish = false` crate.
+
+## 🔌 `embed` — in-process embedding seam (#1248)
+
+[OPUS-4.8] The `embed` module is a documented facade that lets an external host
+(e.g. `solid-server-rs`) call the engine **in-process** instead of over HTTP — the
+read/write/probe entry points (`query_json` / `ask` / `update_in_place` /
+`apply_delta_nquads` / `exists`+`metadata`, thin wrappers, no new behaviour) plus a
+re-export of the runtime-agnostic concurrency wrapper (`GenerationRing` +
+`GraphApplier` / `Writer`, factored out of `sparq-server`'s axum/tokio glue so an
+embedder reuses sparq's *tested* fork → update → publish + generation-pinning model).
+It is the surface the maintainer **intends** to commit to as the stable embedding
+API ([#1248](https://github.com/jeswr/sparq/issues/1248)) — but **NOT yet a frozen
+semver-tier-1 surface**: the formal freeze is the maintainer's to ratify on #1248,
+and until then a minor pre-`1.0` release MAY still change it.
 
 ## 🚀 Quickstart
 
@@ -52,35 +63,27 @@ cargo run -p sparq-server -- --format turtle data.ttl
   run strictly between batches — never racing a commit.
 - **Sync, runtime-agnostic, library-first** — no HTTP or async-runtime types;
   consumers wrap it. It must never enter `sparq-wasm`'s dependency graph.
-- **Online backup/restore** (opt-in `backup` feature, default OFF) — `backup::export`
-  serialises an already-immutable pinned `Generation` (triples + per-pod epoch vectors +
-  writer seq) to one self-describing artifact **while serving** (no stop-the-world);
-  `backup::import` re-hydrates a `Graph` from one, **fail-closed** on a corrupt/mismatched
-  artifact. Distinct from the offline `sparq-cli save` and the `--persist` WAL. At-rest
-  encryption is out of scope. `sparq-server` mounts `/admin/backup` + `/admin/restore` on it.
-- **Incremental delta / PITR** (same `backup` feature) — `backup_delta::export_delta`
-  captures the quad-set change between two **same-lineage** generations as a self-describing
-  delta artifact keyed off the generation/writer-seq range; `backup_delta::replay` applies an
-  ordered chain forward onto a restored base to reach a chosen recovery point (fail-closed on a
-  corrupt or discontinuous chain). `sparq-server` adds `/admin/backup/delta?from=N` +
-  `--restore-delta` for point-in-time recovery.
-- **Durable change-data-capture stream** *(opt-in: `--features change-stream`, OFF by
-  default)* — `change_stream::ChangeLog` persists each commit as an ordered,
-  monotonically-sequenced change record (op + quad(s) + commit seq/generation + timestamp) to a
-  segmented, fsync'd append-only log (Neptune-Streams shape). A consumer `poll(from_seq)`s from
-  any offset and **replays after a restart** (`ChangeLog::open` re-reads the segments) — a raw
-  durable cross-service feed, unlike the ephemeral in-process WebSocket subscriptions. Same
-  N-Quads same-lineage diff + fail-closed FNV-1a digest as the backup family (no new dependency;
-  no HTTP/async). At-rest encryption + authenticity are out of scope.
-- **Response-bytes result cache** *(opt-in: `--features result-cache`, OFF by
-  default)* — see below.
+- **Online backup/restore** (opt-in `backup` feature, default OFF) —
+  `backup::export` serialises an already-immutable pinned `Generation` to one
+  self-describing artifact **while serving** (no stop-the-world); `backup::import`
+  re-hydrates a `Graph` from one, **fail-closed** on a corrupt/mismatched artifact.
+  `sparq-server` mounts `/admin/backup` + `/admin/restore`. At-rest encryption is
+  out of scope. (Same feature: `backup_delta` incremental-delta / point-in-time
+  recovery between **same-lineage** generations — see rustdoc.)
+- **Durable change-data-capture stream** *(opt-in `change-stream`, OFF by default)*
+  — `change_stream::ChangeLog` persists each commit as an ordered,
+  monotonically-sequenced change record to a segmented, fsync'd append-only log
+  (Neptune-Streams shape); a consumer `poll(from_seq)`s from any offset and
+  **replays after a restart**. No new dependency, no HTTP/async; at-rest encryption
+  + authenticity out of scope. See rustdoc for the segment format.
+- **Response-bytes result cache** *(opt-in `result-cache`, OFF by default)* — see
+  below.
 
 ## 🗃️ Result cache (opt-in, `result-cache` feature)
 
 A serving-layer cache from a request *identity* to the complete pre-serialized
-response body, so a repeated read returns bytes in tens of nanoseconds instead of
-re-executing. **OFF by default**; the default build carries zero cache code and no
-extra dependency.
+response body, so a repeated read returns bytes without re-executing. **OFF by
+default**; the default build carries zero cache code and no extra dependency.
 
 - **Key = (canonical-query × visibility-scope × per-pod epoch-vector)** (design
   §6.3). The query is cheaply canonicalized (whitespace, and opt-in variable
@@ -99,13 +102,11 @@ extra dependency.
   Queries with an unbounded read footprint pin the global generation (invalidated
   by any write).
 - **Single-flight leases** collapse a stampede on a hot uncached key into one
-  execution + N waiters. **Byte-budget LRU + admission**: oversize/streaming bodies
-  are never cached.
+  execution + N waiters; **byte-budget LRU + admission** never cache oversize bodies.
 
-The cache stores opaque `Arc<[u8]>` bodies and a caller-derived `ScopeKey`; it never
-depends on `sparq-solid` and never parses a query. It is a **different layer** from
-`sparq-engine`'s embedded `result-cache` (the in-engine algebra-keyed LRU). Perf
-targets (design §6.3) require a canonical host and are validated there, not in-tree.
+The cache stores opaque `Arc<[u8]>` bodies + a caller-derived `ScopeKey`; it never
+depends on `sparq-solid` and never parses a query, and is a **different layer** from
+`sparq-engine`'s embedded `result-cache` (the in-engine algebra-keyed LRU).
 
 ## 📚 Learn more
 

--- a/crates/sparq-serve/src/embed.rs
+++ b/crates/sparq-serve/src/embed.rs
@@ -1,0 +1,208 @@
+//! [OPUS-4.8] sq-xa15c (#1248 items 1+2) — the **in-process embedding seam**.
+//!
+//! A small, documented facade that lets an external host (e.g. `solid-server-rs`,
+//! the PSS agent's experimental Rust Solid server) call the sparq engine
+//! **in-process** instead of over the SPARQL-1.1-over-HTTP transport — dropping the
+//! HTTP hop, the results (de)serialise, the connection pool, and the serial
+//! round-trips of a multi-resource read.
+//!
+//! Everything here is a **thin re-export / one-line wrapper** over already-public
+//! entry points — nothing is reimplemented, and binding to this module instead of
+//! reaching into `sparq-core` / `sparq-engine` directly buys the embedder ONE place
+//! that the maintainer intends to keep stable.
+//!
+//! # The two halves
+//!
+//! 1. **The data-path facade** (`query_json` / `query`, `ask`, `update_in_place`,
+//!    `apply_delta_nquads`, `exists` / `metadata`) — the read/write/probe calls a
+//!    per-resource Solid backend makes against one `sparq_core::Graph`.
+//! 2. **The concurrency wrapper** — the runtime-agnostic [`GenerationRing`] (+
+//!    [`GraphApplier`], [`Writer`]) re-exported from [`crate`] so an embedder gets
+//!    sparq's *tested* fork → update → publish + generation-pinning read/write
+//!    concurrency model instead of re-implementing (and diverging from) it. The
+//!    ring already lives in this crate (the runtime-agnostic core was factored out
+//!    of `sparq-server`'s axum/tokio glue); the embedding seam is the documented
+//!    front door to it.
+//!
+//! # Stability — INTENDED stable, semver-tier-1 freeze PENDING ratification
+//!
+//! This is the surface the maintainer **intends** to commit to as the stable
+//! embedding API (the request in [issue #1248]). It is **NOT yet a frozen
+//! semver-tier-1 surface**: the formal commitment is the maintainer's to ratify on
+//! #1248, and until that ratification a minor pre-`1.0` release MAY still change it.
+//! It is documented as the embedding seam so an embedder pins ONE module rather than
+//! a scatter of functions the underlying crates mark "unstable", and so the freeze,
+//! when ratified, has a single well-defined shape. No behaviour here is new: every
+//! call is the same engine path `sparq-server` already exercises in production.
+//!
+//! [issue #1248]: https://github.com/jeswr/sparq/issues/1248
+//!
+//! # Example — embed one resource graph behind the generation ring
+//!
+//! ```
+//! use sparq_serve::embed::{self, GenerationRing, GraphApplier};
+//! use sparq_core::Graph;
+//!
+//! // A per-resource (named-graph-per-document) store, seeded once.
+//! let mut g = Graph::load_str(
+//!     "<http://ex/alice> <http://xmlns.com/foaf/0.1/name> \"Alice\" .",
+//!     "ntriples",
+//! ).unwrap();
+//!
+//! // Read path: ASK / SELECT-as-JSON, no HTTP, no serialise round-trip.
+//! assert!(embed::ask(&g, "ASK { ?s ?p ?o }").unwrap());
+//! assert_eq!(embed::exists(&g), true);
+//!
+//! // Write path: apply a SPARQL Update in place …
+//! embed::update_in_place(
+//!     &mut g,
+//!     "INSERT DATA { <http://ex/bob> <http://xmlns.com/foaf/0.1/name> \"Bob\" }",
+//! ).unwrap();
+//! assert_eq!(embed::metadata(&g).triples, 2);
+//!
+//! // … or publish it through the ring for snapshot-isolated concurrent reads.
+//! let ring = GenerationRing::new(g);
+//! let pinned = ring.current(); // a reader pins this snapshot
+//! assert_eq!(pinned.snapshot().len(), 2);
+//! ```
+
+use sparq_core::Graph;
+use sparq_engine::{QueryBudget, QueryResult};
+
+// ── The concurrency wrapper (item 2): the runtime-agnostic core, re-exported ──
+//
+// These are the SAME types `sparq-server` wraps behind its axum endpoint; an
+// embedder gets the tested fork → update → publish + generation-pinning model
+// without an HTTP/async dependency. Re-exported here so the embedding seam is one
+// `use sparq_serve::embed::*;` rather than a scatter across the crate root.
+pub use crate::{
+    ApplyUpdates, Generation, GenerationRing, GraphApplier, PodId, RingConfig, TimeTravelConfig,
+    WriteError, Writer, WriterConfig,
+};
+
+// ── The data-path facade (item 1): thin wrappers over the engine entry points ──
+
+/// Evaluate a SELECT/ASK query against `graph`, serialised directly to a **SPARQL
+/// 1.1 Query Results JSON** string (the `query(&Graph, sparql) -> Json` shape).
+///
+/// This is the fast path the server itself returns to clients — it skips the
+/// intermediate [`QueryResult`] and its per-cell term allocation. For an embedder
+/// that wants the structured rows instead of JSON bytes, use [`query`].
+///
+/// Wraps [`sparq_engine::query_json`]; identical behaviour.
+#[inline]
+pub fn query_json(graph: &Graph, sparql: &str) -> Result<String, String> {
+    sparq_engine::query_json(graph, sparql)
+}
+
+/// [`query_json`] under a cooperative [`QueryBudget`] (deadline / max result rows /
+/// max bytes) — the embedder-facing knob for bounding an untrusted query.
+#[inline]
+pub fn query_json_with_budget(
+    graph: &Graph,
+    sparql: &str,
+    budget: &QueryBudget,
+) -> Result<String, String> {
+    sparq_engine::query_json_with_budget(graph, sparql, budget)
+}
+
+/// Evaluate a SELECT/ASK query against `graph`, returning the structured
+/// [`QueryResult`] (variables + rows of [`oxrdf::Term`]) rather than JSON bytes.
+///
+/// Wraps [`sparq_engine::query`]; identical behaviour. Use [`query_json`] when the
+/// caller just needs the JSON body to hand back over a wire.
+#[inline]
+pub fn query(graph: &Graph, sparql: &str) -> Result<QueryResult, String> {
+    sparq_engine::query(graph, sparql)
+}
+
+/// Evaluate an ASK query: `true` iff the pattern has at least one solution. The
+/// engine early-exits (effectively `LIMIT 1`) where it has a streaming path.
+///
+/// Wraps [`sparq_engine::ask`]; identical behaviour.
+#[inline]
+pub fn ask(graph: &Graph, sparql: &str) -> Result<bool, String> {
+    sparq_engine::ask(graph, sparql)
+}
+
+/// Apply a SPARQL 1.1 Update to `graph` **in place** (the
+/// `update_in_place(&mut Graph, sparql)` shape) — the O(batch) delta-overlay write
+/// path. On `Err` the graph may hold a partially applied prefix of the update's
+/// operations (the same hazard `sparq-server`'s sequenced writer handles by
+/// re-fork-and-replay); an embedder that needs all-or-nothing on one graph should
+/// use [`update_in_place_atomic`].
+///
+/// Wraps [`sparq_engine::update_in_place`]; identical behaviour.
+#[inline]
+pub fn update_in_place(graph: &mut Graph, sparql: &str) -> Result<(), String> {
+    sparq_engine::update_in_place(graph, sparql)
+}
+
+/// [`update_in_place`] with all-or-nothing semantics on a single graph: a failing
+/// operation leaves `graph` exactly as it was (no partial prefix applied).
+///
+/// Wraps [`sparq_engine::update_in_place_atomic`]; identical behaviour.
+#[inline]
+pub fn update_in_place_atomic(graph: &mut Graph, sparql: &str) -> Result<(), String> {
+    sparq_engine::update_in_place_atomic(graph, sparql)
+}
+
+/// Apply a quad-level delta to the whole dataset from two **N-Quads** documents
+/// (`deletes` applied first, then `inserts`), grouped and applied per graph —
+/// default-graph statements to `graph`, named-graph statements to the matching
+/// named sub-graph (auto-created on first insert; deleting from an absent graph is a
+/// no-op). O(batch) through each graph's delta overlay, no index rebuild.
+///
+/// Unlike SPARQL `DELETE DATA`, blank nodes here denote concrete nodes **by label**,
+/// so quad-level retraction of blank-node triples is possible — the property a
+/// Solid `PATCH` / per-resource-replace backend relies on.
+///
+/// Wraps [`Graph::apply_delta_nquads`]; identical behaviour.
+#[inline]
+pub fn apply_delta_nquads(graph: &mut Graph, inserts: &str, deletes: &str) -> Result<(), String> {
+    graph.apply_delta_nquads(inserts, deletes)
+}
+
+/// A cheap existence/metadata probe over `graph` — the "does this resource exist
+/// and how big is it" check a per-resource backend makes before/without a full
+/// query (e.g. to answer a Solid `HEAD` or to decide create-vs-update).
+///
+/// `triples` is the default-graph triple count; `named_graphs` is the number of
+/// distinct named graphs (named-graph-per-document deployments map one resource to
+/// one named graph). Both are O(1)/O(graphs) reads, not a query evaluation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Metadata {
+    /// Triples in the default graph ([`Graph::len`]).
+    pub triples: usize,
+    /// Distinct named graphs in the dataset.
+    pub named_graphs: usize,
+}
+
+/// Existence probe: `true` iff `graph`'s default graph holds at least one triple.
+///
+/// Equivalent to `!graph.is_empty()`; named here as the embedding seam's
+/// resource-existence check so the intent (and the stable name) is explicit.
+#[inline]
+pub fn exists(graph: &Graph) -> bool {
+    !graph.is_empty()
+}
+
+/// `true` iff `graph` contains the named graph `name` — the per-resource existence
+/// check in a named-graph-per-document deployment, where one Solid resource maps to
+/// one named graph addressed by its IRI.
+///
+/// Wraps [`Graph::named_graph`]`(name).is_some()`.
+#[inline]
+pub fn named_graph_exists(graph: &Graph, name: &oxrdf::Term) -> bool {
+    graph.named_graph(name).is_some()
+}
+
+/// The cheap [`Metadata`] probe over `graph` (default-graph triple count + named
+/// graph count). No query evaluation; see [`Metadata`] for the field meanings.
+#[inline]
+pub fn metadata(graph: &Graph) -> Metadata {
+    Metadata {
+        triples: graph.len(),
+        named_graphs: graph.named.len(),
+    }
+}

--- a/crates/sparq-serve/src/lib.rs
+++ b/crates/sparq-serve/src/lib.rs
@@ -7,6 +7,16 @@
 #![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
 
 mod applier;
+/// [OPUS-4.8] sq-xa15c (#1248 items 1+2) — the **in-process embedding seam**: a small,
+/// documented facade over the engine's read/write/probe entry points
+/// ([`query_json`](embed::query_json) / [`ask`](embed::ask) /
+/// [`update_in_place`](embed::update_in_place) / [`apply_delta_nquads`](embed::apply_delta_nquads)
+/// / [`exists`](embed::exists)+[`metadata`](embed::metadata)) plus a re-export of the
+/// runtime-agnostic concurrency wrapper ([`GenerationRing`] + [`GraphApplier`] / [`Writer`]),
+/// so an external host can call sparq in-process instead of over HTTP. INTENDED stable embedding
+/// API; the formal semver-tier-1 freeze is **pending maintainer ratification on #1248** (see the
+/// module docs) — not unilaterally frozen here. Thin re-exports only; no new behaviour.
+pub mod embed;
 /// [OPUS-4.8] (sq-o5bi) ONLINE consistent-snapshot backup + restore for the serving store
 /// — export an already-immutable pinned [`Generation`] to a single self-describing artifact
 /// WHILE SERVING (no stop-the-world), and re-hydrate a [`sparq_core::Graph`] from one

--- a/crates/sparq-serve/tests/embed_facade.rs
+++ b/crates/sparq-serve/tests/embed_facade.rs
@@ -1,0 +1,259 @@
+//! [OPUS-4.8] sq-xa15c (#1248 items 1+2) — DIRECT unit coverage of the in-process
+//! embedding-seam data-path facade ([`sparq_serve::embed`]).
+//!
+//! The companion `embed_seam.rs` proves the generation-ring concurrency wrapper
+//! preserves snapshot isolation, but it only routes through two of the facade's
+//! data-path functions (`query_json` + `update_in_place`). This file exercises EACH
+//! remaining public facade wrapper directly on a small in-memory `Graph` and asserts
+//! the correct result, so the facade's own one-line bodies are covered (not just the
+//! underlying engine path) and the load-bearing property of each — read/ask returns
+//! the right value, the two write paths mutate as documented, the atomic write is
+//! all-or-nothing, the quad-level delta applies adds/deletes across default + named
+//! graphs, and the existence/metadata probes return correct presence/counts.
+//!
+//! Everything here is deterministic and network-free.
+
+use oxrdf::{NamedNode, Term};
+use sparq_core::Graph;
+use sparq_serve::embed::{self, Metadata};
+use sparq_engine::QueryBudget;
+
+/// A two-triple default-graph resource on one subject.
+fn seed() -> Graph {
+    Graph::load_str(
+        "<http://ex/alice> <http://xmlns.com/foaf/0.1/name> \"Alice\" .\n\
+         <http://ex/alice> <http://xmlns.com/foaf/0.1/age> \"30\" .\n",
+        "ntriples",
+    )
+    .expect("load seed graph")
+}
+
+/// Pull the single scalar `?c` value out of a SPARQL-1.1-JSON SELECT body without a
+/// JSON dependency (mirrors `embed_seam.rs`'s helper so the JSON path stays asserted).
+fn json_scalar(json: &str) -> String {
+    let needle = "\"value\":\"";
+    let start = json.rfind(needle).expect("value present") + needle.len();
+    let end = json[start..].find('"').expect("close quote") + start;
+    json[start..end].to_string()
+}
+
+#[test]
+fn query_json_returns_expected_rows() {
+    let g = seed();
+    // Two triples on one subject -> SELECT ?p ?o yields two result bindings, and the
+    // JSON carries the two predicate IRIs.
+    let json = embed::query_json(&g, "SELECT ?p ?o WHERE { <http://ex/alice> ?p ?o }")
+        .expect("query_json ok");
+    assert!(
+        json.contains("http://xmlns.com/foaf/0.1/name"),
+        "name predicate present in JSON: {}",
+        json
+    );
+    assert!(
+        json.contains("http://xmlns.com/foaf/0.1/age"),
+        "age predicate present in JSON: {}",
+        json
+    );
+    // A COUNT(*) over the graph reads exactly 2 through the JSON facade.
+    let cj = embed::query_json(&g, "SELECT (COUNT(*) AS ?c) WHERE { ?s ?p ?o }")
+        .expect("count json ok");
+    assert_eq!(json_scalar(&cj), "2");
+}
+
+#[test]
+fn query_json_with_budget_enforces_row_cap() {
+    let g = seed();
+    // An unlimited budget returns the same body as the plain facade.
+    let unlimited = embed::query_json_with_budget(
+        &g,
+        "SELECT (COUNT(*) AS ?c) WHERE { ?s ?p ?o }",
+        &QueryBudget::unlimited(),
+    )
+    .expect("unlimited budget ok");
+    assert_eq!(json_scalar(&unlimited), "2");
+
+    // A 1-row working-set cap refuses the 2-row SELECT (the budget is enforced at the
+    // working-set, so the materialised 2-row intermediate trips the ceiling).
+    let tight = QueryBudget {
+        max_rows: Some(1),
+        ..QueryBudget::unlimited()
+    };
+    let refused = embed::query_json_with_budget(&g, "SELECT ?s ?p ?o WHERE { ?s ?p ?o }", &tight);
+    assert!(
+        refused.is_err(),
+        "a 2-row result must be refused under a 1-row budget, got {:?}",
+        refused
+    );
+}
+
+#[test]
+fn query_returns_structured_rows() {
+    let g = seed();
+    let res = embed::query(&g, "SELECT ?p WHERE { <http://ex/alice> ?p ?o }")
+        .expect("query ok");
+    assert_eq!(res.vars.len(), 1, "one projected variable");
+    assert_eq!(res.vars[0].as_str(), "p");
+    assert_eq!(res.rows.len(), 2, "two predicate bindings");
+    // Every row has the single ?p column bound to a NamedNode (the predicate IRI).
+    for row in &res.rows {
+        assert_eq!(row.len(), 1);
+        assert!(
+            matches!(row[0], Some(Term::NamedNode(_))),
+            "?p binds to an IRI, got {:?}",
+            row[0]
+        );
+    }
+}
+
+#[test]
+fn ask_returns_correct_bool() {
+    let g = seed();
+    assert!(
+        embed::ask(&g, "ASK { <http://ex/alice> ?p ?o }").expect("ask present"),
+        "pattern with solutions -> true"
+    );
+    assert!(
+        !embed::ask(&g, "ASK { <http://ex/nobody> ?p ?o }").expect("ask absent"),
+        "pattern with no solutions -> false"
+    );
+}
+
+#[test]
+fn update_in_place_mutates_graph() {
+    let mut g = seed();
+    embed::update_in_place(
+        &mut g,
+        "INSERT DATA { <http://ex/bob> <http://xmlns.com/foaf/0.1/name> \"Bob\" }",
+    )
+    .expect("insert ok");
+    assert_eq!(g.len(), 3, "one triple inserted");
+
+    embed::update_in_place(
+        &mut g,
+        "DELETE DATA { <http://ex/alice> <http://xmlns.com/foaf/0.1/age> \"30\" }",
+    )
+    .expect("delete ok");
+    assert_eq!(g.len(), 2, "one triple deleted");
+    assert!(
+        !embed::ask(&g, "ASK { <http://ex/alice> <http://xmlns.com/foaf/0.1/age> ?o }")
+            .expect("ask"),
+        "deleted triple gone"
+    );
+}
+
+#[test]
+fn update_in_place_atomic_is_all_or_nothing() {
+    let mut g = seed();
+    // A syntactically invalid update must leave the graph exactly as it was.
+    let before = g.len();
+    let err = embed::update_in_place_atomic(&mut g, "INSERT DATA { this is not sparql }");
+    assert!(err.is_err(), "malformed update is rejected");
+    assert_eq!(g.len(), before, "atomic failure left no partial prefix applied");
+
+    // A well-formed atomic update commits.
+    embed::update_in_place_atomic(
+        &mut g,
+        "INSERT DATA { <http://ex/carol> <http://xmlns.com/foaf/0.1/name> \"Carol\" }",
+    )
+    .expect("atomic insert ok");
+    assert_eq!(g.len(), before + 1, "valid atomic update committed");
+}
+
+#[test]
+fn apply_delta_nquads_applies_adds_and_deletes() {
+    let mut g = seed();
+    // Insert one default-graph triple and one NAMED-graph triple; delete one of the
+    // seed triples. Deletes are applied before inserts, per the documented contract.
+    let inserts = "<http://ex/bob> <http://xmlns.com/foaf/0.1/name> \"Bob\" .\n\
+         <http://ex/doc1> <http://ex/p> \"v\" <http://ex/graph1> .\n";
+    let deletes = "<http://ex/alice> <http://xmlns.com/foaf/0.1/age> \"30\" .\n";
+    embed::apply_delta_nquads(&mut g, inserts, deletes).expect("delta ok");
+
+    // Default graph: started 2, -1 delete +1 insert = 2.
+    assert_eq!(g.len(), 2, "default-graph triple count after delta");
+    assert!(
+        embed::ask(&g, "ASK { <http://ex/bob> ?p ?o }").expect("ask bob"),
+        "inserted default-graph triple present"
+    );
+    assert!(
+        !embed::ask(&g, "ASK { <http://ex/alice> <http://xmlns.com/foaf/0.1/age> ?o }")
+            .expect("ask age"),
+        "deleted triple gone"
+    );
+    // The named-graph statement auto-created the named graph.
+    let g1 = Term::NamedNode(NamedNode::new("http://ex/graph1").unwrap());
+    assert!(
+        embed::named_graph_exists(&g, &g1),
+        "named graph auto-created by the delta insert"
+    );
+
+    // Deleting from an absent named graph is a no-op (does not error).
+    let del_named =
+        "<http://ex/doc1> <http://ex/p> \"v\" <http://ex/graph1> .\n";
+    embed::apply_delta_nquads(&mut g, "", del_named).expect("named-graph delete ok");
+}
+
+#[test]
+fn exists_reflects_presence() {
+    let g = seed();
+    assert!(embed::exists(&g), "non-empty default graph -> exists");
+
+    let empty = Graph::load_str("", "ntriples").expect("empty graph");
+    assert!(!embed::exists(&empty), "empty default graph -> not exists");
+}
+
+#[test]
+fn named_graph_exists_reports_correct_presence() {
+    let mut g = seed();
+    let name = Term::NamedNode(NamedNode::new("http://ex/doc").unwrap());
+    assert!(
+        !embed::named_graph_exists(&g, &name),
+        "named graph absent before any named-graph statement"
+    );
+    // Add a statement in that named graph via the quad-delta facade.
+    embed::apply_delta_nquads(
+        &mut g,
+        "<http://ex/s> <http://ex/p> <http://ex/o> <http://ex/doc> .\n",
+        "",
+    )
+    .expect("named insert ok");
+    assert!(
+        embed::named_graph_exists(&g, &name),
+        "named graph present after insert"
+    );
+    // A different IRI is still absent.
+    let other = Term::NamedNode(NamedNode::new("http://ex/other").unwrap());
+    assert!(!embed::named_graph_exists(&g, &other), "unrelated IRI absent");
+}
+
+#[test]
+fn metadata_reports_correct_counts() {
+    let mut g = seed();
+    // Fresh seed: 2 default-graph triples, 0 named graphs.
+    let m0 = embed::metadata(&g);
+    assert_eq!(
+        m0,
+        Metadata {
+            triples: 2,
+            named_graphs: 0,
+        }
+    );
+
+    // Add a default-graph triple and two distinct named graphs.
+    embed::update_in_place(
+        &mut g,
+        "INSERT DATA { <http://ex/bob> <http://xmlns.com/foaf/0.1/name> \"Bob\" }",
+    )
+    .expect("insert ok");
+    embed::apply_delta_nquads(
+        &mut g,
+        "<http://ex/s> <http://ex/p> <http://ex/o> <http://ex/g1> .\n\
+         <http://ex/s> <http://ex/p> <http://ex/o> <http://ex/g2> .\n",
+        "",
+    )
+    .expect("named inserts ok");
+
+    let m1 = embed::metadata(&g);
+    assert_eq!(m1.triples, 3, "default-graph triple count tracks inserts");
+    assert_eq!(m1.named_graphs, 2, "two distinct named graphs counted");
+}

--- a/crates/sparq-serve/tests/embed_seam.rs
+++ b/crates/sparq-serve/tests/embed_seam.rs
@@ -1,0 +1,171 @@
+//! [OPUS-4.8] sq-xa15c (#1248 items 1+2) — REGRESSION TEST for the in-process
+//! embedding seam.
+//!
+//! Proves that the extracted, runtime-agnostic [`GenerationRing`] core
+//! (`sparq-serve`, factored out of `sparq-server`'s axum/tokio glue) preserves the
+//! `fork → update → publish` + generation-pinning semantics an embedder depends on,
+//! and that the [`embed`] facade routes through that same engine path:
+//!
+//! - a writer **forks** a base `Graph`, applies a real SPARQL Update, and
+//!   **publishes** the new immutable generation (the production
+//!   [`GraphApplier`]/`update_in_place` path — the same code `sparq-server` runs);
+//! - a concurrent reader that **pinned** an older generation keeps a
+//!   snapshot-consistent view: a SELECT against its pinned snapshot returns the OLD
+//!   answer no matter how far the writer publishes past it;
+//! - generations advance monotonically and a query against `ring.current()` sees the
+//!   NEW answer.
+//!
+//! If a future refactor reintroduces a private `GenerationRing` copy in
+//! `sparq-server`, or breaks fork/publish snapshot isolation, this test fails.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Barrier};
+
+use sparq_core::Graph;
+use sparq_serve::embed::{self, ApplyUpdates, GenerationRing, GraphApplier, PodId};
+
+/// One named-graph-per-document resource graph, seeded with `n` triples on a single
+/// subject (`<http://ex/r> <http://ex/p> "vK">`), so a `COUNT(*)` over it reads `n`.
+fn resource_graph(n: usize) -> Graph {
+    let mut nt = String::new();
+    for i in 0..n {
+        nt.push_str(&format!("<http://ex/r> <http://ex/p> \"v{i}\" .\n"));
+    }
+    Graph::load_str(&nt, "ntriples").expect("load resource graph")
+}
+
+fn count(graph: &Graph) -> usize {
+    // Goes through the SAME facade read path an embedder uses.
+    let json = embed::query_json(graph, "SELECT (COUNT(*) AS ?c) WHERE { ?s ?p ?o }")
+        .expect("count query");
+    // The single COUNT row carries the value as an xsd:integer literal; pull it out
+    // of the SPARQL-JSON body without a JSON dependency.
+    let needle = "\"value\":\"";
+    let start = json.rfind(needle).expect("count value present") + needle.len();
+    let end = json[start..].find('"').expect("close quote") + start;
+    json[start..end].parse().expect("integer count")
+}
+
+/// fork → update → publish through the production applier, with a reader pinning an
+/// old generation throughout: snapshot isolation + monotone generations.
+#[test]
+fn fork_update_publish_preserves_pinned_snapshot_and_advances_generations() {
+    // Seed: a resource with 3 triples, generation 0.
+    let ring = GenerationRing::new(resource_graph(3));
+    let mut applier = GraphApplier::new();
+
+    // A reader pins generation 0 (e.g. a long-lived stream / an in-flight request).
+    let pinned_gen0 = ring.current();
+    assert_eq!(pinned_gen0.number(), 0);
+    assert_eq!(count(pinned_gen0.snapshot()), 3, "pinned view starts at 3");
+
+    // Writer publishes 5 generations, each: fork the current snapshot, apply a real
+    // SPARQL INSERT through the engine, publish the sealed graph. This is exactly the
+    // sequenced writer's per-commit cycle (applier.rs), driven directly so the test
+    // owns the timing.
+    for g in 1..=5u64 {
+        let base = ring.current();
+        let mut working = applier.fork(base.snapshot()).expect("fork");
+        embed::update_in_place(
+            &mut working,
+            &format!("INSERT DATA {{ <http://ex/r> <http://ex/q> \"add{g}\" }}"),
+        )
+        .expect("update_in_place");
+        let sealed = applier.seal(working).expect("seal");
+        let published = ring.publish(sealed, [PodId::from("http://ex/r")]);
+        assert_eq!(published.number(), g, "generations advance by exactly 1");
+    }
+
+    // Generations advanced; the current snapshot reflects all 5 inserts.
+    let current = ring.current();
+    assert_eq!(current.number(), 5);
+    assert_eq!(count(current.snapshot()), 8, "3 seed + 5 inserts");
+    assert_eq!(
+        current.epochs().epoch(&PodId::from("http://ex/r")),
+        5,
+        "the touched pod's epoch bumped once per publish"
+    );
+
+    // The load-bearing invariant: the reader's PINNED generation 0 is byte-stable —
+    // a query against it still returns the OLD answer, untouched by 5 fork/publishes.
+    assert_eq!(pinned_gen0.number(), 0);
+    assert_eq!(
+        count(pinned_gen0.snapshot()),
+        3,
+        "pinned snapshot unaffected by concurrent fork/update/publish"
+    );
+
+    // Read-your-writes: the generation that acked publish #5 satisfies token 5.
+    assert!(ring.read_your_writes(5).is_some());
+    assert!(
+        ring.read_your_writes(6).is_none(),
+        "a not-yet-applied commit token is not satisfiable"
+    );
+}
+
+/// Concurrent: while a writer thread forks/updates/publishes, a reader thread holds
+/// a pin and keeps querying it — it must ALWAYS see its own snapshot, never a torn
+/// or advanced state. Mirrors a streaming reader racing the sequenced writer.
+#[test]
+fn concurrent_reader_pins_consistent_snapshot_across_publishes() {
+    let ring = Arc::new(GenerationRing::new(resource_graph(4)));
+    let start = Arc::new(Barrier::new(2));
+    let max_seen = Arc::new(AtomicU64::new(0));
+
+    let writer = {
+        let ring = ring.clone();
+        let start = start.clone();
+        let max_seen = max_seen.clone();
+        std::thread::spawn(move || {
+            let mut applier = GraphApplier::new();
+            start.wait();
+            for g in 1..=30u64 {
+                let base = ring.current();
+                let mut working = applier.fork(base.snapshot()).expect("fork");
+                embed::update_in_place(
+                    &mut working,
+                    &format!("INSERT DATA {{ <http://ex/r> <http://ex/q> \"c{g}\" }}"),
+                )
+                .expect("update");
+                let sealed = applier.seal(working).expect("seal");
+                let n = ring.publish(sealed, [PodId::from("http://ex/r")]).number();
+                max_seen.store(n, Ordering::SeqCst);
+            }
+        })
+    };
+
+    let reader = {
+        let ring = ring.clone();
+        let start = start.clone();
+        std::thread::spawn(move || {
+            // Pin the generation that is current at the barrier; its count is fixed
+            // for the pin's lifetime no matter what the writer does.
+            start.wait();
+            let pin = ring.current();
+            let pinned_count = count(pin.snapshot());
+            for _ in 0..200 {
+                assert_eq!(
+                    count(pin.snapshot()),
+                    pinned_count,
+                    "pinned snapshot must never change under concurrent publishes"
+                );
+            }
+            (pin.number(), pinned_count)
+        })
+    };
+
+    writer.join().expect("writer panicked");
+    let (pin_num, pin_count) = reader.join().expect("reader panicked");
+
+    // The writer ran to completion: 30 generations published.
+    assert_eq!(max_seen.load(Ordering::SeqCst), 30);
+    assert_eq!(ring.current().number(), 30);
+    // The reader's pinned snapshot is internally consistent: count == seed + (its gen).
+    assert_eq!(
+        pin_count,
+        4 + pin_num as usize,
+        "pinned count is exactly the seed plus its own generation's inserts"
+    );
+    // And the current generation reflects every insert.
+    assert_eq!(count(ring.current().snapshot()), 4 + 30);
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -215,6 +215,33 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   update-side `using-*` override), `enum QueryForm { Select, Ask, Construct, Describe }`; module
   `sparq_server::results`.
 
+### In-process embedding seam — `sparq_serve::embed` ([OPUS-4.8] sq-xa15c, #1248)
+
+When the consumer is **another Rust process** (e.g. `solid-server-rs`) and wants to
+drop the HTTP hop entirely, embed the engine in-process via the `sparq_serve::embed`
+facade instead of running `sparq-server` and talking to it over HTTP. It is the
+documented **embedding seam**: thin wrappers over the engine entry points plus a
+re-export of the runtime-agnostic concurrency wrapper. No axum/tokio, no HTTP.
+
+- Data path (over one `&Graph` / `&mut Graph`): `embed::query_json(&Graph, sparql)
+  -> Result<String, _>` (SPARQL-JSON), `embed::query(&Graph, sparql) ->
+  Result<QueryResult, _>`, `embed::ask(&Graph, sparql) -> Result<bool, _>`,
+  `embed::update_in_place(&mut Graph, sparql)` (+ `..._atomic` for all-or-nothing on
+  one graph), `embed::apply_delta_nquads(&mut Graph, inserts, deletes)` (quad-level,
+  per-graph; blank nodes by label), and the probes `embed::exists(&Graph) -> bool`,
+  `embed::named_graph_exists(&Graph, &Term) -> bool`, `embed::metadata(&Graph) ->
+  Metadata { triples, named_graphs }`. `query_json_with_budget` takes a `QueryBudget`.
+- Concurrency wrapper (re-exported from the crate root): `GenerationRing` /
+  `Generation` / `GraphApplier` / `Writer` (+ `RingConfig`, `WriterConfig`, `PodId`,
+  `TimeTravelConfig`) — the SAME `fork → update → publish` + generation-pinning model
+  `sparq-server` wraps behind its endpoint. A reader `ring.current()` pins an
+  immutable snapshot; the writer publishes new generations without blocking readers.
+- **Stability:** the INTENDED stable embedding API, but **NOT yet a frozen
+  semver-tier-1 surface** — the formal freeze is the maintainer's to ratify on #1248
+  (pre-`1.0` minor releases MAY still change it). Pin to `sparq_serve::embed` rather
+  than reaching into `sparq-core` / `sparq-engine` directly so the freeze, when
+  ratified, has one well-defined shape.
+
 ## Common recipes
 
 **1. Query forms and result negotiation.** Default result media is SPARQL-JSON. Set


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-xa15c** for the PSS agent's in-process embedding ask in **#1248** (items 1 + 2), so `solid-server-rs` can embed SPARQ **in-process** instead of over the SPARQL-1.1-over-HTTP transport.

## What this ships (buildable-now, additive, default-off)

### Item 1 — the embedding facade
A new `sparq_serve::embed` module: a small, **documented** tier-1 facade over the existing engine entry points, matching the shapes PSS listed so an `EmbeddedSparqClient` binds cleanly:

- `embed::query_json(&Graph, sparql) -> Result<String>` (SPARQL-JSON) + `embed::query(..) -> QueryResult` + `query_json_with_budget`
- `embed::ask(&Graph, sparql) -> Result<bool>`
- `embed::update_in_place(&mut Graph, sparql)` (+ `update_in_place_atomic` for all-or-nothing on one graph)
- `embed::apply_delta_nquads(&mut Graph, inserts, deletes)` (quad-level, per-graph; blank nodes by label)
- existence / metadata probes: `embed::exists`, `embed::named_graph_exists`, `embed::metadata -> Metadata { triples, named_graphs }`

These are **thin re-exports / one-line wrappers** — no reimplementation, no new behaviour. Binding to this one module (instead of reaching into `sparq-core`/`sparq-engine` directly) buys the embedder a single place the maintainer intends to keep stable.

### Item 2 — the runtime-agnostic `GenerationRing` core
**The extraction was already done in a prior wave**: the runtime-agnostic core was factored out of `sparq-server`'s axum/tokio glue into `sparq-serve` as `pub GenerationRing<S>`; `sparq-server` already re-uses `sparq_serve::GenerationRing` and holds **no private copy** (verified: there is no `struct GenerationRing` anywhere in `sparq-server`). So there is already ONE implementation and zero semantic divergence.

This PR therefore (a) makes that core the **documented embedding front door** by re-exporting `GenerationRing` / `Generation` / `GraphApplier` / `Writer` (+ `RingConfig`, `WriterConfig`, `PodId`, `TimeTravelConfig`) through `embed`, and (b) adds the **missing regression test** the brief requires — see below.

## Additive / semver-pending stance
- **Purely additive.** No existing public API or behaviour of `sparq-server` (or its users) changes. All existing `sparq-server` (199 tests) and `sparq-serve` tests pass **unchanged**.
- **Semver honesty.** Documented in rustdoc + README + SKILL as the **INTENDED** stable embedding API, but **explicitly NOT a frozen semver-tier-1 surface** — the formal freeze is the maintainer's to ratify on #1248. Not unilaterally stamped frozen. No fabricated perf numbers.

## Regression test — `tests/embed_seam.rs`
Exercises the extracted core through the **real** `fork → update → publish` + generation-pinning path with a real `sparq_core::Graph` (the production `GraphApplier` + `update_in_place`), proving the load-bearing invariant the embedding seam relies on:

- `fork_update_publish_preserves_pinned_snapshot_and_advances_generations` — a reader pins generation 0, queries it via the facade (count = seed); a writer forks→updates→publishes 5 generations; the **pinned snapshot still returns the OLD answer**, generations advance by exactly 1, the touched pod's epoch bumps once per publish, read-your-writes tokens resolve correctly.
- `concurrent_reader_pins_consistent_snapshot_across_publishes` — a reader thread holds a pin and repeatedly queries it while a writer thread publishes 30 generations; the pinned snapshot **never changes** (count == seed + its own generation), and the current generation reflects every insert.

If a future refactor reintroduces a private ring copy in `sparq-server` or breaks fork/publish snapshot isolation, this test fails.

## Placement — why `sparq-serve` (a module, not a new crate)
`sparq-serve` is the only existing **sync, runtime-agnostic** crate that sees BOTH the engine entry points AND the `GenerationRing` without a dependency cycle (it already depends on `sparq-core` + `sparq-engine` and **owns** the ring). A module + re-exports here gives an equally clean surface with **far less gate overhead** than a new crate — no `gate-new-crate`, no new feature-matrix leg, no new `cargo-vet` exemption, no extra README/SKILL crate. The one added dependency (`oxrdf`, for the named-graph probe's `&Term`) is a workspace dep already exempted at the workspace level. **No new cargo feature.** `sparq-serve` stays out of `sparq-wasm`'s dependency graph (verified `cargo tree -p sparq-wasm | grep -c serve` = 0).

## Gates (green, both states)
- `cargo build` / `clippy --all-targets -D warnings` / `test` — green in **default** AND `--all-features` for `sparq-serve` and `sparq-server` (no new feature added; the matrix legs are unchanged).
- `rustdoc --workspace --no-deps --all-features` with `RUSTDOCFLAGS="-D warnings"` — clean (demoted the module-summary links to code spans per the doc-link rule).
- `readme-template` — 0 deviations; `sparq-serve/README.md` is exactly 120 lines.
- `check-privacy-claims`, `typos`, `terminology` — clean. feature-matrix assemble + golden test — pass (unchanged).

## Out of scope (PSS items 3 + 4)
Item 3 (WAC-as-a-call / `PodStore::query_as`) and item 4 (shared durable backend for active/active) are separately tracked; this PR closes the **data-path** embed (items 1 + 2). A P2 follow-up bead is filed for items 3 + 4.

Closes the data-path embed for #1248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)