### PR TITLE
feat(core): opt-in RDF/XML ingest in parse_to_triples (sq-f47w1, §B1) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3642,6 +3642,7 @@ dependencies = [
  "memmap2",
  "oxjsonld",
  "oxrdf 0.3.3",
+ "oxrdfxml",
  "oxttl 0.2.3",
  "rayon",
  "rustc-hash 2.1.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,11 @@ oxttl = { version = "0.2", features = ["rdf-12"] }
 # native-only deps, so it is safe in the lean wasm bundle). [OPUS-4.8] sq-dvyi: the
 # engine-side JSON-LD ingest the browser REPL's upload/URL path needs.
 oxjsonld = { version = "0.2", features = ["rdf-12"] }
+# RDF/XML parser (same oxigraph family; the version sparq-server already pins for its GSP
+# request-body reader + conformance harness, so it is proven in-tree). [OPUS-4.8] sq-f47w1
+# (survey §B1): the engine-side RDF/XML ingest gap — OPT-IN behind sparq-core's `rdfxml`
+# feature so the lean default / wasm build never links it (it pulls `quick-xml`).
+oxrdfxml = { version = "0.2", features = ["rdf-12"] }
 # SPARQL syntax -> algebra (we build the planner + physical execution ourselves).
 spargebra = { version = "0.4", features = ["sparql-12", "sep-0006"] }
 # Fast hashing / maps.

--- a/crates/sparq-core/Cargo.toml
+++ b/crates/sparq-core/Cargo.toml
@@ -49,6 +49,14 @@ block-bloom = []
 # whole-document JSON parse (not chunkable), so it has no parallel/streaming variant to
 # gate further. Consumers that want JSON-LD (the site REPL upload/URL path) enable this.
 jsonld = ["dep:oxjsonld"]
+# [OPUS-4.8] sq-f47w1 (survey §B1): RDF/XML ingest for the in-memory loaders
+# (`load_str` / `load_str_with_base` / `parse_to_triples`). OPT-IN and OFF by default,
+# mirroring `jsonld`, so the DEFAULT lean wasm bundle (which the perf-gate tracks via
+# `cargo build -p sparq-wasm`, no features) does NOT link `oxrdfxml` (it pulls `quick-xml`)
+# and stays under the wasm_bundle_bytes floor. RDF/XML is a whole-document XML parse (not
+# line-delimited / chunkable), so it has no parallel/streaming variant to gate further.
+# The dependency is already proven in-tree (sparq-server's GSP + conformance paths use it).
+rdfxml = ["dep:oxrdfxml"]
 # Spillable BUILD-time term dictionary (native only, off by default): bound the peak
 # build RSS by a configurable memory budget — term occurrences spill to disk and are
 # externally sorted/deduplicated into the SAME ids (byte-identical output) as the
@@ -71,6 +79,11 @@ oxttl.workspace = true
 # `jsonld` feature (OFF by default) so the tracked lean wasm bundle never links it and
 # stays under the wasm_bundle_bytes perf floor — the site REPL enables the feature.
 oxjsonld = { workspace = true, optional = true }
+# [OPUS-4.8] sq-f47w1 (survey §B1): RDF/XML ingest for the in-memory loaders. Same
+# oxigraph family as oxrdf/oxttl, OPT-IN behind the `rdfxml` feature (OFF by default) so
+# the tracked lean wasm bundle never links it (it pulls `quick-xml`) and stays under the
+# wasm_bundle_bytes perf floor. Already proven in-tree (sparq-server pins the same version).
+oxrdfxml = { workspace = true, optional = true }
 rustc-hash.workspace = true
 hashbrown.workspace = true
 rayon = { workspace = true, optional = true }

--- a/crates/sparq-core/README.md
+++ b/crates/sparq-core/README.md
@@ -30,9 +30,10 @@ assert_eq!(count, 1);
 ## ✨ Features
 
 - **RDF parsing & ingest** — load Turtle, N-Triples, N-Quads, and TriG from a `&str` or any
-  `Read`. `load_reader*` accepts any `Read`, so you can wrap a `gzip` / `bzip2` / `zstd`
-  decoder around your file and stream it in — sparq does not content-sniff or auto-decompress
-  ([guide](../../skills/data-formats/SKILL.md)).
+  `Read`; the opt-in `jsonld` and `rdfxml` features add JSON-LD and RDF/XML ingest (kept off
+  the lean default/wasm build). `load_reader*` accepts any `Read`, so you can wrap a `gzip` /
+  `bzip2` / `zstd` decoder around your file and stream it in — sparq does not content-sniff or
+  auto-decompress ([guide](../../skills/data-formats/SKILL.md)).
 - **Triple-pattern scans** — look up any triple pattern over the loaded graph.
 - **Incremental updates** — start from `Graph::new()` / `Graph::default()` (an empty graph) and
   `insert_triple(s, p, o)` / `remove_triple(s, p, o)` a single triple from `oxrdf` terms, or apply

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -32,6 +32,10 @@ type ChunkPartials = Vec<(Dict, Vec<[Id; 3]>)>;
 // default (lean) wasm bundle never links `oxjsonld`.
 #[cfg(feature = "jsonld")]
 use oxjsonld::JsonLdParser;
+// [OPUS-4.8] sq-f47w1 (survey §B1): RDF/XML parser is OPT-IN behind the `rdfxml` feature
+// so the default (lean) wasm bundle never links `oxrdfxml` (which pulls `quick-xml`).
+#[cfg(feature = "rdfxml")]
+use oxrdfxml::RdfXmlParser;
 use oxrdf::vocab::xsd;
 use oxrdf::{Literal, NamedNode, Term};
 use oxttl::{NQuadsParser, NTriplesParser, TriGParser, TurtleParser};
@@ -726,6 +730,18 @@ impl Graph {
                     push_triple!(&q.subject, &q.predicate, &q.object);
                 }
             }
+            // [OPUS-4.8] sq-f47w1 (survey §B1): RDF/XML. A whole-document XML parse (NOT
+            // line-oriented, so no parallel chunking applies) yielding TRIPLES — RDF/XML has
+            // no named-graph syntax, so nothing is folded. OPT-IN behind the `rdfxml` feature
+            // (keeps the lean bundle free of oxrdfxml / quick-xml). Same proven parser the
+            // sparq-server GSP write-body + conformance paths already use.
+            #[cfg(feature = "rdfxml")]
+            _ if is_rdfxml_format(format) => {
+                for t in RdfXmlParser::new().for_slice(bytes) {
+                    let t = t.map_err(|e| e.to_string())?;
+                    push_triple!(&t.subject, &t.predicate, &t.object);
+                }
+            }
             // [OPUS-4.8] (sq-m2pc) Turtle is gated on its explicit alias set — NOT a
             // catch-all — so a typo'd or unsupported `format` errors below instead of
             // silently parsing as Turtle and returning `Ok`.
@@ -808,6 +824,19 @@ impl Graph {
                 for q in parser.for_slice(bytes) {
                     let q = q.map_err(|e| e.to_string())?;
                     push_triple!(&q.subject, &q.predicate, &q.object);
+                }
+            }
+            // [OPUS-4.8] sq-f47w1 (survey §B1): RDF/XML with a document base — `rdf:ID`
+            // fragments and relative IRIs resolve against `base` (the URL load path). RDF/XML
+            // has no named graphs, so nothing is folded. OPT-IN behind the `rdfxml` feature.
+            #[cfg(feature = "rdfxml")]
+            _ if is_rdfxml_format(format) => {
+                let parser = RdfXmlParser::new()
+                    .with_base_iri(base)
+                    .map_err(|e| format!("invalid base IRI {base:?}: {e}"))?;
+                for t in parser.for_slice(bytes) {
+                    let t = t.map_err(|e| e.to_string())?;
+                    push_triple!(&t.subject, &t.predicate, &t.object);
                 }
             }
             // [OPUS-4.8] (sq-m2pc) Turtle is gated on its explicit alias set, mirroring
@@ -4019,6 +4048,18 @@ fn is_jsonld_format(format: &str) -> bool {
     matches!(format, "jsonld" | "json-ld" | "application/ld+json")
 }
 
+/// [OPUS-4.8] sq-f47w1 (survey §B1) Whether `format` names the RDF/XML serialization: the
+/// short key, the hyphenated spelling, and the IANA media type (`application/rdf+xml`, what
+/// an `Accept`-negotiated URL load reports). Kept in one place so every RDF/XML loader arm
+/// (`parse_to_triples` / `…_with_base`) recognises the same set. OPT-IN behind the `rdfxml`
+/// feature; every call site is gated on the same feature, so the helper is only compiled
+/// when RDF/XML is. When the feature is OFF these strings fall through to `unknown_format_err`
+/// (NOT mis-parsed as Turtle), exactly as a `"jsonld"` string does in a non-`jsonld` build.
+#[cfg(feature = "rdfxml")]
+fn is_rdfxml_format(format: &str) -> bool {
+    matches!(format, "rdfxml" | "rdf-xml" | "application/rdf+xml")
+}
+
 /// [OPUS-4.8] (sq-m2pc) Whether `format` names the Turtle serialization. The single
 /// authority for the Turtle alias set, kept in lock-step with the CLI's `is_known_format`.
 /// `parse_to_triples`/`parse_to_triples_with_base` previously fell back to Turtle for ANY
@@ -4060,10 +4101,13 @@ fn is_dataset_format(format: &str) -> bool {
 /// "unknown ⇒ Turtle" catch-all. The `jsonld` entry only appears when that opt-in
 /// feature is compiled in (the only build in which a "jsonld"/"json-ld" string parses).
 fn unknown_format_err(format: &str) -> String {
-    let known = if cfg!(feature = "jsonld") {
-        "turtle | ntriples | nquads | trig | jsonld"
-    } else {
-        "turtle | ntriples | nquads | trig"
+    // [OPUS-4.8] sq-f47w1: the `jsonld` / `rdfxml` entries only appear when their opt-in
+    // feature is compiled in (the only build in which those strings parse rather than error).
+    let known = match (cfg!(feature = "jsonld"), cfg!(feature = "rdfxml")) {
+        (true, true) => "turtle | ntriples | nquads | trig | jsonld | rdfxml",
+        (true, false) => "turtle | ntriples | nquads | trig | jsonld",
+        (false, true) => "turtle | ntriples | nquads | trig | rdfxml",
+        (false, false) => "turtle | ntriples | nquads | trig",
     };
     format!("unknown RDF format {format:?} (known: {known})")
 }
@@ -5744,6 +5788,155 @@ mod tests {
         assert!(Graph::load_str("{ not json", "jsonld").is_err());
     }
 
+    // [OPUS-4.8] sq-f47w1 (survey §B1) — RDF/XML ingest. These tests exercise the REAL
+    // `parse_to_triples` RDF/XML arm (not a mock), and are gated on the OPT-IN `rdfxml`
+    // feature so the lean default build (where `oxrdfxml` is not linked) does not see them.
+
+    /// A small RDF/XML document parses through `load_str` for EVERY accepted alias
+    /// (`rdfxml` / `rdf-xml` / `application/rdf+xml`) to the same triple set: an IRI object,
+    /// a plain literal, and a typed (`xsd:integer`) literal. Directly line-covers the new
+    /// dispatch arm + `is_rdfxml_format` matcher for the per-crate coverage ratchet.
+    #[cfg(feature = "rdfxml")]
+    #[test]
+    fn rdfxml_load_str_object() {
+        let doc = r#"<?xml version="1.0"?>
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                     xmlns:ex="http://ex/">
+              <rdf:Description rdf:about="http://ex/alice">
+                <ex:name>Alice</ex:name>
+                <ex:age rdf:datatype="http://www.w3.org/2001/XMLSchema#integer">30</ex:age>
+                <ex:knows rdf:resource="http://ex/bob"/>
+              </rdf:Description>
+            </rdf:RDF>"#;
+        for fmt in ["rdfxml", "rdf-xml", "application/rdf+xml"] {
+            let g = Graph::load_str(doc, fmt).unwrap_or_else(|e| panic!("{fmt}: {e}"));
+            assert_eq!(g.len(), 3, "{fmt}: subject has three predicates");
+            let terms = dump_terms(&g);
+            let has = |s: &str, p: &str, o: &str| {
+                terms.iter().any(|(ts, tp, to)| ts == s && tp == p && to == o)
+            };
+            assert!(
+                has("<http://ex/alice>", "<http://ex/name>", "\"Alice\""),
+                "{fmt}: name triple missing: {terms:?}"
+            );
+            assert!(
+                has(
+                    "<http://ex/alice>",
+                    "<http://ex/age>",
+                    "\"30\"^^<http://www.w3.org/2001/XMLSchema#integer>"
+                ),
+                "{fmt}: typed age triple missing: {terms:?}"
+            );
+            assert!(
+                has("<http://ex/alice>", "<http://ex/knows>", "<http://ex/bob>"),
+                "{fmt}: knows IRI triple missing: {terms:?}"
+            );
+        }
+    }
+
+    /// Relative IRIs / `rdf:ID` in an RDF/XML document resolve against the supplied base — the
+    /// URL load path (a document fetched from `https://host/dir/data.rdf`) relies on this.
+    /// Line-covers the `parse_to_triples_with_base` RDF/XML arm.
+    #[cfg(feature = "rdfxml")]
+    #[test]
+    fn rdfxml_load_str_with_base_resolves_relative() {
+        let doc = r#"<?xml version="1.0"?>
+            <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                     xmlns:ex="http://ex/knows#">
+              <rdf:Description rdf:about="alice">
+                <ex:knows rdf:resource="bob"/>
+              </rdf:Description>
+            </rdf:RDF>"#;
+        let g = Graph::load_str_with_base(doc, "rdfxml", "http://base.example/dir/").unwrap();
+        let terms = dump_terms(&g);
+        assert!(
+            terms.iter().any(|(s, p, o)| s == "<http://base.example/dir/alice>"
+                && p == "<http://ex/knows#knows>"
+                && o == "<http://base.example/dir/bob>"),
+            "relative IRIs must resolve against the base: {terms:?}"
+        );
+    }
+
+    /// Malformed RDF/XML surfaces a parse error (not a silent empty graph), so a loader can
+    /// report the failure inline rather than swallowing it.
+    #[cfg(feature = "rdfxml")]
+    #[test]
+    fn rdfxml_malformed_errors() {
+        // Not well-formed XML (unclosed element).
+        assert!(Graph::load_str("<rdf:RDF><not closed", "rdfxml").is_err());
+    }
+
+    /// ROUND-TRIP: a known graph serialised to RDF/XML (via `oxrdfxml::RdfXmlSerializer`, the
+    /// same writer the sparq-server GSP/conformance paths use) and parsed back through
+    /// `parse_to_triples` recovers the SAME triple set. This is the load-bearing invariant for
+    /// the arm — serialise→parse equivalence — so a future regression in the dispatch wiring or
+    /// term interning is caught. Covers an IRI object, a plain literal, a language-tagged
+    /// literal, and a typed literal (the term shapes RDF/XML must preserve).
+    #[cfg(feature = "rdfxml")]
+    #[test]
+    fn rdfxml_load_str_round_trip() {
+        use oxrdf::{Literal, NamedNode, Triple};
+        use oxrdfxml::RdfXmlSerializer;
+
+        // `Triple::new` takes `impl Into<Subject>` / `impl Into<Term>`, so a `NamedNode`
+        // converts directly — no need to name the deprecated `oxrdf::Subject` alias.
+        let s = NamedNode::new("http://ex/alice").unwrap();
+        let triples = vec![
+            Triple::new(
+                s.clone(),
+                NamedNode::new("http://ex/knows").unwrap(),
+                NamedNode::new("http://ex/bob").unwrap(),
+            ),
+            Triple::new(
+                s.clone(),
+                NamedNode::new("http://ex/name").unwrap(),
+                Literal::new_simple_literal("Alice"),
+            ),
+            Triple::new(
+                s.clone(),
+                NamedNode::new("http://ex/greeting").unwrap(),
+                Literal::new_language_tagged_literal("hi", "en").unwrap(),
+            ),
+            Triple::new(
+                s,
+                NamedNode::new("http://ex/age").unwrap(),
+                Literal::new_typed_literal(
+                    "30",
+                    NamedNode::new("http://www.w3.org/2001/XMLSchema#integer").unwrap(),
+                ),
+            ),
+        ];
+
+        // Serialise to RDF/XML. An in-memory writer cannot fail, so the `expect`s are inert.
+        let mut ser = RdfXmlSerializer::new().for_writer(Vec::new());
+        for t in &triples {
+            ser.serialize_triple(t.as_ref()).expect("serialise RDF/XML triple");
+        }
+        let bytes = ser.finish().expect("finish RDF/XML serialisation");
+        let xml = String::from_utf8(bytes).expect("RDF/XML serialiser emits UTF-8");
+
+        // Parse it back through the real dispatch and compare the recovered triple SET.
+        let g = Graph::load_str(&xml, "rdfxml")
+            .unwrap_or_else(|e| panic!("round-trip RDF/XML must re-parse, got {e}\n{xml}"));
+        let got: std::collections::BTreeSet<_> = dump_terms(&g).into_iter().collect();
+
+        let want: std::collections::BTreeSet<(String, String, String)> = [
+            ("<http://ex/alice>", "<http://ex/knows>", "<http://ex/bob>"),
+            ("<http://ex/alice>", "<http://ex/name>", "\"Alice\""),
+            ("<http://ex/alice>", "<http://ex/greeting>", "\"hi\"@en"),
+            (
+                "<http://ex/alice>",
+                "<http://ex/age>",
+                "\"30\"^^<http://www.w3.org/2001/XMLSchema#integer>",
+            ),
+        ]
+        .into_iter()
+        .map(|(s, p, o)| (s.to_string(), p.to_string(), o.to_string()))
+        .collect();
+
+        assert_eq!(got, want, "RDF/XML serialise→parse must round-trip the triple set");
+    }
+
     /// [OPUS-4.8] (sq-zz8z, gh-51) The graph-IRI prefix RANGE SCAN returns EXACTLY the named graphs
     /// whose `STR(name)` starts with the prefix, and its lazily-built cache stays coherent across
     /// add/remove (which change `named.len()`, the cache key) on the SAME graph object. Adjacent
@@ -6631,7 +6824,11 @@ mod tests {
 
         // Unknown / typo'd / unsupported strings now ERROR instead of silently parsing as
         // Turtle. Empty string is included — it must not be a Turtle alias either.
-        for bogus in ["bogusfmt", "turtl", "Turtle", "rdfxml", "n3", ""] {
+        // [OPUS-4.8] sq-f47w1 (survey §B1): `"rdfxml"` moved OUT of this always-bogus list —
+        // it is an accepted format when the OPT-IN `rdfxml` feature is built (asserted below /
+        // in `rdfxml_load_str_round_trip`), and only bogus when the feature is OFF (asserted in
+        // the `not(feature = "rdfxml")` block), exactly mirroring how `"jsonld"` is gated.
+        for bogus in ["bogusfmt", "turtl", "Turtle", "n3", ""] {
             // (`Result::Ok` carries `(Dict, Vec<…>)`, which is not `Debug`, so `expect_err`
             // cannot be used — match on the error directly.)
             let e = match Graph::parse_to_triples(ttl, bogus) {
@@ -6645,6 +6842,21 @@ mod tests {
             );
             // The public `load_str` wrappers propagate the same error.
             assert!(Graph::load_str(ttl, bogus).is_err(), "load_str must reject {bogus:?}");
+        }
+
+        // [OPUS-4.8] sq-f47w1: with the OPT-IN `rdfxml` feature OFF, the RDF/XML aliases are
+        // NOT recognised — they must ERROR (fall through to `unknown_format_err`), NOT be
+        // mis-parsed as Turtle, exactly as `"jsonld"` does in a non-`jsonld` build.
+        #[cfg(not(feature = "rdfxml"))]
+        for off in ["rdfxml", "rdf-xml", "application/rdf+xml"] {
+            assert!(
+                Graph::parse_to_triples(ttl, off).is_err(),
+                "without the `rdfxml` feature {off:?} must error"
+            );
+            assert!(
+                Graph::parse_to_triples_with_base(ttl, off, "http://base/").is_err(),
+                "without the `rdfxml` feature {off:?} (base) must error"
+            );
         }
     }
 
@@ -6677,7 +6889,13 @@ mod tests {
 
         // Unknown / typo'd / unsupported strings now ERROR instead of silently parsing as TriG.
         // `trg` is the load-bearing case: previously it hit the catch-all and parsed as TriG.
-        for bogus in ["bogusfmt", "trg", "TriG", "rdfxml", ""] {
+        // [OPUS-4.8] sq-f47w1 (survey §B1): `"rdfxml"` moved OUT of this list. RDF/XML has no
+        // named-graph syntax, so it is NOT a dataset format — `load_dataset_serial` rejects it
+        // regardless of the feature (asserted below, unconditionally), but the public
+        // `load_dataset` routes a non-dataset format to `load_str`, which ACCEPTS RDF/XML when
+        // the OPT-IN `rdfxml` feature is built, so the blanket `load_dataset(...).is_err()`
+        // assertion no longer holds for it. Handled in the dedicated block after this loop.
+        for bogus in ["bogusfmt", "trg", "TriG", ""] {
             let e = match Graph::load_dataset_serial(trig, bogus) {
                 Err(e) => e,
                 Ok(_) => panic!("unknown format {bogus:?} must error, not fall back to TriG"),
@@ -6688,6 +6906,16 @@ mod tests {
             assert!(
                 Graph::load_dataset(trig, bogus).is_err(),
                 "public load_dataset must reject {bogus:?}"
+            );
+        }
+
+        // [OPUS-4.8] sq-f47w1: the RDF/XML aliases are NOT dataset formats — `load_dataset_serial`
+        // (the per-graph serial reference) rejects them whether or not the `rdfxml` feature is
+        // built, because RDF/XML carries no named graphs and never reaches a quad-bearing parser.
+        for off in ["rdfxml", "rdf-xml", "application/rdf+xml"] {
+            assert!(
+                Graph::load_dataset_serial(trig, off).is_err(),
+                "RDF/XML {off:?} is not a dataset serial format — must error"
             );
         }
     }

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -32,6 +32,10 @@
 #                     stated EXPLICITLY so a future refactor that decouples dict-spill from
 #                     mmap cannot silently drop the security-code coverage this gate exists
 #                     to enforce. [OPUS-4.8]
+#                       * rdfxml      -> the OPT-IN RDF/XML parse arm in `parse_to_triples` /
+#                                       `…_with_base` (`#[cfg(feature = "rdfxml")]`) + its
+#                                       direct unit tests are otherwise compiled out / 0%.
+#                                       [OPUS-4.8] sq-f47w1 (survey §B1).
 #   - sparq-vectors   the two `*_recall_at_10_vs_brute_force_on_50k` tests (HNSW +
 #                     DiskANN) are EXCLUDED from the per-commit subset via `--skip`
 #                     (they dominate wall-clock under instrumentation). They are
@@ -223,8 +227,12 @@ measure_merged() {
   local -a features=("conformance-merge")
   local -a feat_flags=()
   # sparq-core keeps its mmap,dict-spill security surface (see PER-CRATE QUIRKS).
+  # [OPUS-4.8] sq-f47w1 (survey §B1): `rdfxml` is added so the OPT-IN RDF/XML parse arm
+  # (`#[cfg(feature = "rdfxml")]` in `parse_to_triples` / `…_with_base`) is COMPILED and its
+  # direct unit tests run, MEASURING the new lines for the coverage ratchet (without the
+  # feature those lines are cfg'd out and never enter the report).
   if [ "$crate" = "sparq-core" ]; then
-    feat_flags+=(--features mmap,dict-spill); features+=("mmap" "dict-spill")
+    feat_flags+=(--features mmap,dict-spill,rdfxml); features+=("mmap" "dict-spill" "rdfxml")
   fi
   local start end rc=0 json="$WORK/$crate.json" err="$WORK/$crate.err"
   start=$(date +%s)
@@ -320,7 +328,9 @@ measure() {
       # mmap is named EXPLICITLY (not relied on via the dict-spill -> mmap transitive
       # dep) so the on-disk-store security surface this gate guards is always compiled +
       # exercised. See the PER-CRATE QUIRKS header for the full rationale. [OPUS-4.8]
-      cargo_args+=(--features mmap,dict-spill); features+=("mmap" "dict-spill") ;;
+      # [OPUS-4.8] sq-f47w1: `rdfxml` so the OPT-IN RDF/XML parse arm is compiled + its
+      # direct tests run (measured by the ratchet); cfg'd out otherwise. Mirrors line 227.
+      cargo_args+=(--features mmap,dict-spill,rdfxml); features+=("mmap" "dict-spill" "rdfxml") ;;
     sparq-vectors)
       # Only skip the heavy 50k tests OUTSIDE the nightly/full tiers.
       if [ "$TIER" = "per-commit" ]; then

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -40,6 +40,11 @@ use sparq_core::Graph;
 //   without it those strings also error rather than mis-parsing. [OPUS-4.8] sq-oy1f.4: the
 //   `sparq-cli` and `sparq-server` BINARIES enable `jsonld` by DEFAULT (a maintainer-directed
 //   exception), so they read/write JSON-LD out of the box; a library embedder opts in explicitly.
+//   [OPUS-4.8] sq-f47w1 (survey §B1): RDF/XML ("rdfxml"/"rdf-xml"/"application/rdf+xml")
+//   likewise needs the OPT-IN `rdfxml` feature on `sparq-core` (OFF by default — it links
+//   `oxrdfxml`/`quick-xml`, kept off the lean wasm bundle); without it those strings error
+//   rather than mis-parsing. RDF/XML has no named-graph syntax, so it loads via `load_str` /
+//   `parse_to_triples` (not the dataset path), serial-only (XML is not line-delimited).
 let ttl = r#"@prefix ex: <http://ex/> .
 ex:alice ex:knows ex:bob ."#;
 let g = Graph::load_str(ttl, "turtle").expect("parse");


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-f47w1** (survey **§B1**: RDF/XML parsing in `sparq-core`) from `research/codebase-improvement-opportunities-2026-06-23.md`.

## What this does

`Graph::parse_to_triples` dispatched N-Triples / N-Quads / Turtle / TriG / JSON-LD but **RDF/XML was absent** — the format tests explicitly *rejected* `"rdfxml"`. `sparq-server` already serialises *and* parses RDF/XML via `oxrdfxml` (GSP write-body + conformance), so callers could round-trip RDF/XML through the server but could not parse it into a `sparq` `Graph` — a real W3C standard-syntax interop gap.

This wires `oxrdfxml::RdfXmlParser` into `parse_to_triples` and `parse_to_triples_with_base` under a new `is_rdfxml_format` matcher (`"rdfxml"` / `"rdf-xml"` / `"application/rdf+xml"`). RDF/XML has no named-graph syntax, so it loads via `load_str` / `parse_to_triples` (not the dataset path) and is **serial-only** (XML is not line-delimited / chunkable).

## Stance

- **Additive — no dispatch break.** The existing NT / NQ / Turtle / TriG / JSON-LD arms and their behaviour are **unchanged**; this only *adds* the RDF/XML arm and its matcher. The `unknown_format_err` known-list is extended only when the relevant opt-in feature is built.
- **No new dependency.** `oxrdfxml` is already proven in-tree (sparq-server pins the same `0.2` / `rdf-12`). No new crate enters the ecosystem; `memmap2` stays `0.9.11`; the only `Cargo.lock` change is adding the existing `oxrdfxml` to sparq-core's dep list.
- **OPT-IN feature, OFF by default.** Per the project's lean-core architectural constraint, the surface is gated behind a new `rdfxml` cargo feature, mirroring `jsonld` exactly — so the default / wasm bundle never links `oxrdfxml` (which pulls `quick-xml`) and stays under the `wasm_bundle_bytes` floor. With the feature OFF the RDF/XML aliases **error** (not mis-parse as Turtle), just like `"jsonld"` without its feature.

## Tests (the real path, not a mock)

Gated on `rdfxml`, calling the real `parse_to_triples` dispatch:
- `rdfxml_load_str_object` — direct coverage for **every** accepted format string (`rdfxml` / `rdf-xml` / `application/rdf+xml`); IRI object + plain literal + typed literal.
- `rdfxml_load_str_with_base_resolves_relative` — base-IRI / relative-IRI resolution (the `…_with_base` arm).
- `rdfxml_malformed_errors` — malformed input surfaces an `Err`, not a silent empty graph.
- `rdfxml_load_str_round_trip` — the load-bearing invariant: a graph serialised via `oxrdfxml::RdfXmlSerializer` then parsed back through `parse_to_triples` recovers the **same triple set** (IRI / plain / language-tagged / typed terms).

The `rdfxml`-OFF blocks in the two existing rejection tests assert the aliases still error rather than mis-parse.

## Gates (run in-worktree, BOTH feature states)

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — green with the `rdfxml` feature **OFF** (default) and **ON**.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `cargo +1.88 check` (workspace, default) and `cargo +1.88 check -p sparq-core --features rdfxml --tests` — MSRV 1.88 clean.
- Coverage: `COVERAGE_CRATES=sparq-core scripts/coverage.sh` (now measured with `rdfxml` on) → `coverage-gate.py --check-robust` → **`ok sparq-core 93.09% >= floor 90`**.
- `readme-template` (0 deviations, sparq-core README 63 lines), `check-terminology.py`, `check-privacy-claims.sh`, markdown `typos` — all clean.

## Docs

`crates/sparq-core/README.md` + `skills/data-formats/SKILL.md` note the opt-in `rdfxml` feature, its aliases, the no-named-graph / serial-only semantics, and the lean-bundle boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)