### PR TITLE
docs: honesty-reconcile survey §B2/§C1 + FINDINGS F21 against build-phase findings (sq-ygkhf, sq-gw8tq) [OPUS-4.8]

### DIFF
--- a/crates/sparq-conformance/FINDINGS.md
+++ b/crates/sparq-conformance/FINDINGS.md
@@ -73,7 +73,7 @@ Headline at sparq `454593c`+round-3 / rdf-tests `f25dbc0`, full scope (1229 test
 | SPARQL 1.0 query eval | 268 / 3 / 12 | 268 / 3 / 12 | unchanged (skips are FROM/FROM NAMED) |
 | SPARQL 1.1 query eval | 220 / 4 / 1 | 222 / 2 / 1 | +2: empty named graphs now registered |
 | SPARQL 1.1 update eval | 23 / 20 / 51 | **94 / 0 / 0** | F19: suite is 100%, zero skips |
-| 1.1 result formats | 6 / 1 / 0 | 6 / 1 / 0 | tsv03 = F21 (lexical preservation) |
+| 1.1 result formats | 6 / 1 / 0 | 6 / 1 / 0 | tsv03 = F21 (documented divergence, see below) |
 | SPARQL 1.2 eval | 25 / 41 / 0 | **65 / 1 / 0** | F14–F18; last fail is upstream-parser F20 |
 | syntax (1.0/1.1/1.2) | 550 / 4 / 0 | 550 / 4 / 0 | all F20 (spargebra 0.4.6 posture) |
 
@@ -125,8 +125,9 @@ not a leaked feature).
 
 - 5× **F20 upstream spargebra 0.4.6** (4 syntax-negative + the 1.2 grouping eval test
   that fails at parse) + *case-insensitive booleans* (F13).
-- 3× **lexical-form preservation / suite-convention conflicts**: *xsd:decimal cast*,
-  *tsv03* (F21), *SUM DISTINCT with GROUP BY* (canonical-vs-plain double, see round 2).
+- 3× **suite-convention conflicts** (expected file diverges, engine term is correct):
+  *xsd:decimal cast*, *tsv03* (F21 — TSV serialisation; the store already preserves data
+  lexical forms, see F21 below), *SUM DISTINCT with GROUP BY* (canonical-vs-plain double, round 2).
 - *"/" on mixed datatypes* (suites disagree on integer-division scale, round-2 note).
 - *dawg-optional-filter-005-not-simplified* (algebra-duality, round-2 note).
 
@@ -215,11 +216,21 @@ The syntax suites measure the parser dependency; sparq inherits these:
 Everything else parses cleanly: 550/554 — including all 113 positive triple-term
 documents, VERSION declarations and codepoint escapes.
 
-#### F21. Lexical forms of data terms not preserved — 1 test (`csv-tsv-res` tsv03)
-`"1.0e6"^^xsd:double` from the data comes back as `"1.0E6"` — the store normalises
-numeric lexical forms instead of preserving them; SPARQL requires bound values to keep
-the original lexical form. (Adjacent to round-1 F4 but the inverse: F4 wants
-*canonical* forms for computed values, F21 wants *preserved* forms for data values.)
+#### F21. `tsv03` — DOCUMENTED_DIVERGENCE (TSV serialisation, conformance-neutral)
+**Premise corrected by the build phase (PR #1258, sq-u79ee).** The earlier text here claimed
+"the store normalises numeric lexical forms instead of preserving them". That is **false** on
+current `main`: the load + projection path **already preserves** the original lexical form
+(`"1.0E6"^^xsd:double` → `1.0E6`, `"1.0e6"^^xsd:double` → `1.0e6`), so no `sparq-core` Dict
+change was needed. The single real gap was the SPARQL-Results **TSV** writer, which quoted every
+typed literal instead of abbreviating `xsd:integer`/`xsd:decimal`/`xsd:double`/`xsd:boolean` to
+their bare Turtle token; PR #1258 fixed that in `sparq_server::results::term_to_tsv`.
+
+`tsv03` itself stays a tracked DOCUMENTED_DIVERGENCE and is **conformance-neutral**: its expected
+file writes `1.0e6` for the data term `"1.0E6"^^xsd:double` (a *different* RDF term under identity
+projection), and the harness compares **parsed expected terms vs in-memory `QueryResult` terms**,
+never the serialised TSV string — so the divergence is a suite-convention mismatch, not a fixable
+engine failure. (Adjacent to round-1 F4 but the inverse: F4 wants *canonical* forms for computed
+values; F21 concerns *preserved* forms for data values, which the store already honours.)
 
 Other 1.2 notes: `sparql12/rdf11` (singleton bnode graphs, plain-vs-xsd:string) passes
 3/3; codepoint-escape evaluation passes 4/4 (+1 CONSTRUCT skip); 1.2 CONSTRUCT tests

--- a/research/codebase-improvement-opportunities-2026-06-23.md
+++ b/research/codebase-improvement-opportunities-2026-06-23.md
@@ -24,8 +24,9 @@ The single most concentrated cluster of real, high-leverage, buildable-now wins 
 but the code does **not** yet implement: per-block Bloom filters, Elias-Fano compressed-seek
 columns, and the exact-bitmap semi-join reducer. These are designed-and-prioritised but
 unbuilt. The second cluster is a small number of **standalone correctness/functionality gaps**
-(RDF/XML parse, lexical-form preservation, streaming Turtle serialisation, N3 `log:semantics`
-cycle-safety, SPARQL 1.2 `multiplicity()`).
+(RDF/XML parse, numeric/boolean TSV abbreviation, streaming Turtle serialisation, N3
+`log:semantics` cycle-safety, the `MULTIPLICITY()` algebra-device vendor extension). *Two of
+this cluster's original premises were corrected during the build phase — see §B2 and §C1.*
 
 Several headline "opportunities" in the raw set were **false-premise** and are dropped:
 SPARQL Protocol is *already* implemented in `sparq-server`; `$currentShape` is *already* bound
@@ -234,19 +235,26 @@ in `sparq-shacl`; per-predicate coverage and samples are *already* rendered in t
   dependency, trivial dispatch). **Measured by:** round-trip correctness and W3C RDF/XML test
   pass count.
 
-### B2. SPARQL 1.2 `multiplicity()` builtin function
+### B2. `MULTIPLICITY()` aggregate device — a vendor extension, *not* a 1.2 conformance gap
+- **Premise corrected by the build phase (PR #1257, sq-v411r).** This item originally claimed
+  "SPARQL 1.2 adds the standard `multiplicity()` function" and treated it as a *conformance* gap.
+  That was **wrong**: there is **no callable `multiplicity()` builtin** in the SPARQL 1.2 grammar
+  / `BuiltInCall` production, and **no W3C conformance suite** for one (verified against the
+  pinned `w3c/rdf-tests @ f25dbc0` — no `multiplicity` test directory). "multiplicity" appears
+  **only as algebra/semantics NOTATION** — the `card[Ω](μ)` device renamed `multiplicity(μ|Ω)` in
+  the §18.4 BGP-matching and Set-Function definitions (see `research/sparql12-engine.md` §1.4).
 - **Current state.** No `multiplicity` in the engine (the `multiplicity` references in
   `crates/sparq-engine/src/cs.rs` are the *cardinality-estimation* characteristic-set model, a
-  different concept). `research/sparql12-engine.md` §1.4 notes SPARQL 1.2 adds the standard
-  `multiplicity()` function (replacing the informal `card[Ω](μ)`) for accessing a solution's
-  group multiplicity inside an aggregate (e.g. `SUM(?x * multiplicity())`).
-- **Opportunity.** A standard SPARQL 1.2 function for full 1.2 conformance; small, side-effect
-  free.
-- **Approach.** Add the builtin in the aggregate evaluator (`aggregate.rs`): when an aggregate
-  argument contains `multiplicity()`, substitute the current group member's cardinality; wire
-  into function dispatch; verify against the SPARQL 1.2 suite cases.
-- **Feasibility.** buildable-now. **Crate:** `sparq-engine`. **Risk:** very low. **Measured
-  by:** SPARQL 1.2 `multiplicity` conformance-suite pass count.
+  different concept).
+- **What landed.** sparq ships `MULTIPLICITY()` as a **clearly-labelled VENDOR EXTENSION**
+  (reserved IRI `urn:sparq:fn:multiplicity`) that exposes the 1.2 algebra device inside an
+  aggregate argument (e.g. `SUM(?x * MULTIPLICITY())`), gated behind `sparql-12`. It is **not** a
+  conformance feature; the boundary is documented in the engine README, the `sparql-query` SKILL,
+  and `vendor/spargebra/SPARQ-PATCHES.md` §10. PR #1257 verified the existing
+  aggregate/grouping/subquery conformance lanes are unchanged (no regression).
+- **Feasibility.** delivered (additive, side-effect-free). **Crate:** `sparq-engine`. **Risk:**
+  very low. **Measured by:** existing aggregate/grouping/subquery suites stay green; there is no
+  `multiplicity` conformance suite to pass.
 
 ### B3. RDF 1.2 triple-term (quoted-triple) support in the RDF/JS surface
 - **Current state.** The engine parses/queries RDF-star, but the JS RDF/JS surface does not
@@ -286,21 +294,28 @@ in `sparq-shacl`; per-predicate coverage and samples are *already* rendered in t
 
 ## C. Accuracy / Conformance
 
-### C1. Lexical-form preservation for data-sourced literals (F21)
-- **Current state.** `crates/sparq-conformance/FINDINGS.md` F21 (lines 218–222): a data term
-  `"1.0e6"^^xsd:double` comes back as `"1.0E6"` — the store normalises numeric lexical forms,
-  but SPARQL 1.1 §18.2 requires a bound value drawn from the input data to **preserve its
-  original lexical form**. Documented as a real spec deviation (`csv-tsv-res/tsv03`), not yet a
-  standalone bead (the broad test epic `sq-bif` covers correctness generally, not this fix).
-- **Opportunity.** Preserve the original spelling for literals interned from source data and
-  emit it on projection/serialisation, falling back to canonical form for *computed* values.
-- **Approach.** Optional preserved-lexical-form field on literal terms, populated at parse/load
-  only; serialisers prefer it when present; careful coverage across JSON/CSV/TSV/XML in both
-  `sparq-engine` and `sparq-server`.
-- **Feasibility.** buildable-now. **Crate:** `sparq-core` (Dict) + `sparq-engine` (serialise).
-  **Risk:** low — additive, no hot-path impact; small per-unique-literal memory cost.
-  **Measured by:** `csv-tsv-res/tsv03` (and the F4 canonical-form sibling cases) passing without
-  regressing other result-format tests; SPARQL result-format suite delta.
+### C1. Spec-conformant numeric/boolean TSV abbreviation (F21)
+- **Premise corrected by the build phase (PR #1258, sq-u79ee).** This item originally claimed
+  "the store normalises numeric lexical forms" and proposed a `sparq-core` Dict change. A proven
+  repro on current `main` shows that is **false**: the N-Quads/Turtle load + projection path
+  **already preserves** the original lexical form (`"1.0E6"^^xsd:double` → `1.0E6`,
+  `"1.0e6"^^xsd:double` → `1.0e6`), and a computed double already serialises canonical. So **no
+  `sparq-core` Dict change was needed** — a preserved-lexical-form field would have been dead
+  storage, and the per-unique-literal memory cost flagged below is **not** incurred.
+- **What landed.** The single real, narrow gap was the SPARQL-Results **TSV** writer
+  (`sparq_server::results::term_to_tsv`), which quoted **every** typed literal instead of
+  abbreviating `xsd:integer`/`xsd:decimal`/`xsd:double`/`xsd:boolean` to their bare Turtle token
+  per the [W3C CSV/TSV results format](https://www.w3.org/TR/sparql11-results-csv-tsv/), matching
+  the oxigraph `sparesults` reference. CSV already wrote bare values; JSON/XML carry the full
+  term — all unaffected.
+- **`tsv03` stays a DOCUMENTED_DIVERGENCE (conformance-neutral).** The W3C `tsv03` expected file
+  writes `1.0e6` for the data term `"1.0E6"^^xsd:double` — a *different* RDF term under identity
+  projection. The conformance harness compares **parsed expected terms vs in-memory
+  `QueryResult` terms**, never the serialised TSV string, so this fix is conformance-neutral
+  there; `tsv03` remains a tracked divergence (now better explained), not a fixable failure.
+- **Feasibility.** delivered. **Crate:** `sparq-server` (serialise only — *not* `sparq-core`).
+  **Risk:** low — additive, no hot-path impact. **Measured by:** `csv-tsv-res` suite unchanged
+  (2 pass / 0 fail / 1 documented divergence), no SPARQL result-format regression.
 
 ### C2. Predicate-selectivity-aware cardinality in non-star federated joins
 - **Current state.** `crates/sparq-fedplan/src/plan.rs` `independence_estimate` (line 412+)
@@ -371,14 +386,16 @@ buildable-now beats gated.
    technique-fit; localised; reused by A4.
 3. **B1 — RDF/XML parsing** (`sparq-core`). Real standard-syntax gap; proven in-tree dependency;
    very low risk.
-4. **C1 — Lexical-form preservation (F21)** (`sparq-core`/`sparq-engine`). Concrete documented
-   conformance failure; narrow; not individually beaded.
+4. **C1 — Numeric/boolean TSV abbreviation (F21)** (`sparq-server`). Narrow serialiser gap; the
+   store already preserves data lexical forms, so *not* a `sparq-core` change (premise corrected,
+   PR #1258).
 5. **A7 — Streaming Turtle serialisation** (`sparq-engine`). Mostly refactor; real memory win
    for large CONSTRUCT/DESCRIBE; enables HTTP streaming.
 6. **A10 — N3 `log:semantics` cycle detection** (`sparq-reason`). Genuine safety/DoS fix for
    live resolvers; cheap, standard.
-7. **B2 — SPARQL 1.2 `multiplicity()`** (`sparq-engine`). Small standard-function gap; trivial,
-   suite-verified.
+7. **B2 — `MULTIPLICITY()` vendor extension** (`sparq-engine`). Exposes the 1.2 algebra device;
+   *not* a conformance gap (no `multiplicity()` builtin exists in the spec — premise corrected,
+   PR #1257).
 8. **C2 — Predicate-selectivity in fedplan non-star joins** (`sparq-fedplan`). Real estimate
    gap using stats already present; correctness-neutral.
 9. **A2 — Elias-Fano compressed-seek codec** (`sparq-core`). Highest *storage* upside but
@@ -485,7 +502,7 @@ buildable-now beats gated.
 > 🤖 **SPARQ agent** — Conclusion: the genuinely-open, high-value, buildable-now wins are
 > concentrated and few. Build the storage-layer trio the maintainer's own research already
 > blessed (**A1 Bloom, A3 bitmap semi-join, A2 Elias-Fano**), close the small standalone
-> correctness/functionality gaps (**B1 RDF/XML, C1 lexical preservation, B2 multiplicity,
-> A10 N3 cycle-safety, A7 streaming Turtle**), and fold the rest into existing epics rather
-> than spawning duplicate beads. Every perf claim here is a hypothesis to be confirmed on the
+> correctness/functionality gaps (**B1 RDF/XML, C1 TSV abbreviation, B2 `MULTIPLICITY()`
+> vendor extension, A10 N3 cycle-safety, A7 streaming Turtle**), and fold the rest into existing
+> epics rather than spawning duplicate beads. Every perf claim here is a hypothesis to be confirmed on the
 > canonical perf host (`sq-0g6g`); no numbers are asserted.

--- a/research/sparql12-engine.md
+++ b/research/sparql12-engine.md
@@ -120,7 +120,7 @@ Conformance nests: `"1.1"` ⊆ `"1.2-basic"` ⊆ `"1.2"`. Processors MAY treat u
 ### 1.4 Other deltas (federation, results, properties)
 
 - **Property paths**: unchanged in 1.2 (the grammar productions [94]–[102] are identical to 1.1).
-- **Aggregation**: no new aggregates; only editorial fixes to the Sum/Group/set-function definitions, plus the `multiplicity` function replacing `card[Ω](μ)` ([§18.4](https://www.w3.org/TR/sparql12-query/#x18-4-basic-graph-patterns)), and tightened `SELECT *` restriction under implicit grouping.
+- **Aggregation**: no new aggregates; only editorial fixes to the Sum/Group/set-function definitions, plus the `multiplicity(μ|Ω)` algebra **notation** renaming the informal `card[Ω](μ)` ([§18.4](https://www.w3.org/TR/sparql12-query/#x18-4-basic-graph-patterns)), and tightened `SELECT *` restriction under implicit grouping. (`multiplicity` is a semantics device, **not** a callable `BuiltInCall` — there is no `multiplicity()` builtin in the 1.2 grammar and no conformance suite for one; sparq exposes it as a labelled vendor extension `MULTIPLICITY()`, see PR #1257 / survey §B2.)
 - **Federated Query / SERVICE**: **no new SERVICE features.** [Federated Query Changes](https://www.w3.org/TR/sparql12-federated-query/) are editorial only ("RDF data model not data format", errata-fq-1 fix to the SERVICE+VALUES example, 1.1→1.2 reference bumps). Triple terms simply pass through `SERVICE`.
 - **Results formats**: now carry triple terms and base direction (see §4 below).
 - **Update**: triple-term/reifier syntax in `INSERT DATA`/`DELETE DATA`/templates; revised `LOAD` for documents containing a dataset ([Update Changes](https://www.w3.org/TR/sparql12-update/#a-changes-between-sparql-1-1-update-and-sparql-1-2-update)).


### PR DESCRIPTION
> 🤖 **SPARQ agent** — honesty-reconciliation docs fix for beads **sq-ygkhf** + **sq-gw8tq**. The autonomous improvement-survey's build phase proved **two of its own premises inaccurate**; this corrects the research/doc record so it stays honest. **DOC-ONLY** — no `crates/` source, no test changes. Cites the two proving PRs (**#1257**, **#1258**) so a reader can verify.

## Correction 1 — §B2 `multiplicity()` (sq-ygkhf, proven by #1257)

The survey §B2 and `research/sparql12-engine.md` §1.4 framed `multiplicity()` as "the standard SPARQL 1.2 function" and a **conformance** gap. That is **false**:

- There is **no callable `multiplicity()` builtin** in the SPARQL 1.2 grammar / `BuiltInCall` production, and **no W3C conformance suite** for one (verified in #1257 against the pinned `w3c/rdf-tests @ f25dbc0` — no `multiplicity` test directory).
- "multiplicity" appears **only as algebra/semantics NOTATION** — the `card[Ω](μ)` device renamed `multiplicity(μ|Ω)` in the §18.4 BGP-matching / Set-Function definitions.
- sparq ships `MULTIPLICITY()` as a **clearly-labelled vendor extension** (`urn:sparq:fn:multiplicity`), **not** a conformance feature.

Reconciled: survey §B2 (rewritten as "a vendor extension, *not* a 1.2 conformance gap"), the executive-summary / priority-list / conclusion references, and `research/sparql12-engine.md` §1.4 (`multiplicity` now stated as a semantics device, not a builtin).

## Correction 2 — §C1 / FINDINGS F21 (sq-gw8tq, proven by #1258)

The survey §C1 and `crates/sparq-conformance/FINDINGS.md` F21 said "the store normalises numeric lexical forms". That is **false** on current `main`:

- The load + projection path **already preserves** the original lexical form (`"1.0E6"^^xsd:double` → `1.0E6`, `"1.0e6"^^xsd:double` → `1.0e6`), so **no `sparq-core` Dict change was needed** (a preserved-lexical-form field would have been dead storage).
- The real gap was **spec-conformant numeric/boolean TSV abbreviation** in `sparq-server` (`term_to_tsv`), matching the oxigraph `sparesults` reference.
- `tsv03` stays a **DOCUMENTED_DIVERGENCE** and is **conformance-neutral**: the harness compares **parsed expected terms vs in-memory `QueryResult` terms**, never the serialised TSV string, and the expected file writes a different RDF term under identity projection.

Reconciled: survey §C1 (rewritten as "Spec-conformant numeric/boolean TSV abbreviation"), the priority-list entry (now `sparq-server`, not `sparq-core`/`sparq-engine`), and FINDINGS F21 prose + the result-formats table row + the round-3 conflict summary.

## Before → after (status/scoping wording)

| | before | after |
|---|---|---|
| §B2 | "SPARQL 1.2 adds the standard `multiplicity()` function" / conformance gap | algebra-device **vendor extension** `MULTIPLICITY()`; no spec builtin, no suite |
| §C1 | "the store normalises numeric lexical forms" / `sparq-core` Dict fix | store **already preserves**; narrow `sparq-server` TSV-serialiser fix |
| F21 | "the store normalises … instead of preserving" | premise corrected; `tsv03` = conformance-neutral DOCUMENTED_DIVERGENCE |
| §1.4 | "`multiplicity` function replacing `card[Ω](μ)`" | "`multiplicity(μ|Ω)` algebra **notation**", not a callable `BuiltInCall` |

## Honesty framing

Each correction is framed as **"the build phase corrected this"** and cites the proving PR — no overclaim, no laundering of a verdict into a clean bill of health. No unqualified ZK/MPC privacy/soundness claim is introduced (this PR touches none).

## Gates (run in-worktree, all green)

- `scripts/check-terminology.py` — clean.
- `typos` (1.47.2) on all three changed files — clean.
- `markdownlint-cli2` over the full doc surface (249 files) — **0 errors**.
- `scripts/check-no-perf-numbers.py` — 0 findings; `scripts/check-privacy-claims.sh` — OK, no unqualified ZK/MPC claim.
- No README touched (no `readme-template` exposure).

Closes sq-ygkhf, sq-gw8tq.

🤖 Generated with [Claude Code](https://claude.com/claude-code)