### PR TITLE
feat(site): bold dark-first design foundation (redesign)

### DIFF
--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -54,6 +54,27 @@
   --sidebar-accent-foreground: oklch(0.24 0.05 215);
   --sidebar-border: oklch(0.91 0.012 220);
   --sidebar-ring: oklch(0.52 0.094 205);
+
+  /* [OPUS-4.8] sq-vw3ax (bold redesign foundation) — derived BOLD-direction tokens.
+     All are mixed/derived from the existing OKLCH teal palette above; NO new hue is
+     invented. They power the atmospheric glow, the hero gradient, hairline rules, and
+     the elevation scale that the home/try/capabilities redesigns build on. Light values
+     here; the .dark strip below carries the lead (dark-first) values. */
+  --teal-glow: oklch(0.52 0.094 205 / 0.25);
+  --teal-soft: color-mix(in oklch, var(--primary) 10%, transparent);
+  --hairline: oklch(0 0 0 / 7%);
+  --hero-grad: linear-gradient(
+    105deg,
+    var(--primary) 10%,
+    var(--chart-2) 70%,
+    var(--chart-5) 130%
+  );
+
+  /* elevation / shadow scale — soft, teal-tinted depth (subtle in light) */
+  --elevation-1: 0 1px 2px 0 oklch(0.21 0.022 235 / 0.06);
+  --elevation-2: 0 8px 24px -16px oklch(0.21 0.022 235 / 0.18);
+  --elevation-3: 0 18px 40px -28px oklch(0.21 0.022 235 / 0.22);
+  --elevation-glow: 0 24px 50px -34px var(--teal-glow);
 }
 
 .dark {
@@ -101,6 +122,20 @@
   --sidebar-accent-foreground: oklch(0.96 0.006 210);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.7 0.1 200);
+
+  /* [OPUS-4.8] sq-vw3ax — dark-first LEAD values for the bold-direction tokens. The
+     glow is more present and the hairline brighter against the deep teal-charcoal
+     ground, matching the approved mockups (proposals/web-{home,try,capabilities}.html).
+     Still strictly inside the existing OKLCH teal palette — no new hue. */
+  --teal-glow: oklch(0.7 0.1 200 / 0.45);
+  --teal-soft: color-mix(in oklch, var(--primary) 14%, transparent);
+  --hairline: oklch(1 0 0 / 8%);
+
+  /* elevation scale — deeper, teal-tinted shadows read on the dark ground */
+  --elevation-1: 0 1px 0 0 var(--hairline) inset;
+  --elevation-2: 0 18px 40px -34px var(--teal-glow);
+  --elevation-3: 0 30px 80px -40px var(--teal-glow);
+  --elevation-glow: 0 24px 50px -34px var(--teal-glow);
 }
 
 @theme inline {
@@ -139,6 +174,16 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
 
+  /* [OPUS-4.8] sq-vw3ax — expose the bold-direction derived tokens to Tailwind so the
+     redesign layouts can use `border-hairline`, `bg-teal-soft`, `shadow-elevation-2`,
+     etc. These are colour/shadow aliases of the OKLCH teal tokens — no new hue. */
+  --color-hairline: var(--hairline);
+  --color-teal-soft: var(--teal-soft);
+  --shadow-elevation-1: var(--elevation-1);
+  --shadow-elevation-2: var(--elevation-2);
+  --shadow-elevation-3: var(--elevation-3);
+  --shadow-elevation-glow: var(--elevation-glow);
+
   --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   --font-heading: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   --font-mono: ui-monospace, "SFMono-Regular", "Menlo", monospace;
@@ -175,6 +220,97 @@
 
 @utility measure {
   max-width: 65ch;
+}
+
+/* [OPUS-4.8] sq-vw3ax — BOLD DARK-FIRST FOUNDATION utilities.
+   The shared visual language extracted VERBATIM from the approved mockups
+   (sparq-design-system/proposals/web-{home,try,capabilities}.html). These are the base
+   the home/try/capabilities surface redesigns build on; they are OPT-IN (a page must add
+   the class), so un-redesigned routes are unaffected. All effects are pure CSS — no
+   runtime, no new dependency — and read in BOTH themes via the design tokens above.
+   ──────────────────────────────────────────────────────────────────────────────── */
+@layer components {
+  /* Atmospheric ground: a fixed, layered radial teal/cyan glow. Sits behind content
+     (z-index:-1), inert to pointer events. Reads as a deliberate brand statement on the
+     dark ground and a soft tint in light. Mount once near the top of a redesigned page. */
+  .bg-atmos {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    background:
+      radial-gradient(
+        70rem 40rem at 72% -8%,
+        color-mix(in oklch, var(--primary) 22%, transparent),
+        transparent 60%
+      ),
+      radial-gradient(
+        55rem 38rem at 4% 8%,
+        color-mix(in oklch, var(--chart-2) 14%, transparent),
+        transparent 55%
+      );
+  }
+
+  /* Faint masked grid for depth — fades out radially so it never competes with content. */
+  .bg-grid {
+    position: fixed;
+    inset: 0;
+    z-index: -1;
+    pointer-events: none;
+    opacity: 0.5;
+    background-image:
+      linear-gradient(to right, var(--hairline) 1px, transparent 1px),
+      linear-gradient(to bottom, var(--hairline) 1px, transparent 1px);
+    background-size: 56px 56px;
+    -webkit-mask-image: radial-gradient(
+      60rem 50rem at 60% 0%,
+      #000 30%,
+      transparent 75%
+    );
+    mask-image: radial-gradient(60rem 50rem at 60% 0%, #000 30%, transparent 75%);
+  }
+
+  /* Hero gradient text — clips the --hero-grad (primary → chart-2 → chart-5) to glyphs. */
+  .text-gradient {
+    background: var(--hero-grad);
+    -webkit-background-clip: text;
+    background-clip: text;
+    color: transparent;
+  }
+
+  /* Display headline scale — the clamp() responsive display type the redesign hero uses. */
+  .display-1 {
+    font-size: clamp(2.6rem, 6.2vw, 4.5rem);
+    line-height: 1.02;
+    letter-spacing: -0.035em;
+    text-wrap: balance;
+  }
+  .display-2 {
+    font-size: clamp(2rem, 4.4vw, 3rem);
+    line-height: 1.05;
+    letter-spacing: -0.03em;
+    text-wrap: balance;
+  }
+
+  /* Mono section kicker — the small uppercase teal label above each section title. */
+  .kicker {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
+    color: var(--primary);
+  }
+}
+
+/* Elevation helpers usable as plain classes (in addition to the Tailwind shadow-* aliases). */
+@utility elevation-2 {
+  box-shadow: var(--elevation-2);
+}
+@utility elevation-3 {
+  box-shadow: var(--elevation-3);
+}
+@utility elevation-glow {
+  box-shadow: var(--elevation-glow);
 }
 
 /* [OPUS-4.8] sq-gum8 — scoped styling for the build-time Typst HTML export rendered on a

--- a/site/src/app/layout.tsx
+++ b/site/src/app/layout.tsx
@@ -77,10 +77,20 @@ export default function RootLayout({
         />
       </head>
       <body className={`${inter.variable} font-sans antialiased`}>
+        {/* [OPUS-4.8] sq-vw3ax — DARK-FIRST default (the approved bold redesign direction).
+            Was `defaultTheme="system"` + `enableSystem`; the lead is now genuinely dark to
+            match the mockups (proposals/web-{home,try,capabilities}.html lead in .dark).
+            `enableSystem` is turned OFF so a no-preference visitor gets the dark lead rather
+            than their OS scheme; the ThemeToggle still flips to light and persists the
+            choice (next-themes localStorage), so the light toggle keeps working. This is
+            SAFE for un-redesigned routes: every page already renders coherently under the
+            complete `.dark` OKLCH palette in globals.css. The atmospheric .bg-atmos/.bg-grid
+            utilities are OPT-IN per page, so this flip changes only the default colour
+            scheme, never any page's structure. */}
         <ThemeProvider
           attribute="class"
-          defaultTheme="system"
-          enableSystem
+          defaultTheme="dark"
+          enableSystem={false}
           disableTransitionOnChange
         >
           <TooltipProvider>

--- a/site/src/components/ui/badge.tsx
+++ b/site/src/components/ui/badge.tsx
@@ -6,8 +6,16 @@ import { cn } from "@/lib/utils";
 
 // Pill badge (rounded-4xl, h-5) — the tier badges ("Live in your tab" / "Hosted" /
 // "Walkthrough") reuse the success/warning/muted tokens.
+//
+// [OPUS-4.8] sq-vw3ax — bolder spec from the synced design-system card
+// (sparq-design-system/components/badge.html). Two purely-additive upgrades, NO API break:
+//   1. a focus-visible ring (ring-3 ring-ring/50, offset by the background) so the asChild
+//      link/button case is keyboard-visible — the one consistency gap vs Button, which the
+//      card flagged. Inert for non-focusable spans.
+//   2. a `count` variant (min-w + centred padding + tabular figures) for numeric pills, so
+//      single/double-digit counts stay aligned. Default variant unchanged.
 const badgeVariants = cva(
-  "inline-flex items-center justify-center rounded-4xl h-5 px-2 text-xs font-medium w-fit whitespace-nowrap shrink-0 gap-1 [&>svg]:size-3",
+  "inline-flex items-center justify-center rounded-4xl h-5 px-2 text-xs font-medium w-fit whitespace-nowrap shrink-0 gap-1 [&>svg]:size-3 transition-shadow outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background",
   {
     variants: {
       variant: {
@@ -20,6 +28,9 @@ const badgeVariants = cva(
           "bg-[color-mix(in_oklch,var(--warning)_18%,transparent)] text-[color-mix(in_oklch,var(--warning)_80%,var(--foreground))]",
         muted: "bg-muted text-muted-foreground",
       },
+      count: {
+        true: "min-w-5 px-1.5 tabular-nums",
+      },
     },
     defaultVariants: { variant: "default" },
   },
@@ -28,13 +39,18 @@ const badgeVariants = cva(
 function Badge({
   className,
   variant,
+  count,
   asChild = false,
   ...props
 }: React.ComponentProps<"span"> &
   VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
   const Comp = asChild ? Slot.Root : "span";
   return (
-    <Comp data-slot="badge" className={cn(badgeVariants({ variant }), className)} {...props} />
+    <Comp
+      data-slot="badge"
+      className={cn(badgeVariants({ variant, count }), className)}
+      {...props}
+    />
   );
 }
 

--- a/site/src/components/ui/button.tsx
+++ b/site/src/components/ui/button.tsx
@@ -6,12 +6,20 @@ import { cn } from "@/lib/utils";
 
 // Compact sizing + tinted (not solid) destructive + active nudge — copied from
 // solid-pod-manager's Button conventions.
+//
+// [OPUS-4.8] sq-vw3ax — bolder spec from the synced design-system card
+// (sparq-design-system/components/button.html) + the mockup .btn-primary glow. Additive
+// only, NO API break: the focus ring gains a 2px background offset (crisper halo, matches
+// the card), and the `default` (primary) variant carries a soft teal elevation glow that
+// lifts on hover — the brand statement the bold direction asks for. All other variants and
+// every existing call site are unchanged.
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-all outline-none focus-visible:ring-3 focus-visible:ring-ring/50 active:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg text-sm font-medium transition-all outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background active:translate-y-px disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0",
   {
     variants: {
       variant: {
-        default: "bg-primary text-primary-foreground hover:bg-primary/90",
+        default:
+          "bg-primary text-primary-foreground hover:bg-primary/90 shadow-[var(--elevation-glow)] hover:shadow-[0_14px_38px_-8px_var(--teal-glow)]",
         destructive:
           "bg-destructive/10 text-destructive hover:bg-destructive/20",
         outline:

--- a/site/src/components/ui/card.tsx
+++ b/site/src/components/ui/card.tsx
@@ -3,12 +3,18 @@ import { cn } from "@/lib/utils";
 
 // Card uses `ring-1 ring-foreground/10` instead of a border + rounded-xl
 // (solid-pod-manager convention).
+//
+// [OPUS-4.8] sq-vw3ax — bolder spec from the synced card (components/card.html): the flat
+// `shadow-sm` becomes the teal-tinted `--elevation-1` token so depth reads consistently in
+// BOTH themes (a soft drop in light, a hairline inset on the dark ground). Same ring, same
+// radius, same API — every existing call site is unchanged. Pages that want the hover-lift
+// treatment from the mockups add it via className (e.g. `hover:shadow-elevation-2`).
 function Card({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="card"
       className={cn(
-        "bg-card text-card-foreground flex flex-col gap-4 rounded-xl py-5 ring-1 ring-foreground/10 shadow-sm",
+        "bg-card text-card-foreground flex flex-col gap-4 rounded-xl py-5 ring-1 ring-foreground/10 shadow-[var(--elevation-1)]",
         className,
       )}
       {...props}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — the shared **BOLD DARK-FIRST visual FOUNDATION** for the sparq website (`site/`), the base the home/try/capabilities surface redesigns build on. The maintainer approved the bold direction; this PR ships the foundation only — **the surface page layouts follow** in later PRs (the `sq-vw3ax` children).

Design proposals (the approved target visual language): the inline CSS in `sparq-design-system/proposals/web-home.html`, `web-try.html`, `web-capabilities.html` (the [claude.ai/design](https://claude.ai/design) bold-redesign mockups), plus the synced design-system cards under `foundations/*` + `components/*`.

## What this PR adds (foundation only)

**`globals.css` — tokens + utilities (both themes, NO new hue)**
- Derived BOLD-direction tokens for **both** themes (light `:root` + dark `.dark` lead), all `color-mix`/derived from the existing **OKLCH teal palette**: `--teal-glow`, `--teal-soft`, `--hairline`, `--hero-grad` (`--primary → --chart-2 → --chart-5`), and an **elevation/shadow scale** (`--elevation-1..3` + `--elevation-glow`), exposed to Tailwind as `shadow-elevation-*` / `border-hairline` / `bg-teal-soft` aliases.
- Pure-CSS, **opt-in** foundation utilities (no runtime, no new dep): `.bg-atmos` (layered radial teal/cyan glow), `.bg-grid` (masked faint grid), `.text-gradient` (hero gradient text), `.display-1`/`.display-2` (`clamp()` display type), `.kicker` (mono section label), `elevation-*` helpers.

**`layout.tsx` — DARK-FIRST default**
- `defaultTheme` `"system"` → `"dark"` with `enableSystem` off, so the lead is genuinely dark per the approved direction. The **light `ThemeToggle` still works** and persists (next-themes localStorage).

**Primitives — additive, NO API/prop break (all existing call sites compile)**
- `badge.tsx`: a `focus-visible` ring (closes the `asChild` link/button a11y gap the synced badge card flagged) + a `count` variant (min-width + `tabular-nums`) for numeric pills.
- `button.tsx`: crisper focus ring (background offset) + a soft **teal elevation glow** on the primary variant that lifts on hover.
- `card.tsx`: flat `shadow-sm` → teal-tinted `--elevation-1` token so depth reads in **both** themes.

## Why this is safe for un-redesigned pages
The dark-first flip only changes the **default colour scheme** — every existing route already renders coherently under the complete `.dark` OKLCH palette in `globals.css`. The atmospheric `.bg-atmos`/`.bg-grid` utilities are **opt-in per page**, so no page's structure changes; only home/try/capabilities will add them when their layouts land.

## Gates (all green, run locally)
- **WASM prereq**: built `js/ → npm run build:wasm` (build artifact only, no `crates/` changes) and synced into `public/wasm/`.
- `npm run build`: green — **all 52 pages / every route** (`/`, `/about`, `/app`, `/benchmarks/*`, `/capabilities`, `/download`, `/examples`, `/gui`, `/papers/*`, `/showcase/*`, `/surface/*`, `/try`) exported into `out/` with `basePath /sparq` intact.
- `next lint`: clean. `tsc` (via the Next build): clean — no `any`-escape hatches.
- **No fabricated numbers**; no marketing copy touched (so no new ZK/MPC claims to caveat). The unrelated `benchmarks.generated.json` prebuild refresh was intentionally **not** staged — this PR is design-foundation only.

auto-merge intentionally **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)