### PR TITLE
feat(gui): bold dark-first desktop redesign

### DIFF
--- a/gui/app/src/app/globals.css
+++ b/gui/app/src/app/globals.css
@@ -51,6 +51,15 @@
   --sidebar-accent-foreground: oklch(0.24 0.05 215);
   --sidebar-border: oklch(0.91 0.012 220);
   --sidebar-ring: oklch(0.52 0.094 205);
+
+  /* [OPUS-4.8] sq-vw3ax / #820 redesign — derived teal-forward surfaces for the bold dark-first
+     workbench chrome. Each is a MIX of the existing brand `--primary` (no new hue invented),
+     so it follows the theme automatically and adds no palette. Translated from the approved
+     desktop-gui.html proposal; light-theme strengths kept slightly softer than dark. */
+  --teal-glow: color-mix(in oklch, var(--primary) 30%, transparent);
+  --teal-faint: color-mix(in oklch, var(--primary) 8%, transparent);
+  --teal-line: color-mix(in oklch, var(--primary) 22%, transparent);
+  --hero-from: color-mix(in oklch, var(--primary) 9%, var(--card));
 }
 
 .dark {
@@ -92,6 +101,13 @@
   --sidebar-accent-foreground: oklch(0.96 0.006 210);
   --sidebar-border: oklch(1 0 0 / 10%);
   --sidebar-ring: oklch(0.7 0.1 200);
+
+  /* [OPUS-4.8] sq-vw3ax / #820 redesign — the DARK lead. Teal-forward surfaces pushed harder
+     than the light strip (the proposal's dark block is the lead). Still pure mixes of --primary. */
+  --teal-glow: color-mix(in oklch, var(--primary) 38%, transparent);
+  --teal-faint: color-mix(in oklch, var(--primary) 12%, transparent);
+  --teal-line: color-mix(in oklch, var(--primary) 26%, transparent);
+  --hero-from: color-mix(in oklch, var(--primary) 16%, var(--background));
 }
 
 @theme inline {
@@ -124,6 +140,13 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
+
+  /* [OPUS-4.8] sq-vw3ax / #820 redesign — expose the derived teal surfaces as Tailwind colours
+     (bg-teal-faint / border-teal-line / text-teal-glow …) for the bold chrome components. */
+  --color-teal-glow: var(--teal-glow);
+  --color-teal-faint: var(--teal-faint);
+  --color-teal-line: var(--teal-line);
+  --color-hero-from: var(--hero-from);
 
   --font-sans: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
   --font-mono: ui-monospace, "SFMono-Regular", "Menlo", monospace;
@@ -188,5 +211,127 @@
   .sq-tok-comment {
     color: var(--muted-foreground);
     font-style: italic;
+  }
+
+  /* ==========================================================================
+     [OPUS-4.8] sq-vw3ax / #820 redesign — the BOLD dark-first workbench chrome.
+     Faithful to /home/ubuntu/sparq-design-system/proposals/desktop-gui.html: a
+     native-feeling titlebar, a teal-forward top bar, an accent-lit Run button,
+     a teal-capped result/status atmosphere — all from the existing OKLCH tokens
+     (the --teal-* surfaces above), so light + dark follow the theme.
+     ========================================================================== */
+
+  /* (1) Native title bar — a thin branded strip with a subtle vertical sheen. */
+  .sq-titlebar {
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklch, var(--card) 82%, var(--background)),
+      var(--card)
+    );
+  }
+
+  /* (2) Top bar — the teal-forward hero gradient (the brand as identity, not garnish). */
+  .sq-topbar {
+    background: linear-gradient(180deg, var(--hero-from), var(--card));
+  }
+
+  /* The brand wordmark's teal full-stop. */
+  .sq-brand-dot {
+    color: var(--primary);
+  }
+
+  /* The primary Run / Import button: a lit teal gradient with an ambient glow. */
+  .sq-glow-btn {
+    background: linear-gradient(
+      180deg,
+      color-mix(in oklch, var(--primary) 90%, white),
+      var(--primary)
+    );
+    color: var(--primary-foreground);
+    box-shadow:
+      0 0 22px -6px var(--teal-glow),
+      0 1px 0 0 oklch(1 0 0 / 20%) inset;
+  }
+  .sq-glow-btn:hover {
+    filter: brightness(1.04);
+  }
+
+  /* The accent spine on the active rail tool / IDE tab — a teal bar with a soft glow. */
+  .sq-active-spine {
+    position: relative;
+    background: linear-gradient(90deg, var(--teal-faint), transparent 80%);
+  }
+  .sq-active-spine::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 6px;
+    bottom: 6px;
+    width: 2.5px;
+    border-radius: 2px;
+    background: var(--primary);
+    box-shadow: 0 0 10px var(--primary);
+  }
+
+  /* Status bar — a quiet card gradient strip carrying the measured/disk/ingest fields. */
+  .sq-statusbar {
+    background: linear-gradient(
+      180deg,
+      var(--card),
+      color-mix(in oklch, var(--card) 80%, var(--background))
+    );
+  }
+
+  /* The #820 disk-usage ring — a tiny conic gauge whose filled arc is set inline
+     (`--disk-pct`) from the REAL store footprint; never a baked-in figure. */
+  .sq-disk-ring {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background: conic-gradient(
+      var(--primary) 0 calc(var(--disk-pct, 0) * 1%),
+      var(--secondary) calc(var(--disk-pct, 0) * 1%) 100%
+    );
+    -webkit-mask: radial-gradient(circle 3px at center, transparent 99%, #000 100%);
+    mask: radial-gradient(circle 3px at center, transparent 99%, #000 100%);
+  }
+
+  /* The #820 ingest meter — an indeterminate sweep while a real ingest is in flight (no
+     fabricated %); the loader is synchronous, so the bar conveys "working", with the
+     measured elapsed shown beside it as text. */
+  .sq-ingest-bar {
+    width: 72px;
+    height: 4px;
+    border-radius: 999px;
+    background: var(--secondary);
+    overflow: hidden;
+  }
+  .sq-ingest-fill {
+    display: block;
+    height: 100%;
+    width: 40%;
+    border-radius: 999px;
+    background: linear-gradient(
+      90deg,
+      var(--primary),
+      color-mix(in oklch, var(--primary) 50%, var(--success))
+    );
+    box-shadow: 0 0 8px var(--teal-glow);
+    animation: sq-ingest-sweep 1.1s ease-in-out infinite;
+  }
+  @keyframes sq-ingest-sweep {
+    0% {
+      transform: translateX(-120%);
+    }
+    100% {
+      transform: translateX(280%);
+    }
+  }
+
+  /* Teal-capped sticky result-table header (the IDE typographic rhythm of the proposal). */
+  .sq-result-head th {
+    color: var(--primary);
+    border-bottom-color: var(--teal-line);
+    background: color-mix(in oklch, var(--card) 84%, var(--background));
   }
 }

--- a/gui/app/src/components/workbench/left-rail.tsx
+++ b/gui/app/src/components/workbench/left-rail.tsx
@@ -99,13 +99,14 @@ function DatasetsTree() {
       )}
 
       {/* [OPUS-4.8] sq-ixc3.13 — the working "+ Import" entry point (opens the Import drawer). */}
+      {/* [OPUS-4.8] sq-vw3ax (#820 redesign) — a dashed teal "drop zone" affordance for import. */}
       <button
         onClick={() => setOpen(true)}
-        className="mt-1 flex w-full items-center gap-1.5 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-sidebar-accent/40 hover:text-foreground"
+        className="mt-2 flex w-full items-center gap-1.5 rounded-md border border-dashed border-teal-line px-2 py-1.5 text-xs text-muted-foreground hover:bg-teal-faint hover:text-foreground"
         title="Import RDF from a disk file (compressed / HDT), a URL, or pasted text"
         data-import-trigger="rail"
       >
-        <Plus className="size-3" /> Import
+        <Plus className="size-3" /> Import data…
       </button>
     </div>
   );
@@ -140,7 +141,7 @@ export function LeftRail({ tools, activeId, onOpenTool }: LeftRailProps) {
           className="flex w-full items-center gap-1.5 rounded-md border bg-background px-2 py-1.5 text-left text-xs hover:bg-sidebar-accent/40"
           title="Workspace switcher — persistent workspaces are a later phase (sq-atb0)"
         >
-          <Circle className="size-2.5 fill-[var(--success)] text-[var(--success)]" />
+          <Circle className="size-2.5 fill-[var(--success)] text-[var(--success)] drop-shadow-[0_0_5px_var(--success)]" />
           <span className="flex-1 truncate font-medium">default workspace</span>
           <ChevronDown className="size-3 text-muted-foreground" />
         </button>
@@ -167,11 +168,18 @@ export function LeftRail({ tools, activeId, onOpenTool }: LeftRailProps) {
                   onClick={() => onOpenTool(tool.id)}
                   className={cn(
                     "group flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-sidebar-accent/50",
-                    isActive && "bg-sidebar-accent/70 font-medium",
+                    // [OPUS-4.8] sq-vw3ax (#820 redesign) — the active tool gets the accent-lit
+                    // teal spine (a glowing left bar), not just a tint, so the brand leads.
+                    isActive && "sq-active-spine font-medium",
                   )}
                   title={`${tool.blurb} — ${tier.label}`}
                 >
-                  <Icon className="size-3.5 shrink-0 text-muted-foreground" />
+                  <Icon
+                    className={cn(
+                      "size-3.5 shrink-0",
+                      isActive ? "text-primary" : "text-muted-foreground",
+                    )}
+                  />
                   <span className="min-w-0 flex-1 truncate">{tool.label}</span>
                   <span
                     className={cn("size-2 shrink-0 rounded-full", tier.dot)}

--- a/gui/app/src/components/workbench/query-workbench.tsx
+++ b/gui/app/src/components/workbench/query-workbench.tsx
@@ -126,7 +126,9 @@ function SelectTable({ results }: { results: SparqlResults }) {
     <div className="flex h-full flex-col" data-result-view="table">
       <div className="min-h-0 flex-1 overflow-auto">
         <table className="w-full border-collapse text-sm">
-          <thead className="sticky top-0 bg-card">
+          {/* [OPUS-4.8] sq-vw3ax (#820 redesign) — teal-capped sticky header (the proposal's IDE
+              result rhythm). The token colour follows the theme. */}
+          <thead className="sq-result-head sticky top-0">
             <tr>
               {table.vars.map((v) => (
                 <th
@@ -594,6 +596,7 @@ export function QueryWorkbench() {
               size="sm"
               onClick={() => void onRun("run")}
               disabled={!ready || running}
+              className="sq-glow-btn border-transparent"
               title="Run the query against the live store (⌘↵)"
             >
               {running ? <Loader2 className="animate-spin" /> : <Play />}

--- a/gui/app/src/components/workbench/status-bar.tsx
+++ b/gui/app/src/components/workbench/status-bar.tsx
@@ -1,13 +1,26 @@
 "use client";
 
-// [OPUS-4.8] sq-ixc3.9 — the bottom STATUS BAR (h-6, research/gui-design.md §A.2):
+// [OPUS-4.8] sq-ixc3.9 — the bottom STATUS BAR (research/gui-design.md §A.2):
 // MEASURED performance.now() latency of the last run · row count · target · persistence backend.
 //
-// HONESTY: the latency is the wall-clock of the query the user JUST ran, measured with
-// performance.now() and LABELLED as a per-run latency — it is NOT a benchmark claim, and no
-// canonical number is baked in (this work box / CI runner is non-canonical).
+// [OPUS-4.8] sq-vw3ax (#820 "GUI: unintrusive stats") — the bold redesign adds the issue's two
+// asked-for stats, unintrusively (no modal): a slim INGEST meter (the real file label + a live
+// MEASURED elapsed while an import is in flight) and a tiny DISK gauge (the REAL on-device store
+// footprint — the byte length of the persisted whole-dataset N-Quads snapshot).
+//
+// HONESTY. Every figure here is real:
+//   * latency  — wall-clock of the query the user JUST ran (performance.now), labelled per-run,
+//                NOT a benchmark claim (this work box / CI runner is non-canonical).
+//   * disk     — the actual size of what the workspace persists (snapshot bytes). There is no
+//                fixed capacity, so the gauge shows the live footprint; the conic ring's fill is a
+//                log-scaled visual cue only, and the tooltip states the exact bytes. A precise
+//                filesystem probe of the app-data dir is a follow-up bead (new Tauri command).
+//   * ingest   — the loaders are synchronous (no byte-level progress callback), so this is an
+//                honest indeterminate "ingesting <file>…" with a real elapsed — never a fake %/ETA.
 
-import { useEngine } from "@/lib/engine-context";
+import * as React from "react";
+
+import { useEngine, type IngestState } from "@/lib/engine-context";
 import { useWorkspace } from "@/lib/workspace-context";
 
 /**
@@ -22,19 +35,74 @@ function backendLabel(backend: "tauri" | "web" | "memory" | null): string {
   return "resolving…";
 }
 
+/** Format a real byte count as a compact human size (KB/MB/GB). Pure presentation of a real value. */
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const units = ["KB", "MB", "GB", "TB"];
+  let v = bytes / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v < 10 ? v.toFixed(1) : Math.round(v)} ${units[i]}`;
+}
+
+/**
+ * A log-scaled 0–100 fill for the disk gauge's conic ring. There is no fixed capacity, so this is
+ * a purely VISUAL cue (empty store → a sliver, ~1 GB → nearly full); the tooltip + label carry the
+ * exact real bytes. Kept monotonic so a bigger store always reads as a fuller ring.
+ */
+function diskRingPct(bytes: number): number {
+  if (bytes <= 0) return 0;
+  // 1 KB → ~0%, 1 GB → ~100%, log-spaced across the six orders of magnitude in between.
+  const pct = (Math.log10(bytes) - 3) * (100 / 6);
+  return Math.max(2, Math.min(100, pct));
+}
+
+/**
+ * The unintrusive #820 ingest meter: an indeterminate sweep + the source label + a LIVE measured
+ * elapsed (re-rendered ~4×/s from `performance.now()` against the ingest start). No fabricated %.
+ */
+function IngestMeter({ ingest }: { ingest: IngestState }) {
+  const [elapsedMs, setElapsedMs] = React.useState(0);
+  React.useEffect(() => {
+    const tick = () => setElapsedMs(performance.now() - ingest.startedAt);
+    tick();
+    const id = window.setInterval(tick, 250);
+    return () => window.clearInterval(id);
+  }, [ingest.startedAt]);
+  return (
+    <span
+      className="flex items-center gap-2 text-muted-foreground"
+      title={`Ingesting ${ingest.label} — ${(elapsedMs / 1000).toFixed(1)} s elapsed (measured)`}
+      data-status-ingest
+    >
+      <span className="max-w-[10rem] truncate">↧ {ingest.label}</span>
+      <span className="sq-ingest-bar" aria-hidden>
+        <span className="sq-ingest-fill" />
+      </span>
+      <span className="tabular">{(elapsedMs / 1000).toFixed(1)} s</span>
+    </span>
+  );
+}
+
 export function StatusBar() {
-  const { lastLatencyMs, lastRowCount, storeSize, nativeLoaderAvailable } = useEngine();
+  const { lastLatencyMs, lastRowCount, storeSize, storeBytes, ingest, nativeLoaderAvailable } =
+    useEngine();
   const { backend } = useWorkspace();
   return (
-    <footer className="flex h-6 shrink-0 items-center gap-4 border-t bg-card px-3 text-[11px] text-muted-foreground">
-      <span className="tabular" title="Wall-clock latency of the last query (performance.now)">
+    <footer className="sq-statusbar flex h-7 shrink-0 items-center gap-4 border-t px-3 font-mono text-[11px] text-muted-foreground">
+      <span
+        className="tabular text-primary"
+        title="Wall-clock latency of the last query (performance.now) — measured, not a benchmark"
+      >
         {lastLatencyMs === null ? "— ms" : `${lastLatencyMs.toFixed(1)} ms`}
       </span>
       <span className="tabular" title="Rows / triples returned by the last run">
         {lastRowCount === null ? "— rows" : `${lastRowCount.toLocaleString()} rows`}
       </span>
-      <span className="ml-auto tabular">{storeSize.toLocaleString()} quads</span>
-      <span title="Where queries run">target: local (in-tab WASM)</span>
+      <span title="Where queries run">target: local · in-tab WASM</span>
       <span
         title={
           nativeLoaderAvailable
@@ -42,9 +110,33 @@ export function StatusBar() {
             : "Imports parse in the in-tab WASM engine (no compressed-file / HDT path)"
         }
       >
-        loader: {nativeLoaderAvailable ? "native" : "in-tab"}
+        loader: <span className="text-[var(--success)]">{nativeLoaderAvailable ? "native" : "in-tab"}</span>
       </span>
       <span title="Where the workspace persists">backend: {backendLabel(backend)}</span>
+
+      {/* push the #820 stats to the right edge. */}
+      <span className="ml-auto" />
+
+      <span className="tabular" title="Quads in the live store (default + every named graph)">
+        {storeSize.toLocaleString()} quads
+      </span>
+
+      {/* [OPUS-4.8] sq-vw3ax (#820) — the unintrusive ingest meter (only while an import runs). */}
+      {ingest && <IngestMeter ingest={ingest} />}
+
+      {/* [OPUS-4.8] sq-vw3ax (#820) — the disk gauge: the REAL persisted store footprint. */}
+      <span
+        className="flex items-center gap-1.5"
+        title={`Workspace store on disk: ${storeBytes.toLocaleString()} bytes (the persisted whole-dataset snapshot)`}
+        data-status-disk
+      >
+        <span
+          className="sq-disk-ring"
+          style={{ ["--disk-pct" as string]: diskRingPct(storeBytes) }}
+          aria-hidden
+        />
+        disk {formatBytes(storeBytes)}
+      </span>
     </footer>
   );
 }

--- a/gui/app/src/components/workbench/tab-strip.tsx
+++ b/gui/app/src/components/workbench/tab-strip.tsx
@@ -19,9 +19,11 @@ interface TabStripProps {
 
 export function TabStrip({ tabs, activeId, onSelect, onClose }: TabStripProps) {
   return (
+    // [OPUS-4.8] sq-vw3ax (#820 redesign) — IDE tab strip with a subtle card gradient + a
+    // teal-glow underline on the active tab (the proposal's accent-lit spine).
     <div
       role="tablist"
-      className="flex h-9 shrink-0 items-stretch overflow-x-auto border-b bg-card"
+      className="flex h-9 shrink-0 items-stretch overflow-x-auto border-b bg-gradient-to-b from-card to-[color-mix(in_oklch,var(--card)_70%,var(--background))]"
     >
       {tabs.map((tab) => {
         const tool = toolById(tab.id);
@@ -34,9 +36,9 @@ export function TabStrip({ tabs, activeId, onSelect, onClose }: TabStripProps) {
             role="tab"
             aria-selected={isActive}
             className={cn(
-              "group flex cursor-pointer items-center gap-1.5 border-r px-3 text-xs",
+              "group relative flex cursor-pointer items-center gap-1.5 border-r px-3 text-xs",
               isActive
-                ? "border-b-2 border-b-primary bg-background font-medium"
+                ? "bg-background font-medium text-foreground after:absolute after:inset-x-2.5 after:-bottom-px after:h-0.5 after:rounded-full after:bg-gradient-to-r after:from-primary after:to-transparent after:shadow-[0_0_8px_var(--primary)]"
                 : "text-muted-foreground hover:bg-accent/40",
             )}
             onClick={() => onSelect(tab.id)}

--- a/gui/app/src/components/workbench/title-bar.tsx
+++ b/gui/app/src/components/workbench/title-bar.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+// [OPUS-4.8] sq-vw3ax (#820 bold redesign) — the NATIVE TITLE BAR.
+//
+// The single strongest "this is a desktop app, not the website in a frame" signal from the
+// approved proposal (/home/ubuntu/sparq-design-system/proposals/desktop-gui.html §1): a thin,
+// branded title strip with a centred window title + an engine/runtime badge.
+//
+// NATIVE FEEL, HONESTLY. The strip is a Tauri DRAG REGION (`data-tauri-drag-region`) — inside the
+// desktop shell, dragging it moves the OS window, exactly like a real titlebar; on the hosted web
+// target the attribute is inert (no Tauri runtime) and it is just a header strip. We do NOT claim
+// custom traffic-light WINDOW CONTROLS: the Tauri window keeps its OS decorations (tauri.conf.json
+// has no `decorations: false`), so the three dots here are a decorative brand flourish, not fake
+// close/minimise buttons that would do nothing. The badge reports the REAL runtime: inside Tauri
+// the workbench has the direct native-engine ingest link, on the web it is the in-tab WASM engine
+// — read from the engine context's resolved `nativeLoaderAvailable`, never hard-coded.
+
+import { useEngine } from "@/lib/engine-context";
+
+export function TitleBar() {
+  const { nativeLoaderAvailable } = useEngine();
+  // The badge is an honest CAPABILITY statement (which engine path is wired), not a perf claim.
+  const runtimeLabel = nativeLoaderAvailable ? "native engine" : "in-tab WASM";
+  return (
+    <div
+      data-tauri-drag-region
+      className="sq-titlebar grid h-8 shrink-0 select-none grid-cols-[1fr_auto_1fr] items-center border-b px-3.5"
+    >
+      {/* A decorative brand flourish (NOT functional window controls — OS decorations remain). */}
+      <div className="flex items-center gap-2" aria-hidden>
+        <span className="size-3 rounded-full bg-[oklch(0.68_0.18_25)] shadow-[0_0_0_0.5px_oklch(0_0_0/0.3)_inset]" />
+        <span className="size-3 rounded-full bg-[oklch(0.82_0.14_85)] shadow-[0_0_0_0.5px_oklch(0_0_0/0.3)_inset]" />
+        <span className="size-3 rounded-full bg-[oklch(0.74_0.15_150)] shadow-[0_0_0_0.5px_oklch(0_0_0/0.3)_inset]" />
+      </div>
+      <div className="text-center text-[12.5px] tracking-tight text-muted-foreground">
+        <span className="font-semibold text-foreground">sparq</span> — RDF + SPARQL workbench
+      </div>
+      <div className="flex items-center justify-end">
+        <span
+          className="rounded-full border px-2.5 py-0.5 font-mono text-[10.5px] tracking-wide text-muted-foreground"
+          title={
+            nativeLoaderAvailable
+              ? "Desktop shell: ingest runs through the direct native engine link (threads, no ~2 GiB wasm-tab ceiling, native-only HDT)"
+              : "Hosted web target: the in-tab WASM engine (no native-only ingest path)"
+          }
+        >
+          {runtimeLabel}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/gui/app/src/components/workbench/top-bar.tsx
+++ b/gui/app/src/components/workbench/top-bar.tsx
@@ -68,22 +68,26 @@ export function TopBar() {
   // [OPUS-4.8] sq-ixc3.13 — the top-bar "+ Import" affordance (opens the Import drawer).
   const { setOpen: setImportOpen } = useImportDrawer();
   return (
-    <header className="flex h-10 shrink-0 items-center gap-3 border-b bg-card px-3">
-      <span className="font-mono text-sm font-semibold tracking-tight">sparq</span>
-      <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+    // [OPUS-4.8] sq-vw3ax (#820 redesign) — the teal-forward TOP BAR (the hero gradient makes the
+    // brand the lead, not a faint sprinkle). Same controls, bolder identity.
+    <header className="sq-topbar flex h-11 shrink-0 items-center gap-3 border-b px-3">
+      <span className="font-mono text-[15px] font-bold tracking-tight">
+        sparq<span className="sq-brand-dot">.</span>
+      </span>
+      <span className="text-[10px] uppercase tracking-[0.16em] text-muted-foreground">
         workbench
       </span>
 
       {/* LOCAL⇄ENDPOINT target switch — stub (the Server/endpoint tool is a later phase). */}
-      <div className="ml-2 flex items-center rounded-md border bg-background text-xs">
+      <div className="ml-2 flex items-center overflow-hidden rounded-md border bg-background text-[11.5px] font-semibold">
         <button
-          className="rounded-l-md bg-primary px-2 py-1 font-medium text-primary-foreground"
+          className="bg-primary px-2.5 py-1 text-primary-foreground shadow-[0_0_18px_-4px_var(--teal-glow)]"
           title="Run queries against the in-tab engine (this build)"
         >
           LOCAL
         </button>
         <button
-          className="cursor-not-allowed rounded-r-md px-2 py-1 text-muted-foreground"
+          className="cursor-not-allowed px-2.5 py-1 text-muted-foreground/70"
           title="Endpoint mode (connect to a running sparq-server) — coming in a later phase"
           disabled
         >
@@ -91,15 +95,15 @@ export function TopBar() {
         </button>
       </div>
 
-      <span className="tabular text-xs text-muted-foreground">
+      <span className="tabular font-mono text-xs text-muted-foreground">
         {storeSize.toLocaleString()} quads
       </span>
 
-      {/* [OPUS-4.8] sq-ixc3.13 — "+ Import": real disk/URL/paste ingest via the native loader. */}
+      {/* [OPUS-4.8] sq-ixc3.13 — "+ Import": real disk/URL/paste ingest via the native loader.
+          [OPUS-4.8] sq-vw3ax — promoted to the lit primary action in the bold chrome. */}
       <Button
-        variant="outline"
         size="sm"
-        className="ml-1"
+        className="sq-glow-btn ml-1 border-transparent"
         onClick={() => setImportOpen(true)}
         title="Import RDF from a disk file (compressed / HDT), a URL, or pasted text"
         data-import-trigger="topbar"

--- a/gui/app/src/components/workbench/workbench.tsx
+++ b/gui/app/src/components/workbench/workbench.tsx
@@ -22,6 +22,7 @@ import * as React from "react";
 import { PanelsTopLeft, X, Layers, Upload } from "lucide-react";
 
 import { LeftRail } from "@/components/workbench/left-rail";
+import { TitleBar } from "@/components/workbench/title-bar";
 import { TopBar } from "@/components/workbench/top-bar";
 import { TabStrip } from "@/components/workbench/tab-strip";
 import { StatusBar } from "@/components/workbench/status-bar";
@@ -101,7 +102,20 @@ export function Workbench() {
           onSelectTab={setActiveId}
           onCloseTab={closeTab}
         />
-        <div className="flex h-screen flex-col overflow-hidden bg-background text-foreground">
+        {/* [OPUS-4.8] sq-vw3ax (#820 redesign) — a native-feeling dark workspace. The ambient teal
+            aura (a faint radial wash behind the chrome) makes the brand the lead, not garnish; the
+            title bar above the top bar signals a real desktop window. */}
+        <div className="relative flex h-screen flex-col overflow-hidden bg-background text-foreground">
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-x-0 top-0 z-0 h-56 opacity-60"
+            style={{
+              background:
+                "radial-gradient(900px 220px at 22% -10%, var(--teal-glow), transparent 60%), radial-gradient(700px 200px at 92% 0%, color-mix(in oklch, var(--primary) 18%, transparent), transparent 62%)",
+            }}
+          />
+          <div className="relative z-10 flex min-h-0 flex-1 flex-col">
+          <TitleBar />
           <TopBar />
           <div className="flex min-h-0 flex-1">
             <LeftRail tools={TOOLS} activeId={activeId} onOpenTool={openTool} />
@@ -126,6 +140,7 @@ export function Workbench() {
               </div>
               <StatusBar />
             </main>
+          </div>
           </div>
         </div>
         </ImportDrawerProvider>

--- a/gui/app/src/lib/engine-context.tsx
+++ b/gui/app/src/lib/engine-context.tsx
@@ -167,10 +167,41 @@ export interface ImportResult {
   bytes: number;
 }
 
+/**
+ * [OPUS-4.8] sq-vw3ax (#820) — the live INGEST signal the status bar's unintrusive ingest meter
+ * reads. While an import is decoding/merging, `active` is true and `label` names the source; the
+ * elapsed time is MEASURED by the status bar from `startedAt` (performance.now). The native + WASM
+ * loaders are SYNCHRONOUS (no byte-level progress callback exists), so this is honestly an
+ * indeterminate "ingesting <file>…" with a real elapsed — never a fabricated percentage or ETA.
+ * `null` when no import is in flight.
+ */
+export interface IngestState {
+  /** A human label for the source being ingested (filename / URL tail / "pasted document"). */
+  label: string;
+  /** performance.now() at ingest start — the status bar derives the live elapsed from this. */
+  startedAt: number;
+}
+
+/**
+ * [OPUS-4.8] sq-vw3ax (#820) — the live on-device store FOOTPRINT the status bar's disk gauge
+ * reads. This is the REAL byte length of the whole-dataset N-Quads snapshot the workspace persists
+ * (the `dataSnapshot` save/open cache, sq-atb0) — i.e. the actual size of what is written to disk
+ * on the desktop target (or to localStorage on the web). It is a real measured figure, not a
+ * fabricated capacity: there is no fixed cap, so the gauge shows the snapshot bytes, recomputed
+ * after every load/import/update. A precise filesystem probe of the app-data dir (vs this snapshot
+ * estimate) is a follow-up that needs a new Tauri command + capability (beaded).
+ */
 export interface EngineContextValue {
   status: EngineStatus;
   /** Total quads in the live store (default + all named graphs). */
   storeSize: number;
+  /**
+   * [OPUS-4.8] sq-vw3ax (#820) — the REAL on-device store footprint in bytes (the UTF-8 length of
+   * the persisted whole-dataset N-Quads snapshot). 0 before the store warms. Honest measured value.
+   */
+  storeBytes: number;
+  /** [OPUS-4.8] sq-vw3ax (#820) — the in-flight import, or null. Drives the status bar ingest meter. */
+  ingest: IngestState | null;
   /** Per-graph counts for the datasets tree. */
   graphs: GraphSummary[];
   /** The latency (ms) of the most recent run, or null before any run. */
@@ -332,9 +363,25 @@ function summariseGraphs(store: WasmStore): { size: number; graphs: GraphSummary
   return { size, graphs };
 }
 
+/**
+ * [OPUS-4.8] sq-vw3ax (#820) — the REAL on-device footprint of a store: the UTF-8 byte length of
+ * its whole-dataset N-Quads snapshot (exactly what the workspace persists to disk / localStorage).
+ * Used for the status bar disk gauge — a measured figure, never a fabricated capacity.
+ */
+function snapshotBytes(store: WasmStore): number {
+  try {
+    return new Blob([storeToNQuads(store)]).size;
+  } catch {
+    return 0;
+  }
+}
+
 export function EngineProvider({ children }: { children: React.ReactNode }) {
   const [status, setStatus] = React.useState<EngineStatus>({ kind: "cold" });
   const [storeSize, setStoreSize] = React.useState(0);
+  // [OPUS-4.8] sq-vw3ax (#820) — the live on-device footprint (snapshot bytes) + in-flight import.
+  const [storeBytes, setStoreBytes] = React.useState(0);
+  const [ingest, setIngest] = React.useState<IngestState | null>(null);
   const [graphs, setGraphs] = React.useState<GraphSummary[]>([]);
   const [lastLatencyMs, setLastLatencyMs] = React.useState<number | null>(null);
   const [lastRowCount, setLastRowCount] = React.useState<number | null>(null);
@@ -356,6 +403,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
         storeRef.current = store;
         const { size, graphs: gs } = summariseGraphs(store);
         setStoreSize(size);
+        setStoreBytes(snapshotBytes(store));
         setGraphs(gs);
         setStatus({ kind: "ready" });
       })
@@ -376,6 +424,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     if (!store) return;
     const { size, graphs: gs } = summariseGraphs(store);
     setStoreSize(size);
+    setStoreBytes(snapshotBytes(store));
     setGraphs(gs);
   }, []);
 
@@ -387,13 +436,9 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
   // `loadDataset(_, "nquads")` so every named graph of both sides survives. On the hosted web
   // target (no native loader), `paste`/`url` parse directly in the in-tab WASM engine; a `file`
   // import is rejected there with a clear message (browsers cannot read an arbitrary disk path).
-  const importRdf = React.useCallback(
-    async (req: ImportRequest): Promise<ImportResult> => {
-      const Store = ctorRef.current;
-      if (!Store) {
-        throw new Error("The engine is not ready yet — wait for the store to warm.");
-      }
-
+  // The actual ingest body (separated so `importRdf` can bracket it with the ingest signal).
+  const runImport = React.useCallback(
+    async (req: ImportRequest, Store: WasmStoreCtor): Promise<ImportResult> => {
       // 1. Decode the incoming document to N-Quads (native loader when available, else in-tab).
       let incomingNQuads: string;
       let added: number;
@@ -446,14 +491,43 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       const merged = Store.loadDataset(combined, "nquads");
       storeRef.current = merged;
 
-      // 3. Refresh the datasets tree + store size from the new store.
+      // 3. Refresh the datasets tree + store size + on-device footprint from the new store.
       const { size, graphs: gs } = summariseGraphs(merged);
       setStoreSize(size);
+      setStoreBytes(snapshotBytes(merged));
       setGraphs(gs);
 
       return { added, storeSize: size, loadedNatively, format, bytes };
     },
     [],
+  );
+
+  // [OPUS-4.8] sq-ixc3.13 — the Import drawer's ingest. A `file` import (a disk path) goes
+  // through the NATIVE loader IPC (`load_path`: compressed + native-only HDT, no wasm-tab
+  // ceiling) inside the Tauri shell; `paste`/`url` documents go through native `load_text` there
+  // too. Either way the loader hands back the document as N-QUADS (named-graph-preserving), which
+  // we MERGE (concatenate with the live store's N-Quads) or REPLACE, then re-load with
+  // `loadDataset(_, "nquads")` so every named graph of both sides survives. On the hosted web
+  // target (no native loader), `paste`/`url` parse directly in the in-tab WASM engine; a `file`
+  // import is rejected there with a clear message (browsers cannot read an arbitrary disk path).
+  const importRdf = React.useCallback(
+    async (req: ImportRequest): Promise<ImportResult> => {
+      const Store = ctorRef.current;
+      if (!Store) {
+        throw new Error("The engine is not ready yet — wait for the store to warm.");
+      }
+      // [OPUS-4.8] sq-vw3ax (#820) — mark the ingest in-flight so the status bar shows the
+      // unintrusive ingest meter (the real file label + a live measured elapsed). Cleared in the
+      // `finally` whether the import succeeds or fails. The loaders are synchronous, so this is an
+      // honest "ingesting <file>…" indicator, not a fabricated progress percentage or ETA.
+      setIngest({ label: req.label, startedAt: performance.now() });
+      try {
+        return await runImport(req, Store);
+      } finally {
+        setIngest(null);
+      }
+    },
+    [runImport],
   );
 
   const run = React.useCallback(
@@ -601,6 +675,8 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     () => ({
       status,
       storeSize,
+      storeBytes,
+      ingest,
       graphs,
       lastLatencyMs,
       lastRowCount,
@@ -613,6 +689,8 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     [
       status,
       storeSize,
+      storeBytes,
+      ingest,
       graphs,
       lastLatencyMs,
       lastRowCount,


### PR DESCRIPTION
> 🤖 **SPARQ agent** — reshaping the Tauri desktop main window into a native-feeling dark workspace, faithful to the approved [`desktop-gui.html`](https://github.com/jeswr/sparq/blob/main/sparq-design-system/proposals/desktop-gui.html) proposal (its inline CSS = the target). Resolves part of #820 (GUI: unintrusive stats).

## What this ships

A bold reimagining of `gui/app`'s main window: a dark, IDE-grade operational shell — **not the website in a frame** — over the live engine. Scope is `gui/app/` only (no `crates/` source, no IPC changes).

- **Native title bar** (`title-bar.tsx`, new): a thin branded strip — a **Tauri drag region** (`data-tauri-drag-region`, moves the OS window in the desktop shell; inert on the hosted web target), a centred `sparq — RDF + SPARQL workbench` title, and a runtime badge that reads the **real** engine path (`native engine` vs `in-tab WASM`, from the engine context — never hard-coded). The traffic-light dots are a decorative brand flourish; the window keeps its OS decorations (no `decorations: false`), so they are **not** fake window controls.
- **Teal-forward identity, not garnish**: an ambient teal aura behind the chrome, a hero-gradient top bar, an accent-lit active rail-tool / IDE-tab spine, a lit Run / Import primary, a dashed teal import affordance, and a teal-capped sticky result header. All derived as **pure mixes of the existing OKLCH `--primary`** (`--teal-glow/-faint/-line`, `--hero-from`) — **no new hue invented**; dark-first (the GUI already defaults to dark) and theme-following.
- **The #820 stats, designed in unintrusively** (status bar, no modal):
  - a tiny **disk gauge** showing the **real** on-device store footprint — the byte length of the persisted whole-dataset N-Quads snapshot (exactly what the workspace writes to disk / localStorage), recomputed after every load / import / update;
  - an unintrusive **ingest meter** (the real file label + a **live measured elapsed**) while an import is in flight.

## Honesty

No fabricated figures in shipped code (the mockup's numbers were illustrative only):
- The disk figure is a **real measured** value (snapshot bytes). There is no fixed capacity, so the conic ring's fill is a log-scaled **visual cue** only and the tooltip states the exact bytes.
- The loaders are **synchronous** (no byte-level progress callback exists), so the ingest meter is an honest indeterminate "ingesting <file>…" with a real elapsed — **never a fabricated % or ETA**.
- The measured per-run latency stays labelled (non-canonical work box / CI runner); no benchmark or capacity number is baked in.
- Tier dots, the honest tool stubs, and every e2e `data-*` hook (`id="repl-query"`, `Run query`, `data-tool="shacl"`, `data-import-trigger="rail"`) are unchanged. Existing Tauri commands / IPC are untouched.

## Gates

- **WASM prereq** built first (`cd js && npm run build:wasm` — build artifact only, no `crates/` changes).
- `cd gui/app && npm install && npm run build:tauri` — **succeeds end-to-end**, emits `/` into `out/`; the new chrome classes + teal tokens are present in the exported CSS, and all e2e hooks survive in the exported HTML.
- `npm run lint` — clean. `tsc --noEmit` — passes (no `any`-escape hatches).

## Follow-up

- `sq-cno90` — a precise **native filesystem disk-usage probe** (a minimal Tauri command + capability that stats `$APPLOCALDATA/workspaces`) to tighten the disk figure from the snapshot-bytes estimate to the OS-reported size on the desktop target.