### PR TITLE
feat(site): bold homepage redesign

### DIFF
--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -1,41 +1,39 @@
 import Link from "next/link";
-import { ArrowRight, Cpu, ShieldCheck, Boxes, Github } from "lucide-react";
 
-// [OPUS-4.8] sq-vw3ax.5 — the Home rewrite: route + prove in under one screen.
+// [OPUS-4.8] sq-vw3ax.5 — the BOLD homepage redesign, built on the merged dark-first
+// foundation (#1261) and faithful to the approved mockup
+// (sparq-design-system/proposals/web-home.html). It reimagines the landing as:
+//   1. an atmospheric teal HERO (.bg-atmos/.bg-grid + .text-gradient .display-1 headline +
+//      mono .kicker rhythm) with a four-stat STRUCTURAL strip (count-badge style figures);
+//   2. the live-REPL "moment" — the heavy <ReplLazy> framed (USED AS-IS; the /try redesign
+//      owns the REPL internals) as the killer artifact, immediately after the hero;
+//   3. the bold "See it work" flagship showcase (the real FLAGSHIPS) and the five capability
+//      THEME cards with per-surface honesty-tier dots; and
+//   4. the "How it runs" honesty strip — the tier legend + a "How tiers work" <details>.
 //
-// CUT (research/website-redesign.md §3, §4): the 14-card "Every surface" grid (moved to
-// /capabilities) and the 4-sentence hero honesty preamble (now ONE success badge + one
-// #how-it-runs tier strip + a "How tiers work" <details>). KEPT: the live REPL as the killer
-// artifact, immediately after the hero.
-//
-// Top-to-bottom: hero (1 sentence + badge + 2 buttons + 3 pills) → live REPL → 3 flagship
-// cards (→ /showcase) → 5 capability THEME cards (each listing its surfaces as links to
-// /capabilities#<theme>) → #how-it-runs tier-legend strip + "How tiers work" details.
+// REAL DATA / HONESTY (load-bearing): every figure is a STRUCTURAL fact derived from the
+// single GROUPS/FLAGSHIPS source (data/surfaces.ts) or a query-form/format list — NOT a
+// performance/timing claim and NOT fabricated. The REPL's results come from the real engine
+// at runtime; nothing here hardcodes a result row, triple count, or timing.
 import { ReplLazy } from "@/components/repl-lazy";
 import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
 import {
   FLAGSHIPS,
   GROUPS,
   TIER_LABEL,
   TIER_VARIANT,
-  type Surface,
   type Tier,
 } from "@/data/surfaces";
-import { DEEP_PAGE_SLUGS, capabilityAnchor } from "@/data/capabilities";
+import { Hero } from "@/components/home/hero";
+import { SectionHeader } from "@/components/home/section-header";
+import { FlagshipCard } from "@/components/home/flagship-card";
+import { CapabilityCard } from "@/components/home/capability-card";
 
 const REPO_URL = "https://github.com/jeswr/sparq";
 
-// The honesty tiers, told ONCE here (the per-surface badge is the per-page pointer). Order
-// mirrors the strongest → most-hedged execution model. Each is a real Tier so the legend can
-// never drift from the badges the rest of the site renders.
+// The honesty tiers, told ONCE here (the per-surface badge/dot is the per-page pointer).
+// Order mirrors the strongest → most-hedged execution model. Each is a real Tier so the
+// legend can never drift from the badges the rest of the site renders.
 const TIER_LEGEND: { tier: Tier; note: string }[] = [
   { tier: "live", note: "the real Rust engine, compiled to wasm, in your browser tab" },
   { tier: "live-bbjs", note: "in-tab proving via the 3rd-party bb.js UltraHonk prover" },
@@ -44,135 +42,87 @@ const TIER_LEGEND: { tier: Tier; note: string }[] = [
   { tier: "walkthrough", note: "real, captured engine output replayed (native-only surface)" },
 ];
 
-/** A surface's link on Home → its post-redesign home (deep page or /capabilities#theme). */
-function surfaceHref(surface: Surface, groupId: string): string {
-  if (DEEP_PAGE_SLUGS.has(surface.slug)) return surface.href;
-  if (surface.slug === "try") return surface.href;
-  return capabilityAnchor(groupId);
-}
-
 export default function HomePage() {
   return (
-    <div className="space-y-14">
-      {/* 1 — Hero: one sentence, one badge, two buttons, three pills. */}
-      <section className="space-y-4">
-        <Badge variant="success" className="h-6 px-3">
-          The live REPL below runs in your browser tab
-        </Badge>
-        <h1 className="text-3xl font-semibold tracking-tight md:text-4xl">
-          A state-of-the-art RDF triplestore &amp; SPARQL 1.1/1.2 engine,{" "}
-          <span className="text-primary">live in your browser tab</span>.
-        </h1>
-        <div className="flex flex-wrap gap-3 pt-1">
-          <Button asChild size="lg">
-            <Link href="/try">Try the REPL</Link>
-          </Button>
-          <Button asChild size="lg" variant="outline">
-            <a href={REPO_URL} target="_blank" rel="noopener noreferrer">
-              <Github className="size-4" aria-hidden />
-              GitHub
-            </a>
-          </Button>
-        </div>
-        <div className="flex flex-wrap gap-2 pt-1 text-sm text-muted-foreground">
-          <Pill icon={Cpu} text="Rust core, compiled to WebAssembly" />
-          <Pill icon={Boxes} text="RDF/JS @jeswr/sparq API" />
-          <Pill icon={ShieldCheck} text="ZK + MPC privacy surfaces" />
-        </div>
-      </section>
+    <div className="space-y-20">
+      {/* 1 — Hero: atmospheric ground, gradient display headline, structural stat strip. */}
+      <Hero />
 
-      {/* 2 — The live REPL: the killer artifact, immediately. */}
-      <section className="space-y-3">
+      {/* 2 — The live REPL: the killer artifact, framed. ReplLazy is used AS-IS. */}
+      <section id="repl" className="scroll-mt-20 space-y-5">
+        <SectionHeader
+          kicker="The killer artifact"
+          title="A live SPARQL REPL — real engine, real graph, real results"
+          note="Edit the query, pick an example, hit Run. The lean wasm bundle parses the sample Turtle and answers in-tab."
+        />
         <ReplLazy />
         <p className="text-xs text-muted-foreground">
           This REPL loads the lean sparq wasm bundle and runs your SPARQL against
           the sample graph using the real Rust engine — the same code that ships as{" "}
-          <code className="font-mono">@jeswr/sparq</code>. Nothing is sent to a
-          server.
+          <code className="font-mono text-foreground">@jeswr/sparq</code>. Nothing
+          is sent to a server.
         </p>
       </section>
 
-      {/* 3 — See it work: the 3 flagship showcases, large. */}
-      <section className="space-y-4">
-        <div>
-          <h2 className="text-2xl font-semibold">See it work</h2>
-          <p className="text-sm text-muted-foreground">
-            Three end-to-end privacy demonstrations, each runnable —{" "}
-            <Link
-              href="/examples"
-              className="text-primary underline-offset-4 hover:underline"
-            >
-              browse the examples gallery
-            </Link>
-            .
-          </p>
-        </div>
+      {/* 3 — See it work: the real flagship showcases, large. */}
+      <section className="space-y-6">
+        <SectionHeader
+          kicker="See it work"
+          title="Three end-to-end privacy demonstrations, each runnable"
+          note={
+            <>
+              From a live in-tab proof to a faithful protocol simulation — pick one,
+              or{" "}
+              <Link
+                href="/examples"
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                browse the examples gallery
+              </Link>
+              .
+            </>
+          }
+        />
         <div className="grid gap-4 md:grid-cols-3">
-          {FLAGSHIPS.map((f) => (
-            <FlagshipCard key={f.href} surface={f} />
+          {FLAGSHIPS.map((surface) => (
+            <FlagshipCard key={surface.href} surface={surface} />
           ))}
         </div>
       </section>
 
-      {/* 4 — What sparq can do: the 5 capability THEME cards. */}
-      <section className="space-y-4">
-        <div>
-          <h2 className="text-2xl font-semibold">What sparq can do</h2>
-          <p className="text-sm text-muted-foreground">
-            The feature set in five themes —{" "}
-            <Link
-              href="/capabilities"
-              className="text-primary underline-offset-4 hover:underline"
-            >
-              browse the full capabilities gallery
-            </Link>
-            .
-          </p>
-        </div>
+      {/* 4 — What sparq can do: the 5 capability THEME cards, with honesty-tier dots. */}
+      <section className="space-y-6">
+        <SectionHeader
+          kicker="What sparq can do"
+          title="The full feature set, in five themes"
+          note={
+            <>
+              Every surface declares how it runs — the coloured dot before each is
+              its honesty tier.{" "}
+              <Link
+                href="/capabilities"
+                className="text-primary underline-offset-4 hover:underline"
+              >
+                Browse all surfaces
+              </Link>
+              .
+            </>
+          }
+        />
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {GROUPS.map((group) => (
-            <Card key={group.id} className="flex h-full flex-col">
-              <CardHeader className="gap-1.5">
-                <CardTitle className="text-base">
-                  <Link
-                    href={capabilityAnchor(group.id)}
-                    className="hover:text-primary"
-                  >
-                    {group.label}
-                  </Link>
-                </CardTitle>
-                <CardDescription className="leading-relaxed">
-                  {group.description}
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="mt-auto">
-                <ul className="flex flex-wrap gap-x-3 gap-y-1.5 text-sm">
-                  {group.surfaces.map((s) => (
-                    <li key={s.slug}>
-                      <Link
-                        href={surfaceHref(s, group.id)}
-                        className="text-foreground/80 underline-offset-4 hover:text-primary hover:underline"
-                      >
-                        {s.title}
-                      </Link>
-                    </li>
-                  ))}
-                </ul>
-              </CardContent>
-            </Card>
+          {GROUPS.map((group, i) => (
+            <CapabilityCard key={group.id} group={group} index={i} />
           ))}
         </div>
       </section>
 
-      {/* 5 — #how-it-runs: ONE tier-legend strip + "How tiers work" details. */}
-      <section id="how-it-runs" className="scroll-mt-20 space-y-4">
-        <div>
-          <h2 className="text-2xl font-semibold">How it runs</h2>
-          <p className="text-sm text-muted-foreground">
-            Every surface is honestly labelled by how it executes — colour is never
-            the only signal, the text label carries the truth.
-          </p>
-        </div>
+      {/* 5 — How it runs: ONE tier-legend strip + "How tiers work" details (honesty). */}
+      <section id="how-it-runs" className="scroll-mt-20 space-y-6">
+        <SectionHeader
+          kicker="Honesty by design"
+          title="How it runs"
+          note="Every surface is honestly labelled by how it executes — colour is never the only signal; the text label carries the truth."
+        />
         <div className="flex flex-wrap gap-2">
           {TIER_LEGEND.map(({ tier, note }) => (
             <span
@@ -236,55 +186,5 @@ export default function HomePage() {
         </details>
       </section>
     </div>
-  );
-}
-
-function Pill({
-  icon: Icon,
-  text,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  text: string;
-}) {
-  return (
-    <span className="inline-flex items-center gap-1.5 rounded-full bg-muted px-3 py-1">
-      <Icon className="size-3.5" />
-      {text}
-    </span>
-  );
-}
-
-function FlagshipCard({ surface }: { surface: Surface }) {
-  const Icon = surface.icon;
-  return (
-    <Link href={surface.href} className="group block focus-visible:outline-none">
-      <Card className="h-full transition-colors group-hover:ring-primary/40 group-focus-visible:ring-3 group-focus-visible:ring-ring/50">
-        <CardHeader className="gap-2">
-          <div className="flex items-start justify-between gap-2">
-            <span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-              <Icon className="size-5" />
-            </span>
-            <Badge variant={TIER_VARIANT[surface.tier]}>
-              {TIER_LABEL[surface.tier]}
-            </Badge>
-          </div>
-          <CardTitle className="flex items-center gap-1.5">
-            <span className="text-[var(--warning)]" aria-hidden>
-              ★
-            </span>
-            {surface.title}
-          </CardTitle>
-          <CardDescription className="leading-relaxed">
-            {surface.blurb}
-          </CardDescription>
-        </CardHeader>
-        <CardContent>
-          <span className="inline-flex items-center gap-1 text-sm font-medium text-primary">
-            Open demo
-            <ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
-          </span>
-        </CardContent>
-      </Card>
-    </Link>
   );
 }

--- a/site/src/components/home/capability-card.tsx
+++ b/site/src/components/home/capability-card.tsx
@@ -1,0 +1,64 @@
+// [OPUS-4.8] sq-vw3ax.5 — the bold homepage capability THEME card (the mockup's `.cap`):
+// a numbered chip + theme title, the theme description, and a wrapped list of the theme's
+// REAL surfaces, each prefixed by its honesty-tier dot. All data is the single GROUPS source
+// (data/surfaces.ts) — theme label, description and every surface title/tier verbatim, links
+// resolved exactly as the prior Home did (deep page / /try keep their route, others go to the
+// /capabilities#theme anchor). The privacy theme's research-grade caveat already lives in its
+// GROUPS description, so the not-externally-audited caveat is rendered here unchanged.
+
+import Link from "next/link";
+
+import { Card } from "@/components/ui/card";
+import {
+  DEEP_PAGE_SLUGS,
+  capabilityAnchor,
+} from "@/data/capabilities";
+import { type Surface, type SurfaceGroup } from "@/data/surfaces";
+import { TierDot } from "@/components/home/tier-dot";
+
+/** A surface's link on Home → its post-redesign home (deep page, /try, or /capabilities#theme). */
+function surfaceHref(surface: Surface, groupId: string): string {
+  if (DEEP_PAGE_SLUGS.has(surface.slug)) return surface.href;
+  if (surface.slug === "try") return surface.href;
+  return capabilityAnchor(groupId);
+}
+
+export function CapabilityCard({
+  group,
+  index,
+}: {
+  group: SurfaceGroup;
+  index: number;
+}) {
+  const num = String(index + 1).padStart(2, "0");
+  return (
+    <Card className="flex h-full flex-col p-5 transition-all duration-200 hover:-translate-y-0.5 hover:shadow-elevation-2 hover:ring-primary/30">
+      <div className="flex items-center gap-2.5">
+        <span className="grid size-6 flex-none place-items-center rounded-md font-mono text-xs text-primary ring-1 ring-primary/35">
+          {num}
+        </span>
+        <h3 className="text-base font-semibold">
+          <Link href={capabilityAnchor(group.id)} className="hover:text-primary">
+            {group.label}
+          </Link>
+        </h3>
+      </div>
+      <p className="mt-3 flex-1 text-sm leading-relaxed text-muted-foreground">
+        {group.description}
+      </p>
+      <ul className="mt-4 flex flex-wrap gap-x-2.5 gap-y-2 border-t border-[var(--hairline)] pt-3.5">
+        {group.surfaces.map((surface) => (
+          <li key={surface.slug}>
+            <Link
+              href={surfaceHref(surface, group.id)}
+              className="inline-flex items-center gap-1.5 text-sm text-foreground/80 underline-offset-4 hover:text-primary hover:underline"
+            >
+              <TierDot tier={surface.tier} />
+              {surface.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </Card>
+  );
+}

--- a/site/src/components/home/flagship-card.tsx
+++ b/site/src/components/home/flagship-card.tsx
@@ -1,0 +1,57 @@
+// [OPUS-4.8] sq-vw3ax.5 — the bold homepage "See it work" flagship card, faithful to the
+// mockup's `.flag` (sparq-design-system/proposals/web-home.html): an icon tile + tier badge
+// row, a starred title, the blurb, and an "Open demo →" affordance, with the hover-lift +
+// radial-sheen treatment from the merged foundation (shadow-elevation-2, the `::before`
+// glow rendered here as a sibling layer). Data is the real FLAGSHIPS row from data/surfaces.ts
+// (route, blurb, tier all verbatim) — no fabricated copy. Home-scoped presentational only.
+
+import Link from "next/link";
+import { ArrowRight, Star } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { TIER_LABEL, TIER_VARIANT, type Surface } from "@/data/surfaces";
+
+export function FlagshipCard({ surface }: { surface: Surface }) {
+  const Icon = surface.icon;
+  return (
+    <Link
+      href={surface.href}
+      className="group block rounded-xl focus-visible:outline-none focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+    >
+      <Card className="relative h-full overflow-hidden p-6 transition-all duration-200 group-hover:-translate-y-0.5 group-hover:shadow-elevation-2 group-hover:ring-primary/40">
+        {/* Radial sheen — the mockup's `.flag::before`, top-right teal glow on hover. */}
+        <div
+          className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100"
+          style={{
+            background:
+              "radial-gradient(28rem 16rem at 100% 0%, color-mix(in oklch, var(--primary) 16%, transparent), transparent 60%)",
+          }}
+          aria-hidden
+        />
+        <div className="relative flex items-start justify-between gap-2">
+          <span className="flex size-10 items-center justify-center rounded-lg bg-teal-soft text-primary">
+            <Icon className="size-5" aria-hidden />
+          </span>
+          <Badge variant={TIER_VARIANT[surface.tier]}>
+            {TIER_LABEL[surface.tier]}
+          </Badge>
+        </div>
+        <h3 className="relative mt-4 flex items-center gap-1.5 text-base font-semibold">
+          <Star className="size-4 fill-[var(--warning)] text-[var(--warning)]" aria-hidden />
+          {surface.title}
+        </h3>
+        <p className="relative mt-2 text-sm leading-relaxed text-muted-foreground">
+          {surface.blurb}
+        </p>
+        <span className="relative mt-4 inline-flex items-center gap-1.5 text-sm font-medium text-primary">
+          Open demo
+          <ArrowRight
+            className="size-4 transition-transform group-hover:translate-x-0.5"
+            aria-hidden
+          />
+        </span>
+      </Card>
+    </Link>
+  );
+}

--- a/site/src/components/home/hero.tsx
+++ b/site/src/components/home/hero.tsx
@@ -1,0 +1,163 @@
+// [OPUS-4.8] sq-vw3ax.5 — the bold homepage HERO, faithful to the approved mockup
+// (sparq-design-system/proposals/web-home.html `.hero`). Built from the merged dark-first
+// foundation utilities (.bg-atmos / .bg-grid / .display-1 / .text-gradient / .kicker) and
+// the count-badge variant — NO new hue, NO globals.css edit. The atmospheric ground is
+// mounted here, page-scoped (the utilities are fixed/inset:0/z-index:-1, so they layer
+// behind the AppShell content without touching the shell chrome).
+//
+// REAL DATA / HONESTY: the four structural stats are STRUCTURAL FACTS, not performance
+// claims — the SPARQL query forms + RDF text formats the engine ships, the surface count
+// derived from the single GROUPS source (data/surfaces.ts), and "0 servers" (the engine
+// runs in-tab). No number is fabricated or a timing/throughput claim.
+
+import Link from "next/link";
+import { Boxes, Cpu, Github, Play, ShieldCheck } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ALL_SURFACES, GROUPS } from "@/data/surfaces";
+import { RDF_TEXT_FORMATS } from "@/data/home-facts";
+
+const REPO_URL = "https://github.com/jeswr/sparq";
+
+// Derived from the single IA source so the headline counts can never drift from the nav,
+// the capability gallery, or Cmd-K. (No literal "16"/"5" hardcoded here.)
+const SURFACE_COUNT = ALL_SURFACES.length;
+const THEME_COUNT = GROUPS.length;
+const FORMAT_COUNT = RDF_TEXT_FORMATS.length;
+
+interface Stat {
+  /** The leading number/value (mono, the `--primary` accent unit lives in `unit`). */
+  value: string;
+  unit?: string;
+  /** Whether the value should render after the unit (e.g. "4 formats"). */
+  unitLeads?: boolean;
+  label: string;
+}
+
+const STATS: Stat[] = [
+  {
+    value: "SPARQL",
+    unit: "1.1/1.2",
+    label: "SELECT · ASK · CONSTRUCT · DESCRIBE · UPDATE",
+  },
+  {
+    value: "formats",
+    unit: String(FORMAT_COUNT),
+    unitLeads: true,
+    label: RDF_TEXT_FORMATS.join(" · "),
+  },
+  {
+    value: "surfaces",
+    unit: String(SURFACE_COUNT),
+    unitLeads: true,
+    label: `across ${THEME_COUNT} capability themes`,
+  },
+  {
+    value: "servers",
+    unit: "0",
+    unitLeads: true,
+    label: "the engine runs entirely in your tab",
+  },
+];
+
+export function Hero() {
+  return (
+    <section className="relative -mt-8 pb-2 pt-10 md:-mt-10 md:pt-14">
+      {/* Atmospheric ground — mounted page-scoped. Fixed + inert, behind all content. */}
+      <div className="bg-atmos" aria-hidden />
+      <div className="bg-grid" aria-hidden />
+
+      <Badge
+        variant="success"
+        className="h-7 gap-2 rounded-full px-3 text-[0.78rem]"
+      >
+        <span
+          className="size-1.5 animate-pulse rounded-full bg-[var(--success)]"
+          aria-hidden
+        />
+        The live REPL below runs in your browser tab — nothing is sent to a server
+      </Badge>
+
+      <h1 className="display-1 mt-5 max-w-[17ch] font-semibold">
+        A state-of-the-art RDF engine,{" "}
+        <span className="text-gradient">running live in your browser tab.</span>
+      </h1>
+
+      <p className="mt-5 max-w-[56ch] text-lg leading-relaxed text-muted-foreground">
+        sparq is a SOTA Rust triplestore and SPARQL 1.1/1.2 engine, compiled to
+        WebAssembly. The same code ships as{" "}
+        <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.92em] text-foreground">
+          @jeswr/sparq
+        </code>{" "}
+        — streaming cursors, property paths, RDF 1.2 triple terms — and answers
+        your queries in-tab, on the real engine.
+      </p>
+
+      <div className="mt-7 flex flex-wrap gap-3">
+        <Button asChild size="lg">
+          <Link href="#repl">
+            <Play className="size-4" aria-hidden />
+            Run a query now
+          </Link>
+        </Button>
+        <Button asChild size="lg" variant="outline">
+          <a href={REPO_URL} target="_blank" rel="noopener noreferrer">
+            <Github className="size-4" aria-hidden />
+            GitHub
+          </a>
+        </Button>
+      </div>
+
+      <div className="mt-6 flex flex-wrap gap-2 text-sm text-muted-foreground">
+        <Pill icon={Cpu} text="Rust core → WebAssembly" />
+        <Pill icon={Boxes} text="RDF/JS @jeswr/sparq API" />
+        <Pill icon={ShieldCheck} text="ZK + MPC privacy surfaces" />
+      </div>
+
+      {/* Structural stat strip — a single hairline-divided grid, mono figures. */}
+      <dl
+        className="mt-11 grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border ring-1 ring-foreground/10 md:grid-cols-4"
+        aria-label="What the engine answers in-tab"
+      >
+        {STATS.map((stat) => (
+          <div
+            key={stat.label}
+            className="bg-[color-mix(in_oklch,var(--card)_80%,var(--background))] px-5 py-4"
+          >
+            <dt className="block font-mono text-2xl font-semibold tracking-tight">
+              {stat.unitLeads ? (
+                <>
+                  <span className="text-primary">{stat.unit}</span> {stat.value}
+                </>
+              ) : (
+                <>
+                  {stat.value}{" "}
+                  {stat.unit ? (
+                    <span className="text-primary">{stat.unit}</span>
+                  ) : null}
+                </>
+              )}
+            </dt>
+            <dd className="mt-1 text-xs text-muted-foreground">{stat.label}</dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}
+
+function Pill({
+  icon: Icon,
+  text,
+}: {
+  icon: React.ComponentType<{ className?: string }>;
+  text: string;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border bg-card px-3 py-1.5">
+      <Icon className="size-3.5 text-primary" aria-hidden />
+      {text}
+    </span>
+  );
+}

--- a/site/src/components/home/section-header.tsx
+++ b/site/src/components/home/section-header.tsx
@@ -1,0 +1,47 @@
+// [OPUS-4.8] sq-vw3ax.5 — the bold homepage redesign. Home-only presentational
+// section header: a mono `.kicker` over a display-2 / section title, with an optional
+// right-aligned note — the per-section rhythm the approved mockup
+// (sparq-design-system/proposals/web-home.html, `.repl-head` / `.sec-kicker`) establishes.
+// Pure presentation, no data; kept home-scoped so it never collides with shared primitives.
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export function SectionHeader({
+  kicker,
+  title,
+  note,
+  className,
+  titleClassName,
+}: {
+  kicker: string;
+  title: React.ReactNode;
+  note?: React.ReactNode;
+  className?: string;
+  titleClassName?: string;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between",
+        className,
+      )}
+    >
+      <div className="space-y-1.5">
+        <div className="kicker">{kicker}</div>
+        <h2
+          className={cn(
+            "text-2xl font-semibold tracking-tight sm:text-3xl",
+            titleClassName,
+          )}
+        >
+          {title}
+        </h2>
+      </div>
+      {note ? (
+        <p className="max-w-[46ch] text-sm text-muted-foreground">{note}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/site/src/components/home/tier-dot.tsx
+++ b/site/src/components/home/tier-dot.tsx
@@ -1,0 +1,34 @@
+// [OPUS-4.8] sq-vw3ax.5 — the per-surface honesty-tier DOT used inline in the homepage
+// capability cards (the mockup's `.tdot`). The colour is DERIVED from the same TIER_VARIANT
+// map that drives every honesty badge on the site, so the dot can never disagree with the
+// badge a surface's own page renders. Colour is NEVER the only signal — every dot carries an
+// aria-label and sits beside the surface's text label + (in the legend) the written tier name.
+
+import { TIER_LABEL, TIER_VARIANT, type Tier } from "@/data/surfaces";
+
+// Map the four badge variants to their token colour. success/warning/muted/default are the
+// only variants TIER_VARIANT yields, so this is total over the tier space.
+const VARIANT_COLOR: Record<
+  (typeof TIER_VARIANT)[Tier],
+  string
+> = {
+  success: "var(--success)",
+  warning: "var(--warning)",
+  muted: "var(--muted-foreground)",
+  default: "var(--primary)",
+};
+
+export function tierDotColor(tier: Tier): string {
+  return VARIANT_COLOR[TIER_VARIANT[tier]];
+}
+
+export function TierDot({ tier }: { tier: Tier }) {
+  return (
+    <span
+      className="inline-block size-1.5 shrink-0 rounded-full align-middle"
+      style={{ backgroundColor: tierDotColor(tier) }}
+      role="img"
+      aria-label={`Honesty tier: ${TIER_LABEL[tier]}`}
+    />
+  );
+}

--- a/site/src/data/home-facts.ts
+++ b/site/src/data/home-facts.ts
@@ -1,0 +1,13 @@
+// [OPUS-4.8] sq-vw3ax.5 — single source for the homepage's STRUCTURAL facts so the hero
+// stat strip never hardcodes a count inline. These are structural facts about the engine,
+// NOT performance claims and NOT fabricated: the four RDF *text* formats the lean wasm
+// bundle parses/serialises (mirrors the `data-formats` surface blurb in data/surfaces.ts:
+// "Turtle / N-Triples / N-Quads / TriG"). The hero derives `4` from this list's length, so
+// the displayed number and the listed formats can never drift apart.
+
+export const RDF_TEXT_FORMATS = [
+  "Turtle",
+  "N-Triples",
+  "N-Quads",
+  "TriG",
+] as const;


### PR DESCRIPTION
> 🤖 **SPARQ agent** — the bold redesign of the **home** surface, on the merged dark-first foundation.

Reimagines the landing per the approved mockup ([`proposals/web-home.html`](https://github.com/jeswr/sparq/blob/main/../sparq-design-system/proposals/web-home.html), local: `sparq-design-system/proposals/web-home.html`), built on the merged dark-first foundation (#1261).

## What's new
- **Atmospheric teal HERO** — mounts the foundation `.bg-atmos` / `.bg-grid` ground, a `.text-gradient` `.display-1` headline (`--primary → --chart-2 → --chart-5`, the `--hero-grad` token), mono `.kicker` section rhythm, and a four-stat **structural strip** (`SPARQL 1.1/1.2 · 4 formats · 16 surfaces · 0 servers`) in the count-badge style.
- **Live-REPL moment** — `<ReplLazy>` used **as-is** (the `/try` redesign owns the REPL internals), framed by a new section header as the killer artifact.
- **"See it work" flagship showcase** — the real `FLAGSHIPS` (ZK car-hire, MPC £100k, Solid pairs) with hover-lift + radial sheen.
- **Five capability THEME cards** — each surface prefixed by a per-surface **honesty-tier dot** whose colour derives from the same `TIER_VARIANT` map every badge uses.
- **"How it runs" honesty strip** — the tier legend + a "How tiers work" `<details>`.

## Real data / honesty (load-bearing)
- Every figure is a **structural fact derived from the single `GROUPS`/`FLAGSHIPS` source** (`data/surfaces.ts`) or the format list (`data/home-facts.ts`) — `16` is `ALL_SURFACES.length`, `5` is `GROUPS.length`, `4` is the format list length, `0 servers` is the in-tab fact. **No fabricated result rows, triple counts, timings, or throughput claims** — the REPL's results come from the real engine at runtime.
- **Privacy-claims caveat preserved**: the ZK/MPC copy keeps the *research-grade, not-externally-audited* caveat ("indicative engineering, not an audited cryptographic guarantee"); the Privacy theme card renders its `GROUPS` caveat verbatim. No unqualified "sound" / "zero-knowledge-secure".

## Scope
Touches **only** `site/src/app/page.tsx` + new home-only presentational components under `site/src/components/home/*` + one `site/src/data/home-facts.ts`. **No** `globals.css`, shared-primitive, or other-surface edits — the foundation owns those. The nav / Cmd-K / footer are AppShell territory (untouched).

## Gates (green)
- `cd site && npm install && npm run build` → static export, **all routes emitted to `out/`**, `/sparq` basePath intact (verified in `out/index.html`). Home route: `2.13 kB` / `189 kB` First Load.
- `next lint` clean · `tsc --noEmit` clean.
- **WASM prereq built first** (build artifact only, no `crates/` source change): lean `js/wasm/sparq_wasm_bg.wasm` + the W-reason bundle for `/surface/inference`.
- No new dependency added.

Follow-up under the redesign epic **sq-vw3ax**. Auto-merge **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)