### PR TITLE
feat(site): bold capabilities showcase redesign

### DIFF
--- a/site/src/app/capabilities/page.tsx
+++ b/site/src/app/capabilities/page.tsx
@@ -1,76 +1,60 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import { PlayCircle } from "lucide-react";
 
-// [OPUS-4.8] sq-vw3ax.3 — /capabilities: ONE compact gallery that replaces the 14 dense
-// /surface/* pages. Five theme sections, each a list of ~64px rows derived from the single
-// GROUPS source (data/surfaces.ts). Each row is one of:
-//   * "Open →"  — a retained live deep page (sparql/data-formats/javascript-wasm/shacl/inference)
-//   * "Demo ▸"  — a removed walkthrough whose existing component LAZILY mounts in-place; the
-//                 demo chunk is fetched only on first expand (components/capabilities/lazy-demo.tsx),
-//                 so this gallery is NOT heavier than the 14 pages it replaces — the #1 review risk.
-//   * "Source"  — a not-yet-built surface (cli/python).
-// The removed /surface/* routes ship client redirect stubs to /capabilities#<theme>.
+// [OPUS-4.8] sq-vw3ax — /capabilities: the BOLD redesign on the merged dark-first foundation,
+// faithful to the approved mockup (sparq-design-system/proposals/web-capabilities.html).
+//
+// The page is an opinionated, scannable showcase of the full surface set, built entirely from
+// the single GROUPS / FLAGSHIPS source (data/surfaces.ts) — every name, blurb, tier badge, and
+// route is REAL; every hero figure is DERIVED from that data (hero-stats.ts), never hardcoded.
+// Structure (mockup order):
+//   1. HERO — display heading + brand gradient + derived stat strip + theme jump-rail + the
+//      REAL prefilled REPL query (→ run it live in /try).
+//   2. FLAGSHIP band — the three flagships promoted to "start here" depth cards.
+//   3. LEGEND — the tier honesty contract, first-class.
+//   4. five LANES — each a sticky numbered spine + a per-theme accent + a tile grid; the
+//      tiles reuse the lazy-mount machinery (the #1 risk, unchanged); the privacy lane carries
+//      the explicit research-grade caveat strip.
+// The atmospheric .bg-atmos/.bg-grid foundation utilities are mounted once (OPT-IN, pure CSS).
 import { capabilityThemes } from "@/data/capabilities";
-import { CapabilityRowItem } from "@/components/capabilities/capability-row";
+import { CapabilityHero } from "@/components/capabilities/capability-hero";
+import { FlagshipBand } from "@/components/capabilities/flagship-band";
+import { TierLegend } from "@/components/capabilities/tier-legend";
+import { CapabilityLane } from "@/components/capabilities/capability-lane";
 
 export const metadata: Metadata = {
   title: "Capabilities",
   description:
-    "Every sparq capability in one compact gallery — grouped into five themes. Open a live deep page or expand a demo in place. Each surface is honestly tier-labelled by how it runs.",
+    "Every sparq capability in one bold, scannable showcase — grouped into five themes. Open a live deep page, expand a demo in place, or open a flagship end-to-end. Each surface runs the real engine and is honestly tier-labelled by how it runs.",
 };
 
 export default function CapabilitiesPage() {
   const themes = capabilityThemes();
+
   return (
-    <div className="space-y-10">
-      <header className="space-y-3">
-        <h1 className="text-3xl font-semibold tracking-tight">Capabilities</h1>
-        <p className="measure text-muted-foreground">
-          The full sparq feature set, grouped into five themes. Open a live deep
-          page, or expand a demo in place — each one runs the real engine and is
-          labelled by how it runs. For depth, every demo links its crate README and{" "}
-          <code className="font-mono">SKILL.md</code>.
-        </p>
-      </header>
+    <>
+      {/* Atmospheric backdrop — fixed, inert, pure CSS (foundation utilities). */}
+      <div className="bg-atmos" aria-hidden />
+      <div className="bg-grid" aria-hidden />
 
-      {themes.map(({ group, rows }) => (
-        <section
-          key={group.id}
-          id={group.id}
-          // scroll-mt clears the sticky h-16 header when an in-page #anchor is targeted.
-          className="scroll-mt-20 space-y-3"
-        >
-          <div className="space-y-1">
-            <h2 className="text-xl font-semibold">{group.label}</h2>
-            <p className="measure text-sm text-muted-foreground">
-              {group.description}
-            </p>
-          </div>
+      <div className="space-y-16">
+        <CapabilityHero />
 
-          <div className="divide-y rounded-2xl border bg-card">
-            {rows.map(({ surface, kind }) => (
-              <CapabilityRowItem
-                key={surface.slug}
-                slug={surface.slug}
-                kind={kind}
+        <FlagshipBand />
+
+        <div className="space-y-2">
+          <TierLegend />
+          <div className="mt-2">
+            {themes.map((theme, i) => (
+              <CapabilityLane
+                key={theme.group.id}
+                theme={theme}
+                index={i}
+                total={themes.length}
               />
             ))}
           </div>
-
-          {group.id === "query-data" && (
-            <p className="text-sm">
-              <Link
-                href="/try"
-                className="inline-flex items-center gap-1.5 font-medium text-primary underline-offset-4 hover:underline"
-              >
-                <PlayCircle className="size-4" aria-hidden />
-                Open the full live SPARQL REPL
-              </Link>
-            </p>
-          )}
-        </section>
-      ))}
-    </div>
+        </div>
+      </div>
+    </>
   );
 }

--- a/site/src/components/capabilities/capability-hero.tsx
+++ b/site/src/components/capabilities/capability-hero.tsx
@@ -1,0 +1,128 @@
+// [OPUS-4.8] sq-vw3ax — bold /capabilities redesign HERO (server component).
+//
+// Faithful to the approved mockup (sparq-design-system/proposals/web-capabilities.html §HERO):
+// a confident display heading with the brand teal→violet gradient (the foundation `.text-gradient`
+// / `--hero-grad`, NO new hue), a lede, a DERIVED stat strip (hero-stats.ts — every figure from
+// real data), a theme jump-rail of the five lanes, and the REAL prefilled REPL query from
+// sample-graph.ts rendered with the shared `.sq-tok-*` highlighter. The "Run query" affordance
+// links to /try (the live in-tab REPL) — it never shows a fabricated result inline.
+
+import Link from "next/link";
+import { ArrowRight, Play } from "lucide-react";
+
+import { GROUPS } from "@/data/surfaces";
+import { EXAMPLE_QUERIES } from "@/data/sample-graph";
+import { Badge } from "@/components/ui/badge";
+import { HERO_STATS } from "@/components/capabilities/hero-stats";
+import { laneAccent } from "@/components/capabilities/lane-accents";
+import { SparqlHighlight } from "@/components/capabilities/sparql-highlight";
+
+// The prefilled default query the live REPL opens with (the ex:alice profile) — REAL, from the
+// single sample-graph source. Shown read-only here; "Run query" opens it live in /try.
+const HERO_QUERY = EXAMPLE_QUERIES[0].sparql;
+
+export function CapabilityHero() {
+  return (
+    <header className="relative pb-2 pt-4 sm:pt-8">
+      {/* Eyebrow — live pulse + the one-line honest framing. */}
+      <span className="kicker inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/[0.07] px-3 py-1.5 normal-case">
+        <span className="relative flex size-2">
+          <span className="absolute inline-flex size-full animate-ping rounded-full bg-[var(--success)] opacity-60" />
+          <span className="relative inline-flex size-2 rounded-full bg-[var(--success)]" />
+        </span>
+        One engine · {GROUPS.length} themes · honestly labelled
+      </span>
+
+      <h1 className="display-1 mt-6 max-w-[16ch] font-semibold">
+        The whole RDF stack,{" "}
+        <span className="text-gradient">one Rust engine</span> — in your tab.
+      </h1>
+
+      <p className="measure mt-5 text-lg text-muted-foreground">
+        Every sparq capability, grouped into five themes you can scan in seconds.
+        Query, reason, search, prove, and serve — each surface runs the{" "}
+        <span className="font-medium text-foreground">real engine</span> and wears
+        a badge that says exactly how it runs, from{" "}
+        <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.85em] text-foreground">
+          live wasm
+        </code>{" "}
+        to a captured-output walkthrough. No demo pretends to be more than it is.
+      </p>
+
+      <div className="mt-9 grid gap-6 lg:grid-cols-[1fr_1.05fr] lg:items-stretch">
+        {/* Left: derived stat strip + theme jump-rail. */}
+        <div className="flex flex-col justify-between gap-8">
+          <dl className="grid grid-cols-2 gap-x-6 gap-y-7 border-t pt-6 sm:grid-cols-4 lg:grid-cols-2">
+            {HERO_STATS.map((s) => (
+              <div key={s.caption}>
+                <dt className="sr-only">{s.caption}</dt>
+                <dd>
+                  <span className="font-mono text-3xl font-semibold tracking-tight tabular">
+                    {s.value}
+                    {s.unit && (
+                      <span className="ml-1 text-base text-primary">{s.unit}</span>
+                    )}
+                  </span>
+                  <span className="mt-1.5 block text-[12.5px] text-muted-foreground">
+                    {s.caption}
+                  </span>
+                </dd>
+              </div>
+            ))}
+          </dl>
+
+          <nav aria-label="Jump to a capability theme" className="flex flex-wrap gap-2">
+            {GROUPS.map((g) => (
+              <a
+                key={g.id}
+                href={`#${g.id}`}
+                className="inline-flex items-center gap-2 rounded-full border bg-card px-3 py-1.5 text-[13px] text-muted-foreground transition-colors hover:border-primary/45 hover:text-foreground"
+              >
+                <span
+                  aria-hidden
+                  className="size-2.5 rounded-[3px]"
+                  style={{ background: laneAccent(g.id) }}
+                />
+                {g.label}
+              </a>
+            ))}
+          </nav>
+        </div>
+
+        {/* Right: a real prefilled REPL query → "Run query" opens it live in /try. */}
+        <div className="overflow-hidden rounded-2xl border border-primary/25 bg-card shadow-elevation-2">
+          <div className="flex items-center justify-between gap-3 border-b px-4 py-3">
+            <div className="flex items-center gap-2.5">
+              <Badge variant="success" className="h-5 px-2 text-[11px]">
+                Live in your tab
+              </Badge>
+              <span className="text-sm font-medium">Live SPARQL REPL</span>
+            </div>
+            <Link
+              href="/try"
+              className="inline-flex h-8 items-center gap-1.5 rounded-md bg-primary px-3 text-[13px] font-semibold text-primary-foreground shadow-elevation-glow transition-transform hover:translate-y-px"
+            >
+              <Play className="size-3.5 fill-current" aria-hidden />
+              Run query
+            </Link>
+          </div>
+          <SparqlHighlight
+            query={HERO_QUERY}
+            className="overflow-x-auto bg-[color-mix(in_oklch,var(--background)_55%,var(--card))] px-5 py-4 text-[12.5px] leading-[1.7] text-foreground"
+          />
+          <p className="border-t px-5 py-2.5 text-[12px] text-muted-foreground">
+            The real prefilled query from the sample social graph —{" "}
+            <Link
+              href="/try"
+              className="inline-flex items-center gap-1 font-medium text-primary underline-offset-4 hover:underline"
+            >
+              open it in the live REPL
+              <ArrowRight className="size-3" aria-hidden />
+            </Link>
+            .
+          </p>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/site/src/components/capabilities/capability-lane.tsx
+++ b/site/src/components/capabilities/capability-lane.tsx
@@ -1,0 +1,96 @@
+// [OPUS-4.8] sq-vw3ax — bold /capabilities redesign LANE (server component).
+//
+// Faithful to the approved mockup (web-capabilities.html §LANE): each theme is a horizontal
+// "lane" with a sticky NUMBERED spine (01 / 05) + a per-theme accent (chart-1…5) + a tile grid,
+// so the five capability areas read as five distinct places — scannable without reading every
+// blurb. The tiles are the existing CapabilityRowItem (lazy-mount machinery preserved); the
+// query-data lane carries the "open the live REPL" affordance, and the privacy lane carries the
+// explicit research-grade caveat strip (LIVE privacy-claims honesty, made loud not hidden).
+
+import Link from "next/link";
+import { AlertTriangle, PlayCircle } from "lucide-react";
+
+import { type CapabilityTheme } from "@/data/capabilities";
+import { CapabilityRowItem } from "@/components/capabilities/capability-row";
+import { laneAccent } from "@/components/capabilities/lane-accents";
+
+export function CapabilityLane({
+  theme,
+  index,
+  total,
+}: {
+  theme: CapabilityTheme;
+  index: number;
+  total: number;
+}) {
+  const { group, rows } = theme;
+  const accent = laneAccent(group.id);
+  const idx = String(index + 1).padStart(2, "0");
+  const count = String(total).padStart(2, "0");
+
+  return (
+    <section
+      id={group.id}
+      // scroll-mt clears the sticky h-16 shell header when an in-page #anchor is targeted.
+      className="scroll-mt-24 grid gap-7 border-t py-8 lg:grid-cols-[232px_1fr]"
+    >
+      {/* Sticky numbered spine — the lane's identity. */}
+      <div className="lg:sticky lg:top-24 lg:self-start">
+        <div className="font-mono text-[12px] tracking-wide text-primary">
+          {idx} / {count}
+        </div>
+        <h3 className="mt-2.5 text-[22px] font-semibold tracking-tight">
+          {group.label}
+        </h3>
+        <p className="mt-2.5 max-w-[30ch] text-[13.5px] text-muted-foreground">
+          {group.description}
+        </p>
+        <span
+          aria-hidden
+          className="mt-3.5 block h-[3px] w-9 rounded-full"
+          style={{ background: accent }}
+        />
+        {group.id === "query-data" && (
+          <Link
+            href="/try"
+            className="mt-4 inline-flex items-center gap-1.5 text-[13px] font-semibold text-primary underline-offset-4 hover:underline"
+          >
+            <PlayCircle className="size-4" aria-hidden />
+            Open the full live SPARQL REPL
+          </Link>
+        )}
+      </div>
+
+      {/* The tile grid. */}
+      <div className="grid gap-3 sm:grid-cols-2">
+        {rows.map(({ surface, kind }) => (
+          <CapabilityRowItem
+            key={surface.slug}
+            slug={surface.slug}
+            kind={kind}
+            accent={accent}
+          />
+        ))}
+
+        {/* Privacy lane: the explicit research-grade caveat strip (made loud, not a footnote). */}
+        {group.id === "privacy" && (
+          <div className="flex items-start gap-3 rounded-[var(--radius-lg)] border border-dashed border-[color-mix(in_oklch,var(--warning)_45%,var(--border))] bg-[color-mix(in_oklch,var(--warning)_7%,transparent)] px-4 py-3 text-[12.7px] text-muted-foreground sm:col-span-2">
+            <AlertTriangle
+              className="mt-0.5 size-4 shrink-0 text-[var(--warning)]"
+              aria-hidden
+            />
+            <span>
+              <span className="font-semibold text-foreground">
+                Research-grade, labelled as such.
+              </span>{" "}
+              The v1 ZK verifier is not externally audited — sound as landed under its
+              stated threat model, pending re-review. MPC runs as a faithful in-tab
+              simulation of the native protocol, not a proof of correctness. Indicative
+              engineering, not an audited cryptographic guarantee.
+            </span>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/site/src/components/capabilities/capability-row.tsx
+++ b/site/src/components/capabilities/capability-row.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-// [OPUS-4.8] sq-vw3ax.3 — one ~64px gallery row in /capabilities.
+// [OPUS-4.8] sq-vw3ax.3 / sq-vw3ax — one capability affordance in /capabilities.
 //
 // Three shapes (data/capabilities.ts `classify`):
 //   * deep  → a plain link "Open →" to the surface's retained /surface/<slug> deep page.
@@ -9,9 +9,13 @@
 //             <details> holding ONE caveat sentence + README + SKILL links.
 //   * soon  → a non-interactive "Coming soon" row that links out to GitHub.
 //
-// The lazy-mount is the load-bearing requirement: `mounted` flips true on first expand and the
-// demo chunk is fetched only then (see lazy-demo.tsx). Collapsing keeps `mounted` true so a
-// re-expand never re-fetches; we hide the body with CSS rather than unmounting.
+// [OPUS-4.8] sq-vw3ax — BOLD redesign: each affordance now renders as a depth TILE (the
+// approved web-capabilities.html lane layout) instead of a flat 64px row, with a per-theme
+// accent line that reveals on hover. The lazy-mount machinery is UNCHANGED — it is the
+// load-bearing #1 risk (research/website-redesign.md §3 COLLAPSE): `mounted` flips true on
+// first expand and the demo chunk is fetched only then (see lazy-demo.tsx). Collapsing keeps
+// `mounted` true so a re-expand never re-fetches; we hide the body with CSS rather than
+// unmounting. The heavy bb.js / noir_js graph stays isolated to the ZK chunk alone.
 
 import * as React from "react";
 import Link from "next/link";
@@ -102,42 +106,69 @@ function TierBadge({ surface }: { surface: Surface }) {
   );
 }
 
-function RowShell({
+/** The shared tile body: accent line + icon + title/blurb + tier badge + a trailing CTA.
+ *  `interactive` toggles the hover lift (a button/link wrapper supplies the actual semantics). */
+function TileShell({
   surface,
-  trailing,
+  accent,
+  cta,
+  interactive = true,
 }: {
   surface: Surface;
-  trailing: React.ReactNode;
+  accent: string;
+  cta: React.ReactNode;
+  interactive?: boolean;
 }) {
   const Icon = surface.icon;
   return (
-    <div className="flex items-center gap-3 px-3 py-3">
-      <span className="flex size-9 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
-        <Icon className="size-4.5" aria-hidden />
+    <div
+      className={cn(
+        "relative flex items-start gap-3 overflow-hidden rounded-[var(--radius-lg)] border bg-card px-4 py-3.5 transition-all duration-150",
+        interactive &&
+          "hover:-translate-y-0.5 hover:border-primary/45 hover:shadow-elevation-2 [&:hover>[data-accent]]:opacity-90",
+      )}
+    >
+      {/* The per-theme accent spine — revealed on hover. */}
+      <span
+        data-accent
+        aria-hidden
+        className="absolute inset-y-0 left-0 w-[3px] opacity-0 transition-opacity duration-150"
+        style={{ background: accent }}
+      />
+      <span className="flex size-9 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-primary/10 text-primary">
+        <Icon className="size-[18px]" aria-hidden />
       </span>
-      <div className="flex min-w-0 flex-1 flex-col">
-        <span className="truncate text-sm font-medium">{surface.title}</span>
-        <span className="truncate text-sm text-muted-foreground">{surface.blurb}</span>
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-semibold tracking-tight">{surface.title}</div>
+        <div className="mt-1 text-[12.7px] leading-snug text-muted-foreground">
+          {surface.blurb}
+        </div>
       </div>
-      <TierBadge surface={surface} />
-      {trailing}
+      <div className="flex shrink-0 flex-col items-end gap-2">
+        <TierBadge surface={surface} />
+        {cta}
+      </div>
     </div>
   );
 }
 
-/** "Open →" deep-page row — a plain link to the surface's retained deep page. */
-function DeepRow({ surface }: { surface: Surface }) {
+const CTA_CLASS =
+  "inline-flex items-center gap-1 text-[12px] font-semibold text-primary";
+
+/** "Open →" deep-page tile — a plain link to the surface's retained deep page. */
+function DeepTile({ surface, accent }: { surface: Surface; accent: string }) {
   return (
     <Link
       href={surface.href}
-      className="group block rounded-xl transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      className="group block rounded-[var(--radius-lg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
     >
-      <RowShell
+      <TileShell
         surface={surface}
-        trailing={
-          <span className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-primary">
+        accent={accent}
+        cta={
+          <span className={CTA_CLASS}>
             Open
-            <ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+            <ArrowRight className="size-3 transition-transform group-hover:translate-x-0.5" />
           </span>
         }
       />
@@ -145,21 +176,22 @@ function DeepRow({ surface }: { surface: Surface }) {
   );
 }
 
-/** "Coming soon" row — no demo yet; links out to source. */
-function SoonRow({ surface }: { surface: Surface }) {
+/** "Coming soon" tile — no demo yet; links out to source. */
+function SoonTile({ surface, accent }: { surface: Surface; accent: string }) {
   return (
     <a
       href={REPO_URL}
       target="_blank"
       rel="noopener noreferrer"
-      className="group block rounded-xl transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+      className="group block rounded-[var(--radius-lg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
     >
-      <RowShell
+      <TileShell
         surface={surface}
-        trailing={
-          <span className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-muted-foreground">
+        accent={accent}
+        cta={
+          <span className="inline-flex items-center gap-1 text-[12px] font-medium text-muted-foreground">
             Source
-            <ExternalLink className="size-3.5" />
+            <ExternalLink className="size-3" />
           </span>
         }
       />
@@ -167,8 +199,16 @@ function SoonRow({ surface }: { surface: Surface }) {
   );
 }
 
-/** "Demo ▸" expand-in-place row — lazily mounts the demo on first expand. */
-function DemoRow({ surface, slug }: { surface: Surface; slug: LazyDemoSlug }) {
+/** "Demo ▸" expand-in-place tile — lazily mounts the demo on first expand. */
+function DemoTile({
+  surface,
+  slug,
+  accent,
+}: {
+  surface: Surface;
+  slug: LazyDemoSlug;
+  accent: string;
+}) {
   const [open, setOpen] = React.useState(false);
   // Once mounted, stay mounted across collapse/re-expand so the chunk is fetched at most once.
   const [mounted, setMounted] = React.useState(false);
@@ -183,21 +223,22 @@ function DemoRow({ surface, slug }: { surface: Surface; slug: LazyDemoSlug }) {
   };
 
   return (
-    <div className="rounded-xl">
+    <div>
       <button
         type="button"
         onClick={toggle}
         aria-expanded={open}
-        className="group flex w-full items-center rounded-xl text-left transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+        className="group block w-full rounded-[var(--radius-lg)] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
       >
-        <RowShell
+        <TileShell
           surface={surface}
-          trailing={
-            <span className="inline-flex shrink-0 items-center gap-1 text-sm font-medium text-primary">
+          accent={accent}
+          cta={
+            <span className={CTA_CLASS}>
               Demo
               <ChevronRight
                 className={cn(
-                  "size-3.5 transition-transform",
+                  "size-3 transition-transform",
                   open && "rotate-90",
                 )}
                 aria-hidden
@@ -210,12 +251,12 @@ function DemoRow({ surface, slug }: { surface: Surface; slug: LazyDemoSlug }) {
       {/* The body is only present in the DOM once first expanded; CSS hides it on collapse so a
           re-expand does not re-fetch the chunk (mounted stays true). */}
       {mounted && (
-        <div className={cn("px-3 pb-4", !open && "hidden")} data-demo-body={slug}>
-          <div className="rounded-lg border bg-muted/20 p-3">
+        <div className={cn("px-1 pt-3", !open && "hidden")} data-demo-body={slug}>
+          <div className="rounded-[var(--radius-lg)] border bg-muted/20 p-3">
             <LazyDemo slug={slug} mounted={mounted} />
           </div>
 
-          <details className="mt-3 rounded-lg border bg-card px-3 py-2 text-sm">
+          <details className="mt-3 rounded-[var(--radius-lg)] border bg-card px-3 py-2 text-sm">
             <summary className="cursor-pointer select-none font-medium text-foreground/90">
               Details &amp; caveats
             </summary>
@@ -247,24 +288,26 @@ function DemoRow({ surface, slug }: { surface: Surface; slug: LazyDemoSlug }) {
   );
 }
 
-// [OPUS-4.8] sq-vw3ax.3 — the boundary is `slug` (a string) + `kind`, NOT the Surface object:
-// a Surface carries a lucide `icon` function, which cannot cross the server→client RSC boundary
-// (it is not serializable). The server /capabilities page passes the serializable slug; this
-// client component resolves the full surface (icon included) from the GROUPS source by slug.
+// [OPUS-4.8] sq-vw3ax.3 — the boundary is `slug` (a string) + `kind` + `accent`, NOT the Surface
+// object: a Surface carries a lucide `icon` function, which cannot cross the server→client RSC
+// boundary (it is not serializable). The server /capabilities page passes the serializable slug
+// + the theme accent; this client component resolves the full surface (icon included) by slug.
 export function CapabilityRowItem({
   slug,
   kind,
+  accent = "var(--primary)",
 }: {
   slug: string;
   kind: "deep" | "demo" | "soon";
+  accent?: string;
 }) {
   const surface = surfaceBySlug(slug);
   if (!surface) return null; // data drift — a row for an unknown surface; render nothing.
-  if (kind === "deep") return <DeepRow surface={surface} />;
-  if (kind === "soon") return <SoonRow surface={surface} />;
+  if (kind === "deep") return <DeepTile surface={surface} accent={accent} />;
+  if (kind === "soon") return <SoonTile surface={surface} accent={accent} />;
   // demo — guard against a data drift where a "demo" surface lacks a registered demo.
   if (hasLazyDemo(surface.slug)) {
-    return <DemoRow surface={surface} slug={surface.slug} />;
+    return <DemoTile surface={surface} slug={surface.slug} accent={accent} />;
   }
-  return <SoonRow surface={surface} />;
+  return <SoonTile surface={surface} accent={accent} />;
 }

--- a/site/src/components/capabilities/flagship-band.tsx
+++ b/site/src/components/capabilities/flagship-band.tsx
@@ -1,0 +1,80 @@
+// [OPUS-4.8] sq-vw3ax — bold /capabilities redesign FLAGSHIP band (server component).
+//
+// Faithful to the approved mockup (web-capabilities.html §FLAGSHIPS): the three flagship demos
+// promoted to a hero band ("start here") as large depth cards, BEFORE the long tail. Each card
+// is a real Surface from FLAGSHIPS (data/surfaces.ts) — real title, blurb, tier badge, and the
+// real /showcase/<slug> route. The lead card gets extra glow + a span. NO fabricated metrics:
+// the card shows only the honest blurb + tier badge; the proof itself runs on the linked page.
+
+import Link from "next/link";
+import { ArrowRight, Star } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Badge } from "@/components/ui/badge";
+import { FLAGSHIPS, TIER_LABEL, TIER_VARIANT } from "@/data/surfaces";
+
+export function FlagshipBand() {
+  return (
+    <section aria-labelledby="flagships-heading" className="space-y-5">
+      <div className="space-y-2">
+        <p className="kicker">Start here</p>
+        <h2 id="flagships-heading" className="display-2 font-semibold">
+          Three proofs that the breadth is real
+        </h2>
+        <p className="measure text-[15px] text-muted-foreground">
+          Not feature checkboxes — complete, runnable demos that each prove one hard
+          thing. Open one and walk away having seen it work.
+        </p>
+      </div>
+
+      <ul className="grid gap-4 lg:grid-cols-[1.25fr_1fr_1fr]">
+        {FLAGSHIPS.map((surface, i) => {
+          const Icon = surface.icon;
+          const lead = i === 0;
+          return (
+            <li key={surface.slug} className={cn(lead && "lg:row-span-1")}>
+              <Link
+                href={surface.href}
+                className={cn(
+                  "group relative flex h-full flex-col overflow-hidden rounded-[var(--radius-2xl)] border bg-card p-6 transition-all duration-200",
+                  "hover:-translate-y-0.5 hover:border-primary/45 hover:shadow-elevation-glow",
+                  lead &&
+                    "bg-[radial-gradient(110%_90%_at_100%_0%,color-mix(in_oklch,var(--primary)_16%,transparent),transparent_55%),radial-gradient(90%_90%_at_0%_100%,color-mix(in_oklch,var(--chart-5)_12%,transparent),transparent_55%),var(--card)]",
+                )}
+              >
+                <span className="absolute right-5 top-5 inline-flex items-center gap-1 font-mono text-[11px] text-primary">
+                  <Star className="size-3 fill-current" aria-hidden />
+                  {lead && "flagship"}
+                </span>
+
+                <span className="flex size-11 items-center justify-center rounded-[var(--radius-md)] border border-primary/30 bg-primary/15 text-primary">
+                  <Icon className="size-5" aria-hidden />
+                </span>
+
+                <h3 className="mt-4 text-lg font-semibold tracking-tight">
+                  {surface.title}
+                </h3>
+                <p className="mt-2 flex-1 text-sm text-muted-foreground">
+                  {surface.blurb}
+                </p>
+
+                <div className="mt-4 flex items-center justify-between gap-3">
+                  <Badge
+                    variant={TIER_VARIANT[surface.tier]}
+                    className="h-5 px-2 text-[11px]"
+                  >
+                    {TIER_LABEL[surface.tier]}
+                  </Badge>
+                  <span className="inline-flex items-center gap-1.5 text-[13.5px] font-semibold text-primary">
+                    Open demo
+                    <ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+                  </span>
+                </div>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/site/src/components/capabilities/hero-stats.ts
+++ b/site/src/components/capabilities/hero-stats.ts
@@ -1,0 +1,58 @@
+// [OPUS-4.8] sq-vw3ax — bold /capabilities redesign: the hero stat strip, computed from REAL
+// data (data/surfaces.ts), NEVER hardcoded. The approved mockup showed illustrative figures
+// ("16 surfaces · 5 live · 3 flagships"); here every number is DERIVED from GROUPS / FLAGSHIPS /
+// the tier set at module load, so a future surface/tier edit re-derives the strip and the page
+// can never drift into a fabricated count.
+
+import { ALL_SURFACES, FLAGSHIPS, GROUPS, type Tier } from "@/data/surfaces";
+
+/** Tiers that actually EXECUTE the engine in the visitor's tab (wasm or 3rd-party wasm/JS),
+ *  as opposed to a captured-output walkthrough / hosted / not-yet-built surface. This is the
+ *  honest "runs in your tab" set — derived from the Tier union, not a magic number. */
+const IN_TAB_TIERS: ReadonlySet<Tier> = new Set<Tier>([
+  "live",
+  "live-new-wasm",
+  "live-bbjs",
+  "live-sim",
+]);
+
+export interface HeroStat {
+  /** The numeric value (rendered in mono). */
+  value: string;
+  /** A short unit suffix shown in the primary colour (optional). */
+  unit?: string;
+  /** The caption beneath the figure. */
+  caption: string;
+}
+
+/** The number of surfaces that run the engine live in-tab (any in-tab tier). */
+export const IN_TAB_SURFACE_COUNT = ALL_SURFACES.filter((s) =>
+  IN_TAB_TIERS.has(s.tier),
+).length;
+
+export const SURFACE_COUNT = ALL_SURFACES.length;
+export const THEME_COUNT = GROUPS.length;
+export const FLAGSHIP_COUNT = FLAGSHIPS.length;
+
+/** The hero stat strip — all four figures derived from the real data model. */
+export const HERO_STATS: HeroStat[] = [
+  {
+    value: String(SURFACE_COUNT),
+    unit: "surfaces",
+    caption: `across ${THEME_COUNT} capability themes`,
+  },
+  {
+    value: String(IN_TAB_SURFACE_COUNT),
+    unit: "in-tab",
+    caption: "run the real engine in your browser",
+  },
+  {
+    value: String(FLAGSHIP_COUNT),
+    unit: "flagships",
+    caption: "ZK · MPC · Solid, end-to-end",
+  },
+  {
+    value: "1.1 / 1.2",
+    caption: "SPARQL + RDF-star, native Rust",
+  },
+];

--- a/site/src/components/capabilities/lane-accents.ts
+++ b/site/src/components/capabilities/lane-accents.ts
@@ -1,0 +1,24 @@
+// [OPUS-4.8] sq-vw3ax — bold /capabilities redesign: the per-theme accent map.
+//
+// The approved mockup (sparq-design-system/proposals/web-capabilities.html) gives each of the
+// five capability themes a distinct accent drawn from the existing OKLCH chart palette
+// (--chart-1…5) so the lanes read as five distinct PLACES, scannable without reading every
+// blurb. This is a single source of truth keyed by the theme's stable anchor id (data/surfaces.ts
+// `GROUPS[].id`). NO new hue is invented — every value is an existing `--chart-*` token, which
+// already carries light + dark variants, so the accents follow the theme automatically.
+
+/** The `--chart-*` CSS variable each theme's lane is accented with (mockup order). */
+export const LANE_ACCENT: Record<string, string> = {
+  "query-data": "var(--chart-1)",
+  "reason-validate": "var(--chart-2)",
+  "search-genai": "var(--chart-3)",
+  privacy: "var(--chart-5)",
+  "serve-embed": "var(--chart-4)",
+};
+
+/** Fallback accent for any theme id not in the map (keeps the brand teal). */
+export const DEFAULT_ACCENT = "var(--primary)";
+
+export function laneAccent(themeId: string): string {
+  return LANE_ACCENT[themeId] ?? DEFAULT_ACCENT;
+}

--- a/site/src/components/capabilities/sparql-highlight.tsx
+++ b/site/src/components/capabilities/sparql-highlight.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+// [OPUS-4.8] sq-vw3ax — read-only SPARQL syntax-highlight renderer for the /capabilities hero
+// code panel. The display counterpart of RdfHighlight (which does Turtle): it tokenizes the
+// query with the dependency-free `@sparq/client` `tokenizeSparql` core and wraps each token in
+// the SAME `.sq-tok-*` classes globals.css already defines, so highlighting follows light/dark
+// automatically and adds NO new palette and NO new dependency. Pure presentation, static-export
+// safe — the gap-free tokenizer reproduces the source query exactly.
+
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+import { type SparqlToken, tokenizeSparql } from "@sparq/client";
+
+const TOKEN_CLASS: Record<SparqlToken["type"], string> = {
+  keyword: "sq-tok-keyword",
+  variable: "sq-tok-variable",
+  iri: "sq-tok-iri",
+  prefixed: "sq-tok-prefixed",
+  string: "sq-tok-string",
+  number: "sq-tok-number",
+  comment: "sq-tok-comment",
+  punctuation: "",
+  plain: "",
+};
+
+export function SparqlHighlight({
+  query,
+  className,
+}: {
+  query: string;
+  className?: string;
+}) {
+  const tokens = React.useMemo(() => tokenizeSparql(query), [query]);
+  return (
+    <pre className={cn("font-mono", className)} aria-label="Example SPARQL query">
+      {tokens.map((t, idx) => {
+        const cls = TOKEN_CLASS[t.type];
+        return cls ? (
+          <span key={idx} className={cls}>
+            {t.text}
+          </span>
+        ) : (
+          <React.Fragment key={idx}>{t.text}</React.Fragment>
+        );
+      })}
+    </pre>
+  );
+}

--- a/site/src/components/capabilities/tier-legend.tsx
+++ b/site/src/components/capabilities/tier-legend.tsx
@@ -1,0 +1,69 @@
+// [OPUS-4.8] sq-vw3ax — bold /capabilities redesign tier LEGEND (server component).
+//
+// Faithful to the approved mockup (web-capabilities.html §LEGEND): the honesty contract made
+// first-class — a legend of the tier badges with a one-line gloss each. DRIVEN BY REAL DATA:
+// it lists exactly the tiers that ACTUALLY appear across the surface set (data/surfaces.ts), in
+// the canonical Tier order, so it can never advertise a badge no surface uses or omit one that
+// does. The gloss explains what each badge promises about how that surface runs in-tab.
+
+import { ALL_SURFACES, TIER_LABEL, TIER_VARIANT, type Tier } from "@/data/surfaces";
+import { Badge } from "@/components/ui/badge";
+
+/** Canonical tier order (matches the Tier union) for a stable legend. */
+const TIER_ORDER: Tier[] = [
+  "live",
+  "live-new-wasm",
+  "live-bbjs",
+  "live-sim",
+  "hosted",
+  "walkthrough",
+  "soon",
+];
+
+/** One-line honest gloss per tier — what the badge promises about execution. */
+const TIER_GLOSS: Record<Tier, string> = {
+  live: "shipped wasm, running in your tab now",
+  "live-new-wasm": "an additional wasm bundle, lazy-loaded on expand",
+  "live-bbjs": "in-tab proving via 3rd-party bb.js UltraHonk",
+  "live-sim": "a faithful in-tab JS simulation of the native protocol",
+  hosted: "a sparq-server endpoint",
+  walkthrough: "captured, verbatim engine output replayed (no backend on a static site)",
+  soon: "not built yet — an honest placeholder",
+};
+
+export function TierLegend() {
+  const present = new Set(ALL_SURFACES.map((s) => s.tier));
+  const tiers = TIER_ORDER.filter((t) => present.has(t));
+
+  return (
+    <section aria-labelledby="surfaces-heading" className="space-y-4">
+      <div className="space-y-2">
+        <p className="kicker">The full surface set</p>
+        <h2 id="surfaces-heading" className="display-2 font-semibold">
+          Every capability, five themes
+        </h2>
+        <p className="measure text-[15px] text-muted-foreground">
+          Each tile is a real surface. The badge is the honest contract for how that
+          surface runs on this static site.
+        </p>
+      </div>
+
+      <ul className="flex flex-wrap gap-x-5 gap-y-2.5 rounded-[var(--radius-lg)] border bg-card/60 px-4 py-3.5">
+        {tiers.map((t) => (
+          <li
+            key={t}
+            className="inline-flex items-center gap-2 text-[12.5px] text-muted-foreground"
+          >
+            <Badge
+              variant={TIER_VARIANT[t]}
+              className="h-5 px-2 text-[11px]"
+            >
+              {TIER_LABEL[t]}
+            </Badge>
+            {TIER_GLOSS[t]}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bold redesign of the `/capabilities` surface on the merged dark-first foundation.

Reimagines `/capabilities` faithful to the approved mockup ([`proposals/web-capabilities.html`](https://github.com/jeswr/sparq/blob/main/../sparq-design-system/proposals/web-capabilities.html) — `sparq-design-system/proposals/web-capabilities.html`) on top of the now-merged dark-first foundation (#1261), under the redesign epic **sq-vw3ax**. The maintainer approved shipping all surfaces.

## What it is
An opinionated, scannable showcase of the full **16-surface / 5-theme** set — not a wall of uniform cards. Built entirely from the single `GROUPS` / `FLAGSHIPS` source (`data/surfaces.ts`): **every name, blurb, tier badge, and route is REAL**, and **every hero figure is DERIVED from that data** (`hero-stats.ts`), never hardcoded.

Structure (mockup order):
1. **HERO** — display heading + brand teal→violet gradient (foundation `.text-gradient` / `--hero-grad`, **no new hue**), a derived stat strip (**16 surfaces · 10 in-tab · 3 flagships · SPARQL 1.1/1.2** — all computed from the real tier set), a theme jump-rail with per-theme accent swatches, and the **REAL prefilled REPL query** from `sample-graph.ts` rendered with the shared `.sq-tok-*` highlighter. The **Run query** CTA opens it live in `/try` — no fabricated result rendered inline.
2. **FLAGSHIP band** — the three flagships promoted to "start here" depth cards, linking their real `/showcase/*` routes.
3. **LEGEND** — the tier honesty contract made first-class, driven by the tiers actually present in the data.
4. **Five LANES** — each a sticky numbered spine (`01 / 05` …) + a per-theme `--chart-*` accent + a tile grid. The query lane carries the "open the live REPL" affordance; the **privacy lane carries the explicit research-grade caveat strip** (the v1 ZK verifier is **not externally audited** — sound as landed under its stated threat model, pending re-review; MPC runs as a faithful in-tab **simulation**, not a proof of correctness; indicative engineering, not an audited cryptographic guarantee).

## Honesty / real data (load-bearing)
- No placeholder/fabricated result rows, triple counts, or timings. The hero panel shows the real query and links out to the live REPL; the flagship cards show only the honest blurb + tier badge (the proof runs on the linked page).
- The stat strip's "10 in-tab" is **derived** (`live` + `live-new-wasm` + `live-bbjs` + `live-sim`), not the mockup's illustrative "5".
- LIVE **privacy-claims** gate passes; the ZK/MPC copy carries the not-externally-audited caveat.

## Lazy-mount preserved (the #1 risk)
The tiles reuse the existing lazy-demo machinery **unchanged** — the heavy `bb.js`/`noir_js` graph stays code-split off the `/capabilities` first-load bundle (the route exports at **8.49 kB / 199 kB First Load JS**). The `data-demo-body` / `aria-expanded` hooks the e2e spec asserts are preserved.

## Scope discipline
Touched **only** `site/src/app/capabilities/page.tsx` + `site/src/components/capabilities/*`. **No** edits to `globals.css` or shared primitives (the foundation owns them) and no other surface's files. Foundation utilities used as-is: `.bg-atmos`/`.bg-grid`/`.text-gradient`/`.display-1`/`.display-2`/`.kicker`/`shadow-elevation-*`.

## Gates (all green locally)
- `cd site && npm install && npm run build` → static export succeeds **end-to-end**, all routes emitted to `out/` with `basePath` `/sparq` intact (`/`, `/benchmarks/*`, `/papers`, `/try`, `/surface/*`, `/showcase/*` all still build).
- `npm run lint` clean · `tsc --noEmit` clean · `scripts/check-privacy-claims.sh` clean.
- **WASM prereq** built first (`cd js && npm run build:wasm`) — a build artifact only, **no** `crates/` source changes.
- No new dependency — pure CSS/foundation utilities + a dependency-free read-only SPARQL highlighter reusing `@sparq/client`'s `tokenizeSparql`. Zero bundle-size cost beyond the page itself.

## Verification
Rendered the static `out/` under a `/sparq` mount and screenshotted both themes — the dark-first ground + atmospheric glow + gradient heading + lanes render faithfully, and the brand holds in light too.

**Covered:** the full mockup layout/hierarchy/visual language for `/capabilities`.
**Deferred:** none for this surface. (The mockup's aspirational extra rows — a structural-similarity surface, a federation surface page — have no route today and are intentionally NOT fabricated here, per the data source's note; they remain beads under the epic, not invented nav entries.)

auto-merge intentionally **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)