### PR TITLE
test(shacl): gate the FULL vendored W3C SHACL 1.2 suite in CI (sq-6glcr)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -839,7 +839,7 @@ jobs:
           path: conformance-report.md
 
   shacl-conformance:
-    # [OPUS-4.8] W3C SHACL conformance RATCHET (sq-qap0). The data-shapes
+    # [OPUS-4.8] W3C SHACL conformance RATCHET (sq-qap0, sq-6glcr). The data-shapes
     # sht:Validate suites run as `cargo test` (the runners live in
     # crates/sparq-shacl/tests/w3c_core.rs + w3c_sparql.rs, each carrying its own
     # pinned pass-count floor); the normal `cargo test --workspace` job runs
@@ -850,7 +850,16 @@ jobs:
     # `assert!(pass >= BASELINE_PASS)` is the primary gate; the grep below is the
     # same `>= N` belt-and-braces check the conformance jobs use. Never lower the
     # ratchet (raise BASELINE_PASS / SHACL_SPARQL_FLOOR as coverage grows).
-    name: W3C SHACL conformance (ratchet — core >= 98, sparql >= 5)
+    #
+    # [OPUS-4.8] sq-6glcr: this job ALSO gates the FULL vendored SHACL **1.2**
+    # suite (shacl12-test-suite/tests), not just the 1.0/1.1 data-shapes core/node
+    # slice. The full core manifest tree (w3c_core_full_shacl12 — complex / misc /
+    # node / path / property / targets / validation-reports), the 1.2 SPARQL suite
+    # (w3c_sparql_shacl12, including the 7 `mf:result sht:Failure` rejection
+    # entries), and the node-expr suites (w3c_node_expr{,_constraints}) each carry
+    # their own ratchet floor and run in BOTH feature states (default + shacl-af).
+    # See research/shacl12-conformance-gap.md for the per-category gap map.
+    name: W3C SHACL conformance (ratchet — core >= 98, sparql >= 5; full 1.2 ratchets in-runner)
     needs: changes
     if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
@@ -899,6 +908,35 @@ jobs:
             echo "::warning::SHACL conformance attempt $attempt failed (exit $rc) — retrying once (sq-shacl-flake transient self-heal: most often a transient crates.io download hiccup before any test ran)."
             attempt=$((attempt + 1))
           done
+      - name: Run FULL W3C SHACL 1.2 suites (core / sparql / node-expr, both feature states)
+        # [OPUS-4.8] sq-6glcr: gate the FULL vendored SHACL 1.2 tree. Each runner
+        # carries its own pinned ratchet floor (pass must not drop, gap must not
+        # grow) and self-SKIPs when the fixtures are absent, so this step is the
+        # primary gate for the 1.2 surface; the scoreboards are captured for the
+        # artifact. Run in BOTH feature states — default (SHACL Core + SHACL-SPARQL)
+        # and shacl-af (sh:rule / sh:expression / sh:nodeByExpression) — so the
+        # feature-gated entries (e.g. nodeByExpression-001, the node-expr suites)
+        # are gated too. A genuine regression trips a runner's own
+        # `assert!(pass >= floor)` / `assert!(gap <= ceiling)`. The w3c_node_expr*
+        # runners are themselves `#[cfg(feature = "shacl-af")]`, so they only
+        # produce a scoreboard in the shacl-af pass (compiled out by default).
+        run: |
+          set -uo pipefail
+          SHACL12_TESTS="--test w3c_core_full_shacl12 --test w3c_sparql_shacl12 --test w3c_node_expr --test w3c_node_expr_constraints"
+          echo "::group::SHACL 1.2 — default features"
+          cargo test -p sparq-shacl $SHACL12_TESTS -- --nocapture \
+            | tee -a shacl-conformance.out
+          rc_default=${PIPESTATUS[0]}
+          echo "::endgroup::"
+          echo "::group::SHACL 1.2 — shacl-af feature"
+          cargo test -p sparq-shacl --features shacl-af $SHACL12_TESTS -- --nocapture \
+            | tee -a shacl-conformance.out
+          rc_af=${PIPESTATUS[0]}
+          echo "::endgroup::"
+          if [ "$rc_default" -ne 0 ] || [ "$rc_af" -ne 0 ]; then
+            echo "::error::FULL SHACL 1.2 suite regressed (default rc=$rc_default, shacl-af rc=$rc_af) — a runner's pinned ratchet floor/ceiling tripped. Inspect the per-category scoreboard above; see research/shacl12-conformance-gap.md. The floors are never weakened — closing a gap moves a FAIL to PASS and bumps the floor in the same commit."
+            exit 1
+          fi
       - name: Enforce ratchet (pass counts must not regress)
         run: |
           CORE_FLOOR=98

--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -60,10 +60,11 @@ For many data graphs against one shapes graph, parse once with
   `cargo test -p sparq-shacl --test w3c_core`.
 - **SHACL 1.2 core constraints** — `sh:memberShape`, `sh:uniqueMembers`,
   `sh:{min,max}ListLength`, `sh:uniqueValuesFor`, `sh:closed sh:ByTypes`, and the
-  disjunctive-list forms of `sh:datatype`/`sh:nodeKind` (sq-vg3y). The 1.2 harness
-  passes strictly **44/45** with `shacl-af` off — the one SKIP is `nodeByExpression-001`,
-  a `shacl-af` constraint — and **45/45** with it on; it stays SKIP-tolerant only for a
-  constraint predicate the build still lacks, never masking a regression.
+  disjunctive-list forms of `sh:datatype`/`sh:nodeKind` (sq-vg3y). The **full** vendored
+  1.2 suite is gated by a ratchet (sq-6glcr): core **114/115** (of 137), SPARQL **10** (of
+  24, incl. 7 expected-rejection `sht:Failure` entries), node-expr **65/65** — pass must
+  not drop, the gap must not grow, in both feature states. The not-yet-passing entries are
+  the honest gap map in [`research/shacl12-conformance-gap.md`](../../research/shacl12-conformance-gap.md).
 - **SHACL-SPARQL + custom §6 components** — `sh:sparql` (§5.2) and SPARQL-based
   constraint *components* (custom `sh:ConstraintComponent` with `sh:parameter` /
   `sh:validator`, §6), pinned by the W3C `sparql/*` sub-suites.

--- a/crates/sparq-shacl/tests/w3c_core_full_shacl12.rs
+++ b/crates/sparq-shacl/tests/w3c_core_full_shacl12.rs
@@ -1,0 +1,530 @@
+//! [OPUS-4.8] (sq-6glcr) Manifest-driven runner for the **FULL** SHACL 1.2 core
+//! test suite — the whole `shacl12-test-suite/tests/core/manifest.ttl`
+//! `mf:include` tree (`complex/`, `misc/`, `node/`, `path/`, `property/`,
+//! `targets/`, `validation-reports/`), not just the `node/` subtree that
+//! `w3c_core_shacl12.rs` gates.
+//!
+//! `w3c_core_shacl12.rs` is the tight strict gate over `core/node` only;
+//! `w3c_core.rs` walks the *older* `data-shapes-test-suite/tests/core` tree. This
+//! harness closes the gap flagged in `research/shacl12-conformance-gap.md`: until
+//! sq-6glcr the SHACL-1.2-specific behaviour exercised by `complex/` (recursive
+//! shapes, message templating), `path/` (alternative / one-or-more / zero-or-more
+//! property paths), `property/` (the full property-constraint matrix),
+//! `targets/`, and `validation-reports/` (report-shape detail) was never gated in
+//! CI, so a regression there could merge unnoticed.
+//!
+//! ## SKIP vs FAIL — and why this gate does NOT assert all-pass
+//!
+//! An entry is **SKIP**, not FAIL, exactly when its shapes graph uses a
+//! constraint-component *predicate* that is wholly out of scope for the Core
+//! validator ([`unimplemented`]) — `sh:sparql` (SPARQL-based constraints),
+//! `sh:js` (JavaScript constraints), and (with `shacl-af` off) the
+//! node-expression constraints. Those are a different surface, so counting them
+//! as FAILs would be noise.
+//!
+//! Every *other* entry is compared strictly. Some of those entries exercise
+//! SHACL-**1.2** behaviour this crate does not yet fully implement (the
+//! path-list spelling of `sh:disjoint` / `sh:equals` / `sh:lessThan{,OrEquals}`,
+//! and the new `sh:reifierShape` / `sh:rootClass` / `sh:singleLine` /
+//! `sh:someValue` / `sh:subsetOf` / `sh:targetWhere` / `sh:shape` /
+//! `sh:ShapeClass` features), so they produce the wrong report and are honest
+//! **FAIL**s — they are the live gap map in `research/shacl12-conformance-gap.md`.
+//! This harness deliberately does **not** assert `fail == 0` for the full tree:
+//! that would be a false claim of full SHACL-1.2 conformance.
+//!
+//! ## Ratchet (two-sided)
+//!
+//! Instead the gate is a *ratchet*: the pass count must not drop
+//! ([`BASELINE_PASS_CORE`] / [`BASELINE_PASS_AF`]) **and** the fail count must
+//! not grow ([`BASELINE_FAIL_CORE`] / [`BASELINE_FAIL_AF`]). Together these catch
+//! a regression in either direction — a currently-passing entry breaking (pass
+//! drops) or a currently-failing entry that was being computed correctly
+//! flipping (fail grows) — while staying green today. Closing a gap means an
+//! entry moves FAIL → PASS: bump *both* baselines in the same commit. The floors
+//! were calibrated by running the harness at the pinned suite commit
+//! in-worktree.
+//!
+//! ## Two gates
+//!
+//!   * **Suite gate** — the suite is fetched by `./fetch-shacl-tests.sh` into
+//!     `tests/shacl/` (gitignored). When absent the test SKIPS itself so
+//!     `cargo test --workspace` stays green on a fresh checkout.
+//!   * **Feature gate** — this file is *not* `#[cfg]`-gated as a whole: it runs in
+//!     **both** feature states. With `shacl-af` ON, `sh:nodeByExpression` /
+//!     `sh:expression` based entries are implemented and the floor rises to
+//!     [`BASELINE_PASS_AF`].
+//!
+//! The report-comparison policy mirrors `w3c_core.rs` / `w3c_core_shacl12.rs`:
+//! `sh:conforms` must match, and the result multisets must correspond 1:1 where
+//! each expected result's stated `sh:focusNode` / `sh:resultPath` / `sh:value` /
+//! `sh:resultSeverity` / `sh:sourceConstraintComponent` / `sh:sourceShape` /
+//! `sh:resultMessage` agree (blank nodes match any blank node).
+
+use oxrdf::Term;
+use sparq_core::Graph;
+use sparq_shacl::view::GraphView;
+use sparq_shacl::{validate, Path, ValidationResult};
+use std::collections::BTreeMap;
+use std::path::{Path as FsPath, PathBuf};
+
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const MF: &str = "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#";
+const SHT: &str = "http://www.w3.org/ns/shacl-test#";
+const SH: &str = "http://www.w3.org/ns/shacl#";
+
+/// Constraint-component *predicates* (full IRIs) this crate's Core path does NOT
+/// implement; an entry whose shapes use any of these is a SKIP rather than a
+/// FAIL. `sh:sparql` (SPARQL-based constraints) and `sh:js` (JavaScript
+/// constraints) are out of scope for the Core validator; `sh:nodeByExpression` /
+/// `sh:expression` are implemented only under `shacl-af` and added per-build in
+/// [`unimplemented`].
+const UNIMPLEMENTED_CORE: &[&str] = &[
+    "http://www.w3.org/ns/shacl#sparql",
+    "http://www.w3.org/ns/shacl#js",
+    "http://www.w3.org/ns/shacl#jsLibrary",
+];
+
+/// The unimplemented-constraint predicate set for the current build. Feature
+/// dependent: `sh:nodeByExpression` / `sh:expression` are implemented only with
+/// `shacl-af`.
+fn unimplemented() -> Vec<String> {
+    let mut v: Vec<String> = UNIMPLEMENTED_CORE.iter().map(|s| s.to_string()).collect();
+    if cfg!(not(feature = "shacl-af")) {
+        v.push(format!("{SH}nodeByExpression"));
+        v.push(format!("{SH}expression"));
+    }
+    v
+}
+
+/// Pass-floor over the FULL core tree with `shacl-af` OFF, at the pinned suite
+/// commit (`fetch-shacl-tests.sh` PIN). Calibrated by running the harness; a
+/// regression below this fails the build, raising it is a deliberate bump.
+///
+/// [OPUS-4.8] (sq-6glcr) Set to the measured pass count; see
+/// `research/shacl12-conformance-gap.md` for the per-category gap map. With
+/// `shacl-af` off the `nodeByExpression-001` node entry is a SKIP, so the floor
+/// is one below the `shacl-af`-on floor.
+const BASELINE_PASS_CORE: usize = 114;
+
+/// Pass-floor over the FULL core tree with `shacl-af` ON: the `shacl-af`
+/// `sh:nodeByExpression` core/node entry becomes implemented and PASSes, so the
+/// floor rises by one.
+const BASELINE_PASS_AF: usize = 115;
+
+/// Fail-ceiling over the FULL core tree — the count of entries whose SHACL-1.2
+/// behaviour this crate does not yet implement (the gap map). A *new* mismatch (a
+/// previously-correct entry breaking) pushes the fail count above this and fails
+/// the build; closing a gap drops it (bump down). The same in both feature
+/// states: the `shacl-af`-gated entries flip SKIP↔PASS, never to/from FAIL.
+const BASELINE_FAIL_CORE: usize = 22;
+
+/// Fail-ceiling with `shacl-af` ON — identical to [`BASELINE_FAIL_CORE`].
+const BASELINE_FAIL_AF: usize = 22;
+
+fn baseline_pass() -> usize {
+    if cfg!(feature = "shacl-af") {
+        BASELINE_PASS_AF
+    } else {
+        BASELINE_PASS_CORE
+    }
+}
+
+fn baseline_fail() -> usize {
+    if cfg!(feature = "shacl-af") {
+        BASELINE_FAIL_AF
+    } else {
+        BASELINE_FAIL_CORE
+    }
+}
+
+fn suite_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/shacl/data-shapes/shacl12-test-suite/tests/core")
+}
+
+#[test]
+fn w3c_shacl12_core_full_suite() {
+    let root = suite_root();
+    if !root.exists() {
+        eprintln!(
+            "SKIP: W3C SHACL 1.2 core suite not present at {} — run crates/sparq-shacl/fetch-shacl-tests.sh",
+            root.display()
+        );
+        return;
+    }
+    let unimpl = unimplemented();
+    let mut score = Scoreboard::default();
+    walk_manifest(&root.join("manifest.ttl"), &root, &unimpl, &mut score);
+
+    let (mut pass, mut fail, mut skip) = (0usize, 0usize, 0usize);
+    println!(
+        "\nW3C SHACL 1.2 FULL core suite scoreboard (shacl-af = {})",
+        cfg!(feature = "shacl-af")
+    );
+    println!("{:<24} {:>5} {:>5} {:>5}", "category", "pass", "fail", "skip");
+    for (group, (p, f, s)) in &score.by_group {
+        println!("{group:<24} {p:>5} {f:>5} {s:>5}");
+        pass += p;
+        fail += f;
+        skip += s;
+    }
+    println!("{:<24} {pass:>5} {fail:>5} {skip:>5}", "TOTAL");
+    if !score.failures.is_empty() {
+        println!("\nFAIL detail:");
+        for (id, why) in &score.failures {
+            println!("  {id}: {why}");
+        }
+    }
+    if !score.skips.is_empty() {
+        println!("\nSKIP (out-of-scope constraint surface):");
+        for (id, why) in &score.skips {
+            println!("  {id}: {why}");
+        }
+    }
+    println!("TOTAL pass {pass} fail {fail} skip {skip}");
+    // Two-sided ratchet: pass must not drop, fail must not grow. Together they
+    // detect a regression in either direction while staying green at the current
+    // (partial) SHACL-1.2 coverage. This is NOT an all-pass assertion — the
+    // failing entries are the live gap map (research/shacl12-conformance-gap.md).
+    assert!(
+        pass >= baseline_pass(),
+        "SHACL 1.2 full-core pass count regressed: {pass} < floor {} (fail {fail}, skip {skip})",
+        baseline_pass()
+    );
+    assert!(
+        fail <= baseline_fail(),
+        "SHACL 1.2 full-core fail count grew: {fail} > ceiling {} — a previously-correct entry broke (pass {pass}, skip {skip})",
+        baseline_fail()
+    );
+}
+
+#[derive(Default)]
+struct Scoreboard {
+    /// category -> (pass, fail, skip), in a BTreeMap so the print is stable.
+    by_group: BTreeMap<String, (usize, usize, usize)>,
+    failures: Vec<(String, String)>,
+    skips: Vec<(String, String)>,
+}
+
+impl Scoreboard {
+    fn record(&mut self, group: &str, id: &str, outcome: Outcome) {
+        let e = self.by_group.entry(group.to_string()).or_default();
+        match outcome {
+            Outcome::Pass => e.0 += 1,
+            Outcome::Fail(why) => {
+                e.1 += 1;
+                self.failures.push((id.to_string(), why));
+            }
+            Outcome::Skip(why) => {
+                e.2 += 1;
+                self.skips.push((id.to_string(), why));
+            }
+        }
+    }
+}
+
+enum Outcome {
+    Pass,
+    Fail(String),
+    Skip(String),
+}
+
+fn file_iri(path: &FsPath) -> String {
+    format!("file://{}", path.display())
+}
+
+fn iri_to_path(iri: &str) -> Option<PathBuf> {
+    iri.strip_prefix("file://").map(PathBuf::from)
+}
+
+fn load(path: &FsPath) -> Result<Graph, String> {
+    let text =
+        std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    sparq_shacl::load_turtle_with_base(&text, &file_iri(path))
+}
+
+/// The category label for an entry's manifest file: the first path component
+/// under `core/` (`node`, `path`, `property`, …), so the scoreboard groups by
+/// suite category.
+fn category(path: &FsPath, root: &FsPath) -> String {
+    path.parent()
+        .and_then(|d| d.strip_prefix(root).ok())
+        .and_then(|p| p.components().next())
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .unwrap_or_else(|| ".".into())
+}
+
+/// Recursively walks `mf:include`s; runs every `sht:Validate` entry.
+fn walk_manifest(path: &FsPath, root: &FsPath, unimpl: &[String], score: &mut Scoreboard) {
+    let path = match path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let group = category(&path, root);
+    let g = match load(&path) {
+        Ok(g) => g,
+        Err(e) => {
+            score.record(
+                &group,
+                &path.display().to_string(),
+                Outcome::Fail(format!("parse: {e}")),
+            );
+            return;
+        }
+    };
+    let view = GraphView::new(&g);
+    let manifests: Vec<Term> = view
+        .triples(None, Some(RDF_TYPE), Some(&iri(&format!("{MF}Manifest"))))
+        .into_iter()
+        .map(|[s, _, _]| s)
+        .collect();
+    for m in &manifests {
+        for inc in view.objects(m, &format!("{MF}include")) {
+            if let Term::NamedNode(n) = &inc {
+                if let Some(p) = iri_to_path(n.as_str()) {
+                    walk_manifest(&p, root, unimpl, score);
+                }
+            }
+        }
+        for head in view.objects(m, &format!("{MF}entries")) {
+            for entry in view.list(&head) {
+                let id = match &entry {
+                    Term::NamedNode(n) => n.as_str().to_string(),
+                    other => other.to_string(),
+                };
+                let outcome = run_entry(&path, &g, &view, &entry, unimpl)
+                    .unwrap_or_else(|e| Outcome::Fail(format!("harness error: {e}")));
+                score.record(&group, &id, outcome);
+            }
+        }
+    }
+}
+
+fn run_entry(
+    file: &FsPath,
+    g: &Graph,
+    view: &GraphView,
+    entry: &Term,
+    unimpl: &[String],
+) -> Result<Outcome, String> {
+    let is_validate = view
+        .objects(entry, RDF_TYPE)
+        .iter()
+        .any(|t| matches!(t, Term::NamedNode(n) if n.as_str() == format!("{SHT}Validate")));
+    if !is_validate {
+        return Ok(Outcome::Skip("not sht:Validate".into()));
+    }
+
+    let action = view
+        .object(entry, &format!("{MF}action"))
+        .ok_or("entry has no mf:action")?;
+    let graph_of = |pred: &str| -> Result<Option<Graph>, String> {
+        match view.object(&action, &format!("{SHT}{pred}")) {
+            Some(Term::NamedNode(n)) => {
+                let p = iri_to_path(n.as_str()).ok_or_else(|| format!("non-file graph IRI {n}"))?;
+                if p == file {
+                    Ok(None) // the test document itself — reuse the loaded graph
+                } else {
+                    load(&p).map(Some)
+                }
+            }
+            other => Err(format!("missing/odd {pred}: {other:?}")),
+        }
+    };
+    let data = graph_of("dataGraph")?;
+    let shapes = graph_of("shapesGraph")?;
+    let shapes_graph = shapes.as_ref().unwrap_or(g);
+
+    // SKIP up front when the shapes use a constraint FORM this build does not
+    // implement: the report would necessarily mismatch, but that is an absence of
+    // a feature, not a regression. Structural (not outcome-driven) so a wrong
+    // report on an IMPLEMENTED constraint can never be laundered into a SKIP.
+    if let Some(why) = unimplemented_form(shapes_graph, unimpl) {
+        return Ok(Outcome::Skip(why));
+    }
+
+    let report = validate(data.as_ref().unwrap_or(g), shapes_graph);
+
+    let exp_node = view
+        .object(entry, &format!("{MF}result"))
+        .ok_or("entry has no mf:result")?;
+    let exp_conforms = matches!(
+        view.object(&exp_node, &format!("{SH}conforms")),
+        Some(Term::Literal(l)) if l.value() == "true"
+    );
+    if exp_conforms != report.conforms {
+        return Ok(Outcome::Fail(format!(
+            "conforms: expected {exp_conforms}, got {} ({} results)",
+            report.conforms,
+            report.results.len()
+        )));
+    }
+    let expected: Vec<Expected> = view
+        .objects(&exp_node, &format!("{SH}result"))
+        .iter()
+        .map(|r| Expected::parse(view, r))
+        .collect::<Result<_, _>>()?;
+    if expected.len() != report.results.len() {
+        return Ok(Outcome::Fail(format!(
+            "result count: expected {}, got {} — {}",
+            expected.len(),
+            report.results.len(),
+            summarize(&report.results)
+        )));
+    }
+    if !bipartite_match(
+        &expected,
+        &report.results,
+        &mut vec![false; expected.len()],
+        0,
+    ) {
+        return Ok(Outcome::Fail(format!(
+            "results do not correspond — got {}",
+            summarize(&report.results)
+        )));
+    }
+    Ok(Outcome::Pass)
+}
+
+/// The reason (if any) the shapes graph uses a constraint **predicate** this
+/// build does not implement — identifying an entry to SKIP. Returns `None` when
+/// every constraint the shapes use is implemented (so the entry is compared
+/// strictly).
+fn unimplemented_form(shapes: &Graph, unimpl: &[String]) -> Option<String> {
+    let view = GraphView::new(shapes);
+    if let Some(p) = unimpl.iter().find(|p| !view.subjects_of(p).is_empty()) {
+        return Some(format!("shapes use unimplemented constraint <{p}>"));
+    }
+    None
+}
+
+fn summarize(rs: &[ValidationResult]) -> String {
+    let items: Vec<String> = rs
+        .iter()
+        .map(|r| {
+            format!(
+                "[focus {} comp {} value {}]",
+                r.focus_node,
+                r.source_component.rsplit('#').next().unwrap_or(""),
+                r.value
+                    .as_ref()
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "-".into())
+            )
+        })
+        .collect();
+    items.join(" ")
+}
+
+/// One expected validation result. Absent properties are left unconstrained.
+struct Expected {
+    focus: Option<Term>,
+    path: Option<Path>,
+    has_path: bool,
+    value: Option<Term>,
+    has_value: bool,
+    severity: Option<String>,
+    component: Option<String>,
+    source_shape: Option<Term>,
+    messages: Vec<Term>,
+}
+
+impl Expected {
+    fn parse(view: &GraphView, node: &Term) -> Result<Expected, String> {
+        let path_term = view.object(node, &format!("{SH}resultPath"));
+        let path = match &path_term {
+            Some(t) => Some(Path::parse(view, t).map_err(|e| format!("expected path: {e}"))?),
+            None => None,
+        };
+        let value = view.object(node, &format!("{SH}value"));
+        Ok(Expected {
+            focus: view.object(node, &format!("{SH}focusNode")),
+            has_path: path_term.is_some(),
+            path,
+            has_value: value.is_some(),
+            value,
+            severity: match view.object(node, &format!("{SH}resultSeverity")) {
+                Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+                _ => None,
+            },
+            component: match view.object(node, &format!("{SH}sourceConstraintComponent")) {
+                Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+                _ => None,
+            },
+            source_shape: view.object(node, &format!("{SH}sourceShape")),
+            messages: view.objects(node, &format!("{SH}resultMessage")),
+        })
+    }
+
+    fn matches(&self, a: &ValidationResult) -> bool {
+        if let Some(f) = &self.focus {
+            if !term_matches(f, &a.focus_node) {
+                return false;
+            }
+        }
+        if self.has_path != a.path.is_some() || (self.has_path && self.path != a.path) {
+            return false;
+        }
+        if self.has_value != a.value.is_some() {
+            return false;
+        }
+        if let (Some(e), Some(av)) = (&self.value, &a.value) {
+            if !term_matches(e, av) {
+                return false;
+            }
+        }
+        if let Some(s) = &self.severity {
+            if s != &a.severity {
+                return false;
+            }
+        }
+        if let Some(c) = &self.component {
+            if c != &a.source_component {
+                return false;
+            }
+        }
+        if let Some(s) = &self.source_shape {
+            if !term_matches(s, &a.source_shape) {
+                return false;
+            }
+        }
+        let actual_messages = a.effective_messages();
+        self.messages.iter().all(|m| actual_messages.contains(m))
+    }
+}
+
+/// Term correspondence across graphs: exact, except blank nodes match any blank
+/// node (they have no stable cross-graph identity).
+fn term_matches(expected: &Term, actual: &Term) -> bool {
+    match (expected, actual) {
+        (Term::BlankNode(_), Term::BlankNode(_)) => true,
+        _ => expected == actual,
+    }
+}
+
+/// Backtracking perfect matching: every expected result claims a distinct actual
+/// result it matches (counts already verified equal).
+fn bipartite_match(
+    expected: &[Expected],
+    actual: &[ValidationResult],
+    used: &mut Vec<bool>,
+    i: usize,
+) -> bool {
+    if i == expected.len() {
+        return true;
+    }
+    for (j, a) in actual.iter().enumerate() {
+        if !used[j] && expected[i].matches(a) {
+            used[j] = true;
+            if bipartite_match(expected, actual, used, i + 1) {
+                return true;
+            }
+            used[j] = false;
+        }
+    }
+    false
+}
+
+fn iri(s: &str) -> Term {
+    Term::NamedNode(oxrdf::NamedNode::new_unchecked(s))
+}

--- a/crates/sparq-shacl/tests/w3c_sparql_shacl12.rs
+++ b/crates/sparq-shacl/tests/w3c_sparql_shacl12.rs
@@ -1,0 +1,473 @@
+//! [OPUS-4.8] (sq-6glcr) Manifest-driven runner for the **SHACL 1.2 SPARQL** test
+//! suite — `shacl12-test-suite/tests/sparql/manifest.ttl` (the `component/`,
+//! `node/`, `property/`, `pre-binding/`, `targets/` sub-trees).
+//!
+//! `w3c_sparql.rs` / `w3c_sparql_component.rs` walk the *older*
+//! `data-shapes-test-suite/tests/sparql` tree. This harness gates the SHACL-1.2
+//! revision of the `sh:sparql` suite, which was previously ungated (the gap
+//! sq-6glcr closes; see `research/shacl12-conformance-gap.md`).
+//!
+//! ## `sht:Failure` entries (expected rejection)
+//!
+//! Seven `pre-binding/` entries have `mf:result sht:Failure` rather than an
+//! `sh:ValidationReport`: they declare a SPARQL constraint the processor MUST
+//! reject (an unsupported `MINUS` / `SERVICE`, or a query that re-binds a
+//! pre-bound variable). A conformant processor signals a *failure* (not a normal
+//! report). This crate has no such failure channel yet — `validate` always
+//! returns a report — so the harness records those entries as **ExpectedFailure**
+//! (a distinct, non-passing outcome), counted in the gap, not as PASS. When the
+//! failure channel lands they become PASS and the floor is bumped.
+//!
+//! ## SKIP vs FAIL — and why this gate does NOT assert all-pass
+//!
+//! An entry is **SKIP** when its constraint surface is out of scope here
+//! (a `component/` entry needing the custom-component declaration machinery the
+//! sibling `w3c_sparql_component.rs` handles, or any non-`sht:Validate`/`Failure`
+//! entry). Every other `sht:Validate` entry is compared strictly; an entry whose
+//! 1.2 behaviour this crate does not yet implement produces the wrong report and
+//! is an honest **FAIL** (the gap map), so this harness deliberately does not
+//! assert `fail == 0`.
+//!
+//! ## Ratchet (two-sided)
+//!
+//! The gate is a ratchet: pass must not drop ([`BASELINE_PASS`]) and the combined
+//! fail + expected-failure count must not grow ([`BASELINE_GAP`]). Together they
+//! catch a regression in either direction while staying green at the current
+//! partial 1.2 coverage. Floors calibrated by running the harness at the pinned
+//! suite commit in-worktree.
+//!
+//! The report-comparison policy mirrors `w3c_core.rs`: `sh:conforms` must match,
+//! and the result multisets correspond 1:1 where each expected result's stated
+//! `sh:focusNode` / `sh:resultPath` / `sh:value` / `sh:resultSeverity` /
+//! `sh:sourceConstraintComponent` / `sh:sourceShape` / `sh:resultMessage` agree
+//! (blank nodes match any blank node).
+
+use oxrdf::Term;
+use sparq_core::Graph;
+use sparq_shacl::view::GraphView;
+use sparq_shacl::{validate, Path, ValidationResult};
+use std::collections::BTreeMap;
+use std::path::{Path as FsPath, PathBuf};
+
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+const MF: &str = "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#";
+const SHT: &str = "http://www.w3.org/ns/shacl-test#";
+const SH: &str = "http://www.w3.org/ns/shacl#";
+
+/// Pass-floor: the SHACL-1.2 SPARQL `sht:Validate` entries this crate validates
+/// correctly at the pinned suite commit (`fetch-shacl-tests.sh` PIN). A
+/// regression below this fails the build; raising it is a deliberate bump.
+///
+/// [OPUS-4.8] (sq-6glcr) Calibrated by running the harness in-worktree.
+const BASELINE_PASS: usize = 10;
+
+/// Gap-ceiling: the count of entries this crate does NOT yet get right — the sum
+/// of strict-comparison FAILs and the `sht:Failure` ExpectedFailure entries (the
+/// rejection channel is unbuilt). A *new* gap (a previously-correct entry
+/// breaking) pushes this above the ceiling and fails the build; closing a gap
+/// drops it (bump down).
+const BASELINE_GAP: usize = 14;
+
+/// Of [`BASELINE_GAP`], the count attributable to the unbuilt rejection channel
+/// (`mf:result sht:Failure`). Asserted exactly so the scoreboard documents the
+/// split between "wrong report" and "should have rejected".
+const EXPECTED_FAILURE_COUNT: usize = 7;
+
+fn suite_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/shacl/data-shapes/shacl12-test-suite/tests/sparql")
+}
+
+#[test]
+fn w3c_shacl12_sparql_suite() {
+    let root = suite_root();
+    if !root.exists() {
+        eprintln!(
+            "SKIP: W3C SHACL 1.2 SPARQL suite not present at {} — run crates/sparq-shacl/fetch-shacl-tests.sh",
+            root.display()
+        );
+        return;
+    }
+    let mut score = Scoreboard::default();
+    walk_manifest(&root.join("manifest.ttl"), &root, &mut score);
+
+    let (mut pass, mut fail, mut skip, mut xfail) = (0usize, 0usize, 0usize, 0usize);
+    println!("\nW3C SHACL 1.2 SPARQL suite scoreboard");
+    println!(
+        "{:<14} {:>5} {:>5} {:>6} {:>5}",
+        "category", "pass", "fail", "xfail", "skip"
+    );
+    for (group, c) in &score.by_group {
+        println!(
+            "{group:<14} {:>5} {:>5} {:>6} {:>5}",
+            c.pass, c.fail, c.xfail, c.skip
+        );
+        pass += c.pass;
+        fail += c.fail;
+        xfail += c.xfail;
+        skip += c.skip;
+    }
+    println!(
+        "{:<14} {pass:>5} {fail:>5} {xfail:>6} {skip:>5}",
+        "TOTAL"
+    );
+    if !score.failures.is_empty() {
+        println!("\nFAIL detail:");
+        for (id, why) in &score.failures {
+            println!("  {id}: {why}");
+        }
+    }
+    if !score.xfails.is_empty() {
+        println!("\nExpectedFailure (mf:result sht:Failure — rejection channel unbuilt):");
+        for id in &score.xfails {
+            println!("  {id}");
+        }
+    }
+    if !score.skips.is_empty() {
+        println!("\nSKIP (out-of-scope here):");
+        for (id, why) in &score.skips {
+            println!("  {id}: {why}");
+        }
+    }
+    println!("TOTAL pass {pass} fail {fail} xfail {xfail} skip {skip}");
+
+    // Two-sided ratchet: pass must not drop, the gap (fail + xfail) must not grow.
+    assert!(
+        pass >= BASELINE_PASS,
+        "SHACL 1.2 SPARQL pass count regressed: {pass} < floor {BASELINE_PASS} (fail {fail}, xfail {xfail}, skip {skip})"
+    );
+    let gap = fail + xfail;
+    assert!(
+        gap <= BASELINE_GAP,
+        "SHACL 1.2 SPARQL gap grew: {gap} > ceiling {BASELINE_GAP} — a previously-correct entry broke (pass {pass}, skip {skip})"
+    );
+    assert_eq!(
+        xfail, EXPECTED_FAILURE_COUNT,
+        "SHACL 1.2 SPARQL: expected {EXPECTED_FAILURE_COUNT} sht:Failure (rejection) entries, found {xfail} — the rejection-channel set changed"
+    );
+}
+
+#[derive(Default)]
+struct Counts {
+    pass: usize,
+    fail: usize,
+    xfail: usize,
+    skip: usize,
+}
+
+#[derive(Default)]
+struct Scoreboard {
+    by_group: BTreeMap<String, Counts>,
+    failures: Vec<(String, String)>,
+    xfails: Vec<String>,
+    skips: Vec<(String, String)>,
+}
+
+impl Scoreboard {
+    fn record(&mut self, group: &str, id: &str, outcome: Outcome) {
+        let e = self.by_group.entry(group.to_string()).or_default();
+        match outcome {
+            Outcome::Pass => e.pass += 1,
+            Outcome::Fail(why) => {
+                e.fail += 1;
+                self.failures.push((id.to_string(), why));
+            }
+            Outcome::ExpectedFailure => {
+                e.xfail += 1;
+                self.xfails.push(id.to_string());
+            }
+            Outcome::Skip(why) => {
+                e.skip += 1;
+                self.skips.push((id.to_string(), why));
+            }
+        }
+    }
+}
+
+enum Outcome {
+    Pass,
+    Fail(String),
+    /// `mf:result sht:Failure`: a conformant processor must REJECT the query.
+    /// This crate has no rejection channel, so this is a non-passing gap entry.
+    ExpectedFailure,
+    Skip(String),
+}
+
+fn file_iri(path: &FsPath) -> String {
+    format!("file://{}", path.display())
+}
+
+fn iri_to_path(iri: &str) -> Option<PathBuf> {
+    iri.strip_prefix("file://").map(PathBuf::from)
+}
+
+fn load(path: &FsPath) -> Result<Graph, String> {
+    let text =
+        std::fs::read_to_string(path).map_err(|e| format!("read {}: {e}", path.display()))?;
+    sparq_shacl::load_turtle_with_base(&text, &file_iri(path))
+}
+
+/// The category label for an entry: the first path component under `sparql/`.
+fn category(path: &FsPath, root: &FsPath) -> String {
+    path.parent()
+        .and_then(|d| d.strip_prefix(root).ok())
+        .and_then(|p| p.components().next())
+        .map(|c| c.as_os_str().to_string_lossy().into_owned())
+        .unwrap_or_else(|| ".".into())
+}
+
+/// Recursively walks `mf:include`s; runs every `sht:Validate` entry.
+fn walk_manifest(path: &FsPath, root: &FsPath, score: &mut Scoreboard) {
+    let path = match path.canonicalize() {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let group = category(&path, root);
+    let g = match load(&path) {
+        Ok(g) => g,
+        Err(e) => {
+            score.record(
+                &group,
+                &path.display().to_string(),
+                Outcome::Fail(format!("parse: {e}")),
+            );
+            return;
+        }
+    };
+    let view = GraphView::new(&g);
+    let manifests: Vec<Term> = view
+        .triples(None, Some(RDF_TYPE), Some(&iri(&format!("{MF}Manifest"))))
+        .into_iter()
+        .map(|[s, _, _]| s)
+        .collect();
+    for m in &manifests {
+        for inc in view.objects(m, &format!("{MF}include")) {
+            if let Term::NamedNode(n) = &inc {
+                if let Some(p) = iri_to_path(n.as_str()) {
+                    walk_manifest(&p, root, score);
+                }
+            }
+        }
+        for head in view.objects(m, &format!("{MF}entries")) {
+            for entry in view.list(&head) {
+                let id = match &entry {
+                    Term::NamedNode(n) => n.as_str().to_string(),
+                    other => other.to_string(),
+                };
+                let outcome = run_entry(&path, &g, &view, &entry)
+                    .unwrap_or_else(|e| Outcome::Fail(format!("harness error: {e}")));
+                score.record(&group, &id, outcome);
+            }
+        }
+    }
+}
+
+fn run_entry(file: &FsPath, g: &Graph, view: &GraphView, entry: &Term) -> Result<Outcome, String> {
+    let is_validate = view
+        .objects(entry, RDF_TYPE)
+        .iter()
+        .any(|t| matches!(t, Term::NamedNode(n) if n.as_str() == format!("{SHT}Validate")));
+    if !is_validate {
+        return Ok(Outcome::Skip("not sht:Validate".into()));
+    }
+
+    let exp_node = view
+        .object(entry, &format!("{MF}result"))
+        .ok_or("entry has no mf:result")?;
+
+    // `mf:result sht:Failure` — a conformant processor must REJECT the query. The
+    // crate has no rejection channel, so this is a non-passing gap entry. (Classed
+    // BEFORE running the validator: the expectation is "must fail", and producing
+    // any normal report is itself the gap.)
+    if matches!(&exp_node, Term::NamedNode(n) if n.as_str() == format!("{SHT}Failure")) {
+        return Ok(Outcome::ExpectedFailure);
+    }
+
+    let action = view
+        .object(entry, &format!("{MF}action"))
+        .ok_or("entry has no mf:action")?;
+    let graph_of = |pred: &str| -> Result<Option<Graph>, String> {
+        match view.object(&action, &format!("{SHT}{pred}")) {
+            Some(Term::NamedNode(n)) => {
+                let p = iri_to_path(n.as_str()).ok_or_else(|| format!("non-file graph IRI {n}"))?;
+                if p == file {
+                    Ok(None) // the test document itself — reuse the loaded graph
+                } else {
+                    load(&p).map(Some)
+                }
+            }
+            other => Err(format!("missing/odd {pred}: {other:?}")),
+        }
+    };
+    let data = graph_of("dataGraph")?;
+    let shapes = graph_of("shapesGraph")?;
+    let report = validate(data.as_ref().unwrap_or(g), shapes.as_ref().unwrap_or(g));
+
+    let exp_conforms = matches!(
+        view.object(&exp_node, &format!("{SH}conforms")),
+        Some(Term::Literal(l)) if l.value() == "true"
+    );
+    if exp_conforms != report.conforms {
+        return Ok(Outcome::Fail(format!(
+            "conforms: expected {exp_conforms}, got {} ({} results)",
+            report.conforms,
+            report.results.len()
+        )));
+    }
+    let expected: Vec<Expected> = view
+        .objects(&exp_node, &format!("{SH}result"))
+        .iter()
+        .map(|r| Expected::parse(view, r))
+        .collect::<Result<_, _>>()?;
+    if expected.len() != report.results.len() {
+        return Ok(Outcome::Fail(format!(
+            "result count: expected {}, got {} — {}",
+            expected.len(),
+            report.results.len(),
+            summarize(&report.results)
+        )));
+    }
+    if !bipartite_match(
+        &expected,
+        &report.results,
+        &mut vec![false; expected.len()],
+        0,
+    ) {
+        return Ok(Outcome::Fail(format!(
+            "results do not correspond — got {}",
+            summarize(&report.results)
+        )));
+    }
+    Ok(Outcome::Pass)
+}
+
+fn summarize(rs: &[ValidationResult]) -> String {
+    let items: Vec<String> = rs
+        .iter()
+        .map(|r| {
+            format!(
+                "[focus {} comp {} value {}]",
+                r.focus_node,
+                r.source_component.rsplit('#').next().unwrap_or(""),
+                r.value
+                    .as_ref()
+                    .map(|v| v.to_string())
+                    .unwrap_or_else(|| "-".into())
+            )
+        })
+        .collect();
+    items.join(" ")
+}
+
+/// One expected validation result. Absent properties are left unconstrained.
+struct Expected {
+    focus: Option<Term>,
+    path: Option<Path>,
+    has_path: bool,
+    value: Option<Term>,
+    has_value: bool,
+    severity: Option<String>,
+    component: Option<String>,
+    source_shape: Option<Term>,
+    messages: Vec<Term>,
+}
+
+impl Expected {
+    fn parse(view: &GraphView, node: &Term) -> Result<Expected, String> {
+        let path_term = view.object(node, &format!("{SH}resultPath"));
+        let path = match &path_term {
+            Some(t) => Some(Path::parse(view, t).map_err(|e| format!("expected path: {e}"))?),
+            None => None,
+        };
+        let value = view.object(node, &format!("{SH}value"));
+        Ok(Expected {
+            focus: view.object(node, &format!("{SH}focusNode")),
+            has_path: path_term.is_some(),
+            path,
+            has_value: value.is_some(),
+            value,
+            severity: match view.object(node, &format!("{SH}resultSeverity")) {
+                Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+                _ => None,
+            },
+            component: match view.object(node, &format!("{SH}sourceConstraintComponent")) {
+                Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+                _ => None,
+            },
+            source_shape: view.object(node, &format!("{SH}sourceShape")),
+            messages: view.objects(node, &format!("{SH}resultMessage")),
+        })
+    }
+
+    fn matches(&self, a: &ValidationResult) -> bool {
+        if let Some(f) = &self.focus {
+            if !term_matches(f, &a.focus_node) {
+                return false;
+            }
+        }
+        if self.has_path != a.path.is_some() || (self.has_path && self.path != a.path) {
+            return false;
+        }
+        if self.has_value != a.value.is_some() {
+            return false;
+        }
+        if let (Some(e), Some(av)) = (&self.value, &a.value) {
+            if !term_matches(e, av) {
+                return false;
+            }
+        }
+        if let Some(s) = &self.severity {
+            if s != &a.severity {
+                return false;
+            }
+        }
+        if let Some(c) = &self.component {
+            if c != &a.source_component {
+                return false;
+            }
+        }
+        if let Some(s) = &self.source_shape {
+            if !term_matches(s, &a.source_shape) {
+                return false;
+            }
+        }
+        let actual_messages = a.effective_messages();
+        self.messages.iter().all(|m| actual_messages.contains(m))
+    }
+}
+
+/// Term correspondence across graphs: exact, except blank nodes match any blank
+/// node (they have no stable cross-graph identity).
+fn term_matches(expected: &Term, actual: &Term) -> bool {
+    match (expected, actual) {
+        (Term::BlankNode(_), Term::BlankNode(_)) => true,
+        _ => expected == actual,
+    }
+}
+
+/// Backtracking perfect matching: every expected result claims a distinct actual
+/// result it matches (counts already verified equal).
+fn bipartite_match(
+    expected: &[Expected],
+    actual: &[ValidationResult],
+    used: &mut Vec<bool>,
+    i: usize,
+) -> bool {
+    if i == expected.len() {
+        return true;
+    }
+    for (j, a) in actual.iter().enumerate() {
+        if !used[j] && expected[i].matches(a) {
+            used[j] = true;
+            if bipartite_match(expected, actual, used, i + 1) {
+                return true;
+            }
+            used[j] = false;
+        }
+    }
+    false
+}
+
+fn iri(s: &str) -> Term {
+    Term::NamedNode(oxrdf::NamedNode::new_unchecked(s))
+}

--- a/research/shacl12-conformance-gap.md
+++ b/research/shacl12-conformance-gap.md
@@ -1,0 +1,163 @@
+# SHACL 1.2 conformance — gap map (vendored W3C suite)
+
+**Status: gap analysis + ratchet baseline. Date 2026-06-27.** Epic `sq-waf9o`
+([EPIC] Full W3C SHACL 1.2 conformance). This record was produced by `sq-6glcr`,
+which makes CI gate the **full** vendored SHACL-1.2 test tree (not just
+`core/node/`) at a calibrated ratchet floor. It is the honest, sourced map of
+exactly what the `sparq-shacl` crate does and does not yet pass, so the
+follow-on feature waves are measurable rather than guesswork.
+
+The vendored suite is the W3C `w3c/data-shapes` repo pinned at
+`b6e73695d6196f33d7ce3ba47094a10fbc298e65` (`crates/sparq-shacl/fetch-shacl-tests.sh`),
+under `crates/sparq-shacl/tests/shacl/data-shapes/shacl12-test-suite/tests/`.
+
+All counts below are **measured** by running the harnesses in-worktree in both
+feature states (default = SHACL Core + SHACL-SPARQL; `shacl-af` = SHACL-AF
+`sh:rule` / `sh:expression` / `sh:nodeByExpression`). No figure is estimated.
+
+---
+
+## 1. What is gated now
+
+Three manifest-driven runners walk the 1.2 tree, each asserting a **ratchet**
+(pass must not drop; the gap must not grow) using the same strict report
+comparison as `w3c_core.rs` — `sh:conforms` must match and the
+`sh:ValidationResult` multisets must correspond 1:1 on `sh:focusNode` /
+`sh:resultPath` / `sh:value` / `sh:resultSeverity` /
+`sh:sourceConstraintComponent` / `sh:sourceShape` / `sh:resultMessage`
+(blank-node-tolerant, via backtracking bipartite matching).
+
+| Runner (`crates/sparq-shacl/tests/`) | Manifest tree | Entries | PASS (default / `shacl-af`) | Gap |
+| --- | --- | --- | --- | --- |
+| `w3c_core_full_shacl12.rs` | `core/manifest.ttl` (all 7 categories) | 137 | **114 / 115** | 22 FAIL (+ 1 SKIP default) |
+| `w3c_sparql_shacl12.rs` | `sparql/manifest.ttl` | 24 | **10 / 10** | 7 FAIL + 7 expected-failure |
+| `w3c_node_expr.rs` + `w3c_node_expr_constraints.rs` | `node-expr/` | 65 | **— / 65** | 0 (the node-expr runners are `#[cfg(feature = "shacl-af")]`) |
+
+The two runners that gate `core` and `sparql` are NOT feature-gated as a whole —
+they run in both states. The `shacl-af`-only delta in `core` is one entry
+(`nodeByExpression-001`, a SKIP by default → PASS under `shacl-af`).
+
+### Per-category core scoreboard (`shacl-af` ON)
+
+| category | pass | fail | skip |
+| --- | ---: | ---: | ---: |
+| complex | 2 | 0 | 0 |
+| misc | 5 | 5 | 0 |
+| node | 45 | 0 | 0 |
+| path | 11 | 0 | 0 |
+| property | 43 | 13 | 0 |
+| targets | 7 | 3 | 0 |
+| validation-reports | 2 | 1 | 0 |
+| **TOTAL** | **115** | **22** | **0** |
+
+The harnesses do **not** assert all-pass — that would be a false claim of full
+SHACL-1.2 conformance. They assert a two-sided ratchet so a regression in either
+direction (a passing entry breaking, or a previously-correct entry flipping)
+reds CI, while the documented gap entries below stay counted-not-asserted.
+Closing a gap moves a FAIL → PASS and bumps the floor in the same commit.
+
+---
+
+## 2. Gap clusters — core (22 FAIL)
+
+Each cluster is a coherent SHACL-1.2 feature the Core validator does not yet
+implement; the entry produces a structurally-wrong report (usually
+`conforms=true` because an unrecognised constraint predicate is silently
+ignored, or a wrong result count / message). Mapped to the implementation beads
+under the epic.
+
+| # | Cluster | Entries | Predicate(s) | Bead |
+| --- | --- | --- | --- | --- |
+| 1 | Path-list comparands of `sh:disjoint` / `sh:equals` | `property/disjoint-002`, `property/equals-002` | comparand is a property-path list, not a single IRI | `sq-sx15d` |
+| 2 | Path-list comparands of `sh:lessThan` / `sh:lessThanOrEquals` | `property/lessThan-003`, `property/lessThanOrEquals-002` | same, ordered comparison | `sq-sx15d` |
+| 3 | Disjunctive `sh:class` (ClassIn) | `property/class-002` | `sh:class ( C1 C2 )` list + `rdfs:subClassOf` | `sq-sx15d` |
+| 4 | `sh:subsetOf` constraint | `property/subsetOf-001`, `property/subsetOf-002` | `sh:SubsetOfConstraintComponent` | `sq-sx15d` |
+| 5 | `sh:someValue` constraint | `property/someValue-001` | `sh:SomeValueConstraintComponent` | `sq-sx15d` |
+| 6 | `sh:singleLine` constraint | `property/singleLine-001` | `sh:SingleLineConstraintComponent` | `sq-sx15d` |
+| 7 | `sh:rootClass` constraint | `property/rootClass-001` | `sh:RootClassConstraintComponent` | `sq-sx15d` |
+| 8 | Severity-threshold conformance | `misc/severity-003`, `misc/severity-004`, `misc/severity-005`, `validation-reports/conformance-disallows-001` | `sh:Debug` / `sh:Info` severities + `sh:conformanceDisallows` (a result below the disallowed threshold still `conforms`) | `sq-sx15d` |
+| 9 | `sh:targetWhere` target | `targets/targetWhere-001` | SPARQL-ish target selector | `sq-rnkdh` |
+| 10 | `sh:shape` implicit / `sh:ShapeClass` target | `targets/shape-001`, `targets/targetClassImplicit-002` | `sh:shape` value-target + `sh:ShapeClass` implicit class target | `sq-rnkdh` |
+| 11 | `sh:reifierShape` constraint | `property/reifierShape-001`, `property/reifierShape-002` | `sh:ReifierShapeConstraintComponent` (RDF-1.2 reifiers) | `sq-0mjfd` |
+| 12 | RDF-1.2 reified-annotation parsing | `misc/deactivated-003`, `misc/message-002` | the `{\| sh:deactivated true \|}` / `{\| sh:message ... \|}` triple-term annotation syntax on a constraint | `sq-0mjfd` |
+| 13 | `sh:uniqueLang` over `rdf:dirLangString` | `property/uniqueLang-003` | direction-tagged language strings | `sq-0mjfd` |
+
+Clusters 1–8 (eight beads' worth of "value constraints", 13 entries) are `sq-sx15d`;
+9–10 (targets, 3 entries) are `sq-rnkdh`; 11–13 (the RDF-1.2 draft/hard zone, 6
+entries) are `sq-0mjfd`.
+
+---
+
+## 3. Gap clusters — SPARQL (7 FAIL + 7 expected-failure)
+
+The 1.2 SPARQL suite has 24 `sht:Validate` entries; 10 pass. Of the 14
+non-passing, **7 carry `mf:result sht:Failure`** — they declare a SPARQL
+constraint a conformant processor MUST **reject** (re-binding a pre-bound
+variable, or an unsupported `MINUS` / `SERVICE`). The crate has no rejection /
+failure channel — `validate` always returns a report — so the runner records
+those as a distinct **ExpectedFailure** outcome (counted in the gap, not as
+PASS) and asserts there are exactly 7 of them.
+
+| # | Cluster | Entries | Why it fails | Bead |
+| --- | --- | --- | --- | --- |
+| 14 | SPARQL constraint result detail | `sparql/node/sparql-001`, `sparql/property/property-select-001` | `sh:select` constraint result message / count detail | `sq-rnkdh` |
+| 15 | `sh:sparqlExpr` value-expression constraint | `sparql/property/property-sparqlExpr-001` | SPARQL-expression-valued property constraint | `sq-rnkdh` |
+| 16 | SPARQL `sh:target` (targetNode-select) | `sparql/targets/targetNode-select-001` | SPARQL-based target | `sq-rnkdh` |
+| 17 | Pre-binding VALUES propagation | `sparql/pre-binding/pre-binding-002`, `pre-binding-005`, `pre-binding-007` | the full pre-binding algebra-rewrite (UNION / sibling / sub-SELECT scope) | `sq-mue75` |
+| 18 | Pre-binding **rejection** channel (`sht:Failure`) | `sparql/pre-binding/pre-binding-006`, `unsupported-sparql-001..006` (7) | a query that re-binds a pre-bound variable, or uses unsupported `MINUS`/`SERVICE`, MUST be rejected — the crate has no failure channel | `sq-0mjfd` |
+
+### Per-category SPARQL scoreboard
+
+| category | pass | fail | xfail | skip |
+| --- | ---: | ---: | ---: | ---: |
+| component | 3 | 0 | 0 | 0 |
+| node | 3 | 1 | 0 | 0 |
+| pre-binding | 3 | 3 | 7 | 0 |
+| property | 1 | 2 | 0 | 0 |
+| targets | 0 | 1 | 0 | 0 |
+| **TOTAL** | **10** | **7** | **7** | **0** |
+
+---
+
+## 4. The 16 clusters and the implementation beads
+
+The 13 core + 3 SPARQL = **16 clusters** above are the buildable backlog,
+grouped into four implementation beads under epic `sq-waf9o`:
+
+- **`sq-sx15d`** — SHACL 1.2 core value constraints (clusters 1–8, 13 entries):
+  path-comparands, disjunctive `sh:class`, `sh:subsetOf` / `sh:someValue` /
+  `sh:singleLine` / `sh:rootClass`, and severity-threshold conformance.
+- **`sq-rnkdh`** — SHACL 1.2 targets + SPARQL constraint extras (clusters 9–10,
+  14–16, 6 entries): `sh:targetWhere` / `sh:shape` / `sh:ShapeClass`, SPARQL
+  targets, SPARQL constraint result detail, and `sh:select` / `sh:sparqlExpr`.
+- **`sq-mue75`** — SHACL-SPARQL pre-binding VALUES propagation (cluster 17, 3
+  entries) + node-expr harness fidelity + `sh:sourceConstraint`.
+- **`sq-0mjfd`** — the draft / hard zone (clusters 11–13, 18; 6 core + 7
+  SPARQL): RDF-1.2 reified-annotation parsing, `sh:reifierShape`,
+  `rdf:dirLangString` `uniqueLang`, and the `sht:Failure` pre-binding **rejection
+  channel**.
+
+### Genuinely-draft zones (do not over-invest until the spec settles)
+
+- **RDF-1.2 triple-term annotation parsing** (`{\| ... \|}` reifier syntax) — the
+  Turtle parser must surface the reified triple term so `sh:deactivated` /
+  `sh:message` attached to a constraint are honoured. This is RDF-1.2 (still
+  CR-stage) surface, not SHACL-1.2 proper; `sq-0mjfd` is `P3` for that reason.
+- **The 7 `sht:Failure` tests** assert that a processor *rejects* certain
+  queries. SHACL's failure semantics (what a "failure" report looks like, and
+  when a constraint MUST fail vs MAY warn) are the least-settled part of the
+  1.2 SPARQL chapter. Building a fail-closed rejection channel is `sq-0mjfd`;
+  until then the harness counts these as a known, asserted-exactly gap (7).
+
+---
+
+## 5. Why a ratchet, not all-pass
+
+The Core validator is correct on the constraints it implements (the 115/137
+core + 10/24 SPARQL passing entries are compared strictly — a wrong report
+there is a FAIL, never laundered into a SKIP). The remaining entries exercise
+SHACL-1.2 features that simply are not built yet. Asserting all-pass would force
+either a false green or disabling real comparison; the two-sided ratchet keeps
+the gate honest *and* regression-proof. When a bead lands, its cluster's entries
+move FAIL → PASS, the per-runner floor is bumped in the same commit, and this
+table shrinks.

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -436,7 +436,15 @@ conforms/violations).
   by resolving that import against a vendored, minimal pinned excerpt at
   `crates/sparq-shacl/tests/vendor/dash.ttl`. Full `sparql/pre-binding` semantics (rejecting
   variable re-binding, `$shapesGraph`) are out of scope — see the crate's open beads (`bd list -l area:sparq-shacl`).
-- **W3C conformance:** 98/98 of the core `sht:Validate` suite passes. Reproduce with
+- **W3C conformance:** 98/98 of the *1.0/1.1* core `sht:Validate` suite passes
+  (`--test w3c_core`). The **full vendored SHACL 1.2** tree is gated by a ratchet
+  (sq-6glcr) in BOTH feature states: full core **114/115** of 137
+  (`--test w3c_core_full_shacl12`), 1.2 SPARQL **10** of 24 incl. 7 expected-rejection
+  `sht:Failure` entries (`--test w3c_sparql_shacl12`), node-expr **65/65**
+  (`--test w3c_node_expr{,_constraints}`, `shacl-af`). Pass must not drop, the gap must
+  not grow — the not-yet-passing entries are the honest per-category gap map in
+  `research/shacl12-conformance-gap.md` (clustered into beads sq-sx15d / sq-rnkdh /
+  sq-mue75 / sq-0mjfd under epic sq-waf9o). Reproduce with
   `crates/sparq-shacl/fetch-shacl-tests.sh` then
   `cargo test -p sparq-shacl --test w3c_core` (self-skips if the gitignored suite is absent).
 - §6 SPARQL-based constraint *components* are implemented and tested


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated contribution. Closes **sq-6glcr** (under epic **sq-waf9o**, full W3C SHACL 1.2 conformance).

## What & why

Until now CI gated only `tests/core/node/` (44 entries) of the vendored W3C SHACL **1.2** suite — the rest of the 1.2 tree (`complex` / `misc` / `path` / `property` / `targets` / `validation-reports`, the whole `sparql/` tree, and node-expr) could regress unnoticed. This closes that **invisibility gap** so the follow-on feature waves are measurable.

**TEST + CI + DOC only — no `crates/sparq-shacl/src/` change.**

## Harnesses added (same strict comparison as the existing runners)

Both walk the full `mf:include` tree and compare strictly — `sh:conforms` + a backtracking bipartite 1:1 `ValidationResult` match on `focusNode` / `resultPath` / `value` / `severity` / `sourceConstraintComponent` / `sourceShape` / `resultMessage` (blank-node-tolerant) — and run in **both** feature states (default + `shacl-af`):

| Harness | Tree | Entries | PASS (default / `shacl-af`) | Ratchet |
| --- | --- | ---: | --- | --- |
| `w3c_core_full_shacl12.rs` | `core/manifest.ttl` (7 categories) | 137 | **114 / 115** | pass ≥ floor **and** fail ≤ 22 |
| `w3c_sparql_shacl12.rs` | `sparql/manifest.ttl` | 24 | **10 / 10** | pass ≥ 10, gap ≤ 14, xfail == 7 |
| `w3c_node_expr{,_constraints}.rs` (existing) | `node-expr/` | 65 | **— / 65** | pass ≥ 65 |

The gate is a **two-sided ratchet** (pass must not drop, the gap must not grow), **not** an all-pass assertion — that would be a false claim of full 1.2 conformance. The 22 core + 14 SPARQL not-yet-passing entries are the honest gap, **counted not asserted**; closing one moves it FAIL → PASS and bumps the floor in the same commit.

### `sht:Failure` entries (expected rejection)

The 7 `sparql/pre-binding/` entries with `mf:result sht:Failure` declare a query a conformant processor MUST **reject** (re-binding a pre-bound variable, unsupported `MINUS`/`SERVICE`). The crate has no rejection channel yet, so they are recorded as a distinct **ExpectedFailure** outcome (counted in the gap, asserted at exactly 7), per the brief.

## CI

The existing **W3C SHACL conformance** job now also runs the full-1.2 harnesses in both feature states (a new step; the 1.0/1.1 `data-shapes` gates and their existing grep ratchet are kept untouched). Each runner's own `assert!(pass >= floor)` / `assert!(gap <= ceiling)` is the primary gate.

## Gap map

`research/shacl12-conformance-gap.md` is the honest per-category gap map: the 16 clusters (path-comparands, disjunctive `sh:class`, `sh:subsetOf`/`someValue`/`singleLine`/`rootClass`, severity-threshold conforms, `sh:targetWhere`/`shape`/`ShapeClass`, SPARQL pre-binding VALUES, …), mapped to the implementation beads **sq-sx15d / sq-rnkdh / sq-mue75 / sq-0mjfd** under epic **sq-waf9o**, plus the genuinely-draft zones (RDF-1.2 `{| … |}` annotation parsing + the 7 `sht:Failure` rejection tests). No fabricated numbers — every count is measured in-worktree at the pinned suite commit `b6e73695`.

## Gates run (green, both feature states unless noted)

- `cargo test -p sparq-shacl` (default **and** `--features shacl-af`) — all green; the new gates pass at their baseline floors.
- `cargo clippy -p sparq-shacl --all-targets -- -D warnings` (both states) — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-shacl --no-deps --all-features` — clean.
- `cargo +1.88 check -p sparq-shacl` (both states) — clean (pre-existing `gen`/`diff_fuzz` *dev-dependency* test-only MSRV breakage is unrelated and not hit by the CI `cargo check --workspace` MSRV gate).
- `scripts/check-readme-template.py --enforce` (README now exactly 120 lines, at the cap), `check-terminology.py`, `check-no-perf-numbers.py`, `typos` — all clean.

Auto-merge intentionally **OFF**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
