### PR TITLE
feat(shacl): SHACL 1.2 core value constraints + severity-threshold conforms (sq-sx15d) [OPUS-4.8]

### DIFF
--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -42,8 +42,9 @@ let report = sparq_shacl::validate(&data, &shapes);
 if !report.conforms {
     eprintln!("{}", report.to_text());   // or report.to_turtle() for the report graph
 }
-// `conforms` counts EVERY result; for "warnings don't fail the build":
-if report.conforms_violations_only() { /* only sh:Warning / sh:Info results */ }
+// `conforms` fails on the SHACL-1.2 default disallowed set {Violation,Warning,Info}
+// (Debug/Trace are reported but conform); `conforms_violations_only` fails on Violation only:
+if report.conforms_violations_only() { /* a stricter-threshold CI toggle */ }
 # assert!(!report.conforms);
 # Ok(()) }
 ```
@@ -58,9 +59,12 @@ For many data graphs against one shapes graph, parse once with
   section of the official [w3c/data-shapes](https://github.com/w3c/data-shapes) suite
   (pinned commit `b6e73695`). Run it: `crates/sparq-shacl/fetch-shacl-tests.sh` then
   `cargo test -p sparq-shacl --test w3c_core`.
-- **SHACL 1.2 core constraints** — `sh:memberShape`, `sh:uniqueMembers`,
-  `sh:{min,max}ListLength`, `sh:uniqueValuesFor`, `sh:closed sh:ByTypes`, and the
-  disjunctive-list forms of `sh:datatype`/`sh:nodeKind` (sq-vg3y). The 1.2 harness
+- **SHACL 1.2 core constraints** — `sh:memberShape`/`sh:uniqueMembers`/
+  `sh:{min,max}ListLength`/`sh:uniqueValuesFor`/`sh:closed sh:ByTypes` (sq-vg3y),
+  disjunctive-list `sh:datatype`/`sh:nodeKind`/`sh:class`, path-valued comparands for
+  `sh:equals`/`sh:disjoint`/`sh:lessThan`/`sh:lessThanOrEquals`, `sh:subsetOf`/
+  `sh:someValue`/`sh:singleLine`/`sh:rootClass`, and severity-threshold `conforms`
+  (default disallows {Violation,Warning,Info}) (sq-sx15d). The 1.2 harness
   passes strictly **44/45** with `shacl-af` off — the one SKIP is `nodeByExpression-001`,
   a `shacl-af` constraint — and **45/45** with it on; it stays SKIP-tolerant only for a
   constraint predicate the build still lacks, never masking a regression.
@@ -86,13 +90,10 @@ For many data graphs against one shapes graph, parse once with
   SCS surface; the *display* direction ships client-side in the site). It round-trips
   **32/32** of the vendored W3C `shacl12-cs` valid fixtures graph-isomorphically
   (`cargo test -p sparq-shacl --features scs --test scs_roundtrip`). A hand-rolled lexer +
-  recursive-descent parser over the `SHACLC.g4` grammar — directives (`BASE`/`IMPORTS`/
-  `PREFIX` with the four implicit prefixes), `shape`/`shapeClass`, path expressions
-  (`^` / `/` / `|` / `?*+` / grouping), `[min..max]` counts, `nodeKind`, bare-IRI
-  `sh:datatype`-vs-`sh:class`, `@`shape-refs, `param=value`, `!`negation (`sh:not`),
-  `|` disjunction (`sh:or`), nested `{...}` shapes and `[ ... ]` arrays. Adds **zero new
-  dependencies**; unsupported constructs return a typed `ScsError` (never a silent
-  mis-parse). Off ⇒ none of it compiles. The wasm `Store` binding is deferred (sq-quly).
+  recursive-descent parser over the `SHACLC.g4` grammar (directives, `shape`/`shapeClass`,
+  path expressions, counts, negation/disjunction, nested shapes/arrays — full list in
+  the SKILL). Adds **zero new dependencies**; unsupported constructs return a typed
+  `ScsError` (never a silent mis-parse). Off ⇒ none of it compiles.
 
 ## 📚 Learn more
 
@@ -105,14 +106,13 @@ For many data graphs against one shapes graph, parse once with
 
 ## Scope and non-goals
 
-The remaining out-of-scope item is the full `sparql/pre-binding` semantics (rejecting
-variable re-binding, `$shapesGraph`) — see `bd list -l area:sparq-shacl`. Validation
-results are **not deduplicated** across traversal routes (matching the test suite: a
-nested shape reached through two parents reports twice), and re-entrant recursion on the
-same focus/shape pair counts as conforming (SHACL leaves recursion undefined). An
-**uncompilable `sh:pattern`** (e.g. a `(?!…)` lookahead — unsupported by Rust `regex`
-*and* by XML Schema regex) is **skipped**, surfaced in `report.diagnostics`, never
-fail-closed onto every value.
+Out of scope: full `sparql/pre-binding` semantics (rejecting variable re-binding,
+`$shapesGraph`) — see `bd list -l area:sparq-shacl`. Validation results are **not
+deduplicated** across traversal routes (a nested shape reached through two parents
+reports twice, matching the suite), re-entrant recursion on the same focus/shape pair
+counts as conforming (SHACL leaves recursion undefined), and an **uncompilable
+`sh:pattern`** (e.g. a `(?!…)` lookahead) is **skipped** into `report.diagnostics`,
+never fail-closed onto every value.
 
 ## License
 

--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -227,6 +227,27 @@ impl<'a> Validator<'a> {
                     }
                 }
             }
+            // [OPUS-4.8] (sq-sx15d) `sh:class ( ex:A ex:B )` (SHACL 1.2): a value
+            // conforms iff it is a SHACL instance of ANY listed class (the
+            // subclass-aware `is_instance_of` is reused per listed class).
+            Component::ClassIn(classes) => {
+                for v in values {
+                    if !classes.iter().any(|cls| self.data.is_instance_of(v, cls)) {
+                        let joined = classes
+                            .iter()
+                            .map(|c| c.to_string())
+                            .collect::<Vec<_>>()
+                            .join(" ");
+                        out.push(self.result(
+                            sid,
+                            focus,
+                            Some(v.clone()),
+                            "ClassConstraintComponent",
+                            format!("Value does not have any of the allowed classes {joined}"),
+                        ));
+                    }
+                }
+            }
             // [OPUS-4.8] (sq-vg3y) A value conforms iff it is a literal whose
             // (well-formed) datatype is ANY of the allowed datatypes — the single
             // IRI is a singleton set, the SHACL-1.2 list form is the disjunction.
@@ -429,8 +450,12 @@ impl<'a> Validator<'a> {
                     ));
                 }
             }
+            // [OPUS-4.8] (sq-sx15d) `sh:equals` — the comparand is a SHACL property
+            // PATH (SHACL 1.2; a bare predicate IRI is a trivial path). The value
+            // sets must be equal: one result per path value absent from the
+            // comparand set, and one per comparand value absent from the path set.
             Component::Equals(p) => {
-                let others = self.data.objects(focus, p);
+                let others = p.values(&self.data, focus);
                 for v in values {
                     if !others.contains(v) {
                         out.push(self.result(
@@ -438,7 +463,7 @@ impl<'a> Validator<'a> {
                             focus,
                             Some(v.clone()),
                             "EqualsConstraintComponent",
-                            format!("Value missing from <{p}>"),
+                            format!("Value missing from {}", p.to_turtle()),
                         ));
                     }
                 }
@@ -449,28 +474,32 @@ impl<'a> Validator<'a> {
                             focus,
                             Some(o.clone()),
                             "EqualsConstraintComponent",
-                            format!("Value of <{p}> missing from the path values"),
+                            format!("Value of {} missing from the path values", p.to_turtle()),
                         ));
                     }
                 }
             }
+            // [OPUS-4.8] (sq-sx15d) `sh:disjoint` — the comparand is a PATH (SHACL
+            // 1.2). A path value shared with the comparand value set is a result.
             Component::Disjoint(p) => {
+                let others = p.values(&self.data, focus);
                 for v in values {
-                    if self.data.contains(focus, p, v) {
+                    if others.contains(v) {
                         out.push(self.result(
                             sid,
                             focus,
                             Some(v.clone()),
                             "DisjointConstraintComponent",
-                            format!("Value shared with <{p}>"),
+                            format!("Value shared with {}", p.to_turtle()),
                         ));
                     }
                 }
             }
             // One result per FAILING PAIR (value, other) — the suite expects e.g.
             // `1 < "a"` and `1 < "b"` to report `sh:value 1` twice.
+            // [OPUS-4.8] (sq-sx15d) the comparand is a PATH (SHACL 1.2).
             Component::LessThan(p) => {
-                let others = self.data.objects(focus, p);
+                let others = p.values(&self.data, focus);
                 for v in values {
                     for o in &others {
                         if !matches!(cmp_terms(v, o), Some(Ordering::Less)) {
@@ -479,14 +508,14 @@ impl<'a> Validator<'a> {
                                 focus,
                                 Some(v.clone()),
                                 "LessThanConstraintComponent",
-                                format!("Value is not less than {o} (via <{p}>)"),
+                                format!("Value is not less than {o} (via {})", p.to_turtle()),
                             ));
                         }
                     }
                 }
             }
             Component::LessThanOrEquals(p) => {
-                let others = self.data.objects(focus, p);
+                let others = p.values(&self.data, focus);
                 for v in values {
                     for o in &others {
                         if !matches!(cmp_terms(v, o), Some(Ordering::Less | Ordering::Equal)) {
@@ -495,9 +524,80 @@ impl<'a> Validator<'a> {
                                 focus,
                                 Some(v.clone()),
                                 "LessThanOrEqualsConstraintComponent",
-                                format!("Value is not less than or equal to {o} (via <{p}>)"),
+                                format!(
+                                    "Value is not less than or equal to {o} (via {})",
+                                    p.to_turtle()
+                                ),
                             ));
                         }
+                    }
+                }
+            }
+            // [OPUS-4.8] (sq-sx15d) `sh:subsetOf` (SHACL 1.2) — the value set of the
+            // shape's path must be a SUBSET of the comparand path's value set. One
+            // result per path value absent from the comparand set.
+            Component::SubsetOf(p) => {
+                let others = p.values(&self.data, focus);
+                for v in values {
+                    if !others.contains(v) {
+                        out.push(self.result(
+                            sid,
+                            focus,
+                            Some(v.clone()),
+                            "SubsetOfConstraintComponent",
+                            format!("Value not in the value set of {}", p.to_turtle()),
+                        ));
+                    }
+                }
+            }
+            // [OPUS-4.8] (sq-sx15d) `sh:someValue` (SHACL 1.2) — EXISTENTIAL: at
+            // least one value node must conform to the nested shape. One result on
+            // the focus/path (NO sh:value) when NONE conform. An empty value set
+            // also fails (no value can satisfy the existential).
+            Component::SomeValue(inner) => {
+                if !values.iter().any(|v| self.conforms(v, *inner)) {
+                    out.push(self.result(
+                        sid,
+                        focus,
+                        None,
+                        "SomeValueConstraintComponent",
+                        "No value node conforms to the sh:someValue shape".into(),
+                    ));
+                }
+            }
+            // [OPUS-4.8] (sq-sx15d) `sh:singleLine true` (SHACL 1.2) — each string
+            // value must contain no line-break character (LF / CR / FF / VT). A
+            // non-string value contributes its lexical form; a blank node has none
+            // and conforms vacuously (no string to break).
+            Component::SingleLine => {
+                for v in values {
+                    if let Some(s) = string_repr(v) {
+                        if s.chars().any(is_line_break) {
+                            out.push(self.result(
+                                sid,
+                                focus,
+                                Some(v.clone()),
+                                "SingleLineConstraintComponent",
+                                "Value contains a line break".into(),
+                            ));
+                        }
+                    }
+                }
+            }
+            // [OPUS-4.8] (sq-sx15d) `sh:rootClass` (SHACL 1.2) — each value node must
+            // be the named class or a transitive `rdfs:subClassOf`-descendant of it
+            // (reuses the `sh:class` subclass closure).
+            Component::RootClass(cls) => {
+                let closure = self.data.subclass_closure(cls);
+                for v in values {
+                    if !closure.contains(v) {
+                        out.push(self.result(
+                            sid,
+                            focus,
+                            Some(v.clone()),
+                            "RootClassConstraintComponent",
+                            format!("Value is not {cls} or a subclass of it"),
+                        ));
                     }
                 }
             }
@@ -1322,6 +1422,13 @@ fn value_signature(data: &GraphView, node: &Term, props: &[String]) -> Vec<Vec<S
             vs
         })
         .collect()
+}
+
+/// [OPUS-4.8] (sq-sx15d) A line-break character for `sh:singleLine`: line feed
+/// (U+000A), carriage return (U+000D), form feed (U+000C) or vertical tab
+/// (U+000B). The W3C `singleLine-001` test exercises all four.
+fn is_line_break(c: char) -> bool {
+    matches!(c, '\u{000A}' | '\u{000D}' | '\u{000C}' | '\u{000B}')
 }
 
 /// The string a value node contributes to sh:minLength/maxLength/pattern:

--- a/crates/sparq-shacl/src/lib.rs
+++ b/crates/sparq-shacl/src/lib.rs
@@ -24,7 +24,11 @@ pub use model::{Component, Shape, ShapesModel, Target};
 pub use path::Path;
 // [OPUS-4.8] (sq-lz99x) `ShapeDiagnostic` surfaces a constraint the validator
 // SKIPPED because it could not be evaluated (e.g. an uncompilable `sh:pattern`).
-pub use report::{ShapeDiagnostic, ValidationReport, ValidationResult};
+// [OPUS-4.8] (sq-sx15d) `DEFAULT_CONFORMANCE_DISALLOWS` is the SHACL 1.2 default
+// disallowed-severity set used to compute `ValidationReport::conforms`.
+pub use report::{
+    ShapeDiagnostic, ValidationReport, ValidationResult, DEFAULT_CONFORMANCE_DISALLOWS,
+};
 
 // [OPUS-4.8] (sq-v0b8) SHACL Compact Syntax parser public surface (feature `scs`).
 #[cfg(feature = "scs")]
@@ -263,8 +267,11 @@ mod tests {
             .any(|t| t.predicate.as_str().ends_with("conforms")));
     }
 
-    /// `sh:conforms` counts every result regardless of severity (what the W3C
-    /// suite checks); `conforms_violations_only` is the severity-aware toggle.
+    /// [OPUS-4.8] (sq-sx15d) `sh:conforms` fails when ANY result is in the SHACL-1.2
+    /// default disallowed set {Violation, Warning, Info}; `conforms_violations_only`
+    /// is the strictly-weaker CI toggle that fails only on `sh:Violation`. A
+    /// Warning result fails `conforms` (Warning is disallowed by default) but
+    /// passes the violations-only toggle.
     #[test]
     fn severity_aware_conformance_toggle() {
         let data = Graph::load_str(
@@ -303,6 +310,12 @@ mod tests {
         let r = validate(&data, &shapes("sh:Violation"));
         assert!(!r.conforms);
         assert!(!r.conforms_violations_only());
+        // A sh:Debug result is below the default threshold: conforms is true even
+        // though a result is reported (the violations-only toggle agrees).
+        let r = validate(&data, &shapes("sh:Debug"));
+        assert!(r.conforms, "Debug result must not break default conformance");
+        assert_eq!(r.results.len(), 1);
+        assert!(r.conforms_violations_only());
         // Conforming data conforms under both.
         let ok = Graph::load_str(
             "@prefix ex: <http://example.org/> . ex:a a ex:Person ; ex:age 3 .",

--- a/crates/sparq-shacl/src/model.rs
+++ b/crates/sparq-shacl/src/model.rs
@@ -33,6 +33,12 @@ pub enum Target {
 #[derive(Debug, Clone)]
 pub enum Component {
     Class(Term),
+    /// [OPUS-4.8] (sq-sx15d) `sh:class` with a SHACL-list object
+    /// (`sh:class ( ex:A ex:B )`, SHACL 1.2): a value node conforms iff it is a
+    /// SHACL instance of ANY listed class (`sh:ClassConstraintComponent`).
+    /// Mirrors the disjunctive `sh:datatype` / `sh:nodeKind` list spelling; a
+    /// single IRI object stays [`Component::Class`].
+    ClassIn(Vec<Term>),
     /// `sh:datatype` — the allowed-datatype set (SHACL §4.5.2). A single IRI
     /// object is a singleton set; the SHACL-1.2 disjunctive list form
     /// `sh:datatype ( xsd:string rdf:langString )` is the multi-element set. A
@@ -58,10 +64,42 @@ pub enum Component {
     },
     LanguageIn(Vec<String>),
     UniqueLang,
-    Equals(String),
-    Disjoint(String),
-    LessThan(String),
-    LessThanOrEquals(String),
+    /// [OPUS-4.8] (sq-sx15d) `sh:equals` — the value set of the shape's path must
+    /// equal the value set of the comparand. SHACL 1.2 lets the comparand be a
+    /// full property [`Path`] (often an RDF-list sequence), not just a predicate
+    /// IRI; a bare IRI parses to a trivial [`Path::Predicate`], so the SHACL 1.0
+    /// `-001` predicate form stays backward-compatible.
+    Equals(Path),
+    /// [OPUS-4.8] (sq-sx15d) `sh:disjoint` — the value set of the shape's path
+    /// must be disjoint from the comparand's. The comparand is a [`Path`] (SHACL
+    /// 1.2 list/path form; a bare IRI is a trivial path).
+    Disjoint(Path),
+    /// [OPUS-4.8] (sq-sx15d) `sh:lessThan` — every path value must be `<` every
+    /// comparand value. The comparand is a [`Path`] (SHACL 1.2).
+    LessThan(Path),
+    /// [OPUS-4.8] (sq-sx15d) `sh:lessThanOrEquals` — every path value must be
+    /// `<=` every comparand value. The comparand is a [`Path`] (SHACL 1.2).
+    LessThanOrEquals(Path),
+    /// [OPUS-4.8] (sq-sx15d) `sh:subsetOf` (SHACL 1.2) — the value set of the
+    /// shape's path must be a SUBSET of the comparand path's value set
+    /// (`sh:SubsetOfConstraintComponent`). One result per path value absent from
+    /// the comparand set. The comparand is a [`Path`].
+    SubsetOf(Path),
+    /// [OPUS-4.8] (sq-sx15d) `sh:someValue` (SHACL 1.2) — EXISTENTIAL: at least
+    /// one value node must conform to the nested shape
+    /// (`sh:SomeValueConstraintComponent`). The index is into
+    /// [`ShapesModel::shapes`]. One result on the focus/path when NONE conform.
+    SomeValue(usize),
+    /// [OPUS-4.8] (sq-sx15d) `sh:singleLine true` (SHACL 1.2) — each string value
+    /// must contain no line-break characters (LF/CR/FF/VT)
+    /// (`sh:SingleLineConstraintComponent`). `sh:singleLine false` imposes no
+    /// constraint (not parsed into a component).
+    SingleLine,
+    /// [OPUS-4.8] (sq-sx15d) `sh:rootClass` (SHACL 1.2) — each value node must be
+    /// the named class or a transitive `rdfs:subClassOf`-descendant of it
+    /// (`sh:RootClassConstraintComponent`). Reuses the `sh:class` subclass
+    /// closure.
+    RootClass(Term),
     Not(usize),
     And(Vec<usize>),
     Or(Vec<usize>),
@@ -596,8 +634,24 @@ impl ShapesModel {
         }
 
         let c = &mut shape.components;
+        // [OPUS-4.8] (sq-sx15d) `sh:class` accepts a single class IRI/blank node or
+        // the SHACL-1.2 disjunctive SHACL-list form `( ex:A ex:B )` — a value node
+        // conforms iff it is an instance of ANY listed class. A blank-node object
+        // that is a well-formed SHACL list (≥1 member) is the disjunctive form;
+        // any other object is a single class. Mirrors the `sh:datatype` /
+        // `sh:nodeKind` disjunctive handling above.
         for o in g.objects(node, &sh("class")) {
-            c.push(Component::Class(o));
+            match &o {
+                Term::BlankNode(_) => {
+                    let members = g.list(&o);
+                    if members.is_empty() {
+                        c.push(Component::Class(o));
+                    } else {
+                        c.push(Component::ClassIn(members));
+                    }
+                }
+                _ => c.push(Component::Class(o)),
+            }
         }
         // [OPUS-4.8] (sq-vg3y) `sh:datatype` / `sh:nodeKind` accept either a single
         // IRI or the SHACL-1.2 disjunctive SHACL-list form (`( a b )`). `iri_set`
@@ -675,20 +729,40 @@ impl ShapesModel {
         {
             c.push(Component::UniqueLang);
         }
+        // [OPUS-4.8] (sq-sx15d) `sh:equals` / `sh:disjoint` / `sh:lessThan` /
+        // `sh:lessThanOrEquals` / `sh:subsetOf` carry a comparand SHACL property
+        // PATH in SHACL 1.2 (often an RDF-list sequence), not just a predicate
+        // IRI. Parse the comparand with the same `Path` parser used for `sh:path`
+        // (a bare NamedNode → `Path::Predicate`, so the SHACL-1.0 predicate forms
+        // stay backward-compatible); an ill-formed comparand is dropped (lenient).
         for (pred, ctor) in [
-            ("equals", Component::Equals as fn(String) -> Component),
-            ("disjoint", Component::Disjoint as fn(String) -> Component),
-            ("lessThan", Component::LessThan as fn(String) -> Component),
+            ("equals", Component::Equals as fn(Path) -> Component),
+            ("disjoint", Component::Disjoint as fn(Path) -> Component),
+            ("lessThan", Component::LessThan as fn(Path) -> Component),
             (
                 "lessThanOrEquals",
-                Component::LessThanOrEquals as fn(String) -> Component,
+                Component::LessThanOrEquals as fn(Path) -> Component,
             ),
+            ("subsetOf", Component::SubsetOf as fn(Path) -> Component),
         ] {
             for o in g.objects(node, &sh(pred)) {
-                if let Term::NamedNode(n) = o {
-                    c.push(ctor(n.as_str().to_string()));
+                if let Ok(path) = Path::parse(g, &o) {
+                    c.push(ctor(path));
                 }
             }
+        }
+        // [OPUS-4.8] (sq-sx15d) `sh:rootClass` (SHACL 1.2): each value node must be
+        // the named class or a transitive `rdfs:subClassOf`-descendant of it. The
+        // object is a single class term.
+        for o in g.objects(node, &sh("rootClass")) {
+            c.push(Component::RootClass(o));
+        }
+        // [OPUS-4.8] (sq-sx15d) `sh:singleLine true` (SHACL 1.2): string values must
+        // contain no line-break characters. `sh:singleLine false` (or any non-true
+        // object) imposes no constraint.
+        if matches!(g.object(node, &sh("singleLine")), Some(Term::Literal(l)) if l.value() == "true")
+        {
+            c.push(Component::SingleLine);
         }
         for o in g.objects(node, &sh("hasValue")) {
             c.push(Component::HasValue(o));
@@ -776,6 +850,14 @@ impl ShapesModel {
         for o in g.objects(node, &sh("node")) {
             let id = self.shape_id(g, &o);
             shape.components.push(Component::Node(id));
+        }
+        // [OPUS-4.8] (sq-sx15d) `sh:someValue` (SHACL 1.2): EXISTENTIAL — at least
+        // one value node must conform to the referenced (nested) shape. Parsed/
+        // interned recursively like `sh:node`; the quantifier is inverted at eval
+        // time (a violation iff NO value conforms).
+        for o in g.objects(node, &sh("someValue")) {
+            let id = self.shape_id(g, &o);
+            shape.components.push(Component::SomeValue(id));
         }
         for o in g.objects(node, &sh("property")) {
             let id = self.shape_id(g, &o);

--- a/crates/sparq-shacl/src/report.rs
+++ b/crates/sparq-shacl/src/report.rs
@@ -6,6 +6,25 @@ use crate::path::Path;
 use oxrdf::Term;
 use std::fmt::Write as _;
 
+/// [OPUS-4.8] (sq-sx15d) The DEFAULT `sh:conformanceDisallows` severity set
+/// (SHACL 1.2 Core §3.9): a data graph fails to conform when ANY validation
+/// result carries one of these severities. Results at `sh:Debug` / `sh:Trace`
+/// (below `sh:Info` in the `sh:Trace < sh:Debug < sh:Info < sh:Warning <
+/// sh:Violation` ordering) are reported but do not break conformance.
+pub const DEFAULT_CONFORMANCE_DISALLOWS: &[&str] = &[
+    "http://www.w3.org/ns/shacl#Violation",
+    "http://www.w3.org/ns/shacl#Warning",
+    "http://www.w3.org/ns/shacl#Info",
+];
+
+/// [OPUS-4.8] (sq-sx15d) `true` iff none of `results` carries a severity in the
+/// `disallowed` set — the SHACL 1.2 conformance test (default or custom set).
+fn conforms_over(results: &[ValidationResult], disallowed: &[&str]) -> bool {
+    !results
+        .iter()
+        .any(|r| disallowed.iter().any(|d| r.severity == *d))
+}
+
 /// One validation result (one constraint violation/warning/info).
 #[derive(Debug, Clone)]
 pub struct ValidationResult {
@@ -85,20 +104,40 @@ impl ValidationReport {
         results: Vec<ValidationResult>,
         diagnostics: Vec<ShapeDiagnostic>,
     ) -> Self {
+        // [OPUS-4.8] (sq-sx15d) SHACL 1.2 conformance: the graph conforms iff NO
+        // result carries a severity in the DEFAULT disallowed set (sh:Violation /
+        // sh:Warning / sh:Info). Results at sh:Debug / sh:Trace (and any custom
+        // severity outside the default set) are reported but do not break
+        // conformance — so a Debug/Trace-only report conforms. (A custom
+        // disallowed set, when a caller carries `sh:conformanceDisallows`, is
+        // recomputed via `conforms_with_disallowed`.)
+        let conforms = conforms_over(&results, DEFAULT_CONFORMANCE_DISALLOWS);
         ValidationReport {
-            conforms: results.is_empty(),
+            conforms,
             results,
             diagnostics,
         }
     }
 
+    /// [OPUS-4.8] (sq-sx15d) Recompute conformance against a CUSTOM disallowed
+    /// severity set (the SHACL 1.2 `sh:conformanceDisallows` of a results graph,
+    /// SHACL Core §3.9): `true` iff no result carries a severity in `disallowed`.
+    /// `disallowed` holds full severity IRIs (e.g.
+    /// `http://www.w3.org/ns/shacl#Violation`). The public [`conforms`](Self::conforms)
+    /// field uses the default set [`DEFAULT_CONFORMANCE_DISALLOWS`]; this lets a
+    /// caller that read an explicit `sh:conformanceDisallows` apply it instead
+    /// (e.g. a Warning result conforms when only `sh:Violation` is disallowed).
+    pub fn conforms_with_disallowed(&self, disallowed: &[&str]) -> bool {
+        conforms_over(&self.results, disallowed)
+    }
+
     /// Severity-aware conformance: `true` iff no result carries
     /// `sh:Violation` severity — i.e. `sh:Warning` / `sh:Info` (and custom
-    /// severities) are reported but not conformance-breaking. The spec's
-    /// `sh:conforms` ([`conforms`](Self::conforms), what the W3C suite
-    /// checks) counts EVERY result regardless of severity; this is the
+    /// severities) are reported but not conformance-breaking. This is the
     /// "violations only" toggle several implementations expose for CI-style
-    /// gating.
+    /// gating (equivalent to `conforms_with_disallowed(&[sh:Violation])`). It is
+    /// strictly weaker than the spec default [`conforms`](Self::conforms) field,
+    /// which also disallows `sh:Warning` / `sh:Info`.
     pub fn conforms_violations_only(&self) -> bool {
         self.results_with_severity(&format!("{SH}Violation"))
             .next()
@@ -523,8 +562,10 @@ mod tests {
                 vec![],
             ),
         ]);
-        // sh:conforms counts every result; the violations-only toggle passes
-        // because neither result is a sh:Violation.
+        // [OPUS-4.8] (sq-sx15d) sh:conforms uses the DEFAULT disallowed set
+        // {Violation, Warning, Info}: a Warning/Info report does NOT conform.
+        // The violations-only toggle is strictly weaker and passes here (no
+        // sh:Violation).
         assert!(!r.conforms);
         assert!(r.conforms_violations_only());
         assert_eq!(r.results_with_severity(&format!("{SH}Warning")).count(), 1);
@@ -544,5 +585,55 @@ mod tests {
             vec![],
         )]);
         assert!(!r.conforms_violations_only());
+    }
+
+    // [OPUS-4.8] (sq-sx15d) SHACL-1.2 conformance threshold: results below
+    // sh:Info (sh:Debug / sh:Trace) are reported but DO NOT break the default
+    // `conforms`; a custom disallowed set is applied via
+    // `conforms_with_disallowed`.
+    #[test]
+    fn severity_threshold_default_and_custom_disallowed() {
+        // A Debug-only and a Trace-only report each conform under the default set.
+        for sev in ["Debug", "Trace"] {
+            let r = ValidationReport::new(vec![result(
+                iri(&format!("{EX}x")),
+                None,
+                None,
+                "DatatypeConstraintComponent",
+                sev,
+                vec![],
+            )]);
+            assert!(r.conforms, "a {sev}-only report must conform by default");
+            // Still reported (one result), just below the threshold.
+            assert_eq!(r.results.len(), 1);
+        }
+
+        // A Warning result breaks the default conformance...
+        let r = ValidationReport::new(vec![result(
+            iri(&format!("{EX}w")),
+            None,
+            None,
+            "DatatypeConstraintComponent",
+            "Warning",
+            vec![],
+        )]);
+        assert!(!r.conforms);
+        // ...but conforms under the custom set {sh:Violation} only.
+        assert!(r.conforms_with_disallowed(&[&format!("{SH}Violation")]));
+        // The default set is exactly {Violation, Warning, Info}.
+        assert_eq!(DEFAULT_CONFORMANCE_DISALLOWS.len(), 3);
+        assert!(DEFAULT_CONFORMANCE_DISALLOWS.contains(&format!("{SH}Violation").as_str()));
+        assert!(DEFAULT_CONFORMANCE_DISALLOWS.contains(&format!("{SH}Info").as_str()));
+        // A custom set that disallows Debug catches a Debug result.
+        let r = ValidationReport::new(vec![result(
+            iri(&format!("{EX}d")),
+            None,
+            None,
+            "DatatypeConstraintComponent",
+            "Debug",
+            vec![],
+        )]);
+        assert!(r.conforms);
+        assert!(!r.conforms_with_disallowed(&[&format!("{SH}Debug")]));
     }
 }

--- a/crates/sparq-shacl/tests/w3c_core_shacl12_value_constraints.rs
+++ b/crates/sparq-shacl/tests/w3c_core_shacl12_value_constraints.rs
@@ -1,0 +1,547 @@
+//! [OPUS-4.8] (sq-sx15d, epic sq-waf9o) SHACL 1.2 CORE value-constraint coverage.
+//!
+//! Direct, fixture-free tests for the SHACL-1.2 value constraints implemented in
+//! sq-sx15d, mirroring the W3C `shacl12-test-suite` `core/{property,misc,
+//! validation-reports}` entries this bead targets. Each test inlines the suite
+//! entry's shapes+data (the fetched suite tree is gitignored, so the data is
+//! copied here so the test runs on a fresh checkout) and asserts the produced
+//! report against the suite's expected report through the REAL `validate()`:
+//!
+//!   * A. path-valued comparands — `equals-002`, `disjoint-002`, `lessThan-003`,
+//!     `lessThanOrEquals-002` (`sh:equals` / `sh:disjoint` / `sh:lessThan` /
+//!     `sh:lessThanOrEquals` taking a SHACL property PATH, often an RDF-list
+//!     sequence, as comparand).
+//!   * B. disjunctive `sh:class` — `class-002` (`sh:class ( ex:A ex:B )`).
+//!   * C. four new components — `subsetOf-001`, `someValue-001`,
+//!     `singleLine-001`, `rootClass-001`.
+//!   * D. severity-threshold conformance — `severity-004` (sh:Debug),
+//!     `severity-005` (sh:Trace), `conformance-disallows-001` (a Warning result
+//!     conforming under a custom `sh:conformanceDisallows sh:Violation`).
+//!
+//! The suite's own manifest-driven runner lives in `w3c_core_shacl12.rs` (which a
+//! parallel PR extends to walk `core/property|misc|validation-reports`); this
+//! file is the in-tree, suite-independent counterpart for the same entries.
+
+use oxrdf::Term;
+use sparq_core::Graph;
+use sparq_shacl::{validate, Path, ValidationReport, ValidationResult};
+
+const PREFIXES: &str = r#"
+@prefix ex: <http://example.com/ns#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+"#;
+
+const NS: &str = "http://example.com/ns#";
+const SH: &str = "http://www.w3.org/ns/shacl#";
+
+/// Validates one document acting as BOTH the data and the shapes graph (the
+/// suite entries set `sht:dataGraph` = `sht:shapesGraph` = the test document).
+fn run(doc: &str) -> ValidationReport {
+    let g = Graph::load_str(&format!("{PREFIXES}{doc}"), "turtle").unwrap();
+    validate(&g, &g)
+}
+
+fn ex(local: &str) -> Term {
+    Term::NamedNode(oxrdf::NamedNode::new_unchecked(format!("{NS}{local}")))
+}
+
+fn sh_comp(local: &str) -> String {
+    format!("{SH}{local}")
+}
+
+/// An expected validation result: focus / path / value / component / severity.
+/// `None` for `value` means "no `sh:value`"; `Some(None)` is not expressible —
+/// use `value_none` for the no-value case.
+struct Exp {
+    focus: Term,
+    path: Option<Path>,
+    value: Option<Term>,
+    component: String,
+    severity: String,
+}
+
+fn pred_path(local: &str) -> Path {
+    Path::Predicate(format!("{NS}{local}"))
+}
+
+fn violation(focus: Term, path: Option<Path>, value: Option<Term>, component: &str) -> Exp {
+    Exp {
+        focus,
+        path,
+        value,
+        component: sh_comp(component),
+        severity: format!("{SH}Violation"),
+    }
+}
+
+/// Asserts the report's results are a 1:1 match for `expected` (multiset, with
+/// blank nodes matching any blank node), and that `conforms` matches.
+fn assert_report(r: &ValidationReport, conforms: bool, expected: &[Exp]) {
+    assert_eq!(
+        r.conforms,
+        conforms,
+        "conforms mismatch: got {} results: {}",
+        r.results.len(),
+        summarize(&r.results)
+    );
+    assert_eq!(
+        expected.len(),
+        r.results.len(),
+        "result count: expected {}, got {}: {}",
+        expected.len(),
+        r.results.len(),
+        summarize(&r.results)
+    );
+    let mut used = vec![false; r.results.len()];
+    for e in expected {
+        let found = r
+            .results
+            .iter()
+            .enumerate()
+            .position(|(j, a)| !used[j] && matches(e, a));
+        match found {
+            Some(j) => used[j] = true,
+            None => panic!(
+                "no actual result matches expected [focus {} comp {} value {:?}]; got {}",
+                e.focus,
+                e.component.rsplit('#').next().unwrap_or(""),
+                e.value.as_ref().map(|v| v.to_string()),
+                summarize(&r.results)
+            ),
+        }
+    }
+}
+
+fn matches(e: &Exp, a: &ValidationResult) -> bool {
+    if !term_matches(&e.focus, &a.focus_node) {
+        return false;
+    }
+    if e.path != a.path {
+        return false;
+    }
+    match (&e.value, &a.value) {
+        (None, None) => {}
+        (Some(ev), Some(av)) if term_matches(ev, av) => {}
+        _ => return false,
+    }
+    e.component == a.source_component && e.severity == a.severity
+}
+
+fn term_matches(e: &Term, a: &Term) -> bool {
+    match (e, a) {
+        (Term::BlankNode(_), Term::BlankNode(_)) => true,
+        _ => e == a,
+    }
+}
+
+fn summarize(rs: &[ValidationResult]) -> String {
+    rs.iter()
+        .map(|r| {
+            format!(
+                "[focus {} comp {} path {:?} value {} sev {}]",
+                r.focus_node,
+                r.source_component.rsplit('#').next().unwrap_or(""),
+                r.path.as_ref().map(|p| p.to_turtle()),
+                r.value.as_ref().map(|v| v.to_string()).unwrap_or_default(),
+                r.severity.rsplit('#').next().unwrap_or("")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+/// An `xsd:integer` literal term (the suite writes bare integers like `4`).
+fn int(n: i64) -> Term {
+    Term::Literal(oxrdf::Literal::new_typed_literal(
+        n.to_string(),
+        oxrdf::NamedNode::new_unchecked("http://www.w3.org/2001/XMLSchema#integer"),
+    ))
+}
+
+fn lit(s: &str) -> Term {
+    Term::Literal(oxrdf::Literal::new_simple_literal(s))
+}
+
+// ============================ A. path-valued comparands ====================
+
+/// `equals-002`: `sh:equals ( ex:property2 ex:property3 )` — a sequence-PATH
+/// comparand. Value set of ex:property1 must equal the value set reached along
+/// the sequence. Five results across four invalid resources (both directions).
+#[test]
+fn equals_002_path_valued_comparand() {
+    let doc = r#"
+ex:InvalidResource1 ex:property1 "A" ; ex:property2 [ ex:property3 "B" ] .
+ex:InvalidResource2 ex:property1 "A" .
+ex:InvalidResource3 ex:property2 [ ex:property3 "A" ] .
+ex:InvalidResource4 ex:property1 "A" ; ex:property1 "B" ; ex:property2 [ ex:property3 "A" ] .
+ex:TestShape a sh:NodeShape ; sh:property ex:TestShape-property1 ;
+  sh:targetNode ex:InvalidResource1, ex:InvalidResource2, ex:InvalidResource3,
+                ex:InvalidResource4, ex:ValidResource1, ex:ValidResource2 .
+ex:TestShape-property1 sh:path ex:property1 ; sh:equals ( ex:property2 ex:property3 ) .
+ex:ValidResource1 ex:property1 "A" ; ex:property2 [ ex:property3 "A" ] .
+ex:ValidResource2 ex:property1 "A" ; ex:property1 "B" ;
+  ex:property2 [ ex:property3 "A" ] ; ex:property2 [ ex:property3 "B" ] .
+"#;
+    let r = run(doc);
+    let p1 = Some(pred_path("property1"));
+    assert_report(
+        &r,
+        false,
+        &[
+            violation(ex("InvalidResource1"), p1.clone(), Some(lit("A")), "EqualsConstraintComponent"),
+            violation(ex("InvalidResource1"), p1.clone(), Some(lit("B")), "EqualsConstraintComponent"),
+            violation(ex("InvalidResource2"), p1.clone(), Some(lit("A")), "EqualsConstraintComponent"),
+            violation(ex("InvalidResource3"), p1.clone(), Some(lit("A")), "EqualsConstraintComponent"),
+            violation(ex("InvalidResource4"), p1, Some(lit("B")), "EqualsConstraintComponent"),
+        ],
+    );
+}
+
+/// `disjoint-002`: BOTH the shape path AND the comparand are sequence paths
+/// (`sh:path ( ex:property1 ex:property2 )`, `sh:disjoint ( ex:property3
+/// ex:property4 )`). The reported `sh:resultPath` is the sequence path.
+#[test]
+fn disjoint_002_sequence_path_and_comparand() {
+    let doc = r#"
+ex:InvalidResource1 ex:property1 [ ex:property2 "A" ] ; ex:property3 [ ex:property4 "A" ] .
+ex:InvalidResource2 ex:property1 [ ex:property2 "A" ] ; ex:property1 [ ex:property2 "B" ] ;
+  ex:property3 [ ex:property4 "A" ] .
+ex:TestShape a sh:NodeShape ; sh:property ex:TestShape-property1 ;
+  sh:targetNode ex:InvalidResource1, ex:InvalidResource2, ex:ValidResource1, ex:ValidResource2 .
+ex:TestShape-property1 sh:path ( ex:property1 ex:property2 ) ;
+  sh:disjoint ( ex:property3 ex:property4 ) .
+ex:ValidResource1 ex:property1 [ ex:property2 "A" ] ; ex:property3 [ ex:property4 "B" ] .
+ex:ValidResource2 ex:property1 [ ex:property2 "A" ] ; ex:property1 [ ex:property2 "B" ] ;
+  ex:property3 [ ex:property4 "C" ] ; ex:property3 [ ex:property4 "D" ] .
+"#;
+    let r = run(doc);
+    let seq = Some(Path::Sequence(vec![pred_path("property1"), pred_path("property2")]));
+    assert_report(
+        &r,
+        false,
+        &[
+            violation(ex("InvalidResource1"), seq.clone(), Some(lit("A")), "DisjointConstraintComponent"),
+            violation(ex("InvalidResource2"), seq, Some(lit("A")), "DisjointConstraintComponent"),
+        ],
+    );
+}
+
+/// `lessThan-003`: `sh:lessThan ( ex:property2 ex:property3 )` — sequence-PATH
+/// comparand. One result per failing (value, comparand) pair.
+#[test]
+fn less_than_003_path_valued_comparand() {
+    let doc = r#"
+ex:InvalidResource1 ex:property1 4 ; ex:property2 [ ex:property3 4 ] .
+ex:InvalidResource2 ex:property1 4 ; ex:property1 6 ; ex:property2 [ ex:property3 5 ] .
+ex:InvalidResource3 ex:property1 5 ; ex:property2 [ ex:property3 4 ] .
+ex:TestShape a sh:NodeShape ; sh:property ex:TestShape-property1 ;
+  sh:targetNode ex:InvalidResource1, ex:InvalidResource2, ex:InvalidResource3,
+                ex:ValidResource1, ex:ValidResource2 .
+ex:TestShape-property1 sh:path ex:property1 ; sh:lessThan ( ex:property2 ex:property3 ) .
+ex:ValidResource1 ex:property1 4 ; ex:property2 [ ex:property3 6 ] .
+ex:ValidResource2 ex:property1 3.1 .
+"#;
+    let r = run(doc);
+    let p1 = Some(pred_path("property1"));
+    assert_report(
+        &r,
+        false,
+        &[
+            violation(ex("InvalidResource1"), p1.clone(), Some(int(4)), "LessThanConstraintComponent"),
+            violation(ex("InvalidResource2"), p1.clone(), Some(int(6)), "LessThanConstraintComponent"),
+            violation(ex("InvalidResource3"), p1, Some(int(5)), "LessThanConstraintComponent"),
+        ],
+    );
+}
+
+/// `lessThanOrEquals-002`: `sh:lessThanOrEquals ( ex:property2 ex:property3 )`.
+#[test]
+fn less_than_or_equals_002_path_valued_comparand() {
+    let doc = r#"
+ex:InvalidResource1 ex:property1 5 ; ex:property2 [ ex:property3 4 ] .
+ex:InvalidResource2 ex:property1 4 ; ex:property1 6 ; ex:property2 [ ex:property3 5 ] .
+ex:TestShape a sh:NodeShape ; sh:property ex:TestShape-property1 ;
+  sh:targetNode ex:InvalidResource1, ex:InvalidResource2,
+                ex:ValidResource1, ex:ValidResource2, ex:ValidResource3 .
+ex:TestShape-property1 sh:path ex:property1 ; sh:lessThanOrEquals ( ex:property2 ex:property3 ) .
+ex:ValidResource1 ex:property1 4 ; ex:property2 [ ex:property3 6 ] .
+ex:ValidResource2 ex:property1 3.1 .
+ex:ValidResource3 ex:property1 5 ; ex:property2 [ ex:property3 5 ] .
+"#;
+    let r = run(doc);
+    let p1 = Some(pred_path("property1"));
+    assert_report(
+        &r,
+        false,
+        &[
+            violation(ex("InvalidResource1"), p1.clone(), Some(int(5)), "LessThanOrEqualsConstraintComponent"),
+            violation(ex("InvalidResource2"), p1, Some(int(6)), "LessThanOrEqualsConstraintComponent"),
+        ],
+    );
+}
+
+/// A bare-predicate comparand (the SHACL-1.0 `-001` form) still works after the
+/// switch from a `String` predicate to a `Path` comparand — backward-compat.
+#[test]
+fn equals_predicate_comparand_backward_compatible() {
+    let doc = r#"
+ex:n a ex:T ; ex:a 1, 2 ; ex:b 2, 3 .
+ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+  sh:property [ sh:path ex:a ; sh:equals ex:b ] .
+"#;
+    let r = run(doc);
+    // ex:a = {1,2}, ex:b = {2,3}: 1 absent from b, 3 absent from a -> 2 results.
+    assert_eq!(
+        r.results
+            .iter()
+            .filter(|x| x.source_component.ends_with("EqualsConstraintComponent"))
+            .count(),
+        2,
+        "{}",
+        summarize(&r.results)
+    );
+    assert!(!r.conforms);
+}
+
+// ============================ B. disjunctive sh:class ======================
+
+/// `class-002`: `sh:class ( ex:SuperClass ex:OtherClass )` — instance of ANY
+/// listed class, subclass-aware (ex:SubClass ⊑ ex:SuperClass conforms).
+#[test]
+fn class_002_disjunctive_class_list() {
+    let doc = r#"
+ex:InvalidResource1 rdf:type rdfs:Resource ;
+  ex:testProperty ex:InvalidResource1 ; ex:testProperty "A string" .
+ex:OtherClass rdf:type rdfs:Class .
+ex:OtherClassInstance rdf:type ex:OtherClass .
+ex:SubClass rdf:type rdfs:Class ; rdfs:subClassOf ex:SuperClass .
+ex:SubClassInstance rdf:type ex:SubClass .
+ex:SuperClass rdf:type rdfs:Class .
+ex:SuperClassInstance rdf:type ex:SuperClass .
+ex:TestShape a sh:NodeShape ; sh:property ex:TestShape-testProperty ;
+  sh:targetNode ex:InvalidResource1, ex:ValidResource1, ex:ValidResource2 .
+ex:TestShape-testProperty sh:path ex:testProperty ;
+  sh:class ( ex:SuperClass ex:OtherClass ) .
+ex:ValidResource1 rdf:type rdfs:Resource ;
+  ex:testProperty ex:OtherClassInstance, ex:SubClassInstance, ex:SuperClassInstance .
+ex:ValidResource2 rdf:type rdfs:Resource ;
+  ex:testProperty [ rdf:type ex:SubClass ] ; ex:testProperty [ rdf:type ex:SuperClass ] .
+"#;
+    let r = run(doc);
+    let tp = Some(pred_path("testProperty"));
+    assert_report(
+        &r,
+        false,
+        &[
+            violation(ex("InvalidResource1"), tp.clone(), Some(ex("InvalidResource1")), "ClassConstraintComponent"),
+            violation(ex("InvalidResource1"), tp, Some(lit("A string")), "ClassConstraintComponent"),
+        ],
+    );
+}
+
+// ============================ C. four new components =======================
+
+/// `subsetOf-001`: `sh:subsetOf ex:property2` — the value set of ex:property1
+/// must be a SUBSET of the value set of ex:property2. One result per path value
+/// absent from the comparand set.
+#[test]
+fn subset_of_001() {
+    let doc = r#"
+ex:InvalidResource1 ex:property1 "A" ; ex:property2 "B" .
+ex:InvalidResource2 ex:property1 "A" .
+ex:InvalidResource3 ex:property1 "A" ; ex:property1 "B" ; ex:property2 "A" .
+ex:TestShape a sh:NodeShape ; sh:property ex:TestShape-property1 ;
+  sh:targetNode ex:InvalidResource1, ex:InvalidResource2, ex:InvalidResource3,
+                ex:ValidResource1, ex:ValidResource2 .
+ex:TestShape-property1 sh:path ex:property1 ; sh:subsetOf ex:property2 .
+ex:ValidResource1 ex:property1 "A" ; ex:property2 "A" .
+ex:ValidResource2 ex:property1 "A" ; ex:property2 "A" ; ex:property2 "B" .
+ex:property1 rdf:type rdf:Property .
+ex:property2 rdf:type rdf:Property .
+"#;
+    let r = run(doc);
+    let p1 = Some(pred_path("property1"));
+    assert_report(
+        &r,
+        false,
+        &[
+            violation(ex("InvalidResource1"), p1.clone(), Some(lit("A")), "SubsetOfConstraintComponent"),
+            violation(ex("InvalidResource2"), p1.clone(), Some(lit("A")), "SubsetOfConstraintComponent"),
+            violation(ex("InvalidResource3"), p1, Some(lit("B")), "SubsetOfConstraintComponent"),
+        ],
+    );
+}
+
+/// `someValue-001`: `sh:someValue [ sh:class ex:Duck ]` — EXISTENTIAL. Alice
+/// tends only a Cow -> one violation (no `sh:value`); Bob tends a Duck -> ok.
+#[test]
+fn some_value_001() {
+    let doc = r#"
+ex:Donald a ex:Duck .
+ex:Daisy a ex:Duck .
+ex:Eliza a ex:Cow .
+ex:Alice ex:tendsAnimal ex:Eliza .
+ex:Bob ex:tendsAnimal ex:Donald, ex:Eliza .
+ex:DuckFarmerShape a sh:NodeShape ; sh:targetNode ex:Alice, ex:Bob ;
+  sh:property ex:DuckFarmerShape-tendsAnimal .
+ex:DuckFarmerShape-tendsAnimal sh:path ex:tendsAnimal ;
+  sh:someValue [ sh:class ex:Duck ] .
+"#;
+    let r = run(doc);
+    assert_report(
+        &r,
+        false,
+        &[violation(
+            ex("Alice"),
+            Some(pred_path("tendsAnimal")),
+            None,
+            "SomeValueConstraintComponent",
+        )],
+    );
+}
+
+/// `singleLine-001`: `sh:singleLine true` flags strings containing LF/CR/FF/VT;
+/// `sh:singleLine false` imposes no constraint (the multi-line comment is ok).
+#[test]
+fn single_line_001() {
+    let doc = "
+ex:InvalidInstanceF a ex:SingleLineExampleShape ; rdfs:label \"Invalid\\u000Cinstance\" .
+ex:InvalidInstanceN a ex:SingleLineExampleShape ; rdfs:label \"Invalid\\u000Ainstance\" .
+ex:InvalidInstanceR a ex:SingleLineExampleShape ; rdfs:label \"Invalid\\u000Dinstance\" .
+ex:InvalidInstanceV a ex:SingleLineExampleShape ; rdfs:label \"Invalid\\u000Binstance\" .
+ex:SingleLineExampleShape a sh:NodeShape, rdfs:Class ;
+  sh:property ex:SingleLineExampleShape-label ; sh:property ex:SingleLineExampleShape-comment .
+ex:SingleLineExampleShape-label a sh:PropertyShape ; sh:path rdfs:label ;
+  sh:datatype xsd:string ; sh:singleLine true .
+ex:SingleLineExampleShape-comment a sh:PropertyShape ; sh:path rdfs:comment ;
+  sh:or ( [ sh:datatype xsd:string ] [ sh:datatype rdf:langString ] ) ; sh:singleLine false .
+ex:ValidInstance1 a ex:SingleLineExampleShape ; rdfs:label \"Valid instance1\" ;
+  rdfs:comment \"\"\"This is a multi-\nline comment.\n\"\"\" .
+";
+    let r = run(doc);
+    let label_path = Some(Path::Predicate(
+        "http://www.w3.org/2000/01/rdf-schema#label".into(),
+    ));
+    let mk = |focus: &str, value: Term| Exp {
+        focus: ex(focus),
+        path: label_path.clone(),
+        value: Some(value),
+        component: sh_comp("SingleLineConstraintComponent"),
+        severity: format!("{SH}Violation"),
+    };
+    assert_report(
+        &r,
+        false,
+        &[
+            mk("InvalidInstanceF", lit("Invalid\u{000C}instance")),
+            mk("InvalidInstanceN", lit("Invalid\u{000A}instance")),
+            mk("InvalidInstanceR", lit("Invalid\u{000D}instance")),
+            mk("InvalidInstanceV", lit("Invalid\u{000B}instance")),
+        ],
+    );
+}
+
+/// `rootClass-001`: `sh:rootClass ex:Animal` — a value must be ex:Animal or a
+/// transitive `rdfs:subClassOf`-descendant. ex:Plant / ex:Car fail; ex:Animal /
+/// ex:Mammal / ex:Dog (subclasses) pass.
+#[test]
+fn root_class_001() {
+    let doc = r#"
+ex:Organism a rdfs:Class .
+ex:Animal a rdfs:Class ; rdfs:subClassOf ex:Organism .
+ex:Mammal a rdfs:Class ; rdfs:subClassOf ex:Animal .
+ex:Dog a rdfs:Class ; rdfs:subClassOf ex:Mammal .
+ex:Plant a rdfs:Class ; rdfs:subClassOf ex:Organism .
+ex:Car a rdfs:Class .
+ex:Zoo ex:holds ex:Animal, ex:Mammal, ex:Dog, ex:Plant, ex:Car .
+ex:TestShape a sh:NodeShape ; sh:targetNode ex:Zoo ; sh:property ex:TestShape-holds .
+ex:TestShape-holds a sh:PropertyShape ; sh:path ex:holds ; sh:rootClass ex:Animal .
+"#;
+    let r = run(doc);
+    let p = Some(pred_path("holds"));
+    assert_report(
+        &r,
+        false,
+        &[
+            violation(ex("Zoo"), p.clone(), Some(ex("Plant")), "RootClassConstraintComponent"),
+            violation(ex("Zoo"), p, Some(ex("Car")), "RootClassConstraintComponent"),
+        ],
+    );
+}
+
+// ============================ D. severity-threshold conforms ===============
+
+/// `severity-004`: a `sh:Debug`-severity result is reported but does NOT break
+/// conformance (Debug is below the default `sh:Info` threshold).
+#[test]
+fn severity_004_debug_conforms() {
+    let doc = r#"
+ex:TestShape a sh:NodeShape ; sh:datatype xsd:integer ; sh:severity sh:Debug ;
+  sh:targetNode "Hello" .
+"#;
+    let r = run(doc);
+    // One Debug-severity DatatypeConstraintComponent result, yet conforms = true.
+    assert!(r.conforms, "Debug-only report must conform: {}", summarize(&r.results));
+    assert_eq!(r.results.len(), 1);
+    assert_eq!(r.results[0].severity, format!("{SH}Debug"));
+    assert!(r.results[0].source_component.ends_with("DatatypeConstraintComponent"));
+}
+
+/// `severity-005`: a `sh:Trace`-severity result conforms (Trace is the lowest).
+#[test]
+fn severity_005_trace_conforms() {
+    let doc = r#"
+ex:TestShape a sh:NodeShape ; sh:datatype xsd:integer ; sh:severity sh:Trace ;
+  sh:targetNode "Hello" .
+"#;
+    let r = run(doc);
+    assert!(r.conforms, "Trace-only report must conform: {}", summarize(&r.results));
+    assert_eq!(r.results.len(), 1);
+    assert_eq!(r.results[0].severity, format!("{SH}Trace"));
+}
+
+/// A `sh:Warning`-severity result DOES break the DEFAULT conformance (Warning is
+/// in the default disallowed set) — guards against over-relaxing `conforms`.
+/// This mirrors the suite's `severity-001` / `conformance-disallows-002`.
+#[test]
+fn warning_breaks_default_conformance() {
+    let doc = r#"
+ex:PersonShape a sh:NodeShape ; sh:property ex:PersonShape-age ; sh:targetClass ex:Person .
+ex:PersonShape-age a sh:PropertyShape ; sh:path ex:age ; sh:severity sh:Warning ;
+  sh:datatype xsd:integer .
+ex:Bob a ex:Person ; ex:age "twenty two" .
+"#;
+    let r = run(doc);
+    assert!(!r.conforms, "a Warning result must break default conformance");
+    assert_eq!(r.results.len(), 1);
+    assert_eq!(r.results[0].severity, format!("{SH}Warning"));
+}
+
+/// `conformance-disallows-001`: the same Warning result CONFORMS under a custom
+/// `sh:conformanceDisallows sh:Violation` (only Violation disallowed), recomputed
+/// via `conforms_with_disallowed`. The default `conforms` field stays false.
+#[test]
+fn conformance_disallows_001_custom_threshold() {
+    let doc = r#"
+ex:PersonShape a sh:NodeShape ; sh:property ex:PersonShape-age ; sh:targetClass ex:Person .
+ex:PersonShape-age a sh:PropertyShape ; sh:path ex:age ; sh:severity sh:Warning ;
+  sh:datatype xsd:integer .
+ex:Bob a ex:Person ; ex:age "twenty two" .
+"#;
+    let r = run(doc);
+    // The default disallowed set includes sh:Warning -> field is false.
+    assert!(!r.conforms);
+    // Under the custom set {sh:Violation}, the Warning result conforms.
+    assert!(r.conforms_with_disallowed(&["http://www.w3.org/ns/shacl#Violation"]));
+    // The single result is the expected Warning datatype violation on ex:Bob.
+    assert_eq!(r.results.len(), 1);
+    let res = &r.results[0];
+    assert_eq!(res.focus_node, ex("Bob"));
+    assert_eq!(res.path, Some(pred_path("age")));
+    assert_eq!(res.value, Some(lit("twenty two")));
+    assert_eq!(res.severity, format!("{SH}Warning"));
+    assert!(res.source_component.ends_with("DatatypeConstraintComponent"));
+}

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: shacl-validation
-description: "Validate RDF data against SHACL shapes with the sparq engine: SHACL Core constraints (class, datatype incl. the SHACL-1.2 disjunctive list form, cardinality, ranges, paths, logical, node/property, qualified, closed incl. sh:ByTypes, in/hasValue, and the SHACL-1.2 list constraints sh:memberShape / sh:uniqueMembers / sh:min+maxListLength / sh:uniqueValuesFor), SHACL-SPARQL sh:sparql constraints (§5.2), and custom SPARQL-based constraint components (sh:ConstraintComponent, §6) — then read the conformance/violations validation report (W3C report vocabulary as Turtle or human text). Also runs opt-in SHACL Advanced Features (SHACL-AF) rules — sh:rule (sh:TripleRule + sh:SPARQLRule) — to INFER triples (feature `shacl-af`). Use when an agent needs to check whether a sparq_core::Graph conforms to shapes, run shape validation, produce a SHACL validation report, or apply SHACL rules to infer/expand a graph in Rust."
+description: "Validate RDF data against SHACL shapes with the sparq engine: SHACL Core constraints (class, datatype incl. the SHACL-1.2 disjunctive list form, cardinality, ranges, paths, logical, node/property, qualified, closed incl. sh:ByTypes, in/hasValue, the SHACL-1.2 list constraints sh:memberShape / sh:uniqueMembers / sh:min+maxListLength / sh:uniqueValuesFor, and the SHACL-1.2 value constraints sh:subsetOf / sh:someValue / sh:singleLine / sh:rootClass with path-valued sh:equals/disjoint/lessThan comparands and severity-threshold sh:conforms), SHACL-SPARQL sh:sparql constraints (§5.2), and custom SPARQL-based constraint components (sh:ConstraintComponent, §6) — then read the conformance/violations validation report (W3C report vocabulary as Turtle or human text). Also runs opt-in SHACL Advanced Features (SHACL-AF) rules — sh:rule (sh:TripleRule + sh:SPARQLRule) — to INFER triples (feature `shacl-af`). Use when an agent needs to check whether a sparq_core::Graph conforms to shapes, run shape validation, produce a SHACL validation report, or apply SHACL rules to infer/expand a graph in Rust."
 ---
 
 # sparq-shacl-validation
@@ -122,10 +122,12 @@ pub fn ShapesModel::parse(shapes_graph: &Graph) -> ShapesModel;   // parse once,
 `ValidationReport` (`sparq_shacl::ValidationReport`):
 
 ```rust
-pub conforms: bool;                         // true iff results is empty (spec sh:conforms — counts EVERY result)
+pub conforms: bool;                         // SHACL-1.2 sh:conforms: false iff any result is in the
+                                            // default disallowed set {Violation,Warning,Info}; Debug/Trace conform
 pub results: Vec<ValidationResult>;
 pub diagnostics: Vec<ShapeDiagnostic>;      // skipped-constraint diagnostics (e.g. uncompilable sh:pattern); never affect `conforms`
-pub fn conforms_violations_only(&self) -> bool;                       // ignore sh:Warning / sh:Info
+pub fn conforms_violations_only(&self) -> bool;                       // stricter-threshold toggle: ignore sh:Warning / sh:Info
+pub fn conforms_with_disallowed(&self, disallowed: &[&str]) -> bool;  // custom sh:conformanceDisallows set (full severity IRIs)
 pub fn results_with_severity<'a>(&'a self, severity: &'a str)         // full IRI, e.g. ".../shacl#Warning"
     -> impl Iterator<Item = &'a ValidationResult>;
 pub fn to_turtle(&self) -> String;          // W3C report vocabulary (valid, round-trippable Turtle)
@@ -162,8 +164,10 @@ expression used in `sh:resultPath`.
 
 ## Common recipes
 
-**CI gating — fail on violations, allow warnings.** `report.conforms` counts every
-result; use the severity-aware toggle so `sh:Warning`/`sh:Info` don't fail the build:
+**CI gating — fail on violations, allow warnings.** `report.conforms` follows the
+SHACL-1.2 default (also disallows `sh:Warning`/`sh:Info`); use the stricter-threshold
+toggle so only `sh:Violation` fails the build (or `conforms_with_disallowed` for a
+custom `sh:conformanceDisallows` set):
 
 ```rust
 let report = sparq_shacl::validate(&data, &shapes);
@@ -232,6 +236,18 @@ and `sh:uniqueValuesFor` (the listed properties' values are unique across the
 shape's target nodes — one IRI, or a SHACL list for a composite key). A value that
 is not a well-formed SHACL list violates the list constraints; a node with no
 values for any `sh:uniqueValuesFor` property is never reported.
+
+**SHACL-1.2 value constraints (always on, sq-sx15d).** `sh:class` also takes a
+disjunctive SHACL-list object (`sh:class ( ex:A ex:B )` — a value conforms iff it is a
+SHACL instance of ANY listed class, subclass-aware). The comparand of `sh:equals` /
+`sh:disjoint` / `sh:lessThan` / `sh:lessThanOrEquals` — and the new `sh:subsetOf`
+(path value set ⊆ comparand value set) — is a full SHACL property PATH (often an
+RDF-list sequence `( ex:p ex:q )`), not just a predicate IRI; a bare IRI parses to a
+trivial predicate path, so the SHACL-1.0 forms stay unchanged. `sh:someValue [ shape ]`
+is EXISTENTIAL (at least one value node must conform to the nested shape; one result on
+the focus/path when none do). `sh:singleLine true` flags string values containing a
+line break (LF/CR/FF/VT). `sh:rootClass C` requires each value node to be `C` or a
+transitive `rdfs:subClassOf`-descendant of it.
 
 **Custom SPARQL-based constraint component (`sh:ConstraintComponent`, §6).** Declare
 the component (parameters + an `sh:ask`/`sh:select` validator) IN THE SHAPES GRAPH; it
@@ -406,9 +422,10 @@ conforms/violations).
   pass infers nothing, capped at `rules::MAX_ITERATIONS` (100); `Inference::capped`
   flags a non-terminating rule set (e.g. a CONSTRUCT minting a fresh blank node each
   pass) whose inferred set may be incomplete.
-- **`sh:conforms` counts EVERY result regardless of severity** (matches the W3C suite).
-  For "warnings don't fail" gating use `conforms_violations_only()` /
-  `results_with_severity(..)`, NOT `conforms`.
+- **`sh:conforms` uses the SHACL-1.2 default disallowed set {Violation,Warning,Info}**
+  (sq-sx15d): a Debug/Trace-only report conforms; a Warning/Info result does NOT. For a
+  stricter "only Violation fails" gate use `conforms_violations_only()`; for a custom
+  `sh:conformanceDisallows` set use `conforms_with_disallowed(&[..])`.
 - **Ill-formed shapes are skipped, not errored.** A shape never declared, an
   unparsable path, or an `sh:select` that fails to parse (e.g. undeclared prefix)
   contributes no results; the rest of validation still runs. `validate` never returns


### PR DESCRIPTION
> 🤖 **SPARQ agent**

Implements **sq-sx15d** (epic **sq-waf9o**): SHACL 1.2 CORE value constraints in `crates/sparq-shacl/src/` (`model.rs`, `eval.rs`, `report.rs`), making these 12 vendored `shacl12-test-suite` core entries pass through the REAL crate `validate()`:

- **A. Path-valued comparands** — `property/{equals-002, disjoint-002, lessThan-003, lessThanOrEquals-002}`. `sh:equals`/`sh:disjoint`/`sh:lessThan`/`sh:lessThanOrEquals` now carry a SHACL property **`Path`** (parsed by the existing `Path` parser — a bare IRI is a trivial `Path::Predicate`, so the SHACL-1.0 `-001` predicate forms stay backward-compatible) and eval via `Path::values`. Previously the model only matched `Term::NamedNode`, so an RDF-list sequence comparand was **silently dropped**.
- **B. Disjunctive `sh:class`** — `property/class-002`. `sh:class ( ex:A ex:B )` → `Component::ClassIn(Vec<Term>)`, any-of subclass-aware `is_instance_of`, mirroring the existing disjunctive `sh:datatype`/`sh:nodeKind` handling.
- **C. Four new components** — `property/{subsetOf-001, someValue-001, singleLine-001, rootClass-001}`. `sh:subsetOf` (path value set ⊆ comparand path value set), `sh:someValue` (existential — at least one value node conforms to a nested shape; one result on focus/path when none do), `sh:singleLine true` (no LF/CR/FF/VT), `sh:rootClass` (value is the class or a transitive `rdfs:subClassOf`-descendant). Each is a `Component` variant + parse + eval + the correct `...ConstraintComponent` IRI.
- **D. Severity-threshold conforms** — `misc/{severity-004, severity-005}`, `validation-reports/conformance-disallows-001`. `ValidationReport.conforms` now uses the SHACL 1.2 **default disallowed set `{Violation, Warning, Info}`** (severity ordering `Trace < Debug < Info < Warning < Violation`): a Debug/Trace-only report **conforms**; a Violation/Warning/Info result does not. Adds `conforms_with_disallowed(&[..])` + `DEFAULT_CONFORMANCE_DISALLOWS` so a caller (or the harness) can apply a custom `sh:conformanceDisallows` set — that is what lets `conformance-disallows-001` (a Warning result under `sh:conformanceDisallows sh:Violation`) conform.

### Spec note (honest deviation from the terse brief)
The brief said to wire `conforms_violations_only()` into `conforms`. The actual suite data falsifies that: `severity-001` (Warning) and `conformance-disallows-002` (Warning) expect `sh:conforms false`, while `severity-004/005` (Debug/Trace) expect true. Per the SHACL 1.2 Core spec, the **default** `sh:conformanceDisallows` set is `{Violation, Warning, Info}` (not just Violation), so I implemented that. A `sh:Violation` result still sets `conforms=false`, guarding the previously-passing tests.

### Tests
- New permanent, fixture-free `tests/w3c_core_shacl12_value_constraints.rs` inlines the 12 suite entries' shapes+data (the fetched suite tree is gitignored) and asserts the produced report 1:1 against each suite expected report through real `validate()`, plus a backward-compat bare-predicate `sh:equals` case and Debug/Trace/Warning/custom-threshold conformance cases. Per-component unit coverage added in `report.rs`/`lib.rs`.
- I also confirmed all 12 pass against the **actual fetched suite** via a temporary manifest walker (removed before this PR).

### Gates (run in-worktree)
- `cargo build` / `cargo clippy --all-targets -D warnings` / `cargo test -p sparq-shacl` — GREEN in **both** feature states: default (feature OFF) **and** `--features shacl-af`. (The new constraints are always-on Core, not gated.)
- `cargo +1.88 check -p sparq-shacl` (and `--features shacl-af`) — OK.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `python3 scripts/check-readme-template.py --enforce` — **0 deviations**; README ≤120 lines.

Does **not** touch `tests/w3c_core_shacl12.rs` or `ci.yml` (a parallel PR owns the harness extension). No regression: the full existing `sparq-shacl` suite passes in both states, including the SHACL-1.2 harness at its 44/45 (off) and 45/45 (on) baselines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
