### PR TITLE
docs: recurring doc-maintenance sweep — fix garbled OWL2-EL clause + refresh capability roster [OPUS-4.8]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@
 
 sparq is a from-scratch **RDF triplestore and SPARQL 1.1 engine in Rust** — dictionary-encoded, six sorted permutation indexes, parallel + streaming execution, RDFS/OWL-RL/N3 inference, an out-of-core (mmap) mode with a compressed on-disk format, a WebAssembly build, and a W3C-conformant HTTP server. The engine is published across several surfaces:
 
-- **Rust crates** (crates.io): `sparq-core`, `sparq-engine` (core), `sparq-cli`, `sparq-server`, plus opt-in capability crates (`sparq-reason`, `sparq-reason-el`, `sparq-shacl`, `sparq-geo`, `sparq-text`, `sparq-rsp`, `sparq-hdt`, `sparq-solid`, ...). `sparq-reason-el` is a **separate** opt-in crate (depending on it is the opt-in): an OWL 2 EL consequence-based classifier that computes the **complete** `rdfs:subClassOf` subsumption lattice OWL 2 RL (`sparq-reason`) is sound but silently incomplete for — see [`skills/inference/SKILL.md`](skills/inference/SKILL.md).
+- **Rust crates** (crates.io): `sparq-core`, `sparq-engine` (core), `sparq-cli`, `sparq-server`, plus opt-in capability crates (`sparq-reason`, `sparq-reason-el`, `sparq-shacl`, `sparq-geo`, `sparq-text`, `sparq-rsp`, `sparq-hdt`, `sparq-solid`, `sparq-arrow`, `sparq-mcp`, `sparq-vc`, ...). `sparq-reason-el` is a **separate** opt-in crate (depending on it is the opt-in): an OWL 2 EL consequence-based classifier that computes the **complete** `rdfs:subClassOf` subsumption lattice that OWL 2 RL (`sparq-reason`) is sound but silently incomplete for — see [`skills/inference/SKILL.md`](skills/inference/SKILL.md).
 - **npm**: `@jeswr/sparq` — RDF/JS-typed API over the wasm build, zero runtime deps.
 - **PyPI**: `sparq-rdf` (import name `sparq`) — pyo3/maturin bindings.
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — I am @jeswr's agent for the jeswr/sparq RDF/SPARQL engine. @jeswr runs multiple agents; this was written by the SPARQ agent, not the PSS agent (prod-solid-server).

## What this is

The recurring **doc-maintenance + honesty-reconciliation sweep** (DOC-ONLY; no `crates/` source). Two tight, verified fixes to `AGENTS.md`; everything else swept was already clean.

## Fixes (before → after)

1. **§"What sparq is" — garbled OWL 2 EL sentence.** The relative clause was misplaced, producing a broken sentence:
   - **before:** "…computes the **complete** `rdfs:subClassOf` subsumption lattice OWL 2 RL (`sparq-reason`) is sound but silently incomplete for —"
   - **after:** "…computes the **complete** `rdfs:subClassOf` subsumption lattice **that** OWL 2 RL (`sparq-reason`) is sound but silently incomplete for —"
   - Matches `skills/inference/SKILL.md` ("the COMPLETE OWL 2 EL class-subsumption lattice (which RL is sound-but-incomplete for)"). The **load-bearing honesty caveat** (RL is "sound but silently incomplete") is preserved verbatim.

2. **Capability-crate roster refreshed.** Added the three recently-merged opt-in capability crates — `sparq-arrow` (Apache Arrow export, #1224), `sparq-mcp` (MCP server), `sparq-vc` (W3C Data Integrity) — to the illustrative list. The trailing `...` (non-exhaustive by design) is retained.

## Duties swept (all verified against `origin/main`)

- **SKILL.md coverage:** router (`skills/SKILL.md`) links **all 27** surface dirs, no dead links; spot-checked `python` (`query_arrow`), `http-server` (`GET /streams`), `sparql-query` (prepared queries) — all current.
- **Honesty drift:** no hard-coded perf numbers outside `bench/`; no stale "not implemented" claims for shipped features; `check-privacy-claims.sh` **exit 0** (485 files) — no unqualified ZK/MPC claim; the pending-external-audit caveat (`sq-qhy4`) + "MPC semi-honest only" are intact.
- **Cross-references:** all AGENTS.md-referenced scripts/skills/workflows exist; READMEs within the 120-line cap (`check-readme-template.py` → **0 deviations**).
- **Repo hygiene:** no `HANDOVER*`/`SESSION*`/scratch docs, no `TODO.md` / `- [ ]` checklists.

## Gates (changed file)

`privacy-claims` exit 0 · `terminology` exit 0 · `markdownlint-cli2` 0 errors · `readme-template` 0 deviations.

Auto-merge intentionally **OFF** — left for the orchestrator/maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)