### PR TITLE
ci(sparq-py): wire `arrow` pyproject extra + PR-gate the Arrow functional lane (sq-5jjei) [OPUS-4.8]

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,10 +1,45 @@
 name: Python bindings
 
-# Informational build + test of the `sparq` Python package (crates/sparq-py, T21) on
-# every push to main: maturin builds the abi3 wheel, pip installs it, pytest runs the
-# round-trip suite. The release wheels matrix (manylinux / macOS / Windows via
-# maturin-action) is a follow-up — see docs/release.md "Python wheels".
+# Build + test of the `sparq` Python package (crates/sparq-py, T21): maturin builds the
+# abi3 wheel, pip installs it, pytest runs the round-trip suite. The release wheels matrix
+# (manylinux / macOS / Windows via maturin-action) is a follow-up — see docs/release.md
+# "Python wheels".
+#
+# THESE GATE (not informational). Both jobs (`maturin build + pytest` and the opt-in
+# `maturin build (arrow) + pytest`) carry NO `advisory`/`informational` token, so the
+# `ci-summary / gate` aggregator (.github/workflows/ci-summary.yml — it excludes only
+# names matching the whole word `\b(advisory|informational)\b`) treats them as HARD
+# required gates whenever they RUN on a PR.
+#
+# WHY a `pull_request` trigger ([OPUS-4.8] sq-5jjei, gh-910): python.yml USED to trigger
+# on `push: branches:[main]` + `workflow_dispatch` ONLY, so the `arrow` functional lane
+# (the `Graph.query_arrow -> pyarrow.Table` round-trip in tests/test_arrow.py) — and the
+# lean wheel test too — only went green/red AFTER merge to main, never at PR time. The
+# `pull_request` trigger below validates both BEFORE merge, exactly as js.yml does for the
+# `js` gate (sq-5lof). The feature-matrix `opt-in sparq-py (arrow …)` leg already gates the
+# cargo build+clippy of the `arrow` feature; this lane adds the FUNCTIONAL pytest cover a
+# cargo leg cannot reproduce (it needs a maturin-built wheel + pyarrow).
+#
+# SCOPE: PRs that touch the Python-binding surfaces (paths below) — a docs-only or
+# unrelated-crate PR matches none, so neither job runs and the required `ci-summary / gate`
+# simply never waits on them (cross-workflow `needs:` is impossible — see js.yml/gui.yml).
+# This keeps the maturin build off unrelated PRs. NOT a `merge_group` lane (ci-summary.yml
+# never cross-workflow-needs python.yml), matching js.yml/gui.yml. The unfiltered
+# `push: branches:[main]` trigger is KEPT for post-merge cover on every main push.
 on:
+  pull_request:
+    # Every input the jobs read: the crate (Rust binding source + Cargo.toml + tests +
+    # pyproject), the workspace manifests/lock the maturin build resolves from, the
+    # sparq-arrow crate the `arrow` feature compiles in, the hash-pinned build/arrow
+    # requirement sets the pip installs verify against, and this workflow file.
+    paths:
+      - "crates/sparq-py/**"
+      - "crates/sparq-arrow/**"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/requirements/python-build.txt"
+      - ".github/requirements/python-arrow.txt"
+      - ".github/workflows/python.yml"
   push:
     branches: [main]
   workflow_dispatch:

--- a/crates/sparq-py/README.md
+++ b/crates/sparq-py/README.md
@@ -76,12 +76,16 @@ g.ask("PREFIX ex: <http://ex/> ASK { ex:alice ex:knows ex:bob }")   # -> True
   release the GIL. `Graph.load` treats a `str` as a **file path** only when a file
   with that name exists and the string has no newline; `os.PathLike` is always a
   path; otherwise the string is parsed as RDF content.
-- **Opt-in Arrow export** (`pip install sparq-rdf[arrow]`, needs `pyarrow ≥ 14`) —
-  `g.query_arrow(sparql)` returns a `pyarrow.Table` (one
+- **Opt-in Arrow export** — `g.query_arrow(sparql)` returns a `pyarrow.Table` (one
   `struct<kind,value,datatype,language,direction>` column per variable; unbound → null
   struct slot) over the merged `sparq-arrow` projection, bridged through the Arrow C
   Data Interface (no re-serialisation). OFF by default, so the lean wheel pays nothing.
-  v1 boundary: no numeric narrowing yet, RDF 1.2 triple terms stringified.
+  v1 boundary: no numeric narrowing yet, RDF 1.2 triple terms stringified. The `arrow`
+  extra (`pip install sparq-rdf[arrow]`) pulls in the `pyarrow ≥ 14` consumer side, but
+  `query_arrow` only EXISTS in a wheel built with the cargo `arrow` feature
+  (`maturin build --features arrow`). Which published PyPI wheels ship with `arrow`
+  baked in is the broader release-matrix question (sq-v286); until then, build/install
+  an `--features arrow` wheel yourself.
 
 ## 📚 Learn more
 

--- a/crates/sparq-py/pyproject.toml
+++ b/crates/sparq-py/pyproject.toml
@@ -35,6 +35,18 @@ Issues = "https://github.com/jeswr/sparq/issues"
 
 [project.optional-dependencies]
 test = ["pytest>=8.4.2"]
+# [OPUS-4.8] sq-5jjei (gh-910): the `arrow` extra makes `pip install sparq-rdf[arrow]`
+# pull in pyarrow — the CONSUMER side of the Arrow C Data Interface the opt-in
+# `Graph.query_arrow() -> pyarrow.Table` surface uses (the binding hands the batch over a
+# PyCapsule stream, no re-serialisation). This extra is necessary BUT NOT SUFFICIENT to
+# use query_arrow: the
+# method only EXISTS in a wheel compiled with the cargo `arrow` feature (`maturin build
+# --features arrow`). Which PUBLISHED-PyPI wheels ship with `arrow` baked in is the
+# broader sq-v286 release-matrix question (NOTE: not resolved here — see the README's
+# "Arrow export" note); until that lands, install an `--features arrow` wheel yourself.
+# Floor `pyarrow>=14`: the first release exposing the PyCapsule-based C Data Interface
+# import path (a `pyarrow.Table` built from a stream capsule) this binding relies on.
+arrow = ["pyarrow>=14"]
 
 [tool.maturin]
 # [OPUS-4.8] sq-8slf: pin the IMPORT/module name to `sparq` independently of the


### PR DESCRIPTION
> 🤖 **SPARQ agent** — package/CI-only follow-up to sq-lt1ml (gh-910). **No engine logic.**

Closes the two gaps the brief identified after the opt-in `Graph.query_arrow() -> pyarrow.Table` export landed. Both were package/CI, not code.

### 1. `arrow` pyproject extra (`pip install sparq-rdf[arrow]`)
`crates/sparq-py/pyproject.toml` gains `[project.optional-dependencies] arrow = ["pyarrow>=14"]`. The README already *advertised* this extra but it was never *defined* in pyproject, so `pip install sparq-rdf[arrow]` could not resolve pyarrow. Now it does (verified end-to-end below).

Honest caveat carried in both pyproject and README: the extra is **necessary but not sufficient** — `query_arrow` only EXISTS in a wheel built with the cargo `arrow` feature (`maturin build --features arrow`). **Which published PyPI wheels ship `arrow` baked in is the broader sq-v286 release-matrix question** — left as a one-line noted follow-up rather than rebuilding the whole wheel matrix here (per the brief).

### 2. Promote the Arrow functional lane to PR-gating
`.github/workflows/python.yml` now triggers on `pull_request` (path-filtered to the Python-binding surfaces, keeping `push: branches:[main]` post-merge cover + `workflow_dispatch`), mirroring `js.yml`'s `js` gate (sq-5lof). The existing `maturin build (arrow) + pytest` job (already present from sq-lt1ml) and the lean wheel job thereby become **HARD `ci-summary / gate` legs at PR time** — the aggregator discovers them dynamically by name (neither carries an `advisory`/`informational` token). The real `test_arrow.py` round-trip now runs **before** merge, complementing the already-gating feature-matrix `opt-in sparq-py (arrow …)` build+clippy leg (a cargo leg cannot run the maturin-wheel + pyarrow round-trip). **SHA-pinned actions kept.**

**No feature-matrix golden change:** the arrow job is a *workflow* job, not a feature-matrix `opt-in <name>` leg; the sparq-py arrow leg + its `scripts/tests/feature-matrix-legnames.golden.txt` line already exist (sq-lt1ml). The assemble/golden consistency test still passes (7/7).

### Brief-premise correction (honesty)
The brief described the `arrow` job as "currently push/dispatch only". In fact, on `origin/main` (post-#1238) the `arrow` job, `python-arrow.txt` (hash-pinned pyarrow), `test_arrow.py`, and the feature-matrix leg+golden **all already existed**; the only true remaining gaps were the pyproject extra and the missing `pull_request` trigger. This PR fixes exactly those.

### Gates (worktree, BOTH feature states)
- `cargo clippy -p sparq-py --all-targets -- -D warnings` — GREEN default **and** `--features arrow`
- `cargo build` / `cargo test -p sparq-py` — GREEN both states (`[lib] test = false` by design; functional tests are pytest)
- `cargo +1.88 build -p sparq-py` (MSRV) — GREEN both states
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean
- `scripts/check-readme-template.py --enforce` — 0 deviations (README 101 lines, ≤120)
- `scripts/tests/test_feature_matrix_assemble.py` — 7 passed
- `python.yml` YAML parses (3 triggers: pull_request/push/workflow_dispatch; 2 jobs)
- **End-to-end:** built the `--features arrow` wheel with maturin → `pip install "sparq-rdf[arrow]"` pulled pyarrow 24.0.0 → `pytest tests/test_arrow.py` = **7 passed** (term-struct columns, unbound→null slot, query_json parity)

No new public Rust fn (so no coverage-ratchet direct-test owed); the public surface `query_arrow` is from sq-lt1ml and is already covered by `test_arrow.py`. SKILL.md (`skills/python/SKILL.md`) already documents the extra + feature.

Feature flag: cargo `arrow` (sparq-py). Cites **sq-5jjei**.