### PR TITLE
feat(gui): OS-reported disk-usage probe for the status bar gauge (sq-cno90)

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -78,8 +78,12 @@ gui/
 - **Top bar** (`h-10`): a LOCAL⇄ENDPOINT target switch, the store size, a ⌘K hint, a theme toggle,
   and an engine status LED.
 - **IDE tab strip** + a full-bleed work area (default = Query).
-- **Status bar** (`h-6`): the **measured `performance.now()` latency** of the last run, the row
-  count, the target, and the persistence backend.
+- **Status bar** (`h-7`): the **measured `performance.now()` latency** of the last run, the row
+  count, the target, the persistence backend, the live store size, an unintrusive ingest meter
+  (`sq-vw3ax`, #820), and a **disk gauge**. The disk gauge shows the **OS-reported** on-disk size
+  of the app-data `workspaces/` dir in the desktop shell (a recursive native `stat()` via the
+  `disk_usage` command, `sq-cno90`) and falls back to the **snapshot-bytes estimate** on the web
+  target — always labelled which of the two it is (`disk` vs `≈disk`), never a fabricated figure.
 
 ## The direct native engine link (desktop)
 
@@ -88,7 +92,10 @@ gui/
 (`load` / `query` / `query_quads` / `update_in_place` / `explain` / `explain_analyze` / `count` /
 `ask` / `store_size`) but backed by the full native store. Its `#[cfg(test)]` tests exercise the
 engine calls directly. The foundation frontend runs the in-tab WASM engine in BOTH targets for
-**query** (the honest, working-today path).
+**query** (the honest, working-today path). `src-tauri/src/disk.rs` adds the `disk_usage` command
+(`sq-cno90`): a recursive `stat()` of `$APPLOCALDATA/workspaces` that returns its real on-disk byte
+total for the status bar's disk gauge (least-privilege — confined in Rust to that subtree, follows
+no symlink out of it; the byte-summing walk is unit-tested directly).
 
 For **ingest**, the Import drawer (`sq-ixc3.13`) calls the engine's **native loader** IPC
 (`load_path` / `load_text`) when running in the desktop shell: a disk file — including

--- a/gui/app/src/components/workbench/import-drawer.tsx
+++ b/gui/app/src/components/workbench/import-drawer.tsx
@@ -97,7 +97,7 @@ function ImportDrawer({
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }) {
-  const { importRdf, snapshotStore } = useEngine();
+  const { importRdf, snapshotStore, refreshDiskUsage } = useEngine();
   const { recordImport } = useWorkspace();
   const native = hasNativeLoader();
 
@@ -137,6 +137,9 @@ function ImportDrawer({
         const { source, storeSize, added } = await run();
         // Record the source + persist a fresh snapshot of the now-updated live store.
         await recordImport(source, snapshotStore());
+        // [OPUS-4.8] sq-cno90 — the snapshot was just written to disk; re-probe the OS-reported
+        // footprint so the desktop status bar reflects the new on-disk bytes (no-op on the web).
+        refreshDiskUsage();
         setFeedback({
           kind: "ok",
           message: `Imported ${added.toLocaleString()} quad${added === 1 ? "" : "s"} (${sourceKind}). Store now holds ${storeSize.toLocaleString()}.`,
@@ -150,7 +153,7 @@ function ImportDrawer({
         setBusy(false);
       }
     },
-    [recordImport, snapshotStore],
+    [recordImport, snapshotStore, refreshDiskUsage],
   );
 
   // FILE — pick via the native dialog, then load via the native loader.

--- a/gui/app/src/components/workbench/status-bar.tsx
+++ b/gui/app/src/components/workbench/status-bar.tsx
@@ -6,15 +6,23 @@
 // [OPUS-4.8] sq-vw3ax (#820 "GUI: unintrusive stats") — the bold redesign adds the issue's two
 // asked-for stats, unintrusively (no modal): a slim INGEST meter (the real file label + a live
 // MEASURED elapsed while an import is in flight) and a tiny DISK gauge (the REAL on-device store
-// footprint — the byte length of the persisted whole-dataset N-Quads snapshot).
+// footprint).
+//
+// [OPUS-4.8] sq-cno90 (#820 follow-up) — the disk gauge now PREFERS the OS-reported on-disk byte
+// total (a recursive native `stat()` of the `$APPLOCALDATA/workspaces` tree via the `disk_usage`
+// command) when running in the desktop shell, and FALLS BACK to the snapshot-bytes estimate on the
+// web target (no native FS). The two are clearly distinguished in the label + tooltip — it is never
+// dressed up as OS-reported when it is the estimate.
 //
 // HONESTY. Every figure here is real:
 //   * latency  — wall-clock of the query the user JUST ran (performance.now), labelled per-run,
 //                NOT a benchmark claim (this work box / CI runner is non-canonical).
-//   * disk     — the actual size of what the workspace persists (snapshot bytes). There is no
-//                fixed capacity, so the gauge shows the live footprint; the conic ring's fill is a
-//                log-scaled visual cue only, and the tooltip states the exact bytes. A precise
-//                filesystem probe of the app-data dir is a follow-up bead (new Tauri command).
+//   * disk     — on the desktop shell, the OS-reported byte total of the workspaces dir (the
+//                precise on-disk size, incl. the workspace index JSON); on the web target, the
+//                snapshot-bytes ESTIMATE (the byte length of the persisted whole-dataset N-Quads
+//                snapshot). There is no fixed capacity, so the gauge shows the live footprint; the
+//                conic ring's fill is a log-scaled visual cue only, and the tooltip states the
+//                exact bytes AND which of the two sources it is. Never a fabricated number.
 //   * ingest   — the loaders are synchronous (no byte-level progress callback), so this is an
 //                honest indeterminate "ingesting <file>…" with a real elapsed — never a fake %/ETA.
 
@@ -88,9 +96,23 @@ function IngestMeter({ ingest }: { ingest: IngestState }) {
 }
 
 export function StatusBar() {
-  const { lastLatencyMs, lastRowCount, storeSize, storeBytes, ingest, nativeLoaderAvailable } =
-    useEngine();
+  const {
+    lastLatencyMs,
+    lastRowCount,
+    storeSize,
+    storeBytes,
+    diskBytes,
+    ingest,
+    nativeLoaderAvailable,
+  } = useEngine();
   const { backend } = useWorkspace();
+
+  // [OPUS-4.8] sq-cno90 — PREFER the OS-reported on-disk figure when the desktop probe returned one;
+  // otherwise fall back to the snapshot-bytes estimate (the web target). Labelled honestly either
+  // way: "disk" for the OS figure, "≈disk" for the estimate. Never fabricated — `diskBytes` is null
+  // unless the native probe actually reported real bytes.
+  const osReported = diskBytes !== null;
+  const displayBytes = osReported ? diskBytes : storeBytes;
   return (
     <footer className="sq-statusbar flex h-7 shrink-0 items-center gap-4 border-t px-3 font-mono text-[11px] text-muted-foreground">
       <span
@@ -124,18 +146,24 @@ export function StatusBar() {
       {/* [OPUS-4.8] sq-vw3ax (#820) — the unintrusive ingest meter (only while an import runs). */}
       {ingest && <IngestMeter ingest={ingest} />}
 
-      {/* [OPUS-4.8] sq-vw3ax (#820) — the disk gauge: the REAL persisted store footprint. */}
+      {/* [OPUS-4.8] sq-vw3ax (#820) + sq-cno90 (#820 follow-up) — the disk gauge: the OS-reported
+          on-disk footprint in the desktop shell, else the snapshot-bytes estimate (≈) on the web. */}
       <span
         className="flex items-center gap-1.5"
-        title={`Workspace store on disk: ${storeBytes.toLocaleString()} bytes (the persisted whole-dataset snapshot)`}
+        title={
+          osReported
+            ? `Workspace store on disk: ${displayBytes.toLocaleString()} bytes — OS-reported size of the app-data workspaces/ dir`
+            : `Workspace store ≈ ${displayBytes.toLocaleString()} bytes — estimate (persisted whole-dataset snapshot); the OS-reported size shows in the desktop app`
+        }
         data-status-disk
+        data-disk-source={osReported ? "os" : "estimate"}
       >
         <span
           className="sq-disk-ring"
-          style={{ ["--disk-pct" as string]: diskRingPct(storeBytes) }}
+          style={{ ["--disk-pct" as string]: diskRingPct(displayBytes) }}
           aria-hidden
         />
-        disk {formatBytes(storeBytes)}
+        {osReported ? "disk" : "≈disk"} {formatBytes(displayBytes)}
       </span>
     </footer>
   );

--- a/gui/app/src/lib/engine-context.tsx
+++ b/gui/app/src/lib/engine-context.tsx
@@ -29,6 +29,7 @@ import { basePath } from "@/lib/base-path";
 import { SAMPLE_TURTLE, SAMPLE_FORMAT } from "@/data/sample-graph";
 import {
   hasNativeLoader,
+  nativeDiskUsage,
   nativeLoadPath,
   nativeLoadText,
   type LoadedDocument,
@@ -196,10 +197,26 @@ export interface EngineContextValue {
   /** Total quads in the live store (default + all named graphs). */
   storeSize: number;
   /**
-   * [OPUS-4.8] sq-vw3ax (#820) — the REAL on-device store footprint in bytes (the UTF-8 length of
-   * the persisted whole-dataset N-Quads snapshot). 0 before the store warms. Honest measured value.
+   * [OPUS-4.8] sq-vw3ax (#820) — the on-device store footprint ESTIMATE in bytes (the UTF-8 length
+   * of the persisted whole-dataset N-Quads snapshot). 0 before the store warms. Honest measured
+   * value, but an estimate of the on-disk size — it omits the workspace index JSON + encoding
+   * overhead. On the desktop shell {@link diskBytes} reports the OS's exact figure instead.
    */
   storeBytes: number;
+  /**
+   * [OPUS-4.8] sq-cno90 (#820 follow-up) — the OS-REPORTED on-disk byte total of the
+   * `$APPLOCALDATA/workspaces` tree (a recursive native `stat()` sum via the `disk_usage` command),
+   * or `null` on the web target / before the first probe / if the probe failed. When present this
+   * is the precise on-disk footprint the status bar PREFERS over the {@link storeBytes} estimate;
+   * when `null` the gauge falls back to the estimate, labelled as such. Never fabricated.
+   */
+  diskBytes: number | null;
+  /**
+   * [OPUS-4.8] sq-cno90 (#820 follow-up) — re-run the OS-reported `disk_usage` probe (e.g. after a
+   * workspace SAVE, which an import triggers, so {@link diskBytes} reflects the just-written file).
+   * A no-op on the web target. Best-effort: a failure leaves the last value, never a fabrication.
+   */
+  refreshDiskUsage: () => void;
   /** [OPUS-4.8] sq-vw3ax (#820) — the in-flight import, or null. Drives the status bar ingest meter. */
   ingest: IngestState | null;
   /** Per-graph counts for the datasets tree. */
@@ -381,6 +398,9 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
   const [storeSize, setStoreSize] = React.useState(0);
   // [OPUS-4.8] sq-vw3ax (#820) — the live on-device footprint (snapshot bytes) + in-flight import.
   const [storeBytes, setStoreBytes] = React.useState(0);
+  // [OPUS-4.8] sq-cno90 (#820 follow-up) — the OS-reported on-disk byte total of the workspaces
+  // tree (desktop only); null on the web target, where the gauge uses the snapshot estimate.
+  const [diskBytes, setDiskBytes] = React.useState<number | null>(null);
   const [ingest, setIngest] = React.useState<IngestState | null>(null);
   const [graphs, setGraphs] = React.useState<GraphSummary[]>([]);
   const [lastLatencyMs, setLastLatencyMs] = React.useState<number | null>(null);
@@ -419,6 +439,29 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
+  // [OPUS-4.8] sq-cno90 (#820 follow-up) — probe the OS-reported on-disk byte total of the
+  // workspaces tree via the native `disk_usage` command. On the desktop shell this is the precise
+  // figure the status bar prefers; on the web target (no native FS) it stays `null` and the gauge
+  // shows the snapshot estimate instead. Best-effort: a probe failure leaves the last value (or
+  // `null`) — the gauge never fabricates a number. The on-disk figure lags a freshly persisted
+  // snapshot by one write, so we re-probe after the workspace save that an import/update triggers.
+  const refreshDiskUsage = React.useCallback(() => {
+    nativeDiskUsage()
+      .then((du) => {
+        if (du) setDiskBytes(du.bytes);
+      })
+      .catch(() => {
+        /* a probe failure must never break the status bar — keep the last value / estimate */
+      });
+  }, []);
+
+  // [OPUS-4.8] sq-cno90 — probe the OS-reported on-disk footprint once on mount (desktop only; a
+  // no-op that leaves diskBytes null on the web target). A restored workspace already has bytes on
+  // disk, so this surfaces the real figure on first paint of the desktop shell.
+  React.useEffect(() => {
+    refreshDiskUsage();
+  }, [refreshDiskUsage]);
+
   const refreshSummary = React.useCallback(() => {
     const store = storeRef.current;
     if (!store) return;
@@ -426,7 +469,8 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     setStoreSize(size);
     setStoreBytes(snapshotBytes(store));
     setGraphs(gs);
-  }, []);
+    refreshDiskUsage();
+  }, [refreshDiskUsage]);
 
   // [OPUS-4.8] sq-ixc3.13 — the Import drawer's ingest. A `file` import (a disk path) goes
   // through the NATIVE loader IPC (`load_path`: compressed + native-only HDT, no wasm-tab
@@ -676,6 +720,8 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       status,
       storeSize,
       storeBytes,
+      diskBytes,
+      refreshDiskUsage,
       ingest,
       graphs,
       lastLatencyMs,
@@ -690,6 +736,8 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       status,
       storeSize,
       storeBytes,
+      diskBytes,
+      refreshDiskUsage,
       ingest,
       graphs,
       lastLatencyMs,

--- a/gui/app/src/lib/tauri-ipc.ts
+++ b/gui/app/src/lib/tauri-ipc.ts
@@ -35,6 +35,22 @@ export interface LoadedDocument {
   format: string;
 }
 
+/**
+ * [OPUS-4.8] sq-cno90 (#820 follow-up) — what the native disk-usage probe (`disk_usage`) hands
+ * back, byte-for-byte the Rust `DiskUsage` (gui/src-tauri/src/disk.rs): the resolved
+ * `$APPLOCALDATA/workspaces` path, its REAL on-disk byte total (a recursive `stat()` sum of every
+ * file), and whether the dir exists yet. This is the OS-reported store footprint the desktop
+ * status bar PREFERS over the snapshot-bytes estimate.
+ */
+export interface DiskUsage {
+  /** The resolved absolute path of the `$APPLOCALDATA/workspaces` tree the figure covers. */
+  path: string;
+  /** The summed real byte size of every regular file under `path` (apparent size, `du --bytes`). */
+  bytes: number;
+  /** Whether the workspaces dir exists yet (false on a fresh install → `bytes` is 0). */
+  exists: boolean;
+}
+
 /** Re-export the runtime detector so callers need only one import. */
 export { isTauriRuntime };
 
@@ -143,4 +159,23 @@ export async function nativeLoadText(
 /** True when the native loader IPC path is available (we are inside a Tauri webview). */
 export function hasNativeLoader(): boolean {
   return isTauriRuntime();
+}
+
+/**
+ * [OPUS-4.8] sq-cno90 (#820 follow-up) — probe the REAL on-disk byte size of the
+ * `$APPLOCALDATA/workspaces` tree through the native `disk_usage` command, or `null` outside the
+ * desktop shell (the web target has no native FS — the status bar falls back to the snapshot-bytes
+ * estimate there). This is the OS-reported store footprint: a recursive `stat()` sum the desktop
+ * status bar PREFERS over the snapshot estimate. Never fabricated — a real value or `null`.
+ */
+export async function nativeDiskUsage(): Promise<DiskUsage | null> {
+  const invoke = tauriInvoke();
+  if (!invoke) return null;
+  try {
+    return await invoke<DiskUsage>("disk_usage");
+  } catch {
+    // A path-resolution failure (or an old desktop build without the command) must not break the
+    // status bar — fall back to the snapshot estimate by reporting "no OS figure available".
+    return null;
+  }
 }

--- a/gui/src-tauri/capabilities/default.json
+++ b/gui/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "[OPUS-4.8] sq-2e93 / sq-ixc3.6 — default capability for the sparq GUI main window: the minimal core-window permissions, the file-open dialog (for loading an RDF file from disk into the native store), and a LEAST-PRIVILEGE filesystem grant scoped to the app's local-data `workspaces/` dir ONLY (durable on-disk workspace persistence, epic sq-ixc3). No shell, no HTTP, NO arbitrary FS — every fs permission is path-scoped to $APPLOCALDATA/workspaces; the engine runs in-process over IPC.",
+  "description": "[OPUS-4.8] sq-2e93 / sq-ixc3.6 / sq-cno90 — default capability for the sparq GUI main window: the minimal core-window permissions, the file-open dialog (for loading an RDF file from disk into the native store), and a LEAST-PRIVILEGE filesystem grant scoped to the app's local-data `workspaces/` dir ONLY (durable on-disk workspace persistence, epic sq-ixc3). No shell, no HTTP, NO arbitrary FS — every fs-PLUGIN permission is path-scoped to $APPLOCALDATA/workspaces; the engine runs in-process over IPC. The app-defined `disk_usage` command (sq-cno90, the OS-reported store-footprint probe) is invocable on this window by `core:default`; it adds NO new fs-plugin surface — it reads via the engine's own std::fs and is confined in Rust to the SAME $APPLOCALDATA/workspaces subtree (it resolves that dir, sums its files' real byte sizes, and follows no symlink out of the tree).",
   "windows": [
     "main"
   ],

--- a/gui/src-tauri/src/disk.rs
+++ b/gui/src-tauri/src/disk.rs
@@ -1,0 +1,219 @@
+// [OPUS-4.8] sq-cno90 (#820 follow-up) — a precise native disk-usage probe for the GUI status
+// bar's store-footprint figure.
+//
+// WHY. The status bar's store-footprint estimate is the UTF-8 byte length of the persisted
+// whole-dataset N-Quads snapshot (the engine context's snapshot, sq-ixc3.13). That is an
+// HONEST measured value, but it is an ESTIMATE of the on-disk size — it does not count the
+// workspace index JSON, the per-workspace metadata, or any encoding overhead the on-disk
+// `<app-local-data>/workspaces/*.json` files carry. This module adds the OS-reported number:
+// a recursive `stat()` walk of the resolved `$APPLOCALDATA/workspaces` tree that sums the real
+// byte size every file reports, so the desktop shell can show what the OS actually stores.
+//
+// HONESTY. This is the REAL on-disk byte total of the workspaces tree, or nothing — never a
+// fabricated figure. The status bar PREFERS this OS-reported value in the desktop shell and
+// falls back to the snapshot-bytes estimate on the web target (where no native FS exists),
+// always making clear which of the two is shown. The walk counts regular-file byte lengths
+// (`metadata.len()`); it does not chase symlinks out of the tree and does not try to model the
+// filesystem's block/allocation overhead (an apparent-size sum, the same notion `du --bytes`
+// reports), so it is exact for the JSON workspace files this app writes.
+//
+// No `unsafe`, no performance claim — this is a plain `std::fs` walk.
+
+use std::path::Path;
+
+use serde::Serialize;
+use tauri::Manager;
+
+/// The result of the disk-usage probe: the resolved workspaces directory and its real on-disk
+/// byte total. Serialised to the webview so the status bar can show the OS-reported footprint
+/// (and label it as such). `exists` is false when the workspaces dir has not been created yet
+/// (a fresh install before the first persisted workspace) — then `bytes` is 0, which is the
+/// honest answer, not a fabricated one.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct DiskUsage {
+    /// The resolved absolute path of the `$APPLOCALDATA/workspaces` tree the figure covers.
+    pub path: String,
+    /// The summed real byte size of every regular file under `path` (apparent size, `du --bytes`).
+    pub bytes: u64,
+    /// Whether the workspaces directory exists yet (false on a fresh install → `bytes` is 0).
+    pub exists: bool,
+}
+
+/// Recursively sum the real byte size (`metadata.len()`) of every regular file under `root`.
+///
+/// This is the load-bearing byte-summing walk the [`disk_usage`] command wraps. It is a pure
+/// function of the filesystem so it is unit-tested directly (no Tauri runtime needed):
+///
+///   * a missing `root` sums to `0` (a fresh install before any workspace is persisted);
+///   * directory entries recurse; regular files contribute `metadata.len()`;
+///   * symlinks are NOT followed (we read the link's own metadata via the directory entry, whose
+///     `len()` is the link itself), so the walk cannot escape the tree or loop on a cycle;
+///   * an unreadable entry is skipped rather than aborting the whole sum — a partial real total
+///     is still honest, and the probe must never panic the command.
+///
+/// The total is an APPARENT-SIZE sum (the same notion `du --bytes` / `du --apparent-size`
+/// reports), not an allocated-blocks figure; for the small JSON workspace files this app writes
+/// the two agree in practice, and apparent size is the portable, filesystem-independent number.
+pub fn dir_size_bytes(root: &Path) -> u64 {
+    // `symlink_metadata` reads the entry itself (does not traverse a symlink target).
+    let Ok(meta) = std::fs::symlink_metadata(root) else {
+        // Missing path (fresh install) or an unreadable root — honestly contributes nothing.
+        return 0;
+    };
+
+    if meta.is_file() {
+        return meta.len();
+    }
+
+    if !meta.is_dir() {
+        // A symlink or other special entry at this position: do not follow it (would let the
+        // walk escape the tree / loop), and do not count the link node's own size.
+        return 0;
+    }
+
+    let Ok(entries) = std::fs::read_dir(root) else {
+        // Directory we cannot enumerate — skip it rather than abort the whole walk.
+        return 0;
+    };
+
+    let mut total: u64 = 0;
+    for entry in entries.flatten() {
+        // `saturating_add` so a pathological tree can never overflow-panic the probe.
+        total = total.saturating_add(dir_size_bytes(&entry.path()));
+    }
+    total
+}
+
+/// The native disk-usage probe command: resolve `$APPLOCALDATA/workspaces` and return its REAL
+/// on-disk byte total (the recursive [`dir_size_bytes`] sum), the resolved path, and whether the
+/// dir exists yet.
+///
+/// This is the OS-reported counterpart to the webview's snapshot-bytes estimate — the same
+/// `<app-local-data>/workspaces` tree the granted `fs` capability scopes (capabilities/
+/// default.json) and the `@sparq/client` `TauriWorkspaceStore` persists into. The status bar
+/// PREFERS this value in the desktop shell and falls back to the snapshot estimate on the web
+/// target (where this command does not exist). It is read-only and panic-free: a missing dir is
+/// `bytes: 0, exists: false` (an honest fresh-install answer, not a fabricated figure), and a
+/// path-resolution failure is the only `Err` (stringified for the webview's `Result<_, String>`).
+#[tauri::command]
+pub fn disk_usage(app: tauri::AppHandle) -> Result<DiskUsage, String> {
+    // `app_local_data_dir()` is the SAME base dir the `fs` capability + workspace store key off
+    // (BaseDirectory::AppLocalData); the probe scopes itself to its `workspaces/` subtree only.
+    let base = app
+        .path()
+        .app_local_data_dir()
+        .map_err(|e| format!("cannot resolve app local data dir: {}", e))?;
+    let workspaces = base.join("workspaces");
+    let exists = workspaces.is_dir();
+    let bytes = dir_size_bytes(&workspaces);
+    Ok(DiskUsage {
+        path: workspaces.to_string_lossy().into_owned(),
+        bytes,
+        exists,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// A unique scratch dir under the system temp dir for one test, removed on drop.
+    struct Scratch {
+        dir: std::path::PathBuf,
+    }
+
+    impl Scratch {
+        fn new(tag: &str) -> Self {
+            let dir = std::env::temp_dir().join(format!(
+                "sparq-disk-{}-{}-{:?}",
+                tag,
+                std::process::id(),
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_nanos())
+                    .unwrap_or(0)
+            ));
+            std::fs::create_dir_all(&dir).expect("mk scratch dir");
+            Self { dir }
+        }
+
+        fn write(&self, rel: &str, bytes: &[u8]) {
+            let path = self.dir.join(rel);
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent).expect("mk parent");
+            }
+            let mut f = std::fs::File::create(&path).expect("create file");
+            f.write_all(bytes).expect("write file");
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    #[test]
+    fn missing_path_sums_to_zero() {
+        // A path that does not exist (fresh install, no workspaces yet) is an honest 0, not a panic.
+        let missing = std::env::temp_dir().join("sparq-disk-definitely-absent-xyz-123");
+        assert_eq!(dir_size_bytes(&missing), 0);
+    }
+
+    #[test]
+    fn a_single_file_reports_its_real_byte_length() {
+        let s = Scratch::new("single");
+        s.write("only.json", b"0123456789"); // exactly 10 bytes
+        assert_eq!(dir_size_bytes(&s.dir), 10);
+    }
+
+    #[test]
+    fn sums_every_file_across_nested_directories() {
+        // The load-bearing invariant: the walk is RECURSIVE and sums each file's real size.
+        let s = Scratch::new("nested");
+        s.write("a.json", &[0u8; 100]); // 100
+        s.write("b.json", &[0u8; 23]); //  23
+        s.write("nested/c.json", &[0u8; 7]); //   7
+        s.write("nested/deep/d.json", &[0u8; 1000]); // 1000
+        // An empty directory contributes nothing.
+        std::fs::create_dir_all(s.dir.join("empty-dir")).expect("mk empty dir");
+        assert_eq!(dir_size_bytes(&s.dir), 100 + 23 + 7 + 1000);
+    }
+
+    #[test]
+    fn an_empty_directory_sums_to_zero() {
+        let s = Scratch::new("empty");
+        assert_eq!(dir_size_bytes(&s.dir), 0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_symlink_is_not_followed_so_the_walk_cannot_escape_the_tree() {
+        // Guard the least-privilege intent: a symlink pointing OUT of the workspaces tree must
+        // not pull the linked file's bytes into the total (which would also enable a traversal
+        // escape). We point a link at a large file outside the scratch dir and assert it is not
+        // counted.
+        use std::os::unix::fs::symlink;
+        let s = Scratch::new("symlink");
+        s.write("real.json", &[0u8; 50]); // the only thing that should count: 50 bytes
+
+        let outside = std::env::temp_dir().join(format!(
+            "sparq-disk-outside-{}-{:?}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        std::fs::write(&outside, [0u8; 9999]).expect("write outside file");
+
+        let link = s.dir.join("escape.json");
+        symlink(&outside, &link).expect("create symlink");
+
+        // Only `real.json` (50 bytes) counts; the symlink target's 9999 bytes are excluded.
+        assert_eq!(dir_size_bytes(&s.dir), 50);
+
+        let _ = std::fs::remove_file(&outside);
+    }
+}

--- a/gui/src-tauri/src/lib.rs
+++ b/gui/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@
 // libraries (webkit2gtk / WebView2 / WKWebView) and is validated in CI (gui.yml), not
 // necessarily locally. The engine command layer itself is unit-tested natively (engine.rs).
 
+mod disk;
 mod engine;
 
 use engine::EngineState;
@@ -48,6 +49,10 @@ pub fn run() {
             engine::count,
             engine::ask,
             engine::store_size,
+            // [OPUS-4.8] sq-cno90 (#820 follow-up) — the precise native disk-usage probe: stat()s
+            // the resolved $APPLOCALDATA/workspaces tree and returns its REAL byte total, so the
+            // status bar can show the OS-reported store footprint instead of the snapshot estimate.
+            disk::disk_usage,
         ])
         .run(tauri::generate_context!())
         .expect("error while running the sparq Tauri application");


### PR DESCRIPTION
> 🤖 **SPARQ agent**

Closes the **#820** follow-up bead **sq-cno90**: tighten the GUI status-bar disk gauge from the snapshot-bytes ESTIMATE to the precise **OS-reported** on-disk size — in the desktop (Tauri) shell only, falling back to the honest estimate on the web target.

## What this implements
- **`gui/src-tauri/src/disk.rs`** — a minimal `disk_usage` Tauri command. It resolves `$APPLOCALDATA/workspaces` (the same base dir the granted `fs` capability + the `@sparq/client` workspace store key off) and returns its **real byte total** via `dir_size_bytes`: a recursive `stat()` walk that sums each regular file's `metadata.len()`. It follows **no symlink out of the tree** (least-privilege — cannot escape / loop), skips an unreadable entry rather than panicking, and reports a missing dir as `bytes: 0, exists: false` (an honest fresh-install answer).
- **Least-privilege capability** (`capabilities/default.json`) — documents that `disk_usage` is an app-defined command invocable by `core:default` and adds **NO new fs-plugin surface**: it reads via the engine's own `std::fs`, confined in Rust to the `workspaces/` subtree. (App-defined commands are not permission-gated in Tauri 2; adding a bogus `fs:` grant would misrepresent that it uses the fs plugin — it does not.)
- **Frontend wiring** — `tauri-ipc.ts` `nativeDiskUsage()` feature-detects the Tauri API; the engine context exposes `diskBytes` (OS-reported, `null` on web) + `refreshDiskUsage()` (probed on mount and after each persisted import). The status bar **PREFERS** the OS figure in the desktop shell (`disk N`) and **FALLS BACK** to the estimate on the web target (`≈disk N`) — clearly labelled which of the two it is, never fabricated.
- The existing #820 redesign styling (conic disk ring, ingest meter) is kept.

## Honesty
The gauge goes from estimate → OS-reported **in the desktop shell only**; on the hosted web target there is no native FS, so it stays the snapshot-bytes estimate (shown as `≈disk`). Either way it is a real measured value or the labelled estimate — never a fabricated number. No performance figure is asserted.

## A note on the brief's premise
The brief described the gauge as already wired to `snapshotBytes`; on `origin/main` the #820 redesign wires it to `storeBytes` (the snapshot-bytes estimate, computed via `snapshotBytes(store)`). Same intent — this PR is the precise-probe follow-up that bead described.

## Gates (all green)
Run in **BOTH** feature states — default (feature OFF) **and** `--features hdt`:
- `cargo build` · `cargo clippy --all-targets -- -D warnings` · `cargo test` (`gui/src-tauri`)
  - 5 **direct** unit tests for the byte-summing walk: nested-dir sum, single-file real length, empty dir, missing path → 0, **symlink-not-followed** (Unix).
- MSRV `cargo +1.88 check --all-targets` (both states).
- `gui/app`: `npm run typecheck` · `npm run lint` (no ESLint warnings/errors) · `npm run build:tauri` (static export) — all green.

`gui/src-tauri` is a standalone crate (own `[workspace]`, excluded from the main workspace gate), validated in `.github/workflows/gui.yml` which installs the webview system libs.

Cites **sq-cno90** + **#820**.