### PR TITLE
feat(shacl): SHACL 1.2 targets + SPARQL node-expression value/target/severity (sq-rnkdh) [OPUS-4.8]

### DIFF
--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -65,9 +65,9 @@ For many data graphs against one shapes graph, parse once with
   `sh:equals`/`sh:disjoint`/`sh:lessThan`/`sh:lessThanOrEquals`, `sh:subsetOf`/
   `sh:someValue`/`sh:singleLine`/`sh:rootClass`, and severity-threshold `conforms`
   (default disallows {Violation,Warning,Info}) (sq-sx15d). The **full** vendored
-  1.2 suite is gated by a ratchet (sq-6glcr): core, SPARQL (incl. expected-rejection
-  `sht:Failure` entries) and node-expr pass counts must not drop and the gap must not
-  grow, in both feature states. The not-yet-passing entries are the honest gap map in
+  1.2 suite is gated by a ratchet (sq-6glcr): core / SPARQL (incl. expected-rejection
+  `sht:Failure` entries) / node-expr pass counts must not drop and the gap must not
+  grow, in both feature states — gap map in
   [`research/shacl12-conformance-gap.md`](../../research/shacl12-conformance-gap.md).
 - **SHACL-SPARQL + custom §6 components** — `sh:sparql` (§5.2) and SPARQL-based
   constraint *components* (custom `sh:ConstraintComponent` with `sh:parameter` /
@@ -78,13 +78,13 @@ For many data graphs against one shapes graph, parse once with
   `sh:expression` / `sh:nodeByExpression` constraints. Off ⇒ none of it compiles.
 - **Differential fuzzing** — a deterministic SplitMix64 fuzzer
   (`tests/diff_fuzz.rs`) cross-checks reports against pluggable reference engines
-  (pySHACL, Apache Jena SHACL, and the Zazuko / `rdf-validate-shacl` Node engines); it
-  is `#[ignore]`d and runs as a nightly CI lane, skipping cleanly when no reference
-  resolves.
+  (pySHACL, Apache Jena SHACL, the Zazuko / `rdf-validate-shacl` Node engines); it is
+  `#[ignore]`d, runs as a nightly CI lane, and skips cleanly when none resolves.
 - **Full path + target support** — all SHACL path forms (sequence / alternative /
   inverse / `zeroOrMore`·`oneOrMore`·`zeroOrOne`), `sh:targetNode`/`Class`/
-  `SubjectsOf`/`ObjectsOf` + implicit class targets, plus `sh:severity` / `sh:message` /
-  `sh:deactivated`.
+  `SubjectsOf`/`ObjectsOf` + implicit class targets, the SHACL-1.2 targets
+  `sh:targetWhere`/`sh:shape`/`sh:ShapeClass` + SPARQL-valued targets & value nodes
+  (`sh:select`/`sh:sparqlExpr`, sq-rnkdh), plus `sh:severity`/`sh:message`/`sh:deactivated`.
 - **SHACL Compact Syntax parser (opt-in `scs`)** — `parse_scs(text, base)` /
   `parse_scs_to_graph(text, base)` turn a [W3C SHACL Compact Syntax](https://w3c.github.io/shacl/shacl-compact-syntax/)
   document into the same shapes triples `validate` consumes (the *parse* direction of the

--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -2,7 +2,7 @@
 //! emits [`ValidationResult`]s via direct graph scans (no SPARQL round-trip).
 
 use crate::model::{
-    sh, Component, ComponentDef, PreparedComponentValidator, Shape, ShapesModel, Target,
+    sh, Component, ComponentDef, PreparedComponentValidator, ShapesModel, Target,
 };
 use crate::path::Path;
 use crate::report::{ShapeDiagnostic, ValidationResult};
@@ -37,11 +37,47 @@ pub(crate) fn validate_graph(
     };
     let mut out = Vec::new();
     for &sid in &shapes.targeted {
-        for focus in v.focus_nodes(&shapes.shapes[sid]) {
+        for focus in v.focus_nodes(sid) {
             v.validate_shape(sid, &focus, &mut out);
         }
     }
+    // [OPUS-4.8] (sq-rnkdh) SHACL 1.2 `sh:shape` data-graph targets: a triple
+    // `?n sh:shape ?S` in the DATA graph makes `?n` a focus node of shape `?S`.
+    // Unlike the shapes-graph targets above this is discovered per-data-graph, so
+    // it is handled here rather than as a per-shape `Target`.
+    v.validate_data_shape_targets(shapes, &mut out);
     (out, v.diagnostics)
+}
+
+/// [OPUS-4.8] (sq-rnkdh) The number of DISTINCT focus nodes the model's targets
+/// select over `data` — the deterministic target-selection statistic exposed as
+/// [`crate::count_focus_nodes`]. Built on the same [`Validator::focus_nodes`]
+/// enumeration the real validation walk uses (plus the `sh:shape` data-graph
+/// targets), so it stays in lock-step with validation, including the SHACL-1.2
+/// data-dependent targets (`sh:targetWhere` / SPARQL-valued `sh:targetNode`).
+pub(crate) fn count_focus_nodes(data: &Graph, shapes: &ShapesModel) -> usize {
+    let mut v = Validator {
+        data: GraphView::new(data),
+        shapes,
+        stack: Vec::new(),
+        memo: vec![FxHashMap::default(); shapes.shapes.len()],
+        min_reentry: usize::MAX,
+        regexes: FxHashMap::default(),
+        uvf_targets: FxHashMap::default(),
+        diagnostics: Vec::new(),
+    };
+    let mut all: Vec<Term> = Vec::new();
+    for &sid in &shapes.targeted {
+        all.extend(v.focus_nodes(sid));
+    }
+    // `sh:shape` data-graph targets contribute their linked subjects as focus nodes
+    // (only when the linked shape is in the model — matching the validation walk).
+    for [focus, _, shape_node] in v.data.triples(None, Some(&sh("shape")), None) {
+        if shapes.by_node(&shape_node).is_some() {
+            all.push(focus);
+        }
+    }
+    crate::view::dedup(all).len()
 }
 
 /// [OPUS-4.8] (sq-d1dw, `shacl-af`) True iff `node` conforms to the shape `sid`
@@ -93,9 +129,16 @@ struct Validator<'a> {
 }
 
 impl<'a> Validator<'a> {
-    fn focus_nodes(&self, shape: &Shape) -> Vec<Term> {
+    /// The focus nodes selected by shape `sid`'s targets, deduplicated. Takes `sid`
+    /// (not a `&Shape`) and `&mut self` because the SHACL-1.2 `sh:targetWhere`
+    /// target evaluates conformance through the validator (which mutates the
+    /// conformance memo/stack), and the SPARQL-valued target runs a query.
+    fn focus_nodes(&mut self, sid: usize) -> Vec<Term> {
         let mut out = Vec::new();
-        for t in &shape.targets {
+        // Clone the targets so the per-target `&mut self` work (sh:targetWhere
+        // conformance, SPARQL target queries) does not alias the model borrow.
+        let targets = self.shapes.shapes[sid].targets.clone();
+        for t in &targets {
             match t {
                 Target::Node(n) => out.push(n.clone()),
                 Target::Class(c) | Target::ImplicitClass(c) => {
@@ -103,9 +146,62 @@ impl<'a> Validator<'a> {
                 }
                 Target::SubjectsOf(p) => out.extend(self.data.subjects_of(p)),
                 Target::ObjectsOf(p) => out.extend(self.data.objects_of(p)),
+                // [OPUS-4.8] (sq-rnkdh) SHACL 1.2 `sh:targetWhere [ <shape> ]`:
+                // every data-graph node that CONFORMS to the inline (object) shape.
+                Target::Where(inner) => out.extend(self.target_where_nodes(*inner)),
+                // [OPUS-4.8] (sq-rnkdh) SHACL 1.2 `sh:targetNode [ sh:select … ]`:
+                // the output nodes of the SPARQL node expression.
+                Target::Sparql(idx) => out.extend(self.target_sparql_nodes(*idx)),
             }
         }
         crate::view::dedup(out)
+    }
+
+    /// [OPUS-4.8] (sq-rnkdh) The `sh:targetWhere` focus nodes: every node that
+    /// appears in the data graph (as a subject OR object of any triple) and
+    /// CONFORMS to the inline shape `inner`. This mirrors the SHACL-1.2 target
+    /// definition ("all nodes from the data graph that conform to the given
+    /// shape"); a node that appears only as a predicate is not a focus candidate.
+    fn target_where_nodes(&mut self, inner: usize) -> Vec<Term> {
+        let mut candidates: Vec<Term> = Vec::new();
+        let mut seen: rustc_hash::FxHashSet<Term> = rustc_hash::FxHashSet::default();
+        for [s, _, o] in self.data.triples(None, None, None) {
+            for n in [s, o] {
+                if seen.insert(n.clone()) {
+                    candidates.push(n);
+                }
+            }
+        }
+        candidates
+            .into_iter()
+            .filter(|n| self.conforms(n, inner))
+            .collect()
+    }
+
+    /// [OPUS-4.8] (sq-rnkdh) The output nodes of a SPARQL-valued target node
+    /// expression (`sh:targetNode [ sh:select … ]`): the node expression is run
+    /// with no specific `$this` (there is no focus node yet — a target query
+    /// SELECTs the focus nodes), so `$this` is left unbound and the bindings of the
+    /// first result variable are the focus nodes.
+    fn target_sparql_nodes(&self, idx: usize) -> Vec<Term> {
+        self.shapes.select_exprs[idx].eval_target(self.data.graph())
+    }
+
+    /// [OPUS-4.8] (sq-rnkdh) SHACL 1.2 `sh:shape` data-graph targets: for every
+    /// triple `?n sh:shape ?S` in the DATA graph, `?n` is validated against the
+    /// shape `?S` (resolved in the shapes model — a shape not present in the model
+    /// is skipped). This is the data-driven dual of `sh:targetNode`: the link lives
+    /// in the data graph, so it is discovered here (not as a per-shape `Target`).
+    fn validate_data_shape_targets(
+        &mut self,
+        shapes: &ShapesModel,
+        out: &mut Vec<ValidationResult>,
+    ) {
+        for [focus, _, shape_node] in self.data.triples(None, Some(&sh("shape")), None) {
+            if let Some(sid) = shapes.by_node(&shape_node) {
+                self.validate_shape(sid, &focus, out);
+            }
+        }
     }
 
     /// True iff `node` produces no results against `shape` (conformance
@@ -171,9 +267,19 @@ impl<'a> Validator<'a> {
         if shape.deactivated {
             return;
         }
-        let values: Vec<Term> = match &shape.path {
-            Some(path) => path.values(&self.data, focus),
-            None => vec![focus.clone()],
+        // [OPUS-4.8] (sq-rnkdh) SHACL 1.2 SPARQL-valued value nodes: when the shape
+        // carries `sh:values [ sh:select … ]` / `[ sh:sparqlExpr … ]`, the value
+        // nodes are COMPUTED by the node expression (`$this` = focus node) instead
+        // of derived by traversing `sh:path`. The reported `sh:resultPath` is still
+        // the shape's path (set in `result`), so only the value-node SET changes.
+        let values: Vec<Term> = match shape.value_expr {
+            Some(idx) => {
+                crate::view::dedup(self.shapes.select_exprs[idx].eval(self.data.graph(), focus))
+            }
+            None => match &shape.path {
+                Some(path) => path.values(&self.data, focus),
+                None => vec![focus.clone()],
+            },
         };
         let components = shape.components.clone();
         for comp in &components {
@@ -1030,12 +1136,15 @@ impl<'a> Validator<'a> {
         };
         let component = sh("SPARQLConstraintComponent");
         let shape = &self.shapes.shapes[sid];
-        let (shape_node, shape_path, severity, shape_messages) = (
-            shape.node.clone(),
-            shape.path.clone(),
-            shape.severity.clone(),
-            shape.messages.clone(),
-        );
+        // [OPUS-4.8] (sq-rnkdh) A constraint-level `sh:severity` on the
+        // `sh:SPARQLConstraint` node OVERRIDES the shape's default severity (SHACL
+        // 1.2 `sparql/node/sparql-001`); otherwise inherit the shape's severity.
+        let severity = constraint
+            .severity
+            .clone()
+            .unwrap_or_else(|| shape.severity.clone());
+        let (shape_node, shape_path, shape_messages) =
+            (shape.node.clone(), shape.path.clone(), shape.messages.clone());
         let data = self.data.graph();
         prepared.evaluate(
             data,
@@ -1251,7 +1360,7 @@ impl<'a> Validator<'a> {
         if let Some(cached) = self.uvf_targets.get(&sid) {
             return cached.clone();
         }
-        let targets = self.focus_nodes(&self.shapes.shapes[sid]);
+        let targets = self.focus_nodes(sid);
         self.uvf_targets.insert(sid, targets.clone());
         targets
     }

--- a/crates/sparq-shacl/src/lib.rs
+++ b/crates/sparq-shacl/src/lib.rs
@@ -90,24 +90,12 @@ pub fn graph_from_triples<I: IntoIterator<Item = Triple>>(triples: I) -> Graph {
 /// the SHACL benchmark suite as a target-selection regression detector alongside
 /// the violation count.
 ///
-/// It reuses the public [`view::GraphView`] target-selection primitives
-/// (`instances_of`/`subjects_of`/`objects_of`), so it stays in lock-step with
-/// the validator without exposing internals.
+/// It delegates to the validator's own focus-node enumeration (`eval`), so it
+/// stays in lock-step with validation — including the SHACL-1.2 data-dependent
+/// targets (`sh:targetWhere`, the SPARQL-valued `sh:targetNode`, and the
+/// `sh:shape` data-graph link) that a pure shapes-graph scan cannot express.
 pub fn count_focus_nodes(data: &Graph, model: &ShapesModel) -> usize {
-    use oxrdf::Term;
-    let g = view::GraphView::new(data);
-    let mut all: Vec<Term> = Vec::new();
-    for &sid in &model.targeted {
-        for t in &model.shapes[sid].targets {
-            match t {
-                Target::Node(n) => all.push(n.clone()),
-                Target::Class(c) | Target::ImplicitClass(c) => all.extend(g.instances_of(c)),
-                Target::SubjectsOf(p) => all.extend(g.subjects_of(p)),
-                Target::ObjectsOf(p) => all.extend(g.objects_of(p)),
-            }
-        }
-    }
-    view::dedup(all).len()
+    eval::count_focus_nodes(data, model)
 }
 
 /// Loads a Turtle document into a [`Graph`], resolving relative IRIs against
@@ -245,6 +233,147 @@ mod tests {
         .unwrap();
         let model = ShapesModel::parse(&shapes);
         assert_eq!(count_focus_nodes(&data, &model), 3);
+    }
+
+    // --- [OPUS-4.8] (sq-rnkdh) SHACL 1.2 targets & SPARQL node expressions ------
+
+    /// `sh:targetWhere [ <inline shape> ]`: the focus nodes are the data-graph
+    /// nodes that CONFORM to the inline shape. Here only `ex:alice` (a Person with
+    /// age ≥ 18) is in scope; `ex:bob` (age 17) is not, so its violation of the
+    /// outer constraint is NOT reported. `count_focus_nodes` agrees.
+    #[test]
+    fn target_where_selects_conforming_nodes() {
+        const TW_SHAPES: &str = r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:AdultShape a sh:NodeShape ;
+              sh:targetWhere [
+                sh:class ex:Person ;
+                sh:property [ sh:path ex:age ; sh:minInclusive 18 ] ;
+              ] ;
+              sh:property [ sh:path ex:votedFor ; sh:minCount 1 ] .
+        "#;
+        let shapes = Graph::load_str(TW_SHAPES, "turtle").unwrap();
+        let data = Graph::load_str(
+            r#"
+            @prefix ex: <http://example.org/> .
+            ex:alice a ex:Person ; ex:age 30 .
+            ex:bob   a ex:Person ; ex:age 17 .
+        "#,
+            "turtle",
+        )
+        .unwrap();
+        let model = ShapesModel::parse(&shapes);
+        // alice is the only in-target node (≥18); bob (17) is out of target.
+        assert_eq!(count_focus_nodes(&data, &model), 1);
+        let r = validate(&data, &shapes);
+        assert!(!r.conforms, "{}", r.to_text());
+        assert_eq!(r.results.len(), 1, "{}", r.to_text());
+        assert_eq!(
+            r.results[0].focus_node,
+            oxrdf::Term::NamedNode(oxrdf::NamedNode::new("http://example.org/alice").unwrap())
+        );
+    }
+
+    /// `sh:shape` data-graph link: a triple `?n sh:shape ?S` in the DATA graph
+    /// makes `?n` a focus node of shape `?S`.
+    #[test]
+    fn data_graph_sh_shape_target() {
+        let shapes = Graph::load_str(
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            ex:TestShape a sh:NodeShape ;
+              sh:property [ sh:path rdfs:label ; sh:datatype xsd:string ; sh:maxCount 0 ] .
+        "#,
+            "turtle",
+        )
+        .unwrap();
+        let data = Graph::load_str(
+            r#"
+            @prefix ex: <http://example.org/> .
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+            ex:Invalid rdfs:label "x" ; <http://www.w3.org/ns/shacl#shape> ex:TestShape .
+            ex:Valid <http://www.w3.org/ns/shacl#shape> ex:TestShape .
+        "#,
+            "turtle",
+        )
+        .unwrap();
+        let r = validate(&data, &shapes);
+        assert!(!r.conforms, "{}", r.to_text());
+        // Only ex:Invalid has a label (maxCount 0 violated); ex:Valid conforms.
+        assert_eq!(r.results.len(), 1, "{}", r.to_text());
+        assert_eq!(
+            r.results[0].focus_node,
+            oxrdf::Term::NamedNode(oxrdf::NamedNode::new("http://example.org/Invalid").unwrap())
+        );
+    }
+
+    /// `sh:ShapeClass` is a class that is ALSO a node shape (SHACL 1.2): instances
+    /// (via the subclass closure) are implicit-class-targeted by it.
+    #[test]
+    fn shape_class_is_implicit_class_target() {
+        let g = Graph::load_str(
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+            ex:Super a sh:ShapeClass ; sh:in ( ex:Good ) .
+            ex:Sub rdfs:subClassOf ex:Super .
+            ex:Good a ex:Sub .
+            ex:Bad  a ex:Sub .
+        "#,
+            "turtle",
+        )
+        .unwrap();
+        let r = validate(&g, &g);
+        assert!(!r.conforms, "{}", r.to_text());
+        // ex:Bad is not in the sh:in list -> one InConstraintComponent violation.
+        assert_eq!(r.results.len(), 1, "{}", r.to_text());
+        assert!(r.results[0]
+            .source_component
+            .ends_with("InConstraintComponent"));
+    }
+
+    /// SPARQL-valued `sh:targetNode [ sh:select … ]` computes target nodes, and
+    /// `sh:values [ sh:sparqlExpr … ]` computes value nodes; a constraint-level
+    /// `sh:severity` overrides the shape default.
+    #[test]
+    fn sparql_valued_target_and_values_and_severity() {
+        let shapes = Graph::load_str(
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            ex:S a sh:NodeShape ;
+              sh:targetNode [ sh:select "SELECT ?p WHERE { ?p <http://example.org/flag> true }" ] ;
+              sh:sparql [
+                sh:select "SELECT $this WHERE { $this <http://example.org/bad> true }" ;
+                sh:severity sh:Warning ;
+              ] .
+        "#,
+            "turtle",
+        )
+        .unwrap();
+        let data = Graph::load_str(
+            r#"
+            @prefix ex: <http://example.org/> .
+            ex:x ex:flag true ; ex:bad true .
+            ex:y ex:bad true .
+        "#,
+            "turtle",
+        )
+        .unwrap();
+        let model = ShapesModel::parse(&shapes);
+        // Only ex:x is selected by the SPARQL target (ex:y has no ex:flag).
+        assert_eq!(count_focus_nodes(&data, &model), 1);
+        let r = validate(&data, &shapes);
+        assert!(!r.conforms, "{}", r.to_text());
+        assert_eq!(r.results.len(), 1, "{}", r.to_text());
+        // The constraint-level sh:severity overrode the shape's default Violation.
+        assert!(r.results[0].severity.ends_with("Warning"), "{}", r.to_text());
     }
 
     /// The Turtle rendering must itself be valid Turtle.

--- a/crates/sparq-shacl/src/model.rs
+++ b/crates/sparq-shacl/src/model.rs
@@ -21,12 +21,22 @@ pub enum Target {
     Node(Term),
     /// sh:targetClass — all SHACL instances of the class in the data graph.
     Class(Term),
-    /// Implicit class target: the shape is itself an rdfs:Class.
+    /// Implicit class target: the shape is itself an rdfs:Class (or, SHACL 1.2,
+    /// an `sh:ShapeClass` — a class that is also a node shape).
     ImplicitClass(Term),
     /// sh:targetSubjectsOf — all subjects of the predicate.
     SubjectsOf(String),
     /// sh:targetObjectsOf — all objects of the predicate.
     ObjectsOf(String),
+    /// [OPUS-4.8] (sq-rnkdh) SHACL 1.2 `sh:targetWhere [ <inline shape> ]`: the
+    /// focus nodes are every data-graph node that CONFORMS to the inline (object)
+    /// shape. The `usize` is the inline shape's id in [`ShapesModel::shapes`].
+    Where(usize),
+    /// [OPUS-4.8] (sq-rnkdh) SHACL 1.2 SPARQL-valued target
+    /// `sh:targetNode [ sh:select … ]` / `[ sh:sparqlExpr … ]`: the focus nodes are
+    /// the output nodes of the SPARQL node expression (the bindings of its first
+    /// result variable). The index is into the model's `select_exprs` table.
+    Sparql(usize),
 }
 
 /// One occurrence of a constraint component on a shape.
@@ -293,6 +303,12 @@ pub(crate) struct SparqlConstraint {
     /// The constraint's own `sh:message` template, if any (takes precedence over
     /// a `?message` binding and over the shape's `sh:message`).
     pub message: Option<String>,
+    /// [OPUS-4.8] (sq-rnkdh) The constraint node's own `sh:severity` IRI, if any.
+    /// SHACL 1.2 lets a `sh:SPARQLConstraint` declare a `sh:severity` that
+    /// OVERRIDES the enclosing shape's severity for the results it produces
+    /// (`sparql/node/sparql-001`: a `sh:Warning` constraint on an otherwise
+    /// default-`Violation` shape). `None` ⇒ inherit the shape's severity.
+    pub severity: Option<String>,
     /// `sh:deactivated true` on the constraint node.
     pub deactivated: bool,
     /// The parsed query; `None` if `select` did not parse as a SELECT — the
@@ -315,6 +331,12 @@ pub struct Shape {
     pub deactivated: bool,
     /// Child property shapes (sh:property) — also feeds sh:closed.
     pub property_children: Vec<usize>,
+    /// [OPUS-4.8] (sq-rnkdh) SHACL 1.2 `sh:values [ sh:select … ]` /
+    /// `[ sh:sparqlExpr … ]`: when present, the value nodes of this (property)
+    /// shape are COMPUTED by the SPARQL node expression (index into
+    /// [`ShapesModel::select_exprs`]) instead of derived by traversing `sh:path`.
+    /// The reported `sh:resultPath` is still the shape's `sh:path`.
+    pub(crate) value_expr: Option<usize>,
 }
 
 /// All shapes parsed from a shapes graph, indexed densely (cycle-safe).
@@ -325,6 +347,12 @@ pub struct ShapesModel {
     pub targeted: Vec<usize>,
     /// SPARQL-based constraints (`sh:sparql`), referenced by [`Component::Sparql`].
     pub(crate) sparql: Vec<SparqlConstraint>,
+    /// [OPUS-4.8] (sq-rnkdh) SHACL 1.2 SPARQL-based node expressions
+    /// (`sh:select` / `sh:sparqlExpr`) used by SPARQL-valued targets
+    /// ([`Target::Sparql`]) and SPARQL-valued value nodes
+    /// ([`Shape::value_expr`]). Off the public surface (the prepared type is
+    /// crate-private), like `sparql` / `path_validators`.
+    pub(crate) select_exprs: Vec<crate::sparql::PreparedSelectExpr>,
     /// [OPUS-4.8] SPARQL-based constraint COMPONENTS (`sh:ConstraintComponent`,
     /// SHACL §6) declared in the shapes graph, referenced by
     /// [`Component::CustomSparql`]. The registry is keyed (for activation) on the
@@ -359,6 +387,7 @@ impl ShapesModel {
             by_node: FxHashMap::default(),
             targeted: Vec::new(),
             sparql: Vec::new(),
+            select_exprs: Vec::new(),
             components: Vec::new(),
             path_validators: Vec::new(),
             by_types_closures: FxHashMap::default(),
@@ -371,8 +400,12 @@ impl ShapesModel {
         m.components = discover_components(&g);
 
         // Top-level shape discovery: explicitly typed shapes plus anything with a target.
+        // [OPUS-4.8] (sq-rnkdh) `sh:ShapeClass` (SHACL 1.2) is "a class that is also a
+        // node shape" — discovered as a root here so its constraints are parsed and
+        // its implicit class target registered (it carries neither `sh:NodeShape` nor
+        // an explicit `sh:target*`).
         let mut roots: Vec<Term> = Vec::new();
-        for class in ["NodeShape", "PropertyShape"] {
+        for class in ["NodeShape", "PropertyShape", "ShapeClass"] {
             for t in g.triples(None, Some(RDF_TYPE), Some(&iri(&sh(class)))) {
                 roots.push(t[0].clone());
             }
@@ -581,6 +614,7 @@ impl ShapesModel {
             messages: Vec::new(),
             deactivated: false,
             property_children: Vec::new(),
+            value_expr: None,
         });
         let parsed = self.parse_shape(g, node);
         self.shapes[id] = parsed;
@@ -605,11 +639,18 @@ impl ShapesModel {
                 Some(Term::Literal(l)) if l.value() == "true"
             ),
             property_children: Vec::new(),
+            value_expr: None,
         };
 
         // Targets.
         for t in g.objects(node, &sh("targetNode")) {
-            shape.targets.push(Target::Node(t));
+            // [OPUS-4.8] (sq-rnkdh) SHACL 1.2: a `sh:targetNode` object that is a
+            // SPARQL-based node expression (`[ sh:select … ]` / `[ sh:sparqlExpr … ]`)
+            // COMPUTES the target nodes; any other object is a literal target node.
+            match self.intern_select_expr(g, &t) {
+                Some(idx) => shape.targets.push(Target::Sparql(idx)),
+                None => shape.targets.push(Target::Node(t)),
+            }
         }
         for t in g.objects(node, &sh("targetClass")) {
             shape.targets.push(Target::Class(t));
@@ -628,9 +669,33 @@ impl ShapesModel {
                     .push(Target::ObjectsOf(n.as_str().to_string()));
             }
         }
-        // Implicit class target: the shape node is itself an rdfs:Class.
-        if matches!(node, Term::NamedNode(_)) && g.has_type(node, RDFS_CLASS) {
+        // [OPUS-4.8] (sq-rnkdh) SHACL 1.2 `sh:targetWhere`: the focus nodes are the
+        // data-graph nodes that CONFORM to the inline (object) shape. Parse the
+        // object as a shape on demand (it may be an inline anonymous shape with no
+        // `rdf:type`/target, so it is not a top-level root) and record its id.
+        for t in g.objects(node, &sh("targetWhere")) {
+            let inner = self.shape_id(g, &t);
+            shape.targets.push(Target::Where(inner));
+        }
+        // Implicit class target: the shape node is itself an rdfs:Class, OR (SHACL
+        // 1.2) an `sh:ShapeClass` — "a class that is also a node shape", usable as
+        // `rdf:type` in place of the `rdfs:Class` + `sh:NodeShape` combination.
+        if matches!(node, Term::NamedNode(_))
+            && (g.has_type(node, RDFS_CLASS) || g.has_type(node, &sh("ShapeClass")))
+        {
             shape.targets.push(Target::ImplicitClass(node.clone()));
+        }
+
+        // [OPUS-4.8] (sq-rnkdh) SHACL 1.2 `sh:values [ sh:select … ]` /
+        // `[ sh:sparqlExpr … ]` on a property shape: the value nodes are COMPUTED by
+        // the SPARQL node expression (`$this` = focus node) instead of derived by
+        // traversing `sh:path`. The reported `sh:resultPath` stays the shape's path.
+        // Only the SPARQL-valued `sh:values` form is handled here; the SHACL-AF
+        // node-expression value RULE form (`apply_rules`) is a separate surface.
+        if let Some(v) = g.object(node, &sh("values")) {
+            if let Some(idx) = self.intern_select_expr(g, &v) {
+                shape.value_expr = Some(idx);
+            }
         }
 
         let c = &mut shape.components;
@@ -947,6 +1012,36 @@ impl ShapesModel {
         shape
     }
 
+    /// [OPUS-4.8] (sq-rnkdh) Interns a SHACL 1.2 **SPARQL-based node expression**
+    /// (`[ sh:select "…" ]` or `[ sh:sparqlExpr "…" ]`, with optional
+    /// `sh:prefixes`) into [`Self::select_exprs`], returning its index. `None` when
+    /// `node` carries neither (so the caller falls back to the literal/term reading
+    /// — e.g. a plain `sh:targetNode` IRI), or when the derived query is ill-formed
+    /// (dropped leniently, like an ill-formed `sh:sparql`). `sh:select` takes
+    /// precedence over `sh:sparqlExpr` when both are present.
+    fn intern_select_expr(&mut self, g: &GraphView, node: &Term) -> Option<usize> {
+        // Only blank-node / IRI node-expression resources carry these predicates; a
+        // literal `sh:targetNode` is a target node, never an expression.
+        if matches!(node, Term::Literal(_)) {
+            return None;
+        }
+        let prefixes = collect_prefixes_from(g, &g.objects(node, &sh("prefixes")));
+        let prepared = match g.object(node, &sh("select")) {
+            Some(Term::Literal(l)) => {
+                crate::sparql::PreparedSelectExpr::build_select(&prefixes, l.value())
+            }
+            _ => match g.object(node, &sh("sparqlExpr")) {
+                Some(Term::Literal(l)) => {
+                    crate::sparql::PreparedSelectExpr::build_expr(&prefixes, l.value())
+                }
+                _ => return None, // not a SPARQL node expression — caller's fallback
+            },
+        }?;
+        let idx = self.select_exprs.len();
+        self.select_exprs.push(prepared);
+        Some(idx)
+    }
+
     /// Parses one `sh:sparql` constraint node into a [`SparqlConstraint`],
     /// interning it into [`Self::sparql`] and returning its index. `None` when the
     /// node has no `sh:select` literal (an ill-formed constraint — skipped).
@@ -977,10 +1072,17 @@ impl ShapesModel {
             g.object(node, &sh("deactivated")),
             Some(Term::Literal(l)) if l.value() == "true"
         );
+        // [OPUS-4.8] (sq-rnkdh) A constraint-level `sh:severity` IRI overrides the
+        // shape's default severity for this constraint's results (SHACL 1.2).
+        let severity = match g.object(node, &sh("severity")) {
+            Some(Term::NamedNode(n)) => Some(n.as_str().to_string()),
+            _ => None,
+        };
         let mut constraint = SparqlConstraint {
             select,
             prefixes,
             message,
+            severity,
             deactivated,
             prepared: None,
         };

--- a/crates/sparq-shacl/src/rules.rs
+++ b/crates/sparq-shacl/src/rules.rs
@@ -721,6 +721,24 @@ fn focus_nodes(view: &GraphView, model: &ShapesModel, sid: usize) -> Vec<Term> {
             Target::Class(c) | Target::ImplicitClass(c) => out.extend(view.instances_of(c)),
             Target::SubjectsOf(p) => out.extend(view.subjects_of(p)),
             Target::ObjectsOf(p) => out.extend(view.objects_of(p)),
+            // [OPUS-4.8] (sq-rnkdh) SHACL 1.2 SPARQL-valued `sh:targetNode`: the
+            // node expression SELECTs the focus nodes (no `$this` to bind).
+            Target::Sparql(idx) => out.extend(model.select_exprs[*idx].eval_target(view.graph())),
+            // [OPUS-4.8] (sq-rnkdh) SHACL 1.2 `sh:targetWhere`: every data-graph node
+            // conforming to the inline shape. Conformance is checked through the
+            // full validator (`conforms_node`), mirroring `sh:condition` gating.
+            Target::Where(inner) => {
+                let mut seen: FxHashSet<Term> = FxHashSet::default();
+                for [s, _, o] in view.triples(None, None, None) {
+                    for n in [s, o] {
+                        if seen.insert(n.clone())
+                            && crate::eval::conforms_node(view.graph(), model, *inner, &n)
+                        {
+                            out.push(n);
+                        }
+                    }
+                }
+            }
         }
     }
     crate::view::dedup(out)

--- a/crates/sparq-shacl/src/sparql.rs
+++ b/crates/sparq-shacl/src/sparql.rs
@@ -141,6 +141,90 @@ pub(crate) struct ResultFields {
     pub default_message: String,
 }
 
+/// [OPUS-4.8] (sq-rnkdh) A parsed SHACL 1.2 **SPARQL-based node expression**
+/// (`sh:select` / `sh:sparqlExpr`, SHACL 1.2 §"SPARQL-based Node Expressions"):
+/// a SELECT query that, run with `$this` pre-bound to a focus node, yields the
+/// output nodes as the bindings of its FIRST result variable. Used by the
+/// SHACL-1.2 SPARQL-valued **targets** (`sh:targetNode [ sh:select … ]`) and the
+/// SPARQL-valued **value nodes** of a property shape (`sh:values [ sh:select … ]`
+/// / `[ sh:sparqlExpr … ]`). Built once at shapes-model parse so a malformed
+/// query is rejected up front (`None`), not per focus node.
+///
+/// This deliberately reuses the always-on `sh:sparql` pre-binding machinery
+/// ([`pre_bind_select`] / `sparq_engine::query_prepared`), so it works in BOTH
+/// the default and `shacl-af` feature states (it is SHACL-1.2 core/SPARQL, not a
+/// SHACL-AF rule).
+#[derive(Debug, Clone)]
+pub(crate) struct PreparedSelectExpr {
+    /// The parsed SELECT algebra (prefixes already resolved at build time).
+    query: Query,
+}
+
+impl PreparedSelectExpr {
+    /// Builds from a `sh:select` SELECT query (with its `sh:prefixes` prepended).
+    /// `None` for a non-SELECT / unparsable query (ill-formed → the expression is
+    /// dropped leniently, so its target/value set is empty rather than misfiring).
+    pub(crate) fn build_select(prefixes: &str, select: &str) -> Option<PreparedSelectExpr> {
+        let text = format!("{}\n{}", prefixes, select);
+        let query = SparqlParser::new().parse_query(&text).ok()?;
+        if !matches!(query, Query::Select { .. }) {
+            return None;
+        }
+        Some(PreparedSelectExpr { query })
+    }
+
+    /// Builds from a `sh:sparqlExpr` SPARQL EXPRESSION string. The SHACL-1.2
+    /// derivation wraps the expression in a single-solution projection
+    /// `SELECT ((EXPR) AS ?result) WHERE {}`; running it with `$this` pre-bound
+    /// evaluates the expression for the focus node and yields its value as the
+    /// (single) output node. `None` if the derived query does not parse.
+    pub(crate) fn build_expr(prefixes: &str, expr: &str) -> Option<PreparedSelectExpr> {
+        let select = format!("SELECT (({}) AS ?result) WHERE {{ }}", expr);
+        Self::build_select(prefixes, &select)
+    }
+
+    /// Evaluates the expression for `focus` against `data`, returning the output
+    /// nodes (the bindings of the FIRST result variable, in solution order,
+    /// duplicates preserved — the caller dedups/uses them as value nodes). An
+    /// unbound first-variable solution contributes no node. A focus node not
+    /// expressible as a VALUES ground term (a blank node) or a runtime query error
+    /// yields an empty set (lenient; never panics `validate`).
+    pub(crate) fn eval(&self, data: &sparq_core::Graph, focus: &Term) -> Vec<Term> {
+        let Some(bound) = pre_bind_select(&self.query, &[("this", focus)]) else {
+            return Vec::new();
+        };
+        Self::run(data, bound)
+    }
+
+    /// [OPUS-4.8] (sq-rnkdh) Evaluates the expression as a **target** query — with
+    /// no `$this` pre-binding (a target SELECT computes the focus nodes itself) —
+    /// returning the bindings of the FIRST result variable as the focus-node set.
+    pub(crate) fn eval_target(&self, data: &sparq_core::Graph) -> Vec<Term> {
+        Self::run(data, self.query.clone())
+    }
+
+    /// Runs a (possibly pre-bound) SELECT and collects the FIRST-result-variable
+    /// bindings, skipping unbound rows. A runtime query error yields no nodes
+    /// (lenient; never panics `validate`).
+    fn run(data: &sparq_core::Graph, query: Query) -> Vec<Term> {
+        let prepared = sparq_engine::PreparedQuery::from(query);
+        let Ok(result) = sparq_engine::query_prepared(data, &prepared) else {
+            return Vec::new();
+        };
+        // The output nodes are the bindings of the FIRST result variable. For an
+        // `eval` (pre-bound) query the injection appends `?this` to the projection
+        // only if it was absent, so the author's first projected variable stays at
+        // position 0.
+        let mut out = Vec::new();
+        for row in &result.rows {
+            if let Some(Some(t)) = row.first() {
+                out.push(t.clone());
+            }
+        }
+        out
+    }
+}
+
 /// Builds the single-row `VALUES (?n1 ?n2 …) { (v1 v2 …) }` table that pre-binds
 /// each `(name, term)` in `bindings`. Returns `None` if any value is not
 /// expressible as a SPARQL ground term (e.g. a blank node — see `term_to_ground`).
@@ -982,6 +1066,7 @@ mod tests {
             select: "ASK { ?s ?p ?o }".to_string(),
             prefixes: String::new(),
             message: None,
+            severity: None,
             deactivated: false,
             prepared: None,
         };
@@ -991,6 +1076,7 @@ mod tests {
             select: "SELECT ??? garbage".to_string(),
             prefixes: String::new(),
             message: None,
+            severity: None,
             deactivated: false,
             prepared: None,
         };
@@ -1000,6 +1086,7 @@ mod tests {
             select: "SELECT ?this WHERE { ?this ?p ?o }".to_string(),
             prefixes: String::new(),
             message: None,
+            severity: None,
             deactivated: false,
             prepared: None,
         };
@@ -1161,6 +1248,7 @@ mod tests {
                 .to_string(),
             prefixes: String::new(),
             message: None,
+            severity: None,
             deactivated: false,
             prepared: None,
         };
@@ -1196,6 +1284,7 @@ mod tests {
                 .to_string(),
             prefixes: String::new(),
             message: Some("offender {?value} via {?path}".to_string()),
+            severity: None,
             deactivated: false,
             prepared: None,
         };
@@ -1251,6 +1340,7 @@ mod tests {
                 .to_string(),
             prefixes: String::new(),
             message: None, // no constraint message -> fall through to ?message
+            severity: None,
             deactivated: false,
             prepared: None,
         };
@@ -1287,6 +1377,7 @@ mod tests {
             select: "SELECT ?this WHERE { ?this ?p ?o }".to_string(),
             prefixes: String::new(),
             message: None,
+            severity: None,
             deactivated: false,
             prepared: None,
         };
@@ -1380,5 +1471,72 @@ mod tests {
             out[0].path.is_none(),
             "a literal ?path is not a predicate path"
         );
+    }
+
+    // --- [OPUS-4.8] (sq-rnkdh) SHACL 1.2 SPARQL-based node expressions ---------
+
+    const EXPR_DATA: &str = r#"
+        @prefix ex: <http://example.org/> .
+        ex:alice ex:age 30 ; ex:firstName "Al" ; ex:lastName "Ice" .
+        ex:bob   ex:age 15 .
+    "#;
+
+    fn iri(s: &str) -> Term {
+        Term::NamedNode(NamedNode::new(s).unwrap())
+    }
+
+    #[test]
+    fn select_expr_build_rejects_non_select() {
+        // A non-SELECT (or unparsable) sh:select is ill-formed -> None.
+        assert!(PreparedSelectExpr::build_select("", "ASK { ?s ?p ?o }").is_none());
+        assert!(PreparedSelectExpr::build_select("", "SELECT ??? nope").is_none());
+        assert!(PreparedSelectExpr::build_select("", "SELECT ?x WHERE { ?x ?p ?o }").is_some());
+    }
+
+    #[test]
+    fn select_expr_eval_pre_binds_this_and_takes_first_var() {
+        // sh:values-style: per focus, project the value via $this.
+        let data = graph(EXPR_DATA);
+        let expr = PreparedSelectExpr::build_select(
+            "PREFIX ex: <http://example.org/>",
+            "SELECT ?n WHERE { $this ex:firstName ?n }",
+        )
+        .unwrap();
+        let nodes = expr.eval(&data, &iri("http://example.org/alice"));
+        assert_eq!(
+            nodes,
+            vec![Term::Literal(oxrdf::Literal::new_simple_literal("Al"))]
+        );
+        // A focus with no firstName yields no value nodes.
+        assert!(expr.eval(&data, &iri("http://example.org/bob")).is_empty());
+    }
+
+    #[test]
+    fn select_expr_build_expr_evaluates_expression() {
+        // sh:sparqlExpr: SELECT ((EXPR) AS ?result) WHERE {} with $this bound.
+        let data = graph(EXPR_DATA);
+        let expr = PreparedSelectExpr::build_expr("", "STRLEN(STR($this))").unwrap();
+        let nodes = expr.eval(&data, &iri("http://example.org/alice"));
+        // STRLEN("http://example.org/alice") = 24.
+        assert_eq!(
+            nodes,
+            vec![Term::Literal(oxrdf::Literal::new_typed_literal(
+                "24",
+                NamedNode::new("http://www.w3.org/2001/XMLSchema#integer").unwrap(),
+            ))]
+        );
+    }
+
+    #[test]
+    fn select_expr_eval_target_runs_unbound_and_collects_first_var() {
+        // sh:targetNode [ sh:select ]: no $this, the query SELECTs the focus nodes.
+        let data = graph(EXPR_DATA);
+        let expr = PreparedSelectExpr::build_select(
+            "PREFIX ex: <http://example.org/>",
+            "SELECT ?p WHERE { ?p ex:age ?a . FILTER (?a < 18) }",
+        )
+        .unwrap();
+        let nodes = expr.eval_target(&data);
+        assert_eq!(nodes, vec![iri("http://example.org/bob")]);
     }
 }

--- a/crates/sparq-shacl/tests/w3c_core_full_shacl12.rs
+++ b/crates/sparq-shacl/tests/w3c_core_full_shacl12.rs
@@ -104,22 +104,33 @@ fn unimplemented() -> Vec<String> {
 /// `research/shacl12-conformance-gap.md` for the per-category gap map. With
 /// `shacl-af` off the `nodeByExpression-001` node entry is a SKIP, so the floor
 /// is one below the `shacl-af`-on floor.
-const BASELINE_PASS_CORE: usize = 114;
+///
+/// [OPUS-4.8] (sq-rnkdh) Raised 114 → 129: locks in the SHACL-1.2 core value
+/// constraints (sq-sx15d / #1267) and the 1.2 TARGET features added here —
+/// `sh:targetWhere`, the `sh:shape` data-graph link, and the `sh:ShapeClass`
+/// implicit class target (`targets/` now 10/10).
+const BASELINE_PASS_CORE: usize = 129;
 
 /// Pass-floor over the FULL core tree with `shacl-af` ON: the `shacl-af`
 /// `sh:nodeByExpression` core/node entry becomes implemented and PASSes, so the
-/// floor rises by one.
-const BASELINE_PASS_AF: usize = 115;
+/// floor rises by one. [OPUS-4.8] (sq-rnkdh) Raised 115 → 130 in lock-step with
+/// [`BASELINE_PASS_CORE`].
+const BASELINE_PASS_AF: usize = 130;
 
 /// Fail-ceiling over the FULL core tree — the count of entries whose SHACL-1.2
 /// behaviour this crate does not yet implement (the gap map). A *new* mismatch (a
 /// previously-correct entry breaking) pushes the fail count above this and fails
 /// the build; closing a gap drops it (bump down). The same in both feature
 /// states: the `shacl-af`-gated entries flip SKIP↔PASS, never to/from FAIL.
-const BASELINE_FAIL_CORE: usize = 22;
+///
+/// [OPUS-4.8] (sq-rnkdh) Lowered 22 → 7: sq-sx15d (#1267) closed the value-constraint
+/// gaps and this change closes the `targets/` gaps. The remaining 7 are the live gap
+/// map (reifierShape ×2, deactivated-003, message-002, severity-003, uniqueLang-003,
+/// conformance-disallows-001) — see `research/shacl12-conformance-gap.md`.
+const BASELINE_FAIL_CORE: usize = 7;
 
 /// Fail-ceiling with `shacl-af` ON — identical to [`BASELINE_FAIL_CORE`].
-const BASELINE_FAIL_AF: usize = 22;
+const BASELINE_FAIL_AF: usize = 7;
 
 fn baseline_pass() -> usize {
     if cfg!(feature = "shacl-af") {

--- a/crates/sparq-shacl/tests/w3c_sparql_shacl12.rs
+++ b/crates/sparq-shacl/tests/w3c_sparql_shacl12.rs
@@ -59,14 +59,25 @@ const SH: &str = "http://www.w3.org/ns/shacl#";
 /// regression below this fails the build; raising it is a deliberate bump.
 ///
 /// [OPUS-4.8] (sq-6glcr) Calibrated by running the harness in-worktree.
-const BASELINE_PASS: usize = 10;
+///
+/// [OPUS-4.8] (sq-rnkdh) Raised 10 → 14: the SHACL-1.2 SPARQL-based node
+/// expressions added here — the SPARQL-valued target `sh:targetNode [ sh:select ]`
+/// (`targets/targetNode-select-001`), the SPARQL-valued value nodes
+/// `sh:values [ sh:select / sh:sparqlExpr ]` (`property/property-select-001`,
+/// `property/property-sparqlExpr-001`), and constraint-level `sh:severity`
+/// (`node/sparql-001`) — now PASS.
+const BASELINE_PASS: usize = 14;
 
 /// Gap-ceiling: the count of entries this crate does NOT yet get right — the sum
 /// of strict-comparison FAILs and the `sht:Failure` ExpectedFailure entries (the
 /// rejection channel is unbuilt). A *new* gap (a previously-correct entry
 /// breaking) pushes this above the ceiling and fails the build; closing a gap
 /// drops it (bump down).
-const BASELINE_GAP: usize = 14;
+///
+/// [OPUS-4.8] (sq-rnkdh) Lowered 14 → 10: the 4 entries above moved FAIL → PASS.
+/// The remaining 10 are 3 `pre-binding/` FAILs + the 7 `sht:Failure`
+/// ExpectedFailure entries (the rejection channel is still unbuilt).
+const BASELINE_GAP: usize = 10;
 
 /// Of [`BASELINE_GAP`], the count attributable to the unbuilt rejection channel
 /// (`mf:result sht:Failure`). Asserted exactly so the scoreboard documents the

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -249,6 +249,21 @@ the focus/path when none do). `sh:singleLine true` flags string values containin
 line break (LF/CR/FF/VT). `sh:rootClass C` requires each value node to be `C` or a
 transitive `rdfs:subClassOf`-descendant of it.
 
+**SHACL-1.2 targets & SPARQL node expressions (always on, no feature flag, sq-rnkdh).**
+Beyond `sh:targetNode`/`Class`/`SubjectsOf`/`ObjectsOf` + implicit class targets:
+- **`sh:targetWhere [ <inline shape> ]`** — focus nodes are every data-graph node that
+  CONFORMS to the inline (object) shape (conformance is checked through the validator).
+- **`sh:shape`** — a DATA-graph triple `?n sh:shape ?S` makes `?n` a focus node of
+  shape `?S` (the data-driven dual of `sh:targetNode`).
+- **`sh:ShapeClass`** — a class that is ALSO a node shape; its instances (via the
+  subclass closure) are implicit-class-targeted, no `rdfs:Class`+`sh:NodeShape` pair.
+- **SPARQL-valued targets / value nodes** — `sh:targetNode [ sh:select "…" ]` computes
+  focus nodes from the first result variable; on a property shape `sh:values [ sh:select
+  "…" ]` / `[ sh:sparqlExpr "EXPR" ]` COMPUTES the value nodes (with `$this` = focus
+  node) instead of traversing `sh:path` (the reported `sh:resultPath` is still the path).
+- A constraint-level **`sh:severity`** on a `sh:SPARQLConstraint` overrides the shape's
+  default severity for the results it produces.
+
 **Custom SPARQL-based constraint component (`sh:ConstraintComponent`, §6).** Declare
 the component (parameters + an `sh:ask`/`sh:select` validator) IN THE SHAPES GRAPH; it
 activates on any shape that uses all its mandatory parameter predicates. Each parameter


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-rnkdh** (epic sq-waf9o): SHACL 1.2 TARGETS + SPARQL constraint extras in `crates/sparq-shacl`.

## What this implements

All on the **always-on** SHACL Core / SHACL-SPARQL path — **no feature flag**, green in BOTH default (feature OFF) and `shacl-af` ON. These are SHACL-1.2 core/sparql suite features (not SHACL-AF rules), so they reuse the always-compiled `sh:sparql` `$this` pre-binding rather than the `shacl-af`-gated node-expression algebra.

- **`sh:targetWhere [ <inline shape> ]`** (`Target::Where`) — focus nodes are every data-graph node that CONFORMS to the inline (object) shape (conformance via the validator's own memoised `conforms`).
- **`sh:shape`** — a DATA-graph triple `?n sh:shape ?S` makes `?n` a focus node of shape `?S` (the data-driven dual of `sh:targetNode`; discovered per data graph in `validate_graph`, not as a per-shape `Target`).
- **`sh:ShapeClass`** — "a class that is also a node shape" (1.2): discovered as a shape root and given an implicit class target, exactly like `rdfs:Class`.
- **SPARQL-valued targets & value nodes** (`PreparedSelectExpr`) — `sh:targetNode [ sh:select … ]` (`Target::Sparql`) computes focus nodes from the first result variable; on a property shape `sh:values [ sh:select … ]` / `[ sh:sparqlExpr "EXPR" ]` COMPUTES the value nodes (`$this` = focus) instead of traversing `sh:path` (the reported `sh:resultPath` stays the shape path). `sh:sparqlExpr` is derived as `SELECT ((EXPR) AS ?result) WHERE {}`.
- **Constraint-level `sh:severity`** on a `sh:SPARQLConstraint` overrides the shape's default severity for its results.

## Tests made to pass via the REAL `validate()`

Vendored `shacl12-test-suite` entries (pinned suite `b6e73695`):

- core: `targets/targetWhere-001`, `targets/shape-001`, `targets/targetClassImplicit-002`
- sparql: `targets/targetNode-select-001`, `node/sparql-001`, `property/property-select-001`, `property/property-sparqlExpr-001`

## 1.2-draft semantics

`sh:targetWhere` / `sh:shape` / `sh:ShapeClass` are SHACL-1.2-draft terms. Each was implemented to the **vendored draft vocabulary** (`shacl12-vocabularies/shacl.ttl`) read against each test's expected report — no divergence was needed:
- `sh:targetWhere` rdfs:comment: *"all nodes from the data graph that conform to the given (object) shape must conform to the (subject) shape"* → conforming-nodes target. ✓ matches `targetWhere-001`.
- `sh:shape` rdfs:comment: *"Links from a node in the data graph to a shape that it is expected to conform to."* → data-graph focus link. ✓ matches `shape-001`.
- `sh:ShapeClass` rdfs:comment: *"a class that is also a node shape … instead of the combination of rdfs:Class and sh:NodeShape."* → implicit class target + node shape. ✓ matches `targetClassImplicit-002`.

## Ratchet floors re-measured to ACTUAL achieved counts

(this also locks in the already-merged sq-sx15d / #1267 value-constraint gains)

- `w3c_core_full_shacl12.rs`: `BASELINE_PASS_CORE` 114→**129**, `BASELINE_PASS_AF` 115→**130**; `BASELINE_FAIL_CORE`/`_AF` 22→**7** (the `targets/` category is now **10/10** in both states; the remaining 7 fails are the honest gap map — reifierShape ×2, deactivated-003, message-002, severity-003, uniqueLang-003, conformance-disallows-001).
- `w3c_sparql_shacl12.rs`: `BASELINE_PASS` 10→**14**, `BASELINE_GAP` 14→**10** (`EXPECTED_FAILURE_COUNT` stays 7 — the unbuilt rejection channel).

## Gates run (in-worktree, BOTH feature states)

- `cargo clippy --all-targets -D warnings` — default, `shacl-af`, `--all-features`: clean.
- `cargo test -p sparq-shacl` — full suite green in default, `shacl-af`, and `scs`; no regression in the older `w3c_core` / tight `w3c_core_shacl12` / value-constraints gates.
- `RUSTDOCFLAGS=-D warnings cargo doc --no-deps --all-features` — clean (demoted a public→`pub(crate)` doc-link to a code span).
- `cargo +1.88 check` (CI MSRV invocation) — clean.
- `scripts/check-readme-template.py --enforce` — 0 deviations, README at the 120-line cap.
- Direct unit tests added per new public fn (coverage ratchet): `PreparedSelectExpr::build_select`/`build_expr`/`eval`/`eval_target` + one integration test per 1.2 target via `validate()`.

## Honesty notes

- `count_focus_nodes` now delegates to the validator's focus-node enumeration so the data-dependent 1.2 targets are counted correctly (a pure shapes-graph scan can't express them).
- Pre-existing (NOT introduced here): the `tests/gen.rs` test helper fails to compile on `cargo +1.88 --all-targets` (a `pick<T>` generic), but the **CI MSRV gate runs `cargo check --workspace`** (no test targets), which is green; verified the same failure exists on the base branch. Captured as discovered work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)