### PR TITLE
test(site): Playwright E2E smoke (home/try/capabilities) + SHACL __wbg_ptr re-run regression guard (sq-jp7ry)

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -144,15 +144,24 @@ npx playwright install chromium
 npm run test:e2e
 ```
 
-The current coverage is the **ZK car-hire prover pre-warm** (`e2e/zk-prewarm.spec.ts`,
-bead sq-5q63): it loads `/showcase/zk-car-hire`, waits for the *Prover ready* pill, and
-asserts the first **Generate ZK proof** click pays no cold start — i.e. it does not
-re-pay the lazy `@noir-lang/noir_js` + `@aztec/bb.js` dynamic-import or the
-`Barretenberg.new` WASM instantiate that `prewarmProver()` already did on route mount.
-That is observed via a test-only cold-start counter the prover mirrors onto
-`window.__zkProverColdStarts` (pure observability; it changes nothing the prover proves).
-CI runs this lane on site-touching PRs (`.github/workflows/site-e2e.yml`); Playwright
-outputs (`test-results/`, `playwright-report/`, the browser cache) are git-ignored.
+Coverage spans the critical site flows. **Critical-flow smoke** (bead sq-jp7ry, issue #835):
+`home-smoke.spec.ts` asserts the home hero + primary nav boot with zero console errors;
+`try-query-smoke.spec.ts` runs the trivial `SELECT * WHERE { ?s ?p ?o }` on the bundled
+sample in the `/try` REPL and asserts a non-empty results table; `capabilities-smoke.spec.ts`
+asserts the `/capabilities` showcase renders its hero, flagship band and all five theme
+sections. **Regression guards:** `shacl-rerun-regression.spec.ts` (sq-jp7ry) drives the
+`/surface/shacl` validator three times in one session and asserts no wasm object-lifecycle
+fault (`__wbg_ptr` / "null pointer passed to rust" / "recursive use of an object") and a
+fresh report each run — guarding the issue-#835 SHACL `__wbg_ptr` class; `repl-results.spec.ts`
+and `shacl-validator.spec.ts` cover the REPL result panel and single-validate report. The
+**ZK car-hire prover pre-warm** (`zk-prewarm.spec.ts`, sq-5q63) loads `/showcase/zk-car-hire`,
+waits for the *Prover ready* pill, and asserts the first **Generate ZK proof** click pays no
+cold start (observed via a test-only `window.__zkProverColdStarts` counter — pure observability).
+The wasm-engine specs (`try-query`, `shacl-*`, `repl-results`) `test.skip` when the wasm bundle
+is absent, so the **light** CI lane (no Rust toolchain) stays green; they run in full once
+`npm run sync-wasm` has synced a `build:wasm` bundle. CI runs this lane on site-touching PRs
+(`.github/workflows/site-e2e.yml`); Playwright outputs (`test-results/`, `playwright-report/`,
+the browser cache) are git-ignored.
 
 ## Papers (the academic paper factory)
 

--- a/site/e2e/capabilities-smoke.spec.ts
+++ b/site/e2e/capabilities-smoke.spec.ts
@@ -1,0 +1,85 @@
+// [OPUS-4.8] sq-jp7ry (issue #835) — CRITICAL-FLOW smoke test for the /capabilities SHOWCASE.
+//
+// WHAT IT GUARDS. /capabilities (src/app/capabilities/page.tsx) is the consolidated, bold
+// showcase of the full feature set — a hero, a flagship "start here" band, and five capability
+// THEME lanes (Query & data / Reason & validate / Search & GenAI / Privacy (ZK / MPC) / Serve &
+// embed), all derived from the single data/surfaces.ts source. This spec asserts the page renders
+// ALL of those structural sections on a DIRECT load AND produces ZERO console errors. It is the
+// SECTIONS-RENDER smoke (complementing capabilities-lazy.spec.ts, which guards the lazy-mount /
+// code-split invariant, and site-nav.spec.ts, which reaches the themes via a nav click): here we
+// confirm the showcase itself boots clean with every theme present — the regression net issue
+// #835 asks for ("unexpected bugs get introduced").
+//
+// NO WASM NEEDED. The hero + flagship band + theme-lane HEADINGS are server-rendered shell that
+// paint without the wasm engine (a demo's heavy body mounts only on expand — that is the
+// lazy-mount spec's concern), so this spec runs on EVERY lane, including the light site-e2e CI
+// lane that builds no wasm bundle.
+//
+// It is a CORRECTNESS smoke test, not a benchmark: it asserts the DOM + console, never a
+// wall-clock threshold (timings on a work-box / CI runner are non-canonical).
+import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
+
+// Relative (no leading slash) so it resolves UNDER the baseURL's `/sparq/` basePath.
+const ROUTE = "capabilities/";
+
+// The five capability themes (data/surfaces.ts GROUPS labels). Kept here as the expected set so
+// a dropped/renamed lane fails this smoke loudly.
+const THEMES = [
+  "Query & data",
+  "Reason & validate",
+  "Search & GenAI",
+  "Privacy (ZK / MPC)",
+  "Serve & embed",
+];
+
+/** Collect every `console.error` the page emits, so the test can assert there were none. */
+function trackConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(String(err)));
+  return errors;
+}
+
+async function gotoSettled(page: Page, route: string): Promise<void> {
+  await page.goto(route, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle").catch(() => {});
+  await page
+    .waitForFunction(() => navigator.serviceWorker?.controller != null, undefined, {
+      timeout: 10_000,
+    })
+    .catch(() => {});
+}
+
+test("the showcase renders its hero, flagship band and all five theme sections with no console errors", async ({
+  page,
+}) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoSettled(page, ROUTE);
+
+  // The hero <h1> (server-rendered display headline). Matched on a stable copy substring.
+  await expect(
+    page.getByRole("heading", { name: /one Rust engine/i, level: 1 }),
+  ).toBeVisible();
+
+  // The flagship "start here" band heading (the <section aria-labelledby="flagships-heading">
+  // names its region by this <h2>). Asserting the heading proves the band rendered.
+  await expect(
+    page.getByRole("heading", { name: /the breadth is real/i, level: 2 }),
+  ).toBeVisible();
+
+  // Every one of the five capability-theme lanes renders its heading. A dropped or renamed
+  // theme fails this loudly — the showcase's load-bearing structural invariant.
+  for (const theme of THEMES) {
+    await expect(page.getByRole("heading", { name: theme })).toBeVisible();
+  }
+
+  // No demo BODY is eagerly mounted on entry (the lazy-mount invariant is fully owned by
+  // capabilities-lazy.spec.ts; asserted here only to keep this smoke honest about what "renders
+  // its sections" means — the headings, not the heavy demo bodies).
+  await expect(page.locator("[data-demo-body]")).toHaveCount(0);
+
+  // The whole render produced zero console errors (the regression net for issue #835).
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});

--- a/site/e2e/home-smoke.spec.ts
+++ b/site/e2e/home-smoke.spec.ts
@@ -21,24 +21,46 @@ import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
 // Empty relative route → resolves to the baseURL's `/sparq/` basePath (the home page).
 const ROUTE = "";
 
-/** Collect every `console.error` the page emits, so the test can assert there were none. */
+// The home page eagerly mounts the lazy in-tab REPL (`<ReplLazy>`), which pre-warms the wasm
+// engine by FETCHING `public/wasm/sparq_wasm_bg.wasm`. On the LIGHT site-e2e CI lane that bundle
+// is intentionally NOT built (no Rust toolchain), so the fetch 404s and the browser logs a bare
+// "Failed to load resource: the server responded with a status of 404 (Not Found)" console
+// error. That is the repo's documented "optional wasm — warn and skip" posture (sync-wasm.mjs),
+// NOT a product bug — the REPL surfaces a clear in-page "engine failed to load" state and the
+// SHELL we are smoke-testing (hero + nav) is unaffected. So we IGNORE that benign resource-load
+// 404 while still catching every real client-side error (a JS throw / bad import / hydration
+// fault arrives as a `pageerror` or a NON-404 `console.error`, both of which still fail the test).
+const BENIGN_RESOURCE_404 = /Failed to load resource:.*\b404\b/i;
+
+/**
+ * Collect every REAL `console.error` / `pageerror` the page emits — minus the benign
+ * optional-wasm-bundle 404 that the light CI lane produces by design — so the test can assert
+ * the shell booted clean.
+ */
 function trackConsoleErrors(page: Page): string[] {
   const errors: string[] = [];
   page.on("console", (msg: ConsoleMessage) => {
-    if (msg.type() === "error") errors.push(msg.text());
+    if (msg.type() !== "error") return;
+    const text = msg.text();
+    if (BENIGN_RESOURCE_404.test(text)) return; // optional wasm bundle absent on the light lane
+    errors.push(text);
   });
+  // A real JS throw (never a network 404) — always load-bearing, never filtered.
   page.on("pageerror", (err) => errors.push(String(err)));
   return errors;
 }
 
 // The site ships the coi-serviceworker shim which reloads the tab ONCE on a fresh visit. That
 // one-time reload tears down a pending render, so wait until the SW is CONTROLLING the page (the
-// deterministic signal the reload has already fired and won't fire again) before asserting — the
-// same settle the site-nav specs use. Wrapped in `.catch` so it still proceeds if the SW never
-// registers (e.g. an environment without service-worker support).
+// deterministic signal the reload has already fired and won't fire again) before asserting.
+//
+// We deliberately do NOT wait for `networkidle` here (unlike the lighter site-nav specs): the
+// home route eagerly mounts the in-tab REPL, whose wasm pre-warm fetch RETRIES when the bundle is
+// absent (the light CI lane), so the network never goes idle and a `networkidle` wait would hang
+// to the test timeout. The deterministic SW-controller signal plus the explicit element waits in
+// the test body are sufficient — and `.catch` keeps it working if the SW never registers.
 async function gotoSettled(page: Page, route: string): Promise<void> {
   await page.goto(route, { waitUntil: "domcontentloaded" });
-  await page.waitForLoadState("networkidle").catch(() => {});
   await page
     .waitForFunction(() => navigator.serviceWorker?.controller != null, undefined, {
       timeout: 10_000,

--- a/site/e2e/home-smoke.spec.ts
+++ b/site/e2e/home-smoke.spec.ts
@@ -1,0 +1,72 @@
+// [OPUS-4.8] sq-jp7ry (issue #835) — CRITICAL-FLOW smoke test for the HOME route.
+//
+// WHAT IT GUARDS. The landing page (src/app/page.tsx) is the site's front door: a server-
+// rendered atmospheric HERO (`src/components/home/hero.tsx`) with the gradient display headline
+// and the primary nav (the AppShell "Primary" navigation landmark). This is the #1 "did the app
+// even boot" smoke: it asserts the hero headline paints AND every primary-nav destination is
+// present, and — load-bearing for catching a quiet runtime fault — that the route produces ZERO
+// console errors. A broken client component, a bad import, or a hydration throw all surface as a
+// console error here even when the page still paints, so the zero-error assertion is the real
+// regression net (issue #835's standing ask: "unexpected bugs get introduced").
+//
+// NO WASM NEEDED. The hero + nav are server-rendered shell — they paint without the wasm engine,
+// so this spec runs on EVERY lane (including the light site-e2e CI lane that builds no wasm
+// bundle). The heavy in-tab REPL below the hero is its own (wasm-gated) concern, covered by
+// repl-results.spec.ts + try-query-smoke.spec.ts; here we only assert the shell boots clean.
+//
+// It is a CORRECTNESS smoke test, not a benchmark: it asserts the DOM + console, never a
+// wall-clock threshold (timings on a work-box / CI runner are non-canonical).
+import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
+
+// Empty relative route → resolves to the baseURL's `/sparq/` basePath (the home page).
+const ROUTE = "";
+
+/** Collect every `console.error` the page emits, so the test can assert there were none. */
+function trackConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(String(err)));
+  return errors;
+}
+
+// The site ships the coi-serviceworker shim which reloads the tab ONCE on a fresh visit. That
+// one-time reload tears down a pending render, so wait until the SW is CONTROLLING the page (the
+// deterministic signal the reload has already fired and won't fire again) before asserting — the
+// same settle the site-nav specs use. Wrapped in `.catch` so it still proceeds if the SW never
+// registers (e.g. an environment without service-worker support).
+async function gotoSettled(page: Page, route: string): Promise<void> {
+  await page.goto(route, { waitUntil: "domcontentloaded" });
+  await page.waitForLoadState("networkidle").catch(() => {});
+  await page
+    .waitForFunction(() => navigator.serviceWorker?.controller != null, undefined, {
+      timeout: 10_000,
+    })
+    .catch(() => {});
+}
+
+test("the home route renders the hero headline and the primary nav with no console errors", async ({
+  page,
+}) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoSettled(page, ROUTE);
+
+  // The hero <h1> (server-rendered, paints with the shell). Matched on a stable substring of the
+  // headline copy rather than the whole gradient-split markup.
+  await expect(
+    page.getByRole("heading", { name: /state-of-the-art RDF engine/i, level: 1 }),
+  ).toBeVisible();
+
+  // The slim top bar (the AppShell "Primary" navigation landmark) carries the six content
+  // destinations. Asserting the landmark + its core links proves the nav booted, not just copy.
+  const primary = page.getByRole("navigation", { name: "Primary" }).first();
+  await expect(primary).toBeVisible();
+  for (const label of ["Home", "Capabilities", "Try", "Benchmarks"]) {
+    await expect(primary.getByRole("link", { name: label, exact: true })).toBeVisible();
+  }
+
+  // The whole boot produced zero console errors — the regression net for a quiet client-side
+  // throw / bad import / hydration fault that still paints (issue #835's "unexpected bugs").
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});

--- a/site/e2e/shacl-rerun-regression.spec.ts
+++ b/site/e2e/shacl-rerun-regression.spec.ts
@@ -1,0 +1,136 @@
+// [OPUS-4.8] sq-jp7ry (issue #835) — REGRESSION GUARD for the SHACL-validator wasm
+// OBJECT-LIFECYCLE bug (the `__wbg_ptr` family of faults), exercised by RE-RUNNING the
+// validator twice in ONE browser session.
+//
+// THE BUG CLASS THIS GUARDS. Issue #835's reported symptom was the live SHACL validator
+// throwing `Cannot read properties of undefined (reading '__wbg_ptr')` — a wasm-bindgen
+// object-lifecycle misuse. The first incarnation (sq-800o, fixed) was a LOST RECEIVER: the
+// validate method was extracted detached and invoked bare, so `this.__wbg_ptr` was undefined.
+// The whole `__wbg_ptr` / "null pointer passed to rust" / "recursive use of an object" family
+// is what surfaces when a wasm `Store` is reused after free, double-borrowed, or invoked on a
+// detached receiver. shacl-validator.spec.ts covers a SINGLE validate per page load; the bug
+// most likely to slip back in is a SECOND-RUN one — e.g. a future change that caches/reuses the
+// ephemeral wasm `Store` across `sparqShaclValidate` calls and frees it on the first run, so the
+// SECOND `run()` invokes a dangling pointer. This spec drives the validator surface TWICE in one
+// session (validate → validate again, including a content change between runs) and asserts:
+//   (a) NO `__wbg_ptr` / "null pointer passed to rust" / "recursive use of an object" console
+//       error is ever emitted (the lifecycle-fault net — these are the exact wasm-bindgen
+//       panic/throw strings for the bug class); and
+//   (b) the SECOND run STILL renders a fresh report (the validator is not left wedged after the
+//       first run consumes/frees a shared object).
+//
+// The SHACL surface lives at /surface/shacl (the same route shacl-validator.spec.ts drives — the
+// validator UI is not a distinct "SHACL validator" route, it is the /surface/shacl playground's
+// Validate path, which calls `sparqShaclValidate` → the wasm `Store.validate` binding).
+//
+// WASM PREREQ. The validator loads the shacl-enabled wasm bundle from `public/wasm/` (a gitignored
+// build artifact synced from `js`'s `build:wasm`, which builds `--features shacl,…` so `validate`
+// exists). The light site-e2e CI lane has no Rust toolchain to build it, so this whole spec SKIPS
+// when the bundle is absent and runs in full when present. Run after `npm run sync-wasm`:
+//   npx playwright install chromium && npm run test:e2e
+import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Relative (no leading slash) so it resolves UNDER the baseURL's `/sparq/` basePath.
+const ROUTE = "surface/shacl/";
+
+// The shacl-enabled wasm bundle the validator loads at runtime. Synced into public/wasm/ by
+// `sync-wasm` from the `js` build; gitignored, so its presence gates this spec.
+const WASM_BUNDLE = fileURLToPath(
+  new URL("../public/wasm/sparq_wasm_bg.wasm", import.meta.url),
+);
+
+// Skip the whole file when the wasm bundle has not been built/synced — the light CI lane does
+// not produce it, and a validator that cannot load the engine is not the thing under test.
+test.skip(
+  !existsSync(WASM_BUNDLE),
+  "wasm bundle absent (public/wasm/sparq_wasm_bg.wasm) — run `npm run sync-wasm` after `(cd ../js && npm run build:wasm)`",
+);
+
+// The exact wasm object-lifecycle fault strings the regression must never re-introduce. Matched
+// case-insensitively as substrings against every console error + pageerror the session emits.
+const LIFECYCLE_FAULTS = [
+  "__wbg_ptr",
+  "null pointer passed to rust",
+  "recursive use of an object",
+];
+
+/** Collect every `console.error` (and pageerror) the page emits across the whole session. */
+function trackConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(String(err)));
+  return errors;
+}
+
+/** Assert none of the collected errors is a wasm object-lifecycle fault. */
+function assertNoLifecycleFault(errors: string[]): void {
+  const hits = errors.filter((e) => {
+    const lower = e.toLowerCase();
+    return LIFECYCLE_FAULTS.some((f) => lower.includes(f));
+  });
+  expect(
+    hits,
+    `wasm object-lifecycle fault(s) detected (the __wbg_ptr regression class):\n${hits.join("\n")}`,
+  ).toEqual([]);
+}
+
+/** Navigate to /surface/shacl and wait for the wasm engine readiness pill to settle. */
+async function gotoReady(page: Page): Promise<void> {
+  await page.goto(ROUTE, { waitUntil: "domcontentloaded" });
+  await expect(page.getByText("Engine ready")).toBeVisible({ timeout: 90_000 });
+}
+
+test("re-running the validator twice in one session never throws a __wbg_ptr lifecycle fault and still reports", async ({
+  page,
+}) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoReady(page);
+
+  const report = page.locator('[data-testid="shacl-report"]');
+  const validate = page.getByRole("button", { name: "Validate" });
+
+  // ── FIRST RUN — the default example (`ex:age "thirty"` datatype violation). ───────────────
+  await validate.click();
+  await expect(report).toBeVisible({ timeout: 30_000 });
+  await expect(report.locator("[data-conforms]")).toHaveAttribute("data-conforms", "false");
+  // No lifecycle fault after the first run (this also re-covers the original sq-800o lost-receiver).
+  assertNoLifecycleFault(consoleErrors);
+
+  // ── SECOND RUN, SAME SESSION — switch to the CONFORMING example, then validate AGAIN. ─────
+  // Changing the data between runs forces a genuinely fresh validate on the SAME live page (a
+  // shared/freed wasm Store reused from the first run would now fault), and gives the second
+  // report a DIFFERENT, deterministic outcome (conforms = true) so we know it is a fresh render
+  // and not a stale first-run panel left on screen.
+  await page.getByRole("button", { name: "Conforming data" }).click();
+  // Selecting an example resets the report to idle (component `selectExample`), so the prior
+  // panel detaches before the second run — the re-run starts from a clean slate.
+  await expect(report).toHaveCount(0);
+
+  await validate.click();
+  // The SECOND run still produces a report — the validator is not wedged after the first run.
+  await expect(report).toBeVisible({ timeout: 30_000 });
+  await expect(report.locator("[data-conforms]")).toHaveAttribute("data-conforms", "true");
+  // A conforming report carries no per-violation cards — proof the second validate really ran
+  // against the new data, not a cached first-run result.
+  await expect(report.locator('[data-testid="shacl-violation"]')).toHaveCount(0);
+
+  // ── THIRD RUN — a DIFFERENT non-conforming example ("Missing required property"), a THIRD
+  // validate in the same session. Three validates stresses the object lifecycle past the first
+  // re-use; a pointer freed on run 1 or 2 and reused here would fault deterministically.
+  await page.getByRole("button", { name: "Missing required property" }).click();
+  await expect(report).toHaveCount(0);
+  await validate.click();
+  await expect(report).toBeVisible({ timeout: 30_000 });
+  // The third run is genuinely non-conforming (a missing required property), so it renders a
+  // report with at least one violation — proof it really executed, not a stale panel.
+  await expect(report.locator("[data-conforms]")).toHaveAttribute("data-conforms", "false");
+  expect(await report.locator('[data-testid="shacl-violation"]').count()).toBeGreaterThan(0);
+
+  // Across all THREE validate runs in this single session, NO wasm object-lifecycle fault was
+  // ever emitted — the `__wbg_ptr` regression class stays fixed.
+  assertNoLifecycleFault(consoleErrors);
+});

--- a/site/e2e/try-query-smoke.spec.ts
+++ b/site/e2e/try-query-smoke.spec.ts
@@ -1,0 +1,83 @@
+// [OPUS-4.8] sq-jp7ry (issue #835) — CRITICAL-FLOW smoke test for the /try SPARQL playground.
+//
+// WHAT IT GUARDS. The /try REPL (src/components/repl.tsx) is the site's killer artifact: edit a
+// query, hit Run, get answers from the real Rust engine compiled to wasm, in-tab. This is the
+// most basic end-to-end the playground must always satisfy — type the trivial all-triples query
+// `SELECT * WHERE { ?s ?p ?o }`, run it against the bundled sample graph, and get a NON-EMPTY
+// results table back. It complements repl-results.spec.ts (which drives the built-in default
+// example + the view toggles): this one types the query the brief calls out verbatim, so it
+// guards the raw "editor → run → table" path the way a first-time visitor exercises it, and
+// asserts ZERO console errors across the interaction (the wasm-fault net for issue #835).
+//
+// WASM PREREQ. The REPL loads the lean wasm bundle from `public/wasm/` (a gitignored build
+// artifact synced from `js`'s `build:wasm`). The light site-e2e CI lane has no Rust toolchain
+// to build it, so this whole spec SKIPS when the bundle is absent (the same posture as
+// repl-results.spec.ts / shacl-validator.spec.ts) and runs in full when present. Run after
+// `npm run sync-wasm`:  npx playwright install chromium && npm run test:e2e
+import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Relative (no leading slash) so it resolves UNDER the baseURL's `/sparq/` basePath.
+const ROUTE = "try/";
+
+// The lean wasm bundle the REPL loads at runtime. Synced into public/wasm/ by `sync-wasm` from
+// the `js` build; gitignored, so its presence gates this spec.
+const WASM_BUNDLE = fileURLToPath(
+  new URL("../public/wasm/sparq_wasm_bg.wasm", import.meta.url),
+);
+
+// Skip the whole file when the wasm bundle has not been built/synced — the light CI lane does
+// not produce it, and a REPL that cannot load the engine is not the thing under test.
+test.skip(
+  !existsSync(WASM_BUNDLE),
+  "lean wasm bundle absent (public/wasm/sparq_wasm_bg.wasm) — run `npm run sync-wasm` after `(cd ../js && npm run build:wasm)`",
+);
+
+/** Collect every `console.error` the page emits, so the test can assert there were none. */
+function trackConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() === "error") errors.push(msg.text());
+  });
+  page.on("pageerror", (err) => errors.push(String(err)));
+  return errors;
+}
+
+/** Navigate to /try and wait for the wasm engine readiness pill to settle to "ready". */
+async function gotoReady(page: Page): Promise<void> {
+  await page.goto(ROUTE, { waitUntil: "domcontentloaded" });
+  // The engine pre-warms on mount; the pill flips to "Engine ready" when the wasm is loaded.
+  await expect(page.getByText("Engine ready")).toBeVisible({ timeout: 90_000 });
+}
+
+test("the trivial all-triples SELECT runs on the bundled sample and renders a non-empty table", async ({
+  page,
+}) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await gotoReady(page);
+
+  // Type the brief's trivial query verbatim, replacing the editor's default. The editor (sq-n5aw)
+  // is a highlight overlay over a real <textarea> exposed as the accessible "SPARQL query"
+  // textbox, so `fill` replaces its whole value.
+  await page
+    .getByRole("textbox", { name: "SPARQL query" })
+    .fill("SELECT * WHERE { ?s ?p ?o }");
+
+  // Run it. The button label is "Run query" in run mode.
+  await page.getByRole("button", { name: "Run query" }).click();
+
+  // The SELECT result panel appears with the typed table view (the bundled sample graph is
+  // non-empty, so `?s ?p ?o` binds rows for every triple).
+  const panel = page.locator('[data-result-kind="select"]');
+  await expect(panel).toBeVisible({ timeout: 30_000 });
+
+  const table = panel.locator('[data-result-view="table"] table');
+  await expect(table).toBeVisible();
+  // Header columns for the projected variables (?s ?p ?o) and at least one body row.
+  await expect(table.locator("thead th").first()).toBeVisible();
+  expect(await table.locator("tbody tr").count()).toBeGreaterThan(0);
+
+  // The whole interaction produced zero console errors (no wasm/render/runtime faults).
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});


### PR DESCRIPTION
> 🤖 **SPARQ agent** — site lane. Closes part of **sq-jp7ry** (issue #835); GUI/Tauri specs deferred (would race the in-flight gui PR **sq-cno90**).

## What & why

Issue #835 asks for Playwright E2E coverage of the site's critical flows because "unexpected bugs get introduced", with a concrete symptom: the SHACL validator throwing `Cannot read properties of undefined (reading '__wbg_ptr')`. This PR adds the **site-lane** critical-flow smoke specs + a targeted **wasm-object-lifecycle regression guard**, scoped as a bounded leaf (NOT the full e2e epic).

### Critical-flow SMOKE specs
| spec | flow | wasm? |
|---|---|---|
| `site/e2e/home-smoke.spec.ts` | home route renders hero `<h1>` + Primary nav, **zero console errors** | no |
| `site/e2e/try-query-smoke.spec.ts` | `/try` runs `SELECT * WHERE { ?s ?p ?o }` on the bundled sample → **non-empty results table** | gated |
| `site/e2e/capabilities-smoke.spec.ts` | `/capabilities` showcase renders hero + flagship band + all 5 theme sections, zero console errors | no |

### Regression guard
- `site/e2e/shacl-rerun-regression.spec.ts` drives the `/surface/shacl` validator **three times in one session** (datatype-violation → conforming → missing-property) and asserts **no** `__wbg_ptr` / `null pointer passed to rust` / `recursive use of an object` console error, and a **fresh report each run**. This guards the wasm-object-lifecycle bug class *beyond* the single-validate `shacl-validator.spec.ts` (the second-/third-run case a future shared/freed `Store` reuse would re-introduce).

**The `__wbg_ptr` error does NOT reproduce on current main** (fixed via sq-800o) — the guard is **green**, so no bug bead / `test.fixme` was needed. (The validator UI is not a distinct route — it is the `/surface/shacl` playground's Validate path → `sparqShaclValidate` → wasm `Store.validate`; the spec drives that real path.)

## Hermetic + non-flaky
No fixed sleeps — every assertion awaits an explicit condition (the *Engine ready* pill, the `[data-result-kind]` / `[data-testid="shacl-report"]` / `[data-conforms]` anchors) with bounded timeouts. Reuses the existing `data-testid`/`data-*` selectors (none added). The wasm-engine specs reuse the existing `existsSync(public/wasm)` skip gate, so the **light** site-e2e CI lane (no Rust toolchain) stays green; they run in full once `npm run sync-wasm` has synced a `build:wasm` bundle.

## CI
The specs **auto-join** the existing e2e lane (`.github/workflows/site-e2e.yml` runs `npm run test:e2e`, which globs `e2e/`) — **no workflow change** needed. README's e2e section updated to list the new coverage.

## Gates (all green locally)
- **Static export build** (`npm run build`, `output: export`): PASS end-to-end — `/`, `/try`, `/capabilities`, `/surface/shacl` emit into `out/` with the correct `/sparq` basePath.
- **WASM prereq**: built the shacl-enabled bundle (`cd js && npm run build:wasm` → `--features shacl,jsonld,serialize-rdf,scs,canon`) + synced; build artifact only, NO `crates/` changes.
- `npm run lint`: clean. `tsc --noEmit`: clean (no `any` escape hatches).
- **4 new specs PASS** headless; the **18 existing specs** still PASS (no regressions).

## Scope / honesty
Only `site/` files touched (4 specs + a README doc update). The `prebuild`-regenerated `benchmarks.generated.json` (non-canonical work-box data) was **reverted** — not staged. No new dependencies. No fabricated numbers; the specs assert DOM/console correctness, never a wall-clock threshold.

## Deferred (follow-up)
- GUI/Tauri SHACL + critical-flow specs (would race the in-flight gui PR **sq-cno90**) — remainder of the #835 e2e epic.
- Dataset-import (gzip/zip) + format-convert flows from #835 — separate beads.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>