### PR TITLE
feat(shacl): SHACL-SPARQL 1.2 pre-binding propagation + sh:sourceConstraint + node-expr harness fidelity (sq-mue75)

### DIFF
--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -49,9 +49,8 @@ if report.conforms_violations_only() { /* a stricter-threshold CI toggle */ }
 # Ok(()) }
 ```
 
-For many data graphs against one shapes graph, parse once with
-`ShapesModel::parse(&shapes)` and call `validate_with_model`. A CLI run is
-`cargo run -p sparq-shacl --example validate -- data.ttl shapes.ttl [--turtle]`.
+For many data graphs against one shapes graph, parse once with `ShapesModel::parse(&shapes)`
+and call `validate_with_model`. CLI: `cargo run -p sparq-shacl --example validate -- data.ttl shapes.ttl [--turtle]`.
 
 ## ✨ Features
 
@@ -66,16 +65,17 @@ For many data graphs against one shapes graph, parse once with
   `sh:someValue`/`sh:singleLine`/`sh:rootClass`, and severity-threshold `conforms`
   (default disallows {Violation,Warning,Info}) (sq-sx15d). The **full** vendored
   1.2 suite is gated by a ratchet (sq-6glcr): core / SPARQL (incl. expected-rejection
-  `sht:Failure` entries) / node-expr pass counts must not drop and the gap must not
-  grow, in both feature states — gap map in
-  [`research/shacl12-conformance-gap.md`](../../research/shacl12-conformance-gap.md).
-- **SHACL-SPARQL + custom §6 components** — `sh:sparql` (§5.2) and SPARQL-based
-  constraint *components* (custom `sh:ConstraintComponent` with `sh:parameter` /
-  `sh:validator`, §6), pinned by the W3C `sparql/*` sub-suites.
+  `sht:Failure` entries) / node-expr pass counts must not drop and the gap must not grow,
+  in both feature states — gap map in [`research/shacl12-conformance-gap.md`](../../research/shacl12-conformance-gap.md).
+- **SHACL-SPARQL + custom §6 components** — `sh:sparql` (§5.2, results carry
+  `sh:sourceConstraint`; `$this`/`$value` pre-binding propagates into UNION branches,
+  sibling joins and projecting sub-SELECTs, sq-mue75) and SPARQL-based constraint
+  *components* (`sh:ConstraintComponent` + `sh:parameter`/`sh:validator`, §6), pinned
+  by the W3C `sparql/*` sub-suites.
 - **SHACL Advanced Features (opt-in `shacl-af`)** — a rule **inference** step
   (`sh:rule` / `sh:values`, not part of `validate`): `sh:TripleRule`, `sh:SPARQLRule`,
-  value rules, the SHACL 1.2 node-expression algebra + function registry, and the
-  `sh:expression` / `sh:nodeByExpression` constraints. Off ⇒ none of it compiles.
+  value rules, the SHACL 1.2 node-expression algebra + function registry (`shnex:`/`sh:`),
+  and `sh:expression` / `sh:nodeByExpression`. Off ⇒ none of it compiles.
 - **Differential fuzzing** — a deterministic SplitMix64 fuzzer
   (`tests/diff_fuzz.rs`) cross-checks reports against pluggable reference engines
   (pySHACL, Apache Jena SHACL, the Zazuko / `rdf-validate-shacl` Node engines); it is
@@ -92,9 +92,9 @@ For many data graphs against one shapes graph, parse once with
   **32/32** of the vendored W3C `shacl12-cs` valid fixtures graph-isomorphically
   (`cargo test -p sparq-shacl --features scs --test scs_roundtrip`). A hand-rolled lexer +
   recursive-descent parser over the `SHACLC.g4` grammar (directives, `shape`/`shapeClass`,
-  path expressions, counts, negation/disjunction, nested shapes/arrays — full list in
-  the SKILL). Adds **zero new dependencies**; unsupported constructs return a typed
-  `ScsError` (never a silent mis-parse). Off ⇒ none of it compiles.
+  paths, counts, negation/disjunction, nested shapes/arrays — full list in the SKILL).
+  Adds **zero new dependencies**; unsupported constructs return a typed `ScsError`
+  (never a silent mis-parse). Off ⇒ none of it compiles.
 
 ## 📚 Learn more
 
@@ -107,13 +107,13 @@ For many data graphs against one shapes graph, parse once with
 
 ## Scope and non-goals
 
-Out of scope: full `sparql/pre-binding` semantics (rejecting variable re-binding,
-`$shapesGraph`) — see `bd list -l area:sparq-shacl`. Validation results are **not
-deduplicated** across traversal routes (a nested shape reached through two parents
-reports twice, matching the suite), re-entrant recursion on the same focus/shape pair
-counts as conforming (SHACL leaves recursion undefined), and an **uncompilable
-`sh:pattern`** (e.g. a `(?!…)` lookahead) is **skipped** into `report.diagnostics`,
-never fail-closed onto every value.
+Out of scope: the `sparql/pre-binding` *rejection* channel (signalling a failure for a
+variable re-binding / `SELECT *` sub-select) and `$shapesGraph` — see
+`bd list -l area:sparq-shacl`. Validation results are **not deduplicated** across
+traversal routes (a nested shape reached through two parents reports twice, matching the
+suite), re-entrant recursion on the same focus/shape pair counts as conforming (SHACL
+leaves recursion undefined), and an **uncompilable `sh:pattern`** (e.g. a `(?!…)`
+lookahead) is **skipped** into `report.diagnostics`, never fail-closed onto every value.
 
 ## License
 

--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -302,6 +302,8 @@ impl<'a> Validator<'a> {
             path: shape.path.clone(),
             value,
             source_shape: shape.node.clone(),
+            // Core components have no `sh:SPARQLConstraint` node (sq-mue75).
+            source_constraint: None,
             source_component: sh(component),
             severity: shape.severity.clone(),
             messages: shape.messages.clone(),
@@ -1145,6 +1147,9 @@ impl<'a> Validator<'a> {
             .unwrap_or_else(|| shape.severity.clone());
         let (shape_node, shape_path, shape_messages) =
             (shape.node.clone(), shape.path.clone(), shape.messages.clone());
+        // [OPUS-4.8] (sq-mue75) stamp the originating `sh:SPARQLConstraint` node
+        // onto each result as `sh:sourceConstraint` (SHACL §5.2.2).
+        let constraint_node = constraint.node.clone();
         let data = self.data.graph();
         prepared.evaluate(
             data,
@@ -1157,6 +1162,7 @@ impl<'a> Validator<'a> {
                 path: fields.path.or_else(|| shape_path.clone()),
                 value: fields.value,
                 source_shape: shape_node.clone(),
+                source_constraint: Some(constraint_node.clone()),
                 source_component: component.clone(),
                 severity: severity.clone(),
                 messages: shape_messages.clone(),
@@ -1248,6 +1254,9 @@ impl<'a> Validator<'a> {
                             path: shape_path.clone(),
                             value: Some(v.clone()),
                             source_shape: shape_node.clone(),
+                            // A SPARQL-based constraint COMPONENT has no single
+                            // `sh:SPARQLConstraint` node (sq-mue75).
+                            source_constraint: None,
                             source_component: component_iri.clone(),
                             severity: severity.clone(),
                             messages: shape_messages.clone(),
@@ -1274,6 +1283,9 @@ impl<'a> Validator<'a> {
                         path: fields.path.or_else(|| shape_path.clone()),
                         value: fields.value,
                         source_shape: shape_node.clone(),
+                        // A SPARQL-based constraint COMPONENT has no single
+                        // `sh:SPARQLConstraint` node (sq-mue75).
+                        source_constraint: None,
                         source_component: component_iri.clone(),
                         severity: severity.clone(),
                         messages: shape_messages.clone(),

--- a/crates/sparq-shacl/src/func.rs
+++ b/crates/sparq-shacl/src/func.rs
@@ -650,8 +650,12 @@ fn int_literal(n: i128) -> Term {
 }
 
 fn decimal_literal(v: f64) -> Term {
-    // Render without an exponent so the lexical form is a valid xsd:decimal.
+    // Render without an exponent and ALWAYS with a fractional part, so the lexical
+    // form is a canonical xsd:decimal: a whole-valued decimal must read `42.0`, not
+    // `42` (the W3C node-expr `sum-totalRevenue` sums decimals to a whole number
+    // and expects `42.0`^^xsd:decimal). (sq-mue75)
     let s = format!("{v}");
+    let s = if s.contains('.') { s } else { format!("{s}.0") };
     Term::Literal(Literal::new_typed_literal(
         s,
         NamedNode::new_unchecked(format!("{XSD}decimal")),

--- a/crates/sparq-shacl/src/lib.rs
+++ b/crates/sparq-shacl/src/lib.rs
@@ -662,6 +662,79 @@ mod tests {
             .is_empty());
     }
 
+    /// [OPUS-4.8] (sq-mue75) A `sh:sparql` result carries `sh:sourceConstraint`
+    /// pointing at the `sh:SPARQLConstraint` node — distinct from `sh:sourceShape`
+    /// (the shape) — and the Turtle report emits it. A Core (non-sparql) result
+    /// carries no `sh:sourceConstraint`.
+    #[test]
+    fn sparql_result_carries_source_constraint() {
+        let shapes = Graph::load_str(
+            r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            ex:TestShape a sh:NodeShape ;
+              sh:targetNode ex:bad ;
+              sh:sparql ex:TestShape-sparql .
+            ex:TestShape-sparql a sh:SPARQLConstraint ;
+              sh:select "SELECT $this WHERE { $this <http://example.org/flag> true }" .
+        "#,
+            "turtle",
+        )
+        .unwrap();
+        let data = Graph::load_str(
+            "@prefix ex: <http://example.org/> . ex:bad ex:flag true .",
+            "turtle",
+        )
+        .unwrap();
+        let r = validate(&data, &shapes);
+        assert!(!r.conforms, "{}", r.to_text());
+        assert_eq!(r.results.len(), 1, "{}", r.to_text());
+        let res = &r.results[0];
+        // sh:sourceConstraint = the sh:SPARQLConstraint node, NOT the shape.
+        assert_eq!(
+            res.source_constraint,
+            Some(oxrdf::Term::NamedNode(
+                oxrdf::NamedNode::new("http://example.org/TestShape-sparql").unwrap()
+            )),
+            "expected sh:sourceConstraint = the constraint node"
+        );
+        assert_eq!(
+            res.source_shape,
+            oxrdf::Term::NamedNode(
+                oxrdf::NamedNode::new("http://example.org/TestShape").unwrap()
+            ),
+            "sh:sourceShape must remain the shape node"
+        );
+        assert_ne!(
+            res.source_constraint.as_ref(),
+            Some(&res.source_shape),
+            "sourceConstraint and sourceShape must be distinct here"
+        );
+        // The Turtle report emits sh:sourceConstraint.
+        let ttl = r.to_turtle();
+        assert!(
+            ttl.contains("sh:sourceConstraint"),
+            "report Turtle must emit sh:sourceConstraint:\n{ttl}"
+        );
+    }
+
+    /// [OPUS-4.8] (sq-mue75) A Core (non-`sh:sparql`) constraint result carries no
+    /// `sh:sourceConstraint` (the spec stamps it only on SPARQL-based results).
+    #[test]
+    fn core_result_has_no_source_constraint() {
+        let r = check(
+            r#"
+            @prefix ex: <http://example.org/> .
+            ex:bob a ex:Person ; ex:age -1 .
+        "#,
+        );
+        assert!(!r.conforms);
+        assert!(
+            r.results.iter().all(|res| res.source_constraint.is_none()),
+            "Core results must not carry sh:sourceConstraint"
+        );
+    }
+
     #[test]
     fn logical_and_paths() {
         let data = Graph::load_str(

--- a/crates/sparq-shacl/src/model.rs
+++ b/crates/sparq-shacl/src/model.rs
@@ -295,6 +295,10 @@ pub(crate) struct PreparedComponentValidator {
 /// skipped, matching this crate's lenient handling of ill-formed shapes).
 #[derive(Debug, Clone)]
 pub(crate) struct SparqlConstraint {
+    /// [OPUS-4.8] (sq-mue75) The `sh:SPARQLConstraint` node (the object of
+    /// `sh:sparql`), stamped onto each result as `sh:sourceConstraint` (SHACL
+    /// §5.2.2).
+    pub node: Term,
     /// The raw `sh:select` text.
     pub select: String,
     /// PREFIX declarations assembled from `sh:prefixes` (`sh:declare` →
@@ -546,6 +550,16 @@ impl ShapesModel {
                 Component::Expression(idx)
             });
         }
+    }
+
+    /// [OPUS-4.8] (sq-mue75) Registers the inline filter/function shapes a
+    /// standalone node expression references (the public `eval_node_expression`
+    /// seam): the same on-demand inline-shape registration the `sh:expression`
+    /// constraint parse does, so a `findFirst`/`matchAll`/`nodesMatching`/
+    /// `filterShape` over an anonymous `[ … ]` shape resolves at eval time.
+    #[cfg(feature = "shacl-af")]
+    pub(crate) fn register_node_expr_shapes(&mut self, shapes_graph: &Graph, expr: &Term) {
+        self.register_expression_shapes(shapes_graph, expr, 0);
     }
 
     /// Walks an expression term registering inline `sh:filterShape` / function
@@ -1079,6 +1093,7 @@ impl ShapesModel {
             _ => None,
         };
         let mut constraint = SparqlConstraint {
+            node: node.clone(),
             select,
             prefixes,
             message,

--- a/crates/sparq-shacl/src/report.rs
+++ b/crates/sparq-shacl/src/report.rs
@@ -37,6 +37,14 @@ pub struct ValidationResult {
     pub value: Option<Term>,
     /// The shape the failing constraint is declared on.
     pub source_shape: Term,
+    /// [OPUS-4.8] (sq-mue75) The constraint node a SPARQL-based result came from
+    /// (`sh:sourceConstraint`): the `sh:SPARQLConstraint` node (the object of
+    /// `sh:sparql`). SHACL §5.2.2 stamps this on `sh:sparql` results so a report
+    /// can point at the exact constraint, distinct from `sh:sourceShape` (the
+    /// shape) and `sh:sourceConstraintComponent`. `None` for every non-`sh:sparql`
+    /// component (Core constraints and SPARQL-based constraint COMPONENTS have no
+    /// single `sh:SPARQLConstraint` node, so the spec omits it there).
+    pub source_constraint: Option<Term>,
     /// The constraint-component IRI (e.g. `sh:MinCountConstraintComponent`).
     pub source_component: String,
     /// Severity IRI (sh:Violation / sh:Warning / sh:Info, or custom).
@@ -241,6 +249,11 @@ fn write_result_node(out: &mut String, r: &ValidationResult) {
     // A blank-node source shape has no graph-independent identity; emit its
     // label so the report stays self-consistent and parseable.
     let _ = writeln!(out, "    sh:sourceShape {} ;", r.source_shape);
+    // [OPUS-4.8] (sq-mue75) `sh:sourceConstraint` — the originating
+    // `sh:SPARQLConstraint` node, present only on `sh:sparql` results.
+    if let Some(c) = &r.source_constraint {
+        let _ = writeln!(out, "    sh:sourceConstraint {c} ;");
+    }
     for m in r.effective_messages() {
         let _ = writeln!(out, "    sh:resultMessage {m} ;");
     }
@@ -306,6 +319,7 @@ mod tests {
             path,
             value,
             source_shape: iri(&format!("{EX}Shape")),
+            source_constraint: None,
             source_component: format!("{SH}{component}"),
             severity: format!("{SH}{severity}"),
             messages,

--- a/crates/sparq-shacl/src/rules.rs
+++ b/crates/sparq-shacl/src/rules.rs
@@ -73,6 +73,24 @@ use oxrdf::{NamedNode, NamedOrBlankNode, Term, Triple};
 use rustc_hash::FxHashSet;
 use sparq_core::Graph;
 
+/// [OPUS-4.8] (sq-mue75) The SHACL 1.2 node-expression namespace. The SHACL-AF
+/// public API the crate's parser was originally written against spells the
+/// node-expression operators in the `sh:` namespace, but the W3C SHACL 1.2
+/// node-expression vocabulary (and its conformance suite) uses `shnex:`. The
+/// blank-node parser below accepts BOTH spellings of the shared algebra so the
+/// real evaluation path drives the conformance suite directly (no harness-side
+/// re-implementation). The function-operator registry (`func.rs`) already does
+/// this via its own `op_object`.
+const SHNEX: &str = "http://www.w3.org/ns/shacl-node-expr#";
+
+/// The single object of `subject <ns#local>`, trying the SHACL 1.2 `shnex:`
+/// spelling first then the SHACL-AF `sh:` spelling (the two share local names for
+/// the shared node-expression algebra).
+fn ne_object(g: &GraphView, subject: &Term, local: &str) -> Option<Term> {
+    g.object(subject, &format!("{SHNEX}{local}"))
+        .or_else(|| g.object(subject, &sh(local)))
+}
+
 // [OPUS-4.8] (sq-mk9n) The SHACL-function registry + the function-expression form
 // ([`NodeExpr::Func`]). A child module so its (sizeable) operator table stays out
 // of this file; it reaches the node-expression machinery through `super::`.
@@ -376,9 +394,10 @@ fn parse_blank_node_expr(g: &GraphView, model: &ShapesModel, node: &Term) -> Opt
     if g.predicate_objects(node).is_empty() {
         return Some(NodeExpr::List(Vec::new()));
     }
-    // Intersection / union: a SHACL list of member node expressions.
+    // Intersection / union: a SHACL list of member node expressions
+    // (`shnex:`/`sh:` spelling, sq-mue75).
     for (pred, is_union) in [("intersection", false), ("union", true)] {
-        if let Some(list_head) = g.object(node, &sh(pred)) {
+        if let Some(list_head) = ne_object(g, node, pred) {
             let members: Vec<NodeExpr> = g
                 .list(&list_head)
                 .iter()
@@ -394,9 +413,10 @@ fn parse_blank_node_expr(g: &GraphView, model: &ShapesModel, node: &Term) -> Opt
             });
         }
     }
-    // Filter shape: [ sh:filterShape S ; sh:nodes N ]. The shape must be parsed
-    // into the model (typed sh:NodeShape / referenced) — exactly as sh:condition.
-    if let Some(shape_term) = g.object(node, &sh("filterShape")) {
+    // Filter shape: [ shnex:filterShape S ; shnex:nodes N ] (or `sh:` spelling).
+    // The shape must be parsed into the model (typed sh:NodeShape / referenced) —
+    // exactly as sh:condition.
+    if let Some(shape_term) = ne_object(g, node, "filterShape") {
         let shape = model.by_node(&shape_term)?;
         let nodes = parse_nodes_input(g, model, node)?;
         return Some(NodeExpr::FilterShape {
@@ -404,8 +424,10 @@ fn parse_blank_node_expr(g: &GraphView, model: &ShapesModel, node: &Term) -> Opt
             shape,
         });
     }
-    // Path: [ sh:path P ; sh:nodes N? ] (sh:nodes defaults to sh:this).
-    if let Some(p) = g.object(node, &sh("path")) {
+    // Path-values: the SHACL 1.2 `[ shnex:pathValues P ; shnex:focusNode N? ]` and
+    // the SHACL-AF `[ sh:path P ; sh:nodes N? ]` both evaluate a property path P
+    // from a start-node expression (defaulting to `sh:this`) (sq-mue75).
+    if let Some(p) = ne_object(g, node, "pathValues").or_else(|| g.object(node, &sh("path"))) {
         let path = Path::parse(g, &p).ok()?;
         let nodes = parse_nodes_input(g, model, node)?;
         return Some(NodeExpr::Path {
@@ -419,10 +441,12 @@ fn parse_blank_node_expr(g: &GraphView, model: &ShapesModel, node: &Term) -> Opt
     func::parse(g, model, node).map(|f| NodeExpr::Func(Box::new(f)))
 }
 
-/// The `sh:nodes` input node expression of a path / filter expression, defaulting
-/// to the focus-node expression (`sh:this`) when `sh:nodes` is absent.
+/// The input/start node expression of a path / filter expression, defaulting to
+/// the focus-node expression (`sh:this`) when absent. Accepts the SHACL 1.2
+/// `shnex:nodes` (filter input) / `shnex:focusNode` (path start) and the SHACL-AF
+/// `sh:nodes` spellings (sq-mue75).
 fn parse_nodes_input(g: &GraphView, model: &ShapesModel, node: &Term) -> Option<NodeExpr> {
-    match g.object(node, &sh("nodes")) {
+    match ne_object(g, node, "nodes").or_else(|| ne_object(g, node, "focusNode")) {
         Some(n) => parse_node_expr(g, model, &n),
         None => Some(NodeExpr::This),
     }
@@ -534,23 +558,30 @@ pub fn expand(data: &Graph, shapes: &Graph) -> Graph {
 /// not declared in the shapes graph) — the caller can treat that as "skip".
 ///
 /// This is the production public seam onto the implemented algebra
-/// (focus / constant / path-with-`sh:nodes` / `sh:filterShape` /
-/// `sh:intersection` / `sh:union`): it is the same `parse_node_expr` →
-/// `NodeExpr::eval` machinery that backs `apply_rules`' `sh:values` rules, and is
-/// exercised by this crate's `#[cfg(test)]` unit tests (via `apply_rules` for the
-/// production `sh:values` rule path, and directly by the `eval_node_expression_seam`
-/// test). The W3C conformance harness (`tests/w3c_node_expr.rs`) does **not** call
-/// this function: it validates a *parallel re-implementation* of the same algebra
-/// in its own `Evaluator`, and touches the crate only through `conforms` / `Path`.
-/// `shapes` is parsed fresh; for repeated evaluation parse a model once and use the
-/// engine entry points.
+/// (focus / constant / path-with-`sh:nodes` / filter-shape / intersection /
+/// union / the function operators): it is the same `parse_node_expr` →
+/// `NodeExpr::eval` machinery that backs `apply_rules`' `sh:values` rules and the
+/// `sh:expression` / `sh:nodeByExpression` constraints. Both the SHACL 1.2
+/// `shnex:` and the SHACL-AF `sh:` spellings of the shared algebra are accepted.
+///
+/// [OPUS-4.8] (sq-mue75) The W3C conformance harness (`tests/w3c_node_expr.rs`)
+/// now drives THIS function for real (it previously re-implemented the algebra
+/// in-harness — a fidelity gap). Inline anonymous filter shapes the expression
+/// references (`sh:filterShape` / `shnex:findFirst`/`matchAll`/`nodesMatching`
+/// `[ … ]`) are registered into the model before parsing so they resolve at eval
+/// time even when they are not target-bearing roots. `shapes` is parsed fresh;
+/// for repeated evaluation parse a model once and use the engine entry points.
 pub fn eval_node_expression(
     data: &Graph,
     shapes: &Graph,
     expr: &Term,
     focus: &Term,
 ) -> Option<Vec<Term>> {
-    let model = ShapesModel::parse(shapes);
+    let mut model = ShapesModel::parse(shapes);
+    // Register inline filter/function shapes the expression references so a
+    // `findFirst`/`matchAll`/`nodesMatching`/`filterShape` over an anonymous
+    // `[ … ]` shape resolves (mirrors the `sh:expression` constraint parse path).
+    model.register_node_expr_shapes(shapes, expr);
     let g = GraphView::new(shapes);
     let parsed = parse_node_expr(&g, &model, expr)?;
     let view = GraphView::new(data);

--- a/crates/sparq-shacl/src/sparql.rs
+++ b/crates/sparq-shacl/src/sparql.rs
@@ -294,16 +294,48 @@ fn pre_bind_ask(query: &Query, bindings: &[Binding]) -> Option<Query> {
     })
 }
 
-/// Pushes the pre-binding `values` table *down* through single-child algebra
-/// wrappers (`Filter` / `Extend` / `OrderBy` / `Group` / `Distinct` / `Reduced` /
-/// `Slice` / `Minus`-left / `LeftJoin`-left), joining it at the deepest pattern
-/// node. This is load-bearing for FILTER-only patterns like `ASK { FILTER(?value
-/// = $param) }`: a VALUES table joined ABOVE the `Filter` leaves `?value`/`$param`
-/// UNBOUND inside the filter (the filter scopes only its own inner), so the
-/// filter evaluates over empty bindings and the constraint never holds. Joining
-/// the VALUES table BELOW the filter puts the pre-bound terms in scope. Robust to
-/// however the validator query is laid out (no textual prepend). SHACL §6.3
-/// pre-binding semantics (substitute the variable's value everywhere it occurs).
+/// The variable names a pre-binding `values` table binds (each pushed-down
+/// VALUES table is the single-row one built by [`pre_bind_values`]). Used to
+/// decide whether a sub-SELECT keeps a pre-bound variable in scope (it must be
+/// projected) — Union/Join siblings are descended unconditionally because the
+/// single-row VALUES join is idempotent for a branch that does not mention it.
+fn values_var_names(values: &GraphPattern) -> Vec<&str> {
+    match values {
+        GraphPattern::Values { variables, .. } => variables.iter().map(|v| v.as_str()).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Pushes the pre-binding `values` table *down* through algebra wrappers, joining
+/// it at every leaf where the pre-bound variables are in scope. This is
+/// load-bearing for FILTER-only patterns like `ASK { FILTER(?value = $param) }`: a
+/// VALUES table joined ABOVE the `Filter` leaves `?value`/`$param` UNBOUND inside
+/// the filter (the filter scopes only its own inner), so the filter evaluates over
+/// empty bindings and the constraint never holds. Joining the VALUES table BELOW
+/// the filter puts the pre-bound terms in scope. Robust to however the validator
+/// query is laid out (no textual prepend). SHACL §6.3 pre-binding semantics
+/// (substitute the variable's value everywhere it occurs).
+///
+/// [OPUS-4.8] (sq-mue75) The descent now follows EVERY scope a pre-bound variable
+/// can reach, not just one chain, so the binding constrains the whole pattern
+/// (the shacl12 `sparql/pre-binding` 002/005/007 entries):
+///   * single-child wrappers (`Filter` / `Extend` / `OrderBy` / `Group` /
+///     `Distinct` / `Reduced` / `Slice` / `Graph`) — descend into the inner;
+///   * `Minus`-left / `LeftJoin`-left — bind the REQUIRED left only (the
+///     excluded / optional right keeps SHACL substitution semantics);
+///   * `Union` — push into BOTH branches independently, so a pre-bound variable
+///     used only inside one branch's FILTER is in scope there (pre-binding-002);
+///   * `Join` — push into BOTH siblings, so a sibling sub-block that wraps a
+///     FILTER over an empty inner (`{ FILTER(bound($this)) }`) sees the binding
+///     (pre-binding-005); the single-row VALUES join is idempotent for a sibling
+///     that does not mention the variable;
+///   * sub-`SELECT` `Project` — descend through the projection ONLY when every
+///     pre-bound variable is explicitly projected (so it stays in scope inside the
+///     sub-select, pre-binding-007); a `SELECT *` (an empty projection list in this
+///     algebra) or a projection that drops a pre-bound variable re-scopes it, so
+///     the table is joined ABOVE the sub-select instead (the variable is then
+///     out of scope inside — consistent with the spec rejecting that re-binding,
+///     e.g. the `sht:Failure` pre-binding-006).
 fn push_values_down(pattern: &GraphPattern, values: &GraphPattern) -> GraphPattern {
     match pattern {
         GraphPattern::Filter { expr, inner } => GraphPattern::Filter {
@@ -347,6 +379,11 @@ fn push_values_down(pattern: &GraphPattern, values: &GraphPattern) -> GraphPatte
             variables: variables.clone(),
             aggregates: aggregates.clone(),
         },
+        // A GRAPH block keeps the outer pre-bound variables in scope; descend.
+        GraphPattern::Graph { name, inner } => GraphPattern::Graph {
+            name: name.clone(),
+            inner: Box::new(push_values_down(inner, values)),
+        },
         // For a left-join / minus, bind on the (required) left side only.
         GraphPattern::LeftJoin {
             left,
@@ -361,13 +398,66 @@ fn push_values_down(pattern: &GraphPattern, values: &GraphPattern) -> GraphPatte
             left: Box::new(push_values_down(left, values)),
             right: right.clone(),
         },
-        // A leaf (BGP / Path / Join / Union / Values / sub-SELECT Project / …):
-        // join the VALUES table here so its bindings flow up into every parent.
+        // [OPUS-4.8] (sq-mue75) UNION: each branch is an independent scope; push
+        // the pre-binding into BOTH so a variable used only inside one branch's
+        // FILTER is bound there (shacl12 sparql/pre-binding-002).
+        GraphPattern::Union { left, right } => GraphPattern::Union {
+            left: Box::new(push_values_down(left, values)),
+            right: Box::new(push_values_down(right, values)),
+        },
+        // [OPUS-4.8] (sq-mue75) JOIN: push into BOTH siblings so a sibling block
+        // that wraps a FILTER over an empty inner still sees the binding (shacl12
+        // sparql/pre-binding-005). Joining the single-row VALUES into a sibling
+        // that does not mention the variable is idempotent (a cross product with
+        // one deterministic row).
+        GraphPattern::Join { left, right } => GraphPattern::Join {
+            left: Box::new(push_values_down(left, values)),
+            right: Box::new(push_values_down(right, values)),
+        },
+        // [OPUS-4.8] (sq-mue75) sub-SELECT projection: a pre-bound variable stays
+        // in scope inside the sub-select ONLY if it is explicitly projected, so
+        // descend through the Project (and keep it projected) in that case; else
+        // join the VALUES ABOVE the sub-select (fall through to the leaf arm).
+        GraphPattern::Project { inner, variables }
+            if projects_all(variables, &values_var_names(values)) =>
+        {
+            let mut projected = variables.clone();
+            for name in values_var_names(values) {
+                if !projected.iter().any(|v| v.as_str() == name) {
+                    projected.push(Variable::new_unchecked(name));
+                }
+            }
+            GraphPattern::Project {
+                inner: Box::new(push_values_down(inner, values)),
+                variables: projected,
+            }
+        }
+        // A leaf (BGP / Path / Values / a sub-SELECT that re-scopes a pre-bound
+        // variable / …): join the VALUES table here so its bindings flow up into
+        // every parent.
         other => GraphPattern::Join {
             left: Box::new(values.clone()),
             right: Box::new(other.clone()),
         },
     }
+}
+
+/// `true` iff `projected` explicitly lists EVERY name in `names` (so a sub-SELECT
+/// keeps those pre-bound variables in scope inside it). An empty `projected` is a
+/// `SELECT *` in this algebra — treated as NOT explicitly projecting (so a
+/// pre-bound variable is re-scoped, the spec-rejection case, e.g. the
+/// `sht:Failure` pre-binding-006); an empty `names` (nothing pre-bound) trivially
+/// holds but never reaches a Project leaf in practice.
+fn projects_all(projected: &[Variable], names: &[&str]) -> bool {
+    if names.is_empty() {
+        return true;
+    }
+    if projected.is_empty() {
+        return false; // SELECT * — not an explicit projection of the pre-bound var
+    }
+    names
+        .iter()
+        .all(|n| projected.iter().any(|v| v.as_str() == *n))
 }
 
 /// Joins `values` into a SELECT pattern at the right depth: it descends through
@@ -864,6 +954,185 @@ mod tests {
         }
     }
 
+    // --- [OPUS-4.8] (sq-mue75) push_values_down: the new multi-scope arms --------
+    //
+    // UNION / sibling-JOIN / sub-SELECT projection. Each pre-bound variable must
+    // reach EVERY scope it can appear in (shacl12 sparql/pre-binding-002/005/007),
+    // not just one descent chain. Structural assertions over the real recursion.
+
+    /// Is there a `Join { Values, … }` directly under `p` (the pre-binding join)?
+    fn values_join_here(p: &GraphPattern) -> bool {
+        matches!(p, GraphPattern::Join { left, .. } if matches!(**left, GraphPattern::Values { .. }))
+    }
+
+    /// Does some node in `p`'s subtree wrap the FILTER over a `Join { Values, … }`
+    /// (i.e. the pre-binding is in scope INSIDE the filter)?
+    fn filter_over_values_join(p: &GraphPattern) -> bool {
+        match p {
+            GraphPattern::Filter { inner, .. } => {
+                values_join_here(inner) || filter_over_values_join(inner)
+            }
+            GraphPattern::Join { left, right }
+            | GraphPattern::Union { left, right }
+            | GraphPattern::Minus { left, right }
+            | GraphPattern::LeftJoin { left, right, .. } => {
+                filter_over_values_join(left) || filter_over_values_join(right)
+            }
+            GraphPattern::Project { inner, .. }
+            | GraphPattern::Distinct { inner }
+            | GraphPattern::Reduced { inner }
+            | GraphPattern::Slice { inner, .. }
+            | GraphPattern::OrderBy { inner, .. }
+            | GraphPattern::Group { inner, .. }
+            | GraphPattern::Extend { inner, .. } => filter_over_values_join(inner),
+            _ => false,
+        }
+    }
+
+    #[test]
+    fn push_values_down_into_both_union_branches() {
+        // pre-binding-002: `{ FILTER(false) } UNION { FILTER($this = <x>) }`.
+        // The VALUES must be joined under BOTH branches' FILTER so $this is in
+        // scope inside each (joining ABOVE the Union leaves it unbound there).
+        let inner = match select_pattern(
+            "SELECT $this WHERE { { FILTER(false) } UNION { FILTER(?this = <http://x/n>) } }",
+        ) {
+            GraphPattern::Project { inner, .. } => *inner,
+            other => other,
+        };
+        assert!(matches!(inner, GraphPattern::Union { .. }), "{:?}", inner);
+        let out = push_values_down(&inner, &values_this());
+        match &out {
+            GraphPattern::Union { left, right } => {
+                // Each branch is `Filter { Join { Values, Bgp } }`.
+                assert!(
+                    matches!(&**left, GraphPattern::Filter { inner, .. } if values_join_here(inner)),
+                    "UNION left branch missing pre-binding: {:?}",
+                    left
+                );
+                assert!(
+                    matches!(&**right, GraphPattern::Filter { inner, .. } if values_join_here(inner)),
+                    "UNION right branch missing pre-binding: {:?}",
+                    right
+                );
+            }
+            other => panic!("expected Union, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn push_values_down_into_join_siblings() {
+        // pre-binding-005: `{ FILTER(bound($this)) } ?this :p "L" . FILTER(bound($this))`.
+        // The inner `{ FILTER(bound($this)) }` sibling-block wraps a FILTER over an
+        // EMPTY inner; the pre-binding must reach inside it (not just the first
+        // descent), so $this is bound in that filter too.
+        let inner = match select_pattern(
+            "SELECT $this WHERE { { FILTER(bound(?this)) } ?this <http://x/p> \"L\" }",
+        ) {
+            GraphPattern::Project { inner, .. } => *inner,
+            other => other,
+        };
+        assert!(matches!(inner, GraphPattern::Join { .. }), "{:?}", inner);
+        let out = push_values_down(&inner, &values_this());
+        match &out {
+            GraphPattern::Join { left, right } => {
+                // The FILTER sibling now wraps a Values-join (its empty inner is
+                // bound); the BGP sibling is joined with Values directly.
+                assert!(
+                    filter_over_values_join(left),
+                    "JOIN sibling FILTER block not pre-bound: {:?}",
+                    left
+                );
+                assert!(
+                    values_join_here(right) || filter_over_values_join(right),
+                    "JOIN BGP sibling not pre-bound: {:?}",
+                    right
+                );
+            }
+            other => panic!("expected Join, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn push_values_down_through_projecting_subselect() {
+        // pre-binding-007: `{ SELECT $this WHERE { FILTER($this = <x>) } }`. The
+        // inner sub-SELECT explicitly projects ?this, so it stays in scope inside;
+        // the pre-binding must descend THROUGH the Project to the FILTER.
+        let inner = match select_pattern(
+            "SELECT $this WHERE { { SELECT $this WHERE { FILTER(?this = <http://x/n>) } } }",
+        ) {
+            GraphPattern::Project { inner, .. } => *inner,
+            other => other,
+        };
+        assert!(matches!(inner, GraphPattern::Project { .. }), "{:?}", inner);
+        let out = push_values_down(&inner, &values_this());
+        match &out {
+            GraphPattern::Project { inner, variables } => {
+                assert!(
+                    variables.iter().any(|v| v.as_str() == "this"),
+                    "sub-SELECT must keep ?this projected: {:?}",
+                    variables
+                );
+                assert!(
+                    filter_over_values_join(inner),
+                    "sub-SELECT FILTER not pre-bound: {:?}",
+                    inner
+                );
+            }
+            other => panic!("expected Project, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn push_values_down_above_select_star_subselect() {
+        // A `SELECT *` sub-select (an EMPTY projection list in this algebra) does
+        // NOT explicitly project the pre-bound variable, so the spec re-scopes it
+        // (the `sht:Failure` pre-binding-006). The pre-binding is joined ABOVE the
+        // sub-select (the leaf arm), not descended into it.
+        let inner = match select_pattern(
+            "SELECT $this WHERE { { SELECT * WHERE { FILTER(?this = <http://x/n>) } } }",
+        ) {
+            GraphPattern::Project { inner, .. } => *inner,
+            other => other,
+        };
+        // The inner sub-select is `Project { …, variables: [] }` (SELECT *).
+        assert!(
+            matches!(&inner, GraphPattern::Project { variables, .. } if variables.is_empty()),
+            "{:?}",
+            inner
+        );
+        let out = push_values_down(&inner, &values_this());
+        // Joined ABOVE: `Join { Values, Project{…} }`, NOT descended into the inner.
+        assert!(
+            matches!(&out, GraphPattern::Join { left, right }
+                if matches!(**left, GraphPattern::Values { .. })
+                    && matches!(**right, GraphPattern::Project { .. })),
+            "SELECT * sub-select must be bound ABOVE, got {:?}",
+            out
+        );
+    }
+
+    #[test]
+    fn push_values_down_through_graph_block() {
+        // [OPUS-4.8] (sq-mue75) A GRAPH block keeps the outer pre-bound variable in
+        // scope; the pre-binding descends into its inner.
+        let inner = GraphPattern::Graph {
+            name: spargebra::term::NamedNodePattern::NamedNode(
+                NamedNode::new("http://g/named").unwrap(),
+            ),
+            inner: Box::new(filter_bgp()),
+        };
+        let out = push_values_down(&inner, &values_this());
+        match &out {
+            GraphPattern::Graph { inner, .. } => assert!(
+                filter_over_values_join(inner),
+                "GRAPH inner not pre-bound: {:?}",
+                inner
+            ),
+            other => panic!("expected Graph, got {:?}", other),
+        }
+    }
+
     // --- inject_values: solution-modifier descent (Reduced/Slice/OrderBy) -----
 
     #[test]
@@ -969,6 +1238,7 @@ mod tests {
                 path: f.path,
                 value: f.value,
                 source_shape: Term::NamedNode(NamedNode::new("http://example.org/S").unwrap()),
+                source_constraint: None,
                 source_component: "http://www.w3.org/ns/shacl#SPARQLConstraintComponent"
                     .to_string(),
                 severity: "http://www.w3.org/ns/shacl#Violation".to_string(),
@@ -1063,6 +1333,7 @@ mod tests {
     fn prepared_sparql_build_rejects_non_select() {
         // A non-SELECT sh:select is ill-formed -> None.
         let ask = SparqlConstraint {
+            node: Term::NamedNode(NamedNode::new("http://example.org/c").unwrap()),
             select: "ASK { ?s ?p ?o }".to_string(),
             prefixes: String::new(),
             message: None,
@@ -1073,6 +1344,7 @@ mod tests {
         assert!(PreparedSparql::build(&ask).is_none());
         // Unparsable -> None.
         let bad = SparqlConstraint {
+            node: Term::NamedNode(NamedNode::new("http://example.org/c").unwrap()),
             select: "SELECT ??? garbage".to_string(),
             prefixes: String::new(),
             message: None,
@@ -1083,6 +1355,7 @@ mod tests {
         assert!(PreparedSparql::build(&bad).is_none());
         // Valid SELECT -> Some.
         let ok = SparqlConstraint {
+            node: Term::NamedNode(NamedNode::new("http://example.org/c").unwrap()),
             select: "SELECT ?this WHERE { ?this ?p ?o }".to_string(),
             prefixes: String::new(),
             message: None,
@@ -1244,6 +1517,7 @@ mod tests {
         let data = graph(DATA);
         let focus = Term::NamedNode(NamedNode::new("http://example.org/alice").unwrap());
         let constraint = SparqlConstraint {
+            node: Term::NamedNode(NamedNode::new("http://example.org/c").unwrap()),
             select: "SELECT ?this WHERE { SERVICE <http://example.org/remote> { ?this ?p ?o } }"
                 .to_string(),
             prefixes: String::new(),
@@ -1277,6 +1551,7 @@ mod tests {
         let focus = Term::NamedNode(NamedNode::new("http://example.org/alice").unwrap());
         // Project ?value and ?path; the constraint message references {?value}.
         let constraint = SparqlConstraint {
+            node: Term::NamedNode(NamedNode::new("http://example.org/c").unwrap()),
             select: "SELECT ?this ?value ?path WHERE { \
                        BIND(<http://example.org/bob> AS ?value) \
                        BIND(<http://example.org/knows> AS ?path) \
@@ -1299,6 +1574,7 @@ mod tests {
                 path: f.path,
                 value: f.value,
                 source_shape: focus.clone(),
+                source_constraint: None,
                 source_component: "x".to_string(),
                 severity: "x".to_string(),
                 messages: vec![],
@@ -1335,6 +1611,7 @@ mod tests {
         let data = graph("@prefix ex: <http://example.org/> . ex:alice ex:age 30 .");
         let focus = Term::NamedNode(NamedNode::new("http://example.org/alice").unwrap());
         let constraint = SparqlConstraint {
+            node: Term::NamedNode(NamedNode::new("http://example.org/c").unwrap()),
             select: "SELECT ?this ?message WHERE { ?this <http://example.org/age> ?v . \
                        BIND(\"row-level reason\" AS ?message) }"
                 .to_string(),
@@ -1355,6 +1632,7 @@ mod tests {
                 path: f.path,
                 value: f.value,
                 source_shape: focus.clone(),
+                source_constraint: None,
                 source_component: "x".to_string(),
                 severity: "x".to_string(),
                 messages: vec![],
@@ -1374,6 +1652,7 @@ mod tests {
         let data = graph("@prefix ex: <http://example.org/> . ex:alice ex:age 30 .");
         let bnode = Term::BlankNode(oxrdf::BlankNode::new("focus0").unwrap());
         let constraint = SparqlConstraint {
+            node: Term::NamedNode(NamedNode::new("http://example.org/c").unwrap()),
             select: "SELECT ?this WHERE { ?this ?p ?o }".to_string(),
             prefixes: String::new(),
             message: None,
@@ -1417,6 +1696,7 @@ mod tests {
                 path: f.path,
                 value: f.value,
                 source_shape: focus.clone(),
+                source_constraint: None,
                 source_component: "x".to_string(),
                 severity: "x".to_string(),
                 messages: vec![],
@@ -1458,6 +1738,7 @@ mod tests {
                 path: f.path,
                 value: f.value,
                 source_shape: focus.clone(),
+                source_constraint: None,
                 source_component: "x".to_string(),
                 severity: "x".to_string(),
                 messages: vec![],

--- a/crates/sparq-shacl/tests/diff_fuzz.rs
+++ b/crates/sparq-shacl/tests/diff_fuzz.rs
@@ -706,6 +706,7 @@ fn key_normalisation_is_consistent() {
             source_shape: oxrdf::Term::NamedNode(oxrdf::NamedNode::new_unchecked(
                 "http://example.org/S",
             )),
+            source_constraint: None,
             source_component: "http://www.w3.org/ns/shacl#DatatypeConstraintComponent".into(),
             severity: "http://www.w3.org/ns/shacl#Violation".into(),
             messages: vec![],

--- a/crates/sparq-shacl/tests/w3c_node_expr.rs
+++ b/crates/sparq-shacl/tests/w3c_node_expr.rs
@@ -7,6 +7,31 @@
 //! surface for the SHACL-AF node-expression algebra implemented in
 //! `sparq-shacl`'s `shacl-af` feature.
 //!
+//! ## Drives the REAL crate evaluation (sq-mue75)
+//!
+//! [OPUS-4.8] (sq-mue75) This runner drives the crate's own node-expression
+//! parse + evaluation through the public, feature-gated
+//! [`sparq_shacl::eval_node_expression`] seam — it does NOT re-implement the
+//! algebra in the harness. The crate parser now accepts both the SHACL 1.2
+//! `shnex:` and the SHACL-AF `sh:` spellings of the shared algebra (path-values /
+//! nodes / filter-shape / intersection / union), so the suite's `shnex:`-spelled
+//! expressions exercise the production code path. A previous version of this file
+//! inlined a second copy of the algebra and compared order-blind; that was a
+//! fidelity gap (it could pass while the real code was wrong), now closed.
+//!
+//! ## Order-aware comparison
+//!
+//! `mf:result` is an `rdf:list` — an ORDERED sequence. The suite's ordered
+//! operators (`concat` / `orderBy` / `limit` / `offset` / `flatMap` / a
+//! `pathValues` sequence) state a specific order, so the runner compares
+//! SEQUENCE equality (order + duplicates) first. Only when sequence equality
+//! fails does it fall back to multiset equality, recording the entry as an
+//! "order-insensitive PASS" (the set operators `union` / `intersection` /
+//! `distinct` / `instancesOf` / `nodesMatching` leave member order unspecified,
+//! so a multiset match is the correct conformance outcome for them). Both count
+//! as PASS; the split is printed so a genuine ordered-result regression is
+//! visible.
+//!
 //! ## Two gates, both opt-in
 //!
 //!   * **Feature gate** — the whole runner is `#[cfg(feature = "shacl-af")]`; with
@@ -18,25 +43,21 @@
 //!
 //! ## Scope (honest)
 //!
-//! The runner covers the **implemented algebra**: the focus-node expression, a
-//! constant, a path-values expression (`shnex:pathValues` / SHACL-AF
-//! `sh:path`+`sh:nodes`), a filter-shape expression (`shnex:filterShape` +
-//! `shnex:nodes`), and intersection / union. The suite's *function* expressions
-//! (`shnex:concat`/`sum`/`count`/`if`/`orderBy`/`limit`/`distinct`/…) need a
-//! SHACL-function registry the crate does not carry; entries using one are
-//! recorded as SKIP, not FAIL — so the gate is an honest floor over exactly what
-//! is implemented, and grows automatically when the algebra grows.
-//!
-//! The two test vocabularies are recognised interchangeably for the shared
-//! algebra: the SHACL 1.2 `shnex:` namespace the fetched suite uses, and the
-//! SHACL-AF `sh:` namespace the crate's public API speaks.
+//! The runner covers the **implemented algebra** end-to-end. The suite's
+//! `shnex:var "<name>"` entries that resolve a *test-harness* `sht:scope-<name>`
+//! binding (a conformance-suite scope-injection convention, not a SHACL feature)
+//! have no counterpart in the crate's evaluation — the crate binds only the
+//! `"focusNode"` variable — so those entries are recorded as **xfail** (a known,
+//! documented divergence, see the bead noted at [`XFAIL_VAR_SCOPE`]), not faked.
+//! Any other entry whose form the crate cannot parse is a SKIP. The gate is an
+//! honest floor over exactly what the production path evaluates.
 
 #![cfg(feature = "shacl-af")]
 
 use oxrdf::Term;
 use sparq_core::Graph;
+use sparq_shacl::eval_node_expression;
 use sparq_shacl::view::GraphView;
-use sparq_shacl::{conforms, Path};
 use std::collections::BTreeMap;
 use std::path::{Path as FsPath, PathBuf};
 
@@ -45,19 +66,31 @@ const MF: &str = "http://www.w3.org/2001/sw/DataAccess/tests/test-manifest#";
 const SHT: &str = "http://www.w3.org/ns/shacl-test#";
 const SH: &str = "http://www.w3.org/ns/shacl#";
 const SHNEX: &str = "http://www.w3.org/ns/shacl-node-expr#";
-const RDF_FIRST: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#first";
 
-/// Pass-rate floor: the number of `sht:EvalNodeExpr` entries the implemented
-/// algebra evaluates correctly at the pinned suite commit (`fetch-shacl-tests.sh`
-/// PIN). [OPUS-4.8] (sq-mk9n) The SHACL-function registry promotes the suite's
-/// *function* expressions — `concat`/`count`/`sum`/`min`/`max`/`distinct`/`if`/
-/// `exists`/`limit`/`offset`/`instancesOf`/`nodesMatching`/`flatMap`/`findFirst`/
-/// `matchAll`/`remove`/`orderBy`/`var` — from SKIP to PASS, so all 63 evaluation
-/// entries pass (the remaining 2 `constraints/` entries are `sht:Validate` tests
-/// for `sh:expression`/`sh:nodeByExpression`, a different harness, not node-expr
-/// evaluation). A regression below this floor fails the build; raising it is a
-/// deliberate bump.
-const BASELINE_PASS: usize = 63;
+/// Pass-rate floor: the number of `sht:EvalNodeExpr` entries the crate's REAL
+/// node-expression evaluation gets right at the pinned suite commit
+/// (`fetch-shacl-tests.sh` PIN). PASS = the result matches by sequence OR (for an
+/// order-insensitive set operator) by multiset. A regression below this floor
+/// fails the build; raising it is a deliberate bump.
+///
+/// [OPUS-4.8] (sq-mue75) Recalibrated when the harness moved from an inline
+/// re-implementation (set-blind) to driving `eval_node_expression`. The previous
+/// inline harness passed 63 of the runnable `sht:EvalNodeExpr` entries; the real
+/// crate path passes 62 + 1 xfail (the `shnex:var`/`sht:scope-*` harness-scope
+/// entry the crate's evaluation has no counterpart for — see [`XFAIL_VAR_SCOPE`]),
+/// so `pass + xfail` preserves the previous runnable count. The genuine crate gap
+/// surfaced by driving real code (a `sum` decimal that rendered `42` not `42.0`)
+/// was FIXED, not faked.
+const BASELINE_PASS: usize = 62;
+
+/// [OPUS-4.8] (sq-mue75) The number of `sht:EvalNodeExpr` entries that exercise
+/// the test-suite's `sht:scope-<name>` variable-injection convention (a
+/// `shnex:var "<name>"` whose value comes from a harness scope binding, not the
+/// focus node). The crate's evaluation binds only `"focusNode"`, so these are a
+/// known divergence recorded as xfail (asserted exactly so the split is
+/// documented and a change in the suite's scope-entry set is caught). Tracked for
+/// follow-up (caller-supplied node-expression variable scope).
+const XFAIL_VAR_SCOPE: usize = 1;
 
 fn suite_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -77,20 +110,45 @@ fn w3c_shacl_node_expr_suite() {
     let mut score = Scoreboard::default();
     walk_manifest(&root.join("manifest.ttl"), &root, &mut score);
 
-    let (mut pass, mut fail, mut skip) = (0, 0, 0);
+    let (mut pass, mut fail, mut skip, mut xfail) = (0, 0, 0, 0);
     println!("\nW3C SHACL node-expr suite scoreboard");
-    println!("{:<28} {:>5} {:>5} {:>5}", "group", "pass", "fail", "skip");
-    for (group, (p, f, s)) in &score.by_group {
-        println!("{group:<28} {p:>5} {f:>5} {s:>5}");
-        pass += p;
-        fail += f;
-        skip += s;
+    println!(
+        "{:<28} {:>5} {:>5} {:>6} {:>5}",
+        "group", "pass", "fail", "xfail", "skip"
+    );
+    for (group, c) in &score.by_group {
+        println!(
+            "{group:<28} {:>5} {:>5} {:>6} {:>5}",
+            c.pass, c.fail, c.xfail, c.skip
+        );
+        pass += c.pass;
+        fail += c.fail;
+        xfail += c.xfail;
+        skip += c.skip;
     }
-    println!("{:<28} {pass:>5} {fail:>5} {skip:>5}", "TOTAL");
+    println!(
+        "{:<28} {pass:>5} {fail:>5} {xfail:>6} {skip:>5}",
+        "TOTAL"
+    );
+    if !score.relaxed.is_empty() {
+        println!(
+            "\norder-insensitive PASS (matched by multiset, not sequence): {}",
+            score.relaxed.len()
+        );
+        for id in &score.relaxed {
+            println!("  {id}");
+        }
+    }
     if !score.failures.is_empty() {
         println!("\nfailing tests:");
         for (id, why) in &score.failures {
             println!("  {id}: {why}");
+        }
+    }
+    if !score.xfails.is_empty() {
+        println!("\nxfail (harness var scope — crate binds only focusNode):");
+        for id in &score.xfails {
+            println!("  {id}");
         }
     }
     if !score.skips.is_empty() {
@@ -99,34 +157,57 @@ fn w3c_shacl_node_expr_suite() {
             println!("  {id}: {why}");
         }
     }
-    assert!(
-        fail == 0,
-        "SHACL node-expr: {fail} supported-form entries produced the wrong result set"
+    assert_eq!(
+        fail, 0,
+        "SHACL node-expr: {fail} supported-form entries produced the wrong result set (real eval)"
     );
     assert!(
         pass >= BASELINE_PASS,
-        "SHACL node-expr pass count regressed: {pass} < baseline {BASELINE_PASS} (skipped {skip})"
+        "SHACL node-expr pass count regressed: {pass} < baseline {BASELINE_PASS} (xfail {xfail}, skipped {skip})"
+    );
+    assert_eq!(
+        xfail, XFAIL_VAR_SCOPE,
+        "SHACL node-expr: expected {XFAIL_VAR_SCOPE} var-scope xfail entries, found {xfail} — the harness-scope entry set changed"
     );
 }
 
 #[derive(Default)]
+struct Counts {
+    pass: usize,
+    fail: usize,
+    xfail: usize,
+    skip: usize,
+}
+
+#[derive(Default)]
 struct Scoreboard {
-    by_group: BTreeMap<String, (usize, usize, usize)>,
+    by_group: BTreeMap<String, Counts>,
     failures: Vec<(String, String)>,
+    xfails: Vec<String>,
     skips: Vec<(String, String)>,
+    /// Entries that PASSED only after relaxing sequence → multiset comparison.
+    relaxed: Vec<String>,
 }
 
 impl Scoreboard {
     fn record(&mut self, group: &str, id: &str, outcome: Outcome) {
         let e = self.by_group.entry(group.to_string()).or_default();
         match outcome {
-            Outcome::Pass => e.0 += 1,
+            Outcome::Pass => e.pass += 1,
+            Outcome::PassRelaxed => {
+                e.pass += 1;
+                self.relaxed.push(id.to_string());
+            }
             Outcome::Fail(why) => {
-                e.1 += 1;
+                e.fail += 1;
                 self.failures.push((id.to_string(), why));
             }
+            Outcome::Xfail => {
+                e.xfail += 1;
+                self.xfails.push(id.to_string());
+            }
             Outcome::Skip(why) => {
-                e.2 += 1;
+                e.skip += 1;
                 self.skips.push((id.to_string(), why));
             }
         }
@@ -135,7 +216,11 @@ impl Scoreboard {
 
 enum Outcome {
     Pass,
+    /// Matched by multiset (order-insensitive operator) — a PASS, tracked apart.
+    PassRelaxed,
     Fail(String),
+    /// A known divergence (harness `sht:scope-*` variable injection).
+    Xfail,
     Skip(String),
 }
 
@@ -224,475 +309,89 @@ fn run_entry(g: &Graph, view: &GraphView, entry: &Term) -> Outcome {
         .object(&action, &format!("{SHT}focusNode"))
         .unwrap_or_else(|| iri("urn:x-sparq:no-focus"));
 
-    let mut ev = Evaluator {
-        g,
-        view,
-        action: action.clone(),
-    };
-    let actual = match ev.eval(&expr, &focus) {
+    // A `shnex:var "<name>"` that resolves a harness `sht:scope-<name>` binding is
+    // a conformance-suite scope-injection convention with no crate counterpart
+    // (the crate binds only the focus node), so record it as a known xfail rather
+    // than faking the scope. Detected structurally on the expression tree.
+    if uses_harness_scope_var(view, &action, &expr) {
+        return Outcome::Xfail;
+    }
+
+    // Drive the crate's REAL parse + evaluation. The test graph is both the data
+    // and the shapes graph (the suite declares filter shapes inline).
+    let actual = match eval_node_expression(g, g, &expr, &focus) {
         Some(v) => v,
-        None => return Outcome::Skip("unsupported node-expression form".into()),
+        None => return Outcome::Skip("crate could not parse the node expression".into()),
     };
 
     let expected = match view.object(entry, &format!("{MF}result")) {
         Some(list) => view.list(&list),
         None => return Outcome::Skip("no mf:result".into()),
     };
-    if set_eq(&actual, &expected) {
+    if seq_eq(&actual, &expected) {
         Outcome::Pass
+    } else if multiset_eq(&actual, &expected) {
+        Outcome::PassRelaxed
     } else {
         Outcome::Fail(format!("expected {expected:?}, got {actual:?}"))
     }
 }
 
-/// Multiset-as-set equality (node-expression results are sets): same distinct
-/// terms, ignoring order and duplicates.
-fn set_eq(a: &[Term], b: &[Term]) -> bool {
-    let sa: std::collections::HashSet<&Term> = a.iter().collect();
-    let sb: std::collections::HashSet<&Term> = b.iter().collect();
-    sa == sb
-}
-
-/// A node-expression evaluator over the test graph, recognising both the
-/// SHACL-AF `sh:` and the SHACL 1.2 `shnex:` spellings of the implemented
-/// algebra. Returns `None` for any unsupported form (function expressions, …)
-/// so the caller records a SKIP rather than a FAIL.
-struct Evaluator<'a> {
-    g: &'a Graph,
-    view: &'a GraphView<'a>,
-    /// The entry's `mf:action` node — carries the test-suite variable scope
-    /// (`sht:scope-<name>` bindings) a `shnex:var "<name>"` expression resolves.
-    action: Term,
-}
-
-impl Evaluator<'_> {
-    fn eval(&mut self, expr: &Term, focus: &Term) -> Option<Vec<Term>> {
-        match expr {
-            // Focus-node expression.
-            Term::NamedNode(n) if n.as_str() == format!("{SH}this") => Some(vec![focus.clone()]),
-            // Constant.
-            Term::NamedNode(_) | Term::Literal(_) => Some(vec![expr.clone()]),
-            Term::BlankNode(_) => self.eval_blank(expr, focus),
-            #[allow(unreachable_patterns)]
-            _ => None,
+/// Does the expression (transitively) use a `shnex:var "<name>"` whose value is a
+/// harness `sht:scope-<name>` binding on the action (i.e. not `"focusNode"`)?
+fn uses_harness_scope_var(view: &GraphView, action: &Term, expr: &Term) -> bool {
+    // Bounded structural walk over the blank-node expression tree.
+    fn walk(view: &GraphView, action: &Term, node: &Term, depth: usize) -> bool {
+        if depth > 64 {
+            return false;
         }
-    }
-
-    fn eval_blank(&mut self, expr: &Term, focus: &Term) -> Option<Vec<Term>> {
-        // An empty blank node `[]` (no predicates at all) is the EMPTY node
-        // expression — it evaluates to the empty set (so `count []` ⇒ 0,
-        // `exists []` ⇒ false, `min []` ⇒ ()), NOT an unsupported form.
-        if self.view.predicate_objects(expr).is_empty() {
-            return Some(Vec::new());
-        }
-        // shnex *list expression* (SHACL 1.2): a bare rdf:list whose members are
-        // the result node set. This is the SHACL-1.2 input form the suite uses to
-        // feed filter / intersection / union member sets; the crate's SHACL-AF API
-        // has no list-construction expression, but the harness bridges 1.2, so we
-        // evaluate a list head to the set of its members (each itself an expr).
-        if self.view.object(expr, RDF_FIRST).is_some() {
-            let members = self.view.list(expr);
-            let mut out = Vec::new();
-            for m in &members {
-                out.extend(self.eval(m, focus)?);
-            }
-            // A SHACL list expression evaluates to its members in order, preserving
-            // DUPLICATES (a sequence, not a set) — `count`/`concat`/`sum` observe the
-            // multiset; set-valued consumers dedup themselves.
-            return Some(out);
-        }
-        // Path-values expression: shnex:pathValues P (P a property path), with the
-        // start node from shnex:focusNode (a node expression; default = focus).
-        if let Some(p) = pred_object(self.view, expr, "pathValues").or_else(|| {
-            // SHACL-AF spelling: [ sh:path P ; sh:nodes N ].
-            pred_object_ns(self.view, expr, SH, "path")
-        }) {
-            let path = Path::parse(self.view, &p).ok()?;
-            let starts = self.start_nodes(expr, focus)?;
-            return Some(dedup(
-                starts
-                    .iter()
-                    .flat_map(|s| path.values(self.view, s))
-                    .collect(),
-            ));
-        }
-        // Filter-shape expression.
-        if let Some(shape) = pred_object(self.view, expr, "filterShape") {
-            let nodes = self.nodes_input(expr, focus)?;
-            // Build the shapes graph view = the whole test graph (filter shapes are
-            // declared inline as sh:NodeShape) and check conformance per node.
-            let chk = conforms(self.g, self.g, &shape);
-            return Some(nodes.into_iter().filter(|n| chk.holds(n)).collect());
-        }
-        // Intersection / union: a SHACL list of member expressions.
-        for pred in ["intersection", "union"] {
-            if let Some(list) = pred_object(self.view, expr, pred) {
-                let members = self.view.list(&list);
-                let mut sets: Vec<Vec<Term>> = Vec::with_capacity(members.len());
-                for m in &members {
-                    sets.push(self.eval(m, focus)?);
-                }
-                return Some(if pred == "union" {
-                    dedup(sets.into_iter().flatten().collect())
-                } else {
-                    intersect(sets)
-                });
-            }
-        }
-        // [OPUS-4.8] (sq-mk9n) Function-expression operators (SHACL-function
-        // registry). Mirror the crate's `func` registry so the conformance gate is
-        // an end-to-end check of the same algebra.
-        self.eval_func(expr, focus)
-    }
-
-    /// The SHACL 1.2 / SHACL-AF built-in node-expression *function* operators —
-    /// the registry the `sh:`/`shnex:` namespaces spell as predicate-named
-    /// functions (sq-mk9n). Returns `None` for an operator this harness does not
-    /// implement (e.g. `var "bound"`, which needs a caller-supplied scope), so the
-    /// runner records SKIP not FAIL.
-    fn eval_func(&mut self, expr: &Term, focus: &Term) -> Option<Vec<Term>> {
-        // concat ( E1 E2 … ) — members of each argument, in order, NO dedup.
-        if let Some(list) = pred_object(self.view, expr, "concat") {
-            let mut out = Vec::new();
-            for m in &self.view.list(&list) {
-                out.extend(self.eval(m, focus)?);
-            }
-            return Some(out);
-        }
-        // count E — count of the input node set as xsd:integer.
-        if let Some(arg) = pred_object(self.view, expr, "count") {
-            return Some(vec![int_lit(self.eval(&arg, focus)?.len() as i128)]);
-        }
-        // sum E — numeric sum (empty ⇒ 0; integer-typed stays integer).
-        if let Some(arg) = pred_object(self.view, expr, "sum") {
-            return Some(vec![sum_lit(&self.eval(&arg, focus)?)]);
-        }
-        // min / max E.
-        for (op, max) in [("min", false), ("max", true)] {
-            if let Some(arg) = pred_object(self.view, expr, op) {
-                return Some(min_max(&self.eval(&arg, focus)?, max).into_iter().collect());
-            }
-        }
-        // distinct E — dedup by term equality.
-        if let Some(arg) = pred_object(self.view, expr, "distinct") {
-            return Some(dedup(self.eval(&arg, focus)?));
-        }
-        // exists E — { true } if Eval(E) non-empty else { false }.
-        if let Some(arg) = pred_object(self.view, expr, "exists") {
-            return Some(vec![bool_lit(!self.eval(&arg, focus)?.is_empty())]);
-        }
-        // if C ; then T ; else U?.
-        if let Some(cond) = pred_object(self.view, expr, "if") {
-            let is_true = is_true_set(&self.eval(&cond, focus)?);
-            if is_true {
-                return self.eval(&pred_object(self.view, expr, "then")?, focus);
-            }
-            return match pred_object(self.view, expr, "else") {
-                Some(e) => self.eval(&e, focus),
-                None => Some(Vec::new()),
-            };
-        }
-        // instancesOf C.
-        if let Some(class) = pred_object(self.view, expr, "instancesOf") {
-            return Some(self.view.instances_of(&class));
-        }
-        // nodesMatching S — graph nodes conforming to shape S.
-        if let Some(shape) = pred_object(self.view, expr, "nodesMatching") {
-            let chk = conforms(self.g, self.g, &shape);
-            return Some(
-                candidate_nodes(self.view)
-                    .into_iter()
-                    .filter(|n| chk.holds(n))
-                    .collect(),
-            );
-        }
-        // nodes N ; flatMap E — rebind focus to each n, concat (NO dedup).
-        if let Some(body) = pred_object(self.view, expr, "flatMap") {
-            let nodes = self.nodes_input(expr, focus)?;
-            let mut out = Vec::new();
-            for n in &nodes {
-                out.extend(self.eval(&body, n)?);
-            }
-            return Some(out);
-        }
-        // findFirst S ; nodes N — first node of N conforming to S.
-        if let Some(shape) = pred_object(self.view, expr, "findFirst") {
-            let nodes = self.nodes_input(expr, focus)?;
-            let chk = conforms(self.g, self.g, &shape);
-            return Some(
-                nodes
-                    .into_iter()
-                    .find(|n| chk.holds(n))
-                    .into_iter()
-                    .collect(),
-            );
-        }
-        // matchAll S ; nodes N — { true } iff every node of N conforms to S.
-        if let Some(shape) = pred_object(self.view, expr, "matchAll") {
-            let nodes = self.nodes_input(expr, focus)?;
-            let chk = conforms(self.g, self.g, &shape);
-            return Some(vec![bool_lit(nodes.iter().all(|n| chk.holds(n)))]);
-        }
-        // remove R ; nodes N — N minus members of R (term equality).
-        if let Some(removed) = pred_object(self.view, expr, "remove") {
-            let nodes = self.nodes_input(expr, focus)?;
-            let drop: std::collections::HashSet<Term> =
-                self.eval(&removed, focus)?.into_iter().collect();
-            return Some(nodes.into_iter().filter(|n| !drop.contains(n)).collect());
-        }
-        // nodes N ; orderBy K ; desc? — sort N by least key value.
-        if let Some(key) = pred_object(self.view, expr, "orderBy") {
-            let mut nodes = self.nodes_input(expr, focus)?;
-            let desc = matches!(pred_object(self.view, expr, "desc"),
-                Some(Term::Literal(l)) if l.value() == "true");
-            // Precompute keys (eval cannot be called inside sort_by's closure as it
-            // needs &mut self); collect (node, key) pairs first.
-            let mut keyed: Vec<(Term, Vec<Term>)> = Vec::with_capacity(nodes.len());
-            for n in nodes.drain(..) {
-                let k = self.eval(&key, &n)?;
-                keyed.push((n, k));
-            }
-            keyed.sort_by(|a, b| {
-                let ord = cmp_key(&a.1, &b.1);
-                if desc {
-                    ord.reverse()
-                } else {
-                    ord
-                }
-            });
-            return Some(keyed.into_iter().map(|(n, _)| n).collect());
-        }
-        // nodes N ; limit k / offset k.
-        if pred_object(self.view, expr, "limit").is_some()
-            || pred_object(self.view, expr, "offset").is_some()
+        if let Some(Term::Literal(name)) = view
+            .object(node, &format!("{SHNEX}var"))
+            .or_else(|| view.object(node, &format!("{SH}var")))
         {
-            let nodes = self.nodes_input(expr, focus)?;
-            let offset = int_arg(self.view, expr, "offset").unwrap_or(0).max(0) as usize;
-            let limit = int_arg(self.view, expr, "limit").map(|k| k.max(0) as usize);
-            let it = nodes.into_iter().skip(offset);
-            return Some(match limit {
-                Some(k) => it.take(k).collect(),
-                None => it.collect(),
-            });
-        }
-        // var "name" — "focusNode" ⇒ the focus; a test-suite `sht:scope-<name>`
-        // binding ⇒ its value; any other (unbound) name ⇒ the empty set.
-        if let Some(Term::Literal(name)) = pred_object(self.view, expr, "var") {
-            if name.value() == "focusNode" {
-                return Some(vec![focus.clone()]);
+            if name.value() != "focusNode" {
+                let scope_pred = format!("{SHT}scope-{}", name.value());
+                if view.object(action, &scope_pred).is_some() {
+                    return true;
+                }
             }
-            let scope_pred = format!("{SHT}scope-{}", name.value());
-            if let Some(bound) = self.view.object(&self.action, &scope_pred) {
-                return Some(vec![bound]);
+        }
+        // Descend into every object of this node (operands, list members).
+        for (_, o) in view.predicate_objects(node) {
+            if matches!(o, Term::BlankNode(_)) && walk(view, action, &o, depth + 1) {
+                return true;
             }
-            return Some(Vec::new());
         }
-        None // unsupported form (custom SPARQLFunction without decl, …)
+        false
     }
-
-    /// The `shnex:focusNode` / SHACL-AF `sh:nodes` start-node expression of a path
-    /// expression, defaulting to the focus node.
-    fn start_nodes(&mut self, expr: &Term, focus: &Term) -> Option<Vec<Term>> {
-        match pred_object(self.view, expr, "focusNode")
-            .or_else(|| pred_object_ns(self.view, expr, SH, "nodes"))
-        {
-            Some(n) => self.eval(&n, focus),
-            None => Some(vec![focus.clone()]),
-        }
-    }
-
-    /// The `shnex:nodes` / `sh:nodes` input expression of a filter expression.
-    fn nodes_input(&mut self, expr: &Term, focus: &Term) -> Option<Vec<Term>> {
-        let n = pred_object(self.view, expr, "nodes")?;
-        self.eval(&n, focus)
-    }
+    walk(view, action, expr, 0)
 }
 
-/// First object of `subject <ns#local>` trying the `shnex:` namespace first then
-/// `sh:` (the two vocabularies share local names for the shared algebra).
-fn pred_object(view: &GraphView, subject: &Term, local: &str) -> Option<Term> {
-    pred_object_ns(view, subject, SHNEX, local).or_else(|| pred_object_ns(view, subject, SH, local))
+/// Sequence equality: same terms, same order, duplicates significant.
+fn seq_eq(a: &[Term], b: &[Term]) -> bool {
+    a == b
 }
 
-fn pred_object_ns(view: &GraphView, subject: &Term, ns: &str, local: &str) -> Option<Term> {
-    view.object(subject, &format!("{ns}{local}"))
-}
-
-fn intersect(mut sets: Vec<Vec<Term>>) -> Vec<Term> {
-    let Some(first) = sets.first().cloned() else {
-        return Vec::new();
-    };
-    let mut acc = dedup(first);
-    for s in sets.drain(1..) {
-        let other: std::collections::HashSet<Term> = s.into_iter().collect();
-        acc.retain(|t| other.contains(t));
+/// Multiset equality: same terms with the same multiplicities, order ignored.
+fn multiset_eq(a: &[Term], b: &[Term]) -> bool {
+    if a.len() != b.len() {
+        return false;
     }
-    acc
+    let mut counts: BTreeMap<String, i64> = BTreeMap::new();
+    for t in a {
+        *counts.entry(key(t)).or_default() += 1;
+    }
+    for t in b {
+        *counts.entry(key(t)).or_default() -= 1;
+    }
+    counts.values().all(|&c| c == 0)
 }
 
-fn dedup(items: Vec<Term>) -> Vec<Term> {
-    let mut seen = std::collections::HashSet::new();
-    let mut out = Vec::new();
-    for t in items {
-        if seen.insert(t.clone()) {
-            out.push(t);
-        }
-    }
-    out
+/// A stable string key for multiset bookkeeping (term Debug is stable per kind).
+fn key(t: &Term) -> String {
+    format!("{:?}", t)
 }
 
 fn iri(s: &str) -> Term {
     Term::NamedNode(oxrdf::NamedNode::new_unchecked(s))
-}
-
-// ---- [OPUS-4.8] (sq-mk9n) function-operator helpers (mirror crate `func`) ----
-
-const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
-
-/// An integer argument of `subject <ns#local>` (in either namespace).
-fn int_arg(view: &GraphView, subject: &Term, local: &str) -> Option<i64> {
-    match pred_object(view, subject, local) {
-        Some(Term::Literal(l)) => l.value().trim().parse::<i64>().ok(),
-        _ => None,
-    }
-}
-
-/// The candidate node set of the graph for `nodesMatching`: every non-literal
-/// subject / object, deduplicated.
-fn candidate_nodes(view: &GraphView) -> Vec<Term> {
-    let mut out = Vec::new();
-    for [s, _, o] in view.triples(None, None, None) {
-        if !matches!(s, Term::Literal(_)) {
-            out.push(s);
-        }
-        if !matches!(o, Term::Literal(_)) {
-            out.push(o);
-        }
-    }
-    dedup(out)
-}
-
-fn is_true_set(set: &[Term]) -> bool {
-    set.len() == 1
-        && matches!(&set[0], Term::Literal(l)
-            if l.datatype().as_str() == format!("{XSD}boolean") && l.value() == "true")
-}
-
-fn numeric(t: &Term) -> Option<f64> {
-    match t {
-        Term::Literal(l) if is_numeric(l.datatype().as_str()) => l.value().trim().parse().ok(),
-        _ => None,
-    }
-}
-
-fn is_numeric(dt: &str) -> bool {
-    let Some(local) = dt.strip_prefix(XSD) else {
-        return false;
-    };
-    matches!(
-        local,
-        "integer" | "decimal" | "double" | "float" | "long" | "int" | "short" | "byte"
-    )
-}
-
-fn is_integer_typed(t: &Term) -> bool {
-    matches!(t, Term::Literal(l) if matches!(
-        l.datatype().as_str().strip_prefix(XSD),
-        Some("integer" | "long" | "int" | "short" | "byte")
-    ))
-}
-
-fn int_lit(n: i128) -> Term {
-    Term::Literal(oxrdf::Literal::new_typed_literal(
-        n.to_string(),
-        oxrdf::NamedNode::new_unchecked(format!("{XSD}integer")),
-    ))
-}
-
-fn bool_lit(b: bool) -> Term {
-    Term::Literal(oxrdf::Literal::new_typed_literal(
-        if b { "true" } else { "false" },
-        oxrdf::NamedNode::new_unchecked(format!("{XSD}boolean")),
-    ))
-}
-
-fn sum_lit(vals: &[Term]) -> Term {
-    let mut total = 0.0_f64;
-    let mut all_int = true;
-    for v in vals {
-        if let Some(n) = numeric(v) {
-            total += n;
-            all_int &= is_integer_typed(v);
-        }
-    }
-    if all_int && total.fract() == 0.0 {
-        int_lit(total as i128)
-    } else {
-        Term::Literal(oxrdf::Literal::new_typed_literal(
-            decimal_lexical(total),
-            oxrdf::NamedNode::new_unchecked(format!("{XSD}decimal")),
-        ))
-    }
-}
-
-/// A valid `xsd:decimal` lexical form — always carries a fractional part
-/// (`42` ⇒ `42.0`) so an integer-valued decimal is still spelled as a decimal.
-fn decimal_lexical(v: f64) -> String {
-    let s = format!("{v}");
-    if s.contains('.') {
-        s
-    } else {
-        format!("{s}.0")
-    }
-}
-
-fn min_max(vals: &[Term], max: bool) -> Option<Term> {
-    let mut best: Option<(f64, Term)> = None;
-    for v in vals {
-        let Some(n) = numeric(v) else { continue };
-        let take = match &best {
-            None => true,
-            Some((b, _)) => {
-                if max {
-                    n > *b
-                } else {
-                    n < *b
-                }
-            }
-        };
-        if take {
-            best = Some((n, v.clone()));
-        }
-    }
-    best.map(|(_, t)| t)
-}
-
-fn cmp_key(a: &[Term], b: &[Term]) -> std::cmp::Ordering {
-    use std::cmp::Ordering;
-    let la = a.iter().min_by(|x, y| cmp_term(x, y));
-    let lb = b.iter().min_by(|x, y| cmp_term(x, y));
-    match (la, lb) {
-        (None, None) => Ordering::Equal,
-        (None, Some(_)) => Ordering::Less,
-        (Some(_), None) => Ordering::Greater,
-        (Some(x), Some(y)) => cmp_term(x, y),
-    }
-}
-
-fn cmp_term(a: &Term, b: &Term) -> std::cmp::Ordering {
-    use std::cmp::Ordering;
-    if let (Some(na), Some(nb)) = (numeric(a), numeric(b)) {
-        return na.partial_cmp(&nb).unwrap_or(Ordering::Equal);
-    }
-    lexical(a).cmp(&lexical(b))
-}
-
-fn lexical(t: &Term) -> String {
-    match t {
-        Term::NamedNode(n) => n.as_str().to_string(),
-        Term::Literal(l) => l.value().to_string(),
-        Term::BlankNode(b) => b.as_str().to_string(),
-        #[allow(unreachable_patterns)]
-        _ => String::new(),
-    }
 }

--- a/crates/sparq-shacl/tests/w3c_sparql_shacl12.rs
+++ b/crates/sparq-shacl/tests/w3c_sparql_shacl12.rs
@@ -66,7 +66,14 @@ const SH: &str = "http://www.w3.org/ns/shacl#";
 /// `sh:values [ sh:select / sh:sparqlExpr ]` (`property/property-select-001`,
 /// `property/property-sparqlExpr-001`), and constraint-level `sh:severity`
 /// (`node/sparql-001`) — now PASS.
-const BASELINE_PASS: usize = 14;
+///
+/// [OPUS-4.8] (sq-mue75) Raised 14 → 17: the three remaining `pre-binding/`
+/// entries — pre-binding-002 (pre-binding into both UNION branches),
+/// pre-binding-005 (into a sibling Join block) and pre-binding-007 (through a
+/// sub-SELECT projection) — now PASS via the extended `push_values_down`
+/// propagation. (The 6 `sh:sparql`-result entries are also now verified for
+/// `sh:sourceConstraint`.)
+const BASELINE_PASS: usize = 17;
 
 /// Gap-ceiling: the count of entries this crate does NOT yet get right — the sum
 /// of strict-comparison FAILs and the `sht:Failure` ExpectedFailure entries (the
@@ -75,9 +82,13 @@ const BASELINE_PASS: usize = 14;
 /// drops it (bump down).
 ///
 /// [OPUS-4.8] (sq-rnkdh) Lowered 14 → 10: the 4 entries above moved FAIL → PASS.
-/// The remaining 10 are 3 `pre-binding/` FAILs + the 7 `sht:Failure`
+/// The remaining 10 were 3 `pre-binding/` FAILs + the 7 `sht:Failure`
 /// ExpectedFailure entries (the rejection channel is still unbuilt).
-const BASELINE_GAP: usize = 10;
+///
+/// [OPUS-4.8] (sq-mue75) Lowered 10 → 7: the 3 `pre-binding/` FAILs moved
+/// FAIL → PASS, leaving only the 7 `sht:Failure` ExpectedFailure entries (the
+/// rejection channel is still unbuilt — the gap now equals `EXPECTED_FAILURE_COUNT`).
+const BASELINE_GAP: usize = 7;
 
 /// Of [`BASELINE_GAP`], the count attributable to the unbuilt rejection channel
 /// (`mf:result sht:Failure`). Asserted exactly so the scoreboard documents the
@@ -380,6 +391,9 @@ struct Expected {
     severity: Option<String>,
     component: Option<String>,
     source_shape: Option<Term>,
+    /// [OPUS-4.8] (sq-mue75) `sh:sourceConstraint` — the `sh:SPARQLConstraint`
+    /// node the result must point at (only `sh:sparql` results carry it).
+    source_constraint: Option<Term>,
     messages: Vec<Term>,
 }
 
@@ -406,6 +420,7 @@ impl Expected {
                 _ => None,
             },
             source_shape: view.object(node, &format!("{SH}sourceShape")),
+            source_constraint: view.object(node, &format!("{SH}sourceConstraint")),
             messages: view.objects(node, &format!("{SH}resultMessage")),
         })
     }
@@ -440,6 +455,14 @@ impl Expected {
         if let Some(s) = &self.source_shape {
             if !term_matches(s, &a.source_shape) {
                 return false;
+            }
+        }
+        // [OPUS-4.8] (sq-mue75) when the expected report states an
+        // `sh:sourceConstraint`, the actual result must carry the same node.
+        if let Some(sc) = &self.source_constraint {
+            match &a.source_constraint {
+                Some(asc) if term_matches(sc, asc) => {}
+                _ => return false,
             }
         }
         let actual_messages = a.effective_messages();

--- a/research/shacl12-conformance-gap.md
+++ b/research/shacl12-conformance-gap.md
@@ -29,9 +29,9 @@ comparison as `w3c_core.rs` — `sh:conforms` must match and the
 
 | Runner (`crates/sparq-shacl/tests/`) | Manifest tree | Entries | PASS (default / `shacl-af`) | Gap |
 | --- | --- | --- | --- | --- |
-| `w3c_core_full_shacl12.rs` | `core/manifest.ttl` (all 7 categories) | 137 | **114 / 115** | 22 FAIL (+ 1 SKIP default) |
-| `w3c_sparql_shacl12.rs` | `sparql/manifest.ttl` | 24 | **10 / 10** | 7 FAIL + 7 expected-failure |
-| `w3c_node_expr.rs` + `w3c_node_expr_constraints.rs` | `node-expr/` | 65 | **— / 65** | 0 (the node-expr runners are `#[cfg(feature = "shacl-af")]`) |
+| `w3c_core_full_shacl12.rs` | `core/manifest.ttl` (all 7 categories) | 137 | **129 / 130** | 7 FAIL (+ 1 SKIP default) |
+| `w3c_sparql_shacl12.rs` | `sparql/manifest.ttl` | 24 | **17 / 17** | 0 FAIL + 7 expected-failure (sq-mue75 closed the 3 pre-binding FAILs) |
+| `w3c_node_expr.rs` + `w3c_node_expr_constraints.rs` | `node-expr/` | 65 | **— / 62 + 1 xfail** | the xfail is the harness `sht:scope-*` var entry (sq-mue75 drives the REAL `eval_node_expression`; `shacl-af`) |
 
 The two runners that gate `core` and `sparql` are NOT feature-gated as a whole —
 they run in both states. The `shacl-af`-only delta in `core` is one entry
@@ -103,7 +103,7 @@ PASS) and asserts there are exactly 7 of them.
 | 14 | SPARQL constraint result detail | `sparql/node/sparql-001`, `sparql/property/property-select-001` | `sh:select` constraint result message / count detail | `sq-rnkdh` |
 | 15 | `sh:sparqlExpr` value-expression constraint | `sparql/property/property-sparqlExpr-001` | SPARQL-expression-valued property constraint | `sq-rnkdh` |
 | 16 | SPARQL `sh:target` (targetNode-select) | `sparql/targets/targetNode-select-001` | SPARQL-based target | `sq-rnkdh` |
-| 17 | Pre-binding VALUES propagation | `sparql/pre-binding/pre-binding-002`, `pre-binding-005`, `pre-binding-007` | the full pre-binding algebra-rewrite (UNION / sibling / sub-SELECT scope) | `sq-mue75` |
+| 17 | Pre-binding VALUES propagation — **DONE (sq-mue75)** | `sparql/pre-binding/pre-binding-002`, `pre-binding-005`, `pre-binding-007` | the pre-binding algebra-rewrite (UNION / sibling / sub-SELECT scope) — now PASS | `sq-mue75` |
 | 18 | Pre-binding **rejection** channel (`sht:Failure`) | `sparql/pre-binding/pre-binding-006`, `unsupported-sparql-001..006` (7) | a query that re-binds a pre-bound variable, or uses unsupported `MINUS`/`SERVICE`, MUST be rejected — the crate has no failure channel | `sq-0mjfd` |
 
 ### Per-category SPARQL scoreboard
@@ -111,11 +111,14 @@ PASS) and asserts there are exactly 7 of them.
 | category | pass | fail | xfail | skip |
 | --- | ---: | ---: | ---: | ---: |
 | component | 3 | 0 | 0 | 0 |
-| node | 3 | 1 | 0 | 0 |
-| pre-binding | 3 | 3 | 7 | 0 |
-| property | 1 | 2 | 0 | 0 |
-| targets | 0 | 1 | 0 | 0 |
-| **TOTAL** | **10** | **7** | **7** | **0** |
+| node | 4 | 0 | 0 | 0 |
+| pre-binding | 6 | 0 | 7 | 0 |
+| property | 3 | 0 | 0 | 0 |
+| targets | 1 | 0 | 0 | 0 |
+| **TOTAL** | **17** | **0** | **7** | **0** |
+
+(Post-sq-mue75 / sq-rnkdh: the only remaining SPARQL gap is the 7 `sht:Failure`
+expected-rejection entries — the rejection channel is unbuilt, cluster 18 / `sq-0mjfd`.)
 
 ---
 

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -141,6 +141,7 @@ pub focus_node: oxrdf::Term;
 pub path: Option<sparq_shacl::Path>;        // sh:resultPath (property shapes / sh:closed)
 pub value: Option<oxrdf::Term>;             // offending value node
 pub source_shape: oxrdf::Term;
+pub source_constraint: Option<oxrdf::Term>; // sh:sourceConstraint — the sh:SPARQLConstraint node (sh:sparql results only; None for Core + §6 components)
 pub source_component: String;               // constraint-component IRI, e.g. ".../MinCountConstraintComponent"
 pub severity: String;                       // severity IRI (default ".../shacl#Violation")
 pub messages: Vec<oxrdf::Term>;             // sh:message literals
@@ -403,13 +404,14 @@ semantics are gated even when the suite is absent. The SCS parser's fail-closed
 error paths and the SHACL-SPARQL §5.2/§6 edge cases get the same treatment
 (`tests/scs_error_paths.rs` under `scs`, `tests/sparql_edge_cases.rs`). The
 pre-binding's deep-algebra arms (`push_values_down` over Group / Slice / Distinct /
-Reduced / OrderBy / Minus-left / LeftJoin-left) and the fail-closed runtime-error
-paths (an inexpressible blank-node focus, a `SERVICE`-clause runtime query error) are
-pinned directly by the in-`src/sparql.rs` unit module (`sparql::tests`, sq-qcnn.1):
-each modifier arm is asserted both structurally (the `VALUES` table lands BELOW the
-modifier at the deepest leaf, so `$this`/`$value`/`$param` stays in scope) and
-semantically (a real validator over real data yields the SHACL-spec-correct
-conforms/violations).
+Reduced / OrderBy / Minus-left / LeftJoin-left, plus the multi-scope arms — both
+UNION branches, sibling joins, and a projecting sub-SELECT, sq-mue75) and the
+fail-closed runtime-error paths (an inexpressible blank-node focus, a `SERVICE`-clause
+runtime query error) are pinned directly by the in-`src/sparql.rs` unit module
+(`sparql::tests`, sq-qcnn.1 / sq-mue75): each arm is asserted both structurally (the
+`VALUES` table lands BELOW the modifier / inside every branch so `$this`/`$value`/
+`$param` stays in scope) and semantically (a real validator over real data yields the
+SHACL-spec-correct conforms/violations).
 
 ## Gotchas / feature flags / prerequisites
 
@@ -460,20 +462,27 @@ conforms/violations).
   counts as conforming (SHACL leaves recursion undefined); cyclic `sh:node`/`sh:property`
   terminate without stack overflow.
 - **`sh:sparql` pre-binding:** `$this` (and `$PATH` on property shapes) is injected via
-  an algebra-level VALUES on the parsed query — it lands below solution modifiers, so
-  `LIMIT`/`ORDER BY`/`DISTINCT`/`SELECT *` behave correctly. `sh:prefixes` chases
-  `sh:declare`(`sh:prefix`/`sh:namespace`) transitively through `owl:imports`.
+  an algebra-level VALUES on the parsed query — it lands below solution modifiers (so
+  `LIMIT`/`ORDER BY`/`DISTINCT` behave correctly) AND propagates into every scope the
+  variable can reach: both UNION branches, sibling joins, and a sub-SELECT that
+  explicitly projects the variable (sq-mue75). A `SELECT *` sub-select re-scopes the
+  variable, so the VALUES is joined above it (the spec-rejection case). Each `sh:sparql`
+  result carries `sh:sourceConstraint` (the `sh:SPARQLConstraint` node).  `sh:prefixes`
+  chases `sh:declare`(`sh:prefix`/`sh:namespace`) transitively through `owl:imports`.
 - **§6 limits:** the W3C `sparql/component/*` suite `owl:imports` the external
   `http://datashapes.org/dash` vocabulary; it is run offline (`tests/w3c_sparql_component.rs`)
   by resolving that import against a vendored, minimal pinned excerpt at
-  `crates/sparq-shacl/tests/vendor/dash.ttl`. Full `sparql/pre-binding` semantics (rejecting
-  variable re-binding, `$shapesGraph`) are out of scope — see the crate's open beads (`bd list -l area:sparq-shacl`).
+  `crates/sparq-shacl/tests/vendor/dash.ttl`. Still out of scope: the `sparql/pre-binding`
+  *rejection* channel (signalling a failure for a re-binding / `SELECT *` sub-select) and
+  `$shapesGraph` — see the crate's open beads (`bd list -l area:sparq-shacl`).
 - **W3C conformance:** 98/98 of the *1.0/1.1* core `sht:Validate` suite passes
   (`--test w3c_core`). The **full vendored SHACL 1.2** tree is gated by a ratchet
-  (sq-6glcr) in BOTH feature states: full core **114/115** of 137
-  (`--test w3c_core_full_shacl12`), 1.2 SPARQL **10** of 24 incl. 7 expected-rejection
-  `sht:Failure` entries (`--test w3c_sparql_shacl12`), node-expr **65/65**
-  (`--test w3c_node_expr{,_constraints}`, `shacl-af`). Pass must not drop, the gap must
+  (sq-6glcr) in BOTH feature states: full core **129** (default) / **130** (`shacl-af`)
+  (`--test w3c_core_full_shacl12`), 1.2 SPARQL **17** of 24 incl. 7 expected-rejection
+  `sht:Failure` entries (`--test w3c_sparql_shacl12`), node-expr **62 + 1 xfail**
+  (driven through the REAL `eval_node_expression`, `--test w3c_node_expr`, `shacl-af`;
+  the xfail is the harness `sht:scope-*` var entry the crate's eval has no counterpart
+  for). Pass must not drop, the gap must
   not grow — the not-yet-passing entries are the honest per-category gap map in
   `research/shacl12-conformance-gap.md` (clustered into beads sq-sx15d / sq-rnkdh /
   sq-mue75 / sq-0mjfd under epic sq-waf9o). Reproduce with


### PR DESCRIPTION
> 🤖 **SPARQ agent**

Implements **sq-mue75** (epic sq-waf9o): SHACL-SPARQL 1.2 pre-binding propagation, `sh:sourceConstraint`, and node-expression harness fidelity in `crates/sparq-shacl/`.

## PRIMARY — pre-binding VALUES propagation (`src/sparql.rs::push_values_down`)
SHACL-SPARQL pre-binds the focus node (`$this`/`$value`/`$PATH`) by injecting a `VALUES` block that must reach the leaf graph patterns. The old descent followed a single chain; it now propagates into **every scope the variable can reach**:
- **UNION** — into BOTH branches independently.
- **sibling Join** — into BOTH children (a `{ FILTER(bound($this)) }` sibling over an empty inner now sees the binding).
- **sub-SELECT `Project`** — through the projection when the variable is explicitly projected; a `SELECT *` (empty projection list) re-scopes it, so the VALUES is joined ABOVE (the spec-rejection case). `GRAPH` blocks are descended too.

Makes these vendored W3C `shacl12-test-suite/tests/sparql/pre-binding` entries PASS via the **real** `validate()`:
- `pre-binding-002` (UNION), `pre-binding-005` (sibling Join/BGP+FILTER), `pre-binding-007` (nested SELECT projecting `$this`).

## SECONDARY — `sh:sourceConstraint` (`src/eval.rs`, `report.rs`, `model.rs`)
`sh:sparql` results now carry `sh:sourceConstraint` = the `sh:SPARQLConstraint` node (distinct from `sh:sourceShape`), per SHACL §5.2.2, emitted in the Turtle report. Core constraints and §6 SPARQL-based **components** carry `None` (the spec omits it there). The shacl12 SPARQL harness now verifies the field.

## SECONDARY — node-expr harness fidelity (`tests/w3c_node_expr.rs`)
The runner re-implemented the node-expression algebra inline and compared order-blind. It now drives the **real** crate path via `eval_node_expression` with **order-aware** (sequence) comparison, falling back to multiset only for order-insensitive set operators. To support this the crate parser learned the SHACL 1.2 `shnex:` spellings of the shared algebra (`pathValues`/`nodes`/`filterShape`/`intersection`/`union`) and `eval_node_expression` now registers inline filter/function shapes.

Driving real code surfaced and **FIXED** a genuine crate bug: a decimal `sum` rendered `42` rather than the canonical `42.0`^^xsd:decimal (`func::decimal_literal`). One honest divergence remains — the harness `sht:scope-*` var-injection entry (`var-bound`), which the crate's evaluation has no counterpart for — recorded as **xfail** (documented, not faked); see the deferred follow-up below.

## FLOORS (re-measured, both feature states)
- `w3c_sparql_shacl12.rs`: `BASELINE_PASS` 14→17, `BASELINE_GAP` 10→7 (the 7 `sht:Failure` rejection entries remain).
- `w3c_node_expr.rs`: real-eval path = **62 pass + 1 xfail** (the previous 63 inline-pass count preserved as 62 + 1 xfail); `BASELINE_PASS` = 62, `XFAIL_VAR_SCOPE` = 1.
- `w3c_core_full_shacl12.rs`: floors unchanged (129 default / 130 `shacl-af`).
- Two-sided ratchet kept (pass ≥ floor AND gap ≤ ceiling); the DEFAULT floor equals the default achieved count; no all-pass assertion.

## Gates (GREEN in BOTH default AND `--features shacl-af`)
- `cargo test -p sparq-shacl` — green both states (0 failures).
- `cargo clippy -p sparq-shacl --all-targets -- -D warnings` — both states.
- `cargo +1.88 check -p sparq-shacl` — both states.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations (README ≤120 lines).
- Direct unit tests added for the new arms (union / sibling-join / projecting sub-SELECT / SELECT*-above / GRAPH) and for `sh:sourceConstraint` presence/absence.
- No regression: the merged core-value + targets tests and the full existing suite still pass.

## Deferred (follow-up bead)
- **Caller-supplied node-expression variable scope** — a `shnex:var "<name>"` resolving a harness `sht:scope-<name>` binding (W3C `node-expr/shnex/var-bound`); the crate binds only `"focusNode"`. Kept honest as an xfail with a clear note in the harness.

Closes sq-mue75.