### PR TITLE
feat(shacl): SHACL 1.2 per-constraint-statement reified-annotation overrides — final core gap (sq-pb0wm) [OPUS-4.8]

### DIFF
--- a/crates/sparq-shacl/README.md
+++ b/crates/sparq-shacl/README.md
@@ -64,11 +64,12 @@ and call `validate_with_model`. CLI: `cargo run -p sparq-shacl --example validat
   `sh:equals`/`sh:disjoint`/`sh:lessThan`/`sh:lessThanOrEquals`, `sh:subsetOf`/
   `sh:someValue`/`sh:singleLine`/`sh:rootClass`, severity-threshold `conforms`
   (shapes-graph `sh:conformanceDisallows` overrides the default {Violation,Warning,Info},
-  sq-5q76d), `sh:reifierShape`/`sh:reificationRequired` over RDF-1.2 reifiers and the
-  `rdf:dirLangString` base-direction `sh:uniqueLang` key (sq-0mjfd). The **full** vendored
-  1.2 suite is gated by a two-sided ratchet (sq-6glcr): core / SPARQL (incl. the
-  `sht:Failure` rejection entries) / node-expr, in both feature states — gap map in
-  [`research/shacl12-conformance-gap.md`](../../research/shacl12-conformance-gap.md).
+  sq-5q76d), `sh:reifierShape`/`sh:reificationRequired` over RDF-1.2 reifiers, the
+  `rdf:dirLangString` `sh:uniqueLang` key (sq-0mjfd), and **per-constraint-statement
+  reified-annotation overrides** (`{| sh:deactivated/message/severity … |}` apply to ONLY that
+  occurrence, sq-pb0wm). The **full** vendored 1.2 suite is gated by a two-sided ratchet
+  (sq-6glcr): core / SPARQL (incl. `sht:Failure` rejection) / node-expr, in both feature
+  states — gap map in [`research/shacl12-conformance-gap.md`](../../research/shacl12-conformance-gap.md).
 - **SHACL-SPARQL + custom §6 components** — `sh:sparql` (§5.2, results carry
   `sh:sourceConstraint`; `$this`/`$value` pre-binding propagates into UNION branches,
   sibling joins and projecting sub-SELECTs, sq-mue75) and SPARQL-based constraint
@@ -107,9 +108,8 @@ and call `validate_with_model`. CLI: `cargo run -p sparq-shacl --example validat
 
 `validate_strict` returns `Err(ShaclFailure)` for an unsound SHACL-SPARQL pre-binding
 (`MINUS`/`VALUES`/`SERVICE` / a sub-`SELECT` dropping `$this` / a `BIND` re-binding it,
-sq-0mjfd); `validate` skips such a constraint. Out of scope: `$shapesGraph` and
-per-constraint reified-annotation overrides (`{| sh:deactivated/message/severity … |}`,
-bead sq-pb0wm) — see `bd list -l area:sparq-shacl`. Validation results are **not deduplicated** across
+sq-0mjfd); `validate` skips such a constraint. Out of scope: `$shapesGraph` — see
+`bd list -l area:sparq-shacl`. Validation results are **not deduplicated** across
 traversal routes (a nested shape reached through two parents reports twice, matching the
 suite), re-entrant recursion on the same focus/shape pair counts as conforming (SHACL
 leaves recursion undefined), and an **uncompilable `sh:pattern`** (e.g. a `(?!…)`

--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -2,7 +2,7 @@
 //! emits [`ValidationResult`]s via direct graph scans (no SPARQL round-trip).
 
 use crate::model::{
-    sh, Component, ComponentDef, PreparedComponentValidator, ShapesModel, Target,
+    sh, Component, ComponentDef, ComponentMeta, PreparedComponentValidator, ShapesModel, Target,
 };
 use crate::path::Path;
 use crate::report::{ShapeDiagnostic, ValidationResult};
@@ -37,6 +37,7 @@ pub(crate) fn validate_graph(
         regexes: FxHashMap::default(),
         uvf_targets: FxHashMap::default(),
         diagnostics: Vec::new(),
+        active_meta: None,
     };
     let mut out = Vec::new();
     for &sid in &shapes.targeted {
@@ -68,6 +69,7 @@ pub(crate) fn count_focus_nodes(data: &Graph, shapes: &ShapesModel) -> usize {
         regexes: FxHashMap::default(),
         uvf_targets: FxHashMap::default(),
         diagnostics: Vec::new(),
+        active_meta: None,
     };
     let mut all: Vec<Term> = Vec::new();
     for &sid in &shapes.targeted {
@@ -101,6 +103,7 @@ pub(crate) fn conforms_node(data: &Graph, shapes: &ShapesModel, sid: usize, node
         regexes: FxHashMap::default(),
         uvf_targets: FxHashMap::default(),
         diagnostics: Vec::new(),
+        active_meta: None,
     };
     v.conforms(node, sid)
 }
@@ -129,6 +132,12 @@ struct Validator<'a> {
     /// uncompilable `sh:pattern` regex). De-duplicated per (shape, pattern, flags)
     /// so a skip is reported once, not once per value/focus node.
     diagnostics: Vec<ShapeDiagnostic>,
+    /// [OPUS-4.8] (sq-pb0wm) The per-constraint-statement RDF-1.2 reified-annotation
+    /// override active for the component CURRENTLY being evaluated, set by
+    /// `validate_shape` around each `eval_component` call. `result()` reads it to
+    /// apply a per-occurrence `sh:message` / `sh:severity` (SHACL 1.2). `None` when
+    /// the current constraint carries no annotation (the common case).
+    active_meta: Option<ComponentMeta>,
 }
 
 impl<'a> Validator<'a> {
@@ -285,12 +294,40 @@ impl<'a> Validator<'a> {
             },
         };
         let components = shape.components.clone();
-        for comp in &components {
+        // [OPUS-4.8] (sq-pb0wm) Per-constraint-statement RDF-1.2 reified-annotation
+        // overrides, PARALLEL to `components`. A `{| sh:deactivated true |}` on a
+        // single constraint statement suppresses ONLY that occurrence (the shape
+        // keeps validating its other constraints); a `{| sh:message … |}` /
+        // `{| sh:severity … |}` overrides the message / severity for ONLY that
+        // occurrence's results. `result()` reads `self.active_meta` (set here) to
+        // apply the message/severity override; deactivation is handled by skipping
+        // the component outright.
+        let metas = shape.component_meta.clone();
+        for (i, comp) in components.iter().enumerate() {
+            // Index access with a default fallback: a component WITHOUT a parallel
+            // meta entry (should never happen — the vectors are kept index-aligned)
+            // is treated as un-annotated rather than silently skipped (a `zip` would
+            // truncate the longer vector and lose the trailing component). [OPUS-4.8] (sq-pb0wm)
+            let meta = metas.get(i);
+            if meta.is_some_and(ComponentMeta::is_deactivated) {
+                continue; // this constraint occurrence is deactivated (sq-pb0wm)
+            }
+            // Set the active per-statement override so `result()` (used by every
+            // Core component arm) can apply a per-occurrence message/severity.
+            self.active_meta = match meta {
+                Some(m) if !m.is_empty() => Some(m.clone()),
+                _ => None,
+            };
             self.eval_component(sid, focus, &values, comp, out);
+            self.active_meta = None;
         }
     }
 
-    /// A result owned by shape `sid` for `focus`.
+    /// A result owned by shape `sid` for `focus`. [OPUS-4.8] (sq-pb0wm) When a
+    /// per-constraint-statement override is active (`self.active_meta`, set by
+    /// `validate_shape` for the component being evaluated), its `sh:message` /
+    /// `sh:severity` REPLACE the shape-level message / severity for this result —
+    /// the SHACL 1.2 reified-annotation semantics applying to one occurrence only.
     fn result(
         &self,
         sid: usize,
@@ -300,6 +337,17 @@ impl<'a> Validator<'a> {
         message: String,
     ) -> ValidationResult {
         let shape = &self.shapes.shapes[sid];
+        let (severity, messages) = match &self.active_meta {
+            Some(meta) => (
+                meta.severity.clone().unwrap_or_else(|| shape.severity.clone()),
+                if meta.messages.is_empty() {
+                    shape.messages.clone()
+                } else {
+                    meta.messages.clone()
+                },
+            ),
+            None => (shape.severity.clone(), shape.messages.clone()),
+        };
         ValidationResult {
             focus_node: focus.clone(),
             path: shape.path.clone(),
@@ -308,8 +356,8 @@ impl<'a> Validator<'a> {
             // Core components have no `sh:SPARQLConstraint` node (sq-mue75).
             source_constraint: None,
             source_component: sh(component),
-            severity: shape.severity.clone(),
-            messages: shape.messages.clone(),
+            severity,
+            messages,
             default_message: message,
             details: Vec::new(),
         }

--- a/crates/sparq-shacl/src/model.rs
+++ b/crates/sparq-shacl/src/model.rs
@@ -209,6 +209,46 @@ pub enum Component {
     NodeByExpression(usize),
 }
 
+/// [OPUS-4.8] (sq-pb0wm) Per-constraint-statement RDF-1.2 reified-annotation
+/// overrides for ONE [`Component`] occurrence (SHACL 1.2 Core, the
+/// `misc/{deactivated-003,message-002,severity-003}` entries). When a constraint
+/// triple `(shapeNode, P, O)` carries a `{| … |}` annotation — parsed as
+/// `_:r rdf:reifies <<( shapeNode P O )>> . _:r sh:deactivated|sh:message|sh:severity V`
+/// — the annotation overrides JUST that occurrence: `deactivated` suppresses only
+/// that constraint (not the whole shape), and `messages` / `severity` replace the
+/// shape-level message / severity for ONLY that constraint's results. Held in a
+/// vector PARALLEL to [`Shape::components`] (a [`Self::default`] entry — no
+/// override — for every component built from something other than a single
+/// reifiable constraint triple). Distinct from the shape-level
+/// [`Shape::deactivated`] / [`Shape::messages`] / [`Shape::severity`].
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ComponentMeta {
+    /// `{| sh:deactivated true |}` on this constraint statement: suppress this
+    /// occurrence only (the rest of the shape still validates).
+    pub deactivated: bool,
+    /// `{| sh:message "…" |}` on this statement: the result message(s) for this
+    /// occurrence's violations, overriding the shape's `sh:message`. Empty ⇒ no
+    /// per-statement message override (inherit the shape's).
+    pub messages: Vec<Term>,
+    /// `{| sh:severity sh:Warning |}` on this statement: the result severity for
+    /// this occurrence's violations, overriding the shape's. `None` ⇒ inherit.
+    pub severity: Option<String>,
+}
+
+impl ComponentMeta {
+    /// Whether this carries any per-statement override (cheap "is the default"
+    /// probe so eval can skip the override path for the common un-annotated case).
+    pub fn is_empty(&self) -> bool {
+        !self.deactivated && self.messages.is_empty() && self.severity.is_none()
+    }
+
+    /// Whether this constraint occurrence is per-statement deactivated
+    /// (`{| sh:deactivated true |}`) — eval skips just this occurrence.
+    pub fn is_deactivated(&self) -> bool {
+        self.deactivated
+    }
+}
+
 /// [OPUS-4.8] A declared `sh:parameter` of a SPARQL-based constraint component
 /// (SHACL §6.2): its predicate (`sh:path`), the pre-bound variable name and
 /// whether it is `sh:optional`.
@@ -340,6 +380,12 @@ pub struct Shape {
     pub path: Option<Path>,
     pub targets: Vec<Target>,
     pub components: Vec<Component>,
+    /// [OPUS-4.8] (sq-pb0wm) Per-constraint-statement RDF-1.2 reified-annotation
+    /// overrides, PARALLEL to [`Self::components`] (index `i` describes
+    /// `components[i]`). A `ComponentMeta::default` entry means "no annotation";
+    /// only components built from a single reifiable constraint triple
+    /// (`(shapeNode, P, O)`) can carry a real override. See [`ComponentMeta`].
+    pub(crate) component_meta: Vec<ComponentMeta>,
     /// Severity IRI (default sh:Violation).
     pub severity: String,
     /// sh:message literals, copied into results.
@@ -612,6 +658,13 @@ impl ShapesModel {
             } else {
                 Component::Expression(idx)
             });
+            // [OPUS-4.8] (sq-pb0wm) Keep the per-statement `component_meta` vector
+            // index-aligned: this second pass pushes components AFTER
+            // `attach_component_meta` sized the meta vector, so push a default
+            // (no-override) meta for each — expression constraints carry no
+            // reified-annotation override. (`validate_shape` is also padded
+            // defensively, so a drift here can never silently drop a component.)
+            self.shapes[sid].component_meta.push(ComponentMeta::default());
         }
     }
 
@@ -687,15 +740,88 @@ impl ShapesModel {
             path: None,
             targets: Vec::new(),
             components: Vec::new(),
+            component_meta: Vec::new(),
             severity: sh("Violation"),
             messages: Vec::new(),
             deactivated: false,
             property_children: Vec::new(),
             value_expr: None,
         });
-        let parsed = self.parse_shape(g, node);
+        let mut parsed = self.parse_shape(g, node);
+        // [OPUS-4.8] (sq-pb0wm) Resolve per-constraint-statement RDF-1.2
+        // reified-annotation overrides AFTER the components are built, so the
+        // parallel `component_meta` vector is index-aligned with `components`. A
+        // no-op (and cheap) when the shape carries no `{| … |}` annotation.
+        self.attach_component_meta(g, node, &mut parsed);
         self.shapes[id] = parsed;
         id
+    }
+
+    /// [OPUS-4.8] (sq-pb0wm) Populates `shape.component_meta` (index-aligned with
+    /// `shape.components`) from RDF-1.2 reified annotations on the constraint
+    /// statements. SHACL 1.2 Core lets a `{| … |}` annotation on ONE constraint
+    /// triple `(shapeNode, P, O)` — stored after parsing as
+    /// `_:r rdf:reifies <<( shapeNode P O )>>` plus `_:r sh:deactivated|message|severity V`
+    /// on the reifier `_:r` — override JUST that occurrence
+    /// (`misc/{deactivated-003,message-002,severity-003}`).
+    ///
+    /// Every component gets a [`ComponentMeta`] (default = no override). A real
+    /// override is attached only to components that map back to a single reifiable
+    /// constraint triple ([`component_source_triple`]); composite / list-valued /
+    /// expression components do not (the reified-annotation form annotates one
+    /// statement). The common un-annotated case short-circuits: a shape with no
+    /// reifier of any of its statements gets all-default metas with no per-triple
+    /// scan.
+    fn attach_component_meta(&self, g: &GraphView, node: &Term, shape: &mut Shape) {
+        shape.component_meta = vec![ComponentMeta::default(); shape.components.len()];
+        // Short-circuit: nothing reifies a statement of this shape ⇒ no overrides.
+        // (`rdf:reifies` objects are triple-terms; we only need the cheap presence
+        // check that SOME reifier names this shape node as the triple subject.)
+        if !shape_has_reified_statement(g, node) {
+            return;
+        }
+        for (i, comp) in shape.components.iter().enumerate() {
+            let Some((pred, obj)) = self.component_source_triple(comp) else {
+                continue;
+            };
+            let meta = reified_meta(g, node, &pred, &obj);
+            if !meta.is_empty() {
+                shape.component_meta[i] = meta;
+            }
+        }
+    }
+
+    /// [OPUS-4.8] (sq-pb0wm) The `(predicateIRI, objectTerm)` of the single
+    /// constraint statement a [`Component`] was built from, for the variants that
+    /// correspond to exactly one reifiable shapes-graph triple
+    /// `(shapeNode, P, O)`. `None` for components built from several triples (a
+    /// SHACL list / RDF-list operand), a transformed object whose original term is
+    /// not faithfully recoverable (a numeric count, a parsed [`Path`]), or a
+    /// feature-gated expression component — per-statement annotation overrides are
+    /// defined for single-statement Core constraints, which is what the W3C 1.2
+    /// suite (`misc/{deactivated-003,message-002,severity-003}`) exercises.
+    fn component_source_triple(&self, comp: &Component) -> Option<(String, Term)> {
+        let shape_node = |idx: usize| self.shapes.get(idx).map(|s| s.node.clone());
+        match comp {
+            Component::Class(t) => Some((sh("class"), t.clone())),
+            // A SINGLE-element datatype/nodeKind set is the single-IRI spelling
+            // `sh:datatype <iri>` (the SHACL-1.2 disjunctive LIST form is several
+            // triples — its operand is an RDF list — so it is not annotated here).
+            Component::Datatype(dts) if dts.len() == 1 => {
+                Some((sh("datatype"), iri(&dts[0])))
+            }
+            Component::NodeKind(kinds) if kinds.len() == 1 => {
+                Some((sh("nodeKind"), iri(&kinds[0])))
+            }
+            Component::HasValue(t) => Some((sh("hasValue"), t.clone())),
+            Component::RootClass(t) => Some((sh("rootClass"), t.clone())),
+            Component::Node(idx) => Some((sh("node"), shape_node(*idx)?)),
+            Component::Property(idx) => Some((sh("property"), shape_node(*idx)?)),
+            Component::SomeValue(idx) => Some((sh("someValue"), shape_node(*idx)?)),
+            Component::Not(idx) => Some((sh("not"), shape_node(*idx)?)),
+            Component::MemberShape(idx) => Some((sh("memberShape"), shape_node(*idx)?)),
+            _ => None,
+        }
     }
 
     fn parse_shape(&mut self, g: &GraphView, node: &Term) -> Shape {
@@ -706,6 +832,7 @@ impl ShapesModel {
                 .and_then(|p| Path::parse(g, &p).ok()),
             targets: Vec::new(),
             components: Vec::new(),
+            component_meta: Vec::new(),
             severity: match g.object(node, &sh("severity")) {
                 Some(Term::NamedNode(n)) => n.as_str().to_string(),
                 _ => sh("Violation"),
@@ -1259,6 +1386,59 @@ fn collect_prefixes_from(g: &GraphView, prefix_roots: &[Term]) -> String {
 
 fn iri(s: &str) -> Term {
     Term::NamedNode(oxrdf::NamedNode::new_unchecked(s))
+}
+
+/// [OPUS-4.8] (sq-pb0wm) The RDF-1.2 reification predicate: a reifier `?r` reifies
+/// a triple-term via `?r rdf:reifies <<( s p o )>>` (the `{| … |}` annotation).
+const RDF_REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
+
+/// [OPUS-4.8] (sq-pb0wm) Cheap presence check: does ANY reifier in the shapes
+/// graph reify a triple whose subject is this shape node? `rdf:reifies` objects
+/// are triple-terms ([`Term::Triple`]); we scan the (few) `rdf:reifies` triples
+/// and test the embedded triple's subject. Lets [`ShapesModel::attach_component_meta`]
+/// skip the per-component triple reconstruction for the common un-annotated shape.
+fn shape_has_reified_statement(g: &GraphView, node: &Term) -> bool {
+    let want: oxrdf::NamedOrBlankNode = match node {
+        Term::NamedNode(n) => n.clone().into(),
+        Term::BlankNode(b) => b.clone().into(),
+        _ => return false,
+    };
+    g.triples(None, Some(RDF_REIFIES), None)
+        .into_iter()
+        .any(|[_, _, o]| matches!(&o, Term::Triple(t) if t.subject == want))
+}
+
+/// [OPUS-4.8] (sq-pb0wm) The per-statement [`ComponentMeta`] for the constraint
+/// triple `(shapeNode, predicate, object)`: scans the reifiers of that exact
+/// triple (the subjects of `?r rdf:reifies <<( shapeNode predicate object )>>`)
+/// and reads any `sh:deactivated` / `sh:message` / `sh:severity` they carry. The
+/// triple-term is reconstructed identically to the eval-side `reifiers_of`, so it
+/// matches the term oxttl/oxrdf stores for the `{| … |}` form. A non-IRI/blank
+/// shape node, or no reifier, yields the default (no override).
+fn reified_meta(g: &GraphView, node: &Term, predicate: &str, object: &Term) -> ComponentMeta {
+    let subj: oxrdf::NamedOrBlankNode = match node {
+        Term::NamedNode(n) => n.clone().into(),
+        Term::BlankNode(b) => b.clone().into(),
+        _ => return ComponentMeta::default(),
+    };
+    let Ok(pred) = oxrdf::NamedNode::new(predicate) else {
+        return ComponentMeta::default();
+    };
+    let triple_term = Term::Triple(Box::new(oxrdf::Triple::new(subj, pred, object.clone())));
+    let reifiers = g.subjects(RDF_REIFIES, &triple_term);
+    let mut meta = ComponentMeta::default();
+    for r in &reifiers {
+        if matches!(g.object(r, &sh("deactivated")), Some(Term::Literal(l)) if l.value() == "true") {
+            meta.deactivated = true;
+        }
+        for m in g.objects(r, &sh("message")) {
+            meta.messages.push(m);
+        }
+        if let Some(Term::NamedNode(n)) = g.object(r, &sh("severity")) {
+            meta.severity = Some(n.as_str().to_string());
+        }
+    }
+    meta
 }
 
 /// [OPUS-4.8] (sq-vg3y) The set of IRIs an object denotes when a constraint

--- a/crates/sparq-shacl/tests/constraints.rs
+++ b/crates/sparq-shacl/tests/constraints.rs
@@ -8,6 +8,7 @@
 //! reported `sh:value` and the result count — the per-pair / per-occurrence
 //! reporting policy `eval.rs` documents.
 
+use oxrdf::Term;
 use sparq_core::Graph;
 use sparq_shacl::ValidationReport;
 
@@ -1100,5 +1101,184 @@ fn pattern_skip_diagnostic_is_deduplicated() {
         1,
         "the skip is reported once, not per focus/value: {}",
         r.to_text()
+    );
+}
+
+// ----------------------------------------------------------------------------
+// [OPUS-4.8] (sq-pb0wm, epic sq-waf9o) Per-constraint-statement RDF-1.2
+// reified-annotation overrides (SHACL 1.2 Core). A `{| … |}` annotation on ONE
+// constraint statement `(<shape> P O)` overrides JUST that occurrence:
+//   * `{| sh:deactivated true |}` suppresses only that constraint (the shape's
+//     OTHER constraints still validate) — distinct from shape-level
+//     `sh:deactivated`, which suppresses the whole shape.
+//   * `{| sh:message "…" |}` sets the result message for only that constraint.
+//   * `{| sh:severity sh:Warning |}` sets the result severity for only that
+//     constraint's violations.
+// These drive the FINAL SHACL-1.2 core gap (`misc/{deactivated-003,message-002,
+// severity-003}`); the assertions below go through the REAL `validate()`. The
+// `{| |}` form is parsed by oxttl's rdf-12 Turtle support (no extra wiring).
+// ----------------------------------------------------------------------------
+
+const SH_WARNING: &str = "http://www.w3.org/ns/shacl#Warning";
+const SH_VIOLATION: &str = "http://www.w3.org/ns/shacl#Violation";
+
+/// `{| sh:deactivated true |}` on a single `sh:datatype` statement suppresses
+/// ONLY that constraint occurrence — mirrors `misc/deactivated-003`'s datatype
+/// half: the shape conforms despite the value violating the (now-deactivated)
+/// datatype constraint.
+#[test]
+fn per_statement_deactivate_suppresses_only_that_constraint() {
+    // The focus is a string literal target node that is NOT an xsd:boolean, so
+    // the datatype constraint WOULD fire — but the per-statement annotation
+    // deactivates this occurrence, so the shape conforms.
+    let data = r#" ex:x ex:dummy "irrelevant" . "#;
+    let annotated = r#"
+        ex:S a sh:NodeShape ; sh:targetNode "hello" ;
+          sh:datatype xsd:boolean {| sh:deactivated true |} .
+    "#;
+    let r = run(data, annotated);
+    assert!(
+        r.conforms,
+        "per-statement-deactivated datatype must produce NO result: {}",
+        r.to_text()
+    );
+    // Control: WITHOUT the `{| … |}` annotation the SAME constraint fires.
+    let live = r#"
+        ex:S a sh:NodeShape ; sh:targetNode "hello" ;
+          sh:datatype xsd:boolean .
+    "#;
+    let r2 = run(data, live);
+    assert!(
+        !r2.conforms,
+        "control (no annotation) must violate: {}",
+        r2.to_text()
+    );
+    assert_eq!(count_component(&r2, "DatatypeConstraintComponent"), 1);
+}
+
+/// A per-statement `{| sh:deactivated true |}` on ONE constraint must NOT
+/// suppress the shape's OTHER constraints (the occurrence-scoped semantics — not
+/// shape-level deactivation). The deactivated `sh:datatype` is silent while the
+/// live `sh:minLength` still fires.
+#[test]
+fn per_statement_deactivate_leaves_sibling_constraints_live() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode "hi" ;
+          sh:datatype xsd:boolean {| sh:deactivated true |} ;
+          sh:minLength 5 .
+    "#;
+    let r = run("ex:x ex:p ex:o .", shapes);
+    assert!(!r.conforms, "the live sh:minLength must still fire: {}", r.to_text());
+    assert_eq!(
+        count_component(&r, "DatatypeConstraintComponent"),
+        0,
+        "the per-statement-deactivated datatype must be silent: {}",
+        r.to_text()
+    );
+    assert_eq!(
+        count_component(&r, "MinLengthConstraintComponent"),
+        1,
+        "the un-annotated sibling constraint must still report: {}",
+        r.to_text()
+    );
+}
+
+/// `{| sh:deactivated true |}` on a single `sh:property` statement suppresses
+/// only that property-constraint occurrence (the nested shape is not validated) —
+/// the `sh:property` half of `misc/deactivated-003`.
+#[test]
+fn per_statement_deactivate_on_property_constraint() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+          sh:property ex:P {| sh:deactivated true |} .
+        ex:P a sh:PropertyShape ; sh:path ex:q ; sh:minCount 1 .
+    "#;
+    // ex:n has NO ex:q value, so the (live) minCount would fire — but the
+    // property statement is deactivated, so the shape conforms.
+    let r = run("ex:n ex:other ex:o .", shapes);
+    assert!(
+        r.conforms,
+        "deactivated sh:property must not validate the nested shape: {}",
+        r.to_text()
+    );
+    // Control: without the annotation the nested minCount fires.
+    let live = r#"
+        ex:S a sh:NodeShape ; sh:targetNode ex:n ;
+          sh:property ex:P .
+        ex:P a sh:PropertyShape ; sh:path ex:q ; sh:minCount 1 .
+    "#;
+    let r2 = run("ex:n ex:other ex:o .", live);
+    assert!(!r2.conforms, "control must violate minCount: {}", r2.to_text());
+}
+
+/// `{| sh:message "…"@en |}` on a single constraint statement sets the result
+/// message for ONLY that occurrence's violations (overriding the absence of a
+/// shape-level message) — mirrors `misc/message-002`.
+#[test]
+fn per_statement_message_override_applies_to_that_constraint() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode ex:InvalidNode ;
+          sh:datatype xsd:integer {| sh:message "Test message"@en |} .
+    "#;
+    let r = run("ex:InvalidNode ex:p ex:o .", shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(r.results.len(), 1, "{}", r.to_text());
+    let msgs = r.results[0].effective_messages();
+    let want = Term::Literal(oxrdf::Literal::new_language_tagged_literal_unchecked(
+        "Test message",
+        "en",
+    ));
+    assert!(
+        msgs.contains(&want),
+        "result message must be the per-statement override, got {msgs:?}"
+    );
+}
+
+/// `{| sh:severity sh:Warning |}` on a single constraint statement sets the
+/// result severity for ONLY that occurrence's violations (the default is
+/// sh:Violation) — mirrors `misc/severity-003`.
+#[test]
+fn per_statement_severity_override_applies_to_that_constraint() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode "Hello" ;
+          sh:datatype xsd:integer {| sh:severity sh:Warning |} .
+    "#;
+    let r = run("ex:x ex:p ex:o .", shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(r.results.len(), 1, "{}", r.to_text());
+    assert_eq!(
+        r.results[0].severity, SH_WARNING,
+        "the per-statement severity override must apply: {}",
+        r.to_text()
+    );
+}
+
+/// A per-statement override applies to ONLY the annotated occurrence: with two
+/// constraints on one shape, only the one annotated with `sh:severity sh:Warning`
+/// gets the Warning severity; the other keeps the default sh:Violation.
+#[test]
+fn per_statement_severity_is_occurrence_scoped() {
+    let shapes = r#"
+        ex:S a sh:NodeShape ; sh:targetNode "Hello" ;
+          sh:datatype xsd:integer {| sh:severity sh:Warning |} ;
+          sh:minLength 99 .
+    "#;
+    let r = run("ex:x ex:p ex:o .", shapes);
+    assert!(!r.conforms, "{}", r.to_text());
+    assert_eq!(r.results.len(), 2, "{}", r.to_text());
+    let dt = r
+        .results
+        .iter()
+        .find(|x| x.source_component.ends_with("DatatypeConstraintComponent"))
+        .expect("datatype result");
+    let ml = r
+        .results
+        .iter()
+        .find(|x| x.source_component.ends_with("MinLengthConstraintComponent"))
+        .expect("minLength result");
+    assert_eq!(dt.severity, SH_WARNING, "annotated occurrence → Warning");
+    assert_eq!(
+        ml.severity, SH_VIOLATION,
+        "un-annotated occurrence keeps the default Violation"
     );
 }

--- a/crates/sparq-shacl/tests/w3c_core_full_shacl12.rs
+++ b/crates/sparq-shacl/tests/w3c_core_full_shacl12.rs
@@ -22,15 +22,15 @@
 //! node-expression constraints. Those are a different surface, so counting them
 //! as FAILs would be noise.
 //!
-//! Every *other* entry is compared strictly. A few entries still exercise
-//! SHACL-**1.2** behaviour this crate does not yet fully implement — currently the
-//! per-constraint-statement RDF-1.2 reified-annotation overrides
-//! (`sh:datatype X {| sh:deactivated/sh:message/sh:severity … |}`,
-//! `misc/{deactivated-003,message-002,severity-003}`) — so they produce the wrong
-//! report and are honest **FAIL**s, the live gap map in
-//! `research/shacl12-conformance-gap.md`.
-//! This harness deliberately does **not** assert `fail == 0` for the full tree:
-//! that would be a false claim of full SHACL-1.2 conformance.
+//! Every *other* entry is compared strictly. As of sq-pb0wm (the per-constraint-
+//! statement RDF-1.2 reified-annotation overrides
+//! `sh:datatype X {| sh:deactivated/sh:message/sh:severity … |}`,
+//! `misc/{deactivated-003,message-002,severity-003}`) the full core tree has NO
+//! honest FAILs in either feature state — the fail-ceiling is 0. This harness
+//! still does **not** hard-assert `fail == 0` as the gate; it keeps the two-sided
+//! ratchet (pass-floor + fail-ceiling) so a future regression in *either*
+//! direction is caught while the live gap map in
+//! `research/shacl12-conformance-gap.md` records the (now-empty) residual.
 //!
 //! ## Ratchet (two-sided)
 //!
@@ -116,13 +116,23 @@ fn unimplemented() -> Vec<String> {
 /// `validation-reports/conformance-disallows-001` (shapes-graph
 /// `sh:conformanceDisallows` threading) gaps. EQUALS the measured default-state
 /// pass count exactly (not above it — see the #1271 near-failure note).
-const BASELINE_PASS_CORE: usize = 133;
+///
+/// [OPUS-4.8] (sq-pb0wm, epic sq-waf9o) Raised 133 → 136: the FINAL SHACL 1.2 core
+/// conformance gap — per-constraint-statement RDF-1.2 reified-annotation overrides
+/// (`<constraint> {| sh:deactivated/sh:message/sh:severity … |}`) — now interpreted,
+/// so `misc/{deactivated-003,message-002,severity-003}` move FAIL → PASS (`misc`
+/// 10/10). EQUALS the measured default-state pass count exactly (not above it).
+const BASELINE_PASS_CORE: usize = 136;
 
 /// Pass-floor over the FULL core tree with `shacl-af` ON: the `shacl-af`
 /// `sh:nodeByExpression` core/node entry becomes implemented and PASSes, so the
 /// floor rises by one. [OPUS-4.8] (sq-0mjfd) Raised 130 → 134 in lock-step with
 /// [`BASELINE_PASS_CORE`].
-const BASELINE_PASS_AF: usize = 134;
+///
+/// [OPUS-4.8] (sq-pb0wm) Raised 134 → 137 in lock-step with [`BASELINE_PASS_CORE`]
+/// (the misc reified-annotation trio). With `shacl-af` ON the whole core tree now
+/// PASSes (137 pass, 0 fail, 0 skip).
+const BASELINE_PASS_AF: usize = 137;
 
 /// Fail-ceiling over the FULL core tree — the count of entries whose SHACL-1.2
 /// behaviour this crate does not yet implement (the gap map). A *new* mismatch (a
@@ -134,15 +144,19 @@ const BASELINE_PASS_AF: usize = 134;
 /// gaps and this change closes the `targets/` gaps.
 ///
 /// [OPUS-4.8] (sq-0mjfd / sq-5q76d) Lowered 7 → 3: reifierShape ×2, uniqueLang-003 and
-/// conformance-disallows-001 now PASS. The remaining 3 are `misc/{deactivated-003,
+/// conformance-disallows-001 now PASS. The remaining 3 were `misc/{deactivated-003,
 /// message-002, severity-003}` — each needs PER-CONSTRAINT-STATEMENT RDF-1.2
-/// reified-annotation interpretation (`sh:datatype X {| sh:deactivated/message/severity … |}`),
-/// a deeper SHACL-model feature (the `{| |}` parser already works — see
-/// `research/shacl12-conformance-gap.md` and the dedicated bead).
-const BASELINE_FAIL_CORE: usize = 3;
+/// reified-annotation interpretation (`sh:datatype X {| sh:deactivated/message/severity … |}`).
+///
+/// [OPUS-4.8] (sq-pb0wm, epic sq-waf9o) Lowered 3 → 0: that final gap is now closed
+/// (the per-statement reified-annotation overrides are interpreted), so NO full-core
+/// entry is an honest FAIL in either feature state. The two-sided ratchet still
+/// guards against a regression in either direction — a previously-correct entry
+/// breaking would push the count above this 0 ceiling and fail the build.
+const BASELINE_FAIL_CORE: usize = 0;
 
 /// Fail-ceiling with `shacl-af` ON — identical to [`BASELINE_FAIL_CORE`].
-const BASELINE_FAIL_AF: usize = 3;
+const BASELINE_FAIL_AF: usize = 0;
 
 fn baseline_pass() -> usize {
     if cfg!(feature = "shacl-af") {

--- a/research/shacl12-conformance-gap.md
+++ b/research/shacl12-conformance-gap.md
@@ -23,6 +23,8 @@ follow-on feature waves are measurable rather than guesswork.
 > interpret a `sh:deactivated`/`sh:message`/`sh:severity` reifier as an override
 > of a SPECIFIC constraint statement (bead `sq-pb0wm`, see §6).
 
+<!-- -->
+
 > **[OPUS-4.8] (sq-pb0wm) update — the FINAL core gap is CLOSED.** The
 > per-constraint-statement reified-annotation overrides are now interpreted, so
 > `misc/{deactivated-003,message-002,severity-003}` move FAIL → PASS. New measured

--- a/research/shacl12-conformance-gap.md
+++ b/research/shacl12-conformance-gap.md
@@ -23,6 +23,15 @@ follow-on feature waves are measurable rather than guesswork.
 > interpret a `sh:deactivated`/`sh:message`/`sh:severity` reifier as an override
 > of a SPECIFIC constraint statement (bead `sq-pb0wm`, see §6).
 
+> **[OPUS-4.8] (sq-pb0wm) update — the FINAL core gap is CLOSED.** The
+> per-constraint-statement reified-annotation overrides are now interpreted, so
+> `misc/{deactivated-003,message-002,severity-003}` move FAIL → PASS. New measured
+> floors: **core 136 (default) / 137 (`shacl-af`)**, fail-ceiling **0** in BOTH
+> feature states — every in-scope full-core entry passes. The two-sided ratchet is
+> kept (not switched to an all-pass assert) so a future regression in either
+> direction is still caught. See §6 for the resolved divergence and the one draft
+> ambiguity that had to be decided.
+
 The vendored suite is the W3C `w3c/data-shapes` repo pinned at
 `b6e73695d6196f33d7ce3ba47094a10fbc298e65` (`crates/sparq-shacl/fetch-shacl-tests.sh`),
 under `crates/sparq-shacl/tests/shacl/data-shapes/shacl12-test-suite/tests/`.
@@ -95,7 +104,7 @@ under the epic.
 | 9 | `sh:targetWhere` target | `targets/targetWhere-001` | SPARQL-ish target selector | `sq-rnkdh` |
 | 10 | `sh:shape` implicit / `sh:ShapeClass` target | `targets/shape-001`, `targets/targetClassImplicit-002` | `sh:shape` value-target + `sh:ShapeClass` implicit class target | `sq-rnkdh` |
 | 11 | `sh:reifierShape` constraint | `property/reifierShape-001`, `property/reifierShape-002` | `sh:ReifierShapeConstraintComponent` (RDF-1.2 reifiers) | `sq-0mjfd` |
-| 12 | RDF-1.2 reified-annotation parsing | `misc/deactivated-003`, `misc/message-002` | the `{\| sh:deactivated true \|}` / `{\| sh:message ... \|}` triple-term annotation syntax on a constraint | `sq-0mjfd` |
+| 12 | Per-statement reified-annotation overrides | `misc/deactivated-003`, `misc/message-002`, `misc/severity-003` | a `{\| sh:deactivated/message/severity … \|}` annotation on a constraint statement overrides ONLY that occurrence (DONE) | `sq-pb0wm` |
 | 13 | `sh:uniqueLang` over `rdf:dirLangString` | `property/uniqueLang-003` | direction-tagged language strings | `sq-0mjfd` |
 
 Clusters 1–8 (eight beads' worth of "value constraints", 13 entries) are `sq-sx15d`;
@@ -155,12 +164,12 @@ grouped into four implementation beads under epic `sq-waf9o`:
 - **`sq-mue75`** — SHACL-SPARQL pre-binding VALUES propagation (cluster 17, 3
   entries) + node-expr harness fidelity + `sh:sourceConstraint`.
 - **`sq-0mjfd`** — the draft / hard zone (clusters 11, 13, 18; +5q76d/u5rxj):
-  **DONE except the per-statement annotation overrides** — `sh:reifierShape` /
-  `sh:reificationRequired` (cluster 11, 2 core), `rdf:dirLangString` `uniqueLang`
-  (cluster 13, 1 core), and the `sht:Failure` pre-binding **rejection channel**
-  (cluster 18, 7 SPARQL) all PASS now. The remaining cluster 12
-  (`misc/{deactivated-003,message-002,severity-003}`) is the honest divergence in
-  §6, moved to its own bead (the `{| |}` parser is NOT the blocker).
+  `sh:reifierShape` / `sh:reificationRequired` (cluster 11, 2 core),
+  `rdf:dirLangString` `uniqueLang` (cluster 13, 1 core), and the `sht:Failure`
+  pre-binding **rejection channel** (cluster 18, 7 SPARQL) all PASS.
+- **`sq-pb0wm`** — the per-constraint-statement reified-annotation overrides
+  (cluster 12, `misc/{deactivated-003,message-002,severity-003}`, 3 core): **DONE**
+  (see §6). This was the FINAL core gap; full core is now 136/137, fail-ceiling 0.
 - **`sq-5q76d`** — shapes-graph `sh:conformanceDisallows` → `validate()` default
   `conforms` (cluster 8 remainder, `validation-reports/conformance-disallows-001`,
   1 core): DONE.
@@ -183,27 +192,64 @@ grouped into four implementation beads under epic `sq-waf9o`:
 
 ## 5. Why a ratchet, not all-pass
 
-The Core validator is correct on the constraints it implements (the 115/137
-core + 10/24 SPARQL passing entries are compared strictly — a wrong report
-there is a FAIL, never laundered into a SKIP). The remaining entries exercise
-SHACL-1.2 features that simply are not built yet. Asserting all-pass would force
-either a false green or disabling real comparison; the two-sided ratchet keeps
-the gate honest *and* regression-proof. When a bead lands, its cluster's entries
-move FAIL → PASS, the per-runner floor is bumped in the same commit, and this
-table shrinks.
+The Core validator is correct on the constraints it implements (the full-core
+**136/137** + SPARQL **24/24** passing entries are compared strictly — a wrong
+report there is a FAIL, never laundered into a SKIP). As of `sq-pb0wm` every
+in-scope full-core entry passes (fail-ceiling 0); a handful of node/SPARQL/JS
+entries remain SKIP because they use a constraint surface out of scope for the
+Core path. Asserting all-pass would force either a false green or disabling real
+comparison; the two-sided ratchet keeps the gate honest *and* regression-proof.
+When a bead lands, its cluster's entries move FAIL → PASS, the per-runner floor is
+bumped in the same commit, and this table shrinks.
 
 ---
 
-## 6. Honest divergence — the 3 remaining core FAILs (per-statement reified-annotation overrides)
+## 6. Resolved divergence — per-statement reified-annotation overrides (sq-pb0wm)
 
-**[OPUS-4.8] (sq-0mjfd)** The only core entries this wave did NOT close are the
-three `misc/` reified-annotation OVERRIDE tests:
+**[OPUS-4.8] (sq-pb0wm, epic sq-waf9o)** The three `misc/` reified-annotation
+OVERRIDE entries — the final core gap — are now CLOSED. Each is matched through
+the REAL `validate()`:
 
-| Entry | What it asserts | Why it still fails |
+| Entry | What it asserts | How it now passes |
 | --- | --- | --- |
-| `misc/deactivated-003` | `sh:datatype X {\| sh:deactivated true \|}` and `sh:property S {\| sh:deactivated true \|}` deactivate **that specific constraint occurrence** | the model reads `sh:datatype` / `sh:property` as plain triples; it does not consult the triple's reifier for a per-statement `sh:deactivated` |
-| `misc/message-002` | `sh:datatype X {\| sh:message "…"@en \|}` attaches a message to **that constraint's** results | same — the per-statement reifier message is not threaded onto the result |
-| `misc/severity-003` | `sh:datatype X {\| sh:severity sh:Warning \|}` overrides **that constraint's** severity | same — the per-statement reifier severity is not applied |
+| `misc/deactivated-003` | `sh:datatype X {\| sh:deactivated true \|}` and `sh:property S {\| sh:deactivated true \|}` deactivate **that specific constraint occurrence** | `parse_shape` resolves the reifier of each constraint triple `(shape, P, O)`; eval skips ONLY that component (the shape keeps validating its others) — conforms |
+| `misc/message-002` | `sh:datatype X {\| sh:message "…"@en \|}` attaches a message to **that constraint's** results | the per-statement message is threaded as a `ComponentMeta` override and applied in `result()` for ONLY that occurrence's results |
+| `misc/severity-003` | `sh:datatype X {\| sh:severity sh:Warning \|}` overrides **that constraint's** severity | the per-statement severity is applied in `result()`, scoped to that occurrence (a sibling constraint keeps the default `sh:Violation`) |
+
+### Implementation (the threading change)
+
+For each constraint triple `(shape, P, O)` turned into a `Component`,
+`ShapesModel::attach_component_meta` looks up the reifier
+`?r rdf:reifies <<( shape P O )>>` in the SHAPES graph and captures any
+`sh:deactivated` / `sh:message` / `sh:severity` into a `ComponentMeta` held in a
+vector PARALLEL to `Shape::components`. `validate_shape` skips a per-statement
+deactivated occurrence and sets the active `ComponentMeta` so `result()` applies a
+per-occurrence message/severity — distinct from the shape-level
+`deactivated`/`messages`/`severity` (which still work). The `{| … |}` syntax is
+parsed by the already-pinned `oxttl 0.2.3` (`rdf-12`); **no Cargo dependency
+change** was needed.
+
+### Draft ambiguity decided (the brief's `divergences`)
+
+Per-statement annotation semantics are the least-settled corner of the SHACL-1.2
+draft; the W3C suite pins only the cases above. Two readings had to be chosen:
+
+1. **Scope of the override = the single annotated occurrence, not the shape.** A
+   `{| sh:deactivated true |}` on ONE constraint does NOT deactivate the whole
+   shape (that is the shape-level `sh:deactivated`). This is exactly what
+   `deactivated-003` encodes (the shape conforms because BOTH its constraints are
+   individually deactivated, while a third un-annotated constraint would still
+   fire) — implemented as written.
+2. **A `{| sh:message |}` / `{| sh:severity |}` on a `sh:property` / `sh:node`
+   statement governs the COMPOSITE component's own results, not the nested
+   shape's.** The nested shape's results carry the nested shape's own
+   metas/severity (it is a separate focus/shape evaluation). The suite does not
+   exercise a message/severity annotation on a shape-referencing constraint, so
+   this is the conservative, occurrence-local reading; `sh:property` deactivation
+   (which IS in the suite) is unambiguous and implemented. Only single-statement
+   Core constraints with a faithfully-recoverable object term carry an override;
+   list-/path-valued operands (e.g. the disjunctive `sh:datatype ( … )`, an
+   RDF-list comparand) are multi-triple and are NOT annotated.
 
 ### oxttl / oxrdf upgrade assessment (the item-6 question)
 

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -265,6 +265,21 @@ the focus/path when none do). `sh:singleLine true` flags string values containin
 line break (LF/CR/FF/VT). `sh:rootClass C` requires each value node to be `C` or a
 transitive `rdfs:subClassOf`-descendant of it.
 
+**SHACL-1.2 per-constraint-statement reified-annotation overrides (always on, sq-pb0wm).**
+An RDF-1.2 reified annotation on a single constraint statement —
+`ex:S sh:datatype xsd:integer {| sh:deactivated true |}` (likewise `{| sh:message … |}` /
+`{| sh:severity … |}`) — overrides JUST that constraint occurrence, distinct from the
+shape-level `sh:deactivated`/`sh:message`/`sh:severity` (which apply to the whole shape).
+`{| sh:deactivated true |}` suppresses ONLY that constraint (the shape's other constraints
+still validate); `{| sh:message "…"@en |}` sets `sh:resultMessage` for ONLY that
+constraint's results; `{| sh:severity sh:Warning |}` sets `sh:resultSeverity` for ONLY that
+constraint's violations. The `{| … |}` is parsed by oxttl's rdf-12 Turtle support and stored
+as `_:r rdf:reifies <<( ex:S sh:datatype xsd:integer )>> . _:r sh:deactivated|message|severity V`;
+the override resolves per occurrence from that reifier (`misc/{deactivated-003,message-002,
+severity-003}`). Supported on single-statement Core constraints (`sh:datatype`, `sh:nodeKind`,
+`sh:class`, `sh:hasValue`, `sh:rootClass`, `sh:node`, `sh:property`, `sh:not`, `sh:someValue`,
+`sh:memberShape`); list-/path-valued operands are not single statements and carry no override.
+
 **SHACL-1.2 targets & SPARQL node expressions (always on, no feature flag, sq-rnkdh).**
 Beyond `sh:targetNode`/`Class`/`SubjectsOf`/`ObjectsOf` + implicit class targets:
 - **`sh:targetWhere [ <inline shape> ]`** — focus nodes are every data-graph node that
@@ -498,8 +513,10 @@ SHACL-spec-correct conforms/violations).
   `$shapesGraph` — see the crate's open beads (`bd list -l area:sparq-shacl`).
 - **W3C conformance:** 98/98 of the *1.0/1.1* core `sht:Validate` suite passes
   (`--test w3c_core`). The **full vendored SHACL 1.2** tree is gated by a ratchet
-  (sq-6glcr) in BOTH feature states: full core **129** (default) / **130** (`shacl-af`)
-  (`--test w3c_core_full_shacl12`), 1.2 SPARQL **17** of 24 incl. 7 expected-rejection
+  (sq-6glcr) in BOTH feature states: full core **136** (default) / **137** (`shacl-af`)
+  — every in-scope core entry passes, 0 honest FAILs (sq-pb0wm closed the final
+  per-statement reified-annotation gap) — (`--test w3c_core_full_shacl12`), 1.2 SPARQL
+  **24** of 24 incl. 7 expected-rejection
   `sht:Failure` entries (`--test w3c_sparql_shacl12`), node-expr **62 + 1 xfail**
   (driven through the REAL `eval_node_expression`, `--test w3c_node_expr`, `shacl-af`;
   the xfail is the harness `sht:scope-*` var entry the crate's eval has no counterpart


### PR DESCRIPTION
> 🤖 **SPARQ agent** implementing bead **sq-pb0wm** (epic **sq-waf9o** — Full W3C SHACL 1.2 conformance).

## What this closes

The **FINAL SHACL 1.2 core conformance gap**: per-constraint-statement RDF-1.2 reified-annotation overrides. A `{| … |}` annotation on **one** constraint statement `(shape P O)` now overrides **just that constraint occurrence** — moving the three vendored W3C entries **`misc/deactivated-003`**, **`misc/message-002`**, **`misc/severity-003`** from FAIL → PASS via the real `validate()`.

| Annotation | Effect (scoped to that occurrence only) |
| --- | --- |
| `{\| sh:deactivated true \|}` | suppress ONLY that constraint (the shape's other constraints still validate) — distinct from shape-level `sh:deactivated` |
| `{\| sh:message "…"@en \|}` | `sh:resultMessage` for ONLY that constraint's results |
| `{\| sh:severity sh:Warning \|}` | `sh:resultSeverity` for ONLY that constraint's violations |

After parsing, the annotation is `_:r rdf:reifies <<( shape P O )>> . _:r sh:deactivated|sh:message|sh:severity V` (confirmed in-worktree). This is a **SHACL-MODEL feature only** — **no `Cargo.toml`/`Cargo.lock` dependency change** (oxttl 0.2.3 + oxrdf 0.3.3 with `rdf-12` already parse `{\| \|}` into a triple-term).

## How

A per-occurrence `ComponentMeta` (`deactivated` / `messages` / `severity`) held in a vector **parallel to `Shape::components`**. `ShapesModel::attach_component_meta` resolves the reifier of each constraint triple in the shapes graph after the components are built; `validate_shape` skips a per-statement-deactivated occurrence and threads the active meta so `result()` applies the per-occurrence message/severity (distinct from the shape-level fields, which keep working). The expression-constraint second pass + `validate_shape` are kept index-aligned with a defensive fallback — this caught a `nodeByExpression-001` regression mid-implementation (a `zip` was truncating the post-built expression component), now fixed.

## Floors (two-sided ratchet, both feature states)

Re-measured in-worktree and raised in `tests/w3c_core_full_shacl12.rs`:

| | default | `--features shacl-af` |
| --- | --- | --- |
| `BASELINE_PASS_*` | 133 → **136** | 134 → **137** |
| `BASELINE_FAIL_*` | 3 → **0** | 3 → **0** |

Every in-scope full-core entry now passes; the gate stays a **two-sided ratchet** (not an all-pass assert) so a future regression in either direction is still caught. The default floor **equals** the default achieved (136), not above it.

## Tests

Direct unit tests in `tests/constraints.rs` exercising the real `validate()`: per-statement deactivate (incl. *sibling-stays-live* and `sh:property`), message override, severity override (incl. *occurrence-scoping* with a sibling keeping default `sh:Violation`). The 3 W3C entries pass through the manifest-driven harness.

## Divergence (draft ambiguity decided)

Per-statement annotation semantics are the least-settled corner of the SHACL 1.2 draft. Decided (documented in `research/shacl12-conformance-gap.md` §6):
1. **Override scope = the single annotated occurrence, not the whole shape** — exactly what `deactivated-003` encodes.
2. A message/severity annotation on a **shape-referencing** constraint (`sh:property`/`sh:node`) governs that composite component's own results; the nested shape uses its own metas (not exercised by the suite — conservative occurrence-local reading). Only **single-statement** Core constraints with a faithfully-recoverable object term carry an override; list-/path-valued operands are multi-triple and are not annotated.

## Gates run (BOTH default and `--features shacl-af`)

- `cargo test -p sparq-shacl` — **0 failures** (all 22 test binaries) in both states
- `cargo clippy -p sparq-shacl --all-targets -- -D warnings` — clean in both states; workspace clippy clean
- `cargo +1.88 check -p sparq-shacl` — clean in both states
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean
- `python3 scripts/check-readme-template.py --enforce` — **0 deviations** (README ≤120 lines)
- `typos` — clean

No regression: the 24 SPARQL entries + shape-level `sh:deactivated`/`sh:message`/`sh:severity` still pass; key dependents (`sparq-server`, `sparq-kb`, `sparq-trust`) build.

Auto-merge intentionally **not** armed.