### PR TITLE
chore(perf): re-baseline wasm_bundle_bytes floor to current main (maintainer-approved)

### DIFF
--- a/bench/perf-baseline.json
+++ b/bench/perf-baseline.json
@@ -40,7 +40,16 @@
     "EXPLAIN / EXPLAIN ANALYZE plan-formatting + analyze-trace code paths (sparq_engine::explain /",
     "explain_analyze) that the prior bundle never reached. 1656470 is the exact CI-measured wasm-pack",
     "release bundle size on this branch (run 27592086692, the 'run + track benchmarks' lane), not a guess.",
-    "Bundle-growth beyond +2% of THIS new floor must again be an explicit raise."
+    "Bundle-growth beyond +2% of THIS new floor must again be an explicit raise.",
+    "[OPUS-4.8] (#1135 🟡#6) 2026-06-29: wasm_bundle_bytes floor RE-BASELINED 1656470 -> 1686907 (+1.84%) to",
+    "current main per MAINTAINER APPROVAL ('you have permission to re-bundle the WASM baseline' — RAISE path #1,",
+    "reviewed-PR). NOT a single new feature: legitimate cumulative merged-feature drift had crept main to +1.84%",
+    "over the stale floor, so any always-on PR's small addition (e.g. #1257 multiplicity() at +0.36%, the",
+    "lexical-form-class always-on changes) topped the +2% gate. Floor set to current-main EXACTLY (the byte-",
+    "deterministic CI-measured value 1686907 — runs 28351377270 & 28349508714 and the benchmark-data series both",
+    "publish 1686907 on the x86_64 runner; a cross-arch local aarch64 build reads 1687481, +0.034%, host-arch",
+    "non-reproducibility, so the CI value is authoritative). NOT set above current so the push-to-main auto-",
+    "ratchet-down stays stable. threshold 0.02 + mode auto UNCHANGED — the +2% guard is RETAINED, not widened."
   ],
   "metrics": {
     "store_bytes_per_triple": {
@@ -59,7 +68,7 @@
       "mode": "auto"
     },
     "wasm_bundle_bytes": {
-      "floor": 1656470,
+      "floor": 1686907,
       "threshold": 0.02,
       "mode": "auto"
     },


### PR DESCRIPTION
> 🤖 **SPARQ agent** — maintainer-approved re-baseline of the wasm bundle-size perf floor.

## What

Raise `metrics.wasm_bundle_bytes.floor` in `bench/perf-baseline.json` from the stale **1656470** to the exact current-main value **1686907** (+1.84%). `threshold: 0.02` and `mode: auto` are **UNCHANGED** — the +2% guard is RETAINED, not widened/disabled. The diff touches ONLY this one file (the floor value + a one-line `_comment` note).

## Why — maintainer permission + honest rationale (#1135 🟡#6)

The maintainer explicitly granted: **"You have permission to re-bundle the WASM baseline."** This is the human-in-the-loop approval for **RAISE path #1** documented in the `scripts/perf-gate.py` header ('Edit `bench/perf-baseline.json` in a reviewed PR').

This is **not** a single new feature's bump — it is legitimate **cumulative merged-feature drift**: main has crept to **+1.84%** over the stale floor (1518547 → … → 1686907 across many accepted feature additions). With only ~0.16% of headroom left, any always-on PR's small addition tops the +2% gate — currently **blocking #1257 `multiplicity()` at +0.36%** and the lexical-form-class always-on changes.

## Canonical value (authoritative)

`wasm_bundle_bytes` is byte-deterministic (integer byte count, runner-noise-immune). The floor is set to current-main **EXACTLY** (1686907), **not above** — an above-current floor would just be pulled back down by the push-to-main auto-ratchet (`--update-baseline`), and would be dishonest. Setting floor = current restores the full +2% headroom via the unchanged threshold.

- **CI (authoritative):** bench.yml runs **28351377270** and **28349508714** (both on `main`) and the published `benchmark-data` series (last 6 main commits incl. HEAD `d351b1f9`) all publish **1686907** bytes on the `x86_64-unknown-linux-gnu` runner. Dead-flat + deterministic across commits.
- **Local cross-check:** reproducing the exact `ci-bench.sh` build (`cargo build --release -q -p sparq-wasm --target wasm32-unknown-unknown`, no wasm-opt step) on this box reads **1687481** bytes (+0.034%). The small delta is host-arch non-reproducibility (CI host x86_64 vs local aarch64; identical rustc `1.96.0 ac68faa20`, identical `wasm32-unknown-unknown` target, clean tree at `d351b1f9`). Per the task contract, the **CI value is authoritative** — the local value is a sanity cross-check only, not the floor.

## Validation (local)

- `python3 scripts/perf-gate.py --self-test` → ALL ASSERTIONS PASSED.
- Current-main exact (1686907) → **PASS** (exit 0, +0.00%).
- A hypothetical +0.36% always-on PR like **#1257** (1692980) → **PASS** (exit 0, +0.36% ≤ +2%) — **#1257 is unblocked**.
- A hypothetical +3% (1737514) → **HARD FAIL** (exit 2) — the **+2% guard is intact**, not disabled.
- `python3 scripts/check-no-perf-numbers.py` → 0 findings (`perf-baseline.json` is explicitly allow-listed).
- Valid JSON; diff touches ONLY `bench/perf-baseline.json`; no other metric's floor/threshold/mode changed.

## Gate impact

The required `ci-summary / gate` aggregator is unaffected — this is a doc/CI-data change (no `crates/` source; the path-filter keeps heavy Rust jobs skipped). The perf-gate leg now passes on current main with full +2% headroom restored, and unblocks #1257 + the lexical-form-class always-on changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)