### PR TITLE
test(conformance): graduate JSON-LD expand + flatten lanes to gated ratchets (sq-oy1f) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1306,8 +1306,8 @@ jobs:
           # never produced" (an infra/compile flake left the .out with no TOTAL line)
           # from a GENUINE regression, so an empty scoreboard is never mis-reported as
           # "regressed below the ratchet".
-          if ! grep -qE '^TOTAL (toRdf|fromRdf|compact|frame) ' jsonld-conformance.out; then
-            echo "::error::JSON-LD conformance scoreboard is missing/empty — the test step produced no 'TOTAL toRdf|fromRdf|compact|frame' line. This is an INFRA/build failure (e.g. a transient crates.io download), NOT a conformance regression. Re-run the job; inspect the 'Run JSON-LD ... suites' step output above."
+          if ! grep -qE '^TOTAL (toRdf|fromRdf|compact|frame|expand|flatten) ' jsonld-conformance.out; then
+            echo "::error::JSON-LD conformance scoreboard is missing/empty — the test step produced no 'TOTAL toRdf|fromRdf|compact|frame|expand|flatten' line. This is an INFRA/build failure (e.g. a transient crates.io download), NOT a conformance regression. Re-run the job; inspect the 'Run JSON-LD ... suites' step output above."
             exit 1
           fi
           # [OPUS-4.8] sq-oy1f.16 — RAISED 163 → 186 after #978's compaction
@@ -1317,16 +1317,25 @@ jobs:
           # [OPUS-4.8] sq-oy1f.19 — the frame ratchet (RDF → framed JSON-LD over the
           # w3c/json-ld-framing suite; normative-answer-equivalence). Same grep shape.
           FRAME_FLOOR=61
+          # [OPUS-4.8] sq-oy1f — the expand + flatten ratchets (RDF → expanded/flattened
+          # JSON-LD via the shipping graph_to_jsonld writer; normative-answer-equivalence).
+          # Same grep shape. MEASURED pass counts at the pinned revision.
+          EXPAND_FLOOR=247
+          FLATTEN_FLOOR=50
           # runner prints: "TOTAL toRdf <pass> <fail> <skip> (floor F)"
           TORDF_PASS=$(grep -E '^TOTAL toRdf ' jsonld-conformance.out | awk '{print $3}' | head -1)
           FROMRDF_PASS=$(grep -E '^TOTAL fromRdf ' jsonld-conformance.out | awk '{print $3}' | head -1)
           COMPACT_PASS=$(grep -E '^TOTAL compact ' jsonld-conformance.out | awk '{print $3}' | head -1)
           FRAME_PASS=$(grep -E '^TOTAL frame ' jsonld-conformance.out | awk '{print $3}' | head -1)
-          echo "JSON-LD toRdf pass: ${TORDF_PASS:-unknown} (floor $TORDF_FLOOR); fromRdf pass: ${FROMRDF_PASS:-unknown} (floor $FROMRDF_FLOOR); compact pass: ${COMPACT_PASS:-unknown} (floor $COMPACT_FLOOR); frame pass: ${FRAME_PASS:-unknown} (floor $FRAME_FLOOR)"
+          EXPAND_PASS=$(grep -E '^TOTAL expand ' jsonld-conformance.out | awk '{print $3}' | head -1)
+          FLATTEN_PASS=$(grep -E '^TOTAL flatten ' jsonld-conformance.out | awk '{print $3}' | head -1)
+          echo "JSON-LD toRdf pass: ${TORDF_PASS:-unknown} (floor $TORDF_FLOOR); fromRdf pass: ${FROMRDF_PASS:-unknown} (floor $FROMRDF_FLOOR); compact pass: ${COMPACT_PASS:-unknown} (floor $COMPACT_FLOOR); frame pass: ${FRAME_PASS:-unknown} (floor $FRAME_FLOOR); expand pass: ${EXPAND_PASS:-unknown} (floor $EXPAND_FLOOR); flatten pass: ${FLATTEN_PASS:-unknown} (floor $FLATTEN_FLOOR)"
           [ -n "$TORDF_PASS" ] && [ "$TORDF_PASS" -ge "$TORDF_FLOOR" ] || { echo "::error::JSON-LD toRdf regressed below the ratchet (${TORDF_PASS:-?} < $TORDF_FLOOR)"; exit 1; }
           [ -n "$FROMRDF_PASS" ] && [ "$FROMRDF_PASS" -ge "$FROMRDF_FLOOR" ] || { echo "::error::JSON-LD fromRdf regressed below the ratchet (${FROMRDF_PASS:-?} < $FROMRDF_FLOOR)"; exit 1; }
           [ -n "$COMPACT_PASS" ] && [ "$COMPACT_PASS" -ge "$COMPACT_FLOOR" ] || { echo "::error::JSON-LD compact regressed below the ratchet (${COMPACT_PASS:-?} < $COMPACT_FLOOR)"; exit 1; }
           [ -n "$FRAME_PASS" ] && [ "$FRAME_PASS" -ge "$FRAME_FLOOR" ] || { echo "::error::JSON-LD frame regressed below the ratchet (${FRAME_PASS:-?} < $FRAME_FLOOR)"; exit 1; }
+          [ -n "$EXPAND_PASS" ] && [ "$EXPAND_PASS" -ge "$EXPAND_FLOOR" ] || { echo "::error::JSON-LD expand regressed below the ratchet (${EXPAND_PASS:-?} < $EXPAND_FLOOR)"; exit 1; }
+          [ -n "$FLATTEN_PASS" ] && [ "$FLATTEN_PASS" -ge "$FLATTEN_FLOOR" ] || { echo "::error::JSON-LD flatten regressed below the ratchet (${FLATTEN_PASS:-?} < $FLATTEN_FLOOR)"; exit 1; }
       - name: Emit consolidated conformance scoreboard
         # Render the ONE central scoreboard index (all suites + floors across crates)
         # into this job's step summary, so the JSON-LD job surfaces where it sits in

--- a/crates/sparq-conformance/README.md
+++ b/crates/sparq-conformance/README.md
@@ -8,17 +8,17 @@ result-comparison machinery: `sparq-conformance` (W3C SPARQL query/update/syntax
 `sparq-inference-conformance` (RDF Semantics, OWL 2 RL, N3, entailment regimes via
 `sparq-reason`), and `sparq-conformance-scoreboard` (consolidated index of every
 ratchet — SPARQL, inference, W3C SHACL, OGC GeoSPARQL, Solid WAC + ACP, **W3C
-JSON-LD 1.1 toRdf + fromRdf + compact + frame**, **SolidLab ODRL Test Suite**).
+JSON-LD 1.1 toRdf + fromRdf + compact + expand + flatten + frame**, **SolidLab ODRL**).
 
 A crate-local `cargo test` ratchet behind the **opt-in `jsonld-suite`** feature
-drives the `w3c/json-ld-api` suite (toRdf + fromRdf + **compact**, lossless
-self-reparse `reparse(compact(D,ctx)) ≡ D`; floor raised 163→186 by sq-oy1f.16) and
-the SEPARATE `w3c/json-ld-framing` suite (**frame**, sq-oy1f.19): each `jld:FrameTest`
-EXPANDED input is framed via the native Framing Algorithm and compared by
-RDF-equivalence to the suite's NORMATIVE expected output (framing is a SELECT+RESHAPE,
-so the oracle anchors on `expected`, not the input). Honest divergences are reported,
-never inflated. The ODRL ratchet (sq-tmsd6) lives in `sparq-policy`; only its FLOOR is
-mirrored here.
+drives the `w3c/json-ld-api` suite (toRdf + fromRdf + **compact** + **expand** +
+**flatten**, sq-oy1f) and the SEPARATE `w3c/json-ld-framing` suite (**frame**,
+sq-oy1f.19). expand/flatten/frame drive the shipping writer and are compared by
+RDF-equivalence to the suite's NORMATIVE expected document (these are normal forms /
+a SELECT+RESHAPE, so the oracle anchors on `expected`, not the input); compact uses a
+lossless self-reparse `reparse(compact(D,ctx)) ≡ D`. Floors are the MEASURED pass
+counts; honest divergences are reported, never inflated. The ODRL ratchet (sq-tmsd6)
+lives in `sparq-policy`; only its FLOOR is mirrored here.
 
 > **Internal dev-only harness — not published** (`publish = false`). Test data is
 > fetched by `scripts/fetch-conformance.sh`, `fetch-jsonld-tests.sh`,

--- a/crates/sparq-conformance/src/inference/sparql_entail.rs
+++ b/crates/sparq-conformance/src/inference/sparql_entail.rs
@@ -109,6 +109,17 @@ fn result(entry: &TestEntry, outcome: Outcome) -> TestResult {
 }
 
 fn run_one(entry: &TestEntry, profile: Profile, direct_sanctioned: bool) -> Outcome {
+    // [OPUS-4.8] sq-oy1f — the `sparql11/entailment` manifest at the pinned
+    // rdf-tests revision contains NO `qt:graphData` entries (every entailment test
+    // uses a single default-graph `qt:data` dataset), so this guard is currently
+    // unreachable: there are zero named-graph entailment cases to graduate. It is
+    // RETAINED as a fail-closed safeguard — should a future suite bump add a
+    // named-graph entailment test, it would be reported OutOfScope (honest) rather
+    // than silently materialized through the default-graph-only path below, which
+    // would give a WRONG closure (the named-graph dataset would need per-graph
+    // entailment semantics in sparq-reason, not just harness wiring). Wiring that
+    // properly is tracked as a deferred bead; do NOT drop the guard to "make it run"
+    // until the reasoner models named-graph materialization.
     if !entry.action.graph_data.is_empty() {
         return Outcome::OutOfScope("named-graph entailment dataset not wired".into());
     }

--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -141,6 +141,14 @@ pub struct Suite {
 ///   `FRAME_FLOOR = 61` (sq-oy1f.19; opt-in `jsonld-suite` feature; RDF → framed
 ///   JSON-LD via the native Framing Algorithm over the SEPARATE w3c/json-ld-framing
 ///   suite, compared by re-parse RDF-equivalence to the normative expected output).
+/// * JSON-LD expand 247 — `sparq-conformance` `tests/jsonld_suite.rs`
+///   `EXPAND_FLOOR = 247` (sq-oy1f; opt-in `jsonld-suite` feature; RDF → expanded
+///   JSON-LD via the shipping `graph_to_jsonld(JsonLdForm::Expanded)` writer,
+///   compared by re-parse RDF-equivalence to the normative expected document).
+/// * JSON-LD flatten 50 — `sparq-conformance` `tests/jsonld_suite.rs`
+///   `FLATTEN_FLOOR = 50` (sq-oy1f; opt-in `jsonld-suite` feature; RDF → flattened
+///   JSON-LD via the shipping `graph_to_jsonld(JsonLdForm::Flattened)` writer,
+///   compared by re-parse RDF-equivalence to the normative expected document).
 /// * Solid WAC differential 0 — `sparq-solid` `tests/differential_oracle.rs`
 ///   `DIVERGENCE_FLOOR = 0` (sq-t58w.8; a divergence-count floor, hard 0 — the WAC
 ///   and ACP differential rows share this one const).
@@ -253,20 +261,23 @@ pub const SUITES: &[Suite] = &[
         note: "engine vs an independent reference evaluator vs the hand Expect table, \
                over the ACP parity corpus (zero divergence)",
     },
-    // [OPUS-4.8] sq-oy1f.2 / sq-3uos5 / sq-oy1f.19 — the W3C JSON-LD 1.1 conformance
-    // ratchets. The runner is crate-local here (`tests/jsonld_suite.rs`) but behind
-    // the OPT-IN `jsonld-suite` feature (forwards to sparq-core/jsonld + sparq-engine/
-    // serialize-rdf) so the default + `--workspace` builds neither link oxjsonld
-    // nor go red — the lean-core posture. Four gated categories: toRdf (JSON-LD →
-    // RDF through the real oxjsonld parse path), fromRdf (RDF → JSON-LD through the
-    // native serialize-rdf writer, re-parse round-trip), compact (RDF → compacted
-    // JSON-LD via the native Compaction Algorithm, lossless round-trip), and frame
-    // (RDF → framed JSON-LD via the native Framing Algorithm over the SEPARATE
-    // w3c/json-ld-framing suite, RDF-equivalence to the normative expected output).
+    // [OPUS-4.8] sq-oy1f.2 / sq-3uos5 / sq-oy1f.19 / sq-oy1f — the W3C JSON-LD 1.1
+    // conformance ratchets. The runner is crate-local here (`tests/jsonld_suite.rs`)
+    // but behind the OPT-IN `jsonld-suite` feature (forwards to sparq-core/jsonld +
+    // sparq-engine/serialize-rdf) so the default + `--workspace` builds neither link
+    // oxjsonld nor go red — the lean-core posture. Six gated categories: toRdf
+    // (JSON-LD → RDF through the real oxjsonld parse path), fromRdf (RDF → JSON-LD
+    // through the native serialize-rdf writer, re-parse round-trip), compact (RDF →
+    // compacted JSON-LD via the native Compaction Algorithm, lossless round-trip),
+    // frame (RDF → framed JSON-LD via the native Framing Algorithm over the SEPARATE
+    // w3c/json-ld-framing suite, RDF-equivalence to the normative expected output),
+    // and expand + flatten (RDF → expanded/flattened JSON-LD via the shipping
+    // `graph_to_jsonld` writer, RDF-equivalence to the normative expected document).
     // The floors are the MEASURED pass counts at the pinned suite revisions (NOT
-    // 100% — remote-context/option divergences are honest, recorded gaps); they may
-    // only RISE. expand-out/flatten-out remain the documented NOT-IMPLEMENTED
-    // buckets the runner reports separately (never failed). Floors kept in lock-step
+    // 100% — remote-context/option/writer-shape divergences are honest, recorded
+    // gaps); they may only RISE. html + remote-doc remain the documented
+    // NOT-IMPLEMENTED buckets the runner reports separately (never failed). Floors
+    // kept in lock-step
     // by `tests/scoreboard_floors.rs`.
     Suite {
         label: "W3C JSON-LD 1.1 toRdf",
@@ -351,6 +362,49 @@ pub const SUITES: &[Suite] = &[
         note: "RDF → framed JSON-LD through the native Framing Algorithm \
                (serialize-rdf) over the w3c/json-ld-framing suite, compared by a \
                re-parse RDF-equivalence to the normative expected output",
+    },
+    // [OPUS-4.8] sq-oy1f — the W3C JSON-LD 1.1 `expand` + `flatten` ratchets (epic
+    // sq-oy1f). Each `jld:ExpandTest` / `jld:FlattenTest` input is parsed to RDF (the
+    // real oxjsonld path), then driven through the ALREADY-SHIPPING native writer
+    // `graph_to_jsonld(JsonLdForm::Expanded|Flattened)` (serialize-rdf), and the
+    // produced document is re-parsed and required to reconstruct the SAME RDF dataset
+    // as the suite's NORMATIVE expected document (`reparse(write(D, form)) ≡
+    // reparse(expected)` — expand/flatten are the JSON-LD normal forms, so the oracle
+    // anchors on the expected document, NOT the input). The floors are the MEASURED
+    // pass counts at the pinned revision (expand 247/385, flatten 50/58); the
+    // remaining cases are honest writer divergences (below the floor, to RISE) or
+    // documented SKIP buckets (negatives sparq's TOTAL writer does not raise,
+    // JSON-LD-1.0-only, empty-RDF inputs). These GRADUATED out of the runner's
+    // NOT_IMPLEMENTED bucket. Floors kept in lock-step by `tests/scoreboard_floors.rs`.
+    Suite {
+        label: "W3C JSON-LD 1.1 expand",
+        family: "W3C JSON-LD",
+        runner: Runner::FeatureGatedCrateTest {
+            krate: "sparq-conformance",
+            target: "jsonld_suite",
+            feature: "jsonld-suite",
+        },
+        ci_job: "jsonld-conformance",
+        ratchet_floor: 247,
+        floor_basis: "pass",
+        note: "RDF → expanded JSON-LD through the shipping graph_to_jsonld(Expanded) \
+               writer (serialize-rdf), compared by a re-parse RDF-equivalence to the \
+               normative expected document",
+    },
+    Suite {
+        label: "W3C JSON-LD 1.1 flatten",
+        family: "W3C JSON-LD",
+        runner: Runner::FeatureGatedCrateTest {
+            krate: "sparq-conformance",
+            target: "jsonld_suite",
+            feature: "jsonld-suite",
+        },
+        ci_job: "jsonld-conformance",
+        ratchet_floor: 50,
+        floor_basis: "pass",
+        note: "RDF → flattened JSON-LD through the shipping graph_to_jsonld(Flattened) \
+               writer (serialize-rdf), compared by a re-parse RDF-equivalence to the \
+               normative expected document",
     },
     // [OPUS-4.8] sq-tmsd6 — the SolidLab ODRL Test Suite, wired as a crate-local
     // decision-parity ratchet in sparq-policy (mirrors the Solid WAC/ACP pattern:

--- a/crates/sparq-conformance/tests/jsonld_suite.rs
+++ b/crates/sparq-conformance/tests/jsonld_suite.rs
@@ -202,6 +202,68 @@ mod gated {
     /// never used to hide a divergence.
     pub const FRAME_FLOOR: usize = 61;
 
+    /// [OPUS-4.8] sq-oy1f — `expand` (RDF → expanded JSON-LD via the
+    /// ALREADY-SHIPPING writer `graph_to_jsonld(JsonLdForm::Expanded)`, the
+    /// `serialize-rdf` feature) pass floor over the `expand` category of
+    /// `w3c/json-ld-api`. RATCHET: may only RISE. This is the MEASURED pass count
+    /// at the pinned suite revision — the number of `jld:ExpandTest` cases for
+    /// which expanding the input's RDF and re-parsing the produced expanded
+    /// document reconstructs the SAME RDF dataset as re-parsing the suite's
+    /// NORMATIVE expected expanded document (`reparse(expand(D)) ≡ reparse(expected)`).
+    ///
+    /// ## Why compare against `expect`, not the input
+    ///
+    /// Expansion is the algorithmic NORMAL FORM, not a lossless round-trip of the
+    /// input JSON layout: it drops free-floating nodes, resolves `@context`, and
+    /// canonicalises value/node objects. Comparing `reparse(expand(D)) ≡ D` would
+    /// over-pass on cases whose input has structure the RDF projection legitimately
+    /// drops. The normative answer is the suite's `*-out.jsonld`; sparq's expanded
+    /// output must encode the SAME RDF as that expected document. Comparing the two
+    /// as canonical RDF datasets is value-faithful while NOT requiring sparq's JSON
+    /// layout to match byte-for-byte (the same oxjsonld self-reparse oracle the
+    /// frame lane uses).
+    ///
+    /// ## Honest SKIP buckets (recorded, not passed, not failed)
+    ///
+    /// * `requires` optional-feature cases — out of the gated surface.
+    /// * NegativeEvaluationTests — sparq's writer is TOTAL and never raises the
+    ///   spec's expansion errors (`invalid @context`, keyword redefinition,
+    ///   collision errors, …); a 1.1 writer that does not model those errors cannot
+    ///   honestly "pass" by rejecting, so these are SKIPPED (the compact/frame-lane
+    ///   posture), never a counted pass.
+    /// * JSON-LD-1.0-only positives (`specVersion`/`processingMode` =
+    ///   `json-ld-1.0`) — a 1.1 writer is not obliged to reproduce 1.0 shape — SKIP.
+    /// * A positive case whose input → RDF is EMPTY (free-floating-node drops, pure
+    ///   `@context` with no triples): nothing to expand, the round-trip is vacuous
+    ///   and tells us nothing about the algorithm — SKIP.
+    ///
+    /// MEASURED 247/385 at the pinned revision: expand 247 pass / 10 fail / 128
+    /// skip. The 10 FAILs are honest writer divergences below the floor (to RISE):
+    /// `@direction`/i18n-datatype shapes (`tdi*`), `@list`/coercion cases whose RDF
+    /// projection differs from the expected expanded document, and one case whose
+    /// expected `*-out.jsonld` oxjsonld itself cannot re-parse (`@id` non-string).
+    /// The 128 SKIP are the documented buckets (NegativeEvaluationTests sparq's
+    /// TOTAL writer does not raise, JSON-LD-1.0-only positives, and positives whose
+    /// input → RDF is empty so the projection is vacuous). The rest stay
+    /// tracked-not-asserted.
+    pub const EXPAND_FLOOR: usize = 247;
+
+    /// [OPUS-4.8] sq-oy1f — `flatten` (RDF → flattened JSON-LD via the
+    /// ALREADY-SHIPPING writer `graph_to_jsonld(JsonLdForm::Flattened)`, the
+    /// `serialize-rdf` feature) pass floor over the `flatten` category of
+    /// `w3c/json-ld-api`. RATCHET: may only RISE. This is the MEASURED pass count
+    /// at the pinned suite revision — the number of `jld:FlattenTest` cases for
+    /// which flattening the input's RDF and re-parsing the produced flattened
+    /// document reconstructs the SAME RDF dataset as re-parsing the suite's
+    /// NORMATIVE expected flattened document (`reparse(flatten(D)) ≡ reparse(expected)`).
+    /// Same oracle, SKIP buckets, and caveat as `EXPAND_FLOOR` (flattening is the
+    /// node-merged normal form; the oracle anchors on the expected document, not the
+    /// input). MEASURED 50/58 at the pinned revision: flatten 50 pass / 0 fail / 8
+    /// skip — every flatten case the writer drives round-trips to the normative
+    /// expected document; the 8 SKIP are the documented buckets (1
+    /// NegativeEvaluationTest, JSON-LD-1.0-only positives, and empty-RDF inputs).
+    pub const FLATTEN_FLOOR: usize = 50;
+
     /// [OPUS-4.8] sq-oy1f.19 — the framing suite's declared base (its
     /// `baseIri`), used to resolve each frame test's input path into the document
     /// IRI. Distinct from `SUITE_BASE` (the json-ld-api base) — framing is a
@@ -955,6 +1017,154 @@ mod gated {
         s
     }
 
+    /// [OPUS-4.8] sq-oy1f — run a W3C JSON-LD `expand` / `flatten` category against
+    /// the ALREADY-SHIPPING native writer (`graph_to_jsonld(graph, form)`, the
+    /// `serialize-rdf` feature), with `form` = [`JsonLdForm::Expanded`] for `expand`
+    /// and [`JsonLdForm::Flattened`] for `flatten`.
+    ///
+    /// ## Pipeline (the REAL writer path)
+    ///
+    /// 1. Parse the case `input` (`.jsonld`) → RDF via the real oxjsonld ingest path
+    ///    (`parse_jsonld_dataset`).
+    /// 2. Re-emit that dataset as N-Quads and load it into a sparq [`Graph`]
+    ///    (preserving named graphs) — the writer takes a `Graph`, not a JSON-LD doc,
+    ///    because sparq's expand/flatten OUTPUT is a projection of RDF (exactly the
+    ///    bridge `run_compact` / `run_frame` use).
+    /// 3. Run `graph_to_jsonld(&graph, form)` — the shipping writer, NOT a stub.
+    /// 4. **Invariant (normative answer-equivalence):** re-parse BOTH sparq's output
+    ///    AND the suite's NORMATIVE expected document (`*-out.jsonld`) to canonical
+    ///    [`Dataset`]s and require they are equal:
+    ///    `reparse(write(D, form)) ≡ reparse(expected)`. Expansion/flattening are the
+    ///    JSON-LD normal forms (they drop free-floating nodes / merge nodes), so the
+    ///    oracle anchors on the W3C-expected document, NOT the input — the same
+    ///    posture as the frame lane. This is envelope-insensitive and value-faithful
+    ///    while NOT requiring sparq's JSON layout to match byte-for-byte.
+    ///
+    /// ## Honest SKIP buckets (recorded, not passed, not failed) — see `EXPAND_FLOOR`
+    fn run_expand_or_flatten(
+        root: &Path,
+        cat: &str,
+        form: sparq_engine::serialize::JsonLdForm,
+    ) -> Score {
+        use sparq_engine::serialize::graph_to_jsonld;
+        let mut s = Score::default();
+        let entries = match read_manifest(root, cat) {
+            Ok(e) => e,
+            Err(why) => {
+                s.fail(&format!("{cat}-manifest"), why);
+                return s;
+            }
+        };
+        for e in &entries {
+            if e.requires.is_some() {
+                s.skip();
+                continue;
+            }
+            // NegativeEvaluationTest: sparq's writer is TOTAL and does not raise the
+            // spec's expansion/flattening errors, so a faithful 1.1 writer cannot
+            // "pass" by rejecting — SKIP (honest), never a counted pass.
+            if e.is_negative {
+                s.skip();
+                continue;
+            }
+            // JSON-LD-1.0-only positives (processing-mode shape differences a 1.1
+            // writer is not obliged to reproduce): SKIP.
+            if e.spec_version.as_deref() == Some("json-ld-1.0")
+                || e.processing_mode.as_deref() == Some("json-ld-1.0")
+            {
+                s.skip();
+                continue;
+            }
+            let Some(expect_rel) = &e.expect else {
+                s.skip();
+                continue;
+            };
+            // Remote input (no network) — guard (the toRdf lane already gates ingest).
+            if e.input.starts_with("http://") || e.input.starts_with("https://") {
+                s.skip();
+                continue;
+            }
+
+            // 1. Parse the input JSON-LD → RDF (the source dataset). An input the
+            //    real oxjsonld path rejects, or `option`-driven cases the writer does
+            //    not apply (e.g. `expandContext`), produce RDF that legitimately
+            //    differs from `expected`; those that fail to parse are SKIPPED (out of
+            //    the gated surface), those that parse but diverge are honest FAILs.
+            let input_path = root.join(&e.input);
+            let in_text = match std::fs::read_to_string(&input_path) {
+                Ok(t) => t,
+                Err(why) => {
+                    s.fail(&e.id, format!("read input: {why}"));
+                    continue;
+                }
+            };
+            let base = doc_base(e);
+            let input_ds = match parse_jsonld_dataset(&in_text, &base) {
+                Ok(ds) => ds,
+                Err(_) => {
+                    s.skip();
+                    continue;
+                }
+            };
+            // No triples → nothing to project; the round-trip is vacuous. SKIP.
+            if input_ds.is_empty() {
+                s.skip();
+                continue;
+            }
+
+            // 2. Load the input RDF into a sparq Graph (named graphs preserved) and
+            //    run the REAL shipping writer in the requested form.
+            let nq = dataset_to_nquads(&input_ds);
+            let graph = match Graph::load_dataset(&nq, "nquads") {
+                Ok(g) => g,
+                Err(why) => {
+                    s.fail(&e.id, format!("load input rdf into graph: {why}"));
+                    continue;
+                }
+            };
+            let out_doc = graph_to_jsonld(&graph, form);
+
+            // 3. Re-parse sparq's output and the suite's NORMATIVE expected document,
+            //    require RDF-dataset equivalence (the normative answer-equivalence
+            //    invariant).
+            let got = match jsonld_to_canonical_dataset(&out_doc, &base) {
+                Ok(ds) => ds,
+                Err(why) => {
+                    s.fail(&e.id, format!("re-parse {cat} output: {why}"));
+                    continue;
+                }
+            };
+            let expect_path = root.join(expect_rel);
+            let exp_text = match std::fs::read_to_string(&expect_path) {
+                Ok(t) => t,
+                Err(why) => {
+                    s.fail(&e.id, format!("read expect: {why}"));
+                    continue;
+                }
+            };
+            let want = match jsonld_to_canonical_dataset(&exp_text, &base) {
+                Ok(ds) => ds,
+                Err(why) => {
+                    s.fail(&e.id, format!("re-parse expected output: {why}"));
+                    continue;
+                }
+            };
+            if got == want {
+                s.pass();
+            } else {
+                s.fail(
+                    &e.id,
+                    format!(
+                        "{cat} RDF != expected RDF ({} vs {} quads)",
+                        got.len(),
+                        want.len()
+                    ),
+                );
+            }
+        }
+        s
+    }
+
     /// The known-gap categories: present in the W3C suite but NOT a sparq-shipped
     /// gateable surface yet. Reported as not-implemented (never failed). The size
     /// is read from each manifest so the scoreboard shows the real backlog and
@@ -962,11 +1172,12 @@ mod gated {
     ///
     /// [OPUS-4.8] sq-3uos5 — `compact` GRADUATED out of this bucket: it is now a
     /// gated category (`run_compact`, `COMPACT_FLOOR`). [OPUS-4.8] sq-oy1f.19 —
-    /// `frame` likewise GRADUATED: it is now a gated category (`run_frame`,
-    /// `FRAME_FLOOR`) over the separate `w3c/json-ld-framing` suite.
+    /// `frame` likewise GRADUATED. [OPUS-4.8] sq-oy1f — `expand` + `flatten` now
+    /// GRADUATED too: each is a gated category (`run_expand_or_flatten`,
+    /// `EXPAND_FLOOR` / `FLATTEN_FLOOR`) driving the shipping
+    /// `graph_to_jsonld(JsonLdForm::Expanded|Flattened)` writer, compared by
+    /// re-parse RDF-equivalence to the suite's normative expected document.
     const NOT_IMPLEMENTED_CATS: &[(&str, &str)] = &[
-        ("expand", "Expansion — output-vs-W3C-document comparison not wired (sq-oy1f)"),
-        ("flatten", "Flattening — output-vs-W3C-document comparison not wired (sq-oy1f)"),
         ("html", "HTML script extraction not implemented"),
         ("remote-doc", "remote @context loader not wired (oxjsonld needs a LoadDocumentCallback)"),
     ];
@@ -991,9 +1202,13 @@ mod gated {
             return;
         }
 
+        use sparq_engine::serialize::JsonLdForm;
         let tordf = run_tordf(&root);
         let fromrdf = run_fromrdf(&root);
         let compact = run_compact(&root);
+        // [OPUS-4.8] sq-oy1f — expand + flatten now drive the shipping writer.
+        let expand = run_expand_or_flatten(&root, "expand", JsonLdForm::Expanded);
+        let flatten = run_expand_or_flatten(&root, "flatten", JsonLdForm::Flattened);
         let not_impl = not_implemented_counts(&root);
 
         // [OPUS-4.8] sq-oy1f.19 — framing lives in the SEPARATE w3c/json-ld-framing
@@ -1021,6 +1236,17 @@ mod gated {
         println!(
             "TOTAL compact {} {} {} (floor {})",
             compact.pass, compact.fail, compact.skip, COMPACT_FLOOR
+        );
+        // [OPUS-4.8] sq-oy1f — the expand + flatten ratchets. The CI grep depends on
+        // these exact `^TOTAL expand `/`^TOTAL flatten ` prefixes with the pass count
+        // in field $3 (same shape as the other lanes).
+        println!(
+            "TOTAL expand {} {} {} (floor {})",
+            expand.pass, expand.fail, expand.skip, EXPAND_FLOOR
+        );
+        println!(
+            "TOTAL flatten {} {} {} (floor {})",
+            flatten.pass, flatten.fail, flatten.skip, FLATTEN_FLOOR
         );
         // [OPUS-4.8] sq-oy1f.19 — the frame ratchet. The CI grep depends on this
         // exact `^TOTAL frame ` prefix with the pass count in field $3 (same shape
@@ -1059,6 +1285,18 @@ mod gated {
                 println!("  {}: {}", id, why);
             }
         }
+        if !expand.failures.is_empty() {
+            println!("\nexpand failures (first 40):");
+            for (id, why) in expand.failures.iter().take(40) {
+                println!("  {}: {}", id, why);
+            }
+        }
+        if !flatten.failures.is_empty() {
+            println!("\nflatten failures (first 40):");
+            for (id, why) in flatten.failures.iter().take(40) {
+                println!("  {}: {}", id, why);
+            }
+        }
         if let Some(frame) = &frame {
             if !frame.failures.is_empty() {
                 println!("\nframe failures (first 40):");
@@ -1088,6 +1326,20 @@ mod gated {
             "JSON-LD compact pass count regressed: {} < floor {} — see failures above",
             compact.pass,
             COMPACT_FLOOR
+        );
+        // [OPUS-4.8] sq-oy1f — the expand + flatten ratchets (normative
+        // answer-equivalence floors over the shipping writer).
+        assert!(
+            expand.pass >= EXPAND_FLOOR,
+            "JSON-LD expand pass count regressed: {} < floor {} — see failures above",
+            expand.pass,
+            EXPAND_FLOOR
+        );
+        assert!(
+            flatten.pass >= FLATTEN_FLOOR,
+            "JSON-LD flatten pass count regressed: {} < floor {} — see failures above",
+            flatten.pass,
+            FLATTEN_FLOOR
         );
         // [OPUS-4.8] sq-oy1f.19 — the frame ratchet (normative answer-equivalence
         // floor), asserted only when the separate framing suite is present.

--- a/crates/sparq-conformance/tests/scoreboard_floors.rs
+++ b/crates/sparq-conformance/tests/scoreboard_floors.rs
@@ -136,6 +136,21 @@ const CRATE_LOCAL_FLOORS: &[(&str, &str, &str)] = &[
         "crates/sparq-conformance/tests/jsonld_suite.rs",
         "FRAME_FLOOR",
     ),
+    // [OPUS-4.8] sq-oy1f — the W3C JSON-LD 1.1 `expand` + `flatten` ratchets driving
+    // the shipping `graph_to_jsonld(JsonLdForm::Expanded|Flattened)` writer.
+    // `pub const EXPAND_FLOOR` / `FLATTEN_FLOOR` live in the same
+    // `tests/jsonld_suite.rs`; the guard reads them textually so the central
+    // scoreboard's `ratchet_floor` can never drift from what the runner asserts.
+    (
+        "W3C JSON-LD 1.1 expand",
+        "crates/sparq-conformance/tests/jsonld_suite.rs",
+        "EXPAND_FLOOR",
+    ),
+    (
+        "W3C JSON-LD 1.1 flatten",
+        "crates/sparq-conformance/tests/jsonld_suite.rs",
+        "FLATTEN_FLOOR",
+    ),
     // [OPUS-4.8] sq-tmsd6 — the SolidLab ODRL Test Suite decision-parity ratchet.
     // The floor const (`pub const ODRL_SUITE_FLOOR`) lives top-level in
     // `sparq-policy`'s `tests/odrl_test_suite.rs`; the guard reads it textually
@@ -224,6 +239,9 @@ fn scoreboard_renders_all_suites() {
     assert!(md.contains("W3C JSON-LD 1.1 fromRdf"));
     // [OPUS-4.8] sq-3uos5 — the W3C JSON-LD 1.1 compact ratchet.
     assert!(md.contains("W3C JSON-LD 1.1 compact"));
+    // [OPUS-4.8] sq-oy1f — the W3C JSON-LD 1.1 expand + flatten ratchets.
+    assert!(md.contains("W3C JSON-LD 1.1 expand"));
+    assert!(md.contains("W3C JSON-LD 1.1 flatten"));
     // [OPUS-4.8] sq-tmsd6 — the SolidLab ODRL Test Suite decision-parity ratchet.
     assert!(md.contains("SolidLab ODRL Test Suite"));
 }

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -527,16 +527,18 @@ cargo build -p sparq-cli --features serialize-rdf
   with it off, and a memory-mapped perm carries no filter. Whether the hypothesised block-skip
   win materialises is to be confirmed on the canonical perf host (no number is asserted here).
 - **JSON-LD W3C conformance is RATCHETED (honest baseline, not 100%).** A ratcheted W3C
-  JSON-LD 1.1 conformance gate (sq-oy1f.2 + sq-3uos5 + sq-oy1f.19) drives the official
+  JSON-LD 1.1 conformance gate (sq-oy1f.2 + sq-3uos5 + sq-oy1f.19 + sq-oy1f) drives the official
   `w3c/json-ld-api` suite AND the SEPARATE `w3c/json-ld-framing` suite through the real paths:
   **toRdf** through the `jsonld` parser (oxjsonld), **fromRdf** through the `serialize-rdf`
-  writer, **compact** through the native Compaction Algorithm (`graph_to_jsonld_compact`), and
-  **frame** through the native Framing Algorithm (`graph_to_jsonld_framed`). toRdf/fromRdf/compact
+  writer, **compact** through the native Compaction Algorithm (`graph_to_jsonld_compact`),
+  **expand** + **flatten** through the shipping writer (`graph_to_jsonld(Expanded|Flattened)`),
+  and **frame** through the native Framing Algorithm (`graph_to_jsonld_framed`). toRdf/fromRdf/compact
   are compared by a re-parse RDF-dataset round-trip against the INPUT (`reparse(out) ≡ in`, the
-  oxjsonld self-reparse oracle); **frame** is compared by re-parse RDF-equivalence against the
-  suite's NORMATIVE expected output (`reparse(frame(D,F)) ≡ reparse(expected)`) — framing is a
-  SELECT+RESHAPE (it prunes/fills/drops), so the oracle anchors on the expected document, not the
-  input. The floors only RISE; they reflect ACTUAL current pass counts, not full conformance — the
+  oxjsonld self-reparse oracle); **expand/flatten/frame** are compared by re-parse RDF-equivalence
+  against the suite's NORMATIVE expected output (`reparse(write(D)) ≡ reparse(expected)`) — these
+  are JSON-LD normal forms / a SELECT+RESHAPE (they drop/merge/prune/fill), so the oracle anchors on
+  the expected document, not the input. The floors only RISE; they reflect ACTUAL current pass
+  counts, not full conformance — the
   remaining toRdf divergences are documented oxjsonld limits (remote/`@import` `@context` needs a
   `LoadDocumentCallback`; `expandContext`/`rdfDirection` options not applied; a few
   base-normalization edge cases + leniently-accepted negative tests), and fromRdf misses
@@ -555,8 +557,14 @@ cargo build -p sparq-cli --features serialize-rdf
   frame-validation errors, so it cannot honestly "pass" by rejecting). The compact/frame oracle
   is oxjsonld self-reparse, so the `@reverse` double-inversion / non-string-language interop gap
   documented above (the compaction interop caveat) is NOT caught by it and is tracked separately.
-  **expand/flatten output-document comparison remain NOT-IMPLEMENTED buckets** the runner reports
-  separately and never fails on (they grow the ratchet as those land). The lane is the opt-in
+  The **expand** + **flatten** lanes (sq-oy1f) GRADUATED out of the NOT-IMPLEMENTED bucket: each
+  `jld:ExpandTest`/`jld:FlattenTest` input is parsed to RDF and projected through the shipping
+  writer, then compared by RDF-equivalence to the normative expected document; below-floor cases
+  are honest writer divergences (`@direction`/i18n-datatype, list/coercion shapes) and the SKIP
+  buckets are the documented ones (negatives sparq's TOTAL writer does not raise, JSON-LD-1.0-only,
+  empty-RDF inputs). Only **html** (script extraction) + **remote-doc** (a `LoadDocumentCallback`)
+  remain NOT-IMPLEMENTED buckets the runner reports separately and never fails on (they grow the
+  ratchet as those land). The lane is the opt-in
   `jsonld-suite` feature on `sparq-conformance` (forwards to `sparq-core/jsonld` +
   `sparq-engine/serialize-rdf`); OFF it compiles to a self-skip. Reproduce with
   `scripts/fetch-jsonld-tests.sh` + `scripts/fetch-jsonld-framing-tests.sh` then


### PR DESCRIPTION
> 🤖 **SPARQ agent** — graduating SKIPPED conformance lanes to honest, gated ratchets.

## What this does (epic **sq-oy1f**, item 4: conformance)

Graduates the W3C JSON-LD 1.1 **`expand`** and **`flatten`** categories from the runner's NOT-IMPLEMENTED buckets to **gated ratchets** in `crates/sparq-conformance/tests/jsonld_suite.rs`, mirroring the **`compact`** (sq-3uos5) and **`frame`** (sq-oy1f.19) graduations EXACTLY (the output-vs-W3C-document oracle).

Both lanes drive the **ALREADY-SHIPPING** writer `graph_to_jsonld(JsonLdForm::Expanded | Flattened)` (the `serialize-rdf` feature) through the **REAL path** — NOT a stub:

1. parse each case `input` → RDF via the real oxjsonld ingest path,
2. re-emit as N-Quads into a sparq `Graph` (named graphs preserved),
3. run the shipping writer in the requested form,
4. re-parse the output AND the suite's NORMATIVE `*-out.jsonld`, require RDF-dataset equivalence: `reparse(write(D)) ≡ reparse(expected)`.

Expansion/flattening are JSON-LD **normal forms** (they drop free-floating nodes / merge nodes), so — exactly like the frame lane — the oracle anchors on the **expected document**, not the input.

## Calibrated floors (MEASURED, honest — may only RISE)

| lane | floor | measured (pass / fail / skip of total) |
|---|---:|---|
| **expand** | `EXPAND_FLOOR = 247` | 247 / 10 / 128 of 385 |
| **flatten** | `FLATTEN_FLOOR = 50` | 50 / 0 / 8 of 58 |

The floors are the EXACT measured pass counts at the pinned suite revision (built + ran the lane + counted). The 10 expand fails are honest writer divergences below the floor (`@direction`/i18n-datatype, list/coercion shapes, and one expected `*-out.jsonld` oxjsonld itself cannot re-parse) — tracked-not-asserted for a future RISE under **sq-oy1f.22**. flatten has zero below-floor fails. SKIP buckets are the documented ones (NegativeEvaluationTests sparq's TOTAL writer does not raise; JSON-LD-1.0-only; empty-RDF inputs).

Floors are mirrored in `scoreboard::SUITES` + the `tests/scoreboard_floors.rs` floor-sync guard + the `ci.yml` `jsonld-conformance` belt-and-braces grep gate. `expand`/`flatten` removed from `NOT_IMPLEMENTED_CATS` (only `html` + `remote-doc` remain). The existing **toRdf / fromRdf / compact / frame** lanes (413 / 51 / 186 / 61) are **unchanged** — no regression.

## Named-graph entailment (dispatched item 3): **deferred-beaded** (`named_graph_tests = 0`)

Honest finding: at the currently-pinned rdf-tests revision the `sparql11/entailment` manifest contains **ZERO `qt:graphData` entries** — every entailment test uses a single default-graph `qt:data` dataset. Verified two ways: manifest grep (no `graphData`), and a live `sparq-inference-conformance` run produced **zero** `named-graph entailment dataset not wired` results. So the guard at `sparql_entail.rs::run_one` is presently **unreachable** — there is nothing to graduate. Per the brief, the fail-closed guard is **retained** (and now documented inline); proper wiring would need **new per-graph materialization semantics in sparq-reason** (not harness wiring), filed as **sq-oy1f.21**.

## Gates (all green)

- `cargo test -p sparq-conformance` — green in **BOTH** states: default (feature **OFF**, self-skips) AND `--features jsonld-suite` (asserts the floors).
- `cargo clippy -p sparq-conformance --all-targets -- -D warnings` — clean in both feature states.
- `cargo +1.88 check` (MSRV) — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `python3 scripts/check-readme-template.py --enforce` — **0 deviations**; README stays at the 30-line internal-stub cap.

**Feature flag:** the whole lane is the opt-in `jsonld-suite` feature on `sparq-conformance` (forwards to `sparq-core/jsonld` + `sparq-engine/serialize-rdf`); OFF it compiles to a self-skip — the lean-core posture is preserved.

Deferred beads: **sq-oy1f.21** (named-graph entailment semantics), **sq-oy1f.22** (raise expand/flatten floors past current writer divergences).

🤖 Generated with [Claude Code](https://claude.com/claude-code)