### PR TITLE
docs(research): design — shared zero-overhead eval substrate + reasoner suite + SERVICE federation + RSP/geo (sq-6tykl)

### DIFF
--- a/research/reasoner-suite-on-substrate.md
+++ b/research/reasoner-suite-on-substrate.md
@@ -1,0 +1,194 @@
+# Design — the reasoner suite on the shared substrate (RL-complete / EL / QL / Direct / RIF / D)
+
+<!-- [OPUS-4.8] Design-for-review for epic sq-pbz04 (under umbrella sq-6tykl). NO production
+code in this PR. Builds on research/owl2-el-ql-reasoning-spike.md (sq-wmeg). 🤖 SPARQ agent. -->
+
+> 🤖 **SPARQ agent** — design record for @jeswr's review. DESIGN-FOR-REVIEW only. This record
+> sequences the reasoner regimes on top of the shared substrate; it does not implement them.
+
+**Status:** DESIGN / design-for-review. **Epic:** sq-pbz04 (reasoners on the shared substrate),
+depends on the substrate design (sq-qonbz, see `research/shared-eval-substrate.md`). **Prior
+art in-repo:** `research/owl2-el-ql-reasoning-spike.md` (the EL/QL feasibility spike, sq-wmeg);
+`research/owl2-el-ql-reasoning-spike.md` already chose **EL-first, QL-second**, which this record
+adopts and extends to the full suite.
+
+**Recommendation in one line:** ship the regimes in increasing soundness-risk order —
+**(1) RL completeness hardening + (2) EL hardening** (both already exist and pass conformance) →
+**(3) D-entailment** (smallest sound addition, value-space closure) → **(4) RIF-Core / N3
+builtins** (existing N3 engine, expand builtins) → **(5) QL query-rewriting** (the PerfectRef /
+tree-witness minefield) → **(6) OWL 2 Direct / DL** (research-grade, EL-first restraint). Each is
+opt-in, each wires into the W3C entailment conformance harness, and each that does materialisation
+adopts the shared join from sq-qonbz.
+
+---
+
+## 0. Premise check (honesty first)
+
+What the brief says, checked against the code:
+
+- **RL and EL already exist and pass conformance.** `crates/sparq-reason` (RDFS + OWL-RL forward
+  chaining, `owl.rs` 3120 LOC, plus `incremental.rs` 3157 LOC — the brief's "3963 LOC" undercounts;
+  it is larger) and `crates/sparq-reason-el` (consequence-based EL classifier with optional `rbox`
+  / `hasse` features) are real, shipped, opt-in crates. The entailment harness already drives them
+  (`sparq_reason::materialize(Profile::Rdfs|OwlRl, …)` in `inference/sparql_entail.rs`).
+- **QL, Direct, RIF-Core, D are NOT built.** Confirmed: no QL rewriter, no tableau, no RIF-Core
+  semantics, no D-entailment materialisation crate exists. These are the genuine new builds.
+- **The EL/QL spike (sq-wmeg) already landed** and reached EL-first / QL-second with the PerfectRef
+  trap called out. This record does not re-litigate that; it folds it into the full-suite sequence
+  and adds D / RIF / Direct.
+
+One correction to emphasise: the brief lists "RL-complete" as a regime to *build*. RL already
+ships and passes 78 OWL-2-RL tests with 13 **documented** divergences (TBox-only conclusions
+outside the RL/RDF completeness theorem). "RL-complete" here means *close those documented
+divergences where the RL/RDF profile actually entails them*, **not** make RL complete for EL —
+RL is provably, mechanistically incomplete for EL (it lacks CR4, the existential-traversal rule;
+the spike has the verified counterexample `A⊑∃r.B, B⊑C, ∃r.C⊑D ⊨ A⊑D`). The honest fix for EL
+completeness is the EL classifier, which already exists, not RL tuning.
+
+---
+
+## 1. The regimes, by soundness risk and build cost
+
+| Regime | Status | Decidable? | Soundness oracle | Build risk |
+|---|---|---|---|---|
+| RDFS / OWL-RL | **shipped** | yes (PTIME, sound, RL-incomplete-for-EL) | W3C inference suite, 48/48 RDFS + RL ratchet | low — harden divergences |
+| OWL 2 EL | **shipped** (`sparq-reason-el`) | yes (PTIME) | EL is its own oracle; SNOMED/GO scale | low–med — fragment gaps (nominals/concrete domains deferred) |
+| D-entailment | not built | yes | datatype value-space spec | **low** — smallest sound add |
+| RIF-Core | not built (N3 engine exists) | Horn-decidable for the core | RIF test suite (if vendorable) | med — builtins + safety |
+| OWL 2 QL | not built | yes (AC0 data complexity) | **PerfectRef** (no Rust impl exists) | **high** — applicability trap + UCQ-containment minimisation (NP-complete) |
+| OWL 2 Direct / DL | not built | **undecidable** for full OWL DL | needs a sound SAT/tableau | **highest** — research-grade |
+
+The sequence below follows this risk gradient: bank the sound, cheap wins first; defer the
+minefields with eyes open.
+
+---
+
+## 2. Per-regime design notes (honest scope)
+
+### 2.1 RL completeness hardening (sound, in-scope)
+
+Close the documented RL/RDF divergences where the profile genuinely entails the conclusion;
+keep the ones that are out of the RL completeness theorem as *honest* `Divergence(reason)` entries
+(never silently "pass"). Adopt the shared join (sq-qonbz phase 5) for rule firing. **No new
+soundness risk** — RL stays sound; we only add derivations the profile already sanctions.
+
+### 2.2 EL hardening (sound, in-scope)
+
+EL already classifies via CR1–CR5 (+ optional CR10/CR11 RBox, + Hasse). The deferred fragment is
+nominals / concrete domains (CR6–CR9). Honest options: (a) leave them deferred and keep surfacing
+them in `Report::skipped_axioms` (current behaviour, recommended for now), or (b) add CR6–CR9 as a
+later opt-in. The **perf** open item the spike flagged remains: an end-to-end SNOMED/GO benchmark
+to confirm normalise + RBox + Hasse compose without a hidden quadratic. The work-box timing is
+non-canonical; the gate is the conformance ratchet + a *relative* (not absolute) perf check.
+
+### 2.3 D-entailment (sound, smallest new build — do this first of the new ones)
+
+Datatype value-space closure: e.g. an `xsd:int` literal entails the corresponding `xsd:integer`
+/ `xsd:decimal` typings, ill-typed literals are detected, and value-equal literals in different
+lexical forms compare equal. The substrate's typed `Num` / `compare_values` already has most of
+the value-space machinery (the harness uses it at entailment-check time today). The build is
+mostly: (a) a small materialisation pass that adds sanctioned datatype triples, (b) wiring it as a
+`Profile::D` into the entailment harness. **Lowest risk of the unbuilt regimes** and a clean
+conformance story.
+
+### 2.4 RIF-Core / N3 builtins (med risk)
+
+sparq already has an N3 forward-chaining engine (`sparq-reason/src/n3`) with builtins. RIF-Core is
+Horn rules + builtins; the honest path is **extend the N3 builtin set and add a RIF-Core
+front-end / mapping**, not a green-field rule engine. Risk items: builtin safety (range-
+restriction), and negation-as-failure is **out of RIF-Core** (it's RIF-BLD/PRD territory) — keep
+the core monotone. If the official RIF test suite is not vendorable (license / format), frame the
+ratchet honestly as "RIF-Core expressivity coverage," not "RIF conformance."
+
+### 2.5 OWL 2 QL — the PerfectRef trap (HIGH risk, sequence late)
+
+This is the regime the brief and the spike both flag hardest, and the verification confirms why:
+
+- **No Rust PerfectRef oracle exists.** Production systems (Ontop, Stardog) are Java/Scala. Ontop
+  ships **tree-witness** rewriting + the **combined approach** + SQL-side optimisation
+  (confirmed against the literature: Kikot et al. tree-witnesses; Ontop's tree-witness + T-mappings).
+  A pure PerfectRef MVP is a *correctness oracle*, not a production rewriter.
+- **Two soundness traps** (both can *silently lose correct answers*): (1) the **applicability
+  condition** — an existential-introducing inclusion may fire only on a non-distinguished,
+  non-shared variable; mis-gating scope (OPTIONAL / FILTER / MINUS / paths passing through the
+  rewrite) is unsound, so a **strict CQ-shape gate** that *rejects* non-CQ queries is mandatory;
+  (2) **UCQ minimisation by query containment** is **NP-complete** and correctness-critical —
+  dropping a CQ that is not actually subsumed loses answers.
+- **Honest plan:** build PerfectRef as a *gated, CQ-only, oracle-tested* MVP first (validated
+  against hand-checked DL-Lite examples since no Rust oracle exists), label it experimental, and
+  **do not ship it as a general entailment regime until tree-witness + minimisation land**. The
+  UCQ blow-up is theoretically unavoidable (exponential in TBox depth, Kikot et al. lower bounds),
+  so production QL is a multi-phase effort, not an MVP.
+
+### 2.6 OWL 2 Direct / DL (HIGHEST risk, research-grade)
+
+Full OWL 2 Direct Semantics (DL) is **undecidable**; a sound implementation needs a tableau / SAT
+reasoner. The spike's restraint holds: **EL-first** (PTIME, closed semantics) covers the high-
+value biomedical use cases. If DL is ever attempted, it is a separate research track and must NOT
+claim soundness without external review — the same discipline the ZK verifier is under (sq-qhy4
+external-audit precedent). Recommend **deferring DL out of this program** and recording it as a
+future research bead.
+
+---
+
+## 3. Substrate coupling
+
+Every regime that **materialises** (RL, EL-as-triples, D, RIF) adopts the shared join from
+sq-qonbz phase 5 in place of hand-rolled adjacency, and interns all output terms through
+`sparq-core::Dict` so the single-id-space soundness keystone holds. QL is the exception: it is a
+**query-rewriter**, not a materialiser — it produces a rewritten SPARQL query through a
+`PreparedQuery`-style seam (the brief's "no store/planner changes needed"), so it reuses the
+*engine's* execution path rather than the materialisation substrate. This split is worth stating
+plainly: **materialisers share the join kernel; the rewriter shares the query engine.**
+
+---
+
+## 4. Conformance wiring (the harness already exists)
+
+The entailment harness (`crates/sparq-conformance/src/inference`) already runs RDFS / OWL-RL /
+N3 and reports a four-bucket scoreboard (Pass / Fail / **Divergence**(reason) / **OutOfScope**).
+Each new regime adds a `Profile` and a suite arm:
+
+- D → a `Profile::D` arm over the rdf-mt datatype tests (currently `OutOfScope`).
+- RIF → an N3/RIF suite arm (if a suite is vendorable; else an expressivity ratchet).
+- QL → an entailment-regime arm gated behind the experimental CQ-only rewriter, with a pinned
+  floor and honest `OutOfScope` for non-CQ shapes.
+
+Every floor is a const in the suite source, synced to `scoreboard::SUITES` by the
+`scoreboard_floors.rs` guard — the established graduation pattern.
+
+---
+
+## 5. Phased plan (each phase = a future bead under sq-pbz04)
+
+1. **RL completeness hardening** — close in-profile divergences; adopt shared join. *Acceptance:*
+   OWL-RL ratchet rises or holds; remaining divergences stay documented; inference conformance
+   green. *Depends on substrate phase 5.*
+2. **EL SNOMED/GO end-to-end benchmark + fragment-gap doc** — confirm normalise+RBox+Hasse compose
+   with no hidden quadratic; document deferred nominals/concrete-domains in SKILL.md. *Acceptance:*
+   relative perf check passes on a fixed ontology slice; EL conformance unchanged.
+3. **D-entailment materialiser** (`Profile::D`) — value-space closure via substrate `Num`.
+   *Acceptance:* new datatype tests move from OutOfScope to Pass with a pinned floor; byte/bundle
+   ratchets unchanged (opt-in). *Independent of QL.*
+4. **RIF-Core front-end on the N3 engine** — extend builtins, add RIF-Core mapping, keep monotone.
+   *Acceptance:* RIF-Core expressivity ratchet (or vendored suite) green; honest scoping note.
+5. **QL PerfectRef MVP (experimental, CQ-only, oracle-tested)** — strict CQ-shape gate that
+   *rejects* non-CQ queries; hand-checked DL-Lite oracle. *Acceptance:* rewrites match the oracle
+   on the test set; non-CQ queries are rejected (not silently wrong); labelled experimental.
+   **Large.** *Depends on nothing in this list but is sequenced late by risk.*
+6. **QL tree-witness + UCQ minimisation** — the production path; bounded ABox closure +
+   containment minimisation. *Acceptance:* QL entailment-regime arm graduates from experimental;
+   matches oracle on the full DL-Lite suite. **Large / long-pole.** *Depends on phase 5.*
+7. **(Deferred / future research bead) OWL 2 Direct / DL** — recorded, not built in this program;
+   needs external soundness review if ever attempted.
+
+---
+
+## 6. Open questions for the maintainer
+
+1. **QL scope for *this* program:** MVP oracle (phase 5) only, or commit to tree-witness (phase 6)
+   now? The spike and I both recommend MVP-then-stop until tree-witness is resourced.
+2. **RIF test suite:** is an executable RIF-Core suite vendorable (license/format), or do we frame
+   the ratchet as expressivity coverage like RSP?
+3. **DL/Direct:** confirm we **defer** it out of this program (record as future research), per the
+   spike's EL-first restraint.

--- a/research/rsp-geo-conformance-integration.md
+++ b/research/rsp-geo-conformance-integration.md
@@ -1,0 +1,124 @@
+# Design — RSP (RDF Stream Processing) + GeoSPARQL conformance integration
+
+<!-- [OPUS-4.8] Design-for-review for epics sq-2n1q3 (RSP) and sq-lk3aw (GeoSPARQL + full-text),
+under umbrella sq-6tykl. NO production code in this PR. 🤖 SPARQ agent. -->
+
+> 🤖 **SPARQ agent** — design record for @jeswr's review. DESIGN-FOR-REVIEW only.
+
+**Status:** DESIGN / design-for-review. **Epics:** sq-2n1q3 (RSP), sq-lk3aw (GeoSPARQL +
+full-text). Both are independent of the substrate and federation — they parallelise.
+
+**Recommendation in one line:** GeoSPARQL already has a hand-curated OGC ratchet (119, in the
+scoreboard); **graduate the geo query-rewrite gap and add the in-scope OGC requirement coverage**,
+and for RSP/text **frame the ratchets honestly** — there is **no W3C/CSPARQL RSP conformance suite
+and no full-text RDF standard**, so wire RSP as an *expressivity/correctness* ratchet (against the
+SRBench oracle) and text as a *BM25 differential-oracle* ratchet, **not** as "conformance to a
+standard."
+
+---
+
+## 0. Premise check (honesty first — this is where the brief most needs discipline)
+
+Verified against the code and the standards landscape:
+
+- **GeoSPARQL: real OGC ratchet, already in the scoreboard.**
+  `crates/sparq-geo/tests/ogc_compliance_ratchet.rs` pins `OGC_RATCHET_FLOOR = 119` and is
+  registered as `Runner::CrateTest { krate: "sparq-geo", target: "ogc_compliance_ratchet" }`
+  (`scoreboard.rs:190`). Covers R1–R30 topology (sf/eh/rcc8). Confirmed.
+- **GeoSPARQL gaps are documented, not hidden:** the query-rewrite *property* form
+  (`geo:sfWithin` as a property path, not a `geof:` FILTER function) is **not implemented**
+  (sq-5ts8); the official OGC TEAM Engine / CITE suite is Java/HTTP and **not vendorable** to an
+  MIT repo; metric distance for extended geometries uses a **local equirectangular approximation**
+  (point-to-point is exact Haversine). All three are real and must stay documented.
+- **RSP: there is NO published executable W3C/CSPARQL conformance suite.** Confirmed against the
+  landscape — C-SPARQL / CQELS / RSP4J are *runtime* engines with wall-clock windows; SRBench is a
+  *correctness benchmark*, not a conformance ETS. sparq-rsp is **clock-free / deterministic**. So
+  **"RSP conformance" is not a thing that exists to conform to.** The brief is explicit about this
+  and it is the single most important honesty point in this epic.
+- **Full-text: no standard at all.** `text:` predicates are a sparq extension
+  (`http://sparq.dev/text#`, BM25 + UAX-#29 tokenisation + phrase/proximity). There is no W3C/ISO
+  full-text-RDF standard. "Text conformance" would be a category error.
+- **RSP and text are ABSENT from the scoreboard** (grep count 0). Confirmed.
+
+**Correction to the brief's framing:** the epic title (sq-lk3aw) says "W3C conformance" for
+GeoSPARQL+text. GeoSPARQL conformance is to **OGC** (not W3C), via a *hand-curated* probe (the
+official suite is not vendorable). Full-text has **no** conformance target. The honest deliverable
+is: graduate/extend the *existing* OGC ratchet for geo, and add *correctness/expressivity*
+ratchets — clearly labelled as such — for RSP and text. Do **not** add a scoreboard row whose
+`family` claims a standard that does not exist.
+
+---
+
+## 1. GeoSPARQL (sq-lk3aw) — extend the existing OGC ratchet
+
+The infrastructure exists; the work is coverage + one capability gap:
+
+- **Graduate the query-rewrite property form** (sq-5ts8): implement `geo:sfWithin`-style topology
+  *property* rewriting (opt-in `geosparql_rewrite`, already partially present) and add it to the
+  ratchet. Honest: keep it behind the existing opt-in entry point so default W3C SPARQL behaviour
+  is unaffected.
+- **Raise the OGC requirement coverage** where the hand-curated probe under-covers (metadata
+  properties `geo:dimension`/`isEmpty`/`isSimple` already partly covered via
+  `tests/ogc_geosparql_requirements.rs`; extend toward the full R1–R30 + metadata set).
+- **Document the distance approximation** prominently in the geometry README + the scoreboard note
+  (extended-geometry distance is approximate; point-to-point is exact). A conformance suite that
+  exercised continent-spanning distance would surface this — naming it is the honest move.
+
+### Full-text (under sq-lk3aw) — differential oracle, not conformance
+
+Wire `sparq-text`'s existing differential BM25 oracle (`tests/oracle.rs`) as a scoreboard ratchet
+labelled **"text-search differential oracle"** (family: sparq extension), NOT "conformance." The
+floor is the oracle pass count. This is honest and still valuable — it catches index/scoring
+regressions — without claiming a nonexistent standard.
+
+## 2. RSP (sq-2n1q3) — expressivity/correctness ratchet against SRBench
+
+- Wire the existing `bench/rsp` SRBench correctness oracle (~22 deterministic per-window
+  assertions across tumbling/sliding/count windows × RSTREAM/ISTREAM/DSTREAM × multi-window joins
+  × the 3–4 EvalModes) into the scoreboard as a `Runner::CrateTest` with a pinned
+  `RSP_EXPRESSIVITY_FLOOR`.
+- **Label it "RSP expressivity / SRBench correctness," with a scoreboard note stating no formal
+  W3C/CSPARQL conformance suite exists.** This is the load-bearing honesty requirement: any claim
+  of "RSP conformance" is challengeable and must not appear.
+- The deterministic per-window row-count assertions are the gate; window *throughput* stays a
+  trend-only advisory metric (not gated), and the work-box timing is non-canonical.
+
+## 3. Soundness / scope notes
+
+- All three crates (`sparq-rsp`, `sparq-geo`, `sparq-text`) are **opt-in, wasm-isolated** (tier-b
+  bundles `sparq-rsp-wasm`, `sparq-text-wasm`), with **zero core-engine dependency**, so wiring
+  their ratchets does **not** touch the lean wasm bundle floor (1686907) or the byte ratchets.
+- The scoreboard crate must stay **free of depending on** `sparq-geo`/`sparq-rsp`/`sparq-text`
+  (it already deliberately avoids pulling them in); the `Runner::CrateTest` indirection (run the
+  crate's own `cargo test` target) is exactly how this is kept acyclic. New rows follow that
+  pattern — no new dependency edge into the scoreboard crate.
+- **No privacy/ZK/MPC surface** in any of these.
+
+## 4. Phased plan (each phase = a future bead)
+
+Under **sq-lk3aw** (geo + text):
+
+1. **Geo: graduate query-rewrite property form** (sq-5ts8) into the OGC ratchet (opt-in). *Acc:*
+   `OGC_RATCHET_FLOOR` rises; default SPARQL behaviour unchanged; scoreboard note updated.
+2. **Geo: extend OGC requirement coverage** (metadata/metric where in-scope) + document the
+   distance approximation. *Acc:* ratchet rises or holds; README + scoreboard note state the
+   approximation honestly.
+3. **Text: wire BM25 differential-oracle ratchet** into the scoreboard, labelled as an extension
+   oracle (not conformance). *Acc:* `TEXT_ORACLE_FLOOR` const + scoreboard row + guard entry;
+   note states no standard exists.
+
+Under **sq-2n1q3** (RSP):
+
+4. **RSP: wire SRBench expressivity/correctness ratchet** into the scoreboard, labelled honestly.
+   *Acc:* `RSP_EXPRESSIVITY_FLOOR` const + scoreboard row + guard entry; note states no W3C/CSPARQL
+   conformance suite exists; deterministic per-window assertions gate, throughput trend-only.
+
+## 5. Open questions for the maintainer
+
+1. **Labelling:** confirm you are comfortable with RSP/text scoreboard rows labelled
+   "expressivity / differential oracle" rather than "conformance" — this is the honest framing and
+   I will not ship a row claiming a nonexistent standard without your steer.
+2. **Geo distance:** is the equirectangular approximation acceptable to keep (documented), or do
+   you want exact geodesic distance for extended geometries as a follow-up bead?
+3. **OGC CITE:** the official suite is not MIT-vendorable; confirm the hand-curated probe remains
+   the sanctioned conformance evidence for GeoSPARQL.

--- a/research/service-federation-conformance.md
+++ b/research/service-federation-conformance.md
@@ -1,0 +1,146 @@
+# Design — SERVICE federation evaluation + in-process mock-server conformance harness
+
+<!-- [OPUS-4.8] Design-for-review for epic sq-my8wd (under umbrella sq-6tykl). NO production
+code in this PR. 🤖 SPARQ agent. -->
+
+> 🤖 **SPARQ agent** — design record for @jeswr's review. DESIGN-FOR-REVIEW only.
+
+**Status:** DESIGN / design-for-review. **Epic:** sq-my8wd (SERVICE federation + HTTP protocol
+conformance), independent of the substrate — parallelises with sq-qonbz/pbz04.
+
+**Recommendation in one line:** wire the W3C `sparql11/service` **evaluation** suite into the
+conformance harness by standing up **real in-process `sparq-server` endpoints on `127.0.0.1:0`
+loopback**, queried through the engine's existing HTTP `Transport`, rather than the current
+`pub(crate)` canned-mock seam — this exercises the *whole* federated path (HTTP, content
+negotiation, SRJ/SRX parsing, bind-join) end-to-end and doubles as the HTTP-protocol /
+Service-Description / Graph-Store-Protocol conformance lane.
+
+---
+
+## 0. Premise check (honesty first)
+
+Verified against the code:
+
+- **SERVICE evaluation is real and feature-gated.** `crates/sparq-engine/src/service.rs` (1803
+  LOC, `service` feature: `ureq` + `serde_json` + `quick-xml`), with `eval_service` (verbatim) and
+  `try_bound_join_service` (VALUES-pushdown bind-join), SSRF egress policy, SRJ/SRX content-
+  sniffing, RDF 1.2 / directional-literal reconstruction. The brief is accurate here.
+- **Syntax conformance runs; evaluation does NOT.** `sparql11/syntax-fed` *is* run
+  (`conformance/src/main.rs:95`); `sparql11/service` (evaluation) is explicitly documented as a
+  gap "needs live remote endpoints" (`main.rs:520`). Service-Description and the CSV/TSV protocol
+  tests are likewise listed as not-run. **Confirmed gap.**
+- **The current mock is `pub(crate)` and engine-test-only.** The `Transport` trait
+  (`service.rs:84`) is `pub(crate)`; `service_transport::install` (`exec.rs:2680`) is
+  `pub(crate)`. The in-tree mocks (`Canned`, `Boom`, `RemoteGraph`) live in `exec.rs` tests. **A
+  conformance harness in `sparq-conformance` cannot reach this seam today** — this is the central
+  design constraint, and the brief's "no in-process server for SERVICE/protocol conformance" is
+  exactly right.
+- **`sparq-server` is embeddable in-process.** `sparq_server::{router, serve, AppState}` are
+  **public** (`lib.rs:132`); the binary binds via `tokio::net::TcpListener::bind` in `main.rs:916`.
+  So a test can build an `AppState` over a fixture graph, `serve` it on an ephemeral loopback port,
+  and point a real `Transport` at it. **This is the key enabler the brief did not spell out.**
+
+So the gap is real and the path is clear: the question is *which* transport the conformance
+harness uses to reach the mock endpoint.
+
+---
+
+## 1. Design options for the mock-endpoint seam
+
+### Option A — Real loopback `sparq-server` + real HTTP `Transport` (recommended)
+
+The harness spins up one or more in-process `sparq_server::serve(...)` instances on `127.0.0.1:0`
+(ephemeral ports), each loaded with the federated test's named-graph fixtures, then runs the
+test's federated query through the **real** `ureq` HTTP `Transport` (with SSRF allowlist set to
+the loopback host). **Pros:** exercises the *entire* stack — HTTP request/response, Accept
+negotiation, SRJ *and* SRX parsing, bind-join VALUES blocks over the wire, SILENT error semantics
+on a real connection-refused — so it is genuine protocol conformance, and it reuses public APIs
+(no new `pub` surface in the engine). **Cons:** needs `tokio` + a port in the test; slightly
+slower than an in-memory mock; loopback only (the SSRF allowlist must permit `127.0.0.1`).
+
+### Option B — Promote the `Transport` seam to a public test-only API
+
+Expose `service_transport::install` / the `Transport` trait behind a `test-transport` feature so
+the conformance crate can inject a `RemoteGraph`-style in-memory mock. **Pros:** fast, no
+network, no port. **Cons:** it does **not** test the HTTP layer, content negotiation, or SRJ/SRX
+*parsing* — it tests the engine's join logic against a function that returns a relation. That is
+already covered by the engine's own in-tree tests, so it adds little conformance value and widens
+the public API for test-only reasons. **Not recommended as the primary path.**
+
+### Option C — Both, layered (recommended overall)
+
+Keep the existing in-engine canned-mock tests (fast, algebra-level, already proven multiset-equal
+to verbatim). **Add** Option A as the conformance lane for the actual W3C `sparql11/service`
+evaluation manifest + the protocol suites. The two layers test different things and both are
+cheap to maintain. **This is the recommendation.**
+
+---
+
+## 2. Recommendation
+
+Adopt **Option C**: real in-process loopback `sparq-server` endpoints (Option A) for the
+`sparql11/service` evaluation lane and the HTTP-protocol / Service-Description / Graph-Store lanes,
+layered over the existing engine-level canned-mock unit tests. Register the new lanes in the
+conformance scoreboard with pinned floors, following the established `Runner` + floor-const +
+`scoreboard_floors.rs`-guard pattern.
+
+Scope, honestly bounded:
+
+- **In scope:** `sparql11/service` evaluation (the manifest is present in rdf-tests, just not
+  run); Service-Description GET `/sparql`; Graph-Store-Protocol PUT/POST/DELETE round-trips;
+  CSV/TSV result-format protocol tests.
+- **Caveats to keep honest:** the variable-endpoint (`SERVICE ?ep`) and high-cardinality cases
+  have a **no per-request cap** risk (brief: a 10M-distinct-`?ep` query spawns 10M requests, only
+  bounded cooperatively post-HTTP). The harness should not paper over this; if the suite exercises
+  it, surface it (and consider a follow-up bead for a per-query remote-request cap). Remote-result
+  materialisation is non-streaming (full relation into memory) — fine for conformance fixtures,
+  noted as a scaling caveat, not a conformance failure.
+
+---
+
+## 3. Soundness / safety notes
+
+- **SSRF policy must stay strict even for loopback tests.** The harness sets the allowlist to
+  exactly the loopback host:port it spun up; it must NOT disable the egress filter globally (that
+  would regress the DNS-rebinding invariant the engine guarantees by installing its own resolver).
+  The test allowlists the *specific* ephemeral endpoint.
+- **SILENT semantics are algebra, not optimisation.** The harness must test that a refused
+  connection under `SERVICE SILENT` yields the join identity (bindings preserved) and a non-SILENT
+  failure propagates — this is a correctness property, verifiable by pointing at a closed port.
+- **No privacy/ZK/MPC claim here.** This is plain federated SPARQL over HTTP. The `sparq-fedplan`
+  cost-based planner and the `sparq-fedplan-mpc` seam are **out of scope** for this epic — the MPC
+  seam has deferred Phases 5–6 (`SeamError::Deferred`, gated on sq-qhy4) and is semi-honest only;
+  nothing here integrates it or makes any privacy guarantee.
+
+---
+
+## 4. Phased plan (each phase = a future bead under sq-my8wd)
+
+1. **In-process test harness helper** — a reusable fixture that loads a graph, `serve`s it on
+   `127.0.0.1:0`, returns the bound URL, and tears it down. *Acceptance:* a smoke test runs a
+   trivial federated query against it end-to-end; SSRF allowlist scoped to the ephemeral port.
+2. **Wire `sparql11/service` evaluation into the conformance harness** — walk the manifest, stand
+   up the per-test endpoints, run the federated query through the real `Transport`, compare with
+   the result oracle. *Acceptance:* a pinned `SERVICE_EVAL_FLOOR` const + scoreboard row + guard
+   entry; CI lane green. *Depends on phase 1.*
+3. **HTTP-protocol conformance lane** — SPARQL Protocol GET/POST + CSV/TSV result-format tests
+   against the in-process server. *Acceptance:* protocol floor pinned + scoreboard row. *Depends
+   on phase 1.*
+4. **Service-Description + Graph-Store-Protocol lane** — assert the `sd:` document advertises the
+   right languages/formats; GSP PUT/POST/DELETE round-trip. *Acceptance:* SD/GSP floor pinned +
+   scoreboard row. *Depends on phase 1.* (These are behind the existing `federation-descriptors`
+   feature; keep them opt-in so the default wasm/byte ratchets are unaffected.)
+5. **(Follow-up bead, honest gap)** — per-query remote-request cap for high-cardinality
+   `SERVICE ?ep`. *Acceptance:* a runaway-endpoint query is bounded before dispatch, not just
+   cooperatively after. *Independent.*
+
+---
+
+## 5. Open questions for the maintainer
+
+1. **Loopback server (Option A/C) vs public test-transport (Option B)?** I recommend the real
+   loopback server for genuine protocol coverage; confirm you are happy with `tokio` + an
+   ephemeral port inside the conformance crate's test deps (it is already a workspace dependency).
+2. **Per-request remote cap** (phase 5): in-scope for this program or a separate hardening bead?
+3. **CSV/TSV + SD/GSP**: include all protocol suites now, or land `sparql11/service` evaluation
+   first and add the protocol lanes as a fast follow?

--- a/research/shared-eval-substrate.md
+++ b/research/shared-eval-substrate.md
@@ -1,0 +1,320 @@
+# Design — shared zero-overhead evaluation substrate for the SPARQL engine and the reasoners
+
+<!-- [OPUS-4.8] Design-for-review for epic sq-qonbz (under umbrella sq-6tykl). NO production
+code in this PR — this is an investigation + plan the maintainer reviews before any refactor.
+🤖 SPARQ agent. -->
+
+> 🤖 **SPARQ agent** — design record for @jeswr's review. DESIGN-FOR-REVIEW only: this PR
+> changes no engine/reasoner code. It proposes *how* to extract a shared eval substrate and
+> *how to prove* the extraction is perf-neutral, then decomposes the work into beads.
+
+**Status:** DESIGN / design-for-review. **Epic:** sq-qonbz (shared substrate), under umbrella
+sq-6tykl. **Gates:** the reasoner refactor (sq-pbz04) depends on the substrate *design* landing
+here; federation (sq-my8wd), RSP (sq-2n1q3) and geo (sq-lk3aw) parallelise independently.
+
+**Recommendation in one line:** extract the engine's id-level join / numeric / term-compare
+hot loops into a **new leaf crate `sparq-substrate`** that depends only on `sparq-core`, is
+**monomorphic over `Id = u32` and the existing `SmallVec` row/key aliases with zero `Box<dyn>`
+on the hot path**, is **feature-gated identically to today** so the lean wasm bundle stays
+byte-identical, and is consumed by *both* `sparq-engine` (which keeps its planner) *and* the
+reasoners (which gain a shared semi-naive join instead of their hand-rolled `FxHashMap`
+adjacency). The extraction is a **pure code-move + generalise**, validated as perf-neutral by
+the existing deterministic ratchets plus the engine micro-benches — not a rewrite.
+
+---
+
+## 0. Premise check (honesty first — what the brief got right and what it got wrong)
+
+The parallel research brief says the engine's join/arith/term machinery "can be REUSED without
+modification" by the reasoners, and frames the substrate as already-shared. **Verified against
+the code, that is the aspiration, not the present reality, and the brief slightly mis-states the
+dependency graph.** Two corrections:
+
+1. **The reasoners do NOT currently call the engine's joins.** `crates/sparq-reason` and
+   `crates/sparq-reason-el` depend **only on `sparq-core`** (`default-features = false`), *not*
+   on `sparq-engine`. The engine's join families (`merge_join`, `hash_join`, `bind_join`,
+   `lftj_recurse`) live in `crates/sparq-engine/src/exec.rs` and are private to that crate. The
+   RL materialiser in `crates/sparq-reason/src/owl.rs` does its joining with its **own**
+   `FxHashMap<Id, FxHashMap<Id, Vec<Id>>>` out/inc adjacency indexes and a bespoke `UnionFind`
+   (lines ~122–326). So today there are **two independent join implementations**, not one shared
+   substrate. "Share the substrate" means *extract and unify*, which is real, larger work — not a
+   no-op reuse.
+
+2. **The shared code cannot live in `sparq-engine`.** Because `sparq-engine` depends on
+   `sparq-core` and the reasoners must *not* take a dependency on the whole engine (it would pull
+   the planner, `service`/`ureq`, serializers and aggregates into the reasoner crates and into
+   the tier-b reasoner wasm bundle), the substrate must sit **at or below `sparq-core`** in the
+   dependency DAG. A new leaf crate `sparq-substrate` (depending only on `sparq-core`, or on
+   nothing and re-exported by `sparq-core`) is the only placement where engine *and* both
+   reasoners can reach it without a cycle.
+
+Everything else in the brief checks out and is load-bearing:
+
+- `type Row = SmallVec<[Id; 4]>` (`exec.rs:720`), `type Key = SmallVec<[Id; 2]>` (`exec.rs:732`),
+  monomorphic joins, `eval_numeric` fast path (`exec.rs:7185`), `compare_values` total order
+  (`exec.rs:7869`), `as_numeric` (`exec.rs:7840`), the three BGP plans and `scan_to_bindings`
+  (`exec.rs:5138`) all exist as described. Line numbers have drifted a little from the brief's
+  snapshot (the file is now 11 411 lines) but the structure is exactly as claimed.
+- The deterministic perf ratchets are real and currently pinned (verified in
+  `bench/perf-baseline.json`): `wasm_bundle_bytes = 1686907`, `store_bytes_per_triple = 92`,
+  `dict_bytes_per_term = 53`, `parse_ns_per_byte = 4.9721`. The brief's older figure of 1656470
+  is stale — the floor was re-baselined to **1686907** (#1286, 2026-06-29). **Use 1686907.**
+- `Graph::from_parts(dict, triples)` (`sparq-core/src/lib.rs:1114`) is the existing seam the
+  reasoners already use to hand materialised closures back as a queryable graph.
+- The entailment harness already calls `sparq_reason::materialize(Profile::Rdfs|OwlRl, …)` and
+  `materialize_owl_rl` (`crates/sparq-conformance/src/inference/{sparql_entail,owl_suite}.rs`).
+
+**Net:** the epic is sound and worth doing, but it is an *extraction-and-unification* project
+with a real (small-to-medium) refactor surface, not a relabelling. The honest framing is "build
+the shared substrate the brief assumes already exists, and prove the move costs nothing."
+
+---
+
+## 1. Problem framing
+
+sparq wants the SPARQL engine *and* every reasoner (RL-complete, EL, QL, Direct, RIF, D) to
+share the parts of evaluation that are genuinely common — joining sets of id-tuples, comparing
+RDF terms by SPARQL's total order, and doing numeric value arithmetic on dict-encoded literals —
+**without** any of them paying for the others, and **without** regressing the engine's hot
+loops, the wasm bundle, or the deterministic byte ratchets.
+
+The tension is concrete:
+
+- **Reuse pressure.** A reasoner's rule body is a conjunctive query; firing a rule is a
+  multi-way join over id-tuples; that is precisely what `hash_join`/`merge_join`/`lftj_recurse`
+  already do well, with cardinality ordering, radix partitioning, and galloping search. Today the
+  reasoners reimplement a weaker version (per-predicate `FxHashMap` adjacency) and miss the
+  engine's WCOJ/merge machinery entirely.
+- **Isolation pressure.** The engine's joins are wired to `Bindings { vars, rows, sorted_by }`,
+  to `LocalVocab`, to the query budget, to the planner's `ScanCmp` pushdown, and (behind feature
+  gates) to rayon. A reasoner does not want the planner, the budget-per-WHERE-solution model, or
+  the `service`/serializer dependencies. Naïvely sharing by depending on `sparq-engine` would
+  bloat the reasoner crates and the reasoner wasm bundle.
+- **Perf pressure.** The engine's hot loops are deliberately monomorphic with near-zero dynamic
+  dispatch (only `ExtFn`, `SpatialProvider`, custom aggregates use `dyn`, all off the hot path).
+  Any "make it generic so it can be shared" refactor that introduces a `Box<dyn>` or a vtable in
+  the probe loop, or that defeats inlining, is an immediate regression risk the byte/throughput
+  ratchets must catch.
+
+So the design question is: **what is the largest set of primitives we can lift into a shared
+leaf crate such that the engine keeps identical codegen on its hot loops, the reasoners gain a
+real join, and nobody takes an unwanted dependency?**
+
+---
+
+## 2. What is genuinely shareable vs what must stay engine-private
+
+Separating the truly-common kernel from the engine-specific glue is the heart of the design.
+
+### 2.1 Shareable (lift into `sparq-substrate`)
+
+These operate purely on `Id` tuples and the `Dict`/value caches that already live in
+`sparq-core`. They have no dependency on the planner, the budget, `LocalVocab`, or feature-gated
+I/O:
+
+- **Join kernels** over `&[Row]` / `&[Key]`: sorted **merge join**, radix-partitioned **hash
+  join**, **index-nested-loop / bind join**, and **leapfrog trie-join** (WCOJ). These are the
+  `merge_join`/`hash_join`/`bind_join`/`lftj_recurse` bodies, generalised to take their inputs as
+  plain row slices + a join-key spec rather than the engine's `Bindings` struct.
+- **Term total order**: `compare_values` (`exec.rs:7869`) — the SPARQL 3-valued / RDF 1.2 total
+  order (unbound < blank < IRI < literal-by-value < triple-term-componentwise). Used by ORDER BY,
+  MIN/MAX, equality *and* by any reasoner type/identity check.
+- **Numeric value layer**: the `Num` enum (`Int`/`Float`/`Decimal` with xsd promotion),
+  `as_numeric` (`exec.rs:7840`), and the `binop` arithmetic — the value-space machinery a
+  D-entailment / RIF-builtin reasoner needs and that the engine uses for FILTER/BIND arithmetic.
+- **The id-tuple vocabulary**: the `Row`/`Key`/`Posting` `SmallVec` aliases and the inline-int
+  helpers (`dict::inline_id_of_int`). These already conceptually belong with `Dict` in
+  `sparq-core`; the substrate crate re-exports them so both consumers agree on representation.
+
+### 2.2 Engine-private (stays in `sparq-engine`)
+
+These are query-shaped and must *not* leak into the reasoners:
+
+- The **planner**: cardinality estimation, `bgp_is_cyclic` (GYO), `extract_sargable`, the choice
+  between `eval_bgp_binary` and `eval_bgp_wcoj`. A reasoner picks its own join order from its rule
+  structure; it does not want the SPARQL planner.
+- `Bindings { vars, rows, sorted_by }`, `LocalVocab` interning of BIND/aggregate/CONSTRUCT
+  results, the per-WHERE-solution **`QueryBudget`** model, and `ScanCmp` filter pushdown (which is
+  about *scanning a store with a SPARQL filter*, not about firing a rule).
+- All of `service.rs`, the serializers, EXISTS/subquery, GROUP BY/aggregation. The reasoners reach
+  the materialised result through `Graph::from_parts` + plain SPARQL, exactly as today, so they
+  inherit aggregation/EXISTS *for free at query time* without sharing that code at build time.
+
+### 2.3 The interface that keeps both happy
+
+The join kernels are exposed as **free functions generic over a tiny `JoinKeys` descriptor**, not
+as methods on `Bindings`:
+
+```rust
+// in sparq-substrate (sketch — not implementation)
+pub fn hash_join(
+    left: &[Row], left_key: &[u16],      // column indices forming the key
+    right: &[Row], right_key: &[u16],
+    out: &mut Vec<Row>,                  // caller-owned output buffer
+);
+```
+
+The engine wraps these with a thin adapter that pulls `left_key`/`right_key` from its `Bindings`
+variable layout and threads its budget around the call; the reasoner wraps them with an adapter
+that derives keys from the shared variables of a rule's body atoms. **Neither wrapper is on the
+hot loop** — the hot loop is inside the kernel and is identical for both callers. Because the
+kernel is monomorphic over the concrete `Row = SmallVec<[Id;4]>` (not over a `dyn` trait or a
+generic `T: Ord` resolved at runtime), the compiler emits one specialised, inlinable body. This
+is the zero-overhead property, stated precisely: **shared by source, monomorphised per call site,
+no vtable, no `Box<dyn>` between the probe and the comparison.**
+
+---
+
+## 3. Design options considered
+
+### Option A — Depend on `sparq-engine` from the reasoners (rejected)
+
+Make the reasoners `use sparq_engine::{hash_join, …}`. **Rejected:** creates the wrong dependency
+direction, pulls the planner + `service` + serializers into the reasoner crates and the tier-b
+reasoner wasm bundle, and risks the `wasm_bundle_bytes` floor on the reasoner bundles. Also makes
+every engine change a reasoner-API change.
+
+### Option B — Copy the kernels into each reasoner (status quo, rejected)
+
+Leave the engine as-is and let each reasoner keep / grow its own join code. **Rejected:** this is
+exactly the duplication the epic exists to remove; the reasoners' `FxHashMap` adjacency is weaker
+than the engine's WCOJ/merge/galloping machinery, so EL/QL/Direct would each reinvent a worse
+join, and a `Dict`/id-format change would have to be applied in N places (the brief's own
+regression risk #9).
+
+### Option C — Extract a shared leaf crate `sparq-substrate` (recommended)
+
+Lift §2.1 into a new crate that depends only on `sparq-core` (or on nothing, re-exported by
+`sparq-core`). `sparq-engine` and both reasoners depend on it. **Chosen.** It is the only
+placement with no dependency cycle, it removes the duplication, it lets the reasoners adopt the
+*good* joins, and — done as a pure code-move — it is provably perf-neutral because the engine's
+hot loop is the same source compiled to the same code. The one cost is a moderate refactor of
+`exec.rs` to call across a crate boundary (mitigated: the boundary is a function-call boundary at
+the *top* of each join, with the loop body fully inside the callee, so cross-crate inlining via
+`#[inline]` / LTO preserves codegen).
+
+### Option D — Make `sparq-core` itself host the kernels (viable fallback)
+
+Put the join kernels directly in `sparq-core` rather than a new crate. **Viable but not
+preferred:** `sparq-core` is the lean ingest/storage crate that the *lean* wasm bundle is built
+from; adding join code there risks the lean-bundle floor unless every kernel is behind a default-
+off feature. A separate `sparq-substrate` keeps `sparq-core` lean by construction and makes the
+feature-gating explicit. Recommend C; fall back to D only if a build-graph constraint forbids the
+new crate.
+
+---
+
+## 4. Recommendation and the zero-overhead contract
+
+Adopt **Option C**. The substrate crate publishes the join/term/numeric kernels under the same
+default-off feature discipline the workspace already uses, with these invariants written as CI-
+checkable rules:
+
+1. **No `Box<dyn>` / `&dyn` / vtable between a join's probe and its key comparison.** Enforced by
+   a clippy-lint / grep gate over `sparq-substrate/src` hot-loop modules and by the kernels being
+   generic only over the concrete `Id`/`SmallVec` aliases.
+2. **`sparq-core` lean wasm bundle byte-identical.** The substrate links no new external
+   dependency; its code is feature-gated so the lean bundle compiles *none* of it. Proven by the
+   `wasm_bundle_bytes` ratchet (floor 1686907) staying green on the lean build.
+3. **Engine hot-loop codegen preserved.** The move is source-identical; cross-crate inlining is
+   kept via `#[inline]` on the kernels + workspace LTO. Proven by the engine join/scan
+   micro-benches and the deterministic byte ratchets (the substrate move touches no storage
+   layout, so `store_bytes_per_triple` / `dict_bytes_per_term` are unaffected; any change there is
+   a red flag).
+4. **Reasoner wasm bundles do not regress.** The tier-b `sparq-reason-wasm` / `sparq-reason-el`
+   bundles gain only the kernels they actually call; if a reasoner adopts the shared join, its
+   bundle delta is measured and either justified or feature-gated.
+
+---
+
+## 5. Perf-neutrality strategy — how we PROVE the move costs nothing
+
+This is the make-or-break of the epic. The proof is layered and uses **only deterministic gates**
+(the EC2/work-box is non-canonical; we never bake a wall-clock number into a ratchet):
+
+| Layer | Gate | What it proves |
+|---|---|---|
+| Bundle | `wasm_bundle_bytes` floor 1686907 (`scripts/perf-gate.py`) | Lean wasm unchanged; substrate compiled out by default |
+| Storage | `store_bytes_per_triple` 92, `dict_bytes_per_term` 53 | The move touches no storage/dict layout |
+| Codegen | engine join/scan/BGP micro-benches in `sparq-bench` / `bench/` | Hot-loop throughput within noise of pre-move baseline |
+| Correctness | W3C SPARQL conformance (floor pinned in `sparq-conformance`) | The engine still computes identical answers after the move |
+| Reasoner | inference conformance (RDFS 48/48, OWL RL ratchet) unchanged | Reasoners that adopt the shared join still materialise the same closure |
+
+The decisive trick is to land the extraction as a **pure refactor PR first** (no behaviour
+change, no reasoner re-wiring) and require *every* ratchet above to stay byte-identical /
+within-noise on that PR. Only once the move is proven neutral do we let the reasoners adopt the
+shared join (a separate, independently-revertible PR). This keeps the perf-risk and the
+behaviour-risk on different PRs.
+
+**Honest perf risks (stated, not hidden):**
+
+- *Cross-crate inlining failure.* If LTO/`#[inline]` does not carry the loop body across the new
+  crate boundary, the engine could regress. Mitigation: micro-bench the move before merge; if a
+  kernel won't inline, keep it `#[inline(always)]` or, worst case, fall back to Option D
+  (in-`sparq-core`) for that kernel.
+- *Materialisation avalanche in reasoners* (brief risk #1). A reasoner's fixpoint can explode the
+  closure; the engine's per-query `QueryBudget` does **not** bound a rule loop. The shared join
+  does not fix this — the reasoner must install its **own** closure-level budget around the
+  fixpoint. This is a reasoner concern (sq-pbz04), not a substrate concern, but the substrate
+  should expose a cooperative cancellation hook the reasoner can poll.
+- *Numeric precision* (brief risk #6). Pushing a high-precision `xsd:decimal` rule threshold
+  through an f64 `ScanCmp` loses precision silently. The substrate's `Num` keeps the typed
+  decimal path; reasoners must use the typed compare, not the f64 fast path, for value-space
+  rules. Documented as a soundness note, not a perf trick.
+
+---
+
+## 6. Soundness notes (substrate scope)
+
+- **Single id space is the soundness keystone.** A join is only correct if both sides agree on
+  term identity. Every reasoner output term MUST be interned through the *same* `Dict` (and
+  `LocalVocab` for computed terms) as query-computed terms, so equal terms get equal ids
+  (brief risk #2). The substrate must NOT offer a constructor that takes raw ids from an external
+  cache. Enforced by making the only term→id path go through `sparq-core::Dict::intern` /
+  `LocalVocab::intern`.
+- **The substrate is value-correct, not entailment-aware.** It computes joins and comparisons; it
+  makes **no** claim about which triples *should* exist. Soundness of a regime (RL completeness,
+  EL CR-rules, QL applicability) lives entirely in the reasoner layer (sq-pbz04) and is verified
+  by the inference conformance suite — the substrate cannot make an unsound reasoner sound, and a
+  sound reasoner on top of a correct substrate stays sound.
+- **No privacy/ZK/MPC surface here.** The substrate is plain id-tuple evaluation. It does not
+  touch the ZK verifier or the MPC seam; nothing in this record makes any privacy claim.
+
+---
+
+## 7. Phased plan (each phase = a future bead under sq-qonbz)
+
+1. **Stand up `sparq-substrate` crate** (leaf, depends only on `sparq-core`, default-off
+   features, README ≤120 lines). No logic yet — just the crate, the `Row`/`Key`/`Num` re-exports,
+   and the feature wiring. *Acceptance:* workspace builds; lean wasm byte-identical (floor
+   1686907); `cargo deny` clean.
+2. **Move `compare_values` + `Num`/`as_numeric` + arithmetic into the substrate**; engine and the
+   value-space machinery call across the boundary. *Acceptance:* W3C SPARQL conformance floor
+   unchanged; engine ORDER BY / FILTER micro-benches within noise; byte ratchets unchanged.
+3. **Move the four join kernels** (merge / hash / bind / LFTJ) behind the `JoinKeys` descriptor;
+   engine adapts its `Bindings` callers. *Acceptance:* full W3C SPARQL conformance unchanged; join
+   micro-benches within noise; no `dyn` in hot-loop modules (grep/clippy gate).
+4. **Cooperative-cancellation hook** in the substrate join driver (a cheap `&AtomicBool` /
+   closure poll) so a reasoner can bound a runaway fixpoint. *Acceptance:* a unit test cancels a
+   long join; engine path unaffected when the hook is `None`.
+5. **Reasoner adoption (RL)**: rewrite `sparq-reason`'s `owl.rs` rule-firing to use the shared
+   join instead of its `FxHashMap` adjacency, keeping `UnionFind` for sameAs. *Acceptance:*
+   inference conformance (RDFS 48/48, OWL RL ratchet + documented divergences) unchanged;
+   `sparq-reason-wasm` bundle delta measured + justified/gated. *Depends on phases 3–4.*
+6. **Perf-neutrality CI rule**: a workspace lint/gate asserting the hot-loop modules carry no
+   `Box<dyn>`/`&dyn`, plus a doc note in `AGENTS.md` recording the substrate boundary as a
+   durable architecture fact. *Acceptance:* gate green on main; AGENTS.md updated.
+
+---
+
+## 8. Open questions for the maintainer
+
+1. **New crate (`sparq-substrate`, Option C) vs hosting the kernels in `sparq-core` (Option D)?**
+   I recommend C for explicit lean-bundle gating; D is a smaller diff. Your call on crate-count
+   vs locality.
+2. **Do you want the RL reasoner adopted onto the shared join *in this program* (phase 5), or is
+   the substrate extraction (phases 1–4) enough for now**, leaving reasoner adoption to land
+   alongside the EL/QL build-out under sq-pbz04? Phase 5 is the riskier, higher-value half.
+3. **Budget model unification.** Should the substrate own a single cooperative-cancellation
+   abstraction that *both* the query budget and the reasoner closure-budget implement, or keep
+   them separate? Unifying is cleaner but touches the engine's budget plumbing.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — design-for-review records for the umbrella program **sq-6tykl** (unified eval substrate + full reasoners + SERVICE federation + RSP/GeoSPARQL). No engine/reasoner code changed; this PR is `research/` design records only, for @jeswr to review and steer. [OPUS-4.8]

## What this adds (`research/`)

- **`shared-eval-substrate.md`** (PRIMARY, epic **sq-qonbz**) — extract the engine's id-level join / numeric / term-compare hot loops into a **new leaf crate `sparq-substrate`** (depends only on `sparq-core`; monomorphic over `Id = u32` + the existing `SmallVec` row/key aliases; **no `Box<dyn>` on the hot path**; feature-gated so the lean wasm bundle stays **byte-identical at floor 1686907**). Consumed by the engine **and** both reasoners with no dependency cycle.
- **`reasoner-suite-on-substrate.md`** (epic **sq-pbz04**) — RL-complete / EL / QL / Direct / RIF / D sequenced by **soundness risk**; the **QL PerfectRef / tree-witness** trap is called out (no Rust oracle exists; NP-complete UCQ-containment minimisation); **DL deferred** (undecidable for OWL DL). Builds on the prior EL/QL spike (sq-wmeg).
- **`service-federation-conformance.md`** (epic **sq-my8wd**) — wire the `sparql11/service` **evaluation** suite via **real in-process `sparq-server` loopback endpoints** (the server APIs are public; today's `Transport` mock seam is only `pub(crate)` and engine-test-only).
- **`rsp-geo-conformance-integration.md`** (epics **sq-2n1q3** / **sq-lk3aw**) — extend the existing OGC geo ratchet (119); RSP/text framed **honestly** as expressivity / differential-oracle ratchets.

## Corrections to the brief's premise (honesty first)

1. **The reasoners do NOT currently call the engine's joins.** `sparq-reason` / `sparq-reason-el` depend **only on `sparq-core`** and roll their own `FxHashMap` adjacency + `UnionFind`. So "share the substrate" is an **extract-and-unify** project, not reuse-as-is. The shared code must live in a leaf crate at/below `sparq-core` (the engine can't host it — the reasoners must not depend on the whole engine).
2. **Wasm floor is 1686907**, not the brief's stale 1656470 (re-baselined #1286).
3. **No W3C/CSPARQL RSP conformance suite and no full-text-RDF standard exist** — those ratchets are labelled expressivity / differential-oracle, never "conformance."

## Honesty / gates

- markdownlint-clean (0 errors); typos gate clean; **no privacy/ZK/MPC claims** (substrate is plain id-tuple eval; the MPC seam stays deferred/semi-honest and out of scope).
- Perf-neutrality is **proven by deterministic ratchets** (`wasm_bundle_bytes` 1686907, `store_bytes_per_triple` 92, `dict_bytes_per_term` 53) + join micro-benches on a **pure-refactor-first** PR — work-box timings are non-canonical and not baked into any ratchet.

Open questions for the maintainer are listed at the end of each record (new crate vs in-`sparq-core`; RL adoption scope; QL MVP-vs-tree-witness; loopback server vs public test-transport; RSP/text honest labelling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)