### PR TITLE
feat(engine): per-query remote-request cap for high-cardinality SERVICE ?ep (sq-b93pv) [OPUS-4.8]

### DIFF
--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -2585,6 +2585,26 @@ fn bound_join_variable_endpoint(
         return Ok(None);
     }
 
+    // [OPUS-4.8] (sq-b93pv) PRE-DISPATCH remote-request cap. `order` is the set of
+    // DISTINCT endpoint IRIs this `SERVICE ?ep` would dial — known now, before any
+    // socket is opened — so a high-cardinality `?ep` (an endpoint var bound to many
+    // distinct IRIs) is BOUNDED HERE rather than after the requests have gone out. The
+    // refusal is a hard, typed error (the `SERVICE_REMOTE_CAP_MARKER` substring) and is
+    // NOT swallowed by SILENT: SILENT masks an endpoint being unreachable, not a
+    // deliberate resource-policy refusal (the same stance `budget::check` takes). When no
+    // cap is installed (the default) this is a single thread-local read and a no-op.
+    if let Some(cap) = crate::service::remote_request_cap() {
+        if order.len() > cap {
+            return Err(format!(
+                "{}: SERVICE ?{} would dispatch to {} distinct endpoints (cap {})",
+                crate::service::SERVICE_REMOTE_CAP_MARKER,
+                ep_var.as_str(),
+                order.len(),
+                cap,
+            ));
+        }
+    }
+
     // Resolve the endpoint IRI strings once (id -> "http://…").
     let mut acc_vars: Vec<Variable> = vec![ep_var.clone()];
     let mut acc_rows: Vec<Row> = Vec::new();
@@ -11118,6 +11138,162 @@ mod service_exec_tests {
             seen.borrow().iter().all(|(e, _)| e == "http://r1/"),
             "only the valid IRI endpoint was contacted"
         );
+    }
+
+    // ---------------------------------------------------------------------
+    // Per-query remote-request cap for high-cardinality SERVICE ?ep. [OPUS-4.8]
+    // (sq-b93pv). The cap bounds the number of DISTINCT endpoints a single
+    // `SERVICE ?ep` may dial, enforced PRE-HTTP: when the cap fires, the mock
+    // transport must record ZERO requests (proof the bound is before dispatch, not
+    // a post-HTTP cancellation).
+    // ---------------------------------------------------------------------
+
+    /// `local` data binding `n` distinct persons each to a DISTINCT endpoint IRI
+    /// (`http://r0/`, `http://r1/`, …) — i.e. a high-cardinality `?ep`.
+    fn persons_with_distinct_endpoints(n: usize) -> Graph {
+        let mut ttl = String::from("@prefix ex: <http://ex/> .\n");
+        for i in 0..n {
+            ttl.push_str(&format!("ex:p{i} ex:ep <http://r{i}/> .\n"));
+        }
+        Graph::load_str(&ttl, "turtle").unwrap()
+    }
+
+    #[test]
+    fn remote_request_cap_fires_before_dispatch() {
+        // 5 distinct endpoints, cap 3 => the query is REFUSED, and the mock records
+        // NO requests (the bound is enforced pre-HTTP, before any socket is opened).
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let _g = service_transport::install(Box::new(RemoteByEndpoint {
+            graphs: std::collections::HashMap::new(),
+            seen: Rc::clone(&seen),
+        }));
+        let q = "PREFIX ex: <http://ex/> SELECT ?s ?name WHERE \
+                 { ?s ex:ep ?e . SERVICE ?e { ?s ex:name ?name } }";
+        let p = pattern(q);
+        let err = crate::service::with_service_remote_request_cap(3, || {
+            eval_select(&persons_with_distinct_endpoints(5), &p)
+        })
+        .unwrap_err();
+        // Typed refusal: carries the stable marker the server classifies on.
+        assert!(
+            err.contains(crate::service::SERVICE_REMOTE_CAP_MARKER),
+            "cap error must carry the marker, got: {err}"
+        );
+        // PRE-DISPATCH: not one remote request was made.
+        assert!(
+            seen.borrow().is_empty(),
+            "cap must fire BEFORE any HTTP dispatch; mock saw: {:?}",
+            seen.borrow()
+        );
+    }
+
+    #[test]
+    fn remote_request_cap_not_swallowed_by_silent() {
+        // The cap is a resource-policy refusal, not a remote failure: SERVICE SILENT
+        // must NOT mask it (SILENT only masks an endpoint being unreachable).
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let _g = service_transport::install(Box::new(RemoteByEndpoint {
+            graphs: std::collections::HashMap::new(),
+            seen: Rc::clone(&seen),
+        }));
+        let q = "PREFIX ex: <http://ex/> SELECT ?s ?name WHERE \
+                 { ?s ex:ep ?e . SERVICE SILENT ?e { ?s ex:name ?name } }";
+        let p = pattern(q);
+        let err = crate::service::with_service_remote_request_cap(2, || {
+            eval_select(&persons_with_distinct_endpoints(5), &p)
+        })
+        .unwrap_err();
+        assert!(
+            err.contains(crate::service::SERVICE_REMOTE_CAP_MARKER),
+            "SILENT must not swallow the cap refusal, got: {err}"
+        );
+        assert!(seen.borrow().is_empty(), "cap fires before dispatch even under SILENT");
+    }
+
+    #[test]
+    fn remote_request_cap_at_or_under_limit_passes() {
+        // 2 distinct endpoints, cap 2 (the boundary: > cap fires, == cap is allowed).
+        // Each endpoint knows its own person's name; the query must succeed normally.
+        let r0 = Graph::load_str(
+            "@prefix ex: <http://ex/> . ex:p0 ex:name \"P0\" .",
+            "turtle",
+        )
+        .unwrap();
+        let r1 = Graph::load_str(
+            "@prefix ex: <http://ex/> . ex:p1 ex:name \"P1\" .",
+            "turtle",
+        )
+        .unwrap();
+        let mut graphs = std::collections::HashMap::new();
+        graphs.insert("http://r0/".to_string(), r0);
+        graphs.insert("http://r1/".to_string(), r1);
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let _g = service_transport::install(Box::new(RemoteByEndpoint {
+            graphs,
+            seen: Rc::clone(&seen),
+        }));
+        let q = "PREFIX ex: <http://ex/> SELECT ?s ?name WHERE \
+                 { ?s ex:ep ?e . SERVICE ?e { ?s ex:name ?name } }";
+        let p = pattern(q);
+        let res = crate::service::with_service_remote_request_cap(2, || {
+            eval_select(&persons_with_distinct_endpoints(2), &p)
+        })
+        .expect("at-cap query is allowed");
+        assert_eq!(res.rows.len(), 2, "both persons resolved against their own endpoint");
+        // Exactly the two distinct endpoints were dialled.
+        let dialled: std::collections::HashSet<String> =
+            seen.borrow().iter().map(|(e, _)| e.clone()).collect();
+        assert_eq!(dialled.len(), 2, "dialled exactly the two permitted endpoints");
+    }
+
+    #[test]
+    fn remote_request_cap_default_off_is_unchanged() {
+        // DEFAULT (no cap installed): a high-cardinality SERVICE ?ep dispatches to ALL
+        // distinct endpoints exactly as before — the cap adds nothing to normal queries.
+        let mut graphs = std::collections::HashMap::new();
+        for i in 0..5 {
+            graphs.insert(
+                format!("http://r{i}/"),
+                Graph::load_str(
+                    &format!("@prefix ex: <http://ex/> . ex:p{i} ex:name \"P{i}\" ."),
+                    "turtle",
+                )
+                .unwrap(),
+            );
+        }
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let _g = service_transport::install(Box::new(RemoteByEndpoint {
+            graphs,
+            seen: Rc::clone(&seen),
+        }));
+        let q = "PREFIX ex: <http://ex/> SELECT ?s ?name WHERE \
+                 { ?s ex:ep ?e . SERVICE ?e { ?s ex:name ?name } }";
+        // No `with_service_remote_request_cap` scope => uncapped (the default).
+        let res = eval_select(&persons_with_distinct_endpoints(5), &pattern(q)).unwrap();
+        assert_eq!(res.rows.len(), 5, "all five persons resolved (no cap by default)");
+        let dialled: std::collections::HashSet<String> =
+            seen.borrow().iter().map(|(e, _)| e.clone()).collect();
+        assert_eq!(dialled.len(), 5, "all five distinct endpoints dialled by default");
+    }
+
+    #[test]
+    fn remote_request_cap_does_not_bound_concrete_endpoint() {
+        // A concrete-IRI SERVICE is a SINGLE endpoint; even cap 0 (refuse any variable
+        // dispatch) must not touch it — the cap is scoped to the variable-endpoint
+        // fan-out, not the per-block request count of a single endpoint.
+        let g = three_persons();
+        let seen = Rc::new(RefCell::new(Vec::new()));
+        let _g = service_transport::install(Box::new(RemoteGraph {
+            remote: remote_names(),
+            seen: Rc::clone(&seen),
+        }));
+        let q = "PREFIX ex: <http://ex/> SELECT ?s ?name WHERE \
+                 { ?s a ex:Person . SERVICE <http://r/> { ?s ex:name ?name } }";
+        let res = crate::service::with_service_remote_request_cap(0, || {
+            eval_select(&g, &pattern(q))
+        })
+        .expect("concrete-IRI SERVICE is unaffected by the variable-endpoint cap");
+        assert_eq!(res.rows.len(), 2, "alice + bob matched, cap did not interfere");
     }
 
     // ---------------------------------------------------------------------

--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -51,6 +51,12 @@ pub use service::with_service_egress_policy;
 // SERVICE bound-join pushdown (on-by-default, correctness-preserving). [OPUS-4.8] (sq-sjkj)
 #[cfg(feature = "service")]
 pub use service::with_service_bound_join_block_size;
+// Per-query remote-request cap for a high-cardinality `SERVICE ?ep` (endpoint var bound
+// to many distinct IRIs): an OPT-IN ceiling on the distinct endpoints one SERVICE ?ep
+// evaluation may dial, enforced PRE-HTTP (a typed refusal, not post-hoc cancellation).
+// DEFAULT is uncapped, so normal SERVICE queries are unchanged. [OPUS-4.8] (sq-b93pv)
+#[cfg(feature = "service")]
+pub use service::{with_service_remote_request_cap, SERVICE_REMOTE_CAP_MARKER};
 // [OPUS-4.8] (sq-678h) RDF serializer matrix (Turtle / TriG / N-Quads writers). NON-DEFAULT
 // `serialize-rdf` feature — when off, zero serializer code compiles and the default build's
 // dependency graph is unchanged (the writers add no new deps). The always-on N-Triples writer

--- a/crates/sparq-engine/src/service.rs
+++ b/crates/sparq-engine/src/service.rs
@@ -219,6 +219,126 @@ pub fn with_service_bound_join_block_size<R>(n: usize, f: impl FnOnce() -> R) ->
     f()
 }
 
+// ---------------------------------------------------------------------------
+// Per-query remote-request cap for high-cardinality `SERVICE ?ep` [OPUS-4.8] (sq-b93pv)
+// ---------------------------------------------------------------------------
+//
+// A `SERVICE ?ep { P }` whose endpoint variable binds to MANY distinct endpoint IRIs
+// fans out into one remote dispatch per distinct endpoint (see
+// `exec::bound_join_variable_endpoint`). With nothing bounding that fan-out, an
+// attacker-shaped query — or simply a large left relation whose `?ep` column is highly
+// distinct — turns a single client request into an unbounded burst of outbound HTTP
+// calls from the engine host (threat-model B4, the SSRF/egress family). This is the
+// amplification dimension the per-request egress allowlist does NOT cover: every dialled
+// host may be individually permitted yet the COUNT still runaway.
+//
+// The cap is an OPT-IN ceiling on the number of distinct remote endpoints a single
+// `SERVICE ?ep` evaluation may dispatch to. It is enforced PRE-HTTP — at plan/eval
+// time, once the distinct-endpoint set is known and BEFORE the first socket is opened —
+// so it BOUNDS the runaway rather than cancelling it after the requests have already
+// gone out. Exceeding it is a hard, typed refusal (the [`SERVICE_REMOTE_CAP_MARKER`]
+// substring), fail-closed: it is NOT swallowed by `SILENT`, because `SILENT` means "a
+// remote endpoint being unreachable/broken must not fail the query", not "my own
+// resource policy refusing the query may be masked as success". This mirrors the
+// `"query budget exceeded"` guard, which `SILENT` likewise does not swallow.
+//
+// DEFAULT is OFF (no cap): a normal `SERVICE` query — concrete endpoint, or a variable
+// endpoint with a handful of distinct values — is entirely unchanged. The cap only
+// exists once an embedder/server opts in via [`with_service_remote_request_cap`] or the
+// `SPARQ_SERVICE_REMOTE_CAP` env var.
+
+/// Stable marker substring embedded in the engine error string when a `SERVICE ?ep`
+/// query is refused for exceeding the per-query remote-request cap. [OPUS-4.8] (sq-b93pv)
+///
+/// Mirrors [`SERVICE_EGRESS_REFUSED_MARKER`]: a network-exposed host (`sparq-server`)
+/// can `contains()`-classify the refusal as a deliberate resource-policy decision (an
+/// honest `429`/`403`-style status) rather than a server fault, and it is deliberately
+/// generic (it names no endpoint) so it is safe to surface to the client.
+pub const SERVICE_REMOTE_CAP_MARKER: &str = "SERVICE remote-request cap exceeded";
+
+#[cfg(feature = "service")]
+mod remote_cap {
+    use std::cell::Cell;
+
+    thread_local! {
+        // `None` => no scope override; consult the env var, else the built-in (OFF).
+        static OVERRIDE: Cell<Option<Option<usize>>> = const { Cell::new(None) };
+    }
+
+    /// RAII override of the remote-request cap for the current scope.
+    pub(crate) struct Guard(Option<Option<usize>>);
+    impl Drop for Guard {
+        fn drop(&mut self) {
+            OVERRIDE.with(|o| o.set(self.0.take()));
+        }
+    }
+
+    /// Installs `cap` (`Some(n)` = cap at `n`; `None` = explicitly UNCAPPED for this
+    /// scope, overriding any env var) and returns a guard that restores the previous
+    /// override on drop/unwind.
+    pub(crate) fn install(cap: Option<usize>) -> Guard {
+        Guard(OVERRIDE.with(|o| o.replace(Some(cap))))
+    }
+
+    /// The active cap: an installed scope override wins (including an explicit `None`
+    /// "uncapped"); otherwise the `SPARQ_SERVICE_REMOTE_CAP` env var; otherwise OFF
+    /// (`None` = no cap). Off the hot path — called once per `SERVICE ?ep` evaluation.
+    pub(crate) fn current() -> Option<usize> {
+        if let Some(scope) = OVERRIDE.with(|o| o.get()) {
+            return scope;
+        }
+        #[cfg(not(target_arch = "wasm32"))]
+        if let Ok(s) = std::env::var("SPARQ_SERVICE_REMOTE_CAP") {
+            if let Ok(n) = s.trim().parse::<usize>() {
+                return Some(n);
+            }
+        }
+        None
+    }
+}
+
+/// The per-query SERVICE remote-request cap in force for the current scope, or `None`
+/// when no cap is active (the default). [OPUS-4.8] (sq-b93pv)
+#[cfg(feature = "service")]
+pub(crate) fn remote_request_cap() -> Option<usize> {
+    remote_cap::current()
+}
+
+/// Runs `f` with a ceiling of `n` distinct remote endpoints per `SERVICE ?ep`
+/// evaluation. [OPUS-4.8] (sq-b93pv)
+///
+/// A `SERVICE ?ep { P }` whose endpoint variable binds to MANY distinct endpoint IRIs
+/// dispatches one remote bind-join per distinct endpoint. This OPT-IN cap bounds that
+/// fan-out: if the number of distinct endpoints the query would dial exceeds `n`, the
+/// query is REJECTED with a typed error (carrying [`SERVICE_REMOTE_CAP_MARKER`]) BEFORE
+/// any HTTP request is sent — a true pre-dispatch bound, not a post-hoc cancellation.
+///
+/// The cap is **not** swallowed by `SERVICE SILENT`: `SILENT` masks an endpoint being
+/// unreachable, not a deliberate resource-policy refusal (the same stance the query
+/// budget takes). It is also a no-op for a concrete-IRI `SERVICE <…>` (a single
+/// endpoint) and for a variable endpoint that binds to at most `n` distinct IRIs, so a
+/// normal federated query is unaffected.
+///
+/// The default (no enclosing scope and no `SPARQ_SERVICE_REMOTE_CAP` env var) is
+/// UNCAPPED — the behaviour every existing `SERVICE` query already had. Passing `n = 0`
+/// caps at zero, which refuses any `SERVICE ?ep` that resolves to one or more
+/// endpoints. The override is thread-local and restored on return/unwind, mirroring
+/// [`with_service_egress_allow`].
+///
+/// ```no_run
+/// # #[cfg(feature = "service")] {
+/// // Allow a high-cardinality SERVICE ?ep to dial at most 8 distinct endpoints.
+/// sparq_engine::with_service_remote_request_cap(8, || {
+///     // ... run a federated query containing `SERVICE ?ep { ... }`
+/// });
+/// # }
+/// ```
+#[cfg(feature = "service")]
+pub fn with_service_remote_request_cap<R>(n: usize, f: impl FnOnce() -> R) -> R {
+    let _guard = remote_cap::install(Some(n));
+    f()
+}
+
 /// Renders a `VALUES` block that binds `vars` to each tuple in `tuples`, in the
 /// SPARQL 1.1 syntax accepted inside a group graph pattern. [OPUS-4.8] (sq-sjkj)
 ///

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -390,6 +390,18 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   names no valid endpoint and contributes no federated answer. A **top-level** `SERVICE ?ep` with
   nothing to bind it still errors (or, under `SILENT`, yields the join identity). (No new public API —
   this is a behavioural addition on the `service` feature.)
+- **Per-query `SERVICE ?ep` remote-request cap** (`sq-b93pv`) — a `SERVICE ?ep` whose endpoint
+  variable binds to **many distinct endpoint IRIs** fans out into one remote dispatch per distinct
+  endpoint, so a hostile / high-cardinality `?ep` can amplify one client query into a burst of
+  outbound calls (the amplification the per-host egress allowlist does not bound). The **opt-in**
+  `with_service_remote_request_cap(n, || query(&g, q))` (or the `SPARQ_SERVICE_REMOTE_CAP` env var)
+  caps the number of distinct endpoints one `SERVICE ?ep` evaluation may dial; exceeding it is a
+  typed refusal **enforced PRE-HTTP** (at eval time, before any socket opens — a true pre-dispatch
+  bound, not a post-hoc cancellation) carrying the stable `sparq_engine::SERVICE_REMOTE_CAP_MARKER`
+  substring (so a server can classify it like the egress marker). It is **not** swallowed by
+  `SILENT` (a resource-policy refusal, not an unreachable endpoint — the same stance the query
+  budget takes). **Default is uncapped**, so a concrete-IRI `SERVICE <…>` and a normal-cardinality
+  `SERVICE ?ep` are unchanged.
 - **Per-query `SERVICE` timeout** (`sq-d4p`) — the SERVICE HTTP transport's socket timeout is now
   bounded by the active `QueryBudget` deadline (it caps at `min(remaining-until-deadline, default)`
   with a small non-zero floor), so a `SERVICE` fetch under a tight `deadline` no longer blocks for the


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bead **sq-b93pv** (epic sq-my8wd). Honest, tight hardening of the SERVICE eval path only.

## What

A per-query remote-request cap for a high-cardinality `SERVICE ?ep` query, behind the non-default **`service`** feature.

A `SERVICE ?ep { P }` whose endpoint variable binds to **many distinct endpoint IRIs** fans out into one remote dispatch per distinct endpoint (`exec::bound_join_variable_endpoint`). With nothing bounding that fan-out, a hostile / high-cardinality `?ep` amplifies a single client query into a burst of outbound HTTP calls from the engine host — threat-model **B4**, the amplification dimension the per-host egress allowlist does **not** cover (every dialled host may be individually permitted yet the *count* still runs away).

## How (BOUNDED BEFORE dispatch — pre-HTTP, not post-hoc cancellation)

The cap is enforced in `bound_join_variable_endpoint` **after** the distinct-endpoint set (`order`) is computed and **before** the dispatch loop — i.e. at eval time, before any socket is opened. An over-cap query is refused with a typed error carrying the stable `SERVICE_REMOTE_CAP_MARKER` substring (mirrors `SERVICE_EGRESS_REFUSED_MARKER`, so a network-exposed server can `contains()`-classify it as a 429/403-style policy refusal). It is **fail-closed**: NOT swallowed by `SILENT` (a resource-policy refusal, not an unreachable endpoint — the same stance the query budget takes).

Opt in via `with_service_remote_request_cap(n, || query(&g, q))` or the `SPARQ_SERVICE_REMOTE_CAP` env var (thread-local, RAII-restored, mirroring `with_service_egress_allow` / the bind-block knob).

## Default behaviour unchanged

**DEFAULT is uncapped.** A concrete-IRI `SERVICE <…>` (a single endpoint) and a normal-cardinality `SERVICE ?ep` are entirely unchanged. When no cap is installed the check is a single thread-local read.

## Tests (real path, mocked-transport seam — no network)

Five in-crate tests in `service_exec_tests` (the `service_transport` injection seam), driving the genuine variable-endpoint dispatch:
- **`remote_request_cap_fires_before_dispatch`** — 5 distinct endpoints, cap 3 ⇒ refused, and the mock records **ZERO** requests (proof the bound is pre-HTTP).
- **`remote_request_cap_not_swallowed_by_silent`** — `SERVICE SILENT ?ep` over-cap still errors (fail-closed), zero requests.
- **`remote_request_cap_at_or_under_limit_passes`** — the `== cap` boundary is allowed; both endpoints dialled, correct rows.
- **`remote_request_cap_default_off_is_unchanged`** — no cap ⇒ all 5 endpoints dialled (the prior behaviour).
- **`remote_request_cap_does_not_bound_concrete_endpoint`** — a concrete-IRI SERVICE is unaffected even at cap 0 (the cap is scoped to variable-endpoint fan-out).

## Feature flags + gates (run in-worktree)

- Feature: **`service`** (OFF by default; never in the wasm bundle).
- `cargo clippy -p sparq-engine --all-targets -- -D warnings` — GREEN **default (feature OFF)** AND **`--features service`**.
- `cargo test -p sparq-engine` (default) GREEN; `cargo test -p sparq-engine --features service` GREEN (275 lib + integration tests, incl. the 5 new).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations (no README touched).
- `cargo +1.88 check -p sparq-engine` — clean.

## Perf-neutral

Every addition is `#[cfg(feature = "service")]` (the `service` feature is never enabled in the default/wasm builds), so the lean default and wasm builds compile **zero** new code — `wasm_bundle_bytes` / store / dict byte floors are byte-identical by construction. `bench/perf-baseline.json` is untouched.

## Honest boundary

This caps the **distinct-endpoint** fan-out of a variable endpoint — the high-cardinality `SERVICE ?ep` shape the bead targets. It does not bound the per-block request count of a *single* concrete endpoint's bind-join (that is the `with_service_bound_join_block_size` knob's territory and a different shape); a follow-up could add a whole-query remote-request budget across all SERVICE clauses if a need is shown.

Touches the sparq-engine SERVICE eval path only (not join/arith).