### PR TITLE
feat(reason): opt-in Profile::D datatype/value-space entailment materialiser (sq-e5atd) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1431,6 +1431,28 @@ jobs:
           TOTAL=$(( ${PASS:-0} + ${DIV:-0} ))
           echo "pass: ${PASS:-unknown} + documented divergences: ${DIV:-0} = $TOTAL (ratchet: $RATCHET)"
           [ -n "$PASS" ] && [ "$TOTAL" -ge "$RATCHET" ] || { echo "::error::inference conformance regressed below the ratchet ($TOTAL < $RATCHET)"; exit 1; }
+      - name: Run D-entailment lane (d-entail feature ON) + enforce floor
+        # [OPUS-4.8] sq-e5atd (epic sq-pbz04) — the OPT-IN D-entailment (datatype /
+        # value-space) ratchet. SEPARATE from the binary ratchet above so the default
+        # inference binary stays byte-for-byte unchanged (the D-only sparql11/entailment
+        # tests remain OutOfScope there). This crate-test runs those tests through the
+        # real `sparq_reason::Profile::D` materializer and prints a `TOTAL d-entail`
+        # line; the floor (D_ENTAIL_FLOOR, mirrored in scoreboard::SUITES) is asserted
+        # in-runner AND re-grepped here. `--nocapture` so the TOTAL line reaches stdout.
+        run: |
+          set -uo pipefail
+          cargo test -p sparq-conformance --features d-entail --test d_entail_suite -- --nocapture \
+            | tee d-entail-conformance.out
+          rc=${PIPESTATUS[0]}
+          [ "$rc" -eq 0 ] || { echo "::error::D-entailment lane test failed (exit $rc)"; exit "$rc"; }
+          if ! grep -qE '^TOTAL d-entail ' d-entail-conformance.out; then
+            echo "::error::D-entailment lane produced no 'TOTAL d-entail' line — infra/build issue, not a conformance change. Re-run the job."
+            exit 1
+          fi
+          FLOOR=1
+          PASS=$(grep -E '^TOTAL d-entail ' d-entail-conformance.out | awk '{print $3}' | head -1)
+          echo "D-entailment pass: ${PASS:-unknown} (floor: $FLOOR)"
+          [ -n "$PASS" ] && [ "$PASS" -ge "$FLOOR" ] || { echo "::error::D-entailment regressed below the ratchet ($PASS < $FLOOR)"; exit 1; }
       - name: Upload report
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/crates/sparq-conformance/Cargo.toml
+++ b/crates/sparq-conformance/Cargo.toml
@@ -42,6 +42,17 @@ path = "src/bin/scoreboard.rs"
 # features and links `oxjsonld` directly (to re-parse the writer's JSON-LD output
 # back to RDF for the fromRdf semantic-equivalence comparison).
 jsonld-suite = ["sparq-core/jsonld", "sparq-engine/serialize-rdf", "dep:oxjsonld"]
+# [OPUS-4.8] sq-e5atd (epic sq-pbz04) — the D-entailment (datatype / value-space)
+# conformance lane (the crate-local `tests/d_entail_suite.rs` runner + the `Regime::D`
+# arm in `inference::entail`). OPT-IN and OFF by default so the default
+# `cargo test -p sparq-conformance` and the inference BINARY are byte-for-byte
+# unchanged (the binary keeps the D-only SPARQL entailment test OutOfScope when the
+# feature is off, so its ratchet floor is untouched). Forwards to sparq-reason's
+# opt-in `d-entail` feature (`Profile::D` + the typed value-space comparator). When
+# OFF the lane compiles to a single self-SKIP `#[test]`; when ON it drives the
+# D-regime tests through the REAL `Profile::D` materializer and asserts the pinned
+# floor. Pure-Rust, no new third-party deps.
+d-entail = ["sparq-reason/d-entail"]
 
 [dependencies]
 sparq-core = { path = "../sparq-core" }

--- a/crates/sparq-conformance/src/inference/entail.rs
+++ b/crates/sparq-conformance/src/inference/entail.rs
@@ -29,6 +29,12 @@ pub enum Regime {
     Rdf,
     Rdfs,
     OwlRl,
+    /// [OPUS-4.8] sq-e5atd — D-entailment (datatype / value-space, RDF 1.1
+    /// Semantics §7-8): the rdfD1 datatype-typing closure under the recognized
+    /// datatype map, computed THROUGH `sparq_reason::Profile::D` (the materializer
+    /// under test). OPT-IN, behind the crate's `d-entail` feature.
+    #[cfg(feature = "d-entail")]
+    D,
 }
 
 pub fn triple_row(t: &Triple) -> Row {
@@ -88,6 +94,15 @@ pub fn close(premise: &[Row], conclusion: &[Row], regime: Regime, d: &Recognized
         Regime::Simple => return set.into_iter().collect(),
         Regime::OwlRl => {
             materialize_through_dict(&mut set, sparq_reason::Profile::OwlRl);
+            return set.into_iter().collect();
+        }
+        // [OPUS-4.8] sq-e5atd — D-entailment: simple entailment PLUS the rdfD1
+        // datatype-typing closure, computed THROUGH the materializer under test
+        // (`sparq_reason::materialize_d`) with the test's recognized datatype map.
+        // No RDF/RDFS axiomatic layer (D-entailment is over simple, not RDFS).
+        #[cfg(feature = "d-entail")]
+        Regime::D => {
+            materialize_d_through_dict(&mut set, d);
             return set.into_iter().collect();
         }
         Regime::Rdf | Regime::Rdfs => {}
@@ -216,6 +231,27 @@ fn materialize_through_dict(set: &mut FxHashSet<Row>, profile: sparq_reason::Pro
         triples.push([dict.intern(s), dict.intern(p), dict.intern(o)]);
     }
     sparq_reason::materialize(profile, &mut dict, &mut triples);
+    for [s, p, o] in triples {
+        set.insert([dict.term(s), dict.term(p), dict.term(o)]);
+    }
+}
+
+/// [OPUS-4.8] sq-e5atd — round-trips the row set through
+/// `sparq_reason::materialize_d` (the D-entailment materializer under test), with
+/// the test's recognized datatype map `d` translated into the reasoner's
+/// [`sparq_reason::Recognized`]. The rdfD1 typing triples it emits are GENERALIZED
+/// (literal in subject position), exactly the shape the homomorphism checker
+/// expects (`lg`/`gl` literal generalization). Like `materialize_through_dict`,
+/// term-level lexical forms survive the dictionary round-trip.
+#[cfg(feature = "d-entail")]
+fn materialize_d_through_dict(set: &mut FxHashSet<Row>, d: &Recognized) {
+    let recognized = sparq_reason::Recognized::new(d.0.iter().cloned());
+    let mut dict = Dict::new();
+    let mut triples: Vec<[sparq_core::dict::Id; 3]> = Vec::with_capacity(set.len());
+    for [s, p, o] in set.iter() {
+        triples.push([dict.intern(s), dict.intern(p), dict.intern(o)]);
+    }
+    sparq_reason::materialize_d(&recognized, &mut dict, &mut triples);
     for [s, p, o] in triples {
         set.insert([dict.term(s), dict.term(p), dict.term(o)]);
     }

--- a/crates/sparq-conformance/src/inference/sparql_entail.rs
+++ b/crates/sparq-conformance/src/inference/sparql_entail.rs
@@ -75,6 +75,13 @@ pub fn run_suite(rdf_tests_root: &Path, out: &mut Vec<TestResult>) -> Result<(),
             Profile::Rdf
         } else if regimes.contains("OWL-RDF-Based") {
             Profile::OwlRl
+        } else if d_regime_profile(&regimes).is_some() {
+            // [OPUS-4.8] sq-e5atd — a D-only (datatype / value-space) test: route
+            // it through the opt-in `Profile::D` materializer when the `d-entail`
+            // feature is ON. When OFF, `d_regime_profile` returns None and the test
+            // stays OutOfScope (below), so the default inference binary's ratchet is
+            // unchanged — the lean opt-in posture.
+            d_regime_profile(&regimes).unwrap()
         } else {
             let mut rs: Vec<&str> = regimes.iter().copied().collect();
             rs.sort_unstable();
@@ -93,11 +100,71 @@ pub fn run_suite(rdf_tests_root: &Path, out: &mut Vec<TestResult>) -> Result<(),
     Ok(())
 }
 
+/// [OPUS-4.8] sq-e5atd — run ONLY the genuinely D-only (`sd:entailmentRegime
+/// ent:D` WITHOUT any stronger RDFS/RDF/OWL-RDF-Based regime) tests of the
+/// `sparql11/entailment` suite, through the real `Profile::D` materializer. This
+/// is the DEDICATED D-regime lane the `tests/d_entail_suite.rs` ratchet asserts a
+/// floor over; it is deliberately a SUBSET of `run_suite` (the stronger-regime
+/// tests are exercised under their own regime there). Opt-in, `d-entail`.
+#[cfg(feature = "d-entail")]
+pub fn run_d_regime_suite(rdf_tests_root: &Path, out: &mut Vec<TestResult>) -> Result<(), String> {
+    let suites_root = rdf_tests_root
+        .join("sparql")
+        .canonicalize()
+        .map_err(|e| format!("rdf-tests sparql dir: {e}"))?;
+    let manifest_path = suites_root.join("sparql11/entailment/manifest.ttl");
+    let mut entries: Vec<TestEntry> = Vec::new();
+    manifest::collect(&manifest_path, &suites_root, &mut entries)?;
+    for entry in &entries {
+        if entry.kind != EntryKind::QueryEval {
+            continue;
+        }
+        let regimes: FxHashSet<&str> = entry
+            .action
+            .entailment_regimes
+            .iter()
+            .filter_map(|r| r.rsplit('/').next())
+            .collect();
+        // A test is D-ONLY when its only materializable regime is D — none of the
+        // stronger regimes (which `run_suite` picks first) apply.
+        let stronger = regimes.contains("RDFS")
+            || regimes.contains("RDF")
+            || regimes.contains("OWL-RDF-Based");
+        if stronger || !regimes.contains("D") {
+            continue;
+        }
+        let direct_sanctioned = regimes.contains("OWL-Direct");
+        out.push(result(entry, run_one(entry, Profile::D, direct_sanctioned)));
+    }
+    Ok(())
+}
+
 #[derive(Clone, Copy, PartialEq)]
 enum Profile {
     Rdf,
     Rdfs,
     OwlRl,
+    /// [OPUS-4.8] sq-e5atd — D-entailment (datatype / value-space). Opt-in,
+    /// `d-entail`. Only reached for a test whose regime set is D WITHOUT any of
+    /// RDFS/RDF/OWL-RDF-Based (those stronger regimes subsume D and are picked
+    /// first), so this arm graduates the genuinely D-only tests.
+    #[cfg(feature = "d-entail")]
+    D,
+}
+
+/// The `Profile::D` for a regime set IFF the `d-entail` feature is ON and the set
+/// contains the D regime; `None` otherwise (so the caller keeps the test
+/// OutOfScope when the feature is off — the default binary is unchanged).
+#[cfg(feature = "d-entail")]
+fn d_regime_profile(regimes: &FxHashSet<&str>) -> Option<Profile> {
+    regimes.contains("D").then_some(Profile::D)
+}
+
+/// Feature-OFF stub: D is never a supported profile, so a D-only test stays
+/// OutOfScope. (Kept as a function so the call site is identical in both states.)
+#[cfg(not(feature = "d-entail"))]
+fn d_regime_profile(_regimes: &FxHashSet<&str>) -> Option<Profile> {
+    None
 }
 
 fn result(entry: &TestEntry, outcome: Outcome) -> TestResult {
@@ -161,6 +228,18 @@ fn run_one(entry: &TestEntry, profile: Profile, direct_sanctioned: bool) -> Outc
             add_declared_reflexives(&mut dict, &mut ids, true);
             sparq_reason::materialize(sparq_reason::Profile::OwlRl, &mut dict, &mut ids);
             add_eq_ref(&mut dict, &mut ids);
+        }
+        // [OPUS-4.8] sq-e5atd — D-entailment: the rdfD1 datatype-typing closure
+        // under the STANDARD recognized datatype map (this suite's D tests do not
+        // restrict D via a per-test set). The emitted typing triples are
+        // GENERALIZED (literal subject `"l"^^d rdf:type d`); the N-Triples
+        // serialization below DROPS literal-subject rows (they can never be a
+        // SPARQL answer — the regime answer restriction, also why `d-ent-01`
+        // correctly returns NO rows), so D-entailment adds no bindable triple but
+        // is computed through the real `Profile::D` materializer.
+        #[cfg(feature = "d-entail")]
+        Profile::D => {
+            sparq_reason::materialize(sparq_reason::Profile::D, &mut dict, &mut ids);
         }
     }
 

--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -157,6 +157,10 @@ pub struct Suite {
 ///   `ODRL_SUITE_FLOOR = 67` (sq-tmsd6 wired it at 59; the constraint-matching batch
 ///   sq-euhr3/sq-k7itg/sq-a0zef raised it to 67 of 68 cases pass, 1 in a documented
 ///   not-implemented bucket).
+/// * D-entailment 1 — `sparq-conformance` `tests/d_entail_suite.rs`
+///   `D_ENTAIL_FLOOR = 1` (sq-e5atd; opt-in `d-entail` feature; the D-only
+///   `sparql11/entailment` tests graduated from OutOfScope to Pass through
+///   sparq-reason's `Profile::D` — rdfD1 typing + typed value-space equality).
 pub const SUITES: &[Suite] = &[
     Suite {
         label: "W3C SPARQL (1.0 / 1.1 / 1.2, query+update+syntax)",
@@ -427,6 +431,37 @@ pub const SUITES: &[Suite] = &[
         floor_basis: "scenario",
         note: "library-level allow/deny parity over the SolidLab self-describing ODRL \
                cases through sparq-policy's real evaluate() path",
+    },
+    // [OPUS-4.8] sq-e5atd (epic sq-pbz04) — the W3C SPARQL 1.1 D-entailment
+    // (datatype / value-space) ratchet. The runner is crate-local here
+    // (`tests/d_entail_suite.rs`) but behind the OPT-IN `d-entail` feature (forwards
+    // to sparq-reason/d-entail) so the default + `--workspace` builds neither link
+    // the `Profile::D` materializer nor go red — the lean-core posture, and the
+    // inference BINARY keeps these tests OutOfScope when the feature is off so its
+    // own ratchet floor is byte-for-byte unchanged. The genuinely D-only
+    // `sparql11/entailment` tests (regime `ent:D` without a stronger RDFS/RDF/
+    // OWL-RDF-Based regime) GRADUATE from that OutOfScope bucket to Pass here:
+    // premise → `sparq_reason::Profile::D` (rdfD1 typing + the typed value-space
+    // comparator — "1"^^xsd:integer ≡ "1.0"^^xsd:decimal, NOT an f64 fast path) →
+    // query over the closure through the same evaluation path as the SPARQL harness,
+    // with the entailment-regime answer restriction applied. The floor is the
+    // MEASURED D-only pass count at the pinned revision (NOT 100%; the broader
+    // D-inconsistency / value-space-subset surface is tracked-not-asserted — a child
+    // of sq-pbz04). Floor kept in lock-step by `tests/scoreboard_floors.rs`.
+    Suite {
+        label: "W3C SPARQL 1.1 D-entailment",
+        family: "W3C RDF Semantics",
+        runner: Runner::FeatureGatedCrateTest {
+            krate: "sparq-conformance",
+            target: "d_entail_suite",
+            feature: "d-entail",
+        },
+        ci_job: "inference-conformance",
+        ratchet_floor: 1,
+        floor_basis: "pass",
+        note: "D-only sparql11/entailment tests graduated from OutOfScope to Pass \
+               through sparq-reason's opt-in Profile::D (rdfD1 typing + typed \
+               value-space equality)",
     },
 ];
 

--- a/crates/sparq-conformance/tests/d_entail_suite.rs
+++ b/crates/sparq-conformance/tests/d_entail_suite.rs
@@ -1,0 +1,136 @@
+//! [OPUS-4.8] sq-e5atd (epic sq-pbz04) — the D-entailment (datatype / value-space)
+//! conformance lane, wired as a RATCHETED gate that mirrors the SPARQL / SHACL /
+//! GeoSPARQL / Solid / JSON-LD ratchets in this crate (crate-local `cargo test` +
+//! a pinned pass-count FLOOR that may only RISE, registered in the central
+//! `scoreboard::SUITES` and guarded by `tests/scoreboard_floors.rs`).
+//!
+//! ## What is gated
+//!
+//! The genuinely D-ONLY tests of the W3C `sparql11/entailment` suite — those whose
+//! `sd:entailmentRegime` is `ent:D` WITHOUT any stronger RDFS/RDF/OWL-RDF-Based
+//! regime (those are exercised under their own regime by the inference binary). Each
+//! is driven through the REAL D path: the premise data is materialized through
+//! `sparq_reason::Profile::D` (the rdfD1 datatype-typing closure, with the typed
+//! value-space comparator — `"1"^^xsd:integer` ≡ `"1.0"^^xsd:decimal`, NOT an f64
+//! fast path), then the query is run over the closure through the SAME
+//! evaluation/comparison machinery as the gating SPARQL harness, with the SPARQL
+//! 1.1 Entailment-Regimes answer restriction applied (literal-subject + surrogate
+//! blank-node bindings are never answers).
+//!
+//! These tests previously sat in the inference scoreboard's OutOfScope bucket
+//! ("entailment regime(s) D not supported"); this lane GRADUATES them to Pass.
+//!
+//! ## Honest floor + the tracked-not-asserted remainder
+//!
+//! `D_ENTAIL_FLOOR` is the MEASURED D-only pass count at the pinned rdf-tests
+//! revision, NOT an aspirational target. At the current pin the suite contains a
+//! single D-only test (`d-ent-01`), which passes — so the floor is 1. The broader
+//! D-entailment surface (D-inconsistency / ill-typed-literal clashes, value-space
+//! subset reasoning across the integer/decimal/temporal spaces, the rdf-mt
+//! recognized-datatype tests that ride RDFS rather than D-only) is exercised
+//! elsewhere — the inference binary's rdf-mt section, and `sparq-reason`'s own
+//! `dtype` unit tests for the value-space invariant — and the rest is honestly
+//! tracked-not-asserted (a child of the D-entailment epic), never skip-laundered to
+//! inflate this count. The floor may only RISE as the D-only corpus grows.
+//!
+//! ## Feature gating (both states)
+//!
+//! The whole lane is behind this crate's opt-in `d-entail` feature (forwards to
+//! `sparq-reason/d-entail`). With the feature OFF this file compiles to a single
+//! self-SKIP `#[test]` (no `Profile::D` code links, and the inference BINARY keeps
+//! these tests OutOfScope, so its ratchet floor is byte-for-byte unchanged — the
+//! lean opt-in posture). With it ON the runner executes the D-only tests and
+//! asserts the pinned floor. The rdf-tests fixtures are fetched by
+//! `scripts/fetch-inference-suites.sh` into the gitignored `tests/w3c/rdf-tests/`;
+//! when absent the runner SKIPS so a fresh offline checkout stays green.
+
+// [OPUS-4.8] When the lane feature is OFF the runner is a single self-SKIP test so
+// the default + `--workspace` builds neither link the D materializer nor go red on
+// a fresh checkout. (cfg gate, not a runtime branch, so zero D-entailment code
+// compiles in the default state — the lean-core invariant.)
+#[cfg(not(feature = "d-entail"))]
+#[test]
+fn d_entail_suite_skipped_without_feature() {
+    eprintln!(
+        "SKIP: D-entailment conformance lane is OFF — build with \
+         `--features d-entail` (and run scripts/fetch-inference-suites.sh) to run it."
+    );
+}
+
+#[cfg(feature = "d-entail")]
+mod gated {
+    use sparq_conformance::inference::report::{Outcome, TestResult};
+    use sparq_conformance::inference::sparql_entail;
+    use std::path::PathBuf;
+
+    /// The D-entailment pass floor (the RATCHET). MEASURED D-only pass count at the
+    /// pinned rdf-tests revision; MIRRORED in the central scoreboard
+    /// (`scoreboard::SUITES`) and read textually by the guard test
+    /// `tests/scoreboard_floors.rs`. It may only RISE — never lower it (raise as the
+    /// D-only corpus / the materializer's value-space coverage grow). This is the
+    /// ACTUAL current pass count, not an aspirational target.
+    pub const D_ENTAIL_FLOOR: usize = 1;
+
+    fn rdf_tests_root() -> PathBuf {
+        // CARGO_MANIFEST_DIR is crates/sparq-conformance; the data lives at the
+        // workspace-root `tests/w3c/rdf-tests` (the same clone the SPARQL +
+        // inference harnesses use, fetched by scripts/fetch-inference-suites.sh).
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tests/w3c/rdf-tests")
+    }
+
+    #[test]
+    fn d_entailment_ratchet() {
+        let root = rdf_tests_root();
+        if !root.join("sparql/sparql11/entailment/manifest.ttl").exists() {
+            eprintln!(
+                "SKIP: rdf-tests `sparql11/entailment` not present under {} — run \
+                 scripts/fetch-inference-suites.sh",
+                root.display()
+            );
+            return;
+        }
+
+        let mut results: Vec<TestResult> = Vec::new();
+        sparql_entail::run_d_regime_suite(&root, &mut results)
+            .unwrap_or_else(|e| panic!("D-regime suite error: {e}"));
+
+        let mut pass = 0usize;
+        let mut fail = 0usize;
+        let mut oos = 0usize;
+        let mut fails: Vec<String> = Vec::new();
+        for r in &results {
+            match &r.outcome {
+                Outcome::Pass | Outcome::Divergence(_, _) => pass += 1,
+                Outcome::Fail(why) => {
+                    fail += 1;
+                    fails.push(format!("{}: {}", r.name, why));
+                }
+                Outcome::OutOfScope(_) => oos += 1,
+            }
+        }
+
+        // [OPUS-4.8] The CI ratchet greps this exact `TOTAL d-entail` line (pass
+        // count in field $3), mirroring the JSON-LD lane's `TOTAL <cat>` shape.
+        // Positional `format!`/`println!` args (not inline `{pass}`) per the CodeQL
+        // `rust/unused-variable` false-positive guard in the shared agent contract.
+        println!("\nW3C SPARQL 1.1 D-entailment conformance (pinned rdf-tests)");
+        println!(
+            "TOTAL d-entail {} {} {} (floor {})",
+            pass, fail, oos, D_ENTAIL_FLOOR
+        );
+        if !fails.is_empty() {
+            println!("D-entailment FAILS:");
+            for f in &fails {
+                println!("  - {}", f);
+            }
+        }
+
+        assert_eq!(fail, 0, "D-entailment lane has failing tests: {:?}", fails);
+        assert!(
+            pass >= D_ENTAIL_FLOOR,
+            "D-entailment pass count {} regressed below the ratchet floor {}",
+            pass,
+            D_ENTAIL_FLOOR
+        );
+    }
+}

--- a/crates/sparq-conformance/tests/scoreboard_floors.rs
+++ b/crates/sparq-conformance/tests/scoreboard_floors.rs
@@ -161,6 +161,17 @@ const CRATE_LOCAL_FLOORS: &[(&str, &str, &str)] = &[
         "crates/sparq-policy/tests/odrl_test_suite.rs",
         "ODRL_SUITE_FLOOR",
     ),
+    // [OPUS-4.8] sq-e5atd (epic sq-pbz04) — the W3C SPARQL 1.1 D-entailment ratchet.
+    // `pub const D_ENTAIL_FLOOR` lives in this crate's `tests/d_entail_suite.rs`
+    // (behind the opt-in `d-entail` feature, inside the `gated` module — the guard
+    // reads it TEXTUALLY, so the `#[cfg]`/module nesting do not affect the match);
+    // the guard pins the central scoreboard's `ratchet_floor` to it so the two can
+    // never silently drift.
+    (
+        "W3C SPARQL 1.1 D-entailment",
+        "crates/sparq-conformance/tests/d_entail_suite.rs",
+        "D_ENTAIL_FLOOR",
+    ),
 ];
 
 #[test]
@@ -244,4 +255,6 @@ fn scoreboard_renders_all_suites() {
     assert!(md.contains("W3C JSON-LD 1.1 flatten"));
     // [OPUS-4.8] sq-tmsd6 — the SolidLab ODRL Test Suite decision-parity ratchet.
     assert!(md.contains("SolidLab ODRL Test Suite"));
+    // [OPUS-4.8] sq-e5atd — the W3C SPARQL 1.1 D-entailment ratchet.
+    assert!(md.contains("W3C SPARQL 1.1 D-entailment"));
 }

--- a/crates/sparq-reason-wasm/Cargo.toml
+++ b/crates/sparq-reason-wasm/Cargo.toml
@@ -44,6 +44,12 @@ default = []
 # the headless wasm tests run with it on. Maps directly to the `why()` proof tree the
 # /surface/inference page renders.
 explain = ["sparq-reason/explain"]
+# [OPUS-4.8] sq-e5atd: expose `Profile::D` (opt-in D-entailment / datatype value-space
+# materialiser) to the bundle's `materialize`/`entailed`/`materializeStats` methods by
+# turning on `sparq-reason`'s non-default `d-entail` feature. OFF by default. The `why()`
+# proof tree is NOT available for D (it is a value-space materialiser, not a rule-based
+# forward-chainer with a derivation DAG), so `why("d", …)` returns an explanatory error.
+d-entail = ["sparq-reason/d-entail"]
 
 [dev-dependencies]
 # [OPUS-4.8] sq-6qw3 — headless wasm test harness, mirroring sparq-wasm: exercises the

--- a/crates/sparq-reason-wasm/src/explain.rs
+++ b/crates/sparq-reason-wasm/src/explain.rs
@@ -95,6 +95,21 @@ impl Reasoner {
                 let g = MaterializedOwlGraph::new(&mut dict, &base);
                 g.why_with(&dict, triple, opts)
             }
+            // [OPUS-4.8] sq-e5atd: D-entailment is a value-space materialiser (the rdfD1
+            // datatype-typing closure with typed literal equality), not a rule-based
+            // forward-chainer that records a premises-before-conclusion derivation DAG, so
+            // there is no `why` proof tree for it. `Profile::D` only exists when the bundle is
+            // built with the `d-entail` feature; gate the arm on the same cfg so the match is
+            // exhaustive in BOTH feature states.
+            #[cfg(feature = "d-entail")]
+            sparq_reason::Profile::D => {
+                return Err(JsError::new(
+                    "why() is not available for the \"d\" (D-entailment) profile: D-entailment \
+                     is a value-space datatype materialiser, not a rule-based derivation, so it \
+                     has no proof tree. Use materialize/entailed for the D closure, or why() \
+                     with the \"rdfs\"/\"owl-rl\" profile.",
+                ));
+            }
         };
         Ok(proof_to_json(proof))
     }

--- a/crates/sparq-reason-wasm/src/lib.rs
+++ b/crates/sparq-reason-wasm/src/lib.rs
@@ -33,12 +33,18 @@ mod explain;
 /// N-Triples via the engine's tested CONSTRUCT path (no hand-rolled term serialiser here).
 const ECHO_CONSTRUCT: &str = "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }";
 
-/// Parses `profile` (`"rdfs"` | `"owl"` / `"owl-rl"`) or returns a JS error naming the
-/// accepted values — the single place the JS-facing profile string is validated.
+/// Parses `profile` (`"rdfs"` | `"owl"` / `"owl-rl"`; with the `d-entail` feature also `"d"`)
+/// or returns a JS error naming the accepted values — the single place the JS-facing profile
+/// string is validated.
 fn parse_profile(profile: &str) -> Result<Profile, JsError> {
     Profile::parse(profile).ok_or_else(|| {
+        // The accepted set widens to include "d" when the bundle is built with `d-entail`.
+        #[cfg(feature = "d-entail")]
+        let expected = "\"rdfs\", \"owl-rl\" or \"d\"";
+        #[cfg(not(feature = "d-entail"))]
+        let expected = "\"rdfs\" or \"owl-rl\"";
         JsError::new(&format!(
-            "unknown reasoning profile {profile:?}; expected \"rdfs\" or \"owl-rl\""
+            "unknown reasoning profile {profile:?}; expected {expected}"
         ))
     })
 }

--- a/crates/sparq-reason/Cargo.toml
+++ b/crates/sparq-reason/Cargo.toml
@@ -33,6 +33,13 @@ parallel = ["dep:rayon", "sparq-core/parallel"]
 # structure and hook is cfg'd out entirely (zero hot-path cost, byte-identical behavior,
 # zero wasm impact: sparq-reason is never in the wasm dependency graph anyway).
 explain = []
+# [OPUS-4.8] sq-e5atd (epic sq-pbz04) — OPT-IN D-entailment (datatype / value-space,
+# RDF 1.1 Semantics §7-8): `Profile::D`, the rdfD1 datatype-typing materializer + the
+# correct typed value-space comparison (`dtype` module). NON-DEFAULT by design — when off
+# the `dtype` module + `Profile::D` variant are cfg'd out entirely (the lean default build
+# carries zero D-entailment code; the byte/bundle ratchets are unchanged, and sparq-reason
+# is never in the wasm dependency graph anyway). Pure-Rust, no new deps.
+d-entail = []
 
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io

--- a/crates/sparq-reason/README.md
+++ b/crates/sparq-reason/README.md
@@ -36,6 +36,9 @@ let g = Graph::from_parts(dict, triples);
 - **RDFS entailment** — the non-explosive subset (rdfs2/3/5/7/9/11), materialized in one pass.
 - **OWL 2 RL** — property/class axioms (`sameAs`, `inverseOf`, Transitive / Symmetric,
   `equivalentClass` / `equivalentProperty`, …) over the same fixpoint engine.
+- **D-entailment** (opt-in `d-entail`) — `Profile::D`: the rdfD1 datatype-typing rule under
+  a recognized datatype map, with **correct typed value-space equality**
+  (`"1"^^xsd:integer` is the same value as `"1.0"^^xsd:decimal`, never an f64 fast path).
 - **Notation3** — `{ … } => { … }` rules with EYE-validated builtins (a separate subsystem).
 - **Incremental maintenance** — `MaterializedGraph` keeps the closure current under
   inserts/deletes by exact derivation counting; cost scales with the change, not a re-run.

--- a/crates/sparq-reason/src/dtype.rs
+++ b/crates/sparq-reason/src/dtype.rs
@@ -1,0 +1,518 @@
+//! D-entailment (datatype / value-space) materialization — RDF 1.1 Semantics §7-8.
+//!
+//! [OPUS-4.8] sq-e5atd (epic sq-pbz04). OPT-IN, behind the `d-entail` cargo
+//! feature — the production materializer never carries it, so the lean default
+//! build (and the wasm bundle, which never depends on this code) is byte-identical.
+//!
+//! ## What D-entailment adds beyond simple entailment
+//!
+//! A *recognized datatype map* D fixes, for each datatype IRI it covers, a lexical
+//! space, a value space, and the lexical-to-value mapping (RDF 1.1 Semantics §7).
+//! The D-entailment lemma then sanctions, on top of simple entailment, the
+//! **datatype typing rule rdfD1**: a well-formed literal `"l"^^d` of a recognized
+//! datatype `d` is an instance of `d`, i.e. it entails `"l"^^d rdf:type d`. (In the
+//! abstract semantics the literal is replaced by a *surrogate* allocated for its
+//! value; the materializer keeps the literal in subject position — a GENERALIZED
+//! triple — and lets the downstream regime restriction decide whether a surrogate
+//! may surface in a query answer. This mirrors the conformance harness's
+//! `harness_rules` rdfD1 arm.)
+//!
+//! The load-bearing invariant is **value-space equality**: two literals whose
+//! values coincide are interchangeable under D — e.g. `"1"^^xsd:integer` and
+//! `"1.0"^^xsd:decimal` denote the SAME value (the integers are a subset of the
+//! decimals), so they must compare equal. [`d_value_key`] is the canonical
+//! comparison: equal keys mean equal D-values, across lexical forms AND across the
+//! integer/decimal value spaces that coincide.
+//!
+//! ## Why NOT an f64 fast path
+//!
+//! Collapsing the numeric value to `f64` is UNSOUND for D-equality: `f64` cannot
+//! represent every `xsd:integer` (anything past 2^53 rounds) nor every
+//! `xsd:decimal` exactly, so distinct values would alias and equal values past the
+//! mantissa would diverge — silent precision loss in a SEMANTIC equality. Instead
+//! the integer/decimal value space is compared as a CANONICAL DECIMAL STRING
+//! (sign + minimal integer digits + minimal fraction digits, parsed exactly): this
+//! is the correct typed comparison, exact at any magnitude.
+//!
+//! ## sparq-core substrate
+//!
+//! Datatype recognition (`is_integer_datatype`) and temporal value parsing
+//! (`temporal::Temporal`) come from `sparq-core` — sparq-reason depends ONLY on
+//! sparq-core, never sparq-engine. NOTE: the shared zero-overhead eval substrate's
+//! typed `Num` compare (the substrate move-chain, research/ sq-6tykl) is not yet
+//! wired; once `sparq-substrate::compare` lands, `d_value_key` migrates onto it
+//! (one canonical typed-value comparator shared by the engine FILTER path and this
+//! materializer), and this module's local canonicalization is deleted.
+
+use crate::Vocab;
+use rustc_hash::FxHashSet;
+use sparq_core::dict::{self, Dict, Id, TermParts};
+use sparq_core::{is_integer_datatype, temporal};
+
+const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
+const XSD_INTEGER: &str = "http://www.w3.org/2001/XMLSchema#integer";
+const RDF_LANG_STRING: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString";
+
+/// The recognized-datatype set D for a materialization. `xsd:string` and
+/// `rdf:langString` are always recognized in RDF 1.1; callers add the others a
+/// test or dataset declares (the `sd:recognizedDatatypes` / OWL 2 datatype map).
+/// The empty constructor (only the always-recognized pair) is the conservative
+/// default — under it the D closure adds NOTHING beyond what is asserted, so it is
+/// safe to materialize over an arbitrary graph.
+#[derive(Clone, Debug)]
+pub struct Recognized {
+    iris: FxHashSet<String>,
+}
+
+impl Default for Recognized {
+    fn default() -> Self {
+        let mut iris = FxHashSet::default();
+        iris.insert(format!("{XSD}string"));
+        iris.insert(RDF_LANG_STRING.to_string());
+        Recognized { iris }
+    }
+}
+
+impl Recognized {
+    /// Recognize exactly `iris` (plus the always-recognized `xsd:string` /
+    /// `rdf:langString`).
+    pub fn new<I: IntoIterator<Item = String>>(iris: I) -> Recognized {
+        let mut r = Recognized::default();
+        r.iris.extend(iris);
+        r
+    }
+
+    /// The standard datatype map — every XSD datatype this module has a value
+    /// mapping for (the OWL 2 datatype map's numeric/boolean/string/temporal core).
+    pub fn standard() -> Recognized {
+        let locals = [
+            "string",
+            "normalizedString",
+            "token",
+            "boolean",
+            "integer",
+            "long",
+            "int",
+            "short",
+            "byte",
+            "nonNegativeInteger",
+            "positiveInteger",
+            "nonPositiveInteger",
+            "negativeInteger",
+            "unsignedLong",
+            "unsignedInt",
+            "unsignedShort",
+            "unsignedByte",
+            "decimal",
+            "double",
+            "float",
+            "dateTime",
+            "dateTimeStamp",
+            "date",
+        ];
+        Recognized::new(locals.iter().map(|l| format!("{XSD}{l}")))
+    }
+
+    /// Is `dt` in the recognized set?
+    pub fn contains(&self, dt: &str) -> bool {
+        self.iris.contains(dt)
+    }
+}
+
+/// Expand `triples` in place with the D-entailment closure for the recognized
+/// datatype map `d`: for every well-formed literal `"l"^^t` whose datatype `t` is
+/// recognized AND has a value mapping here, add the rdfD1 typing triple
+/// `("l"^^t rdf:type t)`. Returns the number of NEW triples added. Idempotent: a
+/// second call adds nothing (the typing triples are already present).
+///
+/// The triple is GENERALIZED — its subject is a literal id — which the regular
+/// triple store cannot index; callers that feed the result to a SPARQL query must
+/// drop literal-subject rows (they can never be a query answer), exactly the
+/// existing entailment-harness contract. The materializer's job is the SOUND
+/// closure; answer-shaping is the regime restriction's.
+pub fn materialize_d(d: &Recognized, dict: &mut Dict, triples: &mut Vec<[Id; 3]>) -> usize {
+    let v = Vocab::intern(dict);
+    let asserted: FxHashSet<[Id; 3]> = triples.iter().copied().collect();
+
+    // Phase 1 (immutable borrow of `dict`): find every literal id of a recognized,
+    // well-formed, value-mapped datatype, recording the literal id + its datatype
+    // IRI as an owned String. We do NOT call `intern_iri` here — that needs a
+    // mutable borrow while a `TermParts` borrow is live — so the datatype IRI is
+    // copied out and interned in phase 2.
+    let mut to_type: Vec<(Id, String)> = Vec::new();
+    let mut literal_ids: FxHashSet<Id> = FxHashSet::default();
+    for &[s, _, o] in triples.iter() {
+        for lit_id in [s, o] {
+            if !literal_ids.insert(lit_id) {
+                continue; // a literal seen once needs typing once
+            }
+            // Inline ids encode a canonical NON-NEGATIVE small `xsd:integer` (value
+            // = id - INLINE_BASE) with NO dictionary record, so `term_parts` cannot
+            // resolve them — handle them directly. They are always well-formed and,
+            // when xsd:integer is recognized, typed by rdfD1.
+            if dict::is_inline(lit_id) {
+                if d.contains(XSD_INTEGER) {
+                    to_type.push((lit_id, XSD_INTEGER.to_string()));
+                }
+                continue;
+            }
+            if let TermParts::Lit { value, datatype, lang } = dict.term_parts(lit_id) {
+                // A language-tagged literal's datatype is rdf:langString; rdfD1 adds
+                // no useful value-space typing for it, so skip.
+                if lang.is_some() {
+                    continue;
+                }
+                if !d.contains(datatype) || !has_value_mapping(datatype) {
+                    continue;
+                }
+                // Ill-formed for its (recognized) datatype: rdfD1 does NOT type it —
+                // that case is a D-CLASH (the inconsistency checker's concern), not
+                // a typing produced by this monotone closure.
+                if d_value_key(value, datatype).is_none() {
+                    continue;
+                }
+                to_type.push((lit_id, datatype.to_string()));
+            }
+        }
+    }
+
+    // Phase 2 (mutable borrow): intern each datatype IRI (idempotent — returns the
+    // id the data already uses) and emit the rdfD1 typing triple, deduplicated
+    // against what is already asserted. Sort the new rows for deterministic output.
+    let mut new_rows: FxHashSet<[Id; 3]> = FxHashSet::default();
+    for (lit_id, dt_iri) in to_type {
+        let dt_id = dict.intern_iri(&dt_iri);
+        let row = [lit_id, v.ty, dt_id];
+        if !asserted.contains(&row) {
+            new_rows.insert(row);
+        }
+    }
+    let added = new_rows.len();
+    let mut new_sorted: Vec<[Id; 3]> = new_rows.into_iter().collect();
+    new_sorted.sort_unstable();
+    triples.extend(new_sorted);
+    added
+}
+
+/// Datatypes this module has a value mapping for (so rdfD1 / value comparison can
+/// judge well-formedness). The numeric/boolean/string core + the temporal types
+/// sparq-core parses. An UNRECOGNIZED-shaped IRI returns false (we cannot judge it,
+/// so we never type or clash on it — conservative).
+pub fn has_value_mapping(dt: &str) -> bool {
+    if dt == RDF_LANG_STRING || dt == format!("{XSD}string") {
+        return true;
+    }
+    if is_integer_datatype(dt) {
+        return true;
+    }
+    matches!(
+        dt.strip_prefix(XSD),
+        Some(
+            "normalizedString"
+                | "token"
+                | "boolean"
+                | "decimal"
+                | "double"
+                | "float"
+                | "dateTime"
+                | "dateTimeStamp"
+                | "date"
+        )
+    )
+}
+
+/// A CANONICAL, value-space comparison key for a typed literal: two literals denote
+/// the same D-value iff their keys are equal. `None` = ill-formed for its datatype
+/// (no value), or a datatype with no value mapping here.
+///
+/// Numbers in the integer/decimal value space share ONE key form
+/// ([`DValue::Decimal`], a canonical decimal STRING — never an `f64`), so
+/// `"1"^^xsd:integer`, `"01"^^xsd:integer`, `"1.0"^^xsd:decimal` and
+/// `"+1.00"^^xsd:decimal` all key-equal. `xsd:float` / `xsd:double` are a DISTINCT
+/// value space (IEEE-754) and key by the rounded bit pattern. Temporal types key by
+/// the sparq-core `Temporal` instant.
+///
+/// [OPUS-4.8] migrates to `sparq-substrate::compare` once the substrate move lands
+/// (sq-6tykl); the canonical-decimal logic here is the interim, sparq-core-only
+/// implementation (the typed Num compare is not yet wired into the substrate).
+pub fn d_value_key(lex: &str, dt: &str) -> Option<DValue> {
+    if dt == RDF_LANG_STRING {
+        return None; // language-tagged: keyed by (lex, lang) elsewhere, not here
+    }
+    if dt == format!("{XSD}string")
+        || dt == format!("{XSD}normalizedString")
+        || dt == format!("{XSD}token")
+    {
+        return Some(DValue::Str(lex.to_string()));
+    }
+    if dt == format!("{XSD}boolean") {
+        return match lex {
+            "true" | "1" => Some(DValue::Bool(true)),
+            "false" | "0" => Some(DValue::Bool(false)),
+            _ => None,
+        };
+    }
+    if is_integer_datatype(dt) {
+        let v: i128 = lex.parse().ok()?;
+        // Integer-subtype range facets (the value must be IN the datatype's space).
+        if !integer_subtype_ok(dt, v) {
+            return None;
+        }
+        return Some(DValue::Decimal(canon_decimal(&v.to_string())?));
+    }
+    if dt == format!("{XSD}decimal") {
+        return Some(DValue::Decimal(canon_decimal(lex)?));
+    }
+    if dt == format!("{XSD}double") {
+        let f = parse_xsd_double(lex)?;
+        return Some(DValue::F64(if f.is_nan() {
+            f64::NAN.to_bits()
+        } else {
+            f.to_bits()
+        }));
+    }
+    if dt == format!("{XSD}float") {
+        let f = parse_xsd_double(lex)? as f32;
+        return Some(DValue::F32(if f.is_nan() {
+            f32::NAN.to_bits()
+        } else {
+            f.to_bits()
+        }));
+    }
+    if dt == format!("{XSD}dateTime")
+        || dt == format!("{XSD}dateTimeStamp")
+        || dt == format!("{XSD}date")
+    {
+        let t = temporal::Temporal::of_lit(lex, dt)?;
+        // Key by the comparable instant (sparq-core's correct temporal value),
+        // tagged with the temporal family and tz-presence so a `date` and a
+        // `dateTime` at the same instant (DISJOINT value spaces) never key-equal,
+        // and a floating vs zoned same-instant pair stays distinguishable.
+        let kind = matches!(t.kind, temporal::TemporalKind::Date);
+        return Some(DValue::Temporal(t.instant.to_bits(), t.has_tz, kind));
+    }
+    None
+}
+
+/// True D-value equality for two typed literals under recognized-map semantics.
+/// Equal iff both have a value mapping AND their canonical value keys coincide.
+pub fn d_value_eq(lex_a: &str, dt_a: &str, lex_b: &str, dt_b: &str) -> bool {
+    match (d_value_key(lex_a, dt_a), d_value_key(lex_b, dt_b)) {
+        (Some(a), Some(b)) => a == b,
+        _ => false,
+    }
+}
+
+/// A canonical D-value, comparable for equality across lexical forms (and across
+/// the integer/decimal value spaces, which coincide). NOT an `f64`-collapsed view
+/// for the exact value spaces — see the module doc on why the f64 fast path is
+/// unsound for semantic equality.
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum DValue {
+    /// Canonical decimal string (sign + minimal int digits + minimal frac digits)
+    /// — the shared key for `xsd:integer` (+ subtypes) and `xsd:decimal`.
+    Decimal(String),
+    /// `xsd:double` value as its IEEE-754 bit pattern (NaN canonicalized).
+    F64(u64),
+    /// `xsd:float` value as its IEEE-754 bit pattern (NaN canonicalized).
+    F32(u32),
+    Bool(bool),
+    Str(String),
+    /// A temporal value: (instant f64 bits, tz-present, is-date-family). The
+    /// instant is sparq-core's `Temporal::instant` (which orders the value space);
+    /// the family flag keeps `xsd:date` and `xsd:dateTime` — DISJOINT value spaces
+    /// — from key-aliasing at a shared instant.
+    Temporal(u64, bool, bool),
+}
+
+/// xsd float/double lexical syntax is a subset of Rust's `f64::parse`; reject the
+/// forms Rust accepts but XSD does not (hex, trailing `f`/`d`, the `inf` spelling).
+fn parse_xsd_double(lex: &str) -> Option<f64> {
+    match lex {
+        "INF" | "+INF" => Some(f64::INFINITY),
+        "-INF" => Some(f64::NEG_INFINITY),
+        "NaN" => Some(f64::NAN),
+        _ => {
+            if lex.contains(['x', 'X']) || lex.ends_with(['f', 'F', 'd', 'D']) || lex.contains("inf")
+            {
+                return None;
+            }
+            lex.parse::<f64>().ok()
+        }
+    }
+}
+
+/// The integer-subtype range facet check: the value must be inside the bounded
+/// derived type's value space (e.g. `xsd:byte` is [-128, 127]). `xsd:long`/`int`/
+/// `short`/`byte` past i128 already failed to parse; the bounded ones below add the
+/// sign facets the XSD spec fixes for the un/signed derived integer types.
+fn integer_subtype_ok(dt: &str, v: i128) -> bool {
+    let Some(local) = dt.strip_prefix(XSD) else {
+        return true;
+    };
+    match local {
+        "nonNegativeInteger" | "unsignedLong" | "unsignedInt" | "unsignedShort"
+        | "unsignedByte" => v >= 0,
+        "positiveInteger" => v > 0,
+        "nonPositiveInteger" => v <= 0,
+        "negativeInteger" => v < 0,
+        _ => true,
+    }
+}
+
+/// Canonicalize a decimal lexical form to (sign)(minimal-int).(minimal-frac);
+/// `None` when ill-formed. `"-0.0"` canonicalizes to `"0"`; `"1.0"` to `"1"`; so
+/// the integer 1 and the decimal 1.0 share the key `"1"`.
+fn canon_decimal(lex: &str) -> Option<String> {
+    let (sign, rest) = match lex.strip_prefix('-') {
+        Some(r) => (true, r),
+        None => (false, lex.strip_prefix('+').unwrap_or(lex)),
+    };
+    let (int_part, frac_part) = match rest.split_once('.') {
+        Some((i, f)) => (i, f),
+        None => (rest, ""),
+    };
+    if (int_part.is_empty() && frac_part.is_empty())
+        || !int_part.bytes().all(|b| b.is_ascii_digit())
+        || !frac_part.bytes().all(|b| b.is_ascii_digit())
+    {
+        return None;
+    }
+    let int_trim = int_part.trim_start_matches('0');
+    let frac_trim = frac_part.trim_end_matches('0');
+    let int_c = if int_trim.is_empty() { "0" } else { int_trim };
+    let neg = sign && !(int_c == "0" && frac_trim.is_empty());
+    Some(format!(
+        "{}{}{}{}",
+        if neg { "-" } else { "" },
+        int_c,
+        if frac_trim.is_empty() { "" } else { "." },
+        frac_trim
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use oxrdf::vocab::rdf;
+    use oxrdf::{Literal, NamedNode, Term};
+
+    fn lit(value: &str, local: &str) -> Term {
+        Term::Literal(Literal::new_typed_literal(
+            value,
+            NamedNode::new_unchecked(format!("{XSD}{local}")),
+        ))
+    }
+
+    /// The load-bearing invariant: integer/decimal value-space equality across
+    /// lexical forms, using the CORRECT TYPED (canonical-decimal) comparison — NOT
+    /// an f64 fast path.
+    #[test]
+    fn integer_decimal_value_space_coincides() {
+        // "1"^^xsd:integer is equivalent to "1.0"^^xsd:decimal — same value.
+        assert!(d_value_eq("1", &format!("{XSD}integer"), "1.0", &format!("{XSD}decimal")));
+        // leading zeros / signs / trailing fraction zeros are all the same value.
+        assert!(d_value_eq("01", &format!("{XSD}integer"), "+1", &format!("{XSD}integer")));
+        assert!(d_value_eq("1", &format!("{XSD}integer"), "1.00", &format!("{XSD}decimal")));
+        assert!(d_value_eq("-0", &format!("{XSD}integer"), "0", &format!("{XSD}decimal")));
+        // distinct values are NOT equal.
+        assert!(!d_value_eq("1", &format!("{XSD}integer"), "2", &format!("{XSD}decimal")));
+        assert!(!d_value_eq("1.5", &format!("{XSD}decimal"), "1", &format!("{XSD}integer")));
+    }
+
+    /// f64 would silently alias these past the 53-bit mantissa; the canonical
+    /// decimal comparison keeps them DISTINCT (the unsound-f64 guard).
+    #[test]
+    fn large_integers_are_not_aliased_by_f64() {
+        let big_a = "9007199254740993"; // 2^53 + 1, not representable in f64
+        let big_b = "9007199254740992"; // 2^53
+        assert!(!d_value_eq(big_a, &format!("{XSD}integer"), big_b, &format!("{XSD}integer")));
+        // ...but each equals its own decimal spelling exactly.
+        assert!(d_value_eq(
+            big_a,
+            &format!("{XSD}integer"),
+            "9007199254740993.0",
+            &format!("{XSD}decimal")
+        ));
+    }
+
+    /// float and double are a SEPARATE value space from integer/decimal.
+    #[test]
+    fn float_double_distinct_from_decimal() {
+        assert!(!d_value_eq("1", &format!("{XSD}integer"), "1.0", &format!("{XSD}double")));
+        assert!(!d_value_eq("1.0", &format!("{XSD}decimal"), "1.0", &format!("{XSD}float")));
+        // but two double lexical forms of the same value are equal.
+        assert!(d_value_eq("1.0E0", &format!("{XSD}double"), "1.0", &format!("{XSD}double")));
+    }
+
+    #[test]
+    fn integer_subtype_range_facets() {
+        // 200 is out of xsd:byte [-128,127] in the XSD value space → ill-formed (no value).
+        assert!(d_value_key("-1", &format!("{XSD}nonNegativeInteger")).is_none());
+        assert!(d_value_key("0", &format!("{XSD}positiveInteger")).is_none());
+        assert!(d_value_key("1", &format!("{XSD}nonPositiveInteger")).is_none());
+        // in range parses.
+        assert!(d_value_key("100", &format!("{XSD}nonNegativeInteger")).is_some());
+    }
+
+    #[test]
+    fn ill_formed_literal_has_no_value() {
+        assert!(d_value_key("abc", &format!("{XSD}integer")).is_none());
+        assert!(d_value_key("not-a-date", &format!("{XSD}dateTime")).is_none());
+    }
+
+    /// rdfD1: a recognized, well-formed literal is typed by its datatype; the
+    /// closure is idempotent and adds nothing for an unrecognized datatype.
+    #[test]
+    fn materialize_d_types_recognized_literals() {
+        let mut dict = Dict::new();
+        let s = dict.intern(&Term::NamedNode(NamedNode::new_unchecked("http://e/s")));
+        let p = dict.intern(&Term::NamedNode(NamedNode::new_unchecked("http://e/p")));
+        let one = dict.intern(&lit("1", "integer"));
+        let ty = dict.intern(&Term::NamedNode(NamedNode::new_unchecked(rdf::TYPE.as_str())));
+        let xsd_integer =
+            dict.intern(&Term::NamedNode(NamedNode::new_unchecked(format!("{XSD}integer"))));
+        let mut triples = vec![[s, p, one]];
+
+        // Recognized: the literal is typed xsd:integer (rdfD1).
+        let d = Recognized::new([format!("{XSD}integer")]);
+        let added = materialize_d(&d, &mut dict, &mut triples);
+        assert_eq!(added, 1, "rdfD1 types the recognized integer literal");
+        assert!(
+            triples.contains(&[one, ty, xsd_integer]),
+            "(\"1\"^^xsd:integer rdf:type xsd:integer)"
+        );
+
+        // Idempotent.
+        let added2 = materialize_d(&d, &mut dict, &mut triples);
+        assert_eq!(added2, 0, "second materialization adds nothing");
+    }
+
+    #[test]
+    fn materialize_d_skips_unrecognized_datatype() {
+        let mut dict = Dict::new();
+        let s = dict.intern(&Term::NamedNode(NamedNode::new_unchecked("http://e/s")));
+        let p = dict.intern(&Term::NamedNode(NamedNode::new_unchecked("http://e/p")));
+        let one = dict.intern(&lit("1", "integer"));
+        let mut triples = vec![[s, p, one]];
+        // integer NOT in D (only the always-recognized string/langString).
+        let d = Recognized::default();
+        let added = materialize_d(&d, &mut dict, &mut triples);
+        assert_eq!(added, 0, "an unrecognized datatype yields no typing");
+    }
+
+    #[test]
+    fn materialize_d_skips_ill_typed_literal() {
+        let mut dict = Dict::new();
+        let s = dict.intern(&Term::NamedNode(NamedNode::new_unchecked("http://e/s")));
+        let p = dict.intern(&Term::NamedNode(NamedNode::new_unchecked("http://e/p")));
+        let bad = dict.intern(&lit("abc", "integer"));
+        let mut triples = vec![[s, p, bad]];
+        let d = Recognized::new([format!("{XSD}integer")]);
+        let added = materialize_d(&d, &mut dict, &mut triples);
+        assert_eq!(
+            added, 0,
+            "ill-typed literal is not typed by rdfD1 (it is a clash, not a typing)"
+        );
+    }
+}

--- a/crates/sparq-reason/src/lib.rs
+++ b/crates/sparq-reason/src/lib.rs
@@ -5,11 +5,15 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use sparq_core::dict::{Dict, Id};
 
 mod incremental;
+#[cfg(feature = "d-entail")]
+pub mod dtype;
 #[cfg(feature = "explain")]
 pub mod explain;
 pub mod n3;
 mod owl;
 mod rdfs;
+#[cfg(feature = "d-entail")]
+pub use dtype::{d_value_eq, d_value_key, materialize_d, DValue, Recognized};
 #[cfg(feature = "explain")]
 pub use explain::{ExplainOpts, ProofNode, ProofTree};
 pub use incremental::{
@@ -29,14 +33,26 @@ pub enum Profile {
     /// OWL 2 RL (a useful subset: equality/sameAs, inverseOf, Symmetric/Transitive/
     /// Functional/InverseFunctional properties, equivalentClass/Property) — includes RDFS.
     OwlRl,
+    /// D-entailment (datatype / value-space, RDF 1.1 Semantics §7-8): the rdfD1
+    /// datatype-typing rule under a recognized datatype map, with CORRECT TYPED
+    /// (value-space) literal equality — `"1"^^xsd:integer` is the SAME value as
+    /// `"1.0"^^xsd:decimal`. OPT-IN, behind the `d-entail` feature; see the
+    /// [`dtype`] module. [OPUS-4.8] sq-e5atd. (`materialize` uses the conservative
+    /// STANDARD datatype map for this profile; for a custom map call
+    /// [`dtype::materialize_d`] with a [`dtype::Recognized`] directly.)
+    #[cfg(feature = "d-entail")]
+    D,
 }
 
 impl Profile {
-    /// Parse a CLI/profile name (`"rdfs"`, `"owl"`/`"owl-rl"`).
+    /// Parse a CLI/profile name (`"rdfs"`, `"owl"`/`"owl-rl"`; with the `d-entail`
+    /// feature also `"d"`).
     pub fn parse(s: &str) -> Option<Profile> {
         match s.to_ascii_lowercase().as_str() {
             "rdfs" => Some(Profile::Rdfs),
             "owl" | "owl-rl" | "owlrl" => Some(Profile::OwlRl),
+            #[cfg(feature = "d-entail")]
+            "d" => Some(Profile::D),
             _ => None,
         }
     }
@@ -49,6 +65,8 @@ pub fn materialize(profile: Profile, dict: &mut Dict, triples: &mut Vec<[Id; 3]>
     match profile {
         Profile::Rdfs => materialize_rdfs(dict, triples),
         Profile::OwlRl => materialize_owl_rl(dict, triples),
+        #[cfg(feature = "d-entail")]
+        Profile::D => dtype::materialize_d(&dtype::Recognized::standard(), dict, triples),
     }
 }
 

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -49,14 +49,25 @@ cargo run --release -p sparq-cli -- query data.ttl 'SELECT ...' --reason rdfs  #
 Re-exported from the crate root (`sparq_reason::…`):
 
 ```rust
-// Which regime to materialize. OwlRl includes RDFS.
-pub enum Profile { Rdfs, OwlRl }
-impl Profile { pub fn parse(s: &str) -> Option<Profile>; } // "rdfs" | "owl" | "owl-rl"
+// Which regime to materialize. OwlRl includes RDFS. `D` is opt-in (`d-entail` feature).
+pub enum Profile { Rdfs, OwlRl, /* #[cfg(d-entail)] */ D }
+impl Profile { pub fn parse(s: &str) -> Option<Profile>; } // "rdfs" | "owl" | "owl-rl" | "d"
 
 // Batch materialization (expand in place; returns NEW triples; idempotent).
 pub fn materialize(profile: Profile, dict: &mut Dict, triples: &mut Vec<[Id;3]>) -> usize;
 pub fn materialize_rdfs (dict: &mut Dict, triples: &mut Vec<[Id;3]>) -> usize;
 pub fn materialize_owl_rl(dict: &mut Dict, triples: &mut Vec<[Id;3]>) -> usize;
+
+// D-entailment (datatype / value-space) — opt-in `d-entail` feature, `sparq_reason::dtype`.
+// rdfD1 datatype-typing under a recognized datatype map; CORRECT TYPED value equality
+// ("1"^^xsd:integer ≡ "1.0"^^xsd:decimal — canonical decimal, NOT an f64 fast path).
+// `materialize(Profile::D, …)` uses the STANDARD map; pass a custom map via:
+#[cfg(feature = "d-entail")]
+pub fn materialize_d(d: &Recognized, dict: &mut Dict, triples: &mut Vec<[Id;3]>) -> usize;
+#[cfg(feature = "d-entail")]
+pub fn d_value_eq(lex_a: &str, dt_a: &str, lex_b: &str, dt_b: &str) -> bool; // value-space eq
+#[cfg(feature = "d-entail")]
+pub struct Recognized; // Recognized::standard() / ::new(iris) / ::default() (string+langString)
 
 // OWL inconsistency check (cax-dw / cls-com / eq-diff / cls-nothing clashes) — run AFTER OWL closure.
 pub fn inconsistencies(dict: &Dict, triples: &[[Id;3]]) -> Vec<String>;
@@ -218,10 +229,11 @@ let closure = reason_n3_terms_with_resolver(src, Some("http://ex/"), Some(&resol
 ## Gotchas / feature flags / prerequisites
 
 - **Not in the *lean* wasm bundle, but wasm-portable.** `sparq-reason` pulls `regex` and (by default) `rayon`; it is never in the **lean** `sparq-wasm` triplestore bundle. For wasm or single-threaded builds use `default-features = false` (disables the `parallel`/rayon feature). The crate itself compiles to `wasm32-unknown-unknown` — `regex` (the N3 `string:matches` builtin) is pure-Rust and wasm-portable — and ships as the **tier-b `sparq-reason-wasm` ("W-reason") bundle** ([OPUS-4.8] sq-6qw3): a `Reasoner` exposing `materialize` / `entailed` / `materializeStats` / `reasonN3` (and, behind the bundle's opt-in `explain` feature, `why()` proof trees) for in-tab live inference, lazy-loaded on the showcase site's `/surface/inference` page. There is no Noir/ZK toolchain requirement here — proofs are plain Rust structs.
-- **Features:** `parallel` (default, rayon-parallel fixpoint), `explain` (NON-default — enables `why()`/`why_with()` and the `explain` module; zero hot-path cost when off, and `why` methods don't exist without it).
+- **Features:** `parallel` (default, rayon-parallel fixpoint), `explain` (NON-default — enables `why()`/`why_with()` and the `explain` module; zero hot-path cost when off, and `why` methods don't exist without it), `d-entail` (NON-default — enables `Profile::D` + the `dtype` module; zero code when off — the lean default/wasm build is byte-identical, `sq-e5atd`).
 - **Two value levels.** RDFS/OWL APIs work on dictionary `Id`s (`materialize*`, `Materialized(Owl)Graph`); N3 batch APIs intern into a `Dict` (`reason_n3`), while term-level N3 (`reason_n3_terms`, `MaterializedN3Graph`) works on `n3::Term` and is **not interned** (formula `{ … }` terms have no dictionary id). Don't mix the two.
 - **The materialize → from_parts seam.** `materialize` mutates `(Dict, Vec<[Id;3]>)` *before* indexes are built. Use `Graph::parse_to_triples` (not `Graph::load_str`) so reasoning runs between parse and index build; then `Graph::from_parts`. It interns any vocabulary terms it needs and is idempotent (a second call adds nothing).
 - **RDFS scope is deliberate:** the non-explosive subset (rdfs2,3,5,7,9,11 — subClass/subProperty/domain/range). No axiomatic or reflexive `rdfs:subClassOf`/`type` triples (they add no useful inferences and explode the store).
+- **D-entailment (`Profile::D`, opt-in `d-entail`) scope + caveats:** materializes the rdfD1 datatype-typing rule — a well-formed literal `"l"^^d` of a *recognized* datatype `d` (the `Recognized` map; `xsd:string`/`rdf:langString` always, `Recognized::standard()` adds the numeric/boolean/temporal core) entails `"l"^^d rdf:type d`. The emitted typing triples are **generalized** (literal in subject position) — feed the closure to a query only after dropping literal-subject rows (they can never be a SPARQL answer; this is also why the W3C `d-ent-01` test correctly returns NO rows). The load-bearing invariant is **value-space equality** via `d_value_eq`: `"1"^^xsd:integer` ≡ `"1.0"^^xsd:decimal` (the integer/decimal value spaces coincide), compared as a CANONICAL DECIMAL STRING — **never an f64 fast path** (f64 silently aliases integers past 2^53 and loses decimal precision). `float`/`double` are a DISJOINT IEEE-754 value space; `date` and `dateTime` are disjoint temporal families. NOTE: the typed numeric comparator will migrate to `sparq-substrate::compare` once the shared eval-substrate move lands (`sq-6tykl`); D-inconsistency (ill-typed-literal / value-space clashes) and cross-type value-space *subset* reasoning are tracked-not-yet-shipped here (epic `sq-pbz04`).
 - **OWL 2 RL is sound but INCOMPLETE for class classification.** Running `Profile::OwlRl` / `--reason owl` over an EL ontology returns a `rdfs:subClassOf` hierarchy that silently omits existential-reasoning subsumptions (the calculus has no rule reasoning through an `∃r` successor). For the **complete** class hierarchy use `sparq-reason-el` (above), not more RL rules.
 - **OWL incremental fallback is silent.** `MaterializedOwlGraph` drops to `OwlMode::Fallback` (re-materializes via `materialize_owl_rl` every mutation, still correct) when the base uses `owl:sameAs`, Functional/InverseFunctional, property chains, restrictions, cardinality, hasKey, oneOf, intersection/union — and on any TBox mutation. Check `.mode()` / `.full_rebuilds()` if incremental cost matters. These usually live in a static TBox, so the mode is decided once at load.
 - **N3 incremental qualification is narrow.** `MaterializedN3Graph` only runs `N3Mode::Counting` (truly incremental) for a monotone, input-stratified rule fragment: forward rules with ground-IRI predicates, no conclusion blank nodes, builtins limited to the parity whitelist (`log:uri`, `log:equalTo`/`notEqualTo`, `string:concatenation`/`scrape`/`encodeForUri`), and negation only via the store-scoped `?x log:notIncludes { … }` idiom over input-only predicates. Anything else → `N3Mode::Fallback`; always consult `.fallback_reason()` (`None` ⇔ counting active). The full *batch* N3 engine (`reason_n3`) supports the much larger `math:`/`string:`/`list:`/`time:`/`log:` builtin set and goal-directed `<=` rules.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-e5atd** (epic sq-pbz04): a D (datatype / value-space) entailment materialiser as an opt-in `Profile::D` in `sparq-reason`, wired into the `sparq-conformance` entailment harness.

## What this does

Adds a **D-entailment** (datatype / value-space, RDF 1.1 Semantics §7-8) materialiser to `sparq-reason` as an **opt-in** `Profile::D` behind a new `d-entail` cargo feature (OFF by default), and **graduates the D-regime conformance lane from OutOfScope to Pass** with an honest pinned floor.

### `sparq-reason` — `dtype` module (feature `d-entail`)
- `Profile::D` + `materialize_d(&Recognized, …)`: the **rdfD1** datatype-typing rule under a recognized datatype map — a well-formed literal `"l"^^d` of a recognized datatype `d` entails `("l"^^d rdf:type d)`. The emitted triples are **generalized** (literal in subject position), the shape the homomorphism / answer-restriction layer expects.
- **CORRECT TYPED value-space equality** (`d_value_eq` / `d_value_key`): the integer/decimal value spaces coincide, so `"1"^^xsd:integer` is the **same value** as `"1.0"^^xsd:decimal` — keyed by a **canonical decimal STRING**, **NOT an f64 fast path** (a unit test pins that 2^53+1 is not silently aliased the way f64 would). `float`/`double` are a disjoint IEEE-754 value space; `date`/`dateTime` are disjoint temporal families.
- Built only on **sparq-core** (`is_integer_datatype` + `temporal::Temporal`) — sparq-reason never depends on sparq-engine. A code comment marks the migration onto `sparq-substrate::compare` once the shared-substrate move lands (sq-6tykl); the typed `Num` compare is not yet wired into the substrate.

### `sparq-conformance` — D-regime lane (feature `d-entail`, forwards to `sparq-reason/d-entail`)
- `Regime::D` arm in `inference::entail::close` + a `Profile::D` arm in `sparql_entail`, mirroring the existing regime arms. The genuinely **D-only** `sparql11/entailment` test (`d-ent-01`) **moves from OutOfScope → Pass** through the real `Profile::D` materializer + the SPARQL 1.1 entailment-regime answer restriction (literal-subject / surrogate-bnode bindings are never answers — which is also why `d-ent-01` correctly returns NO rows).
- New crate-test lane `tests/d_entail_suite.rs` with `D_ENTAIL_FLOOR = 1` — the **MEASURED** D-only pass count at the pinned rdf-tests revision. The broader D-entailment surface (D-inconsistency / ill-typed-literal clashes, cross-type value-space *subset* reasoning) is honestly **tracked-not-asserted** (a child of sq-pbz04), never skip-laundered to inflate the count.
- Central `scoreboard::SUITES` row + the `tests/scoreboard_floors.rs` floor-sync guard entry (the only scoreboard-toucher in this wave); the `inference-conformance` CI job grows a D-entail step that asserts the floor.

## Perf-neutral / lean default (HARD)

`d-entail` is **OFF by default**, so the default build carries **zero** D-entailment code — and both wasm bundles are byte-identical (the lean `sparq-wasm` never touches `sparq-reason`; `sparq-reason-wasm` pins `default-features = false` and never enables `d-entail`). The inference **binary** keeps `d-ent-01` OutOfScope when the feature is off, so its existing `RATCHET=1967` is byte-for-byte unchanged (verified: 1950 pass + 17 divergence = 1967, unchanged). `scripts/perf-gate.py --self-test` passes; no byte/store/dict floor is touched.

## Gates run (BOTH feature states — default OFF and `d-entail` ON)

- `cargo build` — workspace GREEN.
- `cargo clippy --all-targets -- -D warnings` — GREEN for `sparq-reason` + `sparq-conformance` in both states (and `sparq-reason --all-features`).
- `cargo test` — GREEN: `sparq-reason` (incl. 8 new `dtype` unit tests — value-space equality, the f64-aliasing guard, idempotent rdfD1, ill-typed skip), `sparq-conformance` (incl. the new `d_entail_suite` lane = 1 pass / 0 fail and the `scoreboard_floors` guard).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `cargo +1.88 check` (MSRV) — GREEN with `d-entail`.
- `python3 scripts/check-readme-template.py --enforce` — **0 deviations** (sparq-reason README 60 lines).
- typos gate — clean. No ZK/MPC privacy claims touched.

**Feature flags:** `sparq-reason/d-entail`, `sparq-conformance/d-entail` (forwards to the former).

## Deferred (tracked, not in this PR)

- D-**inconsistency** detection (ill-typed-literal / value-space clashes) and cross-type value-space **subset** reasoning through `Profile::D` — the harness has its own `inconsistency()` checker today; lifting it onto the reasoner's typed comparator is a child of epic **sq-pbz04**.
- Migrate `d_value_key` onto `sparq-substrate::compare` once the substrate move-chain lands (**sq-6tykl**).

Auto-merge is **OFF** — leaving the arm decision to the orchestrator's verdict gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)