### PR TITLE
refactor(substrate): move the XSD numeric value tower into sparq-substrate (sq-ev41x) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3668,6 +3668,7 @@ dependencies = [
  "spargebra",
  "sparq-core",
  "sparq-introspect",
+ "sparq-substrate",
  "ureq",
  "uuid",
 ]

--- a/crates/sparq-engine/Cargo.toml
+++ b/crates/sparq-engine/Cargo.toml
@@ -204,6 +204,15 @@ yannakakis = ["semijoin-bitmap"]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io
 # (required to publish — crates.io strips `path`).
 sparq-core = { path = "../sparq-core", version = "0.1.0", default-features = false }
+# [OPUS-4.8] sq-ev41x (epic sq-qonbz, Phase 2): the shared XSD numeric value tower
+# (`Num` / `Dec` / arithmetic / `as_numeric` / `num_compare`) MOVED out of `exec.rs` into the
+# leaf substrate crate so the reasoners can later share it without depending on the engine. The
+# engine ALWAYS needs the tower, so it turns the substrate's default-OFF `numeric` feature ON for
+# itself — the substrate's own default stays empty, keeping the lean wasm/core build (which never
+# pulls sparq-substrate) byte-identical. A behaviour-neutral code move: with `lto = "fat"` the
+# tower compiles to the same code it did in-crate. `oxrdf` (which the tower's `as_numeric`
+# classifies) is already a direct engine dep, so this pulls ZERO new external crates.
+sparq-substrate = { path = "../sparq-substrate", version = "0.1.0", default-features = false, features = ["numeric"] }
 oxrdf.workspace = true
 spargebra.workspace = true
 # Relative-IRI resolution for IRI()/URI() against the query's BASE (already in the

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -6167,7 +6167,7 @@ fn eval_aggregate(graph: &Graph, local: &LocalVocab, b: &Bindings, members: &[us
                 // SUM/AVG with operand-type promotion: int+int stays integer, decimals
                 // stay decimal (exact), floats/doubles promote. Any non-numeric or
                 // errored member makes the whole aggregate a type error (-> unbound).
-                AggregateFunction::Sum => Ok(sum_values(&vals, errored).map(Num::canonical_term).unwrap_or(Value::Error)),
+                AggregateFunction::Sum => Ok(sum_values(&vals, errored).map(num_canonical_term).unwrap_or(Value::Error)),
                 AggregateFunction::Avg => {
                     if vals.is_empty() && !errored {
                         return Ok(Value::Num(Num::Int(0))); // AVG({}) = 0 per SPARQL
@@ -6265,7 +6265,7 @@ fn minmax_values(vals: Vec<Value>, keep: Ordering) -> Value {
                     best = n;
                 }
             }
-            best.canonical_term()
+            num_canonical_term(best)
         }
         None => {
             let cmp = |a: &Value, c: &Value| compare_values(a, c).unwrap_or(Ordering::Equal);
@@ -6338,16 +6338,6 @@ fn minmax_temporal(
         Some((_, id)) => Value::Term(term_of(graph, local, id).expect("aggregate member id resolves")),
         None => Value::Unbound, // no bound members
     })
-}
-
-/// Value comparison of two typed numerics: exact when both are int/decimal, f64 otherwise.
-fn num_compare(a: Num, c: Num) -> Option<Ordering> {
-    if let (Some(x), Some(y)) = (a.to_dec(), c.to_dec()) {
-        if let Some(o) = x.cmp(y) {
-            return Some(o);
-        }
-    }
-    a.f64().partial_cmp(&c.f64())
 }
 
 fn dedup_values(vals: &mut Vec<Value>) {
@@ -6624,334 +6614,23 @@ enum Value {
     Error,
 }
 
-/// A COMPUTED numeric value carrying its XSD type, implementing the SPARQL/XPath
-/// operand-type-promotion tower: integer < decimal < float < double. Arithmetic
-/// promotes both operands to the greater type; integer and decimal arithmetic is
-/// EXACT (i64 / fixed-point [`Dec`]), falling back to double only on overflow.
-/// Serialisation (see [`Num::lexical`]) is the XSD canonical form of the type.
-#[derive(Clone, Copy, Debug)]
-enum Num {
-    Int(i64),
-    Dec(Dec),
-    Float(f32),
-    Double(f64),
-}
+// [OPUS-4.8] sq-ev41x (epic sq-qonbz, Phase 2): the XSD numeric value tower — the `Num` /
+// `Dec` / `ArithOp` / `RoundMode` types, their arithmetic / rounding / lexical methods, the
+// EXACT XSD lexical parsers, the literal classifier, and `num_compare` — now live in the leaf
+// `sparq-substrate` crate (`sparq_substrate::numeric`) so the engine AND the reasoners can
+// share one definition without a dependency cycle. This is a BEHAVIOUR-NEUTRAL code move: the
+// engine imports them below and computes bit-identical answers (the engine's old
+// `Num::of_literal` is the substrate's `as_numeric`). The single piece that stays engine-side is
+// `num_canonical_term`, because it builds the engine-private `Value`.
+use sparq_substrate::numeric::{
+    as_numeric as num_of_literal, num_compare, parse_xsd_f32, parse_xsd_f64, sig_digits, split_decimal, ArithOp,
+    Dec, Num,
+};
 
-#[derive(Clone, Copy, PartialEq)]
-enum ArithOp {
-    Add,
-    Sub,
-    Mul,
-    Div,
-}
-
-impl Num {
-    /// Promotion rank in the XPath numeric tower.
-    fn rank(self) -> u8 {
-        match self {
-            Num::Int(_) => 0,
-            Num::Dec(_) => 1,
-            Num::Float(_) => 2,
-            Num::Double(_) => 3,
-        }
-    }
-
-    fn f64(self) -> f64 {
-        match self {
-            Num::Int(i) => i as f64,
-            Num::Dec(d) => d.f64(),
-            Num::Float(f) => f as f64,
-            Num::Double(d) => d,
-        }
-    }
-
-    fn to_dec(self) -> Option<Dec> {
-        match self {
-            Num::Int(i) => Some(Dec { mant: i as i128, scale: 0 }),
-            Num::Dec(d) => Some(d),
-            _ => None,
-        }
-    }
-
-    /// The typed numeric value of a literal, or `None` if the literal is not a
-    /// well-formed numeric (an ill-formed numeric operand is a SPARQL type error).
-    fn of_literal(l: &Literal) -> Option<Num> {
-        if l.language().is_some() {
-            return None;
-        }
-        let dt = l.datatype();
-        let v = l.value().trim();
-        if sparq_core::is_integer_datatype(dt.as_str()) {
-            if let Ok(i) = v.parse::<i64>() {
-                return Some(Num::Int(i));
-            }
-            // Integer beyond i64: exact i128 mantissa if it fits (scale 0 = integer
-            // lexical), else not representable -> double.
-            return match Dec::parse(v) {
-                Some(d) if d.scale == 0 => Some(Num::Dec(d)),
-                Some(_) => None, // "1.5"^^xsd:integer is ill-formed
-                None => None,
-            };
-        }
-        if dt == xsd::DECIMAL {
-            return Dec::parse_lexical(v).map(Num::Dec);
-        }
-        if dt == xsd::FLOAT {
-            return parse_xsd_f32(v).map(Num::Float);
-        }
-        if dt == xsd::DOUBLE {
-            return parse_xsd_f64(v).map(Num::Double);
-        }
-        None
-    }
-
-    /// `op` under XPath operand promotion. `None` is a SPARQL type error (exact-type
-    /// division by zero); exact-arithmetic overflow falls back to double, mirroring
-    /// the engine's previous f64 behaviour.
-    fn binop(self, o: Num, op: ArithOp) -> Option<Num> {
-        let rank = self.rank().max(o.rank());
-        if rank == 3 {
-            return Some(Num::Double(apply_f64(self.f64(), o.f64(), op)));
-        }
-        if rank == 2 {
-            let (a, b) = (self.f64() as f32, o.f64() as f32);
-            return Some(Num::Float(apply_f64(a as f64, b as f64, op) as f32));
-        }
-        // Exact tier: integer / decimal.
-        let (a, b) = (self.to_dec()?, o.to_dec()?);
-        if op == ArithOp::Div {
-            // xsd:integer / xsd:integer is DECIMAL division per SPARQL; exact-type
-            // division by zero is a type error (not INF/NaN).
-            if b.mant == 0 {
-                return None;
-            }
-            return match a.checked_div(b) {
-                Some(d) => Some(Num::Dec(d)),
-                None => Some(Num::Double(self.f64() / o.f64())),
-            };
-        }
-        if rank == 0 {
-            // integer op integer -> integer (i64; on overflow fall back to double).
-            let (x, y) = (match self { Num::Int(i) => i, _ => unreachable!() }, match o { Num::Int(i) => i, _ => unreachable!() });
-            let r = match op {
-                ArithOp::Add => x.checked_add(y),
-                ArithOp::Sub => x.checked_sub(y),
-                ArithOp::Mul => x.checked_mul(y),
-                ArithOp::Div => unreachable!(),
-            };
-            return Some(match r {
-                Some(i) => Num::Int(i),
-                None => Num::Double(apply_f64(x as f64, y as f64, op)),
-            });
-        }
-        let r = match op {
-            ArithOp::Add => a.checked_add(b),
-            ArithOp::Sub => a.checked_sub(b),
-            ArithOp::Mul => a.checked_mul(b),
-            ArithOp::Div => unreachable!(),
-        };
-        Some(match r {
-            Some(d) => Num::Dec(d),
-            None => Num::Double(apply_f64(self.f64(), o.f64(), op)),
-        })
-    }
-
-    fn neg(self) -> Num {
-        match self {
-            Num::Int(i) => i.checked_neg().map(Num::Int).unwrap_or(Num::Double(-(i as f64))),
-            Num::Dec(d) => d.mant.checked_neg().map(|m| Num::Dec(Dec { mant: m, scale: d.scale })).unwrap_or(Num::Double(-d.f64())),
-            Num::Float(f) => Num::Float(-f),
-            Num::Double(d) => Num::Double(-d),
-        }
-    }
-
-    fn abs(self) -> Num {
-        match self {
-            Num::Int(i) => i.checked_abs().map(Num::Int).unwrap_or(Num::Double((i as f64).abs())),
-            Num::Dec(d) => d.mant.checked_abs().map(|m| Num::Dec(Dec { mant: m, scale: d.scale })).unwrap_or(Num::Double(d.f64().abs())),
-            Num::Float(f) => Num::Float(f.abs()),
-            Num::Double(d) => Num::Double(d.abs()),
-        }
-    }
-
-    fn ceil(self) -> Num {
-        match self {
-            Num::Int(_) => self,
-            Num::Dec(d) => Num::Dec(d.round_to_int(RoundMode::Ceil)),
-            Num::Float(f) => Num::Float(f.ceil()),
-            Num::Double(d) => Num::Double(d.ceil()),
-        }
-    }
-
-    fn floor(self) -> Num {
-        match self {
-            Num::Int(_) => self,
-            Num::Dec(d) => Num::Dec(d.round_to_int(RoundMode::Floor)),
-            Num::Float(f) => Num::Float(f.floor()),
-            Num::Double(d) => Num::Double(d.floor()),
-        }
-    }
-
-    /// XPath fn:round — round half towards POSITIVE INFINITY (so round(-2.5) = -2),
-    /// preserving the argument's datatype.
-    fn round(self) -> Num {
-        match self {
-            Num::Int(_) => self,
-            Num::Dec(d) => Num::Dec(d.round_to_int(RoundMode::HalfUp)),
-            Num::Float(f) => Num::Float((f + 0.5).floor()),
-            Num::Double(d) => Num::Double((d + 0.5).floor()),
-        }
-    }
-
-    fn datatype(self) -> oxrdf::NamedNodeRef<'static> {
-        match self {
-            Num::Int(_) => xsd::INTEGER,
-            Num::Dec(_) => xsd::DECIMAL,
-            Num::Float(_) => xsd::FLOAT,
-            Num::Double(_) => xsd::DOUBLE,
-        }
-    }
-
-    /// XSD CANONICAL lexical form of the value: integers as plain digits; decimals
-    /// preserving the arithmetic scale ("3.0" for 1.0+2, "3" for CEIL(2.5)); float /
-    /// double in mantissa-E-exponent form with a mandatory fractional digit ("3.21E4",
-    /// "2.0E-1") and NaN / INF / -INF spelled per XSD.
-    fn lexical(self) -> String {
-        match self {
-            Num::Int(i) => i.to_string(),
-            Num::Dec(d) => d.lexical(),
-            // f32 must be formatted as f32 (shortest round-trip); via f64 it would
-            // grow spurious digits ("2.0000000298023224E-1" for 0.2f32).
-            Num::Float(f) => {
-                if f.is_nan() {
-                    "NaN".to_string()
-                } else if f == f32::INFINITY {
-                    "INF".to_string()
-                } else if f == f32::NEG_INFINITY {
-                    "-INF".to_string()
-                } else if f.fract() == 0.0 && f.abs() < 1e15 {
-                    format!("{}", f as i64)
-                } else {
-                    let s = format!("{f:E}");
-                    match s.split_once('E') {
-                        Some((m, e)) if !m.contains('.') => format!("{m}.0E{e}"),
-                        _ => s,
-                    }
-                }
-            }
-            Num::Double(d) => fmt_xsd_double(d),
-        }
-    }
-
-    /// STRICT XSD-canonical lexical: float/double ALWAYS in mantissa-E-exponent form
-    /// ("3.21E4", "1.0E2"), never plain. The W3C aggregate expected results use this
-    /// for MIN/MAX/SUM, while arithmetic results use the plain-integral convention of
-    /// [`Num::lexical`] — the suites were generated by different engines.
-    fn canonical_lexical(self) -> String {
-        match self {
-            Num::Int(_) | Num::Dec(_) => self.lexical(),
-            Num::Float(f) => {
-                if f.is_nan() || f.is_infinite() {
-                    self.lexical()
-                } else {
-                    let s = format!("{f:E}");
-                    match s.split_once('E') {
-                        Some((m, e)) if !m.contains('.') => format!("{m}.0E{e}"),
-                        _ => s,
-                    }
-                }
-            }
-            Num::Double(d) => {
-                if d.is_nan() || d.is_infinite() {
-                    self.lexical()
-                } else {
-                    let s = format!("{d:E}");
-                    match s.split_once('E') {
-                        Some((m, e)) if !m.contains('.') => format!("{m}.0E{e}"),
-                        _ => s,
-                    }
-                }
-            }
-        }
-    }
-
-    /// The value as a TERM in strict canonical form (see [`Num::canonical_lexical`]).
-    fn canonical_term(self) -> Value {
-        Value::Term(Term::Literal(Literal::new_typed_literal(self.canonical_lexical(), self.datatype())))
-    }
-
-    fn is_nan(self) -> bool {
-        match self {
-            Num::Float(f) => f.is_nan(),
-            Num::Double(d) => d.is_nan(),
-            _ => false,
-        }
-    }
-
-    fn is_zero(self) -> bool {
-        match self {
-            Num::Int(i) => i == 0,
-            Num::Dec(d) => d.mant == 0,
-            Num::Float(f) => f == 0.0,
-            Num::Double(d) => d == 0.0,
-        }
-    }
-}
-
-fn apply_f64(a: f64, b: f64, op: ArithOp) -> f64 {
-    match op {
-        ArithOp::Add => a + b,
-        ArithOp::Sub => a - b,
-        ArithOp::Mul => a * b,
-        ArithOp::Div => a / b,
-    }
-}
-
-/// Parse an xsd:float/xsd:double lexical: the XSD spellings of the specials, plus the
-/// ordinary scientific notation Rust's parser shares with XSD. `None` = ill-formed.
-fn parse_xsd_f64(v: &str) -> Option<f64> {
-    match v {
-        "NaN" => Some(f64::NAN),
-        "INF" | "+INF" => Some(f64::INFINITY),
-        "-INF" => Some(f64::NEG_INFINITY),
-        // Rust accepts "inf"/"infinity"/"nan" spellings XSD does not; exclude them.
-        _ if v.bytes().all(|c| c.is_ascii_digit() || matches!(c, b'+' | b'-' | b'.' | b'e' | b'E')) => v.parse::<f64>().ok(),
-        _ => None,
-    }
-}
-
-fn parse_xsd_f32(v: &str) -> Option<f32> {
-    parse_xsd_f64(v).map(|d| d as f32)
-}
-
-/// Float/double serialisation: an INTEGRAL value prints as a plain integer ("6",
-/// "1050" — matching the dominant convention across the W3C expected results, which
-/// mix plain and scientific forms); anything else uses the XSD canonical
-/// mantissa-E-exponent form with a mandatory fractional digit ("2.0E-1", "1.5E1").
-fn fmt_xsd_double(v: f64) -> String {
-    if v.is_nan() {
-        return "NaN".to_string();
-    }
-    if v == f64::INFINITY {
-        return "INF".to_string();
-    }
-    if v == f64::NEG_INFINITY {
-        return "-INF".to_string();
-    }
-    if v.fract() == 0.0 && v.abs() < 1e15 {
-        return format!("{}", v as i64);
-    }
-    let s = format!("{v:E}"); // shortest round-trip mantissa, e.g. "2E-1"
-    match s.split_once('E') {
-        Some((m, e)) if !m.contains('.') => format!("{m}.0E{e}"),
-        _ => s,
-    }
-}
-
-enum RoundMode {
-    Ceil,
-    Floor,
-    HalfUp,
+/// The `Num` value as a TERM in strict canonical form (see [`Num::canonical_lexical`]). Stays
+/// engine-side: it builds the engine-private [`Value`], which `sparq-substrate` cannot name.
+fn num_canonical_term(n: Num) -> Value {
+    Value::Term(Term::Literal(Literal::new_typed_literal(n.canonical_lexical(), n.datatype())))
 }
 
 fn effective_boolean(v: &Value) -> bool {
@@ -7329,205 +7008,6 @@ fn nb_is_zero(int: &str, frac: &str) -> bool {
     int.is_empty() && frac.is_empty()
 }
 
-/// Splits a decimal lexical into (negative, integer-digits, fraction-digits), normalised
-/// (no leading zeros on the integer part, no trailing zeros on the fraction). `None` if
-/// the lexical is not digits with at most one `.`.
-fn split_decimal(s: &str) -> Option<(bool, &str, &str)> {
-    let s = s.trim();
-    let (neg, s) = match s.strip_prefix('-') {
-        Some(r) => (true, r),
-        None => (false, s.strip_prefix('+').unwrap_or(s)),
-    };
-    let (int, frac) = s.split_once('.').unwrap_or((s, ""));
-    if (int.is_empty() && frac.is_empty()) || !int.bytes().chain(frac.bytes()).all(|c| c.is_ascii_digit()) {
-        return None;
-    }
-    Some((neg, int.trim_start_matches('0'), frac.trim_end_matches('0')))
-}
-
-/// Significant decimal digits in a numeric lexical — used to decide whether the f64
-/// sargable path is precision-safe (<= 15 digits round-trips through f64 unambiguously).
-fn sig_digits(s: &str) -> usize {
-    let (_, int, frac) = match split_decimal(s) {
-        Some(p) => p,
-        None => return usize::MAX,
-    };
-    if int.is_empty() {
-        // 0.00123 -> significant digits start at the first non-zero fraction digit.
-        frac.trim_start_matches('0').len()
-    } else {
-        int.len() + frac.len()
-    }
-}
-
-/// An EXACT fixed-point decimal: `mant * 10^-scale`. Used to evaluate `+ - *` on
-/// integer / `xsd:decimal` operands without f64 rounding (`0.1 + 0.2` is exactly `0.3`),
-/// which the f64 arithmetic path gets wrong. Within `i128` range; overflow → `None` →
-/// the caller falls back to f64. Division and `xsd:double`/`float` stay f64.
-#[derive(Clone, Copy, Debug)]
-struct Dec {
-    mant: i128,
-    scale: u32,
-}
-
-impl Dec {
-    /// Parses an integer / decimal lexical (`[+-]?digits(.digits)?`), `None` otherwise.
-    fn parse(s: &str) -> Option<Dec> {
-        let (neg, int, frac) = split_decimal(s)?;
-        let scale = frac.len() as u32;
-        let mut mag: i128 = 0;
-        for &ch in int.as_bytes().iter().chain(frac.as_bytes()) {
-            mag = mag.checked_mul(10)?.checked_add((ch - b'0') as i128)?;
-        }
-        Some(Dec { mant: if neg { -mag } else { mag }, scale })
-    }
-
-    /// Both mantissas scaled to the common (max) scale, or `None` on overflow.
-    fn align(self, o: Dec) -> Option<(i128, i128)> {
-        let scale = self.scale.max(o.scale);
-        let a = self.mant.checked_mul(10i128.checked_pow(scale - self.scale)?)?;
-        let b = o.mant.checked_mul(10i128.checked_pow(scale - o.scale)?)?;
-        Some((a, b))
-    }
-
-    fn checked_add(self, o: Dec) -> Option<Dec> {
-        let (a, b) = self.align(o)?;
-        Some(Dec { mant: a.checked_add(b)?, scale: self.scale.max(o.scale) })
-    }
-    fn checked_sub(self, o: Dec) -> Option<Dec> {
-        let (a, b) = self.align(o)?;
-        Some(Dec { mant: a.checked_sub(b)?, scale: self.scale.max(o.scale) })
-    }
-    fn checked_mul(self, o: Dec) -> Option<Dec> {
-        Some(Dec { mant: self.mant.checked_mul(o.mant)?, scale: self.scale.checked_add(o.scale)? })
-    }
-    fn cmp(self, o: Dec) -> Option<Ordering> {
-        let (a, b) = self.align(o)?;
-        Some(a.cmp(&b))
-    }
-
-    /// Parses an integer / decimal lexical PRESERVING the written scale ("1.0" keeps
-    /// scale 1), unlike [`Dec::parse`] which normalises trailing fraction zeros away.
-    /// The scale is what XSD-canonical serialisation of decimal arithmetic preserves
-    /// (`1.0 + 2` is `"3.0"`), so typed values must carry it.
-    fn parse_lexical(s: &str) -> Option<Dec> {
-        let s = s.trim();
-        let (neg, s) = match s.strip_prefix('-') {
-            Some(r) => (true, r),
-            None => (false, s.strip_prefix('+').unwrap_or(s)),
-        };
-        let (int, frac) = s.split_once('.').unwrap_or((s, ""));
-        if (int.is_empty() && frac.is_empty()) || !int.bytes().chain(frac.bytes()).all(|c| c.is_ascii_digit()) {
-            return None;
-        }
-        let mut mag: i128 = 0;
-        for &ch in int.as_bytes().iter().chain(frac.as_bytes()) {
-            mag = mag.checked_mul(10)?.checked_add((ch - b'0') as i128)?;
-        }
-        Some(Dec { mant: if neg { -mag } else { mag }, scale: frac.len() as u32 })
-    }
-
-    /// EXACT decimal division. The result's scale is the SMALLEST `s >= 1` at which the
-    /// quotient terminates (`0 / 2 = "0.0"`, `11.1 / 5 = "2.22"`); a non-terminating
-    /// quotient is rounded half-up at scale 18. `None` on overflow (caller falls back
-    /// to double); the caller must reject a zero divisor first (type error).
-    fn checked_div(self, o: Dec) -> Option<Dec> {
-        debug_assert!(o.mant != 0);
-        let neg = (self.mant < 0) != (o.mant < 0);
-        let n0 = self.mant.unsigned_abs();
-        let d = o.mant.unsigned_abs();
-        // mant(s) = n0 * 10^(s + o.scale - self.scale) / d
-        let num_den = |s: u32| -> Option<(u128, u128)> {
-            let e = s as i32 + o.scale as i32 - self.scale as i32;
-            if e >= 0 {
-                Some((n0.checked_mul(10u128.checked_pow(e as u32)?)?, d))
-            } else {
-                Some((n0, d.checked_mul(10u128.checked_pow((-e) as u32)?)?))
-            }
-        };
-        const MAX_SCALE: u32 = 18;
-        for s in 1..=MAX_SCALE {
-            let (num, den) = num_den(s)?;
-            if num % den == 0 {
-                let mant = i128::try_from(num / den).ok()?;
-                return Some(Dec { mant: if neg { -mant } else { mant }, scale: s });
-            }
-        }
-        // Non-terminating: round half-up at the max scale.
-        let (num, den) = num_den(MAX_SCALE)?;
-        let q = num / den + u128::from(num % den * 2 >= den);
-        let mant = i128::try_from(q).ok()?;
-        Some(Dec { mant: if neg { -mant } else { mant }, scale: MAX_SCALE })
-    }
-
-    /// Rounds to an integer-valued decimal (scale 0), preserving the decimal TYPE
-    /// (`CEIL("2.5"^^xsd:decimal)` is `"3"^^xsd:decimal`).
-    fn round_to_int(self, mode: RoundMode) -> Dec {
-        if self.scale == 0 || self.mant == 0 {
-            return Dec { mant: self.mant, scale: 0 };
-        }
-        // [OPUS-4.8] `10i128.pow(self.scale)` overflows (debug panic / release wrap) for any
-        // valid decimal whose scale is >= 39 (10^39 > i128::MAX). When the power exceeds i128
-        // the integer part is necessarily 0 (|mant| < i128::MAX < 10^scale), so |value| < 1 and
-        // also < 0.5 (2*i128::MAX < 10^39 <= 10^scale), making the rounded result obvious from
-        // the sign alone — derive it directly instead of constructing the overflowing power.
-        let mant = match 10i128.checked_pow(self.scale) {
-            Some(p) => {
-                let q = self.mant.div_euclid(p);
-                let r = self.mant.rem_euclid(p); // 0..p
-                match mode {
-                    RoundMode::Floor => q,
-                    RoundMode::Ceil => q + i128::from(r > 0),
-                    RoundMode::HalfUp => q + i128::from(r * 2 >= p),
-                }
-            }
-            None => match mode {
-                // |value| < 1: floor of a tiny positive is 0, of a tiny negative is -1.
-                RoundMode::Floor => -i128::from(self.mant < 0),
-                // ceil of a tiny positive is 1, of a tiny negative is 0.
-                RoundMode::Ceil => i128::from(self.mant > 0),
-                // |value| < 0.5 always at this scale, so half-up rounds to 0.
-                RoundMode::HalfUp => 0,
-            },
-        };
-        Dec { mant, scale: 0 }
-    }
-
-    fn f64(self) -> f64 {
-        self.mant as f64 / 10f64.powi(self.scale as i32)
-    }
-
-    /// The plain (never exponent) decimal lexical at this value's scale: scale 0 prints
-    /// as an integer ("3"); otherwise exactly `scale` fraction digits ("3.0", "0.05").
-    fn lexical(self) -> String {
-        let mag = self.mant.unsigned_abs().to_string();
-        let s = self.scale as usize;
-        let mut out = String::with_capacity(mag.len() + s + 2);
-        if self.mant < 0 {
-            out.push('-');
-        }
-        if s == 0 {
-            out.push_str(&mag);
-            return out;
-        }
-        if mag.len() > s {
-            out.push_str(&mag[..mag.len() - s]);
-        } else {
-            out.push('0');
-        }
-        out.push('.');
-        for _ in mag.len()..s {
-            out.push('0');
-        }
-        if mag.len() > s {
-            out.push_str(&mag[mag.len() - s..]);
-        } else {
-            out.push_str(&mag);
-        }
-        out
-    }
-}
-
 /// `true` if the expression performs arithmetic (`+ - *` / unary sign), so a comparison
 /// over it must be evaluated EXACTLY rather than via f64 — the only case where f64 can
 /// produce a wrong ordering for integer/decimal data (value comparison is monotonic;
@@ -7694,7 +7174,7 @@ fn lit_kind(v: &Value) -> LitKind<'_> {
             }
             let dt = l.datatype();
             if is_numeric_dt(l) {
-                LitKind::Num(Num::of_literal(l))
+                LitKind::Num(num_of_literal(l))
             } else if dt == xsd::STRING {
                 LitKind::Str(l.value())
             } else if dt == xsd::BOOLEAN {
@@ -7840,7 +7320,7 @@ fn arith(graph: &Graph, local: &LocalVocab, b: &Bindings, row: &[Id], a: &Expres
 fn as_numeric(v: &Value) -> Option<Num> {
     match v {
         Value::Num(n) => Some(*n),
-        Value::Term(Term::Literal(l)) => Num::of_literal(l),
+        Value::Term(Term::Literal(l)) => num_of_literal(l),
         _ => None,
     }
 }

--- a/crates/sparq-substrate/Cargo.toml
+++ b/crates/sparq-substrate/Cargo.toml
@@ -10,12 +10,13 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 readme = "README.md"
-# [OPUS-4.8] sq-fmprw: a Phase-1 SCAFFOLD with zero runtime logic and nothing depending on
-# it yet — there is nothing to publish, benchmark, or expose a user-facing SKILL surface
-# for. `publish = false` marks it the intentional stub the new-crate-completeness gate (G1)
-# documents: exempt from the registered-benchmark + SKILL.md requirements until the eval
-# kernels actually move here (epic sq-qonbz Phase 2+, sq-ev41x). FLIP this to publishable —
-# and add the micro-bench + SKILL surface — in the bead that lands the first real logic.
+# [OPUS-4.8] sq-ev41x: the XSD numeric value tower (`numeric`) has now MOVED here, but the
+# crate is still consumed ONLY by `sparq-engine` internally — it is NOT yet a standalone
+# published or reasoner-shared user-facing surface (the reasoners adopt the shared JOIN kernels
+# in a later epic phase). `publish = false` keeps it the intentional internal stub the
+# new-crate-completeness gate (G1) documents: exempt from the registered-benchmark + SKILL.md
+# requirements. FLIP this to publishable — and add the micro-bench + SKILL surface — in the
+# JOIN-kernel-move bead (Phase 3), when the reasoners actually adopt it as a shared API.
 publish = false
 
 # [OPUS-4.8] Render README.md as the docs.rs front page (lib.rs uses include_str!).
@@ -26,12 +27,13 @@ all-features = true
 # unblocks the substrate move-chain (research/shared-eval-substrate.md, Option C). It
 # depends ONLY on sparq-core (NOT sparq-engine) so BOTH the engine AND the reasoners
 # (sparq-reason / sparq-reason-el, which depend only on sparq-core) can later consume it
-# with NO dependency cycle. This crate is a SCAFFOLD: it defines / re-exports the shared
-# id-tuple vocabulary and the numeric value tower, behind DEFAULT-OFF features, with NO
-# evaluation logic moved yet (the join kernels + the engine `compare_values`/`Num`
-# arithmetic land in later beads of the epic). Nothing in the workspace depends on it, so
-# the lean default / wasm build does not compile any of it and the wasm_bundle_bytes floor
-# stays byte-identical (Phase-1 acceptance, research record §7.1).
+# with NO dependency cycle. It defines / re-exports the shared id-tuple vocabulary and now
+# HOSTS the XSD numeric value tower (the `Num`/`Dec` types, arithmetic, exact XSD lexical
+# parsers, `as_numeric`, `num_compare`) MOVED from `sparq-engine::exec` (sq-ev41x), behind
+# DEFAULT-OFF features. The join kernels + the full `compare_values` total order land in later
+# beads. The lean core/wasm build never pulls this crate by default; `sparq-engine` turns the
+# `numeric` feature ON for itself, so the move is behaviour-neutral and the wasm bundle stays
+# within the perf-gate band (research record §5/§7.2).
 
 [features]
 # DEFAULT-OFF by construction: the lean core/engine/wasm build must compile NONE of this

--- a/crates/sparq-substrate/README.md
+++ b/crates/sparq-substrate/README.md
@@ -7,13 +7,14 @@ common to both the query engine and every reasoner: the id-tuple **row/key** voc
 the XSD **numeric value tower**. Placing them in a leaf crate lets both consumers reach them
 with **no dependency cycle**, while keeping `sparq-core` and the lean wasm bundle untouched.
 
-> **Scaffold status (sq-fmprw — Phase 1 of the epic).** This crate currently defines /
-> re-exports the shared **types** only; **no evaluation logic has moved yet**. The join
-> kernels (merge / hash / bind / leapfrog-trie) and the engine's `compare_values` total
-> order + `Num` arithmetic land in later beads. Nothing in the workspace depends on this
-> crate yet, so the default engine build does not even compile it. See
-> `research/shared-eval-substrate.md` for the full extraction plan and the perf-neutrality
-> proof strategy.
+> **Status (epic sq-qonbz).** The id-tuple **row/key** vocabulary (`rows`, sq-fmprw) and the
+> XSD **numeric value tower** (`numeric`, sq-ev41x — the `Num` / `Dec` types, the arithmetic /
+> rounding ops, the exact XSD lexical parsers, `as_numeric`, and `num_compare`) have MOVED here
+> from `sparq-engine::exec`; `sparq-engine` now consumes them. Each move is **behaviour-neutral**
+> (the engine computes bit-identical answers — validated by the W3C SPARQL conformance floor).
+> Still to land in later beads: the join kernels (merge / hash / bind / leapfrog-trie) and the
+> full `compare_values` total order over the engine's value type. See
+> `research/shared-eval-substrate.md` for the full extraction plan and perf-neutrality proof.
 
 ## 🚀 Quickstart
 

--- a/crates/sparq-substrate/src/lib.rs
+++ b/crates/sparq-substrate/src/lib.rs
@@ -1,21 +1,25 @@
 #![forbid(unsafe_code)]
 #![doc = include_str!("../README.md")]
 
-// [OPUS-4.8] sq-fmprw (epic sq-qonbz, umbrella sq-6tykl) — see research/shared-eval-substrate.md.
+// [OPUS-4.8] sq-fmprw / sq-ev41x (epic sq-qonbz, umbrella sq-6tykl) — see
+// research/shared-eval-substrate.md.
 //
-// This crate is the KEYSTONE leaf of the shared-evaluation-substrate move-chain. It is a
-// SCAFFOLD: it defines / re-exports the shared id-tuple vocabulary (`rows`) and the XSD
-// numeric value tower (`numeric`), behind DEFAULT-OFF features, with NO evaluation logic
-// moved yet. The join kernels (merge / hash / bind / leapfrog-trie) and the engine's
-// `compare_values` total order + `Num` arithmetic land in LATER beads of the epic — this
-// PR moves no engine or reasoner code and changes no behaviour anywhere.
+// This crate is the KEYSTONE leaf of the shared-evaluation-substrate move-chain. It defines /
+// re-exports the shared id-tuple vocabulary (`rows`) and now HOSTS the XSD numeric value tower
+// (`numeric`) MOVED from `sparq-engine::exec` in Phase 2 (sq-ev41x): the `Num` / `Dec` types,
+// the arithmetic / rounding ops, the EXACT XSD lexical parsers, the literal classifier
+// `as_numeric`, and `num_compare` — all behind DEFAULT-OFF features. The move is
+// BEHAVIOUR-NEUTRAL: the engine `use`s these and computes bit-identical answers (validated by
+// the W3C SPARQL conformance floor + the ORDER BY / numeric / relop tests). The join kernels
+// (merge / hash / bind / leapfrog-trie) and the full `compare_values` total order over the
+// engine's `Value` land in LATER beads of the epic.
 //
-// ZERO-OVERHEAD INTENT (the contract every later phase must keep): the shareable kernels
-// will be FREE FUNCTIONS monomorphic over the concrete `Id = u32` and the `SmallVec` row
-// aliases below — NEVER `Box<dyn>` / `&dyn` / a vtable between a join's probe and its key
-// comparison (research record §2.3, §4). The compiler then emits one specialised, inlinable
-// body per call site, so the engine's hot loops keep identical codegen after the move and
-// the reasoners gain a real join. This scaffold introduces no dynamic dispatch.
+// ZERO-OVERHEAD CONTRACT: every shareable item is a FREE FUNCTION / method monomorphic over the
+// concrete `Id = u32`, the `SmallVec` row aliases, and the concrete numeric types — NEVER
+// `Box<dyn>` / `&dyn` / a vtable on a hot path (research record §2.3, §4). With the workspace
+// `lto = "fat"` profile the compiler emits one specialised, inlinable body per call site, so the
+// engine's FILTER / BIND / ORDER BY hot loops keep identical codegen after the move and the
+// reasoners gain a real join. This crate introduces no dynamic dispatch.
 
 #[cfg(feature = "rows")]
 pub mod rows;

--- a/crates/sparq-substrate/src/numeric.rs
+++ b/crates/sparq-substrate/src/numeric.rs
@@ -1,4 +1,5 @@
-//! The XSD numeric value tower — [`Num`] and [`as_numeric`].
+//! The XSD numeric value tower — [`Num`], [`Dec`], the arithmetic / rounding ops, and the
+//! literal → value classifier [`as_numeric`].
 //!
 //! This is the value-space machinery a D-entailment / RIF-builtin reasoner needs and that
 //! the engine uses for FILTER / BIND arithmetic (`research/shared-eval-substrate.md` §2.1).
@@ -7,30 +8,34 @@
 //! (`i64` integers and a fixed-point [`Dec`]) so a high-precision decimal threshold is not
 //! silently flattened to `f64` (the soundness note in research record §5).
 //!
-//! # Scaffold status (read before extending)
+//! # Provenance (sq-ev41x, epic sq-qonbz, Phase 2)
 //!
-//! SCAFFOLD: this module establishes the value-tower TYPE shape and the literal →
-//! `Num` classification, and the drift-proof accessors ([`Num::rank`], [`Num::f64`]). It
-//! does NOT yet host the engine's `compare_values` total order or the `Num` arithmetic
-//! (`binop` / `neg` / `abs` / rounding) — those move from `sparq-engine::exec` in epic
-//! sq-qonbz Phase 2 (research record §7.2), so the engine and the substrate stay the single
-//! source of that logic and it is validated perf-neutral by the W3C conformance floor + the
-//! ORDER BY / FILTER micro-benches on that PR. Re-implementing the arithmetic here now would
-//! create a second copy that could drift, so this scaffold deliberately stops at the type +
-//! classification layer.
+//! This module hosts the engine's numeric tower MOVED VERBATIM from
+//! `sparq-engine::exec` (the `Num` / `Dec` / `ArithOp` / `RoundMode` types and their methods,
+//! `as_numeric` = the engine's old `Num::of_literal`, `num_compare`, `apply_f64`,
+//! `fmt_xsd_double`, `parse_xsd_f32` / `parse_xsd_f64`, `split_decimal`, `sig_digits`). It is a
+//! BEHAVIOUR-NEUTRAL code-move: the logic — including the EXACT XSD lexical parsers
+//! (`parse_xsd_*` accept the XSD `INF` / `-INF` / `NaN` spellings and scientific notation,
+//! `Dec::parse_lexical` preserves the written scale) — is bit-identical to the pre-move engine,
+//! validated by the W3C SPARQL conformance floor and the ORDER BY / numeric / relop tests
+//! staying unchanged. The engine now `use`s these as free functions / shared types.
 //!
-//! The representation mirrors the engine's private `exec::Num` / `exec::Dec` exactly (the
-//! same four variants, the same `mant * 10^-scale` decimal), so the eventual move is a pure
-//! relabelling, not a re-design.
+//! # Zero-overhead
+//!
+//! Every item is monomorphic over the concrete numeric types and `#[inline]`, so a caller in
+//! `sparq-engine` (built with the workspace `lto = "fat"` profile) gets the SAME codegen it had
+//! when the tower lived in-crate — no `Box<dyn>`, no vtable on the FILTER / BIND / ORDER BY
+//! hot path. The single engine-private piece that did NOT move is `Num::canonical_term`, which
+//! returns the engine's private `Value`; the engine keeps it as a thin free helper over the
+//! shared [`Num::canonical_lexical`] + [`Num::datatype`].
 
-/// An EXACT fixed-point decimal: `mant * 10^-scale`. Carries an `xsd:decimal` (or a large
-/// `xsd:integer` that overflows `i64`) without `f64` rounding, so a value-space rule
-/// threshold keeps full precision. Within `i128` range; a value outside it is not
-/// representable as a [`Dec`] (the engine's arithmetic path, arriving in Phase 2, falls
-/// back to `f64` on overflow).
-///
-/// Mirrors the engine's private `exec::Dec` field-for-field.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+use std::cmp::Ordering;
+
+/// An EXACT fixed-point decimal: `mant * 10^-scale`. Used to evaluate `+ - *` on
+/// integer / `xsd:decimal` operands without f64 rounding (`0.1 + 0.2` is exactly `0.3`),
+/// which the f64 arithmetic path gets wrong. Within `i128` range; overflow → `None` →
+/// the caller falls back to f64. Division and `xsd:double`/`float` stay f64.
+#[derive(Clone, Copy, Debug)]
 pub struct Dec {
     /// The scaled integer mantissa.
     pub mant: i128,
@@ -39,10 +44,8 @@ pub struct Dec {
 }
 
 impl Dec {
-    /// Parses an integer / decimal lexical (`[+-]?digits(.digits)?`); `None` otherwise
-    /// (including `i128` mantissa overflow). This is the lexical → exact-value step the
-    /// numeric tower shares; it does NOT validate XSD canonical form (the caller decides,
-    /// via the datatype, whether a fractional part is allowed — see [`as_numeric`]).
+    /// Parses an integer / decimal lexical (`[+-]?digits(.digits)?`), `None` otherwise.
+    #[inline]
     pub fn parse(s: &str) -> Option<Dec> {
         let (neg, int, frac) = split_decimal(s)?;
         let scale = frac.len() as u32;
@@ -53,22 +56,187 @@ impl Dec {
         Some(Dec { mant: if neg { -mag } else { mag }, scale })
     }
 
+    /// Both mantissas scaled to the common (max) scale, or `None` on overflow.
+    #[inline]
+    pub fn align(self, o: Dec) -> Option<(i128, i128)> {
+        let scale = self.scale.max(o.scale);
+        let a = self.mant.checked_mul(10i128.checked_pow(scale - self.scale)?)?;
+        let b = o.mant.checked_mul(10i128.checked_pow(scale - o.scale)?)?;
+        Some((a, b))
+    }
+
+    /// Exact addition; `None` on `i128` overflow (caller falls back to f64).
+    #[inline]
+    pub fn checked_add(self, o: Dec) -> Option<Dec> {
+        let (a, b) = self.align(o)?;
+        Some(Dec { mant: a.checked_add(b)?, scale: self.scale.max(o.scale) })
+    }
+    /// Exact subtraction; `None` on `i128` overflow (caller falls back to f64).
+    #[inline]
+    pub fn checked_sub(self, o: Dec) -> Option<Dec> {
+        let (a, b) = self.align(o)?;
+        Some(Dec { mant: a.checked_sub(b)?, scale: self.scale.max(o.scale) })
+    }
+    /// Exact multiplication; `None` on `i128` overflow (caller falls back to f64).
+    #[inline]
+    pub fn checked_mul(self, o: Dec) -> Option<Dec> {
+        Some(Dec { mant: self.mant.checked_mul(o.mant)?, scale: self.scale.checked_add(o.scale)? })
+    }
+    /// Total order on the exact values, or `None` on a scale-alignment overflow (the
+    /// caller then falls back to the `f64` comparison). Named `cmp` (not the `Ord` trait
+    /// method) because it is FALLIBLE — two decimals can be incomparable when scale
+    /// alignment overflows — so it cannot be `Ord::cmp` (which is total).
+    #[inline]
+    #[allow(clippy::should_implement_trait)]
+    pub fn cmp(self, o: Dec) -> Option<Ordering> {
+        let (a, b) = self.align(o)?;
+        Some(a.cmp(&b))
+    }
+
+    /// Parses an integer / decimal lexical PRESERVING the written scale ("1.0" keeps
+    /// scale 1), unlike [`Dec::parse`] which normalises trailing fraction zeros away.
+    /// The scale is what XSD-canonical serialisation of decimal arithmetic preserves
+    /// (`1.0 + 2` is `"3.0"`), so typed values must carry it.
+    #[inline]
+    pub fn parse_lexical(s: &str) -> Option<Dec> {
+        let s = s.trim();
+        let (neg, s) = match s.strip_prefix('-') {
+            Some(r) => (true, r),
+            None => (false, s.strip_prefix('+').unwrap_or(s)),
+        };
+        let (int, frac) = s.split_once('.').unwrap_or((s, ""));
+        if (int.is_empty() && frac.is_empty()) || !int.bytes().chain(frac.bytes()).all(|c| c.is_ascii_digit()) {
+            return None;
+        }
+        let mut mag: i128 = 0;
+        for &ch in int.as_bytes().iter().chain(frac.as_bytes()) {
+            mag = mag.checked_mul(10)?.checked_add((ch - b'0') as i128)?;
+        }
+        Some(Dec { mant: if neg { -mag } else { mag }, scale: frac.len() as u32 })
+    }
+
+    /// EXACT decimal division. The result's scale is the SMALLEST `s >= 1` at which the
+    /// quotient terminates (`0 / 2 = "0.0"`, `11.1 / 5 = "2.22"`); a non-terminating
+    /// quotient is rounded half-up at scale 18. `None` on overflow (caller falls back
+    /// to double); the caller must reject a zero divisor first (type error).
+    #[inline]
+    pub fn checked_div(self, o: Dec) -> Option<Dec> {
+        debug_assert!(o.mant != 0);
+        let neg = (self.mant < 0) != (o.mant < 0);
+        let n0 = self.mant.unsigned_abs();
+        let d = o.mant.unsigned_abs();
+        // mant(s) = n0 * 10^(s + o.scale - self.scale) / d
+        let num_den = |s: u32| -> Option<(u128, u128)> {
+            let e = s as i32 + o.scale as i32 - self.scale as i32;
+            if e >= 0 {
+                Some((n0.checked_mul(10u128.checked_pow(e as u32)?)?, d))
+            } else {
+                Some((n0, d.checked_mul(10u128.checked_pow((-e) as u32)?)?))
+            }
+        };
+        const MAX_SCALE: u32 = 18;
+        for s in 1..=MAX_SCALE {
+            let (num, den) = num_den(s)?;
+            if num % den == 0 {
+                let mant = i128::try_from(num / den).ok()?;
+                return Some(Dec { mant: if neg { -mant } else { mant }, scale: s });
+            }
+        }
+        // Non-terminating: round half-up at the max scale.
+        let (num, den) = num_den(MAX_SCALE)?;
+        let q = num / den + u128::from(num % den * 2 >= den);
+        let mant = i128::try_from(q).ok()?;
+        Some(Dec { mant: if neg { -mant } else { mant }, scale: MAX_SCALE })
+    }
+
+    /// Rounds to an integer-valued decimal (scale 0), preserving the decimal TYPE
+    /// (`CEIL("2.5"^^xsd:decimal)` is `"3"^^xsd:decimal`).
+    #[inline]
+    pub fn round_to_int(self, mode: RoundMode) -> Dec {
+        if self.scale == 0 || self.mant == 0 {
+            return Dec { mant: self.mant, scale: 0 };
+        }
+        // [OPUS-4.8] `10i128.pow(self.scale)` overflows (debug panic / release wrap) for any
+        // valid decimal whose scale is >= 39 (10^39 > i128::MAX). When the power exceeds i128
+        // the integer part is necessarily 0 (|mant| < i128::MAX < 10^scale), so |value| < 1 and
+        // also < 0.5 (2*i128::MAX < 10^39 <= 10^scale), making the rounded result obvious from
+        // the sign alone — derive it directly instead of constructing the overflowing power.
+        let mant = match 10i128.checked_pow(self.scale) {
+            Some(p) => {
+                let q = self.mant.div_euclid(p);
+                let r = self.mant.rem_euclid(p); // 0..p
+                match mode {
+                    RoundMode::Floor => q,
+                    RoundMode::Ceil => q + i128::from(r > 0),
+                    RoundMode::HalfUp => q + i128::from(r * 2 >= p),
+                }
+            }
+            None => match mode {
+                // |value| < 1: floor of a tiny positive is 0, of a tiny negative is -1.
+                RoundMode::Floor => -i128::from(self.mant < 0),
+                // ceil of a tiny positive is 1, of a tiny negative is 0.
+                RoundMode::Ceil => i128::from(self.mant > 0),
+                // |value| < 0.5 always at this scale, so half-up rounds to 0.
+                RoundMode::HalfUp => 0,
+            },
+        };
+        Dec { mant, scale: 0 }
+    }
+
     /// The value as an `f64` (lossy for mantissas beyond `f64`'s exact integer range — the
-    /// exact value lives in `mant`/`scale`). Used by the LENIENT order / arithmetic fallback
-    /// the engine owns; kept here as the drift-proof accessor the type needs.
+    /// exact value lives in `mant`/`scale`). Used by the lenient order / arithmetic fallback.
+    #[inline]
     pub fn f64(self) -> f64 {
-        (self.mant as f64) / 10f64.powi(self.scale as i32)
+        self.mant as f64 / 10f64.powi(self.scale as i32)
+    }
+
+    /// The plain (never exponent) decimal lexical at this value's scale: scale 0 prints
+    /// as an integer ("3"); otherwise exactly `scale` fraction digits ("3.0", "0.05").
+    #[inline]
+    pub fn lexical(self) -> String {
+        let mag = self.mant.unsigned_abs().to_string();
+        let s = self.scale as usize;
+        let mut out = String::with_capacity(mag.len() + s + 2);
+        if self.mant < 0 {
+            out.push('-');
+        }
+        if s == 0 {
+            out.push_str(&mag);
+            return out;
+        }
+        if mag.len() > s {
+            out.push_str(&mag[..mag.len() - s]);
+        } else {
+            out.push('0');
+        }
+        out.push('.');
+        for _ in mag.len()..s {
+            out.push('0');
+        }
+        if mag.len() > s {
+            out.push_str(&mag[mag.len() - s..]);
+        } else {
+            out.push_str(&mag);
+        }
+        out
     }
 }
 
-/// Splits a decimal lexical into `(is_negative, integer_digits, fractional_digits)` with
-/// the insignificant zeros stripped (leading zeros off the integer part, trailing zeros off
-/// the fraction), or `None` if it is not a well-formed `[+-]?digits(.digits)?`.
-///
-/// Mirrors the engine's private `exec::split_decimal` exactly, so a value classified here
-/// gets the SAME mantissa/scale the engine computes — the scaffold must not diverge from the
-/// logic it will later host.
-fn split_decimal(s: &str) -> Option<(bool, &str, &str)> {
+/// The rounding mode for [`Dec::round_to_int`] — drives `xsd:decimal` CEIL / FLOOR / ROUND.
+pub enum RoundMode {
+    /// Towards positive infinity (CEIL).
+    Ceil,
+    /// Towards negative infinity (FLOOR).
+    Floor,
+    /// Round half towards positive infinity (XPath `fn:round`).
+    HalfUp,
+}
+
+/// Splits a decimal lexical into (negative, integer-digits, fraction-digits), normalised
+/// (no leading zeros on the integer part, no trailing zeros on the fraction). `None` if
+/// the lexical is not digits with at most one `.`.
+#[inline]
+pub fn split_decimal(s: &str) -> Option<(bool, &str, &str)> {
     let s = s.trim();
     let (neg, s) = match s.strip_prefix('-') {
         Some(r) => (true, r),
@@ -81,10 +249,28 @@ fn split_decimal(s: &str) -> Option<(bool, &str, &str)> {
     Some((neg, int.trim_start_matches('0'), frac.trim_end_matches('0')))
 }
 
-/// A numeric VALUE typed by the XPath / XSD numeric tower. Comparison and arithmetic are
-/// done at the highest rank of the two operands (promotion); exact tiers (`Int` / `Dec`)
-/// avoid `f64` rounding. Mirrors the engine's private `exec::Num` variant-for-variant.
-#[derive(Clone, Copy, Debug, PartialEq)]
+/// Significant decimal digits in a numeric lexical — used to decide whether the f64
+/// sargable path is precision-safe (<= 15 digits round-trips through f64 unambiguously).
+#[inline]
+pub fn sig_digits(s: &str) -> usize {
+    let (_, int, frac) = match split_decimal(s) {
+        Some(p) => p,
+        None => return usize::MAX,
+    };
+    if int.is_empty() {
+        // 0.00123 -> significant digits start at the first non-zero fraction digit.
+        frac.trim_start_matches('0').len()
+    } else {
+        int.len() + frac.len()
+    }
+}
+
+/// A COMPUTED numeric value carrying its XSD type, implementing the SPARQL/XPath
+/// operand-type-promotion tower: integer < decimal < float < double. Arithmetic
+/// promotes both operands to the greater type; integer and decimal arithmetic is
+/// EXACT (i64 / fixed-point [`Dec`]), falling back to double only on overflow.
+/// Serialisation (see [`Num::lexical`]) is the XSD canonical form of the type.
+#[derive(Clone, Copy, Debug)]
 pub enum Num {
     /// `xsd:integer` (and its sub-types) within `i64`.
     Int(i64),
@@ -96,9 +282,22 @@ pub enum Num {
     Double(f64),
 }
 
+/// The four arithmetic operators under XPath operand promotion.
+#[derive(Clone, Copy, PartialEq)]
+pub enum ArithOp {
+    /// `+`
+    Add,
+    /// `-`
+    Sub,
+    /// `*`
+    Mul,
+    /// `/`
+    Div,
+}
+
 impl Num {
-    /// Promotion rank in the XPath numeric tower (`Int` < `Dec` < `Float` < `Double`). A
-    /// binary numeric op promotes both operands to the higher rank.
+    /// Promotion rank in the XPath numeric tower.
+    #[inline]
     pub fn rank(self) -> u8 {
         match self {
             Num::Int(_) => 0,
@@ -108,9 +307,10 @@ impl Num {
         }
     }
 
-    /// The value as an `f64`. Lossy for the exact tiers' values beyond `f64`'s exact range
-    /// (the exact value lives in the `Int` / `Dec` payload). The drift-proof accessor the
-    /// type needs; the engine's lenient order / arithmetic fallback uses it.
+    /// The value as an `f64` (lossy for the exact tiers beyond `f64`'s exact range — the
+    /// exact value lives in the `Int` / `Dec` payload). The lenient order / arithmetic
+    /// fallback uses it.
+    #[inline]
     pub fn f64(self) -> f64 {
         match self {
             Num::Int(i) => i as f64,
@@ -119,16 +319,308 @@ impl Num {
             Num::Double(d) => d,
         }
     }
+
+    /// The value as an exact [`Dec`] for the exact tiers (`Int` / `Dec`); `None` for
+    /// `Float` / `Double` (which have no exact fixed-point form).
+    #[inline]
+    pub fn to_dec(self) -> Option<Dec> {
+        match self {
+            Num::Int(i) => Some(Dec { mant: i as i128, scale: 0 }),
+            Num::Dec(d) => Some(d),
+            _ => None,
+        }
+    }
+
+    /// `op` under XPath operand promotion. `None` is a SPARQL type error (exact-type
+    /// division by zero); exact-arithmetic overflow falls back to double, mirroring
+    /// the engine's previous f64 behaviour.
+    #[inline]
+    pub fn binop(self, o: Num, op: ArithOp) -> Option<Num> {
+        let rank = self.rank().max(o.rank());
+        if rank == 3 {
+            return Some(Num::Double(apply_f64(self.f64(), o.f64(), op)));
+        }
+        if rank == 2 {
+            let (a, b) = (self.f64() as f32, o.f64() as f32);
+            return Some(Num::Float(apply_f64(a as f64, b as f64, op) as f32));
+        }
+        // Exact tier: integer / decimal.
+        let (a, b) = (self.to_dec()?, o.to_dec()?);
+        if op == ArithOp::Div {
+            // xsd:integer / xsd:integer is DECIMAL division per SPARQL; exact-type
+            // division by zero is a type error (not INF/NaN).
+            if b.mant == 0 {
+                return None;
+            }
+            return match a.checked_div(b) {
+                Some(d) => Some(Num::Dec(d)),
+                None => Some(Num::Double(self.f64() / o.f64())),
+            };
+        }
+        if rank == 0 {
+            // integer op integer -> integer (i64; on overflow fall back to double).
+            let (x, y) = (match self { Num::Int(i) => i, _ => unreachable!() }, match o { Num::Int(i) => i, _ => unreachable!() });
+            let r = match op {
+                ArithOp::Add => x.checked_add(y),
+                ArithOp::Sub => x.checked_sub(y),
+                ArithOp::Mul => x.checked_mul(y),
+                ArithOp::Div => unreachable!(),
+            };
+            return Some(match r {
+                Some(i) => Num::Int(i),
+                None => Num::Double(apply_f64(x as f64, y as f64, op)),
+            });
+        }
+        let r = match op {
+            ArithOp::Add => a.checked_add(b),
+            ArithOp::Sub => a.checked_sub(b),
+            ArithOp::Mul => a.checked_mul(b),
+            ArithOp::Div => unreachable!(),
+        };
+        Some(match r {
+            Some(d) => Num::Dec(d),
+            None => Num::Double(apply_f64(self.f64(), o.f64(), op)),
+        })
+    }
+
+    /// Unary negation, preserving the datatype (overflow falls back to double). Named `neg`
+    /// to match the SPARQL/XPath operation (not `std::ops::Neg`, which cannot carry the
+    /// datatype-promotion/overflow-fallback semantics this needs).
+    #[inline]
+    #[allow(clippy::should_implement_trait)]
+    pub fn neg(self) -> Num {
+        match self {
+            Num::Int(i) => i.checked_neg().map(Num::Int).unwrap_or(Num::Double(-(i as f64))),
+            Num::Dec(d) => d.mant.checked_neg().map(|m| Num::Dec(Dec { mant: m, scale: d.scale })).unwrap_or(Num::Double(-d.f64())),
+            Num::Float(f) => Num::Float(-f),
+            Num::Double(d) => Num::Double(-d),
+        }
+    }
+
+    /// Absolute value, preserving the datatype (overflow falls back to double).
+    #[inline]
+    pub fn abs(self) -> Num {
+        match self {
+            Num::Int(i) => i.checked_abs().map(Num::Int).unwrap_or(Num::Double((i as f64).abs())),
+            Num::Dec(d) => d.mant.checked_abs().map(|m| Num::Dec(Dec { mant: m, scale: d.scale })).unwrap_or(Num::Double(d.f64().abs())),
+            Num::Float(f) => Num::Float(f.abs()),
+            Num::Double(d) => Num::Double(d.abs()),
+        }
+    }
+
+    /// XPath `fn:ceiling`, preserving the datatype.
+    #[inline]
+    pub fn ceil(self) -> Num {
+        match self {
+            Num::Int(_) => self,
+            Num::Dec(d) => Num::Dec(d.round_to_int(RoundMode::Ceil)),
+            Num::Float(f) => Num::Float(f.ceil()),
+            Num::Double(d) => Num::Double(d.ceil()),
+        }
+    }
+
+    /// XPath `fn:floor`, preserving the datatype.
+    #[inline]
+    pub fn floor(self) -> Num {
+        match self {
+            Num::Int(_) => self,
+            Num::Dec(d) => Num::Dec(d.round_to_int(RoundMode::Floor)),
+            Num::Float(f) => Num::Float(f.floor()),
+            Num::Double(d) => Num::Double(d.floor()),
+        }
+    }
+
+    /// XPath fn:round — round half towards POSITIVE INFINITY (so round(-2.5) = -2),
+    /// preserving the argument's datatype.
+    #[inline]
+    pub fn round(self) -> Num {
+        match self {
+            Num::Int(_) => self,
+            Num::Dec(d) => Num::Dec(d.round_to_int(RoundMode::HalfUp)),
+            Num::Float(f) => Num::Float((f + 0.5).floor()),
+            Num::Double(d) => Num::Double((d + 0.5).floor()),
+        }
+    }
+
+    /// The XSD datatype IRI of this value's tier.
+    #[inline]
+    pub fn datatype(self) -> oxrdf::NamedNodeRef<'static> {
+        use oxrdf::vocab::xsd;
+        match self {
+            Num::Int(_) => xsd::INTEGER,
+            Num::Dec(_) => xsd::DECIMAL,
+            Num::Float(_) => xsd::FLOAT,
+            Num::Double(_) => xsd::DOUBLE,
+        }
+    }
+
+    /// XSD CANONICAL lexical form of the value: integers as plain digits; decimals
+    /// preserving the arithmetic scale ("3.0" for 1.0+2, "3" for CEIL(2.5)); float /
+    /// double in mantissa-E-exponent form with a mandatory fractional digit ("3.21E4",
+    /// "2.0E-1") and NaN / INF / -INF spelled per XSD.
+    #[inline]
+    pub fn lexical(self) -> String {
+        match self {
+            Num::Int(i) => i.to_string(),
+            Num::Dec(d) => d.lexical(),
+            // f32 must be formatted as f32 (shortest round-trip); via f64 it would
+            // grow spurious digits ("2.0000000298023224E-1" for 0.2f32).
+            Num::Float(f) => {
+                if f.is_nan() {
+                    "NaN".to_string()
+                } else if f == f32::INFINITY {
+                    "INF".to_string()
+                } else if f == f32::NEG_INFINITY {
+                    "-INF".to_string()
+                } else if f.fract() == 0.0 && f.abs() < 1e15 {
+                    format!("{}", f as i64)
+                } else {
+                    let s = format!("{f:E}");
+                    match s.split_once('E') {
+                        Some((m, e)) if !m.contains('.') => format!("{m}.0E{e}"),
+                        _ => s,
+                    }
+                }
+            }
+            Num::Double(d) => fmt_xsd_double(d),
+        }
+    }
+
+    /// STRICT XSD-canonical lexical: float/double ALWAYS in mantissa-E-exponent form
+    /// ("3.21E4", "1.0E2"), never plain. The W3C aggregate expected results use this
+    /// for MIN/MAX/SUM, while arithmetic results use the plain-integral convention of
+    /// [`Num::lexical`] — the suites were generated by different engines.
+    #[inline]
+    pub fn canonical_lexical(self) -> String {
+        match self {
+            Num::Int(_) | Num::Dec(_) => self.lexical(),
+            Num::Float(f) => {
+                if f.is_nan() || f.is_infinite() {
+                    self.lexical()
+                } else {
+                    let s = format!("{f:E}");
+                    match s.split_once('E') {
+                        Some((m, e)) if !m.contains('.') => format!("{m}.0E{e}"),
+                        _ => s,
+                    }
+                }
+            }
+            Num::Double(d) => {
+                if d.is_nan() || d.is_infinite() {
+                    self.lexical()
+                } else {
+                    let s = format!("{d:E}");
+                    match s.split_once('E') {
+                        Some((m, e)) if !m.contains('.') => format!("{m}.0E{e}"),
+                        _ => s,
+                    }
+                }
+            }
+        }
+    }
+
+    /// `true` if this value is a floating NaN (used by EBV and equality).
+    #[inline]
+    pub fn is_nan(self) -> bool {
+        match self {
+            Num::Float(f) => f.is_nan(),
+            Num::Double(d) => d.is_nan(),
+            _ => false,
+        }
+    }
+
+    /// `true` if this value is zero in its tier (used by EBV and exact-division guards).
+    #[inline]
+    pub fn is_zero(self) -> bool {
+        match self {
+            Num::Int(i) => i == 0,
+            Num::Dec(d) => d.mant == 0,
+            Num::Float(f) => f == 0.0,
+            Num::Double(d) => d == 0.0,
+        }
+    }
+}
+
+/// Applies `op` to two `f64` operands (the inexact-tier and overflow fallback path).
+#[inline]
+pub fn apply_f64(a: f64, b: f64, op: ArithOp) -> f64 {
+    match op {
+        ArithOp::Add => a + b,
+        ArithOp::Sub => a - b,
+        ArithOp::Mul => a * b,
+        ArithOp::Div => a / b,
+    }
+}
+
+/// Parse an xsd:float/xsd:double lexical: the XSD spellings of the specials, plus the
+/// ordinary scientific notation Rust's parser shares with XSD. `None` = ill-formed.
+#[inline]
+pub fn parse_xsd_f64(v: &str) -> Option<f64> {
+    match v {
+        "NaN" => Some(f64::NAN),
+        "INF" | "+INF" => Some(f64::INFINITY),
+        "-INF" => Some(f64::NEG_INFINITY),
+        // Rust accepts "inf"/"infinity"/"nan" spellings XSD does not; exclude them.
+        _ if v.bytes().all(|c| c.is_ascii_digit() || matches!(c, b'+' | b'-' | b'.' | b'e' | b'E')) => v.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+/// Parse an xsd:float lexical (the `f64` parse, narrowed to `f32`). `None` = ill-formed.
+#[inline]
+pub fn parse_xsd_f32(v: &str) -> Option<f32> {
+    parse_xsd_f64(v).map(|d| d as f32)
+}
+
+/// Float/double serialisation: an INTEGRAL value prints as a plain integer ("6",
+/// "1050" — matching the dominant convention across the W3C expected results, which
+/// mix plain and scientific forms); anything else uses the XSD canonical
+/// mantissa-E-exponent form with a mandatory fractional digit ("2.0E-1", "1.5E1").
+#[inline]
+pub fn fmt_xsd_double(v: f64) -> String {
+    if v.is_nan() {
+        return "NaN".to_string();
+    }
+    if v == f64::INFINITY {
+        return "INF".to_string();
+    }
+    if v == f64::NEG_INFINITY {
+        return "-INF".to_string();
+    }
+    if v.fract() == 0.0 && v.abs() < 1e15 {
+        return format!("{}", v as i64);
+    }
+    let s = format!("{v:E}"); // shortest round-trip mantissa, e.g. "2E-1"
+    match s.split_once('E') {
+        Some((m, e)) if !m.contains('.') => format!("{m}.0E{e}"),
+        _ => s,
+    }
+}
+
+/// Numeric value comparison over the promotion tower: the two exact tiers (`Int` / `Dec`)
+/// compare EXACTLY via [`Dec::cmp`]; anything inexact (or an exact-scale overflow) compares
+/// by `f64` (NaN-aware via `partial_cmp`, so `None` propagates correctly).
+#[inline]
+pub fn num_compare(a: Num, c: Num) -> Option<Ordering> {
+    if let (Some(x), Some(y)) = (a.to_dec(), c.to_dec()) {
+        if let Some(o) = x.cmp(y) {
+            return Some(o);
+        }
+    }
+    a.f64().partial_cmp(&c.f64())
 }
 
 /// The typed numeric value of a literal, or `None` if it is not a well-formed numeric (an
 /// ill-formed numeric operand is a SPARQL type error). A language-tagged literal is never
 /// numeric.
 ///
-/// SCAFFOLD note: this is the literal → tower CLASSIFICATION the substrate owns. It uses the
-/// SAME datatype predicate the engine uses (`sparq_core::is_integer_datatype`), so the
-/// integer-sub-type set is consistent. The engine's `Num::of_literal` will collapse onto this
-/// in Phase 2; until then the engine keeps its own copy (no behaviour change anywhere).
+/// This is the engine's old `Num::of_literal` MOVED HERE VERBATIM (sq-ev41x): it uses the
+/// SAME datatype predicate the engine uses (`sparq_core::is_integer_datatype`) and the SAME
+/// EXACT lexical parsers — `Dec::parse_lexical` (scale-preserving), `parse_xsd_f32` /
+/// `parse_xsd_f64` (XSD `INF` / `-INF` / `NaN` / scientific forms) — so the classification is
+/// bit-identical to pre-move. (It supersedes the Phase-1 scaffold placeholder that used
+/// `Dec::parse` / `str::parse` and so mishandled the XSD special spellings.)
+#[inline]
 pub fn as_numeric(l: &oxrdf::Literal) -> Option<Num> {
     use oxrdf::vocab::xsd;
     if l.language().is_some() {
@@ -140,21 +632,22 @@ pub fn as_numeric(l: &oxrdf::Literal) -> Option<Num> {
         if let Ok(i) = v.parse::<i64>() {
             return Some(Num::Int(i));
         }
-        // Integer beyond i64: exact i128 mantissa if it fits AND it is an integer lexical
-        // (scale 0). "1.5"^^xsd:integer is ill-formed; a too-large magnitude is unrepresentable.
+        // Integer beyond i64: exact i128 mantissa if it fits (scale 0 = integer
+        // lexical), else not representable -> double.
         return match Dec::parse(v) {
             Some(d) if d.scale == 0 => Some(Num::Dec(d)),
-            _ => None,
+            Some(_) => None, // "1.5"^^xsd:integer is ill-formed
+            None => None,
         };
     }
     if dt == xsd::DECIMAL {
-        return Dec::parse(v).map(Num::Dec);
+        return Dec::parse_lexical(v).map(Num::Dec);
     }
     if dt == xsd::FLOAT {
-        return v.parse::<f32>().ok().map(Num::Float);
+        return parse_xsd_f32(v).map(Num::Float);
     }
     if dt == xsd::DOUBLE {
-        return v.parse::<f64>().ok().map(Num::Double);
+        return parse_xsd_f64(v).map(Num::Double);
     }
     None
 }
@@ -172,7 +665,7 @@ mod tests {
     #[test]
     fn integer_literal_classifies_to_int() {
         let n = as_numeric(&typed("42", xsd::INTEGER)).expect("42 is a well-formed integer");
-        assert_eq!(n, Num::Int(42));
+        assert!(matches!(n, Num::Int(42)));
         assert_eq!(n.rank(), 0);
         assert_eq!(n.f64(), 42.0);
     }
@@ -182,7 +675,7 @@ mod tests {
         // 2^63 overflows i64 but fits an i128 mantissa with scale 0 — kept EXACT, not f64.
         let big = "9223372036854775808"; // i64::MAX + 1
         let n = as_numeric(&typed(big, xsd::INTEGER)).expect("a large integer is exact in Dec");
-        assert_eq!(n, Num::Dec(Dec { mant: 9_223_372_036_854_775_808i128, scale: 0 }));
+        assert!(matches!(n, Num::Dec(Dec { mant: 9_223_372_036_854_775_808i128, scale: 0 })));
         assert_eq!(n.rank(), 1);
     }
 
@@ -193,21 +686,37 @@ mod tests {
     }
 
     #[test]
-    fn decimal_keeps_exact_fixed_point() {
+    fn decimal_keeps_exact_fixed_point_and_written_scale() {
         // 0.1 as an EXACT decimal (mant=1, scale=1) — the f64 path would round it.
         let n = as_numeric(&typed("0.1", xsd::DECIMAL)).expect("0.1 is a well-formed decimal");
-        assert_eq!(n, Num::Dec(Dec { mant: 1, scale: 1 }));
-        assert_eq!(n.rank(), 1);
+        assert!(matches!(n, Num::Dec(Dec { mant: 1, scale: 1 })));
+        // parse_lexical PRESERVES the written scale: "1.50" keeps scale 2 (Dec::parse would
+        // normalise the trailing zero away). This is the engine semantics, not the scaffold's.
+        let n = as_numeric(&typed("1.50", xsd::DECIMAL)).expect("1.50 is a well-formed decimal");
+        assert!(matches!(n, Num::Dec(Dec { mant: 150, scale: 2 })));
     }
 
     #[test]
     fn float_and_double_classify_by_datatype() {
         let f = as_numeric(&typed("1.5", xsd::FLOAT)).expect("float");
-        assert_eq!(f, Num::Float(1.5));
+        assert!(matches!(f, Num::Float(x) if x == 1.5));
         assert_eq!(f.rank(), 2);
         let d = as_numeric(&typed("1.5", xsd::DOUBLE)).expect("double");
-        assert_eq!(d, Num::Double(1.5));
+        assert!(matches!(d, Num::Double(x) if x == 1.5));
         assert_eq!(d.rank(), 3);
+    }
+
+    #[test]
+    fn xsd_special_float_double_spellings() {
+        // The REAL engine parsers accept the XSD specials and scientific notation — the
+        // bit that the Phase-1 scaffold placeholder (str::parse) got wrong.
+        assert!(as_numeric(&typed("INF", xsd::DOUBLE)).expect("INF double").f64().is_infinite());
+        assert!(as_numeric(&typed("-INF", xsd::DOUBLE)).expect("-INF double").f64() == f64::NEG_INFINITY);
+        assert!(as_numeric(&typed("NaN", xsd::FLOAT)).expect("NaN float").is_nan());
+        assert!(matches!(as_numeric(&typed("1.5E2", xsd::DOUBLE)), Some(Num::Double(x)) if x == 150.0));
+        // Rust-only spellings XSD forbids are rejected.
+        assert!(as_numeric(&typed("infinity", xsd::DOUBLE)).is_none());
+        assert!(as_numeric(&typed("nan", xsd::DOUBLE)).is_none());
     }
 
     #[test]
@@ -224,6 +733,51 @@ mod tests {
         assert!(Dec::parse(".").is_none());
         assert!(Dec::parse("1.2.3").is_none());
         assert!(Dec::parse("1e5").is_none()); // exponential is not a decimal lexical
-        assert_eq!(Dec::parse("0.25"), Some(Dec { mant: 25, scale: 2 }));
+        assert!(matches!(Dec::parse("0.25"), Some(Dec { mant: 25, scale: 2 })));
+    }
+
+    #[test]
+    fn exact_arithmetic_is_not_f64_rounded() {
+        // 0.1 + 0.2 is EXACTLY 0.3 in the decimal tier (the f64 path gives 0.30000000000000004).
+        let a = as_numeric(&typed("0.1", xsd::DECIMAL)).unwrap();
+        let b = as_numeric(&typed("0.2", xsd::DECIMAL)).unwrap();
+        let s = a.binop(b, ArithOp::Add).unwrap();
+        assert_eq!(s.lexical(), "0.3");
+        // integer / integer is DECIMAL division per SPARQL.
+        let p = Num::Int(1).binop(Num::Int(2), ArithOp::Div).unwrap();
+        assert_eq!(p.lexical(), "0.5");
+        // exact-type division by zero is a type error (None), not INF.
+        assert!(Num::Int(1).binop(Num::Int(0), ArithOp::Div).is_none());
+    }
+
+    #[test]
+    fn promotion_and_canonical_lexical() {
+        // int + double -> double (rank 3); double canonical lexical is mantissa-E-exponent.
+        let r = Num::Int(1).binop(Num::Double(0.5), ArithOp::Add).unwrap();
+        assert!(matches!(r, Num::Double(x) if x == 1.5));
+        assert_eq!(r.canonical_lexical(), "1.5E0");
+        // an integral double prints plain via lexical(), E-form via canonical_lexical().
+        assert_eq!(Num::Double(6.0).lexical(), "6");
+        assert_eq!(Num::Double(6.0).canonical_lexical(), "6.0E0");
+    }
+
+    #[test]
+    fn rounding_preserves_type_and_half_up_to_positive_infinity() {
+        let d = as_numeric(&typed("2.5", xsd::DECIMAL)).unwrap();
+        assert_eq!(d.ceil().lexical(), "3");
+        assert_eq!(d.floor().lexical(), "2");
+        assert_eq!(d.round().lexical(), "3");
+        let nd = as_numeric(&typed("-2.5", xsd::DECIMAL)).unwrap();
+        assert_eq!(nd.round().lexical(), "-2"); // half towards +inf
+    }
+
+    #[test]
+    fn num_compare_uses_exact_tier() {
+        let a = as_numeric(&typed("0.1", xsd::DECIMAL)).unwrap();
+        let b = as_numeric(&typed("0.10", xsd::DECIMAL)).unwrap();
+        assert_eq!(num_compare(a, b), Some(Ordering::Equal));
+        assert_eq!(num_compare(Num::Int(2), Num::Double(2.5)), Some(Ordering::Less));
+        // NaN is unordered: partial_cmp yields None.
+        assert_eq!(num_compare(Num::Double(f64::NAN), Num::Int(1)), None);
     }
 }


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bead **sq-ev41x** (epic **sq-qonbz**, step 1 of the substrate move-chain). 🤖

## What this does

Behaviour-neutral **code move** of the engine's id-level **XSD numeric value tower** out of `sparq-engine::exec` and into the leaf `sparq-substrate` crate (`sparq_substrate::numeric`), so the reasoners can later share it with **no dependency cycle** (research/shared-eval-substrate.md, Phase 2). `sparq-engine` now **consumes** it.

### Moved VERBATIM (made `pub` + `#[inline]`)
- the `Num` / `Dec` / `ArithOp` / `RoundMode` types and all their methods (rank/f64/to_dec/binop/neg/abs/ceil/floor/round/datatype/lexical/canonical_lexical/is_nan/is_zero; `Dec` parse/align/checked_*/cmp/round_to_int/lexical);
- the **EXACT XSD lexical parsers** `parse_xsd_f32` / `parse_xsd_f64` (XSD `INF`/`-INF`/`NaN` + scientific forms) and `Dec::parse_lexical` (scale-preserving);
- `as_numeric` (= the engine's old `Num::of_literal`), `num_compare`, `apply_f64`, `fmt_xsd_double`, `split_decimal`, `sig_digits`.

### Critical reconciliation (per the brief)
The #1290 scaffold's `as_numeric` was a **placeholder** that used `Dec::parse` / `str::parse` and so mishandled the XSD `INF`/`NaN`/exponent spellings. This move uses the **engine's exact lexical/parse path** (`parse_xsd_*` + `Dec::parse_lexical`), so classification is **bit-identical** to pre-move.

### Stays engine-side (honest scope)
- `num_canonical_term` — builds the engine-private `Value`, which the leaf crate cannot name; kept as a thin free helper over the shared `Num::canonical_lexical` + `Num::datatype`.
- **`compare_values`** itself — it routes through the engine-private `Value` / `Term` / datetime `Timeline` model, far outside the substrate's id-level numeric charter; moving it would haul the engine's whole value layer into the leaf crate. Its numeric tier already delegates to the shared `num_compare`. The **full `compare_values` move + the join kernels** are deferred to later epic beads (see Deferred).

## Zero-overhead contract
No `Box<dyn>` / `&dyn` / vtable in the moved modules (grep + clippy confirm). Every item is `#[inline]` and monomorphic over the concrete numeric types, so with the workspace `lto = "fat"` + `codegen-units = 1` profile cross-crate inlining preserves the engine's FILTER / BIND / ORDER BY codegen (design Option C; no fall-back to Option D was needed).

## Gates (run in-worktree, both feature states)
- `cargo build` / `cargo clippy --all-targets -D warnings` / `cargo test` — **GREEN** for: `sparq-substrate` **default (features OFF)**, `sparq-substrate` with **`numeric,rows` ON**, `sparq-engine`, and the **full `--workspace` clippy**. Feature flag on the engine consumer: `sparq-substrate/numeric` (ON).
- `cargo +1.88 check` — green (substrate + engine).
- **rustdoc all-features gate**: `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — **clean** (no private-item doc-link breakage).
- **README**: `scripts/check-readme-template.py --enforce` → **0 deviations**; substrate README **74 lines** (≤120).

## Behaviour-/perf-neutrality (verified, no fabricated numbers)
- **W3C SPARQL conformance UNCHANGED**: **1225 pass / 0 fail / 4 documented divergence** = the **1229** ratchet floor; the 4 divergences are the **pre-existing** decimal lexical-form-echo ones (`cast`, `csv-tsv-res`).
- **216 engine lib tests pass** (numeric / arithmetic / ORDER BY / MIN-MAX).
- `store_bytes_per_triple` (92) / `dict_bytes_per_term` (53) untouched — the move changes no storage/dict layout.
- **wasm bundle**: deterministic **+0.048%** vs the same-arch (aarch64) pre-move baseline built on this box — a stable **LTO symbol-layout shift** from the extra crate boundary, **not new code** (the moved source is byte-for-byte identical) — well within the **+2%** `wasm_bundle_bytes` gate band. (This box is aarch64; the canonical floor 1686907 is the CI x86_64 value, so the same-arch baseline is the honest comparison.)

## Deferred (later epic sq-qonbz beads)
- Full **`compare_values`** total-order move (needs the engine `Value`/`Term`/datetime model factored, or a value-trait seam) — bead to file.
- The four **join kernels** (merge / hash / bind / leapfrog-trie) behind a `JoinKeys` descriptor (Phase 3); flip `publish = false` + add the micro-bench + SKILL surface then.

Auto-merge intentionally **not** armed (per brief).