### PR TITLE
ci(substrate): perf-neutrality no-dyn-dispatch gate + document the substrate boundary (sq-0ja86) [OPUS-4.8]

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -31,6 +31,15 @@
 #                       from advisory to HARD by sq-8ic6 once the backlog cleared (the last
 #                       stray, skills/cli/SKILL.md's inline ratio, was reworded to cite the
 #                       canonical measured source). Deterministic, grep-only, no network.
+#     • no-dyn-dispatch — perf-NEUTRALITY structural gate over the sparq-substrate hot loops
+#                       (the shared zero-overhead eval substrate, epic sq-6tykl/sq-qonbz):
+#                       FAILS if `dyn`/`Box<dyn>`/`&dyn` trait-object dispatch appears in the
+#                       leaf crate's hot paths (src/{join,numeric,rows,lib}.rs), which must stay
+#                       MONOMORPHISED so the substrate is free for sparq-engine AND the reasoners
+#                       (research/shared-eval-substrate.md §2.3/§4). Comment-aware (the source
+#                       documents the invariant in prose) + a narrow `// perf-neutrality-allow:
+#                       <reason>` per-line opt-out for a cold path. scripts/check-no-dyn-dispatch.py;
+#                       bead sq-0ja86. Deterministic, grep-only, no network, no build.
 #     • readme-template — crate-README length cap + 🚀/✨/📚 sections + License
 #                       (scripts/check-readme-template.py --enforce). PROMOTED from advisory
 #                       to HARD by sq-8ic6's deferred half once the sq-9jw5 README-overhaul
@@ -573,6 +582,36 @@ jobs:
           python-version: "3.12"
       - name: No hard-coded performance numbers in user-facing docs — GATING
         run: python3 scripts/check-no-perf-numbers.py --enforce
+
+  # [OPUS-4.8] sq-0ja86 (epic sq-6tykl / sq-qonbz — the shared zero-overhead eval substrate):
+  # a perf-NEUTRALITY structural gate. crates/sparq-substrate is a leaf crate (depends only on
+  # sparq-core) holding the shared evaluation substrate consumed by BOTH sparq-engine AND the
+  # reasoners; the maintainer invariant (research/shared-eval-substrate.md §2.3/§4) is that its
+  # hot loops — the four join kernels behind the generic JoinKeys descriptor + generic Budget
+  # cancel hook (src/join.rs) and the XSD numeric value tower (src/numeric.rs) — stay
+  # MONOMORPHISED: NO `dyn`/`Box<dyn>`/`&dyn` trait-object dispatch on a per-row / per-key-group
+  # hot loop, so the substrate is zero-overhead for both consumers and the deterministic byte
+  # ratchets (wasm_bundle_bytes, store/dict bytes) do not regress. A generic `<B: Budget>` bound
+  # is FINE (it monomorphises); a trait OBJECT is not. The check (scripts/check-no-dyn-dispatch.py)
+  # is COMMENT-AWARE (the source legitimately documents "NO Box<dyn>…" in prose) and supports a
+  # narrow `// perf-neutrality-allow: <reason>` per-line opt-out for a genuinely-cold path. It
+  # mirrors no-perf-numbers exactly: deterministic, grep-only, no network, no build, same
+  # setup-python + `python3 scripts/check-*.py` invocation. The job NAME carries no
+  # "advisory"/"informational" token, so the ci-summary aggregator gates on it — it lives on the
+  # SAME docs-quality structural-gate surface as no-perf-numbers / terminology / readme-template,
+  # not a new branch-protection required check (the only required check stays ci-summary / gate).
+  no-dyn-dispatch:
+    name: no-dyn-dispatch (substrate)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: No dynamic dispatch in the sparq-substrate hot loops (perf-neutrality) — GATING
+        run: python3 scripts/check-no-dyn-dispatch.py
 
   # [OPUS-4.8] sq-8ic6 (deferred half): PROMOTED to a HARD gate. The README-overhaul epic
   # (sq-9jw5) cleared the backlog — sq-inzv (#751) brought 20 publish=true crate READMEs to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,18 @@ If your agent runtime supports the Agent Skills standard, these load via progres
 - Conformance: the W3C SPARQL, inference, W3C SHACL (core + SPARQL), OGC GeoSPARQL and Solid WAC + ACP suites must stay green and are each **ratcheted** (the committed floor only goes up). All of them are indexed in ONE central scoreboard — `cargo run -p sparq-conformance --bin sparq-conformance-scoreboard` (registry: `crates/sparq-conformance/src/scoreboard.rs`) — so a single artifact reports every suite + its floor + the CI job that gates it. The per-suite detail reports are **generated** by that crate, not committed: the SPARQL report `conformance-report.md` is git-ignored and regenerated locally by `cargo run -p sparq-conformance` (the CI job re-runs it and publishes it as a build artifact); the inference report is committed at [`inference-conformance-report.md`](inference-conformance-report.md), and the SHACL/geo/Solid job scoreboards are emitted the same way. Performance is gated the same way against a best-ever floor (`bench/perf-baseline.json`).
 - **Merge discipline:** the gate for landing any change is *full-workspace clippy + `cargo test` + the conformance/perf ratchets*, all green. When work is done in parallel git worktrees, gate and merge **one branch at a time** with a full re-gate between merges; never edit `.beads/` files inside a worktree (it conflicts at merge — `bd export` regenerates the JSONL).
 
+### sparq-substrate (shared eval substrate)
+
+`sparq-substrate` is a **leaf crate** (depends only on `sparq-core`) holding the shared evaluation substrate consumed by **BOTH `sparq-engine` AND the reasoners**, so neither consumer depends on the other and they share one eval body (epic [sq-6tykl]/[sq-qonbz]; design `research/shared-eval-substrate.md`). It holds, behind **default-OFF features**:
+
+- `numeric` — the XSD numeric value tower (`Num`/`Dec` + `as_numeric` classification + the arithmetic ops and XSD lexical helpers), driving the engine's FILTER/BIND/ORDER BY.
+- `join` — the **four id-tuple join kernels** (sorted merge-join, radix-partitioned hash-join, index-nested-loop bind-join, leapfrog trie-join/WCOJ) behind a **generic `JoinKeys` descriptor** (the row→key projection + combine layout) and a **generic `Budget`** cooperative-cancel hook.
+- `rows` — the shared `Row`/`Key`/`Posting` id-tuple vocabulary both kernels operate on.
+
+**INVARIANT (perf-neutrality — enforced):** the hot loops are **MONOMORPHISED** — **NO `Box<dyn>`/`&dyn`/`dyn` trait-object dispatch** on any per-row / per-key-group / per-distinct-value hot loop. Generic type parameters bounded by a trait (`fn merge_join<B: Budget>(…)`) are fine (they monomorphise + inline); a trait *object* inserts a vtable the optimiser cannot inline, which would make the substrate non-zero-overhead for its two consumers and risk regressing the deterministic byte ratchets (`wasm_bundle_bytes`, store/dict bytes). This is enforced structurally by **`scripts/check-no-dyn-dispatch.py`** (the `no-dyn-dispatch (substrate)` gate in `docs-quality.yml` — comment-aware, with a narrow `// perf-neutrality-allow: <reason>` per-line opt-out for a genuinely-cold path). A new hot-path module in the crate must be added to that script's scanned set.
+
+The engine's `compare_values` total order (coupled to the engine's `Value` enum + the temporal subsystem) is the **still-engine-private deferred hoist** — it moves with `Value` in a follow-up (bead [sq-vezew]), NOT here; the join kernels deliberately do not hoist `Value` (the engine supplies its own `Value`-based compare).
+
 ## MAINTENANCE RULE (REQUIRED — read before changing any public surface)
 
 **When you change a public API, update the matching skill in the SAME change (same commit/PR).** A "public API" means any of:

--- a/scripts/check-no-dyn-dispatch.py
+++ b/scripts/check-no-dyn-dispatch.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Perf-neutrality structural gate: NO dynamic dispatch in the
+# sparq-substrate hot loops (bead sq-0ja86, epic sq-6tykl / sq-qonbz — the shared
+# zero-overhead eval substrate).
+#
+# WHY. crates/sparq-substrate is a leaf crate (depends only on sparq-core) holding the
+# shared evaluation substrate consumed by BOTH sparq-engine AND the reasoners. The
+# architectural invariant (maintainer directive, research/shared-eval-substrate.md §2.3
+# / §4) is that its hot paths — the four join kernels (merge / hash / bind / leapfrog
+# trie-join) behind the generic `JoinKeys` descriptor + generic `Budget` cancel hook,
+# and the XSD numeric value tower — must be MONOMORPHISED. A `Box<dyn …>` / `&dyn` /
+# `dyn` trait object on a per-row / per-key-group / per-distinct-value hot loop would
+# insert a vtable indirect call the optimiser cannot inline, making the substrate NOT
+# zero-overhead for its two consumers and risking a regression of the deterministic
+# byte ratchets (wasm_bundle_bytes, store/dict bytes). Generic type parameters bounded
+# by a trait (`fn merge_join<B: Budget>(…)`) are FINE — they monomorphise; trait
+# OBJECTS (`dyn`) are not. This grep enforces the distinction structurally.
+#
+# This MIRRORS scripts/check-no-perf-numbers.py (the repo's structural-grep gate
+# convention): a small Python script that scans a fixed file set, prints clear
+# `path:line:` findings, feeds the GitHub step summary, and exits non-zero on any
+# violation outside a narrow, explicitly-commented allowlist. It is deterministic
+# (grep-only, no network, no build) and is wired into the same docs-quality
+# structural-checks gate surface as check-no-perf-numbers.py.
+#
+# COMMENT-AWARE. The substrate source legitimately *mentions* "`Box<dyn>`" / "`&dyn`"
+# in its doc-comments to DOCUMENT the invariant ("there is NO `Box<dyn>` … anywhere").
+# Flagging those prose mentions would be a false positive, so Rust line comments
+# (`//`, `///`, `//!`) and block comments (`/* … */`, including doc `/** … */`) are
+# stripped before matching — exactly as the perf-numbers gate strips code fences /
+# Typst comments. Only `dyn` in actual *code* is a violation.
+#
+# ALLOWLIST. A genuinely-cold path that needs a trait object can opt out with an
+# explicit, reason-bearing trailing marker on that line:
+#     let f: Box<dyn Fn()> = …;  // perf-neutrality-allow: cold one-time planner setup
+# The marker MUST carry a non-empty reason; a bare marker is rejected so the opt-out
+# stays auditable. Use it sparingly — the whole point of the substrate is that the hot
+# loops have none.
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+
+# --- The substrate hot-path source files this gate guards. Scoped narrowly to the
+#     leaf crate's hot paths (join kernels + numeric tower + the shared row/key
+#     vocabulary they operate on) plus lib.rs, which today is module wiring + the
+#     zero-overhead doc-contract but is included so a future hot helper added there is
+#     also covered. Adding a new hot-path module to the substrate? Add it here. ---
+SUBSTRATE_HOT_PATHS = [
+    "crates/sparq-substrate/src/join.rs",
+    "crates/sparq-substrate/src/numeric.rs",
+    "crates/sparq-substrate/src/rows.rs",
+    "crates/sparq-substrate/src/lib.rs",
+]
+
+# --- The dynamic-dispatch patterns. We match the three trait-OBJECT spellings; a
+#     generic `<B: Budget>` bound is NOT matched (it monomorphises, which is the whole
+#     design). `\bdyn\b` catches `dyn Trait`, `impl SomeTrait + dyn …`, `Rc<dyn …>`,
+#     `Arc<dyn …>`, `*const dyn …`, etc.; the `Box<dyn` / `&dyn` entries make the two
+#     most common spellings explicit in the message. One match per line is enough. ---
+DYN_PATTERNS = [
+    (re.compile(r"Box\s*<\s*dyn\b"), "Box<dyn …> heap trait object"),
+    (re.compile(r"&\s*(?:'\w+\s+)?(?:mut\s+)?dyn\b"), "&dyn … borrowed trait object"),
+    (re.compile(r"\bdyn\b"), "dyn … trait object"),
+]
+
+# The explicit per-line opt-out marker for a genuinely-cold path. Must carry a reason.
+ALLOW_RE = re.compile(r"//\s*perf-neutrality-allow:\s*(\S.*)$")
+
+
+def strip_rust_comments(text: str) -> str:
+    """Replace Rust `//` line comments and `/* … */` block comments (incl. doc
+    variants `///`, `//!`, `/** … */`, `/*! … */`) with spaces, preserving line
+    structure (newlines and column count) so reported line numbers stay exact.
+
+    String/char literals are NOT specially handled: a `dyn` inside a string literal in
+    these hot-path files would itself be unusual and worth a human glance, and the
+    allowlist marker covers any real false positive. The conservative direction here is
+    to NOT silently drop a candidate match. The comment strip exists solely to avoid
+    flagging the documented invariant prose, which is the only real false-positive
+    source in this file set.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    in_line_comment = False
+    in_block_comment = False
+    while i < n:
+        c = text[i]
+        nxt = text[i + 1] if i + 1 < n else ""
+        if in_line_comment:
+            if c == "\n":
+                in_line_comment = False
+                out.append(c)
+            else:
+                out.append(" ")
+            i += 1
+            continue
+        if in_block_comment:
+            if c == "*" and nxt == "/":
+                in_block_comment = False
+                out.append("  ")
+                i += 2
+            else:
+                # Preserve newlines so line numbers don't shift.
+                out.append("\n" if c == "\n" else " ")
+                i += 1
+            continue
+        # Not currently in a comment.
+        if c == "/" and nxt == "/":
+            in_line_comment = True
+            out.append("  ")
+            i += 2
+            continue
+        if c == "/" and nxt == "*":
+            in_block_comment = True
+            out.append("  ")
+            i += 2
+            continue
+        out.append(c)
+        i += 1
+    return "".join(out)
+
+
+def scan_file(path: str) -> tuple[list[tuple[int, str, str]], list[str]]:
+    """Return (findings, warnings) for one hot-path file.
+
+    A finding is `(lineno, label, snippet)`. A line carrying a valid
+    `// perf-neutrality-allow: <reason>` marker is skipped (and not a finding). A bare
+    marker with no reason is itself reported as a finding so the opt-out can't be
+    smuggled in without justification.
+    """
+    findings: list[tuple[int, str, str]] = []
+    warnings: list[str] = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            raw = fh.read()
+    except (OSError, UnicodeDecodeError) as e:
+        # Surface, never swallow: a hot-path file we cannot read might be hiding a
+        # violation, so it counts as a failure (handled by the caller).
+        warnings.append(f"{path}: could not read: {e}")
+        return findings, warnings
+
+    raw_lines = raw.splitlines()
+    code = strip_rust_comments(raw)
+    code_lines = code.splitlines()
+
+    for idx, code_line in enumerate(code_lines):
+        lineno = idx + 1
+        raw_line = raw_lines[idx] if idx < len(raw_lines) else ""
+
+        # Does the ORIGINAL line carry an opt-out marker? (The marker lives in a
+        # comment, which strip_rust_comments removed, so test the raw line.)
+        allow_m = ALLOW_RE.search(raw_line)
+        has_allow = allow_m is not None
+        allow_reason = allow_m.group(1).strip() if allow_m else ""
+
+        match = None
+        match_label = ""
+        for pat, label in DYN_PATTERNS:
+            m = pat.search(code_line)
+            if m:
+                match = m
+                match_label = label
+                break
+
+        if match is None:
+            # No dyn in code on this line. A stray allow marker with no dyn is harmless;
+            # leave it (it documents intent and may guard a multi-line construct's head).
+            continue
+
+        if has_allow and allow_reason:
+            # Explicitly justified cold-path opt-out — permitted.
+            continue
+        if has_allow and not allow_reason:
+            findings.append((
+                lineno,
+                "empty perf-neutrality-allow (reason required)",
+                raw_line.strip(),
+            ))
+            continue
+
+        findings.append((lineno, match_label, raw_line.strip()))
+
+    return findings, warnings
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument(
+        "paths", nargs="*",
+        help="optional explicit hot-path files to scan (default: the substrate "
+             "hot-path file set). Mainly for the self-test / planted-violation check.",
+    )
+    args = ap.parse_args()
+
+    files = args.paths or SUBSTRATE_HOT_PATHS
+
+    total = 0
+    read_errors = 0
+    summary_lines: list[str] = []
+    for path in files:
+        if not os.path.exists(path):
+            # A configured hot-path file that has vanished is a real problem (the gate
+            # would silently guard nothing) — surface it as a failure.
+            read_errors += 1
+            print(f"::warning::{path}: configured hot-path file is missing")
+            summary_lines.append(f"- `{path}` — MISSING configured hot-path file")
+            continue
+        findings, warnings = scan_file(path)
+        for w in warnings:
+            read_errors += 1
+            print(f"::warning::{w}")
+            summary_lines.append(f"- `{path}` — UNREADABLE ({w})")
+        for lineno, label, snippet in findings:
+            total += 1
+            print(f"{path}:{lineno}: dynamic-dispatch [{label}]: {snippet!r}")
+            summary_lines.append(f"- `{path}:{lineno}` — {label}: `{snippet}`")
+
+    step_summary = os.environ.get("GITHUB_STEP_SUMMARY")
+    if step_summary:
+        with open(step_summary, "a", encoding="utf-8") as fh:
+            if total == 0 and read_errors == 0:
+                fh.write("### no-dyn-dispatch (substrate perf-neutrality): clean ✅\n\n"
+                         "No dynamic dispatch in the sparq-substrate hot loops — the join "
+                         "kernels and numeric tower stay monomorphised.\n")
+            else:
+                fh.write(f"### no-dyn-dispatch (substrate perf-neutrality): "
+                         f"{total} violation(s)"
+                         f"{f', {read_errors} unreadable/missing file(s)' if read_errors else ''} ❌\n\n")
+                fh.write("A `dyn` / `Box<dyn>` / `&dyn` trait object on a substrate hot path "
+                         "inserts a vtable the optimiser cannot inline — breaking the "
+                         "zero-overhead invariant (research/shared-eval-substrate.md §2.3/§4). "
+                         "Use a generic type parameter bounded by the trait instead "
+                         "(`fn …<B: Budget>(…)`), or — for a genuinely-cold path — annotate the "
+                         "line `// perf-neutrality-allow: <reason>`.\n\n")
+                for ln in summary_lines[:60]:
+                    fh.write(ln + "\n")
+                if len(summary_lines) > 60:
+                    fh.write(f"\n…and {len(summary_lines) - 60} more (see the job log).\n")
+
+    print(f"\nno-dyn-dispatch: {total} violation(s) across {len(files)} hot-path file(s)"
+          f"{f'; {read_errors} unreadable/missing file(s)' if read_errors else ''}.")
+    if total or read_errors:
+        if total:
+            print("::error::dynamic dispatch found in the sparq-substrate hot loops "
+                  "(see above) — the substrate must stay monomorphised "
+                  "(research/shared-eval-substrate.md §2.3/§4). Use a generic <B: Budget>-style "
+                  "bound, or mark a cold path `// perf-neutrality-allow: <reason>`.")
+        if read_errors:
+            print(f"::error::{read_errors} hot-path file(s) missing/unreadable — cannot certify clean.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change. Bead **sq-0ja86** (epic [sq-6tykl] / [sq-qonbz], the shared zero-overhead eval substrate).

## What & why

`crates/sparq-substrate` is a **leaf crate** (depends only on `sparq-core`) holding the shared evaluation substrate consumed by **BOTH `sparq-engine` AND the reasoners**. Its hot paths — the **four join kernels** (merge / hash / bind / leapfrog-trie-WCOJ) behind a generic `JoinKeys` descriptor + generic `Budget` cancel hook (`src/join.rs`) and the **XSD numeric value tower** (`src/numeric.rs`) — must stay **MONOMORPHISED** (maintainer directive; `research/shared-eval-substrate.md` §2.3/§4): a `dyn` / `Box<dyn>` / `&dyn` trait object on a per-row / per-key-group / per-distinct-value hot loop would insert a vtable the optimiser cannot inline, making the substrate non-zero-overhead for its two consumers and risking a regression of the deterministic byte ratchets (`wasm_bundle_bytes`, store/dict bytes). A generic `<B: Budget>` bound is fine (it monomorphises); a trait *object* is not.

This PR adds a structural CI gate enforcing that invariant, and documents the substrate boundary in `AGENTS.md`.

## Changes

- **`scripts/check-no-dyn-dispatch.py`** — a structural-grep gate that **mirrors `scripts/check-no-perf-numbers.py`** (the repo's grep-gate convention): scans the substrate hot-path source (`join.rs`, `numeric.rs`, `rows.rs`, `lib.rs`) and FAILS on `dyn` / `Box<dyn>` / `&dyn`. **Comment-aware** — the source legitimately documents the invariant in prose (`"there is NO Box<dyn> … anywhere"`), so Rust line (`//`,`///`,`//!`) + block (`/* … */`) comments are stripped before matching (mirrors the perf-numbers code-fence strip), preserving line numbers. **Narrow allowlist:** a genuinely-cold path opts out with a reason-bearing trailing marker `// perf-neutrality-allow: <reason>` (a bare marker with no reason is rejected). Deterministic — grep-only, no network, no build.
- **`.github/workflows/docs-quality.yml`** — wires it onto the **same structural-gate surface** as `no-perf-numbers`: a sibling job `no-dyn-dispatch (substrate)` with the identical `setup-python` + `python3 scripts/check-*.py` invocation style. The job name carries no `advisory`/`informational` token, so the **`ci-summary / gate` aggregator gates on it** — this is **not** a new branch-protection required check (the only required check stays `ci-summary / gate`), so it cannot retroactively block unrelated in-flight PRs. Actions stay SHA-pinned.
- **`AGENTS.md`** — a concise `### sparq-substrate (shared eval substrate)` subsection: leaf-crate / depends-only-on-`sparq-core`; the `numeric` + `join` + `rows` features; consumed by engine AND reasoners; the **monomorphisation invariant** (enforced by the script); and the still-engine-private deferred `compare_values` / `Value` / temporal hoist (bead [sq-vezew]).

## Verification (done locally)

- **(a)** `python3 scripts/check-no-dyn-dispatch.py` → `0 violation(s)`, exit **0** on origin/main's real substrate.
- **(b)** Planted `let _x: Box<dyn std::fmt::Debug> = Box::new(1);` in `join.rs` → re-ran → exit **1** with a clear message (`Box<dyn …> heap trait object`), then **removed the plant** (gate back to 0; `join.rs` has zero diff). Also confirmed the allowlist marker permits a reason-bearing cold line and rejects a bare marker.
- **(c)** `docs-quality.yml` is valid YAML (`yaml.safe_load`) and `actionlint`-clean; the new step uses the same lane/style as `check-no-perf-numbers.py`.
- **(d)** No other gate broken: `check-no-perf-numbers.py --enforce`, `markdownlint-cli2`, `check-terminology.py`, `check-privacy-claims.sh` all clean over the edited docs.

## Compliance gap closed

A **perf-neutrality structural invariant** (no dynamic dispatch in the shared substrate hot loops) is now **enforced in CI** rather than relying on review vigilance — honest level: it is a **grep-level structural guard** (it cannot prove the absence of *all* indirection, e.g. an `fn` pointer or a `Box<dyn>` introduced via a macro expansion or a re-exported generic instantiated with a trait object elsewhere), but it deterministically catches the direct `dyn` spellings the directive names, on every PR, with an auditable opt-out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)