### PR TITLE
feat(server): add the HTTP QUERY method to the SPARQL Protocol endpoint (sq-b3df9) [OPUS-4.8]

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -27,8 +27,8 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
 
 ## ✨ Features
 
-- **SPARQL 1.1 Protocol** — `query` (GET / POST direct / POST url-encoded / HEAD) and `update`
-  (`application/sparql-update` → `204`, atomic), including the protocol dataset-override params.
+- **SPARQL 1.1 Protocol** — `query` (GET / POST / HEAD / the query-only HTTP `QUERY` method, for
+  Oxigraph interop) and `update` (`application/sparql-update` → `204`, atomic) + dataset overrides.
 - **Named graphs + Graph Store Protocol** — a full RDF dataset (`GRAPH` patterns, cross-graph
   joins, `FROM`/`FROM NAMED`, graph-scoped updates through the same writer) plus GSP `GET`/`HEAD`
   read and `PUT`/`POST`/`DELETE`/`PATCH` write (indirect `?graph=`/`?default` or direct request-URI).

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -1,7 +1,9 @@
 //! The axum HTTP surface: routing, extraction, status/error semantics.
 //!
 //! Two route groups:
-//!   * `/sparql` — the SPARQL 1.1 Protocol `query` operation (GET + the two POST forms).
+//!   * `/sparql` — the SPARQL 1.1 Protocol `query` operation (GET + the two POST forms, plus
+//!     the query-only HTTP `QUERY` method — w3c/sparql-protocol#40, sq-b3df9, for Oxigraph
+//!     interop) and the `update` operation (POST).
 //!   * Graph Store HTTP Protocol — `GET`/`HEAD` (read) and, since sq-gxsj, `PUT`/`POST`/
 //!     `DELETE` (write) on `/graphs/*path` (direct) and on `/sparql/graph` via
 //!     `?graph=<uri>` / `?default` (indirect). [OPUS-4.8] The write verbs translate into a
@@ -4221,6 +4223,29 @@ async fn sparql_endpoint(
                 &url_params,
                 &url_dataset,
                 &url_using,
+                false,
+            )
+            .await
+        }
+        // [OPUS-4.8] sq-b3df9 (epic sq-my8wd, w3c/sparql-protocol#40): the HTTP `QUERY` method.
+        // Oxigraph's CLI server already serves this verb (route arm
+        // `("/sparql", "POST" | "QUERY")` with `let is_query = method == "QUERY"`). It behaves
+        // EXACTLY like a POST query EXCEPT it is query-ONLY: an `application/sparql-update` body
+        // falls through to 415, and an `update=` form field is an explicit 400. `QUERY` is not a
+        // const in `http::Method`, so it arrives via `Method::from_bytes(b"QUERY")` and is matched
+        // on its literal token (the same passthrough oxhttp gives Oxigraph). The query input path
+        // (raw body / merged `query` form param) and the URL-query-string dataset overrides feed
+        // the SAME `handle_post` downstream — query execution, Accept negotiation and the auth /
+        // egress gates are shared, so QUERY cannot bypass them.
+        ref m if m.as_str() == "QUERY" => {
+            handle_post(
+                &state,
+                &headers,
+                &body,
+                &url_params,
+                &url_dataset,
+                &url_using,
+                true,
             )
             .await
         }
@@ -4241,6 +4266,13 @@ async fn handle_post(
     // string (applies to the direct `application/sparql-update` POST; the form-POST `update=` path
     // reads it from the form BODY).
     url_using: &UsingOverride,
+    // [OPUS-4.8] sq-b3df9 (epic sq-my8wd, w3c/sparql-protocol#40): `true` when this is the HTTP
+    // `QUERY` method, which is QUERY-ONLY. It mirrors Oxigraph's `is_query` flag: an
+    // `application/sparql-update` body is NOT accepted (it falls through to 415) and a `update=`
+    // form field is rejected with an explicit 400 — a `POST` (`is_query == false`) accepts both.
+    // Per the protocol, the `default-graph-uri` / `named-graph-uri` dataset override for a `QUERY`
+    // always comes from the URL query string (`url_dataset`), even for the url-encoded form body.
+    is_query: bool,
 ) -> Response {
     let ct = content_type(headers);
     if ct.starts_with(SPARQL_QUERY_CT) {
@@ -4318,6 +4350,16 @@ async fn handle_post(
             Err(_) => return bad_request("request body is not valid UTF-8"),
         };
         let params = parse_form(s);
+        // [OPUS-4.8] sq-b3df9 (w3c/sparql-protocol#40): the HTTP `QUERY` method is query-ONLY, so
+        // an `update=` form field is rejected with an explicit 400 BEFORE any auth/work (matching
+        // Oxigraph's "SPARQL updates are not compatible with the QUERY HTTP method"). A normal
+        // `POST` (`is_query == false`) keeps accepting `update=` as a write below.
+        if is_query && params.contains_key("update") {
+            return bad_request(
+                "SPARQL updates are not compatible with the QUERY HTTP method; use POST for an \
+                 'update=' form field",
+            );
+        }
         // [OPUS-4.8] sq-zcby (Copilot PR#71 SECURITY fix): the `update=` form field IS an
         // update operation BY DEFINITION (SPARQL 1.1 Protocol §2.2), so it is a WRITE
         // UNCONDITIONALLY — regardless of whether its value happens to parse as a read-only
@@ -4416,19 +4458,19 @@ async fn handle_post(
                     }
                 };
                 let explain = explain_mode(url_params, Some(&params), headers);
-                // [OPUS-4.8] sq-z33x: per the SPARQL 1.1 Protocol url-encoded encoding, the dataset
-                // override (`default-graph-uri` / `named-graph-uri`) is carried in the FORM BODY for
-                // this content type, not the URL query string.
-                run_query(
-                    state,
-                    q,
-                    headers,
-                    false,
-                    explain,
-                    pin,
-                    &query_dataset_override(s),
-                )
-                .await
+                // [OPUS-4.8] sq-z33x: per the SPARQL 1.1 Protocol url-encoded encoding, a `POST`
+                // form carries the dataset override (`default-graph-uri` / `named-graph-uri`) in the
+                // FORM BODY. [OPUS-4.8] sq-b3df9 (w3c/sparql-protocol#40): the HTTP `QUERY` method
+                // instead always reads the dataset override from the URL query string (Oxigraph's
+                // `url_query_parameters(request)` — body graph params are not consulted on QUERY).
+                let form_dataset;
+                let dataset = if is_query {
+                    url_dataset
+                } else {
+                    form_dataset = query_dataset_override(s);
+                    &form_dataset
+                };
+                run_query(state, q, headers, false, explain, pin, dataset).await
             }
             None => bad_request("missing 'query' or 'update' parameter in url-encoded body"),
         };
@@ -4439,8 +4481,12 @@ async fn handle_post(
         #[cfg(feature = "access-audit")]
         audit_access_finish(state, aa, &resp);
         resp
-    } else if ct.starts_with("application/sparql-update") {
+    } else if ct.starts_with("application/sparql-update") && !is_query {
         // SPARQL 1.1 Protocol — update operation (T11b). Body IS the update; success → 204.
+        // [OPUS-4.8] sq-b3df9 (w3c/sparql-protocol#40): the `&& !is_query` guard mirrors Oxigraph
+        // — under the HTTP `QUERY` method an `application/sparql-update` body is NOT a valid update
+        // operation, so it falls through to the 415 branch below (NOT a 400/403); only a `POST`
+        // reaches this update path.
         // [OPUS-4.8] sq-zcby: an UPDATE is always a write — gate it before doing any work.
         // [OPUS-4.8] sq-0bxp: audit the update (fingerprint the body if it is valid UTF-8).
         #[cfg(feature = "audit-log")]
@@ -4505,10 +4551,20 @@ async fn handle_post(
         audit_access_finish(state, aa, &resp);
         resp
     } else {
-        // Unsupported media type for the POST query operation.
+        // Unsupported media type for the query/update operation. [OPUS-4.8] sq-b3df9
+        // (w3c/sparql-protocol#40): under the HTTP `QUERY` method `application/sparql-update`
+        // is NOT accepted (the `&& !is_query` guard above sent it here) — Oxigraph parity is a
+        // 415, not a 400/403, since QUERY is query-only.
         json_error(
             StatusCode::UNSUPPORTED_MEDIA_TYPE,
-            "POST requires Content-Type 'application/sparql-query' or 'application/x-www-form-urlencoded'",
+            if is_query {
+                "the QUERY method requires Content-Type 'application/sparql-query' or \
+                 'application/x-www-form-urlencoded' (it is query-only; \
+                 'application/sparql-update' is not accepted — use POST)"
+            } else {
+                "POST requires Content-Type 'application/sparql-query' or \
+                 'application/x-www-form-urlencoded'"
+            },
         )
     }
 }
@@ -6545,9 +6601,11 @@ async fn security_headers(mut resp: Response) -> Response {
 
 /// The methods advertised in a CORS preflight response. The HTTP surface accepts GET /
 /// HEAD / POST (SPARQL query + the GSP read/write verbs) plus OPTIONS itself; PUT /
-/// DELETE are the GSP write verbs. A browser's actual request is still subject to every
-/// other guard (auth, body limit, …) — advertising a method here does not bypass them.
-const CORS_ALLOW_METHODS: &str = "GET, HEAD, POST, PUT, DELETE, OPTIONS";
+/// DELETE are the GSP write verbs; QUERY is the SPARQL Protocol query verb
+/// (w3c/sparql-protocol#40, sq-b3df9) so a browser can preflight a `fetch(…, {method:
+/// 'QUERY'})`. A browser's actual request is still subject to every other guard (auth,
+/// body limit, …) — advertising a method here does not bypass them. [OPUS-4.8]
+const CORS_ALLOW_METHODS: &str = "GET, HEAD, POST, PUT, DELETE, QUERY, OPTIONS";
 
 /// The request headers advertised as allowed in a preflight when the browser does not
 /// send its own `Access-Control-Request-Headers` (we otherwise reflect that list). Covers

--- a/crates/sparq-server/tests/auth.rs
+++ b/crates/sparq-server/tests/auth.rs
@@ -344,6 +344,50 @@ async fn reads_gated_when_read_gate_on() {
     assert_eq!(count_rows_authed(&cl, &base, TOKEN).await, 1);
 }
 
+/// [OPUS-4.8] sq-b3df9 (w3c/sparql-protocol#40): the HTTP `QUERY` method enforces the SAME
+/// `--auth-token-read` gate as GET/POST — it is a read on the dataset and must NOT bypass the
+/// hot auth path. No header => 401 + `WWW-Authenticate: Bearer`; correct token => 200.
+#[tokio::test]
+async fn query_method_gated_when_read_gate_on() {
+    let base = spawn_with(token_config(true)).await;
+    let cl = client();
+    let query_method = reqwest::Method::from_bytes(b"QUERY").unwrap();
+
+    // QUERY with NO Authorization header => 401 (the read gate), NOT 200/400 — the auth gate
+    // runs before the query handler ever sees the body.
+    let unauth = cl
+        .request(query_method.clone(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .body(SELECT)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        unauth.status(),
+        401,
+        "QUERY must be gated with --auth-token-read"
+    );
+    assert_eq!(
+        unauth
+            .headers()
+            .get("www-authenticate")
+            .map(|v| v.to_str().unwrap()),
+        Some("Bearer")
+    );
+
+    // With the Bearer token => 200 (the request reaches the shared query path).
+    let authed = cl
+        .request(query_method, format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .header("authorization", format!("Bearer {TOKEN}"))
+        .header("accept", "application/sparql-results+json")
+        .body(SELECT)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(authed.status(), 200, "QUERY with the read token must pass");
+}
+
 // ---------------------------------------------------------------------------
 // [OPUS-4.8] sq-9jrx: /metrics is a READ (it leaks the live triple count and the
 // active-subscription count), so it is gated by --auth-token-read like any other

--- a/crates/sparq-server/tests/query_method.rs
+++ b/crates/sparq-server/tests/query_method.rs
@@ -1,0 +1,428 @@
+//! Integration tests for the HTTP `QUERY` method on the SPARQL Protocol endpoint
+//! (sq-b3df9, epic sq-my8wd, w3c/sparql-protocol#40).
+//!
+//! The `QUERY` verb is a query-ONLY input path that feeds the SAME downstream query
+//! execution + Accept-based content negotiation as GET/POST. These tests drive the real
+//! axum server over real HTTP using exactly the bytes an Oxigraph client would send, so
+//! the two interoperate:
+//!   * the raw SPARQL string IS the body under `Content-Type: application/sparql-query`;
+//!   * OR the `query=` parameter of an `application/x-www-form-urlencoded` body;
+//!   * `default-graph-uri` / `named-graph-uri` come from the URL query string;
+//!   * Accept negotiates SRJ / SRX / CSV / TSV (SELECT/ASK) and RDF (CONSTRUCT/DESCRIBE),
+//!     reusing the SAME negotiation as GET/POST (sparq defaults unsatisfiable Accepts to JSON
+//!     rather than 406 — a documented sparq-vs-Oxigraph difference, see the relevant test);
+//!   * an `update=` form field is a 400 and `application/sparql-update` is a 415 (query-only).
+//!
+//! [OPUS-4.8] Gate the whole suite on the `server` feature (it spins the real axum server
+//! and uses the `server`-gated `router` / `AppState` API). 🤖 SPARQ agent.
+#![cfg(feature = "server")]
+
+use sparq_core::Graph;
+use sparq_server::{router, AppState};
+use tokio::net::TcpListener;
+
+const DATA: &str = r#"
+    @prefix ex: <http://ex/> .
+    ex:alice ex:knows ex:bob ; ex:age 30 ; ex:name "Alice" .
+    ex:bob   ex:age 25 ; ex:name "Bob"@en .
+    ex:carol ex:age 35 .
+"#;
+
+const NQ_DATASET: &str = r#"
+    <http://ex/d> <http://ex/p> <http://ex/in_default> .
+    <http://ex/a> <http://ex/p> <http://ex/in_g1> <http://ex/g1> .
+    <http://ex/b> <http://ex/p> <http://ex/in_g2> <http://ex/g2> .
+"#;
+
+/// Boots the server on a random local port and returns its base URL.
+async fn spawn() -> String {
+    let graph = Graph::load_str(DATA, "turtle").unwrap();
+    spawn_with(graph).await
+}
+
+/// Boots a server over [`NQ_DATASET`] (a default graph + named graphs g1, g2).
+async fn spawn_dataset() -> String {
+    let graph = Graph::load_dataset(NQ_DATASET, "nquads").unwrap();
+    spawn_with(graph).await
+}
+
+async fn spawn_with(graph: Graph) -> String {
+    let app = router(AppState::new(graph));
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+/// The custom HTTP method token an Oxigraph client sends (oxhttp passes "QUERY" through;
+/// reqwest carries it the same way via `Method::from_bytes`).
+fn query_method() -> reqwest::Method {
+    reqwest::Method::from_bytes(b"QUERY").unwrap()
+}
+
+fn json_row_count(body: &str) -> usize {
+    let v: serde_json::Value = serde_json::from_str(body).unwrap();
+    v["results"]["bindings"]
+        .as_array()
+        .map(|a| a.len())
+        .unwrap_or(0)
+}
+
+// ---------------------------------------------------------------------------
+// (1) Content-Type: application/sparql-query — raw query IS the body
+// ---------------------------------------------------------------------------
+
+/// The canonical Oxigraph-interop form: `QUERY /sparql` with the raw SPARQL string as the
+/// `application/sparql-query` body, negotiating SPARQL-results JSON. Same downstream
+/// execution as POST, so the same three `ex:age` subjects come back.
+#[tokio::test]
+async fn query_method_direct_body_json() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .header("accept", "application/sparql-results+json")
+        .body("SELECT ?s WHERE { ?s <http://ex/age> ?a }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()["content-type"],
+        "application/sparql-results+json"
+    );
+    let body = resp.text().await.unwrap();
+    assert_eq!(json_row_count(&body), 3, "three subjects have ex:age: {body}");
+}
+
+/// A `Content-Type` with parameters (`; charset=utf-8`) still matches — the server strips
+/// everything after `;` and lowercases, exactly like Oxigraph.
+#[tokio::test]
+async fn query_method_content_type_with_charset_param() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query; charset=utf-8")
+        .body("ASK { <http://ex/alice> <http://ex/knows> <http://ex/bob> }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert!(resp.text().await.unwrap().contains("true"));
+}
+
+// ---------------------------------------------------------------------------
+// (2) Content-Type: application/x-www-form-urlencoded — query= in the body
+// ---------------------------------------------------------------------------
+
+/// The url-encoded form carries the query as the `query=` body parameter (Oxigraph merges
+/// body+URL `query` parameters; here it is in the body).
+#[tokio::test]
+async fn query_method_urlencoded_form() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("accept", "application/sparql-results+json")
+        .form(&[("query", "SELECT ?s WHERE { ?s <http://ex/age> ?a }")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(json_row_count(&resp.text().await.unwrap()), 3);
+}
+
+// ---------------------------------------------------------------------------
+// Accept negotiation — SRJ / SRX / CSV / TSV (SELECT/ASK) and RDF (CONSTRUCT)
+// ---------------------------------------------------------------------------
+
+async fn select_with_accept(base: &str, accept: &str) -> reqwest::Response {
+    client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .header("accept", accept)
+        .body("SELECT ?s WHERE { ?s <http://ex/age> ?a }")
+        .send()
+        .await
+        .unwrap()
+}
+
+#[tokio::test]
+async fn query_method_accept_xml() {
+    let base = spawn().await;
+    let resp = select_with_accept(&base, "application/sparql-results+xml").await;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()["content-type"],
+        "application/sparql-results+xml"
+    );
+    assert!(resp.text().await.unwrap().contains("<sparql"));
+}
+
+#[tokio::test]
+async fn query_method_accept_csv() {
+    let base = spawn().await;
+    let resp = select_with_accept(&base, "text/csv").await;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.headers()["content-type"], "text/csv; charset=utf-8");
+}
+
+#[tokio::test]
+async fn query_method_accept_tsv() {
+    let base = spawn().await;
+    let resp = select_with_accept(&base, "text/tab-separated-values").await;
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()["content-type"],
+        "text/tab-separated-values; charset=utf-8"
+    );
+}
+
+/// No Accept header → SPARQL-results JSON for solutions (the protocol default), NOT a 406.
+#[tokio::test]
+async fn query_method_no_accept_defaults_to_json() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .body("SELECT ?s WHERE { ?s <http://ex/age> ?a }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()["content-type"],
+        "application/sparql-results+json"
+    );
+}
+
+/// CONSTRUCT under QUERY negotiates an RDF format on Accept (Turtle here). sparq's graph
+/// serialiser emits an N-Triples body (a syntactic subset of Turtle) under the negotiated
+/// `text/turtle` Content-Type — identical to the GET/POST path
+/// (`protocol::construct_negotiates_turtle`), so the QUERY input path reuses it unchanged.
+#[tokio::test]
+async fn query_method_construct_rdf() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .header("accept", "text/turtle")
+        .body("PREFIX ex: <http://ex/> CONSTRUCT { ?s ex:years ?a } WHERE { ?s ex:age ?a }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.headers()["content-type"], "text/turtle; charset=utf-8");
+    // The body is N-Triples (a Turtle subset), so it loads as Turtle: alice/bob/carol's ages.
+    let body = resp.text().await.unwrap();
+    assert_eq!(Graph::load_str(&body, "turtle").unwrap().len(), 3);
+    assert!(body.contains("<http://ex/years>"), "got {body}");
+}
+
+/// An Accept naming only unsupported solution media types falls back to SPARQL-results JSON,
+/// matching sparq's house negotiation for GET/POST (`negotiate::defaults_to_json`): sparq
+/// defaults rather than 406. NB this is a documented sparq-vs-Oxigraph negotiation difference
+/// (Oxigraph 406s an unsatisfiable Accept); the QUERY input path reuses the SAME negotiation
+/// as GET/POST, so changing it is out of scope for this bead (it would alter GET/POST too).
+#[tokio::test]
+async fn query_method_unsupported_accept_falls_back_to_json() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .header("accept", "image/png")
+        .body("SELECT ?s WHERE { ?s <http://ex/age> ?a }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(
+        resp.headers()["content-type"],
+        "application/sparql-results+json"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Dataset graph params — from the URL query string (NOT the body)
+// ---------------------------------------------------------------------------
+
+/// `default-graph-uri=g1` (URL query string) re-scopes the active default graph to g1, even
+/// when the query is sent as the raw `application/sparql-query` body — the graph params come
+/// from the URL, never the body (Oxigraph's `url_query_parameters`).
+#[tokio::test]
+async fn query_method_default_graph_uri_from_url() {
+    let base = spawn_dataset().await;
+    let resp = client()
+        .request(
+            query_method(),
+            format!("{base}/sparql?default-graph-uri=http://ex/g1"),
+        )
+        .header("content-type", "application/sparql-query")
+        .header("accept", "application/sparql-results+json")
+        .body("SELECT ?s ?p ?o WHERE { ?s ?p ?o }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert_eq!(json_row_count(&body), 1);
+    assert!(body.contains("http://ex/in_g1"), "expected g1's triple: {body}");
+    assert!(!body.contains("in_default"), "store default graph must drop out: {body}");
+}
+
+/// The dataset params are read from the URL query string even for the url-encoded FORM body
+/// (Oxigraph reads graph params via `url_query_parameters`, not the body, on QUERY).
+#[tokio::test]
+async fn query_method_named_graph_uri_from_url_with_form_body() {
+    let base = spawn_dataset().await;
+    let resp = client()
+        .request(
+            query_method(),
+            format!("{base}/sparql?named-graph-uri=http://ex/g1"),
+        )
+        .header("accept", "application/sparql-results+json")
+        .form(&[("query", "SELECT ?s ?p ?o WHERE { GRAPH ?g { ?s ?p ?o } }")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body = resp.text().await.unwrap();
+    assert_eq!(json_row_count(&body), 1, "only g1 is a named graph: {body}");
+    assert!(body.contains("http://ex/in_g1"), "got {body}");
+}
+
+// ---------------------------------------------------------------------------
+// Query-only rejections — update= (400) and application/sparql-update (415)
+// ---------------------------------------------------------------------------
+
+/// An `update=` form field under QUERY → 400 (Oxigraph: "SPARQL updates are not compatible
+/// with the QUERY HTTP method"). The data must NOT change.
+#[tokio::test]
+async fn query_method_form_update_is_400() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .form(&[(
+            "update",
+            "INSERT DATA { <http://ex/x> <http://ex/y> <http://ex/z> }",
+        )])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+/// `Content-Type: application/sparql-update` under QUERY → 415 (the `&& !is_query` guard
+/// fails and it falls through to unsupported-media-type, NOT a 400/403). Under POST the same
+/// body is a valid update — see `protocol::sparql_update_insert_then_query`, unchanged.
+#[tokio::test]
+async fn query_method_sparql_update_content_type_is_415() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .body("INSERT DATA { <http://ex/x> <http://ex/y> <http://ex/z> }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 415);
+}
+
+// ---------------------------------------------------------------------------
+// Other status semantics — body / Content-Type edge cases
+// ---------------------------------------------------------------------------
+
+/// Empty body with `application/sparql-query` → empty query string → parse failure → 400.
+#[tokio::test]
+async fn query_method_empty_body_is_400() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .body("")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+/// A malformed query string → 400.
+#[tokio::test]
+async fn query_method_malformed_query_is_400() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .body("SELECT WHERE {")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+/// A wrong/unknown Content-Type (`text/plain`) → 415 (only `application/sparql-query` and
+/// `application/x-www-form-urlencoded` are accepted, matching Oxigraph).
+#[tokio::test]
+async fn query_method_wrong_content_type_is_415() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "text/plain")
+        .body("SELECT ?s WHERE { ?s <http://ex/age> ?a }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 415);
+}
+
+/// A url-encoded form body with neither `query` nor `update` → 400.
+#[tokio::test]
+async fn query_method_form_missing_query_is_400() {
+    let base = spawn().await;
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body("foo=bar")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+}
+
+// ---------------------------------------------------------------------------
+// No regression to GET/POST — QUERY is additive
+// ---------------------------------------------------------------------------
+
+/// A still-unsupported method (DELETE) on `/sparql` stays a 405 — adding QUERY did not open
+/// the door to arbitrary verbs.
+#[tokio::test]
+async fn query_method_does_not_open_arbitrary_verbs() {
+    let base = spawn().await;
+    let resp = client()
+        .request(reqwest::Method::DELETE, format!("{base}/sparql"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 405);
+}
+
+/// POST query still works after the QUERY arm was added (regression guard).
+#[tokio::test]
+async fn post_query_still_works_alongside_query_method() {
+    let base = spawn().await;
+    let resp = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .header("accept", "application/sparql-results+json")
+        .body("SELECT ?s WHERE { ?s <http://ex/age> ?a }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    assert_eq!(json_row_count(&resp.text().await.unwrap()), 3);
+}

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: http-server
-description: Run or point an agent at a sparq SPARQL 1.1 Protocol HTTP endpoint (sparq-server) — /sparql query+update over GET/POST, content negotiation (SELECT/ASK JSON/XML/CSV/TSV; CONSTRUCT/DESCRIBE + Graph Store N-Triples/prefix-Turtle/RDF-XML/JSON-LD — JSON-LD via the default-on jsonld feature), Graph Store read AND write (PUT/POST/DELETE/PATCH on graph resources, RDF/XML + default-on JSON-LD bodies accepted, atomic SPARQL-Update + opt-in Solid N3-Patch on PATCH), EXPLAIN, Prometheus /metrics, WebSocket + SSE subscriptions, and opt-in time-travel ?generation pinning. Use when starting the server, querying/updating a running endpoint, choosing Accept/Content-Type, or embedding the axum router.
+description: Run or point an agent at a sparq SPARQL 1.1 Protocol HTTP endpoint (sparq-server) — /sparql query+update over GET/POST (plus the query-only HTTP QUERY method, w3c/sparql-protocol#40, for Oxigraph interop), content negotiation (SELECT/ASK JSON/XML/CSV/TSV; CONSTRUCT/DESCRIBE + Graph Store N-Triples/prefix-Turtle/RDF-XML/JSON-LD — JSON-LD via the default-on jsonld feature), Graph Store read AND write (PUT/POST/DELETE/PATCH on graph resources, RDF/XML + default-on JSON-LD bodies accepted, atomic SPARQL-Update + opt-in Solid N3-Patch on PATCH), EXPLAIN, Prometheus /metrics, WebSocket + SSE subscriptions, and opt-in time-travel ?generation pinning. Use when starting the server, querying/updating a running endpoint, choosing Accept/Content-Type, or embedding the axum router.
 ---
 
 # sparq-http-server
@@ -96,6 +96,14 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
 # POST direct: body IS the query
 curl http://127.0.0.1:3030/sparql -H 'Content-Type: application/sparql-query' \
      --data 'ASK { ?s ?p ?o }'
+
+# HTTP QUERY method (sq-b3df9, w3c/sparql-protocol#40) — query-only, interoperates with
+# Oxigraph: body IS the query under Content-Type application/sparql-query; graph params
+# (default-graph-uri / named-graph-uri) ride the URL query string. Same downstream query
+# execution + Accept negotiation as POST; an update= form or application/sparql-update body
+# is rejected (400 / 415).
+curl -X QUERY http://127.0.0.1:3030/sparql -H 'Content-Type: application/sparql-query' \
+     -H 'Accept: application/sparql-results+json' --data 'SELECT * WHERE { ?s ?p ?o } LIMIT 5'
 
 # POST url-encoded form, negotiate CSV
 curl http://127.0.0.1:3030/sparql -H 'Accept: text/csv' \
@@ -279,6 +287,30 @@ curl -G http://127.0.0.1:3030/sparql -H 'Accept: application/rdf+xml' \
 curl -G http://127.0.0.1:3030/sparql -H 'Accept: application/ld+json' \
      --data-urlencode 'query=CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }'
 ```
+
+> **HTTP `QUERY` method (sq-b3df9, w3c/sparql-protocol#40, epic sq-my8wd) — query-only,
+> Oxigraph-interop.** `/sparql` accepts the registered HTTP `QUERY` verb in addition to
+> GET/POST. It is a new INPUT path that feeds the SAME query execution + Accept negotiation as
+> POST, so all the result-media rows above apply unchanged. Mirroring Oxigraph
+> (`("/sparql", "POST" | "QUERY")`, `let is_query = method == "QUERY"`):
+> - **Send the query** as the raw `application/sparql-query` body (preferred), OR as the
+>   `query=` value of an `application/x-www-form-urlencoded` body. No other Content-Type is
+>   accepted (else **415**); missing Content-Type is **415**.
+> - **Dataset graphs** (`default-graph-uri` / `named-graph-uri` / `union-default-graph`) ride
+>   the **URL query string**, never the body — even when the query is the raw body.
+> - **Query-only:** an `update=` form field is a **400** and an `application/sparql-update`
+>   body is a **415** (it is not a valid operation under QUERY). Use POST for an update.
+> - It enforces the SAME auth / egress gates as GET/POST (a QUERY is a read — gated by
+>   `--auth-token-read`). It does **not** emit `Cache-Control` / `Content-Location` headers
+>   (Oxigraph does not either). [OPUS-4.8]
+> ```sh
+> curl -X QUERY 'http://127.0.0.1:3030/sparql?default-graph-uri=http://ex/g1' \
+>      -H 'Content-Type: application/sparql-query' \
+>      -H 'Accept: text/csv' \
+>      --data 'SELECT * WHERE { ?s ?p ?o }'
+> ```
+
+<!-- [OPUS-4.8] sq-b3df9: comment separates the two adjacent blockquotes (markdownlint MD028). -->
 
 > **JSON-LD content negotiation (`jsonld` feature — default-on, [OPUS-4.8] sq-oy1f.4).** The
 > server speaks `application/ld+json` out of the box (the `jsonld` feature is in the default set —


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead `sq-b3df9` (epic `sq-my8wd`).

## What

Adds the query-only **HTTP `QUERY` method** to the `sparq-server` SPARQL Protocol
endpoint (`/sparql`), interoperating with **Oxigraph** over HTTP QUERY
([w3c/sparql-protocol#40](https://github.com/w3c/sparql-protocol/issues/40), confirmed
supported by Oxigraph maintainer `Tpt`).

`QUERY` is a new **INPUT path** that feeds the **same** downstream query execution +
Accept-based content negotiation as GET/POST, so it inherits the existing serialisers
and — load-bearing — the existing auth/egress gates in `http.rs` (it does **not** bypass
the hot auth path).

## Contract (mirrors Oxigraph's `("/sparql", "POST" | "QUERY")` + `let is_query = method == "QUERY"`)

- **Query carried in the body:** raw SPARQL string under `Content-Type:
  application/sparql-query` (preferred), OR `query=` in an
  `application/x-www-form-urlencoded` body.
- **Dataset graphs from the URL query string:** `default-graph-uri` / `named-graph-uri`
  ride the URL query string, **never** the body — even when the query is the raw body
  (Oxigraph's `url_query_parameters`).
- **Query-only:** an `update=` form field → **400**; an `application/sparql-update` body
  → **415** (the `&& !is_query` guard falls through to unsupported-media-type). Use POST
  for an update.
- **Status/edge cases:** empty body → 400; malformed query → 400; wrong/missing
  Content-Type → 415; `QUERY` matched on its literal method token
  (`Method::from_bytes(b"QUERY")` via axum's `any(...)`).
- **Auth:** same `--auth-token-read` gate as GET/POST (a QUERY is a read).
- `QUERY` is added to the CORS preflight `Access-Control-Allow-Methods`.

No new cargo feature — `QUERY` is a **default endpoint capability** alongside GET/POST
(it adds no dependency and `sparq-core`/`sparq-engine` are untouched).

## Honest boundary — sparq vs Oxigraph negotiation

sparq's content negotiation (shared with GET/POST) **defaults an unsatisfiable `Accept`
to SPARQL-results JSON** rather than returning **406** as Oxigraph does. This is a
pre-existing sparq house behaviour reused by the QUERY input path; changing it would
alter GET/POST too and is **out of scope** for this bead. The interop suite documents and
asserts the actual sparq behaviour (a regression bead can revisit a strict-406 mode).

## Tests

- **`tests/query_method.rs`** (new, 19 tests) — sends exactly what an Oxigraph client
  would: raw `application/sparql-query` body + url-encoded form; SRJ/SRX/CSV/TSV +
  CONSTRUCT-Turtle negotiation; `default-graph-uri`/`named-graph-uri` from the URL (incl.
  with a form body); the 400 (`update=`) / 415 (`application/sparql-update`) query-only
  rejections; empty body, wrong Content-Type, malformed-query, missing-`query` edge cases;
  and POST/DELETE regression guards.
- **`tests/auth.rs`** — a new test proves the `--auth-token-read` gate is enforced under
  QUERY (no header → 401 + `WWW-Authenticate: Bearer`; correct token → 200).

## Gates (run in-worktree, BOTH feature states)

- `cargo test -p sparq-server` — green (default features) **and** `--all-features` (34
  test binaries, incl. the new suites, 0 failures).
- `cargo clippy -p sparq-server --all-targets -- -D warnings` — clean for **default**,
  **`--all-features`**, and **`--no-default-features`**.
- `cargo +1.88 check -p sparq-server` (MSRV) — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean
  (the bundled rustdoc half of the `clippy (gate)` lane).
- `python3 scripts/check-readme-template.py --enforce` — **0 deviations**; README ≤120
  lines.

No regression to the existing GET/POST query/update handlers or auth.

Refs: `sq-b3df9` (epic `sq-my8wd`), w3c/sparql-protocol#40.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
