### PR TITLE
feat(service): port-scoped SSRF egress allowlist entries (sq-a7jw4) [OPUS-4.8]

### DIFF
--- a/crates/sparq-engine/src/service.rs
+++ b/crates/sparq-engine/src/service.rs
@@ -901,6 +901,25 @@ pub(crate) fn is_forbidden_ip(ip: std::net::IpAddr) -> bool {
 /// as written in the SERVICE IRI authority) on this list is exempt from
 /// [`is_forbidden_ip`] — its resolved addresses are permitted even when private.
 ///
+/// ## Port scoping ([OPUS-4.8] sq-a7jw4)
+///
+/// An allowlist entry may be **host-level** (`sparql.internal`, `127.0.0.1`,
+/// `.example.org`) or **port-scoped** (`127.0.0.1:8053`, `sparql.internal:8443`,
+/// `.example.org:443`). A host-level entry keeps its original meaning — it permits the
+/// host on *every* port. A port-scoped entry is strictly NARROWER: it permits the host
+/// ONLY on that exact port and rejects every other port on the same host. This lets a
+/// deployer (or the in-process loopback SERVICE federation harness) re-open exactly
+/// `127.0.0.1:<ephemeral>` without re-opening the whole loopback host. There is no
+/// wildcard port — a port-scoped entry tightens, never loosens; default-deny stays
+/// default-deny.
+///
+/// The port checked is the SERVICE IRI authority's port (its explicit `:port`, or the
+/// scheme default 443/80), which is exactly the port `to_socket_addrs(host:port)` dials
+/// for *every* resolved address — so port-scoping applies to the post-resolution connect
+/// target and cannot be bypassed by DNS rebinding (the resolved IP is still re-vetted by
+/// [`is_forbidden_ip`] at connect time; the allowlist exemption only fires when BOTH the
+/// host pattern AND the port constraint match).
+///
 /// Two modes (the [`Mode`] flag), both default-deny but at different strictnesses:
 ///
 /// * **`Mode::DenyPrivate`** (the engine's standalone default, installed by
@@ -967,28 +986,81 @@ pub(crate) mod egress_policy {
         POLICY.with(|p| Guard(Some(std::mem::replace(&mut *p.borrow_mut(), next))))
     }
 
-    /// True if `host` (case-insensitive) is on the active allowlist. An entry is
-    /// matched two ways: [OPUS-4.8] (sq-4w18)
-    ///   * **exact** — the entry equals the host (`"sparql.example.org"`).
-    ///   * **suffix wildcard** — an entry beginning with a dot (`".example.org"`)
+    /// Split one allowlist entry into its `(host_pattern, port_constraint)`. [OPUS-4.8] (sq-a7jw4)
+    ///
+    /// An entry is **port-scoped** (`Some(port)`) only when it carries an *unambiguous*
+    /// trailing `:port`; otherwise it is **host-level** (`None` = every port). The split is
+    /// conservative so a bare IPv6 literal is never amputated:
+    ///   * `[::1]:8053` / `[2001:db8::1]:443` — bracketed IPv6 + port → `("::1", Some(8053))`
+    ///     (brackets are stripped from the host pattern, mirroring `is_allowed`'s bare-host key).
+    ///   * `127.0.0.1:8053` / `sparql.internal:8443` / `.example.org:443` — a single-colon
+    ///     `host:digits` (the suffix dot is part of the host pattern) → `Some(port)`.
+    ///   * `::1` / `2001:db8::1` — a bare (unbracketed) multi-colon IPv6 literal → `None`
+    ///     (the trailing hextet is NOT read as a port).
+    ///   * `sparql.internal` / `.example.org` / `127.0.0.1` — no colon → `None`.
+    ///
+    /// A `:port` whose digits do not parse as a `u16` (or is empty) is treated as part of
+    /// the host pattern (it will simply never match a real authority) rather than silently
+    /// dropping the port constraint — fail-closed, never fail-open.
+    pub(crate) fn split_entry(entry: &str) -> (&str, Option<u16>) {
+        // Bracketed IPv6 authority: `[addr]` or `[addr]:port`.
+        if let Some(rest) = entry.strip_prefix('[') {
+            if let Some((inner, after)) = rest.split_once(']') {
+                let port = after
+                    .strip_prefix(':')
+                    .and_then(|p| p.parse::<u16>().ok());
+                return (inner, port);
+            }
+            return (entry, None); // malformed (no closing bracket) — host pattern as-is
+        }
+        // Unbracketed. Only a single-colon `host:port` is a port-bearing authority; a
+        // multi-colon string is a bare IPv6 literal whose last hextet must NOT be read as
+        // a port (e.g. `2001:db8::1`).
+        if let Some((host, port)) = entry.split_once(':') {
+            if !host.contains(':') && !port.contains(':') {
+                if let Ok(p) = port.parse::<u16>() {
+                    return (host, Some(p));
+                }
+            }
+        }
+        (entry, None)
+    }
+
+    /// True iff `host_pattern` (an entry's host part, already lower-cased) matches the
+    /// lower-cased connect host `h`: exact, or a leading-dot suffix wildcard. [OPUS-4.8]
+    ///   * **exact** — the pattern equals the host (`"sparql.example.org"`).
+    ///   * **suffix wildcard** — a pattern beginning with a dot (`".example.org"`)
     ///     matches any host ending in that suffix INCLUDING the bare apex
-    ///     (`example.org`, `a.example.org`, `a.b.example.org`). This is the engine
-    ///     representation of the server's `*.example.org` pattern. The leading-dot
+    ///     (`example.org`, `a.example.org`, `a.b.example.org`). The leading-dot
     ///     boundary means `.example.org` does NOT match `notexample.org`.
-    pub(crate) fn is_allowed(host: &str) -> bool {
+    fn host_matches(host_pattern: &str, h: &str) -> bool {
+        if let Some(suffix) = host_pattern.strip_prefix('.') {
+            h == suffix || h.ends_with(host_pattern)
+        } else {
+            host_pattern == h
+        }
+    }
+
+    /// True if `(host, port)` is permitted by the active allowlist. [OPUS-4.8] (sq-a7jw4)
+    ///
+    /// `host` is the SERVICE IRI authority host (case-insensitive); `port` is the
+    /// authority's port (its explicit `:port` or the scheme default — the SAME port that is
+    /// actually dialled for every resolved address). An entry matches when its host pattern
+    /// matches (exact or `.suffix` wildcard, per [`host_matches`]) AND its port constraint
+    /// is satisfied:
+    ///   * a **host-level** entry (no `:port`) permits the host on EVERY port — the original
+    ///     `sq-4w18` semantics, preserved exactly for backward compatibility;
+    ///   * a **port-scoped** entry (`host:port`) permits the host ONLY on that exact port
+    ///     and rejects every other port on the same host — strictly narrower (`sq-a7jw4`).
+    ///
+    /// There is NO wildcard port: a port-scoped entry can only tighten, never widen, so
+    /// default-deny stays default-deny.
+    pub(crate) fn is_allowed(host: &str, port: u16) -> bool {
         let h = host.to_ascii_lowercase();
         POLICY.with(|p| {
-            let allow = &p.borrow().allow;
-            if allow.contains(&h) {
-                return true;
-            }
-            // Suffix-wildcard entries (".suffix"): match the apex and any subdomain.
-            allow.iter().any(|e| {
-                if let Some(suffix) = e.strip_prefix('.') {
-                    h == suffix || h.ends_with(e.as_str())
-                } else {
-                    false
-                }
+            p.borrow().allow.iter().any(|e| {
+                let (host_pattern, entry_port) = split_entry(e);
+                host_matches(host_pattern, &h) && entry_port.is_none_or(|ep| ep == port)
             })
         })
     }
@@ -1149,10 +1221,15 @@ struct EgressFilterResolver;
 // an empty address set), so ureq cannot fall through to an unguarded dial.
 
 /// `host:port` (for resolution) + bare host (for the allowlist key, IPv6 brackets stripped,
-/// lowercased) from a ureq-3 request [`Uri`](ureq::http::Uri). `port` falls back to the scheme
-/// default (443 for https, 80 otherwise). [OPUS-4.8] sq-g2xs.
+/// lowercased) + the numeric `port` (for the port-scoped allowlist check, sq-a7jw4) from a
+/// ureq-3 request [`Uri`](ureq::http::Uri). `port` falls back to the scheme default (443 for
+/// https, 80 otherwise). [OPUS-4.8] sq-g2xs / sq-a7jw4.
+///
+/// The returned `port` is exactly the port `to_socket_addrs(host:port)` dials for EVERY
+/// resolved address, so a port-scoped allowlist entry is checked against the port actually
+/// connected to — no resolve-then-reconnect port TOCTOU.
 #[cfg(all(feature = "service", not(target_arch = "wasm32")))]
-fn uri_host_port(uri: &ureq::http::Uri) -> Option<(String, String)> {
+fn uri_host_port(uri: &ureq::http::Uri) -> Option<(String, String, u16)> {
     let authority = uri.authority()?;
     let host = authority.host();
     if host.is_empty() {
@@ -1167,7 +1244,7 @@ fn uri_host_port(uri: &ureq::http::Uri) -> Option<(String, String)> {
     // The authority host keeps IPv6 brackets (`[::1]`); strip them for the allowlist key and
     // for `to_socket_addrs` (which wants the bare host + a separate port).
     let bare = host.trim_start_matches('[').trim_end_matches(']');
-    Some((format!("{bare}:{port}"), bare.to_ascii_lowercase()))
+    Some((format!("{bare}:{port}"), bare.to_ascii_lowercase(), port))
 }
 
 /// Wrap a refusal reason as a `PermissionDenied` [`ureq::Error::Io`], preserving both the kind
@@ -1189,12 +1266,15 @@ impl ureq::unversioned::resolver::Resolver for EgressFilterResolver {
         _timeout: ureq::unversioned::transport::NextTimeout,
     ) -> Result<ureq::unversioned::resolver::ResolvedSocketAddrs, ureq::Error> {
         use std::net::ToSocketAddrs;
-        let (host_port, host) = uri_host_port(uri).ok_or_else(|| {
+        let (host_port, host, port) = uri_host_port(uri).ok_or_else(|| {
             egress_refused(format!(
                 "{SERVICE_EGRESS_REFUSED_MARKER}: request URI {uri} has no host authority to vet"
             ))
         })?;
-        let allowed = egress_policy::is_allowed(&host);
+        // [OPUS-4.8] (sq-a7jw4) The allowlist check is port-scoped: a `host:port` entry permits
+        // only that host on that exact port; a bare-host entry still permits every port. `port`
+        // is the authority port that is actually dialled for every resolved address.
+        let allowed = egress_policy::is_allowed(&host, port);
         // [OPUS-4.8] (sq-4w18) STRICT (AllowlistOnly) mode — the server's policy — refuses any
         // host not on the allowlist BEFORE resolving DNS, so a host that is not explicitly
         // permitted never triggers even a lookup. An empty allowlist here = deny ALL SERVICE.
@@ -1658,6 +1738,13 @@ mod tests {
         IpAddr::V4(Ipv4Addr::new(a, b, c, d))
     }
 
+    /// [OPUS-4.8] (sq-a7jw4) Host-level `is_allowed` check at a representative port. A
+    /// host-level (no-`:port`) entry matches EVERY port, so any port reads the same — these
+    /// host-level tests use 80. Port-scoping tests call `is_allowed(host, port)` directly.
+    fn allowed(host: &str) -> bool {
+        egress_policy::is_allowed(host, 80)
+    }
+
     #[test]
     fn loopback_is_forbidden() {
         assert!(is_forbidden_ip(v4(127, 0, 0, 1)));
@@ -1728,30 +1815,30 @@ mod tests {
     #[test]
     fn allowlist_plumbing_install_and_restore() {
         // Default: nothing is allowlisted.
-        assert!(!egress_policy::is_allowed("localhost"));
+        assert!(!allowed("localhost"));
         {
             let _g = egress_policy::install(
                 ["localhost".to_string(), "10.0.0.5".to_string()],
                 egress_policy::Mode::DenyPrivate,
             );
-            assert!(egress_policy::is_allowed("localhost"));
-            assert!(egress_policy::is_allowed("LOCALHOST")); // case-insensitive
-            assert!(egress_policy::is_allowed("10.0.0.5"));
-            assert!(!egress_policy::is_allowed("other.host"));
+            assert!(allowed("localhost"));
+            assert!(allowed("LOCALHOST")); // case-insensitive
+            assert!(allowed("10.0.0.5"));
+            assert!(!allowed("other.host"));
         }
         // Restored to empty on guard drop.
-        assert!(!egress_policy::is_allowed("localhost"));
+        assert!(!allowed("localhost"));
     }
 
     #[test]
     fn with_service_egress_allow_scopes_the_allowlist() {
-        assert!(!egress_policy::is_allowed("sparql.internal"));
+        assert!(!allowed("sparql.internal"));
         let seen = with_service_egress_allow(["sparql.internal".to_string()], || {
-            egress_policy::is_allowed("sparql.internal")
+            allowed("sparql.internal")
         });
         assert!(seen);
         // Allowlist is gone after the scope returns.
-        assert!(!egress_policy::is_allowed("sparql.internal"));
+        assert!(!allowed("sparql.internal"));
     }
 
     #[test]
@@ -1759,15 +1846,15 @@ mod tests {
         // [OPUS-4.8] (sq-4w18) Strict mode: only listed hosts are allowed; the mode
         // and allowlist both restore on scope exit.
         assert_eq!(egress_policy::mode(), egress_policy::Mode::DenyPrivate);
-        assert!(!egress_policy::is_allowed("a.example"));
+        assert!(!allowed("a.example"));
         with_service_egress_policy(true, ["a.example".to_string()], || {
             assert_eq!(egress_policy::mode(), egress_policy::Mode::AllowlistOnly);
-            assert!(egress_policy::is_allowed("a.example"));
-            assert!(egress_policy::is_allowed("A.EXAMPLE")); // case-insensitive
-            assert!(!egress_policy::is_allowed("b.example"));
+            assert!(allowed("a.example"));
+            assert!(allowed("A.EXAMPLE")); // case-insensitive
+            assert!(!allowed("b.example"));
         });
         assert_eq!(egress_policy::mode(), egress_policy::Mode::DenyPrivate);
-        assert!(!egress_policy::is_allowed("a.example"));
+        assert!(!allowed("a.example"));
     }
 
     #[test]
@@ -1775,12 +1862,12 @@ mod tests {
         // [OPUS-4.8] (sq-4w18) A ".example.org" entry matches the apex and any
         // subdomain, but not a host that merely ends in the same letters.
         with_service_egress_policy(true, [".example.org".to_string()], || {
-            assert!(egress_policy::is_allowed("example.org")); // apex
-            assert!(egress_policy::is_allowed("sparql.example.org")); // subdomain
-            assert!(egress_policy::is_allowed("a.b.example.org")); // deep subdomain
-            assert!(egress_policy::is_allowed("SPARQL.EXAMPLE.ORG")); // case-insensitive
-            assert!(!egress_policy::is_allowed("notexample.org")); // boundary respected
-            assert!(!egress_policy::is_allowed("example.org.evil.com")); // suffix only
+            assert!(allowed("example.org")); // apex
+            assert!(allowed("sparql.example.org")); // subdomain
+            assert!(allowed("a.b.example.org")); // deep subdomain
+            assert!(allowed("SPARQL.EXAMPLE.ORG")); // case-insensitive
+            assert!(!allowed("notexample.org")); // boundary respected
+            assert!(!allowed("example.org.evil.com")); // suffix only
         });
     }
 
@@ -1789,7 +1876,7 @@ mod tests {
         // strict=false behaves exactly like with_service_egress_allow (DenyPrivate).
         with_service_egress_policy(false, ["c.example".to_string()], || {
             assert_eq!(egress_policy::mode(), egress_policy::Mode::DenyPrivate);
-            assert!(egress_policy::is_allowed("c.example"));
+            assert!(allowed("c.example"));
         });
     }
 
@@ -1799,11 +1886,122 @@ mod tests {
         // a relaxed allowlist must never leak past the scope on unwind.
         let _ = std::panic::catch_unwind(|| {
             with_service_egress_allow(["leaky.host".to_string()], || {
-                assert!(egress_policy::is_allowed("leaky.host"));
+                assert!(allowed("leaky.host"));
                 panic!("boom");
             });
         });
-        assert!(!egress_policy::is_allowed("leaky.host"));
+        assert!(!allowed("leaky.host"));
+    }
+
+    // ---------------------------------------------------------------------
+    // Port-scoped allowlist entries [OPUS-4.8] (bead sq-a7jw4)
+    // ---------------------------------------------------------------------
+
+    #[test]
+    fn split_entry_parses_host_and_optional_port() {
+        // Direct unit test for the entry parser (coverage ratchet).
+        use egress_policy::split_entry;
+        // Host-level (no port constraint).
+        assert_eq!(split_entry("sparql.internal"), ("sparql.internal", None));
+        assert_eq!(split_entry("127.0.0.1"), ("127.0.0.1", None));
+        assert_eq!(split_entry(".example.org"), (".example.org", None));
+        // Port-scoped.
+        assert_eq!(split_entry("127.0.0.1:8053"), ("127.0.0.1", Some(8053)));
+        assert_eq!(split_entry("sparql.internal:8443"), ("sparql.internal", Some(8443)));
+        assert_eq!(split_entry(".example.org:443"), (".example.org", Some(443)));
+        // Bracketed IPv6 — brackets stripped from the host pattern.
+        assert_eq!(split_entry("[::1]:8080"), ("::1", Some(8080)));
+        assert_eq!(split_entry("[2001:db8::1]:443"), ("2001:db8::1", Some(443)));
+        assert_eq!(split_entry("[::1]"), ("::1", None));
+        // Bare (unbracketed) IPv6 — NOT amputated; host-level.
+        assert_eq!(split_entry("::1"), ("::1", None));
+        assert_eq!(split_entry("2001:db8::1"), ("2001:db8::1", None));
+        // Out-of-range / empty / non-numeric port: kept as host pattern (fail-closed).
+        assert_eq!(split_entry("127.0.0.1:99999"), ("127.0.0.1:99999", None));
+        assert_eq!(split_entry("127.0.0.1:"), ("127.0.0.1:", None));
+        assert_eq!(split_entry("127.0.0.1:http"), ("127.0.0.1:http", None));
+    }
+
+    #[test]
+    fn port_scoped_entry_permits_exact_port_only() {
+        // A `host:port` entry permits ONLY that host on THAT port, and rejects the
+        // same host on any OTHER port — strictly narrower than a host-level entry.
+        with_service_egress_policy(true, ["127.0.0.1:8053".to_string()], || {
+            assert!(egress_policy::is_allowed("127.0.0.1", 8053)); // (a) exact host:port
+            assert!(!egress_policy::is_allowed("127.0.0.1", 8054)); // (b) other port rejected
+            assert!(!egress_policy::is_allowed("127.0.0.1", 80)); //   (b) default port rejected
+            assert!(!egress_policy::is_allowed("127.0.0.2", 8053)); // (c) different host rejected
+        });
+    }
+
+    #[test]
+    fn host_level_entry_permits_all_ports_backward_compat() {
+        // (d) An existing host-level entry (no port) keeps its meaning: every port on
+        // that host. This is the unchanged sq-4w18 semantics.
+        with_service_egress_policy(true, ["127.0.0.1".to_string()], || {
+            assert!(egress_policy::is_allowed("127.0.0.1", 80));
+            assert!(egress_policy::is_allowed("127.0.0.1", 8053));
+            assert!(egress_policy::is_allowed("127.0.0.1", 65535));
+            assert!(!egress_policy::is_allowed("127.0.0.2", 80)); // different host still rejected
+        });
+    }
+
+    #[test]
+    fn port_scoped_suffix_wildcard_is_port_constrained() {
+        // A port on a suffix-wildcard entry constrains the port too: `.example.org:443`
+        // permits any subdomain on 443 only.
+        with_service_egress_policy(true, [".example.org:443".to_string()], || {
+            assert!(egress_policy::is_allowed("sparql.example.org", 443)); // subdomain on 443
+            assert!(egress_policy::is_allowed("example.org", 443)); // apex on 443
+            assert!(!egress_policy::is_allowed("sparql.example.org", 80)); // wrong port
+            assert!(!egress_policy::is_allowed("notexample.org", 443)); // boundary respected
+        });
+    }
+
+    #[test]
+    fn bracketed_ipv6_port_scoped_entry() {
+        // A bracketed IPv6 `[::1]:8080` entry is port-scoped on the bare `::1` host.
+        with_service_egress_policy(true, ["[::1]:8080".to_string()], || {
+            assert!(egress_policy::is_allowed("::1", 8080));
+            assert!(!egress_policy::is_allowed("::1", 80));
+        });
+    }
+
+    #[test]
+    fn bare_ipv6_entry_is_host_level_not_port_amputated() {
+        // A bare (unbracketed) IPv6 literal must NOT have its last hextet read as a
+        // port — `2001:db8::1` is a host-level entry matching every port.
+        with_service_egress_policy(true, ["2001:db8::1".to_string()], || {
+            assert!(egress_policy::is_allowed("2001:db8::1", 443));
+            assert!(egress_policy::is_allowed("2001:db8::1", 80));
+        });
+    }
+
+    #[test]
+    fn mixed_host_and_port_scoped_entries_for_same_host() {
+        // Two entries for the same loopback host: a host-level `127.0.0.1` (all ports)
+        // and a redundant port-scoped one. The host-level entry wins for any port —
+        // additive allowlists only ever widen, never remove a granted port.
+        with_service_egress_policy(
+            true,
+            ["127.0.0.1".to_string(), "10.0.0.5:9000".to_string()],
+            || {
+                assert!(egress_policy::is_allowed("127.0.0.1", 1234)); // host-level: any port
+                assert!(egress_policy::is_allowed("10.0.0.5", 9000)); // port-scoped: exact
+                assert!(!egress_policy::is_allowed("10.0.0.5", 9001)); // port-scoped: other port
+            },
+        );
+    }
+
+    #[test]
+    fn malformed_port_in_entry_fails_closed() {
+        // A `:port` that does not parse as a u16 is treated as part of the (never-matching)
+        // host pattern, NOT as "drop the port constraint and match every port" — fail-closed.
+        with_service_egress_policy(true, ["127.0.0.1:99999".to_string()], || {
+            // 99999 > u16::MAX: the entry matches no real authority at all.
+            assert!(!egress_policy::is_allowed("127.0.0.1", 80));
+            assert!(!egress_policy::is_allowed("127.0.0.1", 65535));
+        });
     }
 
     // The resolver path is native-only (it wraps ureq's Resolver).
@@ -1918,6 +2116,90 @@ mod tests {
             })
             .unwrap();
             assert_eq!(addrs.len(), 1);
+        }
+
+        // [OPUS-4.8] (sq-a7jw4) Port-scoped allowlist entries at the resolver — the real
+        // egress path, not just the `is_allowed` predicate.
+
+        #[test]
+        fn resolver_port_scoped_permits_exact_port_rejects_others() {
+            // A `127.0.0.1:8053` entry lets the loopback endpoint be dialled on 8053 only;
+            // the SAME loopback host on any other port is refused (the private-IP default-deny
+            // re-applies because the allowlist exemption does not match the port).
+            let addrs = with_service_egress_policy(true, ["127.0.0.1:8053".to_string()], || {
+                resolve_netloc("127.0.0.1:8053")
+            })
+            .unwrap();
+            assert_eq!(addrs.len(), 1);
+            assert!(addrs[0].ip().is_loopback());
+            assert_eq!(addrs[0].port(), 8053);
+
+            let err = with_service_egress_policy(true, ["127.0.0.1:8053".to_string()], || {
+                resolve_netloc("127.0.0.1:9999")
+            })
+            .unwrap_err();
+            assert!(is_permission_denied(&err), "other port must be refused, got {err:?}");
+        }
+
+        #[test]
+        fn resolver_in_process_loopback_service_use_case() {
+            // The bead's load-bearing use case: an in-process mock SERVICE endpoint bound to
+            // an EPHEMERAL loopback port. Permit EXACTLY 127.0.0.1:<ephemeral>; the same host
+            // on a different port (a co-resident service, or an attacker probing) is refused.
+            let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+            let ephemeral = listener.local_addr().unwrap().port();
+            let other = ephemeral.wrapping_add(1).max(1);
+            let entry = format!("127.0.0.1:{ephemeral}");
+
+            let permitted = with_service_egress_policy(true, [entry.clone()], || {
+                resolve_netloc(&format!("127.0.0.1:{ephemeral}"))
+            });
+            let addrs = permitted.expect("the exact ephemeral loopback endpoint must be dial-able");
+            assert_eq!(addrs.len(), 1);
+            assert!(addrs[0].ip().is_loopback());
+            assert_eq!(addrs[0].port(), ephemeral);
+
+            if other != ephemeral {
+                let err = with_service_egress_policy(true, [entry], || {
+                    resolve_netloc(&format!("127.0.0.1:{other}"))
+                })
+                .unwrap_err();
+                assert!(
+                    is_permission_denied(&err),
+                    "127.0.0.1:{other} (a different port) must be refused, got {err:?}"
+                );
+            }
+        }
+
+        #[test]
+        fn resolver_port_scoped_does_not_weaken_dns_rebind_revet() {
+            // The port-scoping must NOT bypass the resolved-IP re-vet. A `127.0.0.1:8053`
+            // allowlist entry permits the loopback host on 8053; but if the SAME port were
+            // dialled toward a DIFFERENT private host that is NOT the allowlisted one
+            // (here 169.254.169.254, the cloud-metadata IP), the per-IP `is_forbidden_ip`
+            // check still rejects it — the allowlist exemption is keyed to the host pattern,
+            // so a rebind to an off-allowlist IP on the very same port is still refused.
+            let err = with_service_egress_policy(true, ["127.0.0.1:8053".to_string()], || {
+                resolve_netloc("169.254.169.254:8053")
+            })
+            .unwrap_err();
+            assert!(
+                is_permission_denied(&err),
+                "an off-allowlist private IP on the scoped port must still be re-vetted, got {err:?}"
+            );
+        }
+
+        #[test]
+        fn resolver_host_level_entry_permits_all_ports() {
+            // Backward compat at the resolver: a bare `127.0.0.1` entry dials on any port.
+            for port in [80u16, 8053, 65535] {
+                let addrs = with_service_egress_policy(true, ["127.0.0.1".to_string()], || {
+                    resolve_netloc(&format!("127.0.0.1:{port}"))
+                })
+                .unwrap();
+                assert_eq!(addrs.len(), 1);
+                assert_eq!(addrs[0].port(), port);
+            }
         }
     }
 }

--- a/crates/sparq-server/src/service_config.rs
+++ b/crates/sparq-server/src/service_config.rs
@@ -27,9 +27,15 @@
 //!
 //! Each entry is one of:
 //!   * an **exact host** — `sparql.example.org`, `192.0.2.10`, `localhost`
-//!     (matched case-insensitively against the SERVICE IRI authority);
-//!   * a **suffix wildcard** — `*.example.org`, matching the apex `example.org` and
-//!     any subdomain (`a.example.org`, `a.b.example.org`) but not `notexample.org`.
+//!     (matched case-insensitively against the SERVICE IRI authority — every port);
+//!   * a **port-scoped host** — `sparql.example.org:8443`, `192.0.2.10:8080`,
+//!     `[::1]:8053` ([OPUS-4.8] sq-a7jw4): permits that host ONLY on that exact port and
+//!     rejects every other port on the same host — strictly NARROWER than the bare host.
+//!     This is the way to permit exactly one ephemeral loopback endpoint for in-process
+//!     SERVICE federation without re-opening the whole host;
+//!   * a **suffix wildcard** — `*.example.org` (optionally port-scoped,
+//!     `*.example.org:443`), matching the apex `example.org` and any subdomain
+//!     (`a.example.org`, `a.b.example.org`) but not `notexample.org`.
 //!
 //! Entries come from (union of all three, deduplicated):
 //!   * the repeatable `--service-allow <entry>` CLI flag;
@@ -73,16 +79,18 @@ impl ServiceAllowlist {
     /// error string for a malformed entry so the caller can fail fast at startup
     /// rather than silently dropping a host the operator meant to allow.
     ///
-    /// Accepted forms: a bare host, or `*.suffix` (suffix wildcard). The entry is
-    /// lower-cased; surrounding whitespace is trimmed. A `*` anywhere other than a
-    /// leading `*.` is rejected (we deliberately support only the simple
-    /// apex-and-subdomain suffix wildcard, not arbitrary globs).
+    /// Accepted forms: a bare host, a port-scoped `host:port`, or `*.suffix` (suffix
+    /// wildcard, optionally port-scoped `*.suffix:port`). The entry is lower-cased;
+    /// surrounding whitespace is trimmed. A `*` anywhere other than a leading `*.` is
+    /// rejected (we deliberately support only the simple apex-and-subdomain suffix wildcard,
+    /// not arbitrary globs).
     ///
-    /// [OPUS-4.8] sq-4w18: exact-host entries are NORMALISED to the bare host the
-    /// engine actually compares against (see `Self::normalize_host`), so a copy-
-    /// pasted endpoint like `example.org:443` or a bracketed IPv6 `[::1]` matches
-    /// instead of silently never matching (which would make the allowlist look
-    /// configured but be inert — a fail-open footgun).
+    /// [OPUS-4.8] sq-4w18 / sq-a7jw4: exact-host entries are NORMALISED to the `host` /
+    /// `host:port` form the engine actually compares against (see `Self::normalize_host`), so
+    /// a copy-pasted endpoint like `example.org:443` or a bracketed IPv6 `[::1]` matches
+    /// instead of silently never matching (which would make the allowlist look configured but
+    /// be inert — a fail-open footgun). A `host:port` entry is **port-scoped** (exact port
+    /// only); a bare host stays every-port.
     pub fn add(&mut self, raw: &str) -> Result<(), String> {
         let e = raw.trim().to_ascii_lowercase();
         if e.is_empty() {
@@ -92,7 +100,9 @@ impl ServiceAllowlist {
             if suffix.is_empty() || suffix.contains('*') {
                 return Err(format!("invalid SERVICE allow pattern {raw:?}: expected '*.<suffix>'"));
             }
-            // Engine form: leading dot. Matches the apex + any subdomain.
+            // Engine form: leading dot. Matches the apex + any subdomain. A trailing
+            // `:port` ([OPUS-4.8] sq-a7jw4) is carried through so the wildcard is
+            // port-scoped too (`.suffix:port`); `split_entry` parses it on the engine side.
             self.suffix.insert(format!(".{suffix}"));
             return Ok(());
         }
@@ -105,33 +115,41 @@ impl ServiceAllowlist {
         Ok(())
     }
 
-    /// [OPUS-4.8] sq-4w18: normalise an exact-host entry to the EXACT string the
-    /// engine's egress resolver compares the SERVICE IRI authority against.
+    /// [OPUS-4.8] sq-4w18 / sq-a7jw4: normalise an exact-host entry to the EXACT string
+    /// the engine's egress resolver compares the SERVICE IRI authority against.
     ///
-    /// The engine ([`sparq_engine`]'s `EgressFilterResolver`) is handed `netloc` as
-    /// `host:port` (IPv6 bracketed: `[::1]:80`) and derives the bare host by
-    /// (1) dropping a trailing `:port` via `rsplit_once(':')` and (2) stripping a
-    /// surrounding `[ ]`. An allowlist entry that still carries a port or brackets
-    /// would therefore NEVER equal what the engine looks up. We apply the same two
-    /// transforms here so an operator can paste an authority verbatim:
+    /// The engine ([`sparq_engine`]'s `EgressFilterResolver` + `egress_policy::split_entry`)
+    /// looks up the bare host (IPv6 brackets stripped, lower-cased) AND, for a port-scoped
+    /// entry, the authority's port. An allowlist entry must therefore be in the engine's
+    /// `host` (host-level) or `host:port` / `[ipv6]:port` (port-scoped) form. We normalise so
+    /// an operator can paste an authority verbatim:
     ///
-    ///   * `example.org:443`  -> `example.org`        (port stripped)
-    ///   * `[::1]`            -> `::1`                 (brackets stripped)
-    ///   * `[::1]:443`        -> `::1`                 (port + brackets stripped)
-    ///   * `192.0.2.10:8080`  -> `192.0.2.10`         (port stripped)
-    ///   * `example.org`      -> `example.org`        (unchanged)
-    ///   * `::1` (bare IPv6)  -> `::1`                 (unchanged — NOT mangled)
+    ///   * `example.org`       -> `example.org`        (host-level; unchanged)
+    ///   * `[::1]`             -> `::1`                 (brackets stripped; host-level)
+    ///   * `::1` (bare IPv6)   -> `::1`                 (unchanged — NOT mangled; host-level)
+    ///   * `example.org:443`   -> `example.org:443`    ([OPUS-4.8] sq-a7jw4 PORT PRESERVED)
+    ///   * `192.0.2.10:8080`   -> `192.0.2.10:8080`    (port preserved — exact port only)
+    ///   * `[::1]:8053`        -> `[::1]:8053`          (brackets kept so the engine parses the IPv6 host out from the port)
     ///
-    /// A trailing `:port` is only stripped when the entry is unambiguously
-    /// `host:port`: either bracketed (`[...]:port`) or a single-colon `host:digits`
-    /// form. A bare IPv6 literal (multiple colons, unbracketed) is left intact so we
-    /// never amputate its last hextet.
+    /// **[OPUS-4.8] sq-a7jw4 — this TIGHTENS scoping.** Previously a `host:port` entry had
+    /// its port STRIPPED, silently widening it to "every port on that host" (a fail-open
+    /// footgun). It now means EXACTLY that port — strictly narrower. A bare host (no `:port`)
+    /// is unchanged (every port), so an existing port-less config is byte-for-byte
+    /// unaffected. A `:port` is only honoured when the entry is unambiguously `host:port`
+    /// (bracketed `[...]:port`, or a single-colon `host:digits`); a bare IPv6 literal
+    /// (multiple colons, unbracketed) keeps its last hextet.
     fn normalize_host(e: &str) -> String {
-        // Bracketed IPv6: `[addr]` or `[addr]:port`. Strip the optional `:port`
-        // that follows the closing bracket, then strip the brackets themselves.
+        // Bracketed IPv6: `[addr]` or `[addr]:port`.
         if let Some(rest) = e.strip_prefix('[') {
-            if let Some((inner, _after)) = rest.split_once(']') {
-                // `_after` is either empty or `:port`; the engine drops it either way.
+            if let Some((inner, after)) = rest.split_once(']') {
+                // A trailing `:port` (port-scoped) is KEPT, bracketed, so the engine's
+                // `split_entry` can separate the IPv6 host from the port; a bare `[addr]`
+                // is host-level and stored with brackets stripped.
+                if let Some(port) = after.strip_prefix(':') {
+                    if !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) {
+                        return format!("[{inner}]:{port}");
+                    }
+                }
                 return inner.to_string();
             }
             // Malformed (no closing bracket) — leave verbatim; it just won't match.
@@ -141,7 +159,8 @@ impl ServiceAllowlist {
         // anything with more than one colon is a bare IPv6 literal we must NOT touch.
         if let Some((host, port)) = e.split_once(':') {
             if !host.contains(':') && !port.contains(':') && !port.is_empty() && port.bytes().all(|b| b.is_ascii_digit()) {
-                return host.to_string();
+                // [OPUS-4.8] sq-a7jw4: PRESERVE the port (port-scoped, exact port only).
+                return e.to_string();
             }
         }
         e.to_string()
@@ -256,28 +275,55 @@ mod tests {
     }
 
     #[test]
-    fn exact_host_normalised_to_engine_bare_host() {
-        // [OPUS-4.8] sq-4w18: the engine compares the SERVICE IRI authority with the
-        // port dropped and IPv6 brackets stripped, so `add` must normalise to the same
-        // form or the entry would silently never match (fail-open).
+    fn exact_host_normalised_to_engine_host_form() {
+        // [OPUS-4.8] sq-4w18 / sq-a7jw4: `add` normalises to the engine's `host` (host-level)
+        // or `host:port` / `[ipv6]:port` (port-scoped) form. A bare host has its IPv6 brackets
+        // stripped; a `host:port` PRESERVES the port (sq-a7jw4 — exact port only, NOT widened
+        // to every port the way sq-4w18 used to strip it).
         for (raw, want) in [
-            ("example.org:443", "example.org"),    // host:port -> bare host
-            ("192.0.2.10:8080", "192.0.2.10"),     // ipv4:port -> bare ip
+            // host-level (no port): brackets stripped, bare IPv6 untouched.
             ("[::1]", "::1"),                       // bracketed ipv6 -> bare ipv6
-            ("[::1]:443", "::1"),                   // bracketed ipv6 + port -> bare ipv6
-            ("[2001:db8::1]:80", "2001:db8::1"),    // full bracketed ipv6 + port
             ("example.org", "example.org"),         // already bare -> unchanged
             ("::1", "::1"),                          // bare (unbracketed) ipv6 -> NOT mangled
             ("2001:db8::1", "2001:db8::1"),          // bare full ipv6 -> NOT mangled
+            // port-scoped: port PRESERVED.
+            ("example.org:443", "example.org:443"), // host:port -> port preserved
+            ("192.0.2.10:8080", "192.0.2.10:8080"), // ipv4:port -> port preserved
+            ("[::1]:443", "[::1]:443"),             // bracketed ipv6 + port -> kept bracketed
+            ("[2001:db8::1]:80", "[2001:db8::1]:80"), // full bracketed ipv6 + port
         ] {
             let mut a = ServiceAllowlist::default();
             a.add(raw).unwrap();
             assert_eq!(
                 a.engine_entries(),
                 vec![want.to_string()],
-                "{raw:?} should normalise to the bare host {want:?} the engine compares against",
+                "{raw:?} should normalise to the engine form {want:?}",
             );
         }
+    }
+
+    #[test]
+    fn port_scoped_entry_is_distinct_from_bare_host() {
+        // [OPUS-4.8] sq-a7jw4: `host` and `host:port` are DIFFERENT entries — the port-scoped
+        // one does not subsume or collapse into the bare host, so the operator's intent
+        // (exact port) survives all the way to the engine.
+        let mut a = ServiceAllowlist::default();
+        a.add("127.0.0.1").unwrap();
+        a.add("127.0.0.1:8053").unwrap();
+        assert_eq!(a.len(), 2);
+        let mut e = a.engine_entries();
+        e.sort();
+        assert_eq!(e, vec!["127.0.0.1".to_string(), "127.0.0.1:8053".to_string()]);
+    }
+
+    #[test]
+    fn port_scoped_suffix_wildcard_carries_port() {
+        // [OPUS-4.8] sq-a7jw4: `*.example.org:443` -> `.example.org:443` (engine form), and
+        // display round-trips to the user-facing `*.example.org:443`.
+        let mut a = ServiceAllowlist::default();
+        a.add("*.example.org:443").unwrap();
+        assert_eq!(a.engine_entries(), vec![".example.org:443".to_string()]);
+        assert_eq!(a.display(), "*.example.org:443");
     }
 
     #[test]

--- a/crates/sparq-server/tests/service_allowlist.rs
+++ b/crates/sparq-server/tests/service_allowlist.rs
@@ -10,7 +10,9 @@
 //!   * with the loopback host on the allowlist, the SAME query reaches the endpoint and
 //!     joins the remote solution;
 //!   * `SERVICE SILENT` under the deny posture yields the join identity (the query
-//!     succeeds with the surrounding bindings intact, no network call).
+//!     succeeds with the surrounding bindings intact, no network call);
+//!   * [OPUS-4.8] sq-a7jw4 — a PORT-SCOPED entry (`127.0.0.1:<ephemeral>`) permits exactly
+//!     that endpoint, and REJECTS the same loopback host on a different port (403, no dial).
 #![cfg(feature = "service")]
 
 use std::io::{Read, Write};
@@ -160,6 +162,81 @@ async fn allowlisted_loopback_host_reaches_the_endpoint() {
     let body = resp.text().await.unwrap();
     assert!(body.contains("Alice"), "expected the remote name joined in: {body}");
     assert!(body.contains("Bob"), "expected the remote name joined in: {body}");
+}
+
+#[tokio::test]
+async fn port_scoped_allowlist_permits_exact_endpoint() {
+    // [OPUS-4.8] sq-a7jw4: the in-process loopback SERVICE federation use case — permit
+    // EXACTLY `127.0.0.1:<ephemeral>` (the mock endpoint's bound port), and it is reached.
+    let (remote, _accepts) = serve(remote_body(), 1);
+    let host = remote.trim_start_matches("http://").trim_end_matches('/'); // 127.0.0.1:<port>
+    // Allowlist the FULL host:port (port-scoped) — exactly the mock endpoint, nothing wider.
+    let mut config = ServerConfig::default();
+    let mut allow = ServiceAllowlist::default();
+    allow.add(host).unwrap(); // e.g. "127.0.0.1:54321"
+    config.service_allow = allow;
+    let base = spawn_with(config).await;
+    let q = format!(
+        "PREFIX ex: <http://ex/> SELECT ?s ?name WHERE {{ ?s a ex:Person . SERVICE <http://{host}/> {{ ?s ex:name ?name }} }}"
+    );
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", q)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "exact port-scoped SERVICE must succeed");
+    let body = resp.text().await.unwrap();
+    assert!(body.contains("Alice") && body.contains("Bob"), "expected the remote joined in: {body}");
+}
+
+#[tokio::test]
+async fn port_scoped_allowlist_rejects_same_host_other_port() {
+    // [OPUS-4.8] sq-a7jw4: the security property — a `127.0.0.1:<portA>` entry must REJECT
+    // the SAME loopback host on a DIFFERENT port. We allowlist one ephemeral port but the
+    // SERVICE IRI targets a *second*, live loopback endpoint on another port; the server must
+    // refuse it (403) BEFORE dialling, proven by the live listener accepting nothing.
+    let allowed_listener = StdListener::bind("127.0.0.1:0").expect("bind loopback");
+    let allowed_addr = allowed_listener.local_addr().unwrap(); // the permitted host:port
+    drop(allowed_listener); // we only need its host:port string for the allowlist entry
+
+    // A SECOND live endpoint on a DIFFERENT port — the off-allowlist target.
+    let (other_remote, other_accepts) = serve(remote_body(), 1);
+    let other_host = other_remote.trim_start_matches("http://").trim_end_matches('/');
+    assert_ne!(
+        allowed_addr.port(),
+        other_host.rsplit(':').next().unwrap().parse::<u16>().unwrap(),
+        "the two endpoints must be on different ports for this test to be meaningful",
+    );
+
+    let mut config = ServerConfig {
+        query_timeout: Some(std::time::Duration::from_secs(2)),
+        ..ServerConfig::default()
+    };
+    let mut allow = ServiceAllowlist::default();
+    allow.add(&allowed_addr.to_string()).unwrap(); // port-scoped: ONLY 127.0.0.1:<portA>
+    config.service_allow = allow;
+    let base = spawn_with(config).await;
+    let q = format!(
+        "PREFIX ex: <http://ex/> SELECT ?s WHERE {{ ?s a ex:Person . SERVICE <http://{other_host}/> {{ ?s ex:name ?name }} }}"
+    );
+    let resp = reqwest::Client::new()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", q)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        403,
+        "same host on a non-allowlisted port must be a 403 policy refusal, got {}",
+        resp.status(),
+    );
+    // And the off-allowlist endpoint must never have been dialled.
+    assert!(
+        other_accepts.recv_timeout(std::time::Duration::from_millis(250)).is_err(),
+        "a port off the scoped allowlist must be refused BEFORE any socket is opened",
+    );
 }
 
 #[tokio::test]

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -912,7 +912,7 @@ env overrides the default.
 | `--auth-token TOKEN` | `SPARQ_AUTH_TOKEN` | off (no auth) | require `Authorization: Bearer TOKEN` on every WRITE (SPARQL Update + GSP PUT/POST/DELETE) → `401` + `WWW-Authenticate: Bearer` otherwise; constant-time compared (QLever's `-a`) |
 | `--auth-token-read` | `SPARQ_AUTH_TOKEN_READ` | off | ALSO gate reads with the same token (only meaningful with a token set) |
 | `--allow-remote` | `SPARQ_ALLOW_REMOTE` | off | opt in to a non-loopback bind; without it a non-loopback `--addr` is **refused** unless the surface is fully authenticated (`--auth-token` AND `--auth-token-read`), with it it warns and proceeds |
-| `--service-allow HOST\|*.SUFFIX` (repeatable) | `SPARQ_SERVICE_ALLOW` (comma/ws-sep) | empty = **deny ALL SERVICE** | (feature `service`) allowlist a SERVICE egress host (exact or `*.suffix` wildcard); CLI + file + env are all merged (combined additively) |
+| `--service-allow HOST[:PORT]\|*.SUFFIX[:PORT]` (repeatable) | `SPARQ_SERVICE_ALLOW` (comma/ws-sep) | empty = **deny ALL SERVICE** | (feature `service`) allowlist a SERVICE egress host (exact or `*.suffix` wildcard); a `:PORT` makes it **port-scoped** — that host on THAT port only (else every port) (`sq-a7jw4`); CLI + file + env are all merged (combined additively) |
 | `--service-allow-file PATH` | — | — | (feature `service`) load allowlist entries, one per line (`#` comments + blanks ignored) |
 | `--cors-allow-origin ORIGIN` (repeatable) | `SPARQ_CORS_ALLOW_ORIGIN` (comma/ws-sep) | empty = **no CORS headers** | allowlist a first-party browser origin (`scheme://host[:port]`); a listed `Origin` is reflected into `Access-Control-Allow-Origin` (never `*`, never credentials) + `Vary: Origin`, preflight `OPTIONS` answered; CLI + file + env merged additively — see "CORS" |
 | `--cors-allow-origin-file PATH` | — | — | load CORS origins, one per line (`#` comments + blanks ignored) |
@@ -1008,7 +1008,8 @@ quota:
    SSRF; worst case the `169.254.169.254` cloud-metadata IP), so it reaches **nothing**
    unless its host is allowlisted, enforced on the *resolved* IP before any socket opens
    (DNS-rebinding-safe), uniformly across queries / ASK / CONSTRUCT/DESCRIBE / subscriptions
-   / federated `INSERT … WHERE`.
+   / federated `INSERT … WHERE`. An entry may be **port-scoped** (`host:port`) to permit a
+   host on exactly one port — strictly narrower than the bare host (`sq-a7jw4`).
 
 Library callers set these on `ServerConfig` (`query_timeout`, `max_query_rows`,
 `max_query_bytes`, `max_decompress_ratio`, `service_allow`). Embedders driving the engine
@@ -1199,7 +1200,14 @@ identities and resource IRIs by design (see the privacy-boundary note above).
   host (textbook SSRF; worst case the `169.254.169.254` cloud-metadata IP), so the
   network-exposed surface must opt in to every reachable host. Matching is
   case-insensitive against the SERVICE IRI authority; a `*.example.org` entry matches the
-  apex `example.org` and any subdomain. Unlike the engine's standalone default (which lets
+  apex `example.org` and any subdomain. An entry may be **host-level** (`192.0.2.10` — every
+  port) or **port-scoped** (`192.0.2.10:8080`, `[::1]:8053`, `sparql.example.org:8443`,
+  `*.example.org:443` — that host on THAT port ONLY, rejecting every other port) (`sq-a7jw4`):
+  a port-scoped entry is strictly NARROWER — the way to permit exactly one ephemeral loopback
+  endpoint for in-process SERVICE federation without re-opening the whole host. (This TIGHTENS
+  earlier behaviour: a `host:port` entry used to have its port stripped and widen to every
+  port; it now means EXACTLY that port. A port-LESS entry is unchanged — still every port.)
+  Unlike the engine's standalone default (which lets
   public IPs through and only blocks private ones), the server is **strict**: even a public
   host must be on the allowlist. The allowlist applies uniformly to queries, ASK,
   CONSTRUCT/DESCRIBE, subscriptions and federated `INSERT … WHERE` updates, and is enforced

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -391,7 +391,14 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   cloud-metadata IP) / unique-local / unspecified address is refused (checked on the *resolved* IP,
   so DNS rebinding can't bypass it). To federate to a trusted internal endpoint, allowlist its host
   for the scope: `with_service_egress_allow([host.to_string()], || query(&g, q))`. Public endpoints
-  need no opt-in. Every egress-refusal error string carries the stable
+  need no opt-in. An allowlist entry may be **host-level** (`127.0.0.1` — every port) or
+  **port-scoped** (`127.0.0.1:8053`, `[::1]:8053`, `.example.org:443` — that host on THAT port ONLY,
+  rejecting every other port) (`sq-a7jw4`): a port-scoped entry is strictly NARROWER, so an
+  in-process loopback harness can permit exactly `127.0.0.1:<ephemeral>` without re-opening the whole
+  loopback host. The port checked is the authority's port (its explicit `:port` or the scheme default),
+  which is exactly the dialled port — so port-scoping applies to the connect target and the resolved
+  IP is still re-vetted (no wildcard port; tightens, never loosens). Every egress-refusal error string
+  carries the stable
   `sparq_engine::SERVICE_EGRESS_REFUSED_MARKER` substring (`sq-iu0c`), so a network-exposed host can
   `contains()`-classify a blocked `SERVICE` as an authorization-policy refusal (e.g. HTTP `403`)
   rather than a server fault — `sparq-server` does exactly this.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead `sq-a7jw4` (epic `sq-my8wd`, SERVICE federation).

## What

Extend the SERVICE-federation **SSRF egress allowlist** to support **port-scoped** entries (`host:port`) alongside host-level entries. This lets a deployer — or the in-process loopback SERVICE federation harness — permit **exactly** one ephemeral loopback endpoint (`127.0.0.1:<ephemeral>`) **without re-opening every port** on that host.

## Security rationale (this TIGHTENS precision, never weakens)

- **Narrower, never wider.** A `host:port` entry permits ONLY that host on THAT port and **rejects** the same host on any other port. It is strictly narrower than a host-level entry.
- **Backward compatible.** A host-level (port-less) entry keeps its current meaning — every port on that host. Existing port-less configs are byte-for-byte unaffected.
- **DNS-rebinding re-vet invariant preserved.** The port checked is the SERVICE IRI authority's port, which is exactly the port `to_socket_addrs(host:port)` dials for *every* resolved address — so port-scoping applies to the **post-resolution connect target**, not a pre-resolution check (no TOCTOU). The resolved IP is still re-vetted by `is_forbidden_ip` at connect time; the allowlist exemption only fires when **both** the host pattern AND the port constraint match — so a rebind to an off-allowlist IP on the very same scoped port is still rejected (regression-tested).
- **No global-disable / wildcard port.** There is no `*` port that re-opens everything; a port-scoped entry can only tighten. Default-deny stays default-deny.
- **Server footgun fixed.** `sparq-server`'s `--service-allow` previously **stripped** the port from a `host:port` entry, silently widening it to every port (fail-open). It now **preserves** the port (exact port only). A bare host is unchanged.

## How

- **engine (`sparq-engine/src/service.rs`, feature `service`)** — `egress_policy` gains `split_entry(entry) -> (host_pattern, Option<u16>)` and a port-aware `is_allowed(host, port)`; the ureq `EgressFilterResolver` passes the dialled authority port through (`uri_host_port` now returns the numeric port). IPv6 handled carefully (bracketed `[::1]:8053` scoped; bare `2001:db8::1` never amputated). A non-parsing `:port` is kept as part of the host pattern → fail-closed (inert, never every-port).
- **server (`sparq-server/src/service_config.rs`, always compiled)** — `normalize_host` preserves the port (`host:port`, `[ipv6]:port`); suffix wildcards accept an optional `:port` (`*.example.org:443` → `.example.org:443`).

## Tests (security-focused, real path)

Engine unit + ureq-resolver tests: (a) exact `host:port` permitted; (b) same host other port rejected; (c) different host rejected; (d) host-level entry permits all ports (backward compat); (e) DNS-rebind re-vet still rejects an off-allowlist IP on the scoped port; the **in-process loopback SERVICE federation use case** (permit exactly `127.0.0.1:<ephemeral>`, reject `127.0.0.1:<other>`) at both the `is_allowed` predicate and the real resolver. Direct unit test for `split_entry` (coverage ratchet). Server: `service_config` port-preservation/distinctness tests + an **end-to-end** integration test (`tests/service_allowlist.rs`) that boots the real axum server and proves a port-scoped entry rejects the same loopback host on a different live port with a 403 **before any socket is dialled**.

## Gates (run in-worktree, both feature states)

- `cargo build` / `cargo clippy --all-targets -D warnings` — green **default (feature OFF)** AND **`--features service`** AND `--all-features`, for `sparq-engine` + `sparq-server`.
- `cargo test -p sparq-engine --features service` (lib + SERVICE integration) and `cargo test -p sparq-server --features service` (full suite incl. `service_allowlist`) — green.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` (no-all-features) and `cargo doc -p … --all-features` — clean.
- `scripts/check-readme-template.py --enforce` — 0 deviations (no README touched).

**Feature flags:** `service` (sparq-engine) / `service` (sparq-server). OFF by default; core stays lean (no new deps).

Docs: `skills/sparql-query/SKILL.md` (engine egress) + `skills/http-server/SKILL.md` (`--service-allow` syntax + the tightening note) document the `host:port` syntax.

Closes `sq-a7jw4`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)