### PR TITLE
feat(fedclient): port-scoped SSRF egress allowlist entries, sharing the engine guard's rule (sq-vbnyc) [OPUS-4.8]

### DIFF
--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -47,6 +47,12 @@ pub use service::SERVICE_EGRESS_REFUSED_MARKER;
 // so federation is restricted to operator-configured endpoints. [OPUS-4.8] (sq-4w18)
 #[cfg(feature = "service")]
 pub use service::with_service_egress_policy;
+// [OPUS-4.8] (sq-vbnyc) The SERVICE-egress per-entry host:port matching rule, exposed as a
+// pure function so `sparq-fedclient`'s independent egress guard adopts the SAME port-scoping
+// semantics (port-0/overflow/IPv6-bracket/trailing-colon all handled identically) instead of
+// keeping a second, divergent copy of the allowlist-matching logic — one source of truth.
+#[cfg(feature = "service")]
+pub use service::{allowlist_entry_host_matches, allowlist_entry_permits};
 // Bind-join (VALUES pushdown) block-size knob — the only OPT-IN tunable for the
 // SERVICE bound-join pushdown (on-by-default, correctness-preserving). [OPUS-4.8] (sq-sjkj)
 #[cfg(feature = "service")]

--- a/crates/sparq-engine/src/service.rs
+++ b/crates/sparq-engine/src/service.rs
@@ -1058,17 +1058,79 @@ pub(crate) mod egress_policy {
     pub(crate) fn is_allowed(host: &str, port: u16) -> bool {
         let h = host.to_ascii_lowercase();
         POLICY.with(|p| {
-            p.borrow().allow.iter().any(|e| {
-                let (host_pattern, entry_port) = split_entry(e);
-                host_matches(host_pattern, &h) && entry_port.is_none_or(|ep| ep == port)
-            })
+            p.borrow()
+                .allow
+                .iter()
+                .any(|e| entry_permits(e, &h, port))
         })
+    }
+
+    /// True iff the single allowlist `entry` permits the lower-cased connect host `h` on
+    /// `port` — the pure per-entry predicate `is_allowed`'s `.any(…)` closure applies to
+    /// every stored entry. [OPUS-4.8] (sq-a7jw4)
+    ///
+    /// Factored out so the host:port parsing + matching semantics (port-0/overflow/
+    /// IPv6-bracket/trailing-colon all handled by [`split_entry`]) live in ONE place and can
+    /// be shared verbatim by the `sparq-fedclient` egress guard via
+    /// [`super::allowlist_entry_permits`] — there is no second, divergent copy of the
+    /// host:port rules (bead sq-vbnyc). `h` is expected pre-lower-cased; the public wrapper
+    /// lower-cases for callers that hold a raw host.
+    pub(crate) fn entry_permits(entry: &str, h: &str, port: u16) -> bool {
+        let (host_pattern, entry_port) = split_entry(entry);
+        host_matches(host_pattern, h) && entry_port.is_none_or(|ep| ep == port)
+    }
+
+    /// True iff the allowlist `entry`'s HOST part matches the lower-cased connect host `h`,
+    /// IGNORING any port constraint — i.e. "is `h` named by this entry on *some* port". [OPUS-4.8]
+    /// (sq-vbnyc). The fedclient guard's backward-compatible "is this host allowlisted at all"
+    /// query reuses this so the host-pattern parsing (bracket-stripping, suffix wildcard) lives in
+    /// ONE place rather than being re-derived client-side.
+    pub(crate) fn entry_host_matches(entry: &str, h: &str) -> bool {
+        let (host_pattern, _entry_port) = split_entry(entry);
+        host_matches(host_pattern, h)
     }
 
     /// The active policy mode.
     pub(crate) fn mode() -> Mode {
         POLICY.with(|p| p.borrow().mode)
     }
+}
+
+/// True iff a single SSRF-allowlist `entry` permits connecting to `host` on `port`. [OPUS-4.8] (sq-vbnyc)
+///
+/// This is the engine's SERVICE-egress per-entry matching rule, exposed so the
+/// **`sparq-fedclient`** crate's independent host-level egress guard can adopt the SAME
+/// port-scoping semantics rather than re-implementing the host:port parsing/matching (one
+/// source of truth — bead sq-vbnyc, follow-up to the engine's port-scoped allowlist sq-a7jw4).
+/// The fedclient guard owns its own per-instance allowlist storage but delegates the
+/// per-entry decision here, so the two guards agree byte-for-byte on every edge case:
+///
+/// * a **host-level** entry (no `:port`, e.g. `"sparql.internal"` or `".example.org"`)
+///   permits the host on EVERY port — the original, backward-compatible meaning;
+/// * a **port-scoped** entry (`host:port`, e.g. `"127.0.0.1:8053"` / `"[::1]:8080"` /
+///   `".example.org:443"`) permits the host ONLY on that exact port and rejects every other
+///   port on the same host — strictly narrower;
+/// * a malformed `:port` (out-of-range `:99999`, empty `:` trailing colon, non-numeric) is
+///   treated as part of a never-matching host pattern — fail-CLOSED, never widened;
+/// * a bare (unbracketed) IPv6 literal (`"2001:db8::1"`) is NOT amputated — host-level.
+///
+/// `host` is matched case-insensitively; matching is exact or a leading-dot suffix wildcard.
+/// There is NO wildcard port and no global bypass — a port-scoped entry can only tighten.
+#[cfg(feature = "service")]
+pub fn allowlist_entry_permits(entry: &str, host: &str, port: u16) -> bool {
+    egress_policy::entry_permits(entry, &host.to_ascii_lowercase(), port)
+}
+
+/// True iff a single SSRF-allowlist `entry`'s HOST part names `host`, IGNORING any port
+/// constraint — "is `host` reachable through this entry on *some* port". [OPUS-4.8] (sq-vbnyc)
+///
+/// Companion to [`allowlist_entry_permits`] for the `sparq-fedclient` guard's backward-compatible
+/// "is this host allowlisted at all" query (where the dialled port is not yet known), so the
+/// host-pattern parsing (IPv6-bracket stripping + `.suffix` wildcard) is NOT re-implemented
+/// client-side. Matching is case-insensitive, exact or leading-dot suffix wildcard.
+#[cfg(feature = "service")]
+pub fn allowlist_entry_host_matches(entry: &str, host: &str) -> bool {
+    egress_policy::entry_host_matches(entry, &host.to_ascii_lowercase())
 }
 
 /// Runs `f` with `hosts` allowlisted for SERVICE federation: each host's resolved
@@ -1920,6 +1982,32 @@ mod tests {
         assert_eq!(split_entry("127.0.0.1:99999"), ("127.0.0.1:99999", None));
         assert_eq!(split_entry("127.0.0.1:"), ("127.0.0.1:", None));
         assert_eq!(split_entry("127.0.0.1:http"), ("127.0.0.1:http", None));
+    }
+
+    #[test]
+    fn allowlist_entry_permits_is_the_shared_per_entry_rule() {
+        // Direct unit test for the PUBLIC per-entry predicate that `sparq-fedclient` reuses
+        // (coverage ratchet + the one-source-of-truth contract for bead sq-vbnyc). It is the
+        // pure, stateless form of `egress_policy::is_allowed`'s `.any(…)` closure — no policy
+        // install required.
+        use super::allowlist_entry_permits as permits;
+        // Host-level entry: all ports, case-insensitive host, suffix wildcard.
+        assert!(permits("sparql.internal", "sparql.internal", 80));
+        assert!(permits("sparql.internal", "SPARQL.INTERNAL", 8443)); // host case-insensitive
+        assert!(permits(".example.org", "a.example.org", 443));
+        assert!(permits(".example.org", "example.org", 80)); // apex included
+        assert!(!permits(".example.org", "notexample.org", 80)); // boundary respected
+        // Port-scoped entry: exact port only.
+        assert!(permits("127.0.0.1:8053", "127.0.0.1", 8053));
+        assert!(!permits("127.0.0.1:8053", "127.0.0.1", 8054)); // other port rejected
+        assert!(!permits("127.0.0.1:8053", "127.0.0.2", 8053)); // other host rejected
+        // Bracketed IPv6 + port; bare IPv6 host-level.
+        assert!(permits("[::1]:8080", "::1", 8080));
+        assert!(!permits("[::1]:8080", "::1", 80));
+        assert!(permits("2001:db8::1", "2001:db8::1", 443)); // bare IPv6 = all ports
+        // Malformed port → never-matching host pattern (fail-closed, never widened).
+        assert!(!permits("127.0.0.1:99999", "127.0.0.1", 80));
+        assert!(!permits("127.0.0.1:", "127.0.0.1", 80));
     }
 
     #[test]

--- a/crates/sparq-fedclient/src/discovery.rs
+++ b/crates/sparq-fedclient/src/discovery.rs
@@ -649,12 +649,14 @@ impl ureq::unversioned::resolver::Resolver for EgressFilterResolver {
         _config: &ureq::config::Config,
         _timeout: ureq::unversioned::transport::NextTimeout,
     ) -> Result<ureq::unversioned::resolver::ResolvedSocketAddrs, ureq::Error> {
-        let (host_port, host) = crate::ureq_egress::uri_host_port(uri).ok_or_else(|| {
+        let (host_port, host, port) = crate::ureq_egress::uri_host_port(uri).ok_or_else(|| {
             crate::ureq_egress::egress_refused(format!(
                 "discovery egress refused: request URI {uri} has no host authority to vet"
             ))
         })?;
-        let allowed = self.allow_private.contains(&host);
+        // Port-scoped allowlist: a `host:port` entry re-opens a private host only on its exact
+        // dialled port (shared host:port rule with the engine SERVICE guard; sq-vbnyc).
+        let allowed = crate::ureq_egress::allowlist_permits(&self.allow_private, &host, port);
         crate::ureq_egress::filter_resolved(&host_port, allowed, is_forbidden_ip, || {
             format!(
                 "discovery egress refused: {host_port} resolves only to private/internal \

--- a/crates/sparq-fedclient/src/source.rs
+++ b/crates/sparq-fedclient/src/source.rs
@@ -362,16 +362,47 @@ impl EgressGuard {
         }
     }
 
-    /// Allowlist a host (case-insensitive authority match) so its resolved addresses are
-    /// permitted even if private. Chainable.
+    /// Allowlist an entry so a matching host's resolved addresses are permitted even if private.
+    /// Chainable. An entry is either:
+    ///   * **host-level** (`"sparql.internal"`, `".example.org"` suffix wildcard, `"127.0.0.1"`,
+    ///     a bare IPv6 literal `"::1"`) — permits that host on EVERY port (the original meaning,
+    ///     preserved for backward compatibility); or
+    ///   * **port-scoped** (`"127.0.0.1:8053"`, `".example.org:443"`, bracketed IPv6 `"[::1]:8080"`)
+    ///     — permits that host ONLY on the exact `:port`, rejecting every other port on the same
+    ///     host. This is strictly narrower; there is no wildcard port and no global bypass.
+    ///
+    /// The `host:port` split + matching is the engine SERVICE guard's shared rule
+    /// ([`sparq_engine::allowlist_entry_permits`]) so the two guards agree on every edge case
+    /// (port-0/overflow/IPv6-bracket/trailing-colon all fail-CLOSED). [OPUS-4.8] sq-vbnyc.
     pub fn allow_host(mut self, host: impl Into<String>) -> Self {
         self.allow.insert(host.into().to_ascii_lowercase());
         self
     }
 
-    /// Is `host` (the bare authority, no port) on the allowlist?
+    /// Is `host` permitted on **any** port by the allowlist? Backward-compatible host-level query:
+    /// `true` when some entry permits `host` on at least one port — a host-level entry (all ports)
+    /// or a port-scoped entry (its single port). The load-bearing, port-precise check is
+    /// [`is_allowed_port`](Self::is_allowed_port); this convenience form answers "is this host on
+    /// the allowlist at all" and is used where the port is not yet known. [OPUS-4.8] sq-vbnyc.
     pub fn is_allowed(&self, host: &str) -> bool {
-        self.allow.contains(&host.to_ascii_lowercase())
+        let h = host.to_ascii_lowercase();
+        // "Allowed on SOME port" = some entry's host part names `h` (port ignored). Reuses the
+        // engine's shared host-pattern parse so bracket-stripping + suffix wildcard are not
+        // re-derived here.
+        self.allow
+            .iter()
+            .any(|entry| sparq_engine::allowlist_entry_host_matches(entry, &h))
+    }
+
+    /// Is `(host, port)` permitted by the allowlist? The load-bearing, PORT-SCOPED check: a
+    /// host-level entry permits `host` on every port; a `host:port` entry permits it ONLY on that
+    /// exact port. Delegates to the engine SERVICE guard's shared per-entry rule so the fedclient
+    /// guard and the engine guard decide every host:port case identically. [OPUS-4.8] sq-vbnyc.
+    pub fn is_allowed_port(&self, host: &str, port: u16) -> bool {
+        let h = host.to_ascii_lowercase();
+        self.allow
+            .iter()
+            .any(|entry| sparq_engine::allowlist_entry_permits(entry, &h, port))
     }
 
     /// The set of allowlisted hosts (lowercased bare authorities), so a native transport can
@@ -382,45 +413,52 @@ impl EgressGuard {
         &self.allow
     }
 
-    /// Vet one resolved address for `host`: `Ok(())` to dial it, `Err(reason)` to refuse.
-    /// An allowlisted host is always permitted; otherwise a [`is_forbidden_ip`] address is
-    /// refused. This is the per-address hook a real resolver calls on every candidate IP.
-    pub fn check_addr(&self, host: &str, ip: IpAddr) -> Result<(), String> {
-        if self.is_allowed(host) || !is_forbidden_ip(ip) {
+    /// Vet one resolved address for `host` dialled on `port`: `Ok(())` to dial it, `Err(reason)`
+    /// to refuse. The allowlist exemption fires only when the host AND port BOTH match (a
+    /// port-scoped entry re-opens a private address on its one port only); otherwise a
+    /// [`is_forbidden_ip`] address is refused. This is the per-address hook a resolver calls on
+    /// every candidate IP, now port-scoped to mirror the engine SERVICE guard. [OPUS-4.8] sq-vbnyc.
+    pub fn check_addr(&self, host: &str, port: u16, ip: IpAddr) -> Result<(), String> {
+        if self.is_allowed_port(host, port) || !is_forbidden_ip(ip) {
             Ok(())
         } else {
             Err(format!(
-                "host {host:?} resolved to private/internal address {ip} \
+                "host {host:?} resolved to private/internal address {ip} on port {port} \
                  (default-deny SSRF policy; allowlist the host to permit it)"
             ))
         }
     }
 
-    /// Vet an endpoint IRI end-to-end: parse the host authority, resolve it, and refuse if
-    /// *every* resolved address is forbidden (and the host is not allowlisted). An
-    /// allowlisted host short-circuits without a DNS lookup. Returns the bare host on
-    /// success (handy for logging / the adapter). On a non-allowlisted host this performs
-    /// a real DNS resolution and applies [`check_addr`](Self::check_addr) to each address,
-    /// mirroring the engine's resolver: refuse before any socket is opened. [OPUS-4.8].
+    /// Vet an endpoint IRI end-to-end: parse the host authority + port, resolve it, and refuse if
+    /// *every* resolved address is forbidden (and the host:port is not allowlisted). An
+    /// allowlisted host:port short-circuits without a DNS lookup. Returns the bare host on
+    /// success (handy for logging / the adapter). On a non-allowlisted host this performs a real
+    /// DNS resolution and applies [`check_addr`](Self::check_addr) to each address, mirroring the
+    /// engine's resolver: refuse before any socket is opened.
+    ///
+    /// The PORT is the authority's explicit `:port` or the scheme default (the SAME port actually
+    /// dialled), so a port-scoped allowlist entry (`host:port`) is honoured exactly as the engine
+    /// SERVICE guard honours it: it re-opens the host on that one port only. [OPUS-4.8] sq-vbnyc.
     pub fn check_endpoint(&self, endpoint: &str) -> Result<String, FedError> {
-        let host = endpoint_host(endpoint)
+        let (host, port) = endpoint_host_port(endpoint)
             .ok_or_else(|| FedError::BadEndpoint(format!("no host authority in {endpoint:?}")))?;
-        // Allowlisted host: permitted without a lookup (matches the engine's resolver,
-        // which lets an allowlisted host through even if it resolves privately).
-        if self.is_allowed(&host) {
+        // Allowlisted host:port: permitted without a lookup (matches the engine's resolver, which
+        // lets an allowlisted host through even if it resolves privately). A port-scoped entry
+        // only short-circuits for its exact dialled port.
+        if self.is_allowed_port(&host, port) {
             return Ok(host);
         }
         // An IP-literal authority is vetted directly (no DNS).
         if let Ok(ip) = host.parse::<IpAddr>() {
             return self
-                .check_addr(&host, ip)
+                .check_addr(&host, port, ip)
                 .map(|()| host.clone())
                 .map_err(FedError::EgressRefused);
         }
-        // A DNS name: resolve and require at least one permitted address. Resolution uses
-        // the host with a dummy port so the std resolver returns socket addresses.
+        // A DNS name: resolve and require at least one permitted address. Resolution uses the
+        // host with the dialled port so the std resolver returns socket addresses.
         use std::net::ToSocketAddrs;
-        let resolved: Vec<IpAddr> = (host.as_str(), 80u16)
+        let resolved: Vec<IpAddr> = (host.as_str(), port)
             .to_socket_addrs()
             .map_err(|e| {
                 FedError::EgressRefused(format!("DNS resolution of {host:?} failed: {e}"))
@@ -447,8 +485,17 @@ impl EgressGuard {
 /// A tiny tolerant parser so the egress gate has no URL-crate dependency of its own (the
 /// crate already pulls `oxrdf`/`spargebra`, not `url`, under `fedclient`). [OPUS-4.8].
 fn endpoint_host(endpoint: &str) -> Option<String> {
-    // scheme://authority/path?query — take what follows "://".
-    let after_scheme = endpoint.split_once("://").map(|(_, rest)| rest)?;
+    endpoint_host_port(endpoint).map(|(host, _port)| host)
+}
+
+/// Extract the bare host authority (lowercased, IPv6 brackets stripped) **and** the authority
+/// port from an endpoint IRI: the explicit `:port`, or the scheme default (443 for `https`,
+/// 80 otherwise — the SAME port that is actually dialled). Returns `None` when there is no host
+/// authority. The port is what makes a PORT-SCOPED allowlist entry (`host:port`) decidable, so the
+/// fedclient guard matches the engine SERVICE guard's authority handling exactly. [OPUS-4.8] sq-vbnyc.
+fn endpoint_host_port(endpoint: &str) -> Option<(String, u16)> {
+    // scheme://authority/path?query — take the scheme + what follows "://".
+    let (scheme, after_scheme) = endpoint.split_once("://")?;
     // authority ends at the first '/', '?' or '#'.
     let authority = after_scheme
         .split(['/', '?', '#'])
@@ -462,17 +509,32 @@ fn endpoint_host(endpoint: &str) -> Option<String> {
     if hostport.is_empty() {
         return None;
     }
-    // IPv6 literal: [::1]:80 — take what is inside the brackets.
+    let default_port = if scheme.eq_ignore_ascii_case("https") {
+        443
+    } else {
+        80
+    };
+    // IPv6 literal: [::1] or [::1]:80 — take what is inside the brackets; the port (if any)
+    // follows the closing bracket.
     if let Some(rest) = hostport.strip_prefix('[') {
-        let host = rest.split_once(']').map(|(h, _)| h).unwrap_or(rest);
-        return (!host.is_empty()).then(|| host.to_ascii_lowercase());
+        let (host, after) = rest.split_once(']').unwrap_or((rest, ""));
+        if host.is_empty() {
+            return None;
+        }
+        let port = after
+            .strip_prefix(':')
+            .and_then(|p| p.parse::<u16>().ok())
+            .unwrap_or(default_port);
+        return Some((host.to_ascii_lowercase(), port));
     }
-    // host or host:port — strip the port.
-    let host = hostport
-        .rsplit_once(':')
-        .map(|(h, _)| h)
-        .unwrap_or(hostport);
-    (!host.is_empty()).then(|| host.to_ascii_lowercase())
+    // host or host:port — split off the port (only a single trailing `:digits`; a bare IPv6
+    // literal here has no brackets but `to_socket_addrs` would reject it anyway, so a multi-colon
+    // string keeps the whole thing as the host and the default port).
+    let (host, port) = match hostport.rsplit_once(':') {
+        Some((h, p)) if !h.contains(':') => (h, p.parse::<u16>().unwrap_or(default_port)),
+        _ => (hostport, default_port),
+    };
+    (!host.is_empty()).then(|| (host.to_ascii_lowercase(), port))
 }
 
 // ─── Native HTTP transport that PINS the guard-vetted IP (no re-resolve TOCTOU) ──────
@@ -578,12 +640,14 @@ impl ureq::unversioned::resolver::Resolver for EgressFilterResolver {
         _config: &ureq::config::Config,
         _timeout: ureq::unversioned::transport::NextTimeout,
     ) -> Result<ureq::unversioned::resolver::ResolvedSocketAddrs, ureq::Error> {
-        let (host_port, host) = crate::ureq_egress::uri_host_port(uri).ok_or_else(|| {
+        let (host_port, host, port) = crate::ureq_egress::uri_host_port(uri).ok_or_else(|| {
             crate::ureq_egress::egress_refused(format!(
                 "federation egress refused: request URI {uri} has no host authority to vet"
             ))
         })?;
-        let allowed = self.allow_private.contains(&host);
+        // Port-scoped allowlist: a `host:port` entry re-opens a private host only on its exact
+        // dialled port (shared host:port rule with the engine SERVICE guard; sq-vbnyc).
+        let allowed = crate::ureq_egress::allowlist_permits(&self.allow_private, &host, port);
         crate::ureq_egress::filter_resolved(&host_port, allowed, is_forbidden_ip, || {
             format!(
                 "federation egress refused: {host_port} resolves only to private/internal \
@@ -1685,6 +1749,43 @@ mod tests {
         assert_eq!(endpoint_host("http:///nohost"), None);
     }
 
+    #[test]
+    fn host_port_parsing() {
+        // Direct unit test for the port-aware authority parser (coverage ratchet, sq-vbnyc).
+        // Explicit port preserved.
+        assert_eq!(
+            endpoint_host_port("http://127.0.0.1:8053/sparql"),
+            Some(("127.0.0.1".to_string(), 8053))
+        );
+        assert_eq!(
+            endpoint_host_port("https://EXAMPLE.org:8443/q"),
+            Some(("example.org".to_string(), 8443))
+        );
+        assert_eq!(
+            endpoint_host_port("http://[2001:db8::1]:8080/sparql"),
+            Some(("2001:db8::1".to_string(), 8080))
+        );
+        // Scheme defaults when no explicit port (443 for https, 80 otherwise).
+        assert_eq!(
+            endpoint_host_port("http://dbpedia.org/sparql"),
+            Some(("dbpedia.org".to_string(), 80))
+        );
+        assert_eq!(
+            endpoint_host_port("https://dbpedia.org/sparql"),
+            Some(("dbpedia.org".to_string(), 443))
+        );
+        assert_eq!(
+            endpoint_host_port("http://[::1]/sparql"),
+            Some(("::1".to_string(), 80))
+        );
+        // Userinfo stripped; no authority → None.
+        assert_eq!(
+            endpoint_host_port("http://user:pw@host.example:9000/p"),
+            Some(("host.example".to_string(), 9000))
+        );
+        assert_eq!(endpoint_host_port("http:///nohost"), None);
+    }
+
     // ── DENY: default guard refuses a loopback / private endpoint ─────────────────
 
     #[test]
@@ -1780,6 +1881,145 @@ mod tests {
         let ep = Endpoint::new("http://8.8.8.8/sparql", Box::new(transport));
         let got = ep.execute(&SubQuery::new("ASK { ?s ?p ?o }")).unwrap();
         assert_eq!(got, body);
+    }
+
+    // ── Port-scoped allowlist entries (sq-vbnyc, mirrors engine sq-a7jw4) ─────────
+    //
+    // These adversarial cases mirror `sparq-engine`'s SERVICE-egress port-scoping tests on the
+    // fedclient guard. The fedclient guard delegates the per-entry decision to the engine's
+    // shared `allowlist_entry_permits`, so the two guards MUST agree on every host:port case.
+
+    #[test]
+    fn is_allowed_port_exact_host_port_permitted() {
+        // (a) A `host:port` entry permits ONLY that host on THAT exact port.
+        let g = EgressGuard::deny_private().allow_host("127.0.0.1:8053");
+        assert!(g.is_allowed_port("127.0.0.1", 8053)); // exact host:port
+    }
+
+    #[test]
+    fn is_allowed_port_same_host_other_port_rejected() {
+        // (b) The same host on any OTHER port is rejected — strictly narrower than host-level.
+        let g = EgressGuard::deny_private().allow_host("127.0.0.1:8053");
+        assert!(!g.is_allowed_port("127.0.0.1", 8054)); // other port
+        assert!(!g.is_allowed_port("127.0.0.1", 80)); //   default port
+    }
+
+    #[test]
+    fn is_allowed_port_different_host_rejected() {
+        // (c) A different host on the entry's port is rejected.
+        let g = EgressGuard::deny_private().allow_host("127.0.0.1:8053");
+        assert!(!g.is_allowed_port("127.0.0.2", 8053));
+    }
+
+    #[test]
+    fn host_level_entry_permits_all_ports_backward_compat() {
+        // (d) An existing host-level entry (no port) keeps its meaning: every port on that host.
+        // This is the unchanged pre-sq-vbnyc semantics.
+        let g = EgressGuard::deny_private().allow_host("127.0.0.1");
+        assert!(g.is_allowed_port("127.0.0.1", 80));
+        assert!(g.is_allowed_port("127.0.0.1", 8053));
+        assert!(g.is_allowed_port("127.0.0.1", 65535));
+        assert!(!g.is_allowed_port("127.0.0.2", 80)); // different host still rejected
+        // The host-level convenience query stays true for the bare host (any port).
+        assert!(g.is_allowed("127.0.0.1"));
+    }
+
+    #[test]
+    fn port_scoped_suffix_wildcard_is_port_constrained() {
+        // A port on a suffix-wildcard entry constrains the port too: `.example.org:443` permits
+        // any subdomain (and the apex) on 443 only.
+        let g = EgressGuard::deny_private().allow_host(".example.org:443");
+        assert!(g.is_allowed_port("sparql.example.org", 443)); // subdomain on 443
+        assert!(g.is_allowed_port("example.org", 443)); // apex on 443
+        assert!(!g.is_allowed_port("sparql.example.org", 80)); // wrong port
+        assert!(!g.is_allowed_port("notexample.org", 443)); // boundary respected
+    }
+
+    #[test]
+    fn bracketed_ipv6_port_scoped_entry() {
+        // A bracketed IPv6 `[::1]:8080` entry is port-scoped on the bare `::1` host.
+        let g = EgressGuard::deny_private().allow_host("[::1]:8080");
+        assert!(g.is_allowed_port("::1", 8080));
+        assert!(!g.is_allowed_port("::1", 80));
+    }
+
+    #[test]
+    fn bare_ipv6_entry_is_host_level_not_port_amputated() {
+        // A bare (unbracketed) IPv6 literal must NOT have its last hextet read as a port —
+        // `2001:db8::1` is a host-level entry matching every port (fail-safe, not fail-open).
+        let g = EgressGuard::deny_private().allow_host("2001:db8::1");
+        assert!(g.is_allowed_port("2001:db8::1", 443));
+        assert!(g.is_allowed_port("2001:db8::1", 80));
+    }
+
+    #[test]
+    fn malformed_port_in_entry_fails_closed() {
+        // A `:port` that does not parse as a u16 is treated as part of a never-matching host
+        // pattern, NOT as "drop the port constraint and match every port" — fail-CLOSED, never
+        // widening the allowlist. (port-0 overflow `:99999`, trailing colon `:`, non-numeric.)
+        for entry in ["127.0.0.1:99999", "127.0.0.1:", "127.0.0.1:http"] {
+            let g = EgressGuard::deny_private().allow_host(entry);
+            assert!(!g.is_allowed_port("127.0.0.1", 80), "{entry} widened port 80");
+            assert!(
+                !g.is_allowed_port("127.0.0.1", 65535),
+                "{entry} widened port 65535"
+            );
+            assert!(!g.is_allowed("127.0.0.1"), "{entry} widened host-level query");
+        }
+    }
+
+    #[test]
+    fn check_endpoint_honours_port_scoped_entry_end_to_end() {
+        // The end-to-end guard path: a private literal allowlisted ONLY on :8053 is permitted on
+        // 8053 and refused on 8080 (the scheme default would otherwise apply). This is the load-
+        // bearing invariant — the port that is dialled is the port that is vetted.
+        let g = EgressGuard::deny_private().allow_host("127.0.0.1:8053");
+        assert_eq!(
+            g.check_endpoint("http://127.0.0.1:8053/sparql").unwrap(),
+            "127.0.0.1"
+        );
+        assert!(matches!(
+            g.check_endpoint("http://127.0.0.1:8080/sparql").unwrap_err(),
+            FedError::EgressRefused(_)
+        ));
+        // The scheme default (80) is also refused — only :8053 is open.
+        assert!(matches!(
+            g.check_endpoint("http://127.0.0.1/sparql").unwrap_err(),
+            FedError::EgressRefused(_)
+        ));
+    }
+
+    #[test]
+    fn endpoint_execute_port_scoped_allow_gates_the_transport() {
+        // The full adapter path: a private host allowlisted on :7777 reaches the transport on
+        // 7777 but NOT on 9999 (PanicTransport would panic if a refused dial reached it).
+        let body = r#"{"head":{"vars":[]},"results":{"bindings":[]}}"#;
+        let guard = EgressGuard::deny_private().allow_host("127.0.0.1:7777");
+        let ep_ok = Endpoint::with_guard(
+            "http://127.0.0.1:7777/sparql",
+            Box::new(CannedTransport::new(body)),
+            guard.clone(),
+        );
+        assert_eq!(ep_ok.execute(&SubQuery::new("ASK {}")).unwrap(), body);
+
+        let ep_bad =
+            Endpoint::with_guard("http://127.0.0.1:9999/sparql", Box::new(PanicTransport), guard);
+        assert!(matches!(
+            ep_bad.execute(&SubQuery::new("ASK {}")).unwrap_err(),
+            FedError::EgressRefused(_)
+        ));
+    }
+
+    #[test]
+    fn check_addr_is_port_scoped() {
+        // The per-address hook: an allowlisted-on-:8053 private IP is dialable on 8053, refused on
+        // 8080. A public IP is always dialable regardless of port (the guard only gates private).
+        let g = EgressGuard::deny_private().allow_host("127.0.0.1:8053");
+        let lo: IpAddr = "127.0.0.1".parse().unwrap();
+        assert!(g.check_addr("127.0.0.1", 8053, lo).is_ok());
+        assert!(g.check_addr("127.0.0.1", 8080, lo).is_err());
+        let public: IpAddr = "8.8.8.8".parse().unwrap();
+        assert!(g.check_addr("8.8.8.8", 12345, public).is_ok());
     }
 
     // ── capability defaults ───────────────────────────────────────────────────────

--- a/crates/sparq-fedclient/src/ureq_egress.rs
+++ b/crates/sparq-fedclient/src/ureq_egress.rs
@@ -28,9 +28,12 @@ use std::net::ToSocketAddrs;
 const RESOLVED_ADDRS_CAP: usize = 16;
 
 /// `host:port` (for resolution) + the bare host (the allowlist key — IPv6 brackets stripped,
-/// lowercased) from a ureq-3 request [`Uri`](ureq::http::Uri). `port` falls back to the scheme
-/// default (443 for https, 80 otherwise). `None` when the URI carries no host authority.
-pub(crate) fn uri_host_port(uri: &ureq::http::Uri) -> Option<(String, String)> {
+/// lowercased) + the numeric `port` from a ureq-3 request [`Uri`](ureq::http::Uri). `port` falls
+/// back to the scheme default (443 for https, 80 otherwise). `None` when the URI carries no host
+/// authority. The numeric port lets the SSRF resolver apply a PORT-SCOPED allowlist entry (a
+/// `host:port` allowlist entry permits only that exact dialled port), consistent with the engine's
+/// SERVICE egress guard. [OPUS-4.8] sq-vbnyc.
+pub(crate) fn uri_host_port(uri: &ureq::http::Uri) -> Option<(String, String, u16)> {
     let authority = uri.authority()?;
     let host = authority.host();
     if host.is_empty() {
@@ -43,7 +46,23 @@ pub(crate) fn uri_host_port(uri: &ureq::http::Uri) -> Option<(String, String)> {
     // The authority host keeps IPv6 brackets (`[::1]`); strip them for the allowlist key and for
     // `to_socket_addrs` (which wants the bare host + a separate port).
     let bare = host.trim_start_matches('[').trim_end_matches(']');
-    Some((format!("{bare}:{port}"), bare.to_ascii_lowercase()))
+    Some((format!("{bare}:{port}"), bare.to_ascii_lowercase(), port))
+}
+
+/// True iff any allowlist `entry` permits dialling `host` on `port`, using the engine's shared
+/// SERVICE-egress per-entry rule ([`sparq_engine::allowlist_entry_permits`]). The federation
+/// SSRF resolvers call this instead of a bare `allow.contains(host)`, so a PORT-SCOPED allowlist
+/// entry (`host:port`) re-opens a private host ONLY on its exact dialled port — byte-for-byte the
+/// same host:port matching the engine guard applies (one source of truth, bead sq-vbnyc). A
+/// host-level entry (no `:port`) still re-opens every port (backward compatible). [OPUS-4.8].
+pub(crate) fn allowlist_permits(
+    allow: &std::collections::HashSet<String>,
+    host: &str,
+    port: u16,
+) -> bool {
+    allow
+        .iter()
+        .any(|entry| sparq_engine::allowlist_entry_permits(entry, host, port))
 }
 
 /// Wrap a refusal `reason` as a `PermissionDenied` [`ureq::Error::Io`], preserving the kind (the

--- a/skills/federated-planning/SKILL.md
+++ b/skills/federated-planning/SKILL.md
@@ -274,6 +274,21 @@ since:
   unsupported — distinguish the two with `Capability::advertises_sparql_versions()`.
 - **Phase 2 source abstraction** (`sq-rsxf`) — the `Endpoint` adapter over the engine's
   transport seam behind a default-deny SSRF guard.
+  - **Port-scoped allowlist entries** (`sq-vbnyc`, follow-up to the engine's `sq-a7jw4`):
+    `source::EgressGuard`'s host allowlist now accepts a **port-scoped** entry (`127.0.0.1:8053`,
+    `[::1]:8080`, `.example.org:443`) that re-opens a private host on THAT exact port only —
+    strictly narrower than a bare host-level entry, which still re-opens every port (backward
+    compatible). The dialled port (the authority's `:port` or the scheme default) is the port
+    vetted, so a `host:port` entry never widens. The fedclient guard delegates the per-entry
+    decision to the engine's shared `sparq_engine::allowlist_entry_permits` (and
+    `allowlist_entry_host_matches` for the host-level "is this host on the list at all" query), so
+    the **fedclient guard and the engine SERVICE guard decide every host:port case identically**
+    — one source of truth, no divergent copy of the parsing (port-0/overflow/IPv6-bracket/
+    trailing-colon all fail-CLOSED). The same port-scoping flows through `EgressGuard::check_addr`
+    / `check_endpoint` and all three native ureq SSRF resolvers (`HttpTransport` /
+    `HttpFragmentTransport` / discovery `HttpFetcher`). There is no wildcard port and no global
+    bypass; default-deny stays default-deny. Use `EgressGuard::is_allowed_port(host, port)` for the
+    port-precise check.
 - **Phase 3 planner bridge + single-source interpreter** (`sq-j27p`) — the consumer of THIS
   planner's `JoinTree`. The plan speaks pattern/source **indices** only (no endpoint-URL
   mapping — the Phase-0 finding); `sparq_fedclient::SourceResolver` is the **index → adapter


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-vbnyc** (epic **sq-my8wd**, federation SSRF hardening; the follow-up the #1309 verify identified). Flagged for Fable re-review when available.

## What & why

`sparq-fedclient` had its OWN independent host-level SSRF egress guard (`source::EgressGuard`, an exact-host `is_allowed(host)` check) that was **not port-scoped** — inconsistent with the engine's port-scoped SERVICE egress allowlist that **#1309** (`sq-a7jw4`) just landed. This PR extends the fedclient guard to support **port-scoped (`host:port`) allowlist entries**, made **consistent with the engine guard by REUSING the engine's matching logic** rather than duplicating the host:port parsing — one source of truth.

## How (one source of truth)

- **Engine** (`crates/sparq-engine/src/service.rs`): factored the per-entry predicate out of `egress_policy::is_allowed` into `egress_policy::entry_permits`, and exposed two **pure public** wrappers (feature `service`): `allowlist_entry_permits(entry, host, port)` and `allowlist_entry_host_matches(entry, host)`. `is_allowed` now delegates to `entry_permits` (no behaviour change). So port-0 / `:99999` overflow / IPv6-bracket / trailing-colon are parsed in **exactly one place** (`split_entry`).
- **Fedclient** (`source.rs`): new `EgressGuard::is_allowed_port(host, port)` (the load-bearing port-precise check) + a **port-aware** `check_addr` / `check_endpoint` that parse the **dialled** port (authority `:port` or scheme default) and thread it through; `endpoint_host_port` replaces the bare-host parse. The backward-compatible `is_allowed(host)` "any port" query reuses `allowlist_entry_host_matches`. `allow_host` now accepts `host:port` entries.
- **All three native ureq SSRF resolvers** (`HttpTransport`, `HttpFragmentTransport`, discovery `HttpFetcher`) become port-aware via a shared `ureq_egress::allowlist_permits` helper that calls the engine rule, so the **resolved-IP re-vet** (DNS-rebinding safety) is preserved **and** port-scoped.

## Security invariants (same as #1309)

1. a `host:port` entry permits ONLY that host on THAT port; same-host other-port is **rejected**;
2. **backward compatible** — existing host-level (no-port) entries keep meaning **all ports**;
3. the resolved-IP re-vet on the fedclient path is **preserved** (still vets the dialled IP);
4. **no** wildcard-port / global-disable bypass — a port-scoped entry can only **tighten**; default-deny stays default-deny;
5. the fedclient guard now matches the engine guard's behaviour **exactly** (consistency is the point — same `allowlist_entry_permits`).

## Tests (mirror #1309's adversarial cases on the fedclient path)

exact `host:port` permitted, same-host-other-port rejected, different-host rejected, host-level backward compat, port-scoped suffix wildcard, bracketed-IPv6 port-scoped, bare-IPv6 **not** port-amputated, and malformed ports (port-0, `:99999` overflow, trailing colon, non-numeric) all **fail-CLOSED** (never widen). Direct unit test per new/changed public fn (coverage ratchet), plus end-to-end `check_endpoint` + adapter-`execute` gating (PanicTransport never reached on a refused dial).

## Gates run (BOTH feature states)

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test`: GREEN with **fedclient OFF** (compiles to nothing) and **fedclient ON**, and engine **service OFF** (223 lib tests) and **service ON** (297 lib tests + all integration binaries).
- `cargo clippy --all-features -D warnings`: clean (engine + fedclient).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` **and** `--all-features`: both clean (no feature-gated intra-doc-link breakage).
- `python3 scripts/check-readme-template.py --enforce`: 0 deviations.

Feature flags: `sparq-fedclient/fedclient` (the client surface; pulls `sparq-engine/service`), `sparq-engine/service` (the shared egress helpers). All new code is `#[cfg(feature = …)]`-gated; the default workspace build is byte-identical.

Docs: `skills/federated-planning/SKILL.md` notes the fedclient guard is now port-scoped and consistent with the engine.

Refs **sq-vbnyc**, epic **sq-my8wd**; follow-up to **#1309** (`sq-a7jw4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)