### PR TITLE
feat(server): 406 on a present-but-unsatisfiable Accept (Oxigraph parity) (sq-xpb1z) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1645,7 +1645,9 @@ jobs:
             exit 1
           fi
           PASS=$(grep -E '^TOTAL http-protocol ' http-protocol-conformance.out | awk '{print $3}' | head -1)
-          FLOOR=20
+          # [OPUS-4.8] sq-406acc: raised 20→21 when the present-but-unsatisfiable Accept 406
+          # (Oxigraph parity, w3c/sparql-protocol#40) flipped from a divergence to a genuine PASS.
+          FLOOR=21
           echo "SPARQL 1.1 Protocol (HTTP) pass: ${PASS:-unknown} (floor: $FLOOR)"
           [ -n "$PASS" ] && [ "$PASS" -ge "$FLOOR" ] || { echo "::error::SPARQL-Protocol lane regressed below the ratchet ($PASS < $FLOOR)"; exit 1; }
       # [OPUS-4.8] sq-1uuxz (epic sq-my8wd) — the SPARQL 1.1 SERVICE-DESCRIPTION + GRAPH-STORE

--- a/crates/sparq-conformance/Cargo.toml
+++ b/crates/sparq-conformance/Cargo.toml
@@ -121,7 +121,8 @@ service = ["service-loopback"]
 # and the runner compiles to a single self-SKIP `#[test]`, so the bare `cargo test -p
 # sparq-conformance` (and the default `--workspace` shards) link none of it — the lean opt-in
 # posture. The pinned `HTTP_PROTOCOL_FLOOR` is the MEASURED PASS count; documented protocol
-# divergences (e.g. sparq's 406-less Accept fallback) are reported separately, NEVER summed in.
+# divergences (e.g. an absent / */* Accept defaulting to JSON — the W3C-permitted default; a
+# present-but-unsatisfiable Accept now 406, sq-406acc) are reported separately, NEVER summed in.
 http-protocol = ["service-loopback"]
 
 # [OPUS-4.8] sq-1uuxz (epic sq-my8wd) — the SPARQL 1.1 **Service-Description** + **Graph-Store

--- a/crates/sparq-conformance/src/http_protocol.rs
+++ b/crates/sparq-conformance/src/http_protocol.rs
@@ -31,22 +31,23 @@
 //!
 //! This is a **W3C SPARQL Protocol** conformance lane (family `W3C SPARQL`), distinct from the
 //! experimental `sparq extension` ratchets. Each assertion that PASSES reflects a behaviour the
-//! server genuinely implements end-to-end over real HTTP. The protocol features the server does
-//! **NOT** implement are recorded as DOCUMENTED DIVERGENCES (an [`Outcome::Divergence`]), never
-//! a faked pass:
+//! server genuinely implements end-to-end over real HTTP. [OPUS-4.8] sq-406acc: the server now
+//! returns **406 Not Acceptable** for a present-but-unsatisfiable `Accept` (a SELECT/ASK request
+//! whose `Accept` names no supported result format and no wildcard), matching Oxigraph
+//! (w3c/sparql-protocol#40) — previously the documented sparq-vs-Oxigraph fallback divergence,
+//! now a genuine PASS that raises the floor 20→21. The protocol features the server does **NOT**
+//! implement are recorded as DOCUMENTED DIVERGENCES (an [`Outcome::Divergence`]), never a faked
+//! pass:
 //!
-//! * **406 Not Acceptable for an unsatisfiable `Accept` (SELECT/ASK)** — sparq's content
-//!   negotiation deliberately FALLS BACK to SPARQL-results JSON rather than returning 406 (the
-//!   documented sparq-vs-Oxigraph negotiation difference recorded in
-//!   `server/tests/query_method.rs::query_method_unsupported_accept_falls_back_to_json`). The
-//!   W3C Protocol permits a server to choose a default representation, so this is a permitted
-//!   divergence, not a violation — but it means a 406 is NOT a genuine status the SELECT/ASK
-//!   path emits, so this lane records it as a divergence and asserts the FALLBACK behaviour
-//!   (200 + JSON) honestly, rather than asserting a 406 the server never sends.
 //! * **ASK boolean in CSV/TSV** — CSV and TSV have no boolean serialisation, so an ASK with
 //!   `Accept: text/csv` correctly falls back to a JSON boolean (`ask_content_type`); the lane
 //!   asserts that genuine fallback (a divergence from a naive "every Accept yields its own
 //!   media type" expectation), not a CSV ASK body the server never produces.
+//! * **absent / `*/*` Accept defaults to SRJ** — the W3C Protocol permits a default
+//!   representation when `Accept` is absent (or a wildcard), so sparq keeps serving
+//!   SPARQL-results JSON in that case rather than 406; the lane records this default as a
+//!   divergence (asserting the converse of the 406 strictness) so the floor counts only the one
+//!   genuine 406 pass.
 //!
 //! The FLOOR (`HTTP_PROTOCOL_FLOOR`, in the gating runner `tests/http_protocol_suite.rs`) is
 //! the MEASURED count of PASS assertions — divergences are reported separately and are NOT
@@ -248,9 +249,10 @@ pub fn parse_response(raw: &[u8]) -> Result<HttpResponse, String> {
 pub enum Outcome {
     /// The server genuinely satisfied the W3C-Protocol behaviour this assertion checks.
     Pass,
-    /// A documented divergence: a behaviour the server deliberately does NOT implement (e.g.
-    /// 406 on an unsatisfiable Accept — it falls back to JSON instead). Reported separately,
-    /// NEVER summed into the floor. The string is the human-readable note.
+    /// A documented divergence: a permitted behaviour distinct from a naive expectation (e.g. an
+    /// absent / `*/*` Accept defaulting to SPARQL-results JSON rather than 406 — the W3C-permitted
+    /// default representation). Reported separately, NEVER summed into the floor. The string is
+    /// the human-readable note.
     Divergence(String),
     /// A genuine failure: the server's response contradicts what it is supposed to do. Always
     /// fails the gate.
@@ -577,32 +579,63 @@ pub fn run_protocol_suite() -> SuiteReport {
         &HttpRequest::new("DELETE", "/sparql"),
     );
 
-    // --- Documented divergence: 406 on an unsatisfiable Accept (SELECT) ---
-    // sparq FALLS BACK to SRJ rather than 406 (the documented sparq-vs-Oxigraph difference).
-    // We assert the genuine fallback and record it as a DIVERGENCE, never a faked 406 pass.
+    // --- 406 on a present-but-unsatisfiable Accept (SELECT) — now a genuine PASS ---
+    // [OPUS-4.8] sq-406acc: sparq now returns 406 Not Acceptable when an `Accept` header is
+    // present and names no supported SELECT/ASK result format (and no wildcard), matching
+    // Oxigraph (w3c/sparql-protocol#40). This was the documented sparq-vs-Oxigraph divergence;
+    // closing it raises HTTP_PROTOCOL_FLOOR 20→21 honestly (the server genuinely emits 406).
     {
-        let label = "unsatisfiable Accept (image/png) on SELECT falls back to SRJ, not 406 \
-                     (documented sparq-vs-Oxigraph divergence)";
+        let label = "unsatisfiable Accept (image/png) on SELECT → 406 Not Acceptable \
+                     (Oxigraph parity, sq-406acc)";
         match send(addr, &select_get(&urlenc_select, "image/png")) {
-            Ok(resp) if resp.status == 200 && content_type_is(resp.content_type(), "application/sparql-results+json") => {
-                report.record(
-                    label,
-                    Outcome::Divergence(
-                        "sparq returns 200 + SPARQL-results JSON for an unsatisfiable Accept; \
-                         it does not emit 406 (W3C-permitted default representation)"
-                            .to_string(),
-                    ),
-                );
-            }
+            Ok(resp) if resp.status == 406 => report.record(label, Outcome::Pass),
             Ok(resp) => report.record(
                 label,
                 Outcome::Fail(format!(
-                    "expected the documented 200+SRJ fallback, got status {} ct {:?}",
+                    "expected 406 for a present-but-unsatisfiable Accept, got status {} ct {:?}",
                     resp.status,
                     resp.content_type()
                 )),
             ),
             Err(e) => report.record(label, Outcome::Fail(e)),
+        }
+    }
+
+    // --- The converse: an absent / `*/*` Accept still defaults to SRJ (NOT a 406) ---
+    // [OPUS-4.8] sq-406acc: the strictness above must NOT regress the W3C-permitted default
+    // representation when `Accept` is absent or a wildcard. This is the load-bearing
+    // answer-safety check for the change; recorded as a DIVERGENCE so the floor stays at the
+    // honest single +1 (the 406 pass) while still exercising the converse on every run.
+    {
+        let label = "absent / */* Accept on SELECT still defaults to SRJ, not 406 (sq-406acc)";
+        // No Accept header at all → JSON default.
+        let no_accept = HttpRequest::new("GET", &urlenc_select);
+        let wildcard = select_get(&urlenc_select, "*/*");
+        let absent_ok = matches!(
+            send(addr, &no_accept),
+            Ok(ref r) if r.status == 200 && content_type_is(r.content_type(), "application/sparql-results+json")
+        );
+        let wildcard_ok = matches!(
+            send(addr, &wildcard),
+            Ok(ref r) if r.status == 200 && content_type_is(r.content_type(), "application/sparql-results+json")
+        );
+        if absent_ok && wildcard_ok {
+            report.record(
+                label,
+                Outcome::Divergence(
+                    "absent / */* Accept defaults to SPARQL-results JSON (W3C-permitted default \
+                     representation); only a present-but-unsatisfiable Accept is 406"
+                        .to_string(),
+                ),
+            );
+        } else {
+            report.record(
+                label,
+                Outcome::Fail(format!(
+                    "absent/*/* Accept must default to 200+SRJ (absent_ok={}, wildcard_ok={})",
+                    absent_ok, wildcard_ok
+                )),
+            );
         }
     }
 

--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -171,12 +171,13 @@ pub struct Suite {
 ///   a REAL in-process loopback endpoint — the sq-ushvx harness — and driving the
 ///   federated query end-to-end through the engine's REAL ureq transport; a
 ///   variable SERVICE endpoint + a nested non-SILENT SERVICE are documented Skips).
-/// * SPARQL 1.1 Protocol (HTTP) 20 — `sparq-conformance`
-///   `tests/http_protocol_suite.rs` `HTTP_PROTOCOL_FLOOR = 20` (sq-jaj38; opt-in
+/// * SPARQL 1.1 Protocol (HTTP) 21 — `sparq-conformance`
+///   `tests/http_protocol_suite.rs` `HTTP_PROTOCOL_FLOOR = 21` (sq-jaj38; opt-in
 ///   `http-protocol` feature; RAW HTTP requests at the in-process loopback server
 ///   exercising the SPARQL 1.1 Protocol contract — GET/POST query+update, the QUERY
-///   method, dataset overrides, SRJ/SRX/CSV/TSV negotiation, 200/400/405/415; the
-///   406-less Accept fallback + ASK-in-CSV are documented divergences, NOT summed in).
+///   method, dataset overrides, SRJ/SRX/CSV/TSV negotiation, 200/400/405/406/415; the
+///   present-but-unsatisfiable Accept now 406 (Oxigraph parity, sq-406acc); the
+///   absent/`*/*` Accept JSON default + ASK-in-CSV are documented divergences, NOT summed in).
 /// * SPARQL 1.1 Service Description + Graph Store Protocol 39 — `sparq-conformance`
 ///   `tests/sd_gsp_suite.rs` `SD_GSP_FLOOR = 39` (sq-1uuxz; opt-in
 ///   `federation-descriptors` feature; the `GET /sparql` (no query) Service-Description
@@ -596,12 +597,13 @@ pub const SUITES: &[Suite] = &[
     // status code, the response Content-Type and the payload shape: query via GET /
     // POST-urlencoded / POST-direct, the HTTP QUERY method (#1304), update via POST, the
     // default-graph-uri / named-graph-uri dataset overrides, result-format content negotiation
-    // (SRJ / SRX / CSV / TSV) and the 200/400/405/415 status codes. The floor is the MEASURED
-    // PASS count; documented protocol divergences (sparq's 406-less Accept fallback; an ASK
-    // boolean in CSV/TSV falling back to JSON) are reported separately and NOT summed into it,
-    // so a documented gap can never inflate the conformance number — an honest W3C-Protocol
-    // claim, scoped to what the server genuinely satisfies. Floor kept in lock-step by
-    // `tests/scoreboard_floors.rs`.
+    // (SRJ / SRX / CSV / TSV), the present-but-unsatisfiable Accept → 406 (Oxigraph parity,
+    // sq-406acc) and the 200/400/405/406/415 status codes. The floor is the MEASURED PASS count;
+    // documented protocol divergences (an absent/*/* Accept defaults to JSON per the W3C-permitted
+    // default representation; an ASK boolean in CSV/TSV falling back to JSON) are reported
+    // separately and NOT summed into it, so a documented gap can never inflate the conformance
+    // number — an honest W3C-Protocol claim, scoped to what the server genuinely satisfies. Floor
+    // kept in lock-step by `tests/scoreboard_floors.rs`.
     Suite {
         label: "W3C SPARQL 1.1 Protocol (HTTP)",
         family: "W3C SPARQL",
@@ -611,11 +613,12 @@ pub const SUITES: &[Suite] = &[
             feature: "http-protocol",
         },
         ci_job: "service-federation-conformance",
-        ratchet_floor: 20,
+        ratchet_floor: 21,
         floor_basis: "pass",
         note: "SPARQL 1.1 Protocol operations (GET/POST query+update, the QUERY method, \
-               dataset overrides, SRJ/SRX/CSV/TSV negotiation, 200/400/405/415) over RAW \
-               HTTP against the in-process loopback server; 406-less Accept fallback + \
+               dataset overrides, SRJ/SRX/CSV/TSV negotiation, 200/400/405/406/415) over RAW \
+               HTTP against the in-process loopback server; a present-but-unsatisfiable Accept \
+               now returns 406 (Oxigraph parity, sq-406acc); the absent/*/* Accept JSON default + \
                ASK-in-CSV are documented divergences, NOT summed into the floor",
     },
     // [OPUS-4.8] sq-1uuxz (epic sq-my8wd) — the SPARQL 1.1 SERVICE-DESCRIPTION + GRAPH-STORE

--- a/crates/sparq-conformance/tests/http_protocol_suite.rs
+++ b/crates/sparq-conformance/tests/http_protocol_suite.rs
@@ -19,10 +19,12 @@
 //!
 //! `HTTP_PROTOCOL_FLOOR` is the MEASURED count of PASS assertions, NOT an aspirational target;
 //! MIRRORED in `scoreboard::SUITES` and read textually by `tests/scoreboard_floors.rs`. It may
-//! only RISE. The protocol features sparq does NOT implement (406 on an unsatisfiable Accept —
-//! it falls back to JSON; an ASK boolean in CSV/TSV — it falls back to a JSON boolean) are
-//! recorded as DOCUMENTED DIVERGENCES and are NOT summed into the floor, so a documented gap can
-//! never inflate the conformance number; a genuine FAILURE always fails the gate.
+//! only RISE. [OPUS-4.8] sq-406acc: a present-but-unsatisfiable `Accept` now genuinely returns
+//! 406 (Oxigraph parity) — a PASS, raising the floor 20→21. The remaining documented divergences
+//! (an absent / `*/*` Accept defaults to JSON per the W3C-permitted default; an ASK boolean in
+//! CSV/TSV falls back to a JSON boolean) are recorded as DOCUMENTED DIVERGENCES and are NOT summed
+//! into the floor, so a documented gap can never inflate the conformance number; a genuine FAILURE
+//! always fails the gate.
 //!
 //! ## Feature gating (both states)
 //!
@@ -51,8 +53,10 @@ mod gated {
     /// scoreboard (`scoreboard::SUITES`) and read textually by the guard test
     /// `tests/scoreboard_floors.rs`. It may only RISE — never lower it. This is the ACTUAL
     /// current pass count, not an aspirational target. Documented protocol DIVERGENCES (e.g.
-    /// sparq's 406-less Accept fallback) are reported separately and NOT counted here.
-    pub const HTTP_PROTOCOL_FLOOR: usize = 20;
+    /// sparq's absent-Accept JSON default) are reported separately and NOT counted here.
+    /// [OPUS-4.8] sq-406acc: raised 20→21 when the present-but-unsatisfiable-Accept 406 (Oxigraph
+    /// parity, w3c/sparql-protocol#40) flipped from a documented divergence to a genuine PASS.
+    pub const HTTP_PROTOCOL_FLOOR: usize = 21;
 
     #[test]
     fn http_protocol_ratchet() {

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -39,8 +39,8 @@ curl -G http://127.0.0.1:3030/sparql --data-urlencode 'query=SELECT * WHERE { ?s
 - **Content negotiation** — q-value aware; SELECT/ASK in JSON/XML/CSV/TSV, CONSTRUCT/DESCRIBE and
   GSP read in N-Triples / prefix-Turtle / RDF-XML / **JSON-LD** (`application/ld+json` — the
   `jsonld` feature, **default-on**: both emit and accept — see "Default-on JSON-LD"); streamed
-  SELECT bodies. Plus **EXPLAIN / EXPLAIN ANALYZE**, Prometheus **`/metrics`**, and SEPA-style
-  **WebSocket + SSE** live SELECT diffs.
+  SELECT bodies; a present-but-unsatisfiable `Accept` is **406** (Oxigraph parity), absent/`*/*`
+  keeps the default. Plus **EXPLAIN / EXPLAIN ANALYZE**, Prometheus **`/metrics`**, **WebSocket + SSE**.
 - **Durable persistence** — `--persist <DIR>` makes the on-disk index the source of truth (off by
   default, in-memory). See "Durable persistence".
 - **Authentication** — optional `--auth-token <TOKEN>` Bearer write gate (constant-time; mirrors

--- a/crates/sparq-server/src/http.rs
+++ b/crates/sparq-server/src/http.rs
@@ -55,7 +55,9 @@ use crate::exec::{
     apply_update_dataset, prepare_with_dataset, DatasetOverride, PrepareError, QueryForm,
     UpdateDatasetError, UsingOverride,
 };
-use crate::negotiate::{negotiate, negotiate_graph, Format, GraphFormat};
+use crate::negotiate::{
+    negotiate_graph, negotiate_graph_or_406, negotiate_or_406, Format, GraphFormat,
+};
 use crate::results;
 
 // ---------------------------------------------------------------------------
@@ -4963,7 +4965,6 @@ async fn run_query_pinned(
         return await_worker(task, &config).await;
     }
     let accept = headers.get(header::ACCEPT).and_then(|v| v.to_str().ok());
-    let fmt = negotiate(accept);
     let config = state.config.clone();
     // [OPUS-4.8] sq-9xoh: the per-request SERVICE egress allowlist for this read (the static
     // `service_allow` unless a per-request override hook is installed). Resolved here while the
@@ -4972,6 +4973,14 @@ async fn run_query_pinned(
 
     match prepared.form {
         QueryForm::Select | QueryForm::Ask => {
+            // [OPUS-4.8] sq-406acc: Oxigraph-parity content negotiation — a PRESENT-but-unsatisfiable
+            // `Accept` (naming no supported SELECT/ASK result format and no wildcard) is `406 Not
+            // Acceptable` rather than the old silent JSON fallback. An absent / empty / `*/*` Accept
+            // still defaults to SPARQL-results JSON (W3C-permitted default representation).
+            let fmt = match negotiate_or_406(accept) {
+                Ok(f) => f,
+                Err(_) => return not_acceptable_response(head_only),
+            };
             let is_ask = prepared.form == QueryForm::Ask;
             let select = prepared.runnable;
             let budget = make_budget(&config, !is_ask);
@@ -5006,8 +5015,14 @@ async fn run_query_pinned(
         // The engine's row budget applies to the WHERE-pattern solutions, the deadline
         // to the whole evaluation — same guard semantics as SELECT.
         QueryForm::Construct | QueryForm::Describe => {
+            // [OPUS-4.8] sq-406acc: same Oxigraph-parity strictness for the RDF-graph result — a
+            // PRESENT-but-unsatisfiable `Accept` (no supported RDF media type and no wildcard) is
+            // 406; absent / empty / `*/*` keeps the N-Triples default.
+            let gfmt = match negotiate_graph_or_406(accept) {
+                Ok(f) => f,
+                Err(_) => return not_acceptable_response(head_only),
+            };
             let query = prepared.runnable;
-            let gfmt = negotiate_graph(accept);
             let budget = make_budget(&config, true);
             let cfg = config.clone();
             let task = tokio::task::spawn_blocking(move || {
@@ -6507,6 +6522,26 @@ async fn json_error_bodies(resp: Response) -> Response {
 
 fn bad_request(msg: &str) -> Response {
     json_error(StatusCode::BAD_REQUEST, msg)
+}
+
+/// [OPUS-4.8] sq-406acc: a `406 Not Acceptable` for a present-but-unsatisfiable `Accept` header
+/// on a SPARQL query — the `Accept` named no result/RDF media type the server can produce and no
+/// wildcard, matching Oxigraph (w3c/sparql-protocol#40). The body is the structured
+/// `{"error":"..."}` envelope the rest of the surface uses (so a programmatic client need not
+/// scrape prose); `head_only` mirrors the GET headers with an empty body.
+fn not_acceptable_response(head_only: bool) -> Response {
+    let resp = json_error(
+        StatusCode::NOT_ACCEPTABLE,
+        "no acceptable result format for the request Accept header",
+    );
+    if head_only {
+        // Preserve the status + headers but drop the body, mirroring the HEAD contract used by
+        // `text_response`. `json_error` always builds a valid header set, so this never panics.
+        let (parts, _body) = resp.into_parts();
+        Response::from_parts(parts, axum::body::Body::empty())
+    } else {
+        resp
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/sparq-server/src/negotiate.rs
+++ b/crates/sparq-server/src/negotiate.rs
@@ -79,9 +79,21 @@ impl GraphFormat {
 /// `text/turtle`, `application/n-triples` and — [OPUS-4.8] sq-rt6v — `application/rdf+xml`
 /// (q-value aware), default N-Triples.
 pub fn negotiate_graph(accept: Option<&str>) -> GraphFormat {
+    negotiate_graph_or_406(accept).unwrap_or(GraphFormat::NTriples)
+}
+
+/// Negotiates the CONSTRUCT/DESCRIBE + GSP-read graph serialisation with Oxigraph-parity
+/// strictness ([OPUS-4.8] sq-406acc) — the RDF-graph analogue of [`negotiate_or_406`].
+///
+/// Returns `Ok(format)` when a supported RDF media type (or a wildcard) is named, or when the
+/// `Accept` header is ABSENT / empty (the permitted N-Triples default); returns
+/// `Err(`[`NotAcceptable`]`)` when the header is PRESENT and non-empty but names no supported
+/// RDF media type and no wildcard, which the HTTP layer maps to `406 Not Acceptable`.
+pub fn negotiate_graph_or_406(accept: Option<&str>) -> Result<GraphFormat, NotAcceptable> {
     let accept = match accept {
+        // Absent or empty `Accept` → the N-Triples default is permitted (never a 406).
         Some(a) if !a.trim().is_empty() => a,
-        _ => return GraphFormat::NTriples,
+        _ => return Ok(GraphFormat::NTriples),
     };
     let mut best: Option<(GraphFormat, f32, usize)> = None;
     for (media, q) in media_ranges(accept) {
@@ -113,7 +125,9 @@ pub fn negotiate_graph(accept: Option<&str>) -> GraphFormat {
             }
         }
     }
-    best.map(|(f, _, _)| f).unwrap_or(GraphFormat::NTriples)
+    // A present, non-empty `Accept` that matched no supported RDF range (and no wildcard) is
+    // unsatisfiable → 406, exactly as Oxigraph does for a CONSTRUCT/DESCRIBE result.
+    best.map(|(f, _, _)| f).ok_or(NotAcceptable)
 }
 
 /// Splits an `Accept` header into (lowercased media range, q-value) pairs.
@@ -131,11 +145,43 @@ fn media_ranges(accept: &str) -> impl Iterator<Item = (String, f32)> + '_ {
     })
 }
 
+/// A present-but-unsatisfiable `Accept` header — the HTTP layer maps this to `406 Not
+/// Acceptable`. [OPUS-4.8] sq-406acc: returned only by the `*_or_406` negotiators when an
+/// `Accept` header is PRESENT and non-empty yet names no supported media range and no wildcard.
+/// An absent / empty / `*/*` `Accept` is NEVER a `NotAcceptable` (the W3C SPARQL Protocol
+/// permits a default representation when `Accept` is absent), so the existing default-to-JSON /
+/// default-to-N-Triples behaviour is preserved in those cases.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NotAcceptable;
+
 /// Negotiates the result format from an optional `Accept` header value.
+///
+/// This is the LENIENT entry point used by surfaces that never 406 (it always yields a concrete
+/// format, defaulting to JSON). The HTTP query path uses [`negotiate_or_406`] instead — see that
+/// function for the Oxigraph-parity strict behaviour ([OPUS-4.8] sq-406acc).
 pub fn negotiate(accept: Option<&str>) -> Format {
+    negotiate_or_406(accept).unwrap_or(Format::Json)
+}
+
+/// Negotiates the SELECT/ASK result format with Oxigraph-parity strictness ([OPUS-4.8] sq-406acc).
+///
+/// Returns:
+/// * `Ok(format)` — a usable format was selected: either an explicitly-named supported type,
+///   the wildcard `*/*` (or any matchable range), OR the JSON default when the `Accept` header
+///   is ABSENT / empty (the W3C SPARQL Protocol permits a default representation when `Accept`
+///   is absent — so an absent header is never a 406).
+/// * `Err(`[`NotAcceptable`]`)` — the `Accept` header is PRESENT and non-empty but names NO
+///   supported solution media type and NO wildcard, so the server cannot honour it. The HTTP
+///   layer turns this into a `406 Not Acceptable`, matching Oxigraph (w3c/sparql-protocol#40).
+///
+/// The selection logic (q-values, specificity, `q=0` rejection) is identical to [`negotiate`];
+/// the only difference is that a present-but-unsatisfiable header is reported as an error
+/// instead of silently falling back to JSON.
+pub fn negotiate_or_406(accept: Option<&str>) -> Result<Format, NotAcceptable> {
     let accept = match accept {
+        // Absent or empty `Accept` → the JSON default is permitted (never a 406).
         Some(a) if !a.trim().is_empty() => a,
-        _ => return Format::Json,
+        _ => return Ok(Format::Json),
     };
 
     let mut best: Option<(Format, f32, usize)> = None; // (format, q, specificity)
@@ -163,7 +209,10 @@ pub fn negotiate(accept: Option<&str>) -> Format {
             }
         }
     }
-    best.map(|(f, _, _)| f).unwrap_or(Format::Json)
+    // A present, non-empty `Accept` that matched no supported range (and no wildcard) is
+    // unsatisfiable → 406, exactly as Oxigraph does. `q=0` on a matched type counts as a
+    // rejection, not a match, so `Accept: application/sparql-results+json;q=0` is also a 406.
+    best.map(|(f, _, _)| f).ok_or(NotAcceptable)
 }
 
 #[cfg(test)]
@@ -206,6 +255,85 @@ mod tests {
     #[test]
     fn exact_beats_wildcard() {
         assert_eq!(negotiate(Some("text/csv, */*")), Format::Csv);
+    }
+
+    // [OPUS-4.8] sq-406acc: the Oxigraph-parity strict negotiator. An ABSENT / empty / `*/*`
+    // Accept keeps the JSON default (Ok); a PRESENT-but-unsatisfiable Accept is `NotAcceptable`
+    // (the HTTP layer maps it to 406), instead of the lenient `negotiate`'s JSON fallback.
+    #[test]
+    fn or_406_absent_or_wildcard_keeps_json_default() {
+        assert_eq!(negotiate_or_406(None), Ok(Format::Json));
+        assert_eq!(negotiate_or_406(Some("")), Ok(Format::Json));
+        assert_eq!(negotiate_or_406(Some("   ")), Ok(Format::Json));
+        assert_eq!(negotiate_or_406(Some("*/*")), Ok(Format::Json));
+    }
+
+    #[test]
+    fn or_406_supported_types_select_format() {
+        assert_eq!(
+            negotiate_or_406(Some("application/sparql-results+json")),
+            Ok(Format::Json)
+        );
+        assert_eq!(negotiate_or_406(Some("text/csv")), Ok(Format::Csv));
+        assert_eq!(negotiate_or_406(Some("text/tab-separated-values")), Ok(Format::Tsv));
+        // A supported type alongside an unsupported one still negotiates the supported one.
+        assert_eq!(negotiate_or_406(Some("image/png, text/csv")), Ok(Format::Csv));
+        // An explicit wildcard rescues an otherwise-unsupported list.
+        assert_eq!(negotiate_or_406(Some("image/png, */*")), Ok(Format::Json));
+    }
+
+    #[test]
+    fn or_406_present_unsatisfiable_is_not_acceptable() {
+        // A present Accept naming ONLY unsupported solution media types → 406 (Oxigraph parity).
+        assert_eq!(negotiate_or_406(Some("image/png")), Err(NotAcceptable));
+        assert_eq!(negotiate_or_406(Some("application/pdf")), Err(NotAcceptable));
+        assert_eq!(
+            negotiate_or_406(Some("text/turtle, application/rdf+xml")),
+            Err(NotAcceptable)
+        );
+        // `q=0` rejects the only otherwise-supported type, leaving nothing acceptable.
+        assert_eq!(
+            negotiate_or_406(Some("application/sparql-results+json;q=0")),
+            Err(NotAcceptable)
+        );
+    }
+
+    #[test]
+    fn negotiate_matches_or_406_modulo_default() {
+        // The lenient wrapper is exactly `_or_406` with the error collapsed to the JSON default.
+        for accept in [
+            None,
+            Some(""),
+            Some("*/*"),
+            Some("text/csv"),
+            Some("image/png"),
+            Some("application/sparql-results+json;q=0"),
+        ] {
+            assert_eq!(negotiate(accept), negotiate_or_406(accept).unwrap_or(Format::Json));
+        }
+    }
+
+    // [OPUS-4.8] sq-406acc: the graph (CONSTRUCT/DESCRIBE) analogue.
+    #[test]
+    fn graph_or_406_absent_or_wildcard_keeps_ntriples_default() {
+        assert_eq!(negotiate_graph_or_406(None), Ok(GraphFormat::NTriples));
+        assert_eq!(negotiate_graph_or_406(Some("")), Ok(GraphFormat::NTriples));
+        assert_eq!(negotiate_graph_or_406(Some("*/*")), Ok(GraphFormat::NTriples));
+    }
+
+    #[test]
+    fn graph_or_406_supported_and_unsatisfiable() {
+        assert_eq!(negotiate_graph_or_406(Some("text/turtle")), Ok(GraphFormat::Turtle));
+        assert_eq!(
+            negotiate_graph_or_406(Some("application/n-triples")),
+            Ok(GraphFormat::NTriples)
+        );
+        // A SELECT/ASK result media type is NOT an RDF graph type → 406 for a graph query.
+        assert_eq!(
+            negotiate_graph_or_406(Some("text/csv")),
+            Err(NotAcceptable)
+        );
+        assert_eq!(negotiate_graph_or_406(Some("image/png")), Err(NotAcceptable));
     }
 
     #[test]

--- a/crates/sparq-server/tests/jsonld_content_negotiation.rs
+++ b/crates/sparq-server/tests/jsonld_content_negotiation.rs
@@ -9,15 +9,18 @@
 //!   * ACCEPT — a Graph-Store-Protocol `PUT` of an `application/ld+json` body, then a `GET`,
 //!     returns exactly the triples that were loaded.
 //!   * the q-value-aware negotiation contract: a JSON-LD `Accept` beats a lower-q sibling, a
-//!     `q=0` rejects it, an unknown `Accept` does not 406 (the server has a default), and an
-//!     unsupported write `Content-Type` is a `415`.
+//!     `q=0` rejects it, an `Accept` that is satisfiable (a supported type or a `*/*` wildcard)
+//!     gets the negotiated/default representation, and an unsupported write `Content-Type` is a
+//!     `415`. [OPUS-4.8] sq-406acc: a PRESENT Accept naming ONLY an unproducible type and no
+//!     wildcard is now `406 Not Acceptable` (Oxigraph parity), not a silent fallback.
 //!
 //! The positive tests compile with the `jsonld` feature — which, as of sq-oy1f.4, is in the
 //! server's DEFAULT set (a maintainer-directed exception to opt-in-by-default), so the plain
 //! `cargo test -p sparq-server` runs them. A separate block under `#[cfg(not(feature =
 //! "jsonld"))]` asserts the feature-OFF contract (`--no-default-features --features server`): an
-//! `application/ld+json` write body is a plain `415`, and an `Accept: application/ld+json` query
-//! falls back to a supported graph format (NOT a 406) — so a JSON-LD-disabled build is unchanged.
+//! `application/ld+json` write body is a plain `415`, and (sq-406acc) an `Accept:
+//! application/ld+json` query — naming a type the build cannot produce, with no wildcard — is a
+//! `406 Not Acceptable` (Oxigraph parity), while `application/ld+json, */*` still falls back.
 //!
 //! [OPUS-4.8] (sq-1b390) Gate the whole suite on the `server` feature. It spins the real axum
 //! server and uses the `server`-gated `sparq_server::router` / `AppState` API, so under
@@ -278,17 +281,42 @@ async fn gsp_put_jsonld_is_415_without_feature() {
     );
 }
 
-/// Without the feature, an `Accept: application/ld+json` CONSTRUCT does NOT 406 — content
-/// negotiation falls back to a supported graph format (N-Triples, the default). The endpoint
-/// always has a representation, so it answers 200 with that fallback, never a 406.
+/// [OPUS-4.8] sq-406acc: without the `jsonld` feature, an `Accept: application/ld+json` CONSTRUCT
+/// is now `406 Not Acceptable` — the build genuinely cannot produce JSON-LD, so a request that
+/// accepts ONLY `application/ld+json` (no wildcard) is unsatisfiable, exactly as Oxigraph would
+/// 406 it (w3c/sparql-protocol#40). Previously sparq silently fell back to N-Triples; the
+/// stricter behaviour is the documented Oxigraph-parity change. (A `*/*` alongside the JSON-LD
+/// range would still be satisfiable and fall back — see the companion test below.)
 #[cfg(not(feature = "jsonld"))]
 #[tokio::test]
-async fn construct_accept_jsonld_falls_back_without_feature() {
+async fn construct_accept_jsonld_is_406_without_feature() {
     let base = spawn().await;
     let resp = client()
         .get(format!("{base}/sparql"))
         .query(&[("query", "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")])
         .header("accept", "application/ld+json")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(
+        resp.status(),
+        406,
+        "feature-OFF build cannot produce JSON-LD; an Accept naming only it is unsatisfiable → 406"
+    );
+}
+
+/// [OPUS-4.8] sq-406acc: the converse — without the feature, `Accept: application/ld+json, */*`
+/// is STILL satisfiable (the wildcard is matchable), so the CONSTRUCT falls back to the
+/// N-Triples default with 200, never a 406. Confirms the strictness only bites a wholly
+/// unsatisfiable Accept, not one that also names a wildcard.
+#[cfg(not(feature = "jsonld"))]
+#[tokio::test]
+async fn construct_accept_jsonld_with_wildcard_falls_back_without_feature() {
+    let base = spawn().await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")])
+        .header("accept", "application/ld+json, */*")
         .send()
         .await
         .unwrap();

--- a/crates/sparq-server/tests/query_method.rs
+++ b/crates/sparq-server/tests/query_method.rs
@@ -9,8 +9,9 @@
 //!   * OR the `query=` parameter of an `application/x-www-form-urlencoded` body;
 //!   * `default-graph-uri` / `named-graph-uri` come from the URL query string;
 //!   * Accept negotiates SRJ / SRX / CSV / TSV (SELECT/ASK) and RDF (CONSTRUCT/DESCRIBE),
-//!     reusing the SAME negotiation as GET/POST (sparq defaults unsatisfiable Accepts to JSON
-//!     rather than 406 — a documented sparq-vs-Oxigraph difference, see the relevant test);
+//!     reusing the SAME negotiation as GET/POST. A PRESENT-but-unsatisfiable Accept (naming no
+//!     supported result format and no wildcard) is `406 Not Acceptable`, matching Oxigraph
+//!     ([OPUS-4.8] sq-406acc); an absent / empty / `*/*` Accept still defaults to JSON;
 //!   * an `update=` form field is a 400 and `application/sparql-update` is a 415 (query-only).
 //!
 //! [OPUS-4.8] Gate the whole suite on the `server` feature (it spins the real axum server
@@ -224,13 +225,12 @@ async fn query_method_construct_rdf() {
     assert!(body.contains("<http://ex/years>"), "got {body}");
 }
 
-/// An Accept naming only unsupported solution media types falls back to SPARQL-results JSON,
-/// matching sparq's house negotiation for GET/POST (`negotiate::defaults_to_json`): sparq
-/// defaults rather than 406. NB this is a documented sparq-vs-Oxigraph negotiation difference
-/// (Oxigraph 406s an unsatisfiable Accept); the QUERY input path reuses the SAME negotiation
-/// as GET/POST, so changing it is out of scope for this bead (it would alter GET/POST too).
+/// [OPUS-4.8] sq-406acc: an Accept naming only unsupported solution media types (and no
+/// wildcard) is now `406 Not Acceptable`, matching Oxigraph (w3c/sparql-protocol#40) instead of
+/// the previous silent JSON fallback. The QUERY input path reuses the SAME negotiation as
+/// GET/POST, so this stricter behaviour is consistent across all three query input paths.
 #[tokio::test]
-async fn query_method_unsupported_accept_falls_back_to_json() {
+async fn query_method_unsupported_accept_is_406() {
     let base = spawn().await;
     let resp = client()
         .request(query_method(), format!("{base}/sparql"))
@@ -240,7 +240,38 @@ async fn query_method_unsupported_accept_falls_back_to_json() {
         .send()
         .await
         .unwrap();
-    assert_eq!(resp.status(), 200);
+    assert_eq!(resp.status(), 406, "present-but-unsatisfiable Accept → 406");
+}
+
+/// [OPUS-4.8] sq-406acc: the load-bearing converse — an ABSENT Accept (and `*/*`) still returns
+/// the SPARQL-results JSON default via QUERY, NOT a 406. The W3C SPARQL Protocol permits a
+/// default representation when Accept is absent, so the strictness change must not regress this.
+#[tokio::test]
+async fn query_method_absent_or_wildcard_accept_defaults_to_json() {
+    let base = spawn().await;
+    // No Accept header at all → JSON default, 200.
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .body("SELECT ?s WHERE { ?s <http://ex/age> ?a }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "absent Accept → JSON default, not 406");
+    assert_eq!(
+        resp.headers()["content-type"],
+        "application/sparql-results+json"
+    );
+    // `Accept: */*` → JSON default, 200 (a wildcard is satisfiable).
+    let resp = client()
+        .request(query_method(), format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .header("accept", "*/*")
+        .body("SELECT ?s WHERE { ?s <http://ex/age> ?a }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200, "*/* Accept → JSON default, not 406");
     assert_eq!(
         resp.headers()["content-type"],
         "application/sparql-results+json"

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -214,8 +214,11 @@ Library surface re-exported from `sparq_server` (behind the default `server` fea
   into the axum endpoint and the canonical perf-validation are follow-ups (the perf
   targets need a canonical host).
 - Serializer/negotiation helpers (always compiled, no `server` feature): module
-  `sparq_server::negotiate` — `fn negotiate(accept: Option<&str>) -> Format`,
-  `fn negotiate_graph(accept: Option<&str>) -> GraphFormat`; module
+  `sparq_server::negotiate` — `fn negotiate(accept: Option<&str>) -> Format` (lenient, always
+  yields a format), `fn negotiate_or_406(accept: Option<&str>) -> Result<Format, NotAcceptable>`
+  (Oxigraph-parity strict — the query path uses this; a present-but-unsatisfiable `Accept` is
+  `Err(NotAcceptable)` → 406), `fn negotiate_graph(accept: Option<&str>) -> GraphFormat` and its
+  strict sibling `fn negotiate_graph_or_406(...) -> Result<GraphFormat, NotAcceptable>`; module
   `sparq_server::exec` — `fn prepare(&str) -> Result<Prepared, PrepareError>` and
   `fn prepare_with_dataset(&str, &DatasetOverride) -> Result<Prepared, PrepareError>` (applies the
   SPARQL-Protocol `default-graph-uri`/`named-graph-uri` override, sq-z33x),
@@ -254,7 +257,11 @@ re-export of the runtime-agnostic concurrency wrapper. No axum/tokio, no HTTP.
 
 **1. Query forms and result negotiation.** Default result media is SPARQL-JSON. Set
 `Accept` to choose (q-value aware, defaults to JSON for SELECT/ASK, N-Triples for
-CONSTRUCT/DESCRIBE):
+CONSTRUCT/DESCRIBE). <!-- [OPUS-4.8] sq-406acc --> An **absent / empty / `*/*` `Accept` gets
+that default**; a present `Accept` that names **only unsupported media types and no wildcard is
+`406 Not Acceptable`** (Oxigraph parity, w3c/sparql-protocol#40) — sparq no longer silently
+falls back to JSON in that case (the EXPLAIN `Accept: text/x-sparq-explain` short-circuits this
+and the Graph-Store-Protocol read path keeps its lenient default):
 
 | Query form | Accept | Content-Type returned |
 | --- | --- | --- |
@@ -320,12 +327,15 @@ curl -G http://127.0.0.1:3030/sparql -H 'Accept: application/ld+json' \
 > not touch the engine's egress allowlist). It ratchets a MEASURED PASS floor over: query via
 > GET / POST-urlencoded / POST-direct, the `QUERY` method, update via POST, the
 > `default-graph-uri` / `named-graph-uri` overrides, SELECT/ASK negotiation (SRJ / SRX / CSV /
-> TSV), and the **200 / 400 / 405 (with `Allow`) / 415** status codes. **Honest boundary:** two
-> behaviours are DOCUMENTED DIVERGENCES (reported separately, NOT summed into the floor, so they
-> never inflate the conformance number): an **unsatisfiable `Accept` on SELECT/ASK falls back to
-> SPARQL-results JSON, NOT a 406** (a W3C-permitted default representation — the documented
-> sparq-vs-Oxigraph difference), and an **ASK with `Accept: text/csv` falls back to a JSON
-> boolean** (CSV/TSV have no boolean serialisation). Run it with
+> TSV), a **present-but-unsatisfiable `Accept` → 406 Not Acceptable** (Oxigraph parity,
+> w3c/sparql-protocol#40 — <!-- [OPUS-4.8] sq-406acc --> formerly a divergence, now a genuine
+> PASS that raised the floor 20→21), and the **200 / 400 / 405 (with `Allow`) / 406 / 415**
+> status codes. **Honest boundary:** two behaviours remain DOCUMENTED DIVERGENCES (reported
+> separately, NOT summed into the floor, so they never inflate the conformance number): an
+> **absent / `*/*` `Accept` defaults to SPARQL-results JSON** (a W3C-permitted default
+> representation — only a *present-but-unsatisfiable* `Accept` is a 406), and an **ASK with
+> `Accept: text/csv` falls back to a JSON boolean** (CSV/TSV have no boolean serialisation). Run
+> it with
 > `cargo test -p sparq-conformance --features http-protocol --test http_protocol_suite`; the row
 > is in the central scoreboard (`W3C SPARQL 1.1 Protocol (HTTP)`). [OPUS-4.8]
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** (jeswr/sparq RDF/SPARQL engine). Filed by the SPARQ agent. [OPUS-4.8]

Closes the documented `#1313` HTTP-protocol divergence: the sparq-server SPARQL result content-negotiation path now returns **406 Not Acceptable** when an `Accept` header is **present and non-empty but names no supported result format** (and no wildcard), matching **Oxigraph** and the HTTP `QUERY` contract pinned for `#1304` / w3c/sparql-protocol#40. Bead **sq-xpb1z** (epic sq-my8wd).

## Behaviour change (stricter — Oxigraph-matching)
- **Present-but-unsatisfiable `Accept` → 406** (was: silent JSON fallback). For SELECT/ASK the supported set is `application/sparql-results+json|+xml`, `text/csv`, `text/tab-separated-values`; for CONSTRUCT/DESCRIBE it is the supported RDF media types. An `Accept` naming only types outside that set, with no `*/*`, is now `406`.
- **Absent / empty / `*/*` `Accept` → unchanged default** — SPARQL-results JSON (solutions) or N-Triples (graphs). The W3C SPARQL Protocol permits a default representation when `Accept` is absent, so these are never 406 (Oxigraph behaves the same).
- Applied **consistently across all three query input paths** — GET, POST (urlencoded + direct `application/sparql-query`), and the `QUERY` method — which all funnel through `run_query_pinned`.
- **Scope guards:** EXPLAIN (`Accept: text/x-sparq-explain`) short-circuits before negotiation; the Graph-Store-Protocol read path keeps its lenient default; and this is the **content-negotiation path ONLY** — the authn/authz/egress gate in `http.rs` is **untouched** (an unauthorised request is still rejected exactly as before).

## Implementation
- `negotiate.rs`: new `negotiate_or_406` / `negotiate_graph_or_406` returning `Result<_, NotAcceptable>`; the existing `negotiate` / `negotiate_graph` become thin lenient wrappers (used by the GSP read path). Direct unit tests for strict / lenient / converse cases.
- `http.rs`: per-form strict negotiation in `run_query_pinned` + a HEAD-safe `not_acceptable_response` helper emitting the structured `{"error":...}` envelope the rest of the surface uses.

## Conformance (honest floor)
- Flipped the `http_protocol_suite` unsatisfiable-`Accept` case **Divergence → PASS** (the server genuinely emits 406 now) and added an absent/`*/*` **converse divergence** so the floor counts exactly the one genuine 406 pass.
- **HTTP_PROTOCOL_FLOOR 20 → 21** in lock-step across all mirror sites: `tests/http_protocol_suite.rs`, `scoreboard::SUITES` (`ratchet_floor`), the `tests/scoreboard_floors.rs` guard, and the `ci.yml` `FLOOR` literal. The ASK-in-CSV→JSON divergence is left as-is.
- Suite now reports `21 / 0 / 2` (pass/fail/divergence).

## Gates run (both feature states)
- `cargo build` + `cargo clippy --all-targets -- -D warnings`: **green** for sparq-server `default`, `--no-default-features --features server` (jsonld OFF), and `--all-features`; for sparq-conformance `default` and `--features http-protocol`.
- `cargo test -p sparq-server` (default **and** jsonld-OFF) + `cargo test -p sparq-conformance --features http-protocol` (suite 21/0/2 + floor guard): **green**. Existing-client absent/`*/*` Accept still gets the JSON default (tests added).
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps` AND `--all-features`: **clean**.
- `scripts/check-readme-template.py --enforce`: 0 deviations; sparq-server README ≤120 lines.

## Docs
- `skills/http-server/SKILL.md` — 406 parity in the negotiation table, the helper list, and the conformance honest-boundary.
- `crates/sparq-server/README.md` — content-negotiation bullet notes the 406.

🤖 Generated with [Claude Code](https://claude.com/claude-code)