### PR TITLE
docs(research): Fable-program recon records (sq-rvgr2 + sq-gum8.2 papers audit)

### DIFF
--- a/research/papers-venue-audit.md
+++ b/research/papers-venue-audit.md
@@ -1,0 +1,171 @@
+# Papers Venue-Bar Audit
+
+> Papers venue-bar audit (bead sq-gum8.2). Verdicts are non-sycophantic; KILL means kill.
+
+## How the Papers Pipeline Works
+
+Single-source Typst → gated compile → static-injected fragment + PDF.
+
+**REGISTRY**: `site/src/data/papers.ts` is the one source of truth (`PAPERS[]` with
+slug/source/title/venue/status/family). It drives the index card grid
+(`site/src/app/papers/page.tsx:68`), the per-paper static routes via `generateStaticParams`
+(`site/src/app/papers/[slug]/page.tsx:31`), and the build step.
+
+**BUILD**: `site/scripts/build-papers.mjs` runs on prebuild. It reads slug+source out of
+`papers.ts` with a regex (`readRegistry`, line 68), runs a data-layer honesty gate over
+`site/src/data/paper-evidence.json` (`runHonestyGate`, line 85 — checks every record has
+`environment in {canonical,indicative}+source+value`), then a build-BOUNDARY scan
+(`runBuildBoundaryHonestyScan`, line 137) that re-invokes the two shared CI gates
+`scripts/check-no-perf-numbers.py --enforce` and `scripts/check-privacy-claims.sh` over the
+exact `.typ` sources + evidence JSON (fail-closed). Then `compilePaper` (line 178) shells
+`typst compile <src>.typ <slug>.pdf --input data=<paper-evidence.json>` for the PDF and again
+with `--format html --features html` for the in-site render, and writes the `<body>` inner HTML
+(with a GENERATED provenance comment) to `site/src/generated/papers/<slug>.html`. If typst is
+absent it emits placeholder fragments (line 229).
+
+**EVIDENCE BINDING**: every number in a `.typ` comes only through
+`site/papers/_lib/bench.typ` — `headline(key)` (line 31) PANICS the compile if the record's
+`environment != "canonical"`; `ev(key)` (line 28) is the ungated accessor for indicative
+callouts. Same JSON feeds PDF and HTML so they cannot disagree.
+
+**RENDER**: `site/src/app/papers/[slug]/page.tsx` `readPaperHtml(slug)` reads the generated
+fragment at build time and injects it via `<PaperHtml>`; `provenanceFor` (line 61) stamps
+canonical/indicative counts + commit. `site/src/generated/` is git-ignored (regenerated every
+build).
+
+NOTE: `paper-evidence.json` is distinct from `benchmarks.generated.json` (the latter is all
+`environment=indicative` work-box timing and may never back a headline).
+
+---
+
+## Per-Paper Verdict Table
+
+| slug | topic | novelty verdict | nearest prior work | target venue | verdict |
+|---|---|---|---|---|---|
+| `filtered-ann` | RDF-native filtered-ANN: BGP-to-IdMask pre-filter over shared dict-id space, transitive connected-component pushdown, answer-safety invariant | MODEST — a real integration kernel; but ACORN (SIGMOD'24) already accepts arbitrary predicate bitsets; the genuine delta is the shared-dictionary-id space (no metadata mirroring) and connected-component pushdown | ACORN (Patel et al., SIGMOD 2024); NaviX (Sehgal & Salihoglu, arXiv:2506.23397); PathFinder (arXiv:2511.00995); EMA (2606.00734); E2E adaptive termination (2602.06721); unified filtered-ANN benchmark (2509.07789) | ISWC/ESWC research or resources track, or EDBT short. NOT SIGMOD/VLDB (no new algorithm, no evaluation) | **REWRITE** |
+| `honest-benchmarking` | Benchmarking-methodology / reproducibility note: gate timing on correctness, label every number's environment, no-hard-coded-numbers, negative-results ledger | NONE — correctness-before-timing, full hardware labelling, and a negative-results ledger are all established good practice (SIGMOD reproducibility norms); paper itself admits it "reports no performance number as evidence" | General RDF/DB benchmarking-reproducibility discourse (WatDiv, WDBench, BSBM; ACM/SIGMOD artifact review) | None as a standalone paper. At most SIGMOD Record / reproducibility-track experience note, or website content | **KILL** |
+| `geosparql-optin-crate` | Faithful GeoSPARQL 1.0/1.1 subset as an opt-in crate, OGC topology conformance ratchet floor (119) | ZERO — faithful GeoSPARQL exists in Jena, RDF4J, Virtuoso, Stardog, GraphDB, Oxigraph; opt-in-crate decoupling is routine Rust engineering; the "conformance ratchet" is a CI mechanism, not a result | Apache Jena GeoSPARQL / jena-spatial, RDF4J GeoSPARQL, Virtuoso/Stardog/GraphDB spatial; the OGC GeoSPARQL 1.0/1.1 standard itself | ISWC poster/demo at most. Not a research or resources full paper | **KILL** |
+| `solid-acl-conformance` | Hand-curated per-construct decision-parity test corpus for Solid WAC (12) and ACP (12) at the library level, ratcheted in the cross-family scoreboard | ZERO — 24-scenario unit-test suite plus a CI ratchet, honestly scoped to "decision parity, not wire conformance, no security property"; no research question, no technique | Solid Protocol / WAC / ACP specifications; Solid Conformance Test Harness (CTH) and Community Solid Server conformance suites | None / demo. Could at most be an artifact appendix | **MERGE** (into geosparql paper) |
+| `odrl-policy-bridge` | Single-node ODRL→access-control view bridge: deny-overrides, asymmetric fail-closed deny retraction, re-checked conditional grants, atomic count enforcement | THIN — a Rust re-instantiation of OAC/Pandit-class ODRL→access-control mappings; the genuinely novel half (federated ODRL→MPC disclosure, ODRL-Duty→ZK obligation) is deferred/unbuilt; fail-closed deny-overrides is the ODRL Formal-Semantics default | OAC - ODRL Profile for Access Control (Esteves, Pandit et al., ESWC 2022); ODRE enforcement framework (arXiv:2409.17602); Slabbinck et al. on ODRL+WAC/ACP integration; UMA usage-control (arXiv:2601.18761) | ISWC/ESWC in-use track or SEMANTiCS/policy workshop — IF it adds an evaluation. Not top-tier as-is | **REWRITE** |
+| `unsafe-attestation` | N=1 engineering-discipline write-up: unsafe confined to 5/35 crates by `forbid(unsafe_code)`, 59 sites behind a CI count ratchet, per-site `// SAFETY` register, Miri/oracle/fuzz/ASan coverage matrix | LOW — paper states "we claim no novelty in any one of them"; the claimed contribution is "the composition for one RDF engine"; empirical unsafe-Rust studies already exist | Evans et al. 'Is Rust Used Safely?' (ICSE 2020); Astrauskas et al. 'How Do Programmers Use Unsafe Rust?' (OOPSLA 2020); RustBelt; cargo-geiger / RustSec; Miri | Security-engineering / experience workshop or a resources track at most. NOT a top-tier security venue | **KILL** |
+| `cozk-witness-validation` | Adversarial 're-audit' of the engine's INTENDED collaborative zk-SNARK path against CRYPTO'25 eprint 2025/1026 failure modes; every lens RE-OPEN because the path is unbuilt (6 `NotYetImplemented` stubs) | NONE — the audited path is 6 `NotYetImplemented` stubs; there is nothing built to audit, forge against, or measure; the paper applies (does not extend) 2025/1026's results and explicitly "cannot certify soundness" | eprint 2025/1026 'Malicious Security in Collaborative zk-SNARKs' (Garg, Goel, Jain, Roberts, Sekar, CRYPTO'25); Ozdemir & Boneh collaborative zk-SNARKs (USENIX Security 2022); TACEO co-snarks; eprint 2024/143, 2024/940 | None. No PETS/security venue accepts an audit of unbuilt stubs with no construction, no proof, and no evaluation | **NEW_TOPIC_INSTEAD** |
+
+---
+
+## Writing Gaps per Paper
+
+### `filtered-ann` (REWRITE)
+
+- ZERO performance evaluation — explicitly "no wall-clock claim"; a filtered-ANN paper with no
+  latency/throughput/recall-vs-latency vs ACORN/NaviX is desk-reject at a DB venue and thin
+  even at ISWC.
+- Recall floors (0.95/0.90) are a correctness sanity-check on unmodified prior-art HNSW,
+  presented as if they were the evaluation.
+- Related work is one paragraph and predates the 2025–26 filtered-ANN wave (PathFinder/EMA/
+  E2E/unified benchmark).
+- No scalability study, no selectivity sweep, no figures — only two 3-column tables.
+- Answer-safety is stated as the headline theorem but is near-tautological for an exact mask;
+  needs to either prove something harder or be demoted.
+
+### `honest-benchmarking` (KILL)
+
+- It is an opinion/experience essay with no evaluation that the methodology changes any outcome.
+- Makes no falsifiable claim by its own admission.
+- The "contribution" is a CI gate in this one repo — not generalisable science.
+- The whole content belongs as the Evaluation-Methodology subsection of a real systems paper.
+
+### `geosparql-optin-crate` (KILL)
+
+- No evaluation and no comparison to any existing GeoSPARQL engine (coverage or speed).
+- The single-row "119 passing assertions" table is a CI floor, not a scientific result.
+- The cross-family scoreboard is padded across two papers (also in `solid-acl`) to manufacture
+  substance.
+- Nothing here generalises beyond this repo's CI config.
+
+### `solid-acl-conformance` (MERGE)
+
+- 12+12 scenarios is a tiny hand-authored corpus presented as a conformance result.
+- Explicitly asserts no security/soundness/completeness — so the only claim is "our test count
+  is ≥ N".
+- No comparison to the actual Solid CTH.
+- The cross-family scoreboard section is near-identical to the geosparql paper (self-plagiarised
+  padding).
+
+### `odrl-policy-bridge` (REWRITE)
+
+- No comparison or evaluation vs ODRE / the OAC editor+enforcer — the direct competitors.
+- Novelty leans on a deferred, unbuilt crypto half that is explicitly out of scope, leaving only
+  the non-novel single-node mapping.
+- "Answer-safety invariants" are four unit-test booleans, not an evaluation on real policies.
+- Related-work concedes the contribution is an integration but does not differentiate from
+  ODRE/OAC feature-by-feature.
+
+### `unsafe-attestation` (KILL)
+
+- N=1 case study with no evaluation that the discipline ever caught a real UB (did the
+  corruption oracle/fuzzer find anything?).
+- The counts (59 sites / 5 crates) are project-internal bookkeeping, uninteresting to an
+  outside reader.
+- Honestly concedes it is "coverage, not soundness" — so there is no verifiable safety claim,
+  only a process description.
+- No comparison to how other Rust systems (e.g., other engines/databases) manage their unsafe
+  surface.
+
+### `cozk-witness-validation` (NEW_TOPIC_INSTEAD)
+
+- There is no system — the "evidence" is a count of `NotYetImplemented` stubs (6) and RE-OPEN
+  verdicts (4).
+- A negative result must overturn something that was believed true of a REAL construction; here
+  nothing was ever built or claimed sound.
+- The honest disposition ("cannot certify anything") is itself the admission that there is no
+  reportable finding.
+- The durable output (R-WV) is a project CI gate, not a transferable scientific artifact.
+
+---
+
+## Missing Topics That Deserve a Paper
+
+1. **FO-KM empirical finding (STRONGEST missing paper)**: schema.org-as-top beats gUFO,
+   DOLCE-DUL and the no-FO incumbent for LLM-agent KM over a Project-Knowledge-Graph
+   (`bench/fo-km/RESULTS.md`; measured: schema.org 0.84 vs gUFO 0.58/0.54 and no-FO 0.64
+   answer accuracy; the win is driven by LLM training-data fluency, NOT formal richness). This
+   is a genuinely novel, counterintuitive, MEASURED result with no direct prior work, and NO
+   paper exists yet. Venue: ISWC/ESWC empirical, K-CAP, or a NeSy/LLM+KG workshop. Caveat
+   before top-tier: N=16 single counterbalanced run with heuristic grading is too thin — needs
+   a larger pre-registered multi-run study.
+
+2. **Out-of-core SPARQL engine systems result (highest-impact thread, NO paper)**: matching/
+   beating QLever on compute across few→100M triples while committing single-digit-MB out-of-
+   core (6 permutations, lazy/streaming counts, inline tagged ValueIds, bind joins), correctness
+   canonically gated by differential fuzz vs Oxigraph. This is the repo's flagship engineering
+   and the natural VLDB/CIDR/EDBT paper — yet it has no paper while 3 CI-ratchet artifacts got
+   one. Blocker: all timings are NON-canonical work-box/Docker numbers; needs the canonical
+   bare-metal runner + native (non-Docker) QLever baseline before any speed/memory headline.
+
+3. **Honest verifiable-federated-SPARQL DESIGN / feasibility-envelope SoK** (should REPLACE
+   the `cozk-witness-validation` paper): the composition of ZK query-proofs + MPC + attested
+   inputs + full SPARQL + GLOBAL-IRI federation, with the disqualifying-feature argument vs
+   node-local-id graph-MPC (GOOSE/SMPG/GORAM) and the 3-axis (adversary × output-guarantee ×
+   threshold) capability matrix incl. proven negative results (unbounded property paths
+   OUT-OF-REACH). Framed strictly as design/vision (NOT-YET-SOUND, cite the open external-
+   audit gate sq-qhy4), this is a real PoPETs/SoK-style contribution, unlike auditing unbuilt
+   stubs.
+
+   NOTE — two candidates tested that do NOT deserve their own paper:
+   - The zero-overhead shared eval substrate (`crates/sparq-substrate`, wired into
+     `sparq-engine`+`sparq-reason`) is a perf-neutral code-move extraction — good engineering,
+     but sharing a join/numeric core between an engine and a reasoner is routine (cf
+     RDFox/VLog) and not a research novelty.
+   - The honest-conformance ratchet methodology is a CI-discipline artifact and is already
+     OVER-REPRESENTED (it pads 3 of the 7 existing papers) — it belongs in a reproducibility
+     appendix, not a standalone paper.
+
+---
+
+> **Empirical-honesty reminder**: ZK and MPC estates are NOT production-sound until the
+> external cryptographer audit sq-qhy4 completes. All work-box benchmarks are non-canonical;
+> do not hard-code them in documentation or tests.
+
+---
+
+*Recon captured by Sonnet 4.6 under the Fable program; [SONNET-4.6]*

--- a/research/specs/mpc-sparql-estate-recon.md
+++ b/research/specs/mpc-sparql-estate-recon.md
@@ -1,0 +1,325 @@
+# MPC-SPARQL Estate Recon
+
+> Grounding for the MPC-SPARQL Proposed Spec (bead sq-rvgr2.3). Read-only recon; not itself normative.
+
+## Summary
+
+The MPC-over-federated-SPARQL estate (epic sq-pwr, parent sq-0jsc) is one of the most
+densely-developed tracks in the repo: M0–M3 of sparq-mpc plus the whole single-prover ZK
+binding layer in sparq-zk-compose are MERGED and tested. ~10 design records (headed by
+`research/mpc-zkp-federated-sparql-design.md`) already lay out the four-guarantee framing,
+six-step protocol flow, threat model, and milestone/bead spine.
+
+The load-bearing honesty fact is that the **collaborative ZK proof itself**
+(`crates/sparq-mpc/src/proof.rs` `prove`/`verify`, `Attestation`) is an honest
+`NotYetImplemented` stub — the pipeline assembles the `ProofStatement` shape but emits **NO
+proof**, so guarantee C (attested-source) is DESIGNED-not-built at the federated/MPC layer.
+
+Every production soundness/attestation/privacy claim is HARD-GATED on the external
+accredited-cryptographer audit **sq-qhy4** (P0, OPEN); the estate's soundness today rests
+entirely on internal single-model (Opus 4.8) self-audits.
+
+---
+
+## What Is Built and Tested
+
+- **Honest-majority Shamir t-of-n backend** over F_p = 2^61−1 Mersenne prime:
+  `crates/sparq-mpc/src/field.rs:34`, `shamir.rs:98` (`Share{x: party idx ≥1, y: Fp}`),
+  `ShamirBackend`/`MacSession`; CSPRNG masking via ChaCha20 (`rng.rs`/`chacha.rs`, sq-1vt);
+  insecure deterministic RNG only behind a test feature.
+
+- **BGW degree reduction** — `shamir.rs::degree_reduce`, sq-dvuc CLOSED
+  (`research/mpc-zkp-build-out-delta.md:55-59`).
+
+- **Disclosed-key global-IRI equi-join** (crypto-free) and **hidden-value join** via
+  secret-shared field equality: `crates/sparq-mpc/src/join.rs` (`DisclosedKeyJoin`,
+  `HiddenValueJoin`), `lib.rs:335`.
+
+- **Secure comparison** that opens ONLY the boolean verdict bit, never the operands:
+  `crates/sparq-mpc/src/compare.rs` (`disclose_threshold_verdict`, `secure_greater_than`,
+  `secure_equal_to_bit`); Rabbit-style full-field decomposition to 2^60 (`lib.rs:314–326`).
+
+- **Malicious-secure (honest-majority, with-abort) twins** partially built: IT-MAC
+  authenticated sharing foundation `authenticated.rs` (sq-km34.1), `auth_compare.rs`
+  (sq-ka8m), `auth_disclose.rs` (sq-6fv7) — MAC-checked verdict before open at minimal
+  n=2t+1 (`lib.rs:131–151`).
+
+- **Oblivious shuffle** (Waksman/Benes) + **sort** (Batcher odd-even mergesort) and
+  set-returning oblivious output path: `oblivious.rs`, `oblivious_join.rs` (sq-18lk/sq-jnkm,
+  `lib.rs:217–233`).
+
+- **Robust Reed-Solomon / Berlekamp-Welch reconstruction** (detect/correct tampered shares):
+  `robust.rs` (sq-m34i, `lib.rs:211–215`).
+
+- **Bounded-length property paths**: disclosed-key crypto-free unroll (`bounded_path.rs`) and
+  hidden-intermediate exactly-k chain (`hidden_path.rs`) + hidden-key DISTINCT
+  (`hidden_distinct.rs`) + planner guard (sq-py8h.*).
+
+- **Term→Fp domain-separated join-key encoder**: `encode(term) =
+  reduce_mod_p(SHA-512(DOMAIN_TAG || ntriples(term)))`,
+  `DOMAIN_TAG="sparq-mpc/term-join-key/v1\0"` (`term_encode.rs:87,98`); stated birthday bound
+  q²/2^62; fail-closed `KeyEncoder` collision-detection path (sq-dl81).
+
+- **Three-axis configurable security descriptor** `AdversaryModel × OutputGuarantee ×
+  CorruptionThreshold` + `PublicVerifiability`, Cleve impossibility enforced as a type-level
+  invariant, per-operator `OperatorClass` reporting: `backend.rs:106–180`, `lib.rs:279–283`
+  (sq-mq8q).
+
+- **End-to-end federated pipeline driver** for the four-flatmates scenario composing
+  `holder → share → disclosed-key join → secure sum → threshold-verdict → ProofStatement`,
+  with explicit per-operator Disclosed/Hidden routing and a differential-vs-union-store
+  correctness anchor: `crates/sparq-mpc/src/pipeline.rs:233 run_federated` (sq-6y92).
+
+- **Network-tier loopback transport** (Tier 2): star-coordinator, each party a process
+  holding only its Shamir column, hand-written length-prefixed wire codec with
+  `Message{Shares,Open,Step,Swap,Done}` and `StepCode{SumAndOpen=1,MulAndOpen=2,
+  SwapNetworkAndOpen=3}`, field elements as canonical u64 big-endian (8 bytes):
+  `transport.rs:88–151` (sq-tg6b).
+
+- **In-process benchmark matrix harness** with deterministic communication/round/multiplication
+  counters (Tier 1): `bench.rs`, `metrics.rs` (sq-sxm).
+
+- **Single-prover ZK verifier** public-input reconstruction binding challenge/nonce +
+  commitments + FILTER operands + per-row attribution:
+  `crates/sparq-zk-compose/src/verifier.rs:4786 reconstruct_public_inputs`.
+
+- **Single-prover issuer-attestation binding** anchored on an EXTERNAL relying-party key-set K:
+  `verifier.rs:2242 bind_issuer_attestations`.
+
+- **Freshness/replay**: single-use verifier nonce with burn-on-mismatch and
+  `NonceBindingMismatch`, nonce bound as public-input field 0 of every sub-proof:
+  `verifier.rs:4601–4644` (sq-3v2/#4).
+
+- **Untrusted-planner → MPC routing seam** crate `sparq-fedplan-mpc`:
+  `privacy.rs`, `selection.rs`, `routing.rs`, `envelope.rs`, `seam.rs`, `combination.rs` —
+  privacy-aware default-deny source selection + disclosed/hidden `route_operators` + leakage-
+  envelope dual ratification (navigator §3.4, all DONE).
+
+- **Adversarial test suites**: `witness_validation_tests.rs` (sq-7leq CLOSED),
+  `owa_omission_tests.rs` (sq-2fms), `adversarial_tests.rs` (sq-nuok).
+
+---
+
+## Designed, Not Built
+
+- **Collaborative ZK proof over a secret-shared witness** (`prove`/`verify`) —
+  `crates/sparq-mpc/src/proof.rs:135–149`: both methods return `MpcError::NotYetImplemented`;
+  `Proof` (`proof.rs:155`) is a deliberately field-less opaque placeholder (proof system
+  Noir/UltraHonk vs collaborative-SNARK unchosen).
+
+- **Distributed issuer-signature attestation over a secret-shared witness** —
+  `proof.rs:94–116 Attestation` + `AttestationShare` placeholder (carries NO fields at M0);
+  the unsolved Q1 "join nobody has built" (sq-bjl DEFERRED,
+  `research/mpc-m4-distributed-sig-feasibility.md §1`).
+
+- **M4-v1 verifier-side authenticated-input attestation gate** (Dutta eprint 2022/1648 +
+  Artemis arXiv 2409.12055 commit-and-prove anchor) — bead sq-f7bu OPEN, no code
+  (`research/mpc-zkp-build-out-delta.md M-C`).
+
+- **Federated / multi-source `reconstruct_public_inputs` layout** — bead sq-34ml OPEN
+  (blocks sq-f7bu); today `reconstruct_public_inputs` and `bind_issuer_attestations` are
+  single-prover / single-manifest.
+
+- **Full honest-majority IT-MAC malicious-with-abort** — beads sq-km34.2–.9 OPEN;
+  design `research/mpc-malicious-security-design.md`.
+
+- **ORQ-style O(n log n) oblivious sort-merge / linear circuit-PSI join** to replace the
+  all-pairs hidden join — beads sq-ujz8/sq-t21/sq-h99 OPEN (navigator §3.1).
+
+- **In-circuit distributed signature** over secret-shared witness (source-unlinkable
+  single-proof attestation, the thesis novelty) — sq-bjl DEFERRED spike, unsolved in the
+  literature.
+
+- **Dishonest-majority (SPDZ/MASCOT/Overdrive) backend + WAN constant-round family + DP
+  output-cardinality** with epsilon budget — beads sq-j5ok/sq-38zk/sq-shk5/sq-4i39 OPEN;
+  registry FAIL-CLOSES rather than downgrading.
+
+- **Fresh coZK soundness re-audit** of the collaborative path vs eprint 2025/1026 —
+  `research/mpc-cozk-reaudit.md` exists (sq-9hrn) but is an adversarial risk-surfacing pass,
+  NOT a soundness certificate.
+
+- **`secprop` property-admissibility pre-check** consuming the vendored ISWC-2025 `sec-prop:`
+  ontology in `sparq-trust::admit.rs` — bead sq-dt5hv OPEN (ontology is currently data;
+  nothing loads it, navigator §3.3).
+
+---
+
+## Candidate Normative Surface
+
+The following are the spec-ready normative anchors grounded in code. Items marked (DESIGN)
+are designed-not-built and must not be stated as implemented:
+
+1. **Party/role model**: a conformant MPC-SPARQL federation MUST distinguish four roles —
+   Issuer (honest signer, root of trust, pk in disclosed key-set K), Holder/data-source
+   (mutually-distrusting, possibly-malicious; acts as BOTH an MPC compute party AND a
+   collaborative prover), Verifier/relying-party (honest-but-curious; issues a fresh challenge
+   N, checks the proof), and an UNTRUSTED Planner whose plan MUST NOT be trusted for soundness
+   (arch §4.1; `pipeline.rs`).
+
+2. **Each Holder MUST be exactly one honest-majority compute party**: `n >= 2t+1` required for
+   any multiplication/comparison, checked fail-closed (`pipeline.rs:244`).
+
+3. **Secret-share format** (F_p = 2^61−1 Mersenne, `field.rs:34`): a Share is
+   `(x: party index, u64, always ≥1; y: f(x) in F_p)`; x=0 is RESERVED for the secret and
+   MUST NEVER be handed to a party (`shamir.rs:98`).
+
+4. **Network wire protocol** (star-coordinator simulation, `transport.rs:88`): messages are
+   self-describing length-prefixed frames — `Shares(Vec<Share>)` coordinator→party,
+   `Open(Vec<Share>)` party→coordinator, `Step(StepCode)`, `Swap{a,b,swap}`, `Done`;
+   `StepCode` in `{SumAndOpen=1,MulAndOpen=2,SwapNetworkAndOpen=3}`; field elements travel as
+   canonical u64 big-endian, 8 bytes (`FIELD_BYTES`).
+
+5. **Per-operator disclosure routing (RQ2a) MUST be explicit and inspectable**: every operator
+   is tagged `Disclosed` (crypto-free, global-IRI key, computed in the clear) or
+   `Hidden(OperatorClass)` (secret-shared inside the MPC) — `pipeline.rs:93 Routing`,
+   `:110 OperatorRouting`, surfaced in `FederatedResponse.routing`.
+
+6. **No-proof-of-revealed-properties convention**: anything a deterministic function of the
+   disclosed multiset (DISTINCT/ORDER BY/LIMIT/OFFSET/COUNT/SUM/AVG/MIN/MAX) MUST be
+   recomputed by the verifier outside the cryptographic core, never proven in-circuit (arch
+   §2 conv#4).
+
+7. **Secure aggregate**: zero-round local share-addition; a threshold comparison MUST disclose
+   ONLY the boolean verdict bit and MUST NOT reconstruct the exact sum across the API boundary
+   (`pipeline.rs:270–287`; structural assertion at `:528–534`).
+
+8. **Disclosed issuer key-set K** MUST be canonicalised (sort + dedup) so the
+   `ProofStatement`/public-inputs digest is invariant to caller order and multiplicity
+   (`pipeline.rs:319–322`; `ProofStatement.disclosed_key_set` at `proof.rs:74`).
+
+9. **Join-key encoding for PRIVATE keys**: `encode(term) =
+   reduce_mod_p(SHA-512(DOMAIN_TAG || ntriples(term)))` with
+   `DOMAIN_TAG = b"sparq-mpc/term-join-key/v1\0"` (`term_encode.rs:87,98`).
+
+10. **Commitment + attestation format**: each named graph carries C(G_i) issuer-signed as
+    `Sign(pk_i, {C(G_i), true-triple-count, salt})` (`arch §4.3 step 1`); signed message via
+    Schnorr-over-Baby-JubJub / Poseidon2 challenge with domain tags `ZKSIG_C3/C4`
+    (`verifier.rs:2428–2443`).
+
+11. **Attestation-binding trust anchor** MUST be the EXTERNAL relying-party key-set K, NEVER
+    the prover-supplied `manifest.key_set`; prover MAY narrow but MUST NOT widen K
+    (`verifier.rs:2242–2344`).
+
+12. **Correctness-proof public-input binding**: field 0 of every sub-proof MUST be the
+    verifier's fresh nonce; the canonical verifier key is recomputed verifier-side from the
+    re-derived `CircuitId` (NEVER the prover's `vk`) (`verifier.rs:4685–4707`).
+
+13. **Freshness/replay**: verifier nonce MUST be single-use (recorded BEFORE the crypto gate,
+    burn-on-mismatch) — mandatory, no opt-out path (`verifier.rs:4601–4644`).
+
+14. **`ProofStatement`** is the public statement the collaborative proof binds:
+    `{ query (canonical SPARQL digest), disclosed_key_set K, challenge N, disclosed_result }`
+    (`proof.rs:70–85`).
+
+15. **Collaborative-proof MUST-check obligations** (DESIGN, gated): the joint proof MUST bind
+    (a) `Disclosed(pi)` subset of `Eval_PAG(Q,D)`; (b) each contributing `C(G_i)` issuer-
+    signed under a key in K; (c) the query digest, FILTER operator/operand/verdict, per-row
+    source-graph attribution, and challenge N (`proof.rs:12–23`, arch §4.3 step 5).
+
+16. **Security-model vocabulary**: guarantees reported PER-OPERATOR over three orthogonal axes
+    `AdversaryModel(SemiHonest/Covert-with-epsilon/Malicious) × OutputGuarantee(Abort/
+    Fairness/GuaranteedOutput) × CorruptionThreshold(HonestMajority/DishonestMajority)` plus
+    `PublicVerifiability`, with Cleve's impossibility enforced as a type invariant
+    (`backend.rs:106–180`).
+
+17. **Security-considerations MUST-state**: the verifier-side-attestation v1 GIVES UP
+    (1) source-unlinkability, (2) a single succinct signature-to-witness proof, (3) malicious-
+    against-N-1, and (4) needs explicit out-of-circuit freshness binding; and NO
+    soundness/attestation/privacy property is production-claimable until sq-qhy4 lands.
+
+---
+
+## Gaps (Spec Must Address)
+
+1. **No wire format for the DEPLOYED protocol**: `transport.rs` is an explicit
+   star-coordinator SIMULATION harness; the deployed full party-mesh is unspecified. The spec
+   must define the real inter-party message set, not the simulation.
+
+2. **Federated / multi-source public-input byte layout does not exist**: `reconstruct_public_inputs`
+   is single-manifest; the ordering/packing of all holders' commitments/rows/attribution under
+   ONE federated statement is designed-only (sq-34ml).
+
+3. **No message/handshake formats** for the verifier↔federation exchange (delivery of Q +
+   fresh nonce N, delivery/agreement of trusted key-set K, the response envelope) are
+   formalised — arch §4.3 steps 2/6 are prose only.
+
+4. **Collaborative `Proof` and `AttestationShare` are field-less placeholders** (`proof.rs:113,155`):
+   proof-system choice (Noir/UltraHonk vs collaborative-SNARK), byte layout, and distributed
+   attestation share representation are all unspecified.
+
+5. **Canonical query normalisation/digest is undefined**: `pipeline.rs` uses
+   `FederatedQuery.federated_query` VERBATIM and declares canonicalisation "the caller's
+   responsibility" (`pipeline.rs:154–160`).
+
+6. **Cross-graph blank-node identity for join keys is out of scope** of the encoder (matches
+   on label only, `term_encode.rs:68–77`); the spec must define bnode join semantics or
+   mandate `sparq-canon` relabelling.
+
+7. **Federation-level revocation freshness-window and status-list reference handling** is
+   single-prover (`bind_revocation`, `verifier.rs:2168`); the multi-source revocation/freshness
+   policy is unspecified.
+
+8. **Corruption-threshold normativity**: the honest-majority assumption is asserted (n≥2t+1)
+   but whether a federation MUST refuse to run below a threshold is not pinned as a normative
+   MUST.
+
+9. **Leakage-envelope numeric budgets / DP epsilon accounting** exist as a mechanism but the
+   normative leakage vocabulary and epsilon-budget format are deferred (sq-shk5).
+
+10. **coZK witness-validation-before-proving** is only a TEST obligation (`witness_validation_tests.rs`);
+    the spec must state validation of the extended witness BEFORE proving as a normative MUST
+    for any future collaborative-proof implementation (eprint 2025/1026 pitfall).
+
+---
+
+## Honesty Flags
+
+- **The 'ZKP of correctness' at the MPC/federated layer is NOT built**: `proof.rs prove/verify`
+  are honest `MpcError::NotYetImplemented` stubs. Any spec sentence implying a working
+  federated correctness proof today would be false.
+
+- **Guarantee C (attested-source derivation) at the federated layer is DESIGN-only**; only the
+  SINGLE-PROVER attestation binding (`bind_issuer_attestations`) is built.
+
+- **ALL soundness rests on internal single-model self-audits** (`research/zk-soundness-audit.md`,
+  `research/mpc-cozk-reaudit.md`); the external accredited-cryptographer audit **sq-qhy4** (P0)
+  has NOT run. SECURITY.md correctly publishes "treat as untrusted". Every production
+  soundness/attestation/privacy claim MUST be caveated as NOT-audited / NOT-production-claimable.
+
+- **The collaborative (multi-prover) path is NOT covered** by the single-prover re-audit;
+  coZK malicious security is unsettled — eprint 2025/1026 shows proving on an
+  invalid/inconsistent witness can LEAK honest provers' inputs; the closest usable stack
+  (TACEO co-snarks / coNoir-Barretenberg) is explicitly UNAUDITED.
+
+- **Default security tier is honest-majority SEMI-HONEST, not malicious**: the pipeline
+  threshold comparison is `OperatorClass::Comparison @ semi-honest-only`; IT-MAC
+  malicious-with-abort is only partially landed (sq-km34.* OPEN).
+
+- **In-circuit distributed signature** over a secret-shared witness (source-unlinkable
+  attestation) is UNSOLVED in the literature and correctly deferred (sq-bjl); it MUST NEVER
+  be presented with a performance number.
+
+- **The Term→Fp join-key encoder is a STATISTICAL birthday bound** (q²/2^62), not a security
+  guarantee; the in-circuit encoding-correctness proof is the unbuilt M4 job.
+
+- **Dishonest-majority malicious correctness for ANY SPARQL operator on WAN is NOT achieved**
+  in the literature and has ZERO performance data points; the registry FAIL-CLOSES rather than
+  downgrading.
+
+- **Benchmarks are NON-CANONICAL**: only deterministic metrics (bb gate counts, MPC
+  round/byte COUNTERS, nargo info opcodes) are quotable; netem LAN/WAN wall-clock needs
+  CAP_NET_ADMIN and is gated to sq-hoaj.
+
+- **`sparq-trust` is a research-grade PoC** (clear-text admission, no unlinkability,
+  operator-asserted issuer keys); the vendored ISWC-2025 `sec-prop:` ontology is currently
+  DATA — nothing loads it (navigator §3.3).
+
+---
+
+> **Empirical-honesty reminder**: ZK and MPC estates are NOT production-sound until the
+> external cryptographer audit sq-qhy4 completes. All work-box benchmarks are non-canonical;
+> do not hard-code them in documentation or tests.
+
+---
+
+*Recon captured by Sonnet 4.6 under the Fable program; [SONNET-4.6]*

--- a/research/specs/mpc-sparql-estate-recon.md
+++ b/research/specs/mpc-sparql-estate-recon.md
@@ -138,9 +138,12 @@ entirely on internal single-model (Opus 4.8) self-audits.
   `research/mpc-cozk-reaudit.md` exists (sq-9hrn) but is an adversarial risk-surfacing pass,
   NOT a soundness certificate.
 
-- **`secprop` property-admissibility pre-check** consuming the vendored ISWC-2025 `sec-prop:`
-  ontology in `sparq-trust::admit.rs` — bead sq-dt5hv OPEN (ontology is currently data;
-  nothing loads it, navigator §3.3).
+- **`secprop` property-admissibility pre-check in the MPC-SPARQL federated admission path** —
+  the pre-check primitive itself is BUILT and tested (`sparq_trust::admit_with_precheck`, opt-in
+  `secprop-precheck`, consuming the vendored ISWC-2025 `sec-prop:` ontology via the
+  `secprop-admissibility` N3 reduction; `tests/secprop_precheck_e2e.rs`, sq-dt5hv Phase 5). What
+  remains OPEN for MPC-SPARQL is wiring it into the federated / multi-source admission path —
+  today `admit_with_precheck` is exercised only in single-party `sparq-trust` tests (navigator §3.3).
 
 ---
 

--- a/research/specs/specs-infra-plan.md
+++ b/research/specs/specs-infra-plan.md
@@ -1,0 +1,258 @@
+# /specs Infrastructure Plan
+
+> Grounding for the specs infrastructure work (bead sq-rvgr2.1). Read-only recon; not itself normative.
+
+## Summary
+
+The `/papers` pipeline is a Typst→PDF+HTML build-time factory. Sources live in `site/papers/*.typ`,
+a prebuild script (`site/scripts/build-papers.mjs`) compiles each `.typ` to a PDF artifact
+(`site/public/papers/<slug>.pdf`, git-ignored) and a body-fragment HTML
+(`site/src/generated/papers/<slug>.html`, git-ignored), and the Next.js static route
+(`site/src/app/papers/[slug]/page.tsx`) reads the fragment via `readFileSync` at Next.js build
+time and injects it via `dangerouslySetInnerHTML` — no runtime JS or WASM compiler shipped.
+
+A `/specs` section can be built as an exact parallel, but the source compiler for specs is W3C
+ReSpec (HTML→baked HTML via puppeteer) rather than Typst, which introduces a Chromium dependency
+in the `pages.yml` CI workflow that currently has none.
+
+---
+
+## Papers Pipeline Mechanics (Exact)
+
+### Source layout
+
+- `site/papers/*.typ` — Typst sources; shared helper `site/papers/_lib/bench.typ` (evidence
+  injection + honesty gate accessors `headline()`/`ev()`).
+- `site/src/data/paper-evidence.json` — records with `value`/`source`/`environment`
+  (`canonical|indicative`); the honesty gate in `build-papers.mjs:85–113` rejects any record
+  that is not canonical/indicative or lacks `source`/`value`.
+- `site/src/data/papers.ts` — exports `PAPERS: Paper[]` (slug, source, title, blurb, authors,
+  venue, status, family, evidence). `build-papers.mjs` reads slug and source from this file via
+  two regexes at lines 71–72 (no TS compiler needed); the script is plain `.mjs`.
+
+### Build script `site/scripts/build-papers.mjs` (invoked as `prebuild` step)
+
+1. `runHonestyGate()` — validates evidence JSON schema; exits 1 on bad records.
+2. `runBuildBoundaryHonestyScan()` — re-runs `scripts/check-no-perf-numbers.py --enforce` +
+   `scripts/check-privacy-claims.sh` (from `REPO_ROOT`) over the exact paper `.typ` sources +
+   evidence file; FAIL-CLOSED.
+3. `resolveTypst()` — `PATH || ~/.local/bin/typst || ~/.cargo/bin/typst`; returns null if
+   absent.
+4. Per paper: `execFileSync(typst, ["compile", typPath, pdfOut, "--root", SITE, "--input",
+   "data=<evidenceJson>"])` → `public/papers/<slug>.pdf` (`PDF_OUT_DIR = site/public/papers/`).
+5. Per paper: `execFileSync(typst, ["compile", typPath, htmlOut, "--format","html",
+   "--features","html", "--root", SITE, "--input", "data=..."])` → temp full HTML file.
+6. Regex-extracts `<body>…</body>` innerHTML from the full HTML (line 199–200); prepends a
+   provenance HTML comment (`generatedHeader()`, lines 39–44); writes to
+   `site/src/generated/papers/<slug>.html` (`HTML_OUT_DIR`).
+7. Graceful fallback (lines 224–242): if typst absent, writes a
+   `<p class="paper-placeholder">…</p>` so next build does not hard-fail; this is dev-only —
+   CI always has typst.
+
+### Evidence binding
+
+Every number in a `.typ` comes only through `site/papers/_lib/bench.typ` — `headline(key)`
+(line 31) PANICS the compile if the record's `environment != "canonical"`; `ev(key)` (line 28)
+is the ungated accessor for indicative callouts. Same JSON feeds PDF and HTML so they cannot
+disagree.
+
+### Prebuild hook
+
+`site/package.json` line 14: `"prebuild": "node scripts/sync-wasm.mjs && … && node
+scripts/build-papers.mjs"`. Both `"build"` (via prebuild) and `"dev"` scripts trigger it.
+
+### CI (`pages.yml`)
+
+Installs Typst v0.15.0 pinned by SHA256 `59b207df…` (lines 165–175), then runs
+`npm ci && npm run build` in `site/`.
+
+### Next.js route `site/src/app/papers/[slug]/page.tsx`
+
+- `generateStaticParams()` returns `PAPERS.map(p => ({slug: p.slug}))` — all slugs pre-rendered
+  at build time.
+- `dynamicParams = false` (line 35).
+- `readPaperHtml(slug)` calls `readFileSync(join(process.cwd(), "src","generated","papers",
+  <slug>.html))` at Next.js BUILD TIME (not at runtime; this is an RSC server-side read at the
+  static-export generation step).
+- Renders via `<PaperHtml html={html} />` which is `<article className="paper-prose"
+  dangerouslySetInnerHTML={{__html: html}} />` (`site/src/components/papers/paper-html.tsx`).
+
+### Navigation
+
+`TOP_PAGES[]` entry `{href:"/papers", title:"Papers", blurb:"…"}` at
+`command-palette.tsx:105` — Cmd-K accessible. NOT in `NAV_ITEMS[]` in `app-shell.tsx` (slim
+bar kept at 6 destinations: Home/Capabilities/Try/App/Benchmarks/Download).
+
+### Gitignore
+
+`site/.gitignore` line 14 `/public/papers/` (PDF artifacts); line 15 `/src/generated/`
+(HTML fragments). Both are regenerable build outputs, not tracked source.
+
+---
+
+## Recommended ReSpec Approach for `/specs`
+
+**Option A — ReSpec CLI baked at build time (RECOMMENDED)**: This is an exact parallel of the
+papers pipeline. The `respec` npm package (v37.1.0, devDependency) provides a CLI that uses
+puppeteer (v24) to run ReSpec headlessly. The build script calls:
+
+```
+respec --src file:///abs/path/to/spec.html --out /tmp/spec-full.html \
+  --localhost --use-local --haltonerror --no-sandbox
+```
+
+- `--use-local` avoids the W3C CDN fetch during build (network-independent).
+- `--localhost` starts a local HTTP server so puppeteer loads a proper `http://` URL.
+- `--no-sandbox` is required for headless Chrome in CI without user-namespace support.
+
+After compilation: extract `<body>` innerHTML (same regex as `build-papers.mjs:199–200`),
+prepend a provenance comment, write to `site/src/generated/specs/<slug>.html`. The Next.js
+route reads the fragment at build time via `readFileSync`, injects via `dangerouslySetInnerHTML`
+inside an `<article className="spec-prose">` wrapper. Static, SEO-indexable, no runtime JS.
+
+**Option B — ReSpec client-side (CDN script) — NOT RECOMMENDED**: Page content is not rendered
+in the static HTML, so web crawlers and users without JS see unformatted content. Conflicts with
+the site's static-export philosophy.
+
+**Option C — Bikeshed (no Chrome required)**: `python3 -m bikeshed spec site/specs/<slug>.bs
+/tmp/<slug>.html`; fast (<2s per spec), no browser required, Python already a CI dep. Source
+format `.bs` is less familiar to the Semantic Web/RDF community than ReSpec HTML. Viable if
+Chrome in CI is a hard constraint.
+
+**Overall recommendation**: Option A for correctness to the bead spec ("W3C ReSpec-style"); the
+Chrome overhead in `pages.yml` is real but manageable. If Chrome is a hard constraint, use
+Option C.
+
+---
+
+## Ordered Build Steps (15 steps)
+
+1. Create `site/specs/` directory and write the first spec source as a standard ReSpec HTML
+   file (e.g., `site/specs/sparql-extension-registry.html` with `respecConfig` JSON in a
+   `<script class='remove'>`, `specStatus: 'unofficial'`, `shortName`, `editors` list).
+
+2. Create `site/src/data/specs.ts` mirroring `papers.ts` shape: export `Spec` interface
+   (slug: string, source: string, title: string, blurb: string, shortName: string, status:
+   `'unofficial' | 'cg-draft' | 'draft'`, editors: string), export `SPECS: Spec[]`, export
+   `specBySlug()`. The build script will regex-parse `slug+source` from this file exactly as
+   `build-papers.mjs` reads `papers.ts`.
+
+3. Create `site/scripts/build-specs.mjs` modelled on `build-papers.mjs`: (a) `readRegistry()`
+   via regex over `specs.ts`; (b) `resolveRespec()` — check `node_modules/.bin/respec` (works
+   after `npm ci` installs the devDep); (c) graceful fallback: if respec absent, write
+   placeholder HTML to `src/generated/specs/<slug>.html` and return; (d) per spec: shell out
+   to `respec --src file:///abs/path/to/spec.html --out /tmp/<slug>-full.html --localhost
+   --use-local --haltonerror --no-sandbox`; (e) extract `<body>` innerHTML; (f) write
+   provenance comment + fragment to `site/src/generated/specs/<slug>.html`.
+
+4. Add `respec@37.1.0` as a `devDependency` in `site/package.json` (pin the version; avoids
+   an `npx` download at build time and ensures the version is locked in the workspace
+   lockfile).
+
+5. Append `&& node scripts/build-specs.mjs` to the `prebuild` script in `site/package.json`
+   (after `build-papers.mjs`). Also add it to the `dev` script so local dev generates
+   placeholders.
+
+6. Add `/public/specs/` to `site/.gitignore` (if any downloadable HTML spec artifacts are
+   produced alongside the fragment; the existing `/src/generated/` entry at line 15 already
+   covers `src/generated/specs/`).
+
+7. Create `site/src/app/specs/layout.tsx`: identical to `papers/layout.tsx` —
+   `<div className='mx-auto w-full max-w-3xl'>{children}</div>`.
+
+8. Create `site/src/app/specs/page.tsx`: data-driven index card grid from `SPECS[]`, with
+   status badges and links to `/specs/<slug>`. Mirror the card structure of `papers/page.tsx`.
+
+9. Create `site/src/app/specs/[slug]/page.tsx`: `generateStaticParams()` from `SPECS`;
+   `dynamicParams = false`; `readSpecHtml(slug)` via `readFileSync(join(process.cwd(),
+   'src','generated','specs', slug+'.html'))` at build time; render via `<SpecHtml html={html}
+   />`.
+
+10. Create `site/src/components/specs/spec-html.tsx`:
+    `<article className='spec-prose' dangerouslySetInnerHTML={{__html: html}} />`
+    (mirrors `paper-html.tsx`).
+
+11. Add `.spec-prose` CSS block to `site/src/app/globals.css` covering the ReSpec-generated
+    class names that `.paper-prose` does not: `dfn { font-weight:600; cursor:help }`,
+    `.note`/`.informative` (styled aside boxes), `.issue` (warning-coloured aside), `.example`
+    (code-sample aside), `pre.idl` (monospace, border-left accent), `#toc ol
+    { list-style:decimal; padding-left:1.5rem }`, `figure.syntax`, `.respec-dfn-list`. Reuse
+    the existing OKLCH palette tokens (`--muted`, `--border`, `--primary`) for consistency.
+
+12. Add `{ href: '/specs', title: 'Specs', blurb: 'W3C Unofficial Proposal Draft specifications
+    produced by the sparq project.' }` to `TOP_PAGES[]` in
+    `site/src/components/command-palette.tsx` (after the papers entry at line 105). Do NOT add
+    it to `NAV_ITEMS[]` in `app-shell.tsx` — `/specs` stays Cmd-K accessible, keeping the slim
+    bar at 6.
+
+13. Update `pages.yml`: add a 'Install Chromium for respec' step before 'Build static site':
+    `sudo apt-get install -y chromium-browser`; set env var
+    `PUPPETEER_EXECUTABLE_PATH=$(which chromium-browser)` (or pass it to the `npm run build`
+    env). Optionally cache the apt package or use `actions/cache` keyed on respec version to
+    avoid repeated downloads.
+
+14. Add a unit test or stub in `site/test/` that verifies the specs registry round-trips (slug
+    uniqueness, source file existence check) — mirrors the pattern that `build-papers.mjs` uses
+    for papers.
+
+15. Smoke-test the assembled artifact in `pages.yml`: add `out/specs/` to the existing smoke-
+    check step — assert `out/specs/index.html` exists and at least one `out/specs/<slug>/
+    index.html` is present after the build.
+
+---
+
+## Risks
+
+1. **Chrome/puppeteer not in `pages.yml`**: respec v37 depends on puppeteer v24 which needs
+   Chromium. Adding `sudo apt-get install -y chromium-browser` adds ~60s; `npx playwright
+   install --with-deps chromium` adds ~3min. Must also set `PUPPETEER_EXECUTABLE_PATH` so
+   respec's puppeteer finds the system browser, otherwise puppeteer tries to download its own
+   Chrome (~120MB) into `~/.cache/puppeteer` which may race with CI disk quotas.
+
+2. **Fragment CSS surface area**: Typst HTML export emits clean `h2/h3/p/table/strong/em/code`
+   semantic tags that `.paper-prose` handles with ~40 lines of CSS. ReSpec output uses ReSpec-
+   specific class names (`dfn`, `.note`, `.issue`, `.example`, `.informative`, `.normative`,
+   `pre.idl`, `figure.syntax`, `#toc`, `#toc ol`, `.respec-dfn-list`, `.respec-ref-bibl`)
+   that require a substantially larger `.spec-prose` block. If the CSS block is incomplete,
+   spec pages will render as unstyled HTML inside the sparq site shell.
+
+3. **lychee `--include-fragments` regression**: ReSpec bakes a dense table of contents with
+   `href='#section-N-title'` anchors. The `pages.yml` link-check (`check-site-links.sh`,
+   `lychee --include-fragments`) validates every `#fragment`. If a ReSpec-generated spec
+   section ID does not match a link (e.g., a manually-written cross-reference inside the spec
+   that points to a section that was renumbered), the link-check fails the entire `pages.yml`
+   build. Test locally before merging.
+
+4. **respec `--localhost` port collision**: `build-specs.mjs` runs one respec process per spec;
+   each `--localhost` invocation starts a local HTTP server on the default port 3000. If two
+   specs are compiled in parallel (or if the build environment has another service on 3000),
+   the port conflicts. The `--port` flag can override; process specs sequentially and pass a
+   distinct `--port` per invocation.
+
+5. **ReSpec `--use-local` CDN independence**: without `--use-local`, respec fetches the W3C
+   CDN at render time. In CI this depends on outbound network availability and CDN uptime. The
+   `--use-local` flag MUST be set to make builds deterministic and network-independent.
+
+6. **TypeScript and eslint gates**: the new `specs.ts`, route pages, and `spec-html.tsx`
+   component must pass the `eslint-config-next` typecheck that runs as part of `npm run lint`
+   (`site-e2e.yml` lint step). Any unused import, missing return type annotation, or missing
+   `'use client'` directive on a client component will fail the lint gate.
+
+7. **Nav test brittleness**: `site-e2e.yml` runs `site-nav.spec.ts` which asserts the slim bar
+   has exactly 6 destinations. As long as `/specs` stays in Cmd-K only (`TOP_PAGES`, not
+   `NAV_ITEMS`), this test is unaffected.
+
+8. **Placeholder fallback must match both formats**: `build-specs.mjs` must write a placeholder
+   HTML when respec is absent (following the existing paper placeholder pattern
+   `<p class='paper-placeholder'>…</p>`) so `readFileSync` at Next.js build time does not
+   produce a broken `dangerouslySetInnerHTML` injection.
+
+---
+
+> **Empirical-honesty reminder**: ZK and MPC estates are NOT production-sound until the
+> external cryptographer audit sq-qhy4 completes. All work-box benchmarks are non-canonical;
+> do not hard-code them in documentation or tests.
+
+---
+
+*Recon captured by Sonnet 4.6 under the Fable program; [SONNET-4.6]*

--- a/research/specs/specs-infra-plan.md
+++ b/research/specs/specs-infra-plan.md
@@ -96,7 +96,7 @@ bar kept at 6 destinations: Home/Capabilities/Try/App/Benchmarks/Download).
 papers pipeline. The `respec` npm package (v37.1.0, devDependency) provides a CLI that uses
 puppeteer (v24) to run ReSpec headlessly. The build script calls:
 
-```
+```sh
 respec --src file:///abs/path/to/spec.html --out /tmp/spec-full.html \
   --localhost --use-local --haltonerror --no-sandbox
 ```

--- a/research/specs/vector-genai-estate-recon.md
+++ b/research/specs/vector-genai-estate-recon.md
@@ -1,0 +1,290 @@
+# Vector + GenAI Estate Recon
+
+> Grounding for the Vector/GenAI SPARQL Proposed Spec (bead sq-rvgr2.4). Read-only recon; not itself normative.
+
+## Summary
+
+Opt-in `crates/sparq-vectors` (one f32 embedding per dict term-id, flat mmap `.spqv`) plus
+adjacent `sparq-nlq`/`sparq-introspect` NL crates. The **ONLY parsed+executed vector SPARQL
+surface** is two magic predicates in namespace `http://sparq.dev/vec#`: `?node vec:nearest (
+query k )` and `( ?node ?score ) vec:search ( query k )`, an algebra-to-VALUES rewrite behind
+the `vec-predicate` feature with the engine unchanged (`src/rewrite.rs`).
+
+Search is an answer-exact full scan plus opt-in approximate HNSW / DiskANN-Vamana / PQ
+backends whose recall is explicitly under 1.0. Filtered-ANN (BGP-to-`IdMask`, cost-model
+pre/post-filter, transitive connected-component constraint, cross-prepare mask cache) is built
+and tested.
+
+Key missing provenance: the `.spqv` header records dimension (u32) and a graph fingerprint
+(dict_len+triple_count+content_hash) but records **NO embedding model-id, model-version, or
+distance metric**; cosine is implicit in the mainline path. Vendor precedent (GraphDB
+`similarity:`, Stardog Voicebox, Neptune, Neo4j, Qdrant/Weaviate/pgvector/Milvus) is catalogued
+in `research/`, framing `vec:`-in-SPARQL as the headline parity gap with V4/V5/V6/V8/V9/GNCE
+designed-but-unbuilt.
+
+---
+
+## What Is Built and Tested
+
+- **`.spqv` mmap store**: SPQV magic + version-2 header (dim u32 at off 8, count u64, 12B
+  reserved, 24B graph fingerprint at off 32, dense f32 data, sorted id-to-slot index)
+  `src/store.rs:1–17,62–70`; `StreamingWriter` O(1)-RAM build + `open_from_bytes`;
+  `tests/store.rs`, `staleness_contract.rs`.
+
+- **`vec:nearest` / `vec:search` magic predicates**, the ONLY parsed+executed vector SPARQL
+  surface. NS `http://sparq.dev/vec#` `lib.rs:112–123`; spargebra-algebra to inline VALUES
+  rewrite, engine/planner/wasm unchanged, `src/rewrite.rs:1–79` dispatch `404–412`; entry
+  points `query_vec`/`prepare_vec`/`rewrite_query` `rewrite.rs:170–289` behind `vec-predicate`.
+
+- **Approximate `vec:` twins** `query_vec_approx`/`prepare_vec_approx` over an on-disk
+  `DiskAnnIndex`, `rewrite.rs:214–257`, recall under 1.0, staleness-guarded, gated
+  `approx-ann`.
+
+- **Exact + approximate ANN**: `nearest_exact`/`nearest_term_exact(_checked)` `src/ann.rs`;
+  in-RAM HNSW `VectorIndex` via `instant-distance` (`approx-ann`); on-disk DiskANN/Vamana
+  `.spqg` SPQG (`src/diskann.rs`) with PQ candidate cache.
+
+- **Filtered (predicate-constrained) ANN**: `IdMask` + `nearest_exact_filtered`
+  `src/filter.rs`; BGP-to-`IdMask` derivation over the join-connected connected-component
+  (transitive/cyclic), engine-evaluated mask `rewrite.rs:768–825`,
+  `connected_component 943–979`; pre/post-filter `CostModel` `src/cost.rs`; cross-prepare mask
+  cache keyed by (sub-BGP, graph `Fingerprint`) with soundness proof + adversarial
+  invalidation tests `rewrite.rs:849–1211`.
+
+- **Iterative over-fetch filtered path + pluggable `AnnBackend`** (`ExactBackend` answer-exact,
+  `ApproxBackend` recall under 1.0) `src/backend.rs`.
+
+- **Quantisation**: `ScalarQuantizer` (f32 to u8, 4×) + `ProductQuantizer`
+  (ADC/DistanceTable) with persistable codebook + `EncodedStore`, `src/quant.rs`.
+
+- **Embedder seam**: provider-agnostic `Embedder` trait (one `dim()`-length finite vector per
+  input, in order) + test-only `HashEmbedder` (NO semantics) `src/embed.rs:10–83`; `provider`
+  feature = OpenAI-compatible `/v1/embeddings` request/response shape with caller `Transport`
+  (`embed.rs:108–146`); `embeddings` feature = concrete reqwest `RemoteEmbedder::from_env`
+  reading `SPARQ_EMBEDDINGS_API_KEY/BASE_URL/MODEL` (`embed.rs:159–253`).
+
+- **Verbalisation + label pipelines** `verbalize`/`embed_entities`/`embed_labels` (label chain,
+  multilingual, budgeted) `src/verbalize.rs`, `src/labels.rs`.
+
+- **Hybrid fusion helpers LIBRARY-ONLY** (NOT in SPARQL): `fuse_rrf`/`fuse_rrf_weighted`/
+  `fuse_scores`/`hybrid_search` (RRF k=60) `src/fuse.rs`.
+
+- **Bulk import** `import_npy`/`import_numeric_dump` via a row-to-dict-id contract, fail-closed
+  on dtype/shape/order/length/non-finite, bounded `.npy` header, `src/import.rs`.
+
+- **Incremental delta sidecar** (add/remove/update/compact + crash-durable `.spqd` SPQD
+  sidecar, generation-tied) `src/delta.rs` (`delta` feature).
+
+- **Structure-aware vectorisation epic sq-0wo9e** (behind `structure`/`structure-shacl`/`kge`/
+  `neuro-symbolic` features, zero default-build code): typed-literal encoders + self-describing
+  `.spqs` `SchemaHeader` (SPQS, per-block `Metric` tag Euclidean/NonEuclidean + metric-
+  correctness guard) `src/encode.rs:433–558`; enum `Codebook` + QUDT unit normaliser;
+  SHACL/OWL prior extractor; taxonomy DAG + Euclidean/hyperbolic encoders + `GeometryGate` +
+  `DisjointnessOracle`; closure + type-constrained negative sampler `structure.rs`.
+
+- **KGE trainer + eval harness** (`kge` feature, hand-rolled SGD): DistMult/ComplEx `train.rs`
+  + filtered link-prediction ablation; explicitly NO accuracy claim.
+
+- **Provenance-weight reader** `w(t)` (`structure` feature): mines `pkg:confidence` /
+  `pkg:assurance` (`secx:Proven/Claimed/Conjectured`) / `prov:wasDerivedFrom` /
+  `pkg:discoveredFrom`, fail-open 1.0 on plain graphs, `WeightMode` on/off ablation,
+  `src/provenance.rs:1–67`.
+
+- **Neuro-symbolic propose-then-verify** (`neuro-symbolic` feature): vector ANN proposes
+  candidates then a deductive gate admits only if no new SHACL violation and no new OWL
+  inconsistency, fail-closed, `src/verify.rs`.
+
+- **Compose read-path URI-hiding view** + model-free fidelity/cost `ab_report` + measured K4
+  real-model blinded paired A/B, `src/compose.rs` (`compose` feature).
+
+- **Adjacent NL-retrieval**: `sparq-nlq` NL-to-SPARQL loop (ground/generate/validate/execute/
+  repair; `ReplayLlm`/`RecordingLlm`/live `AnthropicLlm`/`nlq-endpoint`) + `sparq_nlq::eval`
+  answer-F1 harness + `citations`/`qualify` provenance features; `sparq-introspect` schema
+  card/VoID/SHACL/characteristic-sets; `skills/genai-retrieval/SKILL.md`.
+
+---
+
+## Designed, Not Built
+
+- **Richer `vec:` forms**: only `vec:nearest`/`vec:search` exist. `vec:textNearest`,
+  `vec:score`, `vec:hybrid` named only in `research/feature-research-vector-genai.md:177,180`
+  (V1/V4), no parser/executor.
+
+- **V4 in-query hybrid + weighted-RRF in SPARQL**: fusion is library-only (`src/fuse.rs`); no
+  SPARQL exposure. `feature-research-vector-genai.md:180,204`.
+
+- **V5 RaBitQ binary quantisation** (1-bit + popcount) NOT built; only SQ(4×)/PQ exist.
+
+- **V6 cross-encoder rerank stage-2 seam** NOT built.
+
+- **V8 named / multi-vector per dict id** NOT built; store holds exactly one f32 vector per
+  id.
+
+- **V3 GNCE KGE-for-cardinality planner hook** proposed but NOT wired to `cs-planner` (KGE
+  trainer exists, not connected).
+
+- **V9 RDF-native provenance-carrying GraphRAG retriever** is a composition, not a built unit.
+
+- **SERVICE-form and standard-function-form vector search**: `research/genai-kg-embeddings-
+  vectorindex.md:351–352` lists a `sparq:nearest` predicate OR a SERVICE/function as
+  alternatives; only the magic-predicate path was built.
+
+- **Embedding model-id / model-version / metric provenance in the store** NOT recorded in any
+  `.spqv`/`.spqg`/`.spqd` header (only dim + graph fingerprint); the provider model string
+  (`embed::ProviderConfig.model`, `DEFAULT_MODEL embed.rs:168`) is runtime-only, never
+  persisted.
+
+- **Calibrated confidence for `qualify`/`citations`** deferred; band reflects ASSERTED
+  assurance, no reliability-diagram measurement.
+
+- **Provenance-weighting adoption** gated behind on/off ablation with an explicit adopt-only-
+  on-measured-lift-else-ABANDON bar; lift currently UNPROVEN (`provenance.rs:34–43`).
+
+- **Grammar/logit-constrained NL-to-SPARQL decoding** NOT implemented; only a post-hoc N2
+  dictionary constraint exists.
+
+---
+
+## Candidate Normative Surface
+
+1. **Vocabulary**: `vec:` NS IRI is `http://sparq.dev/vec#` (`lib.rs:114`); recognised
+   predicate IRIs are `http://sparq.dev/vec#nearest` and `http://sparq.dev/vec#search`
+   (`lib.rs:119,122`).
+
+2. **Pattern**: `?node vec:nearest ( query k )` MUST bind `?node` to the k nearest neighbours
+   best-first; `( ?node ?score ) vec:search ( query k )` MUST additionally bind `?score` to
+   the cosine similarity as an `xsd:double` (`rewrite.rs:38–52`).
+
+3. **Argument grammar**: `( ... )` are ordinary SPARQL RDF collections (`rdf:first`/`rdf:rest`);
+   the object list MUST be exactly `( query k )` and the `vec:search` subject exactly
+   `( ?node ?score )` (`rewrite.rs:566–596`).
+
+4. **Typing**: `query` MUST be a constant node IRI (its stored vector, seed self-excluded) OR a
+   comma-separated float literal whose dimension MUST equal store dim; `k` MUST be a
+   non-negative integer literal constant (`rewrite.rs:54–64,599–638`, dim-check `719–725`).
+
+5. **MUST-fail (hard query error) obligations**: unknown `vec:` IRI (`rewrite.rs:407–411`);
+   neighbour position not a variable (`require_var 641–646`); non-constant query/k; wrong
+   argument arity (`589–595`); query-vector dim not equal store dim (`720–725`); malformed/
+   dangling/cyclic argument list (`ListCells::elements 523–550`).
+
+6. **Result ordering**: VALUES rows carry no order through joins; a consumer MUST `ORDER BY
+   DESC(?score)` over a `vec:search` score to recover best-first (`rewrite.rs:76–79`).
+
+7. **Semantics**: an absent/unembedded seed IRI MUST yield zero rows (`rewrite.rs:687–693`);
+   an all-zero query MUST yield no results; the exact scan is the answer-exact default,
+   approximate backends MUST be flagged recall under 1.0.
+
+8. **Formats (little-endian)**: `.spqv` v2 magic SPQV, version u32=2, dim u32, count u64, 12B
+   reserved, 24B fingerprint (dict_len, triple_count, content_hash u64), dense f32, sorted
+   (id u32, slot u32) index (`store.rs:1–17,62–70`); siblings `.spqg` SPQG, `.spqd` SPQD,
+   `.spqs` SPQS (`encode.rs:552`).
+
+9. **Staleness contract**: fingerprint = dict_len + triple_count + content_hash over the dict
+   term SET in dict-id-order-INDEPENDENT order, thread-count-stable; `check_graph` is
+   NECESSARY-but-NOT-SUFFICIENT; to serve a persisted store the graph MUST be `Graph::save`/
+   `Graph::open` round-tripped (frozen id order), NEVER re-parsed (`store.rs:26–36`).
+
+10. **Distance metric**: cosine in −1..1 L2-normalised (cos = 1 − d²/2) is the single implicit
+    mainline metric; the structure-feature `.spqs` `SchemaHeader` records a per-block `Metric`
+    in `{Euclidean, NonEuclidean}` with a guard that MUST reject a Euclidean/cosine distance
+    on a NonEuclidean block (`encode.rs:437–447`).
+
+11. **Embedder contract**: MUST return exactly one finite `dim()`-length vector per input, in
+    input order; a live provider response MUST be rejected on wrong count/dim/non-finite/
+    duplicate-index/missing-index/out-of-range index (`embed.rs:10–15,401–453`).
+
+12. **Provider protocol**: OpenAI-compatible `POST base/v1/embeddings` body model+input, Bearer
+    auth, honouring response index; env vars `SPARQ_EMBEDDINGS_API_KEY` (required) /
+    `BASE_URL` / `MODEL` with defaults `api.openai.com/v1/embeddings` and
+    `text-embedding-3-small` (`embed.rs:163–253`).
+
+13. **Provenance-weight vocabulary**: `pkg:confidence` (`https://sparq.dev/ns/pkg#confidence`),
+    `pkg:assurance` (objects `secx:Proven/Claimed/Conjectured`), `prov:wasDerivedFrom`,
+    `pkg:discoveredFrom`; `w(t) = clamp(assurance_mult*confidence*source_reliability, floor,
+    1.0)`, fail-open 1.0 (`provenance.rs:30–67`).
+
+14. **Filtered-ANN answer-safety obligation**: the derived `IdMask` is the connected-component
+    projection of the neighbour variable; filtered top-k MUST equal post-filtering the
+    unfiltered top-k by that transitive constraint; every returned id MUST be in the mask;
+    empty mask yields no results (`rewrite.rs:740–767`).
+
+---
+
+## Gaps (Spec Must Address)
+
+1. **No embedding-model provenance**: the store cannot detect that two `.spqv` files came from
+   different embedding models or dimensions; a spec should mandate recording model-id +
+   model-version + metric + normalisation and MUST-reject a query vector from an incompatible
+   model.
+
+2. **Metric is unspecified in the mainline query surface**: cosine is hardcoded; there is no
+   way to request Euclidean/dot via `vec:`.
+
+3. **Query argument is constant-only**: per-row/correlated query vector or a variable seed is
+   forbidden at bind-time (`rewrite.rs:66–79`); a WG spec must decide how a variable-driven /
+   lateral k-NN is expressed.
+
+4. **No standard SERVICE or extension-function form**; only a magic predicate; no alignment to
+   vendor idioms (GraphDB `similarity:`, Neo4j `db.index.vector.queryNodes`, Stardog Voicebox,
+   pgvector operators).
+
+5. **Scores exposed only as an unordered VALUES column** via `vec:search`; no defined tie-break/
+   determinism contract, no k=0/negative normative text.
+
+6. **No named/multi-vector model** (one vector per id); no in-query hybrid/rerank surface
+   (V4/V6/V8).
+
+7. **Approximate backends recall under 1.0 = non-answer-exact**; a spec must separate
+   answer-serving (exact) from retrieval/estimate (approximate) as a normative mode.
+
+8. **KGE / structure-aware / provenance-weight features carry NO accuracy claim** and are gated
+   on unmeasured lift; no pinned accuracy floor is citable.
+
+9. **All measured numbers (recall, A/B, token) are work-box NON-CANONICAL**; no canonical
+   benchmark authority exists.
+
+---
+
+## Honesty Flags
+
+- **Approximate search** (HNSW, DiskANN/Vamana, PQ, `query_vec_approx`) has recall under 1.0;
+  only `nearest_exact`/`ExactBackend`/`query_vec` are answer-exact; the measured over-fetch
+  floor 0.90 at 10 and recall gates are explicitly NON-CANONICAL.
+
+- **`HashEmbedder` is TEST-ONLY** and captures NO semantics (car and automobile unrelated);
+  MUST NEVER be shipped as a retrieval feature.
+
+- **KGE trainer makes NO accuracy claim, INDICATIVE only**; DistMult is symmetric so near-
+  random on directional data.
+
+- **Provenance-weighting makes NO accuracy claim**; literature reports inconsistent gains;
+  ships behind an on/off ablation with an adopt-only-on-measured-lift-else-ABANDON bar
+  (`provenance.rs:34–43`).
+
+- **Compose K4 real-model A/B win is CONDITIONAL** (rescues opaque-id bindings, roughly zero
+  benefit where the IRI slug is already informative) and is NOT a token-saver; numbers are
+  work-box NON-CANONICAL.
+
+- **`qualify`/`citations` confidence band REFLECTS ASSERTED assurance**, NOT a calibrated
+  confidence; no reliability measurement exists.
+
+- **`sparq_nlq::eval` exec-accuracy scores in CI** come only from scripted/recorded
+  (`ReplayLlm`) completions, validating the harness/mechanism, NOT a real model's accuracy.
+
+- **Recall is anchored against hnswlib** via a committed capture (`tests/ref_lib_verify.rs`)
+  but the recall figures are NON-CANONICAL and the live re-capture is `#[ignore]`d.
+
+- **Vendor-precedent claims** (GraphDB `similarity:`, Stardog Voicebox, Neptune, Neo4j,
+  Qdrant/Weaviate/pgvector/Milvus) are catalogued from external docs in `research/` and tagged
+  `established`/`secondary`, not sparq measurements.
+
+---
+
+> **Empirical-honesty reminder**: ZK and MPC estates are NOT production-sound until the
+> external cryptographer audit sq-qhy4 completes. All work-box benchmarks are non-canonical;
+> do not hard-code them in documentation or tests.
+
+---
+
+*Recon captured by Sonnet 4.6 under the Fable program; [SONNET-4.6]*

--- a/research/specs/vector-genai-estate-recon.md
+++ b/research/specs/vector-genai-estate-recon.md
@@ -61,7 +61,8 @@ designed-but-unbuilt.
   input, in order) + test-only `HashEmbedder` (NO semantics) `src/embed.rs:10–83`; `provider`
   feature = OpenAI-compatible `/v1/embeddings` request/response shape with caller `Transport`
   (`embed.rs:108–146`); `embeddings` feature = concrete reqwest `RemoteEmbedder::from_env`
-  reading `SPARQ_EMBEDDINGS_API_KEY/BASE_URL/MODEL` (`embed.rs:159–253`).
+  reading `SPARQ_EMBEDDINGS_API_KEY` / `SPARQ_EMBEDDINGS_BASE_URL` / `SPARQ_EMBEDDINGS_MODEL`
+  (`embed.rs:159–253`).
 
 - **Verbalisation + label pipelines** `verbalize`/`embed_entities`/`embed_labels` (label chain,
   multilingual, budgeted) `src/verbalize.rs`, `src/labels.rs`.
@@ -194,10 +195,11 @@ designed-but-unbuilt.
     input order; a live provider response MUST be rejected on wrong count/dim/non-finite/
     duplicate-index/missing-index/out-of-range index (`embed.rs:10–15,401–453`).
 
-12. **Provider protocol**: OpenAI-compatible `POST base/v1/embeddings` body model+input, Bearer
-    auth, honouring response index; env vars `SPARQ_EMBEDDINGS_API_KEY` (required) /
-    `BASE_URL` / `MODEL` with defaults `api.openai.com/v1/embeddings` and
-    `text-embedding-3-small` (`embed.rs:163–253`).
+12. **Provider protocol**: OpenAI-compatible `POST <endpoint>` (JSON body model+input, Bearer
+    auth, honouring response index); the endpoint is the full URL in `SPARQ_EMBEDDINGS_BASE_URL`
+    — POSTed as-is, nothing appended — env vars `SPARQ_EMBEDDINGS_API_KEY` (required) /
+    `SPARQ_EMBEDDINGS_BASE_URL` / `SPARQ_EMBEDDINGS_MODEL` with defaults
+    `https://api.openai.com/v1/embeddings` and `text-embedding-3-small` (`embed.rs:163–253`).
 
 13. **Provenance-weight vocabulary**: `pkg:confidence` (`https://sparq.dev/ns/pkg#confidence`),
     `pkg:assurance` (objects `secx:Proven/Claimed/Conjectured`), `prov:wasDerivedFrom`,

--- a/research/specs/zksparql-estate-recon.md
+++ b/research/specs/zksparql-estate-recon.md
@@ -1,0 +1,245 @@
+# zkSPARQL Estate Recon
+
+> Grounding for the zkSPARQL Proposed Spec (bead sq-rvgr2.2). Read-only recon; not itself normative.
+
+## Summary
+
+The zkSPARQL query-proof estate is substantially BUILT and tested across two `publish=false`,
+non-default crates. `sparq-zk` is the off-circuit commitment pipeline (Poseidon2-BN254, RDFC10
+canon, per-graph commitments, Schnorr-over-BabyJubJub issuer sigs). `sparq-zk-compose` holds
+the `ProofManifest` format, the `CircuitId`/`ProofInputs` Noir circuit family, and a 5577-line
+verifier at `crates/sparq-zk-compose/src/verifier.rs`.
+
+The verifier MUST-check list is **exactly 12 `bind_*` obligations** (grep -c confirms 12, not
+13) plus stage-1 recheck, the stage-3a public-input byte-compare (audit 1), stage-3b canonical-
+vk recompute (audit 2), stage-3c bb-verify, and stage-4 nonce single-use/binding. The security-
+properties vocabulary is layered: a VENDORED `sec-prop` ontology (8 properties incl
+unlinkability, PQ-forgery/snooping, circuit-audit) extended by sparq `secprop-ext.ttl`
+(ZK-type, soundness, completeness, hiding/binding, anonymity, setup, single-use, plus an
+orthogonal assurance/audit-status axis). ODRL-driven proof admissibility (sq-0dksu) is BUILT
+and MERGED (#1230).
+
+The **biggest spec gap is transport**: NO HTTP media type, no wire protocol, no JSON-LD
+context; the manifest is serde-JSON tagged `urn:sparq:zk:ProofManifest`, exchanged out-of-band
+via a `VerifierNonce` challenge-response. Everywhere soundness is UNAUDITED (sq-qhy4):
+research-grade, hidden-holder tiers labelled NOT-yet-sound, and a passing proof is not a
+guarantee under an adversarial prover.
+
+---
+
+## What Is Built and Tested
+
+- **Verifier** `crates/sparq-zk-compose/src/verifier.rs` (5577 lines): 12 `bind_*` obligations
+  implemented and tested (`tests/verifier_errors.rs`, `e2e.rs`, `forge_gates.rs`,
+  `join_forge.rs`, `holder_pop_forge.rs`, `differential_fuzz.rs`, `audit_forge_map.rs`).
+  Names and lines: `bind_query_correctness` 3633, `bind_attributions` 3981,
+  `bind_issuer_attestations` 2242, `bind_revocation` 2722, `bind_joins` 3790,
+  `bind_entailment` 4433, `bind_holder_pop` 4082, `bind_holder_binding` 4189,
+  `bind_hidden_revocation` 2871, `bind_hidden_issuer_attestations` 3034,
+  `bind_holder_pok` 3190, `bind_holder_set` 3377.
+
+- **Two entry points**: `prefilter_manifest_structure` near 2040 (stages 1 and 2, NOT sound
+  alone) and `verify_manifest` 4578 (sound entry) adding recheck (Q6 bnode guard, attribution
+  arity, circuit-id re-derivation, strictly-increasing commitments),
+  `reconstruct_public_inputs` byte-compare with verifier nonce field 0 (4685 and 4786, audit
+  1), canonical-vk recompute (4697, audit 2), bb verify (4705), nonce single-use `record_fresh`
+  and `NonceBindingMismatch` (4620–4644, audit 4).
+
+- **`ProofManifest` serde-JSON format**: `manifest.rs` 1116, default type
+  `urn:sparq:zk:ProofManifest` (1497), `to_json` serde_json pretty (1539), `canonicalize`
+  stable hash (1525); `CircuitId` Noir family `manifest.rs:515`
+  (Scan, FilterInt, FilterF64, FilterSignedInt, FilterDecimal, FilterValueDl variants,
+  RevokeUnset, HiddenIssuer, HolderPok, HolderSet, JoinEq); ~70-variant fail-closed
+  `CheckError` `verifier.rs:1020`.
+
+- **External trust anchors**, never manifest-supplied: `KeySet` 164, `HolderRegistry` 299,
+  `HolderBindingPolicy` 444, `RevocationPolicy` 630, `VerifierNonce` 757, `SeenNonces` trait
+  with durable `FileSeenNonces` 909 and `InMemorySeenNonces` 845.
+
+- **Security-properties vocabulary**: VENDORED `sec-prop` 8 properties
+  (`crates/sparq-trust/ontologies/zkp-sparql/vocab/sec-prop.yaml.ld`) EXTENDED by
+  `secprop-ext.ttl` (`crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl`):
+  `ZeroKnowledgeType`, `Soundness`, `Completeness`, `Hiding`, `Binding`, `Anonymity`, `Setup`,
+  `Interactivity`, `SelectiveDisclosure`, `SingleUse` plus `AssuranceLevel`, `AuditStatus`,
+  `Assumption`, `PropertyScope` axes; Rust constants `crates/sparq-trust/src/secprop.rs`.
+
+- **Per-method annotation graph and 3 over-claim guards** (opt-in `secprop-annotations`):
+  `crates/sparq-zk/src/secprop.rs` (`audit_overclaim_violations`,
+  `source_layer_transfer_violations`, `completeness_violations`); data
+  `crates/sparq-zk/ontologies/secprop-methods.ttl`.
+
+- **ODRL admissibility** (sq-0dksu) MERGED #1230: ODRL 2.2 profile
+  `crates/sparq-policy/ontologies/odrl-secprop-profile.ttl` (13+ `secx:requires`
+  leftOperands); N3 reduction `crates/sparq-trust/src/admissibility.rs` (`LEVEL_ORDERS`,
+  `CLOSURE_RULES`, `DISCHARGE_RULE` on `sparq_reason`) with default-deny universal admissible
+  at line 210.
+
+- **Fail-closed pre-check gate** `crates/sparq-trust/src/admit.rs:493 admit_with_precheck`
+  (opt-in `secprop-precheck`): `PrecheckOutcome Admitted, Denied, ReductionError`; reduction
+  error is also deny (614); base admit 175 checks issuer Schnorr sig over RDFC10 commitment
+  plus SHACL scope plus reserved-predicate guard plus clear-WebID holder binding.
+
+---
+
+## Designed, Not Built
+
+- **VC cryptosuite bridge** (sq-9c5e, PR #1155) IMPLEMENTED but UNMERGED — only on branch
+  `feat/sq-9c5e-vc-cryptosuite-bridge` (`crates/sparq-zk/src/vc_bridge.rs`, 699 lines, NOT
+  on main); real off-circuit Ed25519 (`ed25519-dalek`) + ECDSA-P256 (`p256`) Data-Integrity
+  verify for `eddsa-rdfc-2022` / `ecdsa-rdfc-2019`; opt-in `vc-bridge` feature.
+
+- **bbs-2023 / ecdsa-sd-2023 selective-disclosure VC ingest** — explicitly DEFERRED seam in
+  `vc_bridge.rs` (no in-repo BBS verifier); design `zk-configurable-commitment-design.md §5.3`.
+
+- **P-384 ECDSA** (`ecdsa-rdfc-2019` SHA-384 profile) — not implemented, fails closed as
+  `VcBridgeError::UnsupportedKeyCurve` (only P-256/SHA-256 built).
+
+- **In-circuit VC-proof verification** — deliberately OUT OF SCOPE; the query proof does NOT
+  re-verify the source VC Ed25519/ECDSA proof in-circuit; `zk:sourceCryptosuite` is
+  provenance only.
+
+- **Hidden-holder soundness tiers** (`bind_holder_pok` sq-c2ql, `bind_holder_set` sq-3c00)
+  WIRED but code+docs state they do NOT make the verifier sound: NOT-yet-sound
+  (sq-qhy4/sq-9hrn; remediation epic sq-1s2); opt-in only.
+
+- **Live-service / async-proving posture** DESIGNED ONLY in `research/zkp-query-proofs-plan.md
+  §7` (Q9 aggregation, Q11 live-service); no server endpoint, job model, or async proving in
+  code.
+
+- **RDFS/OWL entailment in-circuit closure proof** — `bind_entailment` enforces only a
+  disclosed-base re-check of derivation steps; in-circuit closure deferred
+  (`manifest.rs:1170`); only Simple entailment actually proved.
+
+---
+
+## Candidate Normative Surface
+
+1. **MANIFEST FORMAT**: a zkSPARQL proof response is a JSON object with mandatory
+   `type = urn:sparq:zk:ProofManifest` (`manifest.rs:1498`), serialised canonically
+   (`ProofManifest::canonicalize` before hashing); a spec MUST mint a real media type
+   (candidate `application/vc+zksparql+json` or a `+ld` JSON-LD variant) — currently ABSENT.
+
+2. **CHALLENGE-RESPONSE**: the proof request is a verifier-issued fresh `VerifierNonce` (a
+   BN254 field element, `as_field_hex`) minted out-of-band and handed to the prover BEFORE
+   proving; the prover MUST commit it as public-input field 0 of every sub-proof; the verifier
+   MUST record it single-use before the crypto gate and MUST burn-on-mismatch
+   (`verifier.rs:4620`). Transport UNSPECIFIED.
+
+3. **SUB-PROOF blob layout**: hex-encoded `len|proof|len|pi|vk` (`SubProof.proof_hex`);
+   public_inputs = 32-byte big-endian field elements, structs/arrays flattened row-major,
+   bool to `{0,1}`, u32/u64 to integer value, NO header/length-prefix (empirically pinned to
+   bb 5.0.0-nightly.20260324; `reconstruct_public_inputs` `verifier.rs:4766`).
+
+4. **VERIFIER MUST-CHECK OBLIGATIONS** (12 `bind_*` + 5 structural), all fail-closed:
+   recheck (Q6 bnode cross-graph join guard + attribution arity + strictly-increasing
+   commitments); `bind_query_correctness:3633`; `bind_attributions:3981` superset;
+   `bind_issuer_attestations:2242` key-in-external-K; `bind_revocation:2722`
+   authoritative-snapshot bit; `bind_joins:3790` commitment+slot binding;
+   `bind_entailment:4433` regime+grounded-steps; `bind_holder_pop:4082`;
+   `bind_holder_binding:4189`; `bind_hidden_revocation:2871`;
+   `bind_hidden_issuer_attestations:3034`; `bind_holder_pok:3190`; `bind_holder_set:3377`;
+   `reconstruct_public_inputs` byte-compare with verifier-nonce field 0; canonical-vk
+   recompute; bb verify; nonce single-use + `NonceBindingMismatch`.
+
+5. **TRUST ANCHORS MUST be external relying-party inputs**, never manifest-supplied: trusted
+   `KeySet K` (`manifest.key_set` only accepted as a subset), authoritative
+   `StatusListSnapshot` (`RevocationPolicy`), `HolderRegistry`, fresh `VerifierNonce`,
+   `SeenNonces` store — codified because trusting `manifest.key_set` was the codex 1
+   soundness hole.
+
+6. **ISSUER SIGNATURE binding**: Schnorr over Baby-JubJub with a Poseidon2 challenge;
+   cryptosuite IRI `https://sparq.dev/ns/zk#poseidon2-schnorr-v1`
+   (`SignatureScheme::POSEIDON2_SCHNORR_V1_IRI`); an unresolved cryptosuite MUST reject
+   (fail-closed, no default).
+
+7. **SECURITY-PROPERTIES VOCABULARY** namespace `https://w3id.org/zkp-sparql/sec-prop#`:
+   `Unlinkability(Strength/Scope)`, `PostQuantumForgery/Snooping`, `SignatureTypeLeakage`,
+   `ProofSizeLeakage`, `CircuitAudit`, `ValidityPeriodLeakage` + `secx` extension
+   `ZeroKnowledgeType`, `Soundness`, `Completeness`, `Hiding`, `Binding`, `Anonymity`,
+   `Setup`, `Interactivity`, `SelectiveDisclosure`, `SingleUse`; assurance axis
+   `Proven>Claimed>Conjectured`; `auditStatus` incl `ExternalSignOffPending`; scope
+   `QueryProofLayer` vs `SourceLayerOnly` (source-layer property MUST NOT satisfy a
+   query-proof constraint).
+
+8. **ODRL ADMISSIBILITY PROFILE**: a policy using any `secx:requires` leftOperand MUST assert
+   `odrl:profile <https://sparq.dev/ns/odrl-secprop-profile#>`; each leftOperand carries one
+   `secx:overDimension` fact; only `odrl:gteq` is reduced (other operators to unsatisfied to
+   deny); admissibility = method satisfies EVERY constraint (default-deny);
+   `requiresAssurance gteq secx:Proven` mechanically denies every sparq ZK method while
+   sq-qhy4 is open.
+
+9. **OVER-CLAIM RULE**: NO sparq ZK method MAY be labelled `secx:Proven` on a positive
+   privacy/soundness property while sq-qhy4 is open; only settled-NEGATIVE facts
+   (`PQForgeable`, `Replayable`, `SchemeRevealed`) may be `Proven` — machine-checkable guard
+   (`secprop.rs audit_overclaim_violations`).
+
+---
+
+## Gaps (Spec Must Address)
+
+1. **NO media type / content-type registered** for the proof manifest or the nonce/challenge;
+   the manifest is a bare serde-JSON struct tagged with a URN.
+
+2. **NO JSON-LD context for `ProofManifest`** — it does not round-trip as a Verifiable
+   Presentation and cannot be consumed by a generic VC/DI processor.
+
+3. **NO wire protocol / endpoint** for the challenge-response — `VerifierNonce` issuance and
+   manifest submission transport are entirely out-of-band and unspecified.
+
+4. **Circuit family is version-pinned to an external Noir/bb toolchain** (nargo
+   1.0.0-beta.21, bb 5.0.0-nightly.20260324) driven by subprocess; the public-input byte
+   layout is EMPIRICALLY determined, not normatively specified.
+
+5. **The SPARQL fragment is bucketed and partial**: BGP scan + integer/xsd:double/signed-int/
+   decimal FILTER + a single-prover hidden cross-credential JOIN; no OPTIONAL/UNION/property-
+   paths/aggregation/subqueries — the fragment scope needs a normative definition.
+
+6. **`w3id.org/zkp-sparql/` IRIs were minted as placeholder** while the source repo was
+   private; a spec must confirm the permanent-identifier redirect is live and stable.
+
+7. **No canonical test-vector / conformance suite** for the manifest format or the `bind_*`
+   obligations exposed as portable spec fixtures (forge tests exist but are Rust-internal).
+
+8. **MPC composition surface is referenced by the admissibility vocabulary**
+   (HonestMajority/SemiHonest assumptions) but its interaction with the query-proof verifier
+   is not part of the built verifier.
+
+---
+
+## Honesty Flags
+
+- **sq-qhy4 (P0 external audit) is OPEN**: the ENTIRE ZK estate is research-grade and NOT
+  externally audited; a passing proof is NOT a guarantee the SPARQL statement holds under an
+  adversarial prover.
+
+- **`bind_holder_pok` (sq-c2ql) and `bind_holder_set` (sq-3c00)** are EXPLICITLY labelled
+  NOT-yet-sound in code and manifest docs (remediation epic sq-1s2).
+
+- **The dual-leaf value-lane** (`sparq-zk` feature `dual-leaf`) carries a documented
+  INV-VL downgrade (#769 accepted, CR-G8) and is NOT externally audited.
+
+- **Only Simple entailment is proved**; RDFS/OWL derivation is a disclosed-base host re-check
+  (`bind_entailment`), the in-circuit closure proof is deferred.
+
+- **The admissibility reasoner reasons over ANNOTATIONS**, not cryptography; every sparq ZK
+  property annotation is at most `secx:Claimed` with `auditStatus ExternalSignOffPending`.
+
+- **PostQuantum posture is a settled NEGATIVE**: all current issuer signature suites
+  (Schnorr/EdDSA/BBS+) are Shor-broken; Pedersen binding breaks under a CRQC so
+  retro-soundness fails.
+
+- **The VC cryptosuite bridge (PR #1155) is OPEN and UNMERGED** — its code is NOT on main;
+  any VC-ingest claim must be caveated as branch-only.
+
+- **The vendored `sec-prop` ontology lineage**: the `do-not-cite` draft caveat is superseded
+  by the 2026-06-21 MIT decision (`PROVENANCE.md`) — verify before discounting.
+
+---
+
+> **Empirical-honesty reminder**: ZK and MPC estates are NOT production-sound until the
+> external cryptographer audit sq-qhy4 completes. All work-box benchmarks are non-canonical;
+> do not hard-code them in documentation or tests.
+
+---
+
+*Recon captured by Sonnet 4.6 under the Fable program; [SONNET-4.6]*

--- a/research/specs/zksparql-estate-recon.md
+++ b/research/specs/zksparql-estate-recon.md
@@ -43,7 +43,9 @@ guarantee under an adversarial prover.
   arity, circuit-id re-derivation, strictly-increasing commitments),
   `reconstruct_public_inputs` byte-compare with verifier nonce field 0 (4685 and 4786, audit
   1), canonical-vk recompute (4697, audit 2), bb verify (4705), nonce single-use `record_fresh`
-  and `NonceBindingMismatch` (4620–4644, audit 4).
+  and `NonceBindingMismatch` (4620–4644, audit 4). Audit 3 (issuer-signature / key-set
+  binding, codex #1) is enforced per-scan by `bind_issuer_attestations` (2242, listed above),
+  completing the verifier's audit 1–4 mapping.
 
 - **`ProofManifest` serde-JSON format**: `manifest.rs` 1116, default type
   `urn:sparq:zk:ProofManifest` (1497), `to_json` serde_json pretty (1539), `canonicalize`


### PR DESCRIPTION
> 🤖 SPARQ agent — Sonnet 4.6 under the Fable program
>
> _[OPUS-4.8] housekeeping: added a follow-up commit tagging the respec fenced code block with a language (`sh`) to clear the HARD `markdownlint (docs)` MD040 gate that was blocking this doc-only PR; content otherwise unchanged._

## Summary

Captures the structured recon produced by the Fable specs/papers/UX workflow as durable research records. These files are the mechanism by which the recon survives; the recon agents were read-only and wrote nothing to the repo.

Five files added under `research/`:

- **`research/specs/mpc-sparql-estate-recon.md`** — grounds bead sq-rvgr2.3 (MPC-SPARQL Proposed Spec). Surveys M0–M3 built estate (Shamir backend, BGW, joins, compare, transport, single-prover ZK binding), enumerates designed-not-built (collaborative ZK proof stub, federated public-input layout sq-34ml, IT-MAC malicious beads sq-km34.*), lists 17 normative anchors grounded in source locations, 10 spec gaps, and 9 honesty flags — all gated on sq-qhy4 audit.

- **`research/specs/zksparql-estate-recon.md`** — grounds bead sq-rvgr2.2. 12 `bind_*` obligations built and tested in `verifier.rs`, ODRL admissibility merged (#1230), VC bridge (PR #1155) unmerged (branch only). 9 normative anchors (manifest format, challenge-response, sub-proof blob layout, trust anchors, ODRL profile, over-claim rule), 8 gaps (no media type, no JSON-LD context, no wire protocol, SPARQL fragment scope undefined), 8 honesty flags.

- **`research/specs/vector-genai-estate-recon.md`** — grounds bead sq-rvgr2.4. `vec:nearest`/`vec:search` are the ONLY parsed+executed vector SPARQL surface (`src/rewrite.rs`). Filtered-ANN (BGP-to-`IdMask`, cost-model, transitive connected-component) is built. Missing: embedding model-id/metric provenance not recorded in the `.spqv` store header; no SERVICE/function form; no named/multi-vector model. 14 normative anchors, 9 gaps.

- **`research/specs/specs-infra-plan.md`** — grounds bead sq-rvgr2.1. Exact papers pipeline mechanics (Typst→PDF+HTML prebuild, evidence binding, honesty gate), recommended Option A (ReSpec CLI baked at build time via puppeteer — exact papers-pipeline parallel), 15 ordered build steps for the `/specs` site section, 8 risks (Chrome/puppeteer absent in `pages.yml`, CSS surface area, lychee fragment regression, port collision).

- **`research/papers-venue-audit.md`** — DELIVERABLE for bead sq-gum8.2. Non-sycophantic venue-bar verdicts for all 7 existing papers: KILL 3 (`honest-benchmarking`, `geosparql-optin-crate`, `unsafe-attestation`), REWRITE 2 (`filtered-ann`, `odrl-policy-bridge`), MERGE 1 (`solid-acl-conformance` → into geosparql), NEW_TOPIC_INSTEAD 1 (`cozk-witness-validation`). Three missing papers identified: FO-KM empirical finding (strongest), engine out-of-core systems result (highest impact, no paper), verifiable-federated-SPARQL feasibility SoK.

## Beads grounded

- sq-rvgr2.1 (specs infra plan)
- sq-rvgr2.2 (zkSPARQL spec grounding)
- sq-rvgr2.3 (MPC-SPARQL spec grounding)
- sq-rvgr2.4 (vector/GenAI spec grounding)
- sq-gum8.2 (papers venue audit deliverable)

## No bead edits

`.beads/*.jsonl` not touched. Bead status updates are the orchestrator's responsibility.

## Honesty posture

Every file carries the empirical-honesty reminder that ZK/MPC estates are NOT production-sound until sq-qhy4 (P0 external audit) completes, and that work-box benchmarks are non-canonical.
