### PR TITLE
feat(gui): whole-store "Export dataset as Turtle/TriG/JSON-LD" download (sq-xvj9)

### DIFF
--- a/gui/app/src/components/workbench/left-rail.tsx
+++ b/gui/app/src/components/workbench/left-rail.tsx
@@ -16,6 +16,7 @@ import { cn } from "@/lib/utils";
 import { useEngine } from "@/lib/engine-context";
 import { useWorkspace } from "@/lib/workspace-context";
 import { useImportDrawer } from "@/components/workbench/import-drawer";
+import { ExportDataMenu } from "@/components/workbench/store-export";
 import { TIER_META, type ToolDef } from "@/data/tools";
 
 interface LeftRailProps {
@@ -108,6 +109,11 @@ function DatasetsTree() {
       >
         <Plus className="size-3" /> Import data…
       </button>
+
+      {/* [OPUS-4.8] sq-xvj9 — the sibling EXPORT entry point: serialise the whole live store to a
+          pretty Turtle / TriG / JSON-LD document and download it (disabled while the store is
+          cold/empty). */}
+      <ExportDataMenu />
     </div>
   );
 }

--- a/gui/app/src/components/workbench/store-export.tsx
+++ b/gui/app/src/components/workbench/store-export.tsx
@@ -1,0 +1,120 @@
+"use client";
+
+// [OPUS-4.8] sq-xvj9 (epic sq-ixc3) — the DatasetViewer's EXPORT action: serialise the WHOLE live
+// store to a pretty, prefix-abbreviated RDF document and hand it to the browser as a file download.
+//
+// This is a NEW capability, NOT a swap of the result-graph views: an explicit "export this dataset"
+// affordance next to the rail's "+ Import data…" entry point. It calls the engine context's
+// `exportStore` (which drives the wasm `serialize` binding with the site's COMMON_PREFIXES prefix
+// map — sq-l5kr) and the shared `downloadText` DOM helper. Three formats, matching what the engine
+// writer emits: Turtle (default graph — Turtle has no named-graph syntax), TriG and JSON-LD (the
+// whole dataset). The scope of each is shown in the menu so it is never silently misrepresented.
+//
+// HONESTY. Nothing is fabricated: if the store is cold/empty the trigger is disabled; if a lean
+// bundle lacks the serialise binding, `exportStore` returns null and a clear message is shown.
+
+import * as React from "react";
+import { DropdownMenu as DropdownMenuPrimitive } from "radix-ui";
+import { Download, AlertTriangle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useEngine } from "@/lib/engine-context";
+import { downloadText } from "@/lib/download";
+import { EXPORT_FORMATS, exportFilename, type ExportFormat } from "@/lib/rdf-format";
+
+/**
+ * The "Export data…" control for the left rail's datasets tree: a dashed teal trigger (sibling of
+ * the "+ Import data…" affordance) that opens a small menu of the export serialisations. Selecting
+ * one serialises the whole live store and downloads it. Disabled until the engine is ready with a
+ * non-empty store.
+ */
+export function ExportDataMenu() {
+  const { status, storeSize, exportStore } = useEngine();
+  const [error, setError] = React.useState<string | null>(null);
+
+  const disabled = status.kind !== "ready" || storeSize === 0;
+
+  const onExport = React.useCallback(
+    (format: ExportFormat) => {
+      setError(null);
+      const meta = EXPORT_FORMATS.find((f) => f.value === format);
+      if (!meta) return;
+      try {
+        const text = exportStore(format);
+        if (text === null) {
+          setError("The engine is not ready, or this build cannot serialise RDF.");
+          return;
+        }
+        downloadText(exportFilename(format), text, meta.mime);
+      } catch (e) {
+        setError(e instanceof Error ? e.message : String(e));
+      }
+    },
+    [exportStore],
+  );
+
+  return (
+    <div className="mt-1">
+      <DropdownMenuPrimitive.Root>
+        <DropdownMenuPrimitive.Trigger asChild>
+          <button
+            type="button"
+            disabled={disabled}
+            data-export-trigger="rail"
+            className={cn(
+              "flex w-full items-center gap-1.5 rounded-md border border-dashed border-teal-line px-2 py-1.5 text-xs text-muted-foreground",
+              "hover:bg-teal-faint hover:text-foreground",
+              "disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-transparent disabled:hover:text-muted-foreground",
+            )}
+            title={
+              disabled
+                ? "Load some data first, then export the dataset"
+                : "Export the whole store as pretty Turtle / TriG / JSON-LD"
+            }
+          >
+            <Download className="size-3" /> Export data…
+          </button>
+        </DropdownMenuPrimitive.Trigger>
+        <DropdownMenuPrimitive.Portal>
+          <DropdownMenuPrimitive.Content
+            data-export-menu
+            align="start"
+            sideOffset={4}
+            className={cn(
+              "z-50 min-w-[13rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
+              "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            )}
+          >
+            <DropdownMenuPrimitive.Label className="px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+              Export dataset as…
+            </DropdownMenuPrimitive.Label>
+            {EXPORT_FORMATS.map((f) => (
+              <DropdownMenuPrimitive.Item
+                key={f.value}
+                data-export-format={f.value}
+                onSelect={() => onExport(f.value)}
+                className="flex cursor-pointer items-center justify-between gap-3 rounded-sm px-2 py-1.5 text-xs outline-none focus:bg-accent focus:text-accent-foreground"
+              >
+                <span className="font-medium">{f.label}</span>
+                <span className="text-[10px] text-muted-foreground">{f.scope}</span>
+              </DropdownMenuPrimitive.Item>
+            ))}
+            <p className="px-2 pb-1 pt-1.5 text-[10px] leading-snug text-muted-foreground">
+              Pretty-printed, IRIs abbreviated with the common prefixes.
+            </p>
+          </DropdownMenuPrimitive.Content>
+        </DropdownMenuPrimitive.Portal>
+      </DropdownMenuPrimitive.Root>
+      {error && (
+        <p
+          role="status"
+          data-export-feedback="error"
+          className="mt-1 flex items-start gap-1.5 px-1 text-[11px] text-destructive"
+        >
+          <AlertTriangle className="mt-0.5 size-3 shrink-0" />
+          <span>{error}</span>
+        </p>
+      )}
+    </div>
+  );
+}

--- a/gui/app/src/components/workbench/store-export.tsx
+++ b/gui/app/src/components/workbench/store-export.tsx
@@ -20,7 +20,7 @@ import { Download, AlertTriangle } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useEngine } from "@/lib/engine-context";
 import { downloadText } from "@/lib/download";
-import { EXPORT_FORMATS, exportFilename, type ExportFormat } from "@/lib/rdf-format";
+import { EXPORT_FORMATS, EXPORT_FORMAT_META, exportFilename, type ExportFormat } from "@/lib/rdf-format";
 
 /**
  * The "Export data…" control for the left rail's datasets tree: a dashed teal trigger (sibling of
@@ -37,8 +37,7 @@ export function ExportDataMenu() {
   const onExport = React.useCallback(
     (format: ExportFormat) => {
       setError(null);
-      const meta = EXPORT_FORMATS.find((f) => f.value === format);
-      if (!meta) return;
+      const meta = EXPORT_FORMAT_META[format];
       try {
         const text = exportStore(format);
         if (text === null) {
@@ -69,7 +68,7 @@ export function ExportDataMenu() {
             title={
               disabled
                 ? "Load some data first, then export the dataset"
-                : "Export the whole store as pretty Turtle / TriG / JSON-LD"
+                : "Export the dataset as pretty RDF: Turtle (default graph), TriG or JSON-LD (whole dataset)"
             }
           >
             <Download className="size-3" /> Export data…
@@ -107,7 +106,8 @@ export function ExportDataMenu() {
       </DropdownMenuPrimitive.Root>
       {error && (
         <p
-          role="status"
+          role="alert"
+          aria-live="assertive"
           data-export-feedback="error"
           className="mt-1 flex items-start gap-1.5 px-1 text-[11px] text-destructive"
         >

--- a/gui/app/src/components/workbench/workbench.tsx
+++ b/gui/app/src/components/workbench/workbench.tsx
@@ -19,7 +19,7 @@
 // system browser (the design's rule: the GUI never renders the site, it links to it).
 
 import * as React from "react";
-import { PanelsTopLeft, X, Layers, Upload, Download } from "lucide-react";
+import { PanelsTopLeft, X, Layers, Upload, Download, AlertTriangle } from "lucide-react";
 
 import { LeftRail } from "@/components/workbench/left-rail";
 import { TitleBar } from "@/components/workbench/title-bar";
@@ -175,6 +175,16 @@ function ShellPaletteCommands({
   const { setOpen: setImportOpen } = useImportDrawer();
   // [OPUS-4.8] sq-xvj9 — export is only meaningful once the engine is warm with a non-empty store.
   const exportDisabled = status.kind !== "ready" || storeSize === 0;
+  // [OPUS-4.8] sq-xvj9 — the Cmd-K export path must not fail silently: when `exportStore` returns
+  // null (a lean bundle without the serialise binding) surface the same message the rail shows,
+  // as an ephemeral aria-live alert (the palette has already closed, so an inline note is not
+  // visible from here).
+  const [exportError, setExportError] = React.useState<string | null>(null);
+  React.useEffect(() => {
+    if (!exportError) return;
+    const id = window.setTimeout(() => setExportError(null), 6000);
+    return () => window.clearTimeout(id);
+  }, [exportError]);
 
   const commands = React.useMemo<PaletteCommand[]>(() => {
     const cmds: PaletteCommand[] = [];
@@ -215,7 +225,12 @@ function ShellPaletteCommands({
         disabled: exportDisabled,
         run: () => {
           const text = exportStore(f.value);
-          if (text !== null) downloadText(exportFilename(f.value), text, f.mime);
+          if (text === null) {
+            setExportError("The engine is not ready, or this build cannot serialise RDF.");
+            return;
+          }
+          setExportError(null);
+          downloadText(exportFilename(f.value), text, f.mime);
         },
       });
     }
@@ -287,5 +302,27 @@ function ShellPaletteCommands({
   ]);
 
   useRegisterPaletteCommands("shell", commands);
-  return null;
+
+  if (!exportError) return null;
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-8 z-[60] flex justify-center px-4">
+      <div
+        role="alert"
+        aria-live="assertive"
+        data-export-feedback="error"
+        className="pointer-events-auto flex max-w-md items-start gap-2 rounded-md border border-destructive/40 bg-popover px-3 py-2 text-xs text-destructive shadow-lg"
+      >
+        <AlertTriangle className="mt-0.5 size-3.5 shrink-0" />
+        <span className="min-w-0">{exportError}</span>
+        <button
+          type="button"
+          onClick={() => setExportError(null)}
+          aria-label="Dismiss export error"
+          className="ml-1 shrink-0 rounded-sm text-muted-foreground hover:text-foreground"
+        >
+          <X className="size-3.5" />
+        </button>
+      </div>
+    </div>
+  );
 }

--- a/gui/app/src/components/workbench/workbench.tsx
+++ b/gui/app/src/components/workbench/workbench.tsx
@@ -19,7 +19,7 @@
 // system browser (the design's rule: the GUI never renders the site, it links to it).
 
 import * as React from "react";
-import { PanelsTopLeft, X, Layers, Upload } from "lucide-react";
+import { PanelsTopLeft, X, Layers, Upload, Download } from "lucide-react";
 
 import { LeftRail } from "@/components/workbench/left-rail";
 import { TitleBar } from "@/components/workbench/title-bar";
@@ -44,6 +44,10 @@ import {
   ImportDrawerProvider,
   useImportDrawer,
 } from "@/components/workbench/import-drawer";
+// [OPUS-4.8] sq-xvj9 — the Cmd-K counterpart to the rail's "Export data…": serialise + download the
+// whole store as pretty Turtle / TriG / JSON-LD from the keyboard-first spine.
+import { downloadText } from "@/lib/download";
+import { EXPORT_FORMATS, exportFilename } from "@/lib/rdf-format";
 
 /** An open tab in the IDE tab strip — keyed by tool id (a tool opens at most once). */
 export interface OpenTab {
@@ -166,9 +170,11 @@ function ShellPaletteCommands({
   onSelectTab: (toolId: string) => void;
   onCloseTab: (toolId: string) => void;
 }) {
-  const { graphs } = useEngine();
+  const { graphs, status, storeSize, exportStore } = useEngine();
   // [OPUS-4.8] sq-ixc3.13 — the Cmd-K entry point for the Import drawer.
   const { setOpen: setImportOpen } = useImportDrawer();
+  // [OPUS-4.8] sq-xvj9 — export is only meaningful once the engine is warm with a non-empty store.
+  const exportDisabled = status.kind !== "ready" || storeSize === 0;
 
   const commands = React.useMemo<PaletteCommand[]>(() => {
     const cmds: PaletteCommand[] = [];
@@ -183,6 +189,36 @@ function ShellPaletteCommands({
       icon: Upload,
       run: () => setImportOpen(true),
     });
+
+    // [OPUS-4.8] sq-xvj9 — export the whole store as pretty Turtle / TriG / JSON-LD (the rail's
+    // "Export data…" from the keyboard). Disabled until the engine is warm with a non-empty store.
+    for (const f of EXPORT_FORMATS) {
+      cmds.push({
+        id: `action.export.${f.value}`,
+        group: "Actions",
+        title: `Export dataset as ${f.label}`,
+        blurb: `Download the ${f.scope} as ${f.label}, prefix-abbreviated.`,
+        keywords: [
+          "export",
+          "download",
+          "save",
+          "serialize",
+          "serialise",
+          "dataset",
+          f.label,
+          f.value,
+          "turtle",
+          "trig",
+          "json-ld",
+        ],
+        icon: Download,
+        disabled: exportDisabled,
+        run: () => {
+          const text = exportStore(f.value);
+          if (text !== null) downloadText(exportFilename(f.value), text, f.mime);
+        },
+      });
+    }
 
     // Every TOOL as an "open …" command. A `built` tool opens its working tab; a stub still opens
     // (the panel states its tier + what it will do honestly — no fabricated result).
@@ -238,7 +274,17 @@ function ShellPaletteCommands({
     }
 
     return cmds;
-  }, [tabs, activeId, graphs, onOpenTool, onSelectTab, onCloseTab, setImportOpen]);
+  }, [
+    tabs,
+    activeId,
+    graphs,
+    onOpenTool,
+    onSelectTab,
+    onCloseTab,
+    setImportOpen,
+    exportDisabled,
+    exportStore,
+  ]);
 
   useRegisterPaletteCommands("shell", commands);
   return null;

--- a/gui/app/src/lib/engine-context.tsx
+++ b/gui/app/src/lib/engine-context.tsx
@@ -18,6 +18,7 @@ import {
   isAskResult,
   askValue,
   streamQueryRows,
+  COMMON_PREFIXES,
   type SparqlBinding,
   type SparqlResults,
   type SparqlTerm,
@@ -27,6 +28,7 @@ import {
 
 import { basePath } from "@/lib/base-path";
 import { SAMPLE_TURTLE, SAMPLE_FORMAT } from "@/data/sample-graph";
+import { type ExportFormat } from "@/lib/rdf-format";
 import {
   hasNativeLoader,
   nativeDiskUsage,
@@ -243,6 +245,17 @@ export interface EngineContextValue {
    */
   serializeStore: () => string | null;
   /**
+   * [OPUS-4.8] sq-xvj9 — export the WHOLE live store to a pretty, human-readable RDF document
+   * for download (the DatasetViewer's "Export data" action). Unlike {@link serializeStore} (an
+   * internal, unabbreviated TriG dump the SHACL tool consumes), this is the USER-facing export:
+   * indented + sorted, with IRIs abbreviated against the site's `COMMON_PREFIXES` (sq-l5kr's
+   * caller-supplied prefix map), so `ex:`/`foaf:`/`schema:`/… compact exactly like the rest of
+   * the workbench. `"turtle"` emits the DEFAULT GRAPH (Turtle has no named-graph syntax);
+   * `"trig"` and `"jsonld"` emit the WHOLE dataset (default + every named graph). Returns `null`
+   * before the engine is ready or if the loaded bundle lacks the serialise binding.
+   */
+  exportStore: (format: ExportFormat) => string | null;
+  /**
    * [OPUS-4.8] sq-ixc3.13 — bring RDF into the live store via the Import drawer. A `file` import
    * (a disk path) goes through the NATIVE loader (`load_path`: threads, no wasm-tab ceiling,
    * compressed streams, native-only HDT) when running inside the Tauri desktop shell; `paste` /
@@ -392,6 +405,21 @@ function snapshotBytes(store: WasmStore): number {
     return 0;
   }
 }
+
+// [OPUS-4.8] sq-xvj9 — the caller-supplied prefix map (sq-l5kr) as the `[prefix, iri]` pairs the
+// wasm `serialize` binding takes: the site's `COMMON_PREFIXES`, so an exported document abbreviates
+// `ex:`/`foaf:`/`schema:`/… consistently with the rest of the workbench (and byte-parity with the
+// site's serialiser opinion). Computed once — the registry is static.
+const EXPORT_PREFIXES: [string, string][] = COMMON_PREFIXES.map((b) => [b.prefix, b.iri]);
+
+// The engine `serialize` format string for each UI export format. JSON-LD uses the COMPACTED form
+// so the prefix map drives a readable `@context` (the plain `"jsonld"` form is expanded and ignores
+// `abbreviate`); Turtle/TriG abbreviate via a sorted `@prefix` header (the `abbreviate=true` flag).
+const EXPORT_SERIALIZE_FORMAT: Record<ExportFormat, string> = {
+  turtle: "turtle",
+  trig: "trig",
+  jsonld: "jsonld-compacted",
+};
 
 export function EngineProvider({ children }: { children: React.ReactNode }) {
   const [status, setStatus] = React.useState<EngineStatus>({ kind: "cold" });
@@ -700,6 +728,19 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     return store.serialize("trig", false, null, false, null);
   }, []);
 
+  // [OPUS-4.8] sq-xvj9 — the USER-facing dataset export the DatasetViewer downloads. Serialises the
+  // whole live store PRETTY (indented + sorted) and ABBREVIATED against the site's COMMON_PREFIXES
+  // (sq-l5kr's caller-supplied prefix map), through the SAME engine writer as `serializeStore`.
+  // `turtle` carries the default graph only (Turtle has no named-graph syntax); `trig`/`jsonld`
+  // carry the whole dataset. `null` if the store is cold or a lean bundle lacks the binding.
+  const exportStore = React.useCallback((format: ExportFormat): string | null => {
+    const store = storeRef.current;
+    if (!store) return null;
+    const serialize = (store as { serialize?: WasmStore["serialize"] }).serialize;
+    if (typeof serialize !== "function") return null;
+    return store.serialize(EXPORT_SERIALIZE_FORMAT[format], true, null, true, EXPORT_PREFIXES);
+  }, []);
+
   // [OPUS-4.8] sq-ixc3.13 — the N-Quads whole-dataset snapshot the workspace persists (sq-atb0).
   const snapshotStore = React.useCallback((): string | null => {
     const store = storeRef.current;
@@ -728,6 +769,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       lastRowCount,
       run,
       serializeStore,
+      exportStore,
       importRdf,
       nativeLoaderAvailable,
       snapshotStore,
@@ -744,6 +786,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       lastRowCount,
       run,
       serializeStore,
+      exportStore,
       importRdf,
       nativeLoaderAvailable,
       snapshotStore,

--- a/gui/app/src/lib/rdf-format.ts
+++ b/gui/app/src/lib/rdf-format.ts
@@ -116,10 +116,18 @@ export const EXPORT_FORMATS: readonly ExportFormatMeta[] = [
   },
 ];
 
+/**
+ * Value-keyed view of {@link EXPORT_FORMATS} for O(1) metadata lookup. Typed as a total
+ * `Record<ExportFormat, …>`, so every `ExportFormat` is guaranteed an entry (and a valid
+ * `ext`) at compile time — no per-call `.find()` and no weak string fallback.
+ */
+export const EXPORT_FORMAT_META: Record<ExportFormat, ExportFormatMeta> = Object.fromEntries(
+  EXPORT_FORMATS.map((f) => [f.value, f]),
+) as Record<ExportFormat, ExportFormatMeta>;
+
 /** The download filename for an exported dataset in `format` (e.g. `dataset.trig`). */
 export function exportFilename(format: ExportFormat): string {
-  const meta = EXPORT_FORMATS.find((f) => f.value === format);
-  return `dataset.${meta?.ext ?? format}`;
+  return `dataset.${EXPORT_FORMAT_META[format].ext}`;
 }
 
 /** A short display label for a URL: the last non-empty path segment, or the host. */

--- a/gui/app/src/lib/rdf-format.ts
+++ b/gui/app/src/lib/rdf-format.ts
@@ -77,6 +77,51 @@ export function formatFromContentType(contentType: string | null): string | unde
   return CONTENT_TYPE_FORMATS[mime];
 }
 
+// [OPUS-4.8] sq-xvj9 (epic sq-ixc3) — the store-EXPORT serialisations offered by the DatasetViewer's
+// "Export data" action. This is the OUT direction (serialise the whole live store to a downloadable
+// document), distinct from {@link FORMAT_OPTIONS} above (the IN direction the Import drawer parses).
+// Only the three pretty, human-readable syntaxes the engine writer emits are offered — N-Triples /
+// N-Quads (flat, line-oriented) are the snapshot/merge format, not a "readable export".
+
+/** A store-export target serialisation. */
+export type ExportFormat = "turtle" | "trig" | "jsonld";
+
+/** Display + download metadata for one {@link ExportFormat}. */
+export interface ExportFormatMeta {
+  value: ExportFormat;
+  /** The menu label. */
+  label: string;
+  /** The download filename extension (no leading dot). */
+  ext: string;
+  /** The download MIME type. */
+  mime: string;
+  /**
+   * Which part of the store this serialisation carries. TriG + JSON-LD emit the WHOLE dataset
+   * (default graph + every named graph); Turtle has no named-graph syntax, so it emits the
+   * DEFAULT GRAPH only. Surfaced in the UI so the export scope is never silently misrepresented.
+   */
+  scope: "whole dataset" | "default graph";
+}
+
+/** The export serialisations, in menu order (Turtle · TriG · JSON-LD). */
+export const EXPORT_FORMATS: readonly ExportFormatMeta[] = [
+  { value: "turtle", label: "Turtle (.ttl)", ext: "ttl", mime: "text/turtle", scope: "default graph" },
+  { value: "trig", label: "TriG (.trig)", ext: "trig", mime: "application/trig", scope: "whole dataset" },
+  {
+    value: "jsonld",
+    label: "JSON-LD (.jsonld)",
+    ext: "jsonld",
+    mime: "application/ld+json",
+    scope: "whole dataset",
+  },
+];
+
+/** The download filename for an exported dataset in `format` (e.g. `dataset.trig`). */
+export function exportFilename(format: ExportFormat): string {
+  const meta = EXPORT_FORMATS.find((f) => f.value === format);
+  return `dataset.${meta?.ext ?? format}`;
+}
+
 /** A short display label for a URL: the last non-empty path segment, or the host. */
 export function urlLabel(url: string): string {
   try {


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-xvj9** (epic sq-ixc3, GUI). Running as **Opus 4.8** `[OPUS-4.8]`.

## What

A NEW, explicit **"Export data…"** action in the operational GUI's **DatasetViewer** (the left-rail datasets tree) that serialises the **whole live store** to a pretty, prefix-abbreviated RDF document and downloads it. This is a new capability, **not** a swap of the existing result-graph views.

Three formats, matching what the engine writer emits:

| Format | Scope | Notes |
|---|---|---|
| **Turtle** (`.ttl`) | default graph | Turtle has no named-graph syntax |
| **TriG** (`.trig`) | whole dataset | default graph + every named graph |
| **JSON-LD** (`.jsonld`) | whole dataset | compacted form → readable prefix `@context` |

Each menu item shows its scope so the export is never silently misrepresented.

## How

- **`engine-context.tsx`** — new `exportStore(format)` drives the wasm `serialize` binding with `pretty=true`, `abbreviate=true`, and the site's **`COMMON_PREFIXES`** as the caller-supplied prefix map (the sq-l5kr dependency), so `ex:`/`foaf:`/`schema:`/… compact consistently with the rest of the workbench. Distinct from the internal, unabbreviated `serializeStore` the SHACL tool consumes.
- **`store-export.tsx`** (new) — a radix `DropdownMenu` "Export data…" trigger, sibling of the rail's "+ Import data…", disabled until the engine is warm with a non-empty store; uses the shared `downloadText` DOM helper. Stable test hooks: `data-export-trigger`, `data-export-menu`, `data-export-format`.
- **`rdf-format.ts`** — `EXPORT_FORMATS` metadata + `exportFilename` helper (the OUT direction, alongside the Import drawer's IN-direction `FORMAT_OPTIONS`).
- **`workbench.tsx`** — Cmd-K "Export dataset as …" commands for the keyboard-first spine.

**Judgment call (documented):** JSON-LD exports use the **compacted** form (not expanded) so the prefix map produces a readable `@context` — matching the "abbreviate `ex:`/etc." intent of the bead.

## Gate

- `gui/app`: **lint ✓ · typecheck ✓ · `build:web` ✓ · `build:tauri` ✓**
- `@sparq/client` typecheck ✓
- Runtime-verified the three serialisations against the actual in-tab wasm bundle (Turtle drops named graphs as expected; TriG/JSON-LD carry the whole dataset; prefixes abbreviate).
- The `tauri-driver` e2e is **advisory** (`continue-on-error`) and needs `webkit2gtk` + a built shell binary — not runnable on this box. The e2e harness was **left unchanged**, so the existing e2e is unaffected; the new UI carries `data-export-*` hooks for a future assertion (bead sq-var9 promotes the e2e lane).

Bead **not** closed.
