### PR TITLE
feat(honesty): extend privacy-claims + no-perf-numbers gates to cover site/specs/**/*.typ (sq-rvgr2.5) [OPUS-4.8]

### DIFF
--- a/scripts/check-no-perf-numbers.py
+++ b/scripts/check-no-perf-numbers.py
@@ -82,31 +82,36 @@ ALLOW_PATH_PREFIXES = [
 ]
 
 # Globs of files to scan. Markdown is the original surface; the published-paper Typst
-# sources (`site/papers/**/*.typ`) are ALSO scanned so a hard-coded perf figure typed
-# directly into a paper — the highest-stakes OUTWARD surface — trips the gate too
-# (bead sq-mkza). The `.typ` glob is git-tracked workspace-wide, so it is narrowed to
-# the paper tree by TYPST_SCAN_PREFIX below; non-paper `.typ` (if any ever appear) are
-# left alone. Result numbers in a paper are meant to flow through the Typst data
-# accessor (`paper-evidence.json` → `#headline(...)` / `#ev(...)`), NOT be typed inline.
+# sources (`site/papers/**/*.typ`) AND the /specs Proposed-Specification Typst sources
+# (`site/specs/**/*.typ`) are ALSO scanned so a hard-coded perf figure typed directly into
+# a paper or a spec draft — the highest-stakes OUTWARD surfaces — trips the gate too
+# (beads sq-mkza + sq-rvgr2.5). The `.typ` glob is git-tracked workspace-wide, so it is
+# narrowed to those two trees by TYPST_SCAN_PREFIXES below; any other `.typ` (if one ever
+# appears) is left alone. Result numbers in a paper flow through the Typst data accessor
+# (`paper-evidence.json` → `#headline(...)` / `#ev(...)`) rather than being typed inline;
+# a spec is a DESIGN surface and should carry no benchmark figure at all.
 SCAN_GLOBS = ["*.md", "*.typ"]
 
-# Only `.typ` files under this prefix are scanned (the paper-factory sources). The
-# accessor-aware, result-shaped-only `.typ` scan (scan_typst_file) is deliberately
-# NARROWER than the markdown scan — see its docstring and design record
-# research/paper-factory-honesty-gate-coverage.md §7 (Option b: scan for result-shaped
-# numerics only, leave free-typed setup counts — dataset sizes / dimensions / k — alone,
-# for author ergonomics). It catches only the COARSE perf-number class; subtle semantic
-# overclaims remain Stage-5 human review.
-TYPST_SCAN_PREFIX = "site/papers/"
+# Only `.typ` files under one of these prefixes are scanned (the paper-factory sources and
+# the /specs spec-factory sources). The accessor-aware, result-shaped-only `.typ` scan
+# (scan_typst_file) is deliberately NARROWER than the markdown scan — see its docstring and
+# design record research/paper-factory-honesty-gate-coverage.md §7 (Option b: scan for
+# result-shaped numerics only, leave free-typed setup counts — dataset sizes / dimensions /
+# k — alone, for author ergonomics). It catches only the COARSE perf-number class; subtle
+# semantic overclaims remain Stage-5 human review. `str.startswith` accepts a tuple, so a
+# path matches if it lives under ANY listed prefix. [OPUS-4.8] sq-rvgr2.5 added site/specs/.
+TYPST_SCAN_PREFIXES = ("site/papers/", "site/specs/")
 
 
 def is_typst_paper(path: str) -> bool:
-    return path.endswith(".typ") and path.startswith(TYPST_SCAN_PREFIX)
+    # [OPUS-4.8] sq-rvgr2.5: "paper" is historical — this is any scanned `.typ`, i.e. one
+    # under the paper-factory OR the /specs spec-factory tree (TYPST_SCAN_PREFIXES).
+    return path.endswith(".typ") and path.startswith(TYPST_SCAN_PREFIXES)
 
 
 def tracked_sources() -> list[str]:
     """All git-tracked files in scope (markdown everywhere; `.typ` only under the
-    paper tree). Deterministic, no untracked scratch."""
+    paper / specs trees). Deterministic, no untracked scratch."""
     out = subprocess.run(
         ["git", "ls-files", *SCAN_GLOBS],
         capture_output=True, text=True, check=True,

--- a/scripts/check-privacy-claims.sh
+++ b/scripts/check-privacy-claims.sh
@@ -119,7 +119,7 @@ SOUNDNESS_CLAIMS=(
 NEGATOR_HEDGE_RE="$(_phrases_field negatorHedge)"
 
 # Path surface to scan = the OUTWARD claim surface (docs/READMEs/skills/site copy /
-# the compliance index / the published-paper Typst sources). Excludes:
+# the compliance index / the published-paper + /specs Typst sources). Excludes:
 #   - research/ + the audit docs : design records that must name the properties to
 #     argue (un)soundness — the honesty source of truth, not a claim surface.
 #   - this script + its CI wiring : they QUOTE the forbidden phrases by definition.
@@ -138,6 +138,15 @@ NEGATOR_HEDGE_RE="$(_phrases_field negatorHedge)"
 # This catches the COARSE unqualified-claim class; a subtle semantic overclaim phrased
 # around the patterns remains Stage-5 human review.
 #
+# [OPUS-4.8] bead sq-rvgr2.5: the spec-factory `.typ` sources (`site/specs/*.typ` +
+# `site/specs/**/*.typ`, i.e. every Proposed-Specification draft AND `_lib/*.typ`) are added
+# for the SAME reason — a published /specs draft is an outward claim surface, and the ZK/MPC
+# spec CONTENT (zkSPARQL / MPC-SPARQL, beads sq-rvgr2.2/.3) will author real cryptographic
+# prose. Extending this surface BEFORE that content lands closes the gap the sq-rvgr2.1 infra
+# left open (the claim-free template is unaffected). The inline-allow marker + the negator/
+# hedge exemption apply UNCHANGED; the per-line classification below is reused verbatim, so a
+# spec draft may hedge, negate, or `privacy-claims-allow:`-mark a line exactly like a paper.
+#
 # [OPUS-4.8] bead sq-4hga: the paper-factory EVIDENCE file
 # `site/src/data/paper-evidence.json` is also added — its human `note` / free-text fields
 # are published-paper provenance prose (they surface inline via the `provenance()` helper),
@@ -150,6 +159,7 @@ mapfile -t FILES < <(
   git ls-files \
     '*.md' '*.mdx' '*.tsx' '*.ts' \
     'site/papers/*.typ' 'site/papers/**/*.typ' \
+    'site/specs/*.typ' 'site/specs/**/*.typ' \
     'site/src/data/paper-evidence.json' \
     ':!:research/**' \
     ':!:**/*audit*.md' \

--- a/scripts/tests/test_typ_honesty_gates.sh
+++ b/scripts/tests/test_typ_honesty_gates.sh
@@ -175,7 +175,72 @@ JSON
 code="$(run_priv)"
 expect_exit 0 "privacy: hedged + allow-marked claim in an evidence note => clean" "$code"
 
+# [OPUS-4.8] bead sq-rvgr2.5 — the /specs spec-factory sources (site/specs/**/*.typ) are the
+# NEXT outward claim surface: the ZK/MPC spec CONTENT (zkSPARQL / MPC-SPARQL) lands there. Pin
+# that BOTH gates now cover it BEFORE that content arrives, so a spec draft cannot smuggle an
+# unqualified soundness/privacy claim or a hard-coded perf figure past CI.
+echo "== 4. honesty gates cover site/specs/**/*.typ (the spec-factory sources, sq-rvgr2.5) =="
+
+# 4a. PERF (WHOLE-TREE): the perf gate's default tree scan must now include a spec .typ — i.e.
+#     TYPST_SCAN_PREFIXES covers site/specs/. Drive the gate in WHOLE-TREE mode (no explicit
+#     paths) inside a throwaway git repo, so the coverage rides on is_typst_paper()'s prefix
+#     SET — not on an explicit-path dispatch (which scans any .typ regardless of prefix and so
+#     would NOT prove the prefix change). $PERF_GATE reads git-tracked files relative to cwd.
+SPECREPO="${TMP}/specrepo"
+mkdir -p "${SPECREPO}/site/specs"
+(
+  cd "$SPECREPO"
+  git init -q
+  git config user.email t@t && git config user.name t
+)
+run_specperf() {  # whole-tree perf scan inside $SPECREPO -> echoes exit code
+  (
+    cd "$SPECREPO"
+    git add -A >/dev/null 2>&1
+    set +e
+    python3 "$PERF_GATE" --enforce >/dev/null 2>&1
+    echo $?
+  )
+}
+cat > "${SPECREPO}/site/specs/planted.typ" <<'TYP'
+= Results
+Our engine sustains 12× faster query throughput than the baseline.
+TYP
+code="$(run_specperf)"
+expect_exit 1 "perf: planted '12× faster' in a site/specs/*.typ (whole-tree) => fail" "$code"
+
+# 4b. PERF: the same figure in a Typst comment + a bare setup count (no result-shaped unit) is
+#     the narrow/accessor-aware net — must NOT trip (exit 0).
+cat > "${SPECREPO}/site/specs/planted.typ" <<'TYP'
+// dev note: an earlier draft said 12× faster — do not bake that into a spec.
+This proposal constrains a query over a 50000-triple example graph.
+TYP
+code="$(run_specperf)"
+expect_exit 0 "perf: comment + bare setup count in a site/specs/*.typ (whole-tree) => clean" "$code"
+
+# 4c. PRIVACY: an unqualified ZK/MPC claim in a spec .typ must be caught — proving the privacy
+#     gate's git-ls-files surface now includes site/specs/**/*.typ. Reuse the throwaway $REPO;
+#     remove the section-3 evidence fixture first so the verdict is attributable to the spec.
+rm -f "${REPO}/site/src/data/paper-evidence.json"
+mkdir -p "${REPO}/site/specs"
+cat > "${REPO}/site/specs/planted.typ" <<'TYP'
+= Security considerations
+This zkSPARQL profile is zero-knowledge-secure and the verifier is sound.
+TYP
+code="$(run_priv)"
+expect_exit 1 "privacy: planted 'zero-knowledge-secure' + 'verifier is sound' in a spec .typ => fail" "$code"
+
+# 4d. PRIVACY: the same mentions HEDGED (negator) + ALLOW-MARKED must PASS (exit 0) — the
+#     inline-allow / negator-exemption machinery applies to spec sources unchanged.
+cat > "${REPO}/site/specs/planted.typ" <<'TYP'
+= Security considerations
+The zkSPARQL verifier is NOT yet sound pending external audit.
+This profile does not offer a privacy-preserving guarantee. // privacy-claims-allow: hedged spec caveat
+TYP
+code="$(run_priv)"
+expect_exit 0 "privacy: hedged + allow-marked claim in a spec .typ => clean" "$code"
+
 echo ""
 echo "test_typ_honesty_gates: ${pass} passed, ${fail} failed."
 [ "$fail" -eq 0 ] || exit 1
-echo "test_typ_honesty_gates: OK — both honesty gates cover site/papers/**/*.typ + paper-evidence.json prose."
+echo "test_typ_honesty_gates: OK — both honesty gates cover site/papers/**/*.typ + site/specs/**/*.typ + paper-evidence.json prose."

--- a/site/scripts/build-specs.mjs
+++ b/site/scripts/build-specs.mjs
@@ -108,33 +108,59 @@ function readRegistry() {
   }));
 }
 
-// ---- build-boundary honesty scan (shared no-perf-numbers gate over the spec sources) -------
-// FAIL-CLOSED: a hard-coded performance number in a spec source aborts the build before any
-// artifact is written. (The privacy-claims gate's fixed surface does not yet include
-// site/specs/**; extending it before the ZK/MPC spec CONTENT beads land is tracked as a
-// follow-up bead — this template carries no ZK/MPC claims.)
+// ---- build-boundary honesty scan (the two shared honesty gates over the spec sources) ------
+// [OPUS-4.8] sq-rvgr2.5: FAIL-CLOSED, and now BOTH shared CI honesty gates run here — the same
+// pattern as build-papers.mjs's runBuildBoundaryHonestyScan — so the spec factory can never
+// serve an un-scanned or violating draft before the ZK/MPC spec CONTENT (zkSPARQL / MPC-SPARQL,
+// beads sq-rvgr2.2/.3) lands:
+//   - scripts/check-no-perf-numbers.py --enforce <each spec .typ>  (a hard-coded perf figure in
+//        a spec source aborts the build — a spec is a DESIGN surface, not a benchmark), and
+//   - scripts/check-privacy-claims.sh  (whole-tree; its git-ls-files surface now includes
+//        site/specs/**/*.typ — see the sq-rvgr2.5 note in that gate), so an unqualified ZK/MPC
+//        soundness/privacy claim typed into spec prose aborts the build too.
+// Both gates consume the SINGLE shared forbidden-phrase list (scripts/honesty-phrases.json), so
+// there is ONE source of truth and zero drift with the CI gates. A non-zero gate exit aborts the
+// build (no artifact is written). HONEST SCOPE: this is the COARSE phrase/number class only; a
+// subtle semantic overclaim remains Stage-5 human review.
 function runHonestyScan(specs) {
   const perfGate = join(REPO_ROOT, "scripts", "check-no-perf-numbers.py");
-  if (!existsSync(perfGate)) {
-    console.error(`\n[spec-factory] HONESTY SCAN: required gate missing: ${perfGate}\n`);
-    process.exit(1);
+  const privacyGate = join(REPO_ROOT, "scripts", "check-privacy-claims.sh");
+  const sharedList = join(REPO_ROOT, "scripts", "honesty-phrases.json");
+  for (const p of [perfGate, privacyGate, sharedList]) {
+    if (!existsSync(p)) {
+      console.error(`\n[spec-factory] HONESTY SCAN: required gate missing: ${p}\n`);
+      process.exit(1);
+    }
   }
   const typPaths = specs.map((s) => join(SPECS_DIR, s.source)).filter((t) => existsSync(t));
-  try {
-    execFileSync("python3", [perfGate, "--enforce", ...typPaths], {
-      cwd: REPO_ROOT,
-      stdio: ["ignore", "inherit", "inherit"],
-    });
-  } catch (e) {
-    const code = typeof e.status === "number" ? e.status : 1;
-    console.error(
-      `\n[spec-factory] BUILD-BOUNDARY HONESTY SCAN FAILED (no-perf-numbers, exit ${code}).\n` +
-        "  A spec .typ source carries a hard-coded performance number. Remove it — specs are a\n" +
-        "  design surface, not a benchmark. The factory will not serve an un-scanned spec.\n",
-    );
-    process.exit(1);
-  }
-  console.log(`[spec-factory] honesty scan passed: ${typPaths.length} spec source(s) scanned.`);
+
+  const run = (label, cmd, cmdArgs) => {
+    try {
+      // inherit stderr so a finding is visible; capture nothing — the gate self-reports.
+      execFileSync(cmd, cmdArgs, { cwd: REPO_ROOT, stdio: ["ignore", "inherit", "inherit"] });
+    } catch (e) {
+      const code = typeof e.status === "number" ? e.status : 1;
+      console.error(
+        `\n[spec-factory] BUILD-BOUNDARY HONESTY SCAN FAILED (${label}, exit ${code}).\n` +
+          "  A spec .typ source carries a hard-coded performance number or an unqualified ZK/MPC\n" +
+          "  soundness/privacy claim. A spec is a design surface, not a benchmark — remove the\n" +
+          "  number; and hedge the claim (or add the inline allow marker). The factory will not\n" +
+          "  serve an un-scanned spec. (Shared list: scripts/honesty-phrases.json.)\n",
+      );
+      process.exit(1);
+    }
+  };
+
+  // Perf gate over the exact spec sources (explicit paths => --enforce dispatch to the
+  // accessor-aware Typst scan). Privacy gate whole-tree (it enumerates its surface via
+  // git ls-files, which now includes site/specs/**/*.typ).
+  run("no-perf-numbers", "python3", [perfGate, "--enforce", ...typPaths]);
+  run("privacy-claims", "bash", [privacyGate]);
+
+  console.log(
+    `[spec-factory] honesty scan passed: ${typPaths.length} spec source(s) scanned by both ` +
+      "honesty gates (shared phrase list).",
+  );
 }
 
 // ---- HTML post-processing: inject heading ids + build a linked Table of Contents -----------

--- a/site/scripts/build-specs.mjs
+++ b/site/scripts/build-specs.mjs
@@ -118,10 +118,12 @@ function readRegistry() {
 //   - scripts/check-privacy-claims.sh  (whole-tree; its git-ls-files surface now includes
 //        site/specs/**/*.typ — see the sq-rvgr2.5 note in that gate), so an unqualified ZK/MPC
 //        soundness/privacy claim typed into spec prose aborts the build too.
-// Both gates consume the SINGLE shared forbidden-phrase list (scripts/honesty-phrases.json), so
-// there is ONE source of truth and zero drift with the CI gates. A non-zero gate exit aborts the
-// build (no artifact is written). HONEST SCOPE: this is the COARSE phrase/number class only; a
-// subtle semantic overclaim remains Stage-5 human review.
+// "Shared" means these are the SAME gate scripts CI runs — not a copy — so the build boundary and
+// CI stay in lockstep. The two gates DO NOT share one phrase list: the privacy-claims gate reads
+// scripts/honesty-phrases.json (its single source of truth, also used by CI), while the perf gate
+// carries its own PERF_PATTERNS in check-no-perf-numbers.py. A non-zero gate exit aborts the build
+// (no artifact is written). HONEST SCOPE: this is the COARSE phrase/number class only; a subtle
+// semantic overclaim remains Stage-5 human review.
 function runHonestyScan(specs) {
   const perfGate = join(REPO_ROOT, "scripts", "check-no-perf-numbers.py");
   const privacyGate = join(REPO_ROOT, "scripts", "check-privacy-claims.sh");
@@ -145,7 +147,8 @@ function runHonestyScan(specs) {
           "  A spec .typ source carries a hard-coded performance number or an unqualified ZK/MPC\n" +
           "  soundness/privacy claim. A spec is a design surface, not a benchmark — remove the\n" +
           "  number; and hedge the claim (or add the inline allow marker). The factory will not\n" +
-          "  serve an un-scanned spec. (Shared list: scripts/honesty-phrases.json.)\n",
+          "  serve an un-scanned spec. (Privacy-gate phrase list: scripts/honesty-phrases.json;\n" +
+          "  perf-gate patterns: PERF_PATTERNS in scripts/check-no-perf-numbers.py.)\n",
       );
       process.exit(1);
     }
@@ -159,7 +162,7 @@ function runHonestyScan(specs) {
 
   console.log(
     `[spec-factory] honesty scan passed: ${typPaths.length} spec source(s) scanned by both ` +
-      "honesty gates (shared phrase list).",
+      "honesty gates (perf-number + privacy-claim).",
   );
 }
 


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus 4.8) — bead **sq-rvgr2.5**.

## What & why

The `/specs` Proposed-Specification factory (sq-rvgr2.1) is live with a **claim-free template**, but the ZK/MPC spec **content** beads — sq-rvgr2.2 (zkSPARQL), sq-rvgr2.3 (MPC-SPARQL) — will author real cryptographic prose. Until now the two LIVE honesty gates scanned `site/papers/**` but **not** `site/specs/**`, so a spec draft could have smuggled an unqualified soundness/privacy claim or a hard-coded perf figure past CI. This closes that gap **before** the content lands. It mirrors the existing `site/papers` coverage pattern exactly; the sq-rvgr2.1 template carries no offending claims, so the gap was not yet exploitable.

## Changed (all in scope: `scripts/` + `site/scripts/`)

- **`scripts/check-privacy-claims.sh`** — added `site/specs/*.typ` + `site/specs/**/*.typ` to the `git ls-files` outward-claim surface (right after the paper globs). The inline `privacy-claims-allow:` marker and the same-line negator/hedge exemption apply to spec sources unchanged.
- **`scripts/check-no-perf-numbers.py`** — `TYPST_SCAN_PREFIX` (single string) → `TYPST_SCAN_PREFIXES = ("site/papers/", "site/specs/")` tuple; `is_typst_paper()` now matches either prefix (`str.startswith` accepts a tuple), so the whole-tree `--enforce` scan picks up spec `.typ` via the accessor-aware Typst scan.
- **`site/scripts/build-specs.mjs`** — `runHonestyScan()` now ALSO runs `check-privacy-claims.sh` **fail-closed** (whole-tree), mirroring `build-papers.mjs`'s `runBuildBoundaryHonestyScan`; both gates consume the single shared `scripts/honesty-phrases.json`.
- **`scripts/tests/test_typ_honesty_gates.sh`** — new **section 4** pins both gates over a planted `site/specs/*.typ` violation (perf **whole-tree**, to prove the prefix-set change — not an explicit-path dispatch that would pass regardless — plus privacy via the throwaway git repo), and the hedged / allow-marked clean paths.

## Verification (reproduced locally)

- Syntax: `python3 -c py_compile` ✅, `bash -n` ✅ (both scripts), `node --check` ✅, `shellcheck` clean ✅.
- **Clean on current tree** (now scanning specs): `python3 scripts/check-no-perf-numbers.py --enforce` → 0 findings / 199 files, exit 0; `bash scripts/check-privacy-claims.sh` → OK / 500 files, exit 0.
- **Both spec sources confirmed in-scope** for both gates (`site/specs/_lib/spec.typ` + `proposed-specifications-template.typ`).
- **Gate FIRES on a planted violation** in the REAL template (`zero-knowledge-secure` + `12× faster` appended): perf exit 1 (flags `12× faster`), privacy exit 1 (flags `zero-knowledge-secure`); **both exit 0 after revert**, tree pristine.
- Self-tests: `test_typ_honesty_gates.sh` **12/12** (incl. new section 4); `test_privacy_claims.sh` **32/32** (no regression); `test_build_papers_honesty_boundary.sh` **4/4** (no regression).
- Drove the real `build-specs.mjs` end-to-end: `honesty scan passed: 1 spec source(s) scanned by both honesty gates`; generated PDF/HTML are gitignored, no tracked pollution.

## Gate aggregator

No workflow files touched. The affected CI legs keep their names — `no-perf-numbers (docs)` (GATING) and the `docs-quality` job that runs `bash scripts/check-privacy-claims.sh` + `bash scripts/tests/test_typ_honesty_gates.sh` (GATING, no advisory/informational token) — so `ci-summary / gate` still gates on them; this change strengthens coverage without altering which legs gate.

## Compliance gap closed

The empirical-honesty mandate (no unaudited ZK/MPC soundness/privacy overclaim; the v1 verifier is pending external audit sq-qhy4, `sparq-mpc` is semi-honest only) and the no-hard-coded-perf-numbers house rule now extend to the `/specs` outward surface — coarse-phrase / result-shaped-number class only (a subtle semantic overclaim remains Stage-5 human review), honestly.

Bead sq-rvgr2.5 is left **open** (not closed) per the task brief.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>