### PR TITLE
fix(specs): privacy-claims honesty markers on merged /specs .typ — unblock main gate

### DIFF
--- a/site/specs/mpc-sparql.typ
+++ b/site/specs/mpc-sparql.typ
@@ -131,7 +131,7 @@ its claim to novelty is narrow and architectural, not cryptographic.
 #strong[Secure collaborative query systems (relational).] SMCQL #cite("SMCQL") compiles a
 SQL fragment onto secure-computation backends for a mutually distrusting two-party
 federation; Conclave #cite("CONCLAVE") scales MPC queries by pushing work into annotated
-cleartext pre- and post-processing; Senate #cite("SENATE") provides maliciously secure
+cleartext pre- and post-processing; Senate #cite("SENATE") provides maliciously secure  // privacy-claims-allow: describes prior work (Senate), not a sparq claim
 collaborative analytics via a decomposition that localises cross-party computation; Cerebro
 #cite("CEREBRO") adds a platform layer (policy, auditing, release control) around
 collaborative cryptographic computation. MPC-SPARQL adapts two load-bearing ideas from this
@@ -373,7 +373,7 @@ The protocol field is the prime field `F_p` with `p = 2^61 - 1` (a Mersenne prim
 The evaluation point `x = 0` is #strong[RESERVED] for the secret itself and #strong[MUST
 NEVER] be handed to any party as a share.
 
-Randomness used for share masking #strong[MUST] come from a cryptographically secure
+Randomness used for share masking #strong[MUST] come from a cryptographically secure  // privacy-claims-allow: normative requirement on the RNG, not a soundness claim about sparq
 pseudorandom generator; the reference estate uses ChaCha20 #cite("RFC8439") and confines any
 deterministic test generator behind a test-only build feature that #strong[MUST NOT] be
 enabled in production builds.
@@ -627,7 +627,7 @@ a Rabbit-style full-field bit decomposition #cite("RABBIT") covering operand mag
 `2^60`.
 
 #impl-status("implemented")[Verdict-bit-only comparison is implemented; a
-maliciously-secure (MAC-checked) variant exists for the authenticated tier (§7.5).]
+maliciously-secure (MAC-checked) variant exists for the authenticated tier (§7.5, though not externally audited — see sq-qhy4).]  // privacy-claims-allow: authenticated tier is partially built and here qualified as not externally audited (sq-qhy4); not a settled soundness claim
 
 == Secure aggregates and threshold verdicts
 
@@ -675,7 +675,7 @@ For resilience against tampered shares and cheating parties:
   honest-majority malicious-with-abort protocol suite is incomplete (open work items in the
   reference estate, sq-km34 series), and the default operating tier of the reference pipeline is
   #strong[semi-honest honest-majority]. Deployments MUST NOT describe the default tier as
-  maliciously secure (§12).
+  maliciously secure (§12).  // privacy-claims-allow: honesty caveat forbidding the overclaim; the default tier is semi-honest, not a sparq claim
 ]
 
 = Transport and message formats
@@ -973,7 +973,7 @@ and #strong[MUST] surface this status to relying parties.
 The default operating tier of the reference implementation is #strong[honest-majority
 semi-honest]. The authenticated (IT-MAC) malicious-with-abort tier is only partially built
 (§7.5). A deployment #strong[MUST] report the actual per-operator tier (§3.3) and #strong[MUST
-NOT] describe a semi-honest run as maliciously secure. Semi-honest security assumes every
+NOT] describe a semi-honest run as maliciously secure. Semi-honest security assumes every  // privacy-claims-allow: this is the honesty caveat itself, warning against the overclaim
 party follows the protocol; it provides #emph[no] guarantees against a participant who
 deviates.
 
@@ -1091,7 +1091,7 @@ counters); wall-clock measurements from development machines are non-canonical a
     Bestavros, A. #emph[Conclave: Secure Multi-Party Computation on Big Data]. Proceedings
     of the 14th EuroSys Conference, 2019.]),
   ("SENATE", [Poddar, R., Kalra, S., Yanai, A., Deng, R., Popa, R. A., Hellerstein, J. M.
-    #emph[Senate: A Maliciously-Secure MPC Platform for Collaborative Analytics]. 30th
+    #emph[Senate: A Maliciously-Secure MPC Platform for Collaborative Analytics]. 30th  // privacy-claims-allow: prior-work reference title (Senate), not a sparq claim
     USENIX Security Symposium, 2021.]),
   ("CEREBRO", [Zheng, W., Deng, R., Chen, W., Popa, R. A., Panda, A., Stoica, I.
     #emph[Cerebro: A Platform for Multi-Party Cryptographic Collaborative Learning]. 30th


### PR DESCRIPTION
> 🤖 SPARQ agent

## Why (urgent unblock)

`main` is RED on the `privacy-claims (ZK/MPC honesty gate)`. The gate was extended to scan `site/specs/**/*.typ` in #1341 **after** `site/specs/mpc-sparql.typ` merged in #1332, so 6 uncaveated flagged phrases slipped through and now fail the tree-wide gate on every PR — blocking all open PRs. This qualifies the 6 lines so the gate goes green again.

## What changed

Only `site/specs/mpc-sparql.typ`. Each flagged line gets the CORRECT remedy per `SECURITY.md` + `scripts/check-privacy-claims.sh` (all 6 phrases are ABSOLUTE forbidden patterns, so the inline `privacy-claims-allow:` marker is the only mechanical exemption). Markers are Typst `//` comments — matched by the string-based gate, **stripped from the compiled PDF/HTML** (verified: 0 marker leaks in the rendered HTML).

| Line | Flagged phrase | Remedy |
|------|----------------|--------|
| 134  | Senate "provides maliciously secure collaborative analytics" | marker — describes prior work (Senate), not a sparq claim |
| 376  | RNG "MUST come from a cryptographically secure" PRNG | marker — normative RFC-2119 requirement on the RNG, not a soundness claim about sparq |
| 630  | "a maliciously-secure (MAC-checked) variant exists for the authenticated tier" | **genuine sparq capability claim** — qualified inline `(not externally audited — see sq-qhy4)` in the RENDERED text **and** marker; honestly caveated, not silenced |
| 678  | "…MUST NOT describe the default tier as maliciously secure" | marker — honesty caveat forbidding the overclaim (default tier is semi-honest) |
| 976  | "MUST NOT describe a semi-honest run as maliciously secure" | marker — this is the honesty caveat itself, warning against the overclaim |
| 1094 | reference title "Senate: A Maliciously-Secure MPC Platform…" | marker — prior-work reference title (Senate) |

**No honesty weakened.** The one genuine capability claim (L630, an authenticated/MAC-checked tier that is only partially built and NOT externally audited) is qualified with the `sq-qhy4` not-yet-sound caveat in the published output rather than merely marker-silenced. MPC remains semi-honest-only; the external accredited-cryptographer sign-off (`sq-qhy4`) is still pending.

## Verification

- `bash scripts/check-privacy-claims.sh` → **exit 0** (504 files scanned; no unqualified ZK/MPC claim). Before: 6 failing lines.
- `python3 scripts/check-no-perf-numbers.py` → 0 findings.
- `npm run build-specs` → compiles all 3 specs to PDF + HTML (exit 0); the Typst `//` markers do not break compilation.
- Rendered `mpc-sparql.html`: 0 `privacy-claims-allow` leaks; the `not externally audited` caveat IS present.
- `site/specs/sparql-vector-genai.typ`, `_lib/`, and the template were also scanned — all clean, no changes needed.

DOC/spec-only; no `crates/` source touched.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) — Opus 4.8 [OPUS-4.8]