### PR TITLE
fix(supply-chain): remediate RUSTSEC quick-xml advisory + VEX sync — heal main cargo-deny gate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2593,9 +2593,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.40.1"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -3623,7 +3623,7 @@ dependencies = [
  "oxrdf 0.3.3",
  "oxrdfxml",
  "oxttl 0.2.3",
- "quick-xml 0.40.1",
+ "quick-xml 0.41.0",
  "rustc-hash 2.1.2",
  "serde_json",
  "spargebra",
@@ -3658,7 +3658,7 @@ dependencies = [
  "md-5 0.11.0",
  "oxiri",
  "oxrdf 0.3.3",
- "quick-xml 0.40.1",
+ "quick-xml 0.41.0",
  "rayon",
  "regex",
  "rustc-hash 2.1.2",
@@ -3715,7 +3715,7 @@ dependencies = [
  "i_overlay 7.0.1",
  "oxrdf 0.3.3",
  "proj4rs",
- "quick-xml 0.40.1",
+ "quick-xml 0.41.0",
  "rand 0.10.1",
  "rstar 0.13.0",
  "rustc-hash 2.1.2",

--- a/crates/sparq-conformance/Cargo.toml
+++ b/crates/sparq-conformance/Cargo.toml
@@ -171,7 +171,7 @@ spargebra.workspace = true
 rustc-hash.workspace = true
 # Expected-result parsing only: RDF/XML result sets (.rdf) and SPARQL XML results (.srx).
 oxrdfxml = { version = "0.2", features = ["rdf-12"] }
-quick-xml = "0.40"
+quick-xml = "0.41"
 serde_json = "1"
 # [OPUS-4.8] sq-oy1f.2 — JSON-LD parser, used ONLY by the `jsonld-suite` lane to
 # re-parse the engine writer's JSON-LD output back into RDF (the fromRdf

--- a/crates/sparq-engine/Cargo.toml
+++ b/crates/sparq-engine/Cargo.toml
@@ -239,7 +239,7 @@ serde_json = { version = "1", optional = true }
 # it is safe in the main dep block, like serde_json) and is already in the workspace tree
 # (sparq-conformance, sparq-geo). Pulled in only when `service` is on. `default-features =
 # false` drops its (unused) serde derive support.
-quick-xml = { version = "0.40", default-features = false, optional = true }
+quick-xml = { version = "0.41", default-features = false, optional = true }
 
 # UUID()/STRUUID() need an OS RNG; depending on uuid from the wasm build would drag
 # getrandom into the browser dependency graph, so the functions are native-only.

--- a/crates/sparq-geo/Cargo.toml
+++ b/crates/sparq-geo/Cargo.toml
@@ -86,9 +86,12 @@ rstar = "0.13"
 # GML processor — we walk the OGC GML Simple-Features geometry subset GeoSPARQL
 # uses (Point/LineString/Polygon/Multi*). `default-features = false` keeps it to
 # the pull-parser with no serde. The transitive oxigraph stack (oxrdfxml /
-# sparesults) still pins quick-xml 0.37, so this 0.40 requirement currently
+# sparesults) still pins quick-xml 0.37, so this 0.41 requirement currently
 # resolves as a second copy in the lockfile until those upstreams bump. [OPUS-4.8]
-quick-xml = { version = "0.40", default-features = false }
+# Bumped 0.40 -> 0.41 for RUSTSEC-2026-0194 (quadratic duplicate-attribute check)
+# and RUSTSEC-2026-0195 (unbounded NsReader namespace-declaration allocation); both
+# transitive 0.37.5 copies are scoped-ignored in deny.toml until oxigraph bumps.
+quick-xml = { version = "0.41", default-features = false }
 # Behind the `reproject` feature: pure-Rust proj4 (NOT the C `proj` binding —
 # the workspace's pure-Rust constraint holds). One transitive dep (thiserror).
 proj4rs = { version = "0.1", optional = true }

--- a/deny.toml
+++ b/deny.toml
@@ -20,10 +20,11 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 # registry — a yanked crate is an unbuildable / pulled release.
 yanked = "deny"
 # Advisory IDs to tolerate — each MUST carry a justification. The policy here is
-# strict on what matters: a real VULNERABILITY or a YANKED crate FAILS the gate.
-# Exactly TWO advisories are tolerated (below), BOTH the same root cause — a
-# quick-xml < 0.41 DoS still present ONLY in a transitive copy; the gate re-flags
-# anything else.
+# strict on what matters: a YANKED crate ALWAYS fails the gate, and every
+# vulnerability fails UNLESS it is one of the explicitly justified `ignore` ids
+# listed below. Exactly TWO advisories are tolerated (below), BOTH the same root
+# cause — a quick-xml < 0.41 DoS still present ONLY in a transitive copy; the gate
+# re-flags anything else (any new advisory, or a yanked crate).
 #
 # RUSTSEC-2026-0194 (quick-xml < 0.41: quadratic run time checking a start tag for
 # duplicate attribute names — a CPU/availability DoS, NOT memory-unsafety) and

--- a/deny.toml
+++ b/deny.toml
@@ -21,9 +21,27 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
 # Advisory IDs to tolerate — each MUST carry a justification. The policy here is
 # strict on what matters: a real VULNERABILITY or a YANKED crate FAILS the gate.
-# There are currently NO ignored advisories — the list is empty so the gate
-# re-flags anything new.
+# Exactly TWO advisories are tolerated (below), BOTH the same root cause — a
+# quick-xml < 0.41 DoS still present ONLY in a transitive copy; the gate re-flags
+# anything else.
 #
+# RUSTSEC-2026-0194 (quick-xml < 0.41: quadratic run time checking a start tag for
+# duplicate attribute names — a CPU/availability DoS, NOT memory-unsafety) and
+# RUSTSEC-2026-0195 (quick-xml < 0.41: unbounded namespace-declaration allocation in
+# `NsReader` — a memory-exhaustion/availability DoS, again NOT memory-unsafety). Both
+# are fixed by the same upgrade (quick-xml >= 0.41.0) and both are reachable when
+# parsing untrusted RDF/XML or SPARQL-Results-XML. Our OWN crates were bumped
+# 0.40 -> the patched 0.41 (sparq-conformance / sparq-engine `service` / sparq-geo),
+# so those parse paths are fixed for BOTH advisories. These two ignores tolerate ONLY
+# the transitive `quick-xml 0.37.5` still pinned by the oxigraph 0.5.x stack
+# (oxrdfxml 0.2.3 / sparesults 0.3.3 / spareval 0.2.6): oxigraph has published NO
+# release that moves off quick-xml 0.37, so this transitive copy cannot be upgraded
+# without an upstream oxigraph bump. Remove BOTH ignores once oxigraph ships a
+# quick-xml >= 0.41 release (the gate then surfaces them as unmatched ignores).
+# Announcements: https://github.com/tafia/quick-xml/issues/969 (0194) and
+#                https://github.com/tafia/quick-xml/issues/970 (0195)
+#
+# --- history: advisories that WERE ignored, removed once the crate left the tree ---
 # RUSTSEC-2024-0436 (unmaintained `paste` proc-macro, bead sq-l8bv) was dropped:
 # the GPU stack (wgpu et al.) no longer pulls `paste` transitively, so the crate
 # is absent from Cargo.lock and the advisory no longer matches any crate. The
@@ -36,7 +54,11 @@ yanked = "deny"
 # (its code moved into `rustls-pki-types`' `PemObject`). The crate is now absent
 # from Cargo.lock, so the ignore is removed and the gate re-flags any regression
 # that reintroduces it.
-ignore = []
+ignore = [
+  # quick-xml 0.37.5 (oxigraph 0.5.x transitive) — see the justification above.
+  { id = "RUSTSEC-2026-0194", reason = "quick-xml <0.41 quadratic-time duplicate-attribute DoS. Our own crates are on the patched 0.41; this tolerates ONLY the transitive quick-xml 0.37.5 pinned by the oxigraph 0.5.x stack (oxrdfxml/sparesults/spareval), for which no fixed upstream release exists yet. Availability-only, not memory-unsafety. Remove when oxigraph bumps quick-xml >=0.41. https://github.com/tafia/quick-xml/issues/969" },
+  { id = "RUSTSEC-2026-0195", reason = "quick-xml <0.41 unbounded namespace-declaration allocation in NsReader — memory-exhaustion DoS. Same fix (>=0.41.0) and same scope as RUSTSEC-2026-0194: our own crates are on the patched 0.41; this tolerates ONLY the transitive quick-xml 0.37.5 pinned by the oxigraph 0.5.x stack (oxrdfxml/sparesults/spareval), for which no fixed upstream release exists yet. Availability-only, not memory-unsafety. Remove when oxigraph bumps quick-xml >=0.41. https://github.com/tafia/quick-xml/issues/970" },
+]
 
 [licenses]
 # Confidence floor for SPDX detection from license text (cargo-deny default).

--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -870,7 +870,7 @@ version = "0.37.5"
 criteria = "safe-to-deploy"
 
 [[exemptions.quick-xml]]
-version = "0.40.1"
+version = "0.41.0"
 criteria = "safe-to-deploy"
 
 [[exemptions.quinn]]

--- a/supply-chain/vex.cdx.json
+++ b/supply-chain/vex.cdx.json
@@ -24,8 +24,75 @@
     "the federation HTTP client was migrated ureq 2 -> ureq 3, whose rustls-native-certs 0.8 no",
     "longer depends on the archived `rustls-pemfile` (its code moved into rustls-pki-types'",
     "PemObject). The crate left the tree, the deny.toml ignore was dropped, and this VEX entry was",
-    "removed to keep the 1:1 invariant. The list is now empty — when a future advisory needs a",
-    "justified ignore, add the deny.toml ignore AND the matching `not_affected` entry here together."
+    "removed to keep the 1:1 invariant. When a future advisory needs a justified ignore, add the",
+    "deny.toml ignore AND the matching VEX statement here together, with the HONEST analysis.state",
+    "(`not_affected` ONLY when genuinely so; `exploitable` when the vulnerable code is present and",
+    "reachable but cannot be fixed at sparq's level yet).",
+    "[OPUS-4.8] sq-iywur: RUSTSEC-2026-0194 (quick-xml < 0.41 quadratic duplicate-attribute DoS) and",
+    "RUSTSEC-2026-0195 (quick-xml < 0.41 unbounded NsReader namespace-declaration allocation, a",
+    "memory-exhaustion DoS) are BOTH recorded below as `exploitable` (NOT not_affected): sparq's own",
+    "RDF/XML parse paths are on the patched 0.41, but the transitive quick-xml 0.37.5 pinned by the",
+    "oxigraph 0.5.x stack IS reachable when oxigraph parses untrusted RDF/XML and has no fixed",
+    "upstream release yet. Both are fixed by the same upgrade (>= 0.41.0)."
   ],
-  "vulnerabilities": []
+  "vulnerabilities": [
+    {
+      "id": "RUSTSEC-2026-0194",
+      "source": {
+        "name": "RustSec",
+        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0194"
+      },
+      "ratings": [
+        {
+          "source": {
+            "name": "RustSec"
+          },
+          "severity": "medium"
+        }
+      ],
+      "description": "quick-xml before 0.41 takes quadratic time checking a start tag for duplicate attribute names, so an attacker who controls the XML input can cause a denial of service (excessive CPU) with a crafted start tag carrying many attributes. Availability impact only — this is NOT a memory-safety issue and has no known code-execution vector.",
+      "detail": "Two copies of quick-xml were present in the tree. sparq's OWN RDF/XML and SPARQL-Results-XML parse paths (sparq-conformance, sparq-engine `service`, sparq-geo) were bumped 0.40 -> the patched 0.41 and are fixed. The copy this VEX statement covers is the TRANSITIVE quick-xml 0.37.5 pinned by the oxigraph 0.5.x stack (oxrdfxml 0.2.3 / sparesults 0.3.3 / spareval 0.2.6). oxigraph has published no release that moves off quick-xml 0.37, so this transitive copy cannot be upgraded without an upstream oxigraph bump. Tracked in bead sq-iywur; upstream announcement https://github.com/tafia/quick-xml/issues/969.",
+      "analysis": {
+        "state": "exploitable",
+        "response": [
+          "can_not_fix"
+        ],
+        "detail": "Honest reachability: the vulnerable duplicate-attribute check in quick-xml 0.37.5 IS reachable when oxigraph parses untrusted RDF/XML (oxrdfxml) or SPARQL-Results-XML (sparesults), so this is deliberately NOT marked not_affected. It cannot be fixed at sparq's level — no oxigraph release off quick-xml 0.37 exists yet and oxigraph does not expose the quick-xml version as a feature knob. Mitigation: sparq's own (non-oxigraph) XML parse paths are already on the patched 0.41; operators exposing oxigraph-backed RDF/XML ingest to untrusted input should bound request/body size at the perimeter. Impact is availability-only (quadratic CPU), not memory-unsafety. Remove this statement AND the matching deny.toml [advisories].ignore entry once oxigraph ships a quick-xml >= 0.41 release. Mirrors the deny.toml [advisories].ignore entry (same reason)."
+      },
+      "affects": [
+        {
+          "ref": "pkg:cargo/sparq"
+        }
+      ]
+    },
+    {
+      "id": "RUSTSEC-2026-0195",
+      "source": {
+        "name": "RustSec",
+        "url": "https://rustsec.org/advisories/RUSTSEC-2026-0195"
+      },
+      "ratings": [
+        {
+          "source": {
+            "name": "RustSec"
+          },
+          "severity": "medium"
+        }
+      ],
+      "description": "quick-xml before 0.41, when namespace resolution is used (`NsReader`, or a direct `NamespaceResolver::push`), allocates one namespace-binding entry per namespace declaration on a start tag with no upper bound, so an attacker who controls the XML input can exhaust process memory (OOM) with a crafted start tag carrying a very large number of `xmlns:` declarations. Availability impact only — a memory-exhaustion denial of service, NOT a memory-safety (unsound) issue, and with no known code-execution vector.",
+      "detail": "Same two-copy situation and same fix as RUSTSEC-2026-0194. sparq's OWN RDF/XML and SPARQL-Results-XML parse paths (sparq-conformance, sparq-engine `service`, sparq-geo) were bumped 0.40 -> the patched 0.41 and are fixed (0.41 caps declarations per element via NamespaceResolver::set_max_declarations_per_element). The copy this VEX statement covers is the TRANSITIVE quick-xml 0.37.5 pinned by the oxigraph 0.5.x stack (oxrdfxml 0.2.3 / sparesults 0.3.3 / spareval 0.2.6). oxigraph has published no release that moves off quick-xml 0.37, so this transitive copy cannot be upgraded without an upstream oxigraph bump. Tracked in bead sq-iywur; upstream announcement https://github.com/tafia/quick-xml/issues/970.",
+      "analysis": {
+        "state": "exploitable",
+        "response": [
+          "can_not_fix"
+        ],
+        "detail": "Honest reachability: oxigraph's RDF/XML reader (oxrdfxml) performs namespace resolution via quick-xml's NsReader, so the unbounded namespace-declaration allocation in quick-xml 0.37.5 IS reachable when oxigraph parses untrusted RDF/XML — this is deliberately NOT marked not_affected. It cannot be fixed at sparq's level — no oxigraph release off quick-xml 0.37 exists yet and oxigraph does not expose the quick-xml version as a feature knob, nor the new per-element declaration cap. Mitigation: sparq's own (non-oxigraph) XML parse paths are already on the patched 0.41; operators exposing oxigraph-backed RDF/XML ingest to untrusted input should bound request/body size at the perimeter. Impact is availability-only (memory exhaustion / OOM), not memory-unsafety. Remove this statement AND the matching deny.toml [advisories].ignore entry once oxigraph ships a quick-xml >= 0.41 release. Mirrors the deny.toml [advisories].ignore entry (same reason)."
+      },
+      "affects": [
+        {
+          "ref": "pkg:cargo/sparq"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — standalone supply-chain unblock, authored by Claude Opus 4.8 (1M context).

## Why
Main's `cargo-deny (advisories)` gate is red repo-wide, failing that gate on **every** open PR. A fresh RustSec DB pull surfaced **two** quick-xml `< 0.41` advisories:

- **RUSTSEC-2026-0194** — quadratic run time checking a start tag for duplicate attribute names (CPU/availability DoS). Announcement [quick-xml#969](https://github.com/tafia/quick-xml/issues/969).
- **RUSTSEC-2026-0195** — unbounded namespace-declaration allocation in `NsReader` (memory-exhaustion DoS). Announcement [quick-xml#970](https://github.com/tafia/quick-xml/issues/970). **This one appeared *after* #1344's fix commits**, so it is remediated here for the first time.

The fix previously lived only inside #1344 (entangled with the DPccp planner feature). This PR is the **standalone, minimal extraction** off `origin/main` — supply-chain files only — so main heals fast for everyone. Once merged, #1329/#1337/#1345/#1347/#1349 recover on update-branch and #1344 drops its now-redundant supply-chain changes on its next rebase.

## What
Both advisories are fixed by the same upgrade (quick-xml `>= 0.41.0`); both fired on two lockfile copies:

- **quick-xml 0.40.1** — pinned by *our* crates (`sparq-conformance`, `sparq-engine` `service`, `sparq-geo`). Bumped the constraint `0.40 -> 0.41` (patched, API-compatible). This copy leaves the lockfile entirely → both advisories fixed on our own parse paths.
- **quick-xml 0.37.5** — transitive via the oxigraph 0.5.x stack (`oxrdfxml`/`sparesults`/`spareval`). oxigraph has published **no** release off quick-xml 0.37, so this copy can't be upgraded without an upstream bump. Added **two scoped, justified** `deny.toml [advisories].ignore` entries (0194 + 0195) tolerating **only** this transitive copy, each with a tracking link and a remove-when-oxigraph-bumps note.

**VEX:** added the matching `supply-chain/vex.cdx.json` statements for **both** advisories so the GS-5 VEX ↔ deny.toml drift gate stays in set-sync.

**Honesty:** both are `analysis.state = exploitable`, response `can_not_fix` — deliberately **not** `not_affected`. The transitive 0.37.5 copy *is* reachable when oxigraph parses untrusted RDF/XML / SPARQL-Results-XML. Availability-only DoS (quadratic CPU / OOM), not memory-unsafety.

## Scope discipline
Supply-chain files only — **no DPccp/engine code**. Manifest changes are dependency-version bumps only (no `.rs` source). No gate weakened: two justified advisory ids; `bans`/`sources`/`licenses` unchanged.

## Local verification (all green)
| command | result |
|---|---|
| `cargo deny check advisories` | `advisories ok` (exit 0) |
| `cargo deny check bans sources licenses` | `ok` (exit 0) |
| `python3 scripts/check-vex-deny-drift.py` | in sync, 2 ids 1:1 (exit 0) |
| `python3 scripts/tests/test_vex_deny_drift.py` | 11 tests OK |
| `cargo metadata --locked` | lockfile consistent (exit 0) — no stale 0.40.1 remnant |

Closes the "repo-wide `cargo-deny (advisories)` gate red" incident (bead sq-iywur).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>