### PR TITLE
feat(site): /download one-click DIRECT per-asset downloads (sq-vw3ax.11) [OPUS-4.8]

### DIFF
--- a/site/e2e/download-page.spec.ts
+++ b/site/e2e/download-page.spec.ts
@@ -1,0 +1,140 @@
+// [OPUS-4.8] sq-vw3ax.11 — headless smoke test for the /download DIRECT-download redesign.
+//
+// WHAT IT GUARDS. /download turns every button into a one-click DIRECT download of the right
+// per-platform file via GitHub's version-stable `releases/latest/download/<alias>` endpoint, and
+// ENRICHES each card (version / size / copyable sha256) from an unauthenticated
+// `api.github.com/repos/jeswr/sparq/releases/latest` fetch. Two states must both be correct:
+//
+//   * NO RELEASE YET (API 404 — the current live reality): every download control degrades to a
+//     subdued "No release yet — watch releases" link to the Releases page, and the unsigned-build
+//     banner stays front-and-centre. That Releases link is the ONLY GitHub-page link retained.
+//   * READY (API 200): the buttons are live direct-download links whose href is the STATIC
+//     `…/releases/latest/download/<alias>` (needs no per-release rebuild), the version tag renders,
+//     and the collapsed details expose a copyable sha256.
+//
+// The GitHub API is MOCKED via page.route so the test is hermetic — it never depends on live
+// GitHub state or network, and it deterministically exercises BOTH states. It is a CORRECTNESS
+// smoke test (DOM + hrefs + console), never a timing threshold.
+import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
+
+// Block the coi-serviceworker for this spec. The shim re-issues EVERY fetch (incl. cross-origin)
+// from inside the service worker, which bypasses page.route — so the api.github.com mock below
+// would never intercept. The /download page needs no cross-origin isolation (it only does a plain
+// CORS fetch + renders static links), so blocking the SW is safe here and makes the mock
+// deterministic. (Other specs that DO need the SW keep the config default.)
+test.use({ serviceWorkers: "block" });
+
+const API_GLOB = "**/api.github.com/repos/jeswr/sparq/releases/latest";
+const RELEASES_URL = "https://github.com/jeswr/sparq/releases";
+const LATEST_DL = "https://github.com/jeswr/sparq/releases/latest/download";
+
+// The light site-e2e CI lane builds no wasm bundle, so any optional-wasm fetch 404s benignly;
+// filter that one class of resource error while still catching every REAL client-side fault.
+const BENIGN_RESOURCE_404 = /Failed to load resource:.*\b404\b/i;
+// Blocking the service worker (test.use above) makes the coi-serviceworker registration script
+// throw a benign "reading 'scope'" TypeError — a test-only artifact of the block, never a product
+// fault (in a real browser the SW registers and returns a registration). Filter exactly that.
+const BENIGN_SW_BLOCK = /reading 'scope'|ServiceWorker.*(register|controller)/i;
+
+function trackConsoleErrors(page: Page): string[] {
+  const errors: string[] = [];
+  page.on("console", (msg: ConsoleMessage) => {
+    if (msg.type() !== "error") return;
+    const text = msg.text();
+    if (BENIGN_RESOURCE_404.test(text) || BENIGN_SW_BLOCK.test(text)) return;
+    errors.push(text);
+  });
+  page.on("pageerror", (err) => {
+    const text = String(err);
+    if (BENIGN_SW_BLOCK.test(text)) return;
+    errors.push(text);
+  });
+  return errors;
+}
+
+// With the coi-serviceworker blocked (test.use above) there is no one-time reload to absorb, so a
+// plain domcontentloaded navigation is enough — the assertions below auto-wait for hydration.
+async function gotoSettled(page: Page, route: string): Promise<void> {
+  await page.goto(route, { waitUntil: "domcontentloaded" });
+}
+
+// A minimal `releases/latest` payload with the Windows GUI alias the Playwright Desktop-Chrome
+// device's OS detection promotes (its device UA pins "Windows NT 10.0"), plus a version-stable
+// digest.
+const FAKE_SHA = "a".repeat(64);
+const READY_BODY = JSON.stringify({
+  tag_name: "v9.9.9-test",
+  assets: [
+    {
+      name: "sparq-gui-win-x64.msi",
+      size: 94371840, // 90.0 MB
+      digest: `sha256:${FAKE_SHA}`,
+    },
+  ],
+});
+
+async function mockApi(page: Page, status: number, body: string): Promise<void> {
+  await page.route(API_GLOB, async (route) => {
+    await route.fulfill({
+      status,
+      // CORS + CORP headers so the fetch is allowed under the site's cross-origin isolation.
+      headers: {
+        "content-type": "application/json",
+        "access-control-allow-origin": "*",
+        "cross-origin-resource-policy": "cross-origin",
+      },
+      body,
+    });
+  });
+}
+
+test("no-release state: buttons degrade to a Releases link and the unsigned banner stays", async ({
+  page,
+}) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await mockApi(page, 404, JSON.stringify({ message: "Not Found" }));
+  await gotoSettled(page, "download/");
+
+  // The unsigned-build honesty banner is present in this state too.
+  await expect(page.getByText("Developer builds — unsigned.")).toBeVisible();
+
+  // Every download control is the "No release yet — watch releases" link to the Releases page.
+  const watch = page.getByRole("link", { name: /No release yet — watch releases/i }).first();
+  await expect(watch).toBeVisible();
+  await expect(watch).toHaveAttribute("href", RELEASES_URL);
+
+  // The no-install closer still points at the in-browser playground.
+  await expect(page.getByRole("link", { name: /Open the playground/i })).toBeVisible();
+
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});
+
+test("ready state: the primary button is a static direct-download link with version + sha256", async ({
+  page,
+}) => {
+  const consoleErrors = trackConsoleErrors(page);
+  await mockApi(page, 200, READY_BODY);
+  await gotoSettled(page, "download/");
+
+  // The Playwright Desktop-Chrome device (Windows UA) promotes the Windows platform to the primary row.
+  await expect(page.getByText("For your Windows PC")).toBeVisible();
+
+  // The primary download button is the STATIC latest/download alias URL (no per-release rebuild).
+  // Locate it by href (unambiguous) rather than by its combined accessible name.
+  const primary = page.locator(
+    `a[href="${LATEST_DL}/sparq-gui-win-x64.msi"]`,
+  );
+  await expect(primary).toBeVisible();
+  await expect(primary).toContainText("Download sparq-gui.msi");
+  // The ready-state meta (version · size) is appended to the button in the ready state.
+  await expect(primary).toContainText("v9.9.9-test");
+
+  // The version tag also renders as the "Desktop app" section badge.
+  await expect(page.getByText("v9.9.9-test").first()).toBeVisible();
+
+  // The collapsed details expose the copyable sha256 from the asset digest.
+  await page.getByText("First launch & verification").first().click();
+  await expect(page.getByText(FAKE_SHA).first()).toBeVisible();
+
+  expect(consoleErrors, `console errors: ${consoleErrors.join("\n")}`).toEqual([]);
+});

--- a/site/src/app/download/download-client.tsx
+++ b/site/src/app/download/download-client.tsx
@@ -320,13 +320,22 @@ function detectOs(): OsKey | null {
 function Sha256Line({ digest }: { digest: string }) {
   const hex = digest.replace(/^sha256:/, "");
   const [copied, setCopied] = React.useState(false);
+  // [OPUS-4.8] track the reset timer id so it can be cancelled on unmount / re-arm to avoid leaks
+  const timerRef = React.useRef<ReturnType<typeof window.setTimeout> | null>(null);
+
+  React.useEffect(() => {
+    return () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    };
+  }, []);
 
   const copy = React.useCallback(async () => {
     try {
       await navigator.clipboard.writeText(hex);
       setCopied(true);
       toast.success("sha256 copied");
-      window.setTimeout(() => setCopied(false), 1500);
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+      timerRef.current = window.setTimeout(() => setCopied(false), 1500);
     } catch {
       toast.error("Couldn't copy to the clipboard");
     }

--- a/site/src/app/download/download-client.tsx
+++ b/site/src/app/download/download-client.tsx
@@ -320,8 +320,11 @@ function detectOs(): OsKey | null {
 function Sha256Line({ digest }: { digest: string }) {
   const hex = digest.replace(/^sha256:/, "");
   const [copied, setCopied] = React.useState(false);
-  // [OPUS-4.8] track the reset timer id so it can be cancelled on unmount / re-arm to avoid leaks
-  const timerRef = React.useRef<ReturnType<typeof window.setTimeout> | null>(null);
+  // [OPUS-4.8] track the reset timer id so it can be cancelled on unmount / re-arm to avoid leaks.
+  // `window.setTimeout` returns `number` in the DOM lib; type the ref as `number` to avoid the
+  // @types/node global-augmentation ambiguity where `ReturnType<typeof window.setTimeout>`
+  // resolves to Node's `Timeout` and the assignment fails typecheck (TS2322).
+  const timerRef = React.useRef<number | null>(null);
 
   React.useEffect(() => {
     return () => {

--- a/site/src/app/download/download-client.tsx
+++ b/site/src/app/download/download-client.tsx
@@ -1,37 +1,61 @@
 "use client";
 
-// [OPUS-4.8] sq-gl3cf / sq-ixc3 — the /download page client body.
+// [OPUS-4.8] sq-vw3ax.11 — the /download page client body: DIRECT per-asset downloads.
 //
-// Why a client component: the page progressively ENHANCES with client-side OS
-// detection (navigator.userAgent / userAgentData) to highlight the platform the
-// visitor is most likely on. It is pure progressive enhancement — every platform
-// is ALWAYS listed and linkable; detection only adds a "we think this is you"
-// affordance and reorders the highlighted card. With JS off (or before hydration)
-// the full unfiltered list renders, so nothing depends on the detection.
+// WHAT CHANGED (vs the old "link to the latest-release page" body). Every button is now a
+// one-click DIRECT download of the right file for the visitor's platform, using GitHub's
+// version-stable download endpoint:
 //
-// HONESTY: there are no published GitHub Releases yet (gh release list is empty as
-// of this commit), and the desktop installers are UNSIGNED "developer build"
-// bundles (signing/notarization is the separate needs:user bead sq-v286.8). The
-// copy below says so plainly — no overclaiming. Asset links point at the *latest
-// release* page rather than per-asset deep links, because the release CI
-// (release.yml, sq-8n1c via #808) names each asset
-// `sparq-gui-<tag>-<label>-<tauri-name>` where `<tag>` is the dynamic version, so a
-// static per-asset URL would be a dead link until a tag ships. Once releases exist,
-// the "latest release" page resolves to the real assets.
+//     https://github.com/jeswr/sparq/releases/latest/download/<alias>
+//
+// GitHub 302-redirects that URL straight to the asset on its CDN (no interstitial), PROVIDED
+// the asset name is version-STABLE. The release pipeline names its primary bundles with the
+// version embedded (`sparq-gui_<version>_<arch>.<ext>`, `sparq-cli-<version>-<tier>.tar.gz`),
+// which is NOT stable, so this page targets version-agnostic ALIAS names
+// (`sparq-gui-arm64-darwin.dmg`, `sparq-cli-x64-linux.tar.gz`, …). Those aliases are published
+// by the release pipeline alongside the versioned assets (release.yml — a CI-infra-lane change
+// that is the companion to this site change; see the PR body). The upshot: the button hrefs are
+// STATIC and never need a per-release site rebuild — they resolve to whatever the latest release
+// carries the moment a release ships.
+//
+// METADATA (progressive enhancement, NOT required for the buttons to work). On mount we fetch
+// `api.github.com/repos/jeswr/sparq/releases/latest` (CORS-open, unauthenticated) purely to
+// ENRICH each card with the version tag, the asset byte-size, and a copyable sha256 (the asset
+// `digest` field the API now returns, so we never need the CORS-blocked SHA256SUMS body). If that
+// fetch FAILS for any reason other than a definitive 404, the buttons stay live — the
+// latest/download URL needs no API.
+//
+// NO-RELEASE-YET STATE (current reality: `/releases/latest` 404s because only pre-releases exist,
+// and `/releases/latest/download/*` likewise only resolves to a non-prerelease release). On a
+// 404 we KNOW there is no published release, so every download control renders as a subdued
+// "No release yet — watch releases" link to the Releases page — the ONLY GitHub-page link
+// retained in that state. It flips to live direct-download buttons with ZERO code change the
+// moment the first non-prerelease ships.
+//
+// HONESTY: the desktop bundles are UNSIGNED developer builds (signing/notarization is the
+// separate needs:user bead sq-v286.8). The unsigned-builds banner stays front-and-centre in
+// BOTH states — no overclaiming.
 
 import * as React from "react";
 import Link from "next/link";
+import { toast } from "sonner";
 import {
   Apple,
+  Bell,
+  Check,
+  Copy,
   Cpu,
   Download,
   ExternalLink,
+  Loader2,
   MonitorSmartphone,
   Server,
+  ShieldCheck,
   Terminal,
   TriangleAlert,
 } from "lucide-react";
 
+import { cn } from "@/lib/utils";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -42,34 +66,53 @@ import {
 } from "@/components/ui/card";
 
 const REPO_URL = "https://github.com/jeswr/sparq";
-const LATEST_RELEASE_URL = `${REPO_URL}/releases/latest`;
 const RELEASES_URL = `${REPO_URL}/releases`;
+// The version-STABLE download endpoint. GitHub 302s `<LATEST_DL>/<asset>` to the asset on its
+// CDN with no interstitial, so an <alias> that the latest release carries downloads in one click.
+const LATEST_DL = `${REPO_URL}/releases/latest/download`;
+const API_LATEST =
+  "https://api.github.com/repos/jeswr/sparq/releases/latest";
 
-// The platforms the release matrix actually produces a desktop GUI installer for
-// (release.yml `gui-bundle` job, sq-8n1c via #808). win-arm64 is deliberately
-// absent (the Tauri bundler can't reliably cross-bundle an arm64 Windows installer
-// from the x64 host) — an honest gap, not a silent drop.
+// The platforms the release matrix produces a desktop GUI installer for (release.yml `gui-bundle`
+// job). win-arm64 is deliberately absent (the Tauri bundler can't reliably cross-bundle an arm64
+// Windows installer from the x64 host) — an honest gap, not a silent drop.
 type OsKey = "macos-arm" | "macos-intel" | "windows" | "linux";
 
-interface Platform {
-  /** Detection bucket(s) this card satisfies. */
-  os: OsKey;
+interface SecondaryAsset {
+  /** Version-agnostic alias file name served at `<LATEST_DL>/<file>`. */
+  file: string;
+  /** Short button label, e.g. ".deb (Debian/Ubuntu)". */
   label: string;
-  /** The installer file kind shown in the release assets. */
+}
+
+interface GuiPlatform {
+  /** Detection bucket this card satisfies. */
+  os: OsKey;
+  /** Card title, e.g. "macOS · Apple Silicon". */
+  label: string;
+  /** Full-width primary-row heading when this is the detected platform. */
+  forYou: string;
+  /** Version-agnostic alias file name (release.yml publishes it), served at `<LATEST_DL>/<file>`. */
+  file: string;
+  /** Human-facing short file name shown on the button, e.g. "sparq-gui.dmg". */
+  shortName: string;
+  /** The installer file kind, e.g. ".dmg". */
   ext: string;
-  /** The release-asset label this maps to (release.yml matrix `label`). */
-  assetLabel: string;
+  /** Optional extra download offered on the same card (Linux ships a .deb too). */
+  secondary?: SecondaryAsset;
   icon: React.ReactNode;
-  /** Per-OS unsigned-bundle bypass instructions. */
+  /** Per-OS unsigned-bundle first-launch bypass instructions. */
   bypass: React.ReactNode;
 }
 
-const PLATFORMS: Platform[] = [
+const GUI_PLATFORMS: GuiPlatform[] = [
   {
     os: "macos-arm",
     label: "macOS · Apple Silicon",
+    forYou: "For your Mac (Apple Silicon)",
+    file: "sparq-gui-arm64-darwin.dmg",
+    shortName: "sparq-gui.dmg",
     ext: ".dmg",
-    assetLabel: "arm64-darwin",
     icon: <Apple className="size-5" aria-hidden />,
     bypass: (
       <>
@@ -87,8 +130,10 @@ const PLATFORMS: Platform[] = [
   {
     os: "macos-intel",
     label: "macOS · Intel",
+    forYou: "For your Mac (Intel)",
+    file: "sparq-gui-x64-darwin.dmg",
+    shortName: "sparq-gui.dmg",
     ext: ".dmg",
-    assetLabel: "x64-darwin",
     icon: <Apple className="size-5" aria-hidden />,
     bypass: (
       <>
@@ -98,15 +143,17 @@ const PLATFORMS: Platform[] = [
           <code>xattr -dr com.apple.quarantine /Applications/sparq.app</code>
         </pre>
         Pick this build only on an Intel Mac; Apple Silicon Macs should use the
-        arm64 build above.
+        arm64 build.
       </>
     ),
   },
   {
     os: "windows",
     label: "Windows · x64",
+    forYou: "For your Windows PC",
+    file: "sparq-gui-win-x64.msi",
+    shortName: "sparq-gui.msi",
     ext: ".msi",
-    assetLabel: "win-x64",
     icon: <MonitorSmartphone className="size-5" aria-hidden />,
     bypass: (
       <>
@@ -120,9 +167,12 @@ const PLATFORMS: Platform[] = [
   },
   {
     os: "linux",
-    label: "Linux · x86-64 / arm64",
+    label: "Linux · x86-64",
+    forYou: "For your Linux machine",
+    file: "sparq-gui-x64-linux.AppImage",
+    shortName: "sparq-gui.AppImage",
     ext: ".AppImage",
-    assetLabel: "x64-linux",
+    secondary: { file: "sparq-gui-x64-linux.deb", label: ".deb (Debian/Ubuntu)" },
     icon: <Cpu className="size-5" aria-hidden />,
     bypass: (
       <>
@@ -130,62 +180,316 @@ const PLATFORMS: Platform[] = [
         self-contained binary — no install needed. Mark it executable, then run
         it:
         <pre className="mt-2 overflow-x-auto rounded-md bg-muted px-3 py-2 text-xs">
-          <code>chmod +x sparq-gui-*.AppImage{"\n"}./sparq-gui-*.AppImage</code>
+          <code>chmod +x sparq-gui.AppImage{"\n"}./sparq-gui.AppImage</code>
         </pre>
-        A <code className="font-mono text-xs">.deb</code> is also published for
-        Debian/Ubuntu. Choose the asset matching your CPU (x86-64 or arm64).
+        A <code className="font-mono text-xs">.deb</code> is published for
+        Debian/Ubuntu (button above). arm64 Linux builds are attached to each
+        release on the Releases page.
       </>
     ),
   },
 ];
 
+// ---- GitHub Releases API metadata (progressive enhancement) ------------------------------------
+
+/** One release asset, trimmed to what the cards render. */
+interface ReleaseAsset {
+  name: string;
+  size: number;
+  /** e.g. "sha256:<hex>" — GitHub attaches this per asset (CORS-open on api.github.com). */
+  digest: string | null;
+}
+
+/** The metadata fetch state machine. */
+type ReleaseState =
+  | { kind: "loading" }
+  // A published (non-prerelease) release exists — enrich buttons with version/size/sha.
+  | { kind: "ready"; version: string; assets: Map<string, ReleaseAsset> }
+  // HTTP 404: there is definitively no published release yet.
+  | { kind: "none" }
+  // Network/other failure: we can't confirm, so buttons stay live (latest/download needs no API).
+  | { kind: "error" };
+
+interface ApiReleaseShape {
+  tag_name?: unknown;
+  assets?: unknown;
+}
+
+function parseRelease(
+  json: unknown,
+): { version: string; assets: Map<string, ReleaseAsset> } | null {
+  if (typeof json !== "object" || json === null) return null;
+  const { tag_name, assets } = json as ApiReleaseShape;
+  if (typeof tag_name !== "string" || !Array.isArray(assets)) return null;
+  const map = new Map<string, ReleaseAsset>();
+  for (const a of assets) {
+    if (typeof a !== "object" || a === null) continue;
+    const { name, size, digest } = a as {
+      name?: unknown;
+      size?: unknown;
+      digest?: unknown;
+    };
+    if (typeof name !== "string" || typeof size !== "number") continue;
+    map.set(name, {
+      name,
+      size,
+      digest: typeof digest === "string" ? digest : null,
+    });
+  }
+  return { version: tag_name, assets: map };
+}
+
 /**
- * Best-effort, progressive-enhancement OS detection. Returns the detection bucket
- * we think the visitor is on, or null when we can't tell (in which case nothing is
- * highlighted and the full list still renders). We never branch behaviour on this —
- * it only reorders/annotates.
+ * Fetch the latest published release once on mount. A definitive 404 → `none` (no release yet);
+ * a 200 with a parseable body → `ready`; anything else (network error, rate limit, unparseable)
+ * → `error`, which keeps the direct-download buttons live but without metadata.
+ */
+function useLatestRelease(): ReleaseState {
+  const [state, setState] = React.useState<ReleaseState>({ kind: "loading" });
+
+  React.useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(API_LATEST, {
+          headers: { Accept: "application/vnd.github+json" },
+        });
+        if (cancelled) return;
+        if (res.status === 404) {
+          setState({ kind: "none" });
+          return;
+        }
+        if (!res.ok) {
+          setState({ kind: "error" });
+          return;
+        }
+        const parsed = parseRelease(await res.json());
+        if (cancelled) return;
+        setState(parsed ? { kind: "ready", ...parsed } : { kind: "error" });
+      } catch {
+        if (!cancelled) setState({ kind: "error" });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return state;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  const mb = bytes / (1024 * 1024);
+  if (mb < 1) return `${(bytes / 1024).toFixed(0)} KB`;
+  if (mb < 1024) return `${mb.toFixed(1)} MB`;
+  return `${(mb / 1024).toFixed(2)} GB`;
+}
+
+/** The asset metadata for a given alias, if the ready release carries it. */
+function assetOf(state: ReleaseState, file: string): ReleaseAsset | undefined {
+  return state.kind === "ready" ? state.assets.get(file) : undefined;
+}
+
+// ---- OS detection (progressive enhancement) ----------------------------------------------------
+
+/**
+ * Best-effort OS detection. Returns the bucket we think the visitor is on, or null when we can't
+ * tell (in which case nothing is promoted and the full grid renders). We never branch behaviour
+ * on this — it only promotes/annotates.
  */
 function detectOs(): OsKey | null {
   if (typeof navigator === "undefined") return null;
-
-  // userAgentData is the modern, UA-string-independent surface (Chromium). It can
-  // expose the platform without the increasingly-frozen UA string.
   const uaData = (
-    navigator as Navigator & {
-      userAgentData?: { platform?: string };
-    }
+    navigator as Navigator & { userAgentData?: { platform?: string } }
   ).userAgentData;
   const platform = (uaData?.platform ?? "").toLowerCase();
   const ua = navigator.userAgent.toLowerCase();
   const hay = `${platform} ${ua}`;
-
-  // Apple Silicon vs Intel is not reliably distinguishable from the browser, so we
-  // default macOS to the Apple-Silicon card (the common case for new Macs) and let
-  // the user pick Intel explicitly — both are always visible.
+  // Apple Silicon vs Intel is not reliably distinguishable from the browser, so we default macOS
+  // to the Apple-Silicon card (the common case for new Macs); both are always visible.
   if (/mac|iphone|ipad|ipod/.test(hay)) return "macos-arm";
   if (/win/.test(hay)) return "windows";
   if (/linux|android|cros/.test(hay)) return "linux";
   return null;
 }
 
+// ---- small presentational pieces ---------------------------------------------------------------
+
+/** A copyable sha256 line — click to copy the full hex to the clipboard. */
+function Sha256Line({ digest }: { digest: string }) {
+  const hex = digest.replace(/^sha256:/, "");
+  const [copied, setCopied] = React.useState(false);
+
+  const copy = React.useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(hex);
+      setCopied(true);
+      toast.success("sha256 copied");
+      window.setTimeout(() => setCopied(false), 1500);
+    } catch {
+      toast.error("Couldn't copy to the clipboard");
+    }
+  }, [hex]);
+
+  return (
+    <div className="mt-2 space-y-1">
+      <div className="flex items-center gap-1.5 text-xs font-medium text-foreground">
+        <ShieldCheck className="size-3.5 text-[var(--success)]" aria-hidden />
+        Verify the download (sha256)
+      </div>
+      <div className="flex items-start gap-2">
+        <code className="min-w-0 flex-1 overflow-x-auto rounded-md bg-muted px-2 py-1 font-mono text-[11px] leading-relaxed break-all">
+          {hex}
+        </code>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="size-7 shrink-0"
+          onClick={copy}
+          aria-label="Copy the sha256 checksum"
+        >
+          {copied ? (
+            <Check className="size-4 text-[var(--success)]" />
+          ) : (
+            <Copy className="size-4" />
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * A direct-download control for one alias. In the `none` state it degrades to a subdued
+ * "watch releases" link (the only GitHub-page link retained). Otherwise it is a live
+ * one-click download of `<LATEST_DL>/<file>`; `<meta>` (version · size) is appended when known.
+ */
+function DownloadButton({
+  file,
+  children,
+  state,
+  variant = "outline",
+  size = "sm",
+  className,
+}: {
+  file: string;
+  children: React.ReactNode;
+  state: ReleaseState;
+  variant?: React.ComponentProps<typeof Button>["variant"];
+  size?: React.ComponentProps<typeof Button>["size"];
+  className?: string;
+}) {
+  if (state.kind === "none") {
+    return (
+      <Button
+        asChild
+        variant="outline"
+        size={size}
+        className={cn("w-full text-muted-foreground", className)}
+      >
+        <a href={RELEASES_URL} target="_blank" rel="noopener noreferrer">
+          <Bell className="size-4" />
+          No release yet — watch releases
+        </a>
+      </Button>
+    );
+  }
+  const asset = assetOf(state, file);
+  const meta =
+    state.kind === "ready"
+      ? [state.version, asset ? formatBytes(asset.size) : null]
+          .filter(Boolean)
+          .join(" · ")
+      : null;
+  return (
+    <Button asChild variant={variant} size={size} className={cn("w-full", className)}>
+      {/* The `download` attribute hints a save; on a cross-origin 302 the browser downloads the
+          target regardless. The file name is version-stable, so no rebuild per release. */}
+      <a href={`${LATEST_DL}/${file}`} download>
+        {state.kind === "loading" ? (
+          <Loader2 className="size-4 animate-spin" aria-hidden />
+        ) : (
+          <Download className="size-4" aria-hidden />
+        )}
+        <span className="truncate">
+          {children}
+          {meta ? <span className="opacity-80"> · {meta}</span> : null}
+        </span>
+      </a>
+    </Button>
+  );
+}
+
+/** The collapsed first-launch / verify details shared by every GUI card. */
+function LaunchDetails({
+  bypass,
+  file,
+  state,
+}: {
+  bypass: React.ReactNode;
+  file: string;
+  state: ReleaseState;
+}) {
+  const asset = assetOf(state, file);
+  return (
+    <details className="text-muted-foreground">
+      <summary className="cursor-pointer select-none font-medium text-foreground">
+        First launch &amp; verification
+      </summary>
+      <div className="measure pt-2 leading-relaxed">
+        {bypass}
+        {asset?.digest ? <Sha256Line digest={asset.digest} /> : null}
+      </div>
+    </details>
+  );
+}
+
+// ---- CLI / server aliases ----------------------------------------------------------------------
+
+/** The CLI/server alias platform token + archive extension for the detected OS. */
+function cliTarget(os: OsKey | null): { token: string; ext: string; label: string } {
+  switch (os) {
+    case "macos-arm":
+      return { token: "arm64-darwin", ext: "tar.gz", label: "macOS · Apple Silicon" };
+    case "macos-intel":
+      return { token: "x64-darwin", ext: "tar.gz", label: "macOS · Intel" };
+    case "windows":
+      return { token: "win-x64", ext: "zip", label: "Windows · x64" };
+    case "linux":
+      return { token: "x64-linux", ext: "tar.gz", label: "Linux · x86-64" };
+    default:
+      // Undetected: default to the portable Linux x86-64 archive; every platform's build is on
+      // the Releases page (linked from the banner).
+      return { token: "x64-linux", ext: "tar.gz", label: "Linux · x86-64" };
+  }
+}
+
+// ---- page --------------------------------------------------------------------------------------
+
 export function DownloadClient() {
-  // null until hydrated → SSR renders the full list with nothing highlighted, so
-  // there is no hydration mismatch (the server can't know the OS).
+  // null until hydrated → SSR renders the full grid with nothing promoted (no hydration mismatch;
+  // the server can't know the OS).
   const [detected, setDetected] = React.useState<OsKey | null>(null);
+  const release = useLatestRelease();
 
   React.useEffect(() => {
     setDetected(detectOs());
   }, []);
 
-  // Highlighted-first ordering: the detected card floats to the top of the list,
-  // but every platform stays present and linkable.
-  const ordered = React.useMemo(() => {
-    if (!detected) return PLATFORMS;
-    const match = (p: Platform) => p.os === detected;
-    return [...PLATFORMS].sort(
-      (a, b) => Number(match(b)) - Number(match(a)),
-    );
-  }, [detected]);
+  const primary = React.useMemo(
+    () => (detected ? GUI_PLATFORMS.find((p) => p.os === detected) ?? null : null),
+    [detected],
+  );
+  const rest = React.useMemo(
+    () => (primary ? GUI_PLATFORMS.filter((p) => p !== primary) : GUI_PLATFORMS),
+    [primary],
+  );
+
+  const cli = React.useMemo(() => cliTarget(detected), [detected]);
+  const cliArchive = `sparq-cli-${cli.token}.${cli.ext}`;
+  const serverArchive = `sparq-server-${cli.token}.${cli.ext}`;
 
   return (
     <div className="space-y-10">
@@ -205,7 +509,7 @@ export function DownloadClient() {
         </p>
       </header>
 
-      {/* Unsigned-build honesty banner — front and centre, not buried. */}
+      {/* Unsigned-build honesty banner — front and centre in BOTH states, never buried. */}
       <div
         role="note"
         className="flex items-start gap-3 rounded-xl bg-[color-mix(in_oklch,var(--warning)_12%,transparent)] px-4 py-3 ring-1 ring-[color-mix(in_oklch,var(--warning)_30%,transparent)]"
@@ -241,99 +545,114 @@ export function DownloadClient() {
 
       {/* Desktop GUI downloads */}
       <section className="space-y-4">
-        <div className="flex items-center justify-between gap-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
           <h2 className="text-xl font-semibold">Desktop app</h2>
-          {detected && (
-            <Badge variant="success" className="h-6">
-              Detected your platform
+          {release.kind === "ready" && (
+            <Badge variant="muted" className="h-6 font-mono">
+              {release.version}
             </Badge>
           )}
         </div>
 
-        <div className="grid gap-4 md:grid-cols-2">
-          {ordered.map((p) => {
-            const isMatch = detected !== null && p.os === detected;
-            return (
-              <Card
-                key={`${p.os}`}
-                className={
-                  isMatch
-                    ? "ring-2 ring-primary/60"
-                    : undefined
-                }
-              >
-                <CardHeader>
-                  <CardTitle className="flex items-center gap-2 text-base">
-                    {p.icon}
-                    <span className="flex-1">{p.label}</span>
-                    {isMatch && (
-                      <Badge variant="success" className="h-5">
-                        You
-                      </Badge>
-                    )}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="space-y-3 text-sm">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Badge variant="muted">{p.ext}</Badge>
-                    <Badge variant="warning">Unsigned</Badge>
-                  </div>
-                  <Button asChild variant="outline" size="sm" className="w-full">
-                    <a
-                      href={LATEST_RELEASE_URL}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      <Download className="size-4" />
-                      Get the {p.ext} from the latest release
-                    </a>
-                  </Button>
-                  <details className="text-muted-foreground">
-                    <summary className="cursor-pointer select-none font-medium text-foreground">
-                      First-launch instructions
-                    </summary>
-                    <div className="measure pt-2 leading-relaxed">
-                      {p.bypass}
-                    </div>
-                  </details>
-                </CardContent>
-              </Card>
-            );
-          })}
-        </div>
+        {/* Detected platform → full-width primary row. */}
+        {primary && (
+          <Card className="ring-2 ring-primary/60">
+            <CardContent className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+              <div className="min-w-0 space-y-1">
+                <div className="flex items-center gap-2">
+                  {primary.icon}
+                  <span className="text-base font-semibold">{primary.forYou}</span>
+                  <Badge variant="success" className="h-5">
+                    Detected
+                  </Badge>
+                </div>
+                <p className="text-sm text-muted-foreground">
+                  Recommended installer for your platform — {primary.label},{" "}
+                  <code className="font-mono text-xs">{primary.ext}</code>.
+                </p>
+              </div>
+              <div className="w-full space-y-2 md:w-80">
+                <DownloadButton
+                  file={primary.file}
+                  state={release}
+                  variant="default"
+                  size="lg"
+                >
+                  Download {primary.shortName}
+                </DownloadButton>
+                {primary.secondary && release.kind !== "none" && (
+                  <DownloadButton file={primary.secondary.file} state={release}>
+                    {primary.secondary.label}
+                  </DownloadButton>
+                )}
+              </div>
+            </CardContent>
+            <CardContent className="text-sm">
+              <LaunchDetails
+                bypass={primary.bypass}
+                file={primary.file}
+                state={release}
+              />
+            </CardContent>
+          </Card>
+        )}
 
-        <p className="measure text-xs text-muted-foreground">
-          Releases are published from the build matrix on each tagged version. If
-          the latest-release page shows no assets yet, the first signed-off
-          release hasn&rsquo;t shipped — check back, or watch the{" "}
-          <a
-            className="text-primary underline-offset-4 hover:underline"
-            href={RELEASES_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Releases page
-          </a>
-          . Assets are named{" "}
-          <code className="font-mono text-xs">
-            sparq-gui-&lt;version&gt;-&lt;platform&gt;-&hellip;
-          </code>{" "}
-          (e.g. <code className="font-mono text-xs">arm64-darwin</code>,{" "}
-          <code className="font-mono text-xs">win-x64</code>).
-        </p>
+        {/* Remaining platforms → compact grid (3-up when a platform is promoted, 2×2 otherwise). */}
+        <div
+          className={cn(
+            "grid gap-4",
+            primary ? "md:grid-cols-3" : "sm:grid-cols-2",
+          )}
+        >
+          {rest.map((p) => (
+            <Card key={p.os}>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  {p.icon}
+                  <span className="flex-1">{p.label}</span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3 text-sm">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="muted">{p.ext}</Badge>
+                  <Badge variant="warning">Unsigned</Badge>
+                </div>
+                <DownloadButton file={p.file} state={release}>
+                  Download {p.shortName}
+                </DownloadButton>
+                {p.secondary && release.kind !== "none" && (
+                  <DownloadButton file={p.secondary.file} state={release}>
+                    {p.secondary.label}
+                  </DownloadButton>
+                )}
+                <LaunchDetails bypass={p.bypass} file={p.file} state={release} />
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </section>
 
       {/* CLI + server binaries */}
       <section className="space-y-4">
-        <h2 className="text-xl font-semibold">Command-line & server</h2>
+        <h2 className="text-xl font-semibold">Command-line &amp; server</h2>
         <p className="measure text-sm text-muted-foreground">
           The same releases also carry the standalone{" "}
           <code className="font-mono text-xs">sparq</code> CLI and the{" "}
           <code className="font-mono text-xs">sparq-server</code> HTTP server
           binaries, built across a broad OS &times; CPU matrix
           (macOS/Windows/Linux, x86-64 micro-architecture tiers + arm64). These
-          are plain executables — no signing dialog — verified against the
-          release&rsquo;s <code className="font-mono text-xs">SHA256SUMS</code>.
+          are plain executables — no signing dialog. The buttons below fetch the
+          build for <strong>{cli.label}</strong>; every other platform&rsquo;s
+          archive is attached to the{" "}
+          <a
+            className="text-primary underline-offset-4 hover:underline"
+            href={RELEASES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            latest release
+          </a>
+          .
         </p>
         <div className="grid gap-4 md:grid-cols-2">
           <Card>
@@ -346,19 +665,25 @@ export function DownloadClient() {
             <CardContent className="space-y-3 text-sm text-muted-foreground">
               <p className="measure">
                 Load, query, and convert RDF from the terminal. Download the
-                archive for your platform, extract, and put the binary on your{" "}
+                archive, extract, and put the binary on your{" "}
                 <code className="font-mono text-xs">PATH</code>.
               </p>
-              <Button asChild variant="outline" size="sm" className="w-full">
-                <a
-                  href={LATEST_RELEASE_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Download className="size-4" />
-                  CLI binaries
-                </a>
-              </Button>
+              <DownloadButton file={cliArchive} state={release}>
+                Download sparq CLI
+              </DownloadButton>
+              <LaunchDetails
+                bypass={
+                  <>
+                    Portable archive for <strong>{cli.label}</strong> (
+                    <code className="font-mono text-xs">.{cli.ext}</code>).
+                    Extract and run{" "}
+                    <code className="font-mono text-xs">sparq</code> — no
+                    installer, no signing dialog.
+                  </>
+                }
+                file={cliArchive}
+                state={release}
+              />
             </CardContent>
           </Card>
           <Card>
@@ -374,22 +699,27 @@ export function DownloadClient() {
                 Service Description. The desktop GUI can connect to a running
                 server in endpoint mode.
               </p>
-              <Button asChild variant="outline" size="sm" className="w-full">
-                <a
-                  href={LATEST_RELEASE_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <Download className="size-4" />
-                  Server binaries
-                </a>
-              </Button>
+              <DownloadButton file={serverArchive} state={release}>
+                Download sparq-server
+              </DownloadButton>
+              <LaunchDetails
+                bypass={
+                  <>
+                    Portable archive for <strong>{cli.label}</strong> (
+                    <code className="font-mono text-xs">.{cli.ext}</code>).
+                    Extract and run{" "}
+                    <code className="font-mono text-xs">sparq-server</code>.
+                  </>
+                }
+                file={serverArchive}
+                state={release}
+              />
             </CardContent>
           </Card>
         </div>
       </section>
 
-      {/* No-install option */}
+      {/* No-install closer */}
       <section className="space-y-3">
         <h2 className="text-xl font-semibold">No install needed</h2>
         <p className="measure text-sm text-muted-foreground">
@@ -397,12 +727,18 @@ export function DownloadClient() {
           entirely in your browser tab — nothing is uploaded, nothing is
           installed.
         </p>
-        <Button asChild variant="default" size="sm">
-          <Link href="/try">
-            Open the playground
-            <ExternalLink className="size-4" />
-          </Link>
-        </Button>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button asChild variant="default" size="sm">
+            <Link href="/try">
+              Open the playground
+              <ExternalLink className="size-4" />
+            </Link>
+          </Button>
+          <Badge variant="success" className="h-6 gap-1.5">
+            <ShieldCheck className="size-3.5" aria-hidden />
+            Runs locally — nothing uploaded
+          </Badge>
+        </div>
       </section>
     </div>
   );

--- a/site/src/app/download/page.tsx
+++ b/site/src/app/download/page.tsx
@@ -2,17 +2,18 @@ import type { Metadata } from "next";
 
 import { DownloadClient } from "./download-client";
 
-// [OPUS-4.8] sq-gl3cf / sq-ixc3 — the /download route.
+// [OPUS-4.8] sq-gl3cf / sq-ixc3 / sq-vw3ax.11 — the /download route.
 //
-// Server component: owns the route metadata; the interactive body (client-side OS
-// detection for progressive enhancement) lives in ./download-client.tsx. The page
-// links the GitHub Releases assets — the desktop GUI installers (.dmg/.msi/.AppImage)
-// plus the CLI/server binaries — and is honest that the desktop bundles are UNSIGNED
-// developer builds (signing/notarization is the separate needs:user bead sq-v286.8).
+// Server component: owns the route metadata; the interactive body lives in
+// ./download-client.tsx (client-side OS detection + one-click DIRECT per-asset
+// downloads via GitHub's version-stable `releases/latest/download/<alias>` endpoint,
+// enriched with version/size/sha256 from an unauthenticated api.github.com fetch). It is
+// honest that the desktop bundles are UNSIGNED developer builds (signing/notarization is
+// the separate needs:user bead sq-v286.8).
 export const metadata: Metadata = {
   title: "Download",
   description:
-    "Download the sparq desktop GUI (macOS/Windows/Linux) and the CLI/server binaries from the latest GitHub Release. Desktop bundles are unsigned developer builds; the web playground at /try needs no install.",
+    "Download the sparq desktop GUI (macOS/Windows/Linux) and the CLI/server binaries — one click, straight to the right file for your platform. Desktop bundles are unsigned developer builds; the web playground at /try needs no install.",
 };
 
 export default function DownloadPage() {


### PR DESCRIPTION
> 🤖 SPARQ agent (site lane, Opus 4.8 executing Fable's design). I self-identify as an automated agent working on @jeswr's behalf.

## What & why (epic sq-vw3ax.11 — direct downloads)

The `/download` buttons used to link to the **latest-release landing page** — a two-step affordance that dumps the visitor onto a wall of assets. This makes every button a **one-click DIRECT download of the right file for the visitor's platform**, using GitHub's version-stable endpoint:

```
https://github.com/jeswr/sparq/releases/latest/download/<alias>
```

GitHub 302-redirects that URL straight to the asset CDN (no interstitial) **provided the asset name is version-stable**. The button hrefs are therefore **static version-agnostic aliases** and never need a per-release site rebuild — they resolve to whatever the latest release carries the moment one ships.

## Changes (files / routes)

- **`site/src/app/download/download-client.tsx`** — rewritten:
  - **Layout** per Fable's spec: the detected platform is promoted to a **full-width primary row** ("For your Mac (Apple Silicon)" / "…Intel" / "…Windows PC" / "…Linux machine" + a big teal `Download sparq-gui.dmg · v0.x.y · <size>` button); the remaining platforms sit in a **compact grid**; then the **CLI / server** pair; then the **no-install `/try` closer** with a "runs locally — nothing uploaded" privacy chip.
  - **Metadata** (progressive enhancement): a client-side fetch of `api.github.com/repos/jeswr/sparq/releases/latest` (CORS-open, unauthenticated) enriches each card with the **version tag**, **asset byte-size**, and a **copyable sha256** — taken from the asset `digest` field the API now returns, so we never touch the CORS-blocked `SHA256SUMS` body.
  - **Graceful degradation**: a network/other failure keeps the buttons **live** (the latest/download URL needs no API); only a definitive **404** flips into the no-release state.
  - **No-release-yet state** (current reality — `/releases/latest` 404s while only pre-releases exist): every control degrades to a subdued **"No release yet — watch releases"** link — the **only** GitHub-page link retained. Flips to live direct-download buttons with **zero code change** once the first non-prerelease ships.
  - **Honesty**: the unsigned-builds banner stays **front-and-centre in both states**; no overclaiming. The desktop bundles are unsigned developer builds (signing is the separate needs:user bead sq-v286.8).
- **`site/src/app/download/page.tsx`** — refreshed route metadata/comment to describe the direct-download mechanism.
- **`site/e2e/download-page.spec.ts`** (new) — hermetic Playwright spec that **mocks the GitHub API** to exercise BOTH the no-release (404) and ready (200) states deterministically (no live-network dependency). It blocks the coi-serviceworker for this spec (the shim re-issues cross-origin fetches from inside the SW, bypassing `page.route`); the `/download` page needs no cross-origin isolation.

Route affected: `/download`. No other route touched.

## ⚠️ Required companion (out of the site-only lane)

This site change targets version-agnostic **alias** names. The release pipeline currently names assets with the version embedded (`sparq-gui_<version>_<arch>.<ext>`, `sparq-cli-<version>-<tier>.tar.gz`), which is **not** version-stable — so `releases/latest/download/<alias>` will 404 until **`release.yml` publishes the aliases** alongside the versioned ones:

- `sparq-gui-arm64-darwin.dmg`, `sparq-gui-x64-darwin.dmg`, `sparq-gui-win-x64.msi`, `sparq-gui-x64-linux.AppImage`, `sparq-gui-x64-linux.deb`
- `sparq-cli-<platform>.tar.gz` / `sparq-server-<platform>.tar.gz`
- (`SHA256SUMS` already ships.)

That is a **CI-infra-lane** change (`.github/workflows/release.yml`), outside this agent's `site/`-only staging scope, and should be tracked as a sibling bead under sq-vw3ax.11. **Live impact today is none**: `/releases/latest` 404s (only pre-releases exist), so the page renders the no-release state regardless; the alias dependency only matters the moment a non-prerelease release ships.

## Gates (all green locally)

- WASM prereq built first: `cd js && npm run build:wasm` ✅ (build artifact only, no `crates/` source staged).
- `cd site && npm install && npm run build` → **exit 0**, 58 static pages, `/download` emitted into `out/` with the alias URL baked into the static HTML.
- `npm run lint` → clean. `npx tsc --noEmit` → clean (no `any`-escape hatches).
- `npm run test:unit` → 293 passed. `npx playwright test download-page site-nav home-smoke` → all passed (incl. the existing "Download is a reachable destination" nav test).

No new dependencies (reused Button/Card/Badge/lucide/sonner; added a small clipboard-copy helper inline). basePath (`/sparq`) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)