### PR TITLE
feat(site): in-browser hero runner on home + in-browser-by-default /try redesign (sq-vw3ax.11) [OPUS-4.8]

### DIFF
--- a/site/e2e/home-smoke.spec.ts
+++ b/site/e2e/home-smoke.spec.ts
@@ -21,13 +21,13 @@ import { test, expect, type Page, type ConsoleMessage } from "@playwright/test";
 // Empty relative route → resolves to the baseURL's `/sparq/` basePath (the home page).
 const ROUTE = "";
 
-// The home page eagerly mounts the lazy in-tab REPL (`<ReplLazy>`), which pre-warms the wasm
-// engine by FETCHING `public/wasm/sparq_wasm_bg.wasm`. On the LIGHT site-e2e CI lane that bundle
-// is intentionally NOT built (no Rust toolchain), so the fetch 404s and the browser logs a bare
-// "Failed to load resource: the server responded with a status of 404 (Not Found)" console
+// The home page eagerly mounts the lazy in-tab hero runner (`HeroQueryRunner`), which pre-warms
+// the wasm engine by FETCHING `public/wasm/sparq_wasm_bg.wasm`. On the LIGHT site-e2e CI lane that
+// bundle is intentionally NOT built (no Rust toolchain), so the fetch 404s and the browser logs a
+// bare "Failed to load resource: the server responded with a status of 404 (Not Found)" console
 // error. That is the repo's documented "optional wasm — warn and skip" posture (sync-wasm.mjs),
-// NOT a product bug — the REPL surfaces a clear in-page "engine failed to load" state and the
-// SHELL we are smoke-testing (hero + nav) is unaffected. So we IGNORE that benign resource-load
+// NOT a product bug — the runner surfaces a clear in-page state and the SHELL we are smoke-testing
+// (hero + nav) is unaffected. So we IGNORE that benign resource-load
 // 404 while still catching every real client-side error (a JS throw / bad import / hydration
 // fault arrives as a `pageerror` or a NON-404 `console.error`, both of which still fail the test).
 const BENIGN_RESOURCE_404 = /Failed to load resource:.*\b404\b/i;
@@ -75,9 +75,10 @@ test("the home route renders the hero headline and the primary nav with no conso
   await gotoSettled(page, ROUTE);
 
   // The hero <h1> (server-rendered, paints with the shell). Matched on a stable substring of the
-  // headline copy rather than the whole gradient-split markup.
+  // headline copy rather than the whole gradient-split markup ("A full SPARQL engine. In this
+  // tab.").
   await expect(
-    page.getByRole("heading", { name: /state-of-the-art RDF engine/i, level: 1 }),
+    page.getByRole("heading", { name: /full SPARQL engine/i, level: 1 }),
   ).toBeVisible();
 
   // The slim top bar (the AppShell "Primary" navigation landmark) carries the six content

--- a/site/e2e/site-nav.spec.ts
+++ b/site/e2e/site-nav.spec.ts
@@ -101,11 +101,12 @@ test("the Try destination (/try) is the lightweight live REPL playground", async
   expect(new URL(page.url()).pathname).toContain("/try");
   // [OPUS-4.8] sq-vw3ax — the /try redesign moved the page-identity heading out of the heavy,
   // lazily-loaded REPL card (the old `<h2>Live SPARQL REPL</h2>`) into a server-rendered hero
-  // `<h1>` that paints with the route shell. Assert that hero heading (matched by a stable
-  // substring) — it confirms /try IS the SPARQL playground destination without waiting on the
-  // wasm REPL chunk to stream in.
+  // `<h1>` ("Your SPARQL workbench.") that paints with the route shell. That deliberate copy
+  // (distinct from the home hero, see try/page.tsx) is the page identity; assert it by a stable
+  // substring — it confirms /try IS the SPARQL workbench/playground destination without waiting
+  // on the wasm REPL chunk to stream in.
   await expect(
-    page.getByRole("heading", { name: /SPARQL playground/i }),
+    page.getByRole("heading", { name: /SPARQL workbench/i }),
   ).toBeVisible();
 });
 

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -1,21 +1,19 @@
 import Link from "next/link";
 
-// [OPUS-4.8] sq-vw3ax.5 — the BOLD homepage redesign, built on the merged dark-first
-// foundation (#1261) and faithful to the approved mockup
-// (sparq-design-system/proposals/web-home.html). It reimagines the landing as:
-//   1. an atmospheric teal HERO (.bg-atmos/.bg-grid + .text-gradient .display-1 headline +
-//      mono .kicker rhythm) with a four-stat STRUCTURAL strip (count-badge style figures);
-//   2. the live-REPL "moment" — the heavy <ReplLazy> framed (USED AS-IS; the /try redesign
-//      owns the REPL internals) as the killer artifact, immediately after the hero;
+// [OPUS-4.8] sq-vw3ax.11 — the homepage, with the SPLIT hero making the in-browser runner the
+// hero artifact (the full REPL workbench, which was duplicated with /try, is REMOVED from home).
+// The landing is now:
+//   1. a SPLIT atmospheric HERO — text on the left, a lightweight LIVE in-browser runner
+//      (HeroQueryRunner) on the right, so Run is in-fold (≤3 interactions to a live result);
+//   2. a slim four-stat STRUCTURAL band under the hero (StatBand);
 //   3. the bold "See it work" flagship showcase (the real FLAGSHIPS) and the five capability
 //      THEME cards with per-surface honesty-tier dots; and
 //   4. the "How it runs" honesty strip — the tier legend + a "How tiers work" <details>.
 //
 // REAL DATA / HONESTY (load-bearing): every figure is a STRUCTURAL fact derived from the
 // single GROUPS/FLAGSHIPS source (data/surfaces.ts) or a query-form/format list — NOT a
-// performance/timing claim and NOT fabricated. The REPL's results come from the real engine
-// at runtime; nothing here hardcodes a result row, triple count, or timing.
-import { ReplLazy } from "@/components/repl-lazy";
+// performance/timing claim and NOT fabricated. The hero runner's results come from the real
+// engine at runtime; nothing here hardcodes a result row, triple count, or timing.
 import { Badge } from "@/components/ui/badge";
 import {
   FLAGSHIPS,
@@ -25,6 +23,7 @@ import {
   type Tier,
 } from "@/data/surfaces";
 import { Hero } from "@/components/home/hero";
+import { StatBand } from "@/components/home/stat-band";
 import { SectionHeader } from "@/components/home/section-header";
 import { FlagshipCard } from "@/components/home/flagship-card";
 import { CapabilityCard } from "@/components/home/capability-card";
@@ -45,24 +44,11 @@ const TIER_LEGEND: { tier: Tier; note: string }[] = [
 export default function HomePage() {
   return (
     <div className="space-y-20">
-      {/* 1 — Hero: atmospheric ground, gradient display headline, structural stat strip. */}
-      <Hero />
-
-      {/* 2 — The live REPL: the killer artifact, framed. ReplLazy is used AS-IS. */}
-      <section id="repl" className="scroll-mt-20 space-y-5">
-        <SectionHeader
-          kicker="The killer artifact"
-          title="A live SPARQL REPL — real engine, real graph, real results"
-          note="Edit the query, pick an example, hit Run. The lean wasm bundle parses the sample Turtle and answers in-tab."
-        />
-        <ReplLazy />
-        <p className="text-xs text-muted-foreground">
-          This REPL loads the lean sparq wasm bundle and runs your SPARQL against
-          the sample graph using the real Rust engine — the same code that ships as{" "}
-          <code className="font-mono text-foreground">@jeswr/sparq</code>. Nothing
-          is sent to a server.
-        </p>
-      </section>
+      {/* 1 — Split hero + slim stat band (the band sits close under the hero, one visual group). */}
+      <div className="space-y-6">
+        <Hero />
+        <StatBand />
+      </div>
 
       {/* 3 — See it work: the real flagship showcases, large. */}
       <section className="space-y-6">

--- a/site/src/app/try/page.tsx
+++ b/site/src/app/try/page.tsx
@@ -1,15 +1,14 @@
-import * as React from "react";
 import type { Metadata } from "next";
 
-// [OPUS-4.8] sq-vw3ax (bold /try redesign) — the playground page becomes a teal-forward
-// IDE workbench on top of the merged dark-first foundation (globals.css tokens
-// --hero-grad / --teal-glow / --elevation-*, utilities .bg-atmos / .text-gradient /
-// .display-2 / .kicker). The hero strip states the SAME honest claims as before — the real
-// Rust engine compiled to WebAssembly, running in-tab — but with flagship-product confidence
-// instead of a docs intro. The heavy REPL workbench itself is code-split (repl-lazy.tsx) so the
-// hero/shell paint before the wasm engine streams in. Faithful to
-// sparq-design-system/proposals/web-try.html; every result/stat below the hero comes from REAL
-// query execution against the real sample datasets (no illustrative figures).
+// [OPUS-4.8] sq-vw3ax.11 — /try stays IN-BROWSER-BY-DEFAULT and makes that legible with a SLIM,
+// distinct header (fixing the copy duplication with the home hero). The home page now owns the
+// marketing "A full SPARQL engine. In this tab." pitch + a lightweight in-fold runner; /try is
+// the WORKBENCH — a tooling-voice header short enough that the editor + Run are above the fold on
+// a laptop, then the full IDE workbench. The teal-forward foundation (globals.css tokens
+// --hero-grad / --teal-glow / --elevation-*, utilities .bg-atmos / .text-gradient / .display-2 /
+// .kicker) is unchanged; the heavy REPL workbench is code-split (repl-lazy.tsx) so the header
+// paints before the wasm engine streams in. Every result below comes from REAL query execution
+// against the real sample datasets (no illustrative figures).
 import { ReplLazy } from "@/components/repl-lazy";
 
 export const metadata: Metadata = {
@@ -18,66 +17,34 @@ export const metadata: Metadata = {
     "Run real SPARQL queries with the sparq engine compiled to WebAssembly — live in your browser tab by default — or connect the same editor to a running sparq-server over the SPARQL 1.1 Protocol.",
 };
 
-// The capability pills carry the ACTUAL supported surface — the same honest claims the prose
-// made, stated as a flagship product. Kept as data so the hero markup stays scannable.
-const FORM_PILLS = ["SELECT", "ASK", "CONSTRUCT", "DESCRIBE", "UPDATE"];
-
 export default function TryPage() {
   return (
-    <div className="space-y-8">
+    <div className="space-y-6">
       {/* Atmospheric ground — the foundation's fixed, layered teal/cyan glow + masked grid.
           Opt-in (a page must mount it), so un-redesigned routes are unaffected. Inert to
           pointer events; sits behind all content. */}
       <div className="bg-atmos" aria-hidden="true" />
       <div className="bg-grid" aria-hidden="true" />
 
-      {/* ── Teal-forward hero strip ─────────────────────────────────────────────────── */}
-      <header className="relative pt-2">
-        <span className="kicker inline-flex items-center gap-2 rounded-full border border-primary/30 bg-primary/10 px-3 py-1.5 normal-case tracking-[0.14em]">
-          <span
-            className="size-1.5 rounded-full bg-[var(--success)] shadow-[0_0_0_4px_color-mix(in_oklch,var(--success)_18%,transparent)]"
-            aria-hidden="true"
-          />
-          WebAssembly · in-tab · nothing leaves the page
-        </span>
-
-        <h1 className="display-2 mt-5 font-semibold">
-          The SPARQL playground that runs the{" "}
-          <span className="text-gradient">real Rust engine</span>, live in your tab.
+      {/* ── Slim workbench header (distinct from the home hero; keeps editor + Run above the fold). */}
+      <header className="relative pt-1">
+        <p className="kicker text-primary">Workbench</p>
+        <h1 className="display-2 mt-2 font-semibold">
+          Your SPARQL workbench.{" "}
+          <span className="text-gradient">No install.</span>
         </h1>
-
-        <p className="measure mt-4 text-[15.5px] leading-relaxed text-muted-foreground">
-          Edit the query, pick a dataset, hit{" "}
-          <span className="font-medium text-foreground">Run</span> — every query executes
-          against the in-tab store using the actual sparq engine compiled to{" "}
-          <span className="font-medium text-foreground">WebAssembly</span>. The lean bundle
-          ships the parser, triplestore and full SPARQL 1.1 / 1.2 engine. Switch to{" "}
-          <span className="font-medium text-foreground">EXPLAIN / ANALYZE</span> to read the
-          plan, or <span className="font-medium text-foreground">Connect</span> the same editor
-          to a running sparq-server.
+        <p className="measure mt-3 text-[15px] leading-relaxed text-muted-foreground">
+          Load Turtle / TriG / JSON-LD, run{" "}
+          <span className="font-medium text-foreground">SELECT / CONSTRUCT / UPDATE</span> on the
+          real Rust engine in your tab, and inspect the query plan with{" "}
+          <span className="font-medium text-foreground">EXPLAIN</span>. Nothing leaves this tab
+          unless you connect a server.
         </p>
-
-        <div className="mt-5 flex flex-wrap items-center gap-2">
-          <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card/80 px-3 py-1.5 text-xs font-medium text-muted-foreground">
-            {FORM_PILLS.map((form, i) => (
-              <React.Fragment key={form}>
-                {i > 0 && <span aria-hidden="true">·</span>}
-                <code className="font-mono text-foreground">{form}</code>
-              </React.Fragment>
-            ))}
-          </span>
-          <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card/80 px-3 py-1.5 text-xs font-medium text-muted-foreground">
-            BGP · FILTER · OPTIONAL · UNION · MINUS · BIND · VALUES · paths · sub-SELECT
-          </span>
-          <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card/80 px-3 py-1.5 text-xs font-medium text-muted-foreground">
-            RDF&nbsp;1.2 triple terms
-          </span>
-        </div>
       </header>
 
       {/* ── The IDE workbench (3-pane). Heavy + wasm-backed, so code-split behind a skeleton.
-          Owns the editor, the run/EXPLAIN/ANALYZE toolbar, the typed results table + plan-tree,
-          the dataset / workspace / graphs rail, and the Connect strip. ───────────────────── */}
+          Owns the editor, the Run split-button, the typed results table + plan-tree, the
+          dataset / workspace / graphs rail, and the Advanced · Connect drawer. ───────────────── */}
       <ReplLazy />
     </div>
   );

--- a/site/src/components/home/hero-runner-lazy.tsx
+++ b/site/src/components/home/hero-runner-lazy.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+// [OPUS-4.8] sq-vw3ax.11 — the CODE-SPLIT boundary for the home hero's in-browser runner.
+//
+// The HeroQueryRunner pulls in the SPARQL/RDF editors and the `@sparq/client` query surface, and
+// it pre-warms the wasm engine. Static-importing it would put all of that on the home route's
+// first-load bundle and block the hero from painting. `next/dynamic({ ssr: false })` moves it into
+// its own async chunk fetched AFTER the hero shell renders; the runner's pre-warm then fires on
+// THIS chunk's hydration (see hero-runner.tsx), so the ~300 kB engine wasm never competes with the
+// initial paint. A server component cannot call `dynamic(ssr:false)` directly in the App Router,
+// so this thin "use client" wrapper owns the split.
+//
+// The loading placeholder is a STATIC PREVIEW (not a skeleton): it mirrors the runner's idle state
+// — the same dimmed expected-answer table under a "Preview — press Run" pill — so the swap to the
+// live runner is seamless and there is no skeleton flash on the hero (the design's load-bearing
+// "fixes CTA→skeleton" rule).
+
+import dynamic from "next/dynamic";
+
+import { cn } from "@/lib/utils";
+import { HERO_RESULT_VARS, HERO_PREVIEW_ROWS } from "@/data/hero-sample";
+
+/** A non-interactive static twin of the runner's idle state — no wasm, no client state. */
+function HeroRunnerFallback() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="Loading the in-browser SPARQL runner"
+      className="overflow-hidden rounded-xl border border-primary/25 bg-card shadow-elevation-2"
+    >
+      <div className="flex items-center gap-1 border-b bg-muted/25 px-2 py-1.5">
+        <span className="rounded-md bg-background px-3 py-1 text-xs font-medium text-foreground shadow-sm">
+          Query
+        </span>
+        <span className="rounded-md px-3 py-1 text-xs font-medium text-muted-foreground">
+          Data
+        </span>
+        <span className="ml-auto pr-1 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+          in-browser SPARQL
+        </span>
+      </div>
+      <div className="p-3">
+        <div className="h-[13.5rem] rounded-lg border bg-muted/40" />
+      </div>
+      <div className="relative border-t bg-background/40">
+        <table className="w-full border-collapse text-[13px] opacity-45">
+          <thead>
+            <tr className="border-b">
+              {HERO_RESULT_VARS.map((v, i) => (
+                <th
+                  key={v}
+                  className={cn(
+                    "px-3 py-2 font-mono text-xs font-medium text-primary",
+                    i === 0 ? "text-left" : "text-right",
+                  )}
+                >
+                  ?{v}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {HERO_PREVIEW_ROWS.map((r) => (
+              <tr key={r.name} className="border-b border-border/50 last:border-0">
+                <td className="px-3 py-1.5">
+                  <span className="sq-tok-string">&quot;{r.name}&quot;</span>
+                </td>
+                <td className="px-3 py-1.5 text-right tabular">
+                  <span className="sq-tok-number">{r.linesOfRust}</span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <span className="rounded-full border border-border bg-card/90 px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm">
+            Preview — press Run to compute it live in your tab
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const HeroQueryRunner = dynamic(
+  () => import("@/components/home/hero-runner").then((m) => m.HeroQueryRunner),
+  { ssr: false, loading: () => <HeroRunnerFallback /> },
+);
+
+/** The code-split entry point the (server) home hero renders. */
+export function HeroQueryRunnerLazy() {
+  return <HeroQueryRunner />;
+}

--- a/site/src/components/home/hero-runner.tsx
+++ b/site/src/components/home/hero-runner.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+// [OPUS-4.8] sq-vw3ax.11 — the HOME hero's in-browser SPARQL runner (the landing page's hero
+// artifact). It replaces the heavy full REPL that used to be duplicated on the home page: a
+// LIGHTWEIGHT runner that fits in-fold on the right of the split hero — a two-tab editor
+// (Query | Data, both editable so the sample is inspectable), a big teal Run button bound to
+// Ctrl/Cmd+Enter, and a typed results table below. The full workbench lives at /try; "Open in
+// workbench →" hands the current query + data off there (src/lib/try-handoff.ts).
+//
+// HONESTY (load-bearing). The idle state is an explicit, dimmed PREVIEW of the expected answer
+// behind a "Preview — press Run to compute it live in your tab" pill — never a fake skeleton and
+// never presented as a computed result. When the visitor presses Run, the REAL Rust engine
+// (compiled to wasm) parses the sample Turtle and evaluates the join + SUM + ORDER BY in-tab; the
+// footer's "N results · <t> ms · in-browser · 0 network requests" is measured, not illustrative.
+// Nothing here is sent to a server (the engine runs entirely in the tab).
+//
+// WARM-UP (fixes the CTA→skeleton jank). The wasm engine pre-warms on this lazy chunk's
+// hydration (prewarmSparqWhenIdle, an idle-slot fetch), and any pointerdown/focus inside the
+// panel eagerly kicks loadSparq(). Run NEVER blocks on warmth — it awaits the (memoised) load, so
+// a first Run before warm-up finishes simply shows a one-time "Starting engine…" substate.
+
+import * as React from "react";
+import { useRouter } from "next/navigation";
+import { Play, Loader2, ArrowRight, ShieldCheck } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { SparqlEditor } from "@/components/sparql-editor";
+import { RdfEditor } from "@/components/rdf-editor";
+import { ResultCell } from "@/components/repl-result-cells";
+import {
+  loadSparq,
+  loadIntoStore,
+  prewarmSparqWhenIdle,
+  type SparqlResults,
+  type SparqlTerm,
+} from "@/lib/sparq-wasm";
+import {
+  HERO_SAMPLE_TURTLE,
+  HERO_SAMPLE_FORMAT,
+  HERO_DEFAULT_QUERY,
+  HERO_RESULT_VARS,
+  HERO_PREVIEW_ROWS,
+} from "@/data/hero-sample";
+import { writeHandoff } from "@/lib/try-handoff";
+
+const XSD = "http://www.w3.org/2001/XMLSchema#";
+const NUMERIC_XSD = new Set(
+  ["integer", "decimal", "double", "float", "long", "int", "short", "nonNegativeInteger", "positiveInteger"].map(
+    (t) => XSD + t,
+  ),
+);
+
+/** Whether a term is a numeric literal — used to right-align a numeric result column. */
+function isNumericTerm(t: SparqlTerm | undefined): boolean {
+  return (
+    !!t &&
+    t.type === "literal" &&
+    typeof t.datatype === "string" &&
+    NUMERIC_XSD.has(t.datatype) &&
+    Number.isFinite(Number(t.value))
+  );
+}
+
+/** The first non-empty line of an engine error (keeps the compact strip to one line + any col). */
+function firstErrorLine(err: unknown): string {
+  const msg = err instanceof Error ? err.message : String(err);
+  const line = msg.split("\n").find((l) => l.trim().length > 0);
+  return (line ?? msg).trim();
+}
+
+type RunnerPhase = "idle" | "running" | "done" | "error";
+
+/** A tiny typed results table: columns from `head.vars`, teal-mono IRIs + right-aligned numerics. */
+function ResultsTable({
+  results,
+  dimmed,
+}: {
+  results: SparqlResults;
+  dimmed?: boolean;
+}) {
+  const vars = React.useMemo(() => results.head?.vars ?? [], [results]);
+  const rows = React.useMemo(() => results.results?.bindings ?? [], [results]);
+  // A column is numeric when every bound cell in it is a numeric literal (so we right-align it).
+  const numericVar = React.useMemo(() => {
+    const m: Record<string, boolean> = {};
+    for (const v of vars) {
+      let sawBound = false;
+      let allNumeric = true;
+      for (const row of rows) {
+        const t = row[v];
+        if (!t) continue;
+        sawBound = true;
+        if (!isNumericTerm(t)) allNumeric = false;
+      }
+      m[v] = sawBound && allNumeric;
+    }
+    return m;
+  }, [vars, rows]);
+
+  return (
+    <table
+      className={cn("w-full border-collapse text-[13px]", dimmed && "opacity-45")}
+      data-hero-results-table
+    >
+      <thead>
+        <tr className="border-b">
+          {vars.map((v) => (
+            <th
+              key={v}
+              className={cn(
+                "px-3 py-2 font-mono text-xs font-medium text-primary",
+                numericVar[v] ? "text-right" : "text-left",
+              )}
+            >
+              ?{v}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((row, i) => (
+          <tr key={i} className="border-b border-border/50 last:border-0">
+            {vars.map((v) => (
+              <td
+                key={v}
+                className={cn("px-3 py-1.5", numericVar[v] && "text-right tabular")}
+              >
+                <ResultCell term={row[v]} />
+              </td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+/** The dimmed PREVIEW table (idle state): the expected answer, honestly labelled — not computed. */
+function PreviewTable() {
+  return (
+    <table className="w-full border-collapse text-[13px] opacity-45" aria-hidden="true">
+      <thead>
+        <tr className="border-b">
+          {HERO_RESULT_VARS.map((v, i) => (
+            <th
+              key={v}
+              className={cn(
+                "px-3 py-2 font-mono text-xs font-medium text-primary",
+                i === 0 ? "text-left" : "text-right",
+              )}
+            >
+              ?{v}
+            </th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {HERO_PREVIEW_ROWS.map((r) => (
+          <tr key={r.name} className="border-b border-border/50 last:border-0">
+            <td className="px-3 py-1.5">
+              <span className="sq-tok-string">&quot;{r.name}&quot;</span>
+            </td>
+            <td className="px-3 py-1.5 text-right tabular">
+              <span className="sq-tok-number">{r.linesOfRust}</span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export function HeroQueryRunner() {
+  const router = useRouter();
+  const [tab, setTab] = React.useState<"query" | "data">("query");
+  const [query, setQuery] = React.useState(HERO_DEFAULT_QUERY);
+  const [data, setData] = React.useState(HERO_SAMPLE_TURTLE);
+
+  const [phase, setPhase] = React.useState<RunnerPhase>("idle");
+  const [results, setResults] = React.useState<SparqlResults | null>(null);
+  const [ms, setMs] = React.useState<number | null>(null);
+  const [error, setError] = React.useState<string | null>(null);
+  const [engineReady, setEngineReady] = React.useState(false);
+
+  // WARM-UP 1: pre-warm on this lazy chunk's hydration, on the next browser-idle slot so it never
+  // competes with paint. Cancelled on unmount if it has not fired yet.
+  React.useEffect(() => {
+    const handle = prewarmSparqWhenIdle({ onReady: () => setEngineReady(true) });
+    return () => handle.cancel();
+  }, []);
+
+  // WARM-UP 2: any pointer/focus inside the panel eagerly kicks the (memoised) load — the visitor
+  // is clearly about to interact, so warm now rather than wait for the idle slot.
+  const eagerWarm = React.useCallback(() => {
+    if (engineReady) return;
+    void loadSparq().then(
+      () => setEngineReady(true),
+      () => {},
+    );
+  }, [engineReady]);
+
+  const run = React.useCallback(async () => {
+    setPhase("running");
+    setError(null);
+    const started = performance.now();
+    try {
+      // Run NEVER blocks on warmth — it awaits the memoised load, joining any in-flight prewarm.
+      const Store = await loadSparq();
+      setEngineReady(true);
+      // Rebuild the store from the (possibly edited) Data tab each run, so editing data is live.
+      const store = loadIntoStore(Store, data, HERO_SAMPLE_FORMAT);
+      const json = store.query(query);
+      const parsed = JSON.parse(json) as SparqlResults;
+      setResults(parsed);
+      setMs(performance.now() - started);
+      setPhase("done");
+    } catch (err) {
+      // Keep the previous output visible (dimmed) — the error strip sits above it, not instead.
+      setError(firstErrorLine(err));
+      setPhase("error");
+    }
+  }, [data, query]);
+
+  // Errors clear on edit (the strip is cleared and the phase reverts to whatever the last output
+  // was) — editing the query/data is the natural "try again" gesture.
+  const onQueryChange = React.useCallback(
+    (next: string) => {
+      setQuery(next);
+      if (error !== null) {
+        setError(null);
+        setPhase(results ? "done" : "idle");
+      }
+    },
+    [error, results],
+  );
+  const onDataChange = React.useCallback(
+    (next: string) => {
+      setData(next);
+      if (error !== null) {
+        setError(null);
+        setPhase(results ? "done" : "idle");
+      }
+    },
+    [error, results],
+  );
+
+  // Ctrl/Cmd+Enter runs from anywhere in the panel (the editors' textareas bubble the keydown).
+  const onKeyDown = React.useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault();
+        if (phase !== "running") void run();
+      }
+    },
+    [phase, run],
+  );
+
+  const openInWorkbench = React.useCallback(() => {
+    writeHandoff({ query, data, format: HERO_SAMPLE_FORMAT });
+    router.push("/try");
+  }, [data, query, router]);
+
+  const running = phase === "running";
+  const rowCount = results?.results?.bindings?.length ?? 0;
+
+  return (
+    <div
+      onKeyDownCapture={onKeyDown}
+      onPointerDown={eagerWarm}
+      onFocusCapture={eagerWarm}
+      className="overflow-hidden rounded-xl border border-primary/25 bg-card shadow-elevation-2"
+      style={{ boxShadow: "var(--elevation-2), 0 0 0 1px var(--teal-glow)" }}
+    >
+      {/* Tabs: Query (default) | Data — both editable, so the sample is inspectable. */}
+      <div
+        role="tablist"
+        aria-label="Runner editor"
+        className="flex items-center gap-1 border-b bg-muted/25 px-2 py-1.5"
+      >
+        {(["query", "data"] as const).map((t) => (
+          <button
+            key={t}
+            type="button"
+            role="tab"
+            aria-selected={tab === t}
+            onClick={() => setTab(t)}
+            className={cn(
+              "rounded-md px-3 py-1 text-xs font-medium capitalize transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40",
+              tab === t
+                ? "bg-background text-foreground shadow-sm"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {t === "query" ? "Query" : "Data"}
+          </button>
+        ))}
+        <span className="ml-auto pr-1 font-mono text-[10px] uppercase tracking-[0.12em] text-muted-foreground">
+          in-browser SPARQL
+        </span>
+      </div>
+
+      {/* Editors. Both mounted; the inactive one is hidden (not unmounted) so edits persist. */}
+      <div className="p-3">
+        <div className={cn(tab === "query" ? "block" : "hidden")}>
+          <label htmlFor="hero-query" className="sr-only">
+            SPARQL query
+          </label>
+          <SparqlEditor
+            id="hero-query"
+            ariaLabel="SPARQL query"
+            value={query}
+            onChange={onQueryChange}
+            rows={8}
+          />
+        </div>
+        <div className={cn(tab === "data" ? "block" : "hidden")}>
+          <label htmlFor="hero-data" className="sr-only">
+            Sample data (Turtle)
+          </label>
+          <RdfEditor
+            id="hero-data"
+            ariaLabel="Sample data (Turtle)"
+            value={data}
+            onChange={onDataChange}
+            rows={8}
+          />
+        </div>
+      </div>
+
+      {/* Bottom bar: privacy chip (left) + big teal Run button (right). */}
+      <div className="flex flex-wrap items-center gap-3 border-t bg-muted/15 px-3 py-2.5">
+        <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+          <ShieldCheck className="size-3.5 text-[var(--success)]" aria-hidden />
+          runs in your browser · nothing is sent to a server
+        </span>
+        <Button
+          onClick={() => void run()}
+          disabled={running}
+          size="lg"
+          className="ml-auto bg-[var(--hero-grad)] text-primary-foreground shadow-elevation-glow hover:opacity-95"
+        >
+          {running ? (
+            <Loader2 className="size-4 animate-spin" aria-hidden />
+          ) : (
+            <Play className="size-4" aria-hidden />
+          )}
+          Run
+          <kbd className="ml-1 hidden rounded border border-primary-foreground/30 px-1 text-[10px] font-medium sm:inline-block">
+            ⌘↵
+          </kbd>
+        </Button>
+      </div>
+
+      {/* Error strip — compact destructive token, between editor and results. */}
+      {phase === "error" && error && (
+        <div
+          role="alert"
+          className="flex items-start gap-2 border-t border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
+        >
+          <span className="font-mono">{error}</span>
+        </div>
+      )}
+
+      {/* Results area. */}
+      <div className="relative border-t bg-background/40" data-hero-results>
+        <div className="overflow-x-auto">
+          {phase === "idle" ? (
+            <PreviewTable />
+          ) : results ? (
+            <ResultsTable results={results} dimmed={running || phase === "error"} />
+          ) : (
+            <PreviewTable />
+          )}
+        </div>
+
+        {/* Idle overlay pill — honesty as the hook (never a skeleton, no timing footer). */}
+        {phase === "idle" && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+            <span className="rounded-full border border-border bg-card/90 px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm">
+              Preview — press Run to compute it live in your tab
+            </span>
+          </div>
+        )}
+
+        {/* Running overlay — spinner + first-run-only "Starting engine…" substate. */}
+        {running && (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-background/40">
+            <span className="inline-flex items-center gap-2 rounded-full border border-border bg-card/90 px-3 py-1.5 text-xs font-medium text-muted-foreground shadow-sm">
+              <Loader2 className="size-3.5 animate-spin" aria-hidden />
+              {engineReady ? "Running…" : "Starting engine… (first run only)"}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Proof footer — only in the results state (the real, measured proof line). */}
+      {phase === "done" && ms !== null && (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 border-t bg-muted/15 px-3 py-2 font-mono text-[11px] text-muted-foreground">
+          <span aria-live="polite">
+            {rowCount} result{rowCount === 1 ? "" : "s"} · {ms.toFixed(1)} ms · in-browser · 0
+            network requests
+          </span>
+          <button
+            type="button"
+            onClick={openInWorkbench}
+            className="ml-auto inline-flex items-center gap-1 rounded text-primary outline-none hover:underline focus-visible:ring-3 focus-visible:ring-ring/40"
+          >
+            Open in workbench <ArrowRight className="size-3" aria-hidden />
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/site/src/components/home/hero-runner.tsx
+++ b/site/src/components/home/hero-runner.tsx
@@ -108,6 +108,7 @@ function ResultsTable({
           {vars.map((v) => (
             <th
               key={v}
+              scope="col"
               className={cn(
                 "px-3 py-2 font-mono text-xs font-medium text-primary",
                 numericVar[v] ? "text-right" : "text-left",
@@ -145,6 +146,7 @@ function PreviewTable() {
           {HERO_RESULT_VARS.map((v, i) => (
             <th
               key={v}
+              scope="col"
               className={cn(
                 "px-3 py-2 font-mono text-xs font-medium text-primary",
                 i === 0 ? "text-left" : "text-right",
@@ -281,9 +283,11 @@ export function HeroQueryRunner() {
         {(["query", "data"] as const).map((t) => (
           <button
             key={t}
+            id={`hero-tab-${t}`}
             type="button"
             role="tab"
             aria-selected={tab === t}
+            aria-controls={`hero-panel-${t}`}
             onClick={() => setTab(t)}
             className={cn(
               "rounded-md px-3 py-1 text-xs font-medium capitalize transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40",
@@ -302,7 +306,12 @@ export function HeroQueryRunner() {
 
       {/* Editors. Both mounted; the inactive one is hidden (not unmounted) so edits persist. */}
       <div className="p-3">
-        <div className={cn(tab === "query" ? "block" : "hidden")}>
+        <div
+          id="hero-panel-query"
+          role="tabpanel"
+          aria-labelledby="hero-tab-query"
+          className={cn(tab === "query" ? "block" : "hidden")}
+        >
           <label htmlFor="hero-query" className="sr-only">
             SPARQL query
           </label>
@@ -314,7 +323,12 @@ export function HeroQueryRunner() {
             rows={8}
           />
         </div>
-        <div className={cn(tab === "data" ? "block" : "hidden")}>
+        <div
+          id="hero-panel-data"
+          role="tabpanel"
+          aria-labelledby="hero-tab-data"
+          className={cn(tab === "data" ? "block" : "hidden")}
+        >
           <label htmlFor="hero-data" className="sr-only">
             Sample data (Turtle)
           </label>

--- a/site/src/components/home/hero.tsx
+++ b/site/src/components/home/hero.tsx
@@ -1,163 +1,66 @@
-// [OPUS-4.8] sq-vw3ax.5 — the bold homepage HERO, faithful to the approved mockup
-// (sparq-design-system/proposals/web-home.html `.hero`). Built from the merged dark-first
-// foundation utilities (.bg-atmos / .bg-grid / .display-1 / .text-gradient / .kicker) and
-// the count-badge variant — NO new hue, NO globals.css edit. The atmospheric ground is
-// mounted here, page-scoped (the utilities are fixed/inset:0/z-index:-1, so they layer
-// behind the AppShell content without touching the shell chrome).
+// [OPUS-4.8] sq-vw3ax.11 — the SPLIT homepage hero: text on the left, the LIVE in-browser runner
+// on the right. This makes the in-tab runner the hero artifact (Run is now in-fold, ≤3
+// interactions to a live result), replacing the old full-REPL "moment" that was duplicated with
+// /try. Built on the merged dark-first foundation (.bg-atmos / .bg-grid / .display-1 /
+// .text-gradient / .kicker) — NO new hue, NO globals.css edit. The atmospheric ground is mounted
+// here, page-scoped (fixed/inset:0/z-index:-1, behind all content).
 //
-// REAL DATA / HONESTY: the four structural stats are STRUCTURAL FACTS, not performance
-// claims — the SPARQL query forms + RDF text formats the engine ships, the surface count
-// derived from the single GROUPS source (data/surfaces.ts), and "0 servers" (the engine
-// runs in-tab). No number is fabricated or a timing/throughput claim.
+// The old "Run a query now" scroll-CTA is gone: Run itself is in-fold in the runner card, so the
+// two hero CTAs are just "Open the full workbench →" (/try) and "GitHub". The four-cell stat strip
+// moved to a slim band under the hero (StatBand). No performance/timing claim anywhere here.
 
 import Link from "next/link";
-import { Boxes, Cpu, Github, Play, ShieldCheck } from "lucide-react";
+import { ArrowRight, Github } from "lucide-react";
 
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { ALL_SURFACES, GROUPS } from "@/data/surfaces";
-import { RDF_TEXT_FORMATS } from "@/data/home-facts";
+import { HeroQueryRunnerLazy } from "@/components/home/hero-runner-lazy";
 
 const REPO_URL = "https://github.com/jeswr/sparq";
 
-// Derived from the single IA source so the headline counts can never drift from the nav,
-// the capability gallery, or Cmd-K. (No literal "16"/"5" hardcoded here.)
-const SURFACE_COUNT = ALL_SURFACES.length;
-const THEME_COUNT = GROUPS.length;
-const FORMAT_COUNT = RDF_TEXT_FORMATS.length;
-
-interface Stat {
-  /** The leading number/value (mono, the `--primary` accent unit lives in `unit`). */
-  value: string;
-  unit?: string;
-  /** Whether the value should render after the unit (e.g. "4 formats"). */
-  unitLeads?: boolean;
-  label: string;
-}
-
-const STATS: Stat[] = [
-  {
-    value: "SPARQL",
-    unit: "1.1/1.2",
-    label: "SELECT · ASK · CONSTRUCT · DESCRIBE · UPDATE",
-  },
-  {
-    value: "formats",
-    unit: String(FORMAT_COUNT),
-    unitLeads: true,
-    label: RDF_TEXT_FORMATS.join(" · "),
-  },
-  {
-    value: "surfaces",
-    unit: String(SURFACE_COUNT),
-    unitLeads: true,
-    label: `across ${THEME_COUNT} capability themes`,
-  },
-  {
-    value: "servers",
-    unit: "0",
-    unitLeads: true,
-    label: "the engine runs entirely in your tab",
-  },
-];
-
 export function Hero() {
   return (
-    <section className="relative -mt-8 pb-2 pt-10 md:-mt-10 md:pt-14">
+    <section className="relative -mt-8 pb-2 pt-8 md:-mt-10 md:pt-12">
       {/* Atmospheric ground — mounted page-scoped. Fixed + inert, behind all content. */}
       <div className="bg-atmos" aria-hidden />
       <div className="bg-grid" aria-hidden />
 
-      <Badge
-        variant="success"
-        className="h-7 gap-2 rounded-full px-3 text-[0.78rem]"
-      >
-        <span
-          className="size-1.5 animate-pulse rounded-full bg-[var(--success)]"
-          aria-hidden
-        />
-        The live REPL below runs in your browser tab — nothing is sent to a server
-      </Badge>
+      <div className="grid items-center gap-8 lg:grid-cols-12 lg:gap-10">
+        {/* LEFT (~5/12): kicker, gradient headline, one-line sub-lede, exactly two CTAs. */}
+        <div className="lg:col-span-5">
+          <p className="kicker text-primary">In-browser SPARQL</p>
 
-      <h1 className="display-1 mt-5 max-w-[17ch] font-semibold">
-        A state-of-the-art RDF engine,{" "}
-        <span className="text-gradient">running live in your browser tab.</span>
-      </h1>
+          <h1 className="display-1 mt-4 max-w-[15ch] font-semibold">
+            A full SPARQL engine.{" "}
+            <span className="text-gradient">In this tab.</span>
+          </h1>
 
-      <p className="mt-5 max-w-[56ch] text-lg leading-relaxed text-muted-foreground">
-        sparq is a SOTA Rust triplestore and SPARQL 1.1/1.2 engine, compiled to
-        WebAssembly. The same code ships as{" "}
-        <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-[0.92em] text-foreground">
-          @jeswr/sparq
-        </code>{" "}
-        — streaming cursors, property paths, RDF 1.2 triple terms — and answers
-        your queries in-tab, on the real engine.
-      </p>
+          <p className="mt-5 max-w-[46ch] text-lg leading-relaxed text-muted-foreground">
+            A state-of-the-art Rust triplestore and SPARQL 1.1/1.2 engine, compiled to
+            WebAssembly — it answers your query right here, on the real engine, with nothing
+            sent to a server.
+          </p>
 
-      <div className="mt-7 flex flex-wrap gap-3">
-        <Button asChild size="lg">
-          <Link href="#repl">
-            <Play className="size-4" aria-hidden />
-            Run a query now
-          </Link>
-        </Button>
-        <Button asChild size="lg" variant="outline">
-          <a href={REPO_URL} target="_blank" rel="noopener noreferrer">
-            <Github className="size-4" aria-hidden />
-            GitHub
-          </a>
-        </Button>
-      </div>
-
-      <div className="mt-6 flex flex-wrap gap-2 text-sm text-muted-foreground">
-        <Pill icon={Cpu} text="Rust core → WebAssembly" />
-        <Pill icon={Boxes} text="RDF/JS @jeswr/sparq API" />
-        <Pill icon={ShieldCheck} text="ZK + MPC privacy surfaces" />
-      </div>
-
-      {/* Structural stat strip — a single hairline-divided grid, mono figures. */}
-      <dl
-        className="mt-11 grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border ring-1 ring-foreground/10 md:grid-cols-4"
-        aria-label="What the engine answers in-tab"
-      >
-        {STATS.map((stat) => (
-          <div
-            key={stat.label}
-            className="bg-[color-mix(in_oklch,var(--card)_80%,var(--background))] px-5 py-4"
-          >
-            <dt className="block font-mono text-2xl font-semibold tracking-tight">
-              {stat.unitLeads ? (
-                <>
-                  <span className="text-primary">{stat.unit}</span> {stat.value}
-                </>
-              ) : (
-                <>
-                  {stat.value}{" "}
-                  {stat.unit ? (
-                    <span className="text-primary">{stat.unit}</span>
-                  ) : null}
-                </>
-              )}
-            </dt>
-            <dd className="mt-1 text-xs text-muted-foreground">{stat.label}</dd>
+          <div className="mt-7 flex flex-wrap gap-3">
+            <Button asChild size="lg">
+              <Link href="/try">
+                Open the full workbench
+                <ArrowRight className="size-4" aria-hidden />
+              </Link>
+            </Button>
+            <Button asChild size="lg" variant="ghost">
+              <a href={REPO_URL} target="_blank" rel="noopener noreferrer">
+                <Github className="size-4" aria-hidden />
+                GitHub
+              </a>
+            </Button>
           </div>
-        ))}
-      </dl>
-    </section>
-  );
-}
+        </div>
 
-function Pill({
-  icon: Icon,
-  text,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  text: string;
-}) {
-  return (
-    <span className="inline-flex items-center gap-1.5 rounded-full border bg-card px-3 py-1.5">
-      <Icon className="size-3.5 text-primary" aria-hidden />
-      {text}
-    </span>
+        {/* RIGHT (~7/12): the live in-browser runner (code-split, ssr:false) on the atmos ground. */}
+        <div className="lg:col-span-7">
+          <HeroQueryRunnerLazy />
+        </div>
+      </div>
+    </section>
   );
 }

--- a/site/src/components/home/stat-band.tsx
+++ b/site/src/components/home/stat-band.tsx
@@ -1,0 +1,82 @@
+// [OPUS-4.8] sq-vw3ax.11 — the slim structural stat band that sits UNDER the split hero.
+//
+// The four-cell stat strip used to live inside the hero; the hero is now a split "text + live
+// runner" layout, so the strip moves down here as a slim band. Same content, same single IA
+// source — no number is a performance/timing claim.
+//
+// REAL DATA / HONESTY: every figure is a STRUCTURAL fact derived from the canonical IA source
+// (SPARQL query forms + RDF text formats the engine ships, the surface/theme counts from
+// data/surfaces.ts, and "0 servers" — the engine runs in-tab). Nothing is fabricated.
+
+import { ALL_SURFACES, GROUPS } from "@/data/surfaces";
+import { RDF_TEXT_FORMATS } from "@/data/home-facts";
+
+// Derived from the single IA source so the counts can never drift from the nav / gallery / Cmd-K.
+const SURFACE_COUNT = ALL_SURFACES.length;
+const THEME_COUNT = GROUPS.length;
+const FORMAT_COUNT = RDF_TEXT_FORMATS.length;
+
+interface Stat {
+  /** The leading number/value (mono, the `--primary` accent unit lives in `unit`). */
+  value: string;
+  unit?: string;
+  /** Whether the value should render after the unit (e.g. "4 formats"). */
+  unitLeads?: boolean;
+  label: string;
+}
+
+const STATS: Stat[] = [
+  {
+    value: "SPARQL",
+    unit: "1.1/1.2",
+    label: "SELECT · ASK · CONSTRUCT · DESCRIBE · UPDATE",
+  },
+  {
+    value: "formats",
+    unit: String(FORMAT_COUNT),
+    unitLeads: true,
+    label: RDF_TEXT_FORMATS.join(" · "),
+  },
+  {
+    value: "surfaces",
+    unit: String(SURFACE_COUNT),
+    unitLeads: true,
+    label: `across ${THEME_COUNT} capability themes`,
+  },
+  {
+    value: "servers",
+    unit: "0",
+    unitLeads: true,
+    label: "the engine runs entirely in your tab",
+  },
+];
+
+export function StatBand() {
+  return (
+    <dl
+      className="grid grid-cols-2 gap-px overflow-hidden rounded-xl bg-border ring-1 ring-foreground/10 md:grid-cols-4"
+      aria-label="What the engine answers in-tab"
+    >
+      {STATS.map((stat) => (
+        <div
+          key={stat.label}
+          className="bg-[color-mix(in_oklch,var(--card)_80%,var(--background))] px-5 py-4"
+        >
+          <dt className="block font-mono text-2xl font-semibold tracking-tight">
+            {stat.unitLeads ? (
+              <>
+                <span className="text-primary">{stat.unit}</span> {stat.value}
+              </>
+            ) : (
+              <>
+                {stat.value}{" "}
+                {stat.unit ? <span className="text-primary">{stat.unit}</span> : null}
+              </>
+            )}
+          </dt>
+          <dd className="mt-1 text-xs text-muted-foreground">{stat.label}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -19,10 +19,12 @@ import {
   FolderOpen,
   FilePlus2,
   Save,
+  ChevronDown,
 } from "lucide-react";
+import { DropdownMenu } from "radix-ui";
 import { toast } from "sonner";
 
-import { Button } from "@/components/ui/button";
+import { Button, buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
 // [OPUS-4.8] sq-vw3ax (bold /try redesign) — the local IDE-workbench panel chrome + the
@@ -48,6 +50,9 @@ import {
   type WasmStore,
 } from "@/lib/sparq-wasm";
 import { downloadText } from "@/lib/download";
+// [OPUS-4.8] sq-vw3ax.11 — consume the home → /try handoff (a query + optional dataset handed
+// from the home hero's in-browser runner, via sessionStorage or a shareable /try#q=<…> link).
+import { consumeHandoff, decodeQueryHash } from "@/lib/try-handoff";
 import {
   classifyQueryForm,
   isGraphForm,
@@ -231,16 +236,38 @@ export function Repl() {
   React.useEffect(() => {
     let cancelled = false;
     setEngine("warming");
+    // [OPUS-4.8] sq-vw3ax.11 — consume a home → /try handoff EXACTLY ONCE on mount: the
+    // sessionStorage payload (read + cleared) takes precedence, else a shareable `/try#q=<…>`
+    // link. When present it preloads the editor query and — if the handoff carried a dataset —
+    // loads THAT into the store instead of the default, so "Open in workbench →" continues the
+    // exact home-runner state. No handoff = the historical default dataset, unchanged.
+    const handoff =
+      consumeHandoff() ??
+      (typeof window !== "undefined" ? decodeQueryHash(window.location.hash) : null);
+    if (handoff) setSparql(handoff.query);
+    const initialData =
+      handoff?.data != null
+        ? { text: handoff.data, format: handoff.format ?? "turtle", fromHandoff: true }
+        : { text: DEFAULT_DATASET.text, format: DEFAULT_DATASET.format, fromHandoff: false };
     const handle = prewarmSparqWhenIdle({
       onReady: () => {
         if (cancelled || storeRef.current) {
           if (!cancelled) setEngine("ready");
           return;
         }
-        // The engine is ready; build the default dataset off the render path, then mark ready.
-        buildStore(DEFAULT_DATASET.text, DEFAULT_DATASET.format)
+        // The engine is ready; build the initial dataset off the render path, then mark ready.
+        buildStore(initialData.text, initialData.format)
           .then(() => {
-            if (!cancelled) setEngine("ready");
+            if (cancelled) return;
+            if (initialData.fromHandoff) {
+              // The handoff dataset is a custom in-tab load, not a built-in — reflect that.
+              setActiveBuiltinId(null);
+              setActive({
+                label: "Shared query dataset",
+                description: "Loaded from a shared query link, in your tab.",
+              });
+            }
+            setEngine("ready");
           })
           .catch((e) => {
             if (cancelled) return;
@@ -1096,7 +1123,16 @@ export function Repl() {
             </Badge>
           }
         >
-          <div className="p-3.5">
+          <div
+            className="p-3.5"
+            onKeyDown={(e) => {
+              // [OPUS-4.8] sq-vw3ax.11 — Ctrl/Cmd+Enter runs the query (the keyboard spine).
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                e.preventDefault();
+                if (!busy) void runWithMode("run");
+              }
+            }}
+          >
             <label htmlFor="repl-query" className="sr-only">
               SPARQL query
             </label>
@@ -1110,25 +1146,23 @@ export function Repl() {
           </div>
         </ReplPanel>
 
+        {/* [OPUS-4.8] sq-vw3ax.11 — Run is the SOLE primary action. The Run / EXPLAIN / ANALYZE
+            toolbar collapses into ONE split-button: the big teal "Run query" (Ctrl/Cmd+Enter) plus
+            a ▾ menu for EXPLAIN / EXPLAIN ANALYZE (feeding the same plan-tree views). The status-bar
+            chip states the engine posture — "in-browser" by default, or the connected host. */}
         <div className="flex flex-wrap items-center gap-3">
-          <Button
-            onClick={() => void run()}
-            disabled={busy}
-            className="bg-[var(--hero-grad)] text-primary-foreground shadow-elevation-glow hover:opacity-95"
-          >
-            {busy ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : (
-              <Play className="size-4" />
-            )}
-            {mode === "run" ? "Run query" : "Run EXPLAIN"}
-          </Button>
-          <ModeTabs
-            mode={mode}
-            onChange={setMode}
-            disabled={busy}
+          <RunSplitButton
+            busy={busy}
             form={form}
             endpointMode={endpointActive}
+            onRun={() => void runWithMode("run")}
+            onExplain={() => void runWithMode("explain")}
+            onAnalyze={() => void runWithMode("analyze")}
+          />
+          <EngineChip
+            endpointActive={endpointActive}
+            endpointUrl={endpointConfig.url}
+            onDisconnect={() => setEndpointActive(false)}
           />
           <p
             aria-live="polite"
@@ -1137,13 +1171,6 @@ export function Repl() {
             {statusLine}
           </p>
         </div>
-
-        <ConnectPanel
-          config={endpointConfig}
-          onConfigChange={setEndpointConfig}
-          active={endpointActive}
-          onActiveChange={setEndpointActive}
-        />
       </main>
 
       {/* ── RIGHT: results + EXPLAIN plan-tree + mini-viz ──────────────────────────────── */}
@@ -1156,18 +1183,42 @@ export function Repl() {
           <ResultPanel state={state} statusLine={statusLine} />
         </ReplPanel>
 
-        {/* [OPUS-4.8] sq-9ij6 — the live subscriptions view. Only meaningful in endpoint
-            mode (it streams from a real, mutating server's /subscriptions/sse), so it
-            renders an honest "switch on endpoint mode" hint otherwise. It reuses the SAME
-            endpoint config + bearer/connection-safety posture the Connect panel established. */}
-        <SubscriptionsView config={endpointConfig} active={endpointActive} />
+        {/* [OPUS-4.8] sq-vw3ax.11 / sq-9ij6 — the live subscriptions view mounts ONLY in endpoint
+            mode (it streams from a real, mutating server's /subscriptions/sse — off the workbench
+            there is nothing to subscribe to, so the panel never mounts and never clutters the
+            default in-browser view). */}
+        {endpointActive && (
+          <SubscriptionsView config={endpointConfig} active={endpointActive} />
+        )}
 
-        {/* [OPUS-4.8] sq-he72 — the server health / capabilities panel. Reads the connected
-            server's /health, Prometheus /metrics, and the opt-in VoID / SPARQL Service
-            Description, rendering "not exposed" honestly when the operator left a feature off.
-            Like the subscriptions view, it only runs in endpoint mode and reuses the SAME
-            endpoint config + bearer/connection-safety posture. */}
-        <ServerHealthPanel config={endpointConfig} active={endpointActive} />
+        {/* [OPUS-4.8] sq-vw3ax.11 — the remote endpoint is DEMOTED, never required. It lives in a
+            collapsed "Advanced" disclosure at the bottom of the right rail; the URL field, protocol
+            notes and (when connected) the server-health panel render ONLY inside the expanded
+            drawer. Disconnected (the default) shows no endpoint input anywhere. */}
+        <details className="group overflow-hidden rounded-lg border bg-card shadow-elevation-2">
+          <summary className="flex cursor-pointer select-none items-center gap-2 border-b bg-muted/25 px-3.5 py-3 text-[11.5px] font-semibold uppercase tracking-[0.08em] text-muted-foreground outline-none focus-visible:ring-3 focus-visible:ring-ring/40">
+            <PlugZap className="size-3.5 text-primary" aria-hidden />
+            Advanced · Connect to a sparq-server
+            <ChevronDown
+              className="ml-auto size-3.5 transition-transform group-open:rotate-180"
+              aria-hidden
+            />
+          </summary>
+          <div className="space-y-4 p-3.5">
+            <ConnectPanel
+              config={endpointConfig}
+              onConfigChange={setEndpointConfig}
+              active={endpointActive}
+              onActiveChange={setEndpointActive}
+            />
+            {/* [OPUS-4.8] sq-he72 — server health / capabilities: /health, Prometheus /metrics, and
+                the opt-in VoID / SPARQL Service Description. Only when connected (nothing to read
+                otherwise), and only inside this drawer. */}
+            {endpointActive && (
+              <ServerHealthPanel config={endpointConfig} active={endpointActive} />
+            )}
+          </div>
+        </details>
       </section>
 
       <DatasetViewer
@@ -1209,76 +1260,138 @@ function EngineIndicator({ engine }: { engine: EngineState }) {
 // [OPUS-4.8] sq-xe4f — EXPLAIN / ANALYZE drive the query planner, which rejects SPARQL
 // Update forms, so those tabs are grayed (disabled + aria-disabled) when the editor
 // holds an Update example. The decision is the pure `modeSupportsForm` predicate.
-function ModeTabs({
-  mode,
-  onChange,
-  disabled,
+// [OPUS-4.8] sq-vw3ax.11 — the Run split-button: Run is the SOLE primary action, so the old
+// Run/EXPLAIN/ANALYZE tab strip collapses into ONE control. The big teal primary always executes
+// the query in run mode (label kept exactly "Run query" — Ctrl/Cmd+Enter), and the ▾ menu offers
+// EXPLAIN / EXPLAIN ANALYZE, which feed the SAME plan-tree views. EXPLAIN/ANALYZE are an in-tab
+// planner introspection, so they are disabled in endpoint mode or for a query form that cannot
+// plan (an Update); ANALYZE additionally needs a SELECT/ASK.
+function RunSplitButton({
+  busy,
   form,
   endpointMode,
+  onRun,
+  onExplain,
+  onAnalyze,
 }: {
-  mode: RunMode;
-  onChange: (m: RunMode) => void;
-  disabled: boolean;
+  busy: boolean;
   form: QueryForm;
-  // [OPUS-4.8] sq-2mke — in endpoint mode EXPLAIN / ANALYZE are unavailable (they drive
-  // the in-tab WASM planner, not the remote server), so those tabs are grayed.
   endpointMode: boolean;
+  onRun: () => void;
+  onExplain: () => void;
+  onAnalyze: () => void;
 }) {
-  const tabs: { value: RunMode; label: string; title: string }[] = [
-    { value: "run", label: "Run", title: "Execute the query / update" },
-    {
-      value: "explain",
-      label: "EXPLAIN",
-      title: "Show the query plan without executing it",
-    },
-    {
-      value: "analyze",
-      label: "ANALYZE",
-      title: "Show the plan and execute it with a per-operator trace (SELECT/ASK)",
-    },
-  ];
+  const explainDisabled = endpointMode || !modeSupportsForm("explain", form);
+  const analyzeDisabled = endpointMode || !modeSupportsForm("analyze", form);
+  const menuDisabled = busy || (explainDisabled && analyzeDisabled);
   return (
-    <div
-      role="tablist"
-      aria-label="Run mode"
-      className="inline-flex rounded-lg border bg-muted/40 p-0.5"
-    >
-      {tabs.map((t) => {
-        // Gray out a mode the current query form cannot use (EXPLAIN/ANALYZE on an
-        // Update). The engine still validates — this only stops the user picking a
-        // mode that would parse-error. EXPLAIN/ANALYZE are also unavailable in endpoint
-        // mode (an in-tab planner introspection, not a protocol operation).
-        const planMode = t.value !== "run";
-        const unsupported = !modeSupportsForm(t.value, form) || (endpointMode && planMode);
-        const tabDisabled = disabled || unsupported;
-        return (
+    <div className="inline-flex">
+      <Button
+        onClick={onRun}
+        disabled={busy}
+        className="rounded-r-none bg-[var(--hero-grad)] text-primary-foreground shadow-elevation-glow hover:opacity-95"
+      >
+        {busy ? (
+          <Loader2 className="size-4 animate-spin" aria-hidden />
+        ) : (
+          <Play className="size-4" aria-hidden />
+        )}
+        Run query
+      </Button>
+      <DropdownMenu.Root>
+        {/* A NATIVE button (not the <Button> function component) so radix's asChild ref attaches
+            cleanly to a DOM node; styled with the shared buttonVariants so it matches the primary. */}
+        <DropdownMenu.Trigger asChild>
           <button
-            key={t.value}
             type="button"
-            role="tab"
-            aria-selected={mode === t.value}
-            aria-disabled={unsupported}
-            title={
-              endpointMode && planMode
-                ? `${t.label} runs the in-tab WASM planner — switch to In-tab WASM to use it`
-                : unsupported
-                  ? `${t.label} is unavailable for SPARQL Update — it plans a query`
-                  : t.title
-            }
-            disabled={tabDisabled}
-            onClick={() => onChange(t.value)}
+            aria-label="More run options"
+            disabled={menuDisabled}
             className={cn(
-              "rounded-md px-2.5 py-1 text-xs font-medium transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40 disabled:opacity-50 disabled:cursor-not-allowed",
-              mode === t.value
-                ? "bg-background text-foreground shadow-sm"
-                : "text-muted-foreground hover:text-foreground",
+              buttonVariants(),
+              "rounded-l-none border-l border-primary-foreground/25 bg-[var(--hero-grad)] px-2 text-primary-foreground shadow-elevation-glow hover:opacity-95",
             )}
           >
-            {t.label}
+            <ChevronDown className="size-4" aria-hidden />
           </button>
-        );
-      })}
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            align="start"
+            sideOffset={6}
+            className="z-50 min-w-[15rem] rounded-lg border bg-card p-1 text-sm text-card-foreground shadow-elevation-2"
+          >
+            <DropdownMenu.Item
+              disabled={explainDisabled}
+              onSelect={onExplain}
+              className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-1.5 outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+            >
+              <Telescope className="size-4 text-primary" aria-hidden />
+              <span className="flex flex-col">
+                <span className="font-medium">Run EXPLAIN</span>
+                <span className="text-xs text-muted-foreground">
+                  Show the query plan without executing it
+                </span>
+              </span>
+            </DropdownMenu.Item>
+            <DropdownMenu.Item
+              disabled={analyzeDisabled}
+              onSelect={onAnalyze}
+              className="flex cursor-pointer items-center gap-2 rounded-md px-2.5 py-1.5 outline-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 data-[highlighted]:bg-accent data-[highlighted]:text-accent-foreground"
+            >
+              <Gauge className="size-4 text-primary" aria-hidden />
+              <span className="flex flex-col">
+                <span className="font-medium">Run EXPLAIN ANALYZE</span>
+                <span className="text-xs text-muted-foreground">
+                  Plan + execute with a per-operator trace (SELECT/ASK)
+                </span>
+              </span>
+            </DropdownMenu.Item>
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </DropdownMenu.Root>
     </div>
+  );
+}
+
+// [OPUS-4.8] sq-vw3ax.11 — the status-bar engine chip. Disconnected (the default) states the
+// in-browser posture; connected flips to the remote host + a one-click disconnect (which reverts
+// to the in-tab WASM engine without losing editor state).
+function EngineChip({
+  endpointActive,
+  endpointUrl,
+  onDisconnect,
+}: {
+  endpointActive: boolean;
+  endpointUrl: string;
+  onDisconnect: () => void;
+}) {
+  if (!endpointActive) {
+    return (
+      <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card/80 px-3 py-1.5 text-xs font-medium text-muted-foreground">
+        <CheckCircle2 className="size-3.5 text-[var(--success)]" aria-hidden />
+        Engine: in-browser · nothing leaves this tab
+      </span>
+    );
+  }
+  let host = endpointUrl;
+  try {
+    host = new URL(endpointUrl).host;
+  } catch {
+    // keep the raw string if it is not a parseable URL
+  }
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-primary/40 bg-primary/10 px-3 py-1.5 text-xs font-medium text-foreground">
+      <PlugZap className="size-3.5 text-primary" aria-hidden />
+      Remote: <span className="font-mono">{host}</span>
+      <span className="size-1.5 rounded-full bg-[var(--success)]" aria-hidden />
+      <button
+        type="button"
+        onClick={onDisconnect}
+        className="ml-1 rounded text-muted-foreground underline-offset-2 outline-none hover:text-foreground hover:underline focus-visible:ring-3 focus-visible:ring-ring/40"
+      >
+        Disconnect
+      </button>
+    </span>
   );
 }
 

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -205,6 +205,15 @@ export function Repl() {
   const [workspaceBusy, setWorkspaceBusy] = React.useState(false);
   // Guards the one-shot startup re-hydration so it runs at most once per mount.
   const rehydratedRef = React.useRef(false);
+  // [OPUS-4.8] sq-vw3ax.11 fix — tracks the dataset that the component was asked to load on
+  // mount (either the handoff payload or DEFAULT_DATASET). `ensureStore` reads from this ref
+  // so that clicking "Run query" before `prewarmSparqWhenIdle` fires still loads the correct
+  // dataset (handoff or default) rather than always falling back to DEFAULT_DATASET.
+  const initialDataRef = React.useRef<{
+    text: string;
+    format: string;
+    fromHandoff: boolean;
+  }>({ text: DEFAULT_DATASET.text, format: DEFAULT_DATASET.format, fromHandoff: false });
 
   // Build (or rebuild) the store from RDF text + format. Centralises error handling so
   // every load path (default, picker, upload, URL) reports failures the same way.
@@ -249,6 +258,9 @@ export function Repl() {
       handoff?.data != null
         ? { text: handoff.data, format: handoff.format ?? "turtle", fromHandoff: true }
         : { text: DEFAULT_DATASET.text, format: DEFAULT_DATASET.format, fromHandoff: false };
+    // Persist for the `ensureStore` fallback so a "Run query" before idle warm-up uses the
+    // same dataset (handoff or default) rather than always falling back to DEFAULT_DATASET.
+    initialDataRef.current = initialData;
     const handle = prewarmSparqWhenIdle({
       onReady: () => {
         if (cancelled || storeRef.current) {
@@ -293,13 +305,20 @@ export function Repl() {
 
   // Guarantees a store exists before a query runs — the safety net if pre-warm hasn't
   // finished (or failed): never lets "Run query" no-op or throw on a cold engine.
+  // Uses `initialDataRef` (not DEFAULT_DATASET) so a handoff dataset is respected even when
+  // the user clicks Run before `prewarmSparqWhenIdle` has fired.
   const ensureStore = React.useCallback(async (): Promise<WasmStore> => {
     if (storeRef.current) return storeRef.current;
     setEngine("warming");
-    const store = await buildStore(
-      DEFAULT_DATASET.text,
-      DEFAULT_DATASET.format,
-    );
+    const { text, format, fromHandoff } = initialDataRef.current;
+    const store = await buildStore(text, format);
+    if (fromHandoff) {
+      setActiveBuiltinId(null);
+      setActive({
+        label: "Shared query dataset",
+        description: "Loaded from a shared query link, in your tab.",
+      });
+    }
     setEngine("ready");
     return store;
   }, [buildStore]);

--- a/site/src/data/hero-sample.ts
+++ b/site/src/data/hero-sample.ts
@@ -1,0 +1,70 @@
+// [OPUS-4.8] sq-vw3ax.11 — the HOME hero in-browser runner's sample graph + default query.
+//
+// This is the data behind the home page's HeroQueryRunner (src/components/home/hero-runner.tsx):
+// a tiny, self-contained Turtle graph and a default SELECT that JOINS three relations
+// (person → name, person → component, component → line count), AGGREGATES with SUM, and SORTS
+// DESC. That shape is the whole honesty point: a join + group-by-sum + order-by result cannot be
+// credibly faked by a static site, so when the visitor presses Run and sees these three rows
+// computed in-tab, they are watching the real Rust engine (compiled to wasm) actually evaluate.
+//
+// REAL DATA / HONESTY (load-bearing): the graph is real Turtle parsed by the wasm Store and the
+// result rows are produced by the engine at runtime. The `PREVIEW_ROWS` below are the EXPECTED
+// answer, shown dimmed with an explicit "Preview — press Run to compute it live" pill in the idle
+// state; they are never presented as a computed/live result and carry no timing. No number here
+// is a performance/benchmark claim.
+
+/**
+ * The sample graph: three contributors (`:ada` / `:grace` / `:lin`) who each `:wrote` one or
+ * more engine `:Component`s, and each component's `:linesOfCode` + `:lang "Rust"`. Small on
+ * purpose (marketing density) but real — `:ada` wrote TWO components, so her summed total leads
+ * the sort, which makes the SUM visibly load-bearing (not just a row-per-person passthrough).
+ */
+export const HERO_SAMPLE_TURTLE = `@prefix :     <http://sparq.dev/demo/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+:ada   foaf:name "Ada" ;
+       :wrote :parser, :planner .
+:grace foaf:name "Grace" ;
+       :wrote :optimizer .
+:lin   foaf:name "Lin" ;
+       :wrote :storage .
+
+:parser    a :Component ; :linesOfCode 4200 ; :lang "Rust" .
+:planner   a :Component ; :linesOfCode 3100 ; :lang "Rust" .
+:optimizer a :Component ; :linesOfCode 5300 ; :lang "Rust" .
+:storage   a :Component ; :linesOfCode 6100 ; :lang "Rust" .
+`;
+
+/** The wasm engine's RDF format string for {@link HERO_SAMPLE_TURTLE}. */
+export const HERO_SAMPLE_FORMAT = "turtle";
+
+/**
+ * The prefilled default query: sum each contributor's lines of Rust across every component
+ * they wrote, then rank. Joins `foaf:name` + `:wrote` + `:linesOfCode`, groups by name, orders
+ * by the summed total descending — three rows, each visibly the product of a join + aggregate.
+ */
+export const HERO_DEFAULT_QUERY = `PREFIX :     <http://sparq.dev/demo/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+SELECT ?name (SUM(?loc) AS ?linesOfRust) WHERE {
+  ?dev       foaf:name     ?name .
+  ?dev       :wrote        ?component .
+  ?component :linesOfCode  ?loc .
+}
+GROUP BY ?name
+ORDER BY DESC(?linesOfRust)`;
+
+/** The variable names the default query projects, in `head.vars` order. */
+export const HERO_RESULT_VARS = ["name", "linesOfRust"] as const;
+
+/**
+ * The EXPECTED answer, shown dimmed as an honest PREVIEW before the visitor runs the query (Ada
+ * 4200+3100=7300, Lin 6100, Grace 5300). Rendered behind a "Preview — press Run to compute it
+ * live in your tab" pill; never presented as a computed result. Kept beside the query so a drift
+ * between the two is obvious in review — the live engine remains the source of truth at runtime.
+ */
+export const HERO_PREVIEW_ROWS: { name: string; linesOfRust: number }[] = [
+  { name: "Ada", linesOfRust: 7300 },
+  { name: "Lin", linesOfRust: 6100 },
+  { name: "Grace", linesOfRust: 5300 },
+];

--- a/site/src/global-css.d.ts
+++ b/site/src/global-css.d.ts
@@ -1,0 +1,13 @@
+// [OPUS-4.8] sq-vw3ax.11 — ambient declaration for GLOBAL CSS side-effect imports.
+//
+// Next.js declares `*.module.css` / `*.module.sass` / `*.module.scss` (CSS Modules) in its own
+// `next/types/global.d.ts`, but NOT a bare `*.css`. A GLOBAL stylesheet imported for its side
+// effect — `import "./globals.css"` in `app/layout.tsx` — has no bindings, so historically TS
+// simply did not type-check it. Under TypeScript's `noUncheckedSideEffectImports` (which newer
+// TS defaults ON), that same side-effect import errors TS2882 without an ambient module for it.
+//
+// This one-line declaration makes the global CSS import resolvable regardless of that flag —
+// harmless on older TypeScript (the module is simply unused) and forward-compatible with newer
+// TypeScript. It declares only bare `*.css`; the more specific `*.module.css` (with its typed
+// class map) still comes from Next's own declaration.
+declare module "*.css";

--- a/site/src/lib/try-handoff.ts
+++ b/site/src/lib/try-handoff.ts
@@ -82,7 +82,10 @@ function toBase64Url(json: string): string {
 /** base64url (no padding) → UTF-8. Throws on malformed input (the caller catches). */
 function fromBase64Url(b64url: string): string {
   const b64 = b64url.replace(/-/g, "+").replace(/_/g, "/");
-  const binary = atob(b64);
+  // [OPUS-4.8] restore `=` padding stripped by toBase64Url so atob() doesn't throw on lengths that
+  // are not a multiple of 4 (e.g. a 10-char base64url → 10%4=2 → needs "==" appended).
+  const padded = b64 + "=".repeat((4 - (b64.length % 4)) % 4);
+  const binary = atob(padded);
   const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
   return new TextDecoder().decode(bytes);
 }

--- a/site/src/lib/try-handoff.ts
+++ b/site/src/lib/try-handoff.ts
@@ -1,0 +1,108 @@
+// [OPUS-4.8] sq-vw3ax.11 — the HOME → /try handoff channel.
+//
+// The home page's HeroQueryRunner is a lightweight in-fold runner; "Open in workbench →" hands
+// the current query + sample data off to the full /try workbench so the visitor continues where
+// they left off. Two mechanisms, both client-only and static-export safe (no server):
+//
+//   1. sessionStorage['sparq:handoff'] — the primary path. The runner WRITES the payload, then
+//      navigates to /try; the workbench CONSUMES (reads + clears) it on mount. sessionStorage is
+//      same-tab and cleared when the tab closes, so it never leaks a stale query across sessions.
+//   2. /try#q=<base64url> — a shareable-link fallback. The payload is encoded as base64url JSON
+//      in the URL hash, so a copied /try#q=… link reopens the same query/data on any tab.
+//
+// Nothing here touches the network: the payload never leaves the browser. This is the site's
+// "runs in your tab" posture — the handoff is tab-local plumbing, not a request.
+
+/** The sessionStorage key the home runner writes and the /try workbench consumes. */
+export const HANDOFF_STORAGE_KEY = "sparq:handoff";
+
+/** A query (+ optional dataset) handed from the home runner to the /try workbench. */
+export interface TryHandoff {
+  /** The SPARQL query text to preload into the editor. */
+  query: string;
+  /** The dataset text to load into the in-tab store (Turtle etc.). Omitted = keep the default. */
+  data?: string;
+  /** The engine RDF format string for `data` (e.g. "turtle"). Defaults to "turtle". */
+  format?: string;
+}
+
+/** Narrow an unknown parsed value to a {@link TryHandoff} (a non-empty query string is required). */
+function asHandoff(value: unknown): TryHandoff | null {
+  if (typeof value !== "object" || value === null) return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.query !== "string" || v.query.length === 0) return null;
+  return {
+    query: v.query,
+    data: typeof v.data === "string" ? v.data : undefined,
+    format: typeof v.format === "string" ? v.format : undefined,
+  };
+}
+
+/**
+ * Write a handoff payload into sessionStorage. No-op (never throws) outside a browser or when
+ * storage is unavailable (private-mode quota) — the caller still navigates to /try, which simply
+ * opens with its own default in that case.
+ */
+export function writeHandoff(payload: TryHandoff): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.setItem(HANDOFF_STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Storage disabled/full — the handoff is best-effort; ignore.
+  }
+}
+
+/**
+ * Read AND clear the sessionStorage handoff (single-use). Returns the payload or `null` when
+ * there is none / it is malformed. Clearing on read is what makes it a one-shot: a later reload
+ * of /try does not re-consume a query the visitor has moved on from.
+ */
+export function consumeHandoff(): TryHandoff | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.sessionStorage.getItem(HANDOFF_STORAGE_KEY);
+    if (raw === null) return null;
+    window.sessionStorage.removeItem(HANDOFF_STORAGE_KEY);
+    return asHandoff(JSON.parse(raw));
+  } catch {
+    return null;
+  }
+}
+
+// ── base64url JSON codec for the /try#q=<…> shareable-link fallback ────────────────────────────
+
+/** UTF-8 → base64url (no padding), the URL-hash-safe alphabet. Browser-only. */
+function toBase64Url(json: string): string {
+  const bytes = new TextEncoder().encode(json);
+  let binary = "";
+  for (const b of bytes) binary += String.fromCharCode(b);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** base64url (no padding) → UTF-8. Throws on malformed input (the caller catches). */
+function fromBase64Url(b64url: string): string {
+  const b64 = b64url.replace(/-/g, "+").replace(/_/g, "/");
+  const binary = atob(b64);
+  const bytes = Uint8Array.from(binary, (c) => c.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}
+
+/** Encode a handoff payload as the base64url JSON used in a `/try#q=<…>` shareable link. */
+export function encodeQueryHash(payload: TryHandoff): string {
+  return toBase64Url(JSON.stringify(payload));
+}
+
+/**
+ * Decode a `#q=<base64url>` location hash into a handoff payload, or `null` when the hash is
+ * absent / not a `#q=` fragment / malformed. Accepts the raw `location.hash` (with or without the
+ * leading `#`).
+ */
+export function decodeQueryHash(hash: string): TryHandoff | null {
+  const h = hash.startsWith("#") ? hash.slice(1) : hash;
+  if (!h.startsWith("q=")) return null;
+  try {
+    return asHandoff(JSON.parse(fromBase64Url(h.slice(2))));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — running as **Opus 4.8** executing Fable's design spec for epic **sq-vw3ax.11** (HOME + /try in-browser runner). Scope strictly `site/`.

## What this does

### HOME — the in-browser runner becomes the hero artifact
- The heavy full REPL workbench (which was **duplicated** with `/try`) is **removed** from home and replaced by a new lightweight, code-split **`HeroQueryRunner`** (`ssr:false`).
- **Split hero** at `lg+`: left = `.kicker` "In-browser SPARQL" + `.display-1 .text-gradient` headline "A full SPARQL engine. In this tab." + one-line sub-lede + exactly two CTAs ("Open the full workbench →" `/try` primary; "GitHub" ghost). The old "Run a query now" scroll-CTA is gone — Run is now in-fold.
- Right = an elevation-2 card with a teal glow: two editable tabs **Query | Data** (shared `SparqlEditor` / `RdfEditor`, ~8 lines), a privacy chip "runs in your browser · nothing is sent to a server", and a large teal-gradient **Run** button bound to **Ctrl/Cmd+Enter**.
- **States:** idle = dimmed, honestly-labelled **PREVIEW** of the expected answer behind a "Preview — press Run to compute it live in your tab" pill (never a skeleton); running = Run disabled + spinner, with a first-run-only "Starting engine… (first run only)" substate; results = typed table (right-aligned numerics, teal-mono IRIs) with a **measured** proof footer `N results · <t> ms · in-browser · 0 network requests` + "Open in workbench →"; error = compact destructive strip between editor and results, previous output dimmed not blanked, cleared on edit.
- **Default query** joins `foaf:name` + `:wrote` + `:linesOfCode`, `SUM` grouped by name, `ORDER BY DESC` → 3 rows (Ada 7300 / Lin 6100 / Grace 5300) — a join+aggregate+sort that can't be credibly faked by a static site.
- **Warm-up:** `prewarmSparqWhenIdle` fires on the lazy chunk's hydration; any pointerdown/focus in the panel eagerly calls `loadSparq()`. Run never blocks on warmth.
- **Handoff:** "Open in workbench →" writes `{query,data,format}` to `sessionStorage['sparq:handoff']` then navigates to `/try` (consumed + cleared on mount); a `/try#q=<base64url>` shareable-link fallback is also supported.
- The four-cell stat strip moves to a slim **`StatBand`** under the hero; flagship + capability + "how it runs" sections keep their content/order.

### TRY — in-browser-by-default, made legible
- **Slim distinct header** (`WORKBENCH` kicker + `.display-2` "Your SPARQL workbench. No install." + a tooling-voice sub-line) — fixes the copy duplication with home and keeps editor+Run above the fold.
- **Run split-button:** the Run/EXPLAIN/ANALYZE toolbar collapses into one **"Run ▾"** — primary = **Run query** (Ctrl/Cmd+Enter), the ▾ menu runs EXPLAIN / EXPLAIN ANALYZE into the existing plan-tree views.
- **Remote endpoint demoted:** `ConnectPanel` leaves the centre column into a collapsed **"Advanced · Connect to a sparq-server"** disclosure at the bottom of the right rail. Disconnected (default): no endpoint input visible; status-bar chip "Engine: in-browser · nothing leaves this tab". Connected: chip flips to "Remote: `<host>` ●" + Disconnect (reverts to WASM, editor state kept).
- **Declutter:** `SubscriptionsView` + `ServerHealthPanel` mount **only when connected** (empty panels never mount); `ServerHealthPanel` lives inside the Advanced drawer.
- Consumes the home handoff (`sparq:handoff` / `#q=`).

## Files
- New: `site/src/components/home/hero-runner.tsx`, `hero-runner-lazy.tsx`, `stat-band.tsx`; `site/src/data/hero-sample.ts`; `site/src/lib/try-handoff.ts`; `site/src/global-css.d.ts`.
- Edited: `site/src/components/home/hero.tsx`, `site/src/app/page.tsx`, `site/src/app/try/page.tsx`, `site/src/components/repl.tsx`, `site/e2e/home-smoke.spec.ts` (headline regex → new copy).

## Gates (run once, locally)
- **WASM prereq built:** `cd js && npm run build:wasm` → synced into `site/public/wasm/`.
- `cd site && npm run build` — **green**, static export emits **58 pages** incl. `/` and `/try` into `out/`.
- `next lint` — **clean** (no warnings/errors). `tsc --noEmit` — **clean**.
- e2e (chromium): `home-smoke` + `command-palette` + `try-query-smoke` + `repl-results` = **8/8 pass** (zero console errors).

## Honesty / data labelling
- The hero sample graph + preview rows are real/expected data, labelled as a **preview** until computed live; results + timing come from the real engine at runtime. No fabricated numbers, no benchmark/timing claim baked in.
- No new ZK/MPC copy; the existing caveated "how it runs" honesty strip is untouched.
- No dependencies added. `radix-ui` (already a dep) supplies the split-button menu.

## Note (environment)
The shared local `node_modules` has drifted to **TypeScript 6.0.3** (repo pins `^5.7`); TS 6 defaults `noUncheckedSideEffectImports` on, which makes the pre-existing bare `import "./globals.css"` error `TS2882`. I added a tiny forward-compat ambient `declare module "*.css"` (`global-css.d.ts`) so the static-export typecheck is robust under either TS version (harmless/unused under TS 5.7). It is independent of this feature.

## Covered vs deferred
- **Covered:** everything in the HOME spec; and for /try: the slim header, the Run split-button, the ConnectPanel demotion + status chip, panel gating, Ctrl/Cmd+Enter, and the home→/try handoff.
- **Deferred (low-risk, filed as follow-up):** the /try left-rail *icon-collapsible, persisted* Workspace/Dataset/Graphs **accordion**, and the **example-chip cap → "More examples…" palette** flow. The chip cap is deferred deliberately: the `repl-results` e2e clicks the 8th chip ("CONSTRUCT friend-of graph") directly, so capping to ~5 would need a coupled e2e rework; the existing global Cmd-K palette (which the REPL already contributes run/EXPLAIN/connect/export/workspaces/recent/graphs to) remains the keyboard spine. I'll open a bead for these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
