### PR TITLE
feat(engine): M4 Phase 2 DataChunk::decode_numeric_column decode primitive + inline-int gather-free fast path (sq-pntvh.2)

### DIFF
--- a/crates/sparq-engine/src/chunk.rs
+++ b/crates/sparq-engine/src/chunk.rs
@@ -10,9 +10,15 @@
 //! batch of solutions *column-major* and applies one tight, branch-predictable,
 //! auto-vectorisable loop per column.
 //!
-//! This module provides that columnar intermediate, [`DataChunk`], plus the two
-//! kernels a vector-at-a-time FILTER needs:
+//! This module provides that columnar intermediate, [`DataChunk`], plus the kernels a
+//! vector-at-a-time FILTER needs:
 //!
+//! * a **decode kernel** ([`DataChunk::decode_numeric_column`]) — the actual SIMD
+//!   enabler — that gathers one id column into a *contiguous* `Vec<f64>` value column
+//!   **once** (a `f64::NAN` sentinel for a non-numeric cell), with a gather-free fast
+//!   path for an all-inline-integer column (the value is in the id). Decoding once is
+//!   what turns the per-element cache gather into a straight-line loop the compiler can
+//!   auto-vectorise;
 //! * a **comparison kernel** ([`DataChunk::select_numeric`]) that scans one column
 //!   through the graph's f64 value cache and produces a [`SelVec`] (the indices that
 //!   pass) — never materialising a term, mirroring the row evaluator's sargable
@@ -38,7 +44,7 @@
 //! into the evaluator later (roadmap T1.3 morsel-driven pipelining) without changing
 //! query results.
 
-use sparq_core::dict::Id;
+use sparq_core::dict::{is_inline, Id, INLINE_BASE};
 use sparq_core::Graph;
 
 /// A numeric comparison operator for the vectorized FILTER kernel. Mirrors the
@@ -173,6 +179,49 @@ impl DataChunk {
         self.columns.get(c).map(Vec::as_slice)
     }
 
+    /// **Decode kernel — the actual SIMD enabler.** Gathers id column `c` into a
+    /// *contiguous* `Vec<f64>` value column: each id's numeric value where it has one, and
+    /// the `f64::NAN` **sentinel** where it does not (a non-numeric / unparseable cell — the
+    /// `Graph::numeric_value` cache yields `None`). Returns an empty `Vec` (not a column of
+    /// `NaN`) if `c` is out of range, mirroring `select_numeric`.
+    ///
+    /// Why a separate decode step rather than reusing `select_numeric`: that kernel
+    /// re-gathers `numeric_value(id)` per element — a random-access value-cache lookup plus a
+    /// branch, the *same* access pattern the row path pays and **not** auto-vectorisable.
+    /// Decoding **once** into a contiguous `f64` column lets every subsequent compare / reduce
+    /// run as one branchless loop over `f64` that the compiler auto-vectorises (NEON/AVX on
+    /// native, `+simd128` on wasm). It therefore pays only when the decoded column is *reused*
+    /// by ≥1 downstream kernel, or when the column is inline-int (below).
+    ///
+    /// The **NaN sentinel** is chosen so the decoded column drops straight into the numeric
+    /// kernels with no separate validity bitmap: `VecCmp::test` already rejects `NaN` under
+    /// every operator (IEEE-754), so a non-numeric cell is excluded at the compare step exactly
+    /// as the row FILTER's type-error path excludes it.
+    ///
+    /// **Inline-integer gather-free fast path.** An `xsd:integer` in the inline range carries
+    /// its value in the id itself (`numeric_value` returns `id - INLINE_BASE` with no lookup).
+    /// When *every* id in the column is inline, the decode is a straight-line
+    /// `id - INLINE_BASE` map with no cache access and no per-cell numeric branch — the
+    /// portable, wasm-friendly best case. Its result is bit-identical to the general path (an
+    /// all-inline column contains no `NaN` sentinel), so it is a pure speed specialisation.
+    #[must_use]
+    pub fn decode_numeric_column(&self, graph: &Graph, c: usize) -> Vec<f64> {
+        let Some(col) = self.columns.get(c) else {
+            return Vec::new();
+        };
+        // Fast path: an all-inline-integer column decodes gather-free — the value is in the id,
+        // so this stays a branchless straight-line loop the compiler is free to vectorise. The
+        // `is_inline` scan is itself a tight branch-predictable pass over the contiguous column.
+        if col.iter().all(|&id| is_inline(id)) {
+            return col.iter().map(|&id| f64::from(id - INLINE_BASE)).collect();
+        }
+        // General path: one gather through the value cache; a non-numeric id becomes the NaN
+        // sentinel so `VecCmp` (and later reducers) exclude it without a side validity mask.
+        col.iter()
+            .map(|&id| graph.numeric_value(id).unwrap_or(f64::NAN))
+            .collect()
+    }
+
     /// **Vectorized comparison kernel.** Scans column `c` through the graph's f64 value
     /// cache and returns the [`SelVec`] of row positions whose value passes `cmp`. A
     /// non-numeric / unparseable cell (the cache yields `None`) never passes — the row
@@ -248,6 +297,45 @@ mod tests {
             })
             .collect();
         (g, obj_ids)
+    }
+
+    /// A graph whose object column spans the three decode cases in one column:
+    /// **inline** integers (`5`, `9`), **non-inline cache-backed** numerics (a negative
+    /// integer `-7` and a decimal `3.5`, neither of which inlines), and **non-numeric**
+    /// terms (an IRI and a plain-string literal). Returns the object-id column in subject
+    /// order — the mixed input the decode primitive must handle.
+    fn mixed_column() -> (Graph, Vec<Id>) {
+        let nt = concat!(
+            "<http://ex/s0> <http://ex/p> \"5\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+            "<http://ex/s1> <http://ex/p> \"9\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+            "<http://ex/s2> <http://ex/p> \"-7\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n",
+            "<http://ex/s3> <http://ex/p> \"3.5\"^^<http://www.w3.org/2001/XMLSchema#decimal> .\n",
+            "<http://ex/s4> <http://ex/p> <http://ex/thing> .\n",
+            "<http://ex/s5> <http://ex/p> \"hello\" .\n",
+        );
+        let g = Graph::load_str(nt, "ntriples").unwrap();
+        let int = |v: &str| {
+            oxrdf::Term::Literal(oxrdf::Literal::new_typed_literal(
+                v,
+                oxrdf::NamedNode::new("http://www.w3.org/2001/XMLSchema#integer").unwrap(),
+            ))
+        };
+        let terms = [
+            int("5"),
+            int("9"),
+            int("-7"),
+            oxrdf::Term::Literal(oxrdf::Literal::new_typed_literal(
+                "3.5",
+                oxrdf::NamedNode::new("http://www.w3.org/2001/XMLSchema#decimal").unwrap(),
+            )),
+            oxrdf::Term::NamedNode(oxrdf::NamedNode::new("http://ex/thing").unwrap()),
+            oxrdf::Term::Literal(oxrdf::Literal::new_simple_literal("hello")),
+        ];
+        let ids: Vec<Id> = terms
+            .iter()
+            .map(|t| g.id_of(t).expect("term interned"))
+            .collect();
+        (g, ids)
     }
 
     #[test]
@@ -335,6 +423,113 @@ mod tests {
                 assert!(g.numeric_value(id).is_some_and(|x| cmp.test(x)));
             }
         }
+    }
+
+    #[test]
+    fn decode_numeric_column_matches_scalar_mixed_and_nan_sentinel() {
+        let (g, ids) = mixed_column();
+        let n = ids.len();
+        let chunk = DataChunk::from_columns(vec![ids.clone()], n).unwrap();
+        // Mixed column => the general (gather) path runs, not the inline fast path.
+        assert!(!ids.iter().all(|&id| is_inline(id)), "column must be mixed");
+
+        let decoded = chunk.decode_numeric_column(&g, 0);
+        assert_eq!(decoded.len(), n);
+
+        // (1) Bit-exact against the scalar decode the row path computes per id
+        //     (`.to_bits()` compares the NaN sentinel too — both paths use `f64::NAN`).
+        for (r, &id) in ids.iter().enumerate() {
+            let scalar = g.numeric_value(id).unwrap_or(f64::NAN);
+            assert_eq!(
+                decoded[r].to_bits(),
+                scalar.to_bits(),
+                "decode[{}] must equal scalar numeric_value",
+                r
+            );
+        }
+
+        // (2) Pin the concrete numeric values (inline + cache-backed).
+        assert_eq!(decoded[0], 5.0);
+        assert_eq!(decoded[1], 9.0);
+        assert_eq!(decoded[2], -7.0);
+        assert_eq!(decoded[3], 3.5);
+
+        // (3) Non-vacuous sentinel check: the two non-numeric cells decode to the NaN
+        //     sentinel, NOT a spurious value. A wrong sentinel (e.g. 0.0) would (a) not be
+        //     NaN and (b) spuriously PASS `>= 0.0` — so each assert independently catches it.
+        for r in [4usize, 5] {
+            assert!(
+                decoded[r].is_nan(),
+                "non-numeric cell {} must be the NaN sentinel",
+                r
+            );
+            assert!(
+                !VecCmp::Ge(0.0).test(decoded[r]),
+                "NaN sentinel at {} must not pass any comparison",
+                r
+            );
+        }
+    }
+
+    #[test]
+    fn decode_numeric_column_inline_fast_path_is_exact() {
+        // An all-inline-integer column exercises the gather-free fast path; its output
+        // must be bit-identical to the general (scalar) path and carry no NaN.
+        let (g, obj_ids) = ages_graph(48);
+        assert!(
+            obj_ids.iter().all(|&id| is_inline(id)),
+            "0..n are canonical non-negative integers => inline ids (fast-path precondition)"
+        );
+        let chunk = DataChunk::from_columns(vec![obj_ids.clone()], obj_ids.len()).unwrap();
+        let decoded = chunk.decode_numeric_column(&g, 0);
+
+        let expected: Vec<f64> = (0..48u32).map(f64::from).collect();
+        assert_eq!(decoded, expected);
+        assert!(
+            decoded.iter().all(|x| !x.is_nan()),
+            "no NaN in an all-inline column"
+        );
+        for (r, &id) in obj_ids.iter().enumerate() {
+            assert_eq!(
+                decoded[r].to_bits(),
+                g.numeric_value(id).unwrap().to_bits(),
+                "fast path must match the scalar path at {}",
+                r
+            );
+        }
+    }
+
+    #[test]
+    fn decode_then_compare_matches_select_numeric() {
+        // The decoded column + `VecCmp` must select exactly the rows the row-shaped
+        // `select_numeric` kernel keeps — proving the NaN sentinel yields the same
+        // filtering (non-numeric cells excluded) as the direct per-id gather.
+        let (g, ids) = mixed_column();
+        let n = ids.len();
+        let chunk = DataChunk::from_columns(vec![ids], n).unwrap();
+        let decoded = chunk.decode_numeric_column(&g, 0);
+        for cmp in [
+            VecCmp::Gt(0.0),
+            VecCmp::Ge(-7.0),
+            VecCmp::Lt(5.0),
+            VecCmp::Le(3.5),
+            VecCmp::Eq(9.0),
+        ] {
+            let via_decode: SelVec = (0..n).filter(|&r| cmp.test(decoded[r])).collect();
+            let via_kernel = chunk.select_numeric(&g, 0, cmp);
+            assert_eq!(
+                via_decode, via_kernel,
+                "decode+compare != select_numeric for {:?}",
+                cmp
+            );
+        }
+    }
+
+    #[test]
+    fn decode_numeric_column_out_of_range_is_empty() {
+        let (g, _ids) = ages_graph(4);
+        let chunk = DataChunk::empty(1);
+        assert!(chunk.decode_numeric_column(&g, 5).is_empty());
     }
 
     #[test]

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -490,7 +490,10 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   ```
 - **Vectorized columnar primitives** are the non-default `vectorized` cargo feature (M4 plan, bead
   `sq-hvfe`): the `chunk` module's `DataChunk` (a column-major, vector-at-a-time id-level batch),
-  a numeric FILTER comparison kernel (`DataChunk::select_numeric` → a `SelVec`), and a
+  a **decode kernel** (`DataChunk::decode_numeric_column` → a contiguous `Vec<f64>` value column,
+  `f64::NAN` sentinel for a non-numeric cell, with a gather-free fast path for an all-inline-integer
+  column — the SIMD enabler, M4 Phase 2 `sq-pntvh.2`), a numeric FILTER comparison kernel
+  (`DataChunk::select_numeric` → a `SelVec`), and a
   selection/gather kernel (`DataChunk::apply_selection`). This is a **building block**, NOT yet
   wired into the query evaluator — `query`/`query_json`/etc. are unchanged whether the feature is on
   or off. When off, zero columnar code compiles and the default native + wasm builds are


### PR DESCRIPTION
> 🤖 SPARQ agent — bead **sq-pntvh.2** (M4 vectorization Phase 2, unblocked by sq-pntvh.1 / #1337).

## What this adds

The columnar `select_numeric` kernel re-gathers `numeric_value(id)` **per element** — a random-access value-cache lookup plus a branch, the *same* access pattern the row path pays and **not** auto-vectorisable (see `research/vector-at-a-time-m4.md` §0 refinement 2). This lands the **actual SIMD enabler** the built `chunk.rs` kernels need:

**`DataChunk::decode_numeric_column(&self, graph, c) -> Vec<f64>`** — gather id column `c` **once** into a *contiguous* `Vec<f64>` value column, with the **`f64::NAN` sentinel** for a non-numeric / unparseable cell. After the one decode, every downstream compare/reduce is a branchless loop over contiguous `f64` the compiler auto-vectorises (NEON/AVX native, `+simd128` wasm).

- **Inline-integer gather-free fast path.** An `xsd:integer` in the inline range carries its value in the id itself (`numeric_value` returns `id - INLINE_BASE`, no lookup). When *every* id in the column is inline, the decode is a straight-line `id - INLINE_BASE` map — no cache access, no per-cell branch (the portable, wasm-friendly best case). Bit-identical to the general path (an all-inline column has no `NaN`), so it is a pure speed specialisation.
- **Why the NaN sentinel.** It drops straight into the existing numeric kernels with no side validity bitmap: `VecCmp::test` already rejects `NaN` under every operator (IEEE-754), so a non-numeric cell is excluded at the compare step exactly as the row FILTER's type-error path excludes it.

## Correctness (real-path, direct unit tests)

- `decode_numeric_column_matches_scalar_mixed_and_nan_sentinel` — over a **MIXED** column (inline ints `5`/`9`, non-inline cache-backed `-7`/`3.5`, non-numeric IRI + plain-string literal), the decode is **bit-exact** (`.to_bits()`, so the NaN sentinel is compared too) against the scalar per-id `numeric_value` the row path computes. **Non-vacuous:** the sentinel asserts the non-numeric cells are `NaN` *and* do not pass `>= 0.0` — a wrong sentinel (`0.0`) fails both (verified by mutation: flipping the sentinel to `0.0` turns the test red).
- `decode_numeric_column_inline_fast_path_is_exact` — an all-inline column decodes bit-identically to the scalar path with no `NaN`.
- `decode_then_compare_matches_select_numeric` — decode + `VecCmp` selects exactly the rows the row-shaped `select_numeric` kernel keeps (the NaN sentinel yields the same filtering).
- `decode_numeric_column_out_of_range_is_empty` — an out-of-range column returns an empty `Vec` (mirrors `select_numeric`).

One direct unit test per new public fn (coverage-ratchet rule).

## Feature-gating / neutrality

All new code is inside `chunk.rs`, which is `#[cfg(feature = "vectorized")] pub mod chunk;` — **OFF by default**. With the feature off, **zero new code compiles**: the default native + wasm builds are byte-identical / perf-neutral (does not regress the sq-pntvh.8 gate). **No new dependencies** (only `sparq_core::dict::{is_inline, INLINE_BASE}`, already reachable), `forbid(unsafe_code)`-clean.

## Gates run (both feature states)

- `cargo clippy -p sparq-engine --all-targets -- -D warnings` — **clean** (default) **and** `--features vectorized` — **clean**.
- `cargo test -p sparq-engine --lib` (default) — **230 passed / 0 failed**; `--features vectorized --lib chunk::` — **13 passed** (incl. the 4 new).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — **clean** (no intra-doc link to a `#[cfg(feature)]` item; all cross-refs to `numeric_value`/`VecCmp::test`/`id - INLINE_BASE` are plain code spans).
- `scripts/check-readme-template.py --enforce` — **0 deviations** (no crate README touched).

## Docs

- `chunk.rs` module docs + the method's rustdoc document the decode step, the NaN-sentinel convention, and the inline fast path (with the honest "only pays when the decoded column is reused, or the column is inline-int" boundary from the design record).
- `skills/sparql-query/SKILL.md` vectorized-primitives bullet now lists the decode kernel.

## Scope / follow-on

This is exactly Phase 2 of the `sq-pntvh` roadmap: the decode primitive. It is a **building block** — the evaluator still never constructs a chunk. Phase 3 (`sq-pntvh.3`, columnar residual-FILTER seam) and Phase 4 (`sq-pntvh.4`, reducer aggregates) consume this primitive and remain open/unchanged.

---
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>