### PR TITLE
feat(jsonld): Context Processing + Create Term Definition + IRI Expansion foundation (sq-oy1f.24) [OPUS-4.8]

### DIFF
--- a/crates/sparq-jsonld/README.md
+++ b/crates/sparq-jsonld/README.md
@@ -56,13 +56,17 @@ its off-by-default `serialize-rdf` feature; the crate has **zero mandatory
 dependencies**, is `#![forbid(unsafe_code)]`, and adds no default dependency
 anywhere.
 
-### Scaffold status
+### Build-out status
 
-This is Phase A: the `Json` AST, error registry, options, and loader trait ship
-today. The algorithm modules (`context`, `expand`, `flatten`, `compact`, `frame`,
-`from_rdf`, `to_rdf`, `api`) are documented stubs — spec references and public
-shape only — filled by the dependency-ordered follow-on beads (`sq-oy1f.24`+).
-The crate is `publish = false` until the pipeline is real.
+The `Json` AST, error registry, options, and loader trait ship today, alongside the
+**Context Processing** foundation (`context`): the `ActiveContext`, Create Term
+Definition, and IRI Expansion — the hinge every other algorithm builds on — with
+RFC 3986 reference resolution and deny-by-default remote-context loading. The
+remaining modules (`expand`, `flatten`, `compact`, `frame`, `from_rdf`, `to_rdf`,
+`api`) are documented stubs, filled by dependency-ordered follow-on beads. The
+compaction-side companions of context processing (inverse context, IRI compaction)
+are also deferred to a follow-on bead. The crate is `publish = false` until the
+pipeline is real.
 
 ## 📚 Learn more
 

--- a/crates/sparq-jsonld/src/context/iri.rs
+++ b/crates/sparq-jsonld/src/context/iri.rs
@@ -1,7 +1,393 @@
-//! IRI Expansion, IRI Compaction, and Term Selection (JSON-LD 1.1 API §5.2, §7.1–7.2).
+//! IRI Expansion (JSON-LD 1.1 API §5.2) and RFC 3986 reference resolution.
 //!
-//! **Scaffold (`sq-oy1f.23`).** Spec references only; implemented in bead `sq-oy1f.24`.
-//! Expansion resolves a term/CURIE/relative-IRI against an
-//! [`ActiveContext`](super::ActiveContext) (honouring `@vocab`, `@base`, and keyword
-//! aliases); compaction selects the shortest term via the
-//! [`InverseContext`](super::InverseContext).
+//! [OPUS-4.8] (sq-oy1f.24) IRI Expansion resolves a term / compact IRI / relative
+//! reference against an [`ActiveContext`], honouring keyword
+//! aliases, `@vocab`, `@base`, and on-demand term creation from a local context. The
+//! compaction-side companions (IRI Compaction, Term Selection, inverse-context
+//! construction) are deferred to a follow-on bead — see the module docs.
+
+use std::collections::BTreeMap;
+
+use super::process::{create_term_definition, Env};
+use super::{has_keyword_form, is_keyword, ActiveContext};
+use crate::error::JsonLdError;
+use crate::json::Json;
+
+/// True iff `s` is a blank node identifier (`_:` prefix).
+pub(crate) fn is_blank_node(s: &str) -> bool {
+    s.starts_with("_:")
+}
+
+/// True iff `s` is an absolute IRI: a valid scheme followed by `:`.
+pub(crate) fn is_absolute_iri(s: &str) -> bool {
+    match s.find(':') {
+        Some(colon) => is_valid_scheme(&s[..colon]),
+        None => false,
+    }
+}
+
+/// True iff `s` is a syntactically valid URI scheme: `ALPHA *( ALPHA / DIGIT / "+" / "-" /
+/// "." )` (RFC 3986 §3.1).
+fn is_valid_scheme(s: &str) -> bool {
+    let b = s.as_bytes();
+    !b.is_empty()
+        && b[0].is_ascii_alphabetic()
+        && b.iter()
+            .all(|&c| c.is_ascii_alphanumeric() || c == b'+' || c == b'-' || c == b'.')
+}
+
+impl ActiveContext {
+    /// IRI Expansion (JSON-LD 1.1 API §5.2) — read-only.
+    ///
+    /// Expands `value` (a term, compact IRI, or relative reference) against this active
+    /// context. With `vocab` true, `value` is resolved as a *vocabulary* reference (against
+    /// term definitions and `@vocab`); with `document_relative` true, an otherwise
+    /// unresolved reference is resolved against the base IRI. Returns `None` when `value`
+    /// expands to null (a keyword-shaped non-keyword, or a term bound to null).
+    ///
+    /// This is the entry point once the active context is fully built. During Context
+    /// Processing, expansion may need to define terms on demand; that variant lives in
+    /// the crate-internal `expand_iri_in_context`.
+    pub fn expand_iri(&self, value: &str, document_relative: bool, vocab: bool) -> Option<String> {
+        self.expand_iri_readonly(value, document_relative, vocab)
+    }
+
+    /// The read-only core of IRI Expansion — no on-demand term creation (steps that would
+    /// invoke Create Term Definition are skipped; the active context is assumed complete).
+    pub(crate) fn expand_iri_readonly(
+        &self,
+        value: &str,
+        document_relative: bool,
+        vocab: bool,
+    ) -> Option<String> {
+        // §5.2 step 1: a keyword (or null) expands to itself.
+        if is_keyword(value) {
+            return Some(value.to_string());
+        }
+        // step 2: a keyword-shaped token that is not a recognised keyword expands to null.
+        if has_keyword_form(value) {
+            return None;
+        }
+        // step 4: a term whose IRI mapping is a keyword expands to that keyword.
+        if let Some(def) = self.term_definitions.get(value) {
+            if let Some(iri) = &def.iri {
+                if is_keyword(iri) {
+                    return Some(iri.clone());
+                }
+            }
+        }
+        // step 5: a vocabulary reference that is a defined term expands to its IRI mapping
+        // (which may be null — e.g. an explicit `@id: null`, in which case the term drops).
+        if vocab {
+            if let Some(def) = self.term_definitions.get(value) {
+                return def.iri.clone();
+            }
+        }
+        // step 6: a compact IRI or absolute IRI.
+        if let Some(colon) = value.find(':') {
+            if colon > 0 {
+                let prefix = &value[..colon];
+                let suffix = &value[colon + 1..];
+                // A blank node identifier or an IRI with an authority (`scheme://…`) is
+                // returned unchanged.
+                if prefix == "_" || suffix.starts_with("//") {
+                    return Some(value.to_string());
+                }
+                // If the prefix is a term flagged `@prefix`, concatenate.
+                if let Some(pdef) = self.term_definitions.get(prefix) {
+                    if pdef.prefix {
+                        if let Some(piri) = &pdef.iri {
+                            return Some(format!("{}{}", piri, suffix));
+                        }
+                    }
+                }
+                // Otherwise the value already contains a colon: treat it as an absolute IRI.
+                return Some(value.to_string());
+            }
+        }
+        // step 7: a vocabulary reference with a `@vocab` mapping.
+        if vocab {
+            if let Some(vocab_iri) = &self.vocabulary_mapping {
+                return Some(format!("{}{}", vocab_iri, value));
+            }
+        }
+        // step 8: a document-relative reference resolved against the base IRI.
+        if document_relative {
+            if let Some(base) = &self.base_iri {
+                return Some(resolve_iri(base, value));
+            }
+        }
+        // step 9: return unchanged.
+        Some(value.to_string())
+    }
+}
+
+/// IRI Expansion with on-demand term creation (JSON-LD 1.1 API §5.2 steps 3 and 6.3):
+/// while a local context is being processed, expanding a value may require the referenced
+/// term — or the prefix of a compact IRI — to be defined first. Used by Create Term
+/// Definition; delegates the actual lookup to [`ActiveContext::expand_iri_readonly`].
+#[allow(clippy::too_many_arguments)]
+pub(crate) fn expand_iri_in_context(
+    active: &mut ActiveContext,
+    value: &str,
+    document_relative: bool,
+    vocab: bool,
+    local: &Json,
+    defined: &mut BTreeMap<String, bool>,
+    env: &mut Env,
+) -> Result<Option<String>, JsonLdError> {
+    // Keyword / keyword-shaped tokens short-circuit before any term is created (§5.2 1–2).
+    if is_keyword(value) {
+        return Ok(Some(value.to_string()));
+    }
+    if has_keyword_form(value) {
+        return Ok(None);
+    }
+    // step 3: if the local context defines `value` and it is not yet built, build it.
+    ensure_defined(active, value, local, defined, env)?;
+    // step 6.3: for a compact IRI, ensure its prefix term is built too.
+    if let Some(colon) = value.find(':') {
+        if colon > 0 {
+            let prefix = &value[..colon];
+            let suffix = &value[colon + 1..];
+            if prefix != "_" && !suffix.starts_with("//") {
+                ensure_defined(active, prefix, local, defined, env)?;
+            }
+        }
+    }
+    Ok(active.expand_iri_readonly(value, document_relative, vocab))
+}
+
+/// If `term` is defined by the local context and has not yet been built into `active`,
+/// invoke Create Term Definition for it.
+fn ensure_defined(
+    active: &mut ActiveContext,
+    term: &str,
+    local: &Json,
+    defined: &mut BTreeMap<String, bool>,
+    env: &mut Env,
+) -> Result<(), JsonLdError> {
+    if local.get(term).is_some() && defined.get(term) != Some(&true) {
+        create_term_definition(active, local, term, defined, false, false, env)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------------------
+// RFC 3986 §5 reference resolution (used for `@base`, remote-context URLs, and
+// document-relative IRI expansion). Kept dependency-free and self-contained.
+// ---------------------------------------------------------------------------------------
+
+/// The five components of a URI reference (RFC 3986 §3).
+struct UriRef<'a> {
+    scheme: Option<&'a str>,
+    authority: Option<&'a str>,
+    path: &'a str,
+    query: Option<&'a str>,
+    fragment: Option<&'a str>,
+}
+
+/// Splits a URI reference into its components (RFC 3986 §3.2 / Appendix B).
+fn split_uri(input: &str) -> UriRef<'_> {
+    let (rest, fragment) = match input.find('#') {
+        Some(i) => (&input[..i], Some(&input[i + 1..])),
+        None => (input, None),
+    };
+    let (rest, query) = match rest.find('?') {
+        Some(i) => (&rest[..i], Some(&rest[i + 1..])),
+        None => (rest, None),
+    };
+    let (scheme, rest) = match rest.find(':') {
+        Some(i) if is_valid_scheme(&rest[..i]) => (Some(&rest[..i]), &rest[i + 1..]),
+        _ => (None, rest),
+    };
+    let (authority, path) = if let Some(after) = rest.strip_prefix("//") {
+        let end = after.find('/').unwrap_or(after.len());
+        (Some(&after[..end]), &after[end..])
+    } else {
+        (None, rest)
+    };
+    UriRef {
+        scheme,
+        authority,
+        path,
+        query,
+        fragment,
+    }
+}
+
+/// Removes `.` and `..` complete path segments (RFC 3986 §5.2.4).
+fn remove_dot_segments(path: &str) -> String {
+    let mut input = path.to_string();
+    let mut output = String::new();
+    while !input.is_empty() {
+        if let Some(r) = input.strip_prefix("../") {
+            input = r.to_string();
+        } else if let Some(r) = input.strip_prefix("./") {
+            input = r.to_string();
+        } else if let Some(r) = input.strip_prefix("/./") {
+            input = format!("/{}", r);
+        } else if input == "/." {
+            input = "/".to_string();
+        } else if let Some(r) = input.strip_prefix("/../") {
+            input = format!("/{}", r);
+            remove_last_segment(&mut output);
+        } else if input == "/.." {
+            input = "/".to_string();
+            remove_last_segment(&mut output);
+        } else if input == "." || input == ".." {
+            input.clear();
+        } else {
+            let start = usize::from(input.starts_with('/'));
+            let next = match input[start..].find('/') {
+                Some(i) => start + i,
+                None => input.len(),
+            };
+            output.push_str(&input[..next]);
+            input = input[next..].to_string();
+        }
+    }
+    output
+}
+
+/// Removes the last `/`-delimited segment (and its preceding `/`) from `output`.
+fn remove_last_segment(output: &mut String) {
+    match output.rfind('/') {
+        Some(i) => output.truncate(i),
+        None => output.clear(),
+    }
+}
+
+/// Merges a relative reference path with a base's path (RFC 3986 §5.2.3).
+fn merge(base: &UriRef<'_>, ref_path: &str) -> String {
+    if base.authority.is_some() && base.path.is_empty() {
+        format!("/{}", ref_path)
+    } else {
+        match base.path.rfind('/') {
+            Some(i) => format!("{}{}", &base.path[..=i], ref_path),
+            None => ref_path.to_string(),
+        }
+    }
+}
+
+/// Recomposes URI components into a string (RFC 3986 §5.3).
+fn recompose(
+    scheme: Option<&str>,
+    authority: Option<&str>,
+    path: &str,
+    query: Option<&str>,
+    fragment: Option<&str>,
+) -> String {
+    let mut s = String::new();
+    if let Some(sc) = scheme {
+        s.push_str(sc);
+        s.push(':');
+    }
+    if let Some(a) = authority {
+        s.push_str("//");
+        s.push_str(a);
+    }
+    s.push_str(path);
+    if let Some(q) = query {
+        s.push('?');
+        s.push_str(q);
+    }
+    if let Some(f) = fragment {
+        s.push('#');
+        s.push_str(f);
+    }
+    s
+}
+
+/// Resolves a URI `reference` against a `base` URI (RFC 3986 §5.2.2). Used for `@base`,
+/// remote-context URL resolution, and document-relative IRI expansion.
+pub(crate) fn resolve_iri(base: &str, reference: &str) -> String {
+    let r = split_uri(reference);
+    let b = split_uri(base);
+
+    let (t_scheme, t_authority, t_path, t_query);
+    if r.scheme.is_some() {
+        t_scheme = r.scheme;
+        t_authority = r.authority;
+        t_path = remove_dot_segments(r.path);
+        t_query = r.query;
+    } else {
+        if r.authority.is_some() {
+            t_authority = r.authority;
+            t_path = remove_dot_segments(r.path);
+            t_query = r.query;
+        } else if r.path.is_empty() {
+            t_path = b.path.to_string();
+            t_query = if r.query.is_some() { r.query } else { b.query };
+            t_authority = b.authority;
+        } else {
+            if r.path.starts_with('/') {
+                t_path = remove_dot_segments(r.path);
+            } else {
+                t_path = remove_dot_segments(&merge(&b, r.path));
+            }
+            t_query = r.query;
+            t_authority = b.authority;
+        }
+        t_scheme = b.scheme;
+    }
+    recompose(t_scheme, t_authority, &t_path, t_query, r.fragment)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn scheme_and_absolute_iri_predicates() {
+        assert!(is_valid_scheme("http"));
+        assert!(is_valid_scheme("urn"));
+        assert!(!is_valid_scheme("1http")); // must start with ALPHA
+        assert!(!is_valid_scheme(""));
+        assert!(is_absolute_iri("http://example.org/a"));
+        assert!(is_absolute_iri("mailto:a@example.org"));
+        assert!(!is_absolute_iri("example.org/a"));
+        assert!(!is_absolute_iri("_:b0"));
+        assert!(is_blank_node("_:b0"));
+        assert!(!is_blank_node("http://x"));
+    }
+
+    // RFC 3986 §5.4 normal-example reference-resolution vectors.
+    #[test]
+    fn rfc3986_normal_examples() {
+        let base = "http://a/b/c/d;p?q";
+        assert_eq!(resolve_iri(base, "g"), "http://a/b/c/g");
+        assert_eq!(resolve_iri(base, "./g"), "http://a/b/c/g");
+        assert_eq!(resolve_iri(base, "g/"), "http://a/b/c/g/");
+        assert_eq!(resolve_iri(base, "/g"), "http://a/g");
+        assert_eq!(resolve_iri(base, "?y"), "http://a/b/c/d;p?y");
+        assert_eq!(resolve_iri(base, "g?y"), "http://a/b/c/g?y");
+        assert_eq!(resolve_iri(base, "#s"), "http://a/b/c/d;p?q#s");
+        assert_eq!(resolve_iri(base, "g#s"), "http://a/b/c/g#s");
+        assert_eq!(resolve_iri(base, ""), "http://a/b/c/d;p?q");
+        assert_eq!(resolve_iri(base, "."), "http://a/b/c/");
+        assert_eq!(resolve_iri(base, ".."), "http://a/b/");
+        assert_eq!(resolve_iri(base, "../.."), "http://a/");
+        assert_eq!(resolve_iri(base, "../../g"), "http://a/g");
+    }
+
+    // RFC 3986 §5.4.2 abnormal dot-segment examples.
+    #[test]
+    fn rfc3986_abnormal_dot_segments() {
+        let base = "http://a/b/c/d;p?q";
+        assert_eq!(resolve_iri(base, "../../../g"), "http://a/g");
+        assert_eq!(resolve_iri(base, "/./g"), "http://a/g");
+        assert_eq!(resolve_iri(base, "g."), "http://a/b/c/g.");
+        assert_eq!(resolve_iri(base, ".g"), "http://a/b/c/.g");
+        assert_eq!(resolve_iri(base, "g/./h"), "http://a/b/c/g/h");
+        assert_eq!(resolve_iri(base, "g/../h"), "http://a/b/c/h");
+    }
+
+    #[test]
+    fn absolute_reference_keeps_its_own_scheme() {
+        assert_eq!(
+            resolve_iri("http://a/b", "https://c/d?x#y"),
+            "https://c/d?x#y"
+        );
+    }
+}

--- a/crates/sparq-jsonld/src/context/mod.rs
+++ b/crates/sparq-jsonld/src/context/mod.rs
@@ -1,42 +1,437 @@
 //! Context processing — the active context, term definitions, and the inverse context.
 //!
-//! **Scaffold (`sq-oy1f.23`).** This module currently declares only the public *shape* the
-//! Context Processing Algorithm and IRI expansion/compaction will operate over; the
-//! algorithms land in bead `sq-oy1f.24`:
+//! [OPUS-4.8] (sq-oy1f.24) The document-level **Context Processing** layer of the W3C
+//! JSON-LD 1.1 pipeline (design record `research/jsonld-1.1-design.md` §3.1). The public
+//! surface is:
 //!
-//! - [`process`] — the Context Processing Algorithm (JSON-LD 1.1 API §4) and Create Term
-//!   Definition (§4.2).
-//! - [`iri`] — IRI Expansion (§5.2), IRI Compaction, and Term Selection (§7.1–7.2).
+//! - [`ActiveContext`] — the processed result of folding a chain of `@context` definitions
+//!   (JSON-LD 1.1 API §3.1), with its default base/vocab/language/direction and its map of
+//!   [`TermDefinition`]s.
+//! - [`Direction`] — a base direction (`ltr` / `rtl`).
+//! - [`process`] — the Context Processing Algorithm (§4) and Create Term Definition (§4.2).
+//! - [`iri`] — IRI Expansion (§5.2), plus RFC 3986 reference resolution.
+//!
+//! This bead (`sq-oy1f.24`) implements the **expansion foundation** — the hinge every
+//! other algorithm depends on. The compaction-side companions (inverse-context
+//! construction §4.3 and IRI Compaction / Term Selection §7.1–7.2) are deferred to a
+//! follow-on bead so this slice stays reviewable and can be verified offline against the
+//! spec's worked expansion examples; see the crate README.
 //!
 //! Spec: <https://www.w3.org/TR/json-ld11-api/#context-processing-algorithms>.
+
+use std::collections::BTreeMap;
+
+use crate::json::Json;
 
 pub mod iri;
 pub mod process;
 
+/// A base direction (`@direction`): left-to-right or right-to-left.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Direction {
+    /// `ltr` — left-to-right.
+    Ltr,
+    /// `rtl` — right-to-left.
+    Rtl,
+}
+
+impl Direction {
+    /// The spec string (`"ltr"` / `"rtl"`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Direction::Ltr => "ltr",
+            Direction::Rtl => "rtl",
+        }
+    }
+
+    /// Parses a base direction string, or `None` if it is neither `"ltr"` nor `"rtl"`.
+    pub fn parse(s: &str) -> Option<Direction> {
+        match s {
+            "ltr" => Some(Direction::Ltr),
+            "rtl" => Some(Direction::Rtl),
+            _ => None,
+        }
+    }
+}
+
+/// A tri-state term-scoped override for `@language` / `@direction`: whether the term
+/// definition leaves the value **unset** (fall back to the context default), sets it
+/// explicitly to **null** (no value), or binds a concrete value.
+///
+/// Modelled explicitly because the null-vs-unset distinction is load-bearing during
+/// expansion: an unset language falls back to the active context's default language,
+/// whereas an explicit null suppresses it.
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
+pub enum Override<T> {
+    /// Not set by the term definition — fall back to the context default.
+    #[default]
+    Unset,
+    /// Explicitly set to null — suppress the value.
+    Null,
+    /// Bound to a concrete value.
+    Set(T),
+}
+
+impl<T> Override<T> {
+    /// True iff this override was set by the term definition (either to null or a value).
+    pub fn is_set(&self) -> bool {
+        !matches!(self, Override::Unset)
+    }
+}
+
+/// One **term definition** from an active context (JSON-LD 1.1 API §3.2).
+///
+/// A term definition is created by the Create Term Definition algorithm. A term whose
+/// definition maps to *nothing* (`{"@id": null}` or a plain `null` context value) is a
+/// retained definition with a **null IRI mapping** ([`TermDefinition::iri`] returns
+/// `None`): it is recorded so expansion drops the term (and a later redefinition can be
+/// detected) rather than treating the term as undefined.
+#[derive(Clone, Debug, Default, PartialEq)]
+#[non_exhaustive]
+pub struct TermDefinition {
+    // The fully-expanded IRI mapping (`@id`). `None` means the definition has no IRI
+    // mapping (an explicit `@id: null` on an otherwise-present definition).
+    pub(crate) iri: Option<String>,
+    // `@reverse` — this term is a reverse property.
+    pub(crate) reverse: bool,
+    // `@type` — the type mapping (`@id`, `@vocab`, `@json`, `@none`, or an IRI).
+    pub(crate) type_mapping: Option<String>,
+    // `@language` — tri-state (unset / null / value).
+    pub(crate) language: Override<String>,
+    // `@direction` — tri-state (unset / null / value).
+    pub(crate) direction: Override<Direction>,
+    // `@index` — an index mapping.
+    pub(crate) index: Option<String>,
+    // `@container` — the container mapping, as an ordered list of keywords.
+    pub(crate) container: Vec<String>,
+    // `@nest` — a nest mapping.
+    pub(crate) nest: Option<String>,
+    // `@context` — the raw scoped local context (validated but re-processed on use).
+    pub(crate) context: Option<Json>,
+    // The base URL in effect when this definition was created (for scoped-context resolution).
+    pub(crate) base_url: Option<String>,
+    // `@prefix` — this term may be used as the prefix of a compact IRI.
+    pub(crate) prefix: bool,
+    // `@protected` — this definition may not be redefined by a later context.
+    pub(crate) protected: bool,
+}
+
+impl TermDefinition {
+    /// The fully-expanded IRI mapping (`@id`), or `None` if the definition has no IRI
+    /// mapping.
+    pub fn iri(&self) -> Option<&str> {
+        self.iri.as_deref()
+    }
+
+    /// True iff this is a reverse property (`@reverse`).
+    pub fn is_reverse(&self) -> bool {
+        self.reverse
+    }
+
+    /// The type mapping (`@type`), if any.
+    pub fn type_mapping(&self) -> Option<&str> {
+        self.type_mapping.as_deref()
+    }
+
+    /// The term-scoped language override (`@language`).
+    pub fn language(&self) -> &Override<String> {
+        &self.language
+    }
+
+    /// The term-scoped direction override (`@direction`).
+    pub fn direction(&self) -> &Override<Direction> {
+        &self.direction
+    }
+
+    /// The index mapping (`@index`), if any.
+    pub fn index(&self) -> Option<&str> {
+        self.index.as_deref()
+    }
+
+    /// The container mapping (`@container`) as an ordered slice of keywords.
+    pub fn container(&self) -> &[String] {
+        &self.container
+    }
+
+    /// The nest mapping (`@nest`), if any.
+    pub fn nest(&self) -> Option<&str> {
+        self.nest.as_deref()
+    }
+
+    /// The raw scoped local context (`@context`), if any.
+    pub fn context(&self) -> Option<&Json> {
+        self.context.as_ref()
+    }
+
+    /// True iff this term may be used as the prefix of a compact IRI (`@prefix`).
+    pub fn is_prefix(&self) -> bool {
+        self.prefix
+    }
+
+    /// True iff this definition is protected (`@protected`) against redefinition.
+    pub fn is_protected(&self) -> bool {
+        self.protected
+    }
+
+    /// True iff two definitions are equal ignoring only the `@protected` flag — the
+    /// comparison the spec uses to decide whether a redefinition of a protected term is a
+    /// no-op (allowed) or a `protected term redefinition` error.
+    pub(crate) fn same_except_protected(&self, other: &TermDefinition) -> bool {
+        let a = TermDefinition {
+            protected: false,
+            ..self.clone()
+        };
+        let b = TermDefinition {
+            protected: false,
+            ..other.clone()
+        };
+        a == b
+    }
+}
+
 /// The **active context**: the processed result of applying a chain of `@context`
-/// definitions (JSON-LD 1.1 API §3.1).
-///
-/// Scaffold placeholder — the term-definition map, default language/direction/base/vocab,
-/// the previous-context link, and the cached inverse context are populated by the Context
-/// Processing Algorithm in bead `sq-oy1f.24`.
+/// definitions (JSON-LD 1.1 API §3.1). Construct one with [`ActiveContext::new`] and fold
+/// contexts into it with [`ActiveContext::process`].
 #[derive(Clone, Debug, Default)]
-#[non_exhaustive]
-pub struct ActiveContext {}
+pub struct ActiveContext {
+    // Term → definition. A present key is a defined term (its definition may carry a null
+    // IRI mapping, i.e. the term expands to null / is dropped); an absent key means the
+    // term is undefined.
+    pub(crate) term_definitions: BTreeMap<String, TermDefinition>,
+    // `@base` — the current base IRI for resolving relative references.
+    pub(crate) base_iri: Option<String>,
+    // The document's original base URL, restored when a context is nullified.
+    pub(crate) original_base_url: Option<String>,
+    // `@vocab` — the vocabulary mapping.
+    pub(crate) vocabulary_mapping: Option<String>,
+    // `@language` — the default language.
+    pub(crate) default_language: Option<String>,
+    // `@direction` — the default base direction.
+    pub(crate) default_base_direction: Option<Direction>,
+    // The previous context, retained for `@propagate: false` reversion during expansion.
+    pub(crate) previous_context: Option<Box<ActiveContext>>,
+}
 
-/// One **term definition** from an active context (JSON-LD 1.1 API §3.2), including the
-/// `@protected` flag that guards against redefinition.
-///
-/// Scaffold placeholder — the IRI mapping, type/language/direction/index/container/nest
-/// mappings, the `@prefix`/`@reverse`/`@protected` flags, and the scoped local `@context`
-/// are populated in bead `sq-oy1f.24`.
-#[derive(Clone, Debug, Default)]
-#[non_exhaustive]
-pub struct TermDefinition {}
+impl ActiveContext {
+    /// A newly-initialized active context whose base IRI and original base URL are `base`
+    /// (JSON-LD 1.1 API §4.1.2 step 1) and which has no term definitions.
+    pub fn new(base: Option<&str>) -> ActiveContext {
+        ActiveContext {
+            term_definitions: BTreeMap::new(),
+            base_iri: base.map(str::to_string),
+            original_base_url: base.map(str::to_string),
+            vocabulary_mapping: None,
+            default_language: None,
+            default_base_direction: None,
+            previous_context: None,
+        }
+    }
 
-/// The **inverse context** derived from an active context, used to select the best term for
-/// a given IRI/value during compaction (JSON-LD 1.1 API §4.3).
-///
-/// Scaffold placeholder — built lazily from the active context in bead `sq-oy1f.24`.
-#[derive(Clone, Debug, Default)]
-#[non_exhaustive]
-pub struct InverseContext {}
+    /// The current base IRI (`@base`), if any.
+    pub fn base_iri(&self) -> Option<&str> {
+        self.base_iri.as_deref()
+    }
+
+    /// The vocabulary mapping (`@vocab`), if any.
+    pub fn vocabulary_mapping(&self) -> Option<&str> {
+        self.vocabulary_mapping.as_deref()
+    }
+
+    /// The default language (`@language`), if any.
+    pub fn default_language(&self) -> Option<&str> {
+        self.default_language.as_deref()
+    }
+
+    /// The default base direction (`@direction`), if any.
+    pub fn default_base_direction(&self) -> Option<Direction> {
+        self.default_base_direction
+    }
+
+    /// The term definition for `term`, or `None` if `term` is undefined. A defined term
+    /// with a null IRI mapping still returns `Some` (its [`TermDefinition::iri`] is `None`).
+    pub fn term_definition(&self, term: &str) -> Option<&TermDefinition> {
+        self.term_definitions.get(term)
+    }
+
+    /// True iff `term` is defined in this context (even with a null IRI mapping).
+    pub fn has_term(&self, term: &str) -> bool {
+        self.term_definitions.contains_key(term)
+    }
+
+    /// The number of defined terms.
+    pub fn term_count(&self) -> usize {
+        self.term_definitions.len()
+    }
+
+    /// True iff the context contains any protected term definition (used by the null-context
+    /// nullification guard, §4.1.2 step 5.1.1).
+    pub(crate) fn has_protected_terms(&self) -> bool {
+        self.term_definitions.values().any(TermDefinition::is_protected)
+    }
+}
+
+/// The set of JSON-LD 1.1 keywords recognised by the processing algorithms.
+pub(crate) const KEYWORDS: &[&str] = &[
+    "@base",
+    "@container",
+    "@context",
+    "@direction",
+    "@graph",
+    "@id",
+    "@import",
+    "@included",
+    "@index",
+    "@json",
+    "@language",
+    "@list",
+    "@nest",
+    "@none",
+    "@prefix",
+    "@propagate",
+    "@protected",
+    "@reverse",
+    "@set",
+    "@type",
+    "@value",
+    "@version",
+    "@vocab",
+];
+
+/// True iff `s` is one of the recognised JSON-LD 1.1 [`KEYWORDS`].
+pub(crate) fn is_keyword(s: &str) -> bool {
+    KEYWORDS.contains(&s)
+}
+
+/// True iff `s` has the *form* of a keyword — `@` followed by one or more ASCII letters
+/// and nothing else — regardless of whether it is a recognised keyword. A token with this
+/// form that is **not** a recognised keyword is silently ignored (not treated as an IRI).
+pub(crate) fn has_keyword_form(s: &str) -> bool {
+    match s.strip_prefix('@') {
+        Some(rest) => !rest.is_empty() && rest.bytes().all(|b| b.is_ascii_alphabetic()),
+        None => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn direction_roundtrips() {
+        assert_eq!(Direction::Ltr.as_str(), "ltr");
+        assert_eq!(Direction::Rtl.as_str(), "rtl");
+        assert_eq!(Direction::parse("ltr"), Some(Direction::Ltr));
+        assert_eq!(Direction::parse("rtl"), Some(Direction::Rtl));
+        assert_eq!(Direction::parse("upside-down"), None);
+    }
+
+    #[test]
+    fn override_is_set_discriminates() {
+        assert!(!Override::<String>::Unset.is_set());
+        assert!(Override::<String>::Null.is_set());
+        assert!(Override::Set("en".to_string()).is_set());
+        assert_eq!(Override::<String>::default(), Override::Unset);
+    }
+
+    #[test]
+    fn new_active_context_sets_base_and_is_empty() {
+        let ac = ActiveContext::new(Some("http://example.org/"));
+        assert_eq!(ac.base_iri(), Some("http://example.org/"));
+        assert_eq!(ac.vocabulary_mapping(), None);
+        assert_eq!(ac.default_language(), None);
+        assert_eq!(ac.default_base_direction(), None);
+        assert_eq!(ac.term_count(), 0);
+        assert!(!ac.has_term("x"));
+        assert_eq!(ac.term_definition("x"), None);
+
+        let none = ActiveContext::new(None);
+        assert_eq!(none.base_iri(), None);
+    }
+
+    #[test]
+    fn term_definition_accessors_expose_the_fields() {
+        let def = TermDefinition {
+            iri: Some("http://example.org/name".to_string()),
+            reverse: true,
+            type_mapping: Some("@id".to_string()),
+            language: Override::Set("en".to_string()),
+            direction: Override::Null,
+            index: Some("http://example.org/idx".to_string()),
+            container: vec!["@set".to_string()],
+            nest: Some("@nest".to_string()),
+            context: Some(Json::obj()),
+            base_url: Some("http://example.org/".to_string()),
+            prefix: true,
+            protected: true,
+        };
+        assert_eq!(def.iri(), Some("http://example.org/name"));
+        assert!(def.is_reverse());
+        assert_eq!(def.type_mapping(), Some("@id"));
+        assert_eq!(def.language(), &Override::Set("en".to_string()));
+        assert_eq!(def.direction(), &Override::Null);
+        assert_eq!(def.index(), Some("http://example.org/idx"));
+        assert_eq!(def.container(), &["@set".to_string()]);
+        assert_eq!(def.nest(), Some("@nest"));
+        assert_eq!(def.context(), Some(&Json::obj()));
+        assert!(def.is_prefix());
+        assert!(def.is_protected());
+    }
+
+    #[test]
+    fn same_except_protected_ignores_only_the_protected_flag() {
+        let base = TermDefinition {
+            iri: Some("http://example.org/a".to_string()),
+            ..Default::default()
+        };
+        let protected = TermDefinition {
+            protected: true,
+            ..base.clone()
+        };
+        assert!(base.same_except_protected(&protected));
+        let different = TermDefinition {
+            iri: Some("http://example.org/b".to_string()),
+            ..base.clone()
+        };
+        assert!(!base.same_except_protected(&different));
+    }
+
+    #[test]
+    fn keyword_predicates() {
+        assert!(is_keyword("@id"));
+        assert!(is_keyword("@vocab"));
+        assert!(!is_keyword("@id2"));
+        assert!(!is_keyword("id"));
+
+        assert!(has_keyword_form("@id"));
+        assert!(has_keyword_form("@notakeyword"));
+        assert!(!has_keyword_form("@id2")); // digit breaks the ALPHA-only form
+        assert!(!has_keyword_form("@"));
+        assert!(!has_keyword_form("foo"));
+    }
+
+    #[test]
+    fn has_protected_terms_detects_a_protected_definition() {
+        let mut ac = ActiveContext::new(None);
+        ac.term_definitions.insert(
+            "a".to_string(),
+            TermDefinition {
+                protected: true,
+                ..Default::default()
+            },
+        );
+        assert!(ac.has_protected_terms());
+        let mut plain = ActiveContext::new(None);
+        plain
+            .term_definitions
+            .insert("b".to_string(), TermDefinition::default());
+        // A defined term with a null IRI mapping is retained but is not protected.
+        plain.term_definitions.insert(
+            "c".to_string(),
+            TermDefinition {
+                iri: None,
+                ..Default::default()
+            },
+        );
+        assert!(!plain.has_protected_terms());
+    }
+}

--- a/crates/sparq-jsonld/src/context/process.rs
+++ b/crates/sparq-jsonld/src/context/process.rs
@@ -669,7 +669,10 @@ fn finish_definition(
         let Json::Str(ns) = n else {
             return Err(JsonLdError::new(E::InvalidNestValue));
         };
-        if ns != "@nest" && is_keyword(ns) {
+        // [OPUS-4.8] (sq-oy1f.24) Per JSON-LD 1.1 Create Term Definition, an `@nest` value
+        // must not be a keyword *or have keyword form* other than `@nest` itself — a token
+        // like `@bogus` (keyword-form but unrecognised) is still an invalid @nest value.
+        if ns != "@nest" && has_keyword_form(ns) {
             return Err(JsonLdError::new(E::InvalidNestValue));
         }
         def.nest = Some(ns.clone());

--- a/crates/sparq-jsonld/src/context/process.rs
+++ b/crates/sparq-jsonld/src/context/process.rs
@@ -1,8 +1,807 @@
 //! Context Processing Algorithm + Create Term Definition (JSON-LD 1.1 API §4).
 //!
-//! **Scaffold (`sq-oy1f.23`).** Spec references only; implemented in bead `sq-oy1f.24`.
-//! This is where a chain of local/remote `@context` definitions is folded into an
-//! [`ActiveContext`](super::ActiveContext) — including keyword handling, `@protected` term
-//! protection, `@propagate`, `@import`, and `@vocab`/`@base`/`@language`/`@direction`
-//! defaults — with remote contexts fetched only through the
-//! [`DocumentLoader`](crate::loader::DocumentLoader) (deny-by-default).
+//! [OPUS-4.8] (sq-oy1f.24) Folds a chain of local/remote `@context` definitions into an
+//! [`ActiveContext`], handling keyword aliases, `@protected` term protection,
+//! `@propagate`, `@import`, `@version`, and the `@vocab`/`@base`/`@language`/`@direction`
+//! defaults. Remote contexts (`@context` strings and `@import`) are dereferenced **only**
+//! through the [`DocumentLoader`], which is deny-by-default.
+//!
+//! Spec: <https://www.w3.org/TR/json-ld11-api/#context-processing-algorithm> and
+//! <https://www.w3.org/TR/json-ld11-api/#create-term-definition>.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::iri::{expand_iri_in_context, is_absolute_iri, is_blank_node, resolve_iri};
+use super::{has_keyword_form, is_keyword, ActiveContext, Direction, Override, TermDefinition};
+use crate::error::{JsonLdError, JsonLdErrorCode as E};
+use crate::json::Json;
+use crate::loader::DocumentLoader;
+use crate::options::{JsonLdOptions, ProcessingMode};
+
+/// A processor-defined ceiling on the depth of remote-context dereferencing, guarding the
+/// `context overflow` error condition (JSON-LD 1.1 API §4.1.2 step 5.2).
+const MAX_REMOTE_CONTEXTS: usize = 100;
+
+/// Shared, mutable processing environment threaded through Context Processing and Create
+/// Term Definition — the loader, processing mode, current base URL, the remote-context
+/// recursion guard, and the scoped-context validation flag. Bundled to keep argument
+/// counts sane.
+pub(crate) struct Env<'a> {
+    pub(crate) loader: &'a dyn DocumentLoader,
+    pub(crate) mode: ProcessingMode,
+    pub(crate) base_url: Option<String>,
+    pub(crate) remote_contexts: Vec<String>,
+    pub(crate) validate_scoped: bool,
+}
+
+impl ActiveContext {
+    /// The **Context Processing Algorithm** (JSON-LD 1.1 API §4.1): folds `local_context`
+    /// (a context definition, IRI string, `null`, or array thereof) into a fresh active
+    /// context derived from `self`.
+    ///
+    /// `base_url` is the base for resolving relative references in the context (e.g. remote
+    /// context IRIs and `@import`). Remote references are dereferenced only through
+    /// `loader`; the default [`NoopLoader`](crate::loader::NoopLoader) refuses every fetch,
+    /// so a context that references a remote document fails closed with `loading remote
+    /// context failed`. Returns the processed [`ActiveContext`] or the first spec error.
+    pub fn process(
+        &self,
+        local_context: &Json,
+        base_url: Option<&str>,
+        loader: &dyn DocumentLoader,
+        options: &JsonLdOptions,
+    ) -> Result<ActiveContext, JsonLdError> {
+        let mut env = Env {
+            loader,
+            mode: options.processing_mode,
+            base_url: base_url.map(str::to_string),
+            remote_contexts: Vec::new(),
+            validate_scoped: true,
+        };
+        process_inner(self, local_context, false, true, &mut env)
+    }
+}
+
+/// The recursive core of Context Processing (§4.1.2). `override_protected` disables the
+/// protected-term guard (used when validating scoped contexts); `propagate` controls
+/// whether a null context resets the previous-context link.
+pub(crate) fn process_inner(
+    active: &ActiveContext,
+    local_context: &Json,
+    override_protected: bool,
+    mut propagate: bool,
+    env: &mut Env,
+) -> Result<ActiveContext, JsonLdError> {
+    // step 1: result is a copy of the input active context.
+    let mut result = active.clone();
+
+    // step 2: a top-level @propagate overrides the inherited value.
+    if let Json::Obj(_) = local_context {
+        if let Some(p) = local_context.get("@propagate") {
+            propagate = as_bool(p).ok_or_else(|| JsonLdError::new(E::InvalidPropagateValue))?;
+        }
+    }
+
+    // step 3: when not propagating, remember the input context to revert to.
+    if !propagate && result.previous_context.is_none() {
+        result.previous_context = Some(Box::new(active.clone()));
+    }
+
+    // step 4: normalise to an array of contexts.
+    let contexts: Vec<Json> = match local_context {
+        Json::Arr(items) => items.clone(),
+        other => vec![other.clone()],
+    };
+
+    // step 5: fold each context in turn.
+    for context in &contexts {
+        // 5.1: a null context resets the active context.
+        if is_null(context) {
+            if !override_protected && result.has_protected_terms() {
+                return Err(JsonLdError::new(E::InvalidContextNullification));
+            }
+            let mut fresh = ActiveContext::new(active.original_base_url.as_deref());
+            if !propagate {
+                fresh.previous_context = Some(Box::new(result.clone()));
+            }
+            result = fresh;
+            continue;
+        }
+
+        // 5.2: a string context is a remote reference.
+        if let Json::Str(iri) = context {
+            let resolved = match &env.base_url {
+                Some(b) => resolve_iri(b, iri),
+                None => iri.clone(),
+            };
+            // 5.2.2: skip a context already loaded when not re-validating.
+            if !env.validate_scoped && env.remote_contexts.contains(&resolved) {
+                continue;
+            }
+            // 5.2.3: recursion guard.
+            if env.remote_contexts.len() >= MAX_REMOTE_CONTEXTS {
+                return Err(JsonLdError::new(E::ContextOverflow));
+            }
+            env.remote_contexts.push(resolved.clone());
+            // 5.2.5: dereference through the loader (deny-by-default).
+            let doc = env
+                .loader
+                .load_document(&resolved)
+                .map_err(|e| JsonLdError::with_detail(E::LoadingRemoteContextFailed, e.to_string()))?;
+            let parsed = Json::parse(&doc.document)
+                .map_err(|e| JsonLdError::with_detail(E::InvalidRemoteContext, e.to_string()))?;
+            let loaded_ctx = match parsed.get("@context") {
+                Some(c) => c.clone(),
+                None => return Err(JsonLdError::new(E::InvalidRemoteContext)),
+            };
+            // 5.2.7: recurse using the retrieved document URL as the base. `remote_contexts`
+            // behaves as a properly-scoped stack: `resolved` is visible to the recursion
+            // (so nested self-references are detected and the recursion's own `@base` is
+            // suppressed), then popped so a *sibling* context in this same array is
+            // processed as if freshly invoked (matching the spec's per-invocation
+            // `remote contexts` copy semantics).
+            let saved_base = env.base_url.take();
+            let saved_validate = env.validate_scoped;
+            env.base_url = Some(doc.document_url.clone());
+            env.validate_scoped = false;
+            let recursed = process_inner(&result, &loaded_ctx, override_protected, propagate, env);
+            env.base_url = saved_base;
+            env.validate_scoped = saved_validate;
+            env.remote_contexts.pop();
+            result = recursed?;
+            continue;
+        }
+
+        // 5.3: anything else must be a context-definition map.
+        if !matches!(context, Json::Obj(_)) {
+            return Err(JsonLdError::new(E::InvalidLocalContext));
+        }
+
+        // 5.5: @version.
+        if let Some(v) = context.get("@version") {
+            if !matches!(v, Json::Raw(r) if r == "1.1") {
+                return Err(JsonLdError::new(E::InvalidVersionValue));
+            }
+            if env.mode == ProcessingMode::JsonLd10 {
+                return Err(JsonLdError::new(E::ProcessingModeConflict));
+            }
+        }
+
+        // 5.6: @import merges a remote context under the local one.
+        let merged;
+        let context: &Json = if let Some(imp) = context.get("@import") {
+            if env.mode == ProcessingMode::JsonLd10 {
+                return Err(JsonLdError::new(E::InvalidContextEntry));
+            }
+            let Json::Str(imp_iri) = imp else {
+                return Err(JsonLdError::new(E::InvalidImportValue));
+            };
+            let resolved = match &env.base_url {
+                Some(b) => resolve_iri(b, imp_iri),
+                None => imp_iri.clone(),
+            };
+            let doc = env
+                .loader
+                .load_document(&resolved)
+                .map_err(|e| JsonLdError::with_detail(E::LoadingRemoteContextFailed, e.to_string()))?;
+            let parsed = Json::parse(&doc.document)
+                .map_err(|e| JsonLdError::with_detail(E::InvalidRemoteContext, e.to_string()))?;
+            let import_members = match parsed.get("@context") {
+                Some(Json::Obj(m)) => m.clone(),
+                _ => return Err(JsonLdError::new(E::InvalidRemoteContext)),
+            };
+            if import_members.iter().any(|(k, _)| k == "@import") {
+                return Err(JsonLdError::new(E::InvalidContextEntry));
+            }
+            merged = merge_import(&import_members, context);
+            &merged
+        } else {
+            context
+        };
+
+        // 5.7: @base — only for a directly-embedded (non-remote) context.
+        if env.remote_contexts.is_empty() {
+            if let Some(b) = context.get("@base") {
+                if is_null(b) {
+                    result.base_iri = None;
+                } else if let Json::Str(s) = b {
+                    if is_absolute_iri(s) {
+                        result.base_iri = Some(s.clone());
+                    } else if let Some(cur) = result.base_iri.clone() {
+                        result.base_iri = Some(resolve_iri(&cur, s));
+                    } else {
+                        return Err(JsonLdError::new(E::InvalidBaseIri));
+                    }
+                } else {
+                    return Err(JsonLdError::new(E::InvalidBaseIri));
+                }
+            }
+        }
+
+        // 5.8: @vocab.
+        if let Some(v) = context.get("@vocab") {
+            if is_null(v) {
+                result.vocabulary_mapping = None;
+            } else if let Json::Str(s) = v {
+                match result.expand_iri_readonly(s, true, true) {
+                    Some(e) if e.is_empty() || is_absolute_iri(&e) || is_blank_node(&e) => {
+                        result.vocabulary_mapping = Some(e);
+                    }
+                    _ => return Err(JsonLdError::new(E::InvalidVocabMapping)),
+                }
+            } else {
+                return Err(JsonLdError::new(E::InvalidVocabMapping));
+            }
+        }
+
+        // 5.9: @language.
+        if let Some(v) = context.get("@language") {
+            if is_null(v) {
+                result.default_language = None;
+            } else if let Json::Str(s) = v {
+                result.default_language = Some(s.clone());
+            } else {
+                return Err(JsonLdError::new(E::InvalidDefaultLanguage));
+            }
+        }
+
+        // 5.10: @direction.
+        if let Some(v) = context.get("@direction") {
+            if env.mode == ProcessingMode::JsonLd10 {
+                return Err(JsonLdError::new(E::InvalidContextEntry));
+            }
+            if is_null(v) {
+                result.default_base_direction = None;
+            } else if let Json::Str(s) = v {
+                result.default_base_direction =
+                    Some(Direction::parse(s).ok_or_else(|| JsonLdError::new(E::InvalidBaseDirection))?);
+            } else {
+                return Err(JsonLdError::new(E::InvalidBaseDirection));
+            }
+        }
+
+        // 5.11: @propagate is validated (its effect was applied in step 2).
+        if let Some(v) = context.get("@propagate") {
+            if env.mode == ProcessingMode::JsonLd10 {
+                return Err(JsonLdError::new(E::InvalidContextEntry));
+            }
+            if as_bool(v).is_none() {
+                return Err(JsonLdError::new(E::InvalidPropagateValue));
+            }
+        }
+
+        // 5.12/5.13: the context-wide @protected flag, then a term definition per key.
+        let protected = match context.get("@protected") {
+            Some(v) => as_bool(v).ok_or_else(|| JsonLdError::new(E::InvalidProtectedValue))?,
+            None => false,
+        };
+        let mut defined: BTreeMap<String, bool> = BTreeMap::new();
+        if let Json::Obj(members) = context {
+            for (key, _) in members {
+                if is_context_keyword(key) {
+                    continue;
+                }
+                create_term_definition(
+                    &mut result,
+                    context,
+                    key,
+                    &mut defined,
+                    protected,
+                    override_protected,
+                    env,
+                )?;
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// The context-level keywords handled directly by Context Processing (not term keys).
+fn is_context_keyword(key: &str) -> bool {
+    matches!(
+        key,
+        "@base" | "@direction" | "@import" | "@language" | "@propagate" | "@protected" | "@version" | "@vocab"
+    )
+}
+
+/// Merges an imported context under the local one: the imported entries provide defaults,
+/// which the local context's entries override (`@import` itself is dropped).
+fn merge_import(import_members: &[(String, Json)], context: &Json) -> Json {
+    let mut merged = Json::Obj(import_members.to_vec());
+    if let Json::Obj(members) = context {
+        for (k, v) in members {
+            if k == "@import" {
+                continue;
+            }
+            merged.set(k, v.clone());
+        }
+    }
+    merged
+}
+
+/// The **Create Term Definition** algorithm (JSON-LD 1.1 API §4.2.2). Builds (or validates)
+/// the definition for `term` from `local`, storing it into `active` and recording progress
+/// in `defined` (guarding against cyclic references).
+pub(crate) fn create_term_definition(
+    active: &mut ActiveContext,
+    local: &Json,
+    term: &str,
+    defined: &mut BTreeMap<String, bool>,
+    protected: bool,
+    override_protected: bool,
+    env: &mut Env,
+) -> Result<(), JsonLdError> {
+    // step 1: already built, or a cycle.
+    match defined.get(term) {
+        Some(true) => return Ok(()),
+        Some(false) => return Err(JsonLdError::new(E::CyclicIriMapping)),
+        None => {}
+    }
+    // step 2: an empty term is invalid; mark this term in-progress.
+    if term.is_empty() {
+        return Err(JsonLdError::new(E::InvalidTermDefinition));
+    }
+    defined.insert(term.to_string(), false);
+
+    // step 3: the raw value for this term (a missing key defaults to null).
+    let raw = local.get(term).cloned().unwrap_or_else(json_null);
+
+    // steps 4/5: keyword handling.
+    if term == "@type" {
+        if env.mode == ProcessingMode::JsonLd10 {
+            return Err(JsonLdError::new(E::KeywordRedefinition));
+        }
+        // Redefining @type is allowed only with @container: @set and/or @protected.
+        let ok = match &raw {
+            Json::Obj(members) => {
+                !members.is_empty()
+                    && members.iter().all(|(k, v)| {
+                        (k == "@container" && matches!(v, Json::Str(s) if s == "@set"))
+                            || k == "@protected"
+                    })
+            }
+            _ => false,
+        };
+        if !ok {
+            return Err(JsonLdError::new(E::KeywordRedefinition));
+        }
+    } else if is_keyword(term) {
+        return Err(JsonLdError::new(E::KeywordRedefinition));
+    } else if has_keyword_form(term) {
+        // Keyword-shaped but unrecognised: ignore (no definition created).
+        defined.insert(term.to_string(), true);
+        return Ok(());
+    }
+
+    // step 6: remove and remember any existing definition (for the protected check).
+    let previous_definition = active.term_definitions.remove(term);
+
+    // steps 7–9: normalise the value to a map and record whether it was a simple term.
+    let (value, simple_term) = match &raw {
+        Json::Str(s) => (
+            Json::Obj(vec![("@id".to_string(), Json::Str(s.clone()))]),
+            true,
+        ),
+        Json::Obj(_) => (raw.clone(), false),
+        j if is_null(j) => (Json::Obj(vec![("@id".to_string(), json_null())]), false),
+        _ => return Err(JsonLdError::new(E::InvalidTermDefinition)),
+    };
+
+    // step 10/11: seed the definition and apply @protected.
+    let mut def = TermDefinition {
+        protected,
+        ..Default::default()
+    };
+    if let Some(p) = value.get("@protected") {
+        if env.mode == ProcessingMode::JsonLd10 {
+            return Err(JsonLdError::new(E::InvalidTermDefinition));
+        }
+        def.protected = as_bool(p).ok_or_else(|| JsonLdError::new(E::InvalidProtectedValue))?;
+    }
+
+    // step 12: @type mapping.
+    if let Some(t) = value.get("@type") {
+        let Json::Str(ts) = t else {
+            return Err(JsonLdError::new(E::InvalidTypeMapping));
+        };
+        let ts = ts.clone();
+        let expanded = expand_iri_in_context(active, &ts, false, true, local, defined, env)?
+            .ok_or_else(|| JsonLdError::new(E::InvalidTypeMapping))?;
+        let valid = match expanded.as_str() {
+            "@json" | "@none" => env.mode != ProcessingMode::JsonLd10,
+            "@id" | "@vocab" => true,
+            other => is_absolute_iri(other),
+        };
+        if !valid {
+            return Err(JsonLdError::new(E::InvalidTypeMapping));
+        }
+        def.type_mapping = Some(expanded);
+    }
+
+    // step 13: @reverse — a self-contained branch that stores and returns.
+    if let Some(rev) = value.get("@reverse") {
+        return create_reverse_definition(active, local, term, defined, env, &value, rev.clone(), def);
+    }
+    def.reverse = false;
+
+    // step 14: derive the IRI mapping.
+    let id_entry = value.get("@id").cloned();
+    let id_differs = match &id_entry {
+        Some(Json::Str(s)) => s != term,
+        Some(_) => true, // null (or another non-string) differs from the term
+        None => false,
+    };
+    if let Some(idj) = id_entry.filter(|_| id_differs) {
+        if is_null(&idj) {
+            // @id: null — a retained definition with a null IRI mapping (falls through to
+            // the common tail so container/index/etc. still apply, then is stored).
+            def.iri = None;
+        } else {
+            let Json::Str(ids) = &idj else {
+                return Err(JsonLdError::new(E::InvalidIriMapping));
+            };
+            let ids = ids.clone();
+            if ids != "@none" && !is_keyword(&ids) && has_keyword_form(&ids) {
+                // @id looks like a keyword but is not one: ignore this term.
+                defined.insert(term.to_string(), true);
+                return Ok(());
+            }
+            let expanded = expand_iri_in_context(active, &ids, false, true, local, defined, env)?
+                .ok_or_else(|| JsonLdError::new(E::InvalidIriMapping))?;
+            if expanded == "@context" {
+                return Err(JsonLdError::new(E::InvalidKeywordAlias));
+            }
+            if !(is_keyword(&expanded) || is_absolute_iri(&expanded) || is_blank_node(&expanded)) {
+                return Err(JsonLdError::new(E::InvalidIriMapping));
+            }
+            def.iri = Some(expanded.clone());
+            // Round-trip check for compact / relative-IRI terms.
+            if term.find(':').is_some_and(|i| i > 0) || term.contains('/') {
+                defined.insert(term.to_string(), true);
+                let rt = expand_iri_in_context(active, term, false, true, local, defined, env)?;
+                if rt.as_deref() != Some(expanded.as_str()) {
+                    return Err(JsonLdError::new(E::InvalidIriMapping));
+                }
+            }
+            // Simple-term prefix flag.
+            if simple_term
+                && term.find(':').is_none()
+                && !term.contains('/')
+                && (ends_with_gen_delim(&expanded) || is_blank_node(&expanded))
+            {
+                def.prefix = true;
+            }
+        }
+    } else {
+        derive_iri(active, local, term, defined, env, &mut def)?;
+    }
+
+    finish_definition(
+        active,
+        local,
+        term,
+        defined,
+        override_protected,
+        env,
+        &value,
+        def,
+        previous_definition,
+    )
+}
+
+/// Derives the IRI mapping for a term with no distinct `@id` (§4.2.2 steps 14.3–14.6):
+/// a compact IRI (`prefix:suffix`), a relative-IRI term (contains `/`), the `@type`
+/// keyword, or a term expanded against `@vocab`.
+fn derive_iri(
+    active: &mut ActiveContext,
+    local: &Json,
+    term: &str,
+    defined: &mut BTreeMap<String, bool>,
+    env: &mut Env,
+    def: &mut TermDefinition,
+) -> Result<(), JsonLdError> {
+    if term.find(':').is_some_and(|i| i > 0) {
+        let colon = term.find(':').unwrap();
+        let (prefix, suffix) = (&term[..colon], &term[colon + 1..]);
+        if local.get(prefix).is_some() {
+            create_term_definition(active, local, prefix, defined, false, false, env)?;
+        }
+        if let Some(pdef) = active.term_definitions.get(prefix) {
+            if let Some(piri) = &pdef.iri {
+                def.iri = Some(format!("{}{}", piri, suffix));
+                return Ok(());
+            }
+        }
+        // The term is already an absolute IRI.
+        def.iri = Some(term.to_string());
+        Ok(())
+    } else if term.contains('/') {
+        match active.expand_iri_readonly(term, false, true) {
+            Some(e) if is_absolute_iri(&e) => {
+                def.iri = Some(e);
+                Ok(())
+            }
+            _ => Err(JsonLdError::new(E::InvalidIriMapping)),
+        }
+    } else if term == "@type" {
+        def.iri = Some("@type".to_string());
+        Ok(())
+    } else if let Some(vocab) = &active.vocabulary_mapping {
+        def.iri = Some(format!("{}{}", vocab, term));
+        Ok(())
+    } else {
+        Err(JsonLdError::new(E::InvalidIriMapping))
+    }
+}
+
+/// Builds and stores a reverse-property definition (§4.2.2 step 13).
+#[allow(clippy::too_many_arguments)]
+fn create_reverse_definition(
+    active: &mut ActiveContext,
+    local: &Json,
+    term: &str,
+    defined: &mut BTreeMap<String, bool>,
+    env: &mut Env,
+    value: &Json,
+    rev: Json,
+    mut def: TermDefinition,
+) -> Result<(), JsonLdError> {
+    if value.get("@id").is_some() || value.get("@nest").is_some() {
+        return Err(JsonLdError::new(E::InvalidReverseProperty));
+    }
+    let Json::Str(rs) = &rev else {
+        return Err(JsonLdError::new(E::InvalidIriMapping));
+    };
+    if has_keyword_form(rs) && !is_keyword(rs) {
+        defined.insert(term.to_string(), true);
+        return Ok(());
+    }
+    let rs = rs.clone();
+    match expand_iri_in_context(active, &rs, false, true, local, defined, env)? {
+        Some(e) if is_absolute_iri(&e) || is_blank_node(&e) => def.iri = Some(e),
+        _ => return Err(JsonLdError::new(E::InvalidIriMapping)),
+    }
+    if let Some(c) = value.get("@container") {
+        def.container = match c {
+            Json::Str(s) if s == "@set" || s == "@index" => vec![s.clone()],
+            j if is_null(j) => vec![],
+            _ => return Err(JsonLdError::new(E::InvalidReverseProperty)),
+        };
+    }
+    def.reverse = true;
+    active.term_definitions.insert(term.to_string(), def);
+    defined.insert(term.to_string(), true);
+    Ok(())
+}
+
+/// Applies the remaining term-definition entries (@container, @index, @context, @language,
+/// @direction, @nest, @prefix), validates the key set, enforces the protected-redefinition
+/// rule, and stores the definition (§4.2.2 steps 17–29).
+#[allow(clippy::too_many_arguments)]
+fn finish_definition(
+    active: &mut ActiveContext,
+    local: &Json,
+    term: &str,
+    defined: &mut BTreeMap<String, bool>,
+    override_protected: bool,
+    env: &mut Env,
+    value: &Json,
+    mut def: TermDefinition,
+    previous_definition: Option<TermDefinition>,
+) -> Result<(), JsonLdError> {
+    // @container.
+    if let Some(c) = value.get("@container") {
+        let members = normalize_container(c).ok_or_else(|| JsonLdError::new(E::InvalidContainerMapping))?;
+        if !valid_container(&members, env.mode) {
+            return Err(JsonLdError::new(E::InvalidContainerMapping));
+        }
+        def.container = members;
+        if def.container.iter().any(|m| m == "@type") {
+            match def.type_mapping.as_deref() {
+                None => def.type_mapping = Some("@id".to_string()),
+                Some("@id") | Some("@vocab") => {}
+                Some(_) => return Err(JsonLdError::new(E::InvalidTypeMapping)),
+            }
+        }
+    }
+
+    // @index.
+    if let Some(idx) = value.get("@index") {
+        if env.mode == ProcessingMode::JsonLd10 || !def.container.iter().any(|m| m == "@index") {
+            return Err(JsonLdError::new(E::InvalidTermDefinition));
+        }
+        let Json::Str(is) = idx else {
+            return Err(JsonLdError::new(E::InvalidTermDefinition));
+        };
+        let is = is.clone();
+        match expand_iri_in_context(active, &is, false, true, local, defined, env)? {
+            Some(e) if is_absolute_iri(&e) => {}
+            _ => return Err(JsonLdError::new(E::InvalidTermDefinition)),
+        }
+        def.index = Some(is);
+    }
+
+    // @context (a scoped context) — validated now, re-processed on use.
+    if let Some(ctx) = value.get("@context") {
+        if env.mode == ProcessingMode::JsonLd10 {
+            return Err(JsonLdError::new(E::InvalidTermDefinition));
+        }
+        let saved_validate = env.validate_scoped;
+        env.validate_scoped = false;
+        let validated = process_inner(active, ctx, true, true, env);
+        env.validate_scoped = saved_validate;
+        validated.map_err(|_| JsonLdError::new(E::InvalidScopedContext))?;
+        def.context = Some(ctx.clone());
+        def.base_url = env.base_url.clone();
+    }
+
+    // @language / @direction only apply when there is no type mapping.
+    let has_type = value.get("@type").is_some();
+    if let Some(l) = value.get("@language") {
+        if !has_type {
+            def.language = if is_null(l) {
+                Override::Null
+            } else if let Json::Str(s) = l {
+                Override::Set(s.clone())
+            } else {
+                return Err(JsonLdError::new(E::InvalidLanguageMapping));
+            };
+        }
+    }
+    if let Some(d) = value.get("@direction") {
+        if !has_type {
+            def.direction = if is_null(d) {
+                Override::Null
+            } else if let Json::Str(s) = d {
+                Override::Set(Direction::parse(s).ok_or_else(|| JsonLdError::new(E::InvalidBaseDirection))?)
+            } else {
+                return Err(JsonLdError::new(E::InvalidBaseDirection));
+            };
+        }
+    }
+
+    // @nest.
+    if let Some(n) = value.get("@nest") {
+        if env.mode == ProcessingMode::JsonLd10 {
+            return Err(JsonLdError::new(E::InvalidTermDefinition));
+        }
+        let Json::Str(ns) = n else {
+            return Err(JsonLdError::new(E::InvalidNestValue));
+        };
+        if ns != "@nest" && is_keyword(ns) {
+            return Err(JsonLdError::new(E::InvalidNestValue));
+        }
+        def.nest = Some(ns.clone());
+    }
+
+    // @prefix.
+    if let Some(p) = value.get("@prefix") {
+        if env.mode == ProcessingMode::JsonLd10 || term.contains(':') || term.contains('/') {
+            return Err(JsonLdError::new(E::InvalidTermDefinition));
+        }
+        def.prefix = as_bool(p).ok_or_else(|| JsonLdError::new(E::InvalidPrefixValue))?;
+        if def.prefix && def.iri.as_deref().is_some_and(is_keyword) {
+            return Err(JsonLdError::new(E::InvalidTermDefinition));
+        }
+    }
+
+    // step 27: reject unknown term-definition keys.
+    const ALLOWED: &[&str] = &[
+        "@id",
+        "@reverse",
+        "@container",
+        "@context",
+        "@direction",
+        "@index",
+        "@language",
+        "@nest",
+        "@prefix",
+        "@protected",
+        "@type",
+    ];
+    if let Json::Obj(members) = value {
+        for (k, _) in members {
+            if !ALLOWED.contains(&k.as_str()) {
+                return Err(JsonLdError::new(E::InvalidTermDefinition));
+            }
+        }
+    }
+
+    // step 28: protected-term redefinition guard.
+    if !override_protected {
+        if let Some(prev) = &previous_definition {
+            if prev.is_protected() {
+                if !def.same_except_protected(prev) {
+                    return Err(JsonLdError::new(E::ProtectedTermRedefinition));
+                }
+                // Identical up to @protected: keep the protected definition.
+                def = prev.clone();
+            }
+        }
+    }
+
+    active.term_definitions.insert(term.to_string(), def);
+    defined.insert(term.to_string(), true);
+    Ok(())
+}
+
+/// Normalises an `@container` value (a string or array of strings) to a list of keywords,
+/// or `None` if it is not a string / string-array.
+fn normalize_container(c: &Json) -> Option<Vec<String>> {
+    match c {
+        Json::Str(s) => Some(vec![s.clone()]),
+        Json::Arr(items) => {
+            let mut v = Vec::with_capacity(items.len());
+            for it in items {
+                match it {
+                    Json::Str(s) => v.push(s.clone()),
+                    _ => return None,
+                }
+            }
+            Some(v)
+        }
+        _ => None,
+    }
+}
+
+/// Validates an `@container` mapping against the allowed keyword combinations (§4.2.2
+/// container-mapping rules), honouring the JSON-LD 1.0 restriction to a single
+/// `@list`/`@set`/`@index`.
+fn valid_container(members: &[String], mode: ProcessingMode) -> bool {
+    let set: BTreeSet<&str> = members.iter().map(String::as_str).collect();
+    if set.len() != members.len() {
+        return false; // duplicates
+    }
+    if mode == ProcessingMode::JsonLd10 {
+        return members.len() == 1 && matches!(members[0].as_str(), "@list" | "@set" | "@index");
+    }
+    if members.len() == 1 {
+        return matches!(
+            members[0].as_str(),
+            "@graph" | "@id" | "@index" | "@language" | "@list" | "@set" | "@type"
+        );
+    }
+    if set.contains("@list") {
+        return false; // @list never combines
+    }
+    if set.contains("@graph") {
+        let extra: BTreeSet<&str> = set.iter().filter(|m| **m != "@graph").copied().collect();
+        if !extra.iter().all(|m| matches!(*m, "@id" | "@index" | "@set")) {
+            return false;
+        }
+        return !(extra.contains("@id") && extra.contains("@index"));
+    }
+    if set.contains("@set") {
+        let extra: BTreeSet<&str> = set.iter().filter(|m| **m != "@set").copied().collect();
+        return extra.len() == 1
+            && extra
+                .iter()
+                .all(|m| matches!(*m, "@index" | "@id" | "@type" | "@language"));
+    }
+    false
+}
+
+/// True iff `s` ends with an RFC 3986 gen-delim character (`:` `/` `?` `#` `[` `]` `@`).
+fn ends_with_gen_delim(s: &str) -> bool {
+    s.ends_with([':', '/', '?', '#', '[', ']', '@'])
+}
+
+/// The `Json` representation of a JSON `null`.
+fn json_null() -> Json {
+    Json::Raw("null".to_string())
+}
+
+/// True iff `j` is a JSON `null`.
+fn is_null(j: &Json) -> bool {
+    matches!(j, Json::Raw(r) if r == "null")
+}
+
+/// Interprets a JSON boolean scalar, or `None` for any non-boolean value.
+fn as_bool(j: &Json) -> Option<bool> {
+    match j {
+        Json::Raw(r) if r == "true" => Some(true),
+        Json::Raw(r) if r == "false" => Some(false),
+        _ => None,
+    }
+}

--- a/crates/sparq-jsonld/src/json.rs
+++ b/crates/sparq-jsonld/src/json.rs
@@ -109,6 +109,270 @@ impl Json {
             }
         }
     }
+
+    /// Parses a JSON text into a [`Json`] value. [OPUS-4.8] (sq-oy1f.24) A minimal,
+    /// dependency-free recursive-descent parser used to read remote `@context` and
+    /// `@import` documents retrieved through a [`DocumentLoader`](crate::loader::DocumentLoader).
+    ///
+    /// Numbers, `true`, `false`, and `null` are preserved verbatim as [`Json::Raw`] scalar
+    /// tokens; strings are unescaped. Duplicate object keys keep the last value (first
+    /// position). Object member order is preserved.
+    pub fn parse(input: &str) -> Result<Json, JsonParseError> {
+        let mut p = Parser {
+            bytes: input.as_bytes(),
+            pos: 0,
+        };
+        p.skip_ws();
+        let value = p.parse_value()?;
+        p.skip_ws();
+        if p.pos != p.bytes.len() {
+            return Err(p.error("trailing characters after JSON value"));
+        }
+        Ok(value)
+    }
+}
+
+/// An error from [`Json::parse`]: a human-readable message and the byte offset into the
+/// input at which parsing failed.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct JsonParseError {
+    /// A human-readable description of the failure.
+    pub message: String,
+    /// The byte offset into the input at which the error was detected.
+    pub position: usize,
+}
+
+impl std::fmt::Display for JsonParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "JSON parse error at byte {}: {}", self.position, self.message)
+    }
+}
+
+impl std::error::Error for JsonParseError {}
+
+/// A minimal recursive-descent JSON parser over the input bytes.
+struct Parser<'a> {
+    bytes: &'a [u8],
+    pos: usize,
+}
+
+impl Parser<'_> {
+    fn error(&self, msg: &str) -> JsonParseError {
+        JsonParseError {
+            message: msg.to_string(),
+            position: self.pos,
+        }
+    }
+
+    fn skip_ws(&mut self) {
+        while let Some(&b) = self.bytes.get(self.pos) {
+            if matches!(b, b' ' | b'\t' | b'\n' | b'\r') {
+                self.pos += 1;
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn peek(&self) -> Option<u8> {
+        self.bytes.get(self.pos).copied()
+    }
+
+    fn parse_value(&mut self) -> Result<Json, JsonParseError> {
+        match self.peek() {
+            Some(b'{') => self.parse_object(),
+            Some(b'[') => self.parse_array(),
+            Some(b'"') => Ok(Json::Str(self.parse_string()?)),
+            Some(b't') => self.parse_literal("true", Json::Raw("true".to_string())),
+            Some(b'f') => self.parse_literal("false", Json::Raw("false".to_string())),
+            Some(b'n') => self.parse_literal("null", Json::Raw("null".to_string())),
+            Some(b'-') | Some(b'0'..=b'9') => self.parse_number(),
+            _ => Err(self.error("expected a JSON value")),
+        }
+    }
+
+    fn parse_literal(&mut self, word: &str, value: Json) -> Result<Json, JsonParseError> {
+        if self.bytes[self.pos..].starts_with(word.as_bytes()) {
+            self.pos += word.len();
+            Ok(value)
+        } else {
+            Err(self.error("invalid literal"))
+        }
+    }
+
+    fn parse_number(&mut self) -> Result<Json, JsonParseError> {
+        let start = self.pos;
+        if self.peek() == Some(b'-') {
+            self.pos += 1;
+        }
+        while matches!(self.peek(), Some(b'0'..=b'9')) {
+            self.pos += 1;
+        }
+        if self.peek() == Some(b'.') {
+            self.pos += 1;
+            while matches!(self.peek(), Some(b'0'..=b'9')) {
+                self.pos += 1;
+            }
+        }
+        if matches!(self.peek(), Some(b'e') | Some(b'E')) {
+            self.pos += 1;
+            if matches!(self.peek(), Some(b'+') | Some(b'-')) {
+                self.pos += 1;
+            }
+            while matches!(self.peek(), Some(b'0'..=b'9')) {
+                self.pos += 1;
+            }
+        }
+        let raw = std::str::from_utf8(&self.bytes[start..self.pos])
+            .map_err(|_| self.error("invalid number"))?;
+        // Reject a lone "-" or ".".
+        if raw == "-" || !raw.bytes().any(|b| b.is_ascii_digit()) {
+            return Err(self.error("invalid number"));
+        }
+        Ok(Json::Raw(raw.to_string()))
+    }
+
+    fn parse_string(&mut self) -> Result<String, JsonParseError> {
+        // Consumes the opening quote.
+        self.pos += 1;
+        let mut out = String::new();
+        loop {
+            match self.peek() {
+                None => return Err(self.error("unterminated string")),
+                Some(b'"') => {
+                    self.pos += 1;
+                    return Ok(out);
+                }
+                Some(b'\\') => {
+                    self.pos += 1; // now at the escape character
+                    match self.peek() {
+                        Some(b'"') => self.push_simple_escape(&mut out, '"'),
+                        Some(b'\\') => self.push_simple_escape(&mut out, '\\'),
+                        Some(b'/') => self.push_simple_escape(&mut out, '/'),
+                        Some(b'b') => self.push_simple_escape(&mut out, '\u{08}'),
+                        Some(b'f') => self.push_simple_escape(&mut out, '\u{0C}'),
+                        Some(b'n') => self.push_simple_escape(&mut out, '\n'),
+                        Some(b'r') => self.push_simple_escape(&mut out, '\r'),
+                        Some(b't') => self.push_simple_escape(&mut out, '\t'),
+                        Some(b'u') => self.push_unicode_escape(&mut out)?,
+                        _ => return Err(self.error("invalid escape")),
+                    }
+                }
+                Some(_) => {
+                    // Copy a whole UTF-8 char.
+                    let rest = &self.bytes[self.pos..];
+                    let s = std::str::from_utf8(rest).map_err(|_| self.error("invalid UTF-8"))?;
+                    let c = s.chars().next().unwrap();
+                    out.push(c);
+                    self.pos += c.len_utf8();
+                }
+            }
+        }
+    }
+
+    /// Pushes a single-character escape (`self.pos` is at the escape letter) and steps past it.
+    fn push_simple_escape(&mut self, out: &mut String, c: char) {
+        out.push(c);
+        self.pos += 1;
+    }
+
+    /// Handles a `\u` escape (and a surrogate pair). `self.pos` is at `u`; on return it is
+    /// positioned just past the last consumed hex digit.
+    fn push_unicode_escape(&mut self, out: &mut String) -> Result<(), JsonParseError> {
+        let cp = self.read_hex4_after_u()?;
+        if (0xD800..=0xDBFF).contains(&cp) {
+            // High surrogate: a low surrogate `\uXXXX` must follow.
+            if self.bytes[self.pos..].starts_with(b"\\u") {
+                self.pos += 1; // skip the '\', leaving pos at 'u'
+                let lo = self.read_hex4_after_u()?;
+                if !(0xDC00..=0xDFFF).contains(&lo) {
+                    return Err(self.error("invalid low surrogate"));
+                }
+                let c = 0x10000 + ((cp - 0xD800) << 10) + (lo - 0xDC00);
+                out.push(char::from_u32(c).ok_or_else(|| self.error("invalid code point"))?);
+                Ok(())
+            } else {
+                Err(self.error("unpaired high surrogate"))
+            }
+        } else if (0xDC00..=0xDFFF).contains(&cp) {
+            Err(self.error("unexpected low surrogate"))
+        } else {
+            out.push(char::from_u32(cp).ok_or_else(|| self.error("invalid code point"))?);
+            Ok(())
+        }
+    }
+
+    /// Reads the four hex digits of a `\u` escape. `self.pos` is at `u`; on return it is
+    /// positioned just past the fourth hex digit.
+    fn read_hex4_after_u(&mut self) -> Result<u32, JsonParseError> {
+        let start = self.pos + 1;
+        let end = start + 4;
+        if end > self.bytes.len() {
+            return Err(self.error("truncated \\u escape"));
+        }
+        let hex = std::str::from_utf8(&self.bytes[start..end])
+            .map_err(|_| self.error("invalid \\u escape"))?;
+        let cp = u32::from_str_radix(hex, 16).map_err(|_| self.error("invalid \\u escape"))?;
+        self.pos = end;
+        Ok(cp)
+    }
+
+    fn parse_array(&mut self) -> Result<Json, JsonParseError> {
+        self.pos += 1; // '['
+        let mut items = Vec::new();
+        self.skip_ws();
+        if self.peek() == Some(b']') {
+            self.pos += 1;
+            return Ok(Json::Arr(items));
+        }
+        loop {
+            self.skip_ws();
+            items.push(self.parse_value()?);
+            self.skip_ws();
+            match self.peek() {
+                Some(b',') => self.pos += 1,
+                Some(b']') => {
+                    self.pos += 1;
+                    return Ok(Json::Arr(items));
+                }
+                _ => return Err(self.error("expected ',' or ']'")),
+            }
+        }
+    }
+
+    fn parse_object(&mut self) -> Result<Json, JsonParseError> {
+        self.pos += 1; // '{'
+        let mut obj = Json::obj();
+        self.skip_ws();
+        if self.peek() == Some(b'}') {
+            self.pos += 1;
+            return Ok(obj);
+        }
+        loop {
+            self.skip_ws();
+            if self.peek() != Some(b'"') {
+                return Err(self.error("expected a string key"));
+            }
+            let key = self.parse_string()?;
+            self.skip_ws();
+            if self.peek() != Some(b':') {
+                return Err(self.error("expected ':'"));
+            }
+            self.pos += 1;
+            self.skip_ws();
+            let value = self.parse_value()?;
+            obj.set(&key, value);
+            self.skip_ws();
+            match self.peek() {
+                Some(b',') => self.pos += 1,
+                Some(b'}') => {
+                    self.pos += 1;
+                    return Ok(obj);
+                }
+                _ => return Err(self.error("expected ',' or '}'")),
+            }
+        }
+    }
 }
 
 /// Escapes a string as a JSON string body (without the surrounding quotes) per RFC 8259:
@@ -213,5 +477,74 @@ mod tests {
         Json::Str("\u{01}\u{1f}".into()).write(&mut out);
         // A quote, the two C0 controls as `\u00XX` lower-hex, then a quote.
         assert_eq!(out, "\"\\u0001\\u001f\"");
+    }
+
+    #[test]
+    fn parse_scalars_are_preserved_as_raw_tokens() {
+        assert_eq!(Json::parse("true").unwrap(), Json::Raw("true".into()));
+        assert_eq!(Json::parse("false").unwrap(), Json::Raw("false".into()));
+        assert_eq!(Json::parse("null").unwrap(), Json::Raw("null".into()));
+        assert_eq!(Json::parse("  42 ").unwrap(), Json::Raw("42".into()));
+        assert_eq!(Json::parse("-3.5e10").unwrap(), Json::Raw("-3.5e10".into()));
+        assert_eq!(Json::parse(r#""hi""#).unwrap(), Json::Str("hi".into()));
+    }
+
+    #[test]
+    fn parse_object_preserves_order_and_last_duplicate_wins() {
+        let v = Json::parse(r#"{"b": 1, "a": "x", "b": 2}"#).unwrap();
+        assert_eq!(
+            v,
+            Json::Obj(vec![
+                ("b".into(), Json::Raw("2".into())),
+                ("a".into(), Json::Str("x".into())),
+            ])
+        );
+    }
+
+    #[test]
+    fn parse_nested_arrays_and_objects() {
+        let v = Json::parse(r#"{"@context": {"n": "x"}, "list": [1, "two", true, null]}"#).unwrap();
+        let ctx = v.get("@context").unwrap();
+        assert_eq!(ctx.get("n"), Some(&Json::Str("x".into())));
+        let list = v.get("list").unwrap();
+        assert_eq!(
+            list,
+            &Json::Arr(vec![
+                Json::Raw("1".into()),
+                Json::Str("two".into()),
+                Json::Raw("true".into()),
+                Json::Raw("null".into()),
+            ])
+        );
+        assert_eq!(Json::parse("[]").unwrap(), Json::Arr(vec![]));
+        assert_eq!(Json::parse("{}").unwrap(), Json::obj());
+    }
+
+    #[test]
+    fn parse_decodes_string_escapes_including_unicode_and_surrogates() {
+        // Two-char escapes: quote, backslash, newline, tab, and `\/`.
+        let input = "\"a\\\"b\\\\c\\n\\t\\/A\"";
+        assert_eq!(Json::parse(input).unwrap(), Json::Str("a\"b\\c\n\t/A".into()));
+        // A BMP `\u` escape (U+00E9 "é").
+        assert_eq!(Json::parse("\"\\u00e9\"").unwrap(), Json::Str("é".into()));
+        // A surrogate-pair escape `😀` encoding U+1F600 ("😀").
+        assert_eq!(
+            Json::parse("\"\\uD83D\\uDE00\"").unwrap(),
+            Json::Str("\u{1F600}".into())
+        );
+        // A lone (unpaired) high surrogate is rejected.
+        assert!(Json::parse("\"\\uD83D\"").is_err());
+    }
+
+    #[test]
+    fn parse_rejects_malformed_input() {
+        assert!(Json::parse("{").is_err());
+        assert!(Json::parse("[1,]").is_err());
+        assert!(Json::parse(r#"{"k": }"#).is_err());
+        assert!(Json::parse("nul").is_err());
+        assert!(Json::parse("1 2").is_err()); // trailing characters
+        assert!(Json::parse(r#""unterminated"#).is_err());
+        let err = Json::parse("@").unwrap_err();
+        assert!(err.to_string().contains("byte 0"));
     }
 }

--- a/crates/sparq-jsonld/src/json.rs
+++ b/crates/sparq-jsonld/src/json.rs
@@ -201,23 +201,46 @@ impl Parser<'_> {
     }
 
     fn parse_number(&mut self) -> Result<Json, JsonParseError> {
+        // [OPUS-4.8] (sq-oy1f.24) Enforce the RFC 8259 number grammar strictly:
+        //   number = [ "-" ] int [ frac ] [ exp ]
+        //   int    = "0" / ( digit1-9 *DIGIT )   (no leading zeros)
+        //   frac   = "." 1*DIGIT                 (a "." requires a digit)
+        //   exp    = ("e" / "E") ["+" / "-"] 1*DIGIT
+        // A minimal, remote-context parser must not silently accept malformed forms such as
+        // `01`, `1.`, or `1e`, otherwise invalid JSON is treated as valid.
         let start = self.pos;
         if self.peek() == Some(b'-') {
             self.pos += 1;
         }
-        while matches!(self.peek(), Some(b'0'..=b'9')) {
-            self.pos += 1;
+        // Integer part: a lone "0", or a 1-9 lead followed by any digits.
+        match self.peek() {
+            Some(b'0') => self.pos += 1,
+            Some(b'1'..=b'9') => {
+                self.pos += 1;
+                while matches!(self.peek(), Some(b'0'..=b'9')) {
+                    self.pos += 1;
+                }
+            }
+            _ => return Err(self.error("invalid number: expected a digit")),
         }
+        // Fraction: "." then at least one digit.
         if self.peek() == Some(b'.') {
             self.pos += 1;
+            if !matches!(self.peek(), Some(b'0'..=b'9')) {
+                return Err(self.error("invalid number: fraction requires a digit"));
+            }
             while matches!(self.peek(), Some(b'0'..=b'9')) {
                 self.pos += 1;
             }
         }
+        // Exponent: e/E, optional sign, then at least one digit.
         if matches!(self.peek(), Some(b'e') | Some(b'E')) {
             self.pos += 1;
             if matches!(self.peek(), Some(b'+') | Some(b'-')) {
                 self.pos += 1;
+            }
+            if !matches!(self.peek(), Some(b'0'..=b'9')) {
+                return Err(self.error("invalid number: exponent requires a digit"));
             }
             while matches!(self.peek(), Some(b'0'..=b'9')) {
                 self.pos += 1;
@@ -225,10 +248,6 @@ impl Parser<'_> {
         }
         let raw = std::str::from_utf8(&self.bytes[start..self.pos])
             .map_err(|_| self.error("invalid number"))?;
-        // Reject a lone "-" or ".".
-        if raw == "-" || !raw.bytes().any(|b| b.is_ascii_digit()) {
-            return Err(self.error("invalid number"));
-        }
         Ok(Json::Raw(raw.to_string()))
     }
 
@@ -257,6 +276,12 @@ impl Parser<'_> {
                         Some(b'u') => self.push_unicode_escape(&mut out)?,
                         _ => return Err(self.error("invalid escape")),
                     }
+                }
+                // [OPUS-4.8] (sq-oy1f.24) RFC 8259 forbids raw control characters
+                // (U+0000..=U+001F) inside a string; they must be escaped. Reject them so a
+                // malformed remote `@context`/`@import` document is not treated as valid.
+                Some(b) if b < 0x20 => {
+                    return Err(self.error("unescaped control character in string"));
                 }
                 Some(_) => {
                     // Copy a whole UTF-8 char.
@@ -546,5 +571,37 @@ mod tests {
         assert!(Json::parse(r#""unterminated"#).is_err());
         let err = Json::parse("@").unwrap_err();
         assert!(err.to_string().contains("byte 0"));
+    }
+
+    #[test]
+    fn parse_rejects_unescaped_control_char_in_string() {
+        // RFC 8259 forbids raw control chars (U+0000..=U+001F) inside a string.
+        assert!(Json::parse("\"a\u{01}b\"").is_err());
+        assert!(Json::parse("\"tab\there\"").is_err()); // literal TAB
+        assert!(Json::parse("\"nl\nhere\"").is_err()); // literal newline
+        // The escaped forms remain accepted.
+        assert_eq!(Json::parse("\"\\t\"").unwrap(), Json::Str("\t".into()));
+    }
+
+    #[test]
+    fn parse_rejects_malformed_numbers() {
+        // Leading zeros are forbidden (int = "0" / digit1-9 *DIGIT).
+        assert!(Json::parse("01").is_err());
+        assert!(Json::parse("-01").is_err());
+        assert!(Json::parse("00").is_err());
+        // A fraction requires at least one digit.
+        assert!(Json::parse("1.").is_err());
+        assert!(Json::parse("1.e5").is_err());
+        // An exponent requires at least one digit.
+        assert!(Json::parse("1e").is_err());
+        assert!(Json::parse("1e+").is_err());
+        assert!(Json::parse("1E-").is_err());
+        // A lone sign / no integer part is invalid.
+        assert!(Json::parse("-").is_err());
+        assert!(Json::parse(".5").is_err());
+        // Well-formed forms still parse (including a bare "0").
+        assert_eq!(Json::parse("0").unwrap(), Json::Raw("0".into()));
+        assert_eq!(Json::parse("-0.5e-2").unwrap(), Json::Raw("-0.5e-2".into()));
+        assert_eq!(Json::parse("10").unwrap(), Json::Raw("10".into()));
     }
 }

--- a/crates/sparq-jsonld/src/lib.rs
+++ b/crates/sparq-jsonld/src/lib.rs
@@ -3,37 +3,39 @@
 //!
 //! ---
 //!
-//! # Scaffold status (bead `sq-oy1f.23`)
+//! # Build-out status
 //!
-//! This is **Phase A** of the document-level W3C JSON-LD 1.1 program
-//! (design record `research/jsonld-1.1-design.md`). The concrete surface that ships
-//! today is:
+//! This is the document-level W3C JSON-LD 1.1 program (design record
+//! `research/jsonld-1.1-design.md`). The surface that ships today is:
 //!
 //! - [`json`] — the minimal, dependency-free `Json` AST (moved verbatim out of
-//!   `sparq-engine`'s JSON-LD writer; public API preserved via a re-export shim there).
+//!   `sparq-engine`'s JSON-LD writer; public API preserved via a re-export shim there),
+//!   plus a small `Json::parse` used to read remote contexts.
 //! - [`error`] — the full JSON-LD 1.1 error-code registry ([`JsonLdErrorCode`]) plus the
-//!   fallible [`JsonLdError`] type every algorithm will return.
+//!   fallible [`JsonLdError`] type every algorithm returns.
 //! - [`options`] — [`JsonLdOptions`], the processing options honoured across the pipeline.
 //! - [`loader`] — the [`DocumentLoader`] trait, **deny-by-default** via [`NoopLoader`]
 //!   (no ambient network — a remote fetch raises `loading document failed`), plus the
 //!   local-fixture [`FsLoader`].
+//! - [`context`] — the **Context Processing** foundation (bead `sq-oy1f.24`): the
+//!   [`ActiveContext`], Create Term Definition, and IRI Expansion. The compaction-side
+//!   companions (inverse context, IRI compaction) are deferred to a follow-on bead.
 //!
-//! The algorithm modules ([`context`], [`expand`], [`node_map`], [`flatten`],
-//! [`compact`], [`frame`], [`from_rdf`], [`to_rdf`], [`api`]) are **stubs**: they carry
-//! the spec references and the public shape only. Their implementations land in the
-//! dependency-ordered follow-on beads (`sq-oy1f.24`+). No algorithm here yet, and nothing
-//! panics: the crate is `todo!()`-free.
+//! The remaining algorithm modules ([`expand`], [`node_map`], [`flatten`], [`compact`],
+//! [`frame`], [`from_rdf`], [`to_rdf`], [`api`]) are **stubs**: they carry the spec
+//! references and the public shape only, filled by the dependency-ordered follow-on beads.
+//! Nothing panics: the crate is `todo!()`-free.
 
-// Real, shipped surfaces (Phase A).
+// Real, shipped surfaces.
+pub mod context;
 pub mod error;
 pub mod json;
 pub mod loader;
 pub mod options;
 
-// Algorithm scaffolds — spec references + public shape only (filled by sq-oy1f.24+).
+// Algorithm scaffolds — spec references + public shape only (filled by later beads).
 pub mod api;
 pub mod compact;
-pub mod context;
 pub mod expand;
 pub mod flatten;
 pub mod frame;
@@ -41,7 +43,8 @@ pub mod from_rdf;
 pub mod node_map;
 pub mod to_rdf;
 
+pub use context::{ActiveContext, Direction, Override, TermDefinition};
 pub use error::{JsonLdError, JsonLdErrorCode};
-pub use json::Json;
+pub use json::{Json, JsonParseError};
 pub use loader::{DocumentLoader, FsLoader, NoopLoader, RemoteDocument};
 pub use options::{EmbedFlag, JsonLdOptions, ProcessingMode, RdfDirection};

--- a/crates/sparq-jsonld/tests/context.rs
+++ b/crates/sparq-jsonld/tests/context.rs
@@ -380,6 +380,22 @@ fn invalid_import_value_error() {
 }
 
 #[test]
+fn invalid_nest_value_rejects_keyword_form() {
+    // A keyword-form value other than `@nest` (even an unrecognised one) is invalid.
+    assert_eq!(
+        err_code(r#"{"x": {"@id": "http://example.org/x", "@nest": "@bogus"}}"#),
+        JsonLdErrorCode::InvalidNestValue
+    );
+    assert_eq!(
+        err_code(r#"{"x": {"@id": "http://example.org/x", "@nest": "@id"}}"#),
+        JsonLdErrorCode::InvalidNestValue
+    );
+    // `@nest` itself and a plain nest property name are accepted.
+    ok(r#"{"x": {"@id": "http://example.org/x", "@nest": "@nest"}}"#);
+    ok(r#"{"x": {"@id": "http://example.org/x", "@nest": "nestProp"}}"#);
+}
+
+#[test]
 fn processing_mode_conflict_error() {
     let mut opts = JsonLdOptions::default();
     opts.processing_mode = ProcessingMode::JsonLd10;

--- a/crates/sparq-jsonld/tests/context.rs
+++ b/crates/sparq-jsonld/tests/context.rs
@@ -1,0 +1,514 @@
+//! [OPUS-4.8] (sq-oy1f.24) End-to-end tests for the JSON-LD 1.1 Context Processing +
+//! Create Term Definition + IRI Expansion foundation, exercised through the crate's public
+//! API. Fixtures are drawn from the worked examples of the W3C JSON-LD 1.1 API spec
+//! (<https://www.w3.org/TR/json-ld11-api/>). No network: remote contexts use the
+//! deny-by-default `NoopLoader` (fail-closed) or the local-fixture `FsLoader`.
+
+use std::collections::BTreeMap;
+
+use sparq_jsonld::context::ActiveContext;
+use sparq_jsonld::{
+    DocumentLoader, Direction, FsLoader, Json, JsonLdError, JsonLdErrorCode, JsonLdOptions,
+    NoopLoader, Override, ProcessingMode, RemoteDocument,
+};
+
+const BASE: &str = "http://example.org/";
+
+/// Parses a JSON context fragment.
+fn json(s: &str) -> Json {
+    Json::parse(s).expect("valid JSON fixture")
+}
+
+/// Processes a context fragment against a fresh active context based at [`BASE`], using the
+/// deny-by-default loader.
+fn process(ctx: &str) -> Result<ActiveContext, JsonLdError> {
+    ActiveContext::new(Some(BASE)).process(&json(ctx), Some(BASE), &NoopLoader, &JsonLdOptions::default())
+}
+
+/// Like [`process`] but asserts success.
+fn ok(ctx: &str) -> ActiveContext {
+    process(ctx).expect("context should process")
+}
+
+/// The error code raised by processing `ctx`.
+fn err_code(ctx: &str) -> JsonLdErrorCode {
+    process(ctx).expect_err("context should fail").code()
+}
+
+// -------------------------------------------------------------------------------------
+// Create Term Definition — the shapes.
+// -------------------------------------------------------------------------------------
+
+#[test]
+fn simple_term_maps_to_its_iri() {
+    let ac = ok(r#"{"name": "http://schema.org/name"}"#);
+    assert_eq!(
+        ac.term_definition("name").unwrap().iri(),
+        Some("http://schema.org/name")
+    );
+    assert!(ac.has_term("name"));
+}
+
+#[test]
+fn keyword_alias_definitions() {
+    // Aliasing keywords (§ term definitions): `id` → `@id`, `type` → `@type`.
+    let ac = ok(r#"{"id": "@id", "type": "@type"}"#);
+    assert_eq!(ac.term_definition("id").unwrap().iri(), Some("@id"));
+    assert_eq!(ac.term_definition("type").unwrap().iri(), Some("@type"));
+    // Expansion of the alias yields the keyword (IRI Expansion step 4).
+    assert_eq!(ac.expand_iri("id", false, true).as_deref(), Some("@id"));
+    assert_eq!(ac.expand_iri("type", false, true).as_deref(), Some("@type"));
+}
+
+#[test]
+fn type_container_and_id_type_mapping() {
+    let ac = ok(
+        r#"{"members": {"@id": "http://example.org/members", "@type": "@id", "@container": "@set"}}"#,
+    );
+    let def = ac.term_definition("members").unwrap();
+    assert_eq!(def.iri(), Some("http://example.org/members"));
+    assert_eq!(def.type_mapping(), Some("@id"));
+    assert_eq!(def.container(), &["@set".to_string()]);
+}
+
+#[test]
+fn language_and_index_containers() {
+    let ac = ok(
+        r#"{
+            "label": {"@id": "http://example.org/label", "@container": "@language"},
+            "byIdx": {"@id": "http://example.org/idx", "@container": "@index", "@index": "http://example.org/key"}
+        }"#,
+    );
+    assert_eq!(
+        ac.term_definition("label").unwrap().container(),
+        &["@language".to_string()]
+    );
+    let idx = ac.term_definition("byIdx").unwrap();
+    assert_eq!(idx.container(), &["@index".to_string()]);
+    assert_eq!(idx.index(), Some("http://example.org/key"));
+}
+
+#[test]
+fn graph_container_combinations_are_valid() {
+    // `@container: [@graph, @id]` is one of the allowed 1.1 combinations.
+    let ac = ok(
+        r#"{"g": {"@id": "http://example.org/g", "@container": ["@graph", "@id"]}}"#,
+    );
+    let c = ac.term_definition("g").unwrap().container();
+    assert!(c.contains(&"@graph".to_string()) && c.contains(&"@id".to_string()));
+}
+
+#[test]
+fn redefining_type_with_set_container_is_allowed() {
+    // JSON-LD 1.1 permits redefining @type with @container: @set (and/or @protected).
+    let ac = ok(r#"{"@type": {"@container": "@set"}}"#);
+    let def = ac.term_definition("@type").unwrap();
+    assert_eq!(def.iri(), Some("@type"));
+    assert_eq!(def.container(), &["@set".to_string()]);
+}
+
+#[test]
+fn reverse_property_definition() {
+    let ac = ok(r#"{"parent": {"@reverse": "http://example.org/child"}}"#);
+    let def = ac.term_definition("parent").unwrap();
+    assert!(def.is_reverse());
+    assert_eq!(def.iri(), Some("http://example.org/child"));
+}
+
+#[test]
+fn scoped_context_is_stored_on_the_term() {
+    let ac = ok(
+        r#"{"Person": {"@id": "http://schema.org/Person", "@context": {"name": "http://schema.org/name"}}}"#,
+    );
+    assert!(ac.term_definition("Person").unwrap().context().is_some());
+}
+
+#[test]
+fn term_scoped_language_and_direction_are_tri_state() {
+    let ac = ok(
+        r#"{
+            "@language": "en",
+            "plain": {"@id": "http://example.org/plain", "@language": null},
+            "fr": {"@id": "http://example.org/fr", "@language": "fr", "@direction": "rtl"}
+        }"#,
+    );
+    // Explicit null suppresses the language; a value binds it.
+    assert_eq!(ac.term_definition("plain").unwrap().language(), &Override::Null);
+    assert_eq!(
+        ac.term_definition("fr").unwrap().language(),
+        &Override::Set("fr".to_string())
+    );
+    assert_eq!(
+        ac.term_definition("fr").unwrap().direction(),
+        &Override::Set(Direction::Rtl)
+    );
+    // An unset term keeps the fall-through-to-default marker.
+    assert!(!ac
+        .term_definition("plain")
+        .unwrap()
+        .direction()
+        .is_set());
+}
+
+#[test]
+fn null_mapped_term_is_retained_but_drops_on_expansion() {
+    let ac = ok(r#"{"@vocab": "http://example.org/", "drop": null}"#);
+    assert!(ac.has_term("drop"));
+    assert_eq!(ac.term_definition("drop").unwrap().iri(), None);
+    // A vocab reference to a null-mapped term expands to null (the term is dropped).
+    assert_eq!(ac.expand_iri("drop", false, true), None);
+    // An undefined term still expands via @vocab.
+    assert_eq!(
+        ac.expand_iri("kept", false, true).as_deref(),
+        Some("http://example.org/kept")
+    );
+}
+
+// -------------------------------------------------------------------------------------
+// Context-level defaults.
+// -------------------------------------------------------------------------------------
+
+#[test]
+fn vocab_language_direction_defaults() {
+    let ac = ok(r#"{"@vocab": "http://schema.org/", "@language": "en", "@direction": "ltr"}"#);
+    assert_eq!(ac.vocabulary_mapping(), Some("http://schema.org/"));
+    assert_eq!(ac.default_language(), Some("en"));
+    assert_eq!(ac.default_base_direction(), Some(Direction::Ltr));
+}
+
+#[test]
+fn base_is_set_reset_and_resolved_relatively() {
+    // Absolute @base replaces the base IRI.
+    let ac = ok(r#"{"@base": "http://other.example/"}"#);
+    assert_eq!(ac.base_iri(), Some("http://other.example/"));
+
+    // Relative @base resolves against the current base.
+    let ac = ActiveContext::new(Some("http://example.org/a/b"))
+        .process(
+            &json(r#"{"@base": "sub/"}"#),
+            Some("http://example.org/a/b"),
+            &NoopLoader,
+            &JsonLdOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(ac.base_iri(), Some("http://example.org/a/sub/"));
+
+    // Null @base clears the base IRI.
+    let ac = ok(r#"{"@base": null}"#);
+    assert_eq!(ac.base_iri(), None);
+}
+
+#[test]
+fn null_context_resets_terms() {
+    let base = ok(r#"{"@vocab": "http://schema.org/", "name": "http://schema.org/name"}"#);
+    let reset = base
+        .process(&json("null"), Some(BASE), &NoopLoader, &JsonLdOptions::default())
+        .unwrap();
+    assert_eq!(reset.term_count(), 0);
+    assert_eq!(reset.vocabulary_mapping(), None);
+}
+
+// -------------------------------------------------------------------------------------
+// IRI Expansion — vocab / compact IRIs / relative refs / keywords.
+// -------------------------------------------------------------------------------------
+
+#[test]
+fn expand_prefers_a_term_then_vocab() {
+    let ac = ok(r#"{"@vocab": "http://schema.org/", "name": "http://xmlns.com/foaf/0.1/name"}"#);
+    // A defined term wins.
+    assert_eq!(
+        ac.expand_iri("name", false, true).as_deref(),
+        Some("http://xmlns.com/foaf/0.1/name")
+    );
+    // An undefined vocab reference uses @vocab.
+    assert_eq!(
+        ac.expand_iri("age", false, true).as_deref(),
+        Some("http://schema.org/age")
+    );
+}
+
+#[test]
+fn expand_simple_term_prefix_produces_compact_iri() {
+    // A simple-term prefix whose IRI ends with a gen-delim gets the @prefix flag.
+    let ac = ok(r#"{"foaf": "http://xmlns.com/foaf/0.1/"}"#);
+    assert!(ac.term_definition("foaf").unwrap().is_prefix());
+    assert_eq!(
+        ac.expand_iri("foaf:name", false, true).as_deref(),
+        Some("http://xmlns.com/foaf/0.1/name")
+    );
+}
+
+#[test]
+fn expand_non_prefix_term_leaves_compact_iri_unexpanded() {
+    // A map-form term without @prefix (and not ending in a gen-delim) is not a prefix, so a
+    // compact IRI using it is treated as an already-absolute IRI (returned unchanged).
+    let ac = ok(r#"{"ex": {"@id": "http://example.org/vocab"}}"#);
+    assert!(!ac.term_definition("ex").unwrap().is_prefix());
+    assert_eq!(ac.expand_iri("ex:foo", false, true).as_deref(), Some("ex:foo"));
+}
+
+#[test]
+fn expand_explicit_prefix_flag() {
+    let ac = ok(r#"{"ex": {"@id": "http://example.org/vocab#", "@prefix": true}}"#);
+    assert!(ac.term_definition("ex").unwrap().is_prefix());
+    assert_eq!(
+        ac.expand_iri("ex:foo", false, true).as_deref(),
+        Some("http://example.org/vocab#foo")
+    );
+}
+
+#[test]
+fn expand_keywords_and_document_relative() {
+    let ac = ok(r#"{}"#);
+    // Keywords expand to themselves; keyword-shaped non-keywords expand to null.
+    assert_eq!(ac.expand_iri("@type", false, true).as_deref(), Some("@type"));
+    assert_eq!(ac.expand_iri("@bogus", false, true), None);
+    // A document-relative reference resolves against the base IRI.
+    assert_eq!(
+        ac.expand_iri("thing", true, false).as_deref(),
+        Some("http://example.org/thing")
+    );
+    // An absolute IRI is returned unchanged.
+    assert_eq!(
+        ac.expand_iri("http://x/y", true, false).as_deref(),
+        Some("http://x/y")
+    );
+}
+
+// -------------------------------------------------------------------------------------
+// @protected.
+// -------------------------------------------------------------------------------------
+
+#[test]
+fn protected_flag_propagates_from_context() {
+    let ac = ok(r#"{"@protected": true, "name": "http://schema.org/name"}"#);
+    assert!(ac.term_definition("name").unwrap().is_protected());
+}
+
+#[test]
+fn protected_term_redefinition_is_rejected_but_identical_is_allowed() {
+    let base = ok(r#"{"@protected": true, "name": "http://schema.org/name"}"#);
+    // Redefining a protected term with a different IRI fails.
+    let e = base
+        .process(
+            &json(r#"{"name": "http://other.example/name"}"#),
+            Some(BASE),
+            &NoopLoader,
+            &JsonLdOptions::default(),
+        )
+        .unwrap_err();
+    assert_eq!(e.code(), JsonLdErrorCode::ProtectedTermRedefinition);
+    // Redefining it identically is a no-op (allowed).
+    let ok2 = base.process(
+        &json(r#"{"name": "http://schema.org/name"}"#),
+        Some(BASE),
+        &NoopLoader,
+        &JsonLdOptions::default(),
+    );
+    assert!(ok2.is_ok());
+}
+
+#[test]
+fn nullifying_a_context_with_protected_terms_fails() {
+    let base = ok(r#"{"@protected": true, "name": "http://schema.org/name"}"#);
+    let e = base
+        .process(&json("null"), Some(BASE), &NoopLoader, &JsonLdOptions::default())
+        .unwrap_err();
+    assert_eq!(e.code(), JsonLdErrorCode::InvalidContextNullification);
+}
+
+// -------------------------------------------------------------------------------------
+// Negative tests — exact spec error codes.
+// -------------------------------------------------------------------------------------
+
+#[test]
+fn keyword_redefinition_error() {
+    assert_eq!(err_code(r#"{"@id": "http://example.org/"}"#), JsonLdErrorCode::KeywordRedefinition);
+}
+
+#[test]
+fn cyclic_iri_mapping_error() {
+    assert_eq!(err_code(r#"{"a": "b:x", "b": "a:y"}"#), JsonLdErrorCode::CyclicIriMapping);
+}
+
+#[test]
+fn invalid_reverse_property_with_id() {
+    assert_eq!(
+        err_code(r#"{"x": {"@reverse": "http://example.org/r", "@id": "http://example.org/x"}}"#),
+        JsonLdErrorCode::InvalidReverseProperty
+    );
+}
+
+#[test]
+fn invalid_container_mapping_error() {
+    // @list cannot combine with @set.
+    assert_eq!(
+        err_code(r#"{"x": {"@id": "http://example.org/x", "@container": ["@list", "@set"]}}"#),
+        JsonLdErrorCode::InvalidContainerMapping
+    );
+}
+
+#[test]
+fn invalid_type_mapping_error() {
+    assert_eq!(
+        err_code(r#"{"x": {"@id": "http://example.org/x", "@type": "@bogus"}}"#),
+        JsonLdErrorCode::InvalidTypeMapping
+    );
+}
+
+#[test]
+fn invalid_keyword_alias_to_context() {
+    assert_eq!(
+        err_code(r#"{"ctx": "@context"}"#),
+        JsonLdErrorCode::InvalidKeywordAlias
+    );
+}
+
+#[test]
+fn invalid_vocab_mapping_error() {
+    assert_eq!(err_code(r#"{"@vocab": ["not-a-string"]}"#), JsonLdErrorCode::InvalidVocabMapping);
+}
+
+#[test]
+fn invalid_propagate_value_error() {
+    assert_eq!(err_code(r#"{"@propagate": "yes"}"#), JsonLdErrorCode::InvalidPropagateValue);
+}
+
+#[test]
+fn invalid_import_value_error() {
+    assert_eq!(err_code(r#"{"@import": true}"#), JsonLdErrorCode::InvalidImportValue);
+}
+
+#[test]
+fn processing_mode_conflict_error() {
+    let mut opts = JsonLdOptions::default();
+    opts.processing_mode = ProcessingMode::JsonLd10;
+    let e = ActiveContext::new(Some(BASE))
+        .process(&json(r#"{"@version": 1.1}"#), Some(BASE), &NoopLoader, &opts)
+        .unwrap_err();
+    assert_eq!(e.code(), JsonLdErrorCode::ProcessingModeConflict);
+}
+
+// -------------------------------------------------------------------------------------
+// Remote contexts — deny-by-default, and the explicit fixture loader.
+// -------------------------------------------------------------------------------------
+
+#[test]
+fn remote_context_is_denied_by_default() {
+    // The default NoopLoader refuses; a string (remote) context fails closed with the
+    // `loading remote context failed` code — no ambient network.
+    let e = ActiveContext::new(Some(BASE))
+        .process(
+            &Json::Str("http://remote.example/ctx.jsonld".into()),
+            Some(BASE),
+            &NoopLoader,
+            &JsonLdOptions::default(),
+        )
+        .unwrap_err();
+    assert_eq!(e.code(), JsonLdErrorCode::LoadingRemoteContextFailed);
+}
+
+/// An in-memory loader serving a single fixed URL — a hermetic stand-in for a fetch.
+struct MapLoader(BTreeMap<String, String>);
+
+impl DocumentLoader for MapLoader {
+    fn load_document(&self, url: &str) -> Result<RemoteDocument, JsonLdError> {
+        match self.0.get(url) {
+            Some(doc) => Ok(RemoteDocument::new(doc.clone(), url)),
+            None => Err(JsonLdError::new(JsonLdErrorCode::LoadingDocumentFailed)),
+        }
+    }
+}
+
+#[test]
+fn remote_context_loads_through_an_explicit_loader() {
+    let mut m = BTreeMap::new();
+    m.insert(
+        "http://vocab.example/ctx.jsonld".to_string(),
+        r#"{"@context": {"name": "http://schema.org/name"}}"#.to_string(),
+    );
+    let loader = MapLoader(m);
+    let ac = ActiveContext::new(Some(BASE))
+        .process(
+            &Json::Str("http://vocab.example/ctx.jsonld".into()),
+            Some(BASE),
+            &loader,
+            &JsonLdOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(
+        ac.term_definition("name").unwrap().iri(),
+        Some("http://schema.org/name")
+    );
+}
+
+#[test]
+fn import_merges_a_remote_context_under_the_local_one() {
+    let mut m = BTreeMap::new();
+    m.insert(
+        "http://vocab.example/base.jsonld".to_string(),
+        r#"{"@context": {"name": "http://schema.org/name"}}"#.to_string(),
+    );
+    let loader = MapLoader(m);
+    let ctx = json(
+        r#"{"@version": 1.1, "@import": "http://vocab.example/base.jsonld", "age": "http://schema.org/age"}"#,
+    );
+    let ac = ActiveContext::new(Some(BASE))
+        .process(&ctx, Some(BASE), &loader, &JsonLdOptions::default())
+        .unwrap();
+    // The imported term and the local term both resolve.
+    assert_eq!(
+        ac.term_definition("name").unwrap().iri(),
+        Some("http://schema.org/name")
+    );
+    assert_eq!(
+        ac.term_definition("age").unwrap().iri(),
+        Some("http://schema.org/age")
+    );
+}
+
+#[test]
+fn base_after_a_remote_context_in_the_same_array_still_applies() {
+    // Regression: `remote contexts` is per-invocation, so a remote context earlier in the
+    // array must not suppress a sibling local `@base` (the remote-context stack is popped).
+    let mut m = BTreeMap::new();
+    m.insert(
+        "http://vocab.example/c.jsonld".to_string(),
+        r#"{"@context": {"name": "http://schema.org/name"}}"#.to_string(),
+    );
+    let loader = MapLoader(m);
+    let ctx = json(r#"["http://vocab.example/c.jsonld", {"@base": "http://after.example/"}]"#);
+    let ac = ActiveContext::new(Some(BASE))
+        .process(&ctx, Some(BASE), &loader, &JsonLdOptions::default())
+        .unwrap();
+    assert_eq!(
+        ac.term_definition("name").unwrap().iri(),
+        Some("http://schema.org/name")
+    );
+    assert_eq!(ac.base_iri(), Some("http://after.example/"));
+}
+
+#[test]
+fn fs_loader_serves_a_remote_context_from_a_fixture_file() {
+    // Exercises the crate's own FsLoader on a temp fixture (still no network).
+    let dir = std::env::temp_dir().join(format!("sparq-jsonld-ctx-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).unwrap();
+    let fixture = dir.join("ctx.jsonld");
+    std::fs::write(&fixture, r#"{"@context": {"title": "http://purl.org/dc/terms/title"}}"#).unwrap();
+
+    let loader = FsLoader::new().map_prefix("http://vocab.example/", &dir);
+    let ac = ActiveContext::new(Some(BASE))
+        .process(
+            &Json::Str("http://vocab.example/ctx.jsonld".into()),
+            Some(BASE),
+            &loader,
+            &JsonLdOptions::default(),
+        )
+        .unwrap();
+    assert_eq!(
+        ac.term_definition("title").unwrap().iri(),
+        Some("http://purl.org/dc/terms/title")
+    );
+
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -363,6 +363,18 @@ original triples in a strict external processor, not only in sparq. (An `@id`/`@
 *input* — i.e. compacting an already-indexed document, as distinct from the fromRdf graph sparq
 produces — remains out of scope and falls back to default framing as noted above.)
 
+*Native document-level pipeline (in progress, opt-in, not yet wired to the surfaces).* The
+scope gaps above (scoped/typed contexts, `@propagate`, `@protected`, remote `@context` +
+`@import`) are being closed by a from-scratch, dependency-free **document-level** pipeline in
+the `sparq-jsonld` crate (design record `research/jsonld-1.1-design.md`, epic sq-oy1f). Its
+Context Processing foundation (sq-oy1f.24) ships today: `sparq_jsonld::context::ActiveContext`
+with `process()` (Context Processing + Create Term Definition, fallible with exact spec error
+codes), `expand_iri()` (IRI Expansion), RFC 3986 reference resolution, and **deny-by-default**
+remote-context loading via `DocumentLoader` (`NoopLoader` refuses every fetch — no ambient
+network — while `FsLoader` serves trusted local fixtures). Expansion / compaction / framing on
+this substrate, and the surface wiring, land in later beads; the RDF-first writers above remain
+the shipped path until then.
+
 ```rust
 use sparq_engine::serialize::{graph_to_jsonld_compact, parse_context_json};
 let ctx = parse_context_json(r#"{


### PR DESCRIPTION
> 🤖 SPARQ agent — Opus 4.8 (Fable unavailable; flag for re-review when Fable returns). This PR implements bead **sq-oy1f.24** (JSON-LD 1.1 [B]) — the document-level **Context Processing** foundation of the opt-in `sparq-jsonld` crate (epic `sq-oy1f`, design record `research/jsonld-1.1-design.md` §3.1). This is "the hinge every other algorithm needs".

## What this implements

Fills the scaffold's `context/` stubs (from #1361) with faithful W3C JSON-LD 1.1 API algorithms:

- **Data model** — `ActiveContext` + `TermDefinition` (`@protected`; tri-state term-scoped `@language`/`@direction` via a new `Override<T>`; container/type/index/nest/reverse/scoped-context mappings).
- **Context Processing Algorithm** (§4.1) — `@version` / `@import` / `@base` / `@vocab` / `@language` / `@direction` / `@propagate` / `@protected`, null-context nullification, and remote + scoped context recursion. Fallible throughout, raising the **exact** spec error codes (keyword redefinition, protected term redefinition, invalid `@import` value, context overflow, processing mode conflict, cyclic IRI mapping, invalid container/vocab/reverse, …).
- **Create Term Definition** (§4.2.2) — keyword aliases (`id`→`@id`), `@type` redefinition, `@reverse`, compact/relative/`@vocab` IRI derivation, the `@prefix` flag, container-combination validation, and the protected-redefinition guard (identical redefinition is a no-op; a differing one fails).
- **IRI Expansion** (§5.2) + a dependency-free **RFC 3986** reference resolver (verified against the RFC 3986 §5.4 normal/abnormal vectors).
- A minimal dependency-free `Json::parse` to read remote `@context` / `@import` documents **only** through the **deny-by-default** `DocumentLoader` (`NoopLoader` fails closed — no ambient network; `FsLoader` serves trusted local fixtures).

## Scope / deferred

Per the "deliver a self-contained slice, bead the remainder" guidance, the **compaction-side companions** — inverse-context construction (§4.3) and IRI Compaction / Term Selection (§7.1–7.2) — are **deferred to a follow-on bead**. Rationale: they're only consumed by `sq-oy1f.27` (document Compaction, not yet started), whereas this expansion foundation unblocks the critical path `sq-oy1f.25` (Expansion); keeping compaction out makes this slice reviewable and verifiable **offline** against the spec's worked expansion examples (the W3C suite is fetched in CI, not vendored locally). See "Deferred work" below.

## Tests (real path, spec-worked examples)

- **41 unit** (data model, keyword predicates, RFC 3986 vectors, `Json::parse` incl. surrogate decoding) + **37 integration** + **1 doctest**.
- Integration coverage: term-definition edge cases (`@type`, `@container` incl. `@graph`/`@set`/`@language`/`@index` combos, `@reverse`, keyword aliases, scoped contexts, tri-state `@language`/`@direction`, null-mapped-term drop); IRI expansion of compact IRIs / `@vocab` / relative refs / keywords; remote-context + `@import` loading through a hermetic in-memory loader and the `FsLoader`; and the negative error-code cases.
- A **regression test** for the per-invocation `remote contexts` scoping fix (a sibling `@base` after a remote context in the same array must still apply).

## Gates (both feature states)

- `cargo clippy -p sparq-jsonld --all-targets -- -D warnings` — clean.
- `cargo test -p sparq-jsonld` — 41 + 37 + 1 green.
- `cargo test -p sparq-engine --features serialize-rdf` — green (the `Json` re-export shim is intact).
- `cargo doc --workspace --no-deps --all-features` with `RUSTDOCFLAGS="-D warnings"` — clean (fixed one redundant-explicit-link + one public→private doc-link before opening).
- `scripts/check-readme-template.py --enforce` — 0 deviations (README 80 lines ≤ 120).

**Opt-in discipline:** `sparq-jsonld` keeps **zero mandatory dependencies** and is `#![forbid(unsafe_code)]`; nothing is added to the default `sparq-core` / `sparq-engine` build (the crate is pulled in only behind the off-by-default `serialize-rdf` feature). `publish = false` retained.

## Deferred work (to be beaded by the orchestrator)

1. **Inverse-context construction (§4.3) + IRI Compaction / Term Selection (§7.1–7.2)** — the compaction-side companions of this foundation; dependency for `sq-oy1f.27`.

## Honesty notes

- No performance numbers; no ZK/MPC/privacy claims (N/A — JSON-LD data-format work).
- The RFC 3986 resolver and the algorithms are verified against inline spec-worked examples, **not** yet against the full W3C JSON-LD suite (that oracle wiring lands with the Expansion lane in `sq-oy1f.25`); this is stated so the coverage claim stays honest.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>