### PR TITLE
perf(store): overlay zero-copy scan fast path (count_correction==0 -> borrowed base) (sq-7d3dj.3)

### DIFF
--- a/crates/sparq-core/src/store.rs
+++ b/crates/sparq-core/src/store.rs
@@ -722,8 +722,19 @@ impl TripleStore {
         // base range is returned untouched (borrowed, zero copies); with an overlay the
         // deleted triples are filtered out and the inserted ones merge-interleaved, so
         // the rows keep the permutation's sort order (merge joins stay valid).
+        //
+        // ZERO-COPY FAST PATH (sq-7d3dj.3) [OPUS-4.8]: even WITH an overlay, most ranges a small
+        // overlay does not touch. `count_correction` (O(|overlay|)) tells us exactly how
+        // many `added`/`deleted` triples fall in this range; when it is `(0, 0)` the
+        // overlay contributes nothing here — no `added` row projects into `[lo, hi]` (so
+        // nothing is interleaved) and no in-range base row is deleted (so nothing is
+        // dropped) — hence `merge` would reproduce `base` verbatim, rows AND sort order.
+        // We therefore return the BORROWED base slice directly, restoring allocation-free
+        // scans for every untouched range (the read-mostly mutated-server common case)
+        // instead of copying+re-sorting the whole range through the owned merge path.
         let rows = match &self.overlay {
             None => base,
+            Some(ov) if ov.count_correction(perm, lo, hi) == (0, 0) => base,
             Some(ov) => std::borrow::Cow::Owned(ov.merge(&base, perm, lo, hi)),
         };
         Scan { rows, perm }
@@ -1028,5 +1039,74 @@ mod tests {
         let mut orig: Vec<[Id; 3]> = triples.clone();
         orig.sort_unstable();
         assert_eq!(full.rows.as_ref(), &orig[..]);
+    }
+
+    /// The overlay zero-copy fast path (sq-7d3dj.3) must be PERF-ONLY: a scanned range the
+    /// overlay does not touch (`count_correction == (0, 0)`) returns the BORROWED base
+    /// slice, byte-identical (rows AND sort order) to the general merge path, while a range
+    /// the overlay DOES touch still takes the owned merge path and reflects the correction.
+    /// Proven directly — the `Cow` variant witnesses which path ran (a raw base range
+    /// borrows; `merge` allocates an owned `Vec`), so the equality checks are non-vacuous.
+    #[test]
+    fn overlay_zero_copy_fast_path() {
+        use std::borrow::Cow;
+
+        // Base: subjects 1..=100, predicate 1, objects 1..=10 (1000 triples, several perms).
+        let mut triples: Vec<[Id; 3]> = Vec::new();
+        for s in 1..=100u32 {
+            for o in 1..=10u32 {
+                triples.push([s, 1, o]);
+            }
+        }
+        // A no-overlay reference store: EVERY scan already borrows (the `None` branch).
+        let base_store = TripleStore::from_triples(triples.clone());
+        assert!(!base_store.has_overlay());
+
+        // A small overlay touching ONLY subject 50: insert (50,1,11), delete (50,1,1).
+        let mut store = TripleStore::from_triples(triples.clone());
+        store.apply_delta(&[[50, 1, 11]], &[[50, 1, 1]]);
+        assert!(store.has_overlay(), "the overlay must exist for a non-vacuous test");
+
+        // A full rebuild of the corrected triple set (the general-path oracle).
+        let mut reference: Vec<[Id; 3]> = triples.clone();
+        reference.retain(|t| *t != [50, 1, 1]);
+        reference.push([50, 1, 11]);
+        let rebuilt = TripleStore::from_triples(reference);
+
+        // (i) UNTOUCHED range (subject 7): fast path — rows are BORROWED and identical to
+        // the no-overlay base store (which also borrows). This is the "store WITH an
+        // overlay, scanned range clean" case the fast path exists for.
+        for s in [1u32, 7, 49, 51, 100] {
+            let pat: Pattern = [Some(s), None, None];
+            let scan = store.scan(&pat);
+            assert!(matches!(scan.rows, Cow::Borrowed(_)), "untouched subject {} must be zero-copy borrowed", s);
+            assert_eq!(scan.rows, base_store.scan(&pat).rows, "fast-path rows must equal the base for subject {}", s);
+            // A clean range is untouched by the overlay, so the rebuild agrees too.
+            assert_eq!(scan.rows, rebuilt.scan(&pat).rows, "fast-path rows must equal the rebuild for subject {}", s);
+        }
+
+        // (ii) TOUCHED range (subject 50): general merge path — rows are OWNED, reflect the
+        // correction (object 1 gone, 11 added), and match the rebuild in sort order.
+        let touched: Pattern = [Some(50), None, None];
+        let scan = store.scan(&touched);
+        assert!(matches!(scan.rows, Cow::Owned(_)), "a range the overlay touches must take the merge path");
+        assert_eq!(scan.rows, rebuilt.scan(&touched).rows, "merge-path rows must equal the rebuild");
+        assert!(scan.rows.windows(2).all(|w| w[0] <= w[1]), "merge-path rows must stay sorted");
+
+        // (iii) A full unbound scan intersects the overlay -> merge path, equals rebuild.
+        let all: Pattern = [None, None, None];
+        let scan = store.scan(&all);
+        assert!(matches!(scan.rows, Cow::Owned(_)), "an overlay-intersecting full scan takes the merge path");
+        assert_eq!(scan.rows, rebuilt.scan(&all).rows, "full merge-path scan must equal the rebuild");
+
+        // (iv) An overlay that touches a range only via a DELETE (no insert) must still take
+        // the merge path there (count_correction = (0, 1) != (0, 0)) and drop the row.
+        let mut del_store = TripleStore::from_triples(triples.clone());
+        del_store.apply_delta(&[], &[[7, 1, 5]]);
+        let pat: Pattern = [Some(7), None, None];
+        let scan = del_store.scan(&pat);
+        assert!(matches!(scan.rows, Cow::Owned(_)), "a delete-only touched range must take the merge path");
+        assert!(!scan.rows.contains(&[7, 1, 5]), "the deleted row must be absent");
+        assert_eq!(scan.rows.len(), base_store.scan(&pat).rows.len() - 1, "exactly one row dropped");
     }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-7d3dj.3** (roadmap item 3 of `research/optimization-audit-2026-07.md`, epic sq-7d3dj), part (a). [OPUS-4.8]

## What

A perf-only zero-copy fast path in `TripleStore::scan_with` (`crates/sparq-core/src/store.rs`). Before the delta-overlay `merge` copies the whole base range, gate on the already-existing `count_correction` (O(|overlay|)): when it is `(0, 0)` the overlay touches nothing in this range, so `merge` would reproduce `base` verbatim. We return the **borrowed** base slice directly instead of allocating + copying + re-sorting the range through the owned merge path.

This restores allocation-free scans for every range a small overlay does not touch — the read-mostly mutated-server common case between compactions. For a raw/mmap base range this is now zero-copy again even while an overlay is pending; only ranges the overlay actually intersects pay the merge.

## Why it is byte-identical (the hard constraint)

When `count_correction(perm, lo, hi) == (0, 0)`:
- `add == 0` → no `added` triple projects into `[lo, hi]`, so `merge` interleaves nothing.
- `del == 0` → no `deleted` triple projects into `[lo, hi]`; every base row is in-range, and `merge` drops a base row only if its canonical SPO is deleted (which would count toward `del`), so nothing is dropped.

Hence `merge` returns exactly `base` (same rows, same permutation sort order — merge joins stay valid). Returning the borrowed `base` is byte-identical.

## Tests (real path, non-vacuous)

- New DIRECT test `overlay_zero_copy_fast_path`: uses the `Cow` variant to **witness which path ran** (a raw base range borrows; `merge` allocates an owned `Vec`), so the fast==general equality checks cannot pass vacuously. Covers: untouched ranges (fast path == no-overlay base == full rebuild), a touched range (insert+delete → owned merge path == rebuild, still sorted), a full unbound scan (merge path == rebuild), and a **delete-only** touched range (`count_correction == (0,1) != (0,0)` → merge path, row dropped).
- Existing `overlay_scans_match_rebuild` (hundreds of patterns) now routes its many untouched ranges through the new fast path, giving broad byte-identity regression coverage for free.

## Gates run (both feature states)

- `cargo clippy -p sparq-core --all-targets -D warnings` — GREEN in: **default (`parallel`)**, `--no-default-features` (wasm-like), `--features compact-index,mmap`, `--all-features`.
- `cargo test -p sparq-core` (full suite, default) — GREEN; overlay tests GREEN in all four feature states above.
- rustdoc all-features gate: `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean (no new public API, no intra-doc links added).
- No public-API change → no README/`SKILL.md` edit (transparent perf optimization, identical observable behaviour). No crate README touched → `readme-template` unaffected.

## Ratchets

Runtime-allocation-only change; `count_correction` is already linked into wasm (used by `estimate`), so the fast path only adds a branch to an already-compiled function. No stored bytes / parse path touched → `store_bytes_per_triple[_small]`, `dict_bytes_per_term`, `wasm_bundle_bytes`, `parse_ns_per_byte` neutral by construction. Perf payoff is EC2-gated (non-canonical work box); no perf number asserted here.

## Scope

Ships part (a) — the zero-copy fast path — per this task's scope. Part (b) of the roadmap item (cache perm-sorted `added` projections at `apply_delta`) is deferred to **sq-7d3dj.16** as measure-first: it only helps the merge path (already dominated by the O(range) base copy it does not remove) and carries a ~6x-overlay-memory + larger-fork-clone tradeoff, so per the epic's measure-first discipline it should ship only on a measured A/B win, not bundled here.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>