### PR TITLE
perf(engine): multi-core SELECT-JSON serialize under a deadline-only budget with bounded overrun (sq-7d3dj.10) [OPUS-4.8]

### DIFF
--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -230,15 +230,37 @@ pub(crate) mod budget {
         ACTIVE.with(|a| a.get())
     }
 
-    /// `true` while a deadline / row-cap / byte-cap budget is installed. [OPUS-4.8]
-    /// roborev 1538: the streaming-JSON fast path uses this to take the cooperative
-    /// SERIAL loop (which breaks every 1024 rows) instead of the parallel fan-out that
-    /// materialises every matching fragment before any budget check — so `--max-results`
-    /// / timeouts / the byte cap bound CPU and memory, not just the final response.
-    #[cfg_attr(not(feature = "parallel"), allow(dead_code))]
+    /// Decides whether the multi-core SELECT-JSON serializer may fan out under the
+    /// CURRENTLY installed budget, returning the limit snapshot its workers re-check at
+    /// each par-chunk boundary. [OPUS-4.8] (sq-7d3dj.10, roborev 1538, audit item 6)
+    ///
+    /// The parallel path builds every matching JSON fragment before it can know a row or
+    /// byte count, so it cannot enforce a ROW / BYTE cap mid-serialize:
+    ///
+    /// * `Some(limits)` — fan out. Either NO budget is installed (`limits.on == false`,
+    ///   making the per-chunk `hit` re-check a no-op) OR the budget is DEADLINE-ONLY
+    ///   (both row and byte caps at their `usize::MAX` sentinel). Under a deadline-only
+    ///   budget the per-chunk `limits.hit(0)` re-check stops launching new chunks once
+    ///   the wall-clock deadline has passed, so the worst-case CPU overrun is bounded to
+    ///   the chunks already in flight — approximately one per worker, a bounded constant
+    ///   — not the unbounded burn an uncheckable fan-out under a row/byte cap would allow.
+    /// * `None` — a row and/or byte cap is installed; the caller must take the
+    ///   cooperative SERIAL loop, which cannot over-produce (it checks the sticky flag
+    ///   every 1024 rows and stops early). A blanket "fan out whenever a budget is
+    ///   installed" was REJECTED for exactly this reason (roborev 1538 / audit item 6).
+    ///
+    /// Compiled only for the `parallel` feature — the wasm/serial build never fans out.
+    #[cfg(feature = "parallel")]
     #[inline]
-    pub(crate) fn active() -> bool {
-        ACTIVE.with(|a| a.get().on)
+    pub(crate) fn parallel_json_fanout() -> Option<Limits> {
+        ACTIVE.with(|a| {
+            let l = a.get();
+            if l.on && (l.max_rows != usize::MAX || l.max_bytes != usize::MAX) {
+                None // a row/byte cap the fan-out cannot enforce mid-serialize → serial loop
+            } else {
+                Some(l)
+            }
+        })
     }
 
     /// Time remaining until the installed wall-clock deadline, if any. [OPUS-4.8] (sq-d4p)
@@ -1167,52 +1189,72 @@ fn single_pattern_scan_json(graph: &Graph, pattern: &GraphPattern, flush: Option
     };
 
     let mut s = head;
-    // [OPUS-4.8] roborev 1538: only take the parallel fan-out when NO budget is active. The
-    // parallel path builds every matching JSON fragment before it can check the budget, so a
-    // row cap / deadline would not bound CPU or memory — it would serialise the full result and
-    // only then fail. With a budget installed we fall through to the cooperative serial loop
-    // below, which checks `budget::exhausted` every 1024 rows and stops early.
+    // [OPUS-4.8] roborev 1538 / sq-7d3dj.10 (audit item 6): fan the JSON serialize out
+    // across cores when the installed budget cannot be violated by doing so — NO budget,
+    // or a DEADLINE-ONLY budget (the default HTTP server's 30s timeout, which has no
+    // row/byte cap). The fan-out builds every matching fragment before it can know a row
+    // or byte count, so a ROW / BYTE cap stays on the cooperative serial loop below
+    // (which checks `budget::exhausted` every 1024 rows and stops early). A deadline-only
+    // budget is admitted because the coarse `limits.hit(0)` re-check at each par-chunk
+    // boundary stops launching new chunks once the wall-clock deadline passes, bounding
+    // the overrun to ~one chunk per worker. A blanket !budget-active → true flip is
+    // REJECTED (see `parallel_json_fanout`).
     #[cfg(feature = "parallel")]
-    if scan_rows.len() >= PAR_THRESHOLD && !budget::active() {
-        use rayon::prelude::*;
-        // One string per chunk (≈ per worker), not per row — avoids one heap allocation per
-        // result cell. Chunks stay in order, so the bytes are identical to the serial path.
-        let chunk = scan_rows.len().div_ceil(rayon::current_num_threads() * 4).max(1);
-        let frags: Vec<(usize, String)> = scan_rows
-            .par_chunks(chunk)
-            .map(|rows| {
-                let mut n = 0usize;
-                let mut f = String::new();
-                for row in rows {
-                    if !passes(row) {
-                        continue;
+    if scan_rows.len() >= PAR_THRESHOLD {
+        if let Some(limits) = budget::parallel_json_fanout() {
+            use rayon::prelude::*;
+            // One string per chunk (≈ per worker), not per row — avoids one heap
+            // allocation per result cell. Chunks stay in order, so on the success path
+            // the bytes are identical to the serial path.
+            let chunk = scan_rows.len().div_ceil(rayon::current_num_threads() * 4).max(1);
+            let frags: Vec<(usize, String)> = scan_rows
+                .par_chunks(chunk)
+                .map(|rows| {
+                    // Coarse deadline re-check at the chunk boundary: once the wall-clock
+                    // deadline has passed, every later chunk produces nothing, so at most
+                    // the chunks already in flight (~one per worker) run to completion.
+                    // The installing thread's post-fan-out gate turns the passed deadline
+                    // into the timeout error, discarding this (now partial) result — so a
+                    // skipped chunk NEVER escapes as a truncated body. Under no budget / an
+                    // unexpired deadline this is one non-tripping `Instant` read per chunk.
+                    if limits.hit(0) {
+                        return (0usize, String::new());
                     }
-                    if !f.is_empty() {
-                        f.push(',');
+                    let mut n = 0usize;
+                    let mut f = String::new();
+                    for row in rows {
+                        if !passes(row) {
+                            continue;
+                        }
+                        if !f.is_empty() {
+                            f.push(',');
+                        }
+                        n += 1;
+                        write_row(row, &mut f);
                     }
-                    n += 1;
-                    write_row(row, &mut f);
+                    (n, f)
+                })
+                .collect();
+            // Budget gate on the installing thread over the total row count — and, for a
+            // deadline-only budget, the now-past wall clock: sets the sticky flag the
+            // caller's `budget::check(0)` converts into the budget error (a chunk skipped
+            // above means the deadline is globally past, so this fires deterministically).
+            let _ = budget::exhausted(frags.iter().map(|(n, _)| n).sum());
+            let mut chunks = vec![s];
+            let mut wrote = false;
+            for (_, f) in frags {
+                if f.is_empty() {
+                    continue;
                 }
-                (n, f)
-            })
-            .collect();
-        // Budget gate on the total row count (sets the sticky flag; the caller's
-        // check converts it into the budget error).
-        let _ = budget::exhausted(frags.iter().map(|(n, _)| n).sum());
-        let mut chunks = vec![s];
-        let mut wrote = false;
-        for (_, f) in frags {
-            if f.is_empty() {
-                continue;
+                if wrote {
+                    chunks.last_mut().expect("chunks start non-empty").push(',');
+                }
+                wrote = true;
+                emit_chunk(&mut chunks, f, flush);
             }
-            if wrote {
-                chunks.last_mut().expect("chunks start non-empty").push(',');
-            }
-            wrote = true;
-            emit_chunk(&mut chunks, f, flush);
+            chunks.last_mut().expect("chunks start non-empty").push_str("]}}");
+            return Some(chunks);
         }
-        chunks.last_mut().expect("chunks start non-empty").push_str("]}}");
-        return Some(chunks);
     }
     let mut chunks: Vec<String> = Vec::new();
     let mut written = 0usize;

--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -2115,14 +2115,16 @@ mod tests {
         assert!(e.contains("query budget exceeded (max-rows)"), "got: {e}");
     }
 
-    /// [OPUS-4.8] roborev 1538 (High): a budget must bound CPU/memory on a LARGE
-    /// single-pattern SELECT, not just the final response. Above PAR_THRESHOLD the
-    /// streaming-JSON path used to fan out to rayon and build EVERY matching fragment
-    /// before checking the budget. With a budget active it must instead take the
-    /// cooperative serial loop that stops within ~1024 scanned rows. We build >50k
-    /// matching rows and assert (a) the budget error fires, and (b) an already-expired
-    /// deadline returns near-instantly (a full parallel materialisation of 60k rows
-    /// would be far slower) — guarding against re-introducing the eager fan-out.
+    /// [OPUS-4.8] roborev 1538 (High) / sq-7d3dj.10: a budget must bound CPU/memory on a
+    /// LARGE single-pattern SELECT, not just the final response. A ROW/BYTE cap cannot be
+    /// enforced mid-fan-out (fragments are built before any count is known), so it takes
+    /// the cooperative serial loop that stops within ~1024 scanned rows. A DEADLINE-only
+    /// budget IS allowed to fan out (audit item 6), but the coarse per-par-chunk deadline
+    /// re-check bounds the overrun: an already-expired deadline makes every chunk produce
+    /// nothing, so the call still returns near-instantly. We build >50k matching rows and
+    /// assert (a) the row-cap budget error fires, and (b) an already-expired deadline
+    /// returns the timeout error near-instantly (a full 60k-row materialisation would be
+    /// far slower) — guarding against an UNBOUNDED fan-out under a deadline.
     #[cfg(not(target_arch = "wasm32"))]
     #[test]
     fn budget_bounds_large_single_pattern_json_scan() {
@@ -2136,8 +2138,11 @@ mod tests {
         let b = QueryBudget { max_rows: Some(5), ..QueryBudget::unlimited() };
         let e = query_json_with_budget(&big, q, &b).unwrap_err();
         assert!(e.contains("query budget exceeded (max-rows)"), "got: {e}");
-        // Already-expired deadline: the serial loop trips on its first 1024-row check,
-        // so the call returns quickly without materialising the whole result.
+        // Already-expired deadline-only budget: the multi-core fan-out is now ADMITTED
+        // (no row/byte cap to enforce mid-serialize), but the coarse per-par-chunk
+        // deadline re-check sees the passed deadline so every chunk produces nothing —
+        // the call returns near-instantly without serialising the 60k rows, and the
+        // installing thread's post-fan-out gate reports the timeout.
         let b = QueryBudget {
             deadline: Some(std::time::Instant::now() - std::time::Duration::from_millis(1)),
             ..QueryBudget::unlimited()
@@ -2151,6 +2156,69 @@ mod tests {
         // one `"s":` binding key per result row.
         let full = query_json(&big, q).unwrap();
         assert_eq!(full.matches("\"s\":").count(), 60_000, "unbudgeted scan must return all rows");
+    }
+
+    /// [OPUS-4.8] (sq-7d3dj.10) The multi-core SELECT-JSON serializer runs under a
+    /// DEADLINE-ONLY budget (the default HTTP server's shape) but MUST produce bytes
+    /// identical to the single-core serial path — same row order, same formatting — and
+    /// MUST bound its overrun on an expired deadline. The #1 risk is a nondeterministic
+    /// row order or formatting drift, which breaks SPARQL-results-JSON conformance; the
+    /// `par_chunks` split + ordered `collect` keep the order deterministic.
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn parallel_select_json_deadline_only_is_byte_identical_and_bounded() {
+        use std::time::{Duration, Instant};
+
+        // A >PAR_THRESHOLD (50k) result so the fan-out actually engages, plus small and
+        // empty result sets for the required size coverage.
+        let mut big_ttl = String::from("@prefix ex: <http://ex/> .\n");
+        for i in 0..60_000u32 {
+            big_ttl.push_str(&format!("ex:s{} ex:p \"value-{}-padding-padding-padding\" .\n", i, i));
+        }
+        let big = Graph::load_str(&big_ttl, "turtle").unwrap();
+        let small = g();
+        let cases: Vec<(&Graph, &str)> = vec![
+            (&big, "SELECT * WHERE { ?s ?p ?o }"),                   // large — fan-out engaged
+            (&big, "SELECT ?o WHERE { ?s ?p ?o }"),                 // large, projected
+            (&big, "SELECT * WHERE { ?s <http://ex/absent> ?o }"),  // empty (unsatisfiable predicate)
+            (&small, "SELECT * WHERE { ?s ?p ?o }"),                // small — below the fan-out threshold
+        ];
+
+        for (graph, q) in cases {
+            // Single-core reference: a generous ROW cap forces the cooperative SERIAL
+            // loop (parallel_json_fanout → None) yet never trips (cap ≫ result size).
+            let serial_b = QueryBudget { max_rows: Some(10_000_000), ..QueryBudget::unlimited() };
+            let serial = query_json_with_budget(graph, q, &serial_b).unwrap();
+
+            // Multi-core: a DEADLINE-only budget far in the future admits the fan-out.
+            let par_b = QueryBudget {
+                deadline: Some(Instant::now() + Duration::from_secs(3600)),
+                ..QueryBudget::unlimited()
+            };
+            let parallel = query_json_with_budget(graph, q, &par_b).unwrap();
+            assert_eq!(parallel, serial, "multi-core deadline-only body must be byte-identical to single-core for: {}", q);
+
+            // The chunked (streamed) form the HTTP server uses must concatenate to the
+            // same bytes — Content-Length is derived from these bytes, so this pins it.
+            let chunks = query_json_chunks_with_budget(graph, q, &par_b).unwrap();
+            assert_eq!(chunks.concat(), serial, "chunked deadline-only concat must equal single-core for: {}", q);
+
+            // And the fully-unbudgeted parallel path agrees too.
+            assert_eq!(query_json(graph, q).unwrap(), serial, "unbudgeted body must equal single-core for: {}", q);
+        }
+
+        // Bounded overrun: a huge result under an ALREADY-EXPIRED deadline-only budget
+        // must NOT serialise the whole thing — every par-chunk re-check trips, so the
+        // call returns the timeout error near-instantly rather than 60k serialised rows.
+        let expired = QueryBudget {
+            deadline: Some(Instant::now() - Duration::from_millis(1)),
+            ..QueryBudget::unlimited()
+        };
+        let start = Instant::now();
+        let e = query_json_with_budget(&big, "SELECT * WHERE { ?s ?p ?o }", &expired).unwrap_err();
+        let elapsed = start.elapsed();
+        assert!(e.contains("query budget exceeded (timeout)"), "got: {}", e);
+        assert!(elapsed < Duration::from_secs(2), "expired-deadline fan-out took {:?} — overrun not bounded", elapsed);
     }
 
     #[test]


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-7d3dj.10** (roadmap item 6 of `research/optimization-audit-2026-07.md`, the escalated Fable verdict). [OPUS-4.8]

## What

The rayon parallel SELECT→SPARQL-JSON serializer in the single-pattern streaming fast path (`exec::single_pattern_scan_json`) was gated on `!budget::active()`. The default HTTP server always installs a **deadline-only** budget (30s `query_timeout`, no row/byte cap), so that gate made the fan-out **dead code on the HTTP surface** — every large single-pattern SELECT (`SELECT * WHERE { ?s ?p ?o }`, the canonical large export) serialized on a single core.

Per the audit's verdict (item 6), the blanket gate is replaced with `budget::parallel_json_fanout()`, which admits the multi-core fan-out only when the installed budget **cannot be violated** by it:

- **no budget**, or a **deadline-only** budget (both row and byte caps unset) → **fan out**;
- a **row and/or byte cap** → stay on the cooperative **serial** loop (a cap cannot be enforced mid-serialize, because fragments are built before any count is known).

A **coarse deadline re-check at each par-chunk boundary** (`limits.hit(0)`) bounds the worst-case overrun: once the wall-clock deadline passes, every later chunk produces nothing, so at most the chunks already in flight (~one per worker) run to completion — a bounded constant, not an unbounded CPU burn. The installing thread's post-fan-out budget gate then reports the timeout, discarding the (now partial) result — **a skipped chunk never escapes as a truncated body**. A blanket `!budget::active() → true` flip was **REJECTED** (it would drop the DoS-resistance property the original gate protected).

Rows are already fully materialised before serialization, so **peak memory is unchanged**. The change is entirely in `sparq-engine`; the HTTP server is the beneficiary via the **unchanged public** `query_json_chunks_with_budget` — **no server code changes**.

## Byte-identity (the #1 risk)

SPARQL-results-JSON row order is significant. `par_chunks` splits the scan **in order** and the ordered `collect` reassembles **deterministically**, so the multi-core body is **byte-for-byte identical** to the single-core path (same row order, same formatting, same Content-Length). New direct test `parallel_select_json_deadline_only_is_byte_identical_and_bounded` asserts, across **large / projected / empty / small** result sets:

- multi-core (deadline-only) body **==** single-core (row-capped serial) body, byte-for-byte;
- the streamed-chunk concat **==** the single-core body (pins the Content-Length contract);
- the fully-unbudgeted parallel body **==** the single-core body;
- **bounded overrun** — a huge result under an already-expired deadline returns the timeout error near-instantly rather than serializing the whole result.

The existing `budget_bounds_large_single_pattern_json_scan` guard is retained (its row-cap case still exercises the serial loop; its expired-deadline case now exercises the fan-out + re-check) with its mechanism comment updated to match.

## Gates (all green)

Feature flag: **`parallel`** (sparq-engine default-on; OFF in the wasm / `--no-default-features` build).

- Default (**parallel ON**): `cargo build` / `cargo clippy --all-targets -D warnings` / full `cargo test` (231 pass, 2 ignored).
- **parallel OFF** (`--no-default-features --features regex,digest`): build + clippy `-D warnings`; lib tests 228 pass / 0 fail / 2 ignored (the 3 `parallel`-gated tests compile out).
- **wasm32** (`sparq-wasm`, engine `default-features = false` → serial path): build + clippy `-D warnings`.
- `cargo doc --workspace --no-deps --all-features` with `RUSTDOCFLAGS="-D warnings"` — clean (the new `pub(crate)` doc-comment carries no intra-doc links).
- `readme-template`: 0 deviations (no README changed — internal perf change, no public-API delta).
- **No perf numbers asserted** in markdown; the payoff is EC2-gated (the work box + the sq-7d3dj.5 harness are non-canonical). Deterministic ratchets untouched.

## Honest boundary / deferred

The **general** (multi-pattern) JSON path (`exec::eval_select_json_chunks` after `eval_modified`, `exec.rs:1345`) already fans out under any budget but has **no** mid-serialize deadline re-check **and no** post-serialization budget check, so a large multi-pattern SELECT under a deadline-only budget can serialize the full materialised set past the deadline (bounded by the materialised row count, which any row/byte cap has already enforced). This is **pre-existing** and out of scope for this bead (which targets the `!budget::active()`-gated streaming path); adding the same bounded-overrun re-check there needs a post-serialization budget check (a behavior change for late-but-complete results) and is captured as a follow-up.