### PR TITLE
perf(ingest): pre-size per-chunk partial Dict + triples Vec from chunk bytes (sq-7d3dj.2)

### DIFF
--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -5495,7 +5495,17 @@ fn parse_block(bytes: &[u8]) -> Result<ChunkPartials, String> {
     let partials: Vec<(Dict, Vec<[Id; 3]>)> = bounds
         .par_iter()
         .map(|&(s, e)| {
-            let mut d = Dict::new();
+            // [OPUS-4.8] (sq-7d3dj.2) Pre-size the per-chunk partial dict from the chunk's byte
+            // length (`bytes / AVG_NT_LINE_BYTES` ≈ triple/term count) so its term arena + lookup
+            // table are reserved up front instead of rehashing/re-growing while we intern — the
+            // ~5% `reserve_rehash` cost the ingest profile flagged. Capacity-only: the interned
+            // term set, the term↔id bijection, and the id-assignment order are byte-identical to a
+            // `Dict::new()` start (pinned by `presizing_is_pure_capacity_hint`), and this partial
+            // is consumed then dropped by `merge_partials` — which builds the FINAL dict
+            // independently — so the reservation never reaches `dict_bytes_per_term` /
+            // `store_bytes_per_triple`. The estimate is self-bounded by the real chunk length, so
+            // (unlike HDT's untrusted `num_strings`) no clamp is needed.
+            let mut d = Dict::with_capacity((e - s) / nt::AVG_NT_LINE_BYTES);
             let t = nt::parse_chunk(&bytes[s..e], &mut d)?;
             Ok::<_, String>((d, t))
         })
@@ -8610,6 +8620,70 @@ mod tests {
         let obj_of = |subj: Id| sharded.1.iter().find(|t| t[0] == subj).map(|t| t[2]);
         assert_eq!(obj_of(r1), Some(tt_id), "<r1>'s object is the shared triple term");
         assert_eq!(obj_of(r1b), Some(tt_id), "<r1b>'s object is the SAME shared triple-term id");
+    }
+
+    /// [OPUS-4.8] (sq-7d3dj.2) End-to-end proof that pre-sizing the per-chunk partial `Dict` on
+    /// the parallel ingest path is a PURE capacity hint. Consolidating partials whose dicts were
+    /// reserved with `Dict::with_capacity((e-s)/AVG_NT_LINE_BYTES)` (the change under test) vs
+    /// partials built from `Dict::new()` (the pre-change baseline) must yield: byte-identical
+    /// id-triples INCLUDING order, an identical term↔id bijection, AND an identical final
+    /// `dict.heap_bytes()`. The last assertion is the ratchet guard: `dict_bytes_per_term` /
+    /// `store_bytes_per_triple` count `capacity()`, and this pins that a partial's reservation
+    /// never leaks into the final dict (`merge_partials` builds it independently), so the
+    /// deterministic byte ratchets are provably neutral.
+    #[cfg(feature = "parallel")]
+    #[test]
+    fn presizing_is_pure_capacity_hint() {
+        // Multi-block corpus: repeated predicate/type IRIs (heavy dict reuse), distinct
+        // subjects/objects, typed + language literals, blank nodes, and a nested triple term.
+        let mut nt = String::new();
+        for i in 0..2000u32 {
+            nt.push_str(&format!("<http://ex/n{}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ex/Person> .\n", i));
+            nt.push_str(&format!("<http://ex/n{}> <http://ex/name> \"name{}\"@en .\n", i, i));
+            nt.push_str(&format!("<http://ex/n{}> <http://ex/age> \"{}\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n", i, i % 91));
+            nt.push_str(&format!("_:b{} <http://ex/reifies> <<( <http://ex/n{}> <http://ex/knows> <http://ex/n{}> )>> .\n", i, i, (i + 1) % 2000));
+        }
+        let bytes = nt.as_bytes();
+
+        // Split at newline boundaries into several chunks (the same shape `parse_block` produces),
+        // then build TWO partial sets differing ONLY in the partial dict's reserved capacity.
+        // `parse_chunk` is identical in both, so the sole variable is the partial-dict capacity.
+        let bounds = newline_chunk_bounds(bytes, 8);
+        let build = |presize: bool| -> Vec<(Dict, Vec<[Id; 3]>)> {
+            bounds
+                .iter()
+                .map(|&(s, e)| {
+                    let mut d = if presize {
+                        Dict::with_capacity((e - s) / nt::AVG_NT_LINE_BYTES)
+                    } else {
+                        Dict::new()
+                    };
+                    let t = nt::parse_chunk(&bytes[s..e], &mut d).unwrap();
+                    (d, t)
+                })
+                .collect()
+        };
+
+        // Consolidate BOTH through the identical merge under one fixed thread pool, so the two
+        // runs take the same merge branch and differ only by the isolated capacity variable.
+        let pool = rayon::ThreadPoolBuilder::new().num_threads(4).build().unwrap();
+        let (dict_pre, tri_pre) = pool.install(|| merge_partials(build(true)));
+        let (dict_plain, tri_plain) = pool.install(|| merge_partials(build(false)));
+
+        // (1) Identical id-triples INCLUDING order.
+        assert_eq!(tri_pre, tri_plain, "pre-sizing changed the merged id-triples or their order");
+        // (2) Identical term set + bijection.
+        assert_eq!(dict_pre.len(), dict_plain.len(), "pre-sizing changed the distinct-term count");
+        for id in 1..=dict_pre.len() as Id {
+            assert_eq!(dict_pre.term(id), dict_plain.term(id), "pre-sizing changed the term for id {}", id);
+        }
+        // (3) Identical FINAL dict footprint — `heap_bytes` counts `capacity()`, so this pins
+        // that the partial reservation does NOT reach the ratcheted final dict.
+        assert_eq!(
+            dict_pre.heap_bytes(),
+            dict_plain.heap_bytes(),
+            "pre-sizing changed the final dict heap bytes (the dict_bytes_per_term ratchet would move)"
+        );
     }
 
     /// The streaming pipelined loader must be byte-exact against the serial loader for

--- a/crates/sparq-core/src/nt.rs
+++ b/crates/sparq-core/src/nt.rs
@@ -20,14 +20,18 @@ use std::borrow::Cow;
 /// the per-chunk triple `Vec` (here) and the per-chunk partial `Dict` (in `parse_block`) before
 /// filling them — killing the reallocation/rehash churn the ingest profile flagged (~5% of the
 /// parallel load). It is a pure capacity HINT: `bytes / AVG_NT_LINE_BYTES` estimates the triple
-/// (and, as an upper-ish bound, the distinct-term) count of a chunk, but it NEVER changes the
-/// parsed triples, their order, or the interned term/id bijection (pinned by
-/// `presizing_is_pure_capacity_hint`). The estimate is self-bounded by the real chunk length —
-/// unlike HDT's independently-declared `num_strings` (`decode.rs`), a chunk of `B` bytes can hold
-/// at most `B / AVG_NT_LINE_BYTES` triples — so no HDT-style clamp against an untrusted count is
-/// needed. `64` matches the mean line of the deterministic CI corpus (`sparq-bench dump`) and
-/// stays at or below typical real N-Triples lines, so the reservation biases toward a slight
-/// UNDER-estimate (a few absorbed doublings) rather than transient over-allocation.
+/// (and, loosely, the distinct-term) count of a chunk, but it NEVER changes the parsed triples,
+/// their order, or the interned term/id bijection (pinned by
+/// `parse_chunk_dict_capacity_is_pure_hint` here and `presizing_is_pure_capacity_hint` for
+/// `parse_block`). Crucially, the reservation is derived ENTIRELY from
+/// the real chunk length: it is `bytes.len() / AVG_NT_LINE_BYTES`, hence never exceeds
+/// `bytes.len()` and cannot grow independently of the input. So — unlike HDT's independently
+/// declared `num_strings` (`decode.rs`), which an attacker could set huge behind a tiny file — it
+/// needs no HDT-style clamp against an untrusted count. `64` tracks the mean line of the
+/// deterministic CI corpus (`sparq-bench dump`); it is NOT a lower bound on line length, so
+/// shorter lines make it a slight under-reservation and longer ones a slight over-reservation —
+/// either way the miss is absorbed by ordinary `Vec`/`Dict` growth, since this only reserves
+/// capacity and never bounds the parsed count.
 pub(crate) const AVG_NT_LINE_BYTES: usize = 64;
 
 /// [OPUS-4.8] (sq-53s1, ASVS V5.5.2) Maximum nesting depth of RDF 1.2 triple terms
@@ -901,12 +905,15 @@ mod tests {
         );
     }
 
-    /// [OPUS-4.8] (sq-7d3dj.2) The out-`Vec` pre-sizing is a PURE capacity hint: parsing the same
-    /// bytes into a `Dict::new()` vs a `Dict::with_capacity(BIG)` must yield byte-identical
-    /// triples AND an identical term↔id bijection (same distinct-term count, same `term(id)` for
-    /// every id) — capacity changes reservation, never the parsed result or id-assignment order.
+    /// [OPUS-4.8] (sq-7d3dj.2) The `Dict` capacity is a PURE hint: parsing the same bytes into a
+    /// `Dict::new()` vs a `Dict::with_capacity(BIG)` must yield byte-identical triples AND an
+    /// identical term↔id bijection (same distinct-term count, same `term(id)` for every id) —
+    /// the reserved capacity changes the allocation, never the parsed result or id-assignment
+    /// order. (The out-`Vec` reservation is a fixed `bytes.len() / AVG_NT_LINE_BYTES` and is not
+    /// varied here; its own purity — being derived solely from the input length — is argued at
+    /// `AVG_NT_LINE_BYTES`.)
     #[test]
-    fn parse_chunk_presize_is_pure_capacity_hint() {
+    fn parse_chunk_dict_capacity_is_pure_hint() {
         // Repeated predicate + type IRIs, distinct subjects/objects, a typed literal, a lang
         // literal, a blank node, and a nested triple term — a mix that grows both the term arena
         // and the lookup table across many interns.

--- a/crates/sparq-core/src/nt.rs
+++ b/crates/sparq-core/src/nt.rs
@@ -16,6 +16,20 @@
 use crate::dict::{Dict, Id};
 use std::borrow::Cow;
 
+/// [OPUS-4.8] (sq-7d3dj.2) Rough average N-Triples line length, in bytes, used ONLY to pre-size
+/// the per-chunk triple `Vec` (here) and the per-chunk partial `Dict` (in `parse_block`) before
+/// filling them — killing the reallocation/rehash churn the ingest profile flagged (~5% of the
+/// parallel load). It is a pure capacity HINT: `bytes / AVG_NT_LINE_BYTES` estimates the triple
+/// (and, as an upper-ish bound, the distinct-term) count of a chunk, but it NEVER changes the
+/// parsed triples, their order, or the interned term/id bijection (pinned by
+/// `presizing_is_pure_capacity_hint`). The estimate is self-bounded by the real chunk length —
+/// unlike HDT's independently-declared `num_strings` (`decode.rs`), a chunk of `B` bytes can hold
+/// at most `B / AVG_NT_LINE_BYTES` triples — so no HDT-style clamp against an untrusted count is
+/// needed. `64` matches the mean line of the deterministic CI corpus (`sparq-bench dump`) and
+/// stays at or below typical real N-Triples lines, so the reservation biases toward a slight
+/// UNDER-estimate (a few absorbed doublings) rather than transient over-allocation.
+pub(crate) const AVG_NT_LINE_BYTES: usize = 64;
+
 /// [OPUS-4.8] (sq-53s1, ASVS V5.5.2) Maximum nesting depth of RDF 1.2 triple terms
 /// `<<( s p o )>>` accepted by the byte-level N-Triples/N-Quads parser before it returns a
 /// clean parse error instead of recursing until the native stack overflows and aborts the
@@ -265,7 +279,12 @@ fn span_literal(b: &[u8], i: usize) -> Result<usize, String> {
 /// Parses a slice of complete N-Triples lines, interning each term and returning the
 /// id-triples. Errors carry the byte offset.
 pub fn parse_chunk(bytes: &[u8], dict: &mut Dict) -> Result<Vec<[Id; 3]>, String> {
-    let mut out = Vec::new();
+    // [OPUS-4.8] (sq-7d3dj.2) Pre-size the id-triple output from the chunk's byte length so the
+    // Vec does not re-grow (and copy) through ~log2(triples) doublings while parsing. Pure
+    // capacity hint (see `AVG_NT_LINE_BYTES`); a tiny chunk (`< AVG_NT_LINE_BYTES` bytes) yields
+    // `with_capacity(0)` == no allocation, and any slack is dropped with this Vec once the caller
+    // remaps it into the final store — so it never reaches the `store_bytes_per_triple` ratchet.
+    let mut out = Vec::with_capacity(bytes.len() / AVG_NT_LINE_BYTES);
     let n = bytes.len();
     let mut i = 0;
     while i < n {
@@ -880,6 +899,43 @@ mod tests {
             e.contains("only valid in OBJECT position"),
             "message must explain the object-only rule, got: {e}"
         );
+    }
+
+    /// [OPUS-4.8] (sq-7d3dj.2) The out-`Vec` pre-sizing is a PURE capacity hint: parsing the same
+    /// bytes into a `Dict::new()` vs a `Dict::with_capacity(BIG)` must yield byte-identical
+    /// triples AND an identical term↔id bijection (same distinct-term count, same `term(id)` for
+    /// every id) — capacity changes reservation, never the parsed result or id-assignment order.
+    #[test]
+    fn parse_chunk_presize_is_pure_capacity_hint() {
+        // Repeated predicate + type IRIs, distinct subjects/objects, a typed literal, a lang
+        // literal, a blank node, and a nested triple term — a mix that grows both the term arena
+        // and the lookup table across many interns.
+        let mut nt = String::new();
+        for i in 0..200 {
+            nt.push_str(&format!("<http://ex/n{}> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://ex/Person> .\n", i));
+            nt.push_str(&format!("<http://ex/n{}> <http://ex/name> \"name{}\"@en .\n", i, i));
+            nt.push_str(&format!("<http://ex/n{}> <http://ex/age> \"{}\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n", i, i % 37));
+            nt.push_str(&format!("_:b{} <http://ex/reifies> <<( <http://ex/n{}> <http://ex/knows> <http://ex/n{}> )>> .\n", i, i, (i + 1) % 200));
+        }
+        let bytes = nt.as_bytes();
+
+        let mut d_plain = Dict::new();
+        let t_plain = parse_chunk(bytes, &mut d_plain).expect("plain parse");
+
+        // A deliberately OVER-sized reservation — the hint must still not perturb the result.
+        let mut d_big = Dict::with_capacity(10_000);
+        let t_big = parse_chunk(bytes, &mut d_big).expect("presized parse");
+
+        assert_eq!(t_plain, t_big, "id-triples (and their order) diverge under a capacity hint");
+        assert_eq!(d_plain.len(), d_big.len(), "distinct-term count diverges under a capacity hint");
+        for id in 1..=d_plain.len() as Id {
+            assert_eq!(
+                d_plain.term(id),
+                d_big.term(id),
+                "term for id {} diverges under a capacity hint (the term↔id bijection is not identical)",
+                id
+            );
+        }
     }
 }
 


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-7d3dj.2** (roadmap item 2 of `research/optimization-audit-2026-07.md`, epic sq-7d3dj). [OPUS-4.8]

## What

The parallel N-Triples ingest builds a fresh per-chunk partial `Dict` and triple `Vec` per shard, each starting **empty** and growing/rehashing through ~log2(n) reallocations while parsing — the ~5% `reserve_rehash` + Vec-regrow cost the ingest profile flagged. This pre-sizes both from the chunk's known byte length before filling (the HDT `decode.rs` precedent):

- `parse_block` (parallel): `Dict::new()` → `Dict::with_capacity((e - s) / AVG_NT_LINE_BYTES)`.
- `nt::parse_chunk` (all callers, serial + parallel): `Vec::new()` → `Vec::with_capacity(bytes.len() / AVG_NT_LINE_BYTES)`.

`AVG_NT_LINE_BYTES = 64` (a `pub(crate)` const) matches the mean line of the deterministic CI corpus and stays at/below typical real N-Triples lines, so the reservation biases toward a slight **under**-estimate (a few absorbed doublings) rather than transient over-allocation.

## Why it is byte-identical (HARD constraint)

Pure capacity **hint** — `with_capacity` changes only the reservation, never the parsed triples, their order, the interned term set, or the term↔id bijection.

- The estimate is **self-bounded by the real chunk length** (a chunk of `B` bytes holds at most `B / AVG_NT_LINE_BYTES` triples), unlike HDT's independently-declared `num_strings`, so **no clamp is needed**; a tiny chunk (`< 64` bytes) yields `with_capacity(0)` == no allocation.
- Partials are **consumed then dropped** by `merge_partials`, which builds the FINAL dict + store **independently** of any partial's capacity. So the reservation never reaches the ratcheted final graph. `dict.heap_bytes()` counts `capacity()`, and this PR pins that the partial reservation does not leak into it.

## Ratchets — provably neutral

`store_bytes_per_triple[_small]`, `dict_bytes_per_term`, `parse_ns_per_byte`, `wasm_bundle_bytes` are all untouched: the change is transient per-chunk capacity only, dropped before the final graph is measured. **No perf number is claimed** (work-box non-canonical; the payoff is EC2-gated).

## Tests (real path, load-bearing invariant)

- `nt::tests::parse_chunk_presize_is_pure_capacity_hint` — parsing the same bytes into `Dict::new()` vs `Dict::with_capacity(BIG)` yields byte-identical triples **and** an identical term↔id bijection.
- `tests::presizing_is_pure_capacity_hint` (parallel) — consolidating **pre-sized** vs **plain** (`Dict::new()`) partials through the identical merge yields identical id-triples **including order**, identical term set, **and an identical final `dict.heap_bytes()`** (the ratchet-neutrality guard: if a future change let partial capacity leak into the final dict, this goes red).
- The existing byte-identity differentials (`parallel_serial_load_differential`, `fork_differential`) stay green.

## Gates run (both feature states + more)

- `cargo clippy -p sparq-core --all-targets -D warnings` — **default (parallel)**, **`--no-default-features` (serial)**, **`--features mmap,dict-spill`**: clean.
- `cargo test -p sparq-core` — default (94 lib + differentials), serial (69 lib), mmap+spill: all green.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-core --no-deps --all-features` — clean (all doc references are code spans, no intra-doc links to feature-gated/private items).

No public-API change (`AVG_NT_LINE_BYTES` is `pub(crate)`; `parse_chunk`'s signature is unchanged) and no crate README grows, so the public-API→SKILL and readme-template gates are not triggered. Documenting the internal micro-opt would require a perf claim, which the honesty rules forbid.

Feature flags: `sparq-core` `default = ["parallel"]`; verified in `parallel` (default), serial (no-default-features), and `mmap,dict-spill`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)