### PR TITLE
fix(papers): sq-iixdh — fix 0.x section numbering across paper fleet [OPUS-4.8]

### DIFF
--- a/site/papers/_lib/bench.typ
+++ b/site/papers/_lib/bench.typ
@@ -55,3 +55,25 @@
 } else {
   align(center)[Jesse Wright · the sparq project]
 }
+
+// [OPUS-4.8] sq-iixdh — canonical heading-numbering function for all papers.
+//
+// Papers use level-2 headings (== Section) as their top-level sections (the page h1 or
+// document title occupies the conceptual level-1 slot). A plain `#set heading(numbering:
+// "1.")` over level-2 headings with no level-1 ancestor renders them as "0.1", "0.2",
+// because Typst counts the never-incremented level-1 counter as 0.
+//
+// This function drops the level-1 component so == headings render as "1.", "2.", "3." and
+// === headings as "1.1.", "1.2." — the venue-conventional numbering.
+//
+// Usage in a paper:
+//   #import "_lib/bench.typ": ..., paper_heading_numbering
+//   #set heading(numbering: paper_heading_numbering)
+//   // Abstract must be explicitly un-numbered:
+//   #heading(level: 2, numbering: none, outlined: false)[Abstract]
+#let paper_heading_numbering = (..n) => {
+  let ns = n.pos()
+  // Drop the leading level-1 counter (always 0 for papers) so == sections
+  // are "1.", "2.", ... and === sub-sections are "1.1.", "1.2.", ...
+  numbering("1.", ..if ns.len() > 1 { ns.slice(1) } else { ns })
+}

--- a/site/papers/cozk-witness-validation.typ
+++ b/site/papers/cozk-witness-validation.typ
@@ -16,12 +16,16 @@
 // sq-9hrn (this coZK re-audit). The concept the literature calls the hyphenated adjective is
 // referred to here as "malicious security" (the noun) on purpose.
 
-#import "_lib/bench.typ": headline, ev, provenance, authors, anon
+// [OPUS-4.8] sq-iixdh — import paper_heading_numbering so the Abstract is un-numbered and
+// sections render as "1.", "2." (not "0.1", "0.2").
+#import "_lib/bench.typ": headline, ev, provenance, authors, anon, paper_heading_numbering
 
 #set document(title: "A Collaborative-zk-SNARK Re-Audit as a Witness-Validation Negative Result for Federated SPARQL")
 #set text(size: 11pt)
 #set par(justify: true)
-#set heading(numbering: "1.")
+// Section numbering switched on here; the Abstract below is explicitly un-numbered so it
+// renders as front matter (venue convention), and == sections number as "1.", "2.", ...
+#set heading(numbering: paper_heading_numbering)
 
 #align(center)[
   #text(size: 17pt, weight: "bold")[
@@ -43,7 +47,7 @@
   collaborative re-audit (`sq-9hrn`) — neither of which is discharged here.
 ]]
 
-== Abstract
+#heading(level: 2, numbering: none, outlined: false)[Abstract]
 
 A federated query engine that wants to let several data holders jointly prove one statement over
 their private graphs is reaching for a _collaborative_ zero-knowledge SNARK: an MPC among the

--- a/site/papers/filtered-ann.typ
+++ b/site/papers/filtered-ann.typ
@@ -12,17 +12,16 @@
 // The SPARQL surface (vec:nearest / vec:search) and the recomposition pipeline are documented
 // from skills/vector-search/SKILL.md (the crate's public-API doc).
 
-#import "_lib/bench.typ": headline, ev, provenance, authors, anon
+// [OPUS-4.8] sq-iixdh — use shared paper_heading_numbering (consolidated into _lib/bench.typ).
+#import "_lib/bench.typ": headline, ev, provenance, authors, anon, paper_heading_numbering
 
 #set document(title: "Filter-as-Query")
 #set text(size: 11pt)
 #set par(justify: true)
 // Sections are level-2 headings (the site's HTML convention: h2 under the page h1), so a
-// plain "1." pattern would render "0.1", "0.2" — drop the never-used level-1 component.
-#set heading(numbering: (..n) => {
-  let ns = n.pos()
-  numbering("1.", ..if ns.len() > 1 { ns.slice(1) } else { ns })
-})
+// plain "1." pattern would render "0.1", "0.2" — paper_heading_numbering drops the
+// never-used level-1 component (defined once in _lib/bench.typ, used by all papers).
+#set heading(numbering: paper_heading_numbering)
 
 #align(center)[
   #text(size: 17pt, weight: "bold")[

--- a/site/papers/fo-km-agent.typ
+++ b/site/papers/fo-km-agent.typ
@@ -26,12 +26,16 @@
 //     grader's exact abstention/denominator arithmetic inside analyze.py) are marked as DRAFT
 //     OBLIGATIONS rather than read from code or invented. Grep marker: "DRAFT OBLIGATION".
 
-#import "_lib/bench.typ": headline, ev, provenance, authors, anon
+// [OPUS-4.8] sq-iixdh — import paper_heading_numbering so the Abstract is un-numbered and
+// sections render as "1.", "2." (not "0.1", "0.2").
+#import "_lib/bench.typ": headline, ev, provenance, authors, anon, paper_heading_numbering
 
 #set document(title: "Formal Ontologies for LLM-Agent Knowledge Management: schema.org vs gUFO vs DOLCE")
 #set text(size: 11pt)
 #set par(justify: true)
-#set heading(numbering: "1.")
+// Section numbering switched on here; the Abstract below is explicitly un-numbered so it
+// renders as front matter (venue convention), and == sections number as "1.", "2.", ...
+#set heading(numbering: paper_heading_numbering)
 
 #align(center)[
   #text(size: 17pt, weight: "bold")[
@@ -51,7 +55,7 @@
   to be pre-registered before it runs, is the gate.
 ]]
 
-== Abstract
+#heading(level: 2, numbering: none, outlined: false)[Abstract]
 
 An LLM agent that manages durable project knowledge — decisions, provenance, task structure,
 design records — increasingly does so over a _project knowledge graph_ (PKG) that the agent

--- a/site/papers/odrl-policy-bridge.typ
+++ b/site/papers/odrl-policy-bridge.typ
@@ -31,12 +31,16 @@
 // federated ODRL->MPC / ODRL-Duty->ZK composition is deferred, unbuilt, research-grade, and not
 // externally audited (open gate sq-qhy4) — see §7.
 
-#import "_lib/bench.typ": headline, ev, provenance, authors, anon
+// [OPUS-4.8] sq-iixdh — import paper_heading_numbering so the Abstract is un-numbered and
+// sections render as "1.", "2." (not "0.1", "0.2").
+#import "_lib/bench.typ": headline, ev, provenance, authors, anon, paper_heading_numbering
 
 #set document(title: "An ODRL Policy Bridge for SPARQL Access Control")
 #set text(size: 11pt)
 #set par(justify: true)
-#set heading(numbering: "1.")
+// Section numbering switched on here; the Abstract below is explicitly un-numbered so it
+// renders as front matter (venue convention), and == sections number as "1.", "2.", ...
+#set heading(numbering: paper_heading_numbering)
 
 #align(center)[
   #text(size: 17pt, weight: "bold")[
@@ -51,7 +55,7 @@
   specified in §5.3 has been run and reported; artifact availability is stated in §8.
 ]]
 
-== Abstract
+#heading(level: 2, numbering: none, outlined: false)[Abstract]
 
 Solid's access-control models answer _may this agent read graph G?_; ODRL usage control
 answers a richer question — _may this party use this asset, for purpose P, until time T, with

--- a/site/papers/solid-acl-conformance.typ
+++ b/site/papers/solid-acl-conformance.typ
@@ -8,12 +8,16 @@
 // scoped to LIBRARY-LEVEL decision parity (the authorization content of the specs), not
 // HTTP/CTH wire conformance — that scoping limitation is stated up front, not hidden.
 
-#import "_lib/bench.typ": headline, ev, provenance, authors, anon
+// [OPUS-4.8] sq-iixdh — import paper_heading_numbering so the Abstract is un-numbered and
+// sections render as "1.", "2." (not "0.1", "0.2").
+#import "_lib/bench.typ": headline, ev, provenance, authors, anon, paper_heading_numbering
 
 #set document(title: "Library-Level Solid Access-Control Conformance: WAC and ACP Decision-Parity Ratchets")
 #set text(size: 11pt)
 #set par(justify: true)
-#set heading(numbering: "1.")
+// Section numbering switched on here; the Abstract below is explicitly un-numbered so it
+// renders as front matter (venue convention), and == sections number as "1.", "2.", ...
+#set heading(numbering: paper_heading_numbering)
 
 #align(center)[
   #text(size: 17pt, weight: "bold")[
@@ -32,7 +36,7 @@
   Conformance-Test-Harness wire conformance, which has no library entry point here.
 ]]
 
-== Abstract
+#heading(level: 2, numbering: none, outlined: false)[Abstract]
 
 The Solid ecosystem standardises two access-control models — Web Access Control (WAC) and the
 newer Access Control Policy (ACP) — and a server is expected to honour whichever a pod uses. We


### PR DESCRIPTION
> 🤖 SPARQ agent — sq-iixdh

## Root cause

`#set heading(numbering: "1.")` was applied at document top in 4 papers, while sections used level-2 (`==`) headings with no preceding level-1 (`=`) parent. Typst counts the never-incremented level-1 counter as 0, so every section rendered as `0.1.`, `0.2.`, … and the Abstract was numbered `0.1. Abstract`.

## Fix

**Shared template** (`site/papers/_lib/bench.typ`): added `paper_heading_numbering` — a function that drops the level-1 component so `==` sections render as `1.`, `2.`, `3.` and `===` sub-sections as `1.1.`, `1.2.`. Defined once, imported by all papers.

**Per-paper changes** (4 broken papers + 1 consolidation):

| Paper | Change |
|---|---|
| `cozk-witness-validation.typ` | import + `paper_heading_numbering` + abstract un-numbered |
| `fo-km-agent.typ` | import + `paper_heading_numbering` + abstract un-numbered |
| `odrl-policy-bridge.typ` | import + `paper_heading_numbering` + abstract un-numbered |
| `solid-acl-conformance.typ` | import + `paper_heading_numbering` + abstract un-numbered |
| `filtered-ann.typ` | consolidated to use shared function (was inline-defined, same logic) |

`verifiable-fed-sparql.typ` was already fixed in PR #1359 (abstract before set-rule, promoted `=` sections) and is unchanged.

## Verification

- `node scripts/build-papers.mjs` — all 6 papers compile; honesty gate passes; HTML output shows `Abstract` unnumbered and sections `1.`, `2.`, `3.`
- `npm run build` — static export green (56/56 pages)
- `npm run lint` — no ESLint warnings or errors
- `npx tsc --noEmit` — clean

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>