### PR TITLE
docs(governance): tier-1 embedding-API stability + deprecation policy + in-code markers (sq-tvuw8) [OPUS-4.8]

### DIFF
--- a/crates/sparq-serve/README.md
+++ b/crates/sparq-serve/README.md
@@ -36,9 +36,9 @@ read/write/probe entry points (`query_json` / `ask` / `update_in_place` /
 re-export of the runtime-agnostic concurrency wrapper (`GenerationRing` +
 `GraphApplier` / `Writer`, factored out of `sparq-server`'s axum/tokio glue so an
 embedder reuses sparq's *tested* fork → update → publish + generation-pinning model).
-It is the surface the maintainer **intends** to commit to as the stable embedding
-API ([#1248](https://github.com/jeswr/sparq/issues/1248)) — but **NOT yet a frozen
-semver-tier-1 surface**: the formal freeze is the maintainer's to ratify on #1248,
+It is the proposed **API tier-1 (proposed-stable)** embedding surface (the
+[API stability policy](../../docs/api-stability.md)) — but **NOT yet frozen**: the
+semver freeze is the maintainer's to ratify ([#1248](https://github.com/jeswr/sparq/issues/1248)),
 and until then a minor pre-`1.0` release MAY still change it.
 
 ## 🚀 Quickstart

--- a/crates/sparq-serve/src/embed.rs
+++ b/crates/sparq-serve/src/embed.rs
@@ -24,17 +24,20 @@
 //!    of `sparq-server`'s axum/tokio glue); the embedding seam is the documented
 //!    front door to it.
 //!
-//! # Stability — INTENDED stable, semver-tier-1 freeze PENDING ratification
+//! # Stability — **API tier-1 (proposed-stable)**, semver freeze PENDING ratification
 //!
-//! This is the surface the maintainer **intends** to commit to as the stable
-//! embedding API (the request in [issue #1248]). It is **NOT yet a frozen
-//! semver-tier-1 surface**: the formal commitment is the maintainer's to ratify on
-//! #1248, and until that ratification a minor pre-`1.0` release MAY still change it.
-//! It is documented as the embedding seam so an embedder pins ONE module rather than
-//! a scatter of functions the underlying crates mark "unstable", and so the freeze,
-//! when ratified, has a single well-defined shape. No behaviour here is new: every
-//! call is the same engine path `sparq-server` already exercises in production.
+//! This whole module is the proposed **tier-1** (semver-stable) embedding surface in the
+//! [API stability & deprecation policy]. It is the surface the maintainer **intends** to
+//! commit to as the stable embedding API (the request in [issue #1248]). It is **NOT yet a
+//! frozen semver-tier-1 surface**: the formal commitment is the maintainer's to ratify on
+//! #1248, and until that ratification a minor pre-`1.0` release MAY still change it — the
+//! marker asserts a *proposal*, not an active guarantee. It is documented as the embedding
+//! seam so an embedder pins ONE module rather than a scatter of functions the underlying
+//! crates mark "unstable", and so the freeze, when ratified, has a single well-defined
+//! shape. No behaviour here is new: every call is the same engine path `sparq-server`
+//! already exercises in production.
 //!
+//! [API stability & deprecation policy]: https://github.com/jeswr/sparq/blob/main/docs/api-stability.md
 //! [issue #1248]: https://github.com/jeswr/sparq/issues/1248
 //!
 //! # Example — embed one resource graph behind the generation ring

--- a/crates/sparq-serve/src/lib.rs
+++ b/crates/sparq-serve/src/lib.rs
@@ -13,9 +13,12 @@ mod applier;
 /// [`update_in_place`](embed::update_in_place) / [`apply_delta_nquads`](embed::apply_delta_nquads)
 /// / [`exists`](embed::exists)+[`metadata`](embed::metadata)) plus a re-export of the
 /// runtime-agnostic concurrency wrapper ([`GenerationRing`] + [`GraphApplier`] / [`Writer`]),
-/// so an external host can call sparq in-process instead of over HTTP. INTENDED stable embedding
-/// API; the formal semver-tier-1 freeze is **pending maintainer ratification on #1248** (see the
-/// module docs) — not unilaterally frozen here. Thin re-exports only; no new behaviour.
+/// so an external host can call sparq in-process instead of over HTTP. **API tier-1
+/// (proposed-stable)** — the proposed semver-stable embedding surface in the [API stability
+/// policy]; the formal freeze is **pending maintainer ratification on #1248** (see the module
+/// docs), not unilaterally frozen here. Thin re-exports only; no new behaviour.
+///
+/// [API stability policy]: https://github.com/jeswr/sparq/blob/main/docs/api-stability.md
 pub mod embed;
 /// [OPUS-4.8] (sq-o5bi) ONLINE consistent-snapshot backup + restore for the serving store
 /// — export an already-immutable pinned [`Generation`] to a single self-describing artifact

--- a/crates/sparq-solid/src/decide.rs
+++ b/crates/sparq-solid/src/decide.rs
@@ -10,6 +10,18 @@
 //! and adds no dependency, so it is an always-present public API (no cargo gate), mirroring
 //! [`crate::PodStore::wac_allow`].
 //!
+//! # Stability — **API tier-1 (proposed-stable)**
+//!
+//! The per-resource decision surface ([`crate::PodStore::decide`] / `decide_batch` /
+//! `resolve_acl` / [`crate::PodStore::wac_allow`], with [`WacDecision`] / [`AclStatus`] /
+//! [`AclScope`] / [`EffectiveAcl`]) is proposed **tier-1** (semver-stable) in the [API
+//! stability & deprecation policy]. The freeze is **pending maintainer ratification**
+//! (issue #1346 P0 / #1248); the marker asserts a *proposal*, not an active guarantee.
+//! This is the authorization-**decision** surface only — it does not authenticate and makes
+//! no cryptographic claim (a `Session` is a caller-asserted claim; see the crate README).
+//!
+//! [API stability & deprecation policy]: https://github.com/jeswr/sparq/blob/main/docs/api-stability.md
+//!
 //! # Security posture — fail-CLOSED, never fail-OPEN (FR-6, sq-snopa.2)
 //!
 //! This is authorization decision logic; the cardinal rule is **any uncertainty ⇒ deny**.
@@ -117,6 +129,11 @@ pub struct EffectiveAcl {
 /// module docs and [`AclStatus`]. The grant verdict reuses
 /// [`crate::AuthIndex::accessible`] (the same `∪ allow ∖ ∪ deny` per-mode set), so a
 /// `decide` allow is never wider than what `accessible` / `query_as` would grant.
+///
+/// **API tier-1 (proposed-stable)** — the return type of the proposed semver-stable
+/// per-resource decision surface; see the module docs and the [API stability policy].
+///
+/// [API stability policy]: https://github.com/jeswr/sparq/blob/main/docs/api-stability.md
 ///
 /// # Examples
 ///

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -379,6 +379,8 @@ impl PodStore {
     /// `user="…",public="…"` permission advertisement a Solid server returns on a
     /// `GET`/`HEAD`. [OPUS-4.8] sq-i7k08.
     ///
+    /// **API tier-1 (proposed-stable)** — see [`PodStore::decide`].
+    ///
     /// `user` lists the modes the **authenticated** agent (`session`) holds on the
     /// named graph backing `resource`; `public` lists the modes an **anonymous**
     /// caller ([`Session::default`]) holds — so an unauthenticated request still learns
@@ -458,6 +460,11 @@ impl PodStore {
     /// **may `principal` do `mode` on `resource`?** Returns a typed [`WacDecision`]
     /// (`allow`, `granted_modes`, `governing_acl`, `scope`, fail-closed `status`).
     ///
+    /// **API tier-1 (proposed-stable).** Part of the proposed semver-stable per-resource
+    /// decision surface (with `decide_batch` / [`PodStore::resolve_acl`] /
+    /// [`PodStore::wac_allow`]); the freeze is pending maintainer ratification — see the
+    /// [API stability policy](https://github.com/jeswr/sparq/blob/main/docs/api-stability.md).
+    ///
     /// This is the point-query an LDP resource server asks per request, NOT graph
     /// filtering. Where [`PodStore::query_as`] / [`PodStore::accessible`] return the *set*
     /// of authorized graphs, `decide` answers the single `(principal, resource, mode)`
@@ -516,6 +523,8 @@ impl PodStore {
     /// ONCE and reusing it for every request (the LDP server's "decide a page of
     /// resources" call). Each element's [`WacDecision`] is independent and fail-closed
     /// exactly as [`PodStore::decide`]; the result vector is parallel to the input.
+    ///
+    /// **API tier-1 (proposed-stable)** — see [`PodStore::decide`].
     pub fn decide_batch(&self, session: &Session, requests: &[(&str, Mode)]) -> Vec<WacDecision> {
         let index = decide::AclIndex::build(&self.graph);
         requests
@@ -537,6 +546,8 @@ impl PodStore {
     /// so this per-resource discovery and the materialize-time inheritance can never
     /// disagree. Feeds [`PodStore::decide`]'s `governing_acl`/`scope`, which
     /// [`WacDecision::acl_link_header`] turns into the FR-5 `Link: rel="acl"` surface.
+    ///
+    /// **API tier-1 (proposed-stable)** — see [`PodStore::decide`].
     ///
     /// # Examples
     ///

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -1,0 +1,182 @@
+<!-- [OPUS-4.8] Governance: API stability & deprecation policy-of-record (bead sq-tvuw8; #1346 P0, #1248). -->
+# API stability & deprecation policy
+
+This is the **doc-of-record** for sparq's public-API stability tiers and its deprecation
+policy. It exists to answer the single question a downstream consumer asks before it can
+depend on sparq in production: **which parts of the API will not break under me, and on
+what notice?**
+
+It is filed against the Solid-server track's P0 consumer requirement — a *frozen,
+semver-stable public API surface* ([#1346](https://github.com/jeswr/sparq/issues/1346),
+[#1248](https://github.com/jeswr/sparq/issues/1248)). A consumer that git-pins an
+*unstable* embedded API (as [`solid-server-rs`](https://github.com/jeswr/solid-server-rs)
+does today, ADR 0001) takes on breakage risk on every revision bump. This document
+**proposes** the tier-1 surface and the guarantees attached to it so that the freeze — the
+governance act — has one well-defined shape to ratify.
+
+## Status — PROPOSED, not yet in force
+
+> **The tier-1 semver freeze is NOT active.** Declaring it active is the maintainer's
+> (@jeswr's) governance call ([#1346](https://github.com/jeswr/sparq/issues/1346) P0,
+> [#1248](https://github.com/jeswr/sparq/issues/1248) items 1+2). Until that ratification,
+> **every crate here is pre-`1.0` and API-unstable**, and a minor pre-`1.0` release MAY
+> still change any surface — tier-1 included. This document is the *proposal that tees up
+> the ratification*, together with the in-code markers that annotate the proposed surface.
+> Nothing in this file, and no in-code marker, creates a guarantee before ratification.
+
+The workspace status is *experimental, pre-1.0, API unstable* (root `README.md`,
+`CHANGELOG.md`); this policy does not change that. It describes the *shape* a future
+stable release would commit to, so the shape is reviewable now and the freeze is a
+one-line governance decision rather than a design exercise.
+
+## The tiers
+
+sparq's public API is partitioned into two tiers. The tier is a property of a **surface**
+(a module, a set of functions, a set of types), not of a whole crate.
+
+### Tier-1 — proposed-stable
+
+The surface a downstream consumer is *encouraged to depend on*, and the surface the freeze
+(once ratified) will cover. It is deliberately **small**: the in-process embedding front
+door and the per-resource access-control decision API — the two surfaces the Solid-server
+consumer actually binds to.
+
+Once ratified, tier-1 carries the guarantees in [Tier-1 guarantees](#tier-1-guarantees)
+below.
+
+### Tier-2 — experimental / unstable (everything else)
+
+**Everything not explicitly listed as tier-1 is tier-2.** Tier-2 is the default: it may
+change or be removed in any release, including a minor pre-`1.0` release, without a
+deprecation window. This includes — non-exhaustively — the rest of `sparq-serve` (the
+scheduler, the `backup` / `change-stream` / `result-cache` opt-in features, the write-side
+footprint/commit internals), the graph-filtering and materialization halves of
+`sparq-solid` (`query_as` / `update_as` / `materialize_*` / the conformance harnesses), and
+every other crate in the workspace (`sparq-core`, `sparq-engine`, `sparq-server`'s HTTP
+router and types, and the opt-in capability crates). A consumer may still use tier-2
+surfaces; it just does so without the stability guarantee, and should pin an exact revision.
+
+Opt-in, feature-gated capability crates remain tier-2 regardless of this policy: keeping the
+core lean and the capability surfaces free to evolve is a deliberate architecture choice.
+
+## The proposed tier-1 surface
+
+Grounded in the code as it stands on `main`. Each item is annotated in-code with a
+tier-1 (proposed-stable) marker that links back to this document.
+
+### 1. The in-process embedding data path — `sparq_serve::embed`
+
+The documented facade an external host uses to call the engine **in-process** instead of
+over the SPARQL-1.1-over-HTTP transport (the seam landed for
+[#1248](https://github.com/jeswr/sparq/issues/1248) items 1+2; the generation ring is
+[#1250](https://github.com/jeswr/sparq/issues/1250)). Every entry point is a thin
+re-export or one-line wrapper over an already-public engine path — no new behaviour.
+
+- **Read / probe** (over `&Graph`): `query_json`, `query_json_with_budget`, `query`,
+  `ask`, `exists`, `named_graph_exists`, `metadata` (and the `Metadata` struct).
+- **Write** (over `&mut Graph`): `update_in_place`, `update_in_place_atomic`,
+  `apply_delta_nquads`.
+- **Concurrency wrapper** (re-exported runtime-agnostic core): `GenerationRing`,
+  `Generation`, `GraphApplier`, `Writer`, and their configuration/associated types
+  `RingConfig`, `WriterConfig`, `TimeTravelConfig`, `ApplyUpdates`, `WriteError`, `PodId`.
+
+### 2. The per-resource access-control decision API — `sparq_solid`
+
+The point-query authorization surface an LDP resource server calls per request (issue
+[#992](https://github.com/jeswr/sparq/issues/992) FR-1/5/6/7; the fail-closed decision
+contract is [#1193](https://github.com/jeswr/sparq/issues/1193)). This is the
+**authorization-decision** surface only — it answers *"may principal X do mode M on
+resource R?"* over an already-loaded dataset. It does **not** authenticate, and it makes no
+cryptographic guarantee; a `Session` is a caller-asserted claim (see the `sparq-solid`
+README / the `access-control` skill).
+
+- `PodStore::decide`, `PodStore::decide_batch`, `PodStore::resolve_acl`,
+  `PodStore::wac_allow`.
+- The decision types: `WacDecision`, `AclStatus`, `AclScope`, `EffectiveAcl`, and the
+  `Mode` / `Session` request vocabulary those methods take and return.
+
+The load-time helpers (`PodStore::new`, `materialize_wac` / `materialize_acp`) are the
+prerequisite for a decision but sit at the boundary of the frozen surface; they are listed
+as **tier-1-adjacent** and would be resolved (in or out) at ratification.
+
+## Tier-1 guarantees
+
+These take effect **only once the freeze is ratified** (see [Status](#status--proposed-not-yet-in-force)).
+They are stated here so the ratification is a decision about a known contract.
+
+Within a stable `MAJOR.MINOR.PATCH` line, for a tier-1 item:
+
+- **No breaking change without a major bump.** A function signature, a type's public
+  shape, or a documented behaviour (e.g. the fail-closed rule: any uncertainty ⇒ deny) does
+  not change incompatibly within a major version.
+- **Additive change is allowed in a minor release.** New functions, new tier-1 items, and
+  new fields on types marked `#[non_exhaustive]` may appear in a minor release; consumers
+  are expected to match non-exhaustively and not to rely on a type's field count.
+- **Non-breaking is defined behaviourally, not just by type signature.** The SPARQL Results
+  JSON shape `query_json` returns, the fail-closed `AclStatus` → allow/deny mapping, and the
+  "a `decide` allow is never wider than the oracle would grant" property are part of the
+  contract, not incidental.
+- **Internals may change freely.** Performance, memory layout, and the private
+  implementation behind a tier-1 entry point are never part of the contract. This document
+  carries **no performance numbers** by design; performance is not a stability guarantee.
+
+What is explicitly **out of scope** of a tier-1 guarantee: any tier-2 surface reachable
+*through* a tier-1 type (e.g. a field typed as a tier-2 struct pulls that struct's
+instability along the edge — such edges are called out at ratification), and any behaviour
+under an opt-in feature flag unless that specific item is listed as tier-1.
+
+## Deprecation policy
+
+Once a stable line exists, removing or breaking a tier-1 item follows a **deprecate-then-
+remove** window:
+
+1. **Announce.** Mark the item `#[deprecated(since = "...", note = "...")]` with a note that
+   names the replacement and points at this document. The deprecation ships in a minor
+   release.
+2. **Window.** Keep the deprecated item working, warning-only, for at least **one full
+   minor release cycle** after the announcing release (a longer window for a
+   consumer-critical surface such as the embed data path). The window is measured in
+   releases, not wall-clock time.
+3. **Remove.** Remove only in a subsequent **major** release, with the removal and its
+   replacement recorded in `CHANGELOG.md`.
+
+An *additive* replacement (new stable item alongside the old) is preferred over an
+in-place breaking change wherever a compatible shape exists. Deprecations are tracked in
+`CHANGELOG.md` and, where the removal is deferred work, as a bead.
+
+## In-code markers
+
+The proposed tier-1 surface is annotated in-code with lightweight, non-breaking rustdoc
+markers (a module- or item-level *"API tier-1 (proposed-stable)"* line linking here). The
+markers are documentation only: they change no signature and no behaviour, and — per
+[Status](#status--proposed-not-yet-in-force) — they assert a *proposal*, not an active
+guarantee. On ratification, the markers are updated from "proposed-stable" to the ratified
+wording in the same pass that records the freeze.
+
+## Ratification checklist (for the maintainer)
+
+Activating the freeze is a governance decision. When @jeswr elects to ratify:
+
+1. Confirm the tier-1 surface list above (add/remove items; resolve the tier-1-adjacent
+   load-time helpers).
+2. Cut a version line that carries the tier-1 contract (see `docs/release.md`) and record
+   the freeze in `CHANGELOG.md`.
+3. Flip the in-code markers and the [Status](#status--proposed-not-yet-in-force) section
+   from *proposed* to *in force*.
+4. Note the ratification on [#1248](https://github.com/jeswr/sparq/issues/1248) /
+   [#1346](https://github.com/jeswr/sparq/issues/1346) so the consumer can pin the stable
+   line.
+
+Until step 3, the tier-1 guarantee is **not** in force.
+
+## Related
+
+- [`docs/release.md`](release.md) — how a release is cut (maintainer-triggered).
+- [`docs/branch-protection.md`](branch-protection.md) — the `main` protection doc-of-record.
+- `crates/sparq-serve/README.md` — the `embed` seam narrative.
+- `crates/sparq-solid/README.md` / the `access-control` skill — the decision surface (and
+  its explicit *does-not-authenticate* boundary).
+- [#1346](https://github.com/jeswr/sparq/issues/1346) (consumer requirements) ·
+  [#1248](https://github.com/jeswr/sparq/issues/1248) (embed + decision surface) ·
+  [#1250](https://github.com/jeswr/sparq/issues/1250) (generation ring) ·
+  [#1193](https://github.com/jeswr/sparq/issues/1193) (fail-closed decision contract).

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -14,7 +14,7 @@ does today, ADR 0001) takes on breakage risk on every revision bump. This docume
 **proposes** the tier-1 surface and the guarantees attached to it so that the freeze — the
 governance act — has one well-defined shape to ratify.
 
-## Status — PROPOSED, not yet in force
+## Status: PROPOSED, not yet in force
 
 > **The tier-1 semver freeze is NOT active.** Declaring it active is the maintainer's
 > (@jeswr's) governance call ([#1346](https://github.com/jeswr/sparq/issues/1346) P0,
@@ -101,7 +101,7 @@ as **tier-1-adjacent** and would be resolved (in or out) at ratification.
 
 ## Tier-1 guarantees
 
-These take effect **only once the freeze is ratified** (see [Status](#status--proposed-not-yet-in-force)).
+These take effect **only once the freeze is ratified** (see [Status](#status-proposed-not-yet-in-force)).
 They are stated here so the ratification is a decision about a known contract.
 
 Within a stable `MAJOR.MINOR.PATCH` line, for a tier-1 item:
@@ -149,7 +149,7 @@ in-place breaking change wherever a compatible shape exists. Deprecations are tr
 The proposed tier-1 surface is annotated in-code with lightweight, non-breaking rustdoc
 markers (a module- or item-level *"API tier-1 (proposed-stable)"* line linking here). The
 markers are documentation only: they change no signature and no behaviour, and — per
-[Status](#status--proposed-not-yet-in-force) — they assert a *proposal*, not an active
+[Status](#status-proposed-not-yet-in-force) — they assert a *proposal*, not an active
 guarantee. On ratification, the markers are updated from "proposed-stable" to the ratified
 wording in the same pass that records the freeze.
 
@@ -161,7 +161,7 @@ Activating the freeze is a governance decision. When @jeswr elects to ratify:
    load-time helpers).
 2. Cut a version line that carries the tier-1 contract (see `docs/release.md`) and record
    the freeze in `CHANGELOG.md`.
-3. Flip the in-code markers and the [Status](#status--proposed-not-yet-in-force) section
+3. Flip the in-code markers and the [Status](#status-proposed-not-yet-in-force) section
    from *proposed* to *in force*.
 4. Note the ratification on [#1248](https://github.com/jeswr/sparq/issues/1248) /
    [#1346](https://github.com/jeswr/sparq/issues/1346) so the consumer can pin the stable

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -127,8 +127,7 @@ under an opt-in feature flag unless that specific item is listed as tier-1.
 
 ## Deprecation policy
 
-Once a stable line exists, removing or breaking a tier-1 item follows a **deprecate-then-
-remove** window:
+Once a stable line exists, removing or breaking a tier-1 item follows a **deprecate-then-remove** window:
 
 1. **Announce.** Mark the item `#[deprecated(since = "...", note = "...")]` with a note that
    names the replacement and points at this document. The deprecation ships in a minor

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -146,7 +146,10 @@ Materialize the authorization view from the access-control documents, then enfor
   `AuthIndex::accessible` oracle, so a `decide` allow is never wider than `query_as` would
   grant; `granted_modes` carries the full mode set in one decision (build a `WAC-Allow`
   body without four sweeps). `decide_batch` builds the structural ACL index ONCE for a page
-  of resources. Always-present API (no cargo gate; mirrors `wac_allow`).
+  of resources. Always-present API (no cargo gate; mirrors `wac_allow`). **API tier-1
+  (proposed-stable)** — the proposed semver-stable per-resource decision surface (freeze
+  pending maintainer ratification, #1346 / #1248; see
+  [`docs/api-stability.md`](../../docs/api-stability.md)).
 - `WacDecision::acl_link_header() -> Option<String>` / `AclScope::as_acl_predicate() ->
   &'static str` — **effective-ACL provenance surface** (FR-5, sq-snopa.4): the `<acl-iri>;
   rel="acl"` RFC-8288 [`Link`](https://solidproject.org/TR/protocol#acl-resource) value a

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -247,8 +247,9 @@ re-export of the runtime-agnostic concurrency wrapper. No axum/tokio, no HTTP.
   `TimeTravelConfig`) — the SAME `fork → update → publish` + generation-pinning model
   `sparq-server` wraps behind its endpoint. A reader `ring.current()` pins an
   immutable snapshot; the writer publishes new generations without blocking readers.
-- **Stability:** the INTENDED stable embedding API, but **NOT yet a frozen
-  semver-tier-1 surface** — the formal freeze is the maintainer's to ratify on #1248
+- **Stability — API tier-1 (proposed-stable):** the proposed semver-stable embedding
+  surface in the [API stability & deprecation policy](../../docs/api-stability.md), but
+  **NOT yet frozen** — the formal freeze is the maintainer's to ratify on #1248 / #1346
   (pre-`1.0` minor releases MAY still change it). Pin to `sparq_serve::embed` rather
   than reaching into `sparq-core` / `sparq-engine` directly so the freeze, when
   ratified, has one well-defined shape.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-tvuw8** (P1), the tier-1 embedding-API stability + deprecation policy. Grounds the **P0** consumer requirement in [#1346](https://github.com/jeswr/sparq/issues/1346) (the Solid-server track git-pins an *unstable* embedded API today) and tees up the maintainer's semver freeze ratification ([#1248](https://github.com/jeswr/sparq/issues/1248) items 1+2).

## What this delivers

Two things, one PR — **no behaviour change, no API change**:

1. **`docs/api-stability.md`** — the governance **doc-of-record** (sibling of `docs/branch-protection.md` / `docs/release.md`) that:
   - proposes the **tier-1 (proposed-stable)** public surface, grounded in the actual API: the in-process **embed data path** (`sparq_serve::embed` — `query_json`/`query`/`ask`/`update_in_place`/`apply_delta_nquads`/`exists`/`metadata` + the re-exported `GenerationRing`/`GraphApplier`/`Writer` concurrency wrapper, [#1250](https://github.com/jeswr/sparq/issues/1250)), and the **PodStore per-resource WAC-decision surface** (`decide`/`decide_batch`/`resolve_acl`/`wac_allow` + `WacDecision`/`AclStatus`/`AclScope`/`EffectiveAcl`, [#1193](https://github.com/jeswr/sparq/issues/1193));
   - states the **tier-1 guarantees** (semver: no breaking change without a major bump; additive-in-minor; behaviour is part of the contract; internals free to change) and the **deprecate-then-remove window**;
   - declares **everything else tier-2/experimental**;
   - **does NOT declare the freeze active** — that is @jeswr's governance call. The doc is explicit that it is a *proposal that tees up ratification*, with a maintainer ratification checklist.

2. **In-code tier-1 markers** — lightweight, non-breaking `//! **API tier-1 (proposed-stable)**` rustdoc markers on the embed facade + `decide` module, and item-level markers on the `PodStore` decision fns and `WacDecision`, each linking to the policy doc. Documentation only: no signature, no behaviour change; each marker asserts a *proposal*, not an active guarantee.

Also syncs the `sparq-serve` / `sparq-solid` READMEs and the `http-server` / `access-control` SKILLs to reference the policy.

## Scope guards

- **No freeze declared** — `no_freeze_declared: true`. The Status section and every marker state the guarantee is not in force until @jeswr ratifies.
- **No ZK/MPC/privacy capability claims** — this is API governance; the decision surface is described as the authorization-*decision* API only (does not authenticate, no cryptographic claim). `check-privacy-claims.sh` clean.
- **No performance numbers in markdown** (stated explicitly in the doc: performance is not a stability guarantee).

## Gates

- `rustdoc --no-deps` **default + `--all-features`**, `RUSTDOCFLAGS=-D warnings` — clean (markers use plain URLs, not intra-doc links).
- Doctests (31) + `clippy --all-targets -- -D warnings` green in **both** feature states.
- `readme-template` (0 deviations; both touched READMEs stay ≤120 lines) + `check-privacy-claims.sh` pass. No code added ⇒ coverage floor unaffected.

Closes bead sq-tvuw8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>