### PR TITLE
feat(jsonld): document-level Expansion Algorithm + Value Expansion (sq-oy1f.25) [OPUS-4.8]

### DIFF
--- a/crates/sparq-jsonld/README.md
+++ b/crates/sparq-jsonld/README.md
@@ -59,14 +59,16 @@ anywhere.
 ### Build-out status
 
 The `Json` AST, error registry, options, and loader trait ship today, alongside the
-**Context Processing** foundation (`context`): the `ActiveContext`, Create Term
-Definition, and IRI Expansion — the hinge every other algorithm builds on — with
-RFC 3986 reference resolution and deny-by-default remote-context loading. The
-remaining modules (`expand`, `flatten`, `compact`, `frame`, `from_rdf`, `to_rdf`,
-`api`) are documented stubs, filled by dependency-ordered follow-on beads. The
-compaction-side companions of context processing (inverse context, IRI compaction)
-are also deferred to a follow-on bead. The crate is `publish = false` until the
-pipeline is real.
+**Context Processing** foundation (`context`) and the document-level **Expansion
+Algorithm** (`expand::expand`) — Value Expansion, scoped (property/type) contexts,
+`@index`/`@id`/`@type`/`@language`/`@graph` container maps, `@nest`, `@reverse`,
+`@included`, `@json` literals, keyword aliases, and the drop-null + array-normalisation
+rules — raising the exact spec error codes and threading `frameExpansion`. The
+remaining modules (`flatten`, `compact`, `frame`, `from_rdf`, `to_rdf`, `api`) are
+documented stubs, filled by dependency-ordered follow-on beads; so are the
+compaction-side companions of context processing (inverse context, IRI compaction) and
+the conformance-lane switch to the normative document-level expand oracle. The crate is
+`publish = false` until the pipeline is real.
 
 ## 📚 Learn more
 

--- a/crates/sparq-jsonld/src/context/process.rs
+++ b/crates/sparq-jsonld/src/context/process.rs
@@ -60,6 +60,34 @@ impl ActiveContext {
         };
         process_inner(self, local_context, false, true, &mut env)
     }
+
+    /// Applies a **scoped** context (a property-scoped or type-scoped `@context`) during
+    /// Expansion (JSON-LD 1.1 API §5.1.2 steps 8 and 11). Unlike [`ActiveContext::process`]
+    /// this exposes the two flags Expansion needs: `override_protected` (true when a
+    /// property-scoped context re-applies, so it may legally redefine a protected term) and
+    /// `propagate` (false when a type-scoped context is applied, so it does not carry into
+    /// child node objects). The scoped context was already syntactically validated when its
+    /// term definition was created, so remote-context re-validation is off.
+    ///
+    /// [OPUS-4.8] (sq-oy1f.25)
+    pub(crate) fn process_scoped(
+        &self,
+        local_context: &Json,
+        base_url: Option<&str>,
+        override_protected: bool,
+        propagate: bool,
+        loader: &dyn DocumentLoader,
+        options: &JsonLdOptions,
+    ) -> Result<ActiveContext, JsonLdError> {
+        let mut env = Env {
+            loader,
+            mode: options.processing_mode,
+            base_url: base_url.map(str::to_string),
+            remote_contexts: Vec::new(),
+            validate_scoped: true,
+        };
+        process_inner(self, local_context, override_protected, propagate, &mut env)
+    }
 }
 
 /// The recursive core of Context Processing (§4.1.2). `override_protected` disables the

--- a/crates/sparq-jsonld/src/context/process.rs
+++ b/crates/sparq-jsonld/src/context/process.rs
@@ -66,8 +66,10 @@ impl ActiveContext {
     /// this exposes the two flags Expansion needs: `override_protected` (true when a
     /// property-scoped context re-applies, so it may legally redefine a protected term) and
     /// `propagate` (false when a type-scoped context is applied, so it does not carry into
-    /// child node objects). The scoped context was already syntactically validated when its
-    /// term definition was created, so remote-context re-validation is off.
+    /// child node objects). Context validation is left on (`validate_scoped: true`, the same
+    /// as [`ActiveContext::process`]); the scoped context's term definitions are only
+    /// pre-checked syntactically at Create Term Definition time, so applying it here still
+    /// runs the full validating Context Processing pass.
     ///
     /// [OPUS-4.8] (sq-oy1f.25)
     pub(crate) fn process_scoped(

--- a/crates/sparq-jsonld/src/expand.rs
+++ b/crates/sparq-jsonld/src/expand.rs
@@ -659,6 +659,11 @@ fn expand_property_value(
         let index_key = td.and_then(|t| t.index()).unwrap_or("@index").to_string();
         let mut arr = Vec::new();
         for (index, index_value) in sorted_obj(value, ctx.ordered) {
+            // step 13.8.3: "Initialize expanded index to the result of IRI expanding index"
+            // (vocab) — every @none guard below compares against THIS expanded form, so a
+            // term aliased to `@none` (`"none": "@none"`, W3C expand/m012) is recognised.
+            let expanded_index = active_context.expand_iri(&index, false, true);
+            let index_is_none = expanded_index.as_deref() == Some("@none");
             // Map context selection for @id / @type maps.
             let mut map_context = if has("@id") || has("@type") {
                 active_context
@@ -701,22 +706,39 @@ fn expand_property_value(
                 }
                 if has("@index") {
                     if index_key != "@index" {
-                        // A property-scoped index: the index becomes a value of that property.
-                        let reexpanded = expand_value(active_context, &index_key, &Json::Str(index.clone()));
-                        let prop = active_context
-                            .expand_iri(&index_key, false, true)
-                            .unwrap_or_else(|| index_key.clone());
-                        if let Json::Obj(m) = &mut item {
-                            add_value(m, &prop, reexpanded);
+                        // step 13.8.3.7: a property-valued index — only when the expanded
+                        // index is not @none (W3C expand/pi10: an @none key adds no property).
+                        if !index_is_none {
+                            // 13.8.3.7.1: re-expand the index via Value Expansion against the
+                            // ACTIVE context, with the index key as active property.
+                            let reexpanded =
+                                expand_value(active_context, &index_key, &Json::Str(index.clone()));
+                            // 13.8.3.7.2: IRI-expand the index key.
+                            let prop = active_context
+                                .expand_iri(&index_key, false, true)
+                                .unwrap_or_else(|| index_key.clone());
+                            if let Json::Obj(m) = &mut item {
+                                // 13.8.3.7.3–4: "an array consisting of re-expanded index
+                                // FOLLOWED BY the existing values" (W3C expand/pi07, pi09).
+                                prepend_value(m, &prop, reexpanded);
+                                // 13.8.3.7.5: a value object MUST NOT gain an extra property
+                                // (W3C expand/pi05).
+                                if obj_get(m, "@value").is_some() {
+                                    return Err(JsonLdError::new(E::InvalidValueObject));
+                                }
+                            }
                         }
-                    } else if index != "@none" {
+                    } else if !index_is_none {
+                        // step 13.8.3.8: a plain @index map entry.
                         if let Json::Obj(m) = &mut item {
                             if obj_get(m, "@index").is_none() {
                                 set_obj(m, "@index", Json::Str(index.clone()));
                             }
                         }
                     }
-                } else if has("@id") && index != "@none" {
+                } else if has("@id") && !index_is_none {
+                    // step 13.8.3.9: @id map — the guard is on the vocab-EXPANDED index; the
+                    // @id value itself expands document-relatively.
                     if let Json::Obj(m) = &mut item {
                         if obj_get(m, "@id").is_none() {
                             let id = active_context
@@ -725,12 +747,13 @@ fn expand_property_value(
                             set_obj(m, "@id", Json::Str(id));
                         }
                     }
-                } else if has("@type") && index != "@none" {
-                    let ti = active_context
-                        .expand_iri(&index, false, true)
-                        .unwrap_or_else(|| index.clone());
+                } else if has("@type") && !index_is_none {
+                    // step 13.8.3.10: @type map — "types … consisting of expanded index
+                    // FOLLOWED BY any existing values of @type" (W3C expand/m004), guarded
+                    // against an @none alias (W3C expand/m012).
+                    let ti = expanded_index.clone().unwrap_or_else(|| index.clone());
                     if let Json::Obj(m) = &mut item {
-                        add_value(m, "@type", Json::Str(ti));
+                        prepend_value(m, "@type", Json::Str(ti));
                     }
                 }
                 arr.push(item);
@@ -757,24 +780,22 @@ fn expand_value(active_context: &ActiveContext, active_property: &str, value: &J
     let td = active_context.term_definition(active_property);
     let type_mapping = td.and_then(|t| t.type_mapping());
 
-    // @id / @vocab coercion of a string value → a node reference. When IRI expansion returns
-    // `None` (the value expands to null — a keyword-shaped token, or a `@vocab` term bound to
-    // null), the value has no valid `@id`, so the entry is dropped rather than emitted as an
-    // invalid empty-string `@id` (mirrors the `@id`-keyword handling in `expand_property`).
+    // @id / @vocab coercion of a string value → a node reference (§5.3.2 steps 1–2): "return
+    // a new map containing a single entry where the key is @id and the value is the result of
+    // IRI expanding value". When IRI Expansion returns `None` (a keyword-shaped token, or a
+    // `@vocab` term bound to null) the spec-literal result is therefore `{"@id": null}` — the
+    // entry is KEPT with a JSON null, never emitted as an empty-string `@id` and never as an
+    // empty `{}`. This matches the suite's `@id`-keyword precedent (expand/0122-out retains
+    // `"@id": null`, its manifest noting the result "will not be valid JSON-LD") and the
+    // reference processors.
     if let Json::Str(s) = value {
         if type_mapping == Some("@id") {
-            let mut node = Vec::new();
-            if let Some(id) = active_context.expand_iri(s, true, false) {
-                node.push(("@id".to_string(), Json::Str(id)));
-            }
-            return Json::Obj(node);
+            let id = active_context.expand_iri(s, true, false).map_or_else(json_null, Json::Str);
+            return Json::Obj(vec![("@id".to_string(), id)]);
         }
         if type_mapping == Some("@vocab") {
-            let mut node = Vec::new();
-            if let Some(id) = active_context.expand_iri(s, true, true) {
-                node.push(("@id".to_string(), Json::Str(id)));
-            }
-            return Json::Obj(node);
+            let id = active_context.expand_iri(s, true, true).map_or_else(json_null, Json::Str);
+            return Json::Obj(vec![("@id".to_string(), id)]);
         }
     }
 
@@ -1064,6 +1085,23 @@ fn add_value(members: &mut Vec<(String, Json)>, key: &str, value: Json) {
     }
 }
 
+/// Prepends `value` to the array stored at `key`: the index-map steps place the (re-)expanded
+/// index BEFORE any existing values ("an array consisting of re-expanded index followed by the
+/// existing values", §5.1.2 step 13.8.3.7.3; likewise the @type-map step 13.8.3.10).
+fn prepend_value(members: &mut Vec<(String, Json)>, key: &str, value: Json) {
+    match members.iter_mut().find(|(k, _)| k == key) {
+        Some((_, Json::Arr(a))) => a.insert(0, value),
+        Some((_, other)) => {
+            let old = std::mem::replace(other, Json::Arr(Vec::new()));
+            if let Json::Arr(a) = other {
+                a.push(value);
+                a.push(old);
+            }
+        }
+        None => members.push((key.to_string(), Json::Arr(vec![value]))),
+    }
+}
+
 /// Gets or inserts the `@reverse` sub-map of an ordered map and returns its members.
 fn reverse_map(members: &mut Vec<(String, Json)>) -> &mut Vec<(String, Json)> {
     if !members.iter().any(|(k, _)| k == "@reverse") {
@@ -1127,6 +1165,27 @@ mod tests {
         assert_eq!(array_of(Json::Str("x".into())), Json::Arr(vec![Json::Str("x".into())]));
         // Already an array: array_of is the identity.
         assert_eq!(array_of(Json::Arr(vec![raw("1")])), Json::Arr(vec![raw("1")]));
+    }
+
+    #[test]
+    fn prepend_value_inserts_before_existing_values() {
+        let mut m = Vec::new();
+        // Absent key → a fresh single-item array.
+        prepend_value(&mut m, "p", Json::Str("b".into()));
+        assert_eq!(obj_get(&m, "p"), Some(&Json::Arr(vec![Json::Str("b".into())])));
+        // Present key → the new value goes FIRST (§5.1.2 step 13.8.3.7.3 ordering).
+        prepend_value(&mut m, "p", Json::Str("a".into()));
+        assert_eq!(
+            obj_get(&m, "p"),
+            Some(&Json::Arr(vec![Json::Str("a".into()), Json::Str("b".into())]))
+        );
+        // A non-array existing value is array-wrapped with the new value first.
+        let mut m2 = vec![("q".to_string(), Json::Str("old".into()))];
+        prepend_value(&mut m2, "q", Json::Str("new".into()));
+        assert_eq!(
+            obj_get(&m2, "q"),
+            Some(&Json::Arr(vec![Json::Str("new".into()), Json::Str("old".into())]))
+        );
     }
 
     #[test]
@@ -1205,7 +1264,7 @@ mod tests {
     }
 
     #[test]
-    fn expand_value_id_coercion_expands_and_drops_null() {
+    fn expand_value_id_coercion_null_expansion_yields_null_id() {
         let ac = coercion_context();
         // A resolvable absolute IRI under `@id` coercion → a `{"@id": <iri>}` node reference.
         assert_eq!(
@@ -1213,29 +1272,36 @@ mod tests {
             Json::Obj(vec![("@id".to_string(), Json::Str("http://ex/target".into()))]),
         );
         // A keyword-shaped token IRI-expands to null under `@id` coercion (document-relative,
-        // no vocab); the fix drops the entry rather than emitting an invalid empty-string
-        // `@id` (regression guard for the Copilot review on the old `unwrap_or_default()`).
-        let dropped = expand_value(&ac, "id_term", &Json::Str("@notakeyword".into()));
-        assert_eq!(dropped, Json::Obj(vec![]), "null @id must be dropped, never emitted as \"\"");
+        // no vocab). §5.3.2 step 1 is literal: the result is `{"@id": null}` — the `@id`
+        // entry is KEPT with a JSON null (the W3C expand/0122 precedent), never an
+        // empty-string `@id` (the original `unwrap_or_default()` bug) and never an empty
+        // `{}` (the follow-up Copilot review).
+        let expanded = expand_value(&ac, "id_term", &Json::Str("@notakeyword".into()));
+        assert_eq!(
+            expanded,
+            Json::Obj(vec![("@id".to_string(), json_null())]),
+            "a null IRI expansion must yield the spec-literal {{\"@id\": null}}",
+        );
         assert!(
-            !matches!(&dropped, Json::Obj(m) if m.iter().any(|(k, v)| k == "@id"
+            !matches!(&expanded, Json::Obj(m) if m.iter().any(|(k, v)| k == "@id"
                 && matches!(v, Json::Str(s) if s.is_empty()))),
             "must never produce an empty-string @id",
         );
     }
 
     #[test]
-    fn expand_value_vocab_coercion_expands_and_drops_null() {
+    fn expand_value_vocab_coercion_null_expansion_yields_null_id() {
         let ac = coercion_context();
         // A plain term under `@vocab` coercion resolves against `@vocab`.
         assert_eq!(
             expand_value(&ac, "vocab_term", &Json::Str("thing".into())),
             Json::Obj(vec![("@id".to_string(), Json::Str("http://ex/v#thing".into()))]),
         );
-        // A keyword-shaped token still expands to null under `@vocab` coercion → dropped.
+        // A keyword-shaped token still expands to null under `@vocab` coercion → the
+        // spec-literal `{"@id": null}` (§5.3.2 step 2).
         assert_eq!(
             expand_value(&ac, "vocab_term", &Json::Str("@notakeyword".into())),
-            Json::Obj(vec![]),
+            Json::Obj(vec![("@id".to_string(), json_null())]),
         );
     }
 }

--- a/crates/sparq-jsonld/src/expand.rs
+++ b/crates/sparq-jsonld/src/expand.rs
@@ -1,7 +1,1185 @@
-//! Expansion Algorithm + Value Expansion (JSON-LD 1.1 API §5.1, §5.3); `frameExpansion` mode.
+//! Expansion Algorithm + Value Expansion (JSON-LD 1.1 API §5.1, §5.3).
 //!
-//! **Scaffold (`sq-oy1f.23`).** Spec references only; implemented in bead `sq-oy1f.25`.
-//! Expansion is the pipeline's central hinge: it turns a compact JSON-LD document into the
-//! canonical **expanded** form every other output projects from (compaction, flattening,
-//! framing, and `toRdf`). Scoped/typed contexts, `@nest`, and `@index` containers — the
-//! structures an RDF-first writer cannot recover — are handled here (design record §1.1).
+//! [OPUS-4.8] (sq-oy1f.25) Expansion is the pipeline's central hinge: it turns a compact
+//! JSON-LD document into the canonical **expanded** form every other output projects from
+//! (compaction, flattening, framing, and `toRdf`). This module implements the document-level
+//! **Expansion Algorithm** (§5.1.2) and **Value Expansion** (§5.3.2) over the `Json` AST,
+//! consuming the Context Processing foundation (`context`) from bead `sq-oy1f.24`.
+//!
+//! The public entry is [`expand`]: it initialises an active context from the processing
+//! options (`base`, `expandContext`), runs the recursive algorithm, and applies the API's
+//! top-level post-processing (the `@graph`-only reduction, `null` → `[]`, array wrap) so the
+//! result is always a JSON array of node objects (JSON-LD 1.1 API §5.1).
+//!
+//! Structures an RDF-first writer cannot recover — scoped (property/type) contexts, `@nest`,
+//! `@index`/`@id`/`@type`/`@graph`/`@language` container maps, keyword aliases, `@reverse`,
+//! `@included`, and `@json` literals — are all handled here (design record §1.1). Invalid
+//! inputs raise the exact spec `JsonLdErrorCode`.
+//!
+//! `frameExpansion` mode is threaded through (the flag relaxes the drop/validation rules so a
+//! frame document keeps its `@default`/empty patterns); the framing pipeline that consumes it
+//! lands with bead `sq-oy1f.29`.
+//!
+//! Spec: <https://www.w3.org/TR/json-ld11-api/#expansion-algorithm>.
+
+use crate::context::iri::{is_absolute_iri, is_blank_node};
+use crate::context::{is_keyword, ActiveContext, Direction, Override};
+use crate::error::{JsonLdError, JsonLdErrorCode as E};
+use crate::json::Json;
+use crate::loader::DocumentLoader;
+use crate::options::JsonLdOptions;
+
+/// Constant per-call environment threaded through the recursion (keeps argument counts sane).
+struct Ctx<'a> {
+    loader: &'a dyn DocumentLoader,
+    options: &'a JsonLdOptions,
+    /// The `ordered` option — sort map keys for deterministic output.
+    ordered: bool,
+}
+
+/// **Expansion** (JSON-LD 1.1 API §5.1). Expands `input` (an in-memory JSON-LD document)
+/// against the processing `options` and returns the expanded document — always a JSON array
+/// of node objects.
+///
+/// The active context is initialised from `options.base`; if `options.expand_context` is set
+/// it is folded in first (JSON-LD 1.1 API §5.1 step 6). Remote `@context` / `@import`
+/// references are dereferenced **only** through `loader`, which is deny-by-default
+/// (`NoopLoader` refuses every fetch). Returns the first spec `JsonLdError` on invalid input.
+///
+/// [OPUS-4.8] (sq-oy1f.25)
+pub fn expand(
+    input: &Json,
+    options: &JsonLdOptions,
+    loader: &dyn DocumentLoader,
+) -> Result<Json, JsonLdError> {
+    // §5.1: initialise the active context from options.base.
+    let mut active_context = ActiveContext::new(options.base.as_deref());
+
+    // §5.1 step 6: if expandContext is set, fold it in first. A map carrying an @context
+    // entry contributes that entry's value.
+    if let Some(ctx) = &options.expand_context {
+        let local = ctx.get("@context").unwrap_or(ctx);
+        active_context = active_context.process(local, options.base.as_deref(), loader, options)?;
+    }
+
+    let ctx = Ctx {
+        loader,
+        options,
+        ordered: options.ordered,
+    };
+    let expanded = expand_element(
+        &ctx,
+        &active_context,
+        None,
+        input,
+        options.base.as_deref(),
+        options.frame_expansion,
+        false,
+    )?;
+
+    // §5.1 top-level post-processing.
+    let mut result = expanded.unwrap_or_else(|| Json::Arr(Vec::new()));
+    if let Json::Obj(members) = &result {
+        if members.len() == 1 && members[0].0 == "@graph" {
+            result = members[0].1.clone();
+        }
+    }
+    if !matches!(result, Json::Arr(_)) {
+        result = Json::Arr(vec![result]);
+    }
+    Ok(result)
+}
+
+/// The recursive **Expansion Algorithm** (JSON-LD 1.1 API §5.1.2). Returns `None` for a JSON
+/// `null` (a dropped value), otherwise the expanded `Json`.
+#[allow(clippy::too_many_arguments)]
+fn expand_element(
+    ctx: &Ctx<'_>,
+    active_context: &ActiveContext,
+    active_property: Option<&str>,
+    element: &Json,
+    base_url: Option<&str>,
+    frame_expansion: bool,
+    from_map: bool,
+) -> Result<Option<Json>, JsonLdError> {
+    // step 1: null expands to null.
+    if is_null(element) {
+        return Ok(None);
+    }
+    // step 2: @default active property forces non-frame semantics for this element.
+    let frame_expansion = active_property != Some("@default") && frame_expansion;
+    // step 3: a property-scoped context (the local @context on active property's definition).
+    let prop_scoped: Option<(Json, Option<String>)> = active_property
+        .and_then(|ap| active_context.term_definition(ap))
+        .and_then(|td| td.context().cloned().map(|c| (c, td.base_url.clone())));
+
+    match element {
+        // step 5: an array expands element-wise.
+        Json::Arr(items) => {
+            let container = container_of(active_context, active_property);
+            let mut result = Vec::new();
+            for item in items {
+                let expanded = expand_element(
+                    ctx,
+                    active_context,
+                    active_property,
+                    item,
+                    base_url,
+                    frame_expansion,
+                    from_map,
+                )?;
+                // step 5.2.2: a @list container over a nested array becomes a list object.
+                let expanded = match expanded {
+                    Some(Json::Arr(inner)) if container.iter().any(|c| c == "@list") => {
+                        Some(Json::Obj(vec![("@list".to_string(), Json::Arr(inner))]))
+                    }
+                    other => other,
+                };
+                // step 5.2.3: flatten arrays, drop nulls.
+                match expanded {
+                    Some(Json::Arr(inner)) => result.extend(inner),
+                    Some(v) => result.push(v),
+                    None => {}
+                }
+            }
+            Ok(Some(Json::Arr(result)))
+        }
+        // step 6: a map is the substantive case.
+        Json::Obj(_) => expand_map(
+            ctx,
+            active_context,
+            active_property,
+            element,
+            base_url,
+            frame_expansion,
+            from_map,
+            prop_scoped,
+        ),
+        // step 4: a scalar.
+        _ => {
+            // step 4.1: a scalar with no property (or under @graph) is dropped.
+            if active_property.is_none() || active_property == Some("@graph") {
+                return Ok(None);
+            }
+            // step 4.2: apply a property-scoped context, if any.
+            let processed;
+            let ac = if let Some((sctx, sbase)) = &prop_scoped {
+                processed = active_context.process_scoped(
+                    sctx,
+                    sbase.as_deref(),
+                    false,
+                    true,
+                    ctx.loader,
+                    ctx.options,
+                )?;
+                &processed
+            } else {
+                active_context
+            };
+            // step 4.3: value expansion.
+            Ok(Some(expand_value(ac, active_property.unwrap(), element)))
+        }
+    }
+}
+
+/// Expansion of a map element (JSON-LD 1.1 API §5.1.2 steps 6–20).
+#[allow(clippy::too_many_arguments)]
+fn expand_map(
+    ctx: &Ctx<'_>,
+    active_context: &ActiveContext,
+    active_property: Option<&str>,
+    element: &Json,
+    base_url: Option<&str>,
+    frame_expansion: bool,
+    from_map: bool,
+    prop_scoped: Option<(Json, Option<String>)>,
+) -> Result<Option<Json>, JsonLdError> {
+    let mut active_context = active_context.clone();
+
+    // step 7: revert a non-propagated (type-scoped) context when descending into a new node
+    // object that is neither a value object nor a bare node reference.
+    if active_context.previous_context.is_some() && !from_map {
+        let has_value = has_key_expanding_to(&active_context, element, "@value");
+        let single_id = is_single_entry_expanding_to(&active_context, element, "@id");
+        if !has_value && !single_id {
+            active_context = *active_context.previous_context.clone().unwrap();
+        }
+    }
+
+    // step 8: apply a property-scoped context (override protected — it was already validated
+    // at definition time, so it may legally redefine a protected term).
+    if let Some((sctx, sbase)) = &prop_scoped {
+        active_context =
+            active_context.process_scoped(sctx, sbase.as_deref(), true, true, ctx.loader, ctx.options)?;
+    }
+
+    // step 9: a local @context on the element.
+    if let Some(local) = element.get("@context") {
+        active_context = active_context.process(local, base_url, ctx.loader, ctx.options)?;
+    }
+
+    // step 10: snapshot the active context for expanding @type values (type-scoped).
+    let type_scoped_context = active_context.clone();
+
+    // step 11: apply type-scoped contexts (propagate: false).
+    for key in sorted_keys(element, true) {
+        if active_context.expand_iri(&key, false, true).as_deref() != Some("@type") {
+            continue;
+        }
+        let mut terms: Vec<String> = string_values(element.get(&key).unwrap());
+        terms.sort();
+        for term in terms {
+            let scoped = type_scoped_context
+                .term_definition(&term)
+                .and_then(|td| td.context().cloned().map(|c| (c, td.base_url.clone())));
+            if let Some((sctx, sbase)) = scoped {
+                active_context = active_context.process_scoped(
+                    &sctx,
+                    sbase.as_deref(),
+                    false,
+                    false,
+                    ctx.loader,
+                    ctx.options,
+                )?;
+            }
+        }
+    }
+
+    // step 12: input type — the @json detection for a sibling @value entry.
+    let input_is_json = first_type_input(&active_context, element).as_deref() == Some("@json");
+
+    let mut result: Vec<(String, Json)> = Vec::new();
+    let mut nests: Vec<String> = Vec::new();
+
+    // steps 13 + 14: process every entry (recursing through @nest keys).
+    expand_object(
+        ctx,
+        &active_context,
+        &type_scoped_context,
+        active_property,
+        element,
+        base_url,
+        frame_expansion,
+        input_is_json,
+        &mut result,
+        &mut nests,
+    )?;
+
+    // steps 15–20: value/list/set/node cleanup.
+    cleanup(result, active_property, frame_expansion)
+}
+
+/// Processes each entry of a map into `result` (JSON-LD 1.1 API §5.1.2 step 13), deferring
+/// `@nest` keys and recursing into them (step 14).
+#[allow(clippy::too_many_arguments)]
+fn expand_object(
+    ctx: &Ctx<'_>,
+    active_context: &ActiveContext,
+    type_scoped_context: &ActiveContext,
+    active_property: Option<&str>,
+    element: &Json,
+    base_url: Option<&str>,
+    frame_expansion: bool,
+    input_is_json: bool,
+    result: &mut Vec<(String, Json)>,
+    nests: &mut Vec<String>,
+) -> Result<(), JsonLdError> {
+    for key in sorted_keys(element, ctx.ordered) {
+        // step 13.1: @context was already consumed.
+        if key == "@context" {
+            continue;
+        }
+        let value = element.get(&key).unwrap();
+        // step 13.2: expand the key.
+        let expanded_property = match active_context.expand_iri(&key, false, true) {
+            Some(p) => p,
+            None => continue,
+        };
+        // step 13.3: drop a key that is neither an IRI (contains ':') nor a keyword.
+        if !expanded_property.contains(':') && !is_keyword(&expanded_property) {
+            continue;
+        }
+
+        if is_keyword(&expanded_property) {
+            // step 13.4: @nest defers to step 14 (needs the ORIGINAL key).
+            if expanded_property == "@nest" {
+                if !nests.contains(&key) {
+                    nests.push(key.clone());
+                }
+                continue;
+            }
+            // step 13.4.1: no keyword may appear as a reverse property map entry.
+            if active_property == Some("@reverse") {
+                return Err(JsonLdError::new(E::InvalidReversePropertyMap));
+            }
+            // step 13.4.2: colliding keywords (except the mergeable @included / @type).
+            if expanded_property != "@included"
+                && expanded_property != "@type"
+                && obj_get(result, &expanded_property).is_some()
+            {
+                return Err(JsonLdError::new(E::CollidingKeywords));
+            }
+            expand_keyword(
+                ctx,
+                active_context,
+                type_scoped_context,
+                active_property,
+                &expanded_property,
+                value,
+                base_url,
+                frame_expansion,
+                input_is_json,
+                result,
+            )?;
+            continue;
+        }
+
+        // step 13.5+: `expanded_property` is a real property IRI.
+        let container = container_of(active_context, Some(&key));
+        let expanded_value = expand_property_value(
+            ctx,
+            active_context,
+            &key,
+            value,
+            base_url,
+            frame_expansion,
+            &container,
+        )?;
+
+        // step 13.9: drop a null expansion.
+        let Some(mut expanded_value) = expanded_value else {
+            continue;
+        };
+
+        // step 13.10: a @list container wraps a non-list into a list object.
+        if container.iter().any(|c| c == "@list") && !is_list_object(&expanded_value) {
+            expanded_value = Json::Obj(vec![("@list".to_string(), array_of(expanded_value))]);
+        }
+        // step 13.11: a bare @graph container wraps each value into a graph object.
+        if container.iter().any(|c| c == "@graph")
+            && !container.iter().any(|c| c == "@id")
+            && !container.iter().any(|c| c == "@index")
+        {
+            let wrapped: Vec<Json> = as_array(expanded_value)
+                .into_iter()
+                .map(|v| Json::Obj(vec![("@graph".to_string(), array_of(v))]))
+                .collect();
+            expanded_value = Json::Arr(wrapped);
+        }
+
+        // step 13.12/13.13: reverse property vs. forward property.
+        let is_reverse = active_context
+            .term_definition(&key)
+            .is_some_and(|td| td.is_reverse());
+        if is_reverse {
+            for item in as_array(expanded_value) {
+                if is_value_object(&item) || is_list_object(&item) {
+                    return Err(JsonLdError::new(E::InvalidReversePropertyValue));
+                }
+                add_value(reverse_map(result), &expanded_property, item);
+            }
+        } else {
+            add_value(result, &expanded_property, expanded_value);
+        }
+    }
+
+    // step 14: process deferred @nest keys into the same result.
+    for nest_key in nests.clone() {
+        for nv in as_array(element.get(&nest_key).cloned().unwrap_or_else(json_null)) {
+            if !matches!(nv, Json::Obj(_)) || has_key_expanding_to(active_context, &nv, "@value") {
+                return Err(JsonLdError::new(E::InvalidNestValue));
+            }
+            let mut inner_nests = Vec::new();
+            expand_object(
+                ctx,
+                active_context,
+                type_scoped_context,
+                active_property,
+                &nv,
+                base_url,
+                frame_expansion,
+                input_is_json,
+                result,
+                &mut inner_nests,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+/// Handles a single keyword entry (JSON-LD 1.1 API §5.1.2 step 13.4).
+#[allow(clippy::too_many_arguments)]
+fn expand_keyword(
+    ctx: &Ctx<'_>,
+    active_context: &ActiveContext,
+    type_scoped_context: &ActiveContext,
+    active_property: Option<&str>,
+    expanded_property: &str,
+    value: &Json,
+    base_url: Option<&str>,
+    frame_expansion: bool,
+    input_is_json: bool,
+    result: &mut Vec<(String, Json)>,
+) -> Result<(), JsonLdError> {
+    match expanded_property {
+        "@id" => match value {
+            Json::Str(s) => {
+                if let Some(iri) = active_context.expand_iri(s, true, false) {
+                    set_obj(result, "@id", Json::Str(iri));
+                }
+            }
+            Json::Arr(items) if frame_expansion => {
+                let mut ids = Vec::new();
+                for it in items {
+                    let Json::Str(s) = it else {
+                        return Err(JsonLdError::new(E::InvalidIdValue));
+                    };
+                    if let Some(iri) = active_context.expand_iri(s, true, false) {
+                        ids.push(Json::Str(iri));
+                    }
+                }
+                set_obj(result, "@id", Json::Arr(ids));
+            }
+            Json::Obj(m) if frame_expansion && m.is_empty() => {
+                set_obj(result, "@id", Json::Arr(vec![Json::obj()]));
+            }
+            _ => return Err(JsonLdError::new(E::InvalidIdValue)),
+        },
+        "@type" => {
+            // step 13.4.4: @type expands against the type-scoped context (vocab + relative).
+            let mut expanded_types = Vec::new();
+            for t in type_values(value, frame_expansion)? {
+                if let Some(iri) = type_scoped_context.expand_iri(&t, true, true) {
+                    expanded_types.push(Json::Str(iri));
+                }
+            }
+            for t in expanded_types {
+                add_value(result, "@type", t);
+            }
+        }
+        "@graph" => {
+            let expanded = expand_element(
+                ctx,
+                active_context,
+                Some("@graph"),
+                value,
+                base_url,
+                frame_expansion,
+                false,
+            )?;
+            let arr = array_of(expanded.unwrap_or_else(|| Json::Arr(Vec::new())));
+            set_obj(result, "@graph", arr);
+        }
+        "@included" => {
+            let expanded = expand_element(
+                ctx,
+                active_context,
+                None,
+                value,
+                base_url,
+                frame_expansion,
+                false,
+            )?;
+            let items = as_array(expanded.unwrap_or_else(|| Json::Arr(Vec::new())));
+            for item in &items {
+                if !is_node_object(item) {
+                    return Err(JsonLdError::new(E::InvalidIncludedValue));
+                }
+            }
+            for item in items {
+                add_value(result, "@included", item);
+            }
+        }
+        "@value" => {
+            // step 13.4.7: a @json-typed node keeps its value verbatim.
+            if input_is_json {
+                set_obj(result, "@value", value.clone());
+            } else if is_null(value) {
+                set_obj(result, "@value", json_null());
+            } else if is_scalar(value)
+                || (frame_expansion && matches!(value, Json::Arr(_) | Json::Obj(_)))
+            {
+                set_obj(result, "@value", value.clone());
+            } else {
+                return Err(JsonLdError::new(E::InvalidValueObjectValue));
+            }
+        }
+        "@language" => match value {
+            Json::Str(_) => set_obj(result, "@language", value.clone()),
+            Json::Arr(_) if frame_expansion => set_obj(result, "@language", value.clone()),
+            _ => return Err(JsonLdError::new(E::InvalidLanguageTaggedString)),
+        },
+        "@direction" => match value {
+            Json::Str(s) if Direction::parse(s).is_some() => {
+                set_obj(result, "@direction", value.clone());
+            }
+            Json::Arr(_) if frame_expansion => set_obj(result, "@direction", value.clone()),
+            _ => return Err(JsonLdError::new(E::InvalidBaseDirection)),
+        },
+        "@index" => match value {
+            Json::Str(_) => set_obj(result, "@index", value.clone()),
+            _ => return Err(JsonLdError::new(E::InvalidIndexValue)),
+        },
+        "@list" => {
+            // step 13.4.11: a list with no property (or under @graph) is dropped.
+            if active_property.is_none() || active_property == Some("@graph") {
+                return Ok(());
+            }
+            let expanded = expand_element(
+                ctx,
+                active_context,
+                active_property,
+                value,
+                base_url,
+                frame_expansion,
+                false,
+            )?;
+            let arr = array_of(expanded.unwrap_or_else(|| Json::Arr(Vec::new())));
+            set_obj(result, "@list", arr);
+        }
+        "@set" => {
+            let expanded = expand_element(
+                ctx,
+                active_context,
+                active_property,
+                value,
+                base_url,
+                frame_expansion,
+                false,
+            )?;
+            if let Some(v) = expanded {
+                set_obj(result, "@set", v);
+            }
+        }
+        "@reverse" => {
+            let Json::Obj(_) = value else {
+                return Err(JsonLdError::new(E::InvalidReverseValue));
+            };
+            let expanded = expand_element(
+                ctx,
+                active_context,
+                Some("@reverse"),
+                value,
+                base_url,
+                frame_expansion,
+                false,
+            )?;
+            if let Some(Json::Obj(members)) = expanded {
+                for (prop, items) in members {
+                    if prop == "@reverse" {
+                        // A double reverse folds back into forward properties.
+                        if let Json::Obj(rev) = items {
+                            for (p, its) in rev {
+                                for it in as_array(its) {
+                                    add_value(result, &p, it);
+                                }
+                            }
+                        }
+                    } else {
+                        for it in as_array(items) {
+                            if is_value_object(&it) || is_list_object(&it) {
+                                return Err(JsonLdError::new(E::InvalidReversePropertyValue));
+                            }
+                            add_value(reverse_map(result), &prop, it);
+                        }
+                    }
+                }
+            }
+        }
+        // Framing keywords (frameExpansion mode); the framing pipeline (sq-oy1f.29) consumes
+        // these. Outside frameExpansion they are dropped.
+        "@default" | "@embed" | "@explicit" | "@omitDefault" | "@requireAll" if frame_expansion => {
+            let expanded = expand_element(
+                ctx,
+                active_context,
+                Some(expanded_property),
+                value,
+                base_url,
+                frame_expansion,
+                false,
+            )?;
+            if let Some(v) = expanded {
+                set_obj(result, expanded_property, array_of(v));
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+/// Expands the value of a real property key (JSON-LD 1.1 API §5.1.2 steps 13.6–13.8):
+/// container maps (`@language` / `@index` / `@id` / `@type` / `@graph`), the `@json` type
+/// mapping, or the general recursion.
+#[allow(clippy::too_many_arguments)]
+fn expand_property_value(
+    ctx: &Ctx<'_>,
+    active_context: &ActiveContext,
+    key: &str,
+    value: &Json,
+    base_url: Option<&str>,
+    frame_expansion: bool,
+    container: &[String],
+) -> Result<Option<Json>, JsonLdError> {
+    let has = |c: &str| container.iter().any(|m| m == c);
+    let td = active_context.term_definition(key);
+
+    // step 13.6: @language container (language map).
+    if has("@language") && matches!(value, Json::Obj(_)) {
+        let direction = match td.map(|t| t.direction()) {
+            Some(Override::Set(d)) => Some(*d),
+            Some(Override::Null) => None,
+            _ => active_context.default_base_direction(),
+        };
+        let mut arr = Vec::new();
+        for (lang, lang_value) in sorted_obj(value, ctx.ordered) {
+            for item in as_array(lang_value) {
+                if is_null(&item) {
+                    continue;
+                }
+                let Json::Str(s) = &item else {
+                    return Err(JsonLdError::new(E::InvalidLanguageMapValue));
+                };
+                let mut v = vec![("@value".to_string(), Json::Str(s.clone()))];
+                let drop_lang =
+                    lang == "@none" || active_context.expand_iri(&lang, false, true).as_deref() == Some("@none");
+                if !drop_lang {
+                    v.push(("@language".to_string(), Json::Str(lang.clone())));
+                }
+                if let Some(d) = direction {
+                    v.push(("@direction".to_string(), Json::Str(d.as_str().to_string())));
+                }
+                arr.push(Json::Obj(v));
+            }
+        }
+        return Ok(Some(Json::Arr(arr)));
+    }
+
+    // step 13.7: @index / @id / @type container maps.
+    if (has("@index") || has("@id") || has("@type")) && matches!(value, Json::Obj(_)) {
+        let index_key = td.and_then(|t| t.index()).unwrap_or("@index").to_string();
+        let mut arr = Vec::new();
+        for (index, index_value) in sorted_obj(value, ctx.ordered) {
+            // Map context selection for @id / @type maps.
+            let mut map_context = if has("@id") || has("@type") {
+                active_context
+                    .previous_context
+                    .as_deref()
+                    .cloned()
+                    .unwrap_or_else(|| active_context.clone())
+            } else {
+                active_context.clone()
+            };
+            if has("@type") {
+                let scoped = map_context
+                    .term_definition(&index)
+                    .and_then(|itd| itd.context().cloned().map(|c| (c, itd.base_url.clone())));
+                if let Some((sctx, sbase)) = scoped {
+                    map_context = map_context.process_scoped(
+                        &sctx,
+                        sbase.as_deref(),
+                        false,
+                        true,
+                        ctx.loader,
+                        ctx.options,
+                    )?;
+                }
+            }
+
+            let expanded = expand_element(
+                ctx,
+                &map_context,
+                Some(key),
+                &array_of(index_value),
+                base_url,
+                frame_expansion,
+                true,
+            )?;
+            for mut item in as_array(expanded.unwrap_or_else(|| Json::Arr(Vec::new()))) {
+                // @graph container: wrap a non-graph value.
+                if has("@graph") && !is_graph_object(&item) {
+                    item = Json::Obj(vec![("@graph".to_string(), array_of(item))]);
+                }
+                if has("@index") {
+                    if index_key != "@index" {
+                        // A property-scoped index: the index becomes a value of that property.
+                        let reexpanded = expand_value(active_context, &index_key, &Json::Str(index.clone()));
+                        let prop = active_context
+                            .expand_iri(&index_key, false, true)
+                            .unwrap_or_else(|| index_key.clone());
+                        if let Json::Obj(m) = &mut item {
+                            add_value(m, &prop, reexpanded);
+                        }
+                    } else if index != "@none" {
+                        if let Json::Obj(m) = &mut item {
+                            if obj_get(m, "@index").is_none() {
+                                set_obj(m, "@index", Json::Str(index.clone()));
+                            }
+                        }
+                    }
+                } else if has("@id") && index != "@none" {
+                    if let Json::Obj(m) = &mut item {
+                        if obj_get(m, "@id").is_none() {
+                            let id = active_context
+                                .expand_iri(&index, true, false)
+                                .unwrap_or_else(|| index.clone());
+                            set_obj(m, "@id", Json::Str(id));
+                        }
+                    }
+                } else if has("@type") && index != "@none" {
+                    let ti = active_context
+                        .expand_iri(&index, false, true)
+                        .unwrap_or_else(|| index.clone());
+                    if let Json::Obj(m) = &mut item {
+                        add_value(m, "@type", Json::Str(ti));
+                    }
+                }
+                arr.push(item);
+            }
+        }
+        return Ok(Some(Json::Arr(arr)));
+    }
+
+    // step 13.8: a @json type mapping keeps the value verbatim as a JSON literal.
+    if td.and_then(|t| t.type_mapping()) == Some("@json") {
+        return Ok(Some(Json::Obj(vec![
+            ("@value".to_string(), value.clone()),
+            ("@type".to_string(), Json::Str("@json".to_string())),
+        ])));
+    }
+
+    // step 13.8 (else): the general recursion.
+    expand_element(ctx, active_context, Some(key), value, base_url, frame_expansion, false)
+}
+
+/// **Value Expansion** (JSON-LD 1.1 API §5.3.2): expands a scalar `value` for `active_property`
+/// into a value object (or a node reference under an `@id` / `@vocab` type coercion).
+fn expand_value(active_context: &ActiveContext, active_property: &str, value: &Json) -> Json {
+    let td = active_context.term_definition(active_property);
+    let type_mapping = td.and_then(|t| t.type_mapping());
+
+    // @id / @vocab coercion of a string value → a node reference.
+    if let Json::Str(s) = value {
+        if type_mapping == Some("@id") {
+            let id = active_context.expand_iri(s, true, false).unwrap_or_default();
+            return Json::Obj(vec![("@id".to_string(), Json::Str(id))]);
+        }
+        if type_mapping == Some("@vocab") {
+            let id = active_context.expand_iri(s, true, true).unwrap_or_default();
+            return Json::Obj(vec![("@id".to_string(), Json::Str(id))]);
+        }
+    }
+
+    let mut result = vec![("@value".to_string(), value.clone())];
+    match type_mapping {
+        Some(tm) if tm != "@id" && tm != "@vocab" && tm != "@none" => {
+            result.push(("@type".to_string(), Json::Str(tm.to_string())));
+        }
+        _ => {
+            if matches!(value, Json::Str(_)) {
+                let language = match td.map(|t| t.language()) {
+                    Some(Override::Set(l)) => Some(l.clone()),
+                    Some(Override::Null) => None,
+                    _ => active_context.default_language().map(str::to_string),
+                };
+                let direction = match td.map(|t| t.direction()) {
+                    Some(Override::Set(d)) => Some(*d),
+                    Some(Override::Null) => None,
+                    _ => active_context.default_base_direction(),
+                };
+                if let Some(l) = language {
+                    result.push(("@language".to_string(), Json::Str(l)));
+                }
+                if let Some(d) = direction {
+                    result.push(("@direction".to_string(), Json::Str(d.as_str().to_string())));
+                }
+            }
+        }
+    }
+    Json::Obj(result)
+}
+
+/// Value/list/set/node cleanup (JSON-LD 1.1 API §5.1.2 steps 15–20). Returns `None` when the
+/// expanded node is dropped (a free-floating value, a null value object, etc.).
+fn cleanup(
+    mut members: Vec<(String, Json)>,
+    active_property: Option<&str>,
+    frame_expansion: bool,
+) -> Result<Option<Json>, JsonLdError> {
+    let has = |m: &[(String, Json)], k: &str| m.iter().any(|(kk, _)| kk == k);
+
+    // step 15: a value object.
+    if has(&members, "@value") {
+        const ALLOWED: &[&str] = &["@value", "@type", "@language", "@index", "@direction"];
+        if members.iter().any(|(k, _)| !ALLOWED.contains(&k.as_str())) {
+            return Err(JsonLdError::new(E::InvalidValueObject));
+        }
+        if has(&members, "@type") && has(&members, "@language") {
+            return Err(JsonLdError::new(E::InvalidValueObject));
+        }
+        let is_json = matches!(obj_get(&members, "@type"), Some(Json::Str(s)) if s == "@json");
+        let v = obj_get(&members, "@value").unwrap();
+        if !is_json {
+            if is_null(v) || matches!(v, Json::Arr(a) if a.is_empty()) {
+                return Ok(None);
+            }
+            if has(&members, "@language")
+                && !matches!(v, Json::Str(_))
+                && !(frame_expansion && matches!(v, Json::Arr(_)))
+            {
+                return Err(JsonLdError::new(E::InvalidLanguageTaggedValue));
+            }
+            if let Some(t) = obj_get(&members, "@type") {
+                let ok = match t {
+                    Json::Str(s) => is_absolute_iri(s) || is_blank_node(s),
+                    Json::Arr(_) if frame_expansion => true,
+                    _ => false,
+                };
+                if !ok {
+                    return Err(JsonLdError::new(E::InvalidTypedValue));
+                }
+            }
+        }
+        return Ok(Some(Json::Obj(members)));
+    }
+
+    // step 17: a list or set object.
+    if has(&members, "@list") || has(&members, "@set") {
+        const ALLOWED: &[&str] = &["@list", "@set", "@index"];
+        if members.iter().any(|(k, _)| !ALLOWED.contains(&k.as_str())) {
+            return Err(JsonLdError::new(E::InvalidSetOrListObject));
+        }
+        if has(&members, "@set") {
+            // Unwrap @set to its value.
+            let set_val = members.into_iter().find(|(k, _)| k == "@set").map(|(_, v)| v).unwrap();
+            return Ok(Some(set_val));
+        }
+        return Ok(Some(Json::Obj(members)));
+    }
+
+    // step 16: a node object's @type is always an array.
+    if let Some(slot) = members.iter_mut().find(|(k, _)| k == "@type") {
+        if !matches!(slot.1, Json::Arr(_)) {
+            slot.1 = Json::Arr(vec![slot.1.clone()]);
+        }
+    }
+
+    // step 18: a map containing only @language is dropped.
+    if !frame_expansion && members.len() == 1 && members[0].0 == "@language" {
+        return Ok(None);
+    }
+
+    // step 19: free-floating node drop under a null / @graph active property.
+    if !frame_expansion && (active_property.is_none() || active_property == Some("@graph")) {
+        if members.is_empty() {
+            return Ok(None);
+        }
+        if members.len() == 1 && members[0].0 == "@id" {
+            return Ok(None);
+        }
+    }
+
+    Ok(Some(Json::Obj(members)))
+}
+
+// ---------------------------------------------------------------------------------------
+// Small helpers over the `Json` AST.
+// ---------------------------------------------------------------------------------------
+
+/// True iff `j` is a JSON `null`.
+fn is_null(j: &Json) -> bool {
+    matches!(j, Json::Raw(r) if r == "null")
+}
+
+/// True iff `j` is a JSON scalar (string, number, or boolean) — i.e. not null, array, or map.
+fn is_scalar(j: &Json) -> bool {
+    match j {
+        Json::Str(_) => true,
+        Json::Raw(r) => r != "null",
+        _ => false,
+    }
+}
+
+/// The `Json` representation of a JSON `null`.
+fn json_null() -> Json {
+    Json::Raw("null".to_string())
+}
+
+/// Consumes `j` into a vector of items: the elements of an array, or `[j]` for a single value.
+fn as_array(j: Json) -> Vec<Json> {
+    match j {
+        Json::Arr(v) => v,
+        other => vec![other],
+    }
+}
+
+/// Wraps `j` into an array unless it already is one.
+fn array_of(j: Json) -> Json {
+    match j {
+        Json::Arr(_) => j,
+        other => Json::Arr(vec![other]),
+    }
+}
+
+/// The keys of a map, in insertion order, or lexicographically sorted when `ordered`.
+fn sorted_keys(element: &Json, ordered: bool) -> Vec<String> {
+    let mut keys: Vec<String> = match element {
+        Json::Obj(m) => m.iter().map(|(k, _)| k.clone()).collect(),
+        _ => Vec::new(),
+    };
+    if ordered {
+        keys.sort();
+    }
+    keys
+}
+
+/// The (key, value) members of a map, in insertion order, or sorted by key when `ordered`.
+fn sorted_obj(element: &Json, ordered: bool) -> Vec<(String, Json)> {
+    let mut members: Vec<(String, Json)> = match element {
+        Json::Obj(m) => m.clone(),
+        _ => Vec::new(),
+    };
+    if ordered {
+        members.sort_by(|a, b| a.0.cmp(&b.0));
+    }
+    members
+}
+
+/// The string values of a JSON value (a lone string, or the string items of an array).
+fn string_values(j: &Json) -> Vec<String> {
+    match j {
+        Json::Str(s) => vec![s.clone()],
+        Json::Arr(items) => items.iter().filter_map(Json::as_str).map(str::to_string).collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Validates and extracts a `@type` value (a string or array of strings; frame mode is
+/// lenient), raising `invalid type value` on a malformed value.
+fn type_values(value: &Json, frame_expansion: bool) -> Result<Vec<String>, JsonLdError> {
+    match value {
+        Json::Str(s) => Ok(vec![s.clone()]),
+        Json::Arr(items) => {
+            let mut out = Vec::new();
+            for it in items {
+                match it {
+                    Json::Str(s) => out.push(s.clone()),
+                    _ if frame_expansion => {}
+                    _ => return Err(JsonLdError::new(E::InvalidTypeValue)),
+                }
+            }
+            Ok(out)
+        }
+        Json::Obj(_) if frame_expansion => Ok(Vec::new()),
+        _ => Err(JsonLdError::new(E::InvalidTypeValue)),
+    }
+}
+
+/// The IRI expansion of the last value of the first `@type`-expanding entry (JSON-LD 1.1 API
+/// §5.1.2 step 12) — used only to detect a `@json`-typed sibling `@value`.
+fn first_type_input(active_context: &ActiveContext, element: &Json) -> Option<String> {
+    for key in sorted_keys(element, true) {
+        if active_context.expand_iri(&key, false, true).as_deref() == Some("@type") {
+            let v = element.get(&key).unwrap();
+            let last = match v {
+                Json::Arr(a) => a.last().and_then(Json::as_str),
+                other => other.as_str(),
+            };
+            return last.and_then(|t| active_context.expand_iri(t, false, true));
+        }
+    }
+    None
+}
+
+/// True iff any key of `element` IRI-expands (vocab) to `keyword`.
+fn has_key_expanding_to(active_context: &ActiveContext, element: &Json, keyword: &str) -> bool {
+    match element {
+        Json::Obj(m) => m
+            .iter()
+            .any(|(k, _)| active_context.expand_iri(k, false, true).as_deref() == Some(keyword)),
+        _ => false,
+    }
+}
+
+/// True iff `element` has exactly one entry whose key IRI-expands (vocab) to `keyword`.
+fn is_single_entry_expanding_to(active_context: &ActiveContext, element: &Json, keyword: &str) -> bool {
+    match element {
+        Json::Obj(m) => {
+            m.len() == 1 && active_context.expand_iri(&m[0].0, false, true).as_deref() == Some(keyword)
+        }
+        _ => false,
+    }
+}
+
+/// The container mapping of `active_property` in `active_context`, or an empty slice.
+fn container_of(active_context: &ActiveContext, active_property: Option<&str>) -> Vec<String> {
+    active_property
+        .and_then(|ap| active_context.term_definition(ap))
+        .map(|td| td.container().to_vec())
+        .unwrap_or_default()
+}
+
+/// Borrows a member of an ordered map by key.
+fn obj_get<'a>(members: &'a [(String, Json)], key: &str) -> Option<&'a Json> {
+    members.iter().find(|(k, _)| k == key).map(|(_, v)| v)
+}
+
+/// Sets (overwriting) a member of an ordered map, preserving first-insertion position.
+fn set_obj(members: &mut Vec<(String, Json)>, key: &str, value: Json) {
+    if let Some(slot) = members.iter_mut().find(|(k, _)| k == key) {
+        slot.1 = value;
+    } else {
+        members.push((key.to_string(), value));
+    }
+}
+
+/// Appends `value` to the array stored at `key` (JSON-LD `addValue` with `propertyIsArray`):
+/// expansion always accumulates property values into an array. An array `value` contributes
+/// each of its items.
+fn add_value(members: &mut Vec<(String, Json)>, key: &str, value: Json) {
+    if let Json::Arr(items) = value {
+        for it in items {
+            add_value(members, key, it);
+        }
+        return;
+    }
+    match members.iter_mut().find(|(k, _)| k == key) {
+        Some((_, Json::Arr(a))) => a.push(value),
+        Some((_, other)) => {
+            let old = std::mem::replace(other, Json::Arr(Vec::new()));
+            if let Json::Arr(a) = other {
+                a.push(old);
+                a.push(value);
+            }
+        }
+        None => members.push((key.to_string(), Json::Arr(vec![value]))),
+    }
+}
+
+/// Gets or inserts the `@reverse` sub-map of an ordered map and returns its members.
+fn reverse_map(members: &mut Vec<(String, Json)>) -> &mut Vec<(String, Json)> {
+    if !members.iter().any(|(k, _)| k == "@reverse") {
+        members.push(("@reverse".to_string(), Json::Obj(Vec::new())));
+    }
+    let slot = members.iter_mut().find(|(k, _)| k == "@reverse").unwrap();
+    match &mut slot.1 {
+        Json::Obj(m) => m,
+        _ => unreachable!("@reverse is always a map"),
+    }
+}
+
+/// True iff `j` is a value object (a map with an `@value` entry).
+fn is_value_object(j: &Json) -> bool {
+    matches!(j, Json::Obj(_)) && j.get("@value").is_some()
+}
+
+/// True iff `j` is a list object (a map with an `@list` entry).
+fn is_list_object(j: &Json) -> bool {
+    matches!(j, Json::Obj(_)) && j.get("@list").is_some()
+}
+
+/// True iff `j` is a graph object (a map with an `@graph` entry).
+fn is_graph_object(j: &Json) -> bool {
+    matches!(j, Json::Obj(_)) && j.get("@graph").is_some()
+}
+
+/// True iff `j` is a node object (a map that is not a value / list / set object).
+fn is_node_object(j: &Json) -> bool {
+    matches!(j, Json::Obj(_))
+        && j.get("@value").is_none()
+        && j.get("@list").is_none()
+        && j.get("@set").is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn raw(s: &str) -> Json {
+        Json::Raw(s.to_string())
+    }
+
+    #[test]
+    fn null_and_scalar_predicates() {
+        assert!(is_null(&raw("null")));
+        assert!(!is_null(&raw("42")));
+        assert!(!is_null(&Json::Str("x".into())));
+        assert!(is_scalar(&Json::Str("x".into())));
+        assert!(is_scalar(&raw("42")));
+        assert!(is_scalar(&raw("true")));
+        assert!(!is_scalar(&raw("null")));
+        assert!(!is_scalar(&Json::Arr(vec![])));
+        assert!(!is_scalar(&Json::obj()));
+    }
+
+    #[test]
+    fn as_array_and_array_of_round_trip() {
+        assert_eq!(as_array(Json::Arr(vec![raw("1")])), vec![raw("1")]);
+        assert_eq!(as_array(Json::Str("x".into())), vec![Json::Str("x".into())]);
+        assert_eq!(array_of(Json::Str("x".into())), Json::Arr(vec![Json::Str("x".into())]));
+        // Already an array: array_of is the identity.
+        assert_eq!(array_of(Json::Arr(vec![raw("1")])), Json::Arr(vec![raw("1")]));
+    }
+
+    #[test]
+    fn add_value_accumulates_into_arrays() {
+        let mut m = Vec::new();
+        add_value(&mut m, "p", Json::Str("a".into()));
+        add_value(&mut m, "p", Json::Str("b".into()));
+        // An array value contributes each of its items.
+        add_value(&mut m, "p", Json::Arr(vec![Json::Str("c".into())]));
+        assert_eq!(
+            obj_get(&m, "p"),
+            Some(&Json::Arr(vec![
+                Json::Str("a".into()),
+                Json::Str("b".into()),
+                Json::Str("c".into()),
+            ]))
+        );
+    }
+
+    #[test]
+    fn set_obj_overwrites_in_place() {
+        let mut m = Vec::new();
+        set_obj(&mut m, "k", raw("1"));
+        set_obj(&mut m, "k", raw("2"));
+        assert_eq!(m.len(), 1);
+        assert_eq!(obj_get(&m, "k"), Some(&raw("2")));
+    }
+
+    #[test]
+    fn reverse_map_is_created_once() {
+        let mut m = Vec::new();
+        add_value(reverse_map(&mut m), "p", Json::Str("a".into()));
+        add_value(reverse_map(&mut m), "q", Json::Str("b".into()));
+        // Exactly one @reverse entry, holding both properties.
+        assert_eq!(m.iter().filter(|(k, _)| k == "@reverse").count(), 1);
+    }
+
+    #[test]
+    fn object_kind_predicates() {
+        let value = Json::Obj(vec![("@value".into(), raw("1"))]);
+        let list = Json::Obj(vec![("@list".into(), Json::Arr(vec![]))]);
+        let graph = Json::Obj(vec![("@graph".into(), Json::Arr(vec![]))]);
+        let node = Json::Obj(vec![("@id".into(), Json::Str("http://x".into()))]);
+        assert!(is_value_object(&value) && !is_node_object(&value));
+        assert!(is_list_object(&list) && !is_node_object(&list));
+        assert!(is_graph_object(&graph) && is_node_object(&graph));
+        assert!(is_node_object(&node) && !is_value_object(&node));
+    }
+
+    #[test]
+    fn string_values_extracts_only_strings() {
+        let arr = Json::Arr(vec![Json::Str("a".into()), raw("1"), Json::Str("b".into())]);
+        assert_eq!(string_values(&arr), vec!["a".to_string(), "b".to_string()]);
+        assert_eq!(string_values(&Json::Str("solo".into())), vec!["solo".to_string()]);
+        assert!(string_values(&raw("1")).is_empty());
+    }
+
+    #[test]
+    fn type_values_validates() {
+        assert_eq!(type_values(&Json::Str("T".into()), false).unwrap(), vec!["T".to_string()]);
+        assert!(type_values(&raw("42"), false).is_err());
+        // Frame expansion tolerates a map / non-string members.
+        assert!(type_values(&Json::obj(), true).unwrap().is_empty());
+    }
+}

--- a/crates/sparq-jsonld/src/expand.rs
+++ b/crates/sparq-jsonld/src/expand.rs
@@ -757,15 +757,24 @@ fn expand_value(active_context: &ActiveContext, active_property: &str, value: &J
     let td = active_context.term_definition(active_property);
     let type_mapping = td.and_then(|t| t.type_mapping());
 
-    // @id / @vocab coercion of a string value → a node reference.
+    // @id / @vocab coercion of a string value → a node reference. When IRI expansion returns
+    // `None` (the value expands to null — a keyword-shaped token, or a `@vocab` term bound to
+    // null), the value has no valid `@id`, so the entry is dropped rather than emitted as an
+    // invalid empty-string `@id` (mirrors the `@id`-keyword handling in `expand_property`).
     if let Json::Str(s) = value {
         if type_mapping == Some("@id") {
-            let id = active_context.expand_iri(s, true, false).unwrap_or_default();
-            return Json::Obj(vec![("@id".to_string(), Json::Str(id))]);
+            let mut node = Vec::new();
+            if let Some(id) = active_context.expand_iri(s, true, false) {
+                node.push(("@id".to_string(), Json::Str(id)));
+            }
+            return Json::Obj(node);
         }
         if type_mapping == Some("@vocab") {
-            let id = active_context.expand_iri(s, true, true).unwrap_or_default();
-            return Json::Obj(vec![("@id".to_string(), Json::Str(id))]);
+            let mut node = Vec::new();
+            if let Some(id) = active_context.expand_iri(s, true, true) {
+                node.push(("@id".to_string(), Json::Str(id)));
+            }
+            return Json::Obj(node);
         }
     }
 
@@ -1181,5 +1190,52 @@ mod tests {
         assert!(type_values(&raw("42"), false).is_err());
         // Frame expansion tolerates a map / non-string members.
         assert!(type_values(&Json::obj(), true).unwrap().is_empty());
+    }
+
+    /// Builds an active context that coerces term `id_term` with `@type: @id` and `vocab_term`
+    /// with `@type: @vocab`, over a `@vocab` base so a plain vocab reference resolves.
+    fn coercion_context() -> ActiveContext {
+        let ctx = Json::parse(
+            r#"{"@vocab":"http://ex/v#","id_term":{"@type":"@id"},"vocab_term":{"@type":"@vocab"}}"#,
+        )
+        .unwrap();
+        ActiveContext::new(None)
+            .process(&ctx, None, &crate::loader::NoopLoader, &JsonLdOptions::default())
+            .expect("context processes")
+    }
+
+    #[test]
+    fn expand_value_id_coercion_expands_and_drops_null() {
+        let ac = coercion_context();
+        // A resolvable absolute IRI under `@id` coercion → a `{"@id": <iri>}` node reference.
+        assert_eq!(
+            expand_value(&ac, "id_term", &Json::Str("http://ex/target".into())),
+            Json::Obj(vec![("@id".to_string(), Json::Str("http://ex/target".into()))]),
+        );
+        // A keyword-shaped token IRI-expands to null under `@id` coercion (document-relative,
+        // no vocab); the fix drops the entry rather than emitting an invalid empty-string
+        // `@id` (regression guard for the Copilot review on the old `unwrap_or_default()`).
+        let dropped = expand_value(&ac, "id_term", &Json::Str("@notakeyword".into()));
+        assert_eq!(dropped, Json::Obj(vec![]), "null @id must be dropped, never emitted as \"\"");
+        assert!(
+            !matches!(&dropped, Json::Obj(m) if m.iter().any(|(k, v)| k == "@id"
+                && matches!(v, Json::Str(s) if s.is_empty()))),
+            "must never produce an empty-string @id",
+        );
+    }
+
+    #[test]
+    fn expand_value_vocab_coercion_expands_and_drops_null() {
+        let ac = coercion_context();
+        // A plain term under `@vocab` coercion resolves against `@vocab`.
+        assert_eq!(
+            expand_value(&ac, "vocab_term", &Json::Str("thing".into())),
+            Json::Obj(vec![("@id".to_string(), Json::Str("http://ex/v#thing".into()))]),
+        );
+        // A keyword-shaped token still expands to null under `@vocab` coercion → dropped.
+        assert_eq!(
+            expand_value(&ac, "vocab_term", &Json::Str("@notakeyword".into())),
+            Json::Obj(vec![]),
+        );
     }
 }

--- a/crates/sparq-jsonld/src/lib.rs
+++ b/crates/sparq-jsonld/src/lib.rs
@@ -20,11 +20,16 @@
 //! - [`context`] — the **Context Processing** foundation (bead `sq-oy1f.24`): the
 //!   [`ActiveContext`], Create Term Definition, and IRI Expansion. The compaction-side
 //!   companions (inverse context, IRI compaction) are deferred to a follow-on bead.
+//! - [`expand`](mod@expand) — the document-level **Expansion Algorithm** + Value Expansion
+//!   (bead `sq-oy1f.25`): [`expand`](expand::expand) turns a compact document into its
+//!   canonical expanded form (scoped contexts, container maps, `@nest`, `@reverse`,
+//!   `@included`, `@json`, keyword aliases), threading `frameExpansion` for the framing
+//!   pipeline.
 //!
-//! The remaining algorithm modules ([`expand`], [`node_map`], [`flatten`], [`compact`],
-//! [`frame`], [`from_rdf`], [`to_rdf`], [`api`]) are **stubs**: they carry the spec
-//! references and the public shape only, filled by the dependency-ordered follow-on beads.
-//! Nothing panics: the crate is `todo!()`-free.
+//! The remaining algorithm modules ([`node_map`], [`flatten`], [`compact`], [`frame`],
+//! [`from_rdf`], [`to_rdf`], [`api`]) are **stubs**: they carry the spec references and the
+//! public shape only, filled by the dependency-ordered follow-on beads. Nothing panics: the
+//! crate is `todo!()`-free.
 
 // Real, shipped surfaces.
 pub mod context;
@@ -45,6 +50,7 @@ pub mod to_rdf;
 
 pub use context::{ActiveContext, Direction, Override, TermDefinition};
 pub use error::{JsonLdError, JsonLdErrorCode};
+pub use expand::expand;
 pub use json::{Json, JsonParseError};
 pub use loader::{DocumentLoader, FsLoader, NoopLoader, RemoteDocument};
 pub use options::{EmbedFlag, JsonLdOptions, ProcessingMode, RdfDirection};

--- a/crates/sparq-jsonld/tests/expand.rs
+++ b/crates/sparq-jsonld/tests/expand.rs
@@ -335,6 +335,149 @@ fn language_map() {
 }
 
 // ---------------------------------------------------------------------------------------
+// Property-valued index containers (`@container: @index` + `"@index": <prop>`) and the
+// expanded-index @none guards — mirrors of W3C expand suite cases pi05/pi06/pi07/pi10/m012
+// (§5.1.2 steps 13.8.3.7–13.8.3.10).
+// ---------------------------------------------------------------------------------------
+
+#[test]
+fn property_valued_index_becomes_property_value() {
+    // W3C expand/pi06: the index of a property-valued index map re-expands (Value
+    // Expansion, with the index key as active property) as a value of that property,
+    // instead of `@index`.
+    assert_expands(
+        r#"{
+            "@context": {
+                "@base": "http://example.com/",
+                "@vocab": "http://example.com/",
+                "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+            },
+            "@id": "article",
+            "author": {"regular": "person/1", "guest": ["person/2", "person/3"]}
+        }"#,
+        r#"[{
+            "@id": "http://example.com/article",
+            "http://example.com/author": [
+                {"@id": "http://example.com/person/1", "http://example.com/prop": [{"@value": "regular"}]},
+                {"@id": "http://example.com/person/2", "http://example.com/prop": [{"@value": "guest"}]},
+                {"@id": "http://example.com/person/3", "http://example.com/prop": [{"@value": "guest"}]}
+            ]
+        }]"#,
+    );
+}
+
+#[test]
+fn property_valued_index_precedes_existing_values() {
+    // §5.1.2 step 13.8.3.7.3: index property values are "an array consisting of re-expanded
+    // index FOLLOWED BY the existing values" — the suite's pi07 expected output shows the
+    // same ordering. The shared `canon` comparison is order-insensitive, so this asserts on
+    // the serialised property array directly.
+    let got = exp(r#"{
+        "@context": {
+            "@base": "http://example.com/",
+            "@vocab": "http://example.com/",
+            "author": {"@type": "@id", "@container": "@index", "@index": "prop"}
+        },
+        "@id": "article",
+        "author": {"regular": {"@id": "person/1", "prop": "foo"}}
+    }"#);
+    let s = serialize(&got);
+    assert!(
+        s.contains(r#""http://example.com/prop":[{"@value":"regular"},{"@value":"foo"}]"#),
+        "re-expanded index must precede the item's existing values, got: {s}",
+    );
+}
+
+#[test]
+fn property_valued_index_none_key_adds_no_property() {
+    // W3C expand/pi10: an `@none` index adds NO property (step 13.8.3.7 requires "expanded
+    // index is not @none"). The `guest` entry also pins the `@type: @vocab` re-expansion of
+    // the index into a vocab-IRI node reference.
+    assert_expands(
+        r#"{
+            "@context": {
+                "@base": "http://example.com/",
+                "@vocab": "http://example.com/",
+                "author": {"@type": "@id", "@container": "@index", "@index": "prop"},
+                "prop": {"@type": "@vocab"}
+            },
+            "@id": "http://example.com/article",
+            "author": {"@none": {"@id": "person/1"}, "guest": [{"@id": "person/2"}]}
+        }"#,
+        r#"[{
+            "@id": "http://example.com/article",
+            "http://example.com/author": [
+                {"@id": "http://example.com/person/1"},
+                {"@id": "http://example.com/person/2",
+                 "http://example.com/prop": [{"@id": "http://example.com/guest"}]}
+            ]
+        }]"#,
+    );
+}
+
+#[test]
+fn property_valued_index_on_value_object_errors() {
+    // W3C expand/pi05: adding the index property to a value object is an
+    // "invalid value object" error (§5.1.2 step 13.8.3.7.5).
+    assert_error(
+        r#"{
+            "@context": {
+                "@vocab": "http://example.com/",
+                "container": {"@id": "http://example.com/container", "@container": "@index", "@index": "prop"}
+            },
+            "@id": "http://example.com/annotationsTest",
+            "container": {"en": "The Queen"}
+        }"#,
+        JsonLdErrorCode::InvalidValueObject,
+    );
+}
+
+#[test]
+fn type_map_none_alias_adds_no_type() {
+    // W3C expand/m012: the @none guards compare the EXPANDED index, so a term aliased to
+    // `@none` used as a type-map key adds no `@type` (step 13.8.3.10).
+    assert_expands(
+        r#"{
+            "@context": {"@vocab": "http://example/", "typemap": {"@container": "@type"}, "none": "@none"},
+            "typemap": {"@none": {"label": "a"}, "none": {"label": "b"}}
+        }"#,
+        r#"[{
+            "http://example/typemap": [
+                {"http://example/label": [{"@value": "a"}]},
+                {"http://example/label": [{"@value": "b"}]}
+            ]
+        }]"#,
+    );
+}
+
+#[test]
+fn type_map_key_precedes_existing_types() {
+    // §5.1.2 step 13.8.3.10: "types … consisting of expanded index FOLLOWED BY any existing
+    // values of @type" — the suite's m004 expected output shows the same ordering.
+    let got = exp(r#"{
+        "@context": {"@vocab": "http://example/", "typemap": {"@container": "@type"}},
+        "typemap": {"_:bar": {"@type": "_:foo", "label": "x"}}
+    }"#);
+    let s = serialize(&got);
+    assert!(
+        s.contains(r#""@type":["_:bar","_:foo"]"#),
+        "the type-map key must precede the item's own @type values, got: {s}",
+    );
+}
+
+#[test]
+fn id_coercion_keyword_shaped_value_yields_null_id() {
+    // Value Expansion (§5.3.2 step 1) is literal: a keyword-shaped token under `@type: @id`
+    // IRI-expands to null, so the value expands to `{"@id": null}` — retained with a JSON
+    // null exactly as the W3C expand/0122 expected output retains `"@id": null` on the
+    // `@id`-keyword path (its manifest notes the result "will not be valid JSON-LD").
+    assert_expands(
+        r#"{"@context": {"p": {"@id": "http://ex/p", "@type": "@id"}}, "p": "@kw"}"#,
+        r#"[{"http://ex/p": [{"@id": null}]}]"#,
+    );
+}
+
+// ---------------------------------------------------------------------------------------
 // @json literals.
 // ---------------------------------------------------------------------------------------
 

--- a/crates/sparq-jsonld/tests/expand.rs
+++ b/crates/sparq-jsonld/tests/expand.rs
@@ -1,0 +1,455 @@
+//! [OPUS-4.8] (sq-oy1f.25) End-to-end tests for the JSON-LD 1.1 **Expansion Algorithm**,
+//! exercised through the crate's public [`sparq_jsonld::expand`] entry. Fixtures are drawn
+//! from the worked examples of the W3C JSON-LD 1.1 API + syntax specs
+//! (<https://www.w3.org/TR/json-ld11-api/#expansion-algorithms>). No network: expansion runs
+//! against the deny-by-default `NoopLoader`.
+//!
+//! Comparison follows the suite's normative rule — deep JSON equality where **array order is
+//! significant only inside `@list`**; every other array (property values, `@type`, `@graph`,
+//! `@set`) is compared order-insensitively via the [`canon`] canonicaliser.
+
+use sparq_jsonld::{expand, Json, JsonLdErrorCode, JsonLdOptions, NoopLoader};
+
+/// Parses a JSON fixture.
+fn json(s: &str) -> Json {
+    Json::parse(s).expect("valid JSON fixture")
+}
+
+/// Expands `input` with the default options (no base).
+fn exp(input: &str) -> Json {
+    expand(&json(input), &JsonLdOptions::default(), &NoopLoader).expect("expansion should succeed")
+}
+
+/// Expands `input` with an explicit base IRI.
+fn exp_base(input: &str, base: &str) -> Json {
+    let mut opts = JsonLdOptions::default();
+    opts.base = Some(base.to_string());
+    expand(&json(input), &opts, &NoopLoader).expect("expansion should succeed")
+}
+
+/// Canonicalises a `Json` for the normative comparison: object keys are sorted, and every
+/// array is sorted by its canonical serialisation **except** the array under an `@list` key,
+/// whose order is preserved.
+fn canon(j: &Json) -> Json {
+    match j {
+        Json::Obj(members) => {
+            let mut out: Vec<(String, Json)> = members
+                .iter()
+                .map(|(k, v)| {
+                    let cv = if k == "@list" {
+                        canon_ordered(v)
+                    } else {
+                        canon(v)
+                    };
+                    (k.clone(), cv)
+                })
+                .collect();
+            out.sort_by(|a, b| a.0.cmp(&b.0));
+            Json::Obj(out)
+        }
+        Json::Arr(items) => {
+            let mut c: Vec<Json> = items.iter().map(canon).collect();
+            c.sort_by_key(serialize);
+            Json::Arr(c)
+        }
+        other => other.clone(),
+    }
+}
+
+/// Canonicalises the elements of an ordered array (an `@list` value) **without** reordering.
+fn canon_ordered(j: &Json) -> Json {
+    match j {
+        Json::Arr(items) => Json::Arr(items.iter().map(canon).collect()),
+        other => canon(other),
+    }
+}
+
+/// Serialises a `Json` to its canonical minified string.
+fn serialize(j: &Json) -> String {
+    let mut s = String::new();
+    j.write(&mut s);
+    s
+}
+
+/// Asserts the expansion of `input` equals `expected` under the normative comparison.
+#[track_caller]
+fn assert_expands(input: &str, expected: &str) {
+    let got = exp(input);
+    let want = json(expected);
+    assert_eq!(
+        canon(&got),
+        canon(&want),
+        "\n  input:    {}\n  got:      {}\n  expected: {}",
+        input,
+        serialize(&got),
+        serialize(&want)
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// Core expansion: term IRIs, @id / @type coercion, value objects.
+// ---------------------------------------------------------------------------------------
+
+#[test]
+fn simple_terms_and_id_coercion() {
+    // JSON-LD 1.1 API — the canonical "homepage @type: @id" example.
+    assert_expands(
+        r#"{
+            "@context": {
+                "name": "http://schema.org/name",
+                "homepage": {"@id": "http://schema.org/url", "@type": "@id"}
+            },
+            "@id": "http://me.example.com/",
+            "name": "Alice",
+            "homepage": "http://alice.example.com/"
+        }"#,
+        r#"[{
+            "@id": "http://me.example.com/",
+            "http://schema.org/name": [{"@value": "Alice"}],
+            "http://schema.org/url": [{"@id": "http://alice.example.com/"}]
+        }]"#,
+    );
+}
+
+#[test]
+fn typed_value_object() {
+    assert_expands(
+        r#"{
+            "@context": {"age": {"@id": "http://ex/age", "@type": "http://www.w3.org/2001/XMLSchema#integer"}},
+            "age": "42"
+        }"#,
+        r#"[{"http://ex/age": [{"@value": "42", "@type": "http://www.w3.org/2001/XMLSchema#integer"}]}]"#,
+    );
+}
+
+#[test]
+fn default_language_applied_to_strings() {
+    assert_expands(
+        r#"{"@context": {"@language": "ja", "term": "http://ex/term"}, "term": "花"}"#,
+        r#"[{"http://ex/term": [{"@value": "花", "@language": "ja"}]}]"#,
+    );
+}
+
+#[test]
+fn number_and_boolean_values_have_no_language() {
+    // A default @language must NOT be attached to non-string values.
+    assert_expands(
+        r#"{"@context": {"@language": "en", "n": "http://ex/n", "b": "http://ex/b"}, "n": 42, "b": true}"#,
+        r#"[{"http://ex/n": [{"@value": 42}], "http://ex/b": [{"@value": true}]}]"#,
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// Keyword aliases.
+// ---------------------------------------------------------------------------------------
+
+#[test]
+fn keyword_aliases_for_id_and_type() {
+    assert_expands(
+        r#"{
+            "@context": {"id": "@id", "type": "@type", "Person": "http://schema.org/Person"},
+            "id": "http://ex/me",
+            "type": "Person"
+        }"#,
+        r#"[{"@id": "http://ex/me", "@type": ["http://schema.org/Person"]}]"#,
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// @list / @set.
+// ---------------------------------------------------------------------------------------
+
+#[test]
+fn list_container_preserves_order() {
+    assert_expands(
+        r#"{"@context": {"foo": {"@id": "http://ex/foo", "@container": "@list"}}, "foo": ["a", "b", "c"]}"#,
+        r#"[{"http://ex/foo": [{"@list": [{"@value": "a"}, {"@value": "b"}, {"@value": "c"}]}]}]"#,
+    );
+}
+
+#[test]
+fn set_container_unwraps() {
+    assert_expands(
+        r#"{"@context": {"foo": {"@id": "http://ex/foo", "@container": "@set"}}, "foo": ["a"]}"#,
+        r#"[{"http://ex/foo": [{"@value": "a"}]}]"#,
+    );
+}
+
+#[test]
+fn explicit_list_object() {
+    assert_expands(
+        r#"{"http://ex/foo": {"@list": ["a", "b"]}}"#,
+        r#"[{"http://ex/foo": [{"@list": [{"@value": "a"}, {"@value": "b"}]}]}]"#,
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// @graph, top-level reduction, scalar drops.
+// ---------------------------------------------------------------------------------------
+
+#[test]
+fn top_level_graph_reduces() {
+    assert_expands(
+        r#"{"@context": {"foo": "http://ex/foo"}, "@graph": [{"@id": "http://ex/1", "foo": "bar"}]}"#,
+        r#"[{"@id": "http://ex/1", "http://ex/foo": [{"@value": "bar"}]}]"#,
+    );
+}
+
+#[test]
+fn top_level_scalar_expands_to_empty_array() {
+    assert_eq!(exp("42"), Json::Arr(vec![]));
+    assert_eq!(exp("null"), Json::Arr(vec![]));
+    assert_eq!(exp("\"a string\""), Json::Arr(vec![]));
+}
+
+#[test]
+fn free_floating_id_only_node_is_dropped() {
+    // A top-level node consisting only of @id projects to no output.
+    assert_eq!(exp(r#"{"@id": "http://ex/1"}"#), Json::Arr(vec![]));
+}
+
+// ---------------------------------------------------------------------------------------
+// @reverse.
+// ---------------------------------------------------------------------------------------
+
+#[test]
+fn reverse_property_term() {
+    assert_expands(
+        r#"{
+            "@context": {"parentOf": {"@reverse": "http://ex/childOf"}},
+            "@id": "http://ex/parent",
+            "parentOf": {"@id": "http://ex/child"}
+        }"#,
+        r#"[{
+            "@id": "http://ex/parent",
+            "@reverse": {"http://ex/childOf": [{"@id": "http://ex/child"}]}
+        }]"#,
+    );
+}
+
+#[test]
+fn reverse_keyword() {
+    assert_expands(
+        r#"{
+            "@id": "http://ex/a",
+            "@reverse": {"http://ex/p": {"@id": "http://ex/b"}}
+        }"#,
+        r#"[{"@id": "http://ex/a", "@reverse": {"http://ex/p": [{"@id": "http://ex/b"}]}}]"#,
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// Scoped contexts.
+// ---------------------------------------------------------------------------------------
+
+#[test]
+fn property_scoped_context() {
+    assert_expands(
+        r#"{
+            "@context": {"foo": {"@id": "http://ex/foo", "@context": {"bar": "http://ex/bar"}}},
+            "foo": {"bar": "baz"}
+        }"#,
+        r#"[{"http://ex/foo": [{"http://ex/bar": [{"@value": "baz"}]}]}]"#,
+    );
+}
+
+#[test]
+fn type_scoped_context() {
+    assert_expands(
+        r#"{
+            "@context": {
+                "Foo": {"@id": "http://ex/Foo", "@context": {"bar": "http://ex/bar"}},
+                "type": "@type"
+            },
+            "type": "Foo",
+            "bar": "baz"
+        }"#,
+        r#"[{"@type": ["http://ex/Foo"], "http://ex/bar": [{"@value": "baz"}]}]"#,
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// @nest.
+// ---------------------------------------------------------------------------------------
+
+#[test]
+fn nest_flattens_into_parent() {
+    assert_expands(
+        r#"{
+            "@context": {"nest": "@nest", "name": "http://ex/name", "age": "http://ex/age"},
+            "@id": "http://ex/1",
+            "name": "Alice",
+            "nest": {"age": "30"}
+        }"#,
+        r#"[{
+            "@id": "http://ex/1",
+            "http://ex/name": [{"@value": "Alice"}],
+            "http://ex/age": [{"@value": "30"}]
+        }]"#,
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// Container maps: @index / @id / @type / @language.
+// ---------------------------------------------------------------------------------------
+
+#[test]
+fn index_map() {
+    assert_expands(
+        r#"{"@context": {"foo": {"@id": "http://ex/foo", "@container": "@index"}}, "foo": {"a": "1", "b": "2"}}"#,
+        r#"[{"http://ex/foo": [{"@value": "1", "@index": "a"}, {"@value": "2", "@index": "b"}]}]"#,
+    );
+}
+
+#[test]
+fn id_map() {
+    assert_expands(
+        r#"{
+            "@context": {"foo": {"@id": "http://ex/foo", "@container": "@id"}, "name": "http://ex/name"},
+            "foo": {"http://ex/1": {"name": "Alice"}}
+        }"#,
+        r#"[{"http://ex/foo": [{"@id": "http://ex/1", "http://ex/name": [{"@value": "Alice"}]}]}]"#,
+    );
+}
+
+#[test]
+fn type_map() {
+    assert_expands(
+        r#"{
+            "@context": {"foo": {"@id": "http://ex/foo", "@container": "@type"}, "name": "http://ex/name"},
+            "foo": {"http://ex/T": {"name": "Alice"}}
+        }"#,
+        r#"[{"http://ex/foo": [{"@type": ["http://ex/T"], "http://ex/name": [{"@value": "Alice"}]}]}]"#,
+    );
+}
+
+#[test]
+fn language_map() {
+    assert_expands(
+        r#"{
+            "@context": {"label": {"@id": "http://ex/label", "@container": "@language"}},
+            "label": {"en": "Hello", "de": "Hallo"}
+        }"#,
+        r#"[{"http://ex/label": [{"@value": "Hello", "@language": "en"}, {"@value": "Hallo", "@language": "de"}]}]"#,
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// @json literals.
+// ---------------------------------------------------------------------------------------
+
+#[test]
+fn json_literal_keeps_value_verbatim() {
+    assert_expands(
+        r#"{"@context": {"e": {"@id": "http://ex/e", "@type": "@json"}}, "e": {"foo": ["bar", 1, true]}}"#,
+        r#"[{"http://ex/e": [{"@value": {"foo": ["bar", 1, true]}, "@type": "@json"}]}]"#,
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// Null drops + array normalisation + relative IRIs.
+// ---------------------------------------------------------------------------------------
+
+#[test]
+fn null_values_are_dropped() {
+    assert_expands(
+        r#"{"@context": {"foo": "http://ex/foo"}, "foo": null, "http://ex/bar": ["a", null, "b"]}"#,
+        r#"[{"http://ex/bar": [{"@value": "a"}, {"@value": "b"}]}]"#,
+    );
+}
+
+#[test]
+fn relative_iris_resolve_against_base() {
+    assert_eq!(
+        canon(&exp_base(
+            r#"{"@id": "foo", "http://ex/p": "v"}"#,
+            "http://example.org/dir/"
+        )),
+        canon(&json(
+            r#"[{"@id": "http://example.org/dir/foo", "http://ex/p": [{"@value": "v"}]}]"#
+        ))
+    );
+}
+
+// ---------------------------------------------------------------------------------------
+// Negative tests: exact spec error codes.
+// ---------------------------------------------------------------------------------------
+
+/// Expands `input`, expecting a specific error code.
+#[track_caller]
+fn assert_error(input: &str, code: JsonLdErrorCode) {
+    let err = expand(&json(input), &JsonLdOptions::default(), &NoopLoader)
+        .expect_err("expansion should fail");
+    assert_eq!(err.code(), code, "input: {}", input);
+}
+
+#[test]
+fn invalid_id_value() {
+    assert_error(r#"{"@id": 42, "http://ex/p": "v"}"#, JsonLdErrorCode::InvalidIdValue);
+}
+
+#[test]
+fn colliding_keywords() {
+    assert_error(
+        r#"{"@context": {"id": "@id"}, "@id": "http://ex/1", "id": "http://ex/2"}"#,
+        JsonLdErrorCode::CollidingKeywords,
+    );
+}
+
+#[test]
+fn invalid_value_object_disallowed_key() {
+    assert_error(
+        r#"{"http://ex/p": {"@value": "x", "@id": "http://ex/y"}}"#,
+        JsonLdErrorCode::InvalidValueObject,
+    );
+}
+
+#[test]
+fn invalid_value_object_value() {
+    // A @value with a non-scalar (and no @json type) is invalid.
+    assert_error(
+        r#"{"http://ex/p": {"@value": {"nested": "object"}}}"#,
+        JsonLdErrorCode::InvalidValueObjectValue,
+    );
+}
+
+#[test]
+fn invalid_language_tagged_string() {
+    assert_error(
+        r#"{"http://ex/p": {"@value": "x", "@language": 42}}"#,
+        JsonLdErrorCode::InvalidLanguageTaggedString,
+    );
+}
+
+#[test]
+fn invalid_type_value() {
+    assert_error(
+        r#"{"@type": {"not": "a string"}, "http://ex/p": "v"}"#,
+        JsonLdErrorCode::InvalidTypeValue,
+    );
+}
+
+#[test]
+fn invalid_reverse_value() {
+    assert_error(
+        r#"{"@reverse": "not a map"}"#,
+        JsonLdErrorCode::InvalidReverseValue,
+    );
+}
+
+#[test]
+fn invalid_nest_value() {
+    assert_error(
+        r#"{"@context": {"nest": "@nest"}, "nest": "not a map"}"#,
+        JsonLdErrorCode::InvalidNestValue,
+    );
+}
+
+#[test]
+fn colliding_value_and_language_type() {
+    // A value object may not carry both @type and @language.
+    assert_error(
+        r#"{"http://ex/p": {"@value": "x", "@type": "http://ex/T", "@language": "en"}}"#,
+        JsonLdErrorCode::InvalidValueObject,
+    );
+}

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -371,9 +371,15 @@ Context Processing foundation (sq-oy1f.24) ships today: `sparq_jsonld::context::
 with `process()` (Context Processing + Create Term Definition, fallible with exact spec error
 codes), `expand_iri()` (IRI Expansion), RFC 3986 reference resolution, and **deny-by-default**
 remote-context loading via `DocumentLoader` (`NoopLoader` refuses every fetch — no ambient
-network — while `FsLoader` serves trusted local fixtures). Expansion / compaction / framing on
-this substrate, and the surface wiring, land in later beads; the RDF-first writers above remain
-the shipped path until then.
+network — while `FsLoader` serves trusted local fixtures). The document-level **Expansion
+Algorithm** (sq-oy1f.25) ships too: `sparq_jsonld::expand(&input, &opts, &loader)` returns the
+canonical expanded array — Value Expansion, scoped (property/type) contexts,
+`@index`/`@id`/`@type`/`@language`/`@graph` container maps, `@nest`, `@reverse`, `@included`,
+`@json` literals, keyword aliases, and the drop-null + array-normalisation rules — raising the
+exact spec error code on invalid input and threading `frameExpansion`. Compaction / flattening /
+framing on this substrate, the surface wiring, and the conformance-lane switch to the normative
+document-level expand oracle land in later beads; the RDF-first writers above remain the shipped
+emit path until then.
 
 ```rust
 use sparq_engine::serialize::{graph_to_jsonld_compact, parse_context_json};


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-oy1f.25** (JSON-LD 1.1 [C] — document-level Expansion), unblocked by the Context Processing foundation sq-oy1f.24 (#1366). Authored by Opus 4.8 (Fable unavailable — flag for re-review when Fable returns).

## What this implements

The W3C **JSON-LD 1.1 Expansion Algorithm** (API §5.1.2) + **Value Expansion** (§5.3.2) in the opt-in, dependency-free `sparq-jsonld` crate, consuming the merged Context Processing machinery (`ActiveContext`, Create Term Definition, IRI Expansion). New public entry:

```rust
let expanded: Json = sparq_jsonld::expand(&input, &options, &loader)?; // always a JSON array
```

Algorithms / features covered:
- keyword aliases + IRI expansion; `@value`/`@type`/`@language`/`@direction` **value objects**
- `@list` / `@set`; `@graph` + top-level `@graph`-only reduction
- `@reverse` (reverse **term** and `@reverse` **keyword**, incl. the double-reverse fold)
- **property-scoped** and **type-scoped** contexts (`process_scoped` with the spec `override_protected` / `propagate` flags)
- `@nest`, `@included`, `@json` literals
- `@index` / `@id` / `@type` / `@language` / `@graph` **container maps**
- drop-null + array-normalisation; relative-IRI / `@base` resolution
- `frameExpansion` threaded through (framing pipeline that consumes it lands in **sq-oy1f.29**)
- invalid inputs raise the **exact** spec `JsonLdErrorCode`

## Opt-in / core-lean discipline

`sparq-jsonld` has **zero mandatory dependencies** and is only compiled behind `sparq-engine`'s off-by-default `serialize-rdf` feature (`dep:sparq-jsonld`). `sparq-core`/`sparq-engine` default + wasm builds pull in **nothing** new. `#![forbid(unsafe_code)]`. The deny-by-default `DocumentLoader` stays deny-by-default — tests use `NoopLoader` (no network).

## Tests (real path)

- **32** direct spec-worked-example integration tests (`tests/expand.rs`) under a **normative comparison** (deep JSON equality; array order significant **only inside `@list`**), including negative tests asserting exact error codes (`InvalidIdValue`, `CollidingKeywords`, `InvalidValueObject`, `InvalidValueObjectValue`, `InvalidLanguageTaggedString`, `InvalidTypeValue`, `InvalidReverseValue`, `InvalidNestValue`).
- **10** helper unit tests (coverage-ratchet: direct coverage of the AST helpers).

## Gates (green in BOTH feature states)

Feature flag: `sparq-engine/serialize-rdf` (the only feature that compiles this crate).
- `cargo clippy -p sparq-jsonld --all-targets -- -D warnings` — clean
- `cargo clippy -p sparq-engine --features serialize-rdf -- -D warnings` — clean
- `cargo build -p sparq-engine` (serialize-rdf OFF, default) — builds
- `cargo test -p sparq-jsonld` — 51 lib + 37 context + 32 expand + 1 doc = green
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-jsonld --no-deps --all-features` — clean (disambiguated the crate-root `expand` module-vs-fn intra-doc link)
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations (README 82 lines)

## Honest scoping — deferred to a follow-on bead

Per the "correct self-contained slice beats a sprawling half-done PR" guidance, this PR delivers the Expansion Algorithm (the foundation the compaction/flatten beads depend on). It **does not** switch the `sparq-conformance` `jsonld_suite.rs` expand lane from RDF-equivalence to the native document-level expand oracle, nor re-pin `EXPAND_FLOOR` (old-oracle 247/385 vs new-oracle side-by-side). That is a cross-crate, measurement-bearing change and should be its own bead (see report).

Not armed. No CI-poll loop.