### PR TITLE
feat(site): org-migration Pages cutover — serve at https://sparq.jeswr.org/ (root) (sq-uj38w)

### DIFF
--- a/.claude/agents/sparq-site.md
+++ b/.claude/agents/sparq-site.md
@@ -4,7 +4,7 @@ description: "Implements front-end work in the sparq Next.js site (site/) — th
 model: opus
 ---
 
-You are a **SPARQ agent** 🤖 working in `jeswr/sparq`'s website — a **Next.js** app under `site/`, **statically exported** (`output: export`) to GitHub Pages at `https://jeswr.github.io/sparq/` with `basePath: /sparq`. Everything must work as a static client-side app — no server runtime. You own the **site lane** (only one site branch in flight at a time).
+You are a **SPARQ agent** 🤖 working in `jeswr/sparq`'s website — a **Next.js** app under `site/`, **statically exported** (`output: export`) to GitHub Pages at `https://sparq.jeswr.org/` with `basePath: /sparq`. Everything must work as a static client-side app — no server runtime. You own the **site lane** (only one site branch in flight at a time).
 
 ## Shared SPARQ contract (every task)
 Follow the **sub-agent shared contract** — `AGENTS.md` § *The sub-agent shared contract* is the authoritative source for: own isolated worktree + branch-from-`origin/main` (never `cd /home/ubuntu/sparq`); explicit-path staging (no `git add -A`, never `.beads/`); no push/merge; `[OPUS-4.8]` markers + the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer; 🤖 self-ID in every comment + the PR body; once-a-minute heartbeat (during `npm install`/`npm run build`); the **typos** gate (reword `DELETEd`/`DROPped`/`invokable`/`ANDed`); the LIVE **privacy-claims** gate; non-sycophantic honesty (never fabricate numbers/benchmarks/families), no empty PRs, discovered work as a LIST. A terse task brief gives only the bead + target route/page. **Role-specific deltas:**

--- a/.claude/agents/sparq-site.md
+++ b/.claude/agents/sparq-site.md
@@ -4,7 +4,7 @@ description: "Implements front-end work in the sparq Next.js site (site/) — th
 model: opus
 ---
 
-You are a **SPARQ agent** 🤖 working in `jeswr/sparq`'s website — a **Next.js** app under `site/`, **statically exported** (`output: export`) to GitHub Pages at `https://sparq.jeswr.org/` with `basePath: /sparq`. Everything must work as a static client-side app — no server runtime. You own the **site lane** (only one site branch in flight at a time).
+You are a **SPARQ agent** 🤖 working in `sparq-org/sparq`'s website — a **Next.js** app under `site/`, **statically exported** (`output: export`) to GitHub Pages at `https://sparq.jeswr.org/` with `basePath: ''` (root-relative; custom-domain cutover sq-uj38w). Everything must work as a static client-side app — no server runtime. You own the **site lane** (only one site branch in flight at a time).
 
 ## Shared SPARQ contract (every task)
 Follow the **sub-agent shared contract** — `AGENTS.md` § *The sub-agent shared contract* is the authoritative source for: own isolated worktree + branch-from-`origin/main` (never `cd /home/ubuntu/sparq`); explicit-path staging (no `git add -A`, never `.beads/`); no push/merge; `[OPUS-4.8]` markers + the `Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>` trailer; 🤖 self-ID in every comment + the PR body; once-a-minute heartbeat (during `npm install`/`npm run build`); the **typos** gate (reword `DELETEd`/`DROPped`/`invokable`/`ANDed`); the LIVE **privacy-claims** gate; non-sycophantic honesty (never fabricate numbers/benchmarks/families), no empty PRs, discovered work as a LIST. A terse task brief gives only the bead + target route/page. **Role-specific deltas:**
@@ -14,7 +14,7 @@ Follow the **sub-agent shared contract** — `AGENTS.md` § *The sub-agent share
 ## Your gates (HARD)
 - `cd site && npm install && npm run build` (the static export) succeeds END-TO-END, emitting the affected routes into `out/`. `npm run lint` clean. `tsc --noEmit` (or the build's typecheck) passes — no `any`-escape hatches masking errors.
 - **WASM prereq:** the site build hard-fails if the WASM bundle is absent — build it first if needed: `cd js && npm run build:wasm` (a build artifact only — NO `crates/` changes). 
-- Keep `basePath` (`/sparq`) correct for every asset/link. Do NOT break existing routes: `/`, `/benchmarks/*`, `/papers`, `/try`, `/surface/*`, `/showcase/*`.
+- Keep `basePath` (`''`, root-relative since sq-uj38w cutover) correct for every asset/link. Do NOT break existing routes: `/`, `/benchmarks/*`, `/papers`, `/try`, `/surface/*`, `/showcase/*`.
 - Match the existing AppShell / design-system / component patterns (reuse, don't reinvent). Prefer dependency-free or static-export-safe libs (avoid heavy SSR-incompatible deps); justify + note bundle-size impact for any new dependency.
 - **README template gate (HARD — sq-8ic6):** your scope is `site/`, but on the rare task where you create or edit a crate `README.md`, it MUST pass the readme-template gate. Run `python3 scripts/check-readme-template.py` and ensure ≤120 lines + the `## 🚀 Quickstart` / `## ✨ Features` / `## 📚 Learn more` sections + a License section (or a ≤30-line `<!-- internal-stub -->` stub for a `publish=false` crate). Prefer putting incidental notes in rustdoc rather than expanding the README past the cap.
 

--- a/.github/workflows/bench-ec2.yml
+++ b/.github/workflows/bench-ec2.yml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   ec2-bench:
     name: heavy benchmark on EC2 (spot)
-    if: github.repository == 'jeswr/sparq'
+    if: github.repository == 'sparq-org/sparq'
     runs-on: ubuntu-latest
     # [OPUS-4.8] Job-scoped writes (least privilege):
     #   id-token: write — assume the short-lived, tag-scoped IAM role via OIDC

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -14,7 +14,7 @@ name: Benchmarks
 #   PUBLIC DASHBOARD — REPO-OWNER TOGGLE REQUIRED (one-time, can't be set from a workflow):
 #   Settings → Pages → "Build and deployment" → Source = "Deploy from a branch",
 #   Branch = `benchmark-data` / `/ (root)` → Save. The chart then renders at
-#   https://jeswr.github.io/sparq/dev/bench (the action writes index.html + data.js under dev/bench
+#   https://sparq.jeswr.org/dev/bench (the action writes index.html + data.js under dev/bench
 #   on the benchmark-data branch — see gh-pages-branch + benchmark-data-dir-path below). No new
 #   branch is created; Pages just serves the existing benchmark-data branch.
 on:
@@ -349,7 +349,7 @@ jobs:
           auto-push: ${{ github.ref == 'refs/heads/main' }}
           # The history branch doubles as the Pages source: the action writes index.html + data.js
           # under dev/bench here, so once the owner points Settings → Pages at branch benchmark-data
-          # /(root) the dashboard renders at https://jeswr.github.io/sparq/dev/bench (see header).
+          # /(root) the dashboard renders at https://sparq.jeswr.org/dev/bench (see header).
           gh-pages-branch: benchmark-data
           benchmark-data-dir-path: dev/bench
           # [OPUS-4.8] sq-3g6q: CAP the retained history. github-action-benchmark accumulates EVERY
@@ -419,7 +419,7 @@ jobs:
           done
           # [OPUS-4.8] root redirect (sq-pages-root): the bare Pages root would 404 because the
           # dashboard lives under dev/bench/. Seed bench/dashboard/root-redirect.html to the
-          # benchmark-data branch ROOT as index.html so https://jeswr.github.io/sparq/ bounces to
+          # benchmark-data branch ROOT as index.html so https://sparq.jeswr.org/ bounces to
           # dev/bench/. github-action-benchmark only writes data.js + dev/bench/index.html (never a
           # root index.html), so this coexists with its data and is preserved across runs.
           if [ ! -f "$tmp/index.html" ] || ! cmp -s "$src/root-redirect.html" "$tmp/index.html"; then

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,7 @@
 #   GitHub Pages exposes exactly ONE deploy slot. The live site at
 #   https://sparq.jeswr.org/ is ALREADY published by pages.yml — the Next.js
 #   feature-showcase at the root, with the benchmark dashboard overlaid at
-#   /sparq/dev/. A SECOND `actions/deploy-pages` workflow here would race pages.yml
+#   /dev/. A SECOND `actions/deploy-pages` workflow here would race pages.yml
 #   on every main/benchmark-data push (last-writer-wins) AND replace the live
 #   showcase root with the mdBook guide. The sq-w9sr design (mdBook at "/") predates
 #   the showcase deploy and does not account for it; reconciling "mdBook-at-root vs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,7 +8,7 @@
 #
 # WHY IT DOES NOT DEPLOY TO PAGES (the deferred half, reported as a blocker):
 #   GitHub Pages exposes exactly ONE deploy slot. The live site at
-#   https://jeswr.github.io/sparq/ is ALREADY published by pages.yml — the Next.js
+#   https://sparq.jeswr.org/ is ALREADY published by pages.yml — the Next.js
 #   feature-showcase at the root, with the benchmark dashboard overlaid at
 #   /sparq/dev/. A SECOND `actions/deploy-pages` workflow here would race pages.yml
 #   on every main/benchmark-data push (last-writer-wins) AND replace the live

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,45 +1,46 @@
 # [OPUS-4.8] sq-40y0 — deploy the sparq feature-showcase site (site/) to GitHub Pages.
 #
-# WHAT THIS PUBLISHES: the Next.js static export under the Pages base path /sparq,
-# PLUS the existing benchmark dashboard preserved at /sparq/dev/, PLUS the DISTINCT
-# operational GUI frontend (gui/app) hosted at /sparq/app/. The dashboard tree
+# WHAT THIS PUBLISHES: the Next.js static export served ROOT-RELATIVE (basePath '') at the custom domain
+# https://sparq.jeswr.org/ (org-migration cutover, sq-uj38w),
+# PLUS the existing benchmark dashboard preserved at /dev/, PLUS the DISTINCT
+# operational GUI frontend (gui/app) hosted at /app/. The dashboard tree
 # (`dev/`) lives on the `benchmark-data` branch (written by bench.yml); this workflow
 # fetches that tree and OVERLAYS it into the export's `out/dev/` before upload, so a
 # single Pages artifact serves the showcase root, the unchanged dashboard at
-# /sparq/dev/bench/, AND the live "Try the GUI" workbench at /sparq/app/.
+# /dev/bench/, AND the live "Try the GUI" workbench at /app/.
 #
-# THE /sparq/app/ GUI (sq-vnd0i, maintainer's Option B): the marketing site's `/try` route
+# THE /app/ GUI (sq-vnd0i, maintainer's Option B): the marketing site's `/try` route
 # stays the lightweight in-browser SPARQL REPL playground; the live operational GUI is a
 # SEPARATE destination built from gui/app (a distinct Next.js workbench, NOT the site) and
 # overlaid at out/app/ — the site's "App" nav slot (wired in #1004) points there. Same single
 # Pages deploy; no Pages-API/source change (build_type is already 'workflow').
 #
 # HOW /dev/bench IS PRESERVED (traced):
-#   1. Pages is served at https://jeswr.github.io/sparq/ from this workflow
+#   1. Pages is served at https://sparq.jeswr.org/ from this workflow
 #      (build_type: workflow — the "GitHub Actions" source; the earlier "Deploy from a
 #      branch" legacy source has been retired). The benchmark dashboard formerly served
 #      from the `benchmark-data` branch root (a root index.html redirect + a dev/ tree:
 #      dev/bench/{index.html,dashboard.js,dashboard.css,data.js,...}) is now carried into
-#      THIS workflow's artifact via the overlay step below, so /sparq/dev/bench/ keeps
+#      THIS workflow's artifact via the overlay step below, so /dev/bench/ keeps
 #      working under the single Actions-built artifact.
 #   2. This workflow does NOT touch the `benchmark-data` branch — bench.yml keeps
 #      writing data.js + dev/bench/* there exactly as before. We only READ it.
 #   3. After `next build` writes the showcase to out/ (with its OWN root index.html),
 #      we `git archive` the `benchmark-data` branch's `dev/` directory into `out/dev/`.
 #      The showcase root replaces the old redirect; the dashboard is carried forward
-#      verbatim, so https://jeswr.github.io/sparq/dev/bench/ keeps working.
+#      verbatim, so https://sparq.jeswr.org/dev/bench/ keeps working.
 #   4. `out/.nojekyll` disables Jekyll so `_next/` (underscore-prefixed) assets serve.
 #
 # PAGES SOURCE (DONE — no longer needs:user): the repo's Pages source is already set to
-# "GitHub Actions" (sq-vbq9 resolved; `gh api repos/jeswr/sparq/pages` reports
+# "GitHub Actions" (sq-vbq9 resolved; `gh api repos/sparq-org/sparq/pages` reports
 # build_type: workflow), so this workflow's deploy step IS the live publisher — the site
-# at https://jeswr.github.io/sparq/ is served from the artifact below, not from any branch
+# at https://sparq.jeswr.org/ is served from the artifact below, not from any branch
 # root. No repo-settings action is outstanding for this workflow. (The alternative —
 # committing out/ onto benchmark-data — was rejected: it couples site source to the data
 # branch and races bench.yml's root index.html seed.)
 #
 # OPEN PRODUCT DECISION (sq-svtt, NOT a settings flip): Pages has ONE deploy slot and this
-# workflow owns the /sparq/ root. The mdBook guide (sq-w9sr/sq-h0tr) wants a published
+# workflow owns the / root. The mdBook guide (sq-w9sr/sq-h0tr) wants a published
 # home too; until that root question is decided (guide at /guide subpath vs at root vs a
 # merged deploy), docs.yml deliberately ships NO deploy job (build-validate only) so a
 # second deploy-pages cannot race + overwrite this showcase. That decision does not block
@@ -183,27 +184,37 @@ jobs:
       # before — the migration changes only WHERE deps resolve from, not the produced out/ tree.
       - name: Build static site
         working-directory: site
+        # [OPUS-4.8] sq-uj38w — org-migration Pages cutover (atomic flip). The site now serves at the
+        # ROOT of the custom domain https://sparq.jeswr.org/ (custom domain set via site/public/CNAME
+        # → out/CNAME below), so the Pages build must emit ROOT-RELATIVE assets (/_next/… not
+        # /sparq/_next/…). NEXT_PUBLIC_BASE_PATH='' selects basePath '' in site/next.config.ts (the SAME
+        # switch the Tauri build uses). basePath and the custom domain MUST flip together in THIS one
+        # deploy — changing only one would break every asset/route URL.
+        env:
+          NEXT_PUBLIC_BASE_PATH: ""
         run: |
           npm ci
-          npm run build   # prebuild copies js/wasm → site/public/wasm + builds papers, then next build → out/
+          npm run build   # prebuild copies js/wasm → site/public/wasm + builds papers, then next build → out/ (root-relative, basePath '')
 
       # [OPUS-4.8] sq-vnd0i — build the DISTINCT operational GUI frontend (gui/app) as its hosted
-      # "Try the GUI live" web target and OVERLAY it at /sparq/app/ on the SAME Pages artifact.
+      # "Try the GUI live" web target and OVERLAY it at /app/ on the SAME Pages artifact.
       #
       # The maintainer picked Option B (bead sq-vnd0i): /try stays the lightweight in-browser
       # SPARQL REPL playground (the site's `/try` route, unchanged); the live operational GUI is a
-      # SEPARATE destination hosted at https://jeswr.github.io/sparq/app/ — a sub-path of THIS
+      # SEPARATE destination hosted at https://sparq.jeswr.org/app/ — a sub-path of THIS
       # single GitHub-Actions Pages deploy (the site's "App" nav slot, wired in #1004). This step
       # makes that route real: until now `site/src/app/app/page.tsx` was an honest PLACEHOLDER
-      # promising the hosted app "will live here at /sparq/app/"; this overlay delivers it.
+      # promising the hosted app "will live here at /app/"; this overlay delivers it.
       #
       # The GUI frontend embeds the in-tab WASM engine, so it consumes the SAME lean
       # `--features shacl,jsonld` bundle already built into `js/wasm/` above; its `prebuild`
       # `sync-wasm` copies that bundle into `gui/app/public/wasm/` before `next build`. `build:web`
       # leaves NEXT_PUBLIC_BASE_PATH unset, so `gui/app/next.config.ts` defaults basePath +
-      # assetPrefix to `/sparq/app` (every `_next/*` chunk URL is baked as `/sparq/app/...`), and
-      # the GUI passes the same `/sparq/app` prefix to the @sparq/client wasm loader, so the
-      # runtime engine fetch is `/sparq/app/wasm/...` — exactly where the overlay places it.
+      # assetPrefix to `/app` (every `_next/*` chunk URL is baked as `/app/...`), and
+      # the GUI passes the same `/app` prefix to the @sparq/client wasm loader, so the
+      # runtime engine fetch is `/app/wasm/...` — exactly where the overlay places it. (Pre-cutover
+      # sq-uj38w this sub-path was /sparq/app; the site now serves at the custom-domain ROOT so it
+      # collapsed to /app.)
       #
       # `npm install` at the repo root resolves the gui/app workspace member's deps from the
       # repo-root package-lock (mirrors gui.yml's gui-app job); it does NOT touch the wasm bundle.
@@ -211,7 +222,7 @@ jobs:
         run: npm install
       - name: Build the operational GUI frontend (hosted web target)
         working-directory: gui/app
-        run: npm run build:web   # presync check + prebuild sync-wasm (js/wasm → public/wasm), then next build → out/ (basePath /sparq/app)
+        run: npm run build:web   # presync check + prebuild sync-wasm (js/wasm → public/wasm), then next build → out/ (basePath /app)
 
       # [OPUS-4.8] sq-d8or — anti-drift: link-check the BUILT site HTML before publish.
       # The docs-quality `internal-links` job (sq-5fd1) lychee-checks the repo MARKDOWN;
@@ -234,7 +245,7 @@ jobs:
       - name: Link-check the static-export HTML (lychee --offline)
         run: bash scripts/check-site-links.sh site/out
 
-      # ---- Preserve the existing benchmark dashboard(s) at /sparq/dev/ ----
+      # ---- Preserve the existing benchmark dashboard(s) at /dev/ ----
       # [OPUS-4.8] sq-zngy — fold ALL `dev/bench*` subtrees (not just dev/bench).
       # bench.yml writes benchmark-data:dev/bench (benchmark-data-dir-path: dev/bench);
       # bench-ec2.yml writes benchmark-data:dev/bench-ec2 (benchmark-data-dir-path:
@@ -276,11 +287,11 @@ jobs:
           # Static-export hygiene: disable Jekyll so _next/ assets are served.
           touch out/.nojekyll
 
-      # ---- Overlay the operational GUI frontend at /sparq/app/ ----
+      # ---- Overlay the operational GUI frontend at /app/ ----
       # [OPUS-4.8] sq-vnd0i — place the gui/app hosted web export INTO out/app/, mirroring the
       # dev/bench overlay above (a sub-tree of the SAME single Pages artifact). The GUI's
-      # static export (basePath /sparq/app) writes its index.html at the export ROOT with assets
-      # baked as /sparq/app/_next/... and /sparq/app/wasm/... , so serving it at /sparq/app/
+      # static export (basePath /app) writes its index.html at the export ROOT with assets
+      # baked as /app/_next/... and /app/wasm/... , so serving it at /app/
       # means copying the WHOLE export tree (index.html, _next/, wasm/, 404.html) into out/app/.
       # This step runs AFTER the lychee link-check (which checks only the SITE's own HTML) and
       # DELIBERATELY OVERWRITES the site's /app placeholder marketing card (site/src/app/app/) —
@@ -302,7 +313,7 @@ jobs:
           # tree (its index.html + any chunk it referenced) so only the real GUI remains.
           rsync -a --delete "$gui_out"/ out/app/
           # OVERLAY ASSERTION: the engine asset + the app entry MUST land where the baked URLs
-          # (/sparq/app/...) expect them, or the hosted GUI would 404 its own engine/chunks.
+          # (/app/...) expect them, or the hosted GUI would 404 its own engine/chunks.
           for f in out/app/index.html out/app/wasm/sparq_wasm_bg.wasm; do
             if [ -f "$f" ]; then
               echo "OK present: ${f#out/} ($(wc -c < "$f") bytes)"
@@ -311,19 +322,19 @@ jobs:
               exit 1
             fi
           done
-          # Sanity: the GUI index must reference the /sparq/app asset prefix (catches a basePath
+          # Sanity: the GUI index must reference the /app asset prefix (catches a basePath
           # regression that would silently break every asset/chunk URL once hosted).
-          if grep -q '/sparq/app/_next/' out/app/index.html; then
-            echo "OK: out/app/index.html references the /sparq/app asset prefix"
+          if grep -q '/app/_next/' out/app/index.html; then
+            echo "OK: out/app/index.html references the /app asset prefix"
           else
-            echo "::error::out/app/index.html does NOT reference /sparq/app/_next/ — basePath regression (the GUI would 404 its chunks when hosted)"
+            echo "::error::out/app/index.html does NOT reference /app/_next/ — basePath regression (the GUI would 404 its chunks when hosted)"
             exit 1
           fi
           echo "OK: operational GUI overlaid at out/app/" >> "$GITHUB_STEP_SUMMARY"
 
       # [OPUS-4.8] sq-zngy — ARTIFACT-LEVEL smoke check (NOT a live-URL check).
       # This step asserts the ASSEMBLED Pages output dir (site/out, the exact tree handed to
-      # upload-pages-artifact below) rather than probing the live https://jeswr.github.io/sparq/dev/...
+      # upload-pages-artifact below) rather than probing the live https://sparq.jeswr.org/dev/...
       # URL: the artifact check is deterministic + decoupled from deploy/propagation timing
       # (the live URL lags this run by the deploy + CDN flush), and it catches the dev/bench*
       # reconciliation regression at build time, BEFORE upload. It verifies the artifact
@@ -334,6 +345,16 @@ jobs:
         run: |
           set -euo pipefail
           fail=0
+          # [OPUS-4.8] sq-uj38w — org-migration Pages cutover: the published root MUST carry a CNAME
+          # file (= `sparq.jeswr.org`) so this deploy sets the custom domain. Next copies site/public/
+          # into the export root, so out/CNAME appears from site/public/CNAME. If it is missing or wrong,
+          # the atomic flip would publish a root-relative build WITHOUT the custom domain — hard fail
+          # rather than deploy a half-flipped site.
+          if [ -f out/CNAME ] && grep -qx 'sparq.jeswr.org' out/CNAME; then
+            echo "OK: out/CNAME present and = sparq.jeswr.org (custom domain will be set on deploy)"
+          else
+            echo "::error::out/CNAME missing or not exactly 'sparq.jeswr.org' — custom-domain flip would not take effect"; fail=1
+          fi
           # Core dashboard (dev/bench) MUST always be present — these are hard requirements.
           #   present:            dev/bench/index.html, dev/bench/dashboard.js
           #   present + NON-EMPTY: dev/bench/data.js (the benchmark series; empty = broken overlay)

--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -67,8 +67,8 @@ jobs:
   release-plz-pr:
     name: release-plz / Release-PR
     # Guard against forks: release-plz needs repo write + would open PRs on a fork clone.
-    # Mirrors bench-ec2.yml's `github.repository == 'jeswr/sparq'` guard.
-    if: github.repository == 'jeswr/sparq'
+    # Mirrors bench-ec2.yml's `github.repository == 'sparq-org/sparq'` guard.
+    if: github.repository == 'sparq-org/sparq'
     runs-on: ubuntu-latest
     permissions:
       contents: write       # commit the version bump + changelog onto the Release-PR branch
@@ -100,7 +100,7 @@ jobs:
   #         all the building/packaging/releasing. No build matrix here by design.
   release-plz-release:
     name: release-plz / tag (handoff to release.yml)
-    if: github.repository == 'jeswr/sparq'
+    if: github.repository == 'sparq-org/sparq'
     runs-on: ubuntu-latest
     permissions:
       contents: write  # create + push the v<version> git tag

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ license = "MIT"
 rust-version = "1.88"
 # Shared crates.io metadata (T20). Each publishable crate inherits these via
 # `<field>.workspace = true` and adds its own `description`.
-repository = "https://github.com/jeswr/sparq"
-homepage = "https://github.com/jeswr/sparq"
+repository = "https://github.com/sparq-org/sparq"
+homepage = "https://github.com/sparq-org/sparq"
 keywords = ["rdf", "sparql", "semantic-web", "triplestore", "query-engine"]
 categories = ["database-implementations", "parsing", "science"]
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center">
   <a href="https://github.com/jeswr/sparq/actions/workflows/ci.yml"><img src="https://github.com/jeswr/sparq/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
-  <a href="https://jeswr.github.io/sparq/dev/bench"><img src="https://img.shields.io/badge/benchmarks-dashboard-f5a623.svg" alt="Benchmarks dashboard"></a>
+  <a href="https://sparq.jeswr.org/dev/bench"><img src="https://img.shields.io/badge/benchmarks-dashboard-f5a623.svg" alt="Benchmarks dashboard"></a>
   <img src="https://img.shields.io/badge/rust-1.88%2B-orange.svg" alt="MSRV 1.88">
   <img src="https://img.shields.io/badge/status-experimental-yellow.svg" alt="Status: experimental">
 </p>
@@ -161,7 +161,7 @@ See [`AGENTS.md`](AGENTS.md) for the full crate map and what each one does.
   [completion audit](research/roadmap-completion-audit.md). The `research/` tree holds the design
   notes and measured verdicts for the engine internals.
 - **Performance** — numbers are **not baked into the docs** (they drift). Live per-commit metrics
-  are at the [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench); the registry and
+  are at the [benchmarks dashboard](https://sparq.jeswr.org/dev/bench); the registry and
   exact invocations are in [`bench/benchmarks.toml`](bench/benchmarks.toml) and
   [`bench/CATALOG.md`](bench/CATALOG.md). The QLever comparison methodology is in
   [`bench/qlever-baselines.md`](bench/qlever-baselines.md) and the continuous Oxigraph

--- a/bench/dashboard/root-redirect.html
+++ b/bench/dashboard/root-redirect.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <!-- [OPUS-4.8] sparq Pages root redirect. The benchmark dashboard is served from the
-     benchmark-data branch under dev/bench/, so the bare Pages root (https://jeswr.github.io/sparq/)
+     benchmark-data branch under dev/bench/, so the bare Pages root (https://sparq.jeswr.org/)
      would otherwise 404 and read as "the dashboard is dark". bench.yml's seed step copies this file
      to the benchmark-data branch ROOT as index.html so the bare URL bounces to dev/bench/.
      Kept tiny + dependency-free: a meta refresh does the redirect, a canonical link points search

--- a/bench/qlever-baselines.md
+++ b/bench/qlever-baselines.md
@@ -10,7 +10,7 @@ only when the dataset or QLever version changes (note the date + commit if so).
 > tables below are point-in-time snapshots** of this machine and *will drift*;
 > regenerate them with the `sparq-cli bench … count` / `bench-mmap` commands shown
 > in each section (see also `bench/benchmarks.toml`, `bench/CATALOG.md`, and the
-> per-commit perf dashboard <https://jeswr.github.io/sparq/dev/bench>). This is the
+> per-commit perf dashboard <https://sparq.jeswr.org/dev/bench>). This is the
 > single source for the QLever comparison; other docs link here rather than restate it.
 
 All times are **min-of-N cold** query-time-ms reported by QLever (`query-time-ms`),

--- a/book/src/introduction.md
+++ b/book/src/introduction.md
@@ -26,5 +26,5 @@ Per-surface how-to guides live in the
 [usage skills](https://github.com/jeswr/sparq/blob/main/skills/SKILL.md) router, and the full crate
 map is in [`AGENTS.md`](https://github.com/jeswr/sparq/blob/main/AGENTS.md). Live per-commit
 performance metrics are on the
-[benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench) — numbers are deliberately **not**
+[benchmarks dashboard](https://sparq.jeswr.org/dev/bench) — numbers are deliberately **not**
 baked into these docs, because they drift.

--- a/crates/sparq-bench/README.md
+++ b/crates/sparq-bench/README.md
@@ -14,7 +14,7 @@ benchmarks dashboard.
 
 > **Internal tooling — not published** to crates.io (`publish = false`). Run it
 > as a workspace binary; it is not a library. Measured numbers belong in the
-> [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench), never baked
+> [benchmarks dashboard](https://sparq.jeswr.org/dev/bench), never baked
 > into docs.
 
 Contributing: [`AGENTS.md`](../../AGENTS.md).

--- a/crates/sparq-cli/README.md
+++ b/crates/sparq-cli/README.md
@@ -74,7 +74,7 @@ cargo run --release -p sparq-cli -- query data.ttl turtle 'SELECT * WHERE { ?s ?
 - **API reference** — run `cargo run -p sparq-cli -- --help`; rustdoc at
   [docs.rs/sparq-cli](https://docs.rs/sparq-cli).
 - **Design** — [`research/ARCHITECTURE.md`](../../research/ARCHITECTURE.md).
-- **Performance** — see the [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench);
+- **Performance** — see the [benchmarks dashboard](https://sparq.jeswr.org/dev/bench);
   numbers are not baked into docs.
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 

--- a/crates/sparq-core/README.md
+++ b/crates/sparq-core/README.md
@@ -55,7 +55,7 @@ assert_eq!(count, 1);
 - **Design** — [`research/ARCHITECTURE.md`](../../research/ARCHITECTURE.md); the indexing,
   compression and parsing verdicts live across the [`research/`](../../research) tree.
 - **Performance** — numbers are not baked into docs; see the
-  [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench).
+  [benchmarks dashboard](https://sparq.jeswr.org/dev/bench).
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## License

--- a/crates/sparq-engine/README.md
+++ b/crates/sparq-engine/README.md
@@ -112,7 +112,7 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
 - **Design** — [`research/ARCHITECTURE.md`](../../research/ARCHITECTURE.md) and the planning /
   parallelism verdicts in [`research/`](../../research).
 - **Performance** — numbers live on the
-  [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench), not in docs.
+  [benchmarks dashboard](https://sparq.jeswr.org/dev/bench), not in docs.
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## License

--- a/crates/sparq-hdt/README.md
+++ b/crates/sparq-hdt/README.md
@@ -95,7 +95,7 @@ cargo run --release -p sparq-hdt --example bench_load -- --json /tmp/hdt.json
 ## 📚 Learn more
 
 - Skill: `skills/hdt-format/SKILL.md`
-- Perf dashboard: <https://jeswr.github.io/sparq/dev/bench>
+- Perf dashboard: <https://sparq.jeswr.org/dev/bench>
 - Not yet supported / open work: `bd list -l area:sparq-hdt` (the decode-only ingest fast
   path; upstream notes in `UPSTREAM.md`).
 

--- a/crates/sparq-introspect/README.md
+++ b/crates/sparq-introspect/README.md
@@ -112,7 +112,7 @@ cargo run -p sparq-introspect --example olympics_introspect --release
 - Design records: [`research/genai-design.md`](../../research/genai-design.md),
   [`research/genai-ontology-introspection.md`](../../research/genai-ontology-introspection.md)
 - W3C VoID: <https://www.w3.org/TR/void/>
-- Perf dashboard: <https://jeswr.github.io/sparq/dev/bench>
+- Perf dashboard: <https://sparq.jeswr.org/dev/bench>
 - Open work for this crate: `bd list -l area:sparq-introspect`
 
 ## License

--- a/crates/sparq-nlq/README.md
+++ b/crates/sparq-nlq/README.md
@@ -112,7 +112,7 @@ capture replayable fixtures; `--features nlq-endpoint` points `endpoint::Endpoin
   (§4.3), [`research/genai-design.md`](../../research/genai-design.md) (§4), and schema
   grounding in [`sparq-introspect`](../sparq-introspect).
 - **Performance** — the eval harnesses run network-free in CI; tracked figures live on
-  the [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench), not in docs.
+  the [benchmarks dashboard](https://sparq.jeswr.org/dev/bench), not in docs.
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md).
 
 ## License

--- a/crates/sparq-reason/README.md
+++ b/crates/sparq-reason/README.md
@@ -65,7 +65,7 @@ let g = Graph::from_parts(dict, triples);
 - **API reference** — [docs.rs/sparq-reason](https://docs.rs/sparq-reason).
 - **Design** — the inference verdicts in [`research/`](../../research) and
   [`research/ARCHITECTURE.md`](../../research/ARCHITECTURE.md).
-- **Performance** — see the [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench).
+- **Performance** — see the [benchmarks dashboard](https://sparq.jeswr.org/dev/bench).
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## License

--- a/crates/sparq-rsp/README.md
+++ b/crates/sparq-rsp/README.md
@@ -72,7 +72,7 @@ q.flush(|result| { /* end-of-stream: close everything up to max ts */ })?;
 - **Performance** — the `throughput` example
   (`cargo run --release -p sparq-rsp --example throughput`; append `-- --json <path>` to
   also write the same rows as a machine-readable JSON document, STDOUT unchanged) and
-  [`bench/rsp/`](../../bench/rsp); the [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench).
+  [`bench/rsp/`](../../bench/rsp); the [benchmarks dashboard](https://sparq.jeswr.org/dev/bench).
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md) and [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## License

--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -112,7 +112,7 @@ every update is WAL-fsync'd **before the `204` ack** (restart replays the WAL, n
   (generation-ring + sequenced-writer) and
   [`research/adr-horizontal-scaling.md`](../../research/adr-horizontal-scaling.md) (the non-goal).
 - **Performance** — not baked into docs; see the
-  [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench).
+  [benchmarks dashboard](https://sparq.jeswr.org/dev/bench).
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md), [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## License

--- a/crates/sparq-sim/README.md
+++ b/crates/sparq-sim/README.md
@@ -113,7 +113,7 @@ semantics, hub-cap, neighbor-sparse fallback, AUC gate) plus 1 integration
 - Text embeddings: [`sparq-vectors` README](../sparq-vectors/README.md),
   [`research/genai-text-embedding-practices.md`](../../research/genai-text-embedding-practices.md)
 - Skill: `skills/structural-similarity/SKILL.md`
-- Perf dashboard: <https://jeswr.github.io/sparq/dev/bench>
+- Perf dashboard: <https://sparq.jeswr.org/dev/bench>
 
 ## License
 

--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -112,7 +112,7 @@ rather than trapping (rest of `MaterializeStats` unchanged); a wasm32 runtime sm
 - **API reference** — [docs.rs/sparq-solid](https://docs.rs/sparq-solid); walk-through `cargo run -p
   sparq-solid --example quickstart --release`. Migrating from Oxigraph?
   [`docs/migrating-from-oxigraph.md`](../../docs/migrating-from-oxigraph.md).
-- **Performance / Contribute** — [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench)
+- **Performance / Contribute** — [benchmarks dashboard](https://sparq.jeswr.org/dev/bench)
   (`--example bench`); [`AGENTS.md`](../../AGENTS.md), [`CONTRIBUTING.md`](../../CONTRIBUTING.md).
 
 ## License

--- a/crates/sparq-text/README.md
+++ b/crates/sparq-text/README.md
@@ -109,7 +109,7 @@ let r = query_text(&graph, r#"
 - **Benchmark** — `cargo run --release -p sparq-text --example bench_text` (no figures
   baked in here; query cost is dominated by hits scored — a short prefix over the
   synthetic Zipf vocabulary is a worst case by construction). Tracked figures on the
-  [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench).
+  [benchmarks dashboard](https://sparq.jeswr.org/dev/bench).
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md).
 
 ## License

--- a/crates/sparq-vectors/README.md
+++ b/crates/sparq-vectors/README.md
@@ -107,7 +107,7 @@ let _neighbours = nearest_term_exact(&store, &graph, &some_term, 10);
 - **Design** — [`research/genai-text-embedding-practices.md`](../../research/genai-text-embedding-practices.md).
 - **Accuracy & throughput** — not baked into docs; the recall / DiskANN / PQ / throughput gates
   are `cargo test`s (`tests/recall.rs`, `diskann.rs`, `quant.rs`, `throughput.rs`), with live
-  numbers on the [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench).
+  numbers on the [benchmarks dashboard](https://sparq.jeswr.org/dev/bench).
 - **Verified against an established ANN library (sq-6te5)** — `tests/ref_lib_verify.rs` anchors
   recall against **hnswlib** via a committed capture (`tests/fixtures/hnswlib_ref.tsv`):
   `nearest_exact` reproduces the numpy exact-kNN oracle, and DiskANN (and HNSW under `approx-ann`)

--- a/crates/sparq-wasm/README.md
+++ b/crates/sparq-wasm/README.md
@@ -106,7 +106,7 @@ const n = store.count("SELECT ?s WHERE { ?s a <http://ex/Person> }"); // lazy, n
   and the standalone showcase bundle [`sparq-shacl-wasm`](../sparq-shacl-wasm/README.md).
 - **Performance** — bundle size (`wasm_bundle_*`) and store/dict footprint
   (`store_bytes_per_triple` / `dict_bytes_per_term`) are tracked per-commit on the
-  [benchmarks dashboard](https://jeswr.github.io/sparq/dev/bench), not in docs.
+  [benchmarks dashboard](https://sparq.jeswr.org/dev/bench), not in docs.
   The `test/perf.cjs`, `test/mem.cjs`, and `test/smoke.cjs` harnesses reproduce them.
 - **Contribute** — [`AGENTS.md`](../../AGENTS.md).
 

--- a/gui/app/next.config.ts
+++ b/gui/app/next.config.ts
@@ -11,20 +11,20 @@ import type { NextConfig } from "next";
 //     `beforeBuildCommand` runs `build:tauri`, which sets NEXT_PUBLIC_BASE_PATH='' → basePath ''.
 //   * Hosted "Try the GUI live" web target ("build:web"): served under a sub-path on the same
 //     GitHub-Pages-style host. The maintainer picked the URL slot (bead sq-vnd0i, Option B):
-//     the live GUI is hosted at the `/sparq/app` sub-path (the site's "App" nav destination;
-//     "/try" stays the lightweight REPL). This app defaults the web build to `/sparq/app`,
+//     the live GUI is hosted at the `/app` sub-path (the site's "App" nav destination;
+//     "/try" stays the lightweight REPL). This app defaults the web build to `/app`,
 //     overridable via the env var.
 //
-// An UNSET var keeps the web default (`/sparq/app`); an explicit empty string selects the
+// An UNSET var keeps the web default (`/app`); an explicit empty string selects the
 // root-relative (Tauri) export. Next requires basePath to be empty or start with `/` (no
 // trailing slash), so we honour only `''` or a `/`-leading value and otherwise fall back.
 const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
 const basePath =
   rawBasePath === undefined
-    ? "/sparq/app" // unset → hosted-web default (the live-GUI "/app" sub-path)
+    ? "/app" // unset → hosted-web default (the live-GUI "/app" sub-path)
     : rawBasePath === "" || rawBasePath.startsWith("/")
       ? rawBasePath // '' (Tauri root-relative) or an explicit '/prefix'
-      : "/sparq/app";
+      : "/app";
 
 const nextConfig: NextConfig = {
   output: "export",

--- a/gui/app/src/components/workbench/top-bar.tsx
+++ b/gui/app/src/components/workbench/top-bar.tsx
@@ -17,7 +17,7 @@ import { useCommandPalette } from "@/components/workbench/command-palette";
 import { useImportDrawer } from "@/components/workbench/import-drawer";
 
 /** The honesty-website link target (the marketing site, opened in a NEW tab / system browser). */
-const WEBSITE_URL = "https://jeswr.github.io/sparq/";
+const WEBSITE_URL = "https://sparq.jeswr.org/";
 
 function StatusLed() {
   const { status } = useEngine();

--- a/gui/app/src/lib/base-path.ts
+++ b/gui/app/src/lib/base-path.ts
@@ -2,7 +2,7 @@
 //
 // The operational GUI frontend is served under TWO targets (see gui/app/next.config.ts):
 //   * the Tauri 2 desktop webview — from the `tauri://` root, where a `/prefix` 404s (basePath '');
-//   * the hosted "Try the GUI live" web target — under a sub-path (default `/sparq/app`).
+//   * the hosted "Try the GUI live" web target — under a sub-path (default `/app`).
 //
 // `next.config.ts` env-switches `basePath`/`assetPrefix` off `NEXT_PUBLIC_BASE_PATH`, so Next
 // rewrites `_next/*` chunk URLs and `<Link href>` routes automatically. A HARDCODED absolute
@@ -14,20 +14,20 @@
  * The configured base path, derived from `NEXT_PUBLIC_BASE_PATH` (the same switch
  * `next.config.ts` uses):
  *
- *   * **unset** → `"/sparq/app"` (the hosted-web default);
+ *   * **unset** → `"/app"` (the hosted-web default);
  *   * **`""`** → `""` (the Tauri root-relative export);
  *   * a leading-`/` value → that value (an explicit deploy prefix);
- *   * any malformed value → falls back to `"/sparq/app"`.
+ *   * any malformed value → falls back to `"/app"`.
  *
  * Returns `""` (not `"/"`) for the root, so {@link withBasePath} composes a clean
  * `${basePath}/foo` without a double slash.
  */
 export function basePath(): string {
   const raw = process.env.NEXT_PUBLIC_BASE_PATH;
-  if (raw === undefined) return "/sparq/app";
+  if (raw === undefined) return "/app";
   if (raw === "") return "";
   if (raw.startsWith("/")) return raw.replace(/\/$/, ""); // strip any trailing slash
-  return "/sparq/app";
+  return "/app";
 }
 
 /** Prefix a root-absolute asset path with the configured {@link basePath}. */

--- a/gui/app/src/lib/reason-wasm.ts
+++ b/gui/app/src/lib/reason-wasm.ts
@@ -8,7 +8,7 @@
 // RUNTIME with a webpackIgnore dynamic import from /public, so the ~2.5 MB wasm never enters
 // the page bundle; the asset URLs are prefixed with the SAME NEXT_PUBLIC_BASE_PATH the rest of
 // the GUI keys off (@/lib/base-path), so they resolve under both the Tauri root-relative export
-// and the hosted "/sparq/app" sub-path. The bundle is OPTIONAL: a build that did not sync it
+// and the hosted "/app" sub-path. The bundle is OPTIONAL: a build that did not sync it
 // (see gui/app/scripts/sync-wasm.mjs) surfaces an honest "reasoning unavailable" state at
 // runtime rather than crashing — and, rather than silently answering un-reasoned, queries then
 // hard-fail with a clear message while inference is on (until it is turned off or the bundle is

--- a/js/README.md
+++ b/js/README.md
@@ -6,7 +6,7 @@ triplestore + SPARQL engine compiled to WebAssembly. One compact wasm artifact,
 one tiny runtime npm dependency ([`fzstd`](https://www.npmjs.com/package/fzstd),
 dynamically imported only when ingesting zstd); works in Node ≥ 18 and the
 browser. (The wasm bundle bytes are tracked per-commit on the perf dashboard,
-<https://jeswr.github.io/sparq/dev/bench>.)
+<https://sparq.jeswr.org/dev/bench>.)
 
 - Dictionary-encoded in-memory store (optionally block-compressed: substantially
   less index memory for a bounded scan cost).

--- a/research/BENCHMARKS.md
+++ b/research/BENCHMARKS.md
@@ -6,7 +6,7 @@
 > QLever-gap narrative, the negative results, the methodology); they drift and are
 > not maintained by hand. For current figures:
 > - **Per-commit CI metrics** (deterministic: wasm bundle bytes, store B/triple,
->   dict B/term) → the perf dashboard <https://jeswr.github.io/sparq/dev/bench>
+>   dict B/term) → the perf dashboard <https://sparq.jeswr.org/dev/bench>
 >   (orphan `benchmark-data` branch).
 > - **The benchmark registry + exact invocations** → `bench/benchmarks.toml`
 >   and `bench/CATALOG.md`. Regenerate any figure by running the named harness.

--- a/research/ci-ec2-design.md
+++ b/research/ci-ec2-design.md
@@ -10,7 +10,7 @@ and must stay **under $5/month**. This is the security + cost design.
 > github-action-benchmark on the `benchmark-data` branch under `dev/bench`. **One-time owner
 > action (cannot be set from a workflow):** Settings → Pages → Source = "Deploy from a branch",
 > Branch = `benchmark-data` / `/ (root)` → Save. The dashboard then renders at
-> <https://jeswr.github.io/sparq/dev/bench>. [OPUS-4.8]
+> <https://sparq.jeswr.org/dev/bench>. [OPUS-4.8]
 
 ## Threat model & the three hard rules
 

--- a/research/feature-showcase-site-design.md
+++ b/research/feature-showcase-site-design.md
@@ -135,7 +135,7 @@ QA bar for the whole site.
 
 ## 2. Site IA / sitemap
 
-Root site at `https://jeswr.github.io/sparq/`. Sidebar nav grouped by the surface taxonomy
+Root site at `https://sparq.jeswr.org/`. Sidebar nav grouped by the surface taxonomy
 (`skills/SKILL.md` is the canonical taxonomy source). Each group is a sidebar section; each
 surface is a page; the three flagships are top-billed "Showcase" pages.
 
@@ -376,10 +376,10 @@ bundle), explicitly **not** a prerequisite.
 
 - **Build:** Next.js 15.5 / React 19 / Tailwind v4 / shadcn (`radix-nova`) / `next-themes`,
   matching §1, **statically exported** (`output: 'export'`) to `out/`.
-- **Pages base path:** the repo's Pages site is served at **`https://jeswr.github.io/sparq/`**
+- **Pages base path:** the repo's Pages site is served at **`https://sparq.jeswr.org/`**
   (project page, not a user page), so set **`basePath: '/sparq'`** + matching `assetPrefix` and
   load all wasm/bb.js assets through the base path. (Confirmed: `gh api repos/jeswr/sparq/pages`
-  → `html_url: https://jeswr.github.io/sparq/`.)
+  → `html_url: https://sparq.jeswr.org/`.)
 - **Co-hosting with `/dev/bench`:** today Pages is served from the **`benchmark-data` branch**
   at `/` (`build_type: legacy`), whose tree is `index.html` + `dev/` — i.e. the benchmark
   dashboard lives at **`/sparq/dev/`**. The showcase becomes the **new root site**; we must

--- a/scripts/check-no-perf-numbers.py
+++ b/scripts/check-no-perf-numbers.py
@@ -56,7 +56,7 @@ ALLOW_LINE_SUBSTRINGS = [
     # platform / spec limits
     "wasm32", "4 GB", "2 GB", "4 GiB",
     # the canonical perf homes — a line that POINTS to them is fine
-    "jeswr.github.io/sparq/dev/bench", "benchmarks.toml", "bench/CATALOG.md",
+    "sparq.jeswr.org/dev/bench", "benchmarks.toml", "bench/CATALOG.md",
     "perf-baseline.json", "perf dashboard",
     # explicit opt-out marker a reviewer can add on a justified line
     "<!-- perf-ok -->", "perf-ok:",

--- a/scripts/check-site-links.sh
+++ b/scripts/check-site-links.sh
@@ -10,34 +10,31 @@
 # `next build`) and locally (`scripts/check-site-links.sh site/out`).
 #
 # WHAT: lychee --offline (no network, deterministic) over every *.html under the export,
-# validating relative links AND heading anchors (--include-fragments). The static export is
-# served under the `/sparq` GitHub Pages base path (site/next.config.ts: basePath:"/sparq",
-# trailingSlash:true), so every INTERNAL link in the emitted HTML is an absolute path like
-#   /sparq/about/   (and the bare root link /sparq/).
-# On disk those resolve to <out>/about/index.html and <out>/index.html — i.e. the `/sparq`
-# prefix must be stripped to land in the export root. Three --remap rules do exactly that:
-#   0. file://<out>/sparq/<path>#<frag> -> file://<out>/<path>/index.html#<frag>
-#                                       (a CROSS-PAGE path+fragment link, see [OPUS-4.8] sq-bpoey)
-#   1. file://<out>/sparq/(.*)  -> file://<out>/$1          (every /sparq/<path> link)
-#   2. file://<out>/sparq       -> file://<out>/index.html  (the bare /sparq root link)
+# validating relative links AND heading anchors (--include-fragments).
 #
-# [OPUS-4.8] sq-bpoey — RULE 0 is load-bearing for cross-page anchor links like
-# `/sparq/capabilities/#privacy` (homepage theme grid + the removed /surface/* redirect stubs
-# point at /capabilities/#<theme>). With `--root-dir`, lychee resolves a *directory* link that
-# carries a fragment to the bare directory path (e.g. file://<out>/capabilities) and then,
-# crucially, does NOT fall through to that directory's index.html when locating the `#fragment`
-# heading — so it reports "Cannot find fragment" for EVERY such link. (Verified empirically
-# against the CI lychee 0.23.0: a `/dir/#frag`, a `/dir#frag`, AND a `/dir/` form all fail; only
-# an explicit `/dir/index.html#frag` resolves.) Adding a trailing slash before the fragment in
-# the emitted link — as one might expect under trailingSlash:true — does NOT help; the fix must
-# rewrite the directory to its index.html for the fragment lookup. Rule 0 runs FIRST so it owns
-# the path+fragment case; rule 1 then handles every remaining (fragment-free) /sparq/<path> link.
-# This is the regression that reddened the pages.yml link-check after PR #1003 introduced the
-# first cross-page fragment links on the site (the self-test below only covered same-page #anchors).
+# [OPUS-4.8] sq-uj38w — the org-migration Pages cutover moved the site to the ROOT of the custom
+# domain https://sparq.jeswr.org/, so the Pages build is now ROOT-RELATIVE (basePath '',
+# trailingSlash:true — site/next.config.ts + the pages.yml "Build static site" step set
+# NEXT_PUBLIC_BASE_PATH=''). Every INTERNAL link in the emitted HTML is now an absolute path like
+#   /about/   (and the bare root link /).
+# `--root-dir <out>` resolves those absolute paths against the export root, and lychee resolves a
+# fragment-FREE directory link (/about/) straight to <out>/about/index.html — so NO prefix-strip
+# remap is needed any more (the old `/sparq` rules 1 & 2 are gone with the sub-path).
 #
-# (lychee normalises a trailing-slash dir link to the slashless path before matching, so the
-# two rules together cover both forms — verified empirically: 0 errors over the full export,
-# and an injected dead link is caught.)
+# [OPUS-4.8] sq-bpoey / sq-uj38w — ONE remap survives, for CROSS-PAGE path+fragment links like
+# `/capabilities/#privacy` (homepage theme grid + the removed /surface/* redirect stubs point at
+# /capabilities/#<theme>). With `--root-dir`, lychee resolves a *directory* link that carries a
+# fragment to the bare directory path (e.g. file://<out>/capabilities) and does NOT fall through to
+# that directory's index.html when locating the `#fragment` heading — so it reports "Cannot find
+# fragment" for EVERY such link. (Verified empirically against CI lychee 0.23.0.) The remap rewrites
+# a fragment-carrying DIRECTORY link to that directory's index.html for the fragment lookup:
+#   file://<out>/<dir-path>[/]#<frag> -> file://<out>/<dir-path>/index.html#<frag>
+# The final path segment is matched as `[^#/.]+` (no dot) so it targets ONLY directory links and
+# NEVER a same-page anchor, which lychee resolves against the CURRENT file as
+# file://<out>/<path>/index.html#<frag> — that already ends in `.html`, so the no-dot last-segment
+# guard leaves it untouched. (Pre-cutover the discriminator was the `/sparq/` prefix; at root the
+# no-extension last segment is the discriminator.) A trailing slash before the fragment is consumed
+# by the optional `/?` so both `/dir/#frag` and the slashless `/dir#frag` normalisation are covered.
 #
 # EXIT: non-zero iff lychee finds a broken internal link/anchor (CI-gating). A self-test of
 # the remap + teeth lives in scripts/tests/test_check_site_links.sh.
@@ -60,10 +57,12 @@ fi
 # Absolute path so the file:// remap patterns are unambiguous regardless of CWD.
 OUT_ABS="$(cd "$OUT_DIR" && pwd)"
 
-echo "check-site-links: lychee --offline over ${OUT_ABS}/**/*.html (basePath /sparq remapped)"
+echo "check-site-links: lychee --offline over ${OUT_ABS}/**/*.html (root-relative basePath, sq-uj38w)"
 
-# --root-dir lets lychee resolve absolute (/...) links against the export root; the two
-# --remap rules strip the /sparq Pages base path. `dev/` (the overlaid benchmark dashboard,
+# --root-dir lets lychee resolve absolute (/...) links against the export root. The single
+# --remap rewrites a fragment-carrying DIRECTORY link to that directory's index.html (see the
+# header — the no-dot last-segment `[^#/.]+` targets directory links only, never a same-page
+# anchor that already resolves to a `.html` file). `dev/` (the overlaid benchmark dashboard,
 # a separate first-party artifact written by bench.yml onto benchmark-data) is excluded:
 # it is not part of THIS site's source and carries its own link surface.
 lychee \
@@ -71,8 +70,6 @@ lychee \
   --include-fragments \
   --no-progress \
   --root-dir "$OUT_ABS" \
-  --remap "file://${OUT_ABS}/sparq/([^#]+)#(.+) file://${OUT_ABS}/\$1/index.html#\$2" \
-  --remap "file://${OUT_ABS}/sparq/(.*) file://${OUT_ABS}/\$1" \
-  --remap "file://${OUT_ABS}/sparq file://${OUT_ABS}/index.html" \
+  --remap "file://${OUT_ABS}/((?:[^#]*/)?[^#/.]+)/?#(.+) file://${OUT_ABS}/\$1/index.html#\$2" \
   --exclude-path "${OUT_ABS}/dev" \
   "${OUT_ABS}/**/*.html"

--- a/scripts/check-site-links.sh
+++ b/scripts/check-site-links.sh
@@ -59,17 +59,23 @@ OUT_ABS="$(cd "$OUT_DIR" && pwd)"
 
 echo "check-site-links: lychee --offline over ${OUT_ABS}/**/*.html (root-relative basePath, sq-uj38w)"
 
-# --root-dir lets lychee resolve absolute (/...) links against the export root. The single
-# --remap rewrites a fragment-carrying DIRECTORY link to that directory's index.html (see the
-# header — the no-dot last-segment `[^#/.]+` targets directory links only, never a same-page
-# anchor that already resolves to a `.html` file). `dev/` (the overlaid benchmark dashboard,
-# a separate first-party artifact written by bench.yml onto benchmark-data) is excluded:
-# it is not part of THIS site's source and carries its own link surface.
+# --root-dir lets lychee resolve absolute (/...) links against the export root. TWO --remap
+# rules cover the directory-with-fragment cases lychee can't resolve on its own:
+#   1. a SUB-DIRECTORY fragment link (/capabilities/#privacy) -> that dir's index.html. The no-dot
+#      last-segment `[^#/.]+` targets directory links only, never a same-page anchor (which lychee
+#      already resolves against the CURRENT `.html` file).
+#   2. the BARE-ROOT fragment link (/#how-it-runs — e.g. the /about RedirectStub back to the home
+#      page's #how-it-runs strip) -> the ROOT index.html. This is the root-basePath analogue of the
+#      old `/sparq` "rule 2"; without it lychee resolves `/` to the export dir and cannot find the
+#      fragment. `/?` makes it match both `/#frag` and the slashless `#frag` normalisation.
+# `dev/` (the overlaid benchmark dashboard, a separate first-party artifact written by bench.yml
+# onto benchmark-data) is excluded: it is not part of THIS site's source and carries its own links.
 lychee \
   --offline \
   --include-fragments \
   --no-progress \
   --root-dir "$OUT_ABS" \
   --remap "file://${OUT_ABS}/((?:[^#]*/)?[^#/.]+)/?#(.+) file://${OUT_ABS}/\$1/index.html#\$2" \
+  --remap "file://${OUT_ABS}/?#(.+) file://${OUT_ABS}/index.html#\$1" \
   --exclude-path "${OUT_ABS}/dev" \
   "${OUT_ABS}/**/*.html"

--- a/scripts/ec2-buildfarm.sh
+++ b/scripts/ec2-buildfarm.sh
@@ -73,7 +73,7 @@ MAX_LIFETIME_SEC="${BUILDFARM_MAX_LIFETIME_SEC:-7200}"
 MAX_FLEET="${BUILDFARM_MAX_FLEET:-12}"
 USE_SPOT="${BUILDFARM_SPOT:-1}"            # 1=spot (default, cheap), 0=on-demand
 DISK_GB="${BUILDFARM_DISK_GB:-40}"
-REPO="https://github.com/jeswr/sparq.git"
+REPO="https://github.com/sparq-org/sparq.git"
 
 # ---- tag + protected ids (mirror orphan-check-bench.sh's hard-exclusion discipline) ----
 readonly TAG_KEY="purpose"
@@ -106,10 +106,10 @@ resolve_ref() { # <token> -> prints a git ref (branch name or pull/<n>/head)
                 n="$t" ;;
     *)          printf '%s' "$t"; return 0 ;;     # a normal branch name
   esac
-  # PR form: ask gh for the head ref of PR #n in jeswr/sparq.
+  # PR form: ask gh for the head ref of PR #n in sparq-org/sparq.
   if command -v gh >/dev/null 2>&1; then
     local head
-    head="$(gh pr view "$n" --repo jeswr/sparq --json headRefName --jq .headRefName 2>/dev/null || true)"
+    head="$(gh pr view "$n" --repo sparq-org/sparq --json headRefName --jq .headRefName 2>/dev/null || true)"
     [ -n "$head" ] && { printf '%s' "$head"; return 0; }
   fi
   # Fallback: fetch the immutable pull/<n>/head ref directly (works without gh).

--- a/scripts/tests/test_check_site_links.sh
+++ b/scripts/tests/test_check_site_links.sh
@@ -61,6 +61,7 @@ HTML
 cat > "${GOOD}/about/index.html" <<'HTML'
 <!doctype html><html><head><title>about</title></head><body>
   <a href="/">home</a>
+  <a href="/#section-a">home · section a (BARE-ROOT fragment)</a>
   <a href="/surface/sparql/">sparql</a>
   <h2 id="section-b">Section B</h2>
 </body></html>
@@ -135,6 +136,27 @@ if bash "$GATE" "$XFRAG" >/tmp/site-links-xfrag.log 2>&1; then
   exit 1
 else
   echo "PASS: dangling cross-page fragment is caught (exit non-zero)"
+fi
+
+# --------------------------------------------------------------------------- #
+# Case 5 (should-FAIL): a dangling BARE-ROOT fragment must fail. [OPUS-4.8] sq-uj38w —
+# the bare-root remap (/#frag -> root index.html) is what makes the /about RedirectStub's
+# /#how-it-runs link resolve at the custom-domain root; this pins that it still has TEETH
+# (a fragment that does NOT exist on the home page is caught). Case 1's about page already
+# proves a VALID /#section-a bare-root fragment passes.
+# --------------------------------------------------------------------------- #
+ROOTFRAG="${TMP}/rootfrag"
+cp -r "$GOOD" "$ROOTFRAG"
+cat >> "${ROOTFRAG}/about/index.html" <<'HTML'
+<a href="/#no-such-home-anchor">dangling bare-root fragment</a>
+HTML
+
+if bash "$GATE" "$ROOTFRAG" >/tmp/site-links-rootfrag.log 2>&1; then
+  echo "FAIL: a dangling bare-root fragment was NOT caught (bare-root remap lost its teeth):"
+  sed 's/^/    /' /tmp/site-links-rootfrag.log
+  exit 1
+else
+  echo "PASS: dangling bare-root fragment is caught (exit non-zero)"
 fi
 
 echo "All check-site-links self-tests passed."

--- a/scripts/tests/test_check_site_links.sh
+++ b/scripts/tests/test_check_site_links.sh
@@ -5,14 +5,14 @@
 #
 # WHY: the gate's value rests on TWO load-bearing behaviours that are easy to break
 # silently when the export's basePath / link shape changes:
-#   1. CORRECTNESS — the `/sparq` GitHub-Pages base-path remap must resolve a normal
-#      internal link (/sparq/about/), the bare root link (/sparq/), an in-page #anchor,
+#   1. CORRECTNESS — the root-relative (custom-domain) base-path remap must resolve a normal
+#      internal link (/about/), the bare root link (/), an in-page #anchor,
 #      AND a relative sibling link to the right on-disk file, so a CLEAN export PASSES
 #      with NO false positives (a false positive would block every Pages deploy).
 #   2. TEETH — a genuinely broken internal link MUST fail the gate (exit non-zero), or
 #      the gate is decorative.
 # This harness pins both directions over a tiny synthetic export that mimics the real
-# Next.js static export (basePath:"/sparq", trailingSlash:true) — so a regression in the
+# Next.js static export (basePath:"" root-relative, trailingSlash:true) — so a regression in the
 # remap rules or the lychee invocation is caught here, before the gate guards a deploy.
 #
 # HERMETIC: builds its own throwaway export tree under a mktemp dir; no repo content, no
@@ -44,15 +44,15 @@ GOOD="${TMP}/good"
 mkdir -p "${GOOD}/about" "${GOOD}/surface/sparql"
 
 # Home page: links the bare root, a route, an anchor on this page, a relative sibling, AND a
-# CROSS-PAGE path+fragment link (/sparq/about/#section-b) — [OPUS-4.8] sq-bpoey: this is the
+# CROSS-PAGE path+fragment link (/about/#section-b) — [OPUS-4.8] sq-bpoey: this is the
 # shape the redesign's /capabilities/#<theme> anchors take, and the case the gate must resolve
 # to the target route's index.html (it reddened pages.yml after PR #1003 before rule 0 existed).
 cat > "${GOOD}/index.html" <<'HTML'
 <!doctype html><html><head><title>home</title></head><body>
-  <a href="/sparq/">root</a>
-  <a href="/sparq/about/">about</a>
-  <a href="/sparq/about/#section-b">about · section b (cross-page fragment)</a>
-  <a href="/sparq/surface/sparql/">sparql surface</a>
+  <a href="/">root</a>
+  <a href="/about/">about</a>
+  <a href="/about/#section-b">about · section b (cross-page fragment)</a>
+  <a href="/surface/sparql/">sparql surface</a>
   <a href="#section-a">jump</a>
   <h2 id="section-a">Section A</h2>
 </body></html>
@@ -60,15 +60,15 @@ HTML
 
 cat > "${GOOD}/about/index.html" <<'HTML'
 <!doctype html><html><head><title>about</title></head><body>
-  <a href="/sparq/">home</a>
-  <a href="/sparq/surface/sparql/">sparql</a>
+  <a href="/">home</a>
+  <a href="/surface/sparql/">sparql</a>
   <h2 id="section-b">Section B</h2>
 </body></html>
 HTML
 
 cat > "${GOOD}/surface/sparql/index.html" <<'HTML'
 <!doctype html><html><head><title>sparql</title></head><body>
-  <a href="/sparq/about/">about</a>
+  <a href="/about/">about</a>
 </body></html>
 HTML
 
@@ -76,7 +76,7 @@ HTML
 # Case 1 (should-PASS): the clean export must pass with no findings.
 # --------------------------------------------------------------------------- #
 if bash "$GATE" "$GOOD" >/tmp/site-links-good.log 2>&1; then
-  echo "PASS: clean export with /sparq base-path links passes"
+  echo "PASS: clean export with root-relative links passes"
 else
   echo "FAIL: clean export was rejected (false positive — remap likely broken):"
   sed 's/^/    /' /tmp/site-links-good.log
@@ -89,7 +89,7 @@ fi
 BAD="${TMP}/bad"
 cp -r "$GOOD" "$BAD"
 cat >> "${BAD}/index.html" <<'HTML'
-<a href="/sparq/this-route-does-not-exist/">dead</a>
+<a href="/this-route-does-not-exist/">dead</a>
 HTML
 
 if bash "$GATE" "$BAD" >/tmp/site-links-bad.log 2>&1; then
@@ -119,14 +119,14 @@ fi
 
 # --------------------------------------------------------------------------- #
 # Case 4 (should-FAIL): a dangling CROSS-PAGE fragment must fail. [OPUS-4.8] sq-bpoey —
-# rule 0 resolves /sparq/<route>#<frag> to <route>/index.html for the fragment lookup; this
+# rule 0 resolves /<route>#<frag> to <route>/index.html for the fragment lookup; this
 # pins that the resolution still has TEETH (a fragment that does not exist on the *target*
 # page is caught), not just that valid cross-page fragments pass (Case 1).
 # --------------------------------------------------------------------------- #
 XFRAG="${TMP}/xfrag"
 cp -r "$GOOD" "$XFRAG"
 cat >> "${XFRAG}/index.html" <<'HTML'
-<a href="/sparq/about/#no-such-section">dangling cross-page fragment</a>
+<a href="/about/#no-such-section">dangling cross-page fragment</a>
 HTML
 
 if bash "$GATE" "$XFRAG" >/tmp/site-links-xfrag.log 2>&1; then

--- a/site/README.md
+++ b/site/README.md
@@ -1,7 +1,7 @@
 # sparq feature-showcase site
 
 The live-interactive feature-demonstration website for sparq, served at
-**https://jeswr.github.io/sparq/**. A Next.js static export (`output: "export"`)
+**https://sparq.jeswr.org/**. A Next.js static export (`output: "export"`)
 styled as a sibling of [`jeswr/solid-pod-manager`](https://github.com/jeswr/solid-pod-manager):
 Tailwind v4 theme-in-CSS, the privacy-first teal OKLCH palette, shadcn (`radix-nova`),
 Inter, `--radius 0.7rem`. Design record: `research/feature-showcase-site-design.md`.
@@ -86,7 +86,7 @@ import line — the #981 lazy-load posture:
 
 ```html
 <script type="module">
-  import { Dataset, DataFactory as DF } from "https://jeswr.github.io/sparq/wasm/sparq.js";
+  import { Dataset, DataFactory as DF } from "https://sparq.jeswr.org/wasm/sparq.js";
   const ds = await Dataset.fromString('<a> <b> "x" .', "ntriples"); // wasm lazy-fetched HERE
   ds.add(DF.quad(DF.namedNode("a"), DF.namedNode("b"), DF.literal("y")));
   console.log(ds.size, ds.store.queryBoolean("ASK { ?s ?p ?o }"));
@@ -103,7 +103,7 @@ use; the ~MB `.wasm` is fetched lazily by that init, not by the script tag:
 ```html
 <script type="module">
   // basePath-aware: '/sparq/...' on GitHub Pages, '/...' under the Tauri webview root.
-  import init, { Store } from "https://jeswr.github.io/sparq/wasm/sparq_wasm.js";
+  import init, { Store } from "https://sparq.jeswr.org/wasm/sparq_wasm.js";
   await init(); // lazily fetches + instantiates sparq_wasm_bg.wasm (off the critical path)
   const store = Store.load("<a> <b> <c> .", "ntriples");
   console.log(store.query("SELECT * WHERE { ?s ?p ?o }"));
@@ -122,12 +122,14 @@ prefix stay in lockstep.
 
 | Host | Command | `basePath` | When |
 |---|---|---|---|
-| **GitHub Pages** (default) | `npm run build` | `/sparq` | served under `https://jeswr.github.io/sparq/` — every asset/route is `/sparq`-prefixed |
+| **GitHub Pages** @ custom-domain root (production) | `cross-env NEXT_PUBLIC_BASE_PATH= npm run build` (the Pages workflow sets `NEXT_PUBLIC_BASE_PATH=''`) | `''` (root-relative) | served at `https://sparq.jeswr.org/` (org-migration cutover, `sq-uj38w`) — every asset/route is root-relative (`/_next/…`) |
 | **Tauri 2 webview** | `npm run build:tauri` (= `cross-env NEXT_PUBLIC_BASE_PATH= npm run build`) | `''` (root-relative) | the desktop GUI serves the export from the `tauri://` root, where a `/sparq` prefix would 404 |
+| **Legacy sub-path** (fallback) | `npm run build` (no env) | `/sparq` | the historical `jeswr.github.io/sparq/` sub-path; kept only as the unset-env fallback, not used in production |
 
-The env var is read once in `next.config.ts`: **unset** keeps the historical `/sparq` default
-(no caller change); an explicit **empty string** selects the root-relative export; a malformed
-value falls back to the Pages default. The `build:tauri` script uses [`cross-env`](https://www.npmjs.com/package/cross-env)
+The env var is read once in `next.config.ts`: **unset** keeps the historical `/sparq` sub-path as a
+LEGACY fallback (no test/caller change); an explicit **empty string** selects the root-relative
+export used by BOTH production Pages (custom domain) and Tauri; a malformed value falls back to the
+legacy default. The `build:tauri` script uses [`cross-env`](https://www.npmjs.com/package/cross-env)
 (`cross-env NEXT_PUBLIC_BASE_PATH= npm run build`) so the env var is set to an **empty string**
 identically on Linux, macOS, and Windows `cmd.exe` — the bare `NEXT_PUBLIC_BASE_PATH='' npm run build`
 inline-prefix form is a Unix-shell idiom that `cmd.exe` cannot parse. The GUI's

--- a/site/next.config.ts
+++ b/site/next.config.ts
@@ -1,38 +1,39 @@
 import path from "node:path";
 import type { NextConfig } from "next";
 
-// [OPUS-4.8] sq-8thu — static-export config for GitHub Pages.
-// Pages serves this project site under https://jeswr.github.io/sparq/, so every
-// asset + route must be prefixed with `/sparq`. `output: "export"` writes a fully
-// static `out/` tree (no Node server) that the Pages deploy workflow uploads.
+// [OPUS-4.8] sq-8thu / sq-uj38w — static-export config for GitHub Pages.
+// Pages serves this project site at the ROOT of the custom domain https://sparq.jeswr.org/
+// (org-migration cutover, sq-uj38w), so the deployed build is ROOT-RELATIVE (basePath '',
+// no asset prefix). `output: "export"` writes a fully static `out/` tree (no Node server)
+// that the Pages deploy workflow uploads.
 //
-// [OPUS-4.8] sq-9vw5 — env-switch the base path so the SAME export tree serves TWO hosts:
+// [OPUS-4.8] sq-9vw5 — env-switch the base path so the SAME export tree serves multiple hosts:
 //
-//   * GitHub Pages (the default): served under `/sparq/`, so basePath/assetPrefix must be
-//     `/sparq`. This is what `npm run build` produces with no env set.
+//   * GitHub Pages @ the custom-domain root (production): the Pages workflow builds with
+//     `NEXT_PUBLIC_BASE_PATH=''` (see .github/workflows/pages.yml "Build static site"), so
+//     basePath/assetPrefix are unset and every asset/route is root-relative (`/_next/...`).
 //   * The Tauri 2 desktop webview: serves the frontend from the `tauri://` root (a local
-//     `frontendDist`), so EVERY asset must be ROOT-relative — a `/sparq` prefix 404s there.
+//     `frontendDist`), so EVERY asset must ALSO be ROOT-relative — a `/prefix` 404s there.
 //     The GUI's `gui/src-tauri/tauri.conf.json` `beforeBuildCommand` builds the site with
-//     `NEXT_PUBLIC_BASE_PATH=''`, so this config reads that env var and emits a root-relative
-//     export (`basePath: ''`, no asset prefix).
+//     `NEXT_PUBLIC_BASE_PATH=''` too, honoured by this same config.
 //
 // `NEXT_PUBLIC_BASE_PATH` is the single switch — and the `@sparq/client` wasm loader already
 // keys its RUNTIME asset URLs off the SAME env var, so the build-time route prefix and the
-// runtime wasm-fetch prefix stay in lockstep. Two build modes (also in site/README.md):
-//   * Pages :                      `npm run build`     -> basePath '/sparq'
-//   * Tauri : `NEXT_PUBLIC_BASE_PATH='' npm run build` -> basePath '' (root-relative)
+// runtime wasm-fetch prefix stay in lockstep. Build modes (also in site/README.md):
+//   * Pages / Tauri (root): `NEXT_PUBLIC_BASE_PATH='' npm run build` -> basePath '' (root-relative)
+//   * Legacy sub-path      : `npm run build` (no env)                -> basePath '/sparq' (fallback)
 //
-// An UNSET var keeps the historical `/sparq` default so the Pages build and every existing
-// caller are unchanged; an explicit empty string selects the root-relative (Tauri) export.
-// Next requires basePath to be empty or start with `/` (no trailing slash), so we honour only
-// `''` or a `/`-leading value and otherwise fall back to the Pages default.
+// An UNSET var keeps the historical `/sparq` sub-path as a LEGACY fallback (pre-cutover behaviour,
+// no test/caller change); production (Pages + Tauri) always sets an explicit empty string for the
+// root-relative export. Next requires basePath to be empty or start with `/` (no trailing slash),
+// so we honour only `''` or a `/`-leading value and otherwise fall back to the legacy default.
 const rawBasePath = process.env.NEXT_PUBLIC_BASE_PATH;
 const basePath =
   rawBasePath === undefined
-    ? "/sparq" // unset -> Pages default (historical behaviour, no caller change)
+    ? "/sparq" // unset -> legacy /sparq sub-path fallback (production sets '' for the custom-domain root)
     : rawBasePath === "" || rawBasePath.startsWith("/")
-      ? rawBasePath // '' (Tauri root-relative) or an explicit '/prefix'
-      : "/sparq"; // a malformed value falls back to the Pages default
+      ? rawBasePath // '' (root-relative: Pages custom domain + Tauri) or an explicit '/prefix'
+      : "/sparq"; // a malformed value falls back to the legacy default
 
 const nextConfig: NextConfig = {
   output: "export",

--- a/site/public/CNAME
+++ b/site/public/CNAME
@@ -1,0 +1,1 @@
+sparq.jeswr.org

--- a/site/scripts/bundle-wasm-esm.mjs
+++ b/site/scripts/bundle-wasm-esm.mjs
@@ -4,7 +4,7 @@
 // issue asked for works WITHOUT a third-party ESM CDN:
 //
 //     <script type="module">
-//       import { Dataset } from "https://jeswr.github.io/sparq/wasm/sparq.js";
+//       import { Dataset } from "https://sparq.jeswr.org/wasm/sparq.js";
 //       const ds = await Dataset.fromString('<a> <b> <c> .', 'ntriples'); // wasm lazy-fetched HERE
 //     </script>
 //
@@ -81,9 +81,9 @@ await build({
   banner: {
     js:
       "/* sparq — RDF/JS Dataset + SPARQL engine (Rust→WASM), self-hosted ESM build.\n" +
-      "   import { Dataset } from \"https://jeswr.github.io/sparq/wasm/sparq.js\"\n" +
+      "   import { Dataset } from \"https://sparq.jeswr.org/wasm/sparq.js\"\n" +
       "   The ~MB engine wasm is fetched lazily by the first `await Dataset.…`, not by this import.\n" +
-      "   Docs: https://jeswr.github.io/sparq/surface/javascript-wasm  •  npm: @jeswr/sparq */",
+      "   Docs: https://sparq.jeswr.org/surface/javascript-wasm  •  npm: @jeswr/sparq */",
   },
 });
 

--- a/site/src/app/app/page.tsx
+++ b/site/src/app/app/page.tsx
@@ -16,7 +16,7 @@ import {
 //
 // WHAT ACTUALLY SERVES /app IN PRODUCTION. The hosted web GUI is a SEPARATE Next.js app
 // (gui/app — a workbench, not this site) that the Pages deploy builds with `build:web` and
-// OVERLAYS at /sparq/app/, deliberately replacing this source page (pages.yml, sq-vnd0i /
+// OVERLAYS at /app/, deliberately replacing this source page (pages.yml, sq-vnd0i /
 // maintainer's Option B). So in the deployed site, /app IS the real hosted GUI.
 //
 // WHY THIS SOURCE STILL EXISTS. It is (1) the link-check target for the deploy's lychee pass,
@@ -30,7 +30,7 @@ import {
 export const metadata: Metadata = {
   title: "App — the sparq GUI",
   description:
-    "The sparq operational GUI — a workbench over a persistent local store, hosted in your browser at /sparq/app. Run a quick query in the live REPL, or install the desktop GUI.",
+    "The sparq operational GUI — a workbench over a persistent local store, hosted in your browser at /app. Run a quick query in the live REPL, or install the desktop GUI.",
 };
 
 export default function AppPage() {
@@ -49,7 +49,7 @@ export default function AppPage() {
             </p>
           </div>
         </div>
-        <Badge variant="success">Hosted web GUI — live at /sparq/app</Badge>
+        <Badge variant="success">Hosted web GUI — live at /app</Badge>
       </header>
 
       <Card>
@@ -64,7 +64,7 @@ export default function AppPage() {
             persuades and proves with live demos) and the GUI (a workbench you use
             to do real RDF/SPARQL work over your own data). The hosted,
             run-it-in-your-browser GUI is served here at{" "}
-            <code className="font-mono text-[0.9em]">/sparq/app/</code> — the same
+            <code className="font-mono text-[0.9em]">/app/</code> — the same
             Rust engine compiled to wasm, nothing sent to a server. Want a quick
             query without leaving this tab, or a native build with no wasm ceiling?
             Both paths are below.

--- a/site/src/app/gui/page.tsx
+++ b/site/src/app/gui/page.tsx
@@ -6,9 +6,9 @@ import type { Metadata } from "next";
 // CLIENT REDIRECT STUB that keeps the old /gui path alive — inbound links land on /app.
 //
 // [OPUS-4.8] sq-vw3ax.11 — /app is served by a SEPARATE Next.js app (gui/app, overlaid at
-// /sparq/app/ by pages.yml, sq-vnd0i), so this must be a HARD (full-page) redirect: a router
+// /app/ by pages.yml, sq-vnd0i), so this must be a HARD (full-page) redirect: a router
 // soft `replace` across two distinct Next builds fetches the foreign RSC payload
-// (/sparq/app/index.txt) and lands on a raw .txt instead of the GUI. `hard` forces window.location.
+// (/app/index.txt) and lands on a raw .txt instead of the GUI. `hard` forces window.location.
 import { RedirectStub } from "@/components/redirect-stub";
 
 export const metadata: Metadata = {

--- a/site/src/app/surface/javascript-wasm/esm-import-snippet.tsx
+++ b/site/src/app/surface/javascript-wasm/esm-import-snippet.tsx
@@ -5,7 +5,7 @@
 // literal snippet shape the maintainer's issue asked for.
 //
 // [OPUS-4.8] sq-55w5a (#981) — the PRIMARY recipe now imports from the project's OWN GitHub
-// Pages origin (`https://jeswr.github.io/sparq/wasm/sparq.js`), a SELF-HOSTED single-file ESM
+// Pages origin (`https://sparq.jeswr.org/wasm/sparq.js`), a SELF-HOSTED single-file ESM
 // bundle (built by site/scripts/bundle-wasm-esm.mjs, published into the static export). So the
 // named `Dataset` import works with zero dependency on a third-party CDN — the ~MB engine wasm
 // is still fetched lazily by the first `await Dataset.…` (the bundle keeps the binary external).
@@ -25,7 +25,7 @@ const SNIPPET = `<script type="module">
   // Self-hosted: this project's OWN GitHub Pages origin — no third-party CDN. The
   // ~MB engine wasm is fetched LAZILY by the first \`await Dataset.fromString(...)\`
   // below — NOT by this import line — so it never blocks the page paint.
-  import { Dataset, DataFactory as DF } from "https://jeswr.github.io/sparq/wasm/sparq.js";
+  import { Dataset, DataFactory as DF } from "https://sparq.jeswr.org/wasm/sparq.js";
 
   const ds = await Dataset.fromString(
     '<http://ex/a> <http://ex/name> "Alice" .',
@@ -52,7 +52,7 @@ const CDN_SNIPPET = `<script type="module">
 
 const GLUE_SNIPPET = `<script type="module">
   // Low-level: the wasm-pack \`--target web\` glue is itself a real ESM module.
-  import init, { Store } from "https://jeswr.github.io/sparq/wasm/sparq_wasm.js";
+  import init, { Store } from "https://sparq.jeswr.org/wasm/sparq_wasm.js";
   await init(); // lazily fetches + instantiates sparq_wasm_bg.wasm
   const store = Store.load("<a> <b> <c> .", "ntriples");
 </script>`;

--- a/site/src/components/layout/app-shell.tsx
+++ b/site/src/components/layout/app-shell.tsx
@@ -12,13 +12,13 @@
 // OPTION-B (the maintainer's decision after #1004 opened, sq-rclb8 / sq-vnd0i). Two DISTINCT
 // destinations, not one "Try the GUI": "Try" → /try is the lightweight in-browser SPARQL REPL
 // playground (kept unchanged); "App" → /app is the LIVE operational GUI. That GUI is a SEPARATE
-// Next.js app (gui/app), overlaid at /sparq/app/ by the Pages deploy (pages.yml) — it is NOT a
+// Next.js app (gui/app), overlaid at /app/ by the Pages deploy (pages.yml) — it is NOT a
 // route of this site. The old single "Try the GUI" → /gui slot is dropped (/gui now redirects to
 // /app).
 //
 // [OPUS-4.8] sq-vw3ax.11 — the "App" slot is therefore a HARD (full-page) link, not a next/link
 // soft navigation: soft-navigating across two distinct Next builds fetches the WRONG app's RSC
-// Flight payload (/sparq/app/index.txt) and lands on a raw .txt instead of the GUI. See NavLink.
+// Flight payload (/app/index.txt) and lands on a raw .txt instead of the GUI. See NavLink.
 //
 // Destinations (research §2 + the maintainer's discoverability gaps), slim at 6:
 //   Home · Capabilities · Try · App · Benchmarks · Download
@@ -59,7 +59,7 @@ const REPO_URL = "https://github.com/jeswr/sparq";
 // maintainer's discoverability ask). Each is a real, built route. Papers is intentionally NOT in
 // the bar (it stays a route, reachable via Cmd-K) so the bar stays slim at 6, not bloated.
 // `external: true` marks a destination that is served by a SEPARATE deployed app at the same
-// origin (here: /app = the gui/app workbench overlaid at /sparq/app/). Such a slot must be a hard,
+// origin (here: /app = the gui/app workbench overlaid at /app/). Such a slot must be a hard,
 // full-page navigation — see NavLink — not a next/link soft nav (sq-vw3ax.11).
 const NAV_ITEMS: { href: string; label: string; external?: boolean }[] = [
   { href: "/", label: "Home" },
@@ -97,9 +97,9 @@ function NavLink({
   );
 
   // [OPUS-4.8] sq-vw3ax.11 — an `external` destination (e.g. /app) is served in production by a
-  // DIFFERENT Next.js app overlaid at /sparq/app/ (gui/app, sq-vnd0i), so it must be a hard,
+  // DIFFERENT Next.js app overlaid at /app/ (gui/app, sq-vnd0i), so it must be a hard,
   // full-page navigation. A next/link soft nav across two distinct Next builds would fetch the
-  // foreign RSC Flight payload (/sparq/app/index.txt) and render a raw .txt instead of the GUI —
+  // foreign RSC Flight payload (/app/index.txt) and render a raw .txt instead of the GUI —
   // exactly the bug this fixes. withBasePath prefixes the hand-written absolute href for the
   // /sparq (Pages) vs "" (Tauri) hosts — Next does NOT auto-prefix a plain <a>. The trailing
   // slash matches `trailingSlash: true` so the static export's directory index resolves.

--- a/site/src/components/redirect-stub.tsx
+++ b/site/src/components/redirect-stub.tsx
@@ -33,8 +33,8 @@ export function RedirectStub({
   /**
    * [OPUS-4.8] sq-vw3ax.11 — force a HARD (full-page) redirect via `window.location` instead of a
    * next/router soft `replace`. Required when `to` is served by a SEPARATE Next.js app at the same
-   * origin (e.g. /app = the gui/app workbench overlaid at /sparq/app/): a soft nav across two
-   * distinct Next builds fetches the foreign RSC Flight payload (/sparq/app/index.txt) and lands
+   * origin (e.g. /app = the gui/app workbench overlaid at /app/): a soft nav across two
+   * distinct Next builds fetches the foreign RSC Flight payload (/app/index.txt) and lands
    * on a raw .txt instead of the destination app. Same-site removed routes (the /surface/* and
    * /about stubs) stay a soft `replace` and pass `hard` falsy.
    */


### PR DESCRIPTION
> 🤖 **SPARQ agent** — org-migration Pages cutover (bead **sq-uj38w**). NOT armed; the maintainer verifies + arms into the merge queue.

Cuts the site over from `sparq-org.github.io/sparq/` (basePath `/sparq`) to the custom domain **`https://sparq.jeswr.org/` served at ROOT** (basePath `''`). DNS is already live (`sparq.jeswr.org` CNAME → `sparq-org.github.io`).

## Atomic flip (the critical constraint)
basePath **and** the custom domain change in the **same deploy** — if only one flips, every asset/route URL breaks. This one PR does both, and the deploy flips them together:
- **basePath → root:** `pages.yml` "Build static site" now sets `NEXT_PUBLIC_BASE_PATH=''` → root-relative export (`/_next/…`, not `/sparq/_next/…`). `next.config.ts` already honours `''` (it's the proven Tauri production path); the deploy sets it explicitly.
- **CNAME:** `site/public/CNAME` = `sparq.jeswr.org`; Next copies `public/` → the export root, so `out/CNAME` sets the custom domain on deploy. A new smoke-check step **hard-fails the build unless `out/CNAME` is exactly `sparq.jeswr.org`**, so the flip can't deploy without the custom domain.

## What changed
- **Hosted GUI re-homed `/sparq/app` → `/app`** (same single Pages artifact): `gui/app` default basePath is now `/app`; the site "App" nav (`withBasePath('/app/')`) tracks the root basePath; the `pages.yml` overlay assertion checks `/app/_next/`.
- **URL sweep (~65 refs):** `jeswr.github.io/sparq` → `sparq.jeswr.org` across README / docs / site / crate-READMEs / workflows / the WASM ESM snippet / GUI top-bar — dropping the `/sparq` path (custom domain serves at root). The dated `docs/pages-cutover-runbook.md` (a timestamped live-probe record of a *different* branch→Actions cutover) and the beads DB were left intact.
- **Link-check remap reworked for the root basePath** (`scripts/check-site-links.sh`): the old `/sparq` prefix-strip rules are gone; a dir-fragment rule (no-dot last-segment discriminator) plus a bare-root-fragment rule replace them. Self-test grows to 5 cases (clean passes; broken link / dangling anchor / dangling cross-page fragment / dangling bare-root fragment all caught).
- **Surgical repo-slug fixes** (`jeswr/sparq` → `sparq-org/sparq`) ONLY where GitHub's redirect doesn't help: the `github.repository == '…'` guards in `release-plz.yml` + `bench-ec2.yml` (else those workflows silently skip on the new repo), the live `gh --repo` call + clone URL in `scripts/ec2-buildfarm.sh`, and the canonical `Cargo.toml` `repository`/`homepage`. Prose / comments / compliance-evidence / changelog / test-fixture slug refs were **left** (redirects cover them).

## Verification
- `NEXT_PUBLIC_BASE_PATH='' next build` **succeeds**; `out/index.html` has 22 `/_next/` and **0** `/sparq/_next/`; **0** `/sparq/` absolute paths anywhere in the export; `out/CNAME = sparq.jeswr.org`.
- `check-site-links.sh` over the real root-relative export: **0** real link/anchor errors (the only errors are the Typst-prebuilt spec PDFs, absent solely because the scoped verification skipped `prebuild`; CI runs `prebuild` before the check). The `/#how-it-runs` bare-root fragment resolves.
- Site unit tests 293/293 · site `next lint` clean · `gui/app` typecheck + lint clean · no-perf-numbers 0 findings · readme-template 0 deviations · all edited workflow YAML valid · **no `uses:` lines touched (all action SHA-pins intact)**.

*Worked in an isolated git worktree — a parallel agent's `git reset` on the shared checkout kept wiping uncommitted edits.*