### PR TITLE
test(canon): raise coverage floor 77->93 + honest mutation ceiling (sq-qcnn.14) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2183,6 +2183,14 @@ jobs:
             features: mmap,dict-spill
           - crate: sparq-substrate
             features: numeric,join,compare,rows
+          # [OPUS-4.8] sq-qcnn.14: sparq-canon QUIRK — the `rdf12-triple-terms` feature
+          # gates rdf12.rs (the NON-STANDARD RDF-1.2 triple-term profile). Without it,
+          # cargo-mutants mutates rdf12.rs but the tests never compile that module, so all
+          # rdf12.rs mutations are trivially "missed" (not CAUGHT but also not from a test
+          # gap — just non-compiled code). Enabling the feature exposes the full crate
+          # surface (lib.rs + rdf12.rs) to mutation, making the ceiling honest.
+          - crate: sparq-canon
+            features: rdf12-triple-terms
     concurrency:
       # [OPUS-4.8] sq-qcnn.11: per-crate + per-ref concurrency key ("its own concurrency keys")
       # with cancel-in-progress:false so an overlapping run (e.g. a manual workflow_dispatch

--- a/bench/coverage-floor.json
+++ b/bench/coverage-floor.json
@@ -12,8 +12,8 @@
       "note": "[OPUS-4.8] sq-bif.8: OPT-IN graph analytics (PageRank / degree centrality / WCC + label-propagation communities). Standalone crate (`default = []`, no opt-in features) measured with default features \u2014 its whole surface compiles in a default build. Measured line% 99.14 (575/580) over the inline src oracles + the new tests/topology_oracles.rs (dangling-node PageRank, disconnected/chain WCC+LP, all-singleton communities, NodeFilter::All literal path); floor = floor(measured) - 2 margin. Conservative work-box seed; CI's --check-robust is the ratchet of record."
     },
     "sparq-canon": {
-      "floor": 77,
-      "note": "[OPUS-4.8] sq-bif.9: OPT-IN RDFC-1.0 (RDF Dataset Canonicalization) public API. Standalone crate (no `[features]` table) measured with default features. Measured line% 79.04 (181/229) over tests/rdf_canon_suite.rs (full 86-entry W3C manifest: eval + issued-id map + negative poison-graph) + the new tests/bnode_isomorphism_and_bridge.rs (bnode-isomorphism equivalence, oxrdf-bridge triple-term/Display/literal-roundtrip edge paths); floor = floor(measured) - 2 margin. Conservative work-box seed; CI is the ratchet of record."
+      "floor": 93,
+      "note": "[OPUS-4.8] sq-qcnn.14: RDFC-1.0 / RDF Dataset Canonicalization crate. Measured with DEFAULT features (lib.rs public API surface: parse_nquads, issue_quads_with, canonicalize_quads_with, issue_triples, graph_triples, canonicalize_graph_content + helpers). sq-qcnn.14 added DIRECT, EXACT-VALUE unit tests over all previously-uncovered public functions and integration tests in tests/rdf12_triple_term_canon.rs covering the rdf12-triple-terms profile (canonicalize_graph_content_rdf12, canonicalize_graph_content_rdf12_with::<Sha384>, empty graph). Lifted measured line% 79.04 -> 95.03; floor = floor(measured) - 2 margin = 93. Conservative work-box seed; CI's --check-robust is the ratchet of record. The rdf12.rs module is gated behind the `rdf12-triple-terms` cargo feature and is measured separately under the nightly mutation lane (see bench/mutants-baseline.json sparq-canon entry)."
     },
     "sparq-cli": {
       "floor": 0,

--- a/bench/mutants-baseline.json
+++ b/bench/mutants-baseline.json
@@ -17,12 +17,13 @@
       "unviable": 3
     },
     "sparq-canon": {
-      "caught": 28,
-      "caught_pct": 80.0,
-      "ceiling": 9,
-      "measured_surviving": 7,
+      "_note": "[OPUS-4.8] sq-qcnn.14: measured with --features rdf12-triple-terms (the rdf12.rs NON-STANDARD RDF-1.2 triple-term profile is gated behind this feature; without it, cargo-mutants generates rdf12.rs mutations but they are trivially missed because the module is not compiled). 4 surviving mutations are all comparison-operator variants in CanonState::hash_n_degree_quads path-pruning logic (lines 429, 430, 448, 459) — a hard-to-distinguish HNDQ optimization boundary guard.",
+      "caught": 104,
+      "caught_pct": 96.3,
+      "ceiling": 6,
+      "measured_surviving": 4,
       "timeout": 0,
-      "unviable": 8
+      "unviable": 32
     },
     "sparq-introspect": {
       "caught": 179,

--- a/crates/sparq-canon/src/lib.rs
+++ b/crates/sparq-canon/src/lib.rs
@@ -419,6 +419,209 @@ mod tests {
         NamedNode::new(s).unwrap()
     }
 
+    // [OPUS-4.8] sq-qcnn.14 — direct unit tests per public fn, asserting exact values.
+    // One test per uncovered public fn; each assert is non-vacuous (flip a value → red).
+
+    /// Direct test for `parse_nquads` (public wrapper). Asserts exact quad content,
+    /// killing "return empty vec" / "skip error propagation" mutation classes.
+    #[test]
+    fn parse_nquads_exact_content() {
+        let doc = "<http://ex/s> <http://ex/p> \"hello\" .\n";
+        let quads = parse_nquads(doc).unwrap();
+        assert_eq!(quads.len(), 1, "one line -> one quad");
+        assert_eq!(quads[0].subject.to_string(), "<http://ex/s>");
+        assert_eq!(quads[0].predicate.to_string(), "<http://ex/p>");
+        assert_eq!(quads[0].object.to_string(), "\"hello\"");
+        // Multiple quads: ensure each is returned.
+        let two = "<http://ex/s> <http://ex/p> <http://ex/a> .\n\
+                   <http://ex/s> <http://ex/q> <http://ex/b> .\n";
+        assert_eq!(parse_nquads(two).unwrap().len(), 2, "two lines -> two quads");
+    }
+
+    /// `parse_nquads` error path: malformed N-Quads must return `CanonError::Bridge`,
+    /// not silently succeed. Kills the "always return Ok" mutation.
+    #[test]
+    fn parse_nquads_rejects_malformed() {
+        let result = parse_nquads("not n-quads !!!\n");
+        assert!(
+            matches!(result, Err(CanonError::Bridge(_))),
+            "malformed input must return Bridge error, got: {:?}",
+            result
+        );
+    }
+
+    /// Direct test for `issue_quads_with` (hash-generic issuer, SHA-384 profile).
+    /// Asserts the EXACT issued label: "c14n0" for a single bnode. Kills mutations
+    /// that change the prefix, omit the counter, or skip inserting into the map.
+    #[test]
+    fn issue_quads_with_sha384_exact_label() {
+        use sha2::Sha384;
+        let q = Quad::new(
+            NamedOrBlankNode::BlankNode(BlankNode::new("b0").unwrap()),
+            iri("http://ex/p"),
+            Term::Literal(Literal::new_simple_literal("val")),
+            GraphName::DefaultGraph,
+        );
+        let map = issue_quads_with::<Sha384>(&[q]).unwrap();
+        assert_eq!(map.len(), 1, "one bnode -> one issued id");
+        assert_eq!(
+            map.get("b0").map(String::as_str),
+            Some("c14n0"),
+            "single bnode must issue as c14n0 under SHA-384: {map:?}"
+        );
+    }
+
+    /// Direct test for `canonicalize_quads_with` (hash-generic, SHA-384 profile).
+    /// Asserts exact structural properties so mutations to the format string or
+    /// the hash dispatch are killed.
+    #[test]
+    fn canonicalize_quads_with_sha384_canonical_form() {
+        use sha2::Sha384;
+        let q = Quad::new(
+            NamedOrBlankNode::BlankNode(BlankNode::new("b0").unwrap()),
+            iri("http://ex/p"),
+            Term::Literal(Literal::new_simple_literal("val")),
+            GraphName::DefaultGraph,
+        );
+        let canon = canonicalize_quads_with::<Sha384>(&[q]).unwrap();
+        assert!(
+            canon.contains("_:c14n0"),
+            "bnode must be relabelled to c14n0: {canon:?}"
+        );
+        assert!(
+            canon.contains("<http://ex/p>"),
+            "predicate must appear in canonical output: {canon:?}"
+        );
+        assert!(
+            canon.ends_with('\n'),
+            "canonical doc must end with newline: {canon:?}"
+        );
+        // Isomorphism: relabelling the bnode gives byte-identical output.
+        let q2 = Quad::new(
+            NamedOrBlankNode::BlankNode(BlankNode::new("other").unwrap()),
+            iri("http://ex/p"),
+            Term::Literal(Literal::new_simple_literal("val")),
+            GraphName::DefaultGraph,
+        );
+        assert_eq!(
+            canon,
+            canonicalize_quads_with::<Sha384>(&[q2]).unwrap(),
+            "isomorphic datasets must agree under SHA-384"
+        );
+    }
+
+    /// Direct test for `issue_triples` (single-graph, SHA-256 issuer map).
+    /// Asserts the EXACT issued label "c14n0". Kills bnode-label prefix mutations.
+    #[test]
+    fn issue_triples_exact_label() {
+        let t = Triple::new(
+            NamedOrBlankNode::BlankNode(BlankNode::new("x").unwrap()),
+            iri("http://ex/p"),
+            Term::Literal(Literal::new_simple_literal("v")),
+        );
+        let map = issue_triples(&[t]).unwrap();
+        assert_eq!(map.len(), 1, "one bnode -> one issued id");
+        assert_eq!(
+            map.get("x").map(String::as_str),
+            Some("c14n0"),
+            "single bnode must issue as c14n0: {map:?}"
+        );
+    }
+
+    /// `issue_triples` must reject triple-term objects (same guard as `canonicalize_triples`).
+    /// Kills the "skip the triple-term check" mutation class.
+    #[test]
+    fn issue_triples_rejects_triple_terms() {
+        let inner = Triple::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+            iri("http://ex/p"),
+            Term::Literal(Literal::new_simple_literal("v")),
+        );
+        let t = Triple::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+            iri("http://ex/asserts"),
+            Term::Triple(Box::new(inner)),
+        );
+        assert!(
+            matches!(issue_triples(&[t]), Err(CanonError::TripleTerm)),
+            "`issue_triples` must fail closed on triple-term objects"
+        );
+    }
+
+    /// Direct test for `graph_triples` — materializes a `sparq_core::Graph`'s triples
+    /// as oxrdf Terms, asserting EXACT count + each term. Kills "return empty vec" and
+    /// "skip one term" mutation classes.
+    #[test]
+    fn graph_triples_materializes_exact_terms() {
+        use sparq_core::Graph;
+        let g = Graph::load_str(
+            "<http://ex/s> <http://ex/p> <http://ex/o> .\n",
+            "ntriples",
+        )
+        .expect("load_str");
+        let triples = graph_triples(&g).unwrap();
+        assert_eq!(triples.len(), 1, "one stored triple -> one materialized triple");
+        let t = &triples[0];
+        assert_eq!(t.subject.to_string(), "<http://ex/s>", "subject preserved");
+        assert_eq!(t.predicate.to_string(), "<http://ex/p>", "predicate preserved");
+        assert_eq!(t.object.to_string(), "<http://ex/o>", "object preserved");
+    }
+
+    /// Direct test for `canonicalize_graph_content` — the ZK pipeline's per-graph entry
+    /// point over a `sparq_core::Graph`. Asserts bnode relabelling and exact line count,
+    /// so mutations to the bnode-relabelling logic or the graph→triples extraction are killed.
+    #[test]
+    fn canonicalize_graph_content_relabels_bnode() {
+        use sparq_core::Graph;
+        let g = Graph::load_str(
+            "_:b0 <http://ex/p> <http://ex/o> .\n",
+            "ntriples",
+        )
+        .expect("load_str");
+        let c = canonicalize_graph_content(&g).unwrap();
+        assert_eq!(c.lines.len(), 1, "one stored triple -> one canonical line");
+        assert!(
+            c.lines[0].contains("_:c14n0"),
+            "bnode must be relabelled to c14n0: {:?}",
+            c.lines[0]
+        );
+        assert!(
+            c.lines[0].contains("<http://ex/p>"),
+            "predicate must be preserved: {:?}",
+            c.lines[0]
+        );
+        // The `triples` slice must match the canonical line (re-parsed canonical triple).
+        assert_eq!(c.triples.len(), 1, "one line -> one canonical triple");
+    }
+
+    /// `to_nquads` on a multi-triple graph must join ALL lines, each newline-terminated.
+    /// Kills mutations that omit `push('\n')`, or return only the first line.
+    #[test]
+    fn to_nquads_multi_line_joins_all_lines() {
+        let b1 = BlankNode::new("x").unwrap();
+        let b2 = BlankNode::new("y").unwrap();
+        let t1 = Triple::new(
+            NamedOrBlankNode::BlankNode(b1),
+            iri("http://ex/p"),
+            Term::BlankNode(b2.clone()),
+        );
+        let t2 = Triple::new(
+            NamedOrBlankNode::BlankNode(b2),
+            iri("http://ex/q"),
+            Term::Literal(Literal::new_simple_literal("leaf")),
+        );
+        let c = canonicalize_triples(&[t1, t2]).unwrap();
+        assert_eq!(c.lines.len(), 2, "two triples -> two canonical lines");
+        let doc = c.to_nquads();
+        let expected = format!("{}\n{}\n", c.lines[0], c.lines[1]);
+        assert_eq!(doc, expected, "to_nquads must join all lines with newlines");
+        // Each line must appear in order and be newline-terminated.
+        let parts: Vec<&str> = doc.lines().collect();
+        assert_eq!(parts.len(), 2, "two lines in doc");
+        assert_eq!(parts[0], c.lines[0]);
+        assert_eq!(parts[1], c.lines[1]);
+    }
+
     #[test]
     fn canonical_labels_and_order() {
         let b1 = BlankNode::new("zzz").unwrap();

--- a/crates/sparq-canon/src/rdf12.rs
+++ b/crates/sparq-canon/src/rdf12.rs
@@ -769,3 +769,498 @@ fn permutations(items: &[String]) -> Vec<Vec<String>> {
     }
     out
 }
+
+// ---------------------------------------------------------------------------
+// [OPUS-4.8] sq-qcnn.14 — direct unit tests for PRIVATE helper functions in
+// rdf12.rs. These kill mutation survivors that the external functional tests
+// cannot see (the external tests verify final canonical OUTPUT; internal
+// mutations that produce the same output via different intermediate steps
+// survive unless the intermediates themselves are asserted on here).
+// ---------------------------------------------------------------------------
+#[cfg(test)]
+mod private_tests {
+    use super::*;
+    use oxrdf::{BlankNode, GraphName, Literal, NamedNode, NamedOrBlankNode, Term, Triple};
+
+    fn iri(s: &str) -> NamedNode {
+        NamedNode::new(s).unwrap()
+    }
+    fn bn(s: &str) -> BlankNode {
+        BlankNode::new(s).unwrap()
+    }
+
+    // ---- special_label ----
+
+    /// `special_label(label, reference)` must return `"a"` when label == reference
+    /// and `"z"` otherwise. Kills the `== with !=` comparison mutation (line 609).
+    #[test]
+    fn special_label_reference_becomes_a() {
+        let label = special_label("x", "x");
+        assert_eq!(
+            label.as_str(),
+            "a",
+            "the reference bnode must receive the 'a' special label"
+        );
+    }
+
+    #[test]
+    fn special_label_other_becomes_z() {
+        let label = special_label("y", "x");
+        assert_eq!(
+            label.as_str(),
+            "z",
+            "any non-reference bnode must receive the 'z' special label"
+        );
+    }
+
+    // ---- push_unique ----
+
+    /// `push_unique` must NOT add a label that is already in the list.
+    /// Kills the `delete !` mutation (line 546) that would always push.
+    #[test]
+    fn push_unique_does_not_add_duplicates() {
+        let mut labels: Vec<String> = vec!["a".to_string()];
+        push_unique(&mut labels, "a");
+        assert_eq!(labels.len(), 1, "duplicate must not be added: {labels:?}");
+    }
+
+    #[test]
+    fn push_unique_adds_new_label() {
+        let mut labels: Vec<String> = vec!["a".to_string()];
+        push_unique(&mut labels, "b");
+        assert_eq!(labels.len(), 2);
+        assert_eq!(labels[1], "b");
+    }
+
+    // ---- collect_bnodes_term ----
+
+    /// A `Term::BlankNode` must be collected. Kills `delete match arm
+    /// Term::BlankNode(b)` (line 559).
+    #[test]
+    fn collect_bnodes_term_collects_blank_node() {
+        let mut out: Vec<String> = Vec::new();
+        collect_bnodes_term(&Term::BlankNode(bn("myb")), &mut out);
+        assert_eq!(out, vec!["myb".to_string()]);
+    }
+
+    /// A `Term::Triple` must recurse into subject and object to collect nested
+    /// bnodes. Kills `delete match arm Term::Triple(t)` (line 560).
+    #[test]
+    fn collect_bnodes_term_recurses_into_triple_term() {
+        let inner_bnode = Term::BlankNode(bn("inner"));
+        let tt = Term::Triple(Box::new(Triple::new(
+            NamedOrBlankNode::BlankNode(bn("subj")),
+            iri("http://ex/p"),
+            inner_bnode,
+        )));
+        let mut out: Vec<String> = Vec::new();
+        collect_bnodes_term(&tt, &mut out);
+        // Both the subject bnode and the inner object bnode must be collected.
+        assert!(out.contains(&"subj".to_string()), "subject bnode in triple term: {out:?}");
+        assert!(out.contains(&"inner".to_string()), "object bnode in triple term: {out:?}");
+        assert_eq!(out.len(), 2, "exactly two bnodes: {out:?}");
+    }
+
+    /// A `Term::NamedNode` must NOT contribute any bnodes.
+    #[test]
+    fn collect_bnodes_term_ignores_iri() {
+        let mut out: Vec<String> = Vec::new();
+        collect_bnodes_term(&Term::NamedNode(iri("http://ex/n")), &mut out);
+        assert!(out.is_empty(), "IRI must not contribute a bnode: {out:?}");
+    }
+
+    // ---- collect_bnodes_subject ----
+
+    #[test]
+    fn collect_bnodes_subject_collects_blank_node() {
+        let mut out: Vec<String> = Vec::new();
+        collect_bnodes_subject(&NamedOrBlankNode::BlankNode(bn("s")), &mut out);
+        assert_eq!(out, vec!["s".to_string()]);
+    }
+
+    #[test]
+    fn collect_bnodes_subject_ignores_named_node() {
+        let mut out: Vec<String> = Vec::new();
+        collect_bnodes_subject(&NamedOrBlankNode::NamedNode(iri("http://ex/s")), &mut out);
+        assert!(out.is_empty());
+    }
+
+    // ---- HndqCallCounter ----
+
+    /// `add` must increment the counter and return `Ok(())` until the limit, then
+    /// return an error. Kills `replace += with -=` (line 529) and `replace add
+    /// with Ok(())` (line 529 / replace fn).
+    #[test]
+    fn hndq_call_counter_increments_and_fails_at_limit() {
+        let mut c = HndqCallCounter::new(2);
+        assert!(c.add().is_ok(), "first call must succeed");
+        assert!(c.add().is_ok(), "second call (at limit) must succeed");
+        assert!(c.add().is_err(), "third call (over limit) must fail");
+    }
+
+    // ---- IdentifierIssuer ----
+
+    /// `get` must return `None` for an unlabelled node and `Some(...)` for an
+    /// issued one. Kills `replace get with None` (line 227) and
+    /// `replace get with Some(String::new())` (line 227).
+    #[test]
+    fn identifier_issuer_get_returns_none_for_unlabelled() {
+        let issuer = IdentifierIssuer::new("c14n");
+        assert_eq!(issuer.get("x"), None);
+    }
+
+    #[test]
+    fn identifier_issuer_get_returns_issued_label() {
+        let mut issuer = IdentifierIssuer::new("c14n");
+        let issued = issuer.issue("x");
+        assert_eq!(issuer.get("x"), Some(issued.clone()));
+        assert_eq!(issued, "c14n0");
+    }
+
+    /// `issue` must return incrementing labels `c14n0`, `c14n1`, ... and be
+    /// idempotent (re-issuing the same label returns the same value).
+    /// Kills `replace issue with String::new()` (line 232).
+    #[test]
+    fn identifier_issuer_issues_sequential_labels() {
+        let mut issuer = IdentifierIssuer::new("c14n");
+        assert_eq!(issuer.issue("a"), "c14n0");
+        assert_eq!(issuer.issue("b"), "c14n1");
+        assert_eq!(issuer.issue("c"), "c14n2");
+        // Idempotent: re-issuing returns the SAME label, counter does not advance.
+        assert_eq!(issuer.issue("a"), "c14n0", "re-issue must be idempotent");
+        assert_eq!(issuer.issue("d"), "c14n3", "counter must not advance on re-issue");
+    }
+
+    // ---- hash_hex ----
+
+    /// `hash_hex::<Sha256>` must produce the EXACT lowercase hex of the SHA-256
+    /// digest. Kills format-string mutations (e.g. `{:02x}` → `{:02X}` or `{}`).
+    #[test]
+    fn hash_hex_sha256_known_value() {
+        use sha2::Sha256;
+        // SHA-256("") is a well-known constant; must be exact + lowercase + 64 chars.
+        let hex = hash_hex::<Sha256>(b"");
+        assert_eq!(
+            hex,
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            "hash_hex must produce lowercase hex of SHA-256"
+        );
+        assert_eq!(hex.len(), 64, "SHA-256 hex must be 64 chars");
+        // A non-empty input must differ from the empty-string digest (not hardcoded).
+        let hex2 = hash_hex::<Sha256>(b"abc");
+        assert_ne!(hex, hex2, "different inputs must produce different hashes");
+        assert_eq!(hex2.len(), 64, "SHA-256 hex must be 64 chars");
+        // Must be all-lowercase hex (no uppercase A-F).
+        assert!(
+            hex.chars().all(|c| c.is_ascii_digit() || ('a'..='f').contains(&c)),
+            "hash_hex must be lowercase hex: {hex}"
+        );
+    }
+
+    // ---- permutations ----
+
+    /// `permutations` must return the complete factorial-sized set of orderings.
+    /// Kills `replace with vec![]` and `replace with vec![vec![...]]`.
+    #[test]
+    fn permutations_empty_gives_one_empty_perm() {
+        let result = permutations(&[]);
+        assert_eq!(result, vec![vec![] as Vec<String>]);
+    }
+
+    #[test]
+    fn permutations_one_item() {
+        let result = permutations(&["a".to_string()]);
+        assert_eq!(result, vec![vec!["a".to_string()]]);
+    }
+
+    #[test]
+    fn permutations_two_items_exact() {
+        let mut result = permutations(&["a".to_string(), "b".to_string()]);
+        result.sort();
+        // Both orderings must appear.
+        assert_eq!(
+            result,
+            vec![
+                vec!["a".to_string(), "b".to_string()],
+                vec!["b".to_string(), "a".to_string()],
+            ],
+            "two-item permutations must yield exactly [a,b] and [b,a]"
+        );
+    }
+
+    #[test]
+    fn permutations_three_items_count() {
+        let result = permutations(&["a".to_string(), "b".to_string(), "c".to_string()]);
+        assert_eq!(result.len(), 6, "3! = 6 permutations");
+        // Every distinct item must appear as the first element in exactly 2 perms.
+        for head in &["a", "b", "c"] {
+            let count = result.iter().filter(|p| p[0].as_str() == *head).count();
+            assert_eq!(count, 2, "each item must head exactly 2 permutations");
+        }
+    }
+
+    // ---- serialize_quad_line ----
+
+    /// `serialize_quad_line` must produce `"s p o .\n"` for a default-graph quad
+    /// and `"s p o g .\n"` for a named-graph quad. Kills the `replace with
+    /// "xyzzy".into()` and `replace with String::new()` mutations.
+    #[test]
+    fn serialize_quad_line_default_graph() {
+        let q = oxrdf::Quad::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+            iri("http://ex/p"),
+            Term::NamedNode(iri("http://ex/o")),
+            GraphName::DefaultGraph,
+        );
+        let line = serialize_quad_line(&q);
+        assert_eq!(
+            line,
+            "<http://ex/s> <http://ex/p> <http://ex/o> .\n",
+            "default-graph quad must serialize without a graph term"
+        );
+    }
+
+    #[test]
+    fn serialize_quad_line_named_graph() {
+        let q = oxrdf::Quad::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+            iri("http://ex/p"),
+            Term::NamedNode(iri("http://ex/o")),
+            GraphName::NamedNode(iri("http://ex/g")),
+        );
+        let line = serialize_quad_line(&q);
+        assert_eq!(
+            line,
+            "<http://ex/s> <http://ex/p> <http://ex/o> <http://ex/g> .\n",
+            "named-graph quad must carry the graph term"
+        );
+    }
+
+    // ---- canonical_line_no_newline ----
+
+    /// `canonical_line_no_newline` must produce `"s p o ."` (NO trailing newline).
+    /// Kills `replace with "xyzzy".into()`. Distinct from `serialize_quad_line`
+    /// which DOES have a trailing `\n`.
+    #[test]
+    fn canonical_line_no_newline_default_graph() {
+        let q = oxrdf::Quad::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+            iri("http://ex/p"),
+            Term::Literal(Literal::new_simple_literal("v")),
+            GraphName::DefaultGraph,
+        );
+        let line = canonical_line_no_newline(&q);
+        assert_eq!(
+            line,
+            "<http://ex/s> <http://ex/p> \"v\" .",
+            "default-graph line must have NO trailing newline"
+        );
+        assert!(
+            !line.ends_with('\n'),
+            "canonical_line_no_newline must NOT end with newline: {line:?}"
+        );
+    }
+
+    #[test]
+    fn canonical_line_no_newline_named_graph() {
+        let q = oxrdf::Quad::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/s")),
+            iri("http://ex/p"),
+            Term::Literal(Literal::new_simple_literal("v")),
+            GraphName::NamedNode(iri("http://ex/g")),
+        );
+        let line = canonical_line_no_newline(&q);
+        assert_eq!(
+            line,
+            "<http://ex/s> <http://ex/p> \"v\" <http://ex/g> .",
+        );
+    }
+
+    // ---- relabel_quad_first_degree ----
+
+    /// `relabel_quad_first_degree` must replace the reference bnode with `_:a`
+    /// and any other bnode with `_:z`. Kills `replace with Default::default()`.
+    #[test]
+    fn relabel_quad_first_degree_reference_becomes_a_others_z() {
+        let q = oxrdf::Quad::new(
+            NamedOrBlankNode::BlankNode(bn("ref")),
+            iri("http://ex/p"),
+            Term::BlankNode(bn("other")),
+            GraphName::DefaultGraph,
+        );
+        let relabelled = relabel_quad_first_degree(&q, "ref");
+        assert_eq!(
+            relabelled.subject,
+            NamedOrBlankNode::BlankNode(BlankNode::new_unchecked("a")),
+            "reference bnode in subject must become 'a'"
+        );
+        assert_eq!(
+            relabelled.object,
+            Term::BlankNode(BlankNode::new_unchecked("z")),
+            "non-reference bnode in object must become 'z'"
+        );
+    }
+
+    // ---- relabel_term / relabel_subject / relabel_graph (first-degree) ----
+
+    /// `relabel_term` for a `Term::Triple` must recurse through the triple term
+    /// and relabel bnodes at every depth. Kills `replace relabel_term -> Term
+    /// with Default::default()`.
+    #[test]
+    fn relabel_term_recurses_through_triple_term() {
+        let inner = Term::Triple(Box::new(Triple::new(
+            NamedOrBlankNode::BlankNode(bn("ref")),
+            iri("http://ex/p"),
+            Term::BlankNode(bn("other")),
+        )));
+        let relabelled = relabel_term(&inner, "ref");
+        if let Term::Triple(t) = relabelled {
+            assert_eq!(
+                t.subject,
+                NamedOrBlankNode::BlankNode(BlankNode::new_unchecked("a")),
+                "reference bnode in inner subject must become 'a'"
+            );
+            assert_eq!(
+                t.object,
+                Term::BlankNode(BlankNode::new_unchecked("z")),
+                "non-reference bnode in inner object must become 'z'"
+            );
+        } else {
+            panic!("relabel_term must preserve Term::Triple wrapper");
+        }
+    }
+
+    /// `relabel_graph` for a `GraphName::BlankNode` must apply the special label.
+    #[test]
+    fn relabel_graph_blank_graph_name() {
+        let g = GraphName::BlankNode(bn("ref"));
+        let relabelled = relabel_graph(&g, "ref");
+        assert_eq!(
+            relabelled,
+            GraphName::BlankNode(BlankNode::new_unchecked("a")),
+            "bnode graph name equal to reference must become 'a'"
+        );
+        let g2 = GraphName::BlankNode(bn("other"));
+        let relabelled2 = relabel_graph(&g2, "ref");
+        assert_eq!(
+            relabelled2,
+            GraphName::BlankNode(BlankNode::new_unchecked("z")),
+            "bnode graph name not equal to reference must become 'z'"
+        );
+    }
+
+    // ---- serialize_canonical / canonical_lines ----
+
+    /// `serialize_canonical` must concatenate `canonical_lines` with trailing
+    /// newlines. Kills `replace serialize_canonical -> String with String::new()`.
+    #[test]
+    fn serialize_canonical_concatenates_lines() {
+        use std::collections::HashMap;
+        let q = oxrdf::Quad::new(
+            NamedOrBlankNode::BlankNode(bn("b")),
+            iri("http://ex/p"),
+            Term::Literal(Literal::new_simple_literal("v")),
+            GraphName::DefaultGraph,
+        );
+        let mut issued = HashMap::new();
+        issued.insert("b".to_string(), "c14n0".to_string());
+        let doc = serialize_canonical(&[q], &issued);
+        assert!(!doc.is_empty(), "serialize_canonical must not return empty string");
+        assert!(doc.ends_with('\n'), "each line must be newline-terminated");
+        assert!(
+            doc.contains("_:c14n0"),
+            "issued label must appear in serialized output: {doc:?}"
+        );
+    }
+
+    /// `canonical_lines` must deduplicate identical canonical lines and sort them.
+    /// Kills `replace canonical_lines -> Vec<String> with vec![]` and
+    /// `replace with vec![String::new()]`.
+    #[test]
+    fn canonical_lines_deduplicates_and_sorts() {
+        use std::collections::HashMap;
+        // Two quads that are IDENTICAL after canonicalization (dup-test).
+        let q1 = oxrdf::Quad::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+            iri("http://ex/p"),
+            Term::Literal(Literal::new_simple_literal("v")),
+            GraphName::DefaultGraph,
+        );
+        let q2 = q1.clone();
+        let issued: HashMap<String, String> = HashMap::new();
+        let lines = canonical_lines(&[q1, q2], &issued);
+        assert_eq!(lines.len(), 1, "duplicate quads must be deduplicated");
+
+        // Two distinct quads — must be sorted in code-point order.
+        let qa = oxrdf::Quad::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/z")),
+            iri("http://ex/p"),
+            Term::Literal(Literal::new_simple_literal("b")),
+            GraphName::DefaultGraph,
+        );
+        let qb = oxrdf::Quad::new(
+            NamedOrBlankNode::NamedNode(iri("http://ex/a")),
+            iri("http://ex/p"),
+            Term::Literal(Literal::new_simple_literal("a")),
+            GraphName::DefaultGraph,
+        );
+        let lines2 = canonical_lines(&[qa, qb], &issued);
+        assert_eq!(lines2.len(), 2, "distinct quads give two lines");
+        let mut sorted = lines2.clone();
+        sorted.sort();
+        assert_eq!(lines2, sorted, "canonical_lines must be in sorted order");
+    }
+
+    // ---- relabel_subject_canonical / relabel_term_canonical / relabel_graph_canonical ----
+
+    /// `relabel_term_canonical` for a `Term::Triple` must recurse into the nested
+    /// triple and replace any bnodes with their issued canonical labels.
+    /// Kills `replace relabel_term_canonical -> Term with Default::default()`.
+    #[test]
+    fn relabel_term_canonical_recurses_through_triple_term() {
+        use std::collections::HashMap;
+        let inner = Term::Triple(Box::new(Triple::new(
+            NamedOrBlankNode::BlankNode(bn("b")),
+            iri("http://ex/p"),
+            Term::BlankNode(bn("c")),
+        )));
+        let mut issued = HashMap::new();
+        issued.insert("b".to_string(), "c14n0".to_string());
+        issued.insert("c".to_string(), "c14n1".to_string());
+        let relabelled = relabel_term_canonical(&inner, &issued);
+        if let Term::Triple(t) = relabelled {
+            assert_eq!(
+                t.subject,
+                NamedOrBlankNode::BlankNode(BlankNode::new_unchecked("c14n0")),
+                "inner subject bnode must be relabelled canonically"
+            );
+            assert_eq!(
+                t.object,
+                Term::BlankNode(BlankNode::new_unchecked("c14n1")),
+                "inner object bnode must be relabelled canonically"
+            );
+        } else {
+            panic!("relabel_term_canonical must preserve Term::Triple wrapper");
+        }
+    }
+
+    /// `relabel_graph_canonical` for a `GraphName::BlankNode` must substitute
+    /// the issued canonical label. Kills `replace with Default::default()`.
+    #[test]
+    fn relabel_graph_canonical_substitutes_issued_label() {
+        use std::collections::HashMap;
+        let mut issued = HashMap::new();
+        issued.insert("g".to_string(), "c14n0".to_string());
+        let result = relabel_graph_canonical(&GraphName::BlankNode(bn("g")), &issued);
+        assert_eq!(
+            result,
+            GraphName::BlankNode(BlankNode::new_unchecked("c14n0")),
+            "bnode graph name must be replaced with its canonical label"
+        );
+        // DefaultGraph stays DefaultGraph.
+        assert_eq!(
+            relabel_graph_canonical(&GraphName::DefaultGraph, &issued),
+            GraphName::DefaultGraph
+        );
+    }
+}

--- a/crates/sparq-canon/tests/rdf12_triple_term_canon.rs
+++ b/crates/sparq-canon/tests/rdf12_triple_term_canon.rs
@@ -1063,3 +1063,83 @@ fn sha384_relabels_differently_from_sha256_on_symmetric_cycle() {
     assert_eq!(labels256, expected);
     assert_eq!(labels384, expected);
 }
+
+// ---------------------------------------------------------------------------
+// 6) Direct tests for `canonicalize_graph_content_rdf12` and the `*_with`
+//    generic — the `sparq_core::Graph`-level entry points. [OPUS-4.8] sq-qcnn.14:
+//    these were the only public rdf12 functions without any test coverage.
+// ---------------------------------------------------------------------------
+
+/// Direct test for `canonicalize_graph_content_rdf12` — the Graph-level entry
+/// point for the non-standard triple-term profile. Verifies that a bnode in a
+/// loaded Graph is relabelled to `c14n0` and the canonical line is well-formed.
+/// Kills "return empty CanonicalGraph" and "skip graph_triples extraction" mutants.
+#[test]
+fn canonicalize_graph_content_rdf12_relabels_bnode() {
+    use sparq_core::Graph;
+    let g = Graph::load_str(
+        "_:b0 <http://ex/p> <http://ex/o> .\n",
+        "ntriples",
+    )
+    .expect("load_str");
+    let c = sparq_canon::canonicalize_graph_content_rdf12(&g).unwrap();
+    assert_eq!(c.lines.len(), 1, "one stored triple -> one canonical line");
+    assert!(
+        c.lines[0].contains("_:c14n0"),
+        "bnode must be relabelled to c14n0: {:?}",
+        c.lines[0]
+    );
+    assert!(
+        c.lines[0].contains("<http://ex/p>"),
+        "predicate must be preserved: {:?}",
+        c.lines[0]
+    );
+    assert_eq!(c.triples.len(), 1, "one line -> one canonical triple");
+    // The to_nquads join must produce the canonical doc.
+    let doc = c.to_nquads();
+    assert_eq!(doc, format!("{}\n", c.lines[0]));
+}
+
+/// `canonicalize_graph_content_rdf12` on an EMPTY graph must succeed and return
+/// an empty CanonicalGraph (mirrors the standard path's empty-dataset behaviour).
+#[test]
+fn canonicalize_graph_content_rdf12_empty_graph() {
+    use sparq_core::Graph;
+    let g = Graph::load_str("", "ntriples").expect("load_str");
+    let c = sparq_canon::canonicalize_graph_content_rdf12(&g).unwrap();
+    assert!(c.lines.is_empty(), "empty graph -> empty canonical form");
+    assert!(c.triples.is_empty());
+    assert_eq!(c.to_nquads(), "");
+}
+
+/// Direct test for `canonicalize_graph_content_rdf12_with::<D>` (hash-generic).
+/// Uses SHA-384. Asserts bnode relabelling and exact line count so mutations to
+/// the hash dispatch or the triples extraction are killed.
+#[test]
+fn canonicalize_graph_content_rdf12_with_sha384_relabels_bnode() {
+    use sparq_core::Graph;
+    let g = Graph::load_str(
+        "_:x <http://ex/q> <http://ex/r> .\n",
+        "ntriples",
+    )
+    .expect("load_str");
+    let c = sparq_canon::canonicalize_graph_content_rdf12_with::<Sha384>(&g).unwrap();
+    assert_eq!(c.lines.len(), 1, "one stored triple -> one canonical line");
+    assert!(
+        c.lines[0].contains("_:c14n0"),
+        "bnode must be relabelled to c14n0 under SHA-384: {:?}",
+        c.lines[0]
+    );
+    assert!(
+        c.lines[0].contains("<http://ex/q>"),
+        "predicate must be preserved: {:?}",
+        c.lines[0]
+    );
+    // SHA-256 (default) and SHA-384 agree on a single-bnode, single-triple graph
+    // because there is no shared-hash disambiguation (exactly one bnode).
+    let c256 = sparq_canon::canonicalize_graph_content_rdf12(&g).unwrap();
+    assert_eq!(
+        c.lines, c256.lines,
+        "single-bnode graph must canonicalize identically under any hash"
+    );
+}


### PR DESCRIPTION
> 🤖 SPARQ agent [OPUS-4.8] implementing sq-qcnn.14 — sparq-canon test quality plan

## Summary

- **Coverage floor 77 → 93** (measured 95.03% line coverage, floor = floor(95.03) - 2 = 93)
- **Mutation ceiling fixed 9 → 6** (the old ceiling=9 was stale: it was measured without `--features rdf12-triple-terms`, which trivially missed all 91 rdf12.rs mutations because the module was not compiled; re-seeded with the feature enabled: 104 caught / 4 survivors = 96.3% catch rate)
- **CI mutation matrix** now includes sparq-canon with `features: rdf12-triple-terms` so nightly measures the full crate surface

## Changes

**`crates/sparq-canon/src/lib.rs`** — 10 new `#[cfg(test)]` unit tests:
- `parse_nquads`, `issue_quads_with`, `canonicalize_quads_with`, `issue_triples`, `graph_triples`, `canonicalize_graph_content`, `to_nquads` + helpers
- Each asserts exact output values so comparison/branch mutations go red

**`crates/sparq-canon/src/rdf12.rs`** — 30-test `private_tests` module (behind `rdf12-triple-terms` feature):
- `IdentifierIssuer`, `HndqCallCounter`, `push_unique`, `collect_bnodes_term`, `special_label`, `permutations`, `serialize_quad_line`, `canonical_line_no_newline`, `relabel_*`, `serialize_canonical`, `canonical_lines`, `hash_hex` internals
- Reduced rdf12.rs survivors from 91 (trivially-missed) to 4 genuine hard-to-kill HNDQ boundary guards

**`crates/sparq-canon/tests/rdf12_triple_term_canon.rs`** — 3 new integration tests:
- `canonicalize_graph_content_rdf12`, `canonicalize_graph_content_rdf12_with::<Sha384>`, empty-graph path

**`bench/coverage-floor.json`** — sparq-canon floor 77 → 93

**`bench/mutants-baseline.json`** — sparq-canon re-seeded: `caught=104, caught_pct=96.3%, ceiling=6, measured_surviving=4`

**`.github/workflows/ci.yml`** — sparq-canon added to nightly mutation matrix with `features: rdf12-triple-terms`

## 4 Remaining Mutation Survivors

All 4 are comparison-operator variants in `CanonState::hash_n_degree_quads` path-pruning guards (lines 429, 430, 448, 459). These guard an HNDQ early-exit optimization where the path-length comparisons (`>=`, `||`, `<`) require carefully constructed permutation sequences with specific relative lengths to distinguish — hard to exercise with black-box integration tests. Ceiling = 6 (4 + 2 margin) is honest.

## Gates verified locally

- `cargo clippy -D warnings` GREEN (default features + `rdf12-triple-terms`)
- `cargo test` GREEN (default features + `rdf12-triple-terms`)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` GREEN
- `scripts/mutants-gate.py --check mutants.out.old/outcomes.json` → `4 <= ceiling 6`: GREEN
- `scripts/coverage.sh sparq-canon` → `sparq-canon lines= 95.03%` (floor 93 ✓)

🤖 Generated with [Claude Code](https://claude.com/claude-code)