### PR TITLE
ci(feature-matrix): per-crate rust-cache key + save-if=main — stop the 68-cache budget thrash (sq-3sbrr) [OPUS-4.8]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -224,9 +224,24 @@ jobs:
           components: clippy
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          # Per-leg cache key so each crate+feature combination keeps its own warm
-          # target dir (the feature set changes the compiled artifacts).
-          shared-key: feature-matrix-${{ matrix.crate }}-${{ matrix.features }}
+          # [OPUS-4.8] sq-3sbrr — PER-CRATE (not per-leg) cache key + save-only-on-main.
+          # WHY: rust-cache stores the DEPENDENCY build only (never sparq's own crates —
+          # they recompile per leg regardless, see ci.yml's build-once note), so the prior
+          # per-leg `…-${{ matrix.crate }}-${{ matrix.features }}` key produced 68
+          # near-identical dependency caches (one per matrix leg). At ~0.2 GB each that is
+          # ~14 GB of demand against the repo's 10 GB Actions-cache budget, so GitHub
+          # LRU-evicted them AND the ci.yml caches (test-workspace / coverage / lint /
+          # wasm) on essentially every run — caching was present but self-defeating and
+          # most jobs restored COLD (recompiling the ~131 s dep floor from scratch).
+          # Keying by CRATE collapses the 68 legs to ONE dependency cache per crate (the
+          # 15 sparq-engine legs now share a single warm dep dir); cargo fingerprinting
+          # still recompiles each feature-varying crate itself, so there is no
+          # stale-artifact risk (the rust-cache key already embeds Cargo.lock + the rustc
+          # version + Cargo.toml hashes). `save-if` makes PR and ephemeral merge_group
+          # runs RESTORE-ONLY so they stop writing branch-scoped caches that churn the
+          # shared budget; the post-merge push-to-main run is what seeds/refreshes them.
+          shared-key: feature-matrix-${{ matrix.crate }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Fetch dependencies (retry transient crates.io fetch)
         # [OPUS-4.8] sq-hhxc: these `opt-in <crate>` legs were failing ~8s in with exit 101
         # — i.e. in EARLY SETUP (registry resolve/fetch), BEFORE any real compile (8s is far
@@ -299,6 +314,9 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: feature-matrix-sparq-server-no-default-features
+          # [OPUS-4.8] sq-3sbrr: restore-only off main so PR/merge_group runs don't
+          # write branch-scoped caches that churn the shared 10 GB budget.
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Fetch dependencies (retry transient crates.io fetch)
         run: |
           set -euo pipefail
@@ -340,5 +358,7 @@ jobs:
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
           shared-key: fedclient-boundary
+          # [OPUS-4.8] sq-3sbrr: restore-only off main (see the opt-in-features note).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
       - name: Assert sparq-core/sparq-engine have no edge to sparq-fedclient
         run: scripts/fedclient-boundary-guard.sh


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI build-time optimization (maintainer: *"17-min CI is still too slow; find + fix the base build costs"*). Profiled **from the CI logs** (not re-run locally — aarch64 work-box ≠ CI x86_64). Bead **sq-3sbrr**.

## Root cause: caching is present but self-defeating (budget thrash)

`rust-cache` is already used (18× in `ci.yml`, 3× in `feature-matrix.yml`), so the problem was never "no cache" — it's that the cache **thrashes against the 10 GB per-repo Actions-cache budget**:

- `feature-matrix.yml` keyed its cache **per leg** — `shared-key: feature-matrix-${{ matrix.crate }}-${{ matrix.features }}` — across **68 matrix legs** (26 crates; sparq-engine alone = 15 legs).
- `rust-cache` stores the **dependency build only** (never sparq's own crates — they recompile per leg regardless; ci.yml's build-once note already says as much). So those 68 caches are **near-identical dep closures**, ~0.2 GB each ⇒ **~14 GB of demand** — more than the entire 10 GB budget on its own.
- Live `gh cache list` confirms the eviction: **83 entries, 10.74 GB — over budget**. Only **24 of the 68** feature-matrix caches survive at any moment; the rest, plus the ci.yml caches (test-workspace, coverage shards, lint, wasm), get **LRU-evicted every run**. So most heavy jobs restore **cold** and recompile the **~131 s dependency floor** from scratch.

### Slowest jobs (empirical, run `28627943796`, `merge_group` pr-1394)

`ci.yml`:

| min | job |
|----:|-----|
| 10.9 | coverage ratchet (shard 1/4) |
| 8.95 | test (load-aware shard heavy-hnsw) |
| 8.58 | test (bulk 2/3) |
| 8.45 | build + archive test binaries (+ doctests) |
| 8.45 | test (bulk 1/3) |
| 7.02 | test (bulk 3/3) |
| 6.93 | coverage ratchet (shard 4/4) |
| 6.88 | coverage ratchet (shard 3/4) |
| 6.12 | coverage ratchet (shard 2/4) |
| 5.78 | test (heavy-diskann) |
| 3.57 | wasm build |
| 2.32 | clippy (gate) |

`feature-matrix.yml` (same run): **~50+ `opt-in sparq-<feat>` legs, each ~5–6.5 min**, all recompiling `sparq-engine` + the full dep closure because their cache was evicted (`opt-in sparq-engine (yannakakis)` 6.57, `(serialize-rdf)` 6.12, `(params)` 5.92, … 15 engine legs).

The build-once → test-shard pattern (`nextest archive` + artifact download) and the coverage sharding are already well-designed; the **binding constraint is the cache budget**, dominated by the feature-matrix's 68-way key split.

## Fix (this PR)

`feature-matrix.yml` only — three `rust-cache` steps:
- **Per-leg → per-crate key**: `shared-key: feature-matrix-${{ matrix.crate }}`. Collapses **68 caches → 26** (one dep cache per crate; the 15 sparq-engine legs share one warm dep dir). No stale-artifact risk — cargo fingerprinting recompiles the feature-varying crate itself, and the rust-cache key already embeds `Cargo.lock` + rustc version + `Cargo.toml` hashes.
- **`save-if: ${{ github.ref == 'refs/heads/main' }}`** on all three legs: PR and ephemeral `merge_group` runs are **restore-only**, so they stop writing branch-scoped caches that churn the shared budget. The post-merge push-to-main run seeds/refreshes them.

**Not touched:** check-run names are unchanged (only cache keys), so the `ci-summary / gate` aggregator discovers the exact same required legs — the assembler self-test (`scripts/tests/test_feature_matrix_assemble.py`) is still green (7/7). No ci-summary edit, no path-filter change, no gate weakened.

## Validation
- `python3 -c "import yaml; yaml.safe_load(...)"` → **valid**.
- `actionlint .github/workflows/feature-matrix.yml` → **clean**.
- Assembler self-test 7/7; diff adds **no** `name:` / `matrix.name` line.
- rust-cache action unchanged (already SHA-pinned `e18b497…` # v2); `save-if` is supported on v2.

## Expected speedup — honest, from the CI timing (validate on first post-merge run)
Cannot benchmark x86_64 CI locally, so this is derived from the log durations, not measured here:
- Removing the ~14 GB feature-matrix write-churn lets the ci.yml caches (test-workspace / coverage / lint / wasm) **survive between runs** → the ~131 s dep floor is restored warm instead of recompiled. On the critical path (coverage shard 1/4 ≈ 10.9 min; build-archive ≈ 8.45 min) that is a **~2 min/job** reduction once caches are warm.
- Each feature-matrix leg drops from ~5.5 min toward ~3.5 min (warm deps) — a large **runner-minute** saving, and wall-clock savings where limited runner concurrency serializes the 68 legs into waves.
- Net wall-clock: expect movement from ~17 min toward **~13–14 min** once the shared caches warm (first main run seeds; benefit lands from the run after). **To be confirmed against `gh cache list` (total should drop well under 10 GB) and the next merge_group profile.**

## Compliance / scope
Pure CI throughput change — no compliance control affected; no `crates/` source. Gate semantics + required checks unchanged.

**Follow-up bead** (deferred to keep this PR's blast radius tight): extend `save-if=main` to ci.yml's ~18 rust-cache steps + collapse the 4 `coverage-shard-N` keys to one `shared-key` (identical instrumented dep closure).

*Not armed — no auto-merge.*

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>