### PR TITLE
test(zk): pin encoding/commitment determinism + raise sparq-zk coverage floor 88->90 (sq-qcnn.25) [OPUS-4.8]

### DIFF
--- a/bench/coverage-floor.json
+++ b/bench/coverage-floor.json
@@ -130,7 +130,8 @@
       "floor": 93
     },
     "sparq-zk": {
-      "floor": 88
+      "floor": 90,
+      "note": "[OPUS-4.8] sq-qcnn.25: raised 88 -> 90 (encoding/commitment DETERMINISM; measured with DEFAULT features, matching the ratchet's `cargo llvm-cov -p sparq-zk`). Enumerated FIRST with `cargo mutants -p sparq-zk` scoped to encode/field/commit/poseidon2/canon (113 mutants: 100 caught, 9 unviable, 4 survivors) + scripts/coverage.sh. Added DIRECT value-asserting tests: encode_term exact-composition pins (IRI type-code + h_s layering, literal canonical-N-Triples token, salted two-layer bnode), encode_triple = h_3(s,p,o) with position-sensitivity, RDF-1.2 triple-term fail-closed (None), salt_from_bytes = field_from_hash_bytes; commit leaf_index_map direct map (kills `leaf_index_map -> HashMap::new()`), CommitError Display/From exact strings (kills `fmt -> Ok(Default::default())`), commit_graph_content == commit_triples equivalence, C(G) == Poseidon2 sponge over encode_triple leaves with byte-level determinism; poseidon2 empty-input final-permutation branch. Lifted commit.rs 85.81% -> 99.52%, encode.rs -> 100%; measured crate line% 93.94 (floor(measured) - 2 = 91; floor set to the bead target 90 for a conservative work-box margin, CI --check-robust is the ratchet of record). Two survivors are PROVABLY EQUIVALENT under the DEFAULT feature build and left documented rather than contorted: `CommitmentMethod::is_production_selectable -> true` (the only variant returning false, `ValueOnlyV1`, is behind the OFF-by-default `commitment-value-only` feature) and `delete match arm ZK_SCHEME_POSEIDON2_VALUEHOOK_V1 in from_scheme_iri` (that arm is `#[cfg(feature = \"commitment-value-only\")]`, compiled out by default) — both observable only with `commitment-value-only` ON, which this ratchet does not measure. Tests only, NO crypto-logic change, NO soundness/privacy claim (sq-qhy4)."
     },
     "sparq-zk-compose": {
       "floor": 76

--- a/crates/sparq-zk/src/commit.rs
+++ b/crates/sparq-zk/src/commit.rs
@@ -436,4 +436,94 @@ mod tests {
         );
         assert_eq!(c.leaf_index(&absent), None);
     }
+
+    // [OPUS-4.8] sq-qcnn.25: DETERMINISM + resolution value pins. Assert exact
+    // VALUES (not just no-panic) over the commitment/leaf-resolution surface.
+    // NO soundness claim (sq-qhy4).
+
+    #[test]
+    fn leaf_index_map_maps_every_canonical_triple_to_its_position() {
+        // Direct test of `leaf_index_map`: the bulk map must agree exactly with the
+        // per-triple `leaf_index`, be complete (one entry per canonical triple), and
+        // omit absent triples. (Kills `leaf_index_map -> HashMap::new()`.)
+        let salt = salt_from_bytes(&[7u8; 32]);
+        let c = commit_triples(&bnode_graph("x", "v"), salt).unwrap();
+        let map = c.leaf_index_map();
+        assert_eq!(map.len(), c.canonical.triples.len());
+        assert!(!map.is_empty());
+        for (i, t) in c.canonical.triples.iter().enumerate() {
+            assert_eq!(map.get(t), Some(&i), "map must resolve triple {} to leaf {}", i, i);
+            assert_eq!(c.leaf_index(t), Some(i), "map must agree with leaf_index");
+        }
+        let absent = Triple::new(
+            NamedOrBlankNode::NamedNode(NamedNode::new("http://ex/absent").unwrap()),
+            NamedNode::new("http://ex/p").unwrap(),
+            Term::Literal(Literal::new_simple_literal("v")),
+        );
+        assert!(!map.contains_key(&absent));
+    }
+
+    #[test]
+    fn commit_error_display_is_exact() {
+        // `From<CanonError>` wraps a canonicalization failure, and Display passes the
+        // inner message through verbatim (covers the `From` + `Canon` Display arms;
+        // kills `fmt -> Ok(Default::default())`).
+        let inner = CanonError::Bridge("boom".to_string());
+        let inner_msg = inner.to_string();
+        let wrapped: CommitError = inner.into();
+        assert!(matches!(wrapped, CommitError::Canon(_)));
+        assert_eq!(wrapped.to_string(), inner_msg);
+        // The `UncommittableTerm` Display is the exact "uncommittable term: {t}" form.
+        let ut = CommitError::UncommittableTerm("http://ex/quoted".to_string());
+        assert_eq!(ut.to_string(), "uncommittable term: http://ex/quoted");
+    }
+
+    #[test]
+    fn commitment_pins_poseidon2_sponge_over_encoded_leaves() {
+        // The whole-pipeline determinism contract: C(G) is EXACTLY the Poseidon2
+        // sponge over the ordered leaves, and each leaf is EXACTLY `encode_triple`
+        // of the canonical triple at that index. Recomputed independently from the
+        // public primitives so a mutation of the leaf loop or the final sponge is
+        // caught (not merely a "commit twice is equal" tautology).
+        let salt = salt_from_bytes(&[7u8; 32]);
+        let c = commit_triples(&bnode_graph("x", "v"), salt).unwrap();
+        let recomputed_leaves: Vec<Fr> = c
+            .canonical
+            .triples
+            .iter()
+            .map(|t| crate::encode::encode_triple(t, &salt).unwrap())
+            .collect();
+        assert_eq!(c.leaves, recomputed_leaves, "leaves must be encode_triple per canonical triple");
+        assert_eq!(
+            c.commitment,
+            poseidon2::hash(&recomputed_leaves),
+            "commitment must be the Poseidon2 sponge over the leaf sequence"
+        );
+        // Byte-level determinism: same input -> same commitment bytes.
+        let c2 = commit_triples(&bnode_graph("x", "v"), salt).unwrap();
+        assert_eq!(
+            crate::field::field_to_be_bytes_32(&c.commitment),
+            crate::field::field_to_be_bytes_32(&c2.commitment),
+        );
+    }
+
+    #[test]
+    fn commit_graph_content_matches_commit_triples_over_materialized_triples() {
+        use sparq_core::Graph;
+        // `commit_graph_content` must equal `commit_triples` over the graph's
+        // materialized triples under the same salt (covers the graph-content entry
+        // point; asserts the two commit doors agree by construction).
+        let salt = salt_from_bytes(&[5u8; 32]);
+        let g = Graph::load_str(
+            "<http://ex/s> <http://ex/p> \"o\" .\n<http://ex/s> <http://ex/q> <http://ex/o2> .",
+            "turtle",
+        )
+        .unwrap();
+        let from_store = commit_graph_content(&g, salt).unwrap();
+        let triples = crate::canon::graph_triples(&g).unwrap();
+        let from_triples = commit_triples(&triples, salt).unwrap();
+        assert_eq!(from_store.commitment, from_triples.commitment);
+        assert_eq!(from_store.leaves, from_triples.leaves);
+        assert_eq!(from_store.canonical.lines, from_triples.canonical.lines);
+    }
 }

--- a/crates/sparq-zk/src/encode.rs
+++ b/crates/sparq-zk/src/encode.rs
@@ -115,4 +115,108 @@ mod tests {
         assert_ne!(e[0], e[2]);
         assert_ne!(e[1], e[2]);
     }
+
+    // [OPUS-4.8] sq-qcnn.25: DETERMINISM value pins. These recompute the exact
+    // `Enc_t` composition from the public primitives (independent of `encode_term`'s
+    // body) and assert the encoder reproduces it EXACTLY — so a mutation of the
+    // type-code, the `h_s`/`h_2` layering, or the argument order is caught, not just
+    // a panic. They are the "same input -> same field element" determinism contract
+    // (sq-qcnn.25). `blake3_field` is the module's own `h_s` helper (in scope via
+    // `super::*`), so the recomputation stays byte-for-byte faithful to the encoder.
+    // NO soundness claim is made (sq-qhy4).
+
+    #[test]
+    fn encode_term_iri_pins_type_code_and_hs_layering() {
+        let salt = salt_from_bytes(&[7u8; 32]);
+        let iri = Term::NamedNode(NamedNode::new("http://ex/a").unwrap());
+        // Enc_t(IRI) = h_2(TYPE_CODE_IRI, blake3(iri-string, no <> delimiters)).
+        let expected = crate::poseidon2::hash(&[
+            Fr::from(TYPE_CODE_IRI),
+            blake3_field(b"http://ex/a"),
+        ]);
+        let got = encode_term(&iri, &salt).unwrap();
+        assert_eq!(got, expected);
+        // Byte-stable: the same input yields the same 32-byte field word every call.
+        assert_eq!(
+            crate::field::field_to_be_bytes_32(&got),
+            crate::field::field_to_be_bytes_32(&encode_term(&iri, &salt).unwrap()),
+        );
+    }
+
+    #[test]
+    fn encode_term_literal_pins_canonical_ntriples_token() {
+        let salt = salt_from_bytes(&[7u8; 32]);
+        let lit = Literal::new_language_tagged_literal("x", "en").unwrap();
+        let term = Term::Literal(lit.clone());
+        // Enc_t(literal) = h_2(TYPE_CODE_LITERAL, blake3(canonical N-Triples token)).
+        // The token folds datatype/language: it is `Literal::to_string()`.
+        let expected = crate::poseidon2::hash(&[
+            Fr::from(TYPE_CODE_LITERAL),
+            blake3_field(lit.to_string().as_bytes()),
+        ]);
+        assert_eq!(encode_term(&term, &salt).unwrap(), expected);
+    }
+
+    #[test]
+    fn encode_term_bnode_pins_salted_two_layer_composition() {
+        let salt = salt_from_bytes(&[7u8; 32]);
+        let b = Term::BlankNode(BlankNode::new("c14n0").unwrap());
+        // Enc_t(bnode) = h_2(BLANK_NODE, h_2(salt, blake3(canonical-label, no _:))).
+        let inner = crate::poseidon2::hash(&[salt, blake3_field(b"c14n0")]);
+        let expected = crate::poseidon2::hash(&[Fr::from(TYPE_CODE_BLANK_NODE), inner]);
+        assert_eq!(encode_term(&b, &salt).unwrap(), expected);
+    }
+
+    #[test]
+    fn encode_triple_pins_h3_of_s_p_o_and_is_position_sensitive() {
+        let salt = salt_from_bytes(&[9u8; 32]);
+        let s = NamedNode::new("http://ex/s").unwrap();
+        let p = NamedNode::new("http://ex/p").unwrap();
+        let o = NamedNode::new("http://ex/o").unwrap();
+        let t = Triple::new(
+            NamedOrBlankNode::NamedNode(s.clone()),
+            p.clone(),
+            Term::NamedNode(o.clone()),
+        );
+        // Leaf = h_3(Enc(s), Enc(p), Enc(o)) in exactly that argument order.
+        let expected = crate::poseidon2::hash(&[
+            encode_term(&Term::NamedNode(s.clone()), &salt).unwrap(),
+            encode_term(&Term::NamedNode(p.clone()), &salt).unwrap(),
+            encode_term(&Term::NamedNode(o.clone()), &salt).unwrap(),
+        ]);
+        assert_eq!(encode_triple(&t, &salt).unwrap(), expected);
+        // Swapping predicate<->object roles must change the leaf: the position is
+        // load-bearing (kills an s/p/o argument-swap in the sponge input).
+        let swapped = Triple::new(
+            NamedOrBlankNode::NamedNode(s),
+            o, // predicate slot now holds what was the object IRI
+            Term::NamedNode(p),
+        );
+        assert_ne!(encode_triple(&t, &salt).unwrap(), encode_triple(&swapped, &salt).unwrap());
+    }
+
+    #[test]
+    fn encode_term_rejects_rdf12_triple_term_fail_closed() {
+        // RDF 1.2 triple terms are outside the committed data model: encode_term
+        // returns None so callers fail closed (covers the `Term::Triple(_) => None`
+        // arm). No soundness claim (sq-qhy4).
+        let salt = salt_from_bytes(&[1u8; 32]);
+        let inner = Triple::new(
+            NamedOrBlankNode::NamedNode(NamedNode::new("http://ex/s").unwrap()),
+            NamedNode::new("http://ex/p").unwrap(),
+            Term::NamedNode(NamedNode::new("http://ex/o").unwrap()),
+        );
+        let quoted = Term::Triple(Box::new(inner));
+        assert_eq!(encode_term(&quoted, &salt), None);
+    }
+
+    #[test]
+    fn salt_from_bytes_pins_field_from_hash_bytes() {
+        // salt_from_bytes is exactly field_from_hash_bytes over the entropy word.
+        let bytes = [3u8; 32];
+        assert_eq!(salt_from_bytes(&bytes), crate::field::field_from_hash_bytes(&bytes));
+        // Deterministic + entropy-sensitive.
+        assert_eq!(salt_from_bytes(&bytes), salt_from_bytes(&bytes));
+        assert_ne!(salt_from_bytes(&[3u8; 32]), salt_from_bytes(&[4u8; 32]));
+    }
 }

--- a/crates/sparq-zk/src/poseidon2.rs
+++ b/crates/sparq-zk/src/poseidon2.rs
@@ -182,4 +182,16 @@ mod tests {
         assert_eq!(a, b);
         assert_ne!(a, c, "length must enter the IV");
     }
+
+    // [OPUS-4.8] sq-qcnn.25: the empty-input branch. An empty input still runs the
+    // final permutation (`(in_len == 0) | (in_len % RATE != 0)`), so the digest is
+    // the permuted state[0], NOT the pre-permutation zero. Deterministic + distinct
+    // from a single explicit zero element (which carries a different length IV).
+    #[test]
+    fn hash_empty_input_runs_final_permutation() {
+        let e = hash(&[]);
+        assert_eq!(e, hash(&[]), "empty-input hash is deterministic");
+        assert_ne!(e, Fr::from(0u64), "empty input runs the final permutation, not identity");
+        assert_ne!(e, hash(&[Fr::from(0u64)]), "length enters the IV (0 vs 1 element)");
+    }
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — test-quality work on **sq-qcnn.25** (epic sq-qcnn). `sparq-zk` is a SECURITY crate: this PR adds **TESTS ONLY** — no crypto-logic change, and **no soundness/privacy claim** is made or implied (sq-qhy4 gates all ZK security claims).

## What
Raise `sparq-zk` line-coverage floor **88 → 90**, focused on **encoding/commitment DETERMINISM**, by enumerating survivors with mutation testing FIRST and adding DIRECT, value-asserting tests to kill the killable ones.

### Enumeration (discipline: mutants + coverage FIRST)
`cargo mutants -p sparq-zk` scoped to `encode/field/commit/poseidon2/canon`: **113 mutants → 100 caught, 9 unviable, 4 survivors**. `field.rs`/`poseidon2.rs`/`encode.rs` had **0** survivors; all 4 survivors were in `commit.rs`.

### Tests added (assert VALUES, not just no-panic)
- **encode.rs** — exact-composition pins recomputed from the public primitives (independent of the encoder body): `encode_term` for IRI (type-code + `h_s` layering), literal (canonical N-Triples token), and salted two-layer bnode; `encode_triple = h_3(Enc(s),Enc(p),Enc(o))` with **position-sensitivity**; RDF-1.2 triple-term **fail-closed** (`None`); `salt_from_bytes = field_from_hash_bytes`.
- **commit.rs** — `leaf_index_map` direct map (kills `leaf_index_map -> HashMap::new()`); `CommitError` Display/From exact strings (kills `fmt -> Ok(Default::default())`); `commit_graph_content == commit_triples` equivalence; `C(G) == Poseidon2` sponge over the `encode_triple` leaves with **byte-level determinism** (same input → same commitment bytes).
- **poseidon2.rs** — empty-input final-permutation branch determinism.

### Survivors: killed vs documented
- **Killed 2** (confirmed by a re-run: `2 mutants tested: 2 caught`): `leaf_index_map -> HashMap::new()`, `Display for CommitError::fmt -> Ok(Default::default())`.
- **2 remain, PROVABLY EQUIVALENT under the DEFAULT feature build** — documented in the `bench/coverage-floor.json` note rather than contorted: `CommitmentMethod::is_production_selectable -> true` (the only `false`-returning variant, `ValueOnlyV1`, is behind the OFF-by-default `commitment-value-only` feature) and `delete match arm ZK_SCHEME_POSEIDON2_VALUEHOOK_V1 in from_scheme_iri` (that arm is `#[cfg(feature = "commitment-value-only")]`, compiled out by default). Both are only observable with `commitment-value-only` ON, which the coverage ratchet does not measure.

## Coverage
`commit.rs` 85.81% → **99.52%**, `encode.rs` → **100%**, crate line% **93.94** (work-box; CI `--check-robust` is the ratchet of record). Floor set to the bead target **90** (conservative vs `floor(measured)-2 = 91`). **Only** the `sparq-zk` entry in `bench/coverage-floor.json` is touched; the mutants ratchet (`bench/mutants-baseline.json`) is left untouched (sparq-zk is not seeded there, and this scoped run is not a whole-crate measurement).

## Gates run (in-worktree, BOTH feature states)
- `cargo clippy -p sparq-zk --all-targets -- -D warnings` — green in **default**, **`--features commitment-value-only`**, and **`--all-features`**.
- `cargo test -p sparq-zk` — green in default (98 lib + integration), `commitment-value-only`, and `--all-features` (128 lib).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean (exit 0).

Tests only. No crypto logic changed. No soundness/privacy claim (sq-qhy4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)