### PR TITLE
feat(ci): change-based test-selection affected-set selector (sq-fmx4u.1) [OPUS-4.8]

### DIFF
--- a/scripts/ci_select.py
+++ b/scripts/ci_select.py
@@ -1,0 +1,512 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Change-based CI test-selection: the affected-set selector.
+# Bead sq-fmx4u.1 (epic sq-fmx4u). Design: research/change-based-test-selection.md
+# §3 (affected-set algorithm), §4 (fail-safe rules), §7 (positions P1-P4).
+# Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# WHAT THIS IS (and is NOT):
+#   Given the set of paths changed in a PR (a git diff), compute the set of
+#   workspace crates whose tests/benchmarks MUST run = the reverse-dependency
+#   closure (transitive dependents) of every changed crate, derived from
+#   `cargo metadata`. Emits JSON: {"mode": "selected"|"full", "reason", "affected"}.
+#
+#   This is the SELECTOR LIBRARY ONLY (design §3). The CI WIRING — the `select`
+#   pre-job, the job-level `if:` guards, nextest filtersets, ci-summary
+#   semantics — is the LATER beads sq-fmx4u.2-.6. This file touches no workflow.
+#
+# THE CORE INVARIANT (design §2, normative):
+#   *A test is skipped => provably no change could affect it.* Skipping is an
+#   optimization applied to a proof of non-interference; ABSENCE OF PROOF MEANS
+#   RUN. Every branch below defaults to running MORE, never less:
+#     - any §4.1 full-run trigger changed  => mode=full
+#     - any changed path we cannot confidently attribute to a crate => mode=full
+#     - ANY internal error (metadata parse, diff failure, unfetchable base,
+#       malformed map) => mode=full, exit 0  (fail-closed, design §4.3)
+#
+# OWNERSHIP MAP (ci/path-ownership.toml, design §4.2):
+#   The §4.1 full-run trigger table is baked in here as built-in DEFAULTS so the
+#   selector fail-closes correctly on a clean clone even before the map file
+#   exists. When `ci/path-ownership.toml` IS present it EXTENDS behaviour:
+#   attributes non-crate paths to the crates whose tests read them, or marks a
+#   path SAFE (proven inert for the Rust matrix). Bead sq-fmx4u.2 ships + audits
+#   that map; this selector merely reads it. Absent map => built-in triggers +
+#   crate-prefix ownership only (unmapped/unowned path => full).
+#
+# Usage:
+#   ci_select.py                                   # real: git diff HEAD vs merge-base, cargo metadata
+#   ci_select.py --base <sha> --head <sha>         # explicit revision pair
+#   ci_select.py --event schedule                  # no diff => mode=full
+#   ci_select.py --full                            # forced full (e.g. the `ci-full` label)
+#   ci_select.py --changed-file paths.txt \        # hermetic inputs (tests): newline-delimited
+#                --metadata-file meta.json          # cargo metadata JSON snapshot
+#
+# Stdlib only (design §7 P1): no third-party deps, no compile step. Runs under
+# the CI setup-python 3.12; `tomllib` (stdlib >= 3.11) is imported lazily and
+# only when a map file is actually present.
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+
+# --- §4.1 unconditional full-run triggers (built-in defaults) ----------------
+# Each entry is (pattern, reason). A pattern ending in "/" is a directory prefix
+# (matches the dir itself or anything beneath it); otherwise it is an EXACT
+# repo-relative path. Root "Cargo.toml" therefore matches ONLY the workspace
+# root manifest — a crate's "crates/x/Cargo.toml" is attributed to crate x by
+# ownership (and a version bump there rewrites Cargo.lock => full anyway, §3.3).
+_FULL_TRIGGERS: list[tuple[str, str]] = [
+    ("Cargo.lock", "Cargo.lock changed (resolved versions feed every build)"),
+    ("Cargo.toml", "root Cargo.toml changed (workspace members / deps / lints / profiles / [patch])"),
+    ("rust-toolchain", "toolchain pin changed (compiler version affects all codegen)"),
+    ("rust-toolchain.toml", "toolchain pin changed (compiler version affects all codegen)"),
+    (".cargo/", "cargo config changed (global rustflags / registries / build config)"),
+    (".github/", "CI definition changed (including the selection wiring itself)"),
+    ("scripts/", "shared CI/gate/coverage script changed (executed by CI)"),
+    ("deny.toml", "cargo-deny config changed (redefines a supply-chain green)"),
+    ("supply-chain/", "cargo-vet / supply-chain config changed"),
+    ("ci/path-ownership.toml", "selection policy (ownership map) changed"),
+]
+
+
+class SelectorError(Exception):
+    """Any internal failure. main() traps this => mode=full, exit 0 (§4.3)."""
+
+
+@dataclass
+class Selection:
+    """Rich selection result. main() serialises only {mode, reason, affected}."""
+
+    mode: str  # "selected" | "full"
+    reason: str
+    affected: list[str]  # sorted workspace-member names
+    # Transparency detail for the step-summary (design §5.1); not in the JSON contract.
+    changed_crates: list[str] = field(default_factory=list)
+    file_owners: list[tuple[str, str]] = field(default_factory=list)  # (path, owner-label)
+    all_members: list[str] = field(default_factory=list)
+
+    def to_json_obj(self) -> dict:
+        return {"mode": self.mode, "reason": self.reason, "affected": self.affected}
+
+
+# --- metadata model ----------------------------------------------------------
+@dataclass
+class Workspace:
+    root: str
+    members: set[str]  # workspace-member package names
+    # in-repo path packages (members + non-member in-repo path deps): name -> rel dir
+    owners: list[tuple[str, str]]  # (rel_dir, name), only non-empty dirs, sorted longest-first
+    reverse_adj: dict[str, set[str]]  # dep-name -> {packages that depend on it}
+
+
+def _rel_dir(manifest_path: str, root: str) -> str:
+    """Repo-relative POSIX dir of a Cargo.toml, or '' if outside root / at root."""
+    mp = PurePosixPath(manifest_path)
+    rt = PurePosixPath(root)
+    try:
+        rel = mp.parent.relative_to(rt)
+    except ValueError:
+        return ""  # manifest lives outside the repo root
+    s = rel.as_posix()
+    return "" if s == "." else s
+
+
+def parse_workspace(meta: dict) -> Workspace:
+    """Build the in-repo dependency model from `cargo metadata` JSON.
+
+    In-repo path packages = packages whose `source` is null (path/workspace, not
+    a registry/git dep) AND whose manifest lives under `workspace_root`. This
+    covers workspace members PLUS any non-member in-repo path dependency
+    (design §3.2, P3). Edges are the package-level dependency lists — normal +
+    dev + build kinds, optional regardless of feature, target-specific
+    regardless of host (design §3.3, P2): a conservative superset of any
+    feature-resolved graph.
+    """
+    try:
+        root = meta["workspace_root"]
+        packages = meta["packages"]
+        member_ids = set(meta["workspace_members"])
+    except (KeyError, TypeError) as exc:
+        raise SelectorError(f"cargo metadata missing expected keys: {exc}") from exc
+
+    id_to_name: dict[str, str] = {}
+    inrepo_names: set[str] = set()
+    inrepo_dirs: dict[str, str] = {}
+    inrepo_deps: dict[str, list[dict]] = {}
+
+    for pkg in packages:
+        pid = pkg.get("id")
+        name = pkg.get("name")
+        if pid is not None and name is not None:
+            id_to_name[pid] = name
+        # source == null AND manifest under root => an in-repo path package.
+        if pkg.get("source") is None and name is not None:
+            rel = _rel_dir(pkg.get("manifest_path", ""), root)
+            # A manifest outside the root yields '' here; skip those (external
+            # path deps live outside the repo and cannot own a changed path).
+            manifest_under_root = str(pkg.get("manifest_path", "")).startswith(str(root))
+            if manifest_under_root:
+                inrepo_names.add(name)
+                inrepo_dirs[name] = rel
+                inrepo_deps[name] = pkg.get("dependencies", [])
+
+    members = {id_to_name[i] for i in member_ids if i in id_to_name}
+
+    # Reverse edges among in-repo packages only. A dependency is matched to an
+    # in-repo package by NAME (our crate names are distinctive `sparq-*`); this
+    # is deliberately conservative — if in doubt, an edge is included (run more).
+    reverse_adj: dict[str, set[str]] = {n: set() for n in inrepo_names}
+    for name, deps in inrepo_deps.items():
+        for dep in deps:
+            dn = dep.get("name")
+            if dn in inrepo_names and dn != name:
+                reverse_adj[dn].add(name)
+
+    owners = sorted(
+        ((d, n) for n, d in inrepo_dirs.items() if d),  # drop empty-dir (root) owners: fail-safe
+        key=lambda pair: len(pair[0]),
+        reverse=True,
+    )
+    return Workspace(root=root, members=members, owners=owners, reverse_adj=reverse_adj)
+
+
+def reverse_closure(crate: str, reverse_adj: dict[str, set[str]]) -> set[str]:
+    """{crate} U all transitive dependents of crate."""
+    seen = {crate}
+    stack = [crate]
+    while stack:
+        cur = stack.pop()
+        for dependent in reverse_adj.get(cur, ()):  # .get() tolerates a missing key
+            if dependent not in seen:
+                seen.add(dependent)
+                stack.append(dependent)
+    return seen
+
+
+# --- ownership matching ------------------------------------------------------
+def _trigger_match(path: str) -> str | None:
+    for pattern, reason in _FULL_TRIGGERS:
+        if pattern.endswith("/"):
+            if path == pattern.rstrip("/") or path.startswith(pattern):
+                return reason
+        elif path == pattern:
+            return reason
+    return None
+
+
+def owning_package(path: str, owners: list[tuple[str, str]]) -> str | None:
+    """Longest-prefix crate that owns `path`, or None (design §3.2)."""
+    for reldir, name in owners:  # owners is pre-sorted longest-first
+        if path == reldir or path.startswith(reldir + "/"):
+            return name
+    return None
+
+
+def _glob_match(path: str, pattern: str) -> bool:
+    """Match an ownership-map pattern. `dir/**` => any path under dir; else fnmatch."""
+    if pattern.endswith("/**"):
+        root = pattern[:-3]
+        return path == root or path.startswith(root + "/")
+    return fnmatch.fnmatch(path, pattern)
+
+
+def apply_ownership_map(path: str, map_entries: list[dict]) -> tuple[str, list[str]] | None:
+    """First matching map entry wins.
+
+    Returns ("safe", []) for a SAFE-listed path, ("crates", [names]) for an
+    attributed path, or None if no entry matches (=> caller treats as unowned).
+    """
+    for entry in map_entries:
+        pattern = entry.get("pattern")
+        if not isinstance(pattern, str) or not _glob_match(path, pattern):
+            continue
+        if entry.get("safe") is True:
+            return ("safe", [])
+        crates = entry.get("crates")
+        if isinstance(crates, list) and all(isinstance(c, str) for c in crates):
+            return ("crates", list(crates))
+        # Malformed entry (matched but neither safe nor a crate list) => fail-safe.
+        raise SelectorError(f"ownership-map entry for {pattern!r} is neither safe nor a crate list")
+    return None
+
+
+# --- the selection ----------------------------------------------------------
+def select(
+    changed_paths: list[str],
+    meta: dict,
+    map_entries: list[dict] | None = None,
+) -> Selection:
+    """Pure core: changed paths + cargo metadata + optional map -> Selection.
+
+    Raises SelectorError on any malformed input; main() traps that to mode=full.
+    """
+    map_entries = map_entries or []
+    ws = parse_workspace(meta)
+    all_members = sorted(ws.members)
+
+    def full(reason: str) -> Selection:
+        return Selection(
+            mode="full",
+            reason=reason,
+            affected=all_members,  # "return ALL crates" (run everything)
+            all_members=all_members,
+        )
+
+    changed_crates: set[str] = set()
+    file_owners: list[tuple[str, str]] = []
+
+    for path in changed_paths:
+        path = path.strip()
+        if not path:
+            continue
+        trig = _trigger_match(path)
+        if trig is not None:
+            file_owners.append((path, "FULL-TRIGGER"))
+            return full(trig)
+        owner = owning_package(path, ws.owners)
+        if owner is not None:
+            changed_crates.add(owner)
+            file_owners.append((path, owner))
+            continue
+        verdict = apply_ownership_map(path, map_entries)
+        if verdict is None:
+            file_owners.append((path, "UNOWNED"))
+            return full(f"unowned, unmapped path forces full run: {path}")
+        kind, crates = verdict
+        if kind == "safe":
+            file_owners.append((path, "SAFE"))
+            continue
+        # kind == "crates": every mapped crate must be a real workspace member,
+        # else the map is stale/invalid => fail-safe (design §4.2 validity rule).
+        for c in crates:
+            if c not in ws.members:
+                return full(f"ownership map attributes {path} to unknown crate {c!r}")
+        changed_crates.update(crates)
+        file_owners.append((path, "+".join(crates)))
+
+    affected: set[str] = set()
+    for c in changed_crates:
+        affected |= reverse_closure(c, ws.reverse_adj)
+    affected &= ws.members
+
+    if changed_crates and not affected:
+        # A non-member in-repo path dep changed but nothing member-facing depends
+        # on it; still surface it as changed but with an empty member set.
+        reason = "changed in-repo package(s) have no member dependents"
+    elif not changed_crates:
+        reason = "all changed paths are SAFE-listed or non-crate; no crate affected"
+    else:
+        skipped = len(ws.members) - len(affected)
+        reason = f"{len(affected)} of {len(ws.members)} members affected ({skipped} skippable)"
+
+    return Selection(
+        mode="selected",
+        reason=reason,
+        affected=sorted(affected),
+        changed_crates=sorted(changed_crates),
+        file_owners=file_owners,
+        all_members=all_members,
+    )
+
+
+# --- map validity (design §4.2; #1392 refinement) ---------------------------
+def validate_map(
+    map_entries: list[dict],
+    members: set[str],
+    known_generated_roots: set[str] | None = None,
+    repo_root: str | None = None,
+) -> list[str]:
+    """Return a list of map-validity problems (empty == valid).
+
+    Refinement from #1392: pattern-root existence is checked against a
+    FETCHED/GENERATED allowlist, not a brittle on-disk check — otherwise a
+    perfectly valid pattern like `tests/w3c/**` (the W3C suite is FETCHED by
+    scripts/fetch-conformance.sh and gitignored) would falsely fail on a clean
+    clone. The crate allowlist is likewise GENERATED from `cargo metadata`
+    (`members`), so it never rots when crates move.
+    """
+    known_generated_roots = known_generated_roots or set()
+    problems: list[str] = []
+    for i, entry in enumerate(map_entries):
+        pattern = entry.get("pattern")
+        if not isinstance(pattern, str):
+            problems.append(f"entry #{i}: missing/invalid `pattern`")
+            continue
+        is_safe = entry.get("safe") is True
+        crates = entry.get("crates")
+        if not is_safe and crates is None:
+            problems.append(f"{pattern!r}: neither `safe` nor `crates` set")
+        if crates is not None:
+            if not isinstance(crates, list):
+                problems.append(f"{pattern!r}: `crates` must be a list")
+            else:
+                for c in crates:
+                    if c not in members:
+                        problems.append(f"{pattern!r}: unknown crate {c!r} (not a workspace member)")
+        # Pattern-root existence, tolerant of fetched/generated dirs.
+        root = pattern[:-3] if pattern.endswith("/**") else pattern
+        root = root.split("*", 1)[0].rstrip("/")
+        if root and root not in known_generated_roots and repo_root is not None:
+            on_disk = os.path.exists(os.path.join(repo_root, root))
+            if not on_disk:
+                problems.append(f"{pattern!r}: pattern root {root!r} does not exist and is not allowlisted")
+    return problems
+
+
+# --- input gathering (real, non-hermetic) -----------------------------------
+def _run(cmd: list[str], cwd: str | None = None) -> str:
+    try:
+        out = subprocess.run(
+            cmd, cwd=cwd, check=True, capture_output=True, text=True, timeout=180
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        raise SelectorError(f"command failed: {' '.join(cmd)}: {exc}") from exc
+    return out.stdout
+
+
+def git_changed_paths(base: str, head: str, repo_root: str | None) -> list[str]:
+    # Three-dot = diff against the merge-base; --no-renames reports a move as
+    # delete+add so BOTH crate dirs are attributed (design §3.1).
+    out = _run(
+        ["git", "diff", "--name-only", "--no-renames", f"{base}...{head}"],
+        cwd=repo_root,
+    )
+    return [ln for ln in out.splitlines() if ln.strip()]
+
+
+def load_metadata(metadata_file: str | None, repo_root: str | None) -> dict:
+    if metadata_file:
+        with open(metadata_file, encoding="utf-8") as fh:
+            return json.load(fh)
+    out = _run(["cargo", "metadata", "--format-version", "1", "--locked"], cwd=repo_root)
+    return json.loads(out)
+
+
+def load_ownership_map(map_file: str | None) -> list[dict]:
+    """Read ci/path-ownership.toml if present. Absent => []. Malformed => error."""
+    if not map_file or not os.path.exists(map_file):
+        return []
+    try:
+        import tomllib  # stdlib >= 3.11
+    except ModuleNotFoundError as exc:  # pragma: no cover - CI is 3.12
+        raise SelectorError("tomllib unavailable (needs Python >= 3.11) but a map file exists") from exc
+    try:
+        with open(map_file, "rb") as fh:
+            data = tomllib.load(fh)
+    except (tomllib.TOMLDecodeError, OSError) as exc:
+        raise SelectorError(f"malformed ownership map {map_file}: {exc}") from exc
+    entries = data.get("map", [])
+    if not isinstance(entries, list):
+        raise SelectorError("ownership map: [[map]] must be an array of tables")
+    return entries
+
+
+# --- step summary + outputs --------------------------------------------------
+def render_summary(sel: Selection) -> str:
+    lines = ["### CI test-selection", "", f"**Mode:** `{sel.mode}` — {sel.reason}", ""]
+    if sel.file_owners:
+        lines += ["| Changed file | Owning crate |", "|---|---|"]
+        for path, owner in sel.file_owners:
+            lines.append(f"| `{path}` | {owner} |")
+        lines.append("")
+    if sel.mode == "selected":
+        total = len(sel.all_members)
+        run = len(sel.affected)
+        lines.append(f"**Affected closure ({run} of {total}):** " + (", ".join(sel.affected) or "_none_"))
+        lines.append("")
+        lines.append(f"**Skipped by selection:** {total - run} of {total} members")
+    else:
+        lines.append("**Full matrix:** every crate runs.")
+    return "\n".join(lines) + "\n"
+
+
+def _write_outputs(sel: Selection, output_file: str | None, summary_file: str | None) -> None:
+    if output_file:
+        with open(output_file, "a", encoding="utf-8") as fh:
+            fh.write(f"mode={sel.mode}\n")
+            fh.write("affected=" + json.dumps(sel.affected) + "\n")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as fh:
+            fh.write(render_summary(sel))
+
+
+# --- main --------------------------------------------------------------------
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Change-based CI test-selection (design §3).")
+    p.add_argument("--event", default="pull_request",
+                   help="GitHub event; schedule/workflow_dispatch => full")
+    p.add_argument("--full", action="store_true", help="force mode=full (e.g. the ci-full label)")
+    p.add_argument("--base", help="base SHA/ref for the three-dot diff")
+    p.add_argument("--head", default="HEAD", help="head SHA/ref (default HEAD)")
+    p.add_argument("--changed-file", help="hermetic: newline-delimited changed paths")
+    p.add_argument("--metadata-file", help="hermetic: cargo metadata JSON snapshot")
+    p.add_argument("--map", dest="map_file", help="ownership map toml (default ci/path-ownership.toml)")
+    p.add_argument("--repo-root", help="repo root (default: git toplevel / workspace_root)")
+    p.add_argument("--summary-file", help="write markdown step-summary (default $GITHUB_STEP_SUMMARY)")
+    p.add_argument("--output-file", help="write mode/affected outputs (default $GITHUB_OUTPUT)")
+    return p.parse_args(argv)
+
+
+def _resolve_repo_root(explicit: str | None) -> str | None:
+    if explicit:
+        return explicit
+    try:
+        return _run(["git", "rev-parse", "--show-toplevel"]).strip()
+    except SelectorError:
+        return None
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    summary_file = args.summary_file or os.environ.get("GITHUB_STEP_SUMMARY")
+    output_file = args.output_file or os.environ.get("GITHUB_OUTPUT")
+
+    try:
+        repo_root = _resolve_repo_root(args.repo_root)
+
+        # Events with no diff, or the explicit override => full (design §3.1, §6).
+        if args.full or args.event in ("schedule", "workflow_dispatch"):
+            reason = "forced full run (ci-full override)" if args.full else f"{args.event} event: no diff"
+            meta = load_metadata(args.metadata_file, repo_root)
+            ws = parse_workspace(meta)
+            sel = Selection(mode="full", reason=reason, affected=sorted(ws.members),
+                            all_members=sorted(ws.members))
+        else:
+            if args.changed_file:
+                with open(args.changed_file, encoding="utf-8") as fh:
+                    changed = [ln for ln in fh.read().splitlines() if ln.strip()]
+            else:
+                if not args.base:
+                    raise SelectorError("--base is required for a diff-based run")
+                changed = git_changed_paths(args.base, args.head, repo_root)
+
+            map_file = args.map_file
+            if map_file is None and repo_root is not None:
+                candidate = os.path.join(repo_root, "ci", "path-ownership.toml")
+                map_file = candidate if os.path.exists(candidate) else None
+            map_entries = load_ownership_map(map_file)
+
+            meta = load_metadata(args.metadata_file, repo_root)
+            sel = select(changed, meta, map_entries)
+
+    except Exception as exc:  # fail-closed boundary: ANY error => full run (design §4.3)
+        # We could not even build the member list; emit full with an empty
+        # affected is still "run everything" downstream (mode != 'selected').
+        sel = Selection(mode="full", reason=f"selector error, failing to full run: {exc}", affected=[])
+
+    print(json.dumps(sel.to_json_obj(), indent=2))
+    try:
+        _write_outputs(sel, output_file, summary_file)
+    except OSError:
+        pass  # never let a summary/output write turn a full run into a failure
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_ci_select.py
+++ b/scripts/tests/test_ci_select.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Hermetic unit tests for the change-based CI test-selector
+# (bead sq-fmx4u.1, epic sq-fmx4u). Authored by Opus 4.8 (Fable unavailable;
+# flag for re-review when Fable returns).
+#
+# Covers the design §3/§4 golden cases + the bead acceptance criteria (a)-(i):
+#   (a) leaf-crate change   => exactly that crate
+#   (b) sparq-core change    => all workspace members
+#   (c) dev-dep edge         propagates to the dependent's tests
+#   (d) optional-dep edge    propagates
+#   (e) file move            marks BOTH crates
+#   (f) unowned/unmapped     => full  (fail-safe)
+#   (g) every §4.1 trigger   => full  (fail-safe)
+#   (h) forced internal error=> mode=full, exit 0  (fail-closed)
+#   (i) REAL cargo-metadata  closure shape (core root-like, geo leaf-like)
+#
+# Almost fully hermetic: the synthetic-graph cases build `cargo metadata`-shaped
+# dicts in-process (no workspace resolve). Case (i) shells out to
+# `cargo metadata --no-deps` and self-SKIPS when cargo is unavailable, so the
+# suite never REQUIRES a live cargo (task hermeticity rule).
+#
+# Run:  python3 scripts/tests/test_ci_select.py   (stdlib only; no pytest needed)
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CI_SELECT = REPO_ROOT / "scripts" / "ci_select.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("ci_select", CI_SELECT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["ci_select"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cs = _load_module()
+
+ROOT = "/repo"
+
+
+def _dep(name, kind=None, optional=False, target=None):
+    return {"name": name, "kind": kind, "optional": optional, "target": target, "path": None}
+
+
+def _pkg(name, reldir, deps=(), source=None):
+    return {
+        "id": f"path+file://{ROOT}/{reldir}#0.1.0",
+        "name": name,
+        "source": source,
+        "manifest_path": f"{ROOT}/{reldir}/Cargo.toml",
+        "dependencies": list(deps),
+    }
+
+
+def _synthetic_meta():
+    """A small DAG rooted at `core` (everything depends on core), with `app` a
+    reverse-graph leaf. Exercises normal, dev, build and optional edges.
+
+        core  <- parse <- engine <- app
+        core  <- devlib (dev-dep of engine)
+        core  <- optlib (optional dep of engine)
+        core  <- buildlib (build-dep of parse)
+    """
+    pkgs = [
+        _pkg("core", "crates/core", []),
+        _pkg("parse", "crates/parse", [_dep("core"), _dep("buildlib", kind="build")]),
+        _pkg("engine", "crates/engine",
+             [_dep("core"), _dep("parse"), _dep("devlib", kind="dev"),
+              _dep("optlib", optional=True)]),
+        _pkg("app", "crates/app", [_dep("core"), _dep("engine")]),
+        _pkg("devlib", "crates/devlib", [_dep("core")]),
+        _pkg("optlib", "crates/optlib", [_dep("core")]),
+        _pkg("buildlib", "crates/buildlib", [_dep("core")]),
+        # A registry dep sharing NOTHING in-repo: must be ignored as an owner/edge.
+        {"id": "registry+x#1.0", "name": "serde", "source": "registry+https://x",
+         "manifest_path": "/reg/serde/Cargo.toml", "dependencies": []},
+    ]
+    member_ids = [p["id"] for p in pkgs if p["source"] is None]
+    return {"workspace_root": ROOT, "packages": pkgs, "workspace_members": member_ids}
+
+
+ALL_MEMBERS = ["app", "buildlib", "core", "devlib", "engine", "optlib", "parse"]
+
+
+class SyntheticGraphTests(unittest.TestCase):
+    def setUp(self):
+        self.meta = _synthetic_meta()
+
+    def _select(self, paths, map_entries=None):
+        return cs.select(paths, self.meta, map_entries)
+
+    def test_a_leaf_crate_change_is_exactly_that_crate(self):
+        sel = self._select(["crates/app/src/lib.rs"])
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, ["app"])
+
+    def test_b_core_change_is_all_members(self):
+        sel = self._select(["crates/core/src/dict.rs"])
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, ALL_MEMBERS)
+
+    def test_c_dev_dep_edge_propagates(self):
+        # devlib is a DEV-dep of engine; a devlib change must pull engine (+ app).
+        sel = self._select(["crates/devlib/src/lib.rs"])
+        self.assertEqual(sel.mode, "selected")
+        self.assertIn("engine", sel.affected)
+        self.assertEqual(sel.affected, ["app", "devlib", "engine"])
+
+    def test_d_optional_dep_edge_propagates(self):
+        # optlib is an OPTIONAL dep of engine; included regardless of features.
+        sel = self._select(["crates/optlib/src/lib.rs"])
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, ["app", "engine", "optlib"])
+
+    def test_build_dep_edge_propagates(self):
+        # buildlib is a BUILD-dep of parse; build kind is included.
+        sel = self._select(["crates/buildlib/build_input.rs"])
+        self.assertEqual(sel.affected, ["app", "buildlib", "engine", "parse"])
+
+    def test_e_file_move_marks_both_crates(self):
+        # --no-renames reports a move as delete+add; BOTH crate dirs attributed.
+        sel = self._select(["crates/devlib/moved.rs", "crates/buildlib/moved.rs"])
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sorted(sel.changed_crates), ["buildlib", "devlib"])
+        # parse is reachable ONLY via buildlib, engine via both -> proves union.
+        self.assertIn("parse", sel.affected)
+        self.assertIn("devlib", sel.affected)
+
+    def test_f_unowned_unmapped_path_is_full(self):
+        sel = self._select(["docs/whatever.md"])
+        self.assertEqual(sel.mode, "full")
+        self.assertIn("unowned", sel.reason)
+        self.assertEqual(sel.affected, ALL_MEMBERS)  # full => run ALL crates
+
+    def test_g_every_full_run_trigger_is_full(self):
+        triggers = [
+            "Cargo.lock",
+            "Cargo.toml",
+            "rust-toolchain",
+            "rust-toolchain.toml",
+            ".cargo/config.toml",
+            ".github/workflows/ci.yml",
+            "scripts/ci_select.py",
+            "deny.toml",
+            "supply-chain/audits.toml",
+            "ci/path-ownership.toml",
+        ]
+        for path in triggers:
+            with self.subTest(path=path):
+                sel = self._select([path, "crates/app/src/lib.rs"])
+                self.assertEqual(sel.mode, "full", f"{path} should force full")
+                self.assertEqual(sel.affected, ALL_MEMBERS)
+
+    def test_crate_cargo_toml_is_owned_not_a_root_trigger(self):
+        # A crate manifest is owned by that crate (NOT caught by root Cargo.toml).
+        sel = self._select(["crates/app/Cargo.toml"])
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, ["app"])
+
+    def test_longest_prefix_ownership(self):
+        # Nested-crate safety: prefix match must not leak across sibling dirs.
+        sel = self._select(["crates/engine/benches/x.rs"])
+        self.assertEqual(sel.changed_crates, ["engine"])
+
+    def test_json_contract_keys(self):
+        sel = self._select(["crates/app/src/lib.rs"])
+        obj = sel.to_json_obj()
+        self.assertEqual(set(obj), {"mode", "reason", "affected"})
+
+
+class OwnershipMapTests(unittest.TestCase):
+    def setUp(self):
+        self.meta = _synthetic_meta()
+
+    def test_safe_entry_is_ignored(self):
+        # research/** SAFE + a real crate change => only the crate counts.
+        m = [{"pattern": "research/**", "safe": True}]
+        sel = cs.select(["research/foo.md", "crates/app/src/lib.rs"], self.meta, m)
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, ["app"])
+
+    def test_safe_only_change_selects_empty(self):
+        m = [{"pattern": "research/**", "safe": True}]
+        sel = cs.select(["research/foo.md"], self.meta, m)
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, [])
+
+    def test_map_attributes_out_of_crate_path(self):
+        # The #1392 refinement: the REAL fetched W3C path is tests/w3c/** and it
+        # is read by the conformance crate (here mapped to `engine`).
+        m = [{"pattern": "tests/w3c/**", "crates": ["engine"]}]
+        sel = cs.select(["tests/w3c/rdf-tests/data.ttl"], self.meta, m)
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, ["app", "engine"])
+
+    def test_map_unknown_crate_fails_safe(self):
+        m = [{"pattern": "tests/w3c/**", "crates": ["ghost-crate"]}]
+        sel = cs.select(["tests/w3c/x"], self.meta, m)
+        self.assertEqual(sel.mode, "full")
+        self.assertIn("unknown crate", sel.reason)
+
+    def test_map_malformed_entry_raises(self):
+        m = [{"pattern": "tests/w3c/**"}]  # neither safe nor crates
+        with self.assertRaises(cs.SelectorError):
+            cs.select(["tests/w3c/x"], self.meta, m)
+
+
+class MapValidityTests(unittest.TestCase):
+    # #1392 refinement: validity uses a FETCHED/GENERATED allowlist, not a
+    # brittle on-disk check, so `tests/w3c/**` (fetched, gitignored) validates
+    # clean on a clean clone.
+    def test_fetched_root_validates_when_allowlisted(self):
+        members = {"sparq-conformance"}
+        entries = [{"pattern": "tests/w3c/**", "crates": ["sparq-conformance"]}]
+        with tempfile.TemporaryDirectory() as tmp:  # tests/w3c absent on disk
+            problems = cs.validate_map(
+                entries, members,
+                known_generated_roots={"tests/w3c"}, repo_root=tmp,
+            )
+        self.assertEqual(problems, [])
+
+    def test_unknown_crate_flagged(self):
+        problems = cs.validate_map(
+            [{"pattern": "x/**", "crates": ["nope"]}],
+            members={"sparq-core"}, known_generated_roots={"x"},
+        )
+        self.assertTrue(any("unknown crate" in p for p in problems))
+
+    def test_missing_nonallowlisted_root_flagged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            problems = cs.validate_map(
+                [{"pattern": "nonexistent/**", "safe": True}],
+                members=set(), known_generated_roots=set(), repo_root=tmp,
+            )
+        self.assertTrue(any("does not exist" in p for p in problems))
+
+
+class FailClosedMainTests(unittest.TestCase):
+    """(h) ANY internal error => mode=full, exit 0 — the fail-closed boundary."""
+
+    def _run_main(self, argv):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = cs.main(argv)
+        return code, json.loads(buf.getvalue())
+
+    def _write(self, text, suffix=".json"):
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
+        return path
+
+    def test_malformed_metadata_json_fails_full(self):
+        meta_path = self._write("{ this is not json ")
+        changed = self._write("crates/app/src/lib.rs\n", suffix=".txt")
+        code, obj = self._run_main(["--metadata-file", meta_path, "--changed-file", changed,
+                                    "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "full")
+
+    def test_missing_metadata_keys_fails_full(self):
+        meta_path = self._write(json.dumps({"packages": []}))  # no workspace_root/members
+        changed = self._write("crates/app/src/lib.rs\n", suffix=".txt")
+        code, obj = self._run_main(["--metadata-file", meta_path, "--changed-file", changed,
+                                    "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "full")
+
+    def test_nonexistent_metadata_file_fails_full(self):
+        changed = self._write("crates/app/src/lib.rs\n", suffix=".txt")
+        code, obj = self._run_main(["--metadata-file", "/no/such/meta.json",
+                                    "--changed-file", changed, "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "full")
+
+    def test_schedule_event_is_full(self):
+        meta_path = self._write(json.dumps(_synthetic_meta()))
+        code, obj = self._run_main(["--event", "schedule", "--metadata-file", meta_path,
+                                    "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "full")
+        self.assertEqual(obj["affected"], ALL_MEMBERS)
+
+    def test_ci_full_override_is_full(self):
+        meta_path = self._write(json.dumps(_synthetic_meta()))
+        code, obj = self._run_main(["--full", "--metadata-file", meta_path, "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "full")
+
+    def test_hermetic_end_to_end_selected(self):
+        meta_path = self._write(json.dumps(_synthetic_meta()))
+        changed = self._write("crates/app/src/lib.rs\n", suffix=".txt")
+        code, obj = self._run_main(["--metadata-file", meta_path, "--changed-file", changed,
+                                    "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "selected")
+        self.assertEqual(obj["affected"], ["app"])
+
+
+class RealMetadataShapeTests(unittest.TestCase):
+    """(i) Pinned against the REAL workspace metadata: core is root-like, geo is
+    leaf-like, and closure(geo) is a subset of closure(core) (structural: geo
+    depends on core, so anything depending on geo depends on core)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.meta = None
+        if shutil.which("cargo") is None:
+            return
+        try:
+            out = subprocess.run(
+                ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+                cwd=str(REPO_ROOT), check=True, capture_output=True, text=True, timeout=180,
+            )
+            cls.meta = json.loads(out.stdout)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError, ValueError):
+            cls.meta = None
+
+    def setUp(self):
+        if self.meta is None:
+            self.skipTest("cargo metadata unavailable (hermetic skip)")
+
+    def test_core_root_like_geo_leaf_like(self):
+        ws = cs.parse_workspace(self.meta)
+        self.assertIn("sparq-core", ws.members)
+        self.assertIn("sparq-geo", ws.members)
+        core = cs.reverse_closure("sparq-core", ws.reverse_adj)
+        geo = cs.reverse_closure("sparq-geo", ws.reverse_adj)
+        n = len(ws.members)
+        # core is root-like: a large majority of the workspace depends on it.
+        self.assertGreaterEqual(len(core), n // 2)
+        # geo is leaf-like: only a small handful depend on it.
+        self.assertLess(len(geo), n // 4)
+        # structural invariants that survive crate additions:
+        self.assertIn("sparq-geo", core)               # geo depends on core
+        self.assertNotIn("sparq-core", geo)            # core does not depend on geo
+        self.assertTrue(geo.issubset(core))            # closure(geo) subset of closure(core)
+        self.assertGreater(len(core), len(geo))        # core strictly more root-like
+
+    def test_selected_mode_on_real_leaf_change(self):
+        sel = cs.select(["crates/sparq-geo/src/lib.rs"], self.meta)
+        self.assertEqual(sel.mode, "selected")
+        self.assertIn("sparq-geo", sel.affected)
+        self.assertNotIn("sparq-parse", sel.affected)  # parse does not depend on geo
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated change; see self-ID footer.

## What

Implements bead **sq-fmx4u.1** (epic **sq-fmx4u**): the change-based CI test-selection **affected-set selector** — design record `research/change-based-test-selection.md` §3, §4, §7 (PR #1392).

**Selector library only.** The CI wiring — the `select` pre-job, job-level `if:` guards, nextest filtersets, `ci-summary` semantics, backstops — is the later beads **sq-fmx4u.2–.6**. This PR touches **no** workflow and no `crates/` source. New files only:

- `scripts/ci_select.py` — given a git diff (changed-path set), computes the set of crates whose tests/benchmarks MUST run = the reverse-dependency closure (transitive dependents) of every changed crate, from `cargo metadata` package-level edges (normal + dev + build kinds, optional regardless of features, target-specific regardless of host — a conservative superset of any feature-resolved graph, §3.3 / P2). Emits `{"mode": "selected"|"full", "reason", "affected"}` JSON, a `GITHUB_OUTPUT` (`mode` / `affected`) and a step-summary markdown table.
- `scripts/tests/test_ci_select.py` — 27 hermetic `unittest` cases.

## Fail-safe / fail-closed is the core invariant (design §2, §4.3)

*A test is skipped ⇒ provably no change could affect it.* Absence of proof ⇒ run. The selector returns **`mode=full` (run ALL crates)** whenever:

- a changed path matches a §4.1 **full-run trigger** — `Cargo.lock`, root `Cargo.toml`, `rust-toolchain[.toml]`, `.cargo/**`, `.github/**`, `scripts/**` (incl. the selector itself), `deny.toml`, `supply-chain/**`, `ci/path-ownership.toml`;
- any changed path cannot be confidently attributed to a crate (unowned + unmapped);
- **ANY** internal error (metadata parse, diff failure, unfetchable base, malformed map) → `mode=full`, **exit 0**.

The §4.1 trigger table is baked in as built-in defaults so the selector fail-closes correctly on a clean clone *before* the `ci/path-ownership.toml` map (bead .2) exists; when that map is present it merely EXTENDS behaviour (attribute out-of-crate paths / mark SAFE). This is a deliberate reconciliation of the bead's "ship a starter map" wording with the "new files only" scope — noted here for the maintainer to steer.

## #1392 review refinements honored

- The real fetched W3C suite path is **`tests/w3c/**`** (gitignored, fetched by `scripts/fetch-conformance.sh`, read by `sparq-conformance` via `../../tests/w3c`) — used in the map fixtures, not the design's placeholder `testsuites/w3c-sparql/**`.
- **Map-validity uses a fetched/generated allowlist**: crate names are validated against the `cargo metadata`-generated member set, and pattern-root existence tolerates known fetched/generated roots — so `tests/w3c/**` does not falsely fail on a clean clone.

## Verification

- `python3 scripts/tests/test_ci_select.py` → **27 passed** (acceptance a–i): leaf → exactly that crate; core → all members; dev-dep / optional-dep / build-dep edges propagate; file-move marks BOTH crates; unowned/unmapped → full; every §4.1 trigger → full; forced internal error → `mode=full` exit 0; and one case **pinned against the REAL workspace `cargo metadata`** (sparq-core root-like, sparq-geo leaf-like, `closure(geo) ⊆ closure(core)`).
- `ruff check` (repo default ruleset) → clean; `python3 -m py_compile` → clean.
- Live end-to-end against real `cargo metadata --locked`: a `crates/sparq-geo/src/lib.rs` change selects exactly `{sparq-geo, sparq-cli, sparq-conformance, sparq-server}` (43 of 47 members skippable); a `Cargo.lock` change returns `mode=full`.
- Hermetic tests inject `cargo metadata`-shaped dicts; the one real-metadata case shells out to `cargo metadata --no-deps` and self-**skips** when cargo is unavailable, so the suite never REQUIRES a live workspace resolve.

## Compliance gap closed

Foundation for the change-based selection epic (the real fix for the ~90-check per-PR matrix / CI congestion). This bead closes **only the selector + its tests**; no CI behaviour changes yet — enforcement is gated on the shadow window in sq-fmx4u.5.

Links: sq-fmx4u.1 (this) · epic sq-fmx4u · design PR #1392. Selector library only; CI wiring in sq-fmx4u.2–.6. **Not armed.**

> 🤖 Generated by a **SPARQ agent** (Claude Opus 4.8, 1M context — Fable unavailable; flag for re-review when Fable returns). Human maintainer: @jeswr.