### PR TITLE
perf(ingest): radix-sort permutation indexes (sq-7d3dj.17) [OPUS-4.8]

### DIFF
--- a/bench/perf-baseline.json
+++ b/bench/perf-baseline.json
@@ -73,7 +73,15 @@
     "no --features vectorized). MUST be re-pinned from a CI run — NEVER a local aarch64 measurement.",
     "The vectorized-feature-off gate leg 2 compares against this field, NOT",
     "the floor. A legitimate wasm change (feature add, size opt) MUST update both floor AND feature_off_exact",
-    "in the same PR diff — the script rejects a missing feature_off_exact to prevent silent drift."
+    "in the same PR diff — the script rejects a missing feature_off_exact to prevent silent drift.",
+    "[OPUS-4.8] (sq-7d3dj.17) 2026-07-03: feature_off_exact RE-PINNED 1399110 -> 1399868 (+758 bytes, +0.054%).",
+    "The radix-sort permutation-index change in sparq-core (PR #1407) alters compiled code that sparq-wasm links",
+    "in, so the feature-OFF bundle legitimately grew. The feature-OFF INVARIANT (bundle identical with vectorized",
+    "ON vs OFF) is PRESERVED — only the absolute baseline moved, so re-pinning is correct, not a gate weakening.",
+    "1399868 is the CI x86_64 runner measurement (run 28634216610, artifact-exact-equality leg: cargo build",
+    "--profile release-wasm -p sparq-wasm --target wasm32-unknown-unknown, no --features vectorized) — NEVER a",
+    "local aarch64 build. The ratchet floor (1399703) is UNCHANGED: 1399868 sits within its +2% band (top 1427697),",
+    "so bench.yml stays green; the floor only ratchets DOWN on improvement, never up on a within-band drift."
   ],
   "metrics": {
     "store_bytes_per_triple": {
@@ -95,7 +103,7 @@
       "floor": 1399703,
       "threshold": 0.02,
       "mode": "auto",
-      "feature_off_exact": 1399110
+      "feature_off_exact": 1399868
     },
     "parse_ns_per_byte": {
       "floor": 4.9721,

--- a/crates/sparq-core/src/store.rs
+++ b/crates/sparq-core/src/store.rs
@@ -263,6 +263,67 @@ pub struct TripleStore {
     overlay: Option<Box<Overlay>>,
 }
 
+/// LSD radix sort of `[Id; 3]` rows into ascending lexicographic order — column 0
+/// major, then 1, then 2 — the exact ordering a comparison `sort_unstable()`
+/// produces on the same rows (an `[Id; 3]` compares lexicographically, and with
+/// `Id = u32` the row packs into a 96-bit key whose numeric order IS that
+/// lexicographic order). This is the O(n) index-build sort that replaces the
+/// branchy comparison quicksort over the packed permutation tuples — the single
+/// largest ingest self-time bucket (`research/engine-performance-review.md` §1.1,
+/// sq-7d3dj.17). [OPUS-4.8]
+///
+/// Output equivalence is exact and gated: for any input, the multiset is preserved
+/// and the result is fully sorted, so it is BYTE-IDENTICAL to `sort_unstable()`
+/// (equal rows are indistinguishable, so stability is irrelevant). See the
+/// `radix_sort_equiv_comparison_sort` differential-fuzz test.
+///
+/// Twelve least-significant-digit passes over the 12 key bytes (least-significant
+/// first): passes 0..4 = column 2, 4..8 = column 1, 8..12 = column 0. A pass whose
+/// digit is constant across every row (e.g. the high bytes of a small dictionary)
+/// is a no-op and skipped; the double-buffer invariant keeps the current partial
+/// result in `v` whether or not a pass runs, so the final result is always in `v`.
+fn radix_sort_rows(v: &mut Vec<[Id; 3]>) {
+    let n = v.len();
+    if n < 2 {
+        return;
+    }
+    // Scratch back-buffer; `v` and `scratch` are swapped after each executed pass so
+    // the sorted-so-far data always lives in `v` (a skipped pass leaves it there too).
+    let mut scratch: Vec<[Id; 3]> = vec![[0; 3]; n];
+    for pass in 0..12usize {
+        // Byte `pass` of the packed key, LSB first. col2 holds bytes 0..4, col1 4..8,
+        // col0 8..12 — so the most-significant byte (pass 11) is column 0's top byte.
+        let col = 2 - pass / 4;
+        let shift = ((pass % 4) * 8) as u32;
+        let digit = |row: &[Id; 3]| ((row[col] >> shift) & 0xff) as usize;
+
+        // Histogram of this pass's digit.
+        let mut count = [0usize; 256];
+        for row in v.iter() {
+            count[digit(row)] += 1;
+        }
+        // If every row shares one digit value this pass is a stable no-op — skip the
+        // scatter (and the buffer swap), leaving the correct partial result in `v`.
+        if count[digit(&v[0])] == n {
+            continue;
+        }
+        // Prefix-sum the histogram into per-digit start offsets.
+        let mut sum = 0usize;
+        for c in count.iter_mut() {
+            let here = *c;
+            *c = sum;
+            sum += here;
+        }
+        // Stable scatter into the back-buffer, then make it the live buffer.
+        for row in v.iter() {
+            let d = digit(row);
+            scratch[count[d]] = *row;
+            count[d] += 1;
+        }
+        std::mem::swap(v, &mut scratch);
+    }
+}
+
 impl TripleStore {
     /// Builds the [`BUILT`] permutation indexes from canonical s,p,o triples (all
     /// six by default; just SPO/POS/OSP under `compact-index`). SPO is sorted (in
@@ -296,19 +357,28 @@ impl TripleStore {
     /// six by default; just SPO/POS/OSP under `compact-index`). SPO is sorted (in
     /// parallel) and deduplicated first; the rest are independent and built concurrently.
     fn build_raw_perms(mut triples: Vec<[Id; 3]>) -> [PermData; 6] {
-        // Deduplicate via the SPO ordering first.
+        // Deduplicate via the SPO ordering first. This single large array keeps the
+        // parallel comparison sort: measured on this box, `par_sort_unstable` beats the
+        // sequential radix for one 2M-row array (all cores vs one), so radix here would
+        // REGRESS the SPO/dedup step. The win is below — the FIVE non-SPO permutations move
+        // to the O(n) LSD radix (sq-7d3dj.17), which beats the sequential comparison sort
+        // and is where the flagged sort-family self-time lives (they build concurrently via
+        // par_iter, each a sequential radix). The no-threads build has no parallel sort, so
+        // radix wins the SPO step there too. [OPUS-4.8]
         #[cfg(feature = "parallel")]
         triples.par_sort_unstable();
         #[cfg(not(feature = "parallel"))]
-        triples.sort_unstable();
+        radix_sort_rows(&mut triples);
         triples.dedup();
 
         let build = |order: [usize; 3]| -> Vec<[Id; 3]> {
+            // Pre-sized exactly from the known triple count (the mapped iterator is
+            // ExactSize, so `collect` reserves `triples.len()` up front — no grow tail).
             let mut v: Vec<[Id; 3]> = triples
                 .iter()
                 .map(|t| [t[order[0]], t[order[1]], t[order[2]]])
                 .collect();
-            v.sort_unstable();
+            radix_sort_rows(&mut v);
             v
         };
 
@@ -792,6 +862,120 @@ fn upper_bound(rows: &[[Id; 3]], key: &[Id; 3]) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// MANDATORY differential-fuzz equivalence gate (sq-7d3dj.17): the O(n) LSD
+    /// `radix_sort_rows` used to build every permutation index MUST produce output
+    /// BYTE-IDENTICAL to the comparison `sort_unstable()` it replaces, for every input.
+    /// The permutations back index range lookups and merge-join order, so any divergence
+    /// is a silent correctness bug — this test is the gate that forbids it.
+    ///
+    /// Covers the degenerate shapes the ingest path can hand the sorter: empty, single,
+    /// two (ordered + reversed), all-identical rows, all-same-subject, heavy duplicates,
+    /// the `Id::MAX` boundary (top key bytes = `0xFF`, exercising the no-op-pass skip on a
+    /// non-constant digit), small-range ids (high bytes constant → passes skipped), and
+    /// full 32-bit-range ids (every one of the 12 passes active).
+    #[test]
+    fn radix_sort_equiv_comparison_sort() {
+        // Assert radix output == comparison-sort output on one row set, non-vacuously
+        // (the reference is the exact sort the radix path replaces).
+        fn check(rows: &[[Id; 3]]) {
+            let mut reference = rows.to_vec();
+            reference.sort_unstable();
+            let mut radixed = rows.to_vec();
+            radix_sort_rows(&mut radixed);
+            assert_eq!(radixed, reference, "radix diverged from sort_unstable for {rows:?}");
+        }
+
+        // Fixed degenerate + boundary shapes.
+        check(&[]);
+        check(&[[7, 7, 7]]);
+        check(&[[1, 2, 3], [1, 2, 3]]); // duplicate pair
+        check(&[[2, 0, 0], [1, 0, 0]]); // reversed pair (col-0 tiebreak)
+        check(&[[9; 3]; 64]); // all identical
+        check(&[[5, 1, 9], [5, 3, 2], [5, 2, 2], [5, 2, 1]]); // all-same-subject
+        check(&[
+            [Id::MAX, Id::MAX, Id::MAX],
+            [0, 0, 0],
+            [Id::MAX, 0, Id::MAX],
+            [0, Id::MAX, 0],
+            [Id::MAX, Id::MAX, 0],
+            [1, Id::MAX, Id::MAX],
+        ]); // max-id boundary, high bytes 0xFF but non-constant
+
+        // Randomized sets across several id-range regimes (some keep high key bytes
+        // constant → passes skipped; the full-range regime activates all 12 passes).
+        let mut st = 0x9E3779B9u32;
+        let mut rng = || {
+            st ^= st << 13;
+            st ^= st >> 17;
+            st ^= st << 5;
+            st
+        };
+        for regime in 0..4 {
+            for _ in 0..40 {
+                let n = (rng() % 3000) as usize;
+                let mut rows: Vec<[Id; 3]> = Vec::with_capacity(n);
+                for _ in 0..n {
+                    // Three raw draws, then shape per regime: tiny (byte 0 only), two low
+                    // bytes, ragged per-column widths, or the full 32-bit range.
+                    let (a, b, c) = (rng(), rng(), rng());
+                    let cell = |raw: u32, bits: u32| match regime {
+                        0 => 1 + raw % 16,
+                        1 => 1 + raw % 60_000,
+                        2 => raw & ((1u32 << bits) - 1).max(1),
+                        _ => raw,
+                    };
+                    rows.push([cell(a, 20), cell(b, 12), cell(c, 28)]);
+                }
+                // Salt in exact duplicates + a boundary row so ties + max-id are exercised.
+                if !rows.is_empty() {
+                    rows.push(rows[rows.len() / 2]);
+                    rows.push([Id::MAX, Id::MAX, Id::MAX]);
+                    rows.push([0, 0, 0]);
+                }
+                check(&rows);
+            }
+        }
+    }
+
+    /// End-to-end build equivalence: each BUILT permutation of a radix-built store must
+    /// equal the reference the comparison sort would produce — deduped SPO triples,
+    /// column-permuted, `sort_unstable()`ed. Proves the wiring in `build_raw_perms`, not
+    /// just the sort primitive, and is non-vacuous (the reference is computed independently
+    /// of the store). Runs across both index sets (`compact-index` builds three perms).
+    #[test]
+    fn from_triples_perms_match_reference_sort() {
+        let mut st = 0xC0FFEEu32;
+        let mut rng = || {
+            st ^= st << 13;
+            st ^= st >> 17;
+            st ^= st << 5;
+            st
+        };
+        for _ in 0..8 {
+            let n = 500 + (rng() % 4000) as usize;
+            let mut triples: Vec<[Id; 3]> = Vec::with_capacity(n);
+            for _ in 0..n {
+                triples.push([1 + rng() % 300, 1 + rng() % 20, 1 + rng() % 1500]);
+            }
+            // Reference deduped SPO set (independent of the store under test).
+            let mut deduped = triples.clone();
+            deduped.sort_unstable();
+            deduped.dedup();
+
+            let store = TripleStore::from_triples(triples);
+            for &perm in BUILT {
+                let order = perm.order();
+                let mut want: Vec<[Id; 3]> = deduped
+                    .iter()
+                    .map(|t| [t[order[0]], t[order[1]], t[order[2]]])
+                    .collect();
+                want.sort_unstable();
+                let got = store.perms[perm as usize].as_slice();
+                assert_eq!(got, &want[..], "permutation {perm:?} differs from the comparison-sort reference");
+            }
+        }
+    }
 
     /// The compressed store must answer EVERY triple pattern with the exact same rows
     /// (and the same `estimate`) as the raw store — across all bound/unbound shapes and

--- a/scripts/check-vectorized-feature-off.py
+++ b/scripts/check-vectorized-feature-off.py
@@ -402,8 +402,8 @@ def run_self_test() -> int:
 
     # ----- Tripwire 2: Leg 2 must reject a perturbed wasm bundle size -----
     # [OPUS-4.8] Uses feature_off_exact (NOT floor) — mirrors the live check_leg2() logic.
-    # 1399110 = CI x86_64 feature-OFF wasm bytes. Re-pin from a CI run, never from aarch64.
-    pinned_exact = 1399110
+    # 1399868 = CI x86_64 feature-OFF wasm bytes. Re-pin from a CI run, never from aarch64.
+    pinned_exact = 1399868
     perturbed = pinned_exact + 1  # 1 byte off — must be caught
     bad_results = [{"name": "wasm_bundle_bytes", "unit": "bytes", "value": perturbed}]
     bad_floor = {

--- a/scripts/tests/test_vectorized_feature_off.py
+++ b/scripts/tests/test_vectorized_feature_off.py
@@ -156,7 +156,7 @@ def test_leg2_comparator_rejects_perturbed_size() -> bool:
     (1399703) is the 2%-band ratchet lower bound for bench.yml; the exact equality pin
     is separate so that within-band main drift does not cause a false failure.
     """
-    pinned_exact = 1399110  # [OPUS-4.8] CI x86_64 feature_off_exact pin. Re-pin from CI, never aarch64.
+    pinned_exact = 1399868  # [OPUS-4.8] CI x86_64 feature_off_exact pin. Re-pin from CI, never aarch64.
     perturbed = pinned_exact + 1
     bad_results = [{"name": "wasm_bundle_bytes", "unit": "bytes", "value": perturbed}]
     bad_floor = {
@@ -186,7 +186,7 @@ def test_leg2_rejects_missing_pin() -> bool:
     in the floor, so a corrupted/edited baseline that drops the pin would otherwise
     yield zero violations and silently pass — disabling the exact-equality gate.
     """
-    good_results = [{"name": "wasm_bundle_bytes", "unit": "bytes", "value": 1399110}]
+    good_results = [{"name": "wasm_bundle_bytes", "unit": "bytes", "value": 1399868}]
     floor_without_pin = {
         "metrics": {
             # wasm_bundle_bytes intentionally absent; only an unrelated metric present.
@@ -208,7 +208,7 @@ def test_leg2_accepts_exact_match() -> bool:
 
     [OPUS-4.8] Uses feature_off_exact, not floor — mirrors the updated check_leg2() logic.
     """
-    pinned_exact = 1399110  # [OPUS-4.8] CI x86_64 feature_off_exact pin. Re-pin from CI, never aarch64.
+    pinned_exact = 1399868  # [OPUS-4.8] CI x86_64 feature_off_exact pin. Re-pin from CI, never aarch64.
     good_results = [{"name": "wasm_bundle_bytes", "unit": "bytes", "value": pinned_exact}]
     good_floor = {
         "metrics": {


### PR DESCRIPTION
> 🤖 **SPARQ agent**

## What

Replaces the branchy comparison quicksort over packed `(Id, Id, Id)` permutation tuples in the index build (`sparq-core` `TripleStore::build_raw_perms`) with an O(n) LSD **radix sort** — the #1 impact-per-risk item from the engine-performance review (`research/engine-performance-review.md` §1.1, #1397; bead **sq-7d3dj.17**).

With `Id = u32`, a row packs into a 96-bit key whose numeric order **is** the lexicographic `[Id;3]` order, so 12 least-significant-byte radix passes produce the identical sorted order. Passes whose digit is constant across every row (the high bytes of a small dictionary) are detected and skipped; a double-buffer invariant keeps the live result in place whether or not a pass runs.

**Measure-first scoping (the sub-decision the bead asked for):** on this box `par_sort_unstable` (all cores) beats a sequential radix for the *single* large SPO/dedup array, so that step **keeps** the parallel comparison sort — radix there would regress it. The win is the **five non-SPO permutations**, which are built concurrently via `par_iter` and are where the flagged sort-family self-time lives — each switches to the sequential radix (which beats the sequential comparison sort). The no-threads (wasm / `compact-index`) build has no parallel sort, so radix wins the SPO step there too. Pre-sizing was already exact (the mapped iterator is `ExactSize`, so `collect` reserves up front); the comment now says so.

## The equivalence gate (MANDATORY)

The radix-built permutations back index range lookups **and** merge-join order, so byte-for-byte equivalence with the old comparison sort is correctness-critical. Two new tests wire it as a gate:

- `radix_sort_equiv_comparison_sort` — differential fuzz: asserts the radix output is **BYTE-IDENTICAL** to `sort_unstable()` for empty, single, ordered/reversed pairs, all-identical rows, all-same-subject, heavy duplicates, the `Id::MAX` boundary (top key bytes `0xFF`, exercising the no-op-pass skip on a non-constant digit), and randomized sets across four id-range regimes (some skip high passes, one activates all 12).
- `from_triples_perms_match_reference_sort` — build-level: every BUILT permutation of a radix-built store equals the independently-computed comparison-sort reference (covers both the six- and three-index sets).

Equivalence is the gate; **no** speed number is baked into code or docs.

## Perf (direction only)

Measured **direction** on an aarch64 work box (non-canonical — not baked anywhere): the whole `build_raw_perms` build is consistently faster than the old comparison-sort build across 20k / 200k / 2M rows, and the per-permutation radix beats the sequential comparison sort. `perf_direction = faster`.

## Gates run (both feature states)

- `cargo test -p sparq-core` green in **default**, `--no-default-features`, `--features compact-index`, and `--features mmap,dict-spill`.
- `cargo clippy -p sparq-core --all-targets -D warnings` clean in default **and** `--no-default-features`.
- `cargo test -p sparq-engine` (301 passed / 0 failed) + `cargo clippy -p sparq-engine --all-targets -D warnings` clean (engine depends on core).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` clean (no feature-gated intra-doc-link break).
- No public-API change (`radix_sort_rows` / `build_raw_perms` are private; `from_triples` unchanged), so no README/SKILL surface change — internal detail lives in the new rustdoc + §1.1. Core coverage floor (90) not lowered: the two new tests directly exercise every new non-test line (including the skip branch).

Refs: sq-7d3dj.17, #1397. Not armed — leaving the verdict to the maintainer (perf-affecting).

> 🤖 **SPARQ agent** — implemented on Claude Opus 4.8.