### PR TITLE
test(site): axe-core WCAG 2.1 AA a11y harness (sq-ymr2e.4) [OPUS-4.8]

### DIFF
--- a/.github/workflows/site-e2e-foundation.yml
+++ b/.github/workflows/site-e2e-foundation.yml
@@ -88,3 +88,14 @@ jobs:
       - name: Foundation smoke (headless Chromium)
         continue-on-error: true
         run: npm run test:e2e -- support/foundation.smoke.spec.ts
+
+      # [OPUS-4.8] sq-ymr2e.4 — ADVISORY axe-core WCAG 2.1 AA a11y scan of the P1 interactive
+      # surfaces x their key UI states (research/web-gui-test-program.md §3.1). This lane builds no
+      # wasm bundle, so the two engine-dependent states (home:results, /try:error) self-SKIP; the
+      # wasm-free states (home:idle, /try default/palette/drawer, /download release+no-release) run.
+      # Gate shape: serious+critical = ZERO on the ZERO-tier surfaces, a known-gap regression guard
+      # on the beaded color-contrast surfaces, and a moderate/minor ratchet (bench/a11y-baseline.json).
+      # continue-on-error keeps it advisory until the sq-ymr2e.12 promotion bar.
+      - name: A11y — axe WCAG 2.1 AA (headless Chromium)
+        continue-on-error: true
+        run: npm run test:e2e -- a11y.spec.ts

--- a/bench/a11y-baseline.json
+++ b/bench/a11y-baseline.json
@@ -1,0 +1,95 @@
+{
+  "_comment": [
+    "[OPUS-4.8] A11Y RATCHET (sq-ymr2e.4) — automated axe-core WCAG 2.1 AA violation counts per P1",
+    "interactive surface x UI state, reviewed in diffs exactly like the coverage-floor counts.",
+    "GATE (e2e/support/a11y.ts): two tiers. ZERO-tier surfaces (no allowedSeriousRules) HARD-FAIL on",
+    "any serious/critical (unconditional). KNOWN-GAP surfaces (allowedSeriousRules + bead) tolerate",
+    "EXACTLY the listed, beaded serious rule-ids and FAIL on any NEW one — the allowance may only",
+    "SHRINK. In both tiers moderate+minor are a CEILING that may only FALL. Color-contrast and form-",
+    "label rules are explicitly on and cannot be excluded. Re-seed after a fix or a new state:",
+    "A11Y_SEED=1 npm run test:e2e -- a11y.spec.ts  (needs the wasm bundle for the results/error",
+    "states — synced from `(cd ../js && npm run build:wasm)`; the light CI lane has no wasm, so it",
+    "scans only the wasm-free states and never trips a wasm-state ratchet). Counts are measured on a",
+    "non-canonical work box / CI runner — a REGRESSION ratchet, not a canonical audit number, and a",
+    "FLOOR not a certificate (axe covers ~the mechanical half of WCAG; the keyboard/focus half is",
+    "sq-ymr2e.9). We claim 'zero known serious/critical automated violations at WCAG 2.1 AA' on the",
+    "gated surfaces, never 'WCAG-compliant'."
+  ],
+  "wcagTags": [
+    "wcag2a",
+    "wcag2aa",
+    "wcag21a",
+    "wcag21aa"
+  ],
+  "ruleExclusions": {},
+  "surfaces": {
+    "download:no-release": {
+      "critical": 0,
+      "serious": 0,
+      "moderate": 0,
+      "minor": 0
+    },
+    "download:release": {
+      "critical": 0,
+      "serious": 0,
+      "moderate": 0,
+      "minor": 0
+    },
+    "home:idle": {
+      "critical": 0,
+      "serious": 1,
+      "moderate": 0,
+      "minor": 0,
+      "allowedSeriousRules": [
+        "color-contrast"
+      ],
+      "bead": "sq-ymr2e.13",
+      "reason": "hero preview-table syntax tokens + primary th + gradient Run button need a design-token AA pass"
+    },
+    "home:results": {
+      "critical": 0,
+      "serious": 0,
+      "moderate": 0,
+      "minor": 0,
+      "allowedSeriousRules": [
+        "color-contrast"
+      ],
+      "bead": "sq-ymr2e.13",
+      "reason": "same hero gradient Run button as home:idle (bead sq-ymr2e.13); axe evaluates the --hero-grad gradient bg nondeterministically, so color-contrast is tolerated here to prevent flake — a NEW serious rule still fails the guard"
+    },
+    "try:connect-drawer-open": {
+      "critical": 0,
+      "serious": 0,
+      "moderate": 0,
+      "minor": 0
+    },
+    "try:default": {
+      "critical": 0,
+      "serious": 0,
+      "moderate": 0,
+      "minor": 0
+    },
+    "try:error": {
+      "critical": 0,
+      "serious": 1,
+      "moderate": 0,
+      "minor": 0,
+      "allowedSeriousRules": [
+        "color-contrast"
+      ],
+      "bead": "sq-ymr2e.14",
+      "reason": "the sonner rich-colours error toast is ~4.34:1; override the toast palette for AA"
+    },
+    "try:palette-open": {
+      "critical": 0,
+      "serious": 1,
+      "moderate": 0,
+      "minor": 0,
+      "allowedSeriousRules": [
+        "color-contrast"
+      ],
+      "bead": "sq-ymr2e.14",
+      "reason": "command-palette --success badge is ~4.09:1 (need 4.5); a global token nudge"
+    }
+  }
+}

--- a/bench/a11y-baseline.json
+++ b/bench/a11y-baseline.json
@@ -71,14 +71,9 @@
     },
     "try:error": {
       "critical": 0,
-      "serious": 1,
+      "serious": 0,
       "moderate": 0,
-      "minor": 0,
-      "allowedSeriousRules": [
-        "color-contrast"
-      ],
-      "bead": "sq-ymr2e.14",
-      "reason": "the sonner rich-colours error toast is ~4.34:1; override the toast palette for AA"
+      "minor": 0
     },
     "try:palette-open": {
       "critical": 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -149,6 +149,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
     "node_modules/@aztec/bb.js": {
       "version": "5.0.0-nightly.20260324",
       "resolved": "https://registry.npmjs.org/@aztec/bb.js/-/bb.js-5.0.0-nightly.20260324.tgz",
@@ -13857,6 +13870,7 @@
         "tailwind-merge": "^3.6.0"
       },
       "devDependencies": {
+        "@axe-core/playwright": "^4.12.1",
         "@eslint/eslintrc": "^3.2.0",
         "@playwright/test": "^1.61.0",
         "@tailwindcss/postcss": "^4.1.0",

--- a/site/e2e/a11y.spec.ts
+++ b/site/e2e/a11y.spec.ts
@@ -1,0 +1,183 @@
+// [OPUS-4.8] sq-ymr2e.4 — AUTOMATED accessibility harness: axe-core WCAG 2.1 AA on the P1
+// interactive surfaces × their key UI states.
+//
+// WHAT IT GUARDS. Accessibility bugs live in the states a pristine page-load never shows — the
+// OPEN command palette, the EXPANDED connect drawer, the ERROR strip (a real ARIA tab/panel bug
+// already shipped on /try and was found by hand). This spec scans each of those states with axe
+// pinned to the WCAG 2.1 A+AA rule tags and enforces the two-tier gate in e2e/support/a11y.ts:
+//   * ZERO tier      — serious + critical = HARD FAIL AT ZERO (unconditional).
+//   * KNOWN-GAP tier — a surface with a STRUCTURAL, beaded serious violation (a design-token
+//                      color-contrast fix that wants the visual-regression net) is not dropped: it
+//                      is guarded against any NEW serious rule while its beaded set may only shrink.
+// Both tiers ratchet moderate + minor counts in bench/a11y-baseline.json (a ceiling that may only
+// fall). Non-vacuity: the last test injects an unlabelled icon-button and asserts axe CATCHES it,
+// so a green run proves the scanner is live, not silently disabled.
+//
+// The harness itself found + this PR FIXED two serious findings (WCAG 1.4.1 inline-link underline
+// on home + /download → both /download states are ZERO-gated; keyboard access to the /try error
+// <pre>). The remaining structural color-contrast gaps are beaded (sq-ymr2e.13 home hero table +
+// button; sq-ymr2e.14 palette badge + error toast) and their surfaces run in the KNOWN-GAP tier.
+//
+// Design of record: research/web-gui-test-program.md §3.1. Determinism doctrine §1 (frozen clock,
+// seeded random, hermetic network, web-first waiters — inherited from the shared `test`).
+//
+// WASM PREREQ. Two states need the in-tab engine (home RESULTS, /try ERROR): they SKIP when the
+// lean wasm bundle is absent (the light site-e2e CI lane builds no Rust toolchain), exactly like
+// try-query-smoke.spec.ts. The wasm-FREE states (home idle, /try default/palette/drawer, /download
+// release+no-release) run on every lane. Run the full set after `npm run sync-wasm`.
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { Page } from "@playwright/test";
+import { test, expect, BasePage } from "./support";
+import { assertA11y, writeSeedBaseline, WCAG_TAGS } from "./support/a11y";
+
+// The lean wasm bundle the home runner + /try REPL load at runtime (gitignored build artifact,
+// synced into public/wasm/ by `sync-wasm`). Its presence gates the two engine-dependent states.
+const WASM_BUNDLE = fileURLToPath(new URL("../public/wasm/sparq_wasm_bg.wasm", import.meta.url));
+const WASM_PRESENT = existsSync(WASM_BUNDLE);
+
+// The beaded, structural color-contrast gaps this harness surfaced but did not fix here (§3.1).
+const GAP_HOME = {
+  bead: "sq-ymr2e.13",
+  reason: "hero preview-table syntax tokens + primary th + gradient Run button need a design-token AA pass",
+};
+const GAP_PALETTE = {
+  bead: "sq-ymr2e.14",
+  reason: "command-palette --success badge is ~4.09:1 (need 4.5); a global token nudge",
+};
+const GAP_ERROR = {
+  bead: "sq-ymr2e.14",
+  reason: "the sonner rich-colours error toast is ~4.34:1; override the toast palette for AA",
+};
+
+// In A11Y_SEED mode, rewrite the ratchet baseline from the measured counts (no-op otherwise).
+test.afterAll(() => writeSeedBaseline());
+
+// ── Home — the hero runner is the product claim (§2.1 / §3.1). KNOWN-GAP: color-contrast (.13). ──
+test.describe("a11y · home", () => {
+  test("idle-preview state — WCAG 2.1 AA", async ({ page }) => {
+    const home = new BasePage(page);
+    await home.goto("");
+    await home.expectRunnerState("home", "idle-preview");
+    await assertA11y(page, "home:idle", { knownGap: GAP_HOME });
+  });
+
+  test("results state — WCAG 2.1 AA", async ({ page }) => {
+    test.skip(!WASM_PRESENT, "wasm bundle absent — the home Run→results state needs the in-tab engine");
+    const home = new BasePage(page);
+    await home.goto("");
+    await home.expectRunnerState("home", "idle-preview");
+    // Run the shipped sample; the results table is the wasm-computed state a11y must also cover.
+    await page.getByRole("button", { name: /Run/ }).first().click();
+    await home.expectRunnerState("home", "results");
+    await assertA11y(page, "home:results", { knownGap: GAP_HOME });
+  });
+});
+
+// ── /try — the flagship interactive surface, in its major UI states (§2.2 / §3.1). ──────────────
+test.describe("a11y · /try", () => {
+  /** Navigate to /try and wait for the REPL editor (renders without the engine; wasm-free). */
+  async function gotoTry(page: Page): Promise<BasePage> {
+    const p = new BasePage(page);
+    await p.goto("try/");
+    await expect(page.getByRole("textbox", { name: "SPARQL query" })).toBeVisible();
+    return p;
+  }
+
+  test("default state — WCAG 2.1 AA", async ({ page }) => {
+    await gotoTry(page);
+    await assertA11y(page, "try:default"); // ZERO tier.
+  });
+
+  test("command palette open — WCAG 2.1 AA", async ({ page }) => {
+    const p = await gotoTry(page);
+    await p.openCommandPalette();
+    await assertA11y(page, "try:palette-open", { knownGap: GAP_PALETTE });
+  });
+
+  test("connect drawer expanded — WCAG 2.1 AA", async ({ page }) => {
+    await gotoTry(page);
+    // The endpoint config is a collapsed <details> disclosure; expand it to scan the form fields
+    // (endpoint URL + token inputs) that only exist inside the open drawer.
+    await page.getByText(/Advanced · Connect to a sparq-server/).click();
+    await expect(page.locator("#endpoint-url")).toBeVisible();
+    await assertA11y(page, "try:connect-drawer-open"); // ZERO tier.
+  });
+
+  test("error state — WCAG 2.1 AA", async ({ page }) => {
+    test.skip(!WASM_PRESENT, "wasm bundle absent — the /try error state needs the in-tab engine to reject a query");
+    await gotoTry(page);
+    await expect(page.getByText("Engine ready")).toBeVisible({ timeout: 90_000 });
+    // A deliberately malformed query drives the error strip between editor and results.
+    await page.getByRole("textbox", { name: "SPARQL query" }).fill("SELECT ?s WHERE { ?s ?p");
+    await page.getByRole("button", { name: "Run query" }).click();
+    await expect(page.locator('[data-result-kind="error"]')).toBeVisible({ timeout: 30_000 });
+    await assertA11y(page, "try:error", { knownGap: GAP_ERROR });
+  });
+});
+
+// ── /download — the conversion surface, both release fixture states (§2.3 / §3.1). ZERO tier. ───
+// The releases API is fixture-routed by the hermetic layer; blocking the coi-serviceworker seals
+// its fetch-reissue bypass so the fixture deterministically drives the render (download-page.spec
+// pattern). Wasm-free — these run on every lane.
+test.describe("a11y · /download", () => {
+  test.use({ serviceWorkers: "block" });
+
+  test("release-ready state — WCAG 2.1 AA", async ({ page }) => {
+    // Default github fixture = "release" (200): the buttons become live direct-download links.
+    await page.goto("download/", { waitUntil: "domcontentloaded" });
+    await expect(page.getByText("v0.4.2-e2e-fixture").first()).toBeVisible({ timeout: 30_000 });
+    await assertA11y(page, "download:release");
+  });
+
+  test.describe("no-release state", () => {
+    test.use({ github: "notFound" }); // 404 → the degraded "No release yet" state.
+
+    test("no-release state — WCAG 2.1 AA", async ({ page }) => {
+      await page.goto("download/", { waitUntil: "domcontentloaded" });
+      await expect(
+        page.getByRole("link", { name: /No release yet — watch releases/i }).first(),
+      ).toBeVisible({ timeout: 30_000 });
+      await assertA11y(page, "download:no-release");
+    });
+  });
+});
+
+// ── Non-vacuity: the scanner must CATCH a deliberately unlabelled icon-button (§3.1). ────────────
+// If axe were silently disabled/misconfigured, every gate above would pass vacuously. This injects
+// a real WCAG-A "button-name" failure (a button whose only child is an aria-hidden icon → no
+// accessible name) and asserts axe reports it as a serious/critical violation.
+test.describe("a11y · harness non-vacuity", () => {
+  test("an injected unlabelled icon-button is caught as a serious/critical violation", async ({
+    page,
+  }) => {
+    const home = new BasePage(page);
+    await home.goto("");
+    await home.expectRunnerState("home", "idle-preview");
+
+    // Inject an unlabelled icon-button (button-name is a WCAG 2.1 A rule, impact = critical).
+    await page.evaluate(() => {
+      const probe = document.createElement("div");
+      probe.id = "a11y-nonvacuity-probe";
+      probe.innerHTML =
+        '<button type="button"><svg aria-hidden="true" width="16" height="16"></svg></button>';
+      document.body.appendChild(probe);
+    });
+
+    // Use the raw AxeBuilder (not the gate) so we assert the RULE fires, scoped to the probe.
+    const { AxeBuilder } = await import("@axe-core/playwright");
+    const { violations } = await new AxeBuilder({ page })
+      .withTags([...WCAG_TAGS])
+      .include("#a11y-nonvacuity-probe")
+      .analyze();
+
+    const buttonName = violations.find((v) => v.id === "button-name");
+    expect(
+      buttonName,
+      "axe did not catch the injected unlabelled icon-button — the harness is VACUOUS/misconfigured",
+    ).toBeTruthy();
+    expect(buttonName && (buttonName.impact === "serious" || buttonName.impact === "critical")).toBe(
+      true,
+    );
+  });
+});

--- a/site/e2e/a11y.spec.ts
+++ b/site/e2e/a11y.spec.ts
@@ -13,10 +13,13 @@
 // fall). Non-vacuity: the last test injects an unlabelled icon-button and asserts axe CATCHES it,
 // so a green run proves the scanner is live, not silently disabled.
 //
-// The harness itself found + this PR FIXED two serious findings (WCAG 1.4.1 inline-link underline
+// The harness itself found + this PR FIXED three serious findings (WCAG 1.4.1 inline-link underline
 // on home + /download → both /download states are ZERO-gated; keyboard access to the /try error
-// <pre>). The remaining structural color-contrast gaps are beaded (sq-ymr2e.13 home hero table +
-// button; sq-ymr2e.14 palette badge + error toast) and their surfaces run in the KNOWN-GAP tier.
+// <pre>; and the Sonner rich-colours error-toast color-contrast — #e60000 on #fff0f0 = 4.34:1,
+// darkened to ~5.8:1 in globals.css, so the "Engine failed to load"/"Query failed" toast the /try
+// REPL raises clears AA and the wasm-free /try states stay ZERO-gated even when the engine can't
+// load). The remaining structural color-contrast gaps are beaded (sq-ymr2e.13 home hero table +
+// button; sq-ymr2e.14 command-palette --success badge) and their surfaces run in the KNOWN-GAP tier.
 //
 // Design of record: research/web-gui-test-program.md §3.1. Determinism doctrine §1 (frozen clock,
 // seeded random, hermetic network, web-first waiters — inherited from the shared `test`).
@@ -44,10 +47,6 @@ const GAP_HOME = {
 const GAP_PALETTE = {
   bead: "sq-ymr2e.14",
   reason: "command-palette --success badge is ~4.09:1 (need 4.5); a global token nudge",
-};
-const GAP_ERROR = {
-  bead: "sq-ymr2e.14",
-  reason: "the sonner rich-colours error toast is ~4.34:1; override the toast palette for AA",
 };
 
 // In A11Y_SEED mode, rewrite the ratchet baseline from the measured counts (no-op otherwise).
@@ -112,7 +111,9 @@ test.describe("a11y · /try", () => {
     await page.getByRole("textbox", { name: "SPARQL query" }).fill("SELECT ?s WHERE { ?s ?p");
     await page.getByRole("button", { name: "Run query" }).click();
     await expect(page.locator('[data-result-kind="error"]')).toBeVisible({ timeout: 30_000 });
-    await assertA11y(page, "try:error", { knownGap: GAP_ERROR });
+    // ZERO tier: the rich-colours error toast this state raises had a 4.34:1 color-contrast gap
+    // (the former GAP_ERROR / sq-ymr2e.14); it is now fixed in globals.css, so this surface is clean.
+    await assertA11y(page, "try:error");
   });
 });
 

--- a/site/e2e/support/a11y.ts
+++ b/site/e2e/support/a11y.ts
@@ -1,0 +1,244 @@
+// [OPUS-4.8] sq-ymr2e.4 — the AUTOMATED accessibility gate for the site Playwright suite.
+//
+// Design of record: research/web-gui-test-program.md §3.1 — `@axe-core/playwright` pinned to the
+// WCAG 2.1 A+AA rule tags, run against the P1 interactive surfaces IN THEIR KEY STATES (a11y bugs
+// live in the OPEN palette / EXPANDED drawer / ERROR strip, not the pristine page load). This
+// module is the shared gate the a11y spec (e2e/a11y.spec.ts) calls; the gate shape, the rule
+// pinning, and the ratchet mechanics live here in ONE place.
+//
+// TWO GATE TIERS (both ratchet moderate/minor):
+//   * ZERO gate (assertA11y default) — serious + critical violations = HARD FAIL AT ZERO from day
+//     one. Unconditional; never read from the baseline, so the baseline can never be edited to
+//     hide a serious bug on a clean surface.
+//   * KNOWN-GAP guard (assertA11y with `knownGap`) — a surface with a STRUCTURAL serious violation
+//     that needs a design-token fix (filed as a bead, per §3.1 "file per-surface fix beads where
+//     structural") is NOT dropped: it is scanned with an ALLOWANCE of exactly the beaded serious
+//     rule-ids. The guard FAILS on any NEW serious rule (a regression) — the pre-existing beaded
+//     set may only SHRINK (re-seed as beads land), mirroring the coverage ratchet. Nothing is
+//     hidden: every allowance is listed with its bead in bench/a11y-baseline.json.
+//
+// In BOTH tiers, moderate + minor counts are a CEILING in bench/a11y-baseline.json that may only
+// FALL — the gate fails on any RISE. Color-contrast + form-label rules are explicitly guaranteed
+// on (never excludable). Automated axe covers ~the mechanical half of WCAG; the keyboard/focus
+// half is the sibling behavioural bead (sq-ymr2e.9). We therefore claim "zero known serious/
+// critical automated violations at WCAG 2.1 AA" on the gated surfaces, never "WCAG-compliant".
+import { AxeBuilder } from "@axe-core/playwright";
+import { expect, type Page } from "@playwright/test";
+import { readFileSync, writeFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import type { Result as AxeViolation } from "axe-core";
+
+/** The WCAG 2.1 A + AA rule tags axe runs. Level A + AA only (AAA is not the site's bar, §3). */
+export const WCAG_TAGS = ["wcag2a", "wcag2aa", "wcag21a", "wcag21aa"] as const;
+
+/** Rules the design pins ON and this gate refuses to let the baseline exclude (§3.1). */
+const NEVER_EXCLUDABLE = ["color-contrast", "label"] as const;
+
+/** Axe severity buckets. A `null`-impact violation is counted as `minor` (the axe convention). */
+export type Impact = "critical" | "serious" | "moderate" | "minor";
+export type ImpactCounts = Record<Impact, number>;
+
+/** A structural serious violation tracked as a bead rather than fixed in the harness PR (§3.1). */
+export type KnownGap = {
+  /** The fix bead (e.g. "sq-abc12") so the allowance is never a silent whitewash. */
+  bead: string;
+  /** One line: why this is beaded not fixed here (design-token change, needs the visual-reg net). */
+  reason: string;
+};
+
+/** The committed ratchet file (bench/a11y-baseline.json), repo-root-relative from this module. */
+export const BASELINE_PATH = fileURLToPath(
+  new URL("../../../bench/a11y-baseline.json", import.meta.url),
+);
+
+/** When set (A11Y_SEED=1), the run MEASURES + rewrites the baseline instead of ratcheting — but
+ *  the ZERO tier's serious bar is STILL enforced, so a seed can never bless a NEW serious bug. */
+export const SEED = !!process.env.A11Y_SEED;
+
+type SurfaceBaseline = ImpactCounts & {
+  /** Present ⇒ this surface is a KNOWN-GAP guard; the listed serious rule-ids are the allowance. */
+  allowedSeriousRules?: string[];
+  bead?: string;
+  reason?: string;
+};
+
+type Baseline = {
+  wcagTags: string[];
+  /** ruleId → human reason. Kept SMALL and justified; NEVER a serious/critical rule (§3.1). */
+  ruleExclusions: Record<string, string>;
+  /** surface:state key → the ratchet ceiling (+ known-gap allowance where applicable). */
+  surfaces: Record<string, SurfaceBaseline>;
+};
+
+const BASELINE_COMMENT = [
+  "[OPUS-4.8] A11Y RATCHET (sq-ymr2e.4) — automated axe-core WCAG 2.1 AA violation counts per P1",
+  "interactive surface x UI state, reviewed in diffs exactly like the coverage-floor counts.",
+  "GATE (e2e/support/a11y.ts): two tiers. ZERO-tier surfaces (no allowedSeriousRules) HARD-FAIL on",
+  "any serious/critical (unconditional). KNOWN-GAP surfaces (allowedSeriousRules + bead) tolerate",
+  "EXACTLY the listed, beaded serious rule-ids and FAIL on any NEW one — the allowance may only",
+  "SHRINK. In both tiers moderate+minor are a CEILING that may only FALL. Color-contrast and form-",
+  "label rules are explicitly on and cannot be excluded. Re-seed after a fix or a new state:",
+  "A11Y_SEED=1 npm run test:e2e -- a11y.spec.ts  (needs the wasm bundle for the results/error",
+  "states — synced from `(cd ../js && npm run build:wasm)`; the light CI lane has no wasm, so it",
+  "scans only the wasm-free states and never trips a wasm-state ratchet). Counts are measured on a",
+  "non-canonical work box / CI runner — a REGRESSION ratchet, not a canonical audit number, and a",
+  "FLOOR not a certificate (axe covers ~the mechanical half of WCAG; the keyboard/focus half is",
+  "sq-ymr2e.9). We claim 'zero known serious/critical automated violations at WCAG 2.1 AA' on the",
+  "gated surfaces, never 'WCAG-compliant'.",
+];
+
+/** Load + validate the committed baseline (throws if a serious/critical rule was excluded). */
+export function loadBaseline(): Baseline {
+  const raw = JSON.parse(readFileSync(BASELINE_PATH, "utf8")) as Baseline & { _comment?: unknown };
+  const excluded = Object.keys(raw.ruleExclusions ?? {});
+  for (const rule of NEVER_EXCLUDABLE) {
+    if (excluded.includes(rule)) {
+      throw new Error(
+        `[a11y] baseline excludes "${rule}", which the design pins ON (§3.1). Remove the exclusion.`,
+      );
+    }
+  }
+  return raw;
+}
+
+const baseline = loadBaseline();
+
+/** What each scanned state measured — accumulated so A11Y_SEED can rewrite the baseline in afterAll. */
+type Measured = { counts: ImpactCounts; seriousRules: string[]; knownGap?: KnownGap };
+const measured = new Map<string, Measured>();
+
+/** An axe scanner pinned to the WCAG 2.1 A+AA tags, with any documented rule exclusions applied. */
+function buildAxe(page: Page, include?: string): AxeBuilder {
+  let builder = new AxeBuilder({ page }).withTags([...WCAG_TAGS]);
+  const excluded = Object.keys(baseline.ruleExclusions);
+  if (excluded.length > 0) builder = builder.disableRules(excluded);
+  if (include) builder = builder.include(include);
+  return builder;
+}
+
+/** Count violations by severity. Axe's `impact` can be null on an edge — bucket as minor. */
+export function countByImpact(violations: AxeViolation[]): ImpactCounts {
+  const counts: ImpactCounts = { critical: 0, serious: 0, moderate: 0, minor: 0 };
+  for (const v of violations) counts[(v.impact as Impact | null) ?? "minor"] += 1;
+  return counts;
+}
+
+/** The sorted, de-duplicated rule-ids of the serious+critical violations (the known-gap allowance). */
+function seriousRuleIds(violations: AxeViolation[]): string[] {
+  const ids = violations
+    .filter((v) => v.impact === "serious" || v.impact === "critical")
+    .map((v) => v.id);
+  return [...new Set(ids)].sort();
+}
+
+/** A readable one-block-per-violation summary for a failure message (id · impact · help · targets). */
+export function formatViolations(violations: AxeViolation[]): string {
+  if (violations.length === 0) return "  (none)";
+  return violations
+    .map((v) => {
+      const targets = v.nodes
+        .slice(0, 4)
+        .map((n) => `      ${Array.isArray(n.target) ? n.target.join(" ") : String(n.target)}`)
+        .join("\n");
+      return `  • [${v.impact}] ${v.id}: ${v.help}\n    ${v.helpUrl}\n${targets}`;
+    })
+    .join("\n");
+}
+
+export type AssertA11yOptions = {
+  /** CSS selector to SCOPE the scan (used by the non-vacuity probe). */
+  include?: string;
+  /** Mark this state a KNOWN-GAP guard: tolerate exactly its beaded serious rule-ids (may shrink). */
+  knownGap?: KnownGap;
+};
+
+/**
+ * Run the axe WCAG 2.1 AA scan on the current page state and enforce the gate for `key`
+ * (a "surface:state" label, e.g. "download:release"). Returns the measured counts.
+ */
+export async function assertA11y(
+  page: Page,
+  key: string,
+  opts: AssertA11yOptions = {},
+): Promise<ImpactCounts> {
+  const { violations } = await buildAxe(page, opts.include).analyze();
+  const counts = countByImpact(violations);
+  const observedSerious = seriousRuleIds(violations);
+  measured.set(key, { counts, seriousRules: observedSerious, knownGap: opts.knownGap });
+
+  // In seed mode we purely MEASURE (no assertions): writeSeedBaseline rewrites the ratchet from
+  // these counts, and the author reviews the seeded baseline before committing. The real gate
+  // (enforce mode below) is where the zero-tier serious bar + the known-gap guard actually bite.
+  if (SEED) return counts;
+
+  const blocking = violations.filter((v) => v.impact === "serious" || v.impact === "critical");
+
+  if (opts.knownGap) {
+    // ── KNOWN-GAP tier: only the beaded serious rule-ids are tolerated; NEW ones fail. ──────────
+    const allowed = new Set(baseline.surfaces[key]?.allowedSeriousRules ?? []);
+    const regressions = blocking.filter((v) => !allowed.has(v.id));
+    expect(
+      regressions,
+      `\n[a11y ${key}] NEW serious/critical WCAG 2.1 AA violation on a KNOWN-GAP surface ` +
+        `(allowance: [${[...allowed].join(", ")}], tracked in ${opts.knownGap.bead}) — a regression ` +
+        `beyond the beaded set:\n${formatViolations(regressions)}\n`,
+    ).toHaveLength(0);
+  } else {
+    // ── ZERO tier: unconditional hard fail on any serious/critical. ─────────────────────────────
+    expect(
+      blocking,
+      `\n[a11y ${key}] serious/critical WCAG 2.1 AA violation(s) — must be ZERO:\n${formatViolations(
+        blocking,
+      )}\n`,
+    ).toHaveLength(0);
+  }
+
+  // ── RATCHET (both tiers): moderate + minor may only FALL vs the committed ceiling. ────────────
+  const ceiling = baseline.surfaces[key];
+  expect(
+    ceiling,
+    `[a11y ${key}] no baseline entry — re-seed with A11Y_SEED=1 (the ratchet needs a ceiling).`,
+  ).toBeTruthy();
+
+  const byImpact = (impact: Impact) => violations.filter((v) => (v.impact ?? "minor") === impact);
+  expect(
+    counts.moderate,
+    `[a11y ${key}] moderate violations rose ${ceiling.moderate} → ${counts.moderate} — the ratchet ` +
+      `may only fall. Fix the new issue, or re-seed (A11Y_SEED=1) after an intentional drop.\n` +
+      `${formatViolations(byImpact("moderate"))}\n`,
+  ).toBeLessThanOrEqual(ceiling.moderate);
+  expect(
+    counts.minor,
+    `[a11y ${key}] minor violations rose ${ceiling.minor} → ${counts.minor} — the ratchet may only ` +
+      `fall. Fix the new issue, or re-seed (A11Y_SEED=1) after an intentional drop.\n` +
+      `${formatViolations(byImpact("minor"))}\n`,
+  ).toBeLessThanOrEqual(ceiling.minor);
+
+  return counts;
+}
+
+/** In A11Y_SEED mode, rewrite bench/a11y-baseline.json from the measured counts (call in afterAll). */
+export function writeSeedBaseline(): void {
+  if (!SEED || measured.size === 0) return;
+  const surfaces: Record<string, SurfaceBaseline> = {};
+  for (const key of [...measured.keys()].sort()) {
+    const m = measured.get(key)!;
+    surfaces[key] = m.knownGap
+      ? {
+          ...m.counts,
+          allowedSeriousRules: m.seriousRules,
+          bead: m.knownGap.bead,
+          reason: m.knownGap.reason,
+        }
+      : { ...m.counts };
+  }
+  const doc = {
+    _comment: BASELINE_COMMENT,
+    wcagTags: [...WCAG_TAGS],
+    ruleExclusions: baseline.ruleExclusions ?? {},
+    surfaces,
+  };
+  writeFileSync(BASELINE_PATH, `${JSON.stringify(doc, null, 2)}\n`);
+  // eslint-disable-next-line no-console
+  console.log(`[a11y] re-seeded ${Object.keys(surfaces).length} states → ${BASELINE_PATH}`);
+}

--- a/site/e2e/support/a11y.ts
+++ b/site/e2e/support/a11y.ts
@@ -166,25 +166,28 @@ export async function assertA11y(
   const observedSerious = seriousRuleIds(violations);
   measured.set(key, { counts, seriousRules: observedSerious, knownGap: opts.knownGap });
 
-  // In seed mode we purely MEASURE (no assertions): writeSeedBaseline rewrites the ratchet from
-  // these counts, and the author reviews the seeded baseline before committing. The real gate
-  // (enforce mode below) is where the zero-tier serious bar + the known-gap guard actually bite.
-  if (SEED) return counts;
-
   const blocking = violations.filter((v) => v.impact === "serious" || v.impact === "critical");
 
   if (opts.knownGap) {
     // ── KNOWN-GAP tier: only the beaded serious rule-ids are tolerated; NEW ones fail. ──────────
-    const allowed = new Set(baseline.surfaces[key]?.allowedSeriousRules ?? []);
-    const regressions = blocking.filter((v) => !allowed.has(v.id));
-    expect(
-      regressions,
-      `\n[a11y ${key}] NEW serious/critical WCAG 2.1 AA violation on a KNOWN-GAP surface ` +
-        `(allowance: [${[...allowed].join(", ")}], tracked in ${opts.knownGap.bead}) — a regression ` +
-        `beyond the beaded set:\n${formatViolations(regressions)}\n`,
-    ).toHaveLength(0);
+    // In SEED mode this surface's allowance is being RE-MEASURED — writeSeedBaseline captures the
+    // currently-observed serious rule-ids as `allowedSeriousRules` and the author reviews the
+    // seeded diff — so there is no fixed allowance to enforce against yet; skip while seeding.
+    if (!SEED) {
+      const allowed = new Set(baseline.surfaces[key]?.allowedSeriousRules ?? []);
+      const regressions = blocking.filter((v) => !allowed.has(v.id));
+      expect(
+        regressions,
+        `\n[a11y ${key}] NEW serious/critical WCAG 2.1 AA violation on a KNOWN-GAP surface ` +
+          `(allowance: [${[...allowed].join(", ")}], tracked in ${opts.knownGap.bead}) — a regression ` +
+          `beyond the beaded set:\n${formatViolations(regressions)}\n`,
+      ).toHaveLength(0);
+    }
   } else {
-    // ── ZERO tier: unconditional hard fail on any serious/critical. ─────────────────────────────
+    // ── ZERO tier: unconditional hard fail on any serious/critical — ENFORCED EVEN IN SEED mode.
+    // The zero bar is never read from the baseline, so this bites before/independent of the seed
+    // early-return below: a re-seed can never be a hole that blesses a NEW serious/critical bug on
+    // a supposedly-clean surface by writing it into the baseline. ────────────────────────────────
     expect(
       blocking,
       `\n[a11y ${key}] serious/critical WCAG 2.1 AA violation(s) — must be ZERO:\n${formatViolations(
@@ -192,6 +195,12 @@ export async function assertA11y(
       )}\n`,
     ).toHaveLength(0);
   }
+
+  // In SEED mode the moderate/minor ceiling (and any known-gap allowance) is purely RE-MEASURED,
+  // not enforced: writeSeedBaseline rewrites the ratchet from these counts in afterAll and the
+  // author reviews the seeded baseline before committing. The unconditional zero-tier serious bar
+  // above has ALREADY bitten, so returning here can never bless a new serious/critical violation.
+  if (SEED) return counts;
 
   // ── RATCHET (both tiers): moderate + minor may only FALL vs the committed ceiling. ────────────
   const ceiling = baseline.surfaces[key];

--- a/site/e2e/support/a11y.ts
+++ b/site/e2e/support/a11y.ts
@@ -90,7 +90,11 @@ const BASELINE_COMMENT = [
 /** Load + validate the committed baseline (throws if a serious/critical rule was excluded). */
 export function loadBaseline(): Baseline {
   const raw = JSON.parse(readFileSync(BASELINE_PATH, "utf8")) as Baseline & { _comment?: unknown };
-  const excluded = Object.keys(raw.ruleExclusions ?? {});
+  // Safe defaults so a baseline that omits these keys (e.g. a hand-edited or freshly-seeded file
+  // that hasn't yet committed both sections) can't crash the harness at runtime. [SONNET-4.6]
+  raw.ruleExclusions ??= {};
+  raw.surfaces ??= {};
+  const excluded = Object.keys(raw.ruleExclusions);
   for (const rule of NEVER_EXCLUDABLE) {
     if (excluded.includes(rule)) {
       throw new Error(
@@ -140,7 +144,7 @@ export function formatViolations(violations: AxeViolation[]): string {
         .slice(0, 4)
         .map((n) => `      ${Array.isArray(n.target) ? n.target.join(" ") : String(n.target)}`)
         .join("\n");
-      return `  • [${v.impact}] ${v.id}: ${v.help}\n    ${v.helpUrl}\n${targets}`;
+      return `  • [${v.impact ?? "minor"}] ${v.id}: ${v.help}\n    ${v.helpUrl}\n${targets}`;
     })
     .join("\n");
 }

--- a/site/package.json
+++ b/site/package.json
@@ -42,6 +42,7 @@
     "postcss": ">=8.5.10"
   },
   "devDependencies": {
+    "@axe-core/playwright": "^4.12.1",
     "@eslint/eslintrc": "^3.2.0",
     "@playwright/test": "^1.61.0",
     "@tailwindcss/postcss": "^4.1.0",

--- a/site/src/app/download/download-client.tsx
+++ b/site/src/app/download/download-client.tsx
@@ -511,8 +511,11 @@ export function DownloadClient() {
           The sparq desktop GUI bundles the engine and the playground into a
           native app for macOS, Windows, and Linux. Prefer not to install
           anything? The full SPARQL playground runs entirely in your browser at{" "}
+          {/* [OPUS-4.8] sq-ymr2e.4 — inline prose links carry a PERSISTENT underline (WCAG 2.1
+              §1.4.1 Use of Color / axe `link-in-text-block`): distinguishable without relying on
+              the teal colour alone, which fails the 3:1 contrast vs the surrounding muted text. */}
           <Link
-            className="text-primary underline-offset-4 hover:underline"
+            className="text-primary underline underline-offset-4"
             href="/try"
           >
             /try
@@ -540,7 +543,7 @@ export function DownloadClient() {
             and notarized builds (Apple Developer ID + Windows Authenticode) are
             coming; until then, only install builds you fetched yourself from the{" "}
             <a
-              className="text-primary underline-offset-4 hover:underline"
+              className="text-primary underline underline-offset-4"
               href={RELEASES_URL}
               target="_blank"
               rel="noopener noreferrer"
@@ -657,7 +660,7 @@ export function DownloadClient() {
           build for <strong>{cli.label}</strong>; every other platform&rsquo;s
           archive is attached to the{" "}
           <a
-            className="text-primary underline-offset-4 hover:underline"
+            className="text-primary underline underline-offset-4"
             href={RELEASES_URL}
             target="_blank"
             rel="noopener noreferrer"

--- a/site/src/app/globals.css
+++ b/site/src/app/globals.css
@@ -614,3 +614,20 @@
     font-size: 0.9em;
   }
 }
+
+/* [OPUS-4.8] sq-ymr2e.4 / sq-ymr2e.14 — WCAG 2.1 AA color-contrast on the Sonner `richColors`
+   error toast. Sonner 2.x's default light-theme error palette is hsl(360 100% 45%) (#e60000)
+   text on hsl(359 100% 97%) (#fff0f0) → 4.34:1, below the AA 4.5:1 minimum (axe flags it on the
+   "Engine failed to load" toast the /try REPL raises when the in-tab engine can't load — the
+   wasm-free CI lane, and any real browser where the engine genuinely fails). Darken the error
+   text/border/icon to hsl(360 100% 38%) ≈ #c20000, which is ~5.8:1 on the same background — a
+   comfortable AA margin while staying unmistakably red. Sonner exposes the colour as the
+   `--error-text` custom property on its toaster element (keyed by `data-sonner-theme`), consumed
+   by the `[data-rich-colors=true][data-sonner-toast][data-type=error]` rule; overriding the
+   variable there recolours text, border and icon in one place. The selector is intentionally
+   UNLAYERED and one specificity step above Sonner's own definition so it wins over the style
+   Sonner injects at runtime, regardless of source order. Dark-theme error text (light-on-dark)
+   already clears AA, so it is left untouched. */
+html [data-sonner-toaster][data-sonner-theme="light"] {
+  --error-text: hsl(360, 100%, 38%);
+}

--- a/site/src/app/page.tsx
+++ b/site/src/app/page.tsx
@@ -59,9 +59,11 @@ export default function HomePage() {
             <>
               From a live in-tab proof to a faithful protocol simulation — pick one,
               or{" "}
+              {/* [OPUS-4.8] sq-ymr2e.4 — persistent underline so the inline link is distinguishable
+                  without relying on colour (WCAG 2.1 §1.4.1 / axe `link-in-text-block`). */}
               <Link
                 href="/examples"
-                className="text-primary underline-offset-4 hover:underline"
+                className="text-primary underline underline-offset-4"
               >
                 browse the examples gallery
               </Link>
@@ -87,7 +89,7 @@ export default function HomePage() {
               its honesty tier.{" "}
               <Link
                 href="/capabilities"
-                className="text-primary underline-offset-4 hover:underline"
+                className="text-primary underline underline-offset-4"
               >
                 Browse all surfaces
               </Link>
@@ -154,7 +156,7 @@ export default function HomePage() {
             </p>
             <p className="flex flex-wrap gap-4">
               <a
-                className="text-primary underline-offset-4 hover:underline"
+                className="text-primary underline underline-offset-4"
                 href={REPO_URL}
                 target="_blank"
                 rel="noopener noreferrer"
@@ -162,7 +164,7 @@ export default function HomePage() {
                 Source on GitHub
               </a>
               <Link
-                className="text-primary underline-offset-4 hover:underline"
+                className="text-primary underline underline-offset-4"
                 href="/capabilities"
               >
                 Every surface, by theme

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -1440,8 +1440,14 @@ function ResultPanel({
   }
   if (state.kind === "error") {
     return (
+      // [OPUS-4.8] sq-ymr2e.4 — the horizontally-scrollable error region is keyboard-focusable
+      // (tabIndex + a label) so a keyboard-only user can reach + scroll it (WCAG 2.1 §2.1.1 /
+      // axe `scrollable-region-focusable`).
       <pre
         data-result-kind="error"
+        tabIndex={0}
+        role="group"
+        aria-label="Query error"
         className="m-3.5 overflow-x-auto rounded-lg border border-destructive/30 bg-destructive/5 p-3 text-xs text-destructive"
       >
         {state.message}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated accessibility harness for the site (bead **sq-ymr2e.4**). Site lane.

Adds the **automated a11y gate** for the site Playwright suite: `@axe-core/playwright` pinned to the **WCAG 2.1 A+AA** rule tags, scanning the P1 interactive surfaces in their **key UI states** (design of record: `research/web-gui-test-program.md` §3.1). Builds on the sq-ymr2e.1 foundation (`site/e2e/support/**`) via the shared hermetic + deterministic `test`.

### Gate shape (two tiers, both ratchet moderate/minor)
- **ZERO tier** — serious + critical violations = **hard fail at zero**, unconditional (never read from the baseline, so it can't be edited to hide a bug).
- **KNOWN-GAP tier** — a surface with a *structural* serious violation that needs a design-token fix is **beaded**, not dropped: it's scanned with an allowance of exactly its serious rule-ids and **fails on any NEW one**; the allowance may only **shrink**.
- moderate + minor counts are a **ceiling that may only fall** in `bench/a11y-baseline.json` (coverage-floor mechanics). Color-contrast + form-label rules are pinned on, never excludable. Re-seed: `A11Y_SEED=1 npm run test:e2e -- a11y.spec.ts`.
- **Non-vacuity:** an injected unlabelled icon-button must be caught (proves the scanner is live).

### Surfaces × states scanned (8) + moderate baseline
| state | tier | serious | moderate | minor |
|---|---|---|---|---|
| `try:default` | ZERO | 0 | 0 | 0 |
| `try:connect-drawer-open` | ZERO | 0 | 0 | 0 |
| `download:release` | ZERO | 0 | 0 | 0 |
| `download:no-release` | ZERO | 0 | 0 | 0 |
| `home:idle` | known-gap → sq-ymr2e.13 | *color-contrast* | 0 | 0 |
| `home:results` (wasm) | known-gap → sq-ymr2e.13 | *color-contrast* | 0 | 0 |
| `try:palette-open` | known-gap → sq-ymr2e.14 | *color-contrast* | 0 | 0 |
| `try:error` (wasm) | known-gap → sq-ymr2e.14 | *color-contrast* | 0 | 0 |

**serious/critical on the ZERO-tier surfaces: 0. Moderate baseline (all states): 0.**

### Real findings the harness surfaced
**Fixed here** (small, per §3.1):
- **WCAG 1.4.1** `link-in-text-block` — inline prose links on home + `/download` used a *hover-only* underline (indistinguishable by colour alone at 1.03:1 vs surrounding text) → **persistent underline**. This clears **both `/download` states to the ZERO tier**. (On `page.tsx` the same class/pattern appears on a nearby CTA link row too, so those 2 links get the same treatment for consistency; 2 of the 4 were axe-flagged.)
- **WCAG 2.1.1** `scrollable-region-focusable` — the `/try` error `<pre>` is now keyboard-focusable (`tabIndex` + label).

**Beaded** (structural design-token color-contrast — wants the sq-ymr2e.10 visual-regression net; nothing whitewashed, a NEW serious rule still fails the guard):
- **sq-ymr2e.13** — home hero preview-table syntax tokens + `.text-primary` headers + the gradient Run button.
- **sq-ymr2e.14** — command-palette `--success` badge (~4.09:1) + the sonner rich-colours error toast (~4.34:1).

### CI wiring
Advisory step in `.github/workflows/site-e2e-foundation.yml` (`continue-on-error`) — **not a required check yet**; promotion is **sq-ymr2e.12**. The engine-dependent states (`home:results`, `/try:error`) self-skip when the wasm bundle is absent (the light lane), like the REPL smokes. New dev-dep: `@axe-core/playwright@^4.12.1` (+ its `axe-core`) — **dev-only, not bundled** into the site → zero runtime/bundle impact.

### Honesty
Counts are non-canonical work-box/CI-runner values — a **regression ratchet, not an audit number**. Automated axe is a **floor, not a certificate** (it covers ~the mechanical half of WCAG; the keyboard/focus half is sq-ymr2e.9). We claim *"zero known serious/critical automated violations at WCAG 2.1 AA"* on the gated surfaces, never *"WCAG-compliant"*.

### Gates (green)
- `cd site && npm run build` static export ✅ (56 pages exported; WASM prereq built via `js/ npm run build:wasm` + synced).
- `npm run lint` ✅ · `tsc --noEmit` ✅ · `test:e2e:grep-gate` (no `waitForTimeout`) ✅.
- Enforce-mode **27/27** across `--repeat-each=3 --retries=0` — no flake.

Links: sq-ymr2e.4 · follow-ups sq-ymr2e.13, sq-ymr2e.14 · blocks sq-ymr2e.12 (promotion), sq-ymr2e.11 (nightly full-sweep).

> 🤖 Opened by the **SPARQ agent** (Claude Opus 4.8). @jeswr runs multiple agents on one account. Not armed for auto-merge.
