### PR TITLE
ci(fmx4u): path-ownership map + out-of-crate-input audit (sq-fmx4u.2) [OPUS-4.8]

### DIFF
--- a/ci/path-ownership.toml
+++ b/ci/path-ownership.toml
@@ -1,0 +1,130 @@
+# [OPUS-4.8] Change-based CI test-selection — path -> crate/trigger ownership map.
+# Bead sq-fmx4u.2 (epic sq-fmx4u). Design: research/change-based-test-selection.md
+# §4 (fail-safe rules + the ownership map). Authored by Opus 4.8 (Fable
+# unavailable; flag for re-review when Fable returns).
+#
+# WHO CONSUMES THIS: scripts/ci_select.py (the affected-set selector, bead .1)
+# reads the `[[map]]` array. scripts/ci_audit_inputs.py (the out-of-crate-input
+# audit, this bead) reads `[[map]]` AND the informational `[triggers]` mirror.
+# Any OTHER top-level key is ignored by both — safe to add documentation tables.
+#
+# HOW THE SELECTOR USES A CHANGED PATH (design §4, order is normative):
+#   1. §4.1 unconditional full-run trigger  (baked into ci_select `_FULL_TRIGGERS`)
+#   2. crate-prefix ownership                (a path under crates/<c>/ belongs to c)
+#   3. THIS map's `[[map]]` entries          (first match wins)
+#   4. otherwise UNOWNED, UNMAPPED           => mode=full  (fail-safe, design §2)
+# The map is consulted ONLY for a path that is neither a trigger nor inside a
+# crate dir. It therefore EXTENDS the fail-closed set — it can never weaken it:
+# a `safe=true` entry for a trigger/crate path is unreachable (steps 1-2 win
+# first), and the map-validity + audit tests forbid such an entry anyway.
+#
+# THREE VERDICT FORMS (design §4.2), nothing else:
+#   [[map]] pattern = "<glob>"  crates = ["a", "b"]   # attribute to consumer crates
+#   [[map]] pattern = "<glob>"  safe   = true         # PROVEN inert for the Rust matrix
+#   (an unmatched path falls through to the implicit mode=full default)
+# `pattern` is repo-relative POSIX; `dir/**` matches the dir or anything beneath
+# it, otherwise fnmatch. Every `crates` name must be a live workspace member and
+# every pattern root must exist on disk OR be a fetched/generated suite (the
+# map-validity test uses a git-ignore + scripts/fetch-*.sh allowlist, #1392).
+
+# ---------------------------------------------------------------------------
+# [triggers] — INFORMATIONAL MIRROR of ci_select.py `_FULL_TRIGGERS` (§4.1).
+# The selector does NOT read this table; it is the human-readable, drift-guarded
+# statement of the unconditional full-run set. `test_path_ownership.py` asserts
+# this list equals the selector's built-in patterns, so the two cannot diverge.
+# A change to ANY of these forces the whole matrix — a skip here would be unsound
+# (each feeds every build / redefines what "green" means for the whole repo).
+# ---------------------------------------------------------------------------
+[triggers]
+patterns = [
+  "Cargo.lock",             # resolved versions feed every build
+  "Cargo.toml",             # ROOT manifest: members / [workspace.dependencies] / lints / profiles / [patch]
+  "rust-toolchain",         # compiler pin affects all codegen
+  "rust-toolchain.toml",    # compiler pin affects all codegen
+  ".cargo/",                # global rustflags / registries / build config
+  ".github/",               # the CI definition itself, incl. the selection wiring
+  "scripts/",               # shared gate/coverage/check scripts executed by CI
+  "deny.toml",              # cargo-deny config: redefines a supply-chain green
+  "supply-chain/",          # cargo-vet / audit / SBOM config
+  "ci/path-ownership.toml", # the selection policy (this file) itself
+]
+
+# ---------------------------------------------------------------------------
+# [[map]] — attribution of OUT-OF-CRATE inputs to the crates that read them.
+# Each entry below is an AUDIT-PROVEN finding: a repo-level path referenced from
+# a crate's src/tests/benches/build.rs (include_str!/include_bytes! or an
+# env!("CARGO_MANIFEST_DIR")-relative read). `crates` lists EVERY direct reader
+# so a change to the input triggers each reader's reverse-dependency closure —
+# under-listing a reader would be a silent unsound skip (that is what the audit
+# scripts/ci_audit_inputs.py exists to prevent, fail-closed).
+# ---------------------------------------------------------------------------
+
+# The FO-bridge ingest compiles AGENTS.md + skills/*/SKILL.md front-matter into
+# sparq-kb's vendored ingest/agents-findings.ttl. The current kb tests read that
+# committed in-crate ttl (not the live docs), so this attribution is deliberately
+# CONSERVATIVE: it keeps a charter/skill edit aligned with its ingest consumer
+# (sparq-kb re-runs) instead of being silently skipped — an over-trigger, never
+# a skip (design §4.2). No other crate reads these paths.
+[[map]]
+pattern = "AGENTS.md"
+crates = ["sparq-kb"]
+
+[[map]]
+pattern = "skills/**"
+crates = ["sparq-kb"]
+
+# W3C/RDF conformance corpus — FETCHED (gitignored) by scripts/fetch-conformance.sh
+# et al. into tests/w3c/. Read by sparq-conformance's suites via
+# env!("CARGO_MANIFEST_DIR")/../../tests/w3c/... (smoke/inference/jsonld/d-entail).
+[[map]]
+pattern = "tests/w3c/**"
+crates = ["sparq-conformance"]
+
+# W3C ODRL test suite — FETCHED by scripts/fetch-odrl-suite.sh into
+# tests/odrl-test-suite/. Read by sparq-policy's odrl_test_suite.rs.
+[[map]]
+pattern = "tests/odrl-test-suite/**"
+crates = ["sparq-policy"]
+
+# QLever "olympics" corpus (bench/qlever-olympics/olympics.nt). Read from the
+# tests of the engine + the crates that evaluate over it. Every reader is listed.
+[[map]]
+pattern = "bench/qlever-olympics/**"
+crates = ["sparq-engine", "sparq-introspect", "sparq-nlq", "sparq-sim", "sparq-vectors"]
+
+# QLever synthetic query corpus (bench/qlever-synthetic/queries) — read by
+# sparq-engine's dict-consolidation differential test.
+[[map]]
+pattern = "bench/qlever-synthetic/**"
+crates = ["sparq-engine"]
+
+# ZK-compose gate-count + SPARQL-feature catalog fixtures (committed JSON),
+# include_str!'d by sparq-zk-compose's gate_count/sparql_catalog tests.
+[[map]]
+pattern = "bench/zk-compose/**"
+crates = ["sparq-zk-compose"]
+
+# ---------------------------------------------------------------------------
+# SAFE list — paths AUDIT-PROVEN inert for the Rust matrix (design §4.2). The
+# list started EMPTY; each entry below was added only after the audit confirmed
+# NO workspace crate reads it from src/tests/benches/build.rs. The audit
+# re-verifies this every run (a crate that starts reading a safe path FAILS the
+# audit, forcing a re-evaluation). Docs/site lanes still run — they are separate
+# workflows, not gated by this selector.
+# ---------------------------------------------------------------------------
+
+# Design records / research notes. No crate compiles or reads research/.
+[[map]]
+pattern = "research/**"
+safe = true
+
+# The marketing/explanatory website (Next.js). Owns its own CI lane (pages.yml);
+# no Rust crate reads site/.
+[[map]]
+pattern = "site/**"
+safe = true
+
+# The bead task database. Task-tracking only; no crate reads .beads/.
+[[map]]
+pattern = ".beads/**"
+safe = true

--- a/scripts/ci_audit_inputs.py
+++ b/scripts/ci_audit_inputs.py
@@ -28,7 +28,8 @@
 #   ci_audit_inputs.py                          # real: cargo metadata + repo scan
 #   ci_audit_inputs.py --metadata-file m.json   # hermetic metadata snapshot
 #   ci_audit_inputs.py --repo-root DIR --map DIR/ci/path-ownership.toml
-# Exit 0 == every out-of-crate input is covered; exit 1 == findings (printed).
+# Exit 0 == every out-of-crate input is covered; exit 1 == findings (printed);
+# exit 2 == cargo metadata could not be loaded (fail-closed error, printed to stderr).
 #
 # Stdlib only (matches ci_select.py + the CI setup-python 3.12).
 

--- a/scripts/ci_audit_inputs.py
+++ b/scripts/ci_audit_inputs.py
@@ -1,0 +1,433 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Out-of-crate-input audit for change-based CI test-selection.
+# Bead sq-fmx4u.2 (epic sq-fmx4u). Design: research/change-based-test-selection.md
+# §4.2 (the ownership map + its audit). Authored by Opus 4.8 (Fable unavailable;
+# flag for re-review when Fable returns).
+#
+# WHY THIS EXISTS (the soundness hole it closes):
+#   The selector (scripts/ci_select.py) may SKIP a crate C's tests when no path
+#   in C's dependency closure changed. That is UNSOUND if C reads an input that
+#   lives OUTSIDE its own crate dir — a fetched W3C corpus, a bench fixture, a
+#   sibling crate's data file — because a change to that input would not be
+#   attributed to C and C would be skipped even though its test outcome depends
+#   on the input. This audit greps every crate's src/tests/benches/build.rs for
+#   such out-of-crate reads and PROVES each one is covered:
+#     * a repo-level input  => covered by a §4.1 full-run trigger, or by a
+#       ci/path-ownership.toml `[[map]]` entry whose `crates` list names C;
+#     * a sibling-crate input (path under crates/<D>/, D != C) => covered iff C
+#       is in the reverse-dependency closure of D (a change to D's dir already
+#       runs C's tests).
+#   Anything uncovered is a FINDING and the audit exits non-zero (fail-closed):
+#   either the map must gain an entry, or the read is a genuine residual that
+#   must be explicitly acknowledged below with a justification + a fix bead.
+#
+# It reuses ci_select.py (never edits it) for the map loader, the trigger table,
+# the crate-prefix owner match, the metadata parse and the reverse closure.
+#
+# Usage:
+#   ci_audit_inputs.py                          # real: cargo metadata + repo scan
+#   ci_audit_inputs.py --metadata-file m.json   # hermetic metadata snapshot
+#   ci_audit_inputs.py --repo-root DIR --map DIR/ci/path-ownership.toml
+# Exit 0 == every out-of-crate input is covered; exit 1 == findings (printed).
+#
+# Stdlib only (matches ci_select.py + the CI setup-python 3.12).
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import PurePosixPath
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+
+
+def _load_ci_select():
+    """Import scripts/ci_select.py as a module WITHOUT editing it (DRY reuse)."""
+    path = os.path.join(_HERE, "ci_select.py")
+    spec = importlib.util.spec_from_file_location("ci_select", path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("ci_select", mod)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cs = _load_ci_select()
+
+# The crate sub-trees the audit greps (design §4.2: "src/tests/benches/build.rs").
+# `examples/` is deliberately EXCLUDED: `cargo test -p C` compiles examples but
+# never runs an example `main()`, so an example's runtime file read is not a
+# test input. (An example carrying its own `#[test]` would live under tests/ by
+# convention.)
+_SCAN_SUBDIRS = ("src", "tests", "benches")
+_SCAN_FILES = ("build.rs",)
+
+# include_str!/include_bytes! — target is relative to the SOURCE FILE's dir.
+_INCLUDE_RE = re.compile(r"include_(?:str|bytes)!\(\s*\"([^\"]+)\"")
+# env!("CARGO_MANIFEST_DIR") — target segments follow, relative to the CRATE dir.
+_MANIFEST_RE = re.compile(r"env!\(\s*\"CARGO_MANIFEST_DIR\"\s*\)")
+_STR_RE = re.compile(r"\"([^\"\n]+)\"")
+# A `.join(` whose next non-space char is not a quote == a runtime (non-literal)
+# path segment: the statically-resolved path is only a PREFIX of the real read.
+_DYNAMIC_JOIN_RE = re.compile(r"\.join\(\s*[^\"\s)]")
+
+
+@dataclass
+class Ref:
+    """One out-of-crate input reference discovered in a crate's sources."""
+
+    crate: str  # the reading crate (workspace-member name)
+    src: str  # repo-relative source file the reference lives in
+    resolved: str  # repo-relative POSIX target ('.' == the workspace root)
+    kind: str  # "include" | "manifest_join"
+    dynamic: bool  # True => `resolved` is a prefix (a non-literal join followed)
+
+
+@dataclass(frozen=True)
+class Residual:
+    """A KNOWN out-of-crate read the ownership map CANNOT cover.
+
+    These are sibling-crate reads where the reader is not in the owner's
+    reverse-dependency closure (so no `[[map]]` entry can attribute them — the
+    selector resolves an in-crate path by prefix-ownership before it ever
+    consults the map), or a statically-unresolvable runtime path. Each is
+    backstopped by the nightly FULL run (design §6.1) and carries a fix bead.
+    A residual that matches NO discovered read is flagged STALE (keeps this list
+    honest); a NEW uncovered read that is not listed here FAILS the audit.
+    """
+
+    crate: str
+    target: str  # repo-relative prefix ('.' matches the workspace-root dynamic read)
+    reason: str
+
+
+# --- acknowledged residuals (audit-proven; each has a fix bead) --------------
+# sq-m4bxc tracks relocating these shared inputs to repo-level dirs (mappable)
+# or adding the missing dep edge, so the residual set can shrink to empty.
+KNOWN_RESIDUALS: tuple[Residual, ...] = (
+    Residual(
+        "sparq-zk",
+        "crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl",
+        "sparq-zk's #[cfg(test)] module include_str!s sparq-trust's shared "
+        "secprop-ext vocab to assert cross-crate agreement; a sparq-zk -> "
+        "sparq-trust dep is a forbidden cycle (sparq-trust depends on sparq-zk), "
+        "so the reverse closure cannot cover it. Backstop: nightly FULL run "
+        "(design §6.1). Fix: sq-m4bxc (relocate the shared vocab).",
+    ),
+    Residual(
+        "sparq-reason",
+        "crates/sparq-solid/rules",
+        "sparq-reason's incremental-N3 tests read sparq-solid's WAC/ACP rule "
+        "files; sparq-reason has no dep on sparq-solid. Backstop: nightly FULL "
+        "run. Fix: sq-m4bxc (add a dev-dep edge or relocate the rules).",
+    ),
+    Residual(
+        "sparq-conformance",
+        ".",
+        "scoreboard_floors.rs reads sibling-crate test sources at a "
+        "runtime-computed workspace path to keep floor constants in sync "
+        "(sparq-shacl/sparq-geo are dep-covered; sparq-solid is not). The path "
+        "is statically unresolvable (a runtime arg). Backstop: nightly FULL "
+        "run. Fix: sq-m4bxc (assert floors via a shared crate, not by reading "
+        "foreign test sources).",
+    ),
+)
+
+
+# --- discovery ---------------------------------------------------------------
+def enumerate_crates(repo_root: str) -> dict[str, str]:
+    """Map crates/<dir> (repo-relative) -> crate NAME parsed from its Cargo.toml.
+
+    Name is read from the manifest (not assumed == dir) so the audit stays
+    correct if a crate's package name ever diverges from its directory.
+    """
+    crates_dir = os.path.join(repo_root, "crates")
+    out: dict[str, str] = {}
+    if not os.path.isdir(crates_dir):
+        return out
+    for entry in sorted(os.listdir(crates_dir)):
+        manifest = os.path.join(crates_dir, entry, "Cargo.toml")
+        if not os.path.isfile(manifest):
+            continue
+        name = entry
+        with open(manifest, encoding="utf-8") as fh:
+            for line in fh:
+                m = re.match(r"\s*name\s*=\s*\"([^\"]+)\"", line)
+                if m:
+                    name = m.group(1)
+                    break
+        out[f"crates/{entry}"] = name
+    return out
+
+
+def fetched_roots(repo_root: str) -> set[str]:
+    """Roots that a clean clone does NOT have on disk but a fetch script creates.
+
+    Used by the map-validity check (#1392 refinement): a `tests/w3c/**` or
+    `tests/odrl-test-suite/**` pattern must not falsely fail "pattern root does
+    not exist" on a clean clone. The allowlist is DERIVED from the destination
+    dir literals in scripts/fetch-*.sh (self-maintaining — a new fetched suite
+    is picked up automatically), not hard-coded.
+    """
+    roots: set[str] = set()
+    scripts_dir = os.path.join(repo_root, "scripts")
+    if not os.path.isdir(scripts_dir):
+        return roots
+    dest_re = re.compile(r"(?:tests|bench)/[A-Za-z0-9._-]+(?:/[A-Za-z0-9._-]+)*")
+    for fn in sorted(os.listdir(scripts_dir)):
+        if not (fn.startswith("fetch-") and fn.endswith(".sh")):
+            continue
+        try:
+            with open(os.path.join(scripts_dir, fn), encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        for m in dest_re.finditer(text):
+            parts = m.group(0).split("/")
+            roots.add("/".join(parts[:2]))
+    return roots
+
+
+def _crate_source_files(repo_root: str, crate_reldir: str) -> list[str]:
+    base = os.path.join(repo_root, crate_reldir)
+    files: list[str] = []
+    for sub in _SCAN_SUBDIRS:
+        for dirpath, _dirs, names in os.walk(os.path.join(base, sub)):
+            files += [os.path.join(dirpath, n) for n in names if n.endswith(".rs")]
+    for extra in _SCAN_FILES:
+        p = os.path.join(base, extra)
+        if os.path.isfile(p):
+            files.append(p)
+    return files
+
+
+def _rel(repo_root: str, abspath: str) -> str:
+    return PurePosixPath(os.path.relpath(abspath, repo_root)).as_posix()
+
+
+def _pathlike(seg: str) -> bool:
+    seg = seg.strip()
+    if not seg or " " in seg:
+        return False
+    return "/" in seg or seg.startswith("..") or re.search(r"\.[A-Za-z0-9]{1,6}$", seg) is not None
+
+
+def scan_refs(repo_root: str, crate_roots: dict[str, str]) -> list[Ref]:
+    """Discover every out-of-crate input reference in every crate.
+
+    Returns only references that ESCAPE the reading crate's own directory
+    (in-crate `../README.md`-style includes are not test-selection inputs).
+    Deduplicated per (crate, resolved).
+    """
+    refs: list[Ref] = []
+    seen: set[tuple[str, str]] = set()
+
+    def add(crate: str, src_abs: str, resolved_abs: str, kind: str, dynamic: bool) -> None:
+        resolved = _rel(repo_root, resolved_abs)
+        crate_dir = None
+        for reldir, name in crate_roots.items():
+            if name == crate:
+                crate_dir = reldir
+                break
+        # Skip references that stay inside the reading crate's own dir.
+        if crate_dir is not None and (resolved == crate_dir or resolved.startswith(crate_dir + "/")):
+            return
+        key = (crate, resolved)
+        if key in seen:
+            return
+        seen.add(key)
+        refs.append(Ref(crate=crate, src=_rel(repo_root, src_abs), resolved=resolved, kind=kind, dynamic=dynamic))
+
+    for crate_reldir, crate_name in crate_roots.items():
+        crate_dir_abs = os.path.join(repo_root, crate_reldir)
+        for src_abs in _crate_source_files(repo_root, crate_reldir):
+            try:
+                with open(src_abs, encoding="utf-8", errors="replace") as fh:
+                    text = fh.read()
+            except OSError:
+                continue
+            src_dir = os.path.dirname(src_abs)
+            for m in _INCLUDE_RE.finditer(text):
+                resolved_abs = os.path.normpath(os.path.join(src_dir, m.group(1)))
+                add(crate_name, src_abs, resolved_abs, "include", dynamic=False)
+            for m in _MANIFEST_RE.finditer(text):
+                window = text[m.end():m.end() + 240]
+                window = window.split(";", 1)[0]
+                segs = [s for s in _STR_RE.findall(window) if _pathlike(s)]
+                if not segs:
+                    continue
+                joined = crate_dir_abs
+                for seg in segs:
+                    joined = os.path.join(joined, seg.lstrip("/"))
+                resolved_abs = os.path.normpath(joined)
+                dynamic = bool(_DYNAMIC_JOIN_RE.search(window))
+                add(crate_name, src_abs, resolved_abs, "manifest_join", dynamic)
+    return refs
+
+
+# --- coverage classification -------------------------------------------------
+@dataclass
+class AuditResult:
+    ok: bool
+    findings: list[str] = field(default_factory=list)
+    covered: list[tuple[str, str, str]] = field(default_factory=list)  # (crate, resolved, how)
+    acknowledged: list[tuple[str, str]] = field(default_factory=list)  # (crate, resolved)
+
+
+def _ack_for(ref: Ref, acks: tuple[Residual, ...]) -> Residual | None:
+    for r in acks:
+        if r.crate != ref.crate:
+            continue
+        if r.target == ".":
+            if ref.resolved == ".":
+                return r
+        elif ref.resolved == r.target or ref.resolved.startswith(r.target + "/"):
+            return r
+    return None
+
+
+def audit_refs(
+    refs: list[Ref],
+    crate_roots: dict[str, str],
+    map_entries: list[dict],
+    closures: dict[str, set[str]],
+    acks: tuple[Residual, ...] = KNOWN_RESIDUALS,
+) -> AuditResult:
+    """Pure core: classify each discovered ref; findings => not ok.
+
+    `closures[D]` is D's reverse-dependency closure (from ci_select); a missing
+    key defaults to {D} (conservative: only D itself covers a D-owned path).
+    """
+    owners = sorted(((d, n) for d, n in crate_roots.items()), key=lambda p: len(p[0]), reverse=True)
+    res = AuditResult(ok=True)
+    used_acks: set[Residual] = set()
+
+    for ref in refs:
+        owner = cs.owning_package(ref.resolved, owners) if ref.resolved != "." else None
+
+        if owner == ref.crate:
+            res.covered.append((ref.crate, ref.resolved, "in-crate"))
+            continue
+
+        if owner is None:
+            # Repo-level input: trigger, then map, then ack, then FAIL.
+            trig = cs._trigger_match(ref.resolved)
+            if trig is not None:
+                res.covered.append((ref.crate, ref.resolved, "full-run trigger"))
+                continue
+            verdict = None
+            try:
+                verdict = cs.apply_ownership_map(ref.resolved, map_entries)
+            except cs.SelectorError as exc:  # malformed entry => surface as a finding
+                res.findings.append(f"{ref.crate}: malformed map entry for {ref.resolved}: {exc}")
+                continue
+            if verdict is not None:
+                kind, crates = verdict
+                if kind == "safe":
+                    res.findings.append(
+                        f"{ref.crate} reads {ref.resolved} (from {ref.src}) but it is SAFE-listed "
+                        f"(proven-inert) — a SAFE path must not be read by any crate; remove the "
+                        f"safe entry or attribute the path"
+                    )
+                    continue
+                if ref.crate in crates:
+                    res.covered.append((ref.crate, ref.resolved, "ownership map"))
+                    continue
+                # Mapped, but this reader is not listed -> silent unsound skip.
+                ack = _ack_for(ref, acks)
+                if ack is not None:
+                    used_acks.add(ack)
+                    res.acknowledged.append((ref.crate, ref.resolved))
+                    continue
+                res.findings.append(
+                    f"{ref.crate} reads {ref.resolved} (from {ref.src}) which is mapped to "
+                    f"{crates} but NOT to {ref.crate!r}; add it to that entry's `crates`"
+                )
+                continue
+            # Unmapped repo-level input.
+            ack = _ack_for(ref, acks)
+            if ack is not None:
+                used_acks.add(ack)
+                res.acknowledged.append((ref.crate, ref.resolved))
+                continue
+            res.findings.append(
+                f"{ref.crate} reads UNMAPPED repo-level input {ref.resolved} (from {ref.src}); "
+                f"add a ci/path-ownership.toml [[map]] entry attributing it to {ref.crate!r}"
+            )
+            continue
+
+        # owner is a different crate D: covered iff reader in reverse-closure(D).
+        if ref.crate in closures.get(owner, {owner}):
+            res.covered.append((ref.crate, ref.resolved, f"dep-closure of {owner}"))
+            continue
+        ack = _ack_for(ref, acks)
+        if ack is not None:
+            used_acks.add(ack)
+            res.acknowledged.append((ref.crate, ref.resolved))
+            continue
+        res.findings.append(
+            f"{ref.crate} reads {ref.resolved} owned by {owner!r} (from {ref.src}) but is NOT in "
+            f"{owner}'s reverse-dependency closure; a change to {owner}'s dir would skip {ref.crate}. "
+            f"Add a dep edge, relocate the input, or acknowledge it as a residual"
+        )
+
+    for r in acks:
+        if r not in used_acks:
+            res.findings.append(
+                f"STALE acknowledged residual: {r.crate} -> {r.target} matched no discovered read; "
+                f"remove it from KNOWN_RESIDUALS"
+            )
+
+    res.ok = not res.findings
+    return res
+
+
+# --- real-workspace entrypoint ----------------------------------------------
+def _closures_from_meta(meta: dict) -> dict[str, set[str]]:
+    ws = cs.parse_workspace(meta)
+    return {name: cs.reverse_closure(name, ws.reverse_adj) for name in ws.members}
+
+
+def run_audit(repo_root: str, map_file: str | None, meta: dict) -> AuditResult:
+    crate_roots = enumerate_crates(repo_root)
+    map_entries = cs.load_ownership_map(map_file)
+    closures = _closures_from_meta(meta)
+    refs = scan_refs(repo_root, crate_roots)
+    return audit_refs(refs, crate_roots, map_entries, closures)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Out-of-crate-input audit (design §4.2).")
+    p.add_argument("--repo-root", help="repo root (default: git toplevel)")
+    p.add_argument("--map", dest="map_file", help="ownership map (default ci/path-ownership.toml)")
+    p.add_argument("--metadata-file", help="cargo metadata JSON snapshot (default: run cargo)")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    repo_root = args.repo_root or cs._resolve_repo_root(None) or os.getcwd()
+    map_file = args.map_file or os.path.join(repo_root, "ci", "path-ownership.toml")
+    try:
+        meta = cs.load_metadata(args.metadata_file, repo_root)
+    except Exception as exc:  # noqa: BLE001 - report cleanly, do not traceback
+        print(f"out-of-crate-input audit: could not load cargo metadata: {exc}", file=sys.stderr)
+        return 2
+    result = run_audit(repo_root, map_file if os.path.exists(map_file) else None, meta)
+    print(f"out-of-crate-input audit: {len(result.covered)} covered, "
+          f"{len(result.acknowledged)} acknowledged residual(s), {len(result.findings)} finding(s)")
+    for c, r, how in sorted(result.covered):
+        print(f"  ok   {c} -> {r}  [{how}]")
+    for c, r in sorted(result.acknowledged):
+        print(f"  ack  {c} -> {r}")
+    for f in result.findings:
+        print(f"  FAIL {f}")
+    return 0 if result.ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_path_ownership.py
+++ b/scripts/tests/test_path_ownership.py
@@ -1,0 +1,355 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Hermetic unit tests for the ci/path-ownership.toml map + the
+# out-of-crate-input audit (bead sq-fmx4u.2, epic sq-fmx4u). Authored by Opus
+# 4.8 (Fable unavailable; flag for re-review when Fable returns).
+#
+# Covers the design §4 acceptance criteria:
+#   * map-validity: every `crates` name is a live member, every pattern root
+#     exists OR is a FETCHED/GENERATED suite (allowlist, #1392 — not brittle on
+#     a clean clone);
+#   * the [triggers] mirror stays == ci_select._FULL_TRIGGERS (drift guard);
+#   * one test per §4.1 trigger class => mode=full (the map cannot shadow a
+#     trigger);
+#   * the map never WEAKENS the fail-closed set (no safe/attribution entry
+#     matches a trigger path);
+#   * NEGATIVE: an AGENTS.md / skills/** change SELECTS sparq-kb (not skipped);
+#   * the audit itself: mapped/unmapped/cross-crate/acknowledged/safe-read/stale
+#     classification, plus a live audit of the REAL workspace (self-skips when
+#     cargo metadata is unavailable, so the suite never REQUIRES a live cargo).
+#
+# Disjoint from bead .1's files: this module imports ci_select.py + the sibling
+# ci_audit_inputs.py; it edits neither.
+#
+# Run:  python3 scripts/tests/test_path_ownership.py   (stdlib only; no pytest)
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import shutil
+import subprocess
+import sys
+import tempfile
+import tomllib
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+MAP_FILE = REPO_ROOT / "ci" / "path-ownership.toml"
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cs = _load("ci_select", SCRIPTS / "ci_select.py")
+audit = _load("ci_audit_inputs", SCRIPTS / "ci_audit_inputs.py")
+
+
+# --- shared synthetic metadata ----------------------------------------------
+def _dep(name):
+    return {"name": name, "kind": None, "optional": False, "target": None, "path": None}
+
+
+def _pkg(name, deps=()):
+    return {
+        "id": f"path+file:///repo/crates/{name}#0.1.0",
+        "name": name,
+        "source": None,
+        "manifest_path": f"/repo/crates/{name}/Cargo.toml",
+        "dependencies": [_dep(d) for d in deps],
+    }
+
+
+# A synthetic workspace whose members are exactly the crate names the REAL map
+# references (so cs.select accepts the map), plus a leaf `sparq-leaf`. sparq-kb
+# is a leaf here (no in-repo dependents) so an AGENTS.md change selects exactly
+# {sparq-kb}.
+_MAP_CRATES = [
+    "sparq-kb", "sparq-conformance", "sparq-policy", "sparq-engine",
+    "sparq-introspect", "sparq-nlq", "sparq-sim", "sparq-vectors", "sparq-zk-compose",
+]
+
+
+def _map_meta():
+    pkgs = [_pkg(n) for n in _MAP_CRATES] + [_pkg("sparq-leaf", deps=["sparq-engine"])]
+    return {
+        "workspace_root": "/repo",
+        "packages": pkgs,
+        "workspace_members": [p["id"] for p in pkgs],
+    }
+
+
+def _real_map_entries():
+    return cs.load_ownership_map(str(MAP_FILE))
+
+
+def _raw_toml():
+    with open(MAP_FILE, "rb") as fh:
+        return tomllib.load(fh)
+
+
+# §4.1 trigger rows — one representative changed path per class.
+_TRIGGER_PATHS = {
+    "Cargo.lock": "Cargo.lock",
+    "root Cargo.toml": "Cargo.toml",
+    "rust-toolchain": "rust-toolchain",
+    "rust-toolchain.toml": "rust-toolchain.toml",
+    ".cargo/**": ".cargo/config.toml",
+    ".github/**": ".github/workflows/ci.yml",
+    "scripts/**": "scripts/ci_select.py",
+    "deny.toml": "deny.toml",
+    "supply-chain/**": "supply-chain/audits.toml",
+    "ci/path-ownership.toml": "ci/path-ownership.toml",
+}
+
+
+class MapValidityTests(unittest.TestCase):
+    """Every crates name is a live member; every pattern root exists or is fetched."""
+
+    def _members(self):
+        # Prefer real cargo metadata; fall back to the on-disk crate names so the
+        # test stays hermetic when cargo is unavailable.
+        if shutil.which("cargo") is not None:
+            try:
+                out = subprocess.run(
+                    ["cargo", "metadata", "--no-deps", "--format-version", "1"],
+                    cwd=str(REPO_ROOT), check=True, capture_output=True, text=True, timeout=180,
+                )
+                ws = cs.parse_workspace(json.loads(out.stdout))
+                return ws.members
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError, ValueError):
+                pass
+        return set(audit.enumerate_crates(str(REPO_ROOT)).values())
+
+    def test_map_is_valid_against_real_workspace(self):
+        entries = _real_map_entries()
+        self.assertTrue(entries, "the map should ship at least the audited entries")
+        allow = audit.fetched_roots(str(REPO_ROOT))
+        problems = cs.validate_map(entries, self._members(),
+                                   known_generated_roots=allow, repo_root=str(REPO_ROOT))
+        self.assertEqual(problems, [], f"map-validity problems: {problems}")
+
+    def test_fetched_allowlist_covers_missing_roots(self):
+        # The two fetched suites the map references must be in the allowlist so
+        # they do not falsely fail on a clean clone (design §4.2 / #1392).
+        allow = audit.fetched_roots(str(REPO_ROOT))
+        self.assertIn("tests/w3c", allow)
+        self.assertIn("tests/odrl-test-suite", allow)
+
+    def test_every_crates_name_is_a_real_member(self):
+        members = self._members()
+        for e in _real_map_entries():
+            for c in e.get("crates", []) or []:
+                self.assertIn(c, members, f"map references unknown crate {c!r}")
+
+
+class TriggerMirrorTests(unittest.TestCase):
+    """The informational [triggers] table must not drift from _FULL_TRIGGERS."""
+
+    def test_triggers_mirror_matches_selector(self):
+        declared = _raw_toml()["triggers"]["patterns"]
+        builtin = [pat for pat, _reason in cs._FULL_TRIGGERS]
+        self.assertEqual(declared, builtin,
+                         "ci/path-ownership.toml [triggers] drifted from ci_select._FULL_TRIGGERS")
+
+
+class TriggerClassTests(unittest.TestCase):
+    """One test per §4.1 row: a change there forces mode=full, map notwithstanding."""
+
+    def setUp(self):
+        self.meta = _map_meta()
+        self.map = _real_map_entries()
+
+    def test_each_trigger_class_forces_full(self):
+        for label, path in _TRIGGER_PATHS.items():
+            with self.subTest(trigger=label):
+                # Pair the trigger with an ordinary crate change to prove the
+                # trigger dominates rather than the crate narrowing the run.
+                sel = cs.select([path, "crates/sparq-kb/src/lib.rs"], self.meta, self.map)
+                self.assertEqual(sel.mode, "full", f"{label} ({path}) should force full")
+
+
+class MapNeverWeakensTests(unittest.TestCase):
+    """No map entry may match a trigger path (it can only EXTEND the fail set)."""
+
+    def test_no_map_entry_shadows_a_trigger(self):
+        entries = _real_map_entries()
+        for label, path in _TRIGGER_PATHS.items():
+            with self.subTest(trigger=label):
+                verdict = cs.apply_ownership_map(path, entries)
+                self.assertIsNone(
+                    verdict,
+                    f"map entry matches trigger path {path!r} ({verdict}); it must not — "
+                    f"triggers are the fail-closed backbone",
+                )
+
+
+class NegativeKbSelectionTests(unittest.TestCase):
+    """AGENTS.md / skills/** changes SELECT sparq-kb — they are never skipped."""
+
+    def setUp(self):
+        self.meta = _map_meta()
+        self.map = _real_map_entries()
+
+    def test_agents_md_change_selects_kb(self):
+        sel = cs.select(["AGENTS.md"], self.meta, self.map)
+        self.assertEqual(sel.mode, "selected")
+        self.assertIn("sparq-kb", sel.affected)
+
+    def test_skill_change_selects_kb(self):
+        sel = cs.select(["skills/query-pkg/SKILL.md"], self.meta, self.map)
+        self.assertEqual(sel.mode, "selected")
+        self.assertIn("sparq-kb", sel.affected)
+
+    def test_kb_is_not_silently_skipped(self):
+        # The failure mode the negative test guards against: a SAFE-list mistake
+        # would make the change select the EMPTY set (kb skipped). Prove not.
+        sel = cs.select(["AGENTS.md"], self.meta, self.map)
+        self.assertNotEqual(sel.affected, [], "AGENTS.md must not resolve to an empty (all-skipped) set")
+
+    def test_research_change_is_safe_and_skips_all(self):
+        # Contrast: a proven-inert SAFE path selects nobody (design intent).
+        sel = cs.select(["research/change-based-test-selection.md"], self.meta, self.map)
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, [])
+
+
+# --- audit fixtures ---------------------------------------------------------
+_CRATE_ROOTS = {
+    "crates/a": "crate-a",
+    "crates/b": "crate-b",
+    "crates/c": "crate-c",
+}
+# reverse closures: crate-b depends on crate-c (so c-change runs b).
+_CLOSURES = {"crate-a": {"crate-a"}, "crate-b": {"crate-b"}, "crate-c": {"crate-c", "crate-b"}}
+
+
+def _ref(crate, resolved, kind="manifest_join", src="crates/x/tests/t.rs", dynamic=False):
+    return audit.Ref(crate=crate, src=src, resolved=resolved, kind=kind, dynamic=dynamic)
+
+
+class AuditUnitTests(unittest.TestCase):
+    """Hermetic classification tests — no cargo, no real tree."""
+
+    def _audit(self, refs, entries, acks=()):
+        return audit.audit_refs(refs, _CRATE_ROOTS, entries, _CLOSURES, acks=acks)
+
+    def test_mapped_repo_level_input_is_covered(self):
+        entries = [{"pattern": "data/**", "crates": ["crate-a"]}]
+        r = self._audit([_ref("crate-a", "data/x.ttl")], entries)
+        self.assertTrue(r.ok, r.findings)
+
+    def test_unmapped_repo_level_input_is_a_finding(self):
+        r = self._audit([_ref("crate-a", "data/x.ttl")], [])
+        self.assertFalse(r.ok)
+        self.assertTrue(any("UNMAPPED" in f for f in r.findings))
+
+    def test_trigger_path_is_covered(self):
+        r = self._audit([_ref("crate-a", "scripts/gen.sh")], [])
+        self.assertTrue(r.ok, r.findings)
+
+    def test_cross_crate_read_in_closure_is_covered(self):
+        # crate-b reads a file inside crate-c; b in closure(c) -> covered.
+        r = self._audit([_ref("crate-b", "crates/c/data/x")], [])
+        self.assertTrue(r.ok, r.findings)
+
+    def test_cross_crate_read_not_in_closure_is_a_finding(self):
+        # crate-a reads a file inside crate-c; a NOT in closure(c) -> finding.
+        r = self._audit([_ref("crate-a", "crates/c/data/x")], [])
+        self.assertFalse(r.ok)
+        self.assertTrue(any("reverse-dependency closure" in f for f in r.findings))
+
+    def test_acknowledged_residual_passes(self):
+        acks = (audit.Residual("crate-a", "crates/c/data", "known; backstopped"),)
+        r = self._audit([_ref("crate-a", "crates/c/data/x")], [], acks=acks)
+        self.assertTrue(r.ok, r.findings)
+        self.assertEqual(r.acknowledged, [("crate-a", "crates/c/data/x")])
+
+    def test_stale_acknowledgement_is_a_finding(self):
+        acks = (audit.Residual("crate-a", "crates/nope/data", "matches nothing"),)
+        r = self._audit([_ref("crate-a", "data/x")], [{"pattern": "data/**", "crates": ["crate-a"]}], acks=acks)
+        self.assertFalse(r.ok)
+        self.assertTrue(any("STALE" in f for f in r.findings))
+
+    def test_crate_reading_safe_path_is_a_finding(self):
+        entries = [{"pattern": "docs/**", "safe": True}]
+        r = self._audit([_ref("crate-a", "docs/x.md")], entries)
+        self.assertFalse(r.ok)
+        self.assertTrue(any("SAFE-listed" in f for f in r.findings))
+
+    def test_mapped_but_reader_not_listed_is_a_finding(self):
+        entries = [{"pattern": "data/**", "crates": ["crate-b"]}]  # a reads it but not listed
+        r = self._audit([_ref("crate-a", "data/x")], entries)
+        self.assertFalse(r.ok)
+        self.assertTrue(any("NOT to 'crate-a'" in f for f in r.findings))
+
+
+class ScanRefsTests(unittest.TestCase):
+    """The scanner finds escaping include_str! + manifest-join reads in a tempdir."""
+
+    def test_scan_finds_escaping_reads(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            # crate-a includes a sibling crate-b file and reads a repo-level dir.
+            (root / "crates" / "crate-a" / "src").mkdir(parents=True)
+            (root / "crates" / "crate-a" / "Cargo.toml").write_text('name = "crate-a"\n')
+            (root / "crates" / "crate-b").mkdir(parents=True)
+            (root / "crates" / "crate-b" / "Cargo.toml").write_text('name = "crate-b"\n')
+            (root / "crates" / "crate-a" / "src" / "lib.rs").write_text(
+                'const X: &str = include_str!("../../crate-b/data.ttl");\n'
+                'const README: &str = include_str!("../README.md");\n'  # in-crate: ignored
+            )
+            (root / "crates" / "crate-a" / "tests").mkdir()
+            (root / "crates" / "crate-a" / "tests" / "t.rs").write_text(
+                'let p = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("../../corpus/data");\n'
+            )
+            roots = audit.enumerate_crates(str(root))
+            refs = audit.scan_refs(str(root), roots)
+            resolved = {(r.crate, r.resolved) for r in refs}
+            self.assertIn(("crate-a", "crates/crate-b/data.ttl"), resolved)
+            self.assertIn(("crate-a", "corpus/data"), resolved)
+            # The in-crate README include must NOT be reported.
+            self.assertNotIn(("crate-a", "crates/crate-a/README.md"), resolved)
+
+
+class RealWorkspaceAuditTests(unittest.TestCase):
+    """Live audit of the REAL workspace: the shipped map must fully cover it."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.meta = None
+        if shutil.which("cargo") is None:
+            return
+        try:
+            out = subprocess.run(
+                ["cargo", "metadata", "--format-version", "1"],
+                cwd=str(REPO_ROOT), check=True, capture_output=True, text=True, timeout=300,
+            )
+            cls.meta = json.loads(out.stdout)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError, ValueError):
+            cls.meta = None
+
+    def setUp(self):
+        if self.meta is None:
+            self.skipTest("cargo metadata unavailable (hermetic skip)")
+
+    def test_real_workspace_audit_passes(self):
+        result = audit.run_audit(str(REPO_ROOT), str(MAP_FILE), self.meta)
+        self.assertTrue(
+            result.ok,
+            "out-of-crate-input audit found UNCOVERED inputs — complete the map "
+            "or acknowledge a residual:\n" + "\n".join(result.findings),
+        )
+        # Sanity: the shipped map is actually doing work (not vacuously empty).
+        self.assertGreater(len(result.covered), 5)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI/supply-chain lane. Change-based test-selection program, epic **sq-fmx4u**, design record `research/change-based-test-selection.md` §4.

Implements **sq-fmx4u.2** (design §4), building on the merged selector `scripts/ci_select.py` (sq-fmx4u.1, #1404). **No workflow YAML** — that is sq-fmx4u.3.

## What this ships

**`ci/path-ownership.toml`** — the starter path→crate ownership map the selector consumes:
- 7 attribution entries (each an audit-proven finding): `AGENTS.md` + `skills/**` → `sparq-kb` (ingest provenance); `tests/w3c/**` → `sparq-conformance`; `tests/odrl-test-suite/**` → `sparq-policy`; `bench/qlever-olympics/**` → its 5 readers; `bench/qlever-synthetic/**` → `sparq-engine`; `bench/zk-compose/**` → `sparq-zk-compose`.
- 3 audit-proven **SAFE** entries: `research/**`, `site/**`, `.beads/**` (no crate reads them; the audit re-verifies this every run).
- An informational `[triggers]` mirror of `ci_select._FULL_TRIGGERS` documenting the fail-safe full-run set. The map only **EXTENDS** the fail-closed set — a safe/attribution entry can never match a trigger path (triggers + crate-prefix ownership are resolved *before* the map), proven by `test_no_map_entry_shadows_a_trigger`.

**`scripts/ci_audit_inputs.py`** — the out-of-crate-input audit. Greps every crate's `src/tests/benches/build.rs` for `include_str!`/`include_bytes!` and `env!("CARGO_MANIFEST_DIR")`-relative reads that escape the crate dir, then **proves each is covered**: a §4.1 full-run trigger, an ownership-map entry whose `crates` list names the reader, or the reader being in the owner crate's reverse-dependency closure. Anything uncovered → finding → **exit 1 (fail-closed)**. Reuses `ci_select.py`; never edits it.

**`scripts/tests/test_path_ownership.py`** — 21 hermetic tests: map validity (fetched/generated allowlist derived from `scripts/fetch-*.sh` so `tests/w3c` + `tests/odrl-test-suite` don't falsely fail on a clean clone, per #1392); `[triggers]` == `_FULL_TRIGGERS` drift guard; one test per §4.1 trigger class → full; map-never-weakens; the **negative** `AGENTS.md`/`skills/**` → `sparq-kb` (not skipped) test; the audit classifier (mapped/unmapped/cross-crate/acknowledged/safe-read/stale); and a live audit of the real workspace (self-skips without cargo).

## Audit result on the real workspace (PASSES, exit 0)

`14 covered, 3 acknowledged residual(s), 0 finding(s)`. The 3 residuals are genuine sibling-crate reads the map **cannot** cover (the selector resolves an in-crate path by prefix-ownership before consulting the map, and the reader is not in the owner's closure):
1. `sparq-zk` `#[cfg(test)]` `include_str!`s `crates/sparq-trust/…/secprop-ext.ttl` — a `sparq-zk → sparq-trust` dep is a **forbidden cycle**.
2. `sparq-reason` tests read `crates/sparq-solid/rules/*.n3` — no `reason → solid` dep.
3. `sparq-conformance` `scoreboard_floors.rs` reads sibling test sources at a runtime-computed path (`solid` not dep-covered).

Each is backstopped by the nightly FULL run (design §6.1), acknowledged with justification in `KNOWN_RESIDUALS` (stale acks are flagged), and tracked for a `crates/` fix in **sq-m4bxc**. This bead was scoped to the map + audit + tests only (no `crates/` source change).

Honest note: the design assumed `sparq-kb` reads `AGENTS.md`/`skills/**` live; in the current code the FO-bridge ingest compiles them into a committed in-crate `ingest/agents-findings.ttl`. The map still attributes those docs to `sparq-kb` (conservative over-trigger aligned with the ingest provenance, satisfying the negative-test criterion) rather than skipping — never a skip.

## Gates
- `ruff check` clean on both new Python files; valid TOML.
- `python3 scripts/tests/test_path_ownership.py` → 21 pass (0 warnings under `-W error::ResourceWarning`).
- Audit reproduced locally: exit 0 on the real workspace; **non-vacuous** — dropping any map entry makes it exit 1.
- No `.github/workflows/*` touched; existing `scripts/tests/test_ci_select.py` still green (27 pass); `ci-summary` gate aggregator unaffected (this PR adds no gating leg — wiring is sq-fmx4u.3).

Links: sq-fmx4u.2 · epic sq-fmx4u · sq-fmx4u.1 (#1404) · design `research/change-based-test-selection.md` §4 · follow-up sq-m4bxc.

> 🤖 Generated by a **SPARQ agent** (Claude Opus 4.8, Fable unavailable — flag for re-review when Fable returns). Not armed; leaving merge to the maintainer / arm-on-verdict.