### PR TITLE
ci(substrate): enumerate all hot-loop modules in no-dyn gate + AGENTS.md boundary (sq-qonbz.7) [HAIKU-4.5]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,27 @@ If your agent runtime supports the Agent Skills standard, these load via progres
 
 The engine's `compare_values` total order **now lives in `compare` here** (bead [sq-vezew], Phase 4): the ALGORITHM moved as the generic `compare::compare_terms` over a tiny `CompareTerm` trait, and the engine implements that trait for its `Value` (zero-cost wrappers over `value_str` / `as_num` / `value_compare_strict`) and calls the substrate body — so the engine AND the reasoners share ONE total-order body with no `Box<dyn>` on the compare path. The seam deliberately leaves `Value` **engine-resident**: the engine's `Value` enum, its `LitKind` literal-family classifier and `value_compare_strict` typed/temporal comparison ALSO drive the relational `<`/`>`/`=` operators (not just ORDER BY) and are coupled to `oxrdf::Term`, so a wholesale `Value` relocation would be non-perf-neutral and sprawling; moving the algorithm while surfacing the term observations through the trait is the clean perf-neutral seam (mirrors how `join` keeps `Bindings` engine-private behind `JoinKeys`). The genuinely-deferred remainder — should a reasoner ever need the *full* `Value`/`LitKind` value-space (not just the ordering) shared — is captured as a follow-up bead, not faked complete.
 
+#### Substrate boundary: what lives in sparq-substrate vs. what stays engine-private (durable architecture fact)
+
+[HAIKU-4.5] sq-qonbz.7 — the substrate boundary is architecturally explicit: sparq-substrate holds **ONLY** the four generic hot-loop modules (rows / numeric / join—including join::delta / compare) and nothing else. These modules are consumed by BOTH the SPARQL engine and the reasoners, monomorphised and vtable-free.
+
+**In sparq-substrate (generic, consumer-agnostic, monomorphised, shared):**
+- `rows` — Row/Key/Posting id-tuple vocabulary.
+- `numeric` — XSD numeric value tower + arithmetic ops (monomorphic over concrete u32 ids and SmallVec).
+- `join` — four id-tuple join kernels (merge-join, hash-join, bind-join, trie-join) + `join::delta` (persistent extendable hash table for semi-naive Δ⋈full join). All generic over JoinKeys descriptor and Budget cooperative-cancel hook; no vtable on the hot path.
+- `compare` — SPARQL term total order (compare_terms over CompareTerm trait). Generic over the trait; concrete consumer implements it for its term type; no vtable on the per-comparison hot loop.
+
+**In sparq-engine (engine-private, NOT in sparq-substrate — never moved to the shared crate):**
+- `Value` enum + `LitKind` literal-family classifier + `value_compare_strict` typed/temporal comparison (drives relational ops, ORDER BY, and all value semantics; coupled to oxrdf::Term).
+- `Bindings` struct (engine's result binding representation; the join kernels expose Row/Key instead).
+- `LocalVocab` interning (engine-specific; reasoners have their own vocab).
+- `QueryBudget` thread-local cancellation (engine-specific; reasoners may supply their own Budget impl).
+- `ScanCmp` pushdown filter logic (engine optimizer detail).
+- `service.rs` (SPARQL SERVICE federation).
+- Serializers and EXISTS/aggregation (engine executor details).
+
+The seam is **clean and intentional**: generic algorithms flow outward to sparq-substrate; engine-private types and optimizations stay inward. This is verified structurally by the perf-neutrality gate (scripts/check-no-dyn-dispatch.py enumerates all four hot-loop modules — rows/numeric/join/join::delta/compare — and fails if any Box<dyn> / &dyn enters a hot path).
+
 ## MAINTENANCE RULE (REQUIRED — read before changing any public surface)
 
 **When you change a public API, update the matching skill in the SAME change (same commit/PR).** A "public API" means any of:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,7 +59,7 @@ The engine's `compare_values` total order **now lives in `compare` here** (bead 
 
 **In sparq-substrate (generic, consumer-agnostic, monomorphised, shared):**
 - `rows` — Row/Key/Posting id-tuple vocabulary.
-- `numeric` — XSD numeric value tower + arithmetic ops (monomorphic over concrete u32 ids and SmallVec).
+- `numeric` — XSD numeric value tower + arithmetic ops (monomorphic over the concrete numeric tiers `i64`/`i128`/`f32`/`f64`; `#[inline]` accessors, no `Box<dyn>`/`&dyn`/vtable anywhere).
 - `join` — four id-tuple join kernels (merge-join, hash-join, bind-join, trie-join) + `join::delta` (persistent extendable hash table for semi-naive Δ⋈full join). All generic over JoinKeys descriptor and Budget cooperative-cancel hook; no vtable on the hot path.
 - `compare` — SPARQL term total order (compare_terms over CompareTerm trait). Generic over the trait; concrete consumer implements it for its term type; no vtable on the per-comparison hot loop.
 
@@ -72,7 +72,7 @@ The engine's `compare_values` total order **now lives in `compare` here** (bead 
 - `service.rs` (SPARQL SERVICE federation).
 - Serializers and EXISTS/aggregation (engine executor details).
 
-The seam is **clean and intentional**: generic algorithms flow outward to sparq-substrate; engine-private types and optimizations stay inward. This is verified structurally by the perf-neutrality gate (scripts/check-no-dyn-dispatch.py enumerates all four hot-loop modules — rows/numeric/join/join::delta/compare — and fails if any Box<dyn> / &dyn enters a hot path).
+The seam is **clean and intentional**: generic algorithms flow outward to sparq-substrate; engine-private types and optimizations stay inward. This is verified structurally by the perf-neutrality gate (scripts/check-no-dyn-dispatch.py enumerates the four hot-loop modules — rows/numeric/join (including the join::delta submodule)/compare — and fails if any Box<dyn> / &dyn enters a hot path).
 
 ## MAINTENANCE RULE (REQUIRED — read before changing any public surface)
 

--- a/scripts/check-no-dyn-dispatch.py
+++ b/scripts/check-no-dyn-dispatch.py
@@ -48,16 +48,31 @@ import sys
 #     leaf crate's hot paths (join kernels + numeric tower + the shared row/key
 #     vocabulary they operate on) plus lib.rs, which today is module wiring + the
 #     zero-overhead doc-contract but is included so a future hot helper added there is
-#     also covered. Adding a new hot-path module to the substrate? Add it here. ---
+#     also covered. Adding a new hot-path module to the substrate? Add it here.
+#
+#     [HAIKU-4.5] sq-qonbz.7: EXPLICIT enumeration of ALL FOUR substrate hot-loop modules:
+#     - rows (shared Row/Key/Posting id-tuple vocabulary)
+#     - numeric (XSD numeric value tower + arithmetic + lexical helpers)
+#     - join (four id-tuple join kernels: merge-join, hash-join, bind-join, trie-join/WCOJ)
+#     - join::delta (persistent extendable build-side hash table for semi-naive Δ⋈full join)
+#     - compare (SPARQL term total order over a generic CompareTerm trait)
+#     This enumeration makes the perf-neutrality boundary structurally explicit and auditable.
 SUBSTRATE_HOT_PATHS = [
-    "crates/sparq-substrate/src/join.rs",
-    "crates/sparq-substrate/src/numeric.rs",
+    # Rows: shared Row/Key/Posting vocabulary for both join kernels and reasoner consumers.
     "crates/sparq-substrate/src/rows.rs",
-    # [OPUS-4.8] sq-vezew (epic sq-qonbz, Phase 4): the SPARQL term total order
-    # (`compare::compare_terms`, generic over the `CompareTerm` trait) — an ORDER BY / sort /
+    # Numeric: XSD numeric value tower (Num/Dec + as_numeric + arithmetic ops).
+    "crates/sparq-substrate/src/numeric.rs",
+    # Join: four id-tuple join kernels (merge-join, hash-join, bind-join, trie-join/WCOJ)
+    # behind a generic JoinKeys descriptor and generic Budget cooperative-cancel hook.
+    # INCLUDES join::delta submodule (persistent extendable hash table for semi-naive
+    # Δ⋈full join — no Box<dyn> on the delta probe path either).
+    "crates/sparq-substrate/src/join.rs",
+    # [OPUS-4.8] sq-vezew (epic sq-qonbz, Phase 4): SPARQL term total order
+    # (compare::compare_terms, generic over the CompareTerm trait) — an ORDER BY / sort /
     # range-filter hot path, so it joins the guarded set: the algorithm must stay monomorphic
     # (a `dyn CompareTerm` on the per-comparison loop would defeat the zero-overhead seam).
     "crates/sparq-substrate/src/compare.rs",
+    # Library wiring and zero-overhead doc-contract.
     "crates/sparq-substrate/src/lib.rs",
 ]
 

--- a/scripts/check-no-dyn-dispatch.py
+++ b/scripts/check-no-dyn-dispatch.py
@@ -50,11 +50,14 @@ import sys
 #     zero-overhead doc-contract but is included so a future hot helper added there is
 #     also covered. Adding a new hot-path module to the substrate? Add it here.
 #
-#     [HAIKU-4.5] sq-qonbz.7: EXPLICIT enumeration of ALL FOUR substrate hot-loop modules:
+#     [HAIKU-4.5] sq-qonbz.7: EXPLICIT enumeration of the FOUR substrate hot-loop modules
+#     (join::delta is a SUBMODULE of join, not a fifth top-level module — the count and the
+#     list agree at four):
 #     - rows (shared Row/Key/Posting id-tuple vocabulary)
 #     - numeric (XSD numeric value tower + arithmetic + lexical helpers)
-#     - join (four id-tuple join kernels: merge-join, hash-join, bind-join, trie-join/WCOJ)
-#     - join::delta (persistent extendable build-side hash table for semi-naive Δ⋈full join)
+#     - join (four id-tuple join kernels: merge-join, hash-join, bind-join, trie-join/WCOJ;
+#       INCLUDES the join::delta submodule — persistent extendable build-side hash table for
+#       semi-naive Δ⋈full join)
 #     - compare (SPARQL term total order over a generic CompareTerm trait)
 #     This enumeration makes the perf-neutrality boundary structurally explicit and auditable.
 SUBSTRATE_HOT_PATHS = [


### PR DESCRIPTION
> 🤖 **SPARQ agent** — this PR was opened by an autonomous agent

## Summary

Extend `scripts/check-no-dyn-dispatch.py` to **explicitly enumerate ALL FOUR sparq-substrate hot-loop modules** (rows / numeric / join INCLUDING join::delta / compare) with detailed per-module comments, making the perf-neutrality boundary structurally explicit and auditable.

Record the substrate boundary as a **durable architecture fact** in `AGENTS.md` (§sparq-substrate section): what lives in the shared crate (generic, monomorphised, consumer-agnostic) vs. what deliberately stays engine-private (planner, cardinality, GYO, Bindings, LocalVocab, QueryBudget, ScanCmp, service.rs, serializers, EXISTS/aggregation, Value enum + LitKind + value_compare_strict).

**Invariant enforced:** No `Box<dyn>` / `&dyn` / vtable dispatch on any per-row / per-key-group / per-distinct-value hot loop. This contract is now clearly named in the gate's enumeration and in the architecture doc—it is architecturally explicit, not a convention.

## Acceptance test

- Gate runs green: `python3 scripts/check-no-dyn-dispatch.py` (0 violations, 5 files enumerated: rows / numeric / join(+delta) / compare / lib.rs)
- `python3 -m py_compile scripts/check-no-dyn-dispatch.py` clean
- `ruff check` clean
- No perf numbers added to markdown

## Related

- Bead: sq-qonbz.7 (substrate F4)
- Epic: sq-qonbz (program sq-6tykl, shared zero-overhead eval substrate)

---

> 🤖 **SPARQ agent**