### PR TITLE
perf(ingest): prefix-memoized IRI validation fast path (sq-7d3dj.18) [OPUS-4.8]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3656,6 +3656,7 @@ dependencies = [
  "libc",
  "memchr",
  "memmap2",
+ "oxiri",
  "oxjsonld",
  "oxrdf 0.3.3",
  "oxrdfxml",

--- a/crates/sparq-core/Cargo.toml
+++ b/crates/sparq-core/Cargo.toml
@@ -70,10 +70,22 @@ dict-spill = ["mmap", "parallel", "dep:libc"]
 # dependency — it is `std::sync` only — and is OFF by default so the lean default / wasm build
 # pays nothing. See the `shared` module docs.
 shared = []
+# [OPUS-4.8] sq-7d3dj.18: prefix-memoized IRI-validation fast path in FRONT of the full
+# `oxiri` RFC-3987 automaton (see the `iri` module). OFF by default so the lean default / wasm
+# build never NAMES `oxiri` as a direct dep (it is already in-tree transitively via oxttl, so
+# enabling this adds ZERO new compilation) and the parser keeps its current unvalidated-fast
+# behaviour. When ON, the byte-level N-Triples / N-Quads loader validates each IRI through the
+# fast path (accepting EXACTLY what `oxiri` accepts — a mandatory differential-fuzz gate), so
+# the parallel loader reaches conformance parity with the serial oxttl path at fast-path cost.
+iri-fast = ["dep:oxiri"]
 
 [dependencies]
 oxrdf.workspace = true
 oxttl.workspace = true
+# [OPUS-4.8] sq-7d3dj.18: RFC-3987 IRI automaton, OPT-IN behind `iri-fast` (OFF by default).
+# Already present in-tree transitively (oxttl depends on oxiri), so naming it as a direct dep
+# under the feature adds no new compiled crate; the default build never references it.
+oxiri = { version = "0.2", optional = true }
 # [OPUS-4.8] sq-dvyi: JSON-LD ingest for the in-memory loaders (`load_str` /
 # `load_dataset` / `load_reader`). Pure-Rust + wasm-portable, but OPT-IN behind the
 # `jsonld` feature (OFF by default) so the tracked lean wasm bundle never links it and

--- a/crates/sparq-core/README.md
+++ b/crates/sparq-core/README.md
@@ -34,6 +34,11 @@ assert_eq!(count, 1);
   the lean default/wasm build). `load_reader*` accepts any `Read`, so you can wrap a `gzip` /
   `bzip2` / `zstd` decoder around your file and stream it in — sparq does not content-sniff or
   auto-decompress ([guide](../../skills/data-formats/SKILL.md)).
+- **Opt-in validated fast ingest** — the `iri-fast` feature (OFF by default) has the byte-level
+  N-Triples/N-Quads loader validate every IRI against RFC-3987 through a prefix-memoized fast
+  path in front of `oxiri` — accepting *exactly* what `oxiri` accepts (a mandatory
+  differential-fuzz equivalence gate), so the parallel loader reaches conformance parity with
+  the serial oxttl path at fast-path cost. Zero new dependency (`oxiri` is already in-tree).
 - **Triple-pattern scans** — look up any triple pattern over the loaded graph.
 - **Incremental updates** — start from `Graph::new()` / `Graph::default()` (an empty graph) and
   `insert_triple(s, p, o)` / `remove_triple(s, p, o)` a single triple from `oxrdf` terms, or apply

--- a/crates/sparq-core/src/iri.rs
+++ b/crates/sparq-core/src/iri.rs
@@ -1,0 +1,480 @@
+//! [OPUS-4.8] (sq-7d3dj.18) 🤖 SPARQ agent — a prefix-memoized IRI-validation fast path that
+//! sits *in front of* the full [`oxiri`] RFC-3987 automaton in the ingest lane.
+//!
+//! # Why
+//!
+//! Re-validating every IRI *occurrence* against the full RFC-3987 grammar is one of the
+//! largest aggregate ingest costs, yet real RDF dumps reuse a handful of uniform
+//! `scheme://authority/` prefixes and are overwhelmingly ASCII in the path/query/fragment.
+//! This module skips the full parse for that common case with two stacked ACCEPT-shortcuts,
+//! falling back to `oxiri` on *any* uncertainty:
+//!
+//! 1. **Prefix memo** — the last-N `scheme://authority/` prefixes that `oxiri` has already
+//!    accepted are remembered. An incoming IRI that byte-matches a memoized prefix has its
+//!    authority *already proven valid*, so only its suffix needs checking.
+//! 2. **ASCII suffix pre-scan** — a single vectorizable pass over the suffix. If every byte
+//!    is in the position-independent "always-valid after the authority `/`" ASCII class
+//!    ([`is_safe_suffix_byte`]), the whole IRI is provably a valid absolute IRI. A non-ASCII
+//!    byte, a `%`-escape, a `#`, or any other anomaly drops straight to `oxiri`.
+//!
+//! # The load-bearing invariant (differential-fuzz gated)
+//!
+//! The fast path is an **ACCEPT-shortcut only, never a reject-shortcut**:
+//!
+//! > `fast_accept(s)` ⇒ `oxiri::Iri::parse(s).is_ok()`
+//!
+//! and therefore [`IriPrefixMemo::validate`] accepts *exactly* the set `oxiri` accepts (an
+//! absolute IRI, RFC-3987). This equivalence is proven mechanically by the mandatory
+//! differential-fuzz gate in this module's tests (`fast_accept ⇒ oxiri`, and
+//! `validate == oxiri`) over a committed adversarial corpus plus a deterministic
+//! IRI-structured generator — a wrong accept would corrupt ingest, so the gate is a hard
+//! per-PR replay. See bead sq-7d3dj.18 and `research/engine-performance-review.md` §1.2.
+//!
+//! Because the fallback branch defers to `oxiri` verbatim, correctness never depends on the
+//! memo's contents: the memo is a pure cache of *already-validated* prefixes, so its state
+//! (or staleness across unrelated parses) can only change *speed*, never the answer.
+
+/// [OPUS-4.8] (sq-7d3dj.18) True iff `b` is an ASCII byte that is valid in **every** position
+/// of an IRI *after* the authority-terminating `/` — i.e. the intersection of the classes
+/// legal in `ipath-abempty`, `iquery`, and `ifragment` that needs no context to accept.
+///
+/// This is `iunreserved` (ASCII subset) ∪ `sub-delims` ∪ `{ ':' , '@' }` (the extra `ipchar`
+/// members) ∪ `{ '/' , '?' }` (the path/query separators). It deliberately EXCLUDES:
+///
+/// * `'#'` — a fragment cannot itself contain `'#'`, so a second `'#'` would be invalid;
+/// * `'%'` — percent-encoding needs two following hex digits, which this scan does not check;
+/// * `'['` / `']'` — IP-literal brackets belong to the authority, not the suffix;
+/// * every non-ASCII byte — `ucschar`/`iprivate` are position-dependent (e.g. a private-use
+///   codepoint is legal only in `iquery`), so they always fall back to `oxiri`.
+///
+/// Any excluded byte drops the IRI to the full `oxiri` automaton, preserving equivalence.
+#[inline]
+#[must_use]
+pub const fn is_safe_suffix_byte(b: u8) -> bool {
+    matches!(b,
+        // iunreserved (ASCII subset): ALPHA / DIGIT / "-" / "." / "_" / "~"
+        b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~'
+        // sub-delims: "!" / "$" / "&" / "'" / "(" / ")" / "*" / "+" / "," / ";" / "="
+        | b'!' | b'$' | b'&' | b'\'' | b'(' | b')' | b'*' | b'+' | b',' | b';' | b'='
+        // remaining ipchar members
+        | b':' | b'@'
+        // path/query separators (never re-open the authority, which the memoized '/' closed)
+        | b'/' | b'?'
+    )
+}
+
+/// Position-independent lookup table for [`is_safe_suffix_byte`], so the suffix pre-scan is a
+/// branch-light one-pass load per byte (autovectorizable). [OPUS-4.8]
+const SUFFIX_SAFE: [bool; 256] = {
+    let mut t = [false; 256];
+    let mut i = 0usize;
+    while i < 256 {
+        t[i] = is_safe_suffix_byte(i as u8);
+        i += 1;
+    }
+    t
+};
+
+/// True iff **every** byte of `suffix` is [`is_safe_suffix_byte`] — one vectorizable pass.
+///
+/// An empty suffix is safe (a memoized `scheme://authority/` is itself a valid IRI). [OPUS-4.8]
+#[inline]
+#[must_use]
+fn suffix_all_safe(suffix: &[u8]) -> bool {
+    suffix.iter().all(|&b| SUFFIX_SAFE[b as usize])
+}
+
+/// Length (in bytes) of the leading `scheme://authority/` of `s` — the index one *past* the
+/// first `/` that terminates the authority — or `None` when `s` has no such `/`-terminated
+/// hierarchical prefix worth memoizing.
+///
+/// Only ever called on a string `oxiri` has ALREADY accepted, so the scheme (`ALPHA
+/// *(ALPHA / DIGIT / "+" / "-" / ".")`) contains no `:` and the FIRST `:` is the scheme
+/// separator. Returns `None` for the non-`//` forms (`urn:…`, `mailto:…`) and for an authority
+/// not terminated by a `/` (`http://ex`, `http://ex?q`) — there is no path-prefix to reuse, so
+/// those simply never seed the memo. [OPUS-4.8]
+#[inline]
+#[must_use]
+fn scheme_authority_prefix_len(s: &str) -> Option<usize> {
+    let b = s.as_bytes();
+    let colon = b.iter().position(|&c| c == b':')?;
+    // Require the "scheme://" hierarchical form.
+    if b.get(colon + 1) != Some(&b'/') || b.get(colon + 2) != Some(&b'/') {
+        return None;
+    }
+    // The authority runs from just past "://" to the first '/', '?', or '#' (or end of input).
+    // Only a '/'-terminated authority yields a reusable `scheme://authority/` prefix.
+    let mut i = colon + 3;
+    while i < b.len() {
+        match b[i] {
+            b'/' => return Some(i + 1),
+            b'?' | b'#' => return None,
+            _ => i += 1,
+        }
+    }
+    None
+}
+
+/// Default number of `scheme://authority/` prefixes an [`IriPrefixMemo`] remembers. Real dumps
+/// reuse only a handful of prefixes, so a small ring captures the win while a miss costs one
+/// short `starts_with` per entry. [OPUS-4.8]
+pub const DEFAULT_MEMO_CAPACITY: usize = 8;
+
+/// [OPUS-4.8] (sq-7d3dj.18) A bounded ring of recently `oxiri`-validated `scheme://authority/`
+/// prefixes, used to shortcut re-validation of IRIs that share a validated prefix.
+///
+/// Construct with [`IriPrefixMemo::new`] (or [`IriPrefixMemo::with_capacity`]) and call
+/// [`IriPrefixMemo::validate`] once per IRI occurrence. The memo is a pure *speed* cache: every
+/// stored prefix was accepted by `oxiri`, and any accept/reject the memo cannot *prove* is
+/// deferred to `oxiri` verbatim, so the accepted language is byte-for-byte `oxiri`'s.
+#[derive(Debug, Clone)]
+pub struct IriPrefixMemo {
+    /// Validated `scheme://authority/` prefixes, oldest first (FIFO eviction at `cap`).
+    prefixes: Vec<Box<str>>,
+    cap: usize,
+}
+
+impl Default for IriPrefixMemo {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl IriPrefixMemo {
+    /// A memo with the [`DEFAULT_MEMO_CAPACITY`] ring size.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::with_capacity(DEFAULT_MEMO_CAPACITY)
+    }
+
+    /// A memo that remembers the last `cap` validated prefixes (a `cap` of 0 disables the
+    /// prefix memo — [`validate`](Self::validate) then always falls back to `oxiri`, which
+    /// is still correct, just unaccelerated). [OPUS-4.8]
+    #[must_use]
+    pub fn with_capacity(cap: usize) -> Self {
+        Self { prefixes: Vec::with_capacity(cap), cap }
+    }
+
+    /// Number of memoized prefixes currently held (for tests/introspection). [OPUS-4.8]
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.prefixes.len()
+    }
+
+    /// Whether the memo currently holds no prefixes. [OPUS-4.8]
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.prefixes.is_empty()
+    }
+
+    /// The ACCEPT-shortcut: `true` iff a memoized prefix + ASCII suffix pre-scan *proves* `s`
+    /// is a valid absolute IRI. A `false` result means "unknown — ask `oxiri`", NOT "invalid".
+    ///
+    /// Soundness (`fast_accept(s)` ⇒ `oxiri` accepts `s`) is the differential-fuzz gate's
+    /// load-bearing assertion. [OPUS-4.8]
+    #[must_use]
+    fn fast_accept(&self, s: &str) -> bool {
+        let sb = s.as_bytes();
+        for p in &self.prefixes {
+            let pb = p.as_bytes();
+            if sb.len() >= pb.len() && sb.starts_with(pb) && suffix_all_safe(&sb[pb.len()..]) {
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Seed the ring from a string `oxiri` has just accepted (extract & remember its
+    /// `scheme://authority/` prefix; FIFO-evict the oldest at capacity; no duplicates). [OPUS-4.8]
+    fn record(&mut self, s: &str) {
+        if self.cap == 0 {
+            return;
+        }
+        let Some(plen) = scheme_authority_prefix_len(s) else { return };
+        let prefix = &s[..plen];
+        if self.prefixes.iter().any(|p| p.as_ref() == prefix) {
+            return;
+        }
+        if self.prefixes.len() >= self.cap {
+            self.prefixes.remove(0);
+        }
+        self.prefixes.push(prefix.into());
+    }
+
+    /// Validate `s` as an absolute IRI (RFC-3987), accepting *exactly* the set
+    /// `oxiri::Iri::parse(s).is_ok()` accepts.
+    ///
+    /// Tries the memoized fast path first; on a miss, runs the full `oxiri` automaton and, when
+    /// it accepts, seeds the ring so future IRIs sharing that prefix take the fast path. [OPUS-4.8]
+    #[must_use]
+    pub fn validate(&mut self, s: &str) -> bool {
+        if self.fast_accept(s) {
+            return true;
+        }
+        // Authoritative fallback — this is the only place the accepted language is defined.
+        let ok = oxiri::Iri::parse(s).is_ok();
+        if ok {
+            self.record(s);
+        }
+        ok
+    }
+}
+
+/// Validate `s` as an absolute IRI (RFC-3987) with a throwaway memo — a convenience for callers
+/// that validate a single IRI and keep no state. Accepts exactly `oxiri::Iri::parse(s).is_ok()`.
+/// [OPUS-4.8]
+#[must_use]
+pub fn is_valid_iri(s: &str) -> bool {
+    // No memo state to reuse, so this is just the oxiri automaton (with the ASCII pre-scan of an
+    // empty ring, which never fires) — kept as a named entry point for one-shot callers.
+    oxiri::Iri::parse(s).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Ground truth: the full `oxiri` absolute-IRI automaton.
+    fn oxiri_ok(s: &str) -> bool {
+        oxiri::Iri::parse(s).is_ok()
+    }
+
+    // ---- Unit tests for the building blocks -------------------------------------------------
+
+    #[test]
+    fn safe_suffix_byte_table_matches_predicate() {
+        for b in 0u8..=255 {
+            assert_eq!(SUFFIX_SAFE[b as usize], is_safe_suffix_byte(b), "byte {}", b);
+        }
+        // Spot-check the boundary of what is / isn't safe.
+        assert!(is_safe_suffix_byte(b'a') && is_safe_suffix_byte(b'/') && is_safe_suffix_byte(b'?'));
+        assert!(is_safe_suffix_byte(b':') && is_safe_suffix_byte(b'@') && is_safe_suffix_byte(b'~'));
+        for &bad in &[b'#', b'%', b'[', b']', b' ', b'<', b'>', b'"', b'\\', 0u8, 0x7f] {
+            assert!(!is_safe_suffix_byte(bad), "byte {} must fall back", bad);
+        }
+        // No non-ASCII byte is ever "safe".
+        for b in 128u8..=255 {
+            assert!(!is_safe_suffix_byte(b));
+        }
+    }
+
+    #[test]
+    fn prefix_extraction_covers_the_forms() {
+        assert_eq!(scheme_authority_prefix_len("http://ex/foo"), Some("http://ex/".len()));
+        assert_eq!(scheme_authority_prefix_len("https://a.b.c/x/y"), Some("https://a.b.c/".len()));
+        assert_eq!(scheme_authority_prefix_len("http://[::1]:80/p"), Some("http://[::1]:80/".len()));
+        // No '/'-terminated authority -> nothing to memo.
+        assert_eq!(scheme_authority_prefix_len("http://ex"), None);
+        assert_eq!(scheme_authority_prefix_len("http://ex?q=1"), None);
+        assert_eq!(scheme_authority_prefix_len("http://ex#f"), None);
+        // Non-hierarchical schemes.
+        assert_eq!(scheme_authority_prefix_len("urn:isbn:12345"), None);
+        assert_eq!(scheme_authority_prefix_len("mailto:a@b.c"), None);
+    }
+
+    #[test]
+    fn memo_fast_path_fires_on_repeat_prefix() {
+        let mut memo = IriPrefixMemo::new();
+        assert!(memo.is_empty());
+        // First occurrence: oxiri fallback seeds the prefix.
+        assert!(memo.validate("http://example.org/a"));
+        assert_eq!(memo.len(), 1);
+        // A subsequent IRI sharing the prefix must be provable by the fast path alone.
+        assert!(memo.fast_accept("http://example.org/b/c?d=e"));
+        assert!(memo.validate("http://example.org/b/c?d=e"));
+        // A '#' in the suffix is not fast-provable, but validate still agrees with oxiri.
+        assert!(!memo.fast_accept("http://example.org/a#frag"));
+        assert_eq!(memo.validate("http://example.org/a#frag"), oxiri_ok("http://example.org/a#frag"));
+    }
+
+    #[test]
+    fn memo_capacity_is_a_bounded_fifo_ring() {
+        let mut memo = IriPrefixMemo::with_capacity(2);
+        assert!(memo.validate("http://a/x"));
+        assert!(memo.validate("http://b/x"));
+        assert!(memo.validate("http://c/x")); // evicts http://a/
+        assert_eq!(memo.len(), 2);
+        // http://a/ was evicted, so its suffix is no longer fast-provable...
+        assert!(!memo.fast_accept("http://a/y"));
+        // ...but the two most-recent prefixes still are.
+        assert!(memo.fast_accept("http://b/y"));
+        assert!(memo.fast_accept("http://c/y"));
+        // Cap 0 disables the ring entirely (still correct via fallback).
+        let mut off = IriPrefixMemo::with_capacity(0);
+        assert!(off.validate("http://a/x"));
+        assert_eq!(off.len(), 0);
+        assert!(!off.fast_accept("http://a/y"));
+    }
+
+    #[test]
+    fn is_valid_iri_matches_oxiri() {
+        for s in ["http://ex/a", "urn:x:y", "not an iri", "", "http://ex/a b", "mailto:a@b.c"] {
+            assert_eq!(is_valid_iri(s), oxiri_ok(s), "{:?}", s);
+        }
+    }
+
+    // ---- The MANDATORY differential-fuzz equivalence gate (sq-7d3dj.18) ---------------------
+
+    /// A committed adversarial corpus — unicode boundaries, percent-encoding, empty authority,
+    /// IPv6 literals, bad schemes, and `iunreserved`/`iprivate` edges — replayed deterministically
+    /// every run alongside the generated cases. [OPUS-4.8]
+    const ADVERSARIAL_CORPUS: &[&str] = &[
+        // valid, common
+        "http://example.org/foo",
+        "http://example.org/foo#frag",
+        "http://ex/a?q=1&r=2",
+        "https://a.b.c/p/q?x=y#z",
+        "urn:isbn:0451450523",
+        "mailto:a@b.c",
+        "tag:example.com,2024:x",
+        "a:b",
+        // authority / host edges
+        "http://[::1]/x",
+        "http://[::1]:8080/x",
+        "http://[v1.fe80::a]/x",
+        "http://",          // empty authority, empty path
+        "http:///x",        // empty authority, absolute path
+        "http://u:p@h:1/x", // userinfo + port
+        // percent-encoding edges
+        "http://ex/%20",
+        "http://ex/%2F",
+        "http://ex/%GG",    // bad hex
+        "http://ex/%2",     // truncated
+        "http://ex/%",      // lone percent
+        "http://ex/a%zzb",
+        // non-ASCII / iunreserved / iprivate boundaries
+        "http://ex/\u{00e9}",       // é (ucschar) — valid in path
+        "http://ex/\u{00a0}",       // NBSP — NOT ucschar
+        "http://ex/\u{d7ff}",       // last BMP before surrogates (ucschar)
+        "http://ex/\u{e000}",       // private-use start — iprivate, invalid in PATH
+        "http://ex/?\u{e000}",      // iprivate is valid in QUERY
+        "http://ex/\u{10ffff}",     // max codepoint — not ucschar
+        "http://ex/\u{fdd0}",       // noncharacter
+        // raw-illegal / control / whitespace
+        "http://ex/a<b",
+        "http://ex/a>b",
+        "http://ex/a\"b",
+        "http://ex/a\\b",
+        "http://ex/a`b",
+        "http://ex/a{b}",
+        "http://ex/a|b",
+        "http://ex/a^b",
+        "http://ex/a b",
+        "http://ex/a\tb",
+        "http://ex/a\u{0000}",
+        "http://ex/a\u{007f}",
+        // bad / relative / empty
+        "1http://x",
+        ":x",
+        "foo",
+        "/abs/path",
+        "//host/path",
+        "",
+        "HTTP://EX/x",
+        "h+t-t.p://ex/x",
+        // suffix structure edges the fast path must reason about
+        "http://example.org/a#b#c", // second '#' invalid
+        "http://example.org/a?b?c", // second '?' fine (in query)
+        "http://example.org/:@/?",  // ipchar extras + separators
+        "http://example.org/a;p=1,2",
+    ];
+
+    /// Deterministic, allocation-cheap xorshift64* PRNG (no external `rand` dependency, so the
+    /// fuzz gate replays byte-identically per PR). [OPUS-4.8]
+    struct Rng(u64);
+    impl Rng {
+        fn next_u64(&mut self) -> u64 {
+            let mut x = self.0;
+            x ^= x >> 12;
+            x ^= x << 25;
+            x ^= x >> 27;
+            self.0 = x;
+            x.wrapping_mul(0x2545_f491_4f6c_dd1d)
+        }
+        fn below(&mut self, n: usize) -> usize {
+            (self.next_u64() % n as u64) as usize
+        }
+    }
+
+    /// The character alphabet the generator draws from — a deliberate mix of clearly-safe ASCII,
+    /// structural delimiters, percent-encoding bytes, and non-ASCII boundary codepoints — so the
+    /// generated IRIs straddle the accept/reject frontier where a fast-path bug would hide.
+    const ALPHABET: &[char] = &[
+        'a', 'Z', '0', '9', '-', '.', '_', '~', // iunreserved
+        '!', '$', '&', '\'', '(', ')', '*', '+', ',', ';', '=', // sub-delims
+        ':', '@', '/', '?', '#', // separators / ipchar extras
+        '%', '2', 'F', 'G', // percent-encoding (valid + invalid)
+        '[', ']', ' ', '<', '>', '\\', // illegal-ish / brackets
+        '\u{00e9}', '\u{00a0}', '\u{e000}', '\u{10ffff}', // ucschar / non-ucschar / iprivate / max
+    ];
+
+    fn gen_iri(rng: &mut Rng, out: &mut String) {
+        out.clear();
+        // Half the time, prefix with a realistic uniform `scheme://authority/` so the memo path
+        // is exercised heavily; otherwise build a fully-random string.
+        if rng.below(2) == 0 {
+            let prefixes = ["http://ex/", "https://a.b/", "http://[::1]:80/", "ftp://h.i.j/", "x://y/"];
+            out.push_str(prefixes[rng.below(prefixes.len())]);
+        } else {
+            // Random scheme-ish head.
+            let head_len = rng.below(6);
+            for _ in 0..head_len {
+                out.push(ALPHABET[rng.below(ALPHABET.len())]);
+            }
+            if rng.below(2) == 0 {
+                out.push_str("://");
+            } else {
+                out.push(':');
+            }
+        }
+        let body_len = rng.below(24);
+        for _ in 0..body_len {
+            out.push(ALPHABET[rng.below(ALPHABET.len())]);
+        }
+    }
+
+    #[test]
+    fn differential_fuzz_fast_path_equivalent_to_oxiri() {
+        // 1) The committed adversarial corpus (deterministic replay), each checked against a
+        //    FRESH memo AND against the shared memo below.
+        let mut shared = IriPrefixMemo::new();
+        for &s in ADVERSARIAL_CORPUS {
+            let expected = oxiri_ok(s);
+            // Fresh-memo equivalence.
+            let mut fresh = IriPrefixMemo::new();
+            assert_eq!(fresh.validate(s), expected, "fresh validate != oxiri for {:?}", s);
+            // Accept-shortcut soundness on a memo primed with a matching prefix: prime, then
+            // assert a fast accept is never a wrong accept.
+            if let Some(plen) = scheme_authority_prefix_len(s) {
+                let mut primed = IriPrefixMemo::new();
+                // Seed the prefix by validating a trivially-safe sibling under it.
+                let seed = format!("{}seed", &s[..plen]);
+                let _ = primed.validate(&seed);
+                if primed.fast_accept(s) {
+                    assert!(expected, "fast_accept wrongly accepted {:?} (oxiri rejects)", s);
+                }
+            }
+            // Shared-memo equivalence (state accumulates across the corpus).
+            assert_eq!(shared.validate(s), expected, "shared validate != oxiri for {:?}", s);
+        }
+
+        // 2) The deterministic IRI-structured generator: many randomized cases, each asserting
+        //    both the soundness of the accept-shortcut and full equivalence. Two seeds, a shared
+        //    memo threaded through so memo hits actually occur.
+        for seed in [0x9E37_79B9_7F4A_7C15u64, 0xD1B5_4A32_D192_ED03u64] {
+            let mut rng = Rng(seed);
+            let mut memo = IriPrefixMemo::new();
+            let mut s = String::new();
+            for _ in 0..60_000 {
+                gen_iri(&mut rng, &mut s);
+                let expected = oxiri_ok(&s);
+                // Soundness: a standalone fast-accept must never over-accept.
+                if memo.fast_accept(&s) {
+                    assert!(expected, "fast_accept over-accepted {:?} (oxiri rejects)", s);
+                }
+                // Full equivalence of the wired validator against oxiri, memo state and all.
+                assert_eq!(memo.validate(&s), expected, "validate != oxiri for {:?}", s);
+            }
+        }
+    }
+}

--- a/crates/sparq-core/src/iri.rs
+++ b/crates/sparq-core/src/iri.rs
@@ -220,13 +220,15 @@ impl IriPrefixMemo {
     }
 }
 
-/// Validate `s` as an absolute IRI (RFC-3987) with a throwaway memo — a convenience for callers
-/// that validate a single IRI and keep no state. Accepts exactly `oxiri::Iri::parse(s).is_ok()`.
-/// [OPUS-4.8]
+/// Validate `s` as an absolute IRI (RFC-3987) — a convenience for one-shot callers that
+/// validate a single IRI and keep no state. Calls the `oxiri` automaton DIRECTLY (no memo
+/// fast path). Accepts exactly `oxiri::Iri::parse(s).is_ok()`. [OPUS-4.8]
 #[must_use]
 pub fn is_valid_iri(s: &str) -> bool {
-    // No memo state to reuse, so this is just the oxiri automaton (with the ASCII pre-scan of an
-    // empty ring, which never fires) — kept as a named entry point for one-shot callers.
+    // This one-shot entry point does NOT run the prefix-memo fast path or the ASCII suffix
+    // pre-scan — it calls the `oxiri` automaton directly. Those fast paths need caller-held
+    // ring state, so they live on the stateful validator `IriPrefixMemo::validate`, which the
+    // byte-level N-Triples/N-Quads loader (see `nt.rs`) drives per worker thread.
     oxiri::Iri::parse(s).is_ok()
 }
 

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -9,6 +9,12 @@ pub mod dict;
 pub mod dictspill;
 #[cfg(feature = "mmap")]
 pub mod extsort;
+// [OPUS-4.8] (sq-7d3dj.18) Prefix-memoized IRI-validation fast path in FRONT of the full
+// `oxiri` RFC-3987 automaton. OPT-IN behind `iri-fast` (OFF by default) so the lean default /
+// wasm build never names `oxiri` as a direct dep and pays nothing; when on, the parallel
+// N-Triples / N-Quads loader validates each IRI through it (fast path, oxiri-equivalent).
+#[cfg(feature = "iri-fast")]
+pub mod iri;
 mod nt;
 // [OPUS-4.8] sq-yj76l (gh #1121): the opt-in `SharedGraph` server-sharing handle. OFF by
 // default so the lean default / wasm build never links it (it is `std::sync` only — no new

--- a/crates/sparq-core/src/nt.rs
+++ b/crates/sparq-core/src/nt.rs
@@ -436,9 +436,31 @@ fn decode<'a>(raw: &'a [u8], esc: bool) -> Result<Cow<'a, str>, String> {
     }
 }
 
+// [OPUS-4.8] (sq-7d3dj.18) Per-thread `scheme://authority/` prefix memo for the opt-in IRI
+// validation fast path. A thread-local is sound under the rayon chunk-parallel loader — each
+// worker keeps its own ring — and needs no clearing between parses: every memoized prefix was
+// accepted by `oxiri`, and IRI validity is a pure function of the bytes, so a retained (or
+// cross-parse) prefix can only change SPEED, never the accept/reject answer.
+#[cfg(feature = "iri-fast")]
+thread_local! {
+    static IRI_MEMO: std::cell::RefCell<crate::iri::IriPrefixMemo> =
+        std::cell::RefCell::new(crate::iri::IriPrefixMemo::new());
+}
+
 fn iri(b: &[u8], i: usize, dict: &mut Dict) -> Result<(Id, usize), String> {
     let (start, end, esc, next) = scan_delim(b, i, b'>')?;
     let s = decode(&b[start..end], esc)?;
+    // [OPUS-4.8] (sq-7d3dj.18) When the opt-in `iri-fast` feature is on, validate every IRIREF
+    // against RFC-3987 (fast path in front of `oxiri`) so the byte-level loader rejects the
+    // malformed IRIs the serial oxttl path already rejects — reaching conformance parity at
+    // fast-path cost. OFF by default: the loader keeps its current unvalidated-fast behaviour.
+    #[cfg(feature = "iri-fast")]
+    {
+        let valid = IRI_MEMO.with(|m| m.borrow_mut().validate(&s));
+        if !valid {
+            return Err(format!("N-Triples: invalid IRI <{}> at byte {}", s, i));
+        }
+    }
     Ok((dict.intern_iri(&s), next))
 }
 

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -86,8 +86,10 @@ pub fn load_dataset(text: &str, format: &str) -> Result<Graph, String>
 pub fn load_reader<R: std::io::Read>(reader: R, format: &str) -> Result<Graph, String>
 
 // Streaming + PARALLEL (needs `parallel`): pipelined 32 MiB block parse, never
-// materializes the whole decompressed doc. N-Triples gets the fast path; other
-// formats fall back to serial load_reader.
+// materializes the whole decompressed doc. N-Triples gets this parallel pipelined
+// path; other formats fall back to serial load_reader. (This is the PARALLEL-LOADER
+// fast path — distinct from the byte-level IRI-validation fast path noted below, which
+// is a separate, opt-in mechanism that covers N-Triples AND N-Quads.)
 pub fn load_reader_parallel<R: std::io::Read + Send>(reader: R, format: &str) -> Result<Graph, String>
 
 // [OPUS-4.8] sq-7d3dj.18 — the byte-level N-Triples/N-Quads fast path does NOT validate IRIs

--- a/skills/data-formats/SKILL.md
+++ b/skills/data-formats/SKILL.md
@@ -90,6 +90,18 @@ pub fn load_reader<R: std::io::Read>(reader: R, format: &str) -> Result<Graph, S
 // formats fall back to serial load_reader.
 pub fn load_reader_parallel<R: std::io::Read + Send>(reader: R, format: &str) -> Result<Graph, String>
 
+// [OPUS-4.8] sq-7d3dj.18 — the byte-level N-Triples/N-Quads fast path does NOT validate IRIs
+// against RFC-3987 by default (it trusts input; the serial oxttl path DOES validate). The
+// OPT-IN `iri-fast` feature on `sparq-core` (OFF by default) turns that validation on for the
+// byte parser via a prefix-memoized fast path IN FRONT of `oxiri` — a last-N validated
+// `scheme://authority/` memo + a one-pass ASCII `iunreserved`/sub-delims suffix scan, falling
+// back to the full `oxiri` automaton on any non-ASCII / `%`-escape / `#` / delimiter anomaly.
+// It accepts EXACTLY what `oxiri::Iri::parse` accepts (an absolute IRI) — a MANDATORY
+// differential-fuzz gate (`sparq_core::iri`, run under `--features iri-fast`) asserts
+// `fast_accept ⇒ oxiri` and `validate == oxiri` over a committed adversarial corpus + a
+// deterministic generator, so a malformed IRI can never be wrong-accepted into the store.
+// The `oxiri` dep is already in-tree (via oxttl), so the feature adds zero new compilation.
+
 // Parse WITHOUT building indexes — the seam reasoning/transform hooks use.
 pub fn parse_to_triples(text: &str, format: &str) -> Result<(Dict, Vec<[Id; 3]>), String>
 pub fn from_parts(dict: Dict, triples: Vec<[Id; 3]>) -> Graph


### PR DESCRIPTION
> 🤖 **SPARQ agent**

Implements **sq-7d3dj.18** — the #2 impact-per-risk item from the engine-performance review (`research/engine-performance-review.md` §1.2, #1397; #1 radix-sort landed as #1407).

## What

A prefix-memoized IRI-validation fast path that sits **in front of** the full `oxiri` RFC-3987 automaton, added as the opt-in `iri-fast` feature on `sparq-core` (**OFF by default**). Two stacked ACCEPT-shortcuts, both falling back to `oxiri` on any uncertainty so the accepted language is byte-for-byte `oxiri`'s:

1. **Prefix memo** — a last-N validated `scheme://authority/` ring. An incoming IRI that byte-matches a memoized (already-`oxiri`-validated) prefix has its authority already proven valid, so only the suffix is checked.
2. **ASCII suffix pre-scan** — one vectorizable pass over the suffix against the position-independent "always-valid after the authority `/`" ASCII class (`iunreserved` ∪ `sub-delims` ∪ `{: @ / ?}`). A non-ASCII byte, a `%`-escape, a `#`, or any other anomaly drops straight to the full `oxiri` automaton.

Wired into the byte-level N-Triples/N-Quads loader (`nt::iri`): when the feature is on, the parallel loader validates every IRI (which it does **not** do by default — it trusts input, while the serial oxttl path validates), reaching conformance parity with oxttl at fast-path cost. `oxiri` is already in-tree transitively via `oxttl`, so the feature adds **zero new compilation**; the default/wasm build never names it.

## The equivalence gate (MANDATORY, per the bead)

The fast path is an **accept-shortcut ONLY, never a reject-shortcut** — a wrong accept would corrupt ingest. The load-bearing invariant:

> `fast_accept(s)` ⇒ `oxiri::Iri::parse(s).is_ok()`, and therefore `validate(s) == oxiri accepts s` exactly.

A **differential-fuzz gate** (`sparq_core::iri` tests, run under `--features iri-fast`) proves it every run: it asserts `fast_accept ⇒ oxiri` and `validate == oxiri` over a **committed adversarial corpus** (unicode boundaries, percent-encoding, empty authority, IPv6 literals, bad schemes, the `iunreserved`/`iprivate` edges) plus a **deterministic** seeded IRI-structured generator (120k cases, no external `rand` — replays byte-identically per PR). The reference `oxiri::Iri::parse` was empirically confirmed to match `oxttl` N-Triples and `oxrdf::NamedNode::new` acceptance exactly.

## Gates run (both feature states)

- `cargo test -p sparq-core` — green in **default** (feature OFF), **`--features iri-fast`**, and **`--no-default-features --features iri-fast`**. No existing test broke: the added validation rejects nothing the existing corpora contain.
- `cargo clippy -p sparq-core --all-targets -- -D warnings` — clean in all three feature states.
- `cargo doc --workspace --no-deps --all-features` with `RUSTDOCFLAGS="-D warnings"` — clean (links to feature-gated items live inside the feature-gated module; no always-compiled doc-comment links a gated item).
- `scripts/check-readme-template.py --enforce` — 0 deviations; core README 68 lines (≤120).

## Perf

The gate is the **equivalence**, not a speed claim. Direction was confirmed on the aarch64 work box (**non-canonical — no number is baked into any doc/test/CI threshold**): a warm-memo `validate` over a uniform-prefix ASCII corpus is meaningfully faster than per-IRI `oxiri::Iri::parse`, with identical accept counts. Canonical measurement is the EC2 ingest lane / `parse_ns_per_byte` ratchet.

## Scope note (honest)

The profiled ~30% aggregate cost is in the **serial oxttl** ingest path, which is third-party — a fast path cannot be inserted into it without forking oxttl. This PR therefore lands the equivalence-gated fast validator and wires it into the sparq-owned byte-level parser, where it doubles as opt-in **validated fast ingest** (closing the parallel-loader-vs-oxttl validation gap). Routing the serial path through a sparq-owned validator is a larger, separate change.

Closes sq-7d3dj.18.