### PR TITLE
feat(geo): raise OGC ratchet 158->197 (sq-lk3aw.1) [SONNET-4.6]

### DIFF
--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -123,8 +123,11 @@ pub struct Suite {
 /// * inference 1967 — `ci.yml` job `inference-conformance` (`RATCHET=1967`).
 /// * SHACL core 98 — `sparq-shacl` `w3c_core.rs` `BASELINE_PASS = 98`.
 /// * SHACL-SPARQL 5 — `sparq-shacl` `w3c_sparql.rs` `SHACL_SPARQL_FLOOR = 5`.
-/// * OGC GeoSPARQL 158 — `sparq-geo` `ogc_compliance_ratchet.rs`
-///   `OGC_RATCHET_FLOOR = 158` (sq-cbe4t raised it 119 -> 158).
+/// * OGC GeoSPARQL 197 — `sparq-geo` `ogc_compliance_ratchet.rs`
+///   `OGC_RATCHET_FLOOR = 197` (sq-cbe4t raised it 119 -> 158;
+///   sq-lk3aw.1 raised it 158 -> 197: 39 net-new assertions covering
+///   edge-adjacent polygons / disjoint line+polygon / parallel lines /
+///   point-on-line / and multi-pair rcc8/eh disjoint cells).
 /// * OGC GeoSPARQL query-rewrite 38 — `sparq-geo` `ogc_query_rewrite_ratchet.rs`
 ///   `OGC_QUERY_REWRITE_FLOOR = 38` (sq-wf9qg; opt-in `geosparql_rewrite` feature;
 ///   topology PROPERTY forms answered via the rewrite, MEASURED pass count).
@@ -255,7 +258,10 @@ pub const SUITES: &[Suite] = &[
         // assertions (reverse-order/symmetry coverage + MULTI* operands). The
         // crate-local `OGC_RATCHET_FLOOR` const moved in lock-step; the floor-sync
         // guard (`tests/scoreboard_floors.rs`) pins the two together.
-        ratchet_floor: 158,
+        // [SONNET-4.6] sq-lk3aw.1 — raised 158 -> 197: 39 more net-new assertions
+        // (edge-adjacent polygons / disjoint line+polygon / parallel lines /
+        // point-on-line / multi-pair rcc8/eh disjoint cells).
+        ratchet_floor: 197,
         floor_basis: "pass",
         // [OPUS-4.8] sq-cbe4t — DISTANCE-APPROXIMATION HONESTY NOTE. This topology
         // ratchet is exact DE-9IM (no approximation). The `geof:distance` METRIC

--- a/crates/sparq-geo/tests/ogc_compliance_ratchet.rs
+++ b/crates/sparq-geo/tests/ogc_compliance_ratchet.rs
@@ -68,7 +68,17 @@ use sparq_geo::GeoError;
 /// engine GENUINELY returns — none is a faked pass. The mirrored central
 /// scoreboard floor (`crates/sparq-conformance/src/scoreboard.rs`) and the
 /// floor-sync guard move in the same commit.
-const OGC_RATCHET_FLOOR: usize = 158;
+///
+/// [SONNET-4.6] sq-lk3aw.1 — raised 158 -> 197: 39 net-new hand-derived
+/// DE-9IM assertions extend coverage across five under-covered axes:
+/// (1) sf/eh/rcc8 for two polygons sharing an edge (external-connection cell,
+/// the `rcc8ec`/`ehMeet`/`sfTouches` family that was absent before);
+/// (2) line vs polygon in the DISJOINT case (the `sfCrosses` negative is now
+/// pinned); (3) line vs line PARALLEL/DISJOINT and ENDPOINT-TOUCHING cases;
+/// (4) point vs line (interior-point `sfWithin` and endpoint `sfTouches`);
+/// (5) additional rcc8/eh DISJOINT assertions over the existing polygon pairs
+/// that were missing the reverse-symmetric or multi-pair coverage.
+const OGC_RATCHET_FLOOR: usize = 197;
 
 /// One topology relation under test, named by its `geof:` local name and bound
 /// to its lexical-level implementation.
@@ -346,6 +356,84 @@ const FIXTURES: &[Fixture] = &[
     fx(CORNER_TANGENT, BIG, "rcc8po", false),
     // …and BIG is the tangential proper-part-INVERSE (tppi), not the non-tangential one.
     fx(BIG, CORNER_TANGENT, "rcc8ntppi", false),
+    // ========================================================================
+    // [SONNET-4.6] sq-lk3aw.1 — 39 net-new, hand-derived DE-9IM assertions.
+    // Each expected boolean is derived from the relation's DE-9IM pattern per
+    // the OGC GeoSPARQL specification and verified to be the value the engine
+    // GENUINELY returns; none is a faked pass.
+    //
+    // Five under-covered axes are filled:
+    //   (1) Two polygons sharing an edge (external-connection cell).
+    //   (2) Line vs polygon in the DISJOINT case (negative sfCrosses).
+    //   (3) Line vs line PARALLEL/DISJOINT and ENDPOINT-TOUCHING cases.
+    //   (4) Point vs line — interior point sfWithin and endpoint sfTouches.
+    //   (5) Additional DISJOINT assertions for existing polygon pairs that
+    //       were missing coverage.
+    //
+    // ---- (1) sf/eh/rcc8: two polygons sharing an edge (ADJACENT_TO_SMALL) --
+    // SMALL_INSIDE = (1,2)×(1,2); ADJACENT_TO_SMALL = (2,4)×(1,2).
+    // They share the segment {x=2, 1≤y≤2}: interiors are disjoint (rcc8ec /
+    // ehMeet / sfTouches). The DE-9IM matrix is "FFTFTTTTT".
+    //
+    // sf: boundaries meet → touches; interiors are disjoint → no overlap.
+    fx(SMALL_INSIDE, ADJACENT_TO_SMALL, "sfTouches", true),
+    fx(SMALL_INSIDE, ADJACENT_TO_SMALL, "sfIntersects", true),
+    fx(SMALL_INSIDE, ADJACENT_TO_SMALL, "sfDisjoint", false),
+    fx(SMALL_INSIDE, ADJACENT_TO_SMALL, "sfEquals", false),
+    fx(SMALL_INSIDE, ADJACENT_TO_SMALL, "sfOverlaps", false),
+    // sfTouches is SYMMETRIC for polygons sharing only a boundary segment.
+    fx(ADJACENT_TO_SMALL, SMALL_INSIDE, "sfTouches", true),
+    fx(ADJACENT_TO_SMALL, SMALL_INSIDE, "sfIntersects", true),
+    // eh: "F***T****" matches the "FFTFTTTTT" matrix → ehMeet.
+    fx(SMALL_INSIDE, ADJACENT_TO_SMALL, "ehMeet", true),
+    fx(SMALL_INSIDE, ADJACENT_TO_SMALL, "ehDisjoint", false),
+    fx(SMALL_INSIDE, ADJACENT_TO_SMALL, "ehOverlap", false),
+    // ehMeet is SYMMETRIC.
+    fx(ADJACENT_TO_SMALL, SMALL_INSIDE, "ehMeet", true),
+    fx(ADJACENT_TO_SMALL, SMALL_INSIDE, "ehDisjoint", false),
+    // rcc8ec = "FFTFTTTTT" — matches the matrix exactly.
+    fx(SMALL_INSIDE, ADJACENT_TO_SMALL, "rcc8ec", true),
+    fx(ADJACENT_TO_SMALL, SMALL_INSIDE, "rcc8ec", true),
+    fx(SMALL_INSIDE, ADJACENT_TO_SMALL, "rcc8dc", false),
+    fx(SMALL_INSIDE, ADJACENT_TO_SMALL, "rcc8po", false),
+    // ---- (2) sf: line vs polygon — DISJOINT case ----------------------------
+    // A line entirely to the LEFT of the polygon: disjoint, not crossing.
+    fx("LINESTRING(-5 0, -1 0)", "POLYGON((0 0,2 0,2 2,0 2,0 0))", "sfDisjoint", true),
+    fx("LINESTRING(-5 0, -1 0)", "POLYGON((0 0,2 0,2 2,0 2,0 0))", "sfIntersects", false),
+    fx("LINESTRING(-5 0, -1 0)", "POLYGON((0 0,2 0,2 2,0 2,0 0))", "sfCrosses", false),
+    // ---- (3) sf: line vs line — PARALLEL/DISJOINT and ENDPOINT-TOUCHING -----
+    // Two horizontal lines at y=0 and y=1: parallel, no shared points.
+    fx("LINESTRING(0 0, 2 0)", "LINESTRING(0 1, 2 1)", "sfDisjoint", true),
+    fx("LINESTRING(0 0, 2 0)", "LINESTRING(0 1, 2 1)", "sfIntersects", false),
+    fx("LINESTRING(0 0, 2 0)", "LINESTRING(0 1, 2 1)", "sfCrosses", false),
+    fx("LINESTRING(0 0, 2 0)", "LINESTRING(0 1, 2 1)", "sfOverlaps", false),
+    // Two collinear lines that share only the endpoint (2,0): sfTouches.
+    // I(first) ∩ I(second) = ∅ (their open interiors don't overlap),
+    // ∂(first) ∩ ∂(second) = {(2,0)} ≠ ∅ → "F***T****" matches.
+    fx("LINESTRING(0 0, 2 0)", "LINESTRING(2 0, 4 0)", "sfTouches", true),
+    fx("LINESTRING(0 0, 2 0)", "LINESTRING(2 0, 4 0)", "sfIntersects", true),
+    fx("LINESTRING(0 0, 2 0)", "LINESTRING(2 0, 4 0)", "sfOverlaps", false),
+    // ---- (4) sf: point vs line — interior vs endpoint -----------------------
+    // An interior point on a line: sfWithin (I(point) ∩ I(line) = {(1,0)} ≠ ∅).
+    fx("POINT(1 0)", "LINESTRING(0 0, 2 0)", "sfWithin", true),
+    fx("POINT(1 0)", "LINESTRING(0 0, 2 0)", "sfIntersects", true),
+    fx("POINT(1 0)", "LINESTRING(0 0, 2 0)", "sfTouches", false),
+    // An endpoint of a line: sfTouches (I(point) ∩ I(line) = ∅; point touches
+    // ∂(line)). The endpoint is NOT "within" the line (interior rule).
+    fx("POINT(0 0)", "LINESTRING(0 0, 2 0)", "sfTouches", true),
+    fx("POINT(0 0)", "LINESTRING(0 0, 2 0)", "sfWithin", false),
+    // A point completely outside the line: disjoint.
+    fx("POINT(5 5)", "LINESTRING(0 0, 2 0)", "sfDisjoint", true),
+    fx("POINT(5 5)", "LINESTRING(0 0, 2 0)", "sfIntersects", false),
+    // ---- (5) rcc8/eh: disjoint pairs that had no coverage -------------------
+    // FAR (9,9)-(10,10) and OVERLAP (3,3)-(6,6): no shared points → rcc8dc.
+    fx(FAR, OVERLAP, "rcc8dc", true),
+    fx(OVERLAP, EDGE_ADJACENT, "rcc8dc", true),
+    fx(FAR, SMALL_INSIDE, "rcc8dc", true),
+    // Same disjoint pairs in the Egenhofer family → ehDisjoint.
+    fx(FAR, OVERLAP, "ehDisjoint", true),
+    fx(OVERLAP, FAR, "ehDisjoint", true),
+    fx(EDGE_ADJACENT, OVERLAP, "ehDisjoint", true),
 ];
 
 /// A MultiPolygon of two disjoint unit-ish squares — exercises MULTI* operand
@@ -353,6 +441,12 @@ const FIXTURES: &[Fixture] = &[
 /// disjoint). [OPUS-4.8] sq-cbe4t
 const MULTI_TWO_SQUARES: &str =
     "MULTIPOLYGON(((0 0,4 0,4 4,0 4,0 0)),((6 6,8 6,8 8,6 8,6 6)))";
+
+/// A polygon that shares its LEFT edge with SMALL_INSIDE's RIGHT edge (at x=2,
+/// y=1..2). The two polygons are EXTERNALLY CONNECTED: their interiors are
+/// disjoint but their boundaries meet along a 1-D segment — the
+/// `rcc8ec`/`ehMeet`/`sfTouches` cell. [SONNET-4.6] sq-lk3aw.1
+const ADJACENT_TO_SMALL: &str = "POLYGON((2 1, 4 1, 4 2, 2 2, 2 1))";
 
 fn run_fixtures(fixtures: &[Fixture]) -> (usize, usize, Vec<String>) {
     let relations = all_relations();


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bulk Rust implementer (Sonnet tier) implementing bead **sq-lk3aw.1** (epic sq-lk3aw).

## Summary

Raises `OGC_RATCHET_FLOOR` from 158 to 197 by adding 39 net-new hand-derived DE-9IM assertions to the OGC GeoSPARQL topology compliance corpus in `crates/sparq-geo/tests/ogc_compliance_ratchet.rs`.

All 197 fixtures pass with 0 failures. The floor in the central scoreboard mirror (`crates/sparq-conformance/src/scoreboard.rs`) is updated in lock-step; the `scoreboard_floors.rs` floor-sync guard verifies this automatically.

## Five under-covered axes filled

1. **Polygons sharing an edge** (`rcc8ec` / `ehMeet` / `sfTouches`): the new `ADJACENT_TO_SMALL` polygon shares its left edge with `SMALL_INSIDE`'s right edge (x=2, y=1..2), giving the external-connection DE-9IM matrix `"FFTFTTTTT"`. Previously absent from the corpus.

2. **Line vs polygon — DISJOINT case**: `sfCrosses` negative + `sfDisjoint`/`sfIntersects` pair. Previously only the crossing case was tested.

3. **Line vs line — PARALLEL/DISJOINT and ENDPOINT-TOUCHING**: two new pairs (`y=0` vs `y=1` parallel lines; two collinear lines sharing only an endpoint) covering `sfOverlaps`/`sfCrosses` negatives and `sfTouches` positive.

4. **Point vs line**: interior-point `sfWithin` (DE-9IM verified: `"TFFFFFTTT"` matches `"T*F**F***"`) and endpoint `sfTouches` (boundary-contact rule), both geometry-type pairings absent before.

5. **Additional rcc8/eh DISJOINT assertions** for existing polygon pairs (`FAR×OVERLAP`, `OVERLAP×EDGE_ADJACENT`, `FAR×SMALL_INSIDE`) that were missing symmetric or multi-pair coverage.

## Spec and acceptance test

- **Spec**: bead `sq-lk3aw.1` (parent epic `sq-lk3aw`), OGC GeoSPARQL §9 DE-9IM relations
- **Acceptance test**: `ogc_topology_compliance_ratchet` — `OGC_RATCHET_FLOOR` rises above 158 → **197**; `floor_is_consistent_with_corpus` confirms it is reachable

## Gates run in-worktree (both feature states)

- `cargo test -p sparq-geo` — green (default features)
- `cargo test -p sparq-geo --features geosparql_rewrite` — green
- `cargo clippy -p sparq-geo --all-targets -- -D warnings` — clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-geo --no-deps --all-features` — clean
- `cargo test -p sparq-conformance central_floors_match_crate_local_sources` — green (floor-sync guard)
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations

No new public API added; no functional code changed; core stays lean.

> 🤖 **SPARQ agent** [SONNET-4.6]