### PR TITLE
feat(rsp): raise RSP expressivity ratchet 149->303 (sq-2n1q3.1) [SONNET-4.6]

### DIFF
--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -191,15 +191,15 @@ pub struct Suite {
 ///   / BM25 suite exists; floor = the MEASURED count of bit-exact BM25 score
 ///   assertions the fixed-seed corpus battery makes against a from-scratch
 ///   independent reference scorer; default-on, no opt-in feature required).
-/// * RSP expressivity / SRBench correctness 149 — `sparq-rsp`
-///   `tests/srbench_oracle.rs` `RSP_EXPRESSIVITY_FLOOR = 149` (sq-mcb3q; a sparq
-///   EXTENSION ratchet, NOT standards conformance — RSP-QL is a W3C-COMMUNITY spec
-///   and SRBench is a benchmark, so there is NO normative RDF-Stream-Processing
-///   Recommendation or its conformance suite; floor = the MEASURED count of
-///   deterministic per-window correctness assertions the fixed SRBench-shaped
-///   battery makes across window types / R2S operators / EvalModes / multi-window
-///   joins against an INDEPENDENT batch-rebuild + closed-form oracle; default-on,
-///   no opt-in feature required).
+/// * RSP expressivity / SRBench correctness 303 — `sparq-rsp`
+///   `tests/srbench_oracle.rs` `RSP_EXPRESSIVITY_FLOOR = 303` (sq-2n1q3.1; raised
+///   from 149 sq-mcb3q baseline; a sparq EXTENSION ratchet, NOT standards conformance
+///   — RSP-QL is a W3C-COMMUNITY spec and SRBench is a benchmark, so there is NO
+///   normative RDF-Stream-Processing Recommendation or its conformance suite; floor =
+///   the MEASURED count of deterministic per-window correctness assertions the fixed
+///   SRBench-shaped battery makes across window types / R2S operators / EvalModes /
+///   multi-window joins against an INDEPENDENT batch-rebuild + closed-form oracle;
+///   default-on, no opt-in feature required). [SONNET-4.6]
 /// * OWL 2 QL (DL-Lite_R) certain-answer oracle 11 — `sparq-conformance`
 ///   `tests/ql_dllite_suite.rs` `QL_DLLITE_FLOOR = 11` (sq-qo1a9; opt-in
 ///   `ql-experimental` feature; a sparq EXTENSION ratchet, NOT a
@@ -724,7 +724,7 @@ pub const SUITES: &[Suite] = &[
         family: "sparq extension",
         runner: Runner::CrateTest { krate: "sparq-rsp", target: "srbench_oracle" },
         ci_job: "rsp-oracle",
-        ratchet_floor: 149,
+        ratchet_floor: 303, // [SONNET-4.6] sq-2n1q3.1 raised from 149 (sq-mcb3q baseline)
         floor_basis: "per-window correctness assertions (sparq EXTENSION, NOT standards conformance)",
         note: "EXTENSION ratchet — no normative RDF-Stream-Processing standard / RSP \
                conformance suite exists (RSP-QL is a W3C-community spec; SRBench a \

--- a/crates/sparq-rsp/tests/srbench_oracle.rs
+++ b/crates/sparq-rsp/tests/srbench_oracle.rs
@@ -74,8 +74,11 @@ use sparq_rsp::{
 /// in lock-step by that crate's `tests/scoreboard_floors.rs` guard (read
 /// textually — no cross-crate dep). HONESTLY a sparq EXTENSION ratchet, NOT a
 /// standards conformance claim (no normative RSP / SRBench test suite exists).
-/// [OPUS-4.8] sq-mcb3q
-const RSP_EXPRESSIVITY_FLOOR: usize = 149;
+/// [SONNET-4.6] sq-2n1q3.1 — raised from 149 (sq-mcb3q baseline) by:
+///   +76 sliding_narrow_sum scenario (RANGE 10 STEP 5, 9 windows × 4 EvalModes)
+///   +24 count-window EvalMode crosscheck (4 modes × 6 assertions each)
+///   +54 R2S EvalMode crosscheck (RSTREAM/ISTREAM/DSTREAM × 3 extra modes × 6 assertions)
+const RSP_EXPRESSIVITY_FLOOR: usize = 303;
 
 /// Documented RSP-QL surface that sparq-rsp does NOT execute, so it is NOT
 /// ratcheted here (the honest move: a lower floor reflecting reality + a recorded
@@ -241,6 +244,14 @@ fn scenarios() -> Vec<(&'static str, WindowSpec, &'static str)> {
             "SELECT ?room (AVG(?v) AS ?avg) (COUNT(?v) AS ?n) \
              WHERE { ?s <http://ex/in> ?room . ?s <http://ex/value> ?v } \
              GROUP BY ?room ORDER BY ?room",
+        ),
+        // Sliding narrow SUM (RANGE 10 STEP 5 → 50%-overlap, shorter window than
+        // step < range): 9 windows over the weather_script, exercises the DENSER
+        // sliding case with a global SUM aggregate. [SONNET-4.6] sq-2n1q3.1
+        (
+            "sliding_narrow_sum",
+            WindowSpec::time(10, 5),
+            "SELECT (SUM(?v) AS ?sum) WHERE { ?s <http://ex/value> ?v }",
         ),
     ]
 }
@@ -419,6 +430,47 @@ fn intern_name(iri: &str) -> Option<&'static str> {
     }
 }
 
+// ================================== AXIS 2b: R2S × all EvalModes consistency
+//
+// Cross-check that Rebuild, Delta, Snapshot each produce the same RSTREAM /
+// ISTREAM / DSTREAM window sequence as PersistentDict on the active_script.
+// Proves the R2S diff is EvalMode-agnostic (the diff is applied at the query
+// layer, after graph materialisation, so all four modes must agree).
+// [SONNET-4.6] sq-2n1q3.1
+
+fn axis_r2s_evalmode_crosscheck(tally: &mut Tally) {
+    let script = active_script();
+    let sparql = "SELECT ?s WHERE { ?s <http://ex/active> ?o }";
+    let spec = WindowSpec::time(10, 10);
+
+    for r2s in [R2S::RStream, R2S::IStream, R2S::DStream] {
+        // PersistentDict is the reference (already fully checked in axis_r2s_operators).
+        let reference =
+            run_single(sparql, spec, EvalMode::PersistentDict, r2s, &script);
+        for mode in [EvalMode::Rebuild, EvalMode::Delta, EvalMode::Snapshot] {
+            let result = run_single(sparql, spec, mode, r2s, &script);
+            tally.eq(
+                result.len(),
+                reference.len(),
+                &format!(
+                    "r2s {:?}/{:?}: window count matches PersistentDict reference",
+                    r2s, mode
+                ),
+            );
+            for i in 0..reference.len() {
+                tally.eq(
+                    subjects(&result[i]),
+                    subjects(&reference[i]),
+                    &format!(
+                        "r2s {:?}/{:?} w{}: rows match PersistentDict reference",
+                        r2s, mode, i
+                    ),
+                );
+            }
+        }
+    }
+}
+
 // =============================================== AXIS 3: CQL count (ROWS) windows
 //
 // SRBench expressivity over the programmatic count window: last-N arrivals,
@@ -454,6 +506,54 @@ fn count_val(cell: &Option<Term>) -> Option<i64> {
     match cell {
         Some(Term::Literal(l)) => l.value().parse::<i64>().ok(),
         _ => None,
+    }
+}
+
+// ================================= AXIS 3b: count-window × all EvalModes
+//
+// Assert the per-slot COUNT(*) values (ramp-up then plateau at capacity) and
+// cross-check all four EvalModes agree on every slot — proves the count-window
+// eviction policy (CQL last-N semantics) is EvalMode-agnostic.
+// [SONNET-4.6] sq-2n1q3.1
+
+fn axis_count_window_evalmode_crosscheck(tally: &mut Tally) {
+    let spec = WindowSpec::count(3);
+    let sparql = "SELECT (COUNT(*) AS ?n) WHERE { ?s <http://ex/value> ?v }";
+    let script: Vec<([Term; 3], u64)> = vec![
+        (val("s1", 1), 0),
+        (val("s2", 2), 1),
+        (val("s3", 3), 2),
+        (val("s4", 4), 3),
+        (val("s5", 5), 4),
+    ];
+    // Expected per-slot count(*): ramp up to capacity then plateau.
+    //   slot 0 (s1 only):         COUNT = 1
+    //   slot 1 (s1,s2):           COUNT = 2
+    //   slot 2 (s1,s2,s3 — full): COUNT = 3
+    //   slot 3 (s2,s3,s4):        COUNT = 3
+    //   slot 4 (s3,s4,s5):        COUNT = 3
+    let expected_counts: &[i64] = &[1, 2, 3, 3, 3];
+    for mode in [
+        EvalMode::Rebuild,
+        EvalMode::PersistentDict,
+        EvalMode::Delta,
+        EvalMode::Snapshot,
+    ] {
+        let r = run_single(sparql, spec, mode, R2S::RStream, &script);
+        tally.eq(
+            r.len(),
+            expected_counts.len(),
+            &format!("count window/{:?}: exactly {} slots reported", mode, expected_counts.len()),
+        );
+        for (i, &want) in expected_counts.iter().enumerate() {
+            let got =
+                r[i].rows.first().and_then(|row| row.first()).and_then(count_val).unwrap_or(-1);
+            tally.eq(
+                got,
+                want,
+                &format!("count window/{:?} slot {}: COUNT(*) = {}", mode, i, want),
+            );
+        }
     }
 }
 
@@ -678,12 +778,14 @@ fn rsp_srbench_expressivity_ratchet() {
     let mut tally = Tally::default();
     axis_window_types_x_evalmode(&mut tally);
     axis_r2s_operators(&mut tally);
+    axis_r2s_evalmode_crosscheck(&mut tally); // [SONNET-4.6] sq-2n1q3.1
     axis_count_windows(&mut tally);
+    axis_count_window_evalmode_crosscheck(&mut tally); // [SONNET-4.6] sq-2n1q3.1
     axis_multi_window_joins(&mut tally);
     axis_documented_gaps(&mut tally);
 
     // The line CI re-checks (mirrors the BM25 oracle's `assertions N (floor F)`).
-    // [OPUS-4.8] sq-mcb3q — positional format args (CodeQL rust/unused-variable).
+    // [OPUS-4.8] sq-mcb3q / [SONNET-4.6] sq-2n1q3.1 — positional format args (CodeQL).
     println!(
         "RSP expressivity / SRBench correctness assertions {} (floor {})",
         tally.n, RSP_EXPRESSIVITY_FLOOR

--- a/crates/sparq-rsp/tests/srbench_oracle.rs
+++ b/crates/sparq-rsp/tests/srbench_oracle.rs
@@ -457,10 +457,13 @@ fn axis_r2s_evalmode_crosscheck(tally: &mut Tally) {
                     r2s, mode
                 ),
             );
-            for i in 0..reference.len() {
+            // Use get() so a short `result` (regression) compares [] vs the
+            // reference window through tally rather than panicking on index.
+            // [SONNET-4.6] sq-2n1q3.1 robustness
+            for (i, ref_win) in reference.iter().enumerate() {
                 tally.eq(
-                    subjects(&result[i]),
-                    subjects(&reference[i]),
+                    result.get(i).map(|w| subjects(w)).unwrap_or_default(),
+                    subjects(ref_win),
                     &format!(
                         "r2s {:?}/{:?} w{}: rows match PersistentDict reference",
                         r2s, mode, i
@@ -545,9 +548,16 @@ fn axis_count_window_evalmode_crosscheck(tally: &mut Tally) {
             expected_counts.len(),
             &format!("count window/{:?}: exactly {} slots reported", mode, expected_counts.len()),
         );
+        // Use get() so a short `r` (regression with fewer slots) records -1 vs
+        // want through tally rather than panicking on index.
+        // [SONNET-4.6] sq-2n1q3.1 robustness
         for (i, &want) in expected_counts.iter().enumerate() {
-            let got =
-                r[i].rows.first().and_then(|row| row.first()).and_then(count_val).unwrap_or(-1);
+            let got = r
+                .get(i)
+                .and_then(|win| win.rows.first())
+                .and_then(|row| row.first())
+                .and_then(count_val)
+                .unwrap_or(-1);
             tally.eq(
                 got,
                 want,


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bulk Rust implementer (Sonnet tier), bead sq-2n1q3.1, epic sq-2n1q3.

## Summary

Raises `RSP_EXPRESSIVITY_FLOOR` from **149** (sq-mcb3q baseline) to **303** by adding 154 new deterministic SRBench per-window correctness cells, then mirrors the new floor into the central conformance scoreboard. No architecture change — pure test-battery extension on the existing `ContinuousQuery` / `R2S` / `EvalMode` public API.

**Spec**: bead sq-2n1q3.1 (`bd show sq-2n1q3.1`) — deterministic, clock-free per-window row-count/content assertions driving the REAL public pipeline.
**Acceptance test**: `cargo test -p sparq-rsp rsp_srbench_expressivity_ratchet` — now prints `303 (floor 303)`, was `149 (floor 149)`.

## New axes (154 assertions total)

| Axis | New assertions | Coverage |
|------|---------------|----------|
| `sliding_narrow_sum` (RANGE 10 STEP 5, 9 windows × 4 EvalModes × batch oracle) | +76 | Dense sliding window SUM aggregate |
| `axis_r2s_evalmode_crosscheck` (RSTREAM/ISTREAM/DSTREAM × Rebuild/Delta/Snapshot) | +54 | R2S diff is EvalMode-agnostic |
| `axis_count_window_evalmode_crosscheck` (count(3) ramp-up × 4 EvalModes) | +24 | CQL last-N eviction is EvalMode-agnostic |

All cells are clock-free, deterministic, and drive the REAL `ContinuousQuery.with_mode/with_r2s` path — no mocks, no timing assertions.

## Files changed

- `crates/sparq-rsp/tests/srbench_oracle.rs` — new scenario + 2 new axis functions + runner wired + floor const updated
- `crates/sparq-conformance/src/scoreboard.rs` — `ratchet_floor: 149` → `303`, comment updated (lock-step mirror required by `tests/scoreboard_floors.rs` guard)

## Gates (in-worktree, both feature states)

- `cargo test -p sparq-rsp` → GREEN (303 assertions, all pass)
- `cargo test -p sparq-conformance` → GREEN (scoreboard floor sync guard passes)
- `cargo clippy -p sparq-rsp --all-targets -- -D warnings` → CLEAN
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-rsp --no-deps --all-features` → CLEAN
- `cargo llvm-cov test -p sparq-rsp` → 95.31% (floor 92, no regression)
- `python3 scripts/check-readme-template.py --enforce` → 0 deviations

Auto-merge: NOT armed (per brief).

> 🤖 **SPARQ agent** [SONNET-4.6] — sq-2n1q3.1 / epic sq-2n1q3