### PR TITLE
feat(fedplan): make sparq-fedplan publishable + planner bench + SKILL (sq-my8wd.3) [SONNET-4.6]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3865,6 +3865,7 @@ dependencies = [
 name = "sparq-fedplan"
 version = "0.1.0"
 dependencies = [
+ "criterion",
  "oxrdf 0.3.3",
  "oxttl 0.2.3",
  "rustc-hash 2.1.2",

--- a/crates/sparq-fedplan/Cargo.toml
+++ b/crates/sparq-fedplan/Cargo.toml
@@ -12,15 +12,23 @@ homepage.workspace = true
 keywords.workspace = true
 categories.workspace = true
 description = "Cost-based federated source selection (HiBISCuS prune + CostFed cardinality) and bind-vs-hash join planning over served source descriptors — opt-in, no network I/O"
-publish = false
+readme = "README.md"
+# [SONNET-4.6] sq-my8wd.3: Graduate from publish=false to publishable. The
+# select_sources + plan_bgp planner is feature-complete (HiBISCuS + CostFed +
+# StreamJoin + AdaptiveExecutor). Flip, add the criterion micro-bench and the
+# docs.rs all-features metadata (mirrors sq-qonbz.4 / sparq-substrate).
+publish = true
 
 # OPT-IN, lean core. NOTHING in the workspace's default build depends on this crate:
 # it is a standalone member (like `sparq-canon` / `sparq-prov`), so `sparq-core`'s
 # default build and the wasm artifact are byte-identical with or without it. The
 # capability is therefore OFF BY DEFAULT at the dependency level — the leanest gating,
-# with zero core overhead when absent. A `publish = false` PLANNING crate (no runtime
-# data path, like `sparq-canon`/`sparq-prov`) is bench-exempt under gate G1.
+# with zero core overhead when absent.
 # [OPUS-4.8] sq-a35t, branch feat-fedplan-cost-selection.
+
+# [SONNET-4.6] sq-my8wd.3: Render README.md as the docs.rs front page.
+[package.metadata.docs.rs]
+all-features = true
 
 [features]
 # The whole planner is feature-gated so even a crate that DOES depend on sparq-fedplan
@@ -40,6 +48,19 @@ oxrdf = { workspace = true }
 oxttl = { workspace = true }
 rustc-hash = { workspace = true }
 
+# [SONNET-4.6] sq-my8wd.3: criterion for the select_sources + plan_bgp micro-bench
+# (dev-only, never reaches the lean default or wasm build). Pinned at "0.5" to match
+# the workspace bench pattern (sparq-substrate). Transitive deps (anes, ciborium*,
+# oorandom) are already covered by upstream imports (bytecode-alliance / google /
+# mozilla) in supply-chain/imports.lock from when sparq-substrate added criterion.
 [dev-dependencies]
+criterion = { version = "0.5", features = ["html_reports"] }
 # Round-trip a descriptor parsed from the served N-Triples form.
 oxttl = { workspace = true }
+
+# [SONNET-4.6] sq-my8wd.3: The micro-bench exercises select_sources + plan_bgp
+# over a 3-source, 3-pattern BGP at varying scales. Feature-gated on `fedplan`.
+[[bench]]
+name = "fedplan"
+harness = false
+required-features = ["fedplan"]

--- a/crates/sparq-fedplan/README.md
+++ b/crates/sparq-fedplan/README.md
@@ -1,27 +1,84 @@
-<!-- [OPUS-4.8] sq-inzv: internal-stub README for a publish=false crate; full surface lives in skills/federated-planning/SKILL.md. -->
 # sparq-fedplan
 
-Cost-based **federated source selection** + **bind-vs-hash-vs-streaming join
-planning** over already-fetched source descriptors — a small, opt-in, **pure and
-deterministic** planner with no network I/O. From a SPARQL BGP and a set of
+**Cost-based federated source selection** and **bind-vs-hash join planning** over
+already-fetched source descriptors — a small, opt-in, **pure and deterministic**
+planner with no network I/O (epic sq-3183). From a SPARQL BGP and a set of
 `SourceDescriptor`s (VoID property/class partitions + mined `scs:` characteristic
 sets) it prunes sources per pattern (HiBISCuS-style **recall-safe**), estimates
 cardinality (CostFed skew-aware + characteristic-set star joins), and builds a join
-order; an opt-in `adaptive-replan` feature adds stage-boundary re-planning, and the
-`StreamJoin` operator gives a memory-bounded non-blocking join with spill. The full
-public-API surface, the recall-safety invariant, the multiset-equal correctness
-proof, and the (explicitly hand-tuned, non-optimal) latency/EWMA heuristic caveats
-live in [`skills/federated-planning/SKILL.md`](../../skills/federated-planning/SKILL.md).
+order. An opt-in `adaptive-replan` feature adds stage-boundary re-planning, and the
+`StreamJoin` operator gives a memory-bounded non-blocking join with spill.
 
-> **Internal crate — not published** to crates.io (`publish = false`). Opt-in
-> (`fedplan` / `adaptive-replan` features, OFF by default; the lean core is
-> byte-identical without it). Any timing observed here is **non-canonical**
-> (work-box, not a CI runner) and is therefore not recorded.
+> **Opt-in** (`fedplan` / `adaptive-replan` features, OFF by default). The lean
+> `sparq-core` / `sparq-engine` build and the WASM artifact are byte-identical
+> without this crate. Timings observed on this work box are **non-canonical**.
 
-How-to: [`skills/federated-planning/SKILL.md`](../../skills/federated-planning/SKILL.md).
-Design: [`research/feature-research-federation.md`](../../research/feature-research-federation.md).
-Contributing: [`AGENTS.md`](../../AGENTS.md).
+## 🚀 Quickstart
+
+```toml
+[dependencies]
+sparq-fedplan = { version = "0.1.0", features = ["fedplan"] }
+oxrdf = { version = "0.3", features = ["rdf-12"] }
+```
+
+```rust,ignore
+use sparq_fedplan::{
+    select_sources, plan_bgp, Bgp, TriplePattern, Term, Var,
+    SourceDescriptor, SourceId, PredPartition, PlanOptions,
+};
+
+// 1. Build a source descriptor (or parse it from /.well-known/void).
+let src = SourceDescriptor::builder(SourceId::new("https://a.example/sparql"))
+    .total_triples(10_000)
+    .predicate(PredPartition {
+        predicate: "http://xmlns.com/foaf/0.1/knows".into(),
+        triples: 2000, distinct_subjects: 1000, distinct_objects: 1800,
+    })
+    .build();
+
+// 2. Select sources for a BGP (recall-safe — a source is only pruned when the
+//    descriptor proves it holds no matching triple).
+let bgp = Bgp::new(vec![
+    TriplePattern::new(
+        Term::Var(Var::new("s")),
+        Term::Iri("http://xmlns.com/foaf/0.1/knows".into()),
+        Term::Var(Var::new("o")),
+    ),
+]);
+let sources = [src];
+let selection = select_sources(&bgp, &sources);
+
+// 3. Plan the join (bind vs hash, greedy selectivity-first order).
+let plan = plan_bgp(&bgp, &selection, &sources, &PlanOptions::default()).unwrap();
+let _order: Vec<usize> = plan.join_order();
+```
+
+## ✨ Features
+
+- **`fedplan`** (off by default) — `select_sources` (HiBISCuS recall-safe pruning +
+  CostFed skew-aware cardinality) and `plan_bgp` (greedy bind-vs-hash join planner
+  using characteristic-set star-join cardinality). Also exposes `StreamJoin`, an
+  ANAPSID-style non-blocking symmetric hash join with bounded operator spill, for
+  streaming execution of large joins without materialising a full side up front.
+- **`adaptive-replan`** (off by default; implies `fedplan`) — `AdaptiveExecutor`:
+  mid-execution plan switching at stage boundaries when observed cardinalities or
+  source latencies diverge from estimates past a policy factor, with hysteresis to
+  prevent thrashing. Soundness boundary: only the not-yet-started suffix is reordered;
+  BGP join is commutative/associative so results are unchanged.
+
+All features are **off by default**. The crate is `forbid(unsafe_code)`.
+
+## 📚 Learn more
+
+- `skills/federated-planning/SKILL.md` — full public-API surface: recall-safety
+  invariant, `StreamJoin` spill correctness proof, EWMA latency heuristics, and
+  the `sparq-fedclient` consumer that calls this planner.
+- `research/feature-research-federation.md` — the design record.
+- `crates/sparq-fedclient` — the streaming federation client (epic sq-dnko) that
+  discovers remote source capabilities, calls `select_sources` + `plan_bgp`, and
+  streams results back over the HTTP transport.
+- `AGENTS.md` — contributing guidelines.
 
 ## License
 
-[MIT](../../LICENSE).
+MIT — see the workspace [LICENSE](../../LICENSE).

--- a/crates/sparq-fedplan/benches/fedplan.rs
+++ b/crates/sparq-fedplan/benches/fedplan.rs
@@ -108,8 +108,8 @@ fn bench_plan_bgp(c: &mut Criterion) {
             &n_sources,
             |b, _| {
                 b.iter(|| {
-                    // plan_bgp returns Ok(_) when the BGP is non-empty and sources exist;
-                    // unwrap is infallible here — the bench setup guarantees it.
+                    // plan_bgp returns Some(JoinTree) when the BGP is non-empty and sources
+                    // exist; unwrap is infallible here — the bench setup guarantees it.
                     black_box(
                         plan_bgp(
                             black_box(&bgp),

--- a/crates/sparq-fedplan/benches/fedplan.rs
+++ b/crates/sparq-fedplan/benches/fedplan.rs
@@ -1,0 +1,134 @@
+//! Criterion micro-benches for `sparq-fedplan`: `select_sources` + `plan_bgp`.
+//!
+//! Enabled by `--features fedplan`. The benches measure throughput shapes for the
+//! planner's two public entry points over a small synthetic descriptor set; **no
+//! hard-coded performance numbers are expected** — Criterion records measurements to
+//! `target/criterion/` for local comparison with its own baseline mechanism. Do not
+//! bake numbers into documentation or tests.
+//!
+//! # [SONNET-4.6] sq-my8wd.3 — epic sq-my8wd
+//!
+//! Surfaces covered:
+//! - `select_sources` — HiBISCuS-style recall-safe source selection over a 3-source,
+//!   3-pattern BGP with varying numbers of descriptors.
+//! - `plan_bgp` — bind-vs-hash join planning over the selected sources.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use sparq_fedplan::{
+    plan_bgp, select_sources, Bgp, PlanOptions, PredPartition, SourceDescriptor, SourceId, Term,
+    TriplePattern, Var,
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a `SourceDescriptor` with `n_predicates` predicates, each with `triples`
+/// triples. The source id is derived from the index so each is distinct.
+fn make_source(idx: usize, n_predicates: usize, triples_per_pred: u64) -> SourceDescriptor {
+    let mut b = SourceDescriptor::builder(SourceId::new(format!(
+        "https://s{}.example/sparql",
+        idx
+    )))
+    .total_triples(n_predicates as u64 * triples_per_pred);
+    for p in 0..n_predicates {
+        b = b.predicate(PredPartition {
+            predicate: format!("https://ex.example/p{}", p),
+            triples: triples_per_pred,
+            distinct_subjects: triples_per_pred / 2,
+            distinct_objects: triples_per_pred / 3,
+        });
+    }
+    b.build()
+}
+
+/// A 3-pattern BGP: each pattern uses a distinct predicate `p0`, `p1`, `p2`.
+/// The variables chain: `?s p0 ?o0 . ?o0 p1 ?o1 . ?o1 p2 ?o2`.
+fn chain_bgp() -> Bgp {
+    Bgp::new(vec![
+        TriplePattern::new(
+            Term::Var(Var::new("s")),
+            Term::Iri("https://ex.example/p0".to_string()),
+            Term::Var(Var::new("o0")),
+        ),
+        TriplePattern::new(
+            Term::Var(Var::new("o0")),
+            Term::Iri("https://ex.example/p1".to_string()),
+            Term::Var(Var::new("o1")),
+        ),
+        TriplePattern::new(
+            Term::Var(Var::new("o1")),
+            Term::Iri("https://ex.example/p2".to_string()),
+            Term::Var(Var::new("o2")),
+        ),
+    ])
+}
+
+// ---------------------------------------------------------------------------
+// Bench: select_sources
+// ---------------------------------------------------------------------------
+
+fn bench_select_sources(c: &mut Criterion) {
+    let mut group = c.benchmark_group("select_sources");
+    for n_sources in [1usize, 3, 10] {
+        let sources: Vec<SourceDescriptor> = (0..n_sources)
+            .map(|i| make_source(i, 5, 10_000))
+            .collect();
+        let bgp = chain_bgp();
+        group.bench_with_input(
+            BenchmarkId::new("n_sources", n_sources),
+            &n_sources,
+            |b, _| {
+                b.iter(|| {
+                    // [SONNET-4.6] black_box prevents LLVM from eliding the selection
+                    // when the result would otherwise be dropped unobserved.
+                    black_box(select_sources(black_box(&bgp), black_box(&sources)));
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Bench: plan_bgp
+// ---------------------------------------------------------------------------
+
+fn bench_plan_bgp(c: &mut Criterion) {
+    let mut group = c.benchmark_group("plan_bgp");
+    for n_sources in [1usize, 3, 10] {
+        let sources: Vec<SourceDescriptor> = (0..n_sources)
+            .map(|i| make_source(i, 5, 10_000))
+            .collect();
+        let bgp = chain_bgp();
+        let selection = select_sources(&bgp, &sources);
+        let opts = PlanOptions::default();
+        group.bench_with_input(
+            BenchmarkId::new("n_sources", n_sources),
+            &n_sources,
+            |b, _| {
+                b.iter(|| {
+                    // plan_bgp returns Ok(_) when the BGP is non-empty and sources exist;
+                    // unwrap is infallible here — the bench setup guarantees it.
+                    black_box(
+                        plan_bgp(
+                            black_box(&bgp),
+                            black_box(&selection),
+                            black_box(&sources),
+                            black_box(&opts),
+                        )
+                        .unwrap(),
+                    );
+                });
+            },
+        );
+    }
+    group.finish();
+}
+
+// ---------------------------------------------------------------------------
+// Registration
+// ---------------------------------------------------------------------------
+
+criterion_group!(planner_benches, bench_select_sources, bench_plan_bgp);
+criterion_main!(planner_benches);

--- a/crates/sparq-fedplan/src/lib.rs
+++ b/crates/sparq-fedplan/src/lib.rs
@@ -57,7 +57,7 @@ also serves under the `scs:` vocab (`http://sparq.dev/ns/cs#`). The planner is:
 ## Opt-in (hard constraint)
 
 The whole planner is behind the **`fedplan` cargo feature, OFF by default**, and the
-crate is a standalone workspace member with `publish = false` — `sparq-core` /
+crate is a standalone workspace member published on crates.io — `sparq-core` /
 `sparq-engine` never depend on it, so the default engine and the WASM artifact are
 byte-identical with or without it. A build that does not enable `fedplan` compiles
 an empty crate.
@@ -108,8 +108,8 @@ cost-based federation (bead sq-a35t, epic sq-3183). See `README.md` and
 whole planner (source selection, the bind-vs-hash join planner, the `StreamJoin` streaming
 operator, and the opt-in `AdaptiveExecutor`) and every re-exported item is gated behind the
 **`fedplan` cargo feature, OFF by default**. Build the docs with `--features fedplan` to see the
-planner API and the per-phase narrative; this crate is a standalone workspace member with
-`publish = false`, and `sparq-core` / `sparq-engine` **never** depend on it, so the default
+planner API and the per-phase narrative; this crate is a standalone workspace member published
+on crates.io, and `sparq-core` / `sparq-engine` **never** depend on it, so the default
 engine build and the WASM artifact are byte-identical with or without `sparq-fedplan`. Live
 adaptive re-planning (`AdaptiveExecutor`) is behind the further `adaptive-replan` feature
 (which implies `fedplan`).


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bulk Rust implementer (Sonnet tier), bead **sq-my8wd.3**, epic **sq-my8wd**.

## Summary

Graduate `crates/sparq-fedplan` from `publish = false` to publishable — mirrors the substrate F1 pattern (`sq-qonbz.4` / #1414). **Plan output is unchanged; this is packaging graduation only.**

- **`publish = true`** + `readme = "README.md"` + `[package.metadata.docs.rs] all-features = true`
- **`benches/fedplan.rs`**: Criterion micro-bench covering `select_sources` + `plan_bgp` over a 3-source 3-pattern chain BGP at `n_sources ∈ {1, 3, 10}`; no hard-coded performance numbers.
- **`README.md`**: converted from internal-stub (≤30-line + `<!-- internal-stub -->` directive) to full publishable template (84 lines, 🚀/✨/📚 + License sections). `skills/federated-planning/SKILL.md` is the complete API surface doc (already present and comprehensive).

**Cargo-vet**: all Criterion transitive deps (anes, ciborium\*, oorandom, plotters, clap, is-terminal, etc.) were already covered by upstream imports and `[[exemptions]]` entries from `sq-qonbz.4`/#1414 when `sparq-substrate` added Criterion. No new exemptions needed.

## Gates verified in-worktree

- `cargo bench -p sparq-fedplan --no-run --features fedplan` — GREEN (bench compiles)
- `cargo test -p sparq-fedplan` (default features) — GREEN (1 test)
- `cargo test -p sparq-fedplan --all-features` — GREEN (110 tests; 109 planner determinism tests unchanged)
- `cargo clippy -p sparq-fedplan --all-targets -- -D warnings` — GREEN (default + all-features)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — GREEN
- `cargo vet --locked --frozen` — Vetting Succeeded (106 fully audited, 409 exempted)
- `python3 scripts/check-readme-template.py --enforce crates/sparq-fedplan/README.md` — 0 deviations

## Spec + acceptance test

Spec: bead **sq-my8wd.3** (child of epic **sq-my8wd**).
Acceptance: bench `benches/fedplan.rs` compiles; `skills/federated-planning/SKILL.md` present; readme-template gate passes; planner determinism tests still green.
Feature flags tested: default (OFF) and `fedplan` + `adaptive-replan` (all-features ON).

> 🤖 **SPARQ agent** `[SONNET-4.6]` — do NOT arm; no auto-merge.