### PR TITLE
feat(engine): bounded/streaming remote SERVICE result consumption (sq-my8wd.4) [FABLE-5]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3833,6 +3833,7 @@ dependencies = [
  "rayon",
  "regex",
  "rustc-hash 2.1.2",
+ "serde",
  "serde_json",
  "sha1 0.11.0",
  "sha2 0.11.0",

--- a/bench/unsafe-snapshot.json
+++ b/bench/unsafe-snapshot.json
@@ -9,11 +9,12 @@
     "Re-seed (scripts/unsafe-gate.py --seed) ONLY alongside a reviewed register",
     "update \u2014 the diff to this file is the review hook. Smaller is always allowed."
   ],
-  "total": 63,
+  "total": 67,
   "crates": {
     "sparq-bench": 1,
     "sparq-cli": 2,
     "sparq-core": 45,
+    "sparq-engine": 4,
     "sparq-py": 4,
     "sparq-vectors": 9,
     "sparq-zk-compose": 2

--- a/compliance/memsafety/unsafe-register.md
+++ b/compliance/memsafety/unsafe-register.md
@@ -46,9 +46,12 @@ register distinguishes two trust classes of `unsafe`:
 
 ## Register
 
-**63 `unsafe` sites** across 6 crates (the other 30 crates are `#![forbid(unsafe_code)]`).
+**67 `unsafe` sites** across 7 crates (the other crates are `#![forbid(unsafe_code)]`).
 Counts and the file:line list are produced by `scripts/unsafe-gate.py --list` and
-must equal `bench/unsafe-snapshot.json`.
+must equal `bench/unsafe-snapshot.json`. The 7th crate, **`sparq-engine`**, is a special
+case: its **library** stays `#![forbid(unsafe_code)]` (zero shipped `unsafe`) — the 4 sites
+are confined to a single **integration test's** byte-counting `#[global_allocator]`, which a
+custom allocator unavoidably requires (see the `sparq-engine` subsection below).
 
 Recurring invariant shorthands used below:
 - **POD-bytes** — `[u32;3]` / `u32` / `u64` / `f64` are plain-old-data with no invalid
@@ -168,11 +171,43 @@ capsule destructor's drop is idempotent.
 | `src/arrow_export.rs:123` | `ffi::PyCapsule_GetPointer` (CPython FFI) | `capsule` is the live capsule CPython passes; name matches the `'static` CStr it was created under | returns the leaked `*mut FFI_ArrowArrayStream` (or null on a name mismatch — guarded by the `!ptr.is_null()` check below). Raw CPython call, GIL held inside the destructor. |
 | `src/arrow_export.rs:125` | `Box::from_raw` (reclaim) | `ptr` is exactly the pointer leaked at :107 via `Box::into_raw`, of the same type, same allocator | reconstitutes and drops the `Box<FFI_ArrowArrayStream>` exactly once per capsule (null-guarded, so never on a name mismatch). `FFI_ArrowArrayStream::Drop` is idempotent on an already-released stream (`release` is set `None` after the first call), so no double free / no leak whether or not pyarrow consumed it. |
 
+### `sparq-engine` — 4 sites (test-only byte-counting global allocator) [OPUS-4.8]
+
+(sq-my8wd.4.) The engine **library** is `#![forbid(unsafe_code)]` and ships **zero**
+`unsafe`. These 4 sites live entirely in one integration test,
+`tests/service_stream_bounded.rs`, which pins the DoS-relevant invariant of streaming
+SERVICE consumption: a large/duplicate-heavy remote SPARQL result must be consumed in
+memory **O(body)**, not O(parsed DOM + a term-level relation copy) — the old
+collect-everything path amplified a remote result into a multiple of its wire size. The
+test proves this with a **thread-local byte-counting allocator**, and a `#[global_allocator]`
+unavoidably requires `unsafe` (the `GlobalAlloc` trait is `unsafe` by definition; there is
+no safe substitute for a deterministic per-thread allocation counter). It is deliberately
+placed in the integration-test crate, not the lib, precisely so the lib keeps its
+`forbid(unsafe_code)` posture. **Not** a B5 (untrusted-input) surface: every method is a
+verbatim forward to the process `System` allocator with the identical arguments, so
+`System` discharges all of `GlobalAlloc`'s obligations; the wrapper only reads
+`Layout::size()`/`new_size` and mutates a thread-local `Cell<isize>` — no pointer `System`
+returns is ever dereferenced, retained, or aliased. Bounded by **review + the trivial
+forward-to-`System` argument** and enforced by the file-local
+`#![warn(clippy::undocumented_unsafe_blocks)]` (every site carries a `// SAFETY:` comment);
+Miri does not cover it (Miri supplies its own allocator and does not model a
+`#[global_allocator]` that calls `System`), but the test itself runs on the standard
+`cargo test -p sparq-engine --features service` lane.
+
+| File:line | Kind | Invariant relied on | Why sound / how bounded |
+|---|---|---|---|
+| `tests/service_stream_bounded.rs:83` | `unsafe impl GlobalAlloc for Counting` | forward-to-`System` | every method delegates verbatim to `System` with the same args, so `System` upholds the trait contract; the wrapper adds only size reads + a thread-local counter. TEST-only; lib stays `forbid(unsafe_code)`. |
+| `tests/service_stream_bounded.rs:87` | `unsafe fn alloc` | caller's `layout` contract forwarded | `System.alloc(layout)` unchanged; only the returned pointer's nullness is inspected before recording `layout.size()`. |
+| `tests/service_stream_bounded.rs:98` | `unsafe fn dealloc` | `ptr` came from this allocator with this `layout` | `System.dealloc(ptr, layout)` unchanged; holds because every `alloc`/`realloc` also forwarded to `System`. |
+| `tests/service_stream_bounded.rs:106` | `unsafe fn realloc` | caller's `ptr`/`layout`/`new_size` contract forwarded | `System.realloc(ptr, layout, new_size)` unchanged; only the returned pointer's nullness is inspected before recording the delta. |
+
 ## NEEDS-REVIEW
 
-**None.** Every one of the 63 sites now carries a literal `// SAFETY:` comment
+**None.** Every one of the 67 sites now carries a literal `// SAFETY:` comment
 immediately preceding the `unsafe` block/impl, mechanically enforced by
-`clippy::undocumented_unsafe_blocks` (MS-G2 closed, sq-8wbn, [OPUS-4.8]). The 6 sites that
+`clippy::undocumented_unsafe_blocks` (MS-G2 closed, sq-8wbn, [OPUS-4.8]) — set
+crate-root on the 5 unsafe-bearing lib crates and file-local on the one `sparq-engine`
+integration test that carries the byte-counting allocator. The 6 sites that
 previously relied on an adjacent block comment — the two `unsafe impl Send`/`Sync for
 SlotPtr` pairs (`dict.rs` + `dictspill.rs`), the `MmapMut` `from_raw_parts_mut` view, and
 the test `remove_var` — were reworded so the `// SAFETY:` token sits on the line directly

--- a/crates/sparq-engine/Cargo.toml
+++ b/crates/sparq-engine/Cargo.toml
@@ -55,7 +55,7 @@ zk = []
 # additionally `cfg(not(wasm32))`-gated and never enter the wasm bundle even if the
 # feature were turned on for a wasm target. When off, zero federation/HTTP code
 # compiles. [OPUS-4.8]
-service = ["dep:serde_json", "dep:ureq", "dep:quick-xml"]
+service = ["dep:serde", "dep:serde_json", "dep:ureq", "dep:quick-xml"]
 # [OPUS-4.8] (sq-678h) RDF serializer matrix: Turtle / TriG / N-Quads writers
 # (`serialize` module). The base build can already *parse* every format but only
 # *write* N-Triples (`triples_to_ntriples`, always on). This feature adds the missing
@@ -266,6 +266,13 @@ sha2 = { version = "0.11", optional = true }
 # already in the workspace tree (sparq-conformance, sparq-server) and is
 # platform-independent, but it is only ever pulled in when `service` is on.
 serde_json = { version = "1", optional = true }
+# [FABLE-5] (sq-my8wd.4) The streaming SPARQL-Results-JSON consumption drives serde's
+# `DeserializeSeed`/`Visitor` traits directly (walking `results.bindings` one binding
+# object at a time instead of building a whole-document DOM). serde is ALREADY in the
+# tree as serde_json's own dependency — no new supply-chain surface — but the trait
+# machinery lives in `serde::de`, which serde_json does not re-export. `service`-only,
+# no derive, default-features off (only the core traits are needed).
+serde = { version = "1", default-features = false, optional = true }
 # [OPUS-4.8] (sq-ycu) SPARQL-Results-XML (SRX) parsing for the `service` feature. Some
 # endpoints ignore the `Accept: …+json` header and return XML; without an SRX parser the
 # whole SERVICE call fails. quick-xml is platform-independent (it carries no HTTP/TLS, so

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -286,6 +286,49 @@ pub(crate) mod budget {
         })
     }
 
+    /// A savepoint of the local-vocab byte accumulator + the sticky exhaustion flag,
+    /// taken BEFORE a speculative interning burst — a streaming SERVICE block whose
+    /// rows a SILENT error must discard. [`restore_bytes`] rewinds to it so the
+    /// discarded interns leave the byte budget EXACTLY as if they never happened,
+    /// keeping SILENT SERVICE behaviour-neutral with the pre-streaming
+    /// collect-then-intern-on-success path (which charged nothing on a swallowed
+    /// remote error). [OPUS-4.8] (sq-my8wd.4)
+    #[cfg(feature = "service")]
+    #[derive(Clone, Copy)]
+    pub(crate) struct ByteSavepoint {
+        extra_bytes: usize,
+        exceeded: Option<&'static str>,
+    }
+
+    /// Capture the current byte accumulator + exhaustion flag. [OPUS-4.8] (sq-my8wd.4)
+    #[cfg(feature = "service")]
+    #[inline]
+    pub(crate) fn byte_savepoint() -> ByteSavepoint {
+        ByteSavepoint {
+            extra_bytes: ACTIVE.with(|c| c.get().extra_bytes),
+            exceeded: EXCEEDED.with(|e| e.get()),
+        }
+    }
+
+    /// Rewind the byte accumulator + exhaustion flag to a [`ByteSavepoint`]. Only the
+    /// bytes charged (and any max-bytes exhaustion tripped) SINCE the savepoint are
+    /// undone; an exhaustion that fired for an independent reason before it is
+    /// preserved. Sound because the interning burst it brackets is synchronous and
+    /// single-threaded — the SERVICE sink is the only writer between the savepoint and
+    /// here — so the pre-burst snapshot is exactly the current state minus this burst.
+    /// A deadline that elapsed during the burst is not masked: the next `exhausted`
+    /// re-derives it from the wall clock. [OPUS-4.8] (sq-my8wd.4)
+    #[cfg(feature = "service")]
+    #[inline]
+    pub(crate) fn restore_bytes(sp: ByteSavepoint) {
+        ACTIVE.with(|c| {
+            let mut a = c.get();
+            a.extra_bytes = sp.extra_bytes;
+            c.set(a);
+        });
+        EXCEEDED.with(|e| e.set(sp.exceeded));
+    }
+
     /// `true` once the budget is exhausted (sticky) — row-producing loops break
     /// on it; `rows` is the loop's current output size.
     #[inline]
@@ -929,6 +972,26 @@ impl LocalVocab {
         self.terms.push(t.clone());
         self.ids.insert(t, id);
         id
+    }
+    /// The append cursor into the local vocab, paired with [`LocalVocab::rollback_to`]
+    /// to discard a speculative interning burst. [OPUS-4.8] (sq-my8wd.4)
+    #[cfg(feature = "service")]
+    fn savepoint(&self) -> usize {
+        self.terms.len()
+    }
+    /// Drop every term interned since `mark`, so the rows a SILENT SERVICE error
+    /// discards leave the local vocab EXACTLY as if they were never interned — no
+    /// retained memory. Pairs with a `budget::ByteSavepoint` (which refunds the bytes
+    /// those terms charged); together they are the resource twin of dropping the
+    /// discarded id rows, keeping SILENT SERVICE behaviour-neutral with the pre-streaming
+    /// path. Interns BEFORE `mark` — and re-interns that returned an existing id, which
+    /// pushed nothing — are untouched. [OPUS-4.8] (sq-my8wd.4)
+    #[cfg(feature = "service")]
+    fn rollback_to(&mut self, mark: usize) {
+        for t in self.terms.drain(mark..) {
+            self.ids.remove(&t);
+        }
+        self.nums.truncate(mark);
     }
     fn term(&self, id: Id) -> &Term {
         &self.terms[(id - LOCAL_BASE) as usize]
@@ -2461,6 +2524,10 @@ fn eval_service(
     // the response body plus the id-level relation the join needs anyway, not a
     // whole-document DOM plus a second term-level copy.
     let mut id_rows: Vec<Row> = Vec::new();
+    // [OPUS-4.8] (sq-my8wd.4) Savepoint the local vocab + byte budget BEFORE streaming so
+    // a SILENT error can roll the partially-interned rows back out — see the SILENT arm.
+    let vocab_mark = local.savepoint();
+    let byte_mark = budget::byte_savepoint();
     let fetched = service_transport::with(|t| {
         crate::service::eval_remote_into(t, &endpoint, &query, &mut |row| {
             id_rows.push(intern_remote_row(graph, local, &row));
@@ -2471,9 +2538,17 @@ fn eval_service(
         Ok(vars) => Ok(Bindings::unsorted(vars, id_rows)),
         Err(e) if silent => {
             // SILENT: swallow the error, keep the surrounding bindings. Rows already
-            // interned from a partially-parsed response are discarded with `id_rows`;
-            // the stray LocalVocab entries are inert (no surviving row references them).
+            // interned from a partially-parsed response are discarded with `id_rows` —
+            // and, so the discard is behaviour-NEUTRAL with the pre-streaming
+            // collect-then-intern-on-success path (which interned nothing on a swallowed
+            // error), we ROLL the interned terms out of the local vocab and REFUND the
+            // byte budget they charged. Without this a partial stream would retain memory
+            // and could trip `max_bytes`, turning a query the old path answered into a
+            // "query budget exceeded" error. [OPUS-4.8] (sq-my8wd.4)
             let _ = e;
+            id_rows.clear();
+            local.rollback_to(vocab_mark);
+            budget::restore_bytes(byte_mark);
             Ok(identity())
         }
         Err(e) => Err(e),
@@ -2633,6 +2708,13 @@ fn bound_join_to_endpoint(
     // collect-then-intern path.
     let mut acc_vars: Option<Vec<Variable>> = None;
     let mut acc_rows: Vec<Row> = Vec::new();
+    // [OPUS-4.8] (sq-my8wd.4) Savepoint the local vocab + byte budget BEFORE the first
+    // block so a SILENT failure in ANY block can roll EVERY block's interns back out —
+    // a SILENT failure discards all blocks' rows together (see the SILENT arm), so the
+    // interns must all be rolled back too, or the discarded stream would retain memory
+    // and charge `max_bytes`.
+    let vocab_mark = local.savepoint();
+    let byte_mark = budget::byte_savepoint();
 
     for chunk in tuples.chunks(block) {
         let values = crate::service::render_values_block(&join_vars, chunk);
@@ -2659,9 +2741,13 @@ fn bound_join_to_endpoint(
             // joining `left` with it leaves `left` exactly as it was. This matches the
             // unbound-then-local-join path's SILENT semantics precisely. [OPUS-4.8]
             // (Rows already interned from earlier blocks — or a partially-parsed
-            // failing block — are discarded with `acc_rows`; the stray LocalVocab
-            // entries are inert. [FABLE-5])
+            // failing block — are ROLLED BACK out of the local vocab below, and their
+            // byte-budget charge refunded, so no stray entry or `max_bytes` charge
+            // survives the discard. [OPUS-4.8] sq-my8wd.4)
             Err(_) if silent => {
+                acc_rows.clear();
+                local.rollback_to(vocab_mark);
+                budget::restore_bytes(byte_mark);
                 return Ok(Some(Bindings::unsorted(Vec::new(), vec![Row::new()])));
             }
             Err(e) => return Err(e),
@@ -10555,6 +10641,26 @@ mod service_exec_tests {
             Ok(self.0.to_string())
         }
     }
+    /// Returns an owned body, so a test can build a valid-rows-then-malformed document
+    /// at runtime to drive the SILENT-error-mid-stream path. [OPUS-4.8] (sq-my8wd.4)
+    struct CannedOwned(String);
+    impl Transport for CannedOwned {
+        fn fetch(&self, _e: &str, _q: &str) -> Result<String, String> {
+            Ok(self.0.clone())
+        }
+    }
+    /// An SRJ document that streams ONE valid binding for `vars` (a long literal on the
+    /// last var, so interning it charges the byte budget) then a MALFORMED second
+    /// binding, so the streaming parser delivers row 0 to the sink and then errors —
+    /// the exact adversarial shape the SILENT-rollback fix must neutralise. [OPUS-4.8]
+    fn valid_then_malformed_srj(head_and_first_row: &str, big_literal: &str) -> String {
+        let mut body = String::from(head_and_first_row);
+        body.push_str(big_literal);
+        // Close the first (valid) binding, comma, then a malformed second binding whose
+        // value is an invalid JSON token (`%`), then close results.
+        body.push_str(r#""}},{"o":{"type":"literal","value":%}}]}}"#);
+        body
+    }
     struct Boom;
     impl Transport for Boom {
         fn fetch(&self, _e: &str, _q: &str) -> Result<String, String> {
@@ -10592,6 +10698,67 @@ mod service_exec_tests {
         );
         let res = eval_select(&g, &p).unwrap();
         assert_eq!(res.rows.len(), 1, "SILENT -> identity -> local row survives");
+    }
+
+    // -------------------------------------------------------------------------
+    // [OPUS-4.8] (sq-my8wd.4) SILENT-error-MID-STREAM behaviour-neutrality (Copilot
+    // review of PR #1424, threads on eval_service + bound_join_to_endpoint).
+    //
+    // The streaming path interns each remote row AS IT PARSES, which charges the
+    // `LocalVocab` byte budget (`intern` -> `budget::add_bytes`). The pre-streaming
+    // collect-then-intern-on-success path interned NOTHING on a swallowed (SILENT)
+    // error, so it charged 0 bytes. Without the rollback these tests pin, a SILENT
+    // SERVICE whose response streams a row then errors would RETAIN that row's intern
+    // and its byte charge — tripping a `max_bytes` budget the SILENT fallback (join
+    // identity) otherwise fits, turning a query the old path ANSWERED into a
+    // "query budget exceeded" error. That is an observable, non-neutral result
+    // difference — hence a fix, not just documentation. The budget is deliberately
+    // tight so the single discarded remote row's charge alone would trip it.
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn service_silent_midstream_rollback_verbatim_neutral_under_byte_budget() {
+        let g = Graph::load_str("@prefix ex: <http://ex/> . ex:a a ex:T .", "turtle").unwrap();
+        let big = "A".repeat(120);
+        let body = valid_then_malformed_srj(
+            r#"{"head":{"vars":["o"]},"results":{"bindings":[{"o":{"type":"literal","value":""#,
+            &big,
+        );
+        let _t = service_transport::install(Box::new(CannedOwned(body)));
+        // Standalone SERVICE (no left bindings to push) -> verbatim `eval_service`.
+        let p = pattern(
+            "PREFIX ex: <http://ex/> SELECT ?o WHERE \
+             { SERVICE SILENT <http://remote/> { ?o ex:p ?x } }",
+        );
+        // A cap the ONE discarded remote literal (interned twice) blows, but the SILENT
+        // fallback's own working set (one identity row) fits well under.
+        let b = crate::QueryBudget { max_bytes: Some(64), ..crate::QueryBudget::unlimited() };
+        let _bg = budget::install(&b);
+        let res = eval_select(&g, &p)
+            .expect("SILENT mid-stream error must roll back the discarded row's byte charge");
+        assert_eq!(res.rows.len(), 1, "SILENT verbatim -> identity -> one (unbound ?o) row");
+    }
+
+    #[test]
+    fn service_silent_midstream_rollback_boundjoin_neutral_under_byte_budget() {
+        let g = Graph::load_str("@prefix ex: <http://ex/> . ex:a a ex:T .", "turtle").unwrap();
+        let big = "A".repeat(120);
+        let body = valid_then_malformed_srj(
+            r#"{"head":{"vars":["s","o"]},"results":{"bindings":[{"s":{"type":"uri","value":"http://ex/a"},"o":{"type":"literal","value":""#,
+            &big,
+        );
+        let _t = service_transport::install(Box::new(CannedOwned(body)));
+        // `?s` is bound by the left BGP and shared with the SERVICE -> bind-join pushdown,
+        // so this exercises the `bound_join_to_endpoint` SILENT arm.
+        let p = pattern(
+            "PREFIX ex: <http://ex/> SELECT ?s ?o WHERE \
+             { ?s a ex:T . SERVICE SILENT <http://remote/> { ?s ex:p ?o } }",
+        );
+        let b = crate::QueryBudget { max_bytes: Some(64), ..crate::QueryBudget::unlimited() };
+        let _bg = budget::install(&b);
+        let res = eval_select(&g, &p)
+            .expect("bind-join SILENT mid-stream error must roll back the discarded row's byte charge");
+        assert_eq!(res.rows.len(), 1, "SILENT block failure -> identity -> local ?s=ex:a row survives");
     }
 
     #[test]

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -2453,46 +2453,48 @@ fn eval_service(
     // inside the SERVICE block are all forwarded verbatim.
     let query = format!("SELECT * WHERE {{ {inner} }}");
 
-    let fetched = service_transport::with(|t| crate::service::eval_remote(t, &endpoint, &query));
-    let rel = match fetched {
-        Ok(rel) => rel,
+    // [FABLE-5] (sq-my8wd.4) STREAMING consumption: each remote row is interned to a
+    // compact id-level `Row` AS IT IS PARSED (the owned terms are dropped immediately)
+    // instead of collecting the whole remote relation as `Term`s first. Result-identical
+    // to the collect-then-intern path — same rows, multiplicity and order (pinned by the
+    // service.rs `streaming_equivalence` tests) — but the per-response peak memory is
+    // the response body plus the id-level relation the join needs anyway, not a
+    // whole-document DOM plus a second term-level copy.
+    let mut id_rows: Vec<Row> = Vec::new();
+    let fetched = service_transport::with(|t| {
+        crate::service::eval_remote_into(t, &endpoint, &query, &mut |row| {
+            id_rows.push(intern_remote_row(graph, local, &row));
+            Ok(())
+        })
+    });
+    match fetched {
+        Ok(vars) => Ok(Bindings::unsorted(vars, id_rows)),
         Err(e) if silent => {
-            // SILENT: swallow the error, keep the surrounding bindings.
+            // SILENT: swallow the error, keep the surrounding bindings. Rows already
+            // interned from a partially-parsed response are discarded with `id_rows`;
+            // the stray LocalVocab entries are inert (no surviving row references them).
             let _ = e;
-            return Ok(identity());
+            Ok(identity())
         }
-        Err(e) => return Err(e),
-    };
-
-    Ok(service_relation_to_bindings(graph, local, rel))
+        Err(e) => Err(e),
+    }
 }
 
-/// Intern a remote [`ServiceRelation`](crate::service::ServiceRelation) into id-level
-/// [`Bindings`] against this query's dictionaries — exactly as `VALUES` does — so it
-/// joins with local BGP results. Shared by the verbatim and bound-join paths.
-/// [OPUS-4.8] (sq-sjkj)
+/// Intern ONE remote solution row into an id-level [`Row`] against this query's
+/// dictionaries — exactly as `VALUES` does — so it joins with local BGP results: each
+/// term resolves against the graph dictionary first, else the query-local vocab.
+/// Shared by the verbatim and bound-join paths, which feed it row-by-row from the
+/// streaming SERVICE parser rather than materialising the remote relation first.
+/// [FABLE-5] (sq-my8wd.4; formerly the whole-relation `service_relation_to_bindings`,
+/// sq-sjkj)
 #[cfg(feature = "service")]
-fn service_relation_to_bindings(
-    graph: &Graph,
-    local: &mut LocalVocab,
-    rel: crate::service::ServiceRelation,
-) -> Bindings {
-    // Intern each remote term against the graph dictionary (so it joins with local
-    // BGP results) or the local vocab (terms absent from the data can still match
-    // other remote/VALUES rows) — identical to `values_bindings`.
-    let rows: Vec<Row> = rel
-        .rows
-        .iter()
-        .map(|r| {
-            r.iter()
-                .map(|cell| match cell {
-                    None => NO_ID,
-                    Some(t) => graph.id_of(t).unwrap_or_else(|| local.intern(t.clone())),
-                })
-                .collect()
+fn intern_remote_row(graph: &Graph, local: &mut LocalVocab, row: &[Option<Term>]) -> Row {
+    row.iter()
+        .map(|cell| match cell {
+            None => NO_ID,
+            Some(t) => graph.id_of(t).unwrap_or_else(|| local.intern(t.clone())),
         })
-        .collect();
-    Bindings::unsorted(rel.vars, rows)
+        .collect()
 }
 
 /// Attempt a bind-join (`VALUES` pushdown) of a SERVICE sub-query against the
@@ -2623,21 +2625,30 @@ fn bound_join_to_endpoint(
     let inner_sparql = format!("{inner}");
     let block = crate::service::bind_block_size();
 
-    // Accumulate the union of the per-block remote relations. All blocks share the
-    // remote `head.vars`, so we keep the first block's var list and concatenate rows.
+    // Accumulate the union of the per-block remote relations, interning each row to the
+    // id level AS IT ARRIVES from the streaming parser ([FABLE-5] sq-my8wd.4) — no
+    // block's relation is ever held as owned `Term` rows. All blocks share the remote
+    // `head.vars`, so we keep the first block's var list and concatenate rows
+    // positionally: the same accumulation, and the same row order, as the previous
+    // collect-then-intern path.
     let mut acc_vars: Option<Vec<Variable>> = None;
-    let mut acc_rows: Vec<Vec<Option<oxrdf::Term>>> = Vec::new();
+    let mut acc_rows: Vec<Row> = Vec::new();
 
     for chunk in tuples.chunks(block) {
         let values = crate::service::render_values_block(&join_vars, chunk);
         // Inject the VALUES inside the SELECT * group, alongside the inner pattern, so
         // the remote inner-joins the pushed bindings with its pattern.
         let query = format!("SELECT * WHERE {{ {values} {inner_sparql} }}");
-        match service_transport::with(|t| crate::service::eval_remote(t, endpoint, &query)) {
-            Ok(rel) => {
-                acc_rows.extend(rel.rows);
+        let fetched = service_transport::with(|t| {
+            crate::service::eval_remote_into(t, endpoint, &query, &mut |row| {
+                acc_rows.push(intern_remote_row(graph, local, &row));
+                Ok(())
+            })
+        });
+        match fetched {
+            Ok(vars) => {
                 if acc_vars.is_none() {
-                    acc_vars = Some(rel.vars);
+                    acc_vars = Some(vars);
                 }
             }
             // SILENT: a failed block means the SERVICE as a whole must behave EXACTLY
@@ -2647,6 +2658,9 @@ fn bound_join_to_endpoint(
             // caller the identity relation (one zero-column row); joining / left-outer
             // joining `left` with it leaves `left` exactly as it was. This matches the
             // unbound-then-local-join path's SILENT semantics precisely. [OPUS-4.8]
+            // (Rows already interned from earlier blocks — or a partially-parsed
+            // failing block — are discarded with `acc_rows`; the stray LocalVocab
+            // entries are inert. [FABLE-5])
             Err(_) if silent => {
                 return Ok(Some(Bindings::unsorted(Vec::new(), vec![Row::new()])));
             }
@@ -2660,8 +2674,7 @@ fn bound_join_to_endpoint(
     // relation has zero rows, so the var list only names columns that, being the join
     // keys, always exist on both sides). [OPUS-4.8]
     let vars = acc_vars.unwrap_or_else(|| join_vars.clone());
-    let rel = crate::service::ServiceRelation { vars, rows: acc_rows };
-    Ok(Some(service_relation_to_bindings(graph, local, rel)))
+    Ok(Some(Bindings::unsorted(vars, acc_rows)))
 }
 
 /// Evaluate `SERVICE ?ep { inner }` — a VARIABLE endpoint — against the `left`

--- a/crates/sparq-engine/src/service.rs
+++ b/crates/sparq-engine/src/service.rs
@@ -21,17 +21,44 @@
 //!    a blank node, …). The block size is the one OPT-IN tuning knob
 //!    ([`with_service_bound_join_block_size`] / `SPARQ_SERVICE_BIND_BLOCK`,
 //!    default [`DEFAULT_BIND_BLOCK`]). The remote relation that is NOT bound-joined is
-//!    still materialised and joined locally by the caller.
+//!    still fetched in full and consumed row-by-row into the caller's id-level join
+//!    input (see *Bounded result consumption* below).
 //! 2. The query is sent over HTTP (form-encoded POST, `Accept:
 //!    application/sparql-results+json, application/sparql-results+xml;q=0.9` — JSON is
 //!    preferred but XML is accepted as a fallback).
-//! 3. The response is parsed into a [`ServiceRelation`] (variable list + rows of optional
-//!    [`Term`]s). The body is content-sniffed (`parse_results`): a leading `{` is parsed
-//!    as SPARQL-Results-JSON ([`parse_srj`]); a leading `<` as SPARQL-Results-XML
-//!    ([`parse_srx`]). The XML path matters because some endpoints ignore `Accept` and
-//!    always return XML — without it the whole SERVICE call would fail (bead sq-ycu).
-//! 4. The caller (`exec::eval_service`) interns those terms into the local/graph
-//!    dictionaries — exactly like `VALUES` — and joins them with the rest of the query.
+//! 3. The response is parsed INCREMENTALLY ([`parse_results_into`], bead sq-my8wd.4):
+//!    each solution row (`Vec<Option<Term>>`, `None` = unbound) is handed to the
+//!    caller's row sink AS IT IS PARSED — the parser never materialises the whole
+//!    remote relation, and a sink error aborts the parse. The body is content-sniffed:
+//!    a leading `{` is parsed as SPARQL-Results-JSON ([`parse_srj_into`]); a leading
+//!    `<` as SPARQL-Results-XML ([`parse_srx_into`]). The XML path matters because
+//!    some endpoints ignore `Accept` and always return XML — without it the whole
+//!    SERVICE call would fail (bead sq-ycu).
+//! 4. The caller (`exec::eval_service`) interns each row into the local/graph
+//!    dictionaries as it arrives — exactly like `VALUES` — dropping the owned terms
+//!    immediately, and joins the compact id-level relation with the rest of the query.
+//!
+//! ## Bounded result consumption (bead sq-my8wd.4)
+//!
+//! A large (or adversarial) remote result must not exhaust engine memory. The bounds:
+//!
+//! * the raw response BODY is capped at a finite limit (`SERVICE_MAX_BODY_BYTES`, the
+//!   native transport's read limit) — a runaway endpoint cannot stream unbounded bytes;
+//! * parsing is per-row streaming for BOTH result formats: the SRJ parser walks the
+//!   `results.bindings` array one binding object at a time (never building a whole-
+//!   document JSON DOM), and the SRX parser was already event-driven — so the parser's
+//!   own working state is one solution, not the relation;
+//! * the consumer interns rows to id-level `Bindings` on arrival, so the only
+//!   result-sized state is the compact id relation the join itself requires.
+//!
+//! Result-equivalence with the previous collect-everything path (identical rows,
+//! multiplicity AND order, and identical errors on malformed documents) is pinned by
+//! the `streaming_equivalence` tests against a frozen DOM reference implementation.
+//! Honest boundary: an SRJ document whose `results` precedes its `head` (legal JSON,
+//! unseen in practice) degrades to buffering the raw binding objects until `head`
+//! arrives — still bounded by the body cap; and on documents with DUPLICATE top-level
+//! keys (malformed per RFC 8259 §4) the error/row precedence may reflect document
+//! order rather than the old DOM's fixed check order.
 //!
 //! ## `SERVICE SILENT`
 //!
@@ -70,13 +97,28 @@
 
 use oxrdf::{BlankNode, Literal, NamedNode, NamedOrBlankNode, Term, Triple, Variable};
 
-/// A materialised remote SELECT result: the projected variables and one row per
+/// A fully-collected remote SELECT result: the projected variables and one row per
 /// solution (`None` = the variable is unbound in that solution).
-#[derive(Debug)]
+///
+/// PRODUCTION consumption is streaming ([`eval_remote_into`] hands rows to a sink as
+/// they are parsed, bead sq-my8wd.4); this collected form backs the convenience
+/// wrappers ([`eval_remote`], [`parse_results`], [`parse_srj`], [`parse_srx`]) and the
+/// tests. `PartialEq` supports the streaming-vs-reference equivalence tests. [FABLE-5]
+#[derive(Debug, PartialEq)]
 pub(crate) struct ServiceRelation {
     pub vars: Vec<Variable>,
     pub rows: Vec<Vec<Option<Term>>>,
 }
+
+/// Shorthand for the streaming row-sink contract (bead sq-my8wd.4): called once per
+/// parsed solution row, positionally projected over the result's variables (`None` =
+/// unbound). Returning `Err` ABORTS the parse and the error string is propagated to
+/// the caller VERBATIM (so a sink can enforce its own resource policy). [FABLE-5]
+///
+/// A closure bound rather than a trait object: every call site is monomorphised, so
+/// the per-row delivery adds no dynamic dispatch (the #1303 perf-neutrality stance).
+pub(crate) trait RowSink: FnMut(Vec<Option<Term>>) -> Result<(), String> {}
+impl<F: FnMut(Vec<Option<Term>>) -> Result<(), String>> RowSink for F {}
 
 /// Abstracts the HTTP round-trip so tests can inject a fake endpoint. `query` is the
 /// SPARQL query string; the return is the raw response body (expected to be
@@ -85,19 +127,42 @@ pub(crate) trait Transport {
     fn fetch(&self, endpoint: &str, query: &str) -> Result<String, String>;
 }
 
-/// Evaluate one SERVICE call end-to-end: send `query` to `endpoint` via `transport`
-/// and parse the response into a [`ServiceRelation`]. SILENT handling is the caller's
-/// responsibility (it owns the join-identity fallback).
+/// Evaluate one SERVICE call end-to-end, STREAMING the parsed rows into `on_row` as
+/// they are decoded (bead sq-my8wd.4): send `query` to `endpoint` via `transport`,
+/// content-sniff + parse the response incrementally, and return the projected
+/// variable list. SILENT handling is the caller's responsibility (it owns the
+/// join-identity fallback, and must discard whatever the sink accumulated when this
+/// returns `Err`). [FABLE-5]
+pub(crate) fn eval_remote_into<F: RowSink>(
+    transport: &dyn Transport,
+    endpoint: &str,
+    query: &str,
+    on_row: &mut F,
+) -> Result<Vec<Variable>, String> {
+    let body = transport.fetch(endpoint, query)?;
+    parse_results_into(&body, on_row)
+}
+
+/// Collecting wrapper over [`eval_remote_into`]: evaluate one SERVICE call end-to-end
+/// into a fully-collected [`ServiceRelation`]. Kept for tests and small-result
+/// callers; production SERVICE evaluation streams via [`eval_remote_into`].
+#[cfg_attr(not(test), allow(dead_code))]
 pub(crate) fn eval_remote(
     transport: &dyn Transport,
     endpoint: &str,
     query: &str,
 ) -> Result<ServiceRelation, String> {
-    let body = transport.fetch(endpoint, query)?;
-    parse_results(&body)
+    let mut rows: Vec<Vec<Option<Term>>> = Vec::new();
+    let vars = eval_remote_into(transport, endpoint, query, &mut |row| {
+        rows.push(row);
+        Ok(())
+    })?;
+    Ok(ServiceRelation { vars, rows })
 }
 
-/// Parse a remote SELECT results document, content-sniffing JSON vs XML. [OPUS-4.8]
+/// Parse a remote SELECT results document incrementally, content-sniffing JSON vs
+/// XML, delivering each row to `on_row` and returning the projected variables.
+/// [OPUS-4.8] / streaming form [FABLE-5] (sq-my8wd.4)
 ///
 /// The SPARQL Protocol lets a client advertise an `Accept` preference, but a server MAY
 /// ignore it; in practice some endpoints always emit SPARQL-Results-XML even when we ask
@@ -106,10 +171,13 @@ pub(crate) fn eval_remote(
 /// SPARQL-Results-JSON, `<` ⇒ SPARQL-Results-XML. Anything else is an error (or, under
 /// `SILENT`, the caller's empty result).
 #[cfg(feature = "service")]
-pub(crate) fn parse_results(text: &str) -> Result<ServiceRelation, String> {
+pub(crate) fn parse_results_into<F: RowSink>(
+    text: &str,
+    on_row: &mut F,
+) -> Result<Vec<Variable>, String> {
     match text.trim_start().as_bytes().first() {
-        Some(b'<') => parse_srx(text),
-        Some(b'{') => parse_srj(text),
+        Some(b'<') => parse_srx_into(text, on_row),
+        Some(b'{') => parse_srj_into(text, on_row),
         // An empty body or a leading byte that is neither `{` nor `<` is not a results
         // document we can parse; report it (SILENT turns this into an empty result).
         _ => Err(
@@ -118,6 +186,18 @@ pub(crate) fn parse_results(text: &str) -> Result<ServiceRelation, String> {
                 .into(),
         ),
     }
+}
+
+/// Collecting wrapper over [`parse_results_into`] (tests / small-result callers).
+#[cfg(feature = "service")]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn parse_results(text: &str) -> Result<ServiceRelation, String> {
+    let mut rows: Vec<Vec<Option<Term>>> = Vec::new();
+    let vars = parse_results_into(text, &mut |row| {
+        rows.push(row);
+        Ok(())
+    })?;
+    Ok(ServiceRelation { vars, rows })
 }
 
 // ---------------------------------------------------------------------------
@@ -404,49 +484,328 @@ pub(crate) fn pushable_term(t: &Term) -> bool {
 // (https://www.w3.org/TR/sparql11-results-json/)
 // ---------------------------------------------------------------------------
 
-/// Parse a SELECT result document. ASK results (`{"boolean": …}`) are reported as an
-/// error here — `SERVICE { … }` always wraps a SELECT in our forwarding, so a boolean
-/// body indicates a misbehaving endpoint.
+/// Parse a SELECT result document INCREMENTALLY (bead sq-my8wd.4): the
+/// `results.bindings` array is walked one binding object at a time through a custom
+/// serde seed (never building a whole-document JSON DOM), each row is projected
+/// positionally over `head.vars` and handed to `on_row` immediately, and the
+/// projected variables are returned. ASK results (`{"boolean": …}`) are reported as
+/// an error — `SERVICE { … }` always wraps a SELECT in our forwarding, so a boolean
+/// body indicates a misbehaving endpoint. [FABLE-5]
+///
+/// Result-equivalent to the previous whole-DOM parse (same rows, order, multiplicity
+/// and errors — pinned by the `streaming_equivalence` tests), with two documented
+/// pathological-input caveats (see the module doc): a `results`-before-`head`
+/// document buffers raw binding objects until `head` arrives, and duplicate top-level
+/// keys (malformed JSON) resolve in document order rather than DOM check order.
 #[cfg(feature = "service")]
-pub(crate) fn parse_srj(text: &str) -> Result<ServiceRelation, String> {
-    let v: serde_json::Value =
-        serde_json::from_str(text).map_err(|e| format!("SERVICE: invalid results JSON: {e}"))?;
-    if v.get("boolean").is_some() {
-        return Err("SERVICE: endpoint returned an ASK boolean, expected SELECT bindings".into());
-    }
-    let vars: Vec<Variable> = v
-        .pointer("/head/vars")
-        .and_then(|a| a.as_array())
-        .map(|a| {
-            a.iter()
-                .filter_map(|s| s.as_str())
-                .map(|s| Variable::new(s).map_err(|e| format!("SERVICE: bad result variable {s:?}: {e}")))
-                .collect::<Result<Vec<_>, _>>()
-        })
-        .transpose()?
-        .ok_or_else(|| "SERVICE: results JSON missing head.vars".to_string())?;
+pub(crate) fn parse_srj_into<F: RowSink>(
+    text: &str,
+    on_row: &mut F,
+) -> Result<Vec<Variable>, String> {
+    use serde::de::DeserializeSeed;
 
+    let mut st = srj_stream::State::new(on_row);
+    let mut de = serde_json::Deserializer::from_str(text);
+    if let Err(e) = srj_stream::TopSeed(&mut st).deserialize(&mut de) {
+        // A semantic error (bad term / bad variable / sink refusal) was smuggled out
+        // through the side channel VERBATIM; anything else is a JSON syntax error and
+        // gets the same wrapping the DOM path used.
+        return Err(st
+            .take_fail()
+            .unwrap_or_else(|| format!("SERVICE: invalid results JSON: {}", e)));
+    }
+    de.end()
+        .map_err(|e| format!("SERVICE: invalid results JSON: {}", e))?;
+    // Post-parse checks in the SAME precedence order as the old DOM path: ASK boolean
+    // first, then a missing/invalid `head.vars`, then a missing `results.bindings`.
+    st.finish()
+}
+
+/// Collecting wrapper over [`parse_srj_into`] (tests / small-result callers).
+#[cfg(feature = "service")]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn parse_srj(text: &str) -> Result<ServiceRelation, String> {
     let mut rows: Vec<Vec<Option<Term>>> = Vec::new();
-    for sol in v
-        .pointer("/results/bindings")
-        .and_then(|a| a.as_array())
-        .ok_or_else(|| "SERVICE: results JSON missing results.bindings".to_string())?
-    {
-        let obj = sol
-            .as_object()
-            .ok_or_else(|| "SERVICE: a solution binding is not a JSON object".to_string())?;
-        // Build a row positionally over `vars`; a variable absent from the solution
-        // object is UNBOUND (`None`) — identical to the VALUES UNDEF semantics.
-        let mut row: Vec<Option<Term>> = Vec::with_capacity(vars.len());
-        for var in &vars {
-            match obj.get(var.as_str()) {
-                Some(cell) => row.push(Some(srj_term(cell)?)),
-                None => row.push(None),
+    let vars = parse_srj_into(text, &mut |row| {
+        rows.push(row);
+        Ok(())
+    })?;
+    Ok(ServiceRelation { vars, rows })
+}
+
+/// Streaming serde seeds for SPARQL-Results-JSON (bead sq-my8wd.4). [FABLE-5]
+///
+/// The document shape is `{"head": {"vars": […]}, "results": {"bindings": […]}}`.
+/// Only the `bindings` ARRAY is result-sized, so that is the one place a streaming
+/// seed walks elements one at a time; `head` (and each individual binding object) is
+/// small and is still read through a `serde_json::Value` so the term reconstruction
+/// (`srj_term`) and the `head.vars` extraction are byte-identical to the old DOM
+/// path. Every other value shape is accepted-and-ignored exactly where the DOM path
+/// tolerated it, so the "missing head.vars" / "missing results.bindings" errors fire
+/// under the same conditions.
+#[cfg(feature = "service")]
+mod srj_stream {
+    use super::{srj_term, RowSink};
+    use oxrdf::{Term, Variable};
+    use serde::de::{DeserializeSeed, Deserializer, IgnoredAny, MapAccess, SeqAccess, Visitor};
+    use serde_json::Value;
+    use std::fmt;
+
+    /// Shared parse state threaded through the seeds.
+    pub(super) struct State<'f, F> {
+        on_row: &'f mut F,
+        /// `head.vars`, once seen (rows are projected positionally over these).
+        vars: Option<Vec<Variable>>,
+        /// Raw binding objects seen BEFORE `head` (the reversed-order fallback);
+        /// flushed the moment `head.vars` arrives. Bounded by the response-body cap.
+        pending: Vec<Value>,
+        /// Whether a `results.bindings` ARRAY was seen (empty is fine).
+        bindings_seen: bool,
+        /// Whether a top-level `boolean` key was seen (an ASK body — rejected).
+        boolean_seen: bool,
+        /// Side channel for semantic errors: serde's `Error::custom` would append
+        /// position info, so the exact message is smuggled out here instead.
+        fail: Option<String>,
+    }
+
+    impl<'f, F: RowSink> State<'f, F> {
+        pub(super) fn new(on_row: &'f mut F) -> Self {
+            State {
+                on_row,
+                vars: None,
+                pending: Vec::new(),
+                bindings_seen: false,
+                boolean_seen: false,
+                fail: None,
             }
         }
-        rows.push(row);
+
+        pub(super) fn take_fail(&mut self) -> Option<String> {
+            self.fail.take()
+        }
+
+        /// The post-parse checks, in the old DOM path's precedence order.
+        pub(super) fn finish(self) -> Result<Vec<Variable>, String> {
+            if self.boolean_seen {
+                return Err(
+                    "SERVICE: endpoint returned an ASK boolean, expected SELECT bindings".into(),
+                );
+            }
+            let vars = self
+                .vars
+                .ok_or_else(|| "SERVICE: results JSON missing head.vars".to_string())?;
+            if !self.bindings_seen {
+                return Err("SERVICE: results JSON missing results.bindings".to_string());
+            }
+            Ok(vars)
+        }
+
+        /// Record `msg` in the side channel and produce the serde error that aborts
+        /// the deserialisation (the caller surfaces the side channel verbatim).
+        fn bail<E: serde::de::Error>(&mut self, msg: String) -> E {
+            let e = E::custom(&msg);
+            self.fail = Some(msg);
+            e
+        }
+
+        /// Project one binding object over `vars` and hand the row to the sink.
+        /// Identical cell handling to the old DOM path (absent variable ⇒ `None`).
+        fn emit(&mut self, sol: &Value) -> Result<(), String> {
+            let row = {
+                let vars = self.vars.as_ref().expect("emit is only called once vars are known");
+                let obj = sol.as_object().ok_or_else(|| {
+                    "SERVICE: a solution binding is not a JSON object".to_string()
+                })?;
+                let mut row: Vec<Option<Term>> = Vec::with_capacity(vars.len());
+                for var in vars {
+                    match obj.get(var.as_str()) {
+                        Some(cell) => row.push(Some(srj_term(cell)?)),
+                        None => row.push(None),
+                    }
+                }
+                row
+            };
+            (self.on_row)(row)
+        }
     }
-    Ok(ServiceRelation { vars, rows })
+
+    /// Implements the non-target `Visitor` shapes as accept-and-ignore, so a seed
+    /// tolerates any JSON type exactly where the DOM path did (leaving the relevant
+    /// `*_seen` flag unset ⇒ the same "missing …" error at the end).
+    macro_rules! ignore_scalars {
+        () => {
+            fn visit_bool<E: serde::de::Error>(self, _v: bool) -> Result<(), E> {
+                Ok(())
+            }
+            fn visit_i64<E: serde::de::Error>(self, _v: i64) -> Result<(), E> {
+                Ok(())
+            }
+            fn visit_u64<E: serde::de::Error>(self, _v: u64) -> Result<(), E> {
+                Ok(())
+            }
+            fn visit_f64<E: serde::de::Error>(self, _v: f64) -> Result<(), E> {
+                Ok(())
+            }
+            fn visit_str<E: serde::de::Error>(self, _v: &str) -> Result<(), E> {
+                Ok(())
+            }
+            fn visit_unit<E: serde::de::Error>(self) -> Result<(), E> {
+                Ok(())
+            }
+        };
+    }
+
+    /// Drain-and-ignore a sequence / map (the value is structurally skipped).
+    fn drain_seq<'de, A: SeqAccess<'de>>(mut seq: A) -> Result<(), A::Error> {
+        while seq.next_element::<IgnoredAny>()?.is_some() {}
+        Ok(())
+    }
+    fn drain_map<'de, A: MapAccess<'de>>(mut map: A) -> Result<(), A::Error> {
+        while map.next_entry::<IgnoredAny, IgnoredAny>()?.is_some() {}
+        Ok(())
+    }
+
+    /// Top-level document seed: `{"head": …, "results": …, "boolean": …, …}`.
+    pub(super) struct TopSeed<'a, 'f, F>(pub &'a mut State<'f, F>);
+
+    impl<'de, F: RowSink> DeserializeSeed<'de> for TopSeed<'_, '_, F> {
+        type Value = ();
+        fn deserialize<D: Deserializer<'de>>(self, d: D) -> Result<(), D::Error> {
+            d.deserialize_any(self)
+        }
+    }
+
+    impl<'de, F: RowSink> Visitor<'de> for TopSeed<'_, '_, F> {
+        type Value = ();
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a SPARQL results document")
+        }
+        // A non-object top level parses, binds nothing, and yields the DOM path's
+        // "missing head.vars" from the post-checks.
+        ignore_scalars!();
+        fn visit_seq<A: SeqAccess<'de>>(self, seq: A) -> Result<(), A::Error> {
+            drain_seq(seq)
+        }
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
+            while let Some(key) = map.next_key::<String>()? {
+                match key.as_str() {
+                    "head" => {
+                        // `head` is small; a Value keeps the vars extraction
+                        // byte-identical to the DOM path (non-string entries are
+                        // SKIPPED, a bad variable NAME is an error).
+                        let hv: Value = map.next_value()?;
+                        let extracted = hv
+                            .get("vars")
+                            .and_then(|a| a.as_array())
+                            .map(|a| {
+                                a.iter()
+                                    .filter_map(|s| s.as_str())
+                                    .map(|s| {
+                                        Variable::new(s).map_err(|e| {
+                                            format!(
+                                                "SERVICE: bad result variable {:?}: {}",
+                                                s, e
+                                            )
+                                        })
+                                    })
+                                    .collect::<Result<Vec<_>, _>>()
+                            })
+                            .transpose()
+                            .map_err(|m| self.0.bail(m))?;
+                        if let Some(vars) = extracted {
+                            self.0.vars = Some(vars);
+                            // Flush any rows that arrived before `head` (reversed-order
+                            // documents), in their original order.
+                            for sol in std::mem::take(&mut self.0.pending) {
+                                self.0.emit(&sol).map_err(|m| self.0.bail(m))?;
+                            }
+                        }
+                    }
+                    "results" => map.next_value_seed(ResultsSeed(&mut *self.0))?,
+                    "boolean" => {
+                        self.0.boolean_seen = true;
+                        let _: IgnoredAny = map.next_value()?;
+                    }
+                    // Unknown members (e.g. `link`) are ignored, as in the DOM path.
+                    _ => {
+                        let _: IgnoredAny = map.next_value()?;
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// Seed for the `results` member: only its `bindings` key matters.
+    struct ResultsSeed<'a, 'f, F>(&'a mut State<'f, F>);
+
+    impl<'de, F: RowSink> DeserializeSeed<'de> for ResultsSeed<'_, '_, F> {
+        type Value = ();
+        fn deserialize<D: Deserializer<'de>>(self, d: D) -> Result<(), D::Error> {
+            d.deserialize_any(self)
+        }
+    }
+
+    impl<'de, F: RowSink> Visitor<'de> for ResultsSeed<'_, '_, F> {
+        type Value = ();
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a SPARQL results member")
+        }
+        // A non-object `results` leaves `bindings_seen` unset ⇒ the DOM path's
+        // "missing results.bindings".
+        ignore_scalars!();
+        fn visit_seq<A: SeqAccess<'de>>(self, seq: A) -> Result<(), A::Error> {
+            drain_seq(seq)
+        }
+        fn visit_map<A: MapAccess<'de>>(self, mut map: A) -> Result<(), A::Error> {
+            while let Some(key) = map.next_key::<String>()? {
+                if key.as_str() == "bindings" {
+                    map.next_value_seed(BindingsSeed(&mut *self.0))?;
+                } else {
+                    let _: IgnoredAny = map.next_value()?;
+                }
+            }
+            Ok(())
+        }
+    }
+
+    /// Seed for the `bindings` array — THE streaming site: one binding object is
+    /// deserialised (as a small `Value`), projected and delivered at a time, so the
+    /// parser's working state is a single solution, never the relation.
+    struct BindingsSeed<'a, 'f, F>(&'a mut State<'f, F>);
+
+    impl<'de, F: RowSink> DeserializeSeed<'de> for BindingsSeed<'_, '_, F> {
+        type Value = ();
+        fn deserialize<D: Deserializer<'de>>(self, d: D) -> Result<(), D::Error> {
+            d.deserialize_any(self)
+        }
+    }
+
+    impl<'de, F: RowSink> Visitor<'de> for BindingsSeed<'_, '_, F> {
+        type Value = ();
+        fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            f.write_str("a SPARQL bindings array")
+        }
+        // A non-array `bindings` leaves `bindings_seen` unset ⇒ "missing
+        // results.bindings", matching the DOM path's `as_array` guard.
+        ignore_scalars!();
+        fn visit_map<A: MapAccess<'de>>(self, map: A) -> Result<(), A::Error> {
+            drain_map(map)
+        }
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<(), A::Error> {
+            self.0.bindings_seen = true;
+            while let Some(sol) = seq.next_element::<Value>()? {
+                if self.0.vars.is_some() {
+                    self.0.emit(&sol).map_err(|m| self.0.bail(m))?;
+                } else {
+                    // `head` has not arrived yet (reversed-order document): buffer the
+                    // raw binding for the flush at `head` — bounded by the body cap.
+                    self.0.pending.push(sol);
+                }
+            }
+            Ok(())
+        }
+    }
 }
 
 /// Reconstruct one term from an SRJ binding value object. Mirrors the conformance
@@ -615,10 +974,17 @@ fn srx_term(
     }
 }
 
-/// Parse a SPARQL-Results-XML SELECT document into a [`ServiceRelation`]. ASK `<boolean>`
-/// bodies are rejected (SERVICE always wraps a SELECT in our forwarding).
+/// Parse a SPARQL-Results-XML SELECT document incrementally, delivering each row to
+/// `on_row` at its closing `</result>` and returning the declared variables. ASK
+/// `<boolean>` bodies are rejected (SERVICE always wraps a SELECT in our forwarding).
+/// The quick-xml event loop was already streaming; the only sq-my8wd.4 change is that
+/// a finished row goes to the sink instead of a collected `Vec` — same projection,
+/// same order, same errors. [FABLE-5]
 #[cfg(feature = "service")]
-pub(crate) fn parse_srx(text: &str) -> Result<ServiceRelation, String> {
+pub(crate) fn parse_srx_into<F: RowSink>(
+    text: &str,
+    on_row: &mut F,
+) -> Result<Vec<Variable>, String> {
     use quick_xml::events::Event;
     use quick_xml::Reader;
 
@@ -628,7 +994,6 @@ pub(crate) fn parse_srx(text: &str) -> Result<ServiceRelation, String> {
     let mut vars: Vec<Variable> = Vec::new();
     // Per-row map of variable-name → term; projected positionally over `vars` at </result>.
     let mut cur_row: rustc_hash::FxHashMap<String, Term> = rustc_hash::FxHashMap::default();
-    let mut rows: Vec<Vec<Option<Term>>> = Vec::new();
     let mut cur_var: Option<String> = None;
     // The open value element: (kind, xml:lang, its:dir, datatype, text).
     #[allow(clippy::type_complexity)]
@@ -801,11 +1166,13 @@ pub(crate) fn parse_srx(text: &str) -> Result<ServiceRelation, String> {
                     b"result" => {
                         // Project the row positionally over the declared variables; an
                         // absent binding is UNBOUND (`None`) — the same VALUES-UNDEF
-                        // semantics the SRJ path uses.
+                        // semantics the SRJ path uses. Delivered to the sink NOW
+                        // (streaming, sq-my8wd.4): a sink error aborts the parse and
+                        // propagates verbatim.
                         let row: Vec<Option<Term>> =
                             vars.iter().map(|v| cur_row.remove(v.as_str())).collect();
                         cur_row.clear();
-                        rows.push(row);
+                        on_row(row)?;
                     }
                     b"boolean" => in_boolean = false,
                     _ => {}
@@ -820,6 +1187,18 @@ pub(crate) fn parse_srx(text: &str) -> Result<ServiceRelation, String> {
             "SERVICE: endpoint returned an ASK boolean, expected SELECT bindings".into(),
         );
     }
+    Ok(vars)
+}
+
+/// Collecting wrapper over [`parse_srx_into`] (tests / small-result callers).
+#[cfg(feature = "service")]
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) fn parse_srx(text: &str) -> Result<ServiceRelation, String> {
+    let mut rows: Vec<Vec<Option<Term>>> = Vec::new();
+    let vars = parse_srx_into(text, &mut |row| {
+        rows.push(row);
+        Ok(())
+    })?;
     Ok(ServiceRelation { vars, rows })
 }
 
@@ -2288,6 +2667,311 @@ mod tests {
                 assert_eq!(addrs.len(), 1);
                 assert_eq!(addrs[0].port(), port);
             }
+        }
+    }
+
+    // ---------------------------------------------------------------------
+    // Streaming / bounded result consumption [FABLE-5] (bead sq-my8wd.4)
+    // ---------------------------------------------------------------------
+
+    mod streaming_equivalence {
+        use super::*;
+
+        /// FROZEN pre-sq-my8wd.4 whole-DOM implementation of `parse_srj`, kept
+        /// verbatim as the result-equivalence oracle: the streaming parser must
+        /// produce the SAME relation (rows, multiplicity AND order) and the SAME
+        /// errors. `srj_term` is shared deliberately — it is unchanged by the
+        /// streaming rework; the delta under test is the document walk.
+        fn parse_srj_reference(text: &str) -> Result<ServiceRelation, String> {
+            let v: serde_json::Value = serde_json::from_str(text)
+                .map_err(|e| format!("SERVICE: invalid results JSON: {e}"))?;
+            if v.get("boolean").is_some() {
+                return Err(
+                    "SERVICE: endpoint returned an ASK boolean, expected SELECT bindings".into(),
+                );
+            }
+            let vars: Vec<Variable> = v
+                .pointer("/head/vars")
+                .and_then(|a| a.as_array())
+                .map(|a| {
+                    a.iter()
+                        .filter_map(|s| s.as_str())
+                        .map(|s| {
+                            Variable::new(s)
+                                .map_err(|e| format!("SERVICE: bad result variable {s:?}: {e}"))
+                        })
+                        .collect::<Result<Vec<_>, _>>()
+                })
+                .transpose()?
+                .ok_or_else(|| "SERVICE: results JSON missing head.vars".to_string())?;
+
+            let mut rows: Vec<Vec<Option<Term>>> = Vec::new();
+            for sol in v
+                .pointer("/results/bindings")
+                .and_then(|a| a.as_array())
+                .ok_or_else(|| "SERVICE: results JSON missing results.bindings".to_string())?
+            {
+                let obj = sol.as_object().ok_or_else(|| {
+                    "SERVICE: a solution binding is not a JSON object".to_string()
+                })?;
+                let mut row: Vec<Option<Term>> = Vec::with_capacity(vars.len());
+                for var in &vars {
+                    match obj.get(var.as_str()) {
+                        Some(cell) => row.push(Some(srj_term(cell)?)),
+                        None => row.push(None),
+                    }
+                }
+                rows.push(row);
+            }
+            Ok(ServiceRelation { vars, rows })
+        }
+
+        /// Assert the streaming parser and the frozen DOM reference agree on one
+        /// document — `Ok`: identical vars + rows (order and multiplicity); `Err`:
+        /// identical message.
+        fn assert_equiv(body: &str) {
+            let got = parse_srj(body);
+            let want = parse_srj_reference(body);
+            assert_eq!(got, want, "streaming vs DOM reference diverged on: {}", body);
+        }
+
+        #[test]
+        fn equivalence_on_representative_and_boundary_documents() {
+            for body in [
+                // Boundary: no vars / no rows / a single row.
+                r#"{"head":{"vars":[]},"results":{"bindings":[]}}"#,
+                r#"{"head":{"vars":["x"]},"results":{"bindings":[]}}"#,
+                r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"uri","value":"http://ex/1"}}]}}"#,
+                // Unbound cells + solution keys out of head order.
+                r#"{"head":{"vars":["a","b"]},"results":{"bindings":[
+                    {"b":{"type":"literal","value":"1"}},
+                    {"b":{"type":"bnode","value":"b0"},"a":{"type":"uri","value":"http://ex/a"}}]}}"#,
+                // Every term kind: uri, bnode, plain / lang / dir-lang / typed
+                // literal, legacy typed-literal, SPARQL 1.2 triple term.
+                r#"{"head":{"vars":["u","b","l","g","d","t","o","r"]},"results":{"bindings":[{
+                    "u":{"type":"uri","value":"http://ex/u"},
+                    "b":{"type":"bnode","value":"n1"},
+                    "l":{"type":"literal","value":"plain"},
+                    "g":{"type":"literal","value":"hi","xml:lang":"en"},
+                    "d":{"type":"literal","value":"مرحبا","xml:lang":"ar","its:dir":"rtl"},
+                    "t":{"type":"literal","value":"7","datatype":"http://www.w3.org/2001/XMLSchema#integer"},
+                    "o":{"type":"typed-literal","value":"1.5","datatype":"http://www.w3.org/2001/XMLSchema#decimal"},
+                    "r":{"type":"triple","value":{
+                        "subject":{"type":"uri","value":"http://ex/s"},
+                        "predicate":{"type":"uri","value":"http://ex/p"},
+                        "object":{"type":"literal","value":"o"}}}}]}}"#,
+                // Unknown members are ignored (SRJ `link`, arbitrary extras).
+                r#"{"head":{"vars":["x"],"link":["http://ex/meta"]},"results":{"bindings":[]},"extra":42}"#,
+                // Reversed member order: `results` BEFORE `head` (legal JSON — the
+                // documented buffered fallback must be result-identical).
+                r#"{"results":{"bindings":[{"x":{"type":"uri","value":"http://ex/r"}}]},"head":{"vars":["x"]}}"#,
+                // Leading whitespace before the sniffed `{`.
+                " \n\t {\"head\":{\"vars\":[\"x\"]},\"results\":{\"bindings\":[]}}",
+                // Non-string entries in head.vars are SKIPPED (filter_map parity).
+                r#"{"head":{"vars":["x",5,"y"]},"results":{"bindings":[{"y":{"type":"literal","value":"v"}}]}}"#,
+            ] {
+                assert_equiv(body);
+            }
+        }
+
+        #[test]
+        fn equivalence_on_malformed_documents() {
+            for body in [
+                "not json at all",
+                "{",                                                   // truncated
+                r#"{"head":{}}"#,                                      // missing head.vars
+                r#"{"head":{"vars":5}}"#,                              // vars not an array
+                r#"{"head":{"vars":["x"]}}"#,                          // missing results
+                r#"{"head":{"vars":["x"]},"results":{}}"#,             // results without bindings
+                r#"{"head":{"vars":["x"]},"results":5}"#,              // results not an object
+                r#"{"head":{"vars":["x"]},"results":[1,2]}"#,          // results an array
+                r#"{"head":{"vars":["x"]},"results":{"bindings":5}}"#, // bindings not an array
+                r#"{"head":{"vars":["x"]},"results":{"bindings":{}}}"#, // bindings an object
+                r#"{"head":{"vars":["x"]},"results":{"bindings":[5]}}"#, // binding not an object
+                r#"{"boolean":true}"#,                                 // ASK body
+                // ASK key trailing a full SELECT shape — still rejected.
+                r#"{"head":{"vars":["x"]},"results":{"bindings":[]},"boolean":false}"#,
+                r#"{"head":{"vars":["not a var"]},"results":{"bindings":[]}}"#, // bad var name
+                // Bad IRI / unknown binding type inside a solution.
+                r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"uri","value":"no spaces"}}]}}"#,
+                r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"wat","value":"?"}}]}}"#,
+                // Non-object top levels (all "missing head.vars" in the DOM path).
+                "[]",
+                "5",
+                "\"x\"",
+                "null",
+                "true",
+                // Trailing garbage after a valid document.
+                r#"{"head":{"vars":["x"]},"results":{"bindings":[]}} trailing"#,
+            ] {
+                assert_equiv(body);
+            }
+        }
+
+        #[test]
+        fn equivalence_on_a_large_duplicate_heavy_document() {
+            // 10_000 rows over 7 distinct solutions: multiplicity AND ordering must
+            // survive the streaming rework exactly (row-for-row equality, not just
+            // multiset equality).
+            let mut bindings = Vec::with_capacity(10_000);
+            for i in 0..10_000usize {
+                let k = i % 7;
+                bindings.push(format!(
+                    r#"{{"s":{{"type":"uri","value":"http://ex/dup/{}"}},"n":{{"type":"literal","value":"{}","datatype":"http://www.w3.org/2001/XMLSchema#integer"}}}}"#,
+                    k, k
+                ));
+            }
+            let body = format!(
+                r#"{{"head":{{"vars":["s","n"]}},"results":{{"bindings":[{}]}}}}"#,
+                bindings.join(",")
+            );
+            let got = parse_srj(&body).unwrap();
+            let want = parse_srj_reference(&body).unwrap();
+            assert_eq!(got.rows.len(), 10_000);
+            assert_eq!(got.vars, want.vars);
+            assert_eq!(got.rows, want.rows, "row-for-row identical incl. duplicates");
+        }
+
+        #[test]
+        fn srj_streams_rows_before_later_input_is_parsed() {
+            // Two good rows then a JSON syntax error. A materialise-first parser (the
+            // frozen DOM reference) cannot deliver ANY row from such a document; the
+            // streaming parser must have delivered both BEFORE reaching the error —
+            // the load-bearing "no full-relation buffering" property.
+            let body = r#"{"head":{"vars":["x"]},"results":{"bindings":[
+                {"x":{"type":"uri","value":"http://ex/1"}},
+                {"x":{"type":"uri","value":"http://ex/2"}},
+                {{{"#;
+            let mut seen = 0usize;
+            let err = parse_srj_into(body, &mut |_row| {
+                seen += 1;
+                Ok(())
+            })
+            .unwrap_err();
+            assert!(err.contains("invalid results JSON"), "got: {}", err);
+            assert_eq!(seen, 2, "rows are delivered as parsed, not after the document");
+            // The DOM reference, by contrast, delivers nothing from this document.
+            assert!(parse_srj_reference(body).is_err());
+        }
+
+        #[test]
+        fn srx_streams_rows_before_later_input_is_parsed() {
+            // Two good results, then a stray `</triple>` the parser rejects: both
+            // rows must already have been delivered when the error is reported.
+            let body = r#"<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+              <head><variable name="x"/></head>
+              <results>
+                <result><binding name="x"><uri>http://ex/1</uri></binding></result>
+                <result><binding name="x"><uri>http://ex/2</uri></binding></result>
+                </triple>
+              </results></sparql>"#;
+            let mut seen = 0usize;
+            let err = parse_srx_into(body, &mut |_row| {
+                seen += 1;
+                Ok(())
+            })
+            .unwrap_err();
+            assert!(err.contains("SERVICE:"), "got: {}", err);
+            assert_eq!(seen, 2, "rows are delivered as parsed, not after the document");
+        }
+
+        #[test]
+        fn srj_sink_error_aborts_the_parse_and_propagates_verbatim() {
+            // A 50_000-row document refused by the sink after 3 rows: the consumer's
+            // bound is ENFORCED (the parse stops, no further rows are delivered) and
+            // the sink's own error string surfaces unchanged — the seam an embedder's
+            // resource policy hangs off.
+            let row = r#"{"x":{"type":"uri","value":"http://ex/big"}}"#;
+            let body = format!(
+                r#"{{"head":{{"vars":["x"]}},"results":{{"bindings":[{}]}}}}"#,
+                vec![row; 50_000].join(",")
+            );
+            let mut seen = 0usize;
+            let err = parse_srj_into(&body, &mut |_row| {
+                seen += 1;
+                if seen >= 3 {
+                    Err("row cap exceeded (test sink)".to_string())
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+            assert_eq!(err, "row cap exceeded (test sink)", "sink error is verbatim");
+            assert_eq!(seen, 3, "no rows are delivered after the sink refuses");
+        }
+
+        #[test]
+        fn srx_sink_error_aborts_the_parse_and_propagates_verbatim() {
+            let mut body = String::from(
+                r#"<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+                   <head><variable name="x"/></head><results>"#,
+            );
+            for _ in 0..10_000 {
+                body.push_str(
+                    r#"<result><binding name="x"><uri>http://ex/big</uri></binding></result>"#,
+                );
+            }
+            body.push_str("</results></sparql>");
+            let mut seen = 0usize;
+            let err = parse_srx_into(&body, &mut |_row| {
+                seen += 1;
+                if seen >= 3 {
+                    Err("row cap exceeded (test sink)".to_string())
+                } else {
+                    Ok(())
+                }
+            })
+            .unwrap_err();
+            assert_eq!(err, "row cap exceeded (test sink)", "sink error is verbatim");
+            assert_eq!(seen, 3, "no rows are delivered after the sink refuses");
+        }
+
+        #[test]
+        fn eval_remote_into_streams_rows_from_the_transport() {
+            // Direct coverage for the streaming end-to-end entry point (the
+            // production path exec.rs drives): transport → content sniff → rows.
+            let body = r#"{"head":{"vars":["x"]},"results":{"bindings":[
+                {"x":{"type":"uri","value":"http://ex/1"}},
+                {"x":{"type":"uri","value":"http://ex/2"}}]}}"#;
+            let mut rows: Vec<Vec<Option<Term>>> = Vec::new();
+            let vars = eval_remote_into(
+                &super::Canned(body),
+                "http://unused/",
+                "SELECT * WHERE {}",
+                &mut |r| {
+                    rows.push(r);
+                    Ok(())
+                },
+            )
+            .unwrap();
+            assert_eq!(vars.len(), 1);
+            assert_eq!(rows.len(), 2);
+        }
+
+        #[test]
+        fn parse_results_into_sniffs_both_formats_and_rejects_neither() {
+            let srj = r#"{"head":{"vars":["x"]},"results":{"bindings":[{"x":{"type":"uri","value":"http://ex/j"}}]}}"#;
+            let srx = r#"<sparql xmlns="http://www.w3.org/2005/sparql-results#">
+                <head><variable name="x"/></head>
+                <results><result><binding name="x"><uri>http://ex/x</uri></binding></result></results>
+              </sparql>"#;
+            for body in [srj, srx] {
+                let mut n = 0usize;
+                let vars = parse_results_into(body, &mut |_r| {
+                    n += 1;
+                    Ok(())
+                })
+                .unwrap();
+                assert_eq!(vars.len(), 1);
+                assert_eq!(n, 1);
+            }
+            let mut n = 0usize;
+            assert!(parse_results_into("plain text", &mut |_r| {
+                n += 1;
+                Ok(())
+            })
+            .is_err());
+            assert_eq!(n, 0);
         }
     }
 }

--- a/crates/sparq-engine/tests/service_stream_bounded.rs
+++ b/crates/sparq-engine/tests/service_stream_bounded.rs
@@ -26,6 +26,15 @@
 //!   cargo test -p sparq-engine --features service --test service_stream_bounded
 
 #![cfg(feature = "service")]
+// [OPUS-4.8] sq-my8wd.4 / cert gap GX-5: this is the ONLY first-party `unsafe` in
+// sparq-engine — a byte-counting `#[global_allocator]`, which a custom allocator
+// unavoidably requires (the `GlobalAlloc` trait is `unsafe` by definition and there is
+// no safe substitute for a deterministic thread-local allocation counter). The engine
+// LIBRARY stays `#![forbid(unsafe_code)]`; the allocator is confined to this one
+// integration-test binary and each site carries a `// SAFETY:` argument, mechanically
+// enforced here by `clippy::undocumented_unsafe_blocks` (mirroring the register's
+// 5 unsafe-bearing lib crates) and registered in `compliance/memsafety/unsafe-register.md`.
+#![warn(clippy::undocumented_unsafe_blocks)]
 
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::cell::Cell;
@@ -64,7 +73,17 @@ fn add(d: isize) {
 
 struct Counting;
 
+// SAFETY: every method forwards its call VERBATIM to the process `System` allocator
+// with the identical `Layout`/pointer arguments it received, so all of `GlobalAlloc`'s
+// safety obligations are discharged by `System`'s own (correct) implementation. The
+// wrapper adds nothing unsound: it only reads `layout.size()`/`new_size` (always valid
+// `usize` reads) and updates a thread-local `Cell<isize>` counter; no pointer that
+// `System` returns is ever dereferenced, retained, or aliased here. `System` is
+// zero-sized, so `Counting` is a valid stand-in global allocator. [OPUS-4.8]
 unsafe impl GlobalAlloc for Counting {
+    // SAFETY: forwards to `System.alloc(layout)` unchanged — the caller's `layout`
+    // validity contract (non-zero size, valid align) is passed straight through, and
+    // only the returned pointer's nullness is inspected before recording the size.
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let p = System.alloc(layout);
         if !p.is_null() {
@@ -72,10 +91,18 @@ unsafe impl GlobalAlloc for Counting {
         }
         p
     }
+    // SAFETY: forwards `ptr`/`layout` unchanged to `System.dealloc`. The caller
+    // guarantees `ptr` was returned by a previous `alloc`/`realloc` of THIS allocator
+    // with this same `layout`; that holds because those methods above also forward to
+    // `System`, so the pointer is always a genuine `System` allocation.
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         System.dealloc(ptr, layout);
         add(-(layout.size() as isize));
     }
+    // SAFETY: forwards `ptr`/`layout`/`new_size` unchanged to `System.realloc` — the
+    // caller's contract (valid `ptr` for `layout`, `new_size` non-zero and not
+    // overflowing when rounded up to `layout.align()`) is passed straight through, and
+    // only the returned pointer's nullness is inspected before recording the delta.
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         let p = System.realloc(ptr, layout, new_size);
         if !p.is_null() {

--- a/crates/sparq-engine/tests/service_stream_bounded.rs
+++ b/crates/sparq-engine/tests/service_stream_bounded.rs
@@ -1,0 +1,224 @@
+//! Bounded-memory assertion for streaming SERVICE result consumption. [FABLE-5]
+//! (bead sq-my8wd.4)
+//!
+//! The engine must not materialise a remote SERVICE relation as owned terms before
+//! the join: the pre-sq-my8wd.4 path held the response body PLUS a whole-document
+//! JSON DOM PLUS a term-level copy of every row, so a large/adversarial remote result
+//! amplified into a multiple of its own wire size. The streaming path interns each
+//! row to compact ids as it is parsed, so the only response-scale state is the
+//! (finite, transport-capped) body and the id-level relation the join itself needs.
+//!
+//! This test runs the PRODUCTION path — the real ureq `HttpTransport` against a
+//! loopback endpoint — over a large, duplicate-heavy remote result and asserts, with
+//! a thread-local byte-counting allocator, that the query thread's peak
+//! live-allocation delta stays within a small multiple of the response body. The
+//! multiplier is deliberately generous: the assertion pins the SHAPE of the bound
+//! (O(body), not O(parsed DOM + term relation)), not a tuned number — the old
+//! collect-everything path exceeds it by construction.
+//!
+//! The allocator lives HERE (an integration-test crate) because the engine crate
+//! itself is `#![forbid(unsafe_code)]` and a `GlobalAlloc` impl requires `unsafe`.
+//! Counters are THREAD-LOCAL, so the server thread's allocations (serving the body)
+//! and any parallel sibling test never pollute the measurement, and the measurement
+//! is deterministic (no timing involved).
+//!
+//! Built only when the `service` feature is on:
+//!   cargo test -p sparq-engine --features service --test service_stream_bounded
+
+#![cfg(feature = "service")]
+
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::Cell;
+use std::io::{Read, Write};
+use std::net::TcpListener;
+use std::sync::mpsc;
+use std::thread;
+
+use sparq_core::Graph;
+use sparq_engine::{query, with_service_egress_allow};
+
+// ---------------------------------------------------------------------------
+// Thread-local byte-counting allocator (per-thread live/peak, no timing).
+// ---------------------------------------------------------------------------
+
+thread_local! {
+    static LIVE: Cell<isize> = const { Cell::new(0) };
+    static PEAK: Cell<isize> = const { Cell::new(0) };
+}
+
+/// Record a live-byte delta on THIS thread. `try_with` so a (de)allocation during
+/// thread teardown can never panic inside the allocator — it is simply not counted.
+fn add(d: isize) {
+    let _ = LIVE.try_with(|l| {
+        let v = l.get() + d;
+        l.set(v);
+        if d > 0 {
+            let _ = PEAK.try_with(|p| {
+                if v > p.get() {
+                    p.set(v);
+                }
+            });
+        }
+    });
+}
+
+struct Counting;
+
+unsafe impl GlobalAlloc for Counting {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let p = System.alloc(layout);
+        if !p.is_null() {
+            add(layout.size() as isize);
+        }
+        p
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        add(-(layout.size() as isize));
+    }
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = System.realloc(ptr, layout, new_size);
+        if !p.is_null() {
+            add(new_size as isize - layout.size() as isize);
+        }
+        p
+    }
+}
+
+#[global_allocator]
+static COUNTING: Counting = Counting;
+
+/// Peak live-byte DELTA on this thread while `f` runs.
+fn peak_delta_during<R>(f: impl FnOnce() -> R) -> (isize, R) {
+    let base = LIVE.with(Cell::get);
+    PEAK.with(|p| p.set(base));
+    let r = f();
+    (PEAK.with(Cell::get) - base, r)
+}
+
+// ---------------------------------------------------------------------------
+// Loopback endpoint (same pattern as tests/service_federation.rs).
+// ---------------------------------------------------------------------------
+
+/// Spawn a one-shot HTTP/1.1 server that replies to `n` requests with `body`
+/// (Content-Type sparql-results+json), returning the bound URL. The body is served
+/// from the SERVER thread, so its allocations are outside the measured thread.
+fn serve(body: String, n: usize) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind loopback");
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = mpsc::channel();
+    thread::spawn(move || {
+        tx.send(()).ok();
+        for _ in 0..n {
+            let Ok((mut stream, _)) = listener.accept() else {
+                return;
+            };
+            // Drain the WHOLE request (headers + the Content-Length form body). With a
+            // multi-megabyte response, closing the socket while unread request bytes
+            // are pending would RST the connection and truncate the client's read.
+            let mut req = Vec::new();
+            let mut buf = [0u8; 4096];
+            let (mut hdr_end, mut want) = (None, 0usize);
+            while let Ok(n) = stream.read(&mut buf) {
+                if n == 0 {
+                    break;
+                }
+                req.extend_from_slice(&buf[..n]);
+                if hdr_end.is_none() {
+                    if let Some(pos) = req.windows(4).position(|w| w == b"\r\n\r\n") {
+                        hdr_end = Some(pos + 4);
+                        let headers = String::from_utf8_lossy(&req[..pos]);
+                        want = headers
+                            .lines()
+                            .find_map(|l| {
+                                let (k, v) = l.split_once(':')?;
+                                k.eq_ignore_ascii_case("content-length")
+                                    .then(|| v.trim().parse::<usize>().ok())?
+                            })
+                            .unwrap_or(0);
+                    }
+                }
+                if let Some(h) = hdr_end {
+                    if req.len() >= h + want {
+                        break;
+                    }
+                }
+            }
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\n\
+                 Content-Type: application/sparql-results+json\r\n\
+                 Content-Length: {}\r\n\
+                 Connection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(resp.as_bytes());
+            let _ = stream.flush();
+        }
+    });
+    rx.recv().unwrap(); // wait until the listener thread is live
+    format!("http://{}/", addr)
+}
+
+/// A large, duplicate-heavy SPARQL-Results-JSON body: `rows` solutions over only 7
+/// distinct (s, n) pairs. Duplicate-heavy keeps the query-local vocabulary (which the
+/// join legitimately retains, deduped) tiny, so the assertion isolates the CONSUMPTION
+/// overhead; the duplicates themselves must all survive (multiset semantics).
+fn big_srj_body(rows: usize) -> String {
+    let mut bindings = Vec::with_capacity(rows);
+    for i in 0..rows {
+        let k = i % 7;
+        bindings.push(format!(
+            r#"{{"s":{{"type":"uri","value":"http://remote.example/dup/{}"}},"n":{{"type":"literal","value":"remote-value-{}"}}}}"#,
+            k, k
+        ));
+    }
+    format!(
+        r#"{{"head":{{"vars":["s","n"]}},"results":{{"bindings":[{}]}}}}"#,
+        bindings.join(",")
+    )
+}
+
+#[test]
+fn large_service_result_consumption_is_bounded_by_the_body_not_the_relation() {
+    // ~60k rows, ~7 MB on the wire. All terms are absent from the local graph, so
+    // every distinct term takes the local-vocab interning path.
+    let body = big_srj_body(60_000);
+    let body_len = body.len() as isize;
+    let url = serve(body, 1);
+
+    let g = Graph::load_str("<http://ex/a> <http://ex/p> <http://ex/b> .", "ntriples").unwrap();
+    // COUNT(*) keeps the OUTPUT tiny (one row), so the measurement isolates the
+    // SERVICE consumption itself rather than result materialisation; the count also
+    // proves multiset semantics survive streaming (60_000 rows, NOT 7 deduped).
+    let q = format!(
+        "SELECT (COUNT(*) AS ?c) WHERE {{ SERVICE <{}> {{ ?s ?p ?n }} }}",
+        url
+    );
+
+    let (peak, res) = peak_delta_during(|| {
+        with_service_egress_allow(["127.0.0.1".to_string()], || query(&g, &q))
+    });
+    let res = res.expect("federated COUNT query");
+    assert_eq!(res.rows.len(), 1);
+    let count = res.rows[0][0].as_ref().expect("count term").to_string();
+    assert!(
+        count.starts_with("\"60000\""),
+        "duplicate rows must survive streaming (multiset semantics), got {}",
+        count
+    );
+
+    // The bound: peak consumption stays within a small multiple of the wire body
+    // (body String + read-buffer growth + compact id rows + the tiny deduped vocab).
+    // The pre-streaming path held body + whole-document DOM + a term-level relation
+    // copy — several times this bound on the same fixture.
+    let bound = body_len * 3 + (4 << 20);
+    assert!(
+        peak < bound,
+        "SERVICE consumption peak {} bytes exceeds the O(body) bound {} (body {} bytes): \
+         the remote relation is being materialised again",
+        peak,
+        bound,
+        body_len
+    );
+}

--- a/research/service-federation-conformance.md
+++ b/research/service-federation-conformance.md
@@ -94,7 +94,10 @@ Scope, honestly bounded:
   bounded cooperatively post-HTTP). The harness should not paper over this; if the suite exercises
   it, surface it (and consider a follow-up bead for a per-query remote-request cap). Remote-result
   materialisation is non-streaming (full relation into memory) — fine for conformance fixtures,
-  noted as a scaling caveat, not a conformance failure.
+  noted as a scaling caveat, not a conformance failure. *(Both since addressed: the per-query
+  remote-request cap landed as `sq-b93pv`, and remote-result consumption is streaming/bounded as
+  of `sq-my8wd.4` — rows are interned to id-level bindings as parsed, never held as a
+  whole-document DOM or term-level relation. [FABLE-5])*
 
 ---
 

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -438,6 +438,18 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   bounded by the active `QueryBudget` deadline (it caps at `min(remaining-until-deadline, default)`
   with a small non-zero floor), so a `SERVICE` fetch under a tight `deadline` no longer blocks for the
   full default on an unresponsive endpoint.
+- **Streaming / bounded `SERVICE` result consumption** (`sq-my8wd.4`) — remote SPARQL-Results bodies
+  (JSON and XML) are parsed INCREMENTALLY: each solution row is interned to compact id-level bindings
+  as it is parsed and the owned terms are dropped, so the engine never holds a whole-document JSON DOM
+  or a term-level copy of the remote relation. Peak memory per `SERVICE` response is the
+  (transport-capped, finite) response body plus the id-level relation the join itself needs — a
+  large/adversarial remote result can no longer amplify to a large multiple of its wire size.
+  Behaviour-neutral by test: a frozen DOM-reference oracle pins identical rows, multiplicity, ORDER
+  and errors (`service.rs` `streaming_equivalence` tests), and the O(body) bound is pinned by a
+  byte-counting-allocator integration test over the real loopback HTTP path
+  (`tests/service_stream_bounded.rs`). Honest boundary: the response BODY itself is still fully
+  buffered (bounded by the transport's finite read cap); streaming the HTTP body is a possible
+  follow-up. [FABLE-5]
 - **`SERVICE` evaluation is W3C-conformance-tested end-to-end** (`sq-ddpgx`, epic sq-my8wd) — the
   W3C SPARQL 1.1 `sparql11/service` evaluation suite runs against the engine's REAL `ureq` transport
   through an in-process **loopback** harness: each `qt:serviceData` block is served by a real


### PR DESCRIPTION
> 🤖 **SPARQ agent**

Implements **sq-my8wd.4** (epic **sq-my8wd** — SPARQL SERVICE federation). Makes remote SERVICE result consumption **streaming / bounded**: the engine no longer materialises the full remote relation into memory before the bind-join, so a large or adversarial remote result can't OOM the engine — while keeping the bind-join / SERVICE evaluation **semantics behaviour-neutral**.

## What changed

- **`sparq-engine/src/service.rs`** — remote SPARQL-Results parsing is now per-row streaming for both formats, delivered through a monomorphic `RowSink` closure (no hot-path `dyn` dispatch, respecting the #1303 perf-neutrality constraint):
  - `eval_remote_into` / `parse_results_into` / `parse_srj_into` / `parse_srx_into` hand each solution row to the caller **as it is parsed**.
  - SRJ: a custom serde `DeserializeSeed`/`Visitor` walks `results.bindings` **one binding object at a time** instead of building a whole-document `serde_json` DOM. `head` and each individual binding are still read as small `Value`s so term reconstruction is byte-identical to the old path.
  - SRX: the quick-xml event loop was already streaming; a finished row now goes to the sink at `</result>` instead of a collected `Vec`.
  - The old collect-everything entry points (`eval_remote`/`parse_results`/`parse_srj`/`parse_srx`) are retained as thin collecting wrappers for tests and small-result callers.
- **`sparq-engine/src/exec.rs`** — `intern_remote_row` replaces the whole-relation `service_relation_to_bindings`; the verbatim path (`eval_service`) and the bind-join path (`bound_join_to_endpoint`) now intern each row to a compact id-level `Row` on arrival and drop the owned terms immediately. SILENT algebra, the SSRF egress policy, the `remote_cap` (sq-b93pv) and bind-join multiset/order semantics are all preserved.
- **`serde`** is wired as a `service`-only optional dependency — it is already in the tree as `serde_json`'s own dependency (no new supply-chain surface), but the `de` trait machinery it exposes is not re-exported by `serde_json`.

## Feature flag

Behind the existing non-default **`service`** cargo feature (OFF by default; `sparq-core`/`sparq-engine` default build is unchanged and compiles zero federation code).

## Behaviour-neutrality + bound: the tests

- **`service.rs` `streaming_equivalence` unit tests** — diff the streaming parser against a **FROZEN whole-DOM reference oracle** (the pre-sq-my8wd.4 `parse_srj`) over: representative + boundary documents (empty / single-row / reversed `results`-before-`head` / every term kind incl. SPARQL 1.2 triple terms + `its:dir`), a battery of malformed documents (asserting **identical error messages**), and a **10 000-row duplicate-heavy** document (row-for-row identical, so multiplicity **and** order are pinned).
- **`tests/service_stream_bounded.rs`** — drives the **production** ureq `HttpTransport` over an in-process loopback endpoint serving a **~60 000-row duplicate-heavy** result and asserts, with a thread-local byte-counting global allocator, that the query thread's **peak live-allocation stays within an O(body) bound** (not O(DOM + term relation)). `COUNT(*) = 60000` confirms multiset semantics survive streaming. The pre-streaming path exceeds this bound by construction (mutation-checked in-worktree: ~140 MB vs ~10 MB peak on the same fixture).
- **sink-error tests** (both formats) — a bounded consumer that refuses after N rows aborts the parse immediately and its error string propagates **verbatim** (the seam an embedder's resource policy hangs off).

## Honest boundary

The HTTP response **body** itself is still fully buffered (bounded by the transport's finite `SERVICE_MAX_BODY_BYTES` read cap). Streaming the body through a reader seam (pushing peak below 1× body) is deferred as **sq-my8wd.5**.

## Gates (run in-worktree)

- `cargo test -p sparq-engine` (feature OFF) — green.
- `cargo test -p sparq-engine --features service` — green incl. the equivalence + bound + sink tests.
- `cargo clippy -p sparq-engine --all-targets -- -D warnings` (OFF) and `--features service` (ON) — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `scripts/check-readme-template.py --enforce` — 0 deviations.
- No hard-coded performance numbers in markdown (the ~140 MB / ~10 MB figures above are work-box, non-canonical, PR-body only).

> 🤖 **SPARQ agent** — authored by Claude Fable 5. Not armed; leaving merge to the orchestrator.