### PR TITLE
feat(geo): raise OGC query-rewrite ratchet 38->48 (sq-lk3aw.2) [SONNET-4.6]

### DIFF
--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -128,9 +128,11 @@ pub struct Suite {
 ///   sq-lk3aw.1 raised it 158 -> 197: 39 net-new assertions covering
 ///   edge-adjacent polygons / disjoint line+polygon / parallel lines /
 ///   point-on-line / and multi-pair rcc8/eh disjoint cells).
-/// * OGC GeoSPARQL query-rewrite 38 — `sparq-geo` `ogc_query_rewrite_ratchet.rs`
-///   `OGC_QUERY_REWRITE_FLOOR = 38` (sq-wf9qg; opt-in `geosparql_rewrite` feature;
-///   topology PROPERTY forms answered via the rewrite, MEASURED pass count).
+/// * OGC GeoSPARQL query-rewrite 48 — `sparq-geo` `ogc_query_rewrite_ratchet.rs`
+///   `OGC_QUERY_REWRITE_FLOOR = 48` (sq-wf9qg raised to 38; sq-lk3aw.2 raised 38→48:
+///   [SONNET-4.6] strengthened semantics-preserving comparison + extended coverage;
+///   opt-in `geosparql_rewrite` feature; topology PROPERTY forms answered via the
+///   rewrite, MEASURED pass count).
 /// * Solid WAC 12 — `sparq-solid` `tests/common/mod.rs` `WAC_SCENARIO_FLOOR = 12`
 ///   (sq-j174; floor const moved to the shared parity-corpus module in sq-t58w.6).
 /// * Solid ACP 12 — `sparq-solid` `tests/common/mod.rs` `ACP_SCENARIO_FLOOR = 12`
@@ -296,7 +298,7 @@ pub const SUITES: &[Suite] = &[
             feature: "geosparql_rewrite",
         },
         ci_job: "geo-conformance",
-        ratchet_floor: 38,
+        ratchet_floor: 48,
         floor_basis: "pass",
         note: "topology PROPERTY forms (geo:sf*/eh*/rcc8*) answered end-to-end via the \
                opt-in query-rewrite extension, result-equivalent to the geof: oracle",

--- a/crates/sparq-conformance/tests/scoreboard_floors.rs
+++ b/crates/sparq-conformance/tests/scoreboard_floors.rs
@@ -70,12 +70,13 @@ const CRATE_LOCAL_FLOORS: &[(&str, &str, &str)] = &[
         "crates/sparq-geo/tests/ogc_compliance_ratchet.rs",
         "OGC_RATCHET_FLOOR",
     ),
-    // [OPUS-4.8] sq-wf9qg — the OGC GeoSPARQL QUERY-REWRITE extension ratchet. The
-    // floor const (`const OGC_QUERY_REWRITE_FLOOR: usize = 38;`) lives in
-    // `sparq-geo`'s `tests/ogc_query_rewrite_ratchet.rs` (behind the opt-in
-    // `geosparql_rewrite` feature); the guard reads it textually — exactly like the
-    // sibling OGC topology floor — so the central scoreboard's `ratchet_floor` can
-    // never drift from what the runner asserts.
+    // [OPUS-4.8] sq-wf9qg / [SONNET-4.6] sq-lk3aw.2 — the OGC GeoSPARQL
+    // QUERY-REWRITE extension ratchet. The floor const
+    // (`const OGC_QUERY_REWRITE_FLOOR: usize = 48;`) lives in `sparq-geo`'s
+    // `tests/ogc_query_rewrite_ratchet.rs` (behind the opt-in `geosparql_rewrite`
+    // feature); the guard reads it textually — exactly like the sibling OGC topology
+    // floor — so the central scoreboard's `ratchet_floor` can never drift from what
+    // the runner asserts.
     (
         "OGC GeoSPARQL query-rewrite extension",
         "crates/sparq-geo/tests/ogc_query_rewrite_ratchet.rs",

--- a/crates/sparq-geo/tests/ogc_query_rewrite_ratchet.rs
+++ b/crates/sparq-geo/tests/ogc_query_rewrite_ratchet.rs
@@ -426,7 +426,8 @@ fn semantics_preserving_rewrite_matches_explicit_filter_form() {
 
     // Manually-written equivalent FILTER form — the expansion the rewrite
     // produces, written explicitly so we can run it through the STANDARD path.
-    // Uses positional format args (CodeQL rust/unused-variable guard). [SONNET-4.6]
+    // Plain string literal (no format! — the earlier "positional format args" comment
+    // was a copy/paste error and has been removed). [SONNET-4.6]
     let filter_sparql = "PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
                          PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
                          PREFIX ex:   <http://example.org/>
@@ -447,14 +448,37 @@ fn semantics_preserving_rewrite_matches_explicit_filter_form() {
     let filter_result =
         with_functions(&reg, || query(&graph, filter_sparql)).expect("filter execute");
 
-    // Collect and sort both result sets as (f1_iri, f2_iri) string pairs.
+    // Assert row counts match first so a count divergence is caught before the
+    // pair-by-pair comparison (otherwise a shorter result set could coincidentally
+    // compare equal after sorting). [SONNET-4.6]
+    assert_eq!(
+        rewrite_result.rows.len(),
+        filter_result.rows.len(),
+        "rewrite and FILTER paths returned different row counts ({} vs {})",
+        rewrite_result.rows.len(),
+        filter_result.rows.len(),
+    );
+
+    // Collect both result sets using `map` (NOT `filter_map`) so that a row with an
+    // unbound ?f1 or ?f2 binding causes the test to FAIL loudly rather than being
+    // silently dropped — a silent drop could hide a divergence between the two paths.
+    // [SONNET-4.6]
     let mut rewrite_pairs: Vec<(String, String)> = rewrite_result
         .rows
         .iter()
-        .filter_map(|row| {
-            let f1 = row.first().and_then(|t| t.as_ref()).map(|t| t.to_string())?;
-            let f2 = row.get(1).and_then(|t| t.as_ref()).map(|t| t.to_string())?;
-            Some((f1, f2))
+        .enumerate()
+        .map(|(i, row)| {
+            let f1 = row
+                .first()
+                .and_then(|t| t.as_ref())
+                .unwrap_or_else(|| panic!("rewrite row {i}: ?f1 is unbound"))
+                .to_string();
+            let f2 = row
+                .get(1)
+                .and_then(|t| t.as_ref())
+                .unwrap_or_else(|| panic!("rewrite row {i}: ?f2 is unbound"))
+                .to_string();
+            (f1, f2)
         })
         .collect();
     rewrite_pairs.sort();
@@ -462,10 +486,19 @@ fn semantics_preserving_rewrite_matches_explicit_filter_form() {
     let mut filter_pairs: Vec<(String, String)> = filter_result
         .rows
         .iter()
-        .filter_map(|row| {
-            let f1 = row.first().and_then(|t| t.as_ref()).map(|t| t.to_string())?;
-            let f2 = row.get(1).and_then(|t| t.as_ref()).map(|t| t.to_string())?;
-            Some((f1, f2))
+        .enumerate()
+        .map(|(i, row)| {
+            let f1 = row
+                .first()
+                .and_then(|t| t.as_ref())
+                .unwrap_or_else(|| panic!("filter row {i}: ?f1 is unbound"))
+                .to_string();
+            let f2 = row
+                .get(1)
+                .and_then(|t| t.as_ref())
+                .unwrap_or_else(|| panic!("filter row {i}: ?f2 is unbound"))
+                .to_string();
+            (f1, f2)
         })
         .collect();
     filter_pairs.sort();

--- a/crates/sparq-geo/tests/ogc_query_rewrite_ratchet.rs
+++ b/crates/sparq-geo/tests/ogc_query_rewrite_ratchet.rs
@@ -59,9 +59,11 @@ use sparq_geo::{geof_registry, geosparql_rewrite, GeoError};
 /// serializations) is TRACKED in the module header, NOT asserted — an honest
 /// floor, no skip-laundering.
 ///
-/// MEASURED: the 19 cases in [`CASES`], each driven in BOTH the subject-variable
-/// and object-variable orientation, all pass = 38. Set to that actual count.
-const OGC_QUERY_REWRITE_FLOOR: usize = 38;
+/// MEASURED: the 24 cases in [`CASES`] (19 original + 5 added in sq-lk3aw.2:
+/// `sfCrosses`, `ehEquals`, `ehCovers`, `rcc8eq`, `rcc8tppi`), each driven in
+/// BOTH the subject-variable and object-variable orientation, all pass = 48.
+/// Set to that actual count. [SONNET-4.6] sq-lk3aw.2
+const OGC_QUERY_REWRITE_FLOOR: usize = 48;
 
 /// A named WKT geometry body assigned to a feature in the test graph.
 struct Feature {
@@ -160,6 +162,11 @@ const CASES: &[Case] = &[
     // ---- Simple Features over the region corpus -----------------------------
     Case { relation: "sfOverlaps", features: REGIONS, fixed: "big" },
     Case { relation: "sfEquals", features: REGIONS, fixed: "big" },
+    // [SONNET-4.6] sq-lk3aw.2 — sfCrosses: a line that enters and exits the
+    // big polygon crosses it; the MIXED corpus contains `lineCross` which does
+    // exactly that. sfCrosses is undefined for point-polygon (always false in
+    // DE-9IM), so only `lineCross` matches in the subject orientation.
+    Case { relation: "sfCrosses", features: MIXED, fixed: "region" },
     // ---- Egenhofer over the region corpus -----------------------------------
     Case { relation: "ehInside", features: REGIONS, fixed: "big" },
     Case { relation: "ehContains", features: REGIONS, fixed: "big" },
@@ -167,6 +174,12 @@ const CASES: &[Case] = &[
     Case { relation: "ehDisjoint", features: REGIONS, fixed: "far" },
     Case { relation: "ehMeet", features: REGIONS, fixed: "big" },
     Case { relation: "ehOverlap", features: REGIONS, fixed: "big" },
+    // [SONNET-4.6] sq-lk3aw.2 — ehEquals: reflexive on `big`; the only pair
+    // in REGIONS with the same WKT is (big, big). ehCovers(A, B): A covers B
+    // (every point of B is in the closure of A's interior); `big` covers all
+    // contained regions (`small`, `tangent`). Both fixed on "big".
+    Case { relation: "ehEquals", features: REGIONS, fixed: "big" },
+    Case { relation: "ehCovers", features: REGIONS, fixed: "big" },
     // ---- RCC8 over the region corpus ----------------------------------------
     Case { relation: "rcc8ntpp", features: REGIONS, fixed: "big" },
     Case { relation: "rcc8ntppi", features: REGIONS, fixed: "big" },
@@ -174,6 +187,12 @@ const CASES: &[Case] = &[
     Case { relation: "rcc8ec", features: REGIONS, fixed: "big" },
     Case { relation: "rcc8dc", features: REGIONS, fixed: "far" },
     Case { relation: "rcc8po", features: REGIONS, fixed: "big" },
+    // [SONNET-4.6] sq-lk3aw.2 — rcc8eq: reflexive on `big`. rcc8tppi(A, B)
+    // means B is a Tangential Proper Part of A; with fixed="tangent" the
+    // subject orientation finds `big` (which has `tangent` as a TPP sharing
+    // the corner-vertex boundary).
+    Case { relation: "rcc8eq", features: REGIONS, fixed: "big" },
+    Case { relation: "rcc8tppi", features: REGIONS, fixed: "tangent" },
 ];
 
 /// Build the Turtle for a feature corpus: each feature resolves through
@@ -391,4 +410,75 @@ fn rewrite_is_structural_noop_for_non_topology_query() {
     let before = PreparedQuery::parse(q).unwrap().into_query();
     let after = sparq_geo::rewrite_query(before.clone());
     assert_eq!(before.to_string(), after.to_string());
+}
+
+/// Semantics-preservation assertion for the TWO-VARIABLE form: the property-form
+/// rewrite of `?f1 geo:sfWithin ?f2` yields EXACTLY the same result set as the
+/// manually-written geometry-resolution FILTER form executed through the STANDARD
+/// engine. This directly proves the rewrite is a semantics-preserving algebra
+/// transformation, not just a syntax convenience. [SONNET-4.6] sq-lk3aw.2
+#[test]
+fn semantics_preserving_rewrite_matches_explicit_filter_form() {
+    let graph = Graph::load_str(&corpus_ttl(MIXED), "turtle").unwrap();
+
+    // Property-form query via the REWRITE path.
+    let prop_sparql = format!("{PREFIXES} SELECT ?f1 ?f2 WHERE {{ ?f1 geo:sfWithin ?f2 }}");
+
+    // Manually-written equivalent FILTER form — the expansion the rewrite
+    // produces, written explicitly so we can run it through the STANDARD path.
+    // Uses positional format args (CodeQL rust/unused-variable guard). [SONNET-4.6]
+    let filter_sparql = "PREFIX geo:  <http://www.opengis.net/ont/geosparql#>
+                         PREFIX geof: <http://www.opengis.net/def/function/geosparql/>
+                         PREFIX ex:   <http://example.org/>
+                         SELECT ?f1 ?f2 WHERE {
+                             ?f1 (geo:hasDefaultGeometry|geo:hasGeometry)/geo:asWKT ?g1 .
+                             ?f2 (geo:hasDefaultGeometry|geo:hasGeometry)/geo:asWKT ?g2 .
+                             FILTER(geof:sfWithin(?g1, ?g2))
+                         }";
+
+    let reg = geof_registry();
+
+    // Execute property form through the rewrite.
+    let rewrite_prepared = geosparql_rewrite(&prop_sparql).expect("rewrite parse");
+    let rewrite_result =
+        with_functions(&reg, || query_prepared(&graph, &rewrite_prepared)).expect("rewrite execute");
+
+    // Execute FILTER form through the STANDARD engine (geof: functions registered).
+    let filter_result =
+        with_functions(&reg, || query(&graph, filter_sparql)).expect("filter execute");
+
+    // Collect and sort both result sets as (f1_iri, f2_iri) string pairs.
+    let mut rewrite_pairs: Vec<(String, String)> = rewrite_result
+        .rows
+        .iter()
+        .filter_map(|row| {
+            let f1 = row.first().and_then(|t| t.as_ref()).map(|t| t.to_string())?;
+            let f2 = row.get(1).and_then(|t| t.as_ref()).map(|t| t.to_string())?;
+            Some((f1, f2))
+        })
+        .collect();
+    rewrite_pairs.sort();
+
+    let mut filter_pairs: Vec<(String, String)> = filter_result
+        .rows
+        .iter()
+        .filter_map(|row| {
+            let f1 = row.first().and_then(|t| t.as_ref()).map(|t| t.to_string())?;
+            let f2 = row.get(1).and_then(|t| t.as_ref()).map(|t| t.to_string())?;
+            Some((f1, f2))
+        })
+        .collect();
+    filter_pairs.sort();
+
+    // The two paths must agree exactly on every (f1, f2) pair.
+    assert_eq!(
+        rewrite_pairs, filter_pairs,
+        "property-form rewrite yielded different results than the explicit FILTER form"
+    );
+    // Sanity: sfWithin is reflexive for equal geometries, so we always have
+    // at least the (region, region) self-pair in MIXED.
+    assert!(
+        !rewrite_pairs.is_empty(),
+        "sfWithin must bind at least one pair in the MIXED corpus"
+    );
 }


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bulk Rust implementer (Sonnet 4.6), bead **sq-lk3aw.2**, epic **sq-lk3aw**

## Summary

Raises `OGC_QUERY_REWRITE_FLOOR` from **38 → 48** by adding the 5 missing topology-relation cases to the OGC query-rewrite conformance ratchet (`tests/ogc_query_rewrite_ratchet.rs`). Each case is driven in both the subject-variable and object-variable orientation (2 passes per case × 5 cases = +10 passes).

**New cases added to `CASES`:**
- `sfCrosses` (SF family, MIXED corpus, `fixed="region"`) — line crossing polygon boundary
- `ehEquals` (EH family, REGIONS corpus, `fixed="big"`) — reflexive equality
- `ehCovers` (EH family, REGIONS corpus, `fixed="big"`) — big covers contained features
- `rcc8eq` (RCC8 family, REGIONS corpus, `fixed="big"`) — reflexive equality
- `rcc8tppi` (RCC8 family, REGIONS corpus, `fixed="tangent"`) — big is TPPI of tangent

All 24 topology relations the crate ships (8 SF + 8 EH + 8 RCC8) are now exercised end-to-end through the rewrite.

**New semantics-preserving test:** `semantics_preserving_rewrite_matches_explicit_filter_form` — explicitly proves the two-variable property-form query `?f1 geo:sfWithin ?f2` via the REWRITE yields the same result set as the equivalent manually-written geometry-resolution FILTER form through the STANDARD engine. This directly asserts the rewrite is semantics-preserving as required by the bead spec.

**Acceptance test:** `ogc_query_rewrite_compliance_ratchet` — passes at the new floor of 48 (`pass 48 / fail 0`).

**Spec:** bead sq-lk3aw.2 (`src/rewrite.rs` topology property-form algebra rewrite, `geosparql_rewrite` feature), epic sq-lk3aw.

## Gates

| Gate | Default features | `geosparql_rewrite` feature |
|------|-----------------|----------------------------|
| `cargo test -p sparq-geo` | GREEN | GREEN |
| `cargo clippy -p sparq-geo --all-targets -- -D warnings` | GREEN | GREEN |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` | GREEN | — |
| `readme-template` | 0 deviations | — |
| `OGC_QUERY_REWRITE_FLOOR` | — | 38 → 48 (honest measured count) |

**Production code unchanged** (`src/rewrite.rs` untouched); coverage can only increase.

Feature default-OFF preserved — the `geosparql_rewrite` feature remains opt-in; default SPARQL semantics (`geo:sfWithin` matches only asserted triples) are byte-identical.

> 🤖 **SPARQ agent** [SONNET-4.6] — bead sq-lk3aw.2, epic sq-lk3aw