### PR TITLE
feat(ci): adaptive saturation budget for the ci-summary gate — no false RED under runner-pool congestion (sq-90cv4) [FABLE-5]

### DIFF
--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -30,11 +30,24 @@
 # grew 81 -> 86 mid-poll while every check was terminal+green) reset the settle on each
 # injection, never let it reach the window, and the loop hit its cap and emitted a
 # FALSE RED — even though nothing failed. Now an already-terminal injection cannot
-# starve convergence: only unfinished work (pending) holds or re-arms the gate. And the
-# loop-budget exhaustion is no longer an unconditional RED — see the GRACEFUL TIMEOUT
-# note at the bottom of the poll loop: if at the budget everything is terminal (just
-# never quiet for a full settle), we render the real verdict on the full terminal set
-# rather than blind-failing; a genuine hang (work still pending) is the only timeout RED.
+# starve convergence: only unfinished work (pending) holds or re-arms the gate. And
+# loop-budget exhaustion with everything terminal renders the REAL verdict on the full
+# terminal set rather than blind-failing; a genuine hang is the only timeout RED.
+#
+# ADAPTIVE SATURATION BUDGET (bead sq-90cv4). [FABLE-5] This gate is a WAITER that
+# occupies a runner slot while polling. Under org-pool saturation (many PRs → many
+# concurrent gates), the waiters starve the very builds they wait on, the base budget
+# expires with siblings still QUEUED, and the old unconditional timeout-RED emitted a
+# FALSE gate=FAILURE on PRs whose real legs were green/pending (the 2026-07-02
+# congestion collapse). Runner saturation is a THROUGHPUT signal, not a hang — so at
+# base-budget exhaustion with work still pending, the loop now extends its wait (at a
+# slower poll cadence) ONLY while the repo's Actions queue is deep or sibling
+# completions are still landing, up to a hard absolute cap; an idle-queue/no-progress
+# pending set still REDs immediately (genuine hang), and every verdict — including
+# after an extension — is rendered by the SAME all-terminal gating semantics, so a
+# real failure can never become a pass and the wait can never be infinite. The
+# queue-depth signal needs `actions: read` (read-only) on the token. The deeper fix
+# (moving the waiter OFF the build-runner slot entirely) is a design-record follow-up.
 #
 # ADVISORY/INFORMATIONAL checks are NON-GATING (bead sq-wjth). [OPUS-4.8] A check
 # whose NAME contains the WHOLE WORD "advisory" or "informational" (case-insensitive,
@@ -58,6 +71,12 @@
 # the step-level `continue-on-error`/`|| true` in those jobs is a best-effort first
 # line, and THIS name-rule is the load-bearing backstop that makes advisory failures
 # strictly non-gating regardless of how the job concludes.
+#
+# IMPLEMENTATION (sq-90cv4). [FABLE-5] The poll loop + verdict live in
+# scripts/ci_summary_gate.py (extracted from the previous inline bash so the
+# semantics are UNIT-TESTED — scripts/tests/test_ci_summary_gate.py, run as a HARD
+# step in docs-quality.yml's `ci-scripts` job). This file keeps the doctrine; the
+# script keeps the mechanics.
 name: ci-summary
 
 on:
@@ -72,11 +91,15 @@ on:
   push:
     branches: [main]
 
-# Read-only: the gate only READS check-runs + commit statuses for the head commit.
+# Read-only: the gate READS check-runs + commit statuses for the head commit, plus
+# the repo's queued workflow-run count (`actions: read` — the sq-90cv4 saturation
+# signal; a permissions failure there degrades to the progress-only signal, it never
+# fails the gate by itself).
 permissions:
   checks: read
   statuses: read
   contents: read
+  actions: read
 
 # One in-flight gate per PR (or per branch on push). Cancel a superseded run so a
 # new push doesn't leave a stale, slowly-timing-out gate behind.
@@ -88,11 +111,24 @@ jobs:
   gate:
     name: gate
     runs-on: ubuntu-latest
-    # > the slowest sibling gate (coverage / conformance are the long poles, well
-    # under ~20 min on a warm cache) with generous headroom; the poll loop below
-    # caps itself under this wall-clock so it emits a clear timeout error first.
-    timeout-minutes: 45
+    # > the loop's ABSOLUTE budget: ~37 min base (unchanged from the pre-sq-90cv4
+    # cap) + up to ~30 min of saturation extension + API overhead. The loop caps
+    # itself under this wall-clock so it emits a clear timeout error first. In the
+    # normal (unsaturated) case the gate converges exactly as fast as before —
+    # the extension only ever activates at base-budget exhaustion under a
+    # saturated/progressing queue.
+    timeout-minutes: 80
     steps:
+      # Sparse checkout of ONLY the gate script (+ its blobless tree): the gate needs
+      # no sources. Same trust model as before — on pull_request the workflow file
+      # itself already comes from the merge ref, so scripting from the same ref does
+      # not widen anything. [FABLE-5]
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          sparse-checkout: |
+            scripts/ci_summary_gate.py
+          sparse-checkout-cone-mode: false
       - name: Wait for all other checks, then aggregate
         env:
           GH_TOKEN: ${{ github.token }}
@@ -108,160 +144,7 @@ jobs:
           # run id rather than by the job NAME. A name match ("gate") is fragile:
           # it would also drop any FUTURE sibling job literally named `gate` in any
           # workflow, undermining the "add/rename jobs freely" goal. The run id is
-          # ours alone, so the exclusion is exact and collision-proof. [OPUS-4.8]
+          # ours alone, so the exclusion is exact and collision-proof (anchored to
+          # "/runs/<id>(/|$)" in the script). [OPUS-4.8]
           SELF_RUN_ID: ${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          # CONVERGENCE (handles the startup race + late-registering workflows WITHOUT
-          # thrashing on a matrix, AND without false-RED'ing on a still-injecting set —
-          # bead sq-ipkku). [OPUS-4.8] sq — @jeswr reported the gate wasn't converging
-          # promptly once `build + test` was split into a 4-shard matrix, and later that
-          # a flurry of late-but-already-green check-runs (set grew 81 -> 86 mid-poll on
-          # #997) could time the gate out into a FALSE RED.
-          #
-          # The convergence condition is: every DISCOVERED sibling check-run is TERMINAL
-          # (`pending == 0`) AND that all-terminal state has HELD for a SHORT settle of
-          # SETTLE_POLLS consecutive polls — bounded below by a MIN_POLLS startup floor
-          # and above by the loop/job timeout.
-          #
-          # WHY pending==0 (not name-set-stability) is the settle signal: a check-run
-          # that is still registering/running is NOT `completed`, so it counts in
-          # `pending`. We render a verdict only once EVERY discovered sibling is terminal,
-          # so all N matrix shards (which complete at staggered times) are waited-for and
-          # folded in. While shards keep arriving and running, pending>0 holds the gate;
-          # the settle window then runs AFTER the last sibling finishes, converging in
-          # ~SETTLE_POLLS polls instead of re-waiting a full window per late arrival.
-          #
-          # WHY the settle is re-armed ONLY by pending work, NOT by name-set growth
-          # (sq-ipkku): the previous design reset the settle on ANY change to the sibling
-          # NAME set. That conflated two very different events — (a) genuinely-new
-          # UNFINISHED work appearing (which MUST hold the gate) and (b) a new check-run
-          # arriving already TERMINAL (e.g. a fast docs/advisory job, or a re-run, or a
-          # late workflow whose single job completes instantly). Case (b) represents NO
-          # unfinished work, yet under the old rule each such arrival reset the settle to
-          # 0. When such arrivals trickled in over many minutes (the #997 81->86 growth),
-          # the settle never reached its window before the loop cap, and the gate emitted
-          # a FALSE RED while every check was green. Now `pending > 0` is the ONLY thing
-          # that re-arms the settle: an already-terminal injection cannot starve
-          # convergence, but a genuinely-late workflow (which appears as queued/in_progress
-          # => pending>0) still holds and re-arms the gate exactly as before. We keep the
-          # discovered name set ONLY for human-readable logging of what changed; it no
-          # longer gates convergence.
-          #
-          # WHY MIN_POLLS still matters: it guards the startup race where the FIRST
-          # sibling finishes so fast that a slightly-later-registering workflow hasn't
-          # appeared yet — no verdict is rendered before MIN_POLLS polls have elapsed,
-          # giving slow workflows time to register (and arm pending>0) before an
-          # all-terminal PARTIAL set could pass prematurely. A stable-empty set still
-          # passes (docs-only change with no siblings).
-          #
-          # render_verdict <runs-json-lines>: shared by the normal converge path AND the
-          # graceful-timeout path. Partitions the terminal sibling set into GATING vs
-          # advisory/informational EXCLUDED, then exits 0 (all green/skipped/neutral) or 1
-          # (>=1 non-passing gating check). Defined once so both paths apply IDENTICAL
-          # gating semantics — a timeout that finds everything terminal must judge the set
-          # the same way a clean convergence would, never blind-pass or blind-fail.
-          render_verdict() {
-            local runs="$1" total
-            total=$(printf '%s\n' "$runs" | jq -rs 'length')
-            if [ "$total" -eq 0 ]; then
-              echo "ci-summary: no sibling checks to aggregate (stable empty set) — passing." \
-                | tee -a "$GITHUB_STEP_SUMMARY"
-              exit 0
-            fi
-            # [OPUS-4.8] sq-wjth: a non-passing conclusion gates ONLY for a check that is
-            # NOT advisory/informational. The (.name|ascii_downcase) test drops any check
-            # whose name contains the WHOLE WORD "advisory" or "informational" (case-
-            # insensitive) from the gating set — its failure can never block the merge.
-            # The \b…\b word boundaries make the rule precise: it matches the standalone
-            # words (incl. hyphen-/paren-/comma-delimited, e.g. "markdownlint-advisory",
-            # "(…, advisory)", "(…, informational)") but NOT a word that merely CONTAINS
-            # them as a substring — so "cargo-deny (advisories, …)" (plural) and any
-            # hypothetical required check like "advisories audit" are NOT excluded. See
-            # the ADVISORY/INFORMATIONAL note in the header for the exact names this
-            # covers and why required checks are unaffected.
-            local ADVISORY_RE='\b(advisory|informational)\b' gating excluded failed n
-            # `total` counts ALL siblings; the gate only judges the GATING subset, so the
-            # summary reports gating counts and states how many advisory checks were
-            # excluded — it does not claim the advisory ones were counted toward the
-            # verdict.
-            gating=$(printf '%s\n' "$runs" | jq -rs --arg re "$ADVISORY_RE" \
-              '[.[] | select((.name | ascii_downcase | test($re)) | not)] | length')
-            excluded=$((total - gating))
-            failed=$(printf '%s\n' "$runs" | jq -rs --arg re "$ADVISORY_RE" '[.[]
-              | select((.name | ascii_downcase | test($re)) | not)
-              | select(.conclusion != "success" and .conclusion != "skipped" and .conclusion != "neutral")]')
-            n=$(printf '%s' "$failed" | jq 'length')
-            if [ "$n" -gt 0 ]; then
-              {
-                echo "### ci-summary: FAILED — $n non-passing gating check(s) of $gating gating ($excluded advisory check(s) excluded)"
-                printf '%s' "$failed" | jq -r '.[] | "- ✗ \(.name): \(.conclusion // "incomplete")"'
-              } | tee -a "$GITHUB_STEP_SUMMARY"
-              echo "::error::ci-summary failed — see the non-passing gating checks above."
-              exit 1
-            fi
-            echo "### ci-summary: PASSED — all $gating gating check(s) green (or skipped/neutral); $excluded advisory check(s) excluded; set stable." \
-              | tee -a "$GITHUB_STEP_SUMMARY"
-            exit 0
-          }
-          SETTLE_POLLS=2          # all-terminal state must hold for 2 × 20s = 40s
-          MIN_POLLS=3             # never render a verdict before 3 × 20s = 60s (startup-race floor)
-          INTERVAL=20
-          prev_names=""
-          stable=0
-          runs=""                 # last-fetched sibling set; reused by the graceful timeout
-          pending=0
-          for attempt in $(seq 1 110); do   # 110 × 20s ≈ 37 min, under the job timeout
-            # Exclude THIS gate's own check-run from the aggregate so it can't count
-            # itself into `pending` and self-deadlock. We exclude by THIS workflow run's
-            # id (SELF_RUN_ID), which the check-run's details_url embeds as
-            # …/actions/runs/<RUN_ID>/…, NOT by job name: a name match would also drop a
-            # future sibling job literally named `gate`. The match is anchored to
-            # "/runs/<id>" so it can't accidentally hit a substring of some other numeric
-            # id elsewhere in the URL.
-            runs=$(gh api "repos/$REPO/commits/$SHA/check-runs" --paginate \
-              --jq "[.check_runs[]
-                     | select((.details_url // .html_url // \"\") | contains(\"/runs/$SELF_RUN_ID\") | not)
-                     | {name, status, conclusion}] | .[]")
-            # Names are kept for LOGGING only (what changed since last poll); they no
-            # longer gate convergence — see the sq-ipkku rationale above. Sorted+unique,
-            # newline-joined (a newline cannot appear in a check name; a comma can).
-            names=$(printf '%s\n' "$runs" | jq -rs '[.[].name] | unique | join("\n")')
-            pending=$(printf '%s\n' "$runs" | jq -rs '[.[] | select(.status != "completed")] | length')
-            total=$(printf '%s\n' "$runs" | jq -rs 'length')
-            # Settle is a POST-TERMINAL window re-armed ONLY by pending work. While
-            # anything is still running/registering (pending>0) we reset to 0 so the
-            # window genuinely runs AFTER the last sibling finishes. Once pending==0 we
-            # advance every poll, regardless of already-terminal check-runs that may keep
-            # being injected (the #997 false-RED cause) — a terminal arrival is finished
-            # work and must not starve convergence.
-            if [ "$pending" -ne 0 ]; then stable=0; else stable=$((stable + 1)); fi
-            changed=""; [ "$names" != "$prev_names" ] && changed=" (name set changed)"; prev_names="$names"
-            echo "attempt $attempt: $total check-run(s), $pending running, all-terminal stable for $stable/$SETTLE_POLLS poll(s)$changed"
-            # Converge once every discovered sibling is terminal (pending == 0) AND that
-            # state has held for the short settle — but never before the MIN_POLLS startup
-            # floor, so a slightly-late-registering workflow has time to appear (and
-            # re-arm the settle via pending>0) before an all-terminal PARTIAL set passes.
-            if [ "$attempt" -ge "$MIN_POLLS" ] && [ "$pending" -eq 0 ] && [ "$stable" -ge "$SETTLE_POLLS" ]; then
-              render_verdict "$runs"   # exits 0 or 1
-            fi
-            sleep "$INTERVAL"
-          done
-          # GRACEFUL TIMEOUT (sq-ipkku). [OPUS-4.8] Exhausting the loop budget is NOT an
-          # unconditional RED — a timeout means "didn't reach a quiet settle", which is
-          # only a genuine failure if real WORK is still pending. Two cases:
-          #   • pending == 0 at the budget: every discovered sibling IS terminal; we just
-          #     never got SETTLE_POLLS consecutive quiet polls (e.g. an already-green set
-          #     that kept being injected into). Render the REAL verdict on that full
-          #     terminal set via the same gating semantics as a clean convergence — so a
-          #     still-settling-but-all-green set passes and a genuinely-failed check still
-          #     fails. This is the fix for the #997 false RED.
-          #   • pending > 0 at the budget: something truly hung (a check never finished
-          #     within ~37 min). That is a legitimate RED — we cannot certify a set with
-          #     unfinished work green.
-          if [ "$pending" -eq 0 ]; then
-            echo "::notice::ci-summary loop budget reached with every sibling check terminal (the set kept being injected into without a full quiet settle) — rendering the verdict on the final all-terminal set."
-            render_verdict "$runs"   # exits 0 or 1
-          fi
-          echo "::error::ci-summary timed out — $pending sibling check-run(s) never finished within the loop budget (genuine hang, not a still-settling set). See the per-poll log above."
-          exit 1
+        run: python3 scripts/ci_summary_gate.py

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -119,10 +119,11 @@ jobs:
     # saturated/progressing queue.
     timeout-minutes: 80
     steps:
-      # Sparse checkout of ONLY the gate script (+ its blobless tree): the gate needs
-      # no sources. Same trust model as before — on pull_request the workflow file
-      # itself already comes from the merge ref, so scripting from the same ref does
-      # not widen anything. [FABLE-5]
+      # Sparse checkout of ONLY the gate script: the gate needs no sources. (No
+      # partial-clone filter is configured — this is sparse checkout only, not a
+      # blobless clone.) Same trust model as before — on pull_request the workflow
+      # file itself already comes from the merge ref, so scripting from the same ref
+      # does not widen anything. [FABLE-5] [SONNET-4.6]
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -479,6 +479,18 @@ jobs:
       # runtime-honesty teeth. HARD job (no "advisory" token) — a regression reds the ci-summary gate.
       - name: "Self-test js-sbom lane vs external dev-deps on a published member (sq-pl1p)"
         run: bash scripts/tests/test_js_sbom_external_devdep.sh
+      # [FABLE-5] sq-90cv4: the ci-summary gate poll loop — the brain of the SINGLE
+      # required branch-protection check — lives in scripts/ci_summary_gate.py
+      # (extracted from ci-summary.yml's inline bash). Its verdict semantics
+      # (all-green=>PASS, real-failure=>FAIL, advisory word-boundary exclusion,
+      # sq-ipkku settle guard + #997 graceful timeout, anchored self-exclusion) AND
+      # the sq-90cv4 adaptive saturation budget (queued-siblings-under-saturation =>
+      # still-settling, idle-queue hang => RED, absolute cap bounded) are pinned by a
+      # hermetic stdlib-unittest suite (NO gh, NO network — injected fetchers). HARD
+      # (no "advisory" token): a regression in the gate's own logic must red CI
+      # before every merge depends on it.
+      - name: Self-test ci-summary gate loop (verdict semantics + adaptive saturation budget — sq-90cv4)
+        run: python3 scripts/tests/test_ci_summary_gate.py
 
   # ----------------------------- ADVISORY -----------------------------
   markdownlint-advisory:

--- a/research/ci-gate-slotless-aggregation.md
+++ b/research/ci-gate-slotless-aggregation.md
@@ -1,0 +1,89 @@
+# Getting the ci-summary gate off the build-runner slot — design record (sq-90cv4 follow-up)
+
+> Status: **DESIGN-ONLY.** The shipped sq-90cv4 increment is the *adaptive saturation
+> budget* in `scripts/ci_summary_gate.py` (unit-tested; see the PR that added this
+> record). This record documents the **deferred deeper fix** — removing the gate's
+> slot occupancy entirely — so the follow-up bead starts from a vetted design instead
+> of re-deriving one against the merge-critical required check. Authored by Claude
+> Fable 5 `[FABLE-5]`.
+
+## 1. Problem
+
+`ci-summary / gate` (the single REQUIRED branch-protection check) is a *waiter*: a
+GitHub-hosted job that polls sibling check-runs until they are all terminal. While
+polling it occupies one job slot in the account-wide hosted-runner concurrency pool.
+Under load (many open PRs, each with its own gate) the waiters collectively starve
+the build jobs they are waiting on; observed 2026-07-02 as a congestion collapse with
+false `gate=FAILURE` verdicts on PRs whose real legs were green or merely queued.
+
+The adaptive budget fixes the *false verdict* (queued-under-saturation now extends
+the wait instead of concluding FAILURE; a genuine hang still fails). It does **not**
+fix the *slot occupancy* — a saturated pool now holds gate slots longer, which is the
+correct trade for verdict honesty but leaves throughput on the table.
+
+## 2. Recommended deeper fix: event-driven evaluation, no resident waiter
+
+Replace the resident poll loop with **short-lived evaluations triggered by sibling
+completion events**:
+
+- A `workflow_run` (`types: [completed]`) triggered workflow fires each time any
+  sibling workflow finishes. Each firing runs for seconds: fetch the head commit's
+  check-runs once, apply the *same* verdict function (`render_verdict` in
+  `scripts/ci_summary_gate.py` — already extracted and unit-tested), and publish the
+  result as a **commit status** (`statuses: write`) on the head SHA.
+- Branch protection then requires that commit-status context instead of the
+  `ci-summary / gate` job. The status is "pending" until the evaluator sees an
+  all-terminal set, then success/failure by the existing semantics.
+- Slot cost: O(seconds) per sibling completion instead of O(minutes-to-an-hour) per
+  PR. No waiter exists to starve the pool, so the saturation false-RED class
+  disappears structurally rather than being compensated for.
+
+Why this shape and not the alternatives:
+
+- **Concurrency-exempt / self-hosted tiny runner for the gate** — works, but needs
+  org/runner configuration outside the repo (runner registration, labels, upkeep)
+  and adds an always-on machine to the trust surface. Needs the maintainer; not a
+  repo-only change.
+- **Merge queue + org move** (already planned) reduces how many PR heads run CI
+  concurrently but does not remove the waiter; complementary, not a substitute.
+- **Keeping the poll loop but shortening it** regresses the verdict semantics the
+  current design guarantees (waits for late-registering workflows, settle window).
+
+## 3. Design risks the implementation bead must resolve
+
+1. **Required-check migration.** Swapping the required check from a job to a status
+   context must be atomic-ish: add the status context as required *alongside* the
+   job first, prove parity on live PRs, then drop the job. A missing "expected"
+   required check blocks every merge — stage it.
+2. **Trust model changes (for the better, but verify).** `workflow_run` executes the
+   workflow definition from the **default branch**, not the PR — the evaluator logic
+   stops being PR-attested. Confirm the token scoping (`statuses: write` on the
+   evaluator; the PR cannot forge the status).
+3. **Bootstrap + quiet PRs.** A docs-only PR that triggers few/no sibling workflows
+   needs at least one evaluation to publish the status (the current gate's
+   stable-empty-set pass). A `pull_request`-triggered "seed" evaluation (short-lived,
+   also non-resident) covers it, but its token cannot write statuses from forks —
+   check the fork path.
+4. **`merge_group` compatibility.** The merge-queue ref needs the same status; verify
+   `workflow_run` events fire for merge-group-triggered sibling runs and that the
+   status lands on the merge-group head SHA the ruleset checks.
+5. **Event storms.** One evaluation per sibling-workflow completion is dozens per
+   push; each is cheap, but debounce (concurrency-group per head SHA,
+   `cancel-in-progress`) to keep it tidy.
+6. **Startup race parity.** The current MIN_POLLS floor guards against verdicting a
+   partial early set. The evaluator equivalent: never publish a success while any
+   *expected* workflow for the trigger set has not yet registered — reuse the
+   path-filter outputs or require a minimum sibling count seen before a green status.
+
+## 4. Verdict-function reuse
+
+The sq-90cv4 extraction means the deeper fix does **not** re-implement semantics:
+`is_advisory` / `is_self` / `render_verdict` and their tests
+(`scripts/tests/test_ci_summary_gate.py`) are the shared, already-gated brain. The
+follow-up only replaces the *transport* (resident loop → event-driven invocations).
+
+## 5. Status
+
+Tracked as a follow-up bead (created with sq-90cv4's PR; blocked on maintainer
+appetite for a required-check migration). Until then the adaptive budget is the
+operative mitigation, and the merge-queue/org plans reduce exposure.

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+# ci-summary gate poll loop — the single REQUIRED branch-protection check's brain.
+# [FABLE-5] Extracted from the inline bash in .github/workflows/ci-summary.yml so
+# the loop is UNIT-TESTABLE (bead sq-90cv4 mandates regression tests over the gate's
+# verdict semantics), and extended with the ADAPTIVE SATURATION BUDGET described
+# below. The workflow header comment in ci-summary.yml remains the doctrine for WHY
+# the gate exists and what it aggregates; this file is the doctrine for HOW the loop
+# decides. Invoked by ci-summary.yml with env: REPO, SHA, SELF_RUN_ID (+ GH_TOKEN
+# for `gh`).
+#
+# SEMANTICS (faithful port of the bash — sq-prg4 / sq-ipkku / sq-wjth):
+#   * Discovers every check-run on the head commit EXCEPT this gate's own run
+#     (matched by an ANCHORED "/runs/<SELF_RUN_ID>(/|$)" test on details_url —
+#     strictly tighter than the old substring `contains`, which could in principle
+#     match a longer run id sharing the prefix).
+#   * pending = check-runs with status != "completed". The settle window is re-armed
+#     ONLY by pending work (the sq-ipkku / #997 guard): an injection of
+#     already-terminal check-runs can never starve convergence.
+#   * A verdict renders only when EVERY discovered sibling is terminal, never before
+#     the MIN_POLLS startup floor, and only after SETTLE_POLLS consecutive quiet
+#     polls. Verdict: advisory/informational-named checks (whole-word, case-
+#     insensitive) are EXCLUDED; a gating check passes iff its conclusion is
+#     success/skipped/neutral; an empty stable set passes.
+#   * Exhausting the loop budget with pending == 0 renders the REAL verdict on the
+#     final all-terminal set (the #997 graceful timeout), never a blind RED.
+#
+# ADAPTIVE SATURATION BUDGET (sq-90cv4). The gate is a WAITER occupying a runner
+# slot; under org-pool saturation many concurrent gates starve the very builds they
+# wait on, the base budget expires with siblings still QUEUED, and the old
+# unconditional `exit 1` emitted a FALSE RED on a PR whose real legs never got to
+# run (the 2026-07-02 congestion collapse; memory: reference-ci-congestion-collapse).
+# Runner saturation is a THROUGHPUT signal, not a hang. So: at base-budget
+# exhaustion with pending work, the gate now distinguishes:
+#   * STILL SETTLING — the repo's Actions queue is deep (queued workflow-run count
+#     >= SAT_QUEUE_MIN) OR sibling completions are still landing (completed count
+#     rose over the last PROGRESS_WINDOW polls). Keep polling, at the slower
+#     SAT_INTERVAL to cut API pressure, re-checking the signal each poll, up to the
+#     ABSOLUTE cap MAX_TOTAL_POLLS.
+#   * GENUINE HANG — pending work with an idle queue AND no recent completions.
+#     RED immediately (the old behaviour, now correctly scoped to real hangs).
+# The extension NEVER changes what a verdict says: exit 0 still happens ONLY via
+# render_verdict over an all-terminal set (or the stable-empty set), so a genuinely
+# failing leg still fails and nothing green is synthesised. The absolute cap +
+# the workflow-level timeout-minutes bound the wait — no infinite gate.
+#
+# FETCH-FAILURE TOLERANCE: the bash `set -e` turned ONE transient `gh api` blip
+# into a gate RED. A failed poll is now skipped (state untouched) and only
+# MAX_CONSEC_FETCH_FAILURES consecutive failures fail the gate. No data => no
+# verdict, so this cannot create a false pass.
+#
+# Exit-0 paths, exhaustively: (1) render_verdict over a stable-empty set;
+# (2) render_verdict over an all-terminal set with zero non-passing GATING checks.
+# There is no other `return 0`.
+#
+# Hermetic tests: scripts/tests/test_ci_summary_gate.py (stdlib-only unittest; no
+# network — fetchers are injected). Run: python3 scripts/tests/test_ci_summary_gate.py
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+
+ADVISORY_RE = re.compile(r"\b(advisory|informational)\b")
+_PASSING = ("success", "skipped", "neutral")
+
+
+@dataclass
+class Config:
+    """Loop tunables. Prod values mirror the previous inline bash (INTERVAL /
+    MIN_POLLS / SETTLE_POLLS / BASE_POLLS == the old 110-attempt cap) plus the
+    sq-90cv4 adaptive-extension knobs. Tests inject tiny values."""
+
+    self_run_id: str = ""
+    interval: int = 20          # seconds between polls (base phase)
+    min_polls: int = 3          # startup-race floor: no verdict before 3 polls
+    settle_polls: int = 2       # all-terminal must hold this many consecutive polls
+    base_polls: int = 110       # base budget: 110 x 20s ~= 37 min (the old hard cap)
+    sat_interval: int = 40      # slower poll cadence during the saturation extension
+    max_total_polls: int = 155  # absolute cap: 45 extension polls x 40s = +30 min
+    sat_queue_min: int = 5      # queued workflow-runs in the repo => saturation
+    progress_window: int = 15   # polls over which a completed-count rise = progress
+    max_consec_fetch_failures: int = 5
+    summary_path: str = field(default_factory=lambda: os.environ.get("GITHUB_STEP_SUMMARY", ""))
+
+
+class FetchError(RuntimeError):
+    """A poll's API fetch failed (transient or otherwise)."""
+
+
+def is_advisory(name: str) -> bool:
+    """Whole-word advisory/informational match (sq-wjth): excludes the standalone
+    words (hyphen-/paren-/comma-delimited too) but NOT substrings — notably
+    "cargo-deny (advisories, ...)" is plural and GATES."""
+    return bool(ADVISORY_RE.search(name.lower()))
+
+
+def is_self(run: dict, self_run_id: str) -> bool:
+    """True iff this check-run belongs to THIS gate's workflow run. Anchored to
+    /runs/<id>(/|$) so a longer sibling run id sharing the prefix can't match."""
+    if not self_run_id:
+        return False
+    url = run.get("details_url") or run.get("html_url") or ""
+    return bool(re.search(rf"/runs/{re.escape(self_run_id)}(/|$)", url))
+
+
+def _emit(line: str, summary_path: str = "") -> None:
+    print(line, flush=True)
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+
+
+def render_verdict(runs: list[dict], summary_path: str = "") -> int:
+    """Shared by the clean-converge, graceful-timeout, and post-extension paths, so
+    every path applies IDENTICAL gating semantics. Returns the process exit code."""
+    total = len(runs)
+    if total == 0:
+        _emit("ci-summary: no sibling checks to aggregate (stable empty set) — passing.", summary_path)
+        return 0
+    gating = [r for r in runs if not is_advisory(r.get("name", ""))]
+    excluded = total - len(gating)
+    failed = [r for r in gating if r.get("conclusion") not in _PASSING]
+    if failed:
+        _emit(
+            f"### ci-summary: FAILED — {len(failed)} non-passing gating check(s) of "
+            f"{len(gating)} gating ({excluded} advisory check(s) excluded)",
+            summary_path,
+        )
+        for r in failed:
+            _emit(f"- ✗ {r.get('name')}: {r.get('conclusion') or 'incomplete'}", summary_path)
+        print("::error::ci-summary failed — see the non-passing gating checks above.")
+        return 1
+    _emit(
+        f"### ci-summary: PASSED — all {len(gating)} gating check(s) green (or skipped/neutral); "
+        f"{excluded} advisory check(s) excluded; set stable.",
+        summary_path,
+    )
+    return 0
+
+
+def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep) -> int:
+    """The poll loop. `fetch_runs()` -> list of {name,status,conclusion,details_url}
+    dicts (raises FetchError on API failure); `fetch_queue_depth()` -> int queued
+    workflow-run count for the repo, or None when unknown (API failure — the gate
+    then falls back to the progress signal alone). Returns the exit code."""
+    prev_names: list[str] | None = None
+    stable = 0
+    runs: list[dict] = []
+    pending = 0
+    completed_hist: list[int] = []
+    consec_fetch_failures = 0
+    extension_started = False
+
+    attempt = 0
+    while attempt < cfg.max_total_polls:
+        attempt += 1
+        try:
+            raw = fetch_runs()
+        except FetchError as exc:
+            consec_fetch_failures += 1
+            if consec_fetch_failures >= cfg.max_consec_fetch_failures:
+                print(
+                    f"::error::ci-summary: {consec_fetch_failures} consecutive check-run "
+                    f"fetch failures — cannot observe the sibling set. Last error: {exc}"
+                )
+                return 1
+            print(
+                f"attempt {attempt}: check-run fetch failed ({exc}) — skipping this poll "
+                f"({consec_fetch_failures}/{cfg.max_consec_fetch_failures} consecutive)."
+            )
+            sleep_fn(cfg.sat_interval if extension_started else cfg.interval)
+            continue
+        consec_fetch_failures = 0
+
+        runs = [r for r in raw if not is_self(r, cfg.self_run_id)]
+        total = len(runs)
+        pending = sum(1 for r in runs if r.get("status") != "completed")
+        completed_hist.append(total - pending)
+        # Settle is a POST-TERMINAL window re-armed ONLY by pending work (sq-ipkku):
+        # already-terminal injections must not starve convergence.
+        stable = 0 if pending else stable + 1
+        names = sorted({r.get("name", "") for r in runs})
+        changed = " (name set changed)" if prev_names is not None and names != prev_names else ""
+        prev_names = names
+        print(
+            f"attempt {attempt}: {total} check-run(s), {pending} running, "
+            f"all-terminal stable for {stable}/{cfg.settle_polls} poll(s){changed}",
+            flush=True,
+        )
+
+        # Clean convergence: everything terminal, held for the settle, past the floor.
+        if attempt >= cfg.min_polls and pending == 0 and stable >= cfg.settle_polls:
+            return render_verdict(runs, cfg.summary_path)
+
+        # ADAPTIVE SATURATION BUDGET (sq-90cv4): at/after the base budget with work
+        # still pending, extend ONLY while the evidence says throughput-starvation
+        # (deep queue) or live progress — otherwise it's a genuine hang: RED.
+        if attempt >= cfg.base_polls and pending > 0:
+            progressing = (
+                len(completed_hist) > cfg.progress_window
+                and completed_hist[-1] > completed_hist[-1 - cfg.progress_window]
+            )
+            depth = fetch_queue_depth()
+            saturated = depth is not None and depth >= cfg.sat_queue_min
+            if not (saturated or progressing):
+                print(
+                    f"::error::ci-summary timed out — {pending} sibling check-run(s) never "
+                    f"finished within the base budget, the Actions queue is idle "
+                    f"(depth={depth if depth is not None else 'unknown'} < {cfg.sat_queue_min}) "
+                    f"and no completions landed in the last {cfg.progress_window} poll(s): "
+                    f"genuine hang, not a still-settling set. See the per-poll log above."
+                )
+                return 1
+            if not extension_started:
+                extension_started = True
+                print(
+                    f"::notice::ci-summary base budget reached with {pending} sibling(s) still "
+                    f"pending, but the runner pool shows saturation/progress "
+                    f"(queued runs={depth if depth is not None else 'unknown'}, "
+                    f"progressing={progressing}) — this is a throughput signal, not a hang. "
+                    f"Extending the wait (adaptive budget, sq-90cv4) up to poll "
+                    f"{cfg.max_total_polls}."
+                )
+            else:
+                print(
+                    f"  extension: queued runs={depth if depth is not None else 'unknown'}, "
+                    f"progressing={progressing} — still settling."
+                )
+            if attempt < cfg.max_total_polls:
+                sleep_fn(cfg.sat_interval)
+            continue
+
+        if attempt < cfg.max_total_polls:
+            sleep_fn(cfg.interval)
+
+    # Absolute budget exhausted.
+    if pending == 0:
+        # The #997 graceful timeout: everything IS terminal, we just never got a
+        # full quiet settle — render the real verdict, never a blind RED.
+        print(
+            "::notice::ci-summary loop budget reached with every sibling check terminal "
+            "(the set kept being injected into without a full quiet settle) — rendering "
+            "the verdict on the final all-terminal set."
+        )
+        return render_verdict(runs, cfg.summary_path)
+    print(
+        f"::error::ci-summary timed out — {pending} sibling check-run(s) never finished "
+        f"within the ABSOLUTE budget (base + saturation extension, sq-90cv4). The runner "
+        f"pool stayed saturated longer than the extension allows; re-run this gate once "
+        f"the queue drains. See the per-poll log above."
+    )
+    return 1
+
+
+# ----------------------------- live (gh-backed) wiring -----------------------------
+
+
+def _gh_json_lines(args: list[str]) -> list[dict]:
+    proc = subprocess.run(["gh", "api", *args], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise FetchError(proc.stderr.strip()[:300] or f"gh api exited {proc.returncode}")
+    out = []
+    for line in proc.stdout.splitlines():
+        line = line.strip()
+        if line:
+            out.append(json.loads(line))
+    return out
+
+
+def make_fetch_runs(repo: str, sha: str):
+    def fetch() -> list[dict]:
+        return _gh_json_lines(
+            [
+                f"repos/{repo}/commits/{sha}/check-runs",
+                "--paginate",
+                "--jq",
+                ".check_runs[] | {name, status, conclusion, details_url, html_url}",
+            ]
+        )
+
+    return fetch
+
+
+def make_fetch_queue_depth(repo: str):
+    """Queued workflow-run count for the repo — the saturation signal. Returns None
+    (unknown) on any failure so a permissions/API blip degrades to progress-only,
+    never crashes the gate. Needs `actions: read` on the workflow token."""
+
+    def fetch():
+        proc = subprocess.run(
+            [
+                "gh",
+                "api",
+                f"repos/{repo}/actions/runs?status=queued&per_page=1",
+                "--jq",
+                ".total_count",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode != 0:
+            print(f"  (queue-depth fetch failed: {proc.stderr.strip()[:200]} — treating as unknown)")
+            return None
+        try:
+            return int(proc.stdout.strip())
+        except ValueError:
+            return None
+
+    return fetch
+
+
+def main() -> int:
+    repo = os.environ.get("REPO", "")
+    sha = os.environ.get("SHA", "")
+    self_run_id = os.environ.get("SELF_RUN_ID", "")
+    if not repo or not sha or not self_run_id:
+        print("::error::ci-summary: REPO, SHA and SELF_RUN_ID must all be set.")
+        return 1
+    cfg = Config(self_run_id=self_run_id)
+    return run_gate(cfg, make_fetch_runs(repo, sha), make_fetch_queue_depth(repo))
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -205,7 +205,15 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep) ->
                 len(completed_hist) > cfg.progress_window
                 and completed_hist[-1] > completed_hist[-1 - cfg.progress_window]
             )
-            depth = fetch_queue_depth()
+            # [SONNET-4.6] Guard: if fetch_queue_depth() raises (e.g. subprocess.run
+            # raises inside the closure before returning None), treat depth as the
+            # "unknown" sentinel — never crash the gate, and never grant a saturation
+            # extension on depth alone (None → saturated = False, conservative branch).
+            try:
+                depth = fetch_queue_depth()
+            except Exception as exc:
+                print(f"  (queue-depth fetch raised {exc!r} — treating depth as unknown)")
+                depth = None
             saturated = depth is not None and depth >= cfg.sat_queue_min
             if not (saturated or progressing):
                 print(
@@ -261,7 +269,14 @@ def run_gate(cfg: Config, fetch_runs, fetch_queue_depth, sleep_fn=time.sleep) ->
 
 
 def _gh_json_lines(args: list[str]) -> list[dict]:
-    proc = subprocess.run(["gh", "api", *args], capture_output=True, text=True)
+    # [SONNET-4.6] Wrap subprocess.run so FileNotFoundError / TimeoutExpired / OSError
+    # (e.g. `gh` not on PATH) are converted into FetchError, routing them into the
+    # existing bounded-retry / skip-this-poll tolerance in run_gate exactly as a
+    # non-zero exit code does — no raw crash, no false pass.
+    try:
+        proc = subprocess.run(["gh", "api", *args], capture_output=True, text=True)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as exc:
+        raise FetchError(f"subprocess raised: {exc}") from exc
     if proc.returncode != 0:
         raise FetchError(proc.stderr.strip()[:300] or f"gh api exited {proc.returncode}")
     out = []

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -1,0 +1,286 @@
+#!/usr/bin/env python3
+# [FABLE-5] Hermetic unit tests for the ci-summary gate poll loop
+# (scripts/ci_summary_gate.py — bead sq-90cv4). Authored by Claude Fable 5.
+#
+# The bead's mandate: prove the ADAPTIVE SATURATION BUDGET preserves the gate's
+# real pass/fail semantics EXACTLY. The four load-bearing cases:
+#   (a) all-green                      => SUCCESS   (test_all_green_success)
+#   (b) real gating failure           => FAILURE   (test_real_failure_fails)
+#   (c) saturation w/ queued siblings => still-settling, NOT a false RED, and the
+#       eventual verdict is the REAL one (test_saturation_extension_then_green /
+#       test_failure_during_extension_still_fails)
+#   (d) genuine hang (no progress, idle queue) => FAILURE
+#       (test_genuine_hang_fails), and saturation-forever is BOUNDED: the absolute
+#       cap still REDs (test_saturation_forever_bounded_red) — the extension can
+#       never convert a real failure into a pass NOR wait forever.
+# Plus the pre-existing semantics that must not regress: the sq-ipkku/#997
+# terminal-injection settle guard + graceful timeout, the sq-wjth advisory
+# word-boundary exclusion, the anchored self-run exclusion, and the empty-set pass.
+#
+# Fully hermetic: fetchers are injected (no gh, no network, no sleep).
+# Run:  python3 scripts/tests/test_ci_summary_gate.py   (stdlib only; no pytest)
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import sys
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+sys.dont_write_bytecode = True  # keep repeated local runs hermetic (no stale .pyc)
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "ci_summary_gate.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("ci_summary_gate", SCRIPT)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["ci_summary_gate"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+g = _load_module()
+
+
+def R(name, status="completed", conclusion="success", url=""):
+    return {"name": name, "status": status, "conclusion": conclusion,
+            "details_url": url, "html_url": ""}
+
+
+GREEN = R("build + test")
+GREEN2 = R("clippy")
+PENDING = R("coverage", status="queued", conclusion=None)
+IN_PROGRESS = R("coverage", status="in_progress", conclusion=None)
+RED = R("clippy", conclusion="failure")
+
+
+def tiny_cfg(**over):
+    """Small budgets so the loop phases are reachable in a handful of polls:
+    base budget = 4 polls, absolute cap = 8, settle = 2, floor = 2."""
+    base = dict(self_run_id="999", interval=0, min_polls=2, settle_polls=2,
+                base_polls=4, sat_interval=0, max_total_polls=8,
+                sat_queue_min=5, progress_window=2, max_consec_fetch_failures=3,
+                summary_path="")
+    base.update(over)
+    return g.Config(**base)
+
+
+def scripted(polls, repeat_last=True):
+    """fetch_runs() stub: returns polls[i] on call i (an Exception instance is
+    raised instead); repeats the final entry once exhausted."""
+    state = {"i": 0, "calls": 0}
+
+    def fetch():
+        state["calls"] += 1
+        i = min(state["i"], len(polls) - 1) if repeat_last else state["i"]
+        state["i"] += 1
+        entry = polls[i]
+        if isinstance(entry, Exception):
+            raise entry
+        return list(entry)
+
+    fetch.state = state
+    return fetch
+
+
+def run(cfg, polls, depth=0):
+    """Drive run_gate with scripted polls + a constant queue depth (None = the
+    depth API is unavailable). Returns (exit_code, captured_output)."""
+    out = io.StringIO()
+    fetch = scripted(polls)
+
+    def depth_fn():
+        return depth
+
+    with redirect_stdout(out):
+        code = g.run_gate(cfg, fetch, depth_fn, sleep_fn=lambda s: None)
+    return code, out.getvalue()
+
+
+class TestVerdictSemantics(unittest.TestCase):
+    """The core pass/fail semantics — unchanged by the adaptive budget."""
+
+    def test_all_green_success(self):
+        code, out = run(tiny_cfg(), [[GREEN, GREEN2]])
+        self.assertEqual(code, 0)
+        self.assertIn("PASSED", out)
+
+    def test_real_failure_fails(self):
+        code, out = run(tiny_cfg(), [[GREEN, RED]])
+        self.assertEqual(code, 1)
+        self.assertIn("FAILED", out)
+        self.assertIn("clippy", out)
+
+    def test_skipped_and_neutral_pass(self):
+        runs = [R("docs", conclusion="skipped"), R("wasm", conclusion="neutral"), GREEN]
+        code, _ = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 0)
+
+    def test_empty_set_passes(self):
+        code, out = run(tiny_cfg(), [[]])
+        self.assertEqual(code, 0)
+        self.assertIn("stable empty set", out)
+
+    def test_advisory_failure_excluded(self):
+        runs = [R("vale (prose, advisory)", conclusion="failure"),
+                R("unsafe report (cargo-geiger, informational)", conclusion="failure"),
+                GREEN]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 0)
+        self.assertIn("2 advisory check(s) excluded", out)
+
+    def test_advisories_plural_still_gates(self):
+        # sq-wjth word boundary: "advisories" must NOT match the advisory rule.
+        runs = [R("cargo-deny (advisories, bans, licenses, sources)", conclusion="failure")]
+        code, _ = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1)
+
+    def test_incomplete_conclusion_fails(self):
+        # A terminal-status run with a null conclusion renders as "incomplete" and gates.
+        runs = [R("weird", conclusion=None)]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1)
+        self.assertIn("incomplete", out)
+
+
+class TestSettleAndGracefulTimeout(unittest.TestCase):
+    """The sq-ipkku settle guard + the #997 graceful timeout must not regress."""
+
+    def test_terminal_injection_does_not_starve_settle(self):
+        polls = [
+            [GREEN, PENDING],                    # pending holds the gate
+            [GREEN, R("coverage")],              # all terminal, stable=1
+            [GREEN, R("coverage"), R("late")],   # terminal INJECTION: stable=2 (no reset)
+        ]
+        code, out = run(tiny_cfg(), polls)
+        self.assertEqual(code, 0)
+        self.assertIn("PASSED", out)
+        self.assertNotIn("::error::", out)
+
+    def test_graceful_timeout_all_green_passes(self):
+        # pending flip-flops so a full quiet settle never happens; depth is HIGH so
+        # the pending polls past the base budget extend instead of hanging-RED; the
+        # ABSOLUTE budget then renders the real (green) verdict — the #997 fix.
+        flip = [[GREEN, PENDING], [GREEN, R("coverage")]] * 4
+        code, out = run(tiny_cfg(), flip, depth=20)
+        self.assertEqual(code, 0)
+        self.assertIn("rendering the verdict on the final all-terminal set", out)
+
+    def test_graceful_timeout_real_failure_still_fails(self):
+        flip = [[GREEN, PENDING], [GREEN, R("coverage")]] * 3 \
+            + [[GREEN, PENDING], [GREEN, R("coverage", conclusion="failure")]]
+        code, out = run(tiny_cfg(), flip, depth=20)
+        self.assertEqual(code, 1)
+        self.assertIn("FAILED", out)
+
+
+class TestAdaptiveSaturationBudget(unittest.TestCase):
+    """sq-90cv4: saturation extends, hangs RED, real verdicts are untouched."""
+
+    def test_saturation_extension_then_green(self):
+        # Siblings stay QUEUED through the base budget while the repo queue is deep
+        # (the congestion-collapse shape) — the gate must extend, then pass for real.
+        polls = [[GREEN, GREEN2, PENDING]] * 5 + [[GREEN, GREEN2, R("coverage")]]
+        code, out = run(tiny_cfg(), polls, depth=20)
+        self.assertEqual(code, 0)
+        self.assertIn("Extending the wait (adaptive budget", out)
+        self.assertIn("PASSED", out)
+        self.assertNotIn("::error::", out)
+
+    def test_genuine_hang_fails(self):
+        # Pending forever, idle queue, zero progress => RED at the base budget.
+        polls = [[GREEN, IN_PROGRESS]]
+        code, out = run(tiny_cfg(), polls, depth=0)
+        self.assertEqual(code, 1)
+        self.assertIn("genuine hang", out)
+
+    def test_saturation_forever_bounded_red(self):
+        # The extension is BOUNDED: perpetual saturation still REDs at the absolute
+        # cap — never an infinite wait, never a synthesized pass.
+        polls = [[GREEN, PENDING]]
+        code, out = run(tiny_cfg(), polls, depth=20)
+        self.assertEqual(code, 1)
+        self.assertIn("ABSOLUTE budget", out)
+
+    def test_failure_during_extension_still_fails(self):
+        # The adaptive budget must NEVER convert a real failure into a pass.
+        polls = [[GREEN, PENDING]] * 5 + [[GREEN, R("coverage", conclusion="failure")]]
+        code, out = run(tiny_cfg(), polls, depth=20)
+        self.assertEqual(code, 1)
+        self.assertIn("FAILED", out)
+
+    def test_progress_signal_extends_when_depth_unknown(self):
+        # Queue-depth API unavailable (None) but completions keep landing => the
+        # progress signal alone extends; the eventual verdict is real.
+        polls = [
+            [R("a"), R("b"), PENDING, R("d", status="queued", conclusion=None),
+             R("e", status="queued", conclusion=None), R("f", status="queued", conclusion=None)],
+            [R("a"), R("b"), R("coverage"), R("d", status="queued", conclusion=None),
+             R("e", status="queued", conclusion=None), R("f", status="queued", conclusion=None)],
+            [R("a"), R("b"), R("coverage"), R("d"),
+             R("e", status="queued", conclusion=None), R("f", status="queued", conclusion=None)],
+            [R("a"), R("b"), R("coverage"), R("d"), R("e"),
+             R("f", status="queued", conclusion=None)],
+            [R("a"), R("b"), R("coverage"), R("d"), R("e"), R("f")],
+        ]
+        code, out = run(tiny_cfg(), polls, depth=None)
+        self.assertEqual(code, 0)
+        self.assertIn("PASSED", out)
+
+    def test_no_progress_and_depth_unknown_is_a_hang(self):
+        # Unknown depth + flat completions must NOT extend forever: it REDs at the
+        # base budget exactly like the old behaviour (fail-closed on no evidence).
+        polls = [[GREEN, IN_PROGRESS]]
+        code, out = run(tiny_cfg(), polls, depth=None)
+        self.assertEqual(code, 1)
+        self.assertIn("genuine hang", out)
+
+
+class TestSelfExclusionAndFetch(unittest.TestCase):
+    def test_self_run_excluded_by_anchored_id(self):
+        me = R("gate", status="in_progress", conclusion=None,
+               url="https://github.com/o/r/actions/runs/999/job/1")
+        sibling = R("build + test", url="https://github.com/o/r/actions/runs/9991/job/2")
+        # Without the exclusion the pending self would deadlock the gate; with it,
+        # only the green sibling counts.
+        code, _ = run(tiny_cfg(), [[me, sibling]])
+        self.assertEqual(code, 0)
+
+    def test_anchoring_does_not_match_prefix_ids(self):
+        self.assertTrue(g.is_self({"details_url": "https://x/actions/runs/999/job/4"}, "999"))
+        self.assertTrue(g.is_self({"details_url": "https://x/actions/runs/999"}, "999"))
+        self.assertFalse(g.is_self({"details_url": "https://x/actions/runs/9991/job/4"}, "999"))
+        self.assertFalse(g.is_self({"html_url": "https://x/actions/runs/1999/job/4"}, "999"))
+        # html_url fallback when details_url is absent.
+        self.assertTrue(g.is_self({"html_url": "https://x/actions/runs/999/job/4"}, "999"))
+
+    def test_transient_fetch_failures_tolerated(self):
+        polls = [g.FetchError("blip"), g.FetchError("blip"), [GREEN], [GREEN]]
+        code, out = run(tiny_cfg(), polls)
+        self.assertEqual(code, 0)
+        self.assertIn("skipping this poll", out)
+
+    def test_persistent_fetch_failures_fail_closed(self):
+        polls = [g.FetchError("down")]
+        code, out = run(tiny_cfg(), polls)
+        self.assertEqual(code, 1)
+        self.assertIn("consecutive check-run fetch failures", out)
+
+
+class TestAdvisoryRule(unittest.TestCase):
+    def test_word_boundary_rule(self):
+        self.assertTrue(g.is_advisory("markdownlint-advisory (whole repo)"))
+        self.assertTrue(g.is_advisory("external-links (lychee online, advisory)"))
+        self.assertTrue(g.is_advisory("unsafe report (cargo-geiger, informational)"))
+        self.assertFalse(g.is_advisory("cargo-deny (advisories, bans, licenses, sources)"))
+        self.assertFalse(g.is_advisory("build + test"))
+        self.assertFalse(g.is_advisory("gate"))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -282,5 +282,108 @@ class TestAdvisoryRule(unittest.TestCase):
         self.assertFalse(g.is_advisory("gate"))
 
 
+# [SONNET-4.6] Robustness-hardening tests (sq-90cv4 follow-up: Copilot gaps).
+# Covers:
+#   (a) _gh_json_lines converts subprocess raises (FileNotFoundError, TimeoutExpired)
+#       → FetchError → routed into the existing bounded skip path, not a raw crash.
+#   (b) fetch_queue_depth raising in run_gate → depth treated as None (unknown) →
+#       NO saturation extension granted on depth alone (conservative branch).
+# Mutation check: removing either try/except causes the test to go RED (the
+# underlying exception propagates instead of being caught/re-raised as FetchError).
+class TestSubprocessRobustness(unittest.TestCase):
+    """[SONNET-4.6] subprocess raises in _gh_json_lines / fetch_queue_depth must be
+    converted to graceful-degradation paths, never raw crashes."""
+
+    def test_gh_json_lines_file_not_found_raises_fetch_error(self):
+        """FileNotFoundError (gh not on PATH) must surface as FetchError so the
+        caller's FetchError handler (bounded retry / skip-this-poll) applies."""
+        from unittest.mock import patch
+        with patch("subprocess.run", side_effect=FileNotFoundError("gh: not found")):
+            with self.assertRaises(g.FetchError) as ctx:
+                g._gh_json_lines(["repos/x/y"])
+        self.assertIn("subprocess raised", str(ctx.exception))
+
+    def test_gh_json_lines_timeout_raises_fetch_error(self):
+        """TimeoutExpired must also surface as FetchError (same bounded-retry path)."""
+        from unittest.mock import patch
+        import subprocess as _sp
+        with patch("subprocess.run", side_effect=_sp.TimeoutExpired("gh", 30)):
+            with self.assertRaises(g.FetchError):
+                g._gh_json_lines(["repos/x/y"])
+
+    def test_subprocess_raise_routed_into_skip_tolerance(self):
+        """A FileNotFoundError inside _gh_json_lines → FetchError → treated as a
+        skipped poll (not a gate crash).  Two such errors then a green poll must pass
+        (within the 3-failure tolerance of tiny_cfg)."""
+        # Simulate _gh_json_lines raising FetchError (as it does after the fix for
+        # FileNotFoundError) for the first two calls, then returning [GREEN].
+        call_count = {"n": 0}
+
+        def fake_fetch():
+            n = call_count["n"]
+            call_count["n"] += 1
+            if n < 2:
+                raise g.FetchError("subprocess raised: gh: not found")
+            return [dict(GREEN)]
+
+        out = io.StringIO()
+
+        def depth_fn():
+            return 0
+
+        with redirect_stdout(out):
+            code = g.run_gate(tiny_cfg(), fake_fetch, depth_fn, sleep_fn=lambda s: None)
+        output = out.getvalue()
+        self.assertEqual(code, 0)
+        self.assertIn("skipping this poll", output)
+        self.assertIn("PASSED", output)
+
+    def test_fetch_queue_depth_raises_treated_as_unknown_no_extension(self):
+        """When fetch_queue_depth() RAISES (subprocess spawn error inside the closure),
+        run_gate must catch it, treat depth as None (unknown), and NOT grant a
+        saturation extension — unknown depth with no progress is a genuine hang → RED.
+        Mutation check: remove the try/except in run_gate → RuntimeError propagates
+        instead of being caught → this test goes RED."""
+        out = io.StringIO()
+        fetch = scripted([[GREEN, IN_PROGRESS]])
+
+        def raising_depth():
+            raise RuntimeError("subprocess.run raised: gh not found")
+
+        with redirect_stdout(out):
+            code = g.run_gate(tiny_cfg(), fetch, raising_depth, sleep_fn=lambda s: None)
+        output = out.getvalue()
+        self.assertEqual(code, 1, "unknown-depth + no-progress must be a genuine hang RED")
+        self.assertIn("genuine hang", output)
+        self.assertNotIn("Extending the wait", output)
+
+    def test_fetch_queue_depth_raises_progress_still_extends(self):
+        """Unknown depth (depth_fn raises) does NOT block the progress-signal path:
+        if completions are landing the gate still extends (progress alone suffices)."""
+        # Six polls with decreasing pending; completions rising → progress=True.
+        # depth_fn always raises (unknown). Verify extension activates then passes.
+        polls = [
+            [R("a"), R("b"), PENDING, R("d", status="queued", conclusion=None),
+             R("e", status="queued", conclusion=None), R("f", status="queued", conclusion=None)],
+            [R("a"), R("b"), R("coverage"), R("d", status="queued", conclusion=None),
+             R("e", status="queued", conclusion=None), R("f", status="queued", conclusion=None)],
+            [R("a"), R("b"), R("coverage"), R("d"),
+             R("e", status="queued", conclusion=None), R("f", status="queued", conclusion=None)],
+            [R("a"), R("b"), R("coverage"), R("d"), R("e"),
+             R("f", status="queued", conclusion=None)],
+            [R("a"), R("b"), R("coverage"), R("d"), R("e"), R("f")],
+        ]
+        out = io.StringIO()
+        fetch = scripted(polls)
+
+        def raising_depth():
+            raise RuntimeError("depth API down")
+
+        with redirect_stdout(out):
+            code = g.run_gate(tiny_cfg(), fetch, raising_depth, sleep_fn=lambda s: None)
+        self.assertEqual(code, 0)
+        self.assertIn("PASSED", out.getvalue())
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5 — served tier grep-verified `claude-fable-5` on all turns) — bead **sq-90cv4**. This PR touches the merge-critical required check; per the brief it is **NOT self-armed** — route through independent Opus adversarial verification before arming.

## Problem

`ci-summary / gate` — the single REQUIRED branch-protection check — is a *waiter*: it polls every sibling check-run while occupying a hosted-runner slot. Under load, many concurrent gates starve the very builds they wait on; the base budget then expires with siblings still **queued** and the old unconditional timeout emitted a **false `gate=FAILURE`** on PRs whose real legs were green/pending (the 2026-07-02 congestion collapse — observed as `gate=FAILURE` with 120+ legs SUCCESS and a few IN_PROGRESS).

## The adaptive-budget mechanism (the lowest-risk increment from the bead's options)

Runner saturation is a **throughput** signal, not a hang. At base-budget exhaustion (~37 min, unchanged) with work still pending, the loop now classifies:

- **Still settling** — the repo's Actions queue is deep (queued workflow-run count ≥ 5, via a new read-only `actions: read` permission) **or** sibling completions landed within the last 15 polls → keep polling at a slower cadence (40s, halving API pressure), re-checking the signal each poll, up to a hard **absolute cap** (+~30 min; job `timeout-minutes` 45→80 to cover it).
- **Genuine hang** — pending work with an idle queue **and** no recent completions → RED immediately (the old behaviour, now correctly scoped to real hangs). A queue-depth API failure degrades to the progress signal alone — no-evidence still fails closed.

## Semantics-preservation argument

`exit 0` is reachable **only** via (1) the stable-empty set, or (2) `render_verdict` over an **all-terminal** sibling set with zero non-passing gating checks — both pre-existing paths, untouched by the extension. The extension only ever adds *waiting*; it never renders early and never synthesizes a conclusion, so a genuinely failing leg fails identically before/during/after an extension, and the absolute cap + job timeout make an infinite wait impossible. The #997 graceful-timeout guard, the sq-ipkku settle re-arm rule, and the sq-wjth advisory word-boundary exclusion are ported verbatim and now unit-pinned. One strict tightening: run-id self-exclusion is now anchored to `/runs/<id>(/|$)` (the old `contains` could in principle prefix-match a longer run id). One robustness addition: a transient `gh api` blip no longer REDs the gate (bounded at 5 consecutive failures, then fail-closed).

## Structure

- **`scripts/ci_summary_gate.py`** — the poll loop + verdict, extracted from the inline bash so it is unit-testable (the bead mandates it). `ci-summary.yml` keeps the doctrine header and now sparse-checkouts just this script (same trust model: on `pull_request` the workflow file itself already comes from the merge ref).
- **`scripts/tests/test_ci_summary_gate.py`** — 21 hermetic stdlib tests (no gh/network/sleep; injected fetchers), wired **HARD** into docs-quality.yml's `ci-scripts` job. The four bead-mandated cases, all validated:
  1. all-green → **SUCCESS**
  2. real gating failure → **FAILURE** (also: during extension, at graceful timeout, plural "advisories" still gates)
  3. saturation-with-queued-siblings → **still-settling**, then the *real* verdict
  4. genuine hang (no progress, idle queue) → **FAILURE**; saturation-forever → **bounded RED** at the absolute cap
- **Mutation-checked** (3 mutations, each made the suite go red, then reverted): flipped the real-failure test expectation (1 failure), neutered the genuine-hang branch (2 failures), flipped the failing-verdict return (5 failures).

## Validation on real data

- Live green path: script run with real `gh` fetchers against `origin/main` head — 288 check-runs discovered, 277 gating, 11 advisory excluded, **PASSED, exit 0**.
- Live failure path: against a commit with a genuinely failed check — **FAILED, exit 1**, naming `cargo-vet (per-dependency audit attestations)`.
- `yaml.safe_load` + `actionlint` clean on both workflows; `ruff` clean on both Python files; typos/no-perf-numbers/privacy-claims/terminology/markdownlint gates all pass locally.

## Gate-aggregator integrity

The check name (`ci-summary / gate`), triggers (`pull_request`/`merge_group`/`push: main`), concurrency group, and self-exclusion are unchanged — branch protection still sees the same required check, and this leg contains no advisory token so it still gates. The only permission delta is read-only `actions: read`. The `actions/checkout` addition is SHA-pinned (`9c091bb2… # v7.0.0`, the repo's standard pin). In the normal (unsaturated) case the gate converges exactly as fast as before — the extension activates only at base-budget exhaustion under an observed saturated/progressing queue.

## Deferred deeper fix

Moving the waiter **off** the build-runner slot entirely (event-driven `workflow_run` evaluation publishing a commit status; no resident poller) is design-recorded in `research/ci-gate-slotless-aggregation.md` and tracked as follow-up bead **sq-lfmvd** — it requires a staged required-check migration (maintainer ruleset edit), so it was not attempted here per the bead's risk disposition. No org/runner config is needed for *this* PR (`needs_maintainer=false`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)