### PR TITLE
feat(gui-e2e): Playwright mocked-IPC desktop lane (sq-ymr2e.5) [SONNET-4.6]

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -242,6 +242,81 @@ jobs:
         working-directory: gui/app
         run: npm run build:tauri
 
+  # [SONNET-4.6] sq-ymr2e.5 — Playwright mocked-IPC deterministic desktop lane.
+  #
+  # Drives the GUI FRONTEND (gui/app/out, the Tauri-target static export) in headless Chromium
+  # with window.__TAURI__ + window.__TAURI_INTERNALS__ stubbed via page.addInitScript.  No Tauri
+  # binary, no display server, no real IPC — fully deterministic.
+  #
+  # GATING (no `advisory` keyword): unlike the tauri-driver e2e (which needs webkit2gtk + a
+  # headless webview and keeps `advisory` for runner-image reliability), this lane is pure
+  # Playwright + Chromium on ubuntu-latest — reproducible on every Linux CI runner.  It is the
+  # deterministic, promotable gate for the GUI frontend and is intended to become a required
+  # branch-protection context (bead sq-ymr2e.5 → sq-var9 promotion sequence).
+  #
+  # PATH SCOPE: gui/** + packages/** (changes to the shared @sparq/client can affect the frontend).
+  # The job is NOT in the `merge_group` event (ci-summary.yml cannot cross-workflow `needs:`); it
+  # participates in the `ci-summary / gate` aggregator by name (no advisory token).
+  gui-mock-ipc:
+    name: "GUI Playwright mocked-IPC lane"
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Cache cargo
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: gui-mock-ipc-wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      # The in-tab WASM engine (shacl,jsonld bundle) is required for queries to run in the browser.
+      - name: Build WASM bundle (shacl,jsonld)
+        working-directory: js
+        run: npm run build:wasm
+
+      # The W-reason bundle enables live RDFS / OWL 2 RL inference in the browser — needed for
+      # the inference-toggle journey to reach "ready" rather than "reasoner unavailable".
+      - name: Build W-reason WASM bundle (RDFS / OWL 2 RL reasoner)
+        working-directory: js
+        run: npm run build:reason-wasm
+
+      - name: Install workspace dependencies
+        run: npm install
+
+      # Build the Tauri-target static export (root-relative; the Playwright server serves it).
+      - name: Build GUI frontend static export (Tauri target → gui/app/out/)
+        working-directory: gui/app
+        run: npm run build:tauri
+
+      # Install only the Chromium browser binary (the mock-IPC lane uses only Chromium).
+      - name: Install Playwright Chromium
+        working-directory: gui/e2e-playwright
+        run: npx playwright install --with-deps chromium
+
+      # No-timeout gate: forbids waitForTimeout in specs/ + support/ (determinism doctrine §1.1).
+      - name: Determinism gate — no waitForTimeout
+        working-directory: gui/e2e-playwright
+        run: bash support/no-timeout-gate.sh
+
+      - name: Run Playwright mocked-IPC tests
+        working-directory: gui/e2e-playwright
+        run: npm test
+
   # [OPUS-4.8] sq-bu69 — per-platform Tauri build + clippy matrix.
   #
   # ADVISORY (see the header): every matrix row's NAME carries the `advisory` keyword, so the

--- a/gui/e2e-playwright/package.json
+++ b/gui/e2e-playwright/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "sparq-gui-e2e-playwright",
+  "version": "0.0.0",
+  "private": true,
+  "description": "[SONNET-4.6] sq-ymr2e.5 — Playwright mocked-IPC deterministic desktop lane: 5 journeys driving gui/app/out in headless Chromium with window.__TAURI__ + __TAURI_INTERNALS__ stubbed. No Tauri binary, no display server, fully hermetic — intended as the required gate for the GUI frontend.",
+  "type": "module",
+  "scripts": {
+    "test": "playwright test",
+    "test:headed": "playwright test --headed",
+    "typecheck": "tsc --noEmit",
+    "no-timeout-gate": "bash support/no-timeout-gate.sh"
+  },
+  "engines": {
+    "node": ">=18.20.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.61.0",
+    "@types/node": "^22.10.0",
+    "typescript": "^5.7.0"
+  }
+}

--- a/gui/e2e-playwright/package.json
+++ b/gui/e2e-playwright/package.json
@@ -16,6 +16,7 @@
   "devDependencies": {
     "@playwright/test": "^1.61.0",
     "@types/node": "^22.10.0",
+    "serve": "14.2.6",
     "typescript": "^5.7.0"
   }
 }

--- a/gui/e2e-playwright/playwright.config.ts
+++ b/gui/e2e-playwright/playwright.config.ts
@@ -32,7 +32,9 @@ export default defineConfig({
 
   use: {
     baseURL: "http://127.0.0.1:3007",
-    trace: "on-first-retry",
+    // [SONNET-4.6] retain-on-failure: with retries=0, "on-first-retry" never fires → no trace
+    // ever captured. retain-on-failure emits a trace for every failed test regardless of retries.
+    trace: "retain-on-failure",
     viewport: { width: 1280, height: 720 },
     colorScheme: "dark",
     timezoneId: "UTC",
@@ -59,7 +61,10 @@ export default defineConfig({
   // already installed). Using `npm run serve` via a package.json script would also work; npx
   // is simpler (single config change, no extra script entry). [SONNET-4.6] sq-ymr2e.5 fix.
   webServer: {
-    command: "npx serve -l 3007 -s ../app/out",
+    // [SONNET-4.6] --no-install: fails CLOSED if serve is not already installed rather than
+    // fetching from the registry. serve is a pinned devDependency so it WILL be present after
+    // `npm install`; --no-install makes the dependency on that being true explicit + hermetic.
+    command: "npx --no-install serve -l 3007 -s ../app/out",
     url: "http://127.0.0.1:3007",
     reuseExistingServer: !process.env.CI,
     timeout: 15_000,

--- a/gui/e2e-playwright/playwright.config.ts
+++ b/gui/e2e-playwright/playwright.config.ts
@@ -52,10 +52,14 @@ export default defineConfig({
 
   // Serves gui/app/out (the Tauri-target static export).  -s = SPA mode so every route
   // resolves to index.html (required for Next.js static export with client-side routing).
-  // [SONNET-4.6] serve is a pinned devDependency (14.2.6) so npm ci installs it offline;
-  // the local binary is used directly to avoid any npx network fetch in CI.
+  // [SONNET-4.6] serve is a pinned devDependency (14.2.6) in this workspace member.
+  // gui/e2e-playwright is an npm workspace member so `serve` is HOISTED to the repo-root
+  // node_modules/.bin — it does NOT exist at ./node_modules/.bin/serve. `npx serve` resolves
+  // the hoisted binary via npm's node_modules hierarchy walk with NO network fetch (the dep is
+  // already installed). Using `npm run serve` via a package.json script would also work; npx
+  // is simpler (single config change, no extra script entry). [SONNET-4.6] sq-ymr2e.5 fix.
   webServer: {
-    command: "./node_modules/.bin/serve -l 3007 -s ../app/out",
+    command: "npx serve -l 3007 -s ../app/out",
     url: "http://127.0.0.1:3007",
     reuseExistingServer: !process.env.CI,
     timeout: 15_000,

--- a/gui/e2e-playwright/playwright.config.ts
+++ b/gui/e2e-playwright/playwright.config.ts
@@ -1,0 +1,61 @@
+// [SONNET-4.6] sq-ymr2e.5 — Playwright config for the GUI mocked-IPC deterministic lane.
+//
+// Drives gui/app/out (the Next.js static export) in headless Chromium.  window.__TAURI__ +
+// window.__TAURI_INTERNALS__ are stubbed by the auto-fixture in support/fixtures.ts via
+// page.addInitScript (the withGlobalTauri injection pattern from research/web-gui-test-program.md
+// §5). The in-tab WASM engine (queries / inference) is NOT mocked — it runs for real.
+//
+// Design rules (§1 determinism doctrine):
+//   - NO waitForTimeout — web-first assertions only
+//   - 0 retries — flakes are fixed not hidden
+//   - 1 worker — serial execution for determinism
+//   - External network blocked per test (hermetic)
+//   - Stable selectors: role/data-* only, never CSS classes
+//   - Timing values (ms, row counts) never asserted exactly — only presence checks
+
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./specs",
+
+  // WASM instantiation can be slow; give each assertion generous room.
+  timeout: 120_000,
+  expect: { timeout: 90_000 },
+
+  // Determinism doctrine §1.1 — 0 retries: a flaky test is a broken test.
+  retries: 0,
+  // Serial execution keeps results deterministic across the shared WASM tab.
+  workers: 1,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  reporter: process.env.CI ? [["github"], ["list"]] : [["list"]],
+
+  use: {
+    baseURL: "http://127.0.0.1:3007",
+    trace: "on-first-retry",
+    viewport: { width: 1280, height: 720 },
+    colorScheme: "dark",
+    timezoneId: "UTC",
+    locale: "en-US",
+    contextOptions: { reducedMotion: "reduce" },
+  },
+
+  projects: [
+    {
+      name: "chromium-mock-ipc",
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+  ],
+
+  // Serves gui/app/out (the Tauri-target static export).  -s = SPA mode so every route
+  // resolves to index.html (required for Next.js static export with client-side routing).
+  webServer: {
+    command: "npx serve -l 3007 -s ../app/out",
+    url: "http://127.0.0.1:3007",
+    reuseExistingServer: !process.env.CI,
+    timeout: 15_000,
+  },
+});

--- a/gui/e2e-playwright/playwright.config.ts
+++ b/gui/e2e-playwright/playwright.config.ts
@@ -52,8 +52,10 @@ export default defineConfig({
 
   // Serves gui/app/out (the Tauri-target static export).  -s = SPA mode so every route
   // resolves to index.html (required for Next.js static export with client-side routing).
+  // [SONNET-4.6] serve is a pinned devDependency (14.2.6) so npm ci installs it offline;
+  // the local binary is used directly to avoid any npx network fetch in CI.
   webServer: {
-    command: "npx serve -l 3007 -s ../app/out",
+    command: "./node_modules/.bin/serve -l 3007 -s ../app/out",
     url: "http://127.0.0.1:3007",
     reuseExistingServer: !process.env.CI,
     timeout: 15_000,

--- a/gui/e2e-playwright/specs/export-contract.spec.ts
+++ b/gui/e2e-playwright/specs/export-contract.spec.ts
@@ -1,0 +1,62 @@
+// [SONNET-4.6] sq-ymr2e.5 — export-contract journey: dataset export format menu + download.
+//
+// Exercises ExportDataMenu (gui/app/src/components/workbench/store-export.tsx):
+//   * The rail export trigger is enabled once the engine is ready with a non-empty store.
+//   * Clicking it opens a dropdown with Turtle / TriG / JSON-LD format options.
+//   * Selecting a format triggers a browser download (downloadText creates a Blob URL anchor).
+//
+// Stable selectors:
+//   [data-export-trigger="rail"]   — the "Export data…" button in the left rail
+//   [data-export-format="turtle"]  — Turtle format item in the dropdown
+//   [data-export-format="trig"]    — TriG format item
+//   [data-export-format="jsonld"]  — JSON-LD format item
+//   [data-export-menu]             — the open dropdown content
+//
+// The download is detected by Playwright's `page.waitForEvent('download')`, which fires when
+// downloadText's synthetic anchor click starts a blob: URL download.
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only; never assert file content size.
+
+import { test, expect } from "../support/index.ts";
+
+test.describe("export-contract", () => {
+  test("export trigger is present and enabled after engine ready with non-empty store", async ({
+    page,
+  }) => {
+    // The engine-context loads the sample graph on mount; by the time engine ready fires, the
+    // store has 4 persons (21 quads).  ExportDataMenu disables the trigger when storeSize === 0.
+    const exportTrigger = page.locator('[data-export-trigger="rail"]');
+    await expect(exportTrigger).toBeVisible();
+    // The trigger is enabled because the store is non-empty.
+    await expect(exportTrigger).toBeEnabled();
+  });
+
+  test("export menu shows format options", async ({ page }) => {
+    const exportTrigger = page.locator('[data-export-trigger="rail"]');
+    await expect(exportTrigger).toBeEnabled();
+
+    // Open the dropdown.
+    await exportTrigger.click();
+
+    // All three export formats must be present in the open menu.
+    await expect(page.locator('[data-export-format="turtle"]')).toBeVisible();
+    await expect(page.locator('[data-export-format="trig"]')).toBeVisible();
+    await expect(page.locator('[data-export-format="jsonld"]')).toBeVisible();
+  });
+
+  test("selecting Turtle triggers a browser download", async ({ page }) => {
+    const exportTrigger = page.locator('[data-export-trigger="rail"]');
+    await expect(exportTrigger).toBeEnabled();
+    await exportTrigger.click();
+
+    // Set up the download listener BEFORE clicking the format item.
+    const downloadPromise = page.waitForEvent("download");
+    await page.locator('[data-export-format="turtle"]').click();
+
+    // Playwright detects the blob: URL anchor click that downloadText triggers.
+    const download = await downloadPromise;
+
+    // The filename is "dataset.ttl" (exportFilename("turtle") from rdf-format.ts).
+    expect(download.suggestedFilename()).toBe("dataset.ttl");
+  });
+});

--- a/gui/e2e-playwright/specs/inference-toggle.spec.ts
+++ b/gui/e2e-playwright/specs/inference-toggle.spec.ts
@@ -1,0 +1,63 @@
+// [SONNET-4.6] sq-ymr2e.5 — inference-toggle journey: mode selector aria-pressed + status chip.
+//
+// Exercises the InferenceControl component (gui/app/src/components/workbench/inference-control.tsx):
+//   * Off (default) → RDFS: aria-pressed changes, a status chip appears.
+//   * Status chip settles to either "ready" (+N entailed) or "error" (reasoner unavailable).
+//   * RDFS → Off: chip disappears (InferenceStatusPill returns null when mode is "off").
+//
+// Stable selectors:
+//   [data-inference-mode="off"]    — the Off toggle button
+//   [data-inference-mode="rdfs"]   — the RDFS toggle button
+//   [data-inference-control]       — the toggle group container
+//   [data-inference-status]        — the live status chip (loading / ready / error)
+//   [data-inference-status="loading"] / ["ready"] / ["error"]
+//
+// The W-reason WASM bundle may or may not be present in the test build.  The test asserts the
+// presence of a status chip and that it eventually settles — it does NOT assert the exact state
+// (ready vs error).  Both outcomes are valid depending on the build.
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only.
+
+import { test, expect } from "../support/index.ts";
+
+test.describe("inference-toggle", () => {
+  test("toggle Off → RDFS changes aria-pressed and shows a status chip", async ({ page }) => {
+    // Initial state: Off is active (aria-pressed="true"), RDFS is inactive.
+    const offBtn = page.locator('[data-inference-mode="off"]');
+    const rdfsBtn = page.locator('[data-inference-mode="rdfs"]');
+
+    await expect(offBtn).toBeVisible();
+    await expect(rdfsBtn).toBeVisible();
+
+    await expect(offBtn).toHaveAttribute("aria-pressed", "true");
+    await expect(rdfsBtn).toHaveAttribute("aria-pressed", "false");
+
+    // ── Switch to RDFS ──────────────────────────────────────────────────────────────────────
+    await rdfsBtn.click();
+
+    // The toggle selection must flip immediately.
+    await expect(rdfsBtn).toHaveAttribute("aria-pressed", "true");
+    await expect(offBtn).toHaveAttribute("aria-pressed", "false");
+
+    // A status chip appears (loading → then either ready or error).
+    const statusChip = page.locator("[data-inference-status]");
+    await expect(statusChip).toBeVisible();
+
+    // Wait for the chip to settle out of "loading" (the reasoner either produces a closure
+    // or reports unavailable — both are valid in a test build).
+    // We wait for a non-loading state by polling for either ready or error.
+    await expect(
+      page.locator('[data-inference-status="ready"], [data-inference-status="error"]'),
+    ).toBeVisible({ timeout: 60_000 });
+
+    // ── Restore to Off ──────────────────────────────────────────────────────────────────────
+    await offBtn.click();
+
+    // Off is active again.
+    await expect(offBtn).toHaveAttribute("aria-pressed", "true");
+    await expect(rdfsBtn).toHaveAttribute("aria-pressed", "false");
+
+    // The chip is removed from the DOM (InferenceStatusPill returns null when mode is "off").
+    await expect(page.locator("[data-inference-status]")).not.toBeAttached({ timeout: 10_000 });
+  });
+});

--- a/gui/e2e-playwright/specs/keyboard-spine.spec.ts
+++ b/gui/e2e-playwright/specs/keyboard-spine.spec.ts
@@ -1,0 +1,59 @@
+// [SONNET-4.6] sq-ymr2e.5 — keyboard-spine journey: Ctrl+Enter runs the query; Ctrl-K opens
+// the command palette.
+//
+// Exercises two keyboard paths wired in query-workbench.tsx + command-palette.tsx:
+//
+//   Ctrl+Enter (⌘↵) — the onKeyDown handler on the SPARQL editor textarea; same path as the
+//                      Run query button.  Fires onRun("run") when metaKey || ctrlKey + Enter.
+//
+//   Ctrl-K / ⌘K    — the global keydown listener in CommandPaletteProvider; toggles the
+//                     command palette dialog open/closed.
+//
+// Stable selectors:
+//   #repl-query                        — the SPARQL editor textarea (id in sparql-editor.tsx)
+//   button "Run query"                 — the run button (text match)
+//   [data-result-kind="select"]        — a successful SELECT result
+//   [data-result-kind="error"]         — an engine-rejected query
+//   dialog / [role="dialog"]           — the command palette dialog (Radix UI DialogContent)
+//   DialogPrimitive.Title "Command palette" (sr-only) — the accessible dialog title
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only.
+
+import { test, expect } from "../support/index.ts";
+
+test.describe("keyboard-spine", () => {
+  test("Ctrl+Enter runs the current query (same effect as clicking Run query)", async ({
+    page,
+  }) => {
+    // Focus the SPARQL editor by clicking it.
+    const editor = page.locator("#repl-query");
+    await expect(editor).toBeVisible();
+    await editor.click();
+
+    // Press Ctrl+Enter — the onKeyDown handler in WorkbenchSparqlEditor calls e.preventDefault()
+    // then onRun("run").
+    await page.keyboard.press("Control+Enter");
+
+    // The query should run and show a result (either select or error depending on parse success).
+    await expect(
+      page.locator('[data-result-kind="select"], [data-result-kind="error"]'),
+    ).toBeVisible();
+  });
+
+  test("Ctrl-K opens the command palette dialog", async ({ page }) => {
+    // The global keydown listener on `document` intercepts Ctrl-K and toggles the palette.
+    await page.keyboard.press("Control+k");
+
+    // Radix UI DialogContent renders a [role="dialog"] element.
+    // The accessible title "Command palette" is rendered as an sr-only element inside the dialog.
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+
+    // The accessible title text is present (even though it is visually hidden).
+    await expect(page.getByText("Command palette", { exact: true })).toBeAttached();
+
+    // Pressing Escape closes the palette (Radix UI handles this natively).
+    await page.keyboard.press("Escape");
+    await expect(dialog).not.toBeVisible();
+  });
+});

--- a/gui/e2e-playwright/specs/status-bar.spec.ts
+++ b/gui/e2e-playwright/specs/status-bar.spec.ts
@@ -1,0 +1,69 @@
+// [SONNET-4.6] sq-ymr2e.5 — status-bar journey: latency/rows presence + mocked disk gauge.
+//
+// Exercises StatusBar (gui/app/src/components/workbench/status-bar.tsx):
+//
+//   1. After a query run: the status bar shows "X.Y ms" (latency) and "N rows" (row count).
+//      Presence-checked only — never assert exact values (wall-clock is non-canonical).
+//
+//   2. Disk gauge: the mocked disk_usage IPC returns { bytes: 12345678, exists: true } on mount,
+//      so the status bar should show [data-disk-source="os"] (OS-reported figure) and the label
+//      "disk" (not "≈disk").  The PRESENCE of the gauge is the assertion, not the byte count.
+//
+//   3. Backend label: the backend chip shows "backend:" followed by a resolved state.
+//
+// Stable selectors:
+//   footer.sq-statusbar          — the status bar footer element
+//   [data-status-disk]           — the disk gauge span
+//   [data-disk-source="os"]      — attribute set when diskBytes comes from the native probe
+//   [data-status-ingest]         — the ingest meter (only while an import is in progress)
+//
+// Determinism rules: NO waitForTimeout; presence-only assertions (never specific ms/byte values).
+
+import { test, expect } from "../support/index.ts";
+
+test.describe("status-bar", () => {
+  test("status bar is visible on load", async ({ page }) => {
+    // The status bar is always present (mounted in the workbench shell).
+    const statusBar = page.locator("footer.sq-statusbar");
+    await expect(statusBar).toBeVisible();
+  });
+
+  test("after query run, latency and row count are shown in the status bar", async ({ page }) => {
+    // Run the default query.
+    const runBtn = page.getByRole("button", { name: "Run query" });
+    await runBtn.click();
+
+    // Wait for the result.
+    await expect(page.locator('[data-result-kind="select"]')).toBeVisible();
+
+    const statusBar = page.locator("footer.sq-statusbar");
+
+    // The status bar shows "X.Y ms" — presence-check the "ms" unit, never the numeric value.
+    await expect(statusBar.getByText(/\d+(\.\d+)?\s*ms/)).toBeVisible();
+
+    // The row count shows "N rows" — presence only.
+    await expect(statusBar.getByText(/\d[\d,]*\s*rows/)).toBeVisible();
+  });
+
+  test("disk gauge is present and OS-reported (mocked disk_usage returns bytes)", async ({
+    page,
+  }) => {
+    // The engine-context calls nativeDiskUsage() on mount (disk_usage IPC).
+    // The mock returns { bytes: 12345678, exists: true } → osReported = true.
+    // StatusBar sets data-disk-source="os" and shows "disk" (not "≈disk").
+    const diskGauge = page.locator("[data-status-disk]");
+    await expect(diskGauge).toBeVisible();
+
+    // The OS-reported attribute must be set (not "estimate").
+    await expect(page.locator('[data-disk-source="os"]')).toBeVisible();
+
+    // The gauge label is "disk" (without the ≈ prefix used for estimates).
+    await expect(diskGauge).toContainText("disk");
+  });
+
+  test("backend label is visible in the status bar", async ({ page }) => {
+    const statusBar = page.locator("footer.sq-statusbar");
+    // The backend span shows "backend: <state>" — presence-check the "backend:" text.
+    await expect(statusBar.getByText(/backend:/)).toBeVisible();
+  });
+});

--- a/gui/e2e-playwright/specs/workbench-query.spec.ts
+++ b/gui/e2e-playwright/specs/workbench-query.spec.ts
@@ -1,0 +1,100 @@
+// [SONNET-4.6] sq-ymr2e.5 — workbench-query journey: SPARQL editor run/error/pagination.
+//
+// Exercises the Query Workbench (gui/app/src/components/workbench/query-workbench.tsx) end-to-end
+// with the in-tab WASM engine running for real (NOT mocked).  The Tauri IPC layer IS mocked so
+// the disk_usage / load_path / load_text commands resolve deterministically.
+//
+// Stable selectors used (declared in the E2E contract comment in query-workbench.tsx):
+//   #repl-query                 — the SPARQL editor textarea
+//   button "Run query"          — the run trigger (text match)
+//   [data-result-kind="select"] — outer container when a SELECT result is rendered
+//   [data-result-view="table"]  — the table sub-view (default for SELECT)
+//   [data-result-kind="error"]  — rendered when the engine rejects the query
+//   [data-result-pager]         — the pagination bar (present whenever totalRows > 0)
+//
+// Determinism rules: NO waitForTimeout; NO exact numeric assertions (row counts, ms values);
+// web-first assertions on visible UI state only.
+
+import { test, expect } from "../support/index.ts";
+
+// ---------------------------------------------------------------------------
+// Helper: set the editor value via the native setter + dispatch an input event.
+// Required because WorkbenchSparqlEditor is a React-controlled <textarea>: directly
+// assigning `el.value` would bypass React's synthetic event system.
+// ---------------------------------------------------------------------------
+async function setEditorValue(
+  page: import("@playwright/test").Page,
+  value: string,
+): Promise<void> {
+  await page.evaluate((text) => {
+    const el = document.querySelector<HTMLTextAreaElement>("#repl-query");
+    if (!el) throw new Error("Editor textarea #repl-query not found");
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    if (!setter) throw new Error("Could not access native value setter");
+    setter.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }, value);
+}
+
+test.describe("workbench-query", () => {
+  // The tauriMock auto-fixture navigates to "/" and waits for engine ready before each test.
+
+  test("default query runs and shows Alice in the result table", async ({ page }) => {
+    // The default query is a SELECT over the seeded sample graph (foaf:name + foaf:age,
+    // ORDER BY name → Alice · Bob · Carol · Dan).
+    const runBtn = page.getByRole("button", { name: "Run query" });
+    await expect(runBtn).toBeEnabled();
+    await runBtn.click();
+
+    // Wait for the SELECT result container.
+    const selectResult = page.locator('[data-result-kind="select"]');
+    await expect(selectResult).toBeVisible();
+
+    // The table sub-view is the default for SELECT.
+    const tableView = page.locator('[data-result-view="table"]');
+    await expect(tableView).toBeVisible();
+
+    // Alice is the first row (ORDER BY ?name, "Alice" < "Bob" < "Carol" < "Dan").
+    // Presence-check only — never assert an exact row count.
+    await expect(page.getByRole("cell", { name: "Alice" })).toBeVisible();
+  });
+
+  test("custom query shows a result table", async ({ page }) => {
+    // Clear the editor and type a simple SELECT.
+    await setEditorValue(page, "SELECT * WHERE { ?s ?p ?o } LIMIT 5");
+
+    const runBtn = page.getByRole("button", { name: "Run query" });
+    await runBtn.click();
+
+    // Wait for any SELECT result (not error).
+    const selectResult = page.locator('[data-result-kind="select"]');
+    await expect(selectResult).toBeVisible();
+  });
+
+  test("error result on invalid SPARQL", async ({ page }) => {
+    await setEditorValue(page, "THIS IS NOT SPARQL AT ALL");
+
+    const runBtn = page.getByRole("button", { name: "Run query" });
+    await runBtn.click();
+
+    // The engine rejects the query and renders an error container.
+    const errorResult = page.locator('[data-result-kind="error"]');
+    await expect(errorResult).toBeVisible();
+  });
+
+  test("pagination bar is present after a query with results", async ({ page }) => {
+    // Run the default query (4 rows — the sample graph has Alice, Bob, Carol, Dan).
+    // The pager renders whenever totalRows > 0 (even for a single page).
+    const runBtn = page.getByRole("button", { name: "Run query" });
+    await runBtn.click();
+
+    await expect(page.locator('[data-result-kind="select"]')).toBeVisible();
+
+    // The pager shows the row-range + page-nav controls whenever there are results.
+    const pager = page.locator("[data-result-pager]");
+    await expect(pager).toBeVisible();
+  });
+});

--- a/gui/e2e-playwright/support/fixtures.ts
+++ b/gui/e2e-playwright/support/fixtures.ts
@@ -1,0 +1,83 @@
+// [SONNET-4.6] sq-ymr2e.5 — extended Playwright `test` for the GUI mocked-IPC lane.
+//
+// Every spec imports `{ test, expect }` from here (via support/index.ts) rather than from
+// @playwright/test directly.  The extension adds ONE auto fixture — `tauriMock` — that wires
+// the four invariants required by the determinism doctrine (research/web-gui-test-program.md §1):
+//
+//   1. IPC mock    — injects window.__TAURI__ + __TAURI_INTERNALS__ before the page scripts
+//                    run (page.addInitScript).  isTauriRuntime() returns true; every invoke()
+//                    call resolves from the fixture table, never from the native backend.
+//
+//   2. Hermetic    — blocks all external network requests at the context level.  The in-tab
+//                    WASM engine + all Next.js static assets load from 127.0.0.1:3007 (the
+//                    serve process); nothing else is allowed through.
+//
+//   3. Navigate    — goes to "/" after the mock + block are installed.
+//
+//   4. Engine ready — waits for the literal "Engine ready" copy in the top bar before yielding
+//                    control to the test body. Tests start with a warm engine + loaded sample.
+//
+// All four steps happen before `await use()`, so the test body never races the engine.
+
+import { test as base, expect, type Page } from "@playwright/test";
+import { tauriMockScript } from "./tauri-mock.ts";
+import { waitForEngineReady } from "./gui-ready.ts";
+
+/** The IPC log entry shape exposed on window.__TAURI_IPC_LOG__. */
+export interface IpcLogEntry {
+  cmd: string;
+  args: unknown;
+}
+
+/** Fixtures added by this extension. */
+type GuiMockFixtures = {
+  /** Auto-fixture: injects the Tauri mock, blocks external network, navigates + waits for engine. */
+  tauriMock: void;
+};
+
+export const test = base.extend<GuiMockFixtures>({
+  tauriMock: [
+    async ({ page, context }, use) => {
+      // ── 1. Hermetic network block (context-level, covers all pages) ──────────────────────────
+      // Allow only localhost / 127.0.0.1 (the static file server + blob: URLs the export uses).
+      await context.route("**/*", (route) => {
+        const url = route.request().url();
+        if (
+          url.startsWith("http://127.0.0.1") ||
+          url.startsWith("http://localhost") ||
+          url.startsWith("blob:") ||
+          url.startsWith("data:")
+        ) {
+          return route.continue();
+        }
+        return route.abort();
+      });
+
+      // ── 2. Inject Tauri IPC mock before any page script runs ─────────────────────────────────
+      await page.addInitScript(tauriMockScript);
+
+      // ── 3. Navigate ──────────────────────────────────────────────────────────────────────────
+      await page.goto("/");
+
+      // ── 4. Wait for engine ready (WASM instantiation + sample graph load) ───────────────────
+      // The TopBar's StatusLed renders "Engine ready" when status.kind === "ready".
+      // 90 s is the per-assertion timeout; WASM cold-start on CI can be slow.
+      await waitForEngineReady(page, { timeout: 90_000 });
+
+      await use();
+    },
+    { auto: true },
+  ],
+});
+
+export { expect };
+
+/**
+ * Read the accumulated IPC log from the page.  Call after the action under test to assert
+ * which commands the app fired (e.g. assert `disk_usage` was invoked on mount).
+ */
+export async function readIpcLog(page: Page): Promise<IpcLogEntry[]> {
+  return page.evaluate(
+    () => (window as unknown as { __TAURI_IPC_LOG__: IpcLogEntry[] }).__TAURI_IPC_LOG__,
+  );
+}

--- a/gui/e2e-playwright/support/gui-ready.ts
+++ b/gui/e2e-playwright/support/gui-ready.ts
@@ -1,0 +1,29 @@
+// [SONNET-4.6] sq-ymr2e.5 — shared "wait for engine ready" helper used by the auto-fixture
+// and by any spec that needs to assert against the initial ready state independently.
+//
+// The TopBar renders the literal text "Engine ready" inside a <span> when the WASM engine's
+// status is { kind: "ready" } (gui/app/src/components/workbench/top-bar.tsx: StatusLed).
+// That text is the stable, declared E2E hook — the tauri-driver harness (gui/e2e/run-e2e.mjs)
+// uses the same anchor, so it cannot drift silently.
+
+import type { Page } from "@playwright/test";
+
+/** The literal string the TopBar's StatusLed renders when the engine is warm. */
+const ENGINE_READY_TEXT = "Engine ready";
+
+/**
+ * Wait for the in-tab WASM engine to finish warming.  The engine loads the sample graph and
+ * reaches { kind: "ready" } asynchronously; the top bar's StatusLed then renders the literal
+ * "Engine ready" copy.  WASM instantiation can be slow, so a generous timeout is used.
+ *
+ * NEVER uses waitForTimeout — this is a web-first assertion on a visible UI state.
+ */
+export async function waitForEngineReady(
+  page: Page,
+  options: { timeout?: number } = {},
+): Promise<void> {
+  const timeout = options.timeout ?? 90_000;
+  await page
+    .getByText(ENGINE_READY_TEXT, { exact: true })
+    .waitFor({ state: "visible", timeout });
+}

--- a/gui/e2e-playwright/support/index.ts
+++ b/gui/e2e-playwright/support/index.ts
@@ -1,0 +1,16 @@
+// [SONNET-4.6] sq-ymr2e.5 — barrel: the one import every spec needs.
+//
+// Import from here, not from @playwright/test directly:
+//   import { test, expect } from '../support/index.ts';
+//
+// Exports:
+//   test           — extended test with the tauriMock auto-fixture
+//   expect         — standard Playwright expect (re-exported for convenience)
+//   readIpcLog     — helper to read the accumulated IPC log from the page
+//   waitForEngineReady — wait for "Engine ready" in the top bar
+//   tauriMockScript    — the raw init-script string (rarely needed directly)
+//   IpcLogEntry    — type of entries in the IPC log
+
+export { test, expect, readIpcLog, type IpcLogEntry } from "./fixtures.ts";
+export { waitForEngineReady } from "./gui-ready.ts";
+export { tauriMockScript } from "./tauri-mock.ts";

--- a/gui/e2e-playwright/support/no-timeout-gate.sh
+++ b/gui/e2e-playwright/support/no-timeout-gate.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# [SONNET-4.6] sq-ymr2e.5 — determinism gate: forbids waitForTimeout / sleep in specs + support.
+#
+# Run before (or as part of) the CI test step to enforce the no-sleep doctrine
+# (research/web-gui-test-program.md §1.1 determinism rules): every wait must be a web-first
+# assertion on a real UI state, never a fixed-delay sleep.
+#
+# Usage:  bash support/no-timeout-gate.sh
+#         (run from gui/e2e-playwright/)
+set -euo pipefail
+
+# Match only CALLS (with a parenthesis), not comments that document the rule.
+# This catches `page.waitForTimeout(` / `waitForTimeout(` while ignoring
+# comment lines like "// NO waitForTimeout — use web-first assertions".
+FOUND=$(grep -rn --include="*.ts" "waitForTimeout(" specs/ support/ 2>/dev/null || true)
+
+if [ -n "$FOUND" ]; then
+  echo "ERROR: waitForTimeout() call found — use web-first assertions only (design §1.1):" >&2
+  echo "$FOUND" >&2
+  exit 1
+fi
+
+echo "OK: no waitForTimeout found in specs/ or support/"

--- a/gui/e2e-playwright/support/no-timeout-gate.sh
+++ b/gui/e2e-playwright/support/no-timeout-gate.sh
@@ -1,23 +1,56 @@
 #!/usr/bin/env bash
-# [SONNET-4.6] sq-ymr2e.5 — determinism gate: forbids waitForTimeout / sleep in specs + support.
+# [SONNET-4.6] sq-ymr2e.5 — determinism gate: forbids fixed-delay waits in specs + support.
 #
 # Run before (or as part of) the CI test step to enforce the no-sleep doctrine
 # (research/web-gui-test-program.md §1.1 determinism rules): every wait must be a web-first
 # assertion on a real UI state, never a fixed-delay sleep.
 #
+# Patterns caught (all must be CALLS — have a parenthesis — so doc-comments are not flagged):
+#   waitForTimeout(   — Playwright's fixed-delay API (page.waitForTimeout / locator.waitForTimeout)
+#   sleep(            — any user-defined or imported sleep helper
+#   setTimeout(       — raw JS timer used as a sleep substitute
+#
+# Each grep runs with --include="*.ts" so only TypeScript spec/support files are scanned;
+# shell scripts (*.sh) and config (*.json, *.ts outside these dirs) are not in scope.
+#
 # Usage:  bash support/no-timeout-gate.sh
 #         (run from gui/e2e-playwright/)
 set -euo pipefail
 
-# Match only CALLS (with a parenthesis), not comments that document the rule.
-# This catches `page.waitForTimeout(` / `waitForTimeout(` while ignoring
-# comment lines like "// NO waitForTimeout — use web-first assertions".
-FOUND=$(grep -rn --include="*.ts" "waitForTimeout(" specs/ support/ 2>/dev/null || true)
+FAIL=0
 
+# ── 1. waitForTimeout ─────────────────────────────────────────────────────────────────────────
+# Catches `page.waitForTimeout(` / `waitForTimeout(` while ignoring comment-doc lines like
+# "// NO waitForTimeout — use web-first assertions" (no parenthesis in those comments).
+FOUND=$(grep -rn --include="*.ts" "waitForTimeout(" specs/ support/ 2>/dev/null || true)
 if [ -n "$FOUND" ]; then
   echo "ERROR: waitForTimeout() call found — use web-first assertions only (design §1.1):" >&2
   echo "$FOUND" >&2
+  FAIL=1
+fi
+
+# ── 2. sleep( ─────────────────────────────────────────────────────────────────────────────────
+# Catches any call to a helper named sleep (a common anti-pattern wrapper around setTimeout/delay).
+FOUND=$(grep -rn --include="*.ts" "sleep(" specs/ support/ 2>/dev/null || true)
+if [ -n "$FOUND" ]; then
+  echo "ERROR: sleep() call found — use web-first assertions only (design §1.1):" >&2
+  echo "$FOUND" >&2
+  FAIL=1
+fi
+
+# ── 3. setTimeout( ───────────────────────────────────────────────────────────────────────────
+# Catches raw JS timer calls used as a sleep substitute (setTimeout(fn, N)).
+# In Playwright test specs and support helpers there is no legitimate use of setTimeout;
+# any occurrence means a fixed-delay wait that violates the determinism doctrine.
+FOUND=$(grep -rn --include="*.ts" "setTimeout(" specs/ support/ 2>/dev/null || true)
+if [ -n "$FOUND" ]; then
+  echo "ERROR: setTimeout() call found — use web-first assertions only (design §1.1):" >&2
+  echo "$FOUND" >&2
+  FAIL=1
+fi
+
+if [ "$FAIL" -ne 0 ]; then
   exit 1
 fi
 
-echo "OK: no waitForTimeout found in specs/ or support/"
+echo "OK: no fixed-delay waits (waitForTimeout / sleep / setTimeout) found in specs/ or support/"

--- a/gui/e2e-playwright/support/tauri-mock.ts
+++ b/gui/e2e-playwright/support/tauri-mock.ts
@@ -1,0 +1,49 @@
+// [SONNET-4.6] sq-ymr2e.5 — the Tauri IPC mock injected by page.addInitScript.
+//
+// Stubs window.__TAURI__ + window.__TAURI_INTERNALS__ so isTauriRuntime() returns true
+// (gui/app/src/lib/tauri-ipc.ts checks for either global) and every IPC invoke() call
+// returns a deterministic fixture instead of reaching the native Rust backend.
+//
+// The LOG array is exposed as window.__TAURI_IPC_LOG__ so tests can verify the IPC contract
+// (assert which commands were fired and with which args) via page.evaluate.
+//
+// Commands mocked:
+//   disk_usage       → { path: "/fake/workspaces", bytes: 12345678, exists: true }
+//   load_text        → { nquads: "<...> .", count: 1, format: "turtle" }
+//   load_path        → same as load_text
+//   plugin:dialog|open → "/tmp/test.ttl"
+//   (any other cmd)  → throws Error (catches unexpected IPC surface drift)
+
+/** The script string injected via page.addInitScript before the page's own scripts run. */
+export const tauriMockScript: string = `
+(function () {
+  "use strict";
+  // Satisfy isTauriRuntime() — checks __TAURI_INTERNALS__ || __TAURI__ in window.
+  window.__TAURI_INTERNALS__ = { metadata: { currentWebviewLabel: "main" } };
+
+  var DISK_FIXTURE = { path: "/fake/workspaces", bytes: 12345678, exists: true };
+  var LOAD_FIXTURE = {
+    nquads: "<http://example.org/imported> <http://example.org/p> <http://example.org/o> .",
+    count: 1,
+    format: "turtle"
+  };
+  // The LOG accumulates every invoke call so tests can assert the IPC contract.
+  var LOG = [];
+
+  window.__TAURI__ = {
+    core: {
+      invoke: function (cmd, args) {
+        LOG.push({ cmd: cmd, args: args });
+        if (cmd === "disk_usage")        return Promise.resolve(DISK_FIXTURE);
+        if (cmd === "load_text")         return Promise.resolve(LOAD_FIXTURE);
+        if (cmd === "load_path")         return Promise.resolve(LOAD_FIXTURE);
+        if (cmd === "plugin:dialog|open") return Promise.resolve("/tmp/test.ttl");
+        return Promise.reject(new Error("[tauri-mock] Unexpected IPC invoke: " + cmd));
+      }
+    }
+  };
+
+  // Expose the log for test assertions: page.evaluate(() => window.__TAURI_IPC_LOG__)
+  window.__TAURI_IPC_LOG__ = LOG;
+})();
+`;

--- a/gui/e2e-playwright/tsconfig.json
+++ b/gui/e2e-playwright/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["dom", "dom.iterable", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["playwright.config.ts", "support/**/*.ts", "specs/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "js",
         "site",
         "gui/app",
-        "gui/e2e"
+        "gui/e2e",
+        "gui/e2e-playwright"
       ],
       "devDependencies": {
         "@solid/acl-check": "^0.4.5",
@@ -89,6 +90,49 @@
       "engines": {
         "node": ">=18.20.0"
       }
+    },
+    "gui/e2e-playwright": {
+      "name": "sparq-gui-e2e-playwright",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@playwright/test": "^1.61.0",
+        "@types/node": "^22.10.0",
+        "typescript": "^5.7.0"
+      },
+      "engines": {
+        "node": ">=18.20.0"
+      }
+    },
+    "gui/e2e-playwright/node_modules/@types/node": {
+      "version": "22.20.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.0.tgz",
+      "integrity": "sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "gui/e2e-playwright/node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "gui/e2e-playwright/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "js": {
       "name": "@jeswr/sparq",
@@ -7806,13 +7850,13 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
@@ -12240,6 +12284,10 @@
     },
     "node_modules/sparq-gui-e2e": {
       "resolved": "gui/e2e",
+      "link": true
+    },
+    "node_modules/sparq-gui-e2e-playwright": {
+      "resolved": "gui/e2e-playwright",
       "link": true
     },
     "node_modules/sparq-site": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
       "devDependencies": {
         "@playwright/test": "^1.61.0",
         "@types/node": "^22.10.0",
+        "serve": "14.2.6",
         "typescript": "^5.7.0"
       },
       "engines": {
@@ -5168,6 +5169,13 @@
         "node": "4.x || >=6.0.0"
       }
     },
+    "node_modules/@zeit/schemas": {
+      "version": "2.36.0",
+      "resolved": "https://registry.npmjs.org/@zeit/schemas/-/schemas-2.36.0.tgz",
+      "integrity": "sha512-7kjMwcChYEzMKjeex9ZFXkt1AyNov9R5HZtjBKVsmVpw7pa7ZtlCGvCBC2vnnXctaYN+aRI61HjIqeetZW5ROg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@zip.js/zip.js": {
       "version": "2.8.26",
       "resolved": "https://registry.npmjs.org/@zip.js/zip.js/-/zip.js-2.8.26.tgz",
@@ -5250,6 +5258,61 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-align": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-3.0.1.tgz",
+      "integrity": "sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.1.0"
+      }
+    },
+    "node_modules/ansi-align/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-align/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-align/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
@@ -5289,6 +5352,27 @@
       ],
       "license": "MIT"
     },
+    "node_modules/arch": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
+      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/archiver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
@@ -5324,6 +5408,13 @@
       "engines": {
         "node": ">= 14"
       }
+    },
+    "node_modules/arg": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+      "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -5741,6 +5832,55 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "license": "ISC"
     },
+    "node_modules/boxen": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/boxen/-/boxen-7.0.0.tgz",
+      "integrity": "sha512-j//dBVuyacJbvW+tvZ9HuH03fZ46QcaKvvhZickZqtB271DxJ7SNRSNxrV/dZX0085m7hISRZWbzWlJvx/rHSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-align": "^3.0.1",
+        "camelcase": "^7.0.0",
+        "chalk": "^5.0.1",
+        "cli-boxes": "^3.0.0",
+        "string-width": "^5.1.2",
+        "type-fest": "^2.13.0",
+        "widest-line": "^4.0.1",
+        "wrap-ansi": "^8.0.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/boxen/node_modules/chalk": {
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
+      "integrity": "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/boxen/node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
@@ -5804,6 +5944,16 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/cacheable-lookup": {
       "version": "5.0.4",
@@ -5894,6 +6044,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-7.0.1.tgz",
+      "integrity": "sha512-xlx1yCK2Oc1APsPXDL2LdlNP6+uu8OCDdhOBSVT279M/S+y75O30C2VuD8T2ogdePBBl7PfPF4504tnLgX3zfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001799",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
@@ -5935,6 +6098,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
     },
     "node_modules/cheerio": {
@@ -5991,11 +6170,42 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cli-boxes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-3.0.0.tgz",
+      "integrity": "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
+    },
+    "node_modules/clipboardy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
+      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "arch": "^2.2.0",
+        "execa": "^5.1.1",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -6216,6 +6426,55 @@
         "node": ">= 14"
       }
     },
+    "node_modules/compressible": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
+      "integrity": "sha512-AF3r7P5dWxL8MxyITRMlORQNaOA2IkAFaTr4k7BUumjPtRpGDTZpl0Pb1XCO6JeDCBdp126Cgs9sMxqSjgYyRg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": ">= 1.43.0 < 2"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/compression": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
+      "integrity": "sha512-9mAqGPHLakhCLeNyxPkK4xVo746zQ/czLH1Ky+vkitMnWfWZps8r0qXuwhwizagCRttsL4lfG4pIOvaWLpAP0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "compressible": "~2.0.18",
+        "debug": "2.6.9",
+        "negotiator": "~0.6.4",
+        "on-headers": "~1.1.0",
+        "safe-buffer": "5.2.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/compression/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/compression/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -6277,6 +6536,16 @@
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha512-kRGRZw3bLlFISDBgwTSA1TMBFN6J6GWDeubmDE3AF+3+yXL8hTWv8r5rkLbqYXY4RjPk/EzHnClI3zQf1cFmHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/core-util-is": {
@@ -7601,6 +7870,50 @@
         "typpy": "^2.1.0"
       }
     },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/execa/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/extract-zip": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
@@ -7677,6 +7990,23 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
+      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
       "version": "1.2.0",
@@ -8487,6 +8817,16 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -8760,6 +9100,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-document.all": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-document.all/-/is-document.all-1.0.0.tgz",
@@ -8904,6 +9260,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-port-reachable": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-port-reachable/-/is-port-reachable-4.0.0.tgz",
+      "integrity": "sha512-9UoipoxYmSk6Xy7QFgRv2HDyaysmgSG75TFQs6S+3pDM7ZhKTF/bskZV+0UlABHzKjNVhPjYCLfeZUEg1wXxig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -9086,6 +9455,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -9939,6 +10321,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/merge-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/merge2": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
@@ -9961,6 +10350,49 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "~1.33.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types/node_modules/mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/mimic-response": {
@@ -10111,6 +10543,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.4.tgz",
+      "integrity": "sha512-myRT3DiWPHqho5PrJaIRyaMv2kgYf0mUVgBNOYMuCH5Ki1yEiQaf/ZJuQ62nvpc44wL5WDbTX7yGJi1Neevw8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/netmask": {
       "version": "2.1.1",
@@ -10379,6 +10821,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -10535,6 +10990,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/on-headers": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.1.0.tgz",
+      "integrity": "sha512-737ZY3yNnXy37FHkQxPzt4UZ2UWPWiCZWLvFZ4fu5cueciegX0zGPnrlY6bwRg4FdQOe9YU8MkmJwGhoMybl8A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -10563,6 +11028,22 @@
       "license": "MIT",
       "dependencies": {
         "fn.name": "1.x.x"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -10849,6 +11330,13 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha512-DUWJr3+ULp4zXmol/SZkFf3JGsS9/SIv+Y3Rt93/UjPpDpklB5f1er4O3POIbUuUJ3FXgqte2Q7SrU6zAqwk8w==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)"
+    },
     "node_modules/path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -10880,6 +11368,13 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-3.3.0.tgz",
+      "integrity": "sha512-qyCH421YQPS2WFDxDjftfc1ZR5WKQzVzqsp4n9M2kQhVOo/ByahFoUNJfl58kOcEGfQ//7weFTDhm+ss8Ecxgw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -11220,6 +11715,16 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/rc": {
@@ -11665,6 +12170,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "2.0.0-next.7",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
@@ -11970,6 +12485,95 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/serve": {
+      "version": "14.2.6",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-14.2.6.tgz",
+      "integrity": "sha512-QEjUSA+sD4Rotm1znR8s50YqA3kYpRGPmtd5GlFxbaL9n/FdUNbqMhxClqdditSk0LlZyA/dhud6XNRTOC9x2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@zeit/schemas": "2.36.0",
+        "ajv": "8.18.0",
+        "arg": "5.0.2",
+        "boxen": "7.0.0",
+        "chalk": "5.0.1",
+        "chalk-template": "0.4.0",
+        "clipboardy": "3.0.0",
+        "compression": "1.8.1",
+        "is-port-reachable": "4.0.0",
+        "serve-handler": "6.1.7",
+        "update-check": "1.5.4"
+      },
+      "bin": {
+        "serve": "build/main.js"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/serve-handler": {
+      "version": "6.1.7",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.7.tgz",
+      "integrity": "sha512-CinAq1xWb0vR3twAv9evEU8cNWkXCb9kd5ePAHUKJBkOsUpR1wt/CvGdeca7vqumL1U5cSaeVQ6zZMxiJ3yWsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.0.0",
+        "content-disposition": "0.5.2",
+        "mime-types": "2.1.18",
+        "minimatch": "3.1.5",
+        "path-is-inside": "1.0.2",
+        "path-to-regexp": "3.3.0",
+        "range-parser": "1.2.0"
+      }
+    },
+    "node_modules/serve-handler/node_modules/bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha512-pMhOfFDPiv9t5jjIXkHosWmkSyQbvsgEVNkz0ERHbuLh2T/7j4Mqqpz523Fe8MVY89KC6Sh/QfS2sM+SjgFDcw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/serve/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/serve/node_modules/chalk": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
+      "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/serve/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",
@@ -12610,6 +13214,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -13115,6 +13729,28 @@
         "@unrs/resolver-binding-win32-x64-msvc": "1.12.2"
       }
     },
+    "node_modules/update-check": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/update-check/-/update-check-1.5.4.tgz",
+      "integrity": "sha512-5YHsflzHP4t1G+8WGPlvKbJEbAJGCgw+Em+dGR1KmBUbr1J36SJBqlHLjR7oob7sco5hWHGQVcr9B2poIVDDTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "registry-auth-token": "3.3.2",
+        "registry-url": "3.1.0"
+      }
+    },
+    "node_modules/update-check/node_modules/registry-auth-token": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
+      "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rc": "^1.1.6",
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -13205,6 +13841,16 @@
       "dependencies": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/w-json": {
@@ -13487,6 +14133,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/widest-line": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-4.0.1.tgz",
+      "integrity": "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/winston": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "js",
     "site",
     "gui/app",
-    "gui/e2e"
+    "gui/e2e",
+    "gui/e2e-playwright"
   ],
   "devDependencies": {
     "@solid/acl-check": "^0.4.5",


### PR DESCRIPTION
> 🤖 SPARQ agent (Sonnet 4.6) — bead sq-ymr2e.5: GUI frontend journeys under Playwright with mocked Tauri IPC.

## Summary

Adds `gui/e2e-playwright/` — the **deterministic desktop lane** specified in `research/web-gui-test-program.md §5`: 5 Playwright journeys that drive the GUI frontend in headless Chromium with the Tauri IPC layer fully mocked. No Tauri binary, no `WebKitWebDriver`, no display server, no real IPC calls — fully hermetic and deterministic.

## Journeys covered

| Journey | File | What it tests |
|---|---|---|
| **workbench-query** | `specs/workbench-query.spec.ts` | Default query runs and shows Alice (seeded sample); custom query; error on invalid SPARQL; pagination bar present |
| **inference-toggle** | `specs/inference-toggle.spec.ts` | Off→RDFS `aria-pressed` flip; status chip appears (loading→ready/error); RDFS→Off chip disappears |
| **export-contract** | `specs/export-contract.spec.ts` | Export trigger enabled with non-empty store; format menu shows Turtle/TriG/JSON-LD; Turtle selection fires a browser download |
| **status-bar** | `specs/status-bar.spec.ts` | Status bar visible; latency "ms" + "rows" present after run (presence only, never exact values); disk gauge with `data-disk-source="os"` (mocked `disk_usage`); backend label present |
| **keyboard-spine** | `specs/keyboard-spine.spec.ts` | Ctrl+Enter runs the query; Ctrl-K opens the command palette dialog; Escape closes it |

## IPC mock mechanism

`window.__TAURI__` + `window.__TAURI_INTERNALS__` are injected via `page.addInitScript` before the page scripts run (the `withGlobalTauri: true` injection pattern — the app reads these globals directly from `gui/app/src/lib/tauri-ipc.ts`, not from `@tauri-apps/api`):

```
disk_usage       → { path: "/fake/workspaces", bytes: 12345678, exists: true }
load_text        → { nquads: "<http://example.org/imported> ...", count: 1, format: "turtle" }
load_path        → same fixture as load_text
plugin:dialog|open → "/tmp/test.ttl"
(any other cmd)  → throws Error (catches unexpected IPC drift)
```

The mock accumulates all `invoke` calls in `window.__TAURI_IPC_LOG__` so tests can assert the IPC contract.

## Determinism guarantees

- **Zero `waitForTimeout`**: enforced by `support/no-timeout-gate.sh` (a `grep` gate in CI that exits 1 if any `.ts` file calls `waitForTimeout(`)
- **Hermetic network**: `context.route` blocks all non-localhost requests at the fixture level
- **0 retries**: `retries: 0` in `playwright.config.ts` — a passing-on-retry is a defect to fix
- **1 worker**: serial execution for determinism
- **No exact timing values**: latency and row counts are presence-checked only (`/\d+(\.\d+)?\s*ms/`, `/\d[\d,]*\s*rows/`)
- **Stable selectors**: `data-*` attributes and ARIA roles only

## CI wiring

New non-advisory job `gui-mock-ipc` in `gui.yml`:
- Builds WASM bundle (shacl,jsonld) + W-reason bundle (for live inference in inference-toggle test)
- Builds GUI frontend static export (`build:tauri` → `gui/app/out/`)
- Installs Playwright Chromium only
- Runs the determinism gate (`no-timeout-gate.sh`)
- Runs `npm test` (all 5 spec files)
- **Not advisory** (no `advisory` keyword) — this is the lane that, after earning the probation bar (design §6.3), becomes a required gate

## Per design doc §5

> _No Tauri binary, no WebKitWebDriver, no display server → this is the lane that can become **required**._

The mock/real seam is documented: layer 3's tauri-driver smoke (bead sq-ymr2e.6) exercises the highest-traffic command end-to-end; layer 2's (this PR's) invoke-contract assertions are written against the command names/arg shapes the native unit tests also pin.

## Privacy / honesty

No ZK/MPC copy. No performance numbers asserted or documented. The disk gauge test asserts presence of `data-disk-source="os"` — not the byte value.

## Files

- `gui/e2e-playwright/` — new package (13 files)
- `.github/workflows/gui.yml` — new `gui-mock-ipc` job (~75 lines)
- `package.json` / `package-lock.json` — new workspace member

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>