### PR TITLE
feat(ci): change-based test-selection wiring — select pre-job + fail-closed skip guards + ci-summary skipped-semantics (sq-fmx4u.3)

### DIFF
--- a/.github/workflows/ci-select.yml
+++ b/.github/workflows/ci-select.yml
@@ -1,0 +1,101 @@
+# ci-select — the change-based test-selection pre-job (bead sq-fmx4u.3, epic
+# sq-fmx4u). [FABLE-5]
+#
+# WHAT: one cheap reusable job that computes the AFFECTED CRATE CLOSURE for this
+# revision pair (scripts/ci_select.py — design research/change-based-test-selection.md
+# §3/§4) and exposes it as outputs, so the wide per-crate lanes in ci.yml and the
+# opt-in legs in feature-matrix.yml can be skipped/narrowed when neither their crate
+# nor its transitive dependency closure changed. `needs:` cannot span workflows, so
+# each consuming workflow calls this file as a local reusable workflow (`uses:`) —
+# ONE selector definition, one job instance per calling workflow.
+#
+# OUTPUTS (all produced by scripts/ci_select.py; empty/missing => downstream guards
+# RUN, never skip — design §4.3 fail-closed):
+#   mode      — "selected" | "full" | "shadow". Guards skip ONLY on "selected".
+#   affected  — JSON array of affected workspace-member names. Guards test
+#               membership with contains(affected, '"<crate>"') — the quote
+#               delimiters prevent `sparq-core` matching inside `sparq-core-foo`.
+#   filterset — nextest filterset ("package(a) + package(b)") for NARROWING the
+#               cross-crate bulk shards (they are never skipped, design §5.2).
+#
+# SHADOW MODE (design §6.4 — the sq-fmx4u.5 rollout): DEFAULT-ON. Until the repo
+# variable CI_SELECT_MODE is set to the literal string "enforce", the selector runs
+# with --shadow: it computes + reports the would-be selection in the step summary
+# but emits mode=shadow, so every guard's `mode != 'selected'` disjunct is true and
+# NOTHING is skipped. Fail-safe by construction: an unset/typo'd variable means
+# shadow (full matrix). Bead sq-fmx4u.5 flips enforcement after the shadow window.
+#
+# FAIL-CLOSED CONTRACT (design §4.3):
+#   * the selector traps ALL internal errors => mode=full, exit 0 (this job stays
+#     green and the full matrix runs — a selector bug degrades to the status quo);
+#   * if THIS JOB hard-fails anyway (checkout/runner infrastructure), its needs-
+#     dependents in the calling workflow are SKIPPED and the ci-summary gate goes
+#     RED — scripts/ci_summary_gate.py requires every "change-based test selection"
+#     check-run to conclude success before any skipped sibling counts as satisfied;
+#   * an empty/missing output satisfies every guard's `mode != 'selected'` first
+#     disjunct => RUN.
+#
+# The job name below carries the phrase "change-based test selection" — that is the
+# detection contract with scripts/ci_summary_gate.py (SELECT_RE); the wiring test
+# scripts/tests/test_ci_select_wiring.py pins the two together. Do NOT add the words
+# "advisory"/"informational" to any name here (they would un-gate the check).
+name: ci-select
+
+on:
+  workflow_call:
+    outputs:
+      mode:
+        description: "selected | full | shadow (skip only on 'selected')"
+        value: ${{ jobs.select.outputs.mode }}
+      affected:
+        description: "JSON array of affected workspace-member names"
+        value: ${{ jobs.select.outputs.affected }}
+      filterset:
+        description: "nextest filterset over the affected members (bulk-shard narrowing)"
+        value: ${{ jobs.select.outputs.filterset }}
+
+permissions:
+  contents: read
+
+jobs:
+  select:
+    name: select (change-based test selection)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      mode: ${{ steps.sel.outputs.mode }}
+      affected: ${{ steps.sel.outputs.affected }}
+      filterset: ${{ steps.sel.outputs.filterset }}
+    steps:
+      # Full history so the merge-base for the three-dot diff (base...head) is
+      # always resolvable; an unfetchable base fail-closes to mode=full anyway.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Compute the affected crate closure (scripts/ci_select.py)
+        id: sel
+        env:
+          # cargo metadata resolves the registry index; same transient-network
+          # hardening as every other lane (ci.yml header note).
+          CARGO_NET_RETRY: "10"
+          EVENT: ${{ github.event_name }}
+          # pull_request: PR base/head. merge_group: the queue entry's target-tip
+          # base_sha/head_sha (the diff is then the union of queued content — sound
+          # per design §3.1/P8). Exactly one pair is non-empty per event.
+          BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          # The sq-fmx4u.5 enforcement flip: shadow (report-only) unless the repo
+          # variable CI_SELECT_MODE is exactly "enforce".
+          CI_SELECT_MODE: ${{ vars.CI_SELECT_MODE }}
+        run: |
+          set -euo pipefail
+          args=(--event "$EVENT")
+          case "$EVENT" in
+            pull_request|merge_group) args+=(--base "$BASE" --head "$HEAD") ;;
+          esac
+          if [ "${CI_SELECT_MODE:-}" != "enforce" ]; then
+            args+=(--shadow)
+          fi
+          python3 scripts/ci_select.py "${args[@]}"

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -72,6 +72,20 @@
 # line, and THIS name-rule is the load-bearing backstop that makes advisory failures
 # strictly non-gating regardless of how the job concludes.
 #
+# CHANGE-BASED TEST-SELECTION semantics (bead sq-fmx4u.3). [FABLE-5] The wide
+# per-crate lanes in ci.yml / feature-matrix.yml may now be SKIPPED (or, for the
+# cross-crate bulk shards, narrowed) when the `select (change-based test
+# selection)` pre-job (.github/workflows/ci-select.yml, reused by both workflows)
+# proves their crate outside the affected closure. The gate's rule (design §5.3):
+# a `skipped` conclusion is satisfied ONLY when every selection check-run on the
+# commit concluded SUCCESS — a present-but-not-success select REDs the gate
+# outright even if all other siblings are green, because the thing that decided
+# the skips was never soundly observed. With select green (or absent — a
+# pre-selection sibling set), `skipped` stays non-failing exactly as before, and
+# a job that FAILED still fails the gate regardless (selection can never mask a
+# real failure). Selection ships SHADOW-first (report-only; enforcement flip is
+# bead sq-fmx4u.5 via the CI_SELECT_MODE repo variable).
+#
 # IMPLEMENTATION (sq-90cv4). [FABLE-5] The poll loop + verdict live in
 # scripts/ci_summary_gate.py (extracted from the previous inline bash so the
 # semantics are UNIT-TESTED — scripts/tests/test_ci_summary_gate.py, run as a HARD

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,26 @@ jobs:
             echo "pull_request -> paths-filter says rust=${{ steps.filter.outputs.rust }} docker=${{ steps.filter.outputs.docker }}"
           fi
 
+  # [FABLE-5] sq-fmx4u.3: change-based test-selection pre-job (reusable — see the
+  # doctrine in .github/workflows/ci-select.yml). Computes the affected crate
+  # closure once per run; the wide per-crate lanes below guard on it with the
+  # fail-closed disjunction  `mode != 'selected' || contains(affected, '"<crate>"')`
+  # (empty/missing outputs => RUN), and the cross-crate bulk test shards NARROW
+  # (never skip) via the filterset output. UNCONDITIONAL (no needs/if): the
+  # ci-summary gate REQUIRES every selection check-run to conclude success before
+  # any skipped sibling counts as satisfied, so this job must exist and be green
+  # on every run — including doc-only PRs where `changes` skips the Rust matrix.
+  # Relationship to `changes` (dorny paths-filter) is layered, both directions
+  # preserved: rust_changed==false skips a lane regardless of selection (the
+  # existing doc-PR fast path), and selection can only skip WITHIN
+  # rust_changed==true. SHADOW default-ON until the CI_SELECT_MODE repo variable
+  # says "enforce" (bead sq-fmx4u.5).
+  select:
+    name: select
+    uses: ./.github/workflows/ci-select.yml
+    permissions:
+      contents: read
+
   # [OPUS-4.8] BUILD-ONCE for the sharded test suite (sq-vyxy folded in). The old
   # design had every shard run `cargo build --workspace --all-targets` itself — the
   # 131s build FLOOR that rust-cache makes cheap for *deps* but cannot remove for
@@ -153,8 +173,16 @@ jobs:
   # once, off the warm build this job already has (was a guarded shard-1 step before).
   build-archive:
     name: build + archive test binaries (+ doctests once)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: the workspace archive runs whenever the affected
+    # closure is NON-EMPTY (design §5.2) — the bulk shards it feeds are narrowed,
+    # not skipped, so they need the archive for any non-empty selection. Only a
+    # provably-empty closure (every changed path SAFE-listed/non-crate) skips it;
+    # the shards then skip too via `needs`. Fail-closed: an empty/missing `mode`
+    # or `affected` output satisfies a disjunct => RUN.
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' || needs.select.outputs.affected != '[]')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -284,7 +312,10 @@ jobs:
     # build-archive `if:`-skipped on a doc-only PR, this job is skipped too (a needed job
     # was skipped) — exactly the intent. Keep the explicit `changes` need + `if:` so the
     # skip is driven by the filter, not an incidental artifact-missing failure.
-    needs: [changes, build-archive]
+    # [FABLE-5] sq-fmx4u.3: + `select` for the change-based narrowing below. An
+    # empty-affected selection skips build-archive, which skips every shard here
+    # via `needs` — no shard ever runs against a missing archive.
+    needs: [changes, build-archive, select]
     if: needs.changes.outputs.rust_changed == 'true'
     runs-on: ubuntu-latest
     env:
@@ -310,20 +341,35 @@ jobs:
           # Floors are UNCHANGED (HNSW >= 0.95, DiskANN >= 0.90) — this removes variance, it
           # does not move the bar. Only the heavy shards set this; the bulk shards keep
           # default parallelism (their ~1827 tiny tests want the threads).
+          # [FABLE-5] sq-fmx4u.3: `crate` marks a shard that exercises exactly ONE
+          # crate's tests (both heavies live in crates/sparq-vectors/tests/). When
+          # selection is ENFORCED (mode == 'selected') and that crate is not in the
+          # affected closure, the run step below exits 0 without running the shard
+          # ("skipped by selection"). This cannot be a job-level `if:` — the
+          # `matrix` context is NOT available there (GitHub contexts-availability:
+          # jobs.<job_id>.if sees only github/needs/vars/inputs; a matrix reference
+          # silently evaluates EMPTY, which would skip every leg unconditionally) —
+          # so the guard lives in the step, where `matrix` is available. `crate: ""`
+          # on the bulk shards = cross-crate: NEVER skipped, only narrowed.
           - name: heavy-diskann
             filter: "test(=diskann_recall_at_10_vs_brute_force_on_50k)"
             rayon_threads: "1"
+            crate: "sparq-vectors"
           # Dedicated shard for the 61.2s hnsw recall test — SPLIT from diskann.
           - name: heavy-hnsw
             filter: "test(=hnsw_recall_at_10_vs_brute_force_on_50k)"
             rayon_threads: "1"
+            crate: "sparq-vectors"
           # The uniform remainder (~222s), evenly count-partitioned 3 ways.
           - name: bulk 1/3
             partition: "count:1/3"
+            crate: ""
           - name: bulk 2/3
             partition: "count:2/3"
+            crate: ""
           - name: bulk 3/3
             partition: "count:3/3"
+            crate: ""
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # [OPUS-4.8] sq-c76x: reclaim ~20-30 GB BEFORE downloading/extracting the nextest
@@ -396,8 +442,30 @@ jobs:
         # value leaves RAYON_NUM_THREADS unset, so the bulk shards keep default parallelism.
         env:
           RAYON_NUM_THREADS: ${{ matrix.rayon_threads }}
+          # [FABLE-5] sq-fmx4u.3: selection inputs, passed via env (not inline
+          # `${{ }}` in the script) so the shell sees literal values — no
+          # template-injection surface, and shellcheck-friendly.
+          SELECT_MODE: ${{ needs.select.outputs.mode }}
+          SELECT_AFFECTED: ${{ needs.select.outputs.affected }}
+          SELECT_FILTERSET: ${{ needs.select.outputs.filterset }}
+          SHARD_CRATE: ${{ matrix.crate }}
         run: |
           set -euo pipefail
+          # [FABLE-5] sq-fmx4u.3 (design §5.2): single-crate shard skip guard.
+          # FAIL-CLOSED: only the exact mode 'selected' AND a non-empty SHARD_CRATE
+          # AND a definite non-membership ('"<crate>"' absent from the affected
+          # JSON — the quote delimiters prevent substring-crate collisions) can
+          # skip; empty/missing selection outputs always fall through to a run.
+          if [ "$SELECT_MODE" = "selected" ] && [ -n "$SHARD_CRATE" ]; then
+            case "$SELECT_AFFECTED" in
+              *"\"$SHARD_CRATE\""*) : ;;  # in the affected closure -> run the shard
+              *)
+                echo "shard '${{ matrix.name }}' SKIPPED by change-based selection:"
+                echo "  $SHARD_CRATE is not in the affected closure $SELECT_AFFECTED"
+                exit 0
+                ;;
+            esac
+          fi
           common=(--archive-file nextest.tar.zst --workspace-remap . \
                   --extract-to . --extract-overwrite --retries 2)
           if [ -n "${{ matrix.filter }}" ]; then
@@ -406,6 +474,19 @@ jobs:
             # test is ever renamed in only one place, the shard runs empty rather than
             # silently re-including it in bulk).
             args=("${common[@]}" -E '( ${{ env.HEAVY }} ) & ( ${{ matrix.filter }} )')
+          elif [ "$SELECT_MODE" = "selected" ] && [ -n "$SELECT_FILTERSET" ]; then
+            # [FABLE-5] sq-fmx4u.3: bulk shard under ENFORCED selection — NARROW
+            # (never skip) the cross-crate partition to the affected closure
+            # (design §5.2): intersect the not-heavy set with the package()
+            # filterset. The count partition applies AFTER filtering, so the three
+            # bulk shards still partition the narrowed set exactly. A package()
+            # naming no archived package fails loud (nextest errors), so a stale
+            # filterset cannot silently select nothing; --no-tests=pass is needed
+            # because a legitimately-narrowed shard CAN match zero tests (e.g. an
+            # affected crate whose only tests are heavy/feature-gated) — full and
+            # shadow runs keep the strict no-tests-is-an-error behaviour.
+            args=("${common[@]}" --no-tests=pass --partition ${{ matrix.partition }} \
+                  -E "( not ( $HEAVY ) ) & ( $SELECT_FILTERSET )")
           else
             # Bulk shard: everything that is NOT a known-heavy test, count-partitioned.
             args=("${common[@]}" --partition ${{ matrix.partition }} -E 'not ( ${{ env.HEAVY }} )')
@@ -765,8 +846,14 @@ jobs:
     # drop below the ratchet count is a conformance regression and fails CI. Never
     # lower the ratchet.
     name: W3C SPARQL conformance (ratchet >= 1229 pass+divergence)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: this lane runs `-p sparq-conformance` bins; skip only
+    # when ENFORCED selection proves sparq-conformance unaffected (fail-closed:
+    # empty/missing outputs or shadow/full mode => run).
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-conformance"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -870,8 +957,13 @@ jobs:
     # their own ratchet floor and run in BOTH feature states (default + shacl-af).
     # See research/shacl12-conformance-gap.md for the per-category gap map.
     name: W3C SHACL conformance (ratchet — core >= 98, sparql >= 5; full 1.2 ratchets in-runner)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: this lane runs only `cargo test -p sparq-shacl`; skip
+    # when ENFORCED selection proves sparq-shacl unaffected (fail-closed guard).
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-shacl"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -989,8 +1081,14 @@ jobs:
     # same belt-and-braces `>= floor` gate the SHACL/SPARQL jobs use. Never lower
     # the floor (raise OGC_RATCHET_FLOOR as the corpus grows).
     name: W3C/OGC GeoSPARQL conformance (ratchet — topology >= 119, query-rewrite >= 38)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: runs `cargo test -p sparq-geo` AND the sparq-conformance
+    # scoreboard bin — skip only when ENFORCED selection proves BOTH unaffected.
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-geo"') ||
+       contains(needs.select.outputs.affected, '"sparq-conformance"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -1117,8 +1215,14 @@ jobs:
     # belt-and-braces `>= floor` gate the SHACL/geo jobs use. Never lower the floor
     # (raise WAC_SCENARIO_FLOOR / ACP_SCENARIO_FLOOR as the corpus grows).
     name: Solid WAC/ACP conformance (ratchet — wac >= 12, acp >= 12)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: runs `cargo test -p sparq-solid` AND the
+    # sparq-conformance scoreboard bin — skip only when BOTH are unaffected.
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-solid"') ||
+       contains(needs.select.outputs.affected, '"sparq-conformance"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -1208,8 +1312,14 @@ jobs:
     # umbrella-action divergence, duty-unknown) that never fails the gate. Never
     # lower the ratchet (raise ODRL_SUITE_FLOOR as the fragment grows).
     name: SolidLab ODRL conformance (ratchet — pass >= 59)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: runs `cargo test -p sparq-policy` AND the
+    # sparq-conformance scoreboard bin — skip only when BOTH are unaffected.
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-policy"') ||
+       contains(needs.select.outputs.affected, '"sparq-conformance"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -1296,8 +1406,14 @@ jobs:
     # belt-and-braces `>= floor` gate the other ratchet jobs use. Never lower the
     # floor (raise TEXT_ORACLE_FLOOR as the battery grows).
     name: sparq-text BM25 differential oracle (extension ratchet — assertions >= 18750)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: runs `cargo test -p sparq-text` AND the
+    # sparq-conformance scoreboard bin — skip only when BOTH are unaffected.
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-text"') ||
+       contains(needs.select.outputs.affected, '"sparq-conformance"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -1387,8 +1503,14 @@ jobs:
     # other ratchet jobs use. Never lower the floor (raise RSP_EXPRESSIVITY_FLOOR as
     # the battery grows).
     name: sparq-rsp RSP expressivity / SRBench correctness (extension ratchet — assertions >= 149)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: runs `cargo test -p sparq-rsp` AND the
+    # sparq-conformance scoreboard bin — skip only when BOTH are unaffected.
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-rsp"') ||
+       contains(needs.select.outputs.affected, '"sparq-conformance"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -1481,8 +1603,13 @@ jobs:
     # ratchet (raise TORDF_FLOOR / FROMRDF_FLOOR / COMPACT_FLOOR / FRAME_FLOOR as
     # oxjsonld + the native writer/compactor/framer improve).
     name: W3C JSON-LD 1.1 conformance (ratchet — toRdf >= 413, fromRdf >= 51, compact >= 186, frame >= 61)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: runs `-p sparq-conformance` (jsonld-suite) — skip only
+    # when ENFORCED selection proves sparq-conformance unaffected (fail-closed).
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-conformance"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -1594,8 +1721,13 @@ jobs:
     # suites wire onto it in later beads. NO conformance floor is graduated yet — this lane
     # proves the harness + the end-to-end path + the fail-closed SSRF egress scoping.
     name: SERVICE-federation harness (in-process loopback smoke + egress scoping)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: runs `-p sparq-conformance` (service/http-protocol/
+    # federation-descriptors features) — skip only when it is unaffected.
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-conformance"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -1702,8 +1834,13 @@ jobs:
     # GATES exactly like the SPARQL ratchet above: a drop below the count is a
     # conformance regression and fails CI. Never lower the ratchet.
     name: Inference conformance (ratchet >= 1967 pass+divergence)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: runs `-p sparq-conformance` (inference bin + d-entail/
+    # rif-core suites) — skip only when ENFORCED selection proves it unaffected.
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-conformance"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -491,6 +491,36 @@ jobs:
       # before every merge depends on it.
       - name: Self-test ci-summary gate loop (verdict semantics + adaptive saturation budget — sq-90cv4)
         run: python3 scripts/tests/test_ci_summary_gate.py
+      # [FABLE-5] sq-fmx4u.3: the change-based test-selection stack is now
+      # LOAD-BEARING (the select pre-job feeds every wide lane's skip guard and
+      # the ci-summary gate's skipped-only-under-successful-selection rule), so
+      # its whole test surface gates HERE on every PR:
+      #   * test_ci_select.py       — the affected-set selector (sq-fmx4u.1):
+      #     closure math, §4.1 full-run triggers, fail-closed error paths, the
+      #     shadow/filterset wiring hooks. Hermetic (synthetic metadata; the one
+      #     real-metadata case self-skips without cargo).
+      #   * test_path_ownership.py  — the ownership map + out-of-crate-input
+      #     audit (sq-fmx4u.2): map validity, trigger-mirror drift guard.
+      #   * test_ci_select_wiring.py — cross-file INSPECTION of the wiring
+      #     itself: every selection-consuming `if:` carries the fail-closed
+      #     `mode != 'selected'` disjunct (empty outputs => run), every literal
+      #     '"<crate>"' guard needle is a REAL workspace member (a typo would
+      #     skip a lane exactly when it should run), the ci-select.yml job name
+      #     matches the gate's SELECT_RE, select callers are unconditional, and
+      #     shadow stays default-ON until CI_SELECT_MODE == 'enforce'.
+      # The wiring test needs PyYAML to parse the workflows — same hash-pinned
+      # install the skill-frontmatter/setup jobs use (complete closure, no deps).
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Install PyYAML (pinned) for the selection wiring inspection test
+        run: pip install --require-hashes -r .github/requirements/docs-quality.txt
+      - name: Self-test ci_select.py (affected-set selector — sq-fmx4u.1/.3)
+        run: python3 scripts/tests/test_ci_select.py
+      - name: Self-test path-ownership map + out-of-crate-input audit (sq-fmx4u.2)
+        run: python3 scripts/tests/test_path_ownership.py
+      - name: Selection wiring inspection (fail-closed guards + real crate needles — sq-fmx4u.3)
+        run: python3 scripts/tests/test_ci_select_wiring.py
 
   # ----------------------------- ADVISORY -----------------------------
   markdownlint-advisory:

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -145,6 +145,27 @@ jobs:
             echo "pull_request -> paths-filter says rust=${{ steps.filter.outputs.rust }}"
           fi
 
+  # [FABLE-5] sq-fmx4u.3: change-based test-selection pre-job (reusable — doctrine
+  # in .github/workflows/ci-select.yml; same instance shape as ci.yml's). The
+  # `setup` job below consumes its outputs to FILTER the assembled leg list when
+  # selection is ENFORCED (mode == 'selected'); shadow/full/missing outputs
+  # fail-close to the full leg set inside scripts/assemble-feature-matrix.py.
+  # UNCONDITIONAL (no needs/if): the ci-summary gate requires every selection
+  # check-run to conclude success before any skipped sibling counts as satisfied.
+  # NOTE (why assembly-time filtering, not the per-leg job-level `if:` guard the
+  # design sketched): the `matrix` context is NOT available in jobs.<job_id>.if
+  # (GitHub contexts-availability), where a `matrix.crate` reference silently
+  # evaluates EMPTY — under enforcement that would skip EVERY leg unconditionally.
+  # Filtering in the (unit-tested) assembler keeps the per-leg decision in Python;
+  # an unassembled leg spawns no check-run, which the polling aggregator simply
+  # never waits on (requiredness flows through `ci-summary / gate`, not per-leg
+  # names — bead sq-fmx4u.4 verifies this against live branch protection).
+  select:
+    name: select
+    uses: ./.github/workflows/ci-select.yml
+    permissions:
+      contents: read
+
   # [OPUS-4.8] sq-ibrze: assemble the dynamic matrix from the per-crate fragment files.
   # This decouples adding a leg (edit one `.github/feature-matrix.d/<crate>.yml`) from
   # this shared workflow file, killing the recurring adjacent-append merge conflict. The
@@ -155,7 +176,7 @@ jobs:
   # behind the same `changes` gate as the legs, so a non-Rust PR skips it (and the legs
   # below `need` it, so they skip too — the aggregator treats both as non-failing).
   setup:
-    needs: changes
+    needs: [changes, select]
     if: needs.changes.outputs.rust_changed == 'true'
     name: assemble feature matrix
     runs-on: ubuntu-latest
@@ -163,6 +184,9 @@ jobs:
       contents: read
     outputs:
       matrix: ${{ steps.assemble.outputs.matrix }}
+      # [FABLE-5] sq-fmx4u.3: leg COUNT, so `opt-in-features` can skip (instead of
+      # exploding on an empty matrix) when enforced selection filters every leg out.
+      legs: ${{ steps.assemble.outputs.legs }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -188,16 +212,30 @@ jobs:
         # assembler validates every fragment (required keys, non-empty features, no
         # duplicate leg names) and exits non-zero on any malformed fragment, so a bad
         # fragment fails THIS gating job instead of producing a silently-truncated matrix.
+        # [FABLE-5] sq-fmx4u.3: --select-mode/--affected filter the legs to the
+        # affected closure ONLY when the selection pre-job says mode == 'selected';
+        # shadow/full/empty/malformed inputs fail-close to the FULL leg set inside
+        # the assembler (unit-tested). `legs` is the post-filter count.
+        env:
+          SELECT_MODE: ${{ needs.select.outputs.mode }}
+          SELECT_AFFECTED: ${{ needs.select.outputs.affected }}
         run: |
           set -euo pipefail
-          MATRIX="$(python3 scripts/assemble-feature-matrix.py)"
+          MATRIX="$(python3 scripts/assemble-feature-matrix.py --select-mode "${SELECT_MODE:-}" --affected "${SELECT_AFFECTED:-}")"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
-          echo "Assembled $(echo "$MATRIX" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["include"]))') opt-in leg(s):"
+          LEGS="$(echo "$MATRIX" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["include"]))')"
+          echo "legs=$LEGS" >> "$GITHUB_OUTPUT"
+          echo "Assembled $LEGS opt-in leg(s) (select mode: ${SELECT_MODE:-<unset>}). Full leg-name set:"
           python3 scripts/assemble-feature-matrix.py --names
 
   opt-in-features:
     needs: [changes, setup]
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: `legs != '0'` skips this job when enforced selection
+    # filtered EVERY leg out (an empty `include` would otherwise be a matrix
+    # error, i.e. a false RED). Fail-closed: a missing/empty `legs` output is
+    # != '0' => run; and if `setup` itself failed, this job skips via `needs`
+    # while the gate REDs on setup's failure.
+    if: needs.changes.outputs.rust_changed == 'true' && needs.setup.outputs.legs != '0'
     # One matrix leg per crate + opt-in feature(group). Coexisting opt-in features of a
     # single crate are combined into ONE `--features a,b,c` leg (e.g. the sparq-server
     # federation/persistence/test seams) so the crate is compiled once per leg, not once
@@ -299,8 +337,14 @@ jobs:
   # required `ci-summary / gate` aggregator auto-discovers it as REQUIRED (no edit to
   # ci-summary.yml).
   server-no-default-features:
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [FABLE-5] sq-fmx4u.3: single-crate lane (`-p sparq-server` only) — skip when
+    # ENFORCED selection proves sparq-server unaffected (fail-closed guard: empty/
+    # missing outputs or shadow/full mode => run).
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-server"'))
     name: sparq-server pure-serialiser (--no-default-features)
     runs-on: ubuntu-latest
     permissions:

--- a/scripts/assemble-feature-matrix.py
+++ b/scripts/assemble-feature-matrix.py
@@ -30,6 +30,11 @@
 #                                                         #   names ("opt-in <name>"), one
 #                                                         #   per line (for the gate-name
 #                                                         #   preservation proof / tests)
+#   ... --select-mode <mode> --affected '<json array>'    # [FABLE-5] sq-fmx4u.3: when
+#                                                         #   mode == "selected", keep only
+#                                                         #   legs whose crate is affected;
+#                                                         #   ANY other/malformed input
+#                                                         #   fail-closes to the FULL set
 # Exit non-zero (with a diagnostic on stderr) on any malformed fragment.
 
 import glob
@@ -125,12 +130,64 @@ def load_legs():
     return legs
 
 
+def filter_legs_by_selection(legs, select_mode, affected_json):
+    """[FABLE-5] sq-fmx4u.3 (design §5.2): change-based selection over the leg list.
+
+    Keep only the legs whose `crate` is in the affected closure — but ONLY when
+    the selection pre-job says `--select-mode selected`. Every other input is
+    FAIL-CLOSED to the FULL leg set (running more is always sound, design §2/§4.3):
+      * select_mode empty / "shadow" / "full" / anything else  => full set
+      * affected missing, unparsable, or not a list of strings => full set
+        (with a loud stderr warning — that combination means a wiring bug, and
+        the sound degradation is the status quo, never a skip).
+    An affected closure of [] legitimately yields ZERO legs; the workflow's
+    `setup` job emits a `legs` count so the matrix job skips instead of
+    exploding on an empty `include`. Note: matrix-key selection cannot be a
+    job-level `if:` on GitHub Actions — the `matrix` context is not available
+    there (docs: contexts availability), which is why this filtering happens at
+    assembly time. The gate aggregator discovers checks by polling, so an
+    unassembled leg is simply absent (never an "expected but missing" hang);
+    requiredness continues to flow through `ci-summary / gate`.
+    """
+    if select_mode != "selected":
+        return legs
+    affected = None
+    if affected_json:
+        try:
+            affected = json.loads(affected_json)
+        except json.JSONDecodeError:
+            affected = None
+    if not isinstance(affected, list) or not all(isinstance(a, str) for a in affected):
+        sys.stderr.write(
+            "warning: --select-mode selected but --affected is missing/malformed; "
+            "FAILING CLOSED to the full leg set (sq-fmx4u.3, design §4.3)\n"
+        )
+        return legs
+    keep = set(affected)
+    return [leg for leg in legs if leg["crate"] in keep]
+
+
+def _flag_value(argv, flag):
+    """Value of `--flag value` in argv, or None."""
+    for i, a in enumerate(argv):
+        if a == flag and i + 1 < len(argv):
+            return argv[i + 1]
+    return None
+
+
 def main():
     legs = load_legs()
     if "--names" in sys.argv[1:]:
+        # The golden gate-name proof ALWAYS dumps the full set — selection must
+        # never make the byte-identical name contract unverifiable.
         for name in sorted(f"opt-in {leg['name']}" for leg in legs):
             print(name)
         return
+    legs = filter_legs_by_selection(
+        legs,
+        _flag_value(sys.argv[1:], "--select-mode"),
+        _flag_value(sys.argv[1:], "--affected"),
+    )
     # Emit a single-line JSON object so the workflow can capture it with
     # `echo "matrix=$(...)" >> "$GITHUB_OUTPUT"` and feed `fromJSON(... .matrix)`.
     print(json.dumps({"include": legs}, ensure_ascii=False, separators=(",", ":")))

--- a/scripts/ci_select.py
+++ b/scripts/ci_select.py
@@ -10,9 +10,14 @@
 #   closure (transitive dependents) of every changed crate, derived from
 #   `cargo metadata`. Emits JSON: {"mode": "selected"|"full", "reason", "affected"}.
 #
-#   This is the SELECTOR LIBRARY ONLY (design §3). The CI WIRING — the `select`
-#   pre-job, the job-level `if:` guards, nextest filtersets, ci-summary
-#   semantics — is the LATER beads sq-fmx4u.2-.6. This file touches no workflow.
+#   This is the SELECTOR LIBRARY (design §3). The CI WIRING — the `select`
+#   pre-job (.github/workflows/ci-select.yml), the job-level `if:` guards, the
+#   nextest filterset narrowing, ci-summary semantics — landed with bead
+#   sq-fmx4u.3 [FABLE-5]; the rollout backstops (nightly full, ci-full label,
+#   the enforcement flip) are bead sq-fmx4u.5. This file stays workflow-
+#   agnostic: it reads a diff + cargo metadata and emits {mode, reason,
+#   affected} plus the $GITHUB_OUTPUT lines (mode/affected/filterset) that the
+#   wiring consumes.
 #
 # THE CORE INVARIANT (design §2, normative):
 #   *A test is skipped => provably no change could affect it.* Skipping is an
@@ -37,6 +42,9 @@
 #   ci_select.py --base <sha> --head <sha>         # explicit revision pair
 #   ci_select.py --event schedule                  # no diff => mode=full
 #   ci_select.py --full                            # forced full (e.g. the `ci-full` label)
+#   ci_select.py --shadow ...                      # report-only: compute + report the
+#                                                  #   selection but emit mode=shadow so no
+#                                                  #   downstream guard skips (design §6.4)
 #   ci_select.py --changed-file paths.txt \        # hermetic inputs (tests): newline-delimited
 #                --metadata-file meta.json          # cargo metadata JSON snapshot
 #
@@ -407,15 +415,48 @@ def load_ownership_map(map_file: str | None) -> list[dict]:
     return entries
 
 
+# --- shadow mode (design §6.4; wired by sq-fmx4u.3, flipped by sq-fmx4u.5) ---
+def shadow_wrap(sel: Selection) -> Selection:
+    """[FABLE-5] Report-only rollout mode: keep the computed selection for the
+    step summary but emit mode="shadow", which every downstream guard treats
+    exactly like any non-"selected" mode — RUN EVERYTHING. The wrap is applied
+    UNIFORMLY (even over a computed mode=full / the error path) so the emitted
+    contract is one rule: --shadow => mode is never "selected" => nothing skips.
+    """
+    return Selection(
+        mode="shadow",
+        reason=f"SHADOW (computed mode={sel.mode}; report-only, nothing is skipped): {sel.reason}",
+        affected=sel.affected,
+        changed_crates=sel.changed_crates,
+        file_owners=sel.file_owners,
+        all_members=sel.all_members,
+    )
+
+
+def filterset(sel: Selection) -> str:
+    """[FABLE-5] The nextest filterset over the affected members, e.g.
+    "package(a) + package(b)". Consumed by the cross-crate bulk test shards to
+    NARROW (never skip) their partition when mode == "selected" (design §5.2).
+    nextest fails loud on a package() naming no package in the archive, so a
+    stale name here cannot silently select nothing."""
+    return " + ".join(f"package({m})" for m in sel.affected)
+
+
 # --- step summary + outputs --------------------------------------------------
 def render_summary(sel: Selection) -> str:
     lines = ["### CI test-selection", "", f"**Mode:** `{sel.mode}` — {sel.reason}", ""]
+    if sel.mode == "shadow":
+        lines.append(
+            "**SHADOW MODE** — selection is REPORT-ONLY on this run: every job still "
+            "runs; the closure below is what enforcement WOULD run (flip: sq-fmx4u.5)."
+        )
+        lines.append("")
     if sel.file_owners:
         lines += ["| Changed file | Owning crate |", "|---|---|"]
         for path, owner in sel.file_owners:
             lines.append(f"| `{path}` | {owner} |")
         lines.append("")
-    if sel.mode == "selected":
+    if sel.mode in ("selected", "shadow"):
         total = len(sel.all_members)
         run = len(sel.affected)
         lines.append(f"**Affected closure ({run} of {total}):** " + (", ".join(sel.affected) or "_none_"))
@@ -431,6 +472,7 @@ def _write_outputs(sel: Selection, output_file: str | None, summary_file: str | 
         with open(output_file, "a", encoding="utf-8") as fh:
             fh.write(f"mode={sel.mode}\n")
             fh.write("affected=" + json.dumps(sel.affected) + "\n")
+            fh.write("filterset=" + filterset(sel) + "\n")
     if summary_file:
         with open(summary_file, "a", encoding="utf-8") as fh:
             fh.write(render_summary(sel))
@@ -440,8 +482,11 @@ def _write_outputs(sel: Selection, output_file: str | None, summary_file: str | 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     p = argparse.ArgumentParser(description="Change-based CI test-selection (design §3).")
     p.add_argument("--event", default="pull_request",
-                   help="GitHub event; schedule/workflow_dispatch => full")
+                   help="GitHub event; anything but pull_request/merge_group => full (no PR diff)")
     p.add_argument("--full", action="store_true", help="force mode=full (e.g. the ci-full label)")
+    p.add_argument("--shadow", action="store_true",
+                   help="report-only rollout mode (design §6.4): compute + report the "
+                        "selection but emit mode=shadow so no downstream guard skips")
     p.add_argument("--base", help="base SHA/ref for the three-dot diff")
     p.add_argument("--head", default="HEAD", help="head SHA/ref (default HEAD)")
     p.add_argument("--changed-file", help="hermetic: newline-delimited changed paths")
@@ -470,9 +515,12 @@ def main(argv: list[str] | None = None) -> int:
     try:
         repo_root = _resolve_repo_root(args.repo_root)
 
-        # Events with no diff, or the explicit override => full (design §3.1, §6).
-        if args.full or args.event in ("schedule", "workflow_dispatch"):
-            reason = "forced full run (ci-full override)" if args.full else f"{args.event} event: no diff"
+        # Events with no PR diff, or the explicit override => full (design §3.1, §6).
+        # [FABLE-5] sq-fmx4u.3: only pull_request and merge_group carry a sound
+        # (base, head) revision pair; push/schedule/workflow_dispatch (and any
+        # future event) get the full matrix by construction, not by error-trap.
+        if args.full or args.event not in ("pull_request", "merge_group"):
+            reason = "forced full run (ci-full override)" if args.full else f"{args.event} event: no PR diff"
             meta = load_metadata(args.metadata_file, repo_root)
             ws = parse_workspace(meta)
             sel = Selection(mode="full", reason=reason, affected=sorted(ws.members),
@@ -499,6 +547,9 @@ def main(argv: list[str] | None = None) -> int:
         # We could not even build the member list; emit full with an empty
         # affected is still "run everything" downstream (mode != 'selected').
         sel = Selection(mode="full", reason=f"selector error, failing to full run: {exc}", affected=[])
+
+    if args.shadow:  # [FABLE-5] report-only rollout (design §6.4; flip: sq-fmx4u.5)
+        sel = shadow_wrap(sel)
 
     print(json.dumps(sel.to_json_obj(), indent=2))
     try:

--- a/scripts/ci_summary_gate.py
+++ b/scripts/ci_summary_gate.py
@@ -49,8 +49,10 @@
 # verdict, so this cannot create a false pass.
 #
 # Exit-0 paths, exhaustively: (1) render_verdict over a stable-empty set;
-# (2) render_verdict over an all-terminal set with zero non-passing GATING checks.
-# There is no other `return 0`.
+# (2) render_verdict over an all-terminal set with zero non-passing GATING checks
+# AND every change-based-selection pre-job check green (sq-fmx4u.3: `skipped` is
+# satisfied only under a successful selection; a present-but-not-success select
+# REDs outright). There is no other `return 0`.
 #
 # Hermetic tests: scripts/tests/test_ci_summary_gate.py (stdlib-only unittest; no
 # network — fetchers are injected). Run: python3 scripts/tests/test_ci_summary_gate.py
@@ -67,6 +69,11 @@ from dataclasses import dataclass, field
 
 ADVISORY_RE = re.compile(r"\b(advisory|informational)\b")
 _PASSING = ("success", "skipped", "neutral")
+# [FABLE-5] sq-fmx4u.3: the change-based test-selection pre-job (the reusable
+# .github/workflows/ci-select.yml job, called from ci.yml + feature-matrix.yml).
+# Its check-run name embeds this phrase; scripts/tests/test_ci_select_wiring.py
+# pins the workflow job name against this regex so the two cannot drift apart.
+SELECT_RE = re.compile(r"change-based test selection")
 
 
 @dataclass
@@ -99,6 +106,15 @@ def is_advisory(name: str) -> bool:
     return bool(ADVISORY_RE.search(name.lower()))
 
 
+def is_select(name: str) -> bool:
+    """[FABLE-5] sq-fmx4u.3: is this check-run the change-based test-selection
+    pre-job? Matched by the stable phrase in its job name (case-insensitive).
+    If the name ever drifts, detection degrades to select_runs == [] — i.e. the
+    PRE-selection semantics (skipped is unconditionally satisfied), never a
+    false RED; the wiring inspection test pins the name so it does not drift."""
+    return bool(SELECT_RE.search(name.lower()))
+
+
 def is_self(run: dict, self_run_id: str) -> bool:
     """True iff this check-run belongs to THIS gate's workflow run. Anchored to
     /runs/<id>(/|$) so a longer sibling run id sharing the prefix can't match."""
@@ -117,14 +133,53 @@ def _emit(line: str, summary_path: str = "") -> None:
 
 def render_verdict(runs: list[dict], summary_path: str = "") -> int:
     """Shared by the clean-converge, graceful-timeout, and post-extension paths, so
-    every path applies IDENTICAL gating semantics. Returns the process exit code."""
+    every path applies IDENTICAL gating semantics. Returns the process exit code.
+
+    SELECTION SEMANTICS ([FABLE-5] sq-fmx4u.3, design §5.3): a `skipped`
+    conclusion is satisfied ONLY when the change-based selection pre-job
+    (is_select) succeeded — a skip is trustworthy iff the thing that decided to
+    skip ran to a successful conclusion. Concretely:
+      * every select check-run present must have conclusion == "success";
+        anything else (failure, cancelled, skipped, neutral, stale) REDs the
+        gate outright, even if every other sibling is green — an unobservable
+        selection means the skips on this commit are unattributable (§4.3);
+      * with select green (or absent — e.g. a pre-selection sibling set, where
+        no skip was produced by selection), `skipped` stays non-failing exactly
+        as before. Absent-select degradation is deliberately the PRE-sq-fmx4u.3
+        behaviour, never a new failure mode.
+    A job that FAILED still fails the gate regardless of selection — selection
+    can only ever decide whether a SKIP is satisfied, never mask a failure."""
     total = len(runs)
     if total == 0:
         _emit("ci-summary: no sibling checks to aggregate (stable empty set) — passing.", summary_path)
         return 0
     gating = [r for r in runs if not is_advisory(r.get("name", ""))]
     excluded = total - len(gating)
-    failed = [r for r in gating if r.get("conclusion") not in _PASSING]
+    # Selection pre-job health — searched over ALL runs (not just gating) so a
+    # hypothetical advisory-renamed select could still never green-light a skip.
+    select_runs = [r for r in runs if is_select(r.get("name", ""))]
+    select_ok = all(r.get("conclusion") == "success" for r in select_runs)
+    skipped_ct = sum(1 for r in gating if r.get("conclusion") == "skipped")
+    if not select_ok:
+        _emit(
+            f"### ci-summary: FAILED — the change-based test-selection pre-job did not "
+            f"succeed, so the {skipped_ct} skipped gating check(s) on this commit cannot "
+            f"be attributed to a sound selection (fail-closed, sq-fmx4u.3 / design §4.3).",
+            summary_path,
+        )
+        for r in select_runs:
+            _emit(f"- ✗ {r.get('name')}: {r.get('conclusion') or 'incomplete'}", summary_path)
+        print("::error::ci-summary failed — the selection pre-job must conclude success.")
+        return 1
+
+    def _satisfied(r: dict) -> bool:
+        c = r.get("conclusion")
+        if c == "skipped":
+            return select_ok  # always True past the gate above; kept explicit so a
+            # future refactor that moves this check cannot silently trust a skip.
+        return c in _PASSING
+
+    failed = [r for r in gating if not _satisfied(r)]
     if failed:
         _emit(
             f"### ci-summary: FAILED — {len(failed)} non-passing gating check(s) of "
@@ -140,6 +195,12 @@ def render_verdict(runs: list[dict], summary_path: str = "") -> int:
         f"{excluded} advisory check(s) excluded; set stable.",
         summary_path,
     )
+    if select_runs:
+        _emit(
+            f"selection: {len(gating) - skipped_ct} of {len(gating)} gating check(s) ran, "
+            f"{skipped_ct} skipped (selection and/or path-filter; selection pre-job succeeded).",
+            summary_path,
+        )
     return 0
 
 

--- a/scripts/tests/test_ci_select.py
+++ b/scripts/tests/test_ci_select.py
@@ -313,6 +313,84 @@ class FailClosedMainTests(unittest.TestCase):
         self.assertEqual(obj["affected"], ["app"])
 
 
+class WiringHookTests(unittest.TestCase):
+    """[FABLE-5] sq-fmx4u.3: the hooks the CI wiring consumes — the shadow rollout
+    mode, the nextest filterset output, and clean full-mode on non-PR events."""
+
+    def _run_main(self, argv):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = cs.main(argv)
+        return code, json.loads(buf.getvalue())
+
+    def _write(self, text, suffix=".json"):
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
+        return path
+
+    def test_push_event_is_clean_full(self):
+        # Any event without a PR diff (push, or a future event name) => full by
+        # construction, not via the error trap.
+        meta_path = self._write(json.dumps(_synthetic_meta()))
+        code, obj = self._run_main(["--event", "push", "--metadata-file", meta_path,
+                                    "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "full")
+        self.assertNotIn("selector error", obj["reason"])
+        self.assertEqual(obj["affected"], ALL_MEMBERS)
+
+    def test_shadow_wraps_selected(self):
+        # --shadow: the selection is COMPUTED (affected preserved for the report)
+        # but the emitted mode is 'shadow', so no guard's `mode == 'selected'`
+        # branch can ever fire => nothing skips.
+        meta_path = self._write(json.dumps(_synthetic_meta()))
+        changed = self._write("crates/app/src/lib.rs\n", suffix=".txt")
+        code, obj = self._run_main(["--shadow", "--metadata-file", meta_path,
+                                    "--changed-file", changed, "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "shadow")
+        self.assertIn("SHADOW (computed mode=selected", obj["reason"])
+        self.assertEqual(obj["affected"], ["app"])
+
+    def test_shadow_wraps_full_and_error_uniformly(self):
+        # The wrap is uniform: even a computed full / a selector error emits
+        # mode=shadow — one downstream rule (shadow is never 'selected').
+        meta_path = self._write(json.dumps(_synthetic_meta()))
+        code, obj = self._run_main(["--shadow", "--event", "schedule",
+                                    "--metadata-file", meta_path, "--repo-root", ROOT])
+        self.assertEqual(obj["mode"], "shadow")
+        self.assertIn("computed mode=full", obj["reason"])
+        code, obj = self._run_main(["--shadow", "--metadata-file", "/no/such/meta.json",
+                                    "--changed-file", self._write("x\n", suffix=".txt"),
+                                    "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "shadow")
+        self.assertIn("selector error", obj["reason"])
+
+    def test_output_file_carries_mode_affected_filterset(self):
+        # The $GITHUB_OUTPUT contract the guards + bulk shards consume.
+        meta_path = self._write(json.dumps(_synthetic_meta()))
+        changed = self._write("crates/app/src/lib.rs\n", suffix=".txt")
+        out_path = self._write("", suffix=".out")
+        code, obj = self._run_main(["--metadata-file", meta_path, "--changed-file", changed,
+                                    "--repo-root", ROOT, "--output-file", out_path])
+        self.assertEqual(code, 0)
+        with open(out_path, encoding="utf-8") as fh:
+            lines = dict(ln.split("=", 1) for ln in fh.read().splitlines() if "=" in ln)
+        self.assertEqual(lines["mode"], "selected")
+        self.assertEqual(json.loads(lines["affected"]), ["app"])
+        self.assertEqual(lines["filterset"], "package(app)")
+
+    def test_filterset_joins_members_with_plus(self):
+        self.assertEqual(
+            cs.filterset(cs.Selection(mode="selected", reason="", affected=["a", "b"])),
+            "package(a) + package(b)",
+        )
+        self.assertEqual(cs.filterset(cs.Selection(mode="full", reason="", affected=[])), "")
+
+
 class RealMetadataShapeTests(unittest.TestCase):
     """(i) Pinned against the REAL workspace metadata: core is root-like, geo is
     leaf-like, and closure(geo) is a subset of closure(core) (structural: geo

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# [FABLE-5] sq-fmx4u.3: cross-file INSPECTION tests for the change-based
+# test-selection wiring — the acceptance criterion "all guards verified
+# fail-closed by inspection test (empty outputs => run)".
+#
+# YAML `if:` expressions cannot be unit-tested by execution, so this suite pins
+# their SHAPE instead, plus every cross-file contract the wiring relies on:
+#   * FAIL-CLOSED GUARDS — every job-level `if:` that consumes the selection
+#     outputs must carry the leading disjunct `needs.select.outputs.mode !=
+#     'selected'`: an EMPTY/missing `mode` output (select failed, output lost)
+#     satisfies it => the job RUNS (design §4.3). Nothing may skip on any
+#     condition reachable with empty outputs.
+#   * REAL CRATE NEEDLES — every literal '"<crate>"' needle passed to
+#     contains(needs.select.outputs.affected, ...) must be a CURRENT workspace
+#     member: a typo'd/renamed needle would make its lane skip exactly when it
+#     should run (the silent-unsound-skip class this whole design forbids).
+#   * NAME CONTRACT — the ci-select.yml job name must match the gate's
+#     SELECT_RE (scripts/ci_summary_gate.py) and must NOT match the advisory
+#     exclusion; otherwise a select failure could stop gating skips.
+#   * UNCONDITIONAL SELECT — the `select` caller jobs must have no `if`/`needs`
+#     (the gate REDs when a selection check-run is missing-not-success, so the
+#     job must exist and run on every trigger).
+#   * matrix-context trap — the per-shard skip must NOT be a job-level `if:`
+#     referencing `matrix.*` (the matrix context is unavailable there and
+#     silently evaluates empty — under enforcement that would skip every leg).
+#
+# Needs PyYAML (same dependency the assembler already has); everything else is
+# stdlib. Run:  python3 scripts/tests/test_ci_select_wiring.py
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+import unittest
+from pathlib import Path
+
+try:
+    import tomllib  # stdlib >= 3.11
+except ModuleNotFoundError:  # pragma: no cover
+    tomllib = None
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CI_YML = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+FM_YML = REPO_ROOT / ".github" / "workflows" / "feature-matrix.yml"
+SELECT_YML = REPO_ROOT / ".github" / "workflows" / "ci-select.yml"
+GATE_PY = REPO_ROOT / "scripts" / "ci_summary_gate.py"
+
+FAIL_CLOSED_DISJUNCT = "needs.select.outputs.mode != 'selected'"
+NEEDLE_RE = re.compile(
+    r"contains\(needs\.select\.outputs\.affected,\s*'\"([A-Za-z0-9_-]+)\"'\)"
+)
+
+
+def _load(path: Path) -> dict:
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _gate_module():
+    spec = importlib.util.spec_from_file_location("ci_summary_gate", GATE_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["ci_summary_gate"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _workspace_members() -> set[str]:
+    """Crate names from crates/*/Cargo.toml — hermetic (no cargo invocation)."""
+    assert tomllib is not None, "Python >= 3.11 required (tomllib)"
+    members = set()
+    for manifest in sorted((REPO_ROOT / "crates").glob("*/Cargo.toml")):
+        with open(manifest, "rb") as fh:
+            data = tomllib.load(fh)
+        name = data.get("package", {}).get("name")
+        if isinstance(name, str):
+            members.add(name)
+    return members
+
+
+class TestWiring(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.ci = _load(CI_YML)
+        cls.fm = _load(FM_YML)
+        cls.sel = _load(SELECT_YML)
+        cls.members = _workspace_members()
+        cls.gate = _gate_module()
+
+    # ---- fail-closed guard shape -------------------------------------------------
+    def test_every_selection_consuming_if_carries_the_fail_closed_disjunct(self):
+        """Any job-level `if:` mentioning the selection outputs must include the
+        `mode != 'selected'` disjunct, so empty/missing outputs mean RUN."""
+        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm)):
+            for job_id, job in wf["jobs"].items():
+                cond = job.get("if", "")
+                if "needs.select.outputs" in str(cond):
+                    self.assertIn(
+                        FAIL_CLOSED_DISJUNCT, str(cond),
+                        f"{wf_name}:{job_id}: selection-consuming `if:` lacks the "
+                        f"fail-closed disjunct {FAIL_CLOSED_DISJUNCT!r}",
+                    )
+
+    def test_selection_guarded_jobs_need_select(self):
+        """A guard reading needs.select.* only resolves if `select` is in needs."""
+        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm)):
+            for job_id, job in wf["jobs"].items():
+                if "needs.select.outputs" in str(job.get("if", "")):
+                    needs = job.get("needs", [])
+                    needs = [needs] if isinstance(needs, str) else needs
+                    self.assertIn("select", needs, f"{wf_name}:{job_id}")
+
+    def test_build_archive_runs_on_any_nonempty_affected(self):
+        cond = str(self.ci["jobs"]["build-archive"]["if"])
+        self.assertIn(FAIL_CLOSED_DISJUNCT, cond)
+        self.assertIn("needs.select.outputs.affected != '[]'", cond)
+
+    # ---- crate needles are real --------------------------------------------------
+    def test_every_affected_needle_is_a_workspace_member(self):
+        text = CI_YML.read_text(encoding="utf-8") + FM_YML.read_text(encoding="utf-8")
+        needles = NEEDLE_RE.findall(text)
+        self.assertTrue(needles, "expected contains(affected, ...) guards to exist")
+        unknown = sorted({n for n in needles if n not in self.members})
+        self.assertEqual(
+            unknown, [],
+            f"guard needle(s) {unknown} are not workspace members — such a lane "
+            f"would SKIP exactly when it should run (silent unsound skip)",
+        )
+
+    def test_shard_crate_keys_are_workspace_members(self):
+        matrix = self.ci["jobs"]["test"]["strategy"]["matrix"]["include"]
+        tagged = [e for e in matrix if e.get("crate")]
+        self.assertTrue(tagged, "expected the heavy shards to carry a crate key")
+        for entry in tagged:
+            self.assertIn(entry["crate"], self.members,
+                          f"shard {entry.get('name')}: crate {entry['crate']!r}")
+        # Both known heavies are sparq-vectors tests; the bulk shards must stay
+        # cross-crate (crate == "" -> narrowed, never skipped).
+        for entry in matrix:
+            if not entry.get("crate"):
+                self.assertIn("partition", entry)
+
+    # ---- matrix-context trap -----------------------------------------------------
+    def test_no_job_level_if_references_matrix_context(self):
+        """`matrix` is NOT available in jobs.<job_id>.if — a reference silently
+        evaluates empty, which under enforcement would skip every leg. The
+        per-shard guard must live in a STEP (env/run), never the job `if:`."""
+        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm)):
+            for job_id, job in wf["jobs"].items():
+                self.assertNotIn(
+                    "matrix.", str(job.get("if", "")),
+                    f"{wf_name}:{job_id}: job-level if cannot see the matrix context",
+                )
+
+    # ---- select job shape ----------------------------------------------------------
+    def test_select_caller_jobs_are_unconditional_and_use_the_reusable_workflow(self):
+        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm)):
+            job = wf["jobs"].get("select")
+            self.assertIsNotNone(job, f"{wf_name}: missing the select job")
+            self.assertEqual(job.get("uses"), "./.github/workflows/ci-select.yml", wf_name)
+            self.assertNotIn("if", job, f"{wf_name}: select must be unconditional")
+            self.assertNotIn("needs", job, f"{wf_name}: select must be unconditional")
+
+    def test_select_job_name_matches_the_gate_detection_contract(self):
+        name = self.sel["jobs"]["select"]["name"]
+        self.assertTrue(self.gate.is_select(name),
+                        f"gate SELECT_RE does not match the select job name {name!r}")
+        self.assertTrue(self.gate.is_select(f"select / {name}"),
+                        "the reusable-call display form must match too")
+        self.assertFalse(self.gate.is_advisory(name),
+                         "the select job name must GATE (no advisory/informational)")
+
+    def test_shadow_default_on_until_enforce(self):
+        text = SELECT_YML.read_text(encoding="utf-8")
+        self.assertIn("--shadow", text)
+        self.assertIn("CI_SELECT_MODE", text)
+        self.assertIn('!= "enforce"', text,
+                      "shadow must be the default for ANY value but the literal 'enforce'")
+
+    # ---- narrowing + assembly wiring ----------------------------------------------
+    def test_bulk_shards_narrow_with_no_tests_pass_only_under_selection(self):
+        steps = self.ci["jobs"]["test"]["steps"]
+        run = next(s for s in steps if "cargo nextest run" in str(s.get("run", "")))
+        script = str(run["run"])
+        self.assertIn('[ "$SELECT_MODE" = "selected" ]', script)
+        self.assertIn("SELECT_FILTERSET", script)
+        # --no-tests=pass only in the narrowed branch: a full/shadow run keeps
+        # the strict no-tests-is-an-error behaviour. Count CODE lines only
+        # (the flag is also, correctly, discussed in a comment).
+        code_lines = [ln for ln in script.splitlines() if not ln.lstrip().startswith("#")]
+        self.assertEqual("\n".join(code_lines).count("--no-tests=pass"), 1)
+        env = run.get("env", {})
+        for key in ("SELECT_MODE", "SELECT_AFFECTED", "SELECT_FILTERSET", "SHARD_CRATE"):
+            self.assertIn(key, env, f"test run step must receive {key} via env")
+
+    def test_feature_matrix_setup_passes_selection_into_the_assembler(self):
+        steps = self.fm["jobs"]["setup"]["steps"]
+        assemble = next(s for s in steps if s.get("id") == "assemble")
+        env = assemble.get("env", {})
+        self.assertIn("SELECT_MODE", env)
+        self.assertIn("SELECT_AFFECTED", env)
+        self.assertIn("--select-mode", str(assemble["run"]))
+        self.assertIn("legs=", str(assemble["run"]))
+        # opt-in-features must skip on a zero-leg assembly instead of exploding
+        # on an empty matrix (and != '0' fail-closes: an unset output means run).
+        self.assertIn("needs.setup.outputs.legs != '0'",
+                      str(self.fm["jobs"]["opt-in-features"]["if"]))
+
+    def test_members_parse_sanity(self):
+        self.assertIn("sparq-core", self.members)
+        self.assertGreater(len(self.members), 30)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_ci_summary_gate.py
+++ b/scripts/tests/test_ci_summary_gate.py
@@ -282,6 +282,84 @@ class TestAdvisoryRule(unittest.TestCase):
         self.assertFalse(g.is_advisory("gate"))
 
 
+# [FABLE-5] sq-fmx4u.3: change-based test-selection semantics (design §5.3).
+# The three load-bearing safety invariants, exactly as the bead states them:
+#   (1) skipped-not-affected + select SUCCESS      => gate SUCCESS (no hang, no RED)
+#   (2) a job that FAILED                          => gate FAILURE (selection never
+#       masks a real failure, with or without skips present)
+#   (3) select present-but-not-success             => gate FAILURE even if every
+#       other sibling is green/skipped (a skip is only trustworthy under a
+#       successful selection — fail-closed, design §4.3)
+# plus the transition guarantee: select ABSENT (a pre-selection sibling set)
+# preserves the previous semantics byte-for-byte (skipped is non-failing).
+SELECT_NAME = "select / select (change-based test selection)"
+SEL_OK = R(SELECT_NAME)
+
+
+class TestSelectionSemantics(unittest.TestCase):
+    def test_skipped_not_affected_with_select_success_passes(self):
+        # Invariant 1: an enforced-selection run — wide lanes skipped, select green.
+        runs = [SEL_OK,
+                R("W3C/OGC GeoSPARQL conformance (ratchet)", conclusion="skipped"),
+                R("opt-in sparq-rsp (rsp)", conclusion="skipped"),
+                GREEN]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 0)
+        self.assertIn("PASSED", out)
+        # The bead's transparency line: N of M ran, K skipped, select healthy.
+        self.assertIn("2 skipped", out)
+        self.assertIn("selection pre-job succeeded", out)
+
+    def test_real_failure_still_fails_under_selection(self):
+        # Invariant 2: selection must never mask a genuine failure.
+        runs = [SEL_OK, RED, R("docs", conclusion="skipped")]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1)
+        self.assertIn("FAILED", out)
+        self.assertIn("clippy", out)
+
+    def test_select_failure_reds_even_when_all_siblings_green(self):
+        # Invariant 3: an unobservable selection blocks the merge outright.
+        runs = [R(SELECT_NAME, conclusion="failure"), GREEN, GREEN2]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1)
+        self.assertIn("selection pre-job", out)
+
+    def test_select_skipped_or_neutral_is_not_success(self):
+        # "did not succeed" is anything but success — a skipped/neutral select
+        # would otherwise sneak through the generic skipped/neutral tolerance.
+        for concl in ("skipped", "neutral", "cancelled", None):
+            runs = [R(SELECT_NAME, conclusion=concl),
+                    R("x", conclusion="skipped"), GREEN]
+            code, out = run(tiny_cfg(), [runs])
+            self.assertEqual(code, 1, f"select conclusion={concl!r} must RED the gate")
+            self.assertIn("selection pre-job", out)
+
+    def test_select_absent_preserves_legacy_skip_semantics(self):
+        # Transition guarantee: no selection check-run on the commit (old sibling
+        # sets / other repos' shapes) => skipped stays non-failing, as before.
+        runs = [R("docs", conclusion="skipped"), GREEN]
+        code, out = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 0)
+        self.assertNotIn("selection pre-job", out)
+
+    def test_multiple_select_runs_all_must_succeed(self):
+        # ci.yml AND feature-matrix.yml each call the reusable select job — the
+        # gate sees two same-named runs; ONE failing must RED the gate.
+        runs = [SEL_OK, R(SELECT_NAME, conclusion="failure"), GREEN]
+        code, _ = run(tiny_cfg(), [runs])
+        self.assertEqual(code, 1)
+
+    def test_select_name_detection_contract(self):
+        # The name-detection contract with .github/workflows/ci-select.yml (also
+        # pinned cross-file by scripts/tests/test_ci_select_wiring.py).
+        self.assertTrue(g.is_select(SELECT_NAME))
+        self.assertFalse(g.is_select("build + test"))
+        self.assertFalse(g.is_select("gate"))
+        # And the select job must never be advisory-excluded.
+        self.assertFalse(g.is_advisory(SELECT_NAME))
+
+
 # [SONNET-4.6] Robustness-hardening tests (sq-90cv4 follow-up: Copilot gaps).
 # Covers:
 #   (a) _gh_json_lines converts subprocess raises (FileNotFoundError, TimeoutExpired)

--- a/scripts/tests/test_feature_matrix_assemble.py
+++ b/scripts/tests/test_feature_matrix_assemble.py
@@ -127,7 +127,7 @@ class TestFeatureMatrixAssemble(unittest.TestCase):
                 self.mod.main()
         finally:
             sys.argv = argv
-        printed = [l for l in buf.getvalue().splitlines() if l.strip()]
+        printed = [ln for ln in buf.getvalue().splitlines() if ln.strip()]
         self.assertEqual(printed, self.names)
 
     # ---- workflow wiring guard (prevents reintroducing the static list) ----------
@@ -157,6 +157,81 @@ class TestFeatureMatrixAssemble(unittest.TestCase):
             self.assertIsInstance(
                 data, list, f"{frag.name}: top level must be a YAML list of legs"
             )
+
+
+# [FABLE-5] sq-fmx4u.3: change-based selection over the assembled leg list
+# (filter_legs_by_selection). The load-bearing property is FAIL-CLOSED: the ONLY
+# input shape that may drop a leg is the exact mode "selected" with a well-formed
+# affected list; every other input (shadow, full, unset, malformed JSON, wrong
+# type) yields the FULL leg set — running more is always sound (design §2/§4.3).
+class TestSelectionFiltering(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_assembler()
+        cls.legs = cls.mod.load_legs()
+
+    def _filter(self, mode, affected):
+        return self.mod.filter_legs_by_selection(self.legs, mode, affected)
+
+    def test_selected_keeps_only_affected_crates(self):
+        crates = sorted({leg["crate"] for leg in self.legs})
+        keep = crates[0]
+        got = self._filter("selected", json.dumps([keep]))
+        self.assertTrue(got, "expected at least one leg for a real crate")
+        self.assertEqual({leg["crate"] for leg in got}, {keep})
+        # And every one of that crate's legs survives — filtering is per-crate,
+        # never per-leg-subset.
+        self.assertEqual(len(got), sum(1 for leg in self.legs if leg["crate"] == keep))
+
+    def test_selected_with_empty_affected_yields_zero_legs(self):
+        # Legitimate: a provably-empty closure => no legs; the workflow's `legs`
+        # count output then SKIPS the matrix job (never an empty-matrix error).
+        self.assertEqual(self._filter("selected", "[]"), [])
+
+    def test_shadow_full_and_unset_modes_keep_all(self):
+        for mode in ("shadow", "full", "", None, "SELECTED", "enforce"):
+            self.assertEqual(len(self._filter(mode, "[]")), len(self.legs),
+                             f"mode={mode!r} must fail-close to the FULL leg set")
+
+    def test_malformed_affected_fails_closed_to_full(self):
+        for bad in (None, "", "not json", '{"a": 1}', '"str"', '[1, 2]'):
+            self.assertEqual(len(self._filter("selected", bad)), len(self.legs),
+                             f"affected={bad!r} must fail-close to the FULL leg set")
+
+    def test_names_mode_ignores_selection_flags(self):
+        # The golden gate-name proof must always dump the FULL set.
+        import io
+        from contextlib import redirect_stdout
+
+        buf = io.StringIO()
+        argv = sys.argv
+        sys.argv = ["assemble-feature-matrix.py", "--names",
+                    "--select-mode", "selected", "--affected", "[]"]
+        try:
+            with redirect_stdout(buf):
+                self.mod.main()
+        finally:
+            sys.argv = argv
+        printed = [ln for ln in buf.getvalue().splitlines() if ln.strip()]
+        self.assertEqual(printed, sorted(f"opt-in {leg['name']}" for leg in self.legs))
+
+    def test_main_applies_selection_to_matrix_json(self):
+        import io
+        from contextlib import redirect_stdout
+
+        crates = sorted({leg["crate"] for leg in self.legs})
+        keep = crates[-1]
+        buf = io.StringIO()
+        argv = sys.argv
+        sys.argv = ["assemble-feature-matrix.py",
+                    "--select-mode", "selected", "--affected", json.dumps([keep])]
+        try:
+            with redirect_stdout(buf):
+                self.mod.main()
+        finally:
+            sys.argv = argv
+        obj = json.loads(buf.getvalue())
+        self.assertEqual({leg["crate"] for leg in obj["include"]}, {keep})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5) — bead **sq-fmx4u.3** (epic sq-fmx4u), design [`research/change-based-test-selection.md`](../blob/main/research/change-based-test-selection.md) §5. Merge-critical: routed through independent adversarial verification — **not self-armed**.

Wires the change-based test-selection core into the PR matrix, **SHADOW-first**: on this PR and every PR after it, the selector *computes and reports* the would-be selection in its step summary while **everything still runs**. Enforcement flips only when the repo variable `CI_SELECT_MODE` is set to the literal `enforce` (bead sq-fmx4u.5, after the shadow window).

## What is wired, where

| Piece | File | Mechanism |
|---|---|---|
| `select` pre-job | **new** `.github/workflows/ci-select.yml` (reusable `workflow_call`) | full-history checkout → `scripts/ci_select.py` → outputs `mode` / `affected` (JSON) / `filterset` + step-summary table. Called **unconditionally** from `ci.yml` and `feature-matrix.yml` (`needs:` cannot span workflows) |
| per-crate lanes (conformance / SHACL / geo / Solid / ODRL / text / RSP / JSON-LD / SERVICE-fed / inference, `sparq-server --no-default-features`) | `ci.yml`, `feature-matrix.yml` | job-level fail-closed guard `mode != 'selected' \|\| contains(affected, '"<crate>"')`, needles = the exact `-p` crates each lane runs (incl. the `sparq-conformance` scoreboard bin where used) |
| workspace nextest archive | `ci.yml` `build-archive` | runs whenever the closure is **non-empty**; empty closure ⇒ archive + all shards skip via `needs` |
| cross-crate bulk shards | `ci.yml` `test` | **narrowed, never skipped**: `-E "( not ( HEAVY ) ) & ( package(a) + … )"`; `--no-tests=pass` only in the narrowed branch (full/shadow keep strict no-tests-is-an-error) |
| heavy sparq-vectors shards | `ci.yml` `test` | step-level bash guard (`exit 0` + notice when `sparq-vectors` ∉ affected) |
| opt-in feature legs (~68) | `feature-matrix.yml` `setup` + `scripts/assemble-feature-matrix.py` | **assembly-time filtering** (see deviation below); zero-leg assembly skips the matrix job via the new `legs` output |
| gate semantics | `scripts/ci_summary_gate.py` (+ doctrine in `ci-summary.yml`) | see below |
| selector test surface now CI-gated | `docs-quality.yml` `ci-scripts` | `test_ci_select.py`, `test_path_ownership.py` (**previously unwired**), new `test_ci_select_wiring.py` |

## Gate (`ci-summary / gate`) skipped-job handling

- A `skipped` gating conclusion is satisfied **only when every `select (change-based test selection)` check-run on the commit concluded `success`** — a skip is trustworthy iff the thing that decided it was soundly observed.
- A **present-but-not-success** select (failure/cancelled/skipped/neutral) REDs the gate outright, even with all other siblings green.
- Select **absent** (pre-selection sibling sets, in-flight PRs) ⇒ byte-for-byte the previous semantics — clean transition, no new failure mode.
- A job that **FAILED still fails the gate regardless** — selection can only decide whether a *skip* is satisfied, never mask a failure.
- The check name is **unchanged** (`gate`); requiredness is untouched. PASSED summary now adds "N of M gating check(s) ran, K skipped".

## Fail-safe rules (all inherited from the landed selector, now load-bearing)

1. `Cargo.lock` / root `Cargo.toml` / `rust-toolchain*` / `.cargo/**` / `.github/**` / `scripts/**` / `deny.toml` / `supply-chain/**` / `ci/path-ownership.toml` ⇒ `mode=full`, nothing skips (a selection-logic PR always validates against the full matrix — including this one).
2. Unowned/unmapped path ⇒ full. Selector internal error ⇒ `mode=full`, exit 0.
3. Empty/missing outputs ⇒ every guard's `mode != 'selected'` disjunct ⇒ **run** (inspection-tested).
4. Select job hard-failure ⇒ dependents skip **and the gate REDs** (never a silent pass).
5. Shadow default-ON; unset/typo'd `CI_SELECT_MODE` means shadow (full matrix).
6. `merge_group` uses the same selection over `base_sha…head_sha` (union of queued content — design §3.1/P8).

## Tested safety invariants

1. **skip→SUCCESS** — skipped-not-affected siblings + green select ⇒ gate exit 0 (`test_skipped_not_affected_with_select_success_passes`).
2. **realfail→FAILURE** — a failed sibling under selection ⇒ gate exit 1 (`test_real_failure_still_fails_under_selection`); select failure with all-green siblings ⇒ exit 1; multiple select runs: one bad ⇒ exit 1.
3. **failsafe→run-all** — §4.1 triggers ⇒ full (sq-fmx4u.1 suite, now CI-gated); guard shape inspection: every selection-consuming `if:` carries the fail-closed disjunct, every `'"<crate>"'` needle is a real workspace member (mutation-checked: a typo'd needle reds the suite), select callers unconditional, shadow default pinned.

Mutation checks performed and reverted: `select_ok = True` in the gate ⇒ 2 tests red; `"sparq-geo"`→`"sparq-goe"` needle ⇒ wiring test red.

## Documented deviation from the design/bead text (proceed-and-document)

The bead prescribes the guard **as a job-level `if:` keyed on `matrix.crate`** for the feature-matrix legs. That is not implementable on GitHub Actions: the `matrix` context is **not available** in `jobs.<job_id>.if` (docs → contexts availability: only `github, needs, vars, inputs`); a `matrix.crate` reference silently evaluates empty, and under enforcement `contains(affected, '""')` is false ⇒ **every leg would skip unconditionally** — the exact silent-unsound-skip class the design forbids. Deviations, each fail-closed and pinned by `test_ci_select_wiring.py` (which also asserts no job-level `if:` ever references `matrix.`):
- feature-matrix legs → **assembly-time filtering** in the unit-tested assembler (the matrix was already dynamic post-sq-ibrze; an unassembled leg spawns no check-run, and the polling aggregator never waits on a check that does not exist — requiredness flows through `ci-summary / gate`, which **sq-fmx4u.4 verifies against live branch protection before enforcement**);
- heavy shards → step-level bash guard (the step context *does* see `matrix`), reporting `success` + a skip notice rather than conclusion `skipped`.
- `bench.yml` is untouched: its only per-PR job **is** the perf-gate, which design §5.2 keeps always-run in phase 1 (scoping is bead sq-fmx4u.6). Reconciled lane table is in the ci-select.yml/ci.yml comments.

## Local reproduction (work-box, non-canonical)

- Real selector run (`--event pull_request --base … --head … --shadow` + `$GITHUB_OUTPUT`/`$GITHUB_STEP_SUMMARY`): `.github/**` diff correctly fired the full-run trigger; a `crates/sparq-geo`-only change selects a 4-of-47 closure.
- Assembler: selected+`["sparq-rsp","sparq-server"]` ⇒ 6 legs; shadow ⇒ 68; `[]` ⇒ 0; malformed ⇒ 68 + loud warning.
- nextest 0.9.137: the exact narrowing expression parses and selects; unknown `package()` fails loud (exit 94); empty narrowed set + `--no-tests=pass` ⇒ exit 0.
- All script suites green (33 gate + 32 selector + 13 assembler + 12 wiring + 21 ownership); `ruff` clean; `typos` clean; YAML valid; `actionlint` finding-set identical to baseline (24 pre-existing info-level shellcheck notes in untouched scripts).

**Not locally reproducible** (documented-untested; validate on first CI runs, all shadow-safe): the reusable-workflow check-run display name (`select / select (change-based test selection)`) — the gate matches on the phrase, which survives any `caller / callee` composition, and the wiring test pins both forms; and live `vars.CI_SELECT_MODE` resolution (unset ⇒ shadow by construction).

## Acceptance criteria vs this PR

The bead's selected-mode acceptance run (geo-only branch ⇒ only geo-closure jobs execute) is **exercisable only under enforcement**; this PR ships the wiring shadow-first per the same bead ("ship behind shadow mode default-ON"), so that end-to-end check lands with the sq-fmx4u.5 flip after sq-fmx4u.4's branch-protection verification. What IS verifiable now: this PR's own runs must show `select / select (change-based test selection)` green in the check list, the shadow report in its step summary, and an unchanged-green full matrix.

## Discovered work
- `research/change-based-test-selection.md` §5.2 "The guard" needs an erratum for the matrix-context limitation (research/ is outside this task's staging scope).
- `test_ci_select.py` + `test_path_ownership.py` were never wired into CI by sq-fmx4u.1/.2 — fixed here.
- 24 pre-existing info-level shellcheck findings (SC2015/SC2086) in untouched ci.yml scripts, visible via actionlint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)