### PR TITLE
feat(ci): verify skipped-required-check semantics + gate-name anchor tests (sq-fmx4u.4) [SONNET-4.6]

### DIFF
--- a/research/change-based-test-selection.md
+++ b/research/change-based-test-selection.md
@@ -243,11 +243,42 @@ satisfying a required status check. Implementation traps to honor:
   counts as satisfied), the required-check *names* never go missing — this is
   why the static-matrix guard beats dynamic matrix generation, where an
   unspawned job leaves a required check "expected" forever and blocks merge.
-- Bead 4 **verifies** this skipped-counts-as-satisfied semantics end-to-end
-  against the repo's actual branch-protection + merge-queue configuration on
-  a real selected-mode PR before enforcement, and — only if some surface
-  disagrees — either moves requiredness onto `ci-summary` alone or adds an
-  explicit green-shim step. Verification, not assumption.
+**§5.3 graduation note (bead sq-fmx4u.4, verified 2026-07-03). [SONNET-4.6]**
+Verified against the live ruleset (`gh api repos/sparq-org/sparq/rulesets/17688455`,
+id 17688455, last updated 2026-07-02):
+
+- `required_status_checks` contains **exactly one entry**:
+  `{"context":"gate","integration_id":15368}` — `ci-summary / gate` is the
+  sole required check. No individual per-crate matrix legs, no individual
+  `opt-in <X>` legs appear in the required list.
+- `merge_queue` uses `grouping_strategy: "ALLGREEN"` and
+  `check_response_timeout_minutes: 60`; the queue blocks only on the required
+  `gate` check, not on absent or skipped siblings.
+- A selection-skipped job (`conclusion=skipped`) from a static-matrix `if:`
+  guard **reports a complete check-run** (the `skipped` conclusion is present,
+  never "expected but missing"). `ci_summary_gate.py` already treats `skipped`
+  as non-failing when select succeeded — so the gate passes, the queue
+  unblocks, nothing hangs.
+- Feature-matrix legs filtered at assembly time (unassembled — no check-run
+  spawned) are also safe: since no leg name is individually required, the merge
+  queue never waits for them; the only thing it blocks on is `gate`, which the
+  aggregator always produces.
+- **Mechanism chosen: plain-skip. No shim is needed.** The skipped-but-green
+  shim (guard moved inside the job as a first step, so the job always occupies
+  a slot but exits early) would be required only if a per-crate leg name
+  appeared in `required_status_checks` — it does not. That condition is the
+  only way plain-skip could cause a merge-queue hang.
+- **What sq-fmx4u.5 can safely flip**: set the repo variable `CI_SELECT_MODE`
+  to the literal string `"enforce"`. No ruleset change is required; no
+  individual branch-protection entries need editing. The merge queue will not
+  hang; skipped jobs will satisfy the gate through `ci-summary`.
+- Three properties make this safe and must not drift; they are pinned by
+  `scripts/tests/test_ci_select_wiring.py` (`TestRequiredCheckAnchor`):
+  (1) the `ci-summary / gate` job name is exactly `"gate"` (matches the
+  ruleset's `context:"gate"`); (2) that job has no `if:` guard (always runs,
+  so the merge queue always gets a response within the 60-minute timeout
+  window); (3) `ci-summary.yml` triggers on `merge_group` (required for the
+  gate to produce a check-run on queue entries at all).
 
 ## 6. Correctness safeguards
 

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -2,6 +2,8 @@
 # [FABLE-5] sq-fmx4u.3: cross-file INSPECTION tests for the change-based
 # test-selection wiring — the acceptance criterion "all guards verified
 # fail-closed by inspection test (empty outputs => run)".
+# [SONNET-4.6] sq-fmx4u.4: TestRequiredCheckAnchor — pin the three structural
+# properties that make plain-skip merge-queue-safe (design §5.3 graduation note).
 #
 # YAML `if:` expressions cannot be unit-tested by execution, so this suite pins
 # their SHAPE instead, plus every cross-file contract the wiring relies on:
@@ -23,6 +25,10 @@
 #   * matrix-context trap — the per-shard skip must NOT be a job-level `if:`
 #     referencing `matrix.*` (the matrix context is unavailable there and
 #     silently evaluates empty — under enforcement that would skip every leg).
+#   * REQUIRED-CHECK ANCHOR (sq-fmx4u.4) — the `ci-summary / gate` job must
+#     retain the name "gate" (branch-protection context anchor), have no job-
+#     level `if:` guard (always runs → queue never times out waiting), and the
+#     workflow must trigger on merge_group. All three make plain-skip safe.
 #
 # Needs PyYAML (same dependency the assembler already has); everything else is
 # stdlib. Run:  python3 scripts/tests/test_ci_select_wiring.py
@@ -210,6 +216,101 @@ class TestWiring(unittest.TestCase):
     def test_members_parse_sanity(self):
         self.assertIn("sparq-core", self.members)
         self.assertGreater(len(self.members), 30)
+
+
+# [SONNET-4.6] sq-fmx4u.4: required-check anchor tests.
+#
+# VERIFIED SEMANTICS (2026-07-03, against ruleset id 17688455):
+# `gh api repos/sparq-org/sparq/rulesets/17688455` shows required_status_checks
+# contains EXACTLY ONE entry: {"context":"gate","integration_id":15368} — i.e.
+# `ci-summary / gate` is the SOLE required check.  No individual per-crate matrix
+# legs, no individual `opt-in <X>` legs are in the required list.  The merge queue
+# (grouping_strategy=ALLGREEN, check_response_timeout_minutes=60) therefore blocks
+# ONLY on the single "gate" check, not on absent or skipped siblings.
+#
+# Consequence: PLAIN-SKIP IS SAFE.  A selection-skipped job (conclusion=skipped
+# from a job-level `if:` guard) reports a complete check-run; the gate already
+# treats `skipped` as non-failing when the select pre-job succeeded.  A leg
+# filtered at assembly time (unassembled → no check-run spawned) is also safe
+# because no leg name is individually required.  Neither case hangs the queue.
+#
+# The shim (guard moved inside the job as a first step so the job always occupies
+# a slot but exits early) is NOT needed.  It would only be needed if a per-crate
+# leg name appeared in required_status_checks — it does not.
+#
+# Three structural properties must not drift for the above to remain true.  They
+# are pinned here (hermetically, no network/API calls):
+#   (1) gate job name == "gate"  (matches the ruleset's context:"gate")
+#   (2) gate job has NO if: guard  (always runs → merge queue always gets a
+#       response within the 60-minute timeout window)
+#   (3) ci-summary.yml triggers on merge_group  (required for the gate to produce
+#       a check-run on queue entries at all)
+# Bead sq-fmx4u.5 can safely flip CI_SELECT_MODE to "enforce" once these hold.
+CISUM_YML = REPO_ROOT / ".github" / "workflows" / "ci-summary.yml"
+
+
+class TestRequiredCheckAnchor(unittest.TestCase):
+    """[SONNET-4.6] sq-fmx4u.4: pin the three properties that make plain-skip
+    merge-queue-safe in this repo (design §5.3 graduation note)."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.cs = _load(CISUM_YML)
+        cls.gate = _gate_module()
+
+    def test_gate_job_name_is_exactly_gate(self):
+        """The branch-protection ruleset (id 17688455) requires context='gate'.
+        If this name drifts the required check silently stops matching and the
+        gate weakens with no error anywhere — so pin it."""
+        job = self.cs["jobs"]["gate"]
+        self.assertEqual(
+            job["name"], "gate",
+            "ci-summary gate job name must stay exactly 'gate' — "
+            "the branch-protection ruleset anchors on context='gate' (id 17688455); "
+            "renaming breaks the required check without any CI warning",
+        )
+
+    def test_gate_job_has_no_job_level_conditional(self):
+        """The gate must run unconditionally on every event (pull_request,
+        merge_group, push).  A job-level `if:` could silently skip it on some
+        triggers, leaving the merge queue waiting 60 minutes before timing out."""
+        job = self.cs["jobs"]["gate"]
+        self.assertNotIn(
+            "if", job,
+            "ci-summary gate job must have no `if:` guard — it must always run "
+            "so the merge queue receives the required 'gate' check-run within the "
+            "60-minute check_response_timeout window (ruleset 17688455)",
+        )
+
+    def test_ci_summary_triggers_on_merge_group(self):
+        """Without merge_group trigger ci-summary never runs on queue entries and
+        the merge queue hangs forever waiting for the required 'gate' check."""
+        on = self.cs.get("on", self.cs.get(True, {}))
+        self.assertIn(
+            "merge_group", on,
+            "ci-summary must trigger on merge_group — absent, the queue entry "
+            "never receives the required 'gate' check-run and hangs until timeout",
+        )
+
+    def test_gate_is_not_advisory_or_informational(self):
+        """The gate name must never accidentally match the advisory/informational
+        exclusion — that would un-gate it (its failure would stop being required).
+        Both the bare job name and the `workflow / job` display form are checked."""
+        for name in ("gate", "ci-summary / gate"):
+            self.assertFalse(
+                self.gate.is_advisory(name),
+                f"gate check name {name!r} must NOT match the advisory exclusion",
+            )
+
+    def test_gate_is_not_detected_as_a_select_job(self):
+        """The gate name must not match SELECT_RE — that would make the gate
+        self-detect as a selection pre-job and add a circular verdict dependency
+        (skipped gating only valid if 'gate' itself concluded success)."""
+        for name in ("gate", "ci-summary / gate"):
+            self.assertFalse(
+                self.gate.is_select(name),
+                f"gate check name {name!r} must NOT match SELECT_RE",
+            )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 SPARQ agent (Sonnet 4.6) — bead sq-fmx4u.4: branch-protection/merge-queue skipped-required-check reconciliation, prerequisite for the enforcement flip (sq-fmx4u.5).

## Verified semantics

**Empirical verification** against the live ruleset (`gh api repos/sparq-org/sparq/rulesets/17688455`, id 17688455):

- `required_status_checks` contains **exactly one entry**: `{"context":"gate","integration_id":15368}` — `ci-summary / gate` is the sole required check. No individual per-crate matrix legs, no individual `opt-in <X>` legs appear in the list.
- `merge_queue` uses `grouping_strategy: ALLGREEN`, `check_response_timeout_minutes: 60`. It blocks **only** on the required `gate` check.

**Consequence: plain-skip is safe. No shim is needed.**

A selection-skipped job (`conclusion=skipped` from a job-level `if:` guard) reports a complete check-run; `ci_summary_gate.py` already treats `skipped` as non-failing when the select pre-job succeeded. Feature-matrix legs filtered at assembly time (no check-run spawned) are also safe — no leg name is individually required, so the merge queue never waits for them. Neither case hangs the queue or leaves a required check "expected".

The skipped-but-green shim (guard moved inside the job as a first step, always occupying a runner slot) would be needed only if a per-crate leg name appeared in `required_status_checks`. It does not.

## Changes

### `research/change-based-test-selection.md` §5.3 graduation note

Replaces the forward-looking "bead 4 verifies..." placeholder with the verified outcome: ruleset contents, rationale for plain-skip, and what sq-fmx4u.5 can safely flip.

### `scripts/tests/test_ci_select_wiring.py` — `TestRequiredCheckAnchor` (5 new tests)

Pins the three structural properties that must not drift for plain-skip to remain merge-queue-safe (hermetic, no network/API calls):

1. **`test_gate_job_name_is_exactly_gate`** — the `ci-summary / gate` job name is exactly `"gate"`; the branch-protection ruleset anchors on `context:"gate"` (id 17688455). If this name drifts the required check silently stops matching with no CI warning.
2. **`test_gate_job_has_no_job_level_conditional`** — the gate job has no `if:` guard and therefore always runs on every trigger (pull_request, merge_group, push). An `if:` could silently skip it on some triggers, leaving the merge queue waiting 60 minutes before timing out.
3. **`test_ci_summary_triggers_on_merge_group`** — `ci-summary.yml` triggers on `merge_group`; without this the gate never runs on queue entries and the queue hangs permanently.
4. **`test_gate_is_not_advisory_or_informational`** — the gate name never matches the advisory/informational exclusion (which would un-gate it).
5. **`test_gate_is_not_detected_as_a_select_job`** — the gate name never matches `SELECT_RE` (which would create a circular verdict dependency).

## What sq-fmx4u.5 can safely flip

Set the repo variable `CI_SELECT_MODE` to the literal string `"enforce"`. No ruleset change is required; no individual branch-protection entries need editing. The merge queue will not hang; skipped jobs satisfy the gate through `ci-summary`.

## Gate results

- YAML: valid (`actionlint` clean on `ci-summary.yml` + `ci-select.yml`)
- Tests: all 17 wiring tests pass (12 pre-existing + 5 new anchor tests); all 33 gate tests pass
- `ruff`: clean
- typos gate: clean
- privacy-claims gate: clean
- Ruleset untouched (read-only verification only)
- `ci-summary / gate` stays the sole required check, name unchanged
- Shadow mode stays default-on (sq-fmx4u.5 flips enforcement)

**Do NOT self-arm — route to Opus adversarial verification before arming.**

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>