### PR TITLE
feat(site-e2e): home hero-runner journeys (sq-ymr2e.3) [SONNET-4.6]

### DIFF
--- a/.github/workflows/site-e2e-hero.yml
+++ b/.github/workflows/site-e2e-hero.yml
@@ -74,7 +74,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
+            ${{ github.workspace }}/target
           key: site-e2e-hero-wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
           restore-keys: site-e2e-hero-wasm-${{ runner.os }}-
 
@@ -90,7 +90,7 @@ jobs:
       # Cache Playwright browsers keyed on the resolved @playwright/test version.
       - name: Resolve Playwright version
         id: pw
-        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+        run: echo "version=$(node -p 'require("@playwright/test/package.json").version')" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:

--- a/.github/workflows/site-e2e-hero.yml
+++ b/.github/workflows/site-e2e-hero.yml
@@ -1,0 +1,117 @@
+# [SONNET-4.6] sq-ymr2e.3 — ADVISORY CI lane for the home hero-runner E2E journeys.
+#
+# Runs the five P1 journeys in site/e2e/home-runner.spec.ts against a real headless Chromium
+# with the lean wasm bundle built from source — so the "engine-computed rows" and "zero-network
+# invariant" are verified against the actual Rust engine on every site/ change.
+#
+# ADVISORY (continue-on-error: true on both Playwright steps). The heroic run of all five
+# journeys + the stress (--repeat-each=5) needs a full wasm build (~25 min with warm cache).
+# Making it advisory keeps PR CI snappy on Rust-only changes while surfacing failures as a
+# visible check that the maintainer can inspect.
+#
+# SCOPE: path-scoped to site/**, the root lock files (same reasoning as site-e2e.yml — npm ci
+# resolves from the root lockfile, so a lockfile bump can break the install), and this workflow.
+# A Rust-only or docs-only PR never triggers this lane.
+name: site-e2e-hero
+
+on:
+  pull_request:
+    paths:
+      - "site/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/site-e2e-hero.yml"
+  push:
+    branches: [main]
+    paths:
+      - "site/**"
+      - "package.json"
+      - "package-lock.json"
+      - ".github/workflows/site-e2e-hero.yml"
+
+# Least-privilege default (Scorecard TokenPermissions): read-only; this lane never writes.
+permissions:
+  contents: read
+
+# One in-flight run per PR/branch; cancel a superseded run.
+concurrency:
+  group: site-e2e-hero-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  site-e2e-hero:
+    name: home hero-runner journeys (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # Node 22 — npm cache keys off the REPO-ROOT lockfile (site/ is a workspace member;
+      # the per-member site/package-lock.json was dropped when workspaces were introduced).
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install npm dependencies (from the repo-root workspace lock)
+        run: npm ci
+
+      # Rust stable + wasm32 target + wasm-pack — needed to build the lean wasm bundle.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      # Cache Cargo artefacts keyed on Cargo.lock so a same-tree rebuild skips compilation.
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: site-e2e-hero-wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: site-e2e-hero-wasm-${{ runner.os }}-
+
+      # Build the lean wasm bundle (wasm-pack → crates/sparq-wasm/pkg → js/wasm/).
+      # Run from js/ (one level above site/) so the relative Cargo.toml path is correct.
+      - name: Build lean wasm bundle
+        run: cd ../js && npm run build:wasm:lean
+
+      # Copy the built bundle into site/public/wasm/ (the path next dev serves it from).
+      - name: Sync wasm bundle into site/public/wasm/
+        run: npm run sync-wasm
+
+      # Cache Playwright browsers keyed on the resolved @playwright/test version.
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+
+      - name: Install Playwright Chromium (+ OS deps)
+        run: npx playwright install --with-deps chromium
+
+      # Determinism gate: zero waitForTimeout calls in the whole e2e/ tree (HARD — must pass).
+      - name: Determinism grep gate (no waitForTimeout calls)
+        run: npm run test:e2e:grep-gate
+
+      # Run the five P1 home hero-runner journeys. Advisory: failures surface as a visible check
+      # but do not block the PR while wasm/CI flakiness is worked out.
+      - name: Home hero-runner E2E journeys
+        run: npm run test:e2e -- home-runner.spec.ts
+        continue-on-error: true
+
+      # Stress run (--repeat-each=5 --retries=0): 25 runs with zero retries prove the suite is
+      # deterministic — any flake appears as a failure across 25 iterations. Advisory.
+      - name: Home hero-runner stress test (--repeat-each=5 --retries=0)
+        run: npm run test:e2e:stress -- home-runner.spec.ts
+        continue-on-error: true

--- a/site/e2e/home-runner.spec.ts
+++ b/site/e2e/home-runner.spec.ts
@@ -1,0 +1,323 @@
+// [SONNET-4.6] sq-ymr2e.3 — the HOME hero-runner P1 journey suite.
+//
+// Design of record: research/web-gui-test-program.md §2.1 (home hero-runner journeys).
+//
+// Implements five P1 journeys that prove the home hero's in-browser WASM SPARQL runner
+// actually computes results (a JOIN + SUM + ORDER BY that a static site cannot credibly fake),
+// keeps ZERO network egress (the zero-network invariant, a machine-check of the "runs in your
+// tab" product promise), and hands off faithfully to the /try workbench.
+//
+// Doctrine (research/web-gui-test-program.md §1):
+//   §1.1  No time-based waits — ONLY web-first waiters (expectRunnerState, web assertions).
+//   §1.3  Stable selectors: getByRole / data-* / aria-label — never Tailwind classes.
+//   §1.7  Never assert a timing value (the WASM instantiate timeout is a BOUND, not a result).
+//
+// WASM PREREQ. The hero runner loads the lean wasm bundle from `public/wasm/`. The light
+// site-e2e CI lane has no Rust toolchain, so this whole file SKIPS when the bundle is absent
+// (matching the try-journeys/try-query-smoke posture). Run locally:
+//   (cd ../js && npm run build:wasm) && npm run sync-wasm \
+//     && npx playwright install chromium && npm run test:e2e -- home-runner.spec.ts
+import { test, expect, BasePage } from "./support";
+import { HERO_DEFAULT_QUERY } from "../src/data/hero-sample";
+import { type Locator, type Page } from "@playwright/test";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// The lean wasm bundle the hero runner loads at runtime — gitignored, so its presence gates file.
+const WASM_BUNDLE = fileURLToPath(
+  new URL("../public/wasm/sparq_wasm_bg.wasm", import.meta.url),
+);
+test.skip(
+  !existsSync(WASM_BUNDLE),
+  "lean wasm bundle absent — run `npm run sync-wasm` after `(cd ../js && npm run build:wasm)`",
+);
+
+// ── Custom Turtle for journey (c) ────────────────────────────────────────────────────────────
+// Two contributors with distinct names and line-counts chosen to NOT overlap with the default
+// sample (Ada/Lin/Grace/7300/6100/5300), so the result rows prove the DATA TAB was actually
+// used — a query against the default graph could not produce Xena/999 or Yoko/111.
+const CUSTOM_TURTLE = `@prefix :     <http://sparq.dev/demo/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+:xena foaf:name "Xena" ; :wrote :codeX .
+:yoko foaf:name "Yoko" ; :wrote :codeY .
+
+:codeX a :Component ; :linesOfCode 999 ; :lang "Rust" .
+:codeY a :Component ; :linesOfCode 111 ; :lang "Rust" .
+`;
+
+// Expected DESC rows for CUSTOM_TURTLE with HERO_DEFAULT_QUERY (SUM per contributor, ORDER BY DESC).
+const CUSTOM_ROWS: [string, string][] = [
+  ["Xena", "999"],
+  ["Yoko", "111"],
+];
+
+// Default expected rows (Ada 4200+3100=7300, Lin 6100, Grace 5300) in DESC order.
+const DEFAULT_ROWS: [string, string][] = [
+  ["Ada", "7300"],
+  ["Lin", "6100"],
+  ["Grace", "5300"],
+];
+
+// ── HomeRunnerPage page object ────────────────────────────────────────────────────────────────
+// [SONNET-4.6] Kept LOCAL to this one spec file per the bead scope ("new file … ONLY"): the
+// shared e2e/support/ dir stays read-only. Centralises the stable, role/data-* selectors (never
+// a Tailwind class, §1.3 doctrine). Methods are web-first — they return Locators or click/fill
+// and let Playwright's auto-wait handle readiness; no sleeps, no manual waits.
+class HomeRunnerPage extends BasePage {
+  /** Navigate to the home page (route "" resolves under the /sparq/ basePath) and await app-ready. */
+  async gotoReady(): Promise<void> {
+    await this.goto("");
+  }
+
+  /** Click the primary Run button (the big teal CTA in the bottom bar of the hero panel). */
+  async clickRun(): Promise<void> {
+    await this.page.getByRole("button", { name: /Run/ }).click();
+  }
+
+  /** Click the Query tab (shows the SPARQL editor, hides the Data editor). */
+  async clickQueryTab(): Promise<void> {
+    await this.page.getByRole("tab", { name: "Query" }).click();
+  }
+
+  /** Click the Data tab (shows the Turtle editor, hides the SPARQL editor). */
+  async clickDataTab(): Promise<void> {
+    await this.page.getByRole("tab", { name: "Data" }).click();
+  }
+
+  /**
+   * The SPARQL query textbox (accessible when the Query tab is active; hidden under Data tab).
+   * Locator: the <textarea aria-label="SPARQL query"> rendered by SparqlEditor.
+   */
+  queryEditor(): Locator {
+    return this.page.getByRole("textbox", { name: "SPARQL query" });
+  }
+
+  /**
+   * The Turtle data textbox (accessible when the Data tab is active; hidden under Query tab).
+   * Locator: the <textarea aria-label="Sample data (Turtle)"> rendered by RdfEditor.
+   */
+  dataEditor(): Locator {
+    return this.page.getByRole("textbox", { name: "Sample data (Turtle)" });
+  }
+
+  /**
+   * The typed results table; appears once the engine finishes a successful run.
+   * Locator: <table data-hero-results-table> (the stable data-* anchor set by hero-runner.tsx).
+   */
+  resultsTable(): Locator {
+    return this.page.locator("[data-hero-results-table]");
+  }
+
+  /**
+   * The hero error strip (role="alert", data-testid="hero-error"). Only rendered in
+   * phase === "error" && error is truthy. Using data-testid avoids the Next.js route
+   * announcer (which also has role="alert" and is always-present in the DOM but empty).
+   */
+  heroErrorAlert(): Locator {
+    return this.page.getByTestId("hero-error");
+  }
+
+  /**
+   * The proof footer span that shows row count, timing, and "in-browser · 0 network requests".
+   * Only rendered in phase === "done". Locator strategy: regex over the MEASURED text (never a
+   * Tailwind class); the timing number is excluded from the regex so it is NOT asserted (§1.7).
+   */
+  proofFooter(): Locator {
+    return this.page.getByText(/in-browser · 0 network requests/i).first();
+  }
+
+  /**
+   * The "Open in workbench →" button in the proof footer; navigates to /try via router.push.
+   * Only present in phase === "done".
+   */
+  openInWorkbenchButton(): Locator {
+    return this.page.getByRole("button", { name: /Open in workbench/i });
+  }
+
+  /**
+   * Web-first assert the hero results table renders exactly `rows` in order.
+   * Each [col0, col1] pair is a [name, linesOfRust] value. Uses containsText so it is robust
+   * to typed-cell decoration: string literals render as `"Ada"` (with quotes from ResultCell),
+   * numeric literals render as `7300` (plain, no quotes). The assertion also checks the row COUNT
+   * — if the engine returned a different number of rows, `toHaveCount` fails immediately.
+   */
+  async expectResultRows(rows: [string, string][]): Promise<void> {
+    const table = this.resultsTable();
+    await expect(table).toBeVisible();
+    const trs = table.locator("tbody tr");
+    await expect(trs).toHaveCount(rows.length);
+    for (let r = 0; r < rows.length; r++) {
+      const cells = trs.nth(r).locator("td");
+      for (let c = 0; c < rows[r].length; c++) {
+        await expect(cells.nth(c)).toContainText(rows[r][c]);
+      }
+    }
+  }
+}
+
+// ── (a) P1 — idle → results: engine-computed rows in DESC order ─────────────────────────────
+// [SONNET-4.6] The core "it actually runs" proof: the JOIN + SUM + ORDER BY result cannot be
+// credibly produced by a static site — Ada's 7300 is the SUM of two components (4200+3100),
+// which proves the GROUP BY and SUM are real. The exact DESC order proves the ORDER BY fired.
+test("(a) idle→results: exact engine-computed rows in DESC order", async ({ page }) => {
+  const hp = new HomeRunnerPage(page);
+  await hp.gotoReady();
+
+  // The idle-preview state is server-rendered (no WASM needed) — the deterministic anchor.
+  await hp.expectRunnerState("home", "idle-preview");
+
+  await hp.clickRun();
+
+  // Web-first wait: the results table anchor appears only after the engine completes the query.
+  await hp.expectRunnerState("home", "results");
+
+  // Assert EXACT computed rows in DESC order — the load-bearing honesty check.
+  // Ada's 7300 = SUM(4200+3100) (she wrote :parser AND :planner), NOT a passthrough.
+  await hp.expectResultRows(DEFAULT_ROWS);
+
+  // The proof footer appears only in phase === "done" (the real, measured line).
+  await expect(hp.proofFooter()).toBeVisible();
+  // "3 results" proves the full row count (not a truncation).
+  await expect(hp.proofFooter()).toContainText("3 results");
+  // "0 network requests" is the machine-verifiable side-channel check (see journey b).
+  await expect(hp.proofFooter()).toContainText("0 network requests");
+});
+
+// ── (b) P1 — zero-network invariant ─────────────────────────────────────────────────────────
+// [SONNET-4.6] The load-bearing honesty check: the hero's `run()` callback evaluates ENTIRELY
+// in-tab via the WASM engine — no XHR, no fetch, no WebSocket. The hermetic layer intercepts
+// every outbound request, records it in externalRequests, and aborts it. If this assertion
+// ever fails, a URL will appear in the log showing exactly what called out.
+//
+// Non-vacuity guarantee (mutation spot-check): if you add
+//   `await fetch('https://test.external.example.com/api')`
+// inside the `run` callback in hero-runner.tsx, the hermetic layer would record that URL in
+// `externalRequests`, and `expect(hermetic.externalRequests).toEqual([])` below would fail,
+// printing the offending URL. The assertion is NOT vacuous — it would catch real network egress.
+test("(b) zero-network invariant: no external requests during in-tab run", async ({
+  page,
+  hermetic,
+}) => {
+  const hp = new HomeRunnerPage(page);
+  await hp.gotoReady();
+  await hp.expectRunnerState("home", "idle-preview");
+
+  // Clear the hermetic log AFTER page load (excludes the pre-run wasm/JS resource fetches, which
+  // are same-origin localhost and not external — but reset() gives us a clean slate regardless).
+  hermetic.reset();
+
+  await hp.clickRun();
+  await hp.expectRunnerState("home", "results");
+
+  // Non-vacuity: if the runner called fetch('https://external.example.com'), the hermetic layer
+  // would record it here and this assertion would fail.
+  expect(
+    hermetic.externalRequests,
+    `unexpected external requests:\n${hermetic.externalRequests.join("\n")}`,
+  ).toEqual([]);
+});
+
+// ── (c) P1 — data tab switch → custom Turtle → different results ─────────────────────────────
+// [SONNET-4.6] Proves the "sample is hackable" product promise: a visitor who edits the Data tab
+// and runs the same query gets DIFFERENT results — the engine queried THEIR data, not the default
+// graph. The Xena/999 and Yoko/111 rows could only come from the custom Turtle (they do not
+// appear anywhere in the default graph), so this is a concrete, order-sensitive proof.
+test("(c) data tab switch → custom Turtle → changed results", async ({ page }) => {
+  const hp = new HomeRunnerPage(page);
+  await hp.gotoReady();
+  await hp.expectRunnerState("home", "idle-preview");
+
+  // Switch to the Data tab — makes the Turtle editor accessible (Query panel becomes hidden).
+  await hp.clickDataTab();
+
+  // Replace the data with the custom Turtle (triggers onChange → onDataChange in hero-runner).
+  await hp.dataEditor().fill(CUSTOM_TURTLE);
+
+  // The Run button lives in the bottom bar (always visible regardless of active tab).
+  await hp.clickRun();
+  await hp.expectRunnerState("home", "results");
+
+  // The custom rows prove BOTH that the Data tab change was picked up AND that the engine ran.
+  // These values cannot come from the default Ada/Lin/Grace graph.
+  await hp.expectResultRows(CUSTOM_ROWS);
+});
+
+// ── (d) P1 — error state ────────────────────────────────────────────────────────────────────
+// [SONNET-4.6] Proves friendly error handling without a crash: a syntactically invalid query
+// surfaces a non-empty role="alert" strip (not an unhandled exception), the PREVIOUS results
+// stay intact (dimmed) while the error is shown, and editing the query clears the error strip —
+// the natural "try again" gesture. The workbench recovers fully.
+test("(d) error state: friendly error shown, previous results intact, edit clears error", async ({
+  page,
+}) => {
+  const hp = new HomeRunnerPage(page);
+  await hp.gotoReady();
+  await hp.expectRunnerState("home", "idle-preview");
+
+  // First: a VALID run to establish prior results (Ada/Lin/Grace). This puts the component
+  // in phase === "done" with results in state — the foundation for the "results intact" check.
+  await hp.clickRun();
+  await hp.expectRunnerState("home", "results");
+  await hp.expectResultRows(DEFAULT_ROWS);
+
+  // Fill the query editor with invalid SPARQL (unterminated WHERE clause — always a parse error).
+  // The query tab is the default active panel, so the editor is visible and accessible.
+  await hp.queryEditor().fill("SELECT * WHERE { ?s ?p ?o");
+  await hp.clickRun();
+
+  // Web-first wait: the hero error strip appears — data-testid="hero-error" disambiguates it from
+  // the Next.js route announcer which also carries role="alert" but is always-present and empty.
+  await expect(hp.heroErrorAlert()).not.toBeEmpty();
+
+  // The PREVIOUS results table stays in the DOM (dimmed) — not blanked. This is the "prior
+  // results intact" guarantee: the component keeps `results` in state and renders ResultsTable
+  // (with data-hero-results-table) even in the error phase, so the visitor can still see what
+  // their last GOOD run produced.
+  await expect(hp.resultsTable()).toBeVisible();
+
+  // Edit the query (fill with valid SPARQL) — triggers onQueryChange which clears the error
+  // (setError(null)) and reverts phase to "done". The error strip is removed from the DOM.
+  await hp.queryEditor().fill(HERO_DEFAULT_QUERY);
+  await expect(hp.heroErrorAlert()).toHaveCount(0);
+});
+
+// ── (e) P1 — handoff to /try ─────────────────────────────────────────────────────────────────
+// [SONNET-4.6] Proves the "Open in workbench →" handoff: the hero runner writes the current
+// query + data to sessionStorage["sparq:handoff"], navigates to /try via router.push("/try"),
+// and the /try REPL consumes (reads + clears) the handoff on mount — prepopulating its editor
+// with the exact same query the visitor ran on the home page. The sessionStorage key is null
+// after consumption, proving it was cleared (no stale re-use on subsequent /try visits).
+test("(e) handoff to /try: editor prepopulated + sessionStorage key consumed", async ({ page }) => {
+  const hp = new HomeRunnerPage(page);
+  await hp.gotoReady();
+  await hp.expectRunnerState("home", "idle-preview");
+
+  // Run the default query so the proof footer (and "Open in workbench") appears.
+  await hp.clickRun();
+  await hp.expectRunnerState("home", "results");
+
+  // The "Open in workbench" button only appears in phase === "done".
+  await expect(hp.openInWorkbenchButton()).toBeVisible();
+
+  // Click "Open in workbench": writeHandoff(…) then router.push("/try").
+  await hp.openInWorkbenchButton().click();
+
+  // Client-side navigation — wait for the URL to change to /sparq/try.
+  await page.waitForURL(/\/sparq\/try/);
+
+  // Wait for the /try REPL to reach engine-ready — the WASM module loads and the "Engine ready"
+  // pill appears. The handoff's useEffect runs on mount BEFORE engine-ready, so by this point
+  // the sessionStorage key has already been consumed and cleared.
+  await hp.expectRunnerState("try", "engine-ready");
+
+  // The REPL editor on /try is prepopulated with HERO_DEFAULT_QUERY from the handoff.
+  const replEditor = page.getByRole("textbox", { name: "SPARQL query" });
+  await expect(replEditor).toHaveValue(HERO_DEFAULT_QUERY);
+
+  // The handoff key is null — consumed and cleared on mount (single-use, never re-read on reload).
+  const handoffValue = await page.evaluate(() =>
+    window.sessionStorage.getItem("sparq:handoff"),
+  );
+  expect(handoffValue, "sparq:handoff should be null after consumption").toBeNull();
+});

--- a/site/e2e/home-runner.spec.ts
+++ b/site/e2e/home-runner.spec.ts
@@ -19,7 +19,7 @@
 //     && npx playwright install chromium && npm run test:e2e -- home-runner.spec.ts
 import { test, expect, BasePage } from "./support";
 import { HERO_DEFAULT_QUERY } from "../src/data/hero-sample";
-import { type Locator, type Page } from "@playwright/test";
+import { type Locator } from "@playwright/test";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 

--- a/site/src/components/home/hero-runner.tsx
+++ b/site/src/components/home/hero-runner.tsx
@@ -370,6 +370,7 @@ export function HeroQueryRunner() {
       {phase === "error" && error && (
         <div
           role="alert"
+          data-testid="hero-error"
           className="flex items-start gap-2 border-t border-destructive/30 bg-destructive/10 px-3 py-2 text-xs text-destructive"
         >
           <span className="font-mono">{error}</span>


### PR DESCRIPTION
## Summary

- Adds `site/e2e/home-runner.spec.ts` — five P1 E2E journeys for the home page's in-browser WASM SPARQL runner
- Adds `data-testid="hero-error"` to the hero error strip in `site/src/components/home/hero-runner.tsx` (test hook to disambiguate from the Next.js route announcer which also has `role="alert"`)
- Adds `.github/workflows/site-e2e-hero.yml` — advisory CI lane that builds lean wasm + runs the journeys + stress test

## Five P1 journeys

**(a) idle→results** — clicks Run, waits for `[data-hero-results-table]`, asserts EXACT engine-computed rows Ada/7300, Lin/6100, Grace/5300 in DESC order. Ada's 7300 = SUM(4200+3100) proves the GROUP BY + SUM are real (not a passthrough).

**(b) zero-network invariant** — resets the hermetic log after page load, clicks Run, asserts `hermetic.externalRequests` is empty (`toEqual([])`). The non-vacuity is documented in the test comment: adding `fetch('https://test.external.example.com/api')` inside the `run` callback in `hero-runner.tsx` would record the URL in `externalRequests` and fail the assertion.

**(c) data tab switch → custom Turtle → changed results** — fills the Data editor with Xena/999 + Yoko/111 Turtle (distinct from the default Ada/Lin/Grace graph), clicks Run, asserts the Xena/999 + Yoko/111 rows. Proves the "sample is hackable" promise.

**(d) error state** — runs a valid query first (establishes prior results), then fills with invalid SPARQL (`SELECT * WHERE { ?s ?p ?o`), clicks Run, asserts the hero error strip (`data-testid="hero-error"`) is non-empty AND the previous `[data-hero-results-table]` stays visible (dimmed). Editing the query fills valid SPARQL → the error strip disappears via `onQueryChange`.

**(e) handoff to /try** — runs the default query, clicks "Open in workbench", waits for `page.waitForURL(/\/sparq\/try/)`, waits for "Engine ready" on /try, asserts the REPL editor has `HERO_DEFAULT_QUERY`, asserts `sessionStorage.getItem("sparq:handoff")` is null (consumed-and-cleared on mount).

## Zero-network invariant mechanism + non-vacuity

The hermetic network layer (`e2e/support/hermetic-net.ts`) intercepts every outbound request from the browser context via `context.route("**/*", ...)`. Localhost requests and the Github releases fixture are allowed; anything else is aborted AND its URL is appended to `externalRequests`. Journey (b) calls `hermetic.reset()` after page load (to exclude the pre-run WASM/JS resource fetches, which are same-origin and not logged anyway) then asserts `externalRequests` is empty after the Run.

Non-vacuity: if you add `await fetch('https://test.external.example.com/api')` inside the `run` callback in `hero-runner.tsx`, the hermetic layer records that URL in `externalRequests`, and `expect(hermetic.externalRequests).toEqual([])` fails, printing the offending URL. The assertion is not vacuous.

## Site-only scope

Files touched: `site/e2e/home-runner.spec.ts`, `site/src/components/home/hero-runner.tsx`, `.github/workflows/site-e2e-hero.yml`. `gui/` is untouched.

## Test plan

- [x] `npm run test:e2e -- home-runner.spec.ts` — 5/5 pass
- [x] `npm run test:e2e:stress -- home-runner.spec.ts` — 25/25 pass (`--repeat-each=5 --retries=0`)
- [x] `npm run test:e2e:grep-gate` — zero `waitForTimeout` calls
- [x] `npm run lint` — no ESLint warnings or errors
- [x] `npm run typecheck` — no TypeScript errors

> 🤖 **SPARQ agent** — this PR was opened by a Claude Sonnet 4.6 agent implementing bead `sq-ymr2e.3`. Do NOT arm for auto-merge (advisory CI lane — wait for CI green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)