### PR TITLE
docs(reason-el): record reasoned non-adoption of substrate joins for CR1-CR5 (sq-pbz04.2.3)

### DIFF
--- a/crates/sparq-reason-el/src/classify.rs
+++ b/crates/sparq-reason-el/src/classify.rs
@@ -19,6 +19,75 @@
 // derived membership is processed once. CR6 (the nominal rule, "Pushing the EL Envelope"
 // IJCAI-05) runs as a between-fixpoint pass — see `cr6_pass` for the rule, the ⇝_R
 // side-condition, and the soundness argument. Single-threaded (Phase E1; concurrency is E4).
+//
+// ## Substrate adoption evaluation -- REASONED NON-ADOPTION [SONNET-4.6] sq-pbz04.2.3
+//
+// Bead sq-pbz04.2.3 evaluated whether the CR1-CR5 saturation joins can adopt the shared
+// `sparq_substrate::join` kernels (the `build_table`/`probe_emit`/`hash_probe_serial` and
+// `join::delta::DeltaTable` path, analogously to `sparq-reason/src/substrate_join.rs`
+// which drives rdfs2/3/7 on the substrate). Disposition: DOCUMENTED NON-ADOPTION.
+// Referenced from `research/reasoner-federation-program.md` sections 3 and 6.
+//
+// Five structural reasons this module's join shapes are not profitable substrate consumers:
+//
+// 1. PER-EVENT WORKLIST, NOT BATCH BUILD/PROBE. The substrate `build_table`+`probe_emit`
+//    requires two static `&[Row]` slices: a build side and a batch of probe rows. The EL
+//    fixpoint processes memberships one at a time from a `Vec<(Concept, Concept)>` worklist;
+//    each dequeued `(X, D)` immediately fires rules whose outputs re-enter the queue before
+//    the outer loop resumes. Batching would require collecting an entire delta round first,
+//    but the five rules have heterogeneous triggers and no meaningful "round" boundary --
+//    unlike the OWL-RL semi-naive `delta join full` pattern `DeltaTable` was designed for.
+//
+// 2. SIMULTANEOUS READ AND WRITE ON THE SAME RELATIONS. CR2 reads `S(X)` (checks whether
+//    a partner conjunct is already present) while CR1/CR3/CR4/CR5 write new members into
+//    `S(X)` within the same worklist pass. The substrate kernels assume `&[Row]` immutability
+//    at probe time; there is no safe seam to hand `S(X)` to a kernel as a probe slice while
+//    also holding it mutably for insertion. The `add()` helper at the bottom of this file is
+//    called inside rule-specific borrows that cannot be widened to a whole-relation borrow.
+//
+// 3. AXIOMINDEX IS ALREADY AN OPTIMAL SINGLE-KEY HASH TABLE. The `AxiomIndex` fields are
+//    `FxHashMap<Concept, Vec<...>>` keyed by `Concept = u32` -- a direct O(1) lookup using
+//    the native integer hash. Reshaping to substrate `Row` (`SmallVec<[u32; 4]>`) build
+//    tables would add per-axiom `Row::from_slice` allocation and per-lookup key projection
+//    through `JoinKeys`, replacing a 4-byte integer hash with a `SmallVec` hash over the
+//    same data. Asymptotic complexity is identical; the per-lookup constant is strictly
+//    higher with no algorithmic benefit.
+//
+// 4. CR4 IS A 3-WAY TRIANGLE JOIN WITH THREE GROWING SIDES. CR4 combines S(Y) memberships,
+//    R(r) predecessor links, and axiom index lookups, where both S(Y) and R(r) grow during
+//    the same pass. The substrate handles 2-way binary joins (static build probed by a
+//    batch probe slice) and the 2-way semi-naive delta/full shape. The EL triangle -- where
+//    S-sets, R-links, and AxiomIndex all inform the same rule firing -- has no direct
+//    mapping to any of the four substrate kernels (merge-join, hash-join, bind-join,
+//    trie-join) or to the `DeltaTable` seam. Forcing it would require rebuilding all three
+//    sides at each queue step, which is strictly worse than the current per-event probe.
+//
+// 5. THE QL PRECEDENT APPLIES IN FULL. The OWL 2 QL certain-answer oracle (sq-qo1a9) is a
+//    documented non-consumer of the substrate join kernels: its query-rewriting shape
+//    (PerfectRef + tree-witness + UCQ minimisation) is not a build/probe or semi-naive
+//    fixpoint. The EL worklist fixpoint is a cleaner non-consumer still: QL at least
+//    evaluates CQ answers over a static dataset, which could use the engine join path;
+//    EL saturation joins never produce a relational tuple output -- they grow set-based
+//    state incrementally, and every "join" is a membership test, not a tuple production.
+//
+// Comparison with the RDFS precedent (`sparq-reason/src/substrate_join.rs`, sq-yk6or):
+// rdfs2/3/7 are profitable substrate consumers because (a) the schema closure maps are
+// built ONCE and probed many times without mutation, and (b) the output is a multiset
+// of triples, exactly what `probe_emit`'s combined-row output models. Neither condition
+// holds here: S(X) and R(r) grow during every worklist step, and the output is
+// side-effectful set membership, not a combinatorial tuple join.
+//
+// Also mirroring the note in `substrate_join.rs` module doc: "The OWL-RL semi-naive
+// fixpoint (owl.rs): a delta-driven delta/full join with union-find sameAs
+// canonicalisation. Genuinely a different (incremental, mutating) join shape than the
+// substrate's static &[Row] build/probe kernel." The EL worklist is even more tightly
+// coupled, with no round boundary to hang a delta on.
+//
+// Conclusion: this module stays on its hand-rolled FxHashMap worklist. There is no
+// profitable behaviour-neutral seam to the substrate kernels for CR1-CR5. If a
+// concurrency refactor (Phase E4) eventually batches derivations by concept, that is
+// the point to reconsider whether a per-batch substrate probe makes sense -- that
+// decision belongs to E4, not here.
 
 use crate::normal::{Concept, Names, Normal, Role, BOTTOM, TOP};
 #[cfg(feature = "rbox")]

--- a/research/reasoner-federation-program.md
+++ b/research/reasoner-federation-program.md
@@ -94,10 +94,13 @@ consumer or an honest reasoned non-adoption.
 ### Phase R — Per-profile reasoners (epic sq-pbz04, sub-epics sq-pbz04.1–.6)
 Each profile advances on two axes, kept honest per profile:
 **(a) substrate adoption** where the profile genuinely evaluates
-(RL: delta-seam fixpoint; EL: saturation joins + concrete-domain numerics;
+(RL: delta-seam fixpoint; EL: concrete-domain numerics only — saturation joins
+are a documented non-adoption, see `crates/sparq-reason-el/src/classify.rs`
+section "Substrate adoption evaluation" [SONNET-4.6] sq-pbz04.2.3;
 D: shared value comparator; RIF: builtins over the shared tower) — with QL as
-the documented counter-example: it is a query-rewriter reusing the engine path
-and by design **not** a join-substrate consumer; and
+one documented counter-example (query-rewriter reusing the engine path, not a
+join-substrate consumer) and EL's worklist fixpoint as a second: it is **not** a
+join-substrate consumer by structural incompatibility, not by omission; and
 **(b) profile completion** (RL: the 13 divergences; EL: CR6–CR9; QL: CQ-gate
 broadening + de-experimentalisation where sound; RIF: a conformance arm;
 D: datatype-map broadening; Direct: a research-first fragment-scoping record
@@ -186,6 +189,12 @@ Conflict discipline: the only shared-file overlap in the wave is
 - **Geo conformance is OGC-shaped, not W3C**, via the sanctioned hand-curated
   probe (CITE not MIT-vendorable); the distance-approximation note stands.
 - **QL is not a join-substrate consumer** — by design, not by omission.
+- **EL's CR1-CR5 saturation joins are not join-substrate consumers** — by
+  structural incompatibility (worklist-event shape, simultaneous read+write on
+  S-sets, 3-way triangle join in CR4), not by omission. Concrete-domain numerics
+  (`cdomain` feature, sq-pbz04.2.2) ARE adopted. Full non-adoption rationale:
+  `crates/sparq-reason-el/src/classify.rs` § "Substrate adoption evaluation"
+  [SONNET-4.6] sq-pbz04.2.3.
 - **`sparq-fedplan-mpc` is out of scope** for this program (unaudited research
   scaffold; the MPC/ZK program owns it).
 - **sq-v5evr's un-park is consumer-justified**, not speculative: D-entailment and


### PR DESCRIPTION
> 🤖 SPARQ agent — sq-pbz04.2.3 disposition bead: evaluate the classify.rs saturation joins against sparq-substrate kernels.

## Disposition: DOCUMENTED NON-ADOPTION

Bead sq-pbz04.2.3 asked whether the EL classifier's CR1-CR5 saturation joins can adopt the shared `sparq_substrate::join` kernels (`build_table`/`probe_emit`/`hash_probe_serial` + `join::delta::DeltaTable`), mirroring the `sparq-reason/src/substrate_join.rs` pattern used for rdfs2/3/7.

The answer is **no** — by structural incompatibility, not by omission. The rationale is recorded durably in `crates/sparq-reason-el/src/classify.rs` (the "Substrate adoption evaluation" comment section) and cross-referenced from `research/reasoner-federation-program.md` §3 and §6.

## Behaviour neutrality

**N/A** — this is a documentation-only change. No code logic was altered; all five rules (CR1-CR5) remain exactly as-is on the hand-rolled FxHashMap worklist. The `Classification` output, `ClassHierarchy`, and `classify_graph` emission order are provably unchanged (zero diff to the logic).

## The five structural reasons (full detail in classify.rs)

1. **Per-event worklist, not batch build/probe.** The EL fixpoint processes one `(Concept, Concept)` pair at a time with immediate rule propagation. The substrate requires two static `&[Row]` slices with no meaningful "round" boundary — unlike the OWL-RL semi-naive `Δ⋈full` pattern `DeltaTable` was designed for.

2. **Simultaneous read + write on the same relations.** CR2 reads `S(X)` (membership test for the partner conjunct) while CR1/CR3/CR4/CR5 write new members into `S(X)` in the same worklist pass. The substrate's `&[Row]` immutability at probe time has no safe seam here.

3. **AxiomIndex is already optimal.** `FxHashMap<Concept, Vec<...>>` keyed by `Concept = u32` is a direct O(1) integer-hash lookup. Reshaping to SmallVec-keyed `Row` build tables would add per-axiom `Row::from_slice` allocation and `JoinKeys` projection with a strictly higher per-lookup constant and no algorithmic benefit.

4. **CR4 is a 3-way triangle join with three growing sides.** CR4 combines S(Y) memberships, R(r) predecessor links, and axiom index lookups, where both S(Y) and R(r) grow during the same pass. None of the four substrate kernels (merge/hash/bind/trie-join) or the `DeltaTable` seam models this mutually-growing 3-way shape.

5. **The QL precedent applies in full.** EL's saturation joins grow set-based state (membership tests, not tuple production) — a cleaner non-consumer than QL, which at least evaluates CQ answers over static data. This is the second documented non-consumer after the QL certain-answer oracle (sq-qo1a9).

## What IS adopted (honesty boundary)

Concrete-domain numerics (`cdomain` feature, sq-pbz04.2.2, PR #1434) ARE adopted via `sparq-substrate::numeric`. The non-adoption is specific to the `join` kernel slice for CR1-CR5 worklist saturation.

## Comparison with the RDFS substrate precedent

`sparq-reason/src/substrate_join.rs` (sq-yk6or) shows rdfs2/3/7 ARE profitable consumers because: (a) the schema closure maps are built once and probed many times without mutation, and (b) the output is a multiset of triples that `probe_emit`'s combined-row output models directly. Neither condition holds for EL saturation.

The module doc in `substrate_join.rs` already notes that the OWL-RL semi-naive fixpoint is "genuinely a different (incremental, mutating) join shape than the substrate's static `&[Row]` build/probe kernel." The EL worklist is an even more tightly-coupled incremental computation, with no round boundary to hang a delta on.

## Gates

- `cargo build -p sparq-reason-el` (default features): GREEN
- `cargo build -p sparq-reason-el --all-features`: GREEN
- `cargo clippy -p sparq-reason-el --all-targets -- -D warnings` (default): GREEN
- `cargo clippy -p sparq-reason-el --all-features --all-targets -- -D warnings`: GREEN
- `cargo test -p sparq-reason-el` (default features): GREEN
- `cargo test -p sparq-reason-el --all-features`: GREEN — all four required tests: `differential` (20 tests), `rbox_differential` (12 tests), `hasse_reduction` (10 tests), `snomed_go_scale` (2 tests)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-reason-el --no-deps --all-features`: GREEN
- `cargo clippy --workspace --exclude sparq-py --all-targets -- -D warnings`: GREEN
- `scripts/check-no-dyn-dispatch.py`: GREEN (0 violations)
- `scripts/check-readme-template.py --enforce`: GREEN (0 deviations)

No performance numbers committed. No feature state changes (crate default features remain empty).

## Files changed

- `crates/sparq-reason-el/src/classify.rs` — added "Substrate adoption evaluation" comment section (5 reasons + comparison; comment-only, zero logic change)
- `research/reasoner-federation-program.md` — updated §3 Phase R description + §6 non-goals ledger to record EL as a second documented non-consumer

[SONNET-4.6] sq-pbz04.2.3