### PR TITLE
feat(ci): change-based test-selection SHADOW->ENFORCE flip + ci-full label + nightly backstop (sq-fmx4u.5)

### DIFF
--- a/.github/workflows/ci-select.yml
+++ b/.github/workflows/ci-select.yml
@@ -18,12 +18,22 @@
 #   filterset — nextest filterset ("package(a) + package(b)") for NARROWING the
 #               cross-crate bulk shards (they are never skipped, design §5.2).
 #
-# SHADOW MODE (design §6.4 — the sq-fmx4u.5 rollout): DEFAULT-ON. Until the repo
-# variable CI_SELECT_MODE is set to the literal string "enforce", the selector runs
-# with --shadow: it computes + reports the would-be selection in the step summary
-# but emits mode=shadow, so every guard's `mode != 'selected'` disjunct is true and
-# NOTHING is skipped. Fail-safe by construction: an unset/typo'd variable means
-# shadow (full matrix). Bead sq-fmx4u.5 flips enforcement after the shadow window.
+# ENFORCE MODE (design §6 — the sq-fmx4u.5 rollout, ENFORCEMENT FLIPPED). [FABLE-5]
+# Enforce is now the DEFAULT: the selector's mode=selected skips are HONORED, so a
+# not-affected crate's wide-lane tests/benchmarks are actually SKIPPED. Two overrides,
+# both fail toward RUNNING MORE:
+#   * ci-full PR label => the selector runs with --full (mode=full, nothing skipped);
+#     the calling workflows react to labeled/unlabeled so toggling re-evaluates.
+#   * CI_SELECT_MODE repo variable == the literal "shadow" => report-only rollback
+#     escape hatch (--shadow: compute + report the would-skip set, skip nothing).
+# Any other CI_SELECT_MODE value (incl. unset / "enforce") enforces. Fail-safe is
+# unaffected — ci_select.py returns mode=full for every §4.1 trigger (shared crate /
+# build file / .github/** / Cargo.lock / selector-self change) and for ANY internal
+# error, so enforce NEVER skips a test for an affected crate or its reverse-dep
+# closure. Safe per bead sq-fmx4u.4: the ruleset requires exactly one check
+# (ci-summary / gate), so a selection-skipped leg reports `skipped` (= satisfied) and
+# can never hang the merge queue. Nightly cron (ci.yml `schedule`) + the ci-full label
+# are the permanent backstops (design §6.1/§6.2).
 #
 # FAIL-CLOSED CONTRACT (design §4.3):
 #   * the selector traps ALL internal errors => mode=full, exit 0 (this job stays
@@ -86,16 +96,30 @@ jobs:
           # per design §3.1/P8). Exactly one pair is non-empty per event.
           BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
           HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
-          # The sq-fmx4u.5 enforcement flip: shadow (report-only) unless the repo
-          # variable CI_SELECT_MODE is exactly "enforce".
+          # [FABLE-5] sq-fmx4u.5 ENFORCEMENT FLIP: enforce is the DEFAULT now. The
+          # selector's mode=selected skips are HONORED unless CI_SELECT_MODE is set
+          # to the literal "shadow" (the report-only rollback escape hatch below).
           CI_SELECT_MODE: ${{ vars.CI_SELECT_MODE }}
+          # [FABLE-5] sq-fmx4u.5 ci-full label override (design §6.2): applying the
+          # `ci-full` label to a PR forces the FULL matrix (mode=full, nothing
+          # skipped); removing it re-selects. The calling workflows react to
+          # labeled/unlabeled PR events so a toggle re-runs this pre-job. On non-PR
+          # events there is no pull_request payload, so this evaluates false and the
+          # override is inert (non-PR events already resolve to full by construction).
+          CI_FULL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'ci-full') }}
         run: |
           set -euo pipefail
           args=(--event "$EVENT")
           case "$EVENT" in
             pull_request|merge_group) args+=(--base "$BASE" --head "$HEAD") ;;
           esac
-          if [ "${CI_SELECT_MODE:-}" != "enforce" ]; then
+          if [ "$CI_FULL_LABEL" = "true" ]; then
+            # ci-full label: force the full matrix regardless of mode (design §6.2).
+            args+=(--full)
+          elif [ "${CI_SELECT_MODE:-}" = "shadow" ]; then
+            # Report-only rollback escape hatch (design §6.4): set the repo variable
+            # CI_SELECT_MODE=shadow to compute + report the would-skip set while every
+            # job still runs. Any other value (incl. unset / "enforce") => enforce.
             args+=(--shadow)
           fi
           python3 scripts/ci_select.py "${args[@]}"

--- a/.github/workflows/ci-summary.yml
+++ b/.github/workflows/ci-summary.yml
@@ -83,8 +83,13 @@
 # the skips was never soundly observed. With select green (or absent — a
 # pre-selection sibling set), `skipped` stays non-failing exactly as before, and
 # a job that FAILED still fails the gate regardless (selection can never mask a
-# real failure). Selection ships SHADOW-first (report-only; enforcement flip is
-# bead sq-fmx4u.5 via the CI_SELECT_MODE repo variable).
+# real failure). [FABLE-5] sq-fmx4u.5: selection is now ENFORCED by default (the
+# shadow rollout is flipped) — a not-affected crate's lane reports `skipped`, which
+# the rule above counts as satisfied only under a successful select. This is safe
+# because the ruleset requires exactly one check (this `gate`); no per-leg name is
+# individually required, so a plain-skipped leg can never hang the merge queue
+# (verified in bead sq-fmx4u.4). The `ci-full` PR label + the nightly cron full run
+# are the permanent backstops; CI_SELECT_MODE=shadow is the report-only rollback.
 #
 # IMPLEMENTATION (sq-90cv4). [FABLE-5] The poll loop + verdict live in
 # scripts/ci_summary_gate.py (extracted from the previous inline bash so the

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,12 @@ name: CI
 on:
   push:
     branches: [main]
+  # [FABLE-5] sq-fmx4u.5: react to labeled/unlabeled too so toggling the `ci-full`
+  # label re-evaluates the change-based selection (ci-select.yml maps the label to
+  # `--full`). The default types (opened/synchronize/reopened) are listed explicitly
+  # so adding the label events does NOT drop `synchronize` (the push-to-PR trigger).
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   # [OPUS-4.8] Merge queue: re-run the identical PR check-set on the queue's
   # merge_group ref so the required ci-summary gate finds the same siblings it finds
   # on a PR. The per-commit `coverage` job (if: event_name != 'schedule') runs here;
@@ -21,6 +26,11 @@ on:
   # tests under llvm-cov instrumentation, which a per-commit job cannot afford
   # (measured >10 min for that ONE crate under instrumentation — see the job
   # comment + bench/coverage-floor.json). 03:17 UTC daily.
+  # [FABLE-5] sq-fmx4u.5: this scheduled run is ALSO the change-based-selection
+  # FULL-MATRIX BACKSTOP (design §6.1) — a `schedule` event carries no PR diff so
+  # the `select` pre-job resolves to mode=full and the whole matrix runs, so nothing
+  # a PR selection-skipped can silently rot. The `selection-backstop` job below
+  # asserts that mode=full invariant fail-loud.
   schedule:
     - cron: "17 3 * * *"
 
@@ -152,13 +162,48 @@ jobs:
   # Relationship to `changes` (dorny paths-filter) is layered, both directions
   # preserved: rust_changed==false skips a lane regardless of selection (the
   # existing doc-PR fast path), and selection can only skip WITHIN
-  # rust_changed==true. SHADOW default-ON until the CI_SELECT_MODE repo variable
-  # says "enforce" (bead sq-fmx4u.5).
+  # rust_changed==true. [FABLE-5] sq-fmx4u.5: ENFORCE is now the DEFAULT — a
+  # not-affected crate's wide lane is actually skipped. Overrides: the `ci-full`
+  # PR label forces mode=full; CI_SELECT_MODE=shadow is the report-only rollback
+  # escape hatch (see ci-select.yml). Fail-safe unchanged (§4.1 triggers => full).
   select:
     name: select
     uses: ./.github/workflows/ci-select.yml
     permissions:
       contents: read
+
+  # [FABLE-5] sq-fmx4u.5 (design §6.1): the nightly FULL-MATRIX BACKSTOP guard. The
+  # scheduled (cron) run + a manual workflow_dispatch drive the whole test matrix
+  # with the selector in mode=full — a non-PR event carries no diff, so the `select`
+  # job returns full and NOTHING is narrowed/skipped. That is what stops anything a
+  # PR selection-skipped from silently rotting: a regression in a crate that looked
+  # unaffected on some PR still fails the nightly gate. This job makes that invariant
+  # OBSERVABLE and fail-loud: if a future change ever let a scheduled/dispatch run
+  # resolve to a NARROWED (mode=selected) selection, it REDs here rather than quietly
+  # running a partial nightly. It runs ONLY on the backstop events; on
+  # pull_request/push/merge_group it is `skipped` (which ci-summary counts as
+  # satisfied — no per-leg name is individually required, bead sq-fmx4u.4). Reading
+  # the select mode in a STEP (not the job `if:`) keeps the always-run-on-backstop
+  # trigger decoupled from the selection outputs.
+  selection-backstop:
+    name: nightly selection backstop (full-matrix guard)
+    needs: select
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Assert the scheduled/dispatch run uses the FULL matrix (no selection narrowing)
+        env:
+          SELECT_MODE: ${{ needs.select.outputs.mode }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          set -euo pipefail
+          if [ "$SELECT_MODE" != "full" ]; then
+            echo "::error::nightly selection backstop: expected select mode=full on a '$EVENT' run, got '${SELECT_MODE:-<empty>}'. Change-based selection must NEVER narrow the scheduled full-matrix backstop (design §6.1) — a non-PR event carries no diff and must resolve to full."
+            exit 1
+          fi
+          echo "nightly selection backstop OK ($EVENT): select mode=full — the whole matrix runs, so nothing a PR selection-skipped can silently rot."
 
   # [OPUS-4.8] BUILD-ONCE for the sharded test suite (sq-vyxy folded in). The old
   # design had every shard run `cargo build --workspace --all-targets` itself — the

--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -506,8 +506,9 @@ jobs:
       #     `mode != 'selected'` disjunct (empty outputs => run), every literal
       #     '"<crate>"' guard needle is a REAL workspace member (a typo would
       #     skip a lane exactly when it should run), the ci-select.yml job name
-      #     matches the gate's SELECT_RE, select callers are unconditional, and
-      #     shadow stays default-ON until CI_SELECT_MODE == 'enforce'.
+      #     matches the gate's SELECT_RE, select callers are unconditional,
+      #     ENFORCE is the default with a ci-full label override + shadow rollback
+      #     escape hatch, and the nightly full-matrix backstop is wired (sq-fmx4u.5).
       # The wiring test needs PyYAML to parse the workflows — same hash-pinned
       # install the skill-frontmatter/setup jobs use (complete closure, no deps).
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0

--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -84,7 +84,12 @@ name: feature-matrix
 on:
   push:
     branches: [main]
+  # [FABLE-5] sq-fmx4u.5: react to labeled/unlabeled too so toggling the `ci-full`
+  # label re-evaluates change-based selection for the opt-in leg set as well (the
+  # `setup` assembler filters legs by the selection outputs). Default types are
+  # listed explicitly so adding the label events does not drop `synchronize`.
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   # Merge queue: mirror the PR check-set onto the merge_group ref so the required
   # ci-summary gate finds the same legs it finds on a PR (matches ci.yml/ci-summary.yml).
   merge_group:

--- a/research/change-based-test-selection.md
+++ b/research/change-based-test-selection.md
@@ -303,6 +303,46 @@ id 17688455, last updated 2026-07-02):
 6. **Transparency**: the per-PR step-summary (§5.1) makes every skip decision
    reviewable where reviewers already look.
 
+**§6 graduation note (bead sq-fmx4u.5, ENFORCEMENT FLIPPED 2026-07-03). [FABLE-5]**
+The shadow rollout is now flipped to **enforce by default** — a not-affected
+crate's wide-lane tests/benchmarks are actually skipped. This is the culmination
+of the epic and is proven-safe by bead sq-fmx4u.4: the live ruleset requires
+exactly one check (`ci-summary / gate`), so a selection-skipped leg reports
+`skipped` (= satisfied) and can never individually hang the merge queue. No
+ruleset change was needed. What landed:
+
+- **Enforce flip** (`.github/workflows/ci-select.yml`): `--shadow` is now added
+  *only* when the repo variable `CI_SELECT_MODE` is the literal `"shadow"` (the
+  report-only rollback escape hatch); any other value — including unset and
+  `"enforce"` — enforces. The pre-flip `!= "enforce" ⇒ --shadow` default is gone.
+- **`ci-full` label override** (safeguard 2): the select step computes
+  `CI_FULL_LABEL = contains(github.event.pull_request.labels.*.name, 'ci-full')`
+  and, when true, runs the selector with `--full` (mode=full, nothing skipped).
+  `ci.yml` + `feature-matrix.yml` now trigger on `pull_request:` types
+  `[opened, synchronize, reopened, labeled, unlabeled]`, so toggling the label
+  re-evaluates selection.
+- **Nightly full-matrix backstop** (safeguard 1): the existing `schedule` cron on
+  `ci.yml` resolves to `mode=full` by construction (a non-PR event carries no
+  diff), and a new `selection-backstop` job asserts that `mode=full` invariant
+  fail-loud on `schedule`/`workflow_dispatch` (it REDs if a scheduled run were
+  ever narrowed). `workflow_dispatch` (safeguard 3) is the ad-hoc full run.
+- **Fail-safe preserved** (non-negotiable): `ci_select.py` is unchanged — every
+  §4.1 trigger (shared crate / build file / `.github/**` / `Cargo.lock` /
+  selector-self change) and any internal error still return `mode=full`, so
+  enforce never skips a test for an affected crate or its reverse-dep closure.
+- **Tests** (`scripts/tests/`): `EnforceRolloutTests` (affected⇒RUNS,
+  not-affected⇒SKIPS via the exact shard-guard membership rule, ci-full⇒full,
+  nightly⇒full, fail-safe trigger⇒full, selector-error⇒full, a mutation check on
+  the quoted-needle guard) + wiring inspection (enforce-default, ci-full override,
+  label-toggle triggers, the nightly backstop job).
+
+**Deferred** (proceed-and-document): the §6.1 *selection-bug alarm* — auto-filing
+a P1 bead/issue that names the offending nightly job + the suspect PRs landed
+since the last green nightly — is a distinct, more involved correlation feature
+(it must cross-reference the per-PR selection summaries). The backstop itself
+(the full nightly run that reds the gate on any regression) is live now; the
+auto-alarm is tracked as a follow-up bead.
+
 ## 7. Firm positions (decision record)
 
 - **P1 — selector is stdlib-only Python** (`scripts/ci_select.py`), not a
@@ -333,7 +373,9 @@ id 17688455, last updated 2026-07-02):
   construction, and queue width is where the throughput pain concentrates.
 - **P9 — the SAFE list starts empty** and only audit-proven entries join it.
 - **P10 — enforce only after the shadow window** (§6.4); nightly full +
-  `ci-full` label remain permanent backstops.
+  `ci-full` label remain permanent backstops. *(sq-fmx4u.5, 2026-07-03:
+  ENFORCEMENT FLIPPED — enforce is now the default; `CI_SELECT_MODE=shadow` is the
+  report-only rollback escape hatch. See the §6 graduation note.)*
 
 ## 8. Implementation plan — child beads (disjoint)
 

--- a/scripts/tests/test_ci_select.py
+++ b/scripts/tests/test_ci_select.py
@@ -438,5 +438,130 @@ class RealMetadataShapeTests(unittest.TestCase):
         self.assertNotIn("sparq-parse", sel.affected)  # parse does not depend on geo
 
 
+class EnforceRolloutTests(unittest.TestCase):
+    """[FABLE-5] sq-fmx4u.5: the ENFORCE-mode rollout invariants — the selector
+    outputs the wide-lane skip guards consume once the shadow rollout is flipped
+    OFF (enforce is the default). Under enforce (no --shadow) the affected closure
+    is the RUN set: a crate in it RUNS, a crate absent from it is SKIPPED. Every
+    fail-safe path (§4.1 triggers, the ci-full override, non-PR events) still
+    resolves to mode=full even without shadow — enforce never weakens fail-safe."""
+
+    def _run_main(self, argv):
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            code = cs.main(argv)
+        return code, json.loads(buf.getvalue())
+
+    def _write(self, text, suffix=".json"):
+        fd, path = tempfile.mkstemp(suffix=suffix)
+        with os.fdopen(fd, "w") as fh:
+            fh.write(text)
+        self.addCleanup(lambda: os.path.exists(path) and os.remove(path))
+        return path
+
+    @staticmethod
+    def _guard_runs(affected, crate):
+        """Exact mirror of the ci.yml shard skip guard's membership test:
+            case "$SELECT_AFFECTED" in *"\\"$SHARD_CRATE\\""*) run ;; *) skip ;;
+        i.e. the QUOTED needle '"<crate>"' must be a substring of the affected JSON.
+        `affected` is the parsed list; we re-serialise with json.dumps exactly as
+        ci_select.py writes the $GITHUB_OUTPUT `affected=` line the guard reads."""
+        return f'"{crate}"' in json.dumps(affected)
+
+    def _selected(self, changed_line):
+        meta = self._write(json.dumps(_synthetic_meta()))
+        changed = self._write(changed_line, suffix=".txt")
+        # No --shadow: this is ENFORCE (the sq-fmx4u.5 default).
+        code, obj = self._run_main(["--metadata-file", meta, "--changed-file", changed,
+                                    "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        return obj
+
+    def test_enforce_affected_crate_runs(self):
+        # An `engine` change under enforce => mode=selected; engine + its dependent
+        # `app` are in the closure, so the shard guard RUNS both.
+        obj = self._selected("crates/engine/src/lib.rs\n")
+        self.assertEqual(obj["mode"], "selected")
+        self.assertTrue(self._guard_runs(obj["affected"], "engine"), "affected -> RUNS")
+        self.assertTrue(self._guard_runs(obj["affected"], "app"), "dependent -> RUNS")
+
+    def test_enforce_not_affected_crate_skips(self):
+        # An `app` change under enforce => `app` is a reverse-graph leaf, so nothing
+        # else is affected; `core`/`parse`/`engine` are NOT in the closure and the
+        # shard guard SKIPS them (exit 0 — gate-satisfied via `skipped`, no hang;
+        # the merge-queue safety is pinned by TestRequiredCheckAnchor / sq-fmx4u.4).
+        obj = self._selected("crates/app/src/lib.rs\n")
+        self.assertEqual(obj["mode"], "selected")
+        self.assertEqual(obj["affected"], ["app"])
+        for skipped in ("core", "parse", "engine"):
+            self.assertFalse(self._guard_runs(obj["affected"], skipped),
+                             f"{skipped} not affected -> shard guard SKIPS it")
+
+    def test_enforce_ci_full_label_path_is_full(self):
+        # The `ci-full` label maps to ci_select.py --full: mode=full even without
+        # --shadow, and every member is in `affected` (everything runs).
+        meta = self._write(json.dumps(_synthetic_meta()))
+        code, obj = self._run_main(["--full", "--metadata-file", meta, "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "full")
+        self.assertEqual(obj["affected"], ALL_MEMBERS)
+
+    def test_enforce_nightly_schedule_is_full(self):
+        # The nightly full-matrix backstop: a schedule event carries no PR diff, so
+        # the selector returns full even without --shadow.
+        meta = self._write(json.dumps(_synthetic_meta()))
+        code, obj = self._run_main(["--event", "schedule", "--metadata-file", meta,
+                                    "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "full")
+        self.assertEqual(obj["affected"], ALL_MEMBERS)
+
+    def test_enforce_failsafe_trigger_stays_full(self):
+        # FAIL-SAFE PRESERVED: a §4.1 trigger (Cargo.lock) under enforce (NO --shadow)
+        # still forces full — enforce must never skip a shared/build-file change even
+        # when an otherwise-narrow crate change rides alongside it.
+        obj = self._selected("Cargo.lock\ncrates/app/src/lib.rs\n")
+        self.assertEqual(obj["mode"], "full")
+        self.assertEqual(obj["affected"], ALL_MEMBERS)
+        # And every crate's guard consequently RUNS (nothing skipped under full).
+        for crate in ALL_MEMBERS:
+            self.assertTrue(self._guard_runs(obj["affected"], crate))
+
+    def test_enforce_selector_error_stays_full(self):
+        # FAIL-CLOSED PRESERVED under enforce: a selector error (bad metadata) with
+        # NO --shadow still resolves to full, exit 0 — nothing is skipped on error.
+        changed = self._write("crates/app/src/lib.rs\n", suffix=".txt")
+        code, obj = self._run_main(["--metadata-file", "/no/such/meta.json",
+                                    "--changed-file", changed, "--repo-root", ROOT])
+        self.assertEqual(code, 0)
+        self.assertEqual(obj["mode"], "full")
+
+    def test_enforce_never_emits_shadow(self):
+        # Without --shadow the mode is never 'shadow' (enforce honors selected/full).
+        for changed in ("crates/app/src/lib.rs\n", "Cargo.lock\n", "docs/x.md\n"):
+            obj = self._selected(changed)
+            self.assertIn(obj["mode"], ("selected", "full"))
+            self.assertNotEqual(obj["mode"], "shadow")
+
+    def test_guard_needle_quotes_prevent_prefix_collision(self):
+        # MUTATION CHECK. A guard that dropped the quote delimiters (a bare-name
+        # substring match) would treat `sparq-core` as affected whenever
+        # `sparq-core-foo` is — a SILENT UNSOUND run of a crate selection proved
+        # unaffected. Prove the REAL guard rule (the QUOTED needle) distinguishes
+        # them and the mutant (unquoted substring) does not.
+        affected = ["sparq-core-foo"]
+        self.assertTrue(self._guard_runs(affected, "sparq-core-foo"))
+        self.assertFalse(self._guard_runs(affected, "sparq-core"),
+                         "the quoted needle must NOT match the prefix crate")
+        # The mutant's unquoted substring test WOULD wrongly match:
+        mutant_match = "sparq-core" in json.dumps(affected)
+        self.assertTrue(mutant_match, "sanity: the bare substring IS present")
+        self.assertNotEqual(
+            mutant_match, self._guard_runs(affected, "sparq-core"),
+            "the real (quoted) guard and the mutant (unquoted) must disagree here — "
+            "that disagreement is exactly the soundness the quoting buys",
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -64,6 +64,12 @@ def _load(path: Path) -> dict:
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 
 
+def _on_block(wf: dict) -> dict:
+    """The workflow `on:` mapping. Bare `on` is the YAML boolean True, so PyYAML
+    keys it under `True`; fall back to that (same trick as the anchor tests)."""
+    return wf.get("on", wf.get(True, {})) or {}
+
+
 def _gate_module():
     spec = importlib.util.spec_from_file_location("ci_summary_gate", GATE_PY)
     mod = importlib.util.module_from_spec(spec)
@@ -177,12 +183,83 @@ class TestWiring(unittest.TestCase):
         self.assertFalse(self.gate.is_advisory(name),
                          "the select job name must GATE (no advisory/informational)")
 
-    def test_shadow_default_on_until_enforce(self):
+    def test_enforce_is_default_shadow_is_the_escape_hatch(self):
+        """[FABLE-5] sq-fmx4u.5 ENFORCEMENT FLIP. Enforce is now the DEFAULT — the
+        selector's mode=selected skips are honored unless CI_SELECT_MODE is set to
+        the literal 'shadow' (the report-only rollback escape hatch). The pre-flip
+        shadow-by-default condition (`!= "enforce"` => --shadow) must be GONE."""
         text = SELECT_YML.read_text(encoding="utf-8")
-        self.assertIn("--shadow", text)
+        self.assertIn("--shadow", text, "the shadow escape hatch must still exist")
         self.assertIn("CI_SELECT_MODE", text)
-        self.assertIn('!= "enforce"', text,
-                      "shadow must be the default for ANY value but the literal 'enforce'")
+        self.assertIn('= "shadow"', text,
+                      "shadow must now be OPT-IN (CI_SELECT_MODE == 'shadow'); "
+                      "enforce is the default")
+        self.assertNotIn('!= "enforce"', text,
+                         "the pre-flip shadow-by-default condition must be removed "
+                         "(sq-fmx4u.5 enforce flip)")
+        # Structural: the select step wires the shadow branch off CI_SELECT_MODE.
+        step = self._select_step()
+        self.assertIn("CI_SELECT_MODE", step.get("env", {}))
+
+    def _select_step(self) -> dict:
+        steps = self.sel["jobs"]["select"]["steps"]
+        return next(s for s in steps if s.get("id") == "sel")
+
+    def test_ci_full_label_override_forces_full(self):
+        """[FABLE-5] sq-fmx4u.5 (design §6.2). Applying the `ci-full` PR label maps
+        to ci_select.py --full (mode=full, nothing skipped). The override reads the
+        PR label set and, when present, adds --full."""
+        text = SELECT_YML.read_text(encoding="utf-8")
+        self.assertIn("ci-full", text, "the ci-full label override must be wired")
+        step = self._select_step()
+        env = step.get("env", {})
+        self.assertIn("CI_FULL_LABEL", env, "the select step must compute CI_FULL_LABEL")
+        self.assertIn("labels.*.name", str(env["CI_FULL_LABEL"]),
+                      "CI_FULL_LABEL must read the PR label name set")
+        self.assertIn("'ci-full'", str(env["CI_FULL_LABEL"]))
+        run = str(step["run"])
+        self.assertIn("--full", run, "the ci-full path must force ci_select.py --full")
+        # The label check must gate the --full branch (fail-open toward RUNNING more).
+        self.assertIn('[ "$CI_FULL_LABEL" = "true" ]', run)
+
+    def test_label_toggle_reevaluates_selection(self):
+        """[FABLE-5] sq-fmx4u.5. Toggling the ci-full label must re-run selection, so
+        both selection-consuming workflows react to labeled/unlabeled — and must NOT
+        drop the default `synchronize` (push-to-PR) trigger while doing so."""
+        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm)):
+            on = _on_block(wf)
+            pr = on.get("pull_request") or {}
+            self.assertIsInstance(
+                pr, dict, f"{wf_name}: pull_request must carry a types list")
+            types = pr.get("types", [])
+            for needed in ("labeled", "unlabeled"):
+                self.assertIn(needed, types,
+                              f"{wf_name}: pull_request must react to {needed} so the "
+                              f"ci-full label toggle re-evaluates selection")
+            for keep in ("opened", "synchronize", "reopened"):
+                self.assertIn(keep, types,
+                              f"{wf_name}: must keep the default {keep} trigger")
+
+    def test_nightly_full_matrix_backstop(self):
+        """[FABLE-5] sq-fmx4u.5 (design §6.1). ci.yml runs on a cron schedule (the
+        nightly full-matrix backstop) and carries the `selection-backstop` guard job
+        that fail-loud asserts a scheduled/dispatch run resolves to mode=full."""
+        on = _on_block(self.ci)
+        self.assertIn("schedule", on, "ci.yml must run on a cron schedule (nightly)")
+        job = self.ci["jobs"].get("selection-backstop")
+        self.assertIsNotNone(job, "ci.yml must carry the nightly selection-backstop guard")
+        # Runs ONLY on the backstop events (skipped => gate-satisfied elsewhere).
+        cond = str(job.get("if", ""))
+        self.assertIn("schedule", cond)
+        self.assertIn("workflow_dispatch", cond)
+        # It must depend on select and read its mode, failing if it is not 'full'.
+        needs = job.get("needs", [])
+        needs = [needs] if isinstance(needs, str) else needs
+        self.assertIn("select", needs, "backstop must need the select job")
+        run = " ".join(str(s.get("run", "")) for s in job.get("steps", []))
+        self.assertIn('"$SELECT_MODE" != "full"', run,
+                      "the backstop must fail-loud when the scheduled run is not full")
+        self.assertIn("exit 1", run)
 
     # ---- narrowing + assembly wiring ----------------------------------------------
     def test_bulk_shards_narrow_with_no_tests_pass_only_under_selection(self):


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5) — bead **sq-fmx4u.5**, the CULMINATION of the change-based CI test-selection epic (`sq-fmx4u`): flip `CI_SELECT_MODE` **shadow → enforce** so real per-PR test/benchmark skipping is turned on, plus the safety backstops. Design: `research/change-based-test-selection.md` §6 (+ the §5.3 / §6 graduation notes).

## Why this is safe to enforce now
Empirically verified by **sq-fmx4u.4** (#1440) against the live ruleset (id `17688455`): `required_status_checks` contains **exactly one** entry — `ci-summary / gate`. No individual per-crate matrix leg or `opt-in <X>` leg is individually required. So a selection-skipped leg reports `conclusion=skipped` (which branch protection + `ci_summary_gate.py` count as **satisfied** once the `select` pre-job succeeded) and **can never individually hang the merge queue**. **No ruleset change is required** — this is a code-only flip. (`needs_maintainer` is therefore **not** triggered.)

## What landed
1. **Enforce flip** (`.github/workflows/ci-select.yml`): `--shadow` is now added **only** when the repo variable `CI_SELECT_MODE` is the literal `"shadow"` (the report-only rollback escape hatch). Any other value — including unset and `"enforce"` — **enforces**. The pre-flip `!= "enforce" ⇒ --shadow` default is removed.
2. **`ci-full` PR-label override** (design §6.2): the select step computes `CI_FULL_LABEL = contains(github.event.pull_request.labels.*.name, 'ci-full')` and runs the selector with `--full` (mode=full, nothing skipped) when present. `ci.yml` + `feature-matrix.yml` now trigger on `pull_request:` types `[opened, synchronize, reopened, labeled, unlabeled]` so **toggling the label re-evaluates** selection (default `synchronize` etc. preserved).
3. **Nightly full-matrix backstop** (design §6.1): the existing `schedule` cron on `ci.yml` resolves to `mode=full` by construction (a non-PR event carries no diff), so nothing a PR selection-skipped can silently rot. A new **`selection-backstop`** job asserts that `mode=full` invariant **fail-loud** on `schedule`/`workflow_dispatch` (it REDs if a scheduled run were ever narrowed). `workflow_dispatch` remains the ad-hoc full run.
4. **Fail-safe PRESERVED (non-negotiable)**: `scripts/ci_select.py` is **unchanged** — every §4.1 trigger (shared crate / build file / `.github/**` / `Cargo.lock` / selector-self change) and any internal error still return `mode=full`. Enforce **never** skips a test for an affected crate or its reverse-dependency closure.

## Tested invariants (`scripts/tests/`)
- `EnforceRolloutTests` (test_ci_select.py): enforce + affected ⇒ **RUNS**; enforce + not-affected ⇒ **SKIPPED** (via the *exact* shard-guard membership rule `'"<crate>"' ∈ affected`); `ci-full` ⇒ full; nightly `schedule` ⇒ full; fail-safe trigger (`Cargo.lock`) ⇒ full; selector-error ⇒ full; enforce never emits `shadow`.
- **Mutation check**: `test_guard_needle_quotes_prevent_prefix_collision` proves the quoted needle rejects a prefix collision (`sparq-core` vs `sparq-core-foo`) where an unquoted-substring mutant would wrongly match — the soundness the quoting buys.
- Wiring inspection (test_ci_select_wiring.py): enforce-is-default / shadow-is-escape-hatch, ci-full override wiring, label-toggle triggers on both workflows, the nightly backstop job shape. `TestRequiredCheckAnchor` (sq-fmx4u.4) still pins the no-hang properties.
- All pre-existing `ci_select` / gate / assembler tests stay green: `test_ci_select` 40, `test_ci_select_wiring` 20, `test_path_ownership` 21, `test_ci_summary_gate` 33, `test_feature_matrix_assemble` 13 — all OK.

## Hard gates
- `actionlint`: **0 errors** across all workflows.
- Actions remain **SHA-pinned** (no new/changed action refs).
- `ci-summary / gate` stays **REQUIRED**, name **unchanged** (`gate`), no `if:` guard, still triggers on `merge_group` — pinned by `TestRequiredCheckAnchor`.
- `ruff` clean on the changed Python. Gate/ratchet not weakened anywhere.

## Deferred (proceed-and-document)
The §6.1 **auto-ALARM** — auto-filing a P1 when a nightly failure maps to a job some PR selection-skipped since the last green nightly — is a distinct correlation feature and is tracked as follow-up bead **sq-va7at** (blocked on this). The backstop itself (full nightly run reds the gate on any regression) is live now.

Not self-arming — leaving for review.