### PR TITLE
feat(e2e): tauri-driver smoke shrunk to max-3 assertions + Linux lane stabilized (sq-ymr2e.6)

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -540,16 +540,19 @@ jobs:
         working-directory: gui/e2e
         env:
           APP_BINARY: ${{ github.workspace }}/gui/src-tauri/target/debug/sparq-gui
-          ARTIFACTS_DIR: ${{ github.workspace }}/gui/e2e/artifacts
         run: |
-          if ! xvfb-run --auto-servernum npm run test:e2e; then
-            echo "[tauri-e2e-ci] first attempt failed; retrying once (xvfb startup flake check)…"
+          # [SONNET-4.6] Give each attempt its own artifacts subdir so a second failure does
+          # not overwrite the first attempt's screenshot/driver-log evidence.
+          ARTIFACTS_DIR="${{ github.workspace }}/gui/e2e/artifacts/attempt-1" \
+            xvfb-run --auto-servernum npm run test:e2e && exit 0
+          echo "[tauri-e2e-ci] first attempt failed; retrying once (xvfb startup flake check)…"
+          ARTIFACTS_DIR="${{ github.workspace }}/gui/e2e/artifacts/attempt-2" \
             xvfb-run --auto-servernum npm run test:e2e
-          fi
 
       # Upload failure artifacts (screenshot + driver log) even if the step above succeeded on
       # the retry — the artifacts are only written by the harness when an assertion fails, so
       # uploading unconditionally is safe (the action no-ops when the directory is empty).
+      # Both attempt-1/ and attempt-2/ subdirs are captured by the glob below.
       - name: Upload failure artifacts
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -635,19 +638,20 @@ jobs:
         run: npm ci
 
       # Run the smoke N times, counting greens. A pass-on-N/N means the lane is stable.
-      # Failures write artifacts/ entries; the upload step collects all of them.
+      # [SONNET-4.6] Each iteration writes to its own artifacts/probe-run-$i subdir so earlier
+      # failure evidence is not overwritten by later runs; all subdirs are uploaded below.
       - name: Run flake probe (${{ inputs.probe_runs }} consecutive runs)
         working-directory: gui/e2e
         env:
           APP_BINARY: ${{ github.workspace }}/gui/src-tauri/target/debug/sparq-gui
-          ARTIFACTS_DIR: ${{ github.workspace }}/gui/e2e/artifacts
         run: |
           RUNS=${{ inputs.probe_runs }}
           GREENS=0
           FAILS=0
           for i in $(seq 1 "$RUNS"); do
             echo "--- probe run $i / $RUNS ---"
-            if xvfb-run --auto-servernum npm run test:e2e; then
+            if ARTIFACTS_DIR="${{ github.workspace }}/gui/e2e/artifacts/probe-run-$i" \
+                xvfb-run --auto-servernum npm run test:e2e; then
               GREENS=$((GREENS + 1))
             else
               FAILS=$((FAILS + 1))

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -66,6 +66,16 @@ on:
       - "js/**"
       - "package-lock.json"
       - ".github/workflows/gui.yml"
+  # [SONNET-4.6] sq-ymr2e.6 — manual flake probe: run the tauri-driver smoke N times in sequence
+  # to measure consecutive-green rate. Trigger via "Run workflow" in the GitHub Actions UI.
+  # The `probe_runs` input defaults to 20 (the acceptance-criteria bar); the tauri-e2e-probe job
+  # below runs only when this event fires. Use this to gather evidence before promotion.
+  workflow_dispatch:
+    inputs:
+      probe_runs:
+        description: "Number of consecutive smoke runs (flake probe)"
+        required: false
+        default: "20"
 
 # Least-privilege default (Scorecard TokenPermissions): read-only; this lane never writes.
 permissions:
@@ -397,30 +407,33 @@ jobs:
       - name: Test (engine command layer)
         run: cargo test
 
-  # [OPUS-4.8] sq-pnnl — tauri-driver (WebDriver) e2e: REAL launch + run-a-query assertion.
+  # [SONNET-4.6] sq-ymr2e.6 — SHRUNK tauri-driver smoke: max-3-assertion real-IPC test.
   #
-  # This REPLACES the earlier no-op scaffold smoke (sq-bu69), which only confirmed
-  # tauri-driver / WebKitWebDriver / xvfb were on PATH. The job now builds the frontend the
-  # webview embeds, builds the desktop shell binary, and drives it through tauri-driver: it
-  # launches the shell headless (xvfb), waits for the in-tab WASM REPL to mount + the engine
-  # to warm, ENTERS a SPARQL SELECT into the editor, clicks Run, and ASSERTS the result table
-  # renders with the expected binding. The harness lives in gui/e2e (run-e2e.mjs, webdriverio).
+  # Shrunk from the multi-step sq-pnnl harness to exactly 3 meaningful assertions:
+  #   [1/3] LAUNCH    — real binary launched + React frontend mounted in the native webview.
+  #   [2/3] IPC LIVE  — native engine signalled "Engine ready" over real IPC.
+  #   [3/3] ROUND-TRIP — SELECT executed through real IPC, returned "Alice", status bar updated.
   #
-  # The design (research/gui-design.md §3 E2E) is explicit that Tauri's webview e2e uses
-  # tauri-driver (WebDriver), NOT Playwright's Chromium — so this is a NEW harness, not a reuse
-  # of site-e2e.yml. tauri-driver supports Linux (via WebKitWebDriver, headless under xvfb) and
-  # Windows (via Edge WebDriver); macOS has no WKWebView WebDriver, so the e2e is Linux-only.
+  # Everything beyond these three (EXPLAIN, SHACL, Import) is owned by the deterministic
+  # Playwright mock-IPC lane (gui/e2e-playwright, sq-ymr2e.5). Small surface = small flake budget.
   #
-  # ADVISORY — DELIBERATELY KEPT (the #748-class risk). The frontend-build + shell-build
-  # prerequisites are reproduced locally, but the headless WebKitWebDriver + tauri-driver +
-  # xvfb webview session itself is a NEW surface whose CI reliability is not yet proven across
-  # multiple runs, and it cannot be reproduced on a box without the webkit2gtk system libs. So
-  # the job NAME keeps the whole-word `advisory` token (the `ci-summary / gate` aggregator
-  # excludes `\b(advisory|informational)\b`) AND `continue-on-error: true`, so a flaky webview
-  # session can NEVER turn `ci-summary` red for every PR. The assertion RUNS (it is no longer a
-  # no-op) — it is just non-gating until proven reliably green. Promotion to a hard gate (drop
-  # the token + continue-on-error, add gui to branch-protection required contexts, a
-  # `needs:user` repo-settings action) is the separate follow-up tracked by bead sq-var9.
+  # STABILIZATION (research/web-gui-test-program.md §5.3):
+  #   * tauri-driver PINNED to 2.0.6 (compatible with Tauri 2.11.x on this workspace).
+  #   * WebKitWebDriver: installed from the runner's webkit2gtk-driver apt package (intentionally
+  #     matched to the runner image's webkit2gtk; its version is logged in CI for debugging).
+  #   * xvfb-run --auto-servernum (already present; a virtual display is mandatory on Linux).
+  #   * workers=1: the smoke is a single-process script (no parallelism; inherent).
+  #   * No arbitrary sleeps: all waits use waitForExist / waitUntil with explicit conditions;
+  #     validated by support/no-sleep-gate.sh (step below). The startup port-poll uses a
+  #     callback-style setTimeout (not an awaited sleep) — gate-safe.
+  #   * Shell-level retry 1: if the first attempt fails (driver start flake, display-server
+  #     race), the step retries once before counting as a failure. Evidence of failure is
+  #     captured as artifacts (screenshot + driver logs) on BOTH attempts.
+  #
+  # ADVISORY — DELIBERATELY KEPT. The job NAME carries the whole-word `advisory` token so
+  # the `ci-summary / gate` aggregator excludes it. `continue-on-error: true` ensures a
+  # driver/webview flake never turns ci-summary red. Promotion to a hard gate (bead sq-var9)
+  # requires 20 consecutive green runs of the flake probe (workflow_dispatch trigger above).
   tauri-e2e:
     name: "GUI tauri-driver e2e (Linux, advisory)"
     runs-on: ubuntu-latest
@@ -433,7 +446,9 @@ jobs:
         run: |
           sudo apt-get update
           # webkit2gtk-driver provides WebKitWebDriver, the WebDriver server tauri-driver
-          # proxies on Linux; xvfb gives the headless runner a virtual display for the webview.
+          # proxies on Linux. The version is intentionally matched to the runner image's
+          # webkit2gtk (pinned by the runner; see version-check step below).
+          # xvfb gives the headless runner a virtual display for the webview.
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev \
             libgtk-3-dev \
@@ -444,6 +459,15 @@ jobs:
             patchelf \
             webkit2gtk-driver \
             xvfb
+
+      # Log the installed WebKitWebDriver version. The apt package is matched to the runner
+      # image's webkit2gtk — not independently pinned, but logged here so any drift across
+      # runner image updates is immediately visible in the CI log.
+      - name: Log WebKitWebDriver version
+        run: |
+          WKVER=$(WebKitWebDriver --version 2>&1 || echo "unknown")
+          echo "WebKitWebDriver: $WKVER"
+          echo "webkit2gtk-driver apt: $(dpkg -l webkit2gtk-driver 2>/dev/null | tail -1)"
 
       # wasm32 target is needed to build the lean WASM bundle the in-tab REPL runs.
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -485,25 +509,160 @@ jobs:
           npm install
           (cd gui/app && npm run build:tauri)
 
-      # Build the desktop shell binary (debug). With site/out present, tauri_build embeds the
-      # frontend into the `sparq-gui` binary tauri-driver will launch.
+      # Build the desktop shell binary (debug). With gui/app/out present, tauri_build embeds
+      # the frontend into the `sparq-gui` binary tauri-driver will launch.
       - name: Build the GUI shell (debug, embeds the frontend)
         working-directory: gui/src-tauri
         run: cargo build
 
-      - name: Install tauri-driver
-        run: cargo install tauri-driver --locked
+      # Pin tauri-driver to 2.0.6 — the version published for Tauri 2.x (workspace uses 2.11.x).
+      # Pinning prevents a crates.io update from silently changing driver behaviour mid-run.
+      - name: Install tauri-driver@2.0.6 (pinned)
+        run: cargo install tauri-driver@2.0.6 --locked
 
       - name: Install the e2e harness dependencies
         working-directory: gui/e2e
         run: npm ci
 
-      # The REAL assertion: launch the shell through tauri-driver under a virtual display, run
-      # a SPARQL SELECT in the in-tab WASM REPL, and assert the result table renders. APP_BINARY
-      # is the absolute path to the just-built debug binary. `continue-on-error` above keeps a
-      # webview/driver flake strictly non-gating while this NEW harness is proven on CI.
-      - name: Run the tauri-driver WebDriver e2e (headless under xvfb)
+      # Determinism gate — forbids await sleep / waitForTimeout in the harness.
+      - name: Determinism gate — no arbitrary sleeps (no-sleep-gate)
+        working-directory: gui/e2e
+        run: bash support/no-sleep-gate.sh
+
+      # [1/3] LAUNCH [2/3] IPC LIVE [3/3] ROUND-TRIP — see run-e2e.mjs for the assertion map.
+      #
+      # Shell-level retry 1: xvfb display-server startup races are the primary source of
+      # first-attempt failures; a single retry keeps the job honest (a pass-on-retry is still
+      # logged as a defect to investigate, per §6.3 quarantine policy) without masking real bugs.
+      # Failure artifacts are written by the harness on both attempts (artifacts/ dir).
+      - name: Run the tauri-driver smoke (headless under xvfb; retry once on failure)
+        id: tauri-smoke
         working-directory: gui/e2e
         env:
           APP_BINARY: ${{ github.workspace }}/gui/src-tauri/target/debug/sparq-gui
-        run: xvfb-run --auto-servernum npm run test:e2e
+          ARTIFACTS_DIR: ${{ github.workspace }}/gui/e2e/artifacts
+        run: |
+          if ! xvfb-run --auto-servernum npm run test:e2e; then
+            echo "[tauri-e2e-ci] first attempt failed; retrying once (xvfb startup flake check)…"
+            xvfb-run --auto-servernum npm run test:e2e
+          fi
+
+      # Upload failure artifacts (screenshot + driver log) even if the step above succeeded on
+      # the retry — the artifacts are only written by the harness when an assertion fails, so
+      # uploading unconditionally is safe (the action no-ops when the directory is empty).
+      - name: Upload failure artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tauri-e2e-artifacts-${{ github.run_attempt }}
+          path: gui/e2e/artifacts/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # [SONNET-4.6] sq-ymr2e.6 — flake probe: run the smoke N times to gather consecutive-green
+  # evidence. Only triggered by `workflow_dispatch` (the per-PR lane is the `tauri-e2e` job
+  # above). Requires the same build prerequisites — shares the same setup steps.
+  #
+  # Usage: GitHub Actions UI → "Run workflow" → set probe_runs (default 20). The promotion bar
+  # (sq-ymr2e.6 acceptance criteria) is 20 consecutive greens; link the run in the PR body.
+  tauri-e2e-probe:
+    name: "GUI tauri-driver flake probe (Linux, advisory)"
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Install Tauri system dependencies (+ WebKitWebDriver, xvfb)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            webkit2gtk-driver \
+            xvfb
+
+      - name: Log WebKitWebDriver version
+        run: |
+          echo "WebKitWebDriver: $(WebKitWebDriver --version 2>&1 || echo 'unknown')"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Cache cargo (gui probe)
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            gui/src-tauri/target
+          key: gui-e2e-probe-${{ runner.os }}-${{ hashFiles('gui/src-tauri/Cargo.lock', 'Cargo.lock') }}
+
+      - name: Install wasm-pack
+        run: cargo install wasm-pack --locked
+
+      - name: Build the WASM bundle (shacl,jsonld; the in-tab engine)
+        working-directory: js
+        run: |
+          npm install
+          npm run build:wasm
+
+      - name: Build the GUI frontend static export (root-relative)
+        run: |
+          npm install
+          (cd gui/app && npm run build:tauri)
+
+      - name: Build the GUI shell (debug)
+        working-directory: gui/src-tauri
+        run: cargo build
+
+      - name: Install tauri-driver@2.0.6 (pinned)
+        run: cargo install tauri-driver@2.0.6 --locked
+
+      - name: Install the e2e harness dependencies
+        working-directory: gui/e2e
+        run: npm ci
+
+      # Run the smoke N times, counting greens. A pass-on-N/N means the lane is stable.
+      # Failures write artifacts/ entries; the upload step collects all of them.
+      - name: Run flake probe (${{ inputs.probe_runs }} consecutive runs)
+        working-directory: gui/e2e
+        env:
+          APP_BINARY: ${{ github.workspace }}/gui/src-tauri/target/debug/sparq-gui
+          ARTIFACTS_DIR: ${{ github.workspace }}/gui/e2e/artifacts
+        run: |
+          RUNS=${{ inputs.probe_runs }}
+          GREENS=0
+          FAILS=0
+          for i in $(seq 1 "$RUNS"); do
+            echo "--- probe run $i / $RUNS ---"
+            if xvfb-run --auto-servernum npm run test:e2e; then
+              GREENS=$((GREENS + 1))
+            else
+              FAILS=$((FAILS + 1))
+              echo "FAIL on run $i"
+            fi
+          done
+          echo ""
+          echo "=== FLAKE PROBE RESULT: $GREENS / $RUNS green, $FAILS failures ==="
+          # Exit 0 regardless — the probe is informational; CI captures the count.
+
+      - name: Upload probe failure artifacts
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: tauri-e2e-probe-artifacts
+          path: gui/e2e/artifacts/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/gui/e2e/.gitignore
+++ b/gui/e2e/.gitignore
@@ -1,3 +1,6 @@
 # [OPUS-4.8] sq-pnnl — the e2e harness's installed deps (webdriverio) are restored by
 # `npm ci` in CI from the committed package-lock.json; never commit the tree itself.
 /node_modules
+# [SONNET-4.6] sq-ymr2e.6 — failure artifacts (screenshots, driver logs) written on failure;
+# collected by the CI upload-artifact step, never committed.
+/artifacts

--- a/gui/e2e/README.md
+++ b/gui/e2e/README.md
@@ -1,63 +1,79 @@
-<!-- [OPUS-4.8] sq-pnnl -->
+<!-- [SONNET-4.6] sq-ymr2e.6 — SHRUNK tauri-driver smoke; was sq-pnnl (multi-step harness) -->
 
-# sparq GUI — tauri-driver (WebDriver) e2e
+# sparq GUI — tauri-driver (WebDriver) e2e smoke
 
-A **real** end-to-end test for the Tauri desktop shell: it launches the built shell binary
-through [`tauri-driver`](https://v2.tauri.app/develop/tests/webdriver/) (WebDriver), drives the
-DISTINCT operational GUI frontend (`gui/app`, NOT the marketing site — `sq-ixc3.8`) in the
-native webview, **runs a SPARQL query in the in-tab WASM workbench**, and asserts the result
-table renders. It replaces the earlier no-op harness smoke (`sq-bu69`), which only confirmed
-that `tauri-driver` / `WebKitWebDriver` / `xvfb` were on `PATH`.
+A **max-3-assertion** real-IPC smoke test for the Tauri desktop shell (bead sq-ymr2e.6).
+It launches the built shell binary through
+[`tauri-driver`](https://v2.tauri.app/develop/tests/webdriver/) (WebDriver), drives the
+DISTINCT operational GUI frontend (`gui/app`, NOT the marketing site) in the native WebKit
+webview, and makes exactly three assertions over real IPC.
 
-## What it does (`run-e2e.mjs`)
+UI-logic coverage (EXPLAIN, SHACL, Import drawer, keyboard spine) lives in the deterministic
+Playwright mock-IPC lane at `gui/e2e-playwright` (sq-ymr2e.5) — no real binary required.
 
-1. Spawns `tauri-driver` on `127.0.0.1:4444` (on Linux it proxies `WebKitWebDriver`).
-2. Connects a [`webdriverio`](https://webdriver.io) `remote()` session and launches the built
-   shell binary via the `tauri:options.application` capability.
-3. Waits for the SPARQL editor (`#repl-query`) to mount and the WASM engine to report
-   **Engine ready**.
-4. **Enters** a deterministic `SELECT ?name` over the seeded sample graph (set through the
-   native `<textarea>` value setter + a bubbling `input` event, so the React-controlled editor
-   updates).
-5. Clicks **Run query**.
-6. **Asserts** a `data-result-kind="select"` table renders containing the binding `"Alice"`
-   and at least one data row.
+## What it proves (`run-e2e.mjs`)
 
-The Tauri window loads the GUI frontend's static-export **index** (`gui/app/out/index.html`),
-which renders the workbench shell with the Query tool open by default, so the editor is present
-on load with no in-webview route navigation.
+| # | Assertion | What it proves |
+|---|-----------|----------------|
+| 1/3 | **LAUNCH** | Real binary launched; React workbench frontend mounted in the native webview (`#repl-query` exists). |
+| 2/3 | **IPC LIVE** | Native engine came up and signalled `"Engine ready"` over real IPC (top-bar.tsx `status.kind === "ready"`). |
+| 3/3 | **ROUND-TRIP** | `SELECT ?name` executed through real IPC, returned `"Alice"` in `data-result-kind="select"`, and the status bar shows a numeric row count. |
 
-## Run it locally (Linux)
+Everything else is out of scope here — small surface = small flake budget.
+
+## Determinism
+
+Zero arbitrary sleeps (`await sleep` / `waitForTimeout`). All waits use webdriverio's
+event-driven APIs (`waitForExist` / `waitUntil`). The tauri-driver startup port-poll uses a
+callback-style `setTimeout` (not an awaited sleep). Validated by `support/no-sleep-gate.sh`.
+
+## Run it locally (Linux only)
 
 Requires the webview system libraries (`libwebkit2gtk-4.1-dev`, …), `webkit2gtk-driver`
 (provides `WebKitWebDriver`), and `xvfb`. Then:
 
 ```bash
-# 1. Build the frontend the webview embeds (root-relative, as the GUI consumes it). The
-#    workbench needs the shacl,jsonld bundle (its SHACL tool + JSON-LD ingest).
+# 1. Build the frontend the webview embeds (root-relative).
 cd js && npm install && npm run build:wasm
-cd ../gui/app && npm install && npm run build:tauri   # = NEXT_PUBLIC_BASE_PATH= next build (root-relative)
+cd ../gui/app && npm install && npm run build:tauri
 
 # 2. Build the shell binary (embeds gui/app/out at compile time).
 cd ../src-tauri && cargo build
 
-# 3. Install the e2e deps + the driver, then run under a virtual display.
+# 3. Install the pinned driver, install deps, run under a virtual display.
+cargo install tauri-driver@2.0.6 --locked
 cd ../e2e && npm ci
-cargo install tauri-driver --locked
 xvfb-run --auto-servernum npm run test:e2e
 ```
 
-`APP_BINARY` (absolute path to the built shell binary) and `TAURI_DRIVER_BIN` can override the
-defaults; CI sets `APP_BINARY` explicitly.
+`APP_BINARY` (absolute path to the built shell binary), `TAURI_DRIVER_BIN`, and `ARTIFACTS_DIR`
+can override the defaults. CI sets `APP_BINARY` and `ARTIFACTS_DIR` explicitly.
 
-## CI + honesty
+## Failure artifacts
+
+On assertion failure, the harness writes to `artifacts/` (git-ignored):
+- `artifacts/screenshot.png` — WebDriver screenshot of the webview at failure time.
+- `artifacts/tauri-driver.log` — collected stdout/stderr from the tauri-driver process.
+
+The CI `upload-artifact` step collects these for 7 days so failures are diagnosable.
+
+## CI wiring
 
 Wired as the `tauri-e2e` job in [`.github/workflows/gui.yml`](../../.github/workflows/gui.yml).
-The job keeps the **`(Linux, advisory)`** name token and `continue-on-error: true`, so it is
-**excluded from the `ci-summary / gate`** aggregator and cannot break the merge gate for all
-PRs while the headless `tauri-driver` + `WebKitWebDriver` + `xvfb` stack is being proven
-reliably green on `ubuntu-latest`. The frontend-build + shell-build prerequisites are reproduced
-locally; the headless WebDriver session itself is **documented-untested locally** (it needs
-webkit2gtk system libraries) — it validates on the first CI run. Promotion to a hard gate (drop
-the `advisory` token + `continue-on-error`, add to branch-protection required contexts) is the
-separate maintainer step tracked by `sq-var9`.
+
+- `tauri-driver` is pinned to **2.0.6** (`cargo install tauri-driver@2.0.6 --locked`).
+- `WebKitWebDriver` comes from the runner's `webkit2gtk-driver` apt package (matched to the
+  runner image's webkit2gtk; the version is logged in CI for drift detection).
+- `xvfb-run --auto-servernum` provides the headless display.
+- Single process (workers=1 by construction).
+- Shell-level retry 1 for xvfb startup races; failure artifacts uploaded either way.
+- Job name carries `(Linux, advisory)` so the `ci-summary / gate` aggregator excludes it.
+- `continue-on-error: true` ensures a driver/webview flake never turns `ci-summary` red.
+
+## Flake probe
+
+A `workflow_dispatch` trigger on `gui.yml` runs the smoke N times (default 20) to measure
+consecutive-green rate — the evidence needed for the acceptance criteria (20/20 green).
+To run: GitHub Actions UI → "Run workflow" → set `probe_runs`. Link the run in the PR body.
+
+Promotion to a hard gate (drop `advisory` + `continue-on-error`) is tracked by bead `sq-var9`.

--- a/gui/e2e/package.json
+++ b/gui/e2e/package.json
@@ -2,10 +2,11 @@
   "name": "sparq-gui-e2e",
   "version": "0.0.0",
   "private": true,
-  "description": "tauri-driver (WebDriver) end-to-end test harness for the sparq Tauri GUI shell — launches the built desktop binary, runs a SPARQL query in the in-tab WASM REPL, and asserts the result renders.",
+  "description": "tauri-driver (WebDriver) e2e smoke for the sparq Tauri GUI shell — max-3-assertion real-IPC test (sq-ymr2e.6).",
   "type": "module",
   "scripts": {
-    "test:e2e": "node run-e2e.mjs"
+    "test:e2e": "node run-e2e.mjs",
+    "no-sleep-gate": "bash support/no-sleep-gate.sh"
   },
   "engines": {
     "node": ">=18.20.0"

--- a/gui/e2e/run-e2e.mjs
+++ b/gui/e2e/run-e2e.mjs
@@ -1,62 +1,52 @@
-// [OPUS-4.8] sq-pnnl — REAL tauri-driver (WebDriver) e2e for the sparq Tauri GUI shell.
+// [SONNET-4.6] sq-ymr2e.6 — SHRUNK tauri-driver (WebDriver) smoke: max-3-assertion real-IPC test.
 //
-// Replaces the no-op "harness scaffold OK" smoke (sq-bu69) with a real assertion:
-//   1. spawn tauri-driver (the WebDriver intermediary; on Linux it proxies WebKitWebDriver),
-//   2. connect a WebDriver client (webdriverio) and launch the BUILT Tauri shell binary,
-//   3. wait for the DISTINCT operational GUI frontend (the in-tab WASM workbench) to mount +
-//      the engine to warm,
-//   4. ENTER a known SPARQL SELECT into the editor (the React-controlled `#repl-query`
-//      textarea — set via the native value setter + an `input` event so React's state
-//      updates, the standard controlled-input driving technique),
-//   5. click "Run query", and
-//   6. ASSERT the SELECT result table renders with the expected binding ("Alice", from the
-//      seeded sample graph), then
-//   7. [OPUS-4.8] sq-ixc3.12 — click EXPLAIN and ASSERT the planner plan renders
-//      (data-result-kind="explain"), exercising the UNIFIED run(query,{mode}) EXPLAIN path, then
-//   8. [OPUS-4.8] sq-ixc3.11 — open the SHACL tool (left-rail data-tool="shacl"), click
-//      "Validate live store", and ASSERT a W3C validation report renders over the serialised
-//      live store (proving the SHACL surface is a working TOOL, not a stub).
-//   9. [OPUS-4.8] sq-ixc3.13 — open the Import drawer (left-rail data-import-trigger="rail"),
-//      switch to the Paste tab, enter a triple, click Import, and ASSERT a success feedback
-//      (data-import-feedback="ok") — proving the native loader ingest path merges into the store.
+// Only tauri-driver can prove these three things:
+//   [1/3] LAUNCH   — the real binary launched and the React frontend mounted in the native webview.
+//   [2/3] IPC LIVE — the native engine came up and signalled "Engine ready" over real IPC.
+//   [3/3] ROUND-TRIP — a SPARQL SELECT executed through real IPC, returned rows containing
+//                      the expected binding ("Alice"), and the status bar reflects the row count.
 //
-// This proves the desktop shell actually loads, the WASM engine runs a query IN THE TAB, and
-// the result renders — i.e. the shell is a working app, not just a crate that compiles.
+// Everything beyond these three is covered by the deterministic Playwright mock-IPC lane
+// (gui/e2e-playwright, sq-ymr2e.5): EXPLAIN, SHACL validation, Import drawer, keyboard spine.
+// Keeping this smoke tiny is the whole point — small surface = small flake budget.
 //
-// HOW IT FINDS THINGS (kept faithful to the DISTINCT operational GUI frontend, gui/app, so it
-// cannot silently drift — sq-ixc3.8 repointed the shell off the marketing site onto gui/app):
-//   * The Tauri window loads the GUI frontend's static-export INDEX (gui/app/out/index.html),
-//     which renders the workbench shell with the Query tool open by default — so no in-webview
-//     route navigation is needed.
-//   * The editor is a controlled <textarea id="repl-query">
-//     (gui/app/src/components/workbench/query-workbench.tsx).
-//   * The Run button carries the visible text "Run query" (same file).
-//   * The top bar shows "Engine ready" once the in-tab WASM engine warms
-//     (gui/app/src/components/workbench/top-bar.tsx).
-//   * A SELECT result renders a container with data-result-kind="select" and, in table view,
-//     data-result-view="table" wrapping a <table> (query-workbench.tsx). We assert on those
-//     stable data-* hooks + the literal "Alice" (from the seeded sample graph).
+// DETERMINISM (§1 doctrine): zero arbitrary sleeps. All waits use webdriverio's event-driven
+// polling APIs (waitForExist / waitUntil) with explicit conditions. The tauri-driver startup
+// wait uses a callback-based retry (net.createConnection + setTimeout-in-callback) — not an
+// awaited sleep — so it does not trigger the no-sleep gate (support/no-sleep-gate.sh).
 //
-// CONFIG via env (CI sets APP_BINARY): APP_BINARY is the absolute path to the built shell
-// binary tauri-driver launches (the gui crate's package name is `sparq-gui`, so the debug
-// binary is gui/src-tauri/target/debug/sparq-gui). tauri-driver listens on 127.0.0.1:4444.
+// FAILURE ARTIFACTS: on any assertion failure, a screenshot is saved to artifacts/ and the
+// accumulated tauri-driver logs are flushed to artifacts/tauri-driver.log before exit so the
+// CI `upload-artifact` step can surface them.
+//
+// CONFIG via env:
+//   APP_BINARY        — absolute path to the built shell binary (CI sets this; default: debug path)
+//   TAURI_DRIVER_BIN  — path to the tauri-driver binary (default: ~/.cargo/bin/tauri-driver)
+//   ARTIFACTS_DIR     — directory for failure artifacts (default: ./artifacts)
 
 import { spawn } from "node:child_process";
-import { setTimeout as sleep } from "node:timers/promises";
+import fs from "node:fs";
+import net from "node:net";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 import { remote } from "webdriverio";
+
+// ESM __dirname shim (__dirname requires Node 20.11+; this works from Node 18).
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
 
 const TAURI_DRIVER_PORT = 4444;
 const TAURI_DRIVER_HOST = "127.0.0.1";
 
-// The built shell binary tauri-driver launches. CI passes an absolute APP_BINARY; the default
-// is the debug binary cargo produces for the `sparq-gui` package.
 const APP_BINARY =
   process.env.APP_BINARY ||
   path.resolve(
-    process.cwd(),
+    __dirname,
     "..",
     "src-tauri",
     "target",
@@ -64,57 +54,91 @@ const APP_BINARY =
     "sparq-gui",
   );
 
-// tauri-driver is installed by `cargo install`, so it lives in ~/.cargo/bin on the runner.
 const TAURI_DRIVER_BIN =
   process.env.TAURI_DRIVER_BIN ||
   path.resolve(os.homedir(), ".cargo", "bin", "tauri-driver");
 
-// The query we ENTER + run. A deterministic SELECT over the built-in sample graph — every
-// person's foaf:name, ordered — so "Alice" is guaranteed in the result table.
+const ARTIFACTS_DIR =
+  process.env.ARTIFACTS_DIR ||
+  path.resolve(__dirname, "artifacts");
+
+// The deterministic SELECT — every foaf:name in the seeded sample graph, ordered. "Alice" is
+// the expected first binding and MUST appear in the result table for the assertion to pass.
 const TEST_QUERY = [
   "PREFIX foaf: <http://xmlns.com/foaf/0.1/>",
   "SELECT ?name WHERE { ?s foaf:name ?name } ORDER BY ?name",
 ].join("\n");
 
-const EXPECTED_CELL = "Alice";
+const EXPECTED_BINDING = "Alice";
+
+// ---------------------------------------------------------------------------
+// Utilities
+// ---------------------------------------------------------------------------
 
 function log(...args) {
-  // Prefix so the CI log clearly attributes the harness output.
   console.log("[tauri-e2e]", ...args);
 }
 
-let tauriDriver;
+// Ensure the artifacts output directory exists.
+function ensureArtifactsDir() {
+  fs.mkdirSync(ARTIFACTS_DIR, { recursive: true });
+}
 
-// Spawn tauri-driver and wait until its port accepts a TCP connection (it boots fast, but
-// racing the WebDriver session against an unbound port is the classic flake source).
-async function startTauriDriver() {
+// ---------------------------------------------------------------------------
+// tauri-driver lifecycle
+// ---------------------------------------------------------------------------
+
+let tauriDriver = null;
+const driverLogLines = [];
+
+function startTauriDriver() {
   log(`spawning tauri-driver: ${TAURI_DRIVER_BIN}`);
   tauriDriver = spawn(TAURI_DRIVER_BIN, ["--port", String(TAURI_DRIVER_PORT)], {
-    stdio: ["ignore", "inherit", "inherit"],
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  tauriDriver.stdout?.on("data", (chunk) => {
+    const line = String(chunk);
+    process.stdout.write("[tauri-driver stdout] " + line);
+    driverLogLines.push("stdout: " + line);
+  });
+  tauriDriver.stderr?.on("data", (chunk) => {
+    const line = String(chunk);
+    process.stderr.write("[tauri-driver stderr] " + line);
+    driverLogLines.push("stderr: " + line);
   });
   tauriDriver.on("error", (err) => {
     log("tauri-driver process error:", err.message);
+    driverLogLines.push("process error: " + err.message);
   });
+}
 
-  const net = await import("node:net");
-  const deadline = Date.now() + 20_000;
-  while (Date.now() < deadline) {
-    const up = await new Promise((resolve) => {
+// Wait for the tauri-driver port to accept connections using event-driven retry.
+// Uses callback-style setTimeout (NOT an awaited sleep) so the no-sleep gate passes.
+function waitForDriverPort(port, host, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const deadline = Date.now() + timeoutMs;
+
+    function attempt() {
+      if (Date.now() >= deadline) {
+        reject(new Error(`tauri-driver port ${port} not available after ${timeoutMs} ms`));
+        return;
+      }
       const sock = net
-        .createConnection(TAURI_DRIVER_PORT, TAURI_DRIVER_HOST)
+        .createConnection(port, host)
         .on("connect", () => {
           sock.destroy();
-          resolve(true);
+          log(`tauri-driver is listening on ${host}:${port}`);
+          resolve();
         })
-        .on("error", () => resolve(false));
-    });
-    if (up) {
-      log(`tauri-driver is listening on ${TAURI_DRIVER_HOST}:${TAURI_DRIVER_PORT}`);
-      return;
+        .on("error", () => {
+          sock.destroy();
+          // Retry after 200 ms via callback (not an awaited sleep — no-sleep gate safe).
+          setTimeout(attempt, 200);
+        });
     }
-    await sleep(250);
-  }
-  throw new Error("tauri-driver did not start listening within 20s");
+
+    attempt();
+  });
 }
 
 function stopTauriDriver() {
@@ -124,34 +148,57 @@ function stopTauriDriver() {
   }
 }
 
+// Flush collected driver logs to a file (called on failure before exit).
+function saveDriverLogs() {
+  ensureArtifactsDir();
+  const dest = path.join(ARTIFACTS_DIR, "tauri-driver.log");
+  fs.writeFileSync(dest, driverLogLines.join(""), "utf8");
+  log(`driver logs saved to ${dest}`);
+}
+
+// ---------------------------------------------------------------------------
+// Main smoke — exactly 3 assertions
+// ---------------------------------------------------------------------------
+
 async function main() {
   log(`app binary: ${APP_BINARY}`);
-  await startTauriDriver();
 
-  // webdriverio `remote()` session against tauri-driver. The `tauri:options.application`
-  // capability is what tells tauri-driver which native binary to launch.
+  startTauriDriver();
+  await waitForDriverPort(TAURI_DRIVER_PORT, TAURI_DRIVER_HOST, 20_000);
+
+  // Open a WebDriver session through tauri-driver. `tauri:options.application` tells
+  // tauri-driver which native binary to launch. connectionRetryCount / connectionRetryTimeout
+  // cover transient HTTP hiccups — webdriverio's own retry policy, not arbitrary sleeps.
   const browser = await remote({
     hostname: TAURI_DRIVER_HOST,
     port: TAURI_DRIVER_PORT,
-    // Keep webdriverio's own logging quiet; the harness logs the meaningful steps.
     logLevel: "error",
+    connectionRetryTimeout: 30_000,
+    connectionRetryCount: 5,
     capabilities: {
       "tauri:options": { application: APP_BINARY },
-      // wry/WebKitWebGTK identifies as a generic webkit webview; tauri-driver fills the rest.
       browserName: "wry",
     },
   });
 
   try {
-    // 1. The editing textarea proves the frontend (and React) mounted.
-    log("waiting for the SPARQL editor to mount…");
+    // ------------------------------------------------------------------
+    // ASSERTION 1/3: LAUNCH
+    // The SPARQL editor (#repl-query) being present proves the real binary launched and
+    // the React-based GUI frontend mounted inside the native WebKit webview.
+    // ------------------------------------------------------------------
+    log("[1/3] waiting for the SPARQL editor to mount (#repl-query)…");
     const editor = await browser.$("#repl-query");
     await editor.waitForExist({ timeout: 30_000 });
+    log("PASS [1/3] LAUNCH — editor mounted in the native webview");
 
-    // 2. Wait for the engine to be ready. The REPL shows an "Engine ready" badge once the
-    //    WASM bundle + default dataset are warm. `ensureStore` is a safety net (a click
-    //    before ready still works), but waiting removes the only real timing race.
-    log("waiting for the WASM engine to warm…");
+    // ------------------------------------------------------------------
+    // ASSERTION 2/3: IPC LIVE
+    // The top bar shows "Engine ready" once the native engine has responded over real IPC.
+    // (top-bar.tsx: `status.kind === "ready"` renders the literal "Engine ready" copy —
+    // a comment there marks it as the deterministic hook the e2e waits on.)
+    // ------------------------------------------------------------------
+    log("[2/3] waiting for the native engine to report ready over IPC…");
     await browser.waitUntil(
       async () => {
         const body = await browser.$("body");
@@ -160,15 +207,17 @@ async function main() {
       },
       {
         timeout: 60_000,
-        timeoutMsg: "engine never reported ready",
+        timeoutMsg: "native engine never reported 'Engine ready' — IPC may not be up",
         interval: 500,
       },
     );
+    log("PASS [2/3] IPC LIVE — native engine reported 'Engine ready'");
 
-    // 3. ENTER the query. The textarea is React-controlled, so a plain setValue/sendKeys
-    //    would not update React state (React owns `value`). Set the value through the native
-    //    HTMLTextAreaElement value setter and dispatch a bubbling `input` event — the
-    //    canonical way to drive a controlled React input from outside React.
+    // ------------------------------------------------------------------
+    // Plumbing: enter the test query and click Run.
+    // The textarea is React-controlled — set value via the native setter + dispatch a
+    // bubbling `input` event so React's state updates (standard controlled-input technique).
+    // ------------------------------------------------------------------
     log("entering the test query into the editor…");
     await browser.execute((value) => {
       const el = document.querySelector("#repl-query");
@@ -180,7 +229,6 @@ async function main() {
       el.dispatchEvent(new Event("input", { bubbles: true }));
     }, TEST_QUERY);
 
-    // Sanity-check the editor actually holds our query before running.
     const editorValue = await editor.getValue();
     if (!editorValue.includes("SELECT ?name")) {
       throw new Error(
@@ -188,15 +236,20 @@ async function main() {
       );
     }
 
-    // 4. Click "Run query". Locate the button by its visible label (stable copy).
-    log('clicking "Run query"…');
+    log("clicking 'Run query'…");
     const runButton = await browser.$("button=Run query");
     await runButton.waitForClickable({ timeout: 10_000 });
     await runButton.click();
 
-    // 5. ASSERT the SELECT result table renders. Wait for the select-result container, then
-    //    the table view, then assert the expected binding cell is present.
-    log("waiting for the SELECT result to render…");
+    // ------------------------------------------------------------------
+    // ASSERTION 3/3: ROUND-TRIP
+    // A SELECT result table renders containing the expected binding ("Alice"), proving the
+    // query executed through real IPC against the native engine and a result was returned.
+    // The status bar's row-count field also transitions from "— rows" to "N rows", confirming
+    // the engine plumbed the result count back through IPC (status-bar.tsx: lastRowCount).
+    // ------------------------------------------------------------------
+    log("[3/3] waiting for the SELECT result to render…");
+
     const selectResult = await browser.$('[data-result-kind="select"]');
     await selectResult.waitForExist({ timeout: 30_000 });
 
@@ -204,144 +257,65 @@ async function main() {
     await tableView.waitForExist({ timeout: 10_000 });
 
     const tableText = await tableView.getText();
-    if (!tableText.includes(EXPECTED_CELL)) {
+    if (!tableText.includes(EXPECTED_BINDING)) {
       throw new Error(
-        `result table rendered but did not contain "${EXPECTED_CELL}" (text: ${JSON.stringify(
-          tableText,
-        ).slice(0, 200)}…)`,
+        `result table rendered but did not contain "${EXPECTED_BINDING}" ` +
+          `(text: ${JSON.stringify(tableText).slice(0, 200)}…)`,
       );
     }
 
-    // Assert at least one data row exists (header is a <th>; rows are <td>). In webdriverio
-    // v9 `$$` returns a ChainablePromiseArray; awaiting it yields an ElementArray with a
-    // numeric `.length`.
-    const rows = await browser.$$('[data-result-view="table"] tbody tr');
-    const rowCount = rows.length;
-    if (rowCount < 1) {
-      throw new Error("result table has no data rows");
-    }
-
-    log(
-      `PASS — SELECT ran in the in-tab WASM engine and rendered ${rowCount} row(s) including "${EXPECTED_CELL}".`,
-    );
-
-    // 6. [OPUS-4.8] sq-ixc3.12 — EXPLAIN smoke: click the toolbar EXPLAIN button and assert the
-    //    planner-plan container renders. This exercises the UNIFIED EXPLAIN path —
-    //    run(query, { mode: "explain" }) surfacing a { kind: "explain" } outcome through the
-    //    SAME results pipeline (data-result-kind="explain") the Cmd-K "Run EXPLAIN" verb also
-    //    drives — proving the single EXPLAIN contract works end-to-end after the #1018 reconcile.
-    log('clicking "EXPLAIN"…');
-    const explainButton = await browser.$("button=EXPLAIN");
-    await explainButton.waitForClickable({ timeout: 10_000 });
-    await explainButton.click();
-
-    log("waiting for the EXPLAIN plan to render…");
-    const explainResult = await browser.$('[data-result-kind="explain"]');
-    await explainResult.waitForExist({ timeout: 30_000 });
-    const planText = await explainResult.getText();
-    if (!planText.trim()) {
-      throw new Error("EXPLAIN container rendered but the plan text was empty");
-    }
-    log("PASS — EXPLAIN rendered the planner's plan through the unified run() path.");
-
-    // 7. [OPUS-4.8] sq-ixc3.11 — SHACL TOOL smoke: open the SHACL tab from the left rail
-    //    (data-tool="shacl", left-rail.tsx), click "Validate live store" (shacl-tool.tsx), and
-    //    assert the validation report container renders. This proves the SHACL surface is a
-    //    WORKING tool over the SERIALISED live store (serializeStore → sparqShaclValidate), not
-    //    a stub — without asserting a specific verdict (the starter shapes may or may not flag
-    //    the seeded sample graph), only that the operational round-trip produced a report.
-    log("opening the SHACL tool from the left rail…");
-    const shaclTab = await browser.$('[data-tool="shacl"]');
-    await shaclTab.waitForClickable({ timeout: 10_000 });
-    await shaclTab.click();
-
-    log('clicking "Validate live store"…');
-    const validateButton = await browser.$("button=Validate live store");
-    await validateButton.waitForClickable({ timeout: 10_000 });
-    await validateButton.click();
-
-    log("waiting for the SHACL validation report to render…");
-    const shaclReport = await browser.$('[data-result-kind="shacl"]');
-    await shaclReport.waitForExist({ timeout: 30_000 });
-    // The report pane settles out of the transient "Validating…" placeholder into a verdict
-    // (Conforms / N violations / an error). Assert it reaches one of those terminal states.
+    // Status bar: "N rows" (not "— rows") proves the engine plumbed the count back over IPC.
     await browser.waitUntil(
       async () => {
-        const text = await shaclReport.getText();
-        return /Conforms|violation|cannot be serialised|error/i.test(text) && !/Validating…/.test(text);
+        const body = await browser.$("body");
+        const text = await body.getText();
+        return /\d[\d,]* rows/.test(text);
       },
       {
-        timeout: 30_000,
-        timeoutMsg: "SHACL validation never produced a terminal report",
-        interval: 500,
+        timeout: 10_000,
+        timeoutMsg: "status bar never showed a numeric row count after the SELECT",
+        interval: 200,
       },
     );
-    log("PASS — the SHACL tool validated the live store and rendered a W3C report.");
 
-    // 9. [OPUS-4.8] sq-ixc3.13 — IMPORT DRAWER smoke: open the drawer from the left rail's
-    //    "+ Import" (data-import-trigger="rail"), switch to the Paste tab, enter a triple, and
-    //    click Import — then assert a SUCCESS feedback renders (data-import-feedback="ok"). This
-    //    exercises the real ingest path end-to-end inside the desktop shell: the native loader
-    //    (`load_text`) decodes the document → N-Quads → the in-tab store merges it. The seeded
-    //    triple uses a fresh subject so it adds at least one quad regardless of the sample graph.
-    log("opening the Import drawer from the left rail…");
-    const importTrigger = await browser.$('[data-import-trigger="rail"]');
-    await importTrigger.waitForClickable({ timeout: 10_000 });
-    await importTrigger.click();
-
-    log("switching to the Paste tab…");
-    const pasteTab = await browser.$('[data-import-tab="paste"]');
-    await pasteTab.waitForClickable({ timeout: 10_000 });
-    await pasteTab.click();
-
-    log("entering a triple into the paste textarea…");
-    const IMPORT_DOC =
-      "<http://example.org/imported> <http://example.org/p> <http://example.org/o> .";
-    await browser.execute((value) => {
-      const el = document.querySelector("[data-import-drawer] textarea");
-      const setter = Object.getOwnPropertyDescriptor(
-        window.HTMLTextAreaElement.prototype,
-        "value",
-      ).set;
-      setter.call(el, value);
-      el.dispatchEvent(new Event("input", { bubbles: true }));
-    }, IMPORT_DOC);
-
-    log("clicking the Import button…");
-    // The Import button label carries the mode suffix ("Import (add to store)"); match the lead.
-    const importButton = await browser.$('[data-import-drawer] button*=Import');
-    await importButton.waitForClickable({ timeout: 10_000 });
-    await importButton.click();
-
-    log("waiting for the import success feedback…");
-    const importOk = await browser.$('[data-import-feedback="ok"]');
-    await importOk.waitForExist({ timeout: 30_000 });
-    const okText = await importOk.getText();
-    if (!/Imported/i.test(okText)) {
-      throw new Error(`import feedback rendered but was not a success: ${JSON.stringify(okText)}`);
-    }
-    log("PASS — the Import drawer ingested a pasted document into the live store.");
+    log(
+      `PASS [3/3] ROUND-TRIP — SELECT returned "${EXPECTED_BINDING}" and status bar shows row count`,
+    );
 
     await browser.deleteSession();
   } catch (err) {
-    // Best-effort session teardown; surface the real failure.
+    // Save failure artifacts before tearing down — the CI `upload-artifact` step collects them.
+    log("saving failure artifacts to", ARTIFACTS_DIR);
+    ensureArtifactsDir();
+    try {
+      await browser.saveScreenshot(path.join(ARTIFACTS_DIR, "screenshot.png"));
+      log("screenshot saved");
+    } catch (screenshotErr) {
+      log("could not save screenshot:", screenshotErr.message);
+    }
+    saveDriverLogs();
     try {
       await browser.deleteSession();
     } catch {
-      /* ignore */
+      /* ignore teardown errors — surface the real failure below */
     }
     throw err;
   }
 }
 
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
 main()
   .then(() => {
     stopTauriDriver();
-    log("e2e succeeded");
+    log("smoke succeeded — all 3 assertions passed");
     process.exit(0);
   })
   .catch((err) => {
     stopTauriDriver();
-    console.error("[tauri-e2e] FAILED:", err && err.stack ? err.stack : err);
+    saveDriverLogs();
+    console.error("[tauri-e2e] FAILED:", err?.stack ?? err);
     process.exit(1);
   });

--- a/gui/e2e/support/no-sleep-gate.sh
+++ b/gui/e2e/support/no-sleep-gate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# [SONNET-4.6] sq-ymr2e.6 — determinism gate for the tauri-driver smoke harness.
+#
+# Forbids arbitrary time-based waits (await sleep / await setTimeout / waitForTimeout)
+# in the harness source files (*.mjs, *.js, *.ts). Polling MUST use event-driven APIs
+# (webdriverio waitForExist / waitUntil with an explicit condition), never a fixed delay.
+#
+# Mirrors the no-timeout-gate.sh used by the Playwright mock-IPC lane (gui/e2e-playwright/).
+# Scope: all .mjs/.js/.ts files under gui/e2e/ (excluding node_modules/).
+#
+# Exit 0 = clean; exit 1 = violation found.
+
+set -euo pipefail
+
+HARNESS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+echo "[no-sleep-gate] scanning $HARNESS_DIR for arbitrary time-based waits…"
+
+FOUND=0
+
+while IFS= read -r -d $'\0' f; do
+  # Forbidden patterns:
+  #   await sleep(        — node:timers/promises sleep alias
+  #   await setTimeout(   — direct awaited timer (not a callback-style retry)
+  #   waitForTimeout(     — WebdriverIO / Playwright explicit timeout wait
+  if grep -En 'await sleep\(|await setTimeout\(|waitForTimeout\(' "$f" >/dev/null 2>&1; then
+    echo "FAIL: arbitrary time-based wait found in $f:"
+    grep -En 'await sleep\(|await setTimeout\(|waitForTimeout\(' "$f"
+    FOUND=1
+  fi
+done < <(find "$HARNESS_DIR" \( -name "*.mjs" -o -name "*.js" -o -name "*.ts" \) \
+  ! -path "*/node_modules/*" -print0)
+
+if [ "$FOUND" -eq 1 ]; then
+  echo ""
+  echo "[no-sleep-gate] FAILED — remove arbitrary sleeps; use waitForExist / waitUntil instead"
+  exit 1
+fi
+
+echo "[no-sleep-gate] clean — no arbitrary time-based waits found"


### PR DESCRIPTION
> 🤖 SPARQ agent (Sonnet 4.6) — bead sq-ymr2e.6 implementation.
> Design record: research/web-gui-test-program.md §5.3.

## Summary

- **Shrunk** the tauri-driver smoke from a 4-assertion multi-tool harness (sq-pnnl) to exactly **3 meaningful assertions** — the minimum that only real-IPC can prove: app launches, engine IPC is live, and a SELECT round-trips with the result surfaced in both the result table and the status bar.
- **Removed** EXPLAIN / SHACL / Import-drawer assertions from this lane — they now belong to the deterministic Playwright mock-IPC lane (sq-ymr2e.5, already merged).
- **Stabilized the Linux lane**: `tauri-driver` pinned to `2.0.6`, WebKitWebDriver version logged for drift detection, `no-sleep-gate.sh` determinism gate added, shell-level retry 1 for xvfb startup races, failure artifacts (screenshot + driver log) uploaded on failure.
- **Added flake probe**: `workflow_dispatch` trigger + `tauri-e2e-probe` job runs the smoke N times (default 20) to measure consecutive-green rate — the evidence for the acceptance-criteria bar.

## The 3 assertions

| # | Assertion | What only tauri-driver can prove |
|---|-----------|----------------------------------|
| 1/3 | **LAUNCH** | `#repl-query` mounts in the native WebKit webview (real binary launched) |
| 2/3 | **IPC LIVE** | `"Engine ready"` appears in the top bar (native engine responded over real IPC) |
| 3/3 | **ROUND-TRIP** | `SELECT ?name` returns `"Alice"` + status bar shows numeric row count |

## Stabilization changes

- `tauri-driver@2.0.6` pinned via `cargo install tauri-driver@2.0.6 --locked` (was unversioned).
- WebKitWebDriver: logged via `WebKitWebDriver --version` + `dpkg -l` (matched to runner image's webkit2gtk by construction; version tracked for drift).
- `xvfb-run --auto-servernum` already present; preserved.
- Single process (workers=1 by construction of the .mjs script).
- **Zero arbitrary sleeps**: old `await sleep(250)` TCP poll loop replaced with callback-style `setTimeout`-in-closure retry (gate-safe). All DOM waits use `waitForExist`/`waitUntil` with explicit conditions.
- `support/no-sleep-gate.sh` — new determinism gate, mirrors mock-IPC lane's `no-timeout-gate.sh`.
- Shell-level retry 1: `if ! xvfb-run ... ; then xvfb-run ... ; fi` (xvfb startup races are the primary first-attempt failure source).
- Failure artifacts written by harness on assertion failure: `artifacts/screenshot.png` + `artifacts/tauri-driver.log`; collected by `upload-artifact` step (7-day retention).

## Advisory status

Lane stays advisory: `(Linux, advisory)` job name + `continue-on-error: true` preserved. The `ci-summary / gate` aggregator continues to exclude it. Promotion to a hard gate (bead `sq-var9`) requires 20 consecutive green runs from the flake probe.

## Honesty: ran_locally

`ran_locally: false` — the headless WebKitWebDriver + xvfb + tauri-driver stack requires webkit2gtk system libraries not present on this work box. Verified gates that CAN run locally: no-sleep gate passes, actionlint clean, Node.js syntax check on run-e2e.mjs passes, typos clean.

## Test plan

- [ ] CI `tauri-e2e` job runs and the 3 assertions are visible in the log (`PASS [1/3]`, `[2/3]`, `[3/3]`).
- [ ] If the job fails on first attempt, the retry fires and artifacts are uploaded.
- [ ] `no-sleep-gate` step passes (no arbitrary sleeps in the harness).
- [ ] `actionlint` passes on `gui.yml`.
- [ ] `workflow_dispatch` probe job can be triggered manually to run N consecutive smokes.
- [ ] Advisory lane does not affect `ci-summary / gate`.

🤖 Generated with [Claude Code](https://claude.com/claude-code) (Sonnet 4.6, bead sq-ymr2e.6)