### PR TITLE
ci(coverage): changed-cone coverage with shadow mode (sq-6vshe.8) [SONNET-4.6]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2126,6 +2126,30 @@ jobs:
         uses: taiki-e/install-action@9bcaee1dcae34154180f412e2fa69355a7cda9f6 # cargo-llvm-cov
         with:
           tool: cargo-llvm-cov
+      - name: Compute coverage cone (shadow mode, sq-6vshe.8) [SONNET-4.6]
+        # [SONNET-4.6] sq-6vshe.8: SHADOW-ONLY pre-step. Computes the reverse-dep
+        # closure of the PR diff (reusing ci_select.py's diff classifier and fail-safe
+        # rules via shared import — NOT a diverging copy). The cone.json records which
+        # crates WOULD be measured fresh vs which would inherit their main-run floor.
+        # SHADOW MODE (enforce=False): the full coverage.sh run below is UNCHANGED;
+        # this step only computes + logs the cone for monitoring. Enforce flip is the
+        # follow-up bead (gated by sq-6vshe.8).
+        env:
+          BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || 'HEAD' }}
+        run: |
+          set -euo pipefail
+          if [ -n "${BASE:-}" ]; then
+            python3 scripts/cone_coverage.py \
+              --mode compute-cone \
+              --base "$BASE" --head "$HEAD" \
+              --output cone.json
+          else
+            # Non-PR event (push/schedule) → full run; emit a placeholder cone.json.
+            python3 scripts/cone_coverage.py \
+              --mode compute-cone \
+              --output cone.json || true
+          fi
       - name: Measure + enforce per-crate coverage (shard ${{ matrix.shard }}, max-remeasure gate)
         # [OPUS-4.8] sq-x4jy: ROBUST per-crate MAX-REMEASURE gate. Measure this shard's crate
         # subset once (COVERAGE_SHARD selects SHARD_GROUPS[shard-1]), then --check-robust
@@ -2145,6 +2169,21 @@ jobs:
           set -o pipefail
           ./scripts/coverage.sh
           python3 scripts/coverage-gate.py --check-robust target/coverage/coverage-summary.json
+      - name: Shadow cone-vs-full coverage report (sq-6vshe.8) [SONNET-4.6]
+        # [SONNET-4.6] sq-6vshe.8: SHADOW-ONLY post-step. Compares the cone (from
+        # the pre-step) against the full coverage-summary.json: crates IN the cone are
+        # labeled "cone-measured"; crates OUTSIDE are labeled "inherited (unchanged
+        # cone): PASS". Divergences (outside-cone crates below floor) are logged to
+        # coverage-cone-divergence.json and surfaced as warnings. Never fails the gate
+        # (shadow mode); only the enforce flip (follow-up bead) changes enforcement.
+        if: always() && hashFiles('cone.json') != '' && hashFiles('target/coverage/coverage-summary.json') != ''
+        run: |
+          python3 scripts/cone_coverage.py \
+            --mode shadow-report \
+            --cone cone.json \
+            --coverage-summary target/coverage/coverage-summary.json \
+            --divergence-log coverage-cone-divergence-shard-${{ matrix.shard }}.json \
+            --summary-file "$GITHUB_STEP_SUMMARY" || true
       - name: Upload coverage summary (shard ${{ matrix.shard }})
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2139,11 +2139,15 @@ jobs:
           HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha || 'HEAD' }}
         run: |
           set -euo pipefail
+          # [SONNET-4.6] SHADOW-MODE: the `|| true` on BOTH branches keeps this pre-step
+          # strictly gate-neutral — a cone.json write error or a ci_select.py import error
+          # must NEVER fail the coverage shard (that would cascade to the gate). The full
+          # coverage.sh run below is the sole source of truth until the enforce flip.
           if [ -n "${BASE:-}" ]; then
             python3 scripts/cone_coverage.py \
               --mode compute-cone \
               --base "$BASE" --head "$HEAD" \
-              --output cone.json
+              --output cone.json || true
           else
             # Non-PR event (push/schedule) → full run; emit a placeholder cone.json.
             python3 scripts/cone_coverage.py \

--- a/scripts/cone_coverage.py
+++ b/scripts/cone_coverage.py
@@ -53,7 +53,7 @@ def _load_ci_select():
     if spec is None or spec.loader is None:
         raise ImportError(f"Cannot load ci_select.py from {ci_select_path}")
     mod = importlib.util.module_from_spec(spec)
-    sys.modules.setdefault("ci_select", mod)
+    sys.modules["ci_select"] = mod  # [SONNET-4.6] assign unconditionally to avoid stale-entry cross-test leakage
     spec.loader.exec_module(mod)  # type: ignore[union-attr]
     return mod
 
@@ -164,10 +164,20 @@ def shadow_report(
 
     summary_crates = coverage_summary.get("crates", {})
 
+    # [SONNET-4.6] Operate on the INTERSECTION of workspace members and crates
+    # actually present in this shard's coverage-summary.json. In the CI matrix
+    # each shard measures only its own subset; iterating all_members would include
+    # crates with no measured data, making divergence detection meaningless and
+    # inflating counts. Crates absent from the shard summary are omitted from rows;
+    # a single compact count is emitted instead (not_measured_in_shard).
+    measured_in_shard = set(summary_crates.keys())
+    reported_members = sorted(all_members & measured_in_shard)
+    not_measured_count = len(all_members - measured_in_shard)
+
     rows: list[dict] = []
     divergences: list[dict] = []
 
-    for crate in sorted(all_members):
+    for crate in reported_members:
         row_summary = summary_crates.get(crate, {})
         measured = row_summary.get("measured", False)
         lines_pct = row_summary.get("lines_pct") if measured else None
@@ -212,12 +222,23 @@ def shadow_report(
                     ),
                 })
 
+    # [SONNET-4.6] All derived counts are over the REPORTED set (intersection)
+    # so that counts always match the row set. The workspace-level cone size is
+    # also retained under a distinct key for context.
+    reported_cone_set = (
+        cone_crates & measured_in_shard if mode != "full"
+        else set(reported_members)
+    )
     report = {
         "mode": mode,
         "shadow": True,
         "cone_crates": sorted(cone_crates),
-        "total_crates": len(all_members),
-        "cone_size": len(cone_crates) if mode != "full" else len(all_members),
+        "total_crates": len(reported_members),           # crates in this shard's summary
+        "cone_size": len(reported_cone_set),             # cone crates measured in this shard
+        "cone_size_workspace": (                         # workspace-level cone size for context
+            len(cone_crates) if mode != "full" else len(all_members)
+        ),
+        "not_measured_in_shard": not_measured_count,     # compact count; no per-crate row emitted
         "inherited_count": sum(1 for r in rows if r["status"] == "inherited"),
         "divergences": divergences,
         "rows": rows,
@@ -246,18 +267,25 @@ def _render_report(report: dict) -> str:
         "",
     ]
     mode = report.get("mode", "full")
+    not_in_shard = report.get("not_measured_in_shard", 0)
     if mode == "cone":
         total = report.get("total_crates", 0)
         cone_size = report.get("cone_size", 0)
         inherited = report.get("inherited_count", 0)
         lines += [
-            f"**Cone size:** {cone_size} of {total} crates measured fresh "
+            f"**Cone size:** {cone_size} of {total} shard-measured crates measured fresh "
             f"({inherited} inherited from main — unchanged, no re-measurement needed)",
             "",
         ]
     else:
         lines += [
             "**Full run:** all crates measured (diff triggered full-run fail-safe).",
+            "",
+        ]
+    if not_in_shard:
+        lines += [
+            f"_not-measured-in-this-shard: {not_in_shard} workspace crate(s) "
+            f"(measured in other shards or not applicable here — omitted from rows)_",
             "",
         ]
 

--- a/scripts/cone_coverage.py
+++ b/scripts/cone_coverage.py
@@ -1,0 +1,557 @@
+#!/usr/bin/env python3
+# [SONNET-4.6] Changed-cone coverage selector (sq-6vshe.8).
+#
+# Reuses ci_select.py's diff classification and reverse-dep closure computation
+# (via shared import, NOT a diverging copy) to determine which crates need fresh
+# instrumented-coverage measurement vs which can inherit their floor result from
+# main's last full run (because their code + their transitive deps are unchanged).
+#
+# WHAT THIS IS (and is NOT):
+#   Given the set of paths changed in a PR (same input as ci_select.py), compute
+#   the COVERAGE CONE — the set of crates that MUST be re-measured. Crates outside
+#   the cone are unchanged: if they passed the floor gate on main, they still pass
+#   (SAME soundness argument ci_select.py commits to for test skipping, §2).
+#   Emits JSON: {"mode": "cone"|"full", "cone_crates": [...], "reason": "..."}.
+#
+#   FAIL-SAFE IDENTICAL TO ci_select.py (shared import, not a diverging copy):
+#   if any §4.1 trigger (Cargo.lock, root Cargo.toml, .github/, scripts/, etc.)
+#   is changed → mode=full → ALL crates measured. Any internal error → mode=full.
+#
+# SHADOW MODE (default ON, --enforce OFF):
+#   Does NOT change what coverage.sh measures. Instead logs the cone vs full
+#   comparison so we can validate the cone is correct before enforcing it. The
+#   enforce flip is a follow-up bead (gated by this PR / sq-6vshe.8).
+#
+# USAGE:
+#   cone_coverage.py --mode compute-cone [--output cone.json] [--enforce]
+#   cone_coverage.py --mode shadow-report --cone cone.json
+#                    --coverage-summary coverage-summary.json
+#                    [--divergence-log divergence.json]
+#                    [--floor bench/coverage-floor.json]
+#   cone_coverage.py --changed-file paths.txt --metadata-file meta.json ...
+#
+# STDLIB ONLY: no third-party deps (mirrors ci_select.py §7 P1).
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+# --- shared import from ci_select.py -----------------------------------------
+# [SONNET-4.6] Import the diff classifier and closure computation DIRECTLY from
+# ci_select.py (NOT a copy) so the fail-safe rules stay in sync automatically.
+# Any future change to §4.1 triggers or the closure algorithm applies here too.
+
+def _load_ci_select():
+    here = Path(__file__).resolve().parent
+    ci_select_path = here / "ci_select.py"
+    spec = importlib.util.spec_from_file_location("ci_select", ci_select_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load ci_select.py from {ci_select_path}")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("ci_select", mod)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_ci_select = _load_ci_select()
+
+# Re-export the pieces we use (makes static analysis + tests easier).
+select = _ci_select.select
+parse_workspace = _ci_select.parse_workspace
+load_metadata = _ci_select.load_metadata
+load_ownership_map = _ci_select.load_ownership_map
+git_changed_paths = _ci_select.git_changed_paths
+SelectorError = _ci_select.SelectorError
+
+
+# --- cone computation ---------------------------------------------------------
+
+def compute_cone(
+    changed_paths: list[str],
+    meta: dict,
+    map_entries: list[dict] | None = None,
+) -> dict:
+    """Compute the coverage cone from the set of changed paths.
+
+    [SONNET-4.6] Delegates entirely to ci_select.select() — the SAME diff
+    classifier and reverse-dep closure used by change-based test selection. The
+    cone is exactly the `affected` set: the changed crates PLUS their transitive
+    reverse-dep closure (dependents whose tests might exercise the changed code).
+
+    Returns a plain dict ready to serialise as JSON:
+      {
+        "mode": "cone" | "full",
+        "cone_crates": [...],   # sorted; all workspace members when mode=full
+        "changed_crates": [...],# directly-changed workspace members
+        "all_members": [...],   # sorted full workspace member list
+        "reason": "...",
+        "shadow": true,         # always true in this PR (enforce=False)
+      }
+    """
+    map_entries = map_entries or []
+    try:
+        sel = select(changed_paths, meta, map_entries)
+    except Exception as exc:  # noqa: BLE001 — mirrors ci_select.py §4.3
+        # Any internal error → full run (fail-closed). Use parse_workspace to get
+        # the full member list so cone_crates is correct even on error.
+        try:
+            ws = parse_workspace(meta)
+            all_members = sorted(ws.members)
+        except Exception:  # noqa: BLE001
+            all_members = []
+        return {
+            "mode": "full",
+            "cone_crates": all_members,
+            "changed_crates": [],
+            "all_members": all_members,
+            "reason": f"cone-coverage selector error, failing to full run: {exc}",
+            "shadow": True,
+        }
+
+    if sel.mode == "full":
+        mode = "full"
+        cone_crates = sel.affected  # already == all members for a full run
+    else:
+        # mode == "selected": the cone is exactly the affected closure.
+        mode = "cone"
+        cone_crates = sel.affected
+
+    return {
+        "mode": mode,
+        "cone_crates": sorted(cone_crates),
+        "changed_crates": sorted(getattr(sel, "changed_crates", [])),
+        "all_members": sorted(getattr(sel, "all_members", [])),
+        "reason": sel.reason,
+        "shadow": True,  # enforce=False in this PR; flip is the follow-up bead
+    }
+
+
+# --- shadow report -----------------------------------------------------------
+
+def shadow_report(
+    cone_doc: dict,
+    coverage_summary: dict,
+    floor_doc: dict | None,
+    divergence_log_path: str | None = None,
+) -> dict:
+    """[SONNET-4.6] Compare what the cone WOULD have measured vs the full run.
+
+    For each workspace crate:
+      - IN cone:     reports label "cone-measured" + actual line_pct from summary
+      - OUTSIDE cone: reports label "inherited (unchanged cone): PASS" — we assert
+                      the crate is unchanged so its main-run floor result still holds
+    Divergences (below-floor crates outside the cone — should never happen if the
+    cone is correct) are logged to `divergence_log_path` for monitoring.
+
+    Returns a report dict. Never raises (logs errors; caller continues regardless).
+    """
+    cone_crates = set(cone_doc.get("cone_crates", []))
+    all_members = set(cone_doc.get("all_members", []))
+    mode = cone_doc.get("mode", "full")
+
+    floors: dict[str, float] = {}
+    if floor_doc:
+        for crate, fentry in floor_doc.get("crates", {}).items():
+            if isinstance(fentry, dict):
+                floors[crate] = float(fentry.get("floor", 0))
+            elif isinstance(fentry, (int, float)):
+                floors[crate] = float(fentry)
+
+    summary_crates = coverage_summary.get("crates", {})
+
+    rows: list[dict] = []
+    divergences: list[dict] = []
+
+    for crate in sorted(all_members):
+        row_summary = summary_crates.get(crate, {})
+        measured = row_summary.get("measured", False)
+        lines_pct = row_summary.get("lines_pct") if measured else None
+        floor = floors.get(crate)
+
+        in_cone = (mode == "full") or (crate in cone_crates)
+
+        if in_cone:
+            label = "cone-measured"
+            status = "measured"
+        else:
+            label = "inherited (unchanged cone): PASS"
+            status = "inherited"
+
+        row: dict = {
+            "crate": crate,
+            "label": label,
+            "status": status,
+            "in_cone": in_cone,
+        }
+        if lines_pct is not None:
+            row["lines_pct"] = lines_pct
+        if floor is not None:
+            row["floor"] = floor
+
+        rows.append(row)
+
+        # Divergence: a crate OUTSIDE the cone that is below its floor in the
+        # full measurement would be a soundness problem (cone missed a regression).
+        # Should never happen if the cone is correct.
+        if not in_cone and lines_pct is not None and floor is not None:
+            if lines_pct + 1e-9 < floor:
+                divergences.append({
+                    "crate": crate,
+                    "lines_pct": lines_pct,
+                    "floor": floor,
+                    "type": "outside-cone-below-floor",
+                    "explanation": (
+                        "A crate outside the coverage cone is below its floor. "
+                        "This should be impossible if the cone is correct — "
+                        "an unchanged crate cannot regress. Investigate."
+                    ),
+                })
+
+    report = {
+        "mode": mode,
+        "shadow": True,
+        "cone_crates": sorted(cone_crates),
+        "total_crates": len(all_members),
+        "cone_size": len(cone_crates) if mode != "full" else len(all_members),
+        "inherited_count": sum(1 for r in rows if r["status"] == "inherited"),
+        "divergences": divergences,
+        "rows": rows,
+    }
+
+    if divergence_log_path:
+        try:
+            with open(divergence_log_path, "w", encoding="utf-8") as fh:
+                json.dump(
+                    {"divergences": divergences, "mode": mode, "cone_crates": sorted(cone_crates)},
+                    fh, indent=2,
+                )
+                fh.write("\n")
+        except OSError as exc:
+            print(f"  WARN: could not write divergence log: {exc}", file=sys.stderr)
+
+    return report
+
+
+def _render_report(report: dict) -> str:
+    """Render the shadow report as a Markdown step summary."""
+    lines = [
+        "### Coverage cone shadow report (sq-6vshe.8) [SONNET-4.6]",
+        "",
+        f"**Mode:** `{report['mode']}` — shadow (enforce=False; cone computation validated)",
+        "",
+    ]
+    mode = report.get("mode", "full")
+    if mode == "cone":
+        total = report.get("total_crates", 0)
+        cone_size = report.get("cone_size", 0)
+        inherited = report.get("inherited_count", 0)
+        lines += [
+            f"**Cone size:** {cone_size} of {total} crates measured fresh "
+            f"({inherited} inherited from main — unchanged, no re-measurement needed)",
+            "",
+        ]
+    else:
+        lines += [
+            "**Full run:** all crates measured (diff triggered full-run fail-safe).",
+            "",
+        ]
+
+    divs = report.get("divergences", [])
+    if divs:
+        lines += [
+            f"**DIVERGENCES ({len(divs)}) — INVESTIGATE:**",
+            "",
+            "| Crate | lines_pct | floor | type |",
+            "|---|---|---|---|",
+        ]
+        for d in divs:
+            lines.append(
+                f"| `{d['crate']}` | {d.get('lines_pct', '?')} | {d.get('floor', '?')} | {d['type']} |"
+            )
+        lines.append("")
+    else:
+        lines += ["No divergences — cone is sound for this PR.", ""]
+
+    lines += [
+        "| Crate | Status | lines_pct | floor |",
+        "|---|---|---|---|",
+    ]
+    for row in report.get("rows", []):
+        pct = f"{row['lines_pct']:.2f}%" if row.get("lines_pct") is not None else "—"
+        fl = str(row["floor"]) if row.get("floor") is not None else "—"
+        lines.append(f"| `{row['crate']}` | {row['label']} | {pct} | {fl} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+# --- input gathering (mirrors ci_select.py main) ----------------------------
+
+def _resolve_repo_root(explicit: str | None) -> str | None:
+    if explicit:
+        return explicit
+    import subprocess
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, check=True, timeout=30,
+        )
+        return out.stdout.strip()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _get_changed_paths(args: argparse.Namespace, repo_root: str | None) -> list[str]:
+    """Get changed paths from hermetic file or live git diff."""
+    if args.changed_file:
+        with open(args.changed_file, encoding="utf-8") as fh:
+            return [ln for ln in fh.read().splitlines() if ln.strip()]
+    base = getattr(args, "base", None)
+    head = getattr(args, "head", "HEAD")
+    if base:
+        return git_changed_paths(base, head, repo_root)
+    # No base → can't compute diff → fail-safe to full.
+    raise SelectorError("--base is required for a diff-based cone computation")
+
+
+# --- CLI main ----------------------------------------------------------------
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Coverage-cone selector (sq-6vshe.8) [SONNET-4.6]."
+    )
+    p.add_argument(
+        "--mode",
+        choices=["compute-cone", "shadow-report"],
+        required=True,
+        help=(
+            "compute-cone: diff → cone JSON; "
+            "shadow-report: compare cone JSON vs full coverage summary"
+        ),
+    )
+    # compute-cone inputs
+    p.add_argument("--base", help="base SHA/ref for the three-dot diff")
+    p.add_argument("--head", default="HEAD", help="head SHA/ref (default HEAD)")
+    p.add_argument("--changed-file", help="hermetic: newline-delimited changed paths")
+    p.add_argument("--metadata-file", help="hermetic: cargo metadata JSON snapshot")
+    p.add_argument("--map", dest="map_file", help="ownership map toml (default ci/path-ownership.toml)")
+    p.add_argument("--repo-root", help="repo root (default: git toplevel)")
+    p.add_argument("--output", "-o", default=None, help="write cone JSON here (default: stdout)")
+    p.add_argument(
+        "--enforce",
+        action="store_true",
+        help="[FOLLOW-UP BEAD] enforce the cone (skip crates outside it). "
+             "Default OFF (shadow mode) for this PR.",
+    )
+    # shadow-report inputs
+    p.add_argument("--cone", help="cone JSON from a previous compute-cone run")
+    p.add_argument("--coverage-summary", help="full coverage-summary.json from coverage.sh")
+    p.add_argument("--floor", help="coverage floor JSON (default bench/coverage-floor.json)")
+    p.add_argument("--divergence-log", help="write divergences JSON here")
+    p.add_argument("--summary-file", help="write Markdown step-summary (default $GITHUB_STEP_SUMMARY)")
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    summary_file = args.summary_file or os.environ.get("GITHUB_STEP_SUMMARY")
+
+    if args.mode == "compute-cone":
+        repo_root = _resolve_repo_root(args.repo_root)
+
+        # Load cargo metadata (fail-closed to full on error).
+        try:
+            meta = load_metadata(args.metadata_file, repo_root)
+        except Exception as exc:  # noqa: BLE001
+            doc = {
+                "mode": "full",
+                "cone_crates": [],
+                "changed_crates": [],
+                "all_members": [],
+                "reason": f"cone: could not load metadata, failing to full: {exc}",
+                "shadow": True,
+            }
+            _write_output(doc, args.output, summary_file, enforce=args.enforce)
+            return 0
+
+        # Load ownership map (absent → []).
+        map_file = args.map_file
+        if map_file is None and repo_root is not None:
+            candidate = os.path.join(repo_root, "ci", "path-ownership.toml")
+            map_file = candidate if os.path.exists(candidate) else None
+        try:
+            map_entries = load_ownership_map(map_file)
+        except Exception:  # noqa: BLE001
+            map_entries = []
+
+        # Get changed paths (fail-closed to full on error).
+        try:
+            changed_paths = _get_changed_paths(args, repo_root)
+        except Exception as exc:  # noqa: BLE001
+            # Cannot compute diff → full run (fail-safe).
+            try:
+                ws = parse_workspace(meta)
+                all_members = sorted(ws.members)
+            except Exception:  # noqa: BLE001
+                all_members = []
+            doc = {
+                "mode": "full",
+                "cone_crates": all_members,
+                "changed_crates": [],
+                "all_members": all_members,
+                "reason": f"cone: could not get changed paths, failing to full: {exc}",
+                "shadow": True,
+            }
+            _write_output(doc, args.output, summary_file, enforce=args.enforce)
+            return 0
+
+        doc = compute_cone(changed_paths, meta, map_entries)
+        doc["enforce"] = args.enforce
+        doc["shadow"] = not args.enforce  # shadow when not enforcing
+
+        _write_output(doc, args.output, summary_file, enforce=args.enforce)
+        return 0
+
+    elif args.mode == "shadow-report":
+        if not args.cone:
+            print("::error::--cone is required for shadow-report mode", file=sys.stderr)
+            return 1
+        if not args.coverage_summary:
+            print("::error::--coverage-summary is required for shadow-report mode", file=sys.stderr)
+            return 1
+
+        with open(args.cone, encoding="utf-8") as fh:
+            cone_doc = json.load(fh)
+
+        with open(args.coverage_summary, encoding="utf-8") as fh:
+            coverage_summary = json.load(fh)
+
+        # Load floor file (optional; skipped crates → no floor comparison).
+        floor_doc = None
+        floor_path = args.floor
+        if floor_path is None:
+            # Default: bench/coverage-floor.json relative to repo root.
+            repo_root = _resolve_repo_root(args.repo_root)
+            if repo_root:
+                candidate = os.path.join(repo_root, "bench", "coverage-floor.json")
+                floor_path = candidate if os.path.exists(candidate) else None
+        if floor_path and os.path.exists(floor_path):
+            with open(floor_path, encoding="utf-8") as fh:
+                floor_doc = json.load(fh)
+
+        report = shadow_report(
+            cone_doc, coverage_summary, floor_doc,
+            divergence_log_path=args.divergence_log,
+        )
+
+        # Print report JSON.
+        text = json.dumps(report, indent=2) + "\n"
+        print(text)
+
+        # Write step summary.
+        if summary_file:
+            try:
+                with open(summary_file, "a", encoding="utf-8") as fh:
+                    fh.write(_render_report(report))
+            except OSError:
+                pass
+
+        # Never fail in shadow mode — we are observing, not enforcing.
+        divs = report.get("divergences", [])
+        if divs:
+            print(
+                f"::warning::cone-coverage shadow: {len(divs)} divergence(s) found "
+                f"(outside-cone crates below floor). See the step summary.",
+                file=sys.stderr,
+            )
+        return 0
+
+    return 0  # unreachable
+
+
+def _write_output(doc: dict, output_path: str | None, summary_file: str | None, enforce: bool) -> None:
+    text = json.dumps(doc, indent=2) + "\n"
+    if output_path:
+        with open(output_path, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        print(f"cone_coverage: wrote cone JSON to {output_path}")
+        _print_cone_summary(doc, enforce=enforce)
+    else:
+        sys.stdout.write(text)
+
+    if summary_file:
+        try:
+            with open(summary_file, "a", encoding="utf-8") as fh:
+                fh.write(_render_compute_summary(doc, enforce=enforce))
+        except OSError:
+            pass
+
+
+def _print_cone_summary(doc: dict, enforce: bool) -> None:
+    mode = doc.get("mode", "full")
+    cone = doc.get("cone_crates", [])
+    all_m = doc.get("all_members", [])
+    reason = doc.get("reason", "")
+    shadow = not enforce
+
+    if mode == "full":
+        print(f"  cone_coverage: mode=full (all {len(all_m)} crates) — {reason}")
+    else:
+        inherited = len(all_m) - len(cone)
+        print(
+            f"  cone_coverage: mode=cone — {len(cone)} of {len(all_m)} crates in cone "
+            f"({inherited} inherited from main) — {reason}"
+        )
+    if shadow:
+        print("  [SHADOW MODE] enforce=False: full coverage.sh run unchanged; "
+              "cone is computed for monitoring only.")
+
+
+def _render_compute_summary(doc: dict, enforce: bool) -> str:
+    mode = doc.get("mode", "full")
+    cone = doc.get("cone_crates", [])
+    all_m = doc.get("all_members", [])
+    changed = doc.get("changed_crates", [])
+    reason = doc.get("reason", "")
+
+    lines = [
+        "### Coverage cone (sq-6vshe.8) [SONNET-4.6]",
+        "",
+        f"**Mode:** `{mode}` — {reason}",
+        "",
+    ]
+    if not enforce:
+        lines += [
+            "**SHADOW MODE**: enforce=False — full coverage.sh run unchanged for this PR; "
+            "cone is computed for monitoring only. Enforce flip: follow-up bead.",
+            "",
+        ]
+    if changed:
+        lines += [
+            f"**Directly-changed crates ({len(changed)}):** " + ", ".join(f"`{c}`" for c in changed),
+            "",
+        ]
+    if mode == "cone":
+        inherited = len(all_m) - len(cone)
+        lines += [
+            f"**Coverage cone ({len(cone)} of {len(all_m)} crates):** "
+            + (", ".join(f"`{c}`" for c in cone) or "_empty_"),
+            "",
+            f"**Would inherit from main ({inherited} crates — unchanged cone):** "
+            + (", ".join(f"`{c}`" for c in sorted(set(all_m) - set(cone))) or "_none_"),
+            "",
+        ]
+    else:
+        lines += [
+            "**Full run:** all crates measured (diff triggered full-run fail-safe).",
+            "",
+        ]
+    return "\n".join(lines) + "\n"
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/cone_coverage.py
+++ b/scripts/cone_coverage.py
@@ -170,9 +170,17 @@ def shadow_report(
     # crates with no measured data, making divergence detection meaningless and
     # inflating counts. Crates absent from the shard summary are omitted from rows;
     # a single compact count is emitted instead (not_measured_in_shard).
+    #
+    # [SONNET-4.6] Empty-all_members fallback: when cone.json was produced via the
+    # error path, all_members may be empty (compute_cone() catches selector errors
+    # and emits all_members=[] as a fail-safe). In that case the intersection would
+    # be empty and the report would render no rows even though the shard summary has
+    # measured crates — silent monitoring blindness. Fall back to the shard summary
+    # keys as the effective member universe so divergences still surface.
     measured_in_shard = set(summary_crates.keys())
-    reported_members = sorted(all_members & measured_in_shard)
-    not_measured_count = len(all_members - measured_in_shard)
+    effective_members = all_members if all_members else measured_in_shard
+    reported_members = sorted(effective_members & measured_in_shard)
+    not_measured_count = len(effective_members - measured_in_shard)
 
     rows: list[dict] = []
     divergences: list[dict] = []
@@ -337,7 +345,10 @@ def _get_changed_paths(args: argparse.Namespace, repo_root: str | None) -> list[
     """Get changed paths from hermetic file or live git diff."""
     if args.changed_file:
         with open(args.changed_file, encoding="utf-8") as fh:
-            return [ln for ln in fh.read().splitlines() if ln.strip()]
+            # [SONNET-4.6] Strip leading/trailing whitespace from each line so
+            # behavior is consistent regardless of how the caller wrote the file
+            # (trailing \r on Windows-style line endings, leading spaces, etc.).
+            return [ln.strip() for ln in fh.read().splitlines() if ln.strip()]
     base = getattr(args, "base", None)
     head = getattr(args, "head", "HEAD")
     if base:

--- a/scripts/tests/test_cone_coverage.py
+++ b/scripts/tests/test_cone_coverage.py
@@ -419,5 +419,111 @@ class TestShadowReportFullMode(unittest.TestCase):
         self.assertEqual(report["inherited_count"], 0)
 
 
+class TestShadowReportShardFiltering(unittest.TestCase):
+    """(j) [SONNET-4.6] Crates in all_members but absent from shard summary are omitted from rows.
+
+    In the CI matrix each coverage-measure shard writes coverage-summary.json only
+    for the crates it measured. shadow_report() must operate on the INTERSECTION of
+    cone_doc["all_members"] and coverage_summary["crates"] so that:
+      - unmeasured crates produce no row (avoiding misleading divergence output),
+      - all derived counts (total_crates, cone_size) match the row set,
+      - a compact not_measured_in_shard count is reported instead.
+    """
+
+    def _make_cone(self, all_members, cone_crates):
+        return {
+            "mode": "cone",
+            "cone_crates": sorted(cone_crates),
+            "changed_crates": sorted(cone_crates),
+            "all_members": sorted(all_members),
+            "reason": "test cone",
+            "shadow": True,
+        }
+
+    def test_unmeasured_crates_omitted_from_rows(self):
+        """lib-c is in all_members but NOT in the shard summary → no row emitted."""
+        cone_doc = self._make_cone(
+            all_members=["lib-a", "lib-b", "lib-c"],
+            cone_crates=["lib-a"],
+        )
+        coverage_summary = {
+            "crates": {
+                "lib-a": {"measured": True, "lines_pct": 85.0, "lines_covered": 85, "lines_total": 100, "seconds": 1},
+                "lib-b": {"measured": True, "lines_pct": 90.0, "lines_covered": 90, "lines_total": 100, "seconds": 1},
+                # lib-c intentionally absent — not measured in this shard
+            }
+        }
+        report = cc.shadow_report(cone_doc, coverage_summary, None)
+
+        row_crates = {r["crate"] for r in report["rows"]}
+        self.assertNotIn("lib-c", row_crates,
+                         "unmeasured-in-shard crate must not appear as a row")
+
+    def test_compact_count_reflects_omitted_crates(self):
+        """not_measured_in_shard count equals the number of omitted all_members crates."""
+        cone_doc = self._make_cone(
+            all_members=["lib-a", "lib-b", "lib-c", "lib-d"],
+            cone_crates=["lib-a"],
+        )
+        coverage_summary = {
+            "crates": {
+                "lib-a": {"measured": True, "lines_pct": 85.0, "lines_covered": 85, "lines_total": 100, "seconds": 1},
+                "lib-b": {"measured": True, "lines_pct": 90.0, "lines_covered": 90, "lines_total": 100, "seconds": 1},
+                # lib-c, lib-d absent
+            }
+        }
+        report = cc.shadow_report(cone_doc, coverage_summary, None)
+
+        self.assertEqual(report["not_measured_in_shard"], 2,
+                         "compact count must equal number of all_members crates absent from shard summary")
+
+    def test_counts_match_row_set(self):
+        """total_crates and cone_size must match rows, not workspace totals."""
+        cone_doc = self._make_cone(
+            all_members=["lib-a", "lib-b", "lib-c"],  # 3 workspace crates
+            cone_crates=["lib-a"],
+        )
+        coverage_summary = {
+            "crates": {
+                # Only 2 of 3 measured in this shard; lib-a is in cone
+                "lib-a": {"measured": True, "lines_pct": 85.0, "lines_covered": 85, "lines_total": 100, "seconds": 1},
+                "lib-b": {"measured": True, "lines_pct": 90.0, "lines_covered": 90, "lines_total": 100, "seconds": 1},
+            }
+        }
+        report = cc.shadow_report(cone_doc, coverage_summary, None)
+
+        # total_crates must be 2 (shard-measured), not 3 (workspace)
+        self.assertEqual(report["total_crates"], 2,
+                         "total_crates must reflect shard-measured count, not workspace total")
+        # cone_size: lib-a is in cone AND in shard summary → 1
+        self.assertEqual(report["cone_size"], 1,
+                         "cone_size must be over the shard-measured set")
+        # Rows must have exactly 2 entries
+        self.assertEqual(len(report["rows"]), 2,
+                         "row count must match total_crates")
+        # not_measured_in_shard accounts for the gap
+        self.assertEqual(report["not_measured_in_shard"], 1)
+
+    def test_no_false_divergences_for_unmeasured_crates(self):
+        """A crate absent from the shard summary must NOT produce a divergence entry,
+        even if it would be below-floor (it was simply not measured in this shard)."""
+        cone_doc = self._make_cone(
+            all_members=["lib-a", "lib-b"],
+            cone_crates=["lib-a"],
+        )
+        # lib-b is outside the cone but also NOT in this shard's summary
+        coverage_summary = {
+            "crates": {
+                "lib-a": {"measured": True, "lines_pct": 85.0, "lines_covered": 85, "lines_total": 100, "seconds": 1},
+                # lib-b absent
+            }
+        }
+        floor_doc = {"crates": {"lib-b": {"floor": 99}}}  # impossibly high floor
+        report = cc.shadow_report(cone_doc, coverage_summary, floor_doc)
+
+        self.assertEqual(report["divergences"], [],
+                         "an unmeasured-in-shard crate must not produce a false divergence")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/scripts/tests/test_cone_coverage.py
+++ b/scripts/tests/test_cone_coverage.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+# [SONNET-4.6] Hermetic unit tests for cone_coverage.py (bead sq-6vshe.8).
+#
+# Mirrors the test-file pattern in scripts/tests/test_ci_select.py:
+#   - imports the module under test via importlib.util (no installed package)
+#   - synthetic cargo-metadata dicts (no real workspace needed)
+#   - stdlib only; no pytest required (but pytest works fine)
+#
+# Covers:
+#   (a) test_changed_leaf_crate_gives_exact_cone
+#         A change to a leaf crate → cone = {leaf} ∪ its transitive rev-deps.
+#   (b) test_changed_workspace_file_gives_full_run
+#         A change to Cargo.toml (§4.1 trigger) → mode=full.
+#   (c) test_changed_dev_dep_gives_correct_closure
+#         A dev-dep-only change propagates to the dependent crate's cone.
+#   (d) test_shadow_mode_default
+#         shadow=True in the emitted doc by default (enforce=False).
+#   (e) test_enforce_mode
+#         With enforce=True the doc records enforce=True / shadow=False.
+#   (f) test_compute_cone_unowned_path_gives_full_run
+#         An unowned, unmapped path → fail-safe mode=full.
+#   (g) test_shadow_report_cone_vs_full
+#         shadow_report labels in-cone crates "cone-measured" and outside-cone
+#         crates "inherited (unchanged cone): PASS".
+#   (h) test_shadow_report_divergence_detected
+#         An outside-cone crate below its floor is flagged as a divergence.
+#   (i) test_shadow_report_full_mode_labels_all_measured
+#         When mode=full, every crate is "cone-measured".
+#
+# Run:  python3 scripts/tests/test_cone_coverage.py
+# Run with pytest:  pytest scripts/tests/test_cone_coverage.py -v
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CONE_COVERAGE = REPO_ROOT / "scripts" / "cone_coverage.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("cone_coverage", CONE_COVERAGE)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["cone_coverage"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+cc = _load_module()
+
+ROOT = "/repo"
+
+# ---------- helpers matching test_ci_select.py style -------------------------
+
+def _dep(name, kind=None, optional=False):
+    return {"name": name, "kind": kind, "optional": optional, "target": None, "path": None}
+
+
+def _pkg(name, reldir, deps=(), source=None):
+    return {
+        "id": f"path+file://{ROOT}/{reldir}#0.1.0",
+        "name": name,
+        "source": source,
+        "manifest_path": f"{ROOT}/{reldir}/Cargo.toml",
+        "dependencies": list(deps),
+    }
+
+
+def _synthetic_meta(pkgs):
+    """Build a minimal cargo-metadata dict from a list of _pkg() entries."""
+    member_ids = [p["id"] for p in pkgs]
+    return {
+        "workspace_root": ROOT,
+        "workspace_members": member_ids,
+        "packages": pkgs,
+    }
+
+
+class TestComputeConeLeafCrate(unittest.TestCase):
+    """(a) Changed leaf crate → cone = {leaf} ∪ transitive dependents."""
+
+    def setUp(self):
+        # core ← parse ← engine ← app
+        # parse ← buildlib (build dep)
+        self.pkgs = [
+            _pkg("core", "crates/core", []),
+            _pkg("parse", "crates/parse", [_dep("core")]),
+            _pkg("engine", "crates/engine", [_dep("core"), _dep("parse")]),
+            _pkg("app", "crates/app", [_dep("engine")]),
+        ]
+        self.meta = _synthetic_meta(self.pkgs)
+
+    def test_changed_leaf_crate_gives_exact_cone(self):
+        # Change only the `app` leaf (nothing depends on it).
+        changed = [f"crates/app/src/main.rs"]
+        doc = cc.compute_cone(changed, self.meta)
+        self.assertEqual(doc["mode"], "cone")
+        self.assertEqual(doc["cone_crates"], ["app"])
+        # app has no dependents so the cone is just {app}.
+
+    def test_changed_middle_crate_includes_dependents(self):
+        # Change `parse`; engine and app depend on it transitively.
+        changed = ["crates/parse/src/lib.rs"]
+        doc = cc.compute_cone(changed, self.meta)
+        self.assertEqual(doc["mode"], "cone")
+        self.assertIn("parse", doc["cone_crates"])
+        self.assertIn("engine", doc["cone_crates"])
+        self.assertIn("app", doc["cone_crates"])
+        # core is NOT a dependent of parse — it is a dependency of parse.
+        self.assertNotIn("core", doc["cone_crates"])
+
+    def test_changed_root_crate_includes_all(self):
+        # Change `core`; everything depends on core.
+        changed = ["crates/core/src/lib.rs"]
+        doc = cc.compute_cone(changed, self.meta)
+        self.assertEqual(doc["mode"], "cone")
+        self.assertIn("core", doc["cone_crates"])
+        self.assertIn("parse", doc["cone_crates"])
+        self.assertIn("engine", doc["cone_crates"])
+        self.assertIn("app", doc["cone_crates"])
+
+
+class TestFullRunTriggers(unittest.TestCase):
+    """(b) §4.1 full-run triggers → mode=full."""
+
+    def setUp(self):
+        self.pkgs = [_pkg("mylib", "crates/mylib", [])]
+        self.meta = _synthetic_meta(self.pkgs)
+
+    def test_changed_workspace_file_gives_full_run(self):
+        changed = ["Cargo.toml"]
+        doc = cc.compute_cone(changed, self.meta)
+        self.assertEqual(doc["mode"], "full")
+        self.assertIn("mylib", doc["cone_crates"])
+
+    def test_cargo_lock_gives_full_run(self):
+        doc = cc.compute_cone(["Cargo.lock"], self.meta)
+        self.assertEqual(doc["mode"], "full")
+
+    def test_github_workflows_gives_full_run(self):
+        doc = cc.compute_cone([".github/workflows/ci.yml"], self.meta)
+        self.assertEqual(doc["mode"], "full")
+
+    def test_scripts_gives_full_run(self):
+        doc = cc.compute_cone(["scripts/coverage.sh"], self.meta)
+        self.assertEqual(doc["mode"], "full")
+
+    def test_rust_toolchain_gives_full_run(self):
+        doc = cc.compute_cone(["rust-toolchain.toml"], self.meta)
+        self.assertEqual(doc["mode"], "full")
+
+
+class TestDevDepClosure(unittest.TestCase):
+    """(c) Dev-dep change propagates to the dependent's cone."""
+
+    def setUp(self):
+        # testlib is a dev-dep of engine. A change to testlib should include engine
+        # (because engine's dev tests run against testlib) and engine's rev-deps.
+        pkgs = [
+            _pkg("testlib", "crates/testlib", []),
+            _pkg("engine", "crates/engine", [_dep("testlib", kind="dev")]),
+            _pkg("app", "crates/app", [_dep("engine")]),
+        ]
+        self.meta = _synthetic_meta(pkgs)
+
+    def test_changed_dev_dep_gives_correct_closure(self):
+        changed = ["crates/testlib/src/lib.rs"]
+        doc = cc.compute_cone(changed, self.meta)
+        self.assertEqual(doc["mode"], "cone")
+        # testlib itself must be in the cone.
+        self.assertIn("testlib", doc["cone_crates"])
+        # engine dev-depends on testlib → engine is in the cone.
+        self.assertIn("engine", doc["cone_crates"])
+        # app depends on engine → app is also in the cone.
+        self.assertIn("app", doc["cone_crates"])
+
+
+class TestShadowMode(unittest.TestCase):
+    """(d) shadow=True by default."""
+
+    def setUp(self):
+        self.pkgs = [_pkg("lib", "crates/lib", [])]
+        self.meta = _synthetic_meta(self.pkgs)
+
+    def test_shadow_mode_default(self):
+        doc = cc.compute_cone(["crates/lib/src/lib.rs"], self.meta)
+        # shadow key is always True from compute_cone() since this PR is shadow-only.
+        self.assertTrue(doc["shadow"])
+
+    def test_shadow_mode_in_cli_output(self):
+        # Invoke main() in compute-cone mode without --enforce; check shadow=True.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as changed_f:
+            changed_f.write("crates/lib/src/lib.rs\n")
+            changed_path = changed_f.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as meta_f:
+            json.dump(self.meta, meta_f)
+            meta_path = meta_f.name
+        out_path = changed_path + ".cone.json"
+        try:
+            rc = cc.main([
+                "--mode", "compute-cone",
+                "--changed-file", changed_path,
+                "--metadata-file", meta_path,
+                "--output", out_path,
+            ])
+            self.assertEqual(rc, 0)
+            with open(out_path) as fh:
+                doc = json.load(fh)
+            self.assertTrue(doc.get("shadow"))
+            self.assertFalse(doc.get("enforce"))
+        finally:
+            os.unlink(changed_path)
+            os.unlink(meta_path)
+            if os.path.exists(out_path):
+                os.unlink(out_path)
+
+
+class TestEnforceMode(unittest.TestCase):
+    """(e) With --enforce, enforce=True / shadow=False."""
+
+    def setUp(self):
+        self.pkgs = [_pkg("lib", "crates/lib", [])]
+        self.meta = _synthetic_meta(self.pkgs)
+
+    def test_enforce_mode(self):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as changed_f:
+            changed_f.write("crates/lib/src/lib.rs\n")
+            changed_path = changed_f.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as meta_f:
+            json.dump(self.meta, meta_f)
+            meta_path = meta_f.name
+        out_path = changed_path + ".cone.json"
+        try:
+            rc = cc.main([
+                "--mode", "compute-cone",
+                "--changed-file", changed_path,
+                "--metadata-file", meta_path,
+                "--output", out_path,
+                "--enforce",
+            ])
+            self.assertEqual(rc, 0)
+            with open(out_path) as fh:
+                doc = json.load(fh)
+            self.assertTrue(doc.get("enforce"))
+            self.assertFalse(doc.get("shadow"))
+        finally:
+            os.unlink(changed_path)
+            os.unlink(meta_path)
+            if os.path.exists(out_path):
+                os.unlink(out_path)
+
+
+class TestUnownedPathFullRun(unittest.TestCase):
+    """(f) Unowned, unmapped path → fail-safe mode=full."""
+
+    def setUp(self):
+        self.pkgs = [_pkg("mylib", "crates/mylib", [])]
+        self.meta = _synthetic_meta(self.pkgs)
+
+    def test_compute_cone_unowned_path_gives_full_run(self):
+        changed = ["some/unknown/path/file.txt"]
+        doc = cc.compute_cone(changed, self.meta)
+        self.assertEqual(doc["mode"], "full")
+        self.assertIn("mylib", doc["cone_crates"])
+
+
+class TestShadowReport(unittest.TestCase):
+    """(g) shadow_report labels crates correctly."""
+
+    def setUp(self):
+        self.pkgs = [
+            _pkg("lib-a", "crates/lib-a", []),
+            _pkg("lib-b", "crates/lib-b", []),
+        ]
+        self.meta = _synthetic_meta(self.pkgs)
+        self.cone_doc = {
+            "mode": "cone",
+            "cone_crates": ["lib-a"],
+            "changed_crates": ["lib-a"],
+            "all_members": ["lib-a", "lib-b"],
+            "reason": "test cone",
+            "shadow": True,
+        }
+        self.coverage_summary = {
+            "tier": "per-commit",
+            "crates": {
+                "lib-a": {"measured": True, "lines_pct": 85.0, "lines_covered": 85, "lines_total": 100, "seconds": 1},
+                "lib-b": {"measured": True, "lines_pct": 90.0, "lines_covered": 90, "lines_total": 100, "seconds": 1},
+            },
+        }
+        self.floor_doc = {
+            "crates": {
+                "lib-a": {"floor": 80},
+                "lib-b": {"floor": 88},
+            }
+        }
+
+    def test_shadow_report_cone_vs_full(self):
+        report = cc.shadow_report(self.cone_doc, self.coverage_summary, self.floor_doc)
+        rows = {r["crate"]: r for r in report["rows"]}
+
+        # lib-a is in the cone → cone-measured.
+        self.assertEqual(rows["lib-a"]["label"], "cone-measured")
+        self.assertEqual(rows["lib-a"]["status"], "measured")
+        self.assertTrue(rows["lib-a"]["in_cone"])
+
+        # lib-b is outside the cone → inherited.
+        self.assertEqual(rows["lib-b"]["label"], "inherited (unchanged cone): PASS")
+        self.assertEqual(rows["lib-b"]["status"], "inherited")
+        self.assertFalse(rows["lib-b"]["in_cone"])
+
+        # No divergences (lib-b is above its floor).
+        self.assertEqual(report["divergences"], [])
+
+    def test_shadow_report_inherited_count(self):
+        report = cc.shadow_report(self.cone_doc, self.coverage_summary, self.floor_doc)
+        self.assertEqual(report["inherited_count"], 1)
+        self.assertEqual(report["cone_size"], 1)
+        self.assertEqual(report["total_crates"], 2)
+
+
+class TestShadowReportDivergence(unittest.TestCase):
+    """(h) An outside-cone crate below its floor is flagged as a divergence."""
+
+    def test_shadow_report_divergence_detected(self):
+        cone_doc = {
+            "mode": "cone",
+            "cone_crates": ["lib-a"],
+            "changed_crates": ["lib-a"],
+            "all_members": ["lib-a", "lib-b"],
+            "reason": "test cone",
+            "shadow": True,
+        }
+        # lib-b is OUTSIDE the cone but BELOW its floor.
+        coverage_summary = {
+            "tier": "per-commit",
+            "crates": {
+                "lib-a": {"measured": True, "lines_pct": 85.0, "lines_covered": 85, "lines_total": 100, "seconds": 1},
+                "lib-b": {"measured": True, "lines_pct": 70.0, "lines_covered": 70, "lines_total": 100, "seconds": 1},
+            },
+        }
+        floor_doc = {
+            "crates": {
+                "lib-a": {"floor": 80},
+                "lib-b": {"floor": 88},   # lib-b floor=88 but measured=70.0 → below floor
+            }
+        }
+
+        report = cc.shadow_report(cone_doc, coverage_summary, floor_doc)
+
+        # lib-b should be flagged as a divergence.
+        divs = report["divergences"]
+        self.assertEqual(len(divs), 1)
+        self.assertEqual(divs[0]["crate"], "lib-b")
+        self.assertEqual(divs[0]["type"], "outside-cone-below-floor")
+
+    def test_shadow_report_divergence_log_written(self):
+        cone_doc = {
+            "mode": "cone",
+            "cone_crates": ["lib-a"],
+            "changed_crates": ["lib-a"],
+            "all_members": ["lib-a", "lib-b"],
+            "reason": "test",
+            "shadow": True,
+        }
+        coverage_summary = {
+            "crates": {
+                "lib-a": {"measured": True, "lines_pct": 85.0, "lines_covered": 85, "lines_total": 100, "seconds": 1},
+                "lib-b": {"measured": True, "lines_pct": 70.0, "lines_covered": 70, "lines_total": 100, "seconds": 1},
+            }
+        }
+        floor_doc = {"crates": {"lib-a": {"floor": 80}, "lib-b": {"floor": 88}}}
+
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+            log_path = f.name
+        try:
+            cc.shadow_report(cone_doc, coverage_summary, floor_doc, divergence_log_path=log_path)
+            with open(log_path) as fh:
+                logged = json.load(fh)
+            self.assertEqual(len(logged["divergences"]), 1)
+            self.assertEqual(logged["divergences"][0]["crate"], "lib-b")
+        finally:
+            os.unlink(log_path)
+
+
+class TestShadowReportFullMode(unittest.TestCase):
+    """(i) When mode=full, every crate is labeled 'cone-measured'."""
+
+    def test_shadow_report_full_mode_labels_all_measured(self):
+        cone_doc = {
+            "mode": "full",
+            "cone_crates": ["lib-a", "lib-b"],
+            "changed_crates": [],
+            "all_members": ["lib-a", "lib-b"],
+            "reason": "Cargo.lock changed",
+            "shadow": True,
+        }
+        coverage_summary = {
+            "crates": {
+                "lib-a": {"measured": True, "lines_pct": 85.0, "lines_covered": 85, "lines_total": 100, "seconds": 1},
+                "lib-b": {"measured": True, "lines_pct": 90.0, "lines_covered": 90, "lines_total": 100, "seconds": 1},
+            }
+        }
+        report = cc.shadow_report(cone_doc, coverage_summary, None)
+
+        rows = {r["crate"]: r for r in report["rows"]}
+        # Both should be "cone-measured" since mode=full.
+        for crate in ("lib-a", "lib-b"):
+            self.assertEqual(rows[crate]["label"], "cone-measured",
+                             f"{crate} should be cone-measured in full mode")
+            self.assertTrue(rows[crate]["in_cone"])
+        self.assertEqual(report["inherited_count"], 0)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_cone_coverage.py
+++ b/scripts/tests/test_cone_coverage.py
@@ -525,5 +525,129 @@ class TestShadowReportShardFiltering(unittest.TestCase):
                          "an unmeasured-in-shard crate must not produce a false divergence")
 
 
+class TestEmptyAllMembersFallback(unittest.TestCase):
+    """(k) [SONNET-4.6] When cone.json is produced via the error path, all_members
+    may be empty. shadow_report() must fall back to the shard summary keys so the
+    report still surfaces measured crates and any divergences.
+
+    This guards against the silent-monitoring-blindness path: without the fallback,
+    the intersection of {} and measured_in_shard is {} and no rows are emitted at
+    all, hiding real below-floor crates from the shadow report.
+    """
+
+    def _make_error_cone(self):
+        """Cone doc that mirrors compute_cone()'s error-path output (all_members=[])."""
+        return {
+            "mode": "full",
+            "cone_crates": [],
+            "changed_crates": [],
+            "all_members": [],   # error path: empty
+            "reason": "cone-coverage selector error, failing to full run: <exc>",
+            "shadow": True,
+        }
+
+    def test_empty_all_members_falls_back_to_shard_summary(self):
+        """Rows are produced for shard-measured crates even when all_members is empty."""
+        cone_doc = self._make_error_cone()
+        coverage_summary = {
+            "crates": {
+                "lib-a": {"measured": True, "lines_pct": 85.0, "lines_covered": 85, "lines_total": 100, "seconds": 1},
+                "lib-b": {"measured": True, "lines_pct": 90.0, "lines_covered": 90, "lines_total": 100, "seconds": 1},
+            }
+        }
+        report = cc.shadow_report(cone_doc, coverage_summary, None)
+
+        row_crates = {r["crate"] for r in report["rows"]}
+        self.assertIn("lib-a", row_crates,
+                      "shard-measured crate must appear in rows when all_members is empty")
+        self.assertIn("lib-b", row_crates,
+                      "shard-measured crate must appear in rows when all_members is empty")
+        self.assertEqual(len(report["rows"]), 2,
+                         "all shard-measured crates must produce rows via the fallback")
+
+    def test_empty_all_members_all_rows_cone_measured(self):
+        """When all_members is empty and mode=full (the error path), all shard
+        crates are treated as in-cone (cone-measured) — consistent with full-mode
+        semantics — and no spurious divergences are produced."""
+        cone_doc = self._make_error_cone()
+        coverage_summary = {
+            "crates": {
+                "lib-a": {"measured": True, "lines_pct": 85.0, "lines_covered": 85, "lines_total": 100, "seconds": 1},
+                "lib-b": {"measured": True, "lines_pct": 90.0, "lines_covered": 90, "lines_total": 100, "seconds": 1},
+            }
+        }
+        floor_doc = {"crates": {"lib-a": {"floor": 80.0}, "lib-b": {"floor": 80.0}}}
+        report = cc.shadow_report(cone_doc, coverage_summary, floor_doc)
+
+        # In full mode every crate is in-cone; divergence detection is for outside-cone
+        # crates only, so no divergences must fire.
+        self.assertEqual(report["divergences"], [],
+                         "full-mode error-path fallback must not produce spurious divergences")
+        # But rows must be present — the monitoring is NOT blind.
+        labels = {r["label"] for r in report["rows"]}
+        self.assertEqual(labels, {"cone-measured"},
+                         "all fallback rows must be labelled cone-measured in full mode")
+
+    def test_empty_all_members_not_measured_count_is_zero(self):
+        """When falling back to shard summary, not_measured_in_shard must be 0
+        (effective_members == measured_in_shard, so their difference is empty)."""
+        cone_doc = self._make_error_cone()
+        coverage_summary = {
+            "crates": {
+                "lib-a": {"measured": True, "lines_pct": 85.0, "lines_covered": 85, "lines_total": 100, "seconds": 1},
+            }
+        }
+        report = cc.shadow_report(cone_doc, coverage_summary, None)
+
+        self.assertEqual(report["not_measured_in_shard"], 0,
+                         "no crates are missing from the shard when falling back to its keys")
+
+
+class TestGetChangedPathsStrip(unittest.TestCase):
+    """(l) [SONNET-4.6] _get_changed_paths() strips leading/trailing whitespace
+    from each line in a hermetic --changed-file so callers receive clean paths."""
+
+    def test_leading_trailing_whitespace_stripped(self):
+        """Lines with leading/trailing spaces or \\r are returned stripped."""
+        import tempfile
+
+        content = "  crates/lib-a/src/lib.rs  \n\r\ncrates/lib-b/src/lib.rs\r\n  \n"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as fh:
+            fh.write(content)
+            tmp_path = fh.name
+
+        try:
+            import argparse
+            args = argparse.Namespace(changed_file=tmp_path, base=None, head="HEAD")
+            paths = cc._get_changed_paths(args, None)
+        finally:
+            import os
+            os.unlink(tmp_path)
+
+        self.assertEqual(paths, [
+            "crates/lib-a/src/lib.rs",
+            "crates/lib-b/src/lib.rs",
+        ], "returned paths must have no leading/trailing whitespace")
+
+    def test_blank_lines_excluded(self):
+        """Blank lines (including whitespace-only) are excluded from output."""
+        import tempfile
+
+        content = "crates/lib-a/src/lib.rs\n   \n\ncrates/lib-b/src/lib.rs\n"
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as fh:
+            fh.write(content)
+            tmp_path = fh.name
+
+        try:
+            import argparse
+            args = argparse.Namespace(changed_file=tmp_path, base=None, head="HEAD")
+            paths = cc._get_changed_paths(args, None)
+        finally:
+            import os
+            os.unlink(tmp_path)
+
+        self.assertEqual(len(paths), 2, "whitespace-only lines must be excluded")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
> 🤖 SPARQ agent — CI-infra agent implementing bead sq-6vshe.8

## Summary

- Adds `scripts/cone_coverage.py`: reuses `ci_select.py`'s diff classifier and reverse-dep closure (shared import, not a diverging copy) to compute the coverage cone for a PR
- Adds `scripts/tests/test_cone_coverage.py`: 18 hermetic unit tests covering all acceptance criteria
- Adds two shadow steps to the `coverage-measure` matrix job in `.github/workflows/ci.yml`: cone computation before measurement, shadow report after

**Bead:** sq-6vshe.8 — changed-cone coverage (measure only the changed-crate reverse-dependency closure per PR)

## Cone computation approach

`cone_coverage.py` imports `ci_select.py` via `importlib.util` and calls `select()` directly. The affected closure that `select()` computes (changed crates + transitive reverse dependents) is exactly the coverage cone. If `select()` returns `mode="full"` (a §4.1 trigger fired), `cone_coverage.py` also returns `mode="full"` — all crates are re-measured. The cone JSON includes `mode`, `cone_crates`, `changed_crates`, `all_members`, and `reason`.

## Fail-safe rule reuse evidence

`cone_coverage.py` does **not** duplicate the §4.1 trigger table or the closure algorithm. It imports and calls `select()` from `ci_select.py` at the top of the file:

```python
_ci_select = _load_ci_select()    # importlib.util load from scripts/ci_select.py
select = _ci_select.select        # the exact same function ci_select.yml calls
```

Any future change to `_FULL_TRIGGERS` in `ci_select.py` applies automatically to cone coverage too.

## Shadow-mode default confirmation

`shadow=True` / `enforce=False` is hardcoded in this PR. The `--enforce` flag exists (it sets `enforce=True` / `shadow=False` in the output JSON) but the CI workflow does NOT pass it. The `coverage.sh` run is completely unchanged — the two new steps compute and report the cone for monitoring only, never changing what gets measured.

## CI workflow changes

Two steps added to the `coverage-measure` matrix job only (minimal diff to avoid conflict with in-flight PRs):

1. **Before measurement**: `cone_coverage.py --mode compute-cone` — reads `BASE`/`HEAD` from the PR event context (same source as `ci-select.yml`), emits `cone.json`
2. **After measurement**: `cone_coverage.py --mode shadow-report` — compares `cone.json` vs `coverage-summary.json`, labels each crate `"cone-measured"` (in cone) or `"inherited (unchanged cone): PASS"` (outside cone), logs divergences to `coverage-cone-divergence-shard-N.json`

Gate semantics: both steps use `|| true` / `if: always()` guards; they cannot fail the gate. Shadow mode is a pure observer.

## Follow-up bead

`sq-3dr4t` — "ci(coverage): flip cone-coverage to enforce mode (follow-up to sq-6vshe.8)" — will flip `--enforce` in the workflow step and add the baseline-inheritance logic for outside-cone crates (reading main's latest full coverage summary). Blocked by this PR.

## Honesty

- SHADOW-FIRST: `enforce=False` everywhere in this PR. The gate is NOT enforced. No claim that the cone is enforced when it isn't.
- Gate remains honest: cone crates labeled "cone-measured"; outside-cone crates explicitly labeled "inherited (unchanged cone): PASS" — never conflated.
- Full `coverage.sh` run unchanged; no gate weakened.

## Test plan

- [x] `python3 -m pytest scripts/tests/test_cone_coverage.py -v` — 18 passed
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yml'))"` — OK
- [x] `actionlint .github/workflows/ci.yml` — only pre-existing info-level SC2015/SC2086 notes, none from new steps
- [x] Banned-word scan (DELETEd / DROPped / invokable / ANDed) — clean

[SONNET-4.6]

🤖 Generated with [Claude Code](https://claude.com/claude-code)