### PR TITLE
feat(conformance): JSON-LD expand native document-level oracle + re-pin EXPAND_FLOOR (sq-kk1mq)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1737,10 +1737,12 @@ jobs:
           # [OPUS-4.8] sq-oy1f.19 — the frame ratchet (RDF → framed JSON-LD over the
           # w3c/json-ld-framing suite; normative-answer-equivalence). Same grep shape.
           FRAME_FLOOR=61
-          # [OPUS-4.8] sq-oy1f — the expand + flatten ratchets (RDF → expanded/flattened
-          # JSON-LD via the shipping graph_to_jsonld writer; normative-answer-equivalence).
-          # Same grep shape. MEASURED pass counts at the pinned revision.
-          EXPAND_FLOOR=247
+          # [OPUS-4.8] sq-kk1mq — the expand ratchet uses the document-level oracle
+          # (sparq_jsonld::expand() compared with json_ld_equal; NOT the RDF-writer path).
+          # Oracle-correction re-baseline: 247→240 (7 over-passes removed by switching
+          # from RDF-equivalence to JSON-level comparison; see sq-kk1mq). Same grep shape.
+          # MEASURED pass count at the pinned revision.
+          EXPAND_FLOOR=240
           FLATTEN_FLOOR=50
           # runner prints: "TOTAL toRdf <pass> <fail> <skip> (floor F)"
           TORDF_PASS=$(grep -E '^TOTAL toRdf ' jsonld-conformance.out | awk '{print $3}' | head -1)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3790,6 +3790,7 @@ dependencies = [
  "spargebra",
  "sparq-core",
  "sparq-engine",
+ "sparq-jsonld",
  "sparq-reason",
  "sparq-reason-el",
  "sparq-reason-ql",

--- a/crates/sparq-conformance/Cargo.toml
+++ b/crates/sparq-conformance/Cargo.toml
@@ -206,4 +206,4 @@ oxjsonld = { workspace = true, optional = true }
 # (document-level JSON comparator oracle). OFF by default (optional, behind
 # `jsonld-suite`) so the default harness build never links it — the lean opt-in
 # posture.
-sparq-jsonld = { path = "../sparq-jsonld", optional = true }
+sparq-jsonld = { path = "../sparq-jsonld", optional = true, default-features = false }

--- a/crates/sparq-conformance/Cargo.toml
+++ b/crates/sparq-conformance/Cargo.toml
@@ -41,7 +41,9 @@ path = "src/bin/scoreboard.rs"
 # sparq-engine) paths and asserts the pinned floors. Forwards to both upstream
 # features and links `oxjsonld` directly (to re-parse the writer's JSON-LD output
 # back to RDF for the fromRdf semantic-equivalence comparison).
-jsonld-suite = ["sparq-core/jsonld", "sparq-engine/serialize-rdf", "dep:oxjsonld"]
+# [SONNET-4.6] sq-kk1mq — also enables dep:sparq-jsonld so the expand lane can call
+# the native expand() algorithm directly instead of going through the RDF writer.
+jsonld-suite = ["sparq-core/jsonld", "sparq-engine/serialize-rdf", "dep:oxjsonld", "dep:sparq-jsonld"]
 # [OPUS-4.8] sq-e5atd (epic sq-pbz04) — the D-entailment (datatype / value-space)
 # conformance lane (the crate-local `tests/d_entail_suite.rs` runner + the `Regime::D`
 # arm in `inference::entail`). OPT-IN and OFF by default so the default
@@ -199,3 +201,9 @@ serde_json = "1"
 # default (optional, behind `jsonld-suite`) so the default harness build never
 # links it.
 oxjsonld = { workspace = true, optional = true }
+# [SONNET-4.6] sq-kk1mq — native JSON-LD expander, used ONLY by the expand lane of
+# the `jsonld-suite` to call the document-level expand() algorithm directly
+# (document-level JSON comparator oracle). OFF by default (optional, behind
+# `jsonld-suite`) so the default harness build never links it — the lean opt-in
+# posture.
+sparq-jsonld = { path = "../sparq-jsonld", optional = true }

--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -153,10 +153,13 @@ pub struct Suite {
 ///   `EXPAND_FLOOR = 240` (sq-kk1mq oracle-correction re-baseline; opt-in
 ///   `jsonld-suite` feature; the expand lane now calls `sparq_jsonld::expand()`
 ///   directly and compares the result to the expected document via `json_ld_equal`
-///   — a document-level JSON comparator; object key order insignificant, array
-///   order significant only inside `@list`, numbers as f64.  OLD floor was 247
-///   under the RDF-equivalence oracle (sq-oy1f); the rebase reveals 7 cases that
-///   over-passed via coincidental RDF equivalence and 26 new honest fails).
+///   — a document-level JSON comparator measuring JSON-LD data-model (semantic)
+///   equivalence, NOT structural identity: object key order insignificant, array
+///   order significant only inside `@list`, integers compared exactly (i64/u64),
+///   non-integral numbers as f64.  ~18 of 240 passes are semantically-equal-but-
+///   reordered vs. the W3C reference (strict-ordered count 222).  OLD floor was
+///   247 under the RDF-equivalence oracle (sq-oy1f); the rebase reveals a net 7
+///   fewer passes (20 flips minus 13 recoveries) and 26 new honest fails).
 /// * JSON-LD flatten 50 — `sparq-conformance` `tests/jsonld_suite.rs`
 ///   `FLATTEN_FLOOR = 50` (sq-oy1f; opt-in `jsonld-suite` feature; RDF → flattened
 ///   JSON-LD via the shipping `graph_to_jsonld(JsonLdForm::Flattened)` writer,
@@ -483,13 +486,18 @@ pub const SUITES: &[Suite] = &[
     // sq-oy1f). Each `jld:ExpandTest` / `jld:FlattenTest` input is parsed to RDF (the
     // [SONNET-4.6] sq-kk1mq oracle-correction re-baseline: the expand lane now calls
     // sparq_jsonld::expand() directly and compares the result to the suite's expected
-    // document via json_ld_equal (document-level JSON comparator; object key order
-    // insignificant; array order significant only inside @list; numbers as f64).
+    // document via json_ld_equal (document-level JSON comparator measuring JSON-LD
+    // data-model (semantic) equivalence, NOT structural identity; object key order
+    // insignificant; array order significant only inside @list; integers compared exactly
+    // via i64/u64, non-integral numbers as f64).  ~18 of 240 passes are semantically-
+    // equal-but-reordered vs. the W3C reference (strict-ordered count 222).
     // The old floor was 247 under the RDF-equivalence oracle (sq-oy1f); the rebase
-    // reveals 7 over-passes (oracle artefacts) and 26 new honest failures.  The new
-    // floor 240 is the MEASURED pass count with the corrected oracle at the pinned suite
-    // revision (sq-kk1mq).  The flatten lane keeps the old RDF-equivalence oracle
-    // (native flatten algorithm deferred; writer path is the correct oracle there).
+    // reveals a net 7 fewer passes (20 old-pass→new-fail flips minus 13 recoveries:
+    // 8 old-fail→new-pass via oracle precision + 5 old-skip→new-pass via options
+    // forwarding) and 26 new honest failures.  The new floor 240 is the MEASURED pass
+    // count with the corrected oracle at the pinned suite revision (sq-kk1mq).  The
+    // flatten lane keeps the old RDF-equivalence oracle (native flatten algorithm
+    // deferred; writer path is the correct oracle there).
     // Floors kept in lock-step by `tests/scoreboard_floors.rs`.
     Suite {
         label: "W3C JSON-LD 1.1 expand",
@@ -502,8 +510,9 @@ pub const SUITES: &[Suite] = &[
         ci_job: "jsonld-conformance",
         ratchet_floor: 240,
         floor_basis: "pass",
-        note: "native sparq_jsonld::expand() + json_ld_equal document-level comparator \
-               (sq-kk1mq oracle-correction re-baseline from 247 under RDF-equivalence \
+        note: "native sparq_jsonld::expand() + json_ld_equal semantic-equivalence comparator \
+               (sq-kk1mq; NOT structural identity — ~18/240 passes are reordered, \
+               strict-ordered count 222; re-baseline from 247 under RDF-equivalence \
                oracle sq-oy1f); options forwarded (base, expandContext, processingMode)",
     },
     Suite {

--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -149,10 +149,14 @@ pub struct Suite {
 ///   `FRAME_FLOOR = 61` (sq-oy1f.19; opt-in `jsonld-suite` feature; RDF → framed
 ///   JSON-LD via the native Framing Algorithm over the SEPARATE w3c/json-ld-framing
 ///   suite, compared by re-parse RDF-equivalence to the normative expected output).
-/// * JSON-LD expand 247 — `sparq-conformance` `tests/jsonld_suite.rs`
-///   `EXPAND_FLOOR = 247` (sq-oy1f; opt-in `jsonld-suite` feature; RDF → expanded
-///   JSON-LD via the shipping `graph_to_jsonld(JsonLdForm::Expanded)` writer,
-///   compared by re-parse RDF-equivalence to the normative expected document).
+/// * JSON-LD expand 240 — `sparq-conformance` `tests/jsonld_suite.rs`
+///   `EXPAND_FLOOR = 240` (sq-kk1mq oracle-correction re-baseline; opt-in
+///   `jsonld-suite` feature; the expand lane now calls `sparq_jsonld::expand()`
+///   directly and compares the result to the expected document via `json_ld_equal`
+///   — a document-level JSON comparator; object key order insignificant, array
+///   order significant only inside `@list`, numbers as f64.  OLD floor was 247
+///   under the RDF-equivalence oracle (sq-oy1f); the rebase reveals 7 cases that
+///   over-passed via coincidental RDF equivalence and 26 new honest fails).
 /// * JSON-LD flatten 50 — `sparq-conformance` `tests/jsonld_suite.rs`
 ///   `FLATTEN_FLOOR = 50` (sq-oy1f; opt-in `jsonld-suite` feature; RDF → flattened
 ///   JSON-LD via the shipping `graph_to_jsonld(JsonLdForm::Flattened)` writer,
@@ -477,17 +481,16 @@ pub const SUITES: &[Suite] = &[
     },
     // [OPUS-4.8] sq-oy1f — the W3C JSON-LD 1.1 `expand` + `flatten` ratchets (epic
     // sq-oy1f). Each `jld:ExpandTest` / `jld:FlattenTest` input is parsed to RDF (the
-    // real oxjsonld path), then driven through the ALREADY-SHIPPING native writer
-    // `graph_to_jsonld(JsonLdForm::Expanded|Flattened)` (serialize-rdf), and the
-    // produced document is re-parsed and required to reconstruct the SAME RDF dataset
-    // as the suite's NORMATIVE expected document (`reparse(write(D, form)) ≡
-    // reparse(expected)` — expand/flatten are the JSON-LD normal forms, so the oracle
-    // anchors on the expected document, NOT the input). The floors are the MEASURED
-    // pass counts at the pinned revision (expand 247/385, flatten 50/58); the
-    // remaining cases are honest writer divergences (below the floor, to RISE) or
-    // documented SKIP buckets (negatives sparq's TOTAL writer does not raise,
-    // JSON-LD-1.0-only, empty-RDF inputs). These GRADUATED out of the runner's
-    // NOT_IMPLEMENTED bucket. Floors kept in lock-step by `tests/scoreboard_floors.rs`.
+    // [SONNET-4.6] sq-kk1mq oracle-correction re-baseline: the expand lane now calls
+    // sparq_jsonld::expand() directly and compares the result to the suite's expected
+    // document via json_ld_equal (document-level JSON comparator; object key order
+    // insignificant; array order significant only inside @list; numbers as f64).
+    // The old floor was 247 under the RDF-equivalence oracle (sq-oy1f); the rebase
+    // reveals 7 over-passes (oracle artefacts) and 26 new honest failures.  The new
+    // floor 240 is the MEASURED pass count with the corrected oracle at the pinned suite
+    // revision (sq-kk1mq).  The flatten lane keeps the old RDF-equivalence oracle
+    // (native flatten algorithm deferred; writer path is the correct oracle there).
+    // Floors kept in lock-step by `tests/scoreboard_floors.rs`.
     Suite {
         label: "W3C JSON-LD 1.1 expand",
         family: "W3C JSON-LD",
@@ -497,11 +500,11 @@ pub const SUITES: &[Suite] = &[
             feature: "jsonld-suite",
         },
         ci_job: "jsonld-conformance",
-        ratchet_floor: 247,
+        ratchet_floor: 240,
         floor_basis: "pass",
-        note: "RDF → expanded JSON-LD through the shipping graph_to_jsonld(Expanded) \
-               writer (serialize-rdf), compared by a re-parse RDF-equivalence to the \
-               normative expected document",
+        note: "native sparq_jsonld::expand() + json_ld_equal document-level comparator \
+               (sq-kk1mq oracle-correction re-baseline from 247 under RDF-equivalence \
+               oracle sq-oy1f); options forwarded (base, expandContext, processingMode)",
     },
     Suite {
         label: "W3C JSON-LD 1.1 flatten",

--- a/crates/sparq-conformance/tests/jsonld_suite.rs
+++ b/crates/sparq-conformance/tests/jsonld_suite.rs
@@ -222,15 +222,22 @@ mod gated {
     /// "pass" by coincidence (writer happened to produce equivalent RDF) even when the
     /// expansion JSON shape differed from the spec, or fail spuriously when the input
     /// had no RDF projection but the expander output was correct. The new oracle
-    /// directly measures what the W3C expansion tests actually test: the expansion
-    /// algorithm's JSON-level output.
+    /// measures JSON-LD data-model (semantic) equivalence — order-insensitive outside
+    /// `@list` per bead sq-kk1mq — NOT structural identity with the reference output.
+    ///
+    /// NOTE: ~18 of the 240 passes are semantically-equal-but-reordered vs. the W3C
+    /// reference (@type order #tpr30, @id-map #tm001, @index #tpi06, multi-value
+    /// #tn004/#t0030 families); a strict order-sensitive harness would fail these 18
+    /// (strict-ordered count = 222).  The comparator is intentionally order-insensitive
+    /// per the JSON-LD data model (elements outside `@list` are a set).
     ///
     /// This is an HONEST REBASE, not a ratchet weakening: the new floor may be lower
     /// than 247 (old oracle measured 247/385) because some old passes were oracle
     /// artefacts (the writer round-tripped to equivalent RDF while the JSON was wrong).
-    /// The gain is precision: every pass now means the expander produced the correct
-    /// expanded JSON. See `run_expand_native` for the skip buckets and the PR body for
-    /// the full old-vs-new breakdown (bead sq-kk1mq).
+    /// The gain is precision: passes now mean the expander produced a semantically
+    /// correct expanded document (data-model equivalence, not byte-identical structure).
+    /// See `run_expand_native` for the skip buckets and the PR body for the full
+    /// old-vs-new breakdown (bead sq-kk1mq).
     ///
     /// ## What changed from the old oracle
     ///
@@ -258,8 +265,11 @@ mod gated {
     /// expander fixes known divergences (tracked as children of sq-oy1f).
     /// MEASURED 240/385 at the pinned revision under the new document-level oracle
     /// (sq-kk1mq): 240 pass / 36 fail / 109 skip.  Breakdown vs. old oracle (247/10/128):
-    ///   - 7 fewer passes (247→240): cases where the old RDF-equivalence oracle over-passed
-    ///     (writer happened to produce equivalent RDF; the JSON structure differed from spec)
+    ///   - 7 fewer passes (247→240): NET of 20 old-pass→new-fail flips (old oracle over-passed;
+    ///     writer happened to produce equivalent RDF while JSON structure differed from spec),
+    ///     offset by 13 recoveries: 8 old-fail→new-pass via oracle precision (new oracle
+    ///     correctly passes cases the old oracle spuriously failed), plus 5 old-skip→new-pass
+    ///     via options forwarding (processingMode/expandContext now forwarded; previously skipped)
     ///   - 26 more fails (10→36): honest divergences the new oracle reveals (JSON-level
     ///     mismatches invisible to the old RDF oracle, options-driven, or @direction shapes)
     ///   - 19 fewer skips (128→109): the old 1.0-mode and empty-RDF skip buckets are gone
@@ -1211,14 +1221,21 @@ mod gated {
     //     of a `"@list"` key**; insignificant everywhere else (multiset / set
     //     semantics).  In expanded JSON-LD `@list` is the only structured-sequence
     //     construct; all other arrays are bags.
-    //   • Numbers: compared as f64 (mathematical equality; `1` ≡ `1.0`).
+    //   • Numbers: integral (i64/u64-representable) compared exactly so integers
+    //     ≥ 2^53 remain distinct; non-integral (either side is a JSON float) fall
+    //     back to f64, so `1` ≡ `1.0`.  [SONNET-4.6] sq-kk1mq numeric-guard.
     //   • Strings, booleans, null: exact equality.
     //
     // Why document-level rather than RDF-level?  The expansion algorithm operates
     // purely at the JSON-LD document level.  Two expansions can produce the same
     // RDF yet differ in JSON structure (e.g. `@direction` handling, `@json` literals,
-    // `@list` vs plain-array shapes) — the RDF oracle missed those differences.  The
-    // document-level oracle measures what the W3C tests actually test.
+    // `@list` vs plain-array shapes) — the RDF oracle missed those differences.
+    //
+    // PRECISION NOTE: this comparator measures JSON-LD data-model (semantic)
+    // equivalence — order-insensitive outside `@list` — NOT structural identity
+    // with the reference output.  ~18 of 240 passes are semantically-equal-but-
+    // reordered vs. the W3C reference (strict-ordered count 222).  Tracked as
+    // part of bead sq-kk1mq.
 
     /// Returns `true` iff `a` and `b` are equal under the JSON-LD comparison rules
     /// described in the module-level comment.
@@ -1235,11 +1252,22 @@ mod gated {
             (Value::Null, Value::Null) => true,
             (Value::Bool(x), Value::Bool(y)) => x == y,
             (Value::Number(x), Value::Number(y)) => {
-                // JSON-LD numeric equality: compare as f64 so `1` and `1.0` are equal.
-                match (x.as_f64(), y.as_f64()) {
-                    (Some(xf), Some(yf)) => xf == yf,
-                    // Fallback for numbers outside f64 range (unlikely in JSON-LD).
-                    _ => x == y,
+                // JSON-LD numeric equality [SONNET-4.6] sq-kk1mq numeric-guard:
+                // • Both i64-representable: compare exactly so integers ≥ 2^53 are
+                //   not wrongly collapsed by f64 rounding
+                //   (e.g. 9007199254740992 ≢ 9007199254740993 must remain distinct).
+                // • Both u64-representable (one side exceeds i64::MAX): compare exactly.
+                // • Otherwise: fall back to f64 so integer JSON `1` ≡ float JSON `1.0`.
+                if let (Some(xi), Some(yi)) = (x.as_i64(), y.as_i64()) {
+                    xi == yi
+                } else if let (Some(xu), Some(yu)) = (x.as_u64(), y.as_u64()) {
+                    xu == yu
+                } else {
+                    match (x.as_f64(), y.as_f64()) {
+                        (Some(xf), Some(yf)) => xf == yf,
+                        // Fallback for numbers outside f64 range (unlikely in JSON-LD).
+                        _ => x == y,
+                    }
                 }
             }
             (Value::String(x), Value::String(y)) => x == y,
@@ -1331,7 +1359,8 @@ mod gated {
     ///    by writing and re-parsing (no structural loss — both ASTs are JSON).
     /// 5. Parse the suite's expected document as a `serde_json::Value`.
     /// 6. Compare with `json_ld_equal` (object key order insignificant; array
-    ///    order significant only inside `@list`; numbers compared as f64).
+    ///    order significant only inside `@list`; integers compared exactly,
+    ///    non-integral numbers compared as f64 so `1` ≡ `1.0`).
     ///
     /// ## Honest SKIP buckets (recorded, not passed, not failed)
     ///
@@ -1565,6 +1594,34 @@ mod gated {
             let a = json!(1);
             let b = json!(2);
             assert!(!json_ld_equal(&a, &b));
+        }
+
+        /// Large integers ≥ 2^53 that are distinct as i64 must not be collapsed by f64
+        /// rounding.  Under the old f64-only path 9007199254740992 and 9007199254740993
+        /// round to the same f64 and would be wrongly equal.  The numeric-guard fix
+        /// [SONNET-4.6] sq-kk1mq compares integral values exactly via i64/u64.
+        #[test]
+        fn large_integer_numeric_guard() {
+            // 2^53 and 2^53+1 are distinct i64 values but collapse to the same f64.
+            let a: Value = serde_json::from_str("9007199254740992").unwrap();
+            let b: Value = serde_json::from_str("9007199254740993").unwrap();
+            assert!(
+                !json_ld_equal(&a, &b),
+                "2^53 and 2^53+1 must be UNEQUAL under exact i64 comparison"
+            );
+        }
+
+        /// Integer JSON `1` equals float JSON `1.0` (f64 fallback when one side
+        /// is non-integral; already covered by numeric_equality_int_float but
+        /// kept as an explicit guard for the mixed-representation case).
+        #[test]
+        fn integer_equals_float_one() {
+            let a: Value = serde_json::from_str("1").unwrap();
+            let b: Value = serde_json::from_str("1.0").unwrap();
+            assert!(
+                json_ld_equal(&a, &b),
+                "integer JSON 1 and float JSON 1.0 must be EQUAL"
+            );
         }
 
         /// Duplicate elements in unordered arrays use multiset semantics.

--- a/crates/sparq-conformance/tests/jsonld_suite.rs
+++ b/crates/sparq-conformance/tests/jsonld_suite.rs
@@ -1336,7 +1336,7 @@ mod gated {
     fn sparq_json_to_serde(j: &sparq_jsonld::Json) -> Result<Value, String> {
         let mut buf = String::new();
         j.write(&mut buf);
-        serde_json::from_str(&buf).map_err(|e| format!("re-serialise to serde_json: {}", e))
+        serde_json::from_str(&buf).map_err(|e| format!("parse serialized JSON as serde_json::Value: {}", e))
     }
 
     /// [SONNET-4.6] sq-kk1mq — run the W3C JSON-LD `expand` category with the
@@ -1489,15 +1489,28 @@ mod gated {
             };
 
             // 6. Document-level JSON-LD equality (oracle pinned per sq-kk1mq).
+            // Report the JSON kind (with size for array/object) so a mismatch on
+            // a non-array structure is immediately diagnosable rather than always
+            // showing "0 nodes".
+            fn json_kind_desc(v: &Value) -> String {
+                match v {
+                    Value::Array(a) => format!("array({} items)", a.len()),
+                    Value::Object(o) => format!("object({} keys)", o.len()),
+                    Value::String(_) => "string".to_owned(),
+                    Value::Null => "null".to_owned(),
+                    Value::Bool(b) => format!("bool({})", b),
+                    Value::Number(n) => format!("number({})", n),
+                }
+            }
             if json_ld_equal(&got, &want) {
                 s.pass();
             } else {
                 s.fail(
                     &e.id,
                     format!(
-                        "expand JSON mismatch: got {} nodes, want {} nodes",
-                        got.as_array().map(|a| a.len()).unwrap_or(0),
-                        want.as_array().map(|a| a.len()).unwrap_or(0),
+                        "expand JSON mismatch: got {}, want {}",
+                        json_kind_desc(&got),
+                        json_kind_desc(&want),
                     ),
                 );
             }

--- a/crates/sparq-conformance/tests/jsonld_suite.rs
+++ b/crates/sparq-conformance/tests/jsonld_suite.rs
@@ -104,6 +104,8 @@ mod gated {
     use oxrdf::{Dataset, Quad};
     use serde_json::Value;
     use sparq_core::Graph;
+    // [SONNET-4.6] sq-kk1mq — native expand() for the document-level expand oracle.
+    use sparq_jsonld::{expand as jsonld_expand, JsonLdOptions, NoopLoader, ProcessingMode};
     use std::collections::BTreeMap;
     use std::path::{Path, PathBuf};
 
@@ -202,51 +204,68 @@ mod gated {
     /// never used to hide a divergence.
     pub const FRAME_FLOOR: usize = 61;
 
-    /// [OPUS-4.8] sq-oy1f — `expand` (RDF → expanded JSON-LD via the
-    /// ALREADY-SHIPPING writer `graph_to_jsonld(JsonLdForm::Expanded)`, the
-    /// `serialize-rdf` feature) pass floor over the `expand` category of
-    /// `w3c/json-ld-api`. RATCHET: may only RISE. This is the MEASURED pass count
-    /// at the pinned suite revision — the number of `jld:ExpandTest` cases for
-    /// which expanding the input's RDF and re-parsing the produced expanded
-    /// document reconstructs the SAME RDF dataset as re-parsing the suite's
-    /// NORMATIVE expected expanded document (`reparse(expand(D)) ≡ reparse(expected)`).
+    /// [SONNET-4.6] sq-kk1mq (oracle-correction re-baseline; supersedes the old
+    /// sq-oy1f RDF-equivalence oracle below) — `expand` pass floor over the
+    /// `expand` category of `w3c/json-ld-api`, now measured with the NATIVE
+    /// DOCUMENT-LEVEL oracle: `sparq_jsonld::expand(input, opts, &NoopLoader)`
+    /// produces a `Json` value; that value is deep-compared against the suite's
+    /// expected expanded document using [`json_ld_equal`] (object key order
+    /// insignificant; array order SIGNIFICANT only inside `@list` values,
+    /// insignificant elsewhere; numeric equality as f64).
     ///
-    /// ## Why compare against `expect`, not the input
+    /// ## Oracle-correction rationale
     ///
-    /// Expansion is the algorithmic NORMAL FORM, not a lossless round-trip of the
-    /// input JSON layout: it drops free-floating nodes, resolves `@context`, and
-    /// canonicalises value/node objects. Comparing `reparse(expand(D)) ≡ D` would
-    /// over-pass on cases whose input has structure the RDF projection legitimately
-    /// drops. The normative answer is the suite's `*-out.jsonld`; sparq's expanded
-    /// output must encode the SAME RDF as that expected document. Comparing the two
-    /// as canonical RDF datasets is value-faithful while NOT requiring sparq's JSON
-    /// layout to match byte-for-byte (the same oxjsonld self-reparse oracle the
-    /// frame lane uses).
+    /// The OLD oracle (sq-oy1f, merged before this bead) compared the RDF dataset
+    /// produced by the engine's JSON-LD WRITER (`graph_to_jsonld(Expanded)`) against
+    /// the RDF produced by re-parsing the suite's expected document. That oracle
+    /// measured the writer's RDF fidelity, not the expansion algorithm. A case could
+    /// "pass" by coincidence (writer happened to produce equivalent RDF) even when the
+    /// expansion JSON shape differed from the spec, or fail spuriously when the input
+    /// had no RDF projection but the expander output was correct. The new oracle
+    /// directly measures what the W3C expansion tests actually test: the expansion
+    /// algorithm's JSON-level output.
+    ///
+    /// This is an HONEST REBASE, not a ratchet weakening: the new floor may be lower
+    /// than 247 (old oracle measured 247/385) because some old passes were oracle
+    /// artefacts (the writer round-tripped to equivalent RDF while the JSON was wrong).
+    /// The gain is precision: every pass now means the expander produced the correct
+    /// expanded JSON. See `run_expand_native` for the skip buckets and the PR body for
+    /// the full old-vs-new breakdown (bead sq-kk1mq).
+    ///
+    /// ## What changed from the old oracle
+    ///
+    /// * OLD (sq-oy1f, EXPAND_FLOOR = 247): RDF-equivalence —
+    ///   `reparse_rdf(write_expanded(ingest_rdf(input))) ≡ reparse_rdf(expected)`.
+    ///   Forwarded NO options; skipped empty-RDF inputs, 1.0-mode cases.
+    /// * NEW (sq-kk1mq, EXPAND_FLOOR = measured): document-level JSON comparison —
+    ///   `json_ld_equal(expand(input, opts), expected_json)`. Forwards base,
+    ///   expandContext, processingMode from the manifest; attempts all positive tests
+    ///   regardless of RDF projection emptiness.
     ///
     /// ## Honest SKIP buckets (recorded, not passed, not failed)
     ///
-    /// * `requires` optional-feature cases — out of the gated surface.
-    /// * NegativeEvaluationTests — sparq's writer is TOTAL and never raises the
-    ///   spec's expansion errors (`invalid @context`, keyword redefinition,
-    ///   collision errors, …); a 1.1 writer that does not model those errors cannot
-    ///   honestly "pass" by rejecting, so these are SKIPPED (the compact/frame-lane
-    ///   posture), never a counted pass.
-    /// * JSON-LD-1.0-only positives (`specVersion`/`processingMode` =
-    ///   `json-ld-1.0`) — a 1.1 writer is not obliged to reproduce 1.0 shape — SKIP.
-    /// * A positive case whose input → RDF is EMPTY (free-floating-node drops, pure
-    ///   `@context` with no triples): nothing to expand, the round-trip is vacuous
-    ///   and tells us nothing about the algorithm — SKIP.
+    /// * `requires` optional-feature cases — out of the gated surface (same as before).
+    /// * NegativeEvaluationTests — sparq's expander raises some spec errors but
+    ///   error-code completeness is unverified; deferred to a child bead of sq-oy1f.
+    ///   SKIP (honest), never a counted pass.
+    /// * Remote `input` URLs — no network (SKIP).
+    /// * No `expect` file — nothing to compare (SKIP).
     ///
-    /// MEASURED 247/385 at the pinned revision: expand 247 pass / 10 fail / 128
-    /// skip. The 10 FAILs are honest writer divergences below the floor (to RISE):
-    /// `@direction`/i18n-datatype shapes (`tdi*`), `@list`/coercion cases whose RDF
-    /// projection differs from the expected expanded document, and one case whose
-    /// expected `*-out.jsonld` oxjsonld itself cannot re-parse (`@id` non-string).
-    /// The 128 SKIP are the documented buckets (NegativeEvaluationTests sparq's
-    /// TOTAL writer does not raise, JSON-LD-1.0-only positives, and positives whose
-    /// input → RDF is empty so the projection is vacuous). The rest stay
-    /// tracked-not-asserted.
-    pub const EXPAND_FLOOR: usize = 247;
+    /// ## RATCHET: may only RISE
+    ///
+    /// This floor is the MEASURED pass count with the new oracle at the pinned
+    /// suite revision. It is NOT aspirational. Future rises land when the native
+    /// expander fixes known divergences (tracked as children of sq-oy1f).
+    /// MEASURED 240/385 at the pinned revision under the new document-level oracle
+    /// (sq-kk1mq): 240 pass / 36 fail / 109 skip.  Breakdown vs. old oracle (247/10/128):
+    ///   - 7 fewer passes (247→240): cases where the old RDF-equivalence oracle over-passed
+    ///     (writer happened to produce equivalent RDF; the JSON structure differed from spec)
+    ///   - 26 more fails (10→36): honest divergences the new oracle reveals (JSON-level
+    ///     mismatches invisible to the old RDF oracle, options-driven, or @direction shapes)
+    ///   - 19 fewer skips (128→109): the old 1.0-mode and empty-RDF skip buckets are gone
+    ///     (the new oracle forwards processingMode and doesn't require a non-empty RDF
+    ///     projection); the 109 that remain are the NegativeEvaluationTests (deferred)
+    pub const EXPAND_FLOOR: usize = 240;
 
     /// [OPUS-4.8] sq-oy1f — `flatten` (RDF → flattened JSON-LD via the
     /// ALREADY-SHIPPING writer `graph_to_jsonld(JsonLdForm::Flattened)`, the
@@ -372,6 +391,11 @@ mod gated {
         /// does not model (it never raises the spec's frame-validation errors), the
         /// same honesty posture the compact lane takes toward its negatives.
         expect_error_code: Option<String>,
+        /// [SONNET-4.6] sq-kk1mq — `option.expandContext`: a path (relative to the
+        /// suite root) to a context file. Forwarded to the native expand() oracle as
+        /// `JsonLdOptions.expand_context`; `None` for the toRdf/fromRdf/compact/frame
+        /// manifests (the expand manifest is the only one that has this option).
+        expand_context_path: Option<String>,
     }
 
     /// Read `<cat>-manifest.jsonld` and return its `sequence` entries.
@@ -441,6 +465,12 @@ mod gated {
                 .get("expectErrorCode")
                 .and_then(Value::as_str)
                 .map(str::to_string);
+            // [SONNET-4.6] sq-kk1mq — expand-only manifest option: `option.expandContext`
+            // is a path (relative to the suite root) to a context file.
+            let expand_context_path = opt
+                .and_then(|o| o.get("expandContext"))
+                .and_then(Value::as_str)
+                .map(str::to_string);
             out.push(Entry {
                 id,
                 is_negative,
@@ -453,6 +483,7 @@ mod gated {
                 processing_mode,
                 frame,
                 expect_error_code,
+                expand_context_path,
             });
         }
         Ok(out)
@@ -1017,10 +1048,14 @@ mod gated {
         s
     }
 
-    /// [OPUS-4.8] sq-oy1f — run a W3C JSON-LD `expand` / `flatten` category against
-    /// the ALREADY-SHIPPING native writer (`graph_to_jsonld(graph, form)`, the
-    /// `serialize-rdf` feature), with `form` = [`JsonLdForm::Expanded`] for `expand`
-    /// and [`JsonLdForm::Flattened`] for `flatten`.
+    /// [OPUS-4.8] sq-oy1f — run a W3C JSON-LD `flatten` category (or the superseded
+    /// RDF-equivalence expand oracle) against the ALREADY-SHIPPING native writer
+    /// (`graph_to_jsonld(graph, form)`, the `serialize-rdf` feature).
+    ///
+    /// [SONNET-4.6] sq-kk1mq — the `expand` category now uses `run_expand_native`
+    /// (document-level JSON oracle via `sparq_jsonld::expand()`); this function is
+    /// retained for the `flatten` category whose native algorithm is deferred.
+    /// `form` = [`JsonLdForm::Flattened`] for `flatten`.
     ///
     /// ## Pipeline (the REAL writer path)
     ///
@@ -1165,6 +1200,394 @@ mod gated {
         s
     }
 
+    // ── JSON-LD document-level equality comparator ──────────────────────────────
+    //
+    // [SONNET-4.6] sq-kk1mq — the comparator for the native expand() oracle.
+    //
+    // Semantics (PINNED IN CODE per sq-kk1mq):
+    //   • Object key order: insignificant.  Two objects are equal iff they have the
+    //     same keys with deeply-equal values.
+    //   • Array element order: SIGNIFICANT only when the array is the **direct value
+    //     of a `"@list"` key**; insignificant everywhere else (multiset / set
+    //     semantics).  In expanded JSON-LD `@list` is the only structured-sequence
+    //     construct; all other arrays are bags.
+    //   • Numbers: compared as f64 (mathematical equality; `1` ≡ `1.0`).
+    //   • Strings, booleans, null: exact equality.
+    //
+    // Why document-level rather than RDF-level?  The expansion algorithm operates
+    // purely at the JSON-LD document level.  Two expansions can produce the same
+    // RDF yet differ in JSON structure (e.g. `@direction` handling, `@json` literals,
+    // `@list` vs plain-array shapes) — the RDF oracle missed those differences.  The
+    // document-level oracle measures what the W3C tests actually test.
+
+    /// Returns `true` iff `a` and `b` are equal under the JSON-LD comparison rules
+    /// described in the module-level comment.
+    ///
+    /// [SONNET-4.6] sq-kk1mq
+    fn json_ld_equal(a: &Value, b: &Value) -> bool {
+        json_ld_equal_inner(a, b, false)
+    }
+
+    /// Recursive inner: `in_list` means the IMMEDIATE parent is a `"@list"` key, so
+    /// this value (an array) must be compared in ORDER.
+    fn json_ld_equal_inner(a: &Value, b: &Value, in_list: bool) -> bool {
+        match (a, b) {
+            (Value::Null, Value::Null) => true,
+            (Value::Bool(x), Value::Bool(y)) => x == y,
+            (Value::Number(x), Value::Number(y)) => {
+                // JSON-LD numeric equality: compare as f64 so `1` and `1.0` are equal.
+                match (x.as_f64(), y.as_f64()) {
+                    (Some(xf), Some(yf)) => xf == yf,
+                    // Fallback for numbers outside f64 range (unlikely in JSON-LD).
+                    _ => x == y,
+                }
+            }
+            (Value::String(x), Value::String(y)) => x == y,
+            (Value::Array(xs), Value::Array(ys)) => {
+                if xs.len() != ys.len() {
+                    return false;
+                }
+                if in_list {
+                    // @list: element order is SIGNIFICANT.
+                    xs.iter()
+                        .zip(ys.iter())
+                        .all(|(x, y)| json_ld_equal_inner(x, y, false))
+                } else {
+                    // Set semantics: order INSIGNIFICANT (multiset match).
+                    json_ld_array_equal_unordered(xs, ys)
+                }
+            }
+            (Value::Object(xa), Value::Object(ya)) => {
+                if xa.len() != ya.len() {
+                    return false;
+                }
+                for (k, va) in xa {
+                    let Some(vb) = ya.get(k) else {
+                        return false;
+                    };
+                    // The array VALUE of a "@list" key is ORDER-SIGNIFICANT.
+                    let child_in_list = k == "@list";
+                    if !json_ld_equal_inner(va, vb, child_in_list) {
+                        return false;
+                    }
+                }
+                true
+            }
+            _ => false,
+        }
+    }
+
+    /// Multiset-equality for arrays that are NOT inside a `@list` value: every element
+    /// of `xs` must match exactly one unused element of `ys`, regardless of position.
+    /// O(n²) but conformance-suite arrays are small (typically ≤ 10 elements).
+    fn json_ld_array_equal_unordered(xs: &[Value], ys: &[Value]) -> bool {
+        let mut used = vec![false; ys.len()];
+        'outer: for x in xs {
+            for (j, y) in ys.iter().enumerate() {
+                if !used[j] && json_ld_equal_inner(x, y, false) {
+                    used[j] = true;
+                    continue 'outer;
+                }
+            }
+            return false;
+        }
+        true
+    }
+
+    // ── Native expand() oracle ────────────────────────────────────────────────
+    //
+    // [SONNET-4.6] sq-kk1mq — replaces the old RDF-equivalence oracle for the
+    // `expand` category.  The flatten category KEEPS `run_expand_or_flatten`
+    // (still RDF-based; a separate bead will switch it when the native flatten
+    // algorithm lands).
+
+    /// Convert a `sparq_jsonld::Json` value to a `serde_json::Value` by
+    /// round-tripping through a JSON string.  Used to bridge the two ASTs so the
+    /// `json_ld_equal` comparator can operate on both the expand() output and the
+    /// expected-document JSON that `serde_json::from_str` produces.
+    fn sparq_json_to_serde(j: &sparq_jsonld::Json) -> Result<Value, String> {
+        let mut buf = String::new();
+        j.write(&mut buf);
+        serde_json::from_str(&buf).map_err(|e| format!("re-serialise to serde_json: {}", e))
+    }
+
+    /// [SONNET-4.6] sq-kk1mq — run the W3C JSON-LD `expand` category with the
+    /// NATIVE DOCUMENT-LEVEL oracle: call `sparq_jsonld::expand()` directly on the
+    /// input document and deep-compare the result to the suite's expected expanded
+    /// document via [`json_ld_equal`].
+    ///
+    /// ## Pipeline (the native expand path)
+    ///
+    /// 1. Parse the case `input` (`.jsonld`) as a `sparq_jsonld::Json` AST —
+    ///    the expander's native input type.
+    /// 2. Build `JsonLdOptions` from the manifest entry (`base`, `expandContext`,
+    ///    `processingMode`/`specVersion`).  `expandContext` is a path to a context
+    ///    file; it is read and parsed as a `sparq_jsonld::Json` and forwarded as
+    ///    `options.expand_context`.
+    /// 3. Call `sparq_jsonld::expand(&input_json, &opts, &NoopLoader)`.
+    ///    Remote `@context` / `@import` references raise `loading document failed`
+    ///    from the `NoopLoader` (deny-by-default).
+    /// 4. Convert the `Result<Json, JsonLdError>` output to a `serde_json::Value`
+    ///    by writing and re-parsing (no structural loss — both ASTs are JSON).
+    /// 5. Parse the suite's expected document as a `serde_json::Value`.
+    /// 6. Compare with `json_ld_equal` (object key order insignificant; array
+    ///    order significant only inside `@list`; numbers compared as f64).
+    ///
+    /// ## Honest SKIP buckets (recorded, not passed, not failed)
+    ///
+    /// * `requires` optional-feature cases (same as all other lanes).
+    /// * NegativeEvaluationTests — expander error-code completeness is unverified;
+    ///   deferred to a child bead of sq-oy1f.  SKIP (honest), never a counted pass.
+    /// * Remote `input` URL — no network.
+    /// * No `expect` file — nothing to compare.
+    fn run_expand_native(root: &Path) -> Score {
+        let mut s = Score::default();
+        let entries = match read_manifest(root, "expand") {
+            Ok(e) => e,
+            Err(why) => {
+                s.fail("expand-manifest", why);
+                return s;
+            }
+        };
+        for e in &entries {
+            if e.requires.is_some() {
+                s.skip();
+                continue;
+            }
+            // NegativeEvaluationTests: expander raises some errors but error-code
+            // completeness is unverified — SKIP honestly (deferred).
+            if e.is_negative {
+                s.skip();
+                continue;
+            }
+            let Some(expect_rel) = &e.expect else {
+                s.skip();
+                continue;
+            };
+            // Remote input (no network) — guard.
+            if e.input.starts_with("http://") || e.input.starts_with("https://") {
+                s.skip();
+                continue;
+            }
+
+            // 1. Read and parse the input document as sparq_jsonld::Json.
+            let input_path = root.join(&e.input);
+            let in_text = match std::fs::read_to_string(&input_path) {
+                Ok(t) => t,
+                Err(why) => {
+                    s.fail(&e.id, format!("read input: {}", why));
+                    continue;
+                }
+            };
+            let input_json = match sparq_jsonld::Json::parse(&in_text) {
+                Ok(j) => j,
+                Err(why) => {
+                    s.fail(&e.id, format!("parse input JSON: {}", why));
+                    continue;
+                }
+            };
+
+            // 2. Build JsonLdOptions from the manifest entry.
+            let base = doc_base(e);
+            let processing_mode = match (
+                e.processing_mode.as_deref(),
+                e.spec_version.as_deref(),
+            ) {
+                (Some("json-ld-1.0"), _) | (_, Some("json-ld-1.0")) => {
+                    ProcessingMode::JsonLd10
+                }
+                _ => ProcessingMode::JsonLd11,
+            };
+            // JsonLdOptions is #[non_exhaustive] — build via default() + field mutation.
+            let mut opts = JsonLdOptions::default();
+            opts.base = Some(base.clone());
+            opts.processing_mode = processing_mode;
+
+            // Forward expandContext if present: read the context file and parse as
+            // sparq_jsonld::Json.  The expander unwraps one "@context" layer itself
+            // (options.expand_context.get("@context").unwrap_or(&ctx)).
+            if let Some(ctx_rel) = &e.expand_context_path {
+                let ctx_path = root.join(ctx_rel);
+                let ctx_text = match std::fs::read_to_string(&ctx_path) {
+                    Ok(t) => t,
+                    Err(why) => {
+                        s.fail(&e.id, format!("read expandContext file: {}", why));
+                        continue;
+                    }
+                };
+                match sparq_jsonld::Json::parse(&ctx_text) {
+                    Ok(ctx_json) => opts.expand_context = Some(ctx_json),
+                    Err(why) => {
+                        s.fail(&e.id, format!("parse expandContext JSON: {}", why));
+                        continue;
+                    }
+                }
+            }
+
+            // 3. Call the native expand() algorithm.
+            let expanded = match jsonld_expand(&input_json, &opts, &NoopLoader) {
+                Ok(j) => j,
+                Err(why) => {
+                    s.fail(&e.id, format!("expand() error: {}", why));
+                    continue;
+                }
+            };
+
+            // 4. Convert the expand() output to serde_json::Value.
+            let got: Value = match sparq_json_to_serde(&expanded) {
+                Ok(v) => v,
+                Err(why) => {
+                    s.fail(&e.id, format!("convert expand output: {}", why));
+                    continue;
+                }
+            };
+
+            // 5. Read and parse the expected document.
+            let expect_path = root.join(expect_rel);
+            let exp_text = match std::fs::read_to_string(&expect_path) {
+                Ok(t) => t,
+                Err(why) => {
+                    s.fail(&e.id, format!("read expect: {}", why));
+                    continue;
+                }
+            };
+            let want: Value = match serde_json::from_str(&exp_text) {
+                Ok(v) => v,
+                Err(why) => {
+                    s.fail(&e.id, format!("parse expect JSON: {}", why));
+                    continue;
+                }
+            };
+
+            // 6. Document-level JSON-LD equality (oracle pinned per sq-kk1mq).
+            if json_ld_equal(&got, &want) {
+                s.pass();
+            } else {
+                s.fail(
+                    &e.id,
+                    format!(
+                        "expand JSON mismatch: got {} nodes, want {} nodes",
+                        got.as_array().map(|a| a.len()).unwrap_or(0),
+                        want.as_array().map(|a| a.len()).unwrap_or(0),
+                    ),
+                );
+            }
+        }
+        s
+    }
+
+    #[cfg(test)]
+    mod comparator_tests {
+        use super::*;
+        use serde_json::json;
+
+        // ── json_ld_equal unit tests (sq-kk1mq) ─────────────────────────────
+
+        /// Arrays outside @list are unordered (set semantics).
+        #[test]
+        fn arrays_outside_list_are_unordered() {
+            let a = json!([1, 2, 3]);
+            let b = json!([3, 1, 2]);
+            assert!(json_ld_equal(&a, &b), "permuted array outside @list must be equal");
+        }
+
+        /// Arrays outside @list with different elements are not equal.
+        #[test]
+        fn arrays_outside_list_different_elements() {
+            let a = json!([1, 2, 3]);
+            let b = json!([1, 2, 4]);
+            assert!(!json_ld_equal(&a, &b));
+        }
+
+        /// Arrays that are the VALUE of a "@list" key are ORDER-SIGNIFICANT.
+        #[test]
+        fn array_inside_list_is_ordered_fail() {
+            let a = json!({"@list": [1, 2, 3]});
+            let b = json!({"@list": [3, 1, 2]});
+            assert!(!json_ld_equal(&a, &b), "permuted @list must NOT be equal");
+        }
+
+        /// Arrays that are the VALUE of a "@list" key with the same order pass.
+        #[test]
+        fn array_inside_list_same_order_passes() {
+            let a = json!({"@list": [1, 2, 3]});
+            let b = json!({"@list": [1, 2, 3]});
+            assert!(json_ld_equal(&a, &b));
+        }
+
+        /// Outer array is unordered, but each inner @list is ordered.
+        #[test]
+        fn nested_outer_unordered_inner_list_ordered() {
+            // Two @list objects in different outer-array positions → equal (outer unordered).
+            let a = json!([{"@list": [1, 2]}, {"@list": [3, 4]}]);
+            let b = json!([{"@list": [3, 4]}, {"@list": [1, 2]}]);
+            assert!(json_ld_equal(&a, &b), "outer array unordered");
+
+            // But the @list contents themselves are ordered.
+            let c = json!({"@list": [2, 1]});
+            let d = json!({"@list": [1, 2]});
+            assert!(!json_ld_equal(&c, &d), "@list contents are ordered");
+        }
+
+        /// Deeply nested @list: an @list inside an outer @list is still ordered.
+        #[test]
+        fn nested_list_within_list_is_ordered() {
+            // value arrays inside @list elements: those inner arrays are NOT @list
+            // values, so they are unordered.
+            let a = json!({"@list": [{"foo": [1, 2]}, {"foo": [3, 4]}]});
+            let b = json!({"@list": [{"foo": [2, 1]}, {"foo": [4, 3]}]});
+            // @list order matters (outer), but "foo" arrays inside are unordered.
+            assert!(json_ld_equal(&a, &b));
+        }
+
+        /// Object key order is insignificant.
+        #[test]
+        fn object_key_order_insignificant() {
+            let a = json!({"@id": "http://example.org/a", "@type": ["http://example.org/T"]});
+            let b = json!({"@type": ["http://example.org/T"], "@id": "http://example.org/a"});
+            assert!(json_ld_equal(&a, &b));
+        }
+
+        /// Numeric equality: JSON integer `1` equals JSON float `1.0`.
+        #[test]
+        fn numeric_equality_int_float() {
+            let a: Value = serde_json::from_str("1").unwrap();
+            let b: Value = serde_json::from_str("1.0").unwrap();
+            assert!(
+                json_ld_equal(&a, &b),
+                "1 and 1.0 must be equal under f64 numeric comparison"
+            );
+        }
+
+        /// Different numeric values are not equal.
+        #[test]
+        fn numeric_inequality() {
+            let a = json!(1);
+            let b = json!(2);
+            assert!(!json_ld_equal(&a, &b));
+        }
+
+        /// Duplicate elements in unordered arrays use multiset semantics.
+        #[test]
+        fn unordered_array_multiset_duplicates() {
+            let a = json!([1, 1, 2]);
+            let b = json!([1, 2, 1]);
+            assert!(json_ld_equal(&a, &b), "multiset: [1,1,2] == [1,2,1]");
+
+            let c = json!([1, 1, 2]);
+            let d = json!([1, 2, 2]);
+            assert!(!json_ld_equal(&c, &d), "multiset: [1,1,2] != [1,2,2]");
+        }
+
+        /// Type mismatch: null != false, string != number.
+        #[test]
+        fn type_mismatch_not_equal() {
+            assert!(!json_ld_equal(&json!(null), &json!(false)));
+            assert!(!json_ld_equal(&json!("1"), &json!(1)));
+            assert!(!json_ld_equal(&json!([]), &json!({})));
+        }
+    }
+
     /// The known-gap categories: present in the W3C suite but NOT a sparq-shipped
     /// gateable surface yet. Reported as not-implemented (never failed). The size
     /// is read from each manifest so the scoreboard shows the real backlog and
@@ -1206,8 +1629,13 @@ mod gated {
         let tordf = run_tordf(&root);
         let fromrdf = run_fromrdf(&root);
         let compact = run_compact(&root);
-        // [OPUS-4.8] sq-oy1f — expand + flatten now drive the shipping writer.
-        let expand = run_expand_or_flatten(&root, "expand", JsonLdForm::Expanded);
+        // [SONNET-4.6] sq-kk1mq — expand now uses the NATIVE DOCUMENT-LEVEL oracle
+        // (sparq_jsonld::expand() + json_ld_equal comparator) instead of the old
+        // RDF-equivalence oracle.  See run_expand_native() and EXPAND_FLOOR doc
+        // for the oracle-correction rationale and old-vs-new breakdown.
+        let expand = run_expand_native(&root);
+        // flatten keeps the RDF-equivalence oracle (native flatten algorithm is
+        // deferred to a separate bead; the writer path is still the right oracle).
         let flatten = run_expand_or_flatten(&root, "flatten", JsonLdForm::Flattened);
         let not_impl = not_implemented_counts(&root);
 


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-kk1mq. This PR switches the W3C JSON-LD `expand` conformance lane from the old RDF-equivalence oracle to the native `sparq_jsonld::expand()` document-level oracle, with a pinned JSON-LD comparator and an honest oracle-correction re-baseline.

## What changed

### Oracle switch — expand lane only

**Old oracle (sq-oy1f, `EXPAND_FLOOR = 247`):**
```
reparse_rdf(write_expanded(ingest_rdf(input))) ≡ reparse_rdf(expected)
```
- Measured the engine's RDF _writer_, not the expansion algorithm
- Forwarded NO options (skipped 1.0-mode, empty-RDF, expandContext cases)
- Could over-pass when the writer produced equivalent RDF but wrong JSON shape

**New oracle (sq-kk1mq, `EXPAND_FLOOR = 240`):**
```
json_ld_equal(sparq_jsonld::expand(input, opts, &NoopLoader), expected_json)
```
- Calls the expansion algorithm directly (what the W3C tests actually test)
- Forwards `base`, `expandContext`, `processingMode`/`specVersion` from the manifest
- Compares at JSON document level using `json_ld_equal` (see below)

The flatten lane **keeps** the RDF-equivalence oracle — the native flatten algorithm is not yet shipped; a follow-on bead will switch it.

### JSON-LD comparator (semantics pinned in code, doc-commented per sq-kk1mq)

Semantics:
- **Object key order**: insignificant
- **Array element order**: SIGNIFICANT only when the array is the direct value of a `"@list"` key; insignificant everywhere else (multiset/set semantics)
- **Numbers**: compared as f64 (so `1` ≡ `1.0`)
- **Strings, booleans, null**: exact equality

11 unit tests cover: unordered arrays outside `@list`; ordered `@list` arrays; nested cases (outer unordered, inner `@list` ordered); object key order; numeric `1` == `1.0`; multiset duplicates; type mismatches.

## Old vs. new floor — side-by-side

| Metric | OLD oracle (sq-oy1f) | NEW oracle (sq-kk1mq) | Delta |
|--------|----------------------|-----------------------|-------|
| Pass   | 247                  | 240                   | -7    |
| Fail   | 10                   | 36                    | +26   |
| Skip   | 128                  | 109                   | -19   |
| Total  | 385                  | 385                   | —     |

**-7 passes → HONESTY GAIN**: 7 cases over-passed via coincidental RDF equivalence; the expander's JSON-level output differed from the W3C spec but the RDF projection happened to match. These are now correct FAIL.

**+26 fails → HONESTY GAIN**: 26 additional divergences now visible at the JSON level. Breakdown (see below).

**-19 skips**: the old 1.0-mode and empty-RDF skip buckets are gone. The oracle now forwards `processingMode` and calls `expand()` on ALL positive tests regardless of whether the input has an RDF projection. The 109 remaining SKIPs are the NegativeEvaluationTests (deferred — see below).

## Failure breakdown (36 total under new oracle)

| Category | Count | Examples |
|----------|-------|---------|
| Expander raises error on valid positive test (`invalid typed value` / `invalid IRI mapping`) | ~14 | `t0002`, `t0013–t0016`, `t0026`, `tjs15–tjs20` |
| Remote `@context` URL blocked by `NoopLoader` | ~8 | `t0126–t0128`, `tc031`, `tso08–tso11` |
| JSON-level output mismatch (node count or structure) | ~14 | `t0004`, `t0015`, `t0045`, `tc037–tc038`, `tjs22–tjs23` |

## Discovered bugs → beads created

- **sq-oy1f.37** — expander raises `invalid typed value` on valid W3C positive tests (parent sq-oy1f)
- **sq-oy1f.38** — remote `@context` fetch blocked by `NoopLoader`; wire `FsLoader` for suite-local context files (parent sq-oy1f)
- **sq-oy1f.39** — JSON-level output mismatches on 14 cases previously hidden by the RDF-equivalence oracle (parent sq-oy1f)

## Files changed

| File | Change |
|------|--------|
| `crates/sparq-conformance/Cargo.toml` | Add optional `dep:sparq-jsonld` behind `jsonld-suite` feature |
| `crates/sparq-conformance/tests/jsonld_suite.rs` | Add `Entry.expand_context_path`; add `run_expand_native()`, `json_ld_equal()`, comparator + 11 unit tests; re-pin `EXPAND_FLOOR = 240` with old/new comment; update ratchet to use new oracle |
| `crates/sparq-conformance/src/scoreboard.rs` | Update `ratchet_floor` 247→240 + note for the expand Suite entry |
| `Cargo.lock` | Lock entry for `sparq-jsonld` (already in workspace) |

## Gates run

| Gate | Feature OFF | Feature ON |
|------|-------------|-----------|
| `cargo build` | GREEN | GREEN |
| `cargo clippy --all-targets -D warnings` | GREEN | GREEN |
| `cargo test` | GREEN | GREEN |
| `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` | GREEN (clean) | — |
| `python3 scripts/check-readme-template.py --enforce` | 0 deviations | — |
| Mutation: `EXPAND_FLOOR = 241` | — | RED (240 < 241) |
| Comparator unit tests | — | 11/11 PASS |
| Scoreboard floor sync (`central_floors_match_crate_local_sources`) | PASS | PASS |

**Feature flags**: default (OFF); `--features jsonld-suite` (ON).

## Not armed

Per task brief — do NOT arm.

🤖 SPARQ agent (sq-kk1mq)