### PR TITLE
fix(ieee754): constrain new(bits) decode to IEEE field widths — SOUNDNESS sq-3x7dl.1 [SONNET-4.6]

### DIFF
--- a/zk/ieee754/AGENTS.md
+++ b/zk/ieee754/AGENTS.md
@@ -30,6 +30,12 @@ When the agent runtime supports skills, load the relevant skill before editing. 
 
 - The public API is intentionally the generated `f16`, `f32`, `f64`, and `f128` types.
 - Raw bits are constructed with `new(bits)` and recovered with `bits()`.
+  `new()` enforces TWO in-circuit invariants: (1) `decoded.bits() == bits` and
+  (2) `exponent < 2^EXP_SIZE` and `mantissa < 2^MANT_SIZE` for each width.
+  Invariant (2) is the soundness fix from sq-3x7dl.1: without it the packing
+  `bits() = sign*2^(W-1) + exponent*2^mant_size + mantissa` is non-injective
+  and a malicious prover can substitute `{exp-1, mantissa+2^mant_size}` to
+  prove false float statements.
 - Generated fields, `to_parts`, and internal helpers must remain private.
 - `scripts/test_public_api.sh` checks that external packages can import the generated types and cannot import helper internals.
 - Generated public `type` aliases are not viable in current Noir; generated public structs are used instead.

--- a/zk/ieee754/README.md
+++ b/zk/ieee754/README.md
@@ -43,7 +43,9 @@ fn main(a_bits: u64, b_bits: u64) -> pub u64 {
 The public API is intentionally only the generated `f16`, `f32`, `f64`, and
 `f128` structs:
 
-- `new(bits)` — construct from raw bits (`u16`/`u32`/`u64`/`u128`).
+- `new(bits)` — construct from raw bits (`u16`/`u32`/`u64`/`u128`);
+  constrains `(sign, exponent, mantissa)` to canonical IEEE field widths so
+  `bits()` is injective (soundness fix sq-3x7dl.1).
 - `bits()` — recover raw bits.
 - `std::ops::Add`, `Sub`, `Mul`, `Div` — round-to-nearest-even arithmetic with
   full subnormal, infinity, and NaN handling (NaNs are canonicalised).

--- a/zk/ieee754/src/codegen.nr
+++ b/zk/ieee754/src/codegen.nr
@@ -3,6 +3,9 @@ use crate::sizing::{exponent_size, mantissa_size, uint_type};
 pub comptime fn float_type_from_params(bits: u8) -> Quoted {
     let exp_size: u8 = exponent_size(bits);
     let mant_size: u8 = mantissa_size(bits);
+    // [SONNET-4.6] sq-3x7dl.1: u32 versions for assert_max_bit_size::<N: u32>().
+    let exp_size_u32: u32 = exp_size as u32;
+    let mant_size_u32: u32 = mant_size as u32;
 
     let exp_type = uint_type(exp_size);
     let mant_type = uint_type(mant_size);
@@ -96,6 +99,17 @@ pub comptime fn float_type_from_params(bits: u8) -> Quoted {
                 // and asserting that it exactly matches the input bit pattern.
                 let decoded = unsafe { Self::decode_unconstrained(bits) };
                 assert_eq(decoded.bits(), bits);
+                // [SONNET-4.6] sq-3x7dl.1 SOUNDNESS FIX: pin each decoded field to its
+                // real IEEE field width. The `assert_eq(decoded.bits(), bits)` above is
+                // NECESSARY but NOT SUFFICIENT: because
+                //   bits() = sign*2^(W-1) + exponent*2^mant_size + mantissa
+                // is non-injective when the field types are wider than the IEEE fields, a
+                // malicious prover can substitute {exp-1, mantissa+2^mant_size} for the
+                // canonical {exp, mantissa} and produce the same bits() while denoting a
+                // DIFFERENT real number.  The two range checks below make bits() injective
+                // and pin the unique canonical IEEE decomposition for every generated width.
+                (decoded.exponent as Field).assert_max_bit_size::<$exp_size_u32>();
+                (decoded.mantissa as Field).assert_max_bit_size::<$mant_size_u32>();
 
                 decoded
             }

--- a/zk/ieee754/src/codegen.nr
+++ b/zk/ieee754/src/codegen.nr
@@ -94,22 +94,33 @@ pub comptime fn float_type_from_params(bits: u8) -> Quoted {
         }
 
         impl $type_name {
+            // Private helper: constrain exponent and mantissa to their real IEEE field
+            // widths.  new() calls this after decode; the forge tests call it directly
+            // on malicious field values so that removing the body makes those tests RED
+            // -- they pin the helper's logic, not a disconnected inline assert.
+            // [SONNET-4.6] sq-3x7dl.1
+            fn assert_canonical_fields(exponent: $exp_type, mantissa: $mant_type) {
+                (exponent as Field).assert_max_bit_size::<$exp_size_u32>();
+                (mantissa as Field).assert_max_bit_size::<$mant_size_u32>();
+            }
+
             pub fn new(bits: $full_type) -> Self {
                 // Safety: the decoded witness is constrained by re-encoding it with bits()
                 // and asserting that it exactly matches the input bit pattern.
                 let decoded = unsafe { Self::decode_unconstrained(bits) };
                 assert_eq(decoded.bits(), bits);
-                // [SONNET-4.6] sq-3x7dl.1 SOUNDNESS FIX: pin each decoded field to its
-                // real IEEE field width. The `assert_eq(decoded.bits(), bits)` above is
-                // NECESSARY but NOT SUFFICIENT: because
-                //   bits() = sign*2^(W-1) + exponent*2^mant_size + mantissa
-                // is non-injective when the field types are wider than the IEEE fields, a
+                // [SONNET-4.6] sq-3x7dl.1 SOUNDNESS FIX: assert_eq above is NECESSARY
+                // but NOT SUFFICIENT -- because bits() = sign*2^(W-1) + exp*2^mant_size
+                // + mantissa is non-injective when field types exceed IEEE field widths, a
                 // malicious prover can substitute {exp-1, mantissa+2^mant_size} for the
                 // canonical {exp, mantissa} and produce the same bits() while denoting a
-                // DIFFERENT real number.  The two range checks below make bits() injective
-                // and pin the unique canonical IEEE decomposition for every generated width.
-                (decoded.exponent as Field).assert_max_bit_size::<$exp_size_u32>();
-                (decoded.mantissa as Field).assert_max_bit_size::<$mant_size_u32>();
+                // DIFFERENT real number.  assert_canonical_fields makes bits() injective
+                // and pins the unique canonical IEEE decomposition for every generated width.
+                // NOTE: circuit-level pinning of the new() call-site (a malicious witness
+                // fed through the prover) is a forge/proving-level obligation tracked under
+                // sq-l9ulg / sq-qhy4 -- the functional tests pin the helper's logic; the
+                // forge suite + audit pin the call-site.
+                Self::assert_canonical_fields(decoded.exponent, decoded.mantissa);
 
                 decoded
             }

--- a/zk/ieee754/src/lib.nr
+++ b/zk/ieee754/src/lib.nr
@@ -475,6 +475,109 @@ fn float_to_i64_rejects_below_min() {
 	let _ = f64::new(0xc3e0000000000001 as u64).to_i64();
 }
 
+// ── sq-3x7dl.1 soundness: negative / forge tests ─────────────────────────────
+//
+// Each test constructs the NON-CANONICAL witness that the audit showed re-encodes
+// to the same bit pattern as the canonical decode, then asserts the added
+// `assert_max_bit_size` constraint in new() REJECTS it.
+//
+// Pattern for each width: {exp-1, mantissa+2^mant_size} gives the same bits()
+// as canonical {exp, mantissa} because:
+//   (exp-1)*2^mant_size + (mantissa+2^mant_size) = exp*2^mant_size + mantissa
+//
+// `should_fail` means the test PASSES only when the circuit panics — i.e.
+// only when the range check correctly rejects the over-wide witness.
+// [SONNET-4.6] sq-3x7dl.1
+
+// ── f32: primary counterexample from the audit ───────────────────────────────
+// bits=0x3F800001 (1.0 + 2^-23). Canonical: {sign:0, exp:127, mant:1}.
+// Malicious:       {sign:0, exp:126, mant:0x800001=8388609}.
+// 126*2^23 + 8388609 = 127*2^23 + 1 = 0x3F800001.
+// 8388609 > 2^23-1=8388607 so assert_max_bit_size::<23> rejects it.
+#[test(should_fail)]
+fn f32_new_rejects_malicious_mantissa_overlap() {
+	let malicious = f32 { sign: false, exponent: 126 as u8, mantissa: 0x800001 as u32 };
+	assert_eq(malicious.bits(), 0x3F800001 as u32);
+	(malicious.mantissa as Field).assert_max_bit_size::<23>();
+}
+
+// ── f16: mantissa-overlap attack ─────────────────────────────────────────────
+// bits=0x1400. Canonical: {exp:5, mant:0}.
+// Malicious {exp:4, mant:1024=2^10}: 4*2^10+1024=5*2^10=0x1400. 1024>2^10-1=1023.
+#[test(should_fail)]
+fn f16_new_rejects_malicious_mantissa_overlap() {
+	let malicious = f16 { sign: false, exponent: 4 as u8, mantissa: 1024 as u16 };
+	assert_eq(malicious.bits(), 0x1400 as u16);
+	(malicious.mantissa as Field).assert_max_bit_size::<10>();
+}
+
+// ── f16: exponent-overflow attack ────────────────────────────────────────────
+// bits=0x8000 (-0). Canonical: {sign:1, exp:0, mant:0}.
+// Malicious {sign:0, exp:32, mant:0}: 32*2^10=0x8000 (same bits).
+// exp=32 overflows the 5-bit IEEE exponent field (max 31).
+#[test(should_fail)]
+fn f16_new_rejects_malicious_exponent_overflow() {
+	let malicious = f16 { sign: false, exponent: 32 as u8, mantissa: 0 as u16 };
+	assert_eq(malicious.bits(), 0x8000 as u16);
+	(malicious.exponent as Field).assert_max_bit_size::<5>();
+}
+
+// ── f64: mantissa-overlap attack ─────────────────────────────────────────────
+// bits=0x3FF0000000000001 (1.0 + ulp). Canonical: {exp:1023, mant:1}.
+// Malicious {exp:1022, mant:2^52+1=4503599627370497}:
+//   1022*2^52 + (2^52+1) = 1023*2^52 + 1 = 0x3FF0000000000001.
+// 4503599627370497 > 2^52-1=4503599627370495.
+#[test(should_fail)]
+fn f64_new_rejects_malicious_mantissa_overlap() {
+	let two_pow_52_plus_1: u64 = (1 as u64 << 52) + 1;
+	let malicious = f64 { sign: false, exponent: 1022 as u16, mantissa: two_pow_52_plus_1 };
+	assert_eq(malicious.bits(), 0x3FF0000000000001 as u64);
+	(malicious.mantissa as Field).assert_max_bit_size::<52>();
+}
+
+// ── f128: mantissa-overlap attack ────────────────────────────────────────────
+// bits=0x3FFF0000000000000000000000000001 (canonical: {exp:16383, mant:1}).
+// Malicious {exp:16382, mant:2^112+1}:
+//   16382*2^112 + (2^112+1) = 16383*2^112 + 1 = bits.
+// 2^112+1 > 2^112-1.
+#[test(should_fail)]
+fn f128_new_rejects_malicious_mantissa_overlap() {
+	let two_pow_112: u128 = 1 as u128 << 112;
+	let malicious = f128 {
+		sign: false,
+		exponent: 16382 as u16,
+		mantissa: two_pow_112 + 1,
+	};
+	assert_eq(malicious.bits(), 0x3FFF0000000000000000000000000001 as u128);
+	(malicious.mantissa as Field).assert_max_bit_size::<112>();
+}
+
+// ── positive: canonical boundary values still accepted ───────────────────────
+// Confirms the fix does NOT break canonical decodes at the max-field boundary.
+#[test]
+fn new_accepts_canonical_boundary_values() {
+	// f16 max mantissa (2^10-1=1023) and max exponent (31=0x1F).
+	let half_max_sub = f16::new(0x03FF as u16); // mant=1023, exp=0
+	assert_eq(half_max_sub.mantissa, 1023 as u16);
+	let half_inf = f16::new(0x7C00 as u16); // exp=31, mant=0
+	assert_eq(half_inf.exponent, 31 as u8);
+
+	// f32 max mantissa (2^23-1=8388607) and max exponent (255).
+	let single_nan_payload = f32::new(0x7FFFFFFF as u32);
+	assert_eq(single_nan_payload.exponent, 255 as u8);
+	assert_eq(single_nan_payload.mantissa, 8388607 as u32);
+
+	// f64 max mantissa (2^52-1=4503599627370495) and max exponent (2047).
+	let double_nan = f64::new(0x7FFFFFFFFFFFFFFF as u64);
+	assert_eq(double_nan.exponent, 2047 as u16);
+	assert_eq(double_nan.mantissa, 4503599627370495 as u64);
+
+	// f128 max mantissa (2^112-1) and max exponent (32767).
+	let quad_nan = f128::new(0x7FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF as u128);
+	assert_eq(quad_nan.exponent, 32767 as u16);
+	assert_eq(quad_nan.mantissa, 5192296858534827628530496329220095 as u128);
+}
+
 #[test]
 fn uint_types_match_float_component_sizes() {
 	comptime {

--- a/zk/ieee754/src/lib.nr
+++ b/zk/ieee754/src/lib.nr
@@ -475,43 +475,49 @@ fn float_to_i64_rejects_below_min() {
 	let _ = f64::new(0xc3e0000000000001 as u64).to_i64();
 }
 
-// ── sq-3x7dl.1 soundness: negative / forge tests ─────────────────────────────
+// -- sq-3x7dl.1 soundness: negative / forge tests ----------------------------
 //
 // Each test constructs the NON-CANONICAL witness that the audit showed re-encodes
-// to the same bit pattern as the canonical decode, then asserts the added
-// `assert_max_bit_size` constraint in new() REJECTS it.
+// to the same bit pattern as the canonical decode, then calls assert_canonical_fields
+// on the malicious struct to verify the range check REJECTS it.
 //
 // Pattern for each width: {exp-1, mantissa+2^mant_size} gives the same bits()
 // as canonical {exp, mantissa} because:
 //   (exp-1)*2^mant_size + (mantissa+2^mant_size) = exp*2^mant_size + mantissa
 //
-// `should_fail` means the test PASSES only when the circuit panics — i.e.
+// `should_fail` means the test PASSES only when the circuit panics -- i.e.
 // only when the range check correctly rejects the over-wide witness.
+//
+// The tests call assert_canonical_fields (not assert_max_bit_size inline) so that
+// deleting the assertions from the helper body turns these tests RED -- pinning the
+// helper's logic against regression.  True circuit-level pinning of the new()
+// call-site (a malicious witness fed through the prover) is a forge/proving-level
+// obligation tracked under sq-l9ulg / sq-qhy4.
 // [SONNET-4.6] sq-3x7dl.1
 
-// ── f32: primary counterexample from the audit ───────────────────────────────
+// -- f32: primary counterexample from the audit -------------------------------
 // bits=0x3F800001 (1.0 + 2^-23). Canonical: {sign:0, exp:127, mant:1}.
 // Malicious:       {sign:0, exp:126, mant:0x800001=8388609}.
 // 126*2^23 + 8388609 = 127*2^23 + 1 = 0x3F800001.
-// 8388609 > 2^23-1=8388607 so assert_max_bit_size::<23> rejects it.
+// 8388609 > 2^23-1=8388607 so assert_canonical_fields rejects it.
 #[test(should_fail)]
 fn f32_new_rejects_malicious_mantissa_overlap() {
 	let malicious = f32 { sign: false, exponent: 126 as u8, mantissa: 0x800001 as u32 };
 	assert_eq(malicious.bits(), 0x3F800001 as u32);
-	(malicious.mantissa as Field).assert_max_bit_size::<23>();
+	f32::assert_canonical_fields(malicious.exponent, malicious.mantissa);
 }
 
-// ── f16: mantissa-overlap attack ─────────────────────────────────────────────
+// -- f16: mantissa-overlap attack ---------------------------------------------
 // bits=0x1400. Canonical: {exp:5, mant:0}.
 // Malicious {exp:4, mant:1024=2^10}: 4*2^10+1024=5*2^10=0x1400. 1024>2^10-1=1023.
 #[test(should_fail)]
 fn f16_new_rejects_malicious_mantissa_overlap() {
 	let malicious = f16 { sign: false, exponent: 4 as u8, mantissa: 1024 as u16 };
 	assert_eq(malicious.bits(), 0x1400 as u16);
-	(malicious.mantissa as Field).assert_max_bit_size::<10>();
+	f16::assert_canonical_fields(malicious.exponent, malicious.mantissa);
 }
 
-// ── f16: exponent-overflow attack ────────────────────────────────────────────
+// -- f16: exponent-overflow attack --------------------------------------------
 // bits=0x8000 (-0). Canonical: {sign:1, exp:0, mant:0}.
 // Malicious {sign:0, exp:32, mant:0}: 32*2^10=0x8000 (same bits).
 // exp=32 overflows the 5-bit IEEE exponent field (max 31).
@@ -519,10 +525,10 @@ fn f16_new_rejects_malicious_mantissa_overlap() {
 fn f16_new_rejects_malicious_exponent_overflow() {
 	let malicious = f16 { sign: false, exponent: 32 as u8, mantissa: 0 as u16 };
 	assert_eq(malicious.bits(), 0x8000 as u16);
-	(malicious.exponent as Field).assert_max_bit_size::<5>();
+	f16::assert_canonical_fields(malicious.exponent, malicious.mantissa);
 }
 
-// ── f64: mantissa-overlap attack ─────────────────────────────────────────────
+// -- f64: mantissa-overlap attack ---------------------------------------------
 // bits=0x3FF0000000000001 (1.0 + ulp). Canonical: {exp:1023, mant:1}.
 // Malicious {exp:1022, mant:2^52+1=4503599627370497}:
 //   1022*2^52 + (2^52+1) = 1023*2^52 + 1 = 0x3FF0000000000001.
@@ -532,10 +538,10 @@ fn f64_new_rejects_malicious_mantissa_overlap() {
 	let two_pow_52_plus_1: u64 = (1 as u64 << 52) + 1;
 	let malicious = f64 { sign: false, exponent: 1022 as u16, mantissa: two_pow_52_plus_1 };
 	assert_eq(malicious.bits(), 0x3FF0000000000001 as u64);
-	(malicious.mantissa as Field).assert_max_bit_size::<52>();
+	f64::assert_canonical_fields(malicious.exponent, malicious.mantissa);
 }
 
-// ── f128: mantissa-overlap attack ────────────────────────────────────────────
+// -- f128: mantissa-overlap attack --------------------------------------------
 // bits=0x3FFF0000000000000000000000000001 (canonical: {exp:16383, mant:1}).
 // Malicious {exp:16382, mant:2^112+1}:
 //   16382*2^112 + (2^112+1) = 16383*2^112 + 1 = bits.
@@ -549,10 +555,10 @@ fn f128_new_rejects_malicious_mantissa_overlap() {
 		mantissa: two_pow_112 + 1,
 	};
 	assert_eq(malicious.bits(), 0x3FFF0000000000000000000000000001 as u128);
-	(malicious.mantissa as Field).assert_max_bit_size::<112>();
+	f128::assert_canonical_fields(malicious.exponent, malicious.mantissa);
 }
 
-// ── positive: canonical boundary values still accepted ───────────────────────
+// -- positive: canonical boundary values still accepted -----------------------
 // Confirms the fix does NOT break canonical decodes at the max-field boundary.
 #[test]
 fn new_accepts_canonical_boundary_values() {


### PR DESCRIPTION
> 🤖 SPARQ agent — soundness fix for @jeswr's review. DO NOT arm — this circuit change requires independent adversarial verify.

## Summary

This PR fixes **sq-3x7dl.1**, a HIGH-severity circuit-soundness hole in `zk/ieee754/src/codegen.nr` identified by the upstream audit and documented in `research/zk-correctness-and-proof-program.md §1.1`.

### The bug (under-constrained decode)

`new(bits)` decoded the raw bit pattern into `(sign, exponent, mantissa)` via an `unconstrained` witness and only asserted `decoded.bits() == bits`. Because

```
bits() = sign * 2^(W-1) + exponent * 2^mant_size + mantissa
```

is **non-injective** when the struct field types are wider than the real IEEE fields (mantissa `u16/u32/u64/u128` vs 10/23/52/112 bits; exponent `u8/u16` vs 5/11/15 bits), a malicious prover can substitute `{exp-1, mantissa+2^mant_size}` for the canonical `{exp, mantissa}`. This re-encodes to the same `bits()` value but denotes a **different real number**, allowing false float statements to be proved.

**Concrete f32 counterexample** (`bits = 0x3F800001`, true value 1 + 2⁻²³):

| Witness | sign | exp | mantissa | bits() | Real value |
|---------|------|-----|----------|--------|------------|
| Canonical | 0 | 127 | 1 | `0x3F800001` | 1 + 2⁻²³ |
| Malicious | 0 | 126 | `0x800001 = 8388609` | `0x3F800001` | 1 + 2⁻²⁴ |

`126 * 2^23 + 8388609 = 127 * 2^23 + 1` — identical. The malicious mantissa `8388609 > 2^23-1 = 8388607` fits in `u32` but overflows the 23-bit IEEE mantissa field. The same `{exp-1, mantissa+2^mant_size}` attack applies to every width.

### The fix

In the constrained side of `new()`, immediately after the existing `assert_eq(decoded.bits(), bits)`, add two range checks mirroring the `assert_max_bit_size` discipline already used in `kernels.nr`:

```noir
(decoded.exponent as Field).assert_max_bit_size::<$exp_size_u32>();
(decoded.mantissa as Field).assert_max_bit_size::<$mant_size_u32>();
```

`$exp_size_u32` and `$mant_size_u32` are comptime-substituted `u32` constants per width:

| Width | exp bits (EXP_SIZE) | mant bits (MANT_SIZE) |
|-------|--------------------|-----------------------|
| f16 | 5 | 10 |
| f32 | 8 | 23 |
| f64 | 11 | 52 |
| f128 | 15 | 112 |

This makes `bits()` injective and pins the unique canonical IEEE decomposition for every generated width. The cost is 2 additional range constraints per `new()` call — accepted and expected as the soundness cost.

### Tests added

- **`f32_new_rejects_malicious_mantissa_overlap`** `[should_fail]` — the concrete audit counterexample: `{exp:126, mant:0x800001}` re-encodes to `0x3F800001` but `assert_max_bit_size::<23>()` panics because `8388609 > 2^23-1`.
- **`f16_new_rejects_malicious_mantissa_overlap`** `[should_fail]` — f16 mantissa overflow: `{exp:4, mant:1024}` re-encodes to `0x1400`; `1024 > 2^10-1=1023`.
- **`f16_new_rejects_malicious_exponent_overflow`** `[should_fail]` — f16 exponent overflow: `{sign:false, exp:32, mant:0}` re-encodes to `0x8000` (same bits as -0); `32` overflows 5-bit exponent.
- **`f64_new_rejects_malicious_mantissa_overlap`** `[should_fail]` — f64 mantissa overflow: `{exp:1022, mant:2^52+1}` re-encodes to `0x3FF0000000000001`.
- **`f128_new_rejects_malicious_mantissa_overlap`** `[should_fail]` — f128 mantissa overflow: `{exp:16382, mant:2^112+1}` re-encodes to `0x3FFF0000000000000000000000000001`.
- **`new_accepts_canonical_boundary_values`** — positive test: canonical max-field values for all four widths still pass `new()` without triggering the new constraints.

All pre-existing `lib.nr` tests cover the honest canonical prover path and are unaffected.

### Gate delta

A small increase in UltraHonk gate count per `new()` call (2 range constraints added). This is the intentional soundness cost. `nargo`/`bb` are not on this box — sq-3x7dl.13 will wire the CI lane. Correctness verified by code-read and formal reasoning against the IEEE 754 bit-layout spec.

### Do NOT arm

This change sits at the ZK trust boundary. Per AGENTS.md it requires independent adversarial verify before arming. The `sq-qhy4` external cryptographer audit is the master gate.

## Files changed

- `zk/ieee754/src/codegen.nr` — two `assert_max_bit_size` calls added to `new()`, plus two comptime u32 size variables
- `zk/ieee754/src/lib.nr` — 5 `should_fail` forge tests + 1 positive boundary test
- `zk/ieee754/README.md` — `new()` API doc updated with soundness invariant
- `zk/ieee754/AGENTS.md` — soundness invariant documented for future agents

Refs: sq-3x7dl.1, bead parent sq-3x7dl.

🤖 SPARQ agent [SONNET-4.6]