### PR TITLE
feat(reason-dl): L3 ALCH tableau consistency core with subset-blocking termination argument (sq-pbz04.4.3) [FABLE-5]

### DIFF
--- a/crates/sparq-reason-dl/README.md
+++ b/crates/sparq-reason-dl/README.md
@@ -4,16 +4,19 @@
   <a href="../../LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License: MIT"></a>
 </p>
 
-**Opt-in OWL 2 Direct-Semantics support** for the [sparq](../../README.md) RDF engine. This is
-**layer L1** of a layered, fail-closed Direct-Semantics checker: a purely **structural OWL
-model** for the **ALCH** fragment plus a **fail-closed reverse RDF mapping** (RDF graph → typed
-model). It is a **separate crate** — `sparq-core`, `sparq-engine`, and the wasm build carry zero
-Direct-Semantics code, deps, or cost by default; DL is engaged only by depending on this crate.
+**Opt-in OWL 2 Direct-Semantics support** for the [sparq](../../README.md) RDF engine — a
+layered, fail-closed Direct-Semantics checker. **Built: L1** (structural **ALCH** model +
+fail-closed reverse RDF mapping), **L2** (syntactic EL/QL/RL profile checker), and **L3** (the
+terminating **ALCH tableau** — consistency + class satisfiability). It is a **separate crate** —
+`sparq-core`, `sparq-engine`, and the wasm build carry zero Direct-Semantics code, deps, or cost
+by default; DL is engaged only by depending on this crate.
 
-> **Honest scope.** This crate does **not** implement OWL 2 DL. L1 is a **scoped ALCH-fragment
-> structural layer with no reasoning at all** — it turns an RDF graph into a model it understood
-> *in full*, or refuses it. The profile checker, ALCH tableau, and dispatch checker land in later
-> beads (sq-pbz04.4.2 / .3 / .4). See the design record for the full scope and deferral ledger.
+> **Honest scope.** This crate does **not** implement OWL 2 DL. The tableau is sound and
+> complete **only for the exact ALCH fragment** (named classes, ⊤/⊥, ⊓/⊔/¬, ∃/∀ over named
+> object properties, GCIs, `rdfs:subPropertyOf`, ground ABox) — anything else is refused
+> fail-closed as `Unknown(OutOfFragment)` BEFORE reasoning, and deterministic count-budget
+> exhaustion is `Unknown(ResourceBudget)`, never a verdict. The fragment-dispatch checker (L4)
+> lands in bead sq-pbz04.4.4. See the design record for the full scope and deferral ledger.
 
 ## 🚀 Quickstart
 
@@ -61,16 +64,24 @@ match extract(&dict, &triples) {
   test; annotations, declarations, and ontology headers are recognised and ignored (they carry
   no ALCH-logical import).
 
-**Profile checker (L2, bead sq-pbz04.4.2):** the `profile` module is NOW BUILT. Call
-`profile::profiles(onto)` to check OWL 2 EL/QL/RL profile membership of a structural ontology
-via a purely syntactic grammar walk (W3C OWL 2 Profiles §2/§3/§4). Returns a `ProfileSet` with
-`el`, `ql`, and `rl` fields each holding `Membership::In`, `Membership::NotIn(reason)`, or
-`Membership::Unknown(err)` (only from `profile::profiles_from_extraction` on an extraction
-failure). An empty ontology is `In` all three profiles. Terminating by construction, no semantic
-reasoning.
+**Profile checker (L2, bead sq-pbz04.4.2):** `profile::profiles(onto)` checks OWL 2 EL/QL/RL
+profile membership via a purely syntactic grammar walk (W3C OWL 2 Profiles §2/§3/§4), returning
+a `ProfileSet` of `Membership::In` / `NotIn(reason)` / `Unknown(err)` (the latter only from
+`profile::profiles_from_extraction` on an extraction failure). Terminating by construction, no
+semantic reasoning.
 
-**Reserved (empty stubs):** `nnf`/`tableau` (L3) and `check` (L4) modules are pre-declared
-stubs with no logic — they are populated by the later beads without touching `lib.rs`.
+**ALCH tableau (L3, bead sq-pbz04.4.3):** `tableau::consistency(&Ontology, Budget)` and
+`tableau::class_satisfiability(&ClassExpression, &Ontology, Budget)` decide
+consistency / class satisfiability for the ALCH fragment via a completion-forest tableau —
+GCI internalisation, rules matched modulo the `subPropertyOf` closure, **ancestor subset
+blocking** (sufficient precisely because ALCH has no inverse roles), backtracking over
+⊔-branches. `tableau::consistency_from_extraction` is the fail-closed RDF-level entry. Verdicts
+are tri-state (`Satisfiable` / `Unsatisfiable` / `Unknown`); budgets are deterministic COUNTS
+(`max_nodes` / `max_rule_applications` — wall-clock banned). The termination + soundness +
+completeness argument (Baader–Sattler 2001) is reproduced in the `tableau` module docs. `nnf`
+supplies negation normal form and the finite subexpression closure the argument rests on.
+
+**Reserved (empty stub):** `check` (L4 fragment dispatch + entailment-by-refutation).
 **Deferred** (each rejected, never mis-mapped): inverse roles, cardinality/functionality,
 nominals (`owl:oneOf`/`owl:hasValue`), transitivity, `sameAs`/`differentFrom`, datatypes, keys —
 with a named reason and unlock path in the design record's deferral ledger.

--- a/crates/sparq-reason-dl/src/nnf.rs
+++ b/crates/sparq-reason-dl/src/nnf.rs
@@ -1,7 +1,249 @@
-//! L3 (part 1) — negation normal form + the `sub(O)` subexpression closure (RESERVED STUB).
+//! L3 (part 1) — negation normal form + the `sub(O)` subexpression closure.
 //!
-//! 🤖 SPARQ agent [FABLE-5]. Populated by bead sq-pbz04.4.3. This module will lower a
-//! `crate::model::ClassExpression` into negation normal form and build the finite subexpression
-//! closure the ALCH tableau expands over. It is intentionally empty in L1 (design record
-//! `research/owl2-direct-semantics-scoping.md` §3/§7): the scaffold pre-declares it so the L3
-//! bead never has to touch `lib.rs`.
+//! 🤖 SPARQ agent [FABLE-5]. Bead sq-pbz04.4.3 (epic sq-pbz04.4, design record
+//! `research/owl2-direct-semantics-scoping.md` §3). This module lowers a
+//! [`crate::model::ClassExpression`] into **negation normal form** (NNF) and builds the
+//! finite **subexpression closure** the ALCH tableau (`crate::tableau`) expands over.
+//!
+//! # Negation normal form
+//! A class expression is in NNF when negation ([`ClassExpression::ObjectComplementOf`])
+//! applies **only to named classes** ([`ClassExpression::Class`]). Every ALCH class
+//! expression has a logically **equivalent** NNF, obtained by the standard rewrites
+//! (see Baader & Sattler, *An Overview of Tableau Algorithms for Description Logics*,
+//! Studia Logica 69, 2001, §2):
+//!
+//! ```text
+//! ¬⊤ ⇝ ⊥                      ¬⊥ ⇝ ⊤                      ¬¬C ⇝ C
+//! ¬(C₁ ⊓ … ⊓ Cₙ) ⇝ ¬C₁ ⊔ … ⊔ ¬Cₙ      (De Morgan)
+//! ¬(C₁ ⊔ … ⊔ Cₙ) ⇝ ¬C₁ ⊓ … ⊓ ¬Cₙ      (De Morgan)
+//! ¬(∃R.C) ⇝ ∀R.¬C             ¬(∀R.C) ⇝ ∃R.¬C             (quantifier duality)
+//! ```
+//!
+//! Each rewrite is a classical logical equivalence under the OWL 2 Direct Semantics
+//! (which interprets the ALCH constructors exactly as classical ALC does), so
+//! `nnf(C) ≡ C` and `nnf_complement(C) ≡ ¬C` in every interpretation. NNF does not
+//! duplicate subterms — every input operator is visited once and mapped to exactly one
+//! output operator — so the output size is linear in the input size.
+//!
+//! Why the tableau wants NNF: with negation confined to named classes, a **clash** is
+//! detectable purely locally as `{A, ¬A}` in one node label (or `⊥` in a label), and the
+//! completion rules need no rule for pushing negations around at expansion time.
+//!
+//! # The subexpression closure `sub(O)`
+//! [`subexpression_closure`] computes, for a set of (NNF) seed expressions, the set of
+//! **all** their subexpressions — deduplicated, in deterministic first-visit preorder.
+//! This set is finite and its size is linear in the total size of the seeds. It is the
+//! load-bearing finiteness witness of the tableau's termination argument
+//! (`crate::tableau` module docs, step 1): every node label the tableau ever builds is a
+//! subset of the closure of its preprocessed input, because the completion rules only
+//! ever add (a) subexpressions of concepts already present or (b) the fixed internalised
+//! GCI constraints, which are themselves seeds.
+//!
+//! Fragment note: these functions are total over the L1 [`crate::model`] types, which by
+//! construction admit ONLY the ALCH fragment (no inverses, cardinality, nominals,
+//! datatypes). Nothing here extends the fragment.
+
+use crate::model::ClassExpression;
+use rustc_hash::FxHashSet;
+
+/// Rewrite a class expression into an equivalent negation normal form.
+///
+/// The result contains [`ClassExpression::ObjectComplementOf`] only directly around a
+/// [`ClassExpression::Class`] (see the module docs for the rewrite system and the
+/// equivalence argument). Idempotent: `nnf(&nnf(c)) == nnf(c)`.
+#[must_use]
+pub fn nnf(ce: &ClassExpression) -> ClassExpression {
+    match ce {
+        ClassExpression::Class(_) | ClassExpression::Thing | ClassExpression::Nothing => {
+            ce.clone()
+        }
+        ClassExpression::ObjectIntersectionOf(members) => {
+            ClassExpression::ObjectIntersectionOf(members.iter().map(nnf).collect())
+        }
+        ClassExpression::ObjectUnionOf(members) => {
+            ClassExpression::ObjectUnionOf(members.iter().map(nnf).collect())
+        }
+        // ¬C: push the negation inward over C.
+        ClassExpression::ObjectComplementOf(inner) => nnf_complement(inner),
+        ClassExpression::ObjectSomeValuesFrom(p, filler) => {
+            ClassExpression::ObjectSomeValuesFrom(p.clone(), Box::new(nnf(filler)))
+        }
+        ClassExpression::ObjectAllValuesFrom(p, filler) => {
+            ClassExpression::ObjectAllValuesFrom(p.clone(), Box::new(nnf(filler)))
+        }
+    }
+}
+
+/// The negation normal form of the **complement** of a class expression:
+/// `nnf_complement(c) == nnf(¬c)`, without materialising the intermediate `¬c`.
+///
+/// Used by the tableau's GCI internalisation (`C ⊑ D` becomes the universal constraint
+/// `nnf(¬C) ⊔ nnf(D)`) and by the class-satisfiability entry point.
+#[must_use]
+pub fn nnf_complement(ce: &ClassExpression) -> ClassExpression {
+    match ce {
+        // ¬A for a named class A: already NNF.
+        ClassExpression::Class(_) => ClassExpression::ObjectComplementOf(Box::new(ce.clone())),
+        // ¬⊤ ⇝ ⊥ and ¬⊥ ⇝ ⊤.
+        ClassExpression::Thing => ClassExpression::Nothing,
+        ClassExpression::Nothing => ClassExpression::Thing,
+        // De Morgan.
+        ClassExpression::ObjectIntersectionOf(members) => {
+            ClassExpression::ObjectUnionOf(members.iter().map(nnf_complement).collect())
+        }
+        ClassExpression::ObjectUnionOf(members) => {
+            ClassExpression::ObjectIntersectionOf(members.iter().map(nnf_complement).collect())
+        }
+        // ¬¬C ⇝ C (then normalise C itself).
+        ClassExpression::ObjectComplementOf(inner) => nnf(inner),
+        // Quantifier duality.
+        ClassExpression::ObjectSomeValuesFrom(p, filler) => {
+            ClassExpression::ObjectAllValuesFrom(p.clone(), Box::new(nnf_complement(filler)))
+        }
+        ClassExpression::ObjectAllValuesFrom(p, filler) => {
+            ClassExpression::ObjectSomeValuesFrom(p.clone(), Box::new(nnf_complement(filler)))
+        }
+    }
+}
+
+/// `true` iff the expression is in negation normal form — every
+/// [`ClassExpression::ObjectComplementOf`] applies directly to a named
+/// [`ClassExpression::Class`] (so `¬⊤`, `¬⊥`, `¬¬C`, `¬(C ⊓ D)`, `¬∃R.C`, … all fail).
+///
+/// This is the structural invariant [`nnf`] and [`nnf_complement`] establish; the tableau
+/// debug-asserts it on its preprocessed input.
+#[must_use]
+pub fn is_nnf(ce: &ClassExpression) -> bool {
+    match ce {
+        ClassExpression::Class(_) | ClassExpression::Thing | ClassExpression::Nothing => true,
+        ClassExpression::ObjectComplementOf(inner) => {
+            matches!(inner.as_ref(), ClassExpression::Class(_))
+        }
+        ClassExpression::ObjectIntersectionOf(members)
+        | ClassExpression::ObjectUnionOf(members) => members.iter().all(is_nnf),
+        ClassExpression::ObjectSomeValuesFrom(_, filler)
+        | ClassExpression::ObjectAllValuesFrom(_, filler) => is_nnf(filler),
+    }
+}
+
+/// The subexpression closure of a set of seed class expressions: every seed plus every
+/// (transitive) subexpression of a seed, deduplicated, in deterministic first-visit
+/// preorder over the seed slice.
+///
+/// For NNF seeds this is the finite `sub(O)` universe of the tableau's termination
+/// argument (module docs above; `crate::tableau` module docs step 1). Its length is
+/// linear in the total size of the seeds. Subexpressions of an NNF expression are
+/// themselves NNF, so the closure of NNF seeds is entirely NNF.
+#[must_use]
+pub fn subexpression_closure(seeds: &[ClassExpression]) -> Vec<ClassExpression> {
+    let mut seen: FxHashSet<ClassExpression> = FxHashSet::default();
+    let mut out: Vec<ClassExpression> = Vec::new();
+    for seed in seeds {
+        visit(seed, &mut seen, &mut out);
+    }
+    out
+}
+
+/// Preorder DFS collecting `ce` and all its subexpressions into `out` (first visit wins).
+fn visit(
+    ce: &ClassExpression,
+    seen: &mut FxHashSet<ClassExpression>,
+    out: &mut Vec<ClassExpression>,
+) {
+    if !seen.insert(ce.clone()) {
+        return;
+    }
+    out.push(ce.clone());
+    match ce {
+        ClassExpression::Class(_) | ClassExpression::Thing | ClassExpression::Nothing => {}
+        ClassExpression::ObjectIntersectionOf(members)
+        | ClassExpression::ObjectUnionOf(members) => {
+            for m in members {
+                visit(m, seen, out);
+            }
+        }
+        ClassExpression::ObjectComplementOf(inner) => visit(inner, seen, out),
+        ClassExpression::ObjectSomeValuesFrom(_, filler)
+        | ClassExpression::ObjectAllValuesFrom(_, filler) => visit(filler, seen, out),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::ClassExpression as CE;
+
+    fn a() -> CE {
+        CE::Class(1)
+    }
+    fn b() -> CE {
+        CE::Class(2)
+    }
+    fn not(c: CE) -> CE {
+        CE::ObjectComplementOf(Box::new(c))
+    }
+
+    #[test]
+    fn nnf_pushes_negation_to_named_classes() {
+        // ¬(A ⊓ ∃R.B) ⇝ ¬A ⊔ ∀R.¬B  (De Morgan + quantifier duality)
+        let input = not(CE::ObjectIntersectionOf(vec![a(), CE::some(10, b())]));
+        let expected = CE::ObjectUnionOf(vec![not(a()), CE::only(10, not(b()))]);
+        assert_eq!(nnf(&input), expected);
+        // ¬¬A ⇝ A; ¬⊤ ⇝ ⊥; ¬⊥ ⇝ ⊤; leaves are fixed points.
+        assert_eq!(nnf(&not(not(a()))), a());
+        assert_eq!(nnf(&not(CE::Thing)), CE::Nothing);
+        assert_eq!(nnf(&not(CE::Nothing)), CE::Thing);
+        assert_eq!(nnf(&a()), a());
+        // Idempotent, and the result satisfies is_nnf.
+        let once = nnf(&input);
+        assert_eq!(nnf(&once), once);
+        assert!(is_nnf(&once));
+    }
+
+    #[test]
+    fn nnf_complement_is_nnf_of_negation() {
+        // nnf_complement(C) must equal nnf(¬C) for every constructor.
+        let cases = vec![
+            a(),
+            CE::Thing,
+            CE::Nothing,
+            not(a()),
+            CE::ObjectIntersectionOf(vec![a(), b()]),
+            CE::ObjectUnionOf(vec![a(), not(b())]),
+            CE::some(10, CE::ObjectUnionOf(vec![a(), b()])),
+            CE::only(10, not(a())),
+        ];
+        for c in cases {
+            assert_eq!(nnf_complement(&c), nnf(&not(c.clone())), "case {:?}", c);
+            assert!(is_nnf(&nnf_complement(&c)), "case {:?}", c);
+        }
+    }
+
+    #[test]
+    fn is_nnf_accepts_nnf_and_rejects_buried_negation() {
+        assert!(is_nnf(&a()));
+        assert!(is_nnf(&not(a())));
+        assert!(is_nnf(&CE::only(10, CE::ObjectUnionOf(vec![not(a()), b()]))));
+        // Negation over anything but a named class is NOT NNF.
+        assert!(!is_nnf(&not(CE::Thing)));
+        assert!(!is_nnf(&not(not(a()))));
+        assert!(!is_nnf(&not(CE::ObjectIntersectionOf(vec![a(), b()]))));
+        assert!(!is_nnf(&CE::some(10, not(CE::ObjectUnionOf(vec![a(), b()])))));
+    }
+
+    #[test]
+    fn subexpression_closure_dedups_in_first_visit_order() {
+        // seeds: [∃R.(A ⊓ B), A] — A occurs both nested and as a seed; counted once.
+        let seed0 = CE::some(10, CE::ObjectIntersectionOf(vec![a(), b()]));
+        let closure = subexpression_closure(&[seed0.clone(), a()]);
+        assert_eq!(
+            closure,
+            vec![seed0, CE::ObjectIntersectionOf(vec![a(), b()]), a(), b()]
+        );
+        // Empty seed set: empty closure.
+        assert!(subexpression_closure(&[]).is_empty());
+        // Closure of NNF seeds is entirely NNF.
+        let seeds = vec![CE::ObjectUnionOf(vec![not(a()), CE::only(10, b())])];
+        assert!(subexpression_closure(&seeds).iter().all(is_nnf));
+    }
+}

--- a/crates/sparq-reason-dl/src/tableau.rs
+++ b/crates/sparq-reason-dl/src/tableau.rs
@@ -263,7 +263,9 @@ use std::collections::BTreeSet;
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct Budget {
     /// Maximum total number of forest nodes ever created (roots included). If the ABox
-    /// alone needs more roots than this, the run returns `Unknown` immediately.
+    /// alone needs more roots than this, the run returns `Unknown` immediately — unless
+    /// the asserted facts already clash while seeding, in which case `Unsatisfiable` is
+    /// returned first (the verdict is sound: a seed clash needs no further expansion).
     pub max_nodes: usize,
     /// Maximum total number of completion-rule applications, counting each concept
     /// addition, each ⊔-disjunct trial, and each ∃-expansion — including work re-done

--- a/crates/sparq-reason-dl/src/tableau.rs
+++ b/crates/sparq-reason-dl/src/tableau.rs
@@ -1,10 +1,1041 @@
-//! L3 (part 2) — the terminating ALCH tableau (RESERVED STUB).
+//! L3 (part 2) — the terminating ALCH tableau: consistency + class satisfiability.
 //!
-//! 🤖 SPARQ agent [FABLE-5]. Populated by bead sq-pbz04.4.3. This module will implement the
-//! consistency / class-satisfiability decision procedure for ALCH with general TBoxes and a
-//! ground ABox — a completion forest with the `⊓`/`⊔`/`∃`/`∀`/GCI rules and ANCESTOR SUBSET
-//! BLOCKING, whose termination and soundness/completeness argument (valid precisely because
-//! ALCH has no inverse roles) is reproduced in this module's docs as part of that bead's
-//! acceptance. It is intentionally empty in L1 (design record
-//! `research/owl2-direct-semantics-scoping.md` §3/§7): the scaffold pre-declares it so the L3
-//! bead never has to touch `lib.rs`.
+//! 🤖 SPARQ agent [FABLE-5]. Bead sq-pbz04.4.3 (epic sq-pbz04.4, design record
+//! `research/owl2-direct-semantics-scoping.md` §3). A completion-forest tableau with GCI
+//! internalisation, the `⊓`/`⊔`/`∃`/`∀`/GCI completion rules matched modulo the role
+//! hierarchy, ancestor **subset blocking**, and chronological backtracking over
+//! `⊔`-branches. The termination / soundness / completeness argument is reproduced in
+//! full below (§3–§5), following Baader & Sattler, *An Overview of Tableau Algorithms
+//! for Description Logics*, Studia Logica 69(1):5–40, 2001.
+//!
+//! # 1. Fragment (exactly ALCH — nothing more)
+//!
+//! - **Concepts:** named classes, `owl:Thing` (⊤), `owl:Nothing` (⊥), `⊓`, `⊔`, `¬`,
+//!   `∃R.C`, `∀R.C` over **named** object properties only.
+//! - **TBox:** arbitrary GCIs `C ⊑ D`; `owl:equivalentClass` as two GCIs;
+//!   `owl:disjointWith` as `C ⊓ D ⊑ ⊥`; `rdfs:domain` as `∃R.⊤ ⊑ C`; `rdfs:range` as
+//!   `⊤ ⊑ ∀R.C`.
+//! - **RBox:** `rdfs:subPropertyOf` hierarchies over named object properties; `⊑*` is
+//!   the reflexive-transitive closure of the asserted inclusions.
+//! - **ABox:** ground class assertions `C(a)` and role assertions `R(a, b)`.
+//! - **NOT in the fragment** (and structurally unrepresentable in [`crate::model`]):
+//!   inverse roles, transitivity and all other role characteristics, cardinality /
+//!   functionality, nominals (`oneOf`/`hasValue`), datatypes and data properties,
+//!   `owl:sameAs` / `owl:differentFrom`, property chains, keys. The L1 extractor
+//!   ([`crate::extract()`]) fail-closes on all of them, so
+//!   [`consistency_from_extraction`] returns [`UnknownReason::OutOfFragment`] **before
+//!   the tableau starts** — an out-of-fragment input never receives a verdict.
+//!
+//! # 2. The procedure
+//!
+//! **Preprocessing.** Every TBox axiom is desugared to GCIs as above and each GCI
+//! `Cᵢ ⊑ Dᵢ` is **internalised** into the universal constraint
+//! `Uᵢ = nnf(¬Cᵢ) ⊔ nnf(Dᵢ)` (negation normal form via [`crate::nnf`]; NNF is an
+//! equivalence-preserving rewrite). ABox class assertions are NNF'd and seeded into the
+//! labels of their individuals' **root nodes**; ABox role assertions become edges
+//! between roots. When there is no ABox individual, a single fresh unconstrained root is
+//! created: the OWL 2 Direct Semantics interprets over **non-empty** domains, so
+//! TBox-only inconsistencies such as `⊤ ⊑ ⊥` are still caught. For class
+//! satisfiability of `C` an extra fresh root labelled `{nnf(C)}` is added (`C` is
+//! satisfiable w.r.t. `O` iff `O ∪ {C(a_fresh)}` is consistent, `a_fresh` occurring
+//! nowhere else). Every concept that can ever appear in a label is interned into a
+//! fixed table up front; expansion manipulates only table indices and **cannot mint a
+//! new concept** (debug-asserted against `nnf::subexpression_closure`).
+//!
+//! **Completion rules** (on the current label `L(x)`; `S ⊑* R` written for the role
+//! closure):
+//!
+//! - **GCI-rule:** if `Uᵢ ∉ L(x)` for some internalised constraint: add `Uᵢ` to `L(x)`.
+//! - **⊓-rule:** if `(C₁ ⊓ … ⊓ Cₙ) ∈ L(x)` and some `Cᵢ ∉ L(x)`: add every `Cᵢ`.
+//! - **∀-rule:** if `∀R.C ∈ L(x)`, there is an edge `x –S→ y` with `S ⊑* R`, and
+//!   `C ∉ L(y)`: add `C` to `L(y)`.
+//! - **⊔-rule:** if `(C₁ ⊔ … ⊔ Cₙ) ∈ L(x)` and no `Cᵢ ∈ L(x)`: **choose** some `Cᵢ`
+//!   and add it (the only nondeterministic rule; explored by chronological
+//!   backtracking, disjuncts left to right).
+//! - **∃-rule:** if `∃R.C ∈ L(x)`, `x` is **not blocked** (below), and there is no edge
+//!   `x –S→ y` with `S ⊑* R` and `C ∈ L(y)`: create a fresh tree successor `y` of `x`
+//!   with edge label `R` and `L(y) = {C}`.
+//!
+//! A **clash** is `⊥ ∈ L(x)` or `{A, ¬A} ⊆ L(x)` for a named class `A` (in NNF these
+//! are the only inconsistent local patterns); a clash anywhere abandons the branch. A
+//! branch with no applicable rule is **quiescent** and yields `Satisfiable`; when every
+//! branch clashes the input is `Unsatisfiable`.
+//!
+//! **Blocking (ancestor subset blocking).** A node `y` is *blocked* iff some non-root
+//! node `v` on the tree path from `y`'s root down to `y` (including `y` itself) has an
+//! ancestor `x` in that path with `L(v) ⊆ L(x)`. This explicit form is equivalent to
+//! the standard recursive definition — "`v` is *directly blocked* iff no strict
+//! ancestor of `v` is directly blocked and `L(v) ⊆ L(x)` for some ancestor `x`; `y` is
+//! blocked iff `y` or a strict ancestor of `y` is directly blocked" — because the
+//! *topmost* `v` with the subset property is exactly the directly blocked one. Roots
+//! (ABox individuals, the fresh roots) are never blocked, but a root **may serve as a
+//! blocker**: soundness of that is argued in §5 (it needs no inverse roles). Blocking
+//! gates **only** the ∃-rule and is re-evaluated on the *current* labels at every
+//! prospective application — never cached. All other rules keep firing on and into
+//! blocked nodes; in particular the ∀-rule keeps propagating into a blocked node, so
+//! the subset test is never made against a stale label (labels grow monotonically: a
+//! blocked node can become unblocked when its label outgrows its blocker's, and the
+//! implementation must — and does — notice).
+//!
+//! # 3. Termination (following Baader & Sattler 2001, the ALC-with-GCIs configuration;
+//! role hierarchies change nothing because blocking is label-based only)
+//!
+//! 1. **Finite closure.** Let `sub(O)` be the subexpression closure
+//!    ([`crate::nnf::subexpression_closure`]) of the preprocessed input: all `Uᵢ`, the
+//!    NNF of every ABox-asserted concept, and (for class satisfiability) `nnf(C)`.
+//!    `sub(O)` is finite and linear in the input size (NNF does not duplicate
+//!    subterms). Every label is always a subset of `sub(O)`: the seeds are members, and
+//!    each rule adds only ⊓/⊔-members or ∃/∀-fillers of concepts already in some label
+//!    (all subexpressions), or a `Uᵢ` (a seed). The implementation enforces this
+//!    structurally — the closure is interned before expansion and the rules move only
+//!    indices. Hence at most `2^|sub(O)|` distinct labels exist.
+//! 2. **Monotone rules.** Within one branch, rules only add concepts to labels or add
+//!    nodes and edges; nothing is ever removed (backtracking abandons a branch and
+//!    resumes from a snapshot of an earlier choice point — it never shrinks a label
+//!    within a branch). Each rule instance's applicability is extinguished by the very
+//!    addition it makes, so on a fixed node set only finitely many applications occur.
+//! 3. **Depth bound — where blocking is load-bearing.** Only the ∃-rule lengthens a
+//!    tree path, and it is gated on the focus node being unblocked. Suppose it is about
+//!    to fire on a node `y` whose tree path from its root contains more than
+//!    `2^|sub(O)|` non-root nodes. By (1) and pigeonhole, two nodes on that path carry
+//!    *equal* labels at this instant; the lower one, `v`, then satisfies `L(v) ⊆ L(x)`
+//!    for its ancestor `x` — so `y` is blocked by the §2 definition (`v` lies on `y`'s
+//!    path), and the rule does not fire: contradiction. Subset blocking can only fire
+//!    *earlier* than this equality bound. Every tree path therefore stays at most
+//!    `2^|sub(O)| + 1` nodes deep.
+//! 4. **Node bound.** A node gains tree successors only via the ∃-rule, at most once
+//!    per `∃R.C ∈ sub(O)`: after firing, the fresh `R`-successor containing `C`
+//!    falsifies the rule's precondition forever (labels and edges only grow). So
+//!    out-degree is bounded by `|sub(O)|` plus, at roots, the asserted ABox edges.
+//!    Finitely many roots + bounded depth (3) + bounded out-degree ⇒ each branch's
+//!    forest is finite; with (2), each branch performs finitely many rule applications.
+//!    The ⊔-search tree is finitely branching (disjunction width) with depth bounded by
+//!    the per-branch application count, so chronological backtracking visits finitely
+//!    many branches. The procedure terminates on **every** input — independently of the
+//!    budgets, which bound *work*, not termination. ∎
+//!
+//! # 4. Soundness (an `Unsatisfiable` verdict is true)
+//!
+//! Call a forest *satisfiable* when there is a model `I` of the ontology and a map `π`
+//! from **all** forest nodes (blocked or not) into `Δ^I` with `π(n) ∈ C^I` for every
+//! `C ∈ L(n)` and `(π(n), π(m)) ∈ S^I` for every edge `n –S→ m`. The initial forest is
+//! satisfiable iff the input is: ABox roots carry exactly the (NNF'd,
+//! equivalence-preserved) asserted facts; the fresh unconstrained root is always
+//! satisfiable because Direct-Semantics domains are non-empty; the class-satisfiability
+//! root encodes `O ∪ {C(a_fresh)}` as in §2. Every deterministic rule preserves forest
+//! satisfiability: GCI- and ⊓-additions are entailed at `π(x)` (`I ⊨ Cᵢ ⊑ Dᵢ` makes
+//! `Uᵢ` hold everywhere); a ∀-addition holds at `π(y)` because
+//! `(π(x), π(y)) ∈ S^I ⊆ R^I` (`I` satisfies the role inclusions, hence their
+//! composition `⊑*`); the ∃-rule extends `π` by mapping the fresh node to a witness of
+//! `π(x) ∈ (∃R.C)^I`. For the ⊔-rule, some disjunct holds at `π(x)`, so **at least one
+//! branch** preserves satisfiability. Because `π` covers blocked nodes too (§2: rules
+//! keep firing there, and each addition is entailed at the node's `π`-image), a
+//! satisfiable forest can never exhibit a clash *anywhere* — so abandoning a branch on
+//! any clash is safe. `Unsatisfiable` is returned only when the exhaustive,
+//! terminating (§3) search has clashed on every branch; by preservation the initial
+//! forest — hence the input — has no model. ∎
+//!
+//! # 5. Completeness (a `Satisfiable` verdict is true)
+//!
+//! `Satisfiable` is returned only from a quiescent, clash-free forest `F`. Build a
+//! finite interpretation `I`: for a directly blocked node `m`, let `σ(m)` be its
+//! blocker (nearest ancestor `x` with `L(m) ⊆ L(x)` on the final labels); for unblocked
+//! `m`, `σ(m) = m`. Take `Δ` = the unblocked nodes of `F` (non-empty: roots are never
+//! blocked and at least one root always exists); `A^I = {n ∈ Δ : A ∈ L(n)}`; each ABox
+//! individual denotes its root; for every edge `n –S→ m` with `n ∈ Δ`, put
+//! `(n, σ(m))` into `T^I` for every `T` with `S ⊑* T`. (This is total: if `n` is
+//! unblocked, every strict ancestor of `m` is unblocked, so a blocked `m` is *directly*
+//! blocked and its blocker lies on `n`'s path — unblocked, hence in `Δ`.) Then for
+//! every `n ∈ Δ` and `D ∈ L(n)`: `n ∈ D^I`, by induction on `D`:
+//!
+//! - `⊤` trivially; `⊥ ∉ L(n)` and, for literals, `{A, ¬A} ⊄ L(n)` (clash-freeness)
+//!   give `A`/`¬A` via the definition of `A^I`.
+//! - `⊓`/`⊔`: `n` is unblocked and quiescent, so the conjuncts / a disjunct are in
+//!   `L(n)`; induction.
+//! - `∃R.C ∈ L(n)`: `n` is unblocked, so quiescence means some edge `n –S→ m` with
+//!   `S ⊑* R` and `C ∈ L(m)` exists. Then `(n, σ(m)) ∈ R^I` and
+//!   `C ∈ L(m) ⊆ L(σ(m))` — equality when `m` is unblocked, the *subset-blocking
+//!   condition on the final labels* otherwise (this is why blocking is re-evaluated
+//!   dynamically and never cached). Induction gives `σ(m) ∈ C^I`.
+//! - `∀R.C ∈ L(n)`: every `R^I`-edge out of `n` is `(n, σ(m))` for an `F`-edge
+//!   `n –S→ m` with `S ⊑* R`; quiescence of the ∀-rule (which fires into `m` whether or
+//!   not `m` is blocked) put `C ∈ L(m) ⊆ L(σ(m))`; induction. **This is the step that
+//!   needs the absence of inverse roles — see below.**
+//!
+//! The GCI-rule keeps every `Uᵢ` in every label, so by the above every element of `Δ`
+//! satisfies every internalised GCI; role inclusions hold by the `⊑*`-closure in the
+//! edge construction; ABox assertions hold at the (never redirected) roots. So
+//! `I ⊨ O`, and for class satisfiability the fresh root witnesses `C^I ≠ ∅`. ∎
+//!
+//! ## Why SUBSET blocking suffices here — and would NOT with inverse roles
+//!
+//! (The load-bearing note; design record §3/§5. Cf. Baader & Sattler 2001 §5;
+//! Horrocks & Sattler, *A Description Logic with Transitive and Inverse Roles and Role
+//! Hierarchies*, J. Logic & Computation 9(3), 1999.)
+//!
+//! The construction above replaces a directly blocked node `m` by its blocker
+//! `x = σ(m)`: it redirects `m`'s single incoming tree edge `n –S→ m` to `n –S→ x`.
+//! Every obligation this redirect must honour flows **downward along the edge**: `n`'s
+//! `∀`-constraints demand certain concepts at the edge target, and `L(m) ⊆ L(x)`
+//! delivers exactly them, because the ∀-rule had already pushed each such concept into
+//! `L(m)`. In ALCH **no construct propagates a constraint upward against edge
+//! direction**: with only named roles, giving `x` a new incoming edge imposes nothing
+//! on `x`, and `x`'s label imposes nothing on its new predecessor `n`. So the only
+//! guarantee a blocker must give is "at least the blocked node's concepts" — a subset
+//! test. This also covers a root acting as blocker: the redirect burdens it with
+//! nothing.
+//!
+//! With inverse roles this breaks: `∀R⁻.E ∈ L(x)` imposes `E` on every
+//! `R`-**predecessor** of `x`. In `F` that obligation was discharged against `x`'s own
+//! predecessor, but the redirect gives `x` a *new* predecessor `n` that never saw it —
+//! and `L(m) ⊆ L(x)` is the wrong direction to transfer `x`'s inverse obligations to
+//! `m`'s context (nothing forces `∀R⁻.E ∈ L(m)`, let alone `E ∈ L(n)`). A `Satisfiable`
+//! verdict would then no longer be true: subset blocking must be strengthened to at
+//! least **equality** blocking for ALCI, and to pairwise/dynamic blocking once number
+//! restrictions are added (Horrocks & Sattler 1999). That is exactly why inverse roles
+//! are a deferred, separately-argued extension in the design record's deferral ledger
+//! (§5), and why [`crate::model::ObjectPropertyExpression`] has no inverse variant for
+//! this module to silently mis-handle. (Transitive roles, by contrast, are the
+//! first-in-line extension: absent inverses they need a `∀₊`-propagation rule but no
+//! blocking change — Horrocks & Sattler 1999; still **not implemented here**.)
+//!
+//! # 6. Budgets and determinism
+//!
+//! Budgets are **deterministic counts only** ([`Budget`]): `max_nodes` bounds the total
+//! number of forest nodes ever created over the whole search (roots included; never
+//! decremented on backtracking), `max_rule_applications` bounds completion-rule
+//! applications (including each ⊔-disjunct trial and re-applications after
+//! backtracking). Exhaustion returns [`UnknownReason::ResourceBudget`] — **never a
+//! verdict**. Wall-clock budgets are banned by design (design record §3: conformance
+//! floors must be reproducible). All scan orders are fixed (nodes and edges in creation
+//! order, label concepts in interning order, universal constraints in axiom order,
+//! disjuncts left to right), so for a given [`crate::model::Ontology`] value and
+//! [`Budget`] the outcome — including *which* budget trips — is identical on every run.
+//!
+//! # 7. Honest scope
+//!
+//! This module decides consistency / class satisfiability **only for the exact ALCH
+//! fragment of §1**, as delivered by the L1 structural model. It is **not** an OWL 2 DL
+//! reasoner, and no claim of soundness or completeness is made beyond the argued
+//! fragment. Anything the L1 extractor could not map — genuinely out-of-fragment
+//! constructs *or* malformed encodings — yields `Unknown(OutOfFragment)`, fail-closed,
+//! before any reasoning. Within the fragment, the unique-name assumption is neither
+//! made nor needed: no ALCH construct can force two individuals to be equal or
+//! distinct, and the §5 construction simply keeps roots distinct. Concept
+//! satisfiability w.r.t. general TBoxes in ALC is EXPTIME-complete (Schild's PDL
+//! correspondence; *The Description Logic Handbook*, 2nd ed., ch. 2–3), and role
+//! hierarchies do not change this; this implementation is a straightforward blocking
+//! tableau and is **not** claimed worst-case optimal — the budgets exist to bound its
+//! work deterministically.
+//!
+//! # 8. References
+//!
+//! - F. Baader, U. Sattler: *An Overview of Tableau Algorithms for Description
+//!   Logics*. Studia Logica 69(1):5–40, 2001. (Completion rules, subset blocking for
+//!   ALC with general TBoxes, termination/soundness/completeness scheme.)
+//! - I. Horrocks, U. Sattler: *A Description Logic with Transitive and Inverse Roles
+//!   and Role Hierarchies*. J. Logic & Computation 9(3):385–410, 1999. (Why inverses
+//!   force stronger blocking; role hierarchies in the rules.)
+//! - Baader, Calvanese, McGuinness, Nardi, Patel-Schneider (eds.): *The Description
+//!   Logic Handbook*, 2nd ed., ch. 2–3. (ALC complexity, blocking taxonomy.)
+//! - W3C OWL 2 Direct Semantics (non-empty domains):
+//!   `<https://www.w3.org/TR/owl2-direct-semantics/>`.
+//! - In-repo: `research/owl2-direct-semantics-scoping.md` §3 (the spec this module
+//!   implements) and §5 (the deferral ledger).
+
+use crate::extract::ExtractError;
+use crate::model::{Axiom, ClassExpression, Ontology};
+use crate::nnf::{is_nnf, nnf, nnf_complement, subexpression_closure};
+use rustc_hash::{FxHashMap, FxHashSet};
+use sparq_core::dict::Id;
+use std::collections::BTreeSet;
+
+// -------------------------------------------------------------------------------------------
+// Public API
+// -------------------------------------------------------------------------------------------
+
+/// Deterministic, count-based work budget for one tableau run (module docs §6).
+///
+/// Both limits are counts of work performed across the WHOLE backtracking search and are
+/// never decremented; exhaustion yields [`Verdict::Unknown`] with
+/// [`UnknownReason::ResourceBudget`], never a verdict. Wall-clock budgets are banned by
+/// design (they would make conformance floors non-reproducible).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Budget {
+    /// Maximum total number of forest nodes ever created (roots included). If the ABox
+    /// alone needs more roots than this, the run returns `Unknown` immediately.
+    pub max_nodes: usize,
+    /// Maximum total number of completion-rule applications, counting each concept
+    /// addition, each ⊔-disjunct trial, and each ∃-expansion — including work re-done
+    /// after backtracking.
+    pub max_rule_applications: usize,
+}
+
+impl Default for Budget {
+    /// Generous deterministic defaults for interactive use (10 000 nodes / 200 000 rule
+    /// applications). The values are arbitrary counts, not tuned constants; callers with
+    /// reproducibility requirements (e.g. conformance lanes) should pin their own.
+    fn default() -> Budget {
+        Budget {
+            max_nodes: 10_000,
+            max_rule_applications: 200_000,
+        }
+    }
+}
+
+/// Which count-based budget was exhausted (payload of [`UnknownReason::ResourceBudget`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ExhaustedBudget {
+    /// [`Budget::max_nodes`] was reached.
+    Nodes,
+    /// [`Budget::max_rule_applications`] was reached.
+    RuleApplications,
+}
+
+/// Why the checker abstained ([`Verdict::Unknown`]). Fail-closed: neither reason ever
+/// degrades into a verdict.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum UnknownReason {
+    /// The input RDF graph could not be mapped into the ALCH structural fragment by the
+    /// L1 extractor — either a genuinely out-of-fragment construct (inverses,
+    /// cardinality, nominals, datatypes, `sameAs`, …) or a malformed encoding. The
+    /// payload is the rendered [`ExtractError`]. The tableau never ran: it must not
+    /// reason over a graph it only partially understood.
+    OutOfFragment(String),
+    /// A deterministic count budget was exhausted mid-search (module docs §6). The
+    /// partial search says nothing about consistency either way.
+    ResourceBudget(ExhaustedBudget),
+}
+
+/// The tri-state outcome of a tableau run.
+///
+/// For [`consistency`], `Satisfiable` means the ontology is CONSISTENT and
+/// `Unsatisfiable` means INCONSISTENT (an ontology is consistent iff its constraint
+/// system is satisfiable). For [`class_satisfiability`], they mean the class is
+/// satisfiable / unsatisfiable w.r.t. the ontology. Both verdicts are backed by the
+/// module-doc argument (§4/§5) and are made ONLY within the ALCH fragment (§1/§7).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum Verdict {
+    /// A model exists (ontology consistent / class satisfiable). True by §5.
+    Satisfiable,
+    /// No model exists (ontology inconsistent / class unsatisfiable). True by §4.
+    Unsatisfiable,
+    /// No verdict — out-of-fragment input or budget exhaustion; see [`UnknownReason`].
+    Unknown(UnknownReason),
+}
+
+impl Verdict {
+    /// `true` iff the verdict is [`Verdict::Satisfiable`].
+    #[must_use]
+    pub fn is_satisfiable(&self) -> bool {
+        matches!(self, Verdict::Satisfiable)
+    }
+
+    /// `true` iff the verdict is [`Verdict::Unsatisfiable`].
+    #[must_use]
+    pub fn is_unsatisfiable(&self) -> bool {
+        matches!(self, Verdict::Unsatisfiable)
+    }
+
+    /// `true` iff the checker abstained ([`Verdict::Unknown`]).
+    #[must_use]
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, Verdict::Unknown(_))
+    }
+}
+
+/// Decide consistency of an ALCH structural ontology under a deterministic budget.
+///
+/// Returns [`Verdict::Satisfiable`] (consistent) or [`Verdict::Unsatisfiable`]
+/// (inconsistent) — correct by the module-doc argument (§4/§5) — or
+/// [`Verdict::Unknown`] with [`UnknownReason::ResourceBudget`] when the budget is
+/// exhausted first. The input [`Ontology`] is already fragment-restricted by
+/// construction (L1); RDF-level inputs should go through
+/// [`consistency_from_extraction`] for the fail-closed out-of-fragment path.
+///
+/// The empty ontology is consistent. An ontology with an empty ABox is checked over a
+/// single fresh root (Direct-Semantics domains are non-empty, so e.g. `⊤ ⊑ ⊥` with no
+/// individuals is still inconsistent).
+#[must_use]
+pub fn consistency(onto: &Ontology, budget: Budget) -> Verdict {
+    let (sys, forest, seed_clash) = preprocess(onto, None);
+    if seed_clash {
+        // The asserted ABox facts alone are contradictory ({A(a), ¬A(a)} or ⊥(a)).
+        return Verdict::Unsatisfiable;
+    }
+    run(&sys, forest, budget)
+}
+
+/// Decide satisfiability of a class expression w.r.t. an ALCH structural ontology
+/// (TBox + RBox + ABox) under a deterministic budget.
+///
+/// Implemented as consistency of `O ∪ {C(a_fresh)}` with `a_fresh` occurring nowhere
+/// else — an exact reduction (module docs §2). Consequently, if the ontology itself is
+/// inconsistent, EVERY class is unsatisfiable w.r.t. it, including `⊤`. `class` may be
+/// any ALCH class expression; it is NNF'd internally.
+#[must_use]
+pub fn class_satisfiability(class: &ClassExpression, onto: &Ontology, budget: Budget) -> Verdict {
+    let (sys, forest, seed_clash) = preprocess(onto, Some(class));
+    if seed_clash {
+        return Verdict::Unsatisfiable;
+    }
+    run(&sys, forest, budget)
+}
+
+/// Fail-closed entry point from an L1 extraction result (module docs §1/§7).
+///
+/// `Err(e)` — the RDF graph contains anything the ALCH mapping could not understand —
+/// yields `Unknown(OutOfFragment)` carrying the rendered error, BEFORE any tableau
+/// work: the checker never reasons over a graph it only partially understood. `Ok`
+/// delegates to [`consistency`].
+#[must_use]
+pub fn consistency_from_extraction(
+    result: &Result<Ontology, ExtractError>,
+    budget: Budget,
+) -> Verdict {
+    match result {
+        Ok(onto) => consistency(onto, budget),
+        Err(e) => Verdict::Unknown(UnknownReason::OutOfFragment(format!("{}", e))),
+    }
+}
+
+// -------------------------------------------------------------------------------------------
+// Interned concept table
+// -------------------------------------------------------------------------------------------
+
+/// Index into [`System::shapes`] — an interned NNF class expression.
+type ConceptId = u32;
+
+/// The decomposed shape of an interned NNF concept. Children are interned ids, so the
+/// completion rules never re-examine expression trees (and can never mint a concept
+/// outside the pre-interned closure — termination step 1).
+enum Shape {
+    /// A named class. (The class's dict id is not stored: the completion rules treat
+    /// atoms opaquely by interned id; the expression itself remains retrievable as the
+    /// interning key.)
+    Atom,
+    /// ⊤.
+    Top,
+    /// ⊥ — its presence in any label is a clash.
+    Bottom,
+    /// `¬A` for the named-class concept with the given id (NNF guarantees the inner
+    /// expression is named).
+    NegAtom(ConceptId),
+    /// `C₁ ⊓ … ⊓ Cₙ`.
+    And(Vec<ConceptId>),
+    /// `C₁ ⊔ … ⊔ Cₙ`.
+    Or(Vec<ConceptId>),
+    /// `∃R.C` over the named property `R`.
+    Exists(Id, ConceptId),
+    /// `∀R.C` over the named property `R`.
+    ForAll(Id, ConceptId),
+}
+
+/// The preprocessed, immutable constraint system one tableau run works over.
+#[derive(Default)]
+struct System {
+    /// Interned concept shapes; `ConceptId` indexes this.
+    shapes: Vec<Shape>,
+    /// Expression → id (structural dedup).
+    ids: FxHashMap<ClassExpression, ConceptId>,
+    /// `A ↔ ¬A` pairs (both directions); a label holding both members is a clash.
+    complements: FxHashMap<ConceptId, ConceptId>,
+    /// Internalised GCI constraints `Uᵢ`, deduplicated, in axiom order.
+    universals: Vec<ConceptId>,
+    /// Strict super-roles per role (transitive closure of `rdfs:subPropertyOf`);
+    /// reflexivity is handled in [`System::is_subrole`].
+    super_roles: FxHashMap<Id, FxHashSet<Id>>,
+}
+
+impl System {
+    /// Intern an NNF class expression, recursively interning its subexpressions.
+    fn intern(&mut self, ce: &ClassExpression) -> ConceptId {
+        if let Some(&id) = self.ids.get(ce) {
+            return id;
+        }
+        let shape = match ce {
+            ClassExpression::Class(_) => Shape::Atom,
+            ClassExpression::Thing => Shape::Top,
+            ClassExpression::Nothing => Shape::Bottom,
+            ClassExpression::ObjectIntersectionOf(members) => {
+                Shape::And(members.iter().map(|m| self.intern(m)).collect())
+            }
+            ClassExpression::ObjectUnionOf(members) => {
+                Shape::Or(members.iter().map(|m| self.intern(m)).collect())
+            }
+            ClassExpression::ObjectComplementOf(inner) => {
+                debug_assert!(
+                    matches!(inner.as_ref(), ClassExpression::Class(_)),
+                    "tableau interner requires NNF input"
+                );
+                Shape::NegAtom(self.intern(inner))
+            }
+            ClassExpression::ObjectSomeValuesFrom(p, filler) => {
+                Shape::Exists(p.named(), self.intern(filler))
+            }
+            ClassExpression::ObjectAllValuesFrom(p, filler) => {
+                Shape::ForAll(p.named(), self.intern(filler))
+            }
+        };
+        let id = self.shapes.len() as ConceptId;
+        if let Shape::NegAtom(atom) = &shape {
+            self.complements.insert(*atom, id);
+            self.complements.insert(id, *atom);
+        }
+        self.shapes.push(shape);
+        self.ids.insert(ce.clone(), id);
+        id
+    }
+
+    /// `true` iff `sub ⊑* sup` in the reflexive-transitive role closure.
+    fn is_subrole(&self, sub: Id, sup: Id) -> bool {
+        sub == sup
+            || self
+                .super_roles
+                .get(&sub)
+                .is_some_and(|sups| sups.contains(&sup))
+    }
+}
+
+// -------------------------------------------------------------------------------------------
+// Completion forest
+// -------------------------------------------------------------------------------------------
+
+/// One forest node: a label (interned concepts, ordered by interning index for
+/// deterministic iteration) and an optional tree parent (`None` = root).
+#[derive(Clone)]
+struct Node {
+    label: BTreeSet<ConceptId>,
+    parent: Option<usize>,
+}
+
+/// The completion forest of one search branch: nodes in creation order, plus ALL edges
+/// (root–root ABox edges and ∃-generated tree edges) as `(source, role, target)`.
+#[derive(Clone)]
+struct Forest {
+    nodes: Vec<Node>,
+    edges: Vec<(usize, Id, usize)>,
+}
+
+impl Forest {
+    /// Insert `cid` into `L(n)`; returns `true` on a CLASH (⊥ added, or the complement
+    /// of `cid` already present). No-op (and no clash) if already present.
+    fn add(&mut self, n: usize, cid: ConceptId, sys: &System) -> bool {
+        if !self.nodes[n].label.insert(cid) {
+            return false;
+        }
+        if matches!(sys.shapes[cid as usize], Shape::Bottom) {
+            return true;
+        }
+        if let Some(comp) = sys.complements.get(&cid) {
+            return self.nodes[n].label.contains(comp);
+        }
+        false
+    }
+
+    /// Ancestor subset blocking, evaluated on the CURRENT labels (module docs §2): `y`
+    /// is blocked iff some non-root node `v` on the tree path root‥y (including `y`)
+    /// has an ancestor `x` with `L(v) ⊆ L(x)`. Roots are never blocked.
+    fn is_blocked(&self, y: usize) -> bool {
+        let mut v = y;
+        loop {
+            let Some(parent) = self.nodes[v].parent else {
+                return false; // reached the root: no more non-root nodes on the path
+            };
+            let mut x = Some(parent);
+            while let Some(xi) = x {
+                if self.nodes[v].label.is_subset(&self.nodes[xi].label) {
+                    return true;
+                }
+                x = self.nodes[xi].parent;
+            }
+            v = parent;
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------
+// Preprocessing (module docs §2)
+// -------------------------------------------------------------------------------------------
+
+/// Internalise a GCI `sub ⊑ sup` as the NNF universal constraint `nnf(¬sub) ⊔ nnf(sup)`.
+fn internalise(sub: &ClassExpression, sup: &ClassExpression) -> ClassExpression {
+    ClassExpression::ObjectUnionOf(vec![nnf_complement(sub), nnf(sup)])
+}
+
+/// Build the constraint system and initial forest from a structural ontology, plus an
+/// optional extra fresh root for class satisfiability. Returns `(system, forest,
+/// seed_clash)` where `seed_clash` means the asserted ABox facts alone already clash.
+fn preprocess(onto: &Ontology, extra: Option<&ClassExpression>) -> (System, Forest, bool) {
+    let mut sys = System::default();
+    let mut forest = Forest {
+        nodes: Vec::new(),
+        edges: Vec::new(),
+    };
+    let mut roots: FxHashMap<Id, usize> = FxHashMap::default();
+    let mut universal_set: FxHashSet<ConceptId> = FxHashSet::default();
+    let mut seeds: Vec<ClassExpression> = Vec::new(); // closure cross-check (§3 step 1)
+    let mut seed_clash = false;
+
+    // RBox first: the transitive role closure (independent of the concept table).
+    let mut direct: FxHashMap<Id, FxHashSet<Id>> = FxHashMap::default();
+    for axiom in onto.axioms() {
+        if let Axiom::SubObjectPropertyOf { sub, sup } = axiom {
+            direct.entry(sub.named()).or_default().insert(sup.named());
+        }
+    }
+    for &start in direct.keys() {
+        let mut reach: FxHashSet<Id> = FxHashSet::default();
+        let mut work: Vec<Id> = direct[&start].iter().copied().collect();
+        while let Some(next) = work.pop() {
+            if reach.insert(next) {
+                if let Some(sups) = direct.get(&next) {
+                    work.extend(sups.iter().copied());
+                }
+            }
+        }
+        sys.super_roles.insert(start, reach);
+    }
+
+    // TBox internalisation + ABox seeding, in axiom order (deterministic).
+    let mut push_universal =
+        |sys: &mut System, seeds: &mut Vec<ClassExpression>, u: ClassExpression| {
+            let cid = sys.intern(&u);
+            seeds.push(u);
+            if universal_set.insert(cid) {
+                sys.universals.push(cid);
+            }
+        };
+    fn root_of(forest: &mut Forest, roots: &mut FxHashMap<Id, usize>, ind: Id) -> usize {
+        *roots.entry(ind).or_insert_with(|| {
+            forest.nodes.push(Node {
+                label: BTreeSet::new(),
+                parent: None,
+            });
+            forest.nodes.len() - 1
+        })
+    }
+    for axiom in onto.axioms() {
+        match axiom {
+            Axiom::SubClassOf { sub, sup } => {
+                push_universal(&mut sys, &mut seeds, internalise(sub, sup));
+            }
+            Axiom::EquivalentClasses(left, right) => {
+                push_universal(&mut sys, &mut seeds, internalise(left, right));
+                push_universal(&mut sys, &mut seeds, internalise(right, left));
+            }
+            Axiom::DisjointClasses(left, right) => {
+                // left ⊓ right ⊑ ⊥ (design record §3 desugaring).
+                let both =
+                    ClassExpression::ObjectIntersectionOf(vec![left.clone(), right.clone()]);
+                push_universal(
+                    &mut sys,
+                    &mut seeds,
+                    internalise(&both, &ClassExpression::Nothing),
+                );
+            }
+            Axiom::SubObjectPropertyOf { .. } => {} // handled above
+            Axiom::ObjectPropertyDomain { property, domain } => {
+                // ∃R.⊤ ⊑ domain.
+                let some_top = ClassExpression::some(property.named(), ClassExpression::Thing);
+                push_universal(&mut sys, &mut seeds, internalise(&some_top, domain));
+            }
+            Axiom::ObjectPropertyRange { property, range } => {
+                // ⊤ ⊑ ∀R.range.
+                let all_range = ClassExpression::only(property.named(), range.clone());
+                push_universal(
+                    &mut sys,
+                    &mut seeds,
+                    internalise(&ClassExpression::Thing, &all_range),
+                );
+            }
+            Axiom::ClassAssertion { class, individual } => {
+                let n = root_of(&mut forest, &mut roots, *individual);
+                let seeded = nnf(class);
+                let cid = sys.intern(&seeded);
+                seeds.push(seeded);
+                if forest.add(n, cid, &sys) {
+                    seed_clash = true;
+                }
+            }
+            Axiom::ObjectPropertyAssertion {
+                property,
+                source,
+                target,
+            } => {
+                let s = root_of(&mut forest, &mut roots, *source);
+                let t = root_of(&mut forest, &mut roots, *target);
+                forest.edges.push((s, property.named(), t));
+            }
+        }
+    }
+
+    // Class-satisfiability root, then the non-empty-domain root (module docs §2).
+    if let Some(class) = extra {
+        forest.nodes.push(Node {
+            label: BTreeSet::new(),
+            parent: None,
+        });
+        let n = forest.nodes.len() - 1;
+        let seeded = nnf(class);
+        let cid = sys.intern(&seeded);
+        seeds.push(seeded);
+        if forest.add(n, cid, &sys) {
+            seed_clash = true;
+        }
+    } else if forest.nodes.is_empty() {
+        forest.nodes.push(Node {
+            label: BTreeSet::new(),
+            parent: None,
+        });
+    }
+
+    // §3 step 1, enforced structurally: the interner now holds EXACTLY the (NNF)
+    // subexpression closure of the seeds, and expansion below moves only indices.
+    debug_assert!(seeds.iter().all(is_nnf), "preprocessing must emit NNF seeds");
+    debug_assert_eq!(
+        subexpression_closure(&seeds).len(),
+        sys.shapes.len(),
+        "interned table must equal the subexpression closure of the seeds"
+    );
+
+    (sys, forest, seed_clash)
+}
+
+// -------------------------------------------------------------------------------------------
+// The search (module docs §2/§6)
+// -------------------------------------------------------------------------------------------
+
+/// Monotone work counters for one whole search (never decremented on backtracking).
+struct Search {
+    budget: Budget,
+    nodes_created: usize,
+    rules_applied: usize,
+}
+
+impl Search {
+    fn count_rule(&mut self) -> Result<(), ExhaustedBudget> {
+        if self.rules_applied >= self.budget.max_rule_applications {
+            return Err(ExhaustedBudget::RuleApplications);
+        }
+        self.rules_applied += 1;
+        Ok(())
+    }
+
+    fn count_node(&mut self) -> Result<(), ExhaustedBudget> {
+        if self.nodes_created >= self.budget.max_nodes {
+            return Err(ExhaustedBudget::Nodes);
+        }
+        self.nodes_created += 1;
+        Ok(())
+    }
+}
+
+/// What one saturation pass over a branch ended in.
+enum Step {
+    /// No rule applicable: quiescent, clash-free — Satisfiable (module docs §5).
+    Quiescent,
+    /// A clash: this branch is dead (module docs §4).
+    Clash,
+    /// A ⊔-rule needs a choice: branch over `disjuncts` at `node`.
+    Choice { node: usize, disjuncts: Vec<ConceptId> },
+}
+
+/// Apply deterministic rules (GCI, ⊓, ∀) to fixpoint, then surface the first ⊔-choice,
+/// else apply the first unblocked ∃ and repeat, else report quiescence. Scan orders are
+/// fixed for determinism (module docs §6).
+fn saturate(f: &mut Forest, sys: &System, s: &mut Search) -> Result<Step, ExhaustedBudget> {
+    loop {
+        // Deterministic rules to fixpoint.
+        let mut changed = true;
+        while changed {
+            changed = false;
+            // GCI-rule: every internalised constraint into every node's label.
+            for n in 0..f.nodes.len() {
+                for &u in &sys.universals {
+                    if !f.nodes[n].label.contains(&u) {
+                        s.count_rule()?;
+                        if f.add(n, u, sys) {
+                            return Ok(Step::Clash);
+                        }
+                        changed = true;
+                    }
+                }
+            }
+            // ⊓-rule.
+            for n in 0..f.nodes.len() {
+                let ids: Vec<ConceptId> = f.nodes[n].label.iter().copied().collect();
+                for cid in ids {
+                    if let Shape::And(members) = &sys.shapes[cid as usize] {
+                        for &m in members {
+                            if !f.nodes[n].label.contains(&m) {
+                                s.count_rule()?;
+                                if f.add(n, m, sys) {
+                                    return Ok(Step::Clash);
+                                }
+                                changed = true;
+                            }
+                        }
+                    }
+                }
+            }
+            // ∀-rule, matched modulo the role hierarchy; fires into blocked nodes too
+            // (module docs §2: the subset test must never see a stale label).
+            for ei in 0..f.edges.len() {
+                let (src, role, tgt) = f.edges[ei];
+                let ids: Vec<ConceptId> = f.nodes[src].label.iter().copied().collect();
+                for cid in ids {
+                    if let Shape::ForAll(r, filler) = &sys.shapes[cid as usize] {
+                        let (r, filler) = (*r, *filler);
+                        if sys.is_subrole(role, r) && !f.nodes[tgt].label.contains(&filler) {
+                            s.count_rule()?;
+                            if f.add(tgt, filler, sys) {
+                                return Ok(Step::Clash);
+                            }
+                            changed = true;
+                        }
+                    }
+                }
+            }
+        }
+        // ⊔-rule: first unresolved disjunction in scan order.
+        for (n, node) in f.nodes.iter().enumerate() {
+            for &cid in &node.label {
+                if let Shape::Or(members) = &sys.shapes[cid as usize] {
+                    if !members.iter().any(|m| node.label.contains(m)) {
+                        return Ok(Step::Choice {
+                            node: n,
+                            disjuncts: members.clone(),
+                        });
+                    }
+                }
+            }
+        }
+        // ∃-rule: first unsatisfied existential on an UNBLOCKED node (the only rule
+        // blocking gates; blocking evaluated on current labels, right now).
+        let mut expanded = false;
+        'nodes: for n in 0..f.nodes.len() {
+            let ids: Vec<ConceptId> = f.nodes[n].label.iter().copied().collect();
+            for cid in ids {
+                if let Shape::Exists(r, filler) = &sys.shapes[cid as usize] {
+                    let (r, filler) = (*r, *filler);
+                    let satisfied = f.edges.iter().any(|&(src, erole, tgt)| {
+                        src == n && sys.is_subrole(erole, r) && f.nodes[tgt].label.contains(&filler)
+                    });
+                    if satisfied || f.is_blocked(n) {
+                        continue;
+                    }
+                    s.count_rule()?;
+                    s.count_node()?;
+                    let fresh = f.nodes.len();
+                    f.nodes.push(Node {
+                        label: BTreeSet::new(),
+                        parent: Some(n),
+                    });
+                    f.edges.push((n, r, fresh));
+                    if f.add(fresh, filler, sys) {
+                        return Ok(Step::Clash);
+                    }
+                    expanded = true;
+                    break 'nodes;
+                }
+            }
+        }
+        if !expanded {
+            return Ok(Step::Quiescent);
+        }
+        // A fresh node exists: re-run the deterministic rules over it.
+    }
+}
+
+/// A ⊔ choice point: the forest as it was when the choice arose, plus which disjuncts
+/// remain to try.
+struct ChoicePoint {
+    forest: Forest,
+    node: usize,
+    disjuncts: Vec<ConceptId>,
+    next: usize,
+}
+
+/// Chronological backtracking: take the next untried disjunct from the top-most live
+/// choice point, applying it to a copy of that point's forest. `None` = all branches
+/// exhausted (Unsatisfiable). Disjunct trials count as rule applications.
+fn next_branch(
+    stack: &mut Vec<ChoicePoint>,
+    sys: &System,
+    s: &mut Search,
+) -> Result<Option<Forest>, ExhaustedBudget> {
+    while let Some(ch) = stack.last_mut() {
+        if ch.next >= ch.disjuncts.len() {
+            stack.pop();
+            continue;
+        }
+        let d = ch.disjuncts[ch.next];
+        ch.next += 1;
+        let node = ch.node;
+        s.count_rule()?;
+        let mut f = ch.forest.clone();
+        if !f.add(node, d, sys) {
+            return Ok(Some(f));
+        }
+        // This disjunct clashes immediately; the loop tries the next one.
+    }
+    Ok(None)
+}
+
+/// Drive the search to a verdict (module docs §2/§6).
+fn run(sys: &System, mut forest: Forest, budget: Budget) -> Verdict {
+    if forest.nodes.len() > budget.max_nodes {
+        return Verdict::Unknown(UnknownReason::ResourceBudget(ExhaustedBudget::Nodes));
+    }
+    let mut s = Search {
+        budget,
+        nodes_created: forest.nodes.len(),
+        rules_applied: 0,
+    };
+    let mut stack: Vec<ChoicePoint> = Vec::new();
+    loop {
+        let step = match saturate(&mut forest, sys, &mut s) {
+            Ok(step) => step,
+            Err(b) => return Verdict::Unknown(UnknownReason::ResourceBudget(b)),
+        };
+        match step {
+            Step::Quiescent => return Verdict::Satisfiable,
+            Step::Choice { node, disjuncts } => {
+                stack.push(ChoicePoint {
+                    forest: forest.clone(),
+                    node,
+                    disjuncts,
+                    next: 0,
+                });
+            }
+            Step::Clash => {}
+        }
+        match next_branch(&mut stack, sys, &mut s) {
+            Ok(Some(f)) => forest = f,
+            Ok(None) => return Verdict::Unsatisfiable,
+            Err(b) => return Verdict::Unknown(UnknownReason::ResourceBudget(b)),
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------
+// Direct unit tests (the integration suite lives in tests/tableau.rs)
+// -------------------------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::ClassExpression as CE;
+
+    const A: Id = 1;
+    const B: Id = 2;
+
+    fn subclass(sub: CE, sup: CE) -> Axiom {
+        Axiom::SubClassOf { sub, sup }
+    }
+
+    fn assert_class(class: CE, individual: Id) -> Axiom {
+        Axiom::ClassAssertion { class, individual }
+    }
+
+    fn onto(axioms: Vec<Axiom>) -> Ontology {
+        Ontology { axioms }
+    }
+
+    #[test]
+    fn verdict_predicates() {
+        assert!(Verdict::Satisfiable.is_satisfiable());
+        assert!(!Verdict::Satisfiable.is_unsatisfiable());
+        assert!(Verdict::Unsatisfiable.is_unsatisfiable());
+        assert!(!Verdict::Unsatisfiable.is_unknown());
+        let u = Verdict::Unknown(UnknownReason::ResourceBudget(ExhaustedBudget::Nodes));
+        assert!(u.is_unknown());
+        assert!(!u.is_satisfiable());
+    }
+
+    #[test]
+    fn budget_default_is_positive_and_copy() {
+        let b = Budget::default();
+        assert!(b.max_nodes > 0);
+        assert!(b.max_rule_applications > 0);
+        let c = b; // Copy
+        assert_eq!(b, c);
+    }
+
+    #[test]
+    fn consistency_direct_sat_and_unsat() {
+        // Empty ontology: consistent (checked over the fresh non-empty-domain root).
+        assert_eq!(
+            consistency(&onto(vec![]), Budget::default()),
+            Verdict::Satisfiable
+        );
+        // a : A with A ⊑ ⊥: inconsistent.
+        let o = onto(vec![
+            subclass(CE::Class(A), CE::Nothing),
+            assert_class(CE::Class(A), 100),
+        ]);
+        assert_eq!(consistency(&o, Budget::default()), Verdict::Unsatisfiable);
+    }
+
+    #[test]
+    fn class_satisfiability_direct() {
+        // A w.r.t. {A ⊑ ⊥}: unsatisfiable.
+        let o = onto(vec![subclass(CE::Class(A), CE::Nothing)]);
+        assert_eq!(
+            class_satisfiability(&CE::Class(A), &o, Budget::default()),
+            Verdict::Unsatisfiable
+        );
+        // A w.r.t. {A ⊑ B}: satisfiable.
+        let o = onto(vec![subclass(CE::Class(A), CE::Class(B))]);
+        assert_eq!(
+            class_satisfiability(&CE::Class(A), &o, Budget::default()),
+            Verdict::Satisfiable
+        );
+        // ⊥ is unsatisfiable w.r.t. anything (seed clash path).
+        assert_eq!(
+            class_satisfiability(&CE::Nothing, &onto(vec![]), Budget::default()),
+            Verdict::Unsatisfiable
+        );
+    }
+
+    #[test]
+    fn consistency_from_extraction_direct() {
+        // Extraction failure: fail-closed Unknown(OutOfFragment), never a verdict.
+        let err: Result<Ontology, ExtractError> =
+            Err(ExtractError::OutOfFragment("owl:inverseOf".into()));
+        match consistency_from_extraction(&err, Budget::default()) {
+            Verdict::Unknown(UnknownReason::OutOfFragment(msg)) => {
+                assert!(
+                    msg.contains("owl:inverseOf"),
+                    "diagnostic must carry the cause"
+                );
+            }
+            other => panic!("expected Unknown(OutOfFragment), got {:?}", other),
+        }
+        // Ok delegates to consistency().
+        let ok: Result<Ontology, ExtractError> = Ok(onto(vec![]));
+        assert_eq!(
+            consistency_from_extraction(&ok, Budget::default()),
+            Verdict::Satisfiable
+        );
+    }
+
+    #[test]
+    fn nested_input_exercises_closure_interner_alignment() {
+        // Deeply nested NNF-relevant input: the debug_assert in preprocess() cross-checks
+        // the interner against nnf::subexpression_closure on this run.
+        let complex = CE::ObjectComplementOf(Box::new(CE::ObjectIntersectionOf(vec![
+            CE::Class(A),
+            CE::some(10, CE::ObjectUnionOf(vec![CE::Class(B), CE::Thing])),
+        ])));
+        let o = onto(vec![
+            subclass(CE::Class(A), complex.clone()),
+            Axiom::EquivalentClasses(CE::Class(B), CE::only(10, CE::Class(A))),
+            assert_class(complex, 100),
+        ]);
+        // Verdict value is not the point here; it must simply be a verdict, not a panic.
+        let v = consistency(&o, Budget::default());
+        assert!(v.is_satisfiable() || v.is_unsatisfiable());
+    }
+}

--- a/crates/sparq-reason-dl/tests/tableau.rs
+++ b/crates/sparq-reason-dl/tests/tableau.rs
@@ -1,0 +1,517 @@
+// [FABLE-5] sq-pbz04.4.3 (epic sq-pbz04.4) — integration tests for the L3 ALCH tableau
+// (design record research/owl2-direct-semantics-scoping.md §3).
+//
+// 🤖 SPARQ agent. Four acceptance families (the bead's acceptance criteria):
+//   (a) the BLOCKING-TERMINATION CANARY — cyclic TBoxes terminate with a verdict under a
+//       tight node cap, proving ancestor subset blocking fired (budget exhaustion would
+//       return Unknown, never a verdict), plus the converse canary: a cyclic TBox whose
+//       inconsistency blocking must NOT mask;
+//   (b) sat/unsat PAIRS exercising ⊔-branching with backtracking and ∀-propagation
+//       THROUGH the subPropertyOf hierarchy (a ∀ on a super-role constraining an edge
+//       asserted — or ∃-generated — on a sub-role);
+//   (c) fragment rejection: out-of-fragment RDF yields Unknown(OutOfFragment) fail-closed
+//       BEFORE the tableau starts (end-to-end through the real Dict → extract path);
+//   (d) budget exhaustion yields Unknown(ResourceBudget), never a verdict, and which
+//       budget trips is deterministic.
+//
+// Most tests build the STRUCTURAL model directly (the tableau's real input type, as in
+// tests/profile.rs); the (c) family and one sat/unsat pair go end-to-end from Turtle.
+
+use sparq_core::dict::Id;
+use sparq_core::Graph;
+use sparq_reason_dl::model::{Axiom, ClassExpression as CE};
+use sparq_reason_dl::model::ObjectPropertyExpression as OPE;
+use sparq_reason_dl::tableau::{
+    class_satisfiability, consistency, consistency_from_extraction, Budget, ExhaustedBudget,
+    UnknownReason, Verdict,
+};
+use sparq_reason_dl::{extract, Ontology};
+
+// -------------------------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------------------------
+
+const PRE: &str = r#"
+    @prefix : <http://ex/> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+    @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+"#;
+
+/// Parse Turtle and run the REAL fail-closed pipeline: Dict → extract → tableau.
+fn check_turtle(body: &str, budget: Budget) -> Verdict {
+    let (dict, triples) =
+        Graph::parse_to_triples(&format!("{}{}", PRE, body), "turtle").expect("parse");
+    consistency_from_extraction(&extract(&dict, &triples), budget)
+}
+
+// Stable ids for hand-built structural models (dict ids are opaque u32s to the tableau).
+const A: Id = 1;
+const B: Id = 2;
+const C: Id = 3;
+const D: Id = 4;
+const R: Id = 10; // roles
+const S: Id = 11;
+const T: Id = 12;
+const IA: Id = 100; // individuals
+const IB: Id = 101;
+
+fn named(id: Id) -> CE {
+    CE::Class(id)
+}
+fn not(ce: CE) -> CE {
+    CE::ObjectComplementOf(Box::new(ce))
+}
+fn and(members: Vec<CE>) -> CE {
+    CE::ObjectIntersectionOf(members)
+}
+fn or(members: Vec<CE>) -> CE {
+    CE::ObjectUnionOf(members)
+}
+fn subclass(sub: CE, sup: CE) -> Axiom {
+    Axiom::SubClassOf { sub, sup }
+}
+fn subrole(sub: Id, sup: Id) -> Axiom {
+    Axiom::SubObjectPropertyOf {
+        sub: OPE::ObjectProperty(sub),
+        sup: OPE::ObjectProperty(sup),
+    }
+}
+fn is_a(individual: Id, class: CE) -> Axiom {
+    Axiom::ClassAssertion { class, individual }
+}
+fn edge(source: Id, role: Id, target: Id) -> Axiom {
+    Axiom::ObjectPropertyAssertion {
+        property: OPE::ObjectProperty(role),
+        source,
+        target,
+    }
+}
+fn onto(axioms: Vec<Axiom>) -> Ontology {
+    Ontology { axioms }
+}
+
+// -------------------------------------------------------------------------------------------
+// (a) The blocking-termination canary
+// -------------------------------------------------------------------------------------------
+
+/// ACCEPTANCE (a): the cyclic TBox `⊤ ⊑ ∃R.C` (every element needs an R-successor —
+/// an infinite chain without blocking) must terminate with a VERDICT under a tight node
+/// cap. Getting `Satisfiable` under max_nodes = 4 proves the ∃-rule was stopped by
+/// ancestor subset blocking, NOT by budget exhaustion — exhaustion would return
+/// `Unknown(ResourceBudget)`, never a verdict.
+#[test]
+fn canary_cyclic_tbox_terminates_by_blocking_under_node_cap() {
+    let o = onto(vec![subclass(CE::Thing, CE::some(R, named(C)))]);
+    let tight = Budget {
+        max_nodes: 4,
+        max_rule_applications: 10_000,
+    };
+    assert_eq!(
+        consistency(&o, tight),
+        Verdict::Satisfiable,
+        "cyclic TBox must quiesce by subset blocking within 4 nodes"
+    );
+}
+
+/// Canary variant: `C ⊑ ∃R.C` with `C(a)` — the generated successor's label equals the
+/// ROOT's, so the root itself is the blocker (module docs §2/§5: a root may block, which
+/// is sound precisely because ALCH has no inverse roles).
+#[test]
+fn canary_root_blocks_cyclic_class() {
+    let o = onto(vec![
+        subclass(named(C), CE::some(R, named(C))),
+        is_a(IA, named(C)),
+    ]);
+    let tight = Budget {
+        max_nodes: 3,
+        max_rule_applications: 10_000,
+    };
+    assert_eq!(consistency(&o, tight), Verdict::Satisfiable);
+}
+
+/// Canary variant: a two-class ∃-cycle (A needs an R.B child, B needs an R.A child).
+#[test]
+fn canary_two_class_existential_cycle() {
+    let o = onto(vec![
+        subclass(named(A), CE::some(R, named(B))),
+        subclass(named(B), CE::some(R, named(A))),
+        is_a(IA, named(A)),
+    ]);
+    let tight = Budget {
+        max_nodes: 8,
+        max_rule_applications: 10_000,
+    };
+    assert_eq!(consistency(&o, tight), Verdict::Satisfiable);
+}
+
+/// The CONVERSE canary: blocking must not mask a real inconsistency. `⊤ ⊑ ∃R.A` and
+/// `⊤ ⊑ ∀R.¬A` clash on every generated successor; an over-eager blocking
+/// implementation would wrongly report Satisfiable.
+#[test]
+fn cyclic_tbox_with_universal_contradiction_is_unsatisfiable() {
+    let o = onto(vec![
+        subclass(CE::Thing, CE::some(R, named(A))),
+        subclass(CE::Thing, CE::only(R, not(named(A)))),
+    ]);
+    assert_eq!(consistency(&o, Budget::default()), Verdict::Unsatisfiable);
+}
+
+// -------------------------------------------------------------------------------------------
+// (b) sat/unsat pairs — ⊔-branching with backtracking
+// -------------------------------------------------------------------------------------------
+
+/// ACCEPTANCE (b): `A ⊑ B ⊔ C` — asserting `a : A ⊓ ¬B ⊓ ¬C` kills BOTH branches
+/// (unsat); dropping the `¬C` conjunct leaves the second branch alive (sat).
+#[test]
+fn or_branching_sat_unsat_pair() {
+    let tbox = subclass(named(A), or(vec![named(B), named(C)]));
+    let unsat = onto(vec![
+        tbox.clone(),
+        is_a(IA, named(A)),
+        is_a(IA, not(named(B))),
+        is_a(IA, not(named(C))),
+    ]);
+    assert_eq!(consistency(&unsat, Budget::default()), Verdict::Unsatisfiable);
+
+    let sat = onto(vec![tbox, is_a(IA, named(A)), is_a(IA, not(named(B)))]);
+    assert_eq!(consistency(&sat, Budget::default()), Verdict::Satisfiable);
+}
+
+/// Backtracking correctness: the FIRST disjunct clashes (`B ⊑ ⊥`), the second survives —
+/// the search must backtrack past the clash and find it. Adding `C ⊑ ⊥` too closes every
+/// branch.
+#[test]
+fn or_branch_backtracks_past_first_clash() {
+    let sat = onto(vec![
+        subclass(named(A), or(vec![named(B), named(C)])),
+        subclass(named(B), CE::Nothing),
+        is_a(IA, named(A)),
+    ]);
+    assert_eq!(consistency(&sat, Budget::default()), Verdict::Satisfiable);
+
+    let unsat = onto(vec![
+        subclass(named(A), or(vec![named(B), named(C)])),
+        subclass(named(B), CE::Nothing),
+        subclass(named(C), CE::Nothing),
+        is_a(IA, named(A)),
+    ]);
+    assert_eq!(consistency(&unsat, Budget::default()), Verdict::Unsatisfiable);
+}
+
+// -------------------------------------------------------------------------------------------
+// (b) sat/unsat pairs — ∀-propagation THROUGH the subPropertyOf hierarchy
+// -------------------------------------------------------------------------------------------
+
+/// ACCEPTANCE (b): a ∀ on a SUPER-role constrains an edge asserted on a SUB-role.
+/// With `S ⊑ R`: `(∀R.B)(a)`, `S(a,b)`, `(¬B)(b)` is unsat — the ∀R.B must propagate
+/// B across the S-edge because S ⊑* R. WITHOUT the hierarchy axiom the same ABox is sat
+/// (∀R.B says nothing about a plain S-edge).
+#[test]
+fn forall_on_super_role_constrains_sub_role_edge_pair() {
+    let abox = vec![
+        is_a(IA, CE::only(R, named(B))),
+        edge(IA, S, IB),
+        is_a(IB, not(named(B))),
+    ];
+
+    let mut with_hierarchy = abox.clone();
+    with_hierarchy.push(subrole(S, R));
+    assert_eq!(
+        consistency(&onto(with_hierarchy), Budget::default()),
+        Verdict::Unsatisfiable,
+        "S ⊑ R must route ∀R.B onto the S-edge"
+    );
+
+    assert_eq!(
+        consistency(&onto(abox), Budget::default()),
+        Verdict::Satisfiable,
+        "without S ⊑ R the ∀R.B does not constrain an S-edge"
+    );
+}
+
+/// The hierarchy is closed TRANSITIVELY: `S ⊑ T`, `T ⊑ R` routes `∀R.B` onto an S-edge.
+#[test]
+fn forall_routes_through_transitive_role_hierarchy() {
+    let o = onto(vec![
+        subrole(S, T),
+        subrole(T, R),
+        is_a(IA, CE::only(R, named(B))),
+        edge(IA, S, IB),
+        is_a(IB, not(named(B))),
+    ]);
+    assert_eq!(consistency(&o, Budget::default()), Verdict::Unsatisfiable);
+}
+
+/// The hierarchy also applies to ∃-GENERATED tree edges, and the ∃-rule's satisfaction
+/// check matches modulo ⊑* as well: with `S ⊑ R`, `a : ∃S.A ⊓ ∀R.¬A` is unsat (the
+/// generated S-successor holds A and receives ¬A); without the hierarchy it is sat.
+#[test]
+fn forall_on_super_role_constrains_generated_sub_role_edge_pair() {
+    let concept = and(vec![CE::some(S, named(A)), CE::only(R, not(named(A)))]);
+
+    let unsat = onto(vec![subrole(S, R), is_a(IA, concept.clone())]);
+    assert_eq!(consistency(&unsat, Budget::default()), Verdict::Unsatisfiable);
+
+    let sat = onto(vec![is_a(IA, concept)]);
+    assert_eq!(consistency(&sat, Budget::default()), Verdict::Satisfiable);
+}
+
+// -------------------------------------------------------------------------------------------
+// (b) further sat/unsat pairs — ∃/∀ interplay, desugared axioms
+// -------------------------------------------------------------------------------------------
+
+/// `∃R.A ⊓ ∀R.¬A` is the textbook local clash after one expansion; `∃R.A ⊓ ∀R.B` is sat
+/// (the successor simply holds both A and B).
+#[test]
+fn exists_forall_interaction_pair() {
+    let unsat = onto(vec![is_a(
+        IA,
+        and(vec![CE::some(R, named(A)), CE::only(R, not(named(A)))]),
+    )]);
+    assert_eq!(consistency(&unsat, Budget::default()), Verdict::Unsatisfiable);
+
+    let sat = onto(vec![is_a(
+        IA,
+        and(vec![CE::some(R, named(A)), CE::only(R, named(B))]),
+    )]);
+    assert_eq!(consistency(&sat, Budget::default()), Verdict::Satisfiable);
+}
+
+/// `owl:disjointWith` desugars to `A ⊓ B ⊑ ⊥`.
+#[test]
+fn disjointness_pair() {
+    let unsat = onto(vec![
+        Axiom::DisjointClasses(named(A), named(B)),
+        is_a(IA, named(A)),
+        is_a(IA, named(B)),
+    ]);
+    assert_eq!(consistency(&unsat, Budget::default()), Verdict::Unsatisfiable);
+
+    let sat = onto(vec![
+        Axiom::DisjointClasses(named(A), named(B)),
+        is_a(IA, named(A)),
+    ]);
+    assert_eq!(consistency(&sat, Budget::default()), Verdict::Satisfiable);
+}
+
+/// `owl:equivalentClass` desugars to a GCI in EACH direction — both must bite.
+#[test]
+fn equivalence_desugars_to_both_gcis() {
+    let equiv = Axiom::EquivalentClasses(named(A), and(vec![named(B), named(C)]));
+    // Forward (A ⊑ B ⊓ C): a : A ⊓ ¬B is unsat.
+    let forward = onto(vec![
+        equiv.clone(),
+        is_a(IA, named(A)),
+        is_a(IA, not(named(B))),
+    ]);
+    assert_eq!(consistency(&forward, Budget::default()), Verdict::Unsatisfiable);
+    // Backward (B ⊓ C ⊑ A): a : B ⊓ C ⊓ ¬A is unsat.
+    let backward = onto(vec![
+        equiv.clone(),
+        is_a(IA, named(B)),
+        is_a(IA, named(C)),
+        is_a(IA, not(named(A))),
+    ]);
+    assert_eq!(consistency(&backward, Budget::default()), Verdict::Unsatisfiable);
+    // Consistent use.
+    let sat = onto(vec![equiv, is_a(IA, named(A))]);
+    assert_eq!(consistency(&sat, Budget::default()), Verdict::Satisfiable);
+}
+
+/// `rdfs:domain` (∃R.⊤ ⊑ D) and `rdfs:range` (⊤ ⊑ ∀R.B) both constrain asserted edges.
+#[test]
+fn domain_and_range_pairs() {
+    let domain = Axiom::ObjectPropertyDomain {
+        property: OPE::ObjectProperty(R),
+        domain: named(D),
+    };
+    let range = Axiom::ObjectPropertyRange {
+        property: OPE::ObjectProperty(R),
+        range: named(B),
+    };
+    let unsat_domain = onto(vec![
+        domain.clone(),
+        edge(IA, R, IB),
+        is_a(IA, not(named(D))),
+    ]);
+    assert_eq!(
+        consistency(&unsat_domain, Budget::default()),
+        Verdict::Unsatisfiable
+    );
+    let unsat_range = onto(vec![
+        range.clone(),
+        edge(IA, R, IB),
+        is_a(IB, not(named(B))),
+    ]);
+    assert_eq!(
+        consistency(&unsat_range, Budget::default()),
+        Verdict::Unsatisfiable
+    );
+    let sat = onto(vec![domain, range, edge(IA, R, IB)]);
+    assert_eq!(consistency(&sat, Budget::default()), Verdict::Satisfiable);
+}
+
+/// TBox-only inconsistency: Direct-Semantics domains are NON-EMPTY, so `⊤ ⊑ ⊥` with an
+/// empty ABox is inconsistent — while `A ⊑ ⊥` alone is fine (A is simply empty).
+#[test]
+fn tbox_only_ontology_checked_over_nonempty_domain() {
+    let unsat = onto(vec![subclass(CE::Thing, CE::Nothing)]);
+    assert_eq!(consistency(&unsat, Budget::default()), Verdict::Unsatisfiable);
+
+    let sat = onto(vec![subclass(named(A), CE::Nothing)]);
+    assert_eq!(consistency(&sat, Budget::default()), Verdict::Satisfiable);
+}
+
+/// Class satisfiability w.r.t. a TBox: `A ⊑ B`, `A ⊑ ¬B` makes A unsatisfiable while B
+/// stays satisfiable.
+#[test]
+fn class_satisfiability_pair() {
+    let o = onto(vec![
+        subclass(named(A), named(B)),
+        subclass(named(A), not(named(B))),
+    ]);
+    assert_eq!(
+        class_satisfiability(&named(A), &o, Budget::default()),
+        Verdict::Unsatisfiable
+    );
+    assert_eq!(
+        class_satisfiability(&named(B), &o, Budget::default()),
+        Verdict::Satisfiable
+    );
+}
+
+// -------------------------------------------------------------------------------------------
+// (c) Fragment rejection — fail-closed Unknown(OutOfFragment) BEFORE the tableau
+// -------------------------------------------------------------------------------------------
+
+/// ACCEPTANCE (c): `owl:inverseOf` is outside ALCH (the deferral the module docs argue is
+/// load-bearing for subset blocking) — the real pipeline must abstain, not guess.
+#[test]
+fn fragment_rejection_inverse_roles_yield_unknown_out_of_fragment() {
+    let v = check_turtle(
+        ":r owl:inverseOf :s .\n:A rdfs:subClassOf :B .",
+        Budget::default(),
+    );
+    match v {
+        Verdict::Unknown(UnknownReason::OutOfFragment(msg)) => {
+            assert!(!msg.is_empty(), "diagnostic must not be empty");
+        }
+        other => panic!("expected Unknown(OutOfFragment), got {:?}", other),
+    }
+}
+
+/// Cardinality restrictions are outside ALCH: fail-closed abstention, and the presence of
+/// otherwise-mappable axioms in the same graph must NOT rescue a verdict (the checker
+/// never reasons over a partially-understood graph).
+#[test]
+fn fragment_rejection_cardinality_yields_unknown_out_of_fragment() {
+    let v = check_turtle(
+        ":A rdfs:subClassOf [ a owl:Restriction ; owl:onProperty :p ; \
+         owl:minCardinality \"1\"^^xsd:nonNegativeInteger ] .\n\
+         :x a :A .",
+        Budget::default(),
+    );
+    assert!(
+        matches!(v, Verdict::Unknown(UnknownReason::OutOfFragment(_))),
+        "expected Unknown(OutOfFragment), got {:?}",
+        v
+    );
+}
+
+// -------------------------------------------------------------------------------------------
+// (d) Budget exhaustion — Unknown(ResourceBudget), never a verdict
+// -------------------------------------------------------------------------------------------
+
+/// ACCEPTANCE (d): the same cyclic TBox as the canary, but with a node cap too small for
+/// blocking to be reached: the run must abstain with the NODES budget — it must not
+/// fabricate a verdict from a truncated search.
+#[test]
+fn node_budget_exhaustion_yields_unknown_not_a_verdict() {
+    let o = onto(vec![subclass(CE::Thing, CE::some(R, named(C)))]);
+    let starved = Budget {
+        max_nodes: 2,
+        max_rule_applications: 10_000,
+    };
+    assert_eq!(
+        consistency(&o, starved),
+        Verdict::Unknown(UnknownReason::ResourceBudget(ExhaustedBudget::Nodes))
+    );
+}
+
+/// Rule-application starvation trips the other budget arm — again an abstention, never a
+/// verdict, even though the ontology is in fact satisfiable.
+#[test]
+fn rule_budget_exhaustion_yields_unknown_not_a_verdict() {
+    let o = onto(vec![subclass(CE::Thing, CE::some(R, named(C)))]);
+    let starved = Budget {
+        max_nodes: 1_000,
+        max_rule_applications: 1,
+    };
+    assert_eq!(
+        consistency(&o, starved),
+        Verdict::Unknown(UnknownReason::ResourceBudget(
+            ExhaustedBudget::RuleApplications
+        ))
+    );
+}
+
+/// Budgets and search order are deterministic: identical inputs give identical outcomes,
+/// including WHICH budget arm trips (module docs §6; wall-clock budgets are banned).
+#[test]
+fn outcomes_are_deterministic_across_runs() {
+    let branching = onto(vec![
+        subclass(named(A), or(vec![named(B), named(C)])),
+        subclass(named(B), CE::Nothing),
+        subclass(named(C), CE::Nothing),
+        is_a(IA, named(A)),
+    ]);
+    assert_eq!(
+        consistency(&branching, Budget::default()),
+        consistency(&branching, Budget::default())
+    );
+    let cyclic = onto(vec![subclass(CE::Thing, CE::some(R, named(C)))]);
+    let starved = Budget {
+        max_nodes: 2,
+        max_rule_applications: 10_000,
+    };
+    assert_eq!(consistency(&cyclic, starved), consistency(&cyclic, starved));
+}
+
+// -------------------------------------------------------------------------------------------
+// End-to-end through the real RDF pipeline (Turtle → Dict → extract → tableau)
+// -------------------------------------------------------------------------------------------
+
+/// A real-path sat/unsat pair: disjoint classes with an individual asserted into both.
+#[test]
+fn end_to_end_turtle_consistency_pair() {
+    let unsat = check_turtle(
+        ":A owl:disjointWith :B .\n:x a :A .\n:x a :B .",
+        Budget::default(),
+    );
+    assert_eq!(unsat, Verdict::Unsatisfiable);
+
+    let sat = check_turtle(":A owl:disjointWith :B .\n:x a :A .", Budget::default());
+    assert_eq!(sat, Verdict::Satisfiable);
+}
+
+/// A real-path role-hierarchy pair mirroring the structural-model test: a range on the
+/// SUPER-role constrains an edge asserted on the SUB-role.
+#[test]
+fn end_to_end_turtle_range_through_subproperty() {
+    let unsat = check_turtle(
+        ":p a owl:ObjectProperty .\n:q a owl:ObjectProperty .\n\
+         :p rdfs:subPropertyOf :q .\n:q rdfs:range :B .\n\
+         :x :p :y .\n:y a [ owl:complementOf :B ] .",
+        Budget::default(),
+    );
+    assert_eq!(unsat, Verdict::Unsatisfiable);
+
+    let sat = check_turtle(
+        ":p a owl:ObjectProperty .\n:q a owl:ObjectProperty .\n\
+         :q rdfs:range :B .\n:x :p :y .\n:y a [ owl:complementOf :B ] .",
+        Budget::default(),
+    );
+    assert_eq!(sat, Verdict::Satisfiable);
+}

--- a/crates/sparq-reason-dl/tests/tableau.rs
+++ b/crates/sparq-reason-dl/tests/tableau.rs
@@ -158,6 +158,36 @@ fn cyclic_tbox_with_universal_contradiction_is_unsatisfiable() {
     assert_eq!(consistency(&o, Budget::default()), Verdict::Unsatisfiable);
 }
 
+/// Blocking must not mask an inconsistency that only becomes visible BEYOND depth 1:
+/// `A ⊑ ∃R.B`, `B ⊑ ∃R.Q`, `Q ⊑ ⊥` with `A(a)` clashes only when the depth-1 node is
+/// expanded to depth 2 — an implementation that wrongly blocks non-root nodes (whose
+/// labels are NOT subsets of an ancestor's) would report Satisfiable. (Mutation-derived
+/// canary: an over-eager `is_blocked` passed every other unsat test in this suite.)
+#[test]
+fn unsat_beyond_depth_one_is_not_masked_by_blocking() {
+    let o = onto(vec![
+        subclass(named(A), CE::some(R, named(B))),
+        subclass(named(B), CE::some(R, named(C))),
+        subclass(named(C), CE::Nothing),
+        is_a(IA, named(A)),
+    ]);
+    assert_eq!(consistency(&o, Budget::default()), Verdict::Unsatisfiable);
+}
+
+/// The blocking test must be `L(descendant) ⊆ L(ancestor)` and not the REVERSE: with
+/// `⊤ ⊑ ∃R.(∃S.Q)` and `Q ⊑ ⊥`, the depth-1 node's label is a STRICT SUPERSET of the
+/// root's (it carries the extra `∃S.Q`), so superset-"blocking" would freeze it and
+/// wrongly report Satisfiable; correct subset blocking must expand it and find the `Q`
+/// clash on every branch.
+#[test]
+fn strict_superset_of_ancestor_must_not_block() {
+    let o = onto(vec![
+        subclass(CE::Thing, CE::some(R, CE::some(S, named(C)))),
+        subclass(named(C), CE::Nothing),
+    ]);
+    assert_eq!(consistency(&o, Budget::default()), Verdict::Unsatisfiable);
+}
+
 // -------------------------------------------------------------------------------------------
 // (b) sat/unsat pairs — ⊔-branching with backtracking
 // -------------------------------------------------------------------------------------------

--- a/crates/sparq-reason-dl/tests/tableau.rs
+++ b/crates/sparq-reason-dl/tests/tableau.rs
@@ -545,3 +545,20 @@ fn end_to_end_turtle_range_through_subproperty() {
     );
     assert_eq!(sat, Verdict::Satisfiable);
 }
+
+/// Adversarial-verify canary (PR #1475 round-2): blocking must gate ONLY the generating
+/// (∃) rule — the ∀-rule must keep firing into an already-blocked node. The unsound
+/// mutant that gates the ∀-rule on blocked targets passes every earlier test but returns
+/// a wrong `Satisfiable` here: with `A(a)` seeded, the ∃-child of the root is blocked
+/// (its label is a subset of the root's) exactly when the ∀-propagation of `¬A` into it
+/// is what exposes the clash. Truly Unsatisfiable: A ⊑ ∃R.A forces an R-successor in A,
+/// while A ⊑ ∀R.¬A forces every R-successor out of A.
+#[test]
+fn forall_must_fire_into_already_blocked_node() {
+    let o = onto(vec![
+        subclass(named(A), CE::some(R, named(A))),
+        subclass(named(A), CE::only(R, not(named(A)))),
+        is_a(IA, named(A)),
+    ]);
+    assert_eq!(consistency(&o, Budget::default()), Verdict::Unsatisfiable);
+}

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -207,9 +207,9 @@ match as_conjunctive_query(&q) { Ok(_cq) => {}, Err(CqError::OutOfScope(why)) =>
 - **Oracle-tested; the FORMAL DL-Lite_R suite GRADUATED to a pinned floor (sq-qo1a9).** Validated against a hand-checked DL-Lite_R oracle (`sparq-reason-ql/tests/oracle.rs`, incl. tree-witness + minimisation cases), because no Rust PerfectRef reference exists to diff against. There is **no consistency checking**. On the **formal DL-Lite_R suite** — the hand-derived certain-answer oracle from `sq-g19x0`, every case a conjunctive query within sound rewriting — the rewrite is **sound AND complete case by case**: `rewrite_production`'s UCQ, evaluated over the **unmodified ABox** through the real engine, returns **exactly** the hand-derived certain answers. That is now a **pinned floor** (`sparq-conformance`'s `tests/ql_dllite_suite.rs`, opt-in `ql-experimental`; `QL_DLLITE_FLOOR = 11` sound-and-complete cases), registered as a **`sparq extension`** row in the central scoreboard (`scoreboard::SUITES`) and tallied **separately** — **NOT folded into the standards-conformance total**, and **NOT a full-OWL-2-QL-conformance claim** (there is no runnable normative W3C QL certain-answer suite; the W3C QL material is structural). Like the RIF-Core / RSP / BM25 extension rows, it pins a faithful sparq-OWN oracle. `QL_DLLITE_FLOOR` is read textually by `tests/scoreboard_floors.rs`, so the mirrored scoreboard value cannot drift.
 - **The BROADER `pr:QL` `sparql11/entailment` arm stays EXPERIMENTAL / OutOfScope (sq-kuvu3, opt-in `sparq-conformance/ql-experimental`).** That set is **not** the formal DL-Lite_R suite: it mixes intensional / non-DL-Lite certain-answer cases the sound rewriting fragment cannot answer. The rewriter runs over every `sd:EntailmentProfile pr:QL` case — each conjunctive query rewritten by `rewrite_production` and evaluated over the **unmodified data**, then compared to the suite oracle — and the harness reports **HONESTLY as experimental / OutOfScope, NEVER a graduated conformance pass** (NO floor `const` for this arm, NO row summed into any total). Outcomes (all OutOfScope): an **ABSTAIN** when the fail-closed CQ-shape gate rejects a non-conjunctive / non-DL-Lite query (never a guess), a **computed result-equivalent** evidence row when the rewritten UCQ genuinely matches the oracle, a **computed-DIVERGENT** row when it does not (an honest gap — e.g. an intensional `?c rdfs:subClassOf …` TBox query a certain-ABox-answer rewriter cannot answer), or an **inconclusive** setup-failure row. The runner is `sparq-conformance`'s `tests/ql_experimental_arm.rs` (asserts the honesty invariants — every row OutOfScope, at least one fail-closed abstain — NOT a pass-count floor); the inference binary prints the experimental QL section only with the feature on.
 
-## OWL 2 Direct Semantics (`sparq-reason-dl`, separate opt-in crate — L1 structural model + L2 profile checker built)
+## OWL 2 Direct Semantics (`sparq-reason-dl`, separate opt-in crate — L1 structural model + L2 profile checker + L3 ALCH tableau built)
 
-The three profile reasoners above (RL / EL / QL) each cover a *tractable* OWL fragment; **OWL 2 Direct Semantics** (the model-theoretic DL semantics) covers the boolean heart of DL — arbitrary `⊔` / `¬` / `∀` — that none of them can reach. `sparq-reason-dl` is a **separate opt-in crate** building a **layered, fail-closed Direct-Semantics checker**; **layers L1 (structural model + extractor) and L2 (syntactic EL/QL/RL profile checker) are built**; it does **NO semantic reasoning**. HONEST SCOPE: this is **not** full OWL 2 DL (SROIQ(D) satisfiability is 2NEXPTIME-complete and deliberately out of scope) — it is a scoped **ALCH-fragment** effort whose L1 delivers only:
+The three profile reasoners above (RL / EL / QL) each cover a *tractable* OWL fragment; **OWL 2 Direct Semantics** (the model-theoretic DL semantics) covers the boolean heart of DL — arbitrary `⊔` / `¬` / `∀` — that none of them can reach. `sparq-reason-dl` is a **separate opt-in crate** building a **layered, fail-closed Direct-Semantics checker**; **layers L1 (structural model + extractor), L2 (syntactic EL/QL/RL profile checker), and L3 (ALCH tableau — the first layer that does semantic reasoning) are built**. HONEST SCOPE: this is **not** full OWL 2 DL (SROIQ(D) satisfiability is 2NEXPTIME-complete and deliberately out of scope) — it is a scoped **ALCH-fragment** effort, sound/complete only within the argued fragment. L1 delivers:
 
 - **A structural OWL model** (`sparq_reason_dl::model`) — `Axiom` / `ClassExpression` / `ObjectPropertyExpression` typed enums for the ALCH fragment: named classes, `owl:Thing`/`owl:Nothing`, `owl:intersectionOf` (⊓), `owl:unionOf` (⊔), `owl:complementOf` (¬), `owl:someValuesFrom` (∃R.C) and `owl:allValuesFrom` (∀R.C) over **named object properties**; GCIs, `owl:equivalentClass`, `owl:disjointWith`, `rdfs:subPropertyOf`, `rdfs:domain`/`rdfs:range`, and a ground ABox. Purely structural — **no semantics attached at L1**.
 - **A FAIL-CLOSED reverse RDF mapping** — `extract(&Dict, &[[Id; 3]]) -> Result<Ontology, ExtractError>` maps the `(Dict, triples)` substrate into the model per the W3C *Mapping to RDF Graphs* tables restricted to ALCH. **A single out-of-fragment or malformed triple aborts the WHOLE extraction** with a typed `ExtractError`, rather than being silently dropped: the (future) checker must never reason over a graph it only *partially* understood — a dropped axiom can flip a consistency verdict. Understood in full, or refused. The rejection taxonomy has five arms — `OutOfFragment` (cardinality / nominals / inverses / `owl:sameAs` / property characteristics / chains / keys), `DataConstruct` (datatypes / data properties — no concrete domain in L1), `MalformedList`, `MalformedClassExpression`, `Unclassifiable` (an undeclared predicate that cannot be mapped soundly) — while annotations, declarations, and ontology headers are recognised and ignored.
@@ -224,12 +224,33 @@ Convenience methods: `Membership::is_in()` / `is_not_in()` / `is_unknown()`;
 `ProfileSet::in_all()` / `in_any()`. An empty ontology is `In` all three profiles. Terminating
 by construction — no semantic reasoning, just a grammar walk over the finite acyclic structural model.
 
-**Not yet built (reserved stubs, later beads):** the terminating ALCH tableau (L3,
-`nnf`/`tableau`), the fragment-dispatch checker + entailment-by-refutation (L4, `check`), and
-the `sparq-conformance` DIRECT-arm (L5). Deferred constructs — inverse roles,
-cardinality/functionality, nominals, transitivity, `sameAs`/`differentFrom`, datatypes, keys —
-are each **rejected, never mis-mapped**, with a named reason and unlock path in the design
-record's deferral ledger. See `research/owl2-direct-semantics-scoping.md`.
+**L3 — terminating ALCH tableau (`nnf` + `tableau`, bead sq-pbz04.4.3):** NOW BUILT — the
+consistency / class-satisfiability core. `tableau::consistency(&Ontology, Budget)` and
+`tableau::class_satisfiability(&ClassExpression, &Ontology, Budget)` return a tri-state
+`Verdict` — `Satisfiable`, `Unsatisfiable`, or `Unknown(UnknownReason)` — and
+`tableau::consistency_from_extraction(&Result<Ontology, ExtractError>, Budget)` is the
+fail-closed RDF-level entry: ANY extraction failure yields `Unknown(OutOfFragment)` BEFORE the
+tableau starts (the checker never reasons over a partially-understood graph). The engine is a
+completion-forest tableau with GCI internalisation, `⊓`/`⊔`/`∃`/`∀`/GCI rules matched modulo
+the `rdfs:subPropertyOf` closure, **ancestor subset blocking** (sufficient precisely because
+ALCH has no inverse roles), and chronological backtracking over `⊔`-branches. The full
+termination / soundness / completeness argument — citing Baader–Sattler 2001, including why
+subset blocking would be insufficient with inverses — is reproduced in the `tableau` module
+docs (§3–§5). Budgets are **deterministic counts only** (`Budget { max_nodes,
+max_rule_applications }`; wall-clock budgets banned); exhaustion yields
+`Unknown(ResourceBudget)`, **never a verdict**. `nnf` provides the negation-normal-form
+rewrite (`nnf` / `nnf_complement` / `is_nnf`) and the finite `subexpression_closure` the
+termination argument rests on. HONEST BOUNDARY: verdicts are sound/complete ONLY for the exact
+ALCH fragment (named classes, ⊤/⊥, ⊓/⊔/¬, ∃/∀ over named properties, GCIs, `subPropertyOf`,
+ground ABox) — never beyond it; the implementation is not claimed worst-case optimal (ALC+GCI
+satisfiability is EXPTIME-complete).
+
+**Not yet built (reserved stubs, later beads):** the fragment-dispatch checker +
+entailment-by-refutation (L4, `check`) and the `sparq-conformance` DIRECT-arm (L5). Deferred
+constructs — inverse roles, cardinality/functionality, nominals, transitivity,
+`sameAs`/`differentFrom`, datatypes, keys — are each **rejected, never mis-mapped**, with a
+named reason and unlock path in the design record's deferral ledger. See
+`research/owl2-direct-semantics-scoping.md`.
 
 ## Common recipes
 


### PR DESCRIPTION
> 🤖 SPARQ agent (Fable 5). Implements bead **sq-pbz04.4.3** — DL L3: the ALCH tableau consistency/satisfiability core, per `research/owl2-direct-semantics-scoping.md` §3 (the spec). Wave-2 sibling of #1469 (L2); files strictly disjoint from L1 (#1456) and L2.

## What this adds

- **`crates/sparq-reason-dl/src/nnf.rs`** — negation normal form over the L1 `ClassExpression` (`nnf`, `nnf_complement`, `is_nnf`) + the finite **`subexpression_closure`** the termination argument rests on.
- **`crates/sparq-reason-dl/src/tableau.rs`** — the completion-forest tableau: GCI internalisation (`U = nnf(¬C) ⊔ nnf(D)`), ⊓/⊔/∃/∀/GCI rules matched modulo the `rdfs:subPropertyOf` reflexive-transitive closure, **ancestor SUBSET blocking** (dynamic — re-evaluated on current labels, never cached), chronological backtracking over ⊔-branches, clash = `{A, ¬A}` or `⊥`. Public surface: `consistency`, `class_satisfiability`, `consistency_from_extraction`, `Verdict`/`UnknownReason`/`ExhaustedBudget`/`Budget`.
- **The soundness-critical prose** (bead acceptance): the tableau module docs §3–§5 reproduce the full termination + soundness + completeness argument citing Baader–Sattler 2001 (+ Horrocks–Sattler 1999), **including the load-bearing note on why subset blocking suffices in the ABSENCE of inverse roles** (no construct propagates constraints upward against edge direction, so the blocked-node redirect burdens the blocker with nothing; with inverses the blocker's `∀R⁻` obligations would leak to a predecessor that never saw them → equality/pairwise blocking required). Written from the literature, aligned line-by-line with the implementation; it expects adversarial verification.

## Honest fragment boundary

Verdicts are made **only** for exact ALCH (named classes, ⊤/⊥, ⊓/⊔/¬, ∃/∀ over NAMED object properties, GCIs, `subPropertyOf` hierarchies, ground ABox). Everything else — inverses, transitivity, cardinality, nominals, datatypes, `sameAs` — is refused **fail-closed** as `Unknown(OutOfFragment)` BEFORE the tableau starts. Budgets are deterministic **counts only** (`max_nodes` / `max_rule_applications`); exhaustion is `Unknown(ResourceBudget)`, **never a verdict**; wall-clock budgets banned. This is NOT an OWL 2 DL reasoner and is not claimed worst-case optimal (ALC+GCI sat is EXPTIME-complete). README + `skills/inference/SKILL.md` carry the same boundary.

## Acceptance tests (`cargo test -p sparq-reason-dl --test tableau`, 24 tests)

- **(a) blocking-termination canary**: `⊤ ⊑ ∃R.C` (empty ABox) returns `Satisfiable` under `max_nodes = 4` — a verdict under a tight cap proves blocking fired, not budget exhaustion; variants: root-as-blocker (`C ⊑ ∃R.C`), two-class cycle, and the CONVERSE canary (`⊤ ⊑ ∃R.A`, `⊤ ⊑ ∀R.¬A` → `Unsatisfiable`, blocking must not mask inconsistency).
- **(b) sat/unsat pairs**: ⊔-branching incl. backtracking past a clashing first disjunct; **∀ on a super-role constraining an edge asserted on a sub-role** (with/without `S ⊑ R`, transitive chains, and on ∃-generated edges); ∃/∀ interplay; disjointness/equivalence/domain/range desugarings; TBox-only non-empty-domain (`⊤ ⊑ ⊥` w/ empty ABox is unsat).
- **(c) fragment rejection**: `owl:inverseOf` and `owl:minCardinality` through the REAL Turtle → Dict → `extract` path yield `Unknown(OutOfFragment)`.
- **(d) budget exhaustion**: node-starved and rule-starved runs yield `Unknown(ResourceBudget(Nodes|RuleApplications))` respectively — never a verdict — and outcomes (incl. WHICH budget trips) are deterministic across runs.

**Mutation spot-checks** (done in-worktree, mutants reverted): (1) blocking disabled → 3 canaries red; (2) blocking over-eager (always true) → initially only a budget test went red because every unsat case clashed at depth ≤ 1, so I added two mutation-derived soundness canaries — `unsat_beyond_depth_one_is_not_masked_by_blocking` and `strict_superset_of_ancestor_must_not_block` (subset-DIRECTION sensitivity) — now 3 red; (3) subset direction swapped → 2 red; (4) role-hierarchy closure ignored → 4 red.

## Gates (both feature states — the crate has `default = []` and no cargo features yet; opt-in = depending on the crate)

- `cargo build --workspace` ✅; `cargo clippy --workspace --all-targets -- -D warnings` ✅ (default) and ✅ with `--all-features`
- `cargo test -p sparq-reason-dl` ✅ and `--all-features` ✅ (139 tests: 16 lib-unit incl. one direct test per new public fn, 57 extract, 41 profile, 24 tableau, 1 README doctest)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` ✅ (feature-gated intra-doc-link trap avoided — code spans used for cross-module prose)
- `python3 scripts/check-readme-template.py --enforce` ✅ 0 deviations; README 98/120 lines; `typos` ✅
- No `unsafe` (crate is `#![forbid(unsafe_code)]`); no perf numbers added anywhere.

## Judgment calls (proceed-and-document; none contradict the design record)

1. **README + SKILL.md edited although outside the bead's EXCLUSIVE-FILES list** — that list coordinated the parallel L2∥L3 wave; L2 is merged, so no collision, and the shared public-API → docs rule requires the sync. `Cargo.toml`/`lib.rs` untouched (owned by L4, sq-pbz04.4.4).
2. **Verdict naming `Satisfiable`/`Unsatisfiable`** (design record §3 says "Consistent"/"Inconsistent" verdicts): one enum serves both the consistency and class-satisfiability entry points; the rustdoc states the consistency reading explicitly.
3. **All five `ExtractError` arms map to `Unknown(OutOfFragment)`** — incl. malformed-encoding arms, as the fail-closed reading of "anything the mapping could not understand"; the `UnknownReason::OutOfFragment` doc says so and carries the rendered error.
4. **`max_nodes` counts roots too** (an ABox larger than the cap aborts immediately as `Unknown`), and both counters are monotone across backtracking — documented as work measures, keeping determinism trivial.
5. **Blocking gates ONLY the ∃-rule; all other rules keep firing on/into blocked nodes** — this is what keeps the subset test fresh (a blocked node can unblock as labels grow); argued in module docs §2/§5.

## Discovered work

- Possible follow-up (conditional, not beaded as blocking): the search clones the forest per ⊔-disjunct trial and rescans per pass — deliberately simple and budget-bounded; if the L5 conformance lane (sq-pbz04.4.5) hits CI budgets on the real corpus, a trail-based undo + dirty-queue pass is the obvious optimisation.

**Do not arm** — soundness surface; awaiting independent adversarial verification of the §3–§5 argument against Baader–Sattler 2001. Bead sq-pbz04.4.3 stays open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
