### PR TITLE
feat(engine): Kani result-equivalence proofs for columnar reducers (sq-sqtk2.3) [SONNET-4.6]

### DIFF
--- a/crates/sparq-engine/Cargo.toml
+++ b/crates/sparq-engine/Cargo.toml
@@ -313,3 +313,11 @@ sparq-introspect = { path = "../sparq-introspect", version = "0.1.0" }
 # (the native writer emits JSON by hand and pulls in nothing). serde_json is already in
 # the workspace tree (sparq-server / the `service` feature).
 serde_json = "1"
+
+# [SONNET-4.6] sq-sqtk2.3 — register the `kani` cfg so the `#[cfg(all(kani, feature =
+# "vectorized"))]` bounded-proof harnesses in `reduce.rs` do not trip `-D warnings`
+# (unexpected_cfgs) on the normal build. `cargo kani` sets this cfg itself when it
+# model-checks; under a normal build the harness module is stripped. Mirrors
+# crates/sparq-core/Cargo.toml and crates/sparq-vectors/Cargo.toml.
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(kani)"] }

--- a/crates/sparq-engine/src/reduce.rs
+++ b/crates/sparq-engine/src/reduce.rs
@@ -249,8 +249,9 @@ mod tests {
 // STATED BOUNDS (document honestly; "proved beyond bound" means extrapolated by induction
 // on the loop body, not model-checked):
 //   * Slice length: 0..=MAX_SLICE = 8 (the same element count per probe, not per-group row
-//     count at query time — production groups can be larger; this bound covers every
-//     distinct execution path through the reducer loop body).
+//     count at query time — production groups can be larger; 8 is a pragmatic Kani bound,
+//     not a completeness claim: behavior beyond this length is not model-checked — for
+//     example, reduce_sum's i128 accumulation can exceed i64::MAX at large cardinality). [SONNET-4.6]
 //   * reduce_sum / reduce_min_id / reduce_max_id: each element value is fully symbolic in
 //     [0, INLINE_MAX_I64] (= [0, 2^30 - 1]); the id encoding is id = INLINE_BASE + value.
 //   * reduce_count: each element is fully symbolic over the entire u32 domain (no assume on
@@ -274,8 +275,9 @@ mod kani_proofs {
     use sparq_core::dict::{is_inline, Id, INLINE_BASE, NO_ID};
 
     /// Maximum slice length for the bounded proofs. CBMC symbolic exploration is exponential
-    /// in slice length, so a small bound (8) is picked; every distinct execution path through
-    /// a single-element reducer loop body is covered — no new branches appear beyond length 1.
+    /// in slice length, so 8 is chosen as a pragmatic bound; properties are verified
+    /// exhaustively up to this length and extrapolated by induction beyond it, but
+    /// behavior beyond MAX_SLICE is not model-checked. [SONNET-4.6]
     const MAX_SLICE: usize = 8;
 
     /// Build a symbolic Vec of `len` inline ids, each constrained to

--- a/crates/sparq-engine/src/reduce.rs
+++ b/crates/sparq-engine/src/reduce.rs
@@ -234,3 +234,175 @@ mod tests {
         assert_eq!(reduce_count(&[NO_ID, NO_ID]), 0);
     }
 }
+
+// [SONNET-4.6] (sq-sqtk2.3) Kani result-equivalence harnesses for the columnar reducer
+// kernels (SUM/COUNT/MIN/MAX + narrow). Each harness checks that the REAL implementation
+// function (reduce_sum / reduce_count / reduce_min_id / reduce_max_id / narrow_sum_to_i64)
+// equals an INDEPENDENT in-harness reference written as a plain scalar fold — the reference
+// intentionally does NOT call the columnar code to produce the expected value (that would be
+// vacuously true), and it does NOT call the exec.rs scalar path (to keep the TCB small).
+//
+// TIER: PROVED (bounded, slice length ≤ MAX_SLICE = 8; element values fully symbolic in
+// their stated domains). Kani/CBMC explores ALL inputs within the stated bounds exhaustively.
+// TCB: Kani/CBMC + slice-length bound + in-harness reference-as-spec.
+//
+// STATED BOUNDS (document honestly; "proved beyond bound" means extrapolated by induction
+// on the loop body, not model-checked):
+//   * Slice length: 0..=MAX_SLICE = 8 (the same element count per probe, not per-group row
+//     count at query time — production groups can be larger; this bound covers every
+//     distinct execution path through the reducer loop body).
+//   * reduce_sum / reduce_min_id / reduce_max_id: each element value is fully symbolic in
+//     [0, INLINE_MAX_I64] (= [0, 2^30 - 1]); the id encoding is id = INLINE_BASE + value.
+//   * reduce_count: each element is fully symbolic over the entire u32 domain (no assume on
+//     values; the count only tests id != NO_ID which covers all three partitions).
+//   * narrow_sum_to_i64: the input `sum: i128` is FULLY SYMBOLIC over the complete i128
+//     domain — no assume, no loop, proved without a bound (complete domain).
+//
+// The `kani` cfg is registered in crates/sparq-engine/Cargo.toml [lints.rust] so
+// `-D warnings` (unexpected_cfgs) is clean on the normal build. This module compiles ONLY
+// under `cargo kani -p sparq-engine --features vectorized` (Kani injects `cfg(kani)` itself);
+// under all other builds it is stripped to zero bytes — the default build and wasm bundle are
+// byte-identical to before this bead.
+//
+// NON-VACUITY (documented): locally perturbing one accumulation step — e.g. changing
+// `acc += i128::from(id - INLINE_BASE)` to `acc += 1` in `reduce_sum` — causes
+// `reduce_sum_equals_reference_fold` to go RED (counterexample: any non-unit value in the
+// slice). This mutation spot-check is documented in the PR body per the bead requirement.
+#[cfg(all(kani, feature = "vectorized"))]
+mod kani_proofs {
+    use super::*;
+    use sparq_core::dict::{is_inline, Id, INLINE_BASE, NO_ID};
+
+    /// Maximum slice length for the bounded proofs. CBMC symbolic exploration is exponential
+    /// in slice length, so a small bound (8) is picked; every distinct execution path through
+    /// a single-element reducer loop body is covered — no new branches appear beyond length 1.
+    const MAX_SLICE: usize = 8;
+
+    /// Build a symbolic Vec of `len` inline ids, each constrained to
+    /// `[INLINE_BASE, INLINE_BASE + INLINE_MAX_I64]` so every element is a valid inline
+    /// integer id. Values (offsets from INLINE_BASE) are fully symbolic in [0, INLINE_MAX_I64].
+    fn symbolic_inline_ids(len: usize) -> Vec<Id> {
+        let mut v = vec![0u32; len];
+        for id in v.iter_mut() {
+            let raw: u32 = kani::any();
+            kani::assume(raw <= INLINE_MAX_I64 as u32);
+            *id = INLINE_BASE + raw;
+        }
+        v
+    }
+
+    /// PROPERTY: `reduce_sum` on an all-inline slice equals the independent scalar reference
+    /// fold sum-of-decoded-values over the same slice.
+    ///
+    /// The reference is written fresh here — it does NOT call `reduce_sum` (no vacuity) and
+    /// does NOT call the exec.rs scalar path (to keep TCB minimal).
+    ///
+    /// Bound: slice length 0..=MAX_SLICE = 8; values symbolic in [0, INLINE_MAX_I64].
+    #[kani::proof]
+    #[kani::unwind(12)]
+    fn reduce_sum_equals_reference_fold() {
+        let len: usize = kani::any();
+        kani::assume(len <= MAX_SLICE);
+        let ids = symbolic_inline_ids(len);
+
+        // Independent reference: a fresh scalar fold over decoded values.
+        let mut ref_sum: i128 = 0;
+        for &id in ids.iter() {
+            // is_inline holds by construction; assert defensively so Kani can confirm it.
+            assert!(is_inline(id), "all ids must be inline by construction");
+            ref_sum += i128::from(id - INLINE_BASE);
+        }
+
+        // The implementation must return Some(ref_sum) for any all-inline slice.
+        assert_eq!(reduce_sum(&ids), Some(ref_sum));
+    }
+
+    /// PROPERTY: `reduce_count` on any id slice (symbolic over the full u32 domain) equals
+    /// the independent scalar reference count of non-NO_ID elements.
+    ///
+    /// Bound: slice length 0..=MAX_SLICE = 8; element values symbolic over all of u32.
+    #[kani::proof]
+    #[kani::unwind(12)]
+    fn reduce_count_equals_reference() {
+        let len: usize = kani::any();
+        kani::assume(len <= MAX_SLICE);
+        let mut ids = vec![0u32; len];
+        for id in ids.iter_mut() {
+            *id = kani::any(); // fully symbolic: inline, dict id, or NO_ID
+        }
+
+        // Independent reference: count non-NO_ID elements.
+        let mut ref_count: usize = 0;
+        for &id in ids.iter() {
+            if id != NO_ID {
+                ref_count += 1;
+            }
+        }
+
+        assert_eq!(reduce_count(&ids), ref_count);
+    }
+
+    /// PROPERTY: `reduce_min_id` on a non-empty all-inline slice returns the id with the
+    /// minimum decoded value (equivalently, the minimum id, since all share the same
+    /// INLINE_BASE offset and the mapping id → value is strictly monotone).
+    ///
+    /// Bound: slice length 1..=MAX_SLICE = 8; values symbolic in [0, INLINE_MAX_I64].
+    #[kani::proof]
+    #[kani::unwind(12)]
+    fn reduce_min_id_equals_reference() {
+        let len: usize = kani::any();
+        kani::assume(len >= 1 && len <= MAX_SLICE);
+        let ids = symbolic_inline_ids(len);
+
+        // Independent reference: linear scan for the minimum id.
+        // Initialise to u32::MAX (> any inline id: max inline id =
+        // INLINE_BASE + INLINE_MAX_I64 = 3_221_225_471 < u32::MAX = 4_294_967_295).
+        let mut ref_min: Id = u32::MAX;
+        for &id in ids.iter() {
+            if id < ref_min {
+                ref_min = id;
+            }
+        }
+
+        assert_eq!(reduce_min_id(&ids), Some(ref_min));
+    }
+
+    /// PROPERTY: `reduce_max_id` on a non-empty all-inline slice returns the id with the
+    /// maximum decoded value (equivalently, the maximum id).
+    ///
+    /// Bound: slice length 1..=MAX_SLICE = 8; values symbolic in [0, INLINE_MAX_I64].
+    #[kani::proof]
+    #[kani::unwind(12)]
+    fn reduce_max_id_equals_reference() {
+        let len: usize = kani::any();
+        kani::assume(len >= 1 && len <= MAX_SLICE);
+        let ids = symbolic_inline_ids(len);
+
+        // Independent reference: linear scan for the maximum id.
+        // Initialise to 0 (= NO_ID < INLINE_BASE <= any inline id), updated on first element.
+        let mut ref_max: Id = 0;
+        for &id in ids.iter() {
+            if id > ref_max {
+                ref_max = id;
+            }
+        }
+
+        assert_eq!(reduce_max_id(&ids), Some(ref_max));
+    }
+
+    /// PROPERTY: `narrow_sum_to_i64(s)` returns `Some(s as i64)` exactly when
+    /// `s ∈ [i64::MIN, i64::MAX]`, and `None` for every value outside that range.
+    ///
+    /// TIER: PROVED over the COMPLETE i128 domain — no slice, no loop, no unwind bound;
+    /// CBMC handles the 128-bit integer comparison exhaustively.
+    #[kani::proof]
+    fn narrow_sum_to_i64_iff_in_range() {
+        let s: i128 = kani::any(); // fully symbolic, no assume — complete i128 domain
+        let result = narrow_sum_to_i64(s);
+        if s >= i64::MIN as i128 && s <= i64::MAX as i128 {
+            assert_eq!(result, Some(s as i64));
+        } else {
+            assert_eq!(result, None);
+        }
+    }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — bulk Rust implementer (Sonnet 4.6 tier), bead sq-sqtk2.3

## Summary

- Adds a `#[cfg(all(kani, feature = "vectorized"))]` harness module to `crates/sparq-engine/src/reduce.rs` — PROOF-ONLY DIFF, no runtime logic changed
- Registers `cfg(kani)` in `[lints.rust]` for `sparq-engine/Cargo.toml` (mirrors the same pattern already in sparq-core and sparq-vectors)
- Satisfies bead sq-sqtk2.3 (Phase-1 property B-2 from `research/mechanized-proof-program.md` §5): columnar reducer results equal an independent scalar reference fold on all bounded inputs

## Spec and acceptance test

Spec: `research/mechanized-proof-program.md` §5, property B-2 (design record on PR #1472 branch `research/sq-ksvpk-mechanized-proof-program`).

Acceptance: `cargo kani -p sparq-engine --features vectorized` GREEN — all 5 harnesses verified SUCCESSFUL locally (Kani 0.67.0, CBMC 1.29.0, nightly-2025-11-21-aarch64).

## Five harnesses verified SUCCESSFUL

| Harness | Tier | Bounds |
|---------|------|--------|
| `reduce_sum_equals_reference_fold` | PROVED (bounded) | len ≤ 8; values ∈ [0, 2^30-1] |
| `reduce_count_equals_reference` | PROVED (bounded) | len ≤ 8; all-u32 domain |
| `reduce_min_id_equals_reference` | PROVED (bounded) | len ∈ [1,8]; values ∈ [0, 2^30-1] |
| `reduce_max_id_equals_reference` | PROVED (bounded) | len ∈ [1,8]; values ∈ [0, 2^30-1] |
| `narrow_sum_to_i64_iff_in_range` | PROVED (complete domain) | full symbolic i128 — no loop, no bound |

Each reference is a fresh independent scalar loop — it does NOT call the columnar implementation to produce its own expected value (no vacuity), and does NOT call the exec.rs scalar path (TCB stays minimal).

## Non-vacuity mutation spot-check (documented per bead requirement)

Locally perturbed `reduce_sum` by changing `acc += i128::from(id - INLINE_BASE)` to `acc += 1`. Result: `reduce_sum_equals_reference_fold` went RED — counterexample: any slice element with value ≠ 1 (e.g. `id = INLINE_BASE + 0` → `ref_sum += 0` but `impl acc += 1`, mismatch). Reverted before commit. Confirms the harness is non-vacuous.

## Feature flags

- Default (feature OFF): harness module is compiled out entirely — zero bytes added, default build byte-identical
- `vectorized` (feature ON): harnesses compile under `cargo kani --features vectorized`

## Gates — all GREEN in BOTH feature states

- `cargo build -p sparq-engine` (default + vectorized): GREEN
- `cargo clippy -p sparq-engine --all-targets -- -D warnings` (default + vectorized): GREEN  
- `cargo test -p sparq-engine --features vectorized` (incl. `vectorized_exec_differential`): GREEN
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-engine --no-deps --all-features`: GREEN
- `python3 scripts/check-readme-template.py --enforce`: 0 deviations across 48 READMEs
- `cargo kani -p sparq-engine --features vectorized`: 5/5 VERIFICATION SUCCESSFUL

## PR discipline

Auto-merge NOT armed (per bead instructions). Bead NOT closed (per bead instructions). Runtime logic in `reduce.rs` UNCHANGED — this is a proof-only diff.