### PR TITLE
feat(substrate): Kani order-law harnesses for compare_terms — 3 laws proved, mixed-kind intransitivity FOUND + pinned (sq-sqtk2.4) [FABLE-5]/[SONNET-4.6]

### DIFF
--- a/crates/sparq-substrate/Cargo.toml
+++ b/crates/sparq-substrate/Cargo.toml
@@ -96,3 +96,10 @@ oxrdf = { workspace = true }
 name = "substrate"
 harness = false
 required-features = ["join", "numeric"]
+
+# [FABLE-5] sq-sqtk2.4: `compare.rs` hosts `#[cfg(kani)]` bounded-proof harnesses for the
+# term-total-order laws (run: `cargo kani -p sparq-substrate --features compare`). The Kani
+# model checker injects the `kani` cfg; register it so the normal `-D warnings` build does
+# not trip `unexpected_cfgs` (same pattern as sparq-vectors / sparq-core).
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ["cfg(kani)"] }

--- a/crates/sparq-substrate/README.md
+++ b/crates/sparq-substrate/README.md
@@ -81,7 +81,13 @@ let n: Option<Num> = as_numeric(&lit);  // exact xsd:decimal (no f64 rounding)
   for its own term type — a **monomorphisation seam**, never a `dyn` object. `exact_cmp` is the
   f64-collapse recheck: when the lenient `as_f64` arm ties, it recovers the exact order of
   distinct integers beyond 2^53 / high-precision decimals so `ORDER BY` / `MIN` / `MAX` agree
-  with the relational `=`/`<`. Pure-`std`: links nothing new.
+  with the relational `=`/`<`. Pure-`std`: links nothing new. The order laws (reflexivity,
+  antisymmetry-consistency, per-literal-kind transitivity incl. the 2^53 collapse, within-class
+  totality) are machine-checked by Kani bounded-proof harnesses over a model `CompareTerm` impl
+  — `cargo kani -p sparq-substrate --features compare` (sq-sqtk2.4). Honest boundary: the
+  proofs cover the shared ALGORITHM over the bounded model, not the engine's `Value` impl, and
+  mixed literal-KIND literal pairs are NOT transitive (machine-checked witnesses in the
+  harness module document exactly where the law breaks).
 
 All features are **off by default**. The crate is `forbid(unsafe_code)`.
 
@@ -98,6 +104,8 @@ its join hot loops identical to pre-move codegen. This crate introduces no dynam
 
 - `research/shared-eval-substrate.md` — the design record: what is shareable vs
   engine-private, the options considered, and the layered perf-neutrality proof.
+- `research/mechanized-proof-program.md` — the proof program the `compare` Kani harnesses
+  belong to (property B-1), incl. the claim-tier vocabulary and the not-tractable-now ledger.
 - `crates/sparq-core` — the storage substrate this crate's `Id` / dictionary types come from.
 - `crates/sparq-engine` — the consumer that keeps its planner private and calls the shared
   numeric + join kernels through a thin `Bindings`-side adapter.

--- a/crates/sparq-substrate/README.md
+++ b/crates/sparq-substrate/README.md
@@ -81,13 +81,15 @@ let n: Option<Num> = as_numeric(&lit);  // exact xsd:decimal (no f64 rounding)
   for its own term type — a **monomorphisation seam**, never a `dyn` object. `exact_cmp` is the
   f64-collapse recheck: when the lenient `as_f64` arm ties, it recovers the exact order of
   distinct integers beyond 2^53 / high-precision decimals so `ORDER BY` / `MIN` / `MAX` agree
-  with the relational `=`/`<`. Pure-`std`: links nothing new. The order laws (reflexivity,
-  antisymmetry-consistency, per-literal-kind transitivity incl. the 2^53 collapse, within-class
-  totality) are machine-checked by Kani bounded-proof harnesses over a model `CompareTerm` impl
-  — `cargo kani -p sparq-substrate --features compare` (sq-sqtk2.4). Honest boundary: the
-  proofs cover the shared ALGORITHM over the bounded model, not the engine's `Value` impl, and
-  mixed literal-KIND literal pairs are NOT transitive (machine-checked witnesses in the
-  harness module document exactly where the law breaks).
+  with the relational `=`/`<`. Pure-`std`: links nothing new. The order laws — reflexivity and
+  within-class totality (both over the **NaN-free** domain only: an `xsd:double NaN` makes the
+  comparator partial, bead sq-wjl8i), antisymmetry-consistency (NaN included), and
+  per-literal-kind transitivity incl. the 2^53 collapse — are machine-checked by Kani
+  bounded-proof harnesses over a model `CompareTerm` impl — `cargo kani -p sparq-substrate
+  --features compare` (sq-sqtk2.4). Honest boundary: the proofs cover the shared ALGORITHM
+  over the bounded model (per-harness domains documented in the module), not the engine's
+  `Value` impl, and mixed literal-KIND literal pairs are NOT transitive (machine-checked
+  witnesses in the harness module document exactly where the law breaks).
 
 All features are **off by default**. The crate is `forbid(unsafe_code)`.
 

--- a/crates/sparq-substrate/src/compare.rs
+++ b/crates/sparq-substrate/src/compare.rs
@@ -203,6 +203,517 @@ pub fn compare_terms<T: CompareTerm>(x: &T, y: &T) -> Option<Ordering> {
     }
 }
 
+// [FABLE-5] sq-sqtk2.4 (epic sq-sqtk2, property B-1 of `research/mechanized-proof-program.md`
+// §3.2/§5): Kani bounded-proof harnesses for the ORDER LAWS of [`compare_terms`] — the laws
+// `ORDER BY`'s `sort_by` validity rests on (an inconsistent comparator makes Rust's sort
+// panic or produce garbage). HARNESS-ONLY: the `compare_terms` body above is byte-unchanged.
+//
+// WHAT IS PROVED (tier: PROVED (bounded), per the design record's vocabulary) — over every
+// value of the bounded in-harness model `M` below:
+//   • REFLEXIVITY (NaN-free domain):        compare_terms(x, x) == Some(Equal)
+//   • ANTISYMMETRY-CONSISTENCY (full domain, NaN included):
+//        compare_terms(x, y) == Some(o)  iff  compare_terms(y, x) == Some(o.reverse())
+//        (equivalently: None in one direction iff None in the other)
+//   • TRANSITIVITY on the defined domain, per LITERAL KIND (see the honest boundary below):
+//        exact-integer literals INCLUDING the 2^53 f64-collapse straddle, double literals,
+//        string literals, strict/temporal literals, a collapse-free exact/inexact numeric
+//        mix, and recursive triple terms — composed with the non-literal classes
+//   • WITHIN-CLASS TOTALITY (NaN-free domain): same-class pairs always compare `Some`
+//   • EXACT-ORDER AGREEMENT: for exact-tier integer pairs, compare_terms equals the exact
+//     i128 value order even where the f64 images collapse (THE guarantee the `exact_cmp`
+//     recheck tier exists to provide — delete the recheck in `compare_terms` and this goes
+//     red on the 2^53/2^53+1 pair)
+//
+// HONESTY BOUNDARY (per the bead): this machine-checks the `compare_terms` ALGORITHM over
+// the model observation surface `M` below. It is explicitly NOT a claim about the engine's
+// `Value` impl of `CompareTerm` in `sparq-engine/src/exec.rs` (that instance stays covered
+// by unit + W3C conformance tests; ledgered as the next wave in the design record §6). The
+// model is, however, deliberately FAITHFUL to that impl's observation semantics — each trait
+// method below documents the `exec.rs` behaviour it mirrors — because a convenient model
+// would make these proofs vacuous.
+//
+// MACHINE-CHECKED FINDINGS (not masked — see the `witness_*` harnesses): the order laws do
+// NOT extend across mixed literal KINDS. Three concrete counterexamples, each PROVED
+// reachable (the witness harnesses assert current behaviour and fail if it changes):
+//   1. exact/inexact numeric-tier mix AT the 2^53 collapse boundary is intransitive
+//      (`witness_mixed_tier_collapse_intransitivity`);
+//   2. numeric-vs-plain-string comparison falls to the LEXICAL form, which disagrees with
+//      the numeric order (`witness_numeric_vs_string_lexical_intransitivity`);
+//   3. NaN makes the comparator PARTIAL — `compare_terms` returns `None`, which callers map
+//      to `Equal` (`witness_nan_comparison_partiality`).
+// All three are reachable through the engine's real `Value` impl (verified against
+// `exec.rs`: `num_compare` falls back to the collapsed f64 for float/double operands;
+// `value_compare_strict` is `None` cross-family so the string fallback fires; `parse_xsd_f64`
+// accepts `NaN`). Tracked as a bug bead — the per-kind transitivity harnesses above scope
+// exactly which sub-domains ARE lawful, and the witnesses pin exactly where the law breaks.
+//
+// RUN:  cargo kani -p sparq-substrate --features compare
+// (nightly lane wiring is bead sq-sqtk2.5; under normal build/clippy/test this module is
+// stripped — the `kani` cfg is registered in this crate's Cargo.toml `[lints.rust]`.)
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+    use std::cmp::Ordering;
+
+    /// 2^53 — the f64 integer-exactness boundary: every integer of magnitude ≤ 2^53 has an
+    /// exact f64 image; above it, adjacent integers start sharing one image ("collapse").
+    const TWO53: i128 = 9_007_199_254_740_992;
+
+    /// Adversarial exact-integer domain (the model's `xsd:integer` tier). Deliberately
+    /// STRADDLES the collapse boundary in both signs: `±(2^53 + 1)` are the first
+    /// non-representable integers (ties-to-even rounds them onto `±2^53`), while
+    /// `2^53 - 1` and `2^53 + 2` are exactly representable neighbours. The small values
+    /// `2` and `10` exist for the numeric-vs-lexical witness (`"10" < "11" < "2"`).
+    const INTS: [i128; 10] = [
+        -(TWO53 + 1), // collapses onto -(2^53)
+        -TWO53,
+        -2,
+        0,
+        2,
+        10,
+        TWO53 - 1, // exactly representable
+        TWO53,     // the collapse image
+        TWO53 + 1, // NOT representable: rounds onto 2^53 — the collapse
+        TWO53 + 2, // exactly representable again
+    ];
+    // Index names for the values the harnesses pick out explicitly.
+    const I_TWO: u8 = 4;
+    const I_TEN: u8 = 5;
+    const I_2P53_M1: u8 = 6;
+    const I_2P53: u8 = 7;
+    const I_2P53_P1: u8 = 8;
+    const I_2P53_P2: u8 = 9;
+
+    /// The f64 images of `INTS`, computed at COMPILE TIME by the same `as f64`
+    /// (round-ties-to-even) conversion the engine's numeric tower applies — so the collapse
+    /// is data the solver can see: `INT_F64S[I_2P53] == INT_F64S[I_2P53_P1]`.
+    const INT_F64S: [f64; 10] = [
+        INTS[0] as f64,
+        INTS[1] as f64,
+        INTS[2] as f64,
+        INTS[3] as f64,
+        INTS[4] as f64,
+        INTS[5] as f64,
+        INTS[6] as f64,
+        INTS[7] as f64,
+        INTS[8] as f64,
+        INTS[9] as f64,
+    ];
+
+    /// The decimal lexical forms of `INTS`, index-parallel. COMPILE-TIME constants: the
+    /// model must not run an int→string conversion loop under CBMC, and the values are
+    /// load-bearing for the lexical-fallback arms (`"10" < "11" < "2"` lexically).
+    const INT_STRS: [&str; 10] = [
+        "-9007199254740993",
+        "-9007199254740992",
+        "-2",
+        "0",
+        "2",
+        "10",
+        "9007199254740991",
+        "9007199254740992",
+        "9007199254740993",
+        "9007199254740994",
+    ];
+
+    /// Adversarial inexact (`xsd:double`) domain: `±0.0` (an equal-but-lexically-distinct
+    /// pair), a fraction, and — crucially — `2^53` itself: the shared f64 image of the
+    /// collapsed integers, which is exactly where the mixed-tier witness lives.
+    const DBLS: [f64; 6] = [
+        -9_007_199_254_740_992.0, // -(2^53)
+        -0.0,
+        0.0,
+        0.5,
+        9_007_199_254_740_992.0, // 2^53 — the collapse image
+        9_007_199_254_740_994.0, // 2^53 + 2
+    ];
+    const D_2P53: u8 = 4;
+    /// Lexical forms of `DBLS` (fixed representative renderings; the laws only need
+    /// `value_str` to be a deterministic function of the model value).
+    const DBL_STRS: [&str; 6] = [
+        "-9.007199254740992E15",
+        "-0.0E0",
+        "0.0E0",
+        "5.0E-1",
+        "9.007199254740992E15",
+        "9.007199254740994E15",
+    ];
+
+    /// Blank labels / IRIs / plain-string literal values: tiny but adversarial — the empty
+    /// string, a prefix pair (`"a"` < `"ab"`), and `"11"` (lexically ABOVE `"10"` and BELOW
+    /// `"2"`: the digit-string inversion the numeric-vs-string witness rides on).
+    const STRS: [&str; 4] = ["", "11", "a", "ab"];
+    const S_11: u8 = 1;
+
+    /// Strictly-comparable typed-literal tier (models the engine's dateTime/date-by-timeline
+    /// arm): `Strict(i)` compares to `Strict(j)` by index. The lexical forms are chosen to
+    /// AGREE with that order — the real engine's mixed-timezone dateTimes can order
+    /// lexically ≠ timeline, but that pair never reaches the string fallback (same family ⇒
+    /// `strict_cmp` decides), so agreement here is not a fidelity loss for these laws.
+    const STRICT_STRS: [&str; 3] = ["2024-01-01", "2025-01-01", "2026-01-01"];
+
+    /// The bounded model term. One variant per observation SHAPE the algorithm
+    /// distinguishes; every [`TermClass`] is covered. Triple terms are depth-1 (scalar
+    /// components) — a stated bound; the recursion body is the same for deeper nesting.
+    /// NOT modelled (stated bounds): booleans (an inexact-shaped numeric at 0.0/1.0 —
+    /// `Dbl` covers the shape), decimals (same exact tier as `Int` through `exact_cmp`),
+    /// and `±INF` doubles (totally ordered f64s like every other non-NaN double).
+    enum M {
+        /// Unbound / SPARQL type error.
+        Err,
+        /// Blank node with label `STRS[i]`.
+        Blank(u8),
+        /// IRI `STRS[i]`.
+        Iri(u8),
+        /// Exact-tier numeric literal (`xsd:integer`) with value `INTS[i]`: `as_f64` is the
+        /// COLLAPSING image, `exact_cmp` is exact — the engine's int/decimal tier.
+        Int(u8),
+        /// Inexact-tier numeric literal (`xsd:double`) with value `DBLS[i]`: its value IS
+        /// its f64; no exact tier.
+        Dbl(u8),
+        /// The `xsd:double` NaN (reachable in the engine: `parse_xsd_f64` accepts `NaN`).
+        Nan,
+        /// Plain string literal `STRS[i]`: no numeric / strict tier — lexical fallback.
+        Str(u8),
+        /// Same-family strictly-comparable typed literal (dateTime-by-timeline model).
+        Strict(u8),
+        /// Depth-1 RDF-1.2 quoted triple: `(Iri STRS[s], Iri STRS[p], Int INTS[o])`.
+        Trip(u8, u8, u8),
+    }
+
+    impl M {
+        /// The model's `as_numeric` (mirrors `exec.rs`): `(exact_tier, exact_value, f64_image)`.
+        /// `exact_value` is meaningful only when `exact_tier` — for the inexact tier the
+        /// value IS the image (the engine's `Num::Double`, whose `to_dec()` is `None`).
+        fn num(&self) -> Option<(bool, i128, f64)> {
+            match self {
+                M::Int(i) => Some((true, INTS[usize::from(*i)], INT_F64S[usize::from(*i)])),
+                M::Dbl(i) => Some((false, 0, DBLS[usize::from(*i)])),
+                M::Nan => Some((false, 0, f64::NAN)),
+                _ => None,
+            }
+        }
+    }
+
+    impl CompareTerm for M {
+        fn term_class(&self) -> TermClass {
+            match self {
+                M::Err => TermClass::ErrorOrUnbound,
+                M::Blank(_) => TermClass::Blank,
+                M::Iri(_) => TermClass::Iri,
+                M::Int(_) | M::Dbl(_) | M::Nan | M::Str(_) | M::Strict(_) => TermClass::Literal,
+                M::Trip(..) => TermClass::Triple,
+            }
+        }
+        fn value_str(&self) -> Option<String> {
+            // Engine (`value_str`): the term's lexical form — a deterministic function of
+            // the term. Model: fixed compile-time tables (no conversion loops under CBMC).
+            match self {
+                M::Err => None,
+                M::Blank(i) | M::Iri(i) | M::Str(i) => Some(STRS[usize::from(*i)].to_string()),
+                M::Int(i) => Some(INT_STRS[usize::from(*i)].to_string()),
+                M::Dbl(i) => Some(DBL_STRS[usize::from(*i)].to_string()),
+                M::Nan => Some("NaN".to_string()),
+                M::Strict(i) => Some(STRICT_STRS[usize::from(*i)].to_string()),
+                // Never observed by `compare_terms` (the Triple arm recurses via
+                // `triple_parts` before any string fallback).
+                M::Trip(..) => None,
+            }
+        }
+        fn as_f64(&self) -> Option<f64> {
+            // Engine (`as_num`): the LENIENT f64 coercion — for an exact integer this is the
+            // collapsing `as f64` image; that collapse is the entire point of the domain.
+            self.num().map(|(_, _, f)| f)
+        }
+        fn exact_cmp(&self, other: &Self) -> Option<Ordering> {
+            // Engine (`exec.rs` `exact_cmp` → `num_compare`): EXACT (decimal tower) only
+            // when BOTH operands are int/decimal tier; a float/double operand falls back to
+            // the — possibly collapsed — f64 `partial_cmp` (its value IS its f64). NOT the
+            // convenient "None on mixed pairs": the engine returns the collapsed verdict,
+            // and the mixed-tier witness below exists precisely because of it.
+            let (ax, av, af) = self.num()?;
+            let (bx, bv, bf) = other.num()?;
+            if ax && bx {
+                return Some(av.cmp(&bv));
+            }
+            af.partial_cmp(&bf)
+        }
+        fn strict_cmp(&self, other: &Self) -> Option<Ordering> {
+            // Engine (`value_compare_strict`): decides SAME-FAMILY pairs (dateTime/date by
+            // timeline, same-tag/same-other-XSD lexically); every cross-family pair is
+            // `None` ⇒ the caller falls back to the lexical string form. The model's only
+            // strict family is `Strict`. (The engine also decides plain-string pairs here —
+            // lexically, identical to the fallback the model routes them through.)
+            match (self, other) {
+                (M::Strict(a), M::Strict(b)) => Some(a.cmp(b)),
+                _ => None,
+            }
+        }
+        fn triple_parts(&self) -> Option<[Self; 3]> {
+            match self {
+                M::Trip(s, p, o) => Some([M::Iri(*s), M::Iri(*p), M::Int(*o)]),
+                _ => None,
+            }
+        }
+    }
+
+    /// A symbolic index below `n`.
+    fn any_idx(n: u8) -> u8 {
+        let i: u8 = kani::any();
+        kani::assume(i < n);
+        i
+    }
+
+    /// Any non-literal scalar (`Err` / `Blank` / `Iri`) — the cross-class backdrop.
+    fn any_scalar_nonlit() -> M {
+        match kani::any::<u8>() {
+            0 => M::Err,
+            1 => M::Blank(any_idx(STRS.len() as u8)),
+            _ => M::Iri(any_idx(STRS.len() as u8)),
+        }
+    }
+
+    /// Any depth-1 triple. Objects range over `{2, 2^53, 2^53+1}` so the RECURSIVE numeric
+    /// arm exercises the exact-tier recheck on the collapsed pair inside a triple.
+    fn any_trip() -> M {
+        let o: u8 = kani::any();
+        kani::assume(o == I_TWO || o == I_2P53 || o == I_2P53_P1);
+        M::Trip(any_idx(2), any_idx(2), o)
+    }
+
+    /// A symbolic term over the FULL model domain (`with_nan` gates the NaN double).
+    fn any_term(with_nan: bool) -> M {
+        match kani::any::<u8>() {
+            0 => M::Err,
+            1 => M::Blank(any_idx(STRS.len() as u8)),
+            2 => M::Iri(any_idx(STRS.len() as u8)),
+            3 => M::Int(any_idx(INTS.len() as u8)),
+            4 => M::Dbl(any_idx(DBLS.len() as u8)),
+            5 => M::Str(any_idx(STRS.len() as u8)),
+            6 => M::Strict(any_idx(STRICT_STRS.len() as u8)),
+            7 if with_nan => M::Nan,
+            _ => any_trip(),
+        }
+    }
+
+    /// Strict-weak-order composition at one symbolic triple `(x, y, z)`. Asserting the
+    /// `Less`/`Equal` compositions is COMPLETE: the `Greater` compositions are the same
+    /// instantiations under an `(x, z)` swap, and the harness quantifies symbolically over
+    /// every permutation of the domain (antisymmetry-consistency is proved separately).
+    fn assert_transitive_at(x: &M, y: &M, z: &M) {
+        let (Some(xy), Some(yz)) = (compare_terms(x, y), compare_terms(y, z)) else {
+            return; // outside the defined domain (law scoped to Some legs)
+        };
+        let xz = compare_terms(x, z);
+        match (xy, yz) {
+            (Ordering::Less, Ordering::Less)
+            | (Ordering::Less, Ordering::Equal)
+            | (Ordering::Equal, Ordering::Less) => {
+                assert!(xz == Some(Ordering::Less), "transitivity: x<=y<=z (strict leg) => x<z");
+            }
+            (Ordering::Equal, Ordering::Equal) => {
+                assert!(xz == Some(Ordering::Equal), "transitivity: x~y~z => x~z");
+            }
+            _ => (),
+        }
+    }
+
+    /// Domain self-check: the numeric domain genuinely exhibits the 2^53 collapse (distinct
+    /// integers, one f64 image) and the double table contains the collapse image itself.
+    /// If this fails, the domain is non-adversarial and the other harnesses are vacuous.
+    #[kani::proof]
+    fn domain_exhibits_the_2p53_collapse() {
+        assert!(INTS[usize::from(I_2P53)] != INTS[usize::from(I_2P53_P1)]);
+        // Deliberate exact f64 comparisons: the collapse IS bit-level image equality.
+        assert!(INT_F64S[usize::from(I_2P53)] == INT_F64S[usize::from(I_2P53_P1)]);
+        assert!(INT_F64S[usize::from(I_2P53_M1)] < INT_F64S[usize::from(I_2P53)]);
+        assert!(INT_F64S[usize::from(I_2P53)] < INT_F64S[usize::from(I_2P53_P2)]);
+        assert!(DBLS[usize::from(D_2P53)] == INT_F64S[usize::from(I_2P53)]);
+        assert!(INTS[0] != INTS[1] && INT_F64S[0] == INT_F64S[1]); // negative-sign collapse
+    }
+
+    /// REFLEXIVITY over the NaN-free domain: `compare_terms(x, x) == Some(Equal)`.
+    /// (With NaN the comparator is PARTIAL — see `witness_nan_comparison_partiality`.)
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn reflexivity_nan_free_domain() {
+        let x = any_term(false);
+        assert!(compare_terms(&x, &x) == Some(Ordering::Equal), "reflexivity");
+    }
+
+    /// ANTISYMMETRY-CONSISTENCY over the FULL domain (NaN included): the two directions are
+    /// exact mirrors — `Some(o)` iff `Some(o.reverse())`, and `None` iff `None`.
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn antisymmetry_consistency_full_domain() {
+        let x = any_term(true);
+        let y = any_term(true);
+        match compare_terms(&x, &y) {
+            Some(o) => {
+                assert!(compare_terms(&y, &x) == Some(o.reverse()), "antisymmetry: mirror");
+            }
+            None => assert!(compare_terms(&y, &x).is_none(), "antisymmetry: None mirror"),
+        }
+    }
+
+    /// WITHIN-CLASS TOTALITY over the NaN-free domain: every same-class pair compares
+    /// `Some` — including MIXED literal kinds (which stay totally DEFINED via the string
+    /// fallback even where they are not transitive; see the witnesses).
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn within_class_totality_nan_free_domain() {
+        let x = any_term(false);
+        let y = any_term(false);
+        if x.term_class() == y.term_class() {
+            assert!(compare_terms(&x, &y).is_some(), "within-class totality");
+        }
+    }
+
+    /// TRANSITIVITY: exact-integer literals INCLUDING the 2^53 collapse straddle, composed
+    /// with the non-literal scalar classes. The collapsed pair `{2^53, 2^53+1}` is in-domain,
+    /// so this proves the `exact_cmp` recheck keeps the exact tier transitive ACROSS the
+    /// boundary (and the cross-class precedence composes with it).
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn transitivity_exact_int_literals_incl_2p53_collapse() {
+        let term = || {
+            if kani::any() {
+                M::Int(any_idx(INTS.len() as u8))
+            } else {
+                any_scalar_nonlit()
+            }
+        };
+        assert_transitive_at(&term(), &term(), &term());
+    }
+
+    /// TRANSITIVITY: double literals (NaN-free — with NaN the comparator is partial, see the
+    /// witness). Includes the `±0.0` equal-but-lexically-distinct pair: a mutation that let
+    /// numeric ties fall through to the string form would go red here.
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn transitivity_double_literals() {
+        let term = || M::Dbl(any_idx(DBLS.len() as u8));
+        assert_transitive_at(&term(), &term(), &term());
+    }
+
+    /// TRANSITIVITY: a MIXED exact/inexact numeric domain restricted BELOW the collapse
+    /// boundary (every value exactly representable). Lawful here — which sharpens the
+    /// mixed-tier witness: the law breaks specifically AT the collapse, not on every mix.
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn transitivity_mixed_numeric_collapse_free_range() {
+        let term = || {
+            if kani::any() {
+                // {-2, 0, 2, 10} — exact images
+                let i: u8 = kani::any();
+                kani::assume(i >= 2 && i <= I_TEN);
+                M::Int(i)
+            } else {
+                // {-0.0, 0.0, 0.5} — small doubles
+                let i: u8 = kani::any();
+                kani::assume(i >= 1 && i <= 3);
+                M::Dbl(i)
+            }
+        };
+        assert_transitive_at(&term(), &term(), &term());
+    }
+
+    /// TRANSITIVITY: plain-string literals (lexical order; includes the empty string and a
+    /// prefix pair).
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn transitivity_string_literals() {
+        let term = || M::Str(any_idx(STRS.len() as u8));
+        assert_transitive_at(&term(), &term(), &term());
+    }
+
+    /// TRANSITIVITY: strict/temporal literals (the dateTime-by-timeline model arm).
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn transitivity_strict_typed_literals() {
+        let term = || M::Strict(any_idx(STRICT_STRS.len() as u8));
+        assert_transitive_at(&term(), &term(), &term());
+    }
+
+    /// TRANSITIVITY: depth-1 triple terms — the component-wise recursion, with objects
+    /// ranging over the collapsed integer pair so the recursive numeric arm hits the
+    /// exact-tier recheck INSIDE a triple.
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn transitivity_triple_terms_recursive() {
+        assert_transitive_at(&any_trip(), &any_trip(), &any_trip());
+    }
+
+    /// EXACT-ORDER AGREEMENT: for every exact-tier pair, `compare_terms` equals the exact
+    /// i128 value order — INCLUDING the collapsed pairs, where the lenient f64 arm alone
+    /// would report `Equal`. This is the load-bearing guarantee of the `exact_cmp` recheck:
+    /// delete the recheck in `compare_terms` (or weaken the model's `exact_cmp` to `None` on
+    /// exact pairs) and this harness goes red on `{2^53, 2^53+1}` — the non-vacuity anchor.
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn exact_int_order_agreement_incl_2p53_collapse() {
+        let i = any_idx(INTS.len() as u8);
+        let j = any_idx(INTS.len() as u8);
+        let verdict = compare_terms(&M::Int(i), &M::Int(j));
+        assert!(
+            verdict == Some(INTS[usize::from(i)].cmp(&INTS[usize::from(j)])),
+            "exact tier orders by exact value, collapse notwithstanding"
+        );
+    }
+
+    /// FINDING 1 (machine-checked witness, current behaviour): transitivity FAILS on the
+    /// exact/inexact numeric-tier MIX at the 2^53 collapse boundary. A double equal to the
+    /// shared image ties (via the engine-faithful collapsed-f64 fallback) with BOTH collapsed
+    /// integers, which the exact tier orders strictly:
+    ///   `2^53 ~ 9.007199254740992E15 ~ 2^53+1`  but  `2^53 < 2^53+1`.
+    /// Engine-reachable: `num_compare` falls back to f64 when either operand is
+    /// float/double. If a fix lands (e.g. exact mixed-tier comparison — every finite f64 is
+    /// an exact rational), this harness goes red and should be REMOVED with the fix's bead.
+    #[kani::proof]
+    fn witness_mixed_tier_collapse_intransitivity() {
+        let x = M::Int(I_2P53);
+        let y = M::Dbl(D_2P53);
+        let z = M::Int(I_2P53_P1);
+        assert!(compare_terms(&x, &y) == Some(Ordering::Equal));
+        assert!(compare_terms(&y, &z) == Some(Ordering::Equal));
+        assert!(compare_terms(&x, &z) == Some(Ordering::Less)); // intransitive triple
+    }
+
+    /// FINDING 2 (machine-checked witness, current behaviour): transitivity FAILS on the
+    /// numeric-vs-plain-string mix — cross-family pairs fall back to the LEXICAL form, and
+    /// lexical digit-string order disagrees with numeric order:
+    ///   `10 < "11" < 2` (lexically)  but  `10 > 2` (numerically).
+    /// Engine-reachable: `value_compare_strict` is `None` for a (numeric, plain-string)
+    /// pair, so `compare_terms` reaches its string fallback.
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn witness_numeric_vs_string_lexical_intransitivity() {
+        let x = M::Int(I_TEN); // 10
+        let y = M::Str(S_11); // "11"
+        let z = M::Int(I_TWO); // 2
+        assert!(compare_terms(&x, &y) == Some(Ordering::Less)); // "10" < "11"
+        assert!(compare_terms(&y, &z) == Some(Ordering::Less)); // "11" < "2"
+        assert!(compare_terms(&x, &z) == Some(Ordering::Greater)); // 10 > 2
+    }
+
+    /// FINDING 3 (machine-checked witness, current behaviour): NaN makes the comparator
+    /// PARTIAL — numeric comparison against NaN is `None` (callers map it to `Equal`, so at
+    /// the call site NaN ties with EVERY numeric, collapsing distinct equivalence classes),
+    /// while NaN against a plain string is still DEFINED (lexical fallback). Engine-
+    /// reachable: `parse_xsd_f64` accepts the XSD `NaN` spelling. Also pins that the
+    /// module-level doc's "`None` only when a term has no string form" understates `None`.
+    #[kani::proof]
+    #[kani::unwind(24)]
+    fn witness_nan_comparison_partiality() {
+        assert!(compare_terms(&M::Nan, &M::Nan).is_none());
+        assert!(compare_terms(&M::Nan, &M::Dbl(2)).is_none()); // vs 0.0
+        assert!(compare_terms(&M::Dbl(2), &M::Nan).is_none());
+        assert!(compare_terms(&M::Nan, &M::Int(I_2P53)).is_none());
+        // ... but the string fallback still fires cross-family: "NaN" vs "a".
+        assert!(compare_terms(&M::Nan, &M::Str(2)) == Some(Ordering::Less));
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -414,5 +925,88 @@ mod tests {
         };
         assert_eq!(compare_terms(&nested(1.0), &nested(2.0)), Some(Ordering::Less));
         assert_eq!(compare_terms(&nested(2.0), &nested(2.0)), Some(Ordering::Equal));
+    }
+
+    // --- BUG WITNESSES (pinned by the sq-sqtk2.4 Kani harnesses; tracked as P1 bug bead) ---
+    //
+    // These three tests reproduce the machine-checked counterexamples from the Kani
+    // `kani_proofs` module's `witness_*` harnesses. They are `#[ignore]` because they assert
+    // the ORDER LAW (transitivity of equality) which CURRENTLY FAILS — i.e., removing
+    // `#[ignore]` turns them RED under `cargo test`. Remove `#[ignore]` and run them to
+    // verify a fix; they will pass once the comparator is made consistent. [SONNET-4.6]
+
+    /// BUG witness 1 — mixed exact/inexact numeric pair at the 2^53 collapse boundary.
+    ///
+    /// The transitivity law for equality is: x = y AND y = z => x = z.
+    /// Here: `xsd:integer 2^53` equals `xsd:double 9.007199254740992E15` (their f64 images
+    /// are identical and `exact_cmp` returns `None` on a mixed pair), and
+    /// `xsd:double 9.007199254740992E15` also equals `xsd:integer 2^53+1` (same reason),
+    /// but `compare_terms(xsd:integer 2^53, xsd:integer 2^53+1)` returns `Less` (the
+    /// exact recheck correctly orders them). The triple `(2^53, double(2^53), 2^53+1)` is an
+    /// intransitive witness. Tracked as a P1 correctness bead (see PR body for bead id).
+    /// `ORDER BY` / `GROUP BY` / `MIN` / `MAX` over a column mixing integer and double values
+    /// near 2^53 may produce permutation-unstable output violating SPARQL ordering semantics.
+    #[test]
+    #[ignore = "BUG: mixed exact/inexact numeric intransitivity at 2^53 collapse — remove once fixed (see P1 bug bead in PR body)"]
+    fn bug_witness_mixed_exact_inexact_numeric_intransitivity_at_2p53() {
+        let two53: f64 = 9_007_199_254_740_992.0;
+        // x = xsd:integer 2^53 (exact tier)
+        let x = T::ExactNum { f: two53, mant: 9_007_199_254_740_992_i128, scale: 0 };
+        // y = xsd:double 2^53 (inexact tier — no exact_cmp)
+        let y = T::NumLit(two53);
+        // z = xsd:integer 2^53+1 (exact tier; shares f64 image with x)
+        let z = T::ExactNum { f: two53, mant: 9_007_199_254_740_993_i128, scale: 0 };
+        // Confirm the witnesses: x = y, y = z (the comparator is defined and returns Equal)
+        assert_eq!(compare_terms(&x, &y), Some(Ordering::Equal), "x ~ y");
+        assert_eq!(compare_terms(&y, &z), Some(Ordering::Equal), "y ~ z");
+        // Transitivity of equality would require: x = z.
+        // Currently FAILS (returns Less) — the exact recheck orders x < z correctly, but
+        // inconsistently with the mixed-tier Equal above.
+        assert_eq!(compare_terms(&x, &z), Some(Ordering::Equal), "transitivity: x=y AND y=z => x=z");
+    }
+
+    /// BUG witness 2 — numeric-vs-plain-string cross-family fallback to lexical order.
+    ///
+    /// Cross-family literal pairs (numeric vs plain-string) have no strict_cmp, so
+    /// `compare_terms` falls back to the LEXICAL string form. Lexical digit-string order
+    /// inverts numeric order on certain pairs: `"10" < "11" < "2"` (lexical) while
+    /// `10 > 2` (numeric). The triple `(Int 10, StrLit "11", Int 2)` is an intransitive
+    /// witness: `10 < "11"` and `"11" < 2` (lexical) but `10 > 2` (numeric).
+    /// Tracked as a P1 correctness bead (see PR body for bead id).
+    #[test]
+    #[ignore = "BUG: numeric-vs-plain-string lexical-fallback intransitivity — remove once fixed (see P1 bug bead in PR body)"]
+    fn bug_witness_numeric_vs_string_lexical_fallback_intransitivity() {
+        // x = integer 10, z = integer 2: compare_terms(x, z) = Greater (10 > 2 numerically)
+        let x = T::ExactNum { f: 10.0, mant: 10, scale: 0 };
+        let z = T::ExactNum { f: 2.0, mant: 2, scale: 0 };
+        // y = plain-string "11": compare_terms(x, y) falls back to lexical "10" < "11" (Less)
+        // and compare_terms(y, z) falls back to lexical "11" < "2" (Less)
+        let y = T::StrLit("11".into());
+        // Confirm the two Less legs (current behaviour)
+        assert_eq!(compare_terms(&x, &y), Some(Ordering::Less), "\"10\" < \"11\" lexically");
+        assert_eq!(compare_terms(&y, &z), Some(Ordering::Less), "\"11\" < \"2\" lexically");
+        // Transitivity of the strict-order Less would require: x < z.
+        // Currently FAILS (returns Greater) — numeric order disagrees with lexical.
+        assert_eq!(compare_terms(&x, &z), Some(Ordering::Less), "transitivity: x<y AND y<z => x<z");
+    }
+
+    /// BUG witness 3 — NaN makes the comparator partial on same-class literal pairs.
+    ///
+    /// `xsd:double NaN` has an f64 form (`NaN`), so `as_f64` returns `Some(NaN)`. The numeric
+    /// `partial_cmp` then returns `None` for every NaN comparison. Callers that map `None` to
+    /// `Equal` effectively place NaN equal to every numeric, collapsing distinct equivalence
+    /// classes. Within-class totality is violated: `compare_terms(NaN, Int(0))` returns `None`
+    /// even though both are `TermClass::Literal`. Tracked as a P1 correctness bead.
+    #[test]
+    #[ignore = "BUG: NaN makes comparator partial on same-class Literal pairs — remove once fixed (see P1 bug bead in PR body)"]
+    fn bug_witness_nan_partiality_violates_within_class_totality() {
+        let nan = T::NumLit(f64::NAN);
+        let zero = T::NumLit(0.0);
+        // Both are TermClass::Literal — within-class totality requires Some(_).
+        // Currently returns None (f64::NAN.partial_cmp(0.0) = None).
+        assert!(
+            compare_terms(&nan, &zero).is_some(),
+            "within-class totality: Literal NaN vs Literal 0 must compare Some"
+        );
     }
 }

--- a/crates/sparq-substrate/src/compare.rs
+++ b/crates/sparq-substrate/src/compare.rs
@@ -209,7 +209,8 @@ pub fn compare_terms<T: CompareTerm>(x: &T, y: &T) -> Option<Ordering> {
 // panic or produce garbage). HARNESS-ONLY: the `compare_terms` body above is byte-unchanged.
 //
 // WHAT IS PROVED (tier: PROVED (bounded), per the design record's vocabulary) — over every
-// value of the bounded in-harness model `M` below:
+// value of the PER-HARNESS domain, each a stated sub-domain of the bounded model `M` below
+// (the harness doc-comment is the authoritative domain statement):
 //   • REFLEXIVITY (NaN-free domain):        compare_terms(x, x) == Some(Equal)
 //   • ANTISYMMETRY-CONSISTENCY (full domain, NaN included):
 //        compare_terms(x, y) == Some(o)  iff  compare_terms(y, x) == Some(o.reverse())
@@ -217,12 +218,27 @@ pub fn compare_terms<T: CompareTerm>(x: &T, y: &T) -> Option<Ordering> {
 //   • TRANSITIVITY on the defined domain, per LITERAL KIND (see the honest boundary below):
 //        exact-integer literals INCLUDING the 2^53 f64-collapse straddle, double literals,
 //        string literals, strict/temporal literals, a collapse-free exact/inexact numeric
-//        mix, and recursive triple terms — composed with the non-literal classes
+//        mix, recursive triple terms, the non-literal scalar classes, and a REDUCED
+//        int-with-non-literal composition (3 straddle ints × 2-string blanks/IRIs × Err —
+//        a stated shrink, see its doc)
 //   • WITHIN-CLASS TOTALITY (NaN-free domain): same-class pairs always compare `Some`
 //   • EXACT-ORDER AGREEMENT: for exact-tier integer pairs, compare_terms equals the exact
 //     i128 value order even where the f64 images collapse (THE guarantee the `exact_cmp`
 //     recheck tier exists to provide — delete the recheck in `compare_terms` and this goes
 //     red on the 2^53/2^53+1 pair)
+//
+// TRACTABILITY DISCIPLINE (why the harnesses are shaped this way): a term whose enum
+// DISCRIMINANT is symbolic (built as `let x = match kani::any() { .. => Int, .. => Dbl }`)
+// forks CBMC symex at EVERY downstream `match self` in the comparator's trait methods —
+// multiplicatively per call, so even a UNARY harness over a handful of kinds does not
+// terminate practically. The `for_each_*` kind-dispatch combinators below invert that:
+// the symbolic kind CHOICE happens once, in a match whose arms each pass `f` a term with
+// a CONCRETE discriminant (only the value index stays symbolic), keeping every dispatch
+// leaf linear while the selector still quantifies over all kinds. Additionally, every
+// harness carries the SMALLEST `#[kani::unwind]` bound its loops/recursion need (the
+// bound also caps the syntactic expansion of `compare_terms`' triple-term recursion,
+// which inflates the formula when set high). Under-bounding is LOUD: Kani's unwinding
+// assertion fails, so a too-small bound cannot silently weaken a proof.
 //
 // HONESTY BOUNDARY (per the bead): this machine-checks the `compare_terms` ALGORITHM over
 // the model observation surface `M` below. It is explicitly NOT a claim about the engine's
@@ -244,8 +260,9 @@ pub fn compare_terms<T: CompareTerm>(x: &T, y: &T) -> Option<Ordering> {
 // All three are reachable through the engine's real `Value` impl (verified against
 // `exec.rs`: `num_compare` falls back to the collapsed f64 for float/double operands;
 // `value_compare_strict` is `None` cross-family so the string fallback fires; `parse_xsd_f64`
-// accepts `NaN`). Tracked as a bug bead — the per-kind transitivity harnesses above scope
-// exactly which sub-domains ARE lawful, and the witnesses pin exactly where the law breaks.
+// accepts `NaN`). Tracked as bug bead sq-wjl8i (P1) — the per-kind transitivity harnesses
+// above scope exactly which sub-domains ARE lawful, and the witnesses pin exactly where the
+// law breaks.
 //
 // RUN:  cargo kani -p sparq-substrate --features compare
 // (nightly lane wiring is bead sq-sqtk2.5; under normal build/clippy/test this module is
@@ -464,36 +481,12 @@ mod kani_proofs {
         i
     }
 
-    /// Any non-literal scalar (`Err` / `Blank` / `Iri`) — the cross-class backdrop.
-    fn any_scalar_nonlit() -> M {
-        match kani::any::<u8>() {
-            0 => M::Err,
-            1 => M::Blank(any_idx(STRS.len() as u8)),
-            _ => M::Iri(any_idx(STRS.len() as u8)),
-        }
-    }
-
     /// Any depth-1 triple. Objects range over `{2, 2^53, 2^53+1}` so the RECURSIVE numeric
     /// arm exercises the exact-tier recheck on the collapsed pair inside a triple.
     fn any_trip() -> M {
         let o: u8 = kani::any();
         kani::assume(o == I_TWO || o == I_2P53 || o == I_2P53_P1);
         M::Trip(any_idx(2), any_idx(2), o)
-    }
-
-    /// A symbolic term over the FULL model domain (`with_nan` gates the NaN double).
-    fn any_term(with_nan: bool) -> M {
-        match kani::any::<u8>() {
-            0 => M::Err,
-            1 => M::Blank(any_idx(STRS.len() as u8)),
-            2 => M::Iri(any_idx(STRS.len() as u8)),
-            3 => M::Int(any_idx(INTS.len() as u8)),
-            4 => M::Dbl(any_idx(DBLS.len() as u8)),
-            5 => M::Str(any_idx(STRS.len() as u8)),
-            6 => M::Strict(any_idx(STRICT_STRS.len() as u8)),
-            7 if with_nan => M::Nan,
-            _ => any_trip(),
-        }
     }
 
     /// Strict-weak-order composition at one symbolic triple `(x, y, z)`. Asserting the
@@ -532,96 +525,295 @@ mod kani_proofs {
         assert!(INTS[0] != INTS[1] && INT_F64S[0] == INT_F64S[1]); // negative-sign collapse
     }
 
-    /// REFLEXIVITY over the NaN-free domain: `compare_terms(x, x) == Some(Equal)`.
-    /// (With NaN the comparator is PARTIAL — see `witness_nan_comparison_partiality`.)
-    #[kani::proof]
-    #[kani::unwind(24)]
-    fn reflexivity_nan_free_domain() {
-        let x = any_term(false);
-        assert!(compare_terms(&x, &x) == Some(Ordering::Equal), "reflexivity");
+    // ------------------------------------------------------------------------------
+    // KIND-DISPATCH COMBINATORS. Each `for_each_*` symbolically SELECTS one literal kind
+    // and calls `f` with a term whose enum DISCRIMINANT is concrete (only the value index
+    // inside the kind stays symbolic). This is the load-bearing tractability device: a
+    // term with a SYMBOLIC discriminant forks CBMC symex at every downstream match in the
+    // comparator (multiplicatively, per trait-method call), which does not terminate
+    // practically; a concrete-discriminant term keeps each dispatch leaf linear. Coverage
+    // is unchanged — the symbolic selector still quantifies over every kind in the list.
+    // ------------------------------------------------------------------------------
+
+    /// One symbolic choice of NUMERIC literal kind — `Int` / `Dbl` over their full tables,
+    /// plus NaN when `with_nan` — passed to `f` with a concrete discriminant.
+    fn for_each_numeric(with_nan: bool, f: impl Fn(&M)) {
+        match kani::any::<u8>() {
+            0 => f(&M::Int(any_idx(INTS.len() as u8))),
+            1 if with_nan => f(&M::Nan),
+            _ => f(&M::Dbl(any_idx(DBLS.len() as u8))),
+        }
     }
 
-    /// ANTISYMMETRY-CONSISTENCY over the FULL domain (NaN included): the two directions are
-    /// exact mirrors — `Some(o)` iff `Some(o.reverse())`, and `None` iff `None`.
+    /// One symbolic choice of NON-NUMERIC scalar kind — `Err`, `Blank`/`Iri`/`Str` over the
+    /// full `STRS` table, `Strict` over the full `STRICT_STRS` table.
+    fn for_each_nonnumeric_scalar(f: impl Fn(&M)) {
+        match kani::any::<u8>() {
+            0 => f(&M::Err),
+            1 => f(&M::Blank(any_idx(STRS.len() as u8))),
+            2 => f(&M::Iri(any_idx(STRS.len() as u8))),
+            3 => f(&M::Str(any_idx(STRS.len() as u8))),
+            _ => f(&M::Strict(any_idx(STRICT_STRS.len() as u8))),
+        }
+    }
+
+    /// One symbolic choice of non-literal scalar class — `Err` / `Blank` / `Iri`.
+    fn for_each_nonlit_scalar(f: impl Fn(&M)) {
+        match kani::any::<u8>() {
+            0 => f(&M::Err),
+            1 => f(&M::Blank(any_idx(STRS.len() as u8))),
+            _ => f(&M::Iri(any_idx(STRS.len() as u8))),
+        }
+    }
+
+    /// One symbolic choice of NaN-free literal kind — `Int` / `Dbl` / `Str` / `Strict`.
+    fn for_each_literal_nan_free(f: impl Fn(&M)) {
+        match kani::any::<u8>() {
+            0 => f(&M::Int(any_idx(INTS.len() as u8))),
+            1 => f(&M::Dbl(any_idx(DBLS.len() as u8))),
+            2 => f(&M::Str(any_idx(STRS.len() as u8))),
+            _ => f(&M::Strict(any_idx(STRICT_STRS.len() as u8))),
+        }
+    }
+
+    /// One symbolic choice from the REDUCED int-with-non-literal composition domain:
+    /// `Int` over the 3-value collapse straddle `{2, 2^53, 2^53+1}`, `Err`, and
+    /// `Blank`/`Iri` over the first two `STRS` entries.
+    fn for_each_int_or_nonlit_small(f: impl Fn(&M)) {
+        match kani::any::<u8>() {
+            0 => f(&M::Err),
+            1 => f(&M::Blank(any_idx(2))),
+            2 => f(&M::Iri(any_idx(2))),
+            _ => {
+                let o: u8 = kani::any();
+                kani::assume(o == I_TWO || o == I_2P53 || o == I_2P53_P1);
+                f(&M::Int(o))
+            }
+        }
+    }
+
+    // REFLEXIVITY over the NaN-free domain: `compare_terms(x, x) == Some(Equal)`.
+    // (With NaN the comparator is PARTIAL — see `witness_nan_comparison_partiality`.)
+    // Reflexivity is UNARY and per-value, so splitting the domain by literal kind proves
+    // the SAME law over the SAME union domain: the three harnesses below jointly cover
+    // every NaN-free model term.
+    fn assert_reflexive_at(x: &M) {
+        assert!(compare_terms(x, x) == Some(Ordering::Equal), "reflexivity");
+    }
+
+    /// REFLEXIVITY: numeric literals — `Int` over the full `INTS` table (collapse straddle
+    /// included) and `Dbl` over the full `DBLS` table (NaN excluded — see the witness).
     #[kani::proof]
-    #[kani::unwind(24)]
-    fn antisymmetry_consistency_full_domain() {
-        let x = any_term(true);
-        let y = any_term(true);
-        match compare_terms(&x, &y) {
+    #[kani::unwind(3)]
+    fn reflexivity_numeric_literals_nan_free() {
+        for_each_numeric(false, |x| assert_reflexive_at(x));
+    }
+
+    /// REFLEXIVITY: the non-numeric scalar kinds — `Err`, `Blank`/`Iri`/`Str` over the full
+    /// `STRS` table, `Strict` over the full `STRICT_STRS` table.
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn reflexivity_nonnumeric_scalars() {
+        for_each_nonnumeric_scalar(|x| assert_reflexive_at(x));
+    }
+
+    /// REFLEXIVITY: depth-1 triple terms (objects straddle the 2^53 collapse, so the
+    /// recursive exact-recheck arm is exercised on the x == x diagonal too).
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn reflexivity_triple_terms() {
+        assert_reflexive_at(&any_trip());
+    }
+
+    // ANTISYMMETRY-CONSISTENCY over the FULL domain (NaN included): the two directions are
+    // exact mirrors — `Some(o)` iff `Some(o.reverse())`, and `None` iff `None`. The
+    // assertion checks BOTH directions of one symbolic pair, so covering every unordered
+    // kind-GROUP pair covers every ordered pair of the full domain: with groups
+    // N = {Int, Dbl, Nan}, S = {Err, Blank, Iri, Str, Strict}, T = {Trip}, the five
+    // harnesses below cover N×N, N×S, S×S, T×(N∪S), T×T = (N∪S∪T)².
+    fn assert_antisymmetric_at(x: &M, y: &M) {
+        match compare_terms(x, y) {
             Some(o) => {
-                assert!(compare_terms(&y, &x) == Some(o.reverse()), "antisymmetry: mirror");
+                assert!(compare_terms(y, x) == Some(o.reverse()), "antisymmetry: mirror");
             }
-            None => assert!(compare_terms(&y, &x).is_none(), "antisymmetry: None mirror"),
+            None => assert!(compare_terms(y, x).is_none(), "antisymmetry: None mirror"),
         }
     }
 
-    /// WITHIN-CLASS TOTALITY over the NaN-free domain: every same-class pair compares
-    /// `Some` — including MIXED literal kinds (which stay totally DEFINED via the string
-    /// fallback even where they are not transitive; see the witnesses).
+    /// ANTISYMMETRY: numeric × numeric, NaN INCLUDED (the `None`-mirror leg is live here:
+    /// NaN against any numeric is `None` in BOTH directions).
     #[kani::proof]
-    #[kani::unwind(24)]
-    fn within_class_totality_nan_free_domain() {
-        let x = any_term(false);
-        let y = any_term(false);
-        if x.term_class() == y.term_class() {
-            assert!(compare_terms(&x, &y).is_some(), "within-class totality");
+    #[kani::unwind(3)]
+    fn antisymmetry_numeric_pairs_incl_nan() {
+        for_each_numeric(true, |x| for_each_numeric(true, |y| assert_antisymmetric_at(x, y)));
+    }
+
+    /// ANTISYMMETRY: numeric (NaN included) × non-numeric scalar — the mixed-kind literal
+    /// pairs ride the lexical fallback (including the long `INT_STRS`/`DBL_STRS` forms
+    /// against `STRICT_STRS`, hence the larger unwind); cross-class pairs ride the rank.
+    #[kani::proof]
+    #[kani::unwind(12)]
+    fn antisymmetry_numeric_vs_nonnumeric_incl_nan() {
+        for_each_numeric(true, |x| {
+            for_each_nonnumeric_scalar(|y| assert_antisymmetric_at(x, y));
+        });
+    }
+
+    /// ANTISYMMETRY: non-numeric scalar × non-numeric scalar (string arms + class ranks).
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn antisymmetry_nonnumeric_scalar_pairs() {
+        for_each_nonnumeric_scalar(|x| {
+            for_each_nonnumeric_scalar(|y| assert_antisymmetric_at(x, y));
+        });
+    }
+
+    /// ANTISYMMETRY: triple term × any non-triple (always a cross-class pair — the class
+    /// rank decides; NaN included on the scalar side).
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn antisymmetry_triple_vs_scalar() {
+        let t = any_trip();
+        if kani::any() {
+            for_each_numeric(true, |y| assert_antisymmetric_at(&t, y));
+        } else {
+            for_each_nonnumeric_scalar(|y| assert_antisymmetric_at(&t, y));
         }
     }
 
-    /// TRANSITIVITY: exact-integer literals INCLUDING the 2^53 collapse straddle, composed
-    /// with the non-literal scalar classes. The collapsed pair `{2^53, 2^53+1}` is in-domain,
-    /// so this proves the `exact_cmp` recheck keeps the exact tier transitive ACROSS the
-    /// boundary (and the cross-class precedence composes with it).
+    /// ANTISYMMETRY: triple term × triple term (the component-wise recursion mirrored).
     #[kani::proof]
-    #[kani::unwind(24)]
-    fn transitivity_exact_int_literals_incl_2p53_collapse() {
-        let term = || {
-            if kani::any() {
-                M::Int(any_idx(INTS.len() as u8))
-            } else {
-                any_scalar_nonlit()
-            }
+    #[kani::unwind(4)]
+    fn antisymmetry_triple_pairs() {
+        assert_antisymmetric_at(&any_trip(), &any_trip());
+    }
+
+    // WITHIN-CLASS TOTALITY over the NaN-free domain: every same-class pair compares
+    // `Some` — including MIXED literal kinds (which stay totally DEFINED via the string
+    // fallback even where they are not transitive; see the witnesses). Split: the Literal
+    // class (the only class with multiple kinds) and the singleton-kind classes.
+
+    /// WITHIN-CLASS TOTALITY: the Literal class, NaN-free — every literal-kind pair
+    /// (numeric × numeric, numeric × string/strict via the lexical fallback, ...) is
+    /// `Some`. The larger unwind covers the long-form numeric-vs-`Strict` lexical compare.
+    #[kani::proof]
+    #[kani::unwind(12)]
+    fn within_class_totality_literals_nan_free() {
+        for_each_literal_nan_free(|x| {
+            for_each_literal_nan_free(|y| {
+                assert!(compare_terms(x, y).is_some(), "within-class totality: literals");
+            });
+        });
+    }
+
+    /// WITHIN-CLASS TOTALITY: the singleton-kind classes — `Err`/`Blank`/`Iri`/`Trip`.
+    /// For these classes same-class MEANS same-kind, so the four same-kind pairs below are
+    /// exactly the same-class pairs the law quantifies over.
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn within_class_totality_nonliterals() {
+        let tot = |x: &M, y: &M| {
+            assert!(compare_terms(x, y).is_some(), "within-class totality: non-literals");
         };
+        match kani::any::<u8>() {
+            0 => tot(&M::Err, &M::Err),
+            1 => tot(
+                &M::Blank(any_idx(STRS.len() as u8)),
+                &M::Blank(any_idx(STRS.len() as u8)),
+            ),
+            2 => tot(
+                &M::Iri(any_idx(STRS.len() as u8)),
+                &M::Iri(any_idx(STRS.len() as u8)),
+            ),
+            _ => tot(&any_trip(), &any_trip()),
+        }
+    }
+
+    /// TRANSITIVITY: exact-integer literals over the FULL `INTS` table, INCLUDING the 2^53
+    /// collapse straddle. The collapsed pair `{2^53, 2^53+1}` is in-domain, so this proves
+    /// the `exact_cmp` recheck keeps the exact tier transitive ACROSS the boundary.
+    /// Domain: Int-ONLY (a fixed kind pattern) — the composition with the non-literal
+    /// scalar classes lives in `transitivity_nonliteral_scalars` /
+    /// `transitivity_int_with_nonliteral_scalars` (see the tractability note above).
+    #[kani::proof]
+    #[kani::unwind(3)]
+    fn transitivity_exact_int_literals_incl_2p53_collapse() {
+        let term = || M::Int(any_idx(INTS.len() as u8));
         assert_transitive_at(&term(), &term(), &term());
+    }
+
+    /// TRANSITIVITY: the non-literal scalar classes (`Err` / `Blank` / `Iri` over the full
+    /// `STRS` table) — cross-class precedence plus the within-class string arms.
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn transitivity_nonliteral_scalars() {
+        for_each_nonlit_scalar(|x| {
+            for_each_nonlit_scalar(|y| {
+                for_each_nonlit_scalar(|z| assert_transitive_at(x, y, z));
+            });
+        });
+    }
+
+    /// TRANSITIVITY: exact-integer literals COMPOSED with the non-literal scalar classes —
+    /// the cross-class legs of the law. REDUCED domain (a stated shrink, for symex
+    /// tractability): Int over the 3-value collapse straddle `{2, 2^53, 2^53+1}` (so the
+    /// exact-recheck arm is still exercised next to cross-class legs), Blank/Iri over the
+    /// first two `STRS` entries, and `Err`. The FULL-domain within-class laws are the two
+    /// harnesses above; cross-class order itself is decided purely by the `TermClass` rank,
+    /// which does not depend on the per-kind value domains.
+    #[kani::proof]
+    #[kani::unwind(4)]
+    fn transitivity_int_with_nonliteral_scalars() {
+        for_each_int_or_nonlit_small(|x| {
+            for_each_int_or_nonlit_small(|y| {
+                for_each_int_or_nonlit_small(|z| assert_transitive_at(x, y, z));
+            });
+        });
     }
 
     /// TRANSITIVITY: double literals (NaN-free — with NaN the comparator is partial, see the
     /// witness). Includes the `±0.0` equal-but-lexically-distinct pair: a mutation that let
     /// numeric ties fall through to the string form would go red here.
     #[kani::proof]
-    #[kani::unwind(24)]
+    #[kani::unwind(4)]
     fn transitivity_double_literals() {
         let term = || M::Dbl(any_idx(DBLS.len() as u8));
         assert_transitive_at(&term(), &term(), &term());
     }
 
+    /// One symbolic choice from the collapse-free MIXED numeric domain: `Int` over
+    /// `{-2, 0, 2, 10}` (indices 2..=I_TEN) or `Dbl` over `{-0.0, 0.0, 0.5}` (indices
+    /// 1..=3) — every value exactly representable in f64.
+    fn for_each_cf_numeric(f: impl Fn(&M)) {
+        if kani::any() {
+            let i: u8 = kani::any();
+            kani::assume(i >= 2 && i <= I_TEN);
+            f(&M::Int(i));
+        } else {
+            let i: u8 = kani::any();
+            kani::assume(i >= 1 && i <= 3);
+            f(&M::Dbl(i));
+        }
+    }
+
     /// TRANSITIVITY: a MIXED exact/inexact numeric domain restricted BELOW the collapse
-    /// boundary (every value exactly representable). Lawful here — which sharpens the
-    /// mixed-tier witness: the law breaks specifically AT the collapse, not on every mix.
+    /// boundary (see `for_each_cf_numeric` for the exact values). Lawful here — which
+    /// sharpens the mixed-tier witness: the law breaks specifically AT the collapse, not
+    /// on every exact/inexact mix.
     #[kani::proof]
-    #[kani::unwind(24)]
+    #[kani::unwind(3)]
     fn transitivity_mixed_numeric_collapse_free_range() {
-        let term = || {
-            if kani::any() {
-                // {-2, 0, 2, 10} — exact images
-                let i: u8 = kani::any();
-                kani::assume(i >= 2 && i <= I_TEN);
-                M::Int(i)
-            } else {
-                // {-0.0, 0.0, 0.5} — small doubles
-                let i: u8 = kani::any();
-                kani::assume(i >= 1 && i <= 3);
-                M::Dbl(i)
-            }
-        };
-        assert_transitive_at(&term(), &term(), &term());
+        for_each_cf_numeric(|x| {
+            for_each_cf_numeric(|y| {
+                for_each_cf_numeric(|z| assert_transitive_at(x, y, z));
+            });
+        });
     }
 
     /// TRANSITIVITY: plain-string literals (lexical order; includes the empty string and a
     /// prefix pair).
     #[kani::proof]
-    #[kani::unwind(24)]
+    #[kani::unwind(4)]
     fn transitivity_string_literals() {
         let term = || M::Str(any_idx(STRS.len() as u8));
         assert_transitive_at(&term(), &term(), &term());
@@ -629,7 +821,7 @@ mod kani_proofs {
 
     /// TRANSITIVITY: strict/temporal literals (the dateTime-by-timeline model arm).
     #[kani::proof]
-    #[kani::unwind(24)]
+    #[kani::unwind(4)]
     fn transitivity_strict_typed_literals() {
         let term = || M::Strict(any_idx(STRICT_STRS.len() as u8));
         assert_transitive_at(&term(), &term(), &term());
@@ -639,7 +831,7 @@ mod kani_proofs {
     /// ranging over the collapsed integer pair so the recursive numeric arm hits the
     /// exact-tier recheck INSIDE a triple.
     #[kani::proof]
-    #[kani::unwind(24)]
+    #[kani::unwind(4)]
     fn transitivity_triple_terms_recursive() {
         assert_transitive_at(&any_trip(), &any_trip(), &any_trip());
     }
@@ -650,7 +842,7 @@ mod kani_proofs {
     /// delete the recheck in `compare_terms` (or weaken the model's `exact_cmp` to `None` on
     /// exact pairs) and this harness goes red on `{2^53, 2^53+1}` — the non-vacuity anchor.
     #[kani::proof]
-    #[kani::unwind(24)]
+    #[kani::unwind(3)]
     fn exact_int_order_agreement_incl_2p53_collapse() {
         let i = any_idx(INTS.len() as u8);
         let j = any_idx(INTS.len() as u8);
@@ -667,8 +859,9 @@ mod kani_proofs {
     /// integers, which the exact tier orders strictly:
     ///   `2^53 ~ 9.007199254740992E15 ~ 2^53+1`  but  `2^53 < 2^53+1`.
     /// Engine-reachable: `num_compare` falls back to f64 when either operand is
-    /// float/double. If a fix lands (e.g. exact mixed-tier comparison — every finite f64 is
-    /// an exact rational), this harness goes red and should be REMOVED with the fix's bead.
+    /// float/double. Tracked as bead sq-wjl8i. If a fix lands (e.g. exact mixed-tier
+    /// comparison — every finite f64 is an exact rational), this harness goes red and
+    /// should be REMOVED with the fix.
     #[kani::proof]
     fn witness_mixed_tier_collapse_intransitivity() {
         let x = M::Int(I_2P53);
@@ -684,9 +877,9 @@ mod kani_proofs {
     /// lexical digit-string order disagrees with numeric order:
     ///   `10 < "11" < 2` (lexically)  but  `10 > 2` (numerically).
     /// Engine-reachable: `value_compare_strict` is `None` for a (numeric, plain-string)
-    /// pair, so `compare_terms` reaches its string fallback.
+    /// pair, so `compare_terms` reaches its string fallback. Tracked as bead sq-wjl8i.
     #[kani::proof]
-    #[kani::unwind(24)]
+    #[kani::unwind(4)]
     fn witness_numeric_vs_string_lexical_intransitivity() {
         let x = M::Int(I_TEN); // 10
         let y = M::Str(S_11); // "11"
@@ -700,10 +893,11 @@ mod kani_proofs {
     /// PARTIAL — numeric comparison against NaN is `None` (callers map it to `Equal`, so at
     /// the call site NaN ties with EVERY numeric, collapsing distinct equivalence classes),
     /// while NaN against a plain string is still DEFINED (lexical fallback). Engine-
-    /// reachable: `parse_xsd_f64` accepts the XSD `NaN` spelling. Also pins that the
-    /// module-level doc's "`None` only when a term has no string form" understates `None`.
+    /// reachable: `parse_xsd_f64` accepts the XSD `NaN` spelling. Tracked as bead
+    /// sq-wjl8i. Also pins that the module-level doc's "`None` only when a term has no
+    /// string form" understates `None` — that doc drift is tracked as bead sq-ma9fb.
     #[kani::proof]
-    #[kani::unwind(24)]
+    #[kani::unwind(4)]
     fn witness_nan_comparison_partiality() {
         assert!(compare_terms(&M::Nan, &M::Nan).is_none());
         assert!(compare_terms(&M::Nan, &M::Dbl(2)).is_none()); // vs 0.0
@@ -927,7 +1121,8 @@ mod tests {
         assert_eq!(compare_terms(&nested(2.0), &nested(2.0)), Some(Ordering::Equal));
     }
 
-    // --- BUG WITNESSES (pinned by the sq-sqtk2.4 Kani harnesses; tracked as P1 bug bead) ---
+    // --- BUG WITNESSES (pinned by the sq-sqtk2.4 Kani harnesses; tracked as P1 bug bead
+    //     sq-wjl8i) ---
     //
     // These three tests reproduce the machine-checked counterexamples from the Kani
     // `kani_proofs` module's `witness_*` harnesses. They are `#[ignore]` because they assert
@@ -943,11 +1138,11 @@ mod tests {
     /// `xsd:double 9.007199254740992E15` also equals `xsd:integer 2^53+1` (same reason),
     /// but `compare_terms(xsd:integer 2^53, xsd:integer 2^53+1)` returns `Less` (the
     /// exact recheck correctly orders them). The triple `(2^53, double(2^53), 2^53+1)` is an
-    /// intransitive witness. Tracked as a P1 correctness bead (see PR body for bead id).
+    /// intransitive witness. Tracked as P1 correctness bead sq-wjl8i.
     /// `ORDER BY` / `GROUP BY` / `MIN` / `MAX` over a column mixing integer and double values
     /// near 2^53 may produce permutation-unstable output violating SPARQL ordering semantics.
     #[test]
-    #[ignore = "BUG: mixed exact/inexact numeric intransitivity at 2^53 collapse — remove once fixed (see P1 bug bead in PR body)"]
+    #[ignore = "BUG sq-wjl8i: mixed exact/inexact numeric intransitivity at 2^53 collapse — remove once fixed"]
     fn bug_witness_mixed_exact_inexact_numeric_intransitivity_at_2p53() {
         let two53: f64 = 9_007_199_254_740_992.0;
         // x = xsd:integer 2^53 (exact tier)
@@ -972,9 +1167,9 @@ mod tests {
     /// inverts numeric order on certain pairs: `"10" < "11" < "2"` (lexical) while
     /// `10 > 2` (numeric). The triple `(Int 10, StrLit "11", Int 2)` is an intransitive
     /// witness: `10 < "11"` and `"11" < 2` (lexical) but `10 > 2` (numeric).
-    /// Tracked as a P1 correctness bead (see PR body for bead id).
+    /// Tracked as P1 correctness bead sq-wjl8i.
     #[test]
-    #[ignore = "BUG: numeric-vs-plain-string lexical-fallback intransitivity — remove once fixed (see P1 bug bead in PR body)"]
+    #[ignore = "BUG sq-wjl8i: numeric-vs-plain-string lexical-fallback intransitivity — remove once fixed"]
     fn bug_witness_numeric_vs_string_lexical_fallback_intransitivity() {
         // x = integer 10, z = integer 2: compare_terms(x, z) = Greater (10 > 2 numerically)
         let x = T::ExactNum { f: 10.0, mant: 10, scale: 0 };
@@ -996,9 +1191,9 @@ mod tests {
     /// `partial_cmp` then returns `None` for every NaN comparison. Callers that map `None` to
     /// `Equal` effectively place NaN equal to every numeric, collapsing distinct equivalence
     /// classes. Within-class totality is violated: `compare_terms(NaN, Int(0))` returns `None`
-    /// even though both are `TermClass::Literal`. Tracked as a P1 correctness bead.
+    /// even though both are `TermClass::Literal`. Tracked as P1 correctness bead sq-wjl8i.
     #[test]
-    #[ignore = "BUG: NaN makes comparator partial on same-class Literal pairs — remove once fixed (see P1 bug bead in PR body)"]
+    #[ignore = "BUG sq-wjl8i: NaN makes comparator partial on same-class Literal pairs — remove once fixed"]
     fn bug_witness_nan_partiality_violates_within_class_totality() {
         let nan = T::NumLit(f64::NAN);
         let zero = T::NumLit(0.0);

--- a/crates/sparq-substrate/src/compare.rs
+++ b/crates/sparq-substrate/src/compare.rs
@@ -240,6 +240,16 @@ pub fn compare_terms<T: CompareTerm>(x: &T, y: &T) -> Option<Ordering> {
 // which inflates the formula when set high). Under-bounding is LOUD: Kani's unwinding
 // assertion fails, so a too-small bound cannot silently weaken a proof.
 //
+// DOMAIN-COVERAGE SELF-CHECKS (the sq-og8u8 pattern): a re-scoped (shrunk) domain can
+// silently drop the very inputs that make a harness adversarial, so each shrunk domain's
+// interesting inputs are PINNED by a proof: `domain_exhibits_the_2p53_collapse` pins the
+// collapse straddle used by the full `INTS` table, the reduced int-with-non-literal
+// domain, and the triple-object domain;
+// `domain_cf_numeric_is_collapse_free_with_signed_zero_pair` pins the collapse-free
+// mixed range (exact images only) and its ±0.0 equal-but-lexically-distinct pair. If a
+// future re-scope silences an interesting input, one of these goes red rather than the
+// law harness silently proving less.
+//
 // HONESTY BOUNDARY (per the bead): this machine-checks the `compare_terms` ALGORITHM over
 // the model observation surface `M` below. It is explicitly NOT a claim about the engine's
 // `Value` impl of `CompareTerm` in `sparq-engine/src/exec.rs` (that instance stays covered
@@ -808,6 +818,35 @@ mod kani_proofs {
                 for_each_cf_numeric(|z| assert_transitive_at(x, y, z));
             });
         });
+    }
+
+    /// Domain self-check for the collapse-free mixed-numeric domain (companion to
+    /// `domain_exhibits_the_2p53_collapse`, which pins the straddle domains): every `Int`
+    /// the `for_each_cf_numeric` combinator can emit has an EXACT f64 image (the range is
+    /// genuinely collapse-free — an index drift onto the straddle would surface here), and
+    /// the `Dbl` table's `±0.0` entries (indices 1/2, inside the combinator's `1..=3`
+    /// range) are the equal-but-lexically-distinct pair the double-transitivity harness
+    /// relies on to catch a ties-fall-to-string-form mutation. If this fails, a re-scope
+    /// has silenced the domain's interesting inputs and the harnesses above it are weaker
+    /// than documented. [FABLE-5] sq-sqtk2.4
+    #[kani::proof]
+    #[kani::unwind(3)]
+    fn domain_cf_numeric_is_collapse_free_with_signed_zero_pair() {
+        for_each_cf_numeric(|x| match x {
+            M::Int(i) => {
+                // Exact image: the f64 roundtrips to the same integer (deliberate exact
+                // comparison — exactness IS the property).
+                assert!(
+                    INT_F64S[usize::from(*i)] as i128 == INTS[usize::from(*i)],
+                    "cf domain: Int range must be collapse-free"
+                );
+            }
+            M::Dbl(i) => assert!(usize::from(*i) < DBLS.len(), "cf domain: Dbl index in-table"),
+            _ => unreachable!("for_each_cf_numeric emits only Int/Dbl"),
+        });
+        // The signed-zero pair: numerically equal, lexically distinct.
+        assert!(DBLS[1] == DBLS[2], "signed zeros compare numerically equal");
+        assert!(DBL_STRS[1] != DBL_STRS[2], "signed zeros are lexically distinct");
     }
 
     /// TRANSITIVITY: plain-string literals (lexical order; includes the empty string and a

--- a/skills/substrate/SKILL.md
+++ b/skills/substrate/SKILL.md
@@ -127,6 +127,24 @@ monomorphisation seam, never a `dyn` object. Pure-`std`; pulls nothing new.
 sparq-substrate = { version = "0.1.0", features = ["compare"] }
 ```
 
+**Machine-checked order laws (Kani, sq-sqtk2.4).** `src/compare.rs` hosts a `#[cfg(kani)]`
+bounded-proof module proving, over an adversarial model `CompareTerm` impl whose numeric
+domain straddles the 2^53 f64-collapse boundary (2^53−1 / 2^53 / 2^53+1 / 2^53+2 and their
+shared f64 images, ±0.0, NaN): reflexivity (NaN-free), antisymmetry-consistency (full domain,
+`Some(o)` iff mirrored `Some(o.reverse())`, `None` iff `None`), within-class totality
+(NaN-free), per-literal-kind transitivity (exact ints across the collapse, doubles, strings,
+strict/temporal, a collapse-free exact/inexact mix, recursive triple terms), and exact-order
+agreement on the exact tier (the `exact_cmp` recheck's guarantee — delete the recheck and it
+goes red). Run `cargo kani -p sparq-substrate --features compare` (Kani injects the `kani`
+cfg; the normal build strips the module). Honest boundary: this proves the shared ALGORITHM
+over the bounded model, NOT the engine's `Value` impl (`sparq-engine/src/exec.rs` — covered
+by unit + W3C conformance tests; next-wave in `research/mechanized-proof-program.md` §6).
+Known, machine-checked LAW GAPS (witness harnesses, engine-reachable): mixed exact/inexact
+numerics are intransitive AT the collapse boundary; numeric-vs-plain-string pairs fall to the
+lexical form and are intransitive against the numeric order; NaN makes the comparator partial
+(`None`, mapped to `Equal` by callers). Do not build sort invariants on mixed literal-kind
+columns without consulting those witnesses.
+
 ## Cargo feature summary
 
 | Feature | Enables | Extra deps |


### PR DESCRIPTION
> 🤖 SPARQ agent — harness design [FABLE-5] (research/mechanized-proof-program.md §3.2/§5, bead sq-sqtk2.4); mechanical completion [SONNET-4.6]; verify-driven re-scope + evidence rerun [FABLE-5].

**ERRATUM:** an earlier revision of this PR claimed the law/transitivity harnesses verified in "10–50s each"; a deterministic replay (same box, same kani 0.67.0) showed several never finished in 12–55+ minutes, so that claim could not have been observed on the shipped code and was withdrawn. The harnesses were re-scoped (commit 8a91e0a7: per-kind concrete-discriminant dispatch + minimal unwind bounds) and this body's table now quotes only what the attached rerun log evidences.

## Summary

Adds `#[cfg(kani)]` bounded-proof harnesses for the SPARQL term total-order laws to `crates/sparq-substrate/src/compare.rs`. The `compare_terms` **runtime body is byte-unchanged** — harness-only diff.

**Spec:** `research/mechanized-proof-program.md` §3.2/§5, property B-1, bead sq-sqtk2.4.
**Acceptance test:** the Kani harnesses are the acceptance surface; the `#[test] #[ignore]` bug witnesses provide independent non-Kani pinning.
**Feature flags tested:** default (feature OFF — harnesses compile-gated out) and `--features compare` (Kani injects the `kani` cfg via `[lints.rust] unexpected_cfgs`).

## What is PROVED (bounded, over adversarial model `M`)

The model `M` is a bounded `CompareTerm` impl whose numeric domain straddles the 2^53 f64-collapse boundary (with collapsed f64 images, NaN, ±0.0, small doubles), plain strings, strict/temporal literals, and depth-1 triple terms — deliberately faithful to `sparq-engine/src/exec.rs` semantics (each trait method documents what it mirrors). After the re-scope, each law is proved by per-kind harnesses whose UNION covers the same domain as the original monolithic harnesses (the coverage argument is written next to each split in the module); the only genuinely SHRUNK domain is `transitivity_int_with_nonliteral_scalars` (a stated reduction, documented in its doc comment), and every shrunk domain's adversarial inputs are pinned by the two `domain_*` self-check proofs (the sq-og8u8 pattern).

| Harness | Law / role | Verdict | Time (s) |
|---|---|---|---|
| `reflexivity_numeric_literals_nan_free` | reflexivity, numeric kinds (NaN-free) | SUCCESSFUL | 0.31 |
| `reflexivity_nonnumeric_scalars` | reflexivity, Err/Blank/Iri/Str/Strict | SUCCESSFUL | 5.47 |
| `reflexivity_triple_terms` | reflexivity, depth-1 triples | SUCCESSFUL | 2.73 |
| `antisymmetry_numeric_pairs_incl_nan` | antisymmetry, numeric×numeric (NaN incl.) | SUCCESSFUL | 4.20 |
| `antisymmetry_numeric_vs_nonnumeric_incl_nan` | antisymmetry, numeric×non-numeric | SUCCESSFUL | 70.33 |
| `antisymmetry_nonnumeric_scalar_pairs` | antisymmetry, non-numeric×non-numeric | SUCCESSFUL | 68.51 |
| `antisymmetry_triple_vs_scalar` | antisymmetry, triple×non-triple | SUCCESSFUL | 0.73 |
| `antisymmetry_triple_pairs` | antisymmetry, triple×triple | SUCCESSFUL | 15.37 |
| `within_class_totality_literals_nan_free` | within-class totality, Literal class (NaN-free) | SUCCESSFUL | 55.82 |
| `within_class_totality_nonliterals` | within-class totality, Err/Blank/Iri/Trip | SUCCESSFUL | 9.70 |
| `transitivity_exact_int_literals_incl_2p53_collapse` | transitivity, exact ints incl. collapse | SUCCESSFUL | 0.54 |
| `transitivity_nonliteral_scalars` | transitivity, non-literal scalar classes | SUCCESSFUL | 72.74 |
| `transitivity_int_with_nonliteral_scalars` | transitivity, int×non-literal (REDUCED domain) | SUCCESSFUL | 125.03 |
| `transitivity_double_literals` | transitivity, doubles (NaN-free) | SUCCESSFUL | 0.50 |
| `transitivity_mixed_numeric_collapse_free_range` | transitivity, exact/inexact mix below collapse | SUCCESSFUL | 4.70 |
| `transitivity_string_literals` | transitivity, plain strings | SUCCESSFUL | 7.35 |
| `transitivity_strict_typed_literals` | transitivity, dateTime-by-timeline | SUCCESSFUL | 3.29 |
| `transitivity_triple_terms_recursive` | transitivity, depth-1 triples (recursive) | SUCCESSFUL | 18.45 |
| `exact_int_order_agreement_incl_2p53_collapse` | exact tier = i128 order at collapse | SUCCESSFUL | 0.29 |
| `domain_exhibits_the_2p53_collapse` | self-check: straddle domain is adversarial | SUCCESSFUL | 0.05 |
| `domain_cf_numeric_is_collapse_free_with_signed_zero_pair` | self-check: cf range collapse-free + ±0.0 pair | SUCCESSFUL | 0.09 |
| `witness_mixed_tier_collapse_intransitivity` | FINDING 1 (reachable law gap) | SUCCESSFUL | 0.38 |
| `witness_numeric_vs_string_lexical_intransitivity` | FINDING 2 (reachable law gap) | SUCCESSFUL | 1.12 |
| `witness_nan_comparison_partiality` | FINDING 3 (reachable law gap) | SUCCESSFUL | 0.84 |

**`Complete - 24 successfully verified harnesses, 0 failures, 24 total.`**

**Evidence run:** full `cargo kani -p sparq-substrate --features compare` (kani 0.67.0 / CBMC+CaDiCaL 2.0.0), captured to `/tmp/kani-substrate-final.log`. Every harness reached `VERIFICATION:- SUCCESSFUL`; longest single harness `transitivity_int_with_nonliteral_scalars` at 125.03s, all others under 73s. Total run `Elapsed (wall clock) time: 8:04.28`, `User time 462.57s`, peak RSS ~4.8 GB, on an **EC2 work box (non-canonical)** — Arm Neoverse-V1, 8 vCPU, 61 GB. These wall times are work-box observations, not a canonical performance claim; sq-sqtk2.5 wires the suite into a nightly kani lane so the verdict (not the timing) becomes CI-backed.

## Machine-checked FINDINGS (law gaps — NOT masked)

Three witnesses prove the order laws do NOT extend across mixed literal kinds (all independently confirmed by the adversarial verify):

**FINDING 1 (P1 — bead sq-wjl8i):** Mixed exact/inexact numeric intransitivity at 2^53 collapse.
- `Int(2^53) ~ Dbl(9.007199254740992E15) ~ Int(2^53+1)` (collapsed f64 Equal on each mixed pair)
- But `Int(2^53) < Int(2^53+1)` (exact recheck on the same-tier pair)
- Transitivity of equality VIOLATED. Engine-reachable: `num_compare` falls back to f64 when either operand is float/double.
- Impact: `ORDER BY` / `GROUP BY` / `MIN` / `MAX` over a column mixing `xsd:integer` and `xsd:double` values near 2^53 may produce permutation-unstable output, violating SPARQL ordering semantics.

**FINDING 2 (P1 — bead sq-wjl8i):** Numeric-vs-plain-string lexical-fallback intransitivity.
- `10 <(lex) "11" <(lex) 2` (cross-family pairs fall to the string form) but `10 >(num) 2`
- Transitivity of Less VIOLATED. Engine-reachable: `value_compare_strict` is None for numeric/plain-string cross-family pairs.

**FINDING 3 (P1 — bead sq-wjl8i):** NaN makes the comparator partial.
- `compare_terms(Dbl(NaN), Int(x))` returns `None` for any numeric x.
- Within-class totality VIOLATED on the Literal class (so reflexivity and within-class totality are claimed over the NaN-FREE domain only — README and module doc say so explicitly). Engine-reachable: `parse_xsd_f64` accepts XSD `NaN`.

All three are pinned as `#[test] #[ignore]` in `compare::tests::bug_witness_*` with the bead token `sq-wjl8i` embedded in each `#[ignore]` string and doc comment. Removing `#[ignore]` turns them RED (they assert the law that should hold).

**FINDING 4 (P3 — bead sq-ma9fb):** The `compare_terms` doc comment claims `None` is returned "only when a term has no string form"; the NaN witness proves `None` is also returned when `f64::partial_cmp` fires on NaN. Doc understates the partiality condition (bead token embedded in the witness doc comment). sq-ma9fb also notes the related loose "total order" phrasing in `crates/sparq-reason/README.md` (#1455).

## Mutation spot-checks (re-run first-hand on the shipped code)

1. **Kani exact-recheck mutant** — flipped `compare_terms`'s exact-recheck arm (compare.rs:192, `return Some(exact)` → `return Some(exact.reverse())`):
   - RED: `Failed Checks: "exact tier orders by exact value, collapse notwithstanding"` / `VERIFICATION:- FAILED` (`Verification Time: 0.41679752s`)
   - reverted → GREEN: `VERIFICATION:- SUCCESSFUL` (`Verification Time: 0.301155s`)
2. **Unit-test mutant** — flipped the Blank/IRI comparison arm (`x.value_str()?.cmp(&y…)` → `y.value_str()?.cmp(&x…)`): `compare::tests::blanks_and_iris_order_by_string` FAILED immediately; reverted → `10 passed; 0 failed; 3 ignored`.

## Gates

- `cargo test -p sparq-substrate` (default, feature OFF): 0 tests run, 0 failures ✓
- `cargo test -p sparq-substrate --features compare`: 10 passed, 3 ignored (the `#[ignore]` bug witnesses), 0 failed ✓
- `cargo clippy -p sparq-substrate --all-targets -- -D warnings` (default OFF): clean ✓
- `cargo clippy -p sparq-substrate --all-targets --features compare -- -D warnings`: clean ✓
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-substrate --no-deps --all-features`: clean ✓
- `python3 scripts/check-readme-template.py --enforce`: 0 deviations ✓ (README 117 lines, under the 120-line cap)

## Beads

- **sq-wjl8i** (P1 correctness): the three witness triples, engine-reachability analysis, impact on ORDER BY / MIN / MAX semantics.
- **sq-ma9fb** (P3 docs): `compare_terms` doc-drift on the `None` condition + the sparq-reason README "total order" phrasing.
- **sq-sqtk2.5** (P2): wire these harnesses into a nightly kani lane so evidence claims are CI-backed rather than work-box-attested.

## Honesty boundary

These proofs cover the shared ALGORITHM over the bounded model `M` (per-harness domains as stated in each doc comment — the harness doc is the authoritative domain statement). They are explicitly NOT a proof of the engine's `Value` impl of `CompareTerm` in `sparq-engine/src/exec.rs` — that instance stays covered by unit + W3C conformance tests. The model is deliberately faithful to `exec.rs` semantics, so the law gaps found ARE engine-reachable. The next proof-program wave (§6 of the design record) covers the `Value` impl directly.

Do NOT arm. Do NOT close sq-sqtk2.4.
