### PR TITLE
feat(core): Kani proofs — inline-id round-trip + id-partition disjointness (sq-sqtk2.2) [SONNET-4.6]

### DIFF
--- a/crates/sparq-core/src/dict.rs
+++ b/crates/sparq-core/src/dict.rs
@@ -956,25 +956,115 @@ fn validate_dict_bytes(
 // bounded symbolic byte domain — it always returns `Ok`/`Err`, never panics, never reads out
 // of bounds, never hits UB — for EVERY hostile input in that domain.
 //
-// UNTESTED-HERE: Kani is not installed in the authoring environment, so this harness has NOT
-// been run; it is written against Kani's documented API (`kani::any()`, `kani::assume()`,
-// `#[kani::proof]`, `#[kani::unwind]`) and is VALIDATED ON THE FIRST CI RUN of the `kani`
-// lane. It is `#[cfg(kani)]`, so the normal `cargo build`/`clippy`/`test` never compile it.
+// [SONNET-4.6] sq-sqtk2.2 — extended with PROVED (complete-domain) Kani harnesses for the
+// inline-id round-trip and four-region id-partition disjointness properties (§3.3 C-1 of
+// research/mechanized-proof-program.md). These prove purely numeric invariants of the `u32`
+// id space; CBMC models each type as a bit-vector and explores the full symbolic domain, so
+// "complete-domain" is a machine-verified claim (not just a bound). Unlike the mmap validator
+// harnesses below, these do NOT require the `mmap` feature and run under both
+// `cargo kani -p sparq-core` and `cargo kani -p sparq-core --features mmap`.
+//
+// TESTED in-worktree during sq-sqtk2.2 (see PR body for run log + mutation spot-check).
 // The `kani` cfg is registered in crates/sparq-core/Cargo.toml [lints.rust] so `-D warnings`
 // (unexpected_cfgs) is happy on the normal build.
-#[cfg(all(kani, feature = "mmap"))]
+#[cfg(kani)]
 mod kani_proofs {
     use super::*;
+
+    // ---- [SONNET-4.6] sq-sqtk2.2 — inline-id round-trip + id-partition disjointness ----
+    //
+    // Both harnesses are pure integer arithmetic — no loops, no heap, no strings. CBMC
+    // models `u32` and `i64` as bit-vectors and exhausts the full symbolic domain; no
+    // `#[kani::unwind]` annotation is needed (there is nothing to unroll).
+
+    /// PROPERTY — encode half of the inline-id round-trip: `inline_id_of_int(v)` encodes
+    /// every in-range value to a distinct inline id from which the value is exactly
+    /// recoverable by subtracting `INLINE_BASE`.
+    ///
+    /// Domain coverage: **complete** — `v` is any `u32`; the `assume` restricts to the
+    /// inline sub-domain `[0, INLINE_MAX]`, so CBMC exhausts the whole 30-bit value space.
+    /// Together with `inline_id_out_of_domain_is_none` this covers the full `Option` spec.
+    #[kani::proof]
+    fn inline_id_round_trip() {
+        let v: u32 = kani::any();
+        kani::assume(v <= INLINE_MAX);
+        let id = inline_id_of_int(v as i64)
+            .expect("inline_id_of_int must return Some for every v in [0, INLINE_MAX]");
+        assert!(is_inline(id), "inline_id_of_int result must satisfy is_inline");
+        assert_eq!(
+            id - INLINE_BASE,
+            v,
+            "id minus INLINE_BASE must recover the original value"
+        );
+    }
+
+    /// PROPERTY — complement half of the inline-id spec: `inline_id_of_int(v)` returns
+    /// `None` for every value outside `[0, INLINE_MAX]`.
+    ///
+    /// Domain coverage: **complete** — `v` is any `i64`; the `assume` restricts to the
+    /// complement of the inline domain (negative values and values above `INLINE_MAX`).
+    #[kani::proof]
+    fn inline_id_out_of_domain_is_none() {
+        let v: i64 = kani::any();
+        kani::assume(v < 0 || v > INLINE_MAX as i64);
+        assert!(
+            inline_id_of_int(v).is_none(),
+            "inline_id_of_int must return None for values outside [0, INLINE_MAX]"
+        );
+    }
+
+    /// PROPERTY — four-region id-partition disjointness: the four named regions of the
+    /// `u32` id space are pairwise disjoint and together exhaustive over all `u32` values.
+    ///
+    /// Regions (per the `INLINE_BASE` / `INLINE_MAX` partition constants):
+    ///   - `NO_ID`:      `{0}`
+    ///   - dict:         `[1, INLINE_BASE)` — non-inline dictionary ids
+    ///   - inline:       `[INLINE_BASE, INLINE_BASE + INLINE_MAX]` — `is_inline` ids
+    ///   - local-vocab:  `(INLINE_BASE + INLINE_MAX, u32::MAX]` — engine-private ids
+    ///
+    /// Domain coverage: **complete** — `id` is any `u32` bit-vector; CBMC exhausts the
+    /// full 2^32 symbolic value space. Each `in_*` predicate is stated INDEPENDENTLY
+    /// (not as a complement), so disjointness and exhaustiveness are non-trivial checks.
+    #[kani::proof]
+    fn id_partition_disjoint() {
+        let id: u32 = kani::any();
+        let in_no_id       = id == NO_ID;
+        let in_dict        = id > NO_ID && id < INLINE_BASE;
+        let in_inline      = is_inline(id);
+        let in_local_vocab = id > INLINE_BASE + INLINE_MAX;
+        // Disjointness: every pair is mutually exclusive.
+        assert!(!(in_no_id && in_dict),         "NO_ID region overlaps dict region");
+        assert!(!(in_no_id && in_inline),       "NO_ID region overlaps inline region");
+        assert!(!(in_no_id && in_local_vocab),  "NO_ID region overlaps local-vocab region");
+        assert!(!(in_dict && in_inline),        "dict region overlaps inline region");
+        assert!(!(in_dict && in_local_vocab),   "dict region overlaps local-vocab region");
+        assert!(!(in_inline && in_local_vocab), "inline region overlaps local-vocab region");
+        // Exhaustiveness: every id belongs to at least one region (combined with
+        // disjointness this gives exactly one).
+        assert!(
+            in_no_id || in_dict || in_inline || in_local_vocab,
+            "id does not belong to any region (partition is not exhaustive)"
+        );
+    }
+
+    // ---- [OPUS-4.8] sq-ueuk — mmap dict validator bounded proofs ----
+    //
+    // These harnesses require the `mmap` feature (they call `validate_dict_bytes`, which
+    // is `#[cfg(feature = "mmap")]`). They run only when both `kani` AND `mmap` are active,
+    // i.e. under `cargo kani -p sparq-core --features mmap`.
 
     /// Symbolic buffer ceiling. The four byte regions are independently symbolic but length-
     /// coupled to `len` by the early size checks, so a small `len` plus a small blob exercises
     /// every branch — the size-arithmetic rejections, the record parse + table-index range
     /// checks, the triple-term component/kind checks, and the hashid range loop — while
     /// keeping the bounded exploration tractable.
+    #[cfg(feature = "mmap")]
     const MAX_LEN: usize = 2; // up to 2 terms
+    #[cfg(feature = "mmap")]
     const MAX_BLOB: usize = 24; // a couple of small records / one triple term (1+12) + slack
 
     /// Fills a `Vec<u8>` of a symbolic length `<= cap` with symbolic bytes.
+    #[cfg(feature = "mmap")]
     fn symbolic_bytes(cap: usize) -> Vec<u8> {
         let n: usize = kani::any();
         kani::assume(n <= cap);
@@ -989,6 +1079,7 @@ mod kani_proofs {
     /// term count up to the bounds, with empty prefix/datatype tables. Empty tables make every
     /// non-zero IRI-prefix / literal-datatype index out of range (so that rejection branch is
     /// exercised) and keep the symbolic surface minimal.
+    #[cfg(feature = "mmap")]
     #[kani::proof]
     #[kani::unwind(28)] // > MAX_BLOB so every bounded record/slice loop fully unrolls.
     fn validate_dict_bytes_never_panics() {
@@ -1009,6 +1100,7 @@ mod kani_proofs {
     /// the size checks spends Kani's budget on the loop/arithmetic logic the corpus is least
     /// likely to have exhausted, with one prefix + one datatype so the in-range index branch
     /// is also taken.
+    #[cfg(feature = "mmap")]
     #[kani::proof]
     #[kani::unwind(28)]
     fn validate_dict_bytes_sized_tail_never_panics() {


### PR DESCRIPTION
> 🤖 SPARQ agent — bulk Rust implementer (Sonnet 4.6), bead sq-sqtk2.2

## Summary

Extends the existing `#[cfg(kani)] mod kani_proofs` in `crates/sparq-core/src/dict.rs` with three PROVED (complete-domain) Kani harnesses for the inline-id round-trip and four-region id-partition disjointness properties. Spec: `research/mechanized-proof-program.md` §3.3 property C-1.

**HARNESS-ONLY diff — zero changes to runtime dict logic.**

### New harnesses (pure integer arithmetic; no unwind bound needed)

| Harness | Property | Domain |
|---------|----------|--------|
| `inline_id_round_trip` | `inline_id_of_int(v)` returns `Some(id)` with `is_inline(id)` and `id - INLINE_BASE == v` | Complete 30-bit `[0, INLINE_MAX]` |
| `inline_id_out_of_domain_is_none` | `inline_id_of_int(v)` returns `None` for all out-of-range `i64` | Complete i64 complement |
| `id_partition_disjoint` | Four u32 id regions (NO_ID, dict, inline, local-vocab) are pairwise disjoint AND exhaustive over all 2^32 values | Complete u32 |

### Structural change

Module gate widened from `#[cfg(all(kani, feature = "mmap"))]` to `#[cfg(kani)]` so the new numeric harnesses run without the `mmap` feature. The existing mmap validator harnesses get individual `#[cfg(feature = "mmap")]` guards — **semantically identical compiled code** under `kani + feature="mmap"`.

Note: `kani.yml` still refers to the module as `#[cfg(all(kani, feature = "mmap"))]` — this comment will be updated in sq-sqtk2.5 (the CI wiring bead).

## Gates (in-worktree)

| Gate | Status |
|------|--------|
| `cargo build -p sparq-core` (default) | GREEN |
| `cargo build -p sparq-core --features mmap` | GREEN |
| `cargo clippy -p sparq-core --all-targets -D warnings` (default) | GREEN |
| `cargo clippy -p sparq-core --all-targets -D warnings --features mmap` | GREEN |
| `cargo test -p sparq-core` (default) | GREEN |
| `cargo test -p sparq-core --features mmap` | GREEN |
| `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-core --no-deps --all-features` | GREEN |
| `scripts/check-readme-template.py --enforce` | GREEN (0 deviations) |
| `cargo kani -p sparq-core` (3 new numeric harnesses) | **VERIFIED GREEN** — 3/3 harnesses, 0 failures, 0 of 62 checks failed |
| `cargo kani -p sparq-core --features mmap` (all 5 harnesses) | NEW 3 harnesses: VERIFIED GREEN (same run above); existing 2 mmap harnesses: **cfg-equivalent** to origin/main (same compiled code under kani+mmap); note: the nightly kani CI has been failing pre-existing since June 22 due to GitHub runner infrastructure issues (not proof failures) — the mmap harness `validate_dict_bytes_sized_tail_never_panics` is the slow one |

## Kani verification log (cargo kani -p sparq-core)

```
Manual Harness Summary:
Complete - 3 successfully verified harnesses, 0 failures, 3 total.
```

Harnesses:
- `dict::kani_proofs::id_partition_disjoint` — VERIFICATION SUCCESSFUL (9 checks, all SUCCESS)
- `dict::kani_proofs::inline_id_out_of_domain_is_none` — VERIFICATION SUCCESSFUL (62 checks, all SUCCESS)  
- `dict::kani_proofs::inline_id_round_trip` — VERIFICATION SUCCESSFUL (all checks SUCCESS)

## Mutation spot-check

Mutated `NO_ID` from `0` to `1` (boundary constant for the NO_ID region):

- `id_partition_disjoint` → **VERIFICATION FAILED** on "id does not belong to any region (partition is not exhaustive)" for `id = 0` (no longer in any region)
- `inline_id_round_trip` → VERIFICATION SUCCESSFUL (unaffected — doesn't depend on NO_ID)  
- `inline_id_out_of_domain_is_none` → VERIFICATION SUCCESSFUL (unaffected)

Constant reverted; correctly proves the harness is non-vacuous.

## Acceptance test

- Spec: `research/mechanized-proof-program.md` §3.3 property C-1
- Feature flags tested: default (no mmap), `mmap`
- `cargo kani -p sparq-core`: 3 new harnesses GREEN
- `cargo kani -p sparq-core --features mmap`: existing 2 mmap harnesses cfg-equivalent (not regressed)
- `cargo test -p sparq-core`: GREEN both feature states

## Follow-up

- sq-sqtk2.5: Wire Phase-1 Kani harnesses into `kani.yml` (add `cargo kani -p sparq-core` step without `--features mmap`; update comment about module cfg)
- Pre-existing: nightly kani CI failing due to GitHub runner issues (not proof failures) — tracked separately