### PR TITLE
feat(reason-dl): L4 fragment-dispatch Direct-Semantics checker + entailment-by-refutation (sq-pbz04.4.4) [FABLE-5]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4071,6 +4071,8 @@ dependencies = [
  "oxrdf 0.3.3",
  "rustc-hash 2.1.2",
  "sparq-core",
+ "sparq-reason",
+ "sparq-reason-el",
 ]
 
 [[package]]

--- a/crates/sparq-reason-dl/Cargo.toml
+++ b/crates/sparq-reason-dl/Cargo.toml
@@ -4,7 +4,7 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
-description = "Opt-in OWL 2 Direct-Semantics support for the sparq RDF engine — L1: a structural OWL model for the ALCH fragment + a FAIL-CLOSED reverse RDF mapping (no reasoning yet)"
+description = "Opt-in OWL 2 Direct-Semantics support for the sparq RDF engine — a layered FAIL-CLOSED checker for the scoped ALCH fragment (structural model + reverse RDF mapping, profile checker, tableau, and the opt-in `dispatch` fragment-dispatch checker); NOT full OWL 2 DL"
 repository.workspace = true
 homepage.workspace = true
 keywords.workspace = true
@@ -32,6 +32,15 @@ publish = false
 # the sole bead in its wave, so its Cargo.toml edits do not collide with the L2/L3 beads.
 default = []
 
+# [FABLE-5] sq-pbz04.4.4: the L4 fragment-dispatch Direct-Semantics checker (`check` module,
+# design record §4/§6) — OFF by default so the L1–L3 layers stay dependency-light. Pulls the
+# EXISTING profile reasoners as optional deps: sparq-reason (OWL 2 RL materialization + clash
+# scan) and sparq-reason-el (EL consequence-based classification). sparq-reason-el is used
+# with its DEFAULT features (no rbox/cdomain); the dispatch guards conservatively treat
+# rdfs:subPropertyOf as unapplied by the EL classifier either way (fail-closed under
+# workspace feature unification).
+dispatch = ["dep:sparq-reason", "dep:sparq-reason-el"]
+
 [dependencies]
 # `version` alongside `path`: cargo uses the path locally and the version on crates.io.
 sparq-core = { path = "../sparq-core", version = "0.1.0", default-features = false }
@@ -39,3 +48,8 @@ sparq-core = { path = "../sparq-core", version = "0.1.0", default-features = fal
 # (the same use as sparq-reason-el). rustc-hash: the structural index maps/sets.
 oxrdf.workspace = true
 rustc-hash.workspace = true
+# [FABLE-5] sq-pbz04.4.4: optional profile-reasoner deps, pulled ONLY by the `dispatch`
+# feature (L4). `version` alongside `path`: cargo uses the path locally, the version on
+# crates.io.
+sparq-reason = { path = "../sparq-reason", version = "0.1.0", optional = true }
+sparq-reason-el = { path = "../sparq-reason-el", version = "0.1.0", optional = true }

--- a/crates/sparq-reason-dl/README.md
+++ b/crates/sparq-reason-dl/README.md
@@ -6,17 +6,19 @@
 
 **Opt-in OWL 2 Direct-Semantics support** for the [sparq](../../README.md) RDF engine — a
 layered, fail-closed Direct-Semantics checker. **Built: L1** (structural **ALCH** model +
-fail-closed reverse RDF mapping), **L2** (syntactic EL/QL/RL profile checker), and **L3** (the
-terminating **ALCH tableau** — consistency + class satisfiability). It is a **separate crate** —
-`sparq-core`, `sparq-engine`, and the wasm build carry zero Direct-Semantics code, deps, or cost
-by default; DL is engaged only by depending on this crate.
+fail-closed reverse RDF mapping), **L2** (syntactic EL/QL/RL profile checker), **L3** (the
+terminating **ALCH tableau** — consistency + class satisfiability), and **L4** (the
+fragment-dispatch checker + entailment-by-refutation, behind the opt-in `dispatch` feature).
+It is a **separate crate** — `sparq-core`, `sparq-engine`, and the wasm build carry zero
+Direct-Semantics code, deps, or cost by default; DL is engaged only by depending on this crate.
 
 > **Honest scope.** This crate does **not** implement OWL 2 DL. The tableau is sound and
 > complete **only for the exact ALCH fragment** (named classes, ⊤/⊥, ⊓/⊔/¬, ∃/∀ over named
 > object properties, GCIs, `rdfs:subPropertyOf`, ground ABox) — anything else is refused
 > fail-closed as `Unknown(OutOfFragment)` BEFORE reasoning, and deterministic count-budget
-> exhaustion is `Unknown(ResourceBudget)`, never a verdict. The fragment-dispatch checker (L4)
-> lands in bead sq-pbz04.4.4. See the design record for the full scope and deferral ledger.
+> exhaustion is `Unknown(ResourceBudget)`, never a verdict. The L4 dispatch narrows its RL/EL
+> verdicts further behind explicit completeness guards (see the `check` module docs for the
+> per-branch table). See the design record for the full scope and deferral ledger.
 
 ## 🚀 Quickstart
 
@@ -81,7 +83,20 @@ are tri-state (`Satisfiable` / `Unsatisfiable` / `Unknown`); budgets are determi
 completeness argument (Baader–Sattler 2001) is reproduced in the `tableau` module docs. `nnf`
 supplies negation normal form and the finite subexpression closure the argument rests on.
 
-**Reserved (empty stub):** `check` (L4 fragment dispatch + entailment-by-refutation).
+**Fragment dispatch (L4, bead sq-pbz04.4.4, feature `dispatch`):**
+`check::DirectChecker::consistency` dispatches an extracted ontology to the first matching
+branch — **RL** (`sparq-reason` materialization + clash scan; `Inconsistent` sound via
+*checked* Theorem PR1 preconditions, `Consistent` only past a divergence guard over the
+constructs implicated in the documented RL rule-set divergences), **EL** (`sparq-reason-el`
+classification; verdicts only for a pure ⊤-free EL+⊥ TBox with zero skipped axioms), **QL**
+(always `Unknown` — DL-Lite_R consistency is the QL workstream's, not duplicated), or the
+**ALCH tableau** (complete for the fragment). `check::DirectChecker::entailment` decides
+premise ⊨ conclusion per conclusion-axiom by sound refutation encodings on the tableau
+(GCI / class-assertion / the fresh-class role-assertion trick + the record's desugarings);
+unencoded kinds abstain. Every verdict carries its producing `Branch`; every guard fails
+closed (`Unknown(reason)`, never a guess). The `dispatch` feature pulls `sparq-reason` +
+`sparq-reason-el` as optional deps — **off by default**, so L1–L3 stay dependency-light.
+
 **Deferred** (each rejected, never mis-mapped): inverse roles, cardinality/functionality,
 nominals (`owl:oneOf`/`owl:hasValue`), transitivity, `sameAs`/`differentFrom`, datatypes, keys —
 with a named reason and unlock path in the design record's deferral ledger.

--- a/crates/sparq-reason-dl/src/check.rs
+++ b/crates/sparq-reason-dl/src/check.rs
@@ -1,10 +1,798 @@
-//! L4 — fragment-dispatch Direct-Semantics checker + entailment-by-refutation (RESERVED STUB).
+//! L4 — fragment-dispatch Direct-Semantics checker + entailment-by-refutation.
 //!
-//! 🤖 SPARQ agent [FABLE-5]. Populated by bead sq-pbz04.4.4. This module will compose the L3
-//! ALCH tableau with the EXISTING RL/EL machinery under explicit completeness guards (the RL
-//! divergence guard, the EL skipped-axioms guard, QL pending) and add entailment-by-refutation,
-//! returning a definitive verdict only where a branch is complete and `Unknown` otherwise —
-//! never a guessed verdict. That bead ALSO owns the `dispatch` feature + re-export lines this
-//! layer needs in `Cargo.toml`/`lib.rs` (design record `research/owl2-direct-semantics-scoping.md`
-//! §6/§7); it is the sole bead in its wave so those serialized edits do not collide. It is
-//! intentionally empty in L1.
+//! 🤖 SPARQ agent [FABLE-5]. Bead sq-pbz04.4.4 (epic sq-pbz04.4, design record
+//! `research/owl2-direct-semantics-scoping.md` §4 — the SPEC; its soundness arguments are
+//! binding on this module). Feature-gated behind `dispatch`, which pulls the existing
+//! profile reasoners (`sparq-reason` RL, `sparq-reason-el` EL) as optional dependencies.
+//!
+//! # Dispatch (design record §4)
+//!
+//! [`DirectChecker::consistency`] extracts the graph through the fail-closed L1 mapping,
+//! asks the L2 syntactic profile checker where the ontology lives, and dispatches IN ORDER:
+//!
+//! | # | Branch | Engine | `Consistent` | `Inconsistent` | Abstention |
+//! |---|--------|--------|--------------|----------------|------------|
+//! | 1 | RL (L2 says in-RL) | `sparq_reason::materialize(Profile::OwlRl)` + `inconsistencies()` | only past the **divergence guard** | sound via **Theorem PR1** (preconditions CHECKED, not assumed) | [`UnknownReason::RlPr1Preconditions`], [`UnknownReason::RlDivergenceGuard`] |
+//! | 2 | EL (in-EL) | `sparq_reason_el::Classifier::classify` | only for a pure ⊤-free EL+⊥ TBox (argument below) | never (see the ⊤ guard) | [`UnknownReason::ElSkippedAxioms`], [`UnknownReason::ElUnappliedAxioms`], [`UnknownReason::ElTopGuard`] |
+//! | 3 | QL (in-QL) | none — deferred | never | never | [`UnknownReason::QlConsistencyPending`] (always; DL-Lite_R consistency is sq-pbz04.3.4's, not duplicated here) |
+//! | 4 | ALCH (everything else L1 extracted) | the L3 tableau | complete for the fragment | complete for the fragment | [`UnknownReason::ResourceBudget`] |
+//! | — | extraction failed | none | never | never | [`UnknownReason::OutOfFragment`] |
+//!
+//! The first branch whose profile test matches OWNS the verdict — an abstaining branch does
+//! NOT fall through (the record specifies dispatch-in-order; a tableau fallback for
+//! guard-abstained RL/EL/QL inputs is possible future work, recorded as such, not silently
+//! added). Every verdict carries the [`Branch`] that produced it (the traceability
+//! invariant), and every guard fails CLOSED: uncertainty is [`UnknownReason`], never a
+//! guessed `Consistent`/`Inconsistent`.
+//!
+//! ## RL branch soundness
+//!
+//! - `Inconsistent`: the implemented RL/RDF rules are sound, and for RL ontologies Theorem
+//!   PR1 (W3C OWL 2 Profiles §4.3) ties rule-derived inconsistency to Direct-Semantics
+//!   inconsistency. The PR1 preconditions are **checked**: (a) *no punning* — no id is used
+//!   as more than one of {class, object property, individual} anywhere in the L1 model
+//!   (usage-level punning is exactly what reaches the rule closure; declaration-only typing
+//!   contributes no logical triples in the L1 fragment, and unknown typings fail extraction);
+//!   (b) *no annotation axioms* — guaranteed structurally: the fail-closed L1 mapping has no
+//!   annotation-axiom shape (built-in annotations are ignored, unknown predicates refuse the
+//!   graph). A punning violation abstains BOTH verdicts (under punning the input is not an
+//!   OWL 2 DL ontology, so a Direct-Semantics verdict is ill-posed).
+//! - `Consistent` ("no clash") additionally needs rule-set *completeness*, which sparq's RL
+//!   does not globally have — 13 documented divergences (`DOCUMENTED_DIVERGENCES` in
+//!   sparq-conformance's `owl_suite.rs`). The **divergence guard** abstains when the model
+//!   touches any implicated construct reachable through the L1∩RL funnel:
+//!   `owl:complementOf` (DisjointClasses-001/-003, New-Feature-ObjectQCR-002),
+//!   `owl:unionOf` (WebOnt-I5.5-005), and `owl:disjointWith` (DisjointClasses-001/-003) —
+//!   a deliberate over-approximation (fail-closed). The other ten entries implicate
+//!   constructs (property chains/transitivity, maxQC, `differentFrom`/`AllDifferent`,
+//!   functional/inverse-functional/reflexive/disjoint properties, datatype ranges) that L1
+//!   extraction already refuses, so they cannot reach this branch.
+//!
+//! ## EL branch soundness
+//!
+//! `Classifier::classify` is a TBox classifier: it applies `subClassOf` /
+//! `equivalentClass` / `disjointWith` axioms only, counting out-of-fragment class
+//! expressions in `Report::skipped_axioms`; ABox assertions, `rdfs:subPropertyOf`,
+//! `rdfs:domain`, and `rdfs:range` are neither applied nor counted, and it does NOT track
+//! the satisfiability of ⊤ (verified empirically: `owl:Thing rdfs:subClassOf owl:Nothing`
+//! yields an empty unsatisfiable-class list). Three guards therefore protect the verdict:
+//! skipped axioms abstain ([`UnknownReason::ElSkippedAxioms`], per the record); axiom kinds
+//! the classifier does not apply abstain ([`UnknownReason::ElUnappliedAxioms`]); any
+//! occurrence of `owl:Thing` abstains ([`UnknownReason::ElTopGuard`]). Past all three the
+//! input is a pure EL+⊥ TBox not mentioning ⊤, and `Consistent` is sound by a direct model
+//! construction: interpret every named class and role as empty over a one-element domain —
+//! by induction every ⊤-free EL class expression (named class, ⊥, ⊓, ∃) denotes ∅, so every
+//! GCI/equivalence/disjointness holds. This branch never returns `Inconsistent` (a pure
+//! ⊤-free EL+⊥ TBox is always consistent; anything else is guarded away).
+//!
+//! # Entailment by refutation (design record §4)
+//!
+//! [`DirectChecker::entailment`] checks `O ⊨ α` per conclusion axiom by encoding the
+//! refutation into a consistency question and deciding it with the **L3 ALCH tableau**
+//! (sound and complete for the entire L1 fragment, which contains every premise the L1
+//! mapping accepts and every encoding below — so routing refutations to the tableau, the
+//! strongest complete branch, preserves the record's "definitive verdicts only from a
+//! complete branch" rule; RL/EL refutation routes would add only budget robustness and are
+//! future work):
+//!
+//! - `SubClassOf(C, D)` — `O ∪ {(C ⊓ ¬D)(x)}` with `x` fresh: inconsistent iff `O ⊨ C ⊑ D`.
+//! - `ClassAssertion(C, a)` — `O ∪ {(¬C)(a)}`: inconsistent iff `O ⊨ C(a)`.
+//! - `ObjectPropertyAssertion(R, a, b)` — `O ∪ {B(b), (∀R.¬B)(a)}` with `B` a FRESH class
+//!   name. Sound AND complete (record §4; re-verified for this implementation): if every
+//!   model has `(a,b) ∈ R` then `b ∈ B` and `a ∈ ∀R.¬B` clash, so the union is
+//!   inconsistent; conversely a model `I` of `O` with `(aᴵ,bᴵ) ∉ Rᴵ` extends to a model of
+//!   the union by interpreting `Bᴵ = {bᴵ}` (`B` occurs nowhere in `O`, and no R-successor
+//!   of `aᴵ` is `bᴵ`), so non-entailment yields consistency.
+//! - `EquivalentClasses(C, D)` — the two GCI refutations (`C ⊑ D` and `D ⊑ C`); exact by
+//!   the Direct-Semantics desugaring the record §3 lists.
+//! - `DisjointClasses(C, D)` — `O ∪ {(C ⊓ D)(x)}`, `x` fresh: the `C ⊓ D ⊑ ⊥` desugaring.
+//! - `ObjectPropertyDomain(R, C)` / `ObjectPropertyRange(R, C)` — the `∃R.⊤ ⊑ C` /
+//!   `⊤ ⊑ ∀R.C` desugarings (record §3), then the GCI refutation.
+//! - `SubObjectPropertyOf` — [`UnknownReason::UnencodedConclusion`]: the record defers
+//!   property-axiom conclusions (no argued encoding is composed here).
+//!
+//! `Entailed` needs every conclusion axiom's refutation(s) unsatisfiable; a single
+//! definitively-satisfiable refutation is `NotEntailed` (sound because the tableau is
+//! complete — exactly the record's rule that negative-entailment verdicts come only from a
+//! complete branch); anything else abstains. An empty conclusion ontology is trivially
+//! `Entailed`. Fresh names are minted as `urn:` IRIs checked against every id occurring in
+//! the premise AND conclusion models.
+//!
+//! # Honest boundary
+//!
+//! This module never claims completeness beyond the argued fragment: the only complete
+//! branch is the ALCH tableau (within budget); RL `Consistent` is guard-narrowed, EL
+//! `Consistent` is ⊤-free-TBox-narrowed, QL consistency is wholly deferred, and every
+//! uncertain case is a typed [`UnknownReason`].
+
+use crate::extract::extract;
+use crate::model::{Axiom, ClassExpression, Ontology};
+use crate::profile::profiles;
+use crate::tableau::{self, Budget, ExhaustedBudget};
+use rustc_hash::FxHashSet;
+use sparq_core::dict::{Dict, Id};
+use sparq_reason::{inconsistencies, materialize, Profile};
+use sparq_reason_el::Classifier;
+
+// -------------------------------------------------------------------------------------------
+// Public verdict types
+// -------------------------------------------------------------------------------------------
+
+/// The dispatch branch that produced a verdict — the traceability half of the module
+/// invariant: every verdict is attributable to a branch whose soundness/completeness story
+/// is written in the module docs.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Branch {
+    /// The fail-closed L1 extraction itself (the graph never reached a reasoner).
+    Extraction,
+    /// OWL 2 RL materialization + clash scan (`sparq-reason`), PR1-checked.
+    RlMaterialization,
+    /// OWL 2 EL consequence-based classification (`sparq-reason-el`), triple-guarded.
+    ElClassification,
+    /// OWL 2 QL — consistency wholly deferred to the QL workstream (sq-pbz04.3.4).
+    QlDeferred,
+    /// The L3 ALCH completion-forest tableau (complete for the L1 fragment).
+    AlchTableau,
+}
+
+/// Why the checker abstained. Fail-closed: no reason ever degrades into a verdict.
+#[derive(Clone, Debug, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum UnknownReason {
+    /// The L1 mapping refused the graph (rendered `ExtractError`): the input uses a
+    /// construct outside the ALCH structural fragment, or is malformed.
+    OutOfFragment(String),
+    /// The RL branch matched but a Theorem PR1 precondition failed (usage-level punning);
+    /// the Direct-Semantics bridge does not apply, so BOTH verdicts are withheld.
+    RlPr1Preconditions(String),
+    /// The RL branch found no clash, but the model touches a construct implicated in the
+    /// documented RL rule-set divergences, so "no clash" does not certify consistency.
+    RlDivergenceGuard(String),
+    /// The EL classifier skipped that many axioms (out-of-fragment class expressions); a
+    /// skipped axiom could be the inconsistency.
+    ElSkippedAxioms(usize),
+    /// The model contains an axiom kind the EL classifier does not apply (ABox assertions,
+    /// `rdfs:subPropertyOf`, `rdfs:domain`, `rdfs:range`) — and does not count as skipped.
+    ElUnappliedAxioms(String),
+    /// The model mentions `owl:Thing`: the EL classifier does not track ⊤'s
+    /// satisfiability (empirically verified), so a ⊤-involving verdict is withheld.
+    ElTopGuard,
+    /// The ontology dispatched to the QL branch, whose Direct-Semantics consistency
+    /// procedure is deferred to the QL workstream (sq-pbz04.3.4) — never duplicated here.
+    QlConsistencyPending,
+    /// The ALCH tableau exhausted its deterministic count budget mid-search.
+    ResourceBudget(ExhaustedBudget),
+    /// Entailment only: the conclusion-axiom kind has no argued refutation encoding
+    /// (property-axiom conclusions are deferred by the design record).
+    UnencodedConclusion(String),
+}
+
+/// Tri-state Direct-Semantics consistency verdict (design record §4).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum ConsistencyVerdict {
+    /// The ontology has a model — asserted only by a branch complete for its guard.
+    Consistent,
+    /// The ontology has no model — asserted only where the producing branch is sound.
+    Inconsistent,
+    /// No verdict; the payload says exactly why (fail-closed).
+    Unknown(UnknownReason),
+}
+
+impl ConsistencyVerdict {
+    /// `true` iff the verdict is [`ConsistencyVerdict::Consistent`].
+    #[must_use]
+    pub fn is_consistent(&self) -> bool {
+        matches!(self, ConsistencyVerdict::Consistent)
+    }
+
+    /// `true` iff the verdict is [`ConsistencyVerdict::Inconsistent`].
+    #[must_use]
+    pub fn is_inconsistent(&self) -> bool {
+        matches!(self, ConsistencyVerdict::Inconsistent)
+    }
+
+    /// `true` iff the checker abstained.
+    #[must_use]
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, ConsistencyVerdict::Unknown(_))
+    }
+}
+
+/// Tri-state Direct-Semantics entailment verdict (refutation-based, design record §4).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum EntailmentVerdict {
+    /// Every conclusion axiom is entailed (each refutation is unsatisfiable).
+    Entailed,
+    /// At least one conclusion axiom is definitively NOT entailed (its refutation is
+    /// satisfiable, certified by the complete ALCH tableau).
+    NotEntailed,
+    /// No verdict; the payload says exactly why (fail-closed).
+    Unknown(UnknownReason),
+}
+
+impl EntailmentVerdict {
+    /// `true` iff the verdict is [`EntailmentVerdict::Entailed`].
+    #[must_use]
+    pub fn is_entailed(&self) -> bool {
+        matches!(self, EntailmentVerdict::Entailed)
+    }
+
+    /// `true` iff the verdict is [`EntailmentVerdict::NotEntailed`].
+    #[must_use]
+    pub fn is_not_entailed(&self) -> bool {
+        matches!(self, EntailmentVerdict::NotEntailed)
+    }
+
+    /// `true` iff the checker abstained.
+    #[must_use]
+    pub fn is_unknown(&self) -> bool {
+        matches!(self, EntailmentVerdict::Unknown(_))
+    }
+}
+
+/// A consistency verdict plus the branch that produced it (traceability invariant).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ConsistencyOutcome {
+    /// The tri-state verdict.
+    pub verdict: ConsistencyVerdict,
+    /// The dispatch branch that owned the decision.
+    pub branch: Branch,
+}
+
+/// An entailment verdict plus the branch that produced it (traceability invariant).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct EntailmentOutcome {
+    /// The tri-state verdict.
+    pub verdict: EntailmentVerdict,
+    /// The branch that owned the decision ([`Branch::AlchTableau`] for every refutation
+    /// that ran; [`Branch::Extraction`] when an input graph was refused).
+    pub branch: Branch,
+}
+
+// -------------------------------------------------------------------------------------------
+// The checker
+// -------------------------------------------------------------------------------------------
+
+/// The L4 fragment-dispatch Direct-Semantics checker (module docs; design record §4).
+///
+/// Stateless apart from the deterministic tableau [`Budget`] used by the ALCH branch and
+/// every refutation check. Construct with [`DirectChecker::new`] (default budget) or
+/// [`DirectChecker::with_budget`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct DirectChecker {
+    budget: Budget,
+}
+
+impl Default for DirectChecker {
+    fn default() -> DirectChecker {
+        DirectChecker::new()
+    }
+}
+
+impl DirectChecker {
+    /// A checker with the default deterministic tableau budget.
+    #[must_use]
+    pub fn new() -> DirectChecker {
+        DirectChecker {
+            budget: Budget::default(),
+        }
+    }
+
+    /// A checker with a caller-pinned tableau budget (conformance lanes pin their own for
+    /// reproducibility).
+    #[must_use]
+    pub fn with_budget(budget: Budget) -> DirectChecker {
+        DirectChecker { budget }
+    }
+
+    /// Decide Direct-Semantics consistency of the ontology encoded in `triples` by
+    /// fragment dispatch (module docs table).
+    ///
+    /// `dict` is mutable because the RL branch materializes (interning vocabulary /
+    /// derived terms); existing ids are never changed. The dispatch order is RL → EL →
+    /// QL → ALCH; extraction failure short-circuits to
+    /// [`UnknownReason::OutOfFragment`]. Every guard fails closed.
+    #[must_use]
+    pub fn consistency(&self, dict: &mut Dict, triples: &[[Id; 3]]) -> ConsistencyOutcome {
+        let onto = match extract(dict, triples) {
+            Ok(onto) => onto,
+            Err(e) => {
+                return ConsistencyOutcome {
+                    verdict: ConsistencyVerdict::Unknown(UnknownReason::OutOfFragment(format!(
+                        "{}",
+                        e
+                    ))),
+                    branch: Branch::Extraction,
+                }
+            }
+        };
+        let ps = profiles(&onto);
+        if ps.rl.is_in() {
+            return rl_branch(dict, triples, &onto);
+        }
+        if ps.el.is_in() {
+            return el_branch(dict, triples, &onto);
+        }
+        if ps.ql.is_in() {
+            return ConsistencyOutcome {
+                verdict: ConsistencyVerdict::Unknown(UnknownReason::QlConsistencyPending),
+                branch: Branch::QlDeferred,
+            };
+        }
+        // Everything the L1 mapping accepts is inside the ALCH fragment by construction.
+        ConsistencyOutcome {
+            verdict: tableau_consistency(&onto, self.budget),
+            branch: Branch::AlchTableau,
+        }
+    }
+
+    /// Decide whether the premise ontology entails the conclusion ontology (both given as
+    /// triples over the SAME `dict`), by per-axiom refutation on the ALCH tableau
+    /// (module docs).
+    ///
+    /// `dict` is mutable only to mint the fresh `urn:` individual/class names the
+    /// encodings need; existing ids are never changed. `Entailed` requires every
+    /// conclusion axiom entailed; the first definitively-not-entailed axiom returns
+    /// `NotEntailed`; otherwise any abstention returns `Unknown` (fail-closed). An empty
+    /// conclusion is trivially `Entailed`.
+    #[must_use]
+    pub fn entailment(
+        &self,
+        dict: &mut Dict,
+        premise: &[[Id; 3]],
+        conclusion: &[[Id; 3]],
+    ) -> EntailmentOutcome {
+        let unknown_extraction = |e: String| EntailmentOutcome {
+            verdict: EntailmentVerdict::Unknown(UnknownReason::OutOfFragment(e)),
+            branch: Branch::Extraction,
+        };
+        let prem = match extract(dict, premise) {
+            Ok(onto) => onto,
+            Err(e) => return unknown_extraction(format!("premise: {}", e)),
+        };
+        let concl = match extract(dict, conclusion) {
+            Ok(onto) => onto,
+            Err(e) => return unknown_extraction(format!("conclusion: {}", e)),
+        };
+        let mut fresh = FreshNames::new(dict, [&prem, &concl]);
+        let mut first_unknown: Option<UnknownReason> = None;
+        for axiom in concl.axioms() {
+            match self.axiom_entailed(&prem, axiom, &mut fresh) {
+                AxiomVerdict::Entailed => {}
+                AxiomVerdict::NotEntailed => {
+                    // Sound early exit: the conjunction of conclusion axioms fails as soon
+                    // as one conjunct definitively fails, regardless of abstentions.
+                    return EntailmentOutcome {
+                        verdict: EntailmentVerdict::NotEntailed,
+                        branch: Branch::AlchTableau,
+                    };
+                }
+                AxiomVerdict::Unknown(reason) => {
+                    first_unknown.get_or_insert(reason);
+                }
+            }
+        }
+        let verdict = match first_unknown {
+            Some(reason) => EntailmentVerdict::Unknown(reason),
+            None => EntailmentVerdict::Entailed,
+        };
+        EntailmentOutcome {
+            verdict,
+            branch: Branch::AlchTableau,
+        }
+    }
+
+    /// One conclusion axiom: build its refutation check(s), decide each on the tableau,
+    /// and aggregate (all-unsat = entailed; any-sat = not entailed; else unknown).
+    fn axiom_entailed(
+        &self,
+        premise: &Ontology,
+        conclusion: &Axiom,
+        fresh: &mut FreshNames,
+    ) -> AxiomVerdict {
+        let Some(checks) = refutation_checks(conclusion, fresh) else {
+            return AxiomVerdict::Unknown(UnknownReason::UnencodedConclusion(format!(
+                "no argued refutation encoding for the conclusion-axiom kind of {:?}",
+                conclusion
+            )));
+        };
+        let mut first_unknown: Option<UnknownReason> = None;
+        for additions in checks {
+            let mut augmented = premise.clone();
+            augmented.axioms.extend(additions);
+            match tableau::consistency(&augmented, self.budget) {
+                tableau::Verdict::Unsatisfiable => {} // this component is entailed
+                tableau::Verdict::Satisfiable => return AxiomVerdict::NotEntailed,
+                tableau::Verdict::Unknown(tableau::UnknownReason::ResourceBudget(b)) => {
+                    first_unknown.get_or_insert(UnknownReason::ResourceBudget(b));
+                }
+                tableau::Verdict::Unknown(tableau::UnknownReason::OutOfFragment(m)) => {
+                    // Unreachable in practice (both inputs already extracted, and every
+                    // encoding stays inside ALCH) — kept fail-closed regardless.
+                    first_unknown.get_or_insert(UnknownReason::OutOfFragment(m));
+                }
+            }
+        }
+        match first_unknown {
+            Some(reason) => AxiomVerdict::Unknown(reason),
+            None => AxiomVerdict::Entailed,
+        }
+    }
+}
+
+/// Per-conclusion-axiom tri-state (internal aggregation of one axiom's refutation checks).
+enum AxiomVerdict {
+    Entailed,
+    NotEntailed,
+    Unknown(UnknownReason),
+}
+
+// -------------------------------------------------------------------------------------------
+// RL branch
+// -------------------------------------------------------------------------------------------
+
+/// The RL branch (module docs §"RL branch soundness").
+fn rl_branch(dict: &mut Dict, triples: &[[Id; 3]], onto: &Ontology) -> ConsistencyOutcome {
+    let out = |verdict| ConsistencyOutcome {
+        verdict,
+        branch: Branch::RlMaterialization,
+    };
+    if let Some(msg) = pr1_punning_violation(onto) {
+        return out(ConsistencyVerdict::Unknown(
+            UnknownReason::RlPr1Preconditions(msg),
+        ));
+    }
+    let mut work = triples.to_vec();
+    materialize(Profile::OwlRl, dict, &mut work);
+    let clashes = inconsistencies(dict, &work);
+    if !clashes.is_empty() {
+        return out(ConsistencyVerdict::Inconsistent);
+    }
+    if let Some(construct) = rl_divergence_guard(onto) {
+        return out(ConsistencyVerdict::Unknown(
+            UnknownReason::RlDivergenceGuard(construct),
+        ));
+    }
+    out(ConsistencyVerdict::Consistent)
+}
+
+/// Usage-level punning scan for the PR1 precondition: no id may be used as more than one
+/// of {class, object property, individual} across the model. Returns a diagnostic naming
+/// the first overlap.
+fn pr1_punning_violation(onto: &Ontology) -> Option<String> {
+    let mut classes: FxHashSet<Id> = FxHashSet::default();
+    let mut properties: FxHashSet<Id> = FxHashSet::default();
+    let mut individuals: FxHashSet<Id> = FxHashSet::default();
+    let mut ces: Vec<&ClassExpression> = Vec::new();
+    for axiom in onto.axioms() {
+        ces.extend(axiom_ces(axiom));
+        match axiom {
+            Axiom::SubObjectPropertyOf { sub, sup } => {
+                properties.extend([sub.named(), sup.named()]);
+            }
+            Axiom::ObjectPropertyDomain { property, .. }
+            | Axiom::ObjectPropertyRange { property, .. } => {
+                properties.insert(property.named());
+            }
+            Axiom::ClassAssertion { individual, .. } => {
+                individuals.insert(*individual);
+            }
+            Axiom::ObjectPropertyAssertion {
+                property,
+                source,
+                target,
+            } => {
+                properties.insert(property.named());
+                individuals.extend([*source, *target]);
+            }
+            Axiom::SubClassOf { .. }
+            | Axiom::EquivalentClasses(_, _)
+            | Axiom::DisjointClasses(_, _) => {}
+        }
+    }
+    while let Some(ce) = ces.pop() {
+        match ce {
+            ClassExpression::Class(id) => {
+                classes.insert(*id);
+            }
+            ClassExpression::Thing | ClassExpression::Nothing => {}
+            ClassExpression::ObjectIntersectionOf(members)
+            | ClassExpression::ObjectUnionOf(members) => ces.extend(members),
+            ClassExpression::ObjectComplementOf(inner) => ces.push(inner),
+            ClassExpression::ObjectSomeValuesFrom(p, filler)
+            | ClassExpression::ObjectAllValuesFrom(p, filler) => {
+                properties.insert(p.named());
+                ces.push(filler);
+            }
+        }
+    }
+    let overlap = |a: &FxHashSet<Id>, b: &FxHashSet<Id>| a.intersection(b).next().copied();
+    if let Some(id) = overlap(&classes, &individuals) {
+        return Some(format!("id {} is used as both class and individual", id));
+    }
+    if let Some(id) = overlap(&classes, &properties) {
+        return Some(format!("id {} is used as both class and property", id));
+    }
+    if let Some(id) = overlap(&properties, &individuals) {
+        return Some(format!("id {} is used as both property and individual", id));
+    }
+    None
+}
+
+/// The RL divergence guard (module docs §"RL branch soundness"): the first implicated
+/// construct the model touches, or `None` when "no clash" may soundly read as consistent.
+fn rl_divergence_guard(onto: &Ontology) -> Option<String> {
+    for axiom in onto.axioms() {
+        if matches!(axiom, Axiom::DisjointClasses(_, _)) {
+            return Some(
+                "owl:disjointWith (implicated by DOCUMENTED_DIVERGENCES \
+                 DisjointClasses-001/-003)"
+                    .to_string(),
+            );
+        }
+        if let Some(construct) = axiom_ces(axiom).into_iter().find_map(implicated_construct) {
+            return Some(construct);
+        }
+    }
+    None
+}
+
+/// The class expressions carried by an axiom (none for `SubObjectPropertyOf` /
+/// `ObjectPropertyAssertion`).
+fn axiom_ces(axiom: &Axiom) -> Vec<&ClassExpression> {
+    match axiom {
+        Axiom::SubClassOf { sub, sup } => vec![sub, sup],
+        Axiom::EquivalentClasses(l, r) | Axiom::DisjointClasses(l, r) => vec![l, r],
+        Axiom::ObjectPropertyDomain { domain, .. } => vec![domain],
+        Axiom::ObjectPropertyRange { range, .. } => vec![range],
+        Axiom::ClassAssertion { class, .. } => vec![class],
+        Axiom::SubObjectPropertyOf { .. } | Axiom::ObjectPropertyAssertion { .. } => Vec::new(),
+    }
+}
+
+/// First divergence-implicated construct inside a class expression, if any.
+fn implicated_construct(ce: &ClassExpression) -> Option<String> {
+    match ce {
+        ClassExpression::Class(_) | ClassExpression::Thing | ClassExpression::Nothing => None,
+        ClassExpression::ObjectComplementOf(_) => Some(
+            "owl:complementOf (implicated by DOCUMENTED_DIVERGENCES DisjointClasses-001/-003, \
+             New-Feature-ObjectQCR-002)"
+                .to_string(),
+        ),
+        ClassExpression::ObjectUnionOf(_) => Some(
+            "owl:unionOf (implicated by DOCUMENTED_DIVERGENCES WebOnt-I5.5-005)".to_string(),
+        ),
+        ClassExpression::ObjectIntersectionOf(members) => {
+            members.iter().find_map(implicated_construct)
+        }
+        ClassExpression::ObjectSomeValuesFrom(_, filler)
+        | ClassExpression::ObjectAllValuesFrom(_, filler) => implicated_construct(filler),
+    }
+}
+
+// -------------------------------------------------------------------------------------------
+// EL branch
+// -------------------------------------------------------------------------------------------
+
+/// The EL branch (module docs §"EL branch soundness").
+fn el_branch(dict: &Dict, triples: &[[Id; 3]], onto: &Ontology) -> ConsistencyOutcome {
+    let out = |verdict| ConsistencyOutcome {
+        verdict,
+        branch: Branch::ElClassification,
+    };
+    let report = Classifier::classify(dict, triples).report();
+    if report.skipped_axioms > 0 {
+        return out(ConsistencyVerdict::Unknown(UnknownReason::ElSkippedAxioms(
+            report.skipped_axioms,
+        )));
+    }
+    if let Some(kind) = el_unapplied_kind(onto) {
+        return out(ConsistencyVerdict::Unknown(
+            UnknownReason::ElUnappliedAxioms(kind),
+        ));
+    }
+    if onto
+        .axioms()
+        .iter()
+        .any(|axiom| axiom_ces(axiom).into_iter().any(ce_mentions_thing))
+    {
+        return out(ConsistencyVerdict::Unknown(UnknownReason::ElTopGuard));
+    }
+    // Pure ⊤-free EL+⊥ TBox: consistent by the empty-interpretation model construction
+    // (module docs). The classifier run above contributed the skipped-axioms honesty gate.
+    out(ConsistencyVerdict::Consistent)
+}
+
+/// The first axiom kind the EL classifier neither applies nor counts, if any.
+fn el_unapplied_kind(onto: &Ontology) -> Option<String> {
+    onto.axioms().iter().find_map(|axiom| match axiom {
+        Axiom::SubClassOf { .. }
+        | Axiom::EquivalentClasses(_, _)
+        | Axiom::DisjointClasses(_, _) => None,
+        Axiom::SubObjectPropertyOf { .. } => Some("SubObjectPropertyOf".to_string()),
+        Axiom::ObjectPropertyDomain { .. } => Some("ObjectPropertyDomain".to_string()),
+        Axiom::ObjectPropertyRange { .. } => Some("ObjectPropertyRange".to_string()),
+        Axiom::ClassAssertion { .. } => Some("ClassAssertion".to_string()),
+        Axiom::ObjectPropertyAssertion { .. } => Some("ObjectPropertyAssertion".to_string()),
+    })
+}
+
+/// Whether a class expression mentions `owl:Thing` anywhere.
+fn ce_mentions_thing(ce: &ClassExpression) -> bool {
+    match ce {
+        ClassExpression::Thing => true,
+        ClassExpression::Class(_) | ClassExpression::Nothing => false,
+        ClassExpression::ObjectIntersectionOf(members)
+        | ClassExpression::ObjectUnionOf(members) => members.iter().any(ce_mentions_thing),
+        ClassExpression::ObjectComplementOf(inner) => ce_mentions_thing(inner),
+        ClassExpression::ObjectSomeValuesFrom(_, filler)
+        | ClassExpression::ObjectAllValuesFrom(_, filler) => ce_mentions_thing(filler),
+    }
+}
+
+// -------------------------------------------------------------------------------------------
+// ALCH branch
+// -------------------------------------------------------------------------------------------
+
+/// Map a tableau verdict into the dispatch verdict (the ALCH branch is complete for the
+/// whole L1 fragment, so both definitive verdicts pass through).
+fn tableau_consistency(onto: &Ontology, budget: Budget) -> ConsistencyVerdict {
+    match tableau::consistency(onto, budget) {
+        tableau::Verdict::Satisfiable => ConsistencyVerdict::Consistent,
+        tableau::Verdict::Unsatisfiable => ConsistencyVerdict::Inconsistent,
+        tableau::Verdict::Unknown(tableau::UnknownReason::ResourceBudget(b)) => {
+            ConsistencyVerdict::Unknown(UnknownReason::ResourceBudget(b))
+        }
+        tableau::Verdict::Unknown(tableau::UnknownReason::OutOfFragment(m)) => {
+            // Unreachable in practice: the ontology was already extracted. Fail-closed.
+            ConsistencyVerdict::Unknown(UnknownReason::OutOfFragment(m))
+        }
+    }
+}
+
+// -------------------------------------------------------------------------------------------
+// Refutation encodings
+// -------------------------------------------------------------------------------------------
+
+/// Fresh-name minting for the refutation encodings: `urn:` IRIs interned into the dict and
+/// checked against every id occurring in the premise/conclusion models, so the freshness
+/// premise of the module-doc arguments holds by construction.
+struct FreshNames<'d> {
+    dict: &'d mut Dict,
+    used: FxHashSet<Id>,
+    counter: usize,
+}
+
+impl<'d> FreshNames<'d> {
+    fn new(dict: &'d mut Dict, ontologies: [&Ontology; 2]) -> FreshNames<'d> {
+        let mut used = FxHashSet::default();
+        for onto in ontologies {
+            collect_ids(onto, &mut used);
+        }
+        FreshNames {
+            dict,
+            used,
+            counter: 0,
+        }
+    }
+
+    /// Mint an id occurring in neither input model.
+    fn mint(&mut self) -> Id {
+        loop {
+            let iri = format!("urn:sparq-reason-dl:check:fresh:{}", self.counter);
+            self.counter += 1;
+            let id = self.dict.intern_iri(&iri);
+            if self.used.insert(id) {
+                return id;
+            }
+        }
+    }
+}
+
+/// Every id (class, property, individual) occurring in the model.
+fn collect_ids(onto: &Ontology, into: &mut FxHashSet<Id>) {
+    let mut ces: Vec<&ClassExpression> = Vec::new();
+    for axiom in onto.axioms() {
+        ces.extend(axiom_ces(axiom));
+        match axiom {
+            Axiom::SubObjectPropertyOf { sub, sup } => {
+                into.extend([sub.named(), sup.named()]);
+            }
+            Axiom::ObjectPropertyDomain { property, .. }
+            | Axiom::ObjectPropertyRange { property, .. } => {
+                into.insert(property.named());
+            }
+            Axiom::ClassAssertion { individual, .. } => {
+                into.insert(*individual);
+            }
+            Axiom::ObjectPropertyAssertion {
+                property,
+                source,
+                target,
+            } => {
+                into.extend([property.named(), *source, *target]);
+            }
+            Axiom::SubClassOf { .. }
+            | Axiom::EquivalentClasses(_, _)
+            | Axiom::DisjointClasses(_, _) => {}
+        }
+    }
+    while let Some(ce) = ces.pop() {
+        match ce {
+            ClassExpression::Class(id) => {
+                into.insert(*id);
+            }
+            ClassExpression::Thing | ClassExpression::Nothing => {}
+            ClassExpression::ObjectIntersectionOf(members)
+            | ClassExpression::ObjectUnionOf(members) => ces.extend(members),
+            ClassExpression::ObjectComplementOf(inner) => ces.push(inner),
+            ClassExpression::ObjectSomeValuesFrom(p, filler)
+            | ClassExpression::ObjectAllValuesFrom(p, filler) => {
+                into.insert(p.named());
+                ces.push(filler);
+            }
+        }
+    }
+}
+
+/// The refutation check(s) for one conclusion axiom (module docs): each inner `Vec<Axiom>`
+/// is one set of additions whose UNSATISFIABILITY (together with the premise) certifies
+/// one component of the axiom; the axiom is entailed iff EVERY component's union is
+/// unsatisfiable. `None` = no argued encoding for this axiom kind.
+fn refutation_checks(conclusion: &Axiom, fresh: &mut FreshNames) -> Option<Vec<Vec<Axiom>>> {
+    let gci = |sub: &ClassExpression, sup: &ClassExpression, fresh: &mut FreshNames| {
+        vec![Axiom::ClassAssertion {
+            class: ClassExpression::ObjectIntersectionOf(vec![
+                sub.clone(),
+                ClassExpression::ObjectComplementOf(Box::new(sup.clone())),
+            ]),
+            individual: fresh.mint(),
+        }]
+    };
+    match conclusion {
+        Axiom::SubClassOf { sub, sup } => Some(vec![gci(sub, sup, fresh)]),
+        Axiom::EquivalentClasses(l, r) => Some(vec![gci(l, r, fresh), gci(r, l, fresh)]),
+        // DisjointClasses(C, D) ≡ C ⊓ D ⊑ ⊥ (record §3): refute with a fresh instance of
+        // the intersection.
+        Axiom::DisjointClasses(l, r) => Some(vec![vec![Axiom::ClassAssertion {
+            class: ClassExpression::ObjectIntersectionOf(vec![l.clone(), r.clone()]),
+            individual: fresh.mint(),
+        }]]),
+        // Domain/Range desugar to GCIs (record §3): ∃R.⊤ ⊑ C and ⊤ ⊑ ∀R.C.
+        Axiom::ObjectPropertyDomain { property, domain } => {
+            let some_top = ClassExpression::some(property.named(), ClassExpression::Thing);
+            Some(vec![gci(&some_top, domain, fresh)])
+        }
+        Axiom::ObjectPropertyRange { property, range } => {
+            let all_range = ClassExpression::only(property.named(), range.clone());
+            Some(vec![gci(&ClassExpression::Thing, &all_range, fresh)])
+        }
+        Axiom::ClassAssertion { class, individual } => Some(vec![vec![Axiom::ClassAssertion {
+            class: ClassExpression::ObjectComplementOf(Box::new(class.clone())),
+            individual: *individual,
+        }]]),
+        // The fresh-class trick (module docs; sound AND complete).
+        Axiom::ObjectPropertyAssertion {
+            property,
+            source,
+            target,
+        } => {
+            let b = fresh.mint();
+            Some(vec![vec![
+                Axiom::ClassAssertion {
+                    class: ClassExpression::Class(b),
+                    individual: *target,
+                },
+                Axiom::ClassAssertion {
+                    class: ClassExpression::only(
+                        property.named(),
+                        ClassExpression::ObjectComplementOf(Box::new(ClassExpression::Class(b))),
+                    ),
+                    individual: *source,
+                },
+            ]])
+        }
+        // Property-axiom conclusions are deferred by the record (§4): no encoding here.
+        Axiom::SubObjectPropertyOf { .. } => None,
+    }
+}

--- a/crates/sparq-reason-dl/src/check.rs
+++ b/crates/sparq-reason-dl/src/check.rs
@@ -244,8 +244,10 @@ pub struct ConsistencyOutcome {
 pub struct EntailmentOutcome {
     /// The tri-state verdict.
     pub verdict: EntailmentVerdict,
-    /// The branch that owned the decision ([`Branch::AlchTableau`] for every refutation
-    /// that ran; [`Branch::Extraction`] when an input graph was refused).
+    /// The branch that owned the decision — an ATTRIBUTION, not a claim that a tableau
+    /// ran: [`Branch::AlchTableau`] covers both executed refutations and pre-tableau
+    /// abstentions (e.g. `UnencodedConclusion`, where the verdict is `Unknown` and no
+    /// refutation was attempted); [`Branch::Extraction`] when an input graph was refused.
     pub branch: Branch,
 }
 

--- a/crates/sparq-reason-dl/src/lib.rs
+++ b/crates/sparq-reason-dl/src/lib.rs
@@ -9,22 +9,29 @@
 //! IN FULL, or refuses it with a typed [`ExtractError`].
 //!
 //! The load-bearing entry point is [`extract()`] (`(Dict, &[[Id; 3]])` → [`Ontology`] |
-//! [`ExtractError`]); the typed model lives in [`model`]. The stub modules `profile`, `nnf`,
-//! `tableau`, and `check` are RESERVED for the later layers (L2–L4) and carry no logic yet —
-//! see their module docs for the owning bead.
+//! [`ExtractError`]); the typed model lives in [`model`]. The later layers build on it:
+//! the L2 syntactic profile checker ([`profile`]), the L3 ALCH tableau ([`nnf`] /
+//! [`tableau`]), and — behind the OPT-IN `dispatch` cargo feature, which pulls the existing
+//! RL/EL profile reasoners as optional dependencies — the L4 fragment-dispatch
+//! Direct-Semantics checker + entailment-by-refutation (the `check` module's
+//! `DirectChecker`; code spans, not links, because the module is feature-gated).
 
 pub mod extract;
 pub mod model;
 
-// Stub modules pre-declared by L1 (design record §7) so L2/L3 populate `profile.rs` /
-// `nnf.rs` / `tableau.rs` and L4 populates `check.rs` WITHOUT editing this file. They contain
-// module documentation only — no logic.
-pub mod check;
 pub mod nnf;
 pub mod profile;
 pub mod tableau;
+
+// [FABLE-5] sq-pbz04.4.4 (L4): the fragment-dispatch checker, compiled ONLY under the
+// `dispatch` feature so the L1–L3 layers stay dependency-light (design record §6).
+#[cfg(feature = "dispatch")]
+pub mod check;
 
 #[doc(inline)]
 pub use extract::{extract, ExtractError};
 #[doc(inline)]
 pub use model::{Axiom, ClassExpression, ObjectPropertyExpression, Ontology};
+#[cfg(feature = "dispatch")]
+#[doc(inline)]
+pub use check::DirectChecker;

--- a/crates/sparq-reason-dl/tests/check.rs
+++ b/crates/sparq-reason-dl/tests/check.rs
@@ -1,0 +1,454 @@
+// [FABLE-5] sq-pbz04.4.4 (epic sq-pbz04.4) — integration tests for the L4 fragment-dispatch
+// Direct-Semantics checker + entailment-by-refutation (design record
+// research/owl2-direct-semantics-scoping.md §4).
+//
+// 🤖 SPARQ agent. Every test goes end-to-end through the REAL pipeline: Turtle → Dict →
+// fail-closed L1 extraction → L2 profile dispatch → the RL/EL/QL/ALCH branch under test.
+// The bead's three named acceptance cases are here: the divergence-guarded RL case
+// (`rl_divergence_guard_*`), the EL skipped-axioms case (`el_skipped_axioms_*`), and the
+// fresh-class refutation case (`entailment_role_assertion_*`). Verdicts are asserted as
+// exact enum variants (mutation-robust), and each public API item has a direct test.
+
+#![cfg(feature = "dispatch")]
+
+use sparq_core::dict::{Dict, Id};
+use sparq_core::Graph;
+use sparq_reason_dl::check::{
+    Branch, ConsistencyVerdict, DirectChecker, EntailmentVerdict, UnknownReason,
+};
+use sparq_reason_dl::tableau::Budget;
+
+const PRE: &str = r#"
+    @prefix : <http://ex/> .
+    @prefix owl: <http://www.w3.org/2002/07/owl#> .
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+"#;
+
+/// Parse one Turtle document.
+fn parse(body: &str) -> (Dict, Vec<[Id; 3]>) {
+    Graph::parse_to_triples(&format!("{}{}", PRE, body), "turtle").expect("parse")
+}
+
+/// Parse a premise and a conclusion document into ONE shared dict (the conclusion's ids are
+/// re-interned into the premise dict term-by-term). Conclusion documents in these tests are
+/// blank-node-free, so label re-interning cannot alias distinct blank nodes.
+fn parse_two(premise: &str, conclusion: &str) -> (Dict, Vec<[Id; 3]>, Vec<[Id; 3]>) {
+    let (mut dict, prem) = parse(premise);
+    let (cdict, ctriples) = parse(conclusion);
+    let concl = ctriples
+        .iter()
+        .map(|t| t.map(|id| dict.intern(&cdict.term(id))))
+        .collect();
+    (dict, prem, concl)
+}
+
+fn check(body: &str) -> (ConsistencyVerdict, Branch) {
+    let (mut dict, triples) = parse(body);
+    let out = DirectChecker::new().consistency(&mut dict, &triples);
+    (out.verdict, out.branch)
+}
+
+fn entail(premise: &str, conclusion: &str) -> (EntailmentVerdict, Branch) {
+    let (mut dict, prem, concl) = parse_two(premise, conclusion);
+    let out = DirectChecker::new().entailment(&mut dict, &prem, &concl);
+    (out.verdict, out.branch)
+}
+
+// -------------------------------------------------------------------------------------------
+// Constructor / helper API (direct coverage of every public item)
+// -------------------------------------------------------------------------------------------
+
+#[test]
+fn checker_constructors() {
+    assert_eq!(DirectChecker::new(), DirectChecker::default());
+    let pinned = Budget {
+        max_nodes: 7,
+        max_rule_applications: 9,
+    };
+    // with_budget produces a distinct checker (the budget is load-bearing state).
+    assert_ne!(DirectChecker::with_budget(pinned), DirectChecker::new());
+    assert_eq!(
+        DirectChecker::with_budget(Budget::default()),
+        DirectChecker::new()
+    );
+}
+
+#[test]
+fn consistency_verdict_helpers() {
+    assert!(ConsistencyVerdict::Consistent.is_consistent());
+    assert!(!ConsistencyVerdict::Consistent.is_inconsistent());
+    assert!(ConsistencyVerdict::Inconsistent.is_inconsistent());
+    assert!(!ConsistencyVerdict::Inconsistent.is_unknown());
+    let unknown = ConsistencyVerdict::Unknown(UnknownReason::QlConsistencyPending);
+    assert!(unknown.is_unknown());
+    assert!(!unknown.is_consistent());
+}
+
+#[test]
+fn entailment_verdict_helpers() {
+    assert!(EntailmentVerdict::Entailed.is_entailed());
+    assert!(!EntailmentVerdict::Entailed.is_not_entailed());
+    assert!(EntailmentVerdict::NotEntailed.is_not_entailed());
+    assert!(!EntailmentVerdict::NotEntailed.is_unknown());
+    let unknown = EntailmentVerdict::Unknown(UnknownReason::ElTopGuard);
+    assert!(unknown.is_unknown());
+    assert!(!unknown.is_entailed());
+}
+
+// -------------------------------------------------------------------------------------------
+// RL branch
+// -------------------------------------------------------------------------------------------
+
+#[test]
+fn rl_consistent_past_clean_guard() {
+    // Plain Horn subclass + assertion: in RL, no divergence-implicated construct, no
+    // punning, no clash — the ONE shape where the RL branch may say Consistent.
+    let (verdict, branch) = check(":A rdfs:subClassOf :B . :x a :A .");
+    assert_eq!(verdict, ConsistencyVerdict::Consistent);
+    assert_eq!(branch, Branch::RlMaterialization);
+}
+
+#[test]
+fn rl_inconsistent_via_materialized_clash() {
+    // x ∈ A ⊑ ⊥: the RL closure types x into owl:Nothing (cax-sco + cls-nothing) — an
+    // Inconsistent verdict sound via checked-PR1.
+    let (verdict, branch) = check(":A rdfs:subClassOf owl:Nothing . :x a :A .");
+    assert_eq!(verdict, ConsistencyVerdict::Inconsistent);
+    assert_eq!(branch, Branch::RlMaterialization);
+}
+
+#[test]
+fn rl_divergence_guard_disjointness_blocks_consistent() {
+    // BEAD ACCEPTANCE CASE: in-RL, clash-free, but touching owl:disjointWith — a construct
+    // implicated in DOCUMENTED_DIVERGENCES — so "no clash" must NOT read as Consistent.
+    let (verdict, branch) = check(":A owl:disjointWith :B . :x a :A .");
+    assert!(
+        matches!(
+            verdict,
+            ConsistencyVerdict::Unknown(UnknownReason::RlDivergenceGuard(_))
+        ),
+        "expected RlDivergenceGuard, got {:?}",
+        verdict
+    );
+    assert_eq!(branch, Branch::RlMaterialization);
+}
+
+#[test]
+fn rl_divergence_guard_complement_and_union() {
+    // complementOf (RL super-CE position) and unionOf (RL sub-CE position) each trip the
+    // guard on a clash-free in-RL ontology.
+    let (v1, b1) = check(":A rdfs:subClassOf [ owl:complementOf :B ] . :x a :A .");
+    assert!(
+        matches!(
+            v1,
+            ConsistencyVerdict::Unknown(UnknownReason::RlDivergenceGuard(_))
+        ),
+        "complementOf: expected RlDivergenceGuard, got {:?}",
+        v1
+    );
+    assert_eq!(b1, Branch::RlMaterialization);
+    let (v2, _) = check("[ owl:unionOf (:A :B) ] rdfs:subClassOf :C .");
+    assert!(
+        matches!(
+            v2,
+            ConsistencyVerdict::Unknown(UnknownReason::RlDivergenceGuard(_))
+        ),
+        "unionOf: expected RlDivergenceGuard, got {:?}",
+        v2
+    );
+}
+
+#[test]
+fn rl_divergence_guard_does_not_mask_inconsistency() {
+    // Inconsistent stays sound EVEN with a guarded construct present: the guard narrows
+    // Consistent only.
+    let (verdict, branch) = check(":A owl:disjointWith :B . :x a :A . :x a :B .");
+    assert_eq!(verdict, ConsistencyVerdict::Inconsistent);
+    assert_eq!(branch, Branch::RlMaterialization);
+}
+
+#[test]
+fn rl_pr1_punning_abstains() {
+    // :A is used both as a class (:x a :A) and as an individual (:A a :B) — usage-level
+    // punning violates the Theorem PR1 preconditions, so BOTH verdicts are withheld.
+    let (verdict, branch) = check(":x a :A . :A a :B .");
+    assert!(
+        matches!(
+            verdict,
+            ConsistencyVerdict::Unknown(UnknownReason::RlPr1Preconditions(_))
+        ),
+        "expected RlPr1Preconditions, got {:?}",
+        verdict
+    );
+    assert_eq!(branch, Branch::RlMaterialization);
+}
+
+// -------------------------------------------------------------------------------------------
+// EL branch
+// -------------------------------------------------------------------------------------------
+
+/// An EL ontology (∃-chain on the super side keeps it OUT of RL) nested deeper than the EL
+/// classifier's decode depth, so the classifier reports a skipped axiom.
+fn deep_el_body(depth: usize) -> String {
+    let mut body = String::from(":A rdfs:subClassOf ");
+    for _ in 0..depth {
+        body.push_str("[ owl:onProperty :r ; owl:someValuesFrom ");
+    }
+    body.push_str(":B ");
+    for _ in 0..depth {
+        body.push_str("] ");
+    }
+    body.push('.');
+    body
+}
+
+#[test]
+fn el_skipped_axioms_abstains() {
+    // BEAD ACCEPTANCE CASE: in-EL (L1 extracts it — nesting is under L1's 512 cap), but
+    // the EL classifier skips the axiom (over its 256 decode depth): a skipped axiom could
+    // BE the inconsistency, so the branch abstains rather than trusting the lattice.
+    let (verdict, branch) = check(&deep_el_body(300));
+    assert!(
+        matches!(
+            verdict,
+            ConsistencyVerdict::Unknown(UnknownReason::ElSkippedAxioms(n)) if n >= 1
+        ),
+        "expected ElSkippedAxioms(>=1), got {:?}",
+        verdict
+    );
+    assert_eq!(branch, Branch::ElClassification);
+}
+
+#[test]
+fn el_unapplied_abox_abstains() {
+    // In-EL with an ABox: the TBox classifier neither applies nor counts assertions, so a
+    // Consistent verdict would be unfounded — abstain with the unapplied-kind reason.
+    let (verdict, branch) =
+        check(":A rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] . :x a :A .");
+    assert!(
+        matches!(
+            verdict,
+            ConsistencyVerdict::Unknown(UnknownReason::ElUnappliedAxioms(_))
+        ),
+        "expected ElUnappliedAxioms, got {:?}",
+        verdict
+    );
+    assert_eq!(branch, Branch::ElClassification);
+}
+
+#[test]
+fn el_top_guard_never_calls_thing_bottom_consistent() {
+    // SOUNDNESS PIN: `owl:Thing ⊑ owl:Nothing` is INCONSISTENT under the Direct Semantics
+    // (domains are non-empty), but the EL classifier does not track ⊤'s satisfiability
+    // (its unsatisfiable-class list stays empty here). The ⊤ guard must abstain — a
+    // Consistent verdict would be UNSOUND.
+    let (verdict, branch) = check("owl:Thing rdfs:subClassOf owl:Nothing .");
+    assert_eq!(
+        verdict,
+        ConsistencyVerdict::Unknown(UnknownReason::ElTopGuard)
+    );
+    assert_eq!(branch, Branch::ElClassification);
+}
+
+#[test]
+fn el_consistent_for_top_free_tbox() {
+    // Pure ⊤-free EL+⊥ TBox (super-∃ keeps it out of RL): Consistent by the
+    // empty-interpretation model construction — the one shape the EL branch certifies.
+    let (verdict, branch) = check(
+        ":A rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] . \
+         :B rdfs:subClassOf :C .",
+    );
+    assert_eq!(verdict, ConsistencyVerdict::Consistent);
+    assert_eq!(branch, Branch::ElClassification);
+}
+
+// -------------------------------------------------------------------------------------------
+// QL + ALCH branches, extraction, budget
+// -------------------------------------------------------------------------------------------
+
+#[test]
+fn ql_always_pending() {
+    // In QL (super-∃ with a named filler kills RL; the complement kills EL), so the QL
+    // branch owns it — and QL consistency is wholly deferred (sq-pbz04.3.4), never decided
+    // here.
+    let (verdict, branch) = check(
+        ":A rdfs:subClassOf [ owl:onProperty :r ; owl:someValuesFrom :B ] . \
+         :C rdfs:subClassOf [ owl:complementOf :D ] .",
+    );
+    assert_eq!(
+        verdict,
+        ConsistencyVerdict::Unknown(UnknownReason::QlConsistencyPending)
+    );
+    assert_eq!(branch, Branch::QlDeferred);
+}
+
+#[test]
+fn alch_branch_consistent_and_inconsistent() {
+    // ¬A ⊑ B is in NO profile (complement in sub position) — the tableau owns it and is
+    // complete for the fragment, so BOTH definitive verdicts flow through.
+    let (v1, b1) = check("[ owl:complementOf :A ] rdfs:subClassOf :B .");
+    assert_eq!(v1, ConsistencyVerdict::Consistent);
+    assert_eq!(b1, Branch::AlchTableau);
+    // A ≡ ¬A has no model (also profile-free: complement as an equivalence operand).
+    let (v2, b2) = check(":A owl:equivalentClass [ owl:complementOf :A ] .");
+    assert_eq!(v2, ConsistencyVerdict::Inconsistent);
+    assert_eq!(b2, Branch::AlchTableau);
+}
+
+#[test]
+fn alch_budget_exhaustion_abstains() {
+    let (mut dict, triples) = parse("[ owl:complementOf :A ] rdfs:subClassOf :B .");
+    let starved = DirectChecker::with_budget(Budget {
+        max_nodes: 1,
+        max_rule_applications: 0,
+    });
+    let out = starved.consistency(&mut dict, &triples);
+    assert!(
+        matches!(
+            out.verdict,
+            ConsistencyVerdict::Unknown(UnknownReason::ResourceBudget(_))
+        ),
+        "expected ResourceBudget, got {:?}",
+        out.verdict
+    );
+    assert_eq!(out.branch, Branch::AlchTableau);
+}
+
+#[test]
+fn extraction_failure_fails_closed() {
+    // owl:inverseOf is outside the L1 fragment: refused BEFORE any branch runs.
+    let (verdict, branch) = check(":p owl:inverseOf :q .");
+    assert!(
+        matches!(
+            verdict,
+            ConsistencyVerdict::Unknown(UnknownReason::OutOfFragment(_))
+        ),
+        "expected OutOfFragment, got {:?}",
+        verdict
+    );
+    assert_eq!(branch, Branch::Extraction);
+}
+
+// -------------------------------------------------------------------------------------------
+// Entailment by refutation
+// -------------------------------------------------------------------------------------------
+
+#[test]
+fn entailment_subclass_transitivity() {
+    let premise = ":A rdfs:subClassOf :B . :B rdfs:subClassOf :C .";
+    let (v, b) = entail(premise, ":A rdfs:subClassOf :C .");
+    assert_eq!(v, EntailmentVerdict::Entailed);
+    assert_eq!(b, Branch::AlchTableau);
+    // The converse is NOT entailed — certified by the complete tableau (a definitive
+    // NegativeEntailment-style verdict, sound per the record's complete-branch rule).
+    let (v, b) = entail(premise, ":C rdfs:subClassOf :A .");
+    assert_eq!(v, EntailmentVerdict::NotEntailed);
+    assert_eq!(b, Branch::AlchTableau);
+}
+
+#[test]
+fn entailment_class_assertion() {
+    let premise = ":x a :A . :A rdfs:subClassOf :B .";
+    let (v, _) = entail(premise, ":x a :B .");
+    assert_eq!(v, EntailmentVerdict::Entailed);
+    let (v, _) = entail(premise, ":y a :B .");
+    assert_eq!(v, EntailmentVerdict::NotEntailed);
+}
+
+#[test]
+fn entailment_role_assertion_fresh_class_trick() {
+    // BEAD ACCEPTANCE CASE: ObjectPropertyAssertion via the fresh-class encoding
+    // {B(b), (∀R.¬B)(a)} — r ⊑ s and r(x,y) entail s(x,y); the ∀ on the SUPER-role must
+    // reach the sub-role edge (the L3 hierarchy machinery) to close the refutation.
+    let premise = ":r a owl:ObjectProperty . :s a owl:ObjectProperty . \
+                   :r rdfs:subPropertyOf :s . :x :r :y .";
+    let conclusion = ":s a owl:ObjectProperty . :x :s :y .";
+    let (v, b) = entail(premise, conclusion);
+    assert_eq!(v, EntailmentVerdict::Entailed);
+    assert_eq!(b, Branch::AlchTableau);
+    // Completeness half: the REVERSED assertion is not entailed, and the fresh-class
+    // encoding must certify that (a model interpreting the fresh class as {target} exists).
+    let (v, _) = entail(premise, ":s a owl:ObjectProperty . :y :s :x .");
+    assert_eq!(v, EntailmentVerdict::NotEntailed);
+}
+
+#[test]
+fn entailment_equivalence_needs_both_inclusions() {
+    let (v, _) = entail(
+        ":A rdfs:subClassOf :B . :B rdfs:subClassOf :A .",
+        ":A owl:equivalentClass :B .",
+    );
+    assert_eq!(v, EntailmentVerdict::Entailed);
+    // One inclusion alone does not entail the equivalence: the second refutation
+    // component is satisfiable.
+    let (v, _) = entail(":A rdfs:subClassOf :B .", ":A owl:equivalentClass :B .");
+    assert_eq!(v, EntailmentVerdict::NotEntailed);
+}
+
+#[test]
+fn entailment_disjointness_domain_range_desugarings() {
+    // DisjointClasses via A ⊑ ¬B.
+    let (v, _) = entail(
+        ":A rdfs:subClassOf [ owl:complementOf :B ] .",
+        ":A owl:disjointWith :B .",
+    );
+    assert_eq!(v, EntailmentVerdict::Entailed);
+    // Domain widens along subclassing (∃r.⊤ ⊑ A ⊑ B).
+    let (v, _) = entail(
+        ":r a owl:ObjectProperty . :r rdfs:domain :A . :A rdfs:subClassOf :B .",
+        ":r a owl:ObjectProperty . :r rdfs:domain :B .",
+    );
+    assert_eq!(v, EntailmentVerdict::Entailed);
+    // Range widens along subclassing (⊤ ⊑ ∀r.A, A ⊑ B).
+    let (v, _) = entail(
+        ":r a owl:ObjectProperty . :r rdfs:range :A . :A rdfs:subClassOf :B .",
+        ":r a owl:ObjectProperty . :r rdfs:range :B .",
+    );
+    assert_eq!(v, EntailmentVerdict::Entailed);
+}
+
+#[test]
+fn entailment_unencoded_conclusion_kind_abstains() {
+    // Property-axiom conclusions are deferred by the design record: no encoding, no guess.
+    let (v, b) = entail(
+        ":r a owl:ObjectProperty . :s a owl:ObjectProperty . :r rdfs:subPropertyOf :s .",
+        ":r a owl:ObjectProperty . :s a owl:ObjectProperty . :r rdfs:subPropertyOf :s .",
+    );
+    assert!(
+        matches!(
+            v,
+            EntailmentVerdict::Unknown(UnknownReason::UnencodedConclusion(_))
+        ),
+        "expected UnencodedConclusion, got {:?}",
+        v
+    );
+    assert_eq!(b, Branch::AlchTableau);
+}
+
+#[test]
+fn entailment_out_of_fragment_inputs_fail_closed() {
+    // Premise outside the fragment.
+    let (v, b) = entail(":p owl:inverseOf :q .", ":A rdfs:subClassOf :B .");
+    assert!(
+        matches!(v, EntailmentVerdict::Unknown(UnknownReason::OutOfFragment(_))),
+        "premise: expected OutOfFragment, got {:?}",
+        v
+    );
+    assert_eq!(b, Branch::Extraction);
+    // Conclusion outside the fragment.
+    let (v, b) = entail(":A rdfs:subClassOf :B .", ":p owl:inverseOf :q .");
+    assert!(
+        matches!(v, EntailmentVerdict::Unknown(UnknownReason::OutOfFragment(_))),
+        "conclusion: expected OutOfFragment, got {:?}",
+        v
+    );
+    assert_eq!(b, Branch::Extraction);
+}
+
+#[test]
+fn entailment_empty_conclusion_is_trivially_entailed() {
+    let (v, b) = entail(":A rdfs:subClassOf :B .", "");
+    assert_eq!(v, EntailmentVerdict::Entailed);
+    assert_eq!(b, Branch::AlchTableau);
+}


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Fable 5) — bead **sq-pbz04.4.4** (epic sq-pbz04.4). Spec: `research/owl2-direct-semantics-scoping.md` §4. Do NOT arm — an independent adversarial verify follows.

## What this adds

New **opt-in `dispatch` cargo feature** on `sparq-reason-dl` (OFF by default; pulls `sparq-reason` + `sparq-reason-el` as optional deps — L1–L3 stay dependency-light, core untouched):

- **`check::DirectChecker::consistency`** — fragment dispatch RL → EL → QL → ALCH over the fail-closed L1 extraction + L2 profile verdicts. Every verdict carries its producing `Branch` (traceability invariant); every guard fails closed.
- **`check::DirectChecker::entailment`** — per-conclusion-axiom entailment-by-refutation on the L3 ALCH tableau, with the record's sound encodings.

## Honest per-branch soundness/completeness scoping

| Branch | `Consistent` | `Inconsistent` | Abstentions |
|---|---|---|---|
| **RL** (`materialize(OwlRl)` + `inconsistencies()`) | only past the **divergence guard** (abstains on `owl:disjointWith` / `owl:complementOf` / `owl:unionOf` — the DOCUMENTED_DIVERGENCES-implicated constructs reachable through the L1∩RL funnel; the other ten entries' constructs are already refused by L1) | sound via **Theorem PR1 with CHECKED preconditions**: a usage-level punning scan over the model (punning → abstain BOTH verdicts); the no-annotation-axiom precondition is structural (L1 has no annotation-axiom shape and fail-closes on unknown typings) | `RlPr1Preconditions`, `RlDivergenceGuard` |
| **EL** (`Classifier::classify`) | only for a **pure ⊤-free EL+⊥ TBox** with `skipped_axioms == 0`; then sound by a direct empty-interpretation model construction (in module docs) | **never** — see the ⊤ guard below | `ElSkippedAxioms` (per the record), `ElUnappliedAxioms` (ABox / `subPropertyOf` / domain / range — the classifier neither applies nor counts these), `ElTopGuard` |
| **QL** | never | never | always `QlConsistencyPending` — DL-Lite_R consistency belongs to sq-pbz04.3.4, not duplicated |
| **ALCH** (L3 tableau) | complete for the L1 fragment | complete for the L1 fragment | `ResourceBudget` (deterministic counts) |
| Extraction failure | — | — | `OutOfFragment`, before any reasoning |

**Empirically-found soundness hazard, guarded:** the EL classifier does NOT track ⊤'s satisfiability — `owl:Thing rdfs:subClassOf owl:Nothing` (inconsistent under Direct Semantics) yields an EMPTY unsatisfiable-class list and `skipped_axioms == 0`. A record-literal "skipped==0 ⇒ verdicts" reading would therefore have emitted an UNSOUND `Consistent`. The implementation adds two extra fail-closed guards beyond the record's skipped-axioms guard (`ElUnappliedAxioms`, `ElTopGuard`) and a test pins the ⊤⊑⊥ case (`el_top_guard_never_calls_thing_bottom_consistent`).

## Entailment encodings (all decided on the complete-for-fragment tableau)

`SubClassOf` via fresh individual of `C ⊓ ¬D`; `ClassAssertion` via `¬C(a)`; `ObjectPropertyAssertion` via the fresh-class trick `{B(b), (∀R.¬B)(a)}` (the §4 sound-AND-complete argument re-verified against this implementation — the converse model extension `Bᴵ = {bᴵ}` is written out in the module docs); `EquivalentClasses`/`DisjointClasses`/`Domain`/`Range` via the record §3 exact desugarings composed with the GCI encoding; `SubObjectPropertyOf` → `Unknown(UnencodedConclusion)` per the record's property-axiom deferral. `NotEntailed` only from a definitively-satisfiable refutation (complete branch), matching the record's negative-entailment rule.

## Spec deviations (each documented in module docs)

1. **EL branch is narrower than a literal record reading** — the two extra guards above; required for soundness (the binding invariant "all guards fail-closed / never claim completeness beyond the argued fragment" wins over the branch sketch).
2. **Refutation checks route to the ALCH tableau only** (not per-profile RL/EL routes): the tableau is sound + complete for the ENTIRE L1 fragment, which contains every extractable premise and every encoding, so this loses no verdicts (only potential budget robustness — noted as future work).
3. **`Classifier::classify` instead of `classify_graph`** — same computation (`classify_graph` is documented as a wrapper over it); `classify` needs no triple-vector clone and exposes the `Report` directly.
4. Cargo.toml `description` refreshed (it still said "no reasoning yet", stale since L3 landed) — one line, honesty fix.

## Gates (all run in-worktree)

- `cargo build -p sparq-reason-dl` + `--features dispatch` — green
- `cargo clippy -p sparq-reason-dl --all-targets -- -D warnings` — green in BOTH states (default / `--features dispatch`)
- `cargo test -p sparq-reason-dl` — green in BOTH states; `--features dispatch --test check` = **25/25**, including the bead's three named acceptance cases (divergence-guarded RL, EL skipped-axioms via a >256-deep in-EL nesting that L1 accepts but the EL classifier skips, fresh-class refutation both directions)
- Mutation spot-check: disabling the divergence guard makes both guard tests FAIL (non-vacuous)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — green (feature-gated items referenced via code spans from always-compiled docs)
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations; README 113 lines (≤120)

## Deferred work (for beading — `bd` not available in the worktree)

- Tableau fallback for guard-abstained RL/EL/QL consistency inputs (every extracted ontology is in ALCH; would upgrade many `Unknown`s soundly).
- `SubObjectPropertyOf` conclusion encoding (`{R(a,b)_fresh, B(b), (∀S.¬B)(a)}` sketch looks sound+complete but needs a record §4 amendment first).
- Upstream `sparq-reason-el`: track ⊤'s unsatisfiability in `unsatisfiable_classes` (would let the EL branch return sound `Inconsistent`).
- RL/EL routing for refutation checks (budget robustness only).

`skills/inference/SKILL.md` is deliberately NOT touched — bead sq-pbz04.4.6 owns it (cross-epic contention).