### PR TITLE
ci(scripts): feature-matrix tier detector — mechanized sq-vya1 guard (sq-6g9kr) [SONNET-4.6]

### DIFF
--- a/scripts/feature-matrix-tiers.py
+++ b/scripts/feature-matrix-tiers.py
@@ -1,0 +1,947 @@
+#!/usr/bin/env python3
+# [SONNET-4.6] Feature-matrix tier detector + sq-vya1 guard (bead sq-6g9kr).
+# Design: research/feature-matrix-pyramid.md §4.
+#
+# Classifies each opt-in feature-matrix leg as sensitive (tier: test) or
+# non-sensitive (a check-tier demotion candidate), and enforces the sq-vya1
+# GUARD that every sensitive feature appears in some test:true leg.
+#
+# CORE INVARIANT (fail-closed, §4 "any parse/IO/grep error"):
+#   Any parse/IO/grep error classifies the leg SENSITIVE. A detector bug
+#   degrades to "keep the full leg", never to a silent demotion.
+#
+# Sensitivity criteria for a feature F in crate C:
+#   (a) cfg(feature = "F") / cfg_attr form appears in tests/ or benches/ files
+#   (b) cfg expression combining `test` and feature = "F" in src/ (e.g.,
+#       cfg(all(test, feature = "F")))
+#   (c) cfg(not(feature = "F")) or F under any not() anywhere in the crate
+#   Any of (a/b/c) => SENSITIVE. Nested any()/all() are recursively parsed;
+#   an expression the parser cannot handle => SENSITIVE (fail-closed).
+#
+# Usage:
+#   python3 scripts/feature-matrix-tiers.py --classify
+#       Print a classification table for all legs.
+#   python3 scripts/feature-matrix-tiers.py --enforce
+#       Exit non-zero if:
+#         (1) any leg carries tier: check AND detector says sensitive AND
+#             the fragment has no tier-reason: override; OR
+#         (2) any sensitive feature has no test:true leg (sq-vya1 guard)
+#   python3 scripts/feature-matrix-tiers.py --report-unlegged
+#       Advisory: features with no leg, against the SCOPE allowlist.
+#
+# Stdlib only (no new Python deps beyond stdlib). Runs under Python 3.10+.
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FRAGMENT_DIR = REPO_ROOT / ".github" / "feature-matrix.d"
+CRATES_DIR = REPO_ROOT / "crates"
+
+# Allowlist: features explicitly excluded from the unlegged completeness check.
+# These are known to have no per-PR leg by design (design record §4.3).
+SCOPE_ALLOWLIST: frozenset = frozenset(
+    {"zlib-ng", "hdt", "write", "live", "embeddings", "mimalloc"}
+)
+
+# Rust source file extensions we scan.
+_RUST_EXTENSIONS = frozenset({".rs"})
+
+# Source directories to scan (relative to crate root).
+_TEST_DIRS = ("tests", "benches")
+_SRC_DIRS = ("src", "bin", "examples")
+
+
+# ---------------------------------------------------------------------------
+# cfg expression AST
+# ---------------------------------------------------------------------------
+
+class ParseError(Exception):
+    """Raised when a cfg expression cannot be parsed. Triggers fail-closed."""
+
+
+class _CfgNode:
+    """Base class for cfg expression AST nodes."""
+    __slots__: tuple = ()
+
+
+class CfgFeature(_CfgNode):
+    """cfg(feature = "name")"""
+    __slots__ = ("name",)
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+class CfgTest(_CfgNode):
+    """cfg(test) — the bare `test` predicate."""
+    __slots__ = ()
+
+
+class CfgNot(_CfgNode):
+    """cfg(not(...))"""
+    __slots__ = ("inner",)
+
+    def __init__(self, inner: _CfgNode) -> None:
+        self.inner = inner
+
+
+class CfgAny(_CfgNode):
+    """cfg(any(...))"""
+    __slots__ = ("exprs",)
+
+    def __init__(self, exprs: List[_CfgNode]) -> None:
+        self.exprs = exprs
+
+
+class CfgAll(_CfgNode):
+    """cfg(all(...))"""
+    __slots__ = ("exprs",)
+
+    def __init__(self, exprs: List[_CfgNode]) -> None:
+        self.exprs = exprs
+
+
+class CfgOther(_CfgNode):
+    """Any other predicate (target_arch, etc.) that we do not need to interpret."""
+    __slots__ = ()
+
+
+# ---------------------------------------------------------------------------
+# cfg expression parser
+# ---------------------------------------------------------------------------
+
+def _extract_balanced_parens(s: str, start: int) -> Tuple[str, int]:
+    """Extract content of balanced parentheses at s[start] (which must be '(').
+
+    Returns (inner_content, end_index_exclusive).
+    Raises ParseError on unbalanced parentheses.
+    """
+    if start >= len(s) or s[start] != "(":
+        raise ParseError(
+            "expected '(' at pos {} in {!r}".format(start, s[:start + 20])
+        )
+    depth = 0
+    for i in range(start, len(s)):
+        c = s[i]
+        if c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return s[start + 1 : i], i + 1
+    raise ParseError(
+        "unbalanced parentheses starting at pos {} in {!r}...".format(
+            start, s[start : start + 40]
+        )
+    )
+
+
+def _split_cfg_args(s: str) -> List[str]:
+    """Split comma-separated cfg predicate list, respecting nested parentheses.
+
+    Raises ParseError on unbalanced parentheses.
+    """
+    items: List[str] = []
+    depth = 0
+    current: List[str] = []
+    for ch in s:
+        if ch == "(":
+            depth += 1
+            current.append(ch)
+        elif ch == ")":
+            depth -= 1
+            if depth < 0:
+                raise ParseError(
+                    "unbalanced ')' in cfg arg list: {!r}".format(s[:60])
+                )
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            item = "".join(current).strip()
+            if item:
+                items.append(item)
+            current = []
+        else:
+            current.append(ch)
+    tail = "".join(current).strip()
+    if tail:
+        items.append(tail)
+    return items
+
+
+def parse_cfg(s: str) -> _CfgNode:
+    """Parse a Rust cfg predicate string into an AST node.
+
+    Raises ParseError if the expression cannot be understood.
+    Callers treat ParseError as SENSITIVE (fail-closed).
+
+    Handles: feature = "...", test, not(...), any(...), all(...), and
+    any other bare or key = "value" predicate (CfgOther).
+    """
+    s = s.strip()
+    if not s:
+        raise ParseError("empty cfg expression")
+
+    # bare `test` predicate
+    if s == "test":
+        return CfgTest()
+
+    # feature = "name"
+    m = re.fullmatch(r'feature\s*=\s*"([^"]*)"', s)
+    if m:
+        return CfgFeature(m.group(1))
+
+    # function-form: not(...) / any(...) / all(...)
+    fn_match = re.match(r"^(not|any|all)\s*\(", s)
+    if fn_match:
+        fn_name = fn_match.group(1)
+        paren_pos = s.index("(", fn_match.start())
+        inner, end = _extract_balanced_parens(s, paren_pos)
+        remaining = s[end:].strip()
+        if remaining:
+            raise ParseError(
+                "unexpected content after {}(...): {!r}".format(fn_name, remaining)
+            )
+        items = _split_cfg_args(inner)
+        if fn_name == "not":
+            if len(items) != 1:
+                raise ParseError(
+                    "not() requires exactly 1 argument, got {} in {!r}".format(
+                        len(items), s
+                    )
+                )
+            return CfgNot(parse_cfg(items[0]))
+        # any / all
+        children = [parse_cfg(item) for item in items]
+        return CfgAny(children) if fn_name == "any" else CfgAll(children)
+
+    # Other simple predicate: bare ident or ident = "value"
+    if re.fullmatch(r'[a-zA-Z_][a-zA-Z0-9_\-]*(\s*=\s*"[^"]*")?', s):
+        return CfgOther()
+
+    raise ParseError("cannot parse cfg expression: {!r}".format(s[:80]))
+
+
+# ---------------------------------------------------------------------------
+# cfg tree queries
+# ---------------------------------------------------------------------------
+
+def _mentions_feature(node: _CfgNode, feature: str) -> bool:
+    """Return True if feature F appears anywhere in the cfg tree."""
+    if isinstance(node, CfgFeature):
+        return node.name == feature
+    if isinstance(node, CfgNot):
+        return _mentions_feature(node.inner, feature)
+    if isinstance(node, (CfgAny, CfgAll)):
+        return any(_mentions_feature(e, feature) for e in node.exprs)
+    return False
+
+
+def _feature_under_not(node: _CfgNode, feature: str, _in_not: bool = False) -> bool:
+    """Return True if feature F appears anywhere under a not() in the tree.
+
+    Handles nested combinators: cfg(not(any(x, feature = "F"))) returns True.
+    """
+    if isinstance(node, CfgFeature):
+        return _in_not and node.name == feature
+    if isinstance(node, CfgNot):
+        return _feature_under_not(node.inner, feature, _in_not=True)
+    if isinstance(node, (CfgAny, CfgAll)):
+        return any(_feature_under_not(e, feature, _in_not) for e in node.exprs)
+    return False
+
+
+def _has_test_predicate(node: _CfgNode) -> bool:
+    """Return True if the `test` predicate appears anywhere in the tree."""
+    if isinstance(node, CfgTest):
+        return True
+    if isinstance(node, CfgNot):
+        return _has_test_predicate(node.inner)
+    if isinstance(node, (CfgAny, CfgAll)):
+        return any(_has_test_predicate(e) for e in node.exprs)
+    return False
+
+
+def _feature_in_test_cfg(node: _CfgNode, feature: str) -> bool:
+    """Return True if the expression mentions both `test` and feature F.
+
+    Catches cfg(all(test, feature = "F")) and similar patterns that gate
+    test blocks in src/ files (class b-direct in the design record).
+    """
+    return _mentions_feature(node, feature) and _has_test_predicate(node)
+
+
+def _feature_adjacent_to_test_attr(content: str, feature: str) -> bool:
+    """Return True if #[cfg(feature = "F")] and #[test] appear adjacent in source.
+
+    Detects the b-direct pattern: a feature-gated #[test] function in src/ where
+    the two attributes are on consecutive (or nearly-consecutive) lines:
+
+        #[cfg(feature = "F")]
+        #[test]
+        fn my_test() { ... }
+
+    Uses a conservative window of 3 lines so back-to-back attributes on the same
+    item are caught while avoiding false positives from unrelated code blocks.
+    Fail-closed: any regex error -> returns True (but regexes here are static).
+    """
+    escaped = re.escape(feature)
+    cfg_pat = re.compile(
+        r'#\s*\[?\s*cfg\s*\(\s*feature\s*=\s*"' + escaped + r'"\s*\)'
+    )
+    test_pat = re.compile(r"#\s*\[?\s*test\s*\]")
+    lines = content.splitlines()
+    cfg_lines: List[int] = []
+    test_lines: List[int] = []
+    for i, line in enumerate(lines):
+        if cfg_pat.search(line):
+            cfg_lines.append(i)
+        if test_pat.search(line):
+            test_lines.append(i)
+    # Adjacent within 3 lines (covers #[cfg(...)] then #[test] then fn body)
+    for ci in cfg_lines:
+        for ti in test_lines:
+            if abs(ci - ti) <= 3:
+                return True
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Source file scanner
+# ---------------------------------------------------------------------------
+
+# Pattern to find the start of cfg / cfg_attr attributes (inner and outer form).
+_CFG_START_RE = re.compile(r"#!?\[cfg(?:_attr)?\s*\(")
+
+# String literal masking: matches regular and byte string literals including
+# escaped-quote sequences.  Does NOT handle raw strings r#"..."# (uncommon
+# in the files we scan and not a source of cfg-pattern false positives in
+# practice).  DOTALL is intentionally omitted: multi-line strings are unusual
+# in cfg/test attribute positions and the non-dotall mode is faster + safer.
+_STRLIT_MASK_RE = re.compile(r'b?"[^"\\]*(?:\\.[^"\\]*)*"')
+
+
+def _sanitize_for_cfg_scan(content: str) -> str:
+    """Prepare Rust source content for safe cfg-expression extraction.
+
+    Two passes:
+    1. Mask string literal contents with underscores.  This prevents
+       ``#[cfg(feature = \\"name\\")])`` embedded inside a Rust string
+       literal from being mistakenly extracted as a live cfg attribute.
+       The masking is ONE-WAY (no restore needed): real cfg attributes
+       outside string literals retain their feature names; bogus patterns
+       inside string literals get their names replaced with underscores,
+       so ``_mentions_feature(node, F)`` returns False for them.
+    2. Blank whole-line comments (``//`` including ``///``/``//!`` docs).
+       This prevents doc-comment prose that mentions cfg patterns from
+       being scanned as live attributes.
+    """
+    # Pass 1: mask string literal contents.
+    def _mask(m: "re.Match") -> str:
+        s = m.group()
+        # Keep prefix (b or empty) and the outer quotes; fill inside with '_'
+        # so no '#', '[', '(' characters remain inside the string.
+        prefix_end = 2 if s.startswith('b"') else 1
+        return s[:prefix_end] + "_" * (len(s) - prefix_end - 1) + '"'
+
+    masked = _STRLIT_MASK_RE.sub(_mask, content)
+
+    # Pass 2: blank whole-line comments, PRESERVING LENGTH.
+    # We replace every non-newline character in a comment line with a space
+    # so that positions in the sanitised string align exactly with positions
+    # in the original — the two-phase extraction in _extract_cfg_expressions
+    # depends on this len(safe) == len(original) invariant.
+    lines = masked.splitlines(keepends=True)
+    out: List[str] = []
+    for line in lines:
+        if line.lstrip().startswith("//"):
+            # Blank non-newline chars, keep CR/LF to preserve byte offsets.
+            out.append("".join(" " if c not in ("\n", "\r") else c for c in line))
+        else:
+            out.append(line)
+    return "".join(out)
+
+
+def _extract_cfg_expressions(content: str) -> List[str]:
+    """Extract all cfg predicate strings from Rust source file content.
+
+    For ``#[cfg(...)]`` / ``#![cfg(...)]``: returns the inner content.
+    For ``#[cfg_attr(cond, ...)]``: returns the condition (first arg only).
+
+    Uses a two-phase approach:
+    1. ``_sanitize_for_cfg_scan`` masks string literals + blanks line comments.
+       This prevents false matches from ``#[cfg(...)]`` embedded in string
+       literals or doc comments.  The sanitised string has the SAME LENGTH
+       as the original, so positions are identical.
+    2. We use the sanitised string to FIND cfg attribute positions (balanced
+       parens are resolved on the sanitised content, where fake #[cfg( inside
+       strings no longer appear), then slice the ORIGINAL content at those
+       positions to recover the real feature names.
+
+    Raises ParseError if a balanced-paren extraction or arg split fails.
+    """
+    # _sanitize_for_cfg_scan preserves string length (no chars removed).
+    safe = _sanitize_for_cfg_scan(content)
+    assert len(safe) == len(content), "sanitize must preserve string length"
+
+    results: List[str] = []
+    for m in _CFG_START_RE.finditer(safe):
+        paren_start = m.end() - 1  # the '(' that closes the attribute opener
+        # Resolve balanced parens on the SAFE content (which has no stray
+        # chars inside string literals that could confuse the paren counter).
+        _inner_safe, end_pos = _extract_balanced_parens(safe, paren_start)
+        # Slice the ORIGINAL content at the exact same positions to recover
+        # the real feature names (which were masked in 'safe').
+        outer_inner = content[paren_start + 1 : end_pos - 1]
+
+        if "cfg_attr" in m.group():
+            # cfg_attr(condition, attr, ...): condition is the first argument.
+            # Use _split_cfg_args on the SAFE inner slice so that stray commas
+            # inside string literals don't fragment the condition, then map
+            # back to original positions via the preserved length invariant.
+            inner_safe = safe[paren_start + 1 : end_pos - 1]
+            args_safe = _split_cfg_args(inner_safe)
+            if not args_safe:
+                raise ParseError(
+                    "empty cfg_attr at offset {}".format(m.start())
+                )
+            # The first arg in safe has the same span as in original.
+            # Find its start/end by scanning from paren_start + 1.
+            cond_safe = args_safe[0]
+            cond_start_in_inner = inner_safe.index(cond_safe)
+            cond_orig = outer_inner[
+                cond_start_in_inner : cond_start_in_inner + len(cond_safe)
+            ]
+            results.append(_normalize_cfg_expr(cond_orig.strip()))
+        else:
+            results.append(_normalize_cfg_expr(outer_inner.strip()))
+    return results
+
+
+def _normalize_cfg_expr(s: str) -> str:
+    r"""Normalize backslash-escaped quotes in a cfg expression string.
+
+    Rust multi-line string literals (line continuation with ``\``) can prevent
+    the string-literal masking regex from matching across line boundaries.
+    When a cfg expression is extracted from within such an unmasked string, the
+    feature name may appear as ``feature = \"name\"`` (with ``\"`` escapes)
+    rather than ``feature = "name"``.  Normalising ``\"`` → ``"`` before
+    parsing ensures these expressions parse correctly and produce the right
+    feature name rather than triggering the fail-closed path.
+
+    This is safe because cfg feature names never contain backslashes or bare
+    quotes, so the substitution is unambiguous in this context.
+    """
+    return s.replace('\\"', '"')
+
+
+def _collect_rust_files(directory: Path) -> List[Path]:
+    """Recursively collect .rs files under `directory`.
+
+    Raises OSError if the directory or any subdirectory cannot be listed.
+    Uses ``onerror`` so ``os.walk`` re-raises permission errors instead of
+    silently swallowing them (the default ``onerror=None`` behaviour).
+    """
+    result: List[Path] = []
+
+    def _reraise(exc: OSError) -> None:  # pragma: no cover
+        raise exc
+
+    for root, _dirs, files in os.walk(str(directory), onerror=_reraise):
+        for fname in files:
+            if Path(fname).suffix in _RUST_EXTENSIONS:
+                result.append(Path(root) / fname)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Leg classifier
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LegClassification:
+    """Result of classifying a single feature-matrix leg."""
+
+    sensitive: bool
+    reasons: List[str] = field(default_factory=list)
+    error_msg: Optional[str] = None
+
+
+def _classify_feature_in_test_files(
+    crate_dir: Path,
+    feature: str,
+    fail_open: bool,
+) -> Optional[LegClassification]:
+    """Check tests/ and benches/ directories for cfg(feature = F).
+
+    Returns a SENSITIVE LegClassification if found, else None.
+    Returns a SENSITIVE result on any IO/parse error unless fail_open=True.
+    """
+    for test_dir_name in _TEST_DIRS:
+        test_dir = crate_dir / test_dir_name
+        if not test_dir.is_dir():
+            continue
+        try:
+            rust_files = _collect_rust_files(test_dir)
+        except OSError as exc:
+            msg = "IO error listing {}: {}".format(test_dir, exc)
+            if fail_open:
+                return None
+            return LegClassification(
+                sensitive=True, reasons=["error: " + msg], error_msg=msg
+            )
+        for fpath in rust_files:
+            try:
+                content = fpath.read_text(encoding="utf-8", errors="replace")
+                exprs = _extract_cfg_expressions(content)
+            except (OSError, ParseError) as exc:
+                msg = "error reading/scanning {}: {}".format(fpath, exc)
+                if fail_open:
+                    continue
+                return LegClassification(
+                    sensitive=True, reasons=["error: " + msg], error_msg=msg
+                )
+            for expr_str in exprs:
+                try:
+                    node = parse_cfg(expr_str)
+                except ParseError as exc:
+                    msg = "parse error in {}: {!r} -> {}".format(fpath, expr_str[:60], exc)
+                    if fail_open:
+                        continue
+                    return LegClassification(
+                        sensitive=True, reasons=["error: " + msg], error_msg=msg
+                    )
+                if _mentions_feature(node, feature):
+                    return LegClassification(
+                        sensitive=True,
+                        reasons=[
+                            "cfg(feature={!r}) in test file {}".format(
+                                feature, fpath
+                            )
+                        ],
+                    )
+    return None
+
+
+def _classify_feature_in_src_files(
+    crate_dir: Path,
+    feature: str,
+    fail_open: bool,
+) -> Optional[LegClassification]:
+    """Check src/, bin/, examples/ for not-feature or test+feature cfg patterns.
+
+    Sensitive if:
+    - feature F appears under not() at any nesting level (anywhere)
+    - cfg expression contains both `test` and feature F (b-direct pattern)
+
+    Returns a SENSITIVE LegClassification if found, else None.
+    Returns a SENSITIVE result on any IO/parse error unless fail_open=True.
+    """
+    for src_dir_name in _SRC_DIRS:
+        src_dir = crate_dir / src_dir_name
+        if not src_dir.is_dir():
+            continue
+        try:
+            rust_files = _collect_rust_files(src_dir)
+        except OSError as exc:
+            msg = "IO error listing {}: {}".format(src_dir, exc)
+            if fail_open:
+                return None
+            return LegClassification(
+                sensitive=True, reasons=["error: " + msg], error_msg=msg
+            )
+        for fpath in rust_files:
+            try:
+                content = fpath.read_text(encoding="utf-8", errors="replace")
+                exprs = _extract_cfg_expressions(content)
+            except (OSError, ParseError) as exc:
+                msg = "error reading/scanning {}: {}".format(fpath, exc)
+                if fail_open:
+                    continue
+                return LegClassification(
+                    sensitive=True, reasons=["error: " + msg], error_msg=msg
+                )
+            for expr_str in exprs:
+                try:
+                    node = parse_cfg(expr_str)
+                except ParseError as exc:
+                    msg = "parse error in {}: {!r} -> {}".format(fpath, expr_str[:60], exc)
+                    if fail_open:
+                        continue
+                    return LegClassification(
+                        sensitive=True, reasons=["error: " + msg], error_msg=msg
+                    )
+                # (c) feature under not() anywhere
+                if _feature_under_not(node, feature):
+                    return LegClassification(
+                        sensitive=True,
+                        reasons=[
+                            "cfg(not(... feature={!r} ...)) in {}".format(
+                                feature, fpath
+                            )
+                        ],
+                    )
+                # (b) test+feature cfg expression in src/ (b-direct pattern, form 1:
+                # cfg(all(test, feature = "F")))
+                if _feature_in_test_cfg(node, feature):
+                    return LegClassification(
+                        sensitive=True,
+                        reasons=[
+                            "cfg(test + feature={!r}) in {}".format(feature, fpath)
+                        ],
+                    )
+            # (b) b-direct form 2: #[cfg(feature = "F")] adjacent to #[test]
+            # (checked per file after scanning all cfg expressions)
+            if _feature_adjacent_to_test_attr(content, feature):
+                return LegClassification(
+                    sensitive=True,
+                    reasons=[
+                        "cfg(feature={!r}) adjacent to #[test] in {}".format(
+                            feature, fpath
+                        )
+                    ],
+                )
+    return None
+
+
+def classify_leg(
+    crate_dir: Path,
+    features: List[str],
+    *,
+    fail_open: bool = False,
+) -> LegClassification:
+    """Classify a feature-matrix leg as sensitive or non-sensitive.
+
+    ``crate_dir`` is the root of the crate (contains Cargo.toml, src/, tests/...).
+    ``features`` is the list of feature names for this leg.
+
+    INVARIANT (fail_open=False, the only production path):
+        Any IO/parse error -> sensitive=True (fail-closed). A detector bug can
+        only keep a full leg; it can never silently demote a sensitive leg.
+
+    ``fail_open=True`` is exposed ONLY so the test suite can verify the
+    invariant by mutation: the fail-open copy must disagree with the
+    fail-closed copy on error cases, proving the guard is load-bearing.
+    Do NOT use fail_open=True in production (--classify / --enforce).
+    """
+    if not crate_dir.is_dir():
+        msg = "crate directory not found or not readable: {}".format(crate_dir)
+        if fail_open:
+            return LegClassification(sensitive=False, reasons=[], error_msg=msg)
+        return LegClassification(
+            sensitive=True, reasons=["error: " + msg], error_msg=msg
+        )
+
+    for feature in features:
+        # (a) cfg(feature = F) in test files
+        result = _classify_feature_in_test_files(crate_dir, feature, fail_open)
+        if result is not None:
+            return result
+        # (b) + (c) test+feature or not-feature in src files
+        result = _classify_feature_in_src_files(crate_dir, feature, fail_open)
+        if result is not None:
+            return result
+
+    return LegClassification(sensitive=False, reasons=[])
+
+
+# ---------------------------------------------------------------------------
+# Fragment loader
+# ---------------------------------------------------------------------------
+
+def _crate_dir(crate_name: str) -> Path:
+    """Resolve a crate name to its directory under crates/."""
+    return CRATES_DIR / crate_name
+
+
+def load_fragments() -> List[dict]:
+    """Load all fragment legs from .github/feature-matrix.d/*.yml.
+
+    Returns a list of leg dicts (as assembled by assemble-feature-matrix.py).
+    Exits with a clear error message if PyYAML is unavailable or fragments
+    cannot be loaded.
+    """
+    try:
+        import yaml  # PyYAML — already a dep (assemble-feature-matrix.py)
+    except ImportError:
+        sys.stderr.write(
+            "error: PyYAML is required for loading fragment files "
+            "(pip install pyyaml)\n"
+        )
+        sys.exit(2)
+
+    import glob
+
+    fragments = sorted(glob.glob(str(FRAGMENT_DIR / "*.yml")))
+    if not fragments:
+        sys.stderr.write(
+            "error: no fragment files found under {}\n".format(FRAGMENT_DIR)
+        )
+        sys.exit(1)
+
+    legs: List[dict] = []
+    for fpath in fragments:
+        with open(fpath, "r", encoding="utf-8") as fh:
+            data = yaml.safe_load(fh)
+        if data is None:
+            continue
+        if not isinstance(data, list):
+            sys.stderr.write(
+                "error: {}: expected a YAML list, got {}\n".format(
+                    fpath, type(data).__name__
+                )
+            )
+            sys.exit(1)
+        for leg in data:
+            if not isinstance(leg, dict):
+                sys.stderr.write(
+                    "error: {}: leg is not a dict: {!r}\n".format(fpath, leg)
+                )
+                sys.exit(1)
+            legs.append(leg)
+    return legs
+
+
+# ---------------------------------------------------------------------------
+# Classify mode
+# ---------------------------------------------------------------------------
+
+def _features_from_leg(leg: dict) -> List[str]:
+    """Split the comma-separated features string from a leg dict."""
+    raw = leg.get("features", "") or ""
+    return [f.strip() for f in str(raw).split(",") if f.strip()]
+
+
+def cmd_classify(legs: List[dict]) -> None:
+    """Print a classification table for all legs to stdout."""
+    print("{:<60} {:<12} {}".format("LEG", "TIER", "REASON"))
+    print("-" * 100)
+    for leg in legs:
+        name = leg.get("name", "<unnamed>")
+        crate = leg.get("crate", "")
+        features = _features_from_leg(leg)
+        declared_tier = leg.get("tier", "test")
+        tier_reason = leg.get("tier-reason", "")
+
+        clf = classify_leg(_crate_dir(crate), features)
+
+        detector_tier = "test" if clf.sensitive else "check"
+        reason_str = "; ".join(clf.reasons) if clf.reasons else ""
+        if clf.error_msg:
+            reason_str = "ERROR: " + clf.error_msg
+
+        tier_label = declared_tier if declared_tier else "test"
+        conflict = ""
+        if tier_label == "check" and clf.sensitive and not tier_reason:
+            conflict = " [CONFLICT: declared check but detector=sensitive]"
+
+        print("{:<60} {:<12} {}{}".format(
+            name[:60],
+            "{}->{}{}".format(
+                tier_label, detector_tier, " (override)" if tier_reason else ""
+            ),
+            reason_str[:60] if reason_str else "(none)",
+            conflict,
+        ))
+
+
+# ---------------------------------------------------------------------------
+# Enforce mode
+# ---------------------------------------------------------------------------
+
+def cmd_enforce(legs: List[dict]) -> int:
+    """Enforce tier consistency and the sq-vya1 guard.
+
+    Returns an exit code: 0 = all clean, non-zero = violations found.
+
+    Enforcement invariants (design record §4):
+    (1) A leg may carry tier: check only if the detector says non-sensitive
+        OR the fragment carries an explicit tier-reason: override.
+        tier: check + sensitive + no tier-reason => VIOLATION.
+    (2) Every feature whose leg is sensitive must appear in some test:true leg.
+        A sensitive feature with no test:true leg => VIOLATION (sq-vya1 guard).
+    """
+    violations: List[str] = []
+
+    # Map feature -> has_test_true_leg (for sq-vya1 guard)
+    feature_has_test_leg: dict = {}
+    sensitive_features: set = set()
+
+    for leg in legs:
+        name = leg.get("name", "<unnamed>")
+        crate = leg.get("crate", "")
+        features = _features_from_leg(leg)
+        declared_tier = str(leg.get("tier", "test") or "test").strip()
+        tier_reason = leg.get("tier-reason", "") or ""
+        test_flag = bool(leg.get("test", True))
+
+        clf = classify_leg(_crate_dir(crate), features)
+
+        if clf.sensitive:
+            for f in features:
+                sensitive_features.add(f)
+
+        # Track test:true coverage for all features in this leg
+        if test_flag:
+            for f in features:
+                feature_has_test_leg[f] = True
+        else:
+            for f in features:
+                if f not in feature_has_test_leg:
+                    feature_has_test_leg[f] = False
+
+        # Invariant (1): tier: check + sensitive + no override => VIOLATION
+        if declared_tier == "check" and clf.sensitive and not tier_reason.strip():
+            violations.append(
+                "VIOLATION(1) leg {!r}: declared tier:check but detector "
+                "says sensitive (reasons: {}). Add a tier-reason: override "
+                "or promote the leg back to tier:test.".format(
+                    name,
+                    "; ".join(clf.reasons) or clf.error_msg or "unknown",
+                )
+            )
+
+    # Invariant (2): every sensitive feature must have a test:true leg
+    for f in sorted(sensitive_features):
+        if not feature_has_test_leg.get(f, False):
+            violations.append(
+                "VIOLATION(2) feature {!r} is sensitive (has feature-gated "
+                "tests) but appears in no test:true leg — the sq-vya1 guard. "
+                "Add or restore a test:true leg for this feature.".format(f)
+            )
+
+    if violations:
+        for v in violations:
+            sys.stderr.write(v + "\n")
+        sys.stderr.write(
+            "\n{} enforcement violation(s) found.\n".format(len(violations))
+        )
+        return 1
+
+    print("OK: {} legs checked, 0 enforcement violations.".format(len(legs)))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Report-unlegged mode
+# ---------------------------------------------------------------------------
+
+def cmd_report_unlegged(legs: List[dict]) -> None:
+    """Advisory: report Cargo.toml opt-in features with no leg.
+
+    Compares the set of [features] in each crate's Cargo.toml against the
+    legs declared in the fragment files, excluding the SCOPE_ALLOWLIST.
+    Output is purely informational (exit 0 always).
+    """
+    # Collect all features covered by any leg
+    legged: set = set()
+    for leg in legs:
+        for f in _features_from_leg(leg):
+            legged.add(f)
+
+    # Scan Cargo.tomls for declared features
+    if not CRATES_DIR.is_dir():
+        sys.stderr.write(
+            "warning: crates directory not found: {}\n".format(CRATES_DIR)
+        )
+        return
+
+    unlegged: List[str] = []
+    for cargo_toml in CRATES_DIR.glob("*/Cargo.toml"):
+        try:
+            text = cargo_toml.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        in_features = False
+        for line in text.splitlines():
+            stripped = line.strip()
+            if stripped == "[features]":
+                in_features = True
+                continue
+            if stripped.startswith("[") and stripped != "[features]":
+                in_features = False
+            if not in_features:
+                continue
+            # Feature declaration: name = [...]  or  name = []
+            m = re.match(r"^([a-zA-Z][a-zA-Z0-9_\-]*)\s*=", stripped)
+            if m:
+                fname = m.group(1)
+                if fname == "default":
+                    continue
+                if fname in legged:
+                    continue
+                if fname in SCOPE_ALLOWLIST:
+                    continue
+                unlegged.append("{}/{}".format(cargo_toml.parent.name, fname))
+
+    if unlegged:
+        print(
+            "Advisory: {} feature(s) declared in Cargo.toml but have no "
+            "feature-matrix leg (and are not in the SCOPE allowlist):".format(
+                len(unlegged)
+            )
+        )
+        for item in sorted(unlegged):
+            print("  {}".format(item))
+    else:
+        print("Advisory: all declared features are legged or in the SCOPE allowlist.")
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Feature-matrix tier detector. Classifies feature-matrix legs as "
+            "sensitive (tier:test) or non-sensitive (check-tier candidate), and "
+            "enforces the sq-vya1 GUARD. Design: research/feature-matrix-pyramid.md §4."
+        )
+    )
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument(
+        "--classify",
+        action="store_true",
+        help="Print a classification table for all legs.",
+    )
+    group.add_argument(
+        "--enforce",
+        action="store_true",
+        help=(
+            "Exit non-zero if any tier:check leg is sensitive (no tier-reason "
+            "override), or if any sensitive feature has no test:true leg "
+            "(sq-vya1 guard)."
+        ),
+    )
+    group.add_argument(
+        "--report-unlegged",
+        action="store_true",
+        help=(
+            "Advisory: report features declared in Cargo.tomls but with no leg "
+            "(excluding SCOPE allowlist). Always exits 0."
+        ),
+    )
+    args = parser.parse_args()
+
+    legs = load_fragments()
+
+    if args.classify:
+        cmd_classify(legs)
+        sys.exit(0)
+    elif args.enforce:
+        sys.exit(cmd_enforce(legs))
+    else:
+        cmd_report_unlegged(legs)
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/tests/test_feature_matrix_tiers.py
+++ b/scripts/tests/test_feature_matrix_tiers.py
@@ -1,0 +1,810 @@
+#!/usr/bin/env python3
+# [SONNET-4.6] Hermetic tests for the feature-matrix tier detector (bead sq-6g9kr).
+# Design: research/feature-matrix-pyramid.md §4.
+# Authored under the proceed-and-document rule.
+#
+# Covers the acceptance criteria:
+#   (a) seeded cfg(feature)-gated #[test] in tests/ => SENSITIVE
+#   (b) seeded cfg(not(feature)) in src/ => SENSITIVE
+#   (c) nested any()/all() combinators parsed correctly => SENSITIVE
+#   (d) parse error in cfg expression => SENSITIVE (fail-closed)
+#   (e) unreadable crate dir => SENSITIVE (fail-closed)
+#   (f) tier:check + sensitive verdict => enforce exit != 0
+#   (g) mutation check: fail-open copy => non-sensitive on error
+#   (h) non-sensitive fixture (no cfg refs) => NOT sensitive
+#   (i) cfg(all(test, feature)) in src/ => SENSITIVE (b-direct pattern)
+#
+# All tests are hermetic: they create temporary directories with synthetic
+# Rust files and call the detector functions directly. No subprocess, no
+# network, no PyYAML required for the core logic tests.
+#
+# Run:  python3 scripts/tests/test_feature_matrix_tiers.py
+# (stdlib only; no pytest needed — also discoverable by `pytest`.)
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import stat
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+DETECTOR = REPO_ROOT / "scripts" / "feature-matrix-tiers.py"
+
+
+def _load_detector():
+    """Import the detector module from its file path."""
+    spec = importlib.util.spec_from_file_location("feature_matrix_tiers", DETECTOR)
+    assert spec and spec.loader, "could not load {}".format(DETECTOR)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["feature_matrix_tiers"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+det = _load_detector()
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building fixture crate directories
+# ---------------------------------------------------------------------------
+
+def _make_crate(tmpdir: str, src_files: dict = None, test_files: dict = None) -> Path:
+    """Build a minimal fixture crate directory.
+
+    src_files:  {relative_path_under_src: content, ...}
+    test_files: {relative_path_under_tests: content, ...}
+
+    Returns the crate root Path.
+    """
+    root = Path(tmpdir)
+    # Minimal Cargo.toml so the fixture looks like a real crate
+    (root / "Cargo.toml").write_text(
+        '[package]\nname = "fixture"\nversion = "0.1.0"\n[features]\n',
+        encoding="utf-8",
+    )
+    src_dir = root / "src"
+    src_dir.mkdir()
+    (src_dir / "lib.rs").write_text("", encoding="utf-8")
+
+    if src_files:
+        for rel, content in src_files.items():
+            fpath = src_dir / rel
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.write_text(content, encoding="utf-8")
+
+    if test_files:
+        tests_dir = root / "tests"
+        tests_dir.mkdir()
+        for rel, content in test_files.items():
+            fpath = tests_dir / rel
+            fpath.parent.mkdir(parents=True, exist_ok=True)
+            fpath.write_text(content, encoding="utf-8")
+
+    return root
+
+
+# ---------------------------------------------------------------------------
+# cfg expression parser tests
+# ---------------------------------------------------------------------------
+
+class TestCfgParser(unittest.TestCase):
+    """Unit tests for the recursive cfg expression parser."""
+
+    def test_parse_feature(self):
+        node = det.parse_cfg('feature = "foo"')
+        self.assertIsInstance(node, det.CfgFeature)
+        self.assertEqual(node.name, "foo")
+
+    def test_parse_test(self):
+        node = det.parse_cfg("test")
+        self.assertIsInstance(node, det.CfgTest)
+
+    def test_parse_not_feature(self):
+        node = det.parse_cfg('not(feature = "foo")')
+        self.assertIsInstance(node, det.CfgNot)
+        self.assertIsInstance(node.inner, det.CfgFeature)
+        self.assertEqual(node.inner.name, "foo")
+
+    def test_parse_any(self):
+        node = det.parse_cfg('any(feature = "a", feature = "b")')
+        self.assertIsInstance(node, det.CfgAny)
+        self.assertEqual(len(node.exprs), 2)
+
+    def test_parse_all(self):
+        node = det.parse_cfg('all(test, feature = "a")')
+        self.assertIsInstance(node, det.CfgAll)
+        self.assertEqual(len(node.exprs), 2)
+        self.assertIsInstance(node.exprs[0], det.CfgTest)
+        self.assertIsInstance(node.exprs[1], det.CfgFeature)
+
+    def test_parse_nested_not_any(self):
+        """cfg(not(any(target_arch = "wasm32", feature = "compact-index")))"""
+        node = det.parse_cfg(
+            'not(any(target_arch = "wasm32", feature = "compact-index"))'
+        )
+        self.assertIsInstance(node, det.CfgNot)
+        self.assertIsInstance(node.inner, det.CfgAny)
+        self.assertEqual(len(node.inner.exprs), 2)
+        self.assertIsInstance(node.inner.exprs[1], det.CfgFeature)
+        self.assertEqual(node.inner.exprs[1].name, "compact-index")
+
+    def test_parse_other_predicate(self):
+        node = det.parse_cfg('target_arch = "wasm32"')
+        self.assertIsInstance(node, det.CfgOther)
+
+    def test_parse_empty_raises(self):
+        with self.assertRaises(det.ParseError):
+            det.parse_cfg("")
+
+    def test_parse_garbage_raises(self):
+        """An unrecognised expression raises ParseError (fail-closed)."""
+        with self.assertRaises(det.ParseError):
+            det.parse_cfg("not(not(not(not())))")  # not() with empty inner
+
+    def test_parse_unbalanced_parens_raises(self):
+        with self.assertRaises(det.ParseError):
+            det.parse_cfg('not(feature = "a"')
+
+    def test_feature_under_not_direct(self):
+        node = det.parse_cfg('not(feature = "foo")')
+        self.assertTrue(det._feature_under_not(node, "foo"))
+        self.assertFalse(det._feature_under_not(node, "bar"))
+
+    def test_feature_under_not_nested(self):
+        """cfg(not(any(target_arch = "wasm32", feature = "foo"))) => feature_under_not."""
+        node = det.parse_cfg('not(any(target_arch = "wasm32", feature = "foo"))')
+        self.assertTrue(det._feature_under_not(node, "foo"))
+
+    def test_feature_under_not_false_for_plain_feature(self):
+        """cfg(feature = "foo") alone does NOT put the feature under a not()."""
+        node = det.parse_cfg('feature = "foo"')
+        self.assertFalse(det._feature_under_not(node, "foo"))
+
+    def test_feature_in_test_cfg(self):
+        """cfg(all(test, feature = "foo")) => test + feature."""
+        node = det.parse_cfg('all(test, feature = "foo")')
+        self.assertTrue(det._feature_in_test_cfg(node, "foo"))
+        self.assertFalse(det._feature_in_test_cfg(node, "bar"))
+
+    def test_mentions_feature(self):
+        node = det.parse_cfg('any(feature = "a", feature = "b")')
+        self.assertTrue(det._mentions_feature(node, "a"))
+        self.assertTrue(det._mentions_feature(node, "b"))
+        self.assertFalse(det._mentions_feature(node, "c"))
+
+
+# ---------------------------------------------------------------------------
+# (a) seeded cfg(feature)-gated test in tests/ => SENSITIVE
+# ---------------------------------------------------------------------------
+
+class TestSensitiveTestFile(unittest.TestCase):
+    """Acceptance criterion (a): a test file with cfg(feature) => SENSITIVE."""
+
+    def test_test_file_gated_feature_sensitive(self):
+        """tests/feature_gated.rs with #![cfg(feature = "my-feature")] => sensitive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                test_files={
+                    "feature_gated.rs": (
+                        '#![cfg(feature = "my-feature")]\n'
+                        "#[test]\n"
+                        "fn it_works() { assert_eq!(1, 1); }\n"
+                    )
+                },
+            )
+            clf = det.classify_leg(root, ["my-feature"])
+            self.assertTrue(
+                clf.sensitive,
+                "Expected SENSITIVE: test file has cfg(feature) gate. Reasons: {}".format(
+                    clf.reasons
+                ),
+            )
+
+    def test_benches_file_gated_feature_sensitive(self):
+        """benches/*.rs with cfg(feature) => sensitive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(tmp)
+            benches_dir = root / "benches"
+            benches_dir.mkdir()
+            (benches_dir / "bench_foo.rs").write_text(
+                '#[cfg(feature = "my-feature")]\nfn bench_it() {}\n',
+                encoding="utf-8",
+            )
+            clf = det.classify_leg(root, ["my-feature"])
+            self.assertTrue(clf.sensitive)
+
+    def test_unrelated_feature_in_test_file_not_sensitive(self):
+        """cfg(feature = "other") in test file does NOT make my-feature sensitive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                test_files={
+                    "other.rs": '#![cfg(feature = "other-feature")]\n#[test]\nfn t() {}\n'
+                },
+            )
+            clf = det.classify_leg(root, ["my-feature"])
+            self.assertFalse(
+                clf.sensitive,
+                "Expected NOT sensitive: cfg is for a different feature. Reasons: {}".format(
+                    clf.reasons
+                ),
+            )
+
+
+# ---------------------------------------------------------------------------
+# (b) seeded cfg(not(feature)) in src/ => SENSITIVE
+# ---------------------------------------------------------------------------
+
+class TestSensitiveNotFeature(unittest.TestCase):
+    """Acceptance criterion (b): cfg(not(feature)) in src/ => SENSITIVE."""
+
+    def test_cfg_not_feature_in_src_sensitive(self):
+        """#[cfg(not(feature = "my-feature"))] in src/lib.rs => sensitive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                src_files={
+                    "lib.rs": (
+                        '#[cfg(not(feature = "my-feature"))]\n'
+                        "fn fallback() {}\n"
+                        '#[cfg(feature = "my-feature")]\n'
+                        "fn fast_path() {}\n"
+                    )
+                },
+            )
+            clf = det.classify_leg(root, ["my-feature"])
+            self.assertTrue(
+                clf.sensitive,
+                "Expected SENSITIVE: cfg(not(feature)) in src. Reasons: {}".format(
+                    clf.reasons
+                ),
+            )
+
+    def test_cfg_not_feature_via_cfg_attr_sensitive(self):
+        """#[cfg_attr(not(feature = "my-feature"), allow(dead_code))] => sensitive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                src_files={
+                    "lib.rs": (
+                        '#[cfg_attr(not(feature = "my-feature"), allow(dead_code))]\n'
+                        "fn some_fn() {}\n"
+                    )
+                },
+            )
+            clf = det.classify_leg(root, ["my-feature"])
+            self.assertTrue(clf.sensitive)
+
+
+# ---------------------------------------------------------------------------
+# (c) nested any()/all() combinators => SENSITIVE
+# ---------------------------------------------------------------------------
+
+class TestNestedCombinators(unittest.TestCase):
+    """Acceptance criterion (c): nested any/all combinators parsed correctly."""
+
+    def test_nested_not_any_sensitive(self):
+        """cfg(not(any(target_arch = "wasm32", feature = "compact-index"))) => sensitive.
+
+        This is the real sparq-core compact-index pattern from the design record.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                src_files={
+                    "store.rs": (
+                        '#[cfg(not(any(target_arch = "wasm32", feature = "compact-index")))]\n'
+                        "type IndexSet = [(); 6];\n"
+                        '#[cfg(any(target_arch = "wasm32", feature = "compact-index"))]\n'
+                        "type IndexSet = [(); 3];\n"
+                    )
+                },
+            )
+            clf = det.classify_leg(root, ["compact-index"])
+            self.assertTrue(
+                clf.sensitive,
+                "Expected SENSITIVE: nested not(any(wasm32, feature)) in src. "
+                "Reasons: {}".format(clf.reasons),
+            )
+
+    def test_nested_all_with_not_sensitive(self):
+        """cfg(all(not(feature = "foo"), bar)) => feature foo is under not()."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                src_files={
+                    "lib.rs": (
+                        '#[cfg(all(not(feature = "foo"), target_os = "linux"))]\n'
+                        "fn linux_fallback() {}\n"
+                    )
+                },
+            )
+            clf = det.classify_leg(root, ["foo"])
+            self.assertTrue(clf.sensitive)
+
+    def test_plain_any_feature_in_test_file_sensitive(self):
+        """tests/*.rs with cfg(any(feature = "a", feature = "b")) => sensitive for both."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                test_files={
+                    "combo.rs": '#![cfg(any(feature = "a", feature = "b"))]\n#[test]\nfn t() {}\n'
+                },
+            )
+            clf_a = det.classify_leg(root, ["a"])
+            clf_b = det.classify_leg(root, ["b"])
+            clf_c = det.classify_leg(root, ["c"])
+            self.assertTrue(clf_a.sensitive, "feature a should be sensitive")
+            self.assertTrue(clf_b.sensitive, "feature b should be sensitive")
+            self.assertFalse(clf_c.sensitive, "feature c should not be sensitive")
+
+
+# ---------------------------------------------------------------------------
+# (d) parse error in cfg expression => SENSITIVE (fail-closed)
+# ---------------------------------------------------------------------------
+
+class TestParseErrorFailClosed(unittest.TestCase):
+    """Acceptance criterion (d): a parse error classifies SENSITIVE (fail-closed)."""
+
+    def test_unbalanced_paren_in_src_sensitive(self):
+        """A file with #[cfg(not(feature = "foo")] (unbalanced) => sensitive.
+
+        The detector encounters a parse error and must fail-closed.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                src_files={
+                    # Deliberately malformed: missing closing paren before ']'
+                    "broken.rs": '#[cfg(not(feature = "foo")]\nfn f() {}\n',
+                },
+            )
+            clf = det.classify_leg(root, ["foo"])
+            self.assertTrue(
+                clf.sensitive,
+                "Expected SENSITIVE on parse error (fail-closed). Got: {}".format(
+                    clf.sensitive
+                ),
+            )
+            self.assertIsNotNone(
+                clf.error_msg,
+                "Expected an error_msg when classification fails due to parse error.",
+            )
+
+    def test_empty_cfg_expression_sensitive(self):
+        """A file with #[cfg()] (empty expression) => sensitive (fail-closed)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                src_files={"lib.rs": "#[cfg()]\nfn f() {}\n"},
+            )
+            clf = det.classify_leg(root, ["any-feature"])
+            self.assertTrue(clf.sensitive, "Empty cfg() should be fail-closed sensitive.")
+
+
+# ---------------------------------------------------------------------------
+# (e) unreadable crate dir => SENSITIVE (fail-closed)
+# ---------------------------------------------------------------------------
+
+class TestUnreadableDirFailClosed(unittest.TestCase):
+    """Acceptance criterion (e): unreadable/missing dir => SENSITIVE (fail-closed)."""
+
+    def test_missing_crate_dir_sensitive(self):
+        """A non-existent crate directory => sensitive."""
+        clf = det.classify_leg(Path("/nonexistent/does/not/exist"), ["my-feature"])
+        self.assertTrue(clf.sensitive, "Missing dir must be fail-closed sensitive.")
+        self.assertIsNotNone(clf.error_msg)
+
+    def test_unreadable_tests_dir_sensitive(self):
+        """An unreadable tests/ directory => sensitive (fail-closed)."""
+        if os.geteuid() == 0:
+            self.skipTest("running as root, cannot test permission denial")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(tmp)
+            tests_dir = root / "tests"
+            tests_dir.mkdir()
+            # Write a gated file, then revoke read permission on the directory
+            (tests_dir / "secret.rs").write_text(
+                '#![cfg(feature = "my-feature")]\n#[test]\nfn t() {}\n',
+                encoding="utf-8",
+            )
+            os.chmod(str(tests_dir), 0o000)
+            try:
+                clf = det.classify_leg(root, ["my-feature"])
+                self.assertTrue(
+                    clf.sensitive,
+                    "Unreadable tests/ dir must be fail-closed sensitive.",
+                )
+            finally:
+                # Restore so TemporaryDirectory cleanup can delete it
+                os.chmod(str(tests_dir), 0o755)
+
+
+# ---------------------------------------------------------------------------
+# (f) tier:check + sensitive => enforce exit != 0
+# ---------------------------------------------------------------------------
+
+class TestEnforceMode(unittest.TestCase):
+    """Acceptance criterion (f): tier:check + sensitive verdict => enforce exit != 0."""
+
+    def _make_legs(self, crate_dir: Path, tier: str = "check", tier_reason: str = "") -> list:
+        """Build a minimal synthetic legs list for enforce testing."""
+        leg: dict = {
+            "name": "fixture (my-feature)",
+            "crate": str(crate_dir),  # not used directly; we patch crate_dir below
+            "features": "my-feature",
+            "test": True,
+            "tier": tier,
+        }
+        if tier_reason:
+            leg["tier-reason"] = tier_reason
+        return [leg]
+
+    def _enforce_with_legs(self, legs: list) -> int:
+        """Run cmd_enforce on a synthetic legs list with patched crate_dir."""
+        return det.cmd_enforce(legs)
+
+    def test_check_tier_sensitive_fails(self):
+        """tier:check + sensitive detector verdict => enforce exit != 0."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                test_files={
+                    "feature_gated.rs": '#![cfg(feature = "my-feature")]\n#[test]\nfn t() {}\n'
+                },
+            )
+            # We call classify_leg directly to verify it's sensitive first
+            clf = det.classify_leg(root, ["my-feature"])
+            self.assertTrue(clf.sensitive, "Fixture must be sensitive for this test.")
+
+            # Build a synthetic leg with tier:check pointing to our fixture crate
+            # We need to call cmd_enforce with crate dir patched.
+            # Use a subclass to inject the fixture crate_dir.
+            original_crate_dir = det._crate_dir
+
+            def patched_crate_dir(name: str) -> Path:
+                if name == "fixture":
+                    return root
+                return original_crate_dir(name)
+
+            det._crate_dir = patched_crate_dir
+            try:
+                legs = [
+                    {
+                        "name": "fixture (my-feature)",
+                        "crate": "fixture",
+                        "features": "my-feature",
+                        "test": True,
+                        "tier": "check",
+                    }
+                ]
+                exit_code = det.cmd_enforce(legs)
+                self.assertNotEqual(
+                    exit_code,
+                    0,
+                    "tier:check + sensitive must cause enforce to exit non-zero.",
+                )
+            finally:
+                det._crate_dir = original_crate_dir
+
+    def test_check_tier_with_override_passes(self):
+        """tier:check + sensitive + tier-reason override => enforce passes (exit 0)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                test_files={
+                    "feature_gated.rs": '#![cfg(feature = "my-feature")]\n#[test]\nfn t() {}\n'
+                },
+            )
+            original_crate_dir = det._crate_dir
+
+            def patched_crate_dir(name: str) -> Path:
+                if name == "fixture":
+                    return root
+                return original_crate_dir(name)
+
+            det._crate_dir = patched_crate_dir
+            try:
+                legs = [
+                    {
+                        "name": "fixture (my-feature)",
+                        "crate": "fixture",
+                        "features": "my-feature",
+                        "test": True,
+                        "tier": "check",
+                        "tier-reason": "reviewed: tests run in default lane",
+                    }
+                ]
+                exit_code = det.cmd_enforce(legs)
+                self.assertEqual(
+                    exit_code,
+                    0,
+                    "tier:check + sensitive with tier-reason override must pass.",
+                )
+            finally:
+                det._crate_dir = original_crate_dir
+
+    def test_sensitive_feature_no_test_leg_fails(self):
+        """A sensitive feature appearing only in a test:false leg => sq-vya1 violation."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                test_files={
+                    "feature_gated.rs": '#![cfg(feature = "my-feature")]\n#[test]\nfn t() {}\n'
+                },
+            )
+            original_crate_dir = det._crate_dir
+
+            def patched_crate_dir(name: str) -> Path:
+                if name == "fixture":
+                    return root
+                return original_crate_dir(name)
+
+            det._crate_dir = patched_crate_dir
+            try:
+                # test:false leg => sq-vya1 guard triggered
+                legs = [
+                    {
+                        "name": "fixture (my-feature)",
+                        "crate": "fixture",
+                        "features": "my-feature",
+                        "test": False,  # no test:true leg!
+                        # no tier: field => defaults to 'test', fine for invariant 1
+                    }
+                ]
+                exit_code = det.cmd_enforce(legs)
+                self.assertNotEqual(
+                    exit_code,
+                    0,
+                    "Sensitive feature with no test:true leg must fail enforce (sq-vya1).",
+                )
+            finally:
+                det._crate_dir = original_crate_dir
+
+
+# ---------------------------------------------------------------------------
+# (g) mutation check: fail-open copy => non-sensitive on error
+# ---------------------------------------------------------------------------
+
+class TestMutationFailOpen(unittest.TestCase):
+    """Acceptance criterion (g): the fail-open mutation must disagree with fail-closed.
+
+    This proves the fail-closed behaviour is load-bearing: if someone
+    flips the detector to fail-open on errors, a test goes red.
+    """
+
+    def test_fail_open_returns_non_sensitive_on_missing_dir(self):
+        """Mutant (fail_open=True) returns non-sensitive on a missing crate dir."""
+        clf = det.classify_leg(
+            Path("/nonexistent/does/not/exist"), ["my-feature"], fail_open=True
+        )
+        self.assertFalse(
+            clf.sensitive,
+            "Mutant (fail_open=True) must return non-sensitive on error "
+            "(proving the fail-closed path is load-bearing).",
+        )
+
+    def test_fail_closed_returns_sensitive_on_missing_dir(self):
+        """The real detector (fail_open=False) returns sensitive on same error."""
+        clf = det.classify_leg(
+            Path("/nonexistent/does/not/exist"), ["my-feature"], fail_open=False
+        )
+        self.assertTrue(
+            clf.sensitive,
+            "Real detector (fail-closed) must return sensitive on missing dir.",
+        )
+
+    def test_mutation_check_divergence(self):
+        """Fail-open and fail-closed MUST give different answers on error cases.
+
+        This is the canonical mutation check: if someone changes fail-closed
+        to fail-open, tests (b) and (e) above would pass but THIS test would
+        fail — making the regression visible.
+        """
+        missing = Path("/nonexistent/crate/path")
+        clf_real = det.classify_leg(missing, ["feat"])
+        clf_mutant = det.classify_leg(missing, ["feat"], fail_open=True)
+        self.assertNotEqual(
+            clf_real.sensitive,
+            clf_mutant.sensitive,
+            "fail-closed (sensitive=True) must differ from fail-open (sensitive=False) "
+            "on an error case. Both returned sensitive={}.".format(clf_real.sensitive),
+        )
+
+    def test_fail_open_non_sensitive_on_unreadable_tests_dir(self):
+        """Mutant (fail_open=True) returns non-sensitive on unreadable tests/ dir."""
+        if os.geteuid() == 0:
+            self.skipTest("running as root, cannot test permission denial")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(tmp)
+            tests_dir = root / "tests"
+            tests_dir.mkdir()
+            (tests_dir / "gated.rs").write_text(
+                '#![cfg(feature = "feat")]\n#[test]\nfn t() {}\n',
+                encoding="utf-8",
+            )
+            os.chmod(str(tests_dir), 0o000)
+            try:
+                clf_open = det.classify_leg(root, ["feat"], fail_open=True)
+                clf_closed = det.classify_leg(root, ["feat"], fail_open=False)
+                self.assertFalse(clf_open.sensitive, "fail-open must not escalate on error")
+                self.assertTrue(clf_closed.sensitive, "fail-closed must escalate on error")
+            finally:
+                os.chmod(str(tests_dir), 0o755)
+
+
+# ---------------------------------------------------------------------------
+# (h) non-sensitive fixture => NOT sensitive
+# ---------------------------------------------------------------------------
+
+class TestNonSensitive(unittest.TestCase):
+    """Acceptance criterion (h): a crate with no cfg refs is NOT sensitive."""
+
+    def test_empty_crate_not_sensitive(self):
+        """A crate with no cfg(feature) references is not sensitive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                src_files={"lib.rs": "pub fn add(a: i32, b: i32) -> i32 { a + b }\n"},
+            )
+            clf = det.classify_leg(root, ["my-feature"])
+            self.assertFalse(
+                clf.sensitive,
+                "Expected NOT sensitive: no cfg refs. Reasons: {}".format(clf.reasons),
+            )
+
+    def test_cfg_for_other_feature_not_sensitive(self):
+        """cfg(feature = "other") does NOT make "my-feature" sensitive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                src_files={
+                    "lib.rs": (
+                        '#[cfg(feature = "other")]\n'
+                        "fn other_path() {}\n"
+                    )
+                },
+            )
+            clf = det.classify_leg(root, ["my-feature"])
+            self.assertFalse(clf.sensitive)
+
+
+# ---------------------------------------------------------------------------
+# (i) cfg(all(test, feature)) in src/ => SENSITIVE (b-direct pattern)
+# ---------------------------------------------------------------------------
+
+class TestBDirectPattern(unittest.TestCase):
+    """Acceptance criterion (i): cfg(all(test, feature)) in src/ => SENSITIVE."""
+
+    def test_all_test_feature_in_src_sensitive(self):
+        """#[cfg(all(test, feature = "my-feature"))] in src/lib.rs => sensitive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                src_files={
+                    "lib.rs": (
+                        '#[cfg(all(test, feature = "my-feature"))]\n'
+                        "mod tests {\n"
+                        "    #[test]\n"
+                        "    fn it_works() {}\n"
+                        "}\n"
+                    )
+                },
+            )
+            clf = det.classify_leg(root, ["my-feature"])
+            self.assertTrue(
+                clf.sensitive,
+                "Expected SENSITIVE: cfg(all(test, feature)) in src. Reasons: {}".format(
+                    clf.reasons
+                ),
+            )
+
+    def test_all_feature_test_in_src_sensitive(self):
+        """cfg(all(feature = "my-feature", test)) — reversed order — also sensitive."""
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _make_crate(
+                tmp,
+                src_files={
+                    "lib.rs": (
+                        '#[cfg(all(feature = "my-feature", test))]\n'
+                        "mod tests {\n"
+                        "    #[test]\n"
+                        "    fn it_works() {}\n"
+                        "}\n"
+                    )
+                },
+            )
+            clf = det.classify_leg(root, ["my-feature"])
+            self.assertTrue(clf.sensitive)
+
+
+# ---------------------------------------------------------------------------
+# cfg expression extraction tests
+# ---------------------------------------------------------------------------
+
+class TestCfgExtraction(unittest.TestCase):
+    """Tests for extracting cfg expressions from Rust source content."""
+
+    def test_extract_single_cfg(self):
+        content = '#[cfg(feature = "foo")]\nfn f() {}\n'
+        exprs = det._extract_cfg_expressions(content)
+        self.assertEqual(exprs, ['feature = "foo"'])
+
+    def test_extract_inner_cfg(self):
+        content = '#![cfg(feature = "foo")]\nfn f() {}\n'
+        exprs = det._extract_cfg_expressions(content)
+        self.assertEqual(exprs, ['feature = "foo"'])
+
+    def test_extract_cfg_attr(self):
+        content = '#[cfg_attr(not(feature = "foo"), allow(dead_code))]\nfn f() {}\n'
+        exprs = det._extract_cfg_expressions(content)
+        self.assertEqual(exprs, ['not(feature = "foo")'])
+
+    def test_extract_multiple(self):
+        content = (
+            '#[cfg(feature = "a")]\nfn a() {}\n'
+            '#[cfg(not(feature = "b"))]\nfn b() {}\n'
+        )
+        exprs = det._extract_cfg_expressions(content)
+        self.assertEqual(len(exprs), 2)
+        self.assertIn('feature = "a"', exprs)
+        self.assertIn('not(feature = "b")', exprs)
+
+    def test_extract_nested(self):
+        content = '#[cfg(not(any(target_arch = "wasm32", feature = "ci")))]\nfn f() {}\n'
+        exprs = det._extract_cfg_expressions(content)
+        self.assertEqual(len(exprs), 1)
+        self.assertIn('not(any(target_arch = "wasm32", feature = "ci"))', exprs)
+
+
+# ---------------------------------------------------------------------------
+# Utility tests
+# ---------------------------------------------------------------------------
+
+class TestSplitCfgArgs(unittest.TestCase):
+    def test_simple(self):
+        result = det._split_cfg_args('feature = "a", feature = "b"')
+        self.assertEqual(result, ['feature = "a"', 'feature = "b"'])
+
+    def test_nested(self):
+        result = det._split_cfg_args('any(a, b), feature = "c"')
+        self.assertEqual(result, ["any(a, b)", 'feature = "c"'])
+
+    def test_single(self):
+        result = det._split_cfg_args('feature = "foo"')
+        self.assertEqual(result, ['feature = "foo"'])
+
+    def test_empty(self):
+        result = det._split_cfg_args("")
+        self.assertEqual(result, [])
+
+
+# ---------------------------------------------------------------------------
+# Integration: features_from_leg helper
+# ---------------------------------------------------------------------------
+
+class TestFeaturesFromLeg(unittest.TestCase):
+    def test_single_feature(self):
+        leg = {"features": "foo"}
+        self.assertEqual(det._features_from_leg(leg), ["foo"])
+
+    def test_multiple_features(self):
+        leg = {"features": "foo,bar, baz"}
+        self.assertEqual(det._features_from_leg(leg), ["foo", "bar", "baz"])
+
+    def test_empty_features(self):
+        leg = {"features": ""}
+        self.assertEqual(det._features_from_leg(leg), [])
+
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
> 🤖 SPARQ agent — bulk Rust/Python implementer tier (Sonnet 4.6), bead sq-6g9kr.

## Summary

Implements the feature-matrix tier detector as specified in **research/feature-matrix-pyramid.md §4** (PR #1481 / \`feat/feature-matrix-pyramid-design\`).

Two new files (scripts only, nothing else):
- \`scripts/feature-matrix-tiers.py\` — stdlib-only cfg-expression detector + CLI
- \`scripts/tests/test_feature_matrix_tiers.py\` — 50 hermetic acceptance tests, all green

## What the detector does

For each opt-in feature-matrix leg in \`.github/feature-matrix.d/*.yml\`, classifies
the leg as **sensitive** (must stay tier:test = full build+test leg) or **non-sensitive**
(check-tier demotion candidate) by scanning the crate for:

- **(a)** \`cfg(feature = "F")\` / \`cfg_attr\` forms in \`tests/\` or \`benches/\` files  
- **(b)** \`cfg(all(test, feature = "F"))\` or adjacent \`#[cfg(feature="F")] #[test]\` in \`src/\` (b-direct pattern)  
- **(c)** \`cfg(not(feature = "F"))\` or F under any \`not()\` at any nesting level anywhere in the crate

Handles the real-world nested case from the design record:
\`cfg(not(any(target_arch = "wasm32", feature = "compact-index")))\`

**Core invariant (fail-closed):** any parse/IO/grep error classifies the leg SENSITIVE.
A detector bug degrades to "keep the full leg" — never a silent demotion.

## Enforcement modes

\`--enforce\` mechanizes the **sq-vya1 GUARD** (design record §4):
1. \`tier:check\` + sensitive + no \`tier-reason:\` override → exit non-zero  
2. Sensitive feature with no \`test:true\` leg → exit non-zero (feature-gated suite would run nowhere)

\`--classify\` prints a classification table; \`--report-unlegged\` is advisory.

## Acceptance tests satisfied (50/50)

- seeded cfg(feature)-gated \`#[test]\` in tests/ detected ✓
- cfg(not(feature)) in src/ detected ✓  
- nested any()/all() combinators (compact-index pattern) ✓
- parse error → SENSITIVE (fail-closed) ✓
- unreadable crate dir → SENSITIVE (fail-closed) ✓
- tier:check + sensitive → enforce exit != 0 ✓
- mutation check: fail-open copy → non-sensitive (fail-closed is load-bearing) ✓

## Smoke-tested on real codebase

\`python3 scripts/feature-matrix-tiers.py --enforce\` → **OK: 72 legs checked, 0 enforcement violations**  
\`python3 scripts/feature-matrix-tiers.py --classify\` → **0 parse errors** on the live crate tree

## Gates

- \`python3 scripts/tests/test_feature_matrix_tiers.py\`: **50/50 pass**
- No new Python deps (stdlib only; PyYAML already present for \`--classify\`/\`--enforce\` which load YAML)
- No Rust changes — no \`cargo build\`/\`cargo clippy\`/\`cargo test\` required  
- No README additions (scripts/ tooling, not a publishable crate)

**Spec:** research/feature-matrix-pyramid.md §4  
**Acceptance test:** \`python3 scripts/tests/test_feature_matrix_tiers.py\`  
**Bead:** sq-6g9kr | **Auto-merge:** OFF

🤖 Generated with [Claude Code](https://claude.com/claude-code)