### PR TITLE
docs(zk): zkSPARQL ISWC 2026 submission-support pack — related-work hardening + deterministic constraint-count eval pack (sq-gum8.5)

### DIFF
--- a/bench/zk-compose/README.md
+++ b/bench/zk-compose/README.md
@@ -26,14 +26,54 @@ returns). Numbers below were measured by Opus 4.8.
 | `family_cost_curve.json`          | sq-pn2 full-family (k,n,r,d) prove/verify/size curve |
 | `family_curve/`                   | sq-pn2 standalone timing harness (own cargo project) |
 | `sparql_feature_catalog.json`     | sq-1s2.1.2 SPARQL 1.1 feature → ZK coverage + gate-cost catalog |
+| `eval_pack.json`                  | sq-gum8.5 zkSPARQL submission-support constraint-count manifest (see below) |
+| `RELATED-WORK-DELTA.md`           | sq-gum8.5 related-work hardening note for the zkSPARQL submission |
 | `scripts/gate_counts.sh`          | regenerate the gate-count JSON |
 | `scripts/prove_verify.sh`         | time prove+verify for one member |
 | `scripts/sparql_catalog.py`       | regenerate the SPARQL feature catalog (joins the snapshot) |
+| `scripts/eval_pack.py`            | regenerate `eval_pack.json`; `--check` fails if the committed manifest is stale |
 
 > The gate-count JSON is also the source the in-crate **regression gate**
 > (`crates/sparq-zk-compose/tests/gate_count.rs`, sq-c5f) baselines against —
 > re-run `scripts/gate_counts.sh` after an intentional circuit change and update
 > both that JSON and `crates/sparq-zk-compose/tests/gate_count_snapshot.json`.
+
+## sq-gum8.5: zkSPARQL submission-support evaluation pack
+
+`eval_pack.json` is the single per-circuit **constraint-count manifest** backing
+the zkSPARQL submission's evaluation ([zksparql.org](https://zksparql.org/); spec
+source `site/specs/zksparql.typ`). It is a **deterministic join** — the generator
+re-measures nothing and needs no `nargo`/`bb` — of the repo's committed,
+regression-gated count sources:
+
+- `crates/sparq-zk-compose/tests/gate_count_snapshot.json` (the zk/compose
+  family; cross-checked member-for-member against `gate_counts_latest.json`, so
+  a half-done re-baseline fails generation);
+- `zk/ieee754/bench/float_ops_latest.json` + `float_conversions_latest.json`
+  (the IEEE-754 library's amortised per-operation gate measurements).
+
+Guards (all fail-closed, exit 2):
+
+- **toolchain drift** — the nargo/bb versions recorded in each measured source
+  must equal the pins in `.github/workflows/zk-toolchain.yml`;
+- **freshness chain** — snapshot and latest must agree exactly;
+- **byte-identity** — `scripts/eval_pack.py --check` regenerates in memory and
+  fails if the committed `eval_pack.json` differs, so a source re-baseline that
+  forgets to regenerate the pack is a visible failure. Run `--check` as part of
+  every zk re-baseline (CI wiring for `--check` is follow-up bead sq-yfhho;
+  workflow files were outside sq-gum8.5's file set).
+
+External systems' figures (ZKLP) appear only under `cited_external` with
+`cited_not_remeasured: true` — reported by their authors, never re-measured
+here, and **not** directly comparable to the ultra_honk `circuit_size` numbers
+(different proof systems and arithmetisations). The circuits measured here are
+pre-external-audit (sq-qhy4): a gate count is a size fact, not a soundness or
+privacy claim.
+
+```sh
+bench/zk-compose/scripts/eval_pack.py > bench/zk-compose/eval_pack.json  # regenerate
+bench/zk-compose/scripts/eval_pack.py --check                            # drift guard
+```
 
 ## sq-1s2.1.2: SPARQL feature → ZK gate-cost catalog
 

--- a/bench/zk-compose/RELATED-WORK-DELTA.md
+++ b/bench/zk-compose/RELATED-WORK-DELTA.md
@@ -1,0 +1,186 @@
+<!-- [FABLE-5] sq-gum8.5 — related-work hardening note for the zkSPARQL ISWC 2026 submission.
+     Citations verified 2026-07-04 (venues/DOIs/quotes traced to primary sources; see the
+     per-work "source" lines). This note supports the AUTHORS' rebuttal / camera-ready
+     readiness — it does NOT rewrite the paper. Every claim about the sparq estate is scoped
+     "design + implementation, pre-external-audit" (sq-qhy4 open). -->
+
+# zkSPARQL related-work delta
+
+A reviewer-facing map of the closest prior work to the zkSPARQL submission
+([zksparql.org](https://zksparql.org/), spec source `site/specs/zksparql.typ`), the honest
+differentiation for each, and the exact claim wording the submission can defend. Compiled for
+sq-gum8.5. The spec's `= Related work` section was hardened in the same change; this note is
+the longer working record (evidence, quotes, and the claim-wording recommendations a rebuttal
+would draw on).
+
+All statements about the sparq/zkSPARQL estate are scoped **design + implementation,
+pre-external-audit** — the ZK verifier and Noir circuits have NOT completed external
+accredited-cryptographer review (bead sq-qhy4; forge/soundness tests are toolchain-gated,
+sq-1gir). Do not read any line here as a proven security, privacy, or soundness guarantee.
+
+## The one thing to fix first: fragment-scope claim vs implementation
+
+The live landing page states the system supports
+*"a non-trivial fragment of the SPARQL 1.1 algebra (BGP, Join, Filter, OPTIONAL, UNION,
+bounded property paths, EXISTS, NOT EXISTS, and MINUS)"*. The in-repo spec
+(`site/specs/zksparql.typ` section 7.1) and the compiled circuit family disagree: the spec
+says *"OPTIONAL, UNION, property paths, aggregation, and subqueries are not part of the
+fragment"*, and the compiled family (`zk/compose/`, enumerated in `eval_pack.json`) is
+`Scan` / `Filter{Int,F64,SignedInt,Decimal,ValueDl}` / `JoinEq` plus the credential-layer
+circuits (`RevokeUnset`, `HiddenIssuer`, `HolderPok`, `HolderSet`) — **no** OPTIONAL, UNION,
+property-path, EXISTS, or MINUS circuit exists in this repository today.
+
+This is the single most likely honesty challenge. Either (a) the paper's evaluation covers a
+broader fragment realised outside this repo's `zk/compose/` tree, in which case the mapping
+from paper claim to committed artifact needs to be stated explicitly; or (b) the broader-
+fragment wording is aspirational and should be scoped to what is closed end-to-end. **Do not
+leave the two documents contradicting each other** — a reviewer who reads both will treat the
+gap as an overclaim. Recommended framing: state precisely which operators are
+proof-carrying-today vs. specified-but-not-yet-circuit, exactly as the spec already does.
+
+## Per-work delta
+
+### ZKLP — Ernstberger et al., IEEE S&P 2025
+
+- **Source.** *Zero-Knowledge Location Privacy via Accurate Floating-Point SNARKs*, IEEE S&P
+  2025 pp. 3440–3459; arXiv:2404.14983; IACR ePrint 2024/1842; dblp `conf/sp/ErnstbergerZCJS25`.
+- **What it does.** A library of IEEE-754-compliant f32/f64 SNARK circuits (init/add/sub/
+  mul/div/sqrt/compare, incl. subnormals, NaN, ±∞, round-half-to-even) in gnark over R1CS
+  (BN254; Groth16/Plonk) with LogUp lookups, validated against Berkeley TestFloat, applied to
+  hexagonal-grid location predicates.
+- **Why it matters.** It claims *"the first set of Zero-Knowledge Proof (ZKP) circuits that
+  are fully compliant to the IEEE 754 standard"* (abstract). This is peer-reviewed and prior.
+- **Differentiation.** zkSPARQL's float work is the *integration* of in-circuit IEEE-754 into
+  typed SPARQL value-FILTER evaluation over committed RDF (the `xsd:double` FILTER lane),
+  not the float primitives in isolation.
+- **Defensible wording.** Fine: "in-circuit IEEE-754 typed value filters." **Forbidden:** any
+  "first ZK floats / first IEEE-754 in ZK" phrasing — ZKLP owns it. The landing page's
+  "worked numeric primitive (IEEE 754 add\_f32) closed end-to-end" is acceptable (it does not
+  claim primacy).
+- **Numbers.** ZKLP's per-op constraint counts are **R1CS + LogUp**, a different unit from
+  this estate's UltraHonk `circuit_size`. They are recorded in `eval_pack.json`
+  (`cited_external.zklp`, `cited_not_remeasured: true`) but **must not** be tabulated
+  side-by-side with the sparq gate counts as if comparable.
+
+### ZKGraph — arXiv:2507.00427, 2025 (preprint)
+
+- **Source.** *Zero-Knowledge Verifiable Graph Query Evaluation via Expansion-Centric Operator
+  Decomposition*, arXiv:2507.00427 (Jul 2025); code `github.com/Hao8172/ZKGraph`. No
+  peer-reviewed venue found — treat as preprint.
+- **What it does.** Decomposes graph queries into an "expansion" (node→neighbour) primitive +
+  attribute circuits, verified in Halo2 (PLONKish, KZG), so an owner proves query-execution
+  correctness without disclosing the graph. Evaluated on LDBC SNB; queries expressed in Cypher
+  over **property graphs**.
+- **Differentiation.** Property-graph / Cypher, **not RDF/SPARQL**. No blank-node or per-graph
+  canonicalisation model; no issuer-attestation / multi-credential composition.
+- **Watch-out.** ZKGraph self-positions as *"the first system to leverage non-interactive
+  zero-knowledge proofs for the confidential and verifiable evaluation of arbitrary graph
+  queries."* A reviewer may juxtapose it with any zkSPARQL "first" wording. **Cite it**, and
+  scope zkSPARQL's novelty to RDF/SPARQL semantics + signed-credential composition rather than
+  to "first ZK graph queries."
+
+### PoneglyphDB — Gu, Fang, Nawab, SIGMOD 2025
+
+- **Source.** *PoneglyphDB: Efficient Non-interactive Zero-Knowledge Proofs for Arbitrary
+  SQL-Query Verification*, Proc. ACM Manag. Data 3 (SIGMOD 2025), DOI 10.1145/3709713;
+  arXiv:2411.15031.
+- **What it does.** Non-interactive ZK (Halo2/PLONKish, recursive composition) circuits for
+  SQL operators — range checks/filters, sorting, group-by, joins, aggregation — composed into
+  whole-query proofs; host keeps raw data. Evaluated on TPC-H.
+- **Differentiation.** Relational (SQL) not RDF/SPARQL; single committed database, not issuer-
+  signed multi-graph credentials. The paper does **not** address NULLs / three-valued logic /
+  outer joins (verified: no mention in the full text), so SPARQL OPTIONAL-style semantics are
+  genuinely out of its scope — a real point of distinction if zkSPARQL closes them.
+- **Defensible wording.** "the first *non-interactive* ZK proofs of SQL query results" belongs
+  to PoneglyphDB; zkSPARQL should not claim non-interactivity as novel per se.
+
+### ZKSQL — Li et al., PVLDB 16(8), 2023
+
+- **Source.** *ZKSQL: Verifiable and Efficient Query Evaluation with Zero-Knowledge Proofs*,
+  PVLDB 16(8) 1804–1816, 2023; DOI 10.14778/3594512.3594513.
+- **What it does.** Interactive (VOLE-based) ZK over SQL evaluation steps incl. ZK joins;
+  authenticated set operations; TPC-H. The interactive SQL predecessor to PoneglyphDB.
+- **Differentiation.** Interactive protocol vs zkSPARQL's non-interactive offline-checkable
+  manifest; SQL not SPARQL. Already cited in the spec.
+
+### VeriDKG — Zhou et al., PVLDB 17(4), 2023
+
+- **Source.** *VeriDKG: A Verifiable SPARQL Query Engine for Decentralized Knowledge Graphs*,
+  PVLDB 17(4) 912–925, 2023; DOI 10.14778/3636218.3636242.
+- **What it does.** An authenticated data structure (RGB-Trie + accumulator, blockchain-
+  maintained) so clients verify SPARQL results are correct/complete/fresh. It is the *closest
+  system on the SPARQL axis* a reviewer will name.
+- **Differentiation — the important one.** VeriDKG provides **integrity and completeness, not
+  zero knowledge**: its abstract claims *"both data integrity and query verifiability"* and
+  contains no confidentiality/privacy claim; the queried data is **not** hidden. It is
+  therefore *complementary*, not a competitor — cite it precisely as an integrity system so a
+  reviewer cannot say "SPARQL verifiability is already solved."
+
+### zk-creds — Rosenberg et al., IEEE S&P 2023; Crescent — ePrint 2024/2013
+
+- **Sources.** zk-creds: IEEE S&P 2023 pp. 1882–1900, ePrint 2022/878. Crescent: IACR ePrint
+  2024/2013 (2024, **preprint** — no confirmed peer-reviewed venue; cite as ePrint, not CCS).
+- **What they do.** Prove possession of *existing, unmodified* credentials (e-passports;
+  JWT / ISO mDL) in zero knowledge, adding selective disclosure / unlinkability without issuer
+  cooperation.
+- **Differentiation.** They prove *possession / attribute disclosure of one credential*.
+  zkSPARQL generalises the statement language to *SPARQL query evaluation over the signed
+  data* (joins, typed filters, revocation), spanning multiple credentials. Cite as the
+  credential-layer state of the art the query layer sits above.
+
+### Braun, Wright & Käfer — ESWC 2026 (the authors' own line)
+
+- **Source.** *Proving Soundness of SPARQL Query Results Using Selective Disclosure of RDF
+  Datasets and Zero-Knowledge Proofs*, The Semantic Web — ESWC 2026, LNCS 16549,
+  DOI 10.1007/978-3-032-25156-5\_16; repo `github.com/uvdsl/rdf-zkp-sparql`.
+- **What it does ("zkRDF").** A **data-centric** approach: the holder guarantees *soundness of
+  query results* by proving properties **about the queried RDF dataset**, exposing only the
+  minimal info the proof needs. Abstract: *"Unlike existing methods that prove query
+  execution, we establish soundness of query results by proving properties about the queried
+  RDF dataset."* It also reports it *"outperforms an approach that proves query execution by
+  three orders of magnitude."*
+- **The self-delta a reviewer WILL probe.** This is the authors' own prior/companion work, and
+  it explicitly claims a large speed advantage over the *prove-the-execution* strategy that
+  zkSPARQL embodies. The submission must answer "why prove execution at all?" up front. The honest
+  answer (now in the spec): the two occupy opposite points of a trade-off — zkRDF discloses
+  selective *views* of the dataset and is cheaper; zkSPARQL keeps the source graphs hidden and
+  proves the algebra operators in-circuit, covering operator statements (in-circuit joins,
+  typed filters) that a disclosure-of-views argument does not directly reach. Complementary,
+  per-query-choosable, **not** competing. Do not cite the 3-orders figure without this framing.
+
+## Name-collision heads-up (not related work, but worth knowing)
+
+Dan Yamamoto (IIJ) et al. presented a *"zk-SPARQL"* (verifiable, privacy-preserving SPARQL
+over VCs) at IIW 35 (Nov 2022) and in slide decks — **no citable peer-reviewed paper found**
+under that exact name, but the naming near-collision with "zkSPARQL" is worth a reviewer-
+facing footnote. A related published chapter exists (*RDF-Based Semantics for Selective
+Disclosure and Zero-Knowledge Proofs on Verifiable Credentials*, Springer 2025,
+DOI 10.1007/978-3-031-94575-5\_21) — verify authorship before citing.
+
+## Fresh-search residue (2025–2026)
+
+- **Newer IEEE-754 ZK float circuits than ZKLP: none found.** Predecessor is Garg et al.,
+  *Succinct Zero Knowledge for Floating Point Computations*, CCS 2022 (add/mul only, no
+  concrete implementation). ZKLP remains the reference.
+- Adjacent verifiable-DB preprints a thorough reviewer *might* raise but which are off-axis:
+  V3DB (ZK verifiable vector search, arXiv:2603.03065, 2026, preprint — UNVERIFIED beyond
+  title/abstract); a minor ICBTA 2024 "privacy-enabled databases" workshop paper. Neither is
+  RDF/SPARQL query-evaluation ZK; mention only if a reviewer surfaces them.
+- SparqLog (PVLDB 16(13), 2023) is a Datalog-based SPARQL 1.1 *engine* — **no ZK / verifiable
+  / privacy content**. It is not related work for this submission; do not cite it as such.
+
+## Recommended claim-wording changes for the authors
+
+1. **Reconcile the fragment claim** (top of this note): make the paper's stated fragment match
+   what is proof-carrying in the artifact, or explicitly separate proof-carrying-today from
+   specified-but-not-yet-circuit operators.
+2. **Never claim "first ZK floats / first IEEE-754 in ZK"** — attribute to ZKLP; frame the
+   float contribution as *integration into typed SPARQL FILTER evaluation*.
+3. **Scope any "first ZK graph/SPARQL query" novelty** to *RDF/SPARQL semantics over
+   issuer-signed multi-credential data*, and cite ZKGraph (graph/Cypher) + VeriDKG
+   (SPARQL-integrity) so the novelty is stated as a delta, not a vacuum.
+4. **Cite VeriDKG as integrity-not-ZK** so "SPARQL verifiability already exists" is answered.
+5. **Pre-empt the Braun–Wright–Käfer 3-orders comparison** with the complementary-trade-off
+   framing rather than ignoring it.
+6. Keep every soundness/privacy statement scoped pre-external-audit (sq-qhy4) — the pack's
+   evidence is constraint *sizes* (a size is not a soundness claim), not a security result.

--- a/bench/zk-compose/eval_pack.json
+++ b/bench/zk-compose/eval_pack.json
@@ -1,0 +1,1472 @@
+{
+  "_provenance": {
+    "generator": "bench/zk-compose/scripts/eval_pack.py [FABLE-5] (sq-gum8.5)",
+    "inputs_sha256": {
+      "gate_count_snapshot": {
+        "path": "crates/sparq-zk-compose/tests/gate_count_snapshot.json",
+        "sha256": "de77ad1534c2855256bc40d8c334f2b5728dcb63080357273b89115f8b5f0693"
+      },
+      "gate_counts_latest": {
+        "path": "bench/zk-compose/gate_counts_latest.json",
+        "sha256": "a2e29df934ff2e8ed028357de62cdf07dc57aef65f50fc6bd41395a0ff0a48f4"
+      },
+      "ieee754_float_conversions": {
+        "path": "zk/ieee754/bench/float_conversions_latest.json",
+        "sha256": "b30a89c0b40cdb6b0ffe8cd11b02928a5ec32ec0af2154e43ab98578e8849750"
+      },
+      "ieee754_float_ops": {
+        "path": "zk/ieee754/bench/float_ops_latest.json",
+        "sha256": "e33a0d031d9854f939ee213748dfceedca88660f95e9a76f509748e9f7711441"
+      }
+    },
+    "note": "Deterministic join of the repo's committed, regression-gated constraint-count sources; regenerate with the generator, never hand-edit. No number here is re-measured by this script. Counts are ultra_honk circuit_size per `bb gates -s ultra_honk` (backend gate count after ACIR->backend transformation). The circuits are pre-external-audit (sq-qhy4): a gate count is a size fact, not a soundness or privacy claim."
+  },
+  "_schema": "sparq-zk-eval-pack/1",
+  "cited_external": {
+    "_note": "Figures REPORTED BY THE CITED AUTHORS, reproduced for context only \u2014 never re-measured here, and NOT directly comparable to the counts above (different proof systems, arithmetisations, constraint/gate definitions, and lookup strategies). Comparisons in prose must stay qualitative.",
+    "zklp": {
+      "citation": "Ernstberger, J.; Zhang, C.; Ciprian, L.; Jovanovic, P.; Steinhorst, S. 'Zero-Knowledge Location Privacy via Accurate Floating-Point SNARKs'. IEEE S&P 2025, pp. 3440-3459. arXiv:2404.14983; IACR ePrint 2024/1842.",
+      "cited_not_remeasured": true,
+      "constraint_model": "R1CS constraints in gnark over BN254 (Groth16/Plonk) with LogUp lookups; the authors report a 'native' count and a 'lookup (i)' count per op, plus a one-time lookup-table cost. NOT the same unit as the UltraHonk circuit_size figures above \u2014 do not tabulate side by side as if comparable.",
+      "first_claim_guard": "ZKLP is peer-reviewed and prior, claiming the first fully-IEEE-754 compliant ZKP circuits. The zkSPARQL submission MUST NOT assert a 'first ZK floats' novelty; its float contribution is the INTEGRATION of in-circuit IEEE-754 into typed SPARQL FILTER evaluation, not the primitives themselves.",
+      "reported_amortised_note": "ZKLP abstract/section 5.1: about 64 R1CS constraints per operation for 2^15 FP32 multiplications (amortised); 209 for 2^1 multiplications.",
+      "reported_figures_source": "ZKLP Table 1 (|T_RC|=2^8), author-reported",
+      "reported_r1cs_constraints": {
+        "fp32_lookup_i": {
+          "add_sub": 43,
+          "cmp": 7,
+          "div": 38,
+          "init": 17,
+          "mul": 33,
+          "one_time_ii_iii": 291,
+          "sqrt": 22
+        },
+        "fp32_native": {
+          "add_sub": 42,
+          "cmp": 26,
+          "div": 38,
+          "init": 13,
+          "mul": 31,
+          "sqrt": 23
+        },
+        "fp64_lookup_i": {
+          "add_sub": 71,
+          "cmp": 11,
+          "div": 60,
+          "init": 32,
+          "mul": 57,
+          "one_time_ii_iii": 323,
+          "sqrt": 38
+        },
+        "fp64_native": {
+          "add_sub": 42,
+          "cmp": 26,
+          "div": 38,
+          "init": 13,
+          "mul": 31,
+          "sqrt": 23
+        }
+      }
+    }
+  },
+  "ieee754": {
+    "float_conversions": {
+      "i16_to_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 176.42857142857142,
+        "setup_estimate": 2708.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2885
+        }
+      },
+      "i16_to_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4203
+        },
+        "per_call_estimate": 164.85714285714286,
+        "setup_estimate": 2884.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3049
+        }
+      },
+      "i16_to_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 169.85714285714286,
+        "setup_estimate": 2761.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2931
+        }
+      },
+      "i16_to_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 170.42857142857142,
+        "setup_estimate": 2756.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2927
+        }
+      },
+      "i32_to_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 174.71428571428572,
+        "setup_estimate": 2722.285714285714,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2897
+        }
+      },
+      "i32_to_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4243
+        },
+        "per_call_estimate": 169.85714285714286,
+        "setup_estimate": 2884.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3054
+        }
+      },
+      "i32_to_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 155.85714285714286,
+        "setup_estimate": 2873.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3029
+        }
+      },
+      "i32_to_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 168.71428571428572,
+        "setup_estimate": 2770.285714285714,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2939
+        }
+      },
+      "i64_to_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 167.85714285714286,
+        "setup_estimate": 2777.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2945
+        }
+      },
+      "i64_to_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4323
+        },
+        "per_call_estimate": 179.85714285714286,
+        "setup_estimate": 2884.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3064
+        }
+      },
+      "i64_to_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4200
+        },
+        "per_call_estimate": 165.85714285714286,
+        "setup_estimate": 2873.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3039
+        }
+      },
+      "i64_to_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4245
+        },
+        "per_call_estimate": 172.42857142857142,
+        "setup_estimate": 2865.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3038
+        }
+      },
+      "i8_to_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 169.85714285714286,
+        "setup_estimate": 2761.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2931
+        }
+      },
+      "i8_to_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 169.14285714285714,
+        "setup_estimate": 2766.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2936
+        }
+      },
+      "i8_to_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 170.14285714285714,
+        "setup_estimate": 2758.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2929
+        }
+      },
+      "i8_to_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 170.57142857142858,
+        "setup_estimate": 2755.4285714285716,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2926
+        }
+      },
+      "u128_to_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5795
+        },
+        "per_call_estimate": 207.14285714285714,
+        "setup_estimate": 4137.857142857143,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4345
+        }
+      },
+      "u128_to_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4363
+        },
+        "per_call_estimate": 184.71428571428572,
+        "setup_estimate": 2885.285714285714,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3070
+        }
+      },
+      "u128_to_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4298
+        },
+        "per_call_estimate": 178.0,
+        "setup_estimate": 2874.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3052
+        }
+      },
+      "u128_to_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4271
+        },
+        "per_call_estimate": 175.57142857142858,
+        "setup_estimate": 2866.4285714285716,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3042
+        }
+      },
+      "u16_to_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 177.85714285714286,
+        "setup_estimate": 2697.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2875
+        }
+      },
+      "u16_to_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4147
+        },
+        "per_call_estimate": 157.71428571428572,
+        "setup_estimate": 2885.285714285714,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3043
+        }
+      },
+      "u16_to_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 170.85714285714286,
+        "setup_estimate": 2753.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2924
+        }
+      },
+      "u16_to_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 171.57142857142858,
+        "setup_estimate": 2747.4285714285716,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2919
+        }
+      },
+      "u32_to_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 176.28571428571428,
+        "setup_estimate": 2709.714285714286,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2886
+        }
+      },
+      "u32_to_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4185
+        },
+        "per_call_estimate": 162.57142857142858,
+        "setup_estimate": 2884.4285714285716,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3047
+        }
+      },
+      "u32_to_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 156.85714285714286,
+        "setup_estimate": 2865.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3022
+        }
+      },
+      "u32_to_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 170.0,
+        "setup_estimate": 2760.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2930
+        }
+      },
+      "u64_to_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 169.57142857142858,
+        "setup_estimate": 2763.4285714285716,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2933
+        }
+      },
+      "u64_to_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4253
+        },
+        "per_call_estimate": 171.0,
+        "setup_estimate": 2885.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3056
+        }
+      },
+      "u64_to_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4128
+        },
+        "per_call_estimate": 156.71428571428572,
+        "setup_estimate": 2874.285714285714,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3031
+        }
+      },
+      "u64_to_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4161
+        },
+        "per_call_estimate": 161.85714285714286,
+        "setup_estimate": 2866.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3028
+        }
+      },
+      "u8_to_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 171.28571428571428,
+        "setup_estimate": 2749.714285714286,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2921
+        }
+      },
+      "u8_to_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 170.0,
+        "setup_estimate": 2760.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2930
+        }
+      },
+      "u8_to_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 171.0,
+        "setup_estimate": 2752.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2923
+        }
+      },
+      "u8_to_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 171.85714285714286,
+        "setup_estimate": 2745.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2917
+        }
+      }
+    },
+    "float_ops": {
+      "add_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 9423
+        },
+        "per_call_estimate": 630.1428571428571,
+        "setup_estimate": 4381.857142857143,
+        "small": {
+          "calls": 1,
+          "circuit_size": 5012
+        }
+      },
+      "add_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 6513
+        },
+        "per_call_estimate": 341.85714285714283,
+        "setup_estimate": 3778.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4120
+        }
+      },
+      "add_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 8640
+        },
+        "per_call_estimate": 446.0,
+        "setup_estimate": 5072.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 5518
+        }
+      },
+      "add_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 6691
+        },
+        "per_call_estimate": 367.2857142857143,
+        "setup_estimate": 3752.714285714286,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4120
+        }
+      },
+      "ceil_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 7211
+        },
+        "per_call_estimate": 384.14285714285717,
+        "setup_estimate": 4137.857142857143,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4522
+        }
+      },
+      "ceil_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5850
+        },
+        "per_call_estimate": 284.85714285714283,
+        "setup_estimate": 3571.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3856
+        }
+      },
+      "ceil_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5435
+        },
+        "per_call_estimate": 277.0,
+        "setup_estimate": 3219.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3496
+        }
+      },
+      "ceil_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5996
+        },
+        "per_call_estimate": 305.57142857142856,
+        "setup_estimate": 3551.4285714285716,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3857
+        }
+      },
+      "div_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 8445
+        },
+        "per_call_estimate": 524.5714285714286,
+        "setup_estimate": 4248.428571428572,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4773
+        }
+      },
+      "div_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5909
+        },
+        "per_call_estimate": 255.57142857142858,
+        "setup_estimate": 3864.4285714285716,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4120
+        }
+      },
+      "div_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 7316
+        },
+        "per_call_estimate": 367.85714285714283,
+        "setup_estimate": 4373.142857142857,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4741
+        }
+      },
+      "div_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 6034
+        },
+        "per_call_estimate": 273.42857142857144,
+        "setup_estimate": 3846.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4120
+        }
+      },
+      "eq_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3258
+        },
+        "per_call_estimate": 55.285714285714285,
+        "setup_estimate": 2815.714285714286,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2871
+        }
+      },
+      "eq_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3145
+        },
+        "per_call_estimate": 37.42857142857143,
+        "setup_estimate": 2845.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2883
+        }
+      },
+      "eq_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3134
+        },
+        "per_call_estimate": 36.142857142857146,
+        "setup_estimate": 2844.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2881
+        }
+      },
+      "eq_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3226
+        },
+        "per_call_estimate": 46.42857142857143,
+        "setup_estimate": 2854.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2901
+        }
+      },
+      "floor_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 7203
+        },
+        "per_call_estimate": 383.14285714285717,
+        "setup_estimate": 4137.857142857143,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4521
+        }
+      },
+      "floor_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5842
+        },
+        "per_call_estimate": 283.85714285714283,
+        "setup_estimate": 3571.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3855
+        }
+      },
+      "floor_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5427
+        },
+        "per_call_estimate": 276.0,
+        "setup_estimate": 3219.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3495
+        }
+      },
+      "floor_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5988
+        },
+        "per_call_estimate": 304.57142857142856,
+        "setup_estimate": 3551.4285714285716,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3856
+        }
+      },
+      "ge_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3746
+        },
+        "per_call_estimate": 116.42857142857143,
+        "setup_estimate": 2814.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2931
+        }
+      },
+      "ge_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3429
+        },
+        "per_call_estimate": 73.14285714285714,
+        "setup_estimate": 2843.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2917
+        }
+      },
+      "ge_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3422
+        },
+        "per_call_estimate": 72.14285714285714,
+        "setup_estimate": 2844.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2917
+        }
+      },
+      "ge_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3542
+        },
+        "per_call_estimate": 86.14285714285714,
+        "setup_estimate": 2852.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2939
+        }
+      },
+      "gt_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3818
+        },
+        "per_call_estimate": 125.42857142857143,
+        "setup_estimate": 2814.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2940
+        }
+      },
+      "gt_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3501
+        },
+        "per_call_estimate": 82.14285714285714,
+        "setup_estimate": 2843.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2926
+        }
+      },
+      "gt_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3494
+        },
+        "per_call_estimate": 81.14285714285714,
+        "setup_estimate": 2844.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2926
+        }
+      },
+      "gt_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3614
+        },
+        "per_call_estimate": 95.14285714285714,
+        "setup_estimate": 2852.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2948
+        }
+      },
+      "le_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3810
+        },
+        "per_call_estimate": 124.42857142857143,
+        "setup_estimate": 2814.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2939
+        }
+      },
+      "le_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3493
+        },
+        "per_call_estimate": 81.14285714285714,
+        "setup_estimate": 2843.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2925
+        }
+      },
+      "le_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3486
+        },
+        "per_call_estimate": 80.14285714285714,
+        "setup_estimate": 2844.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2925
+        }
+      },
+      "le_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3606
+        },
+        "per_call_estimate": 94.14285714285714,
+        "setup_estimate": 2852.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2947
+        }
+      },
+      "lt_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3738
+        },
+        "per_call_estimate": 115.42857142857143,
+        "setup_estimate": 2814.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2930
+        }
+      },
+      "lt_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3421
+        },
+        "per_call_estimate": 72.14285714285714,
+        "setup_estimate": 2843.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2916
+        }
+      },
+      "lt_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3414
+        },
+        "per_call_estimate": 71.14285714285714,
+        "setup_estimate": 2844.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2916
+        }
+      },
+      "lt_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3534
+        },
+        "per_call_estimate": 85.14285714285714,
+        "setup_estimate": 2852.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2938
+        }
+      },
+      "mul_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 8946
+        },
+        "per_call_estimate": 543.8571428571429,
+        "setup_estimate": 4595.142857142857,
+        "small": {
+          "calls": 1,
+          "circuit_size": 5139
+        }
+      },
+      "mul_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 6106
+        },
+        "per_call_estimate": 283.7142857142857,
+        "setup_estimate": 3836.285714285714,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4120
+        }
+      },
+      "mul_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 7393
+        },
+        "per_call_estimate": 355.7142857142857,
+        "setup_estimate": 4547.285714285715,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4903
+        }
+      },
+      "mul_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 6273
+        },
+        "per_call_estimate": 307.57142857142856,
+        "setup_estimate": 3812.4285714285716,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4120
+        }
+      },
+      "ne_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3258
+        },
+        "per_call_estimate": 55.285714285714285,
+        "setup_estimate": 2815.714285714286,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2871
+        }
+      },
+      "ne_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3145
+        },
+        "per_call_estimate": 37.42857142857143,
+        "setup_estimate": 2845.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2883
+        }
+      },
+      "ne_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3134
+        },
+        "per_call_estimate": 36.142857142857146,
+        "setup_estimate": 2844.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2881
+        }
+      },
+      "ne_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 3226
+        },
+        "per_call_estimate": 46.42857142857143,
+        "setup_estimate": 2854.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2901
+        }
+      },
+      "round_ties_even_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 7287
+        },
+        "per_call_estimate": 393.7142857142857,
+        "setup_estimate": 4137.285714285715,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4531
+        }
+      },
+      "round_ties_even_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5900
+        },
+        "per_call_estimate": 291.14285714285717,
+        "setup_estimate": 3570.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3862
+        }
+      },
+      "round_ties_even_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5485
+        },
+        "per_call_estimate": 283.2857142857143,
+        "setup_estimate": 3218.714285714286,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3502
+        }
+      },
+      "round_ties_even_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 6046
+        },
+        "per_call_estimate": 311.85714285714283,
+        "setup_estimate": 3551.1428571428573,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3863
+        }
+      },
+      "sqrt_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 8270
+        },
+        "per_call_estimate": 498.2857142857143,
+        "setup_estimate": 4283.714285714285,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4782
+        }
+      },
+      "sqrt_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 8232
+        },
+        "per_call_estimate": 587.4285714285714,
+        "setup_estimate": 3532.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4120
+        }
+      },
+      "sqrt_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 6800
+        },
+        "per_call_estimate": 308.42857142857144,
+        "setup_estimate": 4332.571428571428,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4641
+        }
+      },
+      "sqrt_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 8232
+        },
+        "per_call_estimate": 587.4285714285714,
+        "setup_estimate": 3532.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4120
+        }
+      },
+      "sub_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 9424
+        },
+        "per_call_estimate": 630.1428571428571,
+        "setup_estimate": 4382.857142857143,
+        "small": {
+          "calls": 1,
+          "circuit_size": 5013
+        }
+      },
+      "sub_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 6514
+        },
+        "per_call_estimate": 342.0,
+        "setup_estimate": 3778.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4120
+        }
+      },
+      "sub_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 8641
+        },
+        "per_call_estimate": 446.0,
+        "setup_estimate": 5073.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 5519
+        }
+      },
+      "sub_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 6692
+        },
+        "per_call_estimate": 367.42857142857144,
+        "setup_estimate": 3752.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4120
+        }
+      },
+      "to_i64_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 165.71428571428572,
+        "setup_estimate": 2794.285714285714,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2960
+        }
+      },
+      "to_i64_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4727
+        },
+        "per_call_estimate": 154.14285714285714,
+        "setup_estimate": 3493.8571428571427,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3648
+        }
+      },
+      "to_i64_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4414
+        },
+        "per_call_estimate": 156.71428571428572,
+        "setup_estimate": 3160.285714285714,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3317
+        }
+      },
+      "to_i64_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4835
+        },
+        "per_call_estimate": 167.71428571428572,
+        "setup_estimate": 3493.285714285714,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3661
+        }
+      },
+      "to_u64_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4120
+        },
+        "per_call_estimate": 168.42857142857142,
+        "setup_estimate": 2772.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 2941
+        }
+      },
+      "to_u64_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4553
+        },
+        "per_call_estimate": 132.42857142857142,
+        "setup_estimate": 3493.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3626
+        }
+      },
+      "to_u64_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4240
+        },
+        "per_call_estimate": 135.0,
+        "setup_estimate": 3160.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3295
+        }
+      },
+      "to_u64_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 4661
+        },
+        "per_call_estimate": 146.0,
+        "setup_estimate": 3493.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3639
+        }
+      },
+      "trunc_f128": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 7027
+        },
+        "per_call_estimate": 361.14285714285717,
+        "setup_estimate": 4137.857142857143,
+        "small": {
+          "calls": 1,
+          "circuit_size": 4499
+        }
+      },
+      "trunc_f16": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5718
+        },
+        "per_call_estimate": 268.2857142857143,
+        "setup_estimate": 3571.714285714286,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3840
+        }
+      },
+      "trunc_f32": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5303
+        },
+        "per_call_estimate": 260.42857142857144,
+        "setup_estimate": 3219.5714285714284,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3480
+        }
+      },
+      "trunc_f64": {
+        "big": {
+          "calls": 8,
+          "circuit_size": 5864
+        },
+        "per_call_estimate": 289.0,
+        "setup_estimate": 3552.0,
+        "small": {
+          "calls": 1,
+          "circuit_size": 3841
+        }
+      }
+    },
+    "measured_with": {
+      "conversions_source_timestamp": "2026-05-20T06:08:02.983929",
+      "method": "small-N/big-N amortisation: per_call_estimate = (big.circuit_size - small.circuit_size) / (big.calls - small.calls); estimates are derived, circuit_size values are measured",
+      "n_big": 8,
+      "n_small": 1,
+      "ops_source_timestamp": "2026-06-13T00:11:25.814548",
+      "tool": "bb gates -s ultra_honk via zk/ieee754/scripts/benchmark_float_ops.py"
+    }
+  },
+  "toolchain": {
+    "bb": "5.0.0-nightly.20260324",
+    "nargo": "1.0.0-beta.21",
+    "pinned_in": ".github/workflows/zk-toolchain.yml"
+  },
+  "zk_compose": {
+    "measured_with": {
+      "regression_gate": "crates/sparq-zk-compose/tests/gate_count.rs",
+      "source_timestamp": "2026-06-17T03:48:31Z",
+      "tool": "bb gates -s ultra_honk"
+    },
+    "members": {
+      "filter_decimal_i3_f2": {
+        "circuit_size": 17416,
+        "family": "filter"
+      },
+      "filter_f64": {
+        "circuit_size": 3113,
+        "family": "filter"
+      },
+      "filter_f64_d1": {
+        "circuit_size": 17416,
+        "family": "filter"
+      },
+      "filter_f64_d2": {
+        "circuit_size": 17416,
+        "family": "filter"
+      },
+      "filter_f64_d3": {
+        "circuit_size": 17416,
+        "family": "filter"
+      },
+      "filter_f64_d4": {
+        "circuit_size": 17416,
+        "family": "filter"
+      },
+      "filter_int_d1": {
+        "circuit_size": 17416,
+        "family": "filter"
+      },
+      "filter_int_d2": {
+        "circuit_size": 17416,
+        "family": "filter"
+      },
+      "filter_int_d3": {
+        "circuit_size": 17416,
+        "family": "filter"
+      },
+      "filter_int_d4": {
+        "circuit_size": 17416,
+        "family": "filter"
+      },
+      "filter_signed_int_d2": {
+        "circuit_size": 17416,
+        "family": "filter"
+      },
+      "filter_signed_int_d4": {
+        "circuit_size": 17416,
+        "family": "filter"
+      },
+      "filter_value_dl_decimal": {
+        "circuit_size": 3070,
+        "family": "filter_value_dual_leaf"
+      },
+      "filter_value_dl_f64": {
+        "circuit_size": 4157,
+        "family": "filter_value_dual_leaf"
+      },
+      "filter_value_dl_int": {
+        "circuit_size": 3033,
+        "family": "filter_value_dual_leaf"
+      },
+      "hidden_issuer_d4": {
+        "circuit_size": 16946,
+        "family": "hidden_issuer"
+      },
+      "holder_pok": {
+        "circuit_size": 10334,
+        "family": "holder"
+      },
+      "holder_set_d4": {
+        "circuit_size": 10650,
+        "family": "holder"
+      },
+      "join_eq_na16_nb16": {
+        "circuit_size": 7025,
+        "family": "join_eq"
+      },
+      "join_eq_na16_nb64": {
+        "circuit_size": 12885,
+        "family": "join_eq"
+      },
+      "join_eq_na64_nb16": {
+        "circuit_size": 12885,
+        "family": "join_eq"
+      },
+      "join_eq_na64_nb64": {
+        "circuit_size": 18681,
+        "family": "join_eq"
+      },
+      "revoke_unset_d10": {
+        "circuit_size": 899,
+        "family": "revocation"
+      },
+      "scan_k1_n16_r4": {
+        "circuit_size": 5991,
+        "family": "scan"
+      },
+      "scan_k1_n16_r8": {
+        "circuit_size": 7038,
+        "family": "scan"
+      },
+      "scan_k1_n64_r4": {
+        "circuit_size": 14923,
+        "family": "scan"
+      },
+      "scan_k1_n64_r8": {
+        "circuit_size": 18850,
+        "family": "scan"
+      },
+      "scan_k2_n16_r4": {
+        "circuit_size": 9254,
+        "family": "scan"
+      },
+      "scan_k2_n16_r8": {
+        "circuit_size": 11261,
+        "family": "scan"
+      },
+      "scan_k2_n64_r4": {
+        "circuit_size": 27054,
+        "family": "scan"
+      },
+      "scan_k2_n64_r8": {
+        "circuit_size": 34821,
+        "family": "scan"
+      }
+    }
+  }
+}

--- a/bench/zk-compose/scripts/eval_pack.py
+++ b/bench/zk-compose/scripts/eval_pack.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+# [FABLE-5] sq-gum8.5: zkSPARQL submission-support — deterministic constraint-count
+# evaluation pack generator.
+#
+# Joins the repo's TWO regression-gated, committed constraint-count sources into a
+# single per-circuit manifest (`bench/zk-compose/eval_pack.json`) the paper's
+# evaluation section can cite as one reproducible artifact:
+#
+#   1. zk/compose circuit family  — crates/sparq-zk-compose/tests/gate_count_snapshot.json
+#      (the in-crate `gate_count_regression` test's baseline; ultra_honk
+#      `circuit_size` per compiled member, per the noir-optimisation skill's
+#      "bb gates is ground truth" rule), cross-checked against
+#      bench/zk-compose/gate_counts_latest.json so the two committed copies can
+#      never silently disagree.
+#   2. zk/ieee754 float library    — zk/ieee754/bench/float_ops_latest.json +
+#      float_conversions_latest.json (small-N/big-N amortised UltraHonk gate
+#      measurements per IEEE-754 operation).
+#
+# What it does NOT do (honesty is load-bearing):
+#
+#   * It re-measures NOTHING. Every number is read from a committed,
+#     regression-gated source; the generator needs no nargo/bb and is therefore
+#     deterministic (same committed inputs -> byte-identical output). To refresh
+#     the underlying counts after an INTENTIONAL circuit change, re-run
+#     bench/zk-compose/scripts/gate_counts.sh (compose) or
+#     zk/ieee754/scripts/benchmark_float_ops.py (ieee754) with the pinned
+#     toolchain, re-baseline those sources, then re-run this generator.
+#   * External systems' figures (ZKLP et al.) are CITED, never re-measured, and
+#     carry `cited_not_remeasured: true` plus the exact bibliographic source.
+#     Cross-system constraint counts are NOT directly comparable (different
+#     proof systems, arithmetisations, and lookup strategies) — the manifest
+#     says so rather than implying a comparison.
+#   * It asserts no security/privacy/soundness property. The circuits measured
+#     here are pre-external-audit (sq-qhy4 open); a gate count is a size fact,
+#     not a soundness claim.
+#
+# Drift guards:
+#
+#   * TOOLCHAIN: the nargo/bb versions recorded inside each measured source must
+#     match the pins in .github/workflows/zk-toolchain.yml (NARGO_VERSION /
+#     BB_VERSION). A toolchain bump without a re-measure fails generation.
+#   * FRESHNESS CHAIN: gate_counts_latest.json must agree member-for-member with
+#     the regression-gated snapshot. A re-baseline that updates one but not the
+#     other fails generation.
+#   * BYTE-IDENTITY (--check): regenerates the manifest in memory and fails if
+#     it differs from the committed bench/zk-compose/eval_pack.json — so a
+#     source-count change that forgets to regenerate the pack is a visible
+#     failure, not silent staleness. Run it after any zk/ re-baseline.
+#
+# Usage:
+#   bench/zk-compose/scripts/eval_pack.py > bench/zk-compose/eval_pack.json
+#   bench/zk-compose/scripts/eval_pack.py --check   # verify committed manifest
+#
+# CI wiring for --check is tracked as follow-up bead sq-yfhho (workflow files
+# are outside this bead's file set); until then it is a documented manual step
+# of the re-baseline procedure above and in bench/zk-compose/README.md.
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.normpath(os.path.join(HERE, "..", "..", ".."))
+
+SNAPSHOT_JSON = os.path.join(ROOT, "crates", "sparq-zk-compose", "tests", "gate_count_snapshot.json")
+LATEST_JSON = os.path.join(ROOT, "bench", "zk-compose", "gate_counts_latest.json")
+FLOAT_OPS_JSON = os.path.join(ROOT, "zk", "ieee754", "bench", "float_ops_latest.json")
+FLOAT_CONV_JSON = os.path.join(ROOT, "zk", "ieee754", "bench", "float_conversions_latest.json")
+TOOLCHAIN_YML = os.path.join(ROOT, ".github", "workflows", "zk-toolchain.yml")
+OUT_JSON = os.path.join(ROOT, "bench", "zk-compose", "eval_pack.json")
+
+# Hashed inputs = the four MEASURED sources only. The toolchain workflow is a
+# guard input (its pins are cross-checked + recorded below) but is deliberately
+# NOT hashed: hashing it would make the manifest churn on unrelated workflow
+# edits (comments, unrelated steps) even though no count changed.
+INPUT_PATHS = {
+    "gate_count_snapshot": SNAPSHOT_JSON,
+    "gate_counts_latest": LATEST_JSON,
+    "ieee754_float_ops": FLOAT_OPS_JSON,
+    "ieee754_float_conversions": FLOAT_CONV_JSON,
+}
+
+
+def die(msg: str) -> None:
+    print(f"eval_pack.py: ERROR: {msg}", file=sys.stderr)
+    sys.exit(2)
+
+
+def load_json(path: str):
+    try:
+        with open(path, encoding="utf-8") as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        die(f"cannot read {os.path.relpath(path, ROOT)}: {e}")
+
+
+def sha256_file(path: str) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def pinned_toolchain() -> dict:
+    """Parse NARGO_VERSION / BB_VERSION pins out of zk-toolchain.yml."""
+    try:
+        with open(TOOLCHAIN_YML, encoding="utf-8") as f:
+            text = f.read()
+    except OSError as e:
+        die(f"cannot read {os.path.relpath(TOOLCHAIN_YML, ROOT)}: {e}")
+    pins = {}
+    for key in ("NARGO_VERSION", "BB_VERSION"):
+        m = re.search(rf'^\s*{key}:\s*"([^"]+)"', text, re.MULTILINE)
+        if not m:
+            die(f"pin {key} not found in zk-toolchain.yml — the parse regex or the workflow moved")
+        pins[key] = m.group(1)
+    return {
+        "nargo": pins["NARGO_VERSION"],
+        "bb": pins["BB_VERSION"],
+        "pinned_in": ".github/workflows/zk-toolchain.yml",
+    }
+
+
+def compose_family(member: str) -> str:
+    for prefix, family in (
+        ("scan_", "scan"),
+        ("join_eq_", "join_eq"),
+        ("filter_value_dl_", "filter_value_dual_leaf"),
+        ("filter_", "filter"),
+        ("holder_", "holder"),
+        ("hidden_issuer", "hidden_issuer"),
+        ("revoke_", "revocation"),
+    ):
+        if member.startswith(prefix):
+            return family
+    return "other"
+
+
+def build_manifest() -> dict:
+    toolchain = pinned_toolchain()
+    snapshot = load_json(SNAPSHOT_JSON)
+    latest = load_json(LATEST_JSON)
+    float_ops = load_json(FLOAT_OPS_JSON)
+    float_conv = load_json(FLOAT_CONV_JSON)
+
+    # --- toolchain drift guard -------------------------------------------------
+    lat_bb = latest.get("bb_version", "")
+    lat_nargo = latest.get("nargo_version", "")
+    if toolchain["bb"] != lat_bb:
+        die(
+            f"toolchain drift: zk-toolchain.yml pins bb {toolchain['bb']} but "
+            f"gate_counts_latest.json was measured with bb {lat_bb!r} — re-run "
+            "bench/zk-compose/scripts/gate_counts.sh with the pinned toolchain and re-baseline"
+        )
+    if toolchain["nargo"] not in lat_nargo:
+        die(
+            f"toolchain drift: zk-toolchain.yml pins nargo {toolchain['nargo']} but "
+            f"gate_counts_latest.json records {lat_nargo!r} — re-run "
+            "bench/zk-compose/scripts/gate_counts.sh with the pinned toolchain and re-baseline"
+        )
+    snap_bb = snapshot.get("bb_version_baselined", "")
+    snap_nargo = snapshot.get("nargo_version_baselined", "")
+    if toolchain["bb"] != snap_bb or toolchain["nargo"] != snap_nargo:
+        die(
+            "toolchain drift: gate_count_snapshot.json was baselined with "
+            f"nargo {snap_nargo!r} / bb {snap_bb!r}, which differs from the "
+            f"zk-toolchain.yml pins (nargo {toolchain['nargo']} / bb {toolchain['bb']})"
+        )
+
+    # --- freshness-chain guard: latest must equal the regression-gated snapshot -
+    snap_members = snapshot.get("members", {})
+    latest_members = {
+        name: row.get("circuit_size") for name, row in latest.get("benchmarks", {}).items()
+    }
+    if snap_members != latest_members:
+        only_snap = sorted(set(snap_members) - set(latest_members))
+        only_latest = sorted(set(latest_members) - set(snap_members))
+        diff_vals = sorted(
+            m
+            for m in set(snap_members) & set(latest_members)
+            if snap_members[m] != latest_members[m]
+        )
+        die(
+            "freshness chain broken: gate_count_snapshot.json and gate_counts_latest.json "
+            f"disagree (snapshot-only: {only_snap}; latest-only: {only_latest}; "
+            f"differing values: {diff_vals}) — re-run gate_counts.sh and re-baseline BOTH"
+        )
+
+    zk_compose = {
+        member: {
+            "circuit_size": size,
+            "family": compose_family(member),
+        }
+        for member, size in sorted(snap_members.items())
+    }
+
+    def op_rows(measured: dict) -> dict:
+        rows = {}
+        for op, row in sorted(measured.get("benchmarks", {}).items()):
+            rows[op] = {
+                "small": row.get("small"),
+                "big": row.get("big"),
+                "per_call_estimate": row.get("per_call_estimate"),
+                "setup_estimate": row.get("setup_estimate"),
+            }
+        return rows
+
+    manifest = {
+        "_schema": "sparq-zk-eval-pack/1",
+        "_provenance": {
+            "generator": "bench/zk-compose/scripts/eval_pack.py [FABLE-5] (sq-gum8.5)",
+            "note": (
+                "Deterministic join of the repo's committed, regression-gated constraint-count "
+                "sources; regenerate with the generator, never hand-edit. No number here is "
+                "re-measured by this script. Counts are ultra_honk circuit_size per `bb gates "
+                "-s ultra_honk` (backend gate count after ACIR->backend transformation). "
+                "The circuits are pre-external-audit (sq-qhy4): a gate count is a size fact, "
+                "not a soundness or privacy claim."
+            ),
+            "inputs_sha256": {
+                name: {
+                    "path": os.path.relpath(path, ROOT),
+                    "sha256": sha256_file(path),
+                }
+                for name, path in sorted(INPUT_PATHS.items())
+            },
+        },
+        "toolchain": toolchain,
+        "zk_compose": {
+            "measured_with": {
+                "tool": latest.get("tool"),
+                "source_timestamp": latest.get("timestamp"),
+                "regression_gate": "crates/sparq-zk-compose/tests/gate_count.rs",
+            },
+            "members": zk_compose,
+        },
+        "ieee754": {
+            "measured_with": {
+                "tool": "bb gates -s ultra_honk via zk/ieee754/scripts/benchmark_float_ops.py",
+                "method": (
+                    "small-N/big-N amortisation: per_call_estimate = "
+                    "(big.circuit_size - small.circuit_size) / (big.calls - small.calls); "
+                    "estimates are derived, circuit_size values are measured"
+                ),
+                "ops_source_timestamp": float_ops.get("timestamp"),
+                "conversions_source_timestamp": float_conv.get("timestamp"),
+                "n_small": float_ops.get("n_small"),
+                "n_big": float_ops.get("n_big"),
+            },
+            "float_ops": op_rows(float_ops),
+            "float_conversions": op_rows(float_conv),
+        },
+        "cited_external": {
+            "_note": (
+                "Figures REPORTED BY THE CITED AUTHORS, reproduced for context only — never "
+                "re-measured here, and NOT directly comparable to the counts above (different "
+                "proof systems, arithmetisations, constraint/gate definitions, and lookup "
+                "strategies). Comparisons in prose must stay qualitative."
+            ),
+            "zklp": {
+                "cited_not_remeasured": True,
+                "citation": (
+                    "Ernstberger, J.; Zhang, C.; Ciprian, L.; Jovanovic, P.; Steinhorst, S. "
+                    "'Zero-Knowledge Location Privacy via Accurate Floating-Point SNARKs'. "
+                    "IEEE S&P 2025, pp. 3440-3459. arXiv:2404.14983; IACR ePrint 2024/1842."
+                ),
+                "constraint_model": (
+                    "R1CS constraints in gnark over BN254 (Groth16/Plonk) with LogUp lookups; "
+                    "the authors report a 'native' count and a 'lookup (i)' count per op, plus "
+                    "a one-time lookup-table cost. NOT the same unit as the UltraHonk "
+                    "circuit_size figures above — do not tabulate side by side as if comparable."
+                ),
+                "reported_figures_source": "ZKLP Table 1 (|T_RC|=2^8), author-reported",
+                "reported_r1cs_constraints": {
+                    "fp32_native": {"init": 13, "add_sub": 42, "mul": 31, "div": 38,
+                                    "sqrt": 23, "cmp": 26},
+                    "fp32_lookup_i": {"init": 17, "add_sub": 43, "mul": 33, "div": 38,
+                                      "sqrt": 22, "cmp": 7, "one_time_ii_iii": 291},
+                    "fp64_native": {"init": 13, "add_sub": 42, "mul": 31, "div": 38,
+                                    "sqrt": 23, "cmp": 26},
+                    "fp64_lookup_i": {"init": 32, "add_sub": 71, "mul": 57, "div": 60,
+                                      "sqrt": 38, "cmp": 11, "one_time_ii_iii": 323},
+                },
+                "reported_amortised_note": (
+                    "ZKLP abstract/section 5.1: about 64 R1CS constraints per operation for "
+                    "2^15 FP32 multiplications (amortised); 209 for 2^1 multiplications."
+                ),
+                "first_claim_guard": (
+                    "ZKLP is peer-reviewed and prior, claiming the first fully-IEEE-754 "
+                    "compliant ZKP circuits. The zkSPARQL submission MUST NOT assert a 'first "
+                    "ZK floats' novelty; its float contribution is the INTEGRATION of "
+                    "in-circuit IEEE-754 into typed SPARQL FILTER evaluation, not the "
+                    "primitives themselves."
+                ),
+            },
+        },
+    }
+    return manifest
+
+
+def render(manifest: dict) -> str:
+    return json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> None:
+    check = "--check" in sys.argv[1:]
+    manifest = build_manifest()
+    out = render(manifest)
+    if check:
+        try:
+            with open(OUT_JSON, encoding="utf-8") as f:
+                committed = f.read()
+        except OSError as e:
+            die(f"--check: cannot read committed manifest {os.path.relpath(OUT_JSON, ROOT)}: {e}")
+        if committed != out:
+            die(
+                "--check: committed eval_pack.json is STALE (differs from a fresh regeneration). "
+                "A constraint-count source changed without regenerating the pack — run "
+                "bench/zk-compose/scripts/eval_pack.py > bench/zk-compose/eval_pack.json "
+                "and commit the result"
+            )
+        print("eval_pack.py --check: OK (committed manifest is byte-identical to regeneration)")
+        return
+    sys.stdout.write(out)
+
+
+if __name__ == "__main__":
+    main()

--- a/site/specs/zksparql.typ
+++ b/site/specs/zksparql.typ
@@ -159,26 +159,46 @@ candidate-normative successor to this draft.
 
 This section is informative.
 
-*Verifiable query evaluation over databases.* IntegriDB #cite("INTEGRIDB") and vSQL
+*Verifiable query evaluation over databases and graphs.* IntegriDB #cite("INTEGRIDB") and vSQL
 #cite("VSQL") prove SQL query answers correct against a committed, outsourced database, and
 ZKSQL #cite("ZKSQL") extends the guarantee to zero knowledge: the answer is proven correct
-while the database's records stay hidden. zkSPARQL targets the same class of guarantee for
-RDF and SPARQL, with three structural differences: the data model is graph-shaped, with blank
-nodes and per-graph canonicalisation (section 6); trust is rooted in *issuer attestation
-signatures* over per-graph commitments rather than in a single data owner's commitment, so
-proofs compose across many small signed graphs (credentials); and the admissibility of a
-proof *method* is itself policy-controlled (section 13). The zkSPARQL manifest is a
-non-interactive object designed to be checked offline against externally supplied trust
-anchors (section 11).
+while the database's records stay hidden. PoneglyphDB #cite("PONEGLYPHDB") gives
+*non-interactive* zero-knowledge proofs of SQL query results (a PLONKish/Halo2 construction
+over relational operators — filters, sorting, group-by, joins), and ZKGraph #cite("ZKGRAPH")
+proves correctness of *graph*-query evaluation without disclosing the graph, targeting
+property-graph/Cypher workloads rather than RDF. In a different guarantee class, VeriDKG
+#cite("VERIDKG") verifies SPARQL results over decentralised knowledge graphs through an
+authenticated data structure — an *integrity and completeness* guarantee that does not hide
+the queried data, so it is complementary to, not comparable with, the confidentiality goal
+of this document. zkSPARQL targets the same class of guarantee as the zero-knowledge systems
+above, for RDF and SPARQL, with three structural differences: the data model is graph-shaped,
+with blank nodes and per-graph canonicalisation (section 6); trust is rooted in *issuer
+attestation signatures* over per-graph commitments rather than in a single data owner's
+commitment, so proofs compose across many small signed graphs (credentials); and the
+admissibility of a proof *method* is itself policy-controlled (section 13). The zkSPARQL
+manifest is a non-interactive object designed to be checked offline against externally
+supplied trust anchors (section 11).
+
+*In-circuit floating-point arithmetic.* The typed `xsd:double` FILTER lane (section 7.1)
+depends on IEEE-754 operations realised inside the circuit. ZKLP #cite("ZKLP") contributes a
+library of IEEE-754-compliant floating-point SNARK circuits (single- and double-precision, in
+an R1CS-with-lookups setting) and is the reference point for this component; the contribution
+of this document is not the float primitives in isolation but their integration into typed
+SPARQL value-filter evaluation over committed RDF. Per-operation constraint counts reported by
+ZKLP are measured in a different proof system and arithmetisation and are *not* directly
+comparable to the UltraHonk gate counts of this estate (section 16).
 
 *Anonymous credentials and selective disclosure.* CL signatures #cite("CL02"), the BBS line
 of multi-message signatures #cite("BBS04"), and the `bbs-2023` / `ecdsa-sd-2023`
 Data-Integrity cryptosuites #cite("VC-DI") let a holder reveal a subset of signed attributes,
-sometimes with simple predicates. zkSPARQL generalises the *statement language*: instead of
-disclosing attribute subsets, the holder proves that a SPARQL query — joins, typed value
-filters, revocation state — evaluates as claimed over the signed data (section 7), without
-disclosing the data. It does not replace credential-level selective disclosure: ingest of
-`bbs-2023` credentials is an explicitly deferred seam (section 15).
+sometimes with simple predicates. zk-creds #cite("ZKCREDS") and Crescent #cite("CRESCENT")
+prove possession of existing, unmodified credentials (e-passports; JWT / ISO mDL) in zero
+knowledge and add selective disclosure without issuer cooperation. zkSPARQL generalises the
+*statement language*: instead of disclosing attribute subsets or proving possession of one
+credential, the holder proves that a SPARQL query — joins, typed value filters, revocation
+state — evaluates as claimed over the signed data (section 7), without disclosing the data.
+It does not replace credential-level selective disclosure: ingest of `bbs-2023` credentials is
+an explicitly deferred seam (section 15).
 
 *Zero-knowledge proofs over RDF and SPARQL.* The annotation and admissibility layer of this
 document (sections 12–13) directly extends the `sec-prop` security-properties vocabulary of
@@ -187,11 +207,16 @@ editor — and the query-proof pipeline shares that work's goal of proving corre
 evaluation over verifiable credentials, realised here with a different commitment scheme,
 circuit family, and manifest format. The research agenda is stated in #cite("WRIGHT-DC25").
 Braun, Wright and Käfer #cite("BWK26") prove soundness of SPARQL query results via
-*selectively disclosed views* of the queried dataset — a disclosure-based mechanism, where
-zkSPARQL keeps the source graphs hidden and proves algebra evaluation in-circuit. The sparq
-estate described here is an engine-integrated implementation with its own manifest format,
-verifier obligation set, and admissibility layer; it is not a wire-compatible implementation
-of any of the above.
+*selectively disclosed views* of the queried dataset — a data-centric mechanism that proves
+properties *about the queried RDF dataset* rather than proving query execution, and is
+correspondingly cheaper. zkSPARQL occupies the opposite point of that trade-off: it keeps the
+source graphs hidden and proves evaluation of the algebra operators in-circuit, accepting the
+higher proving cost in exchange for not disclosing views of the data and for covering operator
+statements (in-circuit joins and typed value filters) to which a disclosure-of-views argument
+does not directly apply. The two are complementary, not competing, and a deployment may choose
+between them per query. The sparq estate described here is an engine-integrated implementation
+with its own manifest format, verifier obligation set, and admissibility layer; it is not a
+wire-compatible implementation of any of the above.
 
 = Terminology and conformance
 
@@ -1036,7 +1061,30 @@ policy — it is not, and must not be presented as, an independent cryptographic
     Security and Privacy, 2017.]),
   ("ZKSQL", [Li, X.; Weng, C.; Xu, Y.; Wang, X.; Rogers, J. #emph[ZKSQL: Verifiable and
     Efficient Query Evaluation with Zero-Knowledge Proofs]. Proceedings of the VLDB Endowment
-    16(8), 1804–1816, 2023.]),
+    16(8), 1804–1816, 2023. DOI 10.14778/3594512.3594513.]),
+  ("PONEGLYPHDB", [Gu, B.; Fang, J.; Nawab, F. #emph[PoneglyphDB: Efficient Non-interactive
+    Zero-Knowledge Proofs for Arbitrary SQL-Query Verification]. Proceedings of the ACM on
+    Management of Data 3(1) (SIGMOD), 2025. DOI 10.1145/3709713.]),
+  ("ZKGRAPH", [Wu, H.; Wei, C.; Wang, Y.; Lin, L.; Leng, Y.; He, S.; Zhao, M.; Wu, H.; Yan, Y.;
+    Zhou, A. #emph[Zero-Knowledge Verifiable Graph Query Evaluation via Expansion-Centric
+    Operator Decomposition]. arXiv:2507.00427, 2025. (Preprint; property-graph / Cypher, not
+    RDF/SPARQL.)]),
+  ("VERIDKG", [Zhou, E.; Guo, S.; Hong, Z.; Jensen, C. S.; Xiao, Y.; Zhang, D.; Liang, J.;
+    Pei, Q. #emph[VeriDKG: A Verifiable SPARQL Query Engine for Decentralized Knowledge
+    Graphs]. Proceedings of the VLDB Endowment 17(4), 912–925, 2023.
+    DOI 10.14778/3636218.3636242. (Integrity and completeness via an authenticated data
+    structure, not zero knowledge.)]),
+  ("ZKLP", [Ernstberger, J.; Zhang, C.; Ciprian, L.; Jovanovic, P.; Steinhorst, S.
+    #emph[Zero-Knowledge Location Privacy via Accurate Floating-Point SNARKs]. IEEE Symposium
+    on Security and Privacy (S&P), 3440–3459, 2025. arXiv:2404.14983; IACR ePrint 2024/1842.
+    (Contributes IEEE-754-compliant f32/f64 SNARK circuits; constraint counts are R1CS with
+    lookups, not directly comparable to UltraHonk gates.)]),
+  ("ZKCREDS", [Rosenberg, M.; White, J.; Garman, C.; Miers, I. #emph[zk-creds: Flexible
+    Anonymous Credentials from zkSNARKs and Existing Identity Infrastructure]. IEEE Symposium
+    on Security and Privacy (S&P), 1882–1900, 2023. IACR ePrint 2022/878.]),
+  ("CRESCENT", [Paquin, C.; Policharla, G.-V.; Zaverucha, G. #emph[Crescent: Stronger Privacy
+    for Existing Credentials]. IACR Cryptology ePrint Archive, Paper 2024/2013, 2024.
+    (Preprint at the time of writing.)]),
   ("CL02", [Camenisch, J.; Lysyanskaya, A. #emph[A Signature Scheme with Efficient
     Protocols]. SCN 2002, LNCS 2576, Springer, 2003.]),
   ("BBS04", [Boneh, D.; Boyen, X.; Shacham, H. #emph[Short Group Signatures]. CRYPTO 2004,


### PR DESCRIPTION
> 🤖 **SPARQ agent** — research/design-support work on bead **sq-gum8.5**, model tier **Fable 5** (commits trailered accordingly). @jeswr runs multiple agents on one account.

## Maintainer arms this PR

**MAINTAINER-ARM (live-submission ZK surface).** This is submission support for the LIVE zkSPARQL ISWC 2026 submission ([zksparql.org](https://zksparql.org/); notification 2026-07-16). Per the bead label and the review-discipline for the ZK surface, **the maintainer arms this PR** — no fleet auto-arm, no `--auto`. It does not rewrite the paper; it hardens the in-repo spec's related-work section and adds a reproducible evaluation artifact for the authors' rebuttal / camera-ready readiness.

## Honesty scope

Everything is scoped **design + implementation, pre-external-audit**. The ZK verifier + Noir circuits have NOT completed external accredited-cryptographer review (**sq-qhy4** open; forge/soundness tests toolchain-gated, sq-1gir). A constraint/gate count is a *size* fact, not a soundness or privacy result — nothing here asserts any security/privacy/soundness property as achieved.

## 1. Related-work hardening — `site/specs/zksparql.typ`

Cited + differentiated, with citations **verified against primary sources** (venues, DOIs, and key quotes traced):

- **ZKLP** (Ernstberger et al., IEEE S&P 2025) — first IEEE-754-compliant ZK float circuits. The submission **must not** claim "first ZK floats"; the float contribution is scoped to *integration into typed SPARQL FILTER evaluation*.
- **ZKGraph** (arXiv:2507.00427, 2025, preprint) — ZK graph-query eval, **property-graph/Cypher, not RDF/SPARQL**; self-claims "first ZK arbitrary graph queries" so it is cited to scope our novelty.
- **PoneglyphDB** (SIGMOD 2025) — non-interactive ZK SQL; no NULL/3VL/outer-join handling.
- **VeriDKG** (PVLDB 17(4), 2023) — SPARQL verifiability via an authenticated data structure, **integrity-not-ZK**; cited so "SPARQL verifiability already exists" is answered, not left open.
- **zk-creds** (S&P 2023) / **Crescent** (ePrint 2024/2013, preprint) — credential-possession ZK; zkSPARQL generalises the *statement language* to query evaluation.
- **Braun–Wright–Käfer** (ESWC 2026) — the authors' own data-centric soundness line, which reports a large speed advantage over proving execution; strengthened self-delta with the **complementary-trade-off** framing (hide-the-graph vs disclose-views).

`bench/zk-compose/RELATED-WORK-DELTA.md` is the longer working record with the per-work evidence + the recommended claim-wording changes.

## 2. Deterministic constraint-count evaluation pack — `bench/zk-compose/`

- `scripts/eval_pack.py` → `eval_pack.json`: a **deterministic join** (needs no `nargo`/`bb`, re-measures nothing) of the repo's committed, regression-gated count sources (`gate_count_snapshot.json` cross-checked against `gate_counts_latest.json`, plus the `zk/ieee754` float benches).
- **Fail-closed drift guards** (all verified to exit non-zero): toolchain-drift vs the `.github/workflows/zk-toolchain.yml` pins, freshness-chain (snapshot == latest), and `--check` byte-identity (a source re-baseline that forgets to regenerate the pack fails visibly).
- ZKLP figures appear only under `cited_external` with `cited_not_remeasured: true` and an explicit **not-directly-comparable** note (R1CS+LogUp vs UltraHonk) — never tabulated beside the sparq counts.

CI wiring of `eval_pack.py --check` into the zk-toolchain lane is a follow-up (workflow files were outside this bead's file set): **sq-yfhho**.

## Top claim-wording finding for the authors

The live landing page advertises a fragment "BGP, Join, Filter, OPTIONAL, UNION, bounded property paths, EXISTS, NOT EXISTS, MINUS", but the in-repo spec (§7.1) explicitly **excludes** OPTIONAL/UNION/property-paths/aggregation/subqueries and the compiled circuit family (`zk/compose/`, enumerated in `eval_pack.json`) has **no** OPTIONAL/UNION/property-path/EXISTS/MINUS circuit today. The two documents should be reconciled (proof-carrying-today vs specified-but-not-yet-circuit) before a reviewer treats the gap as an overclaim. Details in `RELATED-WORK-DELTA.md`.

## Gates

Green locally: `typst compile site/specs/zksparql.typ`, `scripts/check-privacy-claims.sh`, `scripts/check-no-perf-numbers.py --enforce site/specs/zksparql.typ`, `eval_pack.py --check` (byte-identical), markdownlint. Files touched are the disjoint set the bead names: `site/specs/zksparql.typ` + `bench/zk-compose/**` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)