### PR TITLE
feat(server): freeze the HTTP wire + error contract — versioned doc + served-surface snapshot tests (sq-fdurb) [FABLE-5]

### DIFF
--- a/crates/sparq-server/README.md
+++ b/crates/sparq-server/README.md
@@ -106,8 +106,8 @@ every update is WAL-fsync'd **before the `204` ack** (restart replays the WAL, n
   status code, the full auth × bind matrix, each hardening cap's honest semantics, CORS, audit
   sinks, TPF/brTPF, SHACL, federation discovery, the container image) and
   [`SUBSCRIPTIONS.md`](SUBSCRIPTIONS.md) (the subscription protocol).
-- **API reference** — [docs.rs/sparq-server](https://docs.rs/sparq-server) (incl. the versioned
-  `status_contract` retry doc).
+- **Wire contract** — [`docs/http-wire-contract.md`](../../docs/http-wire-contract.md): the versioned v1
+  HTTP surface + wire-semver policy, pinned by `tests/wire_contract.rs` (ratification pending, gh-1416). **API reference** — [docs.rs/sparq-server](https://docs.rs/sparq-server).
 - **Design** — [`research/concurrent-serving.md`](../../research/concurrent-serving.md)
   (generation-ring + sequenced-writer) and
   [`research/adr-horizontal-scaling.md`](../../research/adr-horizontal-scaling.md) (the non-goal).

--- a/crates/sparq-server/src/status_contract.rs
+++ b/crates/sparq-server/src/status_contract.rs
@@ -45,8 +45,9 @@
 //! | `400 Bad Request` | malformed query / malformed UPDATE / malformed RDF body / malformed TPF pattern / `GET /sparql` with no `query` / unparsable `?generation` / not-yet-published generation | **permanent** | fix the request; do **not** retry as-is |
 //! | `401 Unauthorized` | a write (or, with `--auth-token-read`, a read) without a valid Bearer token; carries `WWW-Authenticate: Bearer` + `Cache-Control: no-store`; **byte-identical for a missing vs a wrong token** | **permanent** | obtain/correct the token; do **not** retry as-is |
 //! | `403 Forbidden` | (`service` feature) a non-`SILENT` `SERVICE` to a host the egress **allowlist** / default-deny SSRF policy refused (`--service-allow` / `SPARQ_SERVICE_ALLOW`, `sq-4w18`/`sq-iu0c`) -- a **policy** refusal, NOT a server fault | **permanent** | the endpoint is off the server's egress allowlist; do **not** retry -- ask the operator to allowlist it (or use `SERVICE SILENT` to tolerate the refusal) |
-//! | `404 Not Found` | unknown route / GSP `GET` of a named graph that does not exist | **permanent** | -- |
+//! | `404 Not Found` | unknown route / GSP `DELETE` of a named graph that does not exist (a GSP `GET` of an absent named graph serves the EMPTY graph -- `200`, empty body -- it does not `404`; pinned by `tests/protocol.rs` + `tests/wire_contract.rs`) [FABLE-5] sq-fdurb | **permanent** | -- |
 //! | `405 Method Not Allowed` | method not allowed on the route; carries `Allow` | **permanent** | use a listed method |
+//! | `406 Not Acceptable` | a PRESENT, non-empty `Accept` naming no supported result media type and no wildcard (both result classes: SELECT/ASK and CONSTRUCT/DESCRIBE; absent / empty / `*/*` keeps the default, never a `406`) [FABLE-5] sq-fdurb | **permanent** | send a supported `Accept` (or none) |
 //! | `410 Gone` | (`time-travel` feature) `?generation=N` aged out of the retention window | **permanent** | the snapshot is gone; do not retry that pin |
 //! | `413 Payload Too Large` | request **body** over `--max-body-bytes`; **result** over `--max-results` / `--max-query-rows` (row) / `--max-query-bytes` (byte-accounted, `sq-s5is`) working-set cap; gzip body over the `--max-decompress-ratio` zip-bomb cap | **permanent for the identical request** | narrow the query (e.g. add `LIMIT` / project fewer variables) or shrink the body -- retrying the same request fails identically |
 //! | `415 Unsupported Media Type` | POST query/update with an unsupported `Content-Type` | **permanent** | send a supported content type |
@@ -64,7 +65,7 @@
 //!     retry once durability recovers is safe and will not double-apply), and a subscription
 //!     **capacity** refusal.
 //! - **Permanent (retrying the identical request cannot help):** everything else --
-//!   `400` / `401` / `403` / `404` / `405` / `410` / `413` / `415`.
+//!   `400` / `401` / `403` / `404` / `405` / `406` / `410` / `413` / `415`.
 //!   - **`403` is a policy refusal, not a fault.** A blocked `SERVICE` (egress allowlist) is a
 //!     deliberate authorization decision; the same query against the same server config is
 //!     refused every time. Retrying does not help -- the host must be allowlisted (or the
@@ -98,7 +99,9 @@
 //!   HTTP layer with a hard grace even if the engine is mid-stretch, on *all* request forms
 //!   (query, GSP-read and UPDATE), so a slow request cannot hang a client past the deadline.
 //!
-//! See also: the README "Security posture" (auth, bind, header and error-leak posture),
+//! See also: `docs/http-wire-contract.md` (the versioned v1 HTTP wire contract this table is
+//! part of, pinned end-to-end by `tests/wire_contract.rs` -- [FABLE-5] sq-fdurb, gh-1416),
+//! the README "Security posture" (auth, bind, header and error-leak posture),
 //! `skills/http-server/SKILL.md` (the full endpoint + hardening reference), and the inline
 //! `engine_error_response` / `update_rejection_response` / `timeout_response` mappers in
 //! [`crate::http`] that this contract describes.

--- a/crates/sparq-server/tests/wire_contract.rs
+++ b/crates/sparq-server/tests/wire_contract.rs
@@ -1,0 +1,789 @@
+//! [FABLE-5] (sq-fdurb, gh-1416) **Served-surface snapshot suite for the v1 HTTP wire
+//! contract** — `docs/http-wire-contract.md`.
+//!
+//! Pins the wire surface an HTTP-only consumer (the PSS ask, #1416) relies on, AS DOCUMENTED:
+//! for each frozen endpoint behaviour and each documented error class it asserts the exact
+//! status code, the body shape (`{"error":…}` envelope / SPARQL Results JSON envelope), and
+//! the exact emitted `Content-Type` string — against the REAL hardened router (in-process
+//! ephemeral-port server, no external network). Fail-closed: if the server ever answers
+//! differently from the contract document, this suite goes red before the drift can mislead
+//! a consumer.
+//!
+//! Deliberate overlap with `tests/status_contract.rs` (the transient-vs-permanent retry twin)
+//! is the point of a snapshot suite: each documented error class gets ONE direct test HERE,
+//! keyed to the contract table, so the wire doc is self-contained and self-enforcing.
+//!
+//! Gated on the `server` feature (the pure-serialiser `--no-default-features` build compiles
+//! this file out). The `403`/`410` classes exist only under the `service` / `time-travel`
+//! cargo features and are pinned under matching `cfg`. 🤖 SPARQ agent.
+
+#![cfg(feature = "server")]
+
+use std::time::Duration;
+
+use sparq_core::Graph;
+use sparq_server::{harden, router, AppState, ServerConfig};
+use tokio::net::TcpListener;
+
+const DATA: &str = r#"
+    @prefix ex: <http://ex/> .
+    ex:alice ex:knows ex:bob ; ex:age 30 .
+    ex:bob   ex:age 25 .
+"#;
+
+/// Boots the REAL production stack (`harden(router(..))`) over `ttl` with `config`;
+/// returns the base URL. Same idiom as `tests/status_contract.rs`.
+async fn spawn_with(ttl: &str, config: ServerConfig) -> String {
+    let graph = Graph::load_str(ttl, "turtle").unwrap();
+    let app = harden(
+        router(AppState::with_config(graph, config)),
+        &ServerConfig::default(),
+    );
+    serve(app).await
+}
+
+async fn serve(app: axum::Router) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    format!("http://{addr}")
+}
+
+async fn spawn_default() -> String {
+    spawn_with(DATA, ServerConfig::default()).await
+}
+
+fn client() -> reqwest::Client {
+    reqwest::Client::new()
+}
+
+fn content_type(resp: &reqwest::Response) -> String {
+    resp.headers()
+        .get("content-type")
+        .map(|v| v.to_str().unwrap().to_string())
+        .unwrap_or_default()
+}
+
+/// Contract §6: every error body is the structured `{"error":"…"}` JSON envelope.
+async fn assert_error_envelope(resp: reqwest::Response) -> serde_json::Value {
+    let ct = content_type(&resp);
+    assert!(
+        ct.starts_with("application/json"),
+        "error Content-Type must be application/json, got: {ct}"
+    );
+    let body = resp.text().await.unwrap();
+    assert!(
+        body.starts_with("{\"error\":"),
+        "error body must be the {{\"error\":…}} envelope, got: {body}"
+    );
+    serde_json::from_str(&body).unwrap()
+}
+
+// ===========================================================================
+// Contract §1 — SPARQL 1.1 Protocol request forms at /sparql
+// ===========================================================================
+
+/// GET ?query= → 200, the SPARQL Results JSON default, and the documented SELECT envelope
+/// (`head.vars` + `results.bindings`).
+#[tokio::test]
+async fn get_query_defaults_to_results_json_envelope() {
+    let base = spawn_default().await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT ?s WHERE { ?s <http://ex/age> ?a }")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(
+        content_type(&resp),
+        "application/sparql-results+json",
+        "no-Accept default is the exact SPARQL Results JSON content type"
+    );
+    let v: serde_json::Value = resp.json().await.unwrap();
+    assert!(v["head"]["vars"].is_array(), "SELECT envelope has head.vars: {v}");
+    assert_eq!(
+        v["results"]["bindings"].as_array().unwrap().len(),
+        2,
+        "SELECT envelope has results.bindings: {v}"
+    );
+}
+
+/// POST with body = query (`application/sparql-query`) → 200.
+#[tokio::test]
+async fn post_direct_query_is_200() {
+    let base = spawn_default().await;
+    let resp = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .body("SELECT ?s WHERE { ?s ?p ?o }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(content_type(&resp), "application/sparql-results+json");
+}
+
+/// POST url-encoded form with a `query` field → 200.
+#[tokio::test]
+async fn post_form_query_is_200() {
+    let base = spawn_default().await;
+    let resp = client()
+        .post(format!("{base}/sparql"))
+        .form(&[("query", "SELECT ?s WHERE { ?s ?p ?o }")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(content_type(&resp), "application/sparql-results+json");
+}
+
+/// The query-only HTTP QUERY method: a query body → 200; an update body → 415 (query-only by
+/// contract).
+#[tokio::test]
+async fn query_method_is_query_only() {
+    let base = spawn_default().await;
+    let ok = client()
+        .request(
+            reqwest::Method::from_bytes(b"QUERY").unwrap(),
+            format!("{base}/sparql"),
+        )
+        .header("content-type", "application/sparql-query")
+        .body("SELECT ?s WHERE { ?s ?p ?o }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(ok.status().as_u16(), 200, "QUERY runs a query like POST");
+
+    let update = client()
+        .request(
+            reqwest::Method::from_bytes(b"QUERY").unwrap(),
+            format!("{base}/sparql"),
+        )
+        .header("content-type", "application/sparql-update")
+        .body("INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(update.status().as_u16(), 415, "QUERY refuses an update body");
+    assert_error_envelope(update).await;
+}
+
+/// A successful update (both request forms) → 204 with an EMPTY body, atomically.
+#[tokio::test]
+async fn update_success_is_204_empty() {
+    let base = spawn_default().await;
+    let direct = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-update")
+        .body("INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(direct.status().as_u16(), 204);
+    assert!(direct.text().await.unwrap().is_empty(), "204 body is empty");
+
+    let form = client()
+        .post(format!("{base}/sparql"))
+        .form(&[("update", "INSERT DATA { <http://ex/s2> <http://ex/p> <http://ex/o> }")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(form.status().as_u16(), 204, "form-encoded update= also commits");
+}
+
+// ===========================================================================
+// Contract §2 — result media types & negotiation
+// ===========================================================================
+
+/// The SELECT negotiation table: each supported Accept yields its EXACT documented
+/// Content-Type string.
+#[tokio::test]
+async fn select_negotiation_emits_exact_content_types() {
+    let base = spawn_default().await;
+    for (accept, expect) in [
+        ("application/sparql-results+json", "application/sparql-results+json"),
+        ("application/json", "application/sparql-results+json"),
+        ("application/sparql-results+xml", "application/sparql-results+xml"),
+        ("text/csv", "text/csv; charset=utf-8"),
+        (
+            "text/tab-separated-values",
+            "text/tab-separated-values; charset=utf-8",
+        ),
+        ("*/*", "application/sparql-results+json"),
+    ] {
+        let resp = client()
+            .get(format!("{base}/sparql"))
+            .header("accept", accept)
+            .query(&[("query", "SELECT ?s WHERE { ?s ?p ?o }")])
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 200, "Accept: {accept}");
+        assert_eq!(content_type(&resp), expect, "Accept: {accept}");
+    }
+}
+
+/// The ASK envelope (`head` + `boolean`), and the no-boolean-CSV rule: a CSV Accept on an
+/// ASK yields the JSON boolean form.
+#[tokio::test]
+async fn ask_envelope_and_csv_fallback() {
+    let base = spawn_default().await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "ASK { ?s <http://ex/age> ?a }")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(content_type(&resp), "application/sparql-results+json");
+    let v: serde_json::Value = resp.json().await.unwrap();
+    assert!(v["head"].is_object(), "ASK envelope has head: {v}");
+    assert_eq!(v["boolean"], serde_json::Value::Bool(true), "ASK envelope has boolean: {v}");
+
+    let csv = client()
+        .get(format!("{base}/sparql"))
+        .header("accept", "text/csv")
+        .query(&[("query", "ASK { ?s <http://ex/age> ?a }")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(csv.status().as_u16(), 200);
+    assert_eq!(
+        content_type(&csv),
+        "application/sparql-results+json",
+        "ASK has no CSV form; falls back to the JSON boolean"
+    );
+}
+
+/// The CONSTRUCT/DESCRIBE negotiation table, including the N-Triples default.
+#[tokio::test]
+async fn graph_negotiation_emits_exact_content_types() {
+    let base = spawn_default().await;
+    let mut cases = vec![
+        (None, "application/n-triples; charset=utf-8"),
+        (Some("*/*"), "application/n-triples; charset=utf-8"),
+        (Some("application/n-triples"), "application/n-triples; charset=utf-8"),
+        (Some("text/turtle"), "text/turtle; charset=utf-8"),
+        (Some("application/rdf+xml"), "application/rdf+xml; charset=utf-8"),
+    ];
+    #[cfg(feature = "jsonld")]
+    cases.push((Some("application/ld+json"), "application/ld+json; charset=utf-8"));
+    for (accept, expect) in cases {
+        let mut req = client()
+            .get(format!("{base}/sparql"))
+            .query(&[("query", "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }")]);
+        if let Some(a) = accept {
+            req = req.header("accept", a);
+        }
+        let resp = req.send().await.unwrap();
+        assert_eq!(resp.status().as_u16(), 200, "Accept: {accept:?}");
+        assert_eq!(content_type(&resp), expect, "Accept: {accept:?}");
+    }
+}
+
+// ===========================================================================
+// Contract §3 — Graph Store Protocol
+// ===========================================================================
+
+/// The GSP write/read/delete cycle over indirect addressing pins the documented statuses:
+/// PUT-create 201, GET 200 (N-Triples default), PUT-replace 204, DELETE 204, then GET 404.
+#[tokio::test]
+async fn gsp_indirect_lifecycle_statuses() {
+    let base = spawn_default().await;
+    let cl = client();
+    let graph = format!("{base}/sparql/graph");
+    let iri = [("graph", "http://ex/g1")];
+
+    let created = cl
+        .put(&graph)
+        .query(&iri)
+        .header("content-type", "text/turtle")
+        .body("<http://ex/a> <http://ex/b> <http://ex/c> .")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status().as_u16(), 201, "PUT of an absent graph creates → 201");
+
+    let read = cl.get(&graph).query(&iri).send().await.unwrap();
+    assert_eq!(read.status().as_u16(), 200);
+    assert_eq!(
+        content_type(&read),
+        "application/n-triples; charset=utf-8",
+        "GSP read defaults to N-Triples"
+    );
+
+    let replaced = cl
+        .put(&graph)
+        .query(&iri)
+        .header("content-type", "text/turtle")
+        .body("<http://ex/a> <http://ex/b> <http://ex/d> .")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(replaced.status().as_u16(), 204, "PUT of an existing graph replaces → 204");
+
+    let merged = cl
+        .post(&graph)
+        .query(&iri)
+        .header("content-type", "text/turtle")
+        .body("<http://ex/a> <http://ex/b> <http://ex/e> .")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(merged.status().as_u16(), 204, "POST merges into an existing graph → 204");
+
+    let dropped = cl.delete(&graph).query(&iri).send().await.unwrap();
+    assert_eq!(dropped.status().as_u16(), 204, "DELETE of an existing named graph → 204");
+
+    // As-implemented: a GET of an absent named graph serves the EMPTY graph (200), it does
+    // not 404 (pinned since tests/protocol.rs `gsp_delete_then_get_and_404`); the absent-graph
+    // 404 arises on DELETE.
+    let empty = cl.get(&graph).query(&iri).send().await.unwrap();
+    assert_eq!(empty.status().as_u16(), 200, "GET of an absent named graph serves empty");
+    assert_eq!(empty.text().await.unwrap().trim(), "");
+    let gone = cl.delete(&graph).query(&iri).send().await.unwrap();
+    assert_eq!(gone.status().as_u16(), 404, "DELETE of an absent named graph → 404");
+    assert_error_envelope(gone).await;
+}
+
+/// GSP PATCH with an always-on `application/sparql-update` body applies atomically → 204;
+/// an unsupported PATCH body type → 415.
+#[tokio::test]
+async fn gsp_patch_sparql_update_dialect() {
+    let base = spawn_default().await;
+    let cl = client();
+    let graph = format!("{base}/sparql/graph");
+    let iri = [("graph", "http://ex/g2")];
+    let put = cl
+        .put(&graph)
+        .query(&iri)
+        .header("content-type", "text/turtle")
+        .body("<http://ex/a> <http://ex/b> <http://ex/c> .")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(put.status().as_u16(), 201);
+
+    let patch = cl
+        .patch(&graph)
+        .query(&iri)
+        .header("content-type", "application/sparql-update")
+        .body("INSERT DATA { <http://ex/a> <http://ex/b> <http://ex/f> }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(patch.status().as_u16(), 204, "sparql-update PATCH dialect is always-on → 204");
+
+    let bad = cl
+        .patch(&graph)
+        .query(&iri)
+        .header("content-type", "application/pdf")
+        .body("nonsense")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(bad.status().as_u16(), 415, "an unsupported PATCH body type → 415");
+    assert_error_envelope(bad).await;
+}
+
+/// Direct addressing (`/graphs/{path}`) serves the same lifecycle as indirect.
+#[tokio::test]
+async fn gsp_direct_addressing_works() {
+    let base = spawn_default().await;
+    let cl = client();
+    let url = format!("{base}/graphs/people/g3");
+    let created = cl
+        .put(&url)
+        .header("content-type", "text/turtle")
+        .body("<http://ex/a> <http://ex/b> <http://ex/c> .")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(created.status().as_u16(), 201, "direct PUT creates → 201");
+    let read = cl.get(&url).send().await.unwrap();
+    assert_eq!(read.status().as_u16(), 200);
+    assert_eq!(content_type(&read), "application/n-triples; charset=utf-8");
+}
+
+// ===========================================================================
+// Contract §4 — /health
+// ===========================================================================
+
+/// GET /health → 200 with the exact plain-text body `ok`, never auth-gated.
+#[tokio::test]
+async fn health_is_200_ok_and_never_gated() {
+    let config = ServerConfig {
+        auth_token: Some("s3cr3t".to_string()),
+        auth_token_read: true,
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(DATA, config).await;
+    let resp = client().get(format!("{base}/health")).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 200);
+    assert_eq!(resp.text().await.unwrap(), "ok");
+}
+
+// ===========================================================================
+// Contract §5 + §6 — the error taxonomy, one direct test per documented class
+// ===========================================================================
+
+/// 400 — a malformed query is a permanent client error in the JSON envelope.
+#[tokio::test]
+async fn class_400_malformed_query() {
+    let base = spawn_default().await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT ?s WHERE { broken")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+    assert_error_envelope(resp).await;
+}
+
+/// 400 — GET /sparql with no `query` parameter (the default build has no Service Description).
+#[tokio::test]
+async fn class_400_missing_query_param() {
+    let base = spawn_default().await;
+    let resp = client().get(format!("{base}/sparql")).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+    assert_error_envelope(resp).await;
+}
+
+/// 401 — a gated write without a token: WWW-Authenticate + no-store headers, and the
+/// missing-token and wrong-token responses are byte-identical (no oracle).
+#[tokio::test]
+async fn class_401_bearer_gate() {
+    let config = ServerConfig {
+        auth_token: Some("s3cr3t".to_string()),
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(DATA, config).await;
+    let send = |auth: Option<&'static str>| {
+        let cl = client();
+        let base = base.clone();
+        async move {
+            let mut req = cl
+                .post(format!("{base}/sparql"))
+                .header("content-type", "application/sparql-update")
+                .body("INSERT DATA { <http://ex/s> <http://ex/p> <http://ex/o> }");
+            if let Some(a) = auth {
+                req = req.header("authorization", a);
+            }
+            req.send().await.unwrap()
+        }
+    };
+    let missing = send(None).await;
+    assert_eq!(missing.status().as_u16(), 401);
+    assert_eq!(
+        missing.headers().get("www-authenticate").map(|v| v.to_str().unwrap()),
+        Some("Bearer"),
+        "401 carries WWW-Authenticate: Bearer"
+    );
+    assert_eq!(
+        missing.headers().get("cache-control").map(|v| v.to_str().unwrap()),
+        Some("no-store"),
+        "401 carries Cache-Control: no-store"
+    );
+    let missing_body = missing.text().await.unwrap();
+    let wrong = send(Some("Bearer wrong")).await;
+    assert_eq!(wrong.status().as_u16(), 401);
+    assert_eq!(
+        wrong.text().await.unwrap(),
+        missing_body,
+        "missing vs wrong token is byte-identical"
+    );
+}
+
+/// 403 — (`service` feature) a blocked SERVICE egress is a permanent POLICY refusal carrying
+/// the documented `egress allowlist` sentinel, with the refused host sanitised out.
+#[cfg(feature = "service")]
+#[tokio::test]
+async fn class_403_blocked_service_egress() {
+    let config = ServerConfig {
+        query_timeout: Some(Duration::from_secs(2)),
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(DATA, config).await;
+    let q = "SELECT ?s WHERE { ?s <http://ex/age> ?a . \
+             SERVICE <http://127.0.0.1:9/> { ?s <http://ex/name> ?n } }";
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", q)])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 403);
+    let v = assert_error_envelope(resp).await;
+    let msg = v["error"].as_str().unwrap().to_lowercase();
+    assert!(msg.contains("egress allowlist"), "documented sentinel: {msg}");
+    assert!(!msg.contains("127.0.0.1"), "refused host is sanitised out: {msg}");
+}
+
+/// 404 — an unknown route answers the fixed, leak-free `not found` class.
+#[tokio::test]
+async fn class_404_unknown_route() {
+    let base = spawn_default().await;
+    let resp = client()
+        .get(format!("{base}/definitely-not-a-route"))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 404);
+    let v = assert_error_envelope(resp).await;
+    assert_eq!(v["error"], "not found", "documented fixed 404 class");
+}
+
+/// 405 — a wrong method carries the `Allow` header.
+#[tokio::test]
+async fn class_405_carries_allow() {
+    let base = spawn_default().await;
+    let resp = client().post(format!("{base}/health")).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 405);
+    assert!(resp.headers().contains_key("allow"), "405 carries Allow");
+}
+
+/// 406 — a present-but-unsatisfiable Accept is Not Acceptable for BOTH result classes
+/// (SELECT and CONSTRUCT), while absent/wildcard keeps the default (never a 406).
+#[tokio::test]
+async fn class_406_unsatisfiable_accept() {
+    let base = spawn_default().await;
+    for query in [
+        "SELECT ?s WHERE { ?s ?p ?o }",
+        "CONSTRUCT { ?s ?p ?o } WHERE { ?s ?p ?o }",
+    ] {
+        let resp = client()
+            .get(format!("{base}/sparql"))
+            .header("accept", "image/png")
+            .query(&[("query", query)])
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 406, "unsatisfiable Accept on: {query}");
+        assert_error_envelope(resp).await;
+        let ok = client()
+            .get(format!("{base}/sparql"))
+            .header("accept", "image/png, */*")
+            .query(&[("query", query)])
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(ok.status().as_u16(), 200, "a wildcard rescues: {query}");
+    }
+}
+
+/// 410 — (`time-travel` feature) an aged-out `?generation` pin is Gone, with the documented
+/// `aged out` sentinel.
+#[cfg(feature = "time-travel")]
+#[tokio::test]
+async fn class_410_aged_out_generation() {
+    let config = ServerConfig {
+        time_travel_generations: 2,
+        ..ServerConfig::default()
+    };
+    let base = spawn_with("", config).await;
+    let cl = client();
+    for i in 1..=6usize {
+        let resp = cl
+            .post(format!("{base}/sparql"))
+            .header("content-type", "application/sparql-update")
+            .body(format!(
+                "INSERT DATA {{ <http://ex/u{i}> <http://ex/seen> <http://ex/y> }}"
+            ))
+            .send()
+            .await
+            .unwrap();
+        assert_eq!(resp.status().as_u16(), 204);
+    }
+    let resp = cl
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT ?s WHERE { ?s ?p ?o }"), ("generation", "1")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 410);
+    let v = assert_error_envelope(resp).await;
+    assert!(
+        v["error"].as_str().unwrap().contains("aged out"),
+        "documented sentinel: {v}"
+    );
+}
+
+/// 413 — a request body over the cap is a permanent refusal.
+#[tokio::test]
+async fn class_413_body_cap() {
+    let config = ServerConfig {
+        max_body_bytes: 128,
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(DATA, config).await;
+    let resp = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "application/sparql-query")
+        .body(format!("SELECT * WHERE {{ ?s ?p ?o }} # {}", "x".repeat(512)))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 413);
+    assert_error_envelope(resp).await;
+}
+
+/// 413 — a result over the row cap is the HONEST-REFUSAL class: no truncated rows, and the
+/// documented `row limit` sentinel.
+#[tokio::test]
+async fn class_413_row_cap_honest_refusal() {
+    let config = ServerConfig {
+        max_results: Some(1),
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(DATA, config).await;
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", "SELECT ?s WHERE { ?s <http://ex/age> ?a }")])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 413);
+    let v = assert_error_envelope(resp).await;
+    let msg = v["error"].as_str().unwrap();
+    assert!(msg.contains("row limit"), "documented sentinel: {msg}");
+    assert!(!msg.contains("bindings"), "refusal, never truncation: {msg}");
+}
+
+/// 415 — an unsupported POST Content-Type on /sparql.
+#[tokio::test]
+async fn class_415_unsupported_media_type() {
+    let base = spawn_default().await;
+    let resp = client()
+        .post(format!("{base}/sparql"))
+        .header("content-type", "text/plain")
+        .body("SELECT * WHERE { ?s ?p ?o }")
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 415);
+    assert_error_envelope(resp).await;
+}
+
+/// 429 — the concurrency cap sheds a second in-flight request (the TRANSIENT class: the shed
+/// request never ran).
+#[tokio::test]
+async fn class_429_concurrency_shed() {
+    // A dense graph whose 3-way cross-product never finishes within the budget.
+    let mut ttl = String::from("@prefix ex: <http://ex/> .\n");
+    for i in 0..60 {
+        for j in 0..60 {
+            ttl.push_str(&format!("ex:n{i} ex:e ex:n{j} .\n"));
+        }
+    }
+    const SLOW: &str = "PREFIX ex: <http://ex/> SELECT * WHERE { ?a ex:e ?b . ?c ex:e ?d . ?e ex:e ?f }";
+    let config = ServerConfig {
+        max_concurrent: 1,
+        query_timeout: Some(Duration::from_secs(30)),
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(&ttl, config).await;
+    let busy = base.clone();
+    tokio::spawn(async move {
+        let _ = client()
+            .get(format!("{busy}/sparql"))
+            .query(&[("query", SLOW)])
+            .send()
+            .await;
+    });
+    let mut shed = None;
+    for _ in 0..50 {
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        let resp = client()
+            .get(format!("{base}/sparql"))
+            .query(&[("query", "SELECT ?s WHERE { ?s <http://ex/e> ?o } LIMIT 1")])
+            .send()
+            .await
+            .unwrap();
+        if resp.status().as_u16() == 429 {
+            shed = Some(resp);
+            break;
+        }
+    }
+    let resp = shed.expect("the second in-flight request must shed with 429");
+    assert_error_envelope(resp).await;
+}
+
+/// 500 — a caught handler panic maps to the defect class through the production middleware,
+/// keeping the connection alive (same wrap idiom as tests/hardening.rs; the stock routes have
+/// no reachable panic, which is the point of the class being a defect signal).
+#[tokio::test]
+async fn class_500_caught_panic() {
+    async fn panicking() -> &'static str {
+        panic!("boom")
+    }
+    let app = harden(
+        axum::Router::new().route("/panic", axum::routing::get(panicking)),
+        &ServerConfig::default(),
+    );
+    let base = serve(app).await;
+    let cl = client();
+    let resp = cl.get(format!("{base}/panic")).send().await.unwrap();
+    assert_eq!(resp.status().as_u16(), 500);
+    assert_error_envelope(resp).await;
+    // The connection (and server) survives the panic.
+    let again = cl.get(format!("{base}/panic")).send().await.unwrap();
+    assert_eq!(again.status().as_u16(), 500);
+}
+
+/// 503 — a query timeout is the TRANSIENT class with the documented `timed out` sentinel and
+/// a wall-clock guarantee.
+#[tokio::test]
+async fn class_503_query_timeout() {
+    let mut ttl = String::from("@prefix ex: <http://ex/> .\n");
+    for i in 0..60 {
+        for j in 0..60 {
+            ttl.push_str(&format!("ex:n{i} ex:e ex:n{j} .\n"));
+        }
+    }
+    let config = ServerConfig {
+        query_timeout: Some(Duration::from_secs(1)),
+        ..ServerConfig::default()
+    };
+    let base = spawn_with(&ttl, config).await;
+    let started = std::time::Instant::now();
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[(
+            "query",
+            "PREFIX ex: <http://ex/> SELECT * WHERE { ?a ex:e ?b . ?c ex:e ?d . ?e ex:e ?f }",
+        )])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 503);
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "the 503 is wall-clock bounded, took {:?}",
+        started.elapsed()
+    );
+    let v = assert_error_envelope(resp).await;
+    assert!(
+        v["error"].as_str().unwrap().contains("timed out"),
+        "documented sentinel: {v}"
+    );
+}
+
+/// Cross-cutting sanitisation invariant: an error body never echoes the caller's input.
+#[tokio::test]
+async fn error_bodies_never_echo_input() {
+    let base = spawn_default().await;
+    const SENTINEL: &str = "WIRE_CONTRACT_NEEDLE_9";
+    let resp = client()
+        .get(format!("{base}/sparql"))
+        .query(&[("query", format!("SELECT {SENTINEL} WHERE {{ broken"))])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status().as_u16(), 400);
+    let body = resp.text().await.unwrap();
+    assert!(!body.contains(SENTINEL), "no echoed input: {body}");
+}

--- a/docs/api-stability.md
+++ b/docs/api-stability.md
@@ -56,6 +56,12 @@ every other crate in the workspace (`sparq-core`, `sparq-engine`, `sparq-server`
 router and types, and the opt-in capability crates). A consumer may still use tier-2
 surfaces; it just does so without the stability guarantee, and should pin an exact revision.
 
+Note that `sparq-server`'s **Rust** surface being tier-2 is distinct from its **HTTP wire**
+surface: what the server speaks over the network to an HTTP-only consumer has its own
+proposed-frozen contract — [`docs/http-wire-contract.md`](http-wire-contract.md)
+([#1416](https://github.com/jeswr/sparq/issues/1416)) — with the same
+proposed-until-ratified status as this document.
+
 Opt-in, feature-gated capability crates remain tier-2 regardless of this policy: keeping the
 core lean and the capability surfaces free to evolve is a deliberate architecture choice.
 
@@ -170,6 +176,8 @@ Until step 3, the tier-1 guarantee is **not** in force.
 
 ## Related
 
+- [`docs/http-wire-contract.md`](http-wire-contract.md) — the HTTP wire counterpart of this
+  policy: the v1 served-surface contract for HTTP-only consumers (#1416).
 - [`docs/release.md`](release.md) — how a release is cut (maintainer-triggered).
 - [`docs/branch-protection.md`](branch-protection.md) — the `main` protection doc-of-record.
 - `crates/sparq-serve/README.md` — the `embed` seam narrative.

--- a/docs/http-wire-contract.md
+++ b/docs/http-wire-contract.md
@@ -1,0 +1,250 @@
+<!-- [FABLE-5] sparq-server HTTP wire + error contract doc-of-record (bead sq-fdurb; #1416, PSS ADR ask). -->
+# sparq-server HTTP wire contract — v1
+
+This is the **doc-of-record for the HTTP wire surface** of `sparq-server`: the endpoints,
+parameters, request/response media types, content-negotiation rules, status codes and error-body
+shape an **HTTP-only consumer** (one that talks to sparq exclusively over the network, e.g.
+[solid-server-rs / PSS](https://github.com/jeswr/solid-server-rs)) may rely on. It is the HTTP
+counterpart of [`docs/api-stability.md`](api-stability.md), which covers the **in-process
+embedding** surface ([#1248](https://github.com/jeswr/sparq/issues/1248)); this document covers
+the ask in [#1416](https://github.com/jeswr/sparq/issues/1416).
+
+Everything in [The frozen v1 surface](#the-frozen-v1-surface) is enumerated **as-implemented**
+and pinned end-to-end by `crates/sparq-server/tests/wire_contract.rs` (the served-surface
+snapshot suite) together with `crates/sparq-server/tests/status_contract.rs` (the retry
+contract) — an accidental wire change fails CI before it can reach a consumer.
+
+## Status: v1 PROPOSED, not yet ratified
+
+> **The wire freeze is NOT in force.** Declaring it in force is the maintainer's (@jeswr's)
+> governance call, exactly as for the embedding-API freeze
+> ([`docs/api-stability.md` § Status](api-stability.md#status-proposed-not-yet-in-force)).
+> Until ratification the workspace is pre-`1.0` and a release MAY still change this surface —
+> but any such change now fails the snapshot suite first, so it is always a *deliberate,
+> release-noted* act, never an accident. This document tees up the ratification so the freeze
+> is a one-line governance decision.
+
+## Versioning & semver policy for the wire surface
+
+The wire contract is versioned independently of crate versions (this document is **v1**).
+The intended guarantee, once ratified: **the frozen surface is stable within a release
+line** — a consumer pins a release line (e.g. `0.MINOR.*`), not a SHA.
+
+**Breaking** (requires a new release line, a `CHANGELOG.md` release note naming the change,
+and a wire-contract major bump — v1 → v2):
+
+- Removing or renaming a frozen endpoint, method, or request parameter.
+- Changing the status code emitted for a documented condition, or moving a status between
+  the transient and permanent classes.
+- Changing the error-envelope shape, a documented stable message sentinel, or an emitted
+  `Content-Type` string.
+- Changing a negotiation default (e.g. the no-`Accept` result format) or dropping a supported
+  request/response media type.
+- Requiring auth, or a new required parameter/header, on a previously-open frozen request form.
+
+**Additive / non-breaking** (allowed in any release within the line; may extend this document
+in-place as v1.x):
+
+- New endpoints, new *optional* parameters, new negotiable media types, new response headers.
+- New error conditions mapped onto the existing status classes, and new stable sentinels for
+  *new* conditions.
+- New opt-in cargo features / runtime flags (default-off), and anything in the
+  [explicitly-unstable surface](#explicitly-unstable-surface).
+- Changes to the free *wording* of an error message outside its documented sentinel substring
+  (clients must classify on status + documented sentinels, never full-text — see below).
+
+Operator-configurable limits (timeouts, body/row/byte caps, concurrency) are **knobs, not
+contract**: their *default values* may change; the status code each cap emits when tripped may
+not.
+
+## The frozen v1 surface
+
+The default build (`cargo build -p sparq-server`, features `server` + `jsonld`) serves all of
+the following. Behaviour marked *(feature: `jsonld`)* is part of the default build but absent
+from a `--no-default-features --features server` build.
+
+### 1. SPARQL 1.1 Protocol — `/sparql`
+
+**Methods:** `GET`, `HEAD`, `POST`, and the query-only HTTP `QUERY` method
+(w3c/sparql-protocol#40, Oxigraph interop). Any other method → `405` with an `Allow` header.
+
+**Query request forms** (SPARQL 1.1 Protocol §2.1):
+
+| Form | How the query travels | Dataset params |
+| --- | --- | --- |
+| `GET /sparql?query=…` | URL-encoded `query` parameter | `default-graph-uri`, `named-graph-uri` (both repeatable) |
+| `POST` with `Content-Type: application/x-www-form-urlencoded` | `query` form field | same, as form fields |
+| `POST` with `Content-Type: application/sparql-query` | body **is** the query | as URL query-string params |
+| `QUERY` with `Content-Type: application/sparql-query` | body **is** the query | as URL query-string params |
+
+`GET /sparql` with no `query` parameter → `400` (on a build with the opt-in
+`federation-descriptors` feature *and* its runtime flag enabled, it is a SPARQL Service
+Description instead — that variant is [unstable](#explicitly-unstable-surface)).
+`QUERY` is query-only by contract: an `application/sparql-update` body → `415`; an `update=`
+form field → `400`.
+
+**Update request forms** (SPARQL 1.1 Protocol §2.2):
+
+| Form | How the update travels | Dataset params |
+| --- | --- | --- |
+| `POST` with `Content-Type: application/sparql-update` | body **is** the update | `using-default-graph-uri`, `using-named-graph-uri` (repeatable) |
+| `POST` with `Content-Type: application/x-www-form-urlencoded` | `update` form field | same, as form fields |
+
+A successful update → **`204 No Content`** (empty body), atomic: a failed update has **no
+partial effect**. With `--persist`, the `204` is acked only after the write is WAL-durable.
+
+A `POST /sparql` with any other `Content-Type` → `415`.
+
+### 2. Query-result media types & negotiation
+
+Negotiation is `Accept`-header driven, q-value aware (`q=0` rejects; an exact type beats a
+wildcard at equal q). An **absent / empty / `*/*`** `Accept` selects the default and is never
+an error. A **present, non-empty `Accept` naming no supported type and no wildcard** →
+**`406 Not Acceptable`** (Oxigraph parity) for *both* result classes below.
+
+**SELECT / ASK** (default: **SPARQL Results JSON**):
+
+| `Accept` (also accepted aliases) | Emitted `Content-Type` |
+| --- | --- |
+| *(absent)* / `*/*` / `application/sparql-results+json` (`application/json`) | `application/sparql-results+json` |
+| `application/sparql-results+xml` (`application/xml`, `text/xml`) | `application/sparql-results+xml` |
+| `text/csv` | `text/csv; charset=utf-8` |
+| `text/tab-separated-values` | `text/tab-separated-values; charset=utf-8` |
+
+ASK has no CSV/TSV form; a CSV/TSV `Accept` on an ASK yields the JSON boolean form.
+
+**Result envelopes** (SPARQL 1.1 Query Results JSON Format): a SELECT body is
+`{"head":{"vars":[…]},"results":{"bindings":[…]}}`; an ASK body is `{"head":{},"boolean":…}`.
+
+**CONSTRUCT / DESCRIBE** (default: **N-Triples**):
+
+| `Accept` (aliases) | Emitted `Content-Type` |
+| --- | --- |
+| *(absent)* / `*/*` / `application/n-triples` | `application/n-triples; charset=utf-8` |
+| `text/turtle` | `text/turtle; charset=utf-8` |
+| `application/rdf+xml` (`application/xml`, `text/xml` at lower specificity) | `application/rdf+xml; charset=utf-8` |
+| `application/ld+json` *(feature: `jsonld`, default-on)* | `application/ld+json; charset=utf-8` |
+
+### 3. Graph Store HTTP Protocol
+
+Two addressing forms, same semantics:
+
+- **Indirect** — `/sparql/graph?default` or `/sparql/graph?graph=<IRI>` (exactly one; a
+  selector-less `POST` mints a fresh server-named graph).
+- **Direct** — `/graphs/{path}`: the graph IRI is reconstructed from the request
+  (`http://<Host>/graphs/<path>`).
+
+**Methods & statuses:** `GET`/`HEAD` read (negotiated as CONSTRUCT above; a `GET` of an
+absent *named* graph serves the **empty graph** — `200`, empty body — it does not `404`);
+`PUT` replaces (**`201`** if the graph did not exist, **`204`** if replaced — the
+created/replaced distinction is advisory, see `status_contract`); `POST` merges additively
+(`204`; `201` when it creates); `DELETE` drops
+(`204`; `404` for an absent named graph; `?default` always `204` — CLEAR DEFAULT); `PATCH`
+applies an **atomic graph-scoped SPARQL Update** (`Content-Type: application/sparql-update`,
+always-on → `204`; the opt-in `text/n3` N3-Patch dialect is
+[unstable](#explicitly-unstable-surface)).
+
+**Accepted write body types:** `text/turtle` (also the default for an absent/empty
+`Content-Type`), `application/x-turtle`, `application/n-triples`, `text/plain`,
+`application/n-quads`, `application/trig`, `application/rdf+xml`, and
+`application/ld+json` *(feature: `jsonld`)*. Anything else → `415`; a malformed RDF body →
+`400`.
+
+### 4. Liveness — `GET /health`
+
+`200` with the plain-text body `ok`. Never auth-gated. (Deeper health/readiness semantics are
+not part of v1.)
+
+### 5. Authentication — Bearer token
+
+- `--auth-token <TOKEN>` gates the **write** surface (SPARQL Update, GSP
+  `PUT`/`POST`/`DELETE`/`PATCH`, admin routes). Classification is by *what the request does*
+  (a mutating payload is a write regardless of route form).
+- `--auth-token-read` additionally gates the **read** surface (queries, GSP reads, `/metrics`,
+  subscription streams).
+- Credential: `Authorization: Bearer <token>` (scheme case-insensitive).
+- Failure → **`401`** with `WWW-Authenticate: Bearer`, `Cache-Control: no-store`, and a
+  response that is **byte-identical for a missing vs a wrong token** (no oracle). Token
+  comparison is constant-time.
+- No token configured (default): all surfaces open, loopback-only bind by default.
+
+### 6. Error contract
+
+Every error response is the structured envelope **`{"error":"<message>"}`** with
+`Content-Type: application/json` (the `405` additionally carries `Allow`). `<message>` is a
+**stable generic class string** — sanitised, never echoing the caller's query/RDF/paths/tokens.
+**Classify on the status code**, plus at most the documented sentinel substrings below; never
+on full message text.
+
+| Status | Condition | Class | Stable sentinel |
+| --- | --- | --- | --- |
+| `400` | malformed query / update / RDF body; missing `query=`; bad `generation` token | permanent | — |
+| `401` | missing/wrong Bearer token on a gated surface | permanent | — (see §5 headers) |
+| `403` | *(feature: `service`)* non-`SILENT` `SERVICE` to a host the default-deny egress allowlist refuses | permanent (policy refusal) | `egress allowlist` |
+| `404` | unknown route; `DELETE` of an absent named graph (a `GET` serves the empty graph instead, §3); a compiled-but-flag-disabled opt-in route | permanent | `not found` (unknown route) |
+| `405` | method not allowed on a route | permanent | — (carries `Allow`) |
+| `406` | present-but-unsatisfiable `Accept` (both result classes, §2) | permanent | — |
+| `410` | *(feature: `time-travel`)* `?generation=N` aged out of retention | permanent | `aged out` |
+| `413` | body over cap; result row/byte working-set cap; gzip ratio cap | permanent for the identical request (honest refusal, never truncation) | `row limit` / `byte limit` |
+| `415` | unsupported request `Content-Type` (§1, §3) | permanent | — |
+| `429` | concurrency cap: request shed **before it ran** | **transient** | — |
+| `500` | caught handler panic / unclassified internal error | defect — surface, do not hot-retry | — |
+| `503` | query/update timeout; durable-write refusal (write **not** applied); subscription capacity | **transient** | `timed out` (timeout case) |
+
+**Transient = `429` and `503` only; everything else is permanent.** The full
+transient-vs-permanent rationale, per-condition, is the versioned `status_contract` rustdoc
+module in `sparq-server` (`crates/sparq-server/src/status_contract.rs`) — that module is part
+of this contract. No `Retry-After` header is currently emitted.
+
+## Explicitly-unstable surface
+
+Served today, **NOT covered by the v1 freeze** — may change or disappear in any release
+(consumers should pin an exact version if they depend on these):
+
+- `/metrics` — the route and read-gating are stable habits, but the exposition *content*
+  (metric names/labels) is unstable.
+- `/subscriptions` (WebSocket) and `/subscriptions/sse` — the whole subscription protocol,
+  including the `Sec-WebSocket-Protocol: bearer.<token>` auth form
+  (`crates/sparq-server/SUBSCRIPTIONS.md`).
+- `/admin/compact`, and the `backup`-feature routes `/admin/backup`, `/admin/backup/delta`,
+  `/admin/restore` (and their `409` semantics).
+- All opt-in-feature routes and parameters: `/tpf` (+`brtpf`), `/shacl/validate`,
+  `/terse/transpile`, `/streams`, `/.well-known/void`, the Service-Description response on a
+  query-less `GET /sparql`, the `text/n3` GSP `PATCH` dialect, and time-travel's
+  `?generation` / `Sparq-Generation` header (their *error statuses*, where documented in §6,
+  are frozen; the surfaces themselves are not).
+- `EXPLAIN` / `EXPLAIN ANALYZE` output format; audit/log record formats; CORS specifics;
+  response headers not named in this document; exact error-message wording beyond the §6
+  sentinels; default values of operator caps.
+
+## How this contract is enforced
+
+- `crates/sparq-server/tests/wire_contract.rs` — the served-surface snapshot suite: one direct
+  test per documented endpoint behaviour and per §6 error class, asserting the documented
+  status code, body shape, and `Content-Type` against the real hardened router (in-process,
+  no network flakiness). A wire change that contradicts this document turns CI red.
+- `crates/sparq-server/tests/status_contract.rs` — the retry-contract twin (transient vs
+  permanent, sanitisation, byte-identical `401`).
+- Supporting suites: `tests/protocol.rs`, `tests/query_method.rs`,
+  `tests/jsonld_content_negotiation.rs`, `tests/hardening.rs`, `tests/auth.rs`.
+
+## Ratification checklist (for the maintainer)
+
+1. Confirm the [frozen v1 surface](#the-frozen-v1-surface) partition (promote/demote items —
+   e.g. whether `/metrics`' exposition or the subscription protocol should join v1).
+2. Cut the release line that carries it (see [`docs/release.md`](release.md)) and record the
+   freeze in `CHANGELOG.md`.
+3. Flip this document's [Status](#status-v1-proposed-not-yet-ratified) from *PROPOSED* to
+   *in force*, and note it on [#1416](https://github.com/jeswr/sparq/issues/1416) so PSS can
+   pin the release line.
+
+## Related
+
+- [`docs/api-stability.md`](api-stability.md) — the in-process embedding freeze (#1248) and
+  the shared tier model.
+- `crates/sparq-server/src/status_contract.rs` — the versioned retry contract (rustdoc).
+- [`skills/http-server/SKILL.md`](../skills/http-server/SKILL.md) — the full operational
+  endpoint + hardening reference (superset; not a stability contract).
+- [#1416](https://github.com/jeswr/sparq/issues/1416) (PSS HTTP-freeze ask) ·
+  [#1248](https://github.com/jeswr/sparq/issues/1248) (embedding freeze) ·
+  [#50](https://github.com/jeswr/sparq/issues/50) (transient-vs-permanent contract).

--- a/skills/http-server/SKILL.md
+++ b/skills/http-server/SKILL.md
@@ -1397,6 +1397,15 @@ identities and resource IRIs by design (see the privacy-boundary note above).
   truncation. **Classify on the status code, not the body text** (bodies are sanitised generic
   classes — see the next bullet). There is **no `Retry-After`** header today. Full contract +
   rationale: the `sparq_server::status_contract` crate doc, asserted by `tests/status_contract.rs`.
+- **The versioned HTTP wire contract ([FABLE-5] sq-fdurb / gh-1416, PSS ask).** The endpoints,
+  params, media types, negotiation rules, status codes and error-body shape an **HTTP-only
+  consumer** may rely on are enumerated as the **v1 wire contract** in
+  [`docs/http-wire-contract.md`](../../docs/http-wire-contract.md) — frozen-vs-unstable
+  partition, plus the wire-semver policy (breaking vs additive). Pinned end-to-end by the
+  served-surface snapshot suite `tests/wire_contract.rs` (one direct test per documented
+  endpoint behaviour / error class), so an accidental wire break fails CI. Status: **PROPOSED**
+  — the freeze ratification is the maintainer's call, like the embedding freeze in
+  [`docs/api-stability.md`](../../docs/api-stability.md).
 - **Error bodies are sanitized — no information leak (sq-cz89 / sq-j9zs).** On the
   no-auth-by-default path an error body carries only a **stable, generic CLASS message**
   (e.g. `malformed query`, `malformed RDF body`, `malformed gzip body`,


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5) — automated implementation of bead **sq-fdurb** on behalf of @jeswr.

Closes the implementation half of #1416 (the PSS HTTP-freeze ask; distinct from #1248's in-process embedding surface). **The freeze RATIFICATION itself remains the maintainer's governance decision** — this PR drafts the contract, pins it with tests, and tees up a one-line ratification (checklist at the bottom of the doc), per the proceed-without-greenlight rule.

## What this delivers

1. **`docs/http-wire-contract.md` — the versioned v1 wire contract**, enumerated **as-implemented**: the `/sparql` request forms (GET / POST / query-only `QUERY` + update), exact negotiation tables with the exact emitted `Content-Type` strings, the SPARQL Results JSON envelopes, GSP indirect + direct semantics and statuses, `/health`, the `--auth-token` Bearer semantics (byte-identical 401, `WWW-Authenticate: Bearer`, `Cache-Control: no-store`), and the full **12-class error taxonomy** with the transient-vs-permanent split (#50). An **explicitly-unstable partition** (subscriptions, `/metrics` exposition, admin routes, all opt-in-feature surfaces) says what v1 does NOT freeze. Status: **v1 PROPOSED, not yet ratified** — same framing as `docs/api-stability.md`.
2. **`crates/sparq-server/tests/wire_contract.rs` — the served-surface snapshot suite**: 25 tests default-build (27 with `service,time-travel`), in-process ephemeral-port server through the REAL `harden(router(..))` stack, **one direct test per documented error class** (`400/401/403/404/405/406/410/413/415/429/500/503`) plus the frozen endpoint behaviours, each asserting the documented status code + body shape + `Content-Type`. An accidental wire break now fails CI.
3. **The wire-semver policy** (in the doc): *within a release line the frozen v1 surface changes only additively; removing/renaming an endpoint or param, remapping a documented status code or its transient/permanent class, or changing the error envelope / an emitted Content-Type / a negotiation default is a breaking change requiring a new release line, a release note, and a wire-contract version bump.*

## Honest findings while pinning

- **Real doc drift fixed in `src/status_contract.rs`:** its table claimed a GSP `GET` of a non-existent named graph is a `404`. As-implemented (and pinned by `tests/protocol.rs` `gsp_delete_then_get_and_404` since sq-gxsj), a `GET` of an absent named graph serves the **empty graph (200, empty body)**; the absent-graph `404` arises on `DELETE`. The contract doc, the rustdoc table, and the new suite now all state the implemented behaviour.
- **`406` was missing from the `status_contract` table** even though the sq-406acc behaviour ships and is tested; added (permanent class), and the permanent-class list now includes it.

## Non-vacuity mutation evidence

Flipped the documented `400` for a malformed query to `500` in a throwaway copy of the suite — it went red exactly as required, then reverted:

```
thread 'class_400_malformed_query' panicked at crates/sparq-server/tests/wire_contract.rs:443:5:
assertion `left == right` failed
  left: 400
 right: 500
```

## Gates (all run in this worktree)

- `cargo test -p sparq-server` (default features, full crate suite) — green, incl. the new suite (25 passed).
- `cargo test -p sparq-server --test wire_contract --features service,time-travel` — green (27 passed, incl. the feature-gated 403/410 classes).
- `cargo test -p sparq-server --no-default-features` — green (suite compiles out with the `server` feature off, per crate convention).
- `cargo clippy -p sparq-server --all-targets -- -D warnings` in all three feature states (default / `--no-default-features` / `--features service,time-travel`) — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean (exit 0).
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations (README kept at ≤120 lines by compacting the Learn-more bullet it extends).
- `typos` over all changed files — clean. No perf numbers, no new public API, no behaviour change (docs + tests only).

## For the maintainer (ratification)

The doc ends with a 3-step ratification checklist (confirm the frozen/unstable partition → cut the release line + CHANGELOG note → flip PROPOSED to in-force and note it on #1416). Until then nothing here creates a guarantee — it creates the *pinned shape* to ratify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)