### PR TITLE
test(site): keyboard-only /try journey + ARIA focus contracts (sq-ymr2e.9) [FABLE-5]

### DIFF
--- a/site/e2e/a11y-keyboard.spec.ts
+++ b/site/e2e/a11y-keyboard.spec.ts
@@ -1,0 +1,517 @@
+// [FABLE-5] sq-ymr2e.9 — BEHAVIORAL accessibility: the checks axe CANNOT see.
+//
+// Design of record: research/web-gui-test-program.md §3.2 (the behavioral half of the WCAG
+// gate) + §1 (the determinism doctrine, inherited verbatim from the shared `test` — frozen
+// clock, seeded random, hermetic network, web-first waiters, no timing assertions). The axe
+// half lives in a11y.spec.ts; this file is deliberately FILE-DISJOINT from it and from the
+// /try journey suites.
+//
+// WHAT IT GUARDS — four contracts straight from the ARIA Authoring Practices, asserted as
+// CONTRACTS (roles/state/keyboard behavior), never incidental DOM:
+//   (a) A COMPLETE KEYBOARD-ONLY JOURNEY on /try: Tab to the editor → type a query →
+//       Ctrl/Cmd+Enter → reach and read the results by keyboard, with :focus-visible ring
+//       assertions along the path — and a machine check that NO trusted pointer event fired.
+//   (b) The WAI-ARIA TABS pattern on the tab/panel widget family (home Query/Data, the /try
+//       result-view + execution-target selectors): tablist/tab(/tabpanel) roles, exactly one
+//       aria-selected tab, ROVING TABINDEX (only the selected tab in the page Tab-order), and
+//       ArrowRight/ArrowLeft focus movement with selection-follows-focus (automatic
+//       activation). This is the regression class of the real ARIA tab/panel bug already
+//       found on /try by hand.
+//   (c) The ⌘K/Ctrl-K COMMAND PALETTE: focus lands in the combobox input on open with exactly
+//       one active option; from the first arrow key on, the active option is communicated via
+//       aria-activedescendant while DOM focus never leaves the input (the APG combobox/listbox
+//       mechanism cmdk implements — upstream cmdk 1.1.1 emits no aria-activedescendant for the
+//       mount-time initial selection, bead sq-pa15k); Tab cannot escape the dialog while open;
+//       ESC closes it AND RESTORES focus to the invoker.
+//   (d) The /try CONNECT DRAWER disclosure: keyboard-toggleable with a programmatically
+//       exposed expanded/collapsed state (a native <details>/<summary>, so the state is the
+//       host-language semantic ARIA's aria-expanded mirrors), and the endpoint form fields
+//       inside carry PROGRAMMATICALLY-ASSOCIATED labels (resolvable by role + accessible
+//       name, not by proximity).
+//
+// NON-VACUITY. a11y suites rot silently: assertions that keep passing on broken markup are
+// worse than none. The last test strips the load-bearing ARIA attributes (aria-selected, the
+// roving tabindex) off a live tablist via DOM mutation and asserts the tabs-contract helper
+// REJECTS — a green run therefore proves the assertions are live, mirroring the injected
+// unlabelled-button probe in a11y.spec.ts.
+//
+// WASM PREREQ. Only the journey test needs the in-tab engine (it runs a real query); it
+// SKIPS when the lean wasm bundle is absent, exactly like try-journeys.spec.ts. Every other
+// test here is wasm-FREE and runs on the light site-e2e CI lane. Full set locally:
+//   (cd ../js && npm run build:wasm) && npm run sync-wasm && npx playwright install chromium \
+//     && npx playwright test a11y-keyboard.spec.ts --repeat-each=5 --retries=0
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { type Locator, type Page } from "@playwright/test";
+import { test, expect, BasePage } from "./support";
+
+// The lean wasm bundle the /try REPL loads at runtime (gitignored build artifact synced into
+// public/wasm/ by `sync-wasm`). Its presence gates ONLY the run-a-real-query journey test.
+const WASM_BUNDLE = fileURLToPath(new URL("../public/wasm/sparq_wasm_bg.wasm", import.meta.url));
+const WASM_PRESENT = existsSync(WASM_BUNDLE);
+
+// The keyboard "run" chord the app advertises (repl.tsx accepts metaKey OR ctrlKey; we press
+// the HOST-OS convention, same as try-journeys.spec.ts).
+const RUN_CHORD = process.platform === "darwin" ? "Meta+Enter" : "Control+Enter";
+
+// A deterministic, dataset-INDEPENDENT query with exact engine-COMPUTED answers: ?tripled is
+// computed (?n * 3) and ORDER BY DESC proves the engine sorted the VALUES — a static echo of
+// the typed text could not produce these cells (determinism doctrine: concrete values, never
+// row counts or timings).
+const JOURNEY_QUERY =
+  "SELECT ?n ?tripled WHERE { VALUES ?n { 1 4 7 } BIND(?n * 3 AS ?tripled) } ORDER BY DESC(?n)";
+const JOURNEY_ROWS = [
+  ["7", "21"],
+  ["4", "12"],
+  ["1", "3"],
+];
+
+// ── Shared contract helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * The STATIC half of the APG tabs contract on a `role="tablist"` container:
+ *   * at least two `role="tab"` children;
+ *   * EXACTLY ONE tab with aria-selected="true";
+ *   * a roving tabindex — the selected tab (and only it) is in the page Tab-order.
+ * `timeout` is threaded so the non-vacuity probe can assert a FAST rejection instead of
+ * burning the suite-default expect timeout on markup it deliberately broke.
+ */
+async function expectApgTablistStatic(
+  tablist: Locator,
+  opts: { timeout?: number } = {},
+): Promise<void> {
+  const { timeout } = opts;
+  await expect(tablist).toBeVisible({ timeout });
+  const tabs = tablist.locator('[role="tab"]');
+  expect(
+    await tabs.count(),
+    "an APG tablist has at least two tabs — fewer means the widget is mis-roled",
+  ).toBeGreaterThanOrEqual(2);
+  await expect(
+    tablist.locator('[role="tab"][aria-selected="true"]'),
+    "exactly ONE tab must carry aria-selected='true' (APG tabs: single selection)",
+  ).toHaveCount(1, { timeout });
+  await expect(
+    tablist.locator('[role="tab"][aria-selected="true"]'),
+    "the selected tab must be IN the page Tab-order (tabindex 0 — roving tabindex)",
+  ).toHaveAttribute("tabindex", "0", { timeout });
+  const unselected = tablist.locator('[role="tab"]:not([aria-selected="true"])');
+  const n = await unselected.count();
+  for (let i = 0; i < n; i++) {
+    await expect(
+      unselected.nth(i),
+      "every unselected tab must be OUT of the page Tab-order (tabindex -1 — roving tabindex)",
+    ).toHaveAttribute("tabindex", "-1", { timeout });
+  }
+}
+
+/**
+ * The KEYBOARD half of the APG tabs contract: with focus on the selected tab, ArrowRight
+ * moves focus to the next enabled tab and selection FOLLOWS focus (automatic activation —
+ * every panel here is cheap local state); ArrowLeft returns. The roving tabindex is
+ * re-checked after each move so the Tab-stop travels with the selection.
+ */
+async function expectApgTablistArrows(page: Page, tablist: Locator): Promise<void> {
+  const selected = () =>
+    tablist.locator('[role="tab"][aria-selected="true"]');
+  const initialLabel = ((await selected().textContent()) ?? "").trim();
+
+  // Programmatic focus is not a pointer event; it parks focus exactly where a keyboard user
+  // Tab-arrives (the roving tabindex guarantees the selected tab is that Tab-stop).
+  await selected().focus();
+  await expect(selected()).toBeFocused();
+
+  await page.keyboard.press("ArrowRight");
+  // Focus moved AND selection followed it — the selected tab is a *different* one and holds focus.
+  await expect(
+    selected(),
+    "ArrowRight must move focus to the next enabled tab with selection following focus",
+  ).toBeFocused();
+  await expect(selected()).not.toHaveText(initialLabel);
+  await expectApgTablistStatic(tablist); // the Tab-stop (tabindex 0) travelled with the selection
+
+  await page.keyboard.press("ArrowLeft");
+  await expect(
+    selected(),
+    "ArrowLeft must return focus + selection to the previous tab",
+  ).toBeFocused();
+  await expect(selected()).toHaveText(initialLabel);
+  await expectApgTablistStatic(tablist);
+}
+
+/** Assert `loc` holds focus AND paints a visible :focus-visible indicator (the ring). */
+async function expectFocusVisibleRing(loc: Locator): Promise<void> {
+  await expect(loc).toBeFocused();
+  const probe = await loc.evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return {
+      focusVisible: el.matches(":focus-visible"),
+      boxShadow: cs.boxShadow,
+      outlineStyle: cs.outlineStyle,
+    };
+  });
+  expect(
+    probe.focusVisible,
+    ":focus-visible must match after KEYBOARD focus — otherwise the ring styles never apply",
+  ).toBe(true);
+  expect(
+    probe.boxShadow !== "none" || probe.outlineStyle !== "none",
+    `the focused element must paint a visible ring (box-shadow or outline); got box-shadow=${probe.boxShadow}, outline-style=${probe.outlineStyle}`,
+  ).toBe(true);
+}
+
+/**
+ * Press Tab until `target` holds focus (bounded — the DOM is deterministic, so the bound is
+ * a tripwire, never a wait). Returns how many presses it took. Every intermediate stop is
+ * checked too: keyboard focus must NEVER land inside aria-hidden content (the Chromium
+ * keyboard-focusable-scroller class — e.g. an `overflow-auto` aria-hidden highlight layer —
+ * which axe's aria-hidden-focus rule misses because the focusability is UA-derived, not a
+ * tabindex). That real bug existed on the editors' highlight <pre> until sq-ymr2e.9.
+ */
+async function tabUntilFocused(page: Page, target: Locator, maxTabs = 120): Promise<number> {
+  for (let i = 1; i <= maxTabs; i++) {
+    await page.keyboard.press("Tab");
+    const stop = await page.evaluate(() => {
+      const el = document.activeElement;
+      return {
+        inAriaHidden: !!el?.closest('[aria-hidden="true"]'),
+        desc: el ? `${el.tagName} aria-label=${el.getAttribute("aria-label")}` : "none",
+      };
+    });
+    expect(
+      stop.inAriaHidden,
+      `Tab press ${i} put keyboard focus INSIDE aria-hidden content (${stop.desc}) — invisible to AT`,
+    ).toBe(false);
+    const focused = await target
+      .evaluate((el) => el === document.activeElement)
+      .catch(() => false);
+    if (focused) return i;
+  }
+  throw new Error(
+    `keyboard-only journey broken: the target never received focus within ${maxTabs} Tab presses`,
+  );
+}
+
+/**
+ * Machine check that a journey used NO pointing device: counts TRUSTED pointer/mouse
+ * button events (a keyboard Enter/Space on a button synthesizes only `click`, never
+ * pointerdown/mousedown, so a keyboard-only run records zero). Install BEFORE goto.
+ */
+async function installPointerGuard(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const w = window as unknown as { __pointerEvents: string[] };
+    w.__pointerEvents = [];
+    for (const type of ["pointerdown", "pointerup", "mousedown", "mouseup"]) {
+      window.addEventListener(
+        type,
+        (e) => {
+          if (e.isTrusted) w.__pointerEvents.push(type);
+        },
+        true,
+      );
+    }
+  });
+}
+
+async function pointerEvents(page: Page): Promise<string[]> {
+  return page.evaluate(
+    () => (window as unknown as { __pointerEvents?: string[] }).__pointerEvents ?? [],
+  );
+}
+
+/** Navigate to /try and wait for the REPL editor (renders without the engine; wasm-free). */
+async function gotoTry(page: Page): Promise<BasePage> {
+  const p = new BasePage(page);
+  await p.goto("try/");
+  await expect(page.getByRole("textbox", { name: "SPARQL query" })).toBeVisible();
+  return p;
+}
+
+// ── (a) The keyboard-only /try journey: reach the editor, query, run, read results. ─────────────
+test.describe("keyboard-only /try journey", () => {
+  test.skip(
+    !WASM_PRESENT,
+    "lean wasm bundle absent (public/wasm/sparq_wasm_bg.wasm) — run `npm run sync-wasm` after `(cd ../js && npm run build:wasm)`",
+  );
+
+  test("Tab → editor → type → Ctrl/Cmd+Enter → read results, with zero pointer events", async ({
+    page,
+    hermetic,
+  }) => {
+    await installPointerGuard(page);
+    const p = new BasePage(page);
+    await p.goto("try/");
+    await p.expectRunnerState("try", "engine-ready");
+
+    // REACH THE EDITOR BY KEYBOARD. Tab from the document start; the bound is a tripwire on
+    // a deterministic DOM, not a wait. The editor must paint its :focus-visible ring.
+    const editor = page.getByRole("textbox", { name: "SPARQL query" });
+    const tabsToEditor = await tabUntilFocused(page, editor);
+    expect(tabsToEditor, "the editor must be keyboard-reachable").toBeGreaterThan(0);
+    await expectFocusVisibleRing(editor);
+
+    // TYPE THE QUERY — real key events (select-all then type), never fill/paste.
+    await page.keyboard.press("ControlOrMeta+a");
+    await page.keyboard.type(JOURNEY_QUERY);
+    await expect(editor).toHaveValue(JOURNEY_QUERY);
+
+    // RUN via the advertised keyboard chord.
+    await page.keyboard.press(RUN_CHORD);
+
+    // READ THE RESULTS: exact engine-computed cells, in engine-sorted order.
+    const table = page
+      .locator('[data-result-kind="select"]')
+      .locator('[data-result-view="table"] table');
+    await expect(table).toBeVisible();
+    const rows = table.locator("tbody tr");
+    await expect(rows).toHaveCount(JOURNEY_ROWS.length);
+    for (let r = 0; r < JOURNEY_ROWS.length; r++) {
+      for (let c = 0; c < JOURNEY_ROWS[r].length; c++) {
+        await expect(rows.nth(r).locator("td").nth(c)).toContainText(JOURNEY_ROWS[r][c]);
+      }
+    }
+
+    // REACH THE RESULTS REGION BY KEYBOARD: thanks to the roving tabindex the whole
+    // result-view tablist is ONE Tab-stop (the selected "Table" tab). Ring asserted there too.
+    const resultTabs = page.getByRole("tablist", { name: "Result view" });
+    const tableTab = resultTabs.locator('[role="tab"][aria-selected="true"]');
+    await tabUntilFocused(page, tableTab);
+    await expectFocusVisibleRing(tableTab);
+
+    // The /try result-view tablist honours the full APG tabs contract in situ — and the
+    // arrow-key view switch really re-renders the SAME result: the raw SPARQL-JSON view must
+    // contain the engine-computed 21 (7*3), then ArrowLeft restores the typed table.
+    await expectApgTablistStatic(resultTabs);
+    await page.keyboard.press("ArrowRight");
+    await expect(resultTabs.locator('[role="tab"][aria-selected="true"]')).toHaveText(/JSON/);
+    const jsonView = page.locator('[data-result-view="json"]');
+    await expect(jsonView).toBeVisible();
+    await expect(jsonView).toContainText('"21"');
+    await page.keyboard.press("ArrowLeft");
+    await expect(table).toBeVisible();
+
+    // The journey used NO pointing device and NOTHING left the tab (the honest machine
+    // checks of "keyboard-only" and of /try's zero-network promise).
+    expect(await pointerEvents(page), "trusted pointer/mouse events fired").toEqual([]);
+    expect(
+      hermetic.externalRequests,
+      `unexpected external requests:\n${hermetic.externalRequests.join("\n")}`,
+    ).toEqual([]);
+  });
+});
+
+// ── (b) The WAI-ARIA tabs contract on the tab/panel widget family. ──────────────────────────────
+test.describe("WAI-ARIA tabs contract", () => {
+  test("home hero Query/Data: full tabs pattern — roles, panels, roving focus", async ({
+    page,
+  }) => {
+    const home = new BasePage(page);
+    await home.goto("");
+    await home.expectRunnerState("home", "idle-preview");
+
+    const tablist = page.getByRole("tablist", { name: "Runner editor" });
+    await expectApgTablistStatic(tablist);
+    await expectApgTablistArrows(page, tablist);
+
+    // The hero is a FULL tabs widget (it has real panels), so the panel half of the pattern
+    // is asserted too: each tab controls a role=tabpanel labelled by it, and exactly the
+    // selected tab's panel is visible.
+    const queryTab = tablist.getByRole("tab", { name: "Query" });
+    const dataTab = tablist.getByRole("tab", { name: "Data" });
+    await expect(queryTab).toHaveAttribute("aria-controls", "hero-panel-query");
+    await expect(dataTab).toHaveAttribute("aria-controls", "hero-panel-data");
+    const queryPanel = page.locator("#hero-panel-query");
+    const dataPanel = page.locator("#hero-panel-data");
+    await expect(queryPanel).toHaveAttribute("role", "tabpanel");
+    await expect(dataPanel).toHaveAttribute("role", "tabpanel");
+    await expect(queryPanel).toHaveAttribute("aria-labelledby", "hero-tab-query");
+    await expect(dataPanel).toHaveAttribute("aria-labelledby", "hero-tab-data");
+
+    // Switch to Data BY KEYBOARD and assert the panels actually swap…
+    await queryTab.focus();
+    await page.keyboard.press("ArrowRight");
+    await expect(dataTab).toHaveAttribute("aria-selected", "true");
+    await expect(dataPanel).toBeVisible();
+    await expect(queryPanel).toBeHidden();
+
+    // …and the roving-tabindex payoff: Tab from the tablist lands INSIDE the visible panel
+    // (the Data editor), never on another tab (APG: the tablist is one Tab-stop).
+    await page.keyboard.press("Tab");
+    await expect(page.getByRole("textbox", { name: "Sample data (Turtle)" })).toBeFocused();
+  });
+
+  test("/try execution-target switch (connect drawer): tabs roles + roving tabindex", async ({
+    page,
+  }) => {
+    await gotoTry(page);
+    // Open the drawer BY KEYBOARD (its own contract is test (d); here it is just the door).
+    const summary = page.locator("summary", { hasText: "Advanced · Connect to a sparq-server" });
+    await summary.focus();
+    await page.keyboard.press("Enter");
+    await expect(page.locator("#endpoint-url")).toBeVisible();
+
+    // The In-tab-WASM ⇄ Endpoint switch is exposed as a tablist: static contract only.
+    // (Arrow-key activation is exercised on the two sibling widgets above/in the journey —
+    // activating THIS one flips real execution modes, which mounts endpoint-mode panels that
+    // poll the configured server: a network side effect the hermetic harness would have to
+    // absorb for no additional contract coverage, since all three share one roving-tablist
+    // implementation.)
+    const tablist = page.getByRole("tablist", { name: "Execution target" });
+    await expectApgTablistStatic(tablist);
+    // Both execution targets are enabled with the default (valid, loopback) endpoint URL, so
+    // the roving Tab-stop is exactly the selected "In-tab WASM" tab.
+    await expect(tablist.getByRole("tab", { name: "In-tab WASM" })).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(tablist.getByRole("tab", { name: "Endpoint" })).toBeEnabled();
+  });
+});
+
+// ── (c) The ⌘K/Ctrl-K command palette: combobox focus contract + trap + restore. ────────────────
+test.describe("command palette focus contract", () => {
+  test("aria-activedescendant drives the active option; Tab is trapped; ESC restores the invoker", async ({
+    page,
+  }) => {
+    const p = await gotoTry(page);
+
+    // Park focus on a real, identifiable invoker (the editor) so the restore assertion is
+    // meaningful — the palette's document-level shortcut works from any focus target.
+    const editor = page.getByRole("textbox", { name: "SPARQL query" });
+    await editor.focus();
+    await expect(editor).toBeFocused();
+
+    const dialog = await p.openCommandPalette();
+
+    // FOCUS lands in the search input, which cmdk exposes as an APG combobox, and exactly
+    // ONE option is marked active (aria-selected="true") on open. KNOWN UPSTREAM GAP: cmdk
+    // 1.1.1 does not emit aria-activedescendant until the first arrow key (its store only
+    // writes selectedItemId on a value CHANGE, never for the mount-time initial selection) —
+    // bead sq-pa15k tracks it — so the activedescendant contract is asserted on the ARROW
+    // interaction below, where the app satisfies it today.
+    const input = dialog.getByRole("combobox");
+    await expect(input).toBeFocused();
+    await expect(dialog.locator('[role="option"][aria-selected="true"]')).toHaveCount(1);
+
+    // ArrowDown: the active option is communicated via aria-activedescendant — it must
+    // reference a REAL element that is the selected option (a dangling id would pass any
+    // attribute-presence check but be silent to AT) — while DOM focus STAYS on the input
+    // (the APG combobox/listbox mechanism cmdk implements).
+    await page.keyboard.press("ArrowDown");
+    await expect(input).toHaveAttribute("aria-activedescendant", /.+/);
+    const firstActive = await input.getAttribute("aria-activedescendant");
+    await expect(page.locator(`[id="${firstActive}"][role="option"]`)).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(input).toBeFocused();
+
+    // A second ArrowDown MOVES the active option: aria-activedescendant changes to another
+    // real selected option and DOM focus still never leaves the input.
+    await page.keyboard.press("ArrowDown");
+    await expect(input).not.toHaveAttribute("aria-activedescendant", firstActive ?? "");
+    const nextActive = await input.getAttribute("aria-activedescendant");
+    await expect(page.locator(`[id="${nextActive}"][role="option"]`)).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+    await expect(input).toBeFocused();
+
+    // FOCUS TRAP: Tab cycles inside the dialog; focus may never escape to the page below.
+    for (let i = 0; i < 5; i++) {
+      await page.keyboard.press("Tab");
+      expect(
+        await dialog.evaluate((d) => d.contains(document.activeElement)),
+        `Tab press ${i + 1} let focus ESCAPE the open dialog`,
+      ).toBe(true);
+    }
+
+    // ESC closes the palette AND RESTORES focus to the invoker.
+    await p.closeCommandPalette();
+    await expect(editor).toBeFocused();
+  });
+});
+
+// ── (d) The /try connect drawer: disclosure semantics + programmatic labels. ────────────────────
+test.describe("connect drawer disclosure", () => {
+  test("keyboard toggle with exposed expanded state; endpoint fields have programmatic labels", async ({
+    page,
+  }) => {
+    await gotoTry(page);
+
+    const details = page.locator("details", { hasText: "Advanced · Connect to a sparq-server" });
+    const summary = details.locator("summary");
+
+    // Collapsed by default, with the state PROGRAMMATICALLY exposed. The drawer is a native
+    // <details>/<summary>, so the determinable expanded/collapsed state is the host-language
+    // `open` semantic that aria-expanded mirrors on custom disclosures (HTML-AAM maps the
+    // open summary to an expanded disclosure button) — we assert the reflected DOM state, not
+    // a hand-authored (and redundant) aria-expanded attribute.
+    await expect(details).toHaveJSProperty("open", false);
+    await expect(page.locator("#endpoint-url")).toBeHidden();
+
+    // Keyboard-operable: the summary is focusable, paints a focus ring, and Enter expands.
+    await summary.focus();
+    await expectFocusVisibleRing(summary);
+    await page.keyboard.press("Enter");
+    await expect(details).toHaveJSProperty("open", true);
+
+    // The endpoint form fields are labelled PROGRAMMATICALLY: each is resolvable by role +
+    // accessible name (the <label htmlFor> association), not by visual proximity.
+    const urlField = page.getByRole("textbox", { name: "Endpoint URL" });
+    await expect(urlField).toBeVisible();
+    await expect(urlField).toHaveAttribute("id", "endpoint-url");
+    const tokenField = page.getByLabel(/Bearer token/);
+    await expect(tokenField).toBeVisible();
+    await expect(tokenField).toHaveAttribute("id", "endpoint-token");
+
+    // Keyboard-collapsible again (Enter toggles), and the fields leave the page.
+    await summary.focus();
+    await page.keyboard.press("Enter");
+    await expect(details).toHaveJSProperty("open", false);
+    await expect(page.locator("#endpoint-url")).toBeHidden();
+  });
+});
+
+// ── Non-vacuity: stripping the ARIA contract off live markup must FAIL the helper. ──────────────
+// If the tabs-contract helper silently matched nothing (a renamed widget, a lazy locator), every
+// green above would be vacuous. Strip the two load-bearing attributes off the REAL home tablist
+// and assert the helper REJECTS each time — proving the assertions bite on broken markup.
+test.describe("harness non-vacuity", () => {
+  test("stripping aria-selected or the roving tabindex makes the tabs contract FAIL", async ({
+    page,
+  }) => {
+    const home = new BasePage(page);
+    await home.goto("");
+    await home.expectRunnerState("home", "idle-preview");
+    const tablist = page.getByRole("tablist", { name: "Runner editor" });
+
+    // Sanity: the intact widget passes (so the rejections below are caused by the strip).
+    await expectApgTablistStatic(tablist, { timeout: 5_000 });
+
+    // Strip 1 — remove aria-selected from the selected tab (no tab selected): must FAIL fast.
+    await tablist.evaluate((el) => {
+      el.querySelector('[role="tab"][aria-selected="true"]')?.removeAttribute("aria-selected");
+    });
+    await expect(
+      expectApgTablistStatic(tablist, { timeout: 1_500 }),
+      "the contract helper PASSED on a tablist with no selected tab — the a11y assertions are vacuous",
+    ).rejects.toThrow();
+
+    // Restore, then Strip 2 — flatten the roving tabindex (every tab tabbable): must FAIL fast.
+    await tablist.evaluate((el) => {
+      const tabs = el.querySelectorAll<HTMLElement>('[role="tab"]');
+      tabs.forEach((t, i) => t.setAttribute("aria-selected", i === 0 ? "true" : "false"));
+    });
+    await expectApgTablistStatic(tablist, { timeout: 5_000 });
+    await tablist.evaluate((el) => {
+      el.querySelectorAll<HTMLElement>('[role="tab"]').forEach((t) =>
+        t.setAttribute("tabindex", "0"),
+      );
+    });
+    await expect(
+      expectApgTablistStatic(tablist, { timeout: 1_500 }),
+      "the contract helper PASSED on a flattened tabindex — the roving assertion is vacuous",
+    ).rejects.toThrow();
+  });
+});

--- a/site/src/components/command-palette.tsx
+++ b/site/src/components/command-palette.tsx
@@ -215,9 +215,28 @@ function PaletteItem({
 }
 
 export function CommandPalette({ children }: { children: React.ReactNode }) {
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpenState] = React.useState(false);
   const router = useRouter();
   const { theme, setTheme, resolvedTheme } = useTheme();
+
+  // [FABLE-5] sq-ymr2e.9 — ESC must RESTORE focus to the INVOKER (WAI-ARIA dialog focus
+  // contract; asserted by e2e/a11y-keyboard.spec.ts). The palette has no Radix
+  // <Dialog.Trigger> (it opens from a global ⌘K/Ctrl-K listener or the header button), and
+  // without one the close left focus on <body> — invisible to a keyboard/AT user. So every
+  // open path records document.activeElement and onCloseAutoFocus returns focus there.
+  const invokerRef = React.useRef<HTMLElement | null>(null);
+  const setOpen = React.useCallback((next: boolean | ((v: boolean) => boolean)) => {
+    setOpenState((v) => {
+      const n = typeof next === "function" ? next(v) : next;
+      if (n && !v) {
+        // Capturing inside the updater keeps the ⌘K toggle race-free; it is idempotent, so a
+        // StrictMode double-invoke is harmless.
+        invokerRef.current =
+          document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      }
+      return n;
+    });
+  }, []);
 
   // [OPUS-4.8] sq-ixc3.10 — the live operational commands the mounted workbench contributes,
   // bucketed into their fixed-order groups. Empty off the workbench (pure navigation then).
@@ -227,7 +246,7 @@ export function CommandPalette({ children }: { children: React.ReactNode }) {
     [operationalCommands],
   );
 
-  const ctx = React.useMemo(() => ({ open, setOpen }), [open]);
+  const ctx = React.useMemo(() => ({ open, setOpen }), [open, setOpen]);
 
   // Global ⌘K (macOS) / Ctrl-K (Windows/Linux) toggles the palette. We also let the platform
   // browser-search shortcut stay free: only K with the platform modifier is intercepted.
@@ -240,7 +259,7 @@ export function CommandPalette({ children }: { children: React.ReactNode }) {
     };
     document.addEventListener("keydown", onKeyDown);
     return () => document.removeEventListener("keydown", onKeyDown);
-  }, []);
+  }, [setOpen]);
 
   // Navigate (or run an action), then close. next/navigation's router.push respects the
   // configured basePath, so "/surface/zk" resolves under /sparq on Pages and at root under
@@ -250,13 +269,16 @@ export function CommandPalette({ children }: { children: React.ReactNode }) {
       setOpen(false);
       router.push(href);
     },
-    [router],
+    [router, setOpen],
   );
 
-  const runAction = React.useCallback((fn: () => void) => {
-    setOpen(false);
-    fn();
-  }, []);
+  const runAction = React.useCallback(
+    (fn: () => void) => {
+      setOpen(false);
+      fn();
+    },
+    [setOpen],
+  );
 
   const isDark = (resolvedTheme ?? theme) === "dark";
 
@@ -272,6 +294,16 @@ export function CommandPalette({ children }: { children: React.ReactNode }) {
           )}
         />
         <DialogPrimitive.Content
+          // [FABLE-5] sq-ymr2e.9 — return focus to the recorded invoker (fall back to the
+          // Radix default only when it is gone, e.g. after a palette navigation unmounted it).
+          onCloseAutoFocus={(event) => {
+            const invoker = invokerRef.current;
+            invokerRef.current = null;
+            if (invoker?.isConnected) {
+              event.preventDefault();
+              invoker.focus();
+            }
+          }}
           className={cn(
             "bg-card text-card-foreground fixed left-1/2 top-[12vh] z-50 w-[min(38rem,calc(100vw-2rem))] -translate-x-1/2",
             "overflow-hidden rounded-xl p-0 shadow-2xl ring-1 ring-foreground/10",

--- a/site/src/components/connect-panel.tsx
+++ b/site/src/components/connect-panel.tsx
@@ -26,6 +26,7 @@ import {
 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
+import { rovingTabIndex, useRovingTablist } from "@/lib/use-roving-tablist";
 import { Button } from "@/components/ui/button";
 import {
   type EndpointConfig,
@@ -208,11 +209,14 @@ function ModeSwitch({
   disabled: boolean;
   onChange: (active: boolean) => void;
 }) {
+  // [FABLE-5] sq-ymr2e.9 — APG tabs keyboard contract (arrow-key roving focus).
+  const tablistKeys = useRovingTablist();
   return (
     <div
       role="tablist"
       aria-label="Execution target"
       className="inline-flex rounded-lg border bg-background p-0.5"
+      {...tablistKeys}
     >
       <SwitchTab
         label="In-tab WASM"
@@ -254,6 +258,7 @@ function SwitchTab({
       role="tab"
       aria-selected={selected}
       disabled={disabled}
+      tabIndex={rovingTabIndex(selected)}
       title={title}
       onClick={onClick}
       className={cn(

--- a/site/src/components/home/hero-runner.tsx
+++ b/site/src/components/home/hero-runner.tsx
@@ -25,6 +25,7 @@ import { Play, Loader2, ArrowRight, ShieldCheck } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { rovingTabIndex, useRovingTablist } from "@/lib/use-roving-tablist";
 import { SparqlEditor } from "@/components/sparql-editor";
 import { RdfEditor } from "@/components/rdf-editor";
 import { ResultCell } from "@/components/repl-result-cells";
@@ -185,6 +186,8 @@ function PreviewTable() {
 export function HeroQueryRunner() {
   const router = useRouter();
   const [tab, setTab] = React.useState<"query" | "data">("query");
+  // [FABLE-5] sq-ymr2e.9 — APG tabs keyboard contract (arrow-key roving focus).
+  const tablistKeys = useRovingTablist();
   const [query, setQuery] = React.useState(HERO_DEFAULT_QUERY);
   const [data, setData] = React.useState(HERO_SAMPLE_TURTLE);
 
@@ -283,11 +286,14 @@ export function HeroQueryRunner() {
       className="overflow-hidden rounded-xl border border-primary/25 bg-card shadow-elevation-2"
       style={{ boxShadow: "var(--elevation-2), 0 0 0 1px var(--teal-glow)" }}
     >
-      {/* Tabs: Query (default) | Data — both editable, so the sample is inspectable. */}
+      {/* Tabs: Query (default) | Data — both editable, so the sample is inspectable.
+          [FABLE-5] sq-ymr2e.9 — APG tabs keyboard contract: roving tabindex + arrow-key
+          focus movement via the shared hook (asserted by e2e/a11y-keyboard.spec.ts). */}
       <div
         role="tablist"
         aria-label="Runner editor"
         className="flex items-center gap-1 border-b bg-muted/25 px-2 py-1.5"
+        {...tablistKeys}
       >
         {(["query", "data"] as const).map((t) => (
           <button
@@ -297,6 +303,7 @@ export function HeroQueryRunner() {
             role="tab"
             aria-selected={tab === t}
             aria-controls={`hero-panel-${t}`}
+            tabIndex={rovingTabIndex(tab === t)}
             onClick={() => setTab(t)}
             className={cn(
               "rounded-md px-3 py-1 text-xs font-medium capitalize transition-colors outline-none focus-visible:ring-3 focus-visible:ring-ring/40",

--- a/site/src/components/jsonld-editor.tsx
+++ b/site/src/components/jsonld-editor.tsx
@@ -82,10 +82,13 @@ export function JsonLdEditor({
   return (
     <div className={cn("relative rounded-lg border bg-muted/40", className)}>
       {/* Highlight layer: aria-hidden (the textarea is the accessible control). A trailing
-          newline keeps the last line's height stable while typing at the very end. */}
+          newline keeps the last line's height stable while typing at the very end.
+          [FABLE-5] sq-ymr2e.9 — tabIndex -1: keeps this aria-hidden scroller OUT of the
+          keyboard Tab order (Chromium keyboard-focusable scrollers; see sparql-editor.tsx). */}
       <pre
         ref={preRef}
         aria-hidden="true"
+        tabIndex={-1}
         className={cn(
           "pointer-events-none absolute inset-0 m-0 overflow-auto",
           EDITOR_PAD_CLASS,

--- a/site/src/components/rdf-editor.tsx
+++ b/site/src/components/rdf-editor.tsx
@@ -79,10 +79,13 @@ export function RdfEditor({
   return (
     <div className={cn("relative rounded-lg border bg-muted/40", className)}>
       {/* Highlight layer: aria-hidden (the textarea is the accessible control). A trailing
-          newline keeps the last line's height stable while typing at the very end. */}
+          newline keeps the last line's height stable while typing at the very end.
+          [FABLE-5] sq-ymr2e.9 — tabIndex -1: keeps this aria-hidden scroller OUT of the
+          keyboard Tab order (Chromium keyboard-focusable scrollers; see sparql-editor.tsx). */}
       <pre
         ref={preRef}
         aria-hidden="true"
+        tabIndex={-1}
         className={cn(
           "pointer-events-none absolute inset-0 m-0 overflow-auto",
           EDITOR_PAD_CLASS,

--- a/site/src/components/repl.tsx
+++ b/site/src/components/repl.tsx
@@ -27,6 +27,7 @@ import { toast } from "sonner";
 import { Button, buttonVariants } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { cn } from "@/lib/utils";
+import { rovingTabIndex, useRovingTablist } from "@/lib/use-roving-tablist";
 // [OPUS-4.8] sq-vw3ax (bold /try redesign) — the local IDE-workbench panel chrome + the
 // data-tool result rendering (typed-value cells + the live-derived aggregate mini-viz).
 import { ReplPanel } from "@/components/repl-panel";
@@ -1758,11 +1759,14 @@ function GraphFormatTabs({
   format: GraphFormat;
   onChange: (f: GraphFormat) => void;
 }) {
+  // [FABLE-5] sq-ymr2e.9 — APG tabs keyboard contract (arrow-key roving focus).
+  const tablistKeys = useRovingTablist();
   return (
     <div
       role="tablist"
       aria-label="Graph output format"
       className="inline-flex flex-wrap gap-0.5 rounded-lg border bg-muted/40 p-0.5"
+      {...tablistKeys}
     >
       {GRAPH_FORMAT_TABS.map((t) => (
         <button
@@ -1770,6 +1774,7 @@ function GraphFormatTabs({
           type="button"
           role="tab"
           aria-selected={format === t.value}
+          tabIndex={rovingTabIndex(format === t.value)}
           title={t.title}
           onClick={() => onChange(t.value)}
           className={cn(
@@ -1980,11 +1985,14 @@ function ResultViewTabs({
         : "No numeric column to chart — run an aggregate query",
     },
   ];
+  // [FABLE-5] sq-ymr2e.9 — APG tabs keyboard contract (arrow-key roving focus).
+  const tablistKeys = useRovingTablist();
   return (
     <div
       role="tablist"
       aria-label="Result view"
       className="inline-flex rounded-lg border bg-muted/40 p-0.5"
+      {...tablistKeys}
     >
       {tabs.map((t) => (
         <button
@@ -1994,6 +2002,7 @@ function ResultViewTabs({
           aria-selected={view === t.value}
           aria-disabled={t.disabled}
           disabled={t.disabled}
+          tabIndex={rovingTabIndex(view === t.value)}
           title={t.title}
           onClick={() => onChange(t.value)}
           className={cn(

--- a/site/src/components/sparql-editor.tsx
+++ b/site/src/components/sparql-editor.tsx
@@ -101,10 +101,16 @@ export function SparqlEditor({
     <div className={cn("space-y-2", className)}>
       <div className="relative rounded-lg border bg-muted/40">
         {/* Highlight layer: aria-hidden (the textarea is the accessible control). A trailing
-            newline keeps the last line's height stable while typing at the very end. */}
+            newline keeps the last line's height stable while typing at the very end.
+            [FABLE-5] sq-ymr2e.9 — tabIndex -1: modern Chromium makes scrollable containers
+            with no focusable children KEYBOARD-focusable, which put this aria-hidden layer in
+            the Tab order (focus on aria-hidden content — a WCAG 4.1.2-class bug axe cannot
+            see; caught by e2e/a11y-keyboard.spec.ts). Scrolling stays available through the
+            textarea, whose scroll this layer mirrors. */}
         <pre
           ref={preRef}
           aria-hidden="true"
+          tabIndex={-1}
           className={cn(
             "pointer-events-none absolute inset-0 m-0 overflow-auto",
             EDITOR_PAD_CLASS,

--- a/site/src/lib/use-roving-tablist.ts
+++ b/site/src/lib/use-roving-tablist.ts
@@ -1,0 +1,97 @@
+"use client";
+
+// [FABLE-5] sq-ymr2e.9 — shared WAI-ARIA tabs keyboard contract for the site's
+// `role="tablist"` selector family (home hero Query/Data, the /try Result-view /
+// Graph-format / Execution-target selectors).
+//
+// The site's tab widgets already carried the STATIC half of the ARIA Authoring
+// Practices tabs pattern (`tablist`/`tab` roles + `aria-selected`) but not the
+// BEHAVIORAL half: a roving tabindex (exactly one tab in the page Tab-order) and
+// Left/Right-arrow + Home/End focus movement. That gap is exactly the "checks axe
+// cannot see" class research/web-gui-test-program.md §3.2 gates on, and it is
+// asserted end-to-end by e2e/a11y-keyboard.spec.ts — strip this behaviour and that
+// spec goes red (its non-vacuity guard proves the assertions are live).
+//
+// Contract implemented (APG "Tabs Pattern", automatic activation — every panel
+// switch here is cheap local state, so selection follows focus):
+//   * ArrowRight / ArrowLeft move focus to the next / previous ENABLED tab,
+//     wrapping at the ends; Home / End jump to the first / last enabled tab.
+//   * The newly focused tab is ACTIVATED (a programmatic click on the tab button,
+//     the same code path as a keyboard Enter/Space on it).
+//   * `rovingTabIndex(selected)` puts only the selected tab in the Tab-order
+//     (tabIndex 0, all siblings -1), so Tab from the tablist moves INTO the panel
+//     content, never through every tab.
+//
+// Dependency-free (a keydown handler + a tabIndex helper); works on the plain
+// <button role="tab"> markup every widget in the family already renders.
+import * as React from "react";
+
+/** Keys the tablist handles; everything else falls through untouched. */
+const TABLIST_KEYS = ["ArrowRight", "ArrowLeft", "Home", "End"] as const;
+type TablistKey = (typeof TABLIST_KEYS)[number];
+
+function isTablistKey(key: string): key is TablistKey {
+  return (TABLIST_KEYS as readonly string[]).includes(key);
+}
+
+/** The enabled `role="tab"` buttons of the tablist, in DOM order. */
+function enabledTabs(tablist: HTMLElement): HTMLElement[] {
+  return Array.from(
+    tablist.querySelectorAll<HTMLElement>('[role="tab"]'),
+  ).filter(
+    (tab) =>
+      !(tab as HTMLButtonElement).disabled &&
+      tab.getAttribute("aria-disabled") !== "true",
+  );
+}
+
+/**
+ * The roving-tabindex value for one tab: only the SELECTED tab participates in the
+ * page Tab-order (APG tabs pattern), so keyboard users Tab past the widget in one
+ * stop and use arrow keys within it.
+ */
+export function rovingTabIndex(selected: boolean): 0 | -1 {
+  return selected ? 0 : -1;
+}
+
+/**
+ * Arrow-key roving-focus handler for a `role="tablist"` container whose tabs are
+ * `<button role="tab">` children. Attach as the tablist's `onKeyDown`. Focus moves
+ * to the target tab and activates it (automatic activation).
+ */
+export function useRovingTablist(): {
+  onKeyDown: (event: React.KeyboardEvent<HTMLElement>) => void;
+} {
+  const onKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLElement>) => {
+      if (!isTablistKey(event.key)) return;
+      const tabs = enabledTabs(event.currentTarget);
+      const current = tabs.indexOf(event.target as HTMLElement);
+      if (current === -1 || tabs.length < 2) return;
+      event.preventDefault();
+
+      let next: number;
+      switch (event.key) {
+        case "ArrowRight":
+          next = (current + 1) % tabs.length;
+          break;
+        case "ArrowLeft":
+          next = (current - 1 + tabs.length) % tabs.length;
+          break;
+        case "Home":
+          next = 0;
+          break;
+        default: // "End"
+          next = tabs.length - 1;
+      }
+
+      const target = tabs[next];
+      target.focus();
+      // Automatic activation: selection follows focus (cheap local-state panels).
+      target.click();
+    },
+    [],
+  );
+
+  return { onKeyDown };
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — autonomous session working bead `sq-ymr2e.9` (epic `sq-ymr2e`, design of record `research/web-gui-test-program.md` §3.2). Model: Claude Fable 5 `[FABLE-5]` (resumed and finished a prior Fable agent's pushed WIP at 5bdfb478).

## What this is

The **behavioral half** of the site's WCAG gate — the checks axe cannot see — as one new spec, `site/e2e/a11y-keyboard.spec.ts`, on the sq-ymr2e.1 hermetic/determinism harness:

- **(a) Keyboard-only /try journey**: Tab → editor (`:focus-visible` ring asserted) → type a real query → Ctrl/Cmd+Enter → read engine-computed results (exact cells, engine-sorted order) → reach the result-view tabs by keyboard and arrow-switch Table ⇄ JSON — with a machine check that **zero trusted pointer events** fired and zero external requests escaped.
- **(b) WAI-ARIA APG tabs contract** on the tab/panel family (home hero Query/Data incl. the tabpanel half; /try result-view in situ; /try execution-target static contract): roles, exactly one `aria-selected`, **roving tabindex**, ArrowLeft/Right selection-follows-focus, Tab-from-tablist lands inside the visible panel.
- **(c) ⌘K palette focus contract**: focus in the combobox on open; from the first arrow key `aria-activedescendant` references a real selected option while DOM focus never leaves the input; **Tab is trapped**; **ESC restores focus to the invoker**.
- **(d) Connect-drawer disclosure**: keyboard-toggleable native `<details>/<summary>` state + programmatically associated labels on the endpoint fields.

## ⚠️ Feature-adjacent component fixes (user-visible; reviewers please look)

The contracts above **failed against the real components** — the spec surfaced three real a11y bugs, fixed here (this is a test PR that carries behavior changes):

1. **Roving-tabindex + arrow-key keyboard support on every in-scope tablist** (new shared `site/src/lib/use-roving-tablist.ts`, dependency-free, ~40 LOC; wired into `hero-runner.tsx`, `repl.tsx` GraphFormat/ResultView tabs, `connect-panel.tsx` ModeSwitch). The widgets had the static roles but no keyboard half. *Behavior change:* unselected tabs leave the page Tab-order (the tablist becomes one Tab-stop, per APG); arrow keys move focus **and activate** (automatic activation — all panels are cheap local state; on the execution-target switch activation is a reversible local mode flip). Mouse behavior unchanged.
2. **`tabIndex={-1}` on the editors' `aria-hidden` highlight `<pre>`** (`sparql-editor.tsx`, `rdf-editor.tsx`, `jsonld-editor.tsx`). Modern Chromium makes scrollable containers with no focusable children keyboard-focusable, so Tab landed **inside `aria-hidden` content** — a WCAG 4.1.2-class bug axe misses (the focusability is UA-derived, not a tabindex). The journey helper now rejects any focus stop inside `aria-hidden` content.
3. **⌘K palette ESC left focus on `<body>`** (`command-palette.tsx`). The palette has no Radix `Dialog.Trigger`, so close never restored focus. Every open path now records the invoker and `onCloseAutoFocus` returns focus there (falls back to the Radix default if the invoker unmounted). Empirically verified: before the fix, `after ESC focus: BODY`.

**Honest evidence that the tests bite:** the two component-bug tests failed **5/5 deterministically** against the unfixed components in a full `--repeat-each=5 --retries=0` run (`10 failed / 20 passed (17.2m)`), and pass 5/5 after the fixes.

## Non-vacuity (the bead's acceptance criterion)

- **In-suite, permanent**: the `harness non-vacuity` test strips `aria-selected` / flattens the roving tabindex on the live home tablist via DOM mutation and asserts the contract helper **rejects** each time.
- **Source-level spot check** (throwaway strip of `tabIndex={rovingTabIndex(...)}` in `hero-runner.tsx`, then restored):

```
Error: the selected tab must be IN the page Tab-order (tabindex 0 — roving tabindex)
expect(locator).toHaveAttribute(expected) failed
Locator:  getByRole('tablist', { name: 'Runner editor' }).locator('[role="tab"][aria-selected="true"]')
Expected: "0"
Received: ""
  1 failed
    [chromium] › e2e/a11y-keyboard.spec.ts:288:3 › WAI-ARIA tabs contract › home hero Query/Data: full tabs pattern — roles, panels, roving focus
```

## Evidence

- `npx playwright test a11y-keyboard.spec.ts --repeat-each=5 --retries=0` against the harness of record (`next dev`, hermetic fixtures): **`30 passed (1.9m)`**, exit 0.
- Same flags against the **served static export** (`npm run build` → `out/` served under `/sparq`): **`30 passed (42.0s)`**, exit 0.
- `npm run build` (static export, WASM bundle present): `BUILD_EXIT=0`, `✓ Generating static pages (56/56)`, `✓ Exporting (2/2)`. `npm run lint`: `✔ No ESLint warnings or errors`. `tsc --noEmit`: clean. `test:e2e:grep-gate` (zero `waitForTimeout`): clean.
- All wall-clock figures above are indicative work-box values, not canonical.

## Known gaps → beads (not silently absorbed)

- `sq-pa15k` — upstream cmdk 1.1.1 emits no `aria-activedescendant` for the mount-time initial selection (only from the first arrow key); the spec asserts the post-arrow contract and cites the bead.
- `sq-wlnr2` — four showcase-page tablists (`data-formats-demo`, `inference-playground`, `verifiable-credentials`, `shacl-playground`) still lack the keyboard half; same shared hook applies.

Do NOT merge via agent — not armed by design (per task brief).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
