### PR TITLE
fix(zk/xpath): signed epoch for pre-1970 xs:dateTime — floor-division civil extraction + signed ordering (sq-3x7dl.7) [FABLE-5]

### DIFF
--- a/zk/xpath/ARCHITECTURE.md
+++ b/zk/xpath/ARCHITECTURE.md
@@ -81,8 +81,10 @@ noir_XPath/
 // Stores microseconds since Unix epoch (1970-01-01T00:00:00Z) as UTC
 // This minimizes constraints while allowing all component extraction
 struct XsdDateTime {
-    /// Microseconds since Unix epoch (UTC)
-    /// Range: supports dates from ~290,000 BCE to ~290,000 CE with microsecond precision
+    /// Microseconds since Unix epoch (UTC), as a SIGNED i64 stored in its
+    /// two's-complement 64-bit pattern (encode `(e as u64) as Field`, decode
+    /// `f as i64`); pre-1970 instants are negative (sq-3x7dl.7)
+    /// Range: supports dates from ~292,000 BCE to ~292,000 CE with microsecond precision
     epoch_microseconds: Field,
 }
 

--- a/zk/xpath/xpath/src/date.nr
+++ b/zk/xpath/xpath/src/date.nr
@@ -138,7 +138,9 @@ pub fn date_ge(a: XsdDate, b: XsdDate) -> bool {
 
 /// Integer floor division for positive divisors.
 /// Noir division truncates toward zero; for negative numerators we need floor.
-fn floor_div_i64(a: i64, b: i64) -> i64 {
+/// pub(crate): shared with datetime.nr so the signed-epoch dateTime path uses
+/// the same floor-division idiom as the date path (sq-3x7dl.7). [FABLE-5]
+pub(crate) fn floor_div_i64(a: i64, b: i64) -> i64 {
     assert(b > 0, "floor_div_i64 requires positive divisor");
     let q = a / b;
     let r = a % b;
@@ -153,7 +155,8 @@ fn floor_div_i64(a: i64, b: i64) -> i64 {
 /// Proleptic Gregorian calendar, ISO-8601 compatible (allows year 0).
 ///
 /// Based on Howard Hinnant's `days_from_civil` (public domain).
-fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
+/// pub(crate): the single Hinnant implementation, shared with datetime.nr (sq-3x7dl.7).
+pub(crate) fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
     // Shift March to be month 0.
     let y = year - if month <= 2 { 1 } else { 0 };
     let era = floor_div_i64(if y >= 0 { y } else { y - 399 }, 400);
@@ -168,7 +171,8 @@ fn days_from_civil(year: i64, month: i64, day: i64) -> i64 {
 /// Proleptic Gregorian calendar, ISO-8601 compatible (allows year 0).
 ///
 /// Based on Howard Hinnant's `civil_from_days` (public domain).
-fn civil_from_days(epoch_days: i64) -> (i64, i64, i64) {
+/// pub(crate): the single Hinnant implementation, shared with datetime.nr (sq-3x7dl.7).
+pub(crate) fn civil_from_days(epoch_days: i64) -> (i64, i64, i64) {
     let z = epoch_days + 719468;
     let era = floor_div_i64(if z >= 0 { z } else { z - 146096 }, 146097);
     let doe = z - era * 146097; // [0, 146096]

--- a/zk/xpath/xpath/src/datetime.nr
+++ b/zk/xpath/xpath/src/datetime.nr
@@ -5,11 +5,21 @@
 //! Component extraction returns local time values (adjusted by timezone).
 //! Comparisons use UTC time for correct ordering.
 //!
+//! SIGNED EPOCH ENCODING (sq-3x7dl.7) [FABLE-5]:
+//! The epoch value is a SIGNED i64 count of microseconds since 1970-01-01T00:00:00Z;
+//! pre-1970 instants are negative. The `Field` slot on `XsdDateTime` stores the
+//! two's-complement 64-bit pattern of that i64 (encode: `(e as u64) as Field`;
+//! decode: `f as i64`). Every consumer here decodes to i64 first: ordering is a
+//! signed comparison, and calendar extraction uses floor division / Euclidean
+//! remainder (shared with `date.nr`) so that e.g. epoch -1 is
+//! 1969-12-31T23:59:59.999999Z, not garbage. Range: about +/-292,000 years.
+//!
 //! XPath functions implemented:
 //! - fn:year-from-dateTime, fn:month-from-dateTime, fn:day-from-dateTime
 //! - fn:hours-from-dateTime, fn:minutes-from-dateTime, fn:seconds-from-dateTime
 //! - op:dateTime-equal, op:dateTime-less-than, op:dateTime-greater-than
 
+use crate::date::{civil_from_days, days_from_civil, floor_div_i64};
 use crate::duration::duration_from_microseconds;
 use crate::types::XsdDateTime;
 
@@ -29,11 +39,19 @@ global MICROSECONDS_PER_HOUR: u64 = 3_600_000_000;
 /// Microseconds per day
 global MICROSECONDS_PER_DAY: u64 = 86_400_000_000;
 
+/// Microseconds per day as SIGNED i64 -- for floor division over the signed
+/// epoch range (pre-1970 epochs are negative). [FABLE-5]
+global MICROSECONDS_PER_DAY_SIGNED: i64 = 86_400_000_000;
+
 // ============================================================================
 // Construction Functions
 // ============================================================================
 
 /// Create a DateTime from epoch microseconds (assumes UTC, no timezone offset)
+///
+/// `micros` is the SIGNED i64 epoch encoded as its two's-complement 64-bit
+/// pattern (see the module doc): for a pre-1970 instant pass
+/// `(e as u64) as Field` where `e: i64` is negative.
 pub fn datetime_from_epoch_microseconds(micros: Field) -> XsdDateTime {
     XsdDateTime::new(micros)
 }
@@ -88,26 +106,33 @@ pub fn datetime_from_components_with_tz(
     microsecond: u32,
     tz_offset_minutes: i16,
 ) -> XsdDateTime {
-    let days = civil_to_days(year, month, day);
+    // All arithmetic is SIGNED: pre-1970 civil dates give negative day counts,
+    // and Noir u64 arithmetic is overflow-checked, so the old
+    // `(days as u64) * MICROSECONDS_PER_DAY` aborted for any date before 1970.
+    // [FABLE-5]
+    let days: i64 = civil_to_days(year, month, day);
 
     // Convert time components to microseconds (local time)
-    let time_micros: u64 = (hour as u64) * MICROSECONDS_PER_HOUR
-        + (minute as u64) * MICROSECONDS_PER_MINUTE
-        + (second as u64) * MICROSECONDS_PER_SECOND
-        + microsecond as u64;
+    let time_micros: i64 = (hour as i64) * (MICROSECONDS_PER_HOUR as i64)
+        + (minute as i64) * (MICROSECONDS_PER_MINUTE as i64)
+        + (second as i64) * (MICROSECONDS_PER_SECOND as i64)
+        + microsecond as i64;
 
-    // Total microseconds since epoch (in local time)
-    let local_micros: u64 = (days as u64) * MICROSECONDS_PER_DAY + time_micros;
+    // Total microseconds since epoch (in local time), signed
+    let local_micros: i64 = days * MICROSECONDS_PER_DAY_SIGNED + time_micros;
 
     // Convert to UTC by subtracting the timezone offset
     let offset_micros: i64 = (tz_offset_minutes as i64) * 60_000_000;
-    let utc_micros: i64 = (local_micros as i64) - offset_micros;
-    let utc_u64: u64 = utc_micros as u64;
+    let utc_micros: i64 = local_micros - offset_micros;
 
-    XsdDateTime::new_with_tz(utc_u64 as Field, tz_offset_minutes)
+    // Store the two's-complement bit pattern of the signed epoch (see module doc)
+    XsdDateTime::new_with_tz((utc_micros as u64) as Field, tz_offset_minutes)
 }
 
 /// Extract epoch microseconds from a DateTime (UTC)
+///
+/// Returns the two's-complement pattern of the signed i64 epoch; decode a
+/// possibly pre-1970 value with `as i64` (see the module doc).
 pub fn datetime_to_epoch_microseconds(dt: XsdDateTime) -> Field {
     dt.epoch_microseconds
 }
@@ -155,19 +180,30 @@ pub fn day_from_datetime(dt: XsdDateTime) -> u8 {
     day
 }
 
+/// Microseconds elapsed since local midnight, always in [0, MICROSECONDS_PER_DAY).
+///
+/// Euclidean remainder over the SIGNED local epoch value: for a negative local
+/// epoch (pre-1970), a plain u64 `%` of the two's-complement bit pattern is
+/// garbage (e.g. epoch -1 must give 86_399_999_999, i.e. 23:59:59.999999).
+/// Computed as `local - floor(local / day) * day`, mirroring date.nr's
+/// floor-division idiom. [FABLE-5]
+fn time_of_day_micros(dt: XsdDateTime) -> u64 {
+    let local: i64 = dt.local_microseconds() as i64;
+    let days: i64 = floor_div_i64(local, MICROSECONDS_PER_DAY_SIGNED);
+    (local - days * MICROSECONDS_PER_DAY_SIGNED) as u64
+}
+
 /// fn:hours-from-dateTime
 /// Extracts the hours component (0-23) from a dateTime value (in local time).
 pub fn hours_from_datetime(dt: XsdDateTime) -> u8 {
-    let micros: u64 = dt.local_microseconds() as u64;
-    let day_micros = micros % MICROSECONDS_PER_DAY;
+    let day_micros = time_of_day_micros(dt);
     (day_micros / MICROSECONDS_PER_HOUR) as u8
 }
 
 /// fn:minutes-from-dateTime
 /// Extracts the minutes component (0-59) from a dateTime value (in local time).
 pub fn minutes_from_datetime(dt: XsdDateTime) -> u8 {
-    let micros: u64 = dt.local_microseconds() as u64;
-    let day_micros = micros % MICROSECONDS_PER_DAY;
+    let day_micros = time_of_day_micros(dt);
     let hour_micros = day_micros % MICROSECONDS_PER_HOUR;
     (hour_micros / MICROSECONDS_PER_MINUTE) as u8
 }
@@ -177,8 +213,7 @@ pub fn minutes_from_datetime(dt: XsdDateTime) -> u8 {
 /// Note: XPath returns a decimal including fractional seconds;
 /// use microseconds_from_datetime for the fractional part.
 pub fn seconds_from_datetime(dt: XsdDateTime) -> u8 {
-    let micros: u64 = dt.local_microseconds() as u64;
-    let day_micros = micros % MICROSECONDS_PER_DAY;
+    let day_micros = time_of_day_micros(dt);
     let hour_micros = day_micros % MICROSECONDS_PER_HOUR;
     let minute_micros = hour_micros % MICROSECONDS_PER_MINUTE;
     (minute_micros / MICROSECONDS_PER_SECOND) as u8
@@ -186,8 +221,8 @@ pub fn seconds_from_datetime(dt: XsdDateTime) -> u8 {
 
 /// Extract microseconds within the current second (0-999999)
 pub fn microseconds_from_datetime(dt: XsdDateTime) -> u32 {
-    let micros: u64 = dt.local_microseconds() as u64;
-    (micros % MICROSECONDS_PER_SECOND) as u32
+    let day_micros = time_of_day_micros(dt);
+    (day_micros % MICROSECONDS_PER_SECOND) as u32
 }
 
 // ============================================================================
@@ -202,33 +237,38 @@ pub fn datetime_equal(a: XsdDateTime, b: XsdDateTime) -> bool {
 
 /// op:dateTime-less-than
 /// Returns true if the first dateTime is earlier than the second.
+/// SIGNED comparison: a pre-1970 (negative) epoch orders BEFORE any
+/// post-1970 epoch; the old u64 comparison ordered it after. [FABLE-5]
 pub fn datetime_less_than(a: XsdDateTime, b: XsdDateTime) -> bool {
-    let a_micros: u64 = a.epoch_microseconds as u64;
-    let b_micros: u64 = b.epoch_microseconds as u64;
+    let a_micros: i64 = a.epoch_microseconds as i64;
+    let b_micros: i64 = b.epoch_microseconds as i64;
     a_micros < b_micros
 }
 
 /// op:dateTime-greater-than
 /// Returns true if the first dateTime is later than the second.
+/// Signed comparison over the i64 epoch (see datetime_less_than). [FABLE-5]
 pub fn datetime_greater_than(a: XsdDateTime, b: XsdDateTime) -> bool {
-    let a_micros: u64 = a.epoch_microseconds as u64;
-    let b_micros: u64 = b.epoch_microseconds as u64;
+    let a_micros: i64 = a.epoch_microseconds as i64;
+    let b_micros: i64 = b.epoch_microseconds as i64;
     a_micros > b_micros
 }
 
 /// op:dateTime-less-than-or-equal
 /// Returns true if the first dateTime is earlier than or equal to the second.
+/// Signed comparison over the i64 epoch (see datetime_less_than). [FABLE-5]
 pub fn datetime_le(a: XsdDateTime, b: XsdDateTime) -> bool {
-    let a_micros: u64 = a.epoch_microseconds as u64;
-    let b_micros: u64 = b.epoch_microseconds as u64;
+    let a_micros: i64 = a.epoch_microseconds as i64;
+    let b_micros: i64 = b.epoch_microseconds as i64;
     a_micros <= b_micros
 }
 
 /// op:dateTime-greater-than-or-equal
 /// Returns true if the first dateTime is later than or equal to the second.
+/// Signed comparison over the i64 epoch (see datetime_less_than). [FABLE-5]
 pub fn datetime_ge(a: XsdDateTime, b: XsdDateTime) -> bool {
-    let a_micros: u64 = a.epoch_microseconds as u64;
-    let b_micros: u64 = b.epoch_microseconds as u64;
+    let a_micros: i64 = a.epoch_microseconds as i64;
+    let b_micros: i64 = b.epoch_microseconds as i64;
     a_micros >= b_micros
 }
 
@@ -236,74 +276,27 @@ pub fn datetime_ge(a: XsdDateTime, b: XsdDateTime) -> bool {
 // Internal Calendar Functions
 // ============================================================================
 
-/// Convert civil date to days since Unix epoch
-/// Based on Howard Hinnant's algorithms: http://howardhinnant.github.io/date_algorithms.html
+/// Convert civil date to days since Unix epoch.
+/// Delegates to the shared Howard Hinnant `days_from_civil` in date.nr --
+/// one implementation for both xs:date and xs:dateTime (sq-3x7dl.7). [FABLE-5]
 fn civil_to_days(year: i32, month: u8, day: u8) -> i64 {
-    let y: i64 = if month <= 2 {
-        year as i64 - 1
-    } else {
-        year as i64
-    };
-    let m: i64 = month as i64;
-    let d: i64 = day as i64;
-
-    // Calculate era (400-year period)
-    let era: i64 = if y >= 0 { y / 400 } else { (y - 399) / 400 };
-
-    // Year of era [0, 399]
-    let yoe: i64 = y - era * 400;
-
-    // Day of year calculation
-    // For months Mar-Dec, use m-3; for Jan-Feb, use m+9
-    let adj_m: i64 = if m > 2 { m - 3 } else { m + 9 };
-    let doy: i64 = (153 * adj_m + 2) / 5 + d - 1;
-
-    // Day of era
-    let doe: i64 = yoe * 365 + yoe / 4 - yoe / 100 + doy;
-
-    // Total days from epoch
-    era * 146097 + doe - 719468
+    days_from_civil(year as i64, month as i64, day as i64)
 }
 
-/// Convert epoch microseconds to civil date (year, month, day)
-/// Based on Howard Hinnant's algorithms: http://howardhinnant.github.io/date_algorithms.html
+/// Convert SIGNED epoch microseconds (two's-complement pattern in the Field,
+/// see module doc) to a civil date (year, month, day).
+///
+/// FLOOR division to days: for a negative epoch, unsigned division of the bit
+/// pattern is garbage and truncating i64 division rounds toward zero (epoch -1
+/// must land on day -1 = 1969-12-31, not day 0). Delegates to the shared
+/// Hinnant `civil_from_days` in date.nr, which is exact over the signed range
+/// (its `date_from_epoch_days(-1) -> 1969-12-31` test is the precedent).
+/// [FABLE-5]
 fn epoch_to_civil(epoch_micros: Field) -> (i32, u8, u8) {
-    // Convert to days since epoch
-    let micros: u64 = epoch_micros as u64;
-    let days: i64 = (micros / MICROSECONDS_PER_DAY) as i64;
-
-    // Shift epoch from 1970-01-01 to 0000-03-01 for easier leap year handling
-    // days from 1970-01-01 to 0000-03-01 is -719468
-    let z: i64 = days + 719468;
-
-    // Calculate era (400-year period)
-    let era: i64 = if z >= 0 {
-        z / 146097
-    } else {
-        (z - 146096) / 146097
-    };
-
-    // Day of era [0, 146096]
-    let doe: i64 = z - era * 146097;
-
-    // Year of era [0, 399]
-    let yoe: i64 = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-
-    // Year
-    let y: i64 = yoe + era * 400;
-
-    // Day of year [0, 365]
-    let doy: i64 = doe - (365 * yoe + yoe / 4 - yoe / 100);
-
-    // Month and day calculation
-    let mp: i64 = (5 * doy + 2) / 153;
-    let d: i64 = doy - (153 * mp + 2) / 5 + 1;
-    let m: i64 = if mp < 10 { mp + 3 } else { mp - 9 };
-
-    // Adjust year if month is Jan or Feb
-    let year: i64 = if m <= 2 { y + 1 } else { y };
-
-    (year as i32, m as u8, d as u8)
+    let micros: i64 = epoch_micros as i64;
+    let days: i64 = floor_div_i64(micros, MICROSECONDS_PER_DAY_SIGNED);
+    let (y, m, d) = civil_from_days(days);
+    (y as i32, m as u8, d as u8)
 }
 
 // ============================================================================
@@ -334,4 +327,168 @@ pub fn adjust_datetime_to_timezone_none(dt: XsdDateTime) -> XsdDateTime {
     let local_micros: i64 =
         dt.epoch_microseconds as i64 + (dt.tz_offset_minutes as i64) * 60_000_000;
     XsdDateTime::new(local_micros as u64 as Field)
+}
+
+// ============================================================================
+// Tests -- signed (pre-1970) epoch semantics (sq-3x7dl.7) [FABLE-5]
+//
+// Every expected value below is quoted from an INDEPENDENT Python oracle
+// (proleptic-Gregorian `datetime` + `timedelta` microsecond arithmetic):
+//   (dt - datetime(1970,1,1, tzinfo=utc)) // timedelta(microseconds=1)
+// ============================================================================
+
+/// Encode a signed i64 epoch as the canonical Field bit pattern (test helper).
+fn signed_epoch(e: i64) -> Field {
+    (e as u64) as Field
+}
+
+#[test]
+fn test_datetime_negative_epoch_civil_extraction() {
+    // Oracle: epoch_us=-1 -> 1969-12-31T23:59:59.999999+00:00
+    let dt = datetime_from_epoch_microseconds(signed_epoch(-1));
+    assert(year_from_datetime(dt) == 1969);
+    assert(month_from_datetime(dt) == 12);
+    assert(day_from_datetime(dt) == 31);
+    assert(hours_from_datetime(dt) == 23);
+    assert(minutes_from_datetime(dt) == 59);
+    assert(seconds_from_datetime(dt) == 59);
+    assert(microseconds_from_datetime(dt) == 999999);
+
+    // Oracle: epoch_us=-86400000000 -> 1969-12-31T00:00:00+00:00
+    let dt2 = datetime_from_epoch_microseconds(signed_epoch(-86_400_000_000));
+    assert(year_from_datetime(dt2) == 1969);
+    assert(month_from_datetime(dt2) == 12);
+    assert(day_from_datetime(dt2) == 31);
+    assert(hours_from_datetime(dt2) == 0);
+    assert(minutes_from_datetime(dt2) == 0);
+    assert(seconds_from_datetime(dt2) == 0);
+
+    // Oracle: 1965-04-09T03:30:15.250000+00:00 -> epoch_us=-149286584750000
+    let dt3 = datetime_from_epoch_microseconds(signed_epoch(-149_286_584_750_000));
+    assert(year_from_datetime(dt3) == 1965);
+    assert(month_from_datetime(dt3) == 4);
+    assert(day_from_datetime(dt3) == 9);
+    assert(hours_from_datetime(dt3) == 3);
+    assert(minutes_from_datetime(dt3) == 30);
+    assert(seconds_from_datetime(dt3) == 15);
+    assert(microseconds_from_datetime(dt3) == 250000);
+}
+
+#[test]
+fn test_datetime_pre1970_ordering_signed() {
+    // Oracle: 1969-07-20T20:17:40Z -> epoch_us=-14182940000000;
+    //         2020-06-15T12:00:00Z -> epoch_us=1592222400000000
+    let dt1969 = datetime_from_epoch_microseconds(signed_epoch(-14_182_940_000_000));
+    let dt2020 = datetime_from_epoch_microseconds(signed_epoch(1_592_222_400_000_000));
+    // The u64-compared bit pattern of a negative epoch is huge; a signed
+    // comparison must still order 1969 BEFORE 2020.
+    assert(datetime_less_than(dt1969, dt2020));
+    assert(!datetime_less_than(dt2020, dt1969));
+    assert(datetime_greater_than(dt2020, dt1969));
+    assert(datetime_le(dt1969, dt2020));
+    assert(datetime_ge(dt2020, dt1969));
+
+    // -1us orders immediately before the epoch itself
+    let just_before = datetime_from_epoch_microseconds(signed_epoch(-1));
+    let epoch = datetime_from_epoch_microseconds(0);
+    assert(datetime_less_than(just_before, epoch));
+    assert(!datetime_less_than(epoch, just_before));
+
+    // Two negative epochs order among themselves:
+    // Oracle: 1968-02-29T12:00:00Z=-58017600000000 < 1969-07-20T20:17:40Z=-14182940000000
+    let dt1968 = datetime_from_epoch_microseconds(signed_epoch(-58_017_600_000_000));
+    assert(datetime_less_than(dt1968, dt1969));
+    assert(datetime_ge(dt1969, dt1968));
+    assert(datetime_equal(dt1968, dt1968));
+    assert(!datetime_equal(dt1968, dt1969));
+}
+
+#[test]
+fn test_datetime_pre1970_construction_roundtrip() {
+    // Oracle: 1969-07-20T20:17:40Z -> epoch_us=-14182940000000
+    let dt = datetime_from_components(1969, 7, 20, 20, 17, 40, 0);
+    assert((dt.epoch_microseconds as i64) == -14_182_940_000_000);
+    assert(year_from_datetime(dt) == 1969);
+    assert(month_from_datetime(dt) == 7);
+    assert(day_from_datetime(dt) == 20);
+    assert(hours_from_datetime(dt) == 20);
+    assert(minutes_from_datetime(dt) == 17);
+    assert(seconds_from_datetime(dt) == 40);
+
+    // Leap-year boundary. Oracle: 1968-02-29T12:00:00Z -> epoch_us=-58017600000000
+    let leap = datetime_from_components(1968, 2, 29, 12, 0, 0, 0);
+    assert((leap.epoch_microseconds as i64) == -58_017_600_000_000);
+    assert(year_from_datetime(leap) == 1968);
+    assert(month_from_datetime(leap) == 2);
+    assert(day_from_datetime(leap) == 29);
+
+    // Day after the leap day. Oracle: 1968-03-01T00:00:00Z -> epoch_us=-57974400000000
+    let after_leap = datetime_from_components(1968, 3, 1, 0, 0, 0, 0);
+    assert((after_leap.epoch_microseconds as i64) == -57_974_400_000_000);
+
+    // Non-leap century. Oracle: 1900-01-01T00:00:00Z -> epoch_us=-2208988800000000
+    let y1900 = datetime_from_components(1900, 1, 1, 0, 0, 0, 0);
+    assert((y1900.epoch_microseconds as i64) == -2_208_988_800_000_000);
+    assert(year_from_datetime(y1900) == 1900);
+    assert(month_from_datetime(y1900) == 1);
+    assert(day_from_datetime(y1900) == 1);
+}
+
+#[test]
+fn test_datetime_pre1970_tz_construction() {
+    // Oracle: 1969-12-31T19:00:00-05:00 == 1970-01-01T00:00:00Z -> epoch_us=0
+    let dt = datetime_from_components_with_tz(1969, 12, 31, 19, 0, 0, 0, -300);
+    assert(dt.epoch_microseconds == 0);
+    // Local components are the pre-1970 civil values
+    assert(year_from_datetime(dt) == 1969);
+    assert(month_from_datetime(dt) == 12);
+    assert(day_from_datetime(dt) == 31);
+    assert(hours_from_datetime(dt) == 19);
+}
+
+#[test]
+fn test_datetime_year_one_edge() {
+    // Oracle: 0001-01-01T00:00:00Z -> epoch_us=-62135596800000000
+    // (Python datetime.min, proleptic Gregorian)
+    let dt = datetime_from_components(1, 1, 1, 0, 0, 0, 0);
+    assert((dt.epoch_microseconds as i64) == -62_135_596_800_000_000);
+    assert(year_from_datetime(dt) == 1);
+    assert(month_from_datetime(dt) == 1);
+    assert(day_from_datetime(dt) == 1);
+    assert(hours_from_datetime(dt) == 0);
+
+    let extracted = datetime_from_epoch_microseconds(signed_epoch(-62_135_596_800_000_000));
+    assert(year_from_datetime(extracted) == 1);
+    assert(month_from_datetime(extracted) == 1);
+    assert(day_from_datetime(extracted) == 1);
+}
+
+#[test]
+fn test_datetime_signed_epoch_civil_epoch_identity() {
+    // epoch -> civil -> epoch identity over negative oracle vectors.
+    // Oracle epochs: -1 (1969-12-31T23:59:59.999999), -31535999999999
+    // (1969-01-01T00:00:00.000001), -58017600000000 (1968-02-29T12:00:00),
+    // -2208988800000000 (1900-01-01T00:00:00), -14182940000000
+    // (1969-07-20T20:17:40).
+    let epochs: [i64; 5] = [
+        -1,
+        -31_535_999_999_999,
+        -58_017_600_000_000,
+        -2_208_988_800_000_000,
+        -14_182_940_000_000,
+    ];
+    for i in 0..5 {
+        let e = epochs[i];
+        let dt = datetime_from_epoch_microseconds(signed_epoch(e));
+        let rebuilt = datetime_from_components(
+            year_from_datetime(dt),
+            month_from_datetime(dt),
+            day_from_datetime(dt),
+            hours_from_datetime(dt),
+            minutes_from_datetime(dt),
+            seconds_from_datetime(dt),
+            microseconds_from_datetime(dt),
+        );
+        assert((rebuilt.epoch_microseconds as i64) == e);
+    }
 }

--- a/zk/xpath/xpath/src/types.nr
+++ b/zk/xpath/xpath/src/types.nr
@@ -9,7 +9,10 @@
 /// Using two Fields: one for UTC instant, one for timezone offset.
 /// This allows comparison using UTC while extracting local components.
 pub struct XsdDateTime {
-    /// Microseconds since Unix epoch (UTC)
+    /// Microseconds since Unix epoch (UTC), as a SIGNED i64 stored in its
+    /// two's-complement 64-bit pattern (encode `(e as u64) as Field`, decode
+    /// `f as i64`). Pre-1970 instants are negative i64 values; consumers must
+    /// decode before dividing or comparing (sq-3x7dl.7). [FABLE-5]
     pub epoch_microseconds: Field,
     /// Timezone offset in minutes from UTC (e.g., -300 for EST, 0 for UTC)
     /// Stored as signed value: positive = east of UTC, negative = west of UTC
@@ -35,7 +38,9 @@ impl XsdDateTime {
         let offset_micros: i64 = (self.tz_offset_minutes as i64) * 60_000_000;
         let utc_micros: i64 = self.epoch_microseconds as i64;
         let local: i64 = utc_micros + offset_micros;
-        // Safe cast: we ensure the result is non-negative in valid use cases
+        // Re-encode the signed result as its two's-complement pattern; a
+        // pre-1970 local time is a valid NEGATIVE value that callers recover
+        // with `as i64` (sq-3x7dl.7). [FABLE-5]
         let local_u64: u64 = local as u64;
         local_u64 as Field
     }


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Fable 5) — bead sq-3x7dl.7.

## What

`xs:dateTime` before 1970 has a **negative** epoch-microsecond value. Three consumer sites in `zk/xpath/xpath/src/datetime.nr` treated the epoch as an unsigned magnitude, so pre-1970 values were ordered, extracted, and constructed wrongly (audit MEDIUM):

- **Ordering** (`datetime_less_than`/`gt`/`le`/`ge`): compared `as u64`, so a 1969 instant ordered **after** a 2020 instant. Now a **signed i64** comparison.
- **Civil extraction** (`epoch_to_civil`): unsigned division of the bit pattern gave garbage y/m/d for negative epochs. Now **floor division** to days + the shared Hinnant `civil_from_days`, so epoch `-1` is `1969-12-31`, and time-of-day uses a **Euclidean remainder** helper so epoch `-1` gives `23:59:59.999999`.
- **Construction** (`datetime_from_components_with_tz`): `(days as u64) * MICROSECONDS_PER_DAY` — Noir u64 arithmetic is overflow-**checked**, so constructing ANY pre-1970 date **aborted** with a constraint failure (verified: the mutation reproduces `attempt to multiply with overflow`). Now all-signed i64 arithmetic.

## Representation decision

**No struct change.** `XsdDateTime.epoch_microseconds` stays a single `Field`, now documented (module doc + `types.nr` + `ARCHITECTURE.md`) as the **two's-complement 64-bit pattern of a signed i64** (encode `(e as u64) as Field`, decode `f as i64`). This was already the de facto encoding produced by the timezone path (`utc_micros as u64 as Field`) and consumed by `duration.nr`'s `as i64` reads — the minimal sound fix is to make every consumer decode signed, not to change the type. A probe confirmed `i64 -> u64 -> Field -> i64` round-trips negatives exactly in nargo 1.0.0-beta.21. Range: about ±292,000 years (the `ARCHITECTURE.md` claim now actually holds; it previously only held for ≥1970).

Dedup: `datetime.nr`'s duplicated Hinnant calendar functions now delegate to `date.nr`'s (made `pub(crate)`) — the single implementation with the merged `date_from_epoch_days(-1) -> 1969-12-31` precedent (#1467 wave).

## Oracle (independent Python `datetime`, proleptic Gregorian)

Every expected value computed as `(dt - datetime(1970,1,1,tzinfo=utc)) // timedelta(microseconds=1)`:

| instant | epoch µs |
|---|---|
| 1969-12-31T23:59:59.999999Z | -1 |
| 1969-12-31T00:00:00Z | -86400000000 |
| 1969-07-20T20:17:40Z | -14182940000000 |
| 1969-01-01T00:00:00.000001Z | -31535999999999 |
| 1968-02-29T12:00:00Z (leap day) | -58017600000000 |
| 1968-03-01T00:00:00Z | -57974400000000 |
| 1965-04-09T03:30:15.250000Z | -149286584750000 |
| 1900-01-01T00:00:00Z (non-leap century) | -2208988800000000 |
| 0001-01-01T00:00:00Z (year-1 edge) | -62135596800000000 |
| 1969-12-31T19:00:00-05:00 (tz construction) | 0 |
| 2020-06-15T12:00:00Z | 1592222400000000 |

## Tests + suites (local, CI-lane replication)

- 6 new inline `#[test]` fns in `datetime.nr` (mirroring `date.nr`'s test placement): pre-1970 civil extraction, signed ordering (1969 < 2020, -1 < 0, negative-vs-negative), construction round-trips incl. 1968-02-29 leap boundary + 1900 century + year-1 edge, tz construction landing exactly on epoch 0, and an epoch→civil→epoch **identity property** over 5 negative vectors.
- `zk/xpath/xpath` library: **125 passed** (119 baseline + 6 new).
- `zk/xpath/xpath_unit_tests`: **292 passed**.
- `test_packages` loop exactly as the `zk-toolchain.yml` lane (stub/placeholder exclusion + KNOWN_FAILING skips): partition **real=103 | stub=257**, gated **passed=101, failed=0**, known-failing skipped=2.
- Toolchain: local nargo pinned-match `1.0.0-beta.21`.

## Mutation spot-checks (all RED, then restored green)

1. Revert `datetime_less_than` to u64 compare → `test_datetime_pre1970_ordering_signed` **FAIL**.
2. Truncating (`/`) instead of `floor_div_i64` in `epoch_to_civil` → `test_datetime_negative_epoch_civil_extraction` **FAIL**.
3. Revert construction to u64 arithmetic → `test_datetime_pre1970_construction_roundtrip` **FAIL** (`attempt to multiply with overflow`).
4. Unsigned `%` in `time_of_day_micros` → extraction test **FAIL**.

## Honest boundaries / follow-up

- `duration.nr`'s `datetime_add_duration` / `datetime_subtract_duration` still `assert(result >= 0, "DateTime cannot be negative")` — they abort on **valid** pre-1970 results (e.g. epoch − P1D). Left out of this PR to keep the bead's file-disjointness (sq-3x7dl.9 is duration territory); beaded as follow-up.
- ASCII-only comments; no workflow changes; no public-API signature changes (behavior fix + docs), so no `SKILL.md` surface change; `readme-template --enforce`: 0 deviations (no README grown).

Do NOT arm — verification follows separately.