### PR TITLE
fix(zk/xpath): fn:min/fn:max empty sequence returns empty, not unprovable assert (sq-3x7dl.8) [FABLE-5]

### DIFF
--- a/zk/xpath/README.md
+++ b/zk/xpath/README.md
@@ -256,8 +256,14 @@ fn example() {
     assert(count(values) == 5);
     assert(sum_int(values) == 150);
     assert(avg_int(values) == 30);
-    assert(min_int_seq(values) == 10);
-    assert(max_int_seq(values) == 50);
+    // fn:min/fn:max return (value, present); present == false is the
+    // empty sequence (fn:min(()) = () per F&O -- never an assert, so an
+    // empty input keeps the circuit satisfiable). fn:avg over an empty
+    // sequence remains an error in this library.
+    assert(min_int_seq(values) == (10, true));
+    assert(max_int_seq(values) == (50, true));
+    let empty: [i64; 0] = [];
+    assert(min_int_seq(empty) == (0, false));
 }
 ```
 

--- a/zk/xpath/SPARQL_COVERAGE.md
+++ b/zk/xpath/SPARQL_COVERAGE.md
@@ -160,8 +160,8 @@ This document details the implementation status of SPARQL 1.1 functions in noir_
 |----------------|--------|-------|
 | COUNT | ✅ | Implemented as `count` |
 | SUM | ⚠️ | Implemented as `sum_int` for integers only |
-| MIN | ⚠️ | Implemented as `min_int_seq` for integers only |
-| MAX | ⚠️ | Implemented as `max_int_seq` for integers only |
+| MIN | ⚠️ | Implemented as `min_int_seq` for integers only; returns `(value, present)` — empty input yields `present == false` (fn:min(()) = ()), not an error |
+| MAX | ⚠️ | Implemented as `max_int_seq` for integers only; returns `(value, present)` — empty input yields `present == false` (fn:max(()) = ()), not an error |
 | AVG | ⚠️ | Implemented as `avg_int` for integers only |
 | GROUP_CONCAT | 🔮 | Requires string support |
 | SAMPLE | 🔮 | Requires more complex logic |

--- a/zk/xpath/xpath/src/sequence.nr
+++ b/zk/xpath/xpath/src/sequence.nr
@@ -56,31 +56,38 @@ pub fn avg_int<let N: u32>(arr: [i64; N]) -> i64 {
 }
 
 /// fn:min for integer arrays
-/// Returns the minimum value
-/// Panics if array is empty
-pub fn min_int_seq<let N: u32>(arr: [i64; N]) -> i64 {
-    assert(N > 0, "Cannot compute minimum of empty sequence");
-    let mut result = arr[0];
-    for i in 1..N {
-        if arr[i] < result {
+/// Returns (value, present). XPath F&O: fn:min(()) is the EMPTY SEQUENCE,
+/// not an error, so an empty input must stay provable: present == false
+/// models the empty result (value is 0 in that case) and the caller
+/// branches on it. An assert here would make any circuit containing an
+/// empty-sequence min unsatisfiable. The (value, bool) tuple follows this
+/// crate's emptiness convention (cf. string_to_integer, fn_number_from_string).
+pub fn min_int_seq<let N: u32>(arr: [i64; N]) -> (i64, bool) {
+    let mut result: i64 = 0;
+    let mut present: bool = false;
+    for i in 0..N {
+        if (!present) | (arr[i] < result) {
             result = arr[i];
         }
+        present = true;
     }
-    result
+    (result, present)
 }
 
 /// fn:max for integer arrays
-/// Returns the maximum value
-/// Panics if array is empty
-pub fn max_int_seq<let N: u32>(arr: [i64; N]) -> i64 {
-    assert(N > 0, "Cannot compute maximum of empty sequence");
-    let mut result = arr[0];
-    for i in 1..N {
-        if arr[i] > result {
+/// Returns (value, present). XPath F&O: fn:max(()) is the EMPTY SEQUENCE,
+/// not an error; present == false models the empty result (value is 0).
+/// See min_int_seq for the rationale.
+pub fn max_int_seq<let N: u32>(arr: [i64; N]) -> (i64, bool) {
+    let mut result: i64 = 0;
+    let mut present: bool = false;
+    for i in 0..N {
+        if (!present) | (arr[i] > result) {
             result = arr[i];
         }
+        present = true;
     }
-    result
+    (result, present)
 }
 
 // ============================================================================
@@ -108,29 +115,43 @@ pub fn avg_int_partial<let N: u32>(arr: [i64; N], len: u32) -> i64 {
 }
 
 /// Minimum for arrays with explicit length
-pub fn min_int_partial<let N: u32>(arr: [i64; N], len: u32) -> i64 {
-    assert(len > 0, "Cannot compute minimum of empty sequence");
+/// Returns (value, present): fn:min(()) is the empty sequence per XPath F&O,
+/// so len == 0 yields present == false (value 0) instead of an unsatisfiable
+/// assert. len is a runtime witness here, so this is the load-bearing case:
+/// an assert(len > 0) would make provability data-dependent.
+/// The len <= N assert stays: exceeding the array is a caller-contract
+/// violation (a genuine error), not an empty sequence.
+pub fn min_int_partial<let N: u32>(arr: [i64; N], len: u32) -> (i64, bool) {
     assert(len <= N, "Length exceeds array size");
-    let mut result = arr[0];
-    for i in 1..N {
-        if (i < len) & (arr[i] < result) {
-            result = arr[i];
+    let mut result: i64 = 0;
+    let mut present: bool = false;
+    for i in 0..N {
+        if i < len {
+            if (!present) | (arr[i] < result) {
+                result = arr[i];
+            }
+            present = true;
         }
     }
-    result
+    (result, present)
 }
 
 /// Maximum for arrays with explicit length
-pub fn max_int_partial<let N: u32>(arr: [i64; N], len: u32) -> i64 {
-    assert(len > 0, "Cannot compute maximum of empty sequence");
+/// Returns (value, present); len == 0 yields present == false (value 0).
+/// See min_int_partial for the rationale.
+pub fn max_int_partial<let N: u32>(arr: [i64; N], len: u32) -> (i64, bool) {
     assert(len <= N, "Length exceeds array size");
-    let mut result = arr[0];
-    for i in 1..N {
-        if (i < len) & (arr[i] > result) {
-            result = arr[i];
+    let mut result: i64 = 0;
+    let mut present: bool = false;
+    for i in 0..N {
+        if i < len {
+            if (!present) | (arr[i] > result) {
+                result = arr[i];
+            }
+            present = true;
         }
     }
-    result
+    (result, present)
 }
 
 // ============================================================================
@@ -769,12 +790,49 @@ fn test_avg_int() {
 #[test]
 fn test_min_max_int_seq() {
     let arr: [i64; 5] = [3, 1, 4, 1, 5];
-    assert(min_int_seq(arr) == 1);
-    assert(max_int_seq(arr) == 5);
+    assert(min_int_seq(arr) == (1, true));
+    assert(max_int_seq(arr) == (5, true));
 
     let negative: [i64; 3] = [-5, 0, 5];
-    assert(min_int_seq(negative) == -5);
-    assert(max_int_seq(negative) == 5);
+    assert(min_int_seq(negative) == (-5, true));
+    assert(max_int_seq(negative) == (5, true));
+
+    // Single-element sequence: the element itself, present
+    let single: [i64; 1] = [42];
+    assert(min_int_seq(single) == (42, true));
+    assert(max_int_seq(single) == (42, true));
+}
+
+#[test]
+fn test_min_max_int_seq_empty() {
+    // fn:min(()) / fn:max(()) = () per XPath F&O: this test EXECUTES
+    // min/max on an empty sequence, so the circuit stays satisfiable
+    // (with the old assert this test would abort, i.e. be unprovable).
+    let empty: [i64; 0] = [];
+    let (min_val, min_present) = min_int_seq(empty);
+    assert(!min_present);
+    assert(min_val == 0);
+    let (max_val, max_present) = max_int_seq(empty);
+    assert(!max_present);
+    assert(max_val == 0);
+}
+
+#[test]
+fn test_min_max_int_partial_empty() {
+    // len == 0 (a runtime witness, the load-bearing circuit case):
+    // empty in -> present == false out, no unsatisfiable assert.
+    let arr: [i64; 4] = [7, 8, 9, 10];
+    assert(min_int_partial(arr, 0) == (0, false));
+    assert(max_int_partial(arr, 0) == (0, false));
+}
+
+#[test(should_fail_with = "Cannot compute average of empty sequence")]
+fn test_avg_int_partial_empty_still_errors() {
+    // fn:avg over an empty group deliberately stays an error in this
+    // library (see avg_int_partial); the empty-sequence fix is scoped
+    // to min/max only.
+    let arr: [i64; 3] = [1, 2, 3];
+    let _ = avg_int_partial(arr, 0);
 }
 
 #[test]
@@ -788,8 +846,8 @@ fn test_partial_aggregates() {
     assert(avg_int_partial(arr, 2) == 15);
 
     // Min/max of first 3
-    assert(min_int_partial(arr, 3) == 10);
-    assert(max_int_partial(arr, 3) == 30);
+    assert(min_int_partial(arr, 3) == (10, true));
+    assert(max_int_partial(arr, 3) == (30, true));
 }
 
 #[test]

--- a/zk/xpath/xpath/src/xpath_fn.nr
+++ b/zk/xpath/xpath/src/xpath_fn.nr
@@ -121,10 +121,12 @@ pub use crate::sequence::sum_int as sum;
 // fn:avg (integer version)
 pub use crate::sequence::avg_int as avg;
 
-// fn:min (integer sequence version)
+// fn:min (integer sequence version) - returns (value, present);
+// present == false is the empty sequence (fn:min(()) = () per F&O)
 pub use crate::sequence::min_int_seq as min;
 
-// fn:max (integer sequence version)
+// fn:max (integer sequence version) - returns (value, present);
+// present == false is the empty sequence (fn:max(()) = () per F&O)
 pub use crate::sequence::max_int_seq as max;
 
 // fn:head


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Fable 5) — bead sq-3x7dl.8, audit-MEDIUM remediation under the sq-3x7dl ZK correctness epic.

## Bug

XPath F&O: `fn:min(())` / `fn:max(())` = the **empty sequence**, NOT an error. `min_int_seq`/`max_int_seq` (and the runtime-length `min_int_partial`/`max_int_partial`) instead `assert`ed on an empty input, which makes **any circuit containing an empty-sequence min/max unsatisfiable** — the whole proof aborts, so an otherwise-valid query becomes unprovable. For the `_partial` variants the length is a runtime **witness**, so provability was data-dependent: the same circuit proved or failed depending on the private input.

## Fix — emptiness as a value, not an assert

All four functions now return `(value: i64, present: bool)`; `present == false` models the empty result (`value` is `0` in that case) so the caller **branches** on emptiness. Signaling decision: the `(value, bool)` tuple is this crate's established emptiness idiom — `string_to_integer -> (i64, bool)`, `fn_number_from_string -> (i64, bool)`, `string_to_boolean -> (bool, bool)`, and the `([T; N], u32 len)` channel for sequences — so no new convention is introduced.

Deliberately unchanged, per the bead:
- `avg_int` / `avg_int_partial` over empty still assert (now pinned by a `should_fail_with` regression test).
- `min_int_partial`/`max_int_partial` keep `assert(len <= N)` — exceeding the backing array is a caller-contract violation (a genuine error), not an empty sequence.

## Call-site audit (zk/, non-vendor)

| Site | Handling |
|---|---|
| `zk/xpath/xpath/src/xpath_fn.nr` `pub use … as min/max` | signature-transparent re-export; comment updated to document `(value, present)` |
| `zk/xpath/xpath/src/lib.nr` re-export list | name-only, no change needed |
| `sequence.nr` inline tests | updated to the tuple contract |
| `test_packages/xpath_test_fnmin`/`fnmax` | stub-wired (`stub_fnmin`/`stub_fnmax`), CI-excluded; unaffected (retirement tracked by sq-3x7dl.15) |
| `min_int`/`max_int` in `numeric.nr` | different functions (two-arg scalar op), untouched |

No other consumers exist in `zk/` outside `zk/vendor/`.

## Verification (pinned nargo 1.0.0-beta.21, `~/.nargo`)

- `nargo test` @ `zk/xpath/xpath`: **128 passed, 0 failed** (includes the new `test_min_max_int_seq_empty`, `test_min_max_int_partial_empty`, `test_avg_int_partial_empty_still_errors`, and the updated extremum tests).
- `nargo test` @ `zk/xpath/xpath_unit_tests`: **292 passed, 0 failed**.
- Real `test_packages` suite, run the CI-lane way (stub/placeholder grep exclusion + `KNOWN_FAILING` skip, **no fail-fast**): partition **103 real | 257 stub-wired (excluded)**, 2 KNOWN_FAILING skipped → **101 packages passed, 0 failed**.
- **Python oracle**: every changed/new expected value cross-checked against Python `min`/`max` — e.g. `fn:min([3,1,4,1,5]) = (1, present=True)`, `fn:max([-5,0,5]) = (5, present=True)`, `fn:min([42]) = (42, present=True)`, `fn:min(()) = () -> (0, present=False)`, partial `len=3` over `[10,20,30,40,50]` → `(10, true)`/`(30, true)`. All match the test assertions.
- **Mutation spot-check** (throwaway copy, restored the original asserts): `test_min_max_int_seq_empty` FAILS with an **abort** — exactly the unprovability failure mode, not a value mismatch:
  ```
  error: Assertion failed: Cannot compute minimum of empty sequence
     ┌─ src/sequence.nr:66:5
  66 │     assert(N > 0, "Cannot compute minimum of empty sequence");
  ```
  and the partial variant likewise: `error: Assertion failed: Cannot compute minimum of empty sequence` at the restored `assert(len > 0)`. Both new tests are non-vacuous.
- `typos` over the four changed files: clean. Comments ASCII-only.
- No Rust workspace files touched (pure Noir + `zk/xpath` docs), so the cargo/clippy/rustdoc lanes are unaffected by construction; files are disjoint from all open PRs (none touches `zk/` source).

## Docs

- `zk/xpath/README.md` aggregate example shows the `(value, present)` contract incl. the empty case (README is outside the `crates/*/README.md` template-gate scope; `scripts/check-readme-template.py --enforce` scans `crates/*` only).
- `zk/xpath/SPARQL_COVERAGE.md` MIN/MAX rows document empty-input semantics.

## Discovered work (for the orchestrator to bead)

- Per F&O §16.4.5, `fn:avg(())` is ALSO the empty sequence (not an error) — the bead explicitly scopes avg out ("avg over empty CORRECTLY is an error", matching the SPARQL-aggregate reading), but the pure-XPath conformance question may deserve its own bead/decision record.

Do NOT arm — verification follows per the wave discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)