### PR TITLE
feat(site): register the SPARQL logic-bug paper in the factory registry (sq-gum8.9) [SONNET-4.6]

### DIFF
--- a/site/src/data/paper-evidence.json
+++ b/site/src/data/paper-evidence.json
@@ -347,6 +347,33 @@
       "family": "FO-KM pilot",
       "source": "bench/fo-km/RESULTS.md ('The measured result' table, abstain column)",
       "note": "Tasks (of 16) on which the schema.org-as-top condition abstained in the single fully-crossed run. Indicative single-run outcome, not canonical. [FABLE-5 sq-gum8.3-fokm]"
+    },
+    "metamorph.selftest_oracles": {
+      "value": 3,
+      "unit": "oracles",
+      "environment": "canonical",
+      "kind": "structural-count",
+      "family": "SPARQL logic-bug testing instrument",
+      "source": "crates/sparq-metamorph/tests/oracle_self_tests.rs — tlp_flags_the_seeded_wrong_result_mutant, norec_flags_the_seeded_wrong_result_mutant, differential_flags_the_seeded_wrong_result_mutant",
+      "note": "Number of oracle types (TLP, NoREC, differential) whose self-tests assert non-vacuity: each must flag the seeded wrong-result mutant (FilterDropsRow, which silently removes a row from FILTER queries) as a Verdict::Violation. A deterministic structural count of test functions in the committed file; the tests run against the real InProcessSparq engine, not a mock. Campaign-dependent counts (bugs confirmed/reported/rejected) are NOT wired here — they are pending bead sq-gum8.11. [SONNET-4.6 sq-gum8.9]"
+    },
+    "metamorph.selftest_seeds": {
+      "value": 50,
+      "unit": "generator-seeds",
+      "environment": "canonical",
+      "kind": "structural-count",
+      "family": "SPARQL logic-bug testing instrument",
+      "source": "crates/sparq-metamorph/tests/oracle_self_tests.rs::generated_cases_hold_on_pristine_sparq (for seed in 0..50)",
+      "note": "Number of seeds over which the generated_cases_hold_on_pristine_sparq self-test asserts that TLP and NoREC both hold on the pristine sparq engine (both oracles must return Pass for every generated case). A deterministic range constant in the committed test file, not a measurement. Establishes that the oracle passes on the real engine before any campaign dispatches generated cases to third-party engines. [SONNET-4.6 sq-gum8.9]"
+    },
+    "metamorph.grammar_exclusion_seeds": {
+      "value": 200,
+      "unit": "generator-seeds",
+      "environment": "canonical",
+      "kind": "structural-count",
+      "family": "SPARQL logic-bug testing instrument",
+      "source": "crates/sparq-metamorph/src/generate.rs::generated_predicates_respect_the_exclusion_list (for seed in 0..200)",
+      "note": "Number of seeds over which the grammar exclusion-list check asserts that no generated predicate contains a banned non-deterministic construct (RAND, NOW, UUID, STRUUID, BNODE, EXISTS). A deterministic range constant in the committed generate.rs test; ensures the seeded generator never produces non-reproducible predicates, making every campaign ledger entry's test case reproducible from its seed alone. [SONNET-4.6 sq-gum8.9]"
     }
   }
 }

--- a/site/src/data/papers.ts
+++ b/site/src/data/papers.ts
@@ -154,6 +154,28 @@ export const PAPERS: Paper[] = [
     evidence:
       "Systematization — asserts NO proven security/privacy/soundness/attestation property and cites no wall-clock measurement. The only build-injected counts are the deterministic structural facts already gated as canonical for the C-family estate (fail-closed collaborative entry points, re-audit lenses all RE-OPEN, witness-validation obligation clauses, prior single-prover audit findings under the open gate sq-qhy4). Capability tiers are documentary (spec corpus + reconciled capability review), stated as such in the paper's limitations.",
   },
+  {
+    // [SONNET-4.6] sq-gum8.9 — Register the SPARQL logic-bug testing paper. Status is
+    // `draft`: the merged harness (sq-gum8.6, crates/sparq-metamorph) is the committed
+    // instrument, but the cross-engine bug-hunting campaign (bead sq-gum8.11) has NOT run
+    // yet. No third-party bug is claimed anywhere; every campaign table in the .typ is an
+    // explicitly marked PLACEHOLDER. Evidence keys wired: metamorph.selftest_oracles,
+    // metamorph.selftest_seeds, metamorph.grammar_exclusion_seeds (all deterministic, canonical).
+    // Campaign keys (confirmed/reported/rejected) are pending sq-gum8.11 and NOT wired here.
+    slug: "sparql-logic-bugs",
+    source: "sparql-logic-bugs.typ",
+    title:
+      "Reifying the Error: Metamorphic and Differential Logic-Bug Testing for SPARQL Engines",
+    blurb:
+      "SPARQL has no dedicated logic-bug testing work. We re-derive TLP and NoREC for SPARQL by reifying its third evaluation outcome — a type error, not a value — with the language's only error-absorbing forms, yielding a partition that provably recomposes the unpartitioned query under the SPARQL 1.1 spec. The merged instrument (crates/sparq-metamorph) includes a TLP + NoREC + differential oracle suite whose self-tests assert non-vacuity against a seeded wrong-result mutant on the real engine. This is a first draft against the merged instrument only; the cross-engine bug-hunting campaign has not run, every campaign table is an explicit placeholder, and the paper's honest publishability condition — previously-unknown, developer-confirmed bugs in third-party engines — is not yet met.",
+    authors: "Jesse Wright · the sparq project",
+    venue:
+      "ISSTA 2027 (testing track) — first choice; PVLDB Vol 20 rolling or FSE 2027 — second choice. Draft; not submittable until the campaign (bead sq-gum8.11) yields confirmed third-party bugs",
+    status: "draft",
+    family: "A",
+    evidence:
+      "Deterministic instrument self-tests only (no campaign results yet): 3 oracle types (TLP, NoREC, differential) each asserting non-vacuity against a seeded wrong-result mutant on the real sparq engine; oracle correctness verified across 50 generated seeds on the pristine engine; grammar exclusion list verified across 200 seeds (no banned non-deterministic construct). Campaign-dependent evidence (bugs confirmed/reported/rejected) is pending bead sq-gum8.11 and is shown as an explicit PLACEHOLDER in the paper. No third-party bug is claimed.",
+  },
 ];
 
 export function paperBySlug(slug: string): Paper | undefined {


### PR DESCRIPTION
> 🤖 SPARQ agent — sq-gum8.9 (paper-factory registry wiring)

## Summary

- Registers `sparql-logic-bugs` (merged in #1496) in `site/src/data/papers.ts` so the paper is findable on `/papers`
- Wires three deterministic, canonical evidence records into `site/src/data/paper-evidence.json` (all traced to committed test constants in `crates/sparq-metamorph`)
- `sparq-engine-systems` (sq-gum8.8) is explicitly NOT registered: its `.typ` source does not exist yet and `build-papers.mjs` hard-fails on a missing source file

## Registry entry

| Field | Value |
|-------|-------|
| slug | `sparql-logic-bugs` |
| family | A (Systems/DB) |
| status | `draft` |
| venue | ISSTA 2027 (first); PVLDB Vol 20 rolling / FSE 2027 (second) |
| evidence | Instrument self-tests only; campaign pending (sq-gum8.11) |

## Evidence keys wired vs pending

**Wired (canonical, deterministic):**
- `metamorph.selftest_oracles` = 3 — TLP + NoREC + differential oracles, traced to `tests/oracle_self_tests.rs` non-vacuity tests
- `metamorph.selftest_seeds` = 50 — seeds in `generated_cases_hold_on_pristine_sparq` (range `0..50`)
- `metamorph.grammar_exclusion_seeds` = 200 — seeds in `generated_predicates_respect_the_exclusion_list` (range `0..200`)

**Pending (sq-gum8.11 — campaign not run):**
- `metamorph.campaign_bugs_confirmed` — not wired; shown as PLACEHOLDER in the `.typ`
- `metamorph.campaign_bugs_reported` — not wired; shown as PLACEHOLDER in the `.typ`
- `metamorph.campaign_bugs_rejected` — not wired; shown as PLACEHOLDER in the `.typ`

## Build evidence

- Honesty gate: 41 evidence records (33 canonical, 8 indicative) — passed
- Build-boundary honesty scan: 7 papers + paper-evidence.json — passed
- WASM prereq built: `js/ npm run build:wasm`
- Static export (`npm run build`): green, `/papers/sparql-logic-bugs` present in `out/`
- `out/papers/` contains `sparql-logic-bugs/`, `sparql-logic-bugs.pdf`
- Lint: `✔ No ESLint warnings or errors`
- Typecheck: clean (via `next build`)

## Scope note on sq-gum8.8

The bead description lists both sq-gum8.7 and sq-gum8.8 as dependencies, but sq-gum8.8 (`sparq-engine-systems.typ`) is still open (its `.typ` source does not exist). Registering a paper with a missing source would fail the `build-papers.mjs` hard check (`paper source not found`). sq-gum8.8 is deferred to when its paper draft lands.