### PR TITLE
fix(engine): kind-first total order for compare_terms — restores transitivity (sq-wjl8i) [FABLE-5]

### DIFF
--- a/bench/perf-baseline.json
+++ b/bench/perf-baseline.json
@@ -81,8 +81,15 @@
     "1399868 is the CI x86_64 runner measurement (run 28634216610, artifact-exact-equality leg: cargo build",
     "--profile release-wasm -p sparq-wasm --target wasm32-unknown-unknown, no --features vectorized) — NEVER a",
     "local aarch64 build. The ratchet floor (1399703) is UNCHANGED: 1399868 sits within its +2% band (top 1427697),",
-    "so bench.yml stays green; the floor only ratchets DOWN on improvement, never up on a within-band drift."
-  ],
+    "so bench.yml stays green; the floor only ratchets DOWN on improvement, never up on a within-band drift.",
+    "[OPUS-4.8] (sq-wjl8i) 2026-07-04: feature_off_exact RE-PINNED 1399868 -> 1404910 (+5042 bytes, +0.360%).",
+    "The kind-first total-order fix for compare_terms (PR #1502) adds real engine code the feature-OFF wasm links",
+    "in — cmp_exact_lex_f64 / f64_exact_decimal / Num::cmp_total decimal-string arithmetic + NaN totalisation —",
+    "so the bundle legitimately grew. This is SCALAR string/int arithmetic, NOT accidental vectorization (the",
+    "invariant the zero-delta gate exists to protect); the feature-OFF INVARIANT (bundle identical with vectorized",
+    "ON vs OFF) is PRESERVED, only the absolute baseline moved. 1404910 is the CI x86_64 runner measurement",
+    "(run 28722406953, artifact-exact-equality leg2). The ratchet floor (1399703) is UNCHANGED: 1404910 sits",
+    "within its +2% band (top 1427697), so bench.yml stays green."
   "metrics": {
     "store_bytes_per_triple": {
       "floor": 92,
@@ -103,7 +110,7 @@
       "floor": 1399703,
       "threshold": 0.02,
       "mode": "auto",
-      "feature_off_exact": 1399868
+      "feature_off_exact": 1404910
     },
     "parse_ns_per_byte": {
       "floor": 4.9721,

--- a/bench/perf-baseline.json
+++ b/bench/perf-baseline.json
@@ -90,6 +90,7 @@
     "ON vs OFF) is PRESERVED, only the absolute baseline moved. 1404910 is the CI x86_64 runner measurement",
     "(run 28722406953, artifact-exact-equality leg2). The ratchet floor (1399703) is UNCHANGED: 1404910 sits",
     "within its +2% band (top 1427697), so bench.yml stays green."
+  ],
   "metrics": {
     "store_bytes_per_triple": {
       "floor": 92,

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -19,7 +19,7 @@ use sparq_core::Graph;
 // hot path (research/shared-eval-substrate.md, Option C, Phase 2). This is a behaviour-neutral
 // code-move: the engine re-imports the same items here under the same names, so every call
 // site below is unchanged and the W3C conformance / ORDER BY / numeric tests are bit-identical.
-use sparq_substrate::numeric::{parse_xsd_f32, parse_xsd_f64, split_decimal, ArithOp, Dec, Num};
+use sparq_substrate::numeric::{f64_exact_decimal, parse_xsd_f32, parse_xsd_f64, split_decimal, ArithOp, Dec, Num};
 // [OPUS-4.8] sq-hknqs (epic sq-qonbz, Phase 3): the four id-tuple join kernels live in the
 // shared substrate now (merge / hash / bind / leapfrog-trie). The engine's planner, `Bindings`,
 // `LocalVocab` interning and `ScanCmp` pushdown stay private here; the thin adapters below build
@@ -36,7 +36,7 @@ use sparq_substrate::join as sjoin;
 // `Value` / `LitKind` / `value_compare_strict` stay engine-private (they also drive the
 // relational operators); only the algorithm moved. Behaviour-neutral: the W3C SPARQL / ORDER BY
 // / FILTER conformance is bit-identical.
-use sparq_substrate::compare::{compare_terms, CompareTerm, TermClass};
+use sparq_substrate::compare::{compare_terms, CompareTerm, LiteralKind, TermClass};
 use rustc_hash::FxHashSet;
 use spargebra::algebra::{
     AggregateExpression, AggregateFunction, Expression, GraphPattern, OrderExpression, PropertyPathExpression,
@@ -6548,7 +6548,19 @@ fn minmax_temporal(
         best = Some(match best {
             None => (t, id),
             Some((bt, bid)) => {
-                let ord = Temporal::cmp_t(t, bt).unwrap_or_else(|| lex(id).cmp(lex(bid)));
+                // [FABLE-5] sq-wjl8i: KIND-FIRST, mirroring `compare_values` — a
+                // cross-kind (dateTime vs date) pair ranks by `LiteralKind`
+                // (DateTime < Date), never lexically; the timeline order (with the
+                // lexical fallback for the indeterminate window) applies within a kind.
+                let ord = if t.kind != bt.kind {
+                    if t.kind == sparq_core::temporal::TemporalKind::DateTime {
+                        Ordering::Less
+                    } else {
+                        Ordering::Greater
+                    }
+                } else {
+                    Temporal::cmp_t(t, bt).unwrap_or_else(|| lex(id).cmp(lex(bid)))
+                };
                 let replace = if is_min { ord == Ordering::Less } else { ord != Ordering::Less };
                 if replace {
                     (t, id)
@@ -6642,6 +6654,18 @@ enum SortCell {
 fn cmp_sort_cells(graph: &Graph, local: &LocalVocab, a: &SortCell, c: &SortCell) -> Ordering {
     match (a, c) {
         (SortCell::Temp { t: ta, id: ia }, SortCell::Temp { t: tb, id: ib }) => {
+            // [FABLE-5] sq-wjl8i: KIND-FIRST, mirroring `compare_values` — a dateTime
+            // never value-compares against a date (`LiteralKind::DateTime < Date`); the
+            // timeline comparison (then the lexical fallback for the indeterminate
+            // mixed-timezone window) applies only within one temporal kind. Ill-formed
+            // temporals never enter the cache, so both cells here are well-formed.
+            if ta.kind != tb.kind {
+                return if ta.kind == sparq_core::temporal::TemporalKind::DateTime {
+                    Ordering::Less
+                } else {
+                    Ordering::Greater
+                };
+            }
             match Temporal::cmp_t(*ta, *tb) {
                 Some(o) => o,
                 None => cmp_sort_cells_lex(graph, *ia, *ib),
@@ -6681,9 +6705,12 @@ fn cmp_sort_cells(graph: &Graph, local: &LocalVocab, a: &SortCell, c: &SortCell)
 /// [OPUS-4.8] sq-rikm7: f64 rounding is MONOTONIC, so it only ever collapses distinct
 /// numeric values to Equal — so on (and only on) an f64 tie, disambiguate via the ids'
 /// exact lexicals (`exact_numeric_lexical` + `cmp_decimal_str`, the SAME exact path the
-/// relational `cmp_expr` uses). Integers beyond 2^53 and high-precision decimals then
-/// order by value; float/double ids have no exact lexical and stay Equal (their value IS
-/// the f64). Perf-neutral: the allocation happens only on a tie, never on the fast path.
+/// relational `cmp_expr` uses). [FABLE-5] sq-wjl8i extends the recheck to the MIXED
+/// exact/inexact tie: a float/double id has no exact lexical but its VALUE is exactly
+/// the tied f64, so the exact side compares against the f64's exact decimal expansion —
+/// mirroring `compare_values`' `Num::cmp_total` recheck, so the numeric fast path and
+/// the general path order identically. Perf-neutral: the allocations happen only on a
+/// tie, never on the fast path.
 #[inline]
 fn cmp_sort_num(graph: &Graph, fa: f64, ia: Id, fb: f64, ib: Id) -> Ordering {
     match fa.partial_cmp(&fb) {
@@ -6696,11 +6723,41 @@ fn cmp_sort_num(graph: &Graph, fa: f64, ia: Id, fb: f64, ib: Id) -> Ordering {
             }
             match (graph.exact_numeric_lexical(ia), graph.exact_numeric_lexical(ib)) {
                 (Some(la), Some(lb)) => cmp_decimal_str(&la, &lb).unwrap_or(Ordering::Equal),
-                _ => Ordering::Equal,
+                (Some(la), None) => cmp_exact_lex_f64(&la, fb),
+                (None, Some(lb)) => cmp_exact_lex_f64(&lb, fa).reverse(),
+                // Both float/double: the value IS the tied f64 — a true tie.
+                (None, None) => Ordering::Equal,
             }
         }
         Some(o) => o,
-        None => Ordering::Equal, // NaN: unordered, an incomparable tie (as pre-change).
+        // NaN. Unreachable from ORDER BY sort cells today (the numerics cache uses NaN
+        // as its "not numeric" sentinel, so a NaN literal never becomes a `SortCell::Num`
+        // and routes through `compare_values` instead) — kept in lock-step with the
+        // total order's NaN-first rule so the fast path can never diverge. [FABLE-5] sq-wjl8i
+        None => match (fa.is_nan(), fb.is_nan()) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            _ => Ordering::Equal,
+        },
+    }
+}
+
+/// The mixed exact/inexact leg of the f64-tie recheck: an exact int/decimal LEXICAL
+/// against a (finite, non-NaN) f64's exact decimal expansion — string arithmetic
+/// throughout, arbitrary precision. An infinite f64 image (a numeric lexical beyond
+/// f64's finite range collapsed onto ±INF) bounds every finite exact value directly.
+/// [FABLE-5] sq-wjl8i
+#[cold]
+fn cmp_exact_lex_f64(lex: &str, f: f64) -> Ordering {
+    if f == f64::INFINITY {
+        return Ordering::Less;
+    }
+    if f == f64::NEG_INFINITY {
+        return Ordering::Greater;
+    }
+    match f64_exact_decimal(f) {
+        Some(exp) => cmp_decimal_str(lex, &exp).unwrap_or(Ordering::Equal),
+        None => Ordering::Equal, // NaN: handled by the caller's NaN rule
     }
 }
 
@@ -7924,6 +7981,29 @@ impl CompareTerm for Value {
         }
     }
     #[inline]
+    fn literal_kind(&self) -> LiteralKind {
+        // [FABLE-5] sq-wjl8i: the kind-first rank of the total order. Numeric tracks the
+        // LENIENT `as_num` membership (the same set the numeric arm compares), so a
+        // lexical the exact classifier rejects but `parse_xsd_f64` accepts (e.g.
+        // "1.5"^^xsd:integer) still sorts numerically, exactly as it did pre-fix — with
+        // one exception: a computed boolean (whose lenient f64 view is 0.0/1.0)
+        // classifies as Boolean, keeping it in one kind with boolean LITERALS (both
+        // order `false < true` via `strict_cmp`). ILL-FORMED numeric/temporal lexicals
+        // classify as Other (lexical order): a kind mixing value-ordered and
+        // lexical-fallback pairs is intransitive — the very bug this rank removes.
+        match lit_kind(self) {
+            LitKind::Bool(_) => LiteralKind::Boolean,
+            LitKind::Num(_) if as_num(self).is_some() => LiteralKind::Numeric,
+            LitKind::Str(_) => LiteralKind::String,
+            LitKind::Lang(..) => LiteralKind::Lang,
+            LitKind::DateTime(Some(_)) => LiteralKind::DateTime,
+            LitKind::Date(Some(_)) => LiteralKind::Date,
+            // Ill-formed numerics/temporals, other-XSD, unknown datatypes (and the
+            // unreachable non-literal case — `compare_terms` gates on the class).
+            _ => LiteralKind::Other,
+        }
+    }
+    #[inline]
     fn value_str(&self) -> Option<String> {
         value_str(self)
     }
@@ -7933,14 +8013,18 @@ impl CompareTerm for Value {
     }
     #[inline]
     fn exact_cmp(&self, other: &Self) -> Option<Ordering> {
-        // [OPUS-4.8] sq-rikm7: f64-collapse recheck — when the lenient `as_num` arm reports
-        // two numeric literals EQUAL, distinct integers beyond 2^53 or high-precision
-        // decimals that share one f64 must still order. This is the SAME value-exact numeric
-        // comparison the relational `<`/`=` (`cmp_expr`) and MIN/MAX (`minmax_values`) use —
-        // `num_compare` is exact via the decimal tower for the int/decimal tiers and falls
-        // back to f64 for float/double (whose value IS the f64, so the collapse is correct).
+        // [OPUS-4.8] sq-rikm7 / [FABLE-5] sq-wjl8i: f64-collapse recheck — when the
+        // lenient `as_num` arm reports two numeric literals EQUAL, the pair rechecks
+        // under `Num::cmp_total`, the EXACT-RATIONAL total order: exact via the decimal
+        // tower for int/decimal pairs, exact against the double's exact decimal
+        // expansion for the MIXED exact/inexact pair (the pre-fix `num_compare`
+        // fallback kept the collapsed f64 verdict there, which made the order
+        // intransitive at the 2^53 collapse — witness 1 of sq-wjl8i). The relational
+        // `<`/`=` (`cmp_expr`) and MIN/MAX (`minmax_values`) deliberately KEEP the
+        // XPath promoted semantics via `num_compare`; this total order refines only
+        // their ties. `None` (a lexical beyond the exact tower) keeps the tie.
         match (as_numeric(self), as_numeric(other)) {
-            (Some(a), Some(b)) => num_compare(a, b),
+            (Some(a), Some(b)) => Some(a.cmp_total(b)),
             _ => None,
         }
     }
@@ -7968,14 +8052,19 @@ impl CompareTerm for Value {
     }
 }
 
-/// LENIENT total order for ORDER BY (and the MIN/MAX fallback): SPARQL orders
-/// unbound < blank nodes < IRIs < literals, then by value within each class
-/// (numerics by value; everything else by string form, which keeps the order
-/// deterministic across mixed literal types).
+/// The TOTAL order for ORDER BY (and the MIN/MAX fallback): SPARQL orders
+/// unbound < blank nodes < IRIs < literals (< triple terms), then literals KIND-FIRST —
+/// a fixed `LiteralKind` rank between literal kinds (numeric < boolean < dateTime <
+/// date < string < language-tagged < other), value order only WITHIN a kind (numerics
+/// by exact value with NaN first, dateTimes by timeline, else lexically).
 ///
-/// [OPUS-4.8] sq-vezew: the algorithm now lives in `sparq_substrate::compare::compare_terms`,
-/// generic over the `CompareTerm` trait the engine implements for `Value` above. This is a thin
-/// monomorphised call into the shared substrate — behaviour-identical to the pre-move inline body.
+/// [OPUS-4.8] sq-vezew: the algorithm lives in `sparq_substrate::compare::compare_terms`,
+/// generic over the `CompareTerm` trait the engine implements for `Value` above — a thin
+/// monomorphised call into the shared substrate. [FABLE-5] sq-wjl8i: the order is
+/// deliberately NOT the pre-move lexical-fallback body — cross-kind lexical fallback,
+/// collapsed mixed-tier f64 ties and NaN partiality made it intransitive (three
+/// machine-checked witnesses; see the substrate module docs for what is spec-mandated
+/// vs a documented extension). Relational `<` / `=` semantics are UNTOUCHED.
 #[inline]
 fn compare_values(x: &Value, y: &Value) -> Option<Ordering> {
     compare_terms(x, y)
@@ -12144,38 +12233,47 @@ mod f64_collapse_order_agreement {
     #[test]
     fn compare_orders_double_infinities_and_isolates_nan() {
         // [OPUS-4.8] sq-rkzhr: with `as_num` routed through `parse_xsd_f64`, the lenient
-        // compare seam orders the XSD floating specials by value (-INF < finite < +INF),
-        // and NaN is numerically incomparable (the f64 arm's `partial_cmp` -> None, and an
-        // f64 tie is required before any exact recheck, so NaN never reaches one).
+        // compare seam orders the XSD floating specials by value (-INF < finite < +INF).
+        // [FABLE-5] sq-wjl8i: NaN is TOTALISED into the order — it sorts FIRST (before
+        // -INF) and ties with itself, instead of the former `None` (which callers mapped
+        // to Equal, making NaN "equal" to every numeric — the partiality witness).
+        // Relational `<` / `=` keep their NaN type-error semantics untouched.
         let d = |s: &str| Value::Term(Term::Literal(Literal::new_typed_literal(s, xsd::DOUBLE)));
         let (neg_inf, inf, five, nan) = (d("-INF"), d("INF"), d("5.0E0"), d("NaN"));
         assert_eq!(compare_values(&neg_inf, &five), Some(Ordering::Less));
         assert_eq!(compare_values(&five, &inf), Some(Ordering::Less));
         assert_eq!(compare_values(&neg_inf, &inf), Some(Ordering::Less));
         assert_eq!(compare_values(&inf, &inf), Some(Ordering::Equal));
-        assert_eq!(compare_values(&nan, &five), None);
-        assert_eq!(compare_values(&nan, &nan), None);
+        assert_eq!(compare_values(&nan, &five), Some(Ordering::Less));
+        assert_eq!(compare_values(&five, &nan), Some(Ordering::Greater));
+        assert_eq!(compare_values(&nan, &neg_inf), Some(Ordering::Less));
+        assert_eq!(compare_values(&nan, &nan), Some(Ordering::Equal));
 
-        // End-to-end ORDER BY over stored double specials exercises the REAL query path.
+        // End-to-end ORDER BY over stored double specials exercises the REAL query path
+        // (NaN routes through the general sort cell: the numerics cache uses NaN as its
+        // not-numeric sentinel, so the fast numeric cell never sees it).
         let g = Graph::load_str(
             "@prefix ex: <http://ex/> . @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
              ex:a ex:v \"-INF\"^^xsd:double .\n\
              ex:b ex:v \"5.0E0\"^^xsd:double .\n\
-             ex:c ex:v \"INF\"^^xsd:double .\n",
+             ex:c ex:v \"INF\"^^xsd:double .\n\
+             ex:d ex:v \"NaN\"^^xsd:double .\n",
             "turtle",
         )
         .unwrap();
-        assert_eq!(order_by(&g, "ASC(?v)"), vec!["-INF", "5.0E0", "INF"]);
-        assert_eq!(order_by(&g, "DESC(?v)"), vec!["INF", "5.0E0", "-INF"]);
+        assert_eq!(order_by(&g, "ASC(?v)"), vec!["NaN", "-INF", "5.0E0", "INF"]);
+        assert_eq!(order_by(&g, "DESC(?v)"), vec!["INF", "5.0E0", "-INF", "NaN"]);
     }
 
     #[test]
-    fn order_by_mixed_numeric_string_temporal_column_is_unchanged() {
+    fn order_by_mixed_numeric_string_temporal_column_is_deterministic() {
         // A single ORDER BY column mixing a numeric graph term, a plain-string literal and an
-        // xsd:dateTime exercises the new `Num`-vs-`Val` / `Num`-vs-`Temp` sort-cell cross arms
-        // (which reconstruct the pre-change `Val(Num::Double)` representation, so the mixed
-        // order stays byte-identical). SPARQL orders literals: numerics first (by value), then
-        // the deterministic string-form fallback across the remaining literal datatypes.
+        // xsd:dateTime exercises the `Num`-vs-`Val` / `Num`-vs-`Temp` sort-cell cross arms
+        // (which reconstruct the `Val(Num::Double)` representation and defer to the shared
+        // `compare_values`). [FABLE-5] sq-wjl8i: cross-KIND literal pairs rank by
+        // `LiteralKind` (numeric < dateTime < string) — the exact order is additionally
+        // pinned end-to-end by `order_by_cross_kind_ranks_and_collapse_is_exact`; this test
+        // keeps the permutation/reversibility shape claims.
         let g = Graph::load_str(
             "@prefix ex: <http://ex/> . @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
              ex:n ex:v 5 .\n\
@@ -12199,6 +12297,55 @@ mod f64_collapse_order_agreement {
         let mut rev = asc.clone();
         rev.reverse();
         assert_eq!(rev, desc, "DESC(?v) is ASC(?v) reversed");
+    }
+
+    /// [FABLE-5] sq-wjl8i end-to-end: the kind-first rank and the exact mixed-tier
+    /// collapse recheck through the REAL query path (both the numeric sort-cell fast
+    /// path — all-numeric column — and the mixed-kind `compare_values` path).
+    #[test]
+    fn order_by_cross_kind_ranks_and_collapse_is_exact() {
+        // All-NUMERIC column at the 2^53 collapse: int 2^53, int 2^53+1 and the double
+        // carrying their shared f64 image. The exact order is 2^53 = 2^53E0 < 2^53+1
+        // (the former three-way collapsed tie was intransitive against the exact
+        // int/int order). The int/int and int/double ties are decided by
+        // `cmp_sort_num`'s exact recheck (the fast numeric sort cells).
+        let g = Graph::load_str(
+            "@prefix ex: <http://ex/> . @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+             ex:a ex:v \"9007199254740993\"^^xsd:integer .\n\
+             ex:b ex:v \"9007199254740992E0\"^^xsd:double .\n\
+             ex:c ex:v \"9007199254740992\"^^xsd:integer .\n",
+            "turtle",
+        )
+        .unwrap();
+        let asc = order_by(&g, "ASC(?v)");
+        // The equal pair (2^53, 2^53E0) keeps input order (stable sort); both precede 2^53+1.
+        assert_eq!(asc[2], "9007199254740993", "the collapsed neighbour sorts strictly last");
+        assert!(asc[..2].contains(&"9007199254740992E0".to_string()));
+        assert!(asc[..2].contains(&"9007199254740992".to_string()));
+
+        // MIXED-KIND column: every numeric (NaN included) sorts before the boolean,
+        // the dateTime before the date, both before the plain string, the string
+        // before the language-tagged literal, and the unknown-datatype literal last —
+        // the documented LiteralKind rank; the digit-string "11" can no longer
+        // interleave lexically between numerics 10 and 2 (the sq-wjl8i witness).
+        let g2 = Graph::load_str(
+            "@prefix ex: <http://ex/> . @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+             ex:s ex:v \"11\" .\n\
+             ex:n1 ex:v 10 .\n\
+             ex:n2 ex:v 2 .\n\
+             ex:nan ex:v \"NaN\"^^xsd:double .\n\
+             ex:bt ex:v true .\n\
+             ex:dt ex:v \"2024-03-15T13:00:00Z\"^^xsd:dateTime .\n\
+             ex:d ex:v \"2020-01-01\"^^xsd:date .\n\
+             ex:lang ex:v \"chat\"@fr .\n\
+             ex:odd ex:v \"weird\"^^ex:custom .\n",
+            "turtle",
+        )
+        .unwrap();
+        assert_eq!(
+            order_by(&g2, "ASC(?v)"),
+            vec!["NaN", "2", "10", "true", "2024-03-15T13:00:00Z", "2020-01-01", "11", "chat", "weird"]
+        );
     }
 }
 

--- a/crates/sparq-reason/README.md
+++ b/crates/sparq-reason/README.md
@@ -67,6 +67,8 @@ let g = Graph::from_parts(dict, triples);
   substrate's `CompareTerm` for dictionary ids, so ordering entailed solutions
   (`compare::sort_ids` / `compare::compare_ids`) is parity-identical to the SPARQL engine's `ORDER BY`
   total order (pinned byte-for-byte against a real engine query by `tests/compare_parity.rs`).
+  Since sq-wjl8i this is a genuine TOTAL order across mixed literal kinds — kind-first rank,
+  exact mixed-tier numeric ties, NaN totalised first (see the substrate `compare` docs).
   Monomorphic (no trait object on the sort loop) and purely additive — no materialiser calls
   it, so the entailed closure and its emission order are unchanged. Off by default.
 

--- a/crates/sparq-reason/src/compare.rs
+++ b/crates/sparq-reason/src/compare.rs
@@ -16,10 +16,13 @@
 //! [`compare_ids`] / [`sort_ids`] order ids exactly as the engine's `ORDER BY` orders the
 //! terms those ids denote: error/unbound < blank < IRI < literal < RDF 1.2 triple term,
 //! then within each class the engine's arms — blanks/IRIs by string form; literals
-//! numeric-aware (with the `exact_cmp` f64-collapse recheck for distinct integers beyond
-//! 2^53 / high-precision decimals), then strict typed/temporal (`xsd:dateTime`/`xsd:date`
-//! by TIMELINE via the shared `sparq_core::temporal::Timeline`, same-tag language strings
-//! and same-other-XSD lexically), then lexical string fallback; triple terms component-wise
+//! KIND-FIRST (the sq-wjl8i total-order fix: a fixed `LiteralKind` rank between literal
+//! kinds, then within the numeric kind the exact-rational order — NaN first, the
+//! `exact_cmp` f64-collapse recheck exact for integers beyond 2^53 / high-precision
+//! decimals / the mixed exact-vs-double tie — and within the other kinds strict
+//! typed/temporal (`xsd:dateTime`/`xsd:date` by TIMELINE via the shared
+//! `sparq_core::temporal::Timeline`, same-tag language strings and same-other-XSD
+//! lexically), then the lexical fallback); triple terms component-wise
 //! recursively. Every observation hook mirrors the engine's `Value` impl over the SAME
 //! shared machinery (`Timeline`, the substrate `Num`/`Dec` tower, `parse_xsd_f64`), and the
 //! full-multiset parity is pinned against a REAL engine `ORDER BY` over the same
@@ -41,8 +44,9 @@
 //! - Ids must come from the reasoner's id space: dictionary ids plus inline-integer ids
 //!   (`is_inline`). The engine's local-vocab ids (computed BIND/aggregate values above the
 //!   inline window) never appear in a materialised closure and are not meaningful here.
-//! - `None`-comparable pairs (e.g. a `NaN` double vs a numeric) collapse to `Equal`,
-//!   exactly as the engine's `ORDER BY` maps its comparator's `None` (`unwrap_or(Equal)`).
+//! - A `NaN` double is totalised FIRST among numerics (sq-wjl8i) — no numeric pair
+//!   reaches the `unwrap_or(Equal)` mapping any more; the mapping remains only for the
+//!   no-string-form / non-decomposing-triple `None`s, matching the engine exactly.
 //! - Two DISTINCT terms can compare `Equal` under SPARQL's lenient order (equal numeric
 //!   values across datatypes, equal instants across timezones, same-lexical unknown-datatype
 //!   literals). Their relative order after a stable sort is input-order on both sides —
@@ -52,7 +56,7 @@ use std::cmp::Ordering;
 
 use sparq_core::dict::{is_inline, split_lang_dir, Dict, Id, TermParts, INLINE_BASE};
 use sparq_core::temporal::Timeline;
-use sparq_substrate::compare::{compare_terms, CompareTerm, TermClass};
+use sparq_substrate::compare::{compare_terms, CompareTerm, LiteralKind, TermClass};
 use sparq_substrate::numeric::{parse_xsd_f32, parse_xsd_f64, Dec, Num};
 
 /// The XSD namespace prefix — the engine's `lit_kind` "other XSD datatype" family test.
@@ -287,13 +291,37 @@ impl CompareTerm for IdTerm<'_> {
     }
 
     #[inline]
+    fn literal_kind(&self) -> LiteralKind {
+        // [FABLE-5] sq-wjl8i: the kind-first rank — mirrors the engine's
+        // `Value::literal_kind` exactly: Numeric tracks the LENIENT `as_f64` membership
+        // (so a lexical the exact classifier rejects but `parse_xsd_f64` accepts still
+        // sorts numerically); ill-formed numeric/temporal lexicals classify as Other
+        // (a kind mixing value-ordered and lexical-fallback pairs is intransitive).
+        if is_inline(self.id) {
+            return LiteralKind::Numeric; // an inline id IS a well-formed xsd:integer
+        }
+        match self.kind() {
+            Kind::Bool(_) => LiteralKind::Boolean,
+            Kind::Num(_) if self.as_f64().is_some() => LiteralKind::Numeric,
+            Kind::Str(_) => LiteralKind::String,
+            Kind::Lang(..) => LiteralKind::Lang,
+            Kind::DateTime(Some(_)) => LiteralKind::DateTime,
+            Kind::Date(Some(_)) => LiteralKind::Date,
+            // Ill-formed numerics/temporals, other-XSD, unknown datatypes (and the
+            // unreachable non-literal case — `compare_terms` gates on the class).
+            _ => LiteralKind::Other,
+        }
+    }
+
+    #[inline]
     fn exact_cmp(&self, other: &Self) -> Option<Ordering> {
-        // The f64-collapse recheck (called by `compare_terms` only on an f64 tie):
-        // distinct integers beyond 2^53 / high-precision decimals sharing one f64 still
-        // order by exact value — the same `as_numeric` + `num_compare` recheck the engine
-        // makes, so a reasoner-side sort agrees with the engine's relational `=`/`<`.
+        // The f64-collapse recheck (called by `compare_terms` only on an f64 tie),
+        // mirroring the engine's `Value::exact_cmp` → `Num::cmp_total` (sq-wjl8i): the
+        // EXACT-RATIONAL total order — exact for int/decimal pairs AND for the mixed
+        // exact/inexact pair (against the double's exact decimal expansion), NaN
+        // totalised first — so a reasoner-side sort agrees with the engine's ORDER BY.
         match (self.as_num_typed(), other.as_num_typed()) {
-            (Some(a), Some(b)) => num_compare(a, b),
+            (Some(a), Some(b)) => Some(a.cmp_total(b)),
             _ => None,
         }
     }
@@ -334,9 +362,10 @@ impl CompareTerm for IdTerm<'_> {
     }
 }
 
-/// Compares two ids of `dict` under the engine's `ORDER BY` total order. Pairs the shared
-/// algorithm cannot decide (e.g. a `NaN` operand) collapse to `Equal`, exactly as the
-/// engine's sort maps its comparator's `None`.
+/// Compares two ids of `dict` under the engine's `ORDER BY` total order (a `NaN`
+/// operand takes its fixed first-among-numerics position, sq-wjl8i). The rare
+/// undecidable pairs (no string form / a non-decomposing triple) collapse to `Equal`,
+/// exactly as the engine's sort maps its comparator's `None`.
 #[inline]
 pub fn compare_ids(dict: &Dict, a: Id, b: Id) -> Ordering {
     compare_terms(&IdTerm::new(dict, a), &IdTerm::new(dict, b)).unwrap_or(Ordering::Equal)
@@ -438,9 +467,39 @@ mod tests {
         assert_eq!(compare_ids(&d, nine, dec), Ordering::Less);
         assert_eq!(compare_ids(&d, dec, dbl), Ordering::Less);
         assert_eq!(compare_ids(&d, dbl, ten), Ordering::Less);
-        // A NaN pair is undecidable -> collapses to Equal (the engine's unwrap_or(Equal)).
+        // NaN is totalised FIRST among numerics (sq-wjl8i): before every numeric,
+        // equal to itself — no longer an undecidable pair collapsing to Equal.
         let nan = lit(&mut d, "NaN", XSD_DOUBLE);
-        assert_eq!(compare_ids(&d, nan, nine), Ordering::Equal);
+        assert_eq!(compare_ids(&d, nan, nine), Ordering::Less);
+        assert_eq!(compare_ids(&d, nine, nan), Ordering::Greater);
+        assert_eq!(compare_ids(&d, nan, nan), Ordering::Equal);
+        let ninf = lit(&mut d, "-INF", XSD_DOUBLE);
+        assert_eq!(compare_ids(&d, nan, ninf), Ordering::Less);
+    }
+
+    /// [FABLE-5] sq-wjl8i: cross-KIND literal pairs rank by `LiteralKind` (numeric <
+    /// boolean < dateTime < date < string < lang < other), never by the lexical form —
+    /// the digit-inversion triple `10 / "11" / 2` that was intransitive under the
+    /// lexical fallback is consistent under the rank. And the mixed exact-vs-double tie
+    /// at the 2^53 collapse now orders exactly.
+    #[test]
+    fn kind_first_rank_and_exact_mixed_tier() {
+        let mut d = Dict::new();
+        let int = "http://www.w3.org/2001/XMLSchema#integer";
+        let ten = lit(&mut d, "10", int);
+        let two = lit(&mut d, "2", int);
+        let s11 = lit(&mut d, "11", XSD_STRING);
+        assert_eq!(compare_ids(&d, ten, s11), Ordering::Less, "Numeric < String by kind");
+        assert_eq!(compare_ids(&d, s11, two), Ordering::Greater, "String > Numeric (was lexical Less)");
+        assert_eq!(compare_ids(&d, ten, two), Ordering::Greater, "10 > 2 — consistent");
+        // Mixed exact/inexact at the collapse: double(2^53) equals int 2^53 exactly,
+        // and sits strictly below int 2^53+1 (was a three-way Equal tie).
+        let big = lit(&mut d, "9007199254740992", int);
+        let big1 = lit(&mut d, "9007199254740993", int);
+        let dbl = lit(&mut d, "9007199254740992E0", XSD_DOUBLE);
+        assert_eq!(compare_ids(&d, big, dbl), Ordering::Equal);
+        assert_eq!(compare_ids(&d, dbl, big1), Ordering::Less);
+        assert_eq!(compare_ids(&d, big1, dbl), Ordering::Greater);
     }
 
     /// The f64-collapse `exact_cmp` recheck: distinct integers beyond 2^53 share one f64

--- a/crates/sparq-reason/tests/compare_parity.rs
+++ b/crates/sparq-reason/tests/compare_parity.rs
@@ -7,13 +7,18 @@
 //! Non-vacuous by construction: the fixture packs the pairs each comparator arm alone
 //! decides — numeric-vs-lexical divergences (`9` < `10` by value, `"10"` < `"9"`
 //! lexically), a cross-timezone `xsd:dateTime` pair whose TIMELINE order is the reverse
-//! of its lexical order (pins `strict_cmp`), a beyond-2^53 integer pair sharing one f64,
+//! of its lexical order (pins `strict_cmp`), a beyond-2^53 integer pair sharing one f64
+//! PLUS the double carrying their collapse image (pins the sq-wjl8i exact mixed-tier
+//! tie on BOTH engine paths: the numeric sort-cell recheck and `compare_values`), a
+//! decimal/double exact-equal pair, `NaN` / `INF` / `-INF` (pins the NaN-first
+//! totalisation), the plain digit-string `"11"` against integers `10`/`2`-adjacent
+//! values (pins the kind-first rank that replaced the intransitive lexical fallback),
 //! inline and stored integer ids, RDF 1.2 triple terms (pins the component-wise recursion),
 //! plus blanks / IRIs / language-tagged / boolean / date / gYear / unknown-datatype
-//! literals for the class ranks and the string fallback.  Mis-wire any arm and the two
-//! sequences diverge.  The `exact_cmp` collapse-recheck for distinct integers beyond 2^53
-//! is pinned by the `exact_recheck_orders_big_integers_beyond_2_53` unit test in
-//! `compare.rs`, not by this RDFS-entailment multiset (mutation-verified).
+//! literals for the class and kind ranks and the string fallback.  Mis-wire any arm and
+//! the two sequences diverge.  The `exact_cmp` collapse-recheck for distinct integers
+//! beyond 2^53 is pinned by the `exact_recheck_orders_big_integers_beyond_2_53` unit
+//! test in `compare.rs`, not by this RDFS-entailment multiset (mutation-verified).
 //!
 //! ## Full-multiset ordering parity (main parity test)
 //!
@@ -59,7 +64,13 @@ ex:bob ex:tiny "9"^^xsd:integer .
 ex:bob ex:score "9.5"^^xsd:decimal .
 ex:bob ex:big1 "9007199254740992"^^xsd:integer .
 ex:bob ex:big2 "9007199254740993"^^xsd:integer .
+ex:bob ex:big3 "9007199254740992E0"^^xsd:double .
 ex:bob ex:height "1.75E0"^^xsd:double .
+ex:bob ex:heightDec "1.75"^^xsd:decimal .
+ex:bob ex:nan "NaN"^^xsd:double .
+ex:bob ex:inf "INF"^^xsd:double .
+ex:bob ex:ninf "-INF"^^xsd:double .
+ex:bob ex:code "11" .
 ex:bob ex:ok "true"^^xsd:boolean .
 ex:bob ex:no "false"^^xsd:boolean .
 ex:bob ex:t1 "2024-03-15T14:00:00+01:00"^^xsd:dateTime .

--- a/crates/sparq-substrate/README.md
+++ b/crates/sparq-substrate/README.md
@@ -74,22 +74,24 @@ let n: Option<Num> = as_numeric(&lit);  // exact xsd:decimal (no f64 rounding)
   `Budget` cooperative-cancel hook (both monomorphised, never a trait object). Pulls only
   `rustc-hash` when enabled; implies `rows`.
 - **`compare`** — the SPARQL **term total order** `compare_terms` (the engine's `compare_values`):
-  the class precedence error/unbound < blank < IRI < literal < triple, the numeric-aware /
-  strict typed-temporal / lexical-string arms within the literal class, and the recursive
-  component-wise triple-term order. Generic over a tiny `CompareTerm` trait (`term_class` /
+  the spec-fixed class precedence error/unbound < blank < IRI < literal < triple, then a
+  **kind-first** literal order (sq-wjl8i): a fixed `LiteralKind` rank BETWEEN literal kinds
+  (numeric < boolean < dateTime < date < string < lang < other — a documented extension where
+  the spec leaves cross-kind order undefined), value order only WITHIN a kind — numerics by
+  exact rational value (`NaN` totalised FIRST, before `-INF`; an f64 tie rechecked exactly via
+  `exact_cmp`, incl. the MIXED int/decimal-vs-float/double tie — `Num::cmp_total` under
+  `numeric`), dateTimes by timeline, else lexically — and the recursive component-wise
+  triple-term order. Generic over a tiny `CompareTerm` trait (`term_class` / `literal_kind` /
   `value_str` / `as_f64` / `exact_cmp` / `strict_cmp` / `triple_parts`) the consumer implements
-  for its own term type — a **monomorphisation seam**, never a `dyn` object. `exact_cmp` is the
-  f64-collapse recheck: when the lenient `as_f64` arm ties, it recovers the exact order of
-  distinct integers beyond 2^53 / high-precision decimals so `ORDER BY` / `MIN` / `MAX` agree
-  with the relational `=`/`<`. Pure-`std`: links nothing new. The order laws — reflexivity and
-  within-class totality (both over the **NaN-free** domain only: an `xsd:double NaN` makes the
-  comparator partial, bead sq-wjl8i), antisymmetry-consistency (NaN included), and
-  per-literal-kind transitivity incl. the 2^53 collapse — are machine-checked by Kani
-  bounded-proof harnesses over a model `CompareTerm` impl — `cargo kani -p sparq-substrate
-  --features compare` (sq-sqtk2.4). Honest boundary: the proofs cover the shared ALGORITHM
-  over the bounded model (per-harness domains documented in the module), not the engine's
-  `Value` impl, and mixed literal-KIND literal pairs are NOT transitive (machine-checked
-  witnesses in the harness module document exactly where the law breaks).
+  for its own term type — a **monomorphisation seam**, never a `dyn` object. Pure-`std`. The
+  order laws — reflexivity, within-class totality, antisymmetry-consistency and transitivity
+  (per kind AND across mixed kinds, all NaN INCLUDED, incl. the 2^53 collapse) — are
+  machine-checked by Kani bounded-proof harnesses over a model `CompareTerm` impl —
+  `cargo kani -p sparq-substrate --features compare` (sq-sqtk2.4 + sq-wjl8i; the three former
+  intransitivity witnesses are pinned FIXED). Honest boundaries: the proofs cover the shared
+  ALGORITHM over the bounded model (per-harness domains in the module), not the engine's
+  `Value` impl; and within the dateTime kind the indeterminate mixed-timezone window still
+  falls back lexically (a residual partial-order seam, tracked separately).
 
 All features are **off by default**. The crate is `forbid(unsafe_code)`.
 

--- a/crates/sparq-substrate/src/compare.rs
+++ b/crates/sparq-substrate/src/compare.rs
@@ -14,9 +14,10 @@
 //! # What lives here vs. stays engine-private
 //!
 //! The substrate holds the **ordering ALGORITHM**: the SPARQL class precedence
-//! (error/unbound < blank < IRI < literal < triple-term), the numeric-aware /
-//! strict-typed / string-fallback arm selection within the literal class, and the
-//! recursive component-wise triple-term order. It deliberately does **not** hoist the
+//! (error/unbound < blank < IRI < literal < triple-term), the **kind-first** literal
+//! order (a fixed [`LiteralKind`] precedence between literal kinds — the sq-wjl8i
+//! total-order fix — with the numeric / strict-typed / string-fallback arms WITHIN a
+//! kind), and the recursive component-wise triple-term order. It deliberately does **not** hoist the
 //! engine's `Value` enum, its `LitKind` literal-family classifier, or its
 //! `value_compare_strict` typed/temporal comparison: those are reused by the engine's
 //! relational `<` / `>` / `=` operators too (not only the ORDER BY total order), and
@@ -32,11 +33,14 @@
 //! [`compare_terms`] is generic over `T: CompareTerm` — a **generic type parameter**,
 //! NOT a trait object. There is NO `Box<dyn>` / `&dyn` / vtable between the algorithm
 //! and the term observations it makes; the compiler emits one specialised, inlinable
-//! body per call site. Every item carries `#[inline]`, so with the workspace LTO
-//! profile the engine's `ORDER BY` / sort / range-filter hot loops keep codegen
-//! identical to the pre-move `compare_values`. This is verified by the W3C SPARQL
-//! conformance floor staying bit-identical and the structural `no-dyn-dispatch` gate
-//! (`scripts/check-no-dyn-dispatch.py`) listing this file in its hot-path set.
+//! body per call site. Every item carries `#[inline]`; the structural `no-dyn-dispatch`
+//! gate (`scripts/check-no-dyn-dispatch.py`) lists this file in its hot-path set. The
+//! original extraction (sq-vezew) was behaviour-identical to the engine's
+//! `compare_values`; sq-wjl8i then DELIBERATELY changed the order itself (kind-first
+//! literals, exact mixed-tier ties, NaN totalised) to fix three machine-checked
+//! intransitivity witnesses — see [`compare_terms`] for what is spec-mandated vs. a
+//! documented extension. The fast paths (class ranks, the numeric `partial_cmp`) are
+//! unchanged; the exact/lexical work still happens only on cold tie/fallback branches.
 
 use std::cmp::Ordering;
 
@@ -61,6 +65,46 @@ pub enum TermClass {
     Triple = 4,
 }
 
+/// The within-[`Literal`](TermClass::Literal)-class **KIND rank** of the total order —
+/// the fixed precedence [`compare_terms`] applies BETWEEN literal kinds, before any
+/// within-kind value comparison. [FABLE-5] sq-wjl8i
+///
+/// SPARQL 1.1 §15.1 fixes the cross-CLASS order (unbound < blank < IRI < literal) and,
+/// via the `<` operator, the within-kind orders (numerics by value, strings lexically,
+/// booleans, dateTimes by timeline); it leaves CROSS-KIND literal order (a number
+/// against a plain string, …) undefined. This rank is sparq's total-order EXTENSION for
+/// that undefined region: cross-kind pairs order by kind rank ALWAYS — never by a value
+/// or lexical coercion. (The previous lexical cross-kind fallback made the comparator
+/// intransitive: lexically `"10" < "11" < "2"` while numerically `10 > 2` — the
+/// machine-checked witness of bead sq-wjl8i.) The rank values are a documented
+/// implementation choice, not a spec claim.
+///
+/// A term's kind must agree with the observations the within-kind arms use — see the
+/// [`CompareTerm::literal_kind`] contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LiteralKind {
+    /// A numeric literal (or computed numeric) with a lenient `f64` view — orders by
+    /// exact numeric value, `NaN` first (see [`compare_terms`]).
+    Numeric = 0,
+    /// An `xsd:boolean` literal or computed boolean — `false < true`; ill-formed
+    /// boolean lexicals order lexically (consistently: `"false" < "true"`).
+    Boolean = 1,
+    /// A well-formed `xsd:dateTime` / `xsd:dateTimeStamp` — orders by timeline.
+    DateTime = 2,
+    /// A well-formed `xsd:date` — orders by timeline (midnight).
+    Date = 3,
+    /// A plain / `xsd:string` literal — orders lexically.
+    String = 4,
+    /// A language-tagged string — orders by lexical value (same-tag pairs strictly,
+    /// cross-tag pairs by the same lexical value via the string fallback).
+    Lang = 5,
+    /// Everything else — other XSD datatypes, unknown datatypes, and ILL-FORMED
+    /// numeric/temporal lexicals (which must not sit in a value-ordered kind: mixing a
+    /// value order with a lexical fallback inside one kind is exactly the
+    /// intransitivity this rank exists to remove) — orders lexically.
+    Other = 6,
+}
+
 /// The minimal observation surface [`compare_terms`] needs from a term to compute the
 /// SPARQL total order, **without** the substrate knowing about the engine's `Value`
 /// enum, `oxrdf::Term`, or its temporal subsystem.
@@ -72,6 +116,27 @@ pub enum TermClass {
 pub trait CompareTerm: Sized {
     /// The term's top-level SPARQL ordering class (the cross-class precedence bucket).
     fn term_class(&self) -> TermClass;
+
+    /// The literal's [`LiteralKind`] — the within-Literal-class precedence bucket of
+    /// the kind-first total order. Only consulted when BOTH terms are
+    /// [`TermClass::Literal`]; the value for non-literal terms is irrelevant (return
+    /// [`LiteralKind::Other`]). [FABLE-5] sq-wjl8i
+    ///
+    /// # Contract (what keeps the total order lawful)
+    ///
+    /// - [`Numeric`](LiteralKind::Numeric) **iff** [`as_f64`](Self::as_f64) returns
+    ///   `Some` — with one exception: a computed boolean whose lenient `f64` view is
+    ///   0.0/1.0 classifies as [`Boolean`](LiteralKind::Boolean) (the numeric arm is
+    ///   gated on the KIND, so booleans still order `false < true` via
+    ///   [`strict_cmp`](Self::strict_cmp)).
+    /// - An ILL-FORMED numeric / temporal lexical must classify as
+    ///   [`Other`](LiteralKind::Other), not into its value-ordered kind: a kind that
+    ///   mixes value-ordered pairs with lexical-fallback pairs is intransitive (the
+    ///   sq-wjl8i witnesses).
+    /// - Within each kind, the arms the algorithm applies ([`strict_cmp`](Self::strict_cmp)
+    ///   where it decides, else the lexical [`value_str`](Self::value_str) fallback)
+    ///   must agree wherever both decide a pair.
+    fn literal_kind(&self) -> LiteralKind;
 
     /// The term's lexical string form for the deterministic within-class fallback
     /// (the literal string arm, and the blank-node / IRI comparison): the literal
@@ -95,19 +160,26 @@ pub trait CompareTerm: Sized {
     /// numeric arm coerces both operands to `f64` (see [`as_f64`](Self::as_f64)); f64
     /// rounding is MONOTONIC, so it can only COLLAPSE two distinct numeric values to Equal,
     /// never flip a `Less`/`Greater`. So [`compare_terms`] calls this **only** when the f64
-    /// arm reports Equal, to recover the true order for distinct integers beyond 2^53 and
-    /// high-precision decimals that share one f64.
+    /// arm reports Equal, to recover the true order for values that share one f64 image.
     ///
-    /// Returns `Some(ordering)` only when BOTH terms are numeric and value-exactly
-    /// comparable via the exact numeric tower (`xsd:integer` / `xsd:decimal`); `None` when
-    /// either operand is non-numeric, is an inexact tier (`xsd:float`/`xsd:double`, whose
-    /// value IS its f64), or the exact comparison cannot decide — the collapsed f64 verdict
-    /// then stands. A purely symbolic consumer with no exact numeric tier returns `None`.
+    /// Returns `Some(ordering)` when the pair's EXACT-RATIONAL value order is
+    /// computable — including the MIXED exact/inexact pair (an `xsd:integer` /
+    /// `xsd:decimal` against an `xsd:float` / `xsd:double`, whose value is an exact
+    /// rational too): distinct integers beyond 2^53, high-precision decimals sharing
+    /// one f64, and an exact value against the float/double it collapses onto must ALL
+    /// order exactly, or the refined tie relation is not an equivalence and the order
+    /// is intransitive (witness 1 of bead sq-wjl8i — the previous "`None` on mixed
+    /// pairs, engine falls back to the collapsed f64" behaviour). The substrate's
+    /// `Num::cmp_total` (`numeric` feature) implements exactly this order. Returns
+    /// `None` when the exact order cannot be computed (e.g. a lexical beyond the exact
+    /// tower) — the collapsed f64 tie then stands, for EVERY member of that tie class.
+    /// A purely symbolic consumer with no exact numeric tier returns `None`.
     ///
-    /// This mirrors the engine's relational `=`/`<` recheck and its `MIN`/`MAX` value
-    /// comparison — the same value-exact numeric order, surfaced to the shared total order
-    /// so `ORDER BY` / `MIN` / `MAX` agree with them rather than collapsing an f64 tie to
-    /// Equal. [OPUS-4.8] sq-rikm7
+    /// The engine's relational `=`/`<` keep the XPath PROMOTED semantics (a
+    /// float/double operand promotes the pair to f64, so `2^53+1 = 2^53E0` is true
+    /// there); this total order deliberately REFINES those promoted ties — every strict
+    /// promoted verdict is preserved (rounding is monotonic), only ties are split.
+    /// [OPUS-4.8] sq-rikm7 / [FABLE-5] sq-wjl8i
     fn exact_cmp(&self, other: &Self) -> Option<Ordering>;
 
     /// The **strict** value comparison for same-family typed literals the numeric arm
@@ -131,23 +203,39 @@ pub trait CompareTerm: Sized {
     fn triple_parts(&self) -> Option<[Self; 3]>;
 }
 
-/// The SPARQL **lenient total order** for `ORDER BY` (and the `MIN`/`MAX` fallback),
-/// generic over any [`CompareTerm`].
+/// The SPARQL **total order** for `ORDER BY` (and the `MIN`/`MAX` fallback), generic
+/// over any [`CompareTerm`].
 ///
-/// SPARQL orders unbound/error < blank nodes < IRIs < literals < triple terms, then
-/// within each class: blanks / IRIs by their string form; literals by numeric value
-/// when both are numeric, else by the strict same-family value order (dateTime/date by
-/// timeline, same-tag/same-other-XSD lexically) when decidable, else by lexical string
-/// form (which keeps the order deterministic across mixed literal types); triple terms
-/// component-wise (subject, then predicate, then object) recursively under this order.
+/// SPARQL orders unbound/error < blank nodes < IRIs < literals < triple terms
+/// (spec-fixed cross-class order; triple-terms-after-literals is the SPARQL 1.2
+/// extension), then within each class: blanks / IRIs by their string form; literals
+/// **kind-first** (see below); triple terms component-wise (subject, then predicate,
+/// then object) recursively under this order.
 ///
-/// Returns `None` only when a within-class string fallback is needed but a term has no
-/// string form (an unbound/error reaching a literal compare) — matching the engine's
-/// `compare_values`, whose callers map `None` to `Ordering::Equal`.
+/// # The kind-first literal order — [FABLE-5] sq-wjl8i
 ///
-/// This is the body **moved verbatim** from `sparq-engine::exec::compare_values`, with
-/// the concrete `Value` matches replaced by the trait observations. It is generic (not
-/// `dyn`), so it monomorphises and inlines into each caller with no vtable.
+/// Within the literal class, terms first rank by [`LiteralKind`] (numeric < boolean <
+/// dateTime < date < string < language-tagged < other); ONLY same-kind pairs compare by
+/// value. Same-kind: the [`Numeric`](LiteralKind::Numeric) kind orders by exact numeric
+/// value — the lenient `f64` fast path, with `NaN` totalised FIRST (before `-INF`,
+/// `NaN == NaN` — the XPath 3.1 `fn:sort` choice) and an f64 TIE rechecked exactly via
+/// [`exact_cmp`](CompareTerm::exact_cmp) (distinct integers beyond 2^53, high-precision
+/// decimals, and the mixed exact/inexact pair all order by exact rational value);
+/// every other kind orders by [`strict_cmp`](CompareTerm::strict_cmp) where it decides
+/// (dateTime/date by timeline, booleans, same-tag / same-other-XSD lexically), else by
+/// the lexical [`value_str`](CompareTerm::value_str) fallback.
+///
+/// Where SPARQL 1.1 §15.1 / the `<` operator define an order (the cross-class ranks;
+/// numeric, string, boolean, dateTime same-kind pairs) this order agrees with the spec;
+/// the cross-KIND ranking and the NaN / exact-tie refinements are documented
+/// extensions in the region the spec leaves undefined (see [`LiteralKind`]).
+///
+/// Returns `None` only when (a) a within-class string fallback is needed but a term has
+/// no string form (an unbound/error reaching a literal compare), or (b) a
+/// [`TermClass::Triple`]-classed term yields no [`triple_parts`](CompareTerm::triple_parts).
+/// A `NaN` operand no longer yields `None` (the sq-ma9fb doc-drift, fixed with the
+/// behaviour): callers mapping `None` to `Ordering::Equal` no longer make `NaN` "equal"
+/// to every numeric.
 #[inline]
 pub fn compare_terms<T: CompareTerm>(x: &T, y: &T) -> Option<Ordering> {
     let (ca, cb) = (x.term_class(), y.term_class());
@@ -176,25 +264,45 @@ pub fn compare_terms<T: CompareTerm>(x: &T, y: &T) -> Option<Ordering> {
             compare_terms(&ao, &bo)
         }
         TermClass::Literal => {
-            if let (Some(a), Some(b)) = (x.as_f64(), y.as_f64()) {
-                let ord = a.partial_cmp(&b);
-                // f64-collapse EXACT recheck. The lenient numeric arm coerces both operands
-                // to f64, whose rounding is MONOTONIC: it can only COLLAPSE two distinct
-                // numeric values to Equal, never flip a Less/Greater. So — and ONLY — when
-                // the f64 arm reports Equal, recheck the pair exactly; a decisive exact
-                // ordering (distinct integers beyond 2^53, or high-precision decimals that
-                // share one f64) overrides the collapsed verdict. This makes ORDER BY / MIN /
-                // MAX agree with the engine's relational =/< (`cmp_expr`) and MIN/MAX value
-                // comparison (`num_compare`), which already recheck. Perf-neutral: the exact
-                // work happens only on an f64 tie. [OPUS-4.8] sq-rikm7
-                if ord == Some(Ordering::Equal) {
-                    if let Some(exact) = x.exact_cmp(y) {
-                        return Some(exact);
-                    }
-                }
-                return ord;
+            // KIND-FIRST: cross-kind pairs rank by LiteralKind, NEVER by a value or
+            // lexical coercion — a cross-kind lexical fallback is intransitive against
+            // the within-kind value orders (witness 2 of sq-wjl8i: lexically
+            // "10" < "11" < "2" while numerically 10 > 2). [FABLE-5] sq-wjl8i
+            let (ka, kb) = (x.literal_kind(), y.literal_kind());
+            if ka != kb {
+                return Some(ka.cmp(&kb));
             }
-            // dateTime/date (and same-tag / same-other-XSD) order strictly when comparable.
+            if ka == LiteralKind::Numeric {
+                // The literal_kind contract guarantees both f64 views exist here; the
+                // `if let` keeps a contract violation falling through defensively.
+                if let (Some(a), Some(b)) = (x.as_f64(), y.as_f64()) {
+                    return Some(match a.partial_cmp(&b) {
+                        // f64-collapse EXACT recheck. f64 rounding is MONOTONIC: it can
+                        // only COLLAPSE distinct values to Equal, never flip a strict
+                        // verdict. So — and ONLY — on an f64 tie, recheck exactly: the
+                        // exact-rational order splits collapsed integers beyond 2^53,
+                        // high-precision decimals, AND the mixed exact/inexact pair
+                        // (witness 1 of sq-wjl8i). An undecidable recheck keeps the tie.
+                        // Perf-neutral: exact work happens only on a tie.
+                        // [OPUS-4.8] sq-rikm7 / [FABLE-5] sq-wjl8i
+                        Some(Ordering::Equal) => x.exact_cmp(y).unwrap_or(Ordering::Equal),
+                        Some(o) => o,
+                        // NaN (the only `partial_cmp` None): totalise with NaN FIRST —
+                        // before -INF, equal to itself (witness 3 of sq-wjl8i; the
+                        // XPath 3.1 `fn:sort` "NaN least" choice). Relational `<`/`=`
+                        // keep their SPARQL type-error semantics — only this total
+                        // order positions NaN.
+                        None => match (a.is_nan(), b.is_nan()) {
+                            (true, false) => Ordering::Less,
+                            (false, true) => Ordering::Greater,
+                            _ => Ordering::Equal,
+                        },
+                    });
+                }
+            }
+            // Same non-numeric kind: strict value order where decidable (dateTime/date
+            // by timeline, booleans, same-tag / same-other-XSD lexically), else the
+            // deterministic lexical fallback.
             if let Some(o) = x.strict_cmp(y) {
                 return Some(o);
             }
@@ -203,25 +311,32 @@ pub fn compare_terms<T: CompareTerm>(x: &T, y: &T) -> Option<Ordering> {
     }
 }
 
-// [FABLE-5] sq-sqtk2.4 (epic sq-sqtk2, property B-1 of `research/mechanized-proof-program.md`
-// §3.2/§5): Kani bounded-proof harnesses for the ORDER LAWS of [`compare_terms`] — the laws
-// `ORDER BY`'s `sort_by` validity rests on (an inconsistent comparator makes Rust's sort
-// panic or produce garbage). HARNESS-ONLY: the `compare_terms` body above is byte-unchanged.
+// [FABLE-5] sq-sqtk2.4 / sq-wjl8i (epic sq-sqtk2, property B-1 of
+// `research/mechanized-proof-program.md` §3.2/§5): Kani bounded-proof harnesses for the
+// ORDER LAWS of [`compare_terms`] — the laws `ORDER BY`'s `sort_by` validity rests on (an
+// inconsistent comparator makes Rust's sort panic or produce garbage). The sq-sqtk2.4 wave
+// machine-checked three intransitivity WITNESSES across mixed literal kinds; sq-wjl8i then
+// FIXED the order (kind-first literals, exact mixed-tier ties, NaN totalised first) and
+// UPGRADED the law set below — the former documented-as-failing mixed-kind transitivity is
+// now a PROVED harness, and the witness harnesses pin the FIXED behaviour as regressions.
 //
 // WHAT IS PROVED (tier: PROVED (bounded), per the design record's vocabulary) — over every
 // value of the PER-HARNESS domain, each a stated sub-domain of the bounded model `M` below
 // (the harness doc-comment is the authoritative domain statement):
-//   • REFLEXIVITY (NaN-free domain):        compare_terms(x, x) == Some(Equal)
+//   • REFLEXIVITY (full domain, NaN INCLUDED):  compare_terms(x, x) == Some(Equal)
 //   • ANTISYMMETRY-CONSISTENCY (full domain, NaN included):
 //        compare_terms(x, y) == Some(o)  iff  compare_terms(y, x) == Some(o.reverse())
 //        (equivalently: None in one direction iff None in the other)
-//   • TRANSITIVITY on the defined domain, per LITERAL KIND (see the honest boundary below):
-//        exact-integer literals INCLUDING the 2^53 f64-collapse straddle, double literals,
-//        string literals, strict/temporal literals, a collapse-free exact/inexact numeric
-//        mix, recursive triple terms, the non-literal scalar classes, and a REDUCED
-//        int-with-non-literal composition (3 straddle ints × 2-string blanks/IRIs × Err —
-//        a stated shrink, see its doc)
-//   • WITHIN-CLASS TOTALITY (NaN-free domain): same-class pairs always compare `Some`
+//   • TRANSITIVITY on the defined domain — per literal kind AND ACROSS MIXED LITERAL
+//     KINDS (`transitivity_mixed_literal_kinds_incl_nan`, NaN included — the law the
+//     sq-sqtk2.4 witnesses proved FALSE before the sq-wjl8i fix): exact-integer literals
+//     INCLUDING the 2^53 f64-collapse straddle, double literals, string literals,
+//     strict/temporal literals, the full mixed literal-kind domain, a collapse-free
+//     exact/inexact numeric mix, recursive triple terms, the non-literal scalar classes,
+//     and a REDUCED int-with-non-literal composition (3 straddle ints × 2-string
+//     blanks/IRIs × Err — a stated shrink, see its doc)
+//   • WITHIN-CLASS TOTALITY (full literal domain, NaN INCLUDED): same-class pairs always
+//     compare `Some`
 //   • EXACT-ORDER AGREEMENT: for exact-tier integer pairs, compare_terms equals the exact
 //     i128 value order even where the f64 images collapse (THE guarantee the `exact_cmp`
 //     recheck tier exists to provide — delete the recheck in `compare_terms` and this goes
@@ -258,21 +373,21 @@ pub fn compare_terms<T: CompareTerm>(x: &T, y: &T) -> Option<Ordering> {
 // method below documents the `exec.rs` behaviour it mirrors — because a convenient model
 // would make these proofs vacuous.
 //
-// MACHINE-CHECKED FINDINGS (not masked — see the `witness_*` harnesses): the order laws do
-// NOT extend across mixed literal KINDS. Three concrete counterexamples, each PROVED
-// reachable (the witness harnesses assert current behaviour and fail if it changes):
-//   1. exact/inexact numeric-tier mix AT the 2^53 collapse boundary is intransitive
-//      (`witness_mixed_tier_collapse_intransitivity`);
-//   2. numeric-vs-plain-string comparison falls to the LEXICAL form, which disagrees with
-//      the numeric order (`witness_numeric_vs_string_lexical_intransitivity`);
-//   3. NaN makes the comparator PARTIAL — `compare_terms` returns `None`, which callers map
-//      to `Equal` (`witness_nan_comparison_partiality`).
-// All three are reachable through the engine's real `Value` impl (verified against
-// `exec.rs`: `num_compare` falls back to the collapsed f64 for float/double operands;
-// `value_compare_strict` is `None` cross-family so the string fallback fires; `parse_xsd_f64`
-// accepts `NaN`). Tracked as bug bead sq-wjl8i (P1) — the per-kind transitivity harnesses
-// above scope exactly which sub-domains ARE lawful, and the witnesses pin exactly where the
-// law breaks.
+// FORMER MACHINE-CHECKED FINDINGS, NOW FIXED (bead sq-wjl8i; the `witness_*` harnesses pin
+// the FIXED behaviour and go red on a regression): the sq-sqtk2.4 wave proved the order
+// laws did NOT extend across mixed literal KINDS —
+//   1. the exact/inexact numeric-tier mix AT the 2^53 collapse boundary was intransitive
+//      (the collapsed-f64 fallback tied a double with BOTH straddle integers) — fixed by
+//      the exact-rational mixed-tier recheck (`witness_mixed_tier_collapse_now_exact`);
+//   2. numeric-vs-plain-string pairs fell to the LEXICAL form, which disagrees with the
+//      numeric order (`"10" < "11" < "2"` vs `10 > 2`) — fixed by the kind-first rank:
+//      cross-kind pairs order by `LiteralKind`, never by a lexical coercion
+//      (`witness_numeric_vs_string_now_ranked_by_kind`);
+//   3. NaN made the comparator PARTIAL (`None`, mapped to `Equal` by callers) — fixed by
+//      totalising NaN FIRST among numerics (`witness_nan_now_totalised_first`).
+// All three were reachable through the engine's real `Value` impl; the engine-side fix
+// (`Value::literal_kind`, `Num::cmp_total`, the `cmp_sort_num` sort-cell mirror) is pinned
+// by the engine's unit tests and the sparq-reason engine-parity suite.
 //
 // RUN:  cargo kani -p sparq-substrate --features compare
 // (nightly lane wiring is bead sq-sqtk2.5; under normal build/clippy/test this module is
@@ -366,6 +481,20 @@ mod kani_proofs {
         "9.007199254740994E15",
     ];
 
+    /// TWICE each `DBLS` value, as an exact `i128` — the model's exact-rational tier for
+    /// the MIXED exact/inexact comparison (every table double is half-integral, so 2× is
+    /// exact; pinned by `domain_x2_doubles_are_exact`). The engine's real mixed-tier
+    /// tie-break (`Num::cmp_total` → the exact decimal-string comparison) is modelled as
+    /// the i128 order of the doubled values. [FABLE-5] sq-wjl8i
+    const DBL_X2: [i128; 6] = [
+        -18_014_398_509_481_984, // -(2^54)
+        0,                       // -0.0 — exactly equal to +0.0
+        0,
+        1, // 0.5
+        18_014_398_509_481_984, // 2^54
+        18_014_398_509_481_988, // 2^54 + 4
+    ];
+
     /// Blank labels / IRIs / plain-string literal values: tiny but adversarial — the empty
     /// string, a prefix pair (`"a"` < `"ab"`), and `"11"` (lexically ABOVE `"10"` and BELOW
     /// `"2"`: the digit-string inversion the numeric-vs-string witness rides on).
@@ -420,6 +549,17 @@ mod kani_proofs {
                 _ => None,
             }
         }
+
+        /// TWICE the term's exact rational value, as an exact `i128` — the model's
+        /// exact-rational tier for `exact_cmp` (see `DBL_X2`). `None` for NaN and
+        /// non-numerics. [FABLE-5] sq-wjl8i
+        fn x2(&self) -> Option<i128> {
+            match self {
+                M::Int(i) => Some(2 * INTS[usize::from(*i)]),
+                M::Dbl(i) => Some(DBL_X2[usize::from(*i)]),
+                _ => None,
+            }
+        }
     }
 
     impl CompareTerm for M {
@@ -430,6 +570,17 @@ mod kani_proofs {
                 M::Iri(_) => TermClass::Iri,
                 M::Int(_) | M::Dbl(_) | M::Nan | M::Str(_) | M::Strict(_) => TermClass::Literal,
                 M::Trip(..) => TermClass::Triple,
+            }
+        }
+        fn literal_kind(&self) -> LiteralKind {
+            // Engine (`Value::literal_kind`): the lenient numeric family (NaN included —
+            // `parse_xsd_f64` accepts it) is Numeric; plain strings String; the strict
+            // temporal family DateTime. Non-literals are never consulted.
+            match self {
+                M::Int(_) | M::Dbl(_) | M::Nan => LiteralKind::Numeric,
+                M::Str(_) => LiteralKind::String,
+                M::Strict(_) => LiteralKind::DateTime,
+                _ => LiteralKind::Other,
             }
         }
         fn value_str(&self) -> Option<String> {
@@ -453,17 +604,27 @@ mod kani_proofs {
             self.num().map(|(_, _, f)| f)
         }
         fn exact_cmp(&self, other: &Self) -> Option<Ordering> {
-            // Engine (`exec.rs` `exact_cmp` → `num_compare`): EXACT (decimal tower) only
-            // when BOTH operands are int/decimal tier; a float/double operand falls back to
-            // the — possibly collapsed — f64 `partial_cmp` (its value IS its f64). NOT the
-            // convenient "None on mixed pairs": the engine returns the collapsed verdict,
-            // and the mixed-tier witness below exists precisely because of it.
-            let (ax, av, af) = self.num()?;
-            let (bx, bv, bf) = other.num()?;
-            if ax && bx {
-                return Some(av.cmp(&bv));
+            // Engine (`exec.rs` `Value::exact_cmp` → `Num::cmp_total`, the sq-wjl8i fix):
+            // the exact-RATIONAL total order over numeric values — exact for int/decimal
+            // pairs AND for the mixed exact/inexact pair (a finite double's value is an
+            // exact rational; the engine compares against its exact decimal expansion),
+            // with NaN totalised first. Model: every domain value doubled is an exact
+            // i128 (`x2`, pinned by `domain_x2_doubles_are_exact`), so the exact-rational
+            // order IS the i128 order of the doubled values. The NaN arm mirrors
+            // `cmp_total` but is unreachable from `compare_terms` (NaN never produces the
+            // f64 TIE that triggers the recheck).
+            let (_, _, af) = self.num()?;
+            let (_, _, bf) = other.num()?;
+            match (af.is_nan(), bf.is_nan()) {
+                (true, true) => return Some(Ordering::Equal),
+                (true, false) => return Some(Ordering::Less),
+                (false, true) => return Some(Ordering::Greater),
+                (false, false) => {}
             }
-            af.partial_cmp(&bf)
+            match (self.x2(), other.x2()) {
+                (Some(a), Some(b)) => Some(a.cmp(&b)),
+                _ => None,
+            }
         }
         fn strict_cmp(&self, other: &Self) -> Option<Ordering> {
             // Engine (`value_compare_strict`): decides SAME-FAMILY pairs (dateTime/date by
@@ -576,12 +737,15 @@ mod kani_proofs {
         }
     }
 
-    /// One symbolic choice of NaN-free literal kind — `Int` / `Dbl` / `Str` / `Strict`.
-    fn for_each_literal_nan_free(f: impl Fn(&M)) {
+    /// One symbolic choice of literal kind over the FULL literal domain, NaN INCLUDED —
+    /// `Int` / `Dbl` / `Nan` / `Str` / `Strict`. (Before the sq-wjl8i fix the literal
+    /// laws only held NaN-free; the totalised order covers the full domain.)
+    fn for_each_literal(f: impl Fn(&M)) {
         match kani::any::<u8>() {
             0 => f(&M::Int(any_idx(INTS.len() as u8))),
             1 => f(&M::Dbl(any_idx(DBLS.len() as u8))),
-            2 => f(&M::Str(any_idx(STRS.len() as u8))),
+            2 => f(&M::Nan),
+            3 => f(&M::Str(any_idx(STRS.len() as u8))),
             _ => f(&M::Strict(any_idx(STRICT_STRS.len() as u8))),
         }
     }
@@ -602,21 +766,22 @@ mod kani_proofs {
         }
     }
 
-    // REFLEXIVITY over the NaN-free domain: `compare_terms(x, x) == Some(Equal)`.
-    // (With NaN the comparator is PARTIAL — see `witness_nan_comparison_partiality`.)
-    // Reflexivity is UNARY and per-value, so splitting the domain by literal kind proves
-    // the SAME law over the SAME union domain: the three harnesses below jointly cover
-    // every NaN-free model term.
+    // REFLEXIVITY over the FULL domain, NaN INCLUDED: `compare_terms(x, x) == Some(Equal)`.
+    // (Before the sq-wjl8i fix NaN made the comparator partial; the totalised order is
+    // reflexive everywhere.) Reflexivity is UNARY and per-value, so splitting the domain
+    // by literal kind proves the SAME law over the SAME union domain: the three harnesses
+    // below jointly cover every model term.
     fn assert_reflexive_at(x: &M) {
         assert!(compare_terms(x, x) == Some(Ordering::Equal), "reflexivity");
     }
 
     /// REFLEXIVITY: numeric literals — `Int` over the full `INTS` table (collapse straddle
-    /// included) and `Dbl` over the full `DBLS` table (NaN excluded — see the witness).
+    /// included), `Dbl` over the full `DBLS` table, and `NaN` (NaN == NaN in this total
+    /// order — the sq-wjl8i totalisation).
     #[kani::proof]
     #[kani::unwind(3)]
-    fn reflexivity_numeric_literals_nan_free() {
-        for_each_numeric(false, |x| assert_reflexive_at(x));
+    fn reflexivity_numeric_literals_incl_nan() {
+        for_each_numeric(true, |x| assert_reflexive_at(x));
     }
 
     /// REFLEXIVITY: the non-numeric scalar kinds — `Err`, `Blank`/`Iri`/`Str` over the full
@@ -698,19 +863,20 @@ mod kani_proofs {
         assert_antisymmetric_at(&any_trip(), &any_trip());
     }
 
-    // WITHIN-CLASS TOTALITY over the NaN-free domain: every same-class pair compares
-    // `Some` — including MIXED literal kinds (which stay totally DEFINED via the string
-    // fallback even where they are not transitive; see the witnesses). Split: the Literal
-    // class (the only class with multiple kinds) and the singleton-kind classes.
+    // WITHIN-CLASS TOTALITY over the FULL domain, NaN INCLUDED: every same-class pair
+    // compares `Some` — mixed literal kinds rank by `LiteralKind`, same-kind pairs by
+    // their within-kind order, NaN by its fixed first-among-numerics position (all
+    // sq-wjl8i). Split: the Literal class (the only class with multiple kinds) and the
+    // singleton-kind classes.
 
-    /// WITHIN-CLASS TOTALITY: the Literal class, NaN-free — every literal-kind pair
-    /// (numeric × numeric, numeric × string/strict via the lexical fallback, ...) is
-    /// `Some`. The larger unwind covers the long-form numeric-vs-`Strict` lexical compare.
+    /// WITHIN-CLASS TOTALITY: the Literal class over the FULL literal domain (NaN
+    /// included) — every literal-kind pair is `Some`. The larger unwind covers the
+    /// longest within-kind lexical compares.
     #[kani::proof]
     #[kani::unwind(12)]
-    fn within_class_totality_literals_nan_free() {
-        for_each_literal_nan_free(|x| {
-            for_each_literal_nan_free(|y| {
+    fn within_class_totality_literals_incl_nan() {
+        for_each_literal(|x| {
+            for_each_literal(|y| {
                 assert!(compare_terms(x, y).is_some(), "within-class totality: literals");
             });
         });
@@ -866,6 +1032,28 @@ mod kani_proofs {
         assert_transitive_at(&term(), &term(), &term());
     }
 
+    /// TRANSITIVITY across MIXED LITERAL KINDS, NaN INCLUDED — the law the sq-sqtk2.4
+    /// witnesses machine-checked as FALSE before the sq-wjl8i kind-first fix, now PROVED
+    /// over the FULL literal domain: `Int` over the whole `INTS` table (2^53 collapse
+    /// straddle and the `10`/`2` digit-inversion values included), `Dbl` over the whole
+    /// `DBLS` table (the collapse image included), `NaN`, `Str` over the whole `STRS`
+    /// table (`"11"`, the digit-string that lexically inverts against `10`/`2`,
+    /// included), and `Strict`. Cross-kind legs are decided purely by the
+    /// `LiteralKind` rank; within-kind legs by the per-kind orders (exact numeric with
+    /// the mixed-tier recheck, NaN first, strict, lexical). Revert the kind-rank rule
+    /// for any one cross-kind pair (fall back to the lexical form) and this goes red on
+    /// the `10 / "11" / 2` cycle; revert the exact mixed-tier recheck and it goes red on
+    /// the `2^53 / double(2^53) / 2^53+1` collapse triple. [FABLE-5] sq-wjl8i
+    #[kani::proof]
+    #[kani::unwind(12)]
+    fn transitivity_mixed_literal_kinds_incl_nan() {
+        for_each_literal(|x| {
+            for_each_literal(|y| {
+                for_each_literal(|z| assert_transitive_at(x, y, z));
+            });
+        });
+    }
+
     /// TRANSITIVITY: depth-1 triple terms — the component-wise recursion, with objects
     /// ranging over the collapsed integer pair so the recursive numeric arm hits the
     /// exact-tier recheck INSIDE a triple.
@@ -892,58 +1080,69 @@ mod kani_proofs {
         );
     }
 
-    /// FINDING 1 (machine-checked witness, current behaviour): transitivity FAILS on the
-    /// exact/inexact numeric-tier MIX at the 2^53 collapse boundary. A double equal to the
-    /// shared image ties (via the engine-faithful collapsed-f64 fallback) with BOTH collapsed
-    /// integers, which the exact tier orders strictly:
-    ///   `2^53 ~ 9.007199254740992E15 ~ 2^53+1`  but  `2^53 < 2^53+1`.
-    /// Engine-reachable: `num_compare` falls back to f64 when either operand is
-    /// float/double. Tracked as bead sq-wjl8i. If a fix lands (e.g. exact mixed-tier
-    /// comparison — every finite f64 is an exact rational), this harness goes red and
-    /// should be REMOVED with the fix.
+    /// Domain self-check (the sq-og8u8 pattern): every `DBL_X2` entry is EXACTLY twice
+    /// its `DBLS` value — the fidelity condition under which the model's i128
+    /// `exact_cmp` is the exact-rational order the engine's `Num::cmp_total` computes.
+    /// The signed-zero pair collapsing to one x2 value (0) is deliberate: `-0.0` and
+    /// `0.0` are exactly equal rationals. [FABLE-5] sq-wjl8i
     #[kani::proof]
-    fn witness_mixed_tier_collapse_intransitivity() {
+    #[kani::unwind(8)]
+    fn domain_x2_doubles_are_exact() {
+        let mut i = 0;
+        while i < DBLS.len() {
+            // Exact f64 comparison: fidelity IS bit-level agreement (×2 only bumps the
+            // exponent, and every X2 value is within f64's exact-integer range).
+            assert!(DBL_X2[i] as f64 == DBLS[i] * 2.0, "X2 must be exactly twice DBLS");
+            i += 1;
+        }
+        assert!(DBL_X2[1] == 0 && DBL_X2[2] == 0, "signed zeros are exactly equal");
+    }
+
+    /// FIXED — former FINDING 1 (bead sq-wjl8i; this harness pins the FIX and goes red
+    /// on a regression): the exact/inexact numeric-tier MIX at the 2^53 collapse
+    /// boundary now orders EXACTLY (every finite double is an exact rational). The
+    /// double equal to the shared f64 image ties ONLY with the integer it exactly
+    /// equals, and orders strictly below the collapsed neighbour — the triple that was
+    /// `Equal / Equal / Less` (intransitive) is now `Equal / Less / Less` (transitive).
+    #[kani::proof]
+    fn witness_mixed_tier_collapse_now_exact() {
         let x = M::Int(I_2P53);
         let y = M::Dbl(D_2P53);
         let z = M::Int(I_2P53_P1);
-        assert!(compare_terms(&x, &y) == Some(Ordering::Equal));
-        assert!(compare_terms(&y, &z) == Some(Ordering::Equal));
-        assert!(compare_terms(&x, &z) == Some(Ordering::Less)); // intransitive triple
+        assert!(compare_terms(&x, &y) == Some(Ordering::Equal)); // truly equal values
+        assert!(compare_terms(&y, &z) == Some(Ordering::Less)); // was Equal — the bug
+        assert!(compare_terms(&x, &z) == Some(Ordering::Less));
     }
 
-    /// FINDING 2 (machine-checked witness, current behaviour): transitivity FAILS on the
-    /// numeric-vs-plain-string mix — cross-family pairs fall back to the LEXICAL form, and
-    /// lexical digit-string order disagrees with numeric order:
-    ///   `10 < "11" < 2` (lexically)  but  `10 > 2` (numerically).
-    /// Engine-reachable: `value_compare_strict` is `None` for a (numeric, plain-string)
-    /// pair, so `compare_terms` reaches its string fallback. Tracked as bead sq-wjl8i.
+    /// FIXED — former FINDING 2 (bead sq-wjl8i; pins the FIX): numeric vs plain-string
+    /// pairs now rank by KIND (`Numeric < String`), never by the lexical form, so the
+    /// `10 / "11" / 2` digit-inversion cycle (`Less / Less / Greater`) is gone: both
+    /// integers sort below the string, and against each other numerically.
     #[kani::proof]
     #[kani::unwind(4)]
-    fn witness_numeric_vs_string_lexical_intransitivity() {
+    fn witness_numeric_vs_string_now_ranked_by_kind() {
         let x = M::Int(I_TEN); // 10
         let y = M::Str(S_11); // "11"
         let z = M::Int(I_TWO); // 2
-        assert!(compare_terms(&x, &y) == Some(Ordering::Less)); // "10" < "11"
-        assert!(compare_terms(&y, &z) == Some(Ordering::Less)); // "11" < "2"
-        assert!(compare_terms(&x, &z) == Some(Ordering::Greater)); // 10 > 2
+        assert!(compare_terms(&x, &y) == Some(Ordering::Less)); // kind rank, not "10"<"11"
+        assert!(compare_terms(&y, &z) == Some(Ordering::Greater)); // was lexical "11"<"2"
+        assert!(compare_terms(&x, &z) == Some(Ordering::Greater)); // 10 > 2 — consistent
     }
 
-    /// FINDING 3 (machine-checked witness, current behaviour): NaN makes the comparator
-    /// PARTIAL — numeric comparison against NaN is `None` (callers map it to `Equal`, so at
-    /// the call site NaN ties with EVERY numeric, collapsing distinct equivalence classes),
-    /// while NaN against a plain string is still DEFINED (lexical fallback). Engine-
-    /// reachable: `parse_xsd_f64` accepts the XSD `NaN` spelling. Tracked as bead
-    /// sq-wjl8i. Also pins that the module-level doc's "`None` only when a term has no
-    /// string form" understates `None` — that doc drift is tracked as bead sq-ma9fb.
+    /// FIXED — former FINDING 3 (beads sq-wjl8i + the sq-ma9fb doc drift; pins the FIX):
+    /// NaN no longer makes the comparator partial — it is totalised FIRST among
+    /// numerics (before `-INF`) and equal to itself, so callers mapping `None` to
+    /// `Equal` can no longer make NaN "equal" to every numeric. Against a plain string
+    /// NaN now ranks by kind (`Numeric < String`), not by its `"NaN"` lexical form.
     #[kani::proof]
     #[kani::unwind(4)]
-    fn witness_nan_comparison_partiality() {
-        assert!(compare_terms(&M::Nan, &M::Nan).is_none());
-        assert!(compare_terms(&M::Nan, &M::Dbl(2)).is_none()); // vs 0.0
-        assert!(compare_terms(&M::Dbl(2), &M::Nan).is_none());
-        assert!(compare_terms(&M::Nan, &M::Int(I_2P53)).is_none());
-        // ... but the string fallback still fires cross-family: "NaN" vs "a".
-        assert!(compare_terms(&M::Nan, &M::Str(2)) == Some(Ordering::Less));
+    fn witness_nan_now_totalised_first() {
+        assert!(compare_terms(&M::Nan, &M::Nan) == Some(Ordering::Equal));
+        assert!(compare_terms(&M::Nan, &M::Dbl(2)) == Some(Ordering::Less)); // vs 0.0
+        assert!(compare_terms(&M::Dbl(2), &M::Nan) == Some(Ordering::Greater));
+        assert!(compare_terms(&M::Nan, &M::Int(I_2P53)) == Some(Ordering::Less));
+        assert!(compare_terms(&M::Nan, &M::Dbl(0)) == Some(Ordering::Less)); // vs -(2^53)
+        assert!(compare_terms(&M::Nan, &M::Str(2)) == Some(Ordering::Less)); // kind rank
     }
 }
 
@@ -979,6 +1178,75 @@ mod tests {
         Triple(Box<T>, Box<T>, Box<T>),
     }
 
+    /// Test-model mirror of the engine's exact mixed-tier tie-break (`Num::cmp_total` →
+    /// the exact decimal-string comparison): `mant × 10^-scale` against the f64's exact
+    /// decimal expansion, pure string arithmetic. [FABLE-5] sq-wjl8i
+    fn cmp_exact_vs_f64(mant: i128, scale: u32, f: f64) -> Ordering {
+        if f.is_nan() {
+            return Ordering::Greater; // NaN sorts first: every exact value is above it
+        }
+        if f == f64::INFINITY {
+            return Ordering::Less;
+        }
+        if f == f64::NEG_INFINITY {
+            return Ordering::Greater;
+        }
+        cmp_plain_dec(&dec_str(mant, scale), &format!("{:.1074}", f))
+    }
+
+    /// `mant × 10^-scale` as a plain decimal string (test-local `Dec::lexical` mirror).
+    fn dec_str(mant: i128, scale: u32) -> String {
+        let mag = mant.unsigned_abs().to_string();
+        let s = scale as usize;
+        let sign = if mant < 0 { "-" } else { "" };
+        if s == 0 {
+            return format!("{}{}", sign, mag);
+        }
+        if mag.len() > s {
+            format!("{}{}.{}", sign, &mag[..mag.len() - s], &mag[mag.len() - s..])
+        } else {
+            format!("{}0.{}{}", sign, "0".repeat(s - mag.len()), mag)
+        }
+    }
+
+    /// Exact comparison of two well-formed plain decimal strings (test-local mirror of
+    /// `numeric::cmp_plain_decimal`; panics on malformed input — test-only).
+    fn cmp_plain_dec(a: &str, b: &str) -> Ordering {
+        let split = |s: &str| -> (bool, String, String) {
+            let (neg, s) = match s.strip_prefix('-') {
+                Some(r) => (true, r),
+                None => (false, s),
+            };
+            let (int, frac) = s.split_once('.').unwrap_or((s, ""));
+            (neg, int.trim_start_matches('0').to_string(), frac.trim_end_matches('0').to_string())
+        };
+        let (na, ia, fa) = split(a);
+        let (nb, ib, fb) = split(b);
+        let a_zero = ia.is_empty() && fa.is_empty();
+        let b_zero = ib.is_empty() && fb.is_empty();
+        if a_zero && b_zero {
+            return Ordering::Equal;
+        }
+        let mag = ia.len().cmp(&ib.len()).then_with(|| ia.cmp(&ib)).then_with(|| {
+            let n = fa.len().max(fb.len());
+            (0..n)
+                .map(|i| {
+                    (
+                        fa.as_bytes().get(i).copied().unwrap_or(b'0'),
+                        fb.as_bytes().get(i).copied().unwrap_or(b'0'),
+                    )
+                })
+                .find_map(|(x, y)| if x != y { Some(x.cmp(&y)) } else { None })
+                .unwrap_or(Ordering::Equal)
+        });
+        match (na && !a_zero, nb && !b_zero) {
+            (true, false) => Ordering::Less,
+            (false, true) => Ordering::Greater,
+            (false, false) => mag,
+            (true, true) => mag.reverse(),
+        }
+    }
+
     impl CompareTerm for T {
         fn term_class(&self) -> TermClass {
             match self {
@@ -987,6 +1255,14 @@ mod tests {
                 T::Iri(_) => TermClass::Iri,
                 T::NumLit(_) | T::ExactNum { .. } | T::StrLit(_) | T::Strict(_) => TermClass::Literal,
                 T::Triple(..) => TermClass::Triple,
+            }
+        }
+        fn literal_kind(&self) -> LiteralKind {
+            match self {
+                T::NumLit(_) | T::ExactNum { .. } => LiteralKind::Numeric,
+                T::StrLit(_) => LiteralKind::String,
+                T::Strict(_) => LiteralKind::DateTime,
+                _ => LiteralKind::Other, // non-literals: never consulted
             }
         }
         fn value_str(&self) -> Option<String> {
@@ -1010,15 +1286,22 @@ mod tests {
             match (self, other) {
                 // Align both scaled integers to the common (max) scale, then compare the
                 // mantissas exactly (mirrors the substrate `Dec::cmp` the engine's numeric
-                // tower uses). Only `ExactNum` pairs have an exact tier; everything else
-                // (a plain f64 `NumLit`, a non-numeric literal) returns `None` and keeps
-                // the collapsed f64 verdict. [OPUS-4.8] sq-rikm7
+                // tower uses). [OPUS-4.8] sq-rikm7
                 (T::ExactNum { mant: am, scale: asc, .. }, T::ExactNum { mant: bm, scale: bsc, .. }) => {
                     let scale = (*asc).max(*bsc);
                     let a = am.checked_mul(10i128.checked_pow(scale - asc)?)?;
                     let b = bm.checked_mul(10i128.checked_pow(scale - bsc)?)?;
                     Some(a.cmp(&b))
                 }
+                // MIXED exact/inexact pair: the exact-rational order against the f64's
+                // exact decimal expansion — the engine's `Num::cmp_total` mixed arm
+                // (witness 1 of sq-wjl8i: leaving this `None` keeps the collapsed f64
+                // tie, which is intransitive against the exact int/int order).
+                (T::ExactNum { mant, scale, .. }, T::NumLit(f)) => Some(cmp_exact_vs_f64(*mant, *scale, *f)),
+                (T::NumLit(f), T::ExactNum { mant, scale, .. }) => {
+                    Some(cmp_exact_vs_f64(*mant, *scale, *f).reverse())
+                }
+                // Two plain f64 numerics: the value IS the f64 — an f64 tie is a true tie.
                 _ => None,
             }
         }
@@ -1115,10 +1398,16 @@ mod tests {
         let ten_hundredths = T::ExactNum { f: 0.1, mant: 10, scale: 2 };
         let one_tenth = T::ExactNum { f: 0.1, mant: 1, scale: 1 };
         assert_eq!(compare_terms(&ten_hundredths, &one_tenth), Some(Ordering::Equal));
-        // And `exact_cmp` is `None` when either side has no exact tier (a plain f64 numeric),
-        // so such a pair keeps the (correct) f64 verdict.
-        assert_eq!(a.exact_cmp(&T::NumLit(f)), None);
-        assert_eq!(T::NumLit(f).exact_cmp(&a), None);
+        // The MIXED exact/inexact pair also decides exactly (sq-wjl8i): the double f is
+        // exactly 0.12345678901234567736…, so BOTH high-precision decimals (…678, …679)
+        // sit strictly above the double they collapse onto — mirrored in both directions.
+        assert_eq!(a.exact_cmp(&T::NumLit(f)), Some(Ordering::Greater));
+        assert_eq!(T::NumLit(f).exact_cmp(&a), Some(Ordering::Less));
+        assert_eq!(compare_terms(&a, &T::NumLit(f)), Some(Ordering::Greater));
+        assert_eq!(compare_terms(&T::NumLit(f), &b), Some(Ordering::Less));
+        // An exact value that IS its double stays a true tie.
+        let half = T::ExactNum { f: 0.5, mant: 5, scale: 1 };
+        assert_eq!(compare_terms(&half, &T::NumLit(0.5)), Some(Ordering::Equal));
     }
 
     #[test]
@@ -1130,11 +1419,27 @@ mod tests {
 
     #[test]
     fn string_fallback_when_no_numeric_and_no_strict() {
-        // Two plain string literals: as_f64 None, strict_cmp None → lexical string order.
+        // Two plain string literals (same kind): strict_cmp None → lexical string order.
         assert_eq!(compare_terms(&T::StrLit("apple".into()), &T::StrLit("banana".into())), Some(Ordering::Less));
-        // A numeric vs a string literal (same class): numeric arm fails (one side None),
-        // strict_cmp None, so both fall to value_str — "1" vs "z".
-        assert_eq!(compare_terms(&T::NumLit(1.0), &T::StrLit("z".into())), Some(Ordering::Less));
+    }
+
+    #[test]
+    fn cross_kind_literals_rank_by_kind_never_lexically() {
+        // [FABLE-5] sq-wjl8i: a numeric vs a string literal ranks by LiteralKind
+        // (Numeric < String) — NEVER by the lexical form. "0" < "1" lexically would
+        // put the string first; the kind rank keeps every numeric below every string.
+        assert_eq!(compare_terms(&T::NumLit(1.0), &T::StrLit("0".into())), Some(Ordering::Less));
+        assert_eq!(compare_terms(&T::StrLit("0".into()), &T::NumLit(1.0)), Some(Ordering::Greater));
+        // Numeric < DateTime-kind (strict) < String, per the documented rank.
+        assert_eq!(compare_terms(&T::NumLit(1.0), &T::Strict(0)), Some(Ordering::Less));
+        assert_eq!(compare_terms(&T::Strict(0), &T::StrLit("".into())), Some(Ordering::Less));
+        // The enum rank order itself (the documented extension).
+        assert!(LiteralKind::Numeric < LiteralKind::Boolean);
+        assert!(LiteralKind::Boolean < LiteralKind::DateTime);
+        assert!(LiteralKind::DateTime < LiteralKind::Date);
+        assert!(LiteralKind::Date < LiteralKind::String);
+        assert!(LiteralKind::String < LiteralKind::Lang);
+        assert!(LiteralKind::Lang < LiteralKind::Other);
     }
 
     #[test]
@@ -1160,87 +1465,68 @@ mod tests {
         assert_eq!(compare_terms(&nested(2.0), &nested(2.0)), Some(Ordering::Equal));
     }
 
-    // --- BUG WITNESSES (pinned by the sq-sqtk2.4 Kani harnesses; tracked as P1 bug bead
-    //     sq-wjl8i) ---
+    // --- FIXED BUG WITNESSES (sq-wjl8i; formerly `#[ignore]`d red pins of the broken
+    //     behaviour, now ACTIVE regression cases of the FIX) ---
     //
-    // These three tests reproduce the machine-checked counterexamples from the Kani
-    // `kani_proofs` module's `witness_*` harnesses. They are `#[ignore]` because they assert
-    // the ORDER LAW (transitivity of equality) which CURRENTLY FAILS — i.e., removing
-    // `#[ignore]` turns them RED under `cargo test`. Remove `#[ignore]` and run them to
-    // verify a fix; they will pass once the comparator is made consistent. [SONNET-4.6]
+    // These three tests carry the machine-checked counterexamples from the Kani
+    // `kani_proofs` module's `witness_*` harnesses. Before the sq-wjl8i fix they were
+    // `#[ignore]`d and asserted the ORDER LAWS that failed; the comparator is now a total
+    // order, so they run in every `cargo test` and pin the fixed verdicts (the exact
+    // triples that used to be intransitive). [SONNET-4.6] / [FABLE-5]
 
-    /// BUG witness 1 — mixed exact/inexact numeric pair at the 2^53 collapse boundary.
-    ///
-    /// The transitivity law for equality is: x = y AND y = z => x = z.
-    /// Here: `xsd:integer 2^53` equals `xsd:double 9.007199254740992E15` (their f64 images
-    /// are identical and `exact_cmp` returns `None` on a mixed pair), and
-    /// `xsd:double 9.007199254740992E15` also equals `xsd:integer 2^53+1` (same reason),
-    /// but `compare_terms(xsd:integer 2^53, xsd:integer 2^53+1)` returns `Less` (the
-    /// exact recheck correctly orders them). The triple `(2^53, double(2^53), 2^53+1)` is an
-    /// intransitive witness. Tracked as P1 correctness bead sq-wjl8i.
-    /// `ORDER BY` / `GROUP BY` / `MIN` / `MAX` over a column mixing integer and double values
-    /// near 2^53 may produce permutation-unstable output violating SPARQL ordering semantics.
+    /// FIXED witness 1 — the mixed exact/inexact numeric pair at the 2^53 collapse
+    /// boundary now orders EXACTLY (every finite double is an exact rational): the
+    /// double ties only with the integer it exactly equals and sits strictly below the
+    /// collapsed neighbour, so the triple `(2^53, double(2^53), 2^53+1)` — formerly
+    /// `Equal / Equal / Less`, an intransitive equality — is now `Equal / Less / Less`.
+    /// `ORDER BY` / `MIN` / `MAX` over a column mixing integers and doubles near 2^53
+    /// is permutation-stable again. [FABLE-5] sq-wjl8i
     #[test]
-    #[ignore = "BUG sq-wjl8i: mixed exact/inexact numeric intransitivity at 2^53 collapse — remove once fixed"]
-    fn bug_witness_mixed_exact_inexact_numeric_intransitivity_at_2p53() {
+    fn witness1_mixed_exact_inexact_at_2p53_now_transitive() {
         let two53: f64 = 9_007_199_254_740_992.0;
         // x = xsd:integer 2^53 (exact tier)
         let x = T::ExactNum { f: two53, mant: 9_007_199_254_740_992_i128, scale: 0 };
-        // y = xsd:double 2^53 (inexact tier — no exact_cmp)
+        // y = xsd:double 2^53 (inexact tier — its value IS the f64)
         let y = T::NumLit(two53);
-        // z = xsd:integer 2^53+1 (exact tier; shares f64 image with x)
+        // z = xsd:integer 2^53+1 (exact tier; shares its f64 image with x and y)
         let z = T::ExactNum { f: two53, mant: 9_007_199_254_740_993_i128, scale: 0 };
-        // Confirm the witnesses: x = y, y = z (the comparator is defined and returns Equal)
-        assert_eq!(compare_terms(&x, &y), Some(Ordering::Equal), "x ~ y");
-        assert_eq!(compare_terms(&y, &z), Some(Ordering::Equal), "y ~ z");
-        // Transitivity of equality would require: x = z.
-        // Currently FAILS (returns Less) — the exact recheck orders x < z correctly, but
-        // inconsistently with the mixed-tier Equal above.
-        assert_eq!(compare_terms(&x, &z), Some(Ordering::Equal), "transitivity: x=y AND y=z => x=z");
+        assert_eq!(compare_terms(&x, &y), Some(Ordering::Equal), "x IS y exactly");
+        assert_eq!(compare_terms(&y, &z), Some(Ordering::Less), "the collapse no longer ties (was Equal)");
+        assert_eq!(compare_terms(&x, &z), Some(Ordering::Less), "transitive: x = y < z => x < z");
+        assert_eq!(compare_terms(&z, &y), Some(Ordering::Greater), "mirror");
     }
 
-    /// BUG witness 2 — numeric-vs-plain-string cross-family fallback to lexical order.
-    ///
-    /// Cross-family literal pairs (numeric vs plain-string) have no strict_cmp, so
-    /// `compare_terms` falls back to the LEXICAL string form. Lexical digit-string order
-    /// inverts numeric order on certain pairs: `"10" < "11" < "2"` (lexical) while
-    /// `10 > 2` (numeric). The triple `(Int 10, StrLit "11", Int 2)` is an intransitive
-    /// witness: `10 < "11"` and `"11" < 2` (lexical) but `10 > 2` (numeric).
-    /// Tracked as P1 correctness bead sq-wjl8i.
+    /// FIXED witness 2 — numeric vs plain-string pairs now rank by KIND
+    /// (`Numeric < String`), never by the lexical form, so the digit-string inversion
+    /// `"10" < "11" < "2"` can no longer contradict the numeric `10 > 2`: the triple
+    /// `(10, "11", 2)` — formerly `Less / Less / Greater`, an intransitive strict
+    /// order — is now consistent (`2 < 10 < "11"`). Any ORDER BY column mixing numerics
+    /// and plain strings sorts consistently again. [FABLE-5] sq-wjl8i
     #[test]
-    #[ignore = "BUG sq-wjl8i: numeric-vs-plain-string lexical-fallback intransitivity — remove once fixed"]
-    fn bug_witness_numeric_vs_string_lexical_fallback_intransitivity() {
-        // x = integer 10, z = integer 2: compare_terms(x, z) = Greater (10 > 2 numerically)
+    fn witness2_numeric_vs_string_now_ranked_by_kind() {
         let x = T::ExactNum { f: 10.0, mant: 10, scale: 0 };
         let z = T::ExactNum { f: 2.0, mant: 2, scale: 0 };
-        // y = plain-string "11": compare_terms(x, y) falls back to lexical "10" < "11" (Less)
-        // and compare_terms(y, z) falls back to lexical "11" < "2" (Less)
         let y = T::StrLit("11".into());
-        // Confirm the two Less legs (current behaviour)
-        assert_eq!(compare_terms(&x, &y), Some(Ordering::Less), "\"10\" < \"11\" lexically");
-        assert_eq!(compare_terms(&y, &z), Some(Ordering::Less), "\"11\" < \"2\" lexically");
-        // Transitivity of the strict-order Less would require: x < z.
-        // Currently FAILS (returns Greater) — numeric order disagrees with lexical.
-        assert_eq!(compare_terms(&x, &z), Some(Ordering::Less), "transitivity: x<y AND y<z => x<z");
+        assert_eq!(compare_terms(&x, &y), Some(Ordering::Less), "Numeric < String by kind rank");
+        assert_eq!(compare_terms(&y, &z), Some(Ordering::Greater), "String > Numeric (was lexical \"11\" < \"2\")");
+        assert_eq!(compare_terms(&x, &z), Some(Ordering::Greater), "10 > 2 numerically — consistent");
     }
 
-    /// BUG witness 3 — NaN makes the comparator partial on same-class literal pairs.
-    ///
-    /// `xsd:double NaN` has an f64 form (`NaN`), so `as_f64` returns `Some(NaN)`. The numeric
-    /// `partial_cmp` then returns `None` for every NaN comparison. Callers that map `None` to
-    /// `Equal` effectively place NaN equal to every numeric, collapsing distinct equivalence
-    /// classes. Within-class totality is violated: `compare_terms(NaN, Int(0))` returns `None`
-    /// even though both are `TermClass::Literal`. Tracked as P1 correctness bead sq-wjl8i.
+    /// FIXED witness 3 — NaN no longer makes the comparator partial: it is totalised
+    /// FIRST among numerics (before `-INF`) and equal to itself, so a caller mapping
+    /// `None` to `Equal` can no longer place NaN "equal" to every numeric. Within-class
+    /// totality holds NaN included. [FABLE-5] sq-wjl8i (and the sq-ma9fb doc drift:
+    /// `None` is no longer returned for NaN).
     #[test]
-    #[ignore = "BUG sq-wjl8i: NaN makes comparator partial on same-class Literal pairs — remove once fixed"]
-    fn bug_witness_nan_partiality_violates_within_class_totality() {
+    fn witness3_nan_now_totalised_first_among_numerics() {
         let nan = T::NumLit(f64::NAN);
         let zero = T::NumLit(0.0);
-        // Both are TermClass::Literal — within-class totality requires Some(_).
-        // Currently returns None (f64::NAN.partial_cmp(0.0) = None).
-        assert!(
-            compare_terms(&nan, &zero).is_some(),
-            "within-class totality: Literal NaN vs Literal 0 must compare Some"
-        );
+        let neg_inf = T::NumLit(f64::NEG_INFINITY);
+        assert_eq!(compare_terms(&nan, &zero), Some(Ordering::Less), "NaN sorts first");
+        assert_eq!(compare_terms(&zero, &nan), Some(Ordering::Greater), "mirror");
+        assert_eq!(compare_terms(&nan, &neg_inf), Some(Ordering::Less), "NaN before -INF");
+        assert_eq!(compare_terms(&nan, &nan), Some(Ordering::Equal), "NaN ties with itself");
+        // And against another kind, NaN ranks as a numeric (kind rank, not lexical "NaN").
+        assert_eq!(compare_terms(&nan, &T::StrLit("A".into())), Some(Ordering::Less));
     }
 }

--- a/crates/sparq-substrate/src/numeric.rs
+++ b/crates/sparq-substrate/src/numeric.rs
@@ -243,6 +243,74 @@ pub fn split_decimal(s: &str) -> Option<(bool, &str, &str)> {
     Some((neg, int.trim_start_matches('0'), frac.trim_end_matches('0')))
 }
 
+/// Exact comparison of two plain decimal lexicals (`[+-]?digits(.digits)?`) of ANY
+/// length — pure string arithmetic, no `f64` and no `i128` bound. `None` if either
+/// lexical is not a well-formed decimal. Signed zeros (`-0`, `-0.0`) compare equal to
+/// zero. This is the string-exact tier [`Num::cmp_total`]'s f64-tie disambiguation
+/// rides on. [FABLE-5] sq-wjl8i
+pub fn cmp_plain_decimal(a: &str, b: &str) -> Option<Ordering> {
+    let (na, ia, fa) = split_decimal(a)?;
+    let (nb, ib, fb) = split_decimal(b)?;
+    let a_zero = ia.is_empty() && fa.is_empty();
+    let b_zero = ib.is_empty() && fb.is_empty();
+    if a_zero && b_zero {
+        return Some(Ordering::Equal);
+    }
+    // Magnitude: longer (normalised) integer part wins, then integer digits, then
+    // fraction digits with implicit trailing-zero padding.
+    let mag = ia.len().cmp(&ib.len()).then_with(|| ia.cmp(ib)).then_with(|| {
+        let n = fa.len().max(fb.len());
+        (0..n)
+            .map(|i| {
+                (
+                    fa.as_bytes().get(i).copied().unwrap_or(b'0'),
+                    fb.as_bytes().get(i).copied().unwrap_or(b'0'),
+                )
+            })
+            .find_map(|(x, y)| if x != y { Some(x.cmp(&y)) } else { None })
+            .unwrap_or(Ordering::Equal)
+    });
+    let neg_a = na && !a_zero;
+    let neg_b = nb && !b_zero;
+    Some(match (neg_a, neg_b) {
+        (true, false) => Ordering::Less,
+        (false, true) => Ordering::Greater,
+        (false, false) => mag,
+        (true, true) => mag.reverse(),
+    })
+}
+
+/// The EXACT plain-decimal expansion of a finite `f64` (every finite `f64` is an exact
+/// decimal rational; the longest needs 1074 fraction digits). `None` for `NaN` / `±INF`.
+/// Cold-path helper for the f64-tie disambiguation in [`Num::cmp_total`] and the
+/// engine's numeric sort cells. [FABLE-5] sq-wjl8i
+pub fn f64_exact_decimal(f: f64) -> Option<String> {
+    if !f.is_finite() {
+        return None;
+    }
+    // With precision >= the maximum exact digit count, Rust's correctly-rounded
+    // formatting IS the exact expansion.
+    Some(format!("{:.1074}", f))
+}
+
+/// Exact order of an exact fixed-point decimal against a (non-NaN) `f64`'s exact
+/// rational value: the decimal's lexical against the double's exact decimal expansion,
+/// pure string arithmetic throughout. Deliberately NO `f64` fast path: `Dec::f64` is a
+/// two-rounding image (mantissa conversion then a division), so a strict `f64` verdict
+/// here is not boundary-trustworthy — and this helper is only reached on the cold
+/// f64-tie path of the total order. [FABLE-5] sq-wjl8i
+fn cmp_dec_f64(d: Dec, f: f64) -> Ordering {
+    if f == f64::INFINITY {
+        return Ordering::Less;
+    }
+    if f == f64::NEG_INFINITY {
+        return Ordering::Greater;
+    }
+    f64_exact_decimal(f)
+        .and_then(|exp| cmp_plain_decimal(&d.lexical(), &exp))
+        .unwrap_or(Ordering::Equal)
+}
+
 /// The arithmetic operator for [`Num::binop`]: `+ - * /` under XPath operand promotion.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum ArithOp {
@@ -318,6 +386,45 @@ impl Num {
             Num::Int(i) => Some(Dec { mant: i as i128, scale: 0 }),
             Num::Dec(d) => Some(d),
             _ => None,
+        }
+    }
+
+    /// The TOTAL order over numeric values used by the SPARQL `ORDER BY` extension
+    /// (the `CompareTerm::exact_cmp` hook of `sparq_substrate::compare`) — [FABLE-5]
+    /// sq-wjl8i. Unlike the relational comparison (XPath `op:numeric-*`, where a
+    /// float/double operand PROMOTES the pair to a possibly-collapsing `f64` and `NaN`
+    /// is incomparable), this is the **exact-rational** order over the values,
+    /// totalised:
+    ///
+    /// - `NaN` sorts FIRST (before `-INF`), and `NaN == NaN` — the fixed position that
+    ///   makes the order total (the choice XPath 3.1's `fn:sort` makes: "NaN least");
+    /// - an exact-tier operand (`Int` / `Dec`) against a float/double compares against
+    ///   the float/double's EXACT rational value (every finite `f64` is one), so the
+    ///   2^53 collapse cannot make two distinct values tie with a third
+    ///   (the machine-checked intransitivity witness of bead sq-wjl8i);
+    /// - the order REFINES the promoted (`f64`) comparison: `f64` rounding is monotonic,
+    ///   so every strict promoted verdict is preserved — only promoted TIES are refined.
+    ///
+    /// Honest boundary: two `Dec`s whose scale alignment overflows `i128` fall back to
+    /// the `f64` image (as `Dec::cmp` documents); values whose lexicals exceed the
+    /// `i128` tower never reach this type (`as_numeric` classifies them out).
+    pub fn cmp_total(self, o: Num) -> Ordering {
+        let (fa, fb) = (self.f64(), o.f64());
+        match (fa.is_nan(), fb.is_nan()) {
+            (true, true) => return Ordering::Equal,
+            (true, false) => return Ordering::Less,
+            (false, true) => return Ordering::Greater,
+            (false, false) => {}
+        }
+        match (self.to_dec(), o.to_dec()) {
+            (Some(a), Some(b)) => a
+                .cmp(b)
+                .unwrap_or_else(|| fa.partial_cmp(&fb).unwrap_or(Ordering::Equal)),
+            (Some(a), None) => cmp_dec_f64(a, fb),
+            (None, Some(b)) => cmp_dec_f64(b, fa).reverse(),
+            // Both inexact: the value IS the f64 (an `f32` widens exactly); both are
+            // non-NaN here, so `partial_cmp` always decides.
+            (None, None) => fa.partial_cmp(&fb).unwrap_or(Ordering::Equal),
         }
     }
 
@@ -1233,5 +1340,83 @@ mod tests {
         assert_eq!(fmt_xsd_double(f64::NEG_INFINITY), "-INF");
         assert_eq!(fmt_xsd_double(-6.0), "-6");
         assert_eq!(fmt_xsd_double(1.5), "1.5E0");
+    }
+
+    // --- Num::cmp_total — the ORDER BY total order over numeric values (sq-wjl8i) ---
+
+    const TWO53: i64 = 9_007_199_254_740_992;
+
+    /// NaN takes a FIXED position: before -INF, equal to itself — the totalisation.
+    #[test]
+    fn cmp_total_nan_sorts_first_and_equals_itself() {
+        use Ordering::*;
+        let nan = Num::Double(f64::NAN);
+        assert_eq!(nan.cmp_total(Num::Double(f64::NEG_INFINITY)), Less);
+        assert_eq!(nan.cmp_total(Num::Int(0)), Less);
+        assert_eq!(Num::Int(0).cmp_total(nan), Greater);
+        assert_eq!(nan.cmp_total(Num::Float(f32::NAN)), Equal);
+        assert_eq!(nan.cmp_total(nan), Equal);
+    }
+
+    /// The mixed exact/inexact tier at the 2^53 collapse: the double equal to the shared
+    /// f64 image is EQUAL to the integer it exactly is, and strictly BELOW the collapsed
+    /// neighbour 2^53+1 — the intransitivity witness of bead sq-wjl8i, now decided
+    /// exactly instead of collapsing to a three-way tie.
+    #[test]
+    fn cmp_total_mixed_tier_is_exact_at_the_2p53_collapse() {
+        use Ordering::*;
+        let dbl = Num::Double(TWO53 as f64);
+        let int_lo = Num::Int(TWO53);
+        let int_hi = Num::Dec(Dec { mant: TWO53 as i128 + 1, scale: 0 });
+        assert_eq!(int_lo.cmp_total(dbl), Equal, "2^53 IS the double exactly");
+        assert_eq!(dbl.cmp_total(int_hi), Less, "the collapsed neighbour still orders");
+        assert_eq!(int_hi.cmp_total(dbl), Greater);
+        assert_eq!(int_lo.cmp_total(int_hi), Less);
+    }
+
+    /// A decimal against the double it rounds to is NOT equal: `0.1` (exact) is below
+    /// the double `0.1` (exactly 0.1000000000000000055511151231257827…). And ±INF /
+    /// exact pairs order by sign of the infinity.
+    #[test]
+    fn cmp_total_decimal_vs_double_refines_the_f64_tie() {
+        use Ordering::*;
+        let dec = Num::Dec(Dec { mant: 1, scale: 1 });
+        let dbl = Num::Double(0.1);
+        assert_eq!(dec.cmp_total(dbl), Less);
+        assert_eq!(dbl.cmp_total(dec), Greater);
+        assert_eq!(Num::Int(1).cmp_total(Num::Double(f64::INFINITY)), Less);
+        assert_eq!(Num::Int(1).cmp_total(Num::Double(f64::NEG_INFINITY)), Greater);
+        // Both-inexact: the value IS the f64; a float widens exactly.
+        assert_eq!(Num::Float(0.5).cmp_total(Num::Double(0.5)), Equal);
+        assert_eq!(Num::Double(-0.0).cmp_total(Num::Double(0.0)), Equal);
+    }
+
+    /// Direct pin of `cmp_plain_decimal`: arbitrary-length string-exact decimals,
+    /// signed-zero equality, malformed inputs.
+    #[test]
+    fn cmp_plain_decimal_is_exact_and_total_on_decimals() {
+        use Ordering::*;
+        assert_eq!(cmp_plain_decimal("9007199254740992", "9007199254740993"), Some(Less));
+        assert_eq!(cmp_plain_decimal("0.123456789012345678", "0.123456789012345679"), Some(Less));
+        assert_eq!(cmp_plain_decimal("1.50", "1.5"), Some(Equal));
+        assert_eq!(cmp_plain_decimal("-0.0", "0"), Some(Equal));
+        assert_eq!(cmp_plain_decimal("-2", "-10"), Some(Greater));
+        assert_eq!(cmp_plain_decimal("10", "9"), Some(Greater));
+        assert_eq!(cmp_plain_decimal("abc", "1"), None);
+    }
+
+    /// Direct pin of `f64_exact_decimal`: exact expansions (not shortest round-trips),
+    /// and `None` on the non-finite values.
+    #[test]
+    fn f64_exact_decimal_is_the_exact_expansion() {
+        let exp = f64_exact_decimal(0.1).expect("finite");
+        assert!(exp.starts_with("0.1000000000000000055511151231257827"), "got {}", exp);
+        assert_eq!(
+            cmp_plain_decimal(&f64_exact_decimal(TWO53 as f64).unwrap(), "9007199254740992"),
+            Some(Ordering::Equal)
+        );
+        assert_eq!(f64_exact_decimal(f64::NAN), None);
+        assert_eq!(f64_exact_decimal(f64::INFINITY), None);
+        assert_eq!(f64_exact_decimal(f64::NEG_INFINITY), None);
     }
 }

--- a/skills/substrate/SKILL.md
+++ b/skills/substrate/SKILL.md
@@ -116,34 +116,41 @@ hash_probe_serial(&right, &keys, &left, std::slice::from_ref(&table), &[1], &NoB
 
 ### `compare` — `#[cfg(feature = "compare")]`
 
-The SPARQL term total order `compare_terms`: the class precedence error/unbound < blank < IRI
-< literal < triple, numeric-aware within the literal class, strict typed-temporal, string
-fallback, and recursive component-wise triple-term order. Generic over a `CompareTerm` trait
-(`term_class`/`value_str`/`as_f64`/`exact_cmp`/`strict_cmp`/`triple_parts`) — a
-monomorphisation seam, never a `dyn` object. Pure-`std`; pulls nothing new.
+The SPARQL term total order `compare_terms`: the spec-fixed class precedence error/unbound <
+blank < IRI < literal < triple, then KIND-FIRST within the literal class (sq-wjl8i): a fixed
+`LiteralKind` rank between literal kinds — numeric < boolean < dateTime < date < string < lang
+< other, a documented extension where the spec leaves cross-kind order undefined — and value
+order only WITHIN a kind (numerics by exact rational value with NaN totalised FIRST before
+-INF and f64 ties rechecked exactly via `exact_cmp`, incl. the mixed int/decimal-vs-double tie
+— `Num::cmp_total`; dateTimes by timeline; else lexical), plus the recursive component-wise
+triple-term order. Generic over a `CompareTerm` trait
+(`term_class`/`literal_kind`/`value_str`/`as_f64`/`exact_cmp`/`strict_cmp`/`triple_parts`) — a
+monomorphisation seam, never a `dyn` object. Pure-`std`; pulls nothing new. The engine's
+relational `<`/`=` are deliberately untouched (XPath promotion, NaN type errors): only the
+ORDER BY total order refines promoted ties and positions NaN.
 
 ```toml
 [dependencies]
 sparq-substrate = { version = "0.1.0", features = ["compare"] }
 ```
 
-**Machine-checked order laws (Kani, sq-sqtk2.4).** `src/compare.rs` hosts a `#[cfg(kani)]`
-bounded-proof module proving, over an adversarial model `CompareTerm` impl whose numeric
-domain straddles the 2^53 f64-collapse boundary (2^53−1 / 2^53 / 2^53+1 / 2^53+2 and their
-shared f64 images, ±0.0, NaN): reflexivity (NaN-free), antisymmetry-consistency (full domain,
-`Some(o)` iff mirrored `Some(o.reverse())`, `None` iff `None`), within-class totality
-(NaN-free), per-literal-kind transitivity (exact ints across the collapse, doubles, strings,
-strict/temporal, a collapse-free exact/inexact mix, recursive triple terms), and exact-order
+**Machine-checked order laws (Kani, sq-sqtk2.4 + sq-wjl8i).** `src/compare.rs` hosts a
+`#[cfg(kani)]` bounded-proof module proving, over an adversarial model `CompareTerm` impl
+whose numeric domain straddles the 2^53 f64-collapse boundary (2^53−1 / 2^53 / 2^53+1 /
+2^53+2 and their shared f64 images, ±0.0, NaN): reflexivity, antisymmetry-consistency,
+within-class totality and transitivity — per literal kind AND across MIXED literal kinds
+(`transitivity_mixed_literal_kinds_incl_nan`), ALL with NaN included — and exact-order
 agreement on the exact tier (the `exact_cmp` recheck's guarantee — delete the recheck and it
-goes red). Run `cargo kani -p sparq-substrate --features compare` (Kani injects the `kani`
-cfg; the normal build strips the module). Honest boundary: this proves the shared ALGORITHM
-over the bounded model, NOT the engine's `Value` impl (`sparq-engine/src/exec.rs` — covered
-by unit + W3C conformance tests; next-wave in `research/mechanized-proof-program.md` §6).
-Known, machine-checked LAW GAPS (witness harnesses, engine-reachable): mixed exact/inexact
-numerics are intransitive AT the collapse boundary; numeric-vs-plain-string pairs fall to the
-lexical form and are intransitive against the numeric order; NaN makes the comparator partial
-(`None`, mapped to `Equal` by callers). Do not build sort invariants on mixed literal-kind
-columns without consulting those witnesses.
+goes red). The three sq-sqtk2.4 intransitivity findings (mixed-tier collapse, numeric-vs-
+string lexical fallback, NaN partiality) are FIXED and pinned by `witness_*` harnesses that
+go red on regression. Run `cargo kani -p sparq-substrate --features compare` (Kani injects
+the `kani` cfg; the normal build strips the module). Honest boundaries: this proves the
+shared ALGORITHM over the bounded model, NOT the engine's `Value` impl
+(`sparq-engine/src/exec.rs` — covered by unit tests, the sparq-reason engine-parity suite and
+W3C conformance; next-wave in `research/mechanized-proof-program.md` §6); within the dateTime
+kind the indeterminate mixed-timezone window still falls back lexically (residual seam,
+beaded); and `exact_cmp` impls bounded by the i128 tower keep collapsed ties for lexicals
+beyond ~38 significant digits (beaded).
 
 ## Cargo feature summary
 


### PR DESCRIPTION
> 🤖 SPARQ agent — recovery completion of a twice-session-killed WIP. All prior verification claims were treated as NONEXISTENT and every number below was re-measured from scratch in a fresh worktree off the PR branch. **One prior claim was materially wrong and is corrected here: the Kani run verifies 26 harnesses, not 6.**

Fixes **sq-wjl8i** (P1). The SPARQL value comparator `compare_terms` (the engine's `compare_values` — ORDER BY and the MIN/MAX fallback) was **intransitive**. Three machine-checked witnesses:

1. **2^53 double-collapse** — an exact/inexact numeric triple compared `Equal / Equal / Less`.
2. **`10 / "11" / 2` mixed-kind cycle** — a cross-kind lexical fallback (`"10" < "11" < "2"` lexically, `10 > 2` numerically).
3. **NaN → `None`** — mapped by callers to engine `Equal`, making NaN "equal" to every numeric.

**Fix:** literals order **kind-first** by a fixed `LiteralKind` rank; value order only *within* a kind (exact-rational numeric with a mixed-tier f64-tie recheck via `Num::cmp_total`, NaN totalised first, dateTime/date by timeline, else lexical). Relational `<` / `=` (XPath-promoted `num_compare`) semantics are **untouched** — only the ORDER BY total order is refined in the region SPARQL leaves undefined.

## Evidence — regenerated from scratch (2026-07-05, logs teed under `/tmp/sq-wjl8i-*.log`)

**Gates — clippy `-D warnings` + tests GREEN in BOTH feature states:**
- `sparq-substrate` **default (compare OFF)**: clippy clean; the `compare`/`numeric` surface compiles to ZERO code (`0 passed; 0 failed` lib) — the lean-default invariant holds.
- `sparq-substrate` **`--features compare,numeric`**: clippy clean; `64 passed; 0 failed` (lib), the 3 witness tests included.
- `sparq-reason` **default**: clippy clean; `135` lib + integration binaries all green, `0 failed`.
- `sparq-reason` **`--features substrate-compare`**: clippy clean; `146` lib + **`tests/compare_parity.rs` 2 passed** + integration = `260 passed; 0 failed`.
- `sparq-engine` **default**: clippy clean; full suite `259 (lib) + 13 (differentials) + 42 (eval_semantics) + 39 (query_features) + 17 (storage) + 1 (doctest) = 371 passed; 0 failed`.
- New public fns each carry a DIRECT unit test (coverage floor): `Num::cmp_total` (`cmp_total_nan_sorts_first_and_equals_itself`, `cmp_total_mixed_tier_is_exact_at_the_2p53_collapse`, `cmp_total_decimal_vs_double_refines_the_f64_tie`), `f64_exact_decimal` (`f64_exact_decimal_is_the_exact_expansion`), `cmp_plain_decimal` (`cmp_plain_decimal_is_exact_and_total_on_decimals`). CI per-crate coverage ratchet + all 4 shards SUCCESS; CI `clippy (gate)` (bundles the rustdoc `--all-features -D warnings` half) + `readme-template` both SUCCESS.

**The three witness unit tests (`compare,numeric`):**
```
test compare::tests::witness1_mixed_exact_inexact_at_2p53_now_transitive ... ok
test compare::tests::witness2_numeric_vs_string_now_ranked_by_kind ... ok
test compare::tests::witness3_nan_now_totalised_first_among_numerics ... ok
```

**Mutation spot-check (non-vacuity, isolated throwaway worktree):** flipping witness1's expected `Some(Ordering::Less)` → `Some(Ordering::Greater)` on the `x = y < z ⇒ x < z` assertion turns it RED:
```
test compare::tests::witness1_mixed_exact_inexact_at_2p53_now_transitive ... FAILED
thread '...' panicked at crates/sparq-substrate/src/compare.rs:1495:9:
assertion `left == right` failed: transitive: x = y < z => x < z
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 63 filtered out
```
Restored afterwards — the witness is non-vacuous.

**Kani bounded proof (`cargo kani -p sparq-substrate --features compare`):**
```
Complete - 26 successfully verified harnesses, 0 failures, 26 total.
```
26/26 `VERIFICATION:- SUCCESSFUL` — reflexivity / antisymmetry / within-class-totality / transitivity over the full literal domain (NaN included), the 2^53-collapse domain harnesses, and the three witness harnesses. Domain-vacuity guards (`domain_exhibits_the_2p53_collapse`, `domain_cf_numeric_is_collapse_free_with_signed_zero_pair`, `domain_x2_doubles_are_exact`) verified, so no harness is vacuous.

**Engine parity:** `sparq-reason/tests/compare_parity.rs` (2 tests, `substrate-compare`) drives a REAL `sparq_engine::query(g, "SELECT ?o WHERE { ?s ?p ?o } ORDER BY ?o")` and asserts byte-identity of the full solution multiset against the reasoner's `sort_ids` over the same materialised closure; the second test is documented to go RED if `sort_ids` is replaced with a lexicographic sort.

**W3C ORDER BY conformance delta** (branch `1fff7203` vs merge-base `e225bf3f`, same fetched `w3c/rdf-tests` suite, `--filter sort`):
```
sparql10/sort:   14 pass / 0 fail   →   14 pass / 0 fail    (Δ = 0, no regression)
```
The W3C ORDER BY suite pins no outcome in the mixed-kind / 2^53-collapse / NaN regions this fix refines (SPARQL leaves those undefined), so a neutral delta with zero regressions is the expected, correct result. The behavioural proof is the witnesses + the 26 Kani harnesses.

## wasm `artifact-exact-equality (feature-OFF)` — diagnosis + fix (the sole gate blocker)
The comparator fix links real feature-OFF engine code into the wasm bundle (`f64_exact_decimal` / `Num::cmp_total` decimal-string arithmetic + NaN totalisation) — a legitimate **+5042-byte (+0.360%)** growth, `1399868 → 1404910` (CI-measured, run 28722406953, byte-exact). This is SCALAR arithmetic, NOT vectorization: cfg-audit leg3 confirms all 10 vectorized references stay `#[cfg(feature = "vectorized")]`-gated and the feature-OFF zero-delta invariant is preserved. Two follow-up commits:
- `e329efdb` — re-pin `feature_off_exact` to the CI-measured `1404910`. **This commit shipped a JSON syntax bug** (next line).
- `450f5484` — the re-pin had deleted the closing `],` of the perf-baseline comment array, so leg2 failed on the JSON **parse** (`Expecting ',' delimiter: line 93`), not the byte comparison. Restoring the `],` fixes it; leg2 now reports `OK — exact match: 1404910 == 1404910 (zero delta)` and the `vectorized-feature-off` leg is **SUCCESS** on CI (`450f5484`).

## Status
- **Not armed** — this is an ORDER BY total-order change (engine-correctness surface); a full Fable adversarial verify follows separately.
- After the `450f5484` push the PR has **no gating check in FAILURE**; `gate` is IN_PROGRESS awaiting the normal CI matrix re-run (CodeQL-rust, benchmarks, opt-in engine matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
