### PR TITLE
docs(research): §5.2 erratum — job-level matrix guard not implementable, document shipped mechanism (sq-fmx4u.7) [HAIKU-4.5]

### DIFF
--- a/research/change-based-test-selection.md
+++ b/research/change-based-test-selection.md
@@ -231,6 +231,52 @@ satisfying a required status check. Implementation traps to honor:
   `needs.select.outputs.mode != 'selected' || contains(...)` — empty output
   ⇒ run (§4.3).
 
+> **⚠️ ERRATUM (bead sq-fmx4u.7, 2026-07-05, PR #1437). [HAIKU-4.5]**
+>
+> **The prescriptive design above is NOT implementable as written for the
+> feature-matrix legs.** The design (and §7 P5) specify a *job-level* `if:`
+> guard keyed on `matrix.crate` — e.g.
+> `contains(needs.select.outputs.affected, format('"{0}"', matrix.crate))`
+> evaluated in `jobs.<job_id>.if`. GitHub Actions does **not** make the
+> `matrix` context available in `jobs.<job_id>.if`: per the Actions
+> *contexts-availability* table, a job-level `if:` can reference only
+> `github`, `needs`, `vars`, and `inputs` — **not `matrix`**. A `matrix.crate`
+> reference there silently evaluates to the empty string, so under enforcement
+> the guard degrades to `contains(affected, '""')`, which is always false and
+> would skip **every** leg unconditionally — precisely the silent-unsound-skip
+> class the skip invariant (§2) forbids. This is an infeasibility of the
+> original design, **not** an optimization trade-off: the job-level
+> `matrix.crate` guard cannot be built on GitHub Actions at all.
+>
+> **What shipped instead** (both fail-closed, both pinned by
+> `scripts/tests/test_ci_select_wiring.py`, which additionally asserts that no
+> job-level `if:` ever references `matrix.`):
+>
+> 1. **Feature-matrix legs → assembly-time leg filtering** in the unit-tested
+>    `scripts/assemble-feature-matrix.py` (see
+>    `.github/workflows/feature-matrix.yml`, the `select`/`setup` jobs). The
+>    per-leg keep/drop decision is made in Python before the matrix is
+>    materialized; an unassembled leg spawns **no** check-run, and the polling
+>    `ci-summary` aggregator never waits on a check that does not exist
+>    (requiredness flows through `ci-summary / gate`, not per-leg names —
+>    verified against live branch protection by bead sq-fmx4u.4). Shadow /
+>    full / missing selection outputs fail-close to the full leg set inside the
+>    assembler.
+> 2. **Heavy `crates/sparq-vectors` shards → a step-level bash guard** in the
+>    test step (see `.github/workflows/ci.yml`, the shard test step). The *step*
+>    context — unlike the job-level `if:` — **does** see `matrix`, so the guard
+>    reads `${{ matrix.crate }}` and `exit 0`s with a skip notice (reporting
+>    `success`, not conclusion `skipped`) when the shard's crate is absent from
+>    the affected closure. Fail-closed: only `mode = 'selected'` with a
+>    non-empty crate and a definite non-membership can skip; empty/missing
+>    selection outputs fall through to a run.
+>
+> The prescriptive text and §7 P5 are retained above as the original decision
+> record; this erratum is the correction. Where §5.2/§7 P5 say "job-level
+> `if:` guard" for the feature-matrix legs, read "assembly-time filtering";
+> the job-level `if:` guard remains accurate only for the per-crate lanes whose
+> guard keys on `needs`-derived outputs, not on `matrix`.
+
 ### 5.3 `ci-summary` (the aggregator)
 
 - `if: always()`; **fails** if the `select` job did not succeed; **fails** on


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bead **sq-fmx4u.7** (epic sq-fmx4u), doc-only reconciliation. Not self-armed (`auto=false`).

## What this reconciles

`research/change-based-test-selection.md` §5.2 (and §7 P5) prescribe a **job-level `if:` guard keyed on `matrix.crate`** for the feature-matrix legs. That design is **not implementable on GitHub Actions**: the `matrix` context is **not available** in `jobs.<job_id>.if` (Actions *contexts-availability* — only `github`, `needs`, `vars`, `inputs`). A `matrix.crate` reference there silently evaluates to the empty string, so under enforcement the guard becomes `contains(affected, '""')` (always false) and would skip **every** leg — the exact silent-unsound-skip class the skip invariant (§2) forbids.

This PR **appends a clearly-marked ERRATUM** to §5.2 that:

- states plainly that the original design is **infeasible**, not an optimization trade-off;
- preserves the original prescriptive decision record (the job-level `if:` text and §7 P5) intact;
- documents the two fail-closed mechanisms **actually shipped in PR #1437**:
  1. **assembly-time leg filtering** in `scripts/assemble-feature-matrix.py` (feature-matrix legs — an unassembled leg spawns no check-run; requiredness flows through `ci-summary / gate`, per sq-fmx4u.4);
  2. a **step-level bash guard** in the test step for the heavy `crates/sparq-vectors` shards (the *step* context does see `matrix`);
- cites PR #1437 and the specific GitHub Actions context-availability limit;
- both mechanisms are pinned by `scripts/tests/test_ci_select_wiring.py` (which also asserts no job-level `if:` references `matrix.`).

## Verification

- Erratum text cross-checked against `.github/workflows/feature-matrix.yml` (the `select`/`setup` assembly-time filtering + its inline rationale comment) and `.github/workflows/ci.yml` (the heavy-shard step-level bash guard).
- markdownlint (HARD config, `.markdownlint-cli2.jsonc`, which globs `research/**/*.md`): **0 errors**.

## Scope

Doc-only. One file changed (`research/change-based-test-selection.md`, +46 lines). No `crates/` source, no code, no other files. Original §5.2 text unchanged; erratum is append-style per the design-record correction convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)