### PR TITLE
ci: scope fuzz/wasm/perf lanes under change-based selection — phase 2 (sq-fmx4u.6) [OPUS-4.8]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -585,8 +585,29 @@ jobs:
 
   wasm:
     name: wasm build (sparq-wasm + sparq-reason-wasm + sparq-rsp-wasm + sparq-text-wasm + sparq-shacl-wasm + sparq-solid)
-    needs: changes
-    if: needs.changes.outputs.rust_changed == 'true'
+    # [OPUS-4.8] sq-fmx4u.6 (design §5.2, phase 2): scope the wasm bundle build by
+    # the crate closure it exercises. The job builds every browser bundle it names
+    # (sparq-wasm/-reason-wasm/-rsp-wasm/-text-wasm/-shacl-wasm + sparq-introspect +
+    # sparq-solid); it is affected iff any of those is in the affected reverse-dep
+    # closure (single source of truth: `_LANE_SEEDS["wasm"]` in scripts/ci_select.py,
+    # pinned by scripts/tests/test_ci_select_wiring.py). Non-matrix job => the
+    # job-level `if:` can read needs.select.outputs. FAIL-CLOSED: the existing
+    # rust_changed path-filter still gates first, then the `mode != 'selected'`
+    # disjunct means an empty/missing selection output RUNS the lane; a
+    # selection-skipped job reports `skipped` (= gate-satisfied, no per-leg name is
+    # required — bead sq-fmx4u.4). Schedule/push carry no PR diff => mode=full =>
+    # the lane runs (nightly full-matrix backstop, design §6.1).
+    needs: [changes, select]
+    if: >-
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' ||
+       contains(needs.select.outputs.affected, '"sparq-wasm"') ||
+       contains(needs.select.outputs.affected, '"sparq-reason-wasm"') ||
+       contains(needs.select.outputs.affected, '"sparq-rsp-wasm"') ||
+       contains(needs.select.outputs.affected, '"sparq-text-wasm"') ||
+       contains(needs.select.outputs.affected, '"sparq-shacl-wasm"') ||
+       contains(needs.select.outputs.affected, '"sparq-introspect"') ||
+       contains(needs.select.outputs.affected, '"sparq-solid"'))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -2168,8 +2189,22 @@ jobs:
     # that shard — it is gated by the shard that DOES measure it). The `coverage-floors`
     # shard-partition guard proves every per-commit crate is measured by exactly one shard.
     name: coverage ratchet (shard ${{ matrix.shard }}/4)
-    needs: [changes, coverage-floors]
-    if: github.event_name != 'schedule' && needs.changes.outputs.rust_changed == 'true'
+    # [OPUS-4.8] sq-fmx4u.6 (design §5.2, phase 2): coverage is a function of
+    # compiled code + tests, so it stays ALWAYS-RUN with ONE exception — skip only
+    # when the affected closure is PROVABLY EMPTY (every changed path SAFE-listed /
+    # non-crate, so mode=selected AND affected==[]). Any NON-empty closure keeps it
+    # running, because a dependency change can shift executed lines in dependents.
+    # Same fail-closed guard shape build-archive uses: `mode != 'selected'` (full/
+    # shadow/empty output) => RUN, and `affected != '[]'` => RUN; both false (the
+    # SAFE-only case) => skip (the shard reports `skipped`, which the `coverage`
+    # aggregator counts as satisfied). This references only github/needs contexts —
+    # no `matrix.*` — so it is safe as a job-level `if:` on this matrix job. The
+    # nightly full coverage backstop is `coverage-nightly` (schedule), unaffected.
+    needs: [changes, coverage-floors, select]
+    if: >-
+      github.event_name != 'schedule' &&
+      needs.changes.outputs.rust_changed == 'true' &&
+      (needs.select.outputs.mode != 'selected' || needs.select.outputs.affected != '[]')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false   # one failing shard must NOT cancel the others (want all verdicts)

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -27,7 +27,13 @@ name: fuzz
 on:
   push:
     branches: [main]
+  # [OPUS-4.8] sq-fmx4u.6: react to labeled/unlabeled too so toggling the `ci-full`
+  # label re-evaluates the change-based selection for the fuzz lane (ci-select.yml
+  # maps the label to `--full`, which forces the fuzz smoke to run). The default
+  # types (opened/synchronize/reopened) are listed explicitly so adding the label
+  # events does NOT drop `synchronize` (the push-to-PR trigger).
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   # [OPUS-4.8] Merge queue: fuzz surfaces a check on PRs, so it must also run on the
   # queue's merge_group ref or the required ci-summary would wait for a sibling that
   # never appears there. The budget step below maps merge_group to the fast SMOKE
@@ -62,8 +68,45 @@ env:
   FUZZ_BUILD_TARGET: x86_64-unknown-linux-gnu
 
 jobs:
+  # [OPUS-4.8] sq-fmx4u.6 (design §5.2, phase 2): the change-based test-selection
+  # pre-job (the reusable .github/workflows/ci-select.yml — doctrine there). The
+  # `fuzz` job below guards on its affected-crate closure so a PR that touches
+  # neither the fuzzed crates NOR their reverse-dependency closure skips the
+  # (nightly-toolchain + 5-target sanitizer) build entirely. UNCONDITIONAL (no
+  # needs/if): the ci-summary gate REQUIRES every "change-based test selection"
+  # check-run to conclude success before any skipped sibling counts as satisfied,
+  # so this job must exist + be green on every trigger (design §5.3). Fail-closed:
+  # ci_select.py returns mode=full for every §4.1 trigger (shared crate / build
+  # file / .github/** / Cargo.lock / selector-self change) and for ANY internal
+  # error, and an empty/missing output satisfies the guard's `mode != 'selected'`
+  # first disjunct => the fuzz lane RUNS. On schedule (the nightly heavy soak) the
+  # event carries no PR diff => mode=full => the fuzz lane runs — the full-matrix
+  # backstop (design §6.1) is preserved.
+  select:
+    name: select
+    uses: ./.github/workflows/ci-select.yml
+    permissions:
+      contents: read
+
   fuzz:
     name: cargo-fuzz (parsers + mmap loader, bounded)
+    # [OPUS-4.8] sq-fmx4u.6: the fuzz crate (fuzz/Cargo.toml) depends on exactly
+    # sparq-core (RDF parsers + mmap loader), sparq-engine (SPARQL parse), and
+    # sparq-shacl (SHACL validation), so the fuzz smoke is affected iff any of
+    # those three is in the affected reverse-dep closure (single source of truth:
+    # `_LANE_SEEDS["fuzz"]` in scripts/ci_select.py, pinned by
+    # scripts/tests/test_ci_select_wiring.py). This is a job-level `if:` on a
+    # NON-matrix job, so `needs.select.outputs` is available (unlike the ci.yml
+    # per-shard case, which must guard in a step). FAIL-CLOSED: the leading
+    # `mode != 'selected'` disjunct means an empty/missing selection output RUNS
+    # the lane; a skipped job reports conclusion `skipped` (= satisfied) to the
+    # ci-summary gate — no per-leg name is individually required (bead sq-fmx4u.4).
+    needs: select
+    if: >-
+      needs.select.outputs.mode != 'selected' ||
+      contains(needs.select.outputs.affected, '"sparq-core"') ||
+      contains(needs.select.outputs.affected, '"sparq-engine"') ||
+      contains(needs.select.outputs.affected, '"sparq-shacl"')
     runs-on: ubuntu-latest
     # Generous ceiling above the worst case (nightly: 4 targets × 600s + build) so a
     # hung target fails with a clear timeout rather than running away.

--- a/ci/path-ownership.toml
+++ b/ci/path-ownership.toml
@@ -50,6 +50,32 @@ patterns = [
 ]
 
 # ---------------------------------------------------------------------------
+# [lanes] — INFORMATIONAL MIRROR of ci_select.py `_LANE_SEEDS` (design §5.2,
+# bead sq-fmx4u.6, phase 2). The selector does NOT read this table; it documents,
+# in the policy file, which SINGLETON CI lane maps to which SEED crates. A lane is
+# a whole-job that always exercises a FIXED crate set (the fuzz smoke; the wasm
+# bundle build); it is skipped only when NONE of its seeds is in the affected
+# reverse-dependency closure. `test_path_ownership.py` asserts this table equals
+# ci_select.py `_LANE_SEEDS` so the doc + the code cannot diverge; the fuzz.yml +
+# ci.yml `wasm` job `if:` guards reference exactly these crate names, pinned by
+# scripts/tests/test_ci_select_wiring.py. Under-listing a seed would be a silent
+# unsound skip; over-listing merely over-runs the lane (fail-safe).
+# ---------------------------------------------------------------------------
+[lanes]
+# fuzz.yml — the cargo-fuzz targets; the out-of-workspace fuzz crate depends on:
+fuzz = ["sparq-core", "sparq-engine", "sparq-shacl"]
+# ci.yml `wasm` job — every browser bundle it builds (+ the rlib-only wasm smokes):
+wasm = [
+  "sparq-wasm",
+  "sparq-reason-wasm",
+  "sparq-rsp-wasm",
+  "sparq-text-wasm",
+  "sparq-shacl-wasm",
+  "sparq-introspect",
+  "sparq-solid",
+]
+
+# ---------------------------------------------------------------------------
 # [[map]] — attribution of OUT-OF-CRATE inputs to the crates that read them.
 # Each entry below is an AUDIT-PROVEN finding: a repo-level path referenced from
 # a crate's src/tests/benches/build.rs (include_str!/include_bytes! or an

--- a/scripts/ci_select.py
+++ b/scripts/ci_select.py
@@ -83,6 +83,46 @@ _FULL_TRIGGERS: list[tuple[str, str]] = [
 ]
 
 
+# --- phase-2 singleton-lane -> seed crates (design §5.2; bead sq-fmx4u.6) -----
+# [OPUS-4.8] A "lane" is a SINGLETON CI job (not a per-crate matrix leg) that
+# always exercises a FIXED set of crates: the fuzz smoke (fuzz.yml) and the wasm
+# bundle build (ci.yml `wasm`). Phase 1 left these always-run (design P7); phase 2
+# maps each to the crate closure it exercises and skips it when that closure is
+# provably unaffected. A lane is affected iff any SEED crate is in the affected
+# closure — and because `affected` is the REVERSE-dependency closure of the diff,
+# a seed is in it iff the seed itself OR anything it transitively depends on
+# changed, which is exactly "could this lane's build/behaviour differ" (design
+# §3.3). So the forward-dependency reasoning is captured by a membership test on
+# the reverse closure — no separate forward walk is needed here.
+#
+# SEEDS (single source of truth; the fuzz.yml + ci.yml `wasm` job `if:` guards
+# MUST reference exactly these crate names — pinned by
+# scripts/tests/test_ci_select_wiring.py, mirrored informationally in
+# ci/path-ownership.toml `[lanes]`):
+#   * fuzz — the cargo-fuzz targets. The out-of-workspace fuzz crate
+#     (fuzz/Cargo.toml) depends on exactly these three: sparq-core (RDF parsers +
+#     mmap loader), sparq-engine (SPARQL parse), sparq-shacl (SHACL validation).
+#   * wasm — the ci.yml `wasm` job builds every browser bundle it names; each seed
+#     pulls its own engine/core wasm32 graph, so the seed set is the bundle crates.
+# FAIL-CLOSED (design §2/§4.3): `lane_runs` runs the lane whenever mode != selected
+# (full/shadow/error) OR any seed is not a current workspace member (a typo'd or
+# renamed seed can never silently skip a lane — it forces the lane to run). The
+# YAML guards inherit the same posture: an empty/missing `mode`/`affected` output
+# satisfies the `mode != 'selected'` disjunct => RUN.
+_LANE_SEEDS: dict[str, list[str]] = {
+    "fuzz": ["sparq-core", "sparq-engine", "sparq-shacl"],
+    "wasm": [
+        "sparq-wasm",
+        "sparq-reason-wasm",
+        "sparq-rsp-wasm",
+        "sparq-text-wasm",
+        "sparq-shacl-wasm",
+        "sparq-introspect",
+        "sparq-solid",
+    ],
+}
+
+
 class SelectorError(Exception):
     """Any internal failure. main() traps this => mode=full, exit 0 (§4.3)."""
 
@@ -195,6 +235,29 @@ def reverse_closure(crate: str, reverse_adj: dict[str, set[str]]) -> set[str]:
                 seen.add(dependent)
                 stack.append(dependent)
     return seen
+
+
+def lane_runs(sel: "Selection", seeds: list[str]) -> bool:
+    """[OPUS-4.8] sq-fmx4u.6: does a singleton lane (fuzz / wasm) need to run for
+    this Selection? This is the EXECUTABLE SPEC of the fuzz.yml + ci.yml `wasm`
+    job `if:` guards — the YAML expresses the identical rule inline
+    (`mode != 'selected' || contains(affected, '"<seed>"') || ...`), and
+    scripts/tests/test_ci_select_wiring.py pins the guards' seed set against
+    `_LANE_SEEDS` so the two cannot drift.
+
+    Runs (returns True) unless the lane is PROVABLY inert (design §2):
+      * mode != "selected" (full / shadow / error path) => run everything;
+      * any seed is not a current workspace member => run (fail-closed: a
+        typo'd/renamed seed must never silently skip its lane);
+      * otherwise run iff some seed is in the affected reverse-dep closure.
+    """
+    if sel.mode != "selected":
+        return True
+    members = set(sel.all_members)
+    if any(s not in members for s in seeds):
+        return True  # unknown seed: cannot prove inert => run (fail-closed)
+    affected = set(sel.affected)
+    return any(s in affected for s in seeds)
 
 
 # --- ownership matching ------------------------------------------------------

--- a/scripts/tests/test_ci_select.py
+++ b/scripts/tests/test_ci_select.py
@@ -437,6 +437,111 @@ class RealMetadataShapeTests(unittest.TestCase):
         self.assertIn("sparq-geo", sel.affected)
         self.assertNotIn("sparq-parse", sel.affected)  # parse does not depend on geo
 
+    # ---- phase-2 lane mapping against REAL metadata (bead sq-fmx4u.6) ----------
+    def test_lane_seed_crates_are_real_workspace_members(self):
+        # A seed that is not a current member would make its lane skip exactly when
+        # it should run (`lane_runs` fail-closes it to RUN, but the intent is that
+        # the list stays real). Pin every fuzz/wasm seed against the live metadata.
+        ws = cs.parse_workspace(self.meta)
+        for lane, seeds in cs._LANE_SEEDS.items():
+            for seed in seeds:
+                self.assertIn(seed, ws.members,
+                              f"{lane} seed {seed!r} is not a workspace member")
+
+    def test_geo_only_pr_skips_fuzz_and_wasm(self):
+        # ACCEPTANCE: a geo-only PR skips the sparq-core fuzz smoke + wasm builds.
+        # sparq-geo is a reverse-graph leaf; none of the fuzz/wasm seeds depend on
+        # it, so neither lane is affected (skipped-green).
+        sel = cs.select(["crates/sparq-geo/src/lib.rs"], self.meta)
+        self.assertEqual(sel.mode, "selected")
+        self.assertFalse(cs.lane_runs(sel, cs._LANE_SEEDS["fuzz"]),
+                         "geo-only PR must SKIP the fuzz lane")
+        self.assertFalse(cs.lane_runs(sel, cs._LANE_SEEDS["wasm"]),
+                         "geo-only PR must SKIP the wasm lane")
+
+    def test_core_pr_runs_fuzz_and_wasm(self):
+        # ACCEPTANCE: a sparq-core PR still runs both — every fuzz seed and every
+        # wasm bundle depends (transitively) on sparq-core, so both are affected.
+        sel = cs.select(["crates/sparq-core/src/dict.rs"], self.meta)
+        self.assertEqual(sel.mode, "selected")
+        self.assertTrue(cs.lane_runs(sel, cs._LANE_SEEDS["fuzz"]),
+                        "sparq-core PR must RUN the fuzz lane")
+        self.assertTrue(cs.lane_runs(sel, cs._LANE_SEEDS["wasm"]),
+                        "sparq-core PR must RUN the wasm lane")
+
+
+class LaneMappingTests(unittest.TestCase):
+    """[OPUS-4.8] sq-fmx4u.6 (design §5.2, phase 2): hermetic tests of
+    `lane_runs` — the executable spec of the fuzz.yml + ci.yml `wasm` job `if:`
+    guards — and the SAFE-only coverage-ratchet skip. All synthetic (no cargo)."""
+
+    def _sel(self, mode, affected, members):
+        return cs.Selection(mode=mode, reason="", affected=list(affected),
+                            all_members=list(members))
+
+    def test_lane_runs_when_a_seed_is_affected(self):
+        sel = self._sel("selected", ["sparq-core", "sparq-geo"],
+                        ["sparq-core", "sparq-geo", "sparq-wasm"])
+        self.assertTrue(cs.lane_runs(sel, ["sparq-core"]))
+
+    def test_lane_skips_when_no_seed_is_affected(self):
+        sel = self._sel("selected", ["sparq-geo"],
+                        ["sparq-core", "sparq-geo", "sparq-wasm"])
+        self.assertFalse(cs.lane_runs(sel, ["sparq-core", "sparq-wasm"]))
+
+    def test_full_and_shadow_modes_always_run_the_lane(self):
+        # full (nightly backstop / ci-full / error) + shadow (report-only) => RUN.
+        for mode in ("full", "shadow"):
+            sel = self._sel(mode, [], ["sparq-core"])
+            self.assertTrue(cs.lane_runs(sel, ["sparq-core"]),
+                            f"mode={mode} must always run the lane")
+
+    def test_selected_empty_affected_skips_the_lane(self):
+        # SAFE-only change: mode=selected, affected=[] => the lane is inert => skip.
+        sel = self._sel("selected", [], ["sparq-core"])
+        self.assertFalse(cs.lane_runs(sel, ["sparq-core"]))
+
+    def test_unknown_seed_forces_run_fail_closed(self):
+        # A typo'd/renamed seed cannot silently skip its lane: lane_runs RUNS it.
+        sel = self._sel("selected", ["sparq-geo"], ["sparq-core", "sparq-geo"])
+        self.assertTrue(cs.lane_runs(sel, ["sparq-core-TYPO"]),
+                        "an unknown seed must fail-closed to RUN")
+
+    def test_lane_seeds_are_the_expected_two_lanes(self):
+        self.assertEqual(set(cs._LANE_SEEDS), {"fuzz", "wasm"})
+        self.assertEqual(cs._LANE_SEEDS["fuzz"],
+                         ["sparq-core", "sparq-engine", "sparq-shacl"])
+        self.assertIn("sparq-wasm", cs._LANE_SEEDS["wasm"])
+        self.assertIn("sparq-solid", cs._LANE_SEEDS["wasm"])
+
+    # ---- SAFE-only coverage-ratchet skip (acceptance) -------------------------
+    @staticmethod
+    def _coverage_ratchet_skips(sel):
+        """Mirror the ci.yml `coverage-measure` job `if:` disjunction:
+            mode != 'selected' || affected != '[]'   (RUN when either holds)
+        so the ratchet is SKIPPED iff mode == 'selected' AND affected == []."""
+        return sel.mode == "selected" and json.dumps(sel.affected) == "[]"
+
+    def test_safe_only_pr_skips_coverage_ratchet(self):
+        # ACCEPTANCE: an affected-empty (SAFE-only) PR skips the coverage ratchet.
+        m = [{"pattern": "research/**", "safe": True}]
+        sel = cs.select(["research/x.md"], _synthetic_meta(), m)
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, [])
+        self.assertTrue(self._coverage_ratchet_skips(sel))
+
+    def test_nonempty_affected_keeps_coverage_ratchet_running(self):
+        # A non-empty closure keeps coverage always-run (a dep change can shift
+        # executed lines in dependents — design §5.2).
+        sel = cs.select(["crates/app/src/lib.rs"], _synthetic_meta())
+        self.assertEqual(sel.mode, "selected")
+        self.assertFalse(self._coverage_ratchet_skips(sel))
+
+    def test_full_mode_keeps_coverage_ratchet_running(self):
+        sel = cs.select(["Cargo.lock"], _synthetic_meta())
+        self.assertEqual(sel.mode, "full")
+        self.assertFalse(self._coverage_ratchet_skips(sel))
+
 
 class EnforceRolloutTests(unittest.TestCase):
     """[FABLE-5] sq-fmx4u.5: the ENFORCE-mode rollout invariants — the selector

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -51,8 +51,11 @@ import yaml
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CI_YML = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 FM_YML = REPO_ROOT / ".github" / "workflows" / "feature-matrix.yml"
+FUZZ_YML = REPO_ROOT / ".github" / "workflows" / "fuzz.yml"  # [OPUS-4.8] sq-fmx4u.6
 SELECT_YML = REPO_ROOT / ".github" / "workflows" / "ci-select.yml"
 GATE_PY = REPO_ROOT / "scripts" / "ci_summary_gate.py"
+CI_SELECT_PY = REPO_ROOT / "scripts" / "ci_select.py"  # [OPUS-4.8] sq-fmx4u.6
+OWNERSHIP_TOML = REPO_ROOT / "ci" / "path-ownership.toml"  # [OPUS-4.8] sq-fmx4u.6
 
 FAIL_CLOSED_DISJUNCT = "needs.select.outputs.mode != 'selected'"
 NEEDLE_RE = re.compile(
@@ -78,6 +81,16 @@ def _gate_module():
     return mod
 
 
+def _ci_select_module():
+    # [OPUS-4.8] sq-fmx4u.6: import the selector to read `_LANE_SEEDS` — the single
+    # source of truth the fuzz.yml + ci.yml `wasm` guards must mirror.
+    spec = importlib.util.spec_from_file_location("ci_select", CI_SELECT_PY)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["ci_select"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
 def _workspace_members() -> set[str]:
     """Crate names from crates/*/Cargo.toml — hermetic (no cargo invocation)."""
     assert tomllib is not None, "Python >= 3.11 required (tomllib)"
@@ -96,15 +109,18 @@ class TestWiring(unittest.TestCase):
     def setUpClass(cls):
         cls.ci = _load(CI_YML)
         cls.fm = _load(FM_YML)
+        cls.fuzz = _load(FUZZ_YML)  # [OPUS-4.8] sq-fmx4u.6
         cls.sel = _load(SELECT_YML)
         cls.members = _workspace_members()
         cls.gate = _gate_module()
+        cls.lane_seeds = _ci_select_module()._LANE_SEEDS  # [OPUS-4.8] sq-fmx4u.6
 
     # ---- fail-closed guard shape -------------------------------------------------
     def test_every_selection_consuming_if_carries_the_fail_closed_disjunct(self):
         """Any job-level `if:` mentioning the selection outputs must include the
         `mode != 'selected'` disjunct, so empty/missing outputs mean RUN."""
-        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm)):
+        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm),
+                            ("fuzz.yml", self.fuzz)):
             for job_id, job in wf["jobs"].items():
                 cond = job.get("if", "")
                 if "needs.select.outputs" in str(cond):
@@ -116,7 +132,8 @@ class TestWiring(unittest.TestCase):
 
     def test_selection_guarded_jobs_need_select(self):
         """A guard reading needs.select.* only resolves if `select` is in needs."""
-        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm)):
+        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm),
+                            ("fuzz.yml", self.fuzz)):
             for job_id, job in wf["jobs"].items():
                 if "needs.select.outputs" in str(job.get("if", "")):
                     needs = job.get("needs", [])
@@ -130,7 +147,8 @@ class TestWiring(unittest.TestCase):
 
     # ---- crate needles are real --------------------------------------------------
     def test_every_affected_needle_is_a_workspace_member(self):
-        text = CI_YML.read_text(encoding="utf-8") + FM_YML.read_text(encoding="utf-8")
+        text = (CI_YML.read_text(encoding="utf-8") + FM_YML.read_text(encoding="utf-8")
+                + FUZZ_YML.read_text(encoding="utf-8"))  # [OPUS-4.8] sq-fmx4u.6
         needles = NEEDLE_RE.findall(text)
         self.assertTrue(needles, "expected contains(affected, ...) guards to exist")
         unknown = sorted({n for n in needles if n not in self.members})
@@ -158,7 +176,8 @@ class TestWiring(unittest.TestCase):
         """`matrix` is NOT available in jobs.<job_id>.if — a reference silently
         evaluates empty, which under enforcement would skip every leg. The
         per-shard guard must live in a STEP (env/run), never the job `if:`."""
-        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm)):
+        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm),
+                            ("fuzz.yml", self.fuzz)):
             for job_id, job in wf["jobs"].items():
                 self.assertNotIn(
                     "matrix.", str(job.get("if", "")),
@@ -167,7 +186,8 @@ class TestWiring(unittest.TestCase):
 
     # ---- select job shape ----------------------------------------------------------
     def test_select_caller_jobs_are_unconditional_and_use_the_reusable_workflow(self):
-        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm)):
+        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm),
+                            ("fuzz.yml", self.fuzz)):
             job = wf["jobs"].get("select")
             self.assertIsNotNone(job, f"{wf_name}: missing the select job")
             self.assertEqual(job.get("uses"), "./.github/workflows/ci-select.yml", wf_name)
@@ -226,7 +246,8 @@ class TestWiring(unittest.TestCase):
         """[FABLE-5] sq-fmx4u.5. Toggling the ci-full label must re-run selection, so
         both selection-consuming workflows react to labeled/unlabeled — and must NOT
         drop the default `synchronize` (push-to-PR) trigger while doing so."""
-        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm)):
+        for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm),
+                            ("fuzz.yml", self.fuzz)):
             on = _on_block(wf)
             pr = on.get("pull_request") or {}
             self.assertIsInstance(
@@ -293,6 +314,104 @@ class TestWiring(unittest.TestCase):
     def test_members_parse_sanity(self):
         self.assertIn("sparq-core", self.members)
         self.assertGreater(len(self.members), 30)
+
+
+class TestPhase2LaneScoping(unittest.TestCase):
+    """[OPUS-4.8] sq-fmx4u.6 (design §5.2, phase 2): the fuzz + wasm singleton
+    lanes are scoped by their crate closure, and the coverage ratchet skips only
+    on an empty affected set. Pins the guards' SHAPE + the seed sets against the
+    selector's `_LANE_SEEDS` single source of truth so YAML and code cannot drift.
+
+    The seed set a `mode != 'selected' || contains(affected, '"X"') || ...` guard
+    references is exactly the set of quoted needles in the job `if:` expression."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.ci = _load(CI_YML)
+        cls.fuzz = _load(FUZZ_YML)
+        cls.members = _workspace_members()
+        cls.lane_seeds = _ci_select_module()._LANE_SEEDS
+
+    @staticmethod
+    def _guard_needles(cond: str) -> list[str]:
+        """Ordered, de-duplicated crate needles in a job `if:` expression."""
+        seen: list[str] = []
+        for n in NEEDLE_RE.findall(str(cond)):
+            if n not in seen:
+                seen.append(n)
+        return seen
+
+    # ---- fuzz lane (fuzz.yml) ------------------------------------------------------
+    def test_fuzz_job_guarded_by_its_seed_closure(self):
+        job = self.fuzz["jobs"]["fuzz"]
+        cond = str(job.get("if", ""))
+        self.assertIn(FAIL_CLOSED_DISJUNCT, cond,
+                      "fuzz guard must be fail-closed (empty output => RUN)")
+        needs = job.get("needs", [])
+        needs = [needs] if isinstance(needs, str) else needs
+        self.assertIn("select", needs, "fuzz job must need the select pre-job")
+        self.assertEqual(self._guard_needles(cond), self.lane_seeds["fuzz"],
+                         "fuzz guard needles must equal ci_select.py _LANE_SEEDS['fuzz']")
+
+    def test_fuzz_has_unconditional_select_caller(self):
+        job = self.fuzz["jobs"].get("select")
+        self.assertIsNotNone(job, "fuzz.yml must carry the select pre-job")
+        self.assertEqual(job.get("uses"), "./.github/workflows/ci-select.yml")
+        self.assertNotIn("if", job, "select must be unconditional (gate needs it green)")
+        self.assertNotIn("needs", job)
+
+    def test_fuzz_runs_on_schedule_backstop(self):
+        # The nightly heavy fuzz soak is the full-matrix backstop: a schedule event
+        # carries no PR diff => selector mode=full => the fail-closed disjunct RUNS.
+        on = _on_block(self.fuzz)
+        self.assertIn("schedule", on, "fuzz.yml must keep its nightly schedule backstop")
+        self.assertIn("merge_group", on, "fuzz.yml must run on merge_group for the gate")
+
+    # ---- wasm lane (ci.yml) --------------------------------------------------------
+    def test_wasm_job_guarded_by_its_seed_closure(self):
+        job = self.ci["jobs"]["wasm"]
+        cond = str(job.get("if", ""))
+        self.assertIn(FAIL_CLOSED_DISJUNCT, cond)
+        self.assertIn("needs.changes.outputs.rust_changed == 'true'", cond,
+                      "wasm must keep the rust_changed path-filter guard")
+        needs = job.get("needs", [])
+        needs = [needs] if isinstance(needs, str) else needs
+        self.assertIn("select", needs)
+        self.assertIn("changes", needs)
+        self.assertEqual(self._guard_needles(cond), self.lane_seeds["wasm"],
+                         "wasm guard needles must equal ci_select.py _LANE_SEEDS['wasm']")
+
+    # ---- coverage ratchet empty-affected skip (ci.yml) ----------------------------
+    def test_coverage_ratchet_skips_only_on_empty_affected(self):
+        job = self.ci["jobs"]["coverage-measure"]
+        cond = str(job.get("if", ""))
+        self.assertIn(FAIL_CLOSED_DISJUNCT, cond)
+        self.assertIn("needs.select.outputs.affected != '[]'", cond,
+                      "coverage ratchet may skip ONLY when affected == [] (design §5.2)")
+        # It stays off the nightly path and behind rust_changed, unchanged.
+        self.assertIn("github.event_name != 'schedule'", cond)
+        self.assertIn("needs.changes.outputs.rust_changed == 'true'", cond)
+        needs = job.get("needs", [])
+        self.assertIn("select", needs)
+        # Must NOT reference matrix.* in the job-level if (contexts-availability trap).
+        self.assertNotIn("matrix.", cond)
+
+    # ---- seed sets are real + mirrored ---------------------------------------------
+    def test_lane_seeds_are_real_workspace_members(self):
+        for lane, seeds in self.lane_seeds.items():
+            for seed in seeds:
+                self.assertIn(seed, self.members,
+                              f"{lane} seed {seed!r} is not a workspace member")
+
+    def test_ownership_toml_lanes_mirror_matches_lane_seeds(self):
+        # The informational [lanes] table in ci/path-ownership.toml must equal the
+        # selector's _LANE_SEEDS (same drift-guard idiom as [triggers]).
+        self.assertIsNotNone(tomllib, "Python >= 3.11 required (tomllib)")
+        with open(OWNERSHIP_TOML, "rb") as fh:
+            data = tomllib.load(fh)
+        mirror = data.get("lanes", {})
+        self.assertEqual(mirror, self.lane_seeds,
+                         "ci/path-ownership.toml [lanes] mirror drifted from _LANE_SEEDS")
 
 
 # [SONNET-4.6] sq-fmx4u.4: required-check anchor tests.


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI/infra. Implements bead **sq-fmx4u.6** (phase 2 of the change-based test-selection design, research/change-based-test-selection.md §5.2). Authored by Opus 4.8 (Fable unavailable; flagged for re-review). **DO NOT ARM** — CI-surface change; wants mechanical-verify + review.

## What this wires + where

Phase 1 scoped only the wide multipliers (per-crate tests, the ~50 feature legs, benches). Phase 2 scopes the **singleton lanes** by mapping each to the crate closure it exercises and skipping it when that closure is **provably unaffected** (fail-closed).

| Lane | File | Guard |
|---|---|---|
| **fuzz smoke** | `.github/workflows/fuzz.yml` | adds the reusable `select` pre-job; job-level `if:` on the (non-matrix) `fuzz` job: `mode != 'selected' || contains(affected, '"sparq-core"'/'"sparq-engine"'/'"sparq-shacl"')` |
| **wasm bundle build** | `.github/workflows/ci.yml` (`wasm`) | kept behind the existing `rust_changed` path-filter, then guarded on its 7 bundle seed crates |
| **coverage ratchet** | `.github/workflows/ci.yml` (`coverage-measure`) | skips **only** when `affected == '[]'` (SAFE-only PR) — coverage is a function of compiled code + tests, so any non-empty closure keeps it running (design §5.2). Same guard shape as `build-archive` |

**Single source of truth:** `scripts/ci_select.py` `_LANE_SEEDS` (fuzz → core/engine/shacl; wasm → the 7 bundle crates) + `lane_runs()`, the executable spec of the YAML guards. Mirrored informationally in `ci/path-ownership.toml` `[lanes]` (drift-guarded, same idiom as `[triggers]`).

## Invariant (fail-closed) — how it holds

- **Skips only when provably unaffected:** a lane runs whenever `mode != 'selected'` (full / shadow / selector-error), whenever any seed is not a current workspace member (typo/rename → RUN), or whenever any seed is in the affected reverse-dep closure. Empty/missing selection output satisfies the leading disjunct ⇒ RUN.
- **Nightly full backstop preserved:** fuzz.yml keeps its `schedule` cron (heavy soak) and ci.yml keeps its nightly cron + `coverage-nightly`; a non-PR event carries no diff ⇒ `mode=full` ⇒ every scoped lane runs.
- **skipped-green:** every scoped leg is a job-level `if:` (or the empty-affected `if:`), so a skip reports conclusion `skipped`, which `ci-summary / gate` counts as satisfied (no per-leg name is individually required — bead sq-fmx4u.4). The fuzz.yml `select` caller adds a second `change-based test selection` check-run; the gate requires all such checks green (fail-closed), which the selector guarantees (traps errors → exit 0).
- **merge_group unchanged** from the shipped design; fuzz.yml already runs on `merge_group`.

## Local reproduction (real `cargo metadata`)

Ran the real `scripts/ci_select.py` and evaluated the exact `contains(affected, '"X"')` guard semantics:

- **geo-only PR** → `mode=selected`; fuzz seeds ∉ affected, wasm seeds ∉ affected ⇒ **both lanes skip** (skipped-green). ✅
- **sparq-core PR** → `mode=selected`; all fuzz + wasm seeds ∈ affected ⇒ **both lanes run**. ✅
- **SAFE-only PR** (research/site/.beads) → `mode=selected, affected=[]` ⇒ **coverage ratchet skips**. ✅

## Gates

- YAML valid (`yaml.safe_load`) for ci.yml / fuzz.yml / ci-select.yml; TOML valid for path-ownership.toml.
- `actionlint`: fuzz.yml **clean**; no findings on the edited ci.yml lines (pre-existing shellcheck INFO notes in unrelated conformance jobs only).
- Tests: `test_ci_select.py` **52 pass** (+ lane-mapping + coverage-skip cases), `test_ci_select_wiring.py` **27 pass** (+ fuzz.yml coverage, guard-shape fail-closed, needles == `_LANE_SEEDS`, `[lanes]` mirror == `_LANE_SEEDS`). Adjacent `test_path_ownership.py` (21) + `test_ci_summary_gate.py` (33) still pass.
- No `crates/` source touched; no SHA-pin changes (no actions added — fuzz.yml reuses the in-repo ci-select.yml).

## Honest scope note — perf-gate deferred

The bead title says "fuzz/wasm/**perf-gate**". The perf regression gate lives in **`bench.yml`**, not ci.yml, and scoping it properly is a larger, standalone change: bench.yml (a) doesn't call the reusable `select` job at all, and (b) has **no `schedule` trigger**, so there is no nightly full backstop to add a scoped lane under — the fail-closed invariant forbids half-scoping it. Deferred to **sq-mel85** (P3) to keep this change minimal/localized (sibling **sq-va7at** also touches ci.yml). The bead's own acceptance criteria (geo skips fuzz+wasm, core runs both, SAFE-only skips coverage) are fully met without bench.yml.

## Throughput gap closed

A leaf/near-leaf PR (e.g. geo-only, or a non-wasm crate) no longer pays the nightly-toolchain + 5-target sanitizer fuzz build **and** the 7-bundle wasm build; a SAFE-only PR no longer pays the instrumented coverage ratchet — while every lane stays in the nightly full-matrix backstop. No ratchet weakened.

Closes sq-fmx4u.6.