### PR TITLE
build(gui): sync optional text/rsp wasm bundles (sq-9ifq4) [HAIKU-4.5]

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -230,6 +230,26 @@ jobs:
         working-directory: js
         run: npm run build:reason-wasm
 
+      # [HAIKU-4.5] sq-9ifq4 — also build the tier-b W-text bundle (the BM25 inverted index +
+      # text: magic predicates) so the GUI's Full-text tool runs LIVE in the exported artifact.
+      # The GUI's sync-wasm copies it from the crate's pkg/ into public/wasm/text/; it is
+      # OPTIONAL at build time (sync warn-skips when absent), but building it here makes the hosted
+      # "Try the GUI live" export ship real full-text search rather than the honest "unavailable"
+      # fallback.
+      - name: Build W-text wasm bundle (BM25 full-text search)
+        working-directory: js
+        run: npm run build:text-wasm
+
+      # [HAIKU-4.5] sq-9ifq4 — also build the tier-b W-rsp bundle (the windowed RSP-QL stream
+      # processor) so the GUI's Streaming tool runs LIVE in the exported artifact. The GUI's
+      # sync-wasm copies it from the crate's pkg/ into public/wasm/rsp/; it is OPTIONAL at build
+      # time (sync warn-skips when absent), but building it here makes the hosted "Try the GUI
+      # live" export ship real streaming SPARQL processing rather than the honest "unavailable"
+      # fallback.
+      - name: Build W-rsp wasm bundle (windowed RSP-QL stream processor)
+        working-directory: js
+        run: npm run build:rsp-wasm
+
       - name: Install workspace dependencies
         run: npm install
 
@@ -304,6 +324,18 @@ jobs:
       - name: Build W-reason WASM bundle (RDFS / OWL 2 RL reasoner)
         working-directory: js
         run: npm run build:reason-wasm
+
+      # [HAIKU-4.5] sq-9ifq4 — also build the tier-b W-text bundle (BM25 full-text search)
+      # for the Full-text tool to run live in the browser.
+      - name: Build W-text WASM bundle (BM25 full-text search)
+        working-directory: js
+        run: npm run build:text-wasm
+
+      # [HAIKU-4.5] sq-9ifq4 — also build the tier-b W-rsp bundle (windowed RSP-QL stream
+      # processor) for the Streaming tool to run live in the browser.
+      - name: Build W-rsp WASM bundle (windowed RSP-QL stream processor)
+        working-directory: js
+        run: npm run build:rsp-wasm
 
       - name: Install workspace dependencies
         run: npm install

--- a/gui/app/scripts/sync-wasm.mjs
+++ b/gui/app/scripts/sync-wasm.mjs
@@ -62,3 +62,63 @@ try {
       `            live. Build it:  (cd ../../js && npm run build:reason-wasm)`,
   );
 }
+
+// [HAIKU-4.5] sq-9ifq4 — also sync the tier-b "W-text" bundle that powers the Full-text tool
+// (crates/sparq-text-wasm, built with `npm run build:text-wasm` by js/'s wasm build, exactly
+// as the marketing site syncs it). Its wasm-pack output stays in the crate's own pkg/, so we copy
+// it from there into public/wasm/text/. This bundle is OPTIONAL: if it has not been built (e.g. a
+// `next dev` that skips it), we WARN and skip rather than fail — the Full-text tool then
+// surfaces a clear "bundle unavailable" state at runtime and degrades gracefully.
+const textSrc = join(here, "..", "..", "..", "crates", "sparq-text-wasm", "pkg");
+const textDest = join(dest, "text");
+const textFiles = [
+  "sparq_text_wasm.js",
+  "sparq_text_wasm_bg.wasm",
+  "sparq_text_wasm.d.ts",
+];
+
+try {
+  await access(join(textSrc, "sparq_text_wasm_bg.wasm"));
+  await mkdir(textDest, { recursive: true });
+  for (const f of textFiles) {
+    await copyFile(join(textSrc, f), join(textDest, f));
+  }
+  console.log(
+    `[sync-wasm] copied ${textFiles.length} files → public/wasm/text/ (W-text)`,
+  );
+} catch {
+  console.warn(
+    `[sync-wasm] W-text bundle not found at ${textSrc}; the Full-text tool will not run\n` +
+      `            live. Build it:  (cd ../../js && npm run build:text-wasm)`,
+  );
+}
+
+// [HAIKU-4.5] sq-9ifq4 — also sync the tier-b "W-rsp" bundle that powers the Streaming tool
+// (crates/sparq-rsp-wasm, built with `npm run build:rsp-wasm` by js/'s wasm build, exactly
+// as the marketing site syncs it). Its wasm-pack output stays in the crate's own pkg/, so we copy
+// it from there into public/wasm/rsp/. This bundle is OPTIONAL: if it has not been built (e.g. a
+// `next dev` that skips it), we WARN and skip rather than fail — the Streaming tool then
+// surfaces a clear "bundle unavailable" state at runtime and degrades gracefully.
+const rspSrc = join(here, "..", "..", "..", "crates", "sparq-rsp-wasm", "pkg");
+const rspDest = join(dest, "rsp");
+const rspFiles = [
+  "sparq_rsp_wasm.js",
+  "sparq_rsp_wasm_bg.wasm",
+  "sparq_rsp_wasm.d.ts",
+];
+
+try {
+  await access(join(rspSrc, "sparq_rsp_wasm_bg.wasm"));
+  await mkdir(rspDest, { recursive: true });
+  for (const f of rspFiles) {
+    await copyFile(join(rspSrc, f), join(rspDest, f));
+  }
+  console.log(
+    `[sync-wasm] copied ${rspFiles.length} files → public/wasm/rsp/ (W-rsp)`,
+  );
+} catch {
+  console.warn(
+    `[sync-wasm] W-rsp bundle not found at ${rspSrc}; the Streaming tool will not run\n` +
+      `            live. Build it:  (cd ../../js && npm run build:rsp-wasm)`,
+  );
+}


### PR DESCRIPTION
## Summary
- Extend gui/app/scripts/sync-wasm.mjs to optionally sync sparq-text-wasm and sparq-rsp-wasm bundles (warn-and-skip when absent, like W-reason)
- Add build:text-wasm and build:rsp-wasm steps to gui.yml jobs that already run build:reason-wasm (gui-app export + gui-mock-ipc Playwright lane)
- Bundles stay OPTIONAL; lean core bundle untouched

## Acceptance
- [x] node gui/app/scripts/sync-wasm.mjs succeeds with and without pkg/ dirs present
- [x] gui.yml + pages.yml pass actionlint / YAML validation
- [x] Actions SHA-pinned (existing pattern, no new actions)
- [x] gate aggregator untouched

## Test plan
Manual verification:
- Tested sync script without text/rsp bundles: warns appropriately, continues
- Tested sync script with text/rsp bundles built: syncs 3+3+3+3 files correctly
- Validated gui.yml and pages.yml YAML syntax

🤖 SPARQ agent