### PR TITLE
feat(gui): shared multi-file ingest lib + dropzone (sq-vnh1v) [FABLE-5]

### DIFF
--- a/gui/README.md
+++ b/gui/README.md
@@ -107,6 +107,14 @@ engine instead (no compressed-file / HDT path — the drawer says so). A success
 `WorkspaceSourceMeta` + a workspace snapshot (the `sq-atb0` save/open cache). The full on-disk
 workspace persistence path activates once the shell grants the `fs` capability (`sq-ixc3.6`).
 
+## File ingest library (`lib/file-ingest.ts`, sq-vnh1v)
+
+The **file ingest library** is a shared zero-server multi-file upload harness for the RDF import (sq-eydh9), SHACL shapes (sq-txrui), and N3 rules (sq-glo5r) surfaces. It operates on a single `IngestResult` contract: every file is `accepted[]` (name, text, bytes) or `rejected[]` (name, reason) — **no silent drops**. 
+
+**Entry points** — `pickTextFiles(opts)` opens a file picker using File System Access `showOpenFilePicker` where available, falling back to `<input type="file" multiple>` for browser parity (the floor); `readDroppedFiles(dataTransfer, opts)` extracts files from a drop event (must be called synchronously from the drop handler). Both work in the static `/app` export with no server and no Tauri global.
+
+**UI layer** — `<Dropzone>` (standalone dashed panel + keyboard-accessible button), `<DropTarget>` (wraps children as a drop surface with a hover overlay), and `useFileDrop` (raw drag/drop wiring for custom affordances). All three consume the same `IngestResult` contract, so callers surface accepted and rejected files identically.
+
 ## Inference (per-workspace entailment) — `sq-tp1m`
 
 The **Inference tool** (and a compact selector in the Query action row) applies an **RDFS / OWL 2

--- a/gui/app/src/components/workbench/dropzone.tsx
+++ b/gui/app/src/components/workbench/dropzone.tsx
@@ -1,0 +1,211 @@
+"use client";
+
+// [FABLE-5] sq-vnh1v (epic sq-2ucrz) — reusable drag-and-drop surface over `lib/file-ingest`.
+//
+// Three exports, one contract (`IngestResult` — accepted + rejected, no silent drops):
+//   * `useFileDrop`   — the raw dragenter/over/leave/drop wiring as spreadable props, for
+//                       consumers that render their own affordance (e.g. a whole-workbench
+//                       overlay in sq-eydh9);
+//   * `<DropTarget>`  — wraps arbitrary children as a drop target with a visible drag-over
+//                       overlay. It adds NO keyboard path itself — pair it with a visible
+//                       picker control (or use `<Dropzone>`);
+//   * `<Dropzone>`    — a standalone dashed panel: drop affordance + a keyboard-accessible
+//                       "Browse files" button that runs `pickTextFiles` (File System Access
+//                       where available, `input[multiple]` fallback = the browser-parity floor).
+//
+// Consumers: RDF import (sq-eydh9), SHACL shapes (sq-txrui), N3 rules (sq-glo5r). Works in the
+// static /app export — no server, no Tauri global; SSR-safe ("use client" + no module-scope DOM).
+
+import * as React from "react";
+import { FileUp, Loader2, Upload } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  hasDraggedFiles,
+  pickTextFiles,
+  readDroppedFiles,
+  type IngestResult,
+} from "@/lib/file-ingest";
+
+// ── useFileDrop — the shared drag/drop wiring ──────────────────────────────────────────────────
+
+export interface FileDropOptions {
+  /** Receives EVERY outcome — accepted files and per-file rejections — from a drop or pick. */
+  onFiles: (result: IngestResult) => void;
+  /** Dot-prefixed extensions to allow (off-list files are rejected with a reason). */
+  accept?: string[];
+  /** Allow more than one file (default true; extras beyond the first are rejected when false). */
+  multiple?: boolean;
+  /** Ignore drags and disable the picker. */
+  disabled?: boolean;
+}
+
+/** The drag/drop handlers to spread onto a drop-target element. */
+export interface FileDropTargetProps {
+  onDragEnter: React.DragEventHandler<HTMLElement>;
+  onDragOver: React.DragEventHandler<HTMLElement>;
+  onDragLeave: React.DragEventHandler<HTMLElement>;
+  onDrop: React.DragEventHandler<HTMLElement>;
+}
+
+/**
+ * Drag-and-drop wiring for a files drop target: reacts only to drags that actually carry
+ * files, tracks enter/leave depth (child elements re-fire both events), and resolves the
+ * drop through `readDroppedFiles` into the consumer's `onFiles` callback.
+ */
+export function useFileDrop({ onFiles, accept, multiple, disabled }: FileDropOptions): {
+  dragActive: boolean;
+  targetProps: FileDropTargetProps;
+} {
+  const [dragActive, setDragActive] = React.useState(false);
+  const depth = React.useRef(0);
+
+  const targetProps: FileDropTargetProps = {
+    onDragEnter: (e) => {
+      if (disabled || !hasDraggedFiles(e.dataTransfer)) return;
+      e.preventDefault();
+      depth.current += 1;
+      setDragActive(true);
+    },
+    onDragOver: (e) => {
+      if (disabled || !hasDraggedFiles(e.dataTransfer)) return;
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "copy";
+    },
+    onDragLeave: (e) => {
+      if (disabled || !hasDraggedFiles(e.dataTransfer)) return;
+      depth.current = Math.max(0, depth.current - 1);
+      if (depth.current === 0) setDragActive(false);
+    },
+    onDrop: (e) => {
+      if (disabled || !hasDraggedFiles(e.dataTransfer)) return;
+      e.preventDefault();
+      depth.current = 0;
+      setDragActive(false);
+      // readDroppedFiles extracts the File objects synchronously (before its first await) —
+      // load-bearing: browsers neuter DataTransfer items once this handler returns.
+      void readDroppedFiles(e.dataTransfer, { accept, multiple }).then(onFiles);
+    },
+  };
+
+  return { dragActive, targetProps };
+}
+
+// ── <DropTarget> — wrap existing UI as a drop surface ──────────────────────────────────────────
+
+export interface DropTargetProps extends FileDropOptions {
+  /** Overlay affordance text while a files drag hovers the target. */
+  label?: string;
+  className?: string;
+  children: React.ReactNode;
+}
+
+/**
+ * Wraps `children` as a files drop target with a visible drag-over overlay. Provides no
+ * keyboard path of its own — the consumer must keep a visible, focusable picker control
+ * (e.g. an Import button or a `<Dropzone>`) so keyboard-only users reach the same files.
+ */
+export function DropTarget({
+  onFiles,
+  accept,
+  multiple,
+  disabled,
+  label = "Drop files to add them",
+  className,
+  children,
+}: DropTargetProps) {
+  const { dragActive, targetProps } = useFileDrop({ onFiles, accept, multiple, disabled });
+  return (
+    <div data-slot="drop-target" className={cn("relative", className)} {...targetProps}>
+      {children}
+      {dragActive ? (
+        <div
+          aria-hidden
+          className="pointer-events-none absolute inset-0 z-50 flex items-center justify-center rounded-md border-2 border-dashed border-primary bg-background/80"
+        >
+          <div className="flex items-center gap-2 text-sm font-medium">
+            <FileUp className="size-5" aria-hidden />
+            {label}
+          </div>
+        </div>
+      ) : null}
+      <span className="sr-only" role="status">
+        {dragActive ? label : ""}
+      </span>
+    </div>
+  );
+}
+
+// ── <Dropzone> — a standalone panel with the keyboard-accessible fallback ──────────────────────
+
+export interface DropzoneProps extends FileDropOptions {
+  /** Main affordance line (default "Drag & drop files here"). */
+  label?: string;
+  /** Secondary hint line; defaults to the `accept` extension list. */
+  hint?: string;
+  /** Label for the keyboard-accessible picker button (default "Browse files…"). */
+  browseLabel?: string;
+  className?: string;
+}
+
+/**
+ * A standalone dashed drop panel: drop files onto it, or activate the (keyboard-accessible)
+ * browse button to pick them — File System Access where available, `input[multiple]`
+ * everywhere else, so the flow works in a plain browser with no Tauri global.
+ */
+export function Dropzone({
+  onFiles,
+  accept,
+  multiple,
+  disabled,
+  label = "Drag & drop files here",
+  hint,
+  browseLabel = "Browse files…",
+  className,
+}: DropzoneProps) {
+  const { dragActive, targetProps } = useFileDrop({ onFiles, accept, multiple, disabled });
+  const [busy, setBusy] = React.useState(false);
+
+  const browse = async () => {
+    setBusy(true);
+    try {
+      onFiles(await pickTextFiles({ accept, multiple }));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const hintText = hint ?? (accept?.length ? accept.join(" · ") : undefined);
+
+  return (
+    <div
+      data-slot="dropzone"
+      {...targetProps}
+      className={cn(
+        "relative rounded-md border border-dashed p-5 text-center transition-colors",
+        dragActive ? "border-primary bg-primary/5" : "border-border",
+        disabled && "opacity-50",
+        className,
+      )}
+    >
+      <FileUp className="mx-auto size-6 text-muted-foreground" aria-hidden />
+      <p className="mt-2 text-sm">{label}</p>
+      {hintText ? <p className="mt-1 text-xs text-muted-foreground">{hintText}</p> : null}
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="mt-3"
+        onClick={browse}
+        disabled={disabled || busy}
+      >
+        {busy ? <Loader2 className="animate-spin" /> : <Upload />}
+        {browseLabel}
+      </Button>
+      <span className="sr-only" role="status">
+        {dragActive ? "Release to drop the files" : ""}
+      </span>
+    </div>
+  );
+}

--- a/gui/app/src/lib/file-ingest.ts
+++ b/gui/app/src/lib/file-ingest.ts
@@ -1,0 +1,250 @@
+// [FABLE-5] sq-vnh1v (epic sq-2ucrz) — shared BROWSER multi-file ingest for the epic's three
+// upload consumers: RDF import (sq-eydh9), SHACL shapes (sq-txrui), N3 rules (sq-glo5r).
+//
+// Pure library, no React: pick many text files at once (File System Access
+// `showOpenFilePicker` where available, a hidden `<input type="file" multiple>` everywhere
+// else) and read files dropped onto a target (`DataTransfer`). Both paths resolve the SAME
+// `IngestResult` shape so every consumer handles one contract.
+//
+// INVARIANTS (browser-parity floor, research/gui-consolidation-fix-plan.md §1.4):
+//  * works in the static /app export with NO server and NO Tauri global — the
+//    `input[multiple]` fallback is always available; File System Access is opportunistic
+//    (and any picker failure other than a user cancel falls back to the input path);
+//  * NEVER silently drops a selected/dropped file — every file resolves to an `accepted`
+//    entry or a `rejected` entry with a human-readable reason (callers surface both);
+//  * SSR/prerender-safe — importing this module touches no DOM; calling the picker outside
+//    a browser resolves to an empty result instead of throwing.
+//
+// Format guessing intentionally stays in `rdf-format.ts` (`guessFormat`) — consumers call it
+// per accepted file; this module only moves bytes.
+
+/** One successfully read file: its name, full text, and on-disk size in bytes. */
+export interface IngestedFile {
+  name: string;
+  text: string;
+  bytes: number;
+}
+
+/** One file that could NOT be ingested, with a human-readable reason the UI must surface. */
+export interface RejectedFile {
+  name: string;
+  reason: string;
+}
+
+/**
+ * The single result contract for both the picker and the drop reader. Every file the user
+ * selected or dropped appears in exactly one of the two lists — no silent drops.
+ */
+export interface IngestResult {
+  accepted: IngestedFile[];
+  rejected: RejectedFile[];
+}
+
+/** Options shared by {@link pickTextFiles} and {@link readDroppedFiles}. */
+export interface IngestOptions {
+  /**
+   * Dot-prefixed extensions to allow (e.g. `[".ttl", ".nt", ".shacl"]`), matched
+   * case-insensitively against the filename tail. Absent/empty = accept any file.
+   * Non-matching files are REJECTED with an explicit reason (never filtered silently).
+   */
+  accept?: string[];
+  /**
+   * Allow more than one file (default `true` — this library exists for bulk upload).
+   * When `false`, the first acceptable file wins and the rest are rejected with a reason.
+   */
+  multiple?: boolean;
+}
+
+/** Options for {@link pickTextFiles}. */
+export interface PickOptions extends IngestOptions {
+  /** Dialog filter description shown by the File System Access picker (default "Supported files"). */
+  description?: string;
+}
+
+/** True when `name` matches the `accept` extension list (or the list is absent/empty). */
+export function matchesAccept(name: string, accept?: string[]): boolean {
+  if (!accept?.length) return true;
+  const lower = name.toLowerCase();
+  return accept.some((ext) => lower.endsWith(ext.toLowerCase()));
+}
+
+/** True when a drag carries real files (vs dragged text/links), so drop targets can ignore the rest. */
+export function hasDraggedFiles(dataTransfer: DataTransfer | null): boolean {
+  return !!dataTransfer && Array.from(dataTransfer.types ?? []).includes("Files");
+}
+
+const emptyResult = (): IngestResult => ({ accepted: [], rejected: [] });
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === "AbortError";
+}
+
+function rejectedReasonUnsupported(accept: string[]): string {
+  return `unsupported file type — expected ${accept.join(" / ")}`;
+}
+
+/**
+ * Read a list of `File` objects into an {@link IngestResult}: extension filter first, the
+ * single-file cap second, then `File.text()` — a per-file read failure becomes a rejection,
+ * never an exception and never a silent drop.
+ */
+async function readFiles(files: File[], opts: IngestOptions): Promise<IngestResult> {
+  const accepted: IngestedFile[] = [];
+  const rejected: RejectedFile[] = [];
+  for (const file of files) {
+    if (!matchesAccept(file.name, opts.accept)) {
+      rejected.push({ name: file.name, reason: rejectedReasonUnsupported(opts.accept ?? []) });
+      continue;
+    }
+    if (opts.multiple === false && accepted.length >= 1) {
+      rejected.push({ name: file.name, reason: "only one file can be used here" });
+      continue;
+    }
+    try {
+      const text = await file.text();
+      accepted.push({ name: file.name, text, bytes: file.size });
+    } catch (err) {
+      // e.g. a directory masquerading as a File, or a file deleted between pick and read.
+      rejected.push({ name: file.name, reason: `could not be read: ${errorMessage(err)}` });
+    }
+  }
+  return { accepted, rejected };
+}
+
+// ── File System Access (opportunistic; typed locally — not yet in TS lib.dom) ─────────────────
+
+interface PickerFileHandle {
+  readonly name: string;
+  getFile(): Promise<File>;
+}
+
+interface OpenFilePickerOptions {
+  multiple?: boolean;
+  excludeAcceptAllOption?: boolean;
+  types?: { description?: string; accept: Record<string, string[]> }[];
+}
+
+type ShowOpenFilePicker = (options?: OpenFilePickerOptions) => Promise<PickerFileHandle[]>;
+
+// ── The universal fallback: a hidden <input type="file" multiple> ─────────────────────────────
+
+function pickViaInput(opts: PickOptions): Promise<IngestResult> {
+  return new Promise((resolve) => {
+    const input = document.createElement("input");
+    input.type = "file";
+    input.multiple = opts.multiple !== false;
+    if (opts.accept?.length) input.accept = opts.accept.join(",");
+    input.style.display = "none";
+    // The input must be in the document for some engines (notably iOS Safari) to open it.
+    document.body.appendChild(input);
+    const finish = (result: Promise<IngestResult> | IngestResult) => {
+      input.remove();
+      resolve(result instanceof Promise ? result : Promise.resolve(result));
+    };
+    input.addEventListener(
+      "change",
+      () => finish(readFiles(Array.from(input.files ?? []), opts)),
+      { once: true },
+    );
+    // Modern browsers fire `cancel` when the dialog is dismissed; nothing was selected,
+    // so an empty result upholds the no-silent-drop invariant.
+    input.addEventListener("cancel", () => finish(emptyResult()), { once: true });
+    input.click();
+  });
+}
+
+/**
+ * Open a (multi-)file picker and read every selected file as text.
+ *
+ * Uses File System Access `showOpenFilePicker` when the browser provides it; otherwise —
+ * and whenever the picker fails for any reason other than a user cancel (cross-origin
+ * frame `SecurityError`, option `TypeError`, …) — falls back to a hidden
+ * `<input type="file" multiple>`, which is the browser-parity floor. A user cancel
+ * resolves to an empty result. Outside a browser (SSR/prerender) resolves empty, never throws.
+ */
+export async function pickTextFiles(opts: PickOptions = {}): Promise<IngestResult> {
+  if (typeof window === "undefined" || typeof document === "undefined") return emptyResult();
+  const picker = (window as { showOpenFilePicker?: ShowOpenFilePicker }).showOpenFilePicker;
+  if (typeof picker !== "function") return pickViaInput(opts);
+  try {
+    const handles = await picker({
+      multiple: opts.multiple !== false,
+      // Keep "All files" available: the extension filter below REJECTS with a reason
+      // rather than pretending off-list files were never selected.
+      excludeAcceptAllOption: false,
+      types: opts.accept?.length
+        ? [
+            {
+              description: opts.description ?? "Supported files",
+              // The MIME key only labels the filter group; the extension list drives it.
+              accept: { "text/plain": opts.accept },
+            },
+          ]
+        : undefined,
+    });
+    const preRejected: RejectedFile[] = [];
+    const files: File[] = [];
+    for (const handle of handles) {
+      try {
+        files.push(await handle.getFile());
+      } catch (err) {
+        preRejected.push({ name: handle.name, reason: `could not be read: ${errorMessage(err)}` });
+      }
+    }
+    const read = await readFiles(files, opts);
+    return { accepted: read.accepted, rejected: [...preRejected, ...read.rejected] };
+  } catch (err) {
+    if (isAbortError(err)) return emptyResult(); // user cancelled — nothing was selected
+    return pickViaInput(opts); // any other picker failure → the fallback floor
+  }
+}
+
+/**
+ * Read every file in a drop's `DataTransfer` as text.
+ *
+ * MUST be called synchronously from the `drop` handler: the `File` objects are extracted
+ * from `dataTransfer.items` before this function's first `await`, because browsers neuter
+ * the item list once the drop event handler returns. Dropped directories and non-file drag
+ * items that claim to be files are rejected with explicit reasons; dragged text/links
+ * (`kind !== "file"`) are not files and are ignored.
+ */
+export async function readDroppedFiles(
+  dataTransfer: DataTransfer | null,
+  opts: IngestOptions = {},
+): Promise<IngestResult> {
+  if (!dataTransfer) return emptyResult();
+  const files: File[] = [];
+  const preRejected: RejectedFile[] = [];
+  if (dataTransfer.items?.length) {
+    // Synchronous extraction — no await before this loop completes (see doc comment).
+    for (const item of Array.from(dataTransfer.items)) {
+      if (item.kind !== "file") continue;
+      const entry = typeof item.webkitGetAsEntry === "function" ? item.webkitGetAsEntry() : null;
+      const file = item.getAsFile();
+      if (entry?.isDirectory) {
+        preRejected.push({
+          name: entry.name || file?.name || "(directory)",
+          reason: "directories cannot be ingested — drop the files inside it instead",
+        });
+        continue;
+      }
+      if (!file) {
+        preRejected.push({
+          name: entry?.name ?? "(unreadable item)",
+          reason: "the browser could not expose this dropped item as a file",
+        });
+        continue;
+      }
+      files.push(file);
+    }
+  } else {
+    // Engines without DataTransferItemList expose the flat FileList instead.
+    files.push(...Array.from(dataTransfer.files ?? []));
+  }
+  const read = await readFiles(files, opts);
+  return { accepted: read.accepted, rejected: [...preRejected, ...read.rejected] };
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated contribution by an agent working for @jeswr (Claude Fable 5). Bead `sq-vnh1v`, epic `sq-2ucrz`.

## What

The **shared browser multi-file ingest seam** from the GUI-consolidation design record (`research/gui-consolidation-fix-plan.md` §1.4, branch `research/sq-2ucrz-gui-consolidation`) — NEW files only, wired into nothing yet, so the three consumer beads (`sq-eydh9` RDF import, `sq-txrui` SHACL shapes, `sq-glo5r` N3 rules) stay conflict-free and land the e2e specs.

- **`gui/app/src/lib/file-ingest.ts`** — pure library (no React):
  - `pickTextFiles({accept, multiple, description})` — File System Access `showOpenFilePicker` where available; hidden `<input type="file" multiple>` everywhere else. Any picker failure other than a user cancel (e.g. cross-origin `SecurityError`) falls back to the input path.
  - `readDroppedFiles(dataTransfer, {accept, multiple})` — extracts `File`s from `DataTransfer.items` **synchronously before the first `await`** (browsers neuter the item list once the drop handler returns), rejects dropped directories/unreadable items with reasons, falls back to the flat `FileList`.
  - Both resolve one `IngestResult { accepted: [{name, text, bytes}], rejected: [{name, reason}] }`.
- **`gui/app/src/components/workbench/dropzone.tsx`** — `useFileDrop` (depth-tracked dragenter/over/leave/drop wiring that reacts only to drags carrying files), `<DropTarget>` (wraps children, visible drag-over overlay + `role=status` announcement), `<Dropzone>` (standalone dashed panel with the **keyboard-accessible Browse button**).

## Invariants held

- **Browser-parity floor**: the whole flow works in the static `/app` export with no server, no Tauri global, no File System Access API — `input[multiple]` is always reachable.
- **No silent file drop**: every selected/dropped file resolves to an explicit `accepted` or `rejected`-with-reason outcome surfaced to the caller (off-`accept` files are rejected, not filtered; user cancel = empty result, nothing was selected).
- **SSR/prerender-safe**: no module-scope DOM; calling the picker outside a browser resolves empty instead of throwing.
- **No duplication**: format guessing stays in `rdf-format.ts` (consumers call `guessFormat` per accepted file).

## Acceptance (per bead)

`cd gui/app && npm run lint && npm run typecheck` — **both green** locally. `dropzone.tsx` is the inline typechecked usage of the full exported lib surface; consumer beads add the Playwright specs (browser persona via `sq-u0my5`'s `chromium-web` project).

🤖 Generated with [Claude Code](https://claude.com/claude-code)