### PR TITLE
test(gui): web-persona Playwright project — browser code paths in CI (sq-u0my5) [FABLE-5]

### DIFF
--- a/gui/e2e-playwright/playwright.config.ts
+++ b/gui/e2e-playwright/playwright.config.ts
@@ -42,9 +42,26 @@ export default defineConfig({
     contextOptions: { reducedMotion: "reduce" },
   },
 
+  // [FABLE-5] sq-u0my5 — TWO personas over the SAME served export:
+  //   chromium-mock-ipc — desktop persona: support/fixtures.ts injects window.__TAURI__ via
+  //                       addInitScript, so isTauriRuntime() === true (the original lane).
+  //   chromium-web      — browser persona: support/web-fixtures.ts installs NO Tauri globals,
+  //                       so isTauriRuntime() === false and the pure-browser code paths (the
+  //                       deployed /app) are exercised in CI for the first time.
+  // The split is by filename: *.web.spec.ts → chromium-web; everything else → chromium-mock-ipc.
+  // Existing specs are untouched and keep their exact prior behavior.
   projects: [
     {
       name: "chromium-mock-ipc",
+      testIgnore: /.*\.web\.spec\.ts$/,
+      use: {
+        ...devices["Desktop Chrome"],
+        viewport: { width: 1280, height: 720 },
+      },
+    },
+    {
+      name: "chromium-web",
+      testMatch: /.*\.web\.spec\.ts$/,
       use: {
         ...devices["Desktop Chrome"],
         viewport: { width: 1280, height: 720 },

--- a/gui/e2e-playwright/specs/web-persona.web.spec.ts
+++ b/gui/e2e-playwright/specs/web-persona.web.spec.ts
@@ -1,0 +1,75 @@
+// [FABLE-5] sq-u0my5 — web-persona smoke: the workbench boots and a tool works with NO Tauri.
+//
+// Runs under the chromium-web project (support/web-fixtures.ts): no window.__TAURI__ /
+// __TAURI_INTERNALS__ is ever installed, so isTauriRuntime() === false and the page takes the
+// pure-browser code paths of the deployed /app — the persona the mock-IPC lane structurally
+// cannot see. The webPersona auto-fixture already guarantees, before the test body runs:
+//   * hermetic network (only 127.0.0.1 / localhost / blob: / data:),
+//   * the Tauri globals are genuinely absent,
+//   * the in-tab WASM engine reached "Engine ready" (browser-only boot).
+//
+// This spec then proves:
+//   1. the Query tool renders AND executes the default query against the in-tab engine
+//      (a tool demonstrably *works*, not merely mounts, without a native backend);
+//   2. the Import drawer is honest about the browser persona: it defaults to the Paste tab and
+//      the File tab shows the "Desktop app only" notice INSTEAD of the native file picker —
+//      today's honest browser state. (Sibling bead sq-eydh9 adds real browser upload; its spec
+//      will supersede assertion 2 with a positive one.)
+//
+// Stable selectors (all declared E2E hooks — role / data-* only):
+//   #repl-query                 — the SPARQL editor textarea (query-workbench.tsx contract)
+//   button "Run query"          — the run trigger
+//   [data-result-kind="select"] — SELECT result container
+//   [data-import-trigger="rail"]— the left rail's "+ Import data…" entry point
+//   [data-import-drawer]        — the Import drawer dialog content
+//   [data-import-tab="file"] / ["paste"] — the drawer's tab buttons (role="tab", aria-selected)
+//
+// Determinism rules: NO waitForTimeout; NO exact numeric assertions; web-first assertions only.
+
+import { webTest as test, webExpect as expect } from "../support/index.ts";
+
+test.describe("web-persona", () => {
+  // The webPersona auto-fixture navigates to "/" and waits for engine ready before each test.
+
+  test("workbench boots and the Query tool runs against the in-tab engine", async ({ page }) => {
+    // The workbench shell is up: the SPARQL editor and its run trigger render.
+    const editor = page.locator("#repl-query");
+    const runBtn = page.getByRole("button", { name: "Run query" });
+    await expect(editor).toBeVisible();
+    await expect(runBtn).toBeEnabled();
+
+    // The default query executes against the in-tab WASM engine — no native backend exists in
+    // this persona, so a SELECT result rendering proves the browser code path works end-to-end.
+    await runBtn.click();
+    const selectResult = page.locator('[data-result-kind="select"]');
+    await expect(selectResult).toBeVisible();
+
+    // The seeded sample graph is loaded (Alice is its first ORDER BY ?name row); presence-only,
+    // no row-count / timing assertion.
+    await expect(selectResult.getByText("Alice").first()).toBeVisible();
+  });
+
+  test("import drawer offers no native disk path in the browser persona", async ({ page }) => {
+    // Open the Import drawer from the left rail.
+    await page.locator('[data-import-trigger="rail"]').click();
+    const drawer = page.locator("[data-import-drawer]");
+    await expect(drawer).toBeVisible();
+
+    // Browser persona default: the drawer opens on Paste (the File tab is the desktop default —
+    // import-drawer.tsx picks the initial tab off isTauriRuntime()).
+    await expect(drawer.locator('[data-import-tab="paste"]')).toHaveAttribute(
+      "aria-selected",
+      "true",
+    );
+
+    // The File tab exists but is honest: it shows the "Desktop app only" notice and does NOT
+    // offer the native file picker.
+    await drawer.locator('[data-import-tab="file"]').click();
+    await expect(drawer.getByText("Desktop app only")).toBeVisible();
+    await expect(drawer.getByRole("button", { name: /Choose a file/ })).not.toBeAttached();
+
+    // Close the drawer to leave the page in its initial state.
+    await page.getByRole("button", { name: "Close import drawer" }).click();
+    await expect(drawer).not.toBeVisible();
+  });
+});

--- a/gui/e2e-playwright/support/index.ts
+++ b/gui/e2e-playwright/support/index.ts
@@ -4,13 +4,17 @@
 //   import { test, expect } from '../support/index.ts';
 //
 // Exports:
-//   test           — extended test with the tauriMock auto-fixture
+//   test           — extended test with the tauriMock auto-fixture (desktop persona)
 //   expect         — standard Playwright expect (re-exported for convenience)
+//   webTest        — extended test with the webPersona auto-fixture: NO Tauri mock, for
+//                    *.web.spec.ts specs run by the chromium-web project [FABLE-5] sq-u0my5
+//   webExpect      — standard Playwright expect (re-exported alongside webTest)
 //   readIpcLog     — helper to read the accumulated IPC log from the page
 //   waitForEngineReady — wait for "Engine ready" in the top bar
 //   tauriMockScript    — the raw init-script string (rarely needed directly)
 //   IpcLogEntry    — type of entries in the IPC log
 
 export { test, expect, readIpcLog, type IpcLogEntry } from "./fixtures.ts";
+export { webTest, webExpect } from "./web-fixtures.ts";
 export { waitForEngineReady } from "./gui-ready.ts";
 export { tauriMockScript } from "./tauri-mock.ts";

--- a/gui/e2e-playwright/support/web-fixtures.ts
+++ b/gui/e2e-playwright/support/web-fixtures.ts
@@ -1,0 +1,81 @@
+// [FABLE-5] sq-u0my5 — extended Playwright `test` for the GUI WEB-PERSONA lane (no Tauri mock).
+//
+// The mock-IPC lane (support/fixtures.ts) injects window.__TAURI__ + __TAURI_INTERNALS__ into
+// EVERY spec, so isTauriRuntime() returns true and only the *desktop* persona is ever exercised.
+// The pure-browser persona — the deployed /app, where the maintainer reports breakage — had zero
+// CI coverage. This fixture is the browser-persona twin: identical hermetic doctrine, but it
+// deliberately DOES NOT install the Tauri init script, so the page sees exactly what a real
+// browser visitor sees (isTauriRuntime() === false; the in-tab WASM engine carries everything).
+//
+// The persona difference is the ABSENCE of the Tauri globals, not a different bundle: both
+// projects drive the same served root-relative static export (gui/app/out).
+//
+// The auto fixture wires three of the mock lane's four invariants
+// (research/web-gui-test-program.md §1) — the Tauri IPC mock is omitted BY DESIGN:
+//
+//   1. Hermetic    — blocks all external network requests at the context level. The in-tab
+//                    WASM engine + all Next.js static assets load from 127.0.0.1:3007 (the
+//                    serve process); nothing else is allowed through.
+//
+//   2. Navigate    — goes to "/" (no init script installed first).
+//
+//   3. Engine ready — waits for the literal "Engine ready" copy in the top bar before yielding
+//                    control to the test body. The in-tab WASM engine warms + loads the sample
+//                    graph with NO Tauri backend — that this succeeds is itself the core
+//                    browser-persona boot assertion.
+//
+// A guard step then asserts the Tauri globals are genuinely absent, so a future harness change
+// that leaks the mock into this project fails loudly instead of silently re-testing the desktop
+// persona.
+
+import { test as base, expect } from "@playwright/test";
+import { waitForEngineReady } from "./gui-ready.ts";
+
+/** Fixtures added by this extension. */
+type GuiWebFixtures = {
+  /** Auto-fixture: blocks external network, navigates + waits for engine — NO Tauri mock. */
+  webPersona: void;
+};
+
+export const webTest = base.extend<GuiWebFixtures>({
+  webPersona: [
+    async ({ page, context }, use) => {
+      // ── 1. Hermetic network block (context-level, covers all pages) ──────────────────────────
+      // Allow only localhost / 127.0.0.1 (the static file server + blob:/data: URLs the export
+      // uses). Same allowlist as the mock-IPC lane — determinism doctrine §1 (hermetic).
+      await context.route("**/*", (route) => {
+        const url = route.request().url();
+        if (
+          url.startsWith("http://127.0.0.1") ||
+          url.startsWith("http://localhost") ||
+          url.startsWith("blob:") ||
+          url.startsWith("data:")
+        ) {
+          return route.continue();
+        }
+        return route.abort();
+      });
+
+      // ── 2. Navigate — deliberately NO page.addInitScript(tauriMockScript) ────────────────────
+      await page.goto("/");
+
+      // ── 3. Guard: the Tauri globals must be genuinely absent (browser persona) ──────────────
+      const tauriGlobals = await page.evaluate(() => ({
+        tauri: "__TAURI__" in window,
+        internals: "__TAURI_INTERNALS__" in window,
+      }));
+      expect(tauriGlobals, "web persona must run with NO Tauri globals").toEqual({
+        tauri: false,
+        internals: false,
+      });
+
+      // ── 4. Wait for engine ready (WASM instantiation + sample graph load, browser-only) ─────
+      await waitForEngineReady(page, { timeout: 90_000 });
+
+      await use();
+    },
+    { auto: true },
+  ],
+});
+
+export { expect as webExpect };


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated contribution (bead `sq-u0my5`, epic `sq-2ucrz`). Model: Fable 5.

## Why

CI never tested the browser persona: the `tauriMock` auto-fixture (`support/fixtures.ts`) injects `window.__TAURI__` into **every** spec, so `isTauriRuntime()` returns `true` and only the desktop persona was ever exercised. The pure-browser persona — the deployed `/app`, exactly where the maintainer reports breakage ("most tabs don't work, at least in the browser") — had zero CI coverage. Diagnosed in `research/gui-consolidation-fix-plan.md` §1.3.

## What

A second Playwright project over the **same** served root-relative export (the browser persona is the *absence* of the Tauri globals, not a different bundle):

- **`support/web-fixtures.ts` (new)** — `webTest`/`webExpect` with a `webPersona` auto-fixture: identical hermetic network block + `goto` + engine-ready wait, deliberately **without** the Tauri mock init script, plus a guard that fails loudly if the Tauri globals ever leak into this project.
- **`playwright.config.ts`** — new `chromium-web` project matched by `*.web.spec.ts`; the existing `chromium-mock-ipc` project `testIgnore`s that suffix. Determinism doctrine unchanged: 0 retries, 1 worker, hermetic, no `waitForTimeout` (the `no-timeout-gate` still passes).
- **`specs/web-persona.web.spec.ts` (new)** — browser smoke: the workbench boots and the Query tool *executes* the default query against the in-tab WASM engine with no Tauri; the Import drawer defaults to Paste and its File tab shows the honest "Desktop app only" notice with **no** native picker (today's honest browser state — sibling bead `sq-eydh9` will supersede that assertion with a positive upload one).
- **`support/index.ts`** — barrel re-exports.

## Invariants held

- Existing mock-IPC **specs are byte-unchanged** (only the config + barrel touched; `support/fixtures.ts` untouched → no fixture behavior change).
- Acceptance: `cd gui/e2e-playwright && npx playwright test` → **16 passed** (14 `chromium-mock-ipc` + 2 `chromium-web`) against the built `gui/app/out` export. `npm run typecheck` green.

## Browser-persona findings (report-only, per bead scope)

An instrumented (uncommitted) probe under the new persona found **no browser-specific breakage beyond what the design record already documents**: zero console errors / page errors on boot; engine reaches ready; RDFS inference reaches `ready` in-browser (reason bundle served); status bar falls back honestly (`backend: saved in this browser`, ≈disk estimate). The maintainer-perceived "most tabs broken" reproduces as the 8 stub tools in the rail — persona-independent, already decomposed into the sq-2ucrz child beads.

**Do not arm** — normal verify/review flow applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)