### PR TITLE
refactor(gui): tool-panel registry seam — one panel file per tool (sq-5lyme) [FABLE-5]

### DIFF
--- a/gui/app/src/components/workbench/full-text-tool.tsx
+++ b/gui/app/src/components/workbench/full-text-tool.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+// [FABLE-5] sq-5lyme — the Full-text tool's OWN panel file (tool-panel registry seam).
+// Today it renders the exact honest stub it always did; sq-9nwab fills it with the BM25
+// search panel over the sparq-text-wasm bundle. When that lands, flip the honesty metadata
+// via FULL_TEXT_TOOL_OVERRIDE below — never by editing the shared data/tools.ts — so
+// parallel tool beads stay file-disjoint.
+
+import { ToolStub } from "@/components/workbench/tool-stub";
+import type { ToolOverride } from "@/data/tools";
+
+/**
+ * Optional honesty-metadata override merged over the base `ToolDef` (data/tools.ts) by the
+ * tool-panel registry's `resolveTool` and by the stub itself. `undefined` = base metadata
+ * unchanged. Omit fields you do not override.
+ */
+export const FULL_TEXT_TOOL_OVERRIDE: ToolOverride | undefined = undefined;
+
+export function FullTextTool() {
+  return <ToolStub toolId="full-text" override={FULL_TEXT_TOOL_OVERRIDE} />;
+}

--- a/gui/app/src/components/workbench/graph-view-tool.tsx
+++ b/gui/app/src/components/workbench/graph-view-tool.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+// [FABLE-5] sq-5lyme — the Graph-view tool's OWN panel file (tool-panel registry seam).
+// Today it renders the exact honest stub it always did; sq-lxomy fills it with the working
+// CONSTRUCT/DESCRIBE tab over the already-shipped GraphView component. When that lands, flip
+// the honesty metadata via GRAPH_VIEW_TOOL_OVERRIDE below — never by editing the shared
+// data/tools.ts — so parallel tool beads stay file-disjoint.
+
+import { ToolStub } from "@/components/workbench/tool-stub";
+import type { ToolOverride } from "@/data/tools";
+
+/**
+ * Optional honesty-metadata override merged over the base `ToolDef` (data/tools.ts) by the
+ * tool-panel registry's `resolveTool` and by the stub itself. `undefined` = base metadata
+ * unchanged. Omit fields you do not override.
+ */
+export const GRAPH_VIEW_TOOL_OVERRIDE: ToolOverride | undefined = undefined;
+
+export function GraphViewTool() {
+  return <ToolStub toolId="graph-view" override={GRAPH_VIEW_TOOL_OVERRIDE} />;
+}

--- a/gui/app/src/components/workbench/server-tool.tsx
+++ b/gui/app/src/components/workbench/server-tool.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+// [FABLE-5] sq-5lyme — the Server tool's OWN panel file (tool-panel registry seam).
+// Today it renders the exact honest stub it always did; sq-iemfq fills it with the SPARQL 1.1
+// Protocol endpoint client over the existing @sparq/client core. When that lands, flip the
+// honesty metadata via SERVER_TOOL_OVERRIDE below — never by editing the shared
+// data/tools.ts — so parallel tool beads stay file-disjoint.
+
+import { ToolStub } from "@/components/workbench/tool-stub";
+import type { ToolOverride } from "@/data/tools";
+
+/**
+ * Optional honesty-metadata override merged over the base `ToolDef` (data/tools.ts) by the
+ * tool-panel registry's `resolveTool` and by the stub itself. `undefined` = base metadata
+ * unchanged. Omit fields you do not override.
+ */
+export const SERVER_TOOL_OVERRIDE: ToolOverride | undefined = undefined;
+
+export function ServerTool() {
+  return <ToolStub toolId="server" override={SERVER_TOOL_OVERRIDE} />;
+}

--- a/gui/app/src/components/workbench/streaming-tool.tsx
+++ b/gui/app/src/components/workbench/streaming-tool.tsx
@@ -1,0 +1,21 @@
+"use client";
+
+// [FABLE-5] sq-5lyme — the Streaming tool's OWN panel file (tool-panel registry seam).
+// Today it renders the exact honest stub it always did; sq-kwb74 fills it with the RSP-QL
+// tick view over the sparq-rsp-wasm bundle. When that lands, flip the honesty metadata via
+// STREAMING_TOOL_OVERRIDE below — never by editing the shared data/tools.ts — so parallel
+// tool beads stay file-disjoint.
+
+import { ToolStub } from "@/components/workbench/tool-stub";
+import type { ToolOverride } from "@/data/tools";
+
+/**
+ * Optional honesty-metadata override merged over the base `ToolDef` (data/tools.ts) by the
+ * tool-panel registry's `resolveTool` and by the stub itself. `undefined` = base metadata
+ * unchanged. Omit fields you do not override.
+ */
+export const STREAMING_TOOL_OVERRIDE: ToolOverride | undefined = undefined;
+
+export function StreamingTool() {
+  return <ToolStub toolId="streaming" override={STREAMING_TOOL_OVERRIDE} />;
+}

--- a/gui/app/src/components/workbench/tool-panel.tsx
+++ b/gui/app/src/components/workbench/tool-panel.tsx
@@ -1,23 +1,66 @@
 "use client";
 
-// [OPUS-4.8] sq-ixc3.9 / sq-ixc3.11 — dispatches a tab id to its tool panel. The Query and
-// SHACL tools are WORKING tabs over the live store (the surface-to-tool translation of
-// research/gui-design.md §A.4/§A.5, marketing chrome cut); every tool whose capability is not
-// genuinely in the GUI's in-tab wasm bundle stays an honest STUB (ToolStub) that the later
-// phases fill (sq-ixc3.12 the query workbench multi-view, sq-ixc3.13 the import drawer, sq-zeai
-// the native-only vector/geo wasm spike). A stub never fabricates a result — it states the verb
-// + tier.
+// [FABLE-5] sq-5lyme — the static tool-panel REGISTRY (was an if-chain): one panel file per
+// tool, so each later tool bead lands in ITS OWN file with zero shared-file conflict (epic
+// sq-2ucrz, research/gui-consolidation-fix-plan.md). The Query / SHACL / Inference tools are
+// WORKING tabs over the live store; the four feasible-now tools (graph-view / full-text /
+// streaming / server) now have their own panel files that still render the honest stub until
+// sq-lxomy / sq-9nwab / sq-kwb74 / sq-iemfq fill them. Every tool whose capability is not
+// genuinely available stays an honest STUB (ToolStub) — a stub never fabricates a result.
+//
+// A registry entry may carry the optional honesty-metadata override its panel file exports
+// (ToolOverride in data/tools.ts); `resolveTool` merges it over the base ToolDef. That is the
+// read path rail/tab consumers adopt (sq-1odi9 regroups the rail on it), so a tool bead flips
+// its tier/copy/group INSIDE its own panel file — never in the shared data/tools.ts.
 
+import type { ComponentType } from "react";
 import { QueryWorkbench } from "@/components/workbench/query-workbench";
 import { ShaclTool } from "@/components/workbench/shacl-tool";
 import { InferenceTool } from "@/components/workbench/inference-tool";
+import {
+  GraphViewTool,
+  GRAPH_VIEW_TOOL_OVERRIDE,
+} from "@/components/workbench/graph-view-tool";
+import { FullTextTool, FULL_TEXT_TOOL_OVERRIDE } from "@/components/workbench/full-text-tool";
+import { StreamingTool, STREAMING_TOOL_OVERRIDE } from "@/components/workbench/streaming-tool";
+import { ServerTool, SERVER_TOOL_OVERRIDE } from "@/components/workbench/server-tool";
 import { ToolStub } from "@/components/workbench/tool-stub";
+import { applyToolOverride, toolById, type ToolDef, type ToolOverride } from "@/data/tools";
+
+interface ToolPanelEntry {
+  Component: ComponentType;
+  /** The optional honesty-metadata override the panel file owns (undefined = none yet). */
+  override?: ToolOverride;
+}
+
+/**
+ * Static id → panel registry. Tools with no entry (vector / geosparql / zk / mpc — genuinely
+ * deferred behind the sq-zeai portability spike and the ZK/MPC audit posture) fall back to the
+ * shared honest ToolStub, exactly as before.
+ */
+const TOOL_PANELS: Record<string, ToolPanelEntry> = {
+  query: { Component: QueryWorkbench },
+  shacl: { Component: ShaclTool },
+  // [OPUS-4.8] sq-tp1m — the Inference tool is a real, working panel (per-workspace RDFS /
+  // OWL 2 RL entailment wired to the engine's forward-chaining reasoner), not an honest stub.
+  inference: { Component: InferenceTool },
+  "graph-view": { Component: GraphViewTool, override: GRAPH_VIEW_TOOL_OVERRIDE },
+  "full-text": { Component: FullTextTool, override: FULL_TEXT_TOOL_OVERRIDE },
+  streaming: { Component: StreamingTool, override: STREAMING_TOOL_OVERRIDE },
+  server: { Component: ServerTool, override: SERVER_TOOL_OVERRIDE },
+};
+
+/**
+ * Resolved (base ⊕ panel-file override) tool metadata — the honest read path for rail / tab /
+ * palette consumers, so honesty flips land with the panel that earns them (sq-5lyme seam).
+ */
+export function resolveTool(id: string): ToolDef | undefined {
+  const base = toolById(id);
+  return base ? applyToolOverride(base, TOOL_PANELS[id]?.override) : undefined;
+}
 
 export function ToolPanel({ toolId }: { toolId: string }) {
-  if (toolId === "query") return <QueryWorkbench />;
-  if (toolId === "shacl") return <ShaclTool />;
-  // [OPUS-4.8] sq-tp1m — the Inference tool is a real, working panel (per-workspace RDFS / OWL 2
-  // RL entailment wired to the engine's forward-chaining reasoner), no longer an honest stub.
-  if (toolId === "inference") return <InferenceTool />;
+  const entry = TOOL_PANELS[toolId];
+  if (entry) return <entry.Component />;
   return <ToolStub toolId={toolId} />;
 }

--- a/gui/app/src/components/workbench/tool-stub.tsx
+++ b/gui/app/src/components/workbench/tool-stub.tsx
@@ -5,9 +5,13 @@
 // wasm bundle opens this panel, which states plainly what the tool WILL do over the live store,
 // its honesty tier, and which bead lands it. It NEVER fabricates a result or dresses a
 // walkthrough/soon capability up as live.
+//
+// [FABLE-5] sq-5lyme — the stub now also reads an optional per-tool honesty-metadata override
+// (ToolOverride, exported by the tool's own panel file and passed down by it), merged over the
+// base ToolDef. With no override (today's state for every tool) the rendering is IDENTICAL.
 
 import { Badge } from "@/components/ui/badge";
-import { toolById, TIER_META } from "@/data/tools";
+import { applyToolOverride, toolById, TIER_META, type ToolOverride } from "@/data/tools";
 
 /**
  * Which bead lands each remaining stub (so the stub is self-documenting, not a dead
@@ -37,15 +41,23 @@ const TIER_CAVEAT: Record<string, string> = {
     "This capability is a native-only crate not yet compiled to wasm, so it will start as a captured-I/O walkthrough until a portability spike or endpoint mode lands.",
 };
 
-export function ToolStub({ toolId }: { toolId: string }) {
-  const tool = toolById(toolId);
-  if (!tool) {
+export function ToolStub({
+  toolId,
+  override,
+}: {
+  toolId: string;
+  /** [FABLE-5] sq-5lyme — optional honesty-metadata override owned by the tool's panel file. */
+  override?: ToolOverride;
+}) {
+  const base = toolById(toolId);
+  if (!base) {
     return (
       <div className="flex h-full items-center justify-center p-8 text-sm text-muted-foreground">
         Unknown tool: {toolId}
       </div>
     );
   }
+  const tool = applyToolOverride(base, override);
   const Icon = tool.icon;
   const tier = TIER_META[tool.tier];
   const bead = TOOL_BEAD[toolId];

--- a/gui/app/src/data/tools.ts
+++ b/gui/app/src/data/tools.ts
@@ -45,6 +45,13 @@ export type Tier =
   | "walkthrough"
   | "soon";
 
+/**
+ * [FABLE-5] sq-5lyme — rail grouping for the later honesty regroup (sq-1odi9): `working` tools
+ * have a live panel today; `coming-soon` tools are honest stubs. Data-only for now — nothing
+ * renders the group yet.
+ */
+export type ToolGroup = "working" | "coming-soon";
+
 export interface ToolDef {
   /** Stable id — the tab key + the Cmd-K (later) index key. */
   id: string;
@@ -56,6 +63,27 @@ export interface ToolDef {
   icon: LucideIcon;
   /** Does a working tab exist yet, or is this an honest stub the later phases fill? */
   built: boolean;
+  /** Rail group (sq-5lyme): working panel vs coming-soon honest stub. Not yet rendered. */
+  group: ToolGroup;
+}
+
+/**
+ * [FABLE-5] sq-5lyme — an optional honesty-metadata override a per-tool PANEL FILE exports
+ * (see the tool-panel registry), merged over the base `ToolDef` by `applyToolOverride`. This
+ * is the seam that lets a later tool bead flip its tier/copy/group INSIDE its own panel file
+ * when the working panel lands — never by editing this shared file. OMIT fields you do not
+ * override (an explicit `undefined` field would clobber the base value).
+ */
+export interface ToolOverride {
+  tier?: Tier;
+  blurb?: string;
+  built?: boolean;
+  group?: ToolGroup;
+}
+
+/** Merge a panel file's override (if any) over the base tool definition. */
+export function applyToolOverride(tool: ToolDef, override?: ToolOverride): ToolDef {
+  return override ? { ...tool, ...override } : tool;
 }
 
 /** The TOOLS list, in the rail order from research/gui-design.md §A.2. */
@@ -67,6 +95,7 @@ export const TOOLS: ToolDef[] = [
     tier: "live",
     icon: Database,
     built: true,
+    group: "working",
   },
   {
     id: "graph-view",
@@ -75,6 +104,7 @@ export const TOOLS: ToolDef[] = [
     tier: "soon",
     icon: GraphIcon,
     built: false,
+    group: "coming-soon",
   },
   {
     id: "shacl",
@@ -83,6 +113,7 @@ export const TOOLS: ToolDef[] = [
     tier: "live",
     icon: ShieldCheck,
     built: true,
+    group: "working",
   },
   {
     id: "inference",
@@ -93,6 +124,7 @@ export const TOOLS: ToolDef[] = [
     tier: "live-new-wasm",
     icon: Brain,
     built: true,
+    group: "working",
   },
   {
     id: "full-text",
@@ -101,6 +133,7 @@ export const TOOLS: ToolDef[] = [
     tier: "live-new-wasm",
     icon: Search,
     built: false,
+    group: "coming-soon",
   },
   {
     id: "vector",
@@ -109,6 +142,7 @@ export const TOOLS: ToolDef[] = [
     tier: "walkthrough",
     icon: Binary,
     built: false,
+    group: "coming-soon",
   },
   {
     id: "geosparql",
@@ -117,6 +151,7 @@ export const TOOLS: ToolDef[] = [
     tier: "walkthrough",
     icon: MapPin,
     built: false,
+    group: "coming-soon",
   },
   {
     id: "streaming",
@@ -125,6 +160,7 @@ export const TOOLS: ToolDef[] = [
     tier: "live-new-wasm",
     icon: Radio,
     built: false,
+    group: "coming-soon",
   },
   {
     id: "zk",
@@ -134,6 +170,7 @@ export const TOOLS: ToolDef[] = [
     tier: "live-bbjs",
     icon: Lock,
     built: false,
+    group: "coming-soon",
   },
   {
     id: "mpc",
@@ -143,6 +180,7 @@ export const TOOLS: ToolDef[] = [
     tier: "live-sim",
     icon: Users,
     built: false,
+    group: "coming-soon",
   },
   {
     id: "server",
@@ -152,6 +190,7 @@ export const TOOLS: ToolDef[] = [
     tier: "walkthrough",
     icon: Server,
     built: false,
+    group: "coming-soon",
   },
 ];
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated contribution (Claude Fable 5) for bead `sq-5lyme` (epic `sq-2ucrz`, GUI consolidation). DO NOT ARM — leave merge to the orchestrator's verdict flow.

## What

Pure seam refactor per `research/gui-consolidation-fix-plan.md` (Phase 0, sq-5lyme): the tool-panel if-chain becomes a **static id→panel registry**, with **one panel file per feasible-now tool**, so the parallel Phase-1/2 tool beads land file-disjointly with zero shared-file merge conflicts.

- **`tool-panel.tsx`** — if-chain → `TOOL_PANELS` registry. Entries may carry the optional honesty-metadata override their panel file exports; `resolveTool(id)` (base `ToolDef` ⊕ override) is the merged read path downstream consumers adopt. Tools with no entry (vector/geosparql/zk/mpc — genuinely deferred) fall back to the shared honest `ToolStub` exactly as before.
- **NEW `graph-view-tool.tsx` / `full-text-tool.tsx` / `streaming-tool.tsx` / `server-tool.tsx`** — thin per-tool panel files that still render today's exact honest stub (`ToolStub`) and export an `undefined` `ToolOverride`. Downstream beads sq-lxomy / sq-9nwab / sq-kwb74 / sq-iemfq fill them and flip tier/copy **inside their own file** — never `tools.ts`.
- **`tools.ts`** — adds `ToolGroup` (`working` | `coming-soon`) `group` field (data-only, for the sq-1odi9 rail regroup; nothing renders it yet), the `ToolOverride` type, and the pure `applyToolOverride` merge helper.
- **`tool-stub.tsx`** — accepts an optional `override` prop merged over the base def (the 'stub reads the override' half of the seam). With no override — today's state for every tool — rendering is byte-identical.

## Invariant

**Behaviorally invisible**: every tool id renders exactly the same UI as before (query/shacl/inference working panels untouched; all stubs keep their honest copy, tier dots, and ZK/MPC caveat text verbatim).

## Judgment calls (proceed-and-document)

1. `tool-stub.tsx` is touched beyond the bead's FILES list — it is unowned by any sibling bead and the override-read half of the seam ('the rail + stub read') requires it; done via a prop (cycle-free), not a module cycle.
2. The **rail** keeps reading base `TOOLS` for now (unchanged behavior = the invariant); the merged read path (`resolveTool`) is exported and ready for sq-1odi9, which owns `left-rail.tsx` and regroups the rail on the new `group` field.

## Acceptance (all run locally against the rebuilt tauri-target export)

- `gui/app`: `npm run lint` ✓ (0 warnings) · `npm run typecheck` ✓ · `npm run build:tauri` ✓
- `gui/e2e-playwright`: `npx playwright test` — **14/14 passed** (export-contract, inference-toggle, keyboard-spine, status-bar, workbench-query)

Bead: `sq-5lyme` · Epic: `sq-2ucrz` · Design record: `research/gui-consolidation-fix-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)