### PR TITLE
fix(gui): restore persisted workspace on launch — no data loss on reload (sq-lcd6e) [OPUS-4.8]

### DIFF
--- a/gui/app/src/components/workbench/query-workbench.tsx
+++ b/gui/app/src/components/workbench/query-workbench.tsx
@@ -61,6 +61,7 @@ import { GraphView } from "@/components/workbench/graph-view";
 // [OPUS-4.8] sq-tp1m (#757) — the per-workspace inference (RDFS / OWL 2 RL) selector, in the
 // action row so the active entailment regime is visible + controllable while querying.
 import { InferenceControl } from "@/components/workbench/inference-control";
+import { useWorkspace } from "@/lib/workspace-context";
 import { DEFAULT_QUERY } from "@/data/sample-graph";
 // [OPUS-4.8] sq-ixc3.10 — the Query tool contributes its operational verbs (run / EXPLAIN /
 // EXPLAIN ANALYZE / re-run a recent query) to the Cmd-K spine while it is mounted.
@@ -460,7 +461,15 @@ export function QueryWorkbench() {
   // explain() method); the Cmd-K verbs and the EXPLAIN/ANALYZE buttons both drive it.
   const { run, status } = useEngine();
   const workbench = useWorkbench();
+  // [OPUS-4.8] sq-lcd6e — the editor text round-trips through the active workspace so a saved
+  // query survives a reload / workspace switch (the persisted editor state was never restored
+  // before). `workspace` starts null (restore is async); we seed the editor from it once, on the
+  // first restore AND on every workspace-id change, and write the text back (debounced) below.
+  const { workspace, setEditorQuery } = useWorkspace();
   const [query, setQuery] = React.useState(DEFAULT_QUERY);
+  // The id of the workspace whose editor text is currently loaded — guards the write-back from
+  // firing (and clobbering the saved query) before the restore has hydrated the editor.
+  const loadedWsRef = React.useRef<string | null>(null);
   const [outcome, setOutcome] = React.useState<QueryOutcome | null>(null);
   const [view, setView] = React.useState<ResultView>("table");
   const [running, setRunning] = React.useState(false);
@@ -472,6 +481,26 @@ export function QueryWorkbench() {
   const recordRecent = React.useCallback((q: string) => {
     setRecentQueries((prev) => pushRecentQuery(prev, q, Date.now()));
   }, []);
+
+  // [OPUS-4.8] sq-lcd6e — hydrate the editor from the restored / switched workspace's saved query.
+  // Runs once per workspace id (never re-clobbering the user's in-progress edits within a session).
+  React.useEffect(() => {
+    if (!workspace) return;
+    if (loadedWsRef.current === workspace.id) return;
+    loadedWsRef.current = workspace.id;
+    setQuery(workspace.editor.query);
+  }, [workspace]);
+
+  // [OPUS-4.8] sq-lcd6e — write the editor text back to the workspace (debounced) so it persists.
+  // Guarded on `loadedWsRef` so the initial DEFAULT_QUERY never overwrites a saved query before
+  // the restore above has run.
+  React.useEffect(() => {
+    if (loadedWsRef.current === null) return;
+    const handle = setTimeout(() => {
+      void setEditorQuery(query);
+    }, 400);
+    return () => clearTimeout(handle);
+  }, [query, setEditorQuery]);
 
   // [OPUS-4.8] sq-ixc3.10/.12 — the SINGLE run path: plain run, EXPLAIN (plan only), or EXPLAIN
   // ANALYZE (plan + run), each surfaced as a { kind } outcome through the same RunResult pipeline.

--- a/gui/app/src/lib/engine-context.tsx
+++ b/gui/app/src/lib/engine-context.tsx
@@ -327,6 +327,24 @@ export interface EngineContextValue {
    * and it agrees byte-for-byte with the "add to current" merge path. `null` before warm.
    */
   snapshotStore: () => string | null;
+  /**
+   * [OPUS-4.8] sq-lcd6e — REPLACE the live store with a restored workspace's persisted SNAPSHOT
+   * (its whole-dataset N-Quads). This is the fix for the silent data-loss-on-relaunch: the warm
+   * path no longer unconditionally seeds the sample graph — the store's INITIAL content comes
+   * from the workspace being restored.
+   *   * `nquads` non-empty → the store is rebuilt from it (the imported data survives a reload);
+   *   * empty / `null` + `seedSampleWhenEmpty` → seed the SAMPLE graph (a genuinely-fresh
+   *     first-run default workspace, so a new user has something to query);
+   *   * empty / `null` without the flag → an EXPLICITLY-empty workspace stays empty.
+   * Bumps the store epoch so an active inference closure rematerialises over the restored data
+   * (sq-tp1m), refreshes the datasets summary + footprint, and marks the engine ready. If the
+   * wasm ctor has not warmed yet the request is QUEUED and applied the moment warm-up finishes,
+   * so a restore that races the cold-start is never dropped.
+   */
+  hydrateFromSnapshot: (
+    nquads: string | null,
+    opts?: { seedSampleWhenEmpty?: boolean },
+  ) => void;
 }
 
 const EngineContext = React.createContext<EngineContextValue | null>(null);
@@ -543,7 +561,85 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
   // land in the wrong state (e.g. mode Off but status Ready/Error). Only the latest generation writes.
   const inferenceGenRef = React.useRef(0);
 
-  // Warm the engine once on mount: load wasm, seed the sample graph, compute the summary.
+  // [OPUS-4.8] sq-lcd6e — a hydration request that arrived BEFORE the wasm ctor warmed (the
+  // workspace-restore bridge can call hydrateFromSnapshot while the engine is still cold). It is
+  // applied by the warm effect the moment the ctor is ready, so a restore never races the
+  // cold-start and gets dropped (which would silently fall back to an empty / sample store).
+  const pendingHydrationRef = React.useRef<{
+    nquads: string | null;
+    seedSampleWhenEmpty: boolean;
+  } | null>(null);
+
+  // [OPUS-4.8] sq-lcd6e — (re)build the live store from a restored snapshot, then publish the
+  // summary + ready status. The SINGLE place the store's content is (re)seeded, whether on the
+  // initial warm (fresh default → sample) or a workspace switch (target's snapshot). Bumps the
+  // store epoch + drops the cached closure so an active inference regime rematerialises over the
+  // restored data (the sq-tp1m epoch discipline).
+  const applyHydration = React.useCallback(
+    (
+      Store: WasmStoreCtor,
+      req: { nquads: string | null; seedSampleWhenEmpty: boolean },
+    ) => {
+      const content = (req.nquads ?? "").trim();
+      let store: WasmStore;
+      try {
+        if (content !== "") {
+          // A restored workspace snapshot (whole dataset, N-Quads) — the imported data survives.
+          store = Store.loadDataset(req.nquads as string, "nquads");
+        } else if (req.seedSampleWhenEmpty) {
+          // A genuinely-fresh first-run default workspace: seed the sample so there is something
+          // to query. (An explicitly-empty workspace, below, stays empty.)
+          store = Store.load(SAMPLE_TURTLE, SAMPLE_FORMAT);
+        } else {
+          // An explicitly-empty workspace: an empty store (an empty N-Quads document — the same
+          // loader the merge path uses, so an empty parse is unambiguously zero quads).
+          store = Store.loadDataset("", "nquads");
+        }
+      } catch (err: unknown) {
+        setStatus({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+        return;
+      }
+      storeRef.current = store;
+      // The base store was replaced: drop any cached closure + in-flight build so an active
+      // inference regime rematerialises over the RESTORED data rather than a stale prior store.
+      reasonedStoreRef.current = null;
+      reasonedKeyRef.current = null;
+      reasonedBuildRef.current = null;
+      storeEpochRef.current += 1;
+      setStoreEpoch(storeEpochRef.current);
+      const { size, graphs: gs } = summariseGraphs(store);
+      setStoreSize(size);
+      setStoreBytes(snapshotBytes(store));
+      setGraphs(gs);
+      setStatus({ kind: "ready" });
+    },
+    [],
+  );
+  // Keep a stable ref so the warm effect (deps []) can apply a queued request without re-running.
+  const applyHydrationRef = React.useRef(applyHydration);
+  applyHydrationRef.current = applyHydration;
+
+  const hydrateFromSnapshot = React.useCallback(
+    (nquads: string | null, opts?: { seedSampleWhenEmpty?: boolean }) => {
+      const req = { nquads, seedSampleWhenEmpty: opts?.seedSampleWhenEmpty ?? false };
+      const Store = ctorRef.current;
+      if (!Store) {
+        // Cold engine: queue the request — the warm effect applies it once the ctor is ready.
+        pendingHydrationRef.current = req;
+        return;
+      }
+      applyHydration(Store, req);
+    },
+    [applyHydration],
+  );
+
+  // Warm the engine once on mount: load wasm, then HYDRATE the store from the restored workspace
+  // (a queued request, or — if the restore bridge has not called yet — wait for it). The store's
+  // initial content is NO LONGER an unconditional sample seed (sq-lcd6e: that silently replaced a
+  // user's imported data on every relaunch); status stays `warming` until the first hydration.
   React.useEffect(() => {
     let cancelled = false;
     const opts = { basePath: basePath() };
@@ -553,16 +649,11 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       .then((Store) => {
         if (cancelled) return;
         ctorRef.current = Store;
-        const store = Store.load(SAMPLE_TURTLE, SAMPLE_FORMAT);
-        storeRef.current = store;
-        // [OPUS-4.8] sq-tp1m — first content ready: bump the epoch so any active regime materialises.
-        storeEpochRef.current += 1;
-        setStoreEpoch(storeEpochRef.current);
-        const { size, graphs: gs } = summariseGraphs(store);
-        setStoreSize(size);
-        setStoreBytes(snapshotBytes(store));
-        setGraphs(gs);
-        setStatus({ kind: "ready" });
+        const pending = pendingHydrationRef.current;
+        if (pending) {
+          pendingHydrationRef.current = null;
+          applyHydrationRef.current(Store, pending);
+        }
       })
       .catch((err: unknown) => {
         if (cancelled) return;
@@ -1025,6 +1116,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       importRdf,
       nativeLoaderAvailable,
       snapshotStore,
+      hydrateFromSnapshot,
       inferenceMode,
       inferenceStatus,
       setInferenceMode,
@@ -1045,6 +1137,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       importRdf,
       nativeLoaderAvailable,
       snapshotStore,
+      hydrateFromSnapshot,
       inferenceMode,
       inferenceStatus,
       setInferenceMode,

--- a/gui/app/src/lib/workspace-context.tsx
+++ b/gui/app/src/lib/workspace-context.tsx
@@ -237,6 +237,24 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
 
   const createWorkspace = React.useCallback(
     async (name: string): Promise<Workspace> => {
+      // 1. SAVE the current workspace's live snapshot first — no data loss on leaving it.
+      //    Mirrors switchWorkspace step 1: any SPARQL UPDATE (engine-context updateInPlace)
+      //    applied since the last import/switch snapshot is otherwise silently discarded on create.
+      const store = storeRef.current;
+      const current = workspaceRef.current;
+      if (store && current) {
+        const snapshot = engineRef.current.snapshotStore();
+        const saved: Workspace =
+          snapshot !== null
+            ? { ...current, dataSnapshot: snapshot, updatedAt: Date.now() }
+            : current;
+        try {
+          await store.save(saved);
+        } catch {
+          /* best-effort — a save failure must not block the create */
+        }
+      }
+      // 2. Create the new workspace and activate it.
       const ws = newWorkspace(name, STARTER_QUERY);
       applyWorkspace(ws);
       // A brand-new workspace is EMPTY (no sample) — an explicitly-created workspace stays empty.

--- a/gui/app/src/lib/workspace-context.tsx
+++ b/gui/app/src/lib/workspace-context.tsx
@@ -5,14 +5,19 @@
 // The persistent-workspace MODEL + persistence abstraction is the framework-agnostic
 // `@sparq/client` `workspace.ts` (sq-atb0): one `WorkspaceStore` interface with three runtime-
 // selected backends (Tauri on-disk when the fs capability is granted, browser localStorage on
-// the web target, in-memory fallback). This context is the GUI's thin host glue around it for
-// the IMPORT path: it holds the active workspace's imported-source list (drives the left rail's
-// Imports subgroup) and persists a workspace SNAPSHOT (the save/open cache) after each import.
+// the web target, in-memory fallback). This context is the GUI's host glue around it: it holds
+// the active workspace + its imported-source list (drives the left rail's Imports subgroup),
+// persists a workspace SNAPSHOT (the save/open cache) after each import, and — the load-bearing
+// fix (sq-lcd6e) — RESTORES that snapshot into the live engine on launch so a user's imported
+// data + editor state survive a reload instead of being silently replaced by the sample graph.
 //
-// SCOPE (this bead). A SINGLE auto-created/restored workspace — the full switcher/create/delete
-// UI is a separate phase (sq-atb0 model exists; the rail switcher button is still a stub). What
-// this bead needs and lights up: record `WorkspaceSourceMeta` for each import + write the
-// dataset snapshot so a re-open restores the imported store. NO secret is ever persisted.
+// [OPUS-4.8] sq-lcd6e — this context is the workspace⇄engine HYDRATION bridge. Because
+// <WorkspaceProvider> is rendered UNDER <EngineProvider> (see app/layout.tsx), it can call
+// useEngine() and push the restored snapshot into the engine (hydrateFromSnapshot) at each
+// lifecycle point: initial restore, create, switch, delete-of-active. It also exposes the
+// lifecycle APIs (list / create / rename / delete / switch) the switcher UI (sq-lmlch) consumes;
+// this bead is the PLUMBING — the rail switcher UI is a separate, dependent bead. NO secret is
+// ever persisted.
 
 import * as React from "react";
 import {
@@ -23,12 +28,18 @@ import {
   type WorkspaceInferenceMode,
   type WorkspaceSourceMeta,
   type WorkspaceStore,
+  type WorkspaceSummary,
 } from "@sparq/client";
 
+import { useEngine } from "@/lib/engine-context";
 import { loadTauriFs } from "@/lib/tauri-fs";
+import { DEFAULT_QUERY } from "@/data/sample-graph";
 
-/** The starting editor query a freshly-created workspace carries (kept in lockstep with the Query tool default). */
-const STARTER_QUERY = "SELECT * WHERE { ?s ?p ?o } LIMIT 25";
+// [OPUS-4.8] sq-lcd6e — the starting editor query a freshly-created workspace carries. It is the
+// curated Query-tool default (the demonstrative foaf query over the sample graph) so a fresh
+// workspace opens with the SAME editor content the Query tool shows before restore — the editor
+// now round-trips through the workspace (sq-lcd6e), so this is the single source of that default.
+const STARTER_QUERY = DEFAULT_QUERY;
 
 export interface WorkspaceContextValue {
   /** The active workspace, or `null` until the store + workspace are restored on mount. */
@@ -38,12 +49,42 @@ export interface WorkspaceContextValue {
   /** The imported-source metadata list for the active workspace (drives the rail's Imports subgroup). */
   sources: WorkspaceSourceMeta[];
   /**
+   * [OPUS-4.8] sq-lcd6e — lightweight summaries of EVERY stored workspace, for the switcher
+   * (sq-lmlch). Refreshed after any create / rename / delete / switch / import.
+   */
+  workspaces: WorkspaceSummary[];
+  /**
    * Record an imported source + persist a fresh dataset SNAPSHOT of the live store. Called by the
    * Import drawer on a successful ingest. `snapshot` is the live store's whole-dataset N-Quads
    * (the engine context's `snapshotStore()`), the save/open cache. Best-effort persistence: a
    * write failure does not throw (the import itself already succeeded in-memory).
    */
   recordImport: (source: WorkspaceSourceMeta, snapshot: string | null) => Promise<void>;
+  /**
+   * [OPUS-4.8] sq-lcd6e — persist the SPARQL editor text for the active workspace (best-effort,
+   * debounced by the Query tool) so the editor round-trips across a reload. Only the query text
+   * is updated; the other editor fields are preserved.
+   */
+  setEditorQuery: (query: string) => Promise<void>;
+  /**
+   * [OPUS-4.8] sq-lcd6e — create a new, empty workspace and make it active. It seeds NO sample
+   * data (an explicitly-created workspace stays empty); the engine store is hydrated empty.
+   * Returns the new workspace.
+   */
+  createWorkspace: (name: string) => Promise<Workspace>;
+  /** [OPUS-4.8] sq-lcd6e — rename a workspace by id (persisted; updates the active one in place). */
+  renameWorkspace: (id: string, name: string) => Promise<void>;
+  /**
+   * [OPUS-4.8] sq-lcd6e — delete a workspace by id. If it was the ACTIVE one, switch to the most
+   * recently-updated remaining workspace, or create a fresh default if none remain.
+   */
+  deleteWorkspace: (id: string) => Promise<void>;
+  /**
+   * [OPUS-4.8] sq-lcd6e — switch to another workspace: SAVE the current one's live snapshot first
+   * (no data loss), then load the target, hydrate the engine from its snapshot, and re-apply its
+   * inference regime. A no-op when the target is already active or missing.
+   */
+  switchWorkspace: (id: string) => Promise<void>;
   /**
    * [OPUS-4.8] sq-tp1m (#757) — the active workspace's persisted INFERENCE regime (query-time
    * RDFS / OWL 2 RL entailment), defaulting to `"off"`. The inference-mode bridge pushes this
@@ -60,11 +101,40 @@ export interface WorkspaceContextValue {
 const WorkspaceContext = React.createContext<WorkspaceContextValue | null>(null);
 
 export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
-  const [workspace, setWorkspace] = React.useState<Workspace | null>(null);
+  const [workspace, setWorkspaceState] = React.useState<Workspace | null>(null);
   const [backend, setBackend] = React.useState<WorkspaceBackend | null>(null);
+  const [workspaces, setWorkspaces] = React.useState<WorkspaceSummary[]>([]);
   const storeRef = React.useRef<WorkspaceStore | null>(null);
+  // A synchronous mirror of the active workspace so async mutators (switch/delete) can read it
+  // without a stale-closure functional-setState dance.
+  const workspaceRef = React.useRef<Workspace | null>(null);
 
-  // Resolve the persistence backend + restore (or create) the active workspace once on mount.
+  // [OPUS-4.8] sq-lcd6e — the engine hydration + snapshot surface. Held in a ref so the mount
+  // restore effect (deps []) and the lifecycle callbacks reference the latest engine API without
+  // re-running / re-creating. These are stable useCallbacks, but the ref keeps lint honest.
+  const engine = useEngine();
+  const engineRef = React.useRef(engine);
+  engineRef.current = engine;
+
+  /** Commit a workspace to both the render state and the synchronous ref. */
+  const applyWorkspace = React.useCallback((ws: Workspace | null) => {
+    workspaceRef.current = ws;
+    setWorkspaceState(ws);
+  }, []);
+
+  /** Re-read the switcher list from the backend (best-effort; a failure leaves the last list). */
+  const refreshList = React.useCallback(async () => {
+    const store = storeRef.current;
+    if (!store) return;
+    try {
+      setWorkspaces(await store.list());
+    } catch {
+      /* an unreadable index must not break the UI — keep the last list */
+    }
+  }, []);
+
+  // Resolve the persistence backend + restore (or create) the active workspace once on mount,
+  // then HYDRATE the engine store from the restored workspace's snapshot (sq-lcd6e).
   React.useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -74,6 +144,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       setBackend(store.backend);
       // Restore the last-opened workspace if there is one, else create a fresh default.
       let ws: Workspace | null = null;
+      let freshDefault = false;
       try {
         const lastId = await store.lastOpenedId();
         if (lastId) ws = await store.load(lastId);
@@ -82,6 +153,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       }
       if (!ws) {
         ws = newWorkspace("default workspace", STARTER_QUERY);
+        freshDefault = true;
         try {
           await store.save(ws);
           await store.setLastOpenedId(ws.id);
@@ -89,37 +161,64 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
           /* in-memory / locked-down backend — keep the workspace for this session anyway */
         }
       }
-      if (!cancelled) setWorkspace(ws);
+      if (cancelled) return;
+      applyWorkspace(ws);
+      // The load-bearing fix: seed the engine from the RESTORED snapshot — the sample graph is
+      // seeded ONLY for a genuinely-fresh default workspace, never over a user's restored data.
+      engineRef.current.hydrateFromSnapshot(ws.dataSnapshot ?? null, {
+        seedSampleWhenEmpty: freshDefault,
+      });
+      void refreshList();
     })();
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [applyWorkspace, refreshList]);
+
+  // Persist a workspace (best-effort) + keep it as the last-opened, then refresh the switcher list.
+  const persist = React.useCallback(
+    (ws: Workspace) => {
+      const store = storeRef.current;
+      if (!store) return;
+      store
+        .save(ws)
+        .then(() => store.setLastOpenedId(ws.id))
+        .then(() => refreshList())
+        .catch(() => {
+          /* a write failure must not break the in-memory workspace */
+        });
+    },
+    [refreshList],
+  );
 
   const recordImport = React.useCallback(
     async (source: WorkspaceSourceMeta, snapshot: string | null): Promise<void> => {
-      setWorkspace((prev) => {
-        const base = prev ?? newWorkspace("default workspace", STARTER_QUERY);
-        const next: Workspace = {
-          ...base,
-          sources: [...base.sources, source],
-          dataSnapshot: snapshot ?? base.dataSnapshot,
-          updatedAt: Date.now(),
-        };
-        // Persist the updated record (best-effort; the import already succeeded in-memory).
-        const store = storeRef.current;
-        if (store) {
-          store
-            .save(next)
-            .then(() => store.setLastOpenedId(next.id))
-            .catch(() => {
-              /* a write failure must not break the in-memory import */
-            });
-        }
-        return next;
-      });
+      const base = workspaceRef.current ?? newWorkspace("default workspace", STARTER_QUERY);
+      const next: Workspace = {
+        ...base,
+        sources: [...base.sources, source],
+        dataSnapshot: snapshot ?? base.dataSnapshot,
+        updatedAt: Date.now(),
+      };
+      applyWorkspace(next);
+      persist(next);
     },
-    [],
+    [applyWorkspace, persist],
+  );
+
+  const setEditorQuery = React.useCallback(
+    async (query: string): Promise<void> => {
+      const base = workspaceRef.current;
+      if (!base || base.editor.query === query) return;
+      const next: Workspace = {
+        ...base,
+        editor: { ...base.editor, query },
+        updatedAt: Date.now(),
+      };
+      applyWorkspace(next);
+      persist(next);
+    },
+    [applyWorkspace, persist],
   );
 
   // [OPUS-4.8] sq-tp1m (#757) — persist a new inference regime for the active workspace. Same
@@ -127,23 +226,144 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
   // through to the backend without letting a persistence failure surface to the caller.
   const setInference = React.useCallback(
     async (mode: WorkspaceInferenceMode): Promise<void> => {
-      setWorkspace((prev) => {
-        const base = prev ?? newWorkspace("default workspace", STARTER_QUERY);
-        if (base.inference === mode) return base;
-        const next: Workspace = { ...base, inference: mode, updatedAt: Date.now() };
-        const store = storeRef.current;
-        if (store) {
-          store
-            .save(next)
-            .then(() => store.setLastOpenedId(next.id))
-            .catch(() => {
-              /* a write failure must not break the in-memory selection */
-            });
-        }
-        return next;
-      });
+      const base = workspaceRef.current ?? newWorkspace("default workspace", STARTER_QUERY);
+      if (base.inference === mode) return;
+      const next: Workspace = { ...base, inference: mode, updatedAt: Date.now() };
+      applyWorkspace(next);
+      persist(next);
     },
-    [],
+    [applyWorkspace, persist],
+  );
+
+  const createWorkspace = React.useCallback(
+    async (name: string): Promise<Workspace> => {
+      const ws = newWorkspace(name, STARTER_QUERY);
+      applyWorkspace(ws);
+      // A brand-new workspace is EMPTY (no sample) — an explicitly-created workspace stays empty.
+      engineRef.current.hydrateFromSnapshot(null, { seedSampleWhenEmpty: false });
+      persist(ws);
+      return ws;
+    },
+    [applyWorkspace, persist],
+  );
+
+  const renameWorkspace = React.useCallback(
+    async (id: string, name: string): Promise<void> => {
+      const store = storeRef.current;
+      const active = workspaceRef.current;
+      if (active && active.id === id) {
+        const next: Workspace = { ...active, name, updatedAt: Date.now() };
+        applyWorkspace(next);
+        persist(next);
+        return;
+      }
+      if (!store) return;
+      try {
+        const ws = await store.load(id);
+        if (!ws) return;
+        await store.save({ ...ws, name, updatedAt: Date.now() });
+        await refreshList();
+      } catch {
+        /* a rename of a stored (non-active) workspace is best-effort */
+      }
+    },
+    [applyWorkspace, persist, refreshList],
+  );
+
+  // Load `id` and make it active: hydrate the engine from its snapshot + re-apply its inference.
+  const activate = React.useCallback((ws: Workspace) => {
+    applyWorkspace(ws);
+    engineRef.current.hydrateFromSnapshot(ws.dataSnapshot ?? null, {
+      seedSampleWhenEmpty: false,
+    });
+    // Re-apply the target's inference regime (the InferenceModeBridge also reacts to the state
+    // change; setting it here keeps the engine in lockstep even before that effect runs).
+    engineRef.current.setInferenceMode(ws.inference ?? "off");
+  }, [applyWorkspace]);
+
+  const switchWorkspace = React.useCallback(
+    async (id: string): Promise<void> => {
+      const store = storeRef.current;
+      if (!store) return;
+      const current = workspaceRef.current;
+      if (current && current.id === id) return;
+      // 1. SAVE the current workspace's live snapshot first — no data loss on leaving it.
+      if (current) {
+        const snapshot = engineRef.current.snapshotStore();
+        const saved: Workspace =
+          snapshot !== null
+            ? { ...current, dataSnapshot: snapshot, updatedAt: Date.now() }
+            : current;
+        try {
+          await store.save(saved);
+        } catch {
+          /* best-effort — a save failure must not block the switch */
+        }
+      }
+      // 2. Load the target + activate it (hydrate engine + inference).
+      let target: Workspace | null = null;
+      try {
+        target = await store.load(id);
+      } catch {
+        target = null;
+      }
+      if (!target) return;
+      try {
+        await store.setLastOpenedId(target.id);
+      } catch {
+        /* best-effort */
+      }
+      activate(target);
+      void refreshList();
+    },
+    [activate, refreshList],
+  );
+
+  const deleteWorkspace = React.useCallback(
+    async (id: string): Promise<void> => {
+      const store = storeRef.current;
+      if (!store) return;
+      try {
+        await store.remove(id);
+      } catch {
+        /* best-effort idempotent remove */
+      }
+      const active = workspaceRef.current;
+      if (active && active.id === id) {
+        // The active workspace was deleted: switch to the most recent remaining, else fresh.
+        let summaries: WorkspaceSummary[] = [];
+        try {
+          summaries = await store.list();
+        } catch {
+          summaries = [];
+        }
+        const nextId = summaries.find((s) => s.id !== id)?.id ?? null;
+        let target: Workspace | null = null;
+        if (nextId) {
+          try {
+            target = await store.load(nextId);
+          } catch {
+            target = null;
+          }
+        }
+        if (target) {
+          try {
+            await store.setLastOpenedId(target.id);
+          } catch {
+            /* best-effort */
+          }
+          activate(target);
+        } else {
+          const fresh = newWorkspace("default workspace", STARTER_QUERY);
+          applyWorkspace(fresh);
+          // A fresh default AFTER an explicit delete seeds the sample so the app is never blank.
+          engineRef.current.hydrateFromSnapshot(null, { seedSampleWhenEmpty: true });
+          persist(fresh);
+        }
+      }
+      void refreshList();
+    },
+    [activate, applyWorkspace, persist, refreshList],
   );
 
   const value = React.useMemo<WorkspaceContextValue>(
@@ -151,11 +371,28 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       workspace,
       backend,
       sources: workspace?.sources ?? [],
+      workspaces,
       recordImport,
+      setEditorQuery,
+      createWorkspace,
+      renameWorkspace,
+      deleteWorkspace,
+      switchWorkspace,
       inference: workspace?.inference ?? "off",
       setInference,
     }),
-    [workspace, backend, recordImport, setInference],
+    [
+      workspace,
+      backend,
+      workspaces,
+      recordImport,
+      setEditorQuery,
+      createWorkspace,
+      renameWorkspace,
+      deleteWorkspace,
+      switchWorkspace,
+      setInference,
+    ],
   );
 
   return <WorkspaceContext.Provider value={value}>{children}</WorkspaceContext.Provider>;

--- a/gui/e2e-playwright/specs/workspace-restore.spec.ts
+++ b/gui/e2e-playwright/specs/workspace-restore.spec.ts
@@ -1,0 +1,106 @@
+// [OPUS-4.8] sq-lcd6e — workspace RESTORE journey: imported data + editor text survive a reload.
+//
+// This is the regression test for the epic's data-loss bug (sq-2ucrz bug 1): the workspace model
+// persisted a `dataSnapshot` on every import, but the GUI NEVER restored it — the engine warm path
+// unconditionally seeded the sample graph, silently replacing a user's imported data on every
+// relaunch. This spec paste-imports a distinctive triple in REPLACE mode, reloads the page, and
+// asserts (a) the imported triple is still queryable and (b) the sample-graph-only data is gone.
+//
+// Persistence backend: on the served static export `loadTauriFs()` cannot import the (absent)
+// @tauri-apps/plugin-fs, so `createWorkspaceStore` resolves the WEB (localStorage) backend. The
+// Tauri IPC mock is still injected (isTauriRuntime() → true), so the paste import routes through
+// the mocked `load_text` command, which returns a deterministic imported triple.
+//
+// Determinism rules: NO waitForTimeout; NO exact numeric assertions; web-first assertions only.
+
+import { test, expect, waitForEngineReady } from "../support/index.ts";
+
+// The distinctive triple the mocked `load_text` command returns for ANY pasted document
+// (support/tauri-mock.ts → LOAD_FIXTURE). Its subject is the marker we query for after reload.
+const IMPORTED_SUBJECT = "http://example.org/imported";
+
+/**
+ * Set the SPARQL editor value via the native setter + input event (React-controlled textarea).
+ * Mirrors the helper in workbench-query.spec.ts.
+ */
+async function setEditorValue(
+  page: import("@playwright/test").Page,
+  value: string,
+): Promise<void> {
+  await page.evaluate((text) => {
+    const el = document.querySelector<HTMLTextAreaElement>("#repl-query");
+    if (!el) throw new Error("Editor textarea #repl-query not found");
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    if (!setter) throw new Error("Could not access native value setter");
+    setter.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }, value);
+}
+
+/** Run the current editor query and wait for a result of the given kind to render. */
+async function runQuery(
+  page: import("@playwright/test").Page,
+  kind: "ask" | "select" | "error",
+): Promise<void> {
+  await page.getByRole("button", { name: "Run query" }).click();
+  await expect(page.locator(`[data-result-kind="${kind}"]`)).toBeVisible();
+}
+
+test.describe("workspace-restore", () => {
+  test("imported data + editor text survive a page reload (no data loss)", async ({ page }) => {
+    // ── Pre-condition: the fresh default workspace seeded the sample graph (Alice present). ──────
+    await setEditorValue(page, 'PREFIX foaf: <http://xmlns.com/foaf/0.1/> ASK { ?s foaf:name "Alice" }');
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+
+    // ── Paste-import a distinctive triple in REPLACE mode. ───────────────────────────────────────
+    await page.locator('[data-import-trigger="topbar"]').click();
+    const drawer = page.locator("[data-import-drawer]");
+    await expect(drawer).toBeVisible();
+
+    await drawer.locator('[data-import-tab="paste"]').click();
+    await drawer
+      .locator("textarea")
+      .fill(`<${IMPORTED_SUBJECT}> <http://example.org/p> <http://example.org/o> .`);
+
+    // Replace the store (so the sample graph is gone) and import.
+    await drawer.getByRole("button", { name: "Replace store" }).click();
+    await drawer.getByRole("button", { name: /Import \(replace store\)/ }).click();
+
+    // The import succeeded (best-effort snapshot persisted to localStorage).
+    await expect(drawer.locator('[data-import-feedback="ok"]')).toBeVisible();
+
+    // Persist the editor text too: change the query, so the round-trip is exercised on reload.
+    await page.keyboard.press("Escape"); // close the drawer
+    await expect(drawer).toBeHidden();
+    const restoredQuery = `ASK { <${IMPORTED_SUBJECT}> ?p ?o }`;
+    await setEditorValue(page, restoredQuery);
+    // Give the debounced editor write-back time to flush by asserting the pre-reload result first.
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+
+    // ── RELOAD — the moment the old code silently replaced the imported data with the sample. ────
+    await page.reload();
+    await waitForEngineReady(page, { timeout: 90_000 });
+
+    // ── The imported triple is STILL there (restored from the snapshot, not the sample graph). ──
+    await setEditorValue(page, `ASK { <${IMPORTED_SUBJECT}> ?p ?o }`);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+
+    // ── The sample-graph-only data is GONE (the store was replaced, not merged over the sample). ─
+    await setEditorValue(page, 'PREFIX foaf: <http://xmlns.com/foaf/0.1/> ASK { ?s foaf:name "Alice" }');
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("false");
+  });
+
+  test("a fresh workspace with no prior data still seeds the sample graph", async ({ page }) => {
+    // Sanity: the seed-only-a-genuinely-fresh-workspace branch still gives a first-run user data.
+    await setEditorValue(page, 'PREFIX foaf: <http://xmlns.com/foaf/0.1/> ASK { ?s foaf:name "Alice" }');
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+  });
+});

--- a/gui/e2e-playwright/specs/workspace-restore.spec.ts
+++ b/gui/e2e-playwright/specs/workspace-restore.spec.ts
@@ -78,13 +78,39 @@ test.describe("workspace-restore", () => {
     await expect(drawer).toBeHidden();
     const restoredQuery = `ASK { <${IMPORTED_SUBJECT}> ?p ?o }`;
     await setEditorValue(page, restoredQuery);
-    // Give the debounced editor write-back time to flush by asserting the pre-reload result first.
-    await runQuery(page, "ask");
-    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+    // Deterministic flush: poll the persisted localStorage workspace record until it contains the
+    // new query text — guarantees the debounced editor write-back has committed before we reload.
+    // (Running a query alone is non-deterministic: the 400 ms debounce may not have flushed yet.)
+    await expect
+      .poll(
+        () =>
+          page.evaluate((q: string) => {
+            const prefix = "sparq.workspace.v1.";
+            for (let i = 0; i < localStorage.length; i++) {
+              const k = localStorage.key(i);
+              if (!k || !k.startsWith(prefix)) continue;
+              if (k.endsWith("__index__") || k.endsWith("__last__")) continue;
+              const val = localStorage.getItem(k);
+              if (!val) continue;
+              try {
+                const ws = JSON.parse(val) as { editor?: { query?: string } };
+                if (ws?.editor?.query === q) return true;
+              } catch {
+                /* skip corrupt entries */
+              }
+            }
+            return false;
+          }, restoredQuery),
+        { timeout: 5_000 },
+      )
+      .toBe(true);
 
     // ── RELOAD — the moment the old code silently replaced the imported data with the sample. ────
     await page.reload();
     await waitForEngineReady(page, { timeout: 90_000 });
+
+    // ── Editor text survived the reload: assert the restored value BEFORE any overwrite. ─────────
+    await expect(page.locator("#repl-query")).toHaveValue(restoredQuery);
 
     // ── The imported triple is STILL there (restored from the snapshot, not the sample graph). ──
     await setEditorValue(page, `ASK { <${IMPORTED_SUBJECT}> ?p ?o }`);


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated fix for the GUI consolidation epic (`sq-2ucrz`), bead `sq-lcd6e`. Opus 4.8.

## The bug (epic `sq-2ucrz`, maintainer bug 1 root cause)

The framework-agnostic workspace model (`@sparq/client` `workspace.ts`, sq-atb0) persisted a whole-dataset `dataSnapshot` on every import, but **the GUI never restored it**:

- `engine-context.tsx` warmed by **unconditionally seeding `SAMPLE_TURTLE`** (`grep dataSnapshot gui/app/src` found no consumer), and
- the persisted `workspace.editor.query` was never pushed into the Query tool.

So a user's imported data **and** editor text were silently replaced by the sample graph on **every relaunch** — real data loss.

## The fix — workspace restore + lifecycle plumbing

- **`engine-context.tsx`** — new `hydrateFromSnapshot(nquads | null, { seedSampleWhenEmpty })`: the single place the live store is (re)seeded. A non-empty snapshot rebuilds the store via `loadDataset(nquads)`; empty/`null` **+ the seed flag** seeds the sample graph for a *genuinely-fresh first-run default only*; empty/`null` **without** the flag keeps an explicitly-empty workspace empty. It bumps `storeEpoch` and drops the cached reasoning closure so an active inference regime **rematerialises over the restored data** (the sq-tp1m single-flight/epoch discipline), and it **queues** the request if it races the wasm cold-start. The warm path no longer seeds unconditionally.
- **`workspace-context.tsx`** — now the workspace⇄engine **hydration bridge** (it sits under `EngineProvider`, so it calls `useEngine()`). On mount it hydrates the engine from the restored workspace's snapshot; it also exposes the lifecycle APIs the switcher UI (`sq-lmlch`) consumes — `workspaces` (summaries), `createWorkspace`, `renameWorkspace`, `deleteWorkspace`, `switchWorkspace` (save current snapshot → load target → hydrate → re-apply inference) — plus `setEditorQuery` for the editor round-trip. Best-effort persistence throughout; **no secret persisted**.
- **`query-workbench.tsx`** — initialises the editor from `workspace.editor.query` and writes it back (debounced) so the saved editor text survives a reload/switch. A fresh workspace's starter query is the curated `DEFAULT_QUERY`.
- **NEW `gui/e2e-playwright/specs/workspace-restore.spec.ts`** — paste-imports a distinctive triple in **replace** mode → `page.reload()` → asserts the imported triple is **still queryable** and the **sample-graph-only data is gone**; plus a fresh-workspace-still-seeds-the-sample sanity test.

## Invariant

**No user data loss** — after import + page reload the store holds the imported quads (not the sample graph), the editor text survives, and the inference regime re-applies to the restored store. The sample graph seeds **only** a genuinely-fresh workspace. Both personas covered (Tauri fs / browser `localStorage`) — the existing persistence mechanism is kept; only the restore path is fixed.

## Verification (local)

- `npx playwright test specs/workspace-restore.spec.ts` — green
- full `gui/e2e-playwright` suite — **16/16 green** (no existing-test regressions)
- `gui/app` `npm run lint` + `npm run typecheck` — green
- both static-export targets (`build:tauri`, `build:web`) — build

> ⚠️ **Do not arm** — this is a data-loss surface; adversarial verify follows.

Sibling beads `sq-lmlch` (switcher UI) and `sq-glo5r` (N3 inference) are unblocked by this plumbing and share these context files.