### PR TITLE
feat(ci): wire per-merge incremental PKG ingest workflow (sq-tzars.4)

### DIFF
--- a/.github/workflows/pkg-ingest.yml
+++ b/.github/workflows/pkg-ingest.yml
@@ -1,0 +1,77 @@
+name: pkg-ingest
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'crates/sparq-kb/ingest/**'
+      - 'crates/sparq-kb/ontology/**'
+      - 'crates/sparq-kb/shapes/**'
+      - '.beads/**'
+      - 'skills/**'
+  workflow_dispatch: {}
+
+concurrency:
+  group: pkg-ingest
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  ingest:
+    name: pkg-ingest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.0.0
+        with:
+          python-version: '3.11'
+
+      - name: Run ingest
+        run: |
+          python3 crates/sparq-kb/ingest/ingest_pkg.py \
+              --beads .beads/issues.jsonl \
+              --skills-dir skills \
+              --findings-yamlld crates/sparq-kb/ingest/agents-findings.yaml.ld \
+              --out crates/sparq-kb/ingest/pkg-instances.ttl
+        shell: bash
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@1482605baf623a1be434c2297f1ccf42f4271c6c # master
+        with:
+          toolchain: stable
+
+      - name: Cache Rust
+        uses: Swatinem/rust-cache@82a92a6e8fbeee090b81b47073ec8925ba6ecf63 # v2.7.5
+
+      - name: Build validate-pkg
+        run: |
+          cargo build --bin validate-pkg --features validate -p sparq-kb --release
+        shell: bash
+
+      - name: Validate ingest against SHACL shapes
+        run: |
+          ./target/release/validate-pkg crates/sparq-kb/ingest/pkg-instances.ttl
+        shell: bash
+
+      - name: Upload quarantine sidecar
+        if: always()
+        uses: actions/upload-artifact@3cea5372237819ed907bc075d0a19be3688a5be3 # v4.0.0
+        with:
+          name: pkg-ingest-quarantine
+          path: crates/sparq-kb/ingest/pkg-instances.ttl.stale-edges.tsv
+          if-no-files-found: warn
+
+      - name: Upload ingested PKG
+        if: success()
+        uses: actions/upload-artifact@3cea5372237819ed907bc075d0a19be3688a5be3 # v4.0.0
+        with:
+          name: pkg-ingested
+          path: crates/sparq-kb/ingest/pkg-instances.ttl
+          if-no-files-found: error

--- a/crates/sparq-kb/Cargo.toml
+++ b/crates/sparq-kb/Cargo.toml
@@ -92,3 +92,8 @@ serde_json = { version = "1", optional = true }
 name = "pkg-query"
 path = "src/bin/pkg_query.rs"
 required-features = ["query"]
+
+[[bin]]
+name = "validate-pkg"
+path = "src/bin/validate_pkg.rs"
+required-features = ["validate"]

--- a/crates/sparq-kb/src/bin/validate_pkg.rs
+++ b/crates/sparq-kb/src/bin/validate_pkg.rs
@@ -11,50 +11,52 @@ use std::env;
 use std::fs;
 use std::process;
 
-#[cfg(not(feature = "validate"))]
 fn main() {
-    eprintln!("error: this binary requires the 'validate' feature");
-    process::exit(1);
-}
-
-#[cfg(feature = "validate")]
-fn main() {
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("usage: {} <ttl-file>", args.get(0).unwrap_or(&"validate-pkg".to_string()));
+    #[cfg(not(feature = "validate"))]
+    {
+        eprintln!("error: this binary requires the 'validate' feature");
         process::exit(1);
     }
 
-    let ttl_file = &args[1];
-    let content = match fs::read_to_string(ttl_file) {
-        Ok(c) => c,
-        Err(e) => {
-            eprintln!("error reading {}: {}", ttl_file, e);
+    #[cfg(feature = "validate")]
+    {
+        let args: Vec<String> = env::args().collect();
+        if args.len() < 2 {
+            eprintln!("usage: {} <ttl-file>", args.get(0).unwrap_or(&"validate-pkg".to_string()));
             process::exit(1);
         }
-    };
 
-    match sparq_kb::validate::validate_instances(&[&content]) {
-        Ok(report) => {
-            eprintln!(
-                "[validate-pkg] SHACL validation: {} violations (conforms={})",
-                report.results.len(),
-                report.conforms
-            );
-            if !report.results.is_empty() {
-                eprintln!("{}", report.to_text());
-            }
-            if report.conforms && report.results.is_empty() {
-                eprintln!("[validate-pkg] ✓ PKG instances conform to SHACL shapes");
-                process::exit(0);
-            } else {
-                eprintln!("[validate-pkg] ✗ PKG instances FAILED SHACL validation");
+        let ttl_file = &args[1];
+        let content = match fs::read_to_string(ttl_file) {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("error reading {}: {}", ttl_file, e);
                 process::exit(1);
             }
-        }
-        Err(e) => {
-            eprintln!("error validating {}: {}", ttl_file, e);
-            process::exit(1);
+        };
+
+        match sparq_kb::validate::validate_instances(&[&content]) {
+            Ok(report) => {
+                eprintln!(
+                    "[validate-pkg] SHACL validation: {} violations (conforms={})",
+                    report.results.len(),
+                    report.conforms
+                );
+                if !report.results.is_empty() {
+                    eprintln!("{}", report.to_text());
+                }
+                if report.conforms && report.results.is_empty() {
+                    eprintln!("[validate-pkg] ✓ PKG instances conform to SHACL shapes");
+                    process::exit(0);
+                } else {
+                    eprintln!("[validate-pkg] ✗ PKG instances FAILED SHACL validation");
+                    process::exit(1);
+                }
+            }
+            Err(e) => {
+                eprintln!("error validating {}: {}", ttl_file, e);
+                process::exit(1);
+            }
         }
     }
 }

--- a/crates/sparq-kb/src/bin/validate_pkg.rs
+++ b/crates/sparq-kb/src/bin/validate_pkg.rs
@@ -1,0 +1,60 @@
+//! Simple validation binary for PKG instances against SHACL shapes.
+//!
+//! Usage: cargo run --bin validate-pkg --features validate -- <ttl-file>
+//!
+//! Reads a Turtle file, validates it against the PKG SHACL shapes, and reports
+//! the validation result. Exits with 0 if valid, 1 if invalid.
+//!
+//! [HAIKU-4.5] sq-tzars.4 — PKG ingest workflow validation
+
+use std::env;
+use std::fs;
+use std::process;
+
+#[cfg(not(feature = "validate"))]
+fn main() {
+    eprintln!("error: this binary requires the 'validate' feature");
+    process::exit(1);
+}
+
+#[cfg(feature = "validate")]
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 2 {
+        eprintln!("usage: {} <ttl-file>", args.get(0).unwrap_or(&"validate-pkg".to_string()));
+        process::exit(1);
+    }
+
+    let ttl_file = &args[1];
+    let content = match fs::read_to_string(ttl_file) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("error reading {}: {}", ttl_file, e);
+            process::exit(1);
+        }
+    };
+
+    match sparq_kb::validate::validate_instances(&[&content]) {
+        Ok(report) => {
+            eprintln!(
+                "[validate-pkg] SHACL validation: {} violations (conforms={})",
+                report.results.len(),
+                report.conforms
+            );
+            if !report.results.is_empty() {
+                eprintln!("{}", report.to_text());
+            }
+            if report.conforms && report.results.is_empty() {
+                eprintln!("[validate-pkg] ✓ PKG instances conform to SHACL shapes");
+                process::exit(0);
+            } else {
+                eprintln!("[validate-pkg] ✗ PKG instances FAILED SHACL validation");
+                process::exit(1);
+            }
+        }
+        Err(e) => {
+            eprintln!("error validating {}: {}", ttl_file, e);
+            process::exit(1);
+        }
+    }
+}

--- a/crates/sparq-kb/src/bin/validate_pkg.rs
+++ b/crates/sparq-kb/src/bin/validate_pkg.rs
@@ -1,6 +1,6 @@
 //! Simple validation binary for PKG instances against SHACL shapes.
 //!
-//! Usage: cargo run --bin validate-pkg --features validate -- <ttl-file>
+//! Usage: `cargo run --bin validate-pkg --features validate -- <ttl-file>`
 //!
 //! Reads a Turtle file, validates it against the PKG SHACL shapes, and reports
 //! the validation result. Exits with 0 if valid, 1 if invalid.

--- a/crates/sparq-kb/src/bin/validate_pkg.rs
+++ b/crates/sparq-kb/src/bin/validate_pkg.rs
@@ -22,7 +22,7 @@ fn main() {
     {
         let args: Vec<String> = env::args().collect();
         if args.len() < 2 {
-            eprintln!("usage: {} <ttl-file>", args.get(0).unwrap_or(&"validate-pkg".to_string()));
+            eprintln!("usage: {} <ttl-file>", args.first().unwrap_or(&"validate-pkg".to_string()));
             process::exit(1);
         }
 


### PR DESCRIPTION
Adds .github/workflows/pkg-ingest.yml: triggers on push to main with
path-filter (KB-relevant inputs) + workflow_dispatch, runs the deterministic
ingest_pkg.py, validates output against SHACL shapes via new validate-pkg
binary, uploads quarantine sidecar + generated TTL as artifacts, fails
closed on nonconformance. Post-merge only (never gates PRs); concurrency
group prevents piling up.

Also adds crates/sparq-kb/src/bin/validate_pkg.rs (simple validator binary,
required-features=["validate"]) to support the workflow.

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>

## Implementation notes

**Mechanism:** Per-merge deterministic PKG regeneration + SHACL validation.
- The ingest script (crates/sparq-kb/ingest/ingest_pkg.py) is deterministic
  and full-regeneration (not delta-based). "Incremental" here means
  per-merge-trigger (post-main only), not one-time.
- Output TTL is validated against pkg.shapes.ttl via a new validate-pkg
  binary (crates/sparq-kb/src/bin/validate_pkg.rs, feature-gated on
  `validate`).
- SHACL conformance is fail-closed: any violation red-fails the job; the
  quarantine sidecar (.stale-edges.tsv) is always uploaded to show what was
  excluded by the script's guardrail.

**Gates:** actionlint clean; workflow compiles successfully; validate-pkg
binary runs + confirms SHACL shape conformance on the local test ingest.

**Post-merge only:** Workflow triggers on push to main (not PRs) and
workflow_dispatch. Path-filtered to KB-relevant inputs (ingest/, ontology/,
shapes/, .beads/, skills/). Not added to required PR gates (runs async after merge).

**Concurrency:** Single-slot concurrency group (cancel-in-progress: true)
prevents queuing during quick successive pushes.

## Artifacts

- **pkg-ingested:** the regenerated pkg-instances.ttl (success-only).
- **pkg-ingest-quarantine:** the stale-edges.tsv sidecar (always, even on
  failure — shows excluded edges the guardrail caught).

## Local validation

Command run locally to confirm the ingest + validation works:

\`\`\`bash
python3 crates/sparq-kb/ingest/ingest_pkg.py \\
    --beads .beads/issues.jsonl --skills-dir skills \\
    --findings-yamlld crates/sparq-kb/ingest/agents-findings.yaml.ld \\
    --out /tmp/test-pkg-instances.ttl

./target/release/validate-pkg /tmp/test-pkg-instances.ttl
# Output: [validate-pkg] ✓ PKG instances conform to SHACL shapes
\`\`\`

All steps executed successfully. SHACL validation passed with 0 violations.