### PR TITLE
feat(gui): wire the Graph View tool tab — working CONSTRUCT/DESCRIBE panel (sq-lxomy)

### DIFF
--- a/gui/app/src/components/workbench/graph-view-tool.tsx
+++ b/gui/app/src/components/workbench/graph-view-tool.tsx
@@ -1,21 +1,136 @@
 "use client";
 
-// [FABLE-5] sq-5lyme — the Graph-view tool's OWN panel file (tool-panel registry seam).
-// Today it renders the exact honest stub it always did; sq-lxomy fills it with the working
-// CONSTRUCT/DESCRIBE tab over the already-shipped GraphView component. When that lands, flip
-// the honesty metadata via GRAPH_VIEW_TOOL_OVERRIDE below — never by editing the shared
-// data/tools.ts — so parallel tool beads stay file-disjoint.
+// (sq-lxomy) [SONNET-4.6] — Graph-view TOOL tab: working CONSTRUCT/DESCRIBE panel over the live
+// store, using the already-shipped GraphView component (graph-view.tsx, sq-ixc3.12).
+//
+// The tool accepts any CONSTRUCT or DESCRIBE query typed in the compact textarea; the default is
+// CONSTRUCT WHERE { ?s ?p ?o } LIMIT 100, which renders the live store (whatever the user has
+// imported) as a node-link graph immediately on first Run. The result is fed directly to the
+// existing <GraphView> component — this file imports it but DOES NOT EDIT it.
+//
+// INVARIANT: renders REAL query results from the live store (never a canned figure). The
+// MAX_TRIPLES render cap is GraphView's own (and is labelled there — no perf claim here).
+//
+// OVERRIDE: flip tier/built/group via GRAPH_VIEW_TOOL_OVERRIDE — never by editing data/tools.ts.
 
-import { ToolStub } from "@/components/workbench/tool-stub";
+import * as React from "react";
+import { Play, Loader2, Network } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { useEngine, type QueryOutcome } from "@/lib/engine-context";
+import { GraphView } from "@/components/workbench/graph-view";
 import type { ToolOverride } from "@/data/tools";
+
+/** The default CONSTRUCT query the tool opens with — broad enough to show the sample graph. */
+const DEFAULT_CONSTRUCT = `CONSTRUCT WHERE { ?s ?p ?o } LIMIT 100`;
 
 /**
  * Optional honesty-metadata override merged over the base `ToolDef` (data/tools.ts) by the
- * tool-panel registry's `resolveTool` and by the stub itself. `undefined` = base metadata
- * unchanged. Omit fields you do not override.
+ * tool-panel registry's `resolveTool` and by the stub itself. Now that the working panel has
+ * landed, flip tier/built/group to reflect reality — never by editing the shared data/tools.ts.
  */
-export const GRAPH_VIEW_TOOL_OVERRIDE: ToolOverride | undefined = undefined;
+export const GRAPH_VIEW_TOOL_OVERRIDE: ToolOverride = {
+  tier: "live",
+  built: true,
+  group: "working",
+  blurb: "Node-link visualisation of CONSTRUCT/DESCRIBE results over the live store.",
+};
 
 export function GraphViewTool() {
-  return <ToolStub toolId="graph-view" override={GRAPH_VIEW_TOOL_OVERRIDE} />;
+  const { run, status } = useEngine();
+  const [query, setQuery] = React.useState(DEFAULT_CONSTRUCT);
+  const [running, setRunning] = React.useState(false);
+  const [outcome, setOutcome] = React.useState<QueryOutcome | null>(null);
+  const abortRef = React.useRef<AbortController | null>(null);
+
+  const onRun = React.useCallback(async () => {
+    // A run already in flight: ignore (no parallel runs for this tool).
+    if (abortRef.current) return;
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setRunning(true);
+    try {
+      const result = await run(query, { signal: controller.signal });
+      setOutcome(result.outcome);
+    } finally {
+      abortRef.current = null;
+      setRunning(false);
+    }
+  }, [run, query]);
+
+  const ready = status.kind === "ready";
+
+  return (
+    <div className="flex h-full flex-col" data-tool-panel="graph-view">
+      {/* Action row */}
+      <div className="flex items-center gap-2 border-b bg-card px-3 py-1.5">
+        <Network className="size-3.5 shrink-0 text-muted-foreground" />
+        <span className="text-xs font-medium text-muted-foreground">Graph view</span>
+        <Badge variant="outline" className="h-5 gap-1 text-[10px]" title="Where this query runs">
+          LOCAL · in-tab WASM
+        </Badge>
+        <div className="ml-auto flex items-center gap-1.5">
+          <Button
+            size="sm"
+            onClick={() => void onRun()}
+            disabled={!ready || running}
+            title="Run the CONSTRUCT or DESCRIBE over the live store"
+            data-graph-view-run
+          >
+            {running ? <Loader2 className="size-3.5 animate-spin" /> : <Play className="size-3.5" />}
+            Run
+          </Button>
+        </div>
+      </div>
+
+      {/* Compact query textarea */}
+      <div className="border-b bg-background px-3 py-2">
+        <textarea
+          id="graph-view-query"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          rows={3}
+          spellCheck={false}
+          className="w-full resize-y rounded border bg-muted/30 px-2 py-1.5 font-mono text-xs leading-relaxed focus:outline-none focus:ring-1 focus:ring-primary"
+          aria-label="CONSTRUCT or DESCRIBE query"
+          placeholder="CONSTRUCT WHERE { ?s ?p ?o } LIMIT 100"
+        />
+        <p className="mt-1 text-[11px] text-muted-foreground">
+          Enter a <code className="rounded bg-muted px-1 py-0.5">CONSTRUCT</code> or{" "}
+          <code className="rounded bg-muted px-1 py-0.5">DESCRIBE</code> query — the result is
+          rendered as a node-link graph over the live store.
+        </p>
+      </div>
+
+      {/* Result area */}
+      <div className="min-h-0 flex-1 overflow-auto" data-graph-view-result>
+        {outcome === null ? (
+          <p className="p-4 text-sm text-muted-foreground">
+            {ready
+              ? "Run a CONSTRUCT or DESCRIBE query to see the result as a node-link graph."
+              : "Waiting for the engine to warm…"}
+          </p>
+        ) : outcome.kind === "graph" ? (
+          <GraphView ntriples={outcome.ntriples} />
+        ) : outcome.kind === "error" ? (
+          <pre
+            className="overflow-auto whitespace-pre-wrap p-3 font-mono text-xs text-destructive"
+            data-result-kind="error"
+          >
+            {outcome.message}
+          </pre>
+        ) : outcome.kind === "cancelled" ? (
+          <p className="p-4 text-sm text-muted-foreground">Run stopped.</p>
+        ) : (
+          <p className="p-4 text-sm text-muted-foreground">
+            Use a{" "}
+            <code className="rounded bg-muted px-1 py-0.5">CONSTRUCT</code> or{" "}
+            <code className="rounded bg-muted px-1 py-0.5">DESCRIBE</code> query to generate a
+            graph result that can be visualised here.
+          </p>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/gui/e2e-playwright/specs/graph-view-tool.spec.ts
+++ b/gui/e2e-playwright/specs/graph-view-tool.spec.ts
@@ -1,0 +1,86 @@
+// (sq-lxomy) [SONNET-4.6] — graph-view-tool journey: open the tool, run the default CONSTRUCT
+// over the sample graph, assert SVG nodes/edges appear (non-vacuous: real rendered output).
+//
+// Tests run under the chromium-mock-ipc project (Tauri IPC mocked, desktop persona). A parallel
+// web-persona variant lives in graph-view-tool.web.spec.ts (chromium-web project, no Tauri mock).
+//
+// E2E contract (stable selectors — role/data-* only, never CSS classes):
+//   [data-tool="graph-view"]    — the left-rail button that opens the tool tab
+//   [data-tool-panel="graph-view"] — the panel root (graph-view-tool.tsx)
+//   #graph-view-query           — the CONSTRUCT/DESCRIBE query textarea
+//   button with text "Run"      — the run trigger (getByRole)
+//   [data-result-view="graph"]  — result container from GraphView (graph-view.tsx)
+//   [data-result-view="graph"] svg — the rendered SVG (present whenever triples > 0)
+//   [data-result-view="graph"] circle — IRI resource nodes
+//
+// Determinism rules: NO waitForTimeout; NO exact numeric assertions; web-first assertions only.
+
+import { test, expect } from "../support/index.ts";
+
+test.describe("graph-view-tool", () => {
+  // The tauriMock auto-fixture navigates to "/" and waits for engine ready before each test.
+
+  test("tool tab opens and shows the query textarea", async ({ page }) => {
+    // Open the Graph View tool from the left rail.
+    await page.locator('[data-tool="graph-view"]').click();
+
+    // The panel root renders.
+    const panel = page.locator('[data-tool-panel="graph-view"]');
+    await expect(panel).toBeVisible();
+
+    // The query textarea is present and contains the default CONSTRUCT.
+    const textarea = page.locator("#graph-view-query");
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveValue(/CONSTRUCT/i);
+  });
+
+  test("default CONSTRUCT over sample graph renders SVG nodes", async ({ page }) => {
+    // Open the Graph View tool.
+    await page.locator('[data-tool="graph-view"]').click();
+    await expect(page.locator('[data-tool-panel="graph-view"]')).toBeVisible();
+
+    // Run the default CONSTRUCT WHERE { ?s ?p ?o } LIMIT 100 over the seeded sample graph.
+    const runBtn = page.getByRole("button", { name: "Run" });
+    await expect(runBtn).toBeEnabled();
+    await runBtn.click();
+
+    // Wait for the GraphView result container to appear (data-result-view="graph" from graph-view.tsx).
+    const graphResult = page.locator('[data-result-view="graph"]');
+    await expect(graphResult).toBeVisible();
+
+    // Non-vacuous: the SVG renders — the sample graph has IRI resource nodes (rendered as
+    // <circle> elements) and literal value nodes (rendered as <rect> elements). Assert that at
+    // least one circle is present (Alice/Bob/Carol/Dan are all IRI subjects).
+    const svg = graphResult.locator("svg");
+    await expect(svg).toBeVisible();
+
+    // At least one IRI node (circle) must appear — the sample graph has ex:alice/bob/carol/dan.
+    const circles = graphResult.locator("circle");
+    await expect(circles.first()).toBeVisible();
+  });
+
+  test("error result on invalid SPARQL", async ({ page }) => {
+    await page.locator('[data-tool="graph-view"]').click();
+    await expect(page.locator('[data-tool-panel="graph-view"]')).toBeVisible();
+
+    // Replace the query with invalid SPARQL via the native setter (React-controlled textarea).
+    await page.evaluate(() => {
+      const el = document.querySelector<HTMLTextAreaElement>("#graph-view-query");
+      if (!el) throw new Error("graph-view-query textarea not found");
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      if (!setter) throw new Error("Could not access native value setter");
+      setter.call(el, "NOT VALID SPARQL AT ALL");
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+
+    const runBtn = page.getByRole("button", { name: "Run" });
+    await runBtn.click();
+
+    // The engine rejects the query and an error is shown.
+    const errorEl = page.locator('[data-result-kind="error"]');
+    await expect(errorEl).toBeVisible();
+  });
+});

--- a/gui/e2e-playwright/specs/graph-view-tool.web.spec.ts
+++ b/gui/e2e-playwright/specs/graph-view-tool.web.spec.ts
@@ -1,0 +1,58 @@
+// (sq-lxomy) [SONNET-4.6] — graph-view-tool web-persona variant: proves the Graph View tab WORKS
+// with NO Tauri backend (pure browser — the deployed /app code path).
+//
+// Runs under the chromium-web project (support/web-fixtures.ts): window.__TAURI__ /
+// __TAURI_INTERNALS__ are never installed, so isTauriRuntime() === false and the page takes the
+// pure-browser paths. The webPersona auto-fixture guarantees before the test body runs:
+//   * hermetic network (only 127.0.0.1 / localhost / blob: / data:),
+//   * Tauri globals genuinely absent,
+//   * the in-tab WASM engine reached "Engine ready" (browser-only boot).
+//
+// Stable selectors (same contract as graph-view-tool.spec.ts):
+//   [data-tool="graph-view"]      — the left-rail button
+//   [data-tool-panel="graph-view"] — the panel root
+//   #graph-view-query             — the CONSTRUCT/DESCRIBE query textarea
+//   button "Run"                  — the run trigger
+//   [data-result-view="graph"]    — result container from GraphView
+//   [data-result-view="graph"] circle — IRI resource nodes
+//
+// Determinism rules: NO waitForTimeout; NO exact numeric assertions; web-first assertions only.
+
+import { webTest as test, webExpect as expect } from "../support/index.ts";
+
+test.describe("graph-view-tool (web persona)", () => {
+  // The webPersona auto-fixture navigates to "/" and waits for engine ready before each test.
+
+  test("Graph View tab runs CONSTRUCT and renders SVG nodes in the browser persona", async ({
+    page,
+  }) => {
+    // Open the Graph View tool from the left rail — works identically in the browser persona.
+    await page.locator('[data-tool="graph-view"]').click();
+
+    const panel = page.locator('[data-tool-panel="graph-view"]');
+    await expect(panel).toBeVisible();
+
+    // The query textarea is present with the default CONSTRUCT.
+    const textarea = page.locator("#graph-view-query");
+    await expect(textarea).toBeVisible();
+    await expect(textarea).toHaveValue(/CONSTRUCT/i);
+
+    // Run the default CONSTRUCT over the in-tab WASM engine (no native backend — this is the
+    // core browser-persona assertion: the engine runs and returns a graph result).
+    const runBtn = page.getByRole("button", { name: "Run" });
+    await expect(runBtn).toBeEnabled();
+    await runBtn.click();
+
+    // Wait for the GraphView result container.
+    const graphResult = page.locator('[data-result-view="graph"]');
+    await expect(graphResult).toBeVisible();
+
+    // Non-vacuous: the SVG renders with real IRI resource nodes (circles). The sample graph
+    // has ex:alice/bob/carol/dan — all IRI subjects — so at least one circle MUST be present.
+    const svg = graphResult.locator("svg");
+    await expect(svg).toBeVisible();
+
+    const circles = graphResult.locator("circle");
+    await expect(circles.first()).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- **`graph-view-tool.tsx`** — fills the placeholder (sq-5lyme) with a working CONSTRUCT/DESCRIBE panel: compact query textarea (default: `CONSTRUCT WHERE { ?s ?p ?o } LIMIT 100`), a Run button wired to `useEngine().run()`, and the result fed directly to the existing `<GraphView>` component (sq-ixc3.12). No edits to `graph-view.tsx` or `query-workbench.tsx`.
- **`GRAPH_VIEW_TOOL_OVERRIDE`** — flips `tier → live`, `built → true`, `group → working` via the registry seam (sq-5lyme), so `data/tools.ts` is untouched.
- **`specs/graph-view-tool.spec.ts`** (chromium-mock-ipc) — opens the tool, runs the default CONSTRUCT over the seeded sample graph, asserts SVG `<circle>` nodes rendered (IRI resources — Alice/Bob/Carol/Dan); non-vacuous real-result check.
- **`specs/graph-view-tool.web.spec.ts`** (chromium-web) — same assertion in the browser persona (no Tauri mock), proving the tab works end-to-end without a native backend.

## Invariant

Renders REAL query results from the live store (never a canned figure). The `MAX_TRIPLES` render cap belongs to `GraphView` and is labelled there — no perf claim in this file.

## Test plan

- [x] `npm run build:web` green
- [x] `npm run build:tauri` green
- [x] `npx tsc --noEmit` clean
- [x] `npx next lint` — no warnings/errors
- [x] `npx playwright test specs/graph-view-tool.spec.ts` — 3/3 pass (mock-IPC lane)
- [x] `npx playwright test specs/graph-view-tool.web.spec.ts` — 1/1 pass (web-persona lane)
- [x] Full Playwright suite — 20/20 pass (no regressions)

---

> 🤖 SPARQ agent — bead sq-lxomy implemented by claude-sonnet-4-6. Maintainer can steer post-hoc via the bead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)