### PR TITLE
ci(selection): nightly change-based-selection bug alarm (sq-va7at)

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -522,6 +522,16 @@ jobs:
         run: python3 scripts/tests/test_path_ownership.py
       - name: Selection wiring inspection (fail-closed guards + real crate needles — sq-fmx4u.3)
         run: python3 scripts/tests/test_ci_select_wiring.py
+      # [OPUS-4.8] sq-va7at: the nightly selection-bug ALARM
+      # (scripts/ci_selection_alarm.py, .github/workflows/selection-alarm.yml,
+      # design §6.1). Hermetic stdlib-unittest suite (NO gh, NO git, NO cargo,
+      # NO network): the pure correlation core (precise per-crate hit, fail-safe
+      # triage for narrowed shards, the non-spam empty-skip-set property), the
+      # TRIAGE_LANE_RE pin against the real ci.yml shard job name, and the
+      # fail-loud exits (replay error / total blocker => non-zero). HARD (no
+      # "advisory" token): the detector's own logic must red CI if it regresses.
+      - name: Self-test the nightly selection-bug alarm (correlation + fail-loud — sq-va7at)
+        run: python3 scripts/tests/test_ci_selection_alarm.py
 
   # ----------------------------- ADVISORY -----------------------------
   markdownlint-advisory:

--- a/.github/workflows/selection-alarm.yml
+++ b/.github/workflows/selection-alarm.yml
@@ -1,0 +1,105 @@
+# selection-alarm — the nightly change-based-selection BUG ALARM (bead sq-va7at,
+# epic sq-fmx4u). [OPUS-4.8] Design: research/change-based-test-selection.md §6.1.
+#
+# WHAT: when the nightly FULL-matrix backstop (CI workflow, `schedule` =>
+# mode=full) FAILS, correlate each failed job's crate with the crates that
+# change-based selection (scripts/ci_select.py) SKIPPED in the PRs landed since
+# the last green nightly. Any intersection is prima-facie a selection soundness
+# bug (design §2) — scripts/ci_selection_alarm.py files a self-identified SPARQ
+# agent GitHub issue naming the offending job(s) + the suspect PRs. The
+# orchestrator reconciles those issues into P1 beads (we never touch `bd`/`.beads`
+# in CI — same rule as flow-on.yml).
+#
+# NOT A GATE (design §6.1 "fail-open"): this runs AFTER the nightly completes via
+# `workflow_run`, files issues, and blocks NO merge. Its name carries no
+# `advisory`/`informational` token, but it is not on the ci-summary gate's poll
+# set (that polls check-runs on the PR/merge-group head commit; this runs on a
+# past main nightly commit via workflow_run) so it can never affect a merge.
+#
+# FAIL-LOUD (design invariant, opposite of ci_select's fail-CLOSED): an
+# alarm-INFRASTRUCTURE error (cannot list the failed jobs / load cargo metadata /
+# replay a landed commit) makes the script exit NON-ZERO so THIS workflow run goes
+# RED and a human notices the detector is broken — masking a possible selection
+# bug is the one thing the alarm must never do. Redding this post-hoc run blocks
+# nothing.
+#
+# All actions are SHA-pinned (code-scanning / Scorecard posture). The script is
+# unit-tested hermetically by scripts/tests/test_ci_selection_alarm.py, run as a
+# gating step in docs-quality.yml.
+name: selection-alarm
+
+on:
+  # Fire after a CI run on MAIN completes; the job `if:` narrows to a FAILED
+  # nightly (schedule / manual dispatch). The `branches: [main]` filter keys on the
+  # TRIGGERING run's head branch, so a PR's CI completion (head branch = the PR
+  # branch) never fires this workflow — that guarantees selection-alarm produces
+  # NO check-run on any PR head commit and so can never interact with the
+  # `ci-summary / gate` poll set. workflow_run workflows execute from the
+  # default-branch copy of this file.
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
+  # Manual re-run of the correlation for a specific past run (validation / triage).
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "CI run id to correlate (the failed nightly run)"
+        required: true
+      head_sha:
+        description: "head SHA of that run"
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: selection-alarm-${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+  cancel-in-progress: false
+
+jobs:
+  alarm:
+    name: nightly selection-bug alarm
+    # workflow_dispatch: always run (operator asked). workflow_run: only a FAILED
+    # scheduled/dispatched nightly on main (a PR/push/merge_group run carries a diff
+    # => selection may narrow legitimately; only the full-matrix backstop is the
+    # oracle here).
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.workflow_run.conclusion == 'failure' &&
+       (github.event.workflow_run.event == 'schedule' ||
+        github.event.workflow_run.event == 'workflow_dispatch') &&
+       github.event.workflow_run.head_branch == 'main')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # list the failed run's jobs + look up the last green nightly
+      issues: write # file the alarm issue (idempotent, labelled)
+    steps:
+      # Full history so the per-commit selection replay (git diff <sha>^ <sha>) and
+      # the last-green-nightly window (git log base..HEAD) resolve.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          ref: ${{ github.event.workflow_run.head_sha || github.event.inputs.head_sha }}
+      # cargo metadata drives the member set + reverse-dependency closure the
+      # replay needs (scripts/ci_select.parse_workspace); no build, just metadata.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Correlate nightly failures with per-PR selection skips
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          CARGO_NET_RETRY: "10"
+          RUN_ID: ${{ github.event.workflow_run.id || github.event.inputs.run_id }}
+          HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.event.inputs.head_sha }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci_selection_alarm.py \
+            --run-id "$RUN_ID" \
+            --head-sha "$HEAD_SHA" \
+            --repo "$GITHUB_REPOSITORY"

--- a/scripts/ci_selection_alarm.py
+++ b/scripts/ci_selection_alarm.py
@@ -340,6 +340,16 @@ def gather_failed_jobs(run_id: str, repo: str) -> list[str]:
         name, _, conclusion = line.partition("\t")
         if conclusion.strip() in FAILED_CONCLUSIONS:
             failed.append(name)
+    # The workflow only fires on a failure-concluded run, so an empty failed-job
+    # set is always anomalous (jobs-API filter=latest re-run race, shape surprise,
+    # etc.).  Distinguish this from "no correlation found" to prevent silent exit 0
+    # masking a real failure.
+    if not failed:
+        raise AlarmError(
+            "gather_failed_jobs: empty failed-job set on a failure-concluded run "
+            f"(run_id={run_id}); jobs-API shape surprise or filter=latest re-run "
+            "race — cannot correlate, refusing to exit 0"
+        )
     return failed
 
 
@@ -353,7 +363,7 @@ def last_green_nightly_sha(repo: str, workflow_file: str, event: str) -> str | N
             f"?event={event}&status=success&per_page=1",
             "--jq", ".workflow_runs[0].head_sha // \"\"",
         ],
-        check=False,
+        check=True,
     )
     sha = out.strip()
     return sha or None
@@ -540,6 +550,16 @@ def run_alarm(args: argparse.Namespace) -> tuple[list[Finding], list[str], str]:
         if not repo:
             raise AlarmError("--repo (or $GITHUB_REPOSITORY) required for the gh path")
         failed_jobs = gather_failed_jobs(args.run_id, repo)
+    # The workflow only fires on a failure-concluded run, so an empty failed-job
+    # set (from either the file path or the gh path) is always anomalous — an
+    # empty correlation must be distinguishable from anomalous-empty to prevent a
+    # silent exit 0 masking a real failure.
+    if not failed_jobs:
+        raise AlarmError(
+            "run_alarm: empty failed-jobs set; workflow fires on failure-concluded "
+            "runs only, so this is anomalous (jobs-API shape surprise, re-run race, "
+            "or empty --failed-jobs-file). Refusing to exit 0."
+        )
 
     # cargo metadata (member set + reverse closure for the replay).
     meta = ci_select.load_metadata(args.metadata_file, repo_root)

--- a/scripts/ci_selection_alarm.py
+++ b/scripts/ci_selection_alarm.py
@@ -1,0 +1,630 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Nightly change-based-selection BUG ALARM (bead sq-va7at, epic
+# sq-fmx4u). Design: research/change-based-test-selection.md §6.1.
+# Authored by Opus 4.8 (running in place of the intended sonnet tier — Fable
+# unavailable). Flag for re-review when Fable returns.
+#
+# WHAT THIS IS (and is NOT):
+#   The correctness safeguard that closes the loop on change-based test selection
+#   (scripts/ci_select.py). The nightly FULL-matrix backstop (ci.yml `schedule`
+#   => mode=full) already RE-RUNS everything a PR may have selection-skipped; the
+#   `selection-backstop` job asserts that full-run invariant. What was MISSING is
+#   the correlation ALARM: when a scheduled nightly job FAILS and that same job's
+#   crate was selection-SKIPPED in one or more PRs that landed since the last
+#   GREEN nightly, that intersection is *prima-facie* evidence of a selection
+#   soundness bug (the non-interference proof in §2 was wrong — a change that
+#   "looked unaffected" actually broke the crate). This script computes that
+#   intersection and files a self-identified SPARQ-agent GitHub issue naming the
+#   offending job(s) + the suspect PRs.
+#
+#   It is a DETECTOR, never a gate: it runs AFTER a nightly completes (a
+#   `workflow_run` trigger, see .github/workflows/selection-alarm.yml), files
+#   issues, and never blocks a merge (design §6.1: "fail-open").
+#
+# TWO DESIGN INVARIANTS (both load-bearing):
+#   1. FAIL-SAFE / FAIL-LOUD (opposite of ci_select.py's fail-CLOSED). An
+#      alarm-INFRASTRUCTURE error (cannot list the failed jobs, cannot load cargo
+#      metadata, cannot replay a landed commit's selection) must NEVER be swallowed
+#      into a silent exit-0 — that would MASK a real selection bug. main() files
+#      every finding it COULD compute and then exits NON-ZERO with a loud
+#      `::error::` annotation, so the alarm workflow run goes RED and a human
+#      notices the detector itself is broken. Redding this post-hoc workflow blocks
+#      nothing (it is not a required check).
+#   2. NON-SPAMMY (dedupe). One issue per distinct failure<->skip mapping, keyed by
+#      a stable `<!-- selection-alarm-key: ... -->` marker; before filing we search
+#      OPEN labelled issues for that key and skip if one already exists (the exact
+#      flow-on idempotency mechanism). And the alarm fires ONLY when selection
+#      actually skipped something relevant: an empty skip-set in the window => no
+#      finding, because a nightly failure with nothing skipped cannot be a
+#      selection bug.
+#
+# WHY GIT-REPLAY (not a stored artifact) for "record per-PR selection decisions"
+# (design §6.1 item 1): scripts/ci_select.py is a PURE function of (diff, cargo
+# metadata, ownership map). The per-PR selection decision is therefore
+# RECONSTRUCTIBLE from git history — the most durable "record" there is (git
+# history outlives any artifact-retention window). For each landed commit we
+# replay `select(git-diff, metadata)` and take skipped = members - affected when
+# mode=='selected'. Using the CURRENT (HEAD) metadata is conservative: any member
+# added/removed in the window changed the root Cargo.toml, a §4.1 full-run trigger
+# => that commit replays mode=full => skipped=∅ => it cannot be a suspect anyway.
+#
+# WHY GITHUB ISSUES, NOT `bd create` (mirrors flow-on.py): CI has NO `bd` dolt DB
+# (it lives only in the orchestrator's gitignored checkout; hand-editing `.beads/`
+# is forbidden). So this script emits GitHub issues; the orchestrator reconciles
+# alarm issues into P1 beads out-of-band. The bead's "check bd before filing"
+# dedupe is satisfied at that reconciliation layer; in CI, dedupe is by open issue.
+#
+# Usage:
+#   ci_selection_alarm.py --run-id <id> --head-sha <sha>     # real (gh + git + cargo)
+#   ci_selection_alarm.py --run-id <id> --head-sha <sha> --dry-run   # no gh writes
+#   ci_selection_alarm.py --run-id <id> --head-sha <sha> \
+#       --failed-jobs-file jobs.txt --metadata-file meta.json        # hermetic inputs (tests)
+#
+# Stdlib only (design §7 P1): argparse/json/os/re/subprocess/importlib + the
+# shared scripts/ci_select.py (imported by path). Runs under the CI setup-python
+# 3.12.
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Labels every alarm issue carries (mirrors flow-on's `flow-on`+`auto`). The label
+# names carry NO `advisory`/`informational` token — irrelevant here (issues are
+# not check-runs) but kept clean for consistency.
+BASE_LABELS = ["selection-alarm", "auto"]
+
+# Idempotency marker embedded in each issue body (flow-on pattern).
+KEY_PREFIX = "selection-alarm-key"
+
+# Job conclusions that count as a "failed" nightly job.
+FAILED_CONCLUSIONS = {"failure", "timed_out"}
+
+# --- triage lanes (design §5.2 + the erratum) --------------------------------
+# The change-based selector skips two lane CLASSES per PR:
+#   (a) crate-NAMED lanes — feature-matrix legs `opt-in <crate> (...)`, per-crate
+#       wasm/other jobs — where the crate name appears in the JOB name, so a
+#       failed job maps PRECISELY to its crate by a delimited-token match; and
+#   (b) the cross-crate bulk/heavy nextest SHARDS `test (load-aware shard <name>)`,
+#       which are NARROWED per-PR by the nextest `filterset` (bulk) or a
+#       single-crate skip guard (heavy) — their JOB names ("bulk 1/3",
+#       "heavy-diskann") do NOT encode the failing crate.
+# A class-(b) shard failure is a REAL selection-skip signal we must not mask, but
+# we cannot name the crate from the job name alone. So a failed shard with no
+# extractable crate goes to the FAIL-SAFE TRIAGE path: one issue naming the
+# shard(s) + the whole skipped set in the window, for a human to narrow from the
+# shard log. Everything ELSE that is unmappable (coverage/select/backstop/docs/
+# supply-chain jobs — not per-crate test lanes) is NOT triage-eligible, so an
+# infra-lane failure never mints a spurious selection alarm.
+# scripts/tests/test_ci_selection_alarm.py pins this regex against the real
+# ci.yml shard job name (`test (load-aware shard ${{ matrix.name }})`).
+TRIAGE_LANE_RE = re.compile(r"^test \(load-aware shard ")
+
+
+class AlarmError(Exception):
+    """An alarm-INFRASTRUCTURE failure. main() surfaces it LOUD (non-zero exit)."""
+
+
+# --------------------------------------------------------------------------- #
+# Shared selector (imported by path — scripts/ is not an importable package)
+# --------------------------------------------------------------------------- #
+def _load_ci_select():
+    spec = importlib.util.spec_from_file_location(
+        "ci_select", REPO_ROOT / "scripts" / "ci_select.py"
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    # Register before exec so ci_select's dataclass string annotations
+    # (from __future__ import annotations) resolve via sys.modules.
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# Data model
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class WindowCommit:
+    """A landed commit in the (last-green-nightly, HEAD] window and the crate set
+    its PR selection-SKIPPED (empty when it ran mode=full)."""
+
+    sha: str
+    pr: int | None
+    skipped: frozenset[str]
+
+
+@dataclass
+class Finding:
+    """One distinct failure<->skip mapping to file as an issue."""
+
+    kind: str  # "crate" (precise) | "triage" (unmappable shard)
+    key: str  # stable dedup key (embedded in the body marker)
+    crate: str | None  # precise: the offending crate; triage: None
+    failed_jobs: list[str]  # failed job(s) implicating this mapping
+    suspect_prs: list[WindowCommit]  # landed PRs whose skip-set implicates this
+
+
+# --------------------------------------------------------------------------- #
+# Pure correlation core (hermetic-testable — no gh / git / cargo)
+# --------------------------------------------------------------------------- #
+def job_crate_tokens(job_name: str, members: set[str]) -> set[str]:
+    """Workspace-member crate names that appear as DELIMITED tokens in a job name.
+
+    Delimited = bounded on each side by a non `[A-Za-z0-9_-]` char (or a string
+    boundary), so `sparq-core` matches inside `opt-in sparq-core (mmap)` but NOT
+    inside `sparq-core-foo`, and `sparq-vec` does not match inside
+    `sparq-vectors`. Usually 0 or 1 member; a job that names several crates
+    implicates all of them (conservative)."""
+    found: set[str] = set()
+    for m in members:
+        if re.search(rf"(?<![A-Za-z0-9_-]){re.escape(m)}(?![A-Za-z0-9_-])", job_name):
+            found.add(m)
+    return found
+
+
+def correlate(
+    failed_jobs: list[str],
+    window: list[WindowCommit],
+    members: set[str],
+) -> list[Finding]:
+    """Intersect the failed nightly jobs with the per-PR selection skips.
+
+    Precise: for a failed job that names crate C AND C was skipped by some landed
+    PR => a `crate` finding for C (its suspect PRs = the PRs that skipped C).
+    Triage: a failed TRIAGE-LANE shard with no extractable crate, when ANYTHING
+    was skipped in the window => one `triage` finding naming those shards + every
+    PR that skipped anything. Fires only where selection actually skipped
+    something relevant (design non-spam property)."""
+    # crate -> [commits that skipped it]
+    skip_to_prs: dict[str, list[WindowCommit]] = {}
+    for wc in window:
+        for c in wc.skipped:
+            skip_to_prs.setdefault(c, []).append(wc)
+    skipped_union = set(skip_to_prs)
+
+    findings: list[Finding] = []
+
+    # --- precise per-crate findings ---
+    crate_jobs: dict[str, list[str]] = {}
+    unmappable_triage_jobs: list[str] = []
+    for job in failed_jobs:
+        tokens = job_crate_tokens(job, members)
+        implicated = tokens & skipped_union
+        if implicated:
+            for c in implicated:
+                crate_jobs.setdefault(c, []).append(job)
+        elif not tokens and TRIAGE_LANE_RE.match(job):
+            # A narrowed shard with no crate in its name AND not resolved to a
+            # skipped crate => fail-safe triage candidate.
+            unmappable_triage_jobs.append(job)
+        # else: a crate-named job whose crate was NOT skipped (its own tests ran
+        # per-PR — not a selection bug), or a non-test infra lane => ignored.
+
+    for crate in sorted(crate_jobs):
+        findings.append(
+            Finding(
+                kind="crate",
+                key=f"crate:{crate}",
+                crate=crate,
+                failed_jobs=sorted(set(crate_jobs[crate])),
+                suspect_prs=skip_to_prs[crate],
+            )
+        )
+
+    # --- fail-safe triage finding ---
+    if unmappable_triage_jobs and skipped_union:
+        jobs_sorted = sorted(set(unmappable_triage_jobs))
+        # Suspect PRs = every landed PR that skipped ANY crate (we cannot narrow
+        # which crate the generic shard's failure came from).
+        suspects = [wc for wc in window if wc.skipped]
+        findings.append(
+            Finding(
+                kind="triage",
+                key="triage:" + "|".join(jobs_sorted),
+                crate=None,
+                failed_jobs=jobs_sorted,
+                suspect_prs=suspects,
+            )
+        )
+    return findings
+
+
+# --------------------------------------------------------------------------- #
+# Issue rendering
+# --------------------------------------------------------------------------- #
+def _pr_ref(wc: WindowCommit) -> str:
+    return f"#{wc.pr}" if wc.pr is not None else f"`{wc.sha[:12]}`"
+
+
+def key_marker(key: str) -> str:
+    return f"<!-- {KEY_PREFIX}: {key} -->"
+
+
+def render_issue(f: Finding, run_id: str, head_sha: str, repo: str | None) -> tuple[str, str]:
+    """Return (title, body) for a finding."""
+    run_url = (
+        f"https://github.com/{repo}/actions/runs/{run_id}" if repo else f"run {run_id}"
+    )
+    if f.kind == "crate":
+        title = (
+            f"[selection-alarm] crate `{f.crate}` failed the nightly full-matrix "
+            f"but was selection-skipped in landed PR(s)"
+        )
+        lead = (
+            f"The nightly FULL-matrix backstop failed a job for crate "
+            f"**`{f.crate}`**, and that crate was **selection-skipped** in one or "
+            f"more PRs that landed since the last green nightly. Per the skip "
+            f"invariant (research/change-based-test-selection.md §2) a test is "
+            f"skipped only if *provably* no change could affect it — so this "
+            f"intersection is prima-facie evidence the non-interference proof was "
+            f"wrong for `{f.crate}`."
+        )
+    else:
+        title = (
+            "[selection-alarm] nightly full-matrix shard failure needs crate-triage "
+            "(change-based selection active in window)"
+        )
+        lead = (
+            "The nightly FULL-matrix backstop failed a cross-crate/narrowed test "
+            "shard whose job name does not encode the failing crate, and "
+            "change-based selection NARROWED that shard (dropped some crates) in "
+            "PRs that landed since the last green nightly. The failing crate cannot "
+            "be named from the job alone — read the shard log below to identify it, "
+            "then check whether it was among the skipped crates listed."
+        )
+
+    prs = "\n".join(
+        f"- {_pr_ref(wc)} (`{wc.sha[:12]}`)"
+        + (f" — skipped: {', '.join(sorted(wc.skipped))}" if f.kind == "triage" else "")
+        for wc in f.suspect_prs
+    )
+    jobs = "\n".join(f"- `{j}`" for j in f.failed_jobs)
+    body = (
+        f"{lead}\n\n"
+        f"**Failed nightly job(s):**\n{jobs}\n\n"
+        f"**Suspect landed PR(s)** (selection-skipped since last green nightly):\n"
+        f"{prs}\n\n"
+        f"**Nightly run:** {run_url} (head `{head_sha[:12]}`)\n\n"
+        f"This is a DETECTOR signal, not a proof: a nightly failure can also be a "
+        f"flake or an unrelated regression. Verify against the run log before "
+        f"concluding a selection bug — but if it IS one, the selector's ownership "
+        f"map / reverse-closure (scripts/ci_select.py, ci/path-ownership.toml) let "
+        f"`{f.crate or 'the crate'}` be skipped when it should not have been; fix "
+        f"that and add a golden test.\n\n"
+        f"{key_marker(f.key)}\n\n"
+        f"> \U0001f916 SPARQ agent — auto-filed by the change-based-selection "
+        f"nightly alarm (scripts/ci_selection_alarm.py, bead sq-va7at). Reconcile "
+        f"into a **P1** bead. [OPUS-4.8]"
+    )
+    return title, body
+
+
+# --------------------------------------------------------------------------- #
+# gh / git / cargo I/O (real, non-hermetic)
+# --------------------------------------------------------------------------- #
+def _run(cmd: list[str], cwd: str | None = None, check: bool = True) -> str:
+    try:
+        proc = subprocess.run(
+            cmd, cwd=cwd, capture_output=True, text=True, check=check, timeout=300
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        stderr = getattr(exc, "stderr", "") or ""
+        raise AlarmError(f"command failed: {' '.join(cmd)}: {exc}\n{stderr}") from exc
+    return proc.stdout
+
+
+def gather_failed_jobs(run_id: str, repo: str) -> list[str]:
+    """Names of the nightly run's jobs whose conclusion is a failure (design: the
+    failed-job set to correlate). Uses `gh api --paginate` over the run's jobs."""
+    out = _run(
+        [
+            "gh", "api", "--paginate",
+            f"repos/{repo}/actions/runs/{run_id}/jobs",
+            "--jq", ".jobs[] | [.name, (.conclusion // \"\")] | @tsv",
+        ]
+    )
+    failed: list[str] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        name, _, conclusion = line.partition("\t")
+        if conclusion.strip() in FAILED_CONCLUSIONS:
+            failed.append(name)
+    return failed
+
+
+def last_green_nightly_sha(repo: str, workflow_file: str, event: str) -> str | None:
+    """head_sha of the most recent SUCCESSFUL run of `workflow_file` for `event`
+    (the last green nightly). None if there is no prior green run."""
+    out = _run(
+        [
+            "gh", "api",
+            f"repos/{repo}/actions/workflows/{workflow_file}/runs"
+            f"?event={event}&status=success&per_page=1",
+            "--jq", ".workflow_runs[0].head_sha // \"\"",
+        ],
+        check=False,
+    )
+    sha = out.strip()
+    return sha or None
+
+
+_PR_RE = re.compile(r"\(#(\d+)\)\s*$")
+
+
+def window_commits(
+    base_sha: str | None, head_sha: str, lookback_hours: int, repo_root: str
+) -> list[tuple[str, int | None]]:
+    """(sha, pr_number) for each landed commit in the window, newest first.
+
+    Window = (last-green-nightly, HEAD] when base_sha is known; otherwise a
+    time-bounded fallback (`--since`) so a cold start (no prior green nightly) is
+    handled without a spurious loud failure."""
+    if base_sha:
+        rng = [f"{base_sha}..{head_sha}"]
+    else:
+        rng = [head_sha, f"--since={lookback_hours} hours ago"]
+    out = _run(
+        ["git", "log", "--no-merges", "--format=%H%x00%s", *rng],
+        cwd=repo_root,
+    )
+    commits: list[tuple[str, int | None]] = []
+    for line in out.splitlines():
+        if not line.strip():
+            continue
+        sha, _, subject = line.partition("\x00")
+        m = _PR_RE.search(subject)
+        commits.append((sha.strip(), int(m.group(1)) if m else None))
+    return commits
+
+
+def commit_changed_paths(sha: str, repo_root: str) -> list[str]:
+    """Paths a landed commit changed = `git diff --no-renames <sha>^ <sha>` (the
+    PR's net diff on a squash-merged linear main; matches ci_select's --no-renames
+    conservatism)."""
+    out = _run(
+        ["git", "diff", "--name-only", "--no-renames", f"{sha}^", sha],
+        cwd=repo_root,
+    )
+    return [ln for ln in out.splitlines() if ln.strip()]
+
+
+def build_window(
+    commits: list[tuple[str, int | None]], meta: dict, map_entries: list[dict],
+    ci_select, repo_root: str,
+) -> tuple[list[WindowCommit], set[str], list[str]]:
+    """Replay the selection decision for each landed commit. Returns
+    (window, members, replay_errors). A replay error is collected (not swallowed)
+    so main() can fail LOUD while still filing the findings it could compute."""
+    ws = ci_select.parse_workspace(meta)
+    members = set(ws.members)
+    window: list[WindowCommit] = []
+    replay_errors: list[str] = []
+    for sha, pr in commits:
+        try:
+            changed = commit_changed_paths(sha, repo_root)
+            sel = ci_select.select(changed, meta, map_entries)
+            skipped = (
+                frozenset(members - set(sel.affected))
+                if sel.mode == "selected"
+                else frozenset()
+            )
+        except Exception as exc:  # noqa: BLE001 — collect, don't mask (fail-loud later)
+            replay_errors.append(f"{sha[:12]}: {exc}")
+            continue
+        window.append(WindowCommit(sha=sha, pr=pr, skipped=skipped))
+    return window, members, replay_errors
+
+
+# --------------------------------------------------------------------------- #
+# Issue minting (mirror flow-on's CI guard + idempotency + label upsert)
+# --------------------------------------------------------------------------- #
+CI_ENV_VARS = ("GITHUB_ACTIONS", "CI")
+ALLOW_LOCAL_ENV_VAR = "SELECTION_ALARM_ALLOW_LOCAL"
+
+
+def _is_truthy(val: str | None) -> bool:
+    return val is not None and val.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def require_ci(env: dict[str, str] | None = None) -> None:
+    e = os.environ if env is None else env
+    if any(_is_truthy(e.get(v)) for v in CI_ENV_VARS) or _is_truthy(e.get(ALLOW_LOCAL_ENV_VAR)):
+        return
+    raise AlarmError(
+        "refusing to file GitHub issues outside CI (no GITHUB_ACTIONS / CI env "
+        f"set). Use --dry-run to preview, or set {ALLOW_LOCAL_ENV_VAR}=1 to force."
+    )
+
+
+_ENSURED_LABELS: set[str] = set()
+
+
+def ensure_label(label: str) -> None:
+    if label in _ENSURED_LABELS:
+        return
+    try:
+        _run(["gh", "label", "create", label, "--force"], check=True)
+    except AlarmError:
+        pass  # best-effort upsert; create_issue surfaces a genuine failure
+    _ENSURED_LABELS.add(label)
+
+
+def open_issue_exists(key: str, repo: str) -> bool:
+    # Idempotency: list ALL open selection-alarm issues and EXACT-match the body
+    # marker. We deliberately do NOT pass `--search` — a triage key contains
+    # punctuation (parens/slashes) that gh's search tokeniser handles unreliably,
+    # which could MISS an existing issue and break dedupe (mint a duplicate). The
+    # deduped label keeps the open set tiny, so listing 100 is cheap.
+    marker = key_marker(key)
+    out = _run(
+        [
+            "gh", "issue", "list", "--repo", repo, "--state", "open",
+            "--label", "selection-alarm", "--json", "number,body", "--limit", "100",
+        ],
+        check=False,
+    )
+    try:
+        issues = json.loads(out or "[]")
+    except json.JSONDecodeError:
+        return False
+    return any(marker in (i.get("body") or "") for i in issues)
+
+
+def create_issue(title: str, body: str, labels: list[str], repo: str) -> str:
+    args = ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body]
+    for lbl in labels:
+        ensure_label(lbl)
+        args += ["--label", lbl]
+    return _run(args).strip()
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Nightly change-based-selection bug alarm (design §6.1)."
+    )
+    p.add_argument("--run-id", required=True, help="the failed nightly CI run id")
+    p.add_argument("--head-sha", required=True, help="the nightly run's head SHA")
+    p.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY"),
+                   help="owner/name (default $GITHUB_REPOSITORY)")
+    p.add_argument("--event", default="schedule",
+                   help="the nightly trigger event to look up the last green run by")
+    p.add_argument("--workflow-file", default="ci.yml",
+                   help="workflow file whose last green run bounds the window")
+    p.add_argument("--lookback-hours", type=int, default=25,
+                   help="cold-start fallback window when no prior green nightly exists")
+    p.add_argument("--repo-root", help="repo root (default: git toplevel)")
+    p.add_argument("--dry-run", action="store_true", help="print findings; no gh writes")
+    # Hermetic inputs (tests / offline):
+    p.add_argument("--failed-jobs-file", help="hermetic: one failed job name per line")
+    p.add_argument("--metadata-file", help="hermetic: cargo metadata JSON snapshot")
+    return p.parse_args(argv)
+
+
+def _resolve_repo_root(explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    try:
+        return _run(["git", "rev-parse", "--show-toplevel"]).strip()
+    except AlarmError:
+        return str(REPO_ROOT)
+
+
+def run_alarm(args: argparse.Namespace) -> tuple[list[Finding], list[str], str]:
+    """Gather inputs, replay the window, correlate. Returns
+    (findings, replay_errors, repo). Raises AlarmError on a TOTAL blocker."""
+    ci_select = _load_ci_select()
+    repo = args.repo or ""
+    repo_root = _resolve_repo_root(args.repo_root)
+
+    # Failed jobs — hermetic file or gh.
+    if args.failed_jobs_file:
+        failed_jobs = [
+            ln.strip() for ln in Path(args.failed_jobs_file).read_text().splitlines()
+            if ln.strip()
+        ]
+    else:
+        if not repo:
+            raise AlarmError("--repo (or $GITHUB_REPOSITORY) required for the gh path")
+        failed_jobs = gather_failed_jobs(args.run_id, repo)
+
+    # cargo metadata (member set + reverse closure for the replay).
+    meta = ci_select.load_metadata(args.metadata_file, repo_root)
+    map_file = os.path.join(repo_root, "ci", "path-ownership.toml")
+    map_entries = ci_select.load_ownership_map(
+        map_file if os.path.exists(map_file) else None
+    )
+
+    # Window of landed commits since the last green nightly (or time fallback).
+    base = None if args.failed_jobs_file else last_green_nightly_sha(
+        repo, args.workflow_file, args.event
+    )
+    if base is None and not args.failed_jobs_file:
+        print("::notice::selection-alarm: no prior green nightly found; using "
+              f"{args.lookback_hours}h cold-start fallback window")
+    commits = window_commits(base, args.head_sha, args.lookback_hours, repo_root)
+    window, members, replay_errors = build_window(
+        commits, meta, map_entries, ci_select, repo_root
+    )
+
+    findings = correlate(failed_jobs, window, members)
+    return findings, replay_errors, repo
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        findings, replay_errors, repo = run_alarm(args)
+    except AlarmError as exc:
+        # FAIL-LOUD (invariant 1): a total blocker must red the run, never exit 0.
+        print(f"::error::selection-alarm infrastructure error: {exc}", file=sys.stderr)
+        return 1
+
+    if not findings:
+        print("selection-alarm: no nightly failure correlates with a selection "
+              "skip in the window — no alarm.")
+    else:
+        if not args.dry_run:
+            require_ci_error = None
+            try:
+                require_ci()
+            except AlarmError as exc:
+                require_ci_error = exc
+            if require_ci_error is not None:
+                print(f"::error::{require_ci_error}", file=sys.stderr)
+                return 1
+        filed = skipped = 0
+        for f in findings:
+            title, body = render_issue(f, args.run_id, args.head_sha, repo or None)
+            if args.dry_run:
+                print(f"[dry-run] WOULD file (kind={f.kind}, key={f.key}):")
+                print(f"          title: {title}")
+                print(f"          jobs : {', '.join(f.failed_jobs)}")
+                print(f"          PRs  : {', '.join(_pr_ref(wc) for wc in f.suspect_prs)}")
+                continue
+            if open_issue_exists(f.key, repo):
+                print(f"selection-alarm: skip (open issue exists) key={f.key}")
+                skipped += 1
+                continue
+            url = create_issue(title, body, list(dict.fromkeys(BASE_LABELS)), repo)
+            print(f"selection-alarm: filed {url} (kind={f.kind}, key={f.key})")
+            filed += 1
+        if not args.dry_run:
+            print(f"selection-alarm: done — {filed} filed, {skipped} already open.")
+            summary = os.environ.get("GITHUB_STEP_SUMMARY")
+            if summary:
+                try:
+                    with open(summary, "a") as fh:
+                        fh.write(f"### selection-alarm\n\n- filed: {filed}\n"
+                                 f"- skipped (already open): {skipped}\n")
+                except OSError:
+                    pass
+
+    # FAIL-LOUD (invariant 1): findings we COULD compute are filed above; if any
+    # landed commit could not be replayed, red the run so the gap is investigated.
+    if replay_errors:
+        print("::error::selection-alarm: could not replay selection for "
+              f"{len(replay_errors)} landed commit(s) — the correlation window is "
+              "INCOMPLETE and a real selection bug may be unreported:",
+              file=sys.stderr)
+        for e in replay_errors:
+            print(f"::error::  {e}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/test_ci_selection_alarm.py
+++ b/scripts/tests/test_ci_selection_alarm.py
@@ -226,6 +226,25 @@ class TestCliFailLoud(unittest.TestCase):
                 ])
             self.assertEqual(rc, 1)
 
+    def test_empty_failed_jobs_file_exits_nonzero(self):
+        # An empty --failed-jobs-file on a failure-concluded run is anomalous
+        # (jobs-API filter=latest re-run race or shape surprise) — must exit
+        # NON-ZERO, not silently "no alarm" exit 0.  Covers the fix at the
+        # run_alarm call site (sq-va7at reviewer concern 1).
+        mod = _load_module()
+        with tempfile.TemporaryDirectory() as d:
+            meta_f = Path(d) / "meta.json"
+            meta_f.write_text(json.dumps(self._meta()))
+            jobs_f = Path(d) / "jobs.txt"
+            jobs_f.write_text("")  # empty — simulates API race / shape surprise
+            rc = mod.main([
+                "--run-id", "1", "--head-sha", "f" * 40, "--repo", "o/r",
+                "--repo-root", d, "--failed-jobs-file", str(jobs_f),
+                "--metadata-file", str(meta_f), "--dry-run",
+            ])
+            self.assertEqual(rc, 1,
+                             "empty failed-jobs on failure-concluded run must exit non-zero")
+
     def test_dry_run_reports_finding_without_gh(self):
         # End-to-end via the CLI dry-run path (no gh writes), exercising the REAL
         # ci_select replay. The landed commit touches only crates/sparq-geo/src

--- a/scripts/tests/test_ci_selection_alarm.py
+++ b/scripts/tests/test_ci_selection_alarm.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] Hermetic unit tests for the nightly change-based-selection bug ALARM
+# (bead sq-va7at, epic sq-fmx4u). Design: research/change-based-test-selection.md
+# §6.1. Authored by Opus 4.8 (Fable unavailable; flag for re-review when Fable
+# returns).
+#
+# Covers the alarm's load-bearing behaviours:
+#   * job_crate_tokens: delimited-token match (no substring collisions).
+#   * correlate: precise per-crate finding, triage finding for narrowed shards,
+#     the non-spam property (empty skip-set => no finding), and that a crate whose
+#     tests actually RAN in the window is NOT flagged.
+#   * TRIAGE_LANE_RE matches the REAL ci.yml shard job name.
+#   * fail-loud: replay errors AND a total blocker both exit NON-ZERO.
+#   * idempotency-key stability + the dry-run path (no gh calls).
+#
+# Fully hermetic: no gh, no git, no cargo, no network. Correlation is a pure
+# function; the CLI is exercised via --failed-jobs-file + --metadata-file +
+# --dry-run and a monkeypatched git-log/diff.
+#
+# Run:  python3 scripts/tests/test_ci_selection_alarm.py   (stdlib only)
+
+from __future__ import annotations
+
+import importlib.util
+import io
+import json
+import os
+import re
+import sys
+import tempfile
+import unittest
+from contextlib import redirect_stdout
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+ALARM = REPO_ROOT / "scripts" / "ci_selection_alarm.py"
+CI_YML = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("ci_selection_alarm", ALARM)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["ci_selection_alarm"] = mod  # resolve dataclass string annotations
+    spec.loader.exec_module(mod)
+    return mod
+
+
+A = _load_module()
+
+MEMBERS = {"sparq-core", "sparq-engine", "sparq-vectors", "sparq-geo", "sparq-rsp"}
+
+
+def _wc(sha: str, pr: int | None, skipped: set[str]) -> "A.WindowCommit":
+    return A.WindowCommit(sha=sha, pr=pr, skipped=frozenset(skipped))
+
+
+class TestJobCrateTokens(unittest.TestCase):
+    def test_feature_matrix_leg_names_its_crate(self):
+        self.assertEqual(
+            A.job_crate_tokens("opt-in sparq-engine (zk)", MEMBERS), {"sparq-engine"}
+        )
+
+    def test_no_substring_collision(self):
+        # `sparq-core` must NOT match inside a longer hyphenated token.
+        self.assertEqual(A.job_crate_tokens("build sparq-core-foo bundle", MEMBERS), set())
+        # `sparq-vec` (not a member) present-as-prefix must not yield sparq-vectors,
+        # and sparq-vectors delimited DOES match.
+        self.assertEqual(
+            A.job_crate_tokens("test sparq-vectors recall", MEMBERS), {"sparq-vectors"}
+        )
+
+    def test_generic_shard_names_no_crate(self):
+        for name in ("test (load-aware shard bulk 1/3)",
+                     "test (load-aware shard heavy-diskann)",
+                     "coverage (nightly, full incl. heavy vectors)"):
+            self.assertEqual(A.job_crate_tokens(name, MEMBERS), set(), name)
+
+    def test_multiple_crates_all_implicated(self):
+        self.assertEqual(
+            A.job_crate_tokens("wasm (sparq-core, sparq-engine)", MEMBERS),
+            {"sparq-core", "sparq-engine"},
+        )
+
+
+class TestCorrelate(unittest.TestCase):
+    def test_precise_hit(self):
+        # sparq-geo failed a named leg AND was skipped by PR #10 => precise finding.
+        window = [_wc("a" * 40, 10, {"sparq-geo"}), _wc("b" * 40, 11, set())]
+        findings = A.correlate(["opt-in sparq-geo (geosparql)"], window, MEMBERS)
+        self.assertEqual(len(findings), 1)
+        f = findings[0]
+        self.assertEqual((f.kind, f.crate, f.key), ("crate", "sparq-geo", "crate:sparq-geo"))
+        self.assertEqual(f.failed_jobs, ["opt-in sparq-geo (geosparql)"])
+        self.assertEqual([wc.pr for wc in f.suspect_prs], [10])
+
+    def test_named_job_but_crate_not_skipped_is_ignored(self):
+        # sparq-geo failed but was NOT skipped anywhere => its own tests ran per-PR,
+        # so it is NOT a selection bug. No finding.
+        window = [_wc("a" * 40, 10, {"sparq-rsp"})]
+        findings = A.correlate(["opt-in sparq-geo (geosparql)"], window, MEMBERS)
+        # sparq-rsp was skipped but no failed job names it => still no finding.
+        self.assertEqual(findings, [])
+
+    def test_triage_for_narrowed_shard(self):
+        # A generic shard failed AND selection skipped something => fail-safe triage.
+        window = [_wc("a" * 40, 20, {"sparq-vectors"}), _wc("b" * 40, 21, {"sparq-geo"})]
+        findings = A.correlate(["test (load-aware shard bulk 2/3)"], window, MEMBERS)
+        self.assertEqual(len(findings), 1)
+        f = findings[0]
+        self.assertEqual(f.kind, "triage")
+        self.assertIsNone(f.crate)
+        self.assertEqual(f.failed_jobs, ["test (load-aware shard bulk 2/3)"])
+        # both skip-bearing PRs are suspects
+        self.assertEqual(sorted(wc.pr for wc in f.suspect_prs), [20, 21])
+
+    def test_non_spam_empty_skipset_no_finding(self):
+        # Nightly failed but NOTHING was skipped in the window => cannot be a
+        # selection bug => no alarm.
+        window = [_wc("a" * 40, 30, set()), _wc("b" * 40, 31, set())]
+        self.assertEqual(
+            A.correlate(
+                ["test (load-aware shard bulk 1/3)", "opt-in sparq-core (mmap)"],
+                window, MEMBERS,
+            ),
+            [],
+        )
+
+    def test_non_test_infra_failure_not_triaged(self):
+        # A non-shard, non-crate infra lane failing must NOT mint a triage alarm,
+        # even with active skips.
+        window = [_wc("a" * 40, 40, {"sparq-geo"})]
+        findings = A.correlate(["coverage floors (presence + monotonicity)"], window, MEMBERS)
+        self.assertEqual(findings, [])
+
+    def test_precise_and_triage_together(self):
+        window = [_wc("a" * 40, 50, {"sparq-geo", "sparq-vectors"})]
+        findings = A.correlate(
+            ["opt-in sparq-geo (geosparql)", "test (load-aware shard bulk 3/3)"],
+            window, MEMBERS,
+        )
+        kinds = sorted(f.kind for f in findings)
+        self.assertEqual(kinds, ["crate", "triage"])
+
+
+class TestTriageLaneRegexMatchesRealCi(unittest.TestCase):
+    def test_regex_matches_ci_shard_job_name(self):
+        # Pin the triage regex to the REAL ci.yml shard job name so a rename of the
+        # shard lane can't silently drop the fail-safe triage path.
+        text = CI_YML.read_text()
+        self.assertIn("test (load-aware shard ${{ matrix.name }})", text,
+                      "ci.yml shard job name changed — update TRIAGE_LANE_RE + this pin")
+        # Concrete expanded names must match.
+        for expanded in ("test (load-aware shard bulk 1/3)",
+                         "test (load-aware shard heavy-diskann)"):
+            self.assertTrue(A.TRIAGE_LANE_RE.match(expanded), expanded)
+
+
+class TestRenderIssue(unittest.TestCase):
+    def test_crate_issue_has_key_marker_and_selfid(self):
+        f = A.Finding(kind="crate", key="crate:sparq-geo", crate="sparq-geo",
+                      failed_jobs=["opt-in sparq-geo (geosparql)"],
+                      suspect_prs=[_wc("c" * 40, 77, {"sparq-geo"})])
+        title, body = A.render_issue(f, "999", "d" * 40, "sparq-org/sparq")
+        self.assertIn("sparq-geo", title)
+        self.assertIn(A.key_marker("crate:sparq-geo"), body)
+        self.assertIn("\U0001f916 SPARQ agent", body)
+        self.assertIn("#77", body)
+        self.assertIn("P1", body)
+
+    def test_triage_issue_lists_skipped_crates(self):
+        f = A.Finding(kind="triage", key="triage:test (load-aware shard bulk 1/3)",
+                      crate=None, failed_jobs=["test (load-aware shard bulk 1/3)"],
+                      suspect_prs=[_wc("e" * 40, 88, {"sparq-vectors"})])
+        _title, body = A.render_issue(f, "1", "f" * 40, None)
+        self.assertIn("sparq-vectors", body)  # skipped set shown for triage
+
+
+class TestCliFailLoud(unittest.TestCase):
+    """The CLI must exit NON-ZERO on any infra gap (fail-loud), never mask."""
+
+    def _meta(self) -> dict:
+        # Minimal cargo-metadata-shaped dict (see ci_select.parse_workspace).
+        root = "/repo"
+        pkgs = [
+            {"id": "core 0", "name": "sparq-core", "source": None,
+             "manifest_path": f"{root}/crates/sparq-core/Cargo.toml", "dependencies": []},
+            {"id": "geo 0", "name": "sparq-geo", "source": None,
+             "manifest_path": f"{root}/crates/sparq-geo/Cargo.toml",
+             "dependencies": [{"name": "sparq-core"}]},
+        ]
+        return {"workspace_root": root, "packages": pkgs,
+                "workspace_members": ["core 0", "geo 0"]}
+
+    def test_replay_error_exits_nonzero(self):
+        mod = _load_module()
+        with tempfile.TemporaryDirectory() as d:
+            meta_f = Path(d) / "meta.json"
+            meta_f.write_text(json.dumps(self._meta()))
+            jobs_f = Path(d) / "jobs.txt"
+            jobs_f.write_text("test (load-aware shard bulk 1/3)\n")
+
+            # Force one landed commit, then make the per-commit diff replay FAIL.
+            mod.window_commits = lambda *a, **k: [("f" * 40, 123)]
+
+            def _boom(sha, repo_root):
+                raise mod.AlarmError("simulated git diff failure")
+
+            mod.commit_changed_paths = _boom
+            rc = mod.main([
+                "--run-id", "1", "--head-sha", "f" * 40, "--repo", "o/r",
+                "--repo-root", d, "--failed-jobs-file", str(jobs_f),
+                "--metadata-file", str(meta_f), "--dry-run",
+            ])
+            self.assertEqual(rc, 1, "a replay error must fail loud (non-zero)")
+
+    def test_total_blocker_exits_nonzero(self):
+        mod = _load_module()
+        # No --failed-jobs-file and no --repo => gather_failed_jobs total blocker.
+        with tempfile.TemporaryDirectory() as d:
+            meta_f = Path(d) / "meta.json"
+            meta_f.write_text(json.dumps(self._meta()))
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = mod.main([
+                    "--run-id", "1", "--head-sha", "f" * 40,
+                    "--repo-root", d, "--metadata-file", str(meta_f),
+                ])
+            self.assertEqual(rc, 1)
+
+    def test_dry_run_reports_finding_without_gh(self):
+        # End-to-end via the CLI dry-run path (no gh writes), exercising the REAL
+        # ci_select replay. The landed commit touches only crates/sparq-geo/src
+        # => geo is affected (it has no dependents), so sparq-core is SKIPPED
+        # (mode=selected). A failed nightly leg naming sparq-core then intersects
+        # that skip => one precise finding, printed but not filed.
+        mod = _load_module()
+        with tempfile.TemporaryDirectory() as d:
+            meta_f = Path(d) / "meta.json"
+            meta_f.write_text(json.dumps(self._meta()))
+            jobs_f = Path(d) / "jobs.txt"
+            jobs_f.write_text("opt-in sparq-core (mmap)\n")
+
+            mod.window_commits = lambda *a, **k: [("a" * 40, 55)]
+            mod.commit_changed_paths = lambda sha, repo_root: ["crates/sparq-geo/src/x.rs"]
+
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = mod.main([
+                    "--run-id", "42", "--head-sha", "b" * 40, "--repo", "o/r",
+                    "--repo-root", d, "--failed-jobs-file", str(jobs_f),
+                    "--metadata-file", str(meta_f), "--dry-run",
+                ])
+            out = buf.getvalue()
+            self.assertEqual(rc, 0)
+            self.assertIn("[dry-run] WOULD file", out)
+            self.assertIn("crate:sparq-core", out)
+            self.assertIn("#55", out)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/tests/test_ci_selection_alarm.py
+++ b/scripts/tests/test_ci_selection_alarm.py
@@ -24,8 +24,6 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
-import os
-import re
 import sys
 import tempfile
 import unittest


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead **sq-va7at** (epic sq-fmx4u, design `research/change-based-test-selection.md` §6.1). CI/infra lane. Authored by Opus 4.8 running in the sonnet tier's place (Fable unavailable) — attribution kept honest to the real author; flag for re-review when Fable returns.

## What this closes

The nightly FULL-matrix backstop (`ci.yml` `schedule` ⇒ `mode=full`) already **re-runs** everything a PR may have selection-skipped, and the `selection-backstop` job asserts that full-run invariant. What was **missing** (deferred under proceed-and-document at sq-fmx4u.5) is the correlation **ALARM**: when a scheduled nightly job **fails** and that same job's crate was selection-**skipped** in one or more PRs landed since the last green nightly, that intersection is *prima-facie* evidence the non-interference proof (§2) was wrong — a change that "looked unaffected" actually broke the crate.

## Mechanism

- **`scripts/ci_selection_alarm.py`** — reuses the shipped **`scripts/ci_select.py`** (per the brief). The per-PR selection decision is a *pure* function of `(diff, cargo metadata, ownership map)`, so it is **reconstructed by git-replay** over the landed window — the most durable "record" there is (git history outlives any artifact-retention window). Two correlation paths that map onto the two real skip mechanisms:
  - **precise per-crate** for crate-named jobs (feature-matrix legs `opt-in <crate> (...)`) — delimited-token match, no substring collisions;
  - **fail-safe triage** for the **narrowed** bulk/heavy nextest shards `test (load-aware shard ...)` whose generic names do not encode the failing crate (a real selection-skip signal we must not mask; a human narrows from the shard log).
- **`.github/workflows/selection-alarm.yml`** — `workflow_run` on CI completion, `branches: [main]` so it **never** produces a check-run on a PR head commit and therefore **cannot** interact with the `ci-summary / gate` poll set. Job `if:` narrows to a **failed** `schedule`/`workflow_dispatch` nightly on main. SHA-pinned actions; `issues: write` + `actions: read`.

## Design invariants (both load-bearing)

- **FAIL-LOUD** (opposite of `ci_select`'s fail-*closed*): an alarm-infrastructure error — cannot list the failed jobs / load cargo metadata / replay a landed commit — exits **non-zero** so this run reds and a human notices the detector itself is broken. Masking a possible selection bug is the one thing it must never do. Redding this post-hoc run **blocks nothing** (it is not a required check).
- **NON-SPAMMY**: one issue per distinct failure↔skip mapping, deduped by a stable `<!-- selection-alarm-key: ... -->` body marker across open labelled issues (the flow-on idempotency mechanism). Fires **only** when selection actually skipped something relevant — an empty skip-set in the window ⇒ no alarm, because a nightly failure with nothing skipped cannot be a selection bug.

Files **issues**, not beads (CI has no `bd` DB — same rule as `flow-on.yml`); the orchestrator reconciles alarm issues into **P1** beads.

## Gates

- Hermetic stdlib-unittest suite `scripts/tests/test_ci_selection_alarm.py` (16 tests; **no** gh/git/cargo/network) — pure correlation core, the `TRIAGE_LANE_RE` pin against the real `ci.yml` shard job name, and both fail-loud exits — wired as a **gating** step in `docs-quality.yml`.
- `actionlint` + `yaml.safe_load` clean on both workflow files.
- **Locally reproduced** the real command end-to-end (real `cargo metadata` + git-replay, `--dry-run`): produced a precise `sparq-core` finding and a triage finding from the last day's landed PRs. The gh write paths mirror the proven `flow-on.py` patterns; the `gh api --jq` failed-jobs filter validated against sample JSON.
- Gate aggregator intact: `ci-summary` triggers on `pull_request`/`merge_group`/`push` only (not `workflow_run`), and the `branches:[main]` filter means selection-alarm never appears as a PR sibling. **This leg does NOT gate** — it is a post-hoc detector, by design.

Compliance/quality gap closed: the change-based test-selection soundness backstop now has its **detector** (design §6.1), so a wrong per-PR skip that lands a latent regression is auto-surfaced from the nightly full run instead of sitting silently.

**Not armed** — leaving for review. The `research/` design-record graduation of the §6.1 "Deferred" note is out of this lane's staging scope (a docs pass can flip it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)