### PR TITLE
feat(kb): CORE API v3 live connector behind default-OFF literature-live + fail-closed license capture (sq-tzars.1) [SONNET-4.6]

### DIFF
--- a/.claude/skills/query-pkg/SKILL.md
+++ b/.claude/skills/query-pkg/SKILL.md
@@ -334,6 +334,19 @@ batch — no hard-coded number. NOT appended to `pkg-instances.ttl`: bulk ingest
 on the Phase-6 per-topic recommend-adopt verdict. Run:
 `cargo test -p sparq-kb --features literature,validate --test literature_pipeline`.
 
+**CORE API v3 live connector** (`sq-tzars.1`, `connector_core`): a second connector
+(`parse_core_batch` → the same DOI-keyed `SourceStub`s as `parse_openalex_batch`) plus a
+live HTTP client behind the default-OFF **`literature-live`** feature (implies `literature`,
+pulls only `ureq`). The pure parse + paging/retry discipline (`fetch_paginated`,
+`backoff_delay`, the `Transport` trait) is under `literature` and runs over a **fake
+transport** + the committed `fixtures/literature/core-batch.json` (a REAL, SANITIZED CORE
+response — no key, no full-text) so CI stays **network-free**; only `CoreClient` (from the
+`CORE_API_KEY` env var, **never** committed/logged) touches sockets. `SourceStub` now carries
+`license: Option<String>`, captured **fail-closed** by both connectors — `None` (unknown) is
+treated as NON-REDISTRIBUTABLE by the downstream dump tiering (`sq-tzars.7`). Rate-limit
+discipline honours `429`/`Retry-After` with bounded backoff + a HARD per-run request cap.
+Run: `cargo test -p sparq-kb --features literature,literature-live --test core_connector`.
+
 ## When NOT to use this
 
 - The fact is **not in the head slice** (PKG is a Phase-1 subset) → an empty/partial
@@ -369,3 +382,7 @@ on the Phase-6 per-topic recommend-adopt verdict. Run:
   shapes `crates/sparq-kb/shapes/literature.shapes.ttl`, fixtures
   `crates/sparq-kb/fixtures/literature/`, gate
   `crates/sparq-kb/tests/literature_pipeline.rs`.
+- CORE v3 live connector (`literature`/`literature-live`, `sq-tzars.1`):
+  `crates/sparq-kb/src/literature/connector_core.rs`, fixture
+  `crates/sparq-kb/fixtures/literature/core-batch.json`, gate
+  `crates/sparq-kb/tests/core_connector.rs`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3961,6 +3961,7 @@ dependencies = [
  "sparq-engine",
  "sparq-reason",
  "sparq-shacl",
+ "ureq",
 ]
 
 [[package]]

--- a/crates/sparq-kb/Cargo.toml
+++ b/crates/sparq-kb/Cargo.toml
@@ -56,6 +56,16 @@ close = ["query", "dep:sparq-reason"]
 # is run by the `literature_pipeline` integration test, which additionally enables
 # `validate`. [OPUS-4.8] sq-2489d.5
 literature = ["dep:serde_json"]
+# OPT-IN (default-OFF, implies `literature`). Enables the LIVE CORE API v3 connector
+# (sq-tzars.1): the networked socket layer of `connector_core` — `UreqTransport` +
+# `CoreClient` (paged search with rate-limit + retry discipline + fail-closed license
+# capture). The pure parse + retry logic + the fake-transport tests live under `literature`
+# and make ZERO network calls; ONLY this feature pulls the blocking HTTP client (`ureq`,
+# already vendored for the engine's SERVICE transport, so no new lockfile entry) and it is
+# NEVER driven in CI (tests replay the committed `core-batch.json` fixture). The CORE key is
+# read from the `CORE_API_KEY` env var at run time only — never committed or logged.
+# [SONNET-4.6] sq-tzars.1
+literature-live = ["literature", "dep:ureq"]
 
 [dependencies]
 # Engine graph type (only behind `validate`). default-features=false keeps it lean.
@@ -82,6 +92,11 @@ spargebra = { workspace = true, optional = true }
 # [OPUS-4.8] sq-ve5dy
 serde = { version = "1", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
+# Blocking HTTP client for the LIVE CORE connector (only behind `literature-live`).
+# ureq 3 + rustls, mirroring sparq-engine's SERVICE transport EXACTLY (same version +
+# feature set), so it reuses the already-vendored dependency and adds no new lockfile
+# entry; default build stays socket-free. [SONNET-4.6] sq-tzars.1
+ureq = { version = "3", default-features = false, features = ["rustls", "platform-verifier"], optional = true }
 
 # The `pkg-query` helper binary (sq-2m6zm.3): one command to introspect → ground →
 # ask over the ingested PKG. It needs the `query` module (engine), so it is only

--- a/crates/sparq-kb/README.md
+++ b/crates/sparq-kb/README.md
@@ -91,10 +91,10 @@ the write/merge/latency/CLI estate buys nothing (`part2_four_criterion_replaceme
 - **SHACL guardrails** — `pkg.shapes.ttl` makes a source + a confidence value + an
   assurance basis + non-filler content **mandatory** on every `pkg:Finding`, and
   enforces a valid status / bounded priority / no-stale-edge on every `pkg:Task`.
-- **Literature-ingestion scaffolding** (`literature` feature, `sq-2489d.5`) — the
-  `[connector]→[extract (record/replay)]→[ground]→[emit TTL]→[SHACL gate]→[sidecar]`
-  pipeline on **committed fixtures, ZERO network/model calls**; the grounding-resolver
-  **quarantines** (never drops) rejects; machine tier capped at `secx:Conjectured`.
+- **Literature ingestion** (`literature`/`literature-live`, `sq-2489d.5`/`sq-tzars.1`) — the
+  `[connector]→[extract]→[ground]→[SHACL gate]→[sidecar]` pipeline on **committed fixtures,
+  ZERO network in CI** (grounding **quarantines**, never drops; machine tier ≤ `secx:Conjectured`);
+  a CORE v3 **live** connector adds paged search + retry + **fail-closed license** (unknown ⇒ restricted).
 - **Opt-in by construction** — default build is data + constants only; the
   `validate` feature is the only thing that pulls in `sparq-core` + `sparq-shacl`.
 - **No-drift guard** — `vocab.rs` is byte-pinned against `pkg.ttl` by a sync test.
@@ -106,8 +106,8 @@ the write/merge/latency/CLI estate buys nothing (`part2_four_criterion_replaceme
 
 ## 📚 Learn more
 
-- Design records: `research/dogfooding-sparq-knowledge-graph.md` (PR #1063) +
-  `research/provenance-driven-genai-kb.md` (§4/§5 literature-ingestion, `sq-2489d.5`).
+- Design records: `research/dogfooding-sparq-knowledge-graph.md` (PR #1063), `research/
+  provenance-driven-genai-kb.md` (§4/§5 literature, `sq-2489d.5`) + `research/research-kb-program.md` (`sq-tzars`).
 - `ontology/pkg/PROVENANCE.md` — the per-term reuse + verified `skos:closeMatch`
   alignment record; precedent: `crates/sparq-trust/ontologies/zkp-sparql/`.
 - Epic `sq-2m6zm`: ontology/shapes `.1`; ingestion PoC `.2`; the **query-the-PKG** helper

--- a/crates/sparq-kb/fixtures/literature/core-batch.json
+++ b/crates/sparq-kb/fixtures/literature/core-batch.json
@@ -1,0 +1,48 @@
+{
+  "_comment": "sq-tzars.1 [SONNET-4.6] — a REAL, SANITIZED CORE API v3 `/v3/search/works/` response, recorded once locally and scrubbed for offline replay. The CORE-path tests (tests/core_connector.rs) parse THIS committed string; the pipeline makes ZERO network calls in CI. SANITISATION: no API key or auth header is present anywhere (the key is read from the CORE_API_KEY env var at run time only, never committed/logged); the large copyrighted `fullText` body, `downloadUrl`, and `sourceFulltextUrls` of every record were REMOVED (non-redistributable); the `searchId`/`scrollId` session tokens were nulled; abstracts were truncated to a single de-minimis metadata sentence. LICENSE NOTE: CORE v3's search-works schema does NOT carry a per-record `license` field (verified against the live response), so every record here has an UNKNOWN license — which the connector captures as `license: null` and the downstream dump tiering treats as NON-REDISTRIBUTABLE (fail-closed). Field names + nesting mirror the real v3 schema so the parser is exercised against real shapes. Real DOIs/titles/years are retained (bibliographic metadata, not copyrightable).",
+  "totalHits": 3,
+  "limit": 3,
+  "offset": 0,
+  "scrollId": null,
+  "searchId": null,
+  "results": [
+    {
+      "id": 454316,
+      "doi": "10.1145/1754239.1754244",
+      "title": "SPARQL Query Rewriting for Implementing Data Integration over Linked Data",
+      "abstract": "There has been lately an increased activity of publishing structured data in RDF due to the activity of the Linked Data community.",
+      "yearPublished": 2010,
+      "publishedDate": "2010-03-22T00:00:00",
+      "documentType": "research",
+      "language": { "code": "en", "name": "English" },
+      "publisher": "",
+      "authors": [{ "name": "G. Correndo" }],
+      "dataProviders": [{ "id": 34, "name": "e-Prints repository" }],
+      "links": [{ "type": "display", "url": "https://core.ac.uk/works/454316" }]
+    },
+    {
+      "id": 8363380,
+      "doi": "10.1007/s10472-015-9451-0",
+      "title": "Extended RDF: Computability and Complexity Issues",
+      "abstract": "ERDF stable model semantics is a recently proposed semantics for ERDF ontologies and a faithful extension of RDFS semantics on RDF graphs.",
+      "yearPublished": 2015,
+      "publishedDate": "2015-06-01T00:00:00",
+      "documentType": "research",
+      "language": { "code": "en", "name": "English" },
+      "authors": [{ "name": "A. Analyti" }],
+      "dataProviders": [{ "id": 152, "name": "institutional repository" }],
+      "links": [{ "type": "display", "url": "https://core.ac.uk/works/8363380" }]
+    },
+    {
+      "id": 77232155,
+      "doi": null,
+      "title": "Querying the web of data with low latency: high performance distributed SPARQL processing and benchmarking",
+      "abstract": "A study of distributed SPARQL processing and benchmarking for low-latency querying over the web of data.",
+      "yearPublished": 2014,
+      "documentType": "thesis",
+      "language": { "code": "en", "name": "English" },
+      "dataProviders": [{ "id": 34, "name": "e-Prints repository" }],
+      "links": [{ "type": "display", "url": "https://core.ac.uk/works/77232155" }]
+    }
+  ]
+}

--- a/crates/sparq-kb/src/literature.rs
+++ b/crates/sparq-kb/src/literature.rs
@@ -57,6 +57,11 @@
 
 #[cfg(feature = "literature")]
 pub mod connector;
+/// The live CORE API v3 connector (`parse_core_batch` + the `literature-live` HTTP client).
+/// Pure parse + retry discipline is available under `literature`; the networked socket layer
+/// (`CoreClient`) is behind `literature-live`. [SONNET-4.6] sq-tzars.1
+#[cfg(feature = "literature")]
+pub mod connector_core;
 #[cfg(feature = "literature")]
 pub mod extract;
 #[cfg(feature = "literature")]
@@ -74,6 +79,13 @@ pub const FIXTURE_OPENALEX_BATCH: &str = include_str!("../fixtures/literature/op
 /// model call).
 #[cfg(feature = "literature")]
 pub const FIXTURE_EXTRACTIONS: &str = include_str!("../fixtures/literature/extractions.json");
+
+/// The committed CORE API v3 connector fixture — a REAL, SANITIZED `/v3/search/works`
+/// response recorded once locally and scrubbed (no key, no copyrighted full-text; see the
+/// file's `_comment`). The CORE-path tests parse this so CI replays real data with ZERO
+/// network. Consumed by `connector_core::parse_core_batch`.
+#[cfg(feature = "literature")]
+pub const FIXTURE_CORE_BATCH: &str = include_str!("../fixtures/literature/core-batch.json");
 
 /// The literature-tier SHACL guardrails (`shapes/literature.shapes.ttl`) — the extra
 /// write-gate constraints on the machine-extraction tier (assurance ≠ `secx:Proven`,

--- a/crates/sparq-kb/src/literature/connector.rs
+++ b/crates/sparq-kb/src/literature/connector.rs
@@ -26,6 +26,17 @@ pub struct SourceStub {
     pub abstract_text: String,
     /// The publication year, when present.
     pub year: Option<i64>,
+    /// The source's redistribution licence, captured verbatim from the record when it
+    /// carries one (e.g. `cc-by`, `cc-by-nc`), else `None` for an UNKNOWN/absent licence.
+    ///
+    /// This field drives the downstream dump tiering and is **fail-closed**: `None`
+    /// (unknown) is treated as NON-REDISTRIBUTABLE by the tier partition (`sq-tzars.7`),
+    /// so a public projection of an unknown-licence source is metadata-only. Captured by
+    /// both connectors — `parse_openalex_batch` here and `parse_core_batch` in the
+    /// `connector_core` module. Many bibliographic APIs omit licence metadata (CORE v3's
+    /// search schema does), so `None` is the common — and deliberately safe — default.
+    /// [SONNET-4.6] sq-tzars.1
+    pub license: Option<String>,
 }
 
 impl SourceStub {
@@ -89,14 +100,37 @@ pub fn parse_openalex_batch(json: &str) -> Result<(Vec<SourceStub>, usize), Stri
             .unwrap_or("")
             .to_string();
         let year = rec.get("publication_year").and_then(Value::as_i64);
+        let license = openalex_license(rec);
         stubs.push(SourceStub {
             doi,
             title,
             abstract_text,
             year,
+            license,
         });
     }
     Ok((stubs, skipped))
+}
+
+/// Extract the OpenAlex licence for a `/works` record, fail-closed to `None` when absent.
+///
+/// OpenAlex records the licence per open-access LOCATION, not once per work, so we read the
+/// `primary_location.license` (the canonical host copy), falling back to
+/// `best_oa_location.license` and finally a top-level `license`. A blank string is treated
+/// as absent. `None` (the common case) is captured as an UNKNOWN licence and treated as
+/// non-redistributable downstream. [SONNET-4.6] sq-tzars.1
+fn openalex_license(rec: &Value) -> Option<String> {
+    let from = |key: &str| {
+        rec.get(key)
+            .and_then(|loc| loc.get("license"))
+            .and_then(Value::as_str)
+    };
+    from("primary_location")
+        .or_else(|| from("best_oa_location"))
+        .or_else(|| rec.get("license").and_then(Value::as_str))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
 }
 
 #[cfg(test)]
@@ -134,6 +168,30 @@ mod tests {
             zk.source_iri(),
             "https://doi.org/10.5555/example.zk-sparql-soundness"
         );
+        // The fabricated OpenAlex fixture carries no licence metadata, so every stub is
+        // captured with an UNKNOWN licence (fail-closed = non-redistributable downstream).
+        assert!(
+            stubs.iter().all(|s| s.license.is_none()),
+            "unknown licence is captured as None (fail-closed)"
+        );
+    }
+
+    #[test]
+    fn openalex_license_is_read_from_primary_location_when_present() {
+        let json = r#"{ "results": [
+            { "doi": "10.1/a", "title": "cc-by work", "abstract": "x",
+              "primary_location": { "license": "cc-by" } },
+            { "doi": "10.1/b", "title": "best-oa fallback", "abstract": "y",
+              "best_oa_location": { "license": "cc-by-nc" } },
+            { "doi": "10.1/c", "title": "blank licence is unknown", "abstract": "z",
+              "primary_location": { "license": "  " } }
+        ] }"#;
+        let (stubs, _) = parse_openalex_batch(json).expect("parses");
+        let by_doi = |d: &str| stubs.iter().find(|s| s.doi == d).unwrap();
+        assert_eq!(by_doi("10.1/a").license.as_deref(), Some("cc-by"));
+        assert_eq!(by_doi("10.1/b").license.as_deref(), Some("cc-by-nc"));
+        // A blank licence string is treated as absent (fail-closed), not the empty string.
+        assert_eq!(by_doi("10.1/c").license, None);
     }
 
     #[test]

--- a/crates/sparq-kb/src/literature/connector_core.rs
+++ b/crates/sparq-kb/src/literature/connector_core.rs
@@ -1,0 +1,670 @@
+//! The **CORE API v3 connector** — a live (`literature-live`) HTTP adapter that turns the
+//! CORE `/v3/search/works` search response into the same DOI-keyed `SourceStub`s the
+//! `connector` module's `parse_openalex_batch` produces, so the downstream pipeline is
+//! source-agnostic (§4.2). [SONNET-4.6] sq-tzars.1 (epic sq-tzars, design record
+//! `research/research-kb-program.md`). 🤖 SPARQ agent — research-KB live ingestion.
+//!
+//! ## Two layers, two features
+//!
+//! - The **pure parse + retry discipline** (`parse_core_batch`, `RetryPolicy`,
+//!   `backoff_delay`, the `Transport` trait, `fetch_paginated`) is behind the default-OFF
+//!   `literature` feature. It makes NO network call itself — it drives an injected
+//!   `Transport`, so CI exercises the paging + rate-limit + retry logic over a fake
+//!   transport and the committed `core-batch.json` fixture with ZERO sockets.
+//! - The **live socket layer** (`UreqTransport`, `CoreClient`) is behind the default-OFF
+//!   `literature-live` feature (which implies `literature`) and pulls the one blocking HTTP
+//!   client (`ureq`, already vendored for the engine's SERVICE transport). It is the ONLY
+//!   part that touches the network, and it is NEVER driven in CI.
+//!
+//! ## Security posture (HARD constraints)
+//!
+//! - The CORE API key is read from the `CORE_API_KEY` environment variable at run time
+//!   only (`CoreClient::from_env`). It is NEVER committed, logged, echoed, or placed in a
+//!   URL — it travels solely in the `Authorization: Bearer …` request header, and no error
+//!   message in this module interpolates it.
+//! - License capture is **fail-closed**: `parse_core_batch` reads a per-record `license`
+//!   when the CORE record carries one, else `None`. CORE v3's search schema does not
+//!   include a per-record license, so in practice every stub is `license: None` = UNKNOWN,
+//!   which the downstream dump tiering (`sq-tzars.7`) treats as NON-REDISTRIBUTABLE.
+//! - Rate-limit discipline: the paged fetch honours HTTP `429`/`503` with the `Retry-After`
+//!   header (bounded), falls back to bounded exponential backoff, and enforces a HARD cap
+//!   on the total number of requests per run so a runaway query cannot hammer the API.
+
+use std::time::Duration;
+
+use serde_json::Value;
+
+use super::connector::{normalise_doi, SourceStub};
+
+/// The CORE v3 works-search endpoint (note the trailing slash — the API `301`-redirects the
+/// slash-less form). Used only by the live `CoreClient`; tests use a fake base URL.
+pub const CORE_SEARCH_WORKS_URL: &str = "https://api.core.ac.uk/v3/search/works/";
+
+// --------------------------------------------------------------------------------------
+// Pure parse (feature = "literature") — no network.
+// --------------------------------------------------------------------------------------
+
+/// Parse a recorded CORE API v3 `/v3/search/works` response (`{ "totalHits": N, "results":
+/// [ { doi, title, abstract, yearPublished, … }, … ] }`) into normalised `SourceStub`s,
+/// mirroring `parse_openalex_batch`. Records with no DOI or no (non-blank) title are skipped
+/// (they cannot be content-addressed); the skipped count is returned so the caller can
+/// report it (never silently lost).
+///
+/// Each stub's `license` is captured from the record's `license` field when present, else
+/// `None` (UNKNOWN = non-redistributable downstream). Pure + deterministic; reads the
+/// committed JSON string only — NO network.
+pub fn parse_core_batch(json: &str) -> Result<(Vec<SourceStub>, usize), String> {
+    let root: Value = serde_json::from_str(json).map_err(|e| format!("CORE JSON: {}", e))?;
+    let results = root
+        .get("results")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "CORE JSON: missing `results` array".to_string())?;
+    Ok(stubs_from_results(results))
+}
+
+/// Normalise a slice of CORE `results` records into `SourceStub`s (+ skipped count). Shared
+/// by `parse_core_batch` and the paged fetch so both apply identical field mapping.
+fn stubs_from_results(results: &[Value]) -> (Vec<SourceStub>, usize) {
+    let mut stubs = Vec::new();
+    let mut skipped = 0usize;
+    for rec in results {
+        let doi = rec.get("doi").and_then(Value::as_str).and_then(normalise_doi);
+        let title = rec.get("title").and_then(Value::as_str).map(str::to_string);
+        let (Some(doi), Some(title)) = (doi, title) else {
+            skipped += 1;
+            continue;
+        };
+        if title.trim().is_empty() {
+            skipped += 1;
+            continue;
+        }
+        let abstract_text = rec
+            .get("abstract")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+        // CORE v3 uses `yearPublished` (OpenAlex uses `publication_year`).
+        let year = rec.get("yearPublished").and_then(Value::as_i64);
+        let license = core_license(rec);
+        stubs.push(SourceStub {
+            doi,
+            title,
+            abstract_text,
+            year,
+            license,
+        });
+    }
+    (stubs, skipped)
+}
+
+/// Capture the CORE record's license, fail-closed to `None`. A blank string is treated as
+/// absent. CORE v3's search schema omits per-record licensing, so this is `None` in
+/// practice — which the tiering treats as non-redistributable. [SONNET-4.6] sq-tzars.1
+fn core_license(rec: &Value) -> Option<String> {
+    rec.get("license")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+// --------------------------------------------------------------------------------------
+// Rate-limit + retry discipline (feature = "literature") — transport-agnostic, testable.
+// --------------------------------------------------------------------------------------
+
+/// One HTTP response the retry loop inspects: the numeric status, the parsed `Retry-After`
+/// header (seconds, when present), and the response body.
+#[derive(Debug, Clone)]
+pub struct HttpResponse {
+    /// The HTTP status code (e.g. `200`, `429`).
+    pub status: u16,
+    /// The `Retry-After` header parsed as whole seconds, when the server sent one.
+    pub retry_after: Option<u64>,
+    /// The response body (empty for a status-only response).
+    pub body: String,
+}
+
+/// The blocking HTTP transport the paged fetch drives. Implemented by `UreqTransport` in
+/// production and by a fake in tests, so the paging/retry logic runs with ZERO sockets.
+pub trait Transport {
+    /// Perform one `GET` and return the response (or a transport-level error string). The
+    /// implementation must NOT turn a non-2xx status into an error — the retry loop needs
+    /// the status + `Retry-After` header to decide whether to back off.
+    fn get(&self, url: &str) -> Result<HttpResponse, String>;
+}
+
+/// Rate-limit + retry + pagination policy. Defaults are conservative discipline knobs (not
+/// tuned/benchmarked numbers): honour a small burst of retries with bounded backoff, and
+/// HARD-cap the total requests per run so a query cannot hammer the API.
+#[derive(Debug, Clone)]
+pub struct RetryPolicy {
+    /// Maximum retries per URL after a retryable status before giving up.
+    pub max_retries: u32,
+    /// Base backoff delay; the exponential schedule is `base * 2^attempt`, capped.
+    pub base_delay: Duration,
+    /// Upper bound on any single backoff delay (also caps a huge `Retry-After`).
+    pub max_delay: Duration,
+    /// HARD cap on the total number of HTTP requests (incl. retries) across the whole run.
+    pub max_requests_per_run: usize,
+    /// Page size (CORE `limit` parameter).
+    pub page_size: usize,
+    /// HARD cap on the number of pages fetched per run.
+    pub max_pages: usize,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_retries: 4,
+            base_delay: Duration::from_millis(500),
+            max_delay: Duration::from_secs(30),
+            max_requests_per_run: 50,
+            page_size: 25,
+            max_pages: 20,
+        }
+    }
+}
+
+/// Whether an HTTP status is retryable: `429 Too Many Requests` and the transient `5xx`
+/// gateway/overload statuses (`500`, `502`, `503`, `504`). A `4xx` other than `429` is a
+/// permanent client error and is NOT retried.
+pub fn is_retryable_status(status: u16) -> bool {
+    matches!(status, 429 | 500 | 502 | 503 | 504)
+}
+
+/// Compute the backoff delay for a retry attempt. Prefers the server's `Retry-After`
+/// (capped at `max_delay`); otherwise bounded exponential backoff `base * 2^attempt`, capped
+/// at `max_delay`. Pure — the caller does the sleeping (so tests never actually sleep).
+pub fn backoff_delay(attempt: u32, retry_after: Option<u64>, policy: &RetryPolicy) -> Duration {
+    if let Some(secs) = retry_after {
+        return Duration::from_secs(secs).min(policy.max_delay);
+    }
+    let factor = 2u64.saturating_pow(attempt);
+    let base_ms = policy.base_delay.as_millis() as u64;
+    Duration::from_millis(base_ms.saturating_mul(factor)).min(policy.max_delay)
+}
+
+/// Fetch one URL with retry discipline. Increments `requests` per attempt and refuses to
+/// exceed `policy.max_requests_per_run` (the HARD cap). On a retryable status it sleeps the
+/// `backoff_delay` (via the injected `sleep` sink) and retries up to `policy.max_retries`;
+/// a non-retryable `>= 400` status is a hard error; a `< 400` status returns the response.
+fn fetch_with_retry<T: Transport>(
+    transport: &T,
+    url: &str,
+    policy: &RetryPolicy,
+    requests: &mut usize,
+    sleep: &mut dyn FnMut(Duration),
+) -> Result<HttpResponse, String> {
+    let mut attempt = 0u32;
+    loop {
+        if *requests >= policy.max_requests_per_run {
+            return Err(format!(
+                "CORE: hard request cap of {} reached before completing the fetch",
+                policy.max_requests_per_run
+            ));
+        }
+        *requests += 1;
+        let resp = transport.get(url)?;
+        if is_retryable_status(resp.status) {
+            if attempt >= policy.max_retries {
+                return Err(format!(
+                    "CORE: gave up after {} retries; last HTTP status {}",
+                    policy.max_retries, resp.status
+                ));
+            }
+            let delay = backoff_delay(attempt, resp.retry_after, policy);
+            sleep(delay);
+            attempt += 1;
+            continue;
+        }
+        if resp.status >= 400 {
+            return Err(format!("CORE: non-retryable HTTP status {}", resp.status));
+        }
+        return Ok(resp);
+    }
+}
+
+/// The result of a paged CORE search: the accumulated stubs, the skipped-record count, and
+/// how many pages / HTTP requests the run actually made (for honest reporting).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CoreSearchResult {
+    /// The normalised `SourceStub`s accumulated across every fetched page.
+    pub stubs: Vec<SourceStub>,
+    /// Records skipped across all pages (no DOI / no title) — surfaced, not lost.
+    pub skipped: usize,
+    /// Number of pages fetched.
+    pub pages_fetched: usize,
+    /// Total HTTP requests made (including retries) — bounded by `max_requests_per_run`.
+    pub requests_made: usize,
+}
+
+/// Drive a paged CORE search over an injected `Transport`, honouring the `RetryPolicy`
+/// (rate-limit backoff + HARD request/page caps). Stops when a page is empty, the reported
+/// `totalHits` is reached, an under-full page arrives, or a HARD cap is hit. The `sleep`
+/// sink receives each backoff delay (production passes `thread::sleep`; tests pass a
+/// recorder). This is the load-bearing logic and is fully exercised with ZERO sockets.
+pub fn fetch_paginated<T: Transport>(
+    transport: &T,
+    base_url: &str,
+    query: &str,
+    policy: &RetryPolicy,
+    sleep: &mut dyn FnMut(Duration),
+) -> Result<CoreSearchResult, String> {
+    let mut out = CoreSearchResult::default();
+    let mut offset = 0usize;
+    loop {
+        if out.pages_fetched >= policy.max_pages {
+            break;
+        }
+        let url = build_search_url(base_url, query, policy.page_size, offset);
+        let resp = fetch_with_retry(transport, &url, policy, &mut out.requests_made, sleep)?;
+        let root: Value =
+            serde_json::from_str(&resp.body).map_err(|e| format!("CORE JSON: {}", e))?;
+        let results = root
+            .get("results")
+            .and_then(Value::as_array)
+            .ok_or_else(|| "CORE JSON: missing `results` array".to_string())?;
+        let got = results.len();
+        let (page_stubs, page_skipped) = stubs_from_results(results);
+        out.stubs.extend(page_stubs);
+        out.skipped += page_skipped;
+        out.pages_fetched += 1;
+
+        let total = root.get("totalHits").and_then(Value::as_u64).map(|n| n as usize);
+        offset += policy.page_size;
+        if got == 0 {
+            break;
+        }
+        if let Some(total) = total {
+            if offset >= total {
+                break;
+            }
+        }
+        if got < policy.page_size {
+            break;
+        }
+        if out.requests_made >= policy.max_requests_per_run {
+            break;
+        }
+    }
+    Ok(out)
+}
+
+/// Build a CORE search URL: `{base}?q={encoded}&limit={page_size}&offset={offset}`. The API
+/// key is NEVER placed here — it travels only in the `Authorization` header.
+fn build_search_url(base: &str, query: &str, page_size: usize, offset: usize) -> String {
+    format!(
+        "{}?q={}&limit={}&offset={}",
+        base,
+        percent_encode_query(query),
+        page_size,
+        offset
+    )
+}
+
+/// Minimal percent-encoding for a query-string value (RFC 3986 unreserved set kept verbatim,
+/// everything else `%`-encoded). Dep-free so it stays available under `literature` alone.
+fn percent_encode_query(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for b in s.bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char)
+            }
+            _ => out.push_str(&format!("%{:02X}", b)),
+        }
+    }
+    out
+}
+
+// --------------------------------------------------------------------------------------
+// Live socket layer (feature = "literature-live") — the ONLY networked part; never in CI.
+// --------------------------------------------------------------------------------------
+
+/// Max bytes read from a CORE response body — a finite cap so a runaway endpoint cannot OOM
+/// the process (mirrors the engine's SERVICE transport discipline).
+#[cfg(feature = "literature-live")]
+const CORE_MAX_BODY_BYTES: u64 = 64 * 1024 * 1024;
+
+/// The live blocking HTTP transport over `ureq` (rustls). Holds the API key (read from the
+/// environment) and a per-request timeout. The key is sent ONLY in the `Authorization`
+/// header and is never logged.
+#[cfg(feature = "literature-live")]
+pub struct UreqTransport {
+    api_key: String,
+    timeout: Duration,
+}
+
+#[cfg(feature = "literature-live")]
+impl UreqTransport {
+    /// Construct the transport from an API key + per-request timeout. The key is not logged.
+    pub fn new(api_key: String, timeout: Duration) -> Self {
+        Self { api_key, timeout }
+    }
+}
+
+#[cfg(feature = "literature-live")]
+impl Transport for UreqTransport {
+    fn get(&self, url: &str) -> Result<HttpResponse, String> {
+        // `http_status_as_error(false)` so a 429/5xx returns the Response (with its
+        // Retry-After header) instead of an Err — the retry loop needs to inspect it.
+        let config = ureq::Agent::config_builder()
+            .timeout_global(Some(self.timeout))
+            .http_status_as_error(false)
+            .user_agent(concat!("sparq-kb/", env!("CARGO_PKG_VERSION")))
+            .build();
+        let agent = ureq::Agent::new_with_config(config);
+        let mut resp = agent
+            .get(url)
+            // The key travels ONLY here, never in the URL or any log line.
+            .header("Authorization", &format!("Bearer {}", self.api_key))
+            .header("Accept", "application/json")
+            .call()
+            .map_err(|e| format!("CORE: request failed: {}", e))?;
+        let status = resp.status().as_u16();
+        let retry_after = resp
+            .headers()
+            .get("retry-after")
+            .and_then(|v| v.to_str().ok())
+            .and_then(|s| s.trim().parse::<u64>().ok());
+        let body = resp
+            .body_mut()
+            .with_config()
+            .limit(CORE_MAX_BODY_BYTES)
+            .read_to_string()
+            .map_err(|e| format!("CORE: reading response body: {}", e))?;
+        Ok(HttpResponse {
+            status,
+            retry_after,
+            body,
+        })
+    }
+}
+
+/// The live CORE API v3 client: a `UreqTransport` + a `RetryPolicy`. Construct it with
+/// `from_env` (reads `CORE_API_KEY`), then call `search`. NETWORK — never driven in CI.
+#[cfg(feature = "literature-live")]
+pub struct CoreClient {
+    transport: UreqTransport,
+    policy: RetryPolicy,
+}
+
+#[cfg(feature = "literature-live")]
+impl CoreClient {
+    /// Build the client, reading the CORE API key from the `CORE_API_KEY` environment
+    /// variable (loaded locally from `~/.config/sparq/core-api.env`). The key value is NEVER
+    /// included in the returned error, logged, or echoed. Errors if the variable is unset or
+    /// empty.
+    pub fn from_env() -> Result<Self, String> {
+        let api_key = std::env::var("CORE_API_KEY").map_err(|_| {
+            "CORE: CORE_API_KEY is not set in the environment (load it locally from \
+             ~/.config/sparq/core-api.env; it is never committed or logged)"
+                .to_string()
+        })?;
+        if api_key.trim().is_empty() {
+            return Err("CORE: CORE_API_KEY is set but empty".to_string());
+        }
+        Ok(Self {
+            transport: UreqTransport::new(api_key, Duration::from_secs(30)),
+            policy: RetryPolicy::default(),
+        })
+    }
+
+    /// Override the retry/rate-limit policy (e.g. a smaller request cap for a probe run).
+    pub fn with_policy(mut self, policy: RetryPolicy) -> Self {
+        self.policy = policy;
+        self
+    }
+
+    /// The active retry/rate-limit policy (accessor).
+    pub fn policy(&self) -> &RetryPolicy {
+        &self.policy
+    }
+
+    /// Run a paged live CORE search for `query`, honouring the rate-limit + retry policy.
+    /// NETWORK — this is the sole networked entry point and is never called in CI.
+    pub fn search(&self, query: &str) -> Result<CoreSearchResult, String> {
+        fetch_paginated(
+            &self.transport,
+            CORE_SEARCH_WORKS_URL,
+            query,
+            &self.policy,
+            &mut |d| std::thread::sleep(d),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+
+    /// A fake transport that replays a scripted queue of responses (no sockets), recording
+    /// how many times it was called. Used to exercise pagination + retry with ZERO network.
+    struct FakeTransport {
+        responses: RefCell<Vec<HttpResponse>>,
+        calls: RefCell<usize>,
+    }
+    impl FakeTransport {
+        fn new(responses: Vec<HttpResponse>) -> Self {
+            Self {
+                responses: RefCell::new(responses),
+                calls: RefCell::new(0),
+            }
+        }
+    }
+    impl Transport for FakeTransport {
+        fn get(&self, _url: &str) -> Result<HttpResponse, String> {
+            *self.calls.borrow_mut() += 1;
+            let mut q = self.responses.borrow_mut();
+            if q.is_empty() {
+                // Exhausted script => an empty page (stops pagination).
+                Ok(HttpResponse {
+                    status: 200,
+                    retry_after: None,
+                    body: r#"{ "totalHits": 0, "results": [] }"#.to_string(),
+                })
+            } else {
+                Ok(q.remove(0))
+            }
+        }
+    }
+
+    fn ok(body: &str) -> HttpResponse {
+        HttpResponse {
+            status: 200,
+            retry_after: None,
+            body: body.to_string(),
+        }
+    }
+
+    #[test]
+    fn parse_core_batch_reads_doi_title_year_and_absent_license() {
+        let json = r#"{ "totalHits": 1, "results": [
+            { "doi": "10.1/A", "title": "T", "abstract": "abs", "yearPublished": 2021 }
+        ] }"#;
+        let (stubs, skipped) = parse_core_batch(json).unwrap();
+        assert_eq!(skipped, 0);
+        assert_eq!(stubs.len(), 1);
+        assert_eq!(stubs[0].doi, "10.1/a"); // normalised, lower-cased
+        assert_eq!(stubs[0].year, Some(2021));
+        assert_eq!(stubs[0].license, None); // absent license => fail-closed None
+    }
+
+    #[test]
+    fn parse_core_batch_captures_present_license_and_skips_doi_less() {
+        let json = r#"{ "results": [
+            { "doi": "https://doi.org/10.2/B", "title": "Licensed", "license": "cc-by" },
+            { "title": "no doi", "abstract": "x" }
+        ] }"#;
+        let (stubs, skipped) = parse_core_batch(json).unwrap();
+        assert_eq!(stubs.len(), 1);
+        assert_eq!(skipped, 1);
+        assert_eq!(stubs[0].license.as_deref(), Some("cc-by"));
+    }
+
+    #[test]
+    fn parse_core_batch_malformed_is_error() {
+        assert!(parse_core_batch("{ not json").is_err());
+        assert!(parse_core_batch(r#"{ "no_results": 1 }"#).is_err());
+    }
+
+    #[test]
+    fn is_retryable_status_covers_429_and_transient_5xx() {
+        assert!(is_retryable_status(429));
+        assert!(is_retryable_status(503));
+        assert!(!is_retryable_status(200));
+        assert!(!is_retryable_status(404));
+    }
+
+    #[test]
+    fn backoff_delay_prefers_retry_after_and_caps() {
+        let p = RetryPolicy {
+            base_delay: Duration::from_millis(100),
+            max_delay: Duration::from_secs(5),
+            ..RetryPolicy::default()
+        };
+        // Retry-After honoured, capped at max_delay.
+        assert_eq!(backoff_delay(0, Some(2), &p), Duration::from_secs(2));
+        assert_eq!(backoff_delay(0, Some(999), &p), Duration::from_secs(5));
+        // Exponential when no Retry-After: 100, 200, 400 ms …
+        assert_eq!(backoff_delay(0, None, &p), Duration::from_millis(100));
+        assert_eq!(backoff_delay(2, None, &p), Duration::from_millis(400));
+    }
+
+    #[test]
+    fn retry_policy_default_is_conservative() {
+        let p = RetryPolicy::default();
+        assert!(p.max_retries >= 1);
+        assert!(p.max_requests_per_run >= p.page_size.min(p.max_pages));
+        assert!(p.base_delay <= p.max_delay);
+    }
+
+    #[test]
+    fn fetch_paginated_single_page_stops_on_totalhits() {
+        let body = r#"{ "totalHits": 2, "results": [
+            { "doi": "10.1/a", "title": "A" },
+            { "doi": "10.1/b", "title": "B" }
+        ] }"#;
+        let fake = FakeTransport::new(vec![ok(body)]);
+        let mut slept: Vec<Duration> = Vec::new();
+        let p = RetryPolicy {
+            page_size: 25,
+            ..RetryPolicy::default()
+        };
+        let res = fetch_paginated(&fake, "https://x.test/works/", "q", &p, &mut |d| {
+            slept.push(d)
+        })
+        .unwrap();
+        assert_eq!(res.stubs.len(), 2);
+        assert_eq!(res.pages_fetched, 1);
+        assert_eq!(res.requests_made, 1);
+        assert!(slept.is_empty(), "no retry => no sleep");
+        assert_eq!(*fake.calls.borrow(), 1);
+    }
+
+    #[test]
+    fn fetch_paginated_walks_multiple_pages() {
+        let page0 = r#"{ "totalHits": 4, "results": [
+            { "doi": "10.1/a", "title": "A" },
+            { "doi": "10.1/b", "title": "B" }
+        ] }"#;
+        let page1 = r#"{ "totalHits": 4, "results": [
+            { "doi": "10.1/c", "title": "C" },
+            { "doi": "10.1/d", "title": "D" }
+        ] }"#;
+        let fake = FakeTransport::new(vec![ok(page0), ok(page1)]);
+        let p = RetryPolicy {
+            page_size: 2,
+            ..RetryPolicy::default()
+        };
+        let res =
+            fetch_paginated(&fake, "https://x.test/works/", "q", &p, &mut |_| {}).unwrap();
+        assert_eq!(res.stubs.len(), 4);
+        assert_eq!(res.pages_fetched, 2);
+        assert_eq!(*fake.calls.borrow(), 2);
+    }
+
+    #[test]
+    fn fetch_paginated_retries_on_429_then_succeeds() {
+        let mut throttled = ok("");
+        throttled.status = 429;
+        throttled.retry_after = Some(1);
+        let good = r#"{ "totalHits": 1, "results": [ { "doi": "10.1/a", "title": "A" } ] }"#;
+        let fake = FakeTransport::new(vec![throttled, ok(good)]);
+        let mut slept: Vec<Duration> = Vec::new();
+        let res = fetch_paginated(&fake, "https://x.test/works/", "q", &RetryPolicy::default(), &mut |d| slept.push(d)).unwrap();
+        assert_eq!(res.stubs.len(), 1);
+        assert_eq!(res.requests_made, 2, "one 429 + one success");
+        assert_eq!(slept, vec![Duration::from_secs(1)], "slept the Retry-After");
+    }
+
+    #[test]
+    fn fetch_with_retry_honours_hard_request_cap() {
+        let mut throttled = ok("");
+        throttled.status = 429;
+        // Always 429 => never succeeds; the cap must stop it.
+        let fake = FakeTransport::new(vec![throttled.clone(), throttled.clone(), throttled]);
+        let p = RetryPolicy {
+            max_requests_per_run: 2,
+            max_retries: 10,
+            base_delay: Duration::from_millis(1),
+            ..RetryPolicy::default()
+        };
+        let mut requests = 0usize;
+        let err = fetch_with_retry(&fake, "u", &p, &mut requests, &mut |_| {}).unwrap_err();
+        assert!(err.contains("hard request cap"), "got: {}", err);
+        assert_eq!(requests, 2, "stopped exactly at the cap");
+    }
+
+    #[test]
+    fn fetch_with_retry_gives_up_after_max_retries() {
+        let mut throttled = ok("");
+        throttled.status = 503;
+        let fake = FakeTransport::new(vec![
+            throttled.clone(),
+            throttled.clone(),
+            throttled.clone(),
+            throttled,
+        ]);
+        let p = RetryPolicy {
+            max_retries: 2,
+            max_requests_per_run: 100,
+            base_delay: Duration::from_millis(1),
+            ..RetryPolicy::default()
+        };
+        let mut requests = 0usize;
+        let err = fetch_with_retry(&fake, "u", &p, &mut requests, &mut |_| {}).unwrap_err();
+        assert!(err.contains("gave up after 2 retries"), "got: {}", err);
+    }
+
+    #[test]
+    fn fetch_with_retry_non_retryable_4xx_is_hard_error() {
+        let mut forbidden = ok("");
+        forbidden.status = 403;
+        let fake = FakeTransport::new(vec![forbidden]);
+        let mut requests = 0usize;
+        let err =
+            fetch_with_retry(&fake, "u", &RetryPolicy::default(), &mut requests, &mut |_| {})
+                .unwrap_err();
+        assert!(err.contains("non-retryable HTTP status 403"), "got: {}", err);
+        assert_eq!(requests, 1);
+    }
+
+    #[test]
+    fn build_search_url_encodes_query_and_never_carries_a_key() {
+        let url = build_search_url("https://api.core.ac.uk/v3/search/works/", "zero knowledge", 10, 20);
+        assert_eq!(
+            url,
+            "https://api.core.ac.uk/v3/search/works/?q=zero%20knowledge&limit=10&offset=20"
+        );
+        assert!(!url.contains("Bearer"));
+        assert!(!url.to_lowercase().contains("key"));
+    }
+
+    #[test]
+    fn percent_encode_query_keeps_unreserved_and_encodes_the_rest() {
+        assert_eq!(percent_encode_query("a-b_c.d~e"), "a-b_c.d~e");
+        assert_eq!(percent_encode_query("a b&c"), "a%20b%26c");
+    }
+}

--- a/crates/sparq-kb/src/literature/extract.rs
+++ b/crates/sparq-kb/src/literature/extract.rs
@@ -186,6 +186,7 @@ mod tests {
             title: "orphan".to_string(),
             abstract_text: "x".to_string(),
             year: None,
+            license: None,
         };
         let cands = extractor.extract(std::slice::from_ref(&orphan)).unwrap();
         assert!(cands.is_empty());

--- a/crates/sparq-kb/tests/core_connector.rs
+++ b/crates/sparq-kb/tests/core_connector.rs
@@ -1,0 +1,210 @@
+//! CORE API v3 connector integration tests (sq-tzars.1) — exercise the REAL, SANITIZED
+//! `core-batch.json` fixture + the paging/retry logic over an injected fake transport, with
+//! ZERO network. Gated on `literature-live` (which implies `literature`), matching the
+//! acceptance command `cargo test -p sparq-kb --features literature,literature-live`.
+//! [SONNET-4.6] 🤖 SPARQ agent — research-KB live ingestion.
+#![cfg(feature = "literature-live")]
+
+use std::cell::RefCell;
+use std::time::Duration;
+
+use sparq_kb::literature::connector_core::{
+    backoff_delay, fetch_paginated, parse_core_batch, CoreClient, HttpResponse, RetryPolicy,
+    Transport,
+};
+use sparq_kb::literature::FIXTURE_CORE_BATCH;
+
+// -------------------------------------------------------------------------------------
+// parse_core_batch over the REAL recorded fixture.
+// -------------------------------------------------------------------------------------
+
+#[test]
+fn real_fixture_parses_to_two_stubs_one_skipped() {
+    let (stubs, skipped) = parse_core_batch(FIXTURE_CORE_BATCH).expect("fixture parses");
+    // 3 records: 2 carry a DOI, 1 has doi:null (skipped, never silently dropped).
+    assert_eq!(stubs.len(), 2, "two DOI-bearing works");
+    assert_eq!(skipped, 1, "the doi:null record is counted as skipped");
+    // DOIs are normalised (bare, lower-cased) and content-addressed.
+    let sparql = stubs
+        .iter()
+        .find(|s| s.doi == "10.1145/1754239.1754244")
+        .expect("SPARQL rewriting work present");
+    assert_eq!(sparql.year, Some(2010));
+    assert_eq!(
+        sparql.source_iri(),
+        "https://doi.org/10.1145/1754239.1754244"
+    );
+}
+
+#[test]
+fn real_fixture_every_stub_has_unknown_license_fail_closed() {
+    let (stubs, _) = parse_core_batch(FIXTURE_CORE_BATCH).unwrap();
+    // CORE v3's search schema carries no per-record license, so every stub is UNKNOWN
+    // (None) — which the downstream tiering treats as NON-REDISTRIBUTABLE (fail-closed).
+    assert!(
+        stubs.iter().all(|s| s.license.is_none()),
+        "unknown license captured as None"
+    );
+}
+
+// -------------------------------------------------------------------------------------
+// DOI normalisation + license capture (present + absent) on the CORE path.
+// -------------------------------------------------------------------------------------
+
+#[test]
+fn core_doi_is_normalised_from_resolver_prefixed_and_uppercase() {
+    let json = r#"{ "results": [
+        { "doi": "https://doi.org/10.5281/Zenodo.ABC", "title": "Prefixed + mixed case" }
+    ] }"#;
+    let (stubs, _) = parse_core_batch(json).unwrap();
+    assert_eq!(stubs.len(), 1);
+    assert_eq!(stubs[0].doi, "10.5281/zenodo.abc");
+}
+
+#[test]
+fn core_license_present_is_captured_absent_is_none() {
+    let json = r#"{ "results": [
+        { "doi": "10.1/a", "title": "licensed", "license": "cc-by" },
+        { "doi": "10.1/b", "title": "unlicensed" },
+        { "doi": "10.1/c", "title": "blank license", "license": "   " }
+    ] }"#;
+    let (stubs, _) = parse_core_batch(json).unwrap();
+    let by = |d: &str| stubs.iter().find(|s| s.doi == d).unwrap();
+    assert_eq!(by("10.1/a").license.as_deref(), Some("cc-by")); // present
+    assert_eq!(by("10.1/b").license, None); // absent => fail-closed
+    assert_eq!(by("10.1/c").license, None); // blank => treated as absent
+}
+
+// -------------------------------------------------------------------------------------
+// Retry / backoff / rate-limit discipline via an injected fake transport (no sockets).
+// -------------------------------------------------------------------------------------
+
+/// A scripted fake transport — replays a queue of responses, counting calls. No network.
+struct FakeTransport {
+    queue: RefCell<Vec<HttpResponse>>,
+    calls: RefCell<usize>,
+}
+impl FakeTransport {
+    fn new(queue: Vec<HttpResponse>) -> Self {
+        Self {
+            queue: RefCell::new(queue),
+            calls: RefCell::new(0),
+        }
+    }
+}
+impl Transport for FakeTransport {
+    fn get(&self, _url: &str) -> Result<HttpResponse, String> {
+        *self.calls.borrow_mut() += 1;
+        let mut q = self.queue.borrow_mut();
+        if q.is_empty() {
+            Ok(resp(200, None, r#"{ "totalHits": 0, "results": [] }"#))
+        } else {
+            Ok(q.remove(0))
+        }
+    }
+}
+
+fn resp(status: u16, retry_after: Option<u64>, body: &str) -> HttpResponse {
+    HttpResponse {
+        status,
+        retry_after,
+        body: body.to_string(),
+    }
+}
+
+#[test]
+fn retries_on_429_respecting_retry_after_then_succeeds() {
+    let good = r#"{ "totalHits": 1, "results": [ { "doi": "10.1/a", "title": "A" } ] }"#;
+    let fake = FakeTransport::new(vec![resp(429, Some(2), ""), resp(200, None, good)]);
+    let mut slept: Vec<Duration> = Vec::new();
+    let out = fetch_paginated(
+        &fake,
+        "https://x.test/works/",
+        "zk sparql",
+        &RetryPolicy::default(),
+        &mut |d| slept.push(d),
+    )
+    .expect("succeeds after one retry");
+    assert_eq!(out.stubs.len(), 1);
+    assert_eq!(out.requests_made, 2, "one throttled + one success");
+    assert_eq!(*fake.calls.borrow(), 2);
+    // Honoured the server's Retry-After (2s), not the exponential fallback.
+    assert_eq!(slept, vec![Duration::from_secs(2)]);
+}
+
+#[test]
+fn exponential_backoff_when_no_retry_after_header() {
+    let p = RetryPolicy {
+        base_delay: Duration::from_millis(250),
+        max_delay: Duration::from_secs(60),
+        ..RetryPolicy::default()
+    };
+    assert_eq!(backoff_delay(0, None, &p), Duration::from_millis(250));
+    assert_eq!(backoff_delay(1, None, &p), Duration::from_millis(500));
+    assert_eq!(backoff_delay(3, None, &p), Duration::from_millis(2000));
+}
+
+#[test]
+fn hard_request_cap_stops_a_persistently_throttled_endpoint() {
+    let p = RetryPolicy {
+        max_requests_per_run: 3,
+        max_retries: 100,
+        base_delay: Duration::from_millis(1),
+        ..RetryPolicy::default()
+    };
+    // Endpoint always 429s; the cap must halt it (never an unbounded retry loop).
+    let fake = FakeTransport::new(vec![
+        resp(429, None, ""),
+        resp(429, None, ""),
+        resp(429, None, ""),
+        resp(429, None, ""),
+    ]);
+    let err = fetch_paginated(&fake, "https://x.test/works/", "q", &p, &mut |_| {})
+        .expect_err("cap trips");
+    assert!(err.contains("hard request cap"), "got: {}", err);
+    assert_eq!(*fake.calls.borrow(), 3, "stopped exactly at the request cap");
+}
+
+// -------------------------------------------------------------------------------------
+// CoreClient::from_env — key read from the environment, NEVER logged. No network.
+// -------------------------------------------------------------------------------------
+
+#[test]
+fn from_env_errors_without_key_and_succeeds_with_a_dummy_key() {
+    // This is the only test that touches CORE_API_KEY; keep the mutation confined here.
+    let saved = std::env::var("CORE_API_KEY").ok();
+
+    std::env::remove_var("CORE_API_KEY");
+    // NB: `CoreClient` deliberately does NOT derive `Debug` (it holds the key), so use
+    // `.err()` rather than `expect_err` (which would require `T: Debug`).
+    let err = CoreClient::from_env()
+        .err()
+        .expect("missing key is an error");
+    assert!(err.contains("CORE_API_KEY"));
+    // The error must NOT leak any value (there is none, but assert the shape stays generic).
+    assert!(!err.to_lowercase().contains("bearer"));
+
+    // A dummy value (NOT the real key) proves the read path without any network call.
+    std::env::set_var("CORE_API_KEY", "dummy-test-value-not-a-real-key");
+    assert!(CoreClient::from_env().is_ok(), "a set key constructs a client");
+    // with_policy / policy accessor (no network): the override is reflected.
+    let client = CoreClient::from_env()
+        .unwrap()
+        .with_policy(RetryPolicy {
+            max_pages: 1,
+            ..RetryPolicy::default()
+        });
+    assert_eq!(client.policy().max_pages, 1);
+
+    std::env::set_var("CORE_API_KEY", "   ");
+    assert!(
+        CoreClient::from_env().is_err(),
+        "a blank key is rejected (fail-closed)"
+    );
+
+    // Restore the environment for any other test in this binary.
+    match saved {
+        Some(v) => std::env::set_var("CORE_API_KEY", v),
+        None => std::env::remove_var("CORE_API_KEY"),
+    }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead `sq-tzars.1` (epic `sq-tzars`, design record `research/research-kb-program.md`, decomposition PR #1519). Net-new CORE API v3 live literature connector, opt-in behind a new default-OFF `literature-live` cargo feature. This PR is NOT armed — leaving arming to the orchestrator.

## What this implements

A live HTTP connector for **CORE API v3** (`/v3/search/works`), gated behind a new default-OFF **`literature-live`** cargo feature in `crates/sparq-kb` (implies `literature`). The default build of `sparq-kb` is **unchanged and socket-free**.

- **`connector_core::parse_core_batch`** produces the SAME DOI-keyed `SourceStub`s as the existing `parse_openalex_batch`, so the downstream pipeline stays source-agnostic (design §4.2).
- **`SourceStub` gains `license: Option<String>`**, captured **fail-closed** by BOTH connectors: `None` (unknown) is treated as **NON-REDISTRIBUTABLE** by the downstream dump tiering (`sq-tzars.7`). Verified against the live API: CORE v3's search schema omits per-record licence, so `None` is the norm — exactly the fail-closed default.
- **Rate-limit + retry discipline**: honours HTTP `429`/transient `5xx` with `Retry-After` (bounded), bounded exponential backoff otherwise, a **HARD per-run request cap** + page caps. The pure logic drives an injected `Transport` trait, so CI exercises paging/retry over a **fake transport** with ZERO sockets.
- **The live socket layer** (`UreqTransport` + `CoreClient`, behind `literature-live`) is the ONLY networked part and is **NEVER driven in CI**. It pulls only `ureq` (already vendored for the engine's SERVICE transport → **no new lockfile entry**).

## Security posture (HARD constraints honoured)

- The CORE key is read from the `CORE_API_KEY` env var **at run time only** — never committed, logged, or placed in a URL. It travels solely in the `Authorization: Bearer …` header and **no error message interpolates it**. `CoreClient` deliberately does not derive `Debug` (it holds the key).
- **ZERO network in CI**: all tests replay the committed fixture / a fake transport.
- Fixture `fixtures/literature/core-batch.json` is a **REAL, SANITIZED** CORE `/v3/search/works` response recorded once locally, then scrubbed — **no key/auth**, copyrighted `fullText` + download URLs removed, abstracts truncated to de-minimis metadata, session tokens nulled. Real DOIs/titles/years retained (bibliographic metadata). A repo-wide scan confirms the key value appears in **0** files.

## Gates (green in BOTH feature states)

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — green **default (feature OFF, unchanged)** AND **`--features literature,literature-live`** (31 lib unit + 8 integration tests). Also verified `--features literature` alone (ureq NOT in that graph).
- `RUSTDOCFLAGS="-D warnings" cargo doc --all-features` clean, and the default-features rustdoc run is clean too (no feature-gated intra-doc-link trap — code spans used).
- `readme-template` — README stays at 120 lines, 0 deviations. `SKILL.md` (query-pkg) synced.
- One direct unit test per new public fn (`parse_core_batch`, `backoff_delay`, `is_retryable_status`, `fetch_paginated`, `RetryPolicy::default`, `CoreClient::from_env`/`with_policy`/`policy`).

## Honest boundaries

- CORE v3 search does not return per-record licences, so every real stub is `license: None` = restricted; the "licence present" branch is tested with inline records (some providers/other endpoints do supply it).
- MPC is out of scope here; no ZK/MPC/privacy claim about sparq's own verifier is made (external audit still pending, `sq-qhy4`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)