### PR TITLE
(sq-1odi9) GUI rail: split working Tools from Coming-soon subgroup

### DIFF
--- a/gui/app/src/components/workbench/left-rail.tsx
+++ b/gui/app/src/components/workbench/left-rail.tsx
@@ -10,7 +10,7 @@
 //   (3) TOOLS list — each a VERB opened as a tab with an honesty-tier dot (NOT a page).
 
 import * as React from "react";
-import { ChevronDown, Plus, Circle, Database, FolderTree, FileUp, Link2 } from "lucide-react";
+import { ChevronDown, ChevronRight, Plus, Circle, Database, FolderTree, FileUp, Link2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useEngine } from "@/lib/engine-context";
@@ -18,6 +18,7 @@ import { useWorkspace } from "@/lib/workspace-context";
 import { useImportDrawer } from "@/components/workbench/import-drawer";
 import { ExportDataMenu } from "@/components/workbench/store-export";
 import { TIER_META, type ToolDef } from "@/data/tools";
+import { resolveTool } from "@/components/workbench/tool-panel";
 
 interface LeftRailProps {
   tools: ToolDef[];
@@ -139,6 +140,51 @@ function Section({
 }
 
 export function LeftRail({ tools, activeId, onOpenTool }: LeftRailProps) {
+  // [SONNET-4.6] sq-1odi9 — rail honesty regrouping: split working tools from coming-soon stubs.
+  const [comingSoonOpen, setComingSoonOpen] = React.useState(false);
+
+  // Grouping is DATA-DRIVEN off resolveTool(id).group so panel-file overrides (sq-lxomy /
+  // sq-9nwab / sq-kwb74 / sq-iemfq) auto-move tools when they flip their panel override.
+  const workingTools = tools.filter((t) => (resolveTool(t.id) ?? t).group === "working");
+  const comingSoonTools = tools.filter((t) => (resolveTool(t.id) ?? t).group === "coming-soon");
+
+  function renderToolButton(tool: ToolDef, toolGroup: "working" | "coming-soon") {
+    const Icon = tool.icon;
+    const resolved = resolveTool(tool.id) ?? tool;
+    const tier = TIER_META[resolved.tier];
+    const isActive = tool.id === activeId;
+    return (
+      <li key={tool.id}>
+        {/* [OPUS-4.8] sq-ixc3.11 — `data-tool` is a stable e2e/test hook for selecting a
+            tool in the rail (the tauri-driver smoke clicks data-tool="shacl"). */}
+        <button
+          data-tool={tool.id}
+          data-tool-group={toolGroup}
+          onClick={() => onOpenTool(tool.id)}
+          className={cn(
+            "group flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-sidebar-accent/50",
+            // [OPUS-4.8] sq-vw3ax (#820 redesign) — the active tool gets the accent-lit
+            // teal spine (a glowing left bar), not just a tint, so the brand leads.
+            isActive && "sq-active-spine font-medium",
+          )}
+          title={`${resolved.blurb} — ${tier.label}`}
+        >
+          <Icon
+            className={cn(
+              "size-3.5 shrink-0",
+              isActive ? "text-primary" : "text-muted-foreground",
+            )}
+          />
+          <span className="min-w-0 flex-1 truncate">{tool.label}</span>
+          <span
+            className={cn("size-2 shrink-0 rounded-full", tier.dot)}
+            aria-hidden
+          />
+        </button>
+      </li>
+    );
+  }
+
   return (
     <nav className="flex w-56 shrink-0 flex-col overflow-y-auto border-r bg-sidebar text-sidebar-foreground">
       {/* (1) Workspace switcher — the persistent model is sq-atb0; foundation = default. */}
@@ -158,44 +204,33 @@ export function LeftRail({ tools, activeId, onOpenTool }: LeftRailProps) {
         <DatasetsTree />
       </Section>
 
-      {/* (3) TOOLS — each a VERB opened as a tab with its honesty-tier dot. */}
+      {/* (3) TOOLS — each a VERB opened as a tab with its honesty-tier dot.
+          [SONNET-4.6] sq-1odi9 — split into working (visible) + coming-soon (collapsed subgroup). */}
       <Section label="Tools">
-        <ul className="px-1 pb-2">
-          {tools.map((tool) => {
-            const Icon = tool.icon;
-            const tier = TIER_META[tool.tier];
-            const isActive = tool.id === activeId;
-            return (
-              <li key={tool.id}>
-                {/* [OPUS-4.8] sq-ixc3.11 — `data-tool` is a stable e2e/test hook for selecting a
-                    tool in the rail (the tauri-driver smoke clicks data-tool="shacl"). */}
-                <button
-                  data-tool={tool.id}
-                  onClick={() => onOpenTool(tool.id)}
-                  className={cn(
-                    "group flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs hover:bg-sidebar-accent/50",
-                    // [OPUS-4.8] sq-vw3ax (#820 redesign) — the active tool gets the accent-lit
-                    // teal spine (a glowing left bar), not just a tint, so the brand leads.
-                    isActive && "sq-active-spine font-medium",
-                  )}
-                  title={`${tool.blurb} — ${tier.label}`}
-                >
-                  <Icon
-                    className={cn(
-                      "size-3.5 shrink-0",
-                      isActive ? "text-primary" : "text-muted-foreground",
-                    )}
-                  />
-                  <span className="min-w-0 flex-1 truncate">{tool.label}</span>
-                  <span
-                    className={cn("size-2 shrink-0 rounded-full", tier.dot)}
-                    aria-hidden
-                  />
-                </button>
-              </li>
-            );
-          })}
+        <ul className="px-1 pb-1">
+          {workingTools.map((tool) => renderToolButton(tool, "working"))}
         </ul>
+
+        {/* Coming soon subgroup — collapsed by default; expand to see honest stubs. */}
+        <div className="px-1 pb-2">
+          <button
+            data-rail-section="coming-soon-toggle"
+            aria-expanded={comingSoonOpen}
+            onClick={() => setComingSoonOpen((o) => !o)}
+            className="flex w-full items-center gap-1 px-2 py-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground hover:text-foreground"
+          >
+            <ChevronRight
+              className={cn("size-3 shrink-0 transition-transform", comingSoonOpen && "rotate-90")}
+            />
+            <span>Coming soon</span>
+            <span className="ml-1 tabular-nums">({comingSoonTools.length})</span>
+          </button>
+          {comingSoonOpen && (
+            <ul className="mt-0.5">
+              {comingSoonTools.map((tool) => renderToolButton(tool, "coming-soon"))}
+            </ul>
+          )}
+        </div>
       </Section>
     </nav>
   );

--- a/gui/e2e-playwright/specs/rail-groups.spec.ts
+++ b/gui/e2e-playwright/specs/rail-groups.spec.ts
@@ -1,0 +1,98 @@
+// [SONNET-4.6] sq-1odi9 — rail honesty regrouping: working tools vs coming-soon stub subgroup.
+//
+// Verifies the two-group split in left-rail.tsx is data-driven from the panel registry:
+//   [data-tool-group="working"]       — rendered visible by default
+//   [data-tool-group="coming-soon"]   — inside the collapsed subgroup; hidden by default
+//   [data-rail-section="coming-soon-toggle"] — the toggle button that expands/collapses
+//
+// Test strategy: expectations are DERIVED from [data-tool-group] DOM attributes (which the
+// registry writes at render time) — never from a hardcoded list of tool ids. This stays
+// correct as sibling PRs (sq-lxomy / sq-9nwab / sq-kwb74 / sq-iemfq) flip tools to "working".
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only.
+
+import { test, expect } from "../support/index.ts";
+
+test.describe("rail-groups", () => {
+  test("working-group tools are visible by default", async ({ page }) => {
+    // There should be at least one working tool in the rail at all times.
+    const first = page.locator("[data-tool-group='working']").first();
+    await expect(first).toBeVisible();
+  });
+
+  test("coming-soon tools are hidden when section is collapsed (default)", async ({ page }) => {
+    // The coming-soon subgroup starts collapsed — tools should not be in the visible DOM.
+    const first = page.locator("[data-tool-group='coming-soon']").first();
+    await expect(first).not.toBeVisible();
+  });
+
+  test("Coming-soon toggle exists in the rail", async ({ page }) => {
+    const toggle = page.locator("[data-rail-section='coming-soon-toggle']");
+    await expect(toggle).toBeVisible();
+    // Initially collapsed: aria-expanded=false
+    await expect(toggle).toHaveAttribute("aria-expanded", "false");
+  });
+
+  test("expanding Coming soon reveals all stub tools", async ({ page }) => {
+    const toggle = page.locator("[data-rail-section='coming-soon-toggle']");
+    await toggle.click();
+
+    // aria-expanded flips
+    await expect(toggle).toHaveAttribute("aria-expanded", "true");
+
+    // At least one coming-soon tool is now visible
+    const firstStub = page.locator("[data-tool-group='coming-soon']").first();
+    await expect(firstStub).toBeVisible();
+  });
+
+  test("collapsing Coming soon hides stub tools again", async ({ page }) => {
+    const toggle = page.locator("[data-rail-section='coming-soon-toggle']");
+    // Expand first
+    await toggle.click();
+    await expect(page.locator("[data-tool-group='coming-soon']").first()).toBeVisible();
+    // Collapse
+    await toggle.click();
+    await expect(page.locator("[data-tool-group='coming-soon']").first()).not.toBeVisible();
+  });
+
+  test("working tools remain visible when Coming soon section is expanded", async ({ page }) => {
+    const toggle = page.locator("[data-rail-section='coming-soon-toggle']");
+    await toggle.click();
+
+    // Working tools must still be visible after expanding the coming-soon section
+    await expect(page.locator("[data-tool-group='working']").first()).toBeVisible();
+  });
+
+  test("every tool with data-tool-group=coming-soon has an honesty-tier dot", async ({ page }) => {
+    // Expand the coming-soon section so the tools are rendered
+    const toggle = page.locator("[data-rail-section='coming-soon-toggle']");
+    await toggle.click();
+    await expect(page.locator("[data-tool-group='coming-soon']").first()).toBeVisible();
+
+    // Each coming-soon tool button must contain an honesty-tier dot (span[aria-hidden])
+    const stubTools = page.locator("[data-tool-group='coming-soon']");
+    const count = await stubTools.count();
+    // There must be at least one coming-soon tool (sanity)
+    expect(count).toBeGreaterThan(0);
+    for (let i = 0; i < count; i++) {
+      const dot = stubTools.nth(i).locator("span[aria-hidden]");
+      await expect(dot).toBeAttached();
+    }
+  });
+
+  test("every tool remains reachable from the rail (data-tool integrity)", async ({ page }) => {
+    // Expand coming-soon to get all tools rendered
+    await page.locator("[data-rail-section='coming-soon-toggle']").click();
+
+    // Every [data-tool] button in the rail must have a non-empty data-tool-group
+    const allToolBtns = page.locator("[data-tool][data-tool-group]");
+    const count = await allToolBtns.count();
+    expect(count).toBeGreaterThan(0);
+
+    for (let i = 0; i < count; i++) {
+      const btn = allToolBtns.nth(i);
+      const group = await btn.getAttribute("data-tool-group");
+      expect(["working", "coming-soon"]).toContain(group);
+    }
+  });
+});


### PR DESCRIPTION
> 🤖 SPARQ agent implementing bead sq-1odi9 — rail honesty regrouping

## Summary
- Split the left-rail Tools section into "Tools" (working) and "Coming soon" (collapsed by default)
- Grouping is DATA-DRIVEN off `resolveTool(id).group` so sibling PRs (sq-lxomy / sq-9nwab / sq-kwb74 / sq-iemfq) auto-move tools when they flip their panel override
- Every tool stays reachable (rail subgroup + Cmd-K); honesty dots and ZK/MPC caveats unchanged

## Test plan
- [ ] `npm run lint` green
- [ ] `npm run typecheck` green
- [ ] `npm run build:tauri` green
- [ ] `npm run build:web` green
- [ ] `gui/e2e-playwright/specs/rail-groups.spec.ts` — 7 new Playwright assertions covering: working visible, coming-soon hidden, toggle expand/collapse, honesty dots, data-tool integrity