### PR TITLE
feat(gui): full-text BM25 search panel — wire sparq-text-wasm bundle (sq-9nwab)

### DIFF
--- a/gui/app/src/components/workbench/full-text-tool.tsx
+++ b/gui/app/src/components/workbench/full-text-tool.tsx
@@ -1,12 +1,27 @@
 "use client";
 
-// [FABLE-5] sq-5lyme — the Full-text tool's OWN panel file (tool-panel registry seam).
-// Today it renders the exact honest stub it always did; sq-9nwab fills it with the BM25
-// search panel over the sparq-text-wasm bundle. When that lands, flip the honesty metadata
-// via FULL_TEXT_TOOL_OVERRIDE below — never by editing the shared data/tools.ts — so
-// parallel tool beads stay file-disjoint.
+// [SONNET-4.6] sq-9nwab — the Full-text tool: BM25 search panel over the sparq-text-wasm bundle.
+//
+// Translation rule (research/gui-design.md §A.4/§A.5): the website's /surface/full-text PAGE
+// demonstrates BM25 search over a fixture document, wrapped in marketing chrome. Here that chrome
+// is CUT. The tool searches the ACTIVE workspace's LIVE store (not a fixture) using the text:
+// magic predicates exposed by the W-text wasm bundle.
+//
+// What runs: the live store is serialised to TriG (preserving every named graph) and passed to
+// TextSearch.query() along with a SPARQL query using text:matches / text:score. The bundle is
+// SEPARATE from the lean sparq-wasm triplestore engine — it is OPTIONAL. A build that did not
+// sync it surfaces an honest "search unavailable" state rather than crashing or silently failing.
+//
+// This is a keyboard-first operational panel: Enter submits the search (not only the button).
 
-import { ToolStub } from "@/components/workbench/tool-stub";
+import * as React from "react";
+import { Search, Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { useEngine } from "@/lib/engine-context";
+import { loadTextSearch } from "@/lib/text-wasm";
+import { TIER_META, toolById } from "@/data/tools";
 import type { ToolOverride } from "@/data/tools";
 
 /**
@@ -14,8 +29,245 @@ import type { ToolOverride } from "@/data/tools";
  * tool-panel registry's `resolveTool` and by the stub itself. `undefined` = base metadata
  * unchanged. Omit fields you do not override.
  */
-export const FULL_TEXT_TOOL_OVERRIDE: ToolOverride | undefined = undefined;
+export const FULL_TEXT_TOOL_OVERRIDE: ToolOverride | undefined = {
+  built: true,
+  group: "working" as const,
+};
+
+interface HitRow {
+  subject: string;
+  property: string;
+  literal: string;
+  score: string;
+}
+
+type SearchState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "results"; hits: HitRow[]; ms: number; storeQuads: number }
+  | { kind: "error"; message: string };
+
+interface SparqlJsonResult {
+  head: { vars: string[] };
+  results: {
+    bindings: Record<string, { type: string; value: string; datatype?: string }>[];
+  };
+}
+
+/** Escape double quotes and backslashes in a term for SPARQL string literal safety. */
+function buildSearchQuery(term: string): string {
+  const escaped = term.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+  return `PREFIX text: <http://sparq.dev/text#>
+SELECT ?s ?prop ?lit ?score WHERE {
+  ?s ?prop ?lit .
+  ?lit text:matches "${escaped}" ; text:score ?score .
+} ORDER BY DESC(?score) LIMIT 50`;
+}
+
+/** Compact a full IRI to a short form if it's long; strip angle brackets if present. */
+function shortenIri(s: string): string {
+  const inner = s.startsWith("<") && s.endsWith(">") ? s.slice(1, -1) : s;
+  // Show only the last path/fragment segment for readability; full IRI on hover.
+  const m = inner.match(/[#/]([^#/]+)\/?$/);
+  return m ? m[1] : inner;
+}
+
+function HitItem({ hit }: { hit: HitRow }) {
+  return (
+    <div className="border-b px-3 py-2 text-xs" data-text-hit>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-mono text-[11px] text-muted-foreground" title={hit.subject}>
+          {shortenIri(hit.subject)}
+        </span>
+        <span className="text-[11px] text-muted-foreground" title={hit.property}>
+          · {shortenIri(hit.property)}
+        </span>
+        <span className="ml-auto text-[11px] tabular text-muted-foreground">
+          score {parseFloat(hit.score).toFixed(3)}
+        </span>
+      </div>
+      <p className="mt-0.5 break-words">{hit.literal}</p>
+    </div>
+  );
+}
 
 export function FullTextTool() {
-  return <ToolStub toolId="full-text" override={FULL_TEXT_TOOL_OVERRIDE} />;
+  const { status, storeSize, serializeStore } = useEngine();
+  const [term, setTerm] = React.useState("");
+  const [state, setState] = React.useState<SearchState>({ kind: "idle" });
+  const [bundleError, setBundleError] = React.useState<string | null>(null);
+
+  const ready = status.kind === "ready";
+  const tool = toolById("full-text");
+  const tier = tool ? TIER_META[tool.tier] : null;
+
+  // Eagerly probe the bundle on mount (once). This surfaces the unavailable state BEFORE the
+  // user clicks Search, so the honest [data-text-unavailable] block appears immediately for a
+  // build that did not sync the text wasm, and the test can branch correctly between the
+  // "bundle available" and "bundle unavailable" paths without requiring a Search click first.
+  React.useEffect(() => {
+    let cancelled = false;
+    loadTextSearch().then(
+      () => {
+        // Bundle loaded OK — no state change needed; search UI stays enabled.
+      },
+      (err: unknown) => {
+        if (!cancelled) {
+          setBundleError(err instanceof Error ? err.message : String(err));
+        }
+      },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onSearch = React.useCallback(async () => {
+    if (!term.trim()) return;
+    setState({ kind: "running" });
+
+    // Load the text-wasm bundle (cached after the mount probe succeeds).
+    let textSearch;
+    try {
+      textSearch = await loadTextSearch();
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      setBundleError(msg);
+      setState({ kind: "idle" });
+      return;
+    }
+
+    const data = serializeStore();
+    if (data === null) {
+      setState({
+        kind: "error",
+        message:
+          "The live store is not ready (or this wasm bundle lacks the serialise binding), so it cannot be serialised for search.",
+      });
+      return;
+    }
+
+    const t0 = performance.now();
+    try {
+      const sparql = buildSearchQuery(term);
+      const jsonStr = textSearch.query(data, "trig", sparql);
+      const result = JSON.parse(jsonStr) as SparqlJsonResult;
+      const hits: HitRow[] = result.results.bindings.map((b) => ({
+        subject: b["s"]?.value ?? "",
+        property: b["prop"]?.value ?? "",
+        literal: b["lit"]?.value ?? "",
+        score: b["score"]?.value ?? "0",
+      }));
+      setState({
+        kind: "results",
+        hits,
+        ms: performance.now() - t0,
+        storeQuads: storeSize,
+      });
+    } catch (err) {
+      setState({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }, [term, serializeStore, storeSize]);
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      void onSearch();
+    }
+  };
+
+  const searchDisabled =
+    !ready || bundleError !== null || !term.trim() || state.kind === "running";
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header bar: icon + label + tier dot + search input + button */}
+      <div className="flex items-center gap-2 border-b bg-card px-3 py-1.5">
+        <Search className="size-3.5 shrink-0 text-muted-foreground" aria-hidden />
+        <span className="text-xs font-medium">Full-text</span>
+        {tier ? (
+          <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
+            <span className={cn("size-2 rounded-full", tier.dot)} aria-hidden />
+            {tier.label}
+          </span>
+        ) : null}
+        <input
+          data-text-search-input
+          type="text"
+          value={term}
+          onChange={(e) => setTerm(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Enter a search term…"
+          disabled={!ready || bundleError !== null}
+          className="ml-2 min-w-0 flex-1 rounded-md border bg-background px-2 py-1 text-xs outline-none focus:ring-1 focus:ring-primary disabled:opacity-50"
+          aria-label="Full-text search term"
+        />
+        <Button
+          data-text-search-btn
+          size="sm"
+          onClick={() => void onSearch()}
+          disabled={searchDisabled}
+        >
+          {state.kind === "running" ? <Loader2 className="animate-spin" /> : <Search />}
+          Search
+        </Button>
+      </div>
+
+      {/* Bundle unavailable: honest error with rebuild instruction. Rendered once the
+          mount-time probe resolves with a failure (set via the useEffect above). */}
+      {bundleError !== null ? (
+        <div
+          data-text-unavailable
+          className="m-3 rounded-md border border-[var(--warning)]/40 bg-[var(--warning)]/5 p-3 text-xs text-muted-foreground"
+        >
+          The full-text search bundle could not load: {bundleError}. It is a separate wasm
+          bundle — rebuild it with{" "}
+          <code className="rounded bg-muted px-1 py-0.5">npm run build:text-wasm</code> in{" "}
+          <code className="rounded bg-muted px-1 py-0.5">js/</code>. Until then, search is
+          unavailable.
+        </div>
+      ) : null}
+
+      {/* Results pane */}
+      <div data-text-results className="flex min-h-0 flex-1 flex-col overflow-auto">
+        {bundleError !== null ? null : state.kind === "idle" ? (
+          <p className="p-3 text-sm text-muted-foreground">
+            {ready
+              ? "Enter a term to search the live store."
+              : "Waiting for the engine to warm…"}
+          </p>
+        ) : state.kind === "running" ? (
+          <p className="p-3 text-sm text-muted-foreground">Searching…</p>
+        ) : state.kind === "error" ? (
+          <pre className="overflow-auto whitespace-pre-wrap p-3 font-mono text-xs text-destructive">
+            {state.message}
+          </pre>
+        ) : state.hits.length === 0 ? (
+          <p className="p-3 text-sm text-muted-foreground">
+            No results found for &ldquo;{term}&rdquo; in{" "}
+            {state.storeQuads.toLocaleString()} quads ({state.ms.toFixed(1)} ms).
+          </p>
+        ) : (
+          <>
+            <div className="flex items-center gap-2 border-b bg-card px-3 py-1 text-[11px] text-muted-foreground">
+              <span>
+                {state.hits.length} {state.hits.length === 1 ? "result" : "results"}
+              </span>
+              <span className="ml-auto tabular">
+                {state.ms.toFixed(1)} ms over {state.storeQuads.toLocaleString()} quads
+              </span>
+            </div>
+            <div>
+              {state.hits.map((hit, i) => (
+                <HitItem key={i} hit={hit} />
+              ))}
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
 }

--- a/gui/app/src/lib/text-wasm.ts
+++ b/gui/app/src/lib/text-wasm.ts
@@ -1,0 +1,60 @@
+// [SONNET-4.6] sq-9nwab — the GUI-side loader for the tier-b "W-text" wasm bundle
+// (crates/sparq-text-wasm), the SAME BM25 full-text search engine the marketing site's
+// /surface/full-text page runs (site/src/lib/text-wasm.ts). It is a SEPARATE, lazy-loaded
+// bundle from the lean sparq-wasm triplestore engine the workbench queries with: the BM25
+// inverted index + text: magic predicates, built on demand over the live store's serialised
+// TriG so a query can match an indexed literal.
+//
+// Like the reason-wasm loader, the wasm-pack glue is imported at RUNTIME with a webpackIgnore
+// dynamic import from /public, so the wasm never enters the page bundle; the asset URLs are
+// prefixed with the SAME NEXT_PUBLIC_BASE_PATH the rest of the GUI keys off (@/lib/base-path),
+// so they resolve under both the Tauri root-relative export and the hosted "/app" sub-path.
+// The bundle is OPTIONAL: a build that did not sync it surfaces an honest "search unavailable"
+// state at runtime rather than crashing.
+
+import { basePath } from "@/lib/base-path";
+
+/**
+ * The JS-facing `TextSearch` surface the W-text bundle exports (mirrors crates/sparq-text-wasm
+ * and the site loader). Every method is a STATELESS one-shot: it parses the supplied document,
+ * builds the BM25 index, and returns a string — so the JS side never holds a long-lived index
+ * handle. Document `format` is one of `"turtle"` | `"ntriples"` | `"nquads"` | `"trig"`
+ * (named graphs are folded into the default graph so the index covers every literal).
+ */
+export interface WasmTextSearch {
+  /** Run a SPARQL query with text: magic predicates; returns SPARQL-1.1-JSON string. Throws JsError. */
+  query(data: string, format: string, sparql: string): string;
+  /** Index footprint: `{"docs":N,"tokens":M,"heapBytes":B,"hasPositions":bool}` JSON. Throws JsError. */
+  indexStats(data: string, format: string): string;
+}
+
+interface TextModule {
+  default: (opts?: { module_or_path: string | URL }) => Promise<unknown>;
+  TextSearch: WasmTextSearch;
+}
+
+let modulePromise: Promise<TextModule> | null = null;
+
+/**
+ * [SONNET-4.6] sq-9nwab — load + initialise the W-text bundle once; subsequent calls reuse it.
+ * The fetch + compile + instantiate is the expensive cold start (paid the first time the full-text
+ * tool is opened). A failed load resets the cache so a later attempt retries (e.g. after a build
+ * that syncs the bundle). Rejects when the bundle is not present in this build.
+ */
+export async function loadTextSearch(): Promise<WasmTextSearch> {
+  if (!modulePromise) {
+    modulePromise = (async () => {
+      const base = basePath();
+      const gluePath = `${base}/wasm/text/sparq_text_wasm.js`;
+      const wasmPath = `${base}/wasm/text/sparq_text_wasm_bg.wasm`;
+      const mod = (await import(/* webpackIgnore: true */ gluePath)) as TextModule;
+      await mod.default({ module_or_path: new URL(wasmPath, window.location.origin) });
+      return mod;
+    })();
+    modulePromise.catch(() => {
+      modulePromise = null; // allow retry on transient failure / a later synced build
+    });
+  }
+  const mod = await modulePromise;
+  return mod.TextSearch;
+}

--- a/gui/e2e-playwright/specs/full-text-tool.spec.ts
+++ b/gui/e2e-playwright/specs/full-text-tool.spec.ts
@@ -1,0 +1,67 @@
+// [SONNET-4.6] sq-9nwab — full-text BM25 search panel journey (desktop / mock-IPC persona).
+//
+// Runs under chromium-mock-ipc (Tauri IPC mock). The auto-fixture `tauriMock` navigates to "/"
+// and waits for engine ready before the test body runs.
+//
+// The W-text wasm bundle may or may not be present in the test build. The spec distinguishes:
+//   * Bundle UNAVAILABLE → the mount-time probe sets bundleError; [data-text-unavailable] appears
+//     automatically (no Search click needed). Asserts the honest rebuild hint.
+//   * Bundle AVAILABLE   → the search input is enabled; asserts a real BM25 query returns at
+//     least one "Alice" hit from the sample graph (non-vacuous, no blanket pass).
+//
+// Stable selectors (all declared in full-text-tool.tsx):
+//   data-tool="full-text"        — left-rail nav button for the Full-text tool
+//   data-text-search-input       — the search term input (always present; disabled when unavailable)
+//   data-text-search-btn         — the Search button
+//   data-text-results            — the results container div
+//   data-text-unavailable        — the honest unavailable error block (mount-time probe failure)
+//   data-text-hit                — each individual hit row (for counting hits)
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only.
+
+import { test, expect } from "../support/index.ts";
+
+test.describe("full-text-tool", () => {
+  test("full-text tool shows BM25 results or honest unavailable state", async ({ page }) => {
+    // Navigate to the Full-text tab via the left rail.
+    await page.locator('[data-tool="full-text"]').click();
+
+    const unavailableEl = page.locator("[data-text-unavailable]");
+    const searchInput = page.locator("[data-text-search-input]");
+
+    // The search input is ALWAYS rendered (visible when the tab opens). Wait for it — this is
+    // a fast assertion that just confirms the FullTextTool panel mounted.
+    await expect(searchInput).toBeVisible({ timeout: 10_000 });
+
+    // The mount-time probe fires and resolves quickly (a network fetch of the wasm JS glue).
+    // Wait for EITHER the unavailable block to appear (bundle missing) OR the input to become
+    // enabled (bundle loaded). A disabled input means the probe is still in flight or failed;
+    // we poll both outcomes so the test settles as soon as either resolves.
+    //
+    // Strategy: wait up to 30s for the unavailable block; if it doesn't appear, the bundle
+    // loaded successfully and the input should be enabled.
+    const unavailableOrEnabled = unavailableEl.or(
+      page.locator("[data-text-search-input]:not([disabled])"),
+    );
+    await expect(unavailableOrEnabled).toBeVisible({ timeout: 30_000 });
+
+    if (await unavailableEl.isVisible()) {
+      // Bundle unavailable — assert the honest state with the rebuild hint.
+      await expect(unavailableEl).toContainText("build:text-wasm");
+    } else {
+      // Bundle available — assert a real BM25 search works end-to-end.
+      await expect(searchInput).not.toBeDisabled();
+      await searchInput.fill("Alice");
+      await page.locator("[data-text-search-btn]").click();
+
+      const results = page.locator("[data-text-results]");
+      await expect(results).toBeVisible();
+
+      // Must get at least one hit — non-vacuous (real BM25 result from the sample graph).
+      await expect(results.locator("[data-text-hit]").first()).toBeVisible({ timeout: 30_000 });
+
+      // The hit must contain "Alice" — content-level non-vacuous assertion.
+      await expect(results.locator("[data-text-hit]").first()).toContainText("Alice");
+    }
+  });
+});

--- a/gui/e2e-playwright/specs/full-text-tool.web.spec.ts
+++ b/gui/e2e-playwright/specs/full-text-tool.web.spec.ts
@@ -1,0 +1,62 @@
+// [SONNET-4.6] sq-9nwab — full-text BM25 search panel journey (browser / web persona).
+//
+// Runs under chromium-web (NO Tauri mock). The auto-fixture `webPersona` navigates to "/"
+// and waits for engine ready before the test body runs. isTauriRuntime() === false; the
+// in-tab WASM engine carries everything.
+//
+// Mirrors full-text-tool.spec.ts (desktop persona) but exercises the pure-browser code path.
+// Same bundle-available vs bundle-unavailable fork — both paths are valid depending on the build.
+//
+// Stable selectors (all declared in full-text-tool.tsx):
+//   data-tool="full-text"        — left-rail nav button for the Full-text tool
+//   data-text-search-input       — the search term input (always present; disabled when unavailable)
+//   data-text-search-btn         — the Search button
+//   data-text-results            — the results container div
+//   data-text-unavailable        — the honest unavailable error block (mount-time probe failure)
+//   data-text-hit                — each individual hit row (for counting hits)
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only.
+
+import { webTest as test, webExpect as expect } from "../support/index.ts";
+
+test.describe("full-text-tool (web persona)", () => {
+  test("full-text tool shows BM25 results or honest unavailable state", async ({ page }) => {
+    // Navigate to the Full-text tab via the left rail.
+    await page.locator('[data-tool="full-text"]').click();
+
+    const unavailableEl = page.locator("[data-text-unavailable]");
+    const searchInput = page.locator("[data-text-search-input]");
+
+    // The search input is ALWAYS rendered (visible when the tab opens). Wait for it — this is
+    // a fast assertion that just confirms the FullTextTool panel mounted.
+    await expect(searchInput).toBeVisible({ timeout: 10_000 });
+
+    // The mount-time probe fires and resolves quickly (a network fetch of the wasm JS glue).
+    // Wait for EITHER the unavailable block to appear (bundle missing) OR the input to become
+    // enabled (bundle loaded). A disabled input means the probe is still in flight or failed;
+    // we poll both outcomes so the test settles as soon as either resolves.
+    const unavailableOrEnabled = unavailableEl.or(
+      page.locator("[data-text-search-input]:not([disabled])"),
+    );
+    await expect(unavailableOrEnabled).toBeVisible({ timeout: 30_000 });
+
+    if (await unavailableEl.isVisible()) {
+      // Bundle unavailable — assert the honest state with the rebuild hint.
+      await expect(unavailableEl).toContainText("build:text-wasm");
+    } else {
+      // Bundle available — assert a real BM25 search works end-to-end.
+      await expect(searchInput).not.toBeDisabled();
+      await searchInput.fill("Alice");
+      await page.locator("[data-text-search-btn]").click();
+
+      const results = page.locator("[data-text-results]");
+      await expect(results).toBeVisible();
+
+      // Must get at least one hit — non-vacuous (real BM25 result from the sample graph).
+      await expect(results.locator("[data-text-hit]").first()).toBeVisible({ timeout: 30_000 });
+
+      // The hit must contain "Alice" — content-level non-vacuous assertion.
+      await expect(results.locator("[data-text-hit]").first()).toContainText("Alice");
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `gui/app/src/lib/text-wasm.ts`: lazy loader for the W-text wasm bundle (`sparq_text_wasm.js`/`.wasm`), mirroring `reason-wasm.ts`; exposes `loadTextSearch()` returning `WasmTextSearch` with `query()` and `indexStats()` methods; cache clears on error to allow retry
- Replaces `FullTextTool` stub with a real BM25 search panel: eagerly probes the bundle on mount so `[data-text-unavailable]` appears immediately for builds without the bundle (honest state); keyboard-first (`Enter` submits); full state machine (`idle`/`running`/`results`/`error`); sets `FULL_TEXT_TOOL_OVERRIDE { built: true, group: "working" }` via the sq-5lyme panel-file seam
- Adds `gui/e2e-playwright/specs/full-text-tool.spec.ts` (desktop/mock-IPC persona) and `full-text-tool.web.spec.ts` (browser/web persona): each bifurcates on bundle-available vs honest-unavailable without blanket-passing; non-vacuous Alice hit assertion when the bundle is present

## Design notes

The bundle probe is **eager** (fires in `useEffect` on mount) so the `[data-text-unavailable]` block appears before the user ever clicks Search. This is correct UX (no surprise at click-time) and makes the Playwright test's available/unavailable branch deterministic.

The `FULL_TEXT_TOOL_OVERRIDE` flips the tool's honesty metadata inside the panel file only (the sq-5lyme seam), never touching `data/tools.ts`, so parallel tool beads remain file-disjoint.

## Test plan

- [x] `cd gui/app && npm run lint` — no errors
- [x] `cd gui/app && npm run typecheck` — no errors  
- [x] `cd gui/app && npm run build:tauri` — builds successfully
- [x] `cd gui/app && npm run build:web` — builds successfully
- [x] `cd gui/e2e-playwright && npx playwright test specs/full-text-tool.spec.ts` — passes (honest-unavailable path, bundle not built in test env)
- [x] `cd gui/e2e-playwright && npx playwright test specs/full-text-tool.web.spec.ts` — passes (honest-unavailable path, bundle not built in test env)

> 🤖 SPARQ agent | [SONNET-4.6] | bead sq-9nwab

🤖 Generated with [Claude Code](https://claude.com/claude-code)