### PR TITLE
feat(gui): server tool SPARQL endpoint client (sq-iemfq)

### DIFF
--- a/gui/app/src/components/workbench/server-tool.tsx
+++ b/gui/app/src/components/workbench/server-tool.tsx
@@ -1,21 +1,500 @@
 "use client";
 
-// [FABLE-5] sq-5lyme — the Server tool's OWN panel file (tool-panel registry seam).
-// Today it renders the exact honest stub it always did; sq-iemfq fills it with the SPARQL 1.1
-// Protocol endpoint client over the existing @sparq/client core. When that lands, flip the
-// honesty metadata via SERVER_TOOL_OVERRIDE below — never by editing the shared
-// data/tools.ts — so parallel tool beads stay file-disjoint.
+// [SONNET-4.6] sq-iemfq — the Server tool: SPARQL 1.1 Protocol endpoint client.
+//
+// Fills the bead-sq-iemfq panel: a Connect form with honest safety-warning UX (from the
+// connection-safety classifier in @sparq/client/endpoint.ts), a live health badge from
+// fetchServerHealth, and a SPARQL query panel that speaks the SPARQL 1.1 Protocol over
+// `runEndpointQuery`. Follows the GUI workbench translation rule (research/gui-design.md
+// §A.4/§A.5): marketing chrome CUT, live-result rendering only, honest error messaging.
+//
+// INVARIANTS enforced here:
+//   - Bearer token is NEVER persisted (React useState only, cleared on disconnect).
+//   - Fail-closed: an unreachable endpoint shows an error verbatim; no fabricated result.
+//   - Connect is disabled if hasBlockingWarning(warnings) is true.
 
-import { ToolStub } from "@/components/workbench/tool-stub";
+import * as React from "react";
+import { Server, Loader2, RefreshCw, Unplug, Play } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { cn } from "@/lib/utils";
 import type { ToolOverride } from "@/data/tools";
+import {
+  connectionSafetyWarnings,
+  hasBlockingWarning,
+  runEndpointQuery,
+  fetchServerHealth,
+  extractTable,
+  EndpointError,
+  type EndpointConfig,
+  type SafetyWarning,
+  type EndpointResult,
+  type ServerHealth,
+} from "@sparq/client";
 
-/**
- * Optional honesty-metadata override merged over the base `ToolDef` (data/tools.ts) by the
- * tool-panel registry's `resolveTool` and by the stub itself. `undefined` = base metadata
- * unchanged. Omit fields you do not override.
- */
-export const SERVER_TOOL_OVERRIDE: ToolOverride | undefined = undefined;
+// ---------------------------------------------------------------------------
+// Honesty-metadata override — flips this tool from "walkthrough / not built" to
+// "live / working" once this panel lands (sq-iemfq). Never edit data/tools.ts.
+// ---------------------------------------------------------------------------
+
+export const SERVER_TOOL_OVERRIDE: ToolOverride = {
+  tier: "live",
+  built: true,
+  group: "working",
+  blurb:
+    "Connect to a running SPARQL 1.1 Protocol endpoint — query + bindings table, health status.",
+};
+
+// ---------------------------------------------------------------------------
+// State shapes.
+// ---------------------------------------------------------------------------
+
+type HealthState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "loaded"; health: ServerHealth }
+  | { kind: "error"; message: string };
+
+type QueryState =
+  | { kind: "idle" }
+  | { kind: "running" }
+  | { kind: "result"; result: EndpointResult }
+  | { kind: "error"; message: string };
+
+const DEFAULT_QUERY = "SELECT * WHERE { ?s ?p ?o } LIMIT 10";
+
+// ---------------------------------------------------------------------------
+// Safety warning row — colour-coded by level.
+// ---------------------------------------------------------------------------
+
+function WarningRow({ w }: { w: SafetyWarning }) {
+  const colorClass =
+    w.level === "error"
+      ? "text-destructive"
+      : w.level === "warning"
+        ? "text-[var(--warning)]"
+        : "text-muted-foreground";
+  const icon = w.level === "error" ? "✕" : w.level === "warning" ? "⚠" : "ℹ";
+  return (
+    <li className={cn("flex gap-1.5 text-[11px]", colorClass)}>
+      <span aria-hidden className="shrink-0">
+        {icon}
+      </span>
+      <span>{w.message}</span>
+    </li>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Connect panel — shown when disconnected.
+// ---------------------------------------------------------------------------
+
+function ConnectPanel({
+  url,
+  setUrl,
+  token,
+  setToken,
+  warnings,
+  blocked,
+  onConnect,
+}: {
+  url: string;
+  setUrl: (v: string) => void;
+  token: string;
+  setToken: (v: string) => void;
+  warnings: SafetyWarning[];
+  blocked: boolean;
+  onConnect: () => void;
+}) {
+  return (
+    <div className="flex h-full flex-col items-center justify-center p-8">
+      <div className="w-full max-w-md space-y-4">
+        <div className="flex items-center gap-2">
+          <Server className="size-5 text-muted-foreground" />
+          <h2 className="text-base font-semibold">Connect to a SPARQL endpoint</h2>
+        </div>
+
+        {/* Endpoint URL */}
+        <div className="space-y-1.5">
+          <label
+            htmlFor="server-url-input"
+            className="block text-xs font-medium text-muted-foreground"
+          >
+            Endpoint URL
+          </label>
+          <input
+            id="server-url-input"
+            data-server-url=""
+            type="url"
+            value={url}
+            onChange={(e) => setUrl(e.target.value)}
+            placeholder="http://127.0.0.1:3030/sparql"
+            className="w-full rounded-md border bg-background px-3 py-1.5 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
+            spellCheck={false}
+          />
+        </div>
+
+        {/* Bearer token — never persisted */}
+        <div className="space-y-1.5">
+          <label
+            htmlFor="server-token-input"
+            className="block text-xs font-medium text-muted-foreground"
+          >
+            Bearer token{" "}
+            <span className="font-normal text-muted-foreground/70">(optional — not persisted)</span>
+          </label>
+          <input
+            id="server-token-input"
+            data-server-token=""
+            type="password"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="Enter bearer token…"
+            className="w-full rounded-md border bg-background px-3 py-1.5 font-mono text-sm outline-none focus:ring-2 focus:ring-ring"
+            autoComplete="off"
+          />
+        </div>
+
+        {/* Safety warnings (pure — connectionSafetyWarnings is stateless + sync) */}
+        {warnings.length > 0 && (
+          <ul className="space-y-1 rounded-md border bg-card p-2.5">
+            {warnings.map((w) => (
+              <WarningRow key={w.code} w={w} />
+            ))}
+          </ul>
+        )}
+
+        <Button
+          data-server-connect=""
+          onClick={onConnect}
+          disabled={blocked}
+          className="w-full"
+        >
+          Connect
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Health panel — shown after connecting.
+// ---------------------------------------------------------------------------
+
+function HealthPanel({
+  health,
+  onRefresh,
+}: {
+  health: HealthState;
+  onRefresh: () => void;
+}) {
+  let statusNode: React.ReactNode;
+  if (health.kind === "idle") {
+    statusNode = <span className="text-muted-foreground">—</span>;
+  } else if (health.kind === "loading") {
+    statusNode = <Loader2 className="size-3.5 animate-spin text-muted-foreground" />;
+  } else if (health.kind === "error") {
+    statusNode = (
+      <span className="text-destructive" data-server-health-status="">
+        Error: {health.message}
+      </span>
+    );
+  } else {
+    const isLive = health.health.health.status === "ok";
+    statusNode = isLive ? (
+      <Badge variant="success" data-server-health-status="">
+        Live
+      </Badge>
+    ) : (
+      <Badge variant="muted" data-server-health-status="">
+        Unreachable
+      </Badge>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-2 border-b bg-card px-3 py-1.5 text-xs">
+      <span className="font-medium text-muted-foreground">Health</span>
+      <span className="flex items-center gap-1.5">{statusNode}</span>
+      <Button
+        size="icon-sm"
+        variant="ghost"
+        onClick={onRefresh}
+        title="Refresh server health"
+        data-server-health-refresh=""
+        disabled={health.kind === "loading"}
+        className="ml-auto"
+      >
+        <RefreshCw className={cn("size-3.5", health.kind === "loading" && "animate-spin")} />
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Query panel — shown after connecting.
+// ---------------------------------------------------------------------------
+
+function QueryPanel({
+  sparql,
+  setSparql,
+  queryState,
+  onRun,
+}: {
+  sparql: string;
+  setSparql: (v: string) => void;
+  queryState: QueryState;
+  onRun: () => void;
+}) {
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      {/* Editor row */}
+      <div className="flex min-h-0 flex-[2] flex-col border-b">
+        <div className="flex items-center gap-2 border-b bg-card px-3 py-1.5">
+          <span className="text-xs font-medium text-muted-foreground">SPARQL query</span>
+          <Button
+            size="sm"
+            onClick={onRun}
+            disabled={queryState.kind === "running"}
+            data-server-run-query=""
+            className="ml-auto"
+          >
+            {queryState.kind === "running" ? (
+              <Loader2 className="animate-spin" />
+            ) : (
+              <Play />
+            )}
+            Run query
+          </Button>
+        </div>
+        <textarea
+          data-server-sparql-editor=""
+          value={sparql}
+          onChange={(e) => setSparql(e.target.value)}
+          spellCheck={false}
+          className="min-h-0 flex-1 resize-none bg-background p-3 font-mono text-sm outline-none"
+          aria-label="SPARQL query editor"
+        />
+      </div>
+
+      {/* Results pane */}
+      <div className="flex min-h-0 flex-1 flex-col overflow-auto">
+        <QueryResult state={queryState} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Result rendering — fail-closed, no fabricated values.
+// ---------------------------------------------------------------------------
+
+function QueryResult({ state }: { state: QueryState }) {
+  if (state.kind === "idle") {
+    return (
+      <p className="p-3 text-sm text-muted-foreground">Run a query to see results.</p>
+    );
+  }
+
+  if (state.kind === "running") {
+    return <p className="p-3 text-sm text-muted-foreground">Running…</p>;
+  }
+
+  if (state.kind === "error") {
+    return (
+      <pre
+        data-server-result-error=""
+        className="overflow-auto whitespace-pre-wrap p-3 font-mono text-xs text-destructive"
+      >
+        {state.message}
+      </pre>
+    );
+  }
+
+  const { result } = state;
+
+  if (result.kind === "update") {
+    return (
+      <p data-server-result-update="" className="p-3 text-sm text-[var(--success)]">
+        Update applied.
+      </p>
+    );
+  }
+
+  if (result.kind === "graph") {
+    return (
+      <pre
+        data-server-result-graph=""
+        className="overflow-auto whitespace-pre-wrap p-3 font-mono text-xs"
+      >
+        {result.ntriples || "(empty graph)"}
+      </pre>
+    );
+  }
+
+  if (result.kind === "boolean") {
+    return (
+      <p
+        data-server-result-ask=""
+        className={cn(
+          "p-3 text-sm font-medium",
+          result.value ? "text-[var(--success)]" : "text-muted-foreground",
+        )}
+      >
+        {result.value ? "true" : "false"}
+      </p>
+    );
+  }
+
+  // SELECT — bindings table.
+  const table = extractTable(result.results);
+
+  if (table.vars.length === 0) {
+    return <p className="p-3 text-sm text-muted-foreground">(empty result set)</p>;
+  }
+
+  return (
+    <div className="overflow-auto">
+      <table data-server-result-table="" className="w-full text-left text-xs">
+        <thead className="border-b bg-card">
+          <tr>
+            {table.vars.map((v) => (
+              <th key={v} className="px-3 py-1.5 font-medium text-muted-foreground">
+                ?{v}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {table.rows.map((row, ri) => (
+            <tr key={ri} className="border-b hover:bg-sidebar-accent/20">
+              {row.map((cell, ci) => (
+                <td key={ci} className="px-3 py-1 font-mono">
+                  {cell}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main panel — orchestrates connected vs disconnected state.
+// ---------------------------------------------------------------------------
 
 export function ServerTool() {
-  return <ToolStub toolId="server" override={SERVER_TOOL_OVERRIDE} />;
+  const [url, setUrl] = React.useState("");
+  // Bearer token — NEVER persisted to any storage; lives in React state only.
+  const [token, setToken] = React.useState("");
+  const [connected, setConnected] = React.useState(false);
+  const [config, setConfig] = React.useState<EndpointConfig | null>(null);
+  const [health, setHealth] = React.useState<HealthState>({ kind: "idle" });
+  const [sparql, setSparql] = React.useState(DEFAULT_QUERY);
+  const [queryState, setQueryState] = React.useState<QueryState>({ kind: "idle" });
+
+  const warnings = connectionSafetyWarnings({ url, token });
+  const blocked = hasBlockingWarning(warnings);
+
+  const startHealthFetch = React.useCallback((cfg: EndpointConfig) => {
+    setHealth({ kind: "loading" });
+    void fetchServerHealth(cfg).then(
+      (h) => setHealth({ kind: "loaded", health: h }),
+      (err) =>
+        setHealth({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        }),
+    );
+  }, []);
+
+  const onConnect = React.useCallback(() => {
+    const cfg: EndpointConfig = { url, token: token.trim() || undefined };
+    setConfig(cfg);
+    setConnected(true);
+    setQueryState({ kind: "idle" });
+    startHealthFetch(cfg);
+  }, [url, token, startHealthFetch]);
+
+  const onDisconnect = React.useCallback(() => {
+    setConnected(false);
+    setConfig(null);
+    setHealth({ kind: "idle" });
+    setQueryState({ kind: "idle" });
+    // Clear the token from memory on disconnect — never persisted.
+    setToken("");
+  }, []);
+
+  const onRefreshHealth = React.useCallback(() => {
+    if (config) startHealthFetch(config);
+  }, [config, startHealthFetch]);
+
+  const onRunQuery = React.useCallback(() => {
+    if (!config) return;
+    setQueryState({ kind: "running" });
+    void runEndpointQuery(config, sparql).then(
+      (result) => setQueryState({ kind: "result", result }),
+      (err) => {
+        const message =
+          err instanceof EndpointError
+            ? err.message
+            : err instanceof Error
+              ? err.message
+              : String(err);
+        setQueryState({ kind: "error", message });
+      },
+    );
+  }, [config, sparql]);
+
+  if (!connected) {
+    return (
+      <ConnectPanel
+        url={url}
+        setUrl={setUrl}
+        token={token}
+        setToken={setToken}
+        warnings={warnings}
+        blocked={blocked}
+        onConnect={onConnect}
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Connected header with disconnect affordance */}
+      <div className="flex items-center gap-2 border-b bg-card px-3 py-1.5 text-xs">
+        <Server className="size-3.5 text-primary" />
+        <span
+          className="min-w-0 flex-1 truncate font-mono text-muted-foreground"
+          title={config?.url}
+        >
+          {config?.url}
+        </span>
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onDisconnect}
+          title="Disconnect from this endpoint"
+        >
+          <Unplug className="size-3.5" />
+          Disconnect
+        </Button>
+      </div>
+
+      {/* Health status row */}
+      <HealthPanel health={health} onRefresh={onRefreshHealth} />
+
+      {/* Query panel — available immediately after connect */}
+      <QueryPanel
+        sparql={sparql}
+        setSparql={setSparql}
+        queryState={queryState}
+        onRun={onRunQuery}
+      />
+    </div>
+  );
 }

--- a/gui/e2e-playwright/specs/server-tool.web.spec.ts
+++ b/gui/e2e-playwright/specs/server-tool.web.spec.ts
@@ -1,0 +1,119 @@
+// [SONNET-4.6] sq-iemfq — server-tool Playwright spec (web persona).
+//
+// Runs under the chromium-web project (*.web.spec.ts pattern): NO Tauri globals, pure
+// browser persona. The webPersona auto-fixture (support/web-fixtures.ts) has already:
+//   1. Blocked external network (only 127.0.0.1 / localhost allowed through).
+//   2. Navigated to "/" with no Tauri init script.
+//   3. Waited for "Engine ready" in the top bar.
+//
+// This spec drives the Server tool panel — the SPARQL 1.1 Protocol endpoint client —
+// using page.route() to mock a hermetic sparq-server at http://127.0.0.1:7777/sparql.
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only; stable selectors
+// (data-* / role only); no exact numeric assertions on timing or row counts.
+
+import { webTest as test, webExpect as expect } from "../support/index.ts";
+
+// Mock endpoint — loopback, allowed through the hermetic context-level route.
+const MOCK_URL = "http://127.0.0.1:7777/sparql";
+
+// Canned SPARQL-JSON SELECT result for the default query.
+const CANNED_SELECT = JSON.stringify({
+  head: { vars: ["subject", "predicate", "object"] },
+  results: {
+    bindings: [
+      {
+        subject: { type: "uri", value: "http://example.org/alice" },
+        predicate: { type: "uri", value: "http://xmlns.com/foaf/0.1/name" },
+        object: { type: "literal", value: "Alice" },
+      },
+    ],
+  },
+});
+
+test.describe("server-tool (web persona)", () => {
+  // The webPersona auto-fixture navigates to "/" and waits for engine ready before each test.
+
+  test("connect to mock endpoint, run query, assert bindings table", async ({ page }) => {
+    // ── 1. Install page.route mocks before navigating to the server tab ──────────────────────
+    // The context-level hermetic block allows all http://127.0.0.1 regardless of port.
+    // Page-level routes intercept BEFORE the context route, so these fire first.
+
+    // /health → "ok" (plaintext)
+    await page.route("http://127.0.0.1:7777/health", (route) => {
+      void route.fulfill({ status: 200, body: "ok", contentType: "text/plain" });
+    });
+
+    // /metrics → 404 (feature off — not-exposed)
+    await page.route("http://127.0.0.1:7777/metrics", (route) => {
+      void route.fulfill({ status: 404, body: "not found", contentType: "text/plain" });
+    });
+
+    // /.well-known/void → 404 (opt-in feature off — not-exposed)
+    await page.route("http://127.0.0.1:7777/.well-known/void", (route) => {
+      void route.fulfill({ status: 404, body: "not found", contentType: "text/plain" });
+    });
+
+    // /sparql → GET = 400 (SD feature off / no `query` param — treated as not-exposed);
+    //           POST = canned SELECT result
+    await page.route("http://127.0.0.1:7777/sparql", (route) => {
+      if (route.request().method() === "POST") {
+        void route.fulfill({
+          status: 200,
+          body: CANNED_SELECT,
+          contentType: "application/sparql-results+json",
+        });
+      } else {
+        // GET — Service Description not exposed (400 treated as not-exposed by fetchServerHealth)
+        void route.fulfill({ status: 400, body: "missing query", contentType: "text/plain" });
+      }
+    });
+
+    // ── 2. Navigate to the Server tool tab ────────────────────────────────────────────────────
+    await page.locator('[data-tool="server"]').click();
+
+    // ── 3. Fill the endpoint URL ──────────────────────────────────────────────────────────────
+    await page.locator('[data-server-url]').fill(MOCK_URL);
+
+    // ── 4. Click Connect ──────────────────────────────────────────────────────────────────────
+    await page.locator('[data-server-connect]').click();
+
+    // ── 5. Assert health shows "Live" ─────────────────────────────────────────────────────────
+    // The health badge appears after the async fetchServerHealth resolves.
+    await expect(page.locator('[data-server-health-status]')).toContainText("Live");
+
+    // ── 6. Run the default query ──────────────────────────────────────────────────────────────
+    await page.locator('[data-server-run-query]').click();
+
+    // ── 7. Assert the bindings table shows Alice ──────────────────────────────────────────────
+    const table = page.locator('[data-server-result-table]');
+    await expect(table).toBeVisible();
+    await expect(table.getByText("Alice").first()).toBeVisible();
+  });
+
+  test("connect error is shown plainly when endpoint unreachable", async ({ page }) => {
+    // No page.route mock for port 7778 — requests will reach the network stack
+    // and fail with connection refused (the port has no listener).
+    // The hermetic context route allows 127.0.0.1 regardless of port, so the
+    // fetch is attempted and fails with a transport error caught by runEndpointQuery.
+    const DEAD_URL = "http://127.0.0.1:7778/sparql";
+
+    // Navigate to Server tool.
+    await page.locator('[data-tool="server"]').click();
+
+    // Fill the unreachable endpoint URL.
+    await page.locator('[data-server-url]').fill(DEAD_URL);
+
+    // Connect (health fetch will fail, but the UI transitions to connected state immediately).
+    await page.locator('[data-server-connect]').click();
+
+    // The query panel is visible — we can attempt a query right away.
+    await expect(page.locator('[data-server-run-query]')).toBeVisible();
+
+    // Run the query against the unreachable endpoint.
+    await page.locator('[data-server-run-query]').click();
+
+    // An honest error is shown in the results pane — no fabricated result.
+    await expect(page.locator('[data-server-result-error]')).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

- Fills `gui/app/src/components/workbench/server-tool.tsx` with a real SPARQL 1.1 Protocol endpoint client, replacing the `ToolStub` placeholder
- ConnectPanel: URL + bearer-token input, `connectionSafetyWarnings` display, Connect button disabled when `hasBlockingWarning` is true; bearer token **never persisted** (React `useState` only, cleared on disconnect)
- HealthPanel: Live/Unreachable badge sourced from `fetchServerHealth`; refresh button
- QueryPanel: SPARQL textarea + Run button via `runEndpointQuery`; fail-closed error display (transport errors shown verbatim, no fabricated results)
- QueryResult: SELECT bindings table, graph N-Triples, boolean, UPDATE confirmation, and error pre — all using `data-*` selectors
- Exports `SERVER_TOOL_OVERRIDE { tier: "live", built: true, group: "working" }` — `tool-panel.tsx` already has `server: { Component: ServerTool, override: SERVER_TOOL_OVERRIDE }`
- Adds `gui/e2e-playwright/specs/server-tool.web.spec.ts`: two Playwright tests under the `chromium-web` web persona — connect+query+bindings-table via `page.route` mock, and unreachable-endpoint honest-error path

## Test plan

- [x] TypeScript typecheck passes (`tsc --noEmit`)
- [x] ESLint passes on `server-tool.tsx`
- [x] Both Playwright tests pass: `connect to mock endpoint, run query, assert bindings table` and `connect error is shown plainly when endpoint unreachable`
- [x] Bearer token invariant: only `React.useState`, cleared in `onDisconnect`
- [x] Fail-closed invariant: `[data-server-result-error]` shown for unreachable endpoint, no fabricated result
- [x] `hasBlockingWarning` guard on Connect button

> 🤖 SPARQ agent — automated implementation of bead sq-iemfq