### PR TITLE
feat(gui): SHACL tool — Turtle syntax highlighting + bulk shapes upload with per-source toggle (sq-txrui)

### DIFF
--- a/gui/app/src/components/workbench/shacl-sources.tsx
+++ b/gui/app/src/components/workbench/shacl-sources.tsx
@@ -1,0 +1,266 @@
+"use client";
+
+// (sq-txrui) [SONNET-4.6] — SHACL SHAPES SOURCES strip: bulk multi-file upload with per-source
+// enable/disable toggle.
+//
+// Each uploaded .ttl shape file becomes a ShapeSource entry. The parent (shacl-tool.tsx)
+// concatenates the editor doc + every ENABLED source text before passing it to sparqShaclValidate.
+// Prefix redeclaration across Turtle docs is legal and handled by the WASM parser.
+//
+// Design note: the strip is intentionally compact — name truncated at 1fr, toggle and remove at
+// fixed right. A disabled source has opacity-50 treatment on the name to signal it contributes
+// nothing to the current validation run.
+//
+// File ingest: a PERSISTENT hidden <input type="file" multiple> (ref) is always in the DOM.
+// The "Browse files…" button programmatically clicks it. The input also handles drag-and-drop
+// via readDroppedFiles. This design allows Playwright to use setInputFiles() on the labelled
+// input directly — `waitForEvent('filechooser')` + `showOpenFilePicker` can mis-fire in
+// headless environments; a persistent input ref is the robust testable floor.
+//
+// INVARIANTS (bead sq-txrui):
+//   * with zero sources the strip shows only the upload affordance (same validation input as
+//     before — zero uploaded sources → tool behaves exactly as the old textarea);
+//   * a disabled source contributes ZERO text to the concatenated shapes doc;
+//   * every file that comes through the input fires the 'change' event (Playwright's
+//     setInputFiles() path) or the 'drop' event (drag-and-drop path).
+//
+// Stable E2E hooks:
+//   [data-sources-list]           — the <ul> of source rows (present iff sources.length > 0)
+//   [data-source-name]            — the <span> with the file name (per row)
+//   [data-source-toggle]          — the toggle button (aria-pressed="true/false" per row)
+//   [data-source-remove]          — the remove button (per row)
+//   [data-sources-file-input]     — the hidden <input type="file" multiple> (setInputFiles target)
+//   button "Browse files…"        — the keyboard-accessible pick trigger (role="button")
+
+import * as React from "react";
+import { X, Eye, EyeOff, FileUp, Upload, Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import { useFileDrop } from "@/components/workbench/dropzone";
+import { matchesAccept, type IngestResult } from "@/lib/file-ingest";
+
+/** One uploaded shape source — carries a stable React key, its file name, Turtle text and
+ * whether it is currently contributing to validation. */
+export interface ShapeSource {
+  id: string;
+  name: string;
+  text: string;
+  enabled: boolean;
+}
+
+export interface ShaclSourcesProps {
+  sources: ShapeSource[];
+  /** Full replace — the parent owns the list. */
+  onChange: (sources: ShapeSource[]) => void;
+}
+
+// ── internal helpers ────────────────────────────────────────────────────────────────────────────
+
+const ACCEPTED_EXTS = [".ttl", ".shacl", ".n3"];
+
+function makeId(name: string): string {
+  return `${name}-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function ingestToSources(result: IngestResult): ShapeSource[] {
+  return result.accepted.map((f) => ({
+    id: makeId(f.name),
+    name: f.name,
+    text: f.text,
+    enabled: true,
+  }));
+}
+
+/**
+ * The SHAPES SOURCES strip: a persistent file input + drag-and-drop surface for bulk .ttl upload,
+ * plus a list of accepted sources each with an enable/disable toggle and a remove button.
+ *
+ * The parent is responsible for concatenating `source.text` for every `source.enabled` entry into
+ * the shapes document before calling `sparqShaclValidate`.
+ */
+export function ShaclSources({ sources, onChange }: ShaclSourcesProps) {
+  // ── persistent file input ref ────────────────────────────────────────────────────────────────
+  // A permanent DOM node so Playwright can call setInputFiles() on it at any time.
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+  const [busy, setBusy] = React.useState(false);
+
+  // ── add incoming files ───────────────────────────────────────────────────────────────────────
+  const appendSources = React.useCallback(
+    (result: IngestResult) => {
+      const incoming = ingestToSources(result);
+      if (incoming.length > 0) onChange([...sources, ...incoming]);
+    },
+    [sources, onChange],
+  );
+
+  // ── input change handler (covers both manual pick AND Playwright setInputFiles) ──────────────
+  const onInputChange = React.useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files ?? []);
+      // Reset the input value so the same file can be re-selected later.
+      e.target.value = "";
+      if (!files.length) return;
+      setBusy(true);
+      try {
+        const accepted: { name: string; text: string; bytes: number }[] = [];
+        const rejected: { name: string; reason: string }[] = [];
+        for (const file of files) {
+          if (!matchesAccept(file.name, ACCEPTED_EXTS)) {
+            rejected.push({
+              name: file.name,
+              reason: `unsupported file type — expected ${ACCEPTED_EXTS.join(" / ")}`,
+            });
+            continue;
+          }
+          try {
+            accepted.push({ name: file.name, text: await file.text(), bytes: file.size });
+          } catch (err) {
+            rejected.push({
+              name: file.name,
+              reason: `could not be read: ${err instanceof Error ? err.message : String(err)}`,
+            });
+          }
+        }
+        appendSources({ accepted, rejected });
+      } finally {
+        setBusy(false);
+      }
+    },
+    [appendSources],
+  );
+
+  // ── drag-and-drop ────────────────────────────────────────────────────────────────────────────
+  const { dragActive, targetProps } = useFileDrop({
+    accept: ACCEPTED_EXTS,
+    multiple: true,
+    onFiles: appendSources,
+  });
+
+  // ── per-source actions ───────────────────────────────────────────────────────────────────────
+  const toggleSource = React.useCallback(
+    (id: string) => {
+      onChange(sources.map((s) => (s.id === id ? { ...s, enabled: !s.enabled } : s)));
+    },
+    [sources, onChange],
+  );
+
+  const removeSource = React.useCallback(
+    (id: string) => {
+      onChange(sources.filter((s) => s.id !== id));
+    },
+    [sources, onChange],
+  );
+
+  const enabledCount = sources.filter((s) => s.enabled).length;
+
+  // ── render ───────────────────────────────────────────────────────────────────────────────────
+  return (
+    <div className="flex shrink-0 flex-col border-b">
+      {/* strip header */}
+      <div className="flex shrink-0 items-center gap-2 border-b bg-card px-3 py-1.5">
+        <span className="text-xs font-medium text-muted-foreground">Shape sources</span>
+        {sources.length > 0 ? (
+          <span className="text-[11px] text-muted-foreground">
+            {enabledCount} / {sources.length} active
+          </span>
+        ) : null}
+      </div>
+
+      {/* source list — only rendered when at least one source has been uploaded */}
+      {sources.length > 0 ? (
+        <ul data-sources-list className="divide-y overflow-y-auto" style={{ maxHeight: "9rem" }}>
+          {sources.map((src) => (
+            <li key={src.id} className="flex items-center gap-2 px-3 py-1.5 text-xs">
+              {/* toggle */}
+              <button
+                type="button"
+                data-source-toggle
+                aria-pressed={src.enabled}
+                aria-label={src.enabled ? `Disable ${src.name}` : `Enable ${src.name}`}
+                onClick={() => toggleSource(src.id)}
+                className={cn(
+                  "shrink-0 rounded p-0.5 text-muted-foreground hover:text-foreground",
+                  !src.enabled && "opacity-50",
+                )}
+              >
+                {src.enabled ? (
+                  <Eye className="size-3.5" aria-hidden />
+                ) : (
+                  <EyeOff className="size-3.5" aria-hidden />
+                )}
+              </button>
+
+              {/* file name */}
+              <span
+                data-source-name
+                title={src.name}
+                className={cn(
+                  "min-w-0 flex-1 truncate font-mono",
+                  !src.enabled && "opacity-50",
+                )}
+              >
+                {src.name}
+              </span>
+
+              {/* remove */}
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                data-source-remove
+                aria-label={`Remove ${src.name}`}
+                onClick={() => removeSource(src.id)}
+                className="h-5 w-5 shrink-0 p-0 text-muted-foreground hover:text-destructive"
+              >
+                <X className="size-3" aria-hidden />
+              </Button>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+
+      {/* upload affordance: drag target + keyboard-accessible pick button.
+          The hidden <input> is always in the DOM — required for Playwright setInputFiles(). */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        multiple
+        accept={ACCEPTED_EXTS.join(",")}
+        data-sources-file-input
+        aria-label="Select shape files"
+        tabIndex={-1}
+        className="sr-only"
+        onChange={onInputChange}
+      />
+
+      <div
+        data-slot="dropzone"
+        {...targetProps}
+        className={cn(
+          "relative m-2 rounded-md border border-dashed p-4 text-center text-xs transition-colors",
+          dragActive ? "border-primary bg-primary/5" : "border-border",
+        )}
+      >
+        <FileUp className="mx-auto size-5 text-muted-foreground" aria-hidden />
+        <p className="mt-1.5 text-sm text-muted-foreground">Drop .ttl shape files here</p>
+        <p className="mt-0.5 text-[11px] text-muted-foreground">.ttl · .shacl · .n3</p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="mt-2"
+          onClick={() => fileInputRef.current?.click()}
+          disabled={busy}
+          aria-label="Browse files…"
+        >
+          {busy ? <Loader2 className="animate-spin" /> : <Upload />}
+          Browse files…
+        </Button>
+        <span className="sr-only" role="status">
+          {dragActive ? "Release to drop the files" : ""}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/gui/app/src/components/workbench/shacl-tool.tsx
+++ b/gui/app/src/components/workbench/shacl-tool.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 // [OPUS-4.8] sq-ixc3.11 — the SHACL tool: a surface turned into an operational VERB.
+// (sq-txrui) [SONNET-4.6] — upgraded with Turtle syntax highlighting (WorkbenchTurtleEditor,
+// sq-5sjub) + bulk multi-file shapes upload with per-source enable/disable toggle (ShaclSources,
+// sq-vnh1v / sq-txrui).
 //
 // Translation rule (research/gui-design.md §A.4/§A.5): the website's /surface/shacl PAGE
 // validates a pasted DATA document against pasted SHAPES, wrapped in marketing chrome — a hero,
@@ -16,6 +19,21 @@
 // shapes via the shacl binding (Store.validate), all in-tab. This is the same SHACL Core +
 // SHACL-SPARQL engine the native crate ships; the `live` tier is honest because the bundle
 // genuinely carries it.
+//
+// SHAPES INPUT — three inputs concatenated (Turtle docs concatenate safely; prefix redeclaration
+// is legal per the Turtle spec):
+//   1. The inline editor (WorkbenchTurtleEditor with syntax highlighting — sq-5sjub).
+//   2. Each ENABLED source in the ShaclSources strip (bulk .ttl upload — sq-txrui).
+//   Disabled sources contribute nothing; with zero sources behaviour is identical to before.
+//
+// INVARIANT (sq-txrui): with zero uploaded sources the tool behaves exactly as before (editor
+// doc only). A disabled source contributes nothing. The highlight layer never desyncs from the
+// edited text (WorkbenchTurtleEditor owned contract).
+//
+// Stable E2E hooks preserved from sq-ixc3.11:
+//   id="shacl-shapes"             — the textarea inside WorkbenchTurtleEditor
+//   [data-result-kind="shacl"]    — the report pane container
+//   [data-result-kind="error"]    — the error <pre> inside the report pane
 
 import * as React from "react";
 import { Play, Loader2, CheckCircle2, XCircle } from "lucide-react";
@@ -27,9 +45,11 @@ import { useEngine } from "@/lib/engine-context";
 import { sparqShaclValidate, type ShaclReport, type ShaclResult } from "@sparq/client";
 import { basePath } from "@/lib/base-path";
 import { TIER_META, toolById } from "@/data/tools";
+import { WorkbenchTurtleEditor } from "@/components/workbench/turtle-editor";
+import { ShaclSources, type ShapeSource } from "@/components/workbench/shacl-sources";
 
 // A starter shapes graph the operator edits — NOT a fixture wrapped in a "try me" pitch; just a
-// minimal valid SHACL document so the empty textarea is not the first thing the operator faces.
+// minimal valid SHACL document so the empty editor is not the first thing the operator faces.
 // It targets nothing specific in the store; the operator points it at their own classes.
 const STARTER_SHAPES = `@prefix sh:   <http://www.w3.org/ns/shacl#> .
 @prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
@@ -101,6 +121,8 @@ function Violation({ r }: { r: ShaclResult }) {
 export function ShaclTool() {
   const { status, storeSize, serializeStore } = useEngine();
   const [shapes, setShapes] = React.useState(STARTER_SHAPES);
+  // (sq-txrui) uploaded shape sources — each has an id, name, text and enabled flag.
+  const [sources, setSources] = React.useState<ShapeSource[]>([]);
   const [state, setState] = React.useState<RunState>({ kind: "idle" });
 
   const ready = status.kind === "ready";
@@ -120,10 +142,15 @@ export function ShaclTool() {
     }
     const t0 = performance.now();
     try {
+      // (sq-txrui) — concatenate the inline editor doc + every ENABLED source. Turtle docs
+      // concatenate safely; prefix redeclaration is legal per the Turtle spec.
+      const allShapes = [shapes, ...sources.filter((s) => s.enabled).map((s) => s.text)].join(
+        "\n",
+      );
       // Validate the LIVE store (serialised to TriG) against the operator's shapes. The shapes
       // are Turtle; the data is TriG — both are accepted by the validate binding, which folds
       // named graphs into the data graph SHACL validates.
-      const report = await sparqShaclValidate(data, shapes, "trig", {
+      const report = await sparqShaclValidate(data, allShapes, "trig", {
         basePath: basePath(),
       });
       setState({
@@ -138,7 +165,7 @@ export function ShaclTool() {
         message: err instanceof Error ? err.message : String(err),
       });
     }
-  }, [serializeStore, shapes, storeSize]);
+  }, [serializeStore, shapes, sources, storeSize]);
 
   const onKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
@@ -149,9 +176,10 @@ export function ShaclTool() {
 
   return (
     <div className="flex h-full flex-col">
-      {/* Shapes editor — the only input; the DATA is the live store, not a pasted fixture. */}
+      {/* Shapes editor + sources strip — the shapes input: the DATA is the live store. */}
       <div className="flex min-h-0 flex-[3] flex-col border-b">
-        <div className="flex items-center gap-2 border-b bg-card px-3 py-1.5">
+        {/* Editor header: label, tier dot, validate button */}
+        <div className="flex shrink-0 items-center gap-2 border-b bg-card px-3 py-1.5">
           <span className="text-xs font-medium text-muted-foreground">SHACL shapes</span>
           {tier ? (
             <span className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
@@ -170,16 +198,20 @@ export function ShaclTool() {
           </Button>
           <span className="text-[11px] text-muted-foreground">⌘↵</span>
         </div>
-        <textarea
+
+        {/* (sq-txrui) Turtle overlay editor — replaces the plain <textarea>. The id="shacl-shapes"
+            hook is preserved on the inner <textarea> (WorkbenchTurtleEditor passes it through). */}
+        <WorkbenchTurtleEditor
           id="shacl-shapes"
           value={shapes}
-          onChange={(e) => setShapes(e.target.value)}
+          onChange={setShapes}
           onKeyDown={onKeyDown}
-          spellCheck={false}
-          className="min-h-0 flex-1 resize-none bg-background p-3 font-mono text-sm outline-none"
+          ariaLabel="SHACL shapes editor"
           placeholder="Paste a SHACL shapes graph (Turtle)…"
-          aria-label="SHACL shapes editor"
         />
+
+        {/* (sq-txrui) SHAPES SOURCES strip — bulk .ttl upload, per-source toggle. */}
+        <ShaclSources sources={sources} onChange={setSources} />
       </div>
 
       {/* Report pane — conformance flag + per-violation W3C report over the live store. */}

--- a/gui/e2e-playwright/specs/shacl-shapes-upload.web.spec.ts
+++ b/gui/e2e-playwright/specs/shacl-shapes-upload.web.spec.ts
@@ -1,0 +1,195 @@
+// (sq-txrui) [SONNET-4.6] — SHACL tool upgrade: Turtle syntax highlighting + bulk multi-file
+// shapes upload with per-source enable/disable toggle.
+//
+// Runs under the chromium-web project (support/web-fixtures.ts): NO window.__TAURI__ / Tauri
+// globals — the pure-browser code path.  The webPersona auto-fixture boots the app + waits for
+// "Engine ready" before each test.
+//
+// Three obligations (sq-txrui acceptance):
+//   (a) HIGHLIGHTING — assert `.sq-tok-keyword` spans render in the shapes editor (the STARTER_
+//       SHAPES @prefix lines are tokenised as keyword tokens by WorkbenchTurtleEditor).
+//   (b) BULK UPLOAD — upload TWO shape files via setInputFiles on the persistent hidden input;
+//       assert both appear in the sources list as enabled.
+//   (c) NON-VACUOUS VALIDATION — disable the second source, validate, assert the report shows
+//       exactly the violations produced by the FIRST (enabled) source only; no result from the
+//       disabled source appears.
+//
+// File ingest approach: ShaclSources exposes a persistent hidden <input type="file" multiple>
+// with data-sources-file-input. Playwright's setInputFiles() dispatches a native 'change' event
+// on it — more reliable than waitForEvent('filechooser') + showOpenFilePicker in headless CI.
+//
+// Shape files (inlined as buffers):
+//   shape-knows.ttl  — sh:minCount 1 on foaf:knows for foaf:Person
+//                      → violates for ex:dan (no foaf:knows in the sample graph)
+//   shape-age-max.ttl — sh:maxInclusive 25 on foaf:age for foaf:Person
+//                      → violates for ex:alice (30) and ex:carol (41)
+//
+// With only shape-knows.ttl ENABLED:
+//   • 1 violation expected  (ex:dan missing foaf:knows)
+//   • ex:alice / ex:carol age violations must NOT appear
+//
+// Sample graph (gui/app/src/data/sample-graph.ts):
+//   ex:alice  foaf:age 30, foaf:knows ex:bob + ex:carol
+//   ex:bob    foaf:age 25, foaf:knows ex:alice
+//   ex:carol  foaf:age 41, foaf:knows ex:alice + ex:dan
+//   ex:dan    foaf:age 19, NO foaf:knows
+//
+// Stable selectors (all declared in shacl-tool.tsx / shacl-sources.tsx):
+//   [data-tool="shacl"]           — rail entry to open the SHACL tool
+//   #shacl-shapes                 — the TEXTAREA inside WorkbenchTurtleEditor
+//   .sq-tok-keyword               — CSS class on highlighted keyword tokens in the <pre> layer
+//   [data-sources-list]           — the <ul> of source rows (present iff sources > 0)
+//   [data-source-name]            — file name span per source row
+//   [data-source-toggle]          — enable/disable toggle button (aria-pressed="true/false")
+//   [data-sources-file-input]     — hidden <input type="file"> — setInputFiles() target
+//   [data-result-kind="shacl"]    — the report pane container
+//
+// Determinism rules: NO waitForTimeout; web-first assertions; never assert exact timing values.
+
+import { webTest as test, webExpect as expect } from "../support/index.ts";
+
+// ── Inline shape-file content ─────────────────────────────────────────────────────────────────
+
+/** Requires foaf:Person to have foaf:knows ≥1 — violates ex:dan (no foaf:knows). */
+const SHAPE_KNOWS_TTL = `@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+
+<http://example.org/shapes/KnowsShape> a sh:NodeShape ;
+  sh:targetClass foaf:Person ;
+  sh:property [
+    sh:path foaf:knows ;
+    sh:minCount 1
+  ] .
+`;
+
+/** Requires foaf:Person foaf:age ≤25 — violates ex:alice (30) and ex:carol (41). */
+const SHAPE_AGE_MAX_TTL = `@prefix sh:   <http://www.w3.org/ns/shacl#> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix xsd:  <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/shapes/AgeMaxShape> a sh:NodeShape ;
+  sh:targetClass foaf:Person ;
+  sh:property [
+    sh:path foaf:age ;
+    sh:maxInclusive 25
+  ] .
+`;
+
+test.describe("shacl-shapes-upload (browser persona)", () => {
+  // The webPersona auto-fixture navigates to "/" and waits for "Engine ready" before each test.
+
+  test.beforeEach(async ({ page }) => {
+    // Open the SHACL tool via the left-rail entry point.
+    await page.locator('[data-tool="shacl"]').click();
+    // The SHACL shapes editor textarea must be visible before we proceed.
+    await expect(page.locator("#shacl-shapes")).toBeVisible();
+  });
+
+  // ── (a) Syntax highlighting ───────────────────────────────────────────────────────────────────
+
+  test("(a) shapes editor renders Turtle keyword tokens", async ({ page }) => {
+    // The STARTER_SHAPES includes `@prefix sh: …` etc. WorkbenchTurtleEditor tokenises those as
+    // `keyword` and renders a `<span class="sq-tok-keyword">` in the aria-hidden highlight <pre>.
+    // The span is not visible to AT (aria-hidden), but CSS selectors still find it.
+    const kwSpan = page.locator(".sq-tok-keyword").first();
+    await expect(kwSpan).toBeAttached();
+    // The STARTER_SHAPES has `@prefix` tokens — at least one keyword span must be present.
+    const count = await page.locator(".sq-tok-keyword").count();
+    expect(count).toBeGreaterThan(0);
+  });
+
+  // ── (b) Bulk multi-file upload ────────────────────────────────────────────────────────────────
+
+  test("(b) uploading two shape files adds both as enabled sources", async ({ page }) => {
+    // Use the persistent hidden <input type="file" multiple> (data-sources-file-input).
+    // Playwright's setInputFiles() dispatches a native 'change' event so the component's
+    // onInputChange handler fires — more reliable than filechooser interception in headless CI.
+    const fileInput = page.locator("[data-sources-file-input]");
+    await expect(fileInput).toBeAttached();
+
+    await fileInput.setInputFiles([
+      { name: "shape-knows.ttl", mimeType: "text/plain", buffer: Buffer.from(SHAPE_KNOWS_TTL) },
+      {
+        name: "shape-age-max.ttl",
+        mimeType: "text/plain",
+        buffer: Buffer.from(SHAPE_AGE_MAX_TTL),
+      },
+    ]);
+
+    // Both sources must appear in the [data-sources-list].
+    const list = page.locator("[data-sources-list]");
+    await expect(list).toBeVisible();
+
+    const names = list.locator("[data-source-name]");
+    await expect(names).toHaveCount(2);
+
+    // Both sources are enabled by default (aria-pressed="true").
+    const toggles = list.locator("[data-source-toggle]");
+    await expect(toggles.nth(0)).toHaveAttribute("aria-pressed", "true");
+    await expect(toggles.nth(1)).toHaveAttribute("aria-pressed", "true");
+
+    // The correct file names appear.
+    await expect(names.nth(0)).toContainText("shape-knows.ttl");
+    await expect(names.nth(1)).toContainText("shape-age-max.ttl");
+  });
+
+  // ── (c) Non-vacuous validation with per-source toggle ─────────────────────────────────────────
+
+  test("(c) disabling a source excludes its violations; validation is non-vacuous", async ({
+    page,
+  }) => {
+    // Upload both shape files via the persistent file input.
+    const fileInput = page.locator("[data-sources-file-input]");
+    await expect(fileInput).toBeAttached();
+
+    await fileInput.setInputFiles([
+      { name: "shape-knows.ttl", mimeType: "text/plain", buffer: Buffer.from(SHAPE_KNOWS_TTL) },
+      {
+        name: "shape-age-max.ttl",
+        mimeType: "text/plain",
+        buffer: Buffer.from(SHAPE_AGE_MAX_TTL),
+      },
+    ]);
+
+    // Wait for both sources to appear.
+    const list = page.locator("[data-sources-list]");
+    await expect(list).toBeVisible();
+    await expect(list.locator("[data-source-name]")).toHaveCount(2);
+
+    // Disable the SECOND source (shape-age-max.ttl): click its toggle.
+    // After this, only shape-knows.ttl is enabled.
+    const toggles = list.locator("[data-source-toggle]");
+    await toggles.nth(1).click();
+    await expect(toggles.nth(1)).toHaveAttribute("aria-pressed", "false");
+    await expect(toggles.nth(0)).toHaveAttribute("aria-pressed", "true"); // unchanged
+
+    // Clear the inline editor so the STARTER_SHAPES (which defines no constraints) does not
+    // accidentally contribute additional shapes text.  The STARTER_SHAPES is comments only
+    // (the example shape is commented out), so this is conservative; the key intent is that
+    // only shape-knows.ttl contributes constraints.
+    //
+    // Use fill() — Playwright's standard method for clearing + filling text inputs.  It fires
+    // the 'input' event which React's controlled textarea listens to, ensuring the shapes state
+    // updates synchronously before we click Validate.
+    const editor = page.locator("#shacl-shapes");
+    await editor.fill("# no additional shapes\n");
+
+    // Validate the live store.
+    await page.getByRole("button", { name: "Validate live store" }).click();
+
+    // Wait for the report to appear (non-vacuous: it must NOT be "Conforms").
+    const reportPane = page.locator('[data-result-kind="shacl"]');
+    // The report header shows "1 violation" (exactly one, from shape-knows.ttl → ex:dan).
+    // Use first() because the violation ROW also contains "Violation" as a severity label.
+    await expect(reportPane.getByText(/violation/i).first()).toBeVisible({ timeout: 30_000 });
+
+    // shape-knows.ttl → ex:dan (no foaf:knows) → exactly 1 violation.
+    // The violation entry shows the focus node using ex: prefix, so "dan" appears.
+    await expect(reportPane.getByText(/dan/i).first()).toBeVisible();
+
+    // Disabled shape-age-max.ttl violations MUST NOT appear: alice (age 30) and carol (age 41)
+    // would show if that shape were active, but it is disabled.
+    // The violation count in the report header must be 1 (only ex:dan).
+    await expect(reportPane.getByText("1 violation")).toBeVisible();
+  });
+});


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-txrui (P1, epic sq-2ucrz)

## Summary

- **Turtle syntax highlighting** in the SHACL shapes editor: replace the plain `<textarea>` with `WorkbenchTurtleEditor` (sq-5sjub reuse — `tokenizeTurtle` overlay technique). Token markup (`.sq-tok-keyword`, `.sq-tok-iri`, etc.) renders live as the operator edits.
- **Bulk multi-file shapes upload** via new `shacl-sources.tsx` (`ShaclSources` component): persistent `<input type="file" multiple>` with drag-and-drop (`useFileDrop` from sq-vnh1v) and a keyboard-accessible "Browse files…" button. Each uploaded `.ttl` file becomes a `ShapeSource` entry.
- **Per-source enable/disable toggle**: each source row has an `aria-pressed` toggle; disabled sources contribute nothing to the concatenated shapes doc. The header shows "N / total active".
- **Validation concatenation**: `onValidate` joins the inline editor doc + every `enabled` source text before calling `sparqShaclValidate`. With zero sources the tool behaves exactly as before (editor doc only). Turtle prefix redeclaration across docs is legal.

### Files changed

| File | Change |
|---|---|
| `gui/app/src/components/workbench/shacl-tool.tsx` | Replace `<textarea>` with `WorkbenchTurtleEditor`; add `ShaclSources` strip; update `onValidate` to concatenate enabled sources |
| `gui/app/src/components/workbench/shacl-sources.tsx` | **NEW** — `ShaclSources` component + `ShapeSource` type |
| `gui/e2e-playwright/specs/shacl-shapes-upload.web.spec.ts` | **NEW** — browser-persona Playwright spec, 3 tests |

### Stable E2E hooks (preserved + new)

- `id="shacl-shapes"` — textarea inside WorkbenchTurtleEditor (preserved)
- `[data-result-kind="shacl"]` — report pane (preserved)
- `[data-sources-list]` — source list `<ul>` (new)
- `[data-source-name]`, `[data-source-toggle]`, `[data-source-remove]` — per-row hooks (new)
- `[data-sources-file-input]` — persistent `<input type="file">` for `setInputFiles()` (new)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (no ESLint warnings or errors)
- [x] `npm run build:web` — green static export
- [x] `npm run build:tauri` — green static export
- [x] `CI=true npx playwright test` — **19/19 passed** (14 existing + 3 new + 2 web-persona)
  - (a) `.sq-tok-keyword` spans render in the shapes editor
  - (b) `setInputFiles` of two `.ttl` files → both appear enabled in `[data-sources-list]`
  - (c) disable shape-age-max.ttl → validate → exactly "1 violation" (ex:dan) — non-vacuous; no alice/carol age violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)