### PR TITLE
feat(gui): workspace switcher UI — list/create/rename/delete/switch (sq-lmlch)

### DIFF
--- a/gui/app/src/components/workbench/left-rail.tsx
+++ b/gui/app/src/components/workbench/left-rail.tsx
@@ -10,7 +10,7 @@
 //   (3) TOOLS list — each a VERB opened as a tab with an honesty-tier dot (NOT a page).
 
 import * as React from "react";
-import { ChevronDown, ChevronRight, Plus, Circle, Database, FolderTree, FileUp, Link2 } from "lucide-react";
+import { ChevronRight, Plus, Database, FolderTree, FileUp, Link2 } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 import { useEngine } from "@/lib/engine-context";
@@ -19,6 +19,8 @@ import { useImportDrawer } from "@/components/workbench/import-drawer";
 import { ExportDataMenu } from "@/components/workbench/store-export";
 import { TIER_META, type ToolDef } from "@/data/tools";
 import { resolveTool } from "@/components/workbench/tool-panel";
+// [SONNET-4.6] sq-lmlch — the real workspace switcher UI (replaces the dead stub).
+import { WorkspaceSwitcher } from "@/components/workbench/workspace-switcher";
 
 interface LeftRailProps {
   tools: ToolDef[];
@@ -187,16 +189,9 @@ export function LeftRail({ tools, activeId, onOpenTool }: LeftRailProps) {
 
   return (
     <nav className="flex w-56 shrink-0 flex-col overflow-y-auto border-r bg-sidebar text-sidebar-foreground">
-      {/* (1) Workspace switcher — the persistent model is sq-atb0; foundation = default. */}
+      {/* (1) Workspace switcher — [SONNET-4.6] sq-lmlch: replaced stub with real switcher. */}
       <div className="border-b px-2 py-2">
-        <button
-          className="flex w-full items-center gap-1.5 rounded-md border bg-background px-2 py-1.5 text-left text-xs hover:bg-sidebar-accent/40"
-          title="Workspace switcher — persistent workspaces are a later phase (sq-atb0)"
-        >
-          <Circle className="size-2.5 fill-[var(--success)] text-[var(--success)] drop-shadow-[0_0_5px_var(--success)]" />
-          <span className="flex-1 truncate font-medium">default workspace</span>
-          <ChevronDown className="size-3 text-muted-foreground" />
-        </button>
+        <WorkspaceSwitcher />
       </div>
 
       {/* (2) Datasets tree of the LIVE store. */}

--- a/gui/app/src/components/workbench/workspace-switcher.tsx
+++ b/gui/app/src/components/workbench/workspace-switcher.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+// [SONNET-4.6] sq-lmlch — workspace switcher UI in the left rail.
+//
+// Renders a trigger button (active workspace name + ChevronDown) that opens a Popover listing
+// ALL stored WorkspaceSummary rows (name, approxTriples, sourceCount, updatedAt). From the
+// popover the user can:
+//   • SWITCH to any workspace (save-current-snapshot invariant is owned by switchWorkspace)
+//   • CREATE a new empty workspace (name prompt inline; uses createWorkspace which saves outgoing)
+//   • RENAME a workspace (inline edit; uses renameWorkspace)
+//   • DELETE a workspace (inline confirm; deleteWorkspace handles active-deletion fallback)
+//   • see the honest backend label ("saved on device" / "in this browser" / "this session only")
+//
+// INVARIANT: the UI NEVER calls hydrateFromSnapshot directly — all lifecycle goes through the
+// WorkspaceContext APIs (sq-lcd6e). Creating and switching both save the outgoing snapshot first.
+//
+// Cmd-K commands registered here: "New workspace" + "Switch workspace…" (Actions group) +
+// per-workspace "Switch to …" rows for every non-active workspace.
+
+import * as React from "react";
+import { Popover as PopoverPrimitive } from "radix-ui";
+import {
+  ChevronDown,
+  Check,
+  Plus,
+  Pencil,
+  Trash2,
+  Database,
+  X,
+} from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useWorkspace } from "@/lib/workspace-context";
+import { useRegisterPaletteCommands } from "@/components/workbench/command-palette";
+import type { PaletteCommand } from "@/lib/palette-commands";
+import type { WorkspaceBackend } from "@sparq/client";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function backendLabel(backend: WorkspaceBackend | null): string {
+  if (backend === "tauri") return "saved on device";
+  if (backend === "web") return "saved in this browser";
+  return "this session only";
+}
+
+function relativeTime(ts: number): string {
+  const diff = Date.now() - ts;
+  const s = Math.floor(diff / 1_000);
+  if (s < 60) return "just now";
+  const m = Math.floor(s / 60);
+  if (m < 60) return `${m}m ago`;
+  const h = Math.floor(m / 60);
+  if (h < 24) return `${h}h ago`;
+  const d = Math.floor(h / 24);
+  return `${d}d ago`;
+}
+
+// ── Inline-mode union — drives the popover's editing state ───────────────────
+
+type InlineMode =
+  | { kind: "idle" }
+  | { kind: "creating" }
+  | { kind: "renaming"; id: string }
+  | { kind: "confirming-delete"; id: string; name: string };
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function WorkspaceSwitcher() {
+  const {
+    workspace,
+    workspaces,
+    backend,
+    createWorkspace,
+    renameWorkspace,
+    deleteWorkspace,
+    switchWorkspace,
+  } = useWorkspace();
+
+  const [open, setOpen] = React.useState(false);
+  const [mode, setMode] = React.useState<InlineMode>({ kind: "idle" });
+  const [inputValue, setInputValue] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  // Focus the inline input whenever an editing mode activates.
+  React.useEffect(() => {
+    if (mode.kind === "creating" || mode.kind === "renaming") {
+      // A 0-ms tick is enough to let the DOM update before focusing.
+      const id = window.setTimeout(() => inputRef.current?.focus(), 0);
+      return () => window.clearTimeout(id);
+    }
+  }, [mode.kind]);
+
+  const resetMode = React.useCallback(() => {
+    setMode({ kind: "idle" });
+    setInputValue("");
+  }, []);
+
+  const handleCreate = React.useCallback(async () => {
+    const name = inputValue.trim();
+    if (!name) return;
+    resetMode();
+    await createWorkspace(name);
+    setOpen(false);
+  }, [inputValue, resetMode, createWorkspace]);
+
+  const handleRename = React.useCallback(
+    async (id: string) => {
+      const name = inputValue.trim();
+      if (!name) {
+        resetMode();
+        return;
+      }
+      resetMode();
+      await renameWorkspace(id, name);
+    },
+    [inputValue, resetMode, renameWorkspace],
+  );
+
+  const handleDelete = React.useCallback(
+    async (id: string) => {
+      resetMode();
+      // deleteWorkspace handles the active-deletion fallback: switches to the next most-recently-
+      // updated workspace, or creates a fresh default if none remain. The UI does not need to
+      // guard against "deleting the last workspace" separately — the context creates a new default.
+      await deleteWorkspace(id);
+    },
+    [resetMode, deleteWorkspace],
+  );
+
+  const handleSwitch = React.useCallback(
+    async (id: string) => {
+      setOpen(false);
+      if (id === workspace?.id) return;
+      await switchWorkspace(id);
+    },
+    [workspace?.id, switchWorkspace],
+  );
+
+  // ── Palette commands ───────────────────────────────────────────────────────
+
+  const paletteCommands = React.useMemo<PaletteCommand[]>(() => {
+    const cmds: PaletteCommand[] = [
+      {
+        id: "workspace.new",
+        group: "Actions",
+        title: "New workspace",
+        blurb: "Create a fresh, empty workspace",
+        keywords: ["workspace", "new", "create", "add", "fresh"],
+        icon: Plus,
+        run: () => {
+          setOpen(true);
+          setMode({ kind: "creating" });
+          setInputValue("");
+        },
+      },
+      {
+        id: "workspace.switch",
+        group: "Actions",
+        title: "Switch workspace…",
+        blurb:
+          workspaces.length > 1
+            ? `${workspaces.length} workspaces available`
+            : "Only one workspace",
+        keywords: ["workspace", "switch", "open", "change"],
+        icon: Database,
+        disabled: workspaces.length <= 1,
+        run: () => setOpen(true),
+      },
+    ];
+    // Per-workspace "Switch to …" entries for every non-active workspace.
+    for (const ws of workspaces) {
+      if (ws.id === workspace?.id) continue;
+      cmds.push({
+        id: `workspace.switch.${ws.id}`,
+        group: "Actions",
+        title: `Switch to "${ws.name}"`,
+        blurb: `${ws.approxTriples.toLocaleString()} triple${ws.approxTriples !== 1 ? "s" : ""} · ${ws.sourceCount} source${ws.sourceCount !== 1 ? "s" : ""}`,
+        keywords: ["workspace", "switch", ws.name],
+        icon: Database,
+        run: () => {
+          void switchWorkspace(ws.id);
+        },
+      });
+    }
+    return cmds;
+  }, [workspaces, workspace?.id, switchWorkspace]);
+
+  useRegisterPaletteCommands("workspace", paletteCommands);
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  const activeWorkspaceName = workspace?.name ?? "loading…";
+
+  return (
+    <PopoverPrimitive.Root
+      open={open}
+      onOpenChange={(o) => {
+        setOpen(o);
+        if (!o) resetMode();
+      }}
+    >
+      <PopoverPrimitive.Trigger asChild>
+        <button
+          data-workspace-trigger
+          className="flex w-full items-center gap-1.5 rounded-md border bg-background px-2 py-1.5 text-left text-xs hover:bg-sidebar-accent/40"
+          title={`Active workspace: ${activeWorkspaceName} · ${backendLabel(backend)}`}
+        >
+          {/* Saved-status LED: green = workspace loaded + context has a backend */}
+          <span
+            className="size-2.5 shrink-0 rounded-full bg-[var(--success)] drop-shadow-[0_0_5px_var(--success)]"
+            aria-hidden
+          />
+          <span
+            className="flex-1 truncate font-medium"
+            data-workspace-active-name
+          >
+            {activeWorkspaceName}
+          </span>
+          <ChevronDown className="size-3 shrink-0 text-muted-foreground" aria-hidden />
+        </button>
+      </PopoverPrimitive.Trigger>
+
+      <PopoverPrimitive.Portal>
+        <PopoverPrimitive.Content
+          data-workspace-popover
+          align="start"
+          sideOffset={4}
+          className={cn(
+            "z-50 w-56 overflow-hidden rounded-lg border bg-popover p-1 text-popover-foreground shadow-md",
+            "data-[state=open]:animate-in data-[state=closed]:animate-out",
+            "data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+            "data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
+          )}
+        >
+          {/* Honest persistence label */}
+          <p className="px-2 pb-1 pt-0.5 text-[10px] text-muted-foreground" data-workspace-backend-label>
+            {backendLabel(backend)}
+          </p>
+
+          {/* Workspace list */}
+          <ul role="listbox" aria-label="Workspaces" className="space-y-0.5">
+            {workspaces.map((ws) => {
+              const isActive = ws.id === workspace?.id;
+              const isRenaming = mode.kind === "renaming" && mode.id === ws.id;
+              const isConfirming =
+                mode.kind === "confirming-delete" && mode.id === ws.id;
+
+              return (
+                <li key={ws.id} role="option" aria-selected={isActive}>
+                  {isRenaming ? (
+                    // ── Inline rename ──────────────────────────────────────
+                    <div className="flex items-center gap-1 px-1">
+                      <input
+                        ref={inputRef}
+                        data-workspace-rename-input
+                        value={inputValue}
+                        onChange={(e) => setInputValue(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === "Enter") void handleRename(ws.id);
+                          if (e.key === "Escape") resetMode();
+                        }}
+                        className="min-w-0 flex-1 rounded border bg-background px-1.5 py-0.5 text-xs outline-none focus:ring-1 focus:ring-ring/50"
+                        placeholder="Workspace name"
+                        aria-label="Rename workspace"
+                      />
+                      <button
+                        onClick={() => void handleRename(ws.id)}
+                        className="rounded p-0.5 text-primary hover:bg-accent"
+                        aria-label="Save rename"
+                      >
+                        <Check className="size-3" />
+                      </button>
+                      <button
+                        onClick={resetMode}
+                        className="rounded p-0.5 text-muted-foreground hover:bg-accent"
+                        aria-label="Cancel rename"
+                      >
+                        <X className="size-3" />
+                      </button>
+                    </div>
+                  ) : isConfirming ? (
+                    // ── Delete confirm ──────────────────────────────────────
+                    <div className="flex items-center gap-1 rounded px-2 py-1 text-xs">
+                      <span className="min-w-0 flex-1 truncate text-destructive">
+                        Delete &ldquo;{ws.name}&rdquo;?
+                      </span>
+                      <button
+                        data-workspace-delete-confirm
+                        onClick={() => void handleDelete(ws.id)}
+                        className="rounded bg-destructive/10 px-1.5 py-0.5 text-[10px] font-medium text-destructive hover:bg-destructive/20"
+                        aria-label={`Confirm delete workspace ${ws.name}`}
+                      >
+                        Delete
+                      </button>
+                      <button
+                        onClick={resetMode}
+                        className="rounded p-0.5 text-muted-foreground hover:bg-accent"
+                        aria-label="Cancel delete"
+                      >
+                        <X className="size-3" />
+                      </button>
+                    </div>
+                  ) : (
+                    // ── Normal row ──────────────────────────────────────────
+                    <div className="group flex items-center gap-1.5 rounded px-2 py-1 hover:bg-sidebar-accent/40">
+                      <button
+                        data-workspace-item={ws.id}
+                        onClick={() => void handleSwitch(ws.id)}
+                        className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+                        aria-label={`Switch to workspace ${ws.name}`}
+                      >
+                        {isActive ? (
+                          <Check className="size-3 shrink-0 text-primary" />
+                        ) : (
+                          <span className="size-3 shrink-0" aria-hidden />
+                        )}
+                        <span className="min-w-0 flex-1">
+                          <span className="block truncate text-xs font-medium">
+                            {ws.name}
+                          </span>
+                          <span className="block truncate text-[10px] text-muted-foreground">
+                            {ws.approxTriples.toLocaleString()}{" "}
+                            {ws.approxTriples === 1 ? "triple" : "triples"} ·{" "}
+                            {ws.sourceCount} src · {relativeTime(ws.updatedAt)}
+                          </span>
+                        </span>
+                      </button>
+
+                      {/* Rename + delete — shown on hover via group-hover */}
+                      <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100">
+                        <button
+                          data-workspace-rename={ws.id}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setMode({ kind: "renaming", id: ws.id });
+                            setInputValue(ws.name);
+                          }}
+                          className="rounded p-0.5 text-muted-foreground hover:bg-accent hover:text-foreground"
+                          aria-label={`Rename workspace ${ws.name}`}
+                          title="Rename"
+                        >
+                          <Pencil className="size-3" />
+                        </button>
+                        <button
+                          data-workspace-delete={ws.id}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                            setMode({
+                              kind: "confirming-delete",
+                              id: ws.id,
+                              name: ws.name,
+                            });
+                          }}
+                          className="rounded p-0.5 text-muted-foreground hover:bg-destructive/20 hover:text-destructive"
+                          aria-label={`Delete workspace ${ws.name}`}
+                          title="Delete"
+                        >
+                          <Trash2 className="size-3" />
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+
+          {/* Divider + New workspace */}
+          <div className="my-1 border-t" />
+
+          {mode.kind === "creating" ? (
+            // ── Inline create ───────────────────────────────────────────────
+            <div className="flex items-center gap-1 px-1 pb-0.5">
+              <input
+                ref={inputRef}
+                data-workspace-create-input
+                value={inputValue}
+                onChange={(e) => setInputValue(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") void handleCreate();
+                  if (e.key === "Escape") resetMode();
+                }}
+                className="min-w-0 flex-1 rounded border bg-background px-1.5 py-0.5 text-xs outline-none focus:ring-1 focus:ring-ring/50"
+                placeholder="New workspace name"
+                aria-label="New workspace name"
+              />
+              <button
+                data-workspace-create-confirm
+                onClick={() => void handleCreate()}
+                className="rounded p-0.5 text-primary hover:bg-accent"
+                aria-label="Create workspace"
+              >
+                <Check className="size-3" />
+              </button>
+              <button
+                onClick={resetMode}
+                className="rounded p-0.5 text-muted-foreground hover:bg-accent"
+                aria-label="Cancel create"
+              >
+                <X className="size-3" />
+              </button>
+            </div>
+          ) : (
+            <button
+              data-workspace-new
+              onClick={() => {
+                setMode({ kind: "creating" });
+                setInputValue("");
+              }}
+              className="flex w-full items-center gap-1.5 rounded px-2 py-1 text-xs text-muted-foreground hover:bg-sidebar-accent/40 hover:text-foreground"
+            >
+              <Plus className="size-3" />
+              New workspace
+            </button>
+          )}
+        </PopoverPrimitive.Content>
+      </PopoverPrimitive.Portal>
+    </PopoverPrimitive.Root>
+  );
+}

--- a/gui/e2e-playwright/specs/workspace-switcher.spec.ts
+++ b/gui/e2e-playwright/specs/workspace-switcher.spec.ts
@@ -1,0 +1,355 @@
+// [SONNET-4.6] sq-lmlch — workspace switcher UI: create/rename/delete/switch correctness.
+//
+// INVARIANT under test: switching never loses data — the outgoing workspace's snapshot is saved
+// before the incoming one hydrates (delegated to switchWorkspace / createWorkspace in sq-lcd6e).
+//
+// Test strategy: the "paste" import tab sends text DIRECTLY to the WASM engine (bypasses the
+// tauri-mock `load_text` fixture), so each test can pick a DISTINCTIVE triple to import and
+// assert its presence/absence across workspace switches.
+//
+// Persistence backend: web (localStorage) — the Tauri FS plugin is not mocked here, so
+// createWorkspaceStore resolves the WEB backend.  Workspaces persist across reloads but
+// we don't need reloads in this spec — all actions are in-session.
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only; NO exact numeric assertions.
+
+import { test, expect, waitForEngineReady } from "../support/index.ts";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────────────────────
+
+/** Set the SPARQL editor value via the native setter + input event (React-controlled textarea). */
+async function setEditorValue(
+  page: import("@playwright/test").Page,
+  value: string,
+): Promise<void> {
+  await page.evaluate((text) => {
+    const el = document.querySelector<HTMLTextAreaElement>("#repl-query");
+    if (!el) throw new Error("Editor textarea #repl-query not found");
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    if (!setter) throw new Error("Could not access native value setter");
+    setter.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }, value);
+}
+
+/** Run the current editor query and wait for a result of the given kind to render. */
+async function runQuery(
+  page: import("@playwright/test").Page,
+  kind: "ask" | "select" | "error",
+): Promise<void> {
+  await page.getByRole("button", { name: "Run query" }).click();
+  await expect(page.locator(`[data-result-kind="${kind}"]`)).toBeVisible();
+}
+
+/** Paste-import a triple (REPLACE mode) using the import drawer's paste tab. */
+async function pasteImportReplace(
+  page: import("@playwright/test").Page,
+  triple: string,
+): Promise<void> {
+  // Open the import drawer from the topbar trigger.
+  await page.locator('[data-import-trigger="topbar"]').click();
+  const drawer = page.locator("[data-import-drawer]");
+  await expect(drawer).toBeVisible();
+
+  await drawer.locator('[data-import-tab="paste"]').click();
+  await drawer.locator("textarea").fill(triple);
+
+  // Switch to REPLACE mode so the store is deterministic after each import.
+  await drawer.getByRole("button", { name: "Replace store" }).click();
+  await drawer.getByRole("button", { name: /Import \(replace store\)/ }).click();
+  await expect(drawer.locator('[data-import-feedback="ok"]')).toBeVisible();
+
+  await page.keyboard.press("Escape");
+  await expect(drawer).toBeHidden();
+}
+
+/**
+ * Open the workspace switcher popover.
+ * Returns the locator for the popover content (data-workspace-popover).
+ */
+async function openSwitcher(
+  page: import("@playwright/test").Page,
+): Promise<import("@playwright/test").Locator> {
+  await page.locator("[data-workspace-trigger]").click();
+  const popover = page.locator("[data-workspace-popover]");
+  await expect(popover).toBeVisible();
+  return popover;
+}
+
+/**
+ * Create a new workspace via the popover UI.
+ * Leaves the popover closed (createWorkspace closes it after success).
+ */
+async function createWorkspaceViaUI(
+  page: import("@playwright/test").Page,
+  name: string,
+): Promise<void> {
+  const popover = await openSwitcher(page);
+  await popover.locator("[data-workspace-new]").click();
+  const input = popover.locator("[data-workspace-create-input]");
+  await expect(input).toBeVisible();
+  await input.fill(name);
+  await popover.locator("[data-workspace-create-confirm]").click();
+  // Popover closes after create.
+  await expect(popover).toBeHidden();
+}
+
+/** Switch to a workspace by clicking its row in the popover. */
+async function switchWorkspaceViaUI(
+  page: import("@playwright/test").Page,
+  workspaceId: string,
+): Promise<void> {
+  const popover = await openSwitcher(page);
+  await popover.locator(`[data-workspace-item="${workspaceId}"]`).click();
+  await expect(popover).toBeHidden();
+  // Wait for the engine to settle after the snapshot-restore switch.
+  await waitForEngineReady(page, { timeout: 90_000 });
+}
+
+/** Read the active workspace ID from localStorage (the __last__ pointer). */
+async function readActiveWorkspaceId(page: import("@playwright/test").Page): Promise<string | null> {
+  return page.evaluate(() => {
+    return localStorage.getItem("sparq.workspace.v1.__last__");
+  });
+}
+
+/** Read all workspace IDs from the localStorage index. */
+async function readWorkspaceIds(page: import("@playwright/test").Page): Promise<string[]> {
+  return page.evaluate(() => {
+    const raw = localStorage.getItem("sparq.workspace.v1.__index__");
+    if (!raw) return [];
+    try {
+      const parsed = JSON.parse(raw);
+      return Array.isArray(parsed) ? parsed : [];
+    } catch {
+      return [];
+    }
+  });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────────────────────
+
+test.describe("workspace-switcher", () => {
+
+  test("switcher trigger renders with the active workspace name", async ({ page }) => {
+    // The trigger button must be visible with the default workspace name.
+    const trigger = page.locator("[data-workspace-trigger]");
+    await expect(trigger).toBeVisible();
+    // The active name span must be non-empty.
+    const nameSpan = page.locator("[data-workspace-active-name]");
+    await expect(nameSpan).toBeVisible();
+    const name = await nameSpan.textContent();
+    expect(name?.trim().length).toBeGreaterThan(0);
+  });
+
+  test("opening the switcher shows the backend label", async ({ page }) => {
+    const popover = await openSwitcher(page);
+    const label = popover.locator("[data-workspace-backend-label]");
+    await expect(label).toBeVisible();
+    // On the web persona, backend is "web" → "saved in this browser"
+    await expect(label).toContainText("saved in this browser");
+  });
+
+  test("create workspace B → distinct data in each workspace → switch preserves each", async ({
+    page,
+  }) => {
+    // Strategy: the DEFAULT workspace starts with the SAMPLE GRAPH (Alice, from seedSampleWhenEmpty).
+    // Workspace B is created empty then receives a paste import — in the Tauri mock persona the
+    // `load_text` IPC is intercepted, so the actual import result is the LOAD_FIXTURE triple
+    // (<http://example.org/imported>). The distinction between the two workspaces is therefore:
+    //   default → Alice present, imported fixture absent
+    //   workspace B → Alice absent, imported fixture present
+    //
+    // This strategy does not depend on passing custom text through the Tauri IPC mock.
+
+    const ALICE_QUERY = 'PREFIX foaf: <http://xmlns.com/foaf/0.1/> ASK { ?s foaf:name "Alice" }';
+    // The fixture subject returned by the tauri-mock `load_text` stub (tauri-mock.ts LOAD_FIXTURE).
+    const FIXTURE_SUBJECT = "http://example.org/imported";
+    const FIXTURE_QUERY = `ASK { <${FIXTURE_SUBJECT}> ?p ?o }`;
+
+    // ── (A) Default workspace: Alice is present (sample graph). ──────────────────────────────
+    await setEditorValue(page, ALICE_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+
+    // Fixture subject is absent in the default workspace's sample graph.
+    await setEditorValue(page, FIXTURE_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("false");
+
+    // Remember default workspace ID so we can switch back to it later.
+    const defaultId = await readActiveWorkspaceId(page);
+    expect(defaultId).not.toBeNull();
+
+    // ── (B) Create workspace B — createWorkspace saves the default's live snapshot first. ─────
+    await createWorkspaceViaUI(page, "workspace-b-e2e");
+
+    // Workspace B is now active.
+    await expect(page.locator("[data-workspace-active-name]")).toContainText("workspace-b-e2e");
+
+    // Workspace B is empty (no sample, no import yet) — both triples are absent.
+    await setEditorValue(page, ALICE_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("false");
+
+    await setEditorValue(page, FIXTURE_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("false");
+
+    // Import into workspace B (REPLACE mode). The mock returns the LOAD_FIXTURE triple.
+    // The paste text content is irrelevant here — the Tauri IPC mock intercepts load_text
+    // and always returns `<http://example.org/imported> <...> <...>`.
+    await pasteImportReplace(
+      page,
+      "<http://example.org/imported> <http://example.org/p> <http://example.org/o> .",
+    );
+
+    // Workspace B: fixture triple present, Alice absent.
+    await setEditorValue(page, FIXTURE_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+
+    await setEditorValue(page, ALICE_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("false");
+
+    // Remember workspace B ID.
+    const bId = await readActiveWorkspaceId(page);
+    expect(bId).not.toBeNull();
+    expect(bId).not.toBe(defaultId);
+
+    // ── (C) Switch BACK to the default workspace. ─────────────────────────────────────────────
+    await switchWorkspaceViaUI(page, defaultId!);
+    await expect(page.locator("[data-workspace-active-name]")).not.toContainText("workspace-b-e2e");
+
+    // Default workspace: Alice present (sample graph restored), fixture triple absent.
+    await setEditorValue(page, ALICE_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+
+    await setEditorValue(page, FIXTURE_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("false");
+
+    // ── (D) Switch BACK to workspace B — its data must still be there. ───────────────────────
+    await switchWorkspaceViaUI(page, bId!);
+    await expect(page.locator("[data-workspace-active-name]")).toContainText("workspace-b-e2e");
+
+    // Workspace B: fixture triple still present, Alice still absent.
+    await setEditorValue(page, FIXTURE_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+
+    await setEditorValue(page, ALICE_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("false");
+  });
+
+  test("rename is reflected in the trigger and in the popover list", async ({ page }) => {
+    // ── Set up: create a workspace we will rename. ────────────────────────────────────────────
+    await createWorkspaceViaUI(page, "workspace-to-rename");
+    await expect(page.locator("[data-workspace-active-name]")).toContainText("workspace-to-rename");
+
+    // ── Open switcher, find the active workspace, click rename. ───────────────────────────────
+    const popover = await openSwitcher(page);
+
+    // The workspace-to-rename item is active; find its ID.
+    const activeId = await readActiveWorkspaceId(page);
+    expect(activeId).not.toBeNull();
+
+    // Click the rename button for the active workspace.
+    await popover.locator(`[data-workspace-rename="${activeId}"]`).click();
+
+    // Inline rename input should appear pre-filled with the old name.
+    const renameInput = popover.locator("[data-workspace-rename-input]");
+    await expect(renameInput).toBeVisible();
+    await expect(renameInput).toHaveValue("workspace-to-rename");
+
+    // Clear and type a new name.
+    await renameInput.fill("workspace-renamed-e2e");
+    await renameInput.press("Enter");
+
+    // Popover stays open (rename does not close the popover).
+    // The renamed workspace should appear in the list.
+    // The active-name in the trigger must reflect the rename.
+    await expect(page.locator("[data-workspace-active-name]")).toContainText("workspace-renamed-e2e");
+  });
+
+  test("delete non-active workspace falls back safely (active workspace unchanged)", async ({
+    page,
+  }) => {
+    // ── Set up: create two extra workspaces. ─────────────────────────────────────────────────
+    await createWorkspaceViaUI(page, "to-delete-e2e");
+    const toDeleteId = await readActiveWorkspaceId(page);
+    expect(toDeleteId).not.toBeNull();
+
+    // Switch back to the default workspace before deleting to-delete-e2e.
+    const allIds = await readWorkspaceIds(page);
+    const defaultId = allIds.find((id) => id !== toDeleteId);
+    expect(defaultId).toBeDefined();
+    await switchWorkspaceViaUI(page, defaultId!);
+
+    // ── Delete the non-active workspace. ─────────────────────────────────────────────────────
+    const popover = await openSwitcher(page);
+    await popover.locator(`[data-workspace-delete="${toDeleteId}"]`).click();
+
+    // Confirm button must appear.
+    const confirmBtn = popover.locator("[data-workspace-delete-confirm]");
+    await expect(confirmBtn).toBeVisible();
+    await confirmBtn.click();
+
+    // After delete the active workspace has not changed (we deleted a non-active one).
+    await expect(page.locator("[data-workspace-active-name]")).not.toContainText("to-delete-e2e");
+
+    // The deleted workspace row must be gone from the popover list.
+    const deletedRow = page.locator(`[data-workspace-item="${toDeleteId}"]`);
+    // Reopen the popover to confirm the row is absent.
+    await openSwitcher(page);
+    await expect(deletedRow).not.toBeAttached();
+  });
+
+  test("deleting the ACTIVE workspace switches to a fallback workspace", async ({ page }) => {
+    // ── Set up: create workspace B, switch to it, then delete it. ────────────────────────────
+    await createWorkspaceViaUI(page, "active-to-delete-e2e");
+    const toDeleteId = await readActiveWorkspaceId(page);
+    expect(toDeleteId).not.toBeNull();
+
+    // Confirm workspace-b is active.
+    await expect(page.locator("[data-workspace-active-name]")).toContainText("active-to-delete-e2e");
+
+    // Delete the active workspace via the popover.
+    const popover = await openSwitcher(page);
+    await popover.locator(`[data-workspace-delete="${toDeleteId}"]`).click();
+    const confirmBtn = popover.locator("[data-workspace-delete-confirm]");
+    await expect(confirmBtn).toBeVisible();
+    await confirmBtn.click();
+
+    // After deleting the active workspace the context must switch to a fallback.
+    // The trigger must no longer show the deleted workspace's name.
+    await expect(page.locator("[data-workspace-active-name]")).not.toContainText(
+      "active-to-delete-e2e",
+    );
+
+    // The engine must still be ready (no crash / white screen).
+    await waitForEngineReady(page, { timeout: 90_000 });
+  });
+
+  test("'New workspace' Cmd-K command opens the create inline input", async ({ page }) => {
+    // Trigger Cmd-K (or Ctrl-K).
+    await page.keyboard.press("Meta+k");
+    const paletteInput = page.locator("input[placeholder*='Run a tool']");
+    await expect(paletteInput).toBeVisible();
+
+    // Type "New workspace" and press Enter.
+    await paletteInput.fill("New workspace");
+    await page.keyboard.press("Enter");
+
+    // The palette must close and the workspace create input must be visible.
+    await expect(paletteInput).not.toBeVisible();
+    const createInput = page.locator("[data-workspace-create-input]");
+    await expect(createInput).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

> �� SPARQ agent — implementing bead sq-lmlch (workspace switcher UI in the left rail).

- **`workspace-switcher.tsx`** (new): Radix Popover listing all `WorkspaceSummary` rows with switch-on-click, inline rename (Enter to save / Esc to cancel), inline confirm-delete (cannot crash on last-workspace delete — context handles fallback), and "New workspace" name prompt. Shows honest backend label ("saved on device" / "in this browser" / "this session only") in the popover header.
- **`left-rail.tsx`**: replaces the dead stub button (`title="persistent workspaces are a later phase"`) with `<WorkspaceSwitcher />`. Adds import; removes unused `ChevronDown`/`Circle` icons from the stub.
- **`workspace-switcher.spec.ts`** (new): 7 Playwright tests covering trigger rendering, backend label, create→distinct-data→switch-preserves-each (non-vacuous: ASK queries against live engine per workspace), rename reflected in trigger, delete non-active safe, delete active falls back to another workspace, Cmd-K "New workspace" wires up.
- **Cmd-K commands** registered via `useRegisterPaletteCommands("workspace", ...)`: "New workspace", "Switch workspace…", and per-workspace "Switch to `<name>`" rows for every non-active workspace.

## Invariants preserved

- The UI NEVER calls `hydrateFromSnapshot` directly — all lifecycle goes through `switchWorkspace` / `createWorkspace` / `renameWorkspace` / `deleteWorkspace` (sq-lcd6e). Save-current-snapshot before switching is owned by the context.
- Deleting the active workspace is handled by the context (switches to most-recently-updated, or creates a fresh default). UI confirms inline but does not implement fallback logic.
- Data-driven rail structure (sq-1odi9) is untouched — the switcher only touches the `border-b px-2 py-2` header div.
- Does NOT touch inference-control files (sq-glo5r concurrency constraint).

## Gates

- `npm run build:web` ✅
- `npm run build:tauri` ✅  
- `npx tsc --noEmit` ✅
- `next lint` ✅
- Playwright chromium-mock-ipc: 35/35 ✅ (all passing)
- Playwright chromium-web: 9/10 (1 pre-existing failure: `streaming-tool.web.spec.ts` needs the RSP WASM bundle built separately — fails on main HEAD too, from #1529)

## Test plan

- [ ] Open the app; workspace trigger shows active workspace name + green LED
- [ ] Click trigger → popover lists workspaces with backend label  
- [ ] Click "New workspace" → inline input → type name → Enter → workspace created, active
- [ ] Rename a workspace → name updates in trigger and popover list
- [ ] Delete a non-active workspace → row disappears, active workspace unchanged
- [ ] Delete the active workspace → app switches to fallback without crashing
- [ ] Cmd-K → "New workspace" → popover opens in create mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)