### PR TITLE
feat(gui): N3 inference regime + per-workspace rules + bulk upload (sq-glo5r)

### DIFF
--- a/gui/app/src/components/workbench/inference-control.tsx
+++ b/gui/app/src/components/workbench/inference-control.tsx
@@ -33,6 +33,20 @@ export function InferenceModeBridge() {
   return null;
 }
 
+/**
+ * [sq-glo5r] Keep the ENGINE's N3 rules cache in lockstep with the active workspace's persisted
+ * rules docs. Renders null; mounted once alongside {@link InferenceModeBridge} so the N3 closure
+ * is rebuilt whenever rules change, regardless of the focused tool tab.
+ */
+export function N3RulesBridge() {
+  const { rulesDocs } = useWorkspace();
+  const { setN3Rules } = useEngine();
+  React.useEffect(() => {
+    setN3Rules(rulesDocs);
+  }, [rulesDocs, setN3Rules]);
+  return null;
+}
+
 /** A live status pill for the active regime: entailed-triple count / loading / honest error. */
 export function InferenceStatusPill() {
   const { inferenceStatus } = useEngine();

--- a/gui/app/src/components/workbench/inference-tool.tsx
+++ b/gui/app/src/components/workbench/inference-tool.tsx
@@ -6,20 +6,29 @@
 // shows the MEASURED base / closure / entailed triple counts the engine's forward-chaining
 // reasoner (sparq-reason, via the tier-b W-reason wasm bundle) produced over the live store.
 //
+// [sq-glo5r] — N3 RULES section: when the workspace is in "n3" mode, this tool additionally
+// shows the per-workspace N3 rule documents (list + enable/disable + remove), a drag-drop /
+// browse bulk-upload zone (.n3 / .ttl files), and a collapsible "Author a rule" pane with a
+// syntax-highlighting editor + name input + "Add rule" button.
+//
 // HONESTY: reasoning is REAL (not a captured walkthrough), but it is a QUERY-TIME regime — it
 // never mutates the persisted store, and named graphs are folded into the default graph for
-// entailment. RDFS + OWL 2 RL are wired; N3 rule reasoning is deferred (it needs a rules-
-// authoring surface + a store that can hold rule/formula terms — see the caveat below).
+// entailment. RDFS + OWL 2 RL are wired; N3 derives GROUND triples only — formula / quoted-graph
+// conclusions are dropped (the in-tab ground-triple store cannot hold formula terms).
 
 import * as React from "react";
-import { Brain, Info } from "lucide-react";
+import { Brain, Info, Plus, Trash2, ChevronDown, ChevronUp } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import { useEngine } from "@/lib/engine-context";
 import { useWorkspace } from "@/lib/workspace-context";
 import { INFERENCE_MODE_META } from "@/lib/reason-wasm";
 import { toolById, TIER_META } from "@/data/tools";
 import { InferenceControl } from "@/components/workbench/inference-control";
+import { WorkbenchTurtleEditor } from "@/components/workbench/turtle-editor";
+import { Dropzone } from "@/components/workbench/dropzone";
+import type { IngestResult } from "@/lib/file-ingest";
 
 /** One labelled measured count in the stats strip. */
 function Stat({ label, value }: { label: string; value: number }) {
@@ -27,6 +36,198 @@ function Stat({ label, value }: { label: string; value: number }) {
     <div className="flex flex-col rounded-md border bg-card px-3 py-2">
       <span className="tabular text-lg font-semibold">{value.toLocaleString()}</span>
       <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+// Accepted file extensions for N3 rule documents.
+const N3_ACCEPT = [".n3", ".ttl"];
+
+/**
+ * [sq-glo5r] The N3 rules management panel: list of attached rule documents (enable / remove),
+ * a bulk-upload dropzone, and a collapsible inline-authoring pane.
+ */
+function N3RulesPanel() {
+  const { rulesDocs, addRulesDocs, removeRulesDoc, setRulesDocEnabled } = useWorkspace();
+
+  // --- Authoring pane state ---
+  const [authorOpen, setAuthorOpen] = React.useState(false);
+  const [authorText, setAuthorText] = React.useState("");
+  const [authorName, setAuthorName] = React.useState("");
+
+  // --- Dropzone upload handler ---
+  const handleFiles = React.useCallback(
+    (result: IngestResult) => {
+      if (result.accepted.length === 0) return;
+      void addRulesDocs(result.accepted.map((f) => ({ name: f.name, text: f.text })));
+    },
+    [addRulesDocs],
+  );
+
+  // Hidden file input for Playwright setInputFiles() — exercises the same addRulesDocs path.
+  const hiddenInputRef = React.useRef<HTMLInputElement>(null);
+  const handleHiddenInput = React.useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = Array.from(e.target.files ?? []);
+      if (hiddenInputRef.current) hiddenInputRef.current.value = "";
+      if (files.length === 0) return;
+      const read: Array<{ name: string; text: string }> = [];
+      for (const file of files) {
+        try {
+          read.push({ name: file.name, text: await file.text() });
+        } catch {
+          /* skip unreadable files */
+        }
+      }
+      if (read.length > 0) void addRulesDocs(read);
+    },
+    [addRulesDocs],
+  );
+
+  // --- Add authored rule ---
+  const handleAddRule = React.useCallback(() => {
+    const name = authorName.trim() || "rule";
+    const text = authorText.trim();
+    if (!text) return;
+    void addRulesDocs([{ name, text }]);
+    setAuthorText("");
+    setAuthorName("");
+  }, [authorName, authorText, addRulesDocs]);
+
+  return (
+    <div className="space-y-4" data-n3-rules>
+      <h3 className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        N3 Rules ({rulesDocs.length})
+      </h3>
+
+      {/* Rules list */}
+      {rulesDocs.length > 0 ? (
+        <div className="space-y-1">
+          {rulesDocs.map((doc) => (
+            <div
+              key={doc.addedAt}
+              data-n3-rule-row={String(doc.addedAt)}
+              className="flex items-center gap-2 rounded-md border bg-background px-3 py-2"
+            >
+              <input
+                type="checkbox"
+                data-n3-rule-toggle
+                aria-label={`Enable rule "${doc.name}"`}
+                checked={doc.enabled !== false}
+                onChange={(e) => void setRulesDocEnabled(doc.addedAt, e.target.checked)}
+                className="size-3.5 accent-primary"
+              />
+              <span className="min-w-0 flex-1 truncate text-xs font-medium" title={doc.name}>
+                {doc.name}
+              </span>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                className="size-6 shrink-0 text-muted-foreground hover:text-destructive"
+                aria-label={`Remove rule "${doc.name}"`}
+                data-n3-rule-remove
+                onClick={() => void removeRulesDoc(doc.addedAt)}
+              >
+                <Trash2 className="size-3.5" aria-hidden />
+              </Button>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p className="text-xs text-muted-foreground">
+          No rules attached yet — upload .n3 / .ttl files below or author one inline.
+        </p>
+      )}
+
+      {/* Bulk upload dropzone */}
+      <div className="relative" data-n3-dropzone>
+        <Dropzone
+          onFiles={handleFiles}
+          accept={N3_ACCEPT}
+          multiple
+          label="Drop .n3 or .ttl rule files to add them"
+          hint=".n3 · .ttl"
+          browseLabel="Browse rule files…"
+        />
+        {/* Stable hidden input for Playwright setInputFiles() */}
+        <input
+          ref={hiddenInputRef}
+          type="file"
+          multiple
+          accept={N3_ACCEPT.join(",")}
+          className="sr-only"
+          aria-hidden="true"
+          onChange={handleHiddenInput}
+        />
+      </div>
+
+      {/* Scope note */}
+      <p className="text-[11px] text-muted-foreground">
+        Derived ground triples only — formula / quoted-graph conclusions are dropped and not
+        visible in query results.
+      </p>
+
+      {/* Author a rule (collapsible) */}
+      <div className="rounded-md border bg-background">
+        <button
+          type="button"
+          onClick={() => setAuthorOpen((v) => !v)}
+          className="flex w-full items-center justify-between px-3 py-2 text-xs font-medium"
+          aria-expanded={authorOpen}
+        >
+          <span className="flex items-center gap-1.5">
+            <Plus className="size-3.5" aria-hidden /> Author a rule
+          </span>
+          {authorOpen ? (
+            <ChevronUp className="size-3.5 text-muted-foreground" aria-hidden />
+          ) : (
+            <ChevronDown className="size-3.5 text-muted-foreground" aria-hidden />
+          )}
+        </button>
+        {authorOpen ? (
+          <div className="space-y-2 border-t px-3 pb-3 pt-2">
+            {/* Name input */}
+            <div className="flex items-center gap-2">
+              <label htmlFor="n3-author-name" className="shrink-0 text-[11px] text-muted-foreground">
+                Name
+              </label>
+              <input
+                id="n3-author-name"
+                type="text"
+                data-n3-author-name
+                value={authorName}
+                onChange={(e) => setAuthorName(e.target.value)}
+                placeholder="my-rule"
+                className="flex-1 rounded border bg-background px-2 py-1 text-xs outline-none focus:ring-1 focus:ring-primary"
+              />
+            </div>
+            {/* Turtle/N3 editor */}
+            <div
+              data-n3-author-textarea
+              className="h-32 overflow-hidden rounded border bg-background"
+            >
+              <WorkbenchTurtleEditor
+                value={authorText}
+                onChange={setAuthorText}
+                ariaLabel="N3 rule editor"
+                id="n3-author-textarea"
+                placeholder={`@prefix ex: <http://example.org/> .\n{ ?s a ex:A } => { ?s a ex:B . }`}
+              />
+            </div>
+            <Button
+              type="button"
+              size="sm"
+              disabled={!authorText.trim()}
+              onClick={handleAddRule}
+              data-n3-add-rule
+            >
+              <Plus className="mr-1 size-3.5" aria-hidden />
+              Add rule
+            </Button>
+          </div>
+        ) : null}
+      </div>
     </div>
   );
 }
@@ -54,8 +255,8 @@ export function InferenceTool() {
             ) : null}
           </div>
           <p className="text-sm text-muted-foreground">
-            Apply an RDFS / OWL 2 RL entailment regime to your queries over the live store. The
-            engine forward-chains the deductive closure with the real{" "}
+            Apply an RDFS / OWL 2 RL entailment regime or N3 rules to your queries over the live
+            store. The engine forward-chains the deductive closure with the real{" "}
             <code className="rounded bg-muted px-1 py-0.5 text-[11px]">sparq-reason</code> reasoner,
             so a query can match an <em>entailed</em> triple, not just an asserted one. The choice
             is saved per workspace.
@@ -67,6 +268,13 @@ export function InferenceTool() {
           <InferenceControl />
           <p className="mt-3 text-xs text-muted-foreground">{modeMeta.blurb}</p>
         </div>
+
+        {/* N3 rules panel (when N3 mode is active). */}
+        {inference === "n3" ? (
+          <div className="rounded-lg border bg-background p-4">
+            <N3RulesPanel />
+          </div>
+        ) : null}
 
         {/* Live measured stats when a regime is active + ready. */}
         {inferenceStatus.kind === "ready" ? (
@@ -98,8 +306,8 @@ export function InferenceTool() {
           <p className="text-sm text-muted-foreground">Waiting for the engine to warm…</p>
         ) : (
           <p className="text-sm text-muted-foreground">
-            Inference is off — queries run over the asserted data. Pick RDFS or OWL 2 RL above to
-            reason over the live store.
+            Inference is off — queries run over the asserted data. Pick RDFS, OWL 2 RL, or N3
+            above to reason over the live store.
           </p>
         )}
 
@@ -118,13 +326,15 @@ export function InferenceTool() {
               returns you to the asserted data exactly.
             </li>
             <li>
-              N3 rule reasoning is not offered as a store-wide regime: it needs an N3 rules-
-              authoring surface and a store that can carry rule / formula terms, which the in-tab
-              ground-triple store cannot represent (tracked as a follow-up).
+              N3 rules are attached to this workspace — derived ground triples appear in queries
+              while N3 is on; formula conclusions cannot live in the ground-triple store and are
+              dropped. Named graphs are folded into the default graph for N3 reasoning (same as
+              RDFS / OWL-RL).
             </li>
           </ul>
           <div className="pt-1">
             <Badge variant="outline">sq-tp1m</Badge>
+            <Badge variant="outline" className="ml-1">sq-glo5r</Badge>
           </div>
         </div>
       </div>

--- a/gui/app/src/components/workbench/inference-tool.tsx
+++ b/gui/app/src/components/workbench/inference-tool.tsx
@@ -150,14 +150,16 @@ function N3RulesPanel() {
           hint=".n3 · .ttl"
           browseLabel="Browse rule files…"
         />
-        {/* Stable hidden input for Playwright setInputFiles() */}
+        {/* Stable hidden input for Playwright setInputFiles() — mirrors data-global-drop-input
+            (sq-eydh9): sr-only + a real aria-label, never aria-hidden on a focusable control. */}
         <input
           ref={hiddenInputRef}
           type="file"
           multiple
           accept={N3_ACCEPT.join(",")}
+          data-n3-file-input
+          aria-label="Select N3 rule files to add"
           className="sr-only"
-          aria-hidden="true"
           onChange={handleHiddenInput}
         />
       </div>

--- a/gui/app/src/components/workbench/workbench.tsx
+++ b/gui/app/src/components/workbench/workbench.tsx
@@ -51,7 +51,8 @@ import {
 } from "@/components/workbench/import-drawer";
 // [OPUS-4.8] sq-tp1m (#757) — keeps the engine's inference regime in lockstep with the active
 // workspace's persisted choice (restores it on load), mounted once regardless of the active tab.
-import { InferenceModeBridge } from "@/components/workbench/inference-control";
+// [sq-glo5r] — N3RulesBridge keeps the engine's N3 rules cache in lockstep with the workspace.
+import { InferenceModeBridge, N3RulesBridge } from "@/components/workbench/inference-control";
 // [OPUS-4.8] sq-xvj9 — the Cmd-K counterpart to the rail's "Export data…": serialise + download the
 // whole store as pretty Turtle / TriG / JSON-LD from the keyboard-first spine.
 import { downloadText } from "@/lib/download";
@@ -116,6 +117,8 @@ export function Workbench() {
         />
         {/* [OPUS-4.8] sq-tp1m — sync the persisted per-workspace inference regime into the engine. */}
         <InferenceModeBridge />
+        {/* [sq-glo5r] — sync the per-workspace N3 rules into the engine's closure cache. */}
+        <N3RulesBridge />
         {/* (sq-eydh9) [SONNET-4.6] — global RDF file drop overlay, mounted once here. */}
         <GlobalDropOverlay />
         {/* [OPUS-4.8] sq-vw3ax (#820 redesign) — a native-feeling dark workspace. The ambient teal

--- a/gui/app/src/css-modules.d.ts
+++ b/gui/app/src/css-modules.d.ts
@@ -1,0 +1,6 @@
+// Worktree environment stub: allows side-effect CSS imports without node_modules/next.
+// This file is generated for the worktree environment only and is gitignored.
+declare module '*.css' {
+  const content: { [className: string]: string };
+  export default content;
+}

--- a/gui/app/src/lib/engine-context.tsx
+++ b/gui/app/src/lib/engine-context.tsx
@@ -25,6 +25,7 @@ import {
   type WasmStore,
   type WasmStoreCtor,
   type WorkspaceInferenceMode,
+  type WorkspaceRulesDoc,
 } from "@sparq/client";
 
 import { basePath } from "@/lib/base-path";
@@ -321,6 +322,14 @@ export interface EngineContextValue {
    */
   setInferenceMode: (mode: WorkspaceInferenceMode) => void;
   /**
+   * [sq-glo5r] Push the active workspace's N3 rules docs to the engine so the N3 closure is
+   * rebuilt when rules change. Called by `N3RulesBridge` (on workspace rule mutations) and
+   * directly by workspace lifecycle actions (workspace switch, initial restore) as belt-and-
+   * suspenders in lockstep with `setInferenceMode`. A no-op when inference is not `"n3"` — the
+   * rules are cached by content hash so a no-change push is free.
+   */
+  setN3Rules: (docs: WorkspaceRulesDoc[]) => void;
+  /**
    * [OPUS-4.8] sq-ixc3.13 — the whole-dataset N-QUADS snapshot of the live store (default graph +
    * every named graph), the save/open cache a workspace persists as its `dataSnapshot` (sq-atb0).
    * N-Quads (not the TriG `serializeStore` emits) because that is the workspace snapshot format,
@@ -425,6 +434,41 @@ function storeToNQuads(store: WasmStore): string {
     const g = b["g"];
     const tail = g ? ` ${termToNT(g)}` : "";
     lines.push(`${termToNT(s)} ${termToNT(p)} ${termToNT(o)}${tail} .`);
+  }
+  return lines.join("\n");
+}
+
+/** [sq-glo5r] FNV-1a hash for a string — non-crypto, fast; used for the N3 rules cache key. */
+function fnv1aHash(s: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return h;
+}
+
+// [sq-glo5r] — SELECT DISTINCT to fold named graphs into the default graph and deduplicate
+// s/p/o. Used as the base data input for N3 rule reasoning (N3 does not accept N-Quads; named
+// graphs are folded exactly as the RDFS/OWL-RL reasoner folds them).
+const ALL_TRIPLES_QUERY =
+  "SELECT DISTINCT ?s ?p ?o WHERE { { ?s ?p ?o } UNION { GRAPH ?g { ?s ?p ?o } } }";
+
+/**
+ * [sq-glo5r] Serialise the whole dataset as N-TRIPLES, folding named graphs into the default
+ * graph and deduplicating s/p/o (via DISTINCT). Returns `""` for an empty store. Used as the
+ * base for N3 rule reasoning — N3 is a superset of Turtle which accepts full-IRI N-Triple lines.
+ */
+function storeToNTriples(store: WasmStore): string {
+  const json = store.query(ALL_TRIPLES_QUERY);
+  const parsed = JSON.parse(json) as SparqlResults;
+  const lines: string[] = [];
+  for (const b of parsed.results?.bindings ?? []) {
+    const s = b["s"];
+    const p = b["p"];
+    const o = b["o"];
+    if (!s || !p || !o) continue;
+    lines.push(`${termToNT(s)} ${termToNT(p)} ${termToNT(o)} .`);
   }
   return lines.join("\n");
 }
@@ -560,6 +604,14 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
   // or the store epoch bumped mid-build) is stale and must NOT publish its status, or the UI could
   // land in the wrong state (e.g. mode Off but status Ready/Error). Only the latest generation writes.
   const inferenceGenRef = React.useRef(0);
+
+  // [sq-glo5r] — the active workspace's N3 rule documents (pushed by setN3Rules / N3RulesBridge).
+  // Held in a ref so buildReasonedStore always reads the latest docs without adding them to its
+  // useCallback deps; `rulesEpoch` bumps on every setN3Rules call to trigger the applyInferenceMode
+  // effect and rebuild the N3 closure when rules change while N3 is active.
+  const n3RulesRef = React.useRef<WorkspaceRulesDoc[]>([]);
+  const rulesEpochRef = React.useRef(0);
+  const [rulesEpoch, setRulesEpoch] = React.useState(0);
 
   // [OPUS-4.8] sq-lcd6e — a hydration request that arrived BEFORE the wasm ctor warmed (the
   // workspace-restore bridge can call hydrateFromSnapshot while the engine is still cold). It is
@@ -701,10 +753,10 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
   }, [refreshDiskUsage]);
 
   // [OPUS-4.8] sq-tp1m (#757) — build (or reuse) the reasoned CLOSURE store for `mode` over the
-  // current base store: serialise the whole dataset to N-Quads, forward-chain the RDFS / OWL 2 RL
-  // closure with the real W-reason bundle, and load the closure N-Triples into a fresh in-tab
-  // store queries can run against. Cached by `mode:epoch`, so every query while the mode + store
-  // are unchanged reuses the same closure (the materialisation cost is paid once per change).
+  // current base store. For RDFS / OWL-RL: serialise to N-Quads + materialize with the W-reason
+  // bundle. For N3 (sq-glo5r): fold named graphs to N-Triples, concatenate with enabled rules docs,
+  // call reasonN3 for derived ground triples, load base + derived as the closure. Cached by a
+  // `mode:epoch[:rulesHash]` key — the materialisation cost is paid once per change.
   // Throws if the bundle is unavailable or the closure fails — the caller surfaces that honestly.
   const buildReasonedStore = React.useCallback(
     async (mode: Exclude<WorkspaceInferenceMode, "off">): Promise<WasmStore> => {
@@ -713,6 +765,47 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       if (!Store || !base) {
         throw new Error("The engine is not ready yet — wait for the store to warm.");
       }
+
+      // [sq-glo5r] — N3 rules mode: base is folded to N-Triples (same as RDFS/OWL-RL folding),
+      // concatenated with enabled rules texts, then reasonN3 forward-chains the custom rules.
+      // The cache key includes a content hash of the enabled rules so a rules change invalidates
+      // the prior closure even if the store epoch is unchanged.
+      if (mode === "n3") {
+        const enabledRules = n3RulesRef.current.filter((d) => d.enabled !== false);
+        const rulesText = enabledRules.map((d) => d.text).join("\n");
+        const rulesHash = fnv1aHash(rulesText);
+        const key = `n3:${storeEpochRef.current}:${rulesHash}`;
+        if (reasonedKeyRef.current === key && reasonedStoreRef.current) {
+          return reasonedStoreRef.current;
+        }
+        const n3Inflight = reasonedBuildRef.current;
+        if (n3Inflight && n3Inflight.key === key) {
+          return n3Inflight.promise;
+        }
+        const n3Promise = (async () => {
+          const reasoner = await loadReasoner();
+          const baseNTriples = storeToNTriples(base);
+          // Combine rules (N3 Turtle) with base facts (N-Triple lines are valid N3/Turtle syntax).
+          const combined = rulesText + "\n" + baseNTriples;
+          // reasonN3 returns ONLY the newly entailed ground N-Triple lines (not the base triples).
+          const derived = reasoner.reasonN3(combined);
+          // Closure = base triples + derived (so queries over the closure see both).
+          const closure = baseNTriples + (derived.trim() ? "\n" + derived : "");
+          const reasoned = Store.load(closure || " ", "ntriples");
+          reasonedStoreRef.current = reasoned;
+          reasonedKeyRef.current = key;
+          return reasoned;
+        })();
+        reasonedBuildRef.current = { key, promise: n3Promise };
+        try {
+          return await n3Promise;
+        } finally {
+          if (reasonedBuildRef.current?.key === key) reasonedBuildRef.current = null;
+        }
+      }
+
+      // RDFS / OWL-RL: N-Quads snapshot → materialize → N-Triples closure.
+      // TypeScript narrows `mode` to `"rdfs" | "owl-rl"` here after the `=== "n3"` branch above.
       const key = `${mode}:${storeEpochRef.current}`;
       // Completed-closure cache hit: reuse the already-materialised store.
       if (reasonedKeyRef.current === key && reasonedStoreRef.current) {
@@ -770,9 +863,17 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
         setInferenceStatus({ kind: "loading" });
         return;
       }
-      const cachedKey = `${mode}:${storeEpochRef.current}`;
+      // Check if the closure for this mode + store epoch (+ rules hash for N3) is already built.
+      const cachedKeyPrefix =
+        mode === "n3"
+          ? `n3:${storeEpochRef.current}:`
+          : `${mode}:${storeEpochRef.current}`;
       const alreadyBuilt =
-        reasonedKeyRef.current === cachedKey && reasonedStoreRef.current !== null;
+        reasonedKeyRef.current !== null &&
+        reasonedStoreRef.current !== null &&
+        (mode === "n3"
+          ? reasonedKeyRef.current.startsWith(cachedKeyPrefix)
+          : reasonedKeyRef.current === cachedKeyPrefix);
       if (!alreadyBuilt) setInferenceStatus({ kind: "loading" });
       try {
         const reasoned = await buildReasonedStore(mode);
@@ -804,11 +905,20 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
     setInferenceModeState(mode);
   }, []);
 
-  // [OPUS-4.8] sq-tp1m — whenever the mode OR the base store content changes, reconcile the
-  // closure + status. The SINGLE place reasoning is applied.
+  // [sq-glo5r] — push updated N3 rules to the engine; bumps rulesEpoch so the
+  // applyInferenceMode effect fires and rebuilds the N3 closure when rules change.
+  const setN3Rules = React.useCallback((docs: WorkspaceRulesDoc[]) => {
+    n3RulesRef.current = docs;
+    rulesEpochRef.current += 1;
+    setRulesEpoch(rulesEpochRef.current);
+  }, []);
+
+  // [OPUS-4.8] sq-tp1m — whenever the mode OR the base store content OR the N3 rules change,
+  // reconcile the closure + status. The SINGLE place reasoning is applied. `rulesEpoch` is in
+  // deps so a rules change (via setN3Rules) re-fires this effect when N3 is active.
   React.useEffect(() => {
     void applyInferenceMode(inferenceMode);
-  }, [inferenceMode, storeEpoch, applyInferenceMode]);
+  }, [inferenceMode, storeEpoch, rulesEpoch, applyInferenceMode]);
 
   // [OPUS-4.8] sq-ixc3.13 — the Import drawer's ingest. A `file` import (a disk path) goes
   // through the NATIVE loader IPC (`load_path`: compressed + native-only HDT, no wasm-tab
@@ -1120,6 +1230,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       inferenceMode,
       inferenceStatus,
       setInferenceMode,
+      setN3Rules,
     }),
     [
       status,
@@ -1141,6 +1252,7 @@ export function EngineProvider({ children }: { children: React.ReactNode }) {
       inferenceMode,
       inferenceStatus,
       setInferenceMode,
+      setN3Rules,
     ],
   );
 

--- a/gui/app/src/lib/reason-wasm.ts
+++ b/gui/app/src/lib/reason-wasm.ts
@@ -71,12 +71,12 @@ export async function loadReasoner(): Promise<WasmReasoner> {
 // ---------------------------------------------------------------------------
 
 /**
- * The reasoner PROFILE string a non-"off" {@link WorkspaceInferenceMode} maps to. The mode
- * strings deliberately equal the reasoner's own profile names (`"rdfs"` / `"owl-rl"`), so this
- * is the identity for the active modes — but keeping it explicit documents the contract and
- * gives one place to change if the two ever diverge.
+ * The reasoner PROFILE string for RDFS / OWL 2 RL modes. Narrowed to `"rdfs" | "owl-rl"` —
+ * N3 mode calls `reasoner.reasonN3(...)` directly and never maps through this function. The
+ * mode strings equal the reasoner's own profile names, so this is the identity — but keeping
+ * it explicit documents the contract and gives one place to change if the two ever diverge.
  */
-export function modeToProfile(mode: Exclude<WorkspaceInferenceMode, "off">): string {
+export function modeToProfile(mode: "rdfs" | "owl-rl"): string {
   return mode;
 }
 
@@ -101,5 +101,11 @@ export const INFERENCE_MODE_META: Record<
     short: "OWL RL",
     blurb:
       "OWL 2 RL entailment (a superset of RDFS): also inverse/symmetric/transitive properties, sameAs, and more.",
+  },
+  n3: {
+    label: "N3 Rules",
+    short: "N3",
+    blurb:
+      "N3 rule reasoning: forward-chain custom { antecedent } => { consequent } rules over the live store. Attach rules in the Inference tool. Derived ground triples only.",
   },
 };

--- a/gui/app/src/lib/workspace-context.tsx
+++ b/gui/app/src/lib/workspace-context.tsx
@@ -26,6 +26,7 @@ import {
   type Workspace,
   type WorkspaceBackend,
   type WorkspaceInferenceMode,
+  type WorkspaceRulesDoc,
   type WorkspaceSourceMeta,
   type WorkspaceStore,
   type WorkspaceSummary,
@@ -96,6 +97,26 @@ export interface WorkspaceContextValue {
    * mirroring {@link recordImport}: a write failure never breaks the in-memory selection).
    */
   setInference: (mode: WorkspaceInferenceMode) => Promise<void>;
+  /**
+   * [sq-glo5r] The active workspace's persisted N3 rule documents (empty when none). Drives the
+   * Inference tool's N3 rules panel and the engine's N3 closure cache.
+   */
+  rulesDocs: WorkspaceRulesDoc[];
+  /**
+   * [sq-glo5r] Bulk-add N3 rule documents to the active workspace (each gets a unique `addedAt`
+   * timestamp; enabled by default). Persists + pushes to the engine immediately.
+   */
+  addRulesDocs: (docs: Array<{ name: string; text: string }>) => Promise<void>;
+  /**
+   * [sq-glo5r] Remove an N3 rule document by its `addedAt` timestamp (the stable unique key).
+   * Persists + pushes the updated list to the engine.
+   */
+  removeRulesDoc: (addedAt: number) => Promise<void>;
+  /**
+   * [sq-glo5r] Toggle the `enabled` state of an N3 rule document by `addedAt`. A disabled rule
+   * is excluded from the N3 closure (its cache-key hash changes, triggering a rebuild).
+   */
+  setRulesDocEnabled: (addedAt: number, enabled: boolean) => Promise<void>;
 }
 
 const WorkspaceContext = React.createContext<WorkspaceContextValue | null>(null);
@@ -235,6 +256,54 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     [applyWorkspace, persist],
   );
 
+  // [sq-glo5r] — bulk-add N3 rule documents; each gets a unique addedAt (now + index offset so
+  // rapid bulk adds never collide). Pushes the updated list to the engine immediately.
+  const addRulesDocs = React.useCallback(
+    async (docs: Array<{ name: string; text: string }>): Promise<void> => {
+      const base = workspaceRef.current ?? newWorkspace("default workspace", STARTER_QUERY);
+      const now = Date.now();
+      const newDocs: WorkspaceRulesDoc[] = docs.map((d, i) => ({
+        name: d.name,
+        text: d.text,
+        addedAt: now + i, // +i keeps addedAt unique within a single bulk add
+      }));
+      const nextDocs = [...(base.rulesDocs ?? []), ...newDocs];
+      const next: Workspace = { ...base, rulesDocs: nextDocs, updatedAt: Date.now() };
+      applyWorkspace(next);
+      engineRef.current.setN3Rules(nextDocs);
+      persist(next);
+    },
+    [applyWorkspace, persist],
+  );
+
+  // [sq-glo5r] — remove an N3 rule document by addedAt (the stable unique key).
+  const removeRulesDoc = React.useCallback(
+    async (addedAt: number): Promise<void> => {
+      const base = workspaceRef.current ?? newWorkspace("default workspace", STARTER_QUERY);
+      const nextDocs = (base.rulesDocs ?? []).filter((d) => d.addedAt !== addedAt);
+      const next: Workspace = { ...base, rulesDocs: nextDocs, updatedAt: Date.now() };
+      applyWorkspace(next);
+      engineRef.current.setN3Rules(nextDocs);
+      persist(next);
+    },
+    [applyWorkspace, persist],
+  );
+
+  // [sq-glo5r] — toggle the enabled state of an N3 rule document by addedAt.
+  const setRulesDocEnabled = React.useCallback(
+    async (addedAt: number, enabled: boolean): Promise<void> => {
+      const base = workspaceRef.current ?? newWorkspace("default workspace", STARTER_QUERY);
+      const nextDocs = (base.rulesDocs ?? []).map((d) =>
+        d.addedAt === addedAt ? { ...d, enabled } : d,
+      );
+      const next: Workspace = { ...base, rulesDocs: nextDocs, updatedAt: Date.now() };
+      applyWorkspace(next);
+      engineRef.current.setN3Rules(nextDocs);
+      persist(next);
+    },
+    [applyWorkspace, persist],
+  );
+
   const createWorkspace = React.useCallback(
     async (name: string): Promise<Workspace> => {
       // 1. SAVE the current workspace's live snapshot first — no data loss on leaving it.
@@ -288,15 +357,18 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     [applyWorkspace, persist, refreshList],
   );
 
-  // Load `id` and make it active: hydrate the engine from its snapshot + re-apply its inference.
+  // Load `id` and make it active: hydrate the engine from its snapshot + re-apply its inference
+  // regime and N3 rules (belt-and-suspenders alongside the bridges — ensures lockstep even before
+  // the bridge effects fire).
   const activate = React.useCallback((ws: Workspace) => {
     applyWorkspace(ws);
     engineRef.current.hydrateFromSnapshot(ws.dataSnapshot ?? null, {
       seedSampleWhenEmpty: false,
     });
-    // Re-apply the target's inference regime (the InferenceModeBridge also reacts to the state
-    // change; setting it here keeps the engine in lockstep even before that effect runs).
+    // Re-apply the target's inference regime.
     engineRef.current.setInferenceMode(ws.inference ?? "off");
+    // [sq-glo5r] — push the target workspace's N3 rules so the engine rebuilds the N3 closure.
+    engineRef.current.setN3Rules(ws.rulesDocs ?? []);
   }, [applyWorkspace]);
 
   const switchWorkspace = React.useCallback(
@@ -398,6 +470,10 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       switchWorkspace,
       inference: workspace?.inference ?? "off",
       setInference,
+      rulesDocs: workspace?.rulesDocs ?? [],
+      addRulesDocs,
+      removeRulesDoc,
+      setRulesDocEnabled,
     }),
     [
       workspace,
@@ -410,6 +486,9 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       deleteWorkspace,
       switchWorkspace,
       setInference,
+      addRulesDocs,
+      removeRulesDoc,
+      setRulesDocEnabled,
     ],
   );
 

--- a/gui/e2e-playwright/specs/n3-inference.web.spec.ts
+++ b/gui/e2e-playwright/specs/n3-inference.web.spec.ts
@@ -1,0 +1,267 @@
+// [SONNET-4.6] sq-glo5r — N3 inference journey (browser / web persona):
+//   (a) Load data + N3 rule → derived triple appears in ASK query results when reasoner is ready.
+//   (b) BULK upload: setInputFiles on the hidden data-n3-dropzone input → both rules appear.
+//   (c) Toggle a rule off → inference re-settles; derived triple gone (or status off/error).
+//   (d) Rules persist: workspace localStorage entry has rulesDocs array after adding a rule.
+//
+// Uses the chromium-web project (webTest fixture): no Tauri globals, pure browser code path.
+// The W-reason WASM bundle may or may not be present in the test build.  Where status reaches
+// "error" (bundle absent) the test still validates the UI state is honest — it never asserts
+// a vacuous "passed because inference was off".
+//
+// Stable selectors (sq-glo5r data-* contract):
+//   [data-inference-mode="n3"]       — the N3 mode button
+//   [data-n3-rules]                  — the N3 rules panel (visible when inference==="n3")
+//   [data-n3-rule-row]               — one rule row (keyed by addedAt)
+//   [data-n3-rule-toggle]            — enable/disable checkbox inside a rule row
+//   [data-n3-rule-remove]            — remove button inside a rule row
+//   [data-n3-author-textarea]        — wrapper div for the inline N3 editor
+//   [data-n3-author-name]            — the rule-name input
+//   [data-n3-add-rule]               — the "Add rule" button
+//   [data-n3-dropzone]               — wrapper div + the hidden file input for Playwright
+//   [data-inference-status]          — live status pill (loading / ready / error)
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only.
+
+import { webTest as test, webExpect as expect } from "../support/index.ts";
+
+// ---------------------------------------------------------------------------
+// Helper: set a React-controlled textarea value via the native setter + input event.
+// WorkbenchTurtleEditor uses a controlled <textarea> — direct `.fill()` may not trigger
+// React's onChange reliably on all versions, so we use the native prototype setter approach.
+// ---------------------------------------------------------------------------
+async function fillReactTextarea(
+  page: import("@playwright/test").Page,
+  selector: string,
+  value: string,
+): Promise<void> {
+  await page.evaluate(
+    ([sel, text]) => {
+      const el = document.querySelector<HTMLTextAreaElement>(sel);
+      if (!el) throw new Error(`Textarea not found: ${sel}`);
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value",
+      )?.set;
+      if (!setter) throw new Error("Could not get native value setter");
+      setter.call(el, text);
+      el.dispatchEvent(new Event("input", { bubbles: true }));
+    },
+    [selector, value] as [string, string],
+  );
+}
+
+test.describe("n3-inference", () => {
+  // The webPersona auto-fixture navigates to "/" and waits for engine ready before each test.
+
+  test("(a) load data + N3 rule → derived triple in ASK when ready", async ({ page }) => {
+    // 1. Import base data via the Import drawer (paste mode): ex:x a ex:A
+    await page.locator('[data-import-trigger="rail"]').click();
+    const drawer = page.locator("[data-import-drawer]");
+    await expect(drawer).toBeVisible();
+
+    // Switch to Paste tab (the browser persona opens on Paste by default).
+    await drawer.locator('[data-import-tab="paste"]').click();
+    // Fill the paste editor and import (replace mode).
+    const pasteInput = drawer.locator("textarea").first();
+    await pasteInput.fill("@prefix ex: <http://example.org/> . ex:x a ex:A .");
+
+    // Click the Import / replace button.
+    const importBtn = drawer.getByRole("button", { name: /Import/ }).first();
+    await importBtn.click();
+
+    // Close the drawer.
+    await page.getByRole("button", { name: "Close import drawer" }).click();
+    await expect(drawer).not.toBeVisible();
+
+    // 2. Open the Inference tab from the left rail (tool button).
+    // The left rail renders tool buttons; click the one labelled "Inference".
+    await page.getByRole("button", { name: "Inference" }).click();
+    // The N3 mode button should now be visible (from WORKSPACE_INFERENCE_MODES auto-map).
+    const n3Btn = page.locator('[data-inference-mode="n3"]');
+    await expect(n3Btn).toBeVisible();
+
+    // 3. Select N3 mode.
+    await n3Btn.click();
+    await expect(n3Btn).toHaveAttribute("aria-pressed", "true");
+
+    // The N3 rules panel should appear.
+    await expect(page.locator("[data-n3-rules]")).toBeVisible();
+
+    // 4. Author a rule in the inline pane: expand the collapsible.
+    await page.getByRole("button", { name: /Author a rule/i }).click();
+
+    // Fill the rule name.
+    await page.locator("[data-n3-author-name]").fill("test-rule");
+
+    // Fill the N3 rule text via native setter (React-controlled textarea).
+    await fillReactTextarea(
+      page,
+      "#n3-author-textarea",
+      "@prefix ex: <http://example.org/> . { ?s a ex:A } => { ?s a ex:B . }",
+    );
+
+    // Click "Add rule".
+    await page.locator("[data-n3-add-rule]").click();
+
+    // The rule row should appear in the list.
+    await expect(page.locator("[data-n3-rule-row]").first()).toBeVisible();
+
+    // 5. Wait for inference to settle (ready or error — both are valid depending on the build).
+    const statusEl = page.locator(
+      '[data-inference-status="ready"], [data-inference-status="error"]',
+    );
+    await expect(statusEl).toBeVisible({ timeout: 60_000 });
+
+    // 6. If reasoner is ready, run an ASK query to verify the derived triple.
+    const isReady = await page.locator('[data-inference-status="ready"]').isVisible();
+    if (isReady) {
+      // Navigate to Query tab.
+      await page.getByRole("button", { name: "Query" }).click();
+
+      // Set the editor value via native setter + input event.
+      await page.evaluate(() => {
+        const el = document.querySelector<HTMLTextAreaElement>("#repl-query");
+        if (!el) throw new Error("Editor not found");
+        const setter = Object.getOwnPropertyDescriptor(
+          window.HTMLTextAreaElement.prototype,
+          "value",
+        )?.set;
+        setter?.call(
+          el,
+          "PREFIX ex: <http://example.org/> ASK { ex:x a ex:B }",
+        );
+        el.dispatchEvent(new Event("input", { bubbles: true }));
+      });
+
+      await page.getByRole("button", { name: "Run query" }).click();
+
+      // Wait for an ASK result.
+      await expect(page.locator('[data-result-kind="ask"]')).toBeVisible({ timeout: 30_000 });
+      // The derived triple ex:x a ex:B should be present → ASK = true.
+      await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+    } else {
+      // Honest-unavailable: status is "error" — confirm the error UI is visible.
+      await expect(page.locator('[data-inference-status="error"]')).toBeVisible();
+    }
+  });
+
+  test("(b) bulk upload: two .n3 files via hidden input → both rules appear", async ({ page }) => {
+    // Open Inference tab.
+    await page.getByRole("button", { name: "Inference" }).click();
+
+    // Select N3 mode.
+    await page.locator('[data-inference-mode="n3"]').click();
+    await expect(page.locator("[data-n3-rules]")).toBeVisible();
+
+    // Use setInputFiles on the hidden file input inside the dropzone wrapper.
+    const dropzoneInput = page.locator("[data-n3-dropzone] input[type=file]");
+    await expect(dropzoneInput).toBeAttached();
+
+    await dropzoneInput.setInputFiles([
+      {
+        name: "rule-a.n3",
+        mimeType: "text/plain",
+        buffer: Buffer.from("@prefix ex: <http://example.org/> . { ?s a ex:A } => { ?s a ex:B . }"),
+      },
+      {
+        name: "rule-b.n3",
+        mimeType: "text/plain",
+        buffer: Buffer.from("@prefix ex: <http://example.org/> . { ?s a ex:C } => { ?s a ex:D . }"),
+      },
+    ]);
+
+    // Both rule rows should appear in the list.
+    await expect(page.locator("[data-n3-rule-row]")).toHaveCount(2, { timeout: 5_000 });
+  });
+
+  test("(c) toggle a rule off → closure rebuilds (derived triple absent or status non-ready)", async ({
+    page,
+  }) => {
+    // Open Inference, select N3, add one rule.
+    await page.getByRole("button", { name: "Inference" }).click();
+    await page.locator('[data-inference-mode="n3"]').click();
+    await expect(page.locator("[data-n3-rules]")).toBeVisible();
+
+    // Author a rule.
+    await page.getByRole("button", { name: /Author a rule/i }).click();
+    await page.locator("[data-n3-author-name]").fill("toggle-test");
+    await fillReactTextarea(
+      page,
+      "#n3-author-textarea",
+      "@prefix ex: <http://example.org/> . { ?s a ex:A } => { ?s a ex:B . }",
+    );
+    await page.locator("[data-n3-add-rule]").click();
+    await expect(page.locator("[data-n3-rule-row]").first()).toBeVisible();
+
+    // Wait for the status to settle.
+    await expect(
+      page.locator('[data-inference-status="ready"], [data-inference-status="error"]'),
+    ).toBeVisible({ timeout: 60_000 });
+
+    // Toggle the rule off (uncheck).
+    const toggle = page.locator("[data-n3-rule-toggle]").first();
+    await expect(toggle).toBeChecked();
+    await toggle.uncheck();
+
+    // Status must transition back to loading then settle.
+    await expect(
+      page.locator(
+        '[data-inference-status="loading"], [data-inference-status="ready"], [data-inference-status="error"]',
+      ),
+    ).toBeVisible({ timeout: 5_000 });
+    // Settle again.
+    await expect(
+      page.locator('[data-inference-status="ready"], [data-inference-status="error"]'),
+    ).toBeVisible({ timeout: 60_000 });
+
+    // The toggle must now be unchecked in the UI.
+    await expect(toggle).not.toBeChecked();
+  });
+
+  test("(d) rules persist: localStorage contains rulesDocs after adding a rule", async ({
+    page,
+  }) => {
+    // Open Inference, select N3, author a rule.
+    await page.getByRole("button", { name: "Inference" }).click();
+    await page.locator('[data-inference-mode="n3"]').click();
+    await expect(page.locator("[data-n3-rules]")).toBeVisible();
+
+    await page.getByRole("button", { name: /Author a rule/i }).click();
+    await page.locator("[data-n3-author-name]").fill("persist-test");
+    await fillReactTextarea(
+      page,
+      "#n3-author-textarea",
+      "@prefix ex: <http://example.org/> . { ?s a ex:X } => { ?s a ex:Y . }",
+    );
+    await page.locator("[data-n3-add-rule]").click();
+
+    // Rule row must be visible before checking persistence.
+    await expect(page.locator("[data-n3-rule-row]").first()).toBeVisible();
+
+    // Poll localStorage: workspace record must have a non-empty rulesDocs array.
+    await expect
+      .poll(
+        () =>
+          page.evaluate(() => {
+            const prefix = "sparq.workspace.v1.";
+            for (let i = 0; i < localStorage.length; i++) {
+              const k = localStorage.key(i);
+              if (!k?.startsWith(prefix)) continue;
+              if (k.endsWith("__index__") || k.endsWith("__last__")) continue;
+              try {
+                const ws = JSON.parse(localStorage.getItem(k) ?? "{}") as {
+                  rulesDocs?: unknown[];
+                };
+                if (Array.isArray(ws.rulesDocs) && ws.rulesDocs.length > 0) return true;
+              } catch {
+                continue;
+              }
+            }
+            return false;
+          }),
+        { timeout: 5_000 },
+      )
+      .toBe(true);
+  });
+});

--- a/gui/e2e-playwright/specs/n3-inference.web.spec.ts
+++ b/gui/e2e-playwright/specs/n3-inference.web.spec.ts
@@ -1,40 +1,65 @@
 // [SONNET-4.6] sq-glo5r — N3 inference journey (browser / web persona):
-//   (a) Load data + N3 rule → derived triple appears in ASK query results when reasoner is ready.
-//   (b) BULK upload: setInputFiles on the hidden data-n3-dropzone input → both rules appear.
-//   (c) Toggle a rule off → inference re-settles; derived triple gone (or status off/error).
-//   (d) Rules persist: workspace localStorage entry has rulesDocs array after adding a rule.
+//   (a) Load data + an N3 rule → the SPECIFIC derived triple (ex:x a ex:B) answers an ASK true.
+//   (b) BULK upload: setInputFiles with two .n3 files in one action → both listed, each with a
+//       per-source enable toggle.
+//   (c) Toggling a rule off removes its derivations after re-materialisation (ASK flips false).
+//   (d) Rules persist per workspace: the localStorage record carries rulesDocs, and a full page
+//       reload restores the rule list + the N3 regime.
 //
-// Uses the chromium-web project (webTest fixture): no Tauri globals, pure browser code path.
-// The W-reason WASM bundle may or may not be present in the test build.  Where status reaches
-// "error" (bundle absent) the test still validates the UI state is honest — it never asserts
-// a vacuous "passed because inference was off".
+// NON-VACUOUS by design: the gating Playwright lane (gui.yml) BUILDS the W-reason bundle
+// (npm run build:reason-wasm) before exporting the app, so `reasonN3` is present and these
+// tests REQUIRE the reasoner to reach "ready" and the derived triple to appear. A missing
+// bundle fails this spec loudly — that is a build/sync regression, not a tolerated state.
+// (The app itself still degrades honestly at runtime: a missing bundle hard-fails queries
+// with a clear message while N3 is on — that error UI is product behaviour, but this spec
+// never accepts it as a pass.)
+//
+// Runs under the chromium-web project (support/web-fixtures.ts): no Tauri globals, pure
+// browser code path — the deployed /app persona.
 //
 // Stable selectors (sq-glo5r data-* contract):
-//   [data-inference-mode="n3"]       — the N3 mode button
-//   [data-n3-rules]                  — the N3 rules panel (visible when inference==="n3")
+//   [data-tool="inference"] / [data-tool="query"] — left-rail tool nav buttons
+//   [data-inference-mode="n3"]       — the N3 mode button (in InferenceControl; see scoping note)
+//   [data-n3-rules]                  — the N3 rules panel (visible when inference === "n3")
 //   [data-n3-rule-row]               — one rule row (keyed by addedAt)
 //   [data-n3-rule-toggle]            — enable/disable checkbox inside a rule row
 //   [data-n3-rule-remove]            — remove button inside a rule row
-//   [data-n3-author-textarea]        — wrapper div for the inline N3 editor
 //   [data-n3-author-name]            — the rule-name input
+//   #n3-author-textarea              — the inline N3 editor textarea
 //   [data-n3-add-rule]               — the "Add rule" button
-//   [data-n3-dropzone]               — wrapper div + the hidden file input for Playwright
+//   [data-n3-file-input]             — stable hidden <input type="file"> for bulk upload
 //   [data-inference-status]          — live status pill (loading / ready / error)
 //
-// Determinism rules: NO waitForTimeout; web-first assertions only.
+// SCOPING NOTE: InferenceControl is rendered in BOTH the query-toolbar (QueryWorkbench) and the
+// inference tool panel (InferenceTool).  Once the Inference tab is opened, both are in the DOM
+// simultaneously (the inactive tab is hidden via the HTML `hidden` attribute, not unmounted).
+// Playwright strict mode counts ALL matching elements regardless of visibility, so an unscoped
+// `[data-inference-mode="n3"]` resolves to 2 elements → strict-mode violation.
+// Fix: scope those selectors through the inference tab panel: `[data-tab="inference"]`.
+// Selectors that live ONLY in InferenceTool (data-n3-rules, data-n3-rule-row, etc.) are safe
+// without scoping.
+//
+// Determinism notes: NO waitForTimeout; web-first assertions only. The workspace mutators
+// (addRulesDocs / setRulesDocEnabled) push the rules into the engine SYNCHRONOUSLY inside the
+// click handler (engineRef.current.setN3Rules), and run() re-derives the closure cache key from
+// the live rules on every query — so an ASK issued after a toggle deterministically sees the
+// post-toggle closure with no sleep.
 
-import { webTest as test, webExpect as expect } from "../support/index.ts";
+import { webTest as test, webExpect as expect, waitForEngineReady } from "../support/index.ts";
+
+type Page = import("@playwright/test").Page;
+type Locator = import("@playwright/test").Locator;
+
+const RULE_A_TO_B = "@prefix ex: <http://example.org/> . { ?s a ex:A } => { ?s a ex:B . }";
+const DATA_X_A = "@prefix ex: <http://example.org/> . ex:x a ex:A .";
+const ASK_DERIVED = "PREFIX ex: <http://example.org/> ASK { ex:x a ex:B }";
 
 // ---------------------------------------------------------------------------
-// Helper: set a React-controlled textarea value via the native setter + input event.
-// WorkbenchTurtleEditor uses a controlled <textarea> — direct `.fill()` may not trigger
-// React's onChange reliably on all versions, so we use the native prototype setter approach.
+// Helpers.
 // ---------------------------------------------------------------------------
-async function fillReactTextarea(
-  page: import("@playwright/test").Page,
-  selector: string,
-  value: string,
-): Promise<void> {
+
+/** Set a React-controlled textarea via the native setter + input event. */
+async function fillReactTextarea(page: Page, selector: string, value: string): Promise<void> {
   await page.evaluate(
     ([sel, text]) => {
       const el = document.querySelector<HTMLTextAreaElement>(sel);
@@ -51,195 +76,163 @@ async function fillReactTextarea(
   );
 }
 
+/** Paste-import a Turtle document in REPLACE mode and wait for the ok feedback. */
+async function importPasteReplace(page: Page, turtle: string): Promise<void> {
+  await page.locator('[data-import-trigger="rail"]').click();
+  const drawer = page.locator("[data-import-drawer]");
+  await expect(drawer).toBeVisible();
+  await drawer.locator('[data-import-tab="paste"]').click();
+  await drawer.locator("textarea").first().fill(turtle);
+  await drawer.getByRole("button", { name: "Replace store" }).click();
+  await drawer.getByRole("button", { name: /Import \(replace store\)/ }).click();
+  await expect(drawer.locator('[data-import-feedback="ok"]')).toBeVisible();
+  await page.keyboard.press("Escape");
+  await expect(drawer).toBeHidden();
+}
+
+/**
+ * Open the Inference tool and switch the workspace to the N3 regime.
+ *
+ * Returns the inference tab-panel locator (`[data-tab="inference"]`) so callers can scope
+ * follow-up `[data-inference-mode]` / `[data-inference-status]` queries through it and avoid
+ * the strict-mode collision with the query-toolbar's InferenceControl (see SCOPING NOTE above).
+ */
+async function selectN3(page: Page): Promise<Locator> {
+  await page.locator('[data-tool="inference"]').click();
+  // Scope to the inference tab panel — avoids the query-toolbar's InferenceControl duplicate.
+  const panel = page.locator('[data-tab="inference"]');
+  const n3Btn = panel.locator('[data-inference-mode="n3"]');
+  await expect(n3Btn).toBeVisible();
+  await n3Btn.click();
+  await expect(n3Btn).toHaveAttribute("aria-pressed", "true");
+  await expect(page.locator("[data-n3-rules]")).toBeVisible();
+  return panel;
+}
+
+/** Author an inline rule in the N3 rules panel; waits for its row to appear. */
+async function authorRule(page: Page, name: string, text: string): Promise<void> {
+  const before = await page.locator("[data-n3-rule-row]").count();
+  await page.getByRole("button", { name: /Author a rule/i }).click();
+  await page.locator("[data-n3-author-name]").fill(name);
+  await fillReactTextarea(page, "#n3-author-textarea", text);
+  await page.locator("[data-n3-add-rule]").click();
+  await expect(page.locator("[data-n3-rule-row]")).toHaveCount(before + 1);
+}
+
+/** Run an ASK in the Query tool and assert its boolean rendering. */
+async function runAsk(page: Page, query: string, expected: "true" | "false"): Promise<void> {
+  await page.locator('[data-tool="query"]').click();
+  await fillReactTextarea(page, "#repl-query", query);
+  await page.getByRole("button", { name: "Run query" }).click();
+  const result = page.locator('[data-result-kind="ask"]');
+  await expect(result).toBeVisible({ timeout: 60_000 });
+  await expect(result).toContainText(expected);
+}
+
 test.describe("n3-inference", () => {
   // The webPersona auto-fixture navigates to "/" and waits for engine ready before each test.
 
-  test("(a) load data + N3 rule → derived triple in ASK when ready", async ({ page }) => {
-    // 1. Import base data via the Import drawer (paste mode): ex:x a ex:A
-    await page.locator('[data-import-trigger="rail"]').click();
-    const drawer = page.locator("[data-import-drawer]");
-    await expect(drawer).toBeVisible();
+  test("(a) data + an N3 rule derives a specific triple visible to queries", async ({ page }) => {
+    // 1. Replace the store with exactly one asserted triple: ex:x a ex:A.
+    await importPasteReplace(page, DATA_X_A);
 
-    // Switch to Paste tab (the browser persona opens on Paste by default).
-    await drawer.locator('[data-import-tab="paste"]').click();
-    // Fill the paste editor and import (replace mode).
-    const pasteInput = drawer.locator("textarea").first();
-    await pasteInput.fill("@prefix ex: <http://example.org/> . ex:x a ex:A .");
+    // 2. Switch to the N3 regime and attach the {A}=>{B} rule.
+    const panel = await selectN3(page);
+    await authorRule(page, "test-rule", RULE_A_TO_B);
 
-    // Click the Import / replace button.
-    const importBtn = drawer.getByRole("button", { name: /Import/ }).first();
-    await importBtn.click();
+    // 3. The reasoner must reach READY (the Playwright lane always ships the W-reason bundle;
+    //    "error" here is a real regression, never a tolerated alternative).
+    //    Scope through `panel` to avoid the query-toolbar's duplicate InferenceStatusPill.
+    await expect(panel.locator('[data-inference-status="ready"]')).toBeVisible({
+      timeout: 60_000,
+    });
 
-    // Close the drawer.
-    await page.getByRole("button", { name: "Close import drawer" }).click();
-    await expect(drawer).not.toBeVisible();
+    // 4. The SPECIFIC derived triple: ex:x a ex:B was never asserted — only the rule can put it
+    //    in query results. This is the non-vacuous core assertion of sq-glo5r.
+    await runAsk(page, ASK_DERIVED, "true");
 
-    // 2. Open the Inference tab from the left rail (tool button).
-    // The left rail renders tool buttons; click the one labelled "Inference".
-    await page.getByRole("button", { name: "Inference" }).click();
-    // The N3 mode button should now be visible (from WORKSPACE_INFERENCE_MODES auto-map).
-    const n3Btn = page.locator('[data-inference-mode="n3"]');
-    await expect(n3Btn).toBeVisible();
-
-    // 3. Select N3 mode.
-    await n3Btn.click();
-    await expect(n3Btn).toHaveAttribute("aria-pressed", "true");
-
-    // The N3 rules panel should appear.
-    await expect(page.locator("[data-n3-rules]")).toBeVisible();
-
-    // 4. Author a rule in the inline pane: expand the collapsible.
-    await page.getByRole("button", { name: /Author a rule/i }).click();
-
-    // Fill the rule name.
-    await page.locator("[data-n3-author-name]").fill("test-rule");
-
-    // Fill the N3 rule text via native setter (React-controlled textarea).
-    await fillReactTextarea(
-      page,
-      "#n3-author-textarea",
-      "@prefix ex: <http://example.org/> . { ?s a ex:A } => { ?s a ex:B . }",
-    );
-
-    // Click "Add rule".
-    await page.locator("[data-n3-add-rule]").click();
-
-    // The rule row should appear in the list.
-    await expect(page.locator("[data-n3-rule-row]").first()).toBeVisible();
-
-    // 5. Wait for inference to settle (ready or error — both are valid depending on the build).
-    const statusEl = page.locator(
-      '[data-inference-status="ready"], [data-inference-status="error"]',
-    );
-    await expect(statusEl).toBeVisible({ timeout: 60_000 });
-
-    // 6. If reasoner is ready, run an ASK query to verify the derived triple.
-    const isReady = await page.locator('[data-inference-status="ready"]').isVisible();
-    if (isReady) {
-      // Navigate to Query tab.
-      await page.getByRole("button", { name: "Query" }).click();
-
-      // Set the editor value via native setter + input event.
-      await page.evaluate(() => {
-        const el = document.querySelector<HTMLTextAreaElement>("#repl-query");
-        if (!el) throw new Error("Editor not found");
-        const setter = Object.getOwnPropertyDescriptor(
-          window.HTMLTextAreaElement.prototype,
-          "value",
-        )?.set;
-        setter?.call(
-          el,
-          "PREFIX ex: <http://example.org/> ASK { ex:x a ex:B }",
-        );
-        el.dispatchEvent(new Event("input", { bubbles: true }));
-      });
-
-      await page.getByRole("button", { name: "Run query" }).click();
-
-      // Wait for an ASK result.
-      await expect(page.locator('[data-result-kind="ask"]')).toBeVisible({ timeout: 30_000 });
-      // The derived triple ex:x a ex:B should be present → ASK = true.
-      await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
-    } else {
-      // Honest-unavailable: status is "error" — confirm the error UI is visible.
-      await expect(page.locator('[data-inference-status="error"]')).toBeVisible();
-    }
+    // 5. Fail-closed sanity: the derived triple is query-time only. Switching inference Off
+    //    returns exactly the asserted data (the derivation disappears).
+    //    Navigate back to inference, then scope the mode button through the panel.
+    await page.locator('[data-tool="inference"]').click();
+    await panel.locator('[data-inference-mode="off"]').click();
+    await runAsk(page, ASK_DERIVED, "false");
   });
 
-  test("(b) bulk upload: two .n3 files via hidden input → both rules appear", async ({ page }) => {
-    // Open Inference tab.
-    await page.getByRole("button", { name: "Inference" }).click();
+  test("(b) BULK upload: two .n3 files in one action, each listed with a toggle", async ({
+    page,
+  }) => {
+    await selectN3(page);
 
-    // Select N3 mode.
-    await page.locator('[data-inference-mode="n3"]').click();
-    await expect(page.locator("[data-n3-rules]")).toBeVisible();
-
-    // Use setInputFiles on the hidden file input inside the dropzone wrapper.
-    const dropzoneInput = page.locator("[data-n3-dropzone] input[type=file]");
-    await expect(dropzoneInput).toBeAttached();
-
-    await dropzoneInput.setInputFiles([
+    // One setInputFiles call = one user action carrying BOTH files (the bulk contract).
+    const input = page.locator("[data-n3-file-input]");
+    await expect(input).toBeAttached();
+    await input.setInputFiles([
       {
         name: "rule-a.n3",
         mimeType: "text/plain",
-        buffer: Buffer.from("@prefix ex: <http://example.org/> . { ?s a ex:A } => { ?s a ex:B . }"),
+        buffer: Buffer.from(RULE_A_TO_B),
       },
       {
         name: "rule-b.n3",
         mimeType: "text/plain",
-        buffer: Buffer.from("@prefix ex: <http://example.org/> . { ?s a ex:C } => { ?s a ex:D . }"),
+        buffer: Buffer.from(
+          "@prefix ex: <http://example.org/> . { ?s a ex:C } => { ?s a ex:D . }",
+        ),
       },
     ]);
 
-    // Both rule rows should appear in the list.
-    await expect(page.locator("[data-n3-rule-row]")).toHaveCount(2, { timeout: 5_000 });
+    // Both rules are listed, each row carrying its own per-source enable toggle.
+    const rows = page.locator("[data-n3-rule-row]");
+    await expect(rows).toHaveCount(2);
+    await expect(page.locator("[data-n3-rules]")).toContainText("rule-a.n3");
+    await expect(page.locator("[data-n3-rules]")).toContainText("rule-b.n3");
+    await expect(page.locator("[data-n3-rule-toggle]")).toHaveCount(2);
+    for (const i of [0, 1]) {
+      await expect(page.locator("[data-n3-rule-toggle]").nth(i)).toBeChecked();
+    }
   });
 
-  test("(c) toggle a rule off → closure rebuilds (derived triple absent or status non-ready)", async ({
+  test("(c) toggling a rule off removes its derivations after re-materialisation", async ({
     page,
   }) => {
-    // Open Inference, select N3, add one rule.
-    await page.getByRole("button", { name: "Inference" }).click();
-    await page.locator('[data-inference-mode="n3"]').click();
-    await expect(page.locator("[data-n3-rules]")).toBeVisible();
+    // Full chain first: data + rule + N3 → the derived triple answers true.
+    await importPasteReplace(page, DATA_X_A);
+    const panel = await selectN3(page);
+    await authorRule(page, "toggle-test", RULE_A_TO_B);
+    // Scope status check through the panel (avoids the toolbar's InferenceStatusPill duplicate).
+    await expect(panel.locator('[data-inference-status="ready"]')).toBeVisible({
+      timeout: 60_000,
+    });
+    await runAsk(page, ASK_DERIVED, "true");
 
-    // Author a rule.
-    await page.getByRole("button", { name: /Author a rule/i }).click();
-    await page.locator("[data-n3-author-name]").fill("toggle-test");
-    await fillReactTextarea(
-      page,
-      "#n3-author-textarea",
-      "@prefix ex: <http://example.org/> . { ?s a ex:A } => { ?s a ex:B . }",
-    );
-    await page.locator("[data-n3-add-rule]").click();
-    await expect(page.locator("[data-n3-rule-row]").first()).toBeVisible();
-
-    // Wait for the status to settle.
-    await expect(
-      page.locator('[data-inference-status="ready"], [data-inference-status="error"]'),
-    ).toBeVisible({ timeout: 60_000 });
-
-    // Toggle the rule off (uncheck).
+    // Toggle the rule OFF. setRulesDocEnabled pushes the new rules list into the engine
+    // synchronously, so the next query re-materialises without the rule.
+    await page.locator('[data-tool="inference"]').click();
     const toggle = page.locator("[data-n3-rule-toggle]").first();
     await expect(toggle).toBeChecked();
     await toggle.uncheck();
-
-    // Status must transition back to loading then settle.
-    await expect(
-      page.locator(
-        '[data-inference-status="loading"], [data-inference-status="ready"], [data-inference-status="error"]',
-      ),
-    ).toBeVisible({ timeout: 5_000 });
-    // Settle again.
-    await expect(
-      page.locator('[data-inference-status="ready"], [data-inference-status="error"]'),
-    ).toBeVisible({ timeout: 60_000 });
-
-    // The toggle must now be unchecked in the UI.
     await expect(toggle).not.toBeChecked();
+
+    // The derivation is GONE from query results after re-materialisation — while N3 stays ON
+    // and the base data is untouched.
+    await runAsk(page, ASK_DERIVED, "false");
+    await runAsk(page, "PREFIX ex: <http://example.org/> ASK { ex:x a ex:A }", "true");
+
+    // And the re-materialised closure reports zero entailed triples in the status pill.
+    await page.locator('[data-tool="inference"]').click();
+    // Scope through the panel to avoid the toolbar's InferenceStatusPill duplicate.
+    await expect(panel.locator('[data-inference-status="ready"]')).toContainText("+0 entailed", {
+      timeout: 60_000,
+    });
   });
 
-  test("(d) rules persist: localStorage contains rulesDocs after adding a rule", async ({
-    page,
-  }) => {
-    // Open Inference, select N3, author a rule.
-    await page.getByRole("button", { name: "Inference" }).click();
-    await page.locator('[data-inference-mode="n3"]').click();
-    await expect(page.locator("[data-n3-rules]")).toBeVisible();
+  test("(d) rules persist per workspace and survive a reload", async ({ page }) => {
+    await selectN3(page);
+    await authorRule(page, "persist-test", RULE_A_TO_B);
 
-    await page.getByRole("button", { name: /Author a rule/i }).click();
-    await page.locator("[data-n3-author-name]").fill("persist-test");
-    await fillReactTextarea(
-      page,
-      "#n3-author-textarea",
-      "@prefix ex: <http://example.org/> . { ?s a ex:X } => { ?s a ex:Y . }",
-    );
-    await page.locator("[data-n3-add-rule]").click();
-
-    // Rule row must be visible before checking persistence.
-    await expect(page.locator("[data-n3-rule-row]").first()).toBeVisible();
-
-    // Poll localStorage: workspace record must have a non-empty rulesDocs array.
+    // The workspace record in localStorage carries the rulesDocs array (deterministic flush:
+    // poll until the persisted record contains the rule — same pattern as workspace-restore).
     await expect
       .poll(
         () =>
@@ -251,11 +244,18 @@ test.describe("n3-inference", () => {
               if (k.endsWith("__index__") || k.endsWith("__last__")) continue;
               try {
                 const ws = JSON.parse(localStorage.getItem(k) ?? "{}") as {
-                  rulesDocs?: unknown[];
+                  inference?: string;
+                  rulesDocs?: Array<{ name?: string }>;
                 };
-                if (Array.isArray(ws.rulesDocs) && ws.rulesDocs.length > 0) return true;
+                if (
+                  ws.inference === "n3" &&
+                  Array.isArray(ws.rulesDocs) &&
+                  ws.rulesDocs.some((d) => d?.name === "persist-test")
+                ) {
+                  return true;
+                }
               } catch {
-                continue;
+                /* skip corrupt entries */
               }
             }
             return false;
@@ -263,5 +263,21 @@ test.describe("n3-inference", () => {
         { timeout: 5_000 },
       )
       .toBe(true);
+
+    // RELOAD — the restored workspace must come back in the N3 regime with the rule listed.
+    await page.reload();
+    await waitForEngineReady(page, { timeout: 90_000 });
+
+    // After reload only the Query tab is open; open Inference and get a fresh panel locator.
+    await page.locator('[data-tool="inference"]').click();
+    const panel = page.locator('[data-tab="inference"]');
+    // Scope through panel to avoid the toolbar's InferenceControl duplicate (SCOPING NOTE).
+    await expect(panel.locator('[data-inference-mode="n3"]')).toHaveAttribute(
+      "aria-pressed",
+      "true",
+    );
+    await expect(page.locator("[data-n3-rules]")).toBeVisible();
+    await expect(page.locator("[data-n3-rule-row]")).toHaveCount(1);
+    await expect(page.locator("[data-n3-rules]")).toContainText("persist-test");
   });
 });

--- a/packages/sparq-client/src/index.ts
+++ b/packages/sparq-client/src/index.ts
@@ -706,6 +706,8 @@ export {
   type WorkspaceEditorState,
   type WorkspaceRunMode,
   type WorkspaceInferenceMode,
+  // [sq-glo5r] — N3 per-workspace rule documents.
+  type WorkspaceRulesDoc,
   type WorkspaceBackend,
   type WorkspaceStore,
   type WorkspaceStoreOptions,

--- a/packages/sparq-client/src/workspace.ts
+++ b/packages/sparq-client/src/workspace.ts
@@ -71,21 +71,41 @@ export type WorkspaceRunMode = "run" | "explain" | "analyze";
  * includes RDFS) BEFORE the query runs, so an entailed triple can match. This is applied by the
  * engine's real forward-chaining reasoner (`sparq-reason`, via the tier-b W-reason wasm
  * bundle) — NOT a mock. It is a query-time regime: it never mutates the persisted store, only
- * what queries see. (N3 rule reasoning needs a rules-authoring surface + a store that can hold
- * rule/formula terms, which the in-tab ground-triple store cannot — tracked as a follow-up.)
+ * what queries see. `"n3"` applies per-workspace N3 rules ({@link WorkspaceRulesDoc}) via the
+ * same reasoner's `reasonN3` path — derived GROUND triples appear in query results; formula
+ * conclusions are dropped (sq-glo5r).
  */
-export type WorkspaceInferenceMode = "off" | "rdfs" | "owl-rl";
+export type WorkspaceInferenceMode = "off" | "rdfs" | "owl-rl" | "n3";
 
 /** The persisted inference modes, in selector order (the UI mirrors this). */
 export const WORKSPACE_INFERENCE_MODES: readonly WorkspaceInferenceMode[] = [
   "off",
   "rdfs",
   "owl-rl",
+  "n3",
 ] as const;
 
 /** Normalise an arbitrary value to a {@link WorkspaceInferenceMode}, defaulting to `"off"`. */
 export function parseInferenceMode(value: unknown): WorkspaceInferenceMode {
-  return value === "rdfs" || value === "owl-rl" ? value : "off";
+  return value === "rdfs" || value === "owl-rl" || value === "n3" ? value : "off";
+}
+
+/**
+ * [sq-glo5r] One N3 rule document attached to a workspace. Each document is an N3 Turtle file
+ * (prefix declarations + one or more `{ antecedent } => { consequent }` rules). Rules are
+ * applied at query time in `"n3"` inference mode — derived GROUND triples appear in query
+ * results; formula / quoted-graph conclusions are dropped and not visible in the triple store.
+ * `enabled` defaults to `true` when absent (backward-compatible).
+ */
+export interface WorkspaceRulesDoc {
+  /** Human-readable label for the rule document (e.g. a filename or authored name). */
+  name: string;
+  /** The N3 Turtle source text of the rule document. */
+  text: string;
+  /** Epoch milliseconds when the document was added (used as a stable unique key). */
+  addedAt: number;
+  /** Whether this document is applied; defaults to `true` when absent. */
+  enabled?: boolean;
 }
 
 /**
@@ -128,6 +148,12 @@ export interface Workspace {
    * before this field existed simply omits it and loads as `"off"` (no schema bump needed).
    */
   inference?: WorkspaceInferenceMode;
+  /**
+   * [sq-glo5r] Per-workspace N3 rule documents. Applied when inference is `"n3"`. Optional +
+   * backward-compatible: an older record without this field loads with an empty rules list.
+   * Schema stays at 1 (the field is purely additive and defaults gracefully).
+   */
+  rulesDocs?: WorkspaceRulesDoc[];
   /**
    * The schema version of this persisted record. Bumped if the on-disk shape changes so a
    * loader can migrate or discard an incompatible old record rather than crash.
@@ -224,6 +250,8 @@ export function parseWorkspace(value: unknown): Workspace | null {
     },
     // [OPUS-4.8] sq-tp1m — backward-compatible: an older record without `inference` → "off".
     inference: parseInferenceMode(v.inference),
+    // [sq-glo5r] — backward-compatible: an older record without `rulesDocs` → empty array.
+    rulesDocs: parseRulesDocs(v.rulesDocs),
     schema: WORKSPACE_SCHEMA,
   };
 }
@@ -241,6 +269,30 @@ function parseSource(value: unknown): WorkspaceSourceMeta | null {
     bytes: typeof s.bytes === "number" ? s.bytes : undefined,
     importedAt: typeof s.importedAt === "number" ? s.importedAt : Date.now(),
   };
+}
+
+/** [sq-glo5r] Validate + normalise one persisted {@link WorkspaceRulesDoc}, or `null` if malformed. */
+function parseRulesDoc(value: unknown): WorkspaceRulesDoc | null {
+  if (typeof value !== "object" || value === null) return null;
+  const d = value as Record<string, unknown>;
+  if (typeof d.name !== "string" || typeof d.text !== "string") return null;
+  if (typeof d.addedAt !== "number") return null;
+  return {
+    name: d.name,
+    text: d.text,
+    addedAt: d.addedAt,
+    // `enabled` is only persisted when false (absent = true by default).
+    enabled: d.enabled === false ? false : undefined,
+  };
+}
+
+/** [sq-glo5r] Parse an arbitrary value into a {@link WorkspaceRulesDoc} array (empty when absent / invalid). */
+function parseRulesDocs(value: unknown): WorkspaceRulesDoc[] {
+  if (!Array.isArray(value)) return [];
+  return value.flatMap((d) => {
+    const doc = parseRulesDoc(d);
+    return doc ? [doc] : [];
+  });
 }
 
 // ---------------------------------------------------------------------------

--- a/site/test/workspace.test.mjs
+++ b/site/test/workspace.test.mjs
@@ -13,6 +13,7 @@ import assert from "node:assert/strict";
 
 import {
   WORKSPACE_SCHEMA,
+  WORKSPACE_INFERENCE_MODES,
   WebWorkspaceStore,
   MemoryWorkspaceStore,
   TauriWorkspaceStore,
@@ -20,6 +21,7 @@ import {
   detectWebStorage,
   isTauriRuntime,
   newWorkspace,
+  parseInferenceMode,
   parseWorkspace,
   workspaceId,
   workspaceSummary,
@@ -258,4 +260,55 @@ test("createWorkspaceStore ignores a Tauri fs loader outside a Tauri runtime", a
   // Not in a Tauri webview → the loader is never invoked, and it degrades to memory.
   assert.equal(called, false);
   assert.equal(store.backend, "memory");
+});
+
+// --- sq-glo5r: N3 inference mode + rulesDocs --------------------------------
+
+test("parseInferenceMode recognises 'n3'", () => {
+  assert.equal(parseInferenceMode("n3"), "n3");
+});
+
+test("WORKSPACE_INFERENCE_MODES includes 'n3'", () => {
+  assert.ok(WORKSPACE_INFERENCE_MODES.includes("n3"));
+});
+
+test("parseWorkspace round-trips a workspace with rulesDocs", () => {
+  const ws = newWorkspace("N3-test", "SELECT 1");
+  ws.inference = "n3";
+  ws.rulesDocs = [
+    { name: "my-rule", text: "{ ?s a ex:A } => { ?s a ex:B . }", addedAt: 123456 },
+    { name: "disabled-rule", text: "{ ?x a ex:C } => { ?x a ex:D . }", addedAt: 123457, enabled: false },
+  ];
+  const parsed = parseWorkspace(JSON.parse(JSON.stringify(ws)));
+  assert.ok(parsed);
+  assert.equal(parsed.inference, "n3");
+  assert.equal(parsed.rulesDocs.length, 2);
+  assert.equal(parsed.rulesDocs[0].name, "my-rule");
+  assert.equal(parsed.rulesDocs[0].addedAt, 123456);
+  assert.equal(parsed.rulesDocs[0].enabled, undefined); // enabled=true is stored as absent
+  assert.equal(parsed.rulesDocs[1].enabled, false);
+});
+
+test("parseWorkspace defaults to empty rulesDocs when the field is absent (old record)", () => {
+  const ws = newWorkspace("old-record", "SELECT 1");
+  const raw = JSON.parse(JSON.stringify(ws));
+  delete raw.rulesDocs; // simulate a record from before sq-glo5r
+  const parsed = parseWorkspace(raw);
+  assert.ok(parsed);
+  assert.deepEqual(parsed.rulesDocs, []);
+});
+
+test("parseWorkspace skips malformed rulesDocs entries but keeps valid ones", () => {
+  const ws = newWorkspace("M", "SELECT 1");
+  const raw = JSON.parse(JSON.stringify(ws));
+  raw.rulesDocs = [
+    { name: "good", text: "...", addedAt: 1 },
+    { name: "no-text", addedAt: 2 }, // missing text → skipped
+    null, // null → skipped
+    { name: "no-addedAt", text: "..." }, // missing addedAt → skipped
+  ];
+  const parsed = parseWorkspace(raw);
+  assert.ok(parsed);
+  assert.equal(parsed.rulesDocs.length, 1);
+  assert.equal(parsed.rulesDocs[0].name, "good");
 });


### PR DESCRIPTION
> 🤖 **SPARQ agent** — bead `sq-glo5r` implementation

## Summary

- **`WorkspaceInferenceMode`** extended with `'n3'`; new `WorkspaceRulesDoc` interface (`{name, text, addedAt, enabled?}`) + `rulesDocs?` field on `Workspace` in `@sparq/client`
- **Engine**: `storeToNTriples` (folds named graphs → default for N3 input), `fnv1aHash` (FNV-1a, cache-key content addressing), N3 branch in `buildReasonedStore` — calls `reasoner.reasonN3(rulesText + "\n" + baseNTriples)`, cache key `n3:${storeEpoch}:${rulesHash}`; new `setN3Rules` callback + `rulesEpoch` state
- **Workspace context**: `addRulesDocs` / `removeRulesDoc` / `setRulesDocEnabled` mutators; `activate` pushes rules to engine on workspace load
- **`N3RulesBridge`** component (renders null, mirrors workspace `rulesDocs` → engine on each change — same pattern as `InferenceModeBridge`)
- **`N3RulesPanel`** in `inference-tool.tsx`: per-rule enable toggle + remove button, `Dropzone` bulk multi-file upload, collapsible "Author a rule" pane with `WorkbenchTurtleEditor` N3 syntax highlighting
- Removed stale "N3 rule reasoning is not offered" caveat; replaced with honest scope note
- New e2e spec `gui/e2e-playwright/specs/n3-inference.web.spec.ts` (4 browser-persona test cases: load+infer, bulk upload, toggle-off, localStorage persistence)
- 5 new unit tests in `site/test/workspace.test.mjs` (298 total, all pass)

## Key design decisions

- **Cache key**: `n3:epoch:rulesHash` not `n3:epoch` — rule content changes (not just store changes) must invalidate the closure
- **`modeToProfile`** narrowed to `"rdfs" | "owl-rl"` — N3 bypasses it entirely and calls `reasonN3()` directly
- **`enabled` absent ≡ `true`** — only `false` is persisted, matching the sparse-default pattern already used for other workspace fields
- **Belt-and-suspenders push**: both `activate()` in workspace-context AND `N3RulesBridge` call `setN3Rules`, so the engine is always current whether a workspace loads or rules change interactively
- **`css-modules.d.ts`**: worktree-local shim for `*.css` side-effect imports (Next.js provides this via `next-env.d.ts` in the main checkout; the worktree lacks local `node_modules`)

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — static export succeeds
- [x] `site/` unit tests: 298/298 pass (5 new N3 tests)
- [ ] e2e: `gui/e2e-playwright/specs/n3-inference.web.spec.ts` — requires `sparq_reason_wasm` bundle at runtime; marked `e2e_green: "not_run"` per brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)