### PR TITLE
feat(kb): tier-partition KB emission with fail-closed license routing (sq-tzars.7) [SONNET-4.6]

### DIFF
--- a/crates/sparq-kb/README.md
+++ b/crates/sparq-kb/README.md
@@ -91,10 +91,10 @@ the write/merge/latency/CLI estate buys nothing (`part2_four_criterion_replaceme
 - **SHACL guardrails** — `pkg.shapes.ttl` makes a source + a confidence value + an
   assurance basis + non-filler content **mandatory** on every `pkg:Finding`, and
   enforces a valid status / bounded priority / no-stale-edge on every `pkg:Task`.
-- **Literature ingestion** (`literature`/`literature-live`, `sq-2489d.5`/`sq-tzars.1`/`.6`) — the
+- **Literature ingestion + tiered dump** (`literature`/`literature-live`, `sq-2489d.5`/`sq-tzars.*`) — the
   `[connector]→[extract]→[ground]→[SHACL gate]→[sidecar]` pipeline on **committed fixtures,
   ZERO network in CI** (grounding **quarantines**, never drops; machine tier ≤ `secx:Conjectured`);
-  live (`literature-live`) adds a CORE v3 connector (paged search + retry + **fail-closed license**) and a subprocess-seam **live extractor** (record/replay preserved; defensive caps — confidence ≤ 0.7, never `Proven`, non-span justification rejected).
+  live (`literature-live`) adds a CORE v3 connector (paged search + retry + **fail-closed license**) and a subprocess-seam **live extractor** (record/replay preserved; defensive caps — confidence ≤ 0.7, never `Proven`, non-span justification rejected). `run_tiered` partitions emission into per-tier ARTIFACTS with **fail-closed** licence routing (unknown ⇒ restricted; metadata-only public projection).
 - **Opt-in by construction** — default build is data + constants only; the
   `validate` feature is the only thing that pulls in `sparq-core` + `sparq-shacl`.
 - **No-drift guard** — `vocab.rs` is byte-pinned against `pkg.ttl` by a sync test.

--- a/crates/sparq-kb/ingest/ingest_pkg.py
+++ b/crates/sparq-kb/ingest/ingest_pkg.py
@@ -45,6 +45,11 @@ from yamlld_compile import compile_yaml_ld  # noqa: E402
 
 PKG = "https://sparq.dev/ns/pkg#"
 KB = "https://sparq.dev/ns/pkg/kb#"
+# [SONNET-4.6] sq-tzars.7: the HAND-AUTHORED tier named-graph IRI (byte-pinned in Rust as
+# crates/sparq-kb/src/vocab.rs::TIER_HAND_AUTHORED_GRAPH). This script's output IS the
+# hand-authored tier, so it stamps that graph IRI so a tier-aware loader/exporter
+# (sq-tzars.8) can keep the hand-authored tier queryable-apart from the machine tier.
+TIER_HAND_AUTHORED_GRAPH = "https://sparq.dev/ns/pkg/graph#hand-authored"
 
 # [OPUS-4.8] sq-2m6zm.5 (bd-bridge eval). A `research/<doc>.md` reference inside a
 # bead's `design` / `description` is the bd `--spec-id` style knowledge link. Project
@@ -324,7 +329,16 @@ def main():
         "# the script header + the SHACL honesty report).\n\n"
     )
 
-    parts = [header, PREFIXES, "\n# === Tasks (mechanical bd projection) ===\n"]
+    # [SONNET-4.6] sq-tzars.7: stamp this output as the HAND-AUTHORED tier. The stamp is a
+    # single untyped node (no rdf:type), so it is not targeted by any SHACL shape and does
+    # not affect the 0-violation conformance; it names the tier so downstream tooling can
+    # keep the tiers queryable-apart (per-tier ARTIFACTS, not in-store named graphs).
+    tier_stamp = (
+        "\n# === Tier stamp (sq-tzars.7): this graph IS the hand-authored tier ===\n"
+        f"<{TIER_HAND_AUTHORED_GRAPH}> rdfs:label "
+        '"hand-authored tier -- the human-curated PKG (ingest_pkg.py projector output)"@en .\n'
+    )
+    parts = [header, PREFIXES, tier_stamp, "\n# === Tasks (mechanical bd projection) ===\n"]
     bead_lines, bstats = project_beads(args.beads)
     parts.extend(bead_lines)
     parts.append("\n\n# === Sources + Techniques (skills front-matter parse) ===\n")

--- a/crates/sparq-kb/ingest/pkg-instances.ttl
+++ b/crates/sparq-kb/ingest/pkg-instances.ttl
@@ -20,6 +20,10 @@
 @prefix kb:      <https://sparq.dev/ns/pkg/kb#> .
 
 
+# === Tier stamp (sq-tzars.7): this graph IS the hand-authored tier ===
+<https://sparq.dev/ns/pkg/graph#hand-authored> rdfs:label "hand-authored tier -- the human-curated PKG (ingest_pkg.py projector output)"@en .
+
+
 # === Tasks (mechanical bd projection) ===
 
 

--- a/crates/sparq-kb/src/literature/pipeline.rs
+++ b/crates/sparq-kb/src/literature/pipeline.rs
@@ -14,7 +14,7 @@
 //! Phase 5 ships the *scaffolding* and proves it on fixtures; bulk ingestion of real
 //! literature is gated behind the Phase-6 live pilot's per-topic recommend-adopt verdict.
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::fmt::Write as _;
 
 use super::connector::{parse_openalex_batch, SourceStub};
@@ -631,6 +631,24 @@ fn tier_header(
     Ok(t)
 }
 
+/// Compute the DOI-granularity effective tier for every normalised DOI across the full stub
+/// batch (`sq-tzars.7` DOI-granularity fix). A DOI routes to [`Tier::Machine`] ONLY if EVERY
+/// stub sharing that DOI carries an allowlisted licence — any absent, blank, or non-allowlisted
+/// licence forces the WHOLE DOI to [`Tier::LicenseRestricted`] (fail-closed). This prevents a
+/// dup-DOI batch with conflicting licence metadata from emitting the same abstract-derived
+/// finding content into both tiers (violating the one-tier-per-statement invariant).
+fn doi_tier_map(stubs: &[SourceStub]) -> HashMap<String, Tier> {
+    let mut map: HashMap<String, Tier> = HashMap::new();
+    for stub in stubs {
+        let entry = map.entry(stub.doi.clone()).or_insert(Tier::Machine);
+        // Once restricted, it stays restricted (fail-closed).
+        if *entry == Tier::Machine && source_tier(stub.license.as_deref()) != Tier::Machine {
+            *entry = Tier::LicenseRestricted;
+        }
+    }
+    map
+}
+
 /// Emit ONE tier artifact ([`Tier::Machine`] or [`Tier::LicenseRestricted`]) — the full
 /// Sources and Findings for the sources routed to that tier by [`source_tier`]. The global
 /// `finding_n` counter is advanced for EVERY grounded finding (whether or not it is in this
@@ -655,9 +673,25 @@ fn emit_tier(
     };
     let mut t = tier_header(tier.graph_iri(), label, true, completeness)?;
 
+    // DOI-granularity routing (sq-tzars.7): compute the effective tier for each DOI across
+    // ALL stubs before iterating — a dup-DOI batch with one cc-by stub and one licence-absent
+    // stub routes the WHOLE DOI restricted (fail-closed). Then process each DOI exactly once
+    // (first-occurrence representative) to keep `finding_n` stable across both tier runs.
+    let doi_tiers = doi_tier_map(&p.stubs);
+    let mut seen_dois: HashSet<&str> = HashSet::new();
     let mut finding_n = 0usize;
     for stub in &p.stubs {
-        let in_tier = source_tier(stub.license.as_deref()) == tier;
+        // Use the DOI-granularity effective tier, not the per-stub source_tier.
+        let effective_tier = doi_tiers
+            .get(&stub.doi)
+            .copied()
+            .unwrap_or(Tier::LicenseRestricted);
+        let in_tier = effective_tier == tier;
+        // Process each DOI exactly once: the first stub encountered is the representative
+        // (subsequent stubs for the same DOI are skipped; finding_n stays consistent).
+        if !seen_dois.insert(stub.doi.as_str()) {
+            continue;
+        }
         let grounded = p.grounded_by_doi.get(&stub.doi);
         if in_tier {
             let explored = grounded.is_some_and(|v| !v.is_empty());
@@ -691,8 +725,20 @@ fn emit_restricted_projection(
         false,
         completeness,
     )?;
+    // DOI-granularity routing (sq-tzars.7): same effective-tier map used in emit_tier;
+    // emit each restricted DOI's metadata exactly once (first-occurrence representative).
+    let doi_tiers = doi_tier_map(&p.stubs);
+    let mut seen_dois: HashSet<&str> = HashSet::new();
     for stub in &p.stubs {
-        if source_tier(stub.license.as_deref()) != Tier::LicenseRestricted {
+        let effective_tier = doi_tiers
+            .get(&stub.doi)
+            .copied()
+            .unwrap_or(Tier::LicenseRestricted);
+        if effective_tier != Tier::LicenseRestricted {
+            continue;
+        }
+        // Emit each DOI's metadata exactly once.
+        if !seen_dois.insert(stub.doi.as_str()) {
             continue;
         }
         let src = stub.source_iri();

--- a/crates/sparq-kb/src/literature/pipeline.rs
+++ b/crates/sparq-kb/src/literature/pipeline.rs
@@ -14,11 +14,13 @@
 //! Phase 5 ships the *scaffolding* and proves it on fixtures; bulk ingestion of real
 //! literature is gated behind the Phase-6 live pilot's per-topic recommend-adopt verdict.
 
+use std::collections::HashMap;
 use std::fmt::Write as _;
 
 use super::connector::{parse_openalex_batch, SourceStub};
 use super::extract::{CandidateFinding, Extractor};
 use super::ground::{self, GroundingFailure};
+use crate::vocab::{TIER_LICENSE_RESTRICTED_GRAPH, TIER_MACHINE_GRAPH};
 
 /// The machine-extraction agent IRI every emitted Finding is `prov:wasAttributedTo`. Typed
 /// `pkg:MachineAgent`, so the literature-tier SHACL shapes bind to it (and a hand-authored
@@ -31,6 +33,127 @@ pub const MACHINE_AGENT_IRI: &str = "https://sparq.dev/ns/pkg/agent#literature-e
 /// durable backstop. NOT a calibrated number (calibration is Phase 6) — a declarative
 /// "a cheap extractor is not high-confidence" guard.
 pub const MACHINE_CONFIDENCE_CEILING: f64 = 0.7;
+
+/// The named tier a KB statement is emitted into (`sq-tzars.7`). Tier separation v1 is
+/// realised as per-tier Turtle ARTIFACTS (not in-store named graphs); each variant NAMES
+/// a `pkg/graph#` IRI ([`Tier::graph_iri`]). Every emitted machine-pipeline statement
+/// belongs to EXACTLY ONE tier — the load-bearing invariant of `sq-tzars.7`.
+///
+/// The pipeline itself only ever emits [`Tier::Machine`] and [`Tier::LicenseRestricted`]
+/// (the machine-extraction tiers); [`Tier::HandAuthored`] names the `ingest_pkg.py`
+/// projector output, which is stamped with its graph IRI by that script, not here.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Tier {
+    /// The hand-authored, human-curated PKG (`ingest_pkg.py` output).
+    HandAuthored,
+    /// Machine findings from a KNOWN, redistributable-licensed source.
+    Machine,
+    /// Machine findings from an unknown/absent/non-redistributable-licensed source
+    /// (fail-closed). The full findings stay private; only a metadata-only projection is
+    /// published.
+    LicenseRestricted,
+}
+
+impl Tier {
+    /// The `pkg/graph#` named-graph IRI for this tier (a byte-pinned `crate::vocab`
+    /// constant). Downstream artifacts + the export script (`sq-tzars.8`) key off it.
+    pub fn graph_iri(&self) -> &'static str {
+        match self {
+            Tier::HandAuthored => crate::vocab::TIER_HAND_AUTHORED_GRAPH,
+            Tier::Machine => TIER_MACHINE_GRAPH,
+            Tier::LicenseRestricted => TIER_LICENSE_RESTRICTED_GRAPH,
+        }
+    }
+}
+
+/// Route a machine-pipeline source to its emission tier from its captured licence,
+/// **fail-closed**: an UNKNOWN/absent licence (`None`), a blank licence, or any licence
+/// NOT on the conservative redistributable allowlist routes to [`Tier::LicenseRestricted`];
+/// only a licence on the allowlist routes to [`Tier::Machine`]. This is the load-bearing
+/// invariant of `sq-tzars.7`: unknown licence ⇒ restricted.
+///
+/// The allowlist is the clearly-redistributable open set (`cc-by`, `cc-by-sa`, `cc0`,
+/// public-domain); `-nc`/`-nd` variants and anything unrecognised are treated as
+/// non-redistributable (a public dump is a redistribution, so the safe default is to
+/// restrict). It is a deliberately conservative, maintainer-tunable policy — see the crate
+/// README + the `sq-tzars.7` PR body.
+pub fn source_tier(license: Option<&str>) -> Tier {
+    match license.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(l) if is_redistributable_license(l) => Tier::Machine,
+        _ => Tier::LicenseRestricted,
+    }
+}
+
+/// The conservative redistributable-licence allowlist (case-insensitive exact match).
+/// Anything not listed — including an unknown/absent licence — is treated as
+/// non-redistributable by [`source_tier`] (fail-closed).
+fn is_redistributable_license(license: &str) -> bool {
+    const ALLOW: &[&str] = &[
+        "cc-by",
+        "cc-by-sa",
+        "cc0",
+        "cc-0",
+        "public-domain",
+        "publicdomain",
+        "pd",
+    ];
+    let l = license.to_ascii_lowercase();
+    ALLOW.contains(&l.as_str())
+}
+
+/// The metadata-only public licence-status literal for a restricted source: the raw
+/// licence string when one is present (e.g. a known-but-non-redistributable `cc-by-nc`),
+/// else `"unknown"` for an absent/blank licence. Carries NO abstract-derived text.
+fn license_status(license: Option<&str>) -> String {
+    match license.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(l) => l.to_string(),
+        None => "unknown".to_string(),
+    }
+}
+
+/// Whether the connector batch feeding the pipeline was COMPLETE or was cut short by a
+/// pagination hard-cap. A cap-truncated batch (a paged connector run whose
+/// `pages_fetched` reached the policy `max_pages`) may be missing results, so an artifact
+/// emitted from it MUST NOT be presented as the whole result set (`sq-tzars.7` truncation
+/// invariant; the consumer note from the #1527 review). Fail-closed: "hit the cap" is
+/// treated as potentially-incomplete.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BatchCompleteness {
+    /// The connector exhausted the result set (an empty/under-full page arrived, or the
+    /// reported `totalHits` was reached before the cap).
+    Complete,
+    /// The connector stopped at a hard page cap — there may be MORE unfetched results.
+    CapTruncated {
+        /// Pages actually fetched (`== max_pages` when the cap was the stop reason).
+        pages_fetched: usize,
+        /// The policy page cap that was hit.
+        max_pages: usize,
+    },
+}
+
+impl BatchCompleteness {
+    /// Derive completeness from a paginated connector run's `pages_fetched` vs the policy
+    /// page cap (e.g. a `connector_core::CoreSearchResult.pages_fetched` and
+    /// `RetryPolicy.max_pages`). `pages_fetched >= max_pages` (for a positive cap) ⇒
+    /// [`BatchCompleteness::CapTruncated`] — the run may have stopped short of the full
+    /// result set. This decouples the pipeline from the connector: the caller maps its
+    /// run into this without the pipeline importing the connector's paging types.
+    pub fn from_pagination(pages_fetched: usize, max_pages: usize) -> Self {
+        if max_pages > 0 && pages_fetched >= max_pages {
+            BatchCompleteness::CapTruncated {
+                pages_fetched,
+                max_pages,
+            }
+        } else {
+            BatchCompleteness::Complete
+        }
+    }
+
+    /// Whether the batch is known-complete.
+    pub fn is_complete(&self) -> bool {
+        matches!(self, BatchCompleteness::Complete)
+    }
+}
 
 /// One quarantined candidate (recorded, never silently dropped — the sidecar-honesty
 /// pattern §4.7).
@@ -92,6 +215,37 @@ pub struct PipelineOutput {
     pub generated_at_time: String,
 }
 
+/// The output of one TIERED pipeline run ([`run_tiered`], `sq-tzars.7`): the per-tier
+/// Turtle ARTIFACTS (tier separation v1 = separate documents, not in-store named graphs).
+///
+/// The three payload artifacts partition every emitted machine-pipeline statement into
+/// EXACTLY ONE tier by the source's captured licence ([`source_tier`], fail-closed). The
+/// [`restricted_public_projection`](Self::restricted_public_projection) is a metadata-only
+/// VIEW of the restricted tier — it is NOT a fourth tier and carries NO abstract-derived
+/// text.
+#[derive(Debug, Clone)]
+pub struct TieredOutput {
+    /// The MACHINE-tier artifact: full findings + PROV-O lineage for sources whose licence
+    /// is known-redistributable. Stamped with the `pkg/graph#machine` IRI. Publishable.
+    pub machine_tier: String,
+    /// The LICENSE-RESTRICTED artifact: full findings for unknown/absent/non-redistributable
+    /// sources. Stamped with `pkg/graph#license-restricted`. PRIVATE — never published as-is.
+    pub license_restricted_tier: String,
+    /// The metadata-only PUBLIC projection of the restricted tier: only the source IRI
+    /// (DOI), title, year, and licence status. The load-bearing invariant is that it carries
+    /// NO abstract-derived text (no `sigimpl:justification`, no `dcterms:abstract`, no
+    /// `pkg:Finding`) — all a public dump may carry for a restricted source.
+    pub restricted_public_projection: String,
+    /// The run sidecar (grounding metric + quarantine list) — identical to a combined run.
+    pub sidecar: Sidecar,
+    /// The `prov:generatedAtTime` stamped on all emitted machine/restricted Findings.
+    pub generated_at_time: String,
+    /// Whether the connector batch was COMPLETE. When [`BatchCompleteness::CapTruncated`],
+    /// EVERY emitted artifact carries an explicit incompleteness marker (a comment banner +
+    /// an `rdfs:comment` on the tier-graph node) and MUST NOT be presented as the full set.
+    pub completeness: BatchCompleteness,
+}
+
 /// Generate the current UTC time as an ISO 8601 xsd:dateTime string (e.g.,
 /// `2026-07-05T14:30:00Z`). Used as the default `prov:generatedAtTime` when the caller
 /// does not inject a fixed timestamp (as CI tests do for determinism).
@@ -151,6 +305,75 @@ pub fn run_with_time<E: Extractor>(
     extractor: &E,
     generated_at_time: Option<String>,
 ) -> Result<PipelineOutput, String> {
+    let prepared = prepare(connector_json, extractor)?;
+    let gen_time = generated_at_time.unwrap_or_else(current_generated_at_time);
+    // 4. emit the single combined machine-tier TTL (backward-compatible output).
+    let turtle = emit_turtle(
+        &prepared.stubs,
+        &prepared.candidates,
+        &prepared.grounded_by_doi,
+        &gen_time,
+    )?;
+    Ok(PipelineOutput {
+        turtle,
+        sidecar: prepared.sidecar,
+        generated_at_time: gen_time,
+    })
+}
+
+/// Run the full pipeline with the default (current) timestamp.
+/// Convenience wrapper around [`run_with_time`] for callers that do not need to inject
+/// a fixed instant. (sq-tzars.2 [HAIKU-4.5])
+pub fn run<E: Extractor>(connector_json: &str, extractor: &E) -> Result<PipelineOutput, String> {
+    run_with_time(connector_json, extractor, None)
+}
+
+/// Run the full pipeline and partition the emission into the per-tier ARTIFACTS
+/// (`sq-tzars.7`): a machine-tier document, a license-restricted document, and a
+/// metadata-only public projection of the restricted tier. Every grounded finding is
+/// routed to EXACTLY ONE tier by its source's captured licence ([`source_tier`],
+/// fail-closed: unknown ⇒ restricted).
+///
+/// `completeness` records whether the input batch was the whole result set: pass
+/// [`BatchCompleteness::from_pagination`] mapped from a paged connector run so a
+/// cap-truncated batch is stamped with an explicit incompleteness marker in every artifact
+/// (never presented as complete — the #1527 consumer note). For a single-shot fixture
+/// batch the caller passes [`BatchCompleteness::Complete`].
+pub fn run_tiered<E: Extractor>(
+    connector_json: &str,
+    extractor: &E,
+    generated_at_time: Option<String>,
+    completeness: BatchCompleteness,
+) -> Result<TieredOutput, String> {
+    let prepared = prepare(connector_json, extractor)?;
+    let gen_time = generated_at_time.unwrap_or_else(current_generated_at_time);
+    let machine_tier = emit_tier(&prepared, &gen_time, Tier::Machine, completeness)?;
+    let license_restricted_tier =
+        emit_tier(&prepared, &gen_time, Tier::LicenseRestricted, completeness)?;
+    let restricted_public_projection = emit_restricted_projection(&prepared, completeness)?;
+    Ok(TieredOutput {
+        machine_tier,
+        license_restricted_tier,
+        restricted_public_projection,
+        sidecar: prepared.sidecar,
+        generated_at_time: gen_time,
+        completeness,
+    })
+}
+
+/// The connector→extract→ground middle, shared by [`run_with_time`] and [`run_tiered`] so
+/// the grounding logic + sidecar have a single source of truth. `grounded_by_doi` maps a
+/// source DOI to the INDICES (into `candidates`) of its grounded findings, in a stable
+/// global order — the emitters number findings off this so a finding's IRI is identical
+/// across the combined and per-tier outputs.
+struct Prepared {
+    stubs: Vec<SourceStub>,
+    candidates: Vec<CandidateFinding>,
+    sidecar: Sidecar,
+    grounded_by_doi: HashMap<String, Vec<usize>>,
+}
+
+fn prepare<E: Extractor>(connector_json: &str, extractor: &E) -> Result<Prepared, String> {
     // 1. connector -> normalise.
     let (stubs, sources_skipped) = parse_openalex_batch(connector_json)?;
     // 2. extract (replay in CI).
@@ -164,18 +387,14 @@ pub fn run_with_time<E: Extractor>(
         ..Sidecar::default()
     };
 
-    // Per source: collect the grounded candidates so we can flip exploredStatus.
-    let mut grounded_by_doi: std::collections::HashMap<String, Vec<&CandidateFinding>> =
-        std::collections::HashMap::new();
-
-    for c in &candidates {
+    // Per source: collect the INDICES of grounded candidates so we can flip exploredStatus
+    // and route each finding to its tier without cloning the candidates.
+    let mut grounded_by_doi: HashMap<String, Vec<usize>> = HashMap::new();
+    for (i, c) in candidates.iter().enumerate() {
         match ground::verify(c, &abstracts, &source_dois) {
             Ok(()) => {
                 sidecar.grounded += 1;
-                grounded_by_doi
-                    .entry(c.source_doi.clone())
-                    .or_default()
-                    .push(c);
+                grounded_by_doi.entry(c.source_doi.clone()).or_default().push(i);
             }
             Err(failure) => sidecar.quarantined.push(quarantine(c, &failure)),
         }
@@ -183,31 +402,19 @@ pub fn run_with_time<E: Extractor>(
 
     // exploredStatus per source: Explored iff it produced >=1 grounded Finding, else DeadEnd.
     for stub in &stubs {
-        if grounded_by_doi
-            .get(&stub.doi)
-            .is_some_and(|v| !v.is_empty())
-        {
+        if grounded_by_doi.get(&stub.doi).is_some_and(|v| !v.is_empty()) {
             sidecar.sources_explored += 1;
         } else {
             sidecar.sources_dead_end += 1;
         }
     }
 
-    let gen_time = generated_at_time.unwrap_or_else(current_generated_at_time);
-    // 4. emit TTL.
-    let turtle = emit_turtle(&stubs, &grounded_by_doi, &gen_time)?;
-    Ok(PipelineOutput {
-        turtle,
+    Ok(Prepared {
+        stubs,
+        candidates,
         sidecar,
-        generated_at_time: gen_time,
+        grounded_by_doi,
     })
-}
-
-/// Run the full pipeline with the default (current) timestamp.
-/// Convenience wrapper around [`run_with_time`] for callers that do not need to inject
-/// a fixed instant. (sq-tzars.2 [HAIKU-4.5])
-pub fn run<E: Extractor>(connector_json: &str, extractor: &E) -> Result<PipelineOutput, String> {
-    run_with_time(connector_json, extractor, None)
 }
 
 /// Record a quarantined candidate (truncating the justification for triage).
@@ -251,51 +458,253 @@ fn machine_tier(confidence: f64) -> f64 {
     confidence.min(MACHINE_CONFIDENCE_CEILING)
 }
 
-/// Emit the Turtle document: prefixes + the machine agent + each Source (with its grounded
-/// Findings + extraction Activity + full PROV-O lineage). Deterministic ordering (input
-/// order) so the output is stable. Returns a parseable graph string.
-///
-/// Each Finding and its extraction Activity are stamped with `prov:generatedAtTime`
-/// (the `generated_at_time` parameter, an ISO 8601 xsd:dateTime string), as required
-/// by the literature-tier SHACL shapes. (sq-tzars.2 [HAIKU-4.5])
-fn emit_turtle(
-    stubs: &[SourceStub],
-    grounded_by_doi: &std::collections::HashMap<String, Vec<&CandidateFinding>>,
-    generated_at_time: &str,
-) -> Result<String, String> {
-    let mut t = String::new();
-    // Prefixes (the secx: namespace is the CANONICAL pkg one: w3id zkp-sparql sec-prop).
-    t.push_str(
-        "@prefix pkg:     <https://sparq.dev/ns/pkg#> .\n\
-         @prefix prov:    <http://www.w3.org/ns/prov#> .\n\
-         @prefix dcterms: <http://purl.org/dc/terms/> .\n\
-         @prefix cito:    <http://purl.org/spar/cito/> .\n\
-         @prefix sigimpl: <https://w3id.org/zkp-sparql/sig-impl#> .\n\
-         @prefix secx:    <https://w3id.org/zkp-sparql/sec-prop#> .\n\
-         @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .\n\
-         @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .\n\n",
-    );
+/// The Turtle prefix block shared by every emitted artifact (the `secx:` namespace is the
+/// CANONICAL pkg one: w3id zkp-sparql sec-prop).
+const TTL_PREFIXES: &str = "@prefix pkg:     <https://sparq.dev/ns/pkg#> .\n\
+     @prefix prov:    <http://www.w3.org/ns/prov#> .\n\
+     @prefix dcterms: <http://purl.org/dc/terms/> .\n\
+     @prefix cito:    <http://purl.org/spar/cito/> .\n\
+     @prefix sigimpl: <https://w3id.org/zkp-sparql/sig-impl#> .\n\
+     @prefix secx:    <https://w3id.org/zkp-sparql/sec-prop#> .\n\
+     @prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .\n\
+     @prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .\n\n";
 
-    // The extraction agent (typed pkg:MachineAgent so the literature shapes bind).
+/// Write the extraction-agent node (typed `pkg:MachineAgent` so the literature shapes bind).
+fn write_agent_node(t: &mut String) -> Result<(), String> {
     writeln!(
         t,
         "<{}> a pkg:MachineAgent ;\n  rdfs:label \"literature extraction agent (Phase-5 scaffolding, fixtures)\"@en .\n",
         MACHINE_AGENT_IRI
     )
+    .map_err(|e| e.to_string())
+}
+
+/// Write one Source node (DOI-keyed, content-addressed): title, exploredStatus, and year
+/// (when present). The single source of truth for the Source block, shared by the combined
+/// and per-tier emitters so their output cannot drift.
+fn write_source_node(t: &mut String, stub: &SourceStub, explored: bool) -> Result<(), String> {
+    let src = stub.source_iri();
+    let status = if explored {
+        "pkg:Explored"
+    } else {
+        "pkg:DeadEnd"
+    };
+    write!(
+        t,
+        "<{src}> a pkg:Source ;\n  dcterms:title \"{title}\" ;\n  pkg:exploredStatus {status}",
+        src = src,
+        title = ttl_escape(&stub.title),
+        status = status,
+    )
     .map_err(|e| e.to_string())?;
+    if let Some(y) = stub.year {
+        write!(t, " ;\n  dcterms:issued \"{}\"^^xsd:gYear", y).map_err(|e| e.to_string())?;
+    }
+    t.push_str(" .\n");
+    Ok(())
+}
+
+/// Write one grounded Finding node + its extraction Activity, with full PROV-O lineage and
+/// the machine-tier caps (confidence ≤ ceiling, assurance forced to `secx:Conjectured`).
+/// `finding_n` is the stable GLOBAL finding number, so a finding's IRI is identical whether
+/// it lands in the combined output or a per-tier artifact. The single source of truth for
+/// the Finding block. (Timestamps: sq-tzars.2 [HAIKU-4.5].)
+fn write_finding_node(
+    t: &mut String,
+    stub: &SourceStub,
+    c: &CandidateFinding,
+    finding_n: usize,
+    generated_at_time: &str,
+) -> Result<(), String> {
+    let src = stub.source_iri();
+    let f = format!("{}/finding/{}", MACHINE_AGENT_IRI, finding_n);
+    let act = format!("{}/activity/{}", MACHINE_AGENT_IRI, finding_n);
+    let conf = machine_tier(c.confidence);
+    writeln!(
+        t,
+        "<{f}> a pkg:Finding ;\n  \
+         rdfs:label \"{verdict} (machine-extracted)\"@en ;\n  \
+         sigimpl:justification \"{just}\" ;\n  \
+         pkg:confidence {conf:.4} ;\n  \
+         pkg:assurance secx:Conjectured ;\n  \
+         prov:wasDerivedFrom <{src}> ;\n  \
+         prov:wasGeneratedBy <{act}> ;\n  \
+         prov:wasAttributedTo <{agent}> ;\n  \
+         prov:generatedAtTime \"{generated_at_time}\"^^xsd:dateTime ;\n  \
+         cito:citesAsEvidence <{src}> .\n\
+         <{act}> a prov:Activity ;\n  \
+         prov:used <{src}> ;\n  \
+         prov:wasAssociatedWith <{agent}> ;\n  \
+         prov:generatedAtTime \"{generated_at_time}\"^^xsd:dateTime .\n",
+        f = f,
+        verdict = ttl_escape(&c.verdict),
+        just = ttl_escape(&c.justification),
+        conf = conf,
+        src = src,
+        act = act,
+        agent = MACHINE_AGENT_IRI,
+        generated_at_time = generated_at_time,
+    )
+    .map_err(|e| e.to_string())
+}
+
+/// Emit the single COMBINED Turtle document: prefixes + the machine agent + every Source
+/// (with its grounded Findings). Deterministic input-order; byte-stable. Backward-compatible
+/// with the pre-tiering [`PipelineOutput::turtle`]. `grounded_by_doi` holds indices into
+/// `candidates`. (Timestamps: sq-tzars.2 [HAIKU-4.5].)
+fn emit_turtle(
+    stubs: &[SourceStub],
+    candidates: &[CandidateFinding],
+    grounded_by_doi: &HashMap<String, Vec<usize>>,
+    generated_at_time: &str,
+) -> Result<String, String> {
+    let mut t = String::new();
+    t.push_str(TTL_PREFIXES);
+    write_agent_node(&mut t)?;
 
     let mut finding_n = 0usize;
     for stub in stubs {
-        let src = stub.source_iri();
         let grounded = grounded_by_doi.get(&stub.doi);
         let explored = grounded.is_some_and(|v| !v.is_empty());
+        write_source_node(&mut t, stub, explored)?;
+        if let Some(idxs) = grounded {
+            for &ci in idxs {
+                finding_n += 1;
+                write_finding_node(&mut t, stub, &candidates[ci], finding_n, generated_at_time)?;
+            }
+        }
+    }
+    Ok(t)
+}
+
+/// Build the header of a per-tier artifact: the shared prefixes, the extraction agent (when
+/// the tier carries findings), and the self-identifying tier-graph node. When the source
+/// batch was [`BatchCompleteness::CapTruncated`], the header ALSO carries an explicit
+/// incompleteness marker — a comment banner AND an `rdfs:comment` on the tier-graph node —
+/// so the artifact can never be mistaken for the full result set (`sq-tzars.7`).
+fn tier_header(
+    graph_iri: &str,
+    tier_label: &str,
+    with_agent: bool,
+    completeness: BatchCompleteness,
+) -> Result<String, String> {
+    let mut t = String::new();
+    if let BatchCompleteness::CapTruncated {
+        pages_fetched,
+        max_pages,
+    } = completeness
+    {
+        writeln!(
+            t,
+            "# INCOMPLETE ARTIFACT -- the source batch was cut short by a pagination hard cap\n\
+             # (pages_fetched={} == max_pages={}); MORE results may exist. This artifact is\n\
+             # NOT the full result set and must not be presented as complete (sq-tzars.7).",
+            pages_fetched, max_pages
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    t.push_str(TTL_PREFIXES);
+    if with_agent {
+        write_agent_node(&mut t)?;
+    }
+    // The self-identifying tier-graph node (names which tier this artifact is).
+    write!(
+        t,
+        "<{graph}> rdfs:label \"{label}\"@en",
+        graph = graph_iri,
+        label = ttl_escape(tier_label),
+    )
+    .map_err(|e| e.to_string())?;
+    if let BatchCompleteness::CapTruncated {
+        pages_fetched,
+        max_pages,
+    } = completeness
+    {
+        write!(
+            t,
+            " ;\n  rdfs:comment \"INCOMPLETE: cap-truncated batch (pages_fetched={} == max_pages={}); more results may exist -- this artifact is not the full result set.\"@en",
+            pages_fetched, max_pages
+        )
+        .map_err(|e| e.to_string())?;
+    }
+    t.push_str(" .\n\n");
+    Ok(t)
+}
+
+/// Emit ONE tier artifact ([`Tier::Machine`] or [`Tier::LicenseRestricted`]) — the full
+/// Sources and Findings for the sources routed to that tier by [`source_tier`]. The global
+/// `finding_n` counter is advanced for EVERY grounded finding (whether or not it is in this
+/// tier), so a finding's IRI is stable across tiers and the machine/restricted artifacts
+/// never share a Finding IRI: exactly one tier per emitted finding.
+fn emit_tier(
+    p: &Prepared,
+    gen_time: &str,
+    tier: Tier,
+    completeness: BatchCompleteness,
+) -> Result<String, String> {
+    let label = match tier {
+        Tier::Machine => {
+            "machine tier -- literature-pipeline findings from redistributable-licensed sources"
+        }
+        Tier::LicenseRestricted => {
+            "license-restricted tier -- machine findings from unknown/absent/non-redistributable sources (PRIVATE)"
+        }
+        Tier::HandAuthored => {
+            return Err("the literature pipeline does not emit the hand-authored tier".to_string())
+        }
+    };
+    let mut t = tier_header(tier.graph_iri(), label, true, completeness)?;
+
+    let mut finding_n = 0usize;
+    for stub in &p.stubs {
+        let in_tier = source_tier(stub.license.as_deref()) == tier;
+        let grounded = p.grounded_by_doi.get(&stub.doi);
+        if in_tier {
+            let explored = grounded.is_some_and(|v| !v.is_empty());
+            write_source_node(&mut t, stub, explored)?;
+        }
+        if let Some(idxs) = grounded {
+            for &ci in idxs {
+                finding_n += 1;
+                if in_tier {
+                    write_finding_node(&mut t, stub, &p.candidates[ci], finding_n, gen_time)?;
+                }
+            }
+        }
+    }
+    Ok(t)
+}
+
+/// Emit the metadata-only PUBLIC projection of the license-restricted tier (`sq-tzars.7`):
+/// for each restricted source, ONLY its IRI (DOI) + title + exploredStatus + year + licence
+/// status. The load-bearing invariant — NO abstract-derived text: no `sigimpl:justification`,
+/// no `dcterms:abstract`, and NO `pkg:Finding` at all. This is all a public dump may carry
+/// for a restricted source. Truncation marker is propagated (an incomplete restricted batch
+/// yields an incomplete projection).
+fn emit_restricted_projection(
+    p: &Prepared,
+    completeness: BatchCompleteness,
+) -> Result<String, String> {
+    let mut t = tier_header(
+        TIER_LICENSE_RESTRICTED_GRAPH,
+        "license-restricted tier -- metadata-only PUBLIC projection (DOI + title + year + licence status; NO abstract-derived text)",
+        false,
+        completeness,
+    )?;
+    for stub in &p.stubs {
+        if source_tier(stub.license.as_deref()) != Tier::LicenseRestricted {
+            continue;
+        }
+        let src = stub.source_iri();
+        let explored = p
+            .grounded_by_doi
+            .get(&stub.doi)
+            .is_some_and(|v| !v.is_empty());
         let status = if explored {
             "pkg:Explored"
         } else {
             "pkg:DeadEnd"
         };
-
-        // The Source node (DOI-keyed, content-addressed).
         write!(
             t,
             "<{src}> a pkg:Source ;\n  dcterms:title \"{title}\" ;\n  pkg:exploredStatus {status}",
@@ -307,47 +716,13 @@ fn emit_turtle(
         if let Some(y) = stub.year {
             write!(t, " ;\n  dcterms:issued \"{}\"^^xsd:gYear", y).map_err(|e| e.to_string())?;
         }
+        write!(
+            t,
+            " ;\n  dcterms:license \"{}\"",
+            ttl_escape(&license_status(stub.license.as_deref()))
+        )
+        .map_err(|e| e.to_string())?;
         t.push_str(" .\n");
-
-        // The grounded Findings for this source.
-        if let Some(cands) = grounded {
-            for c in cands {
-                finding_n += 1;
-                let f = format!("{}/finding/{}", MACHINE_AGENT_IRI, finding_n);
-                let act = format!("{}/activity/{}", MACHINE_AGENT_IRI, finding_n);
-                let conf = machine_tier(c.confidence);
-                // Full PROV-O lineage: derived-from the Source, generated-by the extraction
-                // Activity, attributed-to the machine agent. Machine tier => secx:Conjectured.
-                // [HAIKU-4.5] sq-tzars.2: stamp prov:generatedAtTime on both the Finding
-                // and the Activity so the SHACL timestamp requirement can be verified.
-                writeln!(
-                    t,
-                    "<{f}> a pkg:Finding ;\n  \
-                     rdfs:label \"{verdict} (machine-extracted)\"@en ;\n  \
-                     sigimpl:justification \"{just}\" ;\n  \
-                     pkg:confidence {conf:.4} ;\n  \
-                     pkg:assurance secx:Conjectured ;\n  \
-                     prov:wasDerivedFrom <{src}> ;\n  \
-                     prov:wasGeneratedBy <{act}> ;\n  \
-                     prov:wasAttributedTo <{agent}> ;\n  \
-                     prov:generatedAtTime \"{generated_at_time}\"^^xsd:dateTime ;\n  \
-                     cito:citesAsEvidence <{src}> .\n\
-                     <{act}> a prov:Activity ;\n  \
-                     prov:used <{src}> ;\n  \
-                     prov:wasAssociatedWith <{agent}> ;\n  \
-                     prov:generatedAtTime \"{generated_at_time}\"^^xsd:dateTime .\n",
-                    f = f,
-                    verdict = ttl_escape(&c.verdict),
-                    just = ttl_escape(&c.justification),
-                    conf = conf,
-                    src = src,
-                    act = act,
-                    agent = MACHINE_AGENT_IRI,
-                    generated_at_time = generated_at_time,
-                )
-                .map_err(|e| e.to_string())?;
-            }
-        }
     }
     Ok(t)
 }
@@ -444,5 +819,82 @@ mod tests {
             "both Findings and Activities should carry the timestamp (got {} occurrences)",
             timestamp_count
         );
+    }
+
+    // --- sq-tzars.7: tier partition ---------------------------------------
+
+    #[test]
+    fn source_tier_is_fail_closed_on_unknown_licence() {
+        // Direct unit test for the public `source_tier`. Unknown/absent/blank/non-allowlist
+        // licences route RESTRICTED (fail-closed); only allowlisted licences route MACHINE.
+        assert_eq!(source_tier(None), Tier::LicenseRestricted);
+        assert_eq!(source_tier(Some("")), Tier::LicenseRestricted);
+        assert_eq!(source_tier(Some("   ")), Tier::LicenseRestricted);
+        assert_eq!(source_tier(Some("cc-by-nc")), Tier::LicenseRestricted);
+        assert_eq!(source_tier(Some("cc-by-nd")), Tier::LicenseRestricted);
+        assert_eq!(source_tier(Some("all-rights-reserved")), Tier::LicenseRestricted);
+        assert_eq!(source_tier(Some("cc-by")), Tier::Machine);
+        assert_eq!(source_tier(Some("CC-BY")), Tier::Machine);
+        assert_eq!(source_tier(Some("cc-by-sa")), Tier::Machine);
+        assert_eq!(source_tier(Some("cc0")), Tier::Machine);
+        assert_eq!(source_tier(Some("public-domain")), Tier::Machine);
+    }
+
+    #[test]
+    fn tier_graph_iri_names_the_vocab_constant() {
+        // Direct unit test for the public `Tier::graph_iri` (all three variants).
+        assert_eq!(Tier::HandAuthored.graph_iri(), crate::vocab::TIER_HAND_AUTHORED_GRAPH);
+        assert_eq!(Tier::Machine.graph_iri(), crate::vocab::TIER_MACHINE_GRAPH);
+        assert_eq!(
+            Tier::LicenseRestricted.graph_iri(),
+            crate::vocab::TIER_LICENSE_RESTRICTED_GRAPH
+        );
+    }
+
+    #[test]
+    fn batch_completeness_from_pagination_detects_the_cap() {
+        // Direct unit test for the public `BatchCompleteness::from_pagination` + `is_complete`.
+        assert_eq!(
+            BatchCompleteness::from_pagination(3, 20),
+            BatchCompleteness::Complete
+        );
+        assert!(BatchCompleteness::from_pagination(3, 20).is_complete());
+        // pages_fetched == max_pages ⇒ potentially truncated (fail-closed).
+        let hit = BatchCompleteness::from_pagination(20, 20);
+        assert_eq!(
+            hit,
+            BatchCompleteness::CapTruncated {
+                pages_fetched: 20,
+                max_pages: 20
+            }
+        );
+        assert!(!hit.is_complete());
+        // A zero cap is never treated as a truncation.
+        assert!(BatchCompleteness::from_pagination(0, 0).is_complete());
+    }
+
+    #[test]
+    fn run_tiered_routes_all_unknown_licence_findings_restricted() {
+        // Direct unit test for the public `run_tiered`. The committed fixture carries NO
+        // licence metadata, so every source is fail-closed to the restricted tier: the
+        // machine tier gets ZERO findings and the restricted tier gets all four.
+        let extractor = RecordedExtractor::from_fixture().unwrap();
+        let out = run_tiered(
+            crate::literature::FIXTURE_OPENALEX_BATCH,
+            &extractor,
+            Some("2026-07-05T14:30:00Z".to_string()),
+            BatchCompleteness::Complete,
+        )
+        .unwrap();
+        // Sidecar is identical to a combined run (4 grounded).
+        assert_eq!(out.sidecar.grounded, 4);
+        // Machine tier: no findings (all sources are restricted).
+        assert!(!out.machine_tier.contains("a pkg:Finding"));
+        // Restricted tier: all four grounded findings land here.
+        assert_eq!(out.license_restricted_tier.matches("a pkg:Finding").count(), 4);
+        // A Complete batch carries NO incompleteness marker.
+        assert!(out.completeness.is_complete());
+        assert!(!out.machine_tier.contains("INCOMPLETE"));
+        assert!(!out.license_restricted_tier.contains("INCOMPLETE"));
     }
 }

--- a/crates/sparq-kb/src/vocab.rs
+++ b/crates/sparq-kb/src/vocab.rs
@@ -169,6 +169,43 @@ pub const CONFIDENCE_MEASUREMENT: &str = "https://sparq.dev/ns/pkg#ConfidenceMea
 pub const SOURCE_RELIABILITY_MEASUREMENT: &str =
     "https://sparq.dev/ns/pkg#SourceReliabilityMeasurement";
 
+// --- tier named-graph IRIs (sq-tzars.7) ------------------------------------
+// The named-graph IRIs for the tiered KB emission (`research/research-kb-program.md`
+// decisions 5–6). Tier separation v1 = per-tier Turtle ARTIFACTS, NOT in-store named
+// graphs (`sparq-kb` loads one in-memory Graph per query today; in-store separation is
+// future work and is NOT claimed). These IRIs NAME each tier's artifact so a downstream
+// loader/exporter (sq-tzars.8) keeps the tiers queryable-apart. They live in the
+// `pkg/graph#` sub-namespace (mirroring the `pkg/agent#` MachineAgent IRI and the
+// `pkg/kb#` instance namespace) — they are GRAPH identifiers, NOT `pkg:` vocabulary
+// terms, so they are byte-pinned by `tier_graph_iris_are_pinned` below and are
+// deliberately NOT in `ALL` (which pins the `pkg:` vocabulary against `pkg.ttl`).
+// [SONNET-4.6] sq-tzars.7 🤖 SPARQ agent — provenance-driven GenAI KB.
+
+/// The `pkg/graph#` sub-namespace holding the per-tier named-graph IRIs.
+pub const GRAPH_NS: &str = "https://sparq.dev/ns/pkg/graph#";
+
+/// Tier graph IRI: the HAND-AUTHORED tier — the `ingest_pkg.py` projector output (the
+/// high-accuracy, human-curated PKG). Stamped on that output so it is queryable-apart.
+pub const TIER_HAND_AUTHORED_GRAPH: &str = "https://sparq.dev/ns/pkg/graph#hand-authored";
+
+/// Tier graph IRI: the MACHINE tier — the literature pipeline output for sources whose
+/// licence is KNOWN and redistributable (full findings + PROV-O lineage; publishable).
+pub const TIER_MACHINE_GRAPH: &str = "https://sparq.dev/ns/pkg/graph#machine";
+
+/// Tier graph IRI: the LICENSE-RESTRICTED tier — machine findings whose source licence is
+/// unknown/absent/non-redistributable (**fail-closed**). The full findings stay in this
+/// PRIVATE artifact; only a metadata-only projection (no abstract-derived text) is public.
+pub const TIER_LICENSE_RESTRICTED_GRAPH: &str =
+    "https://sparq.dev/ns/pkg/graph#license-restricted";
+
+/// Every tier named-graph IRI, in a stable order. Byte-pinned by
+/// `tier_graph_iris_are_pinned`; deliberately disjoint from [`ALL`].
+pub const TIER_GRAPHS: &[&str] = &[
+    TIER_HAND_AUTHORED_GRAPH,
+    TIER_MACHINE_GRAPH,
+    TIER_LICENSE_RESTRICTED_GRAPH,
+];
+
 /// Every `pkg:` IRI this module names — the full set the drift guard pins against
 /// `pkg.ttl`. Keep in sync when adding/removing a constant.
 pub const ALL: &[&str] = &[
@@ -281,6 +318,45 @@ mod tests {
                 ALL.contains(&full.as_str()),
                 "pkg.ttl declares `pkg:{local}` but no Rust constant names it — \
                  add the constant to vocab.rs or remove the term (sq-2m6zm.1)",
+            );
+        }
+    }
+
+    /// Byte-pin the tier named-graph IRIs (sq-tzars.7). The per-tier ARTIFACTS and the
+    /// tier-aware export script (sq-tzars.8) key off these EXACT strings, so a rename must
+    /// be a conscious, test-breaking change. The tier graph IRIs are graph identifiers,
+    /// NOT `pkg:` vocabulary terms, so they must stay OUT of [`ALL`] (which is pinned
+    /// against `pkg.ttl`) — that separation is asserted here too. [SONNET-4.6]
+    #[test]
+    fn tier_graph_iris_are_pinned() {
+        assert_eq!(GRAPH_NS, "https://sparq.dev/ns/pkg/graph#");
+        assert_eq!(
+            TIER_HAND_AUTHORED_GRAPH,
+            "https://sparq.dev/ns/pkg/graph#hand-authored"
+        );
+        assert_eq!(TIER_MACHINE_GRAPH, "https://sparq.dev/ns/pkg/graph#machine");
+        assert_eq!(
+            TIER_LICENSE_RESTRICTED_GRAPH,
+            "https://sparq.dev/ns/pkg/graph#license-restricted"
+        );
+        // Every tier graph IRI is in the `pkg/graph#` namespace.
+        for &g in TIER_GRAPHS {
+            assert!(
+                g.starts_with(GRAPH_NS),
+                "tier graph IRI must be in the pkg/graph# namespace: {}",
+                g
+            );
+        }
+        // The three tier graph IRIs are distinct.
+        let set: std::collections::HashSet<&str> = TIER_GRAPHS.iter().copied().collect();
+        assert_eq!(set.len(), TIER_GRAPHS.len(), "tier graph IRIs must be distinct");
+        // Exactly one tier per emitted statement starts here: the tier graph IRIs are NOT
+        // `pkg:` vocabulary terms, so none may leak into the pkg.ttl-pinned ALL set.
+        for &g in TIER_GRAPHS {
+            assert!(
+                !ALL.contains(&g),
+                "a tier graph IRI must not be in the pkg: vocab set ALL: {}",
+                g
             );
         }
     }

--- a/crates/sparq-kb/tests/literature_pipeline.rs
+++ b/crates/sparq-kb/tests/literature_pipeline.rs
@@ -475,6 +475,86 @@ fn cap_truncated_batch_is_marked_incomplete_in_every_artifact() {
     assert!(!complete.restricted_public_projection.contains("INCOMPLETE"));
 }
 
+/// A dup-DOI mixed batch: the SAME DOI appears TWICE in one connector batch — once with a
+/// "cc-by" licence and once with no licence recorded. Simulates the real OpenAlex case where
+/// two indexing records represent the same work with conflicting licence metadata. The
+/// DOI-granularity fail-closed rule must route the WHOLE DOI restricted.
+const DUP_DOI_MIXED_BATCH: &str = r#"{ "results": [
+  { "doi": "https://doi.org/10.5555/dup.conflict",
+    "title": "A Conflicted Work — open copy",
+    "abstract": "This conflicted work has two indexing records and mentions parallel scanning.",
+    "publication_year": 2024,
+    "primary_location": { "license": "cc-by" } },
+  { "doi": "https://doi.org/10.5555/dup.conflict",
+    "title": "A Conflicted Work — no-licence copy",
+    "abstract": "This conflicted work has two indexing records and mentions parallel scanning.",
+    "publication_year": 2024 }
+] }"#;
+
+#[test]
+fn dup_doi_mixed_licence_fails_closed_whole_doi_restricted() {
+    // DOI-granularity fail-closed (sq-tzars.7): when a batch contains two stubs for the same
+    // DOI — one "cc-by" and one licence-absent — the WHOLE DOI must be routed RESTRICTED.
+    // No abstract-derived content (source node, pkg:Finding, sigimpl:justification) for that
+    // DOI may appear in the machine (publishable) artifact.
+    let out = pipeline::run_tiered(
+        DUP_DOI_MIXED_BATCH,
+        &GroundingExtractor,
+        Some("2026-07-05T00:00:00Z".to_string()),
+        BatchCompleteness::Complete,
+    )
+    .expect("tiered run on dup-DOI batch");
+
+    // Machine artifact must carry NONE of the dup-DOI source content (the invariant).
+    assert!(
+        !out.machine_tier.contains("10.5555/dup.conflict"),
+        "machine tier must not carry any source node from the dup-DOI (fail-closed)"
+    );
+    assert!(
+        !out.machine_tier.contains("a pkg:Finding"),
+        "machine tier must not carry any Finding from the dup-DOI"
+    );
+    assert!(
+        !out.machine_tier.contains("sigimpl:justification"),
+        "machine tier must not carry any justification (abstract-derived text) from the dup-DOI"
+    );
+
+    // Restricted artifact MUST contain the full content (non-vacuousness).
+    assert!(
+        out.license_restricted_tier.contains("10.5555/dup.conflict"),
+        "restricted tier must carry the dup-DOI source"
+    );
+    assert!(
+        out.license_restricted_tier.contains("a pkg:Finding"),
+        "restricted tier must carry at least one Finding for the dup-DOI"
+    );
+    assert!(
+        out.license_restricted_tier.contains("sigimpl:justification"),
+        "restricted tier must carry the abstract-derived justification"
+    );
+
+    // Restricted public projection must carry the DOI metadata but NO abstract-derived text.
+    assert!(
+        out.restricted_public_projection.contains("10.5555/dup.conflict"),
+        "restricted public projection must carry the dup-DOI metadata"
+    );
+    assert!(
+        !out.restricted_public_projection.contains("sigimpl:justification"),
+        "projection must not carry abstract-derived text"
+    );
+    assert!(
+        !out.restricted_public_projection.contains("a pkg:Finding"),
+        "projection must not carry any Finding"
+    );
+
+    // The sidecar must account for all candidates (none silently dropped).
+    assert_eq!(
+        out.sidecar.grounded + out.sidecar.quarantined.len(),
+        out.sidecar.candidates_total,
+        "all candidates must be accounted for in the sidecar"
+    );
+}
+
 #[test]
 fn machine_and_restricted_full_tiers_conform_to_the_shacl_gate() {
     // The REAL path: each full tier artifact (machine + restricted) must independently

--- a/crates/sparq-kb/tests/literature_pipeline.rs
+++ b/crates/sparq-kb/tests/literature_pipeline.rs
@@ -15,10 +15,15 @@
 //! Run: `cargo test -p sparq-kb --features literature,validate -- --nocapture`
 #![cfg(all(feature = "literature", feature = "validate"))]
 
-use sparq_kb::literature::extract::RecordedExtractor;
-use sparq_kb::literature::{pipeline, FIXTURE_OPENALEX_BATCH, LITERATURE_SHAPES};
-use sparq_kb::validate::{graph_from_turtle_docs, validate_instances};
+use sparq_kb::literature::connector::SourceStub;
+use sparq_kb::literature::extract::{CandidateFinding, Extractor, RecordedExtractor};
+use sparq_kb::literature::pipeline::{self, BatchCompleteness, Tier, MACHINE_AGENT_IRI};
+use sparq_kb::literature::{FIXTURE_OPENALEX_BATCH, LITERATURE_SHAPES};
+use sparq_kb::validate::{graph_from_turtle_docs, parse_turtle, validate_instances};
+use sparq_kb::vocab::GRAPH_NS;
 use sparq_kb::{PKG_ONTOLOGY, PKG_SHAPES};
+
+use std::collections::HashSet;
 
 /// Validate a Turtle data document against BOTH the base PKG shapes and the literature-
 /// tier shapes (the real write-gate the design specifies). Returns conformance + the text
@@ -261,4 +266,230 @@ fn base_example_still_conforms_under_the_combined_shapes() {
     // (validate_instances uses only the base shapes; this asserts the ontology + base
     // shapes still load cleanly after the pkg.ttl MachineAgent addition.)
     assert!(report.conforms, "empty-instance base graph must conform");
+}
+
+// ===========================================================================
+// sq-tzars.7 — tier partition (hand-authored / machine / license-restricted)
+// [SONNET-4.6] 🤖 SPARQ agent — provenance-driven GenAI KB. Fail-closed license
+// routing; exactly one tier per emitted statement; metadata-only public projection.
+// ===========================================================================
+
+/// A grounding-guaranteed test extractor: for each stub it proposes one candidate whose
+/// justification is a span of that stub's abstract (a prefix, so it always grounds) and
+/// which cites the stub's own DOI (an in-batch Source). Lets a MIXED-licence batch exercise
+/// real routing of grounded findings — no live model, no committed tape.
+struct GroundingExtractor;
+impl Extractor for GroundingExtractor {
+    fn extract(&self, stubs: &[SourceStub]) -> Result<Vec<CandidateFinding>, String> {
+        Ok(stubs
+            .iter()
+            .map(|s| CandidateFinding {
+                source_doi: s.doi.clone(),
+                verdict: "yes".to_string(),
+                confidence: 0.6,
+                assurance: "Conjectured".to_string(),
+                justification: s.abstract_text.chars().take(48).collect(),
+                cited_dois: vec![s.doi.clone()],
+            })
+            .collect())
+    }
+}
+
+/// A mixed-licence batch: one `cc-by` (redistributable ⇒ machine tier) source and one
+/// unknown-licence (⇒ restricted tier) source, each with a groundable abstract.
+const MIXED_BATCH: &str = r#"{ "results": [
+  { "doi": "https://doi.org/10.5555/mixed.ccby",
+    "title": "An Open-Licensed Work on Parallel Scanning",
+    "abstract": "This open work reports a reproducible parallel-scanning result over graphs.",
+    "publication_year": 2024,
+    "primary_location": { "license": "cc-by" } },
+  { "doi": "https://doi.org/10.5555/mixed.unknown",
+    "title": "A Work With No Recorded Redistribution Licence",
+    "abstract": "This work has no redistribution licence recorded anywhere in its metadata.",
+    "publication_year": 2023 }
+] }"#;
+
+/// The N-Triples subject token of a serialized triple (`<iri>` or `_:b`), for disjointness
+/// checks without pulling `oxrdf` into the integration crate.
+fn subject_token(ntriple: &str) -> &str {
+    ntriple.split_whitespace().next().unwrap_or("")
+}
+
+fn ntriples_set(ttl: &str) -> HashSet<String> {
+    let base = "https://sparq.dev/ns/pkg/example#";
+    parse_turtle(ttl, base)
+        .expect("tier artifact parses")
+        .iter()
+        .map(|t| t.to_string())
+        .collect()
+}
+
+#[test]
+fn no_statement_is_emitted_into_more_than_one_tier() {
+    // The load-bearing partition invariant: no Source/Finding PAYLOAD triple appears in
+    // both the machine and the license-restricted artifacts. (Each artifact independently
+    // repeats the shared machine-agent declaration boilerplate so it stands alone; the
+    // tier-graph node subjects differ per tier, so only the agent decl can overlap — and
+    // that is asserted to be the ONLY overlap.)
+    let out = pipeline::run_tiered(
+        MIXED_BATCH,
+        &GroundingExtractor,
+        Some("2026-07-05T00:00:00Z".to_string()),
+        BatchCompleteness::Complete,
+    )
+    .expect("tiered run");
+
+    let machine = ntriples_set(&out.machine_tier);
+    let restricted = ntriples_set(&out.license_restricted_tier);
+    let agent_subject = format!("<{}>", MACHINE_AGENT_IRI);
+    let graph_prefix = format!("<{}", GRAPH_NS);
+
+    let shared: Vec<&String> = machine.intersection(&restricted).collect();
+    for line in &shared {
+        let subj = subject_token(line);
+        assert!(
+            subj == agent_subject || subj.starts_with(&graph_prefix),
+            "machine and restricted tiers share a PAYLOAD statement (not boilerplate): {}",
+            line
+        );
+    }
+
+    // Non-vacuous: each tier really does carry its own source's finding, and NOT the other's.
+    assert!(out.machine_tier.contains("10.5555/mixed.ccby"));
+    assert!(!out.machine_tier.contains("10.5555/mixed.unknown"));
+    assert!(out.license_restricted_tier.contains("10.5555/mixed.unknown"));
+    assert!(!out.license_restricted_tier.contains("10.5555/mixed.ccby"));
+    // Each tier carries exactly one grounded finding here.
+    assert_eq!(out.machine_tier.matches("a pkg:Finding").count(), 1);
+    assert_eq!(out.license_restricted_tier.matches("a pkg:Finding").count(), 1);
+}
+
+#[test]
+fn unknown_licence_source_findings_land_restricted_only() {
+    // Negative test (REQUIRED): the committed fixture carries NO licence metadata, so every
+    // source is fail-closed to the restricted tier. Its findings must appear ONLY in the
+    // restricted artifact, never in the (publishable) machine artifact.
+    let out = pipeline::run_tiered(
+        FIXTURE_OPENALEX_BATCH,
+        &RecordedExtractor::from_fixture().unwrap(),
+        Some("2026-07-05T00:00:00Z".to_string()),
+        BatchCompleteness::Complete,
+    )
+    .expect("tiered run");
+
+    // Every source routes restricted ⇒ machine tier holds zero findings and zero sources.
+    assert!(!out.machine_tier.contains("a pkg:Finding"));
+    assert!(!out.machine_tier.contains("a pkg:Source"));
+    // All four grounded findings are in the restricted tier.
+    assert_eq!(out.license_restricted_tier.matches("a pkg:Finding").count(), 4);
+    assert!(out.license_restricted_tier.contains("a pkg:Source"));
+    // The classifier agrees on the None-licence fixture sources.
+    assert_eq!(pipeline::source_tier(None), Tier::LicenseRestricted);
+}
+
+#[test]
+fn restricted_public_projection_carries_no_abstract_derived_text() {
+    // The metadata-only public projection must exclude ALL abstract-derived text — no
+    // justification (a span of the abstract), no dcterms:abstract, no pkg:Finding — while
+    // still carrying the source metadata (title + licence status).
+    let out = pipeline::run_tiered(
+        FIXTURE_OPENALEX_BATCH,
+        &RecordedExtractor::from_fixture().unwrap(),
+        Some("2026-07-05T00:00:00Z".to_string()),
+        BatchCompleteness::Complete,
+    )
+    .expect("tiered run");
+
+    let proj = &out.restricted_public_projection;
+    // Non-vacuous baseline: the FULL restricted artifact DOES carry the abstract-derived
+    // justification text, so the projection genuinely stripped it (not merely empty).
+    assert!(
+        out.license_restricted_tier.contains("sigimpl:justification"),
+        "restricted FULL tier must carry the justification (else the test is vacuous)"
+    );
+    assert!(out.license_restricted_tier.contains("We present a chunk-parallel"));
+
+    // The projection carries NONE of it.
+    assert!(!proj.contains("sigimpl:justification"), "projection leaks a justification");
+    assert!(!proj.contains("dcterms:abstract"), "projection leaks an abstract");
+    assert!(!proj.contains("a pkg:Finding"), "projection leaks a Finding");
+    assert!(!proj.contains("We present a chunk-parallel"), "projection leaks abstract text");
+    assert!(!proj.contains("prov:wasGeneratedBy"), "projection leaks finding provenance");
+
+    // But it DOES carry the permitted source metadata + licence status.
+    assert!(proj.contains("Chunk-Parallel Scanning of Line-Delimited RDF"));
+    assert!(proj.contains("dcterms:license \"unknown\""));
+    assert!(proj.contains("a pkg:Source"));
+    // The projection is valid, parseable Turtle.
+    assert!(parse_turtle(proj, "https://sparq.dev/ns/pkg/example#").is_ok());
+}
+
+#[test]
+fn cap_truncated_batch_is_marked_incomplete_in_every_artifact() {
+    // Truncation invariant (the #1527 consumer note): if the input batch was cut short by a
+    // pagination hard cap, EVERY emitted artifact must carry an explicit incompleteness
+    // marker and never be presented as complete.
+    let truncated = BatchCompleteness::from_pagination(20, 20);
+    assert!(!truncated.is_complete());
+    let out = pipeline::run_tiered(
+        FIXTURE_OPENALEX_BATCH,
+        &RecordedExtractor::from_fixture().unwrap(),
+        Some("2026-07-05T00:00:00Z".to_string()),
+        truncated,
+    )
+    .expect("tiered run");
+
+    for (name, art) in [
+        ("machine", &out.machine_tier),
+        ("restricted", &out.license_restricted_tier),
+        ("projection", &out.restricted_public_projection),
+    ] {
+        assert!(
+            art.contains("INCOMPLETE") && art.contains("cap-truncated"),
+            "{} artifact must carry the incompleteness marker",
+            name
+        );
+        assert!(
+            art.contains("rdfs:comment"),
+            "{} artifact must carry a machine-readable incompleteness marker",
+            name
+        );
+        // Still valid Turtle (the banner is a comment; the marker is an rdfs:comment).
+        assert!(
+            parse_turtle(art, "https://sparq.dev/ns/pkg/example#").is_ok(),
+            "{} artifact must remain parseable Turtle",
+            name
+        );
+    }
+
+    // A COMPLETE run carries NO marker.
+    let complete = pipeline::run_tiered(
+        FIXTURE_OPENALEX_BATCH,
+        &RecordedExtractor::from_fixture().unwrap(),
+        Some("2026-07-05T00:00:00Z".to_string()),
+        BatchCompleteness::Complete,
+    )
+    .expect("tiered run");
+    assert!(!complete.machine_tier.contains("INCOMPLETE"));
+    assert!(!complete.license_restricted_tier.contains("INCOMPLETE"));
+    assert!(!complete.restricted_public_projection.contains("INCOMPLETE"));
+}
+
+#[test]
+fn machine_and_restricted_full_tiers_conform_to_the_shacl_gate() {
+    // The REAL path: each full tier artifact (machine + restricted) must independently
+    // conform to pkg.shapes.ttl + literature.shapes.ttl — the tier split must not produce a
+    // non-conformant graph.
+    let out = pipeline::run_tiered(
+        MIXED_BATCH,
+        &GroundingExtractor,
+        Some("2026-07-05T00:00:00Z".to_string()),
+        BatchCompleteness::Complete,
+    )
+    .expect("tiered run");
+
+    let (m_conforms, m_report) = gate(&out.machine_tier);
+    assert!(m_conforms, "machine-tier artifact must conform:\n{m_report}");
+    let (r_conforms, r_report) = gate(&out.license_restricted_tier);
+    assert!(r_conforms, "restricted-tier artifact must conform:\n{r_report}");
 }


### PR DESCRIPTION
> 🤖 **SPARQ agent** [SONNET-4.6] — provenance-driven GenAI KB. Implements bead
> `sq-tzars.7` (epic `sq-tzars`): partition the machine-pipeline KB emission into the
> named tiers of `research/research-kb-program.md` §(tier partition), with **fail-closed**
> licence routing. Tier separation **v1 = per-tier Turtle ARTIFACTS**, NOT in-store named
> graphs (the design-record decision; in-store named-graph separation stays future work and
> is *not* claimed here).

## What this implements

- **`src/vocab.rs`** — the tier named-graph IRI constants `TIER_{HAND_AUTHORED,MACHINE,LICENSE_RESTRICTED}_GRAPH`
  in the `pkg/graph#` sub-namespace (mirroring the existing `pkg/agent#` / `pkg/kb#`), plus a
  byte-pin test. These are **graph identifiers, not `pkg:` vocabulary terms**, so they are
  deliberately kept OUT of the `pkg.ttl`-pinned `ALL` set (asserted by the pin test) — the
  existing `ttl_pins_match_rust_constants` gate is untouched and stays green.
- **`src/literature/pipeline.rs`** — new public surface:
  - `Tier` (+ `graph_iri`) and `source_tier(license)` — **fail-closed** routing: unknown /
    absent / blank / non-allowlist licence ⇒ `LicenseRestricted`; only a conservative
    redistributable allowlist (`cc-by`, `cc-by-sa`, `cc0`, public-domain) ⇒ `Machine`.
  - `BatchCompleteness` (+ `from_pagination`) — honours the **#1527 consumer note**: a paged
    connector run whose `pages_fetched` reached `max_pages` is `CapTruncated`, and every
    emitted artifact then carries an explicit incompleteness marker.
  - `run_tiered(...)` → `TieredOutput` with the machine-tier artifact, the (private)
    license-restricted artifact, and a **metadata-only public projection** (source IRI/DOI +
    title + year + licence status; **no `sigimpl:justification`, no `dcterms:abstract`, no
    `pkg:Finding`**). Finding IRIs use a stable global counter, so the machine and restricted
    artifacts **never share a Finding IRI** — exactly one tier per emitted finding.
  - The pre-existing combined `run` / `run_with_time` / `PipelineOutput.turtle` are
    **byte-for-byte unchanged** (the emit logic was factored into shared write helpers used by
    both paths; the existing SHACL-conformance + cap tests still pass).
- **`ingest/ingest_pkg.py` + `ingest/pkg-instances.ttl`** — the projector now stamps its
  output with the **hand-authored** tier graph IRI (a single untyped node, not targeted by any
  SHACL shape → the 0-violation conformance is preserved: `ingested_graph_conforms_zero_violations`
  stays green). The committed `pkg-instances.ttl` received only the stamp block (a full
  regeneration would also sweep in unrelated skill-front-matter drift, which the per-merge
  ingest CI `sq-tzars.4` owns — see *Scope note*).

## Invariants (all non-vacuously tested, `--features literature,validate`)

| Invariant | Test |
|---|---|
| exactly one tier per emitted statement | `no_statement_is_emitted_into_more_than_one_tier` (parses both artifacts, asserts payload-triple sets disjoint modulo shared boilerplate) |
| unknown licence ⇒ restricted (negative) | `unknown_licence_source_findings_land_restricted_only` (the None-licence fixture: machine tier gets 0 findings) |
| metadata-only projection has no abstract-derived text | `restricted_public_projection_carries_no_abstract_derived_text` (justification present in the FULL tier, absent from the projection) |
| cap-truncated batch marked incomplete | `cap_truncated_batch_is_marked_incomplete_in_every_artifact` |
| tier split stays SHACL-conformant | `machine_and_restricted_full_tiers_conform_to_the_shacl_gate` |

## Gates run (both feature states)

- `cargo clippy -p sparq-kb --all-targets -- -D warnings` — **default (feature OFF)** and
  `--features literature,validate,query,close` — clean.
- `cargo build` / `cargo test -p sparq-kb` default + `--features literature,validate` — green
  (37 lib + 12 integration tests).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.
- `python3 scripts/check-readme-template.py --enforce` → 0 deviations; README ≤ 120 lines.
- **Smoke run:** `ingest_pkg.py` runs green (tasks=1258, 0 SHACL violations) and its stamped
  output matches the committed `pkg-instances.ttl` modulo the pre-existing skill drift.

## Scope / coordination notes

- **Sibling `sq-tzars.6` collision avoidance:** this PR does **not** touch
  `extract*`/`connector*`/`literature.rs` module wiring (that sibling owns `extract_live`
  right now). All changes are in `vocab.rs`, `pipeline.rs`, `ingest_pkg.py`, `pkg-instances.ttl`,
  the test file, and the README.
- **Licence allowlist** is a deliberately conservative, maintainer-tunable policy (proceed-and-document);
  the *load-bearing* invariant (unknown ⇒ restricted) holds regardless of allowlist membership.
- **Not armed** (per the dispatch brief) — leaving for review + the escalation queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
