### PR TITLE
ci(inference): run the dl-direct ratchet lane --release — L4 tableau is impractically slow in debug (sq-25q5q)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2125,9 +2125,20 @@ jobs:
         # consts. HONESTLY sparq-EXTENSION ratchets over the SCOPED FRAGMENT the
         # layered checker implements — NOT full OWL 2 DL, never summed into a
         # conformance number. `--nocapture` so the ratchet lines reach stdout.
+        # [SONNET-4.6] sq-25q5q: run this lane `--release`. The sparq-reason-dl L4
+        # tableau does a per-rule-application O(nodes×labels) rescan (a pre-existing
+        # property found during sq-pbz04.4.5), so the DEBUG test-RUNTIME dominated the
+        # whole inference-conformance job (~9 min of an ~11 min job in CI history vs
+        # seconds for every sibling lane). `--release` collapses that runtime; the one-
+        # time optimized compile of sparq-reason-dl + the dl_suite harness is amortized
+        # by the Swatinem release cache (the `Run inference suites` step above already
+        # warms the release profile via `cargo run --release`). COVERAGE IS UNCHANGED:
+        # same test target, same `dl-direct` feature, same EXACT `==` pins (68 profile /
+        # 184 direct) asserted in-runner and re-grepped from source — only the codegen
+        # optimization level changes, never the assertions or the fail-closed behavior.
         run: |
           set -uo pipefail
-          cargo test -p sparq-conformance --features dl-direct --test dl_suite -- --nocapture \
+          cargo test --release -p sparq-conformance --features dl-direct --test dl_suite -- --nocapture \
             | tee dl-direct-conformance.out
           rc=${PIPESTATUS[0]}
           [ "$rc" -eq 0 ] || { echo "::error::OWL 2 Direct-Semantics arm test failed (exit $rc)"; exit "$rc"; }


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI/release/supply-chain lane. I am an automated agent working on `jeswr/sparq` infrastructure. This PR was authored by an agent (Opus 4.8 acting on the Sonnet-tier bead sq-25q5q); please review before merge.

## What & why (sq-25q5q)

The `inference-conformance` job's **OWL 2 Direct-Semantics arm** ran its ratchet test in **DEBUG**:

```
cargo test -p sparq-conformance --features dl-direct --test dl_suite -- --nocapture
```

The `sparq-reason-dl` **L4 tableau** does a per-rule-application `O(nodes×labels)` rescan (a pre-existing property found during sq-pbz04.4.5). In an unoptimized build the test **runtime** — not the build — dominates the whole job.

**Fix (minimal):** add `--release` to that one lane's `cargo test`. No test-source change; no `#[ignore]` split needed.

## Before / after (ESTIMATE from CI history — not a fabricated benchmark)

Authoritative "before" from CI run `28730417153` (a `rust_changed` run of this job), step timings:

| step | wall time |
|---|---|
| Run inference suites (`cargo run --release` binary) | ~65s |
| D-entailment lane | 17s |
| RIF-Core lane | 4s |
| OWL 2 EL lane | 4s |
| OWL 2 QL lanes | 3s |
| **Run OWL 2 Direct-Semantics arm (dl-direct, DEBUG)** | **~9m10s** |
| **whole job** | **~11m** |

The dl-direct step alone was ~9m of the ~11m job; every sibling lane is seconds.

**After (estimate):** the release compile of `sparq-reason-dl` + the `dl_suite` harness is a one-time cost amortized by the Swatinem release cache (the "Run inference suites" step already warms the release profile via `cargo run --release`); the optimized tableau runtime collapses. Expected dl-direct step ≈ **1–2 min cold** (release compile of the dl-direct feature + run) and less on a warm cache → whole job ≈ **3–4 min**. Exact figures **will be confirmed on the first CI run** of this branch.

### Local reproduction (work-box timings — NON-canonical, per project convention)

Ran the shipped `--release` command against the pinned OWL WG export:

```
release compile (cold)  66s
release run             43s   rc=0
  OWL 2 DL profile-identification ratchet pass 68 of 538 (floor 68)
  OWL 2 DL direct ratchet pass 184 of 704 (floor 184)
  test result: ok. 2 passed; 0 failed
```

For reference, the same test's **debug run** on this box exceeded 16 min before I stopped it — consistent with the bead's "impractically slow in debug" and with CI's ~9m. (Work-box is a contended EC2 host; these numbers are indicative only — CI history above is the authoritative basis.)

## Coverage is preserved (fail-closed unchanged)

- Same test target (`dl_suite`), same `--features dl-direct`, same 2 tests run — only the codegen optimization level changes.
- The two **EXACT `==` pins** are still asserted in-runner (`crates/sparq-conformance/tests/dl_suite.rs`): `report.profile.pass == DL_PROFILE_FLOOR` (**68**) and `report.reasoning_pass() == DL_DIRECT_FLOOR` (**184**) — abstention-inflation *and* regression both go red.
- The divergence **set-equality** assertions (`reasoning_fails == pinned`, `profile_fails == pinned`) are unchanged.
- The workflow still re-greps `DL_PROFILE_FLOOR`/`DL_DIRECT_FLOOR` from source and re-checks the printed pass counts (`awk '{print $7}'` → 68 / 184), so a drift still fails CI. `--release` changes none of this.

## Gates

- `python3 -c "import yaml; yaml.safe_load(...)"` on `ci.yml` → **OK**.
- `actionlint .github/workflows/ci.yml` → **exit 0** (only pre-existing info-level SC2015 notes on the unchanged `[ ] && [ ] || { exit 1; }` floor-assertion idiom, flagged identically across the file; my change adds none).
- Gate aggregator: the job name `Inference conformance (ratchet >= 1967 pass+divergence)` contains no `advisory`/`informational` token, and its `needs`/`if:` (rust path-filter + selection) are untouched — **this leg still gates**.
- Actions remain SHA-pinned (no action added/changed).
- Did **not** touch `kani.yml` (PR #1524) or `pkg-ingest.yml` (PR #1539). No `crates/` source change.

## Compliance gap closed

Makes the OWL 2 DL Direct-Semantics conformance ratchet **practical to keep enabled in CI** without shrinking coverage — the ratchet stays fail-closed at the pinned 68/184 floors, at a reasonable wall time.
