### PR TITLE
fix(vectors/kani): raise open_validated_v2_tail_never_panics unwind bound + domain self-check (sq-gnvfc)

### DIFF
--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -1135,7 +1135,12 @@ mod kani_proofs {
     /// shrinks the symbolic surface so Kani spends its budget on the arithmetic/loop logic
     /// (the part the corpus is least likely to have exhausted) rather than on the magic byte.
     #[kani::proof]
-    #[kani::unwind(40)]
+    // [OPUS-4.8] (sq-gnvfc) The harness buffer is HEADER_LEN + 16 = 72 concrete bytes. The
+    // setup loop `bytes[8..].iter_mut()` runs 64 iterations, and every other per-element pass
+    // over the full 72-byte buffer (aligned copy, the fingerprint scan, the index loop) needs
+    // at most 72 steps; 73 > 72 bounds them all. The old bound of 40 < 64 fired an unwinding
+    // assertion (an INCOMPLETE proof, not a counterexample) on the setup loop.
+    #[kani::unwind(73)]
     fn open_validated_v2_tail_never_panics() {
         let mut bytes = vec![0u8; HEADER_LEN + 16];
         bytes[0..4].copy_from_slice(&SPQV_MAGIC);
@@ -1177,6 +1182,20 @@ mod kani_proofs {
     //   reject-only. [OPUS-4.8] sq-og8u8
     const _DOMAIN_ADMITS_A_WELL_FORMED_STORE: () =
         assert!(MAX_LEN >= HEADER_LEN, "the fuzzed domain must contain a minimal valid store");
+
+    // DOMAIN-COVERAGE SELF-CHECK for the v2-tail harness (sq-og8u8 anti-vacuity pattern): the
+    // focused `open_validated_v2_tail_never_panics` harness fixes a 72-byte (HEADER_LEN + 16)
+    // buffer with the magic + version-2 prefix. Its interesting tail is the index-validation
+    // loop (`for i in 0..count`), which is only reached when count >= 1 — a bound or budget that
+    // silently forced count = 0 would make the harness pass VACUOUSLY over the reject/skip path.
+    // With version 2 (data_offset = HEADER_LEN) the body budget is HEADER_LEN + 16 - HEADER_LEN =
+    // 16 bytes; a minimal 1-entry dim=1 store needs count*dim*4 + count*8 = 1*4 + 8 = 12 <= 16. ✓
+    // Its runtime companion `v2_tail_domain_admits_an_indexed_store` (in `fingerprint_tests`)
+    // proves a concrete such buffer validates `Ok`. [OPUS-4.8] sq-gnvfc
+    const _V2_TAIL_DOMAIN_ADMITS_AN_INDEXED_STORE: () = assert!(
+        HEADER_LEN + 16 >= HEADER_LEN + 4 + 8,
+        "v2-tail harness domain must fit >= 1 index entry (dim=1 count=1: 4-byte vector + 8-byte slot)"
+    );
 }
 
 #[cfg(test)]
@@ -1256,6 +1275,46 @@ mod fingerprint_tests {
             .expect("a minimal well-formed v2 store must validate — else the accept path is vacuous");
         assert_eq!(store.dim(), 1);
         assert!(store.fingerprint().is_none(), "all-zero fingerprint decodes to None");
+    }
+
+    /// DOMAIN-COVERAGE SELF-CHECK for the v2-tail harness (sq-og8u8 anti-vacuity pattern,
+    /// sq-gnvfc — companion to the compile-time `_V2_TAIL_DOMAIN_ADMITS_AN_INDEXED_STORE`
+    /// const in `kani_proofs`). Proves a concrete 72-byte buffer in the
+    /// `open_validated_v2_tail_never_panics` harness's domain (the magic + version-2 prefix,
+    /// count = 1, dim = 2) validates `Ok` — so the index-validation loop `for i in 0..count`
+    /// runs exactly once. This confirms the focused harness genuinely covers the indexed-store
+    /// path, not only the size-mismatch / bad-index reject branches. [OPUS-4.8] sq-gnvfc
+    #[test]
+    fn v2_tail_domain_admits_an_indexed_store() {
+        // Buffer layout for a valid v2 store with dim = 2, count = 1:
+        //   [0..4]   SPQV_MAGIC
+        //   [4..8]   version = 2 (LE u32)
+        //   [8..12]  dim = 2 (LE u32)
+        //   [12..20] count = 1 (LE u64)
+        //   [20..32] reserved (zeros) — fills the rest of HEADER_LEN_V1 (32 bytes)
+        //   [32..56] fingerprint block (all-zero = no fingerprint, still a valid v2) — HEADER_LEN
+        //   [56..64] vector data: one dim=2 f32 vector (2 * 4 = 8 bytes)
+        //   [64..72] index: one entry — id = 1 (u32 LE) + slot = 0 (u32 LE) = 8 bytes
+        //   total = 72 bytes = HEADER_LEN + 16
+        let mut bytes = vec![0u8; HEADER_LEN + 16];
+        assert_eq!(bytes.len(), 72, "buffer must be HEADER_LEN + 16 = 72 bytes");
+        bytes[0..4].copy_from_slice(&SPQV_MAGIC);
+        bytes[4..8].copy_from_slice(&2u32.to_le_bytes()); // version 2
+        bytes[8..12].copy_from_slice(&2u32.to_le_bytes()); // dim = 2
+        bytes[12..20].copy_from_slice(&1u64.to_le_bytes()); // count = 1
+        // fingerprint block [32..56] stays all-zero (valid: no fingerprint).
+        // vector data [56..64]: f32 values [1.0, 0.0] in LE.
+        bytes[56..60].copy_from_slice(&1.0f32.to_le_bytes());
+        bytes[60..64].copy_from_slice(&0.0f32.to_le_bytes());
+        // index [64..72]: entry 0 — id = 1 (u32 LE), slot = 0 (u32 LE).
+        bytes[64..68].copy_from_slice(&1u32.to_le_bytes()); // id = 1
+        bytes[68..72].copy_from_slice(&0u32.to_le_bytes()); // slot = 0
+        let store = VectorStore::open_from_bytes(bytes).expect(
+            "72-byte v2 store with dim=2 count=1 must validate — the index loop must be reachable \
+             in the focused harness domain",
+        );
+        assert_eq!(store.dim(), 2);
+        assert!(store.fingerprint().is_none(), "all-zero fingerprint block decodes to None");
     }
 
     #[test]


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing bead sq-gnvfc (raise Kani unwind bound + sq-og8u8 anti-vacuity self-check). [OPUS-4.8]

## Problem

`open_validated_v2_tail_never_panics` (in `crates/sparq-vectors/src/store.rs`, `#[cfg(kani)] mod kani_proofs`) had `#[kani::unwind(40)]` but its harness setup loop `bytes[8..].iter_mut()` runs over a concrete `HEADER_LEN + 16 = 72`-byte buffer = **64 iterations** — exceeding the bound, so CBMC's unwinding assertion fires. That is an **incomplete proof**, not a counterexample.

## Root-cause analysis

- Buffer: `HEADER_LEN + 16 = 56 + 16 = 72` bytes (concrete, only `dim`/`count`/tail bytes symbolic)
- Setup loop `bytes[8..].iter_mut()` = `72 - 8 = 64` iterations
- Bound `40 < 64` → CBMC unwinding assertion fires

## Fix

Raise `#[kani::unwind(40)] → #[kani::unwind(73)]` for `open_validated_v2_tail_never_panics`. Justification: `73 = buffer_len + 1 = 72 + 1`. Every per-element loop over the 72-byte harness buffer — the setup loop, the `AlignedBytes` aligned copy, the `memchr` inside the error `format!`, and the index-validation loop — needs at most 72 iterations, so 73 covers them all without overreach. The only symbolic loop count (`for i in 0..count`) is bounded to `count ∈ {0, 1}` because the exact-size check `map.len() != expect` rejects unless `count·(dim·4 + 8) = 16`, i.e. `count = 1, dim = 2` (or `count = 0`).

## Domain self-check (sq-og8u8 anti-vacuity pattern)

The existing self-checks cover the *first* harness (`open_from_bytes_never_panics`, `MAX_LEN` domain). This focused v2-tail harness needs its own anti-vacuity proof so the fix doesn't leave the harness passing over reject-only paths:

- **Part 1 (compile-time const in `kani_proofs`):** `_V2_TAIL_DOMAIN_ADMITS_AN_INDEXED_STORE` — asserts `HEADER_LEN + 16 ≥ HEADER_LEN + 4 + 8`, i.e. the 72-byte domain can hold a v2 store with ≥ 1 index entry, so the index-validation loop `for i in 0..count` is reachable (not forced to `count = 0`).
- **Part 2 (runtime test in `fingerprint_tests`):** `v2_tail_domain_admits_an_indexed_store` — opens a concrete 72-byte v2 buffer (`dim = 2`, `count = 1`, one index entry) and verifies it validates `Ok`; the index loop runs exactly once, so the harness's proof is not vacuously reject-only.

## Verification

- `cargo test -p sparq-vectors` (default features) → green, including both domain self-checks
- `cargo test -p sparq-vectors --no-default-features` → green
- `cargo clippy --all-targets -p sparq-vectors -- -D warnings` (default **and** `--no-default-features`) → clean
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-vectors --no-deps --all-features` → clean
- Kani **reproduction** (bound 40, unmodified): `VERIFICATION: FAILED` — `unwinding assertion loop 0` at the setup loop, confirming the exact bug.
- Kani **fixed harness** (bound 73): the local CBMC solve was progressing normally (unwinding the per-element loops within bound, pruning infeasible alloc-error paths, **no counterexample, no failure**) but exceeds practical local runtime (> 20 min) — the exact behavior this harness's own doc comment documents: these totality proofs go over the per-harness budget and are **"VALIDATED ON THE FIRST CI RUN of the kani lane."** The **CI Kani lane is the authoritative validator** and will confirm `VERIFICATION SUCCESSFUL`.

Feature flags: the change lives entirely in `#[cfg(kani)]` + `#[cfg(test)]` modules and is not feature-gated; `default = []`, so default and `--no-default-features` are the meaningful states, both green.

## Do not arm

Proof-program surface + the fixed harness's authoritative confirmation is the CI Kani lane — **do not auto-arm**; leave for CI Kani + maintainer review.

Closes bead sq-gnvfc.