### PR TITLE
test(zk/xpath): real test vectors for 7 placeholder packages + op:NOTATION-equal impl (sq-rcpdz)

### DIFF
--- a/.github/workflows/zk-toolchain.yml
+++ b/.github/workflows/zk-toolchain.yml
@@ -589,20 +589,7 @@ jobs:
           # with a ::warning annotation rather than masking them silently.  Remove an
           # entry here once the corresponding bead is closed and the tests pass.
           #
-          # sq-rcpdz -- fn:contains / fn:ends-with / fn:starts-with / fn:string-length /
-          #            op:NOTATION-equal / op:add-dayTimeDuration-to-dateTime /
-          #            op:subtract-dayTimeDuration-from-dateTime: auto-generated packages
-          #            have a single assert(false) placeholder because no qt3tests
-          #            cases could be converted; real test vectors needed.
-          KNOWN_FAILING=(
-            "xpath_test_fncontains"
-            "xpath_test_fnends_with"
-            "xpath_test_fnstarts_with"
-            "xpath_test_fnstring_length"
-            "xpath_test_opadd_daytimeduration_to_datetime"
-            "xpath_test_opnotation_equal"
-            "xpath_test_opsubtract_daytimeduration_from_datetime"
-          )
+          KNOWN_FAILING=()
           # Partition pass: count real vs stub-wired packages.
           # A package is a stub if any .nr file in its src/ contains 'stub_' (stub-prefixed
           # imports, assert(false) bodies) OR the generated-placeholder marker

--- a/zk/xpath/test_packages/xpath_test_fncontains/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_fncontains/src/chunk_0.nr
@@ -1,8 +1,98 @@
-//! Test chunk 0 for fn:contains
-//! Contains 1 tests
+//! Real test vectors for fn:contains (F&O sec. 7.5.3)
+//! Python oracle: str.__contains__; "" in x is always True; NUL padding = logical terminator.
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::contains;
 
 #[test]
-fn fncontains_no_converted_tests() {
-    // Placeholder: 68 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for fn:contains");
+fn fncontains_tattoo_tat() {
+    // Python: "tat" in "tattoo" -> True
+    let s: str<6> = "tattoo";
+    let n: str<3> = "tat";
+    assert(contains::<6, 3>(s, n));
+}
+
+#[test]
+fn fncontains_tattoo_tow_false() {
+    // Python: "tow" in "tattoo" -> False
+    let s: str<6> = "tattoo";
+    let n: str<3> = "tow";
+    assert(!contains::<6, 3>(s, n));
+}
+
+#[test]
+fn fncontains_any_empty_needle() {
+    // F&O sec.7.5.3: fn:contains($arg1, "") = true for any $arg1
+    // Python: "" in "tattoo" -> True
+    let s: str<6> = "tattoo";
+    let n: str<0> = "";
+    assert(contains::<6, 0>(s, n));
+}
+
+#[test]
+fn fncontains_empty_both() {
+    // Python: "" in "" -> True
+    let s: str<0> = "";
+    let n: str<0> = "";
+    assert(contains::<0, 0>(s, n));
+}
+
+#[test]
+fn fncontains_empty_haystack_nonempty_needle() {
+    // Python: "x" in "" -> False
+    let s: str<1> = "\0";
+    let n: str<1> = "x";
+    assert(!contains::<1, 1>(s, n));
+}
+
+#[test]
+fn fncontains_padded_needle_midstring() {
+    // Python: "ell" in "hello" -> True; needle "ell" in str<6> (NUL-padded)
+    // Logical-length semantics: NUL padding is not content.
+    let s: str<5> = "hello";
+    let n: str<6> = "ell\0\0\0";
+    assert(contains::<5, 6>(s, n));
+}
+
+#[test]
+fn fncontains_needle_equals_haystack() {
+    // Python: "hello" in "hello" -> True (exact match)
+    let s: str<5> = "hello";
+    let n: str<5> = "hello";
+    assert(contains::<5, 5>(s, n));
+}
+
+#[test]
+fn fncontains_needle_longer_than_haystack() {
+    // Python: "hello world" in "hello" -> False
+    let s: str<5> = "hello";
+    let n: str<5> = "world";
+    assert(!contains::<5, 5>(s, n));
+}
+
+#[test]
+fn fncontains_at_start_of_full_buffer() {
+    // Full-buffer: haystack fills capacity, needle at start.
+    // Python: "abc" in "abcdefgh" -> True
+    let s: str<8> = "abcdefgh";
+    let n: str<3> = "abc";
+    assert(contains::<8, 3>(s, n));
+}
+
+#[test]
+fn fncontains_at_end_of_full_buffer() {
+    // Full-buffer: haystack fills capacity, needle at end.
+    // Python: "fgh" in "abcdefgh" -> True
+    let s: str<8> = "abcdefgh";
+    let n: str<3> = "fgh";
+    assert(contains::<8, 3>(s, n));
+}
+
+#[test]
+fn fncontains_logically_empty_haystack() {
+    // Haystack has capacity but logical content is empty (all NUL).
+    // Python: "" in "" -> True (empty needle), "x" in "" -> False.
+    let s: str<4> = "\0\0\0\0";
+    let n_empty: str<0> = "";
+    assert(contains::<4, 0>(s, n_empty));
 }

--- a/zk/xpath/test_packages/xpath_test_fnends_with/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_fnends_with/src/chunk_0.nr
@@ -1,8 +1,89 @@
-//! Test chunk 0 for fn:ends-with
-//! Contains 1 tests
+//! Real test vectors for fn:ends-with (F&O sec. 7.5.2)
+//! Python oracle: str.endswith; empty suffix always matches.
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::ends_with;
 
 #[test]
-fn fnends_with_no_converted_tests() {
-    // Placeholder: 49 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for fn:ends-with");
+fn fnends_with_tattoo_oo() {
+    // Python: "tattoo".endswith("oo") -> True
+    let s: str<6> = "tattoo";
+    let suf: str<2> = "oo";
+    assert(ends_with::<6, 2>(s, suf));
+}
+
+#[test]
+fn fnends_with_tattoo_ta_false() {
+    // Python: "tattoo".endswith("ta") -> False (prefix, not suffix)
+    let s: str<6> = "tattoo";
+    let suf: str<2> = "ta";
+    assert(!ends_with::<6, 2>(s, suf));
+}
+
+#[test]
+fn fnends_with_tattoo_tattoo() {
+    // Python: "tattoo".endswith("tattoo") -> True (full string suffix)
+    let s: str<6> = "tattoo";
+    let suf: str<6> = "tattoo";
+    assert(ends_with::<6, 6>(s, suf));
+}
+
+#[test]
+fn fnends_with_empty_suffix() {
+    // F&O sec.7.5.2: fn:ends-with($arg1, "") = true for any $arg1
+    // Python: "tattoo".endswith("") -> True
+    let s: str<6> = "tattoo";
+    let suf: str<0> = "";
+    assert(ends_with::<6, 0>(s, suf));
+}
+
+#[test]
+fn fnends_with_empty_both() {
+    // Python: "".endswith("") -> True
+    let s: str<0> = "";
+    let suf: str<0> = "";
+    assert(ends_with::<0, 0>(s, suf));
+}
+
+#[test]
+fn fnends_with_empty_haystack_nonempty_suffix() {
+    // Python: "".endswith("x") -> False
+    let s: str<1> = "\0";
+    let suf: str<1> = "x";
+    assert(!ends_with::<1, 1>(s, suf));
+}
+
+#[test]
+fn fnends_with_suffix_longer_than_haystack() {
+    // Python: "lo".endswith("hello") -> False
+    let s: str<2> = "lo";
+    let suf: str<5> = "hello";
+    assert(!ends_with::<2, 5>(s, suf));
+}
+
+#[test]
+fn fnends_with_nul_padded_haystack_logical_length() {
+    // "hello" stored in str<10>; logical end is after 'o', not at capacity.
+    // Python: "hello".endswith("lo") -> True
+    let s: str<10> = "hello\0\0\0\0\0";
+    let suf: str<2> = "lo";
+    assert(ends_with::<10, 2>(s, suf));
+}
+
+#[test]
+fn fnends_with_nul_padded_suffix() {
+    // Suffix "lo" stored in str<5> (NUL-padded); logical suffix length=2.
+    // Python: "hello".endswith("lo") -> True
+    let s: str<5> = "hello";
+    let suf: str<5> = "lo\0\0\0";
+    assert(ends_with::<5, 5>(s, suf));
+}
+
+#[test]
+fn fnends_with_full_buffer() {
+    // Full-buffer haystack, suffix at end.
+    // Python: "abcdefgh".endswith("fgh") -> True
+    let s: str<8> = "abcdefgh";
+    let suf: str<3> = "fgh";
+    assert(ends_with::<8, 3>(s, suf));
 }

--- a/zk/xpath/test_packages/xpath_test_fnstarts_with/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_fnstarts_with/src/chunk_0.nr
@@ -1,8 +1,89 @@
-//! Test chunk 0 for fn:starts-with
-//! Contains 1 tests
+//! Real test vectors for fn:starts-with (F&O sec. 7.5.1)
+//! Python oracle: str.startswith; empty prefix always matches.
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::starts_with;
 
 #[test]
-fn fnstarts_with_no_converted_tests() {
-    // Placeholder: 58 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for fn:starts-with");
+fn fnstarts_with_tattoo_tat() {
+    // Python: "tattoo".startswith("tat") -> True
+    let s: str<6> = "tattoo";
+    let pfx: str<3> = "tat";
+    assert(starts_with::<6, 3>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_tattoo_tow_false() {
+    // Python: "tattoo".startswith("tow") -> False
+    let s: str<6> = "tattoo";
+    let pfx: str<3> = "tow";
+    assert(!starts_with::<6, 3>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_tattoo_full() {
+    // Python: "tattoo".startswith("tattoo") -> True (full match)
+    let s: str<6> = "tattoo";
+    let pfx: str<6> = "tattoo";
+    assert(starts_with::<6, 6>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_tattoo_too_long_false() {
+    // Python: "tattoo".startswith("tattoox") -> False
+    let s: str<6> = "tattoo";
+    let pfx: str<7> = "tattoox";
+    assert(!starts_with::<6, 7>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_empty_prefix() {
+    // F&O sec.7.5.1: fn:starts-with($arg1, "") = true for any $arg1
+    // Python: "tattoo".startswith("") -> True
+    let s: str<6> = "tattoo";
+    let pfx: str<0> = "";
+    assert(starts_with::<6, 0>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_empty_both() {
+    // Python: "".startswith("") -> True
+    let s: str<0> = "";
+    let pfx: str<0> = "";
+    assert(starts_with::<0, 0>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_empty_haystack_nonempty_prefix() {
+    // Python: "".startswith("x") -> False
+    let s: str<1> = "\0";
+    let pfx: str<1> = "x";
+    assert(!starts_with::<1, 1>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_nul_padded_prefix() {
+    // "he" stored in str<5> (NUL-padded); logical prefix length=2.
+    // Python: "hello".startswith("he") -> True
+    let s: str<5> = "hello";
+    let pfx: str<5> = "he\0\0\0";
+    assert(starts_with::<5, 5>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_nul_padded_haystack() {
+    // "hello" in str<10>; logical content = 5 bytes.
+    // Python: "hello".startswith("hel") -> True
+    let s: str<10> = "hello\0\0\0\0\0";
+    let pfx: str<3> = "hel";
+    assert(starts_with::<10, 3>(s, pfx));
+}
+
+#[test]
+fn fnstarts_with_full_buffer() {
+    // Full-buffer haystack, prefix at start.
+    // Python: "abcdefgh".startswith("abc") -> True
+    let s: str<8> = "abcdefgh";
+    let pfx: str<3> = "abc";
+    assert(starts_with::<8, 3>(s, pfx));
 }

--- a/zk/xpath/test_packages/xpath_test_fnstring_length/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_fnstring_length/src/chunk_0.nr
@@ -1,8 +1,76 @@
-//! Test chunk 0 for fn:string-length
-//! Contains 1 tests
+//! Real test vectors for fn:string-length (F&O sec. 7.4.1)
+//! Counts Unicode codepoints (lead bytes in well-formed UTF-8), NOT bytes.
+//! Python oracle: len(str) - Python strings are codepoint sequences.
+//! NUL = logical terminator (not U+0000 content); padded bytes not counted.
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::string_length;
 
 #[test]
-fn fnstring_length_no_converted_tests() {
-    // Placeholder: 29 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for fn:string-length");
+fn fnstring_length_hello() {
+    // Python: len("hello") -> 5
+    let s: str<5> = "hello";
+    assert(string_length::<5>(s) == 5);
+}
+
+#[test]
+fn fnstring_length_empty() {
+    // F&O sec.7.4.1: fn:string-length("") = 0
+    // Python: len("") -> 0
+    let s: str<0> = "";
+    assert(string_length::<0>(s) == 0);
+}
+
+#[test]
+fn fnstring_length_single_char() {
+    // Python: len("a") -> 1
+    let s: str<1> = "a";
+    assert(string_length::<1>(s) == 1);
+}
+
+#[test]
+fn fnstring_length_e_acute_one_codepoint() {
+    // Python: len(U+00E9 e-acute) -> 1 (2 UTF-8 bytes, 1 codepoint)
+    // UTF-8 bytes: [0xC3, 0xA9] = [195, 169]; lead byte count = 1.
+    let s: str<2> = "é";
+    assert(string_length::<2>(s) == 1);
+}
+
+#[test]
+fn fnstring_length_mixed_ascii_multibyte() {
+    // Python: len("a" + U+00E9) -> 2 (1 ASCII + 1 two-byte codepoint = 3 bytes, 2 codepoints)
+    let s: str<3> = "aé";
+    assert(string_length::<3>(s) == 2);
+}
+
+#[test]
+fn fnstring_length_nul_padded_stops_at_nul() {
+    // "hello" stored in str<10>; logical content = 5 bytes; NUL padding ignored.
+    // Python: len("hello") -> 5
+    let s: str<10> = "hello\0\0\0\0\0";
+    assert(string_length::<10>(s) == 5);
+}
+
+#[test]
+fn fnstring_length_full_buffer() {
+    // Full-buffer: "abcdefgh" fills str<8>; all 8 bytes are content (no NUL).
+    // Python: len("abcdefgh") -> 8
+    let s: str<8> = "abcdefgh";
+    assert(string_length::<8>(s) == 8);
+}
+
+#[test]
+fn fnstring_length_known_example() {
+    // F&O spec example: fn:string-length("Harp not on that string, madam; that string") = 43
+    // Python: len("Harp not on that string, madam; that string") -> 43
+    let s: str<43> = "Harp not on that string, madam; that string";
+    assert(string_length::<43>(s) == 43);
+}
+
+#[test]
+fn fnstring_length_logically_empty_padded_buffer() {
+    // Capacity-4 buffer with all NUL bytes -> logical length = 0.
+    // Python: len("") -> 0
+    let s: str<4> = "\0\0\0\0";
+    assert(string_length::<4>(s) == 0);
 }

--- a/zk/xpath/test_packages/xpath_test_opadd_daytimeduration_to_datetime/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_opadd_daytimeduration_to_datetime/src/chunk_0.nr
@@ -1,8 +1,90 @@
-//! Test chunk 0 for op:add-dayTimeDuration-to-dateTime
-//! Contains 1 tests
+//! Real test vectors for op:add-dayTimeDuration-to-dateTime (F&O sec. 8.3.17)
+//! Signed epoch encoding: pre-1970 results are VALID negative i64 epochs.
+//! Python oracle (tz-aware datetime):
+//!   from datetime import datetime, timezone, timedelta
+//!   def epoch_us(dt): return int((dt - datetime(1970,1,1,tzinfo=timezone.utc)).total_seconds() * 1_000_000)
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::{datetime_add_duration, duration_from_components, XsdDateTime};
+
+/// Encode a signed i64 epoch as the canonical Field bit pattern
+/// (mirrors the pattern in duration.nr test helpers).
+fn signed_epoch_us(e: i64) -> Field {
+    (e as u64) as Field
+}
 
 #[test]
-fn opadd_daytimeduration_to_datetime_no_converted_tests() {
-    // Placeholder: 21 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for op:add-dayTimeDuration-to-dateTime");
+fn opadd_dt_dtd_epoch_plus_one_day() {
+    // Oracle: 1970-01-01T00:00:00Z + P1D = 1970-01-02T00:00:00Z
+    // Python: epoch_us(datetime(1970,1,2,tzinfo=timezone.utc)) -> 86400000000
+    let dt = XsdDateTime::new(0);
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_add_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == 86_400_000_000);
+}
+
+#[test]
+fn opadd_dt_dtd_epoch_plus_neg_one_day_pre1970() {
+    // Oracle: 1970-01-01T00:00:00Z + (-P1D) = 1969-12-31T00:00:00Z
+    // Python: epoch_us(datetime(1969,12,31,tzinfo=timezone.utc)) -> -86400000000
+    // Signed epoch: negative result is valid (sq-3x7dl.7).
+    let dt = XsdDateTime::new(0);
+    let neg_one_day = duration_from_components(true, 1, 0, 0, 0, 0); // negative=true
+    let result = datetime_add_duration(dt, neg_one_day);
+    assert((result.epoch_microseconds as i64) == -86_400_000_000);
+}
+
+#[test]
+fn opadd_dt_dtd_pre1970_plus_two_days_cross_epoch() {
+    // Oracle: 1969-12-31T00:00:00Z + P2D = 1970-01-02T00:00:00Z
+    // Python: epoch_us(datetime(1970,1,2,tzinfo=timezone.utc)) -> 86400000000
+    // Crossing 1970 boundary: negative -> positive.
+    let dt = XsdDateTime::new(signed_epoch_us(-86_400_000_000));
+    let two_days = duration_from_components(false, 2, 0, 0, 0, 0);
+    let result = datetime_add_duration(dt, two_days);
+    assert((result.epoch_microseconds as i64) == 86_400_000_000);
+}
+
+#[test]
+fn opadd_dt_dtd_zero_duration() {
+    // Oracle: 1970-01-01T00:00:00Z + PT0S = 1970-01-01T00:00:00Z
+    // Python: epoch_us(datetime(1970,1,1,tzinfo=timezone.utc)) -> 0
+    let dt = XsdDateTime::new(0);
+    let zero = duration_from_components(false, 0, 0, 0, 0, 0);
+    let result = datetime_add_duration(dt, zero);
+    assert((result.epoch_microseconds as i64) == 0);
+}
+
+#[test]
+fn opadd_dt_dtd_year_2000_plus_one_day() {
+    // Oracle: 2000-01-01T00:00:00Z + P1D = 2000-01-02T00:00:00Z
+    // Python: epoch_us(datetime(2000,1,1,tzinfo=timezone.utc)) -> 946684800000000
+    //         epoch_us(datetime(2000,1,2,tzinfo=timezone.utc)) -> 946771200000000
+    let base_us: i64 = 946_684_800_000_000;
+    let dt = XsdDateTime::new(signed_epoch_us(base_us));
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_add_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == 946_771_200_000_000);
+}
+
+#[test]
+fn opadd_dt_dtd_epoch_plus_one_hour_thirty_min() {
+    // Oracle: 1970-01-01T00:00:00Z + PT1H30M = 1970-01-01T01:30:00Z
+    // Python: epoch_us(datetime(1970,1,1,1,30,tzinfo=timezone.utc)) -> 5400000000
+    let dt = XsdDateTime::new(0);
+    let dur = duration_from_components(false, 0, 1, 30, 0, 0);
+    let result = datetime_add_duration(dt, dur);
+    assert((result.epoch_microseconds as i64) == 5_400_000_000);
+}
+
+#[test]
+fn opadd_dt_dtd_deep_pre1970() {
+    // Oracle: 1969-07-20T20:17:40Z + PT1H = 1969-07-20T21:17:40Z
+    // Python: epoch_us(datetime(1969,7,20,20,17,40,tzinfo=timezone.utc)) -> -14182940000000
+    //         epoch_us(datetime(1969,7,20,21,17,40,tzinfo=timezone.utc)) -> -14179340000000
+    let base_us: i64 = -14_182_940_000_000;
+    let dt = XsdDateTime::new(signed_epoch_us(base_us));
+    let one_hour = duration_from_components(false, 0, 1, 0, 0, 0);
+    let result = datetime_add_duration(dt, one_hour);
+    assert((result.epoch_microseconds as i64) == -14_179_340_000_000);
 }

--- a/zk/xpath/test_packages/xpath_test_opnotation_equal/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_opnotation_equal/src/chunk_0.nr
@@ -1,8 +1,72 @@
-//! Test chunk 0 for op:NOTATION-equal
-//! Contains 1 tests
+//! Real test vectors for op:NOTATION-equal (F&O sec. 9.1)
+//! op:NOTATION-equal($arg1 as xs:NOTATION, $arg2 as xs:NOTATION) as xs:boolean
+//! xs:NOTATION equality is by expanded name (namespace URI + local name),
+//! identical to xs:QName equality (F&O sec. 9.1). Oracle: XPath F&O 3.2 sec. 9.1.
+//! Implementation delegates to qname_equal (same type, same semantics).
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::{notation_equal, XsdQName};
 
 #[test]
-fn opnotation_equal_no_converted_tests() {
-    // Placeholder: 20 qt3tests cases could not be converted.
-    assert(false, "No qt3tests cases could be converted for op:NOTATION-equal");
+fn opnotation_equal_same_ns_same_local() {
+    // Same namespace URI and same local name -> equal.
+    // Oracle F&O sec.9.1: identity of expanded names.
+    let ns = "http://example.com".as_bytes();
+    let loc = "foo".as_bytes();
+    let a: XsdQName<18, 3> = XsdQName::new(ns, 18, loc, 3);
+    let b: XsdQName<18, 3> = XsdQName::new(ns, 18, loc, 3);
+    assert(notation_equal::<18, 3, 18, 3>(a, b));
+}
+
+#[test]
+fn opnotation_equal_same_ns_different_local() {
+    // Same NS but different local names -> not equal.
+    // Oracle F&O sec.9.1: local name must match.
+    let ns = "http://example.com".as_bytes();
+    let loc_a = "foo".as_bytes();
+    let loc_b = "bar".as_bytes();
+    let a: XsdQName<18, 3> = XsdQName::new(ns, 18, loc_a, 3);
+    let b: XsdQName<18, 3> = XsdQName::new(ns, 18, loc_b, 3);
+    assert(!notation_equal::<18, 3, 18, 3>(a, b));
+}
+
+#[test]
+fn opnotation_equal_different_ns_same_local() {
+    // Different NS, same local name -> not equal.
+    // Oracle F&O sec.9.1: namespace URI must match.
+    let ns_a = "http://example.com".as_bytes();
+    let ns_b = "http://other.org  ".as_bytes(); // same length, different content
+    let loc = "foo".as_bytes();
+    let a: XsdQName<18, 3> = XsdQName::new(ns_a, 18, loc, 3);
+    let b: XsdQName<18, 3> = XsdQName::new(ns_b, 18, loc, 3);
+    assert(!notation_equal::<18, 3, 18, 3>(a, b));
+}
+
+#[test]
+fn opnotation_equal_no_namespace_same_local() {
+    // No-namespace NOTATION values: equality by local name only.
+    // Oracle F&O sec.9.1: empty namespace URI is a valid expanded name.
+    let loc = "mynotation".as_bytes();
+    let a: XsdQName<0, 10> = XsdQName::from_local_name(loc, 10);
+    let b: XsdQName<0, 10> = XsdQName::from_local_name(loc, 10);
+    assert(notation_equal::<0, 10, 0, 10>(a, b));
+}
+
+#[test]
+fn opnotation_equal_no_namespace_different_local() {
+    // No-namespace NOTATIONs with different local names -> not equal.
+    let loc_a = "nota1     ".as_bytes();
+    let loc_b = "nota2     ".as_bytes();
+    let a: XsdQName<0, 10> = XsdQName::from_local_name(loc_a, 5);
+    let b: XsdQName<0, 10> = XsdQName::from_local_name(loc_b, 5);
+    assert(!notation_equal::<0, 10, 0, 10>(a, b));
+}
+
+#[test]
+fn opnotation_equal_reflexivity() {
+    // Every NOTATION must equal itself (reflexivity).
+    let ns = "http://www.w3.org/TR/".as_bytes();
+    let loc = "html".as_bytes();
+    let a: XsdQName<21, 4> = XsdQName::new(ns, 21, loc, 4);
+    assert(notation_equal::<21, 4, 21, 4>(a, a));
 }

--- a/zk/xpath/test_packages/xpath_test_opsubtract_daytimeduration_from_datetime/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_opsubtract_daytimeduration_from_datetime/src/chunk_0.nr
@@ -1,11 +1,86 @@
-//! Test chunk 0 for op:subtract-dayTimeDuration-from-dateTime
-//! Contains 1 tests
+//! Real test vectors for op:subtract-dayTimeDuration-from-dateTime (F&O sec. 8.3.18)
+//! Signed epoch encoding: pre-1970 results are VALID negative i64 epochs.
+//! Python oracle (tz-aware datetime):
+//!   from datetime import datetime, timezone, timedelta
+//!   def epoch_us(dt): return int((dt - datetime(1970,1,1,tzinfo=timezone.utc)).total_seconds() * 1_000_000)
+//! [SONNET-4.6] (sq-rcpdz)
+
+use dep::xpath::{datetime_subtract_duration, duration_from_components, XsdDateTime};
+
+fn signed_epoch_us(e: i64) -> Field {
+    (e as u64) as Field
+}
 
 #[test]
-fn opsubtract_daytimeduration_from_datetime_no_converted_tests() {
-    // Placeholder: 21 qt3tests cases could not be converted.
-    assert(
-        false,
-        "No qt3tests cases could be converted for op:subtract-dayTimeDuration-from-dateTime",
-    );
+fn opsubtract_dt_dtd_epoch_minus_one_day_pre1970() {
+    // Oracle: 1970-01-01T00:00:00Z - P1D = 1969-12-31T00:00:00Z
+    // Python: epoch_us(datetime(1969,12,31,tzinfo=timezone.utc)) -> -86400000000
+    let dt = XsdDateTime::new(0);
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == -86_400_000_000);
+}
+
+#[test]
+fn opsubtract_dt_dtd_day2_minus_one_day() {
+    // Oracle: 1970-01-02T00:00:00Z - P1D = 1970-01-01T00:00:00Z
+    // Python: epoch_us(datetime(1970,1,1,tzinfo=timezone.utc)) -> 0
+    let dt = XsdDateTime::new(signed_epoch_us(86_400_000_000));
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == 0);
+}
+
+#[test]
+fn opsubtract_dt_dtd_year_2000_minus_one_day() {
+    // Oracle: 2000-01-02T00:00:00Z - P1D = 2000-01-01T00:00:00Z
+    // Python: epoch_us(datetime(2000,1,2,tzinfo=timezone.utc)) -> 946771200000000
+    //         epoch_us(datetime(2000,1,1,tzinfo=timezone.utc)) -> 946684800000000
+    let dt = XsdDateTime::new(signed_epoch_us(946_771_200_000_000));
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == 946_684_800_000_000);
+}
+
+#[test]
+fn opsubtract_dt_dtd_pre1970_minus_one_day_deeper() {
+    // Oracle: 1969-12-31T00:00:00Z - P1D = 1969-12-30T00:00:00Z
+    // Python: epoch_us(datetime(1969,12,30,tzinfo=timezone.utc)) -> -172800000000
+    let dt = XsdDateTime::new(signed_epoch_us(-86_400_000_000));
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == -172_800_000_000);
+}
+
+#[test]
+fn opsubtract_dt_dtd_zero_duration() {
+    // Oracle: 1970-01-01T00:00:00Z - PT0S = 1970-01-01T00:00:00Z
+    // Python: epoch_us(datetime(1970,1,1,tzinfo=timezone.utc)) -> 0
+    let dt = XsdDateTime::new(0);
+    let zero = duration_from_components(false, 0, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, zero);
+    assert((result.epoch_microseconds as i64) == 0);
+}
+
+#[test]
+fn opsubtract_dt_dtd_pre1970_minus_one_hour() {
+    // Oracle: 1969-07-20T21:17:40Z - PT1H = 1969-07-20T20:17:40Z
+    // Python: epoch_us(datetime(1969,7,20,21,17,40,tzinfo=timezone.utc)) -> -14179340000000
+    //         epoch_us(datetime(1969,7,20,20,17,40,tzinfo=timezone.utc)) -> -14182940000000
+    let base_us: i64 = -14_179_340_000_000;
+    let dt = XsdDateTime::new(signed_epoch_us(base_us));
+    let one_hour = duration_from_components(false, 0, 1, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_hour);
+    assert((result.epoch_microseconds as i64) == -14_182_940_000_000);
+}
+
+#[test]
+fn opsubtract_dt_dtd_crosses_1970_boundary() {
+    // Oracle: 1970-01-01T12:00:00Z - P1D = 1969-12-31T12:00:00Z
+    // Python: epoch_us(datetime(1970,1,1,12,tzinfo=timezone.utc)) -> 43200000000
+    //         epoch_us(datetime(1969,12,31,12,tzinfo=timezone.utc)) -> -43200000000
+    let dt = XsdDateTime::new(signed_epoch_us(43_200_000_000));
+    let one_day = duration_from_components(false, 1, 0, 0, 0, 0);
+    let result = datetime_subtract_duration(dt, one_day);
+    assert((result.epoch_microseconds as i64) == -43_200_000_000);
 }

--- a/zk/xpath/xpath/src/lib.nr
+++ b/zk/xpath/xpath/src/lib.nr
@@ -80,7 +80,7 @@ pub use year_month_duration::{
 // Re-export QName type and functions
 pub use qname::{
     fn_qname, fn_qname_from_strings, local_name_from_qname, namespace_uri_from_qname,
-    prefix_from_qname, qname_equal, XsdQName,
+    notation_equal, prefix_from_qname, qname_equal, XsdQName,
 };
 
 // Re-export Gregorian types

--- a/zk/xpath/xpath/src/qname.nr
+++ b/zk/xpath/xpath/src/qname.nr
@@ -175,6 +175,19 @@ pub fn prefix_from_qname<let NS_LEN: u32, let LOCAL_LEN: u32, let PREFIX_LEN: u3
     ([0; PREFIX_LEN], 0)
 }
 
+/// op:NOTATION-equal
+/// Two xs:NOTATION values are equal iff they have the same expanded name
+/// (namespace URI + local name), exactly like xs:QName equality.
+/// F&O sec. 9.1: op:NOTATION-equal($value1 as xs:NOTATION, $value2 as xs:NOTATION) as xs:boolean
+/// Oracle: XPath F&O 3.2 section 9.1; NOTATION comparison is by expanded name.
+/// [SONNET-4.6] (sq-rcpdz)
+pub fn notation_equal<let NS1: u32, let LOCAL1: u32, let NS2: u32, let LOCAL2: u32>(
+    a: XsdQName<NS1, LOCAL1>,
+    b: XsdQName<NS2, LOCAL2>,
+) -> bool {
+    qname_equal(a, b)
+}
+
 // ============================================================================
 // Tests
 // ============================================================================

--- a/zk/xpath/xpath/src/xpath_op.nr
+++ b/zk/xpath/xpath/src/xpath_op.nr
@@ -404,3 +404,6 @@ pub use crate::sequence::range_to as to;
 
 // op:QName-equal
 pub use crate::qname::qname_equal as QName_equal;
+
+// op:NOTATION-equal (F&O sec. 9.1: equality by expanded name, same as QName)
+pub use crate::qname::notation_equal as NOTATION_equal;


### PR DESCRIPTION
## Summary

- Replaces 7 `assert(false, "No qt3tests cases could be converted...")` placeholder stubs in `zk/xpath/test_packages/` with real test vectors grounded against independent Python oracles
- Adds `notation_equal` implementation to `qname.nr` (F&O sec. 9.1: NOTATION equality = QName equality by expanded name) and exports it from `lib.nr` + `xpath_op.nr`
- Removes all 7 entries from `KNOWN_FAILING` in `.github/workflows/zk-toolchain.yml`

## Functions covered and F&O citations

| Package | F&O clause | Tests added | Oracle |
|---|---|---|---|
| `xpath_test_fncontains` | F&O sec. 7.5.3 | 11 | `"needle" in "haystack"` (Python `__contains__`) |
| `xpath_test_fnends_with` | F&O sec. 7.5.2 | 10 | `str.endswith(suffix)` |
| `xpath_test_fnstarts_with` | F&O sec. 7.5.1 | 10 | `str.startswith(prefix)` |
| `xpath_test_fnstring_length` | F&O sec. 7.4.1 | 9 | `len(str)` (codepoints, not bytes) |
| `xpath_test_opnotation_equal` | F&O sec. 9.1 | 6 | identity of expanded name (ns URI + local) |
| `xpath_test_opadd_daytimeduration_to_datetime` | F&O sec. 8.3.17 | 7 | Python tz-aware `datetime` arithmetic |
| `xpath_test_opsubtract_daytimeduration_from_datetime` | F&O sec. 8.3.18 | 7 | Python tz-aware `datetime` arithmetic |

Total: **60 new `#[test]` functions** replacing 7 placeholders.

## Python oracle for datetime tests

```python
from datetime import datetime, timezone
def epoch_us(dt):
    return int((dt - datetime(1970,1,1,tzinfo=timezone.utc)).total_seconds() * 1_000_000)
```

All expected epoch_us values are computed from this oracle. Signed epoch encoding (sq-3x7dl.7): pre-1970 results are valid negative i64 values stored as two's-complement Field patterns.

## Verification

- `nargo test` green on all 7 packages (60/60 tests pass)
- Mutation spot-check confirmed non-vacuity:
  - `fncontains`: flip `assert(contains(...))` → `assert(!contains(...))` → 1 test FAILED, reverted → 11 pass
  - `opadd_daytimeduration`: change expected epoch → 2 tests FAILED, reverted → 7 pass

## Notes

DO NOT arm — ZK surface, escalated review required.

> 🤖 SPARQ agent — automated implementation of bead sq-rcpdz