### PR TITLE
fix(vectors/kani): raise open_from_bytes_never_panics unwind bound 40→89 (sq-kycq5)

### DIFF
--- a/crates/sparq-vectors/src/store.rs
+++ b/crates/sparq-vectors/src/store.rs
@@ -1115,7 +1115,21 @@ mod kani_proofs {
     /// of `open_from_bytes` does an aligned-copy + the full validation; the failure path is a
     /// plain `Err`. Neither may abort.
     #[kani::proof]
-    #[kani::unwind(40)] // > MAX_LEN so every bounded slice/index loop fully unrolls.
+    // (sq-kycq5) [SONNET-4.6] Loop census for this harness: the setup loop `for b in
+    // bytes.iter_mut()` runs up to `len` times where `len <= MAX_LEN`; the
+    // `AlignedBytes::from_vec` aligned copy covers the same `len` bytes; the fingerprint
+    // scan in `Fingerprint::from_bytes_opt` covers FINGERPRINT_LEN = 24 bytes; and the
+    // index-validation loop `for i in 0..count` runs at most 2 times within MAX_LEN = 88
+    // (a dim=1 count=2 store needs 56 + 8 + 16 = 80 bytes; count=3 needs 92 > 88).
+    // All loops are bounded by MAX_LEN = HEADER_LEN + 32 = 56 + 32 = 88.
+    // Therefore the required unwind bound is MAX_LEN + 1 = 89. The previous bound of 40
+    // was LESS than MAX_LEN (40 < 88) and its comment "// > MAX_LEN" was factually wrong;
+    // that bound fired an unwinding assertion in the nightly Kani lane (an INCOMPLETE proof,
+    // not a counterexample). See the sq-gnvfc fix for the sibling harness for the same
+    // pattern. NOTE: raising the bound may make this harness slower (more unwinding steps);
+    // that is acceptable — the lane's per-harness timeout keeps it visible, and an honest
+    // timeout beats a false incomplete proof.
+    #[kani::unwind(89)] // MAX_LEN + 1 = 88 + 1; bounds every loop in the harness cone
     fn open_from_bytes_never_panics() {
         // A symbolic length in `0..=MAX_LEN`, then a symbolic buffer of that length.
         let len: usize = kani::any();


### PR DESCRIPTION
## Summary

- `open_from_bytes_never_panics` carried `#[kani::unwind(40)]` with the comment `// > MAX_LEN so every bounded slice/index loop fully unrolls` — both the bound and the comment were wrong.
- `MAX_LEN = HEADER_LEN + 32 = (32 + 24) + 32 = 88`. The bound 40 < 88 would fire a Kani unwinding assertion in the nightly lane (an **incomplete proof**, not a counterexample — found in the Fable escalated review of PR #1549/sq-gnvfc).
- **Loop census** (sq-gnvfc mirror method): the setup loop `for b in bytes.iter_mut()` runs up to `MAX_LEN = 88` times; `AlignedBytes::from_vec` aligned copy covers the same `len` bytes; `Fingerprint::from_bytes_opt` scans `FINGERPRINT_LEN = 24` bytes; the index-validation loop `for i in 0..count` runs at most 2 times within `MAX_LEN` (dim=1 count=2 store needs 80 bytes; count=3 needs 92 > 88). All loops are bounded by 88.
- Fix: raise bound to `89 = MAX_LEN + 1` and replace the wrong comment with the loop-census arithmetic.
- **Domain self-check**: `_DOMAIN_ADMITS_A_WELL_FORMED_STORE` (`MAX_LEN >= HEADER_LEN`) already covers this harness's domain — no new assertion needed.

## Trade-off note

The original harness ran >20 min to timeout in the lane at bound 40. Raising to 89 (more unwinding steps) may make it **slower or still timeout**. That is acceptable: the lane's per-harness timeout keeps it visible as a long-running proof, and an honest timeout is better than a false incomplete-proof pass. This mirrors the explicit rationale used in sq-gnvfc for the sibling harness.

## Gates

- `cargo test -p sparq-vectors` (default features): ✅ all pass
- `cargo test -p sparq-vectors --no-default-features`: ✅ all pass
- `cargo clippy -p sparq-vectors -- -D warnings`: ✅ clean
- `cargo clippy -p sparq-vectors --no-default-features -- -D warnings`: ✅ clean
- Change is `#[cfg(kani)]`-only — zero runtime diff confirmed
- Local Kani run deferred to the nightly lane (authoritative per in-source doc; harness ran >20 min in lane at bound 40)

> 🤖 SPARQ agent — bead sq-kycq5, found in Fable escalated review of PR #1549