### PR TITLE
feat(kb): golden/byte-pin test for PipelineOutput::turtle (sq-9m3rn)

### DIFF
--- a/crates/sparq-kb/tests/golden/openalex-fixture-combined.ttl
+++ b/crates/sparq-kb/tests/golden/openalex-fixture-combined.ttl
@@ -1,0 +1,84 @@
+@prefix pkg:     <https://sparq.dev/ns/pkg#> .
+@prefix prov:    <http://www.w3.org/ns/prov#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix cito:    <http://purl.org/spar/cito/> .
+@prefix sigimpl: <https://w3id.org/zkp-sparql/sig-impl#> .
+@prefix secx:    <https://w3id.org/zkp-sparql/sec-prop#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+
+<https://sparq.dev/ns/pkg/agent#literature-extractor> a pkg:MachineAgent ;
+  rdfs:label "literature extraction agent (Phase-5 scaffolding, fixtures)"@en .
+
+<https://doi.org/10.5555/example.rdf-parallel-parse> a pkg:Source ;
+  dcterms:title "Chunk-Parallel Scanning of Line-Delimited RDF" ;
+  pkg:exploredStatus pkg:Explored ;
+  dcterms:issued "2023"^^xsd:gYear .
+<https://sparq.dev/ns/pkg/agent#literature-extractor/finding/1> a pkg:Finding ;
+  rdfs:label "partial (machine-extracted)"@en ;
+  sigimpl:justification "We present a chunk-parallel scanner for N-Triples that splits the input on record boundaries and parses each chunk independently." ;
+  pkg:confidence 0.6000 ;
+  pkg:assurance secx:Conjectured ;
+  prov:wasDerivedFrom <https://doi.org/10.5555/example.rdf-parallel-parse> ;
+  prov:wasGeneratedBy <https://sparq.dev/ns/pkg/agent#literature-extractor/activity/1> ;
+  prov:wasAttributedTo <https://sparq.dev/ns/pkg/agent#literature-extractor> ;
+  prov:generatedAtTime "-4656-05-28T09:28:20.459270Z"^^xsd:dateTime ;
+  cito:citesAsEvidence <https://doi.org/10.5555/example.rdf-parallel-parse> .
+<https://sparq.dev/ns/pkg/agent#literature-extractor/activity/1> a prov:Activity ;
+  prov:used <https://doi.org/10.5555/example.rdf-parallel-parse> ;
+  prov:wasAssociatedWith <https://sparq.dev/ns/pkg/agent#literature-extractor> ;
+  prov:generatedAtTime "-4656-05-28T09:28:20.459270Z"^^xsd:dateTime .
+
+<https://doi.org/10.5555/example.zk-sparql-soundness> a pkg:Source ;
+  dcterms:title "Soundness of Zero-Knowledge Proofs over SPARQL Basic Graph Patterns" ;
+  pkg:exploredStatus pkg:Explored ;
+  dcterms:issued "2025"^^xsd:gYear .
+<https://sparq.dev/ns/pkg/agent#literature-extractor/finding/2> a pkg:Finding ;
+  rdfs:label "partial (machine-extracted)"@en ;
+  sigimpl:justification "a full machine-checked soundness proof is left as future work and the security argument is informal." ;
+  pkg:confidence 0.5000 ;
+  pkg:assurance secx:Conjectured ;
+  prov:wasDerivedFrom <https://doi.org/10.5555/example.zk-sparql-soundness> ;
+  prov:wasGeneratedBy <https://sparq.dev/ns/pkg/agent#literature-extractor/activity/2> ;
+  prov:wasAttributedTo <https://sparq.dev/ns/pkg/agent#literature-extractor> ;
+  prov:generatedAtTime "-4656-05-28T09:28:20.459270Z"^^xsd:dateTime ;
+  cito:citesAsEvidence <https://doi.org/10.5555/example.zk-sparql-soundness> .
+<https://sparq.dev/ns/pkg/agent#literature-extractor/activity/2> a prov:Activity ;
+  prov:used <https://doi.org/10.5555/example.zk-sparql-soundness> ;
+  prov:wasAssociatedWith <https://sparq.dev/ns/pkg/agent#literature-extractor> ;
+  prov:generatedAtTime "-4656-05-28T09:28:20.459270Z"^^xsd:dateTime .
+
+<https://sparq.dev/ns/pkg/agent#literature-extractor/finding/3> a pkg:Finding ;
+  rdfs:label "yes (machine-extracted)"@en ;
+  sigimpl:justification "This paper sketches a zero-knowledge protocol for proving the existence of a BGP match over a committed RDF graph." ;
+  pkg:confidence 0.7000 ;
+  pkg:assurance secx:Conjectured ;
+  prov:wasDerivedFrom <https://doi.org/10.5555/example.zk-sparql-soundness> ;
+  prov:wasGeneratedBy <https://sparq.dev/ns/pkg/agent#literature-extractor/activity/3> ;
+  prov:wasAttributedTo <https://sparq.dev/ns/pkg/agent#literature-extractor> ;
+  prov:generatedAtTime "-4656-05-28T09:28:20.459270Z"^^xsd:dateTime ;
+  cito:citesAsEvidence <https://doi.org/10.5555/example.zk-sparql-soundness> .
+<https://sparq.dev/ns/pkg/agent#literature-extractor/activity/3> a prov:Activity ;
+  prov:used <https://doi.org/10.5555/example.zk-sparql-soundness> ;
+  prov:wasAssociatedWith <https://sparq.dev/ns/pkg/agent#literature-extractor> ;
+  prov:generatedAtTime "-4656-05-28T09:28:20.459270Z"^^xsd:dateTime .
+
+<https://doi.org/10.5555/example.semi-honest-mpc-join> a pkg:Source ;
+  dcterms:title "Semi-Honest Multi-Party Computation for Federated Joins" ;
+  pkg:exploredStatus pkg:Explored ;
+  dcterms:issued "2024"^^xsd:gYear .
+<https://sparq.dev/ns/pkg/agent#literature-extractor/finding/4> a pkg:Finding ;
+  rdfs:label "yes (machine-extracted)"@en ;
+  sigimpl:justification "The protocol is secure in the semi-honest model; malicious security is not addressed." ;
+  pkg:confidence 0.6500 ;
+  pkg:assurance secx:Conjectured ;
+  prov:wasDerivedFrom <https://doi.org/10.5555/example.semi-honest-mpc-join> ;
+  prov:wasGeneratedBy <https://sparq.dev/ns/pkg/agent#literature-extractor/activity/4> ;
+  prov:wasAttributedTo <https://sparq.dev/ns/pkg/agent#literature-extractor> ;
+  prov:generatedAtTime "-4656-05-28T09:28:20.459270Z"^^xsd:dateTime ;
+  cito:citesAsEvidence <https://doi.org/10.5555/example.semi-honest-mpc-join> .
+<https://sparq.dev/ns/pkg/agent#literature-extractor/activity/4> a prov:Activity ;
+  prov:used <https://doi.org/10.5555/example.semi-honest-mpc-join> ;
+  prov:wasAssociatedWith <https://sparq.dev/ns/pkg/agent#literature-extractor> ;
+  prov:generatedAtTime "-4656-05-28T09:28:20.459270Z"^^xsd:dateTime .
+

--- a/crates/sparq-kb/tests/literature_pipeline.rs
+++ b/crates/sparq-kb/tests/literature_pipeline.rs
@@ -475,6 +475,36 @@ fn cap_truncated_batch_is_marked_incomplete_in_every_artifact() {
     assert!(!complete.restricted_public_projection.contains("INCOMPLETE"));
 }
 
+/// Generate the golden TTL output for the standard fixture pipeline.
+///
+/// # Generated Golden File
+///
+/// This test is `#[ignore]`d by default. To regenerate the golden file:
+///
+/// ```sh
+/// cd /home/ubuntu/sparq  # or your working repo
+/// cargo test -p sparq-kb --features literature,validate \
+///   --test literature_pipeline -- generate_golden_turtle_output --nocapture --ignored \
+///   | sed -n '/^@prefix/,/^test generate/p' | head -n -1 \
+///   > crates/sparq-kb/tests/golden/openalex-fixture-combined.ttl
+/// # Then manually review and commit the new file.
+/// ```
+///
+/// This is a deliberate (and audited) regeneration path — changes to the golden file are
+/// NEVER silent. The primary golden-pin test is [`emitted_turtle_matches_golden_byte_for_byte`],
+/// which fails loudly if the output drifts.
+#[test]
+#[ignore]
+fn generate_golden_turtle_output() {
+    let extractor = RecordedExtractor::from_fixture().expect("replay extractor builds");
+    // Use a FIXED timestamp (same as the pin test) so golden generation is deterministic.
+    let fixed_time = Some("-4656-05-28T09:28:20.459270Z".to_string());
+    let out = pipeline::run_with_time(FIXTURE_OPENALEX_BATCH, &extractor, fixed_time)
+        .expect("pipeline runs with fixed time");
+    eprintln!("=== Golden Turtle Output (copy to tests/golden/openalex-fixture-combined.ttl) ===");
+    println!("{}", out.turtle);
+}
+
 /// A dup-DOI mixed batch: the SAME DOI appears TWICE in one connector batch — once with a
 /// "cc-by" licence and once with no licence recorded. Simulates the real OpenAlex case where
 /// two indexing records represent the same work with conflicting licence metadata. The
@@ -572,4 +602,58 @@ fn machine_and_restricted_full_tiers_conform_to_the_shacl_gate() {
     assert!(m_conforms, "machine-tier artifact must conform:\n{m_report}");
     let (r_conforms, r_report) = gate(&out.license_restricted_tier);
     assert!(r_conforms, "restricted-tier artifact must conform:\n{r_report}");
+}
+
+// ===========================================================================
+// sq-9m3rn — Golden/byte-pin test: PipelineOutput::turtle byte-compatibility
+// [HAIKU-4.5] 🤖 SPARQ agent — golden-file pin for #1540 refactor.
+// ===========================================================================
+
+/// The committed golden file for the fixture pipeline's combined TTL output. This test
+/// pins the byte-exact output to catch silent drift in the emission logic — the #1540
+/// refactor's "byte-for-byte unchanged" claim is now enforced, not just inspected.
+///
+/// If this test fails, the emission logic has drifted. Review the diff carefully:
+/// - Is the change intended (e.g., a deliberate format refactor)?
+/// - If YES: run the `generate_golden_turtle_output` ignored test to regenerate the golden
+///   and commit the new file.
+/// - If NO: revert the emission code and re-pin the test.
+///
+/// The golden file is at: `crates/sparq-kb/tests/golden/openalex-fixture-combined.ttl`
+#[test]
+fn emitted_turtle_matches_golden_byte_for_byte() {
+    use std::fs;
+    use std::path::PathBuf;
+
+    let extractor = RecordedExtractor::from_fixture().expect("replay extractor builds");
+    // Deterministic timestamp (sq-tzars.2 [HAIKU-4.5]): use the same fixed instant
+    // that was used to generate the golden file. This ensures byte-exact reproducibility.
+    let fixed_time = Some("-4656-05-28T09:28:20.459270Z".to_string());
+    let out = pipeline::run_with_time(FIXTURE_OPENALEX_BATCH, &extractor, fixed_time)
+        .expect("pipeline runs with fixed time");
+
+    // Load the committed golden file from the repo (resolved relative to the crate root).
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let golden_path = manifest_dir.join("tests/golden/openalex-fixture-combined.ttl");
+    let golden = fs::read_to_string(&golden_path).unwrap_or_else(|e| {
+        panic!(
+            "Failed to read golden file at {}: {}. \
+             If regenerating, run: cargo test -p sparq-kb --features literature,validate \
+             --test literature_pipeline -- generate_golden_turtle_output --nocapture --ignored",
+            golden_path.display(),
+            e
+        )
+    });
+
+    // Byte-for-byte comparison: the emission logic must not drift.
+    assert_eq!(
+        out.turtle, golden,
+        "PipelineOutput::turtle has drifted from the golden file (byte-for-byte mismatch). \
+         This indicates a change to the emission logic or the fixture. \
+         \n\nTo deliberately regenerate the golden file (e.g., after an intended refactor): \
+         \n  cargo test -p sparq-kb --features literature,validate --test literature_pipeline \
+         \n  -- generate_golden_turtle_output --nocapture --ignored \
+         \n  > /tmp/golden.ttl \
+         \nThen review the diff carefully and commit the new golden file.\n"
+    );
 }


### PR DESCRIPTION
## Summary

Add a golden/byte-pin test enforcing PipelineOutput::turtle byte-compatibility.
The #1540 refactor's "byte-for-byte unchanged" claim was inspection-verified only.
This test pins the emission output to a committed golden file so future refactors
can't silently drift the legacy combined artifact.

- Runs the standard fixture pipeline with a fixed timestamp
- Asserts output equals committed golden file (tests/golden/openalex-fixture-combined.ttl)
- Includes clear failure message with regeneration instructions
- Mutation testing: verified a single-byte change is caught

## Test plan

- cargo test -p sparq-kb --features literature,validate --test literature_pipeline emitted_turtle_matches_golden_byte_for_byte
- All existing literature pipeline tests still pass
- Clippy clean both feature states
- Mutation spot-check: add space to TTL_PREFIXES → test fails → revert → test passes

## Implementation notes

- Uses run_with_time() with fixed timestamp for deterministic output
- Golden file extracted from current main's behavior (that IS the pin)
- Helper test generate_golden_turtle_output (ignored) for deliberate regeneration
- Proper path resolution via env!(CARGO_MANIFEST_DIR)

🤖 SPARQ agent