### PR TITLE
ci(bench): scope the perf gate under change-based selection + nightly full backstop (sq-mel85) [SONNET-4.6]

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -26,14 +26,34 @@ on:
     # ignoring the baseline path alone never masks a genuine bench-worthy push.
     paths-ignore:
       - 'bench/perf-baseline.json'
+  # [SONNET-4.6] sq-mel85 (design §5.2, phase 2b): react to labeled/unlabeled too so
+  # toggling the `ci-full` label re-evaluates the change-based selection for the bench
+  # lane (ci-select.yml maps the label to `--full`, which forces the perf gate to run).
+  # The default types (opened/synchronize/reopened) are listed explicitly so adding the
+  # label events does NOT drop `synchronize` (the push-to-PR trigger).
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
   # [OPUS-4.8] Merge queue: the perf gate must run on the queue's merge_group ref so
   # the required ci-summary aggregates the benchmark check. The auto-push / baseline-
-  # commit / benchmark-data steps are all gated `if: github.ref == 'refs/heads/main'`
+  # commit / benchmark-data steps are all gated on push-to-main (see the step guards)
   # — on merge_group github.ref is refs/heads/gh-readonly-queue/main/…, so (exactly as
   # on a PR) they SKIP and only the perf gate computes + enforces the floor.
   merge_group:
   workflow_dispatch:
+  # [SONNET-4.6] sq-mel85 (design §6.1): the nightly FULL-RUN BACKSTOP for change-based
+  # selection. bench.yml previously had NO schedule trigger, so a PR that selection-
+  # skipped the bench lane (its closure provably unaffected) had no regular full-matrix
+  # re-run to catch a latent regression other than the next push-to-main. A `schedule`
+  # event carries no PR diff, so ci_select.py returns mode=full and the `bench` job's
+  # `mode != 'selected'` disjunct RUNS the whole suite + the hard perf gate. This run is
+  # a PURE VERIFICATION backstop: the auto-ratchet + benchmark-data history steps are
+  # gated on `github.event_name == 'push'` (see below), so a nightly run NEVER commits
+  # the floor or pushes a duplicate history point — the "one entry per commit" trend and
+  # the source-of-record ratchet stay continuous on the push-to-main path alone.
+  # 05:29 UTC — offset from ci.yml (03:17) + fuzz.yml (04:23) so the three nightly heavy
+  # lanes do not contend for the same runner window.
+  schedule:
+    - cron: "29 5 * * *"
 
 # [OPUS-4.8] Least-privilege default (Scorecard TokenPermissions): top-level is read-only
 # so the dashboard-labels job (and any future read-only job) inherits no write scope. The
@@ -48,6 +68,25 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # [SONNET-4.6] sq-mel85 (design §5.2, phase 2b): the change-based test-selection
+  # pre-job (the reusable .github/workflows/ci-select.yml — doctrine there). The
+  # `bench` job below guards on its benchmarked-crate closure so a PR that touches
+  # neither the benchmarked crates NOR their reverse-dependency closure skips the
+  # (release build + full bench suite + perf gate) run entirely. UNCONDITIONAL (no
+  # needs/if): the ci-summary gate REQUIRES every "change-based test selection"
+  # check-run to conclude success before any skipped sibling counts as satisfied, so
+  # this job must exist + be green on every trigger (design §5.3). Fail-closed:
+  # ci_select.py returns mode=full for every §4.1 trigger (shared crate / build file /
+  # .github/** / Cargo.lock / selector-self change) and for ANY internal error, and an
+  # empty/missing output satisfies the guard's `mode != 'selected'` first disjunct =>
+  # the bench lane RUNS. On push-to-main + schedule (the full backstop) the event
+  # carries no PR diff => mode=full => the bench lane runs the whole suite.
+  select:
+    name: select
+    uses: ./.github/workflows/ci-select.yml
+    permissions:
+      contents: read
+
   # [OPUS-4.8] sq-ocuf: fast, dependency-light gate for the dashboard's readable labels. Runs on
   # PRs + main (no rust/wasm build) so a query added/renamed without regenerating metric-labels.json
   # fails BEFORE merge: validates the JSON, runs the generator's --check drift gate, syntax-checks
@@ -71,6 +110,32 @@ jobs:
 
   bench:
     name: run + track benchmarks
+    # [SONNET-4.6] sq-mel85 (design §5.2, phase 2b): scope the perf gate by the
+    # benchmarked-crate closure. Seeds (single source of truth: `_LANE_SEEDS["bench"]`
+    # in scripts/ci_select.py, pinned by scripts/tests/test_ci_select_wiring.py):
+    # sparq-engine (headline benchmarked crate) + the release binaries this job builds
+    # (sparq-cli + sparq-bench, which depend on sparq-core, so a core change — whose
+    # store/dict/parse byte metrics are HARD-GATED — lands in the affected reverse
+    # closure) + sparq-wasm (the wasm_bundle_bytes floor, enforced ONLY here; a wasm-
+    # only diff does not flow up into engine/cli/bench, so sparq-wasm is a DIRECT seed).
+    # Non-matrix job => the job-level `if:` can read needs.select.outputs (unlike the
+    # ci.yml per-shard case, which must guard in a step). FAIL-CLOSED: the leading
+    # `mode != 'selected'` disjunct means an empty/missing selection output RUNS the
+    # lane; a selection-skipped job reports conclusion `skipped` (= satisfied) to the
+    # ci-summary gate — no per-leg name is individually required (bead sq-fmx4u.4).
+    # CRITICAL (design §6.1 continuity): push-to-main + schedule are NOT pull_request/
+    # merge_group events, so ci_select.py returns mode=full and this disjunct is TRUE =>
+    # the FULL suite runs on every main commit + on the nightly backstop. Selection can
+    # ONLY narrow on pull_request / merge_group. That is what keeps the auto-ratchet
+    # floor + benchmark-data history (both depend on every main commit being benchmarked)
+    # continuous — see the push-gated history/ratchet steps below.
+    needs: select
+    if: >-
+      needs.select.outputs.mode != 'selected' ||
+      contains(needs.select.outputs.affected, '"sparq-engine"') ||
+      contains(needs.select.outputs.affected, '"sparq-cli"') ||
+      contains(needs.select.outputs.affected, '"sparq-bench"') ||
+      contains(needs.select.outputs.affected, '"sparq-wasm"')
     runs-on: ubuntu-latest
     # [OPUS-4.8] Job-scoped writes (least privilege; the rest of the workflow stays read-only):
     #   contents: write     — auto-ratchet commits bench/perf-baseline.json back to main and
@@ -226,7 +291,10 @@ jobs:
       # The fail-soft is the immediate fix (stops the red runs); the floor-landing is deferred to that
       # decision.
       - name: Auto-ratchet the perf floor (commit improvements back to main)
-        if: github.ref == 'refs/heads/main'
+        # [SONNET-4.6] sq-mel85: push-to-main ONLY (excludes the nightly `schedule`
+        # backstop) so a scheduled full-run verifies the gate WITHOUT committing a new
+        # floor — the source-of-record ratchet cadence stays tied to code-landing pushes.
+        if: github.event_name != 'schedule' && github.ref == 'refs/heads/main'
         env:
           PERF_GATE_ALLOW: ${{ vars.PERF_GATE_ALLOW }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -282,7 +350,9 @@ jobs:
       - name: Ensure benchmark-data history branch exists
         # main only: PRs (esp. from forks) get a read-only GITHUB_TOKEN and must never write the
         # history branch — they only compare against it. [OPUS-4.8]
-        if: github.ref == 'refs/heads/main'
+        # [SONNET-4.6] sq-mel85: push-to-main ONLY (the nightly `schedule` backstop is a pure
+        # verification run — it never writes the history branch, so it needs no bootstrap).
+        if: github.event_name != 'schedule' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -320,7 +390,10 @@ jobs:
       # This does NOT alter the measurement — bench-results.json is already written; we only drop the
       # incidental lockfile churn. main-guarded to mirror the auto-push gate (the only path that switches).
       - name: Clean bench-induced tracked churn before history switch (main only)
-        if: github.ref == 'refs/heads/main'
+        # [SONNET-4.6] sq-mel85: push-to-main ONLY. This cleanup exists solely so the
+        # auto-push branch switch below is clean; the nightly `schedule` backstop never
+        # switches branches (auto-push is push-gated), so it needs no cleanup.
+        if: github.event_name != 'schedule' && github.ref == 'refs/heads/main'
         run: |
           set -euo pipefail
           dirty="$(git diff --name-only)"
@@ -346,7 +419,11 @@ jobs:
           # branch (which feeds the public Pages chart). On a PR this is false, so the run COMPUTES
           # + COMPARES against the published series and COMMENTS, but does NOT write benchmark-data —
           # contributors get pre-merge feedback with zero pollution of the public trend.
-          auto-push: ${{ github.ref == 'refs/heads/main' }}
+          # [SONNET-4.6] sq-mel85: ALSO false on the nightly `schedule` backstop — a scheduled run
+          # shares the last main commit's SHA, so pushing would append a DUPLICATE per-commit point
+          # and pollute the "one entry per commit" trend. The backstop verifies the gate only; the
+          # history + ratchet stay on the push-to-main path (design §6.1 continuity).
+          auto-push: ${{ github.event_name != 'schedule' && github.ref == 'refs/heads/main' }}
           # The history branch doubles as the Pages source: the action writes index.html + data.js
           # under dev/bench here, so once the owner points Settings → Pages at branch benchmark-data
           # /(root) the dashboard renders at https://sparq.jeswr.org/dev/bench (see header).
@@ -388,7 +465,9 @@ jobs:
       # Idempotent + MAIN ONLY (PRs/forks get a read-only token and never write the history branch),
       # mirroring the "Ensure benchmark-data history branch exists" bootstrap above.
       - name: Seed Pages dashboard onto benchmark-data (if absent)
-        if: github.ref == 'refs/heads/main'
+        # [SONNET-4.6] sq-mel85: push-to-main ONLY — the nightly `schedule` backstop never
+        # writes the history branch, so it must not seed/update the Pages dashboard either.
+        if: github.event_name != 'schedule' && github.ref == 'refs/heads/main'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |

--- a/ci/path-ownership.toml
+++ b/ci/path-ownership.toml
@@ -76,13 +76,16 @@ wasm = [
   "sparq-introspect",
   "sparq-solid",
 ]
-# [SONNET-4.6] sq-mel85: bench.yml `bench` job — the perf regression gate. Seeds =
-# the closure of the HARD-GATED (merge-blocking) perf metrics: sparq-engine (headline
-# benchmarked crate) + the release binaries the job builds (sparq-cli + sparq-bench,
-# which pull in sparq-core, whose store/dict/parse byte metrics are gated) + sparq-wasm
-# (the wasm_bundle_bytes floor, enforced ONLY here; a wasm-only diff does not flow up
-# into engine/cli/bench, so sparq-wasm must be a DIRECT seed — omitting it would be an
-# unsound skip). Push-to-main runs mode=full, so the FULL suite + auto-ratchet always run.
+# [SONNET-4.6] sq-mel85: bench.yml `bench` job — the perf regression gate.
+# TRUE INVARIANT: every hard-gated metric measured on the PR/merge_group tier must have
+# its source crate reach a bench seed. PR-tier hard-gated metrics today:
+#   store/dict/parse (sparq-core) — reached via sparq-cli + sparq-bench (both bench seeds)
+#   wasm_bundle_bytes (sparq-wasm) — DIRECT seed (a wasm-only diff does not flow up into
+#     engine/cli/bench; omitting sparq-wasm would be an unsound skip)
+# The four additional mode:auto ratchets (fts_bytes_per_doc / vectors_diskann_recall_at10
+# / vectors_pq_recall_at10 / geo_compliance_deficit) need NO bench seed because
+# ci-bench.sh measures them MAIN-tier-only (GITHUB_REF guards skip them on any non-main
+# ref); every main-tier event is mode=full. Push-to-main always runs mode=full.
 bench = ["sparq-engine", "sparq-cli", "sparq-bench", "sparq-wasm"]
 
 # ---------------------------------------------------------------------------

--- a/ci/path-ownership.toml
+++ b/ci/path-ownership.toml
@@ -51,15 +51,17 @@ patterns = [
 
 # ---------------------------------------------------------------------------
 # [lanes] — INFORMATIONAL MIRROR of ci_select.py `_LANE_SEEDS` (design §5.2,
-# bead sq-fmx4u.6, phase 2). The selector does NOT read this table; it documents,
-# in the policy file, which SINGLETON CI lane maps to which SEED crates. A lane is
-# a whole-job that always exercises a FIXED crate set (the fuzz smoke; the wasm
-# bundle build); it is skipped only when NONE of its seeds is in the affected
-# reverse-dependency closure. `test_path_ownership.py` asserts this table equals
-# ci_select.py `_LANE_SEEDS` so the doc + the code cannot diverge; the fuzz.yml +
-# ci.yml `wasm` job `if:` guards reference exactly these crate names, pinned by
-# scripts/tests/test_ci_select_wiring.py. Under-listing a seed would be a silent
-# unsound skip; over-listing merely over-runs the lane (fail-safe).
+# beads sq-fmx4u.6 phase 2 + sq-mel85 phase 2b). The selector does NOT read this
+# table; it documents, in the policy file, which SINGLETON CI lane maps to which
+# SEED crates. A lane is a whole-job that always exercises a FIXED crate set (the
+# fuzz smoke; the wasm bundle build; the perf-gate bench); it is skipped only when
+# NONE of its seeds is in the affected reverse-dependency closure.
+# `test_ci_select_wiring.py::test_ownership_toml_lanes_mirror_matches_lane_seeds`
+# asserts this table equals ci_select.py `_LANE_SEEDS` so the doc + the code cannot
+# diverge; the fuzz.yml + ci.yml `wasm` + bench.yml `bench` job `if:` guards
+# reference exactly these crate names, also pinned by that test. Under-listing a
+# seed would be a silent unsound skip; over-listing merely over-runs the lane
+# (fail-safe).
 # ---------------------------------------------------------------------------
 [lanes]
 # fuzz.yml — the cargo-fuzz targets; the out-of-workspace fuzz crate depends on:
@@ -74,6 +76,14 @@ wasm = [
   "sparq-introspect",
   "sparq-solid",
 ]
+# [SONNET-4.6] sq-mel85: bench.yml `bench` job — the perf regression gate. Seeds =
+# the closure of the HARD-GATED (merge-blocking) perf metrics: sparq-engine (headline
+# benchmarked crate) + the release binaries the job builds (sparq-cli + sparq-bench,
+# which pull in sparq-core, whose store/dict/parse byte metrics are gated) + sparq-wasm
+# (the wasm_bundle_bytes floor, enforced ONLY here; a wasm-only diff does not flow up
+# into engine/cli/bench, so sparq-wasm must be a DIRECT seed — omitting it would be an
+# unsound skip). Push-to-main runs mode=full, so the FULL suite + auto-ratchet always run.
+bench = ["sparq-engine", "sparq-cli", "sparq-bench", "sparq-wasm"]
 
 # ---------------------------------------------------------------------------
 # [[map]] — attribution of OUT-OF-CRATE inputs to the crates that read them.

--- a/scripts/ci_select.py
+++ b/scripts/ci_select.py
@@ -116,12 +116,20 @@ _FULL_TRIGGERS: list[tuple[str, str]] = [
 #     wasm-only diff does NOT flow up into engine/cli/bench (they do not depend on
 #     sparq-wasm), so omitting it would silently drop the bundle gate for a wasm-only
 #     PR — exactly the unsound skip §2 forbids. sparq-engine is the headline
-#     benchmarked crate (and is embedded in the wasm bundle). The many trend-ONLY
-#     latency metrics (geo/text/vectors/rsp/hdt/solid/nlq/zk) are advisory comments,
-#     not merge-blocking, so they are deliberately NOT seeds — skipping their comment
-#     on an unrelated PR loses no gate. On push-to-main the selector returns mode=full
-#     (push is not a pull_request/merge_group event), so the FULL suite always runs on
-#     main and the auto-ratchet + benchmark-data history stay continuous (design §6.1).
+#     benchmarked crate (and is embedded in the wasm bundle).
+#     TRUE INVARIANT FOR SEED SOUNDNESS: every hard-gated metric measured on the
+#     PR/merge_group tier must have its source crate reach a bench seed (store/dict/parse
+#     ← sparq-core via the release binaries; wasm_bundle ← sparq-wasm). The four
+#     additional mode:auto ratchets in bench/perf-baseline.json — fts_bytes_per_doc
+#     (sparq-text), vectors_diskann_recall_at10 / vectors_pq_recall_at10 (sparq-vectors),
+#     geo_compliance_deficit (sparq-geo) — need NO bench seed because scripts/ci-bench.sh
+#     measures them on the MAIN tier only (GITHUB_REF guards skip them on any non-main
+#     ref); every main-tier event is mode=full by construction. vectors/geo additionally
+#     reach the sparq-cli seed transitively, but the soundness rests on the main-tier-only
+#     measurement, not on that incidental reachability. On push-to-main the selector
+#     returns mode=full (push is not a pull_request/merge_group event), so the FULL suite
+#     always runs on main and the auto-ratchet + benchmark-data history stay continuous
+#     (design §6.1).
 # FAIL-CLOSED (design §2/§4.3): `lane_runs` runs the lane whenever mode != selected
 # (full/shadow/error) OR any seed is not a current workspace member (a typo'd or
 # renamed seed can never silently skip a lane — it forces the lane to run). The

--- a/scripts/ci_select.py
+++ b/scripts/ci_select.py
@@ -83,10 +83,11 @@ _FULL_TRIGGERS: list[tuple[str, str]] = [
 ]
 
 
-# --- phase-2 singleton-lane -> seed crates (design §5.2; bead sq-fmx4u.6) -----
+# --- phase-2 singleton-lane -> seed crates (design §5.2; beads sq-fmx4u.6, sq-mel85)
 # [OPUS-4.8] A "lane" is a SINGLETON CI job (not a per-crate matrix leg) that
-# always exercises a FIXED set of crates: the fuzz smoke (fuzz.yml) and the wasm
-# bundle build (ci.yml `wasm`). Phase 1 left these always-run (design P7); phase 2
+# always exercises a FIXED set of crates: the fuzz smoke (fuzz.yml), the wasm
+# bundle build (ci.yml `wasm`), and the perf-gate benchmark (bench.yml `bench` —
+# added by sq-mel85 [SONNET-4.6]). Phase 1 left these always-run (design P7); phase 2
 # maps each to the crate closure it exercises and skips it when that closure is
 # provably unaffected. A lane is affected iff any SEED crate is in the affected
 # closure — and because `affected` is the REVERSE-dependency closure of the diff,
@@ -95,8 +96,8 @@ _FULL_TRIGGERS: list[tuple[str, str]] = [
 # §3.3). So the forward-dependency reasoning is captured by a membership test on
 # the reverse closure — no separate forward walk is needed here.
 #
-# SEEDS (single source of truth; the fuzz.yml + ci.yml `wasm` job `if:` guards
-# MUST reference exactly these crate names — pinned by
+# SEEDS (single source of truth; the fuzz.yml + ci.yml `wasm` + bench.yml `bench`
+# job `if:` guards MUST reference exactly these crate names — pinned by
 # scripts/tests/test_ci_select_wiring.py, mirrored informationally in
 # ci/path-ownership.toml `[lanes]`):
 #   * fuzz — the cargo-fuzz targets. The out-of-workspace fuzz crate
@@ -104,6 +105,23 @@ _FULL_TRIGGERS: list[tuple[str, str]] = [
 #     mmap loader), sparq-engine (SPARQL parse), sparq-shacl (SHACL validation).
 #   * wasm — the ci.yml `wasm` job builds every browser bundle it names; each seed
 #     pulls its own engine/core wasm32 graph, so the seed set is the bundle crates.
+#   * bench — [SONNET-4.6] sq-mel85: the perf-gate benchmark (bench.yml). Seeds are
+#     the benchmarked-crate closure of the HARD-GATED (merge-blocking) metrics that
+#     scripts/perf-gate.py enforces on PRs: the store/dict byte-layout + parse
+#     metrics come from sparq-core (exercised via the release binaries the bench job
+#     builds — sparq-cli + sparq-bench — which both depend on sparq-core, so a core
+#     change lands in this reverse closure), and the wasm_bundle_bytes floor comes
+#     from the sparq-wasm browser bundle ci-bench.sh builds + measures. sparq-wasm
+#     is a DIRECT seed on purpose: that floor is enforced ONLY in bench.yml and a
+#     wasm-only diff does NOT flow up into engine/cli/bench (they do not depend on
+#     sparq-wasm), so omitting it would silently drop the bundle gate for a wasm-only
+#     PR — exactly the unsound skip §2 forbids. sparq-engine is the headline
+#     benchmarked crate (and is embedded in the wasm bundle). The many trend-ONLY
+#     latency metrics (geo/text/vectors/rsp/hdt/solid/nlq/zk) are advisory comments,
+#     not merge-blocking, so they are deliberately NOT seeds — skipping their comment
+#     on an unrelated PR loses no gate. On push-to-main the selector returns mode=full
+#     (push is not a pull_request/merge_group event), so the FULL suite always runs on
+#     main and the auto-ratchet + benchmark-data history stay continuous (design §6.1).
 # FAIL-CLOSED (design §2/§4.3): `lane_runs` runs the lane whenever mode != selected
 # (full/shadow/error) OR any seed is not a current workspace member (a typo'd or
 # renamed seed can never silently skip a lane — it forces the lane to run). The
@@ -119,6 +137,13 @@ _LANE_SEEDS: dict[str, list[str]] = {
         "sparq-shacl-wasm",
         "sparq-introspect",
         "sparq-solid",
+    ],
+    # [SONNET-4.6] sq-mel85: perf-gate bench closure (see the `bench` bullet above).
+    "bench": [
+        "sparq-engine",
+        "sparq-cli",
+        "sparq-bench",
+        "sparq-wasm",
     ],
 }
 
@@ -238,9 +263,10 @@ def reverse_closure(crate: str, reverse_adj: dict[str, set[str]]) -> set[str]:
 
 
 def lane_runs(sel: "Selection", seeds: list[str]) -> bool:
-    """[OPUS-4.8] sq-fmx4u.6: does a singleton lane (fuzz / wasm) need to run for
-    this Selection? This is the EXECUTABLE SPEC of the fuzz.yml + ci.yml `wasm`
-    job `if:` guards — the YAML expresses the identical rule inline
+    """[OPUS-4.8] sq-fmx4u.6 / sq-mel85: does a singleton lane (fuzz / wasm /
+    bench) need to run for this Selection? This is the EXECUTABLE SPEC of the
+    fuzz.yml + ci.yml `wasm` + bench.yml `bench` job `if:` guards — the YAML
+    expresses the identical rule inline
     (`mode != 'selected' || contains(affected, '"<seed>"') || ...`), and
     scripts/tests/test_ci_select_wiring.py pins the guards' seed set against
     `_LANE_SEEDS` so the two cannot drift.

--- a/scripts/tests/test_ci_select.py
+++ b/scripts/tests/test_ci_select.py
@@ -508,9 +508,11 @@ class RealMetadataShapeTests(unittest.TestCase):
         # HONEST over-run (sq-mel85): the seed set is "sparq-engine + the release binaries"
         # (bead spec). sparq-cli transitively depends on sparq-geo (sparq-cli -> sparq-server
         # -> sparq-geo), so a geo change rebuilds a benchmarked release binary and the bench
-        # lane RUNS. This is a conservative over-run (a geo change cannot move a HARD-GATED
-        # metric — store/dict/parse are sparq-core, wasm_bundle is sparq-wasm), never an
-        # unsound skip. Pinned so the behaviour is a documented decision, not a surprise.
+        # lane RUNS. This is a conservative over-run (a geo change cannot move a
+        # PR-tier-measured hard-gated metric — store/dict/parse are sparq-core, wasm_bundle
+        # is sparq-wasm; geo_compliance_deficit is mode:auto but main-tier-only in ci-bench.sh,
+        # where mode=full always), never an unsound skip. Pinned so the behaviour is a
+        # documented decision, not a surprise.
         ws = cs.parse_workspace(self.meta)
         self.assertIn("sparq-cli", cs.reverse_closure("sparq-geo", ws.reverse_adj),
                       "test premise: sparq-cli depends transitively on sparq-geo")

--- a/scripts/tests/test_ci_select.py
+++ b/scripts/tests/test_ci_select.py
@@ -469,6 +469,66 @@ class RealMetadataShapeTests(unittest.TestCase):
         self.assertTrue(cs.lane_runs(sel, cs._LANE_SEEDS["wasm"]),
                         "sparq-core PR must RUN the wasm lane")
 
+    # ---- bench (perf-gate) lane acceptance, real metadata (bead sq-mel85) ------
+    def test_engine_pr_runs_bench(self):
+        # ACCEPTANCE (sq-mel85): an engine-touching PR runs the perf gate — sparq-engine
+        # is a direct bench seed (and the store/dict/parse hard-gated metrics could move).
+        sel = cs.select(["crates/sparq-engine/src/lib.rs"], self.meta)
+        self.assertEqual(sel.mode, "selected")
+        self.assertTrue(cs.lane_runs(sel, cs._LANE_SEEDS["bench"]),
+                        "engine-touching PR must RUN the bench lane")
+
+    def test_core_pr_runs_bench(self):
+        # A sparq-core change moves the HARD-GATED store/dict/parse byte metrics; core is
+        # a dep of every bench seed's release binary, so it lands in the affected closure.
+        sel = cs.select(["crates/sparq-core/src/dict.rs"], self.meta)
+        self.assertTrue(cs.lane_runs(sel, cs._LANE_SEEDS["bench"]),
+                        "sparq-core PR must RUN the bench lane (store/dict/parse floors)")
+
+    def test_wasm_only_pr_runs_bench(self):
+        # SOUNDNESS (sq-mel85): the wasm_bundle_bytes floor is enforced ONLY in bench.yml,
+        # and a wasm-only diff does NOT flow up into engine/cli/bench — so sparq-wasm is a
+        # DIRECT bench seed and a wasm-only PR must still RUN the perf gate.
+        sel = cs.select(["crates/sparq-wasm/src/lib.rs"], self.meta)
+        self.assertEqual(sel.mode, "selected")
+        self.assertTrue(cs.lane_runs(sel, cs._LANE_SEEDS["bench"]),
+                        "wasm-only PR must RUN the bench lane (wasm_bundle_bytes floor)")
+
+    def test_isolated_crate_pr_skips_bench(self):
+        # ACCEPTANCE (sq-mel85): a PR to a crate that NO bench seed depends on skips the
+        # perf gate. sparq-rsp is isolated (its bench is a standalone example, and neither
+        # sparq-engine/-cli/-bench/-wasm depends on it), so the bench closure is unaffected
+        # => skipped-green. Its trend-only latency comment is informational, not a gate.
+        sel = cs.select(["crates/sparq-rsp/src/lib.rs"], self.meta)
+        self.assertEqual(sel.mode, "selected")
+        self.assertFalse(cs.lane_runs(sel, cs._LANE_SEEDS["bench"]),
+                         "isolated-crate PR (sparq-rsp) must SKIP the bench lane")
+
+    def test_cli_linked_crate_runs_bench_conservatively(self):
+        # HONEST over-run (sq-mel85): the seed set is "sparq-engine + the release binaries"
+        # (bead spec). sparq-cli transitively depends on sparq-geo (sparq-cli -> sparq-server
+        # -> sparq-geo), so a geo change rebuilds a benchmarked release binary and the bench
+        # lane RUNS. This is a conservative over-run (a geo change cannot move a HARD-GATED
+        # metric — store/dict/parse are sparq-core, wasm_bundle is sparq-wasm), never an
+        # unsound skip. Pinned so the behaviour is a documented decision, not a surprise.
+        ws = cs.parse_workspace(self.meta)
+        self.assertIn("sparq-cli", cs.reverse_closure("sparq-geo", ws.reverse_adj),
+                      "test premise: sparq-cli depends transitively on sparq-geo")
+        sel = cs.select(["crates/sparq-geo/src/lib.rs"], self.meta)
+        self.assertTrue(cs.lane_runs(sel, cs._LANE_SEEDS["bench"]),
+                        "geo change rebuilds the sparq-cli release binary => bench RUNS")
+
+    def test_docs_only_pr_skips_bench(self):
+        # ACCEPTANCE (sq-mel85): a docs-only PR (SAFE-listed research/**) selects an
+        # EMPTY closure, so the perf gate is inert => skipped-green. Real metadata (so the
+        # bench seeds are known members) + the research SAFE map entry.
+        m = [{"pattern": "research/**", "safe": True}]
+        sel = cs.select(["research/change-based-test-selection.md"], self.meta, m)
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, [])
+        self.assertFalse(cs.lane_runs(sel, cs._LANE_SEEDS["bench"]),
+                         "docs-only PR must SKIP the bench lane")
+
 
 class LaneMappingTests(unittest.TestCase):
     """[OPUS-4.8] sq-fmx4u.6 (design §5.2, phase 2): hermetic tests of
@@ -507,12 +567,17 @@ class LaneMappingTests(unittest.TestCase):
         self.assertTrue(cs.lane_runs(sel, ["sparq-core-TYPO"]),
                         "an unknown seed must fail-closed to RUN")
 
-    def test_lane_seeds_are_the_expected_two_lanes(self):
-        self.assertEqual(set(cs._LANE_SEEDS), {"fuzz", "wasm"})
+    def test_lane_seeds_are_the_expected_three_lanes(self):
+        # [SONNET-4.6] sq-mel85 added the `bench` lane to the fuzz + wasm phase-2 set.
+        self.assertEqual(set(cs._LANE_SEEDS), {"fuzz", "wasm", "bench"})
         self.assertEqual(cs._LANE_SEEDS["fuzz"],
                          ["sparq-core", "sparq-engine", "sparq-shacl"])
         self.assertIn("sparq-wasm", cs._LANE_SEEDS["wasm"])
         self.assertIn("sparq-solid", cs._LANE_SEEDS["wasm"])
+        # bench (perf gate): sparq-engine + the release binaries + sparq-wasm (the
+        # wasm_bundle_bytes floor is enforced only in bench.yml — a direct seed).
+        self.assertEqual(cs._LANE_SEEDS["bench"],
+                         ["sparq-engine", "sparq-cli", "sparq-bench", "sparq-wasm"])
 
     # ---- SAFE-only coverage-ratchet skip (acceptance) -------------------------
     @staticmethod

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -36,6 +36,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import re
 import sys
 import unittest
@@ -409,6 +410,13 @@ class TestPhase2LaneScoping(unittest.TestCase):
             "Auto-ratchet the perf floor (commit improvements back to main)",
             "Ensure benchmark-data history branch exists",
             "Seed Pages dashboard onto benchmark-data (if absent)",
+            # [SONNET-4.6] sq-mel85 nit: the cleanup step (restores Cargo.lock churn before
+            # the benchmark-data branch switch) must also be schedule-excluded — the nightly
+            # backstop never switches branches, so it needs no cleanup, and running it on
+            # schedule would be a no-op that can't break anything, but pinning the guard
+            # prevents silent removal of the schedule-exclusion that would leave the step
+            # active on a path where `git checkout -- .` could discard useful artefacts.
+            "Clean bench-induced tracked churn before history switch (main only)",
         ]
         by_name = {s.get("name"): s for s in steps}
         for n in names:
@@ -470,6 +478,157 @@ class TestPhase2LaneScoping(unittest.TestCase):
         mirror = data.get("lanes", {})
         self.assertEqual(mirror, self.lane_seeds,
                          "ci/path-ownership.toml [lanes] mirror drifted from _LANE_SEEDS")
+
+
+# [SONNET-4.6] sq-mel85: bench metric tier invariant.
+#
+# INVARIANT: every mode:auto metric in bench/perf-baseline.json is either
+#   (a) produced by a main-tier-only ci-bench.sh hook (a GITHUB_REF guard skips it
+#       whenever GITHUB_REF != refs/heads/main, so it only runs on push-to-main and
+#       local dev runs where GITHUB_REF is unset; every such event is mode=full by
+#       construction, so no bench seed is needed), OR
+#   (b) measured on the PR/merge_group tier, in which case its source crate must reach
+#       a bench seed so a PR touching it triggers the gate.
+#
+# RATIONALE: the danger is a future PR-tier PROMOTION of a currently-main-tier-only
+# metric (removing its GITHUB_REF guard). Without this test, that change would:
+#   1. Start measuring, say, fts_bytes_per_doc on PRs that skip the bench lane (because
+#      sparq-text is not a bench seed), and
+#   2. Have the perf gate silently pass because the bench lane was skipped.
+# This would be exactly the unsound skip the design forbids (§2). With this test:
+#   - Moving a metric from main-tier-only to PR-tier fails assertion (b) in
+#     _EXPECTED_MAIN_TIER below, forcing a conscious update.
+#   - The update requires either adding a GITHUB_REF guard (keeping it main-only) OR
+#     adding the source crate to _LANE_SEEDS["bench"] (making it a bench seed).
+#
+# Guard detection uses ci-bench.sh's top-level `if [...] != "refs/heads/main"` blocks
+# (identified by the guard pattern at column 0) to build ranges, then checks that each
+# metric's `add` call falls within a range — no hardcoded line numbers.
+class TestBenchMetricTierInvariant(unittest.TestCase):
+    """[SONNET-4.6] sq-mel85: pin the invariant that every mode:auto metric in
+    bench/perf-baseline.json is either main-tier-only (GITHUB_REF guard in ci-bench.sh)
+    or PR-tier with a bench seed covering its source crate."""
+
+    # Pattern that identifies a top-level GITHUB_REF main-tier guard start line
+    _GUARD_START_RE = re.compile(r'^if\b.*!=\s*["\']refs/heads/main["\']')
+    # Pattern for any top-level `fi` (column 0, no leading whitespace)
+    _TOP_FI_RE = re.compile(r'^fi\b')
+
+    @classmethod
+    def setUpClass(cls):
+        baseline_path = REPO_ROOT / "bench" / "perf-baseline.json"
+        with open(baseline_path, encoding="utf-8") as f:
+            baseline = json.load(f)
+        cls.auto_metrics = frozenset(
+            k for k, v in baseline["metrics"].items() if v.get("mode") == "auto"
+        )
+        cls.cibench_lines = (
+            REPO_ROOT / "scripts" / "ci-bench.sh"
+        ).read_text(encoding="utf-8").splitlines()
+        cls.lane_seeds = _ci_select_module()._LANE_SEEDS
+
+    def _guard_ranges(self) -> list[tuple[int, int]]:
+        """Return (start, end) 0-indexed inclusive ranges for each main-tier guard block.
+        A block spans from the guard `if` to the next top-level `fi` at column 0.
+        This relies on the verified structure of ci-bench.sh: each GITHUB_REF guard block
+        opens with a top-level `if [...] != 'refs/heads/main'` and closes with a top-level
+        `fi` at column 0; no nested top-level `if`/`fi` appear inside these blocks."""
+        lines = self.cibench_lines
+        ranges: list[tuple[int, int]] = []
+        i = 0
+        while i < len(lines):
+            if self._GUARD_START_RE.match(lines[i]):
+                start = i
+                j = i + 1
+                while j < len(lines) and not self._TOP_FI_RE.match(lines[j]):
+                    j += 1
+                ranges.append((start, j))  # j is the `fi` line (0-indexed)
+                i = j + 1
+            else:
+                i += 1
+        return ranges
+
+    def _add_line_indices(self, metric: str) -> list[int]:
+        """Return 0-indexed line numbers of add-call(s) for this metric in ci-bench.sh.
+        Handles both literal names and the dynamic `add "vectors_${name}"` pattern used
+        for the vectors metrics."""
+        if metric.startswith("vectors_"):
+            # Emitted dynamically as `add "vectors_${name}"` — match the shell expansion
+            pat = re.compile(r'\badd\s+["\']?vectors_\$\{')
+        else:
+            pat = re.compile(r'\badd\s+["\']?' + re.escape(metric) + r'["\']?\s')
+        return [i for i, ln in enumerate(self.cibench_lines) if pat.search(ln)]
+
+    def _is_main_tier_only(self, metric: str, ranges: list[tuple[int, int]]) -> bool:
+        """Return True iff every add-call for this metric falls inside a main-tier guard
+        block (start < line_index < end, exclusive of the guard `if` and `fi` lines)."""
+        indices = self._add_line_indices(metric)
+        if not indices:
+            return False  # metric not found → conservatively PR-tier
+        return all(
+            any(start < idx < end for start, end in ranges)
+            for idx in indices
+        )
+
+    def test_auto_metric_tier_invariant(self):
+        """Pin the main-tier-only vs PR-tier classification for every mode:auto metric.
+
+        EXPECTED_MAIN_TIER: metrics behind a GITHUB_REF guard in ci-bench.sh — measured
+        only on push-to-main (and local dev runs). No bench seed required (mode=full on
+        all main-tier events).
+
+        EXPECTED_PR_TIER: metrics measured on every CI tier, incl. PRs. Their source crates
+        must reach a bench seed — verified by the acceptance tests in test_ci_select.py
+        (test_core_pr_runs_bench / test_wasm_only_pr_runs_bench / test_engine_pr_runs_bench).
+
+        IF THIS TEST FAILS after a change to ci-bench.sh or bench/perf-baseline.json:
+          - New metric added? Classify it: add a GITHUB_REF guard (→ EXPECTED_MAIN_TIER) OR
+            add its source crate to _LANE_SEEDS["bench"] (→ EXPECTED_PR_TIER).
+          - Metric promoted from main-tier to PR-tier? Add its source crate to
+            _LANE_SEEDS["bench"] AND move it from EXPECTED_MAIN_TIER to EXPECTED_PR_TIER.
+          - NEVER leave a PR-tier hard-gated metric without a matching bench seed.
+        """
+        _EXPECTED_MAIN_TIER = frozenset({
+            # ci-bench.sh measures these ONLY on push-to-main (GITHUB_REF guard skips on PRs):
+            "fts_bytes_per_doc",           # sparq-text example; FTS_REF guard
+            "vectors_diskann_recall_at10",  # sparq-vectors example; VECTOR_REF guard
+            "vectors_pq_recall_at10",       # sparq-vectors example; VECTOR_REF guard
+            "geo_compliance_deficit",       # sparq-geo example; GEO_REF guard
+        })
+        _EXPECTED_PR_TIER = frozenset({
+            # ci-bench.sh measures these on EVERY tier (no GITHUB_REF guard); bench seeds cover:
+            "store_bytes_per_triple",       # sparq-core (via sparq-cli + sparq-bench seeds)
+            "store_bytes_per_triple_small", # sparq-core (via sparq-cli + sparq-bench seeds)
+            "dict_bytes_per_term",          # sparq-core (via sparq-cli + sparq-bench seeds)
+            "wasm_bundle_bytes",            # sparq-wasm (direct bench seed)
+        })
+        # 1. The union must be exactly the full auto-metric set from perf-baseline.json.
+        self.assertEqual(
+            self.auto_metrics,
+            _EXPECTED_MAIN_TIER | _EXPECTED_PR_TIER,
+            "bench/perf-baseline.json mode:auto metrics changed. Update the expected "
+            "sets in this test. See the docstring for the required update procedure.",
+        )
+        # 2. Guard detection must agree with the expected classification for each metric.
+        ranges = self._guard_ranges()
+        self.assertTrue(ranges, "no GITHUB_REF guard blocks found in ci-bench.sh — "
+                        "guard detection is broken (check _GUARD_START_RE)")
+        for metric in sorted(_EXPECTED_MAIN_TIER):
+            self.assertTrue(
+                self._is_main_tier_only(metric, ranges),
+                f"{metric!r} is expected to be main-tier-only, but ci-bench.sh has no "
+                f"GITHUB_REF main-tier guard enclosing its `add` call. Either add the "
+                f"guard or move it to _EXPECTED_PR_TIER and add a bench seed.",
+            )
+        for metric in sorted(_EXPECTED_PR_TIER):
+            self.assertFalse(
+                self._is_main_tier_only(metric, ranges),
+                f"{metric!r} is expected to be PR-tier, but seems to be behind a "
+                f"GITHUB_REF guard. Move it to _EXPECTED_MAIN_TIER.",
+            )
+        # 3. Bench seed set must be non-empty (sanity guard for the invariant).
+        self.assertGreater(len(self.lane_seeds["bench"]), 0,
+                           "_LANE_SEEDS['bench'] is empty — no PR-tier gate exists")
 
 
 # [SONNET-4.6] sq-fmx4u.4: required-check anchor tests.

--- a/scripts/tests/test_ci_select_wiring.py
+++ b/scripts/tests/test_ci_select_wiring.py
@@ -52,6 +52,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CI_YML = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 FM_YML = REPO_ROOT / ".github" / "workflows" / "feature-matrix.yml"
 FUZZ_YML = REPO_ROOT / ".github" / "workflows" / "fuzz.yml"  # [OPUS-4.8] sq-fmx4u.6
+BENCH_YML = REPO_ROOT / ".github" / "workflows" / "bench.yml"  # [SONNET-4.6] sq-mel85
 SELECT_YML = REPO_ROOT / ".github" / "workflows" / "ci-select.yml"
 GATE_PY = REPO_ROOT / "scripts" / "ci_summary_gate.py"
 CI_SELECT_PY = REPO_ROOT / "scripts" / "ci_select.py"  # [OPUS-4.8] sq-fmx4u.6
@@ -110,6 +111,7 @@ class TestWiring(unittest.TestCase):
         cls.ci = _load(CI_YML)
         cls.fm = _load(FM_YML)
         cls.fuzz = _load(FUZZ_YML)  # [OPUS-4.8] sq-fmx4u.6
+        cls.bench = _load(BENCH_YML)  # [SONNET-4.6] sq-mel85
         cls.sel = _load(SELECT_YML)
         cls.members = _workspace_members()
         cls.gate = _gate_module()
@@ -120,7 +122,7 @@ class TestWiring(unittest.TestCase):
         """Any job-level `if:` mentioning the selection outputs must include the
         `mode != 'selected'` disjunct, so empty/missing outputs mean RUN."""
         for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm),
-                            ("fuzz.yml", self.fuzz)):
+                            ("fuzz.yml", self.fuzz), ("bench.yml", self.bench)):
             for job_id, job in wf["jobs"].items():
                 cond = job.get("if", "")
                 if "needs.select.outputs" in str(cond):
@@ -133,7 +135,7 @@ class TestWiring(unittest.TestCase):
     def test_selection_guarded_jobs_need_select(self):
         """A guard reading needs.select.* only resolves if `select` is in needs."""
         for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm),
-                            ("fuzz.yml", self.fuzz)):
+                            ("fuzz.yml", self.fuzz), ("bench.yml", self.bench)):
             for job_id, job in wf["jobs"].items():
                 if "needs.select.outputs" in str(job.get("if", "")):
                     needs = job.get("needs", [])
@@ -148,7 +150,8 @@ class TestWiring(unittest.TestCase):
     # ---- crate needles are real --------------------------------------------------
     def test_every_affected_needle_is_a_workspace_member(self):
         text = (CI_YML.read_text(encoding="utf-8") + FM_YML.read_text(encoding="utf-8")
-                + FUZZ_YML.read_text(encoding="utf-8"))  # [OPUS-4.8] sq-fmx4u.6
+                + FUZZ_YML.read_text(encoding="utf-8")  # [OPUS-4.8] sq-fmx4u.6
+                + BENCH_YML.read_text(encoding="utf-8"))  # [SONNET-4.6] sq-mel85
         needles = NEEDLE_RE.findall(text)
         self.assertTrue(needles, "expected contains(affected, ...) guards to exist")
         unknown = sorted({n for n in needles if n not in self.members})
@@ -177,7 +180,7 @@ class TestWiring(unittest.TestCase):
         evaluates empty, which under enforcement would skip every leg. The
         per-shard guard must live in a STEP (env/run), never the job `if:`."""
         for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm),
-                            ("fuzz.yml", self.fuzz)):
+                            ("fuzz.yml", self.fuzz), ("bench.yml", self.bench)):
             for job_id, job in wf["jobs"].items():
                 self.assertNotIn(
                     "matrix.", str(job.get("if", "")),
@@ -187,7 +190,7 @@ class TestWiring(unittest.TestCase):
     # ---- select job shape ----------------------------------------------------------
     def test_select_caller_jobs_are_unconditional_and_use_the_reusable_workflow(self):
         for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm),
-                            ("fuzz.yml", self.fuzz)):
+                            ("fuzz.yml", self.fuzz), ("bench.yml", self.bench)):
             job = wf["jobs"].get("select")
             self.assertIsNotNone(job, f"{wf_name}: missing the select job")
             self.assertEqual(job.get("uses"), "./.github/workflows/ci-select.yml", wf_name)
@@ -247,7 +250,7 @@ class TestWiring(unittest.TestCase):
         both selection-consuming workflows react to labeled/unlabeled — and must NOT
         drop the default `synchronize` (push-to-PR) trigger while doing so."""
         for wf_name, wf in (("ci.yml", self.ci), ("feature-matrix.yml", self.fm),
-                            ("fuzz.yml", self.fuzz)):
+                            ("fuzz.yml", self.fuzz), ("bench.yml", self.bench)):
             on = _on_block(wf)
             pr = on.get("pull_request") or {}
             self.assertIsInstance(
@@ -329,6 +332,7 @@ class TestPhase2LaneScoping(unittest.TestCase):
     def setUpClass(cls):
         cls.ci = _load(CI_YML)
         cls.fuzz = _load(FUZZ_YML)
+        cls.bench = _load(BENCH_YML)  # [SONNET-4.6] sq-mel85
         cls.members = _workspace_members()
         cls.lane_seeds = _ci_select_module()._LANE_SEEDS
 
@@ -366,6 +370,60 @@ class TestPhase2LaneScoping(unittest.TestCase):
         on = _on_block(self.fuzz)
         self.assertIn("schedule", on, "fuzz.yml must keep its nightly schedule backstop")
         self.assertIn("merge_group", on, "fuzz.yml must run on merge_group for the gate")
+
+    # ---- bench (perf-gate) lane (bench.yml) — [SONNET-4.6] sq-mel85 ----------------
+    def test_bench_job_guarded_by_its_seed_closure(self):
+        job = self.bench["jobs"]["bench"]
+        cond = str(job.get("if", ""))
+        self.assertIn(FAIL_CLOSED_DISJUNCT, cond,
+                      "bench guard must be fail-closed (empty output => RUN)")
+        needs = job.get("needs", [])
+        needs = [needs] if isinstance(needs, str) else needs
+        self.assertIn("select", needs, "bench job must need the select pre-job")
+        self.assertEqual(self._guard_needles(cond), self.lane_seeds["bench"],
+                         "bench guard needles must equal ci_select.py _LANE_SEEDS['bench']")
+
+    def test_bench_has_unconditional_select_caller(self):
+        job = self.bench["jobs"].get("select")
+        self.assertIsNotNone(job, "bench.yml must carry the select pre-job")
+        self.assertEqual(job.get("uses"), "./.github/workflows/ci-select.yml")
+        self.assertNotIn("if", job, "select must be unconditional (gate needs it green)")
+        self.assertNotIn("needs", job)
+
+    def test_bench_runs_on_schedule_backstop(self):
+        # sq-mel85 added a nightly schedule to bench.yml as the full-run backstop: a
+        # schedule event carries no PR diff => selector mode=full => the fail-closed
+        # disjunct RUNS the whole suite. merge_group is retained for the perf gate.
+        on = _on_block(self.bench)
+        self.assertIn("schedule", on, "bench.yml must have the nightly schedule backstop")
+        self.assertIn("merge_group", on, "bench.yml must run on merge_group for the gate")
+
+    def test_bench_main_history_and_ratchet_exclude_schedule(self):
+        # CRITICAL (design §6.1 continuity, criterion (d)): the auto-ratchet + history +
+        # dashboard writes must stay on the push-to-main path and NOT fire on the new
+        # nightly `schedule` backstop (a scheduled run shares the last main commit's SHA,
+        # so writing history would append a duplicate point + ratchet off a non-landing
+        # run). Every such step's guard must exclude schedule.
+        steps = self.bench["jobs"]["bench"]["steps"]
+        names = [
+            "Auto-ratchet the perf floor (commit improvements back to main)",
+            "Ensure benchmark-data history branch exists",
+            "Seed Pages dashboard onto benchmark-data (if absent)",
+        ]
+        by_name = {s.get("name"): s for s in steps}
+        for n in names:
+            self.assertIn(n, by_name, f"bench.yml lost the '{n}' step")
+            cond = str(by_name[n].get("if", ""))
+            self.assertIn("github.event_name != 'schedule'", cond,
+                          f"'{n}' must exclude the schedule backstop (main continuity)")
+            self.assertIn("refs/heads/main", cond,
+                          f"'{n}' must stay push-to-main scoped")
+        # The github-action-benchmark auto-push must also be schedule-excluded.
+        store = by_name.get("Store + compare against history")
+        self.assertIsNotNone(store, "bench.yml lost the history Store step")
+        self.assertIn("github.event_name != 'schedule'",
+                      str(store.get("with", {}).get("auto-push", "")),
+                      "history auto-push must not fire on the schedule backstop")
 
     # ---- wasm lane (ci.yml) --------------------------------------------------------
     def test_wasm_job_guarded_by_its_seed_closure(self):


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI/infra. Implements bead **sq-mel85** (change-based test-selection phase 2b — the perf gate). Design: research/change-based-test-selection.md §5.2 (perf-gate = phase 2). Deferred from sq-fmx4u.6 (PR #1510); mirrors the fuzz/wasm conventions that shipped there. **DO NOT ARM** — CI-selection surface = escalated review.

## What this wires + where

Phase 2b scopes the last always-run singleton lane — the **perf regression gate** in `.github/workflows/bench.yml` — by mapping it to the crate closure it exercises and skipping it when that closure is **provably unaffected** (fail-closed).

| Piece | File | Change |
|---|---|---|
| **select pre-job** | `.github/workflows/bench.yml` | adds the unconditional reusable `select` job (`uses: ./.github/workflows/ci-select.yml`) |
| **bench guard** | `.github/workflows/bench.yml` | job-level `if:` on the (non-matrix) `bench` job: `mode != 'selected' \|\| contains(affected, '"sparq-engine"'/'\"sparq-cli\"'/'\"sparq-bench\"'/'\"sparq-wasm\"')` |
| **nightly backstop** | `.github/workflows/bench.yml` | new `schedule` cron (05:29 UTC) — full-run backstop (design §6.1) |
| **seed set** | `scripts/ci_select.py` | `_LANE_SEEDS["bench"]` + updated `lane_runs` docstring |
| **mirror** | `ci/path-ownership.toml` | `[lanes] bench = [...]` (drift-guarded == `_LANE_SEEDS`) |
| **tests** | `scripts/tests/test_ci_select*.py` | bench acceptance + wiring/guard-shape + main-continuity pins |

**Single source of truth:** `scripts/ci_select.py` `_LANE_SEEDS["bench"] = ["sparq-engine", "sparq-cli", "sparq-bench", "sparq-wasm"]` — the executable spec of the YAML guard, mirrored in `ci/path-ownership.toml [lanes]`, both pinned by `test_ci_select_wiring.py`.

## Seed soundness (why sparq-wasm is a direct seed)

The bead spec seeds "sparq-engine + the release-binary crates". The **TRUE INVARIANT** for seed soundness: every hard-gated metric measured on the PR/merge_group tier must have its source crate reach a bench seed.

- `store_bytes_per_triple(_small)` / `dict_bytes_per_term` come from **sparq-core** — reached because the release binaries the job builds (`sparq-cli` + `sparq-bench`) depend on it, so a core change lands in the affected reverse closure.
- `wasm_bundle_bytes` comes from the **sparq-wasm** browser bundle `ci-bench.sh` builds + measures. This floor is enforced **only** in bench.yml, and a wasm-only diff does **not** flow up into engine/cli/bench (they don't depend on sparq-wasm) — so `sparq-wasm` is a **direct seed**. Omitting it would silently drop the bundle gate for a wasm-only PR (the unsound skip §2 forbids).

The four additional `mode: auto` ratchets in `bench/perf-baseline.json` — `fts_bytes_per_doc` (sparq-text), `vectors_diskann_recall_at10` / `vectors_pq_recall_at10` (sparq-vectors), `geo_compliance_deficit` (sparq-geo) — are **hard ratchets, not advisory**, but need no bench seed because `scripts/ci-bench.sh` measures them on the **MAIN tier only** (GITHUB_REF guards at the geo/fts/vector blocks skip them on any non-main ref); every main-tier event is `mode=full` by construction. vectors/geo additionally reach the sparq-cli seed transitively, but the soundness rests on the main-tier-only measurement. Measured selectivity: **bench skips 30/49 single-crate PRs, runs 19**.

Honest over-run note: `sparq-cli` transitively depends on `sparq-geo` (`sparq-cli → sparq-server → sparq-geo`), so a geo-only PR **runs** bench (the release binary genuinely rebuilds). This is a conservative over-run (a geo change cannot move a **PR-tier-measured** hard-gated metric — store/dict/parse are sparq-core, wasm_bundle is sparq-wasm; `geo_compliance_deficit` is `mode:auto` but main-tier-only in ci-bench.sh, where mode=full always), never an unsound skip. Pinned by `test_cli_linked_crate_runs_bench_conservatively`.

## Main-branch continuity (CRITICAL — criterion d, fail-closed)

Selection must **never** interfere with the auto-ratchet-floor + history-tracking on main.

- **push-to-main + schedule** are not `pull_request`/`merge_group` events ⇒ `ci_select.py` returns `mode=full` ⇒ the leading `mode != 'selected'` disjunct is TRUE ⇒ the **full** suite runs on every main commit and on the nightly backstop. Selection can **only** narrow on `pull_request`/`merge_group`.
- The auto-ratchet floor commit + `benchmark-data` history push + Pages-dashboard seed steps are re-scoped from `github.ref == 'refs/heads/main'` to `github.event_name != 'schedule' && github.ref == 'refs/heads/main'`, so the nightly backstop verifies the gate **without** committing a floor or pushing a duplicate per-commit history point. **push-to-main and workflow_dispatch behaviour is unchanged.**

## Gate aggregator

Untouched. The `select` reusable job's check-run carries "change-based test selection" (detected by `ci_summary_gate.py` SELECT_RE, required green — the selector traps all errors ⇒ exit 0 ⇒ green). A selection-skipped `bench` reports conclusion `skipped`, which `ci-summary / gate` counts as satisfied (no per-leg name is individually required — bead sq-fmx4u.4). **This leg gates.**

## Verify

- `actionlint` **clean** (bench.yml, ci-select.yml); YAML + TOML valid.
- Tests: `test_ci_select.py` **58 pass** (bench acceptance: engine/core/wasm-only RUN, docs-only + isolated-rsp SKIP), `test_ci_select_wiring.py` **32 pass** (bench guard shape, seed == `_LANE_SEEDS`, `[lanes]` mirror, schedule backstop, main-continuity pin, metric-tier invariant), `test_path_ownership.py` **21**, `test_ci_summary_gate.py` **33** — gate aggregator intact.
- **Local reproduction** (shipped hermetic harness `ci_select.py --changed-file --metadata-file`, real `cargo metadata`, exact `contains(affected, '"X"')` guard semantics):
  - engine-touching (`crates/sparq-engine/src/lib.rs`) → `mode=selected`, affected ∋ sparq-engine ⇒ **bench RUNS**
  - docs-only (`research/**`, SAFE) → `mode=selected, affected=[]` ⇒ **bench SKIPS (skipped-green)**
  - wasm-only (`crates/sparq-wasm/src/lib.rs`) → `affected=["sparq-wasm"]` ⇒ **bench RUNS** (bundle floor)
  - isolated (`crates/sparq-rsp/src/lib.rs`) → `affected=["sparq-rsp","sparq-rsp-wasm"]`, no bench seed ⇒ **bench SKIPS**
  - `push` / `schedule` / `workflow_dispatch` → `mode=full` ⇒ **bench RUNS FULL**

No `crates/` source touched. SHA-pins untouched (reuses the in-repo `ci-select.yml`; no new actions).

## Compliance gap closed

Completes the change-based test-selection design's phase-2 lane scoping: the perf gate is now selection-scoped on PRs with a fail-closed guard, backed by a nightly full-matrix backstop — closing the last always-run singleton lane while preserving the merge-blocking hard-gate coverage and the main-branch ratchet/history continuity.

Closes sq-mel85.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
