### PR TITLE
fix(gui/workspace): snapshot after SPARQL UPDATE — INSERT/DELETE data survives reload (sq-7gdfp)

### DIFF
--- a/gui/app/src/components/workbench/query-workbench.tsx
+++ b/gui/app/src/components/workbench/query-workbench.tsx
@@ -465,7 +465,7 @@ export function QueryWorkbench() {
   // query survives a reload / workspace switch (the persisted editor state was never restored
   // before). `workspace` starts null (restore is async); we seed the editor from it once, on the
   // first restore AND on every workspace-id change, and write the text back (debounced) below.
-  const { workspace, setEditorQuery } = useWorkspace();
+  const { workspace, setEditorQuery, recordUpdateSnapshot } = useWorkspace();
   const [query, setQuery] = React.useState(DEFAULT_QUERY);
   // The id of the workspace whose editor text is currently loaded — guards the write-back from
   // firing (and clobbering the saved query) before the restore has hydrated the editor.
@@ -517,6 +517,12 @@ export function QueryWorkbench() {
         const result = await run(query, { mode, signal: controller.signal });
         setOutcome(result.outcome);
         setRunLatencyMs(result.latencyMs);
+        // (sq-7gdfp) — snapshot the live store after a successful SPARQL UPDATE so INSERT/DELETE
+        // data survives a page reload. A failed update yields outcome.kind === "error" and never
+        // reaches here, so the snapshot is never taken on failure.
+        if (result.outcome.kind === "update") {
+          void recordUpdateSnapshot();
+        }
         // Pick the most useful default view for the result shape.
         if (result.outcome.kind === "graph") {
           if (view === "table" || view === "json") setView("graph");
@@ -528,7 +534,7 @@ export function QueryWorkbench() {
         setRunning(false);
       }
     },
-    [run, query, view, recordRecent],
+    [run, query, view, recordRecent, recordUpdateSnapshot],
   );
 
   const onStop = React.useCallback(() => {

--- a/gui/app/src/lib/workspace-context.tsx
+++ b/gui/app/src/lib/workspace-context.tsx
@@ -7,9 +7,11 @@
 // selected backends (Tauri on-disk when the fs capability is granted, browser localStorage on
 // the web target, in-memory fallback). This context is the GUI's host glue around it: it holds
 // the active workspace + its imported-source list (drives the left rail's Imports subgroup),
-// persists a workspace SNAPSHOT (the save/open cache) after each import, and — the load-bearing
-// fix (sq-lcd6e) — RESTORES that snapshot into the live engine on launch so a user's imported
-// data + editor state survive a reload instead of being silently replaced by the sample graph.
+// persists a workspace SNAPSHOT (the save/open cache) after each import AND after each
+// successful SPARQL UPDATE (sq-7gdfp — INSERT/DELETE-applied data is covered too, plus a
+// best-effort beforeunload flush), and — the load-bearing fix (sq-lcd6e) — RESTORES that
+// snapshot into the live engine on launch so a user's imported + updated data and editor state
+// survive a reload instead of being silently replaced by the sample graph.
 //
 // [OPUS-4.8] sq-lcd6e — this context is the workspace⇄engine HYDRATION bridge. Because
 // <WorkspaceProvider> is rendered UNDER <EngineProvider> (see app/layout.tsx), it can call

--- a/gui/app/src/lib/workspace-context.tsx
+++ b/gui/app/src/lib/workspace-context.tsx
@@ -117,6 +117,12 @@ export interface WorkspaceContextValue {
    * is excluded from the N3 closure (its cache-key hash changes, triggering a rebuild).
    */
   setRulesDocEnabled: (addedAt: number, enabled: boolean) => Promise<void>;
+  /**
+   * (sq-7gdfp) Persist a snapshot of the live store into the active workspace after a
+   * successful SPARQL UPDATE (INSERT/DELETE). Best-effort: a write failure never breaks the
+   * in-memory state. Call this whenever engine.run() returns outcome.kind === "update".
+   */
+  recordUpdateSnapshot: () => Promise<void>;
 }
 
 const WorkspaceContext = React.createContext<WorkspaceContextValue | null>(null);
@@ -304,6 +310,38 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
     [applyWorkspace, persist],
   );
 
+  // (sq-7gdfp) — snapshot the live store into the active workspace after a successful SPARQL UPDATE.
+  // Best-effort: a write failure (persistence layer down) never breaks the in-memory state.
+  const recordUpdateSnapshot = React.useCallback(async (): Promise<void> => {
+    const base = workspaceRef.current;
+    if (!base) return;
+    const snapshot = engineRef.current.snapshotStore();
+    if (snapshot === null) return; // engine not ready — skip; a failed UPDATE never reaches here anyway
+    const next: Workspace = { ...base, dataSnapshot: snapshot, updatedAt: Date.now() };
+    applyWorkspace(next);
+    persist(next);
+  }, [applyWorkspace, persist]);
+
+  // (sq-7gdfp) — belt-and-suspenders save: on page unload, snapshot the live engine store into
+  // the active workspace one final time. This catches any in-flight state that was not yet
+  // persisted (e.g. if the debounce had not fired yet). For the localStorage backend the
+  // store.save() call completes synchronously before the page unloads; for the Tauri FS backend
+  // it is async and may not complete, but the explicit recordUpdateSnapshot after each UPDATE is
+  // the primary mechanism — this is a safety net only.
+  React.useEffect(() => {
+    const handleBeforeUnload = () => {
+      const current = workspaceRef.current;
+      const store = storeRef.current;
+      if (!current || !store) return;
+      const snapshot = engineRef.current.snapshotStore();
+      if (snapshot === null) return;
+      const next: Workspace = { ...current, dataSnapshot: snapshot, updatedAt: Date.now() };
+      void store.save(next).catch(() => {});
+    };
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+  }, []); // storeRef, workspaceRef, engineRef are all refs — stable, no deps needed
+
   const createWorkspace = React.useCallback(
     async (name: string): Promise<Workspace> => {
       // 1. SAVE the current workspace's live snapshot first — no data loss on leaving it.
@@ -474,6 +512,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       addRulesDocs,
       removeRulesDoc,
       setRulesDocEnabled,
+      recordUpdateSnapshot,
     }),
     [
       workspace,
@@ -489,6 +528,7 @@ export function WorkspaceProvider({ children }: { children: React.ReactNode }) {
       addRulesDocs,
       removeRulesDoc,
       setRulesDocEnabled,
+      recordUpdateSnapshot,
     ],
   );
 

--- a/gui/e2e-playwright/specs/update-persist.web.spec.ts
+++ b/gui/e2e-playwright/specs/update-persist.web.spec.ts
@@ -1,0 +1,133 @@
+// (sq-7gdfp) [SONNET-4.6] — UPDATE persistence: SPARQL INSERT/DELETE data survives a page reload.
+//
+// Regression for bead sq-7gdfp (found by #1518 escalated review): workspace snapshots were
+// never taken after a SPARQL UPDATE, so INSERT/DELETE-applied data was silently lost on reload.
+// The fix (workspace-context.tsx recordUpdateSnapshot) snapshots after each successful UPDATE.
+//
+// Browser persona (*.web.spec.ts): no Tauri mock, no Tauri IPC. INSERT DATA runs entirely in
+// the in-tab WASM engine; the workspace persists to localStorage (web backend).
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only; assert the SPECIFIC triple.
+
+import { webTest as test, webExpect as expect, waitForEngineReady } from "../support/index.ts";
+
+// The specific triple we INSERT and then assert survives reload.
+const SUBJECT   = "http://example.org/update-persist-subject";
+const PREDICATE = "http://example.org/update-persist-predicate";
+const OBJECT    = "http://example.org/update-persist-object";
+
+const INSERT_QUERY =
+  `INSERT DATA { <${SUBJECT}> <${PREDICATE}> <${OBJECT}> . }`;
+const ASK_QUERY =
+  `ASK { <${SUBJECT}> <${PREDICATE}> <${OBJECT}> }`;
+
+/** Set the SPARQL editor value via the native setter + input event (React-controlled textarea). */
+async function setEditorValue(
+  page: import("@playwright/test").Page,
+  value: string,
+): Promise<void> {
+  await page.evaluate((text) => {
+    const el = document.querySelector<HTMLTextAreaElement>("#repl-query");
+    if (!el) throw new Error("Editor textarea #repl-query not found");
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    if (!setter) throw new Error("Could not access native value setter");
+    setter.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }, value);
+}
+
+/** Click Run query and wait for an outcome of the given kind. */
+async function runQuery(
+  page: import("@playwright/test").Page,
+  kind: "ask" | "select" | "update" | "error",
+): Promise<void> {
+  await page.getByRole("button", { name: "Run query" }).click();
+  await expect(page.locator(`[data-result-kind="${kind}"]`)).toBeVisible();
+}
+
+/** Poll localStorage until the active workspace's dataSnapshot contains the given string. */
+async function waitForSnapshotToContain(
+  page: import("@playwright/test").Page,
+  needle: string,
+): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate((n: string) => {
+          const prefix = "sparq.workspace.v1.";
+          for (let i = 0; i < localStorage.length; i++) {
+            const k = localStorage.key(i);
+            if (!k || !k.startsWith(prefix)) continue;
+            if (k.endsWith("__index__") || k.endsWith("__last__")) continue;
+            const val = localStorage.getItem(k);
+            if (!val) continue;
+            try {
+              const ws = JSON.parse(val) as { dataSnapshot?: string };
+              if (ws?.dataSnapshot?.includes(n)) return true;
+            } catch {
+              /* skip corrupt entries */
+            }
+          }
+          return false;
+        }, needle),
+      { timeout: 5_000 },
+    )
+    .toBe(true);
+}
+
+test.describe("update-persist", () => {
+  test("INSERT DATA triple survives a page reload", async ({ page }) => {
+    // ── Apply INSERT DATA. ────────────────────────────────────────────────────────────────────
+    await setEditorValue(page, INSERT_QUERY);
+    await runQuery(page, "update");
+
+    // ── Assert the triple is present in the live store (non-vacuous). ─────────────────────────
+    await setEditorValue(page, ASK_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+
+    // ── Wait for the snapshot to be persisted to localStorage. ────────────────────────────────
+    // The snapshot is taken synchronously in recordUpdateSnapshot; poll to confirm the write.
+    await waitForSnapshotToContain(page, SUBJECT);
+
+    // ── Reload — the moment INSERT DATA used to be silently lost. ─────────────────────────────
+    await page.reload();
+    await waitForEngineReady(page, { timeout: 90_000 });
+
+    // ── The inserted triple is STILL queryable after reload. ──────────────────────────────────
+    await setEditorValue(page, ASK_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+  });
+
+  test("a FAILED UPDATE (bad syntax) does NOT corrupt a prior snapshot", async ({ page }) => {
+    // ── First, do a successful INSERT to establish a clean baseline snapshot. ─────────────────
+    await setEditorValue(page, INSERT_QUERY);
+    await runQuery(page, "update");
+
+    // Confirm the triple is present.
+    await setEditorValue(page, ASK_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+
+    // Wait for the snapshot to be persisted.
+    await waitForSnapshotToContain(page, SUBJECT);
+
+    // ── Now run a syntactically invalid UPDATE. ────────────────────────────────────────────────
+    const BAD_UPDATE = "INSERT DATA { BAD SYNTAX TRIPLE . }";
+    await setEditorValue(page, BAD_UPDATE);
+    await runQuery(page, "error");
+
+    // ── Reload — the corrupted-snapshot path. ─────────────────────────────────────────────────
+    await page.reload();
+    await waitForEngineReady(page, { timeout: 90_000 });
+
+    // ── The originally-inserted triple must STILL be present (snapshot not corrupted). ─────────
+    await setEditorValue(page, ASK_QUERY);
+    await runQuery(page, "ask");
+    await expect(page.locator('[data-result-kind="ask"]')).toContainText("true");
+  });
+});


### PR DESCRIPTION
## Bug

SPARQL UPDATE mutations (INSERT DATA / DELETE DATA) applied via the workbench were never snapshotted into the persisted workspace. The workspace model only snapshotted on import, switch, or create — never after an in-place engine mutation. On reload, `hydrateFromSnapshot` used the pre-UPDATE snapshot, silently discarding all inserted or deleted triples.

## Fix

### `workspace-context.tsx` — `recordUpdateSnapshot`
New exported function on `WorkspaceContextValue` that reads the live engine store (`engineRef.current.snapshotStore()`), updates the in-memory workspace's `dataSnapshot` + `updatedAt`, and persists it. Best-effort: a write failure never breaks in-memory state. Added to the context `value` object and `useMemo` deps.

Also adds a `beforeunload` belt-and-suspenders effect: on page unload, one final snapshot is written to the store. This catches any state that slipped through before a debounce fired. The explicit `recordUpdateSnapshot` after each UPDATE is the primary mechanism; the `beforeunload` handler is a safety net only.

### `query-workbench.tsx` — call site
After `setOutcome(result.outcome)`, when `result.outcome.kind === "update"`, calls `void recordUpdateSnapshot()`. A failed UPDATE yields `outcome.kind === "error"` and never reaches this branch, so snapshots are never taken on failure. `recordUpdateSnapshot` is added to the `onRun` `useCallback` deps array.

## Test

New E2E spec: `gui/e2e-playwright/specs/update-persist.web.spec.ts` (web persona, localStorage backend, chromium-web project).

- **INSERT DATA triple survives a page reload** — inserts a specific triple, asserts it is queryable, polls localStorage until the snapshot contains the triple's subject IRI, reloads, asserts the triple is still queryable. Directly regresses the bug.
- **A FAILED UPDATE does NOT corrupt a prior snapshot** — inserts a triple, establishes a clean snapshot, runs a bad-syntax UPDATE (outcome=error), reloads, asserts the prior triple survives. Confirms the "snapshot only on success" invariant.

Both tests pass: 2/2 green in 4.3 s.

## Not armed

Data-loss surface — requires maintainer review before merge.

> 🤖 SPARQ agent (Sonnet 4.6, sq-7gdfp)