### PR TITLE
fix(zk/xpath): op:divide-dayTimeDuration-by-dayTimeDuration returns xs:decimal ratio (sq-3x7dl.9) [FABLE-5]

### DIFF
--- a/zk/xpath/SPARQL_COVERAGE.md
+++ b/zk/xpath/SPARQL_COVERAGE.md
@@ -144,7 +144,7 @@ This document details the implementation status of SPARQL 1.1 functions in noir_
 | duration - duration | op:subtract-dayTimeDurations | ✅ | Implemented as `duration_subtract` |
 | duration * number | op:multiply-dayTimeDuration | ✅ | Implemented as `duration_multiply` |
 | duration / number | op:divide-dayTimeDuration | ✅ | Implemented as `duration_divide` |
-| duration / duration | op:divide-dayTimeDuration-by-dayTimeDuration | ✅ | Implemented as `duration_divide_by_duration` |
+| duration / duration | op:divide-dayTimeDuration-by-dayTimeDuration | ✅ | Implemented as `duration_divide_by_duration` — xs:decimal ratio (never truncates; modelled as IEEE 754 double, the tree's documented decimal approximation) |
 | dateTime + duration | op:add-dayTimeDuration-to-dateTime | ✅ | Implemented as `datetime_add_duration` |
 | dateTime - duration | op:subtract-dayTimeDuration-from-dateTime | ✅ | Implemented as `datetime_subtract_duration` |
 | dateTime - dateTime | op:subtract-dateTimes | ✅ | Implemented as `datetime_difference` |

--- a/zk/xpath/scripts/generate_tests.py
+++ b/zk/xpath/scripts/generate_tests.py
@@ -1894,7 +1894,8 @@ def convert_xpath_expr(
                         setup = f"let dur = duration_from_microseconds({micros});"
                         return (setup, f"{noir_func}(dur, {divisor})", None)
 
-            # duration div duration -> i64 ratio
+            # duration div duration -> xs:decimal ratio (IEEE 754 double,
+            # F&O 3.1 sec. 8.4.10; sq-3x7dl.9)
             if symbol == "div" and noir_func == "duration_divide_by_duration":
                 if (
                     arg1_symbol == "dayTimeDuration"
@@ -2885,6 +2886,9 @@ def generate_noir_test(test: TestCase, function_name: str) -> Optional[str]:
         "ceil_double",
         "floor_double",
         "cast_integer_to_double",  # xs:double(integer)
+        # op:divide-dayTimeDuration-by-dayTimeDuration returns the xs:decimal
+        # ratio, modelled as an IEEE 754 double (F&O 3.1 sec. 8.4.10; sq-3x7dl.9)
+        "duration_divide_by_duration",
     ]
 
     # Functions that return Option<i64>
@@ -3506,6 +3510,12 @@ xpath = {{ path = "../../xpath" }}
             if "float" in func_lower or "float" in noir_func_lower:
                 imports.append("    XsdFloat,")
             if "double" in func_lower or "double" in noir_func_lower:
+                imports.append("    XsdDouble,")
+            # Emitted code can reference XsdDouble even when neither name
+            # mentions "double" (e.g. duration_divide_by_duration's xs:decimal
+            # ratio compares against XsdDouble::zero(); sq-3x7dl.9). The
+            # dedup pass below removes any double-add.
+            if "XsdDouble" in all_test_code:
                 imports.append("    XsdDouble,")
         else:
             # For unimplemented functions, import the stub function

--- a/zk/xpath/test_packages/xpath_test_opdivide_daytimeduration_by_daytimeduration/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_opdivide_daytimeduration_by_daytimeduration/src/chunk_0.nr
@@ -1,44 +1,98 @@
 //! Test chunk 0 for op:divide-dayTimeDuration-by-dayTimeDuration
-//! Contains 5 tests
+//! Contains 6 tests
 
-use dep::xpath::{duration_divide_by_duration, duration_from_microseconds};
+use dep::xpath::{duration_divide_by_duration, duration_from_microseconds, XsdDouble};
 
 #[test]
 fn op_divide_daytimeduration_by_daytimeduration2args_1() {
-    //  ******************************************************* Test:
+    // Test: op-divide-dayTimeDuration-by-dayTimeDuration2args-1
+    // Written By: Carmelo Montanez
+    // Date: Tue Apr 12 16:29:08 GMT-05:00 2005
+    // Purpose: Evaluates The 'op:divide-dayTimeDuration-by-dayTimeDuration' operator
+    // with the arguments set as follows:
+    // $arg1 = xs:dayTimeDuration(lower bound)
+    // $arg2 = xs:dayTimeDuration(lower bound)
+    // XPath: xs:dayTimeDuration("P0DT0H0M0S") div xs:dayTimeDuration("P0DT0H0M01S")
+    // Expected: assert-eq 0
     let dur1 = duration_from_microseconds(0);
     let dur2 = duration_from_microseconds(1000000);
-    assert(duration_divide_by_duration(dur1, dur2) == 0);
+    assert(duration_divide_by_duration(dur1, dur2) == XsdDouble::zero());
 }
 
 #[test]
 fn op_divide_daytimeduration_by_daytimeduration2args_2() {
-    //  ******************************************************* Test:
+    // Test: op-divide-dayTimeDuration-by-dayTimeDuration2args-2
+    // Written By: Carmelo Montanez
+    // Date: Tue Apr 12 16:29:08 GMT-05:00 2005
+    // Purpose: Evaluates The 'op:divide-dayTimeDuration-by-dayTimeDuration' operator
+    // with the arguments set as follows:
+    // $arg1 = xs:dayTimeDuration(mid range)
+    // $arg2 = xs:dayTimeDuration(lower bound)
+    // XPath: xs:dayTimeDuration("P15DT11H59M59S") div xs:dayTimeDuration("P0DT0H0M01S")
+    // Expected: assert-eq 1339199
     let dur1 = duration_from_microseconds(1339199000000);
     let dur2 = duration_from_microseconds(1000000);
-    assert(duration_divide_by_duration(dur1, dur2) == 1339199);
+    assert(duration_divide_by_duration(dur1, dur2).to_bits() == 4698502627627892736);
 }
 
 #[test]
 fn op_divide_daytimeduration_by_daytimeduration2args_3() {
-    //  ******************************************************* Test:
+    // Test: op-divide-dayTimeDuration-by-dayTimeDuration2args-3
+    // Written By: Carmelo Montanez
+    // Date: Tue Apr 12 16:29:08 GMT-05:00 2005
+    // Purpose: Evaluates The 'op:divide-dayTimeDuration-by-dayTimeDuration' operator
+    // with the arguments set as follows:
+    // $arg1 = xs:dayTimeDuration(upper bound)
+    // $arg2 = xs:dayTimeDuration(lower bound)
+    // XPath: xs:dayTimeDuration("P31DT23H59M59S") div xs:dayTimeDuration("P0DT0H0M01S")
+    // Expected: assert-eq 2764799
     let dur1 = duration_from_microseconds(2764799000000);
     let dur2 = duration_from_microseconds(1000000);
-    assert(duration_divide_by_duration(dur1, dur2) == 2764799);
+    assert(duration_divide_by_duration(dur1, dur2).to_bits() == 4703191771989934080);
 }
 
 #[test]
 fn op_divide_daytimeduration_by_daytimeduration2args_4() {
-    //  ******************************************************* Test:
+    // Test: op-divide-dayTimeDuration-by-dayTimeDuration2args-4
+    // Written By: Carmelo Montanez
+    // Date: Tue Apr 12 16:29:08 GMT-05:00 2005
+    // Purpose: Evaluates The 'op:divide-dayTimeDuration-by-dayTimeDuration' operator
+    // with the arguments set as follows:
+    // $arg1 = xs:dayTimeDuration(lower bound)
+    // $arg2 = xs:dayTimeDuration(mid range)
+    // XPath: xs:dayTimeDuration("P0DT0H0M0S") div xs:dayTimeDuration("P15DT11H59M59S")
+    // Expected: assert-eq 0
     let dur1 = duration_from_microseconds(0);
     let dur2 = duration_from_microseconds(1339199000000);
-    assert(duration_divide_by_duration(dur1, dur2) == 0);
+    assert(duration_divide_by_duration(dur1, dur2) == XsdDouble::zero());
 }
 
 #[test]
 fn op_divide_daytimeduration_by_daytimeduration2args_5() {
-    //  ******************************************************* Test:
+    // Test: op-divide-dayTimeDuration-by-dayTimeDuration2args-5
+    // Written By: Carmelo Montanez
+    // Date: Tue Apr 12 16:29:08 GMT-05:00 2005
+    // Purpose: Evaluates The 'op:divide-dayTimeDuration-by-dayTimeDuration' operator
+    // with the arguments set as follows:
+    // $arg1 = xs:dayTimeDuration(lower bound)
+    // $arg2 = xs:dayTimeDuration(upper bound)
+    // XPath: xs:dayTimeDuration("P0DT0H0M0S") div xs:dayTimeDuration("P31DT23H59M59S")
+    // Expected: assert-eq 0
     let dur1 = duration_from_microseconds(0);
     let dur2 = duration_from_microseconds(2764799000000);
-    assert(duration_divide_by_duration(dur1, dur2) == 0);
+    assert(duration_divide_by_duration(dur1, dur2) == XsdDouble::zero());
+}
+
+#[test]
+fn op_divide_daytimeduration_by_dtd_8() {
+    // Test: op-divide-dayTimeDuration-by-dTD-8
+    // Written By: Carmelo Montanez
+    // Date: June 30, 2005
+    // Purpose: Evaluates The 'divide-dayTimeDuration-by-dTD' operator that
+    // returns a negative value.
+    // XPath: (xs:dayTimeDuration("P10DT01H01M") div xs:dayTimeDuration("-P10DT01H01M"))
+    // Expected: assert-eq -1
+    let dur1 = duration_from_microseconds(867660000000);
+    let dur2 = duration_from_microseconds(-867660000000);
+    assert(duration_divide_by_duration(dur1, dur2).to_bits() == 13830554455654793216);
 }

--- a/zk/xpath/xpath/src/duration.nr
+++ b/zk/xpath/xpath/src/duration.nr
@@ -6,6 +6,8 @@
 //! XPath operators implemented:
 //! - op:add-dayTimeDurations, op:subtract-dayTimeDurations
 //! - op:multiply-dayTimeDuration, op:divide-dayTimeDuration
+//! - op:divide-dayTimeDuration-by-dayTimeDuration (xs:decimal ratio,
+//!   modelled as an IEEE 754 double -- the tree's decimal representation)
 //! - op:add-dayTimeDuration-to-dateTime, op:subtract-dayTimeDuration-from-dateTime
 //! - op:dayTimeDuration-equal, op:dayTimeDuration-less-than, op:dayTimeDuration-greater-than
 //! XPath functions implemented (generic dispatch on the duration subtype):
@@ -14,6 +16,7 @@
 //! - fn:months-from-duration (xs:dayTimeDuration -> 0 per F&O sec. 8.4.4,
 //!   xs:yearMonthDuration -> real months)
 
+use crate::numeric_types::{numeric_divide_int_as_double, XsdDouble};
 use crate::types::{XsdDateTime, XsdDayTimeDuration};
 use crate::year_month_duration::XsdYearMonthDuration;
 
@@ -201,11 +204,29 @@ pub fn duration_divide(dur: XsdDayTimeDuration, divisor: i64) -> XsdDayTimeDurat
 }
 
 /// op:divide-dayTimeDuration-by-dayTimeDuration
-/// Divides two durations, returning a ratio as i64
-pub fn duration_divide_by_duration(a: XsdDayTimeDuration, b: XsdDayTimeDuration) -> i64 {
+///
+/// F&O 3.1 sec. 8.4.10: returns the ratio of two xs:dayTimeDurations "as an
+/// xs:decimal number" -- it NEVER truncates: PT1H div PT40M = 1.5. The old
+/// `i64` return silently truncated that to 1 (sq-3x7dl.9).
+///
+/// DECIMAL REPRESENTATION: this codebase has no arbitrary-precision
+/// xs:decimal type -- decimals are modelled as IEEE 754 doubles throughout
+/// (the documented approximation in `numeric_divide_int_as_double`,
+/// numeric_types.nr). Each signed microsecond count converts exactly for
+/// |micros| <= 2^53 (durations up to ~285 years), so the quotient is the
+/// correctly-rounded double of the true rational ratio there; beyond that
+/// the i64 -> f64 conversion itself rounds to nearest first (at most two
+/// roundings total, the same contract as op:numeric-divide on integers).
+///
+/// Division by zero duration raises err:FOAR0001 in XPath (F&O 3.1
+/// sec. 8.4.10 error clause); this tree represents F&O dynamic errors as
+/// fail-closed asserts, so we assert with the duration-specific message
+/// BEFORE delegating (the delegate's own `b != 0` assert is then
+/// unreachable). [FABLE-5] (sq-3x7dl.9)
+pub fn duration_divide_by_duration(a: XsdDayTimeDuration, b: XsdDayTimeDuration) -> XsdDouble {
     let b_micros = b.to_signed_micros();
     assert(b_micros != 0, "Division by zero duration");
-    a.to_signed_micros() / b_micros
+    numeric_divide_int_as_double(a.to_signed_micros(), b_micros)
 }
 
 /// Negates a duration
@@ -488,6 +509,83 @@ fn test_years_months_dt_zero_duration() {
     let zero = duration_zero();
     assert(years_from_duration(zero) == 0);
     assert(months_from_duration(zero) == 0);
+}
+
+// ============================================================================
+// op:divide-dayTimeDuration-by-dayTimeDuration -> xs:decimal ratio
+// (sq-3x7dl.9) [FABLE-5]
+//
+// F&O 3.1 sec. 8.4.10: the ratio of two dayTimeDurations is an xs:decimal and
+// never truncates. xs:decimal is modelled as an IEEE 754 double here -- the
+// documented approximation defined in numeric_types.nr on
+// `numeric_divide_int_as_double` (exact operand conversion for
+// |micros| <= 2^53, correctly-rounded IEEE 754 division), so every expected
+// value below is the correctly-rounded double of the exact rational ratio.
+//
+// Oracle (independent Python, exact rational + hardware IEEE 754 double):
+//   from fractions import Fraction; import struct
+//   Fraction(3_600_000_000, 2_400_000_000)          -> Fraction(3, 2)
+//   struct.unpack('<Q', struct.pack('<d', 3_600_000_000/2_400_000_000))[0]
+//     -> 0x3FF8000000000000  (1.5)
+// ============================================================================
+
+#[test]
+fn test_duration_divide_by_duration_exact_ratio() {
+    // Oracle: PT1H div PT40M = Fraction(3,2) = 1.5 exactly (0x3FF8000000000000).
+    // The pre-fix truncating i64 impl returned 1 -- the sq-3x7dl.9 bug.
+    let pt1h = duration_from_components(false, 0, 1, 0, 0, 0);
+    let pt40m = duration_from_components(false, 0, 0, 40, 0, 0);
+    assert(duration_divide_by_duration(pt1h, pt40m) == XsdDouble::from_bits(0x3FF8000000000000));
+}
+
+#[test]
+fn test_duration_divide_by_duration_non_terminating_ratio() {
+    // Oracle: PT1S div PT3S = Fraction(1,3), a non-terminating decimal. Under
+    // the tree's decimal-as-double convention (numeric_types.nr,
+    // numeric_divide_int_as_double: "DOCUMENTED APPROXIMATION") the result is
+    // the correctly-rounded double of 1/3:
+    //   Python: float(Fraction(1,3)) == 1_000_000/3_000_000 -> True
+    //   struct.pack('<d', 1/3) -> 0x3FD5555555555555 (0.3333333333333333)
+    let pt1s = duration_from_components(false, 0, 0, 0, 1, 0);
+    let pt3s = duration_from_components(false, 0, 0, 0, 3, 0);
+    assert(duration_divide_by_duration(pt1s, pt3s) == XsdDouble::from_bits(0x3FD5555555555555));
+}
+
+#[test]
+fn test_duration_divide_by_duration_signs() {
+    // Oracle: (-PT1H) div (-PT40M) = 1.5 (0x3FF8000000000000) -- negatives cancel.
+    //         PT1H div (-PT40M) = -1.5 (0xBFF8000000000000) -- mixed sign.
+    // Python: (-3_600_000_000)/(-2_400_000_000) -> 1.5;
+    //         3_600_000_000/(-2_400_000_000) -> -1.5
+    let pt1h = duration_from_components(false, 0, 1, 0, 0, 0);
+    let neg_pt1h = duration_from_components(true, 0, 1, 0, 0, 0);
+    let neg_pt40m = duration_from_components(true, 0, 0, 40, 0, 0);
+    assert(
+        duration_divide_by_duration(neg_pt1h, neg_pt40m)
+            == XsdDouble::from_bits(0x3FF8000000000000),
+    );
+    assert(
+        duration_divide_by_duration(pt1h, neg_pt40m) == XsdDouble::from_bits(0xBFF8000000000000),
+    );
+}
+
+#[test]
+fn test_duration_divide_by_duration_self_is_one() {
+    // Oracle: any non-zero duration divided by itself is exactly 1.0
+    // (0x3FF0000000000000). P1DT2H3M4.5S = 93_784_500_000 us;
+    // Python: 93_784_500_000/93_784_500_000 -> 1.0
+    let dur = duration_from_components(false, 1, 2, 3, 4, 500_000);
+    assert(duration_divide_by_duration(dur, dur) == XsdDouble::from_bits(0x3FF0000000000000));
+}
+
+#[test(should_fail_with = "Division by zero duration")]
+fn test_duration_divide_by_duration_zero_divisor_foar0001() {
+    // F&O 3.1 sec. 8.4.10 error clause: dividing by a zero dayTimeDuration
+    // raises err:FOAR0001 (division by zero). This tree represents F&O
+    // dynamic errors as fail-closed asserts (see numeric.nr /
+    // numeric_divide_int_as_double), so the assert must fire.
+    let pt1h = duration_from_components(false, 0, 1, 0, 0, 0);
+    let _ = duration_divide_by_duration(pt1h, duration_zero());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

**Bug (audit LOW, sq-3x7dl.9):** `op:divide-dayTimeDuration-by-dayTimeDuration` returned a truncating `i64` ratio — `PT1H div PT40M` gave `1` instead of `1.5`. F&O 3.1 sec. 8.4.10 declares the result "as an xs:decimal number": it never truncates.

**Fix:** `duration_divide_by_duration` now returns `XsdDouble`, delegating to `numeric_divide_int_as_double` — the tree's **existing** xs:decimal representation (the "DOCUMENTED APPROXIMATION" block in `numeric_types.nr`: no arbitrary-precision decimal type exists; decimals are modelled as IEEE 754 doubles throughout, exact operand conversion for |µs| ≤ 2^53 ≈ 285 years, correctly-rounded division). No new encoding was invented (`needs_architect=false`).

**Zero divisor:** F&O 3.1 sec. 8.4.10 error clause mandates `err:FOAR0001`. This tree represents F&O dynamic errors as fail-closed asserts (see `numeric.nr` / `numeric_divide_int_as_double`), so the duration-specific `assert(b_micros != 0, "Division by zero duration")` is kept and now pinned by a `should_fail_with` test.

## Tests (oracle-quoted: Python `Fraction` + `struct` double bits)

| case | oracle | expected |
|---|---|---|
| exact ratio | `Fraction(3_600_000_000, 2_400_000_000) = 3/2` | `0x3FF8000000000000` (1.5) — old impl returned 1 |
| non-terminating | `Fraction(1,3)`; `float(Fraction(1,3)) == 1_000_000/3_000_000` | `0x3FD5555555555555` — correctly-rounded double, the precision convention **defined in `numeric_types.nr` on `numeric_divide_int_as_double`** |
| neg/neg | `(-PT1H) div (-PT40M)` | `0x3FF8000000000000` (1.5) |
| mixed sign | `PT1H div (-PT40M)` | `0xBFF8000000000000` (−1.5) |
| self ÷ self | `P1DT2H3M4.5S / itself` | `0x3FF0000000000000` (1.0) |
| zero divisor | F&O 8.4.10 → FOAR0001 | `should_fail_with = "Division by zero duration"` |

## Generated qt3 package

- `generate_tests.py`: `duration_divide_by_duration` added to `double_returning_functions`; content-based `XsdDouble` import detection (the name-based check misses this op).
- Regenerated `xpath_test_opdivide_daytimeduration_by_daytimeduration` (6 tests, was 5): comparisons are now `XsdDouble::zero()` / `.to_bits()` bit patterns (each re-verified against the Python hardware oracle), and the previously unconvertible negative-ratio case `op-divide-dayTimeDuration-by-dTD-8` (−1) now converts.
- Generator spillover (workspace-wide `nargo fmt` rewriting `use dep::` → `use ::`, plus 98 `prod*` Nargo.toml members) was **reverted** — only the target package is touched.
- `KNOWN_FAILING` in `zk-toolchain.yml` is **empty** — nothing to de-list.

## Verification

- [x] `nargo test` (1.0.0-beta.21): `xpath` **162 passed** (incl. 5 new), target qt3 package **6 passed**, `xpath_unit_tests` **292 passed**
- [x] Mutation spot-check: flipped expected `1.5` → `1.0` bits ⇒ `test_duration_divide_by_duration_exact_ratio` **FAILS**; restored ⇒ green
- [x] `SPARQL_COVERAGE.md` row no longer overclaims — states the xs:decimal-as-double semantics explicitly

## Notes

- **face re-sync note**: Face re-sync is batched (pending drift: #1541 string.nr, #1547 duration.nr; this PR adds duration.nr + the regenerated divide-dtd-by-dtd package) — the drain runs one `noir_XPath` face re-sync after the xpath wave settles.
- Follow-ups beaded: **sq-3x7dl.19** (`ym_duration_divide_by_duration` has the identical i32 truncation, F&O 3.1 sec. 8.4.5 — kept out for file-disjointness), **sq-3x7dl.20** (pre-existing F&O section-number citations in zk/xpath — 8.4.3/8.4.4/8.3.17/8.3.18 — match neither the 3.1 REC nor the 4.0 draft; this PR cites the verified 3.1 numbers).
- Model tag: the dispatch brief specified `[SONNET-4.6]`, but this session ran on Fable 5 — tagged `[FABLE-5]` for tagging-convention accuracy.
- **Do NOT arm** — ZK surface requires escalated review.

> **SPARQ agent** 🤖 — automated implementation of bead sq-3x7dl.9. @jeswr please review for soundness before arming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)