### PR TITLE
feat(site): surface /papers in top nav + per-paper artifact/repro links (sq-1scgk) [OPUS-4.8]

### DIFF
--- a/site/e2e/home-smoke.spec.ts
+++ b/site/e2e/home-smoke.spec.ts
@@ -81,13 +81,15 @@ test("the home route renders the hero headline and the primary nav with no conso
     page.getByRole("heading", { name: /full SPARQL engine/i, level: 1 }),
   ).toBeVisible();
 
-  // The slim top bar (the AppShell "Primary" navigation landmark) carries the five content
+  // The slim top bar (the AppShell "Primary" navigation landmark) carries the six content
   // destinations. Asserting the landmark + its core links proves the nav booted, not just copy.
-  // [SONNET-4.6] sq-4hiqe — "Try" was removed from the nav (the /try playground is gone);
-  // the bar is now Home · Capabilities · App · Benchmarks · Download (no Try item).
+  // [SONNET-4.6] sq-4hiqe — "Try" was removed from the nav (the /try playground is gone).
+  // [OPUS-4.8] sq-1scgk — "Papers" was promoted INTO the bar (maintainer 2026-07-04 item 9b:
+  // make the paper-factory output prominently findable); the bar is now
+  // Home · Capabilities · App · Benchmarks · Papers · Download (no Try item).
   const primary = page.getByRole("navigation", { name: "Primary" }).first();
   await expect(primary).toBeVisible();
-  for (const label of ["Home", "Capabilities", "App", "Benchmarks", "Download"]) {
+  for (const label of ["Home", "Capabilities", "App", "Benchmarks", "Papers", "Download"]) {
     await expect(primary.getByRole("link", { name: label, exact: true })).toBeVisible();
   }
 

--- a/site/e2e/site-nav.spec.ts
+++ b/site/e2e/site-nav.spec.ts
@@ -3,11 +3,13 @@
 // WHAT IT GUARDS. The redesign removed the persistent w-64 sidebar tree + the duplicate top-tab
 // bar, leaving ONE slim top bar of content destinations (research/website-redesign.md §2, §7).
 // [OPUS-4.8] sq-4hiqe — the /try SPARQL playground was removed entirely: the top-nav "Try" item is
-// GONE and /try now hard-redirects to /app (a redirect stub, like the legacy /gui path). The slim
-// bar's destinations are now Home · Capabilities · App · Benchmarks · Download, where "App" → /app
-// is the live operational GUI. This test asserts the slim bar's five destinations route correctly,
-// that the old full sidebar tree is GONE, that there is NO "Try" nav item, and that both the
-// legacy /gui path and the removed /try path redirect to /app.
+// GONE and /try now hard-redirects to /app (a redirect stub, like the legacy /gui path).
+// [OPUS-4.8] sq-1scgk — "Papers" was promoted INTO the slim bar (maintainer 2026-07-04 item 9b:
+// make the paper-factory output prominently findable). The slim bar's destinations are now
+// Home · Capabilities · App · Benchmarks · Papers · Download, where "App" → /app is the live
+// operational GUI. This test asserts the slim bar's six destinations route correctly, that the old
+// full sidebar tree is GONE, that there is NO "Try" nav item, and that both the legacy /gui path
+// and the removed /try path redirect to /app.
 // [OPUS-4.8] sq-ymr2e.1 — migrated onto the shared E2E foundation: the hermetic + deterministic
 // `test` (e2e/support) and the shared `gotoAppReady` barrier, which absorbs the coi-serviceworker
 // one-time reload via the SW-controller signal and waits for the app-shell hydration — replacing
@@ -26,17 +28,19 @@ async function gotoSettled(page: Page, route: string): Promise<void> {
   await gotoAppReady(page, route);
 }
 
-test("the slim top bar shows the 5 destinations (no Try item) and no full sidebar tree", async ({
+test("the slim top bar shows the 6 destinations (no Try item) and no full sidebar tree", async ({
   page,
 }) => {
   await gotoSettled(page, "");
 
   const primary = page.getByRole("navigation", { name: "Primary" }).first();
+  // [OPUS-4.8] sq-1scgk — "Papers" is now a first-class bar destination alongside the rest.
   for (const label of [
     "Home",
     "Capabilities",
     "App",
     "Benchmarks",
+    "Papers",
     "Download",
   ]) {
     await expect(primary.getByRole("link", { name: label, exact: true })).toBeVisible();
@@ -116,6 +120,19 @@ test("Download is a reachable destination", async ({ page }) => {
     .click();
   await page.waitForURL("**/download/**", { timeout: 30_000 });
   expect(new URL(page.url()).pathname).toContain("/download");
+});
+
+// [OPUS-4.8] sq-1scgk — "Papers" is promoted into the slim bar (maintainer 2026-07-04 item 9b);
+// assert the new bar link routes to the /papers index (the paper-factory output surface).
+test("Papers is a reachable destination", async ({ page }) => {
+  await gotoSettled(page, "");
+  await page
+    .getByRole("navigation", { name: "Primary" })
+    .first()
+    .getByRole("link", { name: "Papers", exact: true })
+    .click();
+  await page.waitForURL("**/papers/**", { timeout: 30_000 });
+  expect(new URL(page.url()).pathname).toContain("/papers");
 });
 
 test("the legacy /gui path client-redirects to /app", async ({ page }) => {

--- a/site/src/app/papers/[slug]/page.tsx
+++ b/site/src/app/papers/[slug]/page.tsx
@@ -8,7 +8,7 @@ import { join } from "node:path";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, Download } from "lucide-react";
+import { ArrowLeft, Download, FileCode } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
@@ -77,6 +77,14 @@ function pdfHref(slug: string): string {
   return withBasePath(`/papers/${slug}.pdf`);
 }
 
+// [OPUS-4.8] sq-1scgk — the paper's single Typst source on GitHub: the authoring artifact the
+// PDF AND the in-site HTML both compile from (build-papers.mjs), so it is the real repro anchor.
+// Matches the site's existing source-link convention (jeswr/sparq blob/main — see the /surface/*
+// readmeHref/skillHref links). An absolute external link, so no basePath prefix.
+function sourceHref(source: string): string {
+  return `https://github.com/jeswr/sparq/blob/main/site/papers/${source}`;
+}
+
 export default async function PaperPage({
   params,
 }: {
@@ -116,6 +124,44 @@ export default async function PaperPage({
           </Button>
         </div>
       </header>
+
+      {/* [OPUS-4.8] sq-1scgk — Artifacts & reproduction. Surfaces the paper's real artifacts:
+          the downloadable PDF and the single Typst source the PDF + in-site render both compile
+          from (the repro anchor). Only existing artifacts are linked — no invented metadata; the
+          per-number evidence provenance is stamped by <PaperProvenance> below. */}
+      <section
+        aria-labelledby="artifacts-heading"
+        className="rounded-lg border bg-muted/30 p-4"
+      >
+        <h2 id="artifacts-heading" className="text-sm font-semibold">
+          Artifacts &amp; reproduction
+        </h2>
+        <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2 text-sm">
+          <a
+            href={pdfHref(paper.slug)}
+            download
+            className="inline-flex items-center gap-1.5 text-primary"
+          >
+            <Download className="size-3.5" aria-hidden />
+            PDF
+          </a>
+          <a
+            href={sourceHref(paper.source)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-muted-foreground hover:text-foreground"
+          >
+            <FileCode className="size-3.5" aria-hidden />
+            Typst source
+          </a>
+        </div>
+        <p className="mt-3 text-xs text-muted-foreground">
+          The PDF and the in-site render below compile from the same single Typst source, fed the
+          same paper-bound evidence, so the two cannot disagree. Every headline number traces to a
+          named test or dataset, gated to deterministic, machine-independent evidence — see the
+          provenance stamp at the foot of the page.
+        </p>
+      </section>
 
       <PaperHtml html={html} />
 

--- a/site/src/app/papers/page.tsx
+++ b/site/src/app/papers/page.tsx
@@ -4,7 +4,7 @@
 // top frames the whole section.
 import type { Metadata } from "next";
 import Link from "next/link";
-import { ArrowRight, FileText, Download, ScrollText } from "lucide-react";
+import { ArrowRight, FileText, FileCode, Download, ScrollText } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge";
 import {
@@ -32,6 +32,12 @@ export const metadata: Metadata = {
 // so the PDF resolves under both the Pages `/sparq` prefix and the Tauri root-relative build.
 function pdfHref(slug: string): string {
   return withBasePath(`/papers/${slug}.pdf`);
+}
+
+// [OPUS-4.8] sq-1scgk — the paper's single Typst source on GitHub (the authoring artifact the
+// PDF + in-site render both compile from). Matches the site's source-link convention.
+function sourceHref(source: string): string {
+  return `https://github.com/jeswr/sparq/blob/main/site/papers/${source}`;
 }
 
 export default function PapersIndexPage() {
@@ -97,6 +103,16 @@ export default function PapersIndexPage() {
                 >
                   <Download className="size-3.5" aria-hidden />
                   PDF
+                </a>
+                {/* [OPUS-4.8] sq-1scgk — the single Typst source (the repro/artifact anchor). */}
+                <a
+                  href={sourceHref(p.source)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+                >
+                  <FileCode className="size-3.5" aria-hidden />
+                  Source
                 </a>
               </div>
             </CardContent>

--- a/site/src/components/command-palette.tsx
+++ b/site/src/components/command-palette.tsx
@@ -102,9 +102,11 @@ const TOP_PAGES: { href: string; title: string; blurb: string }[] = [
   { href: "/capabilities", title: "Capabilities", blurb: "Every surface in one gallery, by theme." },
   { href: "/app", title: "App", blurb: "The live operational GUI (hosted web app coming soon)." },
   { href: "/benchmarks", title: "Benchmarks", blurb: "Per-commit, same-box benchmark dashboard." },
+  // [OPUS-4.8] sq-1scgk — /papers is now a top-bar destination (maintainer 2026-07-04 item
+  // 9b); it stays indexed here too, exactly like the other bar pages above.
   { href: "/papers", title: "Papers", blurb: "The research papers behind sparq." },
   // [OPUS-4.8] sq-rvgr2.1 — the /specs section: W3C ReSpec-style Unofficial Proposal Drafts.
-  // Cmd-K only (like /papers) so the slim top bar stays at 6 destinations.
+  // Cmd-K only (unlike /papers, which is now in the bar) so the slim top bar stays lean.
   { href: "/specs", title: "Specs", blurb: "W3C ReSpec-style Unofficial Proposal Drafts (no W3C standing)." },
   { href: "/download", title: "Download", blurb: "Desktop GUI + CLI/server binaries (latest release)." },
   { href: "/#how-it-runs", title: "How it runs", blurb: "The honest \"what runs where\" tier model." },

--- a/site/src/components/layout/app-shell.tsx
+++ b/site/src/components/layout/app-shell.tsx
@@ -20,11 +20,13 @@
 // soft navigation: soft-navigating across two distinct Next builds fetches the WRONG app's RSC
 // Flight payload (/app/index.txt) and lands on a raw .txt instead of the GUI. See NavLink.
 //
-// Destinations (research §2 + the maintainer's discoverability gaps), slim at 6:
-//   Home · Capabilities · App · Benchmarks · Download
+// Destinations (research §2 + the maintainer's discoverability gaps):
+//   Home · Capabilities · App · Benchmarks · Papers · Download
 //   utility cluster: { Cmd-K · GitHub · theme }
-// Papers stays a real route but lives in Cmd-K (overflow) to keep the bar slim, not bloated.
-// (/examples and the deep-page rebuild are sequenced in sq-vw3ax.6 / .4 — not this PR.)
+// [OPUS-4.8] sq-1scgk (maintainer 2026-07-04 item 9b) — "Papers" is PROMOTED into the slim
+// top bar so the paper-factory output is prominently findable, not buried in Cmd-K overflow.
+// It stays in Cmd-K too (the palette indexes every top-bar page). The bar stays lean at 6 short
+// labels. (/examples and the deep-page rebuild are sequenced in sq-vw3ax.6 / .4 — not this PR.)
 
 import * as React from "react";
 import Link from "next/link";
@@ -57,16 +59,18 @@ const REPO_URL = "https://github.com/jeswr/sparq";
 // The slim top bar's content destinations. Capabilities is the single gallery that replaces
 // the collapsed /surface/* tree; App is the live operational GUI destination (the single
 // workbench — /try redirects here); Download surfaces the desktop GUI + CLI binaries (the
-// maintainer's discoverability ask). Each is a real, built route. Papers is intentionally NOT in
-// the bar (it stays a route, reachable via Cmd-K) so the bar stays slim at 6, not bloated.
-// `external: true` marks a destination that is served by a SEPARATE deployed app at the same
-// origin (here: /app = the gui/app workbench overlaid at /app/). Such a slot must be a hard,
-// full-page navigation — see NavLink — not a next/link soft nav (sq-vw3ax.11).
+// maintainer's discoverability ask). Each is a real, built route. [OPUS-4.8] sq-1scgk — Papers
+// is now a first-class bar destination (maintainer 2026-07-04 item 9b: make the paper-factory
+// output prominently findable), sitting between Benchmarks and Download; it remains reachable
+// via Cmd-K too. `external: true` marks a destination that is served by a SEPARATE deployed app
+// at the same origin (here: /app = the gui/app workbench overlaid at /app/). Such a slot must be
+// a hard, full-page navigation — see NavLink — not a next/link soft nav (sq-vw3ax.11).
 const NAV_ITEMS: { href: string; label: string; external?: boolean }[] = [
   { href: "/", label: "Home" },
   { href: "/capabilities", label: "Capabilities" },
   { href: "/app", label: "App", external: true },
   { href: "/benchmarks", label: "Benchmarks" },
+  { href: "/papers", label: "Papers" },
   { href: "/download", label: "Download" },
 ];
 


### PR DESCRIPTION
> 🤖 **SPARQ agent** (site lane). Autonomous change; opened for review — **not armed**.

## What & why — bead sq-1scgk (epic sq-gum8, maintainer 2026-07-04 item 9b)

Make the paper-factory's papers **prominently findable** on the site. The `/papers` index and per-paper pages already existed but `/papers` lived only in Cmd-K and the per-paper page had no artifact/repro links.

### Changes
- **Top-nav visibility** — add **"Papers"** to the slim top bar (`AppShell`), between Benchmarks and Download. It stays indexed in Cmd-K too (the palette covers every bar page). The bar is now `Home · Capabilities · App · Benchmarks · Papers · Download` (6).
- **Nav specs updated in the same PR** — `e2e/home-smoke.spec.ts` and `e2e/site-nav.spec.ts` **hardcode** the primary-nav label list (the exact failure mode that bounced #1516), so both were updated to the 6-destination list, the `site-nav` title/comments were corrected (`5 → 6`), and a new **"Papers is a reachable destination"** routing regression test was added.
- **Per-paper landing** (`/papers/[slug]`) — new **"Artifacts & reproduction"** section: the downloadable **PDF** + the single **Typst source** (the repro anchor the PDF and in-site render both compile from, linked via the site's existing `jeswr/sparq blob/main` convention). The **status badge**, **abstract** (blurb + the full in-site render), and **evidence provenance** stamp were already present.
- **/papers index cards** — a matching **"Source"** link next to the PDF link.

### Honesty
- Only **real, existing artifacts** are linked (PDF from the factory, Typst source in-repo). **No invented metadata** — no fabricated DOIs, dates, or "submitted/published" states; the registry's honest status labels (`publishable-now` / `wip-arxiv` / `draft`) are preserved verbatim.
- No perf/ZK/MPC claims added; the whole-tree privacy-claims gate passes.

### Gates (all green locally)
- `npm run build` (static export) — **exit 0**; all 8 papers' PDFs + per-paper landing routes emitted into `out/`; the "Papers" nav link + "Artifacts & reproduction" section verified in the built HTML. (WASM prereq: reused the existing prebuilt `js/wasm` bundle as a build artifact — no `crates/` changes.)
- `npm run lint` — **clean** (no ESLint warnings/errors).
- `tsc --noEmit` — **exit 0** (after a clean `npm ci`; a corrupt partial install had masked resolution).
- `npm run test:unit` — **298 passed / 0 failed**.
- Affected e2e — `home-smoke` + `site-nav` (**10 passed**, incl. the new Papers-routing test) and `command-palette` + `surface-sweep` (**54 passed**, papers routes).

### Covered vs deferred
- **Covered:** nav visibility, per-paper artifact/repro links, index source links, honest status badges, spec updates.
- **Deferred:** the assurance-walkthrough site page (sq-wir9k) is not linked because that route does not exist yet; wiring per-paper artifact links to it can follow when it lands.

**Attribution note:** the terse dispatch brief templated the commit tag as `[SONNET-4.6]`; this task was actually executed by **Opus 4.8**, so the inline markers and the `Co-Authored-By` trailer reflect the true author for provenance honesty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)