### PR TITLE
fix(ci): resolve merge_group PR from queue head-ref so G2/G6 escape-hatch labels apply (sq-5owmc) [SONNET-4.6]

### DIFF
--- a/.github/workflows/flow-on-gates.yml
+++ b/.github/workflows/flow-on-gates.yml
@@ -88,19 +88,56 @@ jobs:
         # label is honoured in the merge queue too (otherwise a PR that legitimately
         # carried `skill-not-needed` would pass the PR gate but fail the identical
         # merge_group gate, blocking the queue). On merge_group the PR number is not
-        # in the event payload, so resolve it from the head commit's associated PR.
+        # in the event payload.
+        #
+        # [SONNET-4.6] (sq-5owmc) FIX — the merge_group PR resolution was SILENTLY
+        # failing: it resolved the PR via `commits/<merge_group.head_sha>/pulls`, but
+        # the merge-queue head is a SYNTHETIC merge commit not reliably associated
+        # with the PR (and in the observed run the head_sha env came back empty too),
+        # so pr-labels.txt was empty, `skill-not-needed` never suppressed, G2 failed
+        # the GROUP and the queue ejected the PR with no failed run on the PR itself
+        # (hit #1542 twice). Now the PR number is parsed DETERMINISTICALLY from the
+        # merge-queue head ref (refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>) via
+        # scripts/resolve-merge-group-pr.py; the commits/<sha>/pulls API is only a
+        # secondary fallback; and if BOTH fail the step warns LOUDLY (never silently)
+        # while the gate still runs UNSUPPRESSED (fail-closed is correct, silence is
+        # not).
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          MERGE_SHA: ${{ github.event.merge_group.head_sha }}
+          MERGE_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          MERGE_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           : > pr-labels.txt
           num="${PR_NUMBER:-}"
-          if [ -z "$num" ] && [ -n "${MERGE_SHA:-}" ]; then
-            # Resolve the PR associated with the merge-queue head commit.
-            num="$(gh api "repos/${{ github.repository }}/commits/${MERGE_SHA}/pulls" \
-                     --jq '.[0].number' 2>/dev/null || true)"
+          if [ -z "$num" ] && [ "${EVENT_NAME:-}" = "merge_group" ]; then
+            # Primary (deterministic, no network): parse the PR number from the
+            # gh-readonly-queue head ref.
+            num="$(python3 scripts/resolve-merge-group-pr.py "${MERGE_HEAD_REF:-}" || true)"
+            # Secondary fallback: the head commit's associated PR (best-effort).
+            if [ -z "$num" ] && [ -n "${MERGE_HEAD_SHA:-}" ]; then
+              num="$(gh api "repos/${{ github.repository }}/commits/${MERGE_HEAD_SHA}/pulls" \
+                       --jq '.[0].number' 2>/dev/null || true)"
+            fi
+            if [ -z "$num" ]; then
+              # LOUD fail-closed: do NOT silently skip the label lookup. The gate
+              # below still runs UNSUPPRESSED, but make the unresolved association
+              # visible in the annotations + job summary so it is never invisible
+              # the way it was for #1542.
+              echo "::warning title=flow-on-gates G2::merge_group PR could not be resolved (head_ref='${MERGE_HEAD_REF:-}' head_sha='${MERGE_HEAD_SHA:-}'); the skill-not-needed escape-hatch label will NOT suppress G2 here — gate runs unsuppressed (fail-closed)."
+              {
+                echo "### ⚠️ flow-on-gates G2: merge_group PR unresolved"
+                echo ""
+                echo "Could not resolve the PR number for this merge-queue commit, so the"
+                echo "\`skill-not-needed\` escape-hatch label cannot be honoured here."
+                echo "The gate runs **unsuppressed** (fail-closed)."
+                echo ""
+                echo "- head_ref: \`${MERGE_HEAD_REF:-<empty>}\`"
+                echo "- head_sha: \`${MERGE_HEAD_SHA:-<empty>}\`"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
           if [ -n "$num" ]; then
             gh pr view "$num" \
@@ -170,19 +207,50 @@ jobs:
         id: labels
         # [OPUS-4.8] Mirror G2: run on BOTH pull_request AND merge_group so the
         # escape-hatch label is honoured in the merge queue too. On merge_group the
-        # PR number is not in the event payload, so resolve it from the head
-        # commit's associated PR.
+        # PR number is not in the event payload.
+        #
+        # [SONNET-4.6] (sq-5owmc) FIX — mirrors the G2 fix: the merge_group PR
+        # resolution silently failed via `commits/<head_sha>/pulls` (synthetic merge
+        # commit / empty head_sha), so the `config-internal` label never suppressed
+        # G6 in the queue. Now parse the PR number DETERMINISTICALLY from the
+        # gh-readonly-queue head ref via scripts/resolve-merge-group-pr.py, keep the
+        # API only as a secondary fallback, and warn LOUDLY (never silently) if both
+        # fail — the gate then runs UNSUPPRESSED (fail-closed).
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          MERGE_SHA: ${{ github.event.merge_group.head_sha }}
+          MERGE_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          MERGE_HEAD_SHA: ${{ github.event.merge_group.head_sha }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           : > pr-labels.txt
           num="${PR_NUMBER:-}"
-          if [ -z "$num" ] && [ -n "${MERGE_SHA:-}" ]; then
-            num="$(gh api "repos/${{ github.repository }}/commits/${MERGE_SHA}/pulls" \
-                     --jq '.[0].number' 2>/dev/null || true)"
+          if [ -z "$num" ] && [ "${EVENT_NAME:-}" = "merge_group" ]; then
+            # Primary (deterministic, no network): parse the PR number from the
+            # gh-readonly-queue head ref.
+            num="$(python3 scripts/resolve-merge-group-pr.py "${MERGE_HEAD_REF:-}" || true)"
+            # Secondary fallback: the head commit's associated PR (best-effort).
+            if [ -z "$num" ] && [ -n "${MERGE_HEAD_SHA:-}" ]; then
+              num="$(gh api "repos/${{ github.repository }}/commits/${MERGE_HEAD_SHA}/pulls" \
+                       --jq '.[0].number' 2>/dev/null || true)"
+            fi
+            if [ -z "$num" ]; then
+              # LOUD fail-closed (see the G2 step): make the unresolved association
+              # visible instead of silently dropping the escape-hatch label. The
+              # gate below still runs UNSUPPRESSED.
+              echo "::warning title=flow-on-gates G6::merge_group PR could not be resolved (head_ref='${MERGE_HEAD_REF:-}' head_sha='${MERGE_HEAD_SHA:-}'); the config-internal escape-hatch label will NOT suppress G6 here — gate runs unsuppressed (fail-closed)."
+              {
+                echo "### ⚠️ flow-on-gates G6: merge_group PR unresolved"
+                echo ""
+                echo "Could not resolve the PR number for this merge-queue commit, so the"
+                echo "\`config-internal\` escape-hatch label cannot be honoured here."
+                echo "The gate runs **unsuppressed** (fail-closed)."
+                echo ""
+                echo "- head_ref: \`${MERGE_HEAD_REF:-<empty>}\`"
+                echo "- head_sha: \`${MERGE_HEAD_SHA:-<empty>}\`"
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
           fi
           if [ -n "$num" ]; then
             gh pr view "$num" \

--- a/scripts/resolve-merge-group-pr.py
+++ b/scripts/resolve-merge-group-pr.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# [SONNET-4.6] (sq-5owmc) Resolve the PR number for a `merge_group` event by
+# parsing the merge-queue head ref — the deterministic, network-free primary path
+# for the flow-on-gates G2/G6 escape-hatch label lookup.
+#
+# THE BUG THIS FIXES (cost PR #1542 two silent merge-queue ejections + ~4h stall):
+# in `merge_group` context the G2 "Read PR labels" step resolved the PR via
+# `gh api repos/.../commits/<MERGE_SHA>/pulls`. That lookup is unreliable in the
+# merge queue: the merge-group head commit is a SYNTHETIC merge commit that is not
+# associated with the PR the way `commits/<sha>/pulls` expects, and in the observed
+# run the wired `MERGE_SHA` env came back EMPTY as well — so `pr-labels.txt` was
+# empty, the `skill-not-needed` label never suppressed, G2 failed the whole GROUP,
+# and the queue ejected the PR with NO failed run visible on the PR itself.
+#
+# THE FIX: the merge-queue branch name deterministically encodes the PR number:
+#     refs/heads/gh-readonly-queue/<base_branch>/pr-<N>-<sha>
+# (`github.event.merge_group.head_ref`). Parse <N> from that ref directly — no
+# network, no synthetic-commit association guesswork. The workflow keeps the
+# `commits/<sha>/pulls` API only as a SECONDARY fallback, and warns LOUDLY (never
+# silently) if BOTH fail (fail-closed: the gate then runs unsuppressed).
+#
+# Pure + hermetic: `parse_pr_number_from_ref` does no I/O so the gates self-test
+# suite (scripts/tests/test_gates.py) unit-tests it against synthetic refs.
+#
+# CLI:  python3 scripts/resolve-merge-group-pr.py "<head_ref>"
+#   prints the PR number and exits 0 on a successful parse; exits 1 (no output)
+#   when the ref is empty or not a recognisable gh-readonly-queue ref.
+
+from __future__ import annotations
+
+import re
+import sys
+
+# Anchor on the deterministic `gh-readonly-queue/` marker so an unrelated ref (or a
+# base branch that happens to contain `pr-<n>-`) cannot match. The base branch may
+# itself contain slashes (e.g. `release/v1`), so `.*` greedily consumes up to the
+# LAST `/pr-<digits>-<hex>` segment, which is the PR + queue-head-sha suffix.
+# `head_ref` may or may not carry the leading `refs/heads/` — the search is prefix
+# agnostic.
+_QUEUE_PR_RE = re.compile(r"gh-readonly-queue/.*/pr-(\d+)-[0-9a-fA-F]+")
+
+
+def parse_pr_number_from_ref(ref: str | None) -> int | None:
+    """Parse the PR number from a `gh-readonly-queue` merge-group head ref.
+
+    Returns the PR number (int) or None when `ref` is empty / not a recognisable
+    merge-queue ref. No I/O — safe to unit-test.
+
+    NOTE (single-PR scope): sparq's merge queue validates one PR per group, so the
+    ref carries exactly one `pr-<N>-<sha>` suffix. `.*` anchors the match on the
+    LAST such segment, which is the PR under test. If batched (multi-PR) merge
+    groups are ever enabled, the per-PR label semantics must be revisited — a batch
+    ref would carry several `pr-<N>-` segments and label suppression would need to
+    consider each PR independently.
+    """
+    if not ref:
+        return None
+    m = _QUEUE_PR_RE.search(ref.strip())
+    if not m:
+        return None
+    return int(m.group(1))
+
+
+def main(argv: list[str]) -> int:
+    ref = argv[1] if len(argv) > 1 else ""
+    num = parse_pr_number_from_ref(ref)
+    if num is None:
+        return 1
+    print(num)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/tests/test_gates.py
+++ b/scripts/tests/test_gates.py
@@ -40,6 +40,9 @@ def _load(name: str, filename: str):
 g1 = _load("gate_new_crate", "gate-new-crate.py")
 g2 = _load("gate_api_skill", "gate-api-skill.py")
 g6 = _load("check_config_documented", "check-config-documented.py")
+# [SONNET-4.6] (sq-5owmc) the merge_group PR-number resolver used by the G2/G6
+# "Read PR labels" steps to honour the escape-hatch label in the merge queue.
+resolve_mg = _load("resolve_merge_group_pr", "resolve-merge-group-pr.py")
 
 
 def _statused(added: list[str], modified: list[str] | None = None) -> list[str]:
@@ -637,6 +640,69 @@ class G6Test(unittest.TestCase):
         )
         self.assertTrue(ok)
         self.assertEqual(undoc, [])
+
+
+# --------------------------------------------------------------------------- #
+# merge_group PR-number resolution — G2/G6 escape-hatch label in the queue
+# [SONNET-4.6] (sq-5owmc)
+# --------------------------------------------------------------------------- #
+class MergeGroupPrResolveTest(unittest.TestCase):
+    # [SONNET-4.6] (sq-5owmc) The G2/G6 "Read PR labels" steps must resolve the PR
+    # number in merge_group context so the `skill-not-needed` / `config-internal`
+    # escape-hatch labels are honoured in the merge queue. Before the fix the step
+    # resolved the PR via `commits/<merge_group.head_sha>/pulls`; that returned
+    # empty (synthetic merge commit / empty head_sha), pr-labels.txt was empty, the
+    # label never suppressed, the gate failed the GROUP and the queue silently
+    # ejected the PR (hit #1542 twice). The fix parses the PR number
+    # DETERMINISTICALLY from the gh-readonly-queue head ref; these tests exercise
+    # that pure parse (the network fallback + loud warn live in the workflow).
+
+    def test_parses_pr_from_observed_ref_format(self):
+        # The exact ref shape GitHub sets on github.event.merge_group.head_ref for
+        # the single-PR merge group that ejected #1542.
+        ref = "refs/heads/gh-readonly-queue/main/pr-1542-" + "0" * 40
+        self.assertEqual(resolve_mg.parse_pr_number_from_ref(ref), 1542)
+
+    def test_parses_ref_without_refs_heads_prefix(self):
+        # head_ref may arrive with or without the leading refs/heads/.
+        ref = "gh-readonly-queue/main/pr-42-" + "d" * 40
+        self.assertEqual(resolve_mg.parse_pr_number_from_ref(ref), 42)
+
+    def test_parses_ref_with_slashed_base_branch(self):
+        # A base branch that itself contains a slash must not break the parse.
+        ref = "refs/heads/gh-readonly-queue/release/v1/pr-7-" + "a" * 40
+        self.assertEqual(resolve_mg.parse_pr_number_from_ref(ref), 7)
+
+    def test_empty_ref_returns_none(self):
+        # The fail-closed path: an empty/absent head_ref yields None so the workflow
+        # warns LOUDLY and runs the gate unsuppressed (never silently passes).
+        self.assertIsNone(resolve_mg.parse_pr_number_from_ref(""))
+        self.assertIsNone(resolve_mg.parse_pr_number_from_ref(None))
+
+    def test_non_queue_ref_returns_none(self):
+        self.assertIsNone(resolve_mg.parse_pr_number_from_ref("refs/heads/feature/x"))
+        self.assertIsNone(resolve_mg.parse_pr_number_from_ref("refs/heads/main"))
+
+    def test_cli_entry_point(self):
+        # The workflow invokes the module as a CLI: prints the number + exit 0 on a
+        # successful parse; exit 1 with no output when unparseable.
+        import contextlib
+        import io
+
+        ref = "refs/heads/gh-readonly-queue/main/pr-99-" + "f" * 40
+        buf = io.StringIO()
+        with contextlib.redirect_stdout(buf):
+            rc_ok = resolve_mg.main(["prog", ref])
+        self.assertEqual(rc_ok, 0)
+        self.assertEqual(buf.getvalue().strip(), "99")
+
+        buf_empty = io.StringIO()
+        with contextlib.redirect_stdout(buf_empty):
+            rc_empty = resolve_mg.main(["prog", ""])
+        self.assertEqual(rc_empty, 1)
+        self.assertEqual(buf_empty.getvalue().strip(), "")
+
+        self.assertEqual(resolve_mg.main(["prog"]), 1)  # missing arg → exit 1
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI-infra lane. Bead **sq-5owmc** (P1 bug).

## The bug (cost PR #1542 two silent merge-queue ejections + ~4h stall)

`.github/workflows/flow-on-gates.yml`'s **G2 (public-api-skill)** and **G6 (config-documented)** "Read PR labels" steps support the `skill-not-needed` / `config-internal` escape-hatch labels. In **merge_group** context they resolved the PR via `gh api repos/.../commits/<merge_group.head_sha>/pulls`, but that lookup is unreliable in the merge queue: the merge-group head is a **synthetic merge commit** not reliably associated with the PR, and in the observed run the wired `head_sha` env came back **empty** too. Result: `pr-labels.txt` empty → the escape-hatch label never suppressed → G2 failed the whole **group** → the queue **silently ejected** the PR with no failed run visible on the PR itself.

## The fix

- **Deterministic resolution:** parse the PR number from the merge-queue head ref `refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>` (`github.event.merge_group.head_ref`) via the new pure, network-free helper `scripts/resolve-merge-group-pr.py`.
- `commits/<sha>/pulls` API kept only as a **secondary fallback**.
- **Loud, not silent:** if the event is `merge_group` and the PR still cannot be resolved, the step emits a `::warning::` annotation **and** writes a visible job-summary block. The gate then runs **unsuppressed** — fail-closed is correct, silence is not.
- Applied to **both** G2 and G6 (G6's step is an exact mirror of G2 and had the identical silent-failure bug).

## Self-test (bead requirement)

`scripts/tests/test_gates.py` gains `MergeGroupPrResolveTest` — unit-tests the PR-number parse from a synthetic `gh-readonly-queue` ref (the observed #1542 format), plus the slashed-base-branch and no-`refs/heads/`-prefix variants, the empty/non-queue **fail-closed** path (returns `None`), and the CLI entry point. This suite already runs inside the G6 job, so the fix is guarded at PR time.

## Verification

- `python3 -c "import yaml; yaml.safe_load(...)"` → **YAML OK**
- `actionlint .github/workflows/flow-on-gates.yml` → **clean**
- `python3 scripts/tests/test_gates.py` → **48 passed** (was 42; +6). Mutation spot-check: breaking the resolver produces **4 failures** (tests are non-vacuous), restored → OK.
- Local parse against the real observed ref `refs/heads/gh-readonly-queue/main/pr-1542-<40hex>` → **1542**.
- End-to-end shell simulation of the label block (gh stubbed): merge_group+valid-ref → resolves 1542 (no warn); merge_group+empty ref/sha → empty + **loud warn** + summary; pull_request → uses PR number, block skipped.

## Gates

- Gate aggregator **untouched** — job names unchanged (`public-api-skill (G2)`, `config-documented (G6)`), no `advisory`/`informational` token added, so **G2/G6 still gate**.
- No new GitHub Actions added → SHA-pin posture unchanged.

**Compliance gap closed:** removes a silent merge-queue false-eject failure mode in the proactive maintenance gates — the escape-hatch label is now honoured in the queue, and an unresolvable PR fails **closed + loud** instead of silently.

Not armed (CI-gates surface → escalated review).