### PR TITLE
fix(zk/xpath): op:divide-yearMonthDuration-by-yearMonthDuration returns xs:decimal ratio (sq-3x7dl.19) [SONNET-4.6]

### DIFF
--- a/zk/xpath/SPARQL_COVERAGE.md
+++ b/zk/xpath/SPARQL_COVERAGE.md
@@ -145,6 +145,7 @@ This document details the implementation status of SPARQL 1.1 functions in noir_
 | duration * number | op:multiply-dayTimeDuration | ✅ | Implemented as `duration_multiply` |
 | duration / number | op:divide-dayTimeDuration | ✅ | Implemented as `duration_divide` |
 | duration / duration | op:divide-dayTimeDuration-by-dayTimeDuration | ✅ | Implemented as `duration_divide_by_duration` — xs:decimal ratio (never truncates; modelled as IEEE 754 double, the tree's documented decimal approximation) |
+| yearMonthDuration / yearMonthDuration | op:divide-yearMonthDuration-by-yearMonthDuration | ✅ | Implemented as `ym_duration_divide_by_duration` — xs:decimal ratio (never truncates; modelled as IEEE 754 double, the tree's documented decimal approximation) |
 | dateTime + duration | op:add-dayTimeDuration-to-dateTime | ✅ | Implemented as `datetime_add_duration` |
 | dateTime - duration | op:subtract-dayTimeDuration-from-dateTime | ✅ | Implemented as `datetime_subtract_duration` |
 | dateTime - dateTime | op:subtract-dateTimes | ✅ | Implemented as `datetime_difference` |

--- a/zk/xpath/scripts/generate_tests.py
+++ b/zk/xpath/scripts/generate_tests.py
@@ -1937,7 +1937,8 @@ def convert_xpath_expr(
                         setup = f"let dur = XsdYearMonthDuration::new({months});"
                         return (setup, f"{noir_func}(dur, {divisor})", None)
 
-            # yearMonthDuration div yearMonthDuration -> i32 ratio
+            # yearMonthDuration div yearMonthDuration -> xs:decimal ratio (IEEE 754 double,
+            # F&O 3.1 sec. 8.4.5; sq-3x7dl.19)
             if symbol == "div" and noir_func == "ym_duration_divide_by_duration":
                 if (
                     arg1_symbol == "yearMonthDuration"
@@ -2889,6 +2890,9 @@ def generate_noir_test(test: TestCase, function_name: str) -> Optional[str]:
         # op:divide-dayTimeDuration-by-dayTimeDuration returns the xs:decimal
         # ratio, modelled as an IEEE 754 double (F&O 3.1 sec. 8.4.10; sq-3x7dl.9)
         "duration_divide_by_duration",
+        # op:divide-yearMonthDuration-by-yearMonthDuration returns the xs:decimal
+        # ratio, modelled as an IEEE 754 double (F&O 3.1 sec. 8.4.5; sq-3x7dl.19)
+        "ym_duration_divide_by_duration",
     ]
 
     # Functions that return Option<i64>

--- a/zk/xpath/test_packages/xpath_test_opadd_yearmonthdurations/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_opadd_yearmonthdurations/src/chunk_0.nr
@@ -2,7 +2,7 @@
 //! Contains 23 tests
 
 use dep::xpath::{
-    fn_string_from_ym_duration, XsdYearMonthDuration, ym_duration_add,
+    fn_string_from_ym_duration, XsdDouble, XsdYearMonthDuration, ym_duration_add,
     ym_duration_divide_by_duration, ym_duration_equal, ym_duration_ge, ym_duration_le,
 };
 
@@ -170,6 +170,7 @@ fn op_add_yearmonthdurations_11() {
     //  ******************************************************* Test:
     // XPath: (xs:yearMonthDuration("P42Y10M") + xs:yearMonthDuration("P28Y10M")) div (xs:yearMonthDuration("P10Y10M") + xs:yearMonthDuration("P60Y10M"))
     // Expected: assert-eq 1
+    // Oracle: (514+346)/(130+730) = 860/860 = 1.0 exactly (0x3FF0000000000000)
     assert(
         ym_duration_divide_by_duration(
             ym_duration_add(
@@ -181,7 +182,7 @@ fn op_add_yearmonthdurations_11() {
                 XsdYearMonthDuration::new(730),
             ),
         )
-            == 1,
+            == XsdDouble::from_bits(0x3FF0000000000000),
     );
 }
 

--- a/zk/xpath/test_packages/xpath_test_opdivide_yearmonthduration/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_opdivide_yearmonthduration/src/chunk_0.nr
@@ -2,7 +2,7 @@
 //! Contains 15 tests
 
 use dep::xpath::{
-    fn_string_from_ym_duration, XsdYearMonthDuration, ym_duration_divide,
+    fn_string_from_ym_duration, XsdDouble, XsdYearMonthDuration, ym_duration_divide,
     ym_duration_divide_by_duration, ym_duration_equal, ym_duration_ge, ym_duration_le,
 };
 
@@ -100,12 +100,13 @@ fn op_divide_yearmonthduration_11() {
     //  ******************************************************* Test:
     // XPath: (xs:yearMonthDuration("P20Y11M") div 2.0) div (xs:yearMonthDuration("P20Y11M") div 2.0)
     // Expected: assert-eq 1
+    // Oracle: x div x = 1.0 exactly (0x3FF0000000000000)
     assert(
         ym_duration_divide_by_duration(
             ym_duration_divide(XsdYearMonthDuration::new(251), 2),
             ym_duration_divide(XsdYearMonthDuration::new(251), 2),
         )
-            == 1,
+            == XsdDouble::from_bits(0x3FF0000000000000),
     );
 }
 

--- a/zk/xpath/test_packages/xpath_test_opdivide_yearmonthduration_by_yearmonthduration/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_opdivide_yearmonthduration_by_yearmonthduration/src/chunk_0.nr
@@ -1,8 +1,153 @@
 //! Test chunk 0 for op:divide-yearMonthDuration-by-yearMonthDuration
-//! Contains 1 tests
+//! Contains 7 tests
+
+use dep::xpath::{
+    ym_duration_divide_by_duration,
+    XsdYearMonthDuration,
+    ym_duration_equal,
+    ym_duration_from_string,
+    XsdDouble,
+};
 
 #[test]
-fn opdivide_yearmonthduration_by_yearmonthduration_no_converted_tests() {
-    // Placeholder: 22 qt3tests cases could not be converted.
-    assert(true);
+fn op_divide_yearmonthduration_by_yearmonthduration2args_1() {
+    // Test: op-divide-yearMonthDuration-by-yearMonthDuration2args-1
+    // Written By: Carmelo Montanez
+    // Date: Tue Apr 12 16:29:08 GMT-05:00 2005
+    // Purpose: Evaluates The 'op:divide-yearMonthDuration-by-yearMonthDuration' operator
+    // with the arguments set as follows:
+    // $arg1 = xs:yearMonthDuration(lower bound)
+    // $arg2 = xs:yearMonthDuration(lower bound)
+    // XPath: xs:yearMonthDuration("P0Y0M") div xs:yearMonthDuration("P0Y1M")
+    // Expected: assert-eq 0
+    assert(ym_duration_divide_by_duration(XsdYearMonthDuration::new(0), XsdYearMonthDuration::new(1)) == XsdDouble::zero());
+    // Additional assertions: verify string parsing produces expected durations
+    let (parsed_ymd_0, parse_ok_0) = ym_duration_from_string("P0Y0M".as_bytes(), 5);
+    assert(parse_ok_0);
+    assert(ym_duration_equal(parsed_ymd_0, XsdYearMonthDuration::new(0)));
+    let (parsed_ymd_1, parse_ok_1) = ym_duration_from_string("P0Y1M".as_bytes(), 5);
+    assert(parse_ok_1);
+    assert(ym_duration_equal(parsed_ymd_1, XsdYearMonthDuration::new(1)));
+}
+
+#[test]
+fn op_divide_yearmonthduration_by_yearmonthduration2args_2() {
+    // Test: op-divide-yearMonthDuration-by-yearMonthDuration2args-2
+    // Written By: Carmelo Montanez
+    // Date: Tue Apr 12 16:29:08 GMT-05:00 2005
+    // Purpose: Evaluates The 'op:divide-yearMonthDuration-by-yearMonthDuration' operator
+    // with the arguments set as follows:
+    // $arg1 = xs:yearMonthDuration(mid range)
+    // $arg2 = xs:yearMonthDuration(lower bound)
+    // XPath: xs:yearMonthDuration("P1000Y6M") div xs:yearMonthDuration("P0Y1M")
+    // Expected: assert-eq 12006
+    assert(ym_duration_divide_by_duration(XsdYearMonthDuration::new(12006), XsdYearMonthDuration::new(1)).to_bits() == 4667825982630002688);
+    // Additional assertions: verify string parsing produces expected durations
+    let (parsed_ymd_0, parse_ok_0) = ym_duration_from_string("P1000Y6M".as_bytes(), 8);
+    assert(parse_ok_0);
+    assert(ym_duration_equal(parsed_ymd_0, XsdYearMonthDuration::new(12006)));
+    let (parsed_ymd_1, parse_ok_1) = ym_duration_from_string("P0Y1M".as_bytes(), 5);
+    assert(parse_ok_1);
+    assert(ym_duration_equal(parsed_ymd_1, XsdYearMonthDuration::new(1)));
+}
+
+#[test]
+fn op_divide_yearmonthduration_by_yearmonthduration2args_3() {
+    // Test: op-divide-yearMonthDuration-by-yearMonthDuration2args-3
+    // Written By: Carmelo Montanez
+    // Date: Tue Apr 12 16:29:08 GMT-05:00 2005
+    // Purpose: Evaluates The 'op:divide-yearMonthDuration-by-yearMonthDuration' operator
+    // with the arguments set as follows:
+    // $arg1 = xs:yearMonthDuration(upper bound)
+    // $arg2 = xs:yearMonthDuration(lower bound)
+    // XPath: xs:yearMonthDuration("P2030Y12M") div xs:yearMonthDuration("P0Y1M")
+    // Expected: assert-eq 24372
+    assert(ym_duration_divide_by_duration(XsdYearMonthDuration::new(24372), XsdYearMonthDuration::new(1)).to_bits() == 4672428538303873024);
+    // Additional assertions: verify string parsing produces expected durations
+    let (parsed_ymd_0, parse_ok_0) = ym_duration_from_string("P2030Y12M".as_bytes(), 9);
+    assert(parse_ok_0);
+    assert(ym_duration_equal(parsed_ymd_0, XsdYearMonthDuration::new(24372)));
+    let (parsed_ymd_1, parse_ok_1) = ym_duration_from_string("P0Y1M".as_bytes(), 5);
+    assert(parse_ok_1);
+    assert(ym_duration_equal(parsed_ymd_1, XsdYearMonthDuration::new(1)));
+}
+
+#[test]
+fn op_divide_yearmonthduration_by_yearmonthduration2args_4() {
+    // Test: op-divide-yearMonthDuration-by-yearMonthDuration2args-4
+    // Written By: Carmelo Montanez
+    // Date: Tue Apr 12 16:29:08 GMT-05:00 2005
+    // Purpose: Evaluates The 'op:divide-yearMonthDuration-by-yearMonthDuration' operator
+    // with the arguments set as follows:
+    // $arg1 = xs:yearMonthDuration(lower bound)
+    // $arg2 = xs:yearMonthDuration(mid range)
+    // XPath: xs:yearMonthDuration("P0Y0M") div xs:yearMonthDuration("P1000Y6M")
+    // Expected: assert-eq 0
+    assert(ym_duration_divide_by_duration(XsdYearMonthDuration::new(0), XsdYearMonthDuration::new(12006)) == XsdDouble::zero());
+    // Additional assertions: verify string parsing produces expected durations
+    let (parsed_ymd_0, parse_ok_0) = ym_duration_from_string("P0Y0M".as_bytes(), 5);
+    assert(parse_ok_0);
+    assert(ym_duration_equal(parsed_ymd_0, XsdYearMonthDuration::new(0)));
+    let (parsed_ymd_1, parse_ok_1) = ym_duration_from_string("P1000Y6M".as_bytes(), 8);
+    assert(parse_ok_1);
+    assert(ym_duration_equal(parsed_ymd_1, XsdYearMonthDuration::new(12006)));
+}
+
+#[test]
+fn op_divide_yearmonthduration_by_yearmonthduration2args_5() {
+    // Test: op-divide-yearMonthDuration-by-yearMonthDuration2args-5
+    // Written By: Carmelo Montanez
+    // Date: Tue Apr 12 16:29:08 GMT-05:00 2005
+    // Purpose: Evaluates The 'op:divide-yearMonthDuration-by-yearMonthDuration' operator
+    // with the arguments set as follows:
+    // $arg1 = xs:yearMonthDuration(lower bound)
+    // $arg2 = xs:yearMonthDuration(upper bound)
+    // XPath: xs:yearMonthDuration("P0Y0M") div xs:yearMonthDuration("P2030Y12M")
+    // Expected: assert-eq 0
+    assert(ym_duration_divide_by_duration(XsdYearMonthDuration::new(0), XsdYearMonthDuration::new(24372)) == XsdDouble::zero());
+    // Additional assertions: verify string parsing produces expected durations
+    let (parsed_ymd_0, parse_ok_0) = ym_duration_from_string("P0Y0M".as_bytes(), 5);
+    assert(parse_ok_0);
+    assert(ym_duration_equal(parsed_ymd_0, XsdYearMonthDuration::new(0)));
+    let (parsed_ymd_1, parse_ok_1) = ym_duration_from_string("P2030Y12M".as_bytes(), 9);
+    assert(parse_ok_1);
+    assert(ym_duration_equal(parsed_ymd_1, XsdYearMonthDuration::new(24372)));
+}
+
+#[test]
+fn op_divide_yearmonthduration_by_ymd_1() {
+    // Test: op-divide-yearMonthDuration-by-YMD-1
+    // Written By: Carmelo Montanez
+    // Date: June 30, 2005
+    // Purpose: Evaluates The 'divide-yearMonthDuration-by-YMD' operator
+    // As per example 1 (for this function)of the F&O specs.
+    // XPath: xs:yearMonthDuration("P3Y4M") div xs:yearMonthDuration("-P1Y4M")
+    // Expected: assert-eq -2.5
+    assert(ym_duration_divide_by_duration(XsdYearMonthDuration::new(40), XsdYearMonthDuration::new(-16)).to_bits() == 13836183955189006336);
+    // Additional assertions: verify string parsing produces expected durations
+    let (parsed_ymd_0, parse_ok_0) = ym_duration_from_string("P3Y4M".as_bytes(), 5);
+    assert(parse_ok_0);
+    assert(ym_duration_equal(parsed_ymd_0, XsdYearMonthDuration::new(40)));
+    let (parsed_ymd_1, parse_ok_1) = ym_duration_from_string("-P1Y4M".as_bytes(), 6);
+    assert(parse_ok_1);
+    assert(ym_duration_equal(parsed_ymd_1, XsdYearMonthDuration::new(-16)));
+}
+
+#[test]
+fn op_divide_yearmonthduration_by_ymd_8() {
+    // Test: op-divide-yearMonthDuration-by-YMD-8
+    // Written By: Carmelo Montanez
+    // Date: June 30, 2005
+    // Purpose: Evaluates The 'divide-yearMonthDuration-by-YMD' operator that
+    // returns a negative value.
+    // XPath: (xs:yearMonthDuration("P10Y01M") div xs:yearMonthDuration("-P10Y01M"))
+    // Expected: assert-eq -1
+    assert(ym_duration_divide_by_duration(XsdYearMonthDuration::new(121), XsdYearMonthDuration::new(-121)).to_bits() == 13830554455654793216);
+    // Additional assertions: verify string parsing produces expected durations
+    let (parsed_ymd_0, parse_ok_0) = ym_duration_from_string("P10Y01M".as_bytes(), 7);
+    assert(parse_ok_0);
+    assert(ym_duration_equal(parsed_ymd_0, XsdYearMonthDuration::new(121)));
+    let (parsed_ymd_1, parse_ok_1) = ym_duration_from_string("-P10Y01M".as_bytes(), 8);
+    assert(parse_ok_1);
+    assert(ym_duration_equal(parsed_ymd_1, XsdYearMonthDuration::new(-121)));
 }

--- a/zk/xpath/test_packages/xpath_test_opmultiply_yearmonthduration/src/chunk_0.nr
+++ b/zk/xpath/test_packages/xpath_test_opmultiply_yearmonthduration/src/chunk_0.nr
@@ -2,7 +2,7 @@
 //! Contains 21 tests
 
 use dep::xpath::{
-    fn_string_from_ym_duration, XsdYearMonthDuration, ym_duration_divide_by_duration,
+    fn_string_from_ym_duration, XsdDouble, XsdYearMonthDuration, ym_duration_divide_by_duration,
     ym_duration_equal, ym_duration_ge, ym_duration_le, ym_duration_multiply, ym_duration_subtract,
 };
 
@@ -131,12 +131,13 @@ fn op_multiply_yearmonthduration_11() {
     //  ******************************************************* Test:
     // XPath: (xs:yearMonthDuration("P20Y11M") * 2.0) div (xs:yearMonthDuration("P20Y11M") * 2.0)
     // Expected: assert-eq 1
+    // Oracle: x div x = 1.0 exactly (0x3FF0000000000000)
     assert(
         ym_duration_divide_by_duration(
             ym_duration_multiply(XsdYearMonthDuration::new(251), 2),
             ym_duration_multiply(XsdYearMonthDuration::new(251), 2),
         )
-            == 1,
+            == XsdDouble::from_bits(0x3FF0000000000000),
     );
 }
 

--- a/zk/xpath/xpath/src/year_month_duration.nr
+++ b/zk/xpath/xpath/src/year_month_duration.nr
@@ -6,7 +6,8 @@
 //! XPath operators implemented:
 //! - op:add-yearMonthDurations, op:subtract-yearMonthDurations
 //! - op:multiply-yearMonthDuration, op:divide-yearMonthDuration
-//! - op:divide-yearMonthDuration-by-yearMonthDuration
+//! - op:divide-yearMonthDuration-by-yearMonthDuration (xs:decimal ratio,
+//!   modelled as an IEEE 754 double -- the tree's decimal representation)
 //! - op:add-yearMonthDuration-to-dateTime, op:subtract-yearMonthDuration-from-dateTime
 //! - op:add-yearMonthDuration-to-date, op:subtract-yearMonthDuration-from-date
 //! - op:yearMonthDuration-equal, op:yearMonthDuration-less-than, op:yearMonthDuration-greater-than
@@ -14,6 +15,7 @@
 //! - fn:years-from-duration, fn:months-from-duration (for yearMonthDuration)
 
 use crate::date::{date_from_components_with_tz, day_from_date, month_from_date, year_from_date};
+use crate::numeric_types::{numeric_divide_int_as_double, XsdDouble};
 use crate::datetime::{
     datetime_from_components_with_tz, day_from_datetime, hours_from_datetime,
     microseconds_from_datetime, minutes_from_datetime, month_from_datetime, seconds_from_datetime,
@@ -306,10 +308,24 @@ pub fn ym_duration_divide(dur: XsdYearMonthDuration, divisor: i32) -> XsdYearMon
 }
 
 /// op:divide-yearMonthDuration-by-yearMonthDuration
-/// Divides two yearMonthDurations, returning a ratio
-pub fn ym_duration_divide_by_duration(a: XsdYearMonthDuration, b: XsdYearMonthDuration) -> i32 {
+///
+/// F&O 3.1 sec. 8.4.5: returns the ratio of two xs:yearMonthDurations "as an
+/// xs:decimal number" -- it NEVER truncates: P3Y div P2Y = 1.5. The old
+/// `i32` return silently truncated that to 1 (sq-3x7dl.19).
+///
+/// DECIMAL REPRESENTATION: this codebase has no arbitrary-precision
+/// xs:decimal type -- decimals are modelled as IEEE 754 doubles throughout
+/// (the documented approximation in `numeric_divide_int_as_double`,
+/// numeric_types.nr). Each signed month count converts exactly for
+/// |months| <= 2^53 (far beyond any realistic duration), so the quotient is
+/// the correctly-rounded double of the true rational month ratio.
+///
+/// Division by zero duration raises err:FOAR0001 in XPath (F&O 3.1
+/// sec. 8.4.5 error clause); this tree represents F&O dynamic errors as
+/// fail-closed asserts. [SONNET-4.6] (sq-3x7dl.19)
+pub fn ym_duration_divide_by_duration(a: XsdYearMonthDuration, b: XsdYearMonthDuration) -> XsdDouble {
     assert(b.total_months != 0, "Division by zero duration");
-    a.total_months / b.total_months
+    numeric_divide_int_as_double(a.total_months as i64, b.total_months as i64)
 }
 
 /// Negates a yearMonthDuration
@@ -698,4 +714,78 @@ fn test_ym_duration_from_string() {
     let input_no_p = "1Y2M".as_bytes();
     let (_dur_no_p, valid_no_p) = ym_duration_from_string(input_no_p, 4);
     assert(!valid_no_p);
+}
+
+// ============================================================================
+// op:divide-yearMonthDuration-by-yearMonthDuration -> xs:decimal ratio
+// (sq-3x7dl.19) [SONNET-4.6]
+//
+// F&O 3.1 sec. 8.4.5: the ratio of two yearMonthDurations is an xs:decimal and
+// never truncates. xs:decimal is modelled as an IEEE 754 double here -- the
+// documented approximation defined in numeric_types.nr on
+// `numeric_divide_int_as_double` (exact operand conversion for all practical
+// month counts, correctly-rounded IEEE 754 division).
+//
+// Oracle (independent Python, exact rational + hardware IEEE 754 double):
+//   from fractions import Fraction; import struct
+//   Fraction(36, 24)                                    -> Fraction(3, 2)
+//   struct.unpack('<Q', struct.pack('<d', 36/24))[0]    -> 0x3FF8000000000000  (1.5)
+// ============================================================================
+
+#[test]
+fn test_ym_duration_divide_by_duration_exact_ratio() {
+    // Oracle: P3Y div P2Y = Fraction(36,24) = Fraction(3,2) = 1.5 exactly (0x3FF8000000000000).
+    // The pre-fix truncating i32 impl returned 1 -- the sq-3x7dl.19 bug.
+    let p3y = XsdYearMonthDuration::new(36);
+    let p2y = XsdYearMonthDuration::new(24);
+    assert(ym_duration_divide_by_duration(p3y, p2y) == XsdDouble::from_bits(0x3FF8000000000000));
+}
+
+#[test]
+fn test_ym_duration_divide_by_duration_non_terminating_ratio() {
+    // Oracle: P1Y div P3Y = Fraction(12,36) = Fraction(1,3), a non-terminating decimal.
+    // Under the tree's decimal-as-double convention (numeric_types.nr,
+    // numeric_divide_int_as_double: "DOCUMENTED APPROXIMATION") the result is
+    // the correctly-rounded double of 1/3:
+    //   Python: float(Fraction(12, 36)) == 12/36 -> True
+    //   struct.pack('<d', 12/36) -> 0x3FD5555555555555 (0.3333333333333333)
+    let p1y = XsdYearMonthDuration::new(12);
+    let p3y = XsdYearMonthDuration::new(36);
+    assert(ym_duration_divide_by_duration(p1y, p3y) == XsdDouble::from_bits(0x3FD5555555555555));
+}
+
+#[test]
+fn test_ym_duration_divide_by_duration_signs() {
+    // Oracle: (-P3Y) div (-P2Y) = 1.5 (0x3FF8000000000000) -- negatives cancel.
+    //         P3Y div (-P2Y) = -1.5 (0xBFF8000000000000) -- mixed sign.
+    // Python: (-36)/(-24) -> 1.5;  36/(-24) -> -1.5
+    let p3y = XsdYearMonthDuration::new(36);
+    let neg_p3y = XsdYearMonthDuration::new(-36);
+    let neg_p2y = XsdYearMonthDuration::new(-24);
+    assert(
+        ym_duration_divide_by_duration(neg_p3y, neg_p2y)
+            == XsdDouble::from_bits(0x3FF8000000000000),
+    );
+    assert(
+        ym_duration_divide_by_duration(p3y, neg_p2y) == XsdDouble::from_bits(0xBFF8000000000000),
+    );
+}
+
+#[test]
+fn test_ym_duration_divide_by_duration_self_is_one() {
+    // Oracle: any non-zero duration divided by itself is exactly 1.0
+    // (0x3FF0000000000000). P2Y3M = 27 months;
+    // Python: 27/27 -> 1.0
+    let dur = XsdYearMonthDuration::new(27);
+    assert(ym_duration_divide_by_duration(dur, dur) == XsdDouble::from_bits(0x3FF0000000000000));
+}
+
+#[test(should_fail_with = "Division by zero duration")]
+fn test_ym_duration_divide_by_duration_zero_divisor_foar0001() {
+    // F&O 3.1 sec. 8.4.5 error clause: dividing by a zero yearMonthDuration
+    // raises err:FOAR0001 (division by zero). This tree represents F&O
+    // dynamic errors as fail-closed asserts (see numeric.nr /
+    // numeric_divide_int_as_double), so the assert must fire.
+    let p3y = XsdYearMonthDuration::new(36);
+    let _ = ym_duration_divide_by_duration(p3y, XsdYearMonthDuration::zero());
 }

--- a/zk/xpath/xpath_unit_tests/src/year_month_duration_tests.nr
+++ b/zk/xpath/xpath_unit_tests/src/year_month_duration_tests.nr
@@ -1,7 +1,7 @@
 //! Unit tests for YearMonthDuration functions
 
 use dep::xpath::{
-    months_from_duration, XsdYearMonthDuration, years_from_duration, ym_duration_add,
+    months_from_duration, XsdDouble, XsdYearMonthDuration, years_from_duration, ym_duration_add,
     ym_duration_divide, ym_duration_divide_by_duration, ym_duration_equal, ym_duration_ge,
     ym_duration_greater_than, ym_duration_le, ym_duration_less_than, ym_duration_multiply,
     ym_duration_negate, ym_duration_subtract,
@@ -106,10 +106,11 @@ fn test_ym_duration_divide() {
 
 #[test]
 fn test_ym_duration_divide_by_duration() {
-    let d1 = XsdYearMonthDuration::new(24); // 2 years
+    let d1 = XsdYearMonthDuration::new(24); // 2 years = 24 months
     let d2 = XsdYearMonthDuration::new(6); // 6 months
+    // Oracle: 24/6 = 4 exactly; Python: struct.pack('<d', 4.0) -> 0x4010000000000000
     let result = ym_duration_divide_by_duration(d1, d2);
-    assert(result == 4);
+    assert(result == XsdDouble::from_bits(0x4010000000000000));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

**Bug (audit LOW, sq-3x7dl.19):** `op:divide-yearMonthDuration-by-yearMonthDuration` returned a truncating `i32` ratio — `P3Y div P2Y` gave `1` instead of `1.5`. F&O 3.1 sec. 8.4.5 declares the result "as an xs:decimal number": it never truncates.

**Fix:** `ym_duration_divide_by_duration` now returns `XsdDouble`, delegating to `numeric_divide_int_as_double` — the tree's **existing** xs:decimal representation (the "DOCUMENTED APPROXIMATION" block in `numeric_types.nr`: no arbitrary-precision decimal type exists; decimals are modelled as IEEE 754 doubles throughout, exact operand conversion for all practical month counts, correctly-rounded division). No new encoding was invented.

**Zero divisor:** F&O 3.1 sec. 8.4.5 error clause mandates `err:FOAR0001`. This tree represents F&O dynamic errors as fail-closed asserts, so the existing `assert(b.total_months != 0, "Division by zero duration")` is kept and now pinned by a `should_fail_with` test.

Exact mirror of PR #1559 (sq-3x7dl.9 fix for dayTimeDuration).

## Tests (oracle-quoted: Python `Fraction` + `struct` double bits)

| case | oracle | expected |
|---|---|---|
| exact ratio | `Fraction(36, 24) = 3/2` | `0x3FF8000000000000` (1.5) — old impl returned 1 |
| non-terminating | `Fraction(12, 36) = 1/3`; `float(Fraction(1,3))` | `0x3FD5555555555555` — correctly-rounded double |
| neg/neg | `(-P3Y) div (-P2Y)` | `0x3FF8000000000000` (1.5) |
| mixed sign | `P3Y div (-P2Y)` | `0xBFF8000000000000` (−1.5) |
| self ÷ self | `P2Y3M / itself` | `0x3FF0000000000000` (1.0) |
| zero divisor | F&O 8.4.5 → FOAR0001 | `should_fail_with = "Division by zero duration"` |

## Generated qt3 package

- `generate_tests.py`: `ym_duration_divide_by_duration` added to `double_returning_functions`; content-based `XsdDouble` import detection (from sq-3x7dl.9) handles the import.
- Regenerated `xpath_test_opdivide_yearmonthduration_by_yearmonthduration` package: 7 tests now pass (was a placeholder asserting `true`).
- Generator spillover (workspace-wide `nargo fmt` rewriting `use dep::` → `use ::`, plus `prod*` Nargo.toml members) was **reverted** — only the target package is touched.

## Verification

- [x] `nargo test` (1.0.0-beta.21): `xpath` package green (167 tests, incl. 5 new tests), target qt3 package green (7 tests), `xpath_unit_tests` green (292 tests)
- [x] Mutation spot-check: flipped expected `1.5` → `1.0` bits ⇒ `test_ym_duration_divide_by_duration_exact_ratio` **FAILS**; restored ⇒ green
- [x] `SPARQL_COVERAGE.md` row added for op:divide-yearMonthDuration-by-yearMonthDuration

## Notes

- **Face re-sync note**: Face re-sync is batched (pending drift accumulating across the xpath wave) — a re-sync bead will collect this.
- **Do NOT arm** — ZK surface requires escalated review.

> **SPARQ agent** 🤖 — automated implementation of bead sq-3x7dl.19. @jeswr please review for soundness before arming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)