### PR TITLE
feat(ci): feature-matrix tiers — assembler tier/event awareness + T1 check-tier job + enforce wiring (sq-ldg8c) [SONNET-4.6]

### DIFF
--- a/.github/workflows/feature-matrix.yml
+++ b/.github/workflows/feature-matrix.yml
@@ -218,6 +218,16 @@ jobs:
         # leg "advisory"/"informational") fails THIS gating job — i.e. the gate-critical
         # invariant is enforced on every PR that touches a fragment, not just by review.
         run: python3 scripts/tests/test_feature_matrix_assemble.py
+      - name: Enforce tier ratchet + sq-vya1 guard (feature-matrix-tiers.py --enforce)
+        # [SONNET-4.6] sq-ldg8c (design §4): mechanizes the sq-vya1 GUARD as a HARD gate.
+        # Reds THIS gating job if a leg carries `tier: check` while the detector still finds
+        # feature-gated test code / a `cfg(not(feature))` brace (and no reviewed
+        # `tier-reason:` override), OR if any sensitive feature has no `test: true` leg. So a
+        # future feature-gated test added under a demoted feature re-promotes it at the next
+        # PR — the ratchet. Fail-closed: a detector/IO error classifies a leg SENSITIVE (keep
+        # the full leg), never a silent demotion. Stdlib + the PyYAML installed above; it
+        # scans crates/ (checked out above). At ZERO annotations this is a no-op green.
+        run: python3 scripts/feature-matrix-tiers.py --enforce
       - name: Assemble matrix from .github/feature-matrix.d/*.yml
         id: assemble
         # Emit the leg set as a one-line JSON object on the `matrix` output. The
@@ -233,11 +243,11 @@ jobs:
           SELECT_AFFECTED: ${{ needs.select.outputs.affected }}
         run: |
           set -euo pipefail
-          MATRIX="$(python3 scripts/assemble-feature-matrix.py --select-mode "${SELECT_MODE:-}" --affected "${SELECT_AFFECTED:-}")"
+          MATRIX="$(python3 scripts/assemble-feature-matrix.py --event "${{ github.event_name }}" --select-mode "${SELECT_MODE:-}" --affected "${SELECT_AFFECTED:-}")"
           echo "matrix=$MATRIX" >> "$GITHUB_OUTPUT"
           LEGS="$(echo "$MATRIX" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["include"]))')"
           echo "legs=$LEGS" >> "$GITHUB_OUTPUT"
-          echo "Assembled $LEGS opt-in leg(s) (select mode: ${SELECT_MODE:-<unset>}). Full leg-name set:"
+          echo "Assembled $LEGS opt-in leg(s) (select mode: ${SELECT_MODE:-<unset>}, event ${{ github.event_name }}). Full leg-name set:"
           python3 scripts/assemble-feature-matrix.py --names
 
   opt-in-features:
@@ -333,6 +343,114 @@ jobs:
         run: cargo test -p ${{ matrix.crate }} --features ${{ matrix.features }}
       - name: Clippy (--all-targets -D warnings)
         run: cargo clippy -p ${{ matrix.crate }} --features ${{ matrix.features }} --all-targets -- -D warnings
+
+  # [SONNET-4.6] sq-ldg8c: T1 CHECK TIER — compile+clippy (NO test run) for the opt-in legs a
+  # fragment has DEMOTED with `tier: check`. Design: research/feature-matrix-pyramid.md §3/§5.
+  # The assembler (`--tier check`) emits ONLY the demoted legs on pull_request/merge_group;
+  # on push/schedule/workflow_dispatch it emits NONE — those events run the FULL `opt-in`
+  # matrix above as the per-merge backstop, so the check tier is empty there. TWO shards
+  # (sparq-engine legs vs the rest) each reuse ONE target dir, so a shard's crate+dependency
+  # stack compiles once across its legs (engine's per-feature-state frontend recompile is the
+  # dominant cost — design §3). No `--all-targets`: a demoted leg has, by the demotion
+  # criterion, no feature-gated test code, so the class-A signal is the lib/bin compile+lint.
+  #
+  # BEHAVIOUR-PRESERVING AT MERGE: with ZERO fragments annotated (the state this bead lands
+  # in — the demotion flip is the separate bead sq-s5dvo), the assembler emits an EMPTY leg
+  # set for BOTH shards, so every Rust step is skipped and the job is GREEN-EMPTY (proven by
+  # scripts/tests/test_feature_matrix_assemble.py's behaviour-preservation tests). The job
+  # NAME ("feature-matrix check-tier (<shard>)") is free of the words "advisory"/
+  # "informational", so the single required `ci-summary / gate` aggregator auto-discovers
+  # each shard as a REQUIRED check — once a leg is demoted, its compile/clippy break still
+  # blocks the merge via T1 instead of its old `opt-in <name>` leg. Same assembly-time-
+  # filtering mechanism as the matrix above (sq-fmx4u.4): no ci-summary edit, no ruleset
+  # change. Selection is applied INSIDE the assemble step (env), never the job-level `if:`.
+  check-tier:
+    needs: [changes, select]
+    if: needs.changes.outputs.rust_changed == 'true'
+    name: feature-matrix check-tier (${{ matrix.shard }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [engine, rest]
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Install PyYAML
+        # [OPUS-4.8] HASH-pinned (Scorecard PinnedDependenciesID): same full-closure PyYAML
+        # 6.0.2 hash set the setup job pins; --require-hashes verifies every artifact.
+        run: pip install --require-hashes -r .github/requirements/docs-quality.txt
+      - name: Assemble demoted (tier:check) legs for this shard
+        id: legs
+        # [SONNET-4.6] sq-ldg8c: --tier check emits the demoted legs for this shard, further
+        # filtered by the SAME change-based selection the setup job applies (fail-closed to
+        # the full set inside the assembler). GREEN-EMPTY today: legs=0 => the Rust steps
+        # below all skip.
+        env:
+          SELECT_MODE: ${{ needs.select.outputs.mode }}
+          SELECT_AFFECTED: ${{ needs.select.outputs.affected }}
+        run: |
+          set -euo pipefail
+          CHECK="$(python3 scripts/assemble-feature-matrix.py \
+            --event "${{ github.event_name }}" --tier check --shard "${{ matrix.shard }}" \
+            --select-mode "${SELECT_MODE:-}" --affected "${SELECT_AFFECTED:-}")"
+          echo "matrix=$CHECK" >> "$GITHUB_OUTPUT"
+          N="$(echo "$CHECK" | python3 -c 'import json,sys; print(len(json.load(sys.stdin)["include"]))')"
+          echo "legs=$N" >> "$GITHUB_OUTPUT"
+          echo "check-tier shard '${{ matrix.shard }}': $N demoted leg(s) (event ${{ github.event_name }}, select ${SELECT_MODE:-<unset>})"
+      - name: Install Rust (stable)
+        if: steps.legs.outputs.legs != '0'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        if: steps.legs.outputs.legs != '0'
+        with:
+          shared-key: feature-matrix-check-tier-${{ matrix.shard }}
+          # [OPUS-4.8] sq-3sbrr: restore-only off main (see the opt-in-features note).
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Fetch dependencies (retry transient crates.io fetch)
+        if: steps.legs.outputs.legs != '0'
+        run: |
+          set -euo pipefail
+          n=0
+          until cargo fetch --locked; do
+            n=$((n+1))
+            if [ "$n" -ge 3 ]; then
+              echo "::error::cargo fetch failed after $n attempts (registry outage?)" >&2
+              exit 1
+            fi
+            echo "cargo fetch attempt $n failed; retrying in 10s..." >&2
+            sleep 10
+          done
+      - name: Clippy each demoted leg (shared target dir, -D warnings)
+        if: steps.legs.outputs.legs != '0'
+        env:
+          CHECK_MATRIX: ${{ steps.legs.outputs.matrix }}
+        run: |
+          set -euo pipefail
+          # One clippy per demoted leg, sequentially, sharing the single target dir so the
+          # crate + dependency stack compiles once across the shard's legs. mapfile keeps the
+          # loop in the MAIN shell so `set -e` fails the step on the first clippy error.
+          mapfile -t LEGS < <(printf '%s' "$CHECK_MATRIX" | python3 -c '
+          import json, sys
+          for leg in json.load(sys.stdin)["include"]:
+              print("{}\t{}".format(leg["crate"], leg["features"]))
+          ')
+          for line in "${LEGS[@]:-}"; do
+            [ -z "$line" ] && continue
+            crate="${line%%$'\t'*}"
+            features="${line#*$'\t'}"
+            echo "::group::clippy -p ${crate} --features ${features}"
+            cargo clippy -p "${crate}" --features "${features}" -- -D warnings
+            echo "::endgroup::"
+          done
 
   # [OPUS-4.8] sq-1b390: THE pure-serialiser-library build of sparq-server — i.e. the crate
   # with `--no-default-features` (the `server` async HTTP stack OFF), the contract a consumer

--- a/scripts/assemble-feature-matrix.py
+++ b/scripts/assemble-feature-matrix.py
@@ -35,7 +35,36 @@
 #                                                         #   legs whose crate is affected;
 #                                                         #   ANY other/malformed input
 #                                                         #   fail-closes to the FULL set
+#   ... --event <name> --tier <test|check> [--shard e|r]  # [SONNET-4.6] sq-ldg8c: tier +
+#                                                         #   event awareness (see below)
 # Exit non-zero (with a diagnostic on stderr) on any malformed fragment.
+#
+# TIER + EVENT AWARENESS (bead sq-ldg8c; design research/feature-matrix-pyramid.md §3/§5).
+# A fragment leg MAY carry an optional `tier:` field (plus an optional reviewed
+# `tier-reason:` override the ENFORCER reads — the assembler only allows the key):
+#   - MISSING tier            => `test`  (a full build+test+clippy leg; the default).
+#   - `tier: test`            => full leg.
+#   - `tier: check`           => a DEMOTED leg (the T1 check tier — compile+clippy only).
+#   - anything else / null    => HARD ERROR, exit non-zero. A demotion is NEVER inferred
+#                                from an unrecognised value ("never silently demotes").
+# The `--event <name>` + `--tier <test|check>` flags then partition the legs:
+#   - TIERED events (pull_request, merge_group): `--tier test` (default) emits the legs
+#     whose effective tier is `test`; `--tier check` emits the `check`-tier legs (the
+#     separate T1 output). A demoted leg thus LEAVES the per-PR `opt-in <name>` matrix and
+#     is covered by the check-tier job instead.
+#   - BACKSTOP events (push, schedule, workflow_dispatch, unknown/absent): the FULL
+#     per-merge backstop — ALL legs run as FULL legs, so `--tier test` emits EVERY leg
+#     (byte-identical to today) and `--tier check` emits NONE (the check tier is empty on
+#     a full run).
+# `--shard engine|rest` further splits the (tier/selection-filtered) legs for the T1 job's
+# two build shards: `engine` = the sparq-engine legs (each recompiles the engine frontend
+# per feature state — the dominant cost), `rest` = every other crate.
+# The tier/shard filters AND with the existing --select-mode selection filter. `--names`
+# ALWAYS dumps the FULL set (the gate-name proof must stay tier/event-independent).
+#
+# BEHAVIOUR-PRESERVATION INVARIANT (sq-ldg8c): with ZERO fragments annotated (no `tier:`
+# field anywhere — the state at merge), every event emits exactly today's leg set and the
+# check tier is empty. The demotion flip is a separate fragments-only bead (sq-s5dvo).
 
 import glob
 import json
@@ -55,6 +84,21 @@ FRAGMENT_DIR = os.path.join(
 )
 
 REQUIRED_KEYS = {"name", "crate", "features", "test"}
+# [SONNET-4.6] sq-ldg8c: keys a fragment leg MAY carry in addition to REQUIRED_KEYS.
+# `tier` demotes a leg to the check tier (see the header); `tier-reason` is an override
+# the ENFORCER (feature-matrix-tiers.py) reads — the assembler only allows the key.
+OPTIONAL_KEYS = {"tier", "tier-reason"}
+VALID_TIERS = ("test", "check")
+
+# [SONNET-4.6] sq-ldg8c: events on which the leg set is PARTITIONED by tier. Every other
+# event (push/schedule/workflow_dispatch/unknown/absent) is a FULL per-merge backstop —
+# ALL legs run as full legs and the check tier is empty (byte-identical to today).
+TIERED_EVENTS = frozenset({"pull_request", "merge_group"})
+
+# The T1 check-tier build shards (design §3): the sparq-engine legs recompile the engine
+# frontend per feature state (the dominant cost) and are isolated from the `rest`.
+ENGINE_CRATE = "sparq-engine"
+VALID_SHARDS = ("engine", "rest")
 
 
 def load_legs():
@@ -83,9 +127,12 @@ def load_legs():
                 sys.stderr.write(f"error: {where}: leg must be a mapping\n")
                 sys.exit(1)
             keys = set(leg.keys())
-            if keys != REQUIRED_KEYS:
-                missing = REQUIRED_KEYS - keys
-                extra = keys - REQUIRED_KEYS
+            # [SONNET-4.6] sq-ldg8c: REQUIRED_KEYS must all be present; extras are allowed
+            # ONLY from OPTIONAL_KEYS (tier / tier-reason). Any other key is still a HARD
+            # error (the pre-tier behaviour, minus the two now-permitted optional keys).
+            missing = REQUIRED_KEYS - keys
+            extra = keys - REQUIRED_KEYS - OPTIONAL_KEYS
+            if missing or extra:
                 msg = []
                 if missing:
                     msg.append(f"missing {sorted(missing)}")
@@ -110,6 +157,18 @@ def load_legs():
             if not isinstance(leg["test"], bool):
                 sys.stderr.write(f"error: {where}: `test` must be a boolean\n")
                 sys.exit(1)
+            # [SONNET-4.6] sq-ldg8c: normalise the optional tier. A MISSING tier defaults
+            # to `test` (a full leg — behaviour-preserving). A present-but-unrecognised
+            # value (typo, null, non-string) is a HARD ERROR: a demotion is only ever a
+            # reviewed `tier: check` edit, never inferred from a malformed value.
+            tier = leg.get("tier", "test")
+            if not isinstance(tier, str) or tier not in VALID_TIERS:
+                sys.stderr.write(
+                    f"error: {where}: `tier` must be one of {list(VALID_TIERS)} "
+                    f"(got {tier!r}); a missing `tier` defaults to 'test'. An "
+                    f"unrecognised value is never silently demoted to the check tier.\n"
+                )
+                sys.exit(1)
             name = leg["name"]
             if name in seen_names:
                 sys.stderr.write(
@@ -125,6 +184,10 @@ def load_legs():
                     "crate": leg["crate"],
                     "features": leg["features"],
                     "test": leg["test"],
+                    # Internal only: the normalised tier drives filter_legs_by_tier and is
+                    # STRIPPED before the matrix JSON is emitted (the workflow leg shape
+                    # stays exactly {name, crate, features, test}).
+                    "tier": tier,
                 }
             )
     return legs
@@ -167,6 +230,57 @@ def filter_legs_by_selection(legs, select_mode, affected_json):
     return [leg for leg in legs if leg["crate"] in keep]
 
 
+def filter_legs_by_tier(legs, event, tier):
+    """[SONNET-4.6] sq-ldg8c (design §3/§5): partition the leg list by tier for `event`.
+
+    - TIERED event (pull_request / merge_group): return the legs whose effective
+      tier equals the requested tier. `tier: check` legs are thus EXCLUDED from the
+      default test-tier matrix and surface only under `--tier check` (the T1 output).
+    - Any OTHER event (push / schedule / workflow_dispatch / unknown / absent): the
+      FULL per-merge backstop — ALL legs run as full legs, so `--tier test` (the
+      default) returns EVERY leg (byte-identical to today) and `--tier check` returns
+      NONE (the check tier is empty on a full run).
+
+    `tier` defaults to 'test' (the matrix output) when None. An unrecognised `--tier`
+    value is a HARD ERROR (exit non-zero) — never a silent demotion. This filter ANDs
+    with filter_legs_by_selection (order-independent; both narrow the set).
+    """
+    requested = "test" if tier is None else tier
+    if requested not in VALID_TIERS:
+        sys.stderr.write(
+            f"error: --tier must be one of {list(VALID_TIERS)} (got {tier!r})\n"
+        )
+        sys.exit(2)
+    if event not in TIERED_EVENTS:
+        # FULL backstop: everything is a full leg; the check tier is empty.
+        return list(legs) if requested == "test" else []
+    return [leg for leg in legs if leg.get("tier", "test") == requested]
+
+
+def filter_legs_by_shard(legs, shard):
+    """[SONNET-4.6] sq-ldg8c (design §3): split the (already tier/selection-filtered)
+    legs into the T1 check-tier's two build shards.
+
+      * shard == "engine" => the sparq-engine legs (each recompiles the engine
+        frontend per feature state — the dominant cost, isolated so the rest share a
+        warm target dir);
+      * shard == "rest"   => every other crate's legs;
+      * shard is None     => no split (return the legs unchanged).
+
+    An unrecognised shard value is a HARD ERROR (exit non-zero).
+    """
+    if shard is None:
+        return legs
+    if shard not in VALID_SHARDS:
+        sys.stderr.write(
+            f"error: --shard must be one of {list(VALID_SHARDS)} (got {shard!r})\n"
+        )
+        sys.exit(2)
+    if shard == "engine":
+        return [leg for leg in legs if leg["crate"] == ENGINE_CRATE]
+    return [leg for leg in legs if leg["crate"] != ENGINE_CRATE]
+
+
 def _flag_value(argv, flag):
     """Value of `--flag value` in argv, or None."""
     for i, a in enumerate(argv):
@@ -183,14 +297,36 @@ def main():
         for name in sorted(f"opt-in {leg['name']}" for leg in legs):
             print(name)
         return
+    argv = sys.argv[1:]
+    # AND-composed filters (order-independent): selection narrows by affected crate,
+    # tier partitions by event+tier, shard splits the check tier's build shards.
     legs = filter_legs_by_selection(
         legs,
-        _flag_value(sys.argv[1:], "--select-mode"),
-        _flag_value(sys.argv[1:], "--affected"),
+        _flag_value(argv, "--select-mode"),
+        _flag_value(argv, "--affected"),
     )
+    legs = filter_legs_by_tier(
+        legs,
+        _flag_value(argv, "--event"),
+        _flag_value(argv, "--tier"),
+    )
+    legs = filter_legs_by_shard(legs, _flag_value(argv, "--shard"))
+    # Strip the internal `tier` key so the emitted leg shape stays exactly
+    # {name, crate, features, test} (the workflow matrix contract). Rebuilding in
+    # this fixed key order keeps the default output BYTE-IDENTICAL to the pre-tier
+    # assembler (sq-ldg8c behaviour-preservation invariant).
+    include = [
+        {
+            "name": leg["name"],
+            "crate": leg["crate"],
+            "features": leg["features"],
+            "test": leg["test"],
+        }
+        for leg in legs
+    ]
     # Emit a single-line JSON object so the workflow can capture it with
     # `echo "matrix=$(...)" >> "$GITHUB_OUTPUT"` and feed `fromJSON(... .matrix)`.
-    print(json.dumps({"include": legs}, ensure_ascii=False, separators=(",", ":")))
+    print(json.dumps({"include": include}, ensure_ascii=False, separators=(",", ":")))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_feature_matrix_assemble.py
+++ b/scripts/tests/test_feature_matrix_assemble.py
@@ -22,10 +22,13 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import re
 import sys
+import tempfile
 import unittest
+from contextlib import redirect_stdout
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
@@ -232,6 +235,218 @@ class TestSelectionFiltering(unittest.TestCase):
             sys.argv = argv
         obj = json.loads(buf.getvalue())
         self.assertEqual({leg["crate"] for leg in obj["include"]}, {keep})
+
+
+# [SONNET-4.6] sq-ldg8c: feature-matrix TIER + EVENT awareness.
+#
+# The load-bearing property is BEHAVIOUR-PRESERVATION at ZERO annotations: with no
+# `tier:` field on any fragment (the state at merge), every event emits exactly today's
+# full leg set and the check tier is empty. The tier machinery only takes effect once a
+# fragment opts in (the separate flip bead sq-s5dvo). Malformed/unknown tier => HARD ERROR
+# (never a silent demotion). Design: research/feature-matrix-pyramid.md §3/§5.
+
+
+def _run_main_json(mod, extra_argv):
+    """Run the assembler's main() with argv and return the parsed JSON object."""
+    buf = io.StringIO()
+    saved = sys.argv
+    sys.argv = ["assemble-feature-matrix.py"] + list(extra_argv)
+    try:
+        with redirect_stdout(buf):
+            mod.main()
+    finally:
+        sys.argv = saved
+    return json.loads(buf.getvalue())
+
+
+def _synth_legs():
+    """Synthetic legs exercising both tiers across the engine/rest shard split.
+    (The real fragments carry NO annotations, so the demotion path can only be
+    exercised with synthetic input — the behaviour-preservation tests below cover
+    the real, zero-annotation fragment set.)"""
+    return [
+        {"name": "a", "crate": "sparq-core", "features": "f1", "test": True, "tier": "test"},
+        {"name": "b", "crate": "sparq-engine", "features": "f2", "test": True, "tier": "check"},
+        {"name": "c", "crate": "sparq-kb", "features": "f3", "test": False, "tier": "check"},
+        {"name": "d", "crate": "sparq-engine", "features": "f4", "test": True, "tier": "test"},
+    ]
+
+
+class TestTierFiltering(unittest.TestCase):
+    """filter_legs_by_tier / filter_legs_by_shard as pure functions."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_assembler()
+
+    def _names(self, legs):
+        return sorted(leg["name"] for leg in legs)
+
+    # ---- tiered events (pull_request / merge_group) partition by tier -------------
+    def test_pull_request_test_tier_excludes_check_legs(self):
+        for event in ("pull_request", "merge_group"):
+            got = self.mod.filter_legs_by_tier(_synth_legs(), event, "test")
+            self.assertEqual(self._names(got), ["a", "d"],
+                             f"{event}: default/test tier must exclude tier:check legs")
+
+    def test_pull_request_default_tier_is_test(self):
+        # tier=None defaults to 'test' (the matrix output).
+        got = self.mod.filter_legs_by_tier(_synth_legs(), "pull_request", None)
+        self.assertEqual(self._names(got), ["a", "d"])
+
+    def test_pull_request_check_tier_selects_only_check_legs(self):
+        for event in ("pull_request", "merge_group"):
+            got = self.mod.filter_legs_by_tier(_synth_legs(), event, "check")
+            self.assertEqual(self._names(got), ["b", "c"],
+                             f"{event}: --tier check must emit exactly the demoted legs")
+
+    # ---- backstop events (push/schedule/...) emit ALL as full legs ----------------
+    def test_backstop_test_tier_emits_all_legs_regardless_of_tier(self):
+        for event in ("push", "schedule", "workflow_dispatch", "weird-unknown", None):
+            got = self.mod.filter_legs_by_tier(_synth_legs(), event, "test")
+            self.assertEqual(self._names(got), ["a", "b", "c", "d"],
+                             f"event={event!r}: backstop must run EVERY leg as a full leg")
+
+    def test_backstop_check_tier_is_empty(self):
+        # On a full backstop run everything ran as a full leg => the check tier is empty.
+        for event in ("push", "schedule", "workflow_dispatch", "weird-unknown", None):
+            got = self.mod.filter_legs_by_tier(_synth_legs(), event, "check")
+            self.assertEqual(got, [],
+                             f"event={event!r}: the check tier must be empty on a full run")
+
+    def test_malformed_tier_flag_is_a_hard_error(self):
+        for bad in ("checkk", "TEST", "full", ""):
+            with self.assertRaises(SystemExit) as cm:
+                self.mod.filter_legs_by_tier(_synth_legs(), "pull_request", bad)
+            self.assertNotEqual(cm.exception.code, 0)
+
+    # ---- shard split --------------------------------------------------------------
+    def test_shard_engine_vs_rest_partitions_the_check_legs(self):
+        check = self.mod.filter_legs_by_tier(_synth_legs(), "pull_request", "check")
+        engine = self.mod.filter_legs_by_shard(check, "engine")
+        rest = self.mod.filter_legs_by_shard(check, "rest")
+        self.assertEqual(self._names(engine), ["b"], "engine shard == sparq-engine legs")
+        self.assertEqual(self._names(rest), ["c"], "rest shard == non-engine legs")
+        # The two shards partition the check set exactly (no overlap, no drop).
+        self.assertEqual(self._names(engine) + self._names(rest), self._names(check))
+
+    def test_shard_none_is_a_noop(self):
+        legs = _synth_legs()
+        self.assertEqual(self.mod.filter_legs_by_shard(legs, None), legs)
+
+    def test_malformed_shard_flag_is_a_hard_error(self):
+        with self.assertRaises(SystemExit) as cm:
+            self.mod.filter_legs_by_shard(_synth_legs(), "nope")
+        self.assertNotEqual(cm.exception.code, 0)
+
+
+class TestTierFieldValidation(unittest.TestCase):
+    """load_legs() accepts the optional tier/tier-reason keys and validates the tier
+    value, with a fresh temp fragment dir so the real fragments are untouched."""
+
+    def setUp(self):
+        self.mod = _load_assembler()
+        self._tmp = tempfile.TemporaryDirectory()
+        self._dir = Path(self._tmp.name)
+        self._orig = self.mod.FRAGMENT_DIR
+        self.mod.FRAGMENT_DIR = str(self._dir)
+
+    def tearDown(self):
+        self.mod.FRAGMENT_DIR = self._orig
+        self._tmp.cleanup()
+
+    def _write(self, body):
+        (self._dir / "frag.yml").write_text(body, encoding="utf-8")
+
+    _BASE = (
+        "- name: demo\n"
+        "  crate: sparq-core\n"
+        "  features: jsonld\n"
+        "  test: true\n"
+    )
+
+    def test_missing_tier_defaults_to_test(self):
+        self._write(self._BASE)
+        legs = self.mod.load_legs()
+        self.assertEqual(legs[0]["tier"], "test")
+
+    def test_explicit_test_and_check_are_accepted(self):
+        for value in ("test", "check"):
+            self._write(self._BASE + f"  tier: {value}\n")
+            legs = self.mod.load_legs()
+            self.assertEqual(legs[0]["tier"], value)
+
+    def test_tier_reason_override_key_is_allowed(self):
+        self._write(self._BASE + "  tier: check\n  tier-reason: reviewed keep\n")
+        legs = self.mod.load_legs()
+        self.assertEqual(legs[0]["tier"], "check")
+
+    def test_malformed_tier_value_errors(self):
+        for bad in ("bogus", "checkk", "", "3", "[a, b]"):
+            self._write(self._BASE + f"  tier: {bad}\n")
+            with self.assertRaises(SystemExit) as cm:
+                self.mod.load_legs()
+            self.assertNotEqual(cm.exception.code, 0, f"tier: {bad} must error")
+
+    def test_null_tier_errors(self):
+        # A present-but-null tier (`tier:` with no value) must NOT be silently treated
+        # as check; it is malformed => error.
+        self._write(self._BASE + "  tier:\n")
+        with self.assertRaises(SystemExit):
+            self.mod.load_legs()
+
+    def test_unknown_extra_key_still_errors(self):
+        self._write(self._BASE + "  bogus-key: 1\n")
+        with self.assertRaises(SystemExit):
+            self.mod.load_legs()
+
+
+class TestTierBehaviorPreservation(unittest.TestCase):
+    """THE load-bearing invariant on the REAL fragment set: zero annotations =>
+    byte-identical full leg set on every event, and an empty check tier."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.mod = _load_assembler()
+        cls.full_names = sorted(leg["name"] for leg in cls.mod.load_legs())
+
+    def _include_names(self, obj):
+        return sorted(leg["name"] for leg in obj["include"])
+
+    def test_no_real_fragment_is_annotated_yet(self):
+        # Guards the premise of this whole bead: the demotion flip is a SEPARATE bead.
+        legs = self.mod.load_legs()
+        self.assertTrue(all(leg["tier"] == "test" for leg in legs),
+                        "a fragment carries a tier annotation — that belongs to the "
+                        "flip bead sq-s5dvo, not the behaviour-preserving wiring bead")
+
+    def test_pull_request_and_merge_group_emit_the_full_set(self):
+        for event in ("pull_request", "merge_group"):
+            obj = _run_main_json(self.mod, ["--event", event])
+            self.assertEqual(self._include_names(obj), self.full_names,
+                             f"{event}: test-tier matrix must be the FULL set unchanged")
+
+    def test_push_emits_the_full_set(self):
+        obj = _run_main_json(self.mod, ["--event", "push"])
+        self.assertEqual(self._include_names(obj), self.full_names)
+
+    def test_check_tier_is_green_empty_on_every_event(self):
+        for event in ("pull_request", "merge_group", "push", "schedule"):
+            obj = _run_main_json(self.mod, ["--event", event, "--tier", "check"])
+            self.assertEqual(obj["include"], [],
+                             f"{event}: check tier must be empty at zero annotations")
+            for shard in ("engine", "rest"):
+                obj = _run_main_json(
+                    self.mod, ["--event", event, "--tier", "check", "--shard", shard]
+                )
+                self.assertEqual(obj["include"], [],
+                                 f"{event}/{shard}: check-tier shard must be empty too")
+
+    def test_emitted_legs_have_exactly_the_four_workflow_keys(self):
+        # The internal `tier` key must be stripped from the matrix JSON.
+        obj = _run_main_json(self.mod, ["--event", "pull_request"])
+        for leg in obj["include"]:
+            self.assertEqual(set(leg.keys()), {"name", "crate", "features", "test"})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI/infra lane. Bead **sq-ldg8c** (parent `sq-6vshe.2`; design `research/feature-matrix-pyramid.md` §3/§5). Sonnet-tier task executed under the Opus drain.

## What this wires

Makes the feature-matrix assembler **tier- and event-aware** and adds the **T1 check-tier job** + the **sq-vya1 enforcement step** — explicitly **BEHAVIOUR-PRESERVING**. With **zero fragments annotated** (the state at merge), every event emits exactly today's leg set and the check tier is **green-empty**. Tiers only take effect once fragments opt in via the separate flip bead (`sq-s5dvo`).

### `scripts/assemble-feature-matrix.py`
- Optional per-leg `tier:` field — **missing ⇒ `test`** (full leg); `test`/`check` valid; **any other value / null ⇒ HARD ERROR** (never a silent demotion). `tier-reason:` allowed as the override key the enforcer reads.
- `--event` + `--tier` partition the legs: **tiered** events (`pull_request` / `merge_group`) split test vs check; **backstop** events (`push` / `schedule` / `workflow_dispatch` / unknown) run **ALL** legs full and leave the check tier empty (the per-merge backstop). `--shard engine|rest` splits the check tier's two build shards.
- Tier/shard filters **AND** with the existing `--select-mode` selection filter. `--names` always dumps the full set; the internal `tier` key is stripped so the emitted leg shape stays `{name, crate, features, test}`.

### `.github/workflows/feature-matrix.yml`
- `setup`: pass `--event` to the assemble step; add a gating **`feature-matrix-tiers.py --enforce`** step (mechanizes the sq-vya1 guard + demotion ratchet, fail-closed).
- New **`check-tier`** job, 2 shards (`engine` vs `rest`), names free of `advisory`/`informational` so **`ci-summary / gate` auto-discovers each as REQUIRED**. Assembles the demoted legs and runs `cargo clippy -p <crate> --features <F> -- -D warnings` per leg with a shared target dir; **green-empty** when zero legs demoted. Selection is applied inside the step (env), never the job-level `if:` (fail-closed disjunct / matrix-context traps avoided).

## Behaviour-preserving evidence
- **Byte-identical** assembled output verified against `origin/main` across default / `pull_request` / `merge_group` / `push` / `workflow_dispatch` and `--names` (all 73 legs, unchanged).
- Check tier is **empty on every event** at zero annotations (both shards); `setup` still emits **73** legs.
- Integration demo (scratch dir, one real leg demoted): the demoted leg **leaves the PR matrix** (72), lands in its **correct check-tier shard** with exactly the 4 workflow keys, runs **full on push** (backstop), and the partition invariant `test + check == full` holds. `--enforce` **RED**s a detector-sensitive demotion without a `tier-reason:` (ratchet is load-bearing) and is **green (0 violations)** on the current fragment set.

## Gates
- `python3 scripts/tests/test_feature_matrix_assemble.py` — **33 OK** (20 new: tier partitioning, shard split, tier-field validation, malformed ⇒ error, behaviour-preservation).
- `python3 scripts/tests/test_ci_select_wiring.py` — **32 OK** (the new job respects every structural pin incl. `TestRequiredCheckAnchor`).
- `python3 scripts/feature-matrix-tiers.py --enforce` — **0 violations**.
- `actionlint .github/workflows/feature-matrix.yml` — clean; YAML valid; all added actions SHA-pinned.

## Scope / compliance
- Gate aggregator **untouched**; the new check-tier legs gate via the same **assembly-time-filtering** mechanism (sq-fmx4u.4) — no ci-summary edit, no ruleset change. No `crates/` source touched. Path-filter discipline preserved (did **not** add the enforcer to the `rust:` filter — that would over-trigger the full matrix on a pure-Python edit).
- Closes the compliance gap the pyramid targets: the sq-vya1 GUARD graduates from comment-discipline to a **mechanized ratchet**, at zero behavioural change.

**Not armed** — CI surface = escalated review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)