### PR TITLE
docs(zk/ieee754): fix provenance note — in-tree canonical, sparq-org face

### DIFF
--- a/zk/ieee754/README.md
+++ b/zk/ieee754/README.md
@@ -4,9 +4,10 @@
 > 2026-06-12. At vendoring time that tree was 76 commits ahead of its remote
 > (HEAD `8a6fe4b`), plus uncommitted `src/ops/kernels.nr` edits that contain
 > the newest kernel work; the working tree was copied as-is. The package was
-> renamed from `test_lib` to `sparq_ieee754`. This subfolder is a temporary
-> home: the library is to be broken out into its own repository and upstreamed
-> later.
+> renamed from `test_lib` to `sparq_ieee754`. The in-tree version is canonical;
+> a published face is maintained at [sparq-org/noir_IEEE754](https://github.com/sparq-org/noir_IEEE754)
+> and synced in lockstep with this source. The face's README is face-specific
+> and is not synchronized back to this file.
 >
 > Verified on vendoring: `nargo 1.0.0-beta.21` + `bb 5.0.0-nightly.20260324`;
 > all tests pass and a fresh gate benchmark


### PR DESCRIPTION
## Summary
The zk/ieee754 README carries a stale provenance note claiming the code is a "temporary home... to be broken out into its own repository and upstreamed later." This breakout already happened months ago: the standalone sparq-org/noir_IEEE754 face exists and is synced from the in-tree source, which is canonical.

**Fix:** Update the provenance block to reflect the true current state: in-tree source is canonical; the published face is maintained in lockstep at sparq-org/noir_IEEE754; the face's README is face-specific and not synchronized back to this file.

**Changes:**
- Replace stale "temporary home" text with accurate provenance statement
- Link to the published face repository
- Clarify that in-tree is canonical and face is synced from it

**Gates:**
- ✅ markdownlint (HARD gate for zk/)
- ✅ typos (excludes zk/ by design, passes locally)

🤖 SPARQ agent