### PR TITLE
perf(solid/decide): persistent per-generation AclIndex, epoch-invalidated (sq-j8qtt)

### DIFF
--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -81,7 +81,7 @@ use oxrdf::{NamedNode, Term};
 use rustc_hash::FxHashMap;
 use sparq_core::Graph;
 use sparq_engine::{DatasetView, DefaultGraphMode, FxHashSet, QueryResult};
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// The reserved named graph holding the materialized authorization view.
 ///
@@ -192,6 +192,25 @@ pub struct PodStore {
     pub graph: Graph,
     auth: Arc<AuthIndex>,
     epoch: u64,
+    // [OPUS-4.8] sq-j8qtt (issue #1570): the PERSISTENT structural ACL index — the
+    // `.acl`/`.acr` control-document set + `<urn:sparq:auth>`-materialized flag that
+    // `decide` / `decide_batch` / `resolve_acl` walk to discover the governing ACL. It is
+    // a pure function of the current named-graph NAMES, so it is built LAZILY on the first
+    // point decision of a generation and then reused across the whole generation instead of
+    // rebuilt per call (the pre-fix `AclIndex::build(&self.graph)` was an O(named-graph-
+    // count) whole-store scan on EVERY `decide`). `OnceLock` gives the interior mutability
+    // the `&self` decision surface needs while keeping `PodStore: Sync` (a per-request LDP
+    // server shares `&PodStore` across threads): steady-state reads are a lock-free
+    // `get()`, and the first caller of a generation wins the one-time build.
+    //
+    // INVALIDATION — airtight by construction: it is dropped ONLY in `reindex`, the single
+    // seam that also rebuilds `auth` and clears the session cache (`self.auth` is assigned
+    // NOWHERE else). So it invalidates *exactly* when the authorization view does — a
+    // `put_acl`/`delete_acl`/`materialize_*`/bridge/trust change re-materializes, `reindex`
+    // empties this cell, and the next decision rebuilds from the new graph. It can never be
+    // more stale than `auth` itself, so it introduces no fail-open window. (sq-b7k7u's
+    // incremental reindex + sq-cnuqd's shared `&self` session cache compose on this seam.)
+    acl_index: OnceLock<decide::AclIndex>,
     // [OPUS-4.8] sq-3jtd.6: the cache key ([`SessionKey`]) spans all three session
     // dimensions — agent, client, AND issuer — so two sessions differing only by issuer
     // (e.g. the same WebID vouched for by a trusted vs an untrusted IdP) never collide on
@@ -251,6 +270,7 @@ impl PodStore {
             graph,
             auth: Arc::new(AuthIndex::default()),
             epoch: 0,
+            acl_index: OnceLock::new(), // [OPUS-4.8] sq-j8qtt: built lazily on first decide
             cache: FxHashMap::default(),
             #[cfg(feature = "odrl-bridge")]
             bridge_ledger: odrl_bridge::BridgeLedger::new(),
@@ -368,6 +388,21 @@ impl PodStore {
         self.auth = Arc::new(AuthIndex::from_graph(&self.graph));
         self.epoch += 1;
         self.cache.clear(); // D3: the cache is transient; the triples are the storage
+        // [OPUS-4.8] sq-j8qtt: drop the persistent structural ACL index in lock-step with
+        // the auth rebuild — the SAME seam that clears the session cache — so a rule change
+        // (put_acl/delete_acl/materialize_*/bridge/trust) is reflected by the next decision
+        // and no stale ACL discovery can survive it. `take` empties the cell; the next
+        // `decide`/`resolve_acl` rebuilds from the just-re-materialized graph.
+        self.acl_index.take();
+    }
+
+    /// The persistent structural ACL index for the current generation, built lazily on the
+    /// first point decision after a (re-)materialization and reused across the whole
+    /// generation ([OPUS-4.8] sq-j8qtt). Shared by [`PodStore::decide`] / `decide_batch` /
+    /// [`PodStore::resolve_acl`] so a decision is a point lookup, not a per-call whole-store
+    /// scan. `reindex` empties the cell, so this can never outlive an ACL change.
+    fn acl_index(&self) -> &decide::AclIndex {
+        self.acl_index.get_or_init(|| decide::AclIndex::build(&self.graph))
     }
 
     /// The sorted named-graph set this session may access in `mode`
@@ -538,8 +573,9 @@ impl PodStore {
     /// # Ok::<(), String>(())
     /// ```
     pub fn decide(&self, session: &Session, resource: &str, mode: Mode) -> WacDecision {
-        let index = decide::AclIndex::build(&self.graph);
-        decide::decide_one(&index, &self.auth, session, resource, mode)
+        // [OPUS-4.8] sq-j8qtt: reuse the persistent per-generation index (built once,
+        // dropped on `reindex`) instead of rebuilding it on every call.
+        decide::decide_one(self.acl_index(), &self.auth, session, resource, mode)
     }
 
     /// [OPUS-4.8] issue #992 FR-1 (sq-snopa.1) — [`PodStore::decide`] for a BATCH of
@@ -550,10 +586,12 @@ impl PodStore {
     ///
     /// **API tier-1 (proposed-stable)** — see [`PodStore::decide`].
     pub fn decide_batch(&self, session: &Session, requests: &[(&str, Mode)]) -> Vec<WacDecision> {
-        let index = decide::AclIndex::build(&self.graph);
+        // [OPUS-4.8] sq-j8qtt: the index now persists ACROSS calls too, not just within one
+        // batch — a batch and a stream of single `decide`s share the one per-generation build.
+        let index = self.acl_index();
         requests
             .iter()
-            .map(|(resource, mode)| decide::decide_one(&index, &self.auth, session, resource, *mode))
+            .map(|(resource, mode)| decide::decide_one(index, &self.auth, session, resource, *mode))
             .collect()
     }
 
@@ -590,7 +628,8 @@ impl PodStore {
     /// # Ok::<(), String>(())
     /// ```
     pub fn resolve_acl(&self, resource: &str) -> Option<EffectiveAcl> {
-        decide::AclIndex::build(&self.graph).resolve_acl(resource)
+        // [OPUS-4.8] sq-j8qtt: reuse the persistent per-generation index.
+        self.acl_index().resolve_acl(resource)
     }
 
     fn session_sets(&mut self, s: &Session, mode: Mode) -> &SessionSets {

--- a/crates/sparq-solid/tests/decide.rs
+++ b/crates/sparq-solid/tests/decide.rs
@@ -334,3 +334,110 @@ fn decide_verdict_matches_accessible_oracle() {
         }
     }
 }
+
+// ─── sq-j8qtt (issue #1570): persistent AclIndex — INVALIDATION must be airtight ──────
+//
+// The structural ACL index that `decide`/`decide_batch`/`resolve_acl` walk is now built
+// ONCE per generation and reused (not rebuilt per call). A stale index after an ACL change
+// is a WRONG authorization, so these pin that a rule change is reflected by the very next
+// decision on the SAME store — in BOTH directions (a newly-granting ACL, and the
+// fail-open-critical case of a DELETED granting ACL) — through the real put_acl/delete_acl
+// → reindex seam, and that the lazy build is race-free under a shared `&self`. [OPUS-4.8]
+
+/// A materialized WAC store with content but NO access-control document anywhere.
+fn empty_store() -> PodStore {
+    let nquads =
+        "<https://pod.ex/notes/n1.ttl#it> <https://ex.dev/ns#title> \"hi\" <https://pod.ex/notes/n1.ttl> .\n";
+    let g = Graph::load_dataset(nquads, "nquads").expect("loads");
+    let mut s = PodStore::new(g);
+    s.materialize_wac().expect("materializes");
+    s
+}
+
+#[test]
+fn decide_reflects_put_acl_without_manual_reindex() {
+    // Warm the persistent index on a pod with NO ACL (a NoAcl deny), then authoritatively
+    // PUT a root .acl granting alice Read. The very next decide() on the SAME store must see
+    // the new grant — a stale index would still answer NoAcl (a wrong, fail-closed verdict).
+    let mut store = empty_store();
+    let alice = session(Some(ALICE));
+    let resource = "https://pod.ex/notes/n1.ttl";
+
+    let before = store.decide(&alice, resource, Mode::Read);
+    assert!(!before.allow && before.status == AclStatus::NoAcl, "no ACL yet ⇒ NoAcl deny");
+    assert!(store.resolve_acl(resource).is_none(), "warm the index: no control document yet");
+
+    let acl = format!(
+        "<https://pod.ex/.acl#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> .\n\
+         <https://pod.ex/.acl#o> <http://www.w3.org/ns/auth/acl#default> <https://pod.ex/> .\n\
+         <https://pod.ex/.acl#o> <http://www.w3.org/ns/auth/acl#agent> <{}> .\n\
+         <https://pod.ex/.acl#o> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> .\n",
+        ALICE
+    );
+    store.put_acl("https://pod.ex/.acl", &acl, "ntriples").expect("put_acl");
+
+    let after = store.decide(&alice, resource, Mode::Read);
+    assert!(after.allow, "put_acl grant visible to the next decide (index was invalidated)");
+    assert_eq!(after.status, AclStatus::Resolved);
+    assert_eq!(after.scope, Some(AclScope::Default));
+    assert_eq!(
+        store.resolve_acl(resource).map(|e| e.acl),
+        Some(NamedNode::new_unchecked("https://pod.ex/.acl")),
+        "resolve_acl also sees the new control document"
+    );
+}
+
+#[test]
+fn decide_reflects_delete_acl_no_stale_grant() {
+    // The fail-OPEN-critical direction: an ACL that GRANTED access is DELETED. Warm the
+    // index (alice granted Read via the resource's OWN .acl), delete that .acl, and the next
+    // decision on the same store must STOP granting — a stale structural index would keep
+    // discovering the deleted control document.
+    let mut acl = AclBuilder::new();
+    acl.document("https://pod.ex/d.ttl");
+    acl.access_to("https://pod.ex/d.ttl", |a| a.agent(ALICE).mode(Mode::Read));
+    let mut store = store(acl);
+    let alice = session(Some(ALICE));
+    let resource = "https://pod.ex/d.ttl";
+
+    let before = store.decide(&alice, resource, Mode::Read);
+    assert!(before.allow && before.status == AclStatus::Resolved, "granted via own .acl");
+    assert!(store.resolve_acl(resource).is_some(), "warm the index: control document present");
+
+    store.delete_acl("https://pod.ex/d.ttl.acl").expect("delete_acl");
+
+    let after = store.decide(&alice, resource, Mode::Read);
+    assert!(!after.allow, "deleted ACL must not keep granting (index was invalidated)");
+    assert_eq!(after.status, AclStatus::NoAcl, "no control document remains ⇒ NoAcl");
+    assert!(store.resolve_acl(resource).is_none(), "resolve_acl no longer finds the deleted ACL");
+}
+
+#[test]
+fn concurrent_decide_shares_one_persistent_index() {
+    // `decide`/`resolve_acl` are `&self`; a per-request LDP server shares `&PodStore` across
+    // threads. The persistent index must build ONCE under contention and every thread must
+    // see the correct verdict — asserts PodStore stays Send+Sync and the lazy build is
+    // race-free.
+    fn assert_send_sync<T: Send + Sync>() {}
+    assert_send_sync::<PodStore>();
+
+    let mut acl = AclBuilder::new();
+    acl.document("https://pod.ex/d.ttl");
+    acl.access_to("https://pod.ex/d.ttl", |a| a.agent(ALICE).mode(Mode::Read));
+    let shared = std::sync::Arc::new(store(acl));
+
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let s = std::sync::Arc::clone(&shared);
+        handles.push(std::thread::spawn(move || {
+            for _ in 0..200 {
+                assert!(s.decide(&session(Some(ALICE)), "https://pod.ex/d.ttl", Mode::Read).allow);
+                assert!(!s.decide(&session(Some(BOB)), "https://pod.ex/d.ttl", Mode::Read).allow);
+                assert!(s.resolve_acl("https://pod.ex/d.ttl").is_some());
+            }
+        }));
+    }
+    for h in handles {
+        h.join().expect("thread ok");
+    }
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead `sq-j8qtt` (from PSS issue #1570, the `solid-server-rs` beyond-50k-throughput track). Foundation slice of the PSS decide-scale wave.

## Problem (issue #1570, verified on `origin/main`)

`PodStore::decide` / `decide_batch` / `resolve_acl` rebuilt the structural ACL index —
`decide::AclIndex::build(&self.graph)`, which iterates every named graph in the store — on
**every** call. At an LDP server calling `decide` per request over a large pod that is a
per-request O(named-graph-count) whole-store scan.

## Change — persist the `AclIndex`, invalidate on the existing epoch/reindex seam

- New private `acl_index: OnceLock<decide::AclIndex>` on `PodStore`, built **lazily** on the
  first point decision of a generation and reused across the whole generation.
  `decide`/`decide_batch`/`resolve_acl` now share it instead of rebuilding per call.
- `OnceLock` gives the interior mutability the `&self` decision surface needs while keeping
  `PodStore: Sync` (a per-request server shares `&PodStore` across threads): steady-state
  reads are a lock-free `get()`, and the first caller of a generation wins the one-time build.
- **Invalidation hooks the SAME seam that already clears the session cache + rebuilds `auth`**:
  `reindex` — the *only* site that assigns `self.auth` — now also empties the cell via `take()`.
  So the structural index invalidates **exactly** when the authorization view does; it can
  never be more stale than `auth`, and adds **no fail-open window**. (`put_acl`/`delete_acl`/
  `materialize_*`/bridge/trust all re-materialize → `reindex` → the next decision rebuilds.)
- **No public API change** (internal caching). Decisions are byte-identical — the full
  existing WAC/ACP conformance + differential suites stay green.

## Correctness pins (real `put_acl`/`delete_acl` → `reindex` seam, no mocks)

- `decide_reflects_put_acl_without_manual_reindex` — warm the index on a NoAcl pod, `put_acl`
  a granting root `.acl`, the next `decide` on the SAME store sees the grant.
- `decide_reflects_delete_acl_no_stale_grant` — the **fail-open-critical direction**: a
  granting `.acl` is deleted, the next `decide` stops granting (no stale ACL discovery).
- `concurrent_decide_shares_one_persistent_index` — shared `&PodStore` across 8 threads;
  asserts `Send + Sync` and a race-free one-time build.

## Scope / seams (honest)

This is the **foundation** of the PSS decide-scale wave. It deliberately leaves clean seams
for `sq-b7k7u` (incremental reindex) and `sq-cnuqd` (shared `&self` session cache). Issue
#1570 ask 2 — the `held_modes`/`modes_held` enumeration (materialising the full accessible
`Vec` per mode then scanning it) — is a *different* cost (proportional to the principal's
accessible-set size, not store size) and per the issue depends on the `&self` session cache,
so it is deferred to `sq-cnuqd` (companion #1569), not implemented here. Issue ask 3 (surface
the auth epoch on `WacDecision`) is a public-API change out of this internal-caching slice.

## Gates

- `cargo clippy --all-targets -- -D warnings` + full `sparq-solid` suite **GREEN** in the
  default build **and** in the `odrl-bridge` / `trust-graph` / `solid-sparql-query` feature
  states (the always-compiled `decide` path is unchanged in shape).
- `cargo clippy -p sparq-solid --all-targets --all-features -- -D warnings` clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` clean.
- The 8 `--all-features` `odrl_bridge` test failures **pre-exist on `origin/main`** (verified
  by stashing this change) — a `count-enforcement` feature-combination issue, unrelated.

Perf evidence (indicative work-box, non-canonical) is posted on bead `sq-j8qtt`.

Please **do not auto-merge** — this is an authorization-correctness surface for escalated review.

🤖 SPARQ agent