### PR TITLE
feat(conformance): publish served-surface SPARQL 1.1 Protocol conformance per release (sq-ro6if)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1906,6 +1906,40 @@ jobs:
           FLOOR=39
           echo "SD + Graph Store Protocol pass: ${PASS:-unknown} (floor: $FLOOR)"
           [ -n "$PASS" ] && [ "$PASS" -ge "$FLOOR" ] || { echo "::error::SD/GSP lane regressed below the ratchet ($PASS < $FLOOR)"; exit 1; }
+      # [OPUS-4.8] sq-ro6if (PSS #1415/#1478) — PUBLISH the served-surface conformance as a
+      # MACHINE-READABLE per-build artifact. The `served-conformance-report` binary re-runs the
+      # SAME two served-surface lanes above (sq-jaj38 http-protocol + sq-1uuxz SD/GSP) in-process
+      # and serialises their per-assertion outcomes + counts + provenance to JSON, pulling each
+      # suite's ratchet floor from the central scoreboard registry so the report can never drift
+      # from the enforcer. It is FAIL-CLOSED: it exits non-zero (failing this step) if a lane
+      # produced zero assertions (the vacuous-artifact class), has any genuine failure, or
+      # regressed below its floor — so a bad report can never be uploaded. NO new conformance
+      # tests; publication only. Requires BOTH served-surface features, so clippy the combined
+      # build first (the -D-warnings gate: the single-feature clippy steps above never compile the
+      # emitter's both-features module).
+      - name: Clippy the served-conformance report emitter (both served-surface features ON)
+        run: cargo clippy -p sparq-conformance --all-targets --features http-protocol,federation-descriptors -- -D warnings
+      - name: Emit served-surface conformance report (JSON, fail-closed)
+        env:
+          SPARQ_CONFORMANCE_COMMIT: ${{ github.sha }}
+          SPARQ_CONFORMANCE_VERSION: ${{ github.ref_name }}
+          SPARQ_CONFORMANCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -o pipefail
+          cargo run --release -p sparq-conformance \
+            --features http-protocol,federation-descriptors \
+            --bin served-conformance-report -- --out served-conformance.json 2>&1 \
+            | tee served-conformance.log
+          {
+            echo "### Served-surface SPARQL 1.1 Protocol conformance report"
+            grep -E 'pass /' served-conformance.log || true
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Upload served-surface conformance report
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: served-conformance-report
+          path: served-conformance.json
+          if-no-files-found: error
 
   inference-conformance:
     # Inference/reasoning conformance RATCHET: RDF Semantics (rdf-mt), OWL 2 RL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1926,7 +1926,9 @@ jobs:
           SPARQ_CONFORMANCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -o pipefail
-          cargo run --release -p sparq-conformance \
+          # Debug (no --release): reuses the both-features artifacts the clippy step above already
+          # compiled; the report is a quick in-process run, so optimisation buys nothing here.
+          cargo run -p sparq-conformance \
             --features http-protocol,federation-descriptors \
             --bin served-conformance-report -- --out served-conformance.json 2>&1 \
             | tee served-conformance.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,56 @@ jobs:
           path: sbom/*.json
           if-no-files-found: error
 
-  # ---- 1c. Tauri desktop GUI bundles (UNSIGNED) ----
+  # ---- 1c. per-release served-surface SPARQL 1.1 Protocol conformance report ----
+  # [OPUS-4.8] sq-ro6if (PSS #1415/#1478): publish the MACHINE-READABLE served-surface conformance
+  # report for THIS release commit and attach it to the GitHub Release, so an HTTP consumer (e.g.
+  # prod-solid-server, which consumes only the served /sparql surface) can trust the served WIRE
+  # contract per released tag without re-verifying it against every SHA. Built by re-running the
+  # EXISTING served-surface lanes (sq-jaj38 http-protocol + sq-1uuxz Service-Description/GSP)
+  # in-process via the `served-conformance-report` binary — NO new conformance tests, publication
+  # only. FAIL-CLOSED: the binary exits non-zero (failing this job, blocking the whole release) if a
+  # lane produced zero assertions (the vacuous-artifact class), has any genuine failure, or
+  # regressed below its ratchet floor. SLSA build-provenance attested + uploaded exactly like the
+  # SBOM/VEX above, so the `release` job folds it into SHA256SUMS + the GitHub Release for free.
+  served-conformance:
+    name: served-surface conformance report
+    # [OPUS-4.8] sq-ro6if: needs the resolved version so the per-release report filename carries the
+    # release tag (mirrors the SBOM job's VERSION thread; on dispatch GITHUB_REF_NAME is the branch).
+    needs: setup
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      attestations: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Install Rust (stable)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      - name: Emit served-surface conformance report (JSON, fail-closed)
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+          SPARQ_CONFORMANCE_COMMIT: ${{ github.sha }}
+          SPARQ_CONFORMANCE_VERSION: ${{ needs.setup.outputs.version }}
+          SPARQ_CONFORMANCE_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          mkdir -p conformance
+          cargo run --release -p sparq-conformance \
+            --features http-protocol,federation-descriptors \
+            --bin served-conformance-report -- \
+            --out "conformance/served-conformance-${VERSION}.json"
+      - name: Attest build provenance (served-surface conformance report)
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4.1.1
+        with:
+          subject-path: conformance/served-conformance-*.json
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: served-conformance
+          path: conformance/served-conformance-*.json
+          if-no-files-found: error
+
+  # ---- 1d. Tauri desktop GUI bundles (UNSIGNED) ----
   # [OPUS-4.8] sq-8n1c: build the cross-platform Tauri 2 desktop INSTALLERS — .dmg (+ .app)
   # on macOS, .msi + NSIS .exe on Windows, .deb + .AppImage on Linux — as ADDITIONAL release
   # artifacts on the same desktop platforms the `package` matrix already covers, per the GUI
@@ -459,7 +508,7 @@ jobs:
     # [OPUS-4.8] sq-gl3cf: `setup` added so the Release attaches to the resolved tag (tag_name
     # below) on BOTH triggers — on dispatch, action-gh-release's default tag_name is `github.ref`,
     # which is the BRANCH, so we must override it explicitly.
-    needs: [setup, package, sbom, gui-bundle]
+    needs: [setup, package, sbom, gui-bundle, served-conformance]
     runs-on: ubuntu-latest
     permissions:
       contents: write # create the release + upload assets — the only write this pipeline needs
@@ -474,6 +523,12 @@ jobs:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: sbom-vex
+          path: assets
+      # [OPUS-4.8] sq-ro6if (PSS #1415/#1478): pull the served-surface conformance report in
+      # alongside the archives + SBOM so it is covered by SHA256SUMS and attached to the release.
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: served-conformance
           path: assets
       - name: Generate SHA256SUMS
         run: cd assets && sha256sum -- * > SHA256SUMS
@@ -496,7 +551,9 @@ jobs:
           body: |
             See [CHANGELOG.md](https://github.com/${{ github.repository }}/blob/${{ needs.setup.outputs.version }}/CHANGELOG.md) for the curated changelog.
 
-            `SHA256SUMS` covers every attached archive plus the CycloneDX SBOM + VEX: `shasum -a 256 -c SHA256SUMS`.
+            `SHA256SUMS` covers every attached archive plus the CycloneDX SBOM + VEX and the served-surface conformance report: `shasum -a 256 -c SHA256SUMS`.
+
+            **Served-surface SPARQL 1.1 Protocol conformance.** This release attaches a machine-readable conformance report (`served-conformance-${{ needs.setup.outputs.version }}.json`) recording what the *served HTTP surface* (`sparq-server`'s `/sparql`) passes at this exact commit — the SPARQL 1.1 Protocol lane (GET/POST query+update, the QUERY method, dataset overrides, SRJ/SRX/CSV/TSV negotiation, status codes) and the Service-Description + Graph-Store-Protocol lane, with per-assertion pass/divergence/fail outcomes, per-suite counts + ratchet floors, and provenance (commit, date, CI run). Counts are conformance facts; documented divergences are reported separately and are never summed into the pass count. It is generated fail-closed (a vacuous, failing, or below-floor run blocks the release). See the [served-surface conformance page](https://github.com/${{ github.repository }}/blob/${{ needs.setup.outputs.version }}/site/src/app/assurance/served-conformance/page.tsx) for the rendered view.
 
             **Desktop GUI bundles (UNSIGNED).** This release also includes cross-platform [sparq GUI](https://github.com/${{ github.repository }}/tree/${{ needs.setup.outputs.version }}/gui) desktop installers (`sparq-gui_${{ needs.setup.outputs.version }}_*`): macOS `.dmg`, Windows `.msi` + NSIS `.exe`, and Linux `.deb` + `.AppImage`. **These bundles are NOT code-signed or notarized.** On macOS, Gatekeeper will quarantine them; on Windows, SmartScreen will warn — see [/download](https://github.com/${{ github.repository }}/tree/${{ needs.setup.outputs.version }}/gui) for the install bypass instructions (Gatekeeper/SmartScreen). OS-level code-signing (Apple Developer ID notarization + Windows Authenticode) requires maintainer-held credentials and is tracked separately — until then, treat the GUI bundles as developer/test installs. The SLSA attestation below proves *who built* each bundle (build provenance); it is not a substitute for OS code-signing. (No `win-arm64` GUI installer yet — the Tauri bundler cannot cross-bundle it from the x64 Windows runner; no mobile app bundles yet.)
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p conformance
-          cargo run --release -p sparq-conformance \
+          # Debug (no --release): the report is a quick in-process run against the loopback server,
+          # so optimisation buys nothing and a debug compile is faster to produce the artifact.
+          cargo run -p sparq-conformance \
             --features http-protocol,federation-descriptors \
             --bin served-conformance-report -- \
             --out "conformance/served-conformance-${VERSION}.json"

--- a/crates/sparq-conformance/Cargo.toml
+++ b/crates/sparq-conformance/Cargo.toml
@@ -29,6 +29,17 @@ path = "src/bin/inference.rs"
 name = "sparq-conformance-scoreboard"
 path = "src/bin/scoreboard.rs"
 
+# [OPUS-4.8] sq-ro6if (PSS #1415/#1478) — the MACHINE-READABLE served-surface SPARQL
+# 1.1 Protocol conformance report emitter. Re-runs the EXISTING served-surface lanes
+# (sq-jaj38 http-protocol + sq-1uuxz Service-Description/GSP) in-process and serialises
+# their per-assertion outcomes + counts + provenance to JSON, for the per-release
+# conformance artifact + the site dashboard. Requires BOTH `http-protocol` and
+# `federation-descriptors`; with either off it compiles to a fail-closed stub `main`
+# (so the default + `--workspace` builds link no async stack — the lean opt-in posture).
+[[bin]]
+name = "served-conformance-report"
+path = "src/bin/served-conformance-report.rs"
+
 [features]
 # [OPUS-4.8] sq-oy1f.2 — the W3C JSON-LD 1.1 conformance lane (toRdf + fromRdf
 # ratchets, the crate-local `tests/jsonld_suite.rs` runner). OPT-IN and OFF by

--- a/crates/sparq-conformance/src/bin/served-conformance-report.rs
+++ b/crates/sparq-conformance/src/bin/served-conformance-report.rs
@@ -1,0 +1,308 @@
+//! [OPUS-4.8] sq-ro6if (PSS #1415 / #1478) — `served-conformance-report`: emits the
+//! MACHINE-READABLE served-surface SPARQL 1.1 Protocol conformance report as JSON.
+//!
+//! PUBLICATION ONLY. This binary runs NO new conformance tests: it re-runs the two
+//! EXISTING served-surface lanes in-process against the `sparq-server` loopback
+//! endpoint — the sq-jaj38 HTTP-protocol lane (GET/POST query+update, the QUERY
+//! method, dataset overrides, SRJ/SRX/CSV/TSV negotiation, status codes) and the
+//! sq-1uuxz Service-Description + Graph-Store-Protocol lane — and serialises their
+//! per-assertion outcomes + rolled-up counts to a single JSON document. Consumers
+//! (e.g. PSS, which consumes the served HTTP surface only) get a published, versioned
+//! per-release record of what the WIRE contract passes, without re-running the suite.
+//!
+//! It reuses the SAME public functions the ratchet tests drive
+//! ([`sparq_conformance::http_protocol::run_protocol_suite`],
+//! [`sparq_conformance::sd_gsp::run_sd_gsp_suite`]) and pulls each suite's ratchet
+//! FLOOR from the central registry ([`sparq_conformance::scoreboard::SUITES`]) so the
+//! report can never drift from the enforcer.
+//!
+//! ## Fail-closed discipline (the vacuous-artifact guard)
+//!
+//! The report is emitted from the lanes; it must FAIL LOUDLY rather than silently
+//! publish an incomplete/misleading artifact. The binary writes the JSON (so the
+//! artifact always records the honest state) and then exits NON-ZERO if ANY of:
+//!
+//! - a lane produced ZERO assertions (the loopback server did not run — a suite would be silently omitted);
+//! - a lane has any genuine `Fail` outcome;
+//! - a lane's pass count regressed below its registry ratchet floor;
+//! - a lane is missing from `scoreboard::SUITES` (registry drift — no floor to check).
+//!
+//! A non-zero exit fails the CI/release step, so a bad report can never ship. Documented
+//! DIVERGENCES are reported per-assertion but are NEVER summed into `pass` and never fail the
+//! build — an honest gap can never inflate the conformance number.
+//!
+//! Provenance (commit / version / date / run source) is threaded from env by the
+//! caller (CI/release), with local fall-backs so a bare `cargo run` still produces a
+//! self-describing artifact.
+//!
+//!   cargo run --release -p sparq-conformance \
+//!     --features http-protocol,federation-descriptors \
+//!     --bin served-conformance-report -- --out served-conformance.json
+#![forbid(unsafe_code)] // [OPUS-4.8] sq-emay: crate has zero `unsafe`
+
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    #[cfg(all(feature = "http-protocol", feature = "federation-descriptors"))]
+    {
+        // --out FILE (default served-conformance.json).
+        let mut out = std::path::PathBuf::from("served-conformance.json");
+        let mut args = std::env::args().skip(1);
+        while let Some(a) = args.next() {
+            match a.as_str() {
+                "--out" => out = std::path::PathBuf::from(args.next().unwrap_or_else(|| {
+                    eprintln!("--out needs a path");
+                    std::process::exit(2);
+                })),
+                other => {
+                    eprintln!("unknown argument: {other}");
+                    eprintln!(
+                        "usage: served-conformance-report [--out FILE]  \
+                         (requires --features http-protocol,federation-descriptors)"
+                    );
+                    return ExitCode::from(2);
+                }
+            }
+        }
+        match emit::run(&out) {
+            Ok(()) => ExitCode::SUCCESS,
+            Err(fatal) => {
+                eprintln!("\nserved-conformance-report: FAIL-CLOSED — the report is NOT publishable:");
+                for line in fatal {
+                    eprintln!("  - {line}");
+                }
+                ExitCode::from(1)
+            }
+        }
+    }
+    #[cfg(not(all(feature = "http-protocol", feature = "federation-descriptors")))]
+    {
+        eprintln!(
+            "served-conformance-report requires BOTH the `http-protocol` and \
+             `federation-descriptors` features to run the served-surface lanes.\n\
+             Run: cargo run -p sparq-conformance \
+             --features http-protocol,federation-descriptors \
+             --bin served-conformance-report -- --out served-conformance.json"
+        );
+        ExitCode::from(2)
+    }
+}
+
+#[cfg(all(feature = "http-protocol", feature = "federation-descriptors"))]
+mod emit {
+    use sparq_conformance::http_protocol::{self, Outcome, SuiteReport};
+    use sparq_conformance::scoreboard::{Runner, Suite, SUITES};
+    use sparq_conformance::sd_gsp;
+    use serde_json::{json, Value};
+    use std::path::Path;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// One served-surface lane to publish: the human `id`/`title` for the report and the
+    /// `scoreboard::SUITES` runner `target` used to locate its registry row (label / family /
+    /// ci_job / ratchet floor). Keeping the floor in the registry (never duplicated here) means
+    /// the report can only ever agree with the enforcer.
+    struct Lane {
+        id: &'static str,
+        /// The scoreboard runner `--test` target that identifies the registry row.
+        target: &'static str,
+    }
+
+    const LANES: &[Lane] = &[
+        Lane { id: "http-protocol", target: "http_protocol_suite" },
+        Lane { id: "sd-gsp", target: "sd_gsp_suite" },
+    ];
+
+    /// The `scoreboard::SUITES` row whose feature-gated runner targets `target` (or None on
+    /// registry drift — a fail-closed condition, never silently ignored).
+    fn suite_for(target: &str) -> Option<&'static Suite> {
+        SUITES.iter().find(|s| {
+            matches!(s.runner, Runner::FeatureGatedCrateTest { target: t, .. } if t == target)
+        })
+    }
+
+    /// The cargo feature a feature-gated runner requires (for the report's provenance column).
+    fn suite_feature(s: &Suite) -> &'static str {
+        match s.runner {
+            Runner::FeatureGatedCrateTest { feature, .. } => feature,
+            _ => "",
+        }
+    }
+
+    fn outcome_json(label: &str, o: &Outcome) -> Value {
+        match o {
+            Outcome::Pass => json!({ "label": label, "outcome": "pass" }),
+            Outcome::Divergence(why) => {
+                json!({ "label": label, "outcome": "divergence", "detail": why })
+            }
+            Outcome::Fail(why) => json!({ "label": label, "outcome": "fail", "detail": why }),
+        }
+    }
+
+    /// Build one lane's JSON object and append any FATAL conditions to `fatal`.
+    fn lane_json(lane: &Lane, report: &SuiteReport, fatal: &mut Vec<String>) -> Value {
+        let pass = report.pass();
+        let div = report.divergences();
+        let fails = report.failures();
+        let total = report.outcomes.len();
+
+        // Vacuous-artifact guard: a lane that emitted NO assertions means the loopback server
+        // never ran — the suite would be silently omitted from the published counts.
+        if total == 0 {
+            fatal.push(format!(
+                "lane `{}` produced ZERO assertions (the loopback server did not run) — refusing \
+                 to publish a report that silently omits a served suite",
+                lane.id
+            ));
+        }
+        // A genuine failure is never laundered into the artifact as a pass.
+        for (label, why) in &fails {
+            fatal.push(format!("lane `{}` FAILED assertion: {} — {}", lane.id, label, why));
+        }
+
+        // Floor + registry metadata from the central scoreboard (single source of truth).
+        let (label, family, ci_job, floor, floor_basis, note, feature) = match suite_for(lane.target)
+        {
+            Some(s) => (
+                s.label,
+                s.family,
+                s.ci_job,
+                Some(s.ratchet_floor),
+                s.floor_basis,
+                s.note,
+                suite_feature(s),
+            ),
+            None => {
+                fatal.push(format!(
+                    "registry drift: no scoreboard::SUITES row with a feature-gated runner \
+                     targeting `{}` — cannot bind lane `{}` to a ratchet floor",
+                    lane.target, lane.id
+                ));
+                ("", "", "", None, "", "", "")
+            }
+        };
+        if let Some(f) = floor {
+            if pass < f {
+                fatal.push(format!(
+                    "lane `{}` pass count {} regressed below its ratchet floor {}",
+                    lane.id, pass, f
+                ));
+            }
+        }
+
+        let tests: Vec<Value> =
+            report.outcomes.iter().map(|(l, o)| outcome_json(l, o)).collect();
+
+        json!({
+            "id": lane.id,
+            "label": label,
+            "family": family,
+            "feature": feature,
+            "ci_job": ci_job,
+            "floor": floor,
+            "floor_basis": floor_basis,
+            "note": note,
+            "counts": { "pass": pass, "fail": fails.len(), "divergence": div, "total": total },
+            "tests": tests,
+        })
+    }
+
+    /// `s / 86400` days since the epoch → UTC calendar date (Howard Hinnant's `civil_from_days`),
+    /// plus the wall-clock h:m:s from the day remainder — a dependency-free ISO-8601 UTC stamp for
+    /// the local fall-back (CI/release pass an exact `SPARQ_CONFORMANCE_DATE` instead).
+    fn iso_utc(secs: i64) -> String {
+        let days = secs.div_euclid(86_400);
+        let rem = secs.rem_euclid(86_400);
+        let (h, mi, s) = (rem / 3600, (rem % 3600) / 60, rem % 60);
+        let z = days + 719_468;
+        let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+        let doe = z - era * 146_097; // [0, 146096]
+        let yoe = (doe - doe / 1460 + doe / 36_524 - doe / 146_096) / 365; // [0, 399]
+        let y = yoe + era * 400;
+        let doy = doe - (365 * yoe + yoe / 4 - yoe / 100); // [0, 365]
+        let mp = (5 * doy + 2) / 153; // [0, 11]
+        let d = doy - (153 * mp + 2) / 5 + 1; // [1, 31]
+        let m = if mp < 10 { mp + 3 } else { mp - 9 }; // [1, 12]
+        let y = y + i64::from(m <= 2);
+        format!("{y:04}-{m:02}-{d:02}T{h:02}:{mi:02}:{s:02}Z")
+    }
+
+    /// Env value or a fall-back, trimming to None on empty (so a set-but-empty CI var falls back).
+    fn env_or(key: &str, fallback: &str) -> String {
+        match std::env::var(key) {
+            Ok(v) if !v.trim().is_empty() => v,
+            _ => fallback.to_string(),
+        }
+    }
+
+    pub fn run(out: &Path) -> Result<(), Vec<String>> {
+        let now_unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+
+        // Provenance — threaded from the caller (CI/release) with honest local fall-backs.
+        let commit = env_or("SPARQ_CONFORMANCE_COMMIT", "unknown (local build — set SPARQ_CONFORMANCE_COMMIT)");
+        let version = env_or("SPARQ_CONFORMANCE_VERSION", "unreleased (local build)");
+        let run_source = env_or("SPARQ_CONFORMANCE_RUN_URL", "local build (no CI run source)");
+        let generated_at = env_or("SPARQ_CONFORMANCE_DATE", &iso_utc(now_unix));
+
+        // Re-run the two served-surface lanes in-process (hermetic; each stands up its own
+        // sparq-server loopback endpoint on an ephemeral 127.0.0.1:0 port).
+        let http = http_protocol::run_protocol_suite();
+        let sdgsp = sd_gsp::run_sd_gsp_suite();
+        let reports = [(&LANES[0], http), (&LANES[1], sdgsp)];
+
+        let mut fatal: Vec<String> = Vec::new();
+        let mut suites: Vec<Value> = Vec::new();
+        let (mut tp, mut tf, mut td, mut tt) = (0usize, 0usize, 0usize, 0usize);
+        for (lane, report) in &reports {
+            tp += report.pass();
+            tf += report.failures().len();
+            td += report.divergences();
+            tt += report.outcomes.len();
+            suites.push(lane_json(lane, report, &mut fatal));
+        }
+
+        let doc = json!({
+            "schema": "sparq.served-conformance/v1",
+            "title": "Served-surface SPARQL 1.1 Protocol conformance",
+            "provenance": {
+                "commit": commit,
+                "version": version,
+                "generated_at": generated_at,
+                "generated_at_unix": now_unix,
+                "run_source": run_source,
+                "runner": "sparq-conformance served-conformance-report",
+                "note": "Re-runs the sq-jaj38 (http-protocol) and sq-1uuxz (federation-descriptors) \
+                         served-surface lanes in-process against the sparq-server loopback endpoint. \
+                         Pass/divergence/fail counts are conformance facts; `floor` is each suite's \
+                         ratchet floor (may only rise) from crates/sparq-conformance/src/scoreboard.rs. \
+                         Documented divergences are reported per-assertion and are NEVER summed into \
+                         `pass`, so a documented gap can never inflate the conformance number."
+            },
+            "totals": { "pass": tp, "fail": tf, "divergence": td, "total": tt },
+            "suites": suites,
+        });
+
+        // Write the artifact ALWAYS (it records the honest state even on a fatal condition), then
+        // surface any fatal condition so the caller (CI/release) fails-closed.
+        let pretty = serde_json::to_string_pretty(&doc)
+            .map_err(|e| vec![format!("could not serialise report: {e}")])?;
+        std::fs::write(out, format!("{pretty}\n"))
+            .map_err(|e| vec![format!("could not write {}: {e}", out.display())])?;
+
+        // Human summary for the CI step log / local run.
+        eprintln!(
+            "served-surface SPARQL 1.1 Protocol conformance — {} pass / {} divergence / {} fail \
+             across {} assertions (2 suites)",
+            tp, td, tf, tt
+        );
+        eprintln!("report written to {}", out.display());
+
+        if fatal.is_empty() {
+            Ok(())
+        } else {
+            Err(fatal)
+        }
+    }
+}

--- a/crates/sparq-conformance/src/bin/served-conformance-report.rs
+++ b/crates/sparq-conformance/src/bin/served-conformance-report.rs
@@ -11,8 +11,8 @@
 //! per-release record of what the WIRE contract passes, without re-running the suite.
 //!
 //! It reuses the SAME public functions the ratchet tests drive
-//! ([`sparq_conformance::http_protocol::run_protocol_suite`],
-//! [`sparq_conformance::sd_gsp::run_sd_gsp_suite`]) and pulls each suite's ratchet
+//! (`sparq_conformance::http_protocol::run_protocol_suite`,
+//! `sparq_conformance::sd_gsp::run_sd_gsp_suite`) and pulls each suite's ratchet
 //! FLOOR from the central registry ([`sparq_conformance::scoreboard::SUITES`]) so the
 //! report can never drift from the enforcer.
 //!

--- a/site/src/app/assurance/page.tsx
+++ b/site/src/app/assurance/page.tsx
@@ -473,6 +473,9 @@ export default function AssurancePage() {
           </a>
         </Button>
         <Button asChild variant="outline" size="sm">
+          <Link href="/assurance/served-conformance">Served-surface conformance</Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
           <Link href="/benchmarks">Benchmarks dashboard</Link>
         </Button>
       </section>

--- a/site/src/app/assurance/served-conformance/page.tsx
+++ b/site/src/app/assurance/served-conformance/page.tsx
@@ -1,0 +1,333 @@
+// [OPUS-4.8] sq-ro6if (PSS #1415/#1478) — /assurance/served-conformance: the served-surface
+// SPARQL 1.1 Protocol conformance dashboard. A data-driven page (mirroring the /benchmarks +
+// /assurance precedents) that renders the committed snapshot from
+// src/data/served-conformance.generated.json — the machine-readable per-assertion outcomes +
+// counts the `served-conformance-report` binary emits from the two EXISTING served-surface CI
+// lanes (sq-jaj38 http-protocol + sq-1uuxz Service-Description/Graph-Store-Protocol).
+//
+// HONESTY. These are CONFORMANCE COUNTS, not performance numbers (no timings appear here, so the
+// no-perf-numbers gate is satisfied). Floors are ratchet floors; documented divergences are shown
+// per-assertion and never summed into the pass count. The page states plainly that it is a
+// SNAPSHOT and that the authoritative versioned reports attach to each GitHub Release.
+
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ArrowUpRight, CheckCircle2, ShieldCheck, TriangleAlert, XCircle } from "lucide-react";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  servedConformance,
+  shortCommit,
+  type ConformanceOutcome,
+  type ConformanceSuite,
+} from "@/data/served-conformance";
+
+export const metadata: Metadata = {
+  title: "Served-surface SPARQL 1.1 Protocol conformance",
+  description:
+    "What sparq-server's served HTTP /sparql surface passes of the SPARQL 1.1 Protocol and the Service-Description + Graph-Store-Protocol — machine-readable per-assertion outcomes, published per release.",
+};
+
+const REPO = "https://github.com/jeswr/sparq";
+const RELEASES = `${REPO}/releases`;
+const REPORT_SRC = `${REPO}/blob/main/site/src/data/served-conformance.generated.json`;
+
+const { provenance, totals, suites } = servedConformance;
+
+/** An outcome pill: pass (green), divergence (amber), fail (red). */
+function OutcomePill({ outcome }: { outcome: ConformanceOutcome }) {
+  const map: Record<ConformanceOutcome, { cls: string; label: string }> = {
+    pass: {
+      cls: "border-[var(--success)]/40 bg-[var(--success)]/10 text-[var(--success)]",
+      label: "pass",
+    },
+    divergence: {
+      cls: "border-amber-500/40 bg-amber-500/10 text-amber-600 dark:text-amber-400",
+      label: "divergence",
+    },
+    fail: {
+      cls: "border-red-500/40 bg-red-500/10 text-red-600 dark:text-red-400",
+      label: "fail",
+    },
+  };
+  const { cls, label } = map[outcome];
+  return (
+    <span
+      className={`inline-flex items-center whitespace-nowrap rounded-full border px-2 py-0.5 text-xs font-medium ${cls}`}
+    >
+      {label}
+    </span>
+  );
+}
+
+/** A count chip in a suite header. */
+function Count({
+  icon,
+  n,
+  label,
+  tone,
+}: {
+  icon: React.ReactNode;
+  n: number;
+  label: string;
+  tone: string;
+}) {
+  return (
+    <span className={`inline-flex items-center gap-1.5 text-sm ${tone}`}>
+      {icon}
+      <strong className="font-semibold">{n}</strong>
+      <span className="text-muted-foreground">{label}</span>
+    </span>
+  );
+}
+
+function SuiteCard({ suite }: { suite: ConformanceSuite }) {
+  return (
+    <section className="space-y-4 rounded-xl border p-4">
+      <div className="space-y-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <h3 className="text-base font-semibold">{suite.label}</h3>
+          <Badge variant="outline">{suite.family}</Badge>
+          <Badge variant="outline">
+            <code className="font-mono">{suite.feature}</code>
+          </Badge>
+        </div>
+        <div className="flex flex-wrap items-center gap-x-5 gap-y-1">
+          <Count
+            icon={<CheckCircle2 className="size-4 text-[var(--success)]" aria-hidden />}
+            n={suite.counts.pass}
+            label="pass"
+            tone="text-foreground"
+          />
+          <Count
+            icon={<TriangleAlert className="size-4 text-amber-500" aria-hidden />}
+            n={suite.counts.divergence}
+            label="documented divergence"
+            tone="text-foreground"
+          />
+          <Count
+            icon={<XCircle className="size-4 text-red-500" aria-hidden />}
+            n={suite.counts.fail}
+            label="fail"
+            tone="text-foreground"
+          />
+          <span className="text-sm text-muted-foreground">
+            {suite.counts.total} assertions · ratchet floor{" "}
+            <strong className="text-foreground">{suite.floor ?? "?"}</strong> (
+            {suite.floor_basis})
+          </span>
+        </div>
+      </div>
+      <p className="text-sm text-muted-foreground">{suite.note}</p>
+      <div className="overflow-x-auto rounded-lg border">
+        <table className="w-full border-collapse text-left text-sm">
+          <thead>
+            <tr className="border-b bg-muted/40 text-xs uppercase tracking-wide text-muted-foreground">
+              <th scope="col" className="px-3 py-2 font-medium">
+                Assertion
+              </th>
+              <th scope="col" className="px-3 py-2 font-medium">
+                Outcome
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {suite.tests.map((t, i) => (
+              <tr key={i} className="border-b align-top last:border-0">
+                <td className="px-3 py-2 text-muted-foreground">
+                  {t.label}
+                  {t.detail ? (
+                    <span className="mt-0.5 block text-xs italic text-muted-foreground/80">
+                      {t.detail}
+                    </span>
+                  ) : null}
+                </td>
+                <td className="px-3 py-2">
+                  <OutcomePill outcome={t.outcome} />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}
+
+export default function ServedConformancePage() {
+  return (
+    <div className="space-y-10">
+      {/* ── Header ──────────────────────────────────────────────── */}
+      <header className="space-y-3">
+        <div className="flex items-center gap-3">
+          <span className="flex size-11 items-center justify-center rounded-xl bg-primary/10 text-primary">
+            <ShieldCheck className="size-5" aria-hidden />
+          </span>
+          <div>
+            <h1 className="text-2xl font-semibold">
+              Served-surface SPARQL 1.1 Protocol conformance
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              What the served HTTP <code className="font-mono">/sparql</code> surface passes —
+              published per release.
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <Badge variant="outline">SPARQL 1.1 Protocol</Badge>
+          <Badge variant="outline">Service Description</Badge>
+          <Badge variant="outline">Graph Store Protocol</Badge>
+        </div>
+      </header>
+
+      {/* ── Lead ────────────────────────────────────────────────── */}
+      <section className="measure space-y-3 text-sm text-muted-foreground">
+        <p>
+          A consumer that talks to sparq over its{" "}
+          <strong className="text-foreground">served HTTP surface</strong> (the SPARQL 1.1
+          Protocol <code className="font-mono">/sparql</code> endpoint) depends on the WIRE
+          contract, which can diverge from the engine&rsquo;s internal semantics. This page
+          publishes what that served surface passes, per release: the machine-readable outcomes
+          the two served-surface CI lanes emit — the SPARQL 1.1 Protocol lane and the
+          Service-Description + Graph-Store-Protocol lane — so an HTTP consumer can trust the
+          contract without re-verifying it against every commit.
+        </p>
+        <p>
+          Every number here is a <strong className="text-foreground">conformance count</strong>{" "}
+          (pass / documented-divergence / fail assertion tallies), never a performance number.
+          Documented divergences are shown per-assertion and are{" "}
+          <strong className="text-foreground">never summed into the pass count</strong>, so a
+          documented gap can never inflate the conformance number.
+        </p>
+      </section>
+
+      {/* ── Summary + provenance ────────────────────────────────── */}
+      <section className="space-y-3 rounded-xl border bg-card p-4">
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+          <Count
+            icon={<CheckCircle2 className="size-4 text-[var(--success)]" aria-hidden />}
+            n={totals.pass}
+            label="pass"
+            tone="text-foreground"
+          />
+          <Count
+            icon={<TriangleAlert className="size-4 text-amber-500" aria-hidden />}
+            n={totals.divergence}
+            label="documented divergence"
+            tone="text-foreground"
+          />
+          <Count
+            icon={<XCircle className="size-4 text-red-500" aria-hidden />}
+            n={totals.fail}
+            label="fail"
+            tone="text-foreground"
+          />
+          <span className="text-sm text-muted-foreground">
+            {totals.total} assertions across {suites.length} served suites
+          </span>
+        </div>
+        <dl className="grid grid-cols-1 gap-x-6 gap-y-1 text-xs text-muted-foreground sm:grid-cols-2">
+          <div>
+            <dt className="inline font-medium text-foreground">Snapshot of: </dt>
+            <dd className="inline">
+              <a
+                href={`${REPO}/commit/${provenance.commit}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-primary hover:underline"
+              >
+                {shortCommit(provenance.commit)}
+              </a>{" "}
+              ({provenance.version})
+            </dd>
+          </div>
+          <div>
+            <dt className="inline font-medium text-foreground">Generated: </dt>
+            <dd className="inline">{provenance.generated_at}</dd>
+          </div>
+        </dl>
+        <p className="rounded-lg border border-amber-500/30 bg-amber-500/5 px-3 py-2.5 text-xs text-muted-foreground">
+          <strong className="text-foreground">This is a snapshot.</strong> The authoritative,
+          versioned per-release reports (
+          <code className="font-mono">served-conformance-&lt;version&gt;.json</code>) attach to
+          each <Artifact href={RELEASES} label="GitHub Release" /> and are SLSA build-provenance
+          attested; the same JSON is emitted as a build artifact by the{" "}
+          <code className="font-mono">service-federation-conformance</code> CI job. This page
+          renders the committed{" "}
+          <Artifact href={REPORT_SRC} label="snapshot JSON" />, which may lag a release.
+        </p>
+      </section>
+
+      {/* ── Per-suite detail ────────────────────────────────────── */}
+      <section className="space-y-5">
+        {suites.map((s) => (
+          <SuiteCard key={s.id} suite={s} />
+        ))}
+      </section>
+
+      {/* ── What these numbers mean ─────────────────────────────── */}
+      <section className="space-y-3">
+        <h2 className="text-lg font-semibold">What these numbers mean</h2>
+        <ul className="space-y-3 text-sm text-muted-foreground">
+          <li className="rounded-lg border bg-card px-3 py-2.5">
+            <strong className="text-foreground">Floors are floors.</strong> Each suite&rsquo;s{" "}
+            ratchet floor may only rise; a pass count equal to the floor is the honest current
+            state, not an aspirational target. The floor comes from the same central registry
+            that gates CI.
+          </li>
+          <li className="rounded-lg border bg-card px-3 py-2.5">
+            <strong className="text-foreground">Divergences are part of the claim.</strong> A
+            documented divergence is a W3C-permitted behaviour distinct from a naive expectation
+            (for example, an absent <code className="font-mono">Accept</code> defaulting to
+            SPARQL-results JSON). It is reported, never hidden, and never counted as a pass.
+          </li>
+          <li className="rounded-lg border bg-card px-3 py-2.5">
+            <strong className="text-foreground">Served ≠ engine.</strong> This measures the HTTP
+            wire contract specifically — the surface an out-of-process consumer actually depends
+            on — which is why it is published separately from the engine conformance ratchets.
+          </li>
+          <li className="rounded-lg border bg-card px-3 py-2.5">
+            <strong className="text-foreground">Fail-closed publication.</strong> The report
+            generator refuses to emit a report that silently omits a suite: a vacuous, failing,
+            or below-floor run blocks the release rather than publishing a misleading artifact.
+          </li>
+        </ul>
+      </section>
+
+      {/* ── CTAs ────────────────────────────────────────────────── */}
+      <section className="flex flex-wrap gap-3 border-t pt-6">
+        <Button asChild variant="outline" size="sm">
+          <Link href="/assurance">Back to Assurance</Link>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <a href={RELEASES} target="_blank" rel="noopener noreferrer">
+            Per-release reports (GitHub Releases)
+            <ArrowUpRight className="size-3.5 opacity-60" aria-hidden />
+          </a>
+        </Button>
+        <Button asChild variant="outline" size="sm">
+          <a href={REPORT_SRC} target="_blank" rel="noopener noreferrer">
+            Snapshot JSON
+            <ArrowUpRight className="size-3.5 opacity-60" aria-hidden />
+          </a>
+        </Button>
+      </section>
+    </div>
+  );
+}
+
+/** An external link to a repo artifact, with the small up-right glyph. */
+function Artifact({ href, label }: { href: string; label: string }) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1 text-primary hover:underline"
+    >
+      {label}
+      <ArrowUpRight className="size-3 opacity-70" aria-hidden />
+    </a>
+  );
+}

--- a/site/src/data/served-conformance.generated.json
+++ b/site/src/data/served-conformance.generated.json
@@ -1,0 +1,312 @@
+{
+  "provenance": {
+    "commit": "84aa1e4a8a508f941a961b78b8645696a83fc5c5",
+    "generated_at": "2026-07-05T14:10:00Z",
+    "generated_at_unix": 1783260600,
+    "note": "Re-runs the sq-jaj38 (http-protocol) and sq-1uuxz (federation-descriptors) served-surface lanes in-process against the sparq-server loopback endpoint. Pass/divergence/fail counts are conformance facts; `floor` is each suite's ratchet floor (may only rise) from crates/sparq-conformance/src/scoreboard.rs. Documented divergences are reported per-assertion and are NEVER summed into `pass`, so a documented gap can never inflate the conformance number.",
+    "run_source": "https://github.com/jeswr/sparq/actions (per-build artifact); authoritative per-release reports attach to each GitHub Release",
+    "runner": "sparq-conformance served-conformance-report",
+    "version": "main (snapshot)"
+  },
+  "schema": "sparq.served-conformance/v1",
+  "suites": [
+    {
+      "ci_job": "service-federation-conformance",
+      "counts": {
+        "divergence": 2,
+        "fail": 0,
+        "pass": 21,
+        "total": 23
+      },
+      "family": "W3C SPARQL",
+      "feature": "http-protocol",
+      "floor": 21,
+      "floor_basis": "pass",
+      "id": "http-protocol",
+      "label": "W3C SPARQL 1.1 Protocol (HTTP)",
+      "note": "SPARQL 1.1 Protocol operations (GET/POST query+update, the QUERY method, dataset overrides, SRJ/SRX/CSV/TSV negotiation, 200/400/405/406/415) over RAW HTTP against the in-process loopback server; a present-but-unsatisfiable Accept now returns 406 (Oxigraph parity, sq-406acc); the absent/*/* Accept JSON default + ASK-in-CSV are documented divergences, NOT summed into the floor",
+      "tests": [
+        {
+          "label": "query via GET (?query=…) → 200 + SRJ, 1 default-graph row",
+          "outcome": "pass"
+        },
+        {
+          "label": "query via POST urlencoded (query= body) → 200 + SRJ",
+          "outcome": "pass"
+        },
+        {
+          "label": "query via POST direct (application/sparql-query) → 200 + SRJ",
+          "outcome": "pass"
+        },
+        {
+          "label": "query via the HTTP QUERY method (application/sparql-query) → 200 + SRJ",
+          "outcome": "pass"
+        },
+        {
+          "label": "QUERY method rejects application/sparql-update body → 415",
+          "outcome": "pass"
+        },
+        {
+          "label": "QUERY method rejects update= form field → 400",
+          "outcome": "pass"
+        },
+        {
+          "label": "SELECT Accept application/sparql-results+json → 200 + SRJ",
+          "outcome": "pass"
+        },
+        {
+          "label": "SELECT Accept application/sparql-results+xml → 200 + SRX",
+          "outcome": "pass"
+        },
+        {
+          "label": "SELECT Accept text/csv → 200 + text/csv",
+          "outcome": "pass"
+        },
+        {
+          "label": "SELECT Accept text/tab-separated-values → 200 + TSV",
+          "outcome": "pass"
+        },
+        {
+          "label": "ASK Accept application/sparql-results+json → 200 + SRJ boolean true",
+          "outcome": "pass"
+        },
+        {
+          "label": "ASK Accept application/sparql-results+xml → 200 + SRX",
+          "outcome": "pass"
+        },
+        {
+          "label": "default-graph-uri=g1 re-scopes the default graph → 1 row (g1's triple)",
+          "outcome": "pass"
+        },
+        {
+          "label": "named-graph-uri=g1 exposes exactly g1 as a named graph → 1 row",
+          "outcome": "pass"
+        },
+        {
+          "label": "update via POST (application/sparql-update INSERT DATA) → 2xx",
+          "outcome": "pass"
+        },
+        {
+          "label": "POST update genuinely mutated the store (ASK new triple → true)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GET /sparql with no query parameter → 400",
+          "outcome": "pass"
+        },
+        {
+          "label": "GET /sparql with a malformed query → 400",
+          "outcome": "pass"
+        },
+        {
+          "label": "POST /sparql with an unsupported Content-Type (text/plain) → 415",
+          "outcome": "pass"
+        },
+        {
+          "label": "DELETE /sparql → 405 with an Allow header",
+          "outcome": "pass"
+        },
+        {
+          "label": "unsatisfiable Accept (image/png) on SELECT → 406 Not Acceptable (Oxigraph parity, sq-406acc)",
+          "outcome": "pass"
+        },
+        {
+          "detail": "absent / */* Accept defaults to SPARQL-results JSON (W3C-permitted default representation); only a present-but-unsatisfiable Accept is 406",
+          "label": "absent / */* Accept on SELECT still defaults to SRJ, not 406 (sq-406acc)",
+          "outcome": "divergence"
+        },
+        {
+          "detail": "CSV/TSV have no SPARQL boolean serialisation, so an ASK with Accept: text/csv falls back to a JSON boolean (ask_content_type)",
+          "label": "ASK Accept text/csv falls back to a JSON boolean (CSV has no boolean form)",
+          "outcome": "divergence"
+        }
+      ]
+    },
+    {
+      "ci_job": "service-federation-conformance",
+      "counts": {
+        "divergence": 1,
+        "fail": 0,
+        "pass": 39,
+        "total": 40
+      },
+      "family": "W3C SPARQL",
+      "feature": "federation-descriptors",
+      "floor": 39,
+      "floor_basis": "pass",
+      "id": "sd-gsp",
+      "label": "SPARQL 1.1 Service Description + Graph Store Protocol",
+      "note": "the GET /sparql (no query) Service-Description advertises exactly the formats/languages/versions/features the server genuinely implements (no over-advertising), PLUS a GET/PUT/POST/DELETE Graph-Store-Protocol round-trip (named + default graph, indirect + direct identification) verifying store state after each op; absent-graph 200-empty read is a documented divergence, NOT summed in",
+      "tests": [
+        {
+          "label": "Service Description: GET /sparql (no query) → 200 + N-Triples",
+          "outcome": "pass"
+        },
+        {
+          "label": "SD types an sd:Service with an sd:endpoint",
+          "outcome": "pass"
+        },
+        {
+          "label": "SD advertises sd:SPARQL11Query + the version-agnostic sd:SPARQLQuery",
+          "outcome": "pass"
+        },
+        {
+          "label": "SD advertises sd:SPARQL11Update + sd:SPARQLUpdate (anonymous Update possible, no write-token)",
+          "outcome": "pass"
+        },
+        {
+          "label": "advertised sd:SPARQL11Update is genuine (anonymous POST update succeeds → 2xx)",
+          "outcome": "pass"
+        },
+        {
+          "label": "SD advertises sd:supportedVersion 1.0 / 1.1 / 1.2",
+          "outcome": "pass"
+        },
+        {
+          "label": "SD advertises full version-1.2, NOT the -basic profile",
+          "outcome": "pass"
+        },
+        {
+          "label": "SD advertises sd:resultFormat for SRJ / SRX / CSV / TSV (solution sets)",
+          "outcome": "pass"
+        },
+        {
+          "label": "SD advertises sd:resultFormat for Turtle / N-Triples / RDF-XML (graphs)",
+          "outcome": "pass"
+        },
+        {
+          "label": "SD advertises sd:inputFormat for Turtle / N-Triples / RDF-XML",
+          "outcome": "pass"
+        },
+        {
+          "label": "SD advertises sd:BasicFederatedQuery (the SERVICE clause is genuinely compiled in)",
+          "outcome": "pass"
+        },
+        {
+          "label": "SD does NOT over-advertise JSON-LD (sparq-server/jsonld is not on in this build)",
+          "outcome": "pass"
+        },
+        {
+          "label": "advertised sd:resultFormat SRJ is genuinely served (SELECT Accept → that media type)",
+          "outcome": "pass"
+        },
+        {
+          "label": "advertised sd:resultFormat SRX is genuinely served (SELECT Accept → that media type)",
+          "outcome": "pass"
+        },
+        {
+          "label": "advertised sd:resultFormat CSV is genuinely served (SELECT Accept → that media type)",
+          "outcome": "pass"
+        },
+        {
+          "label": "advertised sd:resultFormat TSV is genuinely served (SELECT Accept → that media type)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP PUT new named graph (indirect ?graph=) → 201 Created",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP GET the PUT graph returns it equal (PUT→GET round-trip)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP PUT existing named graph REPLACES → 204 No Content",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP PUT replaced the graph (old triple gone, new present)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP POST to existing named graph MERGES → 204",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP POST merged additively (both s2 and s3 present)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP DELETE named graph → 204 No Content",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP DELETE removed the graph (GET returns empty)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP DELETE an absent named graph → 404 Not Found",
+          "outcome": "pass"
+        },
+        {
+          "detail": "sparq serialises an absent graph as the empty graph (200, empty body) on a GSP read; it does not 404 (the GSP spec permits treating an empty graph as existing)",
+          "label": "GSP GET an absent named graph is 200 + empty graph, not 404 (GSP-permitted empty-graph read)",
+          "outcome": "divergence"
+        },
+        {
+          "label": "GSP PUT new graph (direct /graphs/<path>) → 201 Created",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP GET the direct-form graph returns it equal",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP DELETE via indirect ?graph= naming the direct IRI → 204 (forms address one graph)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP direct + indirect identification address the SAME graph (GET now empty)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP PUT default graph (?default) → 2xx",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP PUT default graph replaced it (new triple present, fixture triple gone)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP POST default graph (?default) MERGES → 204",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP POST default graph merged (both default triples present)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP DELETE default graph (?default) → 204 (empties it)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP DELETE default graph emptied it (GET returns empty)",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP PUT with a malformed RDF body → 400",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP PUT with an unsupported Content-Type (image/png) → 415",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP GET /sparql/graph with no graph selector → 400",
+          "outcome": "pass"
+        },
+        {
+          "label": "GSP unsupported verb (TRACE) → 405 with an Allow header",
+          "outcome": "pass"
+        }
+      ]
+    }
+  ],
+  "title": "Served-surface SPARQL 1.1 Protocol conformance",
+  "totals": {
+    "divergence": 3,
+    "fail": 0,
+    "pass": 60,
+    "total": 63
+  }
+}

--- a/site/src/data/served-conformance.ts
+++ b/site/src/data/served-conformance.ts
@@ -1,0 +1,78 @@
+// [OPUS-4.8] sq-ro6if (PSS #1415/#1478) — the in-site data layer for the SERVED-SURFACE
+// SPARQL 1.1 Protocol conformance dashboard. Consumes the committed snapshot
+// (src/data/served-conformance.generated.json), which is emitted by the dev-only
+// `served-conformance-report` binary re-running the two EXISTING served-surface CI lanes
+// (sq-jaj38 http-protocol + sq-1uuxz Service-Description/Graph-Store-Protocol) in-process
+// against the sparq-server loopback endpoint. Regenerate the snapshot with:
+//
+//   cargo run -p sparq-conformance --features http-protocol,federation-descriptors \
+//     --bin served-conformance-report -- --out site/src/data/served-conformance.generated.json
+//
+// HONESTY (load-bearing, per the bead + the empirical-honesty rule):
+//   * These are CONFORMANCE COUNTS (pass / divergence / fail assertion tallies), NOT
+//     performance numbers — no timings or throughput appear here.
+//   * `floor` is each suite's RATCHET FLOOR (may only rise); a pass count equal to the floor
+//     is the honest current state, not a target.
+//   * DOCUMENTED DIVERGENCES are reported per-assertion and are NEVER summed into `pass`, so
+//     a documented gap can never inflate the conformance number.
+//   * This page renders a SNAPSHOT of the current main checkout. The AUTHORITATIVE, versioned
+//     per-release reports are attached to each GitHub Release (and emitted as a build artifact
+//     by the service-federation-conformance CI job); this snapshot may lag a release.
+//   * The served surface is the sparq-server `/sparql` HTTP endpoint a consumer (e.g. PSS)
+//     talks to; engine-level conformance can diverge from it, which is why it is published
+//     separately.
+
+import data from "./served-conformance.generated.json";
+
+export type ConformanceOutcome = "pass" | "divergence" | "fail";
+
+export interface ConformanceTest {
+  label: string;
+  outcome: ConformanceOutcome;
+  detail?: string;
+}
+
+export interface ConformanceCounts {
+  pass: number;
+  fail: number;
+  divergence: number;
+  total: number;
+}
+
+export interface ConformanceSuite {
+  id: string;
+  label: string;
+  family: string;
+  feature: string;
+  ci_job: string;
+  floor: number | null;
+  floor_basis: string;
+  note: string;
+  counts: ConformanceCounts;
+  tests: ConformanceTest[];
+}
+
+export interface ConformanceProvenance {
+  commit: string;
+  version: string;
+  generated_at: string;
+  generated_at_unix: number;
+  run_source: string;
+  runner: string;
+  note: string;
+}
+
+export interface ServedConformanceReport {
+  schema: string;
+  title: string;
+  provenance: ConformanceProvenance;
+  totals: ConformanceCounts;
+  suites: ConformanceSuite[];
+}
+
+export const servedConformance = data as ServedConformanceReport;
+
+/** Short (7-char) commit for display; the full SHA stays in the report + provenance. */
+export function shortCommit(sha: string): string {
+  return /^[0-9a-f]{7,}$/i.test(sha) ? sha.slice(0, 7) : sha;
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** — automated PR on behalf of @jeswr.

Closes the **publication** side of bead **sq-ro6if** (PSS ask #1415 / #1478): publish what the *served* HTTP `/sparql` surface passes of the SPARQL 1.1 Protocol as a machine-readable, versioned per-release artifact + a site dashboard. **Publication only — no new conformance tests.** The two served-surface lanes already run in CI; this wires their results into a published report.

## What this wires (and where)

**(a) Machine-readable report — a fail-closed emitter binary + CI artifact**
- `crates/sparq-conformance/src/bin/served-conformance-report.rs` (new, in the dev-only `publish=false` harness crate — mirrors the existing `sparq-conformance-scoreboard` binary). It **re-runs the EXISTING served-surface lanes** — `sq-jaj38` HTTP-protocol (`run_protocol_suite`) + `sq-1uuxz` Service-Description/Graph-Store-Protocol (`run_sd_gsp_suite`) — in-process against the `sparq-server` loopback endpoint, and serialises per-assertion outcomes + per-suite counts + provenance (commit / date / CI run source) to JSON. Ratchet floors are pulled from the central `scoreboard::SUITES` registry (never duplicated).
- **Fail-closed (the vacuous-artifact guard):** it exits non-zero — failing the step and blocking publication — if a lane produced **zero** assertions (loopback didn't run), has any genuine **failure**, regressed **below its floor**, or is missing from the registry (drift). With either feature off it compiles to a fail-closed stub `main`, so the default/`--workspace` build links no async stack (lean-core posture).
- `.github/workflows/ci.yml` (`service-federation-conformance` job): clippy the both-features build, emit the report, upload it as the `served-conformance-report` build artifact.

**(b) Wired into the release artifact set** — `.github/workflows/release.yml`: a new `served-conformance` job (SLSA build-provenance attested, mirroring the `sbom` job) emits `served-conformance-<version>.json` and the `release` job folds it into `SHA256SUMS` + attaches it to the GitHub Release. All actions SHA-pinned (reusing the repo's existing pins).

**(c) Site dashboard** — `site/src/app/assurance/served-conformance/page.tsx` (a data-driven page under the `/assurance` conformance surface) + `site/src/data/served-conformance.ts` wrapper + committed `served-conformance.generated.json` snapshot (mirrors the `benchmarks.generated.json` precedent), linked from `/assurance`. Honest hedges mirror the existing scoreboard: **counts are conformance facts (no perf numbers), floors are floors, documented divergences are shown and never summed into `pass`, and the page states it is a snapshot vs the authoritative per-release artifacts.**

## Snapshot at this commit
`http-protocol` 21 pass / 0 fail / 2 documented divergence (floor 21) · `sd-gsp` 39 pass / 0 fail / 1 divergence (floor 39). Floors match the central registry exactly.

## Gates
- **Locally reproduced:** built + ran the emitter (both features) → valid JSON at the expected path; verified the fail-closed stub exits non-zero with no file written. `cargo clippy … --features http-protocol,federation-descriptors -- -D warnings` clean.
- **Workflows:** both valid YAML; `actionlint` adds **zero** new findings vs `origin/main` (28→28 ci.yml, 0→0 release.yml). Gate aggregator untouched (steps added to an existing gating job + a new release-only job that never runs as a PR check).
- **Site:** `typecheck` + `lint` clean; static export green; `check-site-links.sh` 0 errors on the root-relative (CI-equivalent) build.
- **Honesty:** `check-privacy-claims.sh` PASS; no perf numbers; typos-gate clean. `sparq-conformance` coverage floor is 0 (test-driver) — no ratchet risk.

## Duplicate reconciliation
**#1415 is canonical** (earlier PSS filing, kept open, tracked as bead `sq-ro6if`); **#1478** is a later identical PSS filing, already **closed as a duplicate** of #1415. Per the bead, issues are **not** closed here — they close when the release artifact actually ships. Commenting the PR link on both.

## Model provenance
The terse brief suggested `[SONNET-4.6]`, but this was authored by **Opus 4.8** — stamped `[OPUS-4.8]` + the Opus co-author trailer per the AGENTS.md model-provenance rule (stamp the model that actually authored).

Do **not** arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)