### PR TITLE
fix(gui/graph-view-tool): swap plain textarea for WorkbenchSparqlEditor (sq-plqfs)

### DIFF
--- a/gui/app/src/components/workbench/graph-view-tool.tsx
+++ b/gui/app/src/components/workbench/graph-view-tool.tsx
@@ -20,6 +20,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { useEngine, type QueryOutcome } from "@/lib/engine-context";
 import { GraphView } from "@/components/workbench/graph-view";
+import { WorkbenchSparqlEditor } from "@/components/workbench/sparql-editor";
 import type { ToolOverride } from "@/data/tools";
 
 /** The default CONSTRUCT query the tool opens with — broad enough to show the sample graph. */
@@ -59,6 +60,17 @@ export function GraphViewTool() {
     }
   }, [run, query]);
 
+  // (sq-plqfs) [SONNET-4.6] ⌘/Ctrl-Enter fires Run from within the editor.
+  const onKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        void onRun();
+      }
+    },
+    [onRun],
+  );
+
   const ready = status.kind === "ready";
 
   return (
@@ -84,23 +96,18 @@ export function GraphViewTool() {
         </div>
       </div>
 
-      {/* Compact query textarea */}
-      <div className="border-b bg-background px-3 py-2">
-        <textarea
+      {/* (sq-plqfs) Syntax-highlighting SPARQL editor — replaces the plain <textarea>.
+          The id="graph-view-query" hook is preserved on the inner <textarea>
+          (WorkbenchSparqlEditor passes it through). Fixed-height wrapper keeps the editor
+          compact so the result graph fills most of the panel. */}
+      <div className="flex h-28 flex-col border-b">
+        <WorkbenchSparqlEditor
           id="graph-view-query"
           value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          rows={3}
-          spellCheck={false}
-          className="w-full resize-y rounded border bg-muted/30 px-2 py-1.5 font-mono text-xs leading-relaxed focus:outline-none focus:ring-1 focus:ring-primary"
-          aria-label="CONSTRUCT or DESCRIBE query"
-          placeholder="CONSTRUCT WHERE { ?s ?p ?o } LIMIT 100"
+          onChange={setQuery}
+          onKeyDown={onKeyDown}
+          ariaLabel="CONSTRUCT or DESCRIBE query"
         />
-        <p className="mt-1 text-[11px] text-muted-foreground">
-          Enter a <code className="rounded bg-muted px-1 py-0.5">CONSTRUCT</code> or{" "}
-          <code className="rounded bg-muted px-1 py-0.5">DESCRIBE</code> query — the result is
-          rendered as a node-link graph over the live store.
-        </p>
       </div>
 
       {/* Result area */}

--- a/gui/e2e-playwright/specs/graph-view-tool.spec.ts
+++ b/gui/e2e-playwright/specs/graph-view-tool.spec.ts
@@ -59,6 +59,21 @@ test.describe("graph-view-tool", () => {
     await expect(circles.first()).toBeVisible();
   });
 
+  // (sq-plqfs) [SONNET-4.6] — WorkbenchSparqlEditor renders highlighted tokens in the
+  // aria-hidden <pre> layer.  The default CONSTRUCT query contains "CONSTRUCT" and "WHERE"
+  // which are tokenised as SPARQL keywords, producing <span class="sq-tok-keyword"> elements.
+  test("graph-view editor renders SPARQL keyword highlighting tokens", async ({ page }) => {
+    await page.locator('[data-tool="graph-view"]').click();
+    await expect(page.locator('[data-tool-panel="graph-view"]')).toBeVisible();
+
+    // WorkbenchSparqlEditor renders highlighted tokens in the aria-hidden <pre> layer.
+    // The default CONSTRUCT query contains "CONSTRUCT" and "WHERE" — both are SPARQL keywords.
+    const kwSpan = page.locator(".sq-tok-keyword").first();
+    await expect(kwSpan).toBeAttached();
+    const count = await page.locator(".sq-tok-keyword").count();
+    expect(count).toBeGreaterThan(0);
+  });
+
   test("error result on invalid SPARQL", async ({ page }) => {
     await page.locator('[data-tool="graph-view"]').click();
     await expect(page.locator('[data-tool-panel="graph-view"]')).toBeVisible();

--- a/gui/e2e-playwright/specs/graph-view-tool.web.spec.ts
+++ b/gui/e2e-playwright/specs/graph-view-tool.web.spec.ts
@@ -23,6 +23,23 @@ import { webTest as test, webExpect as expect } from "../support/index.ts";
 test.describe("graph-view-tool (web persona)", () => {
   // The webPersona auto-fixture navigates to "/" and waits for engine ready before each test.
 
+  // (sq-plqfs) [SONNET-4.6] — WorkbenchSparqlEditor renders highlighted tokens in the
+  // aria-hidden <pre> layer.  The default CONSTRUCT query contains "CONSTRUCT" and "WHERE"
+  // which are tokenised as SPARQL keywords, producing <span class="sq-tok-keyword"> elements.
+  test("graph-view editor renders SPARQL keyword highlighting tokens (web persona)", async ({
+    page,
+  }) => {
+    await page.locator('[data-tool="graph-view"]').click();
+    await expect(page.locator('[data-tool-panel="graph-view"]')).toBeVisible();
+
+    // WorkbenchSparqlEditor renders highlighted tokens in the aria-hidden <pre> layer.
+    // The default CONSTRUCT query contains "CONSTRUCT" and "WHERE" — both are SPARQL keywords.
+    const kwSpan = page.locator(".sq-tok-keyword").first();
+    await expect(kwSpan).toBeAttached();
+    const count = await page.locator(".sq-tok-keyword").count();
+    expect(count).toBeGreaterThan(0);
+  });
+
   test("Graph View tab runs CONSTRUCT and renders SVG nodes in the browser persona", async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

- Replaces the plain `<textarea id="graph-view-query">` in `GraphViewTool` with `<WorkbenchSparqlEditor>`, matching the wiring pattern in `query-workbench.tsx` and `shacl-tool.tsx`.
- Adds an `onKeyDown` callback so ⌘/Ctrl-Enter triggers Run from within the editor.
- Removes the now-unnecessary prose hint paragraph below the textarea.
- Adds `.sq-tok-keyword` highlight-presence assertions to both `graph-view-tool.spec.ts` and `graph-view-tool.web.spec.ts`, matching the SHACL tool precedent in `shacl-shapes-upload.web.spec.ts`.

Closes #1578.

## Test plan

- [x] `npx next lint` — no ESLint warnings or errors
- [x] `npx tsc --noEmit` — clean
- [x] `npx next build` — static export succeeds (201 kB first load)
- [ ] `graph-view-tool` Playwright specs — both suites pass (CI)

---

> 🤖 SPARQ agent — @jeswr can steer post-hoc if the height (`h-28`) or any wiring detail needs adjustment.