### PR TITLE
feat(gui/editors): Ctrl+/ comment toggle + Tab indent in SPARQL/Turtle editors (sq-rcuvq) [SONNET-4.6]

### DIFF
--- a/gui/app/package.json
+++ b/gui/app/package.json
@@ -15,7 +15,8 @@
     "build:web": "cross-env NEXT_PUBLIC_GUI_TARGET=web npm run build",
     "start": "npx --yes serve out",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test:unit": "node --import ./test-support/register-ts.mjs --test src/lib/editor-keys.test.ts"
   },
   "dependencies": {
     "class-variance-authority": "^0.7.1",

--- a/gui/app/src/components/workbench/sparql-editor.tsx
+++ b/gui/app/src/components/workbench/sparql-editor.tsx
@@ -18,6 +18,7 @@ import { Sparkles } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { handleEditorKeyDown } from "@/lib/editor-keys";
 import {
   type SparqlToken,
   tokenizeSparql,
@@ -82,6 +83,17 @@ export function WorkbenchSparqlEditor({
     }
   }, []);
 
+  // (sq-rcuvq) Merge editor hotkeys (Ctrl+/, Tab, Shift+Tab) with any parent-provided handler.
+  // The hotkeys handler calls e.preventDefault() for its keys; the parent handler (e.g.
+  // Ctrl+Enter → run query) is always called after so its own keys still fire.
+  const mergedKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      handleEditorKeyDown(e, "#", onChange);
+      onKeyDown?.(e);
+    },
+    [onChange, onKeyDown],
+  );
+
   const tokens = React.useMemo(() => tokenizeSparql(value), [value]);
 
   // The well-known prefixes the query USES but does not DECLARE — the one-click "add prefixes"
@@ -131,7 +143,7 @@ export function WorkbenchSparqlEditor({
           autoCapitalize="off"
           autoCorrect="off"
           onChange={(e) => onChange(e.target.value)}
-          onKeyDown={onKeyDown}
+          onKeyDown={mergedKeyDown}
           onScroll={(e) => syncScroll(e.currentTarget)}
           className={cn(
             "absolute inset-0 block h-full w-full resize-none bg-transparent text-transparent caret-foreground outline-none",

--- a/gui/app/src/components/workbench/turtle-editor.tsx
+++ b/gui/app/src/components/workbench/turtle-editor.tsx
@@ -19,6 +19,7 @@
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
+import { handleEditorKeyDown } from "@/lib/editor-keys";
 import { type SparqlToken, tokenizeTurtle } from "@sparq/client";
 
 // The shared text-metrics: the highlight `<pre>` and the `<textarea>` MUST use identical font,
@@ -86,6 +87,17 @@ export function WorkbenchTurtleEditor({
     }
   }, []);
 
+  // (sq-rcuvq) Merge editor hotkeys (Ctrl+/, Tab, Shift+Tab) with any parent-provided handler.
+  // Turtle/SHACL/N3 comments also use '#'. The parent handler (e.g. Ctrl+Enter → validate) is
+  // always called after so its own keys still fire.
+  const mergedKeyDown = React.useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      handleEditorKeyDown(e, "#", onChange);
+      onKeyDown?.(e);
+    },
+    [onChange, onKeyDown],
+  );
+
   const tokens = React.useMemo(() => tokenizeTurtle(value), [value]);
 
   return (
@@ -126,7 +138,7 @@ export function WorkbenchTurtleEditor({
           autoCapitalize="off"
           autoCorrect="off"
           onChange={(e) => onChange(e.target.value)}
-          onKeyDown={onKeyDown}
+          onKeyDown={mergedKeyDown}
           onScroll={(e) => syncScroll(e.currentTarget)}
           className={cn(
             "absolute inset-0 block h-full w-full resize-none bg-transparent text-transparent caret-foreground outline-none",

--- a/gui/app/src/lib/editor-keys.test.ts
+++ b/gui/app/src/lib/editor-keys.test.ts
@@ -1,0 +1,194 @@
+// (sq-rcuvq) [SONNET-4.6] — unit tests for editor-keys.ts pure transforms.
+//
+// Covers: applyCommentToggle, applyTabIndent, applyShiftTabDedent.
+// handleEditorKeyDown is not unit-tested here (it wires into the DOM/React lifecycle);
+// its behaviour is exercised by the Playwright e2e spec (editor-hotkeys.spec.ts).
+//
+// Run via:   npm run test:unit   (gui/app)
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applyCommentToggle,
+  applyTabIndent,
+  applyShiftTabDedent,
+} from "./editor-keys.js";
+
+// ---------------------------------------------------------------------------
+// applyCommentToggle
+// ---------------------------------------------------------------------------
+
+test("applyCommentToggle – adds '# ' to a single uncommented line (caret anywhere on line)", () => {
+  const text = "SELECT * WHERE { ?s ?p ?o }";
+  const result = applyCommentToggle({ text, selStart: 7, selEnd: 7 }, "#");
+  assert.equal(result.text, "# SELECT * WHERE { ?s ?p ?o }");
+});
+
+test("applyCommentToggle – removes '# ' from a single commented line", () => {
+  const text = "# SELECT * WHERE { ?s ?p ?o }";
+  const result = applyCommentToggle({ text, selStart: 9, selEnd: 9 }, "#");
+  assert.equal(result.text, "SELECT * WHERE { ?s ?p ?o }");
+});
+
+test("applyCommentToggle – caret at column 0 of uncommented line", () => {
+  const text = "hello";
+  const result = applyCommentToggle({ text, selStart: 0, selEnd: 0 }, "#");
+  assert.equal(result.text, "# hello");
+  // Cursor should move right by 2 (past the added '# ')
+  assert.equal(result.selStart, 2);
+  assert.equal(result.selEnd, 2);
+});
+
+test("applyCommentToggle – caret at column 0 of commented line (remove)", () => {
+  const text = "# hello";
+  const result = applyCommentToggle({ text, selStart: 0, selEnd: 0 }, "#");
+  assert.equal(result.text, "hello");
+  // After removing '# ', caret clamps to line start (position 0)
+  assert.equal(result.selStart, 0);
+  assert.equal(result.selEnd, 0);
+});
+
+test("applyCommentToggle – multi-line: adds '# ' to all lines when none commented", () => {
+  const text = "line1\nline2\nline3";
+  // Select across all three lines
+  const result = applyCommentToggle({ text, selStart: 0, selEnd: text.length }, "#");
+  assert.equal(result.text, "# line1\n# line2\n# line3");
+});
+
+test("applyCommentToggle – multi-line: removes '# ' when ALL lines commented", () => {
+  const text = "# line1\n# line2\n# line3";
+  const result = applyCommentToggle({ text, selStart: 0, selEnd: text.length }, "#");
+  assert.equal(result.text, "line1\nline2\nline3");
+});
+
+test("applyCommentToggle – mixed: adds '# ' to ALL lines when not all commented", () => {
+  const text = "# line1\nline2\n# line3";
+  const result = applyCommentToggle({ text, selStart: 0, selEnd: text.length }, "#");
+  assert.equal(result.text, "# # line1\n# line2\n# # line3");
+});
+
+test("applyCommentToggle – partial selection only covers a subset of lines", () => {
+  const text = "line1\nline2\nline3";
+  // Selection only touches line2 (positions 6 to 10)
+  const result = applyCommentToggle({ text, selStart: 6, selEnd: 10 }, "#");
+  assert.equal(result.text, "line1\n# line2\nline3");
+});
+
+test("applyCommentToggle – selection ending at start of next line excludes that line", () => {
+  const text = "line1\nline2\nline3";
+  // selEnd = 6 means the selection ends at the start of line2 (after line1's \n)
+  const result = applyCommentToggle({ text, selStart: 0, selEnd: 6 }, "#");
+  // Only line1 should be commented (selEnd points to char after '\n', so line2 is excluded)
+  assert.equal(result.text, "# line1\nline2\nline3");
+});
+
+test("applyCommentToggle – empty line in block does not prevent adding comments", () => {
+  const text = "line1\n\nline3";
+  const result = applyCommentToggle({ text, selStart: 0, selEnd: text.length }, "#");
+  // Empty line gets '# ' too (it was not counted in nonEmpty check, so allCommented is false for
+  // the non-empty lines when none start with '# ')
+  assert.equal(result.text, "# line1\n# \n# line3");
+});
+
+test("applyCommentToggle – cursor position advances by 2 when adding on non-first line", () => {
+  const text = "line1\nline2";
+  // Caret at start of line2 (position 6)
+  const result = applyCommentToggle({ text, selStart: 6, selEnd: 6 }, "#");
+  assert.equal(result.text, "line1\n# line2");
+  // line2 is the second line of the block (bStart = 6 = lineStart of line2)
+  // linesBeforeCaret for selStart=6 within block starting at 6: slice is empty → 1 line
+  // new caret = 6 + 2*1 = 8
+  assert.equal(result.selStart, 8);
+});
+
+// ---------------------------------------------------------------------------
+// applyTabIndent
+// ---------------------------------------------------------------------------
+
+test("applyTabIndent – inserts 2 spaces at cursor", () => {
+  const text = "hello";
+  const result = applyTabIndent({ text, selStart: 2, selEnd: 2 });
+  assert.equal(result.text, "he  llo");
+  assert.equal(result.selStart, 4);
+  assert.equal(result.selEnd, 4);
+});
+
+test("applyTabIndent – inserts at position 0", () => {
+  const text = "hello";
+  const result = applyTabIndent({ text, selStart: 0, selEnd: 0 });
+  assert.equal(result.text, "  hello");
+  assert.equal(result.selStart, 2);
+});
+
+test("applyTabIndent – inserts at end of text", () => {
+  const text = "hello";
+  const result = applyTabIndent({ text, selStart: 5, selEnd: 5 });
+  assert.equal(result.text, "hello  ");
+  assert.equal(result.selStart, 7);
+});
+
+test("applyTabIndent – guard: returns unchanged state when selection is non-empty", () => {
+  const text = "hello";
+  const result = applyTabIndent({ text, selStart: 1, selEnd: 3 });
+  assert.deepEqual(result, { text: "hello", selStart: 1, selEnd: 3 });
+});
+
+// ---------------------------------------------------------------------------
+// applyShiftTabDedent
+// ---------------------------------------------------------------------------
+
+test("applyShiftTabDedent – removes 2 leading spaces from caret line (no selection)", () => {
+  const text = "  hello";
+  const result = applyShiftTabDedent({ text, selStart: 3, selEnd: 3 });
+  assert.equal(result.text, "hello");
+  assert.equal(result.selStart, 1);
+  assert.equal(result.selEnd, 1);
+});
+
+test("applyShiftTabDedent – removes only 1 space when only 1 is present (no selection)", () => {
+  const text = " hello";
+  const result = applyShiftTabDedent({ text, selStart: 2, selEnd: 2 });
+  assert.equal(result.text, "hello");
+  assert.equal(result.selStart, 1);
+});
+
+test("applyShiftTabDedent – no-op when line has no leading spaces (no selection)", () => {
+  const text = "hello";
+  const result = applyShiftTabDedent({ text, selStart: 2, selEnd: 2 });
+  assert.deepEqual(result, { text: "hello", selStart: 2, selEnd: 2 });
+});
+
+test("applyShiftTabDedent – caret at column 0 moves to line start after removal", () => {
+  const text = "  hello";
+  const result = applyShiftTabDedent({ text, selStart: 0, selEnd: 0 });
+  assert.equal(result.text, "hello");
+  // selStart - toRemove = 0 - 2 = -2 → clamp to 0
+  assert.equal(result.selStart, 0);
+});
+
+test("applyShiftTabDedent – dedents every selected line (multi-line selection)", () => {
+  const text = "  line1\n  line2\n  line3";
+  const result = applyShiftTabDedent({ text, selStart: 0, selEnd: text.length });
+  assert.equal(result.text, "line1\nline2\nline3");
+});
+
+test("applyShiftTabDedent – dedents partially-indented lines (only removes available spaces)", () => {
+  const text = " line1\n  line2";
+  const result = applyShiftTabDedent({ text, selStart: 0, selEnd: text.length });
+  assert.equal(result.text, "line1\nline2");
+});
+
+test("applyShiftTabDedent – column-0 lines in multi-line selection are left unchanged", () => {
+  const text = "  line1\nline2";
+  const result = applyShiftTabDedent({ text, selStart: 0, selEnd: text.length });
+  // line1 loses 2 spaces; line2 has none → no change
+  assert.equal(result.text, "line1\nline2");
+});
+
+test("applyShiftTabDedent – multi-line selection: result selects the whole modified block", () => {
+  const text = "  a\n  b";
+  const result = applyShiftTabDedent({ text, selStart: 0, selEnd: text.length });
+  assert.equal(result.text, "a\nb");
+  assert.equal(result.selStart, 0);
+  assert.equal(result.selEnd, result.text.length);
+});

--- a/gui/app/src/lib/editor-keys.ts
+++ b/gui/app/src/lib/editor-keys.ts
@@ -1,0 +1,226 @@
+// (sq-rcuvq) [SONNET-4.6] — Editor hotkeys: Ctrl+/ comment toggle, Tab indent, Shift+Tab dedent.
+//
+// Pure string-transform helpers so tests need no DOM / React setup, plus a thin handler that
+// applies them to a React-controlled <textarea> via requestAnimationFrame.
+//
+// Exports
+//   EditorState               — {text, selStart, selEnd} shape used by all transforms
+//   applyCommentToggle        — toggle `commentChar + ' '` prefix on affected lines
+//   applyTabIndent            — insert 2 spaces at caret (no selection)
+//   applyShiftTabDedent       — remove up to 2 leading spaces per affected line
+//   EditorKeyEvent            — minimal key-event interface (compatible with React.KeyboardEvent)
+//   handleEditorKeyDown       — wires the three hotkeys into a textarea onKeyDown
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EditorState {
+  text: string;
+  /** Inclusive start of selection, or caret position when equal to selEnd. */
+  selStart: number;
+  /** Exclusive end of selection, or caret position when equal to selStart. */
+  selEnd: number;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Absolute position of the start of the line that contains `pos`. */
+function lineStartOf(text: string, pos: number): number {
+  const i = text.lastIndexOf("\n", pos - 1);
+  return i === -1 ? 0 : i + 1;
+}
+
+/** Absolute position of the end of the line that contains `pos` (before the trailing `\n`). */
+function lineEndOf(text: string, pos: number): number {
+  const i = text.indexOf("\n", pos);
+  return i === -1 ? text.length : i;
+}
+
+// ---------------------------------------------------------------------------
+// applyCommentToggle
+// ---------------------------------------------------------------------------
+
+/**
+ * Toggle `commentChar + ' '` line-comment prefix on all lines that overlap the selection
+ * (or the caret line when there is no selection).
+ *
+ * - If ALL non-empty affected lines already carry the prefix → remove it from every line.
+ * - Otherwise → add the prefix to every line.
+ *
+ * Cursor/selection is adjusted so it tracks the same text content after the transform.
+ */
+export function applyCommentToggle(
+  state: EditorState,
+  commentChar: string,
+): EditorState {
+  const { text, selStart, selEnd } = state;
+  const prefix = commentChar + " ";
+  const P = prefix.length;
+
+  // Block boundaries: full lines spanning the selection (or just the caret line).
+  const bStart = lineStartOf(text, selStart);
+  // If the selection ends exactly at a line-start (the \n was selected), exclude that last line.
+  const effEnd =
+    selEnd > selStart && text[selEnd - 1] === "\n" ? selEnd - 1 : selEnd;
+  const bEnd = lineEndOf(text, effEnd);
+
+  const block = text.slice(bStart, bEnd);
+  const lines = block.split("\n");
+
+  const nonEmpty = lines.filter((l) => l.trim() !== "");
+  const allCommented =
+    nonEmpty.length > 0 && nonEmpty.every((l) => l.startsWith(prefix));
+
+  const newLines = allCommented
+    ? lines.map((l) => (l.startsWith(prefix) ? l.slice(P) : l))
+    : lines.map((l) => prefix + l);
+
+  const newBlock = newLines.join("\n");
+  const newText = text.slice(0, bStart) + newBlock + text.slice(bEnd);
+
+  // Adjust an absolute position `pos` in [bStart, bEnd] after the transform.
+  //
+  // For a position on line index `li` (0-indexed from bStart), all of lines 0..li have
+  // had ±P characters prepended, so the total shift is ±P * (li + 1).  When removing and
+  // the shift would go past bStart we clamp to bStart.
+  function adjustPos(pos: number): number {
+    if (pos < bStart) return pos;
+    if (pos >= bEnd) return pos + (newBlock.length - block.length);
+    const countLines = text.slice(bStart, pos).split("\n").length; // li + 1
+    const delta = allCommented ? -P : P;
+    return Math.max(bStart, pos + delta * countLines);
+  }
+
+  if (selStart === selEnd) {
+    const newCaret = adjustPos(selStart);
+    return { text: newText, selStart: newCaret, selEnd: newCaret };
+  }
+  return {
+    text: newText,
+    selStart: adjustPos(selStart),
+    selEnd: adjustPos(selEnd),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// applyTabIndent
+// ---------------------------------------------------------------------------
+
+/**
+ * Insert two spaces at the caret.
+ * Only called when there is no selection (`selStart === selEnd`); returns state unchanged if
+ * called with a selection (defensive guard).
+ */
+export function applyTabIndent(state: EditorState): EditorState {
+  const { text, selStart, selEnd } = state;
+  if (selStart !== selEnd) return state;
+  const newText = text.slice(0, selStart) + "  " + text.slice(selStart);
+  return { text: newText, selStart: selStart + 2, selEnd: selStart + 2 };
+}
+
+// ---------------------------------------------------------------------------
+// applyShiftTabDedent
+// ---------------------------------------------------------------------------
+
+/**
+ * Remove up to 2 leading spaces from:
+ * - the caret line only (when `selStart === selEnd`), or
+ * - every line that overlaps the selection.
+ */
+export function applyShiftTabDedent(state: EditorState): EditorState {
+  const { text, selStart, selEnd } = state;
+
+  if (selStart === selEnd) {
+    // No selection: operate on caret line only.
+    const ls = lineStartOf(text, selStart);
+    let toRemove = 0;
+    while (toRemove < 2 && text[ls + toRemove] === " ") toRemove++;
+    if (toRemove === 0) return state;
+    const newText = text.slice(0, ls) + text.slice(ls + toRemove);
+    const newCaret = Math.max(ls, selStart - toRemove);
+    return { text: newText, selStart: newCaret, selEnd: newCaret };
+  }
+
+  // Selection: operate on all overlapping lines.
+  const bStart = lineStartOf(text, selStart);
+  const effEnd = text[selEnd - 1] === "\n" ? selEnd - 1 : selEnd;
+  const bEnd = lineEndOf(text, effEnd);
+
+  const block = text.slice(bStart, bEnd);
+  const lines = block.split("\n");
+  const newLines = lines.map((l) => {
+    let r = 0;
+    while (r < 2 && l[r] === " ") r++;
+    return l.slice(r);
+  });
+  const newBlock = newLines.join("\n");
+  const newText = text.slice(0, bStart) + newBlock + text.slice(bEnd);
+
+  // After a multi-line dedent, select the entire modified block.
+  return {
+    text: newText,
+    selStart: bStart,
+    selEnd: bStart + newBlock.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// handleEditorKeyDown
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal key-event interface compatible with `React.KeyboardEvent<HTMLTextAreaElement>`
+ * and the native `KeyboardEvent`.  Written as a structural interface so unit tests can
+ * construct it cheaply without a DOM.
+ */
+export interface EditorKeyEvent {
+  key: string;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  preventDefault(): void;
+  currentTarget: HTMLTextAreaElement;
+}
+
+/**
+ * Wire into a `<textarea onKeyDown>`.  Handles:
+ *
+ * - Ctrl+/ (Cmd+/ on Mac): toggle line-comment using `commentChar + ' '`
+ * - Tab (no selection): insert 2 spaces at cursor
+ * - Shift+Tab: dedent (remove up to 2 leading spaces per affected line)
+ *
+ * Calls `onChange` to update React state, then uses `requestAnimationFrame` to restore
+ * the computed selection AFTER React's controlled-input re-render.
+ */
+export function handleEditorKeyDown(
+  e: EditorKeyEvent,
+  commentChar: string,
+  onChange: (value: string) => void,
+): void {
+  const ta = e.currentTarget;
+  const state: EditorState = {
+    text: ta.value,
+    selStart: ta.selectionStart ?? 0,
+    selEnd: ta.selectionEnd ?? 0,
+  };
+
+  let next: EditorState | null = null;
+
+  if ((e.ctrlKey || e.metaKey) && e.key === "/") {
+    next = applyCommentToggle(state, commentChar);
+  } else if (e.key === "Tab" && !e.shiftKey && state.selStart === state.selEnd) {
+    next = applyTabIndent(state);
+  } else if (e.key === "Tab" && e.shiftKey) {
+    next = applyShiftTabDedent(state);
+  }
+
+  if (next !== null) {
+    e.preventDefault();
+    onChange(next.text);
+    const { selStart, selEnd } = next;
+    requestAnimationFrame(() => ta.setSelectionRange(selStart, selEnd));
+  }
+}

--- a/gui/app/test-support/register-ts.mjs
+++ b/gui/app/test-support/register-ts.mjs
@@ -1,0 +1,8 @@
+// (sq-rcuvq) [SONNET-4.6] — Registers the on-the-fly TypeScript ESM loader (ts-loader.mjs) so
+// `node --test` can import the gui/app's `.ts` helper modules directly. Used by the `test:unit`
+// npm script; keeps the unit-test path build-free (no vitest/jest, no separate tsc emit) — type-
+// checking remains the job of `npm run typecheck`.
+import { register } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+register('./ts-loader.mjs', pathToFileURL(`${import.meta.dirname}/`));

--- a/gui/app/test-support/ts-loader.mjs
+++ b/gui/app/test-support/ts-loader.mjs
@@ -1,0 +1,59 @@
+// (sq-rcuvq) [SONNET-4.6] — A minimal ESM hook that transpiles the gui/app's `.ts` modules
+// on the fly with the already-installed `typescript` devDependency, so `node --test` can import
+// and unit-test pure helpers WITHOUT pulling in a heavy test runner (vitest/jest) or a separate
+// build step. Type-erasure only; no type-checking (that is the job of `next build` / `typecheck`).
+//
+// Adapted from site/test-support/ts-loader.mjs with an added resolve hook for explicit `.ts`
+// specifiers so `node --test src/lib/foo.test.ts` works (the site uses .mjs test files that
+// import .ts sources; here the test file itself is .ts).
+import { access, readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript';
+
+export async function resolve(specifier, context, next) {
+  // Allow explicit `.ts` imports (relative paths or file: URLs) so the test runner can load
+  // a `.ts` test file and tests can import `.ts` sources with the `.ts` extension directly.
+  if (specifier.endsWith('.ts') && !specifier.endsWith('.d.ts')) {
+    try {
+      let href;
+      if (specifier.startsWith('file://')) {
+        href = specifier;
+      } else {
+        href = new URL(specifier, context.parentURL).href;
+      }
+      return { shortCircuit: true, url: href };
+    } catch {
+      // fall through to default resolution
+    }
+  }
+
+  // Rewrite an explicit `.js` import specifier to the sibling `.ts` source when that `.ts`
+  // exists. Needed for packages that use NodeNext `.js`-extension conventions internally.
+  if (specifier.endsWith('.js') && (specifier.startsWith('./') || specifier.startsWith('../'))) {
+    try {
+      const tsUrl = new URL(specifier.slice(0, -'.js'.length) + '.ts', context.parentURL);
+      await access(fileURLToPath(tsUrl));
+      return next(tsUrl.href, context);
+    } catch {
+      // No sibling `.ts` — fall through to the default resolution of the real `.js`.
+    }
+  }
+  return next(specifier, context);
+}
+
+export async function load(url, context, next) {
+  if (url.endsWith('.ts') && !url.endsWith('.d.ts')) {
+    const source = await readFile(fileURLToPath(url), 'utf8');
+    const { outputText } = ts.transpileModule(source, {
+      compilerOptions: {
+        module: ts.ModuleKind.ESNext,
+        target: ts.ScriptTarget.ES2022,
+        isolatedModules: true,
+        verbatimModuleSyntax: false,
+      },
+      fileName: fileURLToPath(url),
+    });
+    return { format: 'module', source: outputText, shortCircuit: true };
+  }
+  return next(url, context);
+}

--- a/gui/e2e-playwright/specs/editor-hotkeys.spec.ts
+++ b/gui/e2e-playwright/specs/editor-hotkeys.spec.ts
@@ -1,0 +1,116 @@
+// (sq-rcuvq) [SONNET-4.6] — editor hotkeys journey: Ctrl+/ comment toggle, Tab indent,
+// Shift+Tab dedent in the SPARQL editor (WorkbenchSparqlEditor, #repl-query).
+//
+// Exercises the handleEditorKeyDown handler wired into sparql-editor.tsx.  The same handler
+// is wired into turtle-editor.tsx (WorkbenchTurtleEditor) but the SPARQL editor is the most
+// accessible fixture in the mock-IPC lane.
+//
+// Stable selectors:
+//   #repl-query   — the SPARQL editor textarea (id in sparql-editor.tsx)
+//
+// Determinism rules: NO waitForTimeout; web-first assertions only.
+// Native value setter required: WorkbenchSparqlEditor is React-controlled — direct property
+// assignment bypasses the synthetic event system, so we use the HTMLTextAreaElement native
+// setter + an 'input' event, exactly as workbench-query.spec.ts does.
+
+import { test, expect } from "../support/index.ts";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Set the SPARQL editor's value through React's controlled-input machinery. */
+async function setEditorValue(
+  page: import("@playwright/test").Page,
+  value: string,
+): Promise<void> {
+  await page.evaluate((text) => {
+    const el = document.querySelector<HTMLTextAreaElement>("#repl-query");
+    if (!el) throw new Error("Editor textarea #repl-query not found");
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    if (!setter) throw new Error("Could not access native value setter");
+    setter.call(el, text);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }, value);
+}
+
+/** Read the current value of the SPARQL editor textarea. */
+async function getEditorValue(
+  page: import("@playwright/test").Page,
+): Promise<string> {
+  return page.evaluate(
+    () =>
+      document.querySelector<HTMLTextAreaElement>("#repl-query")?.value ?? "",
+  );
+}
+
+/** Place the textarea's caret at `pos` (selectionStart = selectionEnd = pos). */
+async function setCaretPos(
+  page: import("@playwright/test").Page,
+  pos: number,
+): Promise<void> {
+  await page.evaluate((p) => {
+    const el = document.querySelector<HTMLTextAreaElement>("#repl-query");
+    if (!el) throw new Error("#repl-query not found");
+    el.focus();
+    el.setSelectionRange(p, p);
+  }, pos);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("editor-hotkeys – SPARQL editor", () => {
+  test("Ctrl+/ toggles a line comment: adds '# ' prefix to an uncommented line", async ({
+    page,
+  }) => {
+    const initial = "SELECT * WHERE { ?s ?p ?o }";
+    await setEditorValue(page, initial);
+    // Place caret at position 7 (somewhere in the middle of the line)
+    await setCaretPos(page, 7);
+
+    await page.keyboard.press("Control+/");
+
+    const value = await getEditorValue(page);
+    expect(value).toBe("# SELECT * WHERE { ?s ?p ?o }");
+  });
+
+  test("Ctrl+/ toggles back: removes '# ' from an already-commented line", async ({
+    page,
+  }) => {
+    const commented = "# SELECT * WHERE { ?s ?p ?o }";
+    await setEditorValue(page, commented);
+    await setCaretPos(page, 5);
+
+    await page.keyboard.press("Control+/");
+
+    const value = await getEditorValue(page);
+    expect(value).toBe("SELECT * WHERE { ?s ?p ?o }");
+  });
+
+  test("Tab (no selection) inserts 2 spaces at cursor", async ({ page }) => {
+    await setEditorValue(page, "hello");
+    await setCaretPos(page, 5); // caret at end
+
+    await page.keyboard.press("Tab");
+
+    const value = await getEditorValue(page);
+    expect(value).toBe("hello  ");
+  });
+
+  test("Shift+Tab removes up to 2 leading spaces from the caret line", async ({
+    page,
+  }) => {
+    await setEditorValue(page, "  hello");
+    await setCaretPos(page, 3); // caret inside content
+
+    await page.keyboard.press("Shift+Tab");
+
+    const value = await getEditorValue(page);
+    expect(value).toBe("hello");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `Ctrl+/` (Cmd+/ on Mac) comment toggle, `Tab` indent (2 spaces, no selection), and `Shift+Tab` dedent to `WorkbenchSparqlEditor` and `WorkbenchTurtleEditor`.
- New `gui/app/src/lib/editor-keys.ts`: pure string-transform functions (no deps, no DOM needed for tests).
- 23 unit tests via Node.js built-in test runner; `test-support/` mirrors `site/test-support/` (no new npm packages).
- 4 Playwright E2E assertions in `editor-hotkeys.spec.ts` (chromium-mock-ipc lane).
- `graph-view-tool.tsx` intentionally excluded — sibling bead sq-plqfs replaces its textarea.
- `Ctrl+Enter` (run query / validate) and `Ctrl+K` (command palette) are unchanged.

## Implementation notes

The hotkeys are implemented inside the editor components themselves (not in each consumer), so `WorkbenchTurtleEditor` in `inference-tool.tsx` (N3 rule editor) also gains Tab/Shift-Tab/Ctrl+/ automatically. The `mergedKeyDown` callback combines the internal hotkeys handler with any parent-provided `onKeyDown`, so `query-workbench.tsx`'s Ctrl+Enter and `shacl-tool.tsx`'s Ctrl+Enter continue to fire normally.

## Test plan

- [ ] `cd gui/app && npm run lint && npm run typecheck` — both clean ✓
- [ ] `cd gui/app && npm run test:unit` — 23/23 pass ✓
- [ ] Playwright suite (`editor-hotkeys.spec.ts`) runs in CI (`chromium-mock-ipc` project)

> 🤖 **SPARQ agent** — implemented bead sq-rcuvq. graph-view-tool.tsx excluded (sibling bead sq-plqfs). Do not arm this PR (bead tracking only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)