### PR TITLE
perf(site): repeatable wasm-free bundle guard for / and /capabilities (sq-vw3ax.9) [FABLE-5]

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -14,6 +14,8 @@
     "build-specs": "node scripts/build-specs.mjs",
     "prebuild": "node scripts/sync-wasm.mjs && node scripts/bundle-wasm-esm.mjs && node scripts/sync-benchmarks.mjs && node scripts/sync-zk-catalog.mjs && node scripts/build-papers.mjs && node scripts/build-specs.mjs",
     "build": "next build",
+    "postbuild": "node scripts/check-bundle.mjs",
+    "check:bundle": "node scripts/check-bundle.mjs",
     "build:tauri": "cross-env NEXT_PUBLIC_BASE_PATH= npm run build",
     "start": "npx --yes serve out",
     "lint": "next lint",

--- a/site/scripts/check-bundle.mjs
+++ b/site/scripts/check-bundle.mjs
@@ -1,0 +1,219 @@
+// [FABLE-5] sq-vw3ax.9 — repeatable, CI-runnable BUNDLE GUARD for the wasm-free main bundle.
+//
+// Proves the two "route + prove in under one screen" surfaces — the Home REPL (`/`) and the
+// consolidated /capabilities gallery — never ship the ~2.5 MB engine wasm, the in-tab ZK prover
+// (@aztec/bb.js + @noir-lang/noir_js, ~MB), or any of the 8 heavy demo chunks in their FIRST-LOAD
+// payload. Each of those must arrive ONLY on disclosure-expand (see components/capabilities/
+// lazy-demo.tsx + components/home/hero-runner-lazy.tsx). This is the §7-risk-2 requirement of
+// research/website-redesign.md: "Verify with a bundle check that no demo chunk loads on route
+// entry." The e2e/capabilities-lazy.spec.ts test proves the SAME invariant in a live browser; this
+// is its cheap, deterministic, build-artifact-only counterpart — no browser, so CI-runnable as:
+//
+//     npm run build && npm run check:bundle            # (also runs automatically as `postbuild`)
+//
+// It reads ONLY the build's own manifests, so there is no wall-clock / timing threshold and no
+// third-party-internal string fingerprint to drift (the honesty copy legitimately mentions
+// "UltraHonk"/"@aztec/bb.js", so a content grep would false-positive — we match CHUNK FILES).
+//
+// TWO invariants, plus a config-preservation guard:
+//   1. PRESENCE — every heavy module is STILL a `next/dynamic` split point (has an entry in
+//      react-loadable-manifest.json). This catches the sneaky regression where a demo is switched
+//      back to a STATIC import: its code would fold into the route-entry chunk AND vanish from the
+//      loadable manifest, so a pure "is this chunk in the entry set" test would FALSELY pass.
+//   2. ISOLATION — none of those heavy modules' code-split chunk files appear in the FIRST-LOAD
+//      set (app-build-manifest.json `pages`) of the guarded routes.
+//   3. CONFIG — images:{unoptimized:true} and basePath prefixing are load-bearing for GitHub
+//      Pages / Tauri (bead item 4). Read straight from the build's OWN resolved artifacts
+//      (routes-manifest.basePath, images-manifest), so the check adapts to BOTH build modes
+//      (the default `/sparq` sub-path and the `NEXT_PUBLIC_BASE_PATH=''` root-relative export).
+
+import { readFileSync, existsSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/**
+ * Heavy modules that MUST stay code-split OUT of the guarded routes' first-load payload. Keyed by
+ * the react-loadable-manifest KEY SUFFIX (the "-> <import specifier>" tail of each dynamic-import
+ * split point), which is stable across builds — the hashed chunk FILENAMES are not, so we never
+ * hard-code them. These are exactly the modules dynamic()-imported by lazy-demo.tsx /
+ * hero-runner-lazy.tsx, and the two ~MB ZK prover deps dynamic-imported by lib/zk-prover.ts.
+ */
+export const HEAVY_MODULE_SUFFIXES = [
+  // The 8 /capabilities gallery demos (lazy-demo.tsx).
+  "-> @/components/geosparql-walkthrough",
+  "-> @/components/text-playground",
+  "-> @/components/vector-walkthrough",
+  "-> @/components/genai-walkthrough",
+  "-> @/components/http-server-walkthrough",
+  "-> @/components/rsp-playground",
+  "-> @/components/zk-car-hire",
+  "-> @/components/mpc-demo",
+  // The Home hero's in-browser SPARQL runner — pulls the editors + @sparq/client engine wasm glue.
+  "-> @/components/home/hero-runner",
+  // The in-tab ZK prover (~MB each), dynamic-imported inside lib/zk-prover.ts.
+  "-> @aztec/bb.js",
+  "-> @noir-lang/noir_js",
+];
+
+/**
+ * The two surfaces this bead guards. `manifestKey` is the app-build-manifest.json `pages` key;
+ * `html` is the exported document under out/ (trailingSlash:true → <route>/index.html).
+ */
+export const GUARDED_ROUTES = [
+  { manifestKey: "/page", label: "/", html: "index.html" },
+  { manifestKey: "/capabilities/page", label: "/capabilities", html: "capabilities/index.html" },
+];
+
+/**
+ * Pure analyser: takes the already-parsed manifests + the exported HTML per guarded route, and
+ * returns `{ errors, summary }`. Pure (no fs) so it is unit-testable with synthetic manifests
+ * (see test/bundle-guard.test.mjs). The CLI `main()` below does the file I/O and calls this.
+ *
+ * @param {object} p
+ * @param {Record<string, {files?: string[]} | string[]>} p.loadable  react-loadable-manifest.json
+ * @param {{ pages: Record<string, string[]> }} p.app                 app-build-manifest.json
+ * @param {{ basePath?: string }} p.routes                            routes-manifest.json
+ * @param {{ images?: { unoptimized?: boolean } }} p.images           images-manifest.json
+ * @param {Record<string, string | undefined>} p.htmlByLabel          exported HTML keyed by route label
+ */
+export function analyzeBundle({ loadable, app, routes, images, htmlByLabel }) {
+  const errors = [];
+
+  // Normalise the loadable manifest into [{ key, files }] (Next has used both shapes historically).
+  const entries = Object.entries(loadable ?? {}).map(([key, v]) => ({
+    key,
+    files: Array.isArray(v) ? v : Array.isArray(v?.files) ? v.files : [],
+  }));
+
+  // 1. PRESENCE — each heavy module must still be a dynamic split point; collect its chunk files.
+  const heavyFiles = new Set();
+  const heavyReport = [];
+  for (const suffix of HEAVY_MODULE_SUFFIXES) {
+    const name = suffix.replace(/^-> /, "");
+    const matches = entries.filter((e) => e.key.endsWith(suffix));
+    if (matches.length === 0) {
+      errors.push(
+        `PRESENCE: "${name}" is no longer a next/dynamic split point (absent from ` +
+          `react-loadable-manifest.json). A static import would fold its heavy code into the ` +
+          `route-entry bundle — keep it wrapped in next/dynamic (see lazy-demo.tsx / ` +
+          `hero-runner-lazy.tsx).`,
+      );
+      continue;
+    }
+    const files = new Set();
+    for (const m of matches) for (const f of m.files) {
+      heavyFiles.add(f);
+      files.add(f);
+    }
+    heavyReport.push(`${name} → ${files.size} chunk(s)`);
+  }
+
+  // 2. ISOLATION — no heavy chunk file may appear in a guarded route's first-load set.
+  const routeReport = [];
+  for (const { manifestKey, label } of GUARDED_ROUTES) {
+    const first = app?.pages?.[manifestKey];
+    if (!Array.isArray(first)) {
+      errors.push(
+        `ISOLATION: no first-load entry for guarded route ${label} (${manifestKey}) in ` +
+          `app-build-manifest.json — did the build write it?`,
+      );
+      continue;
+    }
+    const leaked = first.filter((f) => heavyFiles.has(f));
+    if (leaked.length > 0) {
+      errors.push(
+        `ISOLATION: ${label} first-load bundle ships heavy code-split chunk(s) that must be ` +
+          `lazy-loaded on expand: ${leaked.join(", ")}`,
+      );
+    }
+    routeReport.push(`${label}: ${first.length} first-load JS files, ${leaked.length} heavy`);
+  }
+
+  // 3. CONFIG PRESERVATION — images.unoptimized + basePath prefixing (load-bearing for Pages/Tauri).
+  const unoptimized = images?.images?.unoptimized === true;
+  if (!unoptimized) {
+    errors.push(
+      `CONFIG: images.unoptimized must stay true (a static export cannot run the Next image ` +
+        `optimiser) — images-manifest reports ${JSON.stringify(images?.images?.unoptimized)}.`,
+    );
+  }
+  const basePath = routes?.basePath ?? "";
+  for (const { label, html } of GUARDED_ROUTES) {
+    const doc = htmlByLabel?.[label];
+    if (doc == null) {
+      errors.push(
+        `CONFIG: exported HTML for ${label} not found (out/${html}) — was the static export written?`,
+      );
+      continue;
+    }
+    const prefix = `${basePath}/_next/`;
+    if (!doc.includes(prefix)) {
+      errors.push(
+        `CONFIG: ${label} exported HTML references no assets under the build's resolved basePath ` +
+          `("${prefix}") — basePath prefixing is broken (load-bearing for Pages/Tauri).`,
+      );
+    }
+    if (doc.includes("/_next/image?")) {
+      errors.push(
+        `CONFIG: ${label} exported HTML references the Next image optimiser (/_next/image?), which ` +
+          `a static export can't serve — images.unoptimized must be true.`,
+      );
+    }
+  }
+
+  return { errors, summary: { basePath, unoptimized, heavyReport, routeReport } };
+}
+
+/** Read + JSON-parse a build manifest, or return null if it does not exist. */
+function readJson(path) {
+  return existsSync(path) ? JSON.parse(readFileSync(path, "utf8")) : null;
+}
+
+function main() {
+  const siteRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+  const nextDir = join(siteRoot, ".next");
+  const outDir = join(siteRoot, "out");
+
+  const app = readJson(join(nextDir, "app-build-manifest.json"));
+  const loadable = readJson(join(nextDir, "react-loadable-manifest.json"));
+  const routes = readJson(join(nextDir, "routes-manifest.json"));
+  const images = readJson(join(nextDir, "images-manifest.json"));
+
+  if (!app || !loadable || !routes || !images) {
+    console.error(
+      "[check-bundle] Build manifests missing under site/.next — run `npm run build` first.",
+    );
+    process.exit(1);
+  }
+
+  const htmlByLabel = {};
+  for (const { label, html } of GUARDED_ROUTES) {
+    const p = join(outDir, html);
+    htmlByLabel[label] = existsSync(p) ? readFileSync(p, "utf8") : undefined;
+  }
+
+  const { errors, summary } = analyzeBundle({ loadable, app, routes, images, htmlByLabel });
+
+  console.log("[check-bundle] wasm-free main-bundle guard (sq-vw3ax.9)");
+  console.log(`  basePath (resolved): "${summary.basePath}"   images.unoptimized: ${summary.unoptimized}`);
+  console.log("  heavy modules kept code-split (lazy on expand):");
+  for (const line of summary.heavyReport) console.log(`    - ${line}`);
+  console.log("  guarded route first-load payloads:");
+  for (const line of summary.routeReport) console.log(`    - ${line}`);
+
+  if (errors.length > 0) {
+    console.error(`\n[check-bundle] FAIL — ${errors.length} problem(s):`);
+    for (const e of errors) console.error(`  ✗ ${e}`);
+    process.exit(1);
+  }
+
+  console.log(
+    "\n[check-bundle] PASS — no engine wasm / ZK prover / demo chunk in the / or /capabilities " +
+      "first-load bundle; basePath + images.unoptimized preserved.",
+  );
+}
+
+// Run only as a CLI (not when imported by the unit test).
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/site/src/components/capabilities/lazy-demo.tsx
+++ b/site/src/components/capabilities/lazy-demo.tsx
@@ -16,7 +16,8 @@
 // preserves exactly the route-scoping `sidebar-nav.tsx` enforced for the ZK prover: the
 // bb.js / noir_js chunks stay out of the /capabilities first-load bundle and arrive only if
 // a visitor opens the ZK row. The e2e test (e2e/capabilities-lazy.spec.ts) and a build-time
-// bundle check both assert no demo chunk loads on route entry.
+// bundle check (scripts/check-bundle.mjs, run as `npm run check:bundle` / the build's `postbuild`;
+// [FABLE-5] sq-vw3ax.9) both assert no demo chunk loads on route entry.
 
 import * as React from "react";
 import dynamic from "next/dynamic";

--- a/site/test/bundle-guard.test.mjs
+++ b/site/test/bundle-guard.test.mjs
@@ -1,0 +1,118 @@
+// [FABLE-5] sq-vw3ax.9 — unit tests for the wasm-free-main-bundle guard's pure analyser
+// (scripts/check-bundle.mjs `analyzeBundle`). These feed SYNTHETIC manifests — a healthy build, a
+// chunk that LEAKED into a route entry, a demo that regressed to a STATIC import, and a broken
+// config — and assert the analyser flags exactly the right failure. They need no `next build`, so
+// they run in the fast `npm run test:unit` lane (site-e2e); the real `npm run check:bundle` /
+// `postbuild` run the SAME analyser against the actual .next/out artifacts.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  analyzeBundle,
+  HEAVY_MODULE_SUFFIXES,
+  GUARDED_ROUTES,
+} from "../scripts/check-bundle.mjs";
+
+// A minimal healthy fixture: every heavy module is a distinct dynamic split point with its own
+// chunk, NONE of which appear in either guarded route's first-load set.
+function healthyInputs() {
+  const loadable = {};
+  let n = 0;
+  for (const suffix of HEAVY_MODULE_SUFFIXES) {
+    loadable[`src ${suffix}`] = { files: [`static/chunks/heavy-${n++}.js`] };
+  }
+  const first = ["static/chunks/webpack.js", "static/chunks/main-app.js"];
+  const app = {
+    pages: {
+      "/page": [...first, "static/chunks/app/page.js"],
+      "/capabilities/page": [...first, "static/chunks/app/capabilities/page.js"],
+    },
+  };
+  const routes = { basePath: "/sparq" };
+  const images = { images: { unoptimized: true } };
+  const htmlByLabel = {
+    "/": '<script src="/sparq/_next/static/chunks/webpack.js"></script>',
+    "/capabilities": '<script src="/sparq/_next/static/chunks/app/capabilities/page.js"></script>',
+  };
+  return { loadable, app, routes, images, htmlByLabel };
+}
+
+test("healthy build passes with zero errors", () => {
+  const { errors, summary } = analyzeBundle(healthyInputs());
+  assert.deepEqual(errors, []);
+  assert.equal(summary.unoptimized, true);
+  assert.equal(summary.basePath, "/sparq");
+  assert.equal(summary.heavyReport.length, HEAVY_MODULE_SUFFIXES.length);
+});
+
+test("ISOLATION: a heavy chunk leaked into a route first-load is flagged", () => {
+  const inputs = healthyInputs();
+  // Force the zk-car-hire chunk into the /capabilities first-load set (the regression we guard).
+  const zkChunk = inputs.loadable["src -> @/components/zk-car-hire"].files[0];
+  inputs.app.pages["/capabilities/page"].push(zkChunk);
+  const { errors } = analyzeBundle(inputs);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /^ISOLATION: \/capabilities/);
+  assert.match(errors[0], new RegExp(zkChunk.replace(/[.]/g, "\\.")));
+});
+
+test("PRESENCE: a demo switched to a static import (no split point) is flagged", () => {
+  const inputs = healthyInputs();
+  // Simulate zk-car-hire becoming a static import: its dynamic entry disappears from the manifest.
+  delete inputs.loadable["src -> @/components/zk-car-hire"];
+  const { errors } = analyzeBundle(inputs);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /^PRESENCE:/);
+  assert.match(errors[0], /@\/components\/zk-car-hire/);
+});
+
+test("PRESENCE: the ZK prover deps must stay dynamic", () => {
+  const inputs = healthyInputs();
+  delete inputs.loadable["src -> @aztec/bb.js"];
+  delete inputs.loadable["src -> @noir-lang/noir_js"];
+  const { errors } = analyzeBundle(inputs);
+  assert.equal(errors.length, 2);
+  assert.ok(errors.every((e) => e.startsWith("PRESENCE:")));
+});
+
+test("CONFIG: images.unoptimized=false is flagged", () => {
+  const inputs = healthyInputs();
+  inputs.images.images.unoptimized = false;
+  const { errors } = analyzeBundle(inputs);
+  assert.equal(errors.length, 1);
+  assert.match(errors[0], /images\.unoptimized/);
+});
+
+test("CONFIG: adapts to the root-relative (basePath '') build mode", () => {
+  const inputs = healthyInputs();
+  inputs.routes.basePath = "";
+  inputs.htmlByLabel = {
+    "/": '<script src="/_next/static/chunks/webpack.js"></script>',
+    "/capabilities": '<script src="/_next/static/chunks/app/capabilities/page.js"></script>',
+  };
+  const { errors, summary } = analyzeBundle(inputs);
+  assert.deepEqual(errors, []);
+  assert.equal(summary.basePath, "");
+});
+
+test("CONFIG: HTML missing the resolved basePath prefix is flagged", () => {
+  const inputs = healthyInputs();
+  // basePath is /sparq but the HTML emits root-relative assets → prefixing broke.
+  inputs.htmlByLabel["/"] = '<script src="/_next/static/chunks/webpack.js"></script>';
+  const { errors } = analyzeBundle(inputs);
+  assert.ok(errors.some((e) => /basePath prefixing is broken/.test(e)));
+});
+
+test("CONFIG: an image-optimiser reference in exported HTML is flagged", () => {
+  const inputs = healthyInputs();
+  inputs.htmlByLabel["/capabilities"] += '<img src="/sparq/_next/image?url=%2Fx.png&w=64&q=75">';
+  const { errors } = analyzeBundle(inputs);
+  assert.ok(errors.some((e) => /image optimiser/.test(e)));
+});
+
+test("GUARDED_ROUTES covers exactly the Home REPL and /capabilities", () => {
+  assert.deepEqual(
+    GUARDED_ROUTES.map((r) => r.label).sort(),
+    ["/", "/capabilities"],
+  );
+});


### PR DESCRIPTION
> 🤖 **SPARQ agent** (site lane) — I am an automated sub-agent working the `sq-vw3ax.9` bead. This PR verifies (does not re-implement) the wasm-free main-bundle invariant.

## What & why

Bead **sq-vw3ax.9** (epic sq-vw3ax, website redesign): the `/capabilities` gallery and the Home REPL (`/`) must NOT bundle the ~2.5 MB engine wasm or any heavy demo payload (ZK `@aztec/bb.js`/`@noir-lang/noir_js`, MPC sim, geo/vector/genai/http/rsp/text walkthroughs) into their **first-load** route payload. The async/lazy loading itself already landed (`sq-4296`/`sq-55w5a` for the async engine wasm; the `sq-vw3ax.*` lazy-mount split for the demos). What was **missing** was the item-3 deliverable: a *repeatable* bundle check. The code comments even claimed "a build-time bundle check … assert[s] no demo chunk loads on route entry" — but only a live-browser Playwright test (`e2e/capabilities-lazy.spec.ts`) existed. This PR adds the deterministic, browser-free counterpart (research/website-redesign.md §7-risk-2).

## The bundle check — `site/scripts/check-bundle.mjs`

Reads ONLY the Next build's own manifests (no browser, no wall-clock), so it is cheap and CI-runnable:

```
npm run build && npm run check:bundle      # also runs automatically as the build's `postbuild`
```

It asserts three things for the guarded routes `/` and `/capabilities`:

1. **PRESENCE** — every heavy module is still a `next/dynamic` split point (present in `.next/react-loadable-manifest.json`). This catches the *sneaky* regression where a demo is switched back to a **static import**: its heavy code would fold into the route-entry chunk **and** vanish from the loadable manifest, so a naive "is the chunk in the entry set" test would falsely pass.
2. **ISOLATION** — none of those heavy modules' code-split chunk files appear in the **first-load** set (`.next/app-build-manifest.json` `pages`) of the guarded routes.
3. **CONFIG** — `images:{unoptimized:true}` and `basePath` prefixing are preserved (bead item 4; load-bearing for GitHub Pages/Tauri). Read from the build's own `routes-manifest.basePath` + `images-manifest`, so it adapts to **both** build modes — the default `/sparq` sub-path and the `NEXT_PUBLIC_BASE_PATH=''` root-relative export the Pages deploy uses. (A content grep is deliberately *not* used: the honesty copy legitimately mentions "UltraHonk"/"@aztec/bb.js", so string-fingerprinting would false-positive — we match **chunk files**, not text.)

The pure analyser (`analyzeBundle`) is unit-tested with synthetic manifests in `site/test/bundle-guard.test.mjs` (healthy build, a leaked chunk, a static-import regression, prover-deps regression, and both config modes) — these run in the fast `test:unit` lane, needing no build.

### Result on this build (real artifacts)

```
[check-bundle] PASS — no engine wasm / ZK prover / demo chunk in the / or /capabilities
                       first-load bundle; basePath + images.unoptimized preserved.
  basePath (resolved): "/sparq"   images.unoptimized: true
  / : 9 first-load JS files, 0 heavy
  /capabilities : 10 first-load JS files, 0 heavy
  (11 heavy modules kept code-split: the 8 demos, the Home hero-runner, bb.js, noir_js)
```

Verified PASS in **both** build modes: default (`basePath /sparq`) and `build:tauri` (`basePath ''`, root-relative assets, 0 `/sparq` refs).

## Enforcement

Wired as the build's `postbuild` npm hook, so **every** `npm run build` — including the `pages.yml` deploy build — runs the guard and hard-fails on a regression. No CI-workflow (`.github/`) edits were needed (kept strictly within the site lane's `site/` scope). Also exposed standalone as `npm run check:bundle`.

## Gates (all green)

- `cd site && npm install && npm run build` — succeeds end-to-end, routes emitted to `out/`; the new `postbuild` guard fires and PASSes. WASM prereq built first (`cd js && npm run build:wasm`; build artifact only, no `crates/` changes).
- `npm run lint` — clean. `tsc --noEmit` — clean. `npm run test:unit` — 307 pass (incl. 9 new bundle-guard tests). No `any`-escape hatches.
- `images:{unoptimized:true}` + `basePath` preserved (asserted by the check itself). Existing routes untouched.

## Scope

- Files: `site/scripts/check-bundle.mjs` (new), `site/test/bundle-guard.test.mjs` (new), `site/package.json` (+`check:bundle`, +`postbuild`), `site/src/components/capabilities/lazy-demo.tsx` (one comment made accurate — names the now-real script).
- Covered: `/` and `/capabilities` first-load isolation + config preservation, both build modes.
- Deferred: the `/showcase/*` routes legitimately import their demo as the page body (the demo *is* the page) and are out of scope for this bead's two guarded routes; `zk-prover.ts` already dynamic-imports bb.js/noir_js so even those routes stay light on entry.

Refs sq-vw3ax.9 (verification layer over the already-closed sq-4296 / sq-55w5a). Not arming/merging — leaving review + arm to the maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)