### PR TITLE
spike(solid): measured ODRL-as-N3 differential vs Rust path (sq-zgbso.1, #1582)

### DIFF
--- a/crates/sparq-solid/Cargo.toml
+++ b/crates/sparq-solid/Cargo.toml
@@ -95,6 +95,16 @@ trust-graph-did = ["trust-graph", "sparq-trust/did"]
 # `byte-identical to today` regression is proved by the default-build test suite.
 solid-sparql-query = []
 
+# [OPUS-4.8] sq-zgbso.1 MEASURED SPIKE (issue #1582, design record
+# research/odrl-n3-compiled-rules.md): ODRL permission evaluation as N3 rules
+# (rules/odrl-spike.n3) differentially tested against the hand-written Rust path. Gated on
+# `odrl-bridge` (it drives the real `sparq_policy::evaluate` + `odrl_bridge::materialize_policy`),
+# so it is NOT built in the default (feature-OFF) state and adds zero default-build cost.
+# Measurement-only: no production wiring, no new public API.
+[[example]]
+name = "odrl_n3_spike"
+required-features = ["odrl-bridge"]
+
 # [OPUS-4.8] sq-pfae PoC: the trust-graph end-to-end test (tests/trust_graph.rs, fully
 # `#![cfg(feature = "trust-graph")]`) drives the admission gate through the real
 # PodStore. These are dev-only — they do not touch the default build or publish. Scoped

--- a/crates/sparq-solid/examples/odrl_n3_spike.rs
+++ b/crates/sparq-solid/examples/odrl_n3_spike.rs
@@ -1,0 +1,399 @@
+//! [OPUS-4.8] sq-zgbso.1 — MEASURED SPIKE: ODRL permission evaluation as N3 inference
+//! rules vs the hand-written Rust path. NOT production wiring; no public API; no
+//! default-build change (this example is gated behind the default-OFF `odrl-bridge`
+//! feature). Design record: `research/odrl-n3-compiled-rules.md` (epic sq-zgbso, #1582).
+//!
+//! Run:  cargo run -p sparq-solid --example odrl_n3_spike --features odrl-bridge --release
+//!
+//! What it does (the four things the design record §6.1 asks the spike to measure):
+//!   1. DECISION DIFFERENTIAL — for ONE representative ODRL permission-evaluation case
+//!      (a read permission gated by an `odrl:dateTime lteq` window, plus a deny-overrides
+//!      prohibition), across allow + fail-closed-deny + deny-overrides inputs, the
+//!      `auth:*` triple SET derived by the N3 rules (`rules/odrl-spike.n3` via
+//!      `sparq_reason::reason_n3`) MUST equal the SET materialised by the real Rust path
+//!      (`sparq_solid::odrl_bridge::materialize_policy` over `sparq_policy::evaluate`).
+//!      The invariant is decision equality: ANY divergence exits non-zero (fail loudly).
+//!   2. TIMING RATIO — N3 evaluation vs Rust evaluation on the same case.
+//!   3. PARSE-FRACTION PROFILE — of the EXISTING WAC/ACP materialize pipeline (the
+//!      headroom the design's build-time-compilation option would target).
+//!   4. BUILD-SIZE — the byte cost of carrying the N3 rules at the parse-at-runtime
+//!      baseline, with the honest note on what build-time compilation would/would not
+//!      remove for sparq-solid.
+//!
+//! ALL wall-clock figures are best-of-N on THIS work box and are explicitly
+//! NON-CANONICAL (EC2 execution-env protocol): they belong in the spike report / bead
+//! comment, never in docs, tests, or a perf baseline. The DIFFERENTIAL is the load-bearing
+//! deterministic result; the timings only inform the GO/NO-GO judgement.
+
+use oxrdf::Term;
+use sparq_core::dict::Dict;
+use sparq_core::Graph;
+use sparq_policy::{evaluate, parse_policy_str, Policy, Request};
+use sparq_reason::n3::parser;
+use sparq_reason::reason_n3;
+use sparq_solid::odrl_bridge::materialize_policy;
+use sparq_solid::{acp_fixture, wac_fixture, PodStore, AUTH_NS};
+use std::time::Instant;
+
+/// The spike rules under test, embedded exactly as WAC/ACP embed theirs (`include_str!`).
+const RULES: &str = include_str!("../rules/odrl-spike.n3");
+/// The existing WAC/ACP rule text, for the parse-fraction profile (§6.1 item 3).
+const COMMON: &str = include_str!("../rules/common.n3");
+const WAC: &str = include_str!("../rules/wac.n3");
+const ACP_A: &str = include_str!("../rules/acp-a.n3");
+const ACP_B: &str = include_str!("../rules/acp-b.n3");
+const ACP_C: &str = include_str!("../rules/acp-c.n3");
+
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+const ALICE: &str = "urn:alice";
+const BOB: &str = "urn:bob";
+const TARGET: &str = "urn:t/1";
+
+/// A sorted set of `auth:*` triples, as `(subject, predicate, object)` IRI strings — the
+/// canonical form both paths reduce to for the differential.
+type AuthSet = Vec<(String, String, String)>;
+
+/// One representative scenario: the SAME policy text feeds both paths; the request is
+/// built two ways (a Rust `Request`, an N3 request fact) from the same fields.
+struct Scenario {
+    name: &'static str,
+    policy_ttl: &'static str,
+    action_local: &'static str,
+    target: &'static str,
+    party: &'static str,
+    /// canonical UTC `...Z` request instant, or `None` for "no time supplied".
+    at: Option<&'static str>,
+    /// The expected decision, asserted independently so a BOTH-WRONG agreement can't pass.
+    expect: &'static [(&'static str, &'static str, &'static str)],
+}
+
+// ── the RUST path (real: parse -> evaluate -> materialize_policy into a Graph) ─────────
+
+fn rust_auth_set(s: &Scenario) -> AuthSet {
+    let policy: Policy = parse_policy_str(s.policy_ttl, "turtle").expect("policy parses");
+    let mut req = Request::new(format!("{}{}", ODRL, s.action_local))
+        .on(s.target)
+        .by(s.party);
+    if let Some(t) = s.at {
+        req = req.at(t);
+    }
+    // Exercise the REAL bridge: materialize both sides into a fresh dataset's auth view.
+    let mut graph = Graph::new();
+    let outcome = materialize_policy(&mut graph, &policy, &req);
+    let mut set: AuthSet = Vec::new();
+    if let Some(t) = outcome.grant_triple {
+        set.push(t);
+    }
+    if let Some(t) = outcome.deny_triple {
+        set.push(t);
+    }
+    set.sort();
+    set
+}
+
+// ── the N3 path (real: assemble N3 -> reason_n3 -> filter the auth view) ───────────────
+
+/// Assemble the N3 reasoning source for a scenario: prefixes + the SAME policy text +
+/// the request as an `odrl:Request` fact + the spike rules.
+fn n3_source(s: &Scenario) -> String {
+    let at = match s.at {
+        Some(t) => format!(" ; spike:atTime \"{}\"^^xsd:dateTime", t),
+        None => String::new(),
+    };
+    let request = format!(
+        "<urn:req> a odrl:Request ; odrl:action odrl:{} ; odrl:target <{}> ; odrl:assignee <{}>{} .",
+        s.action_local, s.target, s.party, at
+    );
+    format!(
+        "@prefix odrl: <{}> .\n@prefix spike: <https://sparq.dev/ns/odrl-spike#> .\n\
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n{}\n{}\n{}",
+        ODRL, s.policy_ttl, request, RULES
+    )
+}
+
+fn n3_auth_set(s: &Scenario) -> AuthSet {
+    let mut dict = Dict::new();
+    let closure = reason_n3(&mut dict, &n3_source(s)).expect("N3 reasons");
+    let mut set: AuthSet = Vec::new();
+    for t in &closure {
+        let p = dict.term(t[1]);
+        let Term::NamedNode(pred) = &p else { continue };
+        if !pred.as_str().starts_with(AUTH_NS) {
+            continue;
+        }
+        let (Term::NamedNode(subj), Term::NamedNode(obj)) = (dict.term(t[0]), dict.term(t[2])) else {
+            continue;
+        };
+        set.push((
+            subj.as_str().to_owned(),
+            pred.as_str().to_owned(),
+            obj.as_str().to_owned(),
+        ));
+    }
+    set.sort();
+    set
+}
+
+fn expected_set(s: &Scenario) -> AuthSet {
+    let mut set: AuthSet = s
+        .expect
+        .iter()
+        .map(|(a, m, t)| {
+            (
+                (*a).to_owned(),
+                format!("{}{}", AUTH_NS, m),
+                (*t).to_owned(),
+            )
+        })
+        .collect();
+    set.sort();
+    set
+}
+
+fn fmt_set(set: &AuthSet) -> String {
+    if set.is_empty() {
+        return "{}".to_owned();
+    }
+    let items: Vec<String> = set
+        .iter()
+        .map(|(s, p, o)| format!("{} {} {}", s, p.rsplit('#').next().unwrap_or(p), o))
+        .collect();
+    format!("{{ {} }}", items.join(" | "))
+}
+
+// ── timing helper (best-of-N; inner loop for sub-microsecond ops) ─────────────────────
+
+fn best_ns(iters_outer: u32, iters_inner: u32, mut f: impl FnMut()) -> f64 {
+    let mut best = f64::MAX;
+    for _ in 0..iters_outer {
+        let t = Instant::now();
+        for _ in 0..iters_inner {
+            f();
+        }
+        let per = t.elapsed().as_nanos() as f64 / iters_inner as f64;
+        best = best.min(per);
+    }
+    best
+}
+
+fn main() {
+    let scenarios: &[Scenario] = &[
+        Scenario {
+            name: "A1  alice read, within dateTime window        -> ALLOW",
+            policy_ttl: POLICY_A,
+            action_local: "read",
+            target: TARGET,
+            party: ALICE,
+            at: Some("2026-07-05T00:00:00Z"),
+            expect: &[(ALICE, "read", TARGET)],
+        },
+        Scenario {
+            name: "A2  alice read, AFTER window                  -> DENY (constraint)",
+            policy_ttl: POLICY_A,
+            action_local: "read",
+            target: TARGET,
+            party: ALICE,
+            at: Some("2027-01-01T00:00:00Z"),
+            expect: &[],
+        },
+        Scenario {
+            name: "A3  alice read, no time supplied             -> DENY (unprovable)",
+            policy_ttl: POLICY_A,
+            action_local: "read",
+            target: TARGET,
+            party: ALICE,
+            at: None,
+            expect: &[],
+        },
+        Scenario {
+            name: "A4  bob read, within window                  -> DENY (assignee)",
+            policy_ttl: POLICY_A,
+            action_local: "read",
+            target: TARGET,
+            party: BOB,
+            at: Some("2026-07-05T00:00:00Z"),
+            expect: &[],
+        },
+        Scenario {
+            name: "A5  alice write, within window               -> DENY (action)",
+            policy_ttl: POLICY_A,
+            action_local: "write",
+            target: TARGET,
+            party: ALICE,
+            at: Some("2026-07-05T00:00:00Z"),
+            expect: &[],
+        },
+        Scenario {
+            name: "B1  alice read, unconstrained permission     -> ALLOW",
+            policy_ttl: POLICY_B,
+            action_local: "read",
+            target: TARGET,
+            party: ALICE,
+            at: None,
+            expect: &[(ALICE, "read", TARGET)],
+        },
+        Scenario {
+            name: "C1  alice read, permission + prohibition     -> DENY-OVERRIDES",
+            policy_ttl: POLICY_C,
+            action_local: "read",
+            target: TARGET,
+            party: ALICE,
+            at: None,
+            expect: &[(ALICE, "denyRead", TARGET)],
+        },
+    ];
+
+    println!("== sq-zgbso.1 ODRL-as-N3 spike ==  (work-box measurements are NON-CANONICAL)\n");
+    println!("--- 1. DECISION DIFFERENTIAL (real Rust path vs real N3 path) ---");
+    let mut divergences = 0u32;
+    for s in scenarios {
+        let rust = rust_auth_set(s);
+        let n3 = n3_auth_set(s);
+        let expect = expected_set(s);
+        let agree = rust == n3;
+        let correct = rust == expect && n3 == expect;
+        let tag = if agree && correct {
+            "OK"
+        } else if agree {
+            "AGREE-BUT-WRONG"
+        } else {
+            "DIVERGENCE"
+        };
+        println!("  [{}] {}", tag, s.name);
+        if !(agree && correct) {
+            divergences += 1;
+            println!("        rust   = {}", fmt_set(&rust));
+            println!("        n3     = {}", fmt_set(&n3));
+            println!("        expect = {}", fmt_set(&expect));
+        }
+    }
+    println!(
+        "  => {} scenario(s), {} divergence(s)\n",
+        scenarios.len(),
+        divergences
+    );
+
+    // 2. TIMING RATIO on the representative allow case (A1).
+    println!("--- 2. TIMING: N3 evaluation vs Rust evaluation (best-of-N, work box) ---");
+    let a1 = &scenarios[0];
+    let policy = parse_policy_str(a1.policy_ttl, "turtle").unwrap();
+    let req = Request::new(format!("{}read", ODRL))
+        .on(a1.target)
+        .by(a1.party)
+        .at("2026-07-05T00:00:00Z");
+    let src = n3_source(a1);
+    let t_eval = best_ns(20, 20_000, || {
+        let _ = evaluate(&policy, &req);
+    });
+    let t_rust_text = best_ns(20, 2_000, || {
+        let p = parse_policy_str(a1.policy_ttl, "turtle").unwrap();
+        let _ = evaluate(&p, &req);
+    });
+    let t_n3 = best_ns(20, 200, || {
+        let mut d = Dict::new();
+        let _ = reason_n3(&mut d, &src).unwrap();
+    });
+    let t_n3_parse = best_ns(20, 400, || {
+        let _ = parser::parse(&src).unwrap();
+    });
+    println!("  Rust evaluate (policy pre-parsed)      {:>12.0} ns/op", t_eval);
+    println!("  Rust parse_policy_str + evaluate       {:>12.0} ns/op", t_rust_text);
+    println!("  N3   reason_n3 (parse + fixpoint)      {:>12.0} ns/op", t_n3);
+    println!("  N3   parser::parse only                {:>12.0} ns/op", t_n3_parse);
+    println!(
+        "  ratios: N3/Rust(pre-parsed) = {:.0}x ; N3/Rust(from-text) = {:.1}x ; N3-parse share = {:.0}%\n",
+        t_n3 / t_eval,
+        t_n3 / t_rust_text,
+        100.0 * t_n3_parse / t_n3
+    );
+
+    // 3. PARSE-FRACTION PROFILE of the EXISTING WAC/ACP materialize pipeline.
+    println!("--- 3. PARSE-FRACTION PROFILE of the existing WAC/ACP materialize ---");
+    let wac_rules = format!("{}\n{}", COMMON, WAC);
+    let acp_rules = format!("{}\n{}\n{}\n{}", COMMON, ACP_A, ACP_B, ACP_C);
+
+    let wac_graph = Graph::load_dataset(&wac_fixture(), "nquads").unwrap();
+    let n_wac = wac_graph.named.len();
+    let t_wac_full = best_ns(5, 1, || {
+        // Fresh PodStore per iteration so each measures a cold full materialize (the real
+        // `materialize_wac` path), not a re-run over an already-populated auth view.
+        let mut store = PodStore::new(Graph::load_dataset(&wac_fixture(), "nquads").unwrap());
+        let _ = store.materialize_wac().unwrap();
+    }) / 1e6;
+
+    let acp_graph = Graph::load_dataset(&acp_fixture(), "nquads").unwrap();
+    let n_acp = acp_graph.named.len();
+    let t_acp_full = best_ns(5, 1, || {
+        let mut store = PodStore::new(Graph::load_dataset(&acp_fixture(), "nquads").unwrap());
+        let _ = store.materialize_acp().unwrap();
+    }) / 1e6;
+
+    let t_wac_ruleparse = best_ns(20, 100, || {
+        let _ = parser::parse(&wac_rules).unwrap();
+    }) / 1e6;
+    let t_acp_ruleparse = best_ns(20, 100, || {
+        let _ = parser::parse(&acp_rules).unwrap();
+    }) / 1e6;
+    // rules-only closure (parse + trivial empty fixpoint) — the fixed floor.
+    let t_wac_rulesonly = best_ns(20, 100, || {
+        let mut d = Dict::new();
+        let _ = reason_n3(&mut d, &wac_rules).unwrap();
+    }) / 1e6;
+
+    println!("  WAC fixture: {} named graphs; ACP fixture: {} named graphs", n_wac, n_acp);
+    println!("  WAC materialize (full pipeline)        {:>10.3} ms", t_wac_full);
+    println!("  ACP materialize (full pipeline, 3x)    {:>10.3} ms", t_acp_full);
+    println!("  parse WAC rule text only               {:>10.3} ms", t_wac_ruleparse);
+    println!("  parse ACP rule text only               {:>10.3} ms", t_acp_ruleparse);
+    println!("  reason_n3 WAC rules-only (no facts)    {:>10.3} ms", t_wac_rulesonly);
+    println!(
+        "  => rule-parse share of materialize: WAC ~{:.2}% , ACP ~{:.2}%",
+        100.0 * t_wac_ruleparse / t_wac_full,
+        100.0 * t_acp_ruleparse / t_acp_full
+    );
+    println!(
+        "     (item-3 'parse the rules once' is small; the design's candidate win is the\n\
+         \x20     per-call FACT round-trip (items 1-2), which the public API cannot isolate\n\
+         \x20     from the fixpoint here — isolating it needs the in-crate instrument of sq-zgbso.3/.4.)\n"
+    );
+
+    // 4. BUILD-SIZE of carrying the N3 rules (parse-at-runtime baseline).
+    println!("--- 4. BUILD-SIZE delta of carrying the N3 rules (parse-at-runtime baseline) ---");
+    println!("  odrl-spike.n3 embedded rule text       {:>6} bytes", RULES.len());
+    println!("  (for scale) WAC rule text              {:>6} bytes", wac_rules.len());
+    println!("  (for scale) ACP rule text              {:>6} bytes", acp_rules.len());
+    println!(
+        "  NOTE: the N3 parser is ALREADY linked into sparq-solid (WAC/ACP call reason_n3),\n\
+         \x20     so embedding ODRL rules adds only the rule TEXT bytes to the sparq-solid\n\
+         \x20     artifact, NOT a parser. The design ledger's 'parser leaves the runtime path'\n\
+         \x20     saving (item 4) therefore does NOT apply to sparq-solid; the compiled-IR vs\n\
+         \x20     rule-text size ledger is measured for real at sq-zgbso.4's build.rs.\n"
+    );
+
+    if divergences > 0 {
+        eprintln!(
+            "SPIKE FAILED: {} decision divergence(s) — the N3 path is NOT equivalent to the Rust path.",
+            divergences
+        );
+        std::process::exit(1);
+    }
+    println!("SPIKE OK: N3 and Rust agree on every scenario decision; timings above are non-canonical.");
+}
+
+// ── the ONE representative policy, in three variants (same target/assignee) ────────────
+
+const POLICY_A: &str = r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/a> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lteq ;
+                      odrl:rightOperand "2026-12-31T00:00:00Z"^^xsd:dateTime ] ] ."#;
+
+const POLICY_B: &str = r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/b> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ] ."#;
+
+const POLICY_C: &str = r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/c> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ] ;
+  odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ] ."#;

--- a/crates/sparq-solid/rules/odrl-spike.n3
+++ b/crates/sparq-solid/rules/odrl-spike.n3
@@ -1,0 +1,97 @@
+# [OPUS-4.8] sq-zgbso.1 — MEASURED SPIKE (NOT production wiring).
+# ONE representative ODRL permission-evaluation case expressed as N3 inference rules, to
+# be differentially tested against the hand-written Rust path (`sparq-policy::evaluate` +
+# `sparq-solid::odrl_bridge::materialize_policy`). Design record:
+# research/odrl-n3-compiled-rules.md (epic sq-zgbso, issue #1582).
+#
+# Scope of THIS case (deliberately the faithful subset the design record §3 calls the
+# "stateless core"): a Permission grants a WAC/ACP mode iff its action/target/assignee
+# match the request, its (optional) `odrl:dateTime lteq` window holds, and NO prohibition
+# in the same policy carves the request out (deny-overrides). A matched Prohibition
+# materialises the `auth:deny<Mode>` triple. Everything else (other constraint operators,
+# stateful `odrl:count`, purpose/recipient/spatial taxonomies, the `odrl:use` umbrella)
+# is OUT of this spike's scope and — being unmodelled here — simply never grants
+# (fail-closed): a permission carrying an unmodelled constraint hits NEITHER grant rule.
+#
+# Faithfulness notes (verified against sparq-policy/src/eval.rs on origin/main):
+#   * action -> mode uses the SAME table as odrl_bridge::action_to_mode, supplied as data
+#     facts below (read family -> auth:read, append -> auth:append, modify/delete/write ->
+#     auth:write). The `odrl:use` umbrella and unknown actions are intentionally absent
+#     (no mode fact -> no grant), matching action_to_mode returning None.
+#   * `odrl:dateTime lteq D` is `now <= D`. Rust compares xsd:dateTime by INSTANT
+#     (eval.rs::cmp_datetime); `string:notGreaterThan` compares LEXICALLY. These agree
+#     ONLY for canonical UTC (`...Z`, zero-padded) dateTimes — the spike fixture uses that
+#     form. A production N3 path needs a dateTime-normalising builtin for arbitrary
+#     offsets/precisions; that gap is a finding of this spike, not a claim of parity.
+#   * deny-overrides: a matching prohibition makes `evaluate` return deny with NO allow
+#     grant, so the grant rules carry a scoped `log:notIncludes` over the same-policy
+#     prohibition-match pattern. The negation scopes over INPUT-only predicates (policy
+#     facts), so the engine's no-retraction negation-as-failure is sound in one stratum
+#     (the WAC/ACP §3.5 stratification lesson). Constraint-BEARING prohibitions would need
+#     the fuller stratification the design record §7 flags — the spike keeps prohibitions
+#     constraint-free, within the modelled subset.
+
+@prefix odrl:   <http://www.w3.org/ns/odrl/2/> .
+@prefix auth:   <https://sparq.dev/ns/auth#> .
+@prefix spike:  <https://sparq.dev/ns/odrl-spike#> .
+@prefix log:    <http://www.w3.org/2000/10/swap/log#> .
+@prefix string: <http://www.w3.org/2000/10/swap/string#> .
+
+# ── action -> WAC/ACP mode (mirror of odrl_bridge::action_to_mode) ─────────────────────
+odrl:read    spike:mode auth:read .
+odrl:display spike:mode auth:read .
+odrl:present spike:mode auth:read .
+odrl:print   spike:mode auth:read .
+odrl:play    spike:mode auth:read .
+odrl:append  spike:mode auth:append .
+odrl:modify  spike:mode auth:write .
+odrl:delete  spike:mode auth:write .
+odrl:write   spike:mode auth:write .
+
+# ── action -> the `auth:deny<Mode>` predicate a matched prohibition materialises ───────
+odrl:read    spike:denyMode auth:denyRead .
+odrl:display spike:denyMode auth:denyRead .
+odrl:present spike:denyMode auth:denyRead .
+odrl:print   spike:denyMode auth:denyRead .
+odrl:play    spike:denyMode auth:denyRead .
+odrl:append  spike:denyMode auth:denyAppend .
+odrl:modify  spike:denyMode auth:denyWrite .
+odrl:delete  spike:denyMode auth:denyWrite .
+odrl:write   spike:denyMode auth:denyWrite .
+
+# ── grant: UNCONSTRAINED permission, no carve-out prohibition ──────────────────────────
+# Fires only when the permission carries NO odrl:constraint (a constrained permission is
+# handled by the dateTime rule below; an unmodelled-constraint permission hits neither ->
+# fail-closed). Deny-overrides via the scoped same-policy prohibition-match negation.
+{
+  ?pol odrl:permission ?perm .
+  ?perm odrl:action ?act ; odrl:target ?tgt ; odrl:assignee ?party .
+  ?act spike:mode ?mode .
+  ?req a odrl:Request ; odrl:action ?act ; odrl:target ?tgt ; odrl:assignee ?party .
+  ?S1 log:notIncludes { ?perm odrl:constraint ?anyc } .
+  ?S2 log:notIncludes { ?pol odrl:prohibition ?px .
+                        ?px odrl:action ?act ; odrl:target ?tgt ; odrl:assignee ?party } .
+} => { ?party ?mode ?tgt } .
+
+# ── grant: permission gated by a single `odrl:dateTime lteq D` window ──────────────────
+# Fires when now <= D (canonical UTC lexical == instant order) and no carve-out.
+{
+  ?pol odrl:permission ?perm .
+  ?perm odrl:action ?act ; odrl:target ?tgt ; odrl:assignee ?party ;
+        odrl:constraint ?c .
+  ?c odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lteq ; odrl:rightOperand ?deadline .
+  ?act spike:mode ?mode .
+  ?req a odrl:Request ; odrl:action ?act ; odrl:target ?tgt ; odrl:assignee ?party ;
+       spike:atTime ?now .
+  ?now string:notGreaterThan ?deadline .
+  ?S2 log:notIncludes { ?pol odrl:prohibition ?px .
+                        ?px odrl:action ?act ; odrl:target ?tgt ; odrl:assignee ?party } .
+} => { ?party ?mode ?tgt } .
+
+# ── deny: a matching prohibition materialises `auth:deny<Mode>` (deny-overrides) ───────
+{
+  ?pol odrl:prohibition ?proh .
+  ?proh odrl:action ?act ; odrl:target ?tgt ; odrl:assignee ?party .
+  ?act spike:denyMode ?dmode .
+  ?req a odrl:Request ; odrl:action ?act ; odrl:target ?tgt ; odrl:assignee ?party .
+} => { ?party ?dmode ?tgt } .

--- a/crates/sparq-solid/tests/odrl_n3_spike.rs
+++ b/crates/sparq-solid/tests/odrl_n3_spike.rs
@@ -1,0 +1,153 @@
+//! [OPUS-4.8] sq-zgbso.1 — CI enforcement of the ODRL-as-N3 spike's load-bearing
+//! invariant: for the representative ODRL permission-evaluation case, the `auth:*`
+//! decision SET derived by the N3 rules (`rules/odrl-spike.n3`) MUST EQUAL the SET
+//! materialised by the real Rust path (`odrl_bridge::materialize_policy` over
+//! `sparq_policy::evaluate`). The `examples/odrl_n3_spike.rs` harness ALSO prints the
+//! (non-canonical) timing / parse-fraction / build-size measurements; this test locks
+//! the differential so a future rules or evaluator edit cannot silently break parity.
+//!
+//! Gated behind the default-OFF `odrl-bridge` feature (it drives the real ODRL
+//! evaluator), so the default build compiles none of it.
+#![cfg(feature = "odrl-bridge")]
+
+use oxrdf::Term;
+use sparq_core::dict::Dict;
+use sparq_core::Graph;
+use sparq_policy::{parse_policy_str, Request};
+use sparq_reason::reason_n3;
+use sparq_solid::odrl_bridge::materialize_policy;
+use sparq_solid::AUTH_NS;
+
+const RULES: &str = include_str!("../rules/odrl-spike.n3");
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+
+type AuthSet = Vec<(String, String, String)>;
+
+const POLICY_A: &str = r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+<urn:pol/a> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ;
+    odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lteq ;
+                      odrl:rightOperand "2026-12-31T00:00:00Z"^^xsd:dateTime ] ] ."#;
+
+const POLICY_B: &str = r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/b> a odrl:Set ; odrl:permission [
+    odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ] ."#;
+
+const POLICY_C: &str = r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+<urn:pol/c> a odrl:Set ;
+  odrl:permission [ odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ] ;
+  odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ] ."#;
+
+fn rust_set(policy_ttl: &str, action_local: &str, target: &str, party: &str, at: Option<&str>) -> AuthSet {
+    let policy = parse_policy_str(policy_ttl, "turtle").expect("policy parses");
+    let mut req = Request::new(format!("{}{}", ODRL, action_local)).on(target).by(party);
+    if let Some(t) = at {
+        req = req.at(t);
+    }
+    let mut graph = Graph::new();
+    let outcome = materialize_policy(&mut graph, &policy, &req);
+    let mut set: AuthSet = Vec::new();
+    if let Some(t) = outcome.grant_triple {
+        set.push(t);
+    }
+    if let Some(t) = outcome.deny_triple {
+        set.push(t);
+    }
+    set.sort();
+    set
+}
+
+fn n3_set(policy_ttl: &str, action_local: &str, target: &str, party: &str, at: Option<&str>) -> AuthSet {
+    let at_clause = match at {
+        Some(t) => format!(" ; spike:atTime \"{}\"^^xsd:dateTime", t),
+        None => String::new(),
+    };
+    let request = format!(
+        "<urn:req> a odrl:Request ; odrl:action odrl:{} ; odrl:target <{}> ; odrl:assignee <{}>{} .",
+        action_local, target, party, at_clause
+    );
+    let src = format!(
+        "@prefix odrl: <{}> .\n@prefix spike: <https://sparq.dev/ns/odrl-spike#> .\n\
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n{}\n{}\n{}",
+        ODRL, policy_ttl, request, RULES
+    );
+    let mut dict = Dict::new();
+    let closure = reason_n3(&mut dict, &src).expect("N3 reasons");
+    let mut set: AuthSet = Vec::new();
+    for t in &closure {
+        let p = dict.term(t[1]);
+        let Term::NamedNode(pred) = &p else { continue };
+        if !pred.as_str().starts_with(AUTH_NS) {
+            continue;
+        }
+        let (Term::NamedNode(subj), Term::NamedNode(obj)) = (dict.term(t[0]), dict.term(t[2])) else {
+            continue;
+        };
+        set.push((subj.as_str().to_owned(), pred.as_str().to_owned(), obj.as_str().to_owned()));
+    }
+    set.sort();
+    set
+}
+
+fn expect(pairs: &[(&str, &str, &str)]) -> AuthSet {
+    let mut s: AuthSet = pairs
+        .iter()
+        .map(|(a, m, t)| ((*a).to_owned(), format!("{}{}", AUTH_NS, m), (*t).to_owned()))
+        .collect();
+    s.sort();
+    s
+}
+
+/// Assert Rust == N3 == the independently-stated expected set (so a both-wrong
+/// agreement cannot pass), for one scenario.
+fn assert_case(
+    label: &str,
+    policy: &str,
+    action: &str,
+    party: &str,
+    at: Option<&str>,
+    want: &[(&str, &str, &str)],
+) {
+    let rust = rust_set(policy, action, "urn:t/1", party, at);
+    let n3 = n3_set(policy, action, "urn:t/1", party, at);
+    let expected = expect(want);
+    assert_eq!(rust, expected, "{}: Rust path != expected", label);
+    assert_eq!(n3, expected, "{}: N3 path != expected", label);
+    assert_eq!(rust, n3, "{}: Rust and N3 diverge", label);
+}
+
+#[test]
+fn a1_allow_within_datetime_window() {
+    assert_case("A1", POLICY_A, "read", "urn:alice", Some("2026-07-05T00:00:00Z"), &[("urn:alice", "read", "urn:t/1")]);
+}
+
+#[test]
+fn a2_deny_after_window_fail_closed() {
+    assert_case("A2", POLICY_A, "read", "urn:alice", Some("2027-01-01T00:00:00Z"), &[]);
+}
+
+#[test]
+fn a3_deny_no_time_unprovable_fail_closed() {
+    assert_case("A3", POLICY_A, "read", "urn:alice", None, &[]);
+}
+
+#[test]
+fn a4_deny_wrong_assignee_fail_closed() {
+    assert_case("A4", POLICY_A, "read", "urn:bob", Some("2026-07-05T00:00:00Z"), &[]);
+}
+
+#[test]
+fn a5_deny_action_mismatch_fail_closed() {
+    assert_case("A5", POLICY_A, "write", "urn:alice", Some("2026-07-05T00:00:00Z"), &[]);
+}
+
+#[test]
+fn b1_allow_unconstrained_permission() {
+    assert_case("B1", POLICY_B, "read", "urn:alice", None, &[("urn:alice", "read", "urn:t/1")]);
+}
+
+#[test]
+fn c1_deny_overrides_prohibition_wins() {
+    assert_case("C1", POLICY_C, "read", "urn:alice", None, &[("urn:alice", "denyRead", "urn:t/1")]);
+}


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Opus 4.8) — MEASURED SPIKE for epic `sq-zgbso` / issue #1582, resuming `sq-zgbso.1` after the prior agent hit a session limit. [OPUS-4.8] Measurement-only: **no `src/` change, no production wiring, no default-build change.** The spike is `rules/` + `examples/` + `tests/` + one Cargo `[[example]]` entry, all gated behind the default-OFF `odrl-bridge` feature. Design record: `research/odrl-n3-compiled-rules.md` (PR #1590).

## What this is

One representative ODRL permission-evaluation case expressed as **N3 inference rules** (`rules/odrl-spike.n3`, the same `reason_n3` shape WAC/ACP use), **differentially tested** against the real hand-written Rust path (`sparq_solid::odrl_bridge::materialize_policy` over `sparq_policy::evaluate`). The invariant is **decision equality**; the harness fails loudly on any divergence.

Files (disjoint, per the design record's file-area map):
- `crates/sparq-solid/rules/odrl-spike.n3` — the N3 rules (action/target/assignee match + optional `odrl:dateTime lteq` window + deny-overrides prohibition).
- `crates/sparq-solid/examples/odrl_n3_spike.rs` — the measurement harness (differential + timing + parse-fraction + build-size).
- `crates/sparq-solid/tests/odrl_n3_spike.rs` — CI-locks the differential (7 tests: N3 == Rust == independently-stated expected SET, so a both-wrong agreement cannot pass).
- `crates/sparq-solid/Cargo.toml` — `[[example]]` with `required-features = ["odrl-bridge"]`.

## Results (NON-CANONICAL work-box ratios — bead/PR only, nothing baked into docs/tests)

**1. Decision differential (deterministic, load-bearing):** 7/7 agree — ALLOW (within-window, unconstrained), 4 FAIL-CLOSED denies (after-window / no-time / wrong-assignee / action-mismatch), DENY-OVERRIDES (prohibition wins).

**2. Timing (best-of-N):** Rust `evaluate` pre-parsed ~248 ns; Rust from-text ~296 µs; N3 `reason_n3` ~325 µs. Ratio N3/Rust(pre-parsed) ~1300×, but the fair like-for-like (both from RDF text) is **~1.1×** — Rust's own turtle parse dominates its from-text path too, and WAC/ACP already pay this same `reason_n3` evaluator.

**3. Parse-fraction of the existing WAC/ACP materialize:** WAC ~492 ms / 1148 graphs, ACP ~1031 ms / 1136 graphs; rule-TEXT parse alone is **~0.03% / ~0.05%** of materialize. "Parse the rules once" is negligible. The design's candidate win is the per-call **fact** round-trip (items 1-2), which the public API **cannot isolate** (`assemble_input`/`closure_to_n3` are `pub(crate)`, `mod loader` private) — I did NOT breach that boundary or touch `src/`, and did NOT fabricate a number.

**4. Build-size:** `odrl-spike.n3` = 5766 B rule text. The N3 parser is ALREADY linked (WAC/ACP call `reason_n3`), so embedding ODRL rules adds only text bytes, not a parser — the design ledger's "parser leaves the runtime path" saving does not apply to sparq-solid.

## Verdicts (two independent GO/NO-GO, per design §5)

- **(i) ODRL-as-N3: GO** (gates `sq-zgbso.2`). Correctness parity on the stateless core; ~1.1× the Rust from-text path on the same reasoner. Honest scope findings (not parity claims): `odrl:dateTime` uses `string:notGreaterThan` (LEXICAL), equal to INSTANT order only for canonical-UTC `...Z` form — production needs a dateTime-normalising builtin; stateful `odrl:count` stays Rust; constraint-bearing prohibitions need fuller stratification.
- **(ii) Build-time compilation: NO-GO on this spike's evidence; verdict DEFERRED to `sq-zgbso.3`.** The rule-parse fraction (~0.03-0.05%) does NOT justify build.rs compilation; the design's real thesis (id-level facts removing the fact text round-trip) is unfalsified here because it is not isolable without the in-crate instrument `sq-zgbso.3` builds. Do not architect build-time compilation on the parse-fraction number alone.

## Gates (pinned `--features odrl-bridge`, NOT `--all-features` — pre-existing `sq-s5tkx` is out of scope)

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` GREEN in BOTH states: **default (feature OFF)** — spike compiled out (`#![cfg(feature="odrl-bridge")]`), whole sparq-solid suite 31 passed; **`--features odrl-bridge`** — spike 7/7, whole suite green incl. `odrl_bridge` (57), `differential_oracle` (8), WAC/ACP conformance oracles.
- No `src/` touched → the default build is byte-identical (the measurement-only invariant).

Access-control note: this is a measurement-only spike (`.1`) — no grant-derivation change, no new public API, no ZK/MPC claims. The grant-deriving migration beads (`.2`/`.4`/`.5`) are flagged maintainer-armed in the design record. Not self-armed.

Tracks `sq-zgbso`; closes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)