### PR TITLE
bench: Fable-subject re-run of pkg-dogfood 3-arm A/B + fo-km Metric-1 (sq-2m6zm.9) [FABLE-5]

### DIFF
--- a/bench/fo-km/RESULTS.md
+++ b/bench/fo-km/RESULTS.md
@@ -131,3 +131,139 @@ Haiku NL-tool dispatch is documented in `README.md`. The token miner + coverage 
 `analyze.py` (run it against a directory of the run's `agent-*.jsonl` transcripts). Task
 discrimination — that each FO arm answers under closure while the no-FO arm returns 0 —
 is independently checked by `validate_tasks.py` (needs the `close` feature).
+
+
+---
+
+## RE-RUN — Fable subject (sq-2m6zm.9, 2026-07-05): schema.org's clear win does NOT reproduce — DOLCE-DUL ties
+
+> 🤖 **SPARQ agent** [FABLE-5]. Append-only re-run record for bead **sq-2m6zm.9**
+> (#1111 re-attempt program, thread A rung 1; design record
+> `research/neurosymbolic-fable-program.md`). Everything above this line is the
+> original **Haiku-subject** record, unchanged. Harness **byte-unchanged**: frozen
+> `tasks.jsonl`, `overlays/`, `analyze.py` (verified `git diff` clean against
+> `origin/main`). Subject substitution only: **Fable (`claude-fable-5`) replaces
+> Haiku as the NL-tool subject for every (arm, task) cell.**
+
+### Method delta (vs the original run)
+
+- Same 16 frozen tasks × 4 overlays = 64 cells; **one fresh headless `claude -p`
+  Fable session per cell** (`--allowedTools Bash Read Grep Glob Skill`; brief opens
+  with the `[FOKM task= arm=]` tag and drives `pkg-query --extra-graph
+  overlays/<arm>.ttl --close owl-rl` end to end), graded by the frozen `analyze.py`
+  miner + coverage grader.
+- **Serving-model gate (bead invariant).** Each transcript's `message.model` mined per
+  assistant line (`bench/pkg-dogfood/model_ids.py`). **64/64 cells VALID for
+  `claude-fable-5`, 0 excluded** — no silent model substitution observed. Per-task
+  evidence table below.
+- **Operational note (recorded for honesty).** The first dispatch wave
+  (2026-07-05 ≈ 18:07–18:25 UTC) hit the account session limit: 63 of 64 cells
+  returned 429 error results (only `th01`/no-fo, the smoke-test cell, completed
+  cleanly). The 63 poisoned cells were **discarded entirely and re-run after the
+  window reset** (≈ 20:10 UTC) under the same briefs — no partial or mixed transcript
+  was counted.
+
+### The measured result (verbatim `analyze.py` output)
+
+```
+tasks: 16 {'TH': 7, 'ER': 4, 'CC': 5}
+transcripts: 64 | FOKM-tagged: 64
+
+arm                  acc  abst  med_eff_tok  total_$  by-kind
+no-fo               0.25     0      216,002     4.27  CC=0.2 ER=0.5 TH=0.14
+gufo                0.31     0      182,498     3.85  CC=0.4 ER=0.25 TH=0.29
+dolce-dul           0.56     0      176,194     3.64  CC=0.6 ER=0.25 TH=0.71
+schema-org          0.56     0      187,845     3.92  CC=0.6 ER=0.25 TH=0.71
+
+wrote /tmp/sq2m6zm9/fokm_fable.json
+```
+
+`analyze.py`'s `total_$` column prices at its frozen **Haiku $1/$5** constants — kept
+verbatim per the re-run-not-rebuild invariant; with a Fable subject the actual $ is
+≈ 10× the input leg + the same output rate. **Accuracy is the decision metric for
+Metric 1** (design §5), so the mispriced column is informational only.
+
+### Side-by-side with the Haiku-subject record (accuracy, frozen grader)
+
+| Arm | Haiku subject (above) | Fable subject | abstains (Haiku → Fable) |
+|---|---|---|---|
+| no-FO (incumbent) | 0.58 | **0.25** | 5 → 0 |
+| gUFO | 0.54 | 0.31 | 2 → 0 |
+| DOLCE-DUL | 0.64 | **0.56** | 1 → 0 |
+| schema.org-as-top | **0.84** | **0.56** | 2 → 0 |
+
+Supplementary split (same frozen tasks + grader, splitting by each task's frozen
+per-arm `select` answerability): on the tasks an arm's overlay **can express**,
+schema.org still leads — **0.67 over its 12 expressible tasks vs DOLCE-DUL's 0.53
+over 15**; the tie on the full set comes from schema.org's 4 `select=null` tasks,
+where Fable attempts an answer anyway and misses 3 of 4, while DOLCE recovers its
+single null task by cross-inference (1/1).
+
+### Verdict vs the Haiku-era record — PARTIALLY SHIFTED
+
+1. **The headline dominance does not reproduce.** schema.org's +0.20 clear win over
+   DOLCE-DUL (0.84 vs 0.64) collapses to a **tie (0.56 vs 0.56)** with a Fable
+   subject; schema.org keeps only an expressibility-subset edge (0.67 vs 0.53).
+2. **The #1111 fluency thesis is half-confirmed.** The prediction was that richer FOs
+   become usable at higher fluency: **true for DOLCE-DUL** (gap to schema.org closes
+   from −0.20 to 0.00), **false for gUFO** (0.31 — still clearly behind, as in the
+   Haiku era).
+3. **FO typing now beats no-FO across the board.** The no-FO incumbent is the *worst*
+   arm at Fable fluency (0.25); in the Haiku era gUFO scored below no-FO. Any
+   overlay > none, for a strong agent.
+4. **Abstention collapses (0 vs 10)** — Fable always attempts an answer. It sometimes
+   recovers a formally unanswerable task by cross-inference and sometimes mis-answers
+   it; either way the graded denominators differ from the Haiku run, so **absolute
+   cross-run levels are not comparable** — only within-run ordering is.
+5. **Why every arm's absolute score fell.** Spot-checking graded-wrong cells shows the
+   drop is substantially **grader × answer-style interaction**, not a capability
+   regression: the frozen deterministic grader rewards verbatim row enumeration,
+   exact bucket counts, and Haiku-style abstain phrasing, while Fable summarizes
+   ("86 artifacts, in these categories…"), scopes categories differently, and answers
+   "0 — the data does not model this distinction" instead of the abstain phrases the
+   `is_abstain` regex recognizes. The same grader grades all four arms within the
+   run, so the **ordering** (schema.org = DOLCE > gUFO > no-FO) is the valid signal.
+
+**Consequence (gated bead `sq-mztg8.5`, per its invariant):** a Fable-tier tie does
+**not** auto-flip the schema.org-as-top default — the PKG is also queried by cheaper
+tiers, where the Haiku-era record (0.84 vs 0.64) stands. The per-tier reading this
+record supports: **schema.org remains the right default; DOLCE-DUL is no longer
+dominated at the Fable tier** (and is the natural second arm to watch in `sq-givgo`
+round 2).
+
+### Per-task serving-model ids (validity evidence)
+
+<details>
+<summary>64-cell model-id table (mined from transcript <code>message.model</code>; all VALID)</summary>
+
+| task | no-fo | gufo | dolce-dul | schema-org |
+|---|---|---|---|---|
+| cc01 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| cc02 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| cc03 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| cc04 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| cc05 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| er01 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| er02 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| er03 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| er04 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| th01 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| th02 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| th03 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| th04 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| th05 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| th06 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+| th07 | claude-fable-5 | claude-fable-5 | claude-fable-5 | claude-fable-5 |
+
+</details>
+
+### Honest caveats
+
+- **N = 16, single run per subject**; point estimates carry run-to-run variance, and
+  the grader is heuristic (see item 5 above — quantified here because the re-run made
+  the style sensitivity visible).
+- **This is Metric 1 (the agent) only.** Metric 2 (KGE closure-prior MRR) remains
+  EC2-deferred (`sq-p5ro8`); nothing here reads on it.
+- **All numbers runtime / NON-CANONICAL** (work-box transcripts, list-price
+  approximations). Run artifacts are regenerable scratch; the committed artifact is
+  this record.

--- a/bench/pkg-dogfood/RESULTS.md
+++ b/bench/pkg-dogfood/RESULTS.md
@@ -129,3 +129,145 @@ load-bearing (adopt-or-not), measure the real transcripts. The proxy was useful 
 direction-finder, but the proxy's verdict must not be trusted over the measurement.
 
 Licensed MIT (repo default).
+
+
+---
+
+## RE-RUN — Fable subject (sq-2m6zm.9, 2026-07-05): the A-vs-B verdict SHIFTS
+
+> 🤖 **SPARQ agent** [FABLE-5]. Append-only re-run record for bead **sq-2m6zm.9**
+> (#1111 re-attempt program, thread A rung 1; design record
+> `research/neurosymbolic-fable-program.md`). Everything above this line is the
+> original **Opus-subject** record, unchanged. Harness **byte-unchanged**: frozen
+> `tasks/abm_tasks.json`, `tokens_real.py`, `analyze3.py` (verified `git diff` clean
+> against `origin/main`). Subject substitution only: **Fable (`claude-fable-5`)
+> replaces Opus in arms A and B**; arm C stays a Haiku NL-tool.
+
+### Method delta (vs the original run)
+
+- Same 30 frozen tasks × 3 arms = 90 cells; **one fresh headless `claude -p` session
+  per cell** (`--model claude-fable-5` for A/B, `claude-haiku-4-5` for C;
+  `--allowedTools Bash Read Grep Glob Skill`; brief opens with the `[ABM task= arm=]`
+  tag), transcripts mined by the frozen `tokens_real.py`.
+- **Serving-model gate (bead invariant).** Fable sessions can silently serve a
+  different model mid-run, so each transcript's `message.model` was mined **per
+  assistant line** (`model_ids.py`, committed alongside this record). A cell is valid
+  only if *every* assistant line was served by the expected subject; mixed cells are
+  excluded, never counted. **Result: 90/90 cells VALID, 0 excluded** — arms A/B:
+  811/811 assistant lines `claude-fable-5`; arm C: 329/329 lines
+  `claude-haiku-4-5-20251001`. Per-task evidence table below.
+- **Operational note (recorded for honesty).** The first dispatch wave
+  (2026-07-05 ≈ 18:07–18:25 UTC) hit the account session limit mid-window; 12 of the
+  90 cells (t27–t30 × 3 arms) returned 429 error results. Those cells were **discarded
+  entirely and re-run after the window reset** (≈ 20:10 UTC) under the same briefs —
+  no partial or mixed transcript was counted.
+
+### The measured result (verbatim `analyze3.py` output)
+
+```
+=== 3-ARM VERDICT (N=30 tasks, real cache-discounted tokens) ===
+prices/Mtok (list approx): Opus $15 in/$75 out  Haiku $1 in/$5 out
+
+arm                             med eff_in  med out   total $  med $/task  quality
+A=Opus read-docs                   154,440    2,516    91.246      2.4592     0.96
+B=Opus pkg-query                   185,678    7,551   103.651      3.3475     0.97
+C=Haiku pkg-query (NL-tool)        131,532    3,439     5.209      0.1589     0.92
+
+=== $-COST RATIOS (total over the task set) ===
+  A read-docs total: $91.246
+  B pkg-query total: $103.651   -> A is 0.9x B
+  C Haiku NL-tool:   $5.209   -> A is 17.5x C ; B is 19.9x C
+
+=== QUALITY per arm per stratum (mean gold-coverage) ===
+  stratum           A      B      C
+  point-lookup   0.88   1.00   0.94
+  multi-hop      0.97   0.89   0.78
+  synthesis      1.00   1.00   1.00
+  negative       1.00   1.00   1.00
+
+wrote /tmp/sq2m6zm9/verdict_fable.json
+```
+
+`analyze3.py` prices arms A/B at its frozen **Opus-era $15/$75** — kept verbatim per
+the re-run-not-rebuild invariant. Re-priced at the **actual subject-model list prices**
+(Fable $10 in / $50 out; Haiku $1 / $5 per Mtok — same token rows, reporting script
+`fable_dollars.py` in the run scratch, frozen analyzer untouched):
+
+```
+arm A: n=30 total=$60.831 median/task=$1.6395
+arm B: n=30 total=$69.101 median/task=$2.2317
+arm C: n=30 total=$5.209 median/task=$0.1589
+A/C=11.7x  B/C=13.3x  A/B=0.9x
+```
+
+Per-task pairing on the same frozen rows: **B beats A on effective input tokens on
+only 12/30 tasks; median B/A eff-token ratio 1.11** (median assistant turns: A 7.5,
+B 15).
+
+### Verdict vs the Opus-era record — SHIFTED on A-vs-B; delegation holds in direction
+
+| Opus-era claim (record above) | Fable-subject outcome |
+|---|---|
+| **B (pkg-query) ≈ halves A (read-docs) eff tokens** (B cheaper on 29/30 tasks) | **Does NOT hold.** B is *more* expensive than A: median B/A ratio **1.11**, B cheaper on **12/30**; A ≈ 0.9× B in $ under both pricings. Fable reads docs efficiently (7.5 median turns) but drives a much longer introspect→ground→ask loop (15 median turns). |
+| **C (Haiku NL-tool) ≈ 30× cheaper than A at equal-or-better quality — ADOPTED** | **Direction holds; magnitude compresses; a quality gap appears.** C ≈ **11.7×** cheaper than A at actual subject prices (17.5× at the analyzer's frozen Opus-era prices). Quality: C 0.92 vs A 0.96 / B 0.97 — C loses on multi-hop (0.78) this run, so "equal or better" weakens to "slightly below, at ≈ 1/12 the cost". |
+
+The model-dependence #1111 predicted is real, and it points the **opposite way** on
+this benchmark: with Opus, read-docs was the *worst*-quality arm (0.92 vs 1.00); with
+Fable, read-docs is cheap **and** near-top quality (0.96) while the pkg-query middle
+spends twice the turns for no quality gain. **A stronger orchestrator needs the
+symbolic middle less.** The cheap path for a Fable orchestrator is: read the docs, or
+delegate to the Haiku NL-tool — not run `pkg-query` itself. (The decision consequence
+belongs to the `query-pkg` skill owner / epic `sq-2m6zm`, not this record.)
+
+### Per-task serving-model ids (validity evidence)
+
+<details>
+<summary>90-cell model-id table (mined from transcript <code>message.model</code>; all VALID)</summary>
+
+| task | arm A | arm B | arm C |
+|---|---|---|---|
+| t01 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t02 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t03 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t04 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t05 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t06 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t07 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t08 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t09 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t10 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t11 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t12 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t13 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t14 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t15 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t16 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t17 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t18 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t19 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t20 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t21 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t22 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t23 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t24 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t25 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t26 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t27 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t28 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t29 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+| t30 | claude-fable-5 | claude-fable-5 | claude-haiku-4-5-20251001 |
+
+</details>
+
+### Honest caveats
+
+- **N = 30, single counterbalanced run per subject.** Cross-run deltas (e.g. arm C
+  quality 1.00 → 0.92) carry run-to-run and grader-style variance; the load-bearing
+  signal is the **within-run** arm ordering, measured by the same frozen grader.
+- **Answer-style sensitivity.** The frozen gold-key grader rewards verbatim,
+  row-shaped answers; Fable's synthesizing style can under-resolve keys a row-reading
+  agent surfaces verbatim (same caveat class as the original record's "gold keys
+  mildly favour pkg-query").
+- **All numbers runtime / NON-CANONICAL** (work-box transcripts, list-price
+  approximations, stated openly). Run artifacts are regenerable and git-ignored per
+  the existing policy; the committed artifacts are this record + `model_ids.py`.

--- a/bench/pkg-dogfood/model_ids.py
+++ b/bench/pkg-dogfood/model_ids.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+# [FABLE-5] sq-2m6zm.9 (#1111 re-attempt program, thread A). 🤖 SPARQ agent — per-transcript
+# SERVING-MODEL-identity miner for the Fable-subject benchmark re-runs.
+#
+# WHY THIS EXISTS (bead invariant): Fable sessions can silently serve a different model
+# mid-run, so a "Fable-subject" benchmark row is only valid if the transcript itself
+# evidences the serving model. This miner reads each `agent-*.jsonl` Claude Code
+# transcript in a run directory and reports, per transcript, the set of model ids seen
+# on `type == "assistant"` lines (`message.model`) with per-model assistant-line counts.
+# The analysis marks a subject cell VALID only when every assistant line was served by
+# the expected subject model; mixed/substituted cells are flagged and excluded, never
+# counted as the subject model.
+#
+# Works for both bench/pkg-dogfood ([ABM task= arm=]) and bench/fo-km ([FOKM task= arm=])
+# run directories — it re-uses the tag regexes only for attribution and does not grade.
+#
+# Usage:
+#   model_ids.py <transcript-dir> [expected-model-prefix] [out.json]
+#
+# Exit code 0 always (reporting tool); the VALID/INVALID column is the output.
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import re
+import sys
+
+TAGS = (
+    re.compile(r"\[ABM task=(\S+) arm=([ABC])\]"),
+    re.compile(r"\[FOKM task=(\S+) arm=(no-fo|gufo|dolce-dul|schema-org)\]"),
+)
+
+
+def mine(path: str) -> dict:
+    task = arm = None
+    models: dict[str, int] = {}
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            if task is None:
+                for tag in TAGS:
+                    m = tag.search(line)
+                    if m:
+                        task, arm = m.group(1), m.group(2)
+                        break
+            try:
+                obj = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                continue
+            if obj.get("type") != "assistant":
+                continue
+            model = (obj.get("message") or {}).get("model")
+            if model:
+                models[model] = models.get(model, 0) + 1
+    return {
+        "agent_file": os.path.basename(path),
+        "task": task,
+        "arm": arm,
+        "models": models,
+    }
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print("usage: model_ids.py <transcript-dir> [expected-model-prefix] [out.json]",
+              file=sys.stderr)
+        return 2
+    expected = argv[2] if len(argv) > 2 else None
+    rows = [mine(p) for p in sorted(glob.glob(os.path.join(argv[1], "agent-*.jsonl")))]
+    n_valid = n_invalid = 0
+    for r in rows:
+        ids = sorted(r["models"])
+        if expected:
+            ok = len(ids) >= 1 and all(i.startswith(expected) for i in ids)
+            r["valid_for_expected"] = ok
+            n_valid += ok
+            n_invalid += not ok
+            flag = "VALID" if ok else "INVALID"
+        else:
+            flag = ""
+        print(f"  {r['agent_file']:38s} task={str(r['task']):8s} arm={str(r['arm']):11s} "
+              f"models={','.join(f'{i}:{r['models'][i]}' for i in ids)} {flag}")
+    if expected:
+        print(f"expected prefix '{expected}': {n_valid} valid, {n_invalid} invalid "
+              f"of {len(rows)} transcripts")
+    if len(argv) > 3:
+        with open(argv[3], "w", encoding="utf-8") as fh:
+            json.dump(rows, fh, indent=2)
+        print(f"wrote {argv[3]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5). Bead **sq-2m6zm.9** — #1111 re-attempt program, thread A rung 1 (design record `research/neurosymbolic-fable-program.md`).

## What this is

**Append-only measurement records** re-running the two model-dependent benchmark verdicts with **Fable (`claude-fable-5`) as the subject model**:

1. `bench/pkg-dogfood` 3-arm token A/B — Fable substituted for Opus in arms A (read-docs) and B (pkg-query); arm C (Haiku NL-tool) unchanged. 30 frozen tasks × 3 arms = 90 fresh headless sub-agent cells.
2. `bench/fo-km` Metric-1 — Fable substituted for Haiku as the per-(arm, task) NL-tool subject. 16 frozen tasks × 4 overlays = 64 cells.

**Re-run, not rebuild:** frozen tasks/graders/analyzers are byte-unchanged (`git diff` touches only the two RESULTS.md files + the new `model_ids.py` validity miner). Analyzer outputs are recorded **verbatim**; prior sections untouched.

## Validity gate (bead invariant)

Per-transcript, per-assistant-line serving-model-id mining (`bench/pkg-dogfood/model_ids.py`, committed):
- ABM: **90/90 valid** (A/B: 811/811 lines `claude-fable-5`; C: 329/329 `claude-haiku-4-5-20251001`), 0 excluded.
- FOKM: **64/64 valid** all-`claude-fable-5`, 0 excluded. No silent model substitution observed.
- Operational honesty note: the first dispatch wave hit the account session limit (429) mid-window, poisoning 12 ABM + 63 FOKM cells; those were **discarded entirely and re-run after the reset** — recorded in both RESULTS sections. Per-task model-id tables included as evidence.

## Verdicts (null was acceptable; these are not null)

| Prior verdict (Opus/Haiku subject) | Fable-subject outcome |
|---|---|
| pkg-query ≈ halves the orchestrator's eff tokens (29/30) | **SHIFTED — does not hold.** Median B/A eff-token ratio 1.11; B cheaper on 12/30; A ≈ 0.9× B in $. Fable reads docs efficiently (7.5 median turns) and burns 2× the turns driving pkg-query itself. |
| Haiku NL-tool ≈ 30× cheaper at equal-or-better quality (ADOPTED) | **Direction holds, compressed:** ≈ 11.7× cheaper at actual subject prices, with a small quality gap this run (C 0.92 vs A 0.96, lost on multi-hop). |
| fo-km: schema.org 0.84 ≫ DOLCE 0.64 / gUFO 0.54, no-FO 0.58 | **PARTIALLY SHIFTED:** schema.org ties DOLCE-DUL 0.56/0.56 (schema.org keeps an expressibility-subset edge 0.67 vs 0.53); gUFO still loses (0.31); **no-FO is now worst (0.25)**; abstention collapses 10 → 0. The #1111 fluency thesis is half-confirmed: DOLCE-DUL becomes usable at Fable fluency, gUFO does not. |

Cross-run absolute drops are substantially grader × answer-style interaction (frozen grader rewards verbatim enumeration + Haiku-style abstain phrasing; Fable summarizes and answers "0 — not modelled"); the within-run arm ordering is the load-bearing signal — both records say so explicitly.

## Consequences (not in this PR)

- Gated bead **sq-mztg8.5** (FO-choice reopen) can now proceed: per its invariant, the Fable-tier tie does **not** auto-flip the schema.org default (cheaper tiers still show the 0.84 win); recorded as ratify-with-per-tier-note guidance.
- The `query-pkg` skill's cost rationale is now tier-dependent (a Fable orchestrator should read docs or delegate, not run pkg-query itself) — follow-up belongs to epic `sq-2m6zm`.

## Acceptance (bead)

- `analyze3.py` + `analyze.py` green over the Fable-run artifacts; outputs verbatim in the RESULTS files ✅
- Per-task serving-model-id column recorded; invalid legs = 0 ✅
- `git diff` shows zero edits to `tasks/`, `grade.py`, `stats.py`, `analyze3.py`, `tasks.jsonl`, `overlays/` ✅
- Work-box numbers marked runtime/NON-CANONICAL; `bench/` is the sanctioned numeric home ✅

Not self-arming — leaving merge to the review queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)