### PR TITLE
feat(trust): trustx: certification-scope vocabulary (sq-6syab.2, #1592) [FABLE-5]

### DIFF
--- a/crates/sparq-trust/Cargo.toml
+++ b/crates/sparq-trust/Cargo.toml
@@ -49,6 +49,14 @@ store = []
 # is `const &str` data + a TTL drift test, strictly additive (no new dep, no new edge
 # onto the lean default build).
 secprop-vocab = []
+# [FABLE-5] sq-6syab.2 — the `trustx:` certification-scope vocabulary (`framework_vocab`
+# module + `trust-framework.ttl`): the trust-expression program's layer for expressing
+# framework-certified-issuer trust and issuer certification scope (issue #1592; design
+# `research/trust-expression-spec.md` §3.4). It EXTENDS the `trust:` vocabulary and
+# REFERENCES the vendored `sec-req:` eIDAS/UK-DVS individuals — it does not fork or
+# duplicate them. Dependency-free — `const &str` data + a TTL drift test, strictly
+# additive (no new dep, no new edge onto the lean default build).
+framework-vocab = []
 # [OPUS-4.8] sq-ufsi9 — the N3 proof-admissibility ruleset over `sparq-reason` (the
 # §4.3 ODRL → admissible-proof-set reduction: strongerThan-closure / atLeast /
 # overDimension / satisfies, plus the Rust default-deny universal). Pure N3-text data

--- a/crates/sparq-trust/README.md
+++ b/crates/sparq-trust/README.md
@@ -63,9 +63,8 @@ view; `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
   signature over the commitment (`sparq-zk`, never a self-asserted triple), enforce statement-type scoping
   via a real SHACL shape (`sparq-shacl`), freshness, and the clear-WebID holder binding. Default-deny.
 - **N3 merge** (`wire`) — feed admitted facts into `sparq-reason`; the `.acr` ABAC rule derives the grant (age>18 e2e).
-- **Storage / authoring model** (`store`, **opt-in `store` feature**, `sq-pfae.5`) — a server-wide default + per-`.acr`
-  documents that **NARROW, never broaden** the server ceiling (`effective_rules`); monotone versioning (stale rejected) +
-  revocation; the `AdmissionCacheKey` (evidence hash + policy version) composes with the sparq-solid epoch cache. No new dep.
+- **Storage / authoring model** (`store`, **opt-in `store` feature**, `sq-pfae.5`) — a server-wide default + per-`.acr` documents that **NARROW, never broaden**
+  the ceiling (`effective_rules`); monotone versioning (stale rejected) + revocation; `AdmissionCacheKey` composes with the sparq-solid epoch cache. No new dep.
 - **Static / dynamic admission split** (`admit_static` + `derive_conditional_grants`, `sq-xc4y`) — decides the
   **session-independent** class once at materialise-time and defers the **per-request** class (holder + freshness)
   to an `auth:ConditionalGrant` re-checked per request.
@@ -79,19 +78,20 @@ view; `--features trust-graph-did` forwards the DID issuer-key binding (`sq-pfae
   reads `did:web` via a **pluggable** fetcher). **Narrows** the forgery vector D′ (no absolute anchor).
 - **Security properties** (`secprop` / `admissibility`, **opt-in `secprop-vocab` / `secprop-admissibility`**, `sq-5oru9` /
   `sq-ufsi9`) — the sparq **`sec-prop:` extension** ([`secprop-ext.ttl`](ontologies/zkp-sparql/secprop-ext.ttl); proof-system
-  dimensions + the **assurance / audit-status axis** the vendored ontology lacks) and the §4.3 ODRL → admissible-proof-set
-  reduction as a RUNNABLE N3 ruleset on `sparq-reason` (Rust **default-deny**). Reasons over ANNOTATIONS, not crypto (`sq-qhy4`).
+  dimensions + the **assurance / audit-status axis** the vendored ontology lacks) and the §4.3 ODRL → admissible-proof-set reduction as a RUNNABLE N3 ruleset on `sparq-reason` (Rust **default-deny**). Reasons over ANNOTATIONS, not crypto (`sq-qhy4`).
+- **`trustx:` certification-scope vocabulary** (`framework_vocab`, **opt-in `framework-vocab`**, `sq-6syab.2` / [#1592](https://github.com/jeswr/sparq/issues/1592)) —
+  the trust-expression layer for **framework-certified-issuer** trust + issuer **certification scope**: a verifier→holder trust-requirements graph, two
+  modes (enumerated `trustsIssuer` OR `trustsFramework`), positive time-windowed status attestation. Turtle ([`trust-framework.ttl`](ontologies/trust/trust-framework.ttl))
+  **extends** `trust:` and **`rdfs:seeAlso`s** the vendored `sec-req:` eIDAS/UK-DVS individuals (no fork/duplication); pinned to Rust constants. **Anchored, not proven** (`sq-qhy4`).
 - **Property-admissibility pre-check** (`admit_with_precheck`, **opt-in `secprop-precheck`**, `sq-dt5hv` Ph 5 / `sq-nrwqs` / `sq-ddbm8`) —
   an OPTIONAL pre-admission check: the caller passes ONLY the requester's ODRL preference + the method IRI; the gate resolves the
   method's posture from the **bundled** `secprop-methods.ttl` (tamper-resistant; unknown method / malformed operand fail closed) and **fails closed** *before* the sig/holder checks. NO preference ⇒ **byte-identical** to `admit`.
-- **Live status / revocation** (`status_list`, **opt-in `status-list`**, `sq-pfae.7`) — gate derivations on a **live
-  W3C Bitstring Status List** instead of `revoked: bool`: fetch (pluggable `StatusListResolver`) + decode (multibase
-  over a pluggable `GzipDecoder`; built-in `Flate2GzipDecoder` behind `status-list-flate2`); `admit_with_status` admits
-  ONLY a `LiveStatus::Live` credential — **fail-closed on set/unknown/stale** — with a minimal `prov:`/`trust:` justification.
-- **Verified status-list issuer signature** (`VerifyingLiveStatusCheck`, **`status-list`**, `sq-pfae.13`) — verify the
-  status-list VC's OWN issuer signature (the SAME `sparq-zk` Schnorr-over-RDFC-1.0 path the admit gate uses) against a
-  trusted status-authority key (or a `did:key`/`did:web` issuer via `with_did_issuer`, `did` feature) **before** trusting
-  its bits. **Fail-closed**: an unsigned / bad-signature / wrong-key / unresolvable-issuer list VC is `Unknown` (deny), never trusted.
+- **Live status / revocation** (`status_list`, **opt-in `status-list`**, `sq-pfae.7`) — gate derivations on a **live W3C Bitstring Status List**
+  instead of `revoked: bool`: fetch (pluggable `StatusListResolver`) + decode (multibase over a pluggable `GzipDecoder`; built-in `Flate2GzipDecoder`
+  behind `status-list-flate2`); `admit_with_status` admits ONLY a `LiveStatus::Live` credential — **fail-closed on set/unknown/stale** — with a minimal `prov:`/`trust:` justification.
+- **Verified status-list issuer signature** (`VerifyingLiveStatusCheck`, **`status-list`**, `sq-pfae.13`) — verify the status-list VC's OWN issuer
+  signature (the SAME `sparq-zk` Schnorr-over-RDFC-1.0 path the admit gate uses) against a trusted status-authority key (or a `did:key`/`did:web` issuer
+  via `with_did_issuer`, `did` feature) **before** trusting its bits. **Fail-closed**: an unsigned / bad-sig / wrong-key / unresolvable-issuer list VC is `Unknown` (deny).
 
 ## Honest scope — what this does and does NOT do
 

--- a/crates/sparq-trust/ontologies/trust/trust-framework.ttl
+++ b/crates/sparq-trust/ontologies/trust/trust-framework.ttl
@@ -1,0 +1,225 @@
+# trust-framework.ttl — the `trustx:` certification-scope vocabulary (machine-readable form)
+#
+# [FABLE-5] sq-6syab.2 (epic sq-6syab / issue #1592; decomposition design record
+# `research/trust-expression-spec.md` §3.4 / D4). 🤖 SPARQ agent — trust-expression
+# certification-scope layer. Written on the Fable-tier collaboration program.
+#
+# This is the canonical, machine-readable rendering of the certification-scope
+# vocabulary layer of the trust-expression program: the terms that let a verifier
+# express "certified issuers WITHIN the eIDAS / DIATF framework, that have only issued
+# information they are certified to issue" (issue #1592). It EXTENDS the `trust:`
+# vocabulary (`trust.ttl` in this directory) — it does NOT fork it — and REFERENCES the
+# vendored `sec-req:` regulatory-framework individuals (eIDAS 2.0 / UK DVS) via
+# `rdfs:seeAlso`, adding only the certification mechanics `sec-req:` lacks (an issuer
+# being CERTIFIED UNDER a framework, and a certification SCOPE). No `trust:` or
+# `sec-req:` term is redeclared here (the D5 no-duplication rule).
+#
+# It is byte-pinned against the Rust constants in
+# `crates/sparq-trust/src/framework_vocab.rs` by the `framework_ttl_iris_match_rust_constants`
+# sync test in that module — the two MUST NOT drift (the `trust.ttl`/`vocab.rs` and
+# `secprop-ext.ttl`/`secprop.rs` discipline).
+#
+# *** ALL `trustx:` IRIs ARE NON-STANDARD, INVENTED FOR THIS PROPOSAL. ***
+# `https://sparq.dev/ns/trust#` is a PLACEHOLDER namespace (shared with `trust:`, since
+# `trustx:` is a prose-only sub-prefix that extends it under the SAME base — NOT a
+# distinct namespace) to make the semantics concrete; it is NOT minted, NOT resolvable,
+# and NOT a claim of standardisation. A working group taking this design forward would
+# rename/rehome every term. See the design record §9.3 (upstream home / namespace) and
+# the honest-limitations §7.
+#
+# *** HONESTY (load-bearing — trust-expression program discipline). ***
+# Framework-anchored trust is ANCHORED, NOT PROVEN. A `trustx:Certification` bottoms out
+# in the framework operator's signed trusted-list / register artifacts — it is a trust
+# anchor, not cryptography. The scope-conformance check constrains what the VERIFIER
+# accepts and, via the published certification, what the issuer was AUTHORISED to issue;
+# it CANNOT retroactively prove an issuer never mis-issued elsewhere (design §7.2). No
+# term here asserts a settled cryptographic soundness or privacy guarantee: the sparq ZK
+# estate is internally re-audited but has NO external accredited-cryptographer sign-off
+# (open gate sq-qhy4), and sparq-mpc is honest-majority semi-honest only.
+
+@prefix trust:   <https://sparq.dev/ns/trust#> .
+@prefix trustx:  <https://sparq.dev/ns/trust#> .
+@prefix sh:      <http://www.w3.org/ns/shacl#> .
+@prefix rdf:     <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:    <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl:     <http://www.w3.org/2002/07/owl#> .
+@prefix xsd:     <http://www.w3.org/2001/XMLSchema#> .
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix sec-req: <https://w3id.org/zkp-sparql/sec-req#> .
+
+# --- ontology metadata -------------------------------------------------------
+# NOTE: `trustx:` and `trust:` share the base IRI `https://sparq.dev/ns/trust#`. The
+# `owl:Ontology` node below is a SEPARATE ontology-metadata subject at a distinct IRI
+# (the framework-layer document IRI), so it does NOT collide with the `trust:` ontology
+# node in `trust.ttl` and is exempt from the term-declaration drift check (its subject
+# is the document IRI, not a `trustx:LocalName` term).
+
+<https://sparq.dev/ns/trust-framework> a owl:Ontology ;
+  rdfs:label "Trust-expression certification-scope vocabulary (NON-STANDARD, proposal)"@en ;
+  dcterms:description """The certification-scope layer of the trust-expression program
+(issue #1592): terms for expressing framework-certified-issuer trust and issuer
+certification scope over the trust requirements the verifier sends the holder. EXTENDS the
+trust: vocabulary (imported below) and REFERENCES the vendored sec-req: eIDAS 2.0 / UK
+DVS individuals via rdfs:seeAlso — it does not duplicate them. EVERY term here is
+NON-STANDARD and invented for this proposal; the namespace is a placeholder shared with
+trust:. Framework trust is ANCHORED (the framework operator's signed artifacts), not
+proven; no cryptographic soundness/privacy guarantee is asserted (sq-qhy4 open, MPC
+semi-honest). Companion: research/trust-expression-spec.md §3.4 / §7."""@en ;
+  owl:imports <https://sparq.dev/ns/trust> ;
+  rdfs:seeAlso <https://github.com/jeswr/sparq/issues/1592> ;
+  rdfs:comment "Placeholder namespace shared with trust:; a WG would rename/rehome every term."@en .
+
+# =============================================================================
+# The trust requirements — the verifier→holder contract carrier (design §3.1 / D1)
+# =============================================================================
+# The verifier sends ONE SPARQL query + ONE trust-requirements graph + the existing
+# zkSPARQL nonce. The trust requirements are a small RDF graph in this vocabulary; the
+# trust conditions live in the requirements, NOT in the query (there is no new query
+# syntax — design §3.1).
+
+trustx:TrustRequirements a rdfs:Class, owl:Class ;
+  rdfs:label "Trust requirements"@en ;
+  rdfs:comment "The verifier→holder contract carrier: a small RDF graph binding a query to its trust conditions (enumerated issuers and/or framework certification, plus a status-validity instant). One of the three things the verifier sends the holder (query + trust requirements + zkSPARQL nonce); the trust conditions live HERE, never in the query — there is no new query syntax (design §3.1)."@en ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:question a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "question"@en ;
+  rdfs:comment "Binds the trust requirements to the SPARQL query they scope (the query's identifying IRI). Makes a trust-requirements graph reusable across queries by naming which one it applies to (design §3.2)."@en ;
+  rdfs:domain trustx:TrustRequirements ;
+  rdfs:range rdfs:Resource ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:trustsIssuer a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "trusts issuer"@en ;
+  rdfs:comment "MODE 1 (enumerated parties): admit contributing statements issued by THIS enumerated issuer identity (a DID/key binding, reusing the sq-pfae.3 did:key/did:web work). Multiple values are the maintainer's '[X, Y and Z]' issuer set. Composes with trustx:trustsFramework by plain OR (design §3.2 / D2)."@en ;
+  rdfs:domain trustx:TrustRequirements ;
+  rdfs:range rdfs:Resource ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:trustsFramework a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "trusts framework"@en ;
+  rdfs:comment "MODE 2 (framework-certified issuers): admit contributing statements from issuers CERTIFIED UNDER this trustx:Framework (subject to scope conformance). The maintainer's 'certified issuers WITHIN the eIDAS/DIATF framework'. Composes with trustx:trustsIssuer by plain OR (design §3.2 / D2)."@en ;
+  rdfs:domain trustx:TrustRequirements ;
+  rdfs:range trustx:Framework ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:requiresScopeConformance a rdf:Property, owl:DatatypeProperty ;
+  rdfs:label "requires scope conformance"@en ;
+  rdfs:comment "When true (mode 2), REQUIRES that every contributing attested statement's type/predicate falls under its issuer's trustx:Certification scope valid at the evaluation time — the maintainer's 'issuers have only issued information that they are certified/approved to issue'. A scope-conformance check against the framework's PUBLISHED certifications (a trust-anchored authorisation claim, NOT a cryptographic guarantee that the issuer never mis-issued elsewhere — design §7.2)."@en ;
+  rdfs:domain trustx:TrustRequirements ;
+  rdfs:range xsd:boolean ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:requiresValidStatusAt a rdf:Property, owl:DatatypeProperty ;
+  rdfs:label "requires valid status at"@en ;
+  rdfs:comment "The instant t at which a covering, positive trustx:StatusAttestation must hold for every contributing statement (and, in mode 2, every issuer certification). Non-revocation is asked as the EXISTENCE of a covering positive status window, never as absence of a revocation (OWA/monotonicity — design §3.3 / D3). A verifier-chosen parameter, not a spec constant (design §7.4)."@en ;
+  rdfs:domain trustx:TrustRequirements ;
+  rdfs:range xsd:dateTime ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:methodPolicy a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "method policy"@en ;
+  rdfs:comment "OPTIONAL reference from the trust requirements to an ODRL policy consumed by the existing secprop/ODRL admissible() pre-check (sq-0dksu), which decides which PROOF METHODS are acceptable — an orthogonal axis to which SOURCES are trusted. The spec normatively REFERENCES, and does not restate, that machinery (design §3.5 / D5)."@en ;
+  rdfs:domain trustx:TrustRequirements ;
+  rdfs:range rdfs:Resource ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+# =============================================================================
+# The certification-scope layer (design §3.4 / D4)
+# =============================================================================
+
+# --- framework --------------------------------------------------------------
+
+trustx:Framework a rdfs:Class, owl:Class ;
+  rdfs:label "Governance framework"@en ;
+  rdfs:comment "A governance framework operating a trusted-list / register (e.g. eIDAS 2.0's Trusted Lists, the UK DIATF register of digital identity and attribute services). The framework individuals below carry rdfs:seeAlso to the EXISTING vendored sec-req: individuals — sec-req: stays the regulatory-requirement view; trustx: adds only the certification mechanics it lacks (design §3.4)."@en ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+# --- certification ----------------------------------------------------------
+
+trustx:Certification a rdfs:Class, owl:Class ;
+  rdfs:label "Certification"@en ;
+  rdfs:comment "A time-windowed, authority-signed attestation that an issuer is certified under a framework. A Trusted-List entry or a DIATF-register entry IS a trustx:Certification in this model. Groups the certified issuer (trustx:certifies), the framework (trustx:underFramework), the scope (trustx:scope), the validity window (trustx:validFrom / trustx:validUntil), and the signature/attestation binding. Certifications are status-checked exactly like credentials — same positive-attestation machinery (design §3.4 / §6 case 7)."@en ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:certifies a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "certifies"@en ;
+  rdfs:comment "The issuer identity (DID/key) this certification certifies. Links a trustx:Certification to the issuer whose trustx:trustsFramework membership it establishes."@en ;
+  rdfs:domain trustx:Certification ;
+  rdfs:range rdfs:Resource ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:underFramework a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "under framework"@en ;
+  rdfs:comment "The trustx:Framework this certification is issued under."@en ;
+  rdfs:domain trustx:Certification ;
+  rdfs:range trustx:Framework ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:scope a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "certification scope"@en ;
+  rdfs:comment "What the issuer is certified to issue. Ranges over (i) trustx:AnyServiceScope (service-level — the honest DIATF granularity: DIATF certifies a SERVICE, not an attribute list), (ii) an attestation type / eIDAS Attestation Rulebook IRI, or (iii) a predicate set / SHACL shape — reusing trust:'s existing trust:forPredicate → trust:forShape desugaring rather than inventing a second scoping idiom (design §3.4). A hardwired attribute-level scope would misdescribe DIATF; omitting scope could not express 'only issued what certified to issue' (survey finding 1)."@en ;
+  rdfs:domain trustx:Certification ;
+  rdfs:range rdfs:Resource ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:validFrom a rdf:Property, owl:DatatypeProperty ;
+  rdfs:label "valid from"@en ;
+  rdfs:comment "Start of the certification's (or status attestation's) validity window (inclusive). Time-windowed by construction so a certification is checked at the evaluation instant exactly like a credential status (design §3.3 / §3.4)."@en ;
+  rdfs:domain trustx:Certification ;
+  rdfs:range xsd:dateTime ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:validUntil a rdf:Property, owl:DatatypeProperty ;
+  rdfs:label "valid until"@en ;
+  rdfs:comment "End of the certification's (or status attestation's) validity window (inclusive). A certification whose window does not cover the evaluation instant yields no admissible binding — fail-closed by construction, never by negation (design §3.3)."@en ;
+  rdfs:domain trustx:Certification ;
+  rdfs:range xsd:dateTime ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:AnyServiceScope a rdfs:Class, owl:Class ;
+  rdfs:label "Any-service scope"@en ;
+  rdfs:comment "The coarsest, service-level trustx:scope value: 'everything this certified service issues'. The HONEST DIATF granularity — DIATF certifies a service, not an attribute type (survey finding 1). A certification with this scope is scope-conformant for any contributing statement from the issuer; a spec that omitted this value could not faithfully describe DIATF."@en ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+# =============================================================================
+# Positive, time-windowed status attestation (design §3.3 / D3)
+# =============================================================================
+# Non-revocation is NEVER queried as absence. A trustx:StatusAttestation is a signed
+# statement by the status authority that a credential's (or certification's) status was
+# VALID in a window [validFrom, validUntil]. Realised on the clear path by the merged
+# signed Bitstring status-list machinery (SignedStatusList / VerifyingLiveStatusCheck /
+# justify_status_decision) and on the ZK path by the merged committed-index bit-unset
+# proof at an authoritative snapshot. The reference rewrite asks for the EXISTENCE of a
+# covering status attestation — monotone under OWA.
+
+trustx:StatusAttestation a rdfs:Class, owl:Class ;
+  rdfs:label "Status attestation"@en ;
+  rdfs:comment "A POSITIVE, time-windowed, authority-signed statement that a credential's (or certification's) status was valid in [trustx:validFrom, trustx:validUntil]. 'Unrevoked' is asked as the EXISTENCE of a covering status attestation at trustx:requiresValidStatusAt — never as absence of a revocation (OWA/monotonicity — the agreed #1592 constraint, design §3.3). IETF Token Status List (the eIDAS ARF mechanism) maps to this same shape. A revoked or stale-windowed credential simply yields no admissible binding (fail-closed by construction)."@en ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:coveredBy a rdf:Property, owl:ObjectProperty ;
+  rdfs:label "covered by"@en ;
+  rdfs:comment "Links a contributing statement's provenance reifier (design §4) to the trustx:StatusAttestation that covered it at the evaluation instant. Part of the machine-readable provenance the response carries so the verifier can re-check admissibility under the trust requirements (design §3.1)."@en ;
+  rdfs:range trustx:StatusAttestation ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+# =============================================================================
+# Framework individuals — thin, referencing the vendored sec-req: (design §9.4)
+# =============================================================================
+# These do NOT duplicate the vendored sec-req: regulatory-requirement individuals
+# (sec-req:Eidas20 / sec-req:UkDvs); they carry rdfs:seeAlso to them. sec-req: stays the
+# regulatory-requirement view; trustx: adds only the certification-mechanics view. No
+# vendored file is edited (the D5 no-duplication rule; design §9.4 default).
+
+trustx:eIDAS2 a trustx:Framework ;
+  rdfs:label "eIDAS 2.0 (EU Digital Identity Framework)"@en ;
+  rdfs:comment "The EU eIDAS 2.0 framework: issuer trust via Trusted Lists (PID/QEAA/PuB-EAA providers registered by a Registrar and notified to the Commission); attribute schemas via Attestation Rulebooks; revocation via status lists / identifier lists (IETF Token Status List is the ARF mechanism). Scope granularity: schema-level (Attestation Rulebook / attribute catalogue). Legal base: Regulation (EU) 2024/1183."@en ;
+  rdfs:seeAlso sec-req:Eidas20 ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .
+
+trustx:DIATF a trustx:Framework ;
+  rdfs:label "UK DIATF (Digital Identity and Attributes Trust Framework)"@en ;
+  rdfs:comment "The UK Digital Identity and Attributes Trust Framework: five certifiable roles (identity / attribute / holder / orchestration / component service providers); certification by an independent Conformity Assessment Body, valid three years, applying PER CERTIFIED SERVICE, not per attribute type; certified providers appear on the public register of digital identity and attribute services. Scope granularity: service-level (hence trustx:AnyServiceScope — survey finding 1). Referenced sec-req: individual is UK DVS (the UK Digital Verification Services requirement)."@en ;
+  rdfs:seeAlso sec-req:UkDvs ;
+  rdfs:isDefinedBy <https://sparq.dev/ns/trust-framework> .

--- a/crates/sparq-trust/src/framework_vocab.rs
+++ b/crates/sparq-trust/src/framework_vocab.rs
@@ -1,0 +1,483 @@
+//! # `framework_vocab` — the `trustx:` certification-scope vocabulary (Rust constants)
+//!
+//! The IRIs of the trust-expression program's **certification-scope layer** as Rust
+//! constants: the terms that let a verifier express *"certified issuers WITHIN the
+//! eIDAS / DIATF framework, that have only issued information they are certified to
+//! issue"* (issue #1592, decomposition record `research/trust-expression-spec.md` §3.4
+//! / D4). This module **extends** the [`crate::vocab`] `trust:` vocabulary (it shares
+//! the same placeholder base IRI, `https://sparq.dev/ns/trust#`, since `trustx:` is a
+//! prose-only sub-prefix of `trust:` — not a distinct namespace) and **references** the
+//! vendored `sec-req:` regulatory-framework individuals (eIDAS 2.0 / UK DVS) rather than
+//! duplicating them. It does **not** fork `trust:` and redeclares no `trust:` or
+//! `sec-req:` term (the design's D5 no-duplication rule).
+//!
+//! The three surfaces the layer adds over what the estate already had:
+//!
+//! - **The trust requirements** (`TRUSTX_TRUST_REQUIREMENTS` and its properties) — the
+//!   verifier→holder contract carrier: ONE small RDF graph binding a query to its trust
+//!   conditions (design §3.1 / D1). There is no new query syntax; the trust conditions
+//!   live in the requirements graph, never in the query.
+//! - **The two trust modes** — enumerated parties (`TRUSTX_TRUSTS_ISSUER`) and
+//!   framework-certified issuers (`TRUSTX_TRUSTS_FRAMEWORK`), composing by plain OR
+//!   (design §3.2 / D2).
+//! - **The certification-scope terms** (`TRUSTX_CERTIFICATION`, `TRUSTX_SCOPE`, …)
+//!   — an issuer being *certified under* a framework, over a *scope* that ranges from
+//!   service-level (`TRUSTX_ANY_SERVICE_SCOPE`, the honest DIATF granularity) down to
+//!   a predicate set / SHACL shape reusing the existing `trust:forShape` idiom
+//!   (design §3.4 / D4).
+//!
+//! ## What this vocabulary is — and is NOT (honesty, load-bearing)
+//!
+//! Framework-anchored trust is **anchored, not proven**. A `TRUSTX_CERTIFICATION`
+//! bottoms out in the framework operator's signed trusted-list / register artifacts —
+//! it is a *trust anchor*, not cryptography. The scope-conformance check constrains what
+//! the *verifier accepts* and, via the published certification, what the issuer was
+//! *authorised* to issue; it **cannot** retroactively prove an issuer never mis-issued
+//! elsewhere (design §7.2). No term here asserts a settled cryptographic soundness or
+//! privacy guarantee: the sparq ZK estate is internally re-audited but has **no external
+//! accredited-cryptographer sign-off** (open gate `sq-qhy4`), and `sparq-mpc` is
+//! honest-majority **semi-honest only**. Non-revocation is a *positive*, time-windowed
+//! status attestation (`TRUSTX_STATUS_ATTESTATION`) — existence of a covering window,
+//! never evidence-of-absence (OWA/monotonicity; design §3.3 / D3).
+//!
+//! ## Opt-in by construction
+//!
+//! This whole module (and the `trust-framework.ttl` it pins) is behind the **default-OFF
+//! `framework-vocab`** cargo feature, so it adds **nothing** to the lean default build —
+//! it is plain `const &str` data plus a test, no new dependency, strictly additive
+//! (the same discipline as [`crate::secprop`]).
+//!
+//! The canonical machine-readable form is
+//! `ontologies/trust/trust-framework.ttl`; the `framework_ttl_iris_match_rust_constants`
+//! test below keeps the published Turtle and these constants from drifting (the same
+//! discipline as [`crate::vocab`]).
+//!
+//! [FABLE-5] sq-6syab.2 (epic sq-6syab; issue #1592; design record
+//! `research/trust-expression-spec.md`). 🤖 SPARQ agent — trust-expression
+//! certification-scope layer.
+
+/// The `trust:` / `trustx:` namespace base (non-standard; a WG would rehome it). Shared
+/// with [`crate::vocab::TRUST_NS`] — `trustx:` extends `trust:` under the SAME base IRI.
+pub const TRUSTX_NS: &str = "https://sparq.dev/ns/trust#";
+
+/// The vendored `sec-req:` namespace (a real `w3id.org` permanent identifier). The
+/// framework individuals below `rdfs:seeAlso` its eIDAS / UK DVS requirement instances;
+/// this constant lets the sync test recognise those references as EXEMPT from the
+/// `trustx:`-declaration drift check (they are referenced, never redeclared).
+pub const SEC_REQ_NS: &str = "https://w3id.org/zkp-sparql/sec-req#";
+
+// ── the trust requirements — the verifier→holder contract carrier (design §3.1) ──
+
+/// `trustx:TrustRequirements` — the verifier→holder contract carrier: a small RDF graph
+/// binding a query to its trust conditions. The trust conditions live HERE, never in
+/// the query (no new query syntax — design §3.1 / D1).
+pub const TRUSTX_TRUST_REQUIREMENTS: &str = "https://sparq.dev/ns/trust#TrustRequirements";
+/// `trustx:question` — binds the trust requirements to the SPARQL query they scope.
+pub const TRUSTX_QUESTION: &str = "https://sparq.dev/ns/trust#question";
+/// `trustx:trustsIssuer` — **MODE 1** (enumerated parties): admit contributing
+/// statements issued by this enumerated issuer identity (a DID/key binding; the
+/// maintainer's `[X, Y and Z]` set). Composes with framework mode by plain OR.
+pub const TRUSTX_TRUSTS_ISSUER: &str = "https://sparq.dev/ns/trust#trustsIssuer";
+/// `trustx:trustsFramework` — **MODE 2** (framework-certified issuers): admit statements
+/// from issuers certified under this [`TRUSTX_FRAMEWORK`] (subject to scope conformance).
+pub const TRUSTX_TRUSTS_FRAMEWORK: &str = "https://sparq.dev/ns/trust#trustsFramework";
+/// `trustx:requiresScopeConformance` — when true (mode 2), require every contributing
+/// statement's type/predicate to fall under its issuer's certification scope valid at
+/// the evaluation time (the "only issued what certified to issue" check — design §3.4).
+pub const TRUSTX_REQUIRES_SCOPE_CONFORMANCE: &str =
+    "https://sparq.dev/ns/trust#requiresScopeConformance";
+/// `trustx:requiresValidStatusAt` — the instant *t* at which a covering positive
+/// [`TRUSTX_STATUS_ATTESTATION`] must hold. A verifier-chosen parameter, not a constant.
+pub const TRUSTX_REQUIRES_VALID_STATUS_AT: &str =
+    "https://sparq.dev/ns/trust#requiresValidStatusAt";
+/// `trustx:methodPolicy` — OPTIONAL reference to an ODRL policy consumed by the existing
+/// secprop/ODRL `admissible()` pre-check (which SOURCES vs which PROOF METHODS is an
+/// orthogonal axis; the spec references, not restates, that machinery — design §3.5).
+pub const TRUSTX_METHOD_POLICY: &str = "https://sparq.dev/ns/trust#methodPolicy";
+
+// ── the certification-scope layer (design §3.4 / D4) ─────────────────────────
+
+/// `trustx:Framework` — a governance framework operating a trusted-list / register
+/// (eIDAS 2.0's Trusted Lists, the UK DIATF register). The individuals
+/// [`TRUSTX_EIDAS2`] / [`TRUSTX_DIATF`] `rdfs:seeAlso` the vendored `sec-req:` ones.
+pub const TRUSTX_FRAMEWORK: &str = "https://sparq.dev/ns/trust#Framework";
+/// `trustx:Certification` — a time-windowed, authority-signed attestation that an issuer
+/// is certified under a framework. A Trusted-List / DIATF-register entry IS one.
+pub const TRUSTX_CERTIFICATION: &str = "https://sparq.dev/ns/trust#Certification";
+/// `trustx:certifies` — the issuer identity (DID/key) a certification certifies.
+pub const TRUSTX_CERTIFIES: &str = "https://sparq.dev/ns/trust#certifies";
+/// `trustx:underFramework` — the [`TRUSTX_FRAMEWORK`] a certification is issued under.
+pub const TRUSTX_UNDER_FRAMEWORK: &str = "https://sparq.dev/ns/trust#underFramework";
+/// `trustx:scope` — what the issuer is certified to issue: service-level
+/// ([`TRUSTX_ANY_SERVICE_SCOPE`], the honest DIATF granularity), an attestation-type /
+/// Rulebook IRI, or a predicate set / SHACL shape (reusing `trust:forShape`). Distinct
+/// from `trust:scope` (rule applicability) — the certification-scope reading.
+pub const TRUSTX_SCOPE: &str = "https://sparq.dev/ns/trust#scope";
+/// `trustx:validFrom` — start of a certification's / status attestation's validity
+/// window (inclusive).
+pub const TRUSTX_VALID_FROM: &str = "https://sparq.dev/ns/trust#validFrom";
+/// `trustx:validUntil` — end of a certification's / status attestation's validity
+/// window (inclusive).
+pub const TRUSTX_VALID_UNTIL: &str = "https://sparq.dev/ns/trust#validUntil";
+/// `trustx:AnyServiceScope` — the coarsest, service-level [`TRUSTX_SCOPE`] value
+/// ("everything this certified service issues"), the honest DIATF granularity.
+pub const TRUSTX_ANY_SERVICE_SCOPE: &str = "https://sparq.dev/ns/trust#AnyServiceScope";
+
+// ── positive, time-windowed status attestation (design §3.3 / D3) ────────────
+
+/// `trustx:StatusAttestation` — a POSITIVE, time-windowed, authority-signed statement
+/// that a credential's / certification's status was valid in `[validFrom, validUntil]`.
+/// "Unrevoked" is asked as EXISTENCE of a covering attestation, never as absence of a
+/// revocation (OWA/monotonicity — the agreed #1592 constraint).
+pub const TRUSTX_STATUS_ATTESTATION: &str = "https://sparq.dev/ns/trust#StatusAttestation";
+/// `trustx:coveredBy` — links a contributing statement's provenance reifier to the
+/// [`TRUSTX_STATUS_ATTESTATION`] that covered it at the evaluation instant.
+pub const TRUSTX_COVERED_BY: &str = "https://sparq.dev/ns/trust#coveredBy";
+
+// ── framework individuals — thin, referencing the vendored sec-req: ──────────
+
+/// `trustx:eIDAS2` — the eIDAS 2.0 framework individual; `rdfs:seeAlso`
+/// `sec-req:Eidas20` (schema-level scope granularity via Attestation Rulebooks).
+pub const TRUSTX_EIDAS2: &str = "https://sparq.dev/ns/trust#eIDAS2";
+/// `trustx:DIATF` — the UK DIATF framework individual; `rdfs:seeAlso` `sec-req:UkDvs`
+/// (service-level scope granularity — hence [`TRUSTX_ANY_SERVICE_SCOPE`]).
+pub const TRUSTX_DIATF: &str = "https://sparq.dev/ns/trust#DIATF";
+
+/// The vendored `sec-req:` regulatory-requirement individual for eIDAS 2.0 — the
+/// existing instance [`TRUSTX_EIDAS2`] `rdfs:seeAlso`s (NOT redeclared here; no
+/// duplication of the vendored file — design's D5).
+pub const SEC_REQ_EIDAS20: &str = "https://w3id.org/zkp-sparql/sec-req#Eidas20";
+/// The vendored `sec-req:` regulatory-requirement individual for UK DVS — the existing
+/// instance [`TRUSTX_DIATF`] `rdfs:seeAlso`s (NOT redeclared here; no duplication).
+pub const SEC_REQ_UK_DVS: &str = "https://w3id.org/zkp-sparql/sec-req#UkDvs";
+
+/// Every `trustx:` IRI this module mints (the certification-scope layer), plus the two
+/// vendored `sec-req:` individuals the framework instances reference. The single source
+/// of truth the `tests` drift-check iterates — keeping the published
+/// `trust-framework.ttl` and these constants from diverging (the [`crate::vocab`] and
+/// [`crate::secprop`] discipline).
+pub const ALL_TRUSTX_IRIS: &[&str] = &[
+    // trust requirements
+    TRUSTX_TRUST_REQUIREMENTS,
+    TRUSTX_QUESTION,
+    TRUSTX_TRUSTS_ISSUER,
+    TRUSTX_TRUSTS_FRAMEWORK,
+    TRUSTX_REQUIRES_SCOPE_CONFORMANCE,
+    TRUSTX_REQUIRES_VALID_STATUS_AT,
+    TRUSTX_METHOD_POLICY,
+    // certification-scope layer
+    TRUSTX_FRAMEWORK,
+    TRUSTX_CERTIFICATION,
+    TRUSTX_CERTIFIES,
+    TRUSTX_UNDER_FRAMEWORK,
+    TRUSTX_SCOPE,
+    TRUSTX_VALID_FROM,
+    TRUSTX_VALID_UNTIL,
+    TRUSTX_ANY_SERVICE_SCOPE,
+    // status attestation
+    TRUSTX_STATUS_ATTESTATION,
+    TRUSTX_COVERED_BY,
+    // framework individuals (trustx:)
+    TRUSTX_EIDAS2,
+    TRUSTX_DIATF,
+    // referenced vendored sec-req: individuals (NOT redeclared in trust-framework.ttl)
+    SEC_REQ_EIDAS20,
+    SEC_REQ_UK_DVS,
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The machine-readable `trust-framework.ttl` is the canonical form; keep it pinned
+    /// to these constants so the two cannot drift (the [`crate::vocab`] discipline).
+    const TTL: &str = include_str!("../ontologies/trust/trust-framework.ttl");
+    /// The `trust:` vocabulary this layer extends — read to assert non-duplication.
+    const TRUST_TTL: &str = include_str!("../ontologies/trust/trust.ttl");
+
+    /// The two vendored `sec-req:` individuals are REFERENCED (`rdfs:seeAlso`), never
+    /// redeclared as `trustx:` subjects, so they are exempt from the declared-subject
+    /// check below.
+    const SEC_REQ_REFERENCED_ONLY: &[&str] = &[SEC_REQ_EIDAS20, SEC_REQ_UK_DVS];
+
+    /// Every `trustx:` constant lives in the shared `trust:` base namespace; the two
+    /// vendored references live in the `sec-req:` namespace.
+    #[test]
+    fn all_constants_are_in_a_known_namespace() {
+        for &iri in ALL_TRUSTX_IRIS {
+            assert!(
+                iri.starts_with(TRUSTX_NS) || iri.starts_with(SEC_REQ_NS),
+                "constant `{}` is not in the trust: or sec-req: namespace",
+                iri,
+            );
+        }
+        // The referenced-only set is exactly the sec-req: constants.
+        for &iri in SEC_REQ_REFERENCED_ONLY {
+            assert!(
+                iri.starts_with(SEC_REQ_NS),
+                "referenced-only constant `{}` is not in the sec-req: namespace",
+                iri,
+            );
+        }
+    }
+
+    /// No duplicate IRI in the registry (a copy-paste guard).
+    #[test]
+    fn no_duplicate_iris() {
+        let mut seen = std::collections::HashSet::new();
+        for &iri in ALL_TRUSTX_IRIS {
+            assert!(
+                seen.insert(iri),
+                "duplicate IRI in ALL_TRUSTX_IRIS: {}",
+                iri,
+            );
+        }
+    }
+
+    /// Every minted `trustx:` constant is declared in `trust-framework.ttl` as a
+    /// `trustx:LocalName` subject (a `trustx:Foo a …` declaration). The vendored
+    /// `sec-req:` individuals are referenced (`rdfs:seeAlso`), not subjects of a fresh
+    /// declaration, so they are exempt.
+    #[test]
+    fn framework_ttl_iris_match_rust_constants() {
+        for &iri in ALL_TRUSTX_IRIS {
+            if SEC_REQ_REFERENCED_ONLY.contains(&iri) {
+                continue;
+            }
+            let local = iri
+                .strip_prefix(TRUSTX_NS)
+                .expect("every minted constant is in the trust: namespace");
+            let decl = format!("trustx:{} a ", local);
+            assert!(
+                TTL.contains(&decl),
+                "trust-framework.ttl is missing a declaration for `trustx:{}` ({}) — \
+                 the published vocabulary drifted from the Rust constants (sq-6syab.2)",
+                local,
+                iri,
+            );
+        }
+    }
+
+    /// And every `trustx:LocalName a` declaration in the Turtle is backed by a Rust
+    /// constant — no published term without a constant. Scans start-of-line
+    /// `trustx:Foo a …` subjects, the inverse check (the [`crate::vocab`] discipline).
+    #[test]
+    fn every_ttl_term_has_a_rust_constant() {
+        let declared_locals: Vec<&str> = TTL
+            .lines()
+            .filter_map(|line| {
+                let t = line.trim_start();
+                let rest = t.strip_prefix("trustx:")?;
+                // Skip a bare-namespace metadata line (no local name), if any.
+                if rest.starts_with(char::is_whitespace) {
+                    return None;
+                }
+                let name = rest.split_whitespace().next()?;
+                // A term declaration line looks like `trustx:Foo a …`.
+                if rest[name.len()..].trim_start().starts_with("a ") {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        assert!(
+            !declared_locals.is_empty(),
+            "no trustx: term declarations found in trust-framework.ttl — parser/format drift",
+        );
+
+        let constant_locals: std::collections::HashSet<&str> = ALL_TRUSTX_IRIS
+            .iter()
+            .filter_map(|iri| iri.strip_prefix(TRUSTX_NS))
+            .collect();
+
+        for local in declared_locals {
+            assert!(
+                constant_locals.contains(local),
+                "trust-framework.ttl declares `trustx:{}` but no Rust constant names it — \
+                 add the constant or remove the term (sq-6syab.2)",
+                local,
+            );
+        }
+    }
+
+    /// D5 no-duplication: this extension REDECLARES no `trust:` core term. Every
+    /// `trustx:LocalName` declared here must be a NEW local name — never one already
+    /// declared in `trust.ttl` — with the sole, deliberate exception of `scope`, which
+    /// `trust:` uses for rule-applicability and `trustx:` reuses (under the shared base)
+    /// for the distinct certification-scope reading (documented on the constant).
+    #[test]
+    fn extends_trust_without_redeclaring_its_terms() {
+        // The `trust:` core local names (from trust.ttl `trust:Foo a …` declarations).
+        let trust_locals: std::collections::HashSet<&str> = TRUST_TTL
+            .lines()
+            .filter_map(|line| {
+                let rest = line.trim_start().strip_prefix("trust:")?;
+                if rest.starts_with(char::is_whitespace) {
+                    return None;
+                }
+                let name = rest.split_whitespace().next()?;
+                if rest[name.len()..].trim_start().starts_with("a ") {
+                    Some(name)
+                } else {
+                    None
+                }
+            })
+            .collect();
+        assert!(
+            trust_locals.contains("forShape"),
+            "sanity: trust.ttl should declare trust:forShape",
+        );
+
+        // `scope` is the ONE deliberately-shared local name (distinct reading; see the
+        // TRUSTX_SCOPE doc-comment). Everything else the framework layer mints must be a
+        // NEW local name not already a trust: core term.
+        for &iri in ALL_TRUSTX_IRIS {
+            let Some(local) = iri.strip_prefix(TRUSTX_NS) else {
+                continue; // sec-req: reference, not a trust: base term
+            };
+            if local == "scope" {
+                continue;
+            }
+            assert!(
+                !trust_locals.contains(local),
+                "trustx:{} would REDECLARE a trust: core term — the D5 no-duplication \
+                 rule forbids forking trust: (sq-6syab.2)",
+                local,
+            );
+        }
+    }
+
+    /// The framework individuals REFERENCE the vendored `sec-req:` individuals via
+    /// `rdfs:seeAlso` and do NOT duplicate them: the referenced IRIs appear in the
+    /// Turtle as `rdfs:seeAlso` objects, and the vendored `sec-req:` file is never
+    /// edited (asserted structurally — the Turtle carries the seeAlso links).
+    #[test]
+    fn framework_individuals_reference_vendored_sec_req() {
+        for &iri in SEC_REQ_REFERENCED_ONLY {
+            let local = iri
+                .strip_prefix(SEC_REQ_NS)
+                .expect("referenced individual is in the sec-req: namespace");
+            let see_also = format!("rdfs:seeAlso sec-req:{}", local);
+            assert!(
+                TTL.contains(&see_also),
+                "trust-framework.ttl must rdfs:seeAlso the vendored `sec-req:{}` \
+                 individual (no duplication — design D5)",
+                local,
+            );
+            // And it must NOT be redeclared as a subject in this extension file.
+            let redecl = format!("sec-req:{} a ", local);
+            assert!(
+                !TTL.contains(&redecl),
+                "trust-framework.ttl must NOT redeclare the vendored `sec-req:{}` \
+                 individual (no duplication — design D5)",
+                local,
+            );
+        }
+    }
+
+    /// The honesty banner (framework trust is ANCHORED, not proven; the open external
+    /// audit gate `sq-qhy4`) is documented in the Turtle — a load-bearing honesty
+    /// invariant of the vocabulary (the [`crate::secprop`] audit-gate discipline).
+    #[test]
+    fn anchored_not_proven_and_audit_gate_are_documented() {
+        assert!(
+            TTL.contains("sq-qhy4"),
+            "trust-framework.ttl must reference the open external-audit gate (sq-qhy4)",
+        );
+        assert!(
+            TTL.contains("ANCHORED, NOT PROVEN") || TTL.contains("anchored, not proven"),
+            "trust-framework.ttl must document that framework trust is anchored, not proven",
+        );
+        assert!(
+            TTL.contains("NON-STANDARD"),
+            "trust-framework.ttl must carry the NON-STANDARD placeholder-namespace banner",
+        );
+    }
+
+    // ── one DIRECT unit test per new public constant (coverage-ratchet rule) ──
+    // Each asserts the exact IRI a caller depends on (local name under the correct
+    // base), so a rename that silently changed a wire-visible IRI is caught here as a
+    // direct-coverage failure, not only through the aggregate drift test.
+
+    #[test]
+    fn trustx_ns_is_the_shared_trust_base() {
+        assert_eq!(TRUSTX_NS, "https://sparq.dev/ns/trust#");
+    }
+
+    #[test]
+    fn sec_req_ns_is_the_vendored_w3id_base() {
+        assert_eq!(SEC_REQ_NS, "https://w3id.org/zkp-sparql/sec-req#");
+    }
+
+    #[test]
+    fn trust_requirements_iris_are_stable() {
+        assert_eq!(
+            TRUSTX_TRUST_REQUIREMENTS,
+            "https://sparq.dev/ns/trust#TrustRequirements"
+        );
+        assert_eq!(TRUSTX_QUESTION, "https://sparq.dev/ns/trust#question");
+        assert_eq!(TRUSTX_TRUSTS_ISSUER, "https://sparq.dev/ns/trust#trustsIssuer");
+        assert_eq!(
+            TRUSTX_TRUSTS_FRAMEWORK,
+            "https://sparq.dev/ns/trust#trustsFramework"
+        );
+        assert_eq!(
+            TRUSTX_REQUIRES_SCOPE_CONFORMANCE,
+            "https://sparq.dev/ns/trust#requiresScopeConformance"
+        );
+        assert_eq!(
+            TRUSTX_REQUIRES_VALID_STATUS_AT,
+            "https://sparq.dev/ns/trust#requiresValidStatusAt"
+        );
+        assert_eq!(TRUSTX_METHOD_POLICY, "https://sparq.dev/ns/trust#methodPolicy");
+    }
+
+    #[test]
+    fn certification_scope_iris_are_stable() {
+        assert_eq!(TRUSTX_FRAMEWORK, "https://sparq.dev/ns/trust#Framework");
+        assert_eq!(TRUSTX_CERTIFICATION, "https://sparq.dev/ns/trust#Certification");
+        assert_eq!(TRUSTX_CERTIFIES, "https://sparq.dev/ns/trust#certifies");
+        assert_eq!(
+            TRUSTX_UNDER_FRAMEWORK,
+            "https://sparq.dev/ns/trust#underFramework"
+        );
+        assert_eq!(TRUSTX_SCOPE, "https://sparq.dev/ns/trust#scope");
+        assert_eq!(TRUSTX_VALID_FROM, "https://sparq.dev/ns/trust#validFrom");
+        assert_eq!(TRUSTX_VALID_UNTIL, "https://sparq.dev/ns/trust#validUntil");
+        assert_eq!(
+            TRUSTX_ANY_SERVICE_SCOPE,
+            "https://sparq.dev/ns/trust#AnyServiceScope"
+        );
+    }
+
+    #[test]
+    fn status_attestation_iris_are_stable() {
+        assert_eq!(
+            TRUSTX_STATUS_ATTESTATION,
+            "https://sparq.dev/ns/trust#StatusAttestation"
+        );
+        assert_eq!(TRUSTX_COVERED_BY, "https://sparq.dev/ns/trust#coveredBy");
+    }
+
+    #[test]
+    fn framework_individual_iris_are_stable() {
+        assert_eq!(TRUSTX_EIDAS2, "https://sparq.dev/ns/trust#eIDAS2");
+        assert_eq!(TRUSTX_DIATF, "https://sparq.dev/ns/trust#DIATF");
+        assert_eq!(SEC_REQ_EIDAS20, "https://w3id.org/zkp-sparql/sec-req#Eidas20");
+        assert_eq!(SEC_REQ_UK_DVS, "https://w3id.org/zkp-sparql/sec-req#UkDvs");
+    }
+
+    #[test]
+    fn all_trustx_iris_registry_is_complete() {
+        // The registry must list every public constant above (21 total: 19 trustx: +
+        // 2 sec-req: references). A guard against a new constant that the drift test
+        // would then silently not cover.
+        assert_eq!(
+            ALL_TRUSTX_IRIS.len(),
+            21,
+            "ALL_TRUSTX_IRIS must list every minted constant + the 2 sec-req: references",
+        );
+    }
+}

--- a/crates/sparq-trust/src/lib.rs
+++ b/crates/sparq-trust/src/lib.rs
@@ -147,6 +147,18 @@ pub mod admissibility;
 #[cfg(feature = "secprop-vocab")]
 #[cfg_attr(docsrs, doc(cfg(feature = "secprop-vocab")))]
 pub mod secprop;
+/// The `trustx:` certification-scope vocabulary (`framework_vocab` module +
+/// `trust-framework.ttl`) — the trust-expression program's layer for expressing
+/// framework-certified-issuer trust and issuer certification scope over the
+/// verifier→holder trust requirements (issue #1592; design record
+/// `research/trust-expression-spec.md` §3.4 / D4). It EXTENDS the `trust:` vocabulary
+/// (shared base IRI) and REFERENCES the vendored `sec-req:` eIDAS/UK-DVS individuals via
+/// `rdfs:seeAlso` — it does not fork or duplicate them (the design's D5). Behind the
+/// default-OFF `framework-vocab` feature: `const &str` data + a TTL drift test, no new
+/// dependency, strictly additive.
+#[cfg(feature = "framework-vocab")]
+#[cfg_attr(docsrs, doc(cfg(feature = "framework-vocab")))]
+pub mod framework_vocab;
 /// The trust-document storage / authoring model — server-wide vs per-`.acr` documents,
 /// versioning, revocation, and the admission cache key that composes with the
 /// sparq-solid epoch cache (the P4 model, `sq-pfae.5`). Behind the default-OFF `store`

--- a/crates/sparq-trust/tests/trust_framework_ttl.rs
+++ b/crates/sparq-trust/tests/trust_framework_ttl.rs
@@ -1,0 +1,160 @@
+//! Parse-validation of the published machine-readable certification-scope vocabulary
+//! `ontologies/trust/trust-framework.ttl` (sq-6syab.2; epic sq-6syab / issue #1592;
+//! design record `research/trust-expression-spec.md` §3.4 / D4). The
+//! `framework_vocab::tests` unit tests pin the IRIs against the Rust constants (the
+//! *string* guard); this test is the *syntactic + structural* guard — the Turtle a
+//! working group reads MUST stay valid Turtle, declare the `trustx:` terms, `owl:imports`
+//! the `trust:` vocabulary it extends, and `rdfs:seeAlso` the vendored `sec-req:`
+//! eIDAS/UK-DVS individuals rather than duplicating them (the design's D5).
+//!
+//! Behind the default-OFF `framework-vocab` feature, exactly like the module it guards.
+//!
+//! [FABLE-5] sq-6syab.2 (issue #1592). 🤖 SPARQ agent — trust-expression
+//! certification-scope layer.
+#![cfg(feature = "framework-vocab")]
+
+use oxrdf::{NamedOrBlankNode, Term};
+use oxttl::TurtleParser;
+
+const TTL: &str = include_str!("../ontologies/trust/trust-framework.ttl");
+
+const TRUSTX_NS: &str = "https://sparq.dev/ns/trust#";
+const SEC_REQ_NS: &str = "https://w3id.org/zkp-sparql/sec-req#";
+const RDFS_SEE_ALSO: &str = "http://www.w3.org/2000/01/rdf-schema#seeAlso";
+const OWL_IMPORTS: &str = "http://www.w3.org/2002/07/owl#imports";
+const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
+/// The published vocabulary is valid Turtle (parses without error) and is non-empty.
+#[test]
+fn trust_framework_ttl_is_valid_turtle() {
+    let mut triples = 0usize;
+    for result in TurtleParser::new().for_reader(TTL.as_bytes()) {
+        result.expect("trust-framework.ttl must be valid Turtle");
+        triples += 1;
+    }
+    assert!(
+        triples > 0,
+        "trust-framework.ttl parsed to zero triples — the published vocabulary is empty",
+    );
+}
+
+/// Every `trustx:` term the layer mints is declared in the Turtle as a subject — a
+/// coarse presence check independent of the unit-test constant pinning, so a refactor of
+/// `framework_vocab.rs` cannot silently drop a published term from the gate.
+#[test]
+fn trust_framework_ttl_declares_all_trustx_terms() {
+    let expected = [
+        // trust requirements
+        "TrustRequirements",
+        "question",
+        "trustsIssuer",
+        "trustsFramework",
+        "requiresScopeConformance",
+        "requiresValidStatusAt",
+        "methodPolicy",
+        // certification-scope layer
+        "Framework",
+        "Certification",
+        "certifies",
+        "underFramework",
+        "scope",
+        "validFrom",
+        "validUntil",
+        "AnyServiceScope",
+        // status attestation
+        "StatusAttestation",
+        "coveredBy",
+        // framework individuals
+        "eIDAS2",
+        "DIATF",
+    ];
+
+    let mut subjects = std::collections::HashSet::new();
+    for result in TurtleParser::new().for_reader(TTL.as_bytes()) {
+        let t = result.expect("valid Turtle");
+        if let NamedOrBlankNode::NamedNode(s) = t.subject {
+            subjects.insert(s.into_string());
+        }
+    }
+    for local in expected {
+        let iri = format!("{TRUSTX_NS}{local}");
+        assert!(
+            subjects.contains(&iri),
+            "trust-framework.ttl does not declare `trustx:{local}` ({iri}) as a subject",
+        );
+    }
+}
+
+/// The framework individuals `rdfs:seeAlso` the vendored `sec-req:` eIDAS/UK-DVS
+/// individuals (no duplication — design D5), and the ontology node `owl:imports` the
+/// `trust:` vocabulary it extends. Both are verified against the PARSED graph, not a
+/// substring — the real invariant the design pins.
+#[test]
+fn extends_trust_and_references_vendored_sec_req_in_the_parsed_graph() {
+    let mut see_also_objects: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut import_objects: std::collections::HashSet<String> = std::collections::HashSet::new();
+    // eIDAS2 → sec-req:Eidas20, DIATF → sec-req:UkDvs, both by subject+object.
+    let mut eidas_sees_vendored = false;
+    let mut diatf_sees_vendored = false;
+
+    for result in TurtleParser::new().for_reader(TTL.as_bytes()) {
+        let t = result.expect("valid Turtle");
+        let pred = t.predicate.as_str().to_owned();
+        if pred == RDFS_SEE_ALSO {
+            if let Term::NamedNode(o) = &t.object {
+                see_also_objects.insert(o.as_str().to_owned());
+                if let NamedOrBlankNode::NamedNode(s) = &t.subject {
+                    if s.as_str() == format!("{TRUSTX_NS}eIDAS2")
+                        && o.as_str() == format!("{SEC_REQ_NS}Eidas20")
+                    {
+                        eidas_sees_vendored = true;
+                    }
+                    if s.as_str() == format!("{TRUSTX_NS}DIATF")
+                        && o.as_str() == format!("{SEC_REQ_NS}UkDvs")
+                    {
+                        diatf_sees_vendored = true;
+                    }
+                }
+            }
+        }
+        if pred == OWL_IMPORTS {
+            if let Term::NamedNode(o) = &t.object {
+                import_objects.insert(o.as_str().to_owned());
+            }
+        }
+    }
+
+    assert!(
+        eidas_sees_vendored,
+        "trustx:eIDAS2 must rdfs:seeAlso the vendored sec-req:Eidas20 (no duplication — D5)",
+    );
+    assert!(
+        diatf_sees_vendored,
+        "trustx:DIATF must rdfs:seeAlso the vendored sec-req:UkDvs (no duplication — D5)",
+    );
+    assert!(
+        import_objects.contains("https://sparq.dev/ns/trust"),
+        "the framework ontology node must owl:imports the trust: vocabulary it extends",
+    );
+}
+
+/// No vendored `sec-req:` individual is REDECLARED (given an `rdf:type`) in this
+/// extension file — they are referenced only. Verified on the parsed graph: no triple
+/// has a `sec-req:` subject with predicate `rdf:type` (the D5 no-duplication invariant).
+#[test]
+fn does_not_redeclare_vendored_sec_req_individuals() {
+    for result in TurtleParser::new().for_reader(TTL.as_bytes()) {
+        let t = result.expect("valid Turtle");
+        if let NamedOrBlankNode::NamedNode(s) = &t.subject {
+            if s.as_str().starts_with(SEC_REQ_NS) {
+                assert_ne!(
+                    t.predicate.as_str(),
+                    RDF_TYPE,
+                    "trust-framework.ttl redeclares (types) the vendored `{}` — the D5 \
+                     no-duplication rule forbids editing/duplicating vendored sec-req:",
+                    s.as_str(),
+                );
+            }
+        }
+    }
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -568,7 +568,7 @@ SAME `Vec<TrustRule>` the gate consumes:
 
 Both install on top of the unchanged auth view (the ODRL-bridge precedent). The
 public surface is `sparq_trust::{vocab, policy, admit, wire, delegation}` (+ the opt-in
-`delegation_prov` / `did` / `store` / `secprop` modules) — see
+`delegation_prov` / `did` / `store` / `secprop` / `framework_vocab` modules) — see
 [`crates/sparq-trust/README.md`](../../crates/sparq-trust/README.md) and the design record
 `research/solid-trust-graph-authz-design.md` §6.0 (tracked in
 [issue #940](https://github.com/jeswr/sparq/issues/940); landing via design PR
@@ -646,6 +646,40 @@ sparq ZK method may be labelled `secx:Proven` while the external accredited-cryp
 (`sq-qhy4`) is open.** The vocabulary **records** a claim and its epistemic basis; it is **NOT** a
 proof of any property. DPV alignment is *Light* (#1002 Option 2): `skos:closeMatch` cross-refs to
 W3C DPV `CryptographicMethods` where a near-match exists, not a full regulation→requirement chain.
+
+### `trustx:` certification-scope vocabulary — opt-in `framework-vocab` ([FABLE-5] sq-6syab.2, issue #1592)
+
+The `sparq_trust::framework_vocab` module (behind the **default-OFF `framework-vocab`** cargo feature)
+is the trust-expression program's **certification-scope layer** (design record
+`research/trust-expression-spec.md` §3.4 / D4): the vocabulary a verifier uses to ask *"prove X can be
+attested by unrevoked attributes issued by parties [X, Y, Z] OR by certified issuers WITHIN the eIDAS /
+DIATF framework, that have only issued what they are certified to issue"* (#1592). It **extends** the
+`trust:` vocabulary (shared `https://sparq.dev/ns/trust#` base — `trustx:` is a prose sub-prefix, not a
+new namespace) and **`rdfs:seeAlso`s** the vendored `sec-req:` eIDAS 2.0 / UK-DVS individuals rather than
+duplicating them (extend, do not fork; the design's D5). Like `secprop`, it is **data + Rust constants
+only** — a `const &str` registry (`ALL_TRUSTX_IRIS`) pinned to the canonical
+[`trust-framework.ttl`](../../crates/sparq-trust/ontologies/trust/trust-framework.ttl) by a byte-drift
+test — **not** an evaluator (the holder-side contract evaluation is the later, `sq-3kd2g`-gated
+`sq-6syab.4`).
+
+The three surfaces the layer names: (1) the **trust requirements** (`trustx:TrustRequirements` + `question` /
+`trustsIssuer` / `trustsFramework` / `requiresScopeConformance` / `requiresValidStatusAt`) — the
+verifier→holder contract carrier; the trust conditions live in the requirements graph, **not** in the query (no
+new query syntax); (2) the **two trust modes** — enumerated parties (`trustsIssuer`) OR
+framework-certified issuers (`trustsFramework`), composing by plain OR; (3) the **certification-scope
+terms** (`trustx:Certification` + `certifies` / `underFramework` / `scope` / `validFrom` / `validUntil`),
+where `scope` ranges from service-level (`trustx:AnyServiceScope`, the honest DIATF granularity — DIATF
+certifies a *service*, not an attribute list) down to a predicate set / SHACL shape reusing the existing
+`trust:forShape` idiom. Non-revocation is a **positive**, time-windowed `trustx:StatusAttestation` —
+existence of a covering window at `requiresValidStatusAt`, never evidence-of-absence (OWA/monotonicity).
+
+**Honesty (load-bearing):** framework-anchored trust is **anchored, not proven** — a
+`trustx:Certification` bottoms out in the framework operator's signed trusted-list / register artifacts
+(a trust anchor, not cryptography); the scope-conformance check constrains what the *verifier accepts*
+and, via the published certification, what the issuer was *authorised* to issue, but cannot retroactively
+prove an issuer never mis-issued elsewhere. **No term asserts a settled cryptographic soundness or
+privacy guarantee** (`sq-qhy4` external audit open; `sparq-mpc` semi-honest only). All `trustx:` IRIs are
+**NON-STANDARD** placeholders a WG would rehome.
 
 ### N3 proof-admissibility ruleset — opt-in `secprop-admissibility` ([OPUS-4.8] sq-ufsi9, Phase 2)
 


### PR DESCRIPTION
> 🤖 SPARQ agent — this PR was prepared by an automated SPARQ agent on the Fable-tier collaboration program. Resumed from a prior agent's in-progress worktree; the load-bearing delta of this session is the terminology fix below.

Implements **`sq-6syab.2`** — the `trustx:` **certification-scope vocabulary**, the trust-expression program's layer for expressing framework-certified-issuer trust and issuer certification scope (issue #1592; design record `research/trust-expression-spec.md` §3.4 / D4). Opt-in behind the **default-OFF `framework-vocab`** cargo feature — nothing is added to the lean default build.

## What landed

- **`crates/sparq-trust/ontologies/trust/trust-framework.ttl`** — the canonical machine-readable `trustx:` terms:
  - the verifier→holder **trust-requirements** carrier (`trustx:TrustRequirements` + `question` / `trustsIssuer` / `trustsFramework` / `requiresScopeConformance` / `requiresValidStatusAt`) — the trust conditions live in the requirements graph, never in the query (no new query syntax);
  - the **two trust modes** — enumerated parties (`trustsIssuer`) OR framework-certified issuers (`trustsFramework`), composing by plain OR;
  - the **certification-scope layer** (`trustx:Certification` + `certifies` / `underFramework` / `scope` / `validFrom` / `validUntil`; `trustx:AnyServiceScope` for the honest DIATF service-level granularity);
  - the **positive, time-windowed** `trustx:StatusAttestation` — non-revocation is existence of a covering window, never absence (OWA/monotonicity).
  - It `owl:imports` the `trust:` vocabulary it **EXTENDS** and `rdfs:seeAlso`s the vendored `sec-req:` eIDAS 2.0 / UK-DVS individuals — **no fork, no duplication** (design D5).
- **`crates/sparq-trust/src/framework_vocab.rs`** — the IRIs as `const &str`, byte-pinned to the Turtle by the `framework_ttl_iris_match_rust_constants` drift/sync test, plus one direct unit test per public-constant group.
- **`crates/sparq-trust/tests/trust_framework_ttl.rs`** — parses the published Turtle and checks it declares every `trustx:` term, `owl:imports` `trust:`, and `rdfs:seeAlso`s (without redeclaring) the vendored `sec-req:` individuals.
- README + `skills/access-control/SKILL.md` document the feature, semantics, and honest boundary.

## Terminology fix (this session's delta)

The prior agent's in-progress worktree used the term **"trust envelope"** throughout; the maintainer **banned** that term on 2026-07-06 in favour of **"trust requirements"**. This PR renames the `trustx:TrustEnvelope` class → `trustx:TrustRequirements`, the constant `TRUSTX_TRUST_ENVELOPE` → `TRUSTX_TRUST_REQUIREMENTS`, and every prose reference across the TTL / Rust / README / SKILL. (The unrelated vendored "SD-JWT envelope" JOSE terminology in `sig-impl.yaml.ld` is a distinct, legitimate cryptographic term and is untouched.)

## Honesty (load-bearing)

Framework-anchored trust is **anchored, not proven** — a `trustx:Certification` bottoms out in the framework operator's signed trusted-list / register artifacts, a *trust anchor*, not cryptography. The scope-conformance check constrains what the *verifier accepts* and, via the published certification, what the issuer was *authorised* to issue, but cannot retroactively prove an issuer never mis-issued elsewhere. **No term asserts a settled cryptographic soundness or privacy guarantee** — the sparq ZK estate is internally re-audited but has **no external accredited-cryptographer sign-off** (open gate `sq-qhy4`), and `sparq-mpc` is honest-majority **semi-honest only**. All `trustx:` IRIs are **NON-STANDARD** placeholders a WG would rehome. A `framework_vocab` unit test asserts this banner is present in the Turtle.

## Gates (all run in-worktree)

Feature flag: **`framework-vocab`** (default OFF).

| Gate | Feature OFF | Feature ON |
|---|---|---|
| `cargo build -p sparq-trust` | green | green |
| `cargo clippy -p sparq-trust --all-targets -- -D warnings` | green | green |
| `cargo test -p sparq-trust` | green (2) | green (14 unit + 2 ttl + rest) |
| rustdoc (default, `RUSTDOCFLAGS=-D warnings`) | green | — |
| rustdoc (`--all-features`, `RUSTDOCFLAGS=-D warnings`) | green (bundled `clippy (gate)` half) | — |
| `scripts/check-readme-template.py --enforce` | 0 deviations (README = 120 lines) | — |

The vocabulary is dependency-free `const &str` data + a drift test — no new dependency, no new edge onto the default build.

Refs `sq-6syab.2`, #1592. Not self-armed (no `--auto`) — leaving to the orchestrator per the shared contract.