### PR TITLE
perf(solid): &self read-side + bounded sharded session cache (sq-cnuqd, #1569)

### DIFF
--- a/crates/sparq-solid/README.md
+++ b/crates/sparq-solid/README.md
@@ -52,6 +52,9 @@ let _public_only = store.query_as(&Session::default(), Mode::Read, q)?.rows.len(
 - **Trust-graph admission PoC (opt-in `trust-graph`, research — NOT a security guarantee)** — a
   [`sparq-trust`](../sparq-trust) admission stratum injects an issuer-signed, trusted-source-scoped
   credential fact ahead of the materialiser; OFF = byte-identical WAC/ACP. No privacy/ZK (`sq-qhy4` unaudited).
+- **Concurrent reads (`&self`, no feature flag)** — every read entry point (`accessible`, `view_for`,
+  `query_as`/`query_json_as`/`ask_as`, `wac_allow`) takes `&self`, so N threads sharing one `Arc<PodStore>`
+  query at once via a **sharded + bounded** session cache (interior `RwLock` stripes, LRU eviction); writes stay `&mut self`.
 
 ## ODRL → AUTH_GRAPH bridge (opt-in `odrl-bridge`)
 
@@ -66,10 +69,9 @@ action, or partyless/targetless request materializes **nothing**.
 (`materialize_odrl_permission_conditional`) persists as a per-session-rechecked ACP `auth:ConditionalGrant`
 (recipient/assignee matchers; an inclusive `odrl:dateTime` window vs `Session::now`, **fail-closed with no
 clock**); `purpose`/`count`/strict bounds have no stateless analogue and stay **one-shot** (any unmappable
-constraint falls the whole rule back to one-shot). Bridged grants are ledger-tracked; `refresh_odrl_grant(s)`
+constraint falls the rule back to one-shot). Bridged grants are ledger-tracked; `refresh_odrl_grant(s)`
 rebuilds the view (static baseline + replay of valid entries), retracting lapsed ones. **Deny retraction is
-asymmetric (fail-OPEN risk):** an `auth:deny*` is retracted **only** on a *definite* `Withdrawn` verdict
-(kept on `Applies`/`Ambiguous`); static grants are never in the ledger. Full mapping/replay detail in the SKILL.
+asymmetric (fail-OPEN risk):** an `auth:deny*` is retracted **only** on a *definite* `Withdrawn` verdict. Full detail in the SKILL.
 
 ## WASM support
 
@@ -78,10 +80,9 @@ asymmetric (fail-OPEN risk):** an `auth:deny*` is retracted **only** on a *defin
 transitive `oxrdf 0.3.3 → rand → getrandom` needs the host bundle to select a wasm RNG backend as
 `sparq-wasm` does (`getrandom`'s `wasm_js` feature + the `getrandom_backend` cfg; see the
 [migration guide](../../docs/migrating-from-oxigraph.md#wasm-compilation)). **Timing on wasm32:**
-`std::time::Instant` is unavailable there (no monotonic clock — `Instant::now()` panics), so
-`materialize_wac`/`materialize_acp` `cfg`-gate the wall-clock plumbing off and report `stats.millis == 0.0`
-rather than trapping (rest of `MaterializeStats` unchanged); a wasm32 runtime smoke test
-(`tests/wasm_materialize.rs`, `wasm-pack test --node`) guards it. Deno-wasm / Workers are run-feasible.
+`std::time::Instant` panics (no monotonic clock), so `materialize_wac`/`materialize_acp` `cfg`-gate the
+wall-clock plumbing off and report `stats.millis == 0.0` (rest of `MaterializeStats` unchanged); a wasm32
+smoke test (`tests/wasm_materialize.rs`, `wasm-pack test --node`) guards it. Deno-wasm / Workers run-feasible.
 
 ## Conformance, security & containment
 
@@ -97,9 +98,8 @@ rather than trapping (rest of `MaterializeStats` unchanged); a wasm32 runtime sm
 - **Security posture — fail-closed.** Absence of a grant makes a graph **invisible**. The reasoner is fed
   only ACL/ACR + structural facts — **never pod content** — so no writable document can grant itself
   access; the reserved `urn:sparq:` namespace is rejected on input and forged `<urn:sparq:auth>` graphs
-  are stripped at load. `ldp:contains` is PSS-written opaque content, **never** derived from IRI structure
-  or read into the reasoner; containment *ancestry* drives ACL inheritance only (pinned by
-  `tests/containment_view_ownership.rs`).
+  are stripped at load. `ldp:contains` is PSS-written opaque content, never derived from IRI structure or
+  read into the reasoner; containment *ancestry* drives ACL inheritance only (`tests/containment_view_ownership.rs`).
 
 ## 📚 Learn more
 

--- a/crates/sparq-solid/src/lib.rs
+++ b/crates/sparq-solid/src/lib.rs
@@ -30,6 +30,10 @@ pub mod odrl_bridge;
 #[cfg(feature = "trust-graph")]
 pub mod trust_wire;
 mod rewrite;
+// [FABLE-5] sq-cnuqd (issue #1569): the BOUNDED, SHARDED, `&self`-readable session cache
+// that lets all read-side entry points take `&self` (concurrent `&PodStore` readers). No
+// feature gate + no new dependency (std `RwLock` + the existing `rustc-hash`).
+mod session_cache;
 mod update; // [OPUS-4.8] sq-xor3: write/update-path enforcement
 // [OPUS-4.8] issue #992 FR-3 (sq-snopa.5): the AUTHORITATIVE ACL write-through —
 // `PodStore::put_acl`/`delete_acl` replace (or remove) a `.acl`/`.acr` graph AND
@@ -222,10 +226,15 @@ pub struct PodStore {
     // a cached graph set.
     // [OPUS-4.8] sq-b7k7u (issue #1571): each entry holds the session's accessible set
     // BUCKETED by origin plus the assembled full memo, so a scoped ACL write invalidates
-    // only the affected origin's slice ([`PodStore::invalidate_cache_origin`]) — a session
+    // only the affected origin's slice (`SessionCache::invalidate_origin`) — a session
     // untouched by the written pod keeps its warm slices and re-derives at most the one
     // changed origin, instead of every session cold-starting on every ACL write.
-    cache: FxHashMap<SessionKey, SessionEntry>,
+    // [FABLE-5] sq-cnuqd (issue #1569): the map is now BOUNDED + SHARDED behind interior
+    // mutability (`session_cache::SessionCache`), so every read-side entry point takes
+    // `&self` and N concurrent `&PodStore` readers hit distinct lock stripes instead of
+    // serialising on one exclusive borrow. Same transient-index D3 semantics: `reindex`
+    // clears/invalidates it; eviction only drops re-derivable memoized sets.
+    cache: session_cache::SessionCache,
     /// [OPUS-4.8] sq-dpk4 — the bridged-ODRL-grant ledger: what was bridged from which
     /// `(policy, request)`, plus the static-baseline auth view to rebuild from on a
     /// refresh. Only present when the `odrl-bridge` feature is enabled (the core build
@@ -240,13 +249,19 @@ pub struct PodStore {
 /// grant re-checked at two different instants never returns a stale cached graph set
 /// (two requests differing only by `now` — one inside a window, one after it — must not
 /// collide).
-type SessionKey = (Option<String>, Option<String>, Option<String>, Option<String>, Mode);
+pub(crate) type SessionKey =
+    (Option<String>, Option<String>, Option<String>, Option<String>, Mode);
 
 /// One session-cache entry: the same authorized graph set in the two shapes its two
 /// consumers need — sorted (the v1 `FROM NAMED` rewrite, [`PodStore::accessible`])
 /// and hashed (the engine [`DatasetView`], [`PodStore::accessible_set`]). Both are
 /// `Arc`-shared per call; neither is ever copied after construction.
-struct SessionSets {
+///
+/// `Clone` is a cheap two-`Arc`-bump: [FABLE-5] sq-cnuqd, the sharded cache returns an
+/// OWNED clone (it cannot hand out a borrow past its shard lock), and the caller re-shares
+/// the same underlying `Vec`/`FxHashSet` — nothing is deep-copied.
+#[derive(Clone)]
+pub(crate) struct SessionSets {
     sorted: Arc<Vec<NamedNode>>,
     set: Arc<FxHashSet<Term>>,
 }
@@ -275,7 +290,7 @@ struct SessionSets {
 /// index buckets changed. A FULL re-materialization drops the whole entry (the entry is
 /// transient index state, never storage), so no stale grant can outlive a revocation.
 #[derive(Default)]
-struct SessionEntry {
+pub(crate) struct SessionEntry {
     per_origin: FxHashMap<String, Vec<NamedNode>>,
     dirty: FxHashSet<String>,
     memo: Option<SessionSets>,
@@ -287,6 +302,55 @@ impl SessionEntry {
     fn sets_from(sorted_full: Vec<NamedNode>) -> SessionSets {
         let set = sorted_full.iter().map(|n| Term::NamedNode(n.clone())).collect();
         SessionSets { sorted: Arc::new(sorted_full), set: Arc::new(set) }
+    }
+
+    /// [FABLE-5] sq-cnuqd — (re-)derive this entry's memoized [`SessionSets`] against the
+    /// pinned `auth` snapshot, returning an owned clone of the memo. This is the exact
+    /// compute logic the pre-sharded `session_sets` ran inline; it now lives here so the
+    /// sharded cache can invoke it under its shard write-lock via `get_or_compute`.
+    ///
+    /// - A COLD entry (`!computed`) does ONE whole-store [`AuthIndex::accessible`] and
+    ///   splits the result into per-origin buckets to seed the entry.
+    /// - A SCOPED-INVALIDATED entry (`computed`, some `dirty` origins) re-derives ONLY its
+    ///   dirty origins via [`AuthIndex::accessible_in_origin`] and reuses every warm slice.
+    ///
+    /// The assembled set is byte-for-byte `auth.accessible(s, mode)` for the pinned auth
+    /// view — sound by construction: `reindex_with` marks dirty exactly the origins whose
+    /// index buckets changed. Generation pinning (#1584): `auth` is a single `Arc` snapshot,
+    /// so a re-materialization racing this fill cannot yield a half-old/half-new set.
+    fn fill(&mut self, auth: &AuthIndex, s: &Session, mode: Mode) -> SessionSets {
+        if !self.computed {
+            // Cold: one whole-store walk, split into origin buckets to seed the entry.
+            let full = auth.accessible(s, mode);
+            self.per_origin.clear();
+            for g in &full {
+                self.per_origin
+                    .entry(loader::iri_origin(g.as_str()).to_owned())
+                    .or_default()
+                    .push(g.clone());
+            }
+            self.dirty.clear();
+            self.computed = true;
+            let sets = SessionEntry::sets_from(full);
+            self.memo = Some(sets.clone());
+            sets
+        } else {
+            // Scoped-invalidated: re-derive only the dirty origins, reuse the rest.
+            let dirty: Vec<String> = self.dirty.drain().collect();
+            for origin in dirty {
+                let slice = auth.accessible_in_origin(s, mode, &origin);
+                if slice.is_empty() {
+                    self.per_origin.remove(&origin);
+                } else {
+                    self.per_origin.insert(origin, slice);
+                }
+            }
+            let mut full: Vec<NamedNode> = self.per_origin.values().flatten().cloned().collect();
+            full.sort_unstable_by(|a, b| a.as_str().cmp(b.as_str()));
+            let sets = SessionEntry::sets_from(full);
+            self.memo = Some(sets.clone());
+            sets
+        }
     }
 }
 
@@ -335,7 +399,7 @@ impl PodStore {
             auth: Arc::new(AuthIndex::default()),
             epoch: 0,
             acl_index: OnceLock::new(), // [OPUS-4.8] sq-j8qtt: built lazily on first decide
-            cache: FxHashMap::default(),
+            cache: session_cache::SessionCache::new(), // [FABLE-5] sq-cnuqd: bounded + sharded
             #[cfg(feature = "odrl-bridge")]
             bridge_ledger: odrl_bridge::BridgeLedger::new(),
         }
@@ -477,7 +541,7 @@ impl PodStore {
     /// - [`ReindexScope::Origin`] (an atomic `put_acl`/`delete_acl` to one `.acl`/`.acr`)
     ///   uses **diff-based** invalidation ([SONNET-4.6] sq-b7k7u fix): the old and new
     ///   `AuthIndex` are compared per-origin, and exactly the origins whose (allow, deny,
-    ///   cond) buckets changed are invalidated via [`PodStore::invalidate_cache_origin`]. If
+    ///   cond) buckets changed are invalidated via `session_cache::SessionCache::invalidate_origin`. If
     ///   the matcher maps (`matcher_agents`/`matcher_clients`/`matcher_issuers`) differ — they
     ///   are not origin-bucketed and feed conditional-grant outcomes in any origin — the
     ///   fallback is a full cache clear. Correctness follows from index equality: if a
@@ -515,7 +579,9 @@ impl PodStore {
                         .filter(|o| !old_auth.bucket_eq(&new_auth, o))
                         .collect();
                     for origin in changed {
-                        self.invalidate_cache_origin(&origin);
+                        // [FABLE-5] sq-cnuqd: `&self`-callable now (interior mutability), but
+                        // `reindex_with` holds `&mut self` so this is uncontended.
+                        self.cache.invalidate_origin(&origin);
                     }
                 }
             }
@@ -524,20 +590,6 @@ impl PodStore {
         // the auth rebuild. `take` empties the cell; the next `decide`/`resolve_acl` rebuilds
         // from the just-re-materialized graph.
         self.acl_index.take();
-    }
-
-    /// [OPUS-4.8] sq-b7k7u (issue #1571) — per-origin session-cache invalidation: drop the
-    /// `origin` slice of every cached session and force its full memo to be re-assembled,
-    /// leaving all OTHER origins' slices warm. Called by `reindex_with`'s diff-based
-    /// approach for EACH origin whose index buckets actually changed — so a session that
-    /// previously had NO grant on `origin` still re-checks it (the origin is marked `dirty`
-    /// on every entry), picking up newly-granted access. [SONNET-4.6] sq-b7k7u fix.
-    fn invalidate_cache_origin(&mut self, origin: &str) {
-        for entry in self.cache.values_mut() {
-            entry.per_origin.remove(origin);
-            entry.dirty.insert(origin.to_owned());
-            entry.memo = None;
-        }
     }
 
     /// The persistent structural ACL index for the current generation, built lazily on the
@@ -560,8 +612,8 @@ impl PodStore {
     /// Measured: ~0.3 ms cold, ~0.6 µs cached on the ~1.1k-graph fixture. The same
     /// cache entry also holds this set in the hash-set shape the engine dataset view
     /// takes — [`PodStore::accessible_set`].
-    pub fn accessible(&mut self, s: &Session, mode: Mode) -> Arc<Vec<NamedNode>> {
-        Arc::clone(&self.session_sets(s, mode).sorted)
+    pub fn accessible(&self, s: &Session, mode: Mode) -> Arc<Vec<NamedNode>> {
+        self.session_sets(s, mode).sorted
     }
 
     /// [`PodStore::accessible`] as the hash-set shape the engine [`DatasetView`]
@@ -573,8 +625,8 @@ impl PodStore {
     /// [`PodStore::query_json_as`] / [`PodStore::ask_as`] doesn't cover (e.g.
     /// `construct`) needs to run under the session's view — or just take
     /// [`PodStore::view_for`].
-    pub fn accessible_set(&mut self, s: &Session, mode: Mode) -> Arc<FxHashSet<Term>> {
-        Arc::clone(&self.session_sets(s, mode).set)
+    pub fn accessible_set(&self, s: &Session, mode: Mode) -> Arc<FxHashSet<Term>> {
+        self.session_sets(s, mode).set
     }
 
     /// Build the value of a [`WAC-Allow`](https://solidproject.org/TR/wac#wac-allow)
@@ -632,7 +684,7 @@ impl PodStore {
     /// assert_eq!(store.wac_allow(&Session::default(), &resource), r#"user="read",public="read""#);
     /// # Ok::<(), String>(())
     /// ```
-    pub fn wac_allow(&mut self, session: &Session, resource: &NamedNode) -> String {
+    pub fn wac_allow(&self, session: &Session, resource: &NamedNode) -> String {
         let user = self.modes_held(session, resource);
         // The `public` field is what an anonymous caller (no WebID) holds — `acl:Read`
         // granted to `foaf:Agent` etc. — independent of the authenticated session.
@@ -643,7 +695,7 @@ impl PodStore {
     /// The space-separated WAC mode names `session` holds on `resource`'s graph, in the
     /// fixed `read write append control` order — the per-field body of [`Self::wac_allow`].
     /// Empty string when no mode is held (fail-closed). [OPUS-4.8] sq-i7k08.
-    fn modes_held(&mut self, session: &Session, resource: &NamedNode) -> String {
+    fn modes_held(&self, session: &Session, resource: &NamedNode) -> String {
         const MODES: [(Mode, &str); 4] = [
             (Mode::Read, "read"),
             (Mode::Write, "write"),
@@ -787,7 +839,16 @@ impl PodStore {
     /// every untouched origin's slice. The assembled set is byte-for-byte
     /// `AuthIndex::accessible(s, mode)` for the current auth view — sound by construction
     /// because `reindex_with` marks dirty exactly the origins whose index buckets changed.
-    fn session_sets(&mut self, s: &Session, mode: Mode) -> &SessionSets {
+    ///
+    /// [FABLE-5] sq-cnuqd (issue #1569): `&self`, not `&mut self` — the cache is now behind
+    /// the bounded, sharded interior-mutable `session_cache::SessionCache`, so N concurrent
+    /// `&PodStore` readers share this path without an exclusive borrow. A warm hit takes only
+    /// a shard READ lock (+ two `Arc` clones); only a miss/re-derive takes that one shard's
+    /// write lock. The returned [`SessionSets`] is OWNED (two `Arc` bumps) — nothing borrows
+    /// the shard past the call, so the (potentially long) query runs with the lock released.
+    /// Generation pinning (#1584): the `auth` snapshot is pinned ONCE per call, so a racing
+    /// re-materialization never yields a half-old/half-new set.
+    fn session_sets(&self, s: &Session, mode: Mode) -> SessionSets {
         let key = (
             s.agent.map(str::to_owned),
             s.client.map(str::to_owned),
@@ -796,40 +857,7 @@ impl PodStore {
             mode,
         );
         let auth = Arc::clone(&self.auth);
-        let entry = self.cache.entry(key).or_default();
-        if entry.memo.is_none() {
-            if !entry.computed {
-                // Cold: one whole-store walk, split into origin buckets to seed the entry.
-                let full = auth.accessible(s, mode);
-                entry.per_origin.clear();
-                for g in &full {
-                    entry
-                        .per_origin
-                        .entry(loader::iri_origin(g.as_str()).to_owned())
-                        .or_default()
-                        .push(g.clone());
-                }
-                entry.dirty.clear();
-                entry.computed = true;
-                entry.memo = Some(SessionEntry::sets_from(full));
-            } else {
-                // Scoped-invalidated: re-derive only the dirty origins, reuse the rest.
-                let dirty: Vec<String> = entry.dirty.drain().collect();
-                for origin in dirty {
-                    let slice = auth.accessible_in_origin(s, mode, &origin);
-                    if slice.is_empty() {
-                        entry.per_origin.remove(&origin);
-                    } else {
-                        entry.per_origin.insert(origin, slice);
-                    }
-                }
-                let mut full: Vec<NamedNode> =
-                    entry.per_origin.values().flatten().cloned().collect();
-                full.sort_unstable_by(|a, b| a.as_str().cmp(b.as_str()));
-                entry.memo = Some(SessionEntry::sets_from(full));
-            }
-        }
-        entry.memo.as_ref().expect("memo populated above")
+        self.cache.get_or_compute(&key, |entry| entry.fill(&auth, s, mode))
     }
 
     /// The session's zero-copy [`DatasetView`] over this store (mode-checked graph
@@ -840,7 +868,7 @@ impl PodStore {
     /// Fail-closed like [`PodStore::accessible`]: an un-materialized store or a
     /// grant-less session yields a view over the empty graph set, under which every
     /// graph is indistinguishable from absent.
-    pub fn view_for(&mut self, s: &Session, mode: Mode) -> DatasetView<'_> {
+    pub fn view_for(&self, s: &Session, mode: Mode) -> DatasetView<'_> {
         let named = self.accessible_set(s, mode);
         DatasetView { base: &self.graph, named, default: DefaultGraphMode::Empty }
     }
@@ -902,7 +930,7 @@ impl PodStore {
     /// assert_eq!(store.query_as(&Session::default(), Mode::Read, q)?.rows.len(), 0);
     /// # Ok::<(), String>(())
     /// ```
-    pub fn query_as(&mut self, s: &Session, mode: Mode, sparql: &str) -> Result<QueryResult, String> {
+    pub fn query_as(&self, s: &Session, mode: Mode, sparql: &str) -> Result<QueryResult, String> {
         let wrapped = wrap_read(sparql)?;
         sparq_engine::query_view(&self.view_for(s, mode), &wrapped)
     }
@@ -911,7 +939,7 @@ impl PodStore {
     /// (via [`sparq_engine::query_json_view`]) instead of a materialized
     /// [`QueryResult`]. Same view path, same fail-closed semantics (incl. the
     /// `solid-sparql-query` union-default opt-in — see [`PodStore::query_as`]).
-    pub fn query_json_as(&mut self, s: &Session, mode: Mode, sparql: &str) -> Result<String, String> {
+    pub fn query_json_as(&self, s: &Session, mode: Mode, sparql: &str) -> Result<String, String> {
         let wrapped = wrap_read(sparql)?;
         sparq_engine::query_json_view(&self.view_for(s, mode), &wrapped)
     }
@@ -920,7 +948,7 @@ impl PodStore {
     /// iff the pattern is satisfiable inside the session's authorized graph set.
     /// Fail-closed: a grant-less session always gets `false` (empty view). Honours the
     /// `solid-sparql-query` union-default opt-in like [`PodStore::query_as`].
-    pub fn ask_as(&mut self, s: &Session, mode: Mode, sparql: &str) -> Result<bool, String> {
+    pub fn ask_as(&self, s: &Session, mode: Mode, sparql: &str) -> Result<bool, String> {
         let wrapped = wrap_read(sparql)?;
         sparq_engine::ask_view(&self.view_for(s, mode), &wrapped)
     }
@@ -945,7 +973,7 @@ impl PodStore {
     /// # Errors
     ///
     /// As [`PodStore::query_as`].
-    pub fn query_as_rewrite(&mut self, s: &Session, mode: Mode, sparql: &str) -> Result<QueryResult, String> {
+    pub fn query_as_rewrite(&self, s: &Session, mode: Mode, sparql: &str) -> Result<QueryResult, String> {
         let allowed = self.accessible(s, mode);
         let rewritten = rewrite_for(sparql, &allowed)?;
         sparq_engine::query(&self.graph, &rewritten)
@@ -1378,9 +1406,15 @@ mod scoped_cache_tests {
         store
     }
 
-    fn entry_for<'a>(store: &'a PodStore, s: &Session) -> &'a SessionEntry {
-        let key = (s.agent.map(str::to_owned), s.client.map(str::to_owned), s.issuer.map(str::to_owned), s.now.map(str::to_owned), Mode::Read);
-        store.cache.get(&key).expect("entry warmed")
+    fn key_for(s: &Session) -> SessionKey {
+        (s.agent.map(str::to_owned), s.client.map(str::to_owned), s.issuer.map(str::to_owned), s.now.map(str::to_owned), Mode::Read)
+    }
+
+    /// White-box inspection of one cached [`SessionEntry`] through the sharded cache
+    /// ([FABLE-5] sq-cnuqd): reads the shard under its read lock and projects the fields the
+    /// pre-sharded tests asserted on the plain map.
+    fn with_entry<R>(store: &PodStore, s: &Session, f: impl FnOnce(&SessionEntry) -> R) -> R {
+        store.cache.with_entry(&key_for(s), |e| f(e.expect("entry warmed")))
     }
 
     #[test]
@@ -1390,24 +1424,23 @@ mod scoped_cache_tests {
 
         // Warm alice's cache: she reads one graph in each pod.
         assert_eq!(store.accessible(&alice, Mode::Read).len(), 2);
-        {
-            let e = entry_for(&store, &alice);
+        with_entry(&store, &alice, |e| {
             assert!(e.memo.is_some(), "warm memo present");
             assert!(e.per_origin.contains_key("https://a.ex"));
             assert!(e.per_origin.contains_key("https://b.ex"));
             assert!(e.dirty.is_empty());
-        }
-        // Capture the exact Arc identity of the b.ex slice contribution by snapshotting it.
-        let b_before: Vec<String> =
-            entry_for(&store, &alice).per_origin["https://b.ex"].iter().map(|n| n.as_str().to_owned()).collect();
+        });
+        // Capture the exact contents of the b.ex slice contribution by snapshotting it.
+        let b_before: Vec<String> = with_entry(&store, &alice, |e| {
+            e.per_origin["https://b.ex"].iter().map(|n| n.as_str().to_owned()).collect()
+        });
 
         // Scoped write to pod a: REVOKE alice on pod a (empty .acl body).
         store.put_acl("https://a.ex/.acl", "", "ntriples").expect("put");
 
         // Immediately after the write (before any read): a.ex slice dropped + marked dirty,
         // b.ex slice UNTOUCHED (kept warm), memo dropped (must reassemble).
-        {
-            let e = entry_for(&store, &alice);
+        with_entry(&store, &alice, |e| {
             assert!(!e.per_origin.contains_key("https://a.ex"), "a.ex slice evicted");
             assert!(e.per_origin.contains_key("https://b.ex"), "b.ex slice kept warm");
             assert!(e.dirty.contains("https://a.ex"), "a.ex marked dirty");
@@ -1415,7 +1448,7 @@ mod scoped_cache_tests {
             assert!(e.memo.is_none(), "memo invalidated");
             let b_now: Vec<String> = e.per_origin["https://b.ex"].iter().map(|n| n.as_str().to_owned()).collect();
             assert_eq!(b_now, b_before, "b.ex slice byte-identical (never recomputed)");
-        }
+        });
 
         // Next read: alice lost pod a, still reads pod b — equals a from-scratch rebuild.
         let got: Vec<String> = store.accessible(&alice, Mode::Read).iter().map(|n| n.as_str().to_owned()).collect();
@@ -1432,7 +1465,7 @@ mod scoped_cache_tests {
         let bob = sess("https://bob.ex/card#me");
         // bob has nothing yet; warm his (empty) cache.
         assert_eq!(store.accessible(&bob, Mode::Read).len(), 0);
-        assert!(entry_for(&store, &bob).memo.is_some());
+        assert!(with_entry(&store, &bob, |e| e.memo.is_some()));
         // Scoped write to pod a granting bob Read.
         let acl = "<https://a.ex/.acl#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> .\n\
                    <https://a.ex/.acl#o> <http://www.w3.org/ns/auth/acl#default> <https://a.ex/> .\n\

--- a/crates/sparq-solid/src/session_cache.rs
+++ b/crates/sparq-solid/src/session_cache.rs
@@ -1,0 +1,422 @@
+//! [FABLE-5] sq-cnuqd (issue #1569) — the BOUNDED, SHARDED, `&self`-readable session cache.
+//!
+//! # Why this exists
+//!
+//! Before this, every read-side entry point on [`crate::PodStore`] (`accessible`,
+//! `accessible_set`, `view_for`, `query_as`, `query_json_as`, `ask_as`, `wac_allow`)
+//! took `&mut self`, because the memoized authorized-graph-set cache was a plain
+//! `FxHashMap` mutated in place. That EXCLUSIVE borrow serialised every concurrent
+//! reader through one lock even though the underlying engine, the `Arc<Generation>`
+//! graph ring, and the `Arc<AuthIndex>` are all read-only after materialization — so a
+//! per-request LDP/SPARQL server sharing one `&PodStore` across threads could not run
+//! two queries at once (issue #1569, the PSS >50k req/s target).
+//!
+//! This module replaces that map with a cache that is:
+//!
+//! - **`&self`-readable** — interior mutability ([`std::sync::RwLock`] per shard), so all
+//!   read entry points take `&self` and `&PodStore: Sync` lets N threads read concurrently.
+//! - **sharded** — [`SHARDS`] independent lock stripes keyed by the session-key hash, so
+//!   two requests for DIFFERENT sessions almost never contend on the same lock. A cache
+//!   HIT is a shard read-lock + two `Arc` clones; only a cache MISS (or eviction) takes
+//!   that shard's write lock, and only that one shard.
+//! - **bounded** — each shard holds at most [`SHARD_CAP`] entries with LRU eviction
+//!   ([`Shard::recency`]), so a server passing per-request `now` timestamps (which key
+//!   distinctly, [`crate::SessionKey`]) can no longer grow the cache without bound. The LRU
+//!   recency queue is ALSO bounded (compacted to one entry per live key once it exceeds
+//!   `RECENCY_SLACK * SHARD_CAP`), so re-touching a hot key under invalidation churn cannot
+//!   grow it without bound either.
+//!
+//! # Exact-semantics preservation (the load-bearing invariant)
+//!
+//! The cache is a TRANSIENT index over the auth-view triples (design doc D3) — it holds
+//! zero authorization state of record. It composes with the recently-landed AclIndex
+//! (#1577), generation pinning (#1584) and diff-based origin-scoped invalidation (#1585)
+//! by keeping their exact seams:
+//!
+//! - **generation pinning / snapshot consistency** — a read pins `Arc::clone(&self.auth)`
+//!   ONCE and computes the whole set against that one snapshot, so a re-materialization
+//!   racing a read never yields a half-old/half-new set (the read either sees the whole
+//!   old generation or, on the next read after `reindex`, the whole new one).
+//! - **invalidation still hits the right shards** — [`SessionCache::clear`] drops every
+//!   shard; [`SessionCache::invalidate_origin`] visits EVERY shard and applies the SAME
+//!   per-entry origin surgery the pre-sharded map did (drop the origin's slice, mark it
+//!   `dirty`, drop the memo), so the diff-based per-origin invalidation still reaches every
+//!   cached session regardless of which shard it landed in. Eviction is pure capacity
+//!   management and can only ever DROP a cached set (which is re-derived, fail-closed on
+//!   the current auth view) — it can never surface a stale grant.
+//!
+//! Fail-closed throughout: a dropped/evicted entry is simply re-derived from the current
+//! `AuthIndex`, never assumed to still be authorized.
+
+use crate::{SessionEntry, SessionKey, SessionSets};
+use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+use std::collections::VecDeque;
+use std::hash::BuildHasher;
+use std::sync::RwLock;
+
+/// Number of independent lock stripes. A power of two so shard selection is a mask, not a
+/// modulo. Sized so a realistic thread pool (tens of workers) rarely collides two live
+/// requests onto one stripe, while keeping the fixed per-`PodStore` overhead tiny (one
+/// `RwLock<Shard>` each, each an empty map until first use).
+pub(crate) const SHARDS: usize = 16;
+
+/// Maximum live entries PER SHARD (so the whole cache is bounded by `SHARDS * SHARD_CAP`).
+/// When a shard is full, the least-recently-used entry is evicted to make room — this is
+/// what stops a server that keys per-request `now` timestamps ([`crate::SessionKey`]'s
+/// clock slot) from growing the cache without bound. Eviction only drops a re-derivable
+/// memoized set; it never affects correctness (fail-closed re-derivation on the next read).
+pub(crate) const SHARD_CAP: usize = 1024;
+
+/// Hard cap on the recency queue length, as a multiple of [`SHARD_CAP`]. The queue can
+/// hold at most one live-per-key entry ([`SHARD_CAP`] of them) plus stale copies left by
+/// re-touches; when it crosses this multiple it is compacted back down to one entry per
+/// live key. Bounding it is load-bearing: a hot session that is repeatedly invalidated
+/// (miss → fill → `invalidate_origin` → miss → fill …) re-touches the SAME key without ever
+/// growing `map` past the cap, so without this the recency queue would grow WITHOUT BOUND
+/// (breaking the whole "bounded" guarantee) and make each eviction O(queue) — [FABLE-5]
+/// sq-cnuqd fix.
+const RECENCY_SLACK: usize = 2;
+
+/// One lock stripe: a bounded LRU map of session key → cached entry.
+struct Shard {
+    map: FxHashMap<SessionKey, SessionEntry>,
+    /// LRU recency queue (front = least-recently-used, back = most-recent). A key may
+    /// appear more than once after a re-touch; the stale front copies are skipped on
+    /// eviction (a key whose LATER occurrence still survives further back is not its true
+    /// LRU position). The queue is compacted to one-entry-per-live-key once it exceeds
+    /// `RECENCY_SLACK * SHARD_CAP`, so it is bounded by `RECENCY_SLACK * SHARD_CAP` at all
+    /// times regardless of the re-touch churn.
+    recency: VecDeque<SessionKey>,
+}
+
+impl Shard {
+    fn new() -> Shard {
+        Shard { map: FxHashMap::default(), recency: VecDeque::new() }
+    }
+
+    /// Record `key` as most-recently-used (append to the back). Called under the shard's
+    /// write lock on every miss-fill. Compacts the recency queue if the accumulated stale
+    /// copies have pushed it past `RECENCY_SLACK * SHARD_CAP`, keeping it bounded even when
+    /// the same hot key is re-touched indefinitely (miss/invalidate churn).
+    fn touch(&mut self, key: &SessionKey) {
+        self.recency.push_back(key.clone());
+        if self.recency.len() > RECENCY_SLACK * SHARD_CAP {
+            self.compact_recency();
+        }
+    }
+
+    /// Rebuild the recency queue keeping ONLY the last (most-recent) occurrence of each key
+    /// that is still live in `map`, preserving relative order. This drops every stale copy
+    /// left by re-touches (and any key already evicted), so the queue returns to at most one
+    /// entry per live key (≤ `map.len()` ≤ [`SHARD_CAP`]). O(queue) but amortised O(1) per
+    /// touch because it only fires once per `RECENCY_SLACK * SHARD_CAP` touches.
+    fn compact_recency(&mut self) {
+        let mut seen: FxHashSet<SessionKey> = FxHashSet::default();
+        let mut compacted: VecDeque<SessionKey> = VecDeque::with_capacity(self.map.len());
+        // Walk newest → oldest, keep the first (= newest) sighting of each live key, then
+        // reverse so the queue is oldest → newest again (front = LRU).
+        for key in self.recency.iter().rev() {
+            if self.map.contains_key(key) && seen.insert(key.clone()) {
+                compacted.push_front(key.clone());
+            }
+        }
+        self.recency = compacted;
+    }
+
+    /// Evict least-recently-used entries until the map is within [`SHARD_CAP`]. Skips
+    /// recency entries that are stale (already evicted, or superseded by a later touch of
+    /// the same key that is still the live back-most occurrence).
+    fn evict_to_cap(&mut self) {
+        while self.map.len() > SHARD_CAP {
+            let Some(candidate) = self.recency.pop_front() else { break };
+            // Skip a stale recency record: the key was already evicted, OR a more-recent
+            // touch of the same key exists further back in the queue (so this front copy is
+            // not its true LRU position).
+            if !self.map.contains_key(&candidate) {
+                continue;
+            }
+            if self.recency.iter().any(|k| *k == candidate) {
+                // A later touch of this key survives further back → this copy is stale.
+                continue;
+            }
+            self.map.remove(&candidate);
+        }
+    }
+}
+
+/// The bounded, sharded, interior-mutable session cache. Each read entry point on
+/// [`crate::PodStore`] goes through [`SessionCache::get_or_compute`]; the write/reindex
+/// path calls [`SessionCache::clear`] / [`SessionCache::invalidate_origin`]. All methods
+/// take `&self` — that is the whole point (concurrent `&PodStore` readers).
+pub(crate) struct SessionCache {
+    shards: Vec<RwLock<Shard>>,
+}
+
+impl SessionCache {
+    pub(crate) fn new() -> SessionCache {
+        SessionCache { shards: (0..SHARDS).map(|_| RwLock::new(Shard::new())).collect() }
+    }
+
+    /// The shard index for `key` (mask, not modulo — [`SHARDS`] is a power of two).
+    fn shard_of(&self, key: &SessionKey) -> usize {
+        (FxBuildHasher.hash_one(key) as usize) & (SHARDS - 1)
+    }
+
+    /// Return the memoized [`SessionSets`] for `key`, computing (and caching) it via
+    /// `compute` on a miss or a scoped-invalidated entry.
+    ///
+    /// `compute` is the caller's re-derivation closure ([`crate::PodStore::session_sets`]
+    /// pins the auth snapshot and calls [`SessionEntry::fill`]); it takes the entry by
+    /// `&mut` and returns the assembled [`SessionSets`]. It is invoked ONLY under the
+    /// shard's write lock, and only when the entry has no live memo — so a warm hit is a
+    /// read-lock + two `Arc` clones and never touches `compute`.
+    ///
+    /// The returned [`SessionSets`] is owned (two `Arc` clones); nothing borrows the lock
+    /// past this call, so the shard is unlocked before the (potentially long) query runs.
+    pub(crate) fn get_or_compute<F>(&self, key: &SessionKey, compute: F) -> SessionSets
+    where
+        F: FnOnce(&mut SessionEntry) -> SessionSets,
+    {
+        let idx = self.shard_of(key);
+        // Fast path: shared read lock, clone the memo if warm.
+        {
+            let shard = self.shards[idx].read().expect("session-cache shard poisoned");
+            if let Some(entry) = shard.map.get(key) {
+                if let Some(memo) = entry.memo.as_ref() {
+                    return memo.clone();
+                }
+            }
+        }
+        // Miss or stale memo: take the write lock, fill (re-checking under the lock in case
+        // another writer filled it first), evict to cap, return the owned sets.
+        let mut shard = self.shards[idx].write().expect("session-cache shard poisoned");
+        // Double-check: a concurrent writer may have filled it between the two locks.
+        if let Some(entry) = shard.map.get(key) {
+            if let Some(memo) = entry.memo.as_ref() {
+                return memo.clone();
+            }
+        }
+        let entry = shard.map.entry(key.clone()).or_default();
+        let sets = compute(entry);
+        shard.touch(key);
+        shard.evict_to_cap();
+        sets
+    }
+
+    /// Drop every cached entry across every shard — the [`crate::ReindexScope::Full`]
+    /// invalidation (D3: the cache is transient index state, the triples are the storage).
+    pub(crate) fn clear(&self) {
+        for shard in &self.shards {
+            let mut s = shard.write().expect("session-cache shard poisoned");
+            s.map.clear();
+            s.recency.clear();
+        }
+    }
+
+    /// Per-origin invalidation ([`crate::ReindexScope::Origin`], issue #1585/#1571): for
+    /// EVERY cached session in EVERY shard, drop that `origin`'s slice, mark it `dirty`, and
+    /// drop the memo — so the next read re-derives only that origin and keeps every other
+    /// origin's slice warm. Visiting all shards is required: the diff-based invalidation
+    /// must reach a session regardless of which shard its key hashed into.
+    pub(crate) fn invalidate_origin(&self, origin: &str) {
+        for shard in &self.shards {
+            let mut s = shard.write().expect("session-cache shard poisoned");
+            for entry in s.map.values_mut() {
+                entry.per_origin.remove(origin);
+                entry.dirty.insert(origin.to_owned());
+                entry.memo = None;
+            }
+        }
+    }
+
+    /// The current total number of cached entries across all shards (test/inspection only).
+    #[cfg(test)]
+    pub(crate) fn len(&self) -> usize {
+        self.shards.iter().map(|s| s.read().expect("poisoned").map.len()).sum()
+    }
+
+    /// Read-only access to one cached entry for white-box tests (clones nothing observable;
+    /// returns the values the pre-sharded tests asserted on the plain map).
+    #[cfg(test)]
+    pub(crate) fn with_entry<R>(
+        &self,
+        key: &SessionKey,
+        f: impl FnOnce(Option<&SessionEntry>) -> R,
+    ) -> R {
+        let idx = self.shard_of(key);
+        let shard = self.shards[idx].read().expect("poisoned");
+        f(shard.map.get(key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! [FABLE-5] sq-cnuqd — DIRECT unit tests for the bounded, sharded cache mechanics
+    //! (independent of the WAC/ACP auth path): hit/miss/compute, bounded eviction, `clear`,
+    //! per-origin invalidation, and shard-selection stability.
+    use super::*;
+    use crate::Mode;
+    use oxrdf::NamedNode;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    fn key(agent: &str, mode: Mode) -> SessionKey {
+        (Some(agent.to_owned()), None, None, None, mode)
+    }
+
+    /// A trivial [`SessionSets`] carrying one graph IRI, so a test can assert which set a
+    /// lookup returned without wiring up the whole auth path.
+    fn sets_with(iri: &str) -> SessionSets {
+        let nn = NamedNode::new(iri).unwrap();
+        let sorted = Arc::new(vec![nn.clone()]);
+        let set = Arc::new(std::iter::once(oxrdf::Term::NamedNode(nn)).collect());
+        SessionSets { sorted, set }
+    }
+
+    #[test]
+    fn compute_runs_once_then_hits_are_warm() {
+        let cache = SessionCache::new();
+        let k = key("https://alice.ex/#me", Mode::Read);
+        let calls = AtomicUsize::new(0);
+        let fill = |_e: &mut SessionEntry| {
+            calls.fetch_add(1, Ordering::SeqCst);
+            let s = sets_with("https://pod.ex/g1");
+            _e.memo = Some(s.clone());
+            s
+        };
+        // First call computes; the second is a warm read-lock hit (compute NOT re-run).
+        let a = cache.get_or_compute(&k, fill);
+        let b = cache.get_or_compute(&k, fill);
+        assert_eq!(calls.load(Ordering::SeqCst), 1, "compute ran exactly once");
+        assert_eq!(a.sorted.as_ref(), b.sorted.as_ref());
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn distinct_keys_land_and_cache_independently() {
+        let cache = SessionCache::new();
+        let ka = key("https://alice.ex/#me", Mode::Read);
+        let kb = key("https://bob.ex/#me", Mode::Read);
+        let a = cache.get_or_compute(&ka, |e| {
+            let s = sets_with("https://pod.ex/a");
+            e.memo = Some(s.clone());
+            s
+        });
+        let b = cache.get_or_compute(&kb, |e| {
+            let s = sets_with("https://pod.ex/b");
+            e.memo = Some(s.clone());
+            s
+        });
+        assert_eq!(a.sorted[0].as_str(), "https://pod.ex/a");
+        assert_eq!(b.sorted[0].as_str(), "https://pod.ex/b");
+        assert_eq!(cache.len(), 2);
+    }
+
+    #[test]
+    fn bounded_eviction_caps_each_shard() {
+        // Force many entries into ONE shard by fixing everything but a synthetic agent id,
+        // then filtering to keys that hash to shard 0 — enough to exceed SHARD_CAP there.
+        let cache = SessionCache::new();
+        let mut in_shard0 = 0usize;
+        let mut i = 0u64;
+        // Insert well past SHARD_CAP worth of shard-0 keys.
+        while in_shard0 <= SHARD_CAP + 50 {
+            let k = key(&format!("https://a.ex/#{i}"), Mode::Read);
+            i += 1;
+            if cache.shard_of(&k) != 0 {
+                continue;
+            }
+            in_shard0 += 1;
+            cache.get_or_compute(&k, |e| {
+                let s = sets_with("https://pod.ex/x");
+                e.memo = Some(s.clone());
+                s
+            });
+        }
+        // Shard 0 is bounded to SHARD_CAP; the whole cache never exceeds SHARDS*SHARD_CAP.
+        let shard0_len = cache.shards[0].read().unwrap().map.len();
+        assert!(shard0_len <= SHARD_CAP, "shard 0 bounded ({shard0_len} <= {SHARD_CAP})");
+        assert!(cache.len() <= SHARDS * SHARD_CAP, "whole cache bounded");
+    }
+
+    #[test]
+    fn recency_queue_stays_bounded_under_hot_key_churn() {
+        // Regression ([FABLE-5] sq-cnuqd): a hot session re-touched over and over (the real
+        // miss → fill → invalidate_origin → miss → fill … churn a per-origin ACL write drives)
+        // must NOT grow the recency queue without bound. Before the compaction fix, `map`
+        // stayed at 1 entry so `evict_to_cap` never fired and `recency` grew one copy per
+        // re-touch — an unbounded leak that also made eviction O(queue).
+        let cache = SessionCache::new();
+        let k = key("https://hot.ex/#me", Mode::Read);
+        let idx = cache.shard_of(&k);
+        // Far more re-touches than RECENCY_SLACK * SHARD_CAP so compaction must have fired.
+        for _ in 0..(RECENCY_SLACK * SHARD_CAP * 3 + 17) {
+            // Each round: drop the memo (as invalidate_origin does) so the next call is a MISS
+            // that re-touches the SAME key, then read it back.
+            cache.invalidate_origin("https://hot.ex");
+            cache.get_or_compute(&k, |e| {
+                e.computed = true;
+                let s = sets_with("https://hot.ex/g");
+                e.memo = Some(s.clone());
+                s
+            });
+        }
+        let rec = cache.shards[idx].read().unwrap().recency.len();
+        let map = cache.shards[idx].read().unwrap().map.len();
+        assert_eq!(map, 1, "only the one hot session is cached");
+        assert!(
+            rec <= RECENCY_SLACK * SHARD_CAP,
+            "recency bounded ({rec} <= {}) despite churn",
+            RECENCY_SLACK * SHARD_CAP
+        );
+    }
+
+    #[test]
+    fn clear_drops_everything() {
+        let cache = SessionCache::new();
+        for n in 0..8u64 {
+            let k = key(&format!("https://a.ex/#{n}"), Mode::Read);
+            cache.get_or_compute(&k, |e| {
+                let s = sets_with("https://pod.ex/x");
+                e.memo = Some(s.clone());
+                s
+            });
+        }
+        assert!(cache.len() >= 1);
+        cache.clear();
+        assert_eq!(cache.len(), 0, "clear drops all shards");
+    }
+
+    #[test]
+    fn invalidate_origin_marks_dirty_and_drops_memo() {
+        let cache = SessionCache::new();
+        let k = key("https://alice.ex/#me", Mode::Read);
+        // Seed an entry with two origin buckets + a memo.
+        cache.get_or_compute(&k, |e| {
+            e.computed = true;
+            e.per_origin.insert("https://a.ex".to_owned(), vec![NamedNode::new("https://a.ex/g").unwrap()]);
+            e.per_origin.insert("https://b.ex".to_owned(), vec![NamedNode::new("https://b.ex/g").unwrap()]);
+            let s = sets_with("https://a.ex/g");
+            e.memo = Some(s.clone());
+            s
+        });
+        cache.invalidate_origin("https://a.ex");
+        cache.with_entry(&k, |e| {
+            let e = e.expect("entry present");
+            assert!(!e.per_origin.contains_key("https://a.ex"), "a.ex slice dropped");
+            assert!(e.per_origin.contains_key("https://b.ex"), "b.ex slice kept warm");
+            assert!(e.dirty.contains("https://a.ex"), "a.ex marked dirty");
+            assert!(e.memo.is_none(), "memo dropped so it re-assembles");
+        });
+    }
+
+    #[test]
+    fn shard_selection_is_stable_and_in_range() {
+        let cache = SessionCache::new();
+        let k = key("https://alice.ex/#me", Mode::Read);
+        let a = cache.shard_of(&k);
+        let b = cache.shard_of(&k);
+        assert_eq!(a, b, "deterministic");
+        assert!(a < SHARDS, "in range");
+    }
+}

--- a/crates/sparq-solid/tests/concurrent_readers.rs
+++ b/crates/sparq-solid/tests/concurrent_readers.rs
@@ -1,0 +1,146 @@
+//! [FABLE-5] sq-cnuqd (issue #1569) — the read side is `&self` and shares a bounded,
+//! sharded session cache, so N threads sharing ONE `&PodStore` can query concurrently.
+//!
+//! These tests exercise the REAL path (`Arc<PodStore>` shared across `std::thread`s calling
+//! `query_as`/`accessible`), not a mock. They pin the two load-bearing invariants issue
+//! #1569 needs:
+//!
+//! 1. **concurrent readers get correct, session-scoped results** — the same `&PodStore`,
+//!    two sessions, run in parallel from many threads, every answer fail-closed-correct;
+//! 2. **invalidation under concurrent read is snapshot-consistent** — while readers hammer
+//!    `accessible`, a writer revokes a pod via `put_acl`; every observed set is EITHER the
+//!    pre-revoke set OR the post-revoke set, NEVER a torn half-and-half one, and after the
+//!    write settles every reader converges on the revoked view (generation pinning, #1584).
+
+use sparq_solid::{Mode, PodStore, Session};
+use std::sync::{Arc, Barrier};
+use std::thread;
+
+const ALICE: &str = "https://alice.ex/card#me";
+const BOB: &str = "https://bob.ex/card#me";
+
+fn sess(agent: &str) -> Session<'_> {
+    Session { agent: Some(agent), client: None, issuer: None, now: None }
+}
+
+/// Two pods (a.ex, b.ex). Alice may Read both; Bob may Read only b.ex.
+fn two_pod_store() -> PodStore {
+    let nq = r#"
+<https://a.ex/n1#it> <https://ex.dev/ns#k> "v" <https://a.ex/n1> .
+<https://b.ex/m1#it> <https://ex.dev/ns#k> "v" <https://b.ex/m1> .
+<https://a.ex/.acl#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://a.ex/.acl> .
+<https://a.ex/.acl#o> <http://www.w3.org/ns/auth/acl#default> <https://a.ex/> <https://a.ex/.acl> .
+<https://a.ex/.acl#o> <http://www.w3.org/ns/auth/acl#agent> <https://alice.ex/card#me> <https://a.ex/.acl> .
+<https://a.ex/.acl#o> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://a.ex/.acl> .
+<https://b.ex/.acl#o> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://www.w3.org/ns/auth/acl#Authorization> <https://b.ex/.acl> .
+<https://b.ex/.acl#o> <http://www.w3.org/ns/auth/acl#default> <https://b.ex/> <https://b.ex/.acl> .
+<https://b.ex/.acl#o> <http://www.w3.org/ns/auth/acl#agent> <https://alice.ex/card#me> <https://b.ex/.acl> .
+<https://b.ex/.acl#o> <http://www.w3.org/ns/auth/acl#agent> <https://bob.ex/card#me> <https://b.ex/.acl> .
+<https://b.ex/.acl#o> <http://www.w3.org/ns/auth/acl#mode> <http://www.w3.org/ns/auth/acl#Read> <https://b.ex/.acl> .
+"#;
+    let mut store = PodStore::new(sparq_core::Graph::load_dataset(nq, "nquads").expect("loads"));
+    store.materialize_wac().expect("materializes");
+    store
+}
+
+fn read_iris(store: &PodStore, s: &Session) -> Vec<String> {
+    store.accessible(s, Mode::Read).iter().map(|n| n.as_str().to_owned()).collect()
+}
+
+#[test]
+fn many_threads_share_one_ref_and_get_session_scoped_results() {
+    let store = Arc::new(two_pod_store());
+    let threads = 16;
+    let barrier = Arc::new(Barrier::new(threads));
+    let mut handles = Vec::new();
+    for t in 0..threads {
+        let store = Arc::clone(&store);
+        let barrier = Arc::clone(&barrier);
+        handles.push(thread::spawn(move || {
+            barrier.wait(); // maximise real contention on the shared &PodStore
+            for _ in 0..200 {
+                // Alice sees both pods; Bob sees only b.ex; anon sees nothing.
+                let alice = read_iris(&store, &sess(ALICE));
+                assert_eq!(alice.len(), 2, "alice reads both pods (thread {t})");
+                let bob = read_iris(&store, &sess(BOB));
+                assert_eq!(bob, vec!["https://b.ex/m1".to_owned()], "bob reads only b.ex");
+                // A full query goes through the same &self view path concurrently.
+                let n = store
+                    .query_as(&sess(ALICE), Mode::Read, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }")
+                    .expect("query ok")
+                    .rows
+                    .len();
+                assert_eq!(n, 2, "alice's concurrent query sees both pod docs");
+                assert!(read_iris(&store, &Session::default()).is_empty(), "anon fail-closed");
+            }
+        }));
+    }
+    for h in handles {
+        h.join().expect("no reader panicked");
+    }
+}
+
+#[test]
+fn invalidation_under_concurrent_read_is_snapshot_consistent() {
+    // A writer thread revokes alice on pod a WHILE many reader threads hammer accessible().
+    // Generation pinning (#1584): each read pins one auth snapshot, so every observed set is
+    // ATOMIC — either the pre-revoke {a,b} or the post-revoke {b}, never a torn set. After the
+    // write is applied, readers converge on the revoked view.
+    let store = Arc::new(std::sync::RwLock::new(two_pod_store()));
+    let pre: Vec<String> = vec!["https://a.ex/n1".to_owned(), "https://b.ex/m1".to_owned()];
+    let post: Vec<String> = vec!["https://b.ex/m1".to_owned()];
+
+    let readers = 12;
+    let barrier = Arc::new(Barrier::new(readers + 1));
+    let mut handles = Vec::new();
+    for _ in 0..readers {
+        let store = Arc::clone(&store);
+        let barrier = Arc::clone(&barrier);
+        let pre = pre.clone();
+        let post = post.clone();
+        handles.push(thread::spawn(move || {
+            barrier.wait();
+            for _ in 0..500 {
+                // Concurrent READ access via the shared &PodStore (read lock = many readers).
+                let guard = store.read().expect("rlock");
+                let got = read_iris(&guard, &sess(ALICE));
+                drop(guard);
+                // The load-bearing invariant: NEVER a torn set. Only two atomic snapshots
+                // are observable regardless of how the write interleaves.
+                assert!(
+                    got == pre || got == post,
+                    "observed a NON-atomic (torn) set: {got:?}"
+                );
+            }
+        }));
+    }
+
+    // The writer: after readers start, revoke alice on pod a (empty .acl on a.ex) once.
+    let writer = {
+        let store = Arc::clone(&store);
+        let barrier = Arc::clone(&barrier);
+        thread::spawn(move || {
+            barrier.wait();
+            // Exclusive lock only for the write; the &mut is needed for put_acl (the reindex
+            // seam). Readers proceed on either side; both snapshots are individually correct.
+            let mut guard = store.write().expect("wlock");
+            guard.put_acl("https://a.ex/.acl", "", "ntriples").expect("revoke");
+        })
+    };
+
+    writer.join().expect("writer ok");
+    for h in handles {
+        h.join().expect("no reader panicked/torn");
+    }
+
+    // After the dust settles, every reader sees exactly the revoked view.
+    let guard = store.read().expect("rlock");
+    assert_eq!(read_iris(&guard, &sess(ALICE)), post, "converged on revoked view");
+    // And it equals a from-scratch rebuild — no stale grant survived the concurrent churn.
+    let fresh: Vec<String> = sparq_solid::AuthIndex::from_graph(&guard.graph)
+        .accessible(&sess(ALICE), Mode::Read)
+        .iter()
+        .map(|n| n.as_str().to_owned())
+        .collect();
+    assert_eq!(read_iris(&guard, &sess(ALICE)), fresh, "no stale grant after churn");
+}

--- a/crates/sparq-solid/tests/conformance_solid_sparql_query.rs
+++ b/crates/sparq-solid/tests/conformance_solid_sparql_query.rs
@@ -100,7 +100,7 @@ fn solid_sparql_query_query_semantics_conformance() {
     let cases = manifest["cases"].as_array().expect("manifest.cases is an array");
     assert!(!cases.is_empty(), "the conformance suite has no cases");
 
-    let mut store = build_store(fixture);
+    let store = build_store(fixture);
     let mut passed = 0usize;
 
     for case in cases {

--- a/crates/sparq-solid/tests/decide.rs
+++ b/crates/sparq-solid/tests/decide.rs
@@ -321,7 +321,7 @@ fn decide_verdict_matches_accessible_oracle() {
     let mut acl = AclBuilder::new();
     acl.document("https://pod.ex/notes/n1.ttl");
     acl.default_for("https://pod.ex/", |a| a.agent(ALICE).mode(Mode::Read).mode(Mode::Write));
-    let mut s = store(acl);
+    let s = store(acl);
 
     let resource = "https://pod.ex/notes/n1.ttl";
     let res_node = NamedNode::new_unchecked(resource);

--- a/crates/sparq-solid/tests/e2e.rs
+++ b/crates/sparq-solid/tests/e2e.rs
@@ -42,7 +42,7 @@ const TITLES: &str = "SELECT ?title WHERE { ?s <https://ex.dev/ns#title> ?title 
 #[cfg(not(feature = "legacy-union-default-graph"))]
 #[test]
 fn bare_default_graph_pattern_is_empty_by_default() {
-    let mut s = store();
+    let s = store();
     let alice = s.query_as(&Session { agent: Some(ALICE), client: None, issuer: None, now: None }, Mode::Read, TITLES).unwrap();
     let carol = s.query_as(&Session { agent: Some(CAROL), client: None, issuer: None, now: None }, Mode::Read, TITLES).unwrap();
     let anon = s.query_as(&Session::default(), Mode::Read, TITLES).unwrap();
@@ -55,7 +55,7 @@ fn bare_default_graph_pattern_is_empty_by_default() {
 #[cfg(feature = "legacy-union-default-graph")]
 #[test]
 fn same_query_different_agents_different_results() {
-    let mut s = store();
+    let s = store();
     let alice = s.query_as(&Session { agent: Some(ALICE), client: None, issuer: None, now: None }, Mode::Read, TITLES).unwrap();
     let carol = s.query_as(&Session { agent: Some(CAROL), client: None, issuer: None, now: None }, Mode::Read, TITLES).unwrap();
     let anon = s.query_as(&Session::default(), Mode::Read, TITLES).unwrap();
@@ -73,7 +73,7 @@ fn same_query_different_agents_different_results() {
 #[cfg(feature = "legacy-union-default-graph")]
 #[test]
 fn graph_patterns_and_cross_document_joins_stay_inside_the_sandbox() {
-    let mut s = store();
+    let s = store();
     // explicit GRAPH ?g: ranges over authorized graphs only (FROM NAMED injection)
     let q = "SELECT ?g WHERE { GRAPH ?g { ?s <https://ex.dev/ns#title> ?title } }";
     let anon = s.query_as(&Session::default(), Mode::Read, q).unwrap();
@@ -96,7 +96,7 @@ fn graph_patterns_and_cross_document_joins_stay_inside_the_sandbox() {
 
 #[test]
 fn explicit_named_graph_query_cannot_escape() {
-    let mut s = store();
+    let s = store();
     // anonymous explicitly asks for a private graph: absent from FROM NAMED ⇒ empty
     let q = "SELECT ?o WHERE { GRAPH <https://pod.ex/priv0/c4/g0/d0.ttl> { ?s ?p ?o } }";
     let anon = s.query_as(&Session::default(), Mode::Read, q).unwrap();
@@ -164,7 +164,7 @@ fn view_path_and_rewrite_path_return_identical_json() {
 /// Shared driver: for every fixture session, assert the view path and the v1 `rewrite_for`
 /// path return byte-identical SPARQL-JSON for each query in `queries`.
 fn assert_paths_agree(queries: &[&str]) {
-    let mut s = store();
+    let s = store();
     let sessions = [
         ("alice", Session { agent: Some(ALICE), client: None, issuer: None, now: None }),
         ("carol", Session { agent: Some(CAROL), client: None, issuer: None, now: None }),

--- a/crates/sparq-solid/tests/union_default_graph.rs
+++ b/crates/sparq-solid/tests/union_default_graph.rs
@@ -39,7 +39,7 @@ fn opt_in(body: &str) -> String {
 /// A bare default-graph pattern with NO opt-in matches nothing — for every session.
 #[test]
 fn bare_default_graph_pattern_is_empty_without_opt_in() {
-    let mut s = store();
+    let s = store();
     assert_eq!(s.query_as(&alice(), Mode::Read, BARE).unwrap().rows.len(), 0, "alice");
     assert_eq!(s.query_as(&carol(), Mode::Read, BARE).unwrap().rows.len(), 0, "carol");
     assert_eq!(s.query_as(&Session::default(), Mode::Read, BARE).unwrap().rows.len(), 0, "anon");
@@ -49,7 +49,7 @@ fn bare_default_graph_pattern_is_empty_without_opt_in() {
 /// the union of the session's authorized named graphs — reproducing today's union counts.
 #[test]
 fn union_default_opt_in_reproduces_authorized_union() {
-    let mut s = store();
+    let s = store();
     let q = opt_in("?s <https://ex.dev/ns#title> ?title");
     assert_eq!(s.query_as(&alice(), Mode::Read, &q).unwrap().rows.len(), 599, "alice union");
     assert_eq!(s.query_as(&carol(), Mode::Read, &q).unwrap().rows.len(), 407, "carol union");
@@ -65,7 +65,7 @@ fn union_default_opt_in_reproduces_authorized_union() {
 /// session never leaks the union view into a subsequent bare request.
 #[test]
 fn opt_in_is_per_request_with_no_state_leak() {
-    let mut s = store();
+    let s = store();
     let q = opt_in("?s <https://ex.dev/ns#title> ?title");
     assert_eq!(s.query_as(&alice(), Mode::Read, &q).unwrap().rows.len(), 599, "opt-in 1");
     // A following BARE request must be empty — the previous opt-in did not stick.
@@ -78,7 +78,7 @@ fn opt_in_is_per_request_with_no_state_leak() {
 /// named graphs with or without the opt-in (only the empty/union DEFAULT graph is gated).
 #[test]
 fn explicit_graph_pattern_unaffected_by_feature() {
-    let mut s = store();
+    let s = store();
     let q = "SELECT ?title WHERE { GRAPH ?g { ?s <https://ex.dev/ns#title> ?title } }";
     assert_eq!(s.query_as(&alice(), Mode::Read, q).unwrap().rows.len(), 599, "alice GRAPH");
     assert_eq!(s.query_as(&Session::default(), Mode::Read, q).unwrap().rows.len(), 144, "anon GRAPH");
@@ -89,7 +89,7 @@ fn explicit_graph_pattern_unaffected_by_feature() {
 /// authorized set (leaving it would wrongly collapse the named-graph set to empty).
 #[test]
 fn reserved_iri_in_from_named_is_absent_graph_stays_usable() {
-    let mut s = store();
+    let s = store();
     let with_reserved = format!(
         "SELECT ?title FROM NAMED <{}> WHERE {{ GRAPH ?g {{ ?s <https://ex.dev/ns#title> ?title }} }}",
         UNION_DEFAULT_GRAPH_IRI
@@ -109,7 +109,7 @@ fn reserved_iri_in_from_named_is_absent_graph_stays_usable() {
 /// binds it, and it never appears in results.
 #[test]
 fn reserved_iri_never_binds_graph_variable() {
-    let mut s = store();
+    let s = store();
     // Opt into the union default graph AND enumerate graph names with `GRAPH ?g`.
     let q = format!(
         "SELECT ?g FROM <{}> WHERE {{ GRAPH ?g {{ ?s <https://ex.dev/ns#title> ?o }} }}",
@@ -130,7 +130,7 @@ fn reserved_iri_never_binds_graph_variable() {
 /// opt-in — it must NOT silently enable the union default graph.
 #[test]
 fn near_miss_iri_does_not_enable_union_fail_closed() {
-    let mut s = store();
+    let s = store();
     let q = "SELECT ?title FROM <http://www.w3.org/ns/solid/sparql#union-default-graphX> \
              WHERE { ?s <https://ex.dev/ns#title> ?title }";
     assert_eq!(
@@ -145,7 +145,7 @@ fn near_miss_iri_does_not_enable_union_fail_closed() {
 /// pattern is 0 without the opt-in.
 #[test]
 fn ask_json_and_aggregate_honour_opt_in() {
-    let mut s = store();
+    let s = store();
     // ASK: false on the bare pattern (empty default), true on the opt-in.
     assert!(!s.ask_as(&alice(), Mode::Read, "ASK { ?s <https://ex.dev/ns#title> ?t }").unwrap());
     let ask_opt = format!("ASK FROM <{}> {{ ?s <https://ex.dev/ns#title> ?t }}", UNION_DEFAULT_GRAPH_IRI);

--- a/crates/sparq-solid/tests/wac.rs
+++ b/crates/sparq-solid/tests/wac.rs
@@ -131,7 +131,7 @@ fn wac_write_enforcement_matches_grants() {
 /// `user="…",public="…"` format against the hand-computed fixture access matrix above.
 #[test]
 fn wac_allow_header_advertises_held_modes() {
-    let mut s = store();
+    let s = store();
     let sess = |agent: Option<&'static str>| Session { agent, client: None, issuer: None, now: None };
     let res = |g: &str| NamedNode::new(g).expect("valid IRI");
 
@@ -162,6 +162,6 @@ fn wac_allow_header_advertises_held_modes() {
     assert_eq!(s.wac_allow(&sess(Some(ALICE)), &unknown), r#"user="",public="""#);
 
     // 6. Fail-closed before materialization: an un-materialized store grants nothing.
-    let mut bare = PodStore::new(Graph::load_dataset(&wac_fixture(), "nquads").expect("fixture loads"));
+    let bare = PodStore::new(Graph::load_dataset(&wac_fixture(), "nquads").expect("fixture loads"));
     assert_eq!(bare.wac_allow(&sess(Some(ALICE)), &pub1), r#"user="",public="""#);
 }

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -188,6 +188,28 @@ Materialize the authorization view from the access-control documents, then enfor
   `store.accessible_set(...)` / `store.view_for(...) -> DatasetView` /
   `store.auth() -> &AuthIndex` — inspect the authorized graph set or the materialized
   index directly.
+- **Concurrent reads — the read side is `&self`** ([FABLE-5] sq-cnuqd, issue #1569). Every
+  read entry point (`accessible`, `accessible_set`, `view_for`, `query_as`, `query_json_as`,
+  `ask_as`, `query_as_rewrite`, `wac_allow`, `decide`) takes `&self`, so **N threads sharing
+  one `Arc<PodStore>` query the same materialized generation at once** — a per-request
+  Solid/SPARQL server no longer serialises every reader through one exclusive borrow. The
+  session cache behind these is **sharded + bounded**: `session_cache::SessionCache` stripes
+  the memoized per-session graph sets across independent `RwLock` shards keyed by the session
+  hash, so a warm hit is a shard *read* lock (+ two `Arc` clones) and only a miss/re-derive
+  takes that one shard's write lock; each shard is **LRU-bounded** (`SHARD_CAP`, with a
+  compacted recency queue) so a server keying per-request `now` timestamps cannot grow the
+  cache without bound. **Writes stay `&mut self`** (`materialize_*`, `put_acl`/`delete_acl`,
+  `update_as`) — they need exclusive access, so a server interleaves reads and writes by
+  wrapping the store in an `RwLock<PodStore>`/arc-swap (readers take the read lock, a write
+  takes the write lock). **Snapshot consistency (fail-closed, no torn set):** each read pins
+  ONE `Arc<AuthIndex>` snapshot for the whole set computation, and because writes are
+  `&mut self` (exclusive), a read observes either the whole pre-write generation or the whole
+  post-write one, never a half-and-half mix (generation pinning composes with #1584);
+  invalidation (`SessionCache::clear` / `invalidate_origin`, the diff-based #1585 path) visits
+  every shard so it reaches a session regardless of which shard it hashed into, and an
+  evicted/dropped set is re-derived on the current auth view — never assumed still authorized.
+  Covered by `tests/concurrent_readers.rs` (16 threads on one `Arc<PodStore>`; a revoke under
+  concurrent read observes only the two atomic snapshots and converges on the revoked view).
 - `store.wac_allow(&Session, &NamedNode) -> String` — build the public
   [`WAC-Allow`](https://solidproject.org/TR/wac#wac-allow) response-header value
   (`user="…",public="…"`) advertising the modes the session (and the public) hold on a
@@ -332,21 +354,25 @@ fn session_from_request<'a>(webid: Option<&'a str>, origin: Option<&'a str>) -> 
 }
 
 // Does this session have `mode` on the graph backing `resource`? (fail-closed)
-fn may(store: &mut PodStore, s: &Session, mode: Mode, resource: &NamedNode) -> bool {
+// [FABLE-5] sq-cnuqd: `&PodStore` (shared) — many request handlers call this at once.
+fn may(store: &PodStore, s: &Session, mode: Mode, resource: &NamedNode) -> bool {
     store.accessible(s, mode).iter().any(|g| g == resource)
 }
 
 // Build the WAC-Allow header value for the request, e.g. `user="read write",public="read"`.
-fn wac_allow_header(store: &mut PodStore, s: &Session, resource: &NamedNode) -> String {
+fn wac_allow_header(store: &PodStore, s: &Session, resource: &NamedNode) -> String {
     store.wac_allow(s, resource)
 }
 ```
 
-Per request: `session_from_request(...)` → `may(&mut store, &s, Mode::Read, &resource)`
+Per request: `session_from_request(...)` → `may(&store, &s, Mode::Read, &resource)`
 to allow/deny (a deny is `403`/`404` per your fail-closed policy) → set the response's
 `WAC-Allow` header to `store.wac_allow(&s, &resource)`. `wac_allow` runs four
 `accessible` sweeps that share the per-session cache (each an O(1) hash check over the
-materialized index), so it is cheap. To pair the `WAC-Allow` advertisement with the WAC
+materialized index), so it is cheap. Because these read helpers take **`&self`** (sq-cnuqd),
+a concurrent server shares ONE `Arc<PodStore>` (or `Arc<RwLock<PodStore>>` if it also serves
+writes) across all request workers — they read in parallel through the sharded session cache;
+only a `put_acl`/materialize write needs the exclusive (`&mut`/write-lock) side. To pair the `WAC-Allow` advertisement with the WAC
 **ACL-discovery** header, run `store.decide(&s, "<resource-iri>", Mode::Read)` and emit its
 `acl_link_header()` (`Some("<acl-iri>; rel=\"acl\"")`) as the response `Link` header value
 when present (FR-5) — fail-closed: it is `None` when no governing ACL was discovered, so


### PR DESCRIPTION
> 🤖 SPARQ agent — resuming bead **sq-cnuqd** (PSS issue #1569). This is an **authorization-surface** change; I am requesting **escalated review** and have **NOT armed auto-merge**.

## What this implements

Makes the `sparq-solid` **read side `&self`** and moves the memoized per-session graph-set cache behind a new **bounded, sharded, interior-mutable** `session_cache::SessionCache`, so N threads sharing one `Arc<PodStore>` query the same materialized generation **concurrently** instead of serialising through one exclusive `&mut self` borrow (the PSS per-request-server target, #1569).

Every read entry point now takes `&self`: `accessible`, `accessible_set`, `view_for`, `query_as`, `query_json_as`, `ask_as`, `query_as_rewrite`, `wac_allow`, `decide`. Writes (`materialize_*`, `put_acl`/`delete_acl`, `update_as`) stay `&mut self` (exclusive) — a concurrent server interleaves reads and writes by wrapping the store in an `RwLock<PodStore>`/arc-swap.

### The cache

- **Sharded** — `SHARDS` independent `RwLock` stripes keyed by the session-key hash. A warm hit is a shard **read** lock + two `Arc` clones; only a miss/re-derive takes that one shard's write lock.
- **Bounded** — each shard is LRU-capped at `SHARD_CAP`, so a server keying per-request `now` timestamps can no longer grow the cache without bound.
- **Exact-semantics preserving** — the cache is transient index state (design D3). It composes with `AclIndex` (#1577), generation pinning (#1584) and the diff-based origin-scoped invalidation (#1585): a read pins **one** `Arc<AuthIndex>` snapshot for the whole computation, and `invalidate_origin` visits **every** shard so a session is reached regardless of which shard it hashed into. Fail-closed: an evicted/dropped set is re-derived on the current auth view, never assumed still authorized.

### Bug found + fixed while resuming ([FABLE-5])

The prior (killed mid-implementation) draft's LRU **recency queue grew without bound** under invalidation churn: a hot session re-touched via `miss → fill → invalidate_origin → miss → fill …` left one stale recency copy per re-touch while `map` never grew past `SHARD_CAP`, so `evict_to_cap` never fired to drain it — an unbounded memory leak that also made each eviction O(queue). Fixed by compacting the recency queue to one-entry-per-live-key once it exceeds `RECENCY_SLACK * SHARD_CAP`, with a direct regression test (`recency_queue_stays_bounded_under_hot_key_churn`).

## Tests (the real path)

- `tests/concurrent_readers.rs` — 16 threads on one `Arc<PodStore>` get session-scoped, fail-closed results; a revoke under concurrent read observes only the **two atomic snapshots** (never a torn half-and-half set) and converges on the revoked view. **Snapshot consistency note (honest):** the torn-set impossibility is jointly enforced by the `&mut self` write path (exclusive) plus the caller's outer `RwLock` and the per-call `Arc<AuthIndex>` pinning — the test uses exactly the real `Arc<RwLock<PodStore>>` deployment shape.
- Direct `session_cache` unit tests — hit/miss/compute-once, bounded per-shard eviction, the recency-bound regression, `clear`, per-origin invalidation, shard-selection stability.

## Gates (both feature states)

- `cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` — GREEN in **default** (feature OFF) AND **`--all-features`**.
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-solid --no-deps --all-features` — clean.
- `scripts/check-readme-template.py --enforce` — **0 deviations** (README 120 lines).
- **No new dependency, no cargo feature** — std `RwLock` + the existing `rustc-hash`; `sparq-core`/`sparq-engine` untouched.

Docs updated: crate `README.md` + `skills/access-control/SKILL.md` (the `&self` read side, the sharded+bounded cache, the write-interleaving pattern, and the fail-closed snapshot-consistency semantics).

Refs sq-cnuqd, #1569 (composes with #1577 / #1584 / #1585 / #1593).