### PR TITLE
feat(solid/odrl): stateless ODRL core as stratified N3 rules + CI-locked Rust-vs-N3 decision differential (sq-zgbso.2) [FABLE-5]

### DIFF
--- a/crates/sparq-solid/rules/odrl-core-a.n3
+++ b/crates/sparq-solid/rules/odrl-core-a.n3
@@ -1,0 +1,176 @@
+# [FABLE-5] sq-zgbso.2 — ODRL stateless core as N3, STRATUM A (of A→B→C→D).
+#
+# Input facts are the `oc:` fact schema `odrl_bridge::materialize_policy_n3` serializes
+# from the PARSED `sparq_policy::Policy` + `N3Request` (never raw policy text — the two
+# paths must consume identical semantic content). This stratum derives everything whose
+# negation ranges ONLY over input facts (design record research/odrl-n3-compiled-rules.md;
+# stratification discipline: research/solid-access-control-design.md §3.5 — a negated
+# predicate must be COMPLETE before its stratum runs; input predicates are complete by
+# construction, so `log:notIncludes` here scopes only over `oc:evLeft` / `oc:member` /
+# `oc:discharged` / `oc:TransferAction`, none of which any rule derives).
+#
+# Outputs (inputs to stratum B/C/D):
+#   ?rule oc:actionOK / oc:targetOK / oc:assigneeOK true   — structural match legs
+#   ?c    oc:sat true          — atomic constraint SATISFIED (evidence exists + holds)
+#   ?c    oc:unprovable true   — no evidence for the constraint's dimension
+#   ?c    oc:notSat true       — NOT satisfied (definitely-failed OR unprovable):
+#                                 mirrors `constraint_satisfied == false` (fail-closed)
+#   ?lc   oc:lcNotSat true     — the compound-combinator pieces derivable here
+#   ?rule oc:blocked true      — some DIRECT atomic constraint of the rule is notSat
+#   ?rule oc:dutyBlocked true  — some duty action is undischarged
+#
+# dateTime (spike finding (a) RESOLVED): comparisons normalize BOTH operands to epoch
+# seconds via `time:inSeconds` — the engine's offset-aware civil-time extraction — and
+# compare with `math:*`, so arbitrary `±hh:mm` offsets order by the INSTANT they denote,
+# exactly like `sparq_policy`'s `parse_instant`. The wrapper additionally fail-closes
+# the accepted lexical space to second-precision forms (no fractional seconds, no leap
+# second, no negative year) where the two normalizers provably agree.
+
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix oc:   <https://sparq.dev/ns/odrl-core#> .
+@prefix log:  <http://www.w3.org/2000/10/swap/log#> .
+@prefix math: <http://www.w3.org/2000/10/swap/math#> .
+@prefix time: <http://www.w3.org/2000/10/swap/time#> .
+
+# ── ODRL 2.2 ownership-`transfer` subtree: the ONE top-level branch outside `use`
+#    (mirror of sparq_policy::model::is_transfer_subtree; `use` never permits these).
+odrl:transfer a oc:TransferAction .
+odrl:sell     a oc:TransferAction .
+odrl:give     a oc:TransferAction .
+
+# ── action: the rule's action permits the requested action ────────────────────────────
+# exact-IRI match (Action::permits, first arm)
+{ ?rule a oc:Rule ; oc:action ?a . ?req a oc:Request ; oc:reqAction ?a . }
+=> { ?rule oc:actionOK true . } .
+# the `odrl:use` umbrella permits any requested action NOT in the transfer subtree
+# (Action::permits, second arm — sq-euhr3). Static-set negation: input-only.
+{ ?rule a oc:Rule ; oc:action odrl:use . ?req a oc:Request ; oc:reqAction ?ra .
+  ?UNSCOPED log:notIncludes { ?ra a oc:TransferAction . } . }
+=> { ?rule oc:actionOK true . } .
+
+# ── target / assignee: exact IRI agreement, or the rule leaves the slot open ──────────
+# (rule.target == None → `oc:anyTarget` marker emitted by the serializer — no negation
+# needed; collection membership is OUTSIDE the N3 subset by construction: `N3Request`
+# cannot carry membership evidence, so exact match IS the Rust base case.)
+{ ?rule a oc:Rule ; oc:target ?t . ?req a oc:Request ; oc:reqTarget ?t . }
+=> { ?rule oc:targetOK true . } .
+{ ?rule a oc:Rule ; oc:anyTarget true . }
+=> { ?rule oc:targetOK true . } .
+{ ?rule a oc:Rule ; oc:assignee ?p . ?req a oc:Request ; oc:reqParty ?p . }
+=> { ?rule oc:assigneeOK true . } .
+{ ?rule a oc:Rule ; oc:anyAssignee true . }
+=> { ?rule oc:assigneeOK true . } .
+
+# ── atomic constraints, NON-dateTime dimensions ───────────────────────────────────────
+# Operands are pre-lexicalized by the serializer (`oc:boundLex` / `oc:evLex` carry the
+# SAME `Value::as_str()` string the Rust evaluator compares — one source of value truth),
+# so eq/neq here is exactly `value_eq` and isPartOf exactly `is_part_of` (the serializer
+# splits the set members). Only {eq, isA, neq, isPartOf} exist for non-dateTime
+# dimensions inside the wrapper-guarded subset (order operators there are REFUSED).
+#
+# eq / isA — satisfied iff the evidence lexical equals the bound lexical.
+{ ?c a oc:Atomic ; oc:op oc:eq ; oc:left ?l ; oc:boundLex ?b .
+  ?ev oc:evLeft ?l ; oc:evLex ?v . ?v log:equalTo ?b . }
+=> { ?c oc:sat true . } .
+{ ?c a oc:Atomic ; oc:op oc:eq ; oc:left ?l ; oc:boundLex ?b .
+  ?ev oc:evLeft ?l ; oc:evLex ?v . ?v log:notEqualTo ?b . }
+=> { ?c oc:notSat true . } .
+# neq — the mirror image.
+{ ?c a oc:Atomic ; oc:op oc:neq ; oc:left ?l ; oc:boundLex ?b .
+  ?ev oc:evLeft ?l ; oc:evLex ?v . ?v log:notEqualTo ?b . }
+=> { ?c oc:sat true . } .
+{ ?c a oc:Atomic ; oc:op oc:neq ; oc:left ?l ; oc:boundLex ?b .
+  ?ev oc:evLeft ?l ; oc:evLex ?v . ?v log:equalTo ?b . }
+=> { ?c oc:notSat true . } .
+# isPartOf — the evidence lexical is a member of the pre-split right-operand set.
+# (The negation ranges over `oc:member`, an input-only predicate — safe here. An empty
+# member set — e.g. an empty-string bound — has no member facts, so with evidence
+# present the notSat rule fires, mirroring `any()` over an empty set.)
+{ ?c a oc:Atomic ; oc:op oc:isPartOf ; oc:left ?l .
+  ?ev oc:evLeft ?l ; oc:evLex ?v . ?c oc:member ?v . }
+=> { ?c oc:sat true . } .
+{ ?c a oc:Atomic ; oc:op oc:isPartOf ; oc:left ?l .
+  ?ev oc:evLeft ?l ; oc:evLex ?v .
+  ?UNSCOPED log:notIncludes { ?c oc:member ?v . } . }
+=> { ?c oc:notSat true . } .
+
+# ── atomic constraints, the `odrl:dateTime` dimension ─────────────────────────────────
+# `oc:boundDt` is emitted ONLY for dateTime-dimension constraints; the evidence is the
+# request's `oc:atTime` (the `Request::at` evaluation-time evidence). Both normalize to
+# epoch seconds (offset-aware) before the numeric comparison — instant order, not
+# lexical order.
+{ ?c a oc:Atomic ; oc:op oc:lteq ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:notGreaterThan ?bs . }
+=> { ?c oc:sat true . } .
+{ ?c a oc:Atomic ; oc:op oc:lteq ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:greaterThan ?bs . }
+=> { ?c oc:notSat true . } .
+{ ?c a oc:Atomic ; oc:op oc:lt ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:lessThan ?bs . }
+=> { ?c oc:sat true . } .
+{ ?c a oc:Atomic ; oc:op oc:lt ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:notLessThan ?bs . }
+=> { ?c oc:notSat true . } .
+{ ?c a oc:Atomic ; oc:op oc:gteq ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:notLessThan ?bs . }
+=> { ?c oc:sat true . } .
+{ ?c a oc:Atomic ; oc:op oc:gteq ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:lessThan ?bs . }
+=> { ?c oc:notSat true . } .
+{ ?c a oc:Atomic ; oc:op oc:gt ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:greaterThan ?bs . }
+=> { ?c oc:sat true . } .
+{ ?c a oc:Atomic ; oc:op oc:gt ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:notGreaterThan ?bs . }
+=> { ?c oc:notSat true . } .
+# eq / neq on dateTime compare the INSTANT (value_eq's DateTime arm), not the lexical.
+{ ?c a oc:Atomic ; oc:op oc:eq ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:equalTo ?bs . }
+=> { ?c oc:sat true . } .
+{ ?c a oc:Atomic ; oc:op oc:eq ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:notEqualTo ?bs . }
+=> { ?c oc:notSat true . } .
+{ ?c a oc:Atomic ; oc:op oc:neq ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:notEqualTo ?bs . }
+=> { ?c oc:sat true . } .
+{ ?c a oc:Atomic ; oc:op oc:neq ; oc:boundDt ?b . ?req a oc:Request ; oc:atTime ?t .
+  ?t time:inSeconds ?ts . ?b time:inSeconds ?bs . ?ts math:equalTo ?bs . }
+=> { ?c oc:notSat true . } .
+
+# ── unprovable: no evidence for the constraint's dimension ────────────────────────────
+# Mirrors `resolve_actual == None` (the serializer emits an `oc:evLeft` fact for every
+# dimension the request supplies — including `odrl:dateTime` when `at` is set and the
+# recipient-defaults-to-party rule). Unprovable ⇒ not satisfied (fail-closed): a
+# permission does not grant, a prohibition does not carve out. The unsatisfiable-guard
+# constraint parse.rs emits for malformed input (left `urn:sparq-policy:malformed`)
+# lands here too — no evidence dimension can ever match it.
+{ ?c a oc:Atomic ; oc:left ?l .
+  ?UNSCOPED log:notIncludes { ?ev oc:evLeft ?l . } . }
+=> { ?c oc:unprovable true . } .
+{ ?c oc:unprovable true . } => { ?c oc:notSat true . } .
+
+# ── duties: a permission with an undischarged duty action cannot grant ────────────────
+{ ?rule a oc:Rule ; oc:dutyAction ?a . ?req a oc:Request .
+  ?UNSCOPED log:notIncludes { ?req oc:discharged ?a . } . }
+=> { ?rule oc:dutyBlocked true . } .
+
+# ── compound-combinator pieces derivable in THIS stratum (positive over oc:sat /
+#    oc:notSat / oc:unprovable, which are complete at this stratum's fixpoint) ─────────
+# and: NOT-satisfied iff any operand is notSat (definitely false OR unprovable) —
+# logical_constraint_status: `and` is Satisfied only when EVERY operand is Satisfied.
+{ ?lc oc:combinator oc:and ; oc:operand ?c . ?c oc:notSat true . }
+=> { ?lc oc:lcNotSat true . } .
+# an EMPTY operand set never satisfies any combinator (and→Unprovable, or/xone→
+# DefinitelyUnsatisfied — all fold to notSat for rule matching, fail-closed).
+{ ?lc oc:emptyOperands true . } => { ?lc oc:lcNotSat true . } .
+# xone: an unprovable operand could be the disqualifying second true → never Satisfied.
+{ ?lc oc:combinator oc:xone ; oc:operand ?c . ?c oc:unprovable true . }
+=> { ?lc oc:lcNotSat true . } .
+# xone: two DISTINCT satisfied operands → provably ≥ 2 → not exactly one.
+{ ?lc oc:combinator oc:xone ; oc:operand ?c1 , ?c2 .
+  ?c1 oc:sat true . ?c2 oc:sat true . ?c1 log:notEqualTo ?c2 . }
+=> { ?lc oc:lcNotSat true . } .
+
+# ── a rule with a DIRECT atomic constraint that is notSat can never match ─────────────
+{ ?rule a oc:Rule ; oc:constraint ?c . ?c oc:notSat true . }
+=> { ?rule oc:blocked true . } .

--- a/crates/sparq-solid/rules/odrl-core-b.n3
+++ b/crates/sparq-solid/rules/odrl-core-b.n3
@@ -1,0 +1,35 @@
+# [FABLE-5] sq-zgbso.2 — ODRL stateless core as N3, STRATUM B (of A→B→C→D).
+#
+# Runs as its own `reason_n3` call seeded with stratum A's closure (§3.5 discipline).
+# `oc:sat` is COMPLETE after stratum A (every satisfaction rule lives there), so this
+# stratum may negate over it — the piece the spike's finding (c) said needed fuller
+# stratification: `or`/`xone` require "NO operand is satisfied", a universal that is
+# negation over a DERIVED predicate and therefore cannot live in stratum A.
+#
+# Outputs: the remaining `?lc oc:lcNotSat true` pieces + `?rule oc:blocked true` for
+# rules with an unsatisfied compound constraint. `oc:blocked` is complete after THIS
+# stratum (both its stratum-A atomic piece and this logical piece are in), so stratum C
+# may negate over it.
+
+@prefix oc:  <https://sparq.dev/ns/odrl-core#> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+# or: NOT-satisfied iff no operand is satisfied (logical_constraint_status: `or` is
+# Satisfied iff ANY operand is Satisfied; zero satisfied — whether the rest are
+# definitely-false or unprovable — never satisfies, fail-closed).
+{ ?lc oc:combinator oc:or .
+  ?UNSCOPED log:notIncludes { ?lc oc:operand ?c . ?c oc:sat true . } . }
+=> { ?lc oc:lcNotSat true . } .
+
+# xone: zero satisfied operands → provably not exactly one. (The ≥2 and any-unprovable
+# cases were already derived in stratum A; together the three pieces are exactly
+# "NOT (exactly one Satisfied AND no Unprovable)" — ¬Satisfied for xone.)
+{ ?lc oc:combinator oc:xone .
+  ?UNSCOPED log:notIncludes { ?lc oc:operand ?c . ?c oc:sat true . } . }
+=> { ?lc oc:lcNotSat true . } .
+
+# a rule with a compound constraint that is not Satisfied can never match
+# (rule_matches requires every logical constraint Satisfied — fail-closed on
+# Unprovable as well as DefinitelyUnsatisfied).
+{ ?rule a oc:Rule ; oc:logical ?lc . ?lc oc:lcNotSat true . }
+=> { ?rule oc:blocked true . } .

--- a/crates/sparq-solid/rules/odrl-core-c.n3
+++ b/crates/sparq-solid/rules/odrl-core-c.n3
@@ -1,0 +1,16 @@
+# [FABLE-5] sq-zgbso.2 — ODRL stateless core as N3, STRATUM C (of A→B→C→D).
+#
+# Runs seeded with stratum B's closure. `oc:blocked` is complete after stratum B (its
+# atomic piece from A, its compound piece from B), so rule MATCHING may now negate it.
+#
+# `?rule oc:matches true` mirrors `sparq_policy`'s `rule_matches`: the action permits
+# the requested action, target and assignee agree (or are unconstrained), and NO
+# constraint — atomic or compound — is unsatisfied. Duties are NOT part of matching
+# (they gate only the permission GRANT, stratum D), exactly like the evaluator.
+
+@prefix oc:  <https://sparq.dev/ns/odrl-core#> .
+@prefix log: <http://www.w3.org/2000/10/swap/log#> .
+
+{ ?rule a oc:Rule ; oc:actionOK true ; oc:targetOK true ; oc:assigneeOK true .
+  ?UNSCOPED log:notIncludes { ?rule oc:blocked true . } . }
+=> { ?rule oc:matches true . } .

--- a/crates/sparq-solid/rules/odrl-core-d.n3
+++ b/crates/sparq-solid/rules/odrl-core-d.n3
@@ -1,0 +1,58 @@
+# [FABLE-5] sq-zgbso.2 — ODRL stateless core as N3, STRATUM D (of A→B→C→D).
+#
+# Runs seeded with stratum C's closure. `oc:matches` is complete, so DENY-OVERRIDES —
+# "a matching prohibition blocks every permission grant" (`evaluate` step 1) — is now a
+# sound negation. Derives the SAME `<urn:sparq:auth>` view triples the Rust bridge
+# writes:
+#
+#   allow:  `?party auth:<mode> ?target`      (materialize_permission on a Permit)
+#   deny:   `?party auth:deny<Mode> ?target`  (materialize_prohibition on a match)
+#
+# The mode comes from the REQUEST action through the same table as
+# `odrl_bridge::action_to_mode` (below, as data facts): an unmapped request action —
+# including the `odrl:use` umbrella — yields no mode fact and therefore NO triple,
+# and a request without a concrete party or target derives nothing (fail-closed),
+# exactly like the bridge's concreteness checks.
+
+@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+@prefix auth: <https://sparq.dev/ns/auth#> .
+@prefix oc:   <https://sparq.dev/ns/odrl-core#> .
+@prefix log:  <http://www.w3.org/2000/10/swap/log#> .
+
+# ── request action → WAC/ACP mode (mirror of odrl_bridge::action_to_mode) ─────────────
+odrl:read    oc:mode auth:read .
+odrl:display oc:mode auth:read .
+odrl:present oc:mode auth:read .
+odrl:print   oc:mode auth:read .
+odrl:play    oc:mode auth:read .
+odrl:append  oc:mode auth:append .
+odrl:modify  oc:mode auth:write .
+odrl:delete  oc:mode auth:write .
+odrl:write   oc:mode auth:write .
+
+# ── request action → the `auth:deny<Mode>` predicate a matched prohibition emits ──────
+odrl:read    oc:denyMode auth:denyRead .
+odrl:display oc:denyMode auth:denyRead .
+odrl:present oc:denyMode auth:denyRead .
+odrl:print   oc:denyMode auth:denyRead .
+odrl:play    oc:denyMode auth:denyRead .
+odrl:append  oc:denyMode auth:denyAppend .
+odrl:modify  oc:denyMode auth:denyWrite .
+odrl:delete  oc:denyMode auth:denyWrite .
+odrl:write   oc:denyMode auth:denyWrite .
+
+# ── deny: a matched prohibition materializes the explicit deny triple ─────────────────
+{ ?p a oc:Prohibition ; oc:matches true .
+  ?req a oc:Request ; oc:reqAction ?a ; oc:reqParty ?party ; oc:reqTarget ?t .
+  ?a oc:denyMode ?dm . }
+=> { ?party ?dm ?t . } .
+
+# ── allow: a matched permission grants IFF its duties are discharged AND no
+#    prohibition matches the request (deny-overrides — `evaluate` denies on ANY
+#    matching prohibition, so the negation is over the whole policy's prohibitions) ────
+{ ?p a oc:Permission ; oc:matches true .
+  ?req a oc:Request ; oc:reqAction ?a ; oc:reqParty ?party ; oc:reqTarget ?t .
+  ?a oc:mode ?m .
+  ?UNSCOPED log:notIncludes { ?p oc:dutyBlocked true . } .
+  ?UNSCOPED2 log:notIncludes { ?x a oc:Prohibition ; oc:matches true . } . }
+=> { ?party ?m ?t . } .

--- a/crates/sparq-solid/src/odrl_bridge.rs
+++ b/crates/sparq-solid/src/odrl_bridge.rs
@@ -117,9 +117,10 @@ use oxrdf::{Literal, NamedNode, Term};
 use sparq_core::dict::Dict;
 use sparq_core::Graph;
 use sparq_policy::{
-    conflict_admissibility, evaluate, matched_prohibition, prohibition_status, Operator, Policy,
-    ProhibitionStatus, Request, Rule, Value,
+    conflict_admissibility, evaluate, matched_prohibition, prohibition_status, Constraint,
+    ConstraintNode, LogicalOperator, Operator, Policy, ProhibitionStatus, Request, Rule, Value,
 };
+use std::collections::{BTreeMap, BTreeSet};
 
 /// The ODRL namespace prefix (`odrl:`), re-exported for caller convenience.
 pub const ODRL_NS: &str = sparq_policy::ODRL_NS;
@@ -1722,6 +1723,892 @@ fn reemit_deny(graph: &mut Graph, request: &Request) -> BridgeOutcome {
         deny_triple: Some((party.to_owned(), pred, target.to_owned())),
         emitted: vec![triple],
         ..BridgeOutcome::default()
+    }
+}
+
+// ============================================================================
+// [FABLE-5] sq-zgbso.2 — the ODRL STATELESS core evaluated as N3 rule strata
+// (`rules/odrl-core-{a,b,c,d}.n3`) through the SAME runtime `reason_n3` engine
+// WAC/ACP use, differential-locked against the Rust path (epic sq-zgbso, #1582;
+// design record `research/odrl-n3-compiled-rules.md`).
+//
+// OPT-IN, NON-DEFAULT: nothing in the crate calls this path — the Rust evaluator
+// ([`materialize_policy`] over [`sparq_policy::evaluate`]) remains THE default. This
+// entry point exists to prove decision parity at corpus scale
+// (`tests/odrl_n3_differential.rs`); flipping any default is a later maintainer
+// decision (and the build-time-compiled flip is sq-zgbso.5, gated on sq-zgbso.3/.4).
+//
+// # The stateless N3 subset (fail-closed contract)
+//
+// [`materialize_policy_n3`] evaluates exactly the subset both paths PROVABLY agree
+// on, and returns a loud `Err` — materializing NOTHING — for anything outside it:
+//
+// - **Rules:** Permission/Prohibition with action (incl. the `odrl:use` umbrella
+//   against the transfer subtree), exact-IRI target/assignee (or unconstrained),
+//   duties (discharge-by-action), and deny-overrides.
+// - **Constraints:** `odrl:dateTime` under `lt/lteq/gt/gteq/eq/neq` with the
+//   guarded lexical space below; every other dimension under `eq/neq/isA/isPartOf`
+//   with IRI/string operands, compared by the same `Value::as_str()` lexical the
+//   evaluator uses. Compound `odrl:and`/`or`/`xone` with ATOMIC operands.
+// - **Outside the subset (⇒ `Err`):** nested compound constraints, numeric
+//   operands/evidence (`odrl:count` is STATEFUL and stays Rust — mutation is not
+//   inference), order operators on non-dateTime dimensions, `isA`/`isPartOf` on
+//   `odrl:dateTime`, and non-admissible dateTime lexicals.
+// - **Impossible by construction:** [`N3Request`] carries no party/asset-collection
+//   membership and no purpose/spatial subsumption closure, so exact-IRI matching IS
+//   the Rust base case (with such evidence absent the two paths are byte-identical);
+//   a caller needing taxonomy evidence must use the Rust path.
+//
+// # dateTime normalization (spike sq-zgbso.1 finding (a), RESOLVED)
+//
+// The spike compared `odrl:dateTime` LEXICALLY (`string:notGreaterThan`), which is
+// instant-correct only for canonical UTC forms. The production strata instead
+// normalize BOTH operands to epoch seconds with the engine's offset-aware
+// `time:inSeconds` builtin and compare numerically — mixed `±hh:mm` offsets now
+// order by the INSTANT they denote, exactly like `sparq_policy`'s `parse_instant`.
+// Residually, the two normalizers differ on sub-second precision (Rust keeps
+// nanoseconds; `time:inSeconds` truncates), leap seconds (Rust clamps `:60`), and
+// exotic years — so the accepted lexical space is additionally FAIL-CLOSED to
+// `YYYY-MM-DD` / `YYYY-MM-DDThh:mm:ss` with an optional `Z`/`±hh:mm` offset, no
+// fractional seconds, no leap second, no negative or ≥5-digit year (see
+// `n3_datetime_admissible`). Anything else is a loud `Err`, never a silent
+// divergence window.
+//
+// # Stratification (spike finding (c) + design record §7)
+//
+// The engine's `log:notIncludes` is negation-as-failure WITHOUT retraction, so every
+// negated predicate must be COMPLETE before its stratum runs (the WAC/ACP §3.5
+// lesson). The spike's single stratum could not carry constraint-bearing
+// prohibitions; the production rules run FOUR strata:
+//
+//   A  structural legs + atomic constraint statuses (sat / unprovable / notSat) +
+//      duty blocking — negation over INPUT facts only;
+//   B  `or`/`xone` "no operand satisfied" — negation over A-complete `oc:sat`;
+//   C  rule matching — negation over B-complete `oc:blocked`;
+//   D  decision triples — deny from matched prohibitions; allow negating
+//      C-complete prohibition matches (deny-overrides) + A-complete duty blocks.
+// ============================================================================
+
+/// Stratum A of the ODRL-as-N3 rule set: structural match legs + atomic constraint
+/// statuses (negation over input facts only). [FABLE-5] sq-zgbso.2.
+const ODRL_CORE_A: &str = include_str!("../rules/odrl-core-a.n3");
+/// Stratum B: `or`/`xone` completion over stratum A's satisfaction facts.
+const ODRL_CORE_B: &str = include_str!("../rules/odrl-core-b.n3");
+/// Stratum C: rule matching over stratum B's completed blocking facts.
+const ODRL_CORE_C: &str = include_str!("../rules/odrl-core-c.n3");
+/// Stratum D: auth-view decision triples with deny-overrides.
+const ODRL_CORE_D: &str = include_str!("../rules/odrl-core-d.n3");
+
+/// The `oc:` helper vocabulary namespace the ODRL-as-N3 fact schema + rule strata use.
+const OC_NS: &str = "https://sparq.dev/ns/odrl-core#";
+/// Synthetic node IRI prefix for the serialized policy/request facts (rule nodes,
+/// constraint nodes, evidence nodes — stable, collision-free with real IRIs because
+/// the reserved `urn:sparq:` prefix is rejected in user-supplied principals).
+const OC_NODE: &str = "urn:sparq:odrl-n3#";
+const XSD_DATETIME_IRI: &str = "http://www.w3.org/2001/XMLSchema#dateTime";
+
+/// An evaluation request for the **N3 path** ([`materialize_policy_n3`]) — the
+/// stateless-subset counterpart of [`sparq_policy::Request`]. [FABLE-5] sq-zgbso.2.
+///
+/// By construction this type carries only evidence the N3 strata model faithfully:
+/// action / target / party, the evaluation time ([`at`](N3Request::at)), per-dimension
+/// IRI/string context evidence, and discharged duty actions. It deliberately has **no**
+/// party/asset-collection membership and **no** purpose/spatial subsumption closure —
+/// with that evidence absent, `sparq_policy`'s matching is exactly the exact-IRI base
+/// case the rules implement, so the two paths cannot silently diverge on it. Convert
+/// with [`to_request`](N3Request::to_request) to run the SAME request through the Rust
+/// evaluator (that is what the differential suite does).
+///
+/// # Examples
+///
+/// ```
+/// use sparq_solid::odrl_bridge::N3Request;
+/// let req = N3Request::new("http://www.w3.org/ns/odrl/2/read")
+///     .on("https://pod.ex/notes/n1")
+///     .by("https://alice.ex/card#me")
+///     .at("2026-07-01T00:00:00Z");
+/// let rust_req = req.to_request();
+/// assert_eq!(rust_req.action, "http://www.w3.org/ns/odrl/2/read");
+/// assert_eq!(rust_req.target.as_deref(), Some("https://pod.ex/notes/n1"));
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct N3Request {
+    /// The requested `odrl:` action IRI.
+    pub action: String,
+    /// The target asset/graph IRI, if any (no target ⇒ nothing can materialize).
+    pub target: Option<String>,
+    /// The requesting party (WebID), if any. Doubles as the default
+    /// `odrl:recipient` evidence, mirroring [`Request::by`].
+    pub party: Option<String>,
+    /// The evaluation-time evidence (`odrl:dateTime`), as an admissible
+    /// `xsd:dateTime`/`xsd:date` lexical (see the module notes on the accepted
+    /// lexical space). `None` ⇒ time-gated rules are unprovable (fail-closed).
+    pub at: Option<String>,
+    /// Context evidence keyed by `leftOperand` IRI — [`Value::Iri`]/[`Value::Str`]
+    /// only (numeric/dateTime evidence is outside the subset; the evaluation time
+    /// goes in [`at`](N3Request::at)).
+    pub evidence: BTreeMap<String, Value>,
+    /// Duty action IRIs the caller asserts discharged.
+    pub discharged: BTreeSet<String>,
+}
+
+impl N3Request {
+    /// A request for `action` with no target/party/evidence yet.
+    pub fn new(action: impl Into<String>) -> N3Request {
+        N3Request { action: action.into(), ..N3Request::default() }
+    }
+
+    /// Set the target asset/graph IRI (chainable).
+    pub fn on(mut self, target: impl Into<String>) -> N3Request {
+        self.target = Some(target.into());
+        self
+    }
+
+    /// Set the requesting party (WebID) IRI (chainable).
+    pub fn by(mut self, party: impl Into<String>) -> N3Request {
+        self.party = Some(party.into());
+        self
+    }
+
+    /// Set the evaluation-time evidence (chainable) — the `odrl:dateTime` value
+    /// time-window constraints are checked against, mirroring [`Request::at`].
+    pub fn at(mut self, instant: impl Into<String>) -> N3Request {
+        self.at = Some(instant.into());
+        self
+    }
+
+    /// Add IRI/string context evidence for a `leftOperand` dimension (chainable).
+    pub fn with(mut self, left_operand: impl Into<String>, value: Value) -> N3Request {
+        self.evidence.insert(left_operand.into(), value);
+        self
+    }
+
+    /// Mark a duty action IRI as discharged (chainable).
+    pub fn discharge(mut self, duty_action: impl Into<String>) -> N3Request {
+        self.discharged.insert(duty_action.into());
+        self
+    }
+
+    /// The equivalent [`sparq_policy::Request`], for running the SAME request
+    /// through the Rust evaluator (the differential's other leg).
+    pub fn to_request(&self) -> Request {
+        let mut r = Request::new(self.action.clone());
+        if let Some(t) = &self.target {
+            r = r.on(t.clone());
+        }
+        if let Some(p) = &self.party {
+            r = r.by(p.clone());
+        }
+        if let Some(a) = &self.at {
+            r = r.at(a.clone());
+        }
+        for (k, v) in &self.evidence {
+            r = r.with(k.clone(), v.clone());
+        }
+        for d in &self.discharged {
+            r = r.discharge(d.clone());
+        }
+        r
+    }
+}
+
+/// Whether a dateTime lexical is inside the FAIL-CLOSED space on which the N3
+/// (`time:inSeconds`, second precision) and Rust (`parse_instant`, nanosecond
+/// precision) normalizers provably agree: `YYYY-MM-DD(Thh:mm:ss(Z|±hh:mm)?)?` with
+/// in-range fields, no fractional seconds, no leap second (`:60`), no negative or
+/// ≥5-digit year. [FABLE-5] sq-zgbso.2 (spike finding (a)).
+fn n3_datetime_admissible(s: &str) -> bool {
+    let b = s.as_bytes();
+    let all_digits = |r: &[u8]| r.iter().all(u8::is_ascii_digit);
+    let num2 = |r: &[u8]| -> u32 { (u32::from(r[0]) - 48) * 10 + (u32::from(r[1]) - 48) };
+    // date: YYYY-MM-DD with MM 01–12, DD 01–31
+    if b.len() < 10
+        || !all_digits(&b[0..4])
+        || b[4] != b'-'
+        || !all_digits(&b[5..7])
+        || b[7] != b'-'
+        || !all_digits(&b[8..10])
+    {
+        return false;
+    }
+    if !(1..=12).contains(&num2(&b[5..7])) || !(1..=31).contains(&num2(&b[8..10])) {
+        return false;
+    }
+    if b.len() == 10 {
+        return true; // bare xsd:date (midnight UTC on both paths)
+    }
+    // time: Thh:mm:ss with hh ≤ 23, mm/ss ≤ 59 (no leap second, no fraction)
+    if b.len() < 19
+        || b[10] != b'T'
+        || !all_digits(&b[11..13])
+        || b[13] != b':'
+        || !all_digits(&b[14..16])
+        || b[16] != b':'
+        || !all_digits(&b[17..19])
+        || num2(&b[11..13]) > 23
+        || num2(&b[14..16]) > 59
+        || num2(&b[17..19]) > 59
+    {
+        return false;
+    }
+    match &b[19..] {
+        [] => true,     // no timezone: UTC on both paths
+        [b'Z'] => true, // canonical UTC
+        // ±hh:mm offset with hh ≤ 14, mm ≤ 59 (the XSD offset range)
+        [sign, h1, h0, b':', m1, m0]
+            if matches!(sign, b'+' | b'-')
+                && all_digits(&[*h1, *h0])
+                && all_digits(&[*m1, *m0]) =>
+        {
+            num2(&[*h1, *h0]) <= 14 && num2(&[*m1, *m0]) <= 59
+        }
+        _ => false,
+    }
+}
+
+/// Whether `s` is safe to emit as an N3 IRI (`<…>`): non-empty and free of the
+/// characters N-Triples forbids inside an IRIREF. Fail-closed: an unserializable IRI
+/// is a loud error, never a mangled fact.
+fn n3_iri_ok(s: &str) -> bool {
+    !s.is_empty()
+        && !s
+            .chars()
+            .any(|c| c <= ' ' || matches!(c, '<' | '>' | '"' | '{' | '}' | '|' | '^' | '`' | '\\'))
+}
+
+/// Whether `s` is safe to emit as a (quoted, escaped) N3 string literal: no raw
+/// control characters other than tab/newline/CR (which `n3_escape` escapes).
+fn n3_lit_ok(s: &str) -> bool {
+    !s.chars().any(|c| c.is_control() && !matches!(c, '\t' | '\n' | '\r'))
+}
+
+/// Escape a string for a quoted N3 literal.
+fn n3_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            _ => out.push(c),
+        }
+    }
+    out
+}
+
+/// The `oc:` operator IRI a [`sparq_policy::Operator`] serializes as.
+fn oc_op_iri(op: Operator) -> String {
+    let local = match op {
+        Operator::Eq => "eq",
+        Operator::Neq => "neq",
+        Operator::Lt => "lt",
+        Operator::Lteq => "lteq",
+        Operator::Gt => "gt",
+        Operator::Gteq => "gteq",
+        Operator::IsPartOf => "isPartOf",
+        Operator::IsA => "isA",
+    };
+    format!("{OC_NS}{local}")
+}
+
+/// Check one atomic constraint against the N3 subset (see the module notes):
+/// `odrl:dateTime` gets the order/equality operators with an admissible
+/// `xsd:dateTime` bound; every other dimension gets `eq/neq/isA/isPartOf` with an
+/// IRI/string bound. Anything else is a loud `Err` (fail-closed).
+fn n3_constraint_admissible(c: &Constraint) -> Result<(), String> {
+    if !n3_iri_ok(&c.left) {
+        return Err(format!("N3 path: constraint leftOperand {:?} is not a serializable IRI", c.left));
+    }
+    if c.left == ODRL_DATETIME {
+        if !matches!(
+            c.operator,
+            Operator::Lt | Operator::Lteq | Operator::Gt | Operator::Gteq | Operator::Eq | Operator::Neq
+        ) {
+            return Err(format!(
+                "N3 path: operator {:?} on odrl:dateTime is outside the stateless N3 subset",
+                c.operator
+            ));
+        }
+        match &c.right {
+            Value::DateTime(s) if n3_datetime_admissible(s) => Ok(()),
+            Value::DateTime(s) => Err(format!(
+                "N3 path: odrl:dateTime bound {s:?} is outside the admissible lexical space \
+                 (YYYY-MM-DD[Thh:mm:ss[Z|±hh:mm]], no fractional seconds/leap second/negative year) \
+                 — refusing fail-closed rather than risk instant-order divergence"
+            )),
+            other => Err(format!(
+                "N3 path: odrl:dateTime bound must be an xsd:dateTime/xsd:date literal, got {other}"
+            )),
+        }
+    } else {
+        if !matches!(c.operator, Operator::Eq | Operator::Neq | Operator::IsA | Operator::IsPartOf) {
+            return Err(format!(
+                "N3 path: order operator {:?} on non-dateTime dimension <{}> is outside the \
+                 stateless N3 subset",
+                c.operator, c.left
+            ));
+        }
+        match &c.right {
+            Value::Iri(s) if n3_iri_ok(s) => Ok(()),
+            Value::Str(s) if n3_lit_ok(s) => Ok(()),
+            Value::Iri(s) => Err(format!("N3 path: rightOperand IRI {s:?} is not serializable")),
+            Value::Str(s) => Err(format!("N3 path: rightOperand string {s:?} is not serializable")),
+            Value::Num(_) => Err(format!(
+                "N3 path: numeric rightOperand on <{}> is outside the stateless N3 subset \
+                 (odrl:count and numeric bounds stay on the Rust path)",
+                c.left
+            )),
+            Value::DateTime(_) => Err(format!(
+                "N3 path: dateTime rightOperand on non-dateTime dimension <{}> is outside the \
+                 stateless N3 subset",
+                c.left
+            )),
+        }
+    }
+}
+
+/// Check a whole policy against the N3 subset: every rule's direct constraints
+/// admissible, every compound constraint one level deep with atomic operands.
+fn n3_policy_admissible(policy: &Policy) -> Result<(), String> {
+    for rule in policy.permissions.iter().chain(policy.prohibitions.iter()) {
+        if !n3_iri_ok(&rule.action.0) {
+            return Err(format!("N3 path: rule action {:?} is not a serializable IRI", rule.action.0));
+        }
+        for v in [&rule.target, &rule.assignee].into_iter().flatten() {
+            if !n3_iri_ok(v) {
+                return Err(format!("N3 path: rule target/assignee {v:?} is not a serializable IRI"));
+            }
+        }
+        for d in &rule.duties {
+            if !n3_iri_ok(&d.action.0) {
+                return Err(format!("N3 path: duty action {:?} is not a serializable IRI", d.action.0));
+            }
+        }
+        for c in &rule.constraints {
+            n3_constraint_admissible(c)?;
+        }
+        for lc in &rule.logical_constraints {
+            for operand in &lc.operands {
+                match operand {
+                    ConstraintNode::Atomic(c) => n3_constraint_admissible(c)?,
+                    ConstraintNode::Compound(_) => {
+                        return Err(format!(
+                            "N3 path: nested LogicalConstraint {} is outside the stateless N3 \
+                             subset (one compound level with atomic operands is supported)",
+                            lc.id
+                        ));
+                    }
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Check an [`N3Request`] against the N3 subset: serializable IRIs, an admissible
+/// evaluation-time lexical, IRI/string evidence only (and the evaluation time only
+/// via [`N3Request::at`]).
+fn n3_request_admissible(request: &N3Request) -> Result<(), String> {
+    if !n3_iri_ok(&request.action) {
+        return Err(format!("N3 path: request action {:?} is not a serializable IRI", request.action));
+    }
+    for v in [&request.target, &request.party].into_iter().flatten() {
+        if !n3_iri_ok(v) {
+            return Err(format!("N3 path: request target/party {v:?} is not a serializable IRI"));
+        }
+    }
+    if let Some(at) = &request.at {
+        if !n3_datetime_admissible(at) {
+            return Err(format!(
+                "N3 path: evaluation time {at:?} is outside the admissible lexical space \
+                 (YYYY-MM-DD[Thh:mm:ss[Z|±hh:mm]], no fractional seconds/leap second/negative year)"
+            ));
+        }
+    }
+    for (left, v) in &request.evidence {
+        if left == ODRL_DATETIME {
+            return Err(
+                "N3 path: supply the evaluation time via N3Request::at, not the evidence map".to_owned()
+            );
+        }
+        if !n3_iri_ok(left) {
+            return Err(format!("N3 path: evidence dimension {left:?} is not a serializable IRI"));
+        }
+        match v {
+            Value::Iri(s) if n3_iri_ok(s) => {}
+            Value::Str(s) if n3_lit_ok(s) => {}
+            other => {
+                return Err(format!(
+                    "N3 path: evidence for <{left}> must be a serializable IRI/string, got {other} \
+                     (numeric/dateTime evidence is outside the stateless N3 subset)"
+                ));
+            }
+        }
+    }
+    for d in &request.discharged {
+        if !n3_iri_ok(d) {
+            return Err(format!("N3 path: discharged duty action {d:?} is not a serializable IRI"));
+        }
+    }
+    Ok(())
+}
+
+/// Serialize one admissible atomic constraint node into `oc:` facts. The bound is
+/// pre-lexicalized exactly as the Rust evaluator compares it (`Value::as_str()` for
+/// `eq/neq/isA`, the [`is_part_of`]-identical member split for `isPartOf`, the raw
+/// `xsd:dateTime` lexical for the dateTime dimension), so the rules and the evaluator
+/// share ONE source of value truth.
+///
+/// [`is_part_of`]: sparq_policy::Operator::IsPartOf
+fn n3_emit_constraint(out: &mut String, node: &str, c: &Constraint) {
+    use std::fmt::Write as _;
+    let _ = writeln!(out, "<{node}> <{RDF_TYPE}> <{OC_NS}Atomic> .");
+    let _ = writeln!(out, "<{node}> <{OC_NS}left> <{}> .", c.left);
+    let _ = writeln!(out, "<{node}> <{OC_NS}op> <{}> .", oc_op_iri(c.operator));
+    if c.left == ODRL_DATETIME {
+        let _ = writeln!(out, "<{node}> <{OC_NS}boundDt> \"{}\"^^<{XSD_DATETIME_IRI}> .", c.right.as_str());
+    } else if c.operator == Operator::IsPartOf {
+        // The same member split `sparq_policy`'s `is_part_of` applies.
+        for member in c.right.as_str().split(['|', ' ', ',']).map(str::trim).filter(|s| !s.is_empty()) {
+            let _ = writeln!(out, "<{node}> <{OC_NS}member> \"{}\" .", n3_escape(member));
+        }
+    } else {
+        let _ = writeln!(out, "<{node}> <{OC_NS}boundLex> \"{}\" .", n3_escape(c.right.as_str()));
+    }
+}
+
+/// Serialize an admissible `(policy, request)` pair into the `oc:` fact schema the
+/// ODRL rule strata consume. Serialization works from the PARSED model — the same
+/// [`Policy`] the Rust path evaluates — so the two paths consume identical semantic
+/// content (the WAC/ACP `assemble_input` discipline).
+fn n3_serialize(policy: &Policy, request: &N3Request) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+
+    let kinds: [(&str, &[Rule], &str); 2] = [
+        ("perm", &policy.permissions, "Permission"),
+        ("proh", &policy.prohibitions, "Prohibition"),
+    ];
+    for (tag, rules, class) in kinds {
+        for (i, rule) in rules.iter().enumerate() {
+            let rn = format!("{OC_NODE}{tag}{i}");
+            let _ = writeln!(out, "<{rn}> <{RDF_TYPE}> <{OC_NS}{class}> .");
+            let _ = writeln!(out, "<{rn}> <{RDF_TYPE}> <{OC_NS}Rule> .");
+            let _ = writeln!(out, "<{rn}> <{OC_NS}action> <{}> .", rule.action.0);
+            match &rule.target {
+                Some(t) => {
+                    let _ = writeln!(out, "<{rn}> <{OC_NS}target> <{t}> .");
+                }
+                None => {
+                    let _ = writeln!(out, "<{rn}> <{OC_NS}anyTarget> true .");
+                }
+            }
+            match &rule.assignee {
+                Some(a) => {
+                    let _ = writeln!(out, "<{rn}> <{OC_NS}assignee> <{a}> .");
+                }
+                None => {
+                    let _ = writeln!(out, "<{rn}> <{OC_NS}anyAssignee> true .");
+                }
+            }
+            for d in &rule.duties {
+                let _ = writeln!(out, "<{rn}> <{OC_NS}dutyAction> <{}> .", d.action.0);
+            }
+            for (j, c) in rule.constraints.iter().enumerate() {
+                let cn = format!("{rn}-c{j}");
+                let _ = writeln!(out, "<{rn}> <{OC_NS}constraint> <{cn}> .");
+                n3_emit_constraint(&mut out, &cn, c);
+            }
+            for (j, lc) in rule.logical_constraints.iter().enumerate() {
+                let ln = format!("{rn}-l{j}");
+                let _ = writeln!(out, "<{rn}> <{OC_NS}logical> <{ln}> .");
+                let combinator = match lc.operator {
+                    LogicalOperator::And => "and",
+                    LogicalOperator::Or => "or",
+                    LogicalOperator::Xone => "xone",
+                };
+                let _ = writeln!(out, "<{ln}> <{OC_NS}combinator> <{OC_NS}{combinator}> .");
+                if lc.operands.is_empty() {
+                    let _ = writeln!(out, "<{ln}> <{OC_NS}emptyOperands> true .");
+                }
+                for (k, operand) in lc.operands.iter().enumerate() {
+                    // admissibility guaranteed atomic operands only
+                    if let ConstraintNode::Atomic(c) = operand {
+                        let on = format!("{ln}-o{k}");
+                        let _ = writeln!(out, "<{ln}> <{OC_NS}operand> <{on}> .");
+                        n3_emit_constraint(&mut out, &on, c);
+                    }
+                }
+            }
+        }
+    }
+
+    // The request + its evidence (the state-of-the-world the constraints test).
+    let rq = format!("{OC_NODE}req");
+    let _ = writeln!(out, "<{rq}> <{RDF_TYPE}> <{OC_NS}Request> .");
+    let _ = writeln!(out, "<{rq}> <{OC_NS}reqAction> <{}> .", request.action);
+    if let Some(t) = &request.target {
+        let _ = writeln!(out, "<{rq}> <{OC_NS}reqTarget> <{t}> .");
+    }
+    if let Some(p) = &request.party {
+        let _ = writeln!(out, "<{rq}> <{OC_NS}reqParty> <{p}> .");
+    }
+    if let Some(at) = &request.at {
+        let _ = writeln!(out, "<{rq}> <{OC_NS}atTime> \"{at}\"^^<{XSD_DATETIME_IRI}> .");
+        // evidence marker: the odrl:dateTime dimension is provable
+        let _ = writeln!(out, "<{OC_NODE}ev-dt> <{OC_NS}evLeft> <{ODRL_DATETIME}> .");
+    }
+    for (i, (left, v)) in request.evidence.iter().enumerate() {
+        let en = format!("{OC_NODE}ev{i}");
+        let _ = writeln!(out, "<{en}> <{OC_NS}evLeft> <{left}> .");
+        let _ = writeln!(out, "<{en}> <{OC_NS}evLex> \"{}\" .", n3_escape(v.as_str()));
+    }
+    // The recipient-of-data defaults to the requesting party (resolve_actual's
+    // `odrl:recipient` fallback) unless explicit recipient evidence was supplied.
+    if !request.evidence.contains_key(ODRL_RECIPIENT) {
+        if let Some(p) = &request.party {
+            let en = format!("{OC_NODE}ev-recipient");
+            let _ = writeln!(out, "<{en}> <{OC_NS}evLeft> <{ODRL_RECIPIENT}> .");
+            let _ = writeln!(out, "<{en}> <{OC_NS}evLex> \"{}\" .", n3_escape(p));
+        }
+    }
+    for d in &request.discharged {
+        let _ = writeln!(out, "<{rq}> <{OC_NS}discharged> <{d}> .");
+    }
+    out
+}
+
+/// Re-serialize a stratum's ground closure as facts for the next stratum (the
+/// `materialize_acp` inter-stratum seeding shape).
+fn n3_closure_facts(dict: &Dict, closure: &[[sparq_core::dict::Id; 3]]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::with_capacity(closure.len() * 64);
+    for t in closure {
+        let _ = writeln!(out, "{} {} {} .", dict.term(t[0]), dict.term(t[1]), dict.term(t[2]));
+    }
+    out
+}
+
+/// Evaluate `policy` against `request` **as N3 rule strata** (the WAC/ACP runtime
+/// `reason_n3` pattern) and materialize the derived auth-view triples — the OPT-IN
+/// N3 counterpart of [`materialize_policy`], differential-locked to it by
+/// `tests/odrl_n3_differential.rs`. [FABLE-5] sq-zgbso.2 (epic sq-zgbso, #1582).
+///
+/// The Rust path remains the default evaluator; nothing routes through this
+/// function unless a caller explicitly opts in. On the stateless subset (see the
+/// module notes) the derived triple set is EXACTLY the set the Rust bridge writes:
+/// allow grants from matched, duty-discharged, un-prohibited permissions and
+/// `auth:deny<Mode>` triples from matched prohibitions (deny-overrides). Stateful
+/// `odrl:count` enforcement stays on the Rust path (mutation is not inference).
+///
+/// # Errors / fail-closed
+///
+/// - A policy whose `odrl:conflict` strategy the bridge cannot honour returns the
+///   same loud *refusal* outcome as [`materialize_policy`] (nothing materialized).
+/// - A policy/request outside the stateless N3 subset — a non-admissible dateTime
+///   lexical, numeric operands, nested compounds, order operators on non-dateTime
+///   dimensions, unserializable IRIs — returns `Err` and materializes NOTHING:
+///   loud, never a silent divergence window.
+/// - Within the subset the strata are themselves fail-closed: missing evidence,
+///   unmapped actions, or a missing party/target derive no triple.
+///
+/// # Examples
+///
+/// ```
+/// use sparq_solid::odrl_bridge::{materialize_policy_n3, N3Request};
+/// use sparq_policy::parse_policy_str;
+///
+/// let pol = parse_policy_str(r#"
+/// @prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+/// <urn:pol/1> a odrl:Set ; odrl:permission [
+///     odrl:action odrl:read ;
+///     odrl:target <https://pod.ex/notes/n1> ;
+///     odrl:assignee <https://alice.ex/card#me> ] .
+/// "#, "turtle")?;
+/// let req = N3Request::new("http://www.w3.org/ns/odrl/2/read")
+///     .on("https://pod.ex/notes/n1")
+///     .by("https://alice.ex/card#me");
+///
+/// let mut graph = sparq_core::Graph::new();
+/// let out = materialize_policy_n3(&mut graph, &pol, &req)?;
+/// assert!(out.granted);
+/// # Ok::<(), String>(())
+/// ```
+pub fn materialize_policy_n3(
+    graph: &mut Graph,
+    policy: &Policy,
+    request: &N3Request,
+) -> Result<BridgeOutcome, String> {
+    // 0. Refuse (fail-closed) an unimplementable odrl:conflict strategy FIRST — the
+    //    same guard, and the same refusal outcome, as the Rust path.
+    if let Some(refusal) = refuse_unimplementable_conflict(policy) {
+        return Ok(refusal);
+    }
+    // 1. Subset admissibility — loud errors, nothing materialized.
+    n3_policy_admissible(policy)?;
+    n3_request_admissible(request)?;
+
+    // 2. The four stratified reason_n3 runs (§3.5 discipline: each stratum's negated
+    //    predicates are complete in the seed it receives).
+    let facts = n3_serialize(policy, request);
+    let mut d1 = Dict::new();
+    let c1 = sparq_reason::reason_n3(&mut d1, &format!("{facts}\n{ODRL_CORE_A}"))?;
+    let f1 = n3_closure_facts(&d1, &c1);
+    let mut d2 = Dict::new();
+    let c2 = sparq_reason::reason_n3(&mut d2, &format!("{f1}\n{ODRL_CORE_B}"))?;
+    let f2 = n3_closure_facts(&d2, &c2);
+    let mut d3 = Dict::new();
+    let c3 = sparq_reason::reason_n3(&mut d3, &format!("{f2}\n{ODRL_CORE_C}"))?;
+    let f3 = n3_closure_facts(&d3, &c3);
+    let mut d4 = Dict::new();
+    let c4 = sparq_reason::reason_n3(&mut d4, &format!("{f3}\n{ODRL_CORE_D}"))?;
+
+    // 3. Extract the derived auth-view triples (`auth:*` predicate, IRI subject/object).
+    let mut triples: Vec<(String, String, String)> = Vec::new();
+    for t in &c4 {
+        let Term::NamedNode(p) = d4.term(t[1]) else { continue };
+        if !p.as_str().starts_with(AUTH_NS) {
+            continue;
+        }
+        let (Term::NamedNode(s), Term::NamedNode(o)) = (d4.term(t[0]), d4.term(t[2])) else {
+            continue;
+        };
+        triples.push((s.as_str().to_owned(), p.as_str().to_owned(), o.as_str().to_owned()));
+    }
+    triples.sort();
+    triples.dedup();
+
+    // 4. Materialize into the auth view + bridged-provenance graph (the same append
+    //    path the Rust bridge uses) and report the outcome in the same shape.
+    let emitted: Vec<[Term; 3]> = triples
+        .iter()
+        .map(|(s, p, o)| {
+            [
+                Term::NamedNode(NamedNode::new_unchecked(s)),
+                Term::NamedNode(NamedNode::new_unchecked(p)),
+                Term::NamedNode(NamedNode::new_unchecked(o)),
+            ]
+        })
+        .collect();
+    append_bridged_triples(graph, &emitted);
+
+    let is_deny = |p: &str| p.strip_prefix(AUTH_NS).is_some_and(|l| l.starts_with("deny"));
+    let grant_triple = triples.iter().find(|(_, p, _)| !is_deny(p)).cloned();
+    let deny_triple = triples.iter().find(|(_, p, _)| is_deny(p)).cloned();
+    let granted = grant_triple.is_some();
+    let prohibited = deny_triple.is_some();
+    let reasons = if granted || prohibited {
+        Vec::new()
+    } else {
+        vec!["N3 strata derived no auth-view triple for the request (fail-closed)".to_owned()]
+    };
+    Ok(BridgeOutcome {
+        granted,
+        prohibited,
+        // Mirrors materialize_policy: the mode of the operative decision (both sides
+        // derive it from the REQUEST action, so one lookup serves either).
+        mode: (granted || prohibited).then(|| action_to_mode(&request.action)).flatten(),
+        grant_triple,
+        deny_triple,
+        refused: false,
+        reasons,
+        consumed: None,
+        emitted,
+    })
+}
+
+#[cfg(test)]
+mod odrl_n3_tests {
+    //! [FABLE-5] sq-zgbso.2 — direct unit tests for the N3-path public surface
+    //! (one per new public item, per the coverage-ratchet discipline) plus the
+    //! fail-closed guard edges. The corpus-scale Rust-vs-N3 differential lives in
+    //! `tests/odrl_n3_differential.rs`.
+    use super::*;
+    use sparq_policy::parse_policy_str;
+
+    const READ: &str = "http://www.w3.org/ns/odrl/2/read";
+
+    #[test]
+    fn n3request_builders_and_to_request_round_trip() {
+        let req = N3Request::new(READ)
+            .on("urn:t/1")
+            .by("urn:alice")
+            .at("2026-07-01T00:00:00Z")
+            .with("http://www.w3.org/ns/odrl/2/purpose", Value::Iri("urn:purpose/r".into()))
+            .discharge("http://www.w3.org/ns/odrl/2/anonymize");
+        let r = req.to_request();
+        assert_eq!(r.action, READ);
+        assert_eq!(r.target.as_deref(), Some("urn:t/1"));
+        assert_eq!(r.party.as_deref(), Some("urn:alice"));
+        assert_eq!(
+            r.request_time(),
+            Some(&Value::DateTime("2026-07-01T00:00:00Z".into()))
+        );
+        assert!(r.discharged_duties.contains("http://www.w3.org/ns/odrl/2/anonymize"));
+        assert_eq!(
+            r.context.get("http://www.w3.org/ns/odrl/2/purpose"),
+            Some(&Value::Iri("urn:purpose/r".into()))
+        );
+    }
+
+    #[test]
+    fn datetime_admissible_accepts_agreeing_forms() {
+        for ok in [
+            "2026-07-01T00:00:00Z",
+            "2026-07-01T23:59:59+14:00",
+            "2026-07-01T12:30:00-05:30",
+            "2026-07-01T12:30:00", // no tz = UTC on both paths
+            "2026-02-28",          // bare date = midnight UTC on both paths
+        ] {
+            assert!(n3_datetime_admissible(ok), "{ok} should be admissible");
+        }
+    }
+
+    #[test]
+    fn datetime_admissible_rejects_divergence_windows() {
+        for bad in [
+            "2026-07-01T00:00:00.5Z",  // fractional seconds: Rust keeps, N3 truncates
+            "2026-06-30T23:59:60Z",    // leap second: Rust clamps, N3 adds
+            "-0044-03-15T00:00:00Z",   // negative year
+            "12026-01-01T00:00:00Z",   // ≥5-digit year
+            "2026-7-1T00:00:00Z",      // non-fixed-width
+            "2026-13-01T00:00:00Z",    // month out of range
+            "2026-07-01T24:00:00Z",    // hour out of range
+            "2026-07-01T00:00:00+15:00", // offset beyond the XSD range
+            "not-a-date",
+            "",
+        ] {
+            assert!(!n3_datetime_admissible(bad), "{bad} should be rejected");
+        }
+    }
+
+    #[test]
+    fn materialize_policy_n3_grants_and_appends_auth_view() {
+        let pol = parse_policy_str(
+            r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+            <urn:pol/1> a odrl:Set ; odrl:permission [
+                odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ] ."#,
+            "turtle",
+        )
+        .expect("parses");
+        let mut graph = Graph::new();
+        let out = materialize_policy_n3(&mut graph, &pol, &N3Request::new(READ).on("urn:t/1").by("urn:alice"))
+            .expect("in subset");
+        assert!(out.granted && !out.prohibited && !out.refused);
+        assert_eq!(
+            out.grant_triple,
+            Some(("urn:alice".into(), format!("{AUTH_NS}read"), "urn:t/1".into()))
+        );
+        assert_eq!(out.mode, Some(Mode::Read));
+        // the triple landed in the auth view through the same append path
+        assert!(named_graph_triples(&graph, AUTH_GRAPH)
+            .iter()
+            .any(|t| matches!(&t[1], Term::NamedNode(p) if p.as_str() == format!("{AUTH_NS}read"))));
+    }
+
+    #[test]
+    fn materialize_policy_n3_deny_overrides() {
+        let pol = parse_policy_str(
+            r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+            <urn:pol/1> a odrl:Set ;
+              odrl:permission [ odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ] ;
+              odrl:prohibition [ odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ] ."#,
+            "turtle",
+        )
+        .expect("parses");
+        let mut graph = Graph::new();
+        let out = materialize_policy_n3(&mut graph, &pol, &N3Request::new(READ).on("urn:t/1").by("urn:alice"))
+            .expect("in subset");
+        assert!(!out.granted, "deny-overrides: the matching prohibition blocks the grant");
+        assert!(out.prohibited);
+        assert_eq!(
+            out.deny_triple,
+            Some(("urn:alice".into(), format!("{AUTH_NS}denyRead"), "urn:t/1".into()))
+        );
+    }
+
+    #[test]
+    fn materialize_policy_n3_mirrors_conflict_refusal() {
+        let pol = parse_policy_str(
+            r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+            <urn:pol/1> a odrl:Set ; odrl:conflict odrl:perm ; odrl:permission [
+                odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ] ."#,
+            "turtle",
+        )
+        .expect("parses");
+        let mut graph = Graph::new();
+        let out = materialize_policy_n3(&mut graph, &pol, &N3Request::new(READ).on("urn:t/1").by("urn:alice"))
+            .expect("refusal is an outcome, not an Err");
+        assert!(out.refused && !out.granted && !out.prohibited);
+        assert!(named_graph_triples(&graph, AUTH_GRAPH).is_empty(), "refusal materializes nothing");
+    }
+
+    #[test]
+    fn materialize_policy_n3_errs_loudly_outside_the_subset() {
+        let mut graph = Graph::new();
+        // fractional-second dateTime bound → divergence window → Err
+        let pol = parse_policy_str(
+            r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            <urn:pol/1> a odrl:Set ; odrl:permission [
+                odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ;
+                odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:lteq ;
+                                  odrl:rightOperand "2026-12-31T00:00:00.5Z"^^xsd:dateTime ] ] ."#,
+            "turtle",
+        )
+        .expect("parses");
+        let req = N3Request::new(READ).on("urn:t/1").by("urn:alice").at("2026-07-01T00:00:00Z");
+        let err = materialize_policy_n3(&mut graph, &pol, &req).expect_err("outside the subset");
+        assert!(err.contains("lexical space"), "clear reason, got: {err}");
+
+        // numeric bound (odrl:count) → Err (stateful count stays Rust)
+        let pol = parse_policy_str(
+            r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+            <urn:pol/2> a odrl:Set ; odrl:permission [
+                odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ;
+                odrl:constraint [ odrl:leftOperand odrl:count ; odrl:operator odrl:lteq ;
+                                  odrl:rightOperand 5 ] ] ."#,
+            "turtle",
+        )
+        .expect("parses");
+        let err = materialize_policy_n3(&mut graph, &pol, &N3Request::new(READ).on("urn:t/1").by("urn:alice"))
+            .expect_err("numeric bound outside the subset");
+        assert!(err.contains("subset"), "clear reason, got: {err}");
+        // numeric evidence → Err
+        let req = N3Request::new(READ)
+            .on("urn:t/1")
+            .by("urn:alice")
+            .with("http://www.w3.org/ns/odrl/2/count", Value::Num(3.0));
+        let pol = parse_policy_str(
+            r#"@prefix odrl: <http://www.w3.org/ns/odrl/2/> .
+            <urn:pol/3> a odrl:Set ; odrl:permission [
+                odrl:action odrl:read ; odrl:target <urn:t/1> ; odrl:assignee <urn:alice> ] ."#,
+            "turtle",
+        )
+        .expect("parses");
+        let err = materialize_policy_n3(&mut graph, &pol, &req).expect_err("numeric evidence");
+        assert!(err.contains("subset"), "clear reason, got: {err}");
+        // dateTime evidence must go through `at`
+        let req = N3Request::new(READ)
+            .on("urn:t/1")
+            .by("urn:alice")
+            .with(super::ODRL_DATETIME, Value::Str("2026-07-01T00:00:00Z".into()));
+        let err = materialize_policy_n3(&mut graph, &pol, &req).expect_err("evidence-map time");
+        assert!(err.contains("N3Request::at"), "clear reason, got: {err}");
+        assert!(named_graph_triples(&graph, AUTH_GRAPH).is_empty(), "errors materialize nothing");
+    }
+
+    #[test]
+    fn n3_escape_and_serializability_guards() {
+        assert_eq!(n3_escape("a\"b\\c\nd"), "a\\\"b\\\\c\\nd");
+        assert!(n3_iri_ok("https://alice.ex/card#me"));
+        assert!(!n3_iri_ok("urn:sp ace"));
+        assert!(!n3_iri_ok("urn:angle>bracket"));
+        assert!(!n3_iri_ok(""));
+        assert!(n3_lit_ok("plain value"));
+        assert!(!n3_lit_ok("nul\u{0}byte"));
     }
 }
 

--- a/crates/sparq-solid/tests/odrl_n3_differential.rs
+++ b/crates/sparq-solid/tests/odrl_n3_differential.rs
@@ -1,0 +1,795 @@
+//! [FABLE-5] sq-zgbso.2 — the CI-locked Rust-vs-N3 ODRL decision differential
+//! (epic sq-zgbso, #1582; design record `research/odrl-n3-compiled-rules.md`).
+//!
+//! INVARIANT (fail-closed + decision-equivalence): on every corpus scenario the N3
+//! rule strata (`rules/odrl-core-{a,b,c,d}.n3` via `materialize_policy_n3`) must
+//! produce EXACTLY the auth-view triples the Rust path produces
+//! (`odrl_bridge::materialize_policy` over `sparq_policy::evaluate`) — the same
+//! allow grants, the same `auth:deny*` triples (deny-overrides), the same refusals,
+//! and NOTHING on the fail-closed denies. Any divergence is a red test.
+//!
+//! The corpus = the sq-zgbso.1 spike's 7 scenarios (with their independently-stated
+//! expected sets, so a both-wrong agreement cannot pass) + generated permutations:
+//! the action×action hierarchy matrix, structural (target/assignee) permutations,
+//! `odrl:dateTime` windows across all six operators and mixed-offset request times
+//! (the finding-(a) normalization), dateTime-constrained PROHIBITIONS (the
+//! finding-(c) stratification case), recipient/assignee/purpose constraints,
+//! `and`/`or`/`xone` combinator status patterns, duties, conflict strategies, and
+//! deny-overrides compositions. Out-of-subset constructs are separately asserted to
+//! be LOUD errors that materialize nothing (never a silent divergence window).
+//!
+//! Runs under `--features odrl-bridge` (NOT `--all-features`; the pre-existing
+//! sq-s5tkx count-enforcement failure is out of scope).
+#![cfg(feature = "odrl-bridge")]
+
+use sparq_core::Graph;
+use sparq_policy::{parse_policy_str, Policy, Value};
+use sparq_solid::odrl_bridge::{materialize_policy, materialize_policy_n3, N3Request};
+use sparq_solid::AUTH_NS;
+
+const ODRL: &str = "http://www.w3.org/ns/odrl/2/";
+const T1: &str = "urn:t/1";
+const T2: &str = "urn:t/2";
+const ALICE: &str = "urn:alice";
+const BOB: &str = "urn:bob";
+const CAROL: &str = "urn:carol";
+const PURPOSE: &str = "http://www.w3.org/ns/odrl/2/purpose";
+const SPATIAL: &str = "http://www.w3.org/ns/odrl/2/spatial";
+const RECIPIENT: &str = "http://www.w3.org/ns/odrl/2/recipient";
+
+type AuthSet = Vec<(String, String, String)>;
+
+fn act(local: &str) -> String {
+    format!("{ODRL}{local}")
+}
+
+/// One ODRL rule body (the `[ … ]` block) from parts.
+fn rule_body(action: &str, target: Option<&str>, assignee: Option<&str>, extra: &str) -> String {
+    let mut b = format!("odrl:action odrl:{action}");
+    if let Some(t) = target {
+        b.push_str(&format!(" ; odrl:target <{t}>"));
+    }
+    if let Some(a) = assignee {
+        b.push_str(&format!(" ; odrl:assignee <{a}>"));
+    }
+    if !extra.is_empty() {
+        b.push_str(" ; ");
+        b.push_str(extra);
+    }
+    b
+}
+
+/// A one-rule `odrl:Set` policy ("permission" or "prohibition").
+fn policy_ttl(kind: &str, body: &str) -> String {
+    format!(
+        "@prefix odrl: <http://www.w3.org/ns/odrl/2/> .\n\
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+         <urn:pol/1> a odrl:Set ; odrl:{kind} [ {body} ] ."
+    )
+}
+
+/// A permission + prohibition `odrl:Set` policy.
+fn policy_ttl2(perm_body: &str, proh_body: &str) -> String {
+    format!(
+        "@prefix odrl: <http://www.w3.org/ns/odrl/2/> .\n\
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+         <urn:pol/1> a odrl:Set ; odrl:permission [ {perm_body} ] ; \
+         odrl:prohibition [ {proh_body} ] ."
+    )
+}
+
+/// An `odrl:dateTime <op>` constraint fragment.
+fn dt_constraint(op: &str, bound: &str) -> String {
+    format!(
+        "odrl:constraint [ odrl:leftOperand odrl:dateTime ; odrl:operator odrl:{op} ; \
+         odrl:rightOperand \"{bound}\"^^xsd:dateTime ]"
+    )
+}
+
+/// A generic IRI-bound constraint fragment.
+fn iri_constraint(left_local: &str, op: &str, right_iri: &str) -> String {
+    format!(
+        "odrl:constraint [ odrl:leftOperand odrl:{left_local} ; odrl:operator odrl:{op} ; \
+         odrl:rightOperand <{right_iri}> ]"
+    )
+}
+
+/// A string-bound constraint fragment.
+fn str_constraint(left_local: &str, op: &str, right: &str) -> String {
+    format!(
+        "odrl:constraint [ odrl:leftOperand odrl:{left_local} ; odrl:operator odrl:{op} ; \
+         odrl:rightOperand \"{right}\" ]"
+    )
+}
+
+/// A compound `odrl:LogicalConstraint` fragment over atomic operand fragments.
+fn logical(combinator: &str, operands: &[String]) -> String {
+    let ops: Vec<String> = operands
+        .iter()
+        .map(|o| {
+            // strip the leading "odrl:constraint " to get the bare [ … ] node
+            o.strip_prefix("odrl:constraint ").expect("operand fragment").to_owned()
+        })
+        .collect();
+    format!("odrl:constraint [ odrl:{combinator} {} ]", ops.join(" , "))
+}
+
+/// Collect the (grant, deny) auth triples of a bridge outcome, sorted.
+fn outcome_set(granted: Option<(String, String, String)>, denied: Option<(String, String, String)>) -> AuthSet {
+    let mut s: AuthSet = granted.into_iter().chain(denied).collect();
+    s.sort();
+    s
+}
+
+/// Run BOTH paths on the same (policy, request) and assert decision equality.
+/// Returns the agreed set so spike-style cases can ALSO pin an independently-stated
+/// expectation. Panics with the scenario label + policy text on any divergence.
+fn assert_parity(label: &str, ttl: &str, req: &N3Request) -> AuthSet {
+    let policy: Policy =
+        parse_policy_str(ttl, "turtle").unwrap_or_else(|e| panic!("{label}: policy parse: {e}\n{ttl}"));
+    let mut g_rust = Graph::new();
+    let rust = materialize_policy(&mut g_rust, &policy, &req.to_request());
+    let mut g_n3 = Graph::new();
+    let n3 = materialize_policy_n3(&mut g_n3, &policy, req)
+        .unwrap_or_else(|e| panic!("{label}: N3 path must stay in-subset on the corpus: {e}\n{ttl}"));
+
+    assert_eq!(rust.refused, n3.refused, "{label}: refusal divergence\n{ttl}");
+    assert_eq!(rust.granted, n3.granted, "{label}: granted divergence\n{ttl}");
+    assert_eq!(rust.prohibited, n3.prohibited, "{label}: prohibited divergence\n{ttl}");
+    let rust_set = outcome_set(rust.grant_triple, rust.deny_triple);
+    let n3_set = outcome_set(n3.grant_triple, n3.deny_triple);
+    assert_eq!(rust_set, n3_set, "{label}: auth-triple divergence\n{ttl}");
+    rust_set
+}
+
+/// Pin an independently-stated expected set on top of parity (the spike discipline:
+/// a both-wrong agreement cannot pass).
+fn assert_case(label: &str, ttl: &str, req: &N3Request, want: &[(&str, &str, &str)]) {
+    let got = assert_parity(label, ttl, req);
+    let mut expected: AuthSet = want
+        .iter()
+        .map(|(a, m, t)| ((*a).to_owned(), format!("{AUTH_NS}{m}"), (*t).to_owned()))
+        .collect();
+    expected.sort();
+    assert_eq!(got, expected, "{label}: agreed set != independently-stated expectation\n{ttl}");
+}
+
+// ── the spike's 7 scenarios, expectations restated independently ───────────────────────
+
+#[test]
+fn spike_scenarios_with_pinned_expectations() {
+    let pol_a = policy_ttl(
+        "permission",
+        &rule_body("read", Some(T1), Some(ALICE), &dt_constraint("lteq", "2026-12-31T00:00:00Z")),
+    );
+    let pol_b = policy_ttl("permission", &rule_body("read", Some(T1), Some(ALICE), ""));
+    let pol_c = policy_ttl2(
+        &rule_body("read", Some(T1), Some(ALICE), ""),
+        &rule_body("read", Some(T1), Some(ALICE), ""),
+    );
+    let base = || N3Request::new(act("read")).on(T1).by(ALICE);
+
+    assert_case("A1 within window", &pol_a, &base().at("2026-07-05T00:00:00Z"), &[(ALICE, "read", T1)]);
+    assert_case("A2 after window", &pol_a, &base().at("2027-01-01T00:00:00Z"), &[]);
+    assert_case("A3 no time evidence", &pol_a, &base(), &[]);
+    assert_case(
+        "A4 wrong assignee",
+        &pol_a,
+        &N3Request::new(act("read")).on(T1).by(BOB).at("2026-07-05T00:00:00Z"),
+        &[],
+    );
+    assert_case(
+        "A5 action mismatch",
+        &pol_a,
+        &N3Request::new(act("write")).on(T1).by(ALICE).at("2026-07-05T00:00:00Z"),
+        &[],
+    );
+    assert_case("B1 unconstrained", &pol_b, &base(), &[(ALICE, "read", T1)]);
+    assert_case("C1 deny-overrides", &pol_c, &base(), &[(ALICE, "denyRead", T1)]);
+}
+
+// ── generated permutations ─────────────────────────────────────────────────────────────
+
+#[test]
+fn action_hierarchy_matrix() {
+    // policy action × request action across the mode table, the `use` umbrella, the
+    // transfer subtree, and an unmapped action.
+    for pol_act in ["read", "use", "modify", "transfer", "aggregate"] {
+        for req_act in ["read", "modify", "append", "use", "sell", "aggregate"] {
+            let ttl = policy_ttl("permission", &rule_body(pol_act, Some(T1), Some(ALICE), ""));
+            let req = N3Request::new(act(req_act)).on(T1).by(ALICE);
+            assert_parity(&format!("action {pol_act}×{req_act}"), &ttl, &req);
+        }
+    }
+    // pinned edges of the matrix (independent statement so both-wrong cannot pass):
+    // `use` permits read (grant), does NOT permit sell (nothing), and a `use` REQUEST
+    // is unmapped (nothing even though the evaluator permits).
+    let use_pol = policy_ttl("permission", &rule_body("use", Some(T1), Some(ALICE), ""));
+    assert_case("use permits read", &use_pol, &N3Request::new(act("read")).on(T1).by(ALICE), &[(ALICE, "read", T1)]);
+    assert_case("use excludes sell", &use_pol, &N3Request::new(act("sell")).on(T1).by(ALICE), &[]);
+    assert_case("use request unmapped", &use_pol, &N3Request::new(act("use")).on(T1).by(ALICE), &[]);
+}
+
+#[test]
+fn structural_target_assignee_permutations() {
+    let targets: [Option<&str>; 3] = [Some(T1), Some(T2), None];
+    let assignees: [Option<&str>; 3] = [Some(ALICE), Some(BOB), None];
+    for t in targets {
+        for a in assignees {
+            let ttl = policy_ttl("permission", &rule_body("read", t, a, ""));
+            // request always on T1 by ALICE
+            assert_parity(
+                &format!("structural target={t:?} assignee={a:?}"),
+                &ttl,
+                &N3Request::new(act("read")).on(T1).by(ALICE),
+            );
+            // partyless request (nothing can materialize; unconstrained-assignee
+            // rules still MATCH in the evaluator — concreteness gates the triple)
+            assert_parity(
+                &format!("structural partyless target={t:?} assignee={a:?}"),
+                &ttl,
+                &N3Request::new(act("read")).on(T1),
+            );
+            // targetless request
+            assert_parity(
+                &format!("structural targetless target={t:?} assignee={a:?}"),
+                &ttl,
+                &N3Request::new(act("read")).by(ALICE),
+            );
+        }
+    }
+}
+
+/// The six dateTime operators × request times either side of the bound, INCLUDING
+/// mixed-offset lexicals that denote the same or nearby instants — the spike's
+/// finding-(a) normalization surface. Bound: 2026-07-01T12:00:00Z.
+#[test]
+fn datetime_operator_window_matrix() {
+    let times: [Option<&str>; 6] = [
+        Some("2026-07-01T11:00:00Z"),      // before
+        Some("2026-07-01T12:00:00Z"),      // equal (canonical)
+        Some("2026-07-01T13:00:00Z"),      // after
+        Some("2026-07-01T14:00:00+02:00"), // equal INSTANT via offset
+        Some("2026-07-01T09:30:00-01:00"), // before via offset (=10:30Z)
+        None,                              // unprovable
+    ];
+    for op in ["lt", "lteq", "gt", "gteq", "eq", "neq"] {
+        let ttl = policy_ttl(
+            "permission",
+            &rule_body("read", Some(T1), Some(ALICE), &dt_constraint(op, "2026-07-01T12:00:00Z")),
+        );
+        for at in times {
+            let mut req = N3Request::new(act("read")).on(T1).by(ALICE);
+            if let Some(at) = at {
+                req = req.at(at);
+            }
+            assert_parity(&format!("dateTime perm {op} at={at:?}"), &ttl, &req);
+        }
+    }
+    // pinned: the offset form that equals the bound instant must NOT satisfy `lt`
+    // and MUST satisfy `lteq`/`eq` (lexical comparison would get all three wrong).
+    let lteq = policy_ttl(
+        "permission",
+        &rule_body("read", Some(T1), Some(ALICE), &dt_constraint("lteq", "2026-07-01T12:00:00Z")),
+    );
+    let lt = policy_ttl(
+        "permission",
+        &rule_body("read", Some(T1), Some(ALICE), &dt_constraint("lt", "2026-07-01T12:00:00Z")),
+    );
+    let eq = policy_ttl(
+        "permission",
+        &rule_body("read", Some(T1), Some(ALICE), &dt_constraint("eq", "2026-07-01T12:00:00Z")),
+    );
+    let offset_equal = N3Request::new(act("read")).on(T1).by(ALICE).at("2026-07-01T14:00:00+02:00");
+    assert_case("offset-equal lteq grants", &lteq, &offset_equal, &[(ALICE, "read", T1)]);
+    assert_case("offset-equal lt denies", &lt, &offset_equal, &[]);
+    assert_case("offset-equal eq grants", &eq, &offset_equal, &[(ALICE, "read", T1)]);
+}
+
+/// Constraint-BEARING prohibitions — the spike's finding (c): these need the fuller
+/// stratification (a prohibition's constraint statuses must be complete before the
+/// deny-overrides negation runs). An unconstrained permission sits alongside, so a
+/// mis-stratified rule set would either over-deny or over-grant visibly.
+#[test]
+fn datetime_constrained_prohibition_matrix() {
+    let times: [Option<&str>; 6] = [
+        Some("2026-07-01T11:00:00Z"),
+        Some("2026-07-01T12:00:00Z"),
+        Some("2026-07-01T13:00:00Z"),
+        Some("2026-07-01T14:00:00+02:00"),
+        Some("2026-07-01T09:30:00-01:00"),
+        None,
+    ];
+    for op in ["lt", "lteq", "gt", "gteq", "eq", "neq"] {
+        let ttl = policy_ttl2(
+            &rule_body("read", Some(T1), Some(ALICE), ""),
+            &rule_body("read", Some(T1), Some(ALICE), &dt_constraint(op, "2026-07-01T12:00:00Z")),
+        );
+        for at in times {
+            let mut req = N3Request::new(act("read")).on(T1).by(ALICE);
+            if let Some(at) = at {
+                req = req.at(at);
+            }
+            assert_parity(&format!("dateTime proh {op} at={at:?}"), &ttl, &req);
+        }
+    }
+    // pinned: within the prohibition window → deny WINS (and no allow triple);
+    // window definitely lapsed → the permission grants; NO time evidence → the
+    // prohibition is unprovable, does not carve out, and the permission grants
+    // (matching the evaluator: an unproven prohibition never blocks — the
+    // fail-closed direction is on GRANTS, not on hypothetical denies).
+    let ttl = policy_ttl2(
+        &rule_body("read", Some(T1), Some(ALICE), ""),
+        &rule_body("read", Some(T1), Some(ALICE), &dt_constraint("lt", "2026-07-01T12:00:00Z")),
+    );
+    assert_case(
+        "proh window active",
+        &ttl,
+        &N3Request::new(act("read")).on(T1).by(ALICE).at("2026-07-01T11:00:00Z"),
+        &[(ALICE, "denyRead", T1)],
+    );
+    assert_case(
+        "proh window lapsed",
+        &ttl,
+        &N3Request::new(act("read")).on(T1).by(ALICE).at("2026-07-01T13:00:00Z"),
+        &[(ALICE, "read", T1)],
+    );
+    assert_case(
+        "proh window unprovable",
+        &ttl,
+        &N3Request::new(act("read")).on(T1).by(ALICE),
+        &[(ALICE, "read", T1)],
+    );
+}
+
+#[test]
+fn recipient_and_assignee_constraints() {
+    for op in ["eq", "neq"] {
+        for bound in [ALICE, BOB] {
+            let ttl = policy_ttl(
+                "permission",
+                &rule_body("read", Some(T1), Some(ALICE), &iri_constraint("recipient", op, bound)),
+            );
+            // recipient defaults to the requesting party
+            assert_parity(
+                &format!("recipient {op} {bound} default"),
+                &ttl,
+                &N3Request::new(act("read")).on(T1).by(ALICE),
+            );
+            // explicit recipient evidence takes precedence over the party
+            assert_parity(
+                &format!("recipient {op} {bound} explicit"),
+                &ttl,
+                &N3Request::new(act("read"))
+                    .on(T1)
+                    .by(ALICE)
+                    .with(RECIPIENT, Value::Iri(CAROL.to_owned())),
+            );
+            // no party AND no explicit recipient → unprovable (fail-closed)
+            assert_parity(
+                &format!("recipient {op} {bound} no evidence"),
+                &ttl,
+                &N3Request::new(act("read")).on(T1),
+            );
+        }
+    }
+    // the "everyone-except-BOB" prohibition shape: carved out for ALICE, not for BOB
+    let ttl = policy_ttl2(
+        &rule_body("read", Some(T1), None, ""),
+        &rule_body("read", Some(T1), None, &iri_constraint("recipient", "neq", BOB)),
+    );
+    assert_case(
+        "except-bob denies alice",
+        &ttl,
+        &N3Request::new(act("read")).on(T1).by(ALICE),
+        &[(ALICE, "denyRead", T1)],
+    );
+    assert_case(
+        "except-bob spares bob",
+        &ttl,
+        &N3Request::new(act("read")).on(T1).by(BOB),
+        &[(BOB, "read", T1)],
+    );
+    // assignee-as-CONSTRAINT (distinct from the rule attribute): no evidence
+    // dimension is supplied for it → unprovable → no grant on either path.
+    let ttl = policy_ttl(
+        "permission",
+        &rule_body("read", Some(T1), None, &iri_constraint("assignee", "eq", ALICE)),
+    );
+    assert_case("assignee-constraint unprovable", &ttl, &N3Request::new(act("read")).on(T1).by(ALICE), &[]);
+}
+
+#[test]
+fn purpose_constraints_flat_base_case() {
+    let eq_ttl = policy_ttl(
+        "permission",
+        &rule_body("read", Some(T1), Some(ALICE), &iri_constraint("purpose", "eq", "urn:purpose/research")),
+    );
+    for (label, ev) in [
+        ("match", Some("urn:purpose/research")),
+        ("mismatch", Some("urn:purpose/marketing")),
+        ("missing", None),
+    ] {
+        let mut req = N3Request::new(act("read")).on(T1).by(ALICE);
+        if let Some(p) = ev {
+            req = req.with(PURPOSE, Value::Iri(p.to_owned()));
+        }
+        assert_parity(&format!("purpose eq {label}"), &eq_ttl, &req);
+    }
+    // isPartOf over the compact `|`/space/comma set encoding
+    let set_ttl = policy_ttl(
+        "permission",
+        &rule_body("read", Some(T1), Some(ALICE), &str_constraint("purpose", "isPartOf", "a|b c")),
+    );
+    for ev in ["a", "b", "c", "d"] {
+        assert_parity(
+            &format!("purpose isPartOf ev={ev}"),
+            &set_ttl,
+            &N3Request::new(act("read")).on(T1).by(ALICE).with(PURPOSE, Value::Str(ev.to_owned())),
+        );
+    }
+    assert_parity(
+        "purpose isPartOf missing",
+        &set_ttl,
+        &N3Request::new(act("read")).on(T1).by(ALICE),
+    );
+}
+
+/// `and` / `or` / `xone` over two atomic operands (purpose, spatial), sweeping the
+/// operand statuses: Satisfied / DefinitelyUnsatisfied / Unprovable per operand.
+#[test]
+fn logical_combinator_status_matrix() {
+    let operands = [
+        iri_constraint("purpose", "eq", "urn:purpose/research"),
+        iri_constraint("spatial", "eq", "urn:region/eu"),
+    ];
+    // evidence patterns → (purpose evidence, spatial evidence); None = Unprovable
+    let patterns: [(&str, Option<&str>, Option<&str>); 7] = [
+        ("SS", Some("urn:purpose/research"), Some("urn:region/eu")),
+        ("SD", Some("urn:purpose/research"), Some("urn:region/us")),
+        ("SU", Some("urn:purpose/research"), None),
+        ("DD", Some("urn:purpose/marketing"), Some("urn:region/us")),
+        ("DU", Some("urn:purpose/marketing"), None),
+        ("UU", None, None),
+        ("DS", Some("urn:purpose/marketing"), Some("urn:region/eu")),
+    ];
+    for combinator in ["and", "or", "xone"] {
+        let ttl = policy_ttl(
+            "permission",
+            &rule_body("read", Some(T1), Some(ALICE), &logical(combinator, &operands)),
+        );
+        for (label, purpose, spatial) in patterns {
+            let mut req = N3Request::new(act("read")).on(T1).by(ALICE);
+            if let Some(p) = purpose {
+                req = req.with(PURPOSE, Value::Iri(p.to_owned()));
+            }
+            if let Some(s) = spatial {
+                req = req.with(SPATIAL, Value::Iri(s.to_owned()));
+            }
+            assert_parity(&format!("{combinator} {label}"), &ttl, &req);
+        }
+        // single-operand compound
+        let ttl1 = policy_ttl(
+            "permission",
+            &rule_body("read", Some(T1), Some(ALICE), &logical(combinator, &operands[..1])),
+        );
+        assert_parity(
+            &format!("{combinator} single sat"),
+            &ttl1,
+            &N3Request::new(act("read"))
+                .on(T1)
+                .by(ALICE)
+                .with(PURPOSE, Value::Iri("urn:purpose/research".to_owned())),
+        );
+        // compound on a PROHIBITION (with an unconstrained permission alongside)
+        let ttl_p = policy_ttl2(
+            &rule_body("read", Some(T1), Some(ALICE), ""),
+            &rule_body("read", Some(T1), Some(ALICE), &logical(combinator, &operands)),
+        );
+        for (label, purpose, spatial) in patterns {
+            let mut req = N3Request::new(act("read")).on(T1).by(ALICE);
+            if let Some(p) = purpose {
+                req = req.with(PURPOSE, Value::Iri(p.to_owned()));
+            }
+            if let Some(s) = spatial {
+                req = req.with(SPATIAL, Value::Iri(s.to_owned()));
+            }
+            assert_parity(&format!("proh {combinator} {label}"), &ttl_p, &req);
+        }
+    }
+    // pinned xone semantics: exactly-one satisfied grants; two satisfied does not;
+    // an unprovable sibling never lets xone claim "exactly one" (fail-closed).
+    let xone = policy_ttl(
+        "permission",
+        &rule_body("read", Some(T1), Some(ALICE), &logical("xone", &operands)),
+    );
+    let one = N3Request::new(act("read"))
+        .on(T1)
+        .by(ALICE)
+        .with(PURPOSE, Value::Iri("urn:purpose/research".to_owned()))
+        .with(SPATIAL, Value::Iri("urn:region/us".to_owned()));
+    assert_case("xone exactly-one grants", &xone, &one, &[(ALICE, "read", T1)]);
+    let two = N3Request::new(act("read"))
+        .on(T1)
+        .by(ALICE)
+        .with(PURPOSE, Value::Iri("urn:purpose/research".to_owned()))
+        .with(SPATIAL, Value::Iri("urn:region/eu".to_owned()));
+    assert_case("xone two-sat denies", &xone, &two, &[]);
+    let one_unprovable = N3Request::new(act("read"))
+        .on(T1)
+        .by(ALICE)
+        .with(PURPOSE, Value::Iri("urn:purpose/research".to_owned()));
+    assert_case("xone unprovable sibling denies", &xone, &one_unprovable, &[]);
+}
+
+#[test]
+fn duties_gate_grants_not_matching() {
+    let anonymize = "odrl:duty [ odrl:action odrl:anonymize ]".to_owned();
+    let ttl = policy_ttl("permission", &rule_body("read", Some(T1), Some(ALICE), &anonymize));
+    assert_case(
+        "duty discharged",
+        &ttl,
+        &N3Request::new(act("read")).on(T1).by(ALICE).discharge(act("anonymize")),
+        &[(ALICE, "read", T1)],
+    );
+    assert_case("duty undischarged", &ttl, &N3Request::new(act("read")).on(T1).by(ALICE), &[]);
+    // two duties, one discharged → still blocked
+    let two = "odrl:duty [ odrl:action odrl:anonymize ] , [ odrl:action odrl:compensate ]".to_owned();
+    let ttl2 = policy_ttl("permission", &rule_body("read", Some(T1), Some(ALICE), &two));
+    assert_case(
+        "one of two duties discharged",
+        &ttl2,
+        &N3Request::new(act("read")).on(T1).by(ALICE).discharge(act("anonymize")),
+        &[],
+    );
+    // a second CLEAN permission grants even though the duty-bearing one is blocked
+    let mixed = format!(
+        "@prefix odrl: <http://www.w3.org/ns/odrl/2/> .\n\
+         <urn:pol/1> a odrl:Set ; \
+         odrl:permission [ {} ] ; odrl:permission [ {} ] .",
+        rule_body("read", Some(T1), Some(ALICE), &anonymize),
+        rule_body("read", Some(T1), Some(ALICE), "")
+    );
+    assert_case(
+        "clean sibling permission grants",
+        &mixed,
+        &N3Request::new(act("read")).on(T1).by(ALICE),
+        &[(ALICE, "read", T1)],
+    );
+}
+
+#[test]
+fn conflict_strategy_refusals_mirror() {
+    let body = rule_body("read", Some(T1), Some(ALICE), "");
+    let proh = rule_body("read", Some(T1), Some(ALICE), "");
+    let req = N3Request::new(act("read")).on(T1).by(ALICE);
+    // deny-overrides (odrl:prohibit) is the admissible strategy
+    let ok = format!(
+        "@prefix odrl: <http://www.w3.org/ns/odrl/2/> .\n\
+         <urn:pol/1> a odrl:Set ; odrl:conflict odrl:prohibit ; odrl:permission [ {body} ] ."
+    );
+    assert_case("conflict prohibit admissible", &ok, &req, &[(ALICE, "read", T1)]);
+    // odrl:perm / unknown → REFUSED on both paths (nothing materialized)
+    for strategy in ["odrl:perm", "<urn:strategy/unknown>"] {
+        let ttl = format!(
+            "@prefix odrl: <http://www.w3.org/ns/odrl/2/> .\n\
+             <urn:pol/1> a odrl:Set ; odrl:conflict {strategy} ; odrl:permission [ {body} ] ."
+        );
+        assert_case(&format!("conflict {strategy} refused"), &ttl, &req, &[]);
+    }
+    // odrl:invalid with a DETECTED conflict → refused; without one → admissible
+    let invalid_conflicting = format!(
+        "@prefix odrl: <http://www.w3.org/ns/odrl/2/> .\n\
+         <urn:pol/1> a odrl:Set ; odrl:conflict odrl:invalid ; \
+         odrl:permission [ {body} ] ; odrl:prohibition [ {proh} ] ."
+    );
+    assert_case("conflict invalid+conflict refused", &invalid_conflicting, &req, &[]);
+    let invalid_clean = format!(
+        "@prefix odrl: <http://www.w3.org/ns/odrl/2/> .\n\
+         <urn:pol/1> a odrl:Set ; odrl:conflict odrl:invalid ; odrl:permission [ {body} ] ."
+    );
+    assert_parity("conflict invalid clean", &invalid_clean, &req);
+}
+
+#[test]
+fn deny_overrides_compositions() {
+    // prohibition on a DIFFERENT action does not block
+    let ttl = policy_ttl2(
+        &rule_body("read", Some(T1), Some(ALICE), ""),
+        &rule_body("modify", Some(T1), Some(ALICE), ""),
+    );
+    assert_case(
+        "unrelated prohibition",
+        &ttl,
+        &N3Request::new(act("read")).on(T1).by(ALICE),
+        &[(ALICE, "read", T1)],
+    );
+    // `use`-umbrella prohibition carves out a read request (hierarchy on the DENY side)
+    let ttl = policy_ttl2(
+        &rule_body("read", Some(T1), Some(ALICE), ""),
+        &rule_body("use", Some(T1), Some(ALICE), ""),
+    );
+    assert_case(
+        "umbrella prohibition denies read",
+        &ttl,
+        &N3Request::new(act("read")).on(T1).by(ALICE),
+        &[(ALICE, "denyRead", T1)],
+    );
+    // prohibition scoped to BOB does not carve out ALICE
+    let ttl = policy_ttl2(
+        &rule_body("read", Some(T1), Some(ALICE), ""),
+        &rule_body("read", Some(T1), Some(BOB), ""),
+    );
+    assert_case(
+        "other-party prohibition",
+        &ttl,
+        &N3Request::new(act("read")).on(T1).by(ALICE),
+        &[(ALICE, "read", T1)],
+    );
+    // prohibition on another TARGET does not carve out T1
+    let ttl = policy_ttl2(
+        &rule_body("read", Some(T1), Some(ALICE), ""),
+        &rule_body("read", Some(T2), Some(ALICE), ""),
+    );
+    assert_case(
+        "other-target prohibition",
+        &ttl,
+        &N3Request::new(act("read")).on(T1).by(ALICE),
+        &[(ALICE, "read", T1)],
+    );
+    // an UNMAPPED-action matching prohibition still blocks the grant (evaluate
+    // denies) even though no deny triple can be materialized
+    let ttl = policy_ttl2(
+        &rule_body("aggregate", Some(T1), Some(ALICE), ""),
+        &rule_body("aggregate", Some(T1), Some(ALICE), ""),
+    );
+    assert_case(
+        "unmapped action both ways",
+        &ttl,
+        &N3Request::new(act("aggregate")).on(T1).by(ALICE),
+        &[],
+    );
+    // append/write modes flow through the deny table
+    let ttl = policy_ttl2(
+        &rule_body("append", Some(T1), Some(ALICE), ""),
+        &rule_body("append", Some(T1), Some(ALICE), ""),
+    );
+    assert_case(
+        "append deny mode",
+        &ttl,
+        &N3Request::new(act("append")).on(T1).by(ALICE),
+        &[(ALICE, "denyAppend", T1)],
+    );
+    // a PROHIBITION-ONLY policy: the matched carve-out materializes its deny with no
+    // permission in sight; an unmatched one materializes nothing
+    let ttl = policy_ttl("prohibition", &rule_body("modify", Some(T1), Some(ALICE), ""));
+    assert_case(
+        "prohibition-only matched",
+        &ttl,
+        &N3Request::new(act("modify")).on(T1).by(ALICE),
+        &[(ALICE, "denyWrite", T1)],
+    );
+    assert_case(
+        "prohibition-only unmatched",
+        &ttl,
+        &N3Request::new(act("modify")).on(T2).by(ALICE),
+        &[],
+    );
+    // the `use` umbrella prohibition does NOT carve out the transfer subtree
+    let ttl = policy_ttl("prohibition", &rule_body("use", Some(T1), Some(ALICE), ""));
+    assert_case("umbrella spares sell", &ttl, &N3Request::new(act("sell")).on(T1).by(ALICE), &[]);
+}
+
+#[test]
+fn malformed_constraints_fail_closed_on_both_paths() {
+    // a structurally-incomplete constraint (no operator/right) parses to the
+    // unsatisfiable guard on the Rust side; the N3 side must agree: NOTHING.
+    let ttl = format!(
+        "@prefix odrl: <http://www.w3.org/ns/odrl/2/> .\n\
+         <urn:pol/1> a odrl:Set ; odrl:permission [ {} ; \
+         odrl:constraint [ odrl:leftOperand odrl:purpose ] ] .",
+        rule_body("read", Some(T1), Some(ALICE), "")
+    );
+    assert_case(
+        "incomplete constraint",
+        &ttl,
+        &N3Request::new(act("read"))
+            .on(T1)
+            .by(ALICE)
+            .with(PURPOSE, Value::Iri("urn:purpose/research".to_owned())),
+        &[],
+    );
+    // an unknown operator likewise becomes the unsatisfiable guard
+    let ttl = format!(
+        "@prefix odrl: <http://www.w3.org/ns/odrl/2/> .\n\
+         <urn:pol/1> a odrl:Set ; odrl:permission [ {} ; \
+         odrl:constraint [ odrl:leftOperand odrl:purpose ; odrl:operator odrl:hasPart ; \
+                           odrl:rightOperand <urn:purpose/research> ] ] .",
+        rule_body("read", Some(T1), Some(ALICE), "")
+    );
+    assert_case(
+        "unknown operator",
+        &ttl,
+        &N3Request::new(act("read"))
+            .on(T1)
+            .by(ALICE)
+            .with(PURPOSE, Value::Iri("urn:purpose/research".to_owned())),
+        &[],
+    );
+}
+
+// ── out-of-subset constructs are LOUD errors, never silent divergence ─────────────────
+
+#[test]
+fn out_of_subset_is_a_loud_error_not_a_divergence() {
+    let req = || N3Request::new(act("read")).on(T1).by(ALICE);
+    let cases: [(&str, String); 5] = [
+        (
+            "fractional-second bound",
+            policy_ttl(
+                "permission",
+                &rule_body("read", Some(T1), Some(ALICE), &dt_constraint("lteq", "2026-12-31T00:00:00.5Z")),
+            ),
+        ),
+        (
+            "negative-year bound",
+            policy_ttl(
+                "permission",
+                &rule_body("read", Some(T1), Some(ALICE), &dt_constraint("lteq", "-0044-03-15T00:00:00Z")),
+            ),
+        ),
+        (
+            "order operator on purpose",
+            policy_ttl(
+                "permission",
+                &rule_body("read", Some(T1), Some(ALICE), &str_constraint("purpose", "lteq", "5")),
+            ),
+        ),
+        (
+            "numeric count bound",
+            policy_ttl(
+                "permission",
+                &rule_body(
+                    "read",
+                    Some(T1),
+                    Some(ALICE),
+                    "odrl:constraint [ odrl:leftOperand odrl:count ; odrl:operator odrl:lteq ; \
+                     odrl:rightOperand 5 ]",
+                ),
+            ),
+        ),
+        (
+            "nested logical constraint",
+            policy_ttl(
+                "permission",
+                &rule_body(
+                    "read",
+                    Some(T1),
+                    Some(ALICE),
+                    "odrl:constraint [ odrl:and [ odrl:or [ odrl:leftOperand odrl:purpose ; \
+                     odrl:operator odrl:eq ; odrl:rightOperand <urn:p/r> ] ] ]",
+                ),
+            ),
+        ),
+    ];
+    for (label, ttl) in cases {
+        let policy = parse_policy_str(&ttl, "turtle").expect("parses");
+        let mut g = Graph::new();
+        let err = materialize_policy_n3(&mut g, &policy, &req())
+            .expect_err(&format!("{label}: must be a loud error"));
+        assert!(!err.is_empty(), "{label}: error carries a reason");
+        // and NOTHING was materialized (fail-closed)
+        assert!(
+            g.named.is_empty(),
+            "{label}: an out-of-subset refusal must materialize nothing"
+        );
+    }
+    // request-side: fractional-second evaluation time
+    let ttl = policy_ttl("permission", &rule_body("read", Some(T1), Some(ALICE), ""));
+    let policy = parse_policy_str(&ttl, "turtle").expect("parses");
+    let mut g = Graph::new();
+    let err = materialize_policy_n3(&mut g, &policy, &req().at("2026-07-01T00:00:00.123Z"))
+        .expect_err("fractional-second request time must be a loud error");
+    assert!(err.contains("lexical space"), "clear reason, got: {err}");
+    assert!(g.named.is_empty());
+}

--- a/skills/access-control/SKILL.md
+++ b/skills/access-control/SKILL.md
@@ -268,6 +268,22 @@ Materialize the authorization view from the access-control documents, then enfor
   constraints falls back **entirely** to one-shot (fail-safe — never drops a bound). A
   dateTime window is mapped only on an **allow** (a lapsed *deny* would fail open). Mapping
   table in the [`usage-control-policy`](../usage-control-policy/SKILL.md) skill.
+- `odrl_bridge::materialize_policy_n3(&mut Graph, &Policy, &N3Request) -> Result<BridgeOutcome, String>`
+  — **opt-in** (`odrl-bridge`; [FABLE-5] sq-zgbso.2, epic sq-zgbso/#1582): evaluate the
+  **stateless ODRL core as N3 rule strata** (`rules/odrl-core-{a,b,c,d}.n3`, the WAC/ACP
+  runtime `reason_n3` pattern) and materialize the SAME auth-view triples the Rust bridge
+  writes. **The Rust path (`materialize_policy`) remains the default evaluator** — this
+  entry exists to prove decision parity (CI-locked full-corpus differential
+  `tests/odrl_n3_differential.rs`; flipping any default is a maintainer decision, and the
+  build-time-compiled flip is sq-zgbso.4/.5). `odrl:dateTime` compares by **instant**
+  (offset-aware `time:inSeconds` normalization) with the accepted lexical space fail-closed
+  to second-precision forms; anything outside the stateless subset — numeric operands
+  (stateful `odrl:count` stays Rust), nested compound constraints, order operators on
+  non-dateTime dimensions — is a loud `Err` that materializes nothing. `N3Request` is the
+  evidence-restricted request type (action/target/party, `at` time, IRI/string context
+  evidence, discharged duties; **no** collection-membership/subsumption evidence by
+  construction — use the Rust path for taxonomy evidence); `N3Request::to_request()`
+  yields the equivalent `sparq_policy::Request` for the Rust leg.
 - `store.refresh_odrl_grant(&Policy, &Request, BridgeKind)` / `refresh_odrl_grants()` —
   **opt-in** (`odrl-bridge`; [OPUS-4.8] sq-dpk4): re-evaluate **bridged** ODRL grants when
   the policy changes and **retract** the ones that no longer hold (a withdrawn permission, a


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5) — bead `sq-zgbso.2`, epic `sq-zgbso` / maintainer issue #1582 (Phase 2, gated on the sq-zgbso.1 spike **GO** verdict, PR #1601). Design record: `research/odrl-n3-compiled-rules.md`.
>
> **Authorization surface — MAINTAINER-ARM.** This PR changes how ODRL grants can be derived (design record §7: access-control surface ⇒ maintainer-reviewed, not fleet auto-armed). Do not auto-merge.

Implements the **stateless ODRL core as N3 rule strata** in `sparq-solid` — the exact WAC/ACP runtime pattern (`sparq_reason::reason_n3` over embedded rule text) — with a **CI-locked decision differential** against the Rust path.

## What's in

- **`rules/odrl-core-{a,b,c,d}.n3`** — four stratified rule files generalizing the spike's one-permission shape to the full stateless subset: Permission/Prohibition matching (action incl. the `odrl:use` umbrella vs the transfer subtree; exact-IRI target/assignee or unconstrained), atomic constraints, one compound level of `odrl:and`/`or`/`xone` with the evaluator's three-valued fail-closed semantics, duties, and deny-overrides.
- **`odrl_bridge::materialize_policy_n3` + `N3Request`** — the **OPT-IN** N3 entry point (explicit call path inside the already-default-OFF `odrl-bridge` feature). **The Rust path (`materialize_policy` over `sparq_policy::evaluate`) remains the default evaluator**; this bead proves parity at scale, it does NOT flip any default (later maintainer decision; build-time compilation is sq-zgbso.3/.4).
- **`tests/odrl_n3_differential.rs`** — **236 parity scenarios + 6 loud-error cases**, red on any divergence (runs on `--features odrl-bridge`; NOT `--all-features` — pre-existing sq-s5tkx is out of scope).

## Spike findings addressed (not inherited)

- **(a) dateTime — RESOLVED with a normalizing comparison.** The spike compared `odrl:dateTime` lexically (`string:notGreaterThan`), instant-correct only for canonical UTC. The production strata normalize BOTH operands to epoch seconds with the engine's existing offset-aware **`time:inSeconds`** builtin and compare numerically — mixed `±hh:mm` offsets now order by instant, exactly like `sparq_policy::parse_instant` (differential includes offset-equal-instant cases pinned on `lt`/`lteq`/`eq`). Residual normalizer differences (fractional seconds: Rust keeps ns, `time:inSeconds` truncates; leap-second `:60`; negative/≥5-digit years) are **excluded FAIL-CLOSED**: the wrapper refuses such lexicals with a loud `Err` and materializes nothing — no silent divergence window. So: **both** remedies the brief offered — a normalizing builtin for the offset dimension, plus a fail-closed lexical-space guard for the precision dimension.
- **(c) stratification.** Constraint-bearing prohibitions run under a full A→B→C→D stratification (atomic statuses → `or`/`xone` completion → matching → decisions), so every `log:notIncludes` negates only stratum-complete predicates (design §3.5 / record §7). The differential's prohibition-window matrix covers active/lapsed/unprovable windows against a co-resident permission.
- **(b) stateful `odrl:count` stays Rust** — a usage-counter mutation is not an inference; numeric bounds/evidence are refused loudly by the N3 path.

## Differential shape (the honesty mechanics)

- Both paths consume the SAME parsed `sparq_policy::Policy` (evaluation is differential; parsing is shared — the record's scope) and the same request via `N3Request::to_request()`.
- Operand lexicalization is shared (`Value::as_str()`/the `is_part_of` member split), so value semantics have one source of truth; the DECISION logic (matching, three-valued combinators, deny-overrides, duty gating) is entirely in the rules.
- Spike scenarios keep **independently-stated expected sets** (a both-wrong agreement cannot pass); 20+ generated edges are likewise pinned.
- `N3Request` **by construction** carries no collection-membership/subsumption evidence — with that evidence absent the Rust matcher IS the exact-IRI base case the rules implement (a taxonomy-evidence caller must use the Rust path; refusing at the type level closes the fail-open hole a matching-but-unproven prohibition would otherwise open).
- Conflict-strategy admissibility reuses `sparq_policy::conflict_admissibility` on both paths (same refusal outcomes, differentially asserted for `perm`/`invalid`/unknown).

## Gates

- `cargo test -p sparq-solid` (default) and `--features odrl-bridge` — green (incl. the 7 spike tests unchanged + the new 13-test differential + 8 direct unit tests for the new public items).
- `cargo clippy -p sparq-solid --all-targets -- -D warnings` in both feature states — clean.
- `RUSTDOCFLAGS="-D warnings" cargo doc` in both feature states — clean.
- `scripts/check-readme-template.py` — 0 deviations.
- Coverage ratchet: sparq-solid is measured on default features (no case arm), where this module is compiled out — no floor risk.

## Not in this PR (follow-ups)

- ~~`skills/access-control/SKILL.md` deferral~~ — the required `public-api-skill (G2)` gate enforces the SKILL edit in the SAME PR, so it is now INCLUDED (second commit), placed between #1612's SKILL.md hunks so both merge cleanly; the deferral bead was closed as superseded.
- Runtime-perf/build-size measurement — sq-zgbso.3/.4 per the record's split verdict (the spike measured the like-for-like runtime ratio at ~1.1×, same reasoner class WAC/ACP already pay).

Closes bead `sq-zgbso.2`. Refs #1582.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
