### PR TITLE
feat(acbench): W1-W4 workload + oracle engine — fail-closed harness with anti-vacuity fixture (sq-i6du2.6)

### DIFF
--- a/crates/sparq-acbench/src/oracle.rs
+++ b/crates/sparq-acbench/src/oracle.rs
@@ -8,15 +8,19 @@
 //! Every public function returns [`Decision::Deny`] by default. A request is allowed
 //! only when there exists a matching `Allow` intent that is not overridden by a `Deny`.
 //!
-//! # Determinism
-//! All functions are pure (no mutation, no randomness, no time). Given the same inputs,
-//! they always return the same output.
+//! # Determinism (clock-free)
+//! All functions are pure (no mutation, no randomness, **no wall-clock read**). Temporal
+//! ODRL conditions are decided against a *pinned* evaluation instant
+//! (`BENCH_EVAL_INSTANT`) threaded through `evaluate_odrl_at`, never
+//! `SystemTime::now()`, so an expired-window intent stays `Deny` no matter what day the
+//! benchmark is re-run. Given the same inputs the oracle always returns the same output.
 //!
-//! # Completeness (B6's responsibility)
-//! Full workload-engine integration (W1–W4 decision batches, result-set oracles,
-//! churn delta computation) lives in `workload.rs` and `oracle.rs`'s `workload`
-//! submodule (bead `sq-i6du2.6`). This file implements only the per-row evaluation
-//! functions called from `lib.rs`'s public API.
+//! # Completeness
+//! Per-row evaluation (WAC / ACP / ODRL semantics, including the clock-free temporal +
+//! purpose condition evaluation) lives here; the workload-engine integration (W1–W4
+//! decision batches, result-set oracles, churn delta computation) lives in `workload.rs`.
+//! Both are bead `sq-i6du2.6`'s scope. The three public wrappers in `lib.rs`
+//! (`oracle_wac` / `oracle_acp` / `oracle_odrl`) call the evaluators here.
 
 use crate::{Audience, Condition, Decision, Effect, IntentRow, Request};
 
@@ -161,16 +165,47 @@ fn audience_matches_acp(request: &Request, audience: &Audience) -> bool {
 
 // ── ODRL oracle ─────────────────────────────────────────────────────────────────────
 
-/// Evaluate a request against an intent table using ODRL semantics.
+/// The **pinned benchmark evaluation instant** ("now") that all temporal conditions are
+/// evaluated against.
+///
+/// The oracle must be **clock-free** (no `SystemTime::now()`) so the ground truth is
+/// byte-identical on every run, platform, and date — a wall-clock read would make an
+/// expired-window intent flip from `Deny` to `Allow` merely by re-running the benchmark
+/// on a later day. Instead we pin a single fixed instant, in the same fixed-width UTC
+/// ISO-8601 form the generators emit, and every `Condition::Temporal { start, end }` is
+/// decided by the half-open membership test `start ≤ NOW < end`.
+///
+/// Value: `2026-07-06T00:00:00Z` — the benchmark's authoring date (design record §0). It
+/// sits inside the U3/U4 "current" windows and after the expired ones, so a corpus
+/// deterministically exercises BOTH the in-window (`Allow`) and expired-window (`Deny`)
+/// paths. This is a design decision recorded here and in the PR body; a future EC2 tier
+/// that wants to sweep the clock threads its own instant through
+/// [`evaluate_odrl_at`] instead of relying on this default.
+pub(crate) const BENCH_EVAL_INSTANT: &str = "2026-07-06T00:00:00Z";
+
+/// Evaluate a request against an intent table using ODRL semantics, at the pinned
+/// benchmark evaluation instant ([`BENCH_EVAL_INSTANT`]).
 ///
 /// ODRL rules:
 /// - `Effect::Allow` (Permission): a matching permission grants access if all conditions
 ///   are satisfied.
 /// - `Effect::Deny` (Prohibition): a matching prohibition denies access.
 /// - If both a Permission and a Prohibition match: Permission wins (ODRL precedence).
-/// - Conditions are evaluated procedurally (see [`evaluate_condition`]).
+/// - Conditions are evaluated procedurally against `now` (see [`evaluate_condition`]).
 /// - Fail-closed: no matching Permission → [`Decision::Deny`].
 pub(crate) fn evaluate_odrl(request: &Request, intents: &[IntentRow]) -> Decision {
+    evaluate_odrl_at(request, intents, BENCH_EVAL_INSTANT)
+}
+
+/// Evaluate a request against an intent table using ODRL semantics, at an explicit,
+/// caller-supplied evaluation instant `now` (fixed-width UTC ISO-8601, e.g.
+/// `"2026-07-06T00:00:00Z"`).
+///
+/// This is the clock-free core: `now` is threaded in, never read from the system clock,
+/// so the result is a pure function of `(request, intents, now)`. [`evaluate_odrl`] is the
+/// thin wrapper that pins `now` to [`BENCH_EVAL_INSTANT`]; an alternate-clock lane (e.g. a
+/// U4 embargo sweep) calls this directly.
+pub(crate) fn evaluate_odrl_at(request: &Request, intents: &[IntentRow], now: &str) -> Decision {
     use crate::Scope;
 
     let mut any_permission = false;
@@ -192,7 +227,7 @@ pub(crate) fn evaluate_odrl(request: &Request, intents: &[IntentRow]) -> Decisio
             continue;
         }
 
-        if !evaluate_condition(&intent.condition) {
+        if !evaluate_condition(&intent.condition, now) {
             continue;
         }
 
@@ -231,27 +266,74 @@ fn audience_matches_odrl(request: &Request, audience: &Audience) -> bool {
     }
 }
 
-/// Evaluate an ODRL usage condition.
+/// The **purpose declared by a request** for the benchmark's purpose-of-use evaluation.
 ///
-/// In the scaffold, conditions involving time/purpose/count are evaluated
-/// against fixed test-time values. Full runtime condition evaluation with
-/// real `dateTime` windows is B6's responsibility.
+/// A request carries no purpose field in the current [`Request`] IR (the generators do not
+/// yet declare one — bead `sq-i6du2.4`/`.5`), so a `Condition::Purpose` constraint is
+/// evaluated against this single pinned "authorized purpose" that the corpus grants for.
+/// A purpose-constrained permission is therefore satisfied iff its purpose equals this
+/// pinned value — modelling "this agent's session is running under the granted purpose".
+/// Any other purpose is a deny (fail-closed), so a wrong-purpose ground truth is caught.
+///
+/// This is a design decision (recorded in the PR body): it keeps purpose evaluation
+/// non-vacuous — a mismatched purpose denies — without inventing a `Request.purpose` field
+/// that would break the sibling generator branches. When those branches add a declared
+/// request purpose, this constant becomes the fixture default and the real field threads
+/// through the same way `now` does for temporal windows.
+pub(crate) const BENCH_GRANTED_PURPOSE: &str = "https://sparq.dev/vocab/purpose#reporting";
+
+/// Evaluate an ODRL usage condition against a pinned evaluation instant `now`.
+///
+/// Clock-free by construction: `now` is a fixed-width UTC ISO-8601 string passed in by the
+/// caller (see [`BENCH_EVAL_INSTANT`]); nothing here reads the system clock, so the result
+/// is a pure function of `(condition, now)`.
+///
+/// - `Condition::None` — always satisfied.
+/// - `Condition::Temporal { start, end }` — satisfied iff `start ≤ now < end` (half-open
+///   window). Comparison is lexicographic, which is exact for the fixed-width `Z`-suffixed
+///   UTC ISO-8601 form the generators emit (same width, same zone ⇒ lexical order equals
+///   chronological order). An **expired** window (`now ≥ end`) or a **not-yet-open** one
+///   (`now < start`) is therefore a deny — the correct ground truth for a retention /
+///   embargo constraint.
+/// - `Condition::Purpose(p)` — satisfied iff `p` equals the pinned
+///   [`BENCH_GRANTED_PURPOSE`]; any other purpose denies (fail-closed).
+/// - `Condition::Count(n)` — satisfied iff `n > 0` (a zero-count grant admits nothing).
+/// - `Condition::And(a, b)` — conjunction; both sub-conditions must hold.
 ///
 /// # Fail-closed
-/// Any unrecognised or malformed condition returns `false` (deny).
-pub(crate) fn evaluate_condition(condition: &Condition) -> bool {
+/// A malformed temporal window (a bound that is not parseable as the expected fixed-width
+/// form, detected by a length check) returns `false` (deny) rather than silently admitting.
+pub(crate) fn evaluate_condition(condition: &Condition, now: &str) -> bool {
     match condition {
-        // Scaffold: None, Temporal, and Purpose all return true (always-satisfied stubs).
-        // B6 supplies real clock-free temporal evaluation and purpose-matching.
-        Condition::None | Condition::Temporal { .. } | Condition::Purpose(_) => true,
-        Condition::Count(n) => {
-            // Scaffold: count > 0 is satisfied; 0 is deny.
-            *n > 0
-        }
+        Condition::None => true,
+        Condition::Temporal { start, end } => temporal_in_window(start, end, now),
+        Condition::Purpose(p) => p == BENCH_GRANTED_PURPOSE,
+        Condition::Count(n) => *n > 0,
         Condition::And(a, b) => {
-            evaluate_condition(a) && evaluate_condition(b)
+            evaluate_condition(a, now) && evaluate_condition(b, now)
         }
     }
+}
+
+/// Half-open temporal-window membership test: `start ≤ now < end`.
+///
+/// The three arguments are all fixed-width `Z`-suffixed UTC ISO-8601 instants
+/// (`YYYY-MM-DDTHH:MM:SSZ`). For that canonical form, lexicographic `str` ordering is
+/// identical to chronological ordering, so no date parsing (and no timezone / DST logic,
+/// and no external crate) is needed — this is what keeps the oracle simple and trustworthy.
+///
+/// # Fail-closed
+/// If any of the three instants is not the expected 20-character fixed-width form, the
+/// window is treated as unsatisfiable (`false`) — a malformed bound must never silently
+/// admit access.
+fn temporal_in_window(start: &str, end: &str, now: &str) -> bool {
+    // Canonical form is exactly `YYYY-MM-DDTHH:MM:SSZ` = 20 chars. A differing width would
+    // break the lexicographic ⇔ chronological equivalence, so reject it fail-closed.
+    const CANONICAL_LEN: usize = 20;
+    if start.len() != CANONICAL_LEN || end.len() != CANONICAL_LEN || now.len() != CANONICAL_LEN {
+        return false;
+    }
+    start <= now && now < end
 }
 
 // ── Shared helpers ───────────────────────────────────────────────────────────────────
@@ -289,5 +371,139 @@ pub(crate) fn evaluate(
         crate::AcModel::Wac => evaluate_wac(request, intents),
         crate::AcModel::Acp => evaluate_acp(request, intents),
         crate::AcModel::Odrl => evaluate_odrl(request, intents),
+    }
+}
+
+// ── Direct unit tests for the clock-free condition evaluator (bead `sq-i6du2.6`) ──────
+//
+// These pin the condition-eval semantics at the unit level (per-branch, exact value) so a
+// comparison/boundary mutant in the temporal window test or a stubbed-out condition arm
+// goes red WITHOUT needing a full generator corpus. The integration lane in
+// `tests/workloads.rs` covers the model-differentiating dispatch; this covers the leaf
+// evaluator's arms directly.
+#[cfg(test)]
+mod tests {
+    use super::{
+        BENCH_EVAL_INSTANT, BENCH_GRANTED_PURPOSE, evaluate_condition, temporal_in_window,
+    };
+    use crate::Condition;
+
+    #[test]
+    fn none_condition_is_always_satisfied() {
+        assert!(evaluate_condition(&Condition::None, BENCH_EVAL_INSTANT));
+    }
+
+    #[test]
+    fn temporal_window_half_open_boundaries() {
+        // start ≤ now < end. Same-width canonical instants ⇒ lexical == chronological.
+        assert!(temporal_in_window(
+            "2026-01-01T00:00:00Z",
+            "2027-01-01T00:00:00Z",
+            "2026-07-06T00:00:00Z"
+        ));
+        // now == start is IN (inclusive lower bound).
+        assert!(temporal_in_window(
+            "2026-07-06T00:00:00Z",
+            "2027-01-01T00:00:00Z",
+            "2026-07-06T00:00:00Z"
+        ));
+        // now == end is OUT (exclusive upper bound).
+        assert!(!temporal_in_window(
+            "2026-01-01T00:00:00Z",
+            "2026-07-06T00:00:00Z",
+            "2026-07-06T00:00:00Z"
+        ));
+        // expired (now ≥ end).
+        assert!(!temporal_in_window(
+            "2020-01-01T00:00:00Z",
+            "2021-01-01T00:00:00Z",
+            "2026-07-06T00:00:00Z"
+        ));
+        // not yet open (now < start).
+        assert!(!temporal_in_window(
+            "2099-01-01T00:00:00Z",
+            "2100-01-01T00:00:00Z",
+            "2026-07-06T00:00:00Z"
+        ));
+    }
+
+    #[test]
+    fn temporal_malformed_bound_fails_closed() {
+        // A non-canonical width breaks the lexical⇔chronological equivalence ⇒ deny.
+        assert!(!temporal_in_window("2026", "2027-01-01T00:00:00Z", BENCH_EVAL_INSTANT));
+        assert!(!temporal_in_window(
+            "2026-01-01T00:00:00Z",
+            "not-a-date",
+            BENCH_EVAL_INSTANT
+        ));
+        assert!(!temporal_in_window(
+            "2026-01-01T00:00:00Z",
+            "2027-01-01T00:00:00Z",
+            "now"
+        ));
+    }
+
+    #[test]
+    fn temporal_condition_uses_pinned_instant() {
+        let valid = Condition::Temporal {
+            start: "2026-01-01T00:00:00Z".to_string(),
+            end: "2027-01-01T00:00:00Z".to_string(),
+        };
+        let expired = Condition::Temporal {
+            start: "2020-01-01T00:00:00Z".to_string(),
+            end: "2021-01-01T00:00:00Z".to_string(),
+        };
+        assert!(evaluate_condition(&valid, BENCH_EVAL_INSTANT));
+        assert!(!evaluate_condition(&expired, BENCH_EVAL_INSTANT));
+    }
+
+    #[test]
+    fn purpose_condition_matches_only_granted_purpose() {
+        assert!(evaluate_condition(
+            &Condition::Purpose(BENCH_GRANTED_PURPOSE.to_string()),
+            BENCH_EVAL_INSTANT
+        ));
+        assert!(!evaluate_condition(
+            &Condition::Purpose("https://sparq.dev/vocab/purpose#marketing".to_string()),
+            BENCH_EVAL_INSTANT
+        ));
+    }
+
+    #[test]
+    fn count_condition_zero_denies_positive_admits() {
+        assert!(!evaluate_condition(&Condition::Count(0), BENCH_EVAL_INSTANT));
+        assert!(evaluate_condition(&Condition::Count(1), BENCH_EVAL_INSTANT));
+    }
+
+    #[test]
+    fn and_condition_is_conjunction() {
+        let both_true = Condition::And(
+            Box::new(Condition::Purpose(BENCH_GRANTED_PURPOSE.to_string())),
+            Box::new(Condition::Temporal {
+                start: "2026-01-01T00:00:00Z".to_string(),
+                end: "2027-01-01T00:00:00Z".to_string(),
+            }),
+        );
+        assert!(evaluate_condition(&both_true, BENCH_EVAL_INSTANT));
+
+        // One expired arm makes the conjunction false.
+        let one_expired = Condition::And(
+            Box::new(Condition::Purpose(BENCH_GRANTED_PURPOSE.to_string())),
+            Box::new(Condition::Temporal {
+                start: "2020-01-01T00:00:00Z".to_string(),
+                end: "2021-01-01T00:00:00Z".to_string(),
+            }),
+        );
+        assert!(!evaluate_condition(&one_expired, BENCH_EVAL_INSTANT));
+
+        // Wrong purpose also makes it false.
+        let wrong_purpose = Condition::And(
+            Box::new(Condition::Purpose("https://sparq.dev/vocab/purpose#other".to_string())),
+            Box::new(Condition::Temporal {
+                start: "2026-01-01T00:00:00Z".to_string(),
+                end: "2027-01-01T00:00:00Z".to_string(),
+            }),
+        );
+        assert!(!evaluate_condition(&wrong_purpose, BENCH_EVAL_INSTANT));
     }
 }

--- a/crates/sparq-acbench/src/oracle.rs
+++ b/crates/sparq-acbench/src/oracle.rs
@@ -263,3 +263,31 @@ fn mode_matches(requested: &crate::AccessMode, granted: &crate::AccessMode) -> b
         && (!requested.write || granted.write)
         && (!requested.control || granted.control)
 }
+
+// ── Workload-engine model dispatch (bead `sq-i6du2.6`) ────────────────────────────────
+
+/// Dispatch a request to the by-construction oracle for a given [`AcModel`].
+///
+/// This is the single entry point the workload engine (`workload.rs`, W1/W3/W4) uses to
+/// obtain the ground-truth decision for a `(request, model)` pair. It is a thin router
+/// over [`evaluate_wac`], [`evaluate_acp`], and [`evaluate_odrl`] so the workload engine
+/// never re-implements per-model semantics (single source of truth for the oracle).
+///
+/// **Structural independence**: like the three underlying evaluators, this function reads
+/// only the intent table — it never links or calls any sparq crate. That independence is
+/// the whole point of the benchmark: an unsound system-under-test must *disagree* with
+/// this oracle and thereby FAIL the harness.
+///
+/// **Determinism**: pure function of `(model, request, intents)`.
+#[must_use]
+pub(crate) fn evaluate(
+    model: &crate::AcModel,
+    request: &Request,
+    intents: &[IntentRow],
+) -> Decision {
+    match model {
+        crate::AcModel::Wac => evaluate_wac(request, intents),
+        crate::AcModel::Acp => evaluate_acp(request, intents),
+        crate::AcModel::Odrl => evaluate_odrl(request, intents),
+    }
+}

--- a/crates/sparq-acbench/src/workload.rs
+++ b/crates/sparq-acbench/src/workload.rs
@@ -33,8 +33,10 @@
 //! blocker is gone. However, this crate is a dev-only **oracle** crate with a load-bearing
 //! *zero dependency on `sparq-core` / `sparq-engine` / `sparq-solid`* (Cargo.toml) — it
 //! cannot link the system under test. Driving a live `PodStore::query_as` concurrently
-//! therefore belongs to a `sparq-solid`-linked driver under `bench/ac/` (beads
-//! `sq-i6du2.7` / `.9`), NOT to this oracle crate. The W4 query sub-lane is consequently
+//! therefore belongs to the `sparq-solid`-linked live DRIVER under `bench/ac/` — bead
+//! `sq-kvvcl`, the FILES-scoped owner of that driver (surfaced by the #1627 review:
+//! `sq-i6du2.7` is scripts/registry-only and `.9` is RESULTS-only, so neither actually
+//! links the SUT). It is NOT this oracle crate's job. The W4 query sub-lane is consequently
 //! [`RunOutcome::Skipped`] here with the accurate reason
 //! [`W4_QUERY_SKIP_REASON`] — never a fabricated concurrency number.
 //!
@@ -48,10 +50,11 @@ use crate::{AcModel, Decision, GenParams, IntentRow, QueryClass, Request, oracle
 /// The `&self` read-side (#1569 / PR #1612) has merged, so the reason is NOT "blocked on
 /// an unmerged dependency". The remaining blocker is architectural: this oracle crate is
 /// forbidden (by the Cargo.toml zero-dependency constraint) from linking `sparq-solid`, so
-/// the concurrent live-`query_as` driver lives outside this crate. This string is asserted
-/// in `tests/workloads.rs` so the reason cannot silently drift back to a false claim.
+/// the concurrent live-`query_as` driver lives outside this crate — in the FILES-scoped
+/// live driver bead `sq-kvvcl` under `bench/ac/`. This string is asserted in
+/// `tests/workloads.rs` so the reason cannot silently drift back to a false claim.
 pub const W4_QUERY_SKIP_REASON: &str =
-    "W4 query sub-lane runs in the sparq-solid-linked bench/ac driver (sq-i6du2.7/.9), \
+    "W4 query sub-lane runs in the sparq-solid-linked bench/ac live driver (sq-kvvcl), \
      not this zero-dependency oracle crate; #1569/#1612 (the &self read-side) has merged, \
      so the API blocker is gone but this crate must not link the system under test";
 

--- a/crates/sparq-acbench/src/workload.rs
+++ b/crates/sparq-acbench/src/workload.rs
@@ -1,28 +1,66 @@
-//! Workload engine stubs (W1–W4) — bead `sq-i6du2.6`.
+//! Workload + oracle engine (W1–W4) — bead `sq-i6du2.6`.
 //!
-//! This module provides the typed interfaces for the four benchmark workloads defined
-//! in §2.1 of `research/ac-query-benchmark.md`. The full implementation lives in
-//! bead `sq-i6du2.6` (oracle + workload engine). The scaffold defines the types and
-//! `todo!()` stubs so beads `.2`–`.5` can import them without touching `lib.rs`.
+//! This module implements the four benchmark workloads defined in §2.1 of
+//! `research/ac-query-benchmark.md`, each gated on the by-construction oracle:
 //!
-//! # Fail-closed harness contract (B6's responsibility)
-//! - Any decision mismatch → nonzero exit; no timing is reported for failed lanes.
-//! - Any result-set mismatch → nonzero exit.
-//! - Any post-churn stale grant → nonzero exit.
-//! - W4 query sub-lane emits `RunOutcome::Skipped { reason }` until the `&self`
-//!   read-side (#1569) lands.
+//! - **W1 decision micro-benchmark** — [`W1DecisionBatch`]: batches of
+//!   `(agent, client, resource, mode)` requests checked against pre-computed expected
+//!   decisions via the model oracle.
+//! - **W2 access-controlled query** — [`W2QueryLane`]: closed-form expected result sets
+//!   checked against the authorized-subset the oracle admits.
+//! - **W3 ACL-write + invalidation churn** — [`W3ChurnScript`]: interleaved
+//!   grant/revoke/policy-add writes with expected post-write decision *deltas*; a stale
+//!   grant surviving a revoke is a benchmark FAILURE, not a speedup.
+//! - **W4 concurrent readers** — [`W4Config`]: N threads of W1 batches (the decision
+//!   sub-lane runs today); the query sub-lane is [`RunOutcome::Skipped`] with a recorded
+//!   reason (see below).
+//!
+//! # Fail-closed harness contract (the credibility feature)
+//! A benchmark an unsound implementation can *win* is worthless. Therefore:
+//! - Any decision mismatch (oracle ≠ expected) ⇒ [`RunOutcome::Failed`]; a
+//!   [`HarnessReport`] with any failed lane exits non-zero ([`HarnessReport::exit_code`]).
+//! - Any result-set mismatch (W2) ⇒ [`RunOutcome::Failed`].
+//! - Any post-churn stale grant / missing grant (W3) ⇒ [`RunOutcome::Failed`].
+//! - **No timing is emitted for a lane that failed correctness** — the harness records
+//!   the mismatch, never a wall-clock number, for a red lane (`§2.3`).
+//! - The **anti-vacuity** fixture (`tests/workloads.rs`) proves the harness *does* fail on
+//!   a deliberately-wrong expected set — the oracle's oracle. Without it, a harness that
+//!   always passes would be indistinguishable from a correct one.
+//!
+//! # W4 query sub-lane status (re-checked 2026-07-06)
+//! The design record (§2.1 W4, §4.4) gated the W4 *query* sub-lane on the `sparq-solid`
+//! `&self` read-side (#1569, PR #1612). **That PR has now MERGED**, so the API-level
+//! blocker is gone. However, this crate is a dev-only **oracle** crate with a load-bearing
+//! *zero dependency on `sparq-core` / `sparq-engine` / `sparq-solid`* (Cargo.toml) — it
+//! cannot link the system under test. Driving a live `PodStore::query_as` concurrently
+//! therefore belongs to a `sparq-solid`-linked driver under `bench/ac/` (beads
+//! `sq-i6du2.7` / `.9`), NOT to this oracle crate. The W4 query sub-lane is consequently
+//! [`RunOutcome::Skipped`] here with the accurate reason
+//! [`W4_QUERY_SKIP_REASON`] — never a fabricated concurrency number.
 //!
 //! # File ownership
 //! **Only bead `sq-i6du2.6` edits this file.**
 
-use crate::{AcModel, Decision, GenParams, Request};
+use crate::{AcModel, Decision, GenParams, IntentRow, QueryClass, Request, oracle};
+
+/// The recorded skip reason for the W4 query sub-lane.
+///
+/// The `&self` read-side (#1569 / PR #1612) has merged, so the reason is NOT "blocked on
+/// an unmerged dependency". The remaining blocker is architectural: this oracle crate is
+/// forbidden (by the Cargo.toml zero-dependency constraint) from linking `sparq-solid`, so
+/// the concurrent live-`query_as` driver lives outside this crate. This string is asserted
+/// in `tests/workloads.rs` so the reason cannot silently drift back to a false claim.
+pub const W4_QUERY_SKIP_REASON: &str =
+    "W4 query sub-lane runs in the sparq-solid-linked bench/ac driver (sq-i6du2.7/.9), \
+     not this zero-dependency oracle crate; #1569/#1612 (the &self read-side) has merged, \
+     so the API blocker is gone but this crate must not link the system under test";
 
 /// The outcome of one workload lane run.
 #[derive(Debug, Clone)]
 pub enum RunOutcome {
     /// The lane passed all oracle checks.
     Passed {
-        /// Number of decisions evaluated.
+        /// Number of decisions (or result rows) evaluated.
         decisions: usize,
         /// Hint at wall-clock; NON-CANONICAL on a work-box (labels required by harness).
         wall_us_indicative: u64,
@@ -34,7 +72,7 @@ pub enum RunOutcome {
     },
     /// The lane was explicitly skipped (blocked on a dependency).
     Skipped {
-        /// Reason for skip (e.g. `"blocked: #1569"`).
+        /// Reason for skip (e.g. [`W4_QUERY_SKIP_REASON`]).
         reason: String,
     },
 }
@@ -51,10 +89,34 @@ impl RunOutcome {
     pub fn is_failure(&self) -> bool {
         matches!(self, RunOutcome::Failed { .. })
     }
+
+    /// Returns `true` iff the outcome is a skip.
+    #[must_use]
+    pub fn is_skipped(&self) -> bool {
+        matches!(self, RunOutcome::Skipped { .. })
+    }
+
+    /// The mismatch description if this is a [`RunOutcome::Failed`], else `None`.
+    #[must_use]
+    pub fn mismatch(&self) -> Option<&str> {
+        match self {
+            RunOutcome::Failed { mismatch } => Some(mismatch.as_str()),
+            _ => None,
+        }
+    }
 }
 
+// ── W1: decision micro-benchmark ──────────────────────────────────────────────────────
+
 /// A W1 decision-batch workload: batches of `(agent, client, resource, mode)` tuples
-/// through the access-control evaluator.
+/// checked against the by-construction oracle.
+///
+/// The `intents` table is the ground truth; `expected` is the generator's pre-computed
+/// decision for each request (from its `ExpectedDecision` rows). The lane passes iff, for
+/// every request, the *oracle re-evaluated over `intents`* equals the pre-computed
+/// `expected`. This double-checks the generator against the shared oracle and gives the
+/// workload engine a single decision path (`oracle::evaluate`) it can also run
+/// concurrently in W4.
 pub struct W1DecisionBatch {
     /// The requests to evaluate.
     pub requests: Vec<Request>,
@@ -62,21 +124,285 @@ pub struct W1DecisionBatch {
     pub expected: Vec<Decision>,
     /// The model to evaluate against.
     pub model: AcModel,
+    /// The by-construction intent table the oracle reads (ground truth).
+    pub intents: Vec<IntentRow>,
 }
 
 impl W1DecisionBatch {
-    /// Run this batch through the by-construction oracle and return a `RunOutcome`.
+    /// Run this batch through the by-construction oracle and return a [`RunOutcome`].
     ///
-    /// The oracle is consulted against the generator's intent table (passed via
-    /// the generator's `expected_decisions` field, not re-derived here).
+    /// For each request, the model oracle is evaluated over [`Self::intents`] and compared
+    /// against the parallel [`Self::expected`] entry.
     ///
     /// # Fail-closed
-    /// Any mismatch returns `RunOutcome::Failed`.
+    /// - A `requests` / `expected` length mismatch is a harness wiring bug ⇒
+    ///   [`RunOutcome::Failed`] (never silently truncated).
+    /// - The FIRST `(request, model)` whose oracle decision differs from `expected` ⇒
+    ///   [`RunOutcome::Failed`] with a diagnostic; **no timing** is reported for a failed
+    ///   lane.
+    ///
+    /// # Determinism
+    /// Pure function of the batch contents (no clock affects the pass/fail verdict; the
+    /// indicative wall-clock is measured but never gates correctness).
     #[must_use]
     pub fn run_oracle(&self) -> RunOutcome {
-        todo!("sq-i6du2.6: implement W1 decision-batch oracle runner")
+        if self.requests.len() != self.expected.len() {
+            return RunOutcome::Failed {
+                mismatch: format!(
+                    "W1 wiring bug: {} requests vs {} expected decisions (must be equal)",
+                    self.requests.len(),
+                    self.expected.len()
+                ),
+            };
+        }
+
+        let start = std::time::Instant::now();
+        for (i, (request, want)) in self.requests.iter().zip(self.expected.iter()).enumerate() {
+            let got = oracle::evaluate(&self.model, request, &self.intents);
+            if got != *want {
+                // Correctness failure: report the mismatch, NEVER a timing number.
+                return RunOutcome::Failed {
+                    mismatch: format!(
+                        "W1 decision mismatch at index {i} ({:?}): oracle={got:?} expected={want:?} \
+                         for agent={} resource={} mode={:?}",
+                        self.model, request.agent, request.resource, request.mode
+                    ),
+                };
+            }
+        }
+        // Correctness held: only NOW may we report an (indicative) wall-clock.
+        let wall_us_indicative = u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX);
+        RunOutcome::Passed { decisions: self.requests.len(), wall_us_indicative }
     }
 }
+
+// ── W2: access-controlled query result-set oracle ─────────────────────────────────────
+
+/// A single W2 query check: a set of *candidate* result rows the query would return over
+/// the full dataset, and the set the requesting agent is *authorized* to see.
+///
+/// The by-construction expected result set is
+/// `candidate_rows ∩ authorized_rows` — the query answer restricted to graphs the oracle
+/// admits for the agent. The lane passes iff the engine-produced `produced_rows` equals
+/// that expected set (as a sorted, de-duplicated multiset of N-Quads strings).
+///
+/// In this oracle crate the "engine-produced" rows are the generator's closed-form
+/// `expected_rows` — so the lane validates the generator's result set against the oracle's
+/// authorized subset. A `sparq-solid`-linked driver (`bench/ac/`) later substitutes the
+/// real `query_as` output for `produced_rows` unchanged.
+#[derive(Debug, Clone)]
+pub struct W2QueryCheck {
+    /// The W2 query class this check exercises.
+    pub class: QueryClass,
+    /// The access-control model.
+    pub model: AcModel,
+    /// Rows the query returns over the FULL (unauthorized) dataset, sorted N-Quads.
+    pub candidate_rows: Vec<String>,
+    /// Rows the requesting agent is authorized to observe, sorted N-Quads.
+    pub authorized_rows: Vec<String>,
+    /// The rows actually produced (by the generator here; by `query_as` in the driver).
+    pub produced_rows: Vec<String>,
+}
+
+impl W2QueryCheck {
+    /// The by-construction expected result set: authorized ∩ candidate, sorted+deduped.
+    #[must_use]
+    pub fn expected_rows(&self) -> Vec<String> {
+        let authorized: std::collections::BTreeSet<&String> = self.authorized_rows.iter().collect();
+        let mut out: Vec<String> = self
+            .candidate_rows
+            .iter()
+            .filter(|r| authorized.contains(r))
+            .cloned()
+            .collect();
+        out.sort();
+        out.dedup();
+        out
+    }
+
+    /// Compare the produced rows against the by-construction expected set.
+    ///
+    /// # Fail-closed
+    /// Any element the engine returned that the agent is NOT authorized to see (an
+    /// over-share) — or any authorized row the engine dropped — is a [`RunOutcome::Failed`].
+    #[must_use]
+    fn check(&self) -> RunOutcome {
+        let expected = self.expected_rows();
+        let mut produced = self.produced_rows.clone();
+        produced.sort();
+        produced.dedup();
+
+        if produced != expected {
+            // Diagnose the first divergence for a legible failure message.
+            let over: Vec<&String> = produced.iter().filter(|r| !expected.contains(r)).collect();
+            let under: Vec<&String> = expected.iter().filter(|r| !produced.contains(r)).collect();
+            return RunOutcome::Failed {
+                mismatch: format!(
+                    "W2 {:?}/{:?} result-set mismatch: {} over-shared row(s) (e.g. {:?}), \
+                     {} missing row(s) (e.g. {:?})",
+                    self.class,
+                    self.model,
+                    over.len(),
+                    over.first(),
+                    under.len(),
+                    under.first()
+                ),
+            };
+        }
+        RunOutcome::Passed { decisions: expected.len(), wall_us_indicative: 0 }
+    }
+}
+
+/// A W2 lane: a sequence of [`W2QueryCheck`]s across the four query classes.
+pub struct W2QueryLane {
+    /// The per-query checks in this lane.
+    pub checks: Vec<W2QueryCheck>,
+}
+
+impl W2QueryLane {
+    /// Run every query check; the lane fails on the FIRST mismatch (fail-closed).
+    ///
+    /// A passing lane reports the total number of result rows validated; a failing lane
+    /// reports only the mismatch (no timing).
+    #[must_use]
+    pub fn run_oracle(&self) -> RunOutcome {
+        let start = std::time::Instant::now();
+        let mut rows = 0usize;
+        for check in &self.checks {
+            match check.check() {
+                RunOutcome::Passed { decisions, .. } => rows += decisions,
+                failed @ RunOutcome::Failed { .. } => return failed,
+                RunOutcome::Skipped { reason } => return RunOutcome::Skipped { reason },
+            }
+        }
+        let wall_us_indicative = u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX);
+        RunOutcome::Passed { decisions: rows, wall_us_indicative }
+    }
+}
+
+// ── W3: ACL-write + invalidation churn ────────────────────────────────────────────────
+
+/// A single ACL-write operation in a W3 churn script.
+///
+/// Each write mutates the intent table; the oracle re-evaluates over the *post-write*
+/// table, so a grant that should have been revoked but survives (a stale grant) is caught
+/// as a decision mismatch — the whole point of the invalidation lane.
+#[derive(Debug, Clone)]
+pub enum AclWrite {
+    /// Add (grant) an intent row.
+    Grant(IntentRow),
+    /// Remove every intent row equal to this one (revoke). Idempotent if absent.
+    Revoke(IntentRow),
+}
+
+/// The expected decision for one probe after a specific write step.
+///
+/// A W3 probe is checked against the intent table *as of* [`Self::after_step`] writes
+/// applied — that is what makes a stale grant observable: the probe expects `Deny` after a
+/// revoke, and if the table (or a system under test) still grants, the lane fails.
+#[derive(Debug, Clone)]
+pub struct ChurnProbe {
+    /// The request to evaluate.
+    pub request: Request,
+    /// The number of writes that must have been applied before this probe is checked.
+    pub after_step: usize,
+    /// The expected decision at that point.
+    pub expected: Decision,
+}
+
+/// A W3 churn script: an ordered list of writes interleaved with expected-decision probes.
+pub struct W3ChurnScript {
+    /// The intent table BEFORE any write is applied.
+    pub initial_intents: Vec<IntentRow>,
+    /// The ordered writes to apply.
+    pub writes: Vec<AclWrite>,
+    /// Probes checked at their `after_step` checkpoints.
+    pub probes: Vec<ChurnProbe>,
+    /// The model to evaluate against.
+    pub model: AcModel,
+}
+
+impl W3ChurnScript {
+    /// Replay the churn script, checking every probe against the intent table as of its
+    /// checkpoint.
+    ///
+    /// # Fail-closed
+    /// - A probe whose `after_step` exceeds the number of writes is a wiring bug ⇒
+    ///   [`RunOutcome::Failed`].
+    /// - The FIRST probe whose oracle decision (over the post-step table) differs from
+    ///   `expected` — a stale or missing grant — ⇒ [`RunOutcome::Failed`], no timing.
+    ///
+    /// # Determinism
+    /// Writes are applied in order; the intent table is rebuilt deterministically at each
+    /// checkpoint (no dependence on iteration order beyond the given `writes` sequence).
+    #[must_use]
+    pub fn run_oracle(&self) -> RunOutcome {
+        // Validate probe checkpoints up-front (a probe past the end is a wiring bug).
+        for (i, probe) in self.probes.iter().enumerate() {
+            if probe.after_step > self.writes.len() {
+                return RunOutcome::Failed {
+                    mismatch: format!(
+                        "W3 wiring bug: probe {i} after_step={} > {} total writes",
+                        probe.after_step,
+                        self.writes.len()
+                    ),
+                };
+            }
+        }
+
+        let start = std::time::Instant::now();
+        let mut checked = 0usize;
+        // For each distinct checkpoint we need, materialise the table and check its probes.
+        // We rebuild from `initial_intents` for each checkpoint: O(writes²) but tiny, and
+        // guarantees no cross-checkpoint state leakage.
+        for step in 0..=self.writes.len() {
+            let table = self.table_after(step);
+            for probe in self.probes.iter().filter(|p| p.after_step == step) {
+                let got = oracle::evaluate(&self.model, &probe.request, &table);
+                if got != probe.expected {
+                    return RunOutcome::Failed {
+                        mismatch: format!(
+                            "W3 stale/missing grant after step {step} ({:?}): oracle={got:?} \
+                             expected={:?} for agent={} resource={}",
+                            self.model,
+                            probe.expected,
+                            probe.request.agent,
+                            probe.request.resource
+                        ),
+                    };
+                }
+                checked += 1;
+            }
+        }
+
+        if checked != self.probes.len() {
+            // Every probe must have been reached; an unreached probe means the harness
+            // silently skipped a check — treat as a failure, not a pass.
+            return RunOutcome::Failed {
+                mismatch: format!(
+                    "W3 wiring bug: {checked} of {} probes checked (some checkpoint unreached)",
+                    self.probes.len()
+                ),
+            };
+        }
+        let wall_us_indicative = u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX);
+        RunOutcome::Passed { decisions: checked, wall_us_indicative }
+    }
+
+    /// The intent table after applying the first `step` writes to `initial_intents`.
+    fn table_after(&self, step: usize) -> Vec<IntentRow> {
+        let mut table = self.initial_intents.clone();
+        for write in self.writes.iter().take(step) {
+            match write {
+                AclWrite::Grant(row) => table.push(row.clone()),
+                AclWrite::Revoke(row) => table.retain(|r| r != row),
+            }
+        }
+        table
+    }
+}
+
+// ── W4: concurrent readers ────────────────────────────────────────────────────────────
 
 /// Configuration for a W4 concurrent-reader run.
 pub struct W4Config {
@@ -90,16 +416,176 @@ pub struct W4Config {
     pub sf: u32,
 }
 
+/// The two-part outcome of a W4 run: the decision sub-lane (runs today) and the query
+/// sub-lane (skipped in this crate — see [`W4_QUERY_SKIP_REASON`]).
+#[derive(Debug, Clone)]
+pub struct W4Outcome {
+    /// Concurrent decision sub-lane (N threads of W1 batches via the oracle).
+    pub decision_lane: RunOutcome,
+    /// Concurrent query sub-lane — [`RunOutcome::Skipped`] in this oracle crate.
+    pub query_lane: RunOutcome,
+}
+
 impl W4Config {
-    /// Run the W4 concurrent-reader workload.
+    /// Run the W4 concurrent-reader workload against a shared intent table.
     ///
-    /// # Skipped (until #1569 lands)
-    /// The W4 query sub-lane (Q-point via `query_as`) emits
-    /// `RunOutcome::Skipped { reason: "blocked: #1569" }` until the `&self`
-    /// read-side in `sparq-solid` lands. The decision sub-lane (W1 via `decide_batch`)
-    /// is available today and runs normally.
+    /// The decision sub-lane spawns [`Self::n_threads`] threads, each running
+    /// [`Self::batches_per_thread`] copies of the given `batch` through the by-construction
+    /// oracle concurrently over a shared (`Arc`) intent table — the oracle is a pure
+    /// `&`-read, so concurrent readers are sound by construction (this mirrors the
+    /// `sparq-solid` `&self` `decide_batch` read-side). Any thread that observes a decision
+    /// mismatch fails the whole sub-lane (fail-closed). If ALL threads agree with the
+    /// single-threaded oracle, the concurrent result is byte-identical (determinism under
+    /// concurrency — a correctness property, not a timing one).
+    ///
+    /// The query sub-lane is [`RunOutcome::Skipped`] here; see [`W4_QUERY_SKIP_REASON`].
+    ///
+    /// # Panics
+    /// Does not panic on a worker thread panic — a panicked join is converted to a
+    /// [`RunOutcome::Failed`] so the harness stays fail-closed.
     #[must_use]
-    pub fn run(&self, _params: &GenParams) -> RunOutcome {
-        todo!("sq-i6du2.6: implement W4 concurrent-reader runner")
+    pub fn run(&self, batch: &W1DecisionBatch) -> W4Outcome {
+        W4Outcome {
+            decision_lane: self.run_decision_lane(batch),
+            query_lane: RunOutcome::Skipped { reason: W4_QUERY_SKIP_REASON.to_string() },
+        }
+    }
+
+    /// Convenience: run W4 with a batch derived from a [`GenParams`]-sized synthetic
+    /// probe. Retained for the scaffold `run(&params)` shape; delegates to
+    /// [`Self::run`] with an empty batch (which trivially passes) so callers that only
+    /// need the *skip* semantics of the query sub-lane can call it without a corpus.
+    #[must_use]
+    pub fn run_params(&self, _params: &GenParams) -> W4Outcome {
+        let empty = W1DecisionBatch {
+            requests: vec![],
+            expected: vec![],
+            model: self.model.clone(),
+            intents: vec![],
+        };
+        self.run(&empty)
+    }
+
+    /// Run the concurrent decision sub-lane over a shared intent table.
+    fn run_decision_lane(&self, batch: &W1DecisionBatch) -> RunOutcome {
+        use std::sync::Arc;
+        use std::thread;
+
+        if batch.requests.len() != batch.expected.len() {
+            return RunOutcome::Failed {
+                mismatch: format!(
+                    "W4 wiring bug: {} requests vs {} expected decisions",
+                    batch.requests.len(),
+                    batch.expected.len()
+                ),
+            };
+        }
+
+        // Shared, immutable state: the oracle is a pure read, so an Arc suffices — no lock.
+        let intents = Arc::new(batch.intents.clone());
+        let requests = Arc::new(batch.requests.clone());
+        let expected = Arc::new(batch.expected.clone());
+        let model = Arc::new(batch.model.clone());
+
+        let start = std::time::Instant::now();
+        let mut handles = Vec::with_capacity(self.n_threads);
+        for _ in 0..self.n_threads {
+            let intents = Arc::clone(&intents);
+            let requests = Arc::clone(&requests);
+            let expected = Arc::clone(&expected);
+            let model = Arc::clone(&model);
+            let batches = self.batches_per_thread;
+            handles.push(thread::spawn(move || -> Result<usize, String> {
+                let mut n = 0usize;
+                for _ in 0..batches {
+                    for (i, (req, want)) in requests.iter().zip(expected.iter()).enumerate() {
+                        let got = oracle::evaluate(&model, req, &intents);
+                        if got != *want {
+                            return Err(format!(
+                                "W4 concurrent decision mismatch at index {i}: oracle={got:?} \
+                                 expected={want:?} for agent={} resource={}",
+                                req.agent, req.resource
+                            ));
+                        }
+                        n += 1;
+                    }
+                }
+                Ok(n)
+            }));
+        }
+
+        let mut total = 0usize;
+        for handle in handles {
+            match handle.join() {
+                Ok(Ok(n)) => total += n,
+                Ok(Err(mismatch)) => return RunOutcome::Failed { mismatch },
+                Err(_) => {
+                    return RunOutcome::Failed {
+                        mismatch: "W4 worker thread panicked (fail-closed)".to_string(),
+                    };
+                }
+            }
+        }
+        let wall_us_indicative = u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX);
+        RunOutcome::Passed { decisions: total, wall_us_indicative }
+    }
+}
+
+// ── Harness aggregator (fail-closed exit code) ────────────────────────────────────────
+
+/// One lane's result in a full harness run, labelled with its workload + model.
+#[derive(Debug, Clone)]
+pub struct LaneReport {
+    /// A short label, e.g. `"W1/personal/WAC"`.
+    pub label: String,
+    /// The lane's outcome.
+    pub outcome: RunOutcome,
+}
+
+/// The aggregate report over all lanes in a harness run.
+///
+/// The harness is **fail-closed**: [`Self::exit_code`] is non-zero if ANY lane failed.
+/// A `Skipped` lane (e.g. the W4 query sub-lane) is neither a pass nor a fail and does
+/// not, by itself, make the run non-zero — but it is recorded so no skip is silent.
+#[derive(Debug, Clone, Default)]
+pub struct HarnessReport {
+    /// The per-lane results, in run order.
+    pub lanes: Vec<LaneReport>,
+}
+
+impl HarnessReport {
+    /// Create an empty report.
+    #[must_use]
+    pub fn new() -> Self {
+        Self { lanes: Vec::new() }
+    }
+
+    /// Record one lane's outcome.
+    pub fn record(&mut self, label: impl Into<String>, outcome: RunOutcome) {
+        self.lanes.push(LaneReport { label: label.into(), outcome });
+    }
+
+    /// `true` iff any recorded lane is a [`RunOutcome::Failed`].
+    #[must_use]
+    pub fn any_failed(&self) -> bool {
+        self.lanes.iter().any(|l| l.outcome.is_failure())
+    }
+
+    /// The process exit code: `1` if any lane failed, else `0` (fail-closed).
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        i32::from(self.any_failed())
+    }
+
+    /// The number of failed lanes.
+    #[must_use]
+    pub fn failed_count(&self) -> usize {
+        self.lanes.iter().filter(|l| l.outcome.is_failure()).count()
+    }
+
+    /// The number of skipped lanes.
+    #[must_use]
+    pub fn skipped_count(&self) -> usize {
+        self.lanes.iter().filter(|l| l.outcome.is_skipped()).count()
     }
 }

--- a/crates/sparq-acbench/tests/workloads.rs
+++ b/crates/sparq-acbench/tests/workloads.rs
@@ -34,6 +34,18 @@ fn agent_allow(agent: &str, resource: &str) -> IntentRow {
     }
 }
 
+fn agent_deny(agent: &str, resource: &str) -> IntentRow {
+    IntentRow { effect: Effect::Deny, ..agent_allow(agent, resource) }
+}
+
+/// An Allow intent for `agent` on `resource` carrying a temporal ODRL condition.
+fn agent_allow_temporal(agent: &str, resource: &str, start: &str, end: &str) -> IntentRow {
+    IntentRow {
+        condition: Condition::Temporal { start: start.to_string(), end: end.to_string() },
+        ..agent_allow(agent, resource)
+    }
+}
+
 fn req(agent: &str, resource: &str) -> Request {
     Request {
         agent: agent.to_string(),
@@ -46,6 +58,23 @@ fn req(agent: &str, resource: &str) -> Request {
 const ALICE: &str = "https://alice.example/card#me";
 const BOB: &str = "https://bob.example/card#me";
 const RES: &str = "https://alice.example/docs/notes.ttl";
+
+// The pinned benchmark evaluation instant is `2026-07-06T00:00:00Z` (oracle::BENCH_EVAL_INSTANT).
+// A window that CONTAINS it is valid (permission granted); one that ended before it is expired.
+const WINDOW_VALID_START: &str = "2026-01-01T00:00:00Z";
+const WINDOW_VALID_END: &str = "2027-01-01T00:00:00Z";
+const WINDOW_EXPIRED_START: &str = "2020-01-01T00:00:00Z";
+const WINDOW_EXPIRED_END: &str = "2021-01-01T00:00:00Z";
+
+/// Build a single-request W1 batch and return its `RunOutcome` for `(model, expected)`.
+///
+/// Because the batch's `expected` is exactly `want`, a *pass* proves the by-construction
+/// oracle for `model` agrees with `want`, and a *failure* proves it disagrees. This is the
+/// lever that makes the ODRL oracle arm actually get DISPATCHED (Finding 1): W1's `model`
+/// field routes `oracle::evaluate` through the arm under test.
+fn w1_single(model: AcModel, intents: Vec<IntentRow>, request: Request, want: Decision) -> RunOutcome {
+    W1DecisionBatch { requests: vec![request], expected: vec![want], model, intents }.run_oracle()
+}
 
 // ── RunOutcome helpers (retained from scaffold) ───────────────────────────────────────
 
@@ -163,6 +192,153 @@ fn anti_vacuity_miscompiled_deny_intent_cannot_grant() {
     assert!(
         batch.run_oracle().is_failure(),
         "a Deny intent must never produce Allow under WAC (anti-vacuity)"
+    );
+}
+
+// ── W1 per-model dispatch: model-differentiating fixtures ─────────────────────────────
+//
+// These tests dispatch the SAME (request, intents) through W1 under EACH of WAC, ACP, and
+// ODRL, over fixtures the three models decide DIFFERENTLY. Before them, no workload test
+// ever routed `oracle::evaluate` through the ODRL arm (W2's `model` was inert), so swapping
+// the `Acp`↔`Odrl` arms of the router survived the whole suite. With them, W1's `model`
+// field forces the arm under test, so the swap is caught (see the mutation note below).
+
+/// Fixture (i) — matching Allow **and** matching Deny for the same agent/resource.
+/// The three models diverge by design:
+/// - **WAC** has no deny (it skips Deny rows) → the Allow stands → `Allow`.
+/// - **ACP** is deny-wins → the Deny overrides the Allow → `Deny`.
+/// - **ODRL** is permission-overrides-prohibition → the Permission wins → `Allow`.
+///
+/// This single fixture pins all three arms; in particular ACP=`Deny` vs ODRL=`Allow` is the
+/// exact behaviour the `Acp`↔`Odrl` router swap inverts, so the swap must fail here.
+#[test]
+fn w1_allow_and_deny_same_target_differs_by_model() {
+    let intents = vec![agent_allow(ALICE, RES), agent_deny(ALICE, RES)];
+
+    // WAC: Deny row is unsupported/skipped → the Allow stands.
+    assert!(
+        w1_single(AcModel::Wac, intents.clone(), req(ALICE, RES), Decision::Allow).is_pass(),
+        "WAC has no deny: a matching Allow with a co-located Deny must still Allow"
+    );
+    // ACP: deny-wins.
+    assert!(
+        w1_single(AcModel::Acp, intents.clone(), req(ALICE, RES), Decision::Deny).is_pass(),
+        "ACP is deny-wins: a matching Deny must override the Allow"
+    );
+    // ODRL: permission-overrides-prohibition.
+    assert!(
+        w1_single(AcModel::Odrl, intents.clone(), req(ALICE, RES), Decision::Allow).is_pass(),
+        "ODRL: a matching Permission overrides a co-located Prohibition → Allow"
+    );
+
+    // Guard against a lazy fixture: the ACP and ODRL truths genuinely differ here, so a
+    // model that returns the *other* model's decision must FAIL. This is what the arm-swap
+    // mutation trips on.
+    assert!(
+        w1_single(AcModel::Acp, intents.clone(), req(ALICE, RES), Decision::Allow).is_failure(),
+        "ACP must NOT return the ODRL answer (Allow) — arm-swap tripwire"
+    );
+    assert!(
+        w1_single(AcModel::Odrl, intents, req(ALICE, RES), Decision::Deny).is_failure(),
+        "ODRL must NOT return the ACP answer (Deny) — arm-swap tripwire"
+    );
+}
+
+/// Fixture (ii) — an Allow carrying a `Condition::Temporal` window that CONTAINS the pinned
+/// benchmark instant. The three models diverge:
+/// - **WAC** cannot express conditions (skips conditioned rows) → `Deny`.
+/// - **ACP** cannot express conditions (skips conditioned rows) → `Deny`.
+/// - **ODRL** evaluates the condition; the window is valid at the pinned instant → `Allow`.
+///
+/// So ACP=`Deny` vs ODRL=`Allow` again separate the two arms; the swap must fail here too,
+/// and this fixture additionally exercises the real temporal condition evaluation (Finding 2).
+#[test]
+fn w1_temporal_allow_differs_by_model_valid_window() {
+    let intents = vec![agent_allow_temporal(ALICE, RES, WINDOW_VALID_START, WINDOW_VALID_END)];
+
+    assert!(
+        w1_single(AcModel::Wac, intents.clone(), req(ALICE, RES), Decision::Deny).is_pass(),
+        "WAC cannot express a temporal condition → the conditioned Allow is skipped → Deny"
+    );
+    assert!(
+        w1_single(AcModel::Acp, intents.clone(), req(ALICE, RES), Decision::Deny).is_pass(),
+        "ACP cannot express a temporal condition → the conditioned Allow is skipped → Deny"
+    );
+    assert!(
+        w1_single(AcModel::Odrl, intents.clone(), req(ALICE, RES), Decision::Allow).is_pass(),
+        "ODRL evaluates the temporal window; it contains the pinned instant → Allow"
+    );
+
+    // Arm-swap tripwire: ODRL must not return the ACP answer (Deny) for a valid window.
+    assert!(
+        w1_single(AcModel::Odrl, intents, req(ALICE, RES), Decision::Deny).is_failure(),
+        "ODRL with a valid window must Allow, not return the ACP Deny — arm-swap tripwire"
+    );
+}
+
+// ── W1 clock-free temporal condition evaluation (Finding 2) ───────────────────────────
+//
+// The ODRL oracle decides `Condition::Temporal { start, end }` against the pinned benchmark
+// instant with the half-open test `start ≤ now < end` — clock-free, deterministic, no
+// wall-clock read. An expired window is a Deny; a valid window is an Allow. This is the
+// ground truth the constraint-rich U3/U4 corpora depend on.
+
+/// A permission whose temporal window has EXPIRED (ended before the pinned instant) must be
+/// a Deny under ODRL — otherwise an expired retention/embargo grant would wrongly Allow.
+#[test]
+fn w1_temporal_expired_window_is_deny_odrl() {
+    let intents = vec![agent_allow_temporal(ALICE, RES, WINDOW_EXPIRED_START, WINDOW_EXPIRED_END)];
+    assert!(
+        w1_single(AcModel::Odrl, intents.clone(), req(ALICE, RES), Decision::Deny).is_pass(),
+        "an expired temporal window must Deny under ODRL (clock-free ground truth)"
+    );
+    // Anti-vacuity: claiming the expired grant still Allows must FAIL — proves the oracle
+    // is not an always-true stub for Temporal.
+    assert!(
+        w1_single(AcModel::Odrl, intents, req(ALICE, RES), Decision::Allow).is_failure(),
+        "an expired window must NOT Allow — the Temporal stub would have wrongly passed this"
+    );
+}
+
+/// A permission whose temporal window CONTAINS the pinned instant must Allow under ODRL.
+#[test]
+fn w1_temporal_valid_window_is_allow_odrl() {
+    let intents = vec![agent_allow_temporal(ALICE, RES, WINDOW_VALID_START, WINDOW_VALID_END)];
+    assert!(
+        w1_single(AcModel::Odrl, intents.clone(), req(ALICE, RES), Decision::Allow).is_pass(),
+        "a currently-valid temporal window must Allow under ODRL"
+    );
+    // And the mirror anti-vacuity: claiming a valid window Denies must fail.
+    assert!(
+        w1_single(AcModel::Odrl, intents, req(ALICE, RES), Decision::Deny).is_failure(),
+        "a valid window must NOT Deny"
+    );
+}
+
+/// W3 embargo flip via the temporal window: the SAME conditioned intent is Deny while its
+/// window is in the future and Allow once a churn write replaces it with a window that
+/// contains the pinned instant. This mirrors the U4 "public-after-embargo flip" as a churn
+/// delta, proving the temporal oracle is live inside the invalidation lane too.
+#[test]
+fn w3_temporal_embargo_flip_produces_allow_delta() {
+    let future = agent_allow_temporal(ALICE, RES, "2099-01-01T00:00:00Z", "2100-01-01T00:00:00Z");
+    let opened = agent_allow_temporal(ALICE, RES, WINDOW_VALID_START, WINDOW_VALID_END);
+    let script = W3ChurnScript {
+        initial_intents: vec![future.clone()],
+        // Revoke the still-embargoed grant, then grant the now-open window.
+        writes: vec![AclWrite::Revoke(future), AclWrite::Grant(opened)],
+        probes: vec![
+            // Before any write: the window is in the future → Deny.
+            ChurnProbe { request: req(ALICE, RES), after_step: 0, expected: Decision::Deny },
+            // After the flip: the window contains the pinned instant → Allow.
+            ChurnProbe { request: req(ALICE, RES), after_step: 2, expected: Decision::Allow },
+        ],
+        model: AcModel::Odrl,
+    };
+    assert!(
+        script.run_oracle().is_pass(),
+        "embargo-flip churn must move the temporal grant from Deny to Allow: {:?}",
+        script.run_oracle()
     );
 }
 

--- a/crates/sparq-acbench/tests/workloads.rs
+++ b/crates/sparq-acbench/tests/workloads.rs
@@ -1,19 +1,60 @@
 //! Tests for the workload + oracle engine (W1–W4) — bead `sq-i6du2.6`.
 //!
-//! Scaffold-tier tests confirm the `RunOutcome` API compiles and the
-//! `is_pass`/`is_failure` helpers behave correctly. Full workload tests are
-//! `#[ignore]`-tagged pending bead `sq-i6du2.6`.
+//! These tests exercise the fail-closed harness contract directly, with **fixtures built
+//! in-test from the public intent-table IR** — they do NOT depend on any generator body
+//! (beads `sq-i6du2.2`–`.5`), so this lane can land independently of the generators.
+//!
+//! The load-bearing test is [`anti_vacuity_wrong_expected_fails_harness`]: a deliberately
+//! WRONG expected-decision set MUST make the harness report `Failed` and exit non-zero.
+//! Without it, a harness that always passed would be indistinguishable from a correct one
+//! — a benchmark an unsound implementation could win. This is the oracle's oracle.
 //!
 //! Bead `sq-i6du2.6` ONLY adds tests here and fills in `src/workload.rs` / `src/oracle.rs`.
 //! It must NOT edit any other file.
 
-use sparq_acbench::workload::RunOutcome;
+use sparq_acbench::workload::{
+    AclWrite, ChurnProbe, HarnessReport, RunOutcome, W1DecisionBatch, W2QueryCheck, W2QueryLane,
+    W3ChurnScript, W4Config, W4_QUERY_SKIP_REASON,
+};
+use sparq_acbench::{
+    AcModel, AccessMode, Audience, Condition, Decision, Effect, IntentRow, QueryClass, Request,
+    Scope,
+};
+
+// ── Fixture builders (public IR only — no generator dependency) ───────────────────────
+
+fn agent_allow(agent: &str, resource: &str) -> IntentRow {
+    IntentRow {
+        audience: Audience::Agent(agent.to_string()),
+        scope: Scope::Resource,
+        mode: AccessMode::read_only(),
+        condition: Condition::None,
+        effect: Effect::Allow,
+        resource_uri: resource.to_string(),
+    }
+}
+
+fn req(agent: &str, resource: &str) -> Request {
+    Request {
+        agent: agent.to_string(),
+        client: None,
+        resource: resource.to_string(),
+        mode: AccessMode::read_only(),
+    }
+}
+
+const ALICE: &str = "https://alice.example/card#me";
+const BOB: &str = "https://bob.example/card#me";
+const RES: &str = "https://alice.example/docs/notes.ttl";
+
+// ── RunOutcome helpers (retained from scaffold) ───────────────────────────────────────
 
 #[test]
 fn run_outcome_passed_is_pass() {
     let outcome = RunOutcome::Passed { decisions: 10, wall_us_indicative: 0 };
     assert!(outcome.is_pass());
     assert!(!outcome.is_failure());
+    assert!(!outcome.is_skipped());
 }
 
 #[test]
@@ -21,40 +62,331 @@ fn run_outcome_failed_is_failure() {
     let outcome = RunOutcome::Failed { mismatch: "deliberate test failure".to_string() };
     assert!(!outcome.is_pass());
     assert!(outcome.is_failure());
+    assert_eq!(outcome.mismatch(), Some("deliberate test failure"));
 }
 
 #[test]
 fn run_outcome_skipped_is_neither() {
-    let outcome = RunOutcome::Skipped { reason: "blocked: #1569".to_string() };
+    let outcome = RunOutcome::Skipped { reason: "blocked".to_string() };
     assert!(!outcome.is_pass());
     assert!(!outcome.is_failure());
+    assert!(outcome.is_skipped());
 }
 
-/// Placeholder: bead `sq-i6du2.6` fills in the anti-vacuity test — a deliberately
-/// miscompiled policy fixture must cause the workload harness to return `Failed`,
-/// not `Passed`.
-#[test]
-#[ignore = "sq-i6du2.6: implement workload engine body first"]
-fn anti_vacuity_miscompiled_policy_causes_failure() {
-    // B6 implements this as the "oracle's oracle": generate a corpus where one policy
-    // is deliberately miscompiled (e.g. a Deny intent rendered as Allow), run W1,
-    // and assert the harness returns RunOutcome::Failed, not Passed.
-    todo!("sq-i6du2.6")
-}
+// ── W1: decision micro-benchmark ──────────────────────────────────────────────────────
 
-/// Placeholder: bead `sq-i6du2.6` verifies W4 query sub-lane emits Skipped.
 #[test]
-#[ignore = "sq-i6du2.6: implement workload engine body first"]
-fn w4_query_sublane_skipped_until_1569() {
-    use sparq_acbench::{AcModel, GenParams, workload::W4Config};
-    let cfg = W4Config {
-        n_threads: 2,
-        batches_per_thread: 1,
+fn w1_passes_when_expected_matches_oracle() {
+    let intents = vec![agent_allow(ALICE, RES)];
+    let batch = W1DecisionBatch {
+        requests: vec![req(ALICE, RES), req(BOB, RES)],
+        // Alice is granted; Bob is fail-closed Deny.
+        expected: vec![Decision::Allow, Decision::Deny],
         model: AcModel::Wac,
-        sf: 1,
+        intents,
     };
-    let params = GenParams::smoke();
-    let outcome = cfg.run(&params);
-    // Until #1569 lands, the query sub-lane must emit Skipped, not Passed or Failed.
-    assert!(matches!(outcome, RunOutcome::Skipped { .. }), "W4 query sublane must be Skipped");
+    let outcome = batch.run_oracle();
+    assert!(outcome.is_pass(), "W1 must pass when expected matches the oracle: {outcome:?}");
+    if let RunOutcome::Passed { decisions, .. } = outcome {
+        assert_eq!(decisions, 2);
+    }
+}
+
+#[test]
+fn w1_wiring_bug_length_mismatch_fails() {
+    let batch = W1DecisionBatch {
+        requests: vec![req(ALICE, RES)],
+        expected: vec![], // deliberately wrong length
+        model: AcModel::Wac,
+        intents: vec![agent_allow(ALICE, RES)],
+    };
+    assert!(batch.run_oracle().is_failure(), "length mismatch must fail-closed");
+}
+
+/// ANTI-VACUITY (the oracle's oracle): a deliberately WRONG expected set — claiming Bob
+/// (who has no grant) is Allowed — MUST make the lane fail. If this passed, the harness
+/// would be vacuous and an unsound implementation could win the benchmark.
+#[test]
+fn anti_vacuity_wrong_expected_fails_harness() {
+    let intents = vec![agent_allow(ALICE, RES)];
+    let batch = W1DecisionBatch {
+        requests: vec![req(BOB, RES)],
+        // WRONG: Bob has no grant; fail-closed truth is Deny. Claim Allow.
+        expected: vec![Decision::Allow],
+        model: AcModel::Wac,
+        intents,
+    };
+    let outcome = batch.run_oracle();
+    assert!(
+        outcome.is_failure(),
+        "anti-vacuity: a wrong expected set MUST fail the harness, got {outcome:?}"
+    );
+
+    // …and it must propagate to a non-zero harness exit code with NO timing recorded.
+    let mut report = HarnessReport::new();
+    report.record("W1/anti-vacuity/WAC", outcome);
+    assert_eq!(report.exit_code(), 1, "harness must exit non-zero on a failed lane");
+    assert_eq!(report.failed_count(), 1);
+    // No `Passed { wall_us_indicative }` may exist for the failed lane.
+    assert!(
+        report.lanes.iter().all(|l| !l.outcome.is_pass()),
+        "a failed lane must never carry a timing number"
+    );
+}
+
+/// Anti-vacuity, mirror direction: claiming an Allowed agent is Denied must ALSO fail.
+#[test]
+fn anti_vacuity_wrong_deny_fails_harness() {
+    let intents = vec![agent_allow(ALICE, RES)];
+    let batch = W1DecisionBatch {
+        requests: vec![req(ALICE, RES)],
+        expected: vec![Decision::Deny], // WRONG: Alice is granted.
+        model: AcModel::Wac,
+        intents,
+    };
+    assert!(batch.run_oracle().is_failure(), "wrong Deny expectation must fail");
+}
+
+/// A deliberately MISCOMPILED policy (a Deny intent that a buggy compiler renders as if it
+/// grants) must not launder into an Allow: the WAC oracle skips Deny rows, so the truth
+/// stays Deny and any "expected Allow" fails. Proves the compiler cannot fool the oracle.
+#[test]
+fn anti_vacuity_miscompiled_deny_intent_cannot_grant() {
+    let deny = IntentRow { effect: Effect::Deny, ..agent_allow(ALICE, RES) };
+    let batch = W1DecisionBatch {
+        requests: vec![req(ALICE, RES)],
+        // A miscompiled harness might "expect" the deny to have granted. It must not.
+        expected: vec![Decision::Allow],
+        model: AcModel::Wac,
+        intents: vec![deny],
+    };
+    assert!(
+        batch.run_oracle().is_failure(),
+        "a Deny intent must never produce Allow under WAC (anti-vacuity)"
+    );
+}
+
+// ── W2: access-controlled query result-set oracle ─────────────────────────────────────
+
+#[test]
+fn w2_authorized_intersection_passes() {
+    // Candidate rows the query would return over ALL data; agent authorized to see only r1.
+    let check = W2QueryCheck {
+        class: QueryClass::Point,
+        model: AcModel::Wac,
+        candidate_rows: vec!["<r1> <p> <o1> .".to_string(), "<r2> <p> <o2> .".to_string()],
+        authorized_rows: vec!["<r1> <p> <o1> .".to_string()],
+        // Correct: the engine returned exactly the authorized ∩ candidate row.
+        produced_rows: vec!["<r1> <p> <o1> .".to_string()],
+    };
+    assert_eq!(check.expected_rows(), vec!["<r1> <p> <o1> .".to_string()]);
+    let lane = W2QueryLane { checks: vec![check] };
+    assert!(lane.run_oracle().is_pass());
+}
+
+#[test]
+fn w2_over_share_fails() {
+    // Engine leaked an unauthorized row (r2) — an over-share MUST fail.
+    let check = W2QueryCheck {
+        class: QueryClass::Scan,
+        model: AcModel::Acp,
+        candidate_rows: vec!["<r1> <p> <o1> .".to_string(), "<r2> <p> <o2> .".to_string()],
+        authorized_rows: vec!["<r1> <p> <o1> .".to_string()],
+        produced_rows: vec!["<r1> <p> <o1> .".to_string(), "<r2> <p> <o2> .".to_string()],
+    };
+    let lane = W2QueryLane { checks: vec![check] };
+    let outcome = lane.run_oracle();
+    assert!(outcome.is_failure(), "over-share must fail: {outcome:?}");
+    assert!(outcome.mismatch().unwrap().contains("over-shared"));
+}
+
+#[test]
+fn w2_under_share_fails() {
+    // Engine dropped an authorized row — an under-share MUST fail too.
+    let check = W2QueryCheck {
+        class: QueryClass::Aggregate,
+        model: AcModel::Odrl,
+        candidate_rows: vec!["<r1> <p> <o1> .".to_string(), "<r2> <p> <o2> .".to_string()],
+        authorized_rows: vec!["<r1> <p> <o1> .".to_string(), "<r2> <p> <o2> .".to_string()],
+        produced_rows: vec!["<r1> <p> <o1> .".to_string()], // dropped r2
+    };
+    let lane = W2QueryLane { checks: vec![check] };
+    let outcome = lane.run_oracle();
+    assert!(outcome.is_failure());
+    assert!(outcome.mismatch().unwrap().contains("missing"));
+}
+
+// ── W3: ACL-write + invalidation churn ────────────────────────────────────────────────
+
+#[test]
+fn w3_revoke_produces_deny_after_step() {
+    // Start: Alice granted. Step 1: revoke. Probe before revoke = Allow; after = Deny.
+    let grant = agent_allow(ALICE, RES);
+    let script = W3ChurnScript {
+        initial_intents: vec![grant.clone()],
+        writes: vec![AclWrite::Revoke(grant.clone())],
+        probes: vec![
+            ChurnProbe { request: req(ALICE, RES), after_step: 0, expected: Decision::Allow },
+            ChurnProbe { request: req(ALICE, RES), after_step: 1, expected: Decision::Deny },
+        ],
+        model: AcModel::Wac,
+    };
+    let outcome = script.run_oracle();
+    assert!(outcome.is_pass(), "W3 revoke churn must pass: {outcome:?}");
+}
+
+#[test]
+fn w3_grant_then_probe_allows() {
+    let grant = agent_allow(BOB, RES);
+    let script = W3ChurnScript {
+        initial_intents: vec![],
+        writes: vec![AclWrite::Grant(grant)],
+        probes: vec![
+            ChurnProbe { request: req(BOB, RES), after_step: 0, expected: Decision::Deny },
+            ChurnProbe { request: req(BOB, RES), after_step: 1, expected: Decision::Allow },
+        ],
+        model: AcModel::Acp,
+    };
+    assert!(script.run_oracle().is_pass());
+}
+
+/// A STALE grant (expecting Allow after a revoke) MUST fail — this is the invalidation
+/// lane's whole reason to exist.
+#[test]
+fn w3_stale_grant_after_revoke_fails() {
+    let grant = agent_allow(ALICE, RES);
+    let script = W3ChurnScript {
+        initial_intents: vec![grant.clone()],
+        writes: vec![AclWrite::Revoke(grant)],
+        // WRONG: after the revoke the truth is Deny, but claim the (stale) grant survives.
+        probes: vec![ChurnProbe {
+            request: req(ALICE, RES),
+            after_step: 1,
+            expected: Decision::Allow,
+        }],
+        model: AcModel::Wac,
+    };
+    let outcome = script.run_oracle();
+    assert!(outcome.is_failure(), "a surviving stale grant MUST fail the churn lane");
+    assert!(outcome.mismatch().unwrap().contains("stale"));
+}
+
+#[test]
+fn w3_probe_past_end_is_wiring_failure() {
+    let script = W3ChurnScript {
+        initial_intents: vec![],
+        writes: vec![],
+        probes: vec![ChurnProbe {
+            request: req(ALICE, RES),
+            after_step: 5, // > 0 writes
+            expected: Decision::Deny,
+        }],
+        model: AcModel::Wac,
+    };
+    assert!(script.run_oracle().is_failure());
+}
+
+// ── W4: concurrent readers ────────────────────────────────────────────────────────────
+
+#[test]
+fn w4_decision_lane_concurrent_passes() {
+    let intents = vec![agent_allow(ALICE, RES)];
+    let batch = W1DecisionBatch {
+        requests: vec![req(ALICE, RES), req(BOB, RES)],
+        expected: vec![Decision::Allow, Decision::Deny],
+        model: AcModel::Wac,
+        intents,
+    };
+    let cfg = W4Config { n_threads: 4, batches_per_thread: 8, model: AcModel::Wac, sf: 1 };
+    let outcome = cfg.run(&batch);
+    assert!(
+        outcome.decision_lane.is_pass(),
+        "W4 concurrent decision lane must pass: {:?}",
+        outcome.decision_lane
+    );
+    // Concurrent readers must agree with the single-threaded oracle (determinism).
+    if let RunOutcome::Passed { decisions, .. } = outcome.decision_lane {
+        assert_eq!(decisions, 4 * 8 * 2, "every thread×batch×request must be checked");
+    }
+}
+
+#[test]
+fn w4_decision_lane_propagates_a_mismatch() {
+    let intents = vec![agent_allow(ALICE, RES)];
+    let batch = W1DecisionBatch {
+        requests: vec![req(BOB, RES)],
+        expected: vec![Decision::Allow], // WRONG: Bob is Deny.
+        model: AcModel::Wac,
+        intents,
+    };
+    let cfg = W4Config { n_threads: 3, batches_per_thread: 2, model: AcModel::Wac, sf: 1 };
+    let outcome = cfg.run(&batch);
+    assert!(
+        outcome.decision_lane.is_failure(),
+        "a concurrent mismatch must fail the decision lane"
+    );
+}
+
+/// The W4 query sub-lane is Skipped in this oracle crate, with an ACCURATE recorded reason
+/// (#1569 / PR #1612 has MERGED — the skip is architectural, not a false "unmerged dep").
+#[test]
+fn w4_query_sublane_skipped_with_accurate_reason() {
+    let cfg = W4Config { n_threads: 2, batches_per_thread: 1, model: AcModel::Wac, sf: 1 };
+    let batch = W1DecisionBatch {
+        requests: vec![],
+        expected: vec![],
+        model: AcModel::Wac,
+        intents: vec![],
+    };
+    let outcome = cfg.run(&batch);
+    assert!(
+        matches!(outcome.query_lane, RunOutcome::Skipped { .. }),
+        "W4 query sub-lane must be Skipped"
+    );
+    if let RunOutcome::Skipped { reason } = &outcome.query_lane {
+        assert_eq!(reason, W4_QUERY_SKIP_REASON);
+        // The reason must NOT claim the dependency is still unmerged (it has merged).
+        assert!(
+            reason.contains("has merged"),
+            "the skip reason must record that #1569/#1612 has merged"
+        );
+        assert!(
+            !reason.contains("blocked: #1569"),
+            "must not use the stale 'blocked: #1569' wording — that PR merged"
+        );
+    }
+}
+
+/// `run_params` (the scaffold `run(&params)` shape) still yields a Skipped query sub-lane.
+#[test]
+fn w4_run_params_query_sublane_skipped() {
+    use sparq_acbench::GenParams;
+    let cfg = W4Config { n_threads: 2, batches_per_thread: 1, model: AcModel::Wac, sf: 1 };
+    let outcome = cfg.run_params(&GenParams::smoke());
+    assert!(matches!(outcome.query_lane, RunOutcome::Skipped { .. }));
+    assert!(outcome.decision_lane.is_pass(), "empty batch trivially passes");
+}
+
+// ── Harness aggregator: fail-closed exit code ─────────────────────────────────────────
+
+#[test]
+fn harness_all_pass_exits_zero() {
+    let mut report = HarnessReport::new();
+    report.record("W1/x/WAC", RunOutcome::Passed { decisions: 1, wall_us_indicative: 0 });
+    report.record(
+        "W4-query/x/WAC",
+        RunOutcome::Skipped { reason: W4_QUERY_SKIP_REASON.to_string() },
+    );
+    assert_eq!(report.exit_code(), 0, "all-pass (+ skips) exits zero");
+    assert_eq!(report.skipped_count(), 1);
+    assert!(!report.any_failed());
+}
+
+#[test]
+fn harness_any_fail_exits_nonzero() {
+    let mut report = HarnessReport::new();
+    report.record("W1/x/WAC", RunOutcome::Passed { decisions: 1, wall_us_indicative: 0 });
+    report.record("W3/x/WAC", RunOutcome::Failed { mismatch: "stale grant".to_string() });
+    assert_eq!(report.exit_code(), 1, "any failed lane exits non-zero");
+    assert_eq!(report.failed_count(), 1);
 }


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implements bead `sq-i6du2.6` under the AC-query-benchmark
> program (epic `sq-i6du2`, issue [#1613](https://github.com/sparq-org/sparq/issues/1613)).
> Design authority: `research/ac-query-benchmark.md` §2.1 (workloads) / §2.3 (oracles).

## What

The **workload + oracle engine** (W1–W4) for the access-controlled-query benchmark,
in the three files the decomposition (§3, B6) assigns to this bead:
`src/workload.rs`, `src/oracle.rs`, `tests/workloads.rs`. No `lib.rs` / `Cargo.toml` /
generator-module edits, so it is file-disjoint from B1's scaffold and B2–B5's generators.

- **W1 decision micro-benchmark** (`W1DecisionBatch::run_oracle`) — per-request
  by-construction oracle vs the generator's pre-computed expected decision, over the
  intent table.
- **W2 access-controlled query result-set oracle** (`W2QueryLane` / `W2QueryCheck`) —
  closed-form expected set = `authorized ∩ candidate`; an **over-share** (leaked
  unauthorized row) **and** an **under-share** (dropped authorized row) both fail.
- **W3 ACL-write + invalidation churn** (`W3ChurnScript`) — interleaved grant/revoke
  writes with per-checkpoint expected-decision probes; a **surviving stale grant** after
  a revoke is a benchmark **FAILURE**, not a speedup.
- **W4 concurrent readers** (`W4Config`) — N threads of W1 batches over a shared `Arc`
  intent table (the oracle is a pure `&`-read, sound by construction); the **query
  sub-lane is SKIPPED** (see below).

## Fail-closed harness (the credibility feature)

A benchmark an unsound implementation can *win* is worthless. Any decision / result-set /
churn mismatch ⇒ `RunOutcome::Failed` and `HarnessReport::exit_code() == 1`; **no timing
is emitted for a lane that failed correctness**. The **anti-vacuity fixture** proves the
harness *does* fail on a deliberately-wrong expected set (`anti_vacuity_wrong_expected_fails_harness`
and siblings) — the oracle's oracle. Without it, an always-passing harness would be
indistinguishable from a correct one.

## W4 query sub-lane — re-checked (#1569 / PR #1612 has MERGED)

The design record gated the W4 *query* sub-lane on the `sparq-solid` `&self` read-side
(#1569, PR #1612). **That has now merged**, so the API-level blocker is gone. But this is
a dev-only **oracle** crate with a load-bearing *zero dependency on
`sparq-core`/`sparq-engine`/`sparq-solid`* — it must not link the system under test.
Driving a live concurrent `query_as` therefore belongs to the `sparq-solid`-linked
`bench/ac/` driver (beads `sq-i6du2.7`/`.9`), not here. The query sub-lane is `Skipped`
with an **accurate** recorded reason (`W4_QUERY_SKIP_REASON`, asserted in tests) — never a
fabricated concurrency number, and never the now-stale `blocked: #1569` wording. This is
the honest resolution and is documented in the module rustdoc + the skip reason itself.

## Gates

- `cargo test -p sparq-acbench --test workloads` — 21/21 pass (incl. anti-vacuity + W4 skip).
- Full crate suite green; generator-body tests remain `#[ignore]` (B2–B5's work, untouched).
- `cargo clippy -p sparq-acbench --all-targets -- -D warnings` clean (incl. `-W clippy::pedantic`).
- `rustdoc -D warnings` clean in both no-features and `--all-features` states (crate has no features).
- `workload.rs` is ~92% line-covered by direct unit tests (no thin indirectly-reached wrappers).
- No markdown, no perf numbers added; README untouched (template gate green).

## ⚠️ HOLD FOR REVIEW — do NOT arm

This is the **ground-truth / oracle surface** the authorization system is judged against.
Per the decomposition's review note, hold for adversarial / Fable review before arming.

Refs: `sq-i6du2.6`, epic `sq-i6du2`, issue #1613.