### PR TITLE
fix(bench): run-all-benchmarks pre-builds bench_shacl + probes perm0.bin (sq-k0pml)

### DIFF
--- a/scripts/bench/run-all-benchmarks.sh
+++ b/scripts/bench/run-all-benchmarks.sh
@@ -205,11 +205,17 @@ suite_cmd() {
     watdiv) echo 'bench/watdiv/run.sh 1' ;;
     bsbm) echo 'bench/bsbm/run.sh' ;;
     lubm) echo 'bench/lubm/run.sh' ;;
-    shacl) echo 'bench/shacl/run.sh' ;;
+    # bench/shacl/run.sh reads target/release/examples/bench_shacl (sparq-shacl is NOT a
+    # sparq-cli dependency, so build-core does not produce it) — pre-build it like fts/rsp/
+    # hdt/geo/vector-ann do, else the suite ENOENT-fails on a missing artifact (sq-k0pml).
+    shacl) echo 'cargo build --release -p sparq-shacl --example bench_shacl && bench/shacl/run.sh' ;;
     vector-ann) echo 'cargo build --release -p sparq-vectors --example bench_vectors --features approx-ann && bench/vector/run.sh' ;;
     selective-bindjoin) echo 'python3 bench/selective/gen.py 500000 > "$SCRATCH/selective.nt" && "$CLI" bench "$SCRATCH/selective.nt" ntriples bench/selective/queries 3 count' ;;
     u64-valueids) echo 'python3 bench/u64-valueids/gen.py 1000000 "$SCRATCH/t3-literals.nt" && "$CLI" bench "$SCRATCH/t3-literals.nt" ntriples bench/u64-valueids/queries 3 materialize' ;;
-    ingest-index) echo '"$GEN" dump 100000 "$SCRATCH/data.nt" && "$CLI" ingest "$SCRATCH/data.nt" full && "$CLI" save "$SCRATCH/data.nt" ntriples "$SCRATCH/idx" && "$CLI" probe-compress "$SCRATCH/idx/spo.perm" && "$CLI" compare-compress "$SCRATCH/data.nt" ntriples && "$CLI" bench-mmap "$SCRATCH/idx" bench/qlever-synthetic/queries 3 count' ;;
+    # `save` writes each permutation as perm<i>.bin (i=0 is SPO — see sparq-core store.rs
+    # Perm::ALL / save_with); the old `idx/spo.perm` path never existed, so probe-compress
+    # ENOENT-failed the whole chain. Probe the SPO permutation at perm0.bin (sq-k0pml).
+    ingest-index) echo '"$GEN" dump 100000 "$SCRATCH/data.nt" && "$CLI" ingest "$SCRATCH/data.nt" full && "$CLI" save "$SCRATCH/data.nt" ntriples "$SCRATCH/idx" && "$CLI" probe-compress "$SCRATCH/idx/perm0.bin" && "$CLI" compare-compress "$SCRATCH/data.nt" ntriples && "$CLI" bench-mmap "$SCRATCH/idx" bench/qlever-synthetic/queries 3 count' ;;
     bench-remap) echo '"$CLI" bench-remap 5000000 12500000 3 && SPARQ_NO_PREFETCH=1 "$CLI" bench-remap 5000000 12500000 3' ;;
     parse-baseline) echo '(cd bench/parse && cargo build --release) && "$GEN" dump 200000 "$SCRATCH/parse.nt" && bench/parse/target/release/parse-baseline bench-nt "$SCRATCH/parse.nt"' ;;
     hdt-stage-split) echo '(cd bench/parse && cargo build --release) && "$GEN" dump 125000 "$SCRATCH/h.nt" && bench/parse/target/release/parse-baseline gen-hdt "$SCRATCH/h.nt" "$SCRATCH/h.hdt" && bench/parse/target/release/parse-baseline bench-hdt "$SCRATCH/h.hdt"' ;;


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI / bench-infra. Follows the sub-agent shared contract. [OPUS-4.8]

## What & where
`scripts/bench/run-all-benchmarks.sh` (bead **sq-k0pml**, follow-up to **sq-hz0g2** #1617). Two of the three work-box FAILs were missing/wrong-**artifact** bugs in the suite command strings — reclassified into pass-after-fix. No `crates/` source touched.

| suite | before | root cause | after |
|-------|--------|-----------|-------|
| **shacl** | FAIL (`bench_shacl not found at target/release/examples/bench_shacl`) | `sparq-shacl` is not a `sparq-cli` dependency, so `build-core` never produced the example | **PASS** — `suite_cmd` now pre-builds it (`cargo build --release -p sparq-shacl --example bench_shacl && bench/shacl/run.sh`), mirroring fts/rsp/hdt/geo/vector-ann |
| **ingest-index** | FAIL (`open …/idx/spo.perm: No such file`) | `Graph::save` writes `perm<i>.bin` (SPO = `perm0.bin`, per `sparq-core` store.rs `Perm::ALL`/`save_with`); `idx/spo.perm` never existed | **PASS** — probe-compress now targets `idx/perm0.bin`; the full chain (ingest+save+probe-compress+compare-compress+bench-mmap) passes |
| **fuzz-smoke** | FAIL (42/2000 `full_mismatch`) | **NOT** a missing-artifact issue — a **real** differential regression vs Oxigraph on `FILTER` inequality over mixed-typed literals | **stays FAIL (correct)** — filed as **sq-eibog**; suite must stay red until the engine is fixed |

## Exact commands / local reproduction
- shacl: `cargo build --release -p sparq-shacl --example bench_shacl` then `bench/shacl/run.sh` → exit 0, all 5 workloads match `expected.tsv`.
- ingest-index: `save …/idx` writes `perm0.bin`; `probe-compress …/idx/perm0.bin` → `6.07 B/triple` report; `compare-compress` + `bench-mmap` → rc 0.
- Both driven **through the script** (`--only shacl,ingest-index`): `counts: {"skipped": 69, "pass": 2}`, script exit 0, per-suite JSON `status: pass`, `exit_code: 0`.
- fuzz-smoke: `target/release/sparq-bench fuzz 0 50 all` → `full_mismatch=8` on main `6e9deb88` (seed=15: `SELECT ?s WHERE { ?s ex:val ?v FILTER(?v != "s2") }` → sparq len=2 vs oxigraph 8).

## Gate discipline
- **No suite weakened.** The fuzz-smoke suite correctly caught a real regression and remains red (same real-find handling as sq-kuazr / solid-wac). Filed **sq-eibog** (P1 bug) rather than silencing.
- Incremental-persistence, fail-closed-exit, and orphan-proof-EC2 (`--remote`) properties **untouched** — only two `suite_cmd` echo lines changed (8 insertions, 2 deletions).
- Validity: `bash -n` OK; `shellcheck -S error` clean; no typos-gate words. This is a `scripts/` shell file, not a `.github/workflows/` YAML — the `ci-summary / gate` aggregator and its path-filter are unaffected (no new gating leg; no workflow changed).

## Compliance gap closed
Bench-estate observability: the run-everything orchestrator's pass/fail/skip summary is now **honest** for these two suites (pass-after-build vs the spurious missing-artifact FAILs), and the one genuine regression is escalated as a bead instead of masked.

Refs: sq-k0pml, sq-hz0g2. Real-find follow-up: sq-eibog.