### PR TITLE
fix(solid): un-stale bench.rs default-graph assertion after the #1546 empty-default flip (sq-kuazr)

### DIFF
--- a/crates/sparq-solid/examples/bench.rs
+++ b/crates/sparq-solid/examples/bench.rs
@@ -9,13 +9,46 @@
 //!      dataset directly — including each path's overhead isolated on a query whose
 //!      pattern matches nothing;
 //!   3. session graph-set computation, cold vs cached.
+//!
+//! Default-graph semantics (post PR #1593 / issue #1546): the v2 view path is
+//! spec-conformant empty-by-default, so a *bare* default-graph pattern matches nothing
+//! there unless the query opts in with
+//! `FROM <http://www.w3.org/ns/solid/sparql#union-default-graph>`. The v1 rewrite path is
+//! union-always by construction (`query_as_rewrite` always wraps default-graph patterns in
+//! `GRAPH ?g` over the authorized set; it does not consume the opt-in IRI). So to keep the
+//! rewrite-vs-zero-copy comparison apples-to-apples over the SAME union-default semantics,
+//! this bench runs v1 with the bare `TITLES` query and v2 with `V2_UNION_QUERY` — the opt-in
+//! `TITLES_UNION` on the default build, or bare `TITLES` under the `legacy-union-default-graph`
+//! hatch (where a bare pattern is already union-always). Both then range over exactly the
+//! authorized named graphs and return the same row count. On the default build a third
+//! measurement records the v2 spec default (bare `TITLES` → 0 rows).
 
 use sparq_core::Graph;
 use sparq_solid::fixture::{acp_fixture, wac_fixture, ALICE};
 use sparq_solid::{Mode, PodStore, Session};
 use std::time::Instant;
 
+/// Bare default-graph pattern. On v1 (`query_as_rewrite`) this is union-always over the
+/// authorized graphs; on v2 (`query_as`) it is the spec-conformant empty default (0 rows).
 const TITLES: &str = "SELECT ?title WHERE { ?s <https://ex.dev/ns#title> ?title }";
+/// The same query with the per-request union-default opt-in — makes v2's default graph the
+/// RDF merge of the authorized named graphs, matching v1's union-always semantics
+/// like-for-like for the perf comparison (issue #1546 `#union-default-graph`). Only used on
+/// the spec-conformant default build (under the legacy hatch v2 is already union-always).
+#[cfg(not(feature = "legacy-union-default-graph"))]
+const TITLES_UNION: &str = "SELECT ?title FROM <http://www.w3.org/ns/solid/sparql#union-default-graph> \
+     WHERE { ?s <https://ex.dev/ns#title> ?title }";
+
+/// The v2 query that ranges over the authorized union, so its row count matches v1's
+/// union-always rewrite for the apples-to-apples perf comparison. It is feature-dependent:
+/// on the spec-conformant DEFAULT build a bare pattern is empty, so v2 must opt in with the
+/// reserved IRI (`TITLES_UNION`); under the `legacy-union-default-graph` escape hatch a bare
+/// pattern is already union-always (and the reserved-IRI opt-in is a no-op there — the
+/// legacy rewrite does not consume it), so the bare `TITLES` is the union form.
+#[cfg(not(feature = "legacy-union-default-graph"))]
+const V2_UNION_QUERY: &str = TITLES_UNION;
+#[cfg(feature = "legacy-union-default-graph")]
+const V2_UNION_QUERY: &str = TITLES;
 
 fn timed<T>(label: &str, mut f: impl FnMut() -> T) -> T {
     // best-of-3 for the multi-ms operations
@@ -66,12 +99,26 @@ fn main() {
     let v1 = timed("query_as_rewrite (v1: FROM NAMED build_active copy)", || {
         store.query_as_rewrite(&alice, Mode::Read, TITLES).unwrap()
     });
-    println!("    rows: {} (authorized subset)", v1.rows.len());
-    let v2 = timed("query_as (v2 DEFAULT: zero-copy DatasetView)", || {
-        store.query_as(&alice, Mode::Read, TITLES).unwrap()
+    println!("    rows: {} (authorized subset, union-always)", v1.rows.len());
+    // v2 ranges over the same authorized union as v1's union-always rewrite — the
+    // apples-to-apples perf comparison. On the default build that means opting in with the
+    // reserved IRI; under the legacy hatch a bare pattern is already union-always.
+    let v2 = timed("query_as (v2: zero-copy DatasetView, authorized union)", || {
+        store.query_as(&alice, Mode::Read, V2_UNION_QUERY).unwrap()
     });
-    println!("    rows: {} (authorized subset)", v2.rows.len());
-    assert_eq!(v1.rows.len(), v2.rows.len());
+    println!("    rows: {} (authorized subset, union)", v2.rows.len());
+    assert_eq!(v1.rows.len(), v2.rows.len(), "v1 union-always == v2 authorized union");
+    // v2 spec default (bare default-graph pattern, no opt-in) is EMPTY per the Editor's Draft
+    // (PR #1593): strictly more conservative than v1's union-always. Only holds on the
+    // spec-conformant default build — the legacy hatch makes a bare pattern union-always.
+    #[cfg(not(feature = "legacy-union-default-graph"))]
+    {
+        let v2_default = timed("query_as (v2 spec default: bare pattern, empty default graph)", || {
+            store.query_as(&alice, Mode::Read, TITLES).unwrap()
+        });
+        println!("    rows: {} (empty default graph, spec-conformant)", v2_default.rows.len());
+        assert_eq!(v2_default.rows.len(), 0, "spec-conformant empty default graph (#1546)");
+    }
     // each path's overhead alone, isolated: same query, pattern matched nothing
     const NOTHING: &str = "SELECT ?x WHERE { ?x <urn:none> <urn:none> }";
     let nothing = timed("v1 copy cost isolated (rewritten query, empty pattern)", || {
@@ -102,12 +149,13 @@ fn main() {
     let fat_v1 = timed("query_as_rewrite (v1 copy path), fat fixture", || {
         fat_store.query_as_rewrite(&alice, Mode::Read, TITLES).unwrap()
     });
-    println!("    rows: {}", fat_v1.rows.len());
-    let fat_v2 = timed("query_as (v2 view path), fat fixture", || {
-        fat_store.query_as(&alice, Mode::Read, TITLES).unwrap()
+    println!("    rows: {} (union-always)", fat_v1.rows.len());
+    // like-for-like: v2 over the authorized union matches v1's union-always semantics.
+    let fat_v2 = timed("query_as (v2 view path, authorized union), fat fixture", || {
+        fat_store.query_as(&alice, Mode::Read, V2_UNION_QUERY).unwrap()
     });
-    println!("    rows: {}", fat_v2.rows.len());
-    assert_eq!(fat_v1.rows.len(), fat_v2.rows.len());
+    println!("    rows: {} (union)", fat_v2.rows.len());
+    assert_eq!(fat_v1.rows.len(), fat_v2.rows.len(), "v1 union-always == v2 authorized union (fat)");
     let fat_nothing = timed("v1 copy cost isolated, fat fixture", || {
         fat_store.query_as_rewrite(&alice, Mode::Read, NOTHING).unwrap()
     });


### PR DESCRIPTION
> 🤖 SPARQ agent. This PR un-stales the `sparq-solid` bench example after the issue #1546 / PR #1593 empty-default flip. Example-only; authorization-adjacent (`sparq-solid`) → escalated review, **not** self-armed.

## What & why

The full-benchmark run surfaced a **stale assertion** in `crates/sparq-solid/examples/bench.rs` (~line 74). It asserted `query_as_rewrite` (v1: `FROM NAMED` union rewrite) row count **equals** `query_as` (v2: zero-copy `DatasetView`) for a **bare default-graph pattern**:

```
SELECT ?title WHERE { ?s <https://ex.dev/ns#title> ?title }
```

i.e. `599 == 599`. PR #1593 (the #1546 flip) made v2's **default** the spec-compliant **empty default graph** (*Access-Controlled SPARQL Query over a Solid Pod* Editor's Draft), so under v2 a bare pattern now correctly returns **0 rows** while v1's union rewrite still returns **599** — the assertion fails (`599 != 0`).

**This is a stale example, NOT an engine regression.** Verified: `0` is the correct spec-conformant v2-default for a bare pattern, per #1593's `wrap_for_view_opt_in` semantics and the crate's own `tests/union_default_graph.rs` (bare = empty, opt-in = union). Reproduced the panic at line 74 on `origin/main` (599 vs 0), and confirmed the two paths diverge only in what the **default graph** sees, never in the readable set.

## Fix — option (a): keep it a valid apples-to-apples PERF comparison

Opt v2 into the union default graph so **both** paths evaluate the same union-default semantics and the equality holds. v2 now uses a feature-selected `V2_UNION_QUERY`:

- **default build** → opt-in `TITLES_UNION` (`FROM <http://www.w3.org/ns/solid/sparql#union-default-graph>`): v2's default graph becomes the RDF merge of the authorized named graphs → **599 == v1's 599**;
- **`legacy-union-default-graph` hatch** → bare `TITLES` (already union-always there; the legacy rewrite does not consume the reserved IRI, so feeding it the opt-in IRI would wrongly collapse to 0) → **599 == 599**.

I chose option (a) over the "assert the honest split" option because the bench's stated intent is a `query_as` **rewrite-vs-zero-copy perf comparison** — keeping both paths on the same union-default semantics preserves that as a like-for-like measurement (v2 ~1.9 ms vs v1 ~35 ms; fat ~2.2 ms vs ~74 ms on this non-canonical work box). The **honest post-flip split** is still recorded: on the default build a third measurement asserts the v2 spec default (bare `TITLES` → **0 rows**), gated off under the legacy hatch. The fat-fixture block gets the same `V2_UNION_QUERY` treatment.

No public-API change; no README/SKILL semantics change (the crate README + access-control SKILL already document empty-by-default + the opt-in IRI from #1593).

## Gates (both feature states)

- `cargo run -p sparq-solid --example bench --release` — **exits 0** on default AND `--features legacy-union-default-graph`.
- `cargo clippy -p sparq-solid --all-targets -- -D warnings` — clean; same with `--features legacy-union-default-graph`.
- `cargo test -p sparq-solid` — GREEN (default) and GREEN (`--features legacy-union-default-graph`).
- rustdoc `--workspace --no-deps --all-features` **and** default-feature `-p sparq-solid`, both under `RUSTDOCFLAGS="-D warnings"` — clean.
- `scripts/check-readme-template.py --enforce` — 0 deviations (README untouched).

Refs sq-kuazr, #1546, #1593.

🤖 Generated with [Claude Code](https://claude.com/claude-code)