### PR TITLE
fix(reason-dl): emit EquivalentClasses for named-composite class definitions (sq-pbz04.4.11)

### DIFF
--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -994,16 +994,18 @@ pub const SUITES: &[Suite] = &[
             feature: "dl-direct",
         },
         ci_job: "inference-conformance",
-        ratchet_floor: 184,
+        ratchet_floor: 192,
         floor_basis: "definitive expected verdicts through the L4 dispatch, EXACT-pinned \
-                      (sparq EXTENSION over the scoped fragment — NOT full OWL 2 DL)",
+                      (sparq EXTENSION over the scoped fragment — NOT full OWL 2 DL); \
+                      re-pinned by sq-pbz04.4.11 (M1 named-composite fix: +12 positive- \
+                      entailment passes, -4 consistency passes shifted to abstain, net +8)",
         note: "EXTENSION ratchet — the DIRECT-arm consistency / inconsistency / positive- / \
                negative-entailment tests decided by the REAL sparq-reason-dl L4 dispatch \
                (RL guarded / EL guarded / QL deferred / ALCH tableau) under a pinned \
                deterministic count budget; fail-closed abstentions are reported, never \
-               passes, and all 23 wrong-verdict divergences are pinned by name with audited \
-               mechanisms (incl. the L1 named-composite + orphan-list fidelity gaps this \
-               arm discovered, held open by follow-up beads)",
+               passes, and all 11 wrong-verdict divergences are pinned by name with audited \
+               mechanisms (M1 fixed by sq-pbz04.4.11; M4 orphan-list fidelity gap still \
+               open, held by follow-up bead sq-pbz04.4.12)",
     },
 ];
 

--- a/crates/sparq-conformance/tests/dl_suite.rs
+++ b/crates/sparq-conformance/tests/dl_suite.rs
@@ -33,18 +33,16 @@
 //! export's expectation. Every such row is pinned BY NAME in
 //! [`gated::DOCUMENTED_DIVERGENCES`] with an audited mechanism (exact SET equality: an
 //! unpinned new fail AND a stale entry that stops failing both go RED). The mechanisms
-//! are NOT laundered as acceptable: **M1 and M4 are genuine fidelity gaps in the merged
-//! L1 extractor that this conformance arm DISCOVERED** (they contradict L1's own
+//! are NOT laundered as acceptable: **M4 is a genuine fidelity gap in the merged
+//! L1 extractor that this conformance arm DISCOVERED** (it contradicts L1's own
 //! "understood in full or refused" contract), captured as follow-up work in the PR's
-//! bead list; when the fixes land these entries stop failing and the pin forces a
-//! deliberate re-audit. The mechanisms:
+//! bead list; when the fix lands these entries stop failing and the pin forces a
+//! deliberate re-audit. M1 was FIXED by sq-pbz04.4.11. The mechanisms:
 //!
-//! - **M1 — named-composite inlining loses the name↔expression binding.** L1 inlines a
-//!   NAMED class carrying an inline definition (`:A owl:unionOf (…)` /
-//!   `owl:intersectionOf` / a restriction backbone) at each occurrence and emits NO
-//!   `EquivalentClasses(A, expr)` axiom, so a conclusion that mentions the NAME is
-//!   underivable — the approved corpus expectation (e.g. `c owl:intersectionOf (x y)` ⊨
-//!   `c ⊑ x`) proves the "inlining is model-preserving" claim wrong for entailment.
+//! - **M1 — FIXED (sq-pbz04.4.11).** Named-composite inlining previously lost the
+//!   name↔expression binding; `extract()` now emits `EquivalentClasses(A, expr)` for
+//!   every NAMED class carrying an inline backbone definition, and the 12 corpus cases
+//!   that required this binding now PASS.
 //! - **M2 — anonymous individuals in a conclusion read as constants.** The official
 //!   expectation reads conclusion bnodes EXISTENTIALLY; the L1 model treats them as
 //!   (skolem) constants, so the refutation is satisfiable and the checker certifies a
@@ -109,79 +107,33 @@ mod gated {
     /// `tests/scoreboard_floors.rs`. A sparq EXTENSION measurement over the scoped
     /// fragment — NOT full OWL 2 DL.
     ///
-    /// COMPOSITION: 111 consistency + 14 inconsistency + 57 positive-entailment +
+    /// COMPOSITION: 107 consistency + 14 inconsistency + 69 positive-entailment +
     /// 2 negative-entailment. [FABLE-5] sq-pbz04.4.5
-    pub const DL_DIRECT_FLOOR: usize = 184;
+    /// Re-pinned by sq-pbz04.4.11 (M1 named-composite fix): 12 positive-entailment cases
+    /// now PASS (the EquivalentClasses name-binding axioms enable their entailments);
+    /// 4 consistency cases shift from Pass to abstain because their updated ontology
+    /// models now include EquivalentClasses axioms that, combined with the existing TBox,
+    /// cause budget exhaustion — an honest abstention, not a regression. Net: +8.
+    pub const DL_DIRECT_FLOOR: usize = 192;
 
     /// Abstained (fail-closed OutOfFragment / guard / deferred / budget) row totals,
     /// EXACT-pinned so the tri-state accounting is closed: profile lane, then the four
     /// reasoning lanes summed. [FABLE-5] sq-pbz04.4.5
     pub const DL_PROFILE_ABSTAINED: usize = 114;
     /// See [`DL_PROFILE_ABSTAINED`].
-    pub const DL_DIRECT_ABSTAINED: usize = 452;
+    /// Re-pinned by sq-pbz04.4.11: +4 from the 4 consistency cases that shifted from
+    /// Pass to OutOfFragment (budget exhaustion on the now-more-complete model).
+    pub const DL_DIRECT_ABSTAINED: usize = 456;
 
-    /// Audited, PINNED divergence rows (module docs — mechanisms M1–M7): every row
+    /// Audited, PINNED divergence rows (module docs — mechanisms M2–M7): every row
     /// where a checker verdict contradicts the export expectation, keyed by the
     /// runner's row key. EXACT set equality is asserted: an UNPINNED new fail and a
     /// STALE entry that stops failing both turn the lane RED (the el-suite /
-    /// ql_entailment_floor discipline). M1/M4 rows are DISCOVERED L1 fidelity gaps
+    /// ql_entailment_floor discipline). M4 rows are DISCOVERED L1 fidelity gaps
     /// held open by follow-up beads — never acceptable-by-design, never passes.
-    /// [FABLE-5] sq-pbz04.4.5
+    /// M1 (named-composite name-binding) was FIXED by sq-pbz04.4.11 and removed from
+    /// this list — those 12 cases now PASS. [FABLE-5] sq-pbz04.4.5
     const DOCUMENTED_DIVERGENCES: &[(&str, &str)] = &[
-        // --- M1: named-composite inlining loses the name↔expression binding (L1 gap) ---
-        (
-            "owl2-dl/positive-entailment: rdfbased-sem-bool-intersection-inst-comp",
-            "M1 — premise defines NAMED c by owl:intersectionOf; inlining drops \
-             EquivalentClasses(c, x⊓y), so c(z) is underivable",
-        ),
-        (
-            "owl2-dl/positive-entailment: rdfbased-sem-bool-intersection-term",
-            "M1 — `c owl:intersectionOf (x y)` ⊨ c ⊑ x ∧ c ⊑ y needs the name binding \
-             the inlining drops",
-        ),
-        (
-            "owl2-dl/positive-entailment: rdfbased-sem-bool-union-inst-comp",
-            "M1 — the union dual of rdfbased-sem-bool-intersection-inst-comp",
-        ),
-        (
-            "owl2-dl/positive-entailment: rdfbased-sem-bool-union-term",
-            "M1 — the union dual of rdfbased-sem-bool-intersection-term",
-        ),
-        (
-            "owl2-dl/positive-entailment: rdfbased-sem-restrict-allvalues-cmp-class",
-            "M1 — NAMED x1/x2 defined by ∀p.c restriction backbones; c1 ⊑ c2 ⊨ x1 ⊑ x2 \
-             needs both name bindings",
-        ),
-        (
-            "owl2-dl/positive-entailment: rdfbased-sem-restrict-allvalues-cmp-prop",
-            "M1 — as rdfbased-sem-restrict-allvalues-cmp-class with the property compared",
-        ),
-        (
-            "owl2-dl/positive-entailment: rdfbased-sem-restrict-somevalues-cmp-class",
-            "M1 — the ∃ dual of rdfbased-sem-restrict-allvalues-cmp-class",
-        ),
-        (
-            "owl2-dl/positive-entailment: rdfbased-sem-restrict-somevalues-cmp-prop",
-            "M1 — the ∃ dual of rdfbased-sem-restrict-allvalues-cmp-prop",
-        ),
-        (
-            "owl2-dl/positive-entailment: rdfbased-sem-restrict-somevalues-inst-subj",
-            "M1 — NAMED z defined by an ∃p.c backbone; p(w,x) ∧ c(x) ⊨ z(w) needs the \
-             name binding",
-        ),
-        (
-            "owl2-dl/positive-entailment: WebOnt-unionOf-001",
-            "M1 — `A owl:unionOf (Human Animal)` ∧ Human(John) ⊨ A(John) needs \
-             EquivalentClasses(A, Human⊔Animal)",
-        ),
-        (
-            "owl2-dl/positive-entailment: WebOnt-unionOf-002",
-            "M1 — as WebOnt-unionOf-001 with the subclass direction (B ⊒ union member)",
-        ),
-        (
-            "owl2-dl/positive-entailment: WebOnt-intersectionOf-001",
-            "M1 — the intersection sibling of WebOnt-unionOf-001",
-        ),
         // --- M2: anonymous individuals in the conclusion read as constants (L4 gap) ---
         (
             "owl2-dl/positive-entailment: somevaluesfrom2bnode",

--- a/crates/sparq-reason-dl/src/extract.rs
+++ b/crates/sparq-reason-dl/src/extract.rs
@@ -122,7 +122,129 @@ pub fn extract(dict: &Dict, triples: &[[Id; 3]]) -> Result<Ontology, ExtractErro
         classify_triple(dict, &v, &idx, s, p, o, &mut onto)?;
     }
 
+    // [SONNET-4.6] sq-pbz04.4.11 — named-composite EquivalentClasses pass.
+    //
+    // CORRECTNESS GAP (M1, discovered by the conformance arm):
+    // When a NAMED class IRI carries an inline backbone definition — `:A owl:intersectionOf
+    // (…)`, `:A owl:unionOf (…)`, `:A owl:complementOf :B`, or `:A a owl:Restriction ;
+    // owl:onProperty :r ; owl:someValuesFrom :C` — the main triple loop inlines the decoded
+    // expression at every use site of `:A` (in subClassOf / equivalentClass / domain / range
+    // / classAssertion / restriction objects etc.) but NEVER emits the name↔expression
+    // binding `EquivalentClasses(A, expr)`.
+    //
+    // This violates L1's own "understood in full or refused" contract: a conclusion
+    // `:A rdfs:subClassOf :x` (where x is an operand of `:A`'s intersection) is
+    // underivable from the inlined representation alone — the entailment requires the axiom
+    // `EquivalentClasses(A, x⊓y)` to exist in the structural model so that the downstream
+    // tableau can reason `A ≡ x⊓y ⊨ A ⊑ x`.
+    //
+    // FIX: after the main loop, collect every NAMED class IRI (not blank, not inline, not
+    // a triple-term) that has exactly one composite backbone predicate in the Index, decode
+    // its expression, and prepend `EquivalentClasses(Class(A), expr)` to the axiom list.
+    // Prepend (not append) so the name-binding axioms come before any axioms that use the
+    // name — consistent with a "declare, then use" reading the downstream tableau expects.
+    //
+    // BLANK nodes are excluded: an anonymous blank node `:_x owl:intersectionOf (…)`
+    // denotes an anonymous (unnamed) expression, not a named class binding, and has no
+    // meaningful class IRI to equate.
+    //
+    // No new `is_inline` / `TermParts::Iri` check is needed: the index already records
+    // exactly the backbone-carrying nodes; we just filter to IRI nodes among them.
+    //
+    // Deduplication: `EquivalentClasses(A, expr)` is emitted once per named class, even if
+    // the backbone predicate appears multiple times (the Index de-duplicates backbone
+    // values; a contradicting second value is already an error from `Index::build`).
+    emit_named_composite_equiv(dict, &v, &idx, &mut onto)?;
+
     Ok(onto)
+}
+
+/// Emits one `EquivalentClasses(Class(A), expr)` axiom for every NAMED class IRI that
+/// carries an inline composite backbone definition in the Index (sq-pbz04.4.11, M1 fix).
+///
+/// See the inline comment in [`extract`] for the full correctness rationale. This function
+/// is a pure second-pass over the Index — it never looks at the raw triple slice again.
+fn emit_named_composite_equiv(
+    dict: &Dict,
+    v: &Vocab,
+    idx: &Index,
+    onto: &mut Ontology,
+) -> Result<(), ExtractError> {
+    // Collect the set of named-class candidates: every node that carries at least one
+    // composite backbone predicate and is an IRI (not blank, not inline, not triple-term).
+    // Use a BTreeSet for sorted, deterministic iteration (no hash-map ordering
+    // nondeterminism in the structural model).
+    use std::collections::BTreeSet;
+
+    let mut named_composite_ids: BTreeSet<Id> = BTreeSet::new();
+
+    // Only IRI nodes. `is_named_iri` = not inline, TermParts::Iri.
+    let is_named_iri = |id: Id| -> bool {
+        !is_inline(id) && matches!(dict.term_parts(id), TermParts::Iri { .. })
+    };
+
+    for &id in idx.intersection_of.keys() {
+        if is_named_iri(id) {
+            named_composite_ids.insert(id);
+        }
+    }
+    for &id in idx.union_of.keys() {
+        if is_named_iri(id) {
+            named_composite_ids.insert(id);
+        }
+    }
+    for &id in idx.complement_of.keys() {
+        if is_named_iri(id) {
+            named_composite_ids.insert(id);
+        }
+    }
+    // Restrictions: any node in is_restriction, some_values_from, or all_values_from
+    // that is also a named IRI.
+    for &id in &idx.is_restriction {
+        if is_named_iri(id) {
+            named_composite_ids.insert(id);
+        }
+    }
+    for &id in idx.some_values_from.keys() {
+        if is_named_iri(id) {
+            named_composite_ids.insert(id);
+        }
+    }
+    for &id in idx.all_values_from.keys() {
+        if is_named_iri(id) {
+            named_composite_ids.insert(id);
+        }
+    }
+
+    if named_composite_ids.is_empty() {
+        return Ok(());
+    }
+
+    // Prepend the EquivalentClasses axioms so they precede all use-site axioms.
+    let mut prepend: Vec<Axiom> = Vec::with_capacity(named_composite_ids.len());
+    for id in named_composite_ids {
+        // Decode the composite expression for this named class. We use a fresh call
+        // through decode_class (which creates a fresh `visiting` set), so the cycle guard
+        // works correctly for each named class independently.
+        let expr = decode_class(dict, v, idx, id)?;
+        let name = ClassExpression::Class(id);
+        // Emit only if the expression is not the named class itself (a trivially cyclic
+        // case is caught by the visiting guard already; this guard just avoids emitting
+        // EquivalentClasses(A, A) for any degenerate case that slips through).
+        if expr != name {
+            prepend.push(Axiom::EquivalentClasses(name, expr));
+        }
+    }
+
+    // Prepend: insert the name-binding axioms before the use-site axioms so that
+    // the structural model reads "declare name, then use name" — the downstream
+    // tableau iterates axioms in order and sees the binding before any GCI/assertion
+    // that mentions the named class.
+    if !prepend.is_empty() {
+        let tail = std::mem::replace(&mut onto.axioms, prepend);
+        onto.axioms.extend(tail);
+    }
+    Ok(())
 }
 
 /// Routes one non-backbone triple: into an [`Axiom`] on `onto`, silently past an ignorable
@@ -393,9 +515,20 @@ fn decode_class_inner(
     // Boolean / quantifier shapes, detected by the presence of their defining predicate. This
     // fires for BLANK anonymous nodes AND for a NAMED class that carries an inline definition
     // (`:A owl:intersectionOf (…)`): `owl:intersectionOf`/`unionOf`/`complementOf`/a
-    // `owl:Restriction` on a class node denotes a COMPLETE equivalence, so inlining the decoded
-    // expression at every occurrence of the node is model-preserving (sound). Decoding is
-    // deterministic, so a named node inlines to the same expression consistently everywhere.
+    // `owl:Restriction` on a class node denotes a COMPLETE equivalence.
+    //
+    // ANONYMOUS blank nodes: inlining the decoded expression at every use site is
+    // model-preserving and sufficient — there is no class NAME to bind.
+    //
+    // NAMED class IRIs: inlining alone is NOT sufficient (sq-pbz04.4.11, M1 gap). A
+    // conclusion that mentions the NAME as a class constant is underivable from inlined
+    // expressions alone — the entailment `:A subClassOf :x` (where :x is an operand of
+    // `:A owl:intersectionOf (…)`) requires the axiom `EquivalentClasses(A, x⊓y)` in
+    // the structural model. `extract()` emits that axiom in the post-loop pass
+    // `emit_named_composite_equiv`; this function still inlines so that use-site axioms
+    // (where `:A` appears as a class argument) already hold the full decoded expression.
+    // Decoding is deterministic, so the inlined form and the EquivalentClasses expression
+    // are always the same expression structurally.
     let is_inter = idx.intersection_of.contains_key(&id);
     let is_union = idx.union_of.contains_key(&id);
     let is_compl = idx.complement_of.contains_key(&id);

--- a/crates/sparq-reason-dl/tests/extract.rs
+++ b/crates/sparq-reason-dl/tests/extract.rs
@@ -896,3 +896,170 @@ fn fail_closed_rejects_whole_graph_on_one_bad_triple() {
         "one out-of-fragment triple must reject the whole graph"
     );
 }
+
+// ============================== sq-pbz04.4.11 — named-composite EquivalentClasses (M1 fix) ======
+
+// [SONNET-4.6] sq-pbz04.4.11: the M1 fidelity gap — a NAMED class carrying an inline backbone
+// definition must emit EquivalentClasses(name, expr) so entailment through the name works.
+// These tests are the acceptance tests for the 12 M1 divergence cases identified by the
+// conformance arm in tests/dl_suite.rs.
+
+/// A NAMED class carrying an owl:intersectionOf definition must produce
+/// EquivalentClasses(A, x⊓y) — the M1 fix for intersection cases.
+/// [SONNET-4.6] sq-pbz04.4.11
+#[test]
+fn named_class_intersection_emits_equivalent_classes() {
+    // :A owl:intersectionOf (:B :C) — A is named; must produce EquivalentClasses(A, B⊓C).
+    let (d, t) = parse(":A owl:intersectionOf ( :B :C ) .");
+    let o = extract(&d, &t).expect("accept");
+    let a = class(&d, "A");
+    let expected_expr = CE::ObjectIntersectionOf(vec![class(&d, "B"), class(&d, "C")]);
+    assert!(
+        o.axioms.contains(&Axiom::EquivalentClasses(a.clone(), expected_expr.clone())),
+        "named intersectionOf must emit EquivalentClasses(A, B⊓C); got {:?}",
+        o.axioms
+    );
+    // Exactly one axiom: the name-binding.
+    assert_eq!(
+        o.len(),
+        1,
+        "only the EquivalentClasses name-binding should be emitted; got {:?}",
+        o.axioms
+    );
+}
+
+/// A NAMED class carrying an owl:unionOf definition must produce
+/// EquivalentClasses(A, x⊔y) — the M1 fix for union cases.
+/// [SONNET-4.6] sq-pbz04.4.11
+#[test]
+fn named_class_union_emits_equivalent_classes() {
+    let (d, t) = parse(":A owl:unionOf ( :Human :Animal ) .");
+    let o = extract(&d, &t).expect("accept");
+    let a = class(&d, "A");
+    let expected_expr = CE::ObjectUnionOf(vec![class(&d, "Human"), class(&d, "Animal")]);
+    assert!(
+        o.axioms.contains(&Axiom::EquivalentClasses(a, expected_expr)),
+        "named unionOf must emit EquivalentClasses(A, Human⊔Animal); got {:?}",
+        o.axioms
+    );
+}
+
+/// A NAMED class carrying an owl:complementOf definition must produce
+/// EquivalentClasses(A, ¬B).
+/// [SONNET-4.6] sq-pbz04.4.11
+#[test]
+fn named_class_complement_emits_equivalent_classes() {
+    let (d, t) = parse(":A owl:complementOf :B .");
+    let o = extract(&d, &t).expect("accept");
+    let a = class(&d, "A");
+    let expected_expr = CE::ObjectComplementOf(Box::new(class(&d, "B")));
+    assert!(
+        o.axioms.contains(&Axiom::EquivalentClasses(a, expected_expr)),
+        "named complementOf must emit EquivalentClasses(A, ¬B); got {:?}",
+        o.axioms
+    );
+}
+
+/// A NAMED class carrying an owl:Restriction backbone must produce
+/// EquivalentClasses(A, ∃r.C) — the M1 fix for restriction cases.
+/// [SONNET-4.6] sq-pbz04.4.11
+#[test]
+fn named_class_restriction_backbone_emits_equivalent_classes() {
+    // :z a owl:Restriction; owl:onProperty :p; owl:someValuesFrom :C  (z is named IRI)
+    let (d, t) = parse(":z a owl:Restriction .\n:z owl:onProperty :p .\n:z owl:someValuesFrom :C .");
+    let o = extract(&d, &t).expect("accept");
+    let z = class(&d, "z");
+    let expected_expr = CE::ObjectSomeValuesFrom(prop(&d, "p"), Box::new(class(&d, "C")));
+    assert!(
+        o.axioms.contains(&Axiom::EquivalentClasses(z, expected_expr)),
+        "named restriction must emit EquivalentClasses(z, ∃p.C); got {:?}",
+        o.axioms
+    );
+}
+
+/// The name-binding EquivalentClasses axiom must be PREPENDED before any use-site axioms,
+/// so the structural model sees "define name, then use name". This is the ordering contract
+/// the downstream tableau depends on.
+/// [SONNET-4.6] sq-pbz04.4.11
+#[test]
+fn named_composite_equiv_prepended_before_use_site_axioms() {
+    // :A owl:intersectionOf (:B :C); then a subClassOf using :A.
+    let (d, t) = parse(
+        ":A owl:intersectionOf ( :B :C ) .\n\
+         :D rdfs:subClassOf :A .",
+    );
+    let o = extract(&d, &t).expect("accept");
+    assert!(o.len() >= 2, "expected at least 2 axioms, got {:?}", o.axioms);
+    // The FIRST axiom must be the name-binding EquivalentClasses.
+    assert!(
+        matches!(&o.axioms[0], Axiom::EquivalentClasses(CE::Class(_), _)),
+        "first axiom must be EquivalentClasses (name-binding); got {:?}",
+        o.axioms[0]
+    );
+}
+
+/// A BLANK node carrying a backbone definition must NOT emit EquivalentClasses —
+/// only NAMED classes (IRIs) get the binding; anonymous nodes are just inline expressions.
+/// [SONNET-4.6] sq-pbz04.4.11
+#[test]
+fn blank_node_backbone_does_not_emit_equivalent_classes() {
+    // _:x owl:intersectionOf (:A :B) used in :D rdfs:subClassOf _:x — anonymous expression.
+    let (d, t) = parse(":D rdfs:subClassOf [ owl:intersectionOf ( :A :B ) ] .");
+    let o = extract(&d, &t).expect("accept");
+    // The only axiom must be the SubClassOf (the anonymous blank carries no binding).
+    assert_eq!(o.len(), 1, "blank backbone must yield only SubClassOf, got {:?}", o.axioms);
+    assert!(
+        matches!(&o.axioms[0], Axiom::SubClassOf { .. }),
+        "sole axiom must be SubClassOf, got {:?}",
+        o.axioms[0]
+    );
+    // Verify: no EquivalentClasses axiom.
+    for ax in &o.axioms {
+        assert!(
+            !matches!(ax, Axiom::EquivalentClasses(..)),
+            "blank backbone must NOT produce EquivalentClasses"
+        );
+    }
+}
+
+/// The M1 fix must not regress the existing union-name case: a named union class
+/// (like `A owl:unionOf (Human Animal)`) used with a ClassAssertion must now
+/// allow the downstream checker to derive A(John) from Human(John) — the
+/// EquivalentClasses binding is what makes that entailment possible.
+/// [SONNET-4.6] sq-pbz04.4.11
+#[test]
+fn named_union_with_class_assertion_emits_both_equiv_and_assertion() {
+    // :A owl:unionOf (:Human :Animal) — named union; :John a :Human.
+    let (d, t) = parse(
+        ":A owl:unionOf ( :Human :Animal ) .\n\
+         :John a :Human .",
+    );
+    let o = extract(&d, &t).expect("accept");
+    let a = class(&d, "A");
+    let equiv = Axiom::EquivalentClasses(
+        a,
+        CE::ObjectUnionOf(vec![class(&d, "Human"), class(&d, "Animal")]),
+    );
+    let assertion = Axiom::ClassAssertion {
+        class: class(&d, "Human"),
+        individual: ex(&d, "John"),
+    };
+    assert!(
+        o.axioms.contains(&equiv),
+        "EquivalentClasses(A, Human⊔Animal) must be present; got {:?}",
+        o.axioms
+    );
+    assert!(
+        o.axioms.contains(&assertion),
+        "ClassAssertion(Human, John) must be present; got {:?}",
+        o.axioms
+    );
+    // The EquivalentClasses axiom must come BEFORE the ClassAssertion (name binding first).
+    let equiv_pos = o.axioms.iter().position(|ax| ax == &equiv).unwrap();
+    let assert_pos = o.axioms.iter().position(|ax| ax == &assertion).unwrap();
+    assert!(
+        equiv_pos < assert_pos,
+        "EquivalentClasses must precede ClassAssertion (position {} vs {})",
+        equiv_pos, assert_pos
+    );
+}


### PR DESCRIPTION
> 🤖 SPARQ agent — correctness fix for the M1 fidelity gap in the OWL 2 Direct-Semantics extractor. Epic sq-pbz04.4, program sq-6tykl. [OPUS-4.8]

## Summary

- **Root cause (M1):** When a NAMED class IRI carries an inline composite backbone definition — `:A owl:intersectionOf (…)`, `owl:unionOf`, `owl:complementOf`, or a restriction — `extract()` inlined the decoded expression at every use site but emitted NO `EquivalentClasses(A, expr)` axiom. This violated L1's own "understood in full or refused" contract: entailment through the class NAME was underivable, because the downstream tableau only sees the inlined expression, never the name↔expression binding.
- **Fix:** New post-loop pass `emit_named_composite_equiv` in `extract()`. After the main triple loop, it collects every named class IRI (not blank, not inline) with a composite backbone from the Index and prepends `EquivalentClasses(Class(A), decoded_expr)` before all use-site axioms. Blank anonymous nodes are correctly excluded — they have no class name to bind.
- **12 pinned M1 divergences now PASS:** All 12 `positive-entailment` conformance cases that were pinned as M1 divergences in `tests/dl_suite.rs::DOCUMENTED_DIVERGENCES` now produce the expected `Entailed` verdict. The M1 entries are removed from the divergence list.
- **Ratchet re-pinned:** `DL_DIRECT_FLOOR` 184→192 (+12 positive-entailment passes, -4 consistency cases that shift to abstain on the now more-complete model, net +8). Central scoreboard updated.

## What was NOT changed (sq-pbz04.4.12 scope)

`sq-pbz04.4.12` (orphan/cyclic list cells, M4 gap, touches the same `extract.rs` file) is queued AFTER this PR. This PR stays within the `emit_named_composite_equiv` addition and the conformance pin updates — no changes to list-cell handling.

## Gates run

**Feature OFF (default):**
- `cargo build -p sparq-reason-dl` — clean
- `cargo clippy -p sparq-reason-dl --all-targets -- -D warnings` — clean
- `cargo test -p sparq-reason-dl` — 64 passed (57 pre-existing + 7 new M1 tests)
- `RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-reason-dl --no-deps --all-features` — clean

**Feature ON (`--features dispatch` / `dl-direct`):**
- `cargo clippy -p sparq-reason-dl --all-targets --features dispatch -- -D warnings` — clean
- `cargo test -p sparq-reason-dl --features dispatch` — 64 passed
- `cargo test -p sparq-conformance --features dl-direct --test dl_suite --release` — 2 passed (both `dl_direct_arm_ratchet` and `dl_entailment_derivation_canary`)
- `cargo test -p sparq-conformance --test scoreboard_floors` — 3 passed (central floors in sync)
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations

## Test evidence (M1 cases now pass)

All 12 M1 cases that were in `DOCUMENTED_DIVERGENCES` are now in the stale-pin set (confirmed by the assertion failure before the re-pin, and by the `ok` after). The 7 new unit tests in `tests/extract.rs` cover: named intersection/union/complement/restriction → EquivalentClasses, blank-node exclusion, prepend-before-use-site ordering, and the WebOnt-unionOf end-to-end case with ClassAssertion.

## NOT self-armed (correctness surface)

This is a correctness fix to the L1 extractor. Per the brief: escalated review, do NOT self-arm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)