### PR TITLE
feat(substrate): add Num::cmp_relational + wire sparq-reason (sq-v5evr)

### DIFF
--- a/crates/sparq-reason/src/compare.rs
+++ b/crates/sparq-reason/src/compare.rs
@@ -225,19 +225,13 @@ fn num_of_parts(value: &str, datatype: &str) -> Option<Num> {
     None
 }
 
-/// The engine's `num_compare`: exact via the `Dec` fixed-point tower when both operands
-/// have an exact tier (int/decimal), else by `f64` value (float/double, whose value IS
-/// its f64). (The value-space relational-compare hoist into the substrate is the parked
-/// seam-2 remainder, sq-v5evr; until then this six-line mirror is pinned by the
-/// engine-parity test.)
+/// The numeric relational comparison for `strict_cmp` — delegates to
+/// `Num::cmp_relational` (the shared substrate function, sq-v5evr): exact via the
+/// `Dec` fixed-point tower when both operands have an exact tier (int/decimal), else
+/// by `f64` value (float/double). NaN → `None` (SPARQL type error). [OPUS-4.8] sq-v5evr
 #[inline]
 fn num_compare(a: Num, b: Num) -> Option<Ordering> {
-    if let (Some(x), Some(y)) = (a.to_dec(), b.to_dec()) {
-        if let Some(o) = x.cmp(y) {
-            return Some(o);
-        }
-    }
-    a.f64().partial_cmp(&b.f64())
+    a.cmp_relational(b)
 }
 
 impl CompareTerm for IdTerm<'_> {
@@ -647,5 +641,26 @@ mod tests {
                 dt
             );
         }
+    }
+
+    /// Direct pin of `num_compare` → `Num::cmp_relational` (sq-v5evr): verifies the
+    /// delegation produces the expected relational semantics — exact for int/dec pairs,
+    /// f64 promotion for mixed/inexact, and `None` for NaN (SPARQL type error).
+    /// [OPUS-4.8] sq-v5evr
+    #[test]
+    fn num_compare_delegates_to_substrate_cmp_relational() {
+        use std::cmp::Ordering::*;
+        // Exact same-tier: integer vs integer
+        assert_eq!(num_compare(Num::Int(1), Num::Int(2)), Some(Less));
+        assert_eq!(num_compare(Num::Int(3), Num::Int(3)), Some(Equal));
+        assert_eq!(num_compare(Num::Int(5), Num::Int(4)), Some(Greater));
+        // Exact cross-tier: int vs decimal
+        let dec = Num::Dec(Dec { mant: 10, scale: 1 }); // 1.0
+        assert_eq!(num_compare(Num::Int(1), dec), Some(Equal));
+        // Double: normal
+        assert_eq!(num_compare(Num::Double(1.5), Num::Double(2.5)), Some(Less));
+        // NaN → None (SPARQL type error — the relational semantics, not cmp_total)
+        assert_eq!(num_compare(Num::Double(f64::NAN), Num::Int(0)), None);
+        assert_eq!(num_compare(Num::Int(0), Num::Double(f64::NAN)), None);
     }
 }

--- a/crates/sparq-substrate/README.md
+++ b/crates/sparq-substrate/README.md
@@ -61,8 +61,9 @@ let n: Option<Num> = as_numeric(&lit);  // exact xsd:decimal (no f64 rounding)
   form the W3C SPARQL expected-result files use for computed arithmetic, e.g. `6`) — and the
   shared lexical helpers (`split_decimal`, `parse_xsd_f32` / `parse_xsd_f64`, `fmt_xsd_double`).
   `parse_xsd_f64`/`f32` accept the XSD `INF` / `+INF` / `-INF` / `NaN` spellings and reject the
-  Rust-`FromStr`-only `inf` / `infinity` / `nan`, so the engine's lenient compare seam agrees
-  with the exact classifier on which lexicals are numeric.
+  Rust-`FromStr`-only `inf` / `infinity` / `nan`. `Num::cmp_relational` is the XPath relational
+  comparison (`<`/`>` FILTER, value-space equality) — partial (NaN → `None`), vs `cmp_total`
+  which totalises NaN for `ORDER BY` [OPUS-4.8] sq-v5evr.
 - **`join`** — the four id-tuple join kernels over `&[Row]` slices: `merge_join` (sorted),
   `hash_probe_serial` / `build_table` / `build_partitioned` / `probe_emit` (hash, with a
   radix-partitioned parallel build), `bind_combine` (index-nested-loop), and `lftj_recurse`

--- a/crates/sparq-substrate/src/lib.rs
+++ b/crates/sparq-substrate/src/lib.rs
@@ -32,6 +32,14 @@
 // so a wholesale `Value` relocation would be non-neutral and sprawling — the correct seam moves
 // the ALGORITHM, leaving `Value` engine-resident; see the deferred-remainder note in the PR).
 //
+// sq-v5evr (un-parked, [OPUS-4.8]): the VALUE-SPACE RELATIONAL COMPARE — the XPath
+// `op:numeric-less-than`/`op:numeric-equal` semantics, where NaN is incomparable (`None`)
+// and same-tier pairs compare exactly via the `Dec` tower — has been added to the `numeric`
+// module as `Num::cmp_relational`. This is the correct comparison for SPARQL `<`/`>`/`=`
+// FILTER expressions, D-entailment value-space equality, and RIF `pred:numeric-equal` /
+// `pred:numeric-less-than` builtins. The reasoner's `compare` module now delegates its
+// `num_compare` helper to this shared function instead of duplicating the logic.
+//
 // All moves are behaviour-neutral (the W3C SPARQL conformance floor + the join/scan/BGP/sort
 // micro-benches are bit-identical / within noise).
 //

--- a/crates/sparq-substrate/src/numeric.rs
+++ b/crates/sparq-substrate/src/numeric.rs
@@ -428,6 +428,38 @@ impl Num {
         }
     }
 
+    /// The **relational** numeric comparison used by the SPARQL `<`/`>`/`=` operators
+    /// and by `MIN`/`MAX` — XPath `op:numeric-less-than` / `op:numeric-equal` semantics.
+    ///
+    /// Unlike [`cmp_total`](Self::cmp_total), this comparison is **partial**: `NaN`
+    /// produces `None` (a SPARQL type error), and `+0.0` equals `-0.0`. Same-tier pairs
+    /// (`Int`/`Dec`) compare by exact value via [`Dec::cmp`]; mixed or inexact pairs fall
+    /// back to `f64::partial_cmp` (XPath promotion — a float/double operand promotes the
+    /// pair to `f64`, which is correct for the relational operators but can collapse
+    /// distinct exact values at the 2^53 boundary; that is an accepted consequence of the
+    /// XPath spec, not a bug). Returns `None` when either operand is `NaN`, matching the
+    /// engine's `values_equal`/`value_compare_strict` path (SPARQL type error on NaN).
+    ///
+    /// # When to use `cmp_total` vs `cmp_relational`
+    ///
+    /// - **`ORDER BY`, `MIN`/`MAX` (for the sort tie), `sort_ids`** — use `cmp_total`:
+    ///   NaN must be positioned somewhere to give a total order.
+    /// - **`<`, `>`, `=`, `!=` FILTER expressions and value-space equality**
+    ///   (D-entailment, RIF `pred:numeric-equal`) — use `cmp_relational`: NaN is an error.
+    ///
+    /// [OPUS-4.8] sq-v5evr — the value-space equality/relational-compare hoist.
+    #[inline]
+    pub fn cmp_relational(self, o: Num) -> Option<Ordering> {
+        // Exact tier: both Int/Dec → exact Dec comparison (no f64 promotion).
+        if let (Some(x), Some(y)) = (self.to_dec(), o.to_dec()) {
+            if let Some(ord) = x.cmp(y) {
+                return Some(ord);
+            }
+        }
+        // Mixed or inexact: f64 promotion.  NaN → None (SPARQL type error).
+        self.f64().partial_cmp(&o.f64())
+    }
+
     /// `op` under XPath operand promotion. `None` is a SPARQL type error (exact-type
     /// division by zero); exact-arithmetic overflow falls back to double, mirroring
     /// the engine's previous f64 behaviour.
@@ -1418,5 +1450,56 @@ mod tests {
         assert_eq!(f64_exact_decimal(f64::NAN), None);
         assert_eq!(f64_exact_decimal(f64::INFINITY), None);
         assert_eq!(f64_exact_decimal(f64::NEG_INFINITY), None);
+    }
+
+    // --- Num::cmp_relational — the SPARQL relational (</>/ =) numeric comparison ---
+    // [OPUS-4.8] sq-v5evr: the value-space equality/relational-compare hoist.
+
+    /// Basic ordering: int < dec < float < double ordering by value, and the identity
+    /// `cmp_relational(x, x) == Some(Equal)` for the non-NaN variants.
+    #[test]
+    fn cmp_relational_basic_ordering() {
+        use Ordering::*;
+        // Exact tier: int vs dec
+        assert_eq!(Num::Int(1).cmp_relational(Num::Int(2)), Some(Less));
+        assert_eq!(Num::Int(2).cmp_relational(Num::Int(1)), Some(Greater));
+        assert_eq!(Num::Int(1).cmp_relational(Num::Int(1)), Some(Equal));
+        let dec1 = Num::Dec(Dec { mant: 10, scale: 1 }); // 1.0
+        let dec2 = Num::Dec(Dec { mant: 15, scale: 1 }); // 1.5
+        assert_eq!(dec1.cmp_relational(dec2), Some(Less));
+        assert_eq!(Num::Int(1).cmp_relational(dec1), Some(Equal));
+        // Float / double
+        assert_eq!(Num::Double(1.0).cmp_relational(Num::Double(2.0)), Some(Less));
+        assert_eq!(Num::Float(3.0).cmp_relational(Num::Float(3.0)), Some(Equal));
+    }
+
+    /// NaN operands produce `None` (SPARQL type error) — unlike `cmp_total` which
+    /// totalises NaN first. This pin distinguishes `cmp_relational` from `cmp_total`.
+    #[test]
+    fn cmp_relational_nan_is_type_error() {
+        let nan = Num::Double(f64::NAN);
+        let fnan = Num::Float(f32::NAN);
+        assert_eq!(nan.cmp_relational(Num::Int(0)), None, "NaN vs int is type error");
+        assert_eq!(Num::Int(0).cmp_relational(nan), None, "int vs NaN is type error");
+        assert_eq!(nan.cmp_relational(nan), None, "NaN vs NaN is type error");
+        assert_eq!(fnan.cmp_relational(Num::Double(1.0)), None, "float-NaN is type error");
+    }
+
+    /// The XPath relational compare uses f64 promotion for mixed/inexact pairs — it does
+    /// NOT refine the f64 collapse at 2^53 (unlike `cmp_total`). Two integers that
+    /// collapse to the same f64 compare Equal under relational semantics (XPath spec).
+    #[test]
+    fn cmp_relational_mixed_tier_uses_f64_promotion() {
+        use Ordering::*;
+        // 2^53 and 2^53+1 collapse to the same f64 when compared as int vs double.
+        let int_lo = Num::Int(TWO53);
+        let dbl = Num::Double(TWO53 as f64);
+        // Int vs Int: exact dec path — distinct
+        let int_hi = Num::Dec(Dec { mant: TWO53 as i128 + 1, scale: 0 });
+        assert_eq!(int_lo.cmp_relational(int_hi), Some(Less));
+        // Int vs Double: f64 promotion — the double IS 2^53 exactly, so Equal
+        assert_eq!(int_lo.cmp_relational(dbl), Some(Equal));
+        // ±0.0 are equal (f64 comparison)
+        assert_eq!(Num::Double(-0.0).cmp_relational(Num::Double(0.0)), Some(Equal));
     }
 }

--- a/skills/substrate/SKILL.md
+++ b/skills/substrate/SKILL.md
@@ -40,7 +40,10 @@ The XSD numeric value tower: `Num` (`Int(i64)` / `Dec(Dec)` / `Float(f32)` / `Do
 the fixed-point `Dec` struct (EXACT integer/decimal arithmetic, no f64 rounding), `ArithOp`
 (`Add`/`Sub`/`Mul`/`Div`), `RoundMode`, `as_numeric` (classifies an `oxrdf::Literal` into the
 tower), and the XSD lexical helpers `split_decimal`, `parse_xsd_f64`, `parse_xsd_f32`,
-`fmt_xsd_double`. Pulls `oxrdf` only when enabled.
+`fmt_xsd_double`. Pulls `oxrdf` only when enabled. Two ordering methods on `Num`:
+- `Num::cmp_total` — ORDER BY / MIN/MAX total order; NaN totalised FIRST.
+- `Num::cmp_relational` — SPARQL `<`/`>` / D-entailment / RIF numeric equality; NaN → `None`
+  (type error). [OPUS-4.8] sq-v5evr.
 
 ```toml
 [dependencies]


### PR DESCRIPTION
> 🤖 SPARQ agent — bead sq-v5evr (epic sq-6tykl, reasoner program sq-pbz04).

## Summary

- **Hoists the value-space relational comparator into `sparq-substrate`** (un-parked sq-v5evr). Adds `Num::cmp_relational` to the substrate `numeric` module: the XPath `op:numeric-less-than`/`op:numeric-equal` semantics — exact via the `Dec` tower for same-tier pairs (`Int`/`Dec`), `f64` promotion for mixed/inexact pairs, and `NaN → None` (SPARQL type error). This is the correct comparison for SPARQL `<`/`>` FILTER expressions, D-entailment value-space equality, and RIF `pred:numeric-equal` / `pred:numeric-less-than` builtins. The complementary `cmp_total` (ORDER BY total order, NaN first) is unchanged.
- **Wires `sparq-reason::compare`** to delegate its `num_compare` helper to `Num::cmp_relational` instead of duplicating the six-line mirror that has been parked as "sq-v5evr seam" since the substrate-compare PR.
- **Direct unit tests** in both crates pin: basic ordering, NaN-as-type-error, mixed-tier f64 promotion at the 2^53 collapse boundary, and the delegation contract.
- **Behaviour-neutral**: `compare_parity`, engine, and all reasoner tests green. No new feature flag — `cmp_relational` is on the existing `numeric` feature that `substrate-compare` already enables.
- README (120 lines, template-clean), `SKILL.md`, and `lib.rs` doc comment updated.

## Design decisions

`Num::cmp_relational` vs `Num::cmp_total`:
- `cmp_total` — ORDER BY total order; NaN is positioned FIRST (the XPath 3.1 `fn:sort` "NaN least" choice; sq-wjl8i).
- `cmp_relational` — relational `<`/`>` / value-space equality; NaN → `None` (SPARQL type error, the XPath `op:numeric-*` spec). Does NOT refine the f64 collapse at 2^53 for mixed int/double — that is an accepted consequence of the XPath relational promotion spec (unlike the ORDER BY total order which does refine it via `exact_cmp`).

The design record `research/substrate-remaining-design.md` §7 notes "sq-v5evr stays parked until a second concrete consumer"; the task brief un-parks it with D-entailment + RIF as those consumers.

## Scope note

This PR delivers the load-bearing invariant: the numeric relational comparison is now shared in the substrate. The `d_value_key`/`DValue` machinery in `dtype.rs` (the typed canonical key for D-entailment equality) is a larger surface tied to `sparq-core` temporal parsing and remains in the reasoner — relocating it would be non-neutral and sprawling (per the sq-vezew precedent for `Value`/`LitKind`). That migration is a follow-on bead if a second consumer needs the full typed-key API.

## Test plan

- [x] `cargo test -p sparq-substrate --features numeric` — 53 pass (incl. 3 new `cmp_relational` tests)
- [x] `cargo test -p sparq-reason --features substrate-compare` — all pass
- [x] `cargo test -p sparq-reason --test compare_parity --features substrate-compare` — 2 pass (parity oracle)
- [x] `cargo test -p sparq-engine` — 259 pass (no regressions)
- [x] `cargo clippy -p sparq-substrate --all-targets --features numeric,rows,join,compare -- -D warnings` — clean
- [x] `cargo clippy -p sparq-reason --all-targets --features substrate-compare,substrate-join,d-entail,rif-core,explain -- -D warnings` — clean
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean
- [x] `scripts/check-readme-template.py --enforce` — 0 deviations
- [x] `scripts/check-no-dyn-dispatch.py crates/sparq-substrate/src/numeric.rs` — 0 violations
- [x] Default feature state (feature OFF): builds clean, no tests broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)