### PR TITLE
ci(nightly): full-sweep lane — a11y + visual + cross-browser + tauri, consolidated failure routing (sq-ymr2e.11) [OPUS-4.8]

### DIFF
--- a/.github/workflows/nightly-full-sweep.yml
+++ b/.github/workflows/nightly-full-sweep.yml
@@ -1,0 +1,563 @@
+# [OPUS-4.8] sq-ymr2e.11 — NIGHTLY full-sweep lane (advisory-only, NEVER gates the merge queue).
+#
+# Design of record: research/web-gui-test-program.md §6.2. The per-PR lanes (site-e2e.yml /
+# site-visual.yml / gui.yml) are deliberately SCOPED for speed — chromium-only functional +
+# a11y, key-layout visual, Linux-only tauri smoke, all path-filtered. This lane is the wider,
+# slower net that runs on a SCHEDULE (and on manual dispatch), covering the dimensions the
+# per-PR path intentionally omits:
+#   • a11y / full-surface sweep — the whole site e2e + axe suite, run UNCONDITIONALLY (no path
+#     filter) and WITH the wasm bundle built, so the engine-gated states the light per-PR lane
+#     SKIPS are exercised too.
+#   • visual full-surface sweep — the container-pinned toHaveScreenshot suite.
+#   • cross-browser P1 journeys — firefox + webkit (per-PR runs chromium only).
+#   • tauri-driver GUI smoke — the real-IPC launch/round-trip smoke; its permanent home if the
+#     stabilization bead (sq-var9) ever demotes it from the per-PR gui.yml lane.
+#
+# WHY IT CANNOT GATE ci-summary. The `ci-summary / gate` aggregator polls the sibling
+# check-runs of a PR head / merge_group ref / push-to-main commit. THIS workflow triggers ONLY
+# on `schedule` + `workflow_dispatch`, so it never produces a check-run on any commit the gate
+# evaluates — it is structurally non-gating. As belt-and-suspenders (in case a trigger is ever
+# added), every routed job NAME carries the whole-word `advisory` token, which the aggregator
+# excludes by rule (`\b(advisory|informational)\b`). Two independent guarantees, both honest.
+#
+# FAILURE ROUTING. A nightly that opened one alert per failing TEST would drown the tracker and
+# stop being believed (§6.2: "alert fatigue is how nightlies die"). Instead the `route-failures`
+# job maintains EXACTLY ONE consolidated GitHub issue per failing CATEGORY, via
+# scripts/nightly/route_sweep_failures.py (find-or-refresh while red, auto-close on recovery),
+# always self-identified as a 🤖 SPARQ agent.
+#
+# HONEST COVERAGE NOTES (validate/extend on first CI runs; tracked as follow-ups, not silently):
+#   • The full-inventory AXE scan (axe on EVERY route, not just the key interactive states the
+#     per-PR a11y spec covers) and the FULL-SURFACE visual sweep (beyond the committed key
+#     layouts) both need additional SPEC authoring in site/e2e — this workflow runs the widest
+#     suites that exist TODAY and is ready to pick up new specs automatically.
+#   • firefox/webkit and the macOS/Windows tauri rows are documented-untested in THIS
+#     environment; the smoke-mode `--list` validation of each was reproduced locally, the full
+#     runs mirror the proven per-PR recipes and are validated on the first scheduled run.
+name: nightly-full-sweep
+
+on:
+  schedule:
+    # 05:17 UTC daily — off the top of the hour to dodge the cron thundering herd, and after
+    # the per-PR CI pool has quieted overnight.
+    - cron: "17 5 * * *"
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: "smoke = fast structural validation (reliably green, for manual dispatch); full = the real heavy suites"
+        type: choice
+        options: [smoke, full]
+        default: smoke
+      force_fail_categories:
+        description: "Comma-separated categories to FORCE-FAIL for routing validation (a11y,visual,cross-browser,tauri) or 'none'"
+        type: string
+        default: "none"
+      route_failures:
+        description: "Open/refresh consolidated issues on failure. Set false for a safe scratch-branch demo (routing runs dry, files nothing)."
+        type: boolean
+        default: true
+
+# Least-privilege default: read-only. Only the routing job elevates to issues: write.
+permissions:
+  contents: read
+
+# One nightly per ref; do NOT cancel a run in progress (a scheduled run and a manual dispatch
+# should not evict each other — they are cheap and infrequent).
+concurrency:
+  group: nightly-full-sweep-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  # Resolve the effective run config once. `schedule` carries no inputs, so it hard-codes the
+  # full/route path; `workflow_dispatch` honours the dispatch inputs (with defaults).
+  config:
+    name: resolve nightly run config (advisory)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      mode: ${{ steps.cfg.outputs.mode }}
+      route: ${{ steps.cfg.outputs.route }}
+      force_fail: ${{ steps.cfg.outputs.force_fail }}
+    steps:
+      - id: cfg
+        env:
+          EVENT: ${{ github.event_name }}
+          IN_MODE: ${{ inputs.mode }}
+          IN_ROUTE: ${{ inputs.route_failures }}
+          IN_FORCE: ${{ inputs.force_fail_categories }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = "schedule" ]; then
+            {
+              echo "mode=full"
+              echo "route=true"
+              echo "force_fail=none"
+            } >> "$GITHUB_OUTPUT"
+            echo "scheduled nightly → mode=full route=true"
+          else
+            {
+              echo "mode=${IN_MODE:-smoke}"
+              echo "route=${IN_ROUTE:-true}"
+              echo "force_fail=${IN_FORCE:-none}"
+            } >> "$GITHUB_OUTPUT"
+            echo "manual dispatch → mode=${IN_MODE:-smoke} route=${IN_ROUTE:-true} force_fail=${IN_FORCE:-none}"
+          fi
+
+  # ── Category 1: a11y / full-surface sweep (chromium) ─────────────────────────────────────
+  # full mode mirrors site-e2e.yml's recipe PLUS the lean wasm build (site-visual.yml), so the
+  # engine-gated a11y/render states the light per-PR lane SKIPS run here too. `npm run test:e2e`
+  # runs the whole site suite (surface-sweep full route inventory + a11y axe + functional).
+  a11y-sweep:
+    name: a11y full sweep (chromium, advisory)
+    needs: config
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Force-fail check (routing validation)
+        env:
+          FORCE_FAIL: ${{ needs.config.outputs.force_fail }}
+        run: |
+          set -euo pipefail
+          case ",${FORCE_FAIL}," in
+            *",a11y,"*) echo "::error::forced failure injected for category a11y (routing validation)"; exit 1 ;;
+          esac
+          echo "a11y: no forced failure"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Install npm dependencies (repo-root workspace lock)
+        run: npm ci
+
+      # SMOKE mode: prove the a11y + surface-sweep harness is wired + runnable, without paying
+      # the browser/wasm build. `--list` collects the tests (no browser launch, no web server).
+      - name: Smoke — a11y/surface harness is runnable (--list)
+        if: needs.config.outputs.mode == 'smoke'
+        run: npx playwright test --list e2e/a11y.spec.ts e2e/surface-sweep.spec.ts
+
+      # FULL mode: the real suite. Build the lean wasm bundle (mirrors site-visual.yml) so the
+      # in-tab-engine a11y/render states run, then the pinned Typst → spec/paper fragments the
+      # surface-sweep asserts on (mirrors site-e2e.yml), then the chromium suite.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        if: needs.config.outputs.mode == 'full'
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        if: needs.config.outputs.mode == 'full'
+        run: cargo install wasm-pack --locked
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: needs.config.outputs.mode == 'full'
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/target
+          key: site-e2e-hero-wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: site-e2e-hero-wasm-${{ runner.os }}-
+      - name: Build lean wasm bundle
+        if: needs.config.outputs.mode == 'full'
+        run: cd ../js && npm run build:wasm:lean
+      - name: Sync wasm bundle into site/public/wasm/
+        if: needs.config.outputs.mode == 'full'
+        run: npm run sync-wasm
+      - name: Install Playwright Chromium (+ OS deps)
+        if: needs.config.outputs.mode == 'full'
+        run: npx playwright install --with-deps chromium
+      - name: Install Typst CLI (pinned, SHA-256 verified)
+        if: needs.config.outputs.mode == 'full'
+        run: |
+          set -euo pipefail
+          TYPST_VERSION=v0.15.0
+          TYPST_SHA256=59b207df01be2dab9f13e80f73d04d7ff8273ffd46b3dd1b9eef5c60f3eeabea
+          url="https://github.com/typst/typst/releases/download/${TYPST_VERSION}/typst-x86_64-unknown-linux-musl.tar.xz"
+          curl -sSfL -o /tmp/typst.tar.xz "$url"
+          echo "${TYPST_SHA256}  /tmp/typst.tar.xz" | sha256sum -c -
+          tar -xf /tmp/typst.tar.xz -C /tmp
+          mkdir -p "$HOME/.local/bin"
+          cp /tmp/typst-x86_64-unknown-linux-musl/typst "$HOME/.local/bin/typst"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/typst" --version
+      - name: Build spec + paper fragments (Typst)
+        if: needs.config.outputs.mode == 'full'
+        run: |
+          npm run build-specs
+          npm run build-papers
+      - name: Full site e2e + a11y sweep (headless chromium)
+        if: needs.config.outputs.mode == 'full'
+        run: npm run test:e2e
+      - name: Upload Playwright report on failure
+        if: failure() && needs.config.outputs.mode == 'full'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-a11y-report
+          path: |
+            site/playwright-report/
+            site/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ── Category 2: visual full-surface sweep (container-pinned) ─────────────────────────────
+  visual-sweep:
+    name: visual full-surface sweep (container-pinned, advisory)
+    needs: config
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    defaults:
+      run:
+        working-directory: site
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Force-fail check (routing validation)
+        env:
+          FORCE_FAIL: ${{ needs.config.outputs.force_fail }}
+        run: |
+          set -euo pipefail
+          case ",${FORCE_FAIL}," in
+            *",visual,"*) echo "::error::forced failure injected for category visual (routing validation)"; exit 1 ;;
+          esac
+          echo "visual: no forced failure"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install npm dependencies (repo-root workspace lock)
+        run: npm ci
+
+      # SMOKE: enumerate the visual specs (SPARQ_VR defines the visual projects; the host guard
+      # is bypassed for LISTING only — no screenshots are taken, so nothing is compared).
+      - name: Smoke — visual harness is runnable (--list)
+        if: needs.config.outputs.mode == 'smoke'
+        env:
+          SPARQ_VR: "1"
+          SPARQ_VR_ALLOW_HOST: "1"
+        run: npx playwright test --list e2e/visual
+
+      # FULL: mirror site-visual.yml. Unlike the per-PR lane (which keeps the vr step
+      # continue-on-error to stay advisory-in-the-gate), here a mismatch FAILS the job so the
+      # router files a consolidated visual issue — the nightly routes instead of gating.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        if: needs.config.outputs.mode == 'full'
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        if: needs.config.outputs.mode == 'full'
+        run: cargo install wasm-pack --locked
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: needs.config.outputs.mode == 'full'
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/target
+          key: site-e2e-hero-wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: site-e2e-hero-wasm-${{ runner.os }}-
+      - name: Build lean wasm bundle
+        if: needs.config.outputs.mode == 'full'
+        run: cd ../js && npm run build:wasm:lean
+      - name: Sync wasm bundle into site/public/wasm/
+        if: needs.config.outputs.mode == 'full'
+        run: npm run sync-wasm
+      - name: Determinism grep gate (no waitForTimeout calls)
+        if: needs.config.outputs.mode == 'full'
+        run: npm run test:e2e:grep-gate
+      - name: Visual full-surface sweep vs committed baselines (digest-pinned container)
+        if: needs.config.outputs.mode == 'full'
+        run: npm run vr
+      - name: Upload visual diff artifacts on failure
+        if: failure() && needs.config.outputs.mode == 'full'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-visual-diffs
+          path: |
+            site/test-results/
+            site/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ── Category 3: cross-browser P1 journeys (firefox + webkit) ─────────────────────────────
+  cross-browser:
+    name: cross-browser P1 journeys firefox+webkit (advisory)
+    needs: config
+    runs-on: ubuntu-latest
+    timeout-minutes: 35
+    defaults:
+      run:
+        working-directory: site
+    env:
+      # The nightly-only firefox/webkit projects are opted in here (site/playwright.config.ts).
+      SPARQ_NIGHTLY_BROWSERS: "1"
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Force-fail check (routing validation)
+        env:
+          FORCE_FAIL: ${{ needs.config.outputs.force_fail }}
+        run: |
+          set -euo pipefail
+          case ",${FORCE_FAIL}," in
+            *",cross-browser,"*) echo "::error::forced failure injected for category cross-browser (routing validation)"; exit 1 ;;
+          esac
+          echo "cross-browser: no forced failure"
+
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: package-lock.json
+      - name: Install npm dependencies (repo-root workspace lock)
+        run: npm ci
+
+      # SMOKE: prove the firefox+webkit projects are defined and the journey specs collect under
+      # them (spec filters FIRST — Playwright's `--project` is variadic and would swallow a
+      # trailing path). No browsers installed, no server started.
+      - name: Smoke — firefox+webkit journeys are runnable (--list)
+        if: needs.config.outputs.mode == 'smoke'
+        run: |
+          npx playwright test --list \
+            e2e/home-runner.spec.ts e2e/download-page.spec.ts e2e/download-app.spec.ts \
+            e2e/site-nav.spec.ts e2e/command-palette.spec.ts \
+            --project firefox --project webkit
+
+      # FULL: the real journeys on firefox + webkit. home-runner drives the in-tab engine, so the
+      # lean wasm bundle is built + synced (mirrors site-e2e-hero.yml); the static journeys
+      # (download/nav/palette) need no Typst fragments.
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        if: needs.config.outputs.mode == 'full'
+        with:
+          targets: wasm32-unknown-unknown
+      - name: Install wasm-pack
+        if: needs.config.outputs.mode == 'full'
+        run: cargo install wasm-pack --locked
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        if: needs.config.outputs.mode == 'full'
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ github.workspace }}/target
+          key: site-e2e-hero-wasm-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
+          restore-keys: site-e2e-hero-wasm-${{ runner.os }}-
+      - name: Build lean wasm bundle
+        if: needs.config.outputs.mode == 'full'
+        run: cd ../js && npm run build:wasm:lean
+      - name: Sync wasm bundle into site/public/wasm/
+        if: needs.config.outputs.mode == 'full'
+        run: npm run sync-wasm
+      - name: Install Playwright firefox + webkit (+ OS deps)
+        if: needs.config.outputs.mode == 'full'
+        run: npx playwright install --with-deps firefox webkit
+      - name: P1 journeys on firefox + webkit
+        if: needs.config.outputs.mode == 'full'
+        run: |
+          npx playwright test \
+            e2e/home-runner.spec.ts e2e/download-page.spec.ts e2e/download-app.spec.ts \
+            e2e/site-nav.spec.ts e2e/command-palette.spec.ts \
+            --project firefox --project webkit
+      - name: Upload Playwright report on failure
+        if: failure() && needs.config.outputs.mode == 'full'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-cross-browser-report
+          path: |
+            site/playwright-report/
+            site/test-results/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ── Category 4: tauri-driver GUI smoke (Linux — authoritative, routed) ───────────────────
+  # The Linux row is the authoritative real-IPC smoke (research/web-gui-test-program.md §5); the
+  # non-Linux rows live in the separate `tauri-smoke-other-os` job (documented-untested, NOT
+  # routed). full mode mirrors gui.yml's `tauri-e2e` recipe.
+  tauri-smoke:
+    name: tauri-driver GUI smoke Linux (advisory)
+    needs: config
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Force-fail check (routing validation)
+        env:
+          FORCE_FAIL: ${{ needs.config.outputs.force_fail }}
+        run: |
+          set -euo pipefail
+          case ",${FORCE_FAIL}," in
+            *",tauri,"*) echo "::error::forced failure injected for category tauri (routing validation)"; exit 1 ;;
+          esac
+          echo "tauri: no forced failure"
+
+      # SMOKE: cheap structural check that the tauri e2e harness is present + wired (no native
+      # build, no webview). Verifies the harness the full run depends on exists on disk.
+      - name: Smoke — tauri e2e harness present
+        if: needs.config.outputs.mode == 'smoke'
+        run: |
+          set -euo pipefail
+          test -f gui/e2e/package.json
+          test -f gui/e2e/support/no-sleep-gate.sh
+          node -e "const p=require('./gui/e2e/package.json'); if(!p.scripts||!p.scripts['test:e2e']){process.exit(1)}"
+          echo "tauri e2e harness present + test:e2e script wired"
+
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        if: needs.config.outputs.mode == 'full'
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        if: needs.config.outputs.mode == 'full'
+        with:
+          node-version: 22
+      - name: Install Tauri system dependencies (+ WebKitWebDriver, xvfb)
+        if: needs.config.outputs.mode == 'full'
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libsoup-3.0-dev \
+            libjavascriptcoregtk-4.1-dev \
+            libappindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            webkit2gtk-driver \
+            xvfb
+      - name: Log WebKitWebDriver version
+        if: needs.config.outputs.mode == 'full'
+        run: |
+          echo "WebKitWebDriver: $(WebKitWebDriver --version 2>&1 || echo unknown)"
+          echo "webkit2gtk-driver apt: $(dpkg -l webkit2gtk-driver 2>/dev/null | tail -1)"
+      - name: Cache cargo (gui e2e)
+        if: needs.config.outputs.mode == 'full'
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            gui/src-tauri/target
+          key: gui-e2e-${{ runner.os }}-${{ hashFiles('gui/src-tauri/Cargo.lock', 'Cargo.lock') }}
+      - name: Install wasm-pack
+        if: needs.config.outputs.mode == 'full'
+        run: cargo install wasm-pack --locked
+      - name: Build the WASM bundle (shacl,jsonld; the in-tab engine)
+        if: needs.config.outputs.mode == 'full'
+        working-directory: js
+        run: |
+          npm install
+          npm run build:wasm
+      - name: Build the GUI frontend static export (root-relative; embedded by the shell)
+        if: needs.config.outputs.mode == 'full'
+        run: |
+          npm install
+          (cd gui/app && npm run build:tauri)
+      - name: Build the GUI shell (debug, embeds the frontend)
+        if: needs.config.outputs.mode == 'full'
+        working-directory: gui/src-tauri
+        run: cargo build
+      - name: Install tauri-driver@2.0.6 (pinned)
+        if: needs.config.outputs.mode == 'full'
+        run: cargo install tauri-driver@2.0.6 --locked
+      - name: Install the e2e harness dependencies
+        if: needs.config.outputs.mode == 'full'
+        working-directory: gui/e2e
+        run: npm ci
+      - name: Determinism gate — no arbitrary sleeps (no-sleep-gate)
+        if: needs.config.outputs.mode == 'full'
+        working-directory: gui/e2e
+        run: bash support/no-sleep-gate.sh
+      - name: Run the tauri-driver smoke (headless under xvfb; retry once on failure)
+        if: needs.config.outputs.mode == 'full'
+        working-directory: gui/e2e
+        env:
+          APP_BINARY: ${{ github.workspace }}/gui/src-tauri/target/debug/sparq-gui
+        run: |
+          ARTIFACTS_DIR="${{ github.workspace }}/gui/e2e/artifacts/attempt-1" \
+            xvfb-run --auto-servernum npm run test:e2e && exit 0
+          echo "[tauri-e2e-nightly] first attempt failed; retrying once (xvfb startup flake check)…"
+          ARTIFACTS_DIR="${{ github.workspace }}/gui/e2e/artifacts/attempt-2" \
+            xvfb-run --auto-servernum npm run test:e2e
+      - name: Upload failure artifacts
+        if: always() && needs.config.outputs.mode == 'full'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-tauri-e2e-artifacts
+          path: gui/e2e/artifacts/
+          if-no-files-found: ignore
+          retention-days: 7
+
+  # ── Category 4 (matrix skeleton): macOS + Windows tauri rows ─────────────────────────────
+  # DOCUMENTED-UNTESTED. The per-platform matrix is the design's stated aim (§6.2), but a real
+  # WKWebView (safaridriver) / WebView2 (msedgedriver) driver session on hosted macOS/Windows
+  # runners is unproven here. These rows carry `continue-on-error: true` and are NOT wired into
+  # the router, so a macOS/Windows harness gap can never fail the run nor file an issue — they
+  # are advisory probes to be hardened before promotion. Only runs in full mode.
+  tauri-smoke-other-os:
+    name: "tauri-driver GUI smoke ${{ matrix.os }} (advisory, documented-untested)"
+    needs: config
+    if: needs.config.outputs.mode == 'full'
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Documented-untested per-platform tauri driver plan
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::notice::tauri-driver on ${{ matrix.os }} is a documented-untested nightly probe."
+          echo "macOS  → WKWebView via safaridriver (Tauri macos webview); Windows → WebView2 via msedgedriver."
+          echo "This row is advisory (continue-on-error) and is NOT routed to a consolidated issue"
+          echo "until the per-platform driver session is proven. Bead: harden per-platform tauri matrix."
+
+  # ── Consolidated failure routing ─────────────────────────────────────────────────────────
+  # Reads each ROUTED category job's result and maintains one consolidated issue per FAILING
+  # category (create / refresh / auto-close-on-recovery). Runs always(), so it reports even when
+  # a category failed. `tauri-smoke-other-os` is intentionally excluded (advisory probe).
+  route-failures:
+    name: route consolidated failures (advisory)
+    needs: [config, a11y-sweep, visual-sweep, cross-browser, tauri-smoke]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          sparse-checkout: scripts/nightly/route_sweep_failures.py
+          sparse-checkout-cone-mode: false
+      - name: Route category results to consolidated issues
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          A11Y: ${{ needs.a11y-sweep.result }}
+          VISUAL: ${{ needs.visual-sweep.result }}
+          XBROWSER: ${{ needs.cross-browser.result }}
+          TAURI: ${{ needs.tauri-smoke.result }}
+          ROUTE: ${{ needs.config.outputs.route }}
+        run: |
+          set -euo pipefail
+          echo "category results: a11y=$A11Y visual=$VISUAL cross-browser=$XBROWSER tauri=$TAURI (route=$ROUTE)"
+          args=(--repo "$REPO" --run-url "$RUN_URL"
+                --result "a11y=$A11Y" --result "visual=$VISUAL"
+                --result "cross-browser=$XBROWSER" --result "tauri=$TAURI")
+          if [ "$ROUTE" != "true" ]; then
+            args+=(--dry-run)
+            echo "route_failures=false → routing runs DRY (no issues filed)"
+          fi
+          python3 scripts/nightly/route_sweep_failures.py "${args[@]}"

--- a/scripts/nightly/route_sweep_failures.py
+++ b/scripts/nightly/route_sweep_failures.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+# [OPUS-4.8] sq-ymr2e.11 — consolidated failure routing for the nightly full-sweep lane.
+#
+# WHY: a nightly all-surface sweep (a11y / visual / cross-browser / tauri) that opened one
+# alert per failing TEST would drown the tracker and the nightly would stop being believed
+# (research/web-gui-test-program.md §6.2: "alert fatigue is how nightlies die"). This router
+# instead maintains EXACTLY ONE consolidated GitHub issue per failing CATEGORY: it finds the
+# open issue for a category by its labels, REFRESHES it (a comment) while the category keeps
+# failing, CREATES it on the first failure, and CLOSES it (with a recovery comment) once the
+# category goes green again. Every artifact it files carries the 🤖 SPARQ-agent self-id.
+#
+# It is driven by the per-category job RESULTS of .github/workflows/nightly-full-sweep.yml
+# (`needs.<job>.result` ∈ success | failure | skipped | cancelled). It NEVER gates CI — the
+# nightly workflow runs only on schedule/workflow_dispatch, so it is never a sibling check-run
+# of the `ci-summary / gate` aggregator (see that workflow's advisory/skip semantics).
+#
+# Local reproduction (no API writes):
+#   python3 scripts/nightly/route_sweep_failures.py --dry-run --repo o/r \
+#       --run-url https://example/run/1 \
+#       --result a11y=failure --result visual=success --result cross-browser=skipped
+#
+# The category slugs are a CLOSED SET (CATEGORIES below); an unknown slug is rejected so a
+# workflow-side typo can never silently mis-route or spawn a stray issue class.
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+
+# The consolidated failure categories. Keep in lockstep with the category jobs in
+# .github/workflows/nightly-full-sweep.yml — one entry per job that routes.
+CATEGORIES: dict[str, dict[str, str]] = {
+    "a11y": {
+        "title": "accessibility full-sweep (axe / WCAG 2.1 AA)",
+        "scope": "the full-surface axe + surface-render sweep (site/e2e, all route inventory)",
+        "hint": "Inspect the a11y-sweep job log + the uploaded Playwright report; a serious/"
+        "critical axe violation is a hard fail, a rise in moderate/minor breaks the ratchet "
+        "(bench/a11y-baseline.json).",
+    },
+    "visual": {
+        "title": "visual-regression full-surface sweep",
+        "scope": "the container-pinned toHaveScreenshot sweep (site/e2e/visual)",
+        "hint": "Download the visual-regression-diffs artifact; if the change is intentional, "
+        "refresh baselines in a PR via `npm run vr:update`.",
+    },
+    "cross-browser": {
+        "title": "cross-browser P1 journeys (firefox + webkit)",
+        "scope": "the P1 functional journey suite on firefox + webkit (per-PR runs chromium only)",
+        "hint": "Reproduce with SPARQ_NIGHTLY_BROWSERS=1 npx playwright test <spec> "
+        "--project firefox --project webkit; an engine-specific behavioural gap is the "
+        "usual cause.",
+    },
+    "tauri": {
+        "title": "tauri-driver GUI smoke",
+        "scope": "the real-IPC tauri-driver launch/round-trip smoke (Linux row is authoritative)",
+        "hint": "Inspect the tauri-e2e-artifacts (driver log + screenshot). Environment-coupled "
+        "flake is expected occasionally; a persistent red across several nights is a real "
+        "regression.",
+    },
+}
+
+# Statuses that MEAN a category failed. Everything else (success / skipped / cancelled) does
+# not open an issue; success additionally CLOSES a stale open one (recovery).
+FAILING = {"failure", "timed_out", "action_required"}
+
+BASE_LABEL = "nightly-sweep"
+SELF_ID = "> 🤖 **SPARQ agent** — automated nightly full-sweep report (bead sq-ymr2e.11)."
+
+
+@dataclass
+class Result:
+    category: str
+    status: str
+
+
+def sh(args: list[str], *, check: bool = True, capture: bool = True) -> subprocess.CompletedProcess:
+    """Run a subprocess (gh CLI). Returns the CompletedProcess; raises on non-zero if check."""
+    return subprocess.run(
+        args,
+        check=check,
+        text=True,
+        capture_output=capture,
+    )
+
+
+def cat_label(category: str) -> str:
+    return f"sweep:{category}"
+
+
+def ensure_labels(category: str, dry_run: bool) -> None:
+    """Create the routing labels if absent (idempotent). Never fails the run on label ops."""
+    for name, color, desc in (
+        (BASE_LABEL, "5319e7", "Nightly full-sweep consolidated failure tracker (sq-ymr2e.11)"),
+        (cat_label(category), "b60205", f"Nightly sweep category: {category}"),
+    ):
+        if dry_run:
+            print(f"[dry-run] ensure label {name!r} (color={color})")
+            continue
+        # --force updates an existing label rather than erroring; a perms/transient error here
+        # must not sink the routing run, so we swallow it and let the create/comment step below
+        # surface any genuine problem.
+        sh(["gh", "label", "create", name, "--color", color, "--description", desc, "--force"], check=False)
+
+
+def find_open_issue(repo: str, category: str, dry_run: bool) -> int | None:
+    """Return the number of the single open consolidated issue for this category, or None."""
+    if dry_run:
+        # Test-only hook: SWEEP_DRYRUN_EXISTING=<cat>:<num>[,<cat>:<num>...] lets a local dry-run
+        # exercise the refresh / recovery-close branches without any GitHub API access.
+        import os
+
+        for spec in os.environ.get("SWEEP_DRYRUN_EXISTING", "").split(","):
+            if ":" in spec:
+                c, n = spec.split(":", 1)
+                if c.strip() == category and n.strip().isdigit():
+                    print(f"[dry-run] search open issue: label {BASE_LABEL} + {cat_label(category)} → #{n.strip()} (simulated)")
+                    return int(n.strip())
+        print(f"[dry-run] search open issue: label {BASE_LABEL} + {cat_label(category)} → none")
+        return None
+    cp = sh(
+        [
+            "gh", "issue", "list",
+            "--repo", repo,
+            "--state", "open",
+            "--label", BASE_LABEL,
+            "--label", cat_label(category),
+            "--json", "number,title",
+            "--limit", "10",
+        ],
+        check=False,
+    )
+    if cp.returncode != 0:
+        # A missing label makes `gh issue list --label` error; treat as "no open issue".
+        return None
+    try:
+        rows = json.loads(cp.stdout or "[]")
+    except json.JSONDecodeError:
+        return None
+    return rows[0]["number"] if rows else None
+
+
+def issue_title(category: str) -> str:
+    meta = CATEGORIES[category]
+    return f"🤖 nightly-sweep: {meta['title']} is failing"
+
+
+def issue_body(category: str, run_url: str) -> str:
+    meta = CATEGORIES[category]
+    return "\n".join(
+        [
+            SELF_ID,
+            "",
+            f"The nightly full-sweep lane's **{category}** category is failing.",
+            "",
+            f"- **Covers:** {meta['scope']}",
+            f"- **First-seen run:** {run_url}",
+            "",
+            "### What to check",
+            meta["hint"],
+            "",
+            "---",
+            "This is the single consolidated tracker for this category (research/"
+            "web-gui-test-program.md §6.2). While the category keeps failing, the nightly lane "
+            "**refreshes this issue with a comment** instead of opening new ones; it will "
+            "**close automatically** once the category goes green again. Do not open siblings.",
+        ]
+    )
+
+
+def refresh_comment(category: str, run_url: str) -> str:
+    return "\n".join(
+        [
+            SELF_ID,
+            "",
+            f"Still failing on the latest nightly run: {run_url}",
+        ]
+    )
+
+
+def recovery_comment(category: str, run_url: str) -> str:
+    return "\n".join(
+        [
+            SELF_ID,
+            "",
+            f"✅ Recovered — the **{category}** category passed on {run_url}. Closing this "
+            "consolidated tracker automatically. It will reopen (a fresh issue) if the category "
+            "regresses again.",
+        ]
+    )
+
+
+def create_issue(repo: str, category: str, run_url: str, dry_run: bool) -> None:
+    title = issue_title(category)
+    body = issue_body(category, run_url)
+    if dry_run:
+        print(f"[dry-run] CREATE issue: {title!r}")
+        print(f"          labels: {BASE_LABEL}, {cat_label(category)}")
+        print("          body:\n" + "\n".join("            " + ln for ln in body.splitlines()))
+        return
+    sh(
+        [
+            "gh", "issue", "create",
+            "--repo", repo,
+            "--title", title,
+            "--body", body,
+            "--label", BASE_LABEL,
+            "--label", cat_label(category),
+        ]
+    )
+    print(f"created consolidated issue for category {category!r}")
+
+
+def comment_issue(repo: str, number: int, body: str, dry_run: bool) -> None:
+    if dry_run:
+        print(f"[dry-run] COMMENT on #{number}:\n" + "\n".join("            " + ln for ln in body.splitlines()))
+        return
+    sh(["gh", "issue", "comment", str(number), "--repo", repo, "--body", body])
+
+
+def close_issue(repo: str, number: int, dry_run: bool) -> None:
+    if dry_run:
+        print(f"[dry-run] CLOSE #{number}")
+        return
+    sh(["gh", "issue", "close", str(number), "--repo", repo])
+
+
+def route_one(repo: str, result: Result, run_url: str, dry_run: bool) -> str:
+    category = result.category
+    ensure_labels(category, dry_run)
+    existing = find_open_issue(repo, category, dry_run)
+
+    if result.status in FAILING:
+        if existing is not None:
+            comment_issue(repo, existing, refresh_comment(category, run_url), dry_run)
+            return f"{category}: refreshed #{existing}"
+        create_issue(repo, category, run_url, dry_run)
+        return f"{category}: created new consolidated issue"
+
+    if result.status == "success":
+        if existing is not None:
+            comment_issue(repo, existing, recovery_comment(category, run_url), dry_run)
+            close_issue(repo, existing, dry_run)
+            return f"{category}: recovered — closed #{existing}"
+        return f"{category}: green (no open issue)"
+
+    # skipped / cancelled / unknown terminal — do not file, do not close (ambiguous signal).
+    return f"{category}: {result.status} — no action"
+
+
+def parse_results(pairs: list[str]) -> list[Result]:
+    out: list[Result] = []
+    for p in pairs:
+        if "=" not in p:
+            sys.exit(f"error: --result expects category=status, got {p!r}")
+        cat, status = p.split("=", 1)
+        cat, status = cat.strip(), status.strip().lower()
+        if cat not in CATEGORIES:
+            sys.exit(f"error: unknown category {cat!r} (known: {', '.join(CATEGORIES)})")
+        out.append(Result(cat, status))
+    return out
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser(description="Route nightly full-sweep failures to one consolidated issue per category.")
+    ap.add_argument("--repo", required=True, help="owner/name")
+    ap.add_argument("--run-url", required=True, help="URL of the triggering workflow run")
+    ap.add_argument(
+        "--result",
+        action="append",
+        default=[],
+        metavar="CATEGORY=STATUS",
+        help="repeatable; STATUS is the job result (success|failure|skipped|cancelled|...)",
+    )
+    ap.add_argument("--dry-run", action="store_true", help="print planned actions; make no API calls")
+    args = ap.parse_args(argv)
+
+    results = parse_results(args.result)
+    if not results:
+        print("no --result pairs supplied; nothing to route")
+        return 0
+
+    print(f"routing {len(results)} category result(s) for {args.repo} (dry_run={args.dry_run})")
+    for r in results:
+        outcome = route_one(args.repo, r, args.run_url, args.dry_run)
+        print(f"  - {outcome}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -29,6 +29,15 @@ import { defineConfig, devices } from "@playwright/test";
 // bare-host run even with SPARQ_VR=1 unless explicitly overridden — screenshots minted outside
 // the container are NOT comparable to the committed baselines.
 const SPARQ_VR = !!process.env.SPARQ_VR;
+
+// [OPUS-4.8] sq-ymr2e.11 — the NIGHTLY cross-browser projects. Per-PR e2e runs headless
+// chromium ONLY by design (research/web-gui-test-program.md §6.1); firefox + webkit run in the
+// nightly full-sweep lane (§6.2). Playwright projects can only be DEFINED in the config, so the
+// nightly lane opts them in with SPARQ_NIGHTLY_BROWSERS=1 and selects them with
+// `--project firefox --project webkit`. The env gate keeps a plain `npm run test:e2e` (and every
+// per-PR lane) byte-identical to before — the projects array is spread with `[]` when unset, so
+// the per-PR path is untouched.
+const SPARQ_NIGHTLY_BROWSERS = !!process.env.SPARQ_NIGHTLY_BROWSERS;
 if (SPARQ_VR && !existsSync("/ms-playwright") && !process.env.SPARQ_VR_ALLOW_HOST) {
   throw new Error(
     "SPARQ_VR=1 outside the pinned Playwright container (/ms-playwright not found). " +
@@ -112,6 +121,23 @@ export default defineConfig({
             name: "visual-mobile",
             testMatch: /e2e[\\/]visual[\\/].*\.spec\.ts/,
             use: { viewport: { width: 390, height: 844 } },
+          },
+        ]
+      : []),
+    // [OPUS-4.8] sq-ymr2e.11 — nightly-only firefox + webkit (see SPARQ_NIGHTLY_BROWSERS above).
+    // Same pinned 1280×720 viewport + the shared determinism `use` defaults; the container-only
+    // visual specs are excluded (visual baselines are chromium/Linux-container-pinned by policy).
+    ...(SPARQ_NIGHTLY_BROWSERS
+      ? [
+          {
+            name: "firefox",
+            use: { ...devices["Desktop Firefox"], viewport: { width: 1280, height: 720 } },
+            testIgnore: /e2e[\\/]visual[\\/]/,
+          },
+          {
+            name: "webkit",
+            use: { ...devices["Desktop Safari"], viewport: { width: 1280, height: 720 } },
+            testIgnore: /e2e[\\/]visual[\\/]/,
           },
         ]
       : []),


### PR DESCRIPTION
> 🤖 **SPARQ agent** (ci-infra) implementing bead **sq-ymr2e.11** — the nightly full-sweep lane from research/web-gui-test-program.md §6.2.

## What this wires + where

A **new nightly-only workflow** plus its routing helper and a minimal harness opt-in:

- **`.github/workflows/nightly-full-sweep.yml`** — the wider, slower net the per-PR lanes deliberately omit:
  - **a11y / full-surface sweep** (chromium) — the whole site e2e + axe suite, run **unconditionally** (no path filter) and **with the wasm bundle built**, so the engine-gated a11y/render states the light per-PR lane *skips* run here too.
  - **visual full-surface sweep** — the container-pinned `toHaveScreenshot` suite (`npm run vr`).
  - **cross-browser P1 journeys** — the functional journeys on **firefox + webkit** (per-PR is chromium-only by design).
  - **tauri-driver GUI smoke** — the real-IPC Linux smoke (authoritative, routed); macOS/Windows are a **documented-untested, non-routed** advisory matrix (`tauri-smoke-other-os`, `continue-on-error`).
- **`scripts/nightly/route_sweep_failures.py`** — consolidated failure routing: **exactly ONE** GitHub issue per **failing category** (create → refresh-while-red → auto-close-on-recovery), never one-per-test. Every artifact carries the 🤖 SPARQ-agent self-ID.
- **`site/playwright.config.ts`** — env-gated (`SPARQ_NIGHTLY_BROWSERS=1`) firefox+webkit projects. *(See "scope note" below.)*

## Invariants held

- **Never gates `ci-summary`** — two independent guarantees: (1) the workflow triggers **only** on `schedule` + `workflow_dispatch`, so it never produces a sibling check-run on any commit the `gate` evaluates; (2) as belt-and-suspenders, every routed job name carries the whole-word `advisory` token the aggregator excludes. **`ci-summary.yml` + `scripts/ci_summary_gate.py` are untouched.**
- **Per-PR path untouched** — the config change is byte-identical when `SPARQ_NIGHTLY_BROWSERS` is unset (the projects array spreads `[]`); no Rust touched, so the heavy Rust matrix path-filter still skips.
- **Zero overlap with the in-flight sq-ymr2e.12 PR (#1657)** — that PR edits `gui.yml` / `site-e2e-*.yml` / `site-visual.yml`; this adds a *new* file and touches none of them.

## Commands the lane runs (locally reproduced)

- a11y smoke: `npx playwright test --list e2e/a11y.spec.ts e2e/surface-sweep.spec.ts` ✅
- visual smoke: `SPARQ_VR=1 SPARQ_VR_ALLOW_HOST=1 npx playwright test --list e2e/visual` ✅
- cross-browser smoke: `SPARQ_NIGHTLY_BROWSERS=1 npx playwright test --list <journeys> --project firefox --project webkit` ✅ (enumerates firefox+webkit)
- routing: `python3 scripts/nightly/route_sweep_failures.py [--dry-run] --result <cat>=<status> …` — all four branches exercised in dry-run (create / refresh / recovery-close / no-op); guards + `py_compile` pass.
- Full (heavy) runs mirror the proven `site-e2e.yml` / `site-visual.yml` / `gui.yml` recipes.

## Gates

- **Valid YAML** (`python3 -c "import yaml; yaml.safe_load(...)"`) + **`actionlint` clean**.
- **All actions SHA-pinned** (reused the repo's existing pins; no new/floating tags).
- **`route-failures`** job has `issues: write` (least-privilege elsewhere `contents: read`).
- Config change is **type-clean** (no `playwright.config.ts` errors under tsc; Playwright's loader compiled + ran it in three `--list` reproductions).

## Compliance gap closed

Establishes the **nightly cross-surface regression net** (a11y / visual / cross-browser / tauri) with **consolidated, low-noise failure routing** — the §6.2 requirement — **without** widening the merge gate. Honest level: the lane runs the **widest suites that exist today**; three widenings need follow-up *spec* authoring (listed below), so this is "nightly scaffold + routing complete; coverage breadth grows as specs are added".

## Acceptance

- **Green on manual dispatch:** `mode=smoke` (default for dispatch) runs the fast `--list`/structural validations — reliably green, all reproduced locally.
- **Forced-failure routing:** dispatch with `force_fail_categories=a11y,visual` (any subset) fails exactly those category jobs → `route-failures` files exactly one consolidated issue per failing category. Use `route_failures=false` for a safe scratch-branch demo that runs routing **dry** (files nothing). *Live end-to-end dispatch is left for first-CI validation to avoid littering the tracker; the routing logic is fully proven locally.*
- **Not gating:** structural (schedule/dispatch-only) + name-token.

## Scope note (please steer if unwanted)

Per the ci-infra "tiny test-harness tweak genuinely required" exception: Playwright projects can **only** be defined in the config, and §6.2 mandates firefox+webkit nightly — so I added a ~12-line **env-gated** firefox/webkit block to `site/playwright.config.ts`. It is byte-identical for the per-PR path and does not conflict with #1657. If you'd rather this move to a follow-up, say the word and I'll gate the cross-browser leg behind it.

## Discovered follow-ups (not done here)

1. **Full-inventory AXE** — axe on *every* route (today: key interactive states only) needs a new/extended a11y spec.
2. **Full-surface visual** — visual specs beyond the committed key layouts.
3. **Per-platform tauri hardening** — prove the macOS (safaridriver/WKWebView) + Windows (msedgedriver/WebView2) driver sessions, then route them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)