### PR TITLE
fix(ci/flow-on): stop new-zk-circuit-gatecount mis-firing on zk/compose members (sq-fyzq7, #1655)

### DIFF
--- a/scripts/flow-on-rules.toml
+++ b/scripts/flow-on-rules.toml
@@ -28,17 +28,20 @@
 #
 #   # Trigger predicates (a rule fires when ALL present predicates pass; an
 #   # absent predicate is ignored). At least one must be present.
-#   when_paths      = ["glob", ...]   # fnmatch-style globs over changed files (ANY match)
-#   when_new_paths  = ["glob", ...]   # like when_paths but only counts ADDED files (status "A")
-#   when_label      = "label"          # PR must carry this label (opt-in rules)
-#   when_title      = "regex"          # case-insensitive regex over the PR title
+#   when_paths        = ["glob", ...]  # fnmatch-style globs over changed files (ANY match)
+#   when_new_paths    = ["glob", ...]  # like when_paths but only counts ADDED files (status "A")
+#   exclude_new_paths = ["glob", ...]  # added paths matching these are DROPPED from the
+#                                      #   when_new_paths pool (a sub-tree owned by another gate)
+#   when_label        = "label"        # PR must carry this label (opt-in rules)
+#   when_title        = "regex"        # case-insensitive regex over the PR title
 #
 #   # One or more follow-on issue templates. Placeholders expanded from the match:
 #   #   {pr}        merged PR number
 #   #   {pr_title}  merged PR title
-#   #   {crate}     crate dir name, when a crates/<crate>/... path matched
-#   #   {suite}     bench suite dir name, when a bench/<suite>/... path matched
-#   #   {surface}   skill surface dir name, when a skills/<surface>/... path matched
+#   #   {crate}       crate dir name, when a crates/<crate>/... path matched
+#   #   {suite}       bench suite dir name, when a bench/<suite>/... path matched
+#   #   {surface}     skill surface dir name, when a skills/<surface>/... path matched
+#   #   {zk_circuit}  top-level zk/ circuit family dir (excludes zk/compose/; never bench/)
 #   [[rule.create]]
 #   dedup_key = "kind-{crate}"            # required; expanded, then used as the idempotency key
 #   title     = "..."                      # required; issue title (placeholders expanded)
@@ -143,25 +146,40 @@ Re-run the competitor gather (`bench/` competitor harness) and refresh
 change. This is out-of-band work that cannot be gated at merge time.
 """
 
-# --- New ZK circuit member → gate-count baseline note --------------------------
-# The compose-member gate-count snapshot is enforced in-tree
-# (snapshot_covers_every_member). This flow-on covers NEW top-level `zk/` circuits
-# (outside zk/compose/), which that test does not yet reach — a baseline must be
-# added so the circuit's gate count is tracked.
+# --- New top-level ZK circuit FAMILY → gate-count baseline note ----------------
+# The compose-member gate-count snapshot is enforced in-tree by the HARD gate
+# `snapshot_covers_every_member` (every `zk/compose/` member), and G5's
+# `snapshot_covers_top_level_circuits` fails the build if a NEW top-level `bin`
+# circuit elsewhere under `zk/` lacks a baseline. This flow-on is the reactive
+# reminder for that new-FAMILY case.
+#
+# [OPUS-4.8] sq-fyzq7 (#1655): this rule previously mis-fired on a new
+# `zk/compose/<member>/` addition — `fnmatch`'s `*` crosses `/`, so
+# `zk/*/Nargo.toml` matched a two-level-deep member manifest — and named the
+# phantom circuit `zk-compose` (the `{suite}` placeholder prefers `bench/`, so it
+# picked up the `bench/zk-compose/` output dir). Those members are ALREADY
+# baselined and covered by `snapshot_covers_every_member`, so the follow-on was a
+# double false positive (merged #1608 → spurious #1655). Fixed two ways:
+#   * `exclude_new_paths = ["zk/compose/**"]` drops compose members from the match,
+#     so only a genuinely-NEW top-level family (a new `zk/<family>/`) fires it; and
+#   * the template uses the dedicated `{zk_circuit}` placeholder (derived from
+#     `zk/`, never `bench/`, and with `zk/compose/` excluded) instead of `{suite}`.
 [[rule]]
 id = "new-zk-circuit-gatecount"
-description = "A new top-level ZK circuit landed; record a gate-count baseline."
+description = "A new top-level ZK circuit family landed; record a gate-count baseline."
 when_new_paths = ["zk/*/Nargo.toml", "zk/*/src/main.nr"]
+exclude_new_paths = ["zk/compose/**"]
 
 [[rule.create]]
-dedup_key = "zk-gatecount-{suite}"
-title = "zk: add a gate-count baseline for new circuit {suite}"
+dedup_key = "zk-gatecount-{zk_circuit}"
+title = "zk: add a gate-count baseline for new circuit {zk_circuit}"
 labels = ["zk", "bench"]
 body = """
-Merged PR #{pr} ({pr_title}) added a new top-level ZK circuit `zk/{suite}`.
+Merged PR #{pr} ({pr_title}) added a new top-level ZK circuit `zk/{zk_circuit}`.
 
 Record a gate-count baseline for it (run the gate-count harness and add the row),
-so circuit bloat is caught by the regression gate. Compose members are already
-covered by `snapshot_covers_every_member`; top-level circuits are not yet, so
-this needs a baseline.
+so circuit bloat is caught by the regression gate. `zk/compose/` members are
+already covered by `snapshot_covers_every_member`; a new top-level circuit family
+also needs a `members` baseline (or an `exempt_circuits` entry) so
+`snapshot_covers_top_level_circuits` (Gate G5) passes.
 """

--- a/scripts/flow-on.py
+++ b/scripts/flow-on.py
@@ -91,6 +91,14 @@ class Rule:
     description: str = ""
     when_paths: list[str] = field(default_factory=list)
     when_new_paths: list[str] = field(default_factory=list)
+    # [OPUS-4.8] sq-fyzq7: added paths matching any of these globs are DROPPED
+    # from the `when_new_paths` matching pool. This lets a `when_new_paths` rule
+    # ignore a sub-tree that is already covered elsewhere — e.g.
+    # `new-zk-circuit-gatecount` uses it to skip `zk/compose/**` members (owned by
+    # the hard `snapshot_covers_every_member` gate) so a new compose member does
+    # not mis-fire the "new top-level circuit" follow-on. Only filters the
+    # `when_new_paths` check; other predicates are unaffected.
+    exclude_new_paths: list[str] = field(default_factory=list)
     when_label: str | None = None
     when_title: str | None = None
     creates: list[CreateTemplate] = field(default_factory=list)
@@ -129,6 +137,7 @@ def load_rules(path: Path) -> list[Rule]:
             description=raw.get("description", ""),
             when_paths=list(raw.get("when_paths", [])),
             when_new_paths=list(raw.get("when_new_paths", [])),
+            exclude_new_paths=list(raw.get("exclude_new_paths", [])),
             when_label=raw.get("when_label"),
             when_title=raw.get("when_title"),
             creates=creates,
@@ -163,7 +172,7 @@ def build_context(
     changed: list[str],
     added: list[str],
 ) -> dict[str, str]:
-    """Compute the placeholder dict for {pr}/{pr_title}/{crate}/{suite}/{surface}.
+    """Compute the placeholder dict for {pr}/{pr_title}/{crate}/{suite}/{surface}/{zk_circuit}.
 
     Prefer ADDED paths for crate/suite (the rules that use them are new-* rules),
     falling back to all changed paths so changed-surface rules still resolve."""
@@ -171,12 +180,24 @@ def build_context(
     crate = _first_segment_after("crates/", pool_for_dir)
     suite = _first_segment_after("bench/", pool_for_dir) or _first_segment_after("zk/", pool_for_dir)
     surface = _first_segment_after("skills/", pool_for_dir)
+    # [OPUS-4.8] sq-fyzq7: the NEW top-level `zk/` circuit family, for the
+    # `new-zk-circuit-gatecount` rule. Derived ONLY from `zk/` (NEVER `bench/` —
+    # the shared `{suite}` above prefers `bench/`, which made a #1608-shaped diff
+    # mis-name the circuit `zk-compose` from the `bench/zk-compose/` output dir),
+    # and with `zk/compose/` EXCLUDED: compose members are already covered by the
+    # hard `snapshot_covers_every_member` gate, so a new member must not surface as
+    # a phantom new "circuit". The rule's `exclude_new_paths` keeps it from firing
+    # in that case, so a non-empty value here only appears for a genuine new family.
+    zk_circuit = _first_segment_after(
+        "zk/", [p for p in pool_for_dir if not p.startswith("zk/compose/")]
+    )
     return {
         "pr": str(pr),
         "pr_title": pr_title,
         "crate": crate or "",
         "suite": suite or "",
         "surface": surface or "",
+        "zk_circuit": zk_circuit or "",
     }
 
 
@@ -211,8 +232,15 @@ def rule_matches(
     # ALL present predicates must pass; absent predicates are ignored.
     if rule.when_paths and not _any_glob_match(rule.when_paths, changed):
         return False
-    if rule.when_new_paths and not _any_glob_match(rule.when_new_paths, added):
-        return False
+    if rule.when_new_paths:
+        # [OPUS-4.8] sq-fyzq7: drop any added path under an `exclude_new_paths`
+        # sub-tree BEFORE the match, so a rule can ignore additions already owned
+        # by another gate (e.g. `zk/compose/**` members → `snapshot_covers_every_member`).
+        new_pool = added
+        if rule.exclude_new_paths:
+            new_pool = [p for p in added if not _any_glob_match(rule.exclude_new_paths, [p])]
+        if not _any_glob_match(rule.when_new_paths, new_pool):
+            return False
     if rule.when_label is not None and rule.when_label not in labels:
         return False
     if rule.when_title is not None and not re.search(rule.when_title, title, re.IGNORECASE):

--- a/scripts/tests/test_flow_on.py
+++ b/scripts/tests/test_flow_on.py
@@ -221,6 +221,81 @@ class NewBenchTest(unittest.TestCase):
         self.assertIn("widgets", dash[0].title)
 
 
+class ZkCircuitGatecountTest(unittest.TestCase):
+    """[OPUS-4.8] sq-fyzq7 (#1655): the `new-zk-circuit-gatecount` rule must fire
+    ONLY for a genuinely-new top-level `zk/<family>/` circuit — never for a new
+    member inside the existing `zk/compose/` family (those are already covered by
+    the hard `snapshot_covers_every_member` gate) — and must name the circuit from
+    `zk/`, never from a `bench/` output dir."""
+
+    def setUp(self):
+        self.rules = flow_on.load_rules(RULES)
+
+    def _zk_follow_ons(self, fos):
+        return [fo for fo in fos if fo.rule_id == "new-zk-circuit-gatecount"]
+
+    def test_new_compose_member_does_not_fire(self):
+        # REGRESSION (mis-fired #1655): merged #1608 added `zk/compose/<member>/`
+        # path_reach members (already baselined + covered by
+        # snapshot_covers_every_member) and modified the bench gate-count JSON.
+        # `fnmatch`'s `*` crosses `/`, so `zk/*/Nargo.toml` matched the two-level
+        # member manifest; `exclude_new_paths = ["zk/compose/**"]` now drops it.
+        added = [
+            "zk/compose/path_reach_d2_k1_n16/Nargo.toml",
+            "zk/compose/path_reach_d2_k1_n16/src/main.nr",
+        ]
+        changed = added + [
+            "bench/zk-compose/gate_counts_latest.json",  # MODIFIED, not added
+            "crates/sparq-zk-compose/tests/gate_count_snapshot.json",
+        ]
+        fos = flow_on.evaluate(
+            self.rules, 1608, "feat(zk/compose): path_reach family", changed, added, []
+        )
+        self.assertEqual(self._zk_follow_ons(fos), [])
+        # And no phantom `zk-compose` key leaks from any rule.
+        self.assertNotIn("zk-gatecount-zk-compose", {fo.dedup_key for fo in fos})
+
+    def test_new_top_level_family_fires_with_zk_derived_name(self):
+        # A genuinely-new top-level family under zk/ DOES fire, and the circuit is
+        # named from `zk/` (here `arith`), NOT from a co-changed `bench/` dir.
+        added = ["zk/arith/Nargo.toml", "zk/arith/src/main.nr"]
+        changed = added + ["bench/zk-compose/gate_counts_latest.json"]
+        fos = flow_on.evaluate(
+            self.rules, 2000, "feat(zk): arith circuit", changed, added, []
+        )
+        zk = self._zk_follow_ons(fos)
+        self.assertEqual(len(zk), 1)
+        self.assertEqual(zk[0].dedup_key, "zk-gatecount-arith")
+        self.assertIn("zk/arith", zk[0].body)
+        # The bench dir name must NOT contaminate the zk circuit name.
+        self.assertNotIn("zk-compose", zk[0].dedup_key)
+        self.assertNotIn("zk/zk-compose", zk[0].body)
+
+    def test_new_family_with_member_subdir_fires_once(self):
+        # A new WORKSPACE family (root + a member circuit) still yields exactly one
+        # follow-on, named for the family root.
+        added = [
+            "zk/lattice/Nargo.toml",
+            "zk/lattice/scan_a/Nargo.toml",
+            "zk/lattice/scan_a/src/main.nr",
+        ]
+        fos = flow_on.evaluate(
+            self.rules, 2100, "feat(zk): lattice family", added, added, []
+        )
+        zk = self._zk_follow_ons(fos)
+        self.assertEqual(len(zk), 1)
+        self.assertEqual(zk[0].dedup_key, "zk-gatecount-lattice")
+
+    def test_modified_only_zk_family_does_not_fire(self):
+        # Editing an EXISTING top-level circuit (changed, not added) must not fire
+        # the new-family rule.
+        changed = ["zk/arith/src/main.nr"]
+        fos = flow_on.evaluate(
+            self.rules, 2200, "tweak arith circuit", changed, [], []
+        )
+        self.assertEqual(self._zk_follow_ons(fos), [])
+
+
 class IdempotencyTest(unittest.TestCase):
     """The dedup-key marker is what open_issue_exists() searches for; verify the
     key is stable + embedded so a re-run is a no-op once the issue is open."""


### PR DESCRIPTION
> 🤖 SPARQ agent — autonomous agent working on sparq for @jeswr. Bead **sq-fyzq7**; flow-on issue **#1655** (from merged #1608).

## TL;DR — the requested baseline was a false positive; there is nothing to measure, so I fixed the defect that minted it

Bead sq-fyzq7 / #1655 asked me to "record a gate-count baseline for the new top-level ZK circuit `zk/zk-compose`". Investigating first (the honesty rule: a baseline row must be **measured**, never guessed): **there is no `zk/zk-compose` circuit, and nothing is un-baselined.**

- Merged **#1608** added the `zk/compose/path_reach_d{D}_k{K}_n{N}` members. Those are `zk/compose/` **members** — already baselined by #1608 in both `crates/sparq-zk-compose/tests/gate_count_snapshot.json` and `bench/zk-compose/gate_counts_latest.json`.
- All four `crates/sparq-zk-compose/tests/gate_count.rs` coverage tests pass locally (`snapshot_covers_every_member`, `snapshot_covers_top_level_circuits`, `bench_json_matches_snapshot` run without the toolchain; `gate_count_regression` cleanly skips — nargo/bb are absent on this box).
- There are **zero** top-level `bin` circuits outside `zk/compose/`, so Gate G5 (`snapshot_covers_top_level_circuits`) already covers the "new top-level circuit" case as a **hard** gate.

So inventing a `zk/zk-compose` row would fabricate an unmeasured number. Instead I fixed the root cause: the flow-on engine defect that produced the spurious issue.

## Root cause — a double false positive in `new-zk-circuit-gatecount`

1. **Mis-match:** `fnmatch`'s `*` crosses `/`, so `when_new_paths = ["zk/*/Nargo.toml"]` matched the two-level-deep `zk/compose/path_reach_d2_k1_n16/Nargo.toml` **member** manifest — a case owned by the hard `snapshot_covers_every_member` gate.
2. **Mis-name:** the `{suite}` placeholder prefers `bench/`, so it derived the phantom circuit name `zk-compose` from the `bench/zk-compose/` **output** dir — hence the nonexistent `zk/zk-compose` in #1655's title/body.

Reproduced exactly, and confirmed the real #1608 file list (all `zk/compose/*` additions) now mints **no** follow-on.

## The fix (Python docs-automation only — no crate/API/circuit change)

- `scripts/flow-on.py`: add an `exclude_new_paths` rule predicate that drops matching added paths from the `when_new_paths` pool (only that predicate; others unaffected); add a dedicated `{zk_circuit}` placeholder derived from `zk/` (never `bench/`) with `zk/compose/` excluded.
- `scripts/flow-on-rules.toml`: set `exclude_new_paths = ["zk/compose/**"]` on the rule and switch the template from `{suite}` → `{zk_circuit}`; refresh the stale rule comment + schema/placeholder docs.
- `scripts/tests/test_flow_on.py`: new `ZkCircuitGatecountTest` — a #1608-shaped diff mints **no** follow-on; a genuinely-new top-level family fires exactly once with a `zk/`-derived name (no `bench/` contamination, no phantom `zk-compose`); a member-subdir family fires once; a modified-only edit does not fire.

The rule name is unchanged, so the `test_rules_load_and_are_well_formed` taxonomy contract and the AGENTS.md §"Post-batch re-evaluation checklist" `flow-on:new-zk-circuit-gatecount` reference stay accurate.

## Gates run
- `python3 scripts/tests/test_flow_on.py` — **31/31 green** (4 new).
- `python3 -m py_compile scripts/flow-on.py scripts/tests/test_flow_on.py` — OK; TOML parses.
- End-to-end `flow-on.py --dry-run` over the real #1608 file list — **no rules triggered** (spurious #1655 cannot recur).
- Evidence (not a change of mine): `cargo test -p sparq-zk-compose --test gate_count` — 4/4 green (members already baselined).

No Rust crate, public API, feature flag, crate README, or SKILL.md is touched, so the cargo build/clippy/test/rustdoc feature-state and `readme-template` gates are N/A here.

## Not self-arming — per the brief.

Closes #1655.

🤖 Generated with [Claude Code](https://claude.com/claude-code)