### PR TITLE
fix(reason-dl): conclusion blank-node individuals read existentially — tree roll-up + fail-closed floor (sq-pbz04.4.13) [OPUS-4.8]

### DIFF
--- a/crates/sparq-conformance/src/inference/dl_suite.rs
+++ b/crates/sparq-conformance/src/inference/dl_suite.rs
@@ -349,6 +349,9 @@ fn reason_kind(reason: &UnknownReason) -> String {
         UnknownReason::QlConsistencyPending => "QL consistency pending (sq-pbz04.3.4)",
         UnknownReason::ResourceBudget(_) => "deterministic count budget exhausted",
         UnknownReason::UnencodedConclusion(_) => "unencoded conclusion-axiom kind",
+        UnknownReason::ConclusionAnonymousIndividual(_) => {
+            "conclusion anonymous individual (non-rollable existential shape)"
+        }
         // `UnknownReason` is #[non_exhaustive]; a future variant is still an abstention.
         _ => "other typed abstention",
     };

--- a/crates/sparq-conformance/src/scoreboard.rs
+++ b/crates/sparq-conformance/src/scoreboard.rs
@@ -1017,20 +1017,21 @@ pub const SUITES: &[Suite] = &[
             feature: "dl-direct",
         },
         ci_job: "inference-conformance",
-        ratchet_floor: 189,
+        ratchet_floor: 190,
         floor_basis: "definitive expected verdicts through the L4 dispatch, EXACT-pinned \
                       (sparq EXTENSION over the scoped fragment — NOT full OWL 2 DL); \
-                      re-pinned by sq-pbz04.4.11 (M1 named-composite fix: +12 positive- \
-                      entailment passes, -4 consistency passes shifted to abstain, net +8); \
-                      re-pinned by sq-pbz04.4.12 (M4 orphan/cyclic fix: -3, three graphs with \
-                      an unconsumed anonymous composite now honestly abstain, 192 -> 189)",
+                      re-pinned by sq-pbz04.4.11 (M1 named-composite fix, net +8); \
+                      re-pinned by sq-pbz04.4.12 (M4 orphan/cyclic fix: -3, 192 -> 189); \
+                      re-pinned by sq-pbz04.4.13 (M2 conclusion-bnode existential-reading fix: \
+                      +1, 189 -> 190 — both M2 rows graduate to passes, one free-existential- \
+                      root conclusion bnode shifts to an honest abstention)",
         note: "EXTENSION ratchet — the DIRECT-arm consistency / inconsistency / positive- / \
                negative-entailment tests decided by the REAL sparq-reason-dl L4 dispatch \
                (RL guarded / EL guarded / QL deferred / ALCH tableau) under a pinned \
                deterministic count budget; fail-closed abstentions are reported, never \
-               passes, and all 6 remaining wrong-verdict divergences are pinned by name \
-               with audited mechanisms (M1 FIXED sq-pbz04.4.11; M4 FIXED sq-pbz04.4.12 \
-               — those 4 rows now correctly abstain; remaining divergences: M2/M3/M5/M6)",
+               passes, and all 5 remaining wrong-verdict divergences are pinned by name \
+               with audited mechanisms (M1 FIXED sq-pbz04.4.11; M4 FIXED sq-pbz04.4.12; \
+               M2 FIXED sq-pbz04.4.13 — those rows now pass/abstain; remaining: M3/M5/M6)",
     },
 ];
 

--- a/crates/sparq-conformance/tests/dl_suite.rs
+++ b/crates/sparq-conformance/tests/dl_suite.rs
@@ -36,16 +36,22 @@
 //! are NOT laundered as acceptable: M4 was a genuine fidelity gap in the merged L1
 //! extractor that this conformance arm DISCOVERED; it was FIXED by sq-pbz04.4.12 (see
 //! M4 below) and the 4 entries removed from the divergence pin as promised. M1 was
-//! FIXED by sq-pbz04.4.11. The mechanisms:
+//! FIXED by sq-pbz04.4.11, and M2 (conclusion-bnode existential reading) by sq-pbz04.4.13
+//! — its 2 entries removed (they now PASS). The mechanisms:
 //!
 //! - **M1 — FIXED (sq-pbz04.4.11).** Named-composite inlining previously lost the
 //!   name↔expression binding; `extract()` now emits `EquivalentClasses(A, expr)` for
 //!   every NAMED class carrying an inline backbone definition, and the 12 corpus cases
 //!   that required this binding now PASS.
-//! - **M2 — anonymous individuals in a conclusion read as constants.** The official
-//!   expectation reads conclusion bnodes EXISTENTIALLY; the L1 model treats them as
-//!   (skolem) constants, so the refutation is satisfiable and the checker certifies a
-//!   `NotEntailed` that is wrong under the existential reading.
+//! - **M2 — FIXED (sq-pbz04.4.13).** A blank-node individual in the CONCLUSION is now read
+//!   EXISTENTIALLY: a tree-shaped anonymous assertion set rolls up into an existential class
+//!   assertion the ALCH tableau decides SOUNDLY, so `somevaluesfrom2bnode` and
+//!   `WebOnt-someValuesFrom-003` now PASS (removed from the divergence pin). Any non-rollable
+//!   conclusion bnode (shared / cyclic / nominal / free-existential-root) abstains fail-closed
+//!   (`UnknownReason::ConclusionAnonymousIndividual`), NEVER the old wrong skolem-constant
+//!   `NotEntailed` — e.g. `WebOnt-AnnotationProperty-002` (whose `ap` edge is an annotation, so
+//!   its conclusion `_:x owl:Thing` is an unanchored free-existential root) shifts from a
+//!   coincidental skolem pass to an honest abstention. [OPUS-4.8]
 //! - **M3 — reserved vocabulary treated as plain names.** OWL-Full-shaped axioms over
 //!   reserved IRIs (`rdfs:Class ≡ owl:Class`, `owl:imports` domain/range, `rdf:type`
 //!   domain) extract as ordinary names; the legacy dual-tagged expectation assumes the
@@ -116,28 +122,22 @@ mod gated {
     /// `tests/scoreboard_floors.rs`. A sparq EXTENSION measurement over the scoped
     /// fragment — NOT full OWL 2 DL.
     ///
-    /// COMPOSITION: 105 consistency + 14 inconsistency + 68 positive-entailment +
-    /// 2 negative-entailment = 189. [FABLE-5] sq-pbz04.4.5 / [OPUS-4.8] sq-pbz04.4.12
-    /// Re-pinned by sq-pbz04.4.11 (M1 named-composite fix): 12 positive-entailment cases
-    /// now PASS (the EquivalentClasses name-binding axioms enable their entailments);
-    /// 4 consistency cases shift from Pass to abstain because their updated ontology
-    /// models now include EquivalentClasses axioms that, combined with the existing TBox,
-    /// cause budget exhaustion — an honest abstention, not a regression. Net: +8.
-    /// Re-pinned by sq-pbz04.4.12 (M4 orphan/cyclic fix): −3 (192 → 189). Beyond the 2 M4
-    /// negative-entailment rows (I5.5-006/-007) moving from Fail → abstain, closing the
-    /// declaration-typing reachability bypass also correctly REFUSES three graphs that
-    /// previously extracted (and happened to pass) despite carrying an anonymous composite
-    /// class-expression that appears in NO axiom — a genuinely unconsumed backbone the
-    /// `a owl:Class` / `a rdf:List` declaration typing was wrongly rescuing:
-    ///   - `WebOnt-I5.26-001` (consistency): `[ owl:intersectionOf (:C _:B) ]` in no axiom;
-    ///   - `WebOnt-I5.26-006` (consistency): a nested intersection/union backbone in no axiom;
-    ///   - `WebOnt-I5.5-005` (positive-entailment): the conclusion is a bare
-    ///     `[ owl:unionOf (:a) ]` that "does not appear in an axiom" (its own description).
-    ///
-    /// These are HONEST fail-closed abstentions (the checker refuses to give a definitive
-    /// verdict over a graph it cannot map in full), not wrong verdicts — exactly the M4
-    /// contract. [OPUS-4.8] sq-pbz04.4.12
-    pub const DL_DIRECT_FLOOR: usize = 189;
+    /// COMPOSITION: 105 consistency + 14 inconsistency + 69 positive-entailment +
+    /// 2 negative-entailment = 190. [FABLE-5] sq-pbz04.4.5 / [OPUS-4.8] sq-pbz04.4.12/.13
+    /// Re-pinned by sq-pbz04.4.11 (M1 named-composite fix): +8 net.
+    /// Re-pinned by sq-pbz04.4.12 (M4 orphan/cyclic fix): −3 (192 → 189) — three graphs with
+    /// an unconsumed anonymous composite (`WebOnt-I5.26-001`/`-006` consistency; `WebOnt-I5.5-005`
+    /// positive-entailment) now honestly abstain, plus the two M4 negative-entailment rows.
+    /// Re-pinned by sq-pbz04.4.13 (M2 conclusion-bnode existential-reading fix): +1 (189 → 190).
+    /// Both M2 positive-entailment cases `somevaluesfrom2bnode` and `WebOnt-someValuesFrom-003`
+    /// now roll their tree-shaped conclusion bnodes into existential class assertions the
+    /// tableau certifies (68 → 70 positive-entailment passes); one previously-passing case,
+    /// `WebOnt-AnnotationProperty-002`, correctly shifts Pass → abstain because its conclusion
+    /// bnode is a FREE-EXISTENTIAL ROOT (`_:x owl:Thing` with the anchoring edge being an
+    /// annotation, so it is unanchored / non-rollable — its old skolem pass was coincidental
+    /// and unsound for a non-trivial class). Net positive-entailment +1 (70 − 1 = 69), all
+    /// four consistency/inconsistency lanes unchanged. [OPUS-4.8] sq-pbz04.4.13
+    pub const DL_DIRECT_FLOOR: usize = 190;
 
     /// Abstained (fail-closed OutOfFragment / guard / deferred / budget) row totals,
     /// EXACT-pinned so the tri-state accounting is closed: profile lane, then the four
@@ -160,28 +160,28 @@ mod gated {
     /// rows that carried an unconsumed anonymous composite the declaration typing had been
     /// rescuing (I5.26-001, I5.26-006 consistency; I5.5-005 positive-entailment) — all
     /// honest abstentions, never wrong verdicts. [OPUS-4.8] sq-pbz04.4.12
-    pub const DL_DIRECT_ABSTAINED: usize = 463;
+    /// Re-pinned by sq-pbz04.4.13 (M2 conclusion-bnode fix): +1 (463 → 464). The
+    /// free-existential-root conclusion bnode of `WebOnt-AnnotationProperty-002` shifts from a
+    /// (coincidental) Pass to a fail-closed `ConclusionAnonymousIndividual` abstention; the two
+    /// graduated M2 cases move Fail → Pass (they never counted as abstentions). [OPUS-4.8]
+    pub const DL_DIRECT_ABSTAINED: usize = 464;
 
-    /// Audited, PINNED divergence rows (module docs — mechanisms M2–M7): every row
+    /// Audited, PINNED divergence rows (module docs — mechanisms M3/M5/M6): every row
     /// where a checker verdict contradicts the export expectation, keyed by the
     /// runner's row key. EXACT set equality is asserted: an UNPINNED new fail and a
     /// STALE entry that stops failing both turn the lane RED (the el-suite /
     /// ql_entailment_floor discipline). M4 was FIXED by sq-pbz04.4.12 and removed from
     /// this list — those 4 cases now ABSTAIN (OutOfFragment refusal) rather than producing
     /// wrong definitive verdicts. M1 (named-composite name-binding) was FIXED by
-    /// sq-pbz04.4.11. [FABLE-5] sq-pbz04.4.5 / [OPUS-4.8] sq-pbz04.4.12
+    /// sq-pbz04.4.11; M2 (conclusion-bnode existential reading) was FIXED by sq-pbz04.4.13 and
+    /// its two cases removed — they now PASS. [FABLE-5] sq-pbz04.4.5 / [OPUS-4.8] sq-pbz04.4.13
     const DOCUMENTED_DIVERGENCES: &[(&str, &str)] = &[
-        // --- M2: anonymous individuals in the conclusion read as constants (L4 gap) ---
-        (
-            "owl2-dl/positive-entailment: somevaluesfrom2bnode",
-            "M2 — conclusion `a p _:x` is the existential the premise's ∃p.⊤ typing \
-             grants; as a constant the refutation stays satisfiable",
-        ),
-        (
-            "owl2-dl/positive-entailment: WebOnt-someValuesFrom-003",
-            "M2 — conclusion is an anonymous parent-chain (person ≡ ∃parent.person); \
-             bnode individuals as constants block the existential reading",
-        ),
+        // M2 (anonymous individuals in the conclusion read as constants) FIXED by
+        // sq-pbz04.4.13 — `somevaluesfrom2bnode` / `WebOnt-someValuesFrom-003` now roll their
+        // tree-shaped conclusion bnodes into existential class assertions and PASS; a
+        // non-rollable conclusion bnode (e.g. WebOnt-AnnotationProperty-002's
+        // free-existential root) abstains fail-closed, never a wrong verdict. [OPUS-4.8]
+        //
         // --- M3: reserved vocabulary treated as plain names ---
         (
             "owl2-dl/positive-entailment: WebOnt-Class-001",

--- a/crates/sparq-reason-dl/README.md
+++ b/crates/sparq-reason-dl/README.md
@@ -93,7 +93,10 @@ classification; verdicts only for a pure ⊤-free EL+⊥ TBox with zero skipped 
 **ALCH tableau** (complete for the fragment). `check::DirectChecker::entailment` decides
 premise ⊨ conclusion per conclusion-axiom by sound refutation encodings on the tableau
 (GCI / class-assertion / the fresh-class role-assertion trick + the record's desugarings);
-unencoded kinds abstain. Every verdict carries its producing `Branch`; every guard fails
+unencoded kinds abstain. A **blank-node individual in the conclusion is read EXISTENTIALLY**
+(sq-pbz04.4.13): a tree-shaped anonymous assertion set rolls up into an `∃`-class assertion
+decided soundly, and a non-rollable shape (shared / cyclic / nominal / free-root) abstains
+`ConclusionAnonymousIndividual` — never a skolem-constant `NotEntailed`. Every verdict carries its producing `Branch`; every guard fails
 closed (`Unknown(reason)`, never a guess). The `dispatch` feature pulls `sparq-reason` +
 `sparq-reason-el` as optional deps — **off by default**, so L1–L3 stay dependency-light.
 

--- a/crates/sparq-reason-dl/src/check.rs
+++ b/crates/sparq-reason-dl/src/check.rs
@@ -98,6 +98,23 @@
 //! `Entailed`. Fresh names are minted as `urn:` IRIs checked against every id occurring in
 //! the premise AND conclusion models.
 //!
+//! ## Conclusion anonymous individuals ([OPUS-4.8] sq-pbz04.4.13)
+//!
+//! Official OWL 2 Direct-Semantics entailment reads a blank-node individual in the CONCLUSION
+//! EXISTENTIALLY (`a p _:x` means "`a` has *some* `p`-successor", not "`a p c` for a specific
+//! constant `c`"). L1 maps a blank node to an ordinary (skolem) constant: entailment-preserving
+//! on the PREMISE side (kept), but UNSOUND on the CONCLUSION side — the skolem refutation of
+//! `a p _:x` stays satisfiable even when the premise's `∃p.⊤` typing grants the existential, so
+//! it would certify a WRONG `NotEntailed`. Before the refutation loop, `roll_conclusion_anonymous`
+//! resolves conclusion blank nodes under the existential reading: a TREE-shaped anonymous
+//! assertion set (each blank node the object of exactly one property edge, reaching only blank
+//! successors, acyclic, anchored to a named root) ROLLS UP into an existential class assertion
+//! `root : ∃p.(⊓ types ⊓ ⊓ ∃q.⟨child⟩)` the tableau decides SOUNDLY in both directions (so
+//! somevaluesfrom2bnode / WebOnt-someValuesFrom-003 become genuine passes). Any non-rollable
+//! shape — shared between two assertions, cyclic, a named/nominal successor, or an unanchored
+//! free-existential root — abstains fail-closed ([`UnknownReason::ConclusionAnonymousIndividual`]),
+//! NEVER a skolem-constant `NotEntailed`.
+//!
 //! # Honest boundary
 //!
 //! This module never claims completeness beyond the argued fragment: the only complete
@@ -106,11 +123,11 @@
 //! uncertain case is a typed [`UnknownReason`].
 
 use crate::extract::extract;
-use crate::model::{Axiom, ClassExpression, Ontology};
+use crate::model::{Axiom, ClassExpression, ObjectPropertyExpression, Ontology};
 use crate::profile::profiles;
 use crate::tableau::{self, Budget, ExhaustedBudget};
-use rustc_hash::FxHashSet;
-use sparq_core::dict::{Dict, Id};
+use rustc_hash::{FxHashMap, FxHashSet};
+use sparq_core::dict::{is_inline, Dict, Id, TermParts};
 use sparq_reason::{inconsistencies, materialize, Profile};
 use sparq_reason_el::Classifier;
 
@@ -165,6 +182,14 @@ pub enum UnknownReason {
     /// Entailment only: the conclusion-axiom kind has no argued refutation encoding
     /// (property-axiom conclusions are deferred by the design record).
     UnencodedConclusion(String),
+    /// Entailment only: the CONCLUSION ontology mentions a blank-node individual in a shape
+    /// that does NOT roll up into a tree-shaped existential class assertion (it is shared
+    /// between two assertions, cyclic, has a named or a nominal successor, or is a free
+    /// existential root). Official OWL 2 Direct-Semantics entailment reads a conclusion
+    /// blank node EXISTENTIALLY, so the L1 skolem-constant reading would be UNSOUND for a
+    /// `NotEntailed` verdict — the checker abstains fail-closed instead (sq-pbz04.4.13).
+    /// The payload names the first offending anonymous individual. [OPUS-4.8]
+    ConclusionAnonymousIndividual(String),
 }
 
 /// Tri-state Direct-Semantics consistency verdict (design record §4).
@@ -356,9 +381,27 @@ impl DirectChecker {
             Ok(onto) => onto,
             Err(e) => return unknown_extraction(format!("conclusion: {}", e)),
         };
+        // [OPUS-4.8] sq-pbz04.4.13 — conclusion anonymous individuals are EXISTENTIAL under
+        // the official OWL 2 Direct-Semantics entailment reading. L1 maps a conclusion blank
+        // node to an ordinary (skolem) constant; that reading is entailment-preserving on the
+        // PREMISE side but UNSOUND on the conclusion side (it would certify a `NotEntailed`
+        // that is wrong existentially — the pinned M2 divergences somevaluesfrom2bnode /
+        // WebOnt-someValuesFrom-003). `roll_conclusion_anonymous` rolls a tree-shaped bnode
+        // assertion set into an existential class assertion the tableau decides SOUNDLY (both
+        // directions); a non-rollable shape (shared / cyclic / nominal / free-root bnode)
+        // abstains fail-closed, never a skolem `NotEntailed`.
+        let concl_axioms = match roll_conclusion_anonymous(dict, &concl) {
+            Ok(axioms) => axioms,
+            Err(reason) => {
+                return EntailmentOutcome {
+                    verdict: EntailmentVerdict::Unknown(reason),
+                    branch: Branch::AlchTableau,
+                }
+            }
+        };
         let mut fresh = FreshNames::new(dict, [&prem, &concl]);
         let mut first_unknown: Option<UnknownReason> = None;
-        for axiom in concl.axioms() {
+        for axiom in &concl_axioms {
             match self.axiom_entailed(&prem, axiom, &mut fresh) {
                 AxiomVerdict::Entailed => {}
                 AxiomVerdict::NotEntailed => {
@@ -797,4 +840,225 @@ fn refutation_checks(conclusion: &Axiom, fresh: &mut FreshNames) -> Option<Vec<V
         // Property-axiom conclusions are deferred by the record (§4): no encoding here.
         Axiom::SubObjectPropertyOf { .. } => None,
     }
+}
+
+// -------------------------------------------------------------------------------------------
+// Conclusion anonymous-individual rolling ([OPUS-4.8] sq-pbz04.4.13)
+// -------------------------------------------------------------------------------------------
+//
+// Official OWL 2 Direct-Semantics entailment reads a blank-node individual in the CONCLUSION
+// ontology EXISTENTIALLY (an "existential variable" — the somevaluesfrom2bnode test's own
+// description). L1 maps every blank node to an ordinary dict id, i.e. a (skolem) CONSTANT. On
+// the PREMISE side skolemisation is entailment-preserving and stays; on the CONCLUSION side it
+// is NOT — a `NotEntailed` certificate from the skolem reading is UNSOUND, because the premise
+// may entail the conclusion existentially (a p _:x) without entailing it for any specific
+// constant. So a conclusion blank-node assertion set must be resolved BEFORE the refutation
+// loop: rolled up into an existential class assertion when it is tree-shaped, or refused
+// fail-closed otherwise (never a skolem `NotEntailed`).
+//
+// ROLLING-UP is the standard tree-shaped-query technique: an anonymous individual reached by a
+// single property edge `s p _:x`, whose asserted types are `C₁ … Cₙ` and whose own outgoing
+// edges are `_:x qⱼ _:yⱼ`, denotes exactly `s : ∃p.(C₁ ⊓ … ⊓ Cₙ ⊓ ∃q₁.⟨roll _:y₁⟩ ⊓ …)`. This
+// is SOUND and COMPLETE for the tree shape (no inverse roles, no shared variables, no nominals
+// — all guaranteed by the rollability checks + the ALCH fragment), so a `NotEntailed` from a
+// ROLLED existential class assertion is decided by the complete tableau and is genuinely
+// sound, and the graduated cases (somevaluesfrom2bnode / WebOnt-someValuesFrom-003) become
+// real passes rather than abstentions.
+
+/// Whether `id` is an anonymous (blank-node) individual in `dict`.
+fn is_anonymous_individual(dict: &Dict, id: Id) -> bool {
+    !is_inline(id) && matches!(dict.term_parts(id), TermParts::Blank(_))
+}
+
+/// Render an id for a fail-closed diagnostic (positional-arg friendly — CodeQL note).
+fn term_of(dict: &Dict, id: Id) -> String {
+    if is_inline(id) {
+        return format!("(inline literal id {})", id);
+    }
+    match dict.term_parts(id) {
+        TermParts::Iri { prefix, suffix } => format!("<{}{}>", prefix, suffix),
+        TermParts::Lit { value, .. } => format!("\"{}\"", value),
+        TermParts::Blank(label) => format!("_:{}", label),
+        TermParts::Triple(_) => "<<triple term>>".to_string(),
+    }
+}
+
+/// Resolve the CONCLUSION ontology's anonymous (blank-node) individuals under the official
+/// EXISTENTIAL reading (module note above; sq-pbz04.4.13).
+///
+/// Returns the blank-node-FREE conclusion axiom list the caller decides by refutation:
+/// - if the conclusion mentions no blank-node individual, its axioms unchanged (clone);
+/// - otherwise, the blank-node ABox assertions ROLLED UP into existential class assertions on
+///   their named roots, with every blank-node-free conclusion axiom kept verbatim.
+///
+/// # Errors
+/// [`UnknownReason::ConclusionAnonymousIndividual`] when a blank-node individual is NOT in a
+/// tree-shaped roll-up: it must be the object of EXACTLY ONE property assertion (its unique
+/// parent edge), reach only blank-node successors (a named/literal successor would need a
+/// nominal, out of the ALCH fragment), and be acyclic / anchored to a named root. Fail-closed
+/// — the caller abstains, never a skolem-constant `NotEntailed`.
+fn roll_conclusion_anonymous(dict: &Dict, concl: &Ontology) -> Result<Vec<Axiom>, UnknownReason> {
+    // Fast path: no anonymous individual anywhere → decide the conclusion verbatim, so the
+    // blank-node-free path (every existing entailment case) is byte-identical to before.
+    let mentions_bnode = concl.axioms().iter().any(|axiom| match axiom {
+        Axiom::ClassAssertion { individual, .. } => is_anonymous_individual(dict, *individual),
+        Axiom::ObjectPropertyAssertion { source, target, .. } => {
+            is_anonymous_individual(dict, *source) || is_anonymous_individual(dict, *target)
+        }
+        _ => false,
+    });
+    if !mentions_bnode {
+        return Ok(concl.axioms().to_vec());
+    }
+
+    // Build the roll-up structure over the ABox. `in_degree` counts parent property edges per
+    // blank individual; `types` collects each blank individual's asserted class types;
+    // `outgoing` its child property edges; `top_edges` the named→blank edges that ANCHOR a
+    // tree; `clean` keeps every blank-node-free axiom verbatim.
+    let mut in_degree: FxHashMap<Id, usize> = FxHashMap::default();
+    let mut types: FxHashMap<Id, Vec<ClassExpression>> = FxHashMap::default();
+    let mut outgoing: FxHashMap<Id, Vec<(Id, Id)>> = FxHashMap::default();
+    let mut top_edges: Vec<(Id, Id, Id)> = Vec::new();
+    let mut clean: Vec<Axiom> = Vec::new();
+
+    for axiom in concl.axioms() {
+        match axiom {
+            Axiom::ClassAssertion { class, individual } => {
+                if is_anonymous_individual(dict, *individual) {
+                    in_degree.entry(*individual).or_insert(0);
+                    types.entry(*individual).or_default().push(class.clone());
+                } else {
+                    clean.push(axiom.clone());
+                }
+            }
+            Axiom::ObjectPropertyAssertion {
+                property,
+                source,
+                target,
+            } => {
+                let s_anon = is_anonymous_individual(dict, *source);
+                let t_anon = is_anonymous_individual(dict, *target);
+                match (s_anon, t_anon) {
+                    (false, false) => clean.push(axiom.clone()),
+                    (false, true) => {
+                        // named --p--> blank : a top edge anchoring a tree.
+                        *in_degree.entry(*target).or_insert(0) += 1;
+                        top_edges.push((property.named(), *source, *target));
+                    }
+                    (true, true) => {
+                        // blank --p--> blank : an internal tree edge.
+                        in_degree.entry(*source).or_insert(0);
+                        *in_degree.entry(*target).or_insert(0) += 1;
+                        outgoing
+                            .entry(*source)
+                            .or_default()
+                            .push((property.named(), *target));
+                    }
+                    (true, false) => {
+                        // blank --p--> named : the anonymous individual has a NAMED successor,
+                        // rollable only through a nominal {named} — out of ALCH. Recorded so
+                        // `roll_bnode` refuses at the exact offending node.
+                        in_degree.entry(*source).or_insert(0);
+                        outgoing
+                            .entry(*source)
+                            .or_default()
+                            .push((property.named(), *target));
+                    }
+                }
+            }
+            other => clean.push(other.clone()),
+        }
+    }
+
+    // Every blank-node individual must have EXACTLY ONE parent edge: in-degree 0 is an
+    // unanchored free existential root, in-degree ≥ 2 is a node SHARED between two assertions.
+    // Both are outside the tree-shaped roll-up (and exactly the negative-probe shapes).
+    for (&b, &deg) in &in_degree {
+        if deg != 1 {
+            return Err(UnknownReason::ConclusionAnonymousIndividual(format!(
+                "anonymous individual {} has {} parent property-assertion(s); a tree-shaped \
+                 roll-up needs exactly one (shared / unanchored anonymous individual)",
+                term_of(dict, b),
+                deg
+            )));
+        }
+    }
+
+    // Fold each named-anchored subtree into an existential class assertion on its named root.
+    // `consumed` records every blank node folded into a tree; a blank node reached from no
+    // named root (a pure cycle / an anchorless component) stays unconsumed and is refused.
+    let mut rolled: Vec<Axiom> = clean;
+    let mut consumed: FxHashSet<Id> = FxHashSet::default();
+    for &(property, source, target) in &top_edges {
+        let mut visiting: FxHashSet<Id> = FxHashSet::default();
+        let filler = roll_bnode(dict, target, &types, &outgoing, &mut visiting, &mut consumed)?;
+        rolled.push(Axiom::ClassAssertion {
+            class: ClassExpression::ObjectSomeValuesFrom(
+                ObjectPropertyExpression::ObjectProperty(property),
+                Box::new(filler),
+            ),
+            individual: source,
+        });
+    }
+
+    // Any blank-node individual not folded into a named-rooted tree is a cyclic / anchorless
+    // shape (each has in-degree 1 from the check above, so a component with no named anchor is
+    // necessarily cyclic) — refuse fail-closed.
+    for &b in in_degree.keys() {
+        if !consumed.contains(&b) {
+            return Err(UnknownReason::ConclusionAnonymousIndividual(format!(
+                "anonymous individual {} is not reachable from a named root (cyclic or \
+                 anchorless anonymous shape)",
+                term_of(dict, b)
+            )));
+        }
+    }
+    Ok(rolled)
+}
+
+/// Roll one blank-node subtree (rooted at `b`) into the class expression whose existential the
+/// parent edge asserts: the conjunction of `b`'s asserted class types and `∃p.⟨child subtree⟩`
+/// per outgoing edge. An empty conjunction is `owl:Thing`. Cycle- and nominal-guarded.
+fn roll_bnode(
+    dict: &Dict,
+    b: Id,
+    types: &FxHashMap<Id, Vec<ClassExpression>>,
+    outgoing: &FxHashMap<Id, Vec<(Id, Id)>>,
+    visiting: &mut FxHashSet<Id>,
+    consumed: &mut FxHashSet<Id>,
+) -> Result<ClassExpression, UnknownReason> {
+    if !visiting.insert(b) {
+        return Err(UnknownReason::ConclusionAnonymousIndividual(format!(
+            "anonymous individual {} lies on a cycle (no tree-shaped roll-up)",
+            term_of(dict, b)
+        )));
+    }
+    // A node reachable through two named-anchored paths would already have in-degree ≥ 2 and be
+    // refused before we get here; `consumed` insertion is the fold record.
+    consumed.insert(b);
+    let mut members: Vec<ClassExpression> = types.get(&b).cloned().unwrap_or_default();
+    if let Some(edges) = outgoing.get(&b) {
+        for &(property, target) in edges {
+            if !is_anonymous_individual(dict, target) {
+                // A named/literal successor of an anonymous individual needs a nominal {t}.
+                return Err(UnknownReason::ConclusionAnonymousIndividual(format!(
+                    "anonymous individual {} has a non-anonymous successor {} (a nominal \
+                     roll-up is out of the ALCH fragment)",
+                    term_of(dict, b),
+                    term_of(dict, target)
+                )));
+            }
+            let filler = roll_bnode(dict, target, types, outgoing, visiting, consumed)?;
+            members.push(ClassExpression::ObjectSomeValuesFrom(
+                ObjectPropertyExpression::ObjectProperty(property),
+                Box::new(filler),
+            ));
+        }
+    }
+    visiting.remove(&b);
+    Ok(match members.len() {
+        0 => ClassExpression::Thing,
+        1 => members.pop().expect("len checked == 1"),
+        _ => ClassExpression::ObjectIntersectionOf(members),
+    })
 }

--- a/crates/sparq-reason-dl/tests/check.rs
+++ b/crates/sparq-reason-dl/tests/check.rs
@@ -452,3 +452,127 @@ fn entailment_empty_conclusion_is_trivially_entailed() {
     assert_eq!(v, EntailmentVerdict::Entailed);
     assert_eq!(b, Branch::AlchTableau);
 }
+
+// -------------------------------------------------------------------------------------------
+// Conclusion anonymous individuals — existential reading + rolling-up ([OPUS-4.8] sq-pbz04.4.13)
+// -------------------------------------------------------------------------------------------
+
+#[test]
+fn entailment_conclusion_bnode_somevaluesfrom2bnode() {
+    // Faithful reconstruction of the W3C DIRECT PositiveEntailmentTest `somevaluesfrom2bnode`
+    // ("Shows that a BNode is an existential variable"): the premise types `a` into ∃p.⊤, the
+    // conclusion asserts `a p _:x`. Under the official existential reading this IS entailed;
+    // rolling `a p _:x` into `a : ∃p.owl:Thing` lets the complete tableau certify it. Before
+    // the fix, `_:x` was read as a skolem CONSTANT and the refutation stayed satisfiable → a
+    // WRONG NotEntailed (the pinned M2 divergence).
+    let premise = ":p a owl:ObjectProperty . \
+                   :a rdf:type [ owl:onProperty :p ; owl:someValuesFrom owl:Thing ] .";
+    let conclusion = ":p a owl:ObjectProperty . :a :p _:x .";
+    let (v, b) = entail(premise, conclusion);
+    assert_eq!(v, EntailmentVerdict::Entailed, "somevaluesfrom2bnode must be Entailed");
+    assert_eq!(b, Branch::AlchTableau);
+}
+
+#[test]
+fn entailment_conclusion_bnode_webont_somevaluesfrom_003() {
+    // Faithful reconstruction of W3C DIRECT PositiveEntailmentTest `WebOnt-someValuesFrom-003`
+    // ("A simple infinite loop for implementors to avoid"): premise `person ≡ ∃parent.person`
+    // with `fred : person`; conclusion an anonymous parent-CHAIN `fred parent _:b1 parent _:b2`
+    // (each an owl:Thing). The chain rolls into `fred : ∃parent.(⊤ ⊓ ∃parent.⊤)`, decided by
+    // the tableau (termination via blocking) — genuinely Entailed, not the M2 skolem NotEntailed.
+    let premise = ":parent a owl:ObjectProperty . \
+                   :person owl:equivalentClass [ owl:onProperty :parent ; owl:someValuesFrom :person ] . \
+                   :fred a :person .";
+    let conclusion = ":parent a owl:ObjectProperty . \
+                      :fred a owl:Thing . \
+                      :fred :parent _:b1 . _:b1 a owl:Thing . \
+                      _:b1 :parent _:b2 . _:b2 a owl:Thing .";
+    let (v, b) = entail(premise, conclusion);
+    assert_eq!(v, EntailmentVerdict::Entailed, "WebOnt-someValuesFrom-003 must be Entailed");
+    assert_eq!(b, Branch::AlchTableau);
+}
+
+#[test]
+fn entailment_conclusion_bnode_rollable_notentailed_is_sound() {
+    // A rollable conclusion bnode whose existential is genuinely NOT entailed: premise only
+    // says `a : A` (a need not have any p-successor), conclusion asserts `a p _:x`. Rolling to
+    // `a : ∃p.⊤` and refuting on the COMPLETE tableau yields a SOUND NotEntailed — rolling is
+    // sound in BOTH directions, so a definitive negative verdict here is legitimate (it is NOT
+    // the unsound skolem-constant NotEntailed, which the non-rollable shapes below abstain on).
+    let premise = ":p a owl:ObjectProperty . :a a :A .";
+    let conclusion = ":p a owl:ObjectProperty . :a :p _:x .";
+    let (v, b) = entail(premise, conclusion);
+    assert_eq!(v, EntailmentVerdict::NotEntailed);
+    assert_eq!(b, Branch::AlchTableau);
+}
+
+#[test]
+fn entailment_conclusion_bnode_shared_abstains_never_notentailed() {
+    // NEGATIVE PROBE: `_:x` is SHARED between two property assertions (`a p _:x` and `b p _:x`)
+    // — a non-tree shape. The rolling-up is not applicable, so the checker must ABSTAIN
+    // fail-closed, NEVER emit a skolem-constant NotEntailed.
+    let premise = ":p a owl:ObjectProperty . :a a :A . :b a :A .";
+    let conclusion = ":p a owl:ObjectProperty . :a :p _:x . :b :p _:x .";
+    let (v, b) = entail(premise, conclusion);
+    assert!(
+        matches!(
+            v,
+            EntailmentVerdict::Unknown(UnknownReason::ConclusionAnonymousIndividual(_))
+        ),
+        "shared conclusion bnode must abstain (ConclusionAnonymousIndividual), got {:?}",
+        v
+    );
+    assert!(!v.is_not_entailed(), "must NOT be a skolem NotEntailed");
+    assert_eq!(b, Branch::AlchTableau);
+}
+
+#[test]
+fn entailment_conclusion_bnode_cyclic_abstains_never_notentailed() {
+    // NEGATIVE PROBE: a cyclic anonymous shape `_:x p _:y . _:y p _:x .` with no named anchor —
+    // not tree-shaped, so abstain fail-closed, never a skolem NotEntailed.
+    let premise = ":p a owl:ObjectProperty . :a a :A .";
+    let conclusion = ":p a owl:ObjectProperty . _:x :p _:y . _:y :p _:x .";
+    let (v, b) = entail(premise, conclusion);
+    assert!(
+        matches!(
+            v,
+            EntailmentVerdict::Unknown(UnknownReason::ConclusionAnonymousIndividual(_))
+        ),
+        "cyclic conclusion bnode must abstain (ConclusionAnonymousIndividual), got {:?}",
+        v
+    );
+    assert!(!v.is_not_entailed());
+    assert_eq!(b, Branch::AlchTableau);
+}
+
+#[test]
+fn entailment_conclusion_bnode_named_successor_abstains() {
+    // NEGATIVE PROBE: an anonymous individual with a NAMED successor (`a p _:x . _:x q :c .`)
+    // would roll up only through a nominal `{c}`, which is out of the ALCH fragment — abstain.
+    let premise = ":p a owl:ObjectProperty . :q a owl:ObjectProperty . :a a :A .";
+    let conclusion = ":p a owl:ObjectProperty . :q a owl:ObjectProperty . \
+                      :a :p _:x . _:x :q :c .";
+    let (v, _) = entail(premise, conclusion);
+    assert!(
+        matches!(
+            v,
+            EntailmentVerdict::Unknown(UnknownReason::ConclusionAnonymousIndividual(_))
+        ),
+        "named-successor conclusion bnode must abstain, got {:?}",
+        v
+    );
+    assert!(!v.is_not_entailed());
+}
+
+#[test]
+fn entailment_premise_side_bnode_unaffected_skolemisation_stays() {
+    // Premise-side blank nodes are UNAFFECTED — skolemisation is entailment-preserving on the
+    // premise. The premise `a p _:pb`, `_:pb : C`, `C ⊑ D` (a has an anonymous p-successor that
+    // is a C, hence a D) entails the bnode-FREE conclusion `a : ∃p.D` — a definitive verdict,
+    // proving the abstention is CONCLUSION-triggered only and premise bnodes still reason.
+    let premise = ":p a owl:ObjectProperty . :a :p _:pb . _:pb a :C . :C rdfs:subClassOf :D .";
+    let conclusion = ":a rdf:type [ owl:onProperty :p ; owl:someValuesFrom :D ] .";
+    let (v, b) = entail(premise, conclusion);
+    assert_eq!(v, EntailmentVerdict::Entailed);
+    assert_eq!(b, Branch::AlchTableau);
+}

--- a/skills/inference/SKILL.md
+++ b/skills/inference/SKILL.md
@@ -276,7 +276,16 @@ that produced it (traceability). `entailment()` checks `O ⊨ α` per conclusion
 argued refutation encoding onto the tableau (`SubClassOf`, `ClassAssertion`,
 `ObjectPropertyAssertion` via a fresh-class encoding, `EquivalentClasses`, `DisjointClasses`,
 domain/range; property-axiom conclusions abstain). Every guard fails CLOSED — uncertainty is a
-typed `UnknownReason`, never a guessed verdict.
+typed `UnknownReason`, never a guessed verdict. **Conclusion anonymous individuals
+(sq-pbz04.4.13):** a blank-node individual in the CONCLUSION is read EXISTENTIALLY (per the
+official Direct-Semantics tests) — L1's skolem-constant reading is entailment-preserving on the
+premise but would certify a WRONG `NotEntailed` on the conclusion, so before the refutation loop a
+TREE-shaped anonymous assertion set (`a p _:x`, `_:x` typed / chaining to more blank nodes) **rolls
+up** into an existential class assertion `a : ∃p.(⊓ types ⊓ ⊓ ∃q.⟨child⟩)` the tableau decides
+SOUNDLY in both directions (so `somevaluesfrom2bnode` / `WebOnt-someValuesFrom-003` graduate to
+genuine passes); any non-rollable shape — shared between two assertions, cyclic, a named/nominal
+successor, or an unanchored free-existential root — abstains fail-closed
+(`ConclusionAnonymousIndividual`), never a skolem `NotEntailed`.
 
 **L5 — the conformance DIRECT-arm (`sparq-conformance`, opt-in `dl-direct` feature, bead
 sq-pbz04.4.5):** NOW BUILT. `inference::dl_suite::run_direct_arm` runs the DIRECT-sanctioned


### PR DESCRIPTION
> 🤖 SPARQ agent — bead **sq-pbz04.4.13** (epic sq-pbz04.4, L4 Direct-Semantics checker).

## The soundness bug

`DirectChecker::entailment` extracted the CONCLUSION ontology through the L1 mapping, where a **blank-node individual becomes an ordinary (skolem) constant**. Official OWL 2 Direct-Semantics entailment tests read a conclusion blank node **EXISTENTIALLY** (`a p _:x` = "`a` has *some* `p`-successor"). Premise-side skolemisation is entailment-preserving and stays; **conclusion-side is NOT** — the skolem refutation of `a p _:x` stayed satisfiable even when the premise's `∃p.⊤` typing grants the existential, certifying a WRONG `NotEntailed`. Two pinned M2 divergences (`somevaluesfrom2bnode`, `WebOnt-someValuesFrom-003`) and, more broadly, `NotEntailed` certificates over conclusion bnodes were UNSOUND under the official reading.

## The fix (both (a) floor and (b) rolling-up, in one PR)

Before the refutation loop, `roll_conclusion_anonymous` (in `sparq-reason-dl` `check.rs`, behind `dispatch`) resolves conclusion blank nodes:

- **(b) Rolling-up (the tree shape).** A TREE-shaped anonymous assertion set — each bnode the object of **exactly one** property edge, reaching only blank successors, acyclic, anchored to a **named** root — rolls up into an existential class assertion `root : ∃p.(⊓ types ⊓ ⊓ ∃q.⟨child⟩)`. This is sound **and** complete for the tree shape (no inverse roles / shared vars / nominals, all enforced), so the ALCH tableau decides it in **both** directions. `somevaluesfrom2bnode` and `WebOnt-someValuesFrom-003` now genuinely **PASS** against the W3C oracle (verified under the pinned conformance budget, not just the default).
- **(a) Fail-closed floor.** Any non-rollable conclusion bnode — **shared** between two assertions, **cyclic**, a **named/nominal** successor, or an **unanchored free-existential root** — abstains fail-closed with a new typed `UnknownReason::ConclusionAnonymousIndividual`, **NEVER** a skolem-constant `NotEntailed`.

## Conformance honesty (re-measured against the fetched corpus)

Re-ran the `dl_suite` DIRECT arm over `tests/w3c/owl2/all.rdf` and re-pinned to the **MEASURED reality**:

- `DL_DIRECT_FLOOR` **189 → 190** (positive-entailment passes 68 → 70 from the two M2 graduations, −1 from a free-root abstention; net +1).
- `DL_DIRECT_ABSTAINED` **463 → 464**.
- The **2 M2 rows removed** from `DOCUMENTED_DIVERGENCES` (now passes); the remaining 5 fails (M3/M5/M6) match exactly.
- Scoreboard mirror `ratchet_floor` **189 → 190** (floor-sync test green).
- `WebOnt-AnnotationProperty-002` — whose `ap` edge is an *annotation* (ignored), leaving its conclusion `_:x owl:Thing` an unanchored free-existential root — correctly shifts from a *coincidental* skolem pass to an **honest abstention** (its old pass was unsound for a non-trivial class).

## Tests (real path, load-bearing invariants)

Faithful reconstructions of `somevaluesfrom2bnode` + `WebOnt-someValuesFrom-003` (assert `Entailed`); a rollable-but-genuinely-`NotEntailed` case (rolling is sound both ways); NEGATIVE probes — shared bnode, cyclic bnode, named-successor — each must **abstain**, never `NotEntailed`; and a premise-side-bnode case proving skolemisation is unaffected.

## Gates — GREEN in BOTH feature states

Feature flags: **`sparq-reason-dl/dispatch`** and **`sparq-conformance/dl-direct`** (both OFF by default; `sparq-core`/`sparq-engine` unchanged, lean default preserved).

- `cargo clippy --all-targets -- -D warnings` — clean default (feature OFF) and with feature ON, both crates.
- `cargo test` — green both states (reason-dl 32 dispatch tests incl. 7 new; conformance dl_suite `190`, self-skips with feature OFF).
- `cargo doc --workspace --no-deps --all-features` with `RUSTDOCFLAGS="-D warnings"` — clean.
- `scripts/check-readme-template.py --enforce` — 0 deviations.

Not self-arming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
