### PR TITLE
ci: wire test_flow_on.py into flow-on-gates lane as gating step (sq-8hfhi)

### DIFF
--- a/.github/workflows/flow-on-gates.yml
+++ b/.github/workflows/flow-on-gates.yml
@@ -203,6 +203,16 @@ jobs:
         # Runs the hermetic gate unit tests so a regression in any gate script is
         # caught at PR time (the suite is stdlib-only; no git/network).
         run: python3 scripts/tests/test_gates.py
+      # [SONNET-4.6] sq-8hfhi: wire the reactive flow-on engine tests into CI so a
+      # rule/engine regression (like the #1655 false-positive fnmatch/{suite} defect
+      # fixed in #1664) is caught pre-merge, not post-merge. 31 tests covering: rule
+      # loading + well-formedness, evaluate() rule firing (new-crate / changed-surface /
+      # pub-API diff plumbing / competitor-label / new-bench / ZK circuit gate-count),
+      # idempotency-key stability, dry-run output correctness, and the CI guard that
+      # refuses to mint issues outside CI. Stdlib-only, no network, no git. Gating: the
+      # job name carries no advisory/informational token, so ci-summary gates on it.
+      - name: Self-test the flow-on reactive engine (rule loading + evaluate + dry-run — sq-8hfhi)
+        run: python3 scripts/tests/test_flow_on.py
       - name: Read PR labels (for the config-internal escape hatch)
         id: labels
         # [OPUS-4.8] Mirror G2: run on BOTH pull_request AND merge_group so the


### PR DESCRIPTION
> 🤖 SPARQ agent (Sonnet 4.6) — bead sq-8hfhi

## Summary

- Adds `python3 scripts/tests/test_flow_on.py` as a gating step in the `config-documented` job of `.github/workflows/flow-on-gates.yml`, alongside the existing `test_gates.py` step (proactive merge-gates G1/G2/G3/G6).
- 31 hermetic tests covering: rule loading/well-formedness, `evaluate()` rule firing (new-crate, changed-surface, pub-API diff plumbing, competitor-label, new-bench, ZK circuit gate-count), idempotency-key stability, dry-run output correctness, and the CI guard that refuses to mint issues outside CI.
- The step is stdlib-only, no network, no git, completes in under 0.1 s. The job name carries no `advisory`/`informational` token, so `ci-summary / gate` gates on it.
- **Motivation:** The #1655 false-positive `fnmatch/{suite}` defect (fixed in #1664) was only caught post-merge because these tests ran manually. Now they gate pre-merge.

## Placement rationale

The `config-documented` job in `flow-on-gates.yml` already runs on every `pull_request` and `merge_group` (no path filter), already has Python set up, and already runs `test_gates.py` (proactive gates). Adding `test_flow_on.py` here keeps all flow-on tests co-located without requiring a new job or extra Python setup step.

## Gate aggregator intact

- No new workflow file; the new step lives inside an existing job in `flow-on-gates.yml`.
- No new branch-protection required context; `ci-summary / gate` discovers the job's check-run automatically by polling siblings on the HEAD commit.
- The existing G1/G2/G3/G6 gating steps in the same job are unchanged.

## Other unwired tests found during audit

The following `scripts/tests/*.py` files are hermetic and locally green but not yet wired in CI. Listed here as follow-up work (not in scope for this PR per the bead brief):

- `test_check_new_bench_registered.py` — hermetic tests for G3 (new-bench→registry+dashboard, advisory in flow-on-gates.yml). The advisory job runs the script itself but not this unit test. Follow-up: add a step to the G3 job or to `config-documented`.
- `test_cone_coverage.py` — hermetic tests for `cone_coverage.py` (bead sq-6vshe.8). Natural home: wherever `cone_coverage.py` is invoked in CI.
- `test_drift_scan.py` — hermetic tests for `drift-scan.py` (bead sq-ncvq.11). 37 tests, fast. Natural home: `docs-quality.yml` `ci-scripts` job.
- `test_feature_matrix_tiers.py` — hermetic tests for the feature-matrix tier detector (bead sq-6g9kr). 50 tests. Natural home: `feature-matrix.yml` or `docs-quality.yml` `ci-scripts`.
- `test_check_pypi_name.py` — unit tests for `check-pypi-name.py`; `docs-quality.yml` already runs `check-pypi-name.py --self-test` directly. The separate test file provides broader coverage; could be added to `ci-scripts`.
- `test_install_action_tool.py` — unit tests for `check-install-action-tool.py`; `docs-quality.yml` already runs `check-install-action-tool.py --self-test` directly. Same rationale as above.

## Test plan

- [x] `python3 scripts/tests/test_flow_on.py` — 31/31 pass locally (0.022 s)
- [x] `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/flow-on-gates.yml'))"` — YAML valid
- [x] `actionlint .github/workflows/flow-on-gates.yml` — no findings
- [ ] CI runs the updated `config-documented (G6)` job and all 31 flow-on tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)