### PR TITLE
feat(site/e2e): nightly full-inventory AXE + full-surface visual-regression specs (sq-izpab, sq-ledny)

### DIFF
--- a/.github/workflows/nightly-full-sweep.yml
+++ b/.github/workflows/nightly-full-sweep.yml
@@ -27,10 +27,14 @@
 # always self-identified as a 🤖 SPARQ agent.
 #
 # HONEST COVERAGE NOTES (validate/extend on first CI runs; tracked as follow-ups, not silently):
-#   • The full-inventory AXE scan (axe on EVERY route, not just the key interactive states the
-#     per-PR a11y spec covers) and the FULL-SURFACE visual sweep (beyond the committed key
-#     layouts) both need additional SPEC authoring in site/e2e — this workflow runs the widest
-#     suites that exist TODAY and is ready to pick up new specs automatically.
+#   • The full-inventory AXE scan (sq-izpab) is now implemented in e2e/nightly/ and activated by
+#     SPARQ_NIGHTLY_A11Y=1 in the a11y-sweep job below. The moderate/minor ratchet (beyond the
+#     zero serious/critical tier) is a planned follow-up bead — first nightly run calibrates counts.
+#   • The full-surface visual sweep (sq-ledny) is now implemented in e2e/visual/full-surface.spec.ts
+#     and runs via the container-pinned `npm run vr` path below. Baselines were NOT committed with
+#     the initial PR (container not available in the authoring environment); the first nightly run
+#     will mint them. Until then the first nightly-visual-diffs run may fail — run `npm run
+#     vr:update` after the first scheduled run to seed the missing baselines.
 #   • firefox/webkit and the macOS/Windows tauri rows are documented-untested in THIS
 #     environment; the smoke-mode `--list` validation of each was reproduced locally, the full
 #     runs mirror the proven per-PR recipes and are validated on the first scheduled run.
@@ -137,11 +141,16 @@ jobs:
       - name: Install npm dependencies (repo-root workspace lock)
         run: npm ci
 
-      # SMOKE mode: prove the a11y + surface-sweep harness is wired + runnable, without paying
-      # the browser/wasm build. `--list` collects the tests (no browser launch, no web server).
-      - name: Smoke — a11y/surface harness is runnable (--list)
+      # SMOKE mode: prove the a11y + surface-sweep + nightly-inventory harnesses are wired +
+      # runnable, without paying the browser/wasm build. `--list` collects the tests; the
+      # SPARQ_NIGHTLY_A11Y flag must be set so the nightly-a11y project is defined and the
+      # nightly spec appears in the list (the project is otherwise undefined and the spec
+      # would be invisible to the listing).
+      - name: Smoke — a11y/surface/nightly-inventory harnesses are runnable (--list)
         if: needs.config.outputs.mode == 'smoke'
-        run: npx playwright test --list e2e/a11y.spec.ts e2e/surface-sweep.spec.ts
+        env:
+          SPARQ_NIGHTLY_A11Y: "1"
+        run: npx playwright test --list e2e/a11y.spec.ts e2e/surface-sweep.spec.ts e2e/nightly/a11y-full-inventory.spec.ts
 
       # FULL mode: the real suite. Build the lean wasm bundle (mirrors site-visual.yml) so the
       # in-tab-engine a11y/render states run, then the pinned Typst → spec/paper fragments the
@@ -190,8 +199,14 @@ jobs:
         run: |
           npm run build-specs
           npm run build-papers
-      - name: Full site e2e + a11y sweep (headless chromium)
+      - name: Full site e2e + a11y sweep (headless chromium, incl. nightly full-inventory AXE)
         if: needs.config.outputs.mode == 'full'
+        # [SONNET-4.6] sq-izpab — SPARQ_NIGHTLY_A11Y=1 activates the `nightly-a11y` Playwright
+        # project (defined in playwright.config.ts only under this flag), which runs the full-
+        # inventory AXE sweep from e2e/nightly/. The per-PR `chromium` project (always active)
+        # ignores e2e/nightly/ — both projects run in this one npm run test:e2e invocation.
+        env:
+          SPARQ_NIGHTLY_A11Y: "1"
         run: npm run test:e2e
       - name: Upload Playwright report on failure
         if: failure() && needs.config.outputs.mode == 'full'

--- a/.github/workflows/nightly-full-sweep.yml
+++ b/.github/workflows/nightly-full-sweep.yml
@@ -251,11 +251,15 @@ jobs:
 
       # SMOKE: enumerate the visual specs (SPARQ_VR defines the visual projects; the host guard
       # is bypassed for LISTING only — no screenshots are taken, so nothing is compared).
+      # SPARQ_NIGHTLY_VR=1 so the testMatch expands to ALL e2e/visual/**/*.spec.ts — full-surface
+      # must appear in the nightly listing to confirm it is wired (it would be invisible without
+      # the flag since testMatch defaults to key-layouts only).
       - name: Smoke — visual harness is runnable (--list)
         if: needs.config.outputs.mode == 'smoke'
         env:
           SPARQ_VR: "1"
           SPARQ_VR_ALLOW_HOST: "1"
+          SPARQ_NIGHTLY_VR: "1"
         run: npx playwright test --list e2e/visual
 
       # FULL: mirror site-visual.yml. Unlike the per-PR lane (which keeps the vr step
@@ -286,8 +290,14 @@ jobs:
       - name: Determinism grep gate (no waitForTimeout calls)
         if: needs.config.outputs.mode == 'full'
         run: npm run test:e2e:grep-gate
+      # [SONNET-4.6] sq-ledny — SPARQ_NIGHTLY_VR=1 is forwarded into the container by vr.sh
+      # so the visual-desktop/visual-mobile testMatch expands to ALL e2e/visual/**/*.spec.ts
+      # (including full-surface.spec.ts). Without this flag, vr.sh only runs key-layouts.spec.ts
+      # (the per-PR subset) and the full-surface captures are skipped.
       - name: Visual full-surface sweep vs committed baselines (digest-pinned container)
         if: needs.config.outputs.mode == 'full'
+        env:
+          SPARQ_NIGHTLY_VR: "1"
         run: npm run vr
       - name: Upload visual diff artifacts on failure
         if: failure() && needs.config.outputs.mode == 'full'

--- a/scripts/nightly/route_sweep_failures.py
+++ b/scripts/nightly/route_sweep_failures.py
@@ -42,7 +42,7 @@ CATEGORIES: dict[str, dict[str, str]] = {
     "visual": {
         "title": "visual-regression full-surface sweep",
         "scope": "the container-pinned toHaveScreenshot sweep (site/e2e/visual)",
-        "hint": "Download the visual-regression-diffs artifact; if the change is intentional, "
+        "hint": "Download the nightly-visual-diffs artifact; if the change is intentional, "
         "refresh baselines in a PR via `npm run vr:update`.",
     },
     "cross-browser": {

--- a/site/e2e/nightly/a11y-full-inventory.spec.ts
+++ b/site/e2e/nightly/a11y-full-inventory.spec.ts
@@ -1,0 +1,229 @@
+// [SONNET-4.6] sq-izpab — NIGHTLY full-inventory AXE sweep: axe on EVERY site route in its
+// default load state (advisory, nightly lane only, never per-PR).
+//
+// WHAT IT GUARDS. The P1 interactive-surface axe harness (e2e/a11y.spec.ts) covers key UI
+// states of the home hero + /download surfaces in their per-PR scan. This nightly companion
+// extends coverage to EVERY route in the full site inventory — content pages (papers, specs,
+// benchmarks, surfaces, showcases) that the per-PR scan intentionally omits for speed. Each
+// route is loaded in its DEFAULT render state (no interaction required) and scanned with
+// @axe-core/playwright pinned to the WCAG 2.1 A+AA rule tags.
+//
+// GATE SHAPE. Two-tier, matching a11y.spec.ts §3.1:
+//   * ZERO tier — serious + critical = HARD FAIL AT ZERO (unconditional, same as P1 spec).
+//   * MODERATE/MINOR counts are LOGGED per route (ratchet is a planned follow-up bead; first
+//     nightly run calibrates the ceiling — seed with A11Y_NIGHTLY_SEED=1, see below).
+//
+// NIGHTLY LANE. Lives in e2e/nightly/ — only the `nightly-a11y` Playwright project (defined
+// only when SPARQ_NIGHTLY_A11Y=1, set by .github/workflows/nightly-full-sweep.yml) picks it
+// up. The per-PR `chromium`/`firefox`/`webkit` projects all ignore e2e/nightly/, so the
+// per-PR path is byte-unchanged.
+//
+// ENGINE-GATED STATE. The home:results state (WASM-computed) requires the lean wasm bundle.
+// All other routes render in their default state without WASM and are unconditionally scanned.
+// The nightly lane builds the bundle (site-visual.yml recipe), but the WASM_PRESENT guard lets
+// this spec run in smoke mode (--list) and in any environment without the bundle.
+//
+// NON-VACUITY. A dedicated test injects an unlabelled icon-button and asserts axe catches it
+// — if axe were silently disabled, every ZERO-tier check above would pass vacuously.
+//
+// ROUTE INVENTORY. Sourced from the same data modules as e2e/surface-sweep.spec.ts (PAPERS /
+// SPECS); the filesystem guard tests in surface-sweep validate the BENCHMARK_FAMILY_KEYS /
+// DEEP_SURFACE_SLUGS / SHOWCASE_SLUGS constants — those guard tests are NOT duplicated here.
+// When a new route is added to surface-sweep.spec.ts, add it to the inventory below too.
+//
+// NEXT STEPS (follow-up bead). Add moderate/minor ratchet: run once with A11Y_NIGHTLY_SEED=1
+// to populate bench/a11y-nightly-baseline.json, review the seeded counts, commit, then wire
+// the ceiling check alongside the existing ZERO tier.
+//
+// Design of record: research/web-gui-test-program.md §3.1 + §6.2.
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { AxeBuilder } from "@axe-core/playwright";
+import { test, expect, gotoAppReady } from "../support";
+import { WCAG_TAGS, formatViolations, countByImpact } from "../support/a11y";
+import { PAPERS } from "../../src/data/papers";
+import { SPECS } from "../../src/data/specs";
+import type { Page } from "@playwright/test";
+
+// ── WASM presence check (same as a11y.spec.ts) ───────────────────────────────────────────
+const WASM_BUNDLE = fileURLToPath(new URL("../../public/wasm/sparq_wasm_bg.wasm", import.meta.url));
+const WASM_PRESENT = existsSync(WASM_BUNDLE);
+
+// ── Route inventory ───────────────────────────────────────────────────────────────────────
+// Each entry: path relative to the /sparq/ baseURL (include trailing slash), human name.
+// NOTE: keep in sync with surface-sweep.spec.ts when routes are added/removed (guard tests
+// for the inventory constants live in surface-sweep.spec.ts, NOT duplicated here).
+
+interface RouteEntry {
+  path: string;
+  name: string;
+}
+
+// Benchmark family keys — must stay in sync with BENCHMARK_FAMILY_KEYS in surface-sweep.spec.ts.
+const BENCHMARK_FAMILY_KEYS = [
+  "sparql",
+  "shacl",
+  "geo",
+  "fts",
+  "vector",
+  "reasoning",
+  "core",
+  "zk",
+  "solid",
+  "hdt",
+  "rsp",
+  "genai",
+  "gpu",
+] as const;
+
+// Surface deep-page slugs — must stay in sync with DEEP_SURFACE_SLUGS in surface-sweep.spec.ts.
+const DEEP_SURFACE_SLUGS = [
+  "sparql",
+  "data-formats",
+  "javascript-wasm",
+  "shacl",
+  "inference",
+] as const;
+
+// Showcase slugs — must stay in sync with SHOWCASE_SLUGS in surface-sweep.spec.ts.
+const SHOWCASE_SLUGS = [
+  "mpc-100k",
+  "solid-pairs",
+  "verifiable-credentials",
+  "zk-car-hire",
+] as const;
+
+// ── Static top-level routes ───────────────────────────────────────────────────────────────
+const STATIC_ROUTES: RouteEntry[] = [
+  { path: "", name: "/ (home, idle)" },
+  { path: "capabilities/", name: "/capabilities" },
+  { path: "app/", name: "/app" },
+  { path: "download/", name: "/download" },
+  { path: "examples/", name: "/examples" },
+];
+
+// ── Papers routes ─────────────────────────────────────────────────────────────────────────
+const PAPERS_ROUTES: RouteEntry[] = [
+  { path: "papers/", name: "/papers (index)" },
+  ...PAPERS.map((p) => ({ path: `papers/${p.slug}/`, name: `/papers/${p.slug}` })),
+];
+
+// ── Specs routes ──────────────────────────────────────────────────────────────────────────
+const SPECS_ROUTES: RouteEntry[] = [
+  { path: "specs/", name: "/specs (index)" },
+  ...SPECS.map((s) => ({ path: `specs/${s.slug}/`, name: `/specs/${s.slug}` })),
+];
+
+// ── Benchmarks routes ─────────────────────────────────────────────────────────────────────
+const BENCHMARKS_ROUTES: RouteEntry[] = [
+  { path: "benchmarks/", name: "/benchmarks (index)" },
+  ...BENCHMARK_FAMILY_KEYS.map((key) => ({
+    path: `benchmarks/${key}/`,
+    name: `/benchmarks/${key}`,
+  })),
+];
+
+// ── Surface deep-page routes ──────────────────────────────────────────────────────────────
+const SURFACE_ROUTES: RouteEntry[] = DEEP_SURFACE_SLUGS.map((slug) => ({
+  path: `surface/${slug}/`,
+  name: `/surface/${slug}`,
+}));
+
+// ── Showcase routes ───────────────────────────────────────────────────────────────────────
+const SHOWCASE_ROUTES: RouteEntry[] = SHOWCASE_SLUGS.map((slug) => ({
+  path: `showcase/${slug}/`,
+  name: `/showcase/${slug}`,
+}));
+
+// ── Complete inventory ────────────────────────────────────────────────────────────────────
+const ALL_ROUTES: RouteEntry[] = [
+  ...STATIC_ROUTES,
+  ...PAPERS_ROUTES,
+  ...SPECS_ROUTES,
+  ...BENCHMARKS_ROUTES,
+  ...SURFACE_ROUTES,
+  ...SHOWCASE_ROUTES,
+];
+
+// ── Axe helper: ZERO-tier check + count logging ───────────────────────────────────────────
+
+/** Run the WCAG 2.1 A+AA axe scan and HARD-FAIL on any serious/critical violation. */
+async function assertNoSeriousCritical(page: Page, routeName: string): Promise<void> {
+  const { violations } = await new AxeBuilder({ page })
+    .withTags([...WCAG_TAGS])
+    .analyze();
+
+  const blocking = violations.filter((v) => v.impact === "serious" || v.impact === "critical");
+  const counts = countByImpact(violations);
+
+  // Log moderate/minor for informational tracking (no ratchet in this first version).
+  if (counts.moderate > 0 || counts.minor > 0) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `[a11y-inventory] ${routeName}: moderate=${counts.moderate} minor=${counts.minor} ` +
+        `(zero-tier green; moderate/minor ratchet is a follow-up bead)`,
+    );
+  }
+
+  expect(
+    blocking,
+    `\n[a11y-inventory ${routeName}] serious/critical WCAG 2.1 AA violation(s) — must be ZERO:\n` +
+      `${formatViolations(blocking)}\n`,
+  ).toHaveLength(0);
+}
+
+// ── Parametrized full-inventory ZERO-tier sweep ───────────────────────────────────────────
+
+for (const entry of ALL_ROUTES) {
+  test(`[a11y-inventory] ${entry.name} — ZERO serious/critical WCAG 2.1 AA`, async ({ page }) => {
+    await gotoAppReady(page, entry.path);
+    await assertNoSeriousCritical(page, entry.name);
+  });
+}
+
+// ── Engine-gated state: home:results (WASM-computed) ─────────────────────────────────────
+// The per-PR a11y spec already covers home:results when WASM is present. This nightly entry
+// adds it to the full-inventory scan. Skip when the lean wasm bundle is absent.
+test("[a11y-inventory] / (home, WASM results state) — ZERO serious/critical WCAG 2.1 AA", async ({
+  page,
+}) => {
+  test.skip(!WASM_PRESENT, "wasm bundle absent — home:results needs the in-tab engine (build with npm run sync-wasm)");
+  await gotoAppReady(page, "");
+  await page.getByRole("button", { name: /Run/ }).first().click();
+  // Wait for the WASM-computed results state before scanning.
+  await expect(
+    page.locator("[data-runner-surface='home'][data-runner-state='results']"),
+  ).toBeVisible({ timeout: 60_000 });
+  await assertNoSeriousCritical(page, "/ (home, WASM results)");
+});
+
+// ── Non-vacuity: the scanner must CATCH a deliberately unlabelled icon-button ─────────────
+// Mirrors the non-vacuity check in e2e/a11y.spec.ts. If axe were silently disabled, every
+// ZERO-tier test above would pass vacuously.
+test("[a11y-inventory] harness non-vacuity — injected unlabelled icon-button is caught", async ({
+  page,
+}) => {
+  await gotoAppReady(page, "");
+
+  await page.evaluate(() => {
+    const probe = document.createElement("div");
+    probe.id = "a11y-nightly-nonvacuity-probe";
+    probe.innerHTML =
+      '<button type="button"><svg aria-hidden="true" width="16" height="16"></svg></button>';
+    document.body.appendChild(probe);
+  });
+
+  const { violations } = await new AxeBuilder({ page })
+    .withTags([...WCAG_TAGS])
+    .include("#a11y-nightly-nonvacuity-probe")
+    .analyze();
+
+  const buttonName = violations.find((v) => v.id === "button-name");
+  expect(
+    buttonName,
+    "axe did not catch the injected unlabelled icon-button — the nightly a11y harness is VACUOUS/misconfigured",
+  ).toBeTruthy();
+  expect(
+    buttonName && (buttonName.impact === "serious" || buttonName.impact === "critical"),
+  ).toBe(true);
+});

--- a/site/e2e/visual/full-surface.spec.ts
+++ b/site/e2e/visual/full-surface.spec.ts
@@ -1,0 +1,179 @@
+// [SONNET-4.6] sq-ledny — NIGHTLY full-surface visual-regression specs beyond key layouts.
+//
+// WHAT IT GUARDS. The per-PR key-layouts spec (e2e/visual/key-layouts.spec.ts, sq-ymr2e.10)
+// covers the home first fold (dark + light), /download cards, the mpc-100k showcase, and
+// nav + palette-open overlay. This nightly companion extends visual regression to the rest
+// of the site surface:
+//   • Top-level content routes: /capabilities, /app, /examples
+//   • Papers: /papers index + one representative per-paper page
+//   • Specs: /specs index + one representative per-spec page
+//   • Benchmarks: /benchmarks index (the per-family chart pages are excluded pending
+//     data-vr-mask on chart containers — adding that mask is a follow-up bead)
+//   • Surface deep pages: /surface/sparql, data-formats, javascript-wasm, shacl, inference
+//   • Showcase pages: /showcase/solid-pairs, verifiable-credentials (mpc-100k is per-PR;
+//     zk-car-hire is excluded because its ZK prover auto-starts on mount, making the
+//     pre-interaction snapshot non-deterministic without a state waiter — follow-up bead)
+//
+// ANTI-FLAKE DISCIPLINE. Every capture inherits the full determinism harness from the shared
+// `test` (frozen clock, seeded random, animations-off, reducedMotion, hermetic network,
+// pinned viewport, dark theme, UTC, en-US). On top of that each capture:
+//   * waits for `document.fonts.ready` (font loading is async);
+//   * waits for the app-shell hydration barrier (`data-app-ready`) via gotoAppReady;
+//   * masks every `[data-vr-mask]` region (dynamic content: timing footers, release
+//     version/size/sha strings) via the vrMasks() helper — "mask, don't chase".
+//
+// CONTAINER RULE. Same as key-layouts.spec.ts: these specs run ONLY inside the
+// digest-pinned official Playwright container (SPARQ_VR=1, scripts/vr.sh). The visual-*
+// projects are container-only by design; see e2e/visual/README.md.
+//
+// BASELINE GENERATION. Baselines for this spec do NOT exist in the initial commit of this
+// PR — they CANNOT be generated in the authoring environment (not inside the pinned
+// container). On the first nightly `visual-sweep` run, Playwright will create them
+// automatically (first-run baseline mint). If the nightly visual-sweep fails with
+// "missing snapshot" errors before the first successful run, regenerate with:
+//   npm run vr:update  (from site/, inside the container via scripts/vr.sh)
+// See e2e/visual/README.md for the full baseline-update workflow.
+//
+// Design of record: research/web-gui-test-program.md §4 + §6.2.
+import type { Page } from "@playwright/test";
+
+import { test, expect, gotoAppReady } from "../support";
+import { PAPERS } from "../../src/data/papers";
+import { SPECS } from "../../src/data/specs";
+
+/** Every dynamic region opted into the mask convention (mirrors key-layouts.spec.ts). */
+function vrMasks(page: Page) {
+  return [page.locator("[data-vr-mask]")];
+}
+
+/** Deterministic capture barrier: all declared web fonts are loaded and applied. */
+async function fontsReady(page: Page): Promise<void> {
+  await page.evaluate(() => document.fonts.ready.then(() => undefined));
+}
+
+// ── Top-level content routes ──────────────────────────────────────────────────────────────
+
+test("capabilities page — card grid", async ({ page }) => {
+  await gotoAppReady(page, "capabilities/");
+  await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+  await fontsReady(page);
+  await expect(page).toHaveScreenshot("capabilities.png", { mask: vrMasks(page) });
+});
+
+test("app page — hosted GUI link", async ({ page }) => {
+  await gotoAppReady(page, "app/");
+  await expect(page.getByRole("heading", { level: 1, name: /App/i })).toBeVisible();
+  await fontsReady(page);
+  await expect(page).toHaveScreenshot("app.png", { mask: vrMasks(page) });
+});
+
+test("examples page — examples listing", async ({ page }) => {
+  await gotoAppReady(page, "examples/");
+  await expect(page.getByRole("heading", { level: 1, name: /Examples/i })).toBeVisible();
+  await fontsReady(page);
+  await expect(page).toHaveScreenshot("examples.png", { mask: vrMasks(page) });
+});
+
+// ── Papers ────────────────────────────────────────────────────────────────────────────────
+
+test("papers index — card list", async ({ page }) => {
+  await gotoAppReady(page, "papers/");
+  // At least one "Read paper" link confirms the cards rendered.
+  await expect(page.getByRole("link", { name: /Read paper/i }).first()).toBeVisible();
+  await fontsReady(page);
+  await expect(page).toHaveScreenshot("papers-index.png", { mask: vrMasks(page) });
+});
+
+// Representative per-paper page: first paper in the registry (deterministic, data-driven).
+// The paper blurb is always server-rendered from the data module, so the card is visible
+// even without the Typst-built HTML fragment (which the nightly lane builds).
+test("papers — first paper page", async ({ page }, testInfo) => {
+  // Skip if the paper registry is unexpectedly empty (guard against a broken state).
+  if (PAPERS.length === 0) {
+    testInfo.skip();
+    return;
+  }
+  const paper = PAPERS[0];
+  await gotoAppReady(page, `papers/${paper.slug}/`);
+  // Wait for the blurb (always rendered, from the data module).
+  await expect(
+    page.getByText(paper.blurb.slice(0, 60), { exact: false }).first(),
+  ).toBeVisible({ timeout: 20_000 });
+  await fontsReady(page);
+  await expect(page).toHaveScreenshot(`papers-${paper.slug}.png`, { mask: vrMasks(page) });
+});
+
+// ── Specs ─────────────────────────────────────────────────────────────────────────────────
+
+test("specs index — card list", async ({ page }) => {
+  await gotoAppReady(page, "specs/");
+  await expect(page.getByRole("link", { name: /Read draft/i }).first()).toBeVisible();
+  await fontsReady(page);
+  await expect(page).toHaveScreenshot("specs-index.png", { mask: vrMasks(page) });
+});
+
+// Representative per-spec page: first spec in the registry.
+test("specs — first spec page", async ({ page }, testInfo) => {
+  if (SPECS.length === 0) {
+    testInfo.skip();
+    return;
+  }
+  const spec = SPECS[0];
+  await gotoAppReady(page, `specs/${spec.slug}/`);
+  await expect(
+    page.getByText(spec.blurb.slice(0, 60), { exact: false }).first(),
+  ).toBeVisible({ timeout: 20_000 });
+  await fontsReady(page);
+  await expect(page).toHaveScreenshot(`specs-${spec.slug}.png`, { mask: vrMasks(page) });
+});
+
+// ── Benchmarks (index only; per-family chart pages deferred pending data-vr-mask) ─────────
+// The /benchmarks index page shows family cards (names, labels, counts) — fully static
+// content from the committed benchmarks.generated.json. Per-family pages render SVG charts
+// whose axis labels are derived from the benchmark data; those pages will be added once
+// data-vr-mask is applied to the chart containers (follow-up bead sq-ledny.2).
+
+test("benchmarks index — family cards", async ({ page }) => {
+  await gotoAppReady(page, "benchmarks/");
+  await expect(page.getByRole("heading", { level: 1, name: /Benchmarks/i })).toBeVisible();
+  await fontsReady(page);
+  await expect(page).toHaveScreenshot("benchmarks-index.png", { mask: vrMasks(page) });
+});
+
+// ── Surface deep pages ────────────────────────────────────────────────────────────────────
+
+for (const slug of ["sparql", "data-formats", "javascript-wasm", "shacl", "inference"] as const) {
+  test(`surface deep page — /surface/${slug}`, async ({ page }) => {
+    await gotoAppReady(page, `surface/${slug}/`);
+    await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+    await fontsReady(page);
+    await expect(page).toHaveScreenshot(`surface-${slug}.png`, { mask: vrMasks(page) });
+  });
+}
+
+// ── Showcase pages ────────────────────────────────────────────────────────────────────────
+// mpc-100k is covered by key-layouts.spec.ts (per-PR). zk-car-hire is excluded from this
+// spec because its ZK prover auto-starts on route mount (the prewarm mechanism), making
+// the pre-interaction snapshot non-deterministic without a dedicated state waiter — add it
+// in a follow-up bead once the prover-ready state is observable (data-state attribute).
+
+test("showcase — solid-pairs (pre-interaction idle state)", async ({ page }) => {
+  // The solid-pairs demo starts in idle state (no auto-run on mount). The pre-interaction
+  // render (header, query editor, selector dropdowns, Run button) is static.
+  await gotoAppReady(page, "showcase/solid-pairs/");
+  await expect(page.getByRole("heading", { name: /Solid.*pair/i }).first()).toBeVisible();
+  await fontsReady(page);
+  await expect(page).toHaveScreenshot("showcase-solid-pairs.png", { mask: vrMasks(page) });
+});
+
+test("showcase — verifiable-credentials (pre-interaction idle state)", async ({ page }) => {
+  // The VC import-and-query workbench starts in idle state (awaiting drag/drop). The initial
+  // render (header, import area, query panel) is static.
+  await gotoAppReady(page, "showcase/verifiable-credentials/");
+  await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+  await fontsReady(page);
+  await expect(page).toHaveScreenshot(
+    "showcase-verifiable-credentials.png",
+    { mask: vrMasks(page) },
+  );
+});

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -38,6 +38,14 @@ const SPARQ_VR = !!process.env.SPARQ_VR;
 // per-PR lane) byte-identical to before — the projects array is spread with `[]` when unset, so
 // the per-PR path is untouched.
 const SPARQ_NIGHTLY_BROWSERS = !!process.env.SPARQ_NIGHTLY_BROWSERS;
+
+// [SONNET-4.6] sq-izpab — the NIGHTLY full-inventory a11y project. The per-PR `chromium`,
+// `firefox`, and `webkit` projects all ignore e2e/nightly/ (testIgnore below), so the
+// full-inventory AXE sweep (e2e/nightly/a11y-full-inventory.spec.ts) never runs per-PR.
+// The nightly workflow sets SPARQ_NIGHTLY_A11Y=1 to activate this project for the
+// nightly-full-sweep a11y job. Same chromium browser + determinism defaults as the per-PR
+// project; testMatch restricted to e2e/nightly/ so it does NOT double-run the main suite.
+const SPARQ_NIGHTLY_A11Y = !!process.env.SPARQ_NIGHTLY_A11Y;
 if (SPARQ_VR && !existsSync("/ms-playwright") && !process.env.SPARQ_VR_ALLOW_HOST) {
   throw new Error(
     "SPARQ_VR=1 outside the pinned Playwright container (/ms-playwright not found). " +
@@ -103,9 +111,23 @@ export default defineConfig({
       name: "chromium",
       // Keep the pinned viewport at the project level too (device presets carry their own).
       use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 720 } },
-      // The visual specs run only in the container-scoped visual-* projects below.
-      testIgnore: /e2e[\\/]visual[\\/]/,
+      // Visual specs run only in the container-scoped visual-* projects below.
+      // Nightly a11y specs run only in the nightly-a11y project (activated by SPARQ_NIGHTLY_A11Y=1).
+      // Both are excluded here so the per-PR path is byte-unchanged.
+      testIgnore: [/e2e[\\/]visual[\\/]/, /e2e[\\/]nightly[\\/]/],
     },
+    // [SONNET-4.6] sq-izpab — nightly-only full-inventory a11y project (see SPARQ_NIGHTLY_A11Y above).
+    ...(SPARQ_NIGHTLY_A11Y
+      ? [
+          {
+            name: "nightly-a11y",
+            use: { ...devices["Desktop Chrome"], viewport: { width: 1280, height: 720 } },
+            // Only pick up the nightly specs; the main e2e suite is already run by the
+            // chromium project in the same nightly job (npm run test:e2e runs both).
+            testMatch: /e2e[\\/]nightly[\\/].*\.spec\.ts/,
+          },
+        ]
+      : []),
     // [FABLE-5] sq-ymr2e.10 — container-only visual projects (see the SPARQ_VR guard above).
     // Two pinned viewports per §4: 1280×720 desktop + 390×844 mobile. Plain viewports (no
     // isMobile/deviceScaleFactor emulation): the site is responsive via CSS breakpoints, and
@@ -132,12 +154,14 @@ export default defineConfig({
           {
             name: "firefox",
             use: { ...devices["Desktop Firefox"], viewport: { width: 1280, height: 720 } },
-            testIgnore: /e2e[\\/]visual[\\/]/,
+            // Exclude both container-only visual and nightly-only a11y specs.
+            testIgnore: [/e2e[\\/]visual[\\/]/, /e2e[\\/]nightly[\\/]/],
           },
           {
             name: "webkit",
             use: { ...devices["Desktop Safari"], viewport: { width: 1280, height: 720 } },
-            testIgnore: /e2e[\\/]visual[\\/]/,
+            // Exclude both container-only visual and nightly-only a11y specs.
+            testIgnore: [/e2e[\\/]visual[\\/]/, /e2e[\\/]nightly[\\/]/],
           },
         ]
       : []),

--- a/site/playwright.config.ts
+++ b/site/playwright.config.ts
@@ -46,6 +46,14 @@ const SPARQ_NIGHTLY_BROWSERS = !!process.env.SPARQ_NIGHTLY_BROWSERS;
 // nightly-full-sweep a11y job. Same chromium browser + determinism defaults as the per-PR
 // project; testMatch restricted to e2e/nightly/ so it does NOT double-run the main suite.
 const SPARQ_NIGHTLY_A11Y = !!process.env.SPARQ_NIGHTLY_A11Y;
+
+// [SONNET-4.6] sq-ledny — the NIGHTLY full-surface visual flag. The per-PR visual-desktop
+// and visual-mobile projects match ONLY the committed key-layouts spec by default; the
+// full-surface sweep (e2e/visual/full-surface.spec.ts) has no committed baselines on first
+// land and is nightly-only by design. The nightly workflow sets SPARQ_NIGHTLY_VR=1 so the
+// visual-sweep job (via vr.sh) matches ALL e2e/visual/**/*.spec.ts. Without the flag the
+// per-PR site-visual.yml lane keeps running exactly the pre-existing key-layouts tests.
+const SPARQ_NIGHTLY_VR = !!process.env.SPARQ_NIGHTLY_VR;
 if (SPARQ_VR && !existsSync("/ms-playwright") && !process.env.SPARQ_VR_ALLOW_HOST) {
   throw new Error(
     "SPARQ_VR=1 outside the pinned Playwright container (/ms-playwright not found). " +
@@ -132,16 +140,27 @@ export default defineConfig({
     // Two pinned viewports per §4: 1280×720 desktop + 390×844 mobile. Plain viewports (no
     // isMobile/deviceScaleFactor emulation): the site is responsive via CSS breakpoints, and
     // DSF=1 keeps baselines small + byte-stable.
+    //
+    // [SONNET-4.6] sq-ledny — testMatch is split on SPARQ_NIGHTLY_VR:
+    //   • Without the flag (per-PR site-visual.yml): only key-layouts.spec.ts — the specs
+    //     whose baselines ARE committed. full-surface.spec.ts is excluded so missing baselines
+    //     never advisory-fail the per-PR lane.
+    //   • With SPARQ_NIGHTLY_VR=1 (nightly visual-sweep via vr.sh): all e2e/visual/**/*.spec.ts
+    //     — includes full-surface and any future specs added to e2e/visual/.
     ...(SPARQ_VR
       ? [
           {
             name: "visual-desktop",
-            testMatch: /e2e[\\/]visual[\\/].*\.spec\.ts/,
+            testMatch: SPARQ_NIGHTLY_VR
+              ? /e2e[\\/]visual[\\/].*\.spec\.ts/
+              : /e2e[\\/]visual[\\/]key-layouts\.spec\.ts/,
             use: { viewport: { width: 1280, height: 720 } },
           },
           {
             name: "visual-mobile",
-            testMatch: /e2e[\\/]visual[\\/].*\.spec\.ts/,
+            testMatch: SPARQ_NIGHTLY_VR
+              ? /e2e[\\/]visual[\\/].*\.spec\.ts/
+              : /e2e[\\/]visual[\\/]key-layouts\.spec\.ts/,
             use: { viewport: { width: 390, height: 844 } },
           },
         ]

--- a/site/scripts/vr.sh
+++ b/site/scripts/vr.sh
@@ -50,6 +50,7 @@ exec docker run --rm --init --ipc=host \
   -u "$(id -u):$(id -g)" \
   -e HOME=/tmp \
   -e SPARQ_VR=1 \
+  -e SPARQ_NIGHTLY_VR="${SPARQ_NIGHTLY_VR:-}" \
   -e CI="${CI:-}" \
   -v "${REPO_ROOT}:/work" \
   -w /work/site \


### PR DESCRIPTION
> 🤖 **SPARQ agent** — implementing beads sq-izpab + sq-ledny in one PR (both in-progress, same surface).

## Summary

- **sq-izpab** — full-inventory AXE sweep: `e2e/nightly/a11y-full-inventory.spec.ts` runs axe (WCAG 2.1 AA) on **every site route** (45 tests covering static pages, papers, specs, benchmarks, surface deep pages, and showcase pages). Enforces the zero serious/critical tier unconditionally; moderate/minor logging only (ratchet is a follow-up).
- **sq-ledny** — full-surface visual-regression specs: `e2e/visual/full-surface.spec.ts` adds 30 container-pinned `toHaveScreenshot` captures (desktop + mobile) for all surfaces beyond the per-PR key-layouts (capabilities, app, examples, papers index, specs index, benchmarks index, 5 surface deep pages, solid-pairs and verifiable-credentials showcases).
- **sq-ledny tidy** — one-line fix in `scripts/nightly/route_sweep_failures.py:45`: the visual category hint said `visual-regression-diffs` but the workflow uploads artifact `nightly-visual-diffs`.
- **sq-ledny fixup** (this commit) — correct the Opus review finding: isolate `full-surface.spec.ts` from the per-PR visual lane via a new `SPARQ_NIGHTLY_VR` flag.

## Nightly wiring

**a11y** (sq-izpab) is nightly-only and was correct from the start. The per-PR `chromium`/`firefox`/`webkit` projects ignore `e2e/nightly/`; `SPARQ_NIGHTLY_A11Y=1` activates the `nightly-a11y` Playwright project.

**visual full-surface** (sq-ledny) required a fixup: the per-PR `site-visual.yml` runs `npm run vr` with no spec filter, and `visual-desktop`/`visual-mobile` previously matched ALL `e2e/visual/**/*.spec.ts` — so the 30 new baseline-less captures would advisory-fail on every future site PR until baselines land. Fixed (reviewer option a) by splitting testMatch on a new `SPARQ_NIGHTLY_VR` flag, mirroring `SPARQ_NIGHTLY_A11Y`:

- Without `SPARQ_NIGHTLY_VR` (per-PR `site-visual.yml`): `visual-desktop`/`visual-mobile` match **only** `e2e/visual/key-layouts.spec.ts` — the committed baselines. `full-surface.spec.ts` is excluded; per-PR lane is safe.
- With `SPARQ_NIGHTLY_VR=1` (nightly `visual-sweep` via `vr.sh`): testMatch expands to all `e2e/visual/**/*.spec.ts`, including `full-surface.spec.ts`.

Changes wiring the flag:
- `playwright.config.ts` — `SPARQ_NIGHTLY_VR` constant + testMatch split on visual-desktop/visual-mobile
- `scripts/vr.sh` — forwards `SPARQ_NIGHTLY_VR` from host into the docker container via `-e`
- `nightly-full-sweep.yml` — sets `SPARQ_NIGHTLY_VR: "1"` on both the smoke `--list` step and the full `npm run vr` step of the `visual-sweep` job

## Baseline generation honesty

The full-surface visual baselines are **not committed** — this environment is not the digest-pinned Playwright container and fabricated baselines are prohibited. On the first nightly `visual-sweep` full run, Playwright will attempt to compare against missing baselines and fail. To seed them:

```sh
SPARQ_NIGHTLY_VR=1 npm run vr:update   # inside the container (scripts/vr.sh)
```

Then commit the generated PNGs in a follow-up PR. Until then, the `visual-sweep` nightly category will file a consolidated issue on first failure (expected; the issue auto-closes once baselines are committed and the sweep turns green).

## Gate evidence

- Static export build: `npm run build` passes end-to-end (emits `out/`)
- Lint: `npm run lint` passes (zero warnings/errors)
- `tsc --noEmit`: clean (no errors)
- Playwright `--list` flag-state verification:
  - `SPARQ_VR=1 SPARQ_VR_ALLOW_HOST=1 npx playwright test --list e2e/visual` (no SPARQ_NIGHTLY_VR) → **10 tests, key-layouts only** (5 tests × 2 projects) — full-surface absent
  - `SPARQ_VR=1 SPARQ_VR_ALLOW_HOST=1 SPARQ_NIGHTLY_VR=1 npx playwright test --list e2e/visual` → **40 tests** (key-layouts + full-surface, 20 × 2 projects)
  - `SPARQ_NIGHTLY_A11Y=1 npx playwright test --list e2e/nightly/a11y-full-inventory.spec.ts` → 45 tests in `nightly-a11y` project
  - Per-PR `npx playwright test --list --project chromium` → 117 tests, zero nightly/ or visual/ tests picked up (per-PR path byte-unchanged)
- No-timeout grep gate: passes (zero `waitForTimeout` calls)
- Typos gate: no `DELETEd`/`DROPped`/`invokable`/`ANDed` in new files
- Privacy-claims: no ZK/MPC copy in the test specs (route names like `zk-car-hire` appear only as string constants, not as claims)

## Files changed

- `site/e2e/nightly/a11y-full-inventory.spec.ts` (new) — sq-izpab
- `site/e2e/visual/full-surface.spec.ts` (new) — sq-ledny
- `site/playwright.config.ts` — adds `SPARQ_NIGHTLY_A11Y` + `SPARQ_NIGHTLY_VR` env vars; `nightly-a11y` project; testIgnore for `e2e/nightly/` in all per-PR projects; testMatch split for visual projects
- `.github/workflows/nightly-full-sweep.yml` — wires `SPARQ_NIGHTLY_A11Y=1` into a11y-sweep steps; `SPARQ_NIGHTLY_VR=1` into visual-sweep smoke + full steps; updates HONEST COVERAGE NOTES comment
- `scripts/nightly/route_sweep_failures.py` — fix artifact-name hint (`visual-regression-diffs` → `nightly-visual-diffs`)
- `site/scripts/vr.sh` — forwards `SPARQ_NIGHTLY_VR` into the docker container

## Deferred

- Moderate/minor ratchet for the nightly a11y inventory (seed with `A11Y_NIGHTLY_SEED=1` after first successful run)
- Per-family benchmark page captures in `full-surface.spec.ts` (need `data-vr-mask` on chart containers first)
- `showcase/zk-car-hire` visual capture (ZK prover auto-starts on mount; needs a `prover-ready` state waiter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)