### PR TITLE
ci: wire 6 remaining hermetic test suites into CI (sq-1cb6l)

### DIFF
--- a/.github/workflows/docs-quality.yml
+++ b/.github/workflows/docs-quality.yml
@@ -532,6 +532,49 @@ jobs:
       # "advisory" token): the detector's own logic must red CI if it regresses.
       - name: Self-test the nightly selection-bug alarm (correlation + fail-loud — sq-va7at)
         run: python3 scripts/tests/test_ci_selection_alarm.py
+      # [SONNET-4.6] sq-1cb6l: the 5 remaining hermetic test suites found by the
+      # #1670 audit, wired here alongside the other ci-scripts self-tests.
+      #
+      # test_cone_coverage.py (27 tests) — the cone-based coverage selector
+      # (scripts/cone_coverage.py): compute_cone() closure math, §4.1 full-run
+      # triggers, dev-dep propagation, shadow/enforce mode flags, shadow_report()
+      # label semantics, shard-filtering intersection, and the empty-all_members
+      # fallback. Stdlib-only, no cargo/network.
+      - name: Self-test cone_coverage.py (cone selector + shadow_report — sq-1cb6l)
+        run: python3 scripts/tests/test_cone_coverage.py
+      # test_drift_scan.py (37 tests) — the periodic drift scanner
+      # (scripts/drift-scan.py): all 5 scanner classes (bench-missing,
+      # skill-missing, explain-asymmetry, dashboard-row, conformance-split),
+      # the dedup-key stability contract, main(--dry-run), and the CI-guard
+      # that refuses to mint issues outside CI. Stdlib-only, no gh/git/network.
+      - name: Self-test drift-scan.py (all scanner classes + CI guard — sq-1cb6l)
+        run: python3 scripts/tests/test_drift_scan.py
+      # test_feature_matrix_tiers.py (50 tests) — the feature-matrix tier
+      # detector (scripts/feature-matrix-tiers.py): cfg expression parser
+      # (feature/test/not/any/all/other nodes + balanced-paren error), all
+      # acceptance criteria (a)–(i) (gated test file, cfg(not(feature)) src,
+      # nested combinators, parse-error fail-closed, unreadable-dir fail-closed,
+      # tier:check enforce, fail-open mutation, non-sensitive), plus extraction +
+      # split helpers. Stdlib-only, no subprocess/network.
+      - name: Self-test feature-matrix-tiers.py (cfg parser + tier enforcement — sq-1cb6l)
+        run: python3 scripts/tests/test_feature_matrix_tiers.py
+      # test_check_pypi_name.py (15 tests) — supplements the existing
+      # check-pypi-name.py --self-test: the pure HTTP-status → verdict decision
+      # table (404=AVAILABLE, 200=TAKEN, anything-else=INDETERMINATE — a non-404
+      # must NEVER read as available), the dist-name reader (pins `sparq-rdf`
+      # so a silent rename back to the taken `sparq` fails here), and the
+      # verdict-line rendering. Stdlib-only, no network.
+      - name: Self-test check-pypi-name.py (decision table + dist-name pin — sq-1cb6l)
+        run: python3 scripts/tests/test_check_pypi_name.py
+      # test_install_action_tool.py (11 tests) — supplements the existing
+      # check-install-action-tool.py --self-test + enforce run: pure fixture
+      # coverage (good/bad/no-with/no-tool/tag-pinned/other/mixed/no-leak
+      # cases), the 40-hex SHA pin guard, the live-workflows invariant (all
+      # install-action steps carry `with: tool:`), and the vacuous-pass guard
+      # (at least one SHA-pinned install-action must exist in the repo). Stdlib-
+      # only, no git/network.
+      - name: Self-test check-install-action-tool.py (fixtures + live invariant — sq-1cb6l)
+        run: python3 scripts/tests/test_install_action_tool.py
 
   # ----------------------------- ADVISORY -----------------------------
   markdownlint-advisory:

--- a/.github/workflows/flow-on-gates.yml
+++ b/.github/workflows/flow-on-gates.yml
@@ -175,6 +175,14 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
+      # [SONNET-4.6] sq-1cb6l: hermetic self-test of the G3 gate's pure logic —
+      # evaluate() + parse_status_lines() + registry_blocks() + dashboard_featured_text()
+      # + added_bench_suites() + suite_family(). Runs in this same job so a regression
+      # in the gate's detection logic also blocks the merge here, not only in CI.
+      # Stdlib-only, no git/network (the main() smoke test uses --dry-run +
+      # --changed-files + --base-toml so it never shells out). [SONNET-4.6]
+      - name: Self-test the new-bench-registered gate (G3, sq-1cb6l)
+        run: python3 scripts/tests/test_check_new_bench_registered.py
       - name: G3 — new bench suite is registered + featured (or featured=false)
         env:
           # On pull_request github.base_ref is the bare target branch ('main'); on

--- a/.github/workflows/flow-on-gates.yml
+++ b/.github/workflows/flow-on-gates.yml
@@ -175,14 +175,6 @@ jobs:
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: "3.12"
-      # [SONNET-4.6] sq-1cb6l: hermetic self-test of the G3 gate's pure logic —
-      # evaluate() + parse_status_lines() + registry_blocks() + dashboard_featured_text()
-      # + added_bench_suites() + suite_family(). Runs in this same job so a regression
-      # in the gate's detection logic also blocks the merge here, not only in CI.
-      # Stdlib-only, no git/network (the main() smoke test uses --dry-run +
-      # --changed-files + --base-toml so it never shells out). [SONNET-4.6]
-      - name: Self-test the new-bench-registered gate (G3, sq-1cb6l)
-        run: python3 scripts/tests/test_check_new_bench_registered.py
       - name: G3 — new bench suite is registered + featured (or featured=false)
         env:
           # On pull_request github.base_ref is the bare target branch ('main'); on
@@ -211,6 +203,13 @@ jobs:
         # Runs the hermetic gate unit tests so a regression in any gate script is
         # caught at PR time (the suite is stdlib-only; no git/network).
         run: python3 scripts/tests/test_gates.py
+      # [SONNET-4.6] sq-1cb6l: hermetic self-test of the G3 gate's pure logic —
+      # evaluate() + parse_status_lines() + registry_blocks() + dashboard_featured_text()
+      # + added_bench_suites() + suite_family(). Placed in G6 (the HARD config-documented
+      # job) so a regression in the gate's detection logic actually blocks the merge,
+      # mirroring the test_gates.py pattern. Stdlib-only, no git/network. [SONNET-4.6]
+      - name: Self-test the new-bench-registered gate (G3, sq-1cb6l)
+        run: python3 scripts/tests/test_check_new_bench_registered.py
       # [SONNET-4.6] sq-8hfhi: wire the reactive flow-on engine tests into CI so a
       # rule/engine regression (like the #1655 false-positive fnmatch/{suite} defect
       # fixed in #1664) is caught pre-merge, not post-merge. 31 tests covering: rule


### PR DESCRIPTION
> 🤖 SPARQ agent (Sonnet 4.6) — bead sq-1cb6l

## Summary

Wires the 6 hermetic test suites found by the [#1670](https://github.com/sparq-org/sparq/pull/1670) audit into their natural existing CI homes. All 6 pass locally (confirmed on this box). No new workflow file, no new branch-protection context.

**flow-on-gates.yml** — `config-documented` job (G6, HARD):
- `test_check_new_bench_registered.py` (24 tests): G3 gate pure logic — `evaluate()`, `parse_status_lines()`, `registry_blocks()`, `suite_family()`, `dashboard_featured_text()`, `added_bench_suites()`. Placed in the HARD G6 job (after `test_gates.py`) so a regression in the gate's detection logic blocks the merge. (Removed from the advisory G3 job where it ran but never blocked — fix from Opus review.)

**docs-quality.yml** — `ci-scripts` job (appended after `test_ci_selection_alarm.py`):
- `test_cone_coverage.py` (27 tests): `cone_coverage.py` — `compute_cone()` closure math, §4.1 triggers, dev-dep propagation, `shadow_report()` labels, shard-filtering, empty-`all_members` fallback.
- `test_drift_scan.py` (37 tests): `drift-scan.py` — all 5 scanner classes (bench-missing, skill-missing, explain-asymmetry, dashboard-row, conformance-split), dedup-key stability, `main(--dry-run)`, and the CI-guard that refuses to mint issues outside CI.
- `test_feature_matrix_tiers.py` (50 tests): `feature-matrix-tiers.py` — cfg expression parser (feature/test/not/any/all/other + parse-error fail-closed), all acceptance criteria (a)–(i), extraction + split helpers.
- `test_check_pypi_name.py` (15 tests): supplements `check-pypi-name.py --self-test` — HTTP-status → verdict decision table, dist-name pin (`sparq-rdf` not `sparq`), verdict-line rendering.
- `test_install_action_tool.py` (11 tests): supplements `check-install-action-tool.py --self-test` — pure fixtures, live-workflows invariant, vacuous-pass guard.

## Gates

- YAML validated: `python3 -c "import yaml; yaml.safe_load(open(p))"` on both files — VALID
- `actionlint` on both files — clean (no output)
- `typos` on both files — clean
- All 6 test suites run locally: 24 + 27 + 37 + 50 + 15 + 11 = 164 tests, all OK
- No "advisory"/"informational" in any new step name → the steps are gating inside their parent jobs
- `test_check_new_bench_registered.py` is in `config-documented (G6)` — a HARD gating job (no "advisory" token in job name); it now genuinely blocks the merge as the comment claims
- No new branch-protection context; gate aggregator unchanged
- SHA-pinned actions unchanged; no new actions added (steps are plain `run:`)

## Local reproduction

```
python3 scripts/tests/test_check_new_bench_registered.py  # 24 tests OK (in G6)
python3 scripts/tests/test_cone_coverage.py               # 27 tests OK
python3 scripts/tests/test_drift_scan.py                  # 37 tests OK
python3 scripts/tests/test_feature_matrix_tiers.py        # 50 tests OK
python3 scripts/tests/test_check_pypi_name.py             # 15 tests OK
python3 scripts/tests/test_install_action_tool.py         # 11 tests OK
```

## Fix note (Opus review — sq-1cb6l)

The original commit placed `test_check_new_bench_registered.py` in the advisory G3 job (`new-bench-registry-dashboard (G3, advisory)`). Because the job name contains "advisory", the ci-summary aggregator excludes it as non-required — the step ran but never blocked a merge, contradicting the "also blocks the merge" comment. This commit moves it to the HARD G6 `config-documented` job (beside `test_gates.py`, its true mirror), making the blocks-the-merge claim true.

## Exceptions

None — all 6 suites are hermetic (stdlib-only, no git/network/cargo), sub-second, and green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)