### PR TITLE
test(site/e2e): add /assurance, /assurance/served-conformance, /dogfooding to both e2e inventories (sq-yk2ho)

### DIFF
--- a/site/e2e/nightly/a11y-full-inventory.spec.ts
+++ b/site/e2e/nightly/a11y-full-inventory.spec.ts
@@ -30,6 +30,7 @@
 // SPECS); the filesystem guard tests in surface-sweep validate the BENCHMARK_FAMILY_KEYS /
 // DEEP_SURFACE_SLUGS / SHOWCASE_SLUGS constants — those guard tests are NOT duplicated here.
 // When a new route is added to surface-sweep.spec.ts, add it to the inventory below too.
+// [SONNET-4.6] sq-yk2ho — /assurance, /assurance/served-conformance, /dogfooding added.
 //
 // NEXT STEPS (follow-up bead). Add moderate/minor ratchet: run once with A11Y_NIGHTLY_SEED=1
 // to populate bench/a11y-nightly-baseline.json, review the seeded counts, commit, then wire
@@ -100,6 +101,10 @@ const STATIC_ROUTES: RouteEntry[] = [
   { path: "app/", name: "/app" },
   { path: "download/", name: "/download" },
   { path: "examples/", name: "/examples" },
+  // [SONNET-4.6] sq-yk2ho — previously-unlinked content routes now in inventory.
+  { path: "assurance/", name: "/assurance" },
+  { path: "assurance/served-conformance/", name: "/assurance/served-conformance" },
+  { path: "dogfooding/", name: "/dogfooding" },
 ];
 
 // ── Papers routes ─────────────────────────────────────────────────────────────────────────

--- a/site/e2e/surface-sweep.spec.ts
+++ b/site/e2e/surface-sweep.spec.ts
@@ -38,6 +38,9 @@
 //   app         → h1 "App"
 //   download    → h1 heading
 //   examples    → h1 "Examples"
+//   assurance   → h1 matching /Assurance/i
+//   assurance/served-conformance → h1 heading (long title, first() match)
+//   dogfooding  → h1 matching /Dogfooding/i
 //   papers      → at least one "Read paper" link on the index page
 //   per-paper   → blurb text visible (always sourced from data module, not generated HTML)
 //   specs       → at least one "Read draft" link on the index page
@@ -197,6 +200,37 @@ const STATIC_ROUTES: RouteEntry[] = [
     artifact: async (page) => {
       await expect(
         page.getByRole("heading", { level: 1, name: "Examples" }),
+      ).toBeVisible();
+    },
+  },
+  // [SONNET-4.6] sq-yk2ho — 3 unlinked content routes added to inventory.
+  // These pages exist in src/app/ and each render an h1, but were absent from
+  // both e2e inventories before this PR.
+  {
+    path: "assurance/",
+    name: "/assurance",
+    artifact: async (page) => {
+      // h1: "Assurance — how to check that sparq works"
+      await expect(
+        page.getByRole("heading", { level: 1, name: /Assurance/i }),
+      ).toBeVisible();
+    },
+  },
+  {
+    path: "assurance/served-conformance/",
+    name: "/assurance/served-conformance",
+    artifact: async (page) => {
+      // h1: "Served-surface SPARQL 1.1 Protocol conformance"
+      await expect(page.getByRole("heading", { level: 1 }).first()).toBeVisible();
+    },
+  },
+  {
+    path: "dogfooding/",
+    name: "/dogfooding",
+    artifact: async (page) => {
+      // h1: "Dogfooding sparq"
+      await expect(
+        page.getByRole("heading", { level: 1, name: /Dogfooding/i }),
       ).toBeVisible();
     },
   },


### PR DESCRIPTION
## Summary

> 🤖 SPARQ agent (sq-yk2ho) — adding 3 real, rendered content routes that were absent from both e2e inventories despite existing in `src/app/`.

- **`site/e2e/surface-sweep.spec.ts`**: Added `/assurance`, `/assurance/served-conformance`, `/dogfooding` to `STATIC_ROUTES` in the per-PR surface-sweep lane. Each entry has an h1 artifact assertion (`/Assurance/i`, `first()`, `/Dogfooding/i`) consistent with the existing sweep patterns.
- **`site/e2e/nightly/a11y-full-inventory.spec.ts`**: Added the same 3 routes to `STATIC_ROUTES` in the nightly full-inventory AXE sweep (activated only under `SPARQ_NIGHTLY_A11Y=1`).

All 3 pages existed in `src/app/` and each render an h1 (verified from source):
- `/assurance` — "Assurance — how to check that sparq works"
- `/assurance/served-conformance` — "Served-surface SPARQL 1.1 Protocol conformance"
- `/dogfooding` — "Dogfooding sparq"

None of the 3 routes is intentionally unpublished (each has real content); no exclusion comment is needed.

## Gates

- `npm run build` (static export): green — all 3 routes emitted to `out/`
- `npm run lint`: green (no ESLint warnings/errors)
- `npm run typecheck`: green (tsc --noEmit, no errors)
- `npx playwright test --list`: 3 new `[chromium] surface-sweep.spec.ts` entries visible in per-PR lane
- `SPARQ_NIGHTLY_A11Y=1 npx playwright test --list`: 3 additional `[nightly-a11y] a11y-full-inventory.spec.ts` entries (nightly-only gate confirmed)
- `scripts/check-privacy-claims.sh`: green — no unqualified ZK/MPC claims

## Test plan

- [ ] Verify per-PR CI (chromium) picks up the 3 new `[sweep]` surface-sweep entries and they pass
- [ ] Verify nightly-a11y lane picks up the 3 new `[a11y-inventory]` entries under `SPARQ_NIGHTLY_A11Y=1`
- [ ] Confirm no regressions on existing surface-sweep guard tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)