### PR TITLE
docs(reason-ql): QL combined-approach evaluate-first spike — reasoned non-adoption (measured UCQ ≤4) (sq-pbz04.3.5) [OPUS-4.8]

### DIFF
--- a/crates/sparq-reason-ql/README.md
+++ b/crates/sparq-reason-ql/README.md
@@ -81,8 +81,8 @@ classifies any query as a CQ or `CqError::OutOfScope(reason)` and is the soundne
 > no answers. (Dropping a non-contained disjunct would be an unsoundness bug.)
 
 **Scope (honest):** positive-inclusion rewriting + tree-witness folding + containment minimisation.
-**No consistency checking**, no qualified existentials. The rewriter is oracle-tested
-(`tests/oracle.rs`, incl. the tree-witness + minimisation cases).
+**No consistency checking**, no qualified existentials; the **combined-approach / H-complete-ABox** lever was **evaluated + NOT adopted** (measured minimised UCQ ≤ 4 on the real corpus, no blow-up to amortise — `sq-pbz04.3.5`, profile in `examples/ql_rewrite_bench.rs`, rationale in `research/owl2-ql-cq-gate-broadening.md` §10).
+The rewriter is oracle-tested (`tests/oracle.rs`, incl. the tree-witness + minimisation cases).
 
 **Two conformance arms, two honesty stances (sq-qo1a9):**
 

--- a/crates/sparq-reason-ql/examples/ql_rewrite_bench.rs
+++ b/crates/sparq-reason-ql/examples/ql_rewrite_bench.rs
@@ -35,6 +35,18 @@ use sparq_reason_ql::{rewrite, rewrite_production};
 use std::str::FromStr;
 use std::time::Instant;
 
+// [OPUS-4.8] sq-pbz04.3.5: the SPARQL/Turtle prefixes the corpus-profile section uses (the
+// realistic QL corpus is written with prefixed names for readability). Kept separate from the
+// chain benchmark, which builds bare N-triples.
+const SPARQL_PREFIXES: &str = "PREFIX : <http://ex/> \
+    PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#> \
+    PREFIX owl: <http://www.w3.org/2002/07/owl#> \
+    PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> ";
+const TURTLE_PREFIXES: &str = "@prefix : <http://ex/> . \
+    @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> . \
+    @prefix owl: <http://www.w3.org/2002/07/owl#> . \
+    @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> . ";
+
 const RDFS_SUB_CLASS_OF: &str = "http://www.w3.org/2000/01/rdf-schema#subClassOf";
 const RDFS_SUB_PROPERTY_OF: &str = "http://www.w3.org/2000/01/rdf-schema#subPropertyOf";
 const RDF_TYPE: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
@@ -142,6 +154,156 @@ fn run_production(depth: usize) {
     );
 }
 
+// ===========================================================================================
+// [OPUS-4.8] sq-pbz04.3.5 — the combined-approach / H-complete-ABox EVALUATE-FIRST measurement.
+//
+// The combined approach (Kontchakov, Lutz, Toman, Wolter, Zakharyaschev — "The Combined Approach
+// to Query Answering in DL-Lite") trades a large query REWRITING for a hierarchy-completed
+// (H-complete) ABox plus a small filtering step: it wins ONLY WHEN pure PerfectRef rewriting
+// blows the UCQ up while ABox saturation stays cheap. Whether to adopt it here is therefore an
+// EMPIRICAL question about the UCQ-size DISTRIBUTION on the REAL corpus, not a literature claim.
+//
+// This section profiles `rewrite_production`'s minimised-UCQ size on (1) the REALISTIC corpus —
+// the graduated DL-Lite_R oracle shapes (mirrored from `sparq-conformance`'s `QL_DLLITE_ORACLE`)
+// plus the answered W3C `pr:QL` extensional-CQ shapes — versus (2) deliberately-adversarial
+// CEILING probes that force the product blow-up. UCQ sizes are a PURE, DETERMINISTIC function of
+// the (TBox, query), so every count is a CLOSED-FORM assertion — the reproducible evidence behind
+// the reasoned NON-ADOPTION recorded in `research/owl2-ql-cq-gate-broadening.md` §10. No
+// wall-clock here: the UCQ COUNTS are the canonical, load-robust metric (work-box seconds are not).
+// ===========================================================================================
+
+/// Parse a Turtle TBox (prefixes prepended) into triples for the rewriter.
+fn tbox_ttl(ttl: &str) -> Vec<Triple> {
+    let full = format!("{}{}", TURTLE_PREFIXES, ttl);
+    oxttl::TurtleParser::new()
+        .for_reader(full.as_bytes())
+        .collect::<Result<Vec<_>, _>>()
+        .expect("tbox turtle parse")
+}
+
+/// Parse a prefixed SPARQL `SELECT` query.
+fn cq(body: &str) -> Query {
+    parse(&format!("{}{}", SPARQL_PREFIXES, body))
+}
+
+/// The minimised UCQ size (`rewrite_production`) for a (TBox, query), asserting the raw-vs-minimised
+/// invariant. The realistic-corpus / ceiling helpers call this and assert the closed form.
+fn min_ucq(ttl: &str, body: &str) -> usize {
+    let tbox = tbox_ttl(ttl);
+    let query = cq(body);
+    let p = rewrite_production(&query, &tbox).expect("corpus case is in QL scope");
+    assert!(
+        p.report.disjuncts <= p.report.disjuncts_before_minimisation,
+        "minimisation must only REMOVE disjuncts: {} > {}",
+        p.report.disjuncts,
+        p.report.disjuncts_before_minimisation
+    );
+    p.report.disjuncts
+}
+
+/// The REALISTIC QL corpus: `(id, tbox_ttl, query, expected_minimised_ucq)`. Covers every
+/// DL-Lite_R rewriting axis the oracle proves (class subsumption incl. a transitive chain, the
+/// existential domain/range inclusions, role inclusion, `owl:inverseOf`, the unqualified `∃R`
+/// generator with its applicability condition, a two-distinguished-variable product, and the
+/// conjunction that minimises) PLUS the answered W3C `pr:QL` extensional-CQ shapes (a single/double
+/// class atom over a shallow RDFS hierarchy, a literal-object role atom). Each `expected` is the
+/// hand-verified closed form. [OPUS-4.8] sq-pbz04.3.5
+fn realistic_corpus() -> Vec<(&'static str, &'static str, &'static str, usize)> {
+    vec![
+        // --- graduated DL-Lite_R oracle shapes (mirror of QL_DLLITE_ORACLE C1..C11) ---
+        ("class-subsumption", ":Manager rdfs:subClassOf :Employee .", "SELECT ?x WHERE { ?x a :Employee }", 2),
+        ("transitive-subclass", ":A rdfs:subClassOf :B . :B rdfs:subClassOf :C .", "SELECT ?x WHERE { ?x a :C }", 3),
+        ("domain-introduces-role", ":worksFor rdfs:domain :Employee .", "SELECT ?x WHERE { ?x a :Employee }", 2),
+        ("range-introduces-inverse", ":worksFor rdfs:range :Company .", "SELECT ?y WHERE { ?y a :Company }", 2),
+        ("role-inclusion", ":manages rdfs:subPropertyOf :worksFor .", "SELECT ?x ?y WHERE { ?x :worksFor ?y }", 2),
+        ("inverse-of-role-chain", ":employs owl:inverseOf :worksFor . :manages rdfs:subPropertyOf :employs .", "SELECT ?x ?y WHERE { ?x :worksFor ?y }", 3),
+        ("exists-super-fires-unbound", ":Employee rdfs:subClassOf [ owl:onProperty :worksFor ; owl:someValuesFrom owl:Thing ] .", "SELECT ?x WHERE { ?x :worksFor ?y }", 2),
+        ("exists-super-blocked-bound", ":Employee rdfs:subClassOf [ owl:onProperty :worksFor ; owl:someValuesFrom owl:Thing ] .", "SELECT ?x ?y WHERE { ?x :worksFor ?y }", 1),
+        ("two-var-product", ":A rdfs:subClassOf :B .", "SELECT ?x ?y WHERE { ?x a :B . ?y a :B }", 4),
+        ("conjunction-minimises", ":A rdfs:subClassOf :B . :B rdfs:subClassOf :C .", "SELECT ?x WHERE { ?x a :A . ?x a :C }", 1),
+        ("empty-tbox-identity", "", "SELECT ?x WHERE { ?x a :Employee }", 1),
+        // --- answered W3C pr:QL extensional-CQ shapes ---
+        ("w3c-simple-typed", ":a rdfs:subClassOf :c .", "SELECT ?x WHERE { ?x rdf:type :c }", 2),
+        ("w3c-rdfs-subclass", ":aType rdfs:subClassOf :bType .", "SELECT ?x WHERE { ?x rdf:type :bType }", 2),
+        ("w3c-literal-object", "", "SELECT ?x WHERE { ?x <http://xmlns.com/foaf/0.1/name> \"name\"@en }", 1),
+    ]
+}
+
+/// Profile the realistic corpus + the adversarial ceiling probes and assert the closed forms. The
+/// realistic distribution is the load-bearing datum for the sq-pbz04.3.5 non-adoption verdict.
+fn run_corpus_profile() {
+    println!("\n[sq-pbz04.3.5] combined-approach evaluate-first — minimised-UCQ profile (deterministic)");
+
+    // (1) Realistic corpus: every case is asserted to its hand-verified closed form, and the
+    //     whole distribution is bucketed. The load-bearing claim: NOTHING blows up.
+    let corpus = realistic_corpus();
+    let mut sizes: Vec<usize> = Vec::new();
+    for (id, ttl, body, expected) in &corpus {
+        let m = min_ucq(ttl, body);
+        assert_eq!(
+            m, *expected,
+            "realistic case {} minimised UCQ {} != closed form {}",
+            id, m, expected
+        );
+        sizes.push(m);
+    }
+    sizes.sort_unstable();
+    let n = sizes.len();
+    let max = *sizes.last().unwrap();
+    let (mut b1, mut b2_4, mut b5_16, mut b17) = (0usize, 0usize, 0usize, 0usize);
+    for &s in &sizes {
+        match s {
+            1 => b1 += 1,
+            2..=4 => b2_4 += 1,
+            5..=16 => b5_16 += 1,
+            _ => b17 += 1,
+        }
+    }
+    // The DECISION rests on this: on the REAL corpus the minimised UCQ never exceeds a tiny bound,
+    // so there is no rewriting blow-up for the combined approach to remove. Assert it explicitly.
+    assert!(
+        max <= 4 && b5_16 == 0 && b17 == 0,
+        "REALISTIC corpus produced a large UCQ (max {}) — the non-adoption premise would need re-checking",
+        max
+    );
+    println!(
+        "  realistic corpus: {} answered cases  min {}  median {}  max {}  (dist [1]={} [2-4]={} [5-16]={} [17+]={})",
+        n, sizes[0], sizes[n / 2], max, b1, b2_4, b5_16, b17
+    );
+
+    // (2) Adversarial CEILING probes: the ONLY shape that blows up is a multi-atom CQ over
+    //     INDEPENDENT class hierarchies (the product), which minimisation cannot collapse (the
+    //     disjuncts are mutually incomparable). Closed forms: (k+1)^atoms. This is exactly the
+    //     combined approach's target — and exactly the shape ABSENT from the realistic corpus.
+    for k in [2usize, 3, 5, 8] {
+        // Two independent depth-k subclass chains, both class atoms on the SAME answer variable.
+        let ttl = format!("{} {}", chain_ttl("C", k), chain_ttl("D", k));
+        let body = format!("SELECT ?x WHERE {{ ?x a :C{} . ?x a :D{} }}", k, k);
+        let m = min_ucq(&ttl, &body);
+        assert_eq!(m, (k + 1) * (k + 1), "product-2 k={} UCQ {} != (k+1)^2", k, m);
+        println!("  ceiling product(2 atoms, depth {}): UCQ {} = (k+1)^2 (incomparable — minimisation cannot help)", k, m);
+    }
+    for k in [2usize, 3] {
+        let ttl = format!("{} {} {}", chain_ttl("C", k), chain_ttl("D", k), chain_ttl("E", k));
+        let body = format!("SELECT ?x WHERE {{ ?x a :C{} . ?x a :D{} . ?x a :E{} }}", k, k, k);
+        let m = min_ucq(&ttl, &body);
+        assert_eq!(m, (k + 1) * (k + 1) * (k + 1), "product-3 k={} UCQ {} != (k+1)^3", k, m);
+        println!("  ceiling product(3 atoms, depth {}): UCQ {} = (k+1)^3", k, m);
+    }
+    println!(
+        "  VERDICT: realistic UCQ <= 4; blow-up needs multi-atom CQs over independent deep \
+         hierarchies (absent from the corpus) => combined approach NOT adopted (see design record)."
+    );
+}
+
+/// A depth-`n` `rdfs:subClassOf` chain `:P0 ⊑ :P1 ⊑ … ⊑ :Pn` in Turtle (prefixed names).
+fn chain_ttl(prefix: &str, n: usize) -> String {
+    (0..n)
+        .map(|i| format!(":{}{} rdfs:subClassOf :{}{}.", prefix, i, prefix, i + 1))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
 fn main() {
     let depth: usize = std::env::args()
         .nth(1)
@@ -151,5 +313,6 @@ fn main() {
     run_subclass(depth);
     run_subproperty(depth);
     run_production(depth);
+    run_corpus_profile();
     println!("OK: closed-form UCQ-size assertions held (UCQ scales linearly; wall-clock above is trend-only).");
 }

--- a/research/owl2-ql-cq-gate-broadening.md
+++ b/research/owl2-ql-cq-gate-broadening.md
@@ -306,6 +306,105 @@ pinned `ql_dllite_suite` floor never regresses.**
 - `sq-4ldc4` → **closed as superseded** by `sq-pbz04.3.5` (tree-witness half landed in
   `treewitness.rs`; the H-complete/combined half re-scoped as an evaluate-first spike).
 
+## 10. Combined-approach / H-complete-ABox evaluate-first spike (`sq-pbz04.3.5`) — reasoned NON-ADOPTION
+
+[OPUS-4.8] `sq-pbz04.3.5` (supersedes `sq-4ldc4`). This is the §0-item-3 evaluation, executed
+measure-first. The combined approach (Kontchakov, Lutz, Toman, Wolter, Zakharyaschev — *The
+Combined Approach to Query Answering in DL-Lite*, IJCAI 2011) trades a large query **rewriting**
+for a hierarchy-completed (**H-complete**) ABox plus a small filtering step. It is a **performance
+lever, not a soundness gap**, and it wins **only when pure PerfectRef rewriting blows the UCQ up
+while ABox saturation stays cheap**. Whether it pays off here is therefore an empirical question
+about the **measured UCQ-size distribution** on the real corpus — not the literature's worst-case
+claim. **Verdict: NON-ADOPTION.** The numbers are below; no combined-approach code is added.
+
+### 10.1 What was measured (deterministic; counts, not wall-clock)
+
+The minimised-UCQ size (`rewrite_production`: PerfectRef ∪ tree-witness ∪ containment
+minimisation) is a **pure function of the (TBox, query)**, so every count is a closed form. The
+reproducible harness is `crates/sparq-reason-ql/examples/ql_rewrite_bench.rs` (the
+`run_corpus_profile` section — self-asserting closed forms, no fetched fixtures). Two axes:
+
+- **Realistic corpus** — the 11 graduated DL-Lite_R oracle shapes (mirror of
+  `sparq-conformance`'s `QL_DLLITE_ORACLE` C1..C11) **plus** the answered W3C `pr:QL`
+  extensional-CQ shapes (single/double class atom over a shallow RDFS hierarchy, a literal-object
+  role atom): **14 answered cases**.
+- **Adversarial ceiling probes** — multi-atom CQs over **independent** subclass chains (the
+  product shape), the only construction that forces a blow-up.
+
+### 10.2 The measured distribution
+
+| Corpus | Answered | min UCQ | median | max UCQ | Blow-up? |
+| --- | --- | --- | --- | --- | --- |
+| Realistic (oracle ∪ W3C answered) | 14 | 1 | 2 | **4** | none |
+
+Realistic distribution (minimised UCQ size): `[1] = 4`, `[2–4] = 10`, `[5–16] = 0`, `[17+] = 0`.
+**Nothing in the realistic corpus exceeds 4 disjuncts.**
+
+The full W3C `pr:QL` entailment corpus is **31 cases**; the always-present CQ-shape gate splits it
+**17 admitted / 14 held** (7 BIND-arithmetic, 3 variable-predicate, 4 intensional-schema atoms —
+each `permanently-outside` sound rewriting per §5/§6). Of the 17 admitted, twelve are single-atom
+and only three are multi-atom (`sparqldl-04` at 3 atoms, `sparqldl-06`/`-07` at 4) — **and those
+three carry OWL-DL TBoxes (property chains, `owl:sameAs`) that fall outside DL-Lite_R and are
+`skipped`**, so PerfectRef returns the identity UCQ (≈1 disjunct) despite the atom count. The
+answered class/role-atom cases sit over depth-1/2 RDFS hierarchies, giving 1–3 disjuncts.
+
+Ceiling probes (the shape that *does* blow up), closed forms `(k+1)^atoms`:
+
+| Probe | k = 2 | k = 3 | k = 5 | k = 8 |
+| --- | --- | --- | --- | --- |
+| product, 2 class atoms, same var | 9 | 16 | 36 | 81 |
+| product, 3 class atoms, same var | 27 | 64 | — | — |
+
+For every product probe the pre-minimisation and minimised counts are **equal** — the product
+disjuncts are mutually **incomparable**, so containment minimisation cannot collapse them. This is
+precisely the case the combined approach would remove (one CQ over an H-complete ABox instead of
+`(k+1)^atoms` CQs).
+
+### 10.3 Why NON-ADOPTION is the honest verdict
+
+1. **No blow-up on the real corpus.** The maximum measured realistic UCQ is **4 disjuncts**; the
+   median is 2. A 4-way (or 36-way, or 81-way) union of BGPs is trivially evaluable by the
+   in-memory engine — there is no rewriting cost for the combined approach to amortise.
+2. **The two blow-up sources that the corpus *does* exhibit are already handled.** The existential
+   chase is captured by **bounded tree-witness folding** (`treewitness.rs`), and redundant
+   disjuncts are dropped by **UCQ-containment minimisation** (`minimise.rs`) — both landed and
+   oracle-verified. The one blow-up the corpus does **not** exhibit (the incomparable product) is
+   the *only* thing the combined approach would add, and it is absent.
+3. **The blow-up requires a shape the corpus never produces:** a multi-atom conjunctive query
+   whose atoms sit over **independent, non-trivial (depth ≥ 1) class hierarchies**. It is **not**
+   the CQ-shape gate that bounds the UCQ (the gate admits multi-atom CQs) — it is the realistic
+   **query and TBox shapes** (single-atom-dominated queries, shallow hierarchies, and multi-atom
+   queries whose schema is outside DL-Lite_R). This distinction is the close-out lever below.
+4. **Adopting it cuts against the crate's load-bearing architecture.** The crate is a **pure
+   query-rewriter over the unmodified ABox**, reusing the engine's query path with **no store or
+   planner changes** (README "Query-rewriter seam"). The combined approach requires **materialising
+   an H-complete ABox** (data saturation) **plus** an anonymous-individual **filtering step** — a
+   store-side write path and a non-standard evaluation the engine does not have. Paying that
+   architectural cost for a UCQ that is already ≤ 4 disjuncts is a net regression, not a win.
+
+This mirrors the EL/QL substrate **reasoned non-adoption** precedent (the CR1–CR5 substrate joins,
+`research/owl2-rl-el-wave2-disposition.md` §3.1) and the RSP substrate non-adoption: adopt only
+when a measurement — not a worst-case bound — shows the lever pays.
+
+### 10.4 Close-out criteria — what would flip the calculus (revisit triggers)
+
+Re-open the spike (a fresh child bead, not a reopen of this record) **iff** a future change makes
+the product shape realistic AND the measured distribution shifts into the `[17+]` bucket:
+
+- **Fragment broadening lands multi-atom CQs over deep independent hierarchies** — e.g. graduating
+  a real-ontology QL benchmark whose TBox has wide/deep class hierarchies **and** whose query load
+  joins several such class atoms on one variable (LUBM/NPD-style analytic CQs). The gate already
+  admits the shape; only the corpus is missing.
+- **A DL-Lite_R TBox with deep hierarchies enters the answered set** (e.g. `owl:equivalentClass`
+  capture from `sq-pbz04.3.3` pulling in a large real vocabulary) so that a **single** rewritten
+  atom's UCQ contribution itself grows past a handful.
+- **Re-run `run_corpus_profile` after any such change**: if the realistic max/median climbs out of
+  the `≤ 4` band and minimisation demonstrably cannot collapse the product, the combined approach
+  becomes worth an evaluate-first **spike behind the `experimental` feature**, soundness-first,
+  with a **differential oracle vs `rewrite_production`** (certain-answer set equality on the whole
+  oracle suite) before any default-path change. Until then: no code, `rewrite_production` unchanged,
+  fail-closed gate untouched.
+
 ## References
 
 - Calvanese, De Giacomo, Lembo, Lenzerini, Rosati — *Tractable Reasoning and Efficient Query
@@ -313,6 +412,10 @@ pinned `ql_dllite_suite` floor never regresses.**
   over UCQs).
 - W3C — *OWL 2 Profiles* §3 (OWL 2 QL); *SPARQL 1.1 Entailment Regimes* (the regime semantics
   `.4` must pin its coincidence condition against).
+- Kontchakov, Lutz, Toman, Wolter, Zakharyaschev — *The Combined Approach to Query Answering in
+  DL-Lite*, IJCAI 2011 (the H-complete-ABox + filtering alternative to pure rewriting; §10). Cf.
+  Kontchakov, Rodríguez-Muro, Zakharyaschev — *Ontology-Based Data Access with Databases: A Short
+  Course*, RW 2013 (tree-witness rewriting, the landed `treewitness.rs`).
 - `research/owl2-el-ql-reasoning-spike.md` (the QL track; the applicability trap) and
   `research/reasoner-suite-on-substrate.md` §2.5 (the PerfectRef trap; sequencing).
 - Repo estate: `crates/sparq-reason-ql/` (`sq-t5bne`, `sq-g19x0`), the graduated DL-Lite_R


### PR DESCRIPTION
> 🤖 SPARQ agent — combined-approach / H-complete-ABox **evaluate-first spike** for `sq-pbz04.3.5` (supersedes `sq-4ldc4`), executed measure-first. **Verdict: reasoned NON-ADOPTION.** No speculative code — `src/lib.rs` unchanged, no `combined.rs`, fail-closed gate untouched.

## What this is

The OWL 2 QL **combined approach** (Kontchakov–Lutz–Toman–Wolter–Zakharyaschev, IJCAI 2011) trades a large query **rewriting** for a hierarchy-completed (**H-complete**) ABox + a filtering step. It wins **only when pure PerfectRef rewriting blows the UCQ up while ABox saturation stays cheap** — an *empirical* question about the measured UCQ-size distribution, not a literature claim. The bead asked to **implement only if the measured UCQ sizes warrant it, else a documented reasoned non-adoption** (the EL/QL-substrate + #1645 RSP precedent). They do not warrant it.

## Measured distribution (deterministic UCQ counts; work-box wall-clock is non-canonical and not recorded)

Reproducible harness: `crates/sparq-reason-ql/examples/ql_rewrite_bench.rs` (`run_corpus_profile` — self-asserting closed forms, no fetched fixtures).

- **Realistic corpus** — 11 graduated DL-Lite_R oracle shapes (mirror of `QL_DLLITE_ORACLE`) + the answered W3C `pr:QL` extensional-CQ shapes = **14 answered cases**: minimised UCQ **min 1, median 2, max 4**; distribution `[1]=4 [2-4]=10 [5-16]=0 [17+]=0`. **No blow-up.**
- **W3C `pr:QL` corpus (31 cases)** — the always-present CQ-shape gate splits it **17 admitted / 14 held** (7 BIND-arithmetic, 3 variable-predicate, 4 intensional-schema atoms — all `permanently-outside` sound rewriting). The **only** multi-atom admitted cases (`sparqldl-04`/`-06`/`-07`, 3–4 atoms) carry **OWL-DL** TBoxes (property chains, `owl:sameAs`) outside DL-Lite_R → `skipped` → **identity UCQ**.
- **Adversarial ceiling probes** — blow-up appears **only** for multi-atom CQs over **independent deep** class hierarchies (product = `(k+1)^atoms`: 9/16/36/81 for 2 atoms; 27/64 for 3). Pre-min == min for every probe: the product disjuncts are **incomparable**, so containment minimisation cannot collapse them — this is exactly the combined approach's target, and exactly the shape **absent** from the corpus.

## Why non-adoption is the honest verdict

1. Max realistic UCQ is **4 disjuncts** — a 4-way (or even 81-way) union of BGPs is trivially evaluable; there is no rewriting cost to amortise.
2. The two blow-up sources the corpus **does** exhibit are already handled: bounded **tree-witness folding** (`treewitness.rs`) + **UCQ-containment minimisation** (`minimise.rs`), both landed + oracle-verified. The one thing the combined approach would add (collapsing the incomparable product) is absent.
3. The blow-up needs a shape the corpus never produces (multi-atom CQ over independent deep hierarchies). It is **not** the gate that bounds the UCQ — it is the realistic query/TBox shapes.
4. Adopting it requires **materialising an H-complete ABox + a filtering step** — a store-side write path + non-standard evaluation that cut against the crate's **pure-rewriter / unmodified-ABox / unchanged-engine-query-path** architecture. Net regression for a UCQ already ≤4.

**Close-out triggers** (revisit as a fresh child bead, not a reopen) are recorded in `research/owl2-ql-cq-gate-broadening.md` §10.4: fragment broadening that lands multi-atom CQs over deep independent hierarchies (LUBM/NPD-style), or a deep-hierarchy DL-Lite_R TBox entering the answered set — re-run `run_corpus_profile`; if the realistic max climbs out of the ≤4 band, an evaluate-first `experimental`-gated spike with a differential oracle vs `rewrite_production` becomes warranted.

## Files
- `crates/sparq-reason-ql/examples/ql_rewrite_bench.rs` — reproducible corpus profile + ceiling probes (self-asserting closed forms).
- `crates/sparq-reason-ql/README.md` — terse honest note (net-neutral, stays at 120-line cap).
- `research/owl2-ql-cq-gate-broadening.md` §10 — the reasoned non-adoption + the numbers + close-out criteria.

## Gates (both feature states)
`cargo build` / `cargo clippy --all-targets -- -D warnings` / `cargo test` GREEN with **default (feature OFF)** AND **`--features experimental`**; `cargo doc --workspace --no-deps --all-features` (`RUSTDOCFLAGS=-D warnings`) clean; `check-readme-template.py --enforce` 0 deviations (README 120 lines); markdownlint + typos clean. The extended example runs its closed-form assertions (`cargo run -p sparq-reason-ql --example ql_rewrite_bench --features experimental`).

Not self-armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)