### PR TITLE
docs(research): test-quality program wave 2 — decomposition of the sq-qcnn remainder (sq-qcnn.28–.38) [FABLE-5]

### DIFF
--- a/research/test-quality-program-plan.md
+++ b/research/test-quality-program-plan.md
@@ -178,3 +178,145 @@ policy; everything else is mechanical-once-scoped fleet work.
    documented floor of provably-equivalent survivors — not to an undifferentiated number.
 
 Beads carry ids `sq-qcnn.*` under the epic; this record is the plan of record for the wave.
+
+---
+
+## Wave 2 (2026-07-06) — remaining floors, nightly-mutants truth, per-PR mutation subset, structural guards, Kani disposition
+
+> [FABLE-5] Second architect pass on the same epic (one epic → **one** design record, so
+> this is an update, not a new file). Verified against `origin/main` `f58a9c9f` + the live
+> CI run ledger — not taken from the wave-1 text on faith.
+
+### Corrected premises (what wave 1 got stale)
+
+1. **"The nightly-mutants mechanism is fixed" (sq-qcnn.11 / #1378) is only PARTIALLY true.**
+   The latest scheduled run (28776460517, 2026-07-06) shows **16/26 mutation shards
+   succeed** (and upload artifacts), **5 are cancelled at exactly the ~2 h boundary**
+   (sparq-core, sparq-engine, sparq-solid, sparq-zk-compose, sparq-vectors — a per-job
+   timeout, not the old concurrency-group cancel), and **5 fail outright** (sparq-reason
+   ~10 min, sparq-prov ~6 min, sparq-mpc ~57 min, sparq-server ~108 min, sparq-substrate
+   ~18 min — failure logs NOT yet read; the fix bead reads the full `--log` FIRST, per the
+   house CI-debugging rule). `bench/mutants-baseline.json` still holds only **6** crates.
+   The epic's end-state (sq-qcnn.27 promotion) is blocked here, not on wave-1 test-writing.
+2. **Two new sub-90 crates exist that wave 1 could not plan for:** the sq-6vshe.4 facade
+   split created `sparq-engine-serialize` (floor 88, measured 90.95) and
+   `sparq-engine-service` (floor 84, measured 86.78) after the wave-1 table was written.
+3. **"Raise to 90" wave-1 beads landed floors at `floor(measured)−2`, not 90.** reason
+   (88, measured 90.52), server (88, measured 90.19), engine (87, measured 89.85) all
+   closed honestly below the epic's floor-≥90 bar (floor 90 ⇒ measured ≥ 92). Second
+   passes are genuine remaining work, not re-litigation.
+4. **Open wave-1 beads NOT duplicated here:** sq-qcnn.5–.10 (value-level diff-test lane,
+   own record), sq-qcnn.23 (reason-el/ql gate wiring), sq-qcnn.27 (mutants promotion),
+   sq-has2g (engine mutation-kill once seeded).
+
+### The 2026-07-06 review-catch classes → structural guards
+
+Today's review ledger caught, among others (verifiable instances cited): **(C1)
+feature-gated test modules with no CI executor** — tests compiled but never run (#1672,
+caught **twice**: missing matrix leg, then missing golden line); **(C2) gate-intent checks
+placed in advisory jobs** — provably non-gating (#1679's G3 self-test moved to the hard G6
+job); **(C3) jobs gating `ci-summary` without recorded probation evidence** (#1656,
+gui-mock-ipc); **(C4) vacuous assertions** (the standing class the mutation ratchet exists
+for; cf. the vacuous #1432 egress assertion); **(C5) proof-harness vacuity** via
+`assume`/`unwind` pruning (sq-sqtk2.7; already made structural by #1536 —
+`research/mechanized-proof-program.md` §5.1–§5.2 mandatory domain-coverage self-checks).
+The program's job is to make C1–C4 **checked by machinery, not by reviewer vigilance**:
+
+- **G1 — feature-gated-test execution completeness** (`scripts/check-feature-test-execution.py`,
+  wired GATING in `feature-matrix.yml`): enumerate every `#[cfg(feature = …)]` /
+  `#![cfg(feature = …)]`-gated test module and every `[[test]]`/`[[bench]]` target with
+  `required-features`; assert each feature-set is actually enabled by ≥ 1 CI executor —
+  a feature-matrix leg (`scripts/assemble-feature-matrix.py` output), a
+  `scripts/coverage.sh measure()` feature-set, or an explicit allowlist entry with a
+  reason (device-gated GPU, wasm-pack-only). Fail-closed on unmapped. Static +
+  deterministic ⇒ gating from day one, fixture-tested in both directions (a synthetic
+  ungated feature-test must go RED). Makes the #1672 class structurally impossible.
+- **G2 — advisory-job registry + gate-intent placement** (`.github/advisory-registry.json`
+  + `scripts/check-advisory-registry.py`, wired in `docs-quality.yml`): every job whose
+  name matches the ci-summary `\b(advisory|informational)\b` exclusion regex must carry a
+  registry entry `{owner_bead, promotion_criteria, registered}`; and no step invoking a
+  gate-classified script (`scripts/*gate*.py`, G-numbered self-tests) may sit inside an
+  advisory-named job without an explicit waiver. Generalises the E2E gating-policy ledger
+  (#1657) repo-wide. Makes the #1679 + #1656 classes visible-by-diff instead of
+  visible-by-catch.
+- **C4 (vacuous tests)** is covered by the mutation machinery — the missing piece is the
+  **per-PR subset** (M2 below): nightly-only mutation signal arrives days after the
+  vacuous test merges; `--in-diff` gives the signal at PR time on exactly the changed code.
+
+### Per-PR mutation subset (M2) — design decision
+
+The full ratchet stays **nightly** (cargo-mutants rebuilds + reruns the suite once per
+mutant; a full run is hours per big crate — never per-PR). Per-PR we add a **dedicated
+workflow** (`.github/workflows/mutants-diff.yml` + `scripts/mutants-diff.sh`) running
+`cargo mutants --in-diff` over the PR's merge-base diff, bounded (mutant cap + per-run
+timeout + `--baseline skip` where sound), **ADVISORY at introduction** and registered in
+G2's registry with explicit promotion criteria (stable across N observed PRs, median
+runtime within budget, a survivors-allowlist mechanism designed). Rationale for
+advisory-first rather than gating: surviving mutants on new code include
+provably-equivalent ones (see the sparq-prov/sparq-mpc baseline notes), so an unallowlisted
+hard gate would force either assertion-gaming or blanket overrides — the PR-time value is
+*review signal* ("your new tests never notice this mutant"), promoted only once the
+allowlist idiom exists. A dedicated workflow file keeps it off the required `ci-summary`
+path and file-disjoint from sq-qcnn.27's `ci.yml` promotion edit.
+
+### Kani / #1487 disposition (inventory only — owned by sq-sqtk2, no bead created here)
+
+Draft PR #1487 (WAC/ACP decision-core proof harnesses, `crates/sparq-solid`) is **not
+landable as-is** and is honestly labelled so in its own body: no complete
+`cargo kani -p sparq-solid` run exists (zero harnesses completed in ~50 min under
+contention). It belongs to epic sq-sqtk2 (bead sq-sqtk2.1, blocked by sq-sqtk2.7), not to
+this epic. What it takes to land, per the PR body + sq-sqtk2.7 notes: (a) the in-flight
+re-scoping — FlattenCompat elimination, symbolic-string shrinking, `unwind` 24→40 (which
+also fixes a real vacuity: `unwind(24)` silently `assume`-pruned the 32–39-byte
+PUBLIC/AUTHENTICATED/ANY_* principal paths, so the deny-wins/fail-closed harnesses were
+vacuous for exactly the security-relevant identities); (b) a complete tee'd kani log
+quoting every `VERIFICATION:- SUCCESSFUL` line (likely needs the dedicated/uncontended
+runner sq-sqtk2.7 recommends); (c) the deny-wins mutation RED→GREEN evidence; (d)
+domain-coverage self-checks per `research/mechanized-proof-program.md` §5.1–§5.2 —
+mandatory since #1536. Program touchpoint: C5 is this epic's vacuous-test class applied to
+proofs and is **already codified there** — nothing to duplicate. Consequence for this
+wave: the `sparq-solid` coverage raise (floor 89) stays **deferred** (wave-1 non-target +
+live file-collision with the #1487 branch).
+
+### Wave-2 beads (disjoint; created under the epic 2026-07-06)
+
+| # | bead | surface (files) | tier | invariant | acceptance |
+|---|---|---|---|---|---|
+| W2-M0 | sq-qcnn.28 — fix the 10 non-green nightly mutants shards | `.github/workflows/ci.yml` (mutants job only) | sonnet | lane stays advisory + off the required path; no gating job weakened | next scheduled/dispatched nightly: 26/26 mutation shards `success` + artifacts complete |
+| W2-M1 | sq-qcnn.29 — seed every complete-artifact unseeded crate | `bench/mutants-baseline.json` | sonnet | no knowingly-false ceiling (entries only from COMPLETE rollups; absence ≠ zero) | `scripts/mutants-gate.py --check` green; new entries byte-match their artifact rollups |
+| W2-M2 | sq-qcnn.30 — per-PR `--in-diff` mutation lane | `.github/workflows/mutants-diff.yml` + `scripts/mutants-diff.sh` (new files) | sonnet | advisory + bounded; required `ci-summary` path untouched | forced lane failure does not block a PR; diff-only mutant set demonstrated on a probe PR |
+| W2-G1 | sq-qcnn.31 — feature-gated-test execution check | `scripts/check-feature-test-execution.py` + fixtures + `feature-matrix.yml` | sonnet | every feature-gated test module/target has ≥ 1 CI executor (fail-closed) | check RED on synthetic ungated fixture, GREEN on tree; gating leg wired |
+| W2-G2 | sq-qcnn.32 — advisory-registry + gate-placement check | `scripts/check-advisory-registry.py` + `.github/advisory-registry.json` + `docs-quality.yml` | sonnet | no unregistered advisory job; no gate-script in an advisory job w/o waiver | check RED on both fixture classes, GREEN on tree with seeded registry |
+| W2-R1 | sq-qcnn.33 — sparq-engine-serialize 88→90 | `crates/sparq-engine-serialize/**` + its floor entry | haiku | floors only rise; direct value-asserting tests (no vacuity) | `cargo llvm-cov -p sparq-engine-serialize --features serialize-rdf,streaming-serialization` ≥ 92; `coverage-gate.py --check` at floor 90 |
+| W2-R2 | sq-qcnn.34 — sparq-engine-service 84→90 | `crates/sparq-engine-service/**` + its floor entry | sonnet | same + SSRF egress tests stay fail-closed | `cargo llvm-cov -p sparq-engine-service --features service` ≥ 92; floor 90 |
+| W2-R3 | sq-qcnn.35 — sparq-engine 87→90 (exec.rs 86.99, explain.rs 85.55 first) | `crates/sparq-engine/**` + its floor entry | sonnet | result-equivalence: tests pin exact SPARQL semantics values | `cargo llvm-cov -p sparq-engine` ≥ 92; floor 90 |
+| W2-R4 | sq-qcnn.36 — sparq-reason 88→90 2nd pass (n3/mod.rs 88.92) | `crates/sparq-reason/**` + its floor entry | sonnet | reasoner answer-soundness pins (exact derived triples) | `cargo llvm-cov -p sparq-reason` ≥ 92; floor 90 |
+| W2-R5 | sq-qcnn.37 — sparq-server 88→90 2nd pass | `crates/sparq-server/**` + its floor entry | sonnet | error-envelope/protocol tests assert exact bodies/status | `cargo llvm-cov -p sparq-server` ≥ 92; floor 90 |
+| W2-R6 | sq-qcnn.38 — sparq-zk-compose 85→90 (**route OPUS, maintainer-arm**) | `crates/sparq-zk-compose/**` + its floor entry | opus | determinism/fail-closed tests only; **NO ZK soundness/privacy claim** (external audit pending, sq-qhy4) | `cargo llvm-cov -p sparq-zk-compose` ≥ 92; floor 90; privacy-claims gate green |
+
+**Dependency edges (ordering that is real, plus registry-adjacency sequencing):**
+sq-qcnn.27 ← {W2-M0, W2-M1} (promotion needs a fully-green, fully-seeded lane);
+sq-has2g ← W2-M1 (engine mutation-kill starts from a seeded ceiling);
+W2-M2 ← W2-G2 (the new advisory lane registers itself in G2's registry file);
+W2-R2 ← W2-R1 and W2-R3 ← W2-R2 (their `coverage-floor.json` keys are textually
+**adjacent** — sequenced to honour no-two-in-flight-beads-on-adjacent-lines);
+W2-R4 ← sq-qcnn.23 (sq-qcnn.23 inserts `sparq-reason-el`/`-ql` entries adjacent to
+`sparq-reason`'s).
+
+**Shared-registry caveat (the only intentional disjointness exception, wave-1 precedent):**
+every W2-R bead edits exactly its own crate entry in `bench/coverage-floor.json`. Raise
+beads must **NOT** touch `bench/mutants-baseline.json` (owned by W2-M1 this wave — their
+crates' mutation ceilings arrive via the nightly seed, and mutation-kill passes get their
+own later beads once survivor counts are real, mirroring sq-has2g).
+
+### Wave-2 success criteria (delta over wave 1's)
+
+1. A scheduled nightly exists with **26/26** mutation shards green; `mutants-baseline.json`
+   covers every non-excluded crate (absence ≠ zero survivors stays true until then).
+2. All sub-90 core-logic floors raised to 90 except the two **documented** deferrals:
+   `sparq-solid` (#1487 collision) and the `floor: 0` measurement-artifact crates.
+3. G1 + G2 are gating, fixture-tested, and the current tree passes both — C1/C2/C3 become
+   diff-visible.
+4. The per-PR `--in-diff` lane runs on real PRs as registered-advisory with recorded
+   promotion criteria.
+5. sq-qcnn.27 (promotion to gating) is unblocked by measurement, not by optimism.


### PR DESCRIPTION
> 🤖 SPARQ agent (Fable-tier architect stage, Claude Fable 5). Design record only — no implementation; the child beads carry the impl work.

## What this is

The **wave-2 architect pass** on epic **sq-qcnn** (test-quality program: cargo-mutants ratchet + coverage floors ≥90 on core-logic crates). Wave 1 (this same record, PR #1377) is 19/27 drained; this update appends the wave-2 section to the epic's single design record and decomposes the remainder into **11 disjoint child beads sq-qcnn.28–.38** (created via `bd`, no PRs of their own — one impl PR per bead later).

## Key decisions ([FABLE-5])

- **Corrected premise:** sq-qcnn.11/#1378 did NOT fully fix the nightly mutants lane. Verified on scheduled run 28776460517 (2026-07-06): 16/26 shards green, **5 timeout-cancelled at ~2 h** (core/engine/solid/zk-compose/vectors), **5 failing** (reason/prov/mpc/server/substrate). `bench/mutants-baseline.json` still holds 6 crates. Fix (sq-qcnn.28) + honest seed (sq-qcnn.29) now gate the sq-qcnn.27 promotion.
- **Per-PR mutation subset** (sq-qcnn.30): `cargo mutants --in-diff` in a NEW dedicated workflow, **advisory-first** with registered promotion criteria — full ratchet stays nightly (per-mutant rebuild cost), and surviving-mutant judgment (provably-equivalent survivors exist) needs an allowlist idiom before it can gate.
- **Structural guards for the 2026-07-06 review-catch classes:** C1 feature-gated-tests-with-no-CI-executor (#1672, caught twice) → gating check sq-qcnn.31; C2 gate-intent-in-advisory-job (#1679) + C3 unratified-gating (#1656) → advisory-registry check sq-qcnn.32. C5 (proof vacuity) is already codified in `research/mechanized-proof-program.md` §5.1–§5.2 — nothing duplicated.
- **Kani #1487 disposition:** inventoried as owned by sq-sqtk2.1/sq-sqtk2.7 — not landable without a complete kani log + the unwind-vacuity fix + domain-coverage self-checks; **no bead created here**; the sparq-solid coverage raise stays deferred (file collision with that branch).
- **Coverage raises** sq-qcnn.33–.38 for the remaining sub-90 floors (engine-serialize/service are post-wave-1 facade-split crates). sparq-zk-compose is routed **opus + maintainer-arm**; its tests pin determinism/fail-closed behaviour only and make **no ZK soundness/privacy claim** — the external cryptographer audit remains pending (sq-qhy4).
- **Disjointness:** one crate/surface per bead; the only shared file is `bench/coverage-floor.json` (each bead edits exactly its own entry — wave-1 precedent), with textually-adjacent entries **sequenced via `bd dep`** (serialize→service→engine chain; reason after sq-qcnn.23).

Judgment calls logged for post-hoc steer in the companion issue (proceed-and-document).

Bead: sq-qcnn (epic, in_progress). Gates: markdownlint 0 errors, typos clean, privacy-claims OK.