### PR TITLE
bench(wasm): wasm-opt -Oz shipped-size trend series (sq-7d3dj.14)

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -153,6 +153,12 @@ jobs:
         with:
           targets: wasm32-unknown-unknown   # enables the wasm bundle-size metric in ci-bench.sh
       - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+      # [OPUS-4.8] (sq-7d3dj.14) binaryen (wasm-opt) — installed unconditionally so the
+      # TREND-ONLY wasm_opt_bundle_bytes metric runs on BOTH PR and main tiers. ci-bench.sh
+      # guards on `command -v wasm-opt` so the step is a no-op skip when absent. The version
+      # is logged per CI run (see ci-bench.sh wasm_opt_bundle_bytes block).
+      - name: Install binaryen (wasm-opt for shipped-size trend metric)
+        run: sudo apt-get update -q && sudo apt-get install -y binaryen
       # [OPUS-4.8] Well-known-suite toolchains (sp2b/dbpsb/watdiv/bsbm/lubm), MAIN ONLY. On push to
       # main the full well-known-suite set runs; on PRs we DELIBERATELY do NOT install these, so the
       # ci-bench.sh suite hooks SKIP gracefully (each is guarded on `command -v <tool>`) and PR perf

--- a/bench/dashboard/metric-labels.json
+++ b/bench/dashboard/metric-labels.json
@@ -2500,6 +2500,13 @@
       "query": "compiled sparq-wasm browser bundle size",
       "unit": "bytes"
     },
+    "wasm_opt_bundle_bytes": {
+      "label": "WASM shipped size (wasm-opt -Oz)",
+      "suite": "Memory / Size",
+      "dataset": "n/a (build artifact, post wasm-opt -Oz; binaryen — version logged per CI run)",
+      "query": "sparq-wasm bundle size after wasm-opt -Oz (trend-only; raw gate is wasm_bundle_bytes)",
+      "unit": "bytes"
+    },
     "watdiv_sf1000_C1_count": {
       "label": "WatDiv C1 (SF=1000) — complex query, count",
       "suite": "WatDiv",

--- a/scripts/ci-bench.sh
+++ b/scripts/ci-bench.sh
@@ -955,12 +955,31 @@ infs=$("$CLI" reason "$TMP/inf.ttl" turtle rdfs 2>&1 | grep -oE 'in [0-9.]+s' | 
 # crates + strip=symbols; hot engine crates stay opt-level 3). This ratchets the raw `cargo
 # build` `.wasm`, not the post-wasm-bindgen/wasm-opt npm artifact, so it tracks the profile
 # the shipped bundle uses. Skipped gracefully when the wasm target isn't installed.
+WASM_BIN=""
 if rustup target list --installed 2>/dev/null | grep -q wasm32-unknown-unknown; then
   if cargo build --profile release-wasm -q -p sparq-wasm --target wasm32-unknown-unknown 2>/dev/null; then
     WASM_BIN=$(ls target/wasm32-unknown-unknown/release-wasm/*.wasm 2>/dev/null | head -1)
     if [ -n "${WASM_BIN:-}" ]; then
       add wasm_bundle_bytes bytes "$(wc -c < "$WASM_BIN" | tr -d ' ')"
     fi
+  fi
+fi
+
+# [OPUS-4.8] (sq-7d3dj.14) wasm_opt_bundle_bytes — TREND-ONLY shipped size after wasm-opt -Oz.
+# The raw wasm_bundle_bytes above is the HARD-GATED deterministic ratchet (scripts/perf-gate.py,
+# 2% band). This companion series emits the post-wasm-opt -Oz size (the "shipped" artifact after
+# the same wasm-bindgen/wasm-opt pass that `wasm-pack build` runs for the published npm bundle).
+# The ~10% gap between the two is name-section and producer metadata that browsers strip at load
+# time — real bundle-size wins from the optimisation program show up here while the raw gate stays
+# bit-identical. TREND-ONLY: scripts/perf-gate.py is intentionally UNTOUCHED. The wasm-opt version
+# is logged to stderr so per-run comparisons can account for tool-version changes. Skipped gracefully
+# when wasm-opt (binaryen) is absent or the wasm binary was not built above.
+if command -v wasm-opt >/dev/null 2>&1 && [ -n "${WASM_BIN:-}" ] && [ -f "${WASM_BIN:-}" ]; then
+  WASM_OPT_VER="$(wasm-opt --version 2>&1 | head -1 || echo 'unknown')"
+  echo "note: wasm-opt version for wasm_opt_bundle_bytes: $WASM_OPT_VER" >&2
+  WASM_OPT_OUT="$TMP/opt.wasm"
+  if wasm-opt -Oz --strip-debug --strip-producers "$WASM_BIN" -o "$WASM_OPT_OUT" 2>/dev/null; then
+    add wasm_opt_bundle_bytes bytes "$(wc -c < "$WASM_OPT_OUT" | tr -d ' ')"
   fi
 fi
 

--- a/scripts/gen-metric-labels.py
+++ b/scripts/gen-metric-labels.py
@@ -75,6 +75,15 @@ FIXED = {
         "label": "WASM bundle size",
         "suite": "Memory / Size", "dataset": "n/a (build artifact)",
         "query": "compiled sparq-wasm browser bundle size", "unit": "bytes"},
+    # [OPUS-4.8] (sq-7d3dj.14) TREND-ONLY shipped size after wasm-opt -Oz. Emitted alongside
+    # wasm_bundle_bytes (the hard-gated raw ratchet) to make real shipped-size wins visible.
+    # Not in scripts/perf-gate.py. The wasm-opt version is logged per CI run (see ci-bench.sh).
+    "wasm_opt_bundle_bytes": {
+        "label": "WASM shipped size (wasm-opt -Oz)",
+        "suite": "Memory / Size",
+        "dataset": "n/a (build artifact, post wasm-opt -Oz; binaryen — version logged per CI run)",
+        "query": "sparq-wasm bundle size after wasm-opt -Oz (trend-only; raw gate is wasm_bundle_bytes)",
+        "unit": "bytes"},
 }
 
 # --- qlever-synthetic: descriptive filenames (qNN_<slug>); slug words are the description -----


### PR DESCRIPTION
> 🤖 SPARQ agent — bench(wasm): emit wasm-opt -Oz shipped bundle size as a TREND-ONLY series (sq-7d3dj.14) [OPUS-4.8]

## What

Adds `wasm_opt_bundle_bytes` as a companion metric to the existing hard-gated `wasm_bundle_bytes` ratchet.

After the `cargo build --profile release-wasm` step builds the raw `.wasm` artifact, the new block runs `wasm-opt -Oz --strip-debug --strip-producers` (binaryen) on the same file and emits the post-optimisation byte count as a **TREND-ONLY** series in the benchmark dashboard.

**`scripts/perf-gate.py` is intentionally untouched** — the hard deterministic gate on the raw file size is bit-identical to before. The new metric is purely observational: it surfaces the ~10% gap between the raw `cargo build` artifact and the shipped bundle (name-section + producer metadata that browsers discard at load time), so real wins from the optimisation program (sq-7d3dj) become visible in the trend without risk to the gate.

## Changes

| File | Change |
|------|--------|
| `scripts/ci-bench.sh` | Hoist `WASM_BIN=""` before the wasm build block; add the `wasm_opt_bundle_bytes` measurement block (guarded on `command -v wasm-opt`; graceful skip when binaryen absent) |
| `scripts/gen-metric-labels.py` | Add `wasm_opt_bundle_bytes` to `FIXED` with dataset note that the binaryen version is logged per CI run |
| `bench/dashboard/metric-labels.json` | Regenerated (429 metrics, was 428) |
| `.github/workflows/bench.yml` | Install `binaryen` unconditionally so the trend metric runs on both PR and main tiers |

## Gates run

- `bash -n scripts/ci-bench.sh` — bash syntax OK
- `python3 scripts/gen-metric-labels.py --check` — metric-labels.json up to date
- `python3 scripts/perf-gate.py --self-test` — all assertions passed (perf-gate.py untouched)
- `node scripts/dashboard-smoke.js` — all 183 checks passed
- `python3 scripts/check-readme-template.py --enforce` — 0 deviations across 52 READMEs
- `python3 scripts/check-no-perf-numbers.py` — 0 findings
- `python3 scripts/check-privacy-claims.sh` — OK, no ZK/MPC claims
- `python3 scripts/check-terminology.py` — no deprecated wording
- No Rust code changed; Rust build/clippy/test/rustdoc gates not applicable

## Feature states

This bead has no Cargo feature — the measurement is in a bash script. The `wasm-opt` block is guarded on `command -v wasm-opt`, so it is a no-op if binaryen is absent (the existing `wasm_bundle_bytes` gate is unaffected).

## Parent epic

sq-7d3dj (cross-cutting optimisation program) — measurement-fidelity bead 14.