### PR TITLE
bench(mutants): seed 12 unseeded crates from nightly run 28776460517 wave-2 (sq-qcnn.29) [OPUS-4.8]

### DIFF
--- a/bench/mutants-baseline.json
+++ b/bench/mutants-baseline.json
@@ -17,13 +17,47 @@
       "unviable": 3
     },
     "sparq-canon": {
-      "_note": "[OPUS-4.8] sq-qcnn.14: measured with --features rdf12-triple-terms (the rdf12.rs NON-STANDARD RDF-1.2 triple-term profile is gated behind this feature; without it, cargo-mutants generates rdf12.rs mutations but they are trivially missed because the module is not compiled). 4 surviving mutations are all comparison-operator variants in CanonState::hash_n_degree_quads path-pruning logic (lines 429, 430, 448, 459) — a hard-to-distinguish HNDQ optimization boundary guard.",
+      "_note": "[OPUS-4.8] sq-qcnn.14: measured with --features rdf12-triple-terms (the rdf12.rs NON-STANDARD RDF-1.2 triple-term profile is gated behind this feature; without it, cargo-mutants generates rdf12.rs mutations but they are trivially missed because the module is not compiled). 4 surviving mutations are all comparison-operator variants in CanonState::hash_n_degree_quads path-pruning logic (lines 429, 430, 448, 459) \u2014 a hard-to-distinguish HNDQ optimization boundary guard.",
       "caught": 104,
       "caught_pct": 96.3,
       "ceiling": 6,
       "measured_surviving": 4,
       "timeout": 0,
       "unviable": 32
+    },
+    "sparq-fedclient": {
+      "_note": "[OPUS-4.8] sq-qcnn.29: 0 mutations caught (553 survived) \u2014 same pattern as sparq-fedplan: baseline build passes, but all mutations survive because in-process test assertions are absent. sq-qcnn.22 (PR #1389) raised line coverage to 90% via direct unit tests but those tests do not yet assert on return values or behavioral invariants that cargo-mutants probes. Ceiling is honest; further direct assertion tests are the remedy.",
+      "caught": 0,
+      "caught_pct": 0.0,
+      "ceiling": 555,
+      "measured_surviving": 553,
+      "timeout": 0,
+      "unviable": 0
+    },
+    "sparq-fedplan": {
+      "_note": "[OPUS-4.8] sq-qcnn.29: 0 mutations caught (534 survived) \u2014 the baseline build passes but no in-process assertion detects any behavioral change. sparq-fedplan tests are integration-style (exercised end-to-end via the federation engine path, not via `cargo test` in-crate unit assertions). The ceiling is the honest measured value; adding direct unit tests with value assertions is the sq-qcnn test-raise program for this crate.",
+      "caught": 0,
+      "caught_pct": 0.0,
+      "ceiling": 536,
+      "measured_surviving": 534,
+      "timeout": 0,
+      "unviable": 0
+    },
+    "sparq-geo": {
+      "caught": 499,
+      "caught_pct": 66.23,
+      "ceiling": 261,
+      "measured_surviving": 259,
+      "timeout": 9,
+      "unviable": 468
+    },
+    "sparq-hdt": {
+      "caught": 179,
+      "caught_pct": 82.27,
+      "ceiling": 41,
+      "measured_surviving": 39,
+      "timeout": 2,
+      "unviable": 10
     },
     "sparq-introspect": {
       "caught": 179,
@@ -33,6 +67,14 @@
       "timeout": 23,
       "unviable": 5
     },
+    "sparq-nlq": {
+      "caught": 185,
+      "caught_pct": 51.81,
+      "ceiling": 175,
+      "measured_surviving": 173,
+      "timeout": 1,
+      "unviable": 53
+    },
     "sparq-parse": {
       "caught": 73,
       "caught_pct": 83.17,
@@ -40,6 +82,14 @@
       "measured_surviving": 17,
       "timeout": 11,
       "unviable": 1
+    },
+    "sparq-policy": {
+      "caught": 387,
+      "caught_pct": 70.24,
+      "ceiling": 166,
+      "measured_surviving": 164,
+      "timeout": 0,
+      "unviable": 46
     },
     "sparq-prov": {
       "caught": 151,
@@ -49,6 +99,39 @@
       "timeout": 1,
       "unviable": 22
     },
+    "sparq-rsp": {
+      "caught": 296,
+      "caught_pct": 86.49,
+      "ceiling": 52,
+      "measured_surviving": 50,
+      "timeout": 24,
+      "unviable": 51
+    },
+    "sparq-serve": {
+      "caught": 108,
+      "caught_pct": 24.7,
+      "ceiling": 377,
+      "measured_surviving": 375,
+      "timeout": 15,
+      "unviable": 61
+    },
+    "sparq-shacl": {
+      "_note": "[OPUS-4.8] sq-qcnn.29: 994 surviving mutants on a large crate (1629 viable). 36% catch rate reflects that many SHACL evaluation paths are exercised by W3C conformance tests run via subprocess (sparq-conformance), not in-process assertions inside sparq-shacl itself. Ceiling is the honest measured value; the sq-qcnn coverage-raise program targets adding in-process assertions to reduce survivors.",
+      "caught": 562,
+      "caught_pct": 36.32,
+      "ceiling": 996,
+      "measured_surviving": 994,
+      "timeout": 5,
+      "unviable": 68
+    },
+    "sparq-sim": {
+      "caught": 71,
+      "caught_pct": 76.04,
+      "ceiling": 25,
+      "measured_surviving": 23,
+      "timeout": 2,
+      "unviable": 14
+    },
     "sparq-substrate": {
       "caught": 183,
       "caught_pct": 60.98,
@@ -56,6 +139,22 @@
       "measured_surviving": 128,
       "timeout": 17,
       "unviable": 21
+    },
+    "sparq-text": {
+      "caught": 171,
+      "caught_pct": 77.73,
+      "ceiling": 51,
+      "measured_surviving": 49,
+      "timeout": 0,
+      "unviable": 10
+    },
+    "sparq-zk": {
+      "caught": 283,
+      "caught_pct": 67.3,
+      "ceiling": 140,
+      "measured_surviving": 138,
+      "timeout": 1,
+      "unviable": 62
     }
   },
   "margin": 2


### PR DESCRIPTION
> 🤖 SPARQ agent (Sonnet-tier implementation, sq-qcnn.29). bench/mutants-baseline.json only — no scripts/, no ci.yml, no crate dirs touched per bead constraint.

## What this does

Seeds `bench/mutants-baseline.json` with 12 crates from the 16 successful shards of scheduled nightly run 28776460517 (2026-07-06). Baseline grows from 6 → 18 crates.

Only crates whose `mutation ratchet (cargo-mutants, advisory) (<crate>)` job concluded `success` are seeded — the honesty invariant (no ceiling from a cancelled/failed shard).

## New entries (all traced to complete artifact rollups)

| crate | survived | ceiling | caught% | note |
|---|---|---|---|---|
| sparq-geo | 259 | 261 | 66.23% | |
| sparq-hdt | 39 | 41 | 82.27% | |
| sparq-nlq | 173 | 175 | 51.81% | |
| sparq-policy | 164 | 166 | 70.24% | |
| sparq-rsp | 50 | 52 | 86.49% | |
| sparq-shacl | 994 | 996 | 36.32% | W3C conformance tests run via subprocess — honest measurement, _note in JSON |
| sparq-sim | 23 | 25 | 76.04% | |
| sparq-text | 49 | 51 | 77.73% | |
| sparq-zk | 138 | 140 | 67.30% | |
| sparq-serve | 375 | 377 | 24.70% | |
| sparq-fedplan | 534 | 536 | 0.00% | All mutations survived — integration-style tests, no in-process behavioral assertions. Honest _note in JSON. |
| sparq-fedclient | 553 | 555 | 0.00% | Same pattern; sq-qcnn.22 (#1389) raised line coverage but assertions do not probe mutation sites. Honest _note in JSON. |

## Spot-checks (2 entries verified against artifact rollups)

- **sparq-shacl**: artifact rollup missed=994, caught=562, timeout=5, unviable=68 → caught_pct=36.32%, ceiling=996. EXACT MATCH.
- **sparq-rsp**: artifact rollup missed=50, caught=296, timeout=24, unviable=51 → caught_pct=86.49%, ceiling=52. EXACT MATCH.

## Crates still blocked pending sq-qcnn.28

The following crates are NOT seeded because their shard was cancelled or failed in run 28776460517:

- **Cancelled (~2h timeout)**: sparq-core, sparq-engine, sparq-solid, sparq-zk-compose, sparq-vectors
- **Failed**: sparq-reason, sparq-mpc, sparq-server
- **Previously seeded, re-failed**: sparq-prov, sparq-substrate (baseline unchanged from prior honest seed)

These will be seeded once sq-qcnn.28 fixes the nightly lane and a complete run is available.

## Gates

- `python3 scripts/mutants-gate.py --check` exits 0: 12 ok / 0 fail / 6 missing (existing pre-seeded crates not in this outcomes set — expected without `--require-all`)
- `python3 scripts/mutants-gate.py --self-test`: ALL ASSERTIONS PASSED
- `python3 scripts/check-readme-template.py --enforce`: 0 deviations across 52 READMEs
- `typos bench/mutants-baseline.json`: clean
- No Rust code changed; clippy/cargo-build/rustdoc gates are not applicable to this pure-data JSON change.

Bead: sq-qcnn.29