### PR TITLE
feat(engine/vectorized): M4 Phase 5 — vec_dispatch columnar dispatcher seam + I5 probe counters (sq-pntvh.5)

### DIFF
--- a/crates/sparq-engine/README.md
+++ b/crates/sparq-engine/README.md
@@ -97,12 +97,12 @@ let json = sparq_engine::query_json(&g, "SELECT (COUNT(*) AS ?n) WHERE { ?s ?p ?
   [`skills/sparql-query/SKILL.md`](../../skills/sparql-query/SKILL.md).
 - **Structured EXPLAIN** *(opt-in `explain-json` feature, OFF by default)* — `explain_plan` /
   `explain_plan_analyze` → a typed `PlanNode` tree (BGP `estimated`, `actual`/`nanos`, per-operator **q-error**) + `to_json()` + a bounded `SlowQueryRing`; off, build byte-identical.
-- **Semi-join reducers** *(opt-in `semijoin-bitmap` / `yannakakis` features, OFF by default)* — `semijoin-
-  bitmap` prefilters the next binary-join scan by an EXACT membership filter (`KeyFilter`: a flat bitmap over
-  dense `u32` ids, or a hash set when sparse+huge); `yannakakis` adds the complementary bottom-up
-  full-semijoin **prepass** reducing every relation of an *acyclic* BGP against its join-tree neighbours before
-  the join (cost-gated; cyclic BGPs keep LFTJ). Both drop only rows that cannot match, so the RESULT is
-  **identical** to off (proven by the on-vs-off differential); off, the default build is byte-identical, no new deps.
+- **Semi-join reducers** *(opt-in `semijoin-bitmap` / `yannakakis` features, OFF by default)* — `semijoin-bitmap`
+  prefilters binary-join scans with an exact membership bitmap; `yannakakis` adds a bottom-up full-semijoin prepass
+  for acyclic BGPs (cost-gated; cyclic BGPs keep LFTJ). Result-identical to off (proven by the on-vs-off
+  differential); off, byte-identical, no new deps.
+- **Vector-at-a-time columnar dispatch** *(opt-in `vectorized` feature, OFF by default)* — FILTER and aggregate
+  operators use a columnar path for ≥ 256-row all-inline-integer batches; byte-identical to the scalar path. I5 probe counters (`reset_stats`/`stats_snapshot`/`VecStats`) are test-facing only. Off, zero code compiles, no new deps.
 - **`forbid(unsafe_code)`** — the crate contains zero `unsafe`.
 
 ## 📚 Learn more

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -366,6 +366,18 @@ pub(crate) mod budget {
         Ok(())
     }
 
+    /// Returns `true` when a budget is currently installed (even if not yet exhausted).
+    /// The columnar path uses this for the I3 fallback rule: when a budget is armed the
+    /// seam declines to the scalar path (the scalar debit schedule is not uniform-per-row
+    /// inside `apply_filter`, so the `k = min(batch_len, budget_remaining)` prefix rule
+    /// cannot be applied; the fallback is budget-armed ⇒ decline per the design record
+    /// `research/vector-at-a-time-m4-completion-design.md` §1 I3). [SONNET-4.6] (sq-pntvh.5)
+    #[cfg_attr(not(feature = "vectorized"), allow(dead_code))]
+    #[inline]
+    pub(crate) fn active() -> bool {
+        ACTIVE.with(|c| c.get().on)
+    }
+
     /// Caps a speculative `Vec` pre-allocation while a budget is active, so a
     /// budgeted cross-product cannot allocate its full (possibly astronomical)
     /// output up front before the first cooperative check fires. Honours BOTH the
@@ -6894,12 +6906,12 @@ fn order_bindings(graph: &Graph, local: &LocalVocab, b: &mut Bindings, exprs: &[
 /// skipped; otherwise the scalar row path (`apply_filter_scalar`) runs verbatim. When the
 /// feature is OFF this compiles to exactly the scalar body — byte-identical, zero overhead.
 fn apply_filter(graph: &Graph, local: &LocalVocab, b: &mut Bindings, expr: &Expression) -> Result<(), String> {
-    // [OPUS-4.8] (sq-pntvh.3, M4 Phase 3) Columnar residual-FILTER seam (Seam A): for an
-    // eligible single sargable numeric residual over an all-inline-integer column, transpose to
-    // a `DataChunk`, decode the column ONCE (the Phase-2 primitive), compare over the decoded
-    // column, gather the survivors, and materialise back — byte-identical to the scalar row
-    // path but as one branchless, auto-vectorising compare loop instead of per-row `eval_expr`
-    // dispatch. Declines (→ scalar path) for anything not provably byte-identical.
+    // [SONNET-4.6] (sq-pntvh.5, M4 Phase 5) Dispatcher-gated columnar residual-FILTER seam
+    // (Seam A): the `columnar_filter` helper now runs through the shared `vec_dispatch`
+    // eligibility gate (VEC_MIN_BATCH threshold, I2/I3 checks, dtype precheck) and executes
+    // morsel-by-morsel (VEC_MORSEL rows per decode buffer) — extracting only the one tested
+    // column, not a full-width transpose. Declines (→ scalar path) for anything not provably
+    // byte-identical to `apply_filter_scalar`. I5 probe counters updated on each call.
     #[cfg(feature = "vectorized")]
     if let Some(rows) = columnar_filter(graph, b, expr) {
         b.rows = rows;
@@ -6908,47 +6920,98 @@ fn apply_filter(graph: &Graph, local: &LocalVocab, b: &mut Bindings, expr: &Expr
     apply_filter_scalar(graph, local, b, expr)
 }
 
-/// The columnar residual-FILTER attempt. Returns `Some(new_rows)` (the surviving rows, in the
-/// scalar path's order) when it handled the filter, or `None` to fall back to the scalar row
-/// path. The returned rows are **byte-identical** to `apply_filter_scalar`'s output.
+/// The columnar residual-FILTER attempt (M4 Phase 5 dispatcher-wired Seam A).
 ///
-/// Eligibility is deliberately narrow so the result is *provably* identical to the scalar
-/// `cmp_expr`/`equal_expr` path, not merely "close":
-/// * a **single sargable numeric** residual `?v OP const` (`extract_sargable` → `ScanCmp::Num`);
-///   temporal comparisons decline (there is no temporal vector kernel yet);
-/// * the compared variable is a present column;
-/// * **every** id in that column is an inline integer (`dict::is_inline`). Inline integers are
-///   f64-exact small non-negative integers, so the kernel's f64 comparison agrees with
-///   `cmp_expr` on every value — including the operator's f64-tie exact-lexical recheck, which
-///   for an exact small integer and a ≤15-significant-digit sargable threshold can only agree.
-///   The all-inline gate ALSO excludes local-vocab (computed) numerics — resolved by
-///   `eval_numeric` via `local.numeric`, not `graph.numeric_value` — and any unbound (`NO_ID`,
-///   which is not inline), both of which would otherwise diverge from the row path.
+/// Returns `Some(new_rows)` (the surviving rows, in the scalar path's order) when the
+/// dispatcher admits the operator invocation, or `None` to fall through to
+/// `apply_filter_scalar`. The returned rows are **byte-identical** to
+/// `apply_filter_scalar`'s output.
 ///
-/// **ZK coupling (soundness-relevant):** when the `zk` trace is armed the seam declines
-/// unconditionally, so the row path records the identical per-row `FILTER` obligation set
-/// (`split_sargable` already keeps every filter residual under `zk`). See
-/// `research/vector-at-a-time-m4.md` §3.2.
+/// ## Decline hierarchy (I1–I5, owned by `vec_dispatch`)
+///
+/// Checks are applied in this order; any failing check falls through to the scalar path
+/// with a `vec_dispatch::record_decline()` increment (I1: decline is total, silent-safe):
+///
+/// 1. **I2 (zk-decline):** when the `zk` proof-trace is armed the seam declines so the
+///    scalar path records the complete per-row FILTER obligation set.
+/// 2. **I3 (budget parity — fallback rule):** when a query budget is installed, the seam
+///    declines. The scalar `apply_filter` debit schedule is NOT uniform-per-row (budget is
+///    checked at operator entry, not inside the row loop), so the `k = min(batch, remaining)`
+///    prefix rule cannot be applied without a scalar-side budget-tracking refactor. The
+///    fallback is: budget-armed ⇒ decline. This is zero-risk; revisit when budget tracking
+///    is uniform-per-row.
+/// 3. **Operator shape:** only a single sargable `NUMERIC` comparison `?v OP const` (temporal
+///    comparisons have no vector kernel yet).
+/// 4. **`VEC_MIN_BATCH` (I4):** the batch must have at least `vec_dispatch::VEC_MIN_BATCH`
+///    rows. Smaller batches are cheaper on the scalar path.
+/// 5. **Column-dtype precheck:** every id in the filter column must be an inline integer
+///    (`dict::is_inline`). This is the provable byte-identity gate: an inline-integer id
+///    encodes its exact numeric value (value = id − INLINE_BASE), so the columnar f64
+///    comparison agrees with the scalar `numeric_value` comparison on every cell — including
+///    the f64-tie exact-lexical recheck, which for exact small integers can only agree.
+///    This gate ALSO excludes local-vocab (computed) ids and unbound (`NO_ID`) cells.
+///
+/// ## Execution (morsel-by-morsel, single-column extract)
+///
+/// For eligible invocations the function iterates morsels of `VEC_MORSEL` rows. Each morsel:
+/// - Extracts only the filter column c (O(morsel × 1), not a full-width transpose).
+/// - Builds a single-column `DataChunk` and calls the Phase-2/3 decode + select kernels.
+/// - Records the morsel via `vec_dispatch::record_chunk`.
+/// - Appends global survivor indices.
+///
+/// After all morsels, survivors are gathered from the original `b.rows` (order-preserving).
+///
+/// **ZK coupling (soundness-relevant):** see I2 above and `research/vector-at-a-time-m4.md`
+/// §3.2. [SONNET-4.6] (sq-pntvh.5)
 #[cfg(feature = "vectorized")]
 fn columnar_filter(graph: &Graph, b: &Bindings, expr: &Expression) -> Option<Vec<Row>> {
     use crate::chunk::{DataChunk, VecCmp};
+    use crate::vec_dispatch;
 
-    // ZK trace armed ⇒ decline so the scalar path records the FILTER obligation set.
+    // I2: ZK trace armed ⇒ decline so the scalar path records the FILTER obligation set.
     #[cfg(feature = "zk")]
     if crate::zk::enabled() {
+        vec_dispatch::record_decline();
         return None;
     }
 
-    // Only a single sargable NUMERIC comparison `?v OP const` is columnar-eligible.
-    let num = match extract_sargable(expr)? {
-        (var, ScanCmp::Num(c)) => (var, c),
-        (_, ScanCmp::Temp(..)) => return None,
-    };
-    let (var, cmp) = num;
-    let c = b.col(&var)?;
+    // I3: budget armed ⇒ decline (fallback rule — debit schedule is not uniform-per-row).
+    if budget::active() {
+        vec_dispatch::record_decline();
+        return None;
+    }
 
-    // Provable byte-identity gate: the whole filtered column must be inline integers.
+    // Operator-shape check: only a single sargable NUMERIC comparison is eligible.
+    // NOTE: do NOT use `extract_sargable(expr)?` — the `?` operator returns None without
+    // recording the decline, making the I5 counter miss non-sargable expressions. [SONNET-4.6]
+    let (var, cmp) = match extract_sargable(expr) {
+        None => {
+            vec_dispatch::record_decline();
+            return None;
+        }
+        Some((v, ScanCmp::Num(c))) => (v, c),
+        Some((_, ScanCmp::Temp(..))) => {
+            vec_dispatch::record_decline();
+            return None;
+        }
+    };
+    let c = match b.col(&var) {
+        Some(col) => col,
+        None => {
+            vec_dispatch::record_decline();
+            return None;
+        }
+    };
+
+    // VEC_MIN_BATCH: batches below the threshold are cheaper on the scalar path.
+    if b.rows.len() < vec_dispatch::VEC_MIN_BATCH {
+        vec_dispatch::record_decline();
+        return None;
+    }
+
+    // Column-dtype precheck: the whole filter column must be inline integers (I4-equivalent).
     if !b.rows.iter().all(|r| dict::is_inline(r[c])) {
+        vec_dispatch::record_decline();
         return None;
     }
 
@@ -6960,13 +7023,41 @@ fn columnar_filter(graph: &Graph, b: &Bindings, expr: &Expression) -> Option<Vec
         NumCmp::Eq(t) => VecCmp::Eq(t),
     };
 
-    // transpose → decode column ONCE → compare over the decoded column → gather → materialise.
-    let width = b.vars.len();
-    let chunk = DataChunk::from_rows(&b.rows, width)?;
-    let decoded = chunk.decode_numeric_column(graph, c);
-    let sel = DataChunk::select_decoded(&decoded, veccmp);
-    let filtered = chunk.apply_selection(&sel);
-    Some(filtered.to_rows().iter().map(|r| Row::from_slice(r.as_slice())).collect())
+    // Morsel-by-morsel execution: extract only the filter column (not a full-width
+    // transpose), decode it, select survivors, and collect global indices.
+    let morsel_size = vec_dispatch::VEC_MORSEL;
+    let mut survivor_indices: Vec<usize> = Vec::new();
+    let rows = &b.rows;
+
+    for start in (0..rows.len()).step_by(morsel_size) {
+        let end = (start + morsel_size).min(rows.len());
+        let morsel_len = end - start;
+
+        // Extract just the filter column for this morsel (O(morsel × 1), not O(morsel × width)).
+        let col: Vec<sparq_core::dict::Id> = rows[start..end].iter().map(|r| r[c]).collect();
+        let morsel_chunk = match DataChunk::from_columns(vec![col], morsel_len) {
+            Some(mc) => mc,
+            None => {
+                // Should not happen: col.len() == morsel_len by construction.
+                vec_dispatch::record_decline();
+                return None;
+            }
+        };
+
+        // Phase-2/3 primitives: decode once → compare over the decoded column.
+        let decoded = morsel_chunk.decode_numeric_column(graph, 0);
+        let local_sel = DataChunk::select_decoded(&decoded, veccmp);
+
+        // Record this morsel (I5 counter).
+        vec_dispatch::record_chunk(morsel_len);
+
+        // Translate local morsel indices to global row indices.
+        survivor_indices.extend(local_sel.iter().map(|&i| start + i));
+    }
+
+    // Materialise survivors from the original rows (order-preserving, full-width).
+    let result: Vec<Row> = survivor_indices.iter().map(|&r| Row::from_slice(b.rows[r].as_ref())).collect();
+    Some(result)
 }
 
 /// The columnar per-group aggregate attempt (M4 Phase 4, `sq-pntvh.4`). Returns `Some(rows)`
@@ -6976,6 +7067,8 @@ fn columnar_filter(graph: &Graph, b: &Bindings, expr: &Expression) -> Option<Vec
 /// **Eligibility (conservative — decline is always safe, I1):**
 /// - `vectorized` feature ON (compile-gate only, not checked here)
 /// - ZK trace NOT armed (I2, checked below)
+/// - Budget NOT armed (I3, checked below — fallback rule, same as `columnar_filter`)
+/// - `VEC_MIN_BATCH` rows or more in the input (dispatcher threshold)
 /// - No DISTINCT aggregate
 /// - Only `SUM / COUNT / AVG / MIN / MAX` aggregate functions and `COUNT(*)`
 /// - Aggregate argument is a bare variable `?v` (not an expression)
@@ -6985,7 +7078,7 @@ fn columnar_filter(graph: &Graph, b: &Bindings, expr: &Expression) -> Option<Vec
 ///
 /// When there are multiple aggregates, ALL must be eligible and use the SAME column (or
 /// `COUNT(*)` which needs no column). If any aggregate uses a different column, decline.
-/// [SONNET-4.6]
+/// [SONNET-4.6] (sq-pntvh.4 / sq-pntvh.5 dispatcher hook)
 #[cfg(feature = "vectorized")]
 #[allow(clippy::too_many_arguments)]
 fn columnar_aggregate(
@@ -6999,10 +7092,24 @@ fn columnar_aggregate(
     _out_vars: &[Variable],
 ) -> Option<Vec<Row>> {
     use crate::reduce::{reduce_count, reduce_max_id, reduce_min_id, reduce_sum};
+    use crate::vec_dispatch;
 
     // I2: ZK trace armed → decline so the scalar path records the aggregate obligations.
     #[cfg(feature = "zk")]
     if crate::zk::enabled() {
+        vec_dispatch::record_decline();
+        return None;
+    }
+
+    // I3: budget armed ⇒ decline (same fallback rule as columnar_filter). [SONNET-4.6]
+    if budget::active() {
+        vec_dispatch::record_decline();
+        return None;
+    }
+
+    // VEC_MIN_BATCH dispatcher threshold: small inputs are cheaper on the scalar path.
+    if b.rows.len() < vec_dispatch::VEC_MIN_BATCH {
+        vec_dispatch::record_decline();
         return None;
     }
 
@@ -7015,12 +7122,14 @@ fn columnar_aggregate(
         match agg {
             AggregateExpression::CountSolutions { distinct } => {
                 if *distinct {
+                    vec_dispatch::record_decline();
                     return None; // DISTINCT COUNT(*) requires full row dedup
                 }
                 // CountSolutions needs no column — always eligible.
             }
             AggregateExpression::FunctionCall { name, expr, distinct } => {
                 if *distinct {
+                    vec_dispatch::record_decline();
                     return None; // DISTINCT requires per-group value dedup
                 }
                 // Only the five standard numeric aggregates are supported.
@@ -7030,20 +7139,35 @@ fn columnar_aggregate(
                     | AggregateFunction::Avg
                     | AggregateFunction::Min
                     | AggregateFunction::Max => {}
-                    _ => return None,
+                    _ => {
+                        vec_dispatch::record_decline();
+                        return None;
+                    }
                 }
                 // Argument must be a bare variable (not an expression).
                 let v = match expr {
                     Expression::Variable(v) => v,
-                    _ => return None,
+                    _ => {
+                        vec_dispatch::record_decline();
+                        return None;
+                    }
                 };
                 // The variable must have a column in the input bindings.
-                let c = b.col(v)?;
+                let c = match b.col(v) {
+                    Some(ci) => ci,
+                    None => {
+                        vec_dispatch::record_decline();
+                        return None;
+                    }
+                };
                 // All column-dependent aggregates must reference the SAME column.
                 match agg_col {
                     None => agg_col = Some(c),
                     Some(existing) if existing == c => {}
-                    _ => return None,
+                    _ => {
+                        vec_dispatch::record_decline();
+                        return None;
+                    }
                 }
             }
         }
@@ -7055,6 +7179,7 @@ fn columnar_aggregate(
     // so the reducer sees the exact same integer the scalar eval_expr would materialise.
     if let Some(c) = agg_col {
         if !b.rows.iter().all(|r| dict::is_inline(r[c])) {
+            vec_dispatch::record_decline();
             return None;
         }
     }
@@ -7140,6 +7265,9 @@ fn columnar_aggregate(
         rows.push(row);
     }
 
+    // I5: record one "chunk" for the aggregate seam (the whole group-table counts as one pass).
+    // [SONNET-4.6] (sq-pntvh.5 dispatcher hook)
+    vec_dispatch::record_chunk(b.rows.len());
     Some(rows)
 }
 
@@ -12405,7 +12533,8 @@ mod columnar_filter_seam {
 
     #[test]
     fn columnar_seam_is_byte_identical_to_scalar_on_inline_column() {
-        let n = 40u32;
+        // n=300 ensures the batch exceeds VEC_MIN_BATCH (256) so columnar_filter engages.
+        let n = 300u32;
         let (g, subj, age) = ages_graph(n);
         let vars = vec![var("s"), var("age")];
         let rows: Vec<Row> = (0..n as usize).map(|i| Row::from_slice(&[subj[i], age[i]])).collect();
@@ -12440,15 +12569,16 @@ mod columnar_filter_seam {
     fn columnar_seam_pins_exact_survivors_and_order() {
         // Non-vacuous: pin the EXACT surviving age sequence (content + ascending order) so a
         // wrong mask (off-by-one / inverted / column desync) turns this red.
-        let n = 40u32;
+        // n=300 ensures the batch exceeds VEC_MIN_BATCH (256) so columnar_filter engages.
+        let n = 300u32;
         let (g, subj, age) = ages_graph(n);
         let vars = vec![var("s"), var("age")];
         let rows: Vec<Row> = (0..n as usize).map(|i| Row::from_slice(&[subj[i], age[i]])).collect();
         let age_var = var("age");
 
         let out = columnar_filter(&g, &Bindings::unsorted(vars.clone(), rows.clone()), &mk_filter(">", &age_var, int_lit("20"))).unwrap();
-        let expected: Vec<f64> = (21..40).map(f64::from).collect();
-        assert_eq!(age_values(&g, &out), expected, "age > 20 must keep 21..=39, ascending");
+        let expected: Vec<f64> = (21..300).map(f64::from).collect();
+        assert_eq!(age_values(&g, &out), expected, "age > 20 must keep 21..=299, ascending");
 
         // A DIFFERENT filter must select a DIFFERENT set (the mask does real work).
         let other = columnar_filter(&g, &Bindings::unsorted(vars, rows), &mk_filter("<", &age_var, int_lit("20"))).unwrap();
@@ -12531,7 +12661,8 @@ mod columnar_filter_seam {
         // The zk trace must capture the FILTER obligation set, so the columnar seam DECLINES
         // while the recorder is armed and the scalar path records it
         // (research/vector-at-a-time-m4.md §3.2, open question 2 — simplest-safe rule).
-        let n = 8u32;
+        // n=300 to exceed VEC_MIN_BATCH (256) so the sanity check can confirm eligibility.
+        let n = 300u32;
         let (g, subj, age) = ages_graph(n);
         let vars = vec![var("s"), var("age")];
         let rows: Vec<Row> = (0..n as usize).map(|i| Row::from_slice(&[subj[i], age[i]])).collect();
@@ -12540,7 +12671,7 @@ mod columnar_filter_seam {
 
         // Sanity: eligible (and firing) when zk is NOT armed.
         assert!(columnar_filter(&g, &b, &expr).is_some(), "eligible without zk armed");
-        // Armed ⇒ decline.
+        // Armed ⇒ decline (I2 fires before VEC_MIN_BATCH, so batch size is irrelevant here).
         let _guard = crate::zk::install();
         assert!(crate::zk::enabled());
         assert!(columnar_filter(&g, &b, &expr).is_none(), "columnar seam must decline while zk is armed");
@@ -13015,13 +13146,14 @@ mod columnar_aggregate_seam {
     /// (b) the aggregate result decodes to the scalar-expected value, and (c) the columnar
     /// result is FULL-TERM-identical to the TRUE scalar oracle (catches datatype mutations).
     ///
-    /// Scores 0..=19: SUM=190 (xsd:integer), COUNT=20 (xsd:integer), MIN=0, MAX=19.
+    /// Scores 0..=299: SUM=44850 (xsd:integer), COUNT=300 (xsd:integer), MIN=0, MAX=299.
+    /// n=300 ensures the batch exceeds VEC_MIN_BATCH (256) so columnar_aggregate engages.
     /// A mutation returning `Num::Double` instead of `Num::Int` for SUM changes the xsd:
     /// datatype and fails (c); a MIN→MAX mutation changes the numeric value and fails (b).
     /// [SONNET-4.6] (C2-fix sq-pntvh.4 adversarial review)
     #[test]
     fn t5_whole_dataset_agg_byte_identical_to_scalar() {
-        let n = 20u32;
+        let n = 300u32;
         let (g, _subj, score) = scores_graph(n);
         let score_var = var("score");
         let rows: Vec<Row> = score.iter().map(|&s| Row::from_slice(&[s])).collect();
@@ -13044,10 +13176,10 @@ mod columnar_aggregate_seam {
 
         // (expected_value, AggregateFunction label, aggregates)
         let cases: &[(f64, AggregateFunction)] = &[
-            (190.0, AggregateFunction::Sum),   // 0+1+…+19 = 190
-            (20.0,  AggregateFunction::Count),  // 20 rows
-            (0.0,   AggregateFunction::Min),    // minimum of 0..=19
-            (19.0,  AggregateFunction::Max),    // maximum
+            (44850.0, AggregateFunction::Sum),   // 0+1+…+299 = 299*300/2 = 44850
+            (300.0,   AggregateFunction::Count),  // 300 rows
+            (0.0,     AggregateFunction::Min),    // minimum of 0..=299
+            (299.0,   AggregateFunction::Max),    // maximum
         ];
 
         for &(expected, ref name) in cases {
@@ -13078,7 +13210,7 @@ mod columnar_aggregate_seam {
             });
             assert_eq!(
                 got, expected,
-                "aggregate {:?} over scores 0..=19 must equal {}", name, expected
+                "aggregate {:?} over scores 0..=299 must equal {}", name, expected
             );
 
             // (c) FULL-TERM identity against the TRUE scalar oracle (catches datatype mutations).
@@ -13150,11 +13282,12 @@ mod columnar_aggregate_seam {
     }
 
     /// T5c: AVG over inline-integer column — columnar path engaged, result FULL-TERM-identical
-    /// to the TRUE scalar oracle. AVG(0..=19) = 190/20 = 9.5 (xsd:decimal). [SONNET-4.6]
+    /// to the TRUE scalar oracle. AVG(0..=299) = 44850/300 = 149.5 (xsd:decimal).
+    /// n=300 ensures the batch exceeds VEC_MIN_BATCH (256) so columnar_aggregate engages. [SONNET-4.6]
     /// (C2-fix sq-pntvh.4 adversarial review)
     #[test]
     fn t5c_avg_byte_identical_to_scalar() {
-        let n = 20u32;
+        let n = 300u32;
         let (g, _subj, score) = scores_graph(n);
         let score_var = var("score");
         let rows: Vec<Row> = score.iter().map(|&s| Row::from_slice(&[s])).collect();
@@ -13189,19 +13322,19 @@ mod columnar_aggregate_seam {
             "columnar AVG must be FULL-TERM-identical to the scalar oracle (lexical + datatype)"
         );
 
-        // (b) Non-vacuous: verify the result is 9.5 (190/20), not 0 or some wrong value.
-        //     AVG(0..=19) = 9.5 (xsd:decimal 9.5, stored as a local-vocab Dec term).
+        // (b) Non-vacuous: verify the result is 149.5 (44850/300), not 0 or some wrong value.
+        //     AVG(0..=299) = 149.5 (xsd:decimal, stored as a local-vocab Dec term).
         let result_id = col_rows[0][0];
         let term = term_of(&g, &local_col, result_id).expect("AVG result must be a term");
         let avg_str = match &term {
             Term::Literal(l) => l.value().to_string(),
             _ => panic!("AVG result must be a literal, got {:?}", term),
         };
-        // The decimal 9.5 serialises as "9.5" (or equivalent exact decimal lexical).
+        // The decimal 149.5 serialises as "149.5" (or equivalent exact decimal lexical).
         let avg_f64: f64 = avg_str.parse().expect("AVG lexical must be numeric");
         assert!(
-            (avg_f64 - 9.5_f64).abs() < 1e-9,
-            "AVG(0..=19) = 190/20 = 9.5, got {} (term = {:?})", avg_f64, term
+            (avg_f64 - 149.5_f64).abs() < 1e-9,
+            "AVG(0..=299) = 44850/300 = 149.5, got {} (term = {:?})", avg_f64, term
         );
     }
 

--- a/crates/sparq-engine/src/lib.rs
+++ b/crates/sparq-engine/src/lib.rs
@@ -279,6 +279,16 @@ pub use chunk::{DataChunk, SelVec, VecCmp};
 // when off. No new dependencies.
 #[cfg(feature = "vectorized")]
 pub(crate) mod reduce;
+// [SONNET-4.6] (sq-pntvh.5) M4 Phase 5: columnar_eligible dispatcher + morsel constants
+// (VEC_MIN_BATCH/VEC_MORSEL) + I5 probe counters {chunks_built, rows_columnar,
+// rows_delegated, declines_by_reason}. NON-DEFAULT `vectorized` feature; compiled out
+// entirely when off (relaxed atomics + dispatch helpers compile away). The probe counters
+// and VecStats snapshot are public but UNSTABLE/test-facing (not semver-stable). No new
+// dependencies.
+#[cfg(feature = "vectorized")]
+pub mod vec_dispatch;
+#[cfg(feature = "vectorized")]
+pub use vec_dispatch::{reset_stats, stats_snapshot, VecStats};
 
 // [OPUS-4.8] (sq-gr8mb, survey §A3) Exact-bitmap semi-join reducer on dense u32 ids
 // (CIDR'26 "Not Yannakakis"; research/optimization-techniques.md §1.1/§2(a)). The binary

--- a/crates/sparq-engine/src/vec_dispatch.rs
+++ b/crates/sparq-engine/src/vec_dispatch.rs
@@ -1,0 +1,169 @@
+//! [SONNET-4.6] (sq-pntvh.5) Columnar dispatch gate: the `VEC_MIN_BATCH` / `VEC_MORSEL`
+//! constants and the I5 probe counters that every M4 seam shares.
+//!
+//! This module is the **single owner** of the decline hierarchy (I1–I5) described in
+//! `research/vector-at-a-time-m4-completion-design.md` §4. Every current and future
+//! seam (filter, aggregate, project, join) **inherits** it here by construction rather
+//! than re-implementing per-seam discipline.
+//!
+//! ## Constants (placeholders — EC2-tuned in `sq-pntvh.9`)
+//!
+//! - `VEC_MIN_BATCH` (256): minimum batch size for the columnar path. Batches smaller
+//!   than this are typically cheaper on the scalar row path (transpose overhead).
+//! - `VEC_MORSEL` (2048): decode-buffer length for morsel-by-morsel `apply_filter`
+//!   execution. Each morsel decodes only the filter column, not the full row width.
+//!
+//! ## I5 probe counters (unstable / test-facing)
+//!
+//! Thread-local counters `{chunks_built, rows_columnar, rows_delegated,
+//! declines_by_reason}` that the test suite asserts to confirm the seams are
+//! non-vacuous (see `tests/differentials/vectorized_byte_identity.rs`). They are
+//! compiled out entirely when the `vectorized` feature is OFF and are **NOT
+//! semver-stable** — callers outside the acceptance-test suite must not build stable
+//! logic over them.
+//!
+//! Thread-locals are used (not global atomics) so each test thread gets isolated
+//! counters — parallel `#[test]` invocations cannot interfere. The query evaluator
+//! calls the seams from the installing thread, so thread-local counters capture the
+//! full per-query activity correctly.
+//!
+//! This module is only compiled when `feature = "vectorized"` is active; the whole
+//! file is a `#[cfg(feature = "vectorized")]` compilation unit (registered in
+//! `lib.rs` under the same gate). When the feature is OFF, zero code from here
+//! compiles and the default native + wasm builds are byte-identical.
+
+use std::cell::Cell;
+
+// ---- Morsel constants -------------------------------------------------------
+// Placeholders: EC2-tuned in sq-pntvh.9. NO perf claim attaches to these values.
+// They are referenced from the two exec.rs seam regions; putting them here ensures
+// every seam uses the same constants and they only need to be changed in one place.
+
+/// Minimum batch size (row count) for the columnar path.
+///
+/// Batches with fewer than `VEC_MIN_BATCH` rows are processed by the scalar row path:
+/// the per-column transpose overhead is a net loss on small intermediates, and the
+/// batch-size eligibility check (I4 per the design record §1) sits at this threshold.
+///
+/// **Placeholder value** (256) — to be EC2-measured and adjusted in `sq-pntvh.9`.
+/// No performance claim is implied by this number.
+pub(crate) const VEC_MIN_BATCH: usize = 256;
+
+/// Morsel length: the number of rows the `apply_filter` seam decodes at once.
+///
+/// Each morsel extracts only the single filter column into a contiguous `Vec<f64>`
+/// buffer (O(morsel × 1), not a full-width transpose). This keeps the decode buffer
+/// in L1/L2 across the decode→compare→gather pipeline step.
+///
+/// **Placeholder value** (2048) — to be EC2-measured and adjusted in `sq-pntvh.9`.
+/// No performance claim is implied by this number.
+pub(crate) const VEC_MORSEL: usize = 2048;
+
+// ---- I5 probe counters (thread-local) ---------------------------------------
+//
+// Thread-local so parallel test threads do not interfere with each other.
+// The query evaluator calls `columnar_filter` / `columnar_aggregate` from the
+// thread that runs the query, so thread-local capture is correct for queries.
+
+thread_local! {
+    /// DataChunk morsels built and run through a columnar kernel.
+    static TL_CHUNKS_BUILT: Cell<u64> = const { Cell::new(0) };
+    /// Total rows processed on the columnar path.
+    static TL_ROWS_COLUMNAR: Cell<u64> = const { Cell::new(0) };
+    /// Rows delegated to the scalar predicate (reserved for sq-y5ew5; always 0 in Phase 5).
+    static TL_ROWS_DELEGATED: Cell<u64> = const { Cell::new(0) };
+    /// Operator invocations that declined the columnar path (all reasons).
+    static TL_DECLINES: Cell<u64> = const { Cell::new(0) };
+}
+
+// ---- Public (unstable/test-facing) API --------------------------------------
+
+/// A snapshot of the I5 probe counters for the calling thread.
+///
+/// **Unstable / test-facing** — NOT semver-stable. Only the acceptance tests
+/// (`tests/differentials/vectorized_byte_identity.rs`) should assert on these values.
+/// External callers must not build stable logic over them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct VecStats {
+    /// Number of DataChunk morsels built and processed by a columnar kernel.
+    ///
+    /// The acceptance gate asserts `chunks_built >= 1` for an eligible operator
+    /// invocation to confirm the seam is non-vacuous.
+    pub chunks_built: u64,
+    /// Total rows processed on the columnar path (sum over all morsel sizes).
+    pub rows_columnar: u64,
+    /// Rows delegated to the scalar predicate (reserved for `sq-y5ew5`; 0 in Phase 5).
+    pub rows_delegated: u64,
+    /// Total operator invocations that declined the columnar path (all reasons).
+    pub declines_by_reason: u64,
+}
+
+/// Resets all I5 probe counters to zero for the calling thread.
+///
+/// **Unstable / test-facing.** Call before each test that asserts on [`stats_snapshot`].
+pub fn reset_stats() {
+    TL_CHUNKS_BUILT.with(|c| c.set(0));
+    TL_ROWS_COLUMNAR.with(|c| c.set(0));
+    TL_ROWS_DELEGATED.with(|c| c.set(0));
+    TL_DECLINES.with(|c| c.set(0));
+}
+
+/// Returns a point-in-time snapshot of the I5 probe counters for the calling thread.
+///
+/// **Unstable / test-facing.** See [`VecStats`] for field semantics and the
+/// non-vacuity contract each acceptance test pins.
+pub fn stats_snapshot() -> VecStats {
+    VecStats {
+        chunks_built: TL_CHUNKS_BUILT.with(|c| c.get()),
+        rows_columnar: TL_ROWS_COLUMNAR.with(|c| c.get()),
+        rows_delegated: TL_ROWS_DELEGATED.with(|c| c.get()),
+        declines_by_reason: TL_DECLINES.with(|c| c.get()),
+    }
+}
+
+// ---- Internal counter increments --------------------------------------------
+
+/// Records one morsel of `morsel_rows` rows being processed on the columnar path.
+/// Called once per morsel in the `apply_filter` seam, and once per aggregate invocation
+/// in the `group_aggregate` seam.
+#[inline]
+pub(crate) fn record_chunk(morsel_rows: usize) {
+    TL_CHUNKS_BUILT.with(|c| c.set(c.get() + 1));
+    TL_ROWS_COLUMNAR.with(|c| c.set(c.get() + morsel_rows as u64));
+}
+
+/// Records one operator invocation that declined the columnar path.
+#[inline]
+pub(crate) fn record_decline() {
+    TL_DECLINES.with(|c| c.set(c.get() + 1));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Each public function must compile and work: basic increment + snapshot round-trip. [SONNET-4.6]
+    #[test]
+    fn counters_round_trip() {
+        reset_stats();
+        let snap0 = stats_snapshot();
+        assert_eq!(snap0.chunks_built, 0);
+        assert_eq!(snap0.rows_columnar, 0);
+        assert_eq!(snap0.rows_delegated, 0);
+        assert_eq!(snap0.declines_by_reason, 0);
+
+        record_chunk(100);
+        record_chunk(50);
+        record_decline();
+
+        let snap1 = stats_snapshot();
+        assert_eq!(snap1.chunks_built, 2, "two record_chunk calls");
+        assert_eq!(snap1.rows_columnar, 150, "100+50 rows");
+        assert_eq!(snap1.declines_by_reason, 1);
+        assert_eq!(snap1.rows_delegated, 0, "always 0 in Phase 5");
+
+        reset_stats();
+        let snap2 = stats_snapshot();
+        assert_eq!(snap2.chunks_built, 0, "reset clears all counters");
+    }
+}

--- a/crates/sparq-engine/tests/differentials/vectorized_byte_identity.rs
+++ b/crates/sparq-engine/tests/differentials/vectorized_byte_identity.rs
@@ -247,3 +247,212 @@ fn unfiltered_scan_order_is_deterministic() {
     let b = query_json(&g, &format!("{}{}", PFX, q)).unwrap();
     assert_eq!(a.as_bytes(), b.as_bytes(), "single-pattern scan order must be deterministic");
 }
+
+// =================== T1-T4: Phase-5 dispatcher-seam acceptance tests (sq-pntvh.5) =====
+//
+// These tests exercise the `vec_dispatch` module's I5 probe counters through the full
+// query execution path.
+//
+// Seam B (columnar_aggregate) is tested via whole-dataset SUM on a large graph: the
+// Group → group_aggregate → columnar_aggregate path is not intercepted by
+// single_pattern_scan_json (Group is not conjunctive), so the seam is always exercised
+// end-to-end.
+//
+// Seam A (columnar_filter) decline paths are tested via: (a) a sub-threshold aggregate
+// on a small graph (VEC_MIN_BATCH decline), and (b) a REGEX FILTER on a large graph
+// (shape-check decline). Note: the SPARQL parser combines `FILTER A FILTER B` within one
+// group graph pattern into a single `AND` expression, so the "double-filter trick" does
+// not produce a simple sargable residual — shape-check declines cover non-sargable
+// expressions instead. [SONNET-4.6]
+
+/// T1 (sq-pntvh.5): end-to-end non-vacuity (Seam B / columnar_aggregate) — a
+/// whole-dataset SUM on >= VEC_MIN_BATCH (256) inline rows engages the columnar path
+/// (`chunks_built >= 1`) and produces JSON byte-identical to the budget-armed scalar path
+/// (I3 decline forces scalar fallback). [SONNET-4.6]
+#[test]
+fn t1_eligible_dispatch_engages_columnar_and_is_byte_identical_to_scalar() {
+    use sparq_engine::{query_json_with_budget, reset_stats, stats_snapshot, QueryBudget};
+
+    let g = ages_graph(400);
+    // Whole-dataset SUM: Group → group_aggregate → columnar_aggregate.
+    // 400 rows all-inline integers, > VEC_MIN_BATCH=256.
+    let q = format!(
+        "{}SELECT (SUM(?age) AS ?total) WHERE {{ ?s ex:age ?age }}",
+        PFX
+    );
+
+    // --- Columnar run: no budget => columnar_aggregate engages ---
+    reset_stats();
+    let json_columnar = query_json(&g, &q).expect("T1 columnar query must succeed");
+    let snap_col = stats_snapshot();
+    assert!(
+        snap_col.chunks_built >= 1,
+        "T1: columnar path must engage (chunks_built={}, need >= 1)",
+        snap_col.chunks_built
+    );
+    assert!(
+        snap_col.rows_columnar >= 256,
+        "T1: rows_columnar must be >= VEC_MIN_BATCH=256 (got {})",
+        snap_col.rows_columnar
+    );
+
+    // --- Scalar run: finite max_rows arms budget => I3 decline => scalar fallback ---
+    reset_stats();
+    let json_scalar = query_json_with_budget(
+        &g,
+        &q,
+        &QueryBudget { max_rows: Some(1_000_000), ..Default::default() },
+    ).expect("T1 scalar (budget-armed) query must succeed");
+    let snap_sc = stats_snapshot();
+    assert_eq!(
+        snap_sc.chunks_built, 0,
+        "T1: budget-armed path must not engage columnar (chunks_built={})",
+        snap_sc.chunks_built
+    );
+
+    // --- Byte-identity ---
+    assert_eq!(
+        json_columnar.as_bytes(),
+        json_scalar.as_bytes(),
+        "T1: columnar SUM result must be byte-identical to scalar (budget-armed) result"
+    );
+}
+
+/// T2 (sq-pntvh.5): declined paths — `chunks_built` stays zero and declines are
+/// recorded for:
+/// (a) sub-threshold aggregate (< VEC_MIN_BATCH rows);
+/// (b) non-sargable FILTER shape (REGEX / AND expressions decline via shape check).
+/// In both cases the scalar path produces a correct result. [SONNET-4.6]
+#[test]
+fn t2_decline_paths_record_decline_and_produce_correct_result() {
+    use sparq_engine::{reset_stats, stats_snapshot};
+
+    // (a) Sub-threshold aggregate: SUM on a small graph.
+    // 10 rows < VEC_MIN_BATCH=256 => columnar_aggregate declines.
+    let g_small = ages_graph(10);
+    reset_stats();
+    let json_small = query_json(
+        &g_small,
+        &format!("{}SELECT (SUM(?age) AS ?total) WHERE {{ ?s ex:age ?age }}", PFX),
+    ).expect("T2a sub-threshold aggregate must succeed");
+    let snap_a = stats_snapshot();
+    assert_eq!(
+        snap_a.chunks_built, 0,
+        "T2a: sub-threshold aggregate must decline columnar (chunks_built={})",
+        snap_a.chunks_built
+    );
+    assert!(
+        snap_a.declines_by_reason >= 1,
+        "T2a: at least one VEC_MIN_BATCH decline must be recorded (got {})",
+        snap_a.declines_by_reason
+    );
+
+    // (b) Non-sargable FILTER shape: REGEX is not a numeric comparison;
+    // extract_sargable returns None => shape decline in columnar_filter.
+    // The graph is large (400 rows) so the only reason for decline is the shape check.
+    let g_large = ages_graph(400);
+    reset_stats();
+    let json_nonsarg = query_json(
+        &g_large,
+        &format!(
+            "{}SELECT ?s WHERE {{ ?s ex:age ?age . FILTER(REGEX(STR(?age), \"5\")) }}",
+            PFX
+        ),
+    ).expect("T2b non-sargable query must succeed");
+    let snap_b = stats_snapshot();
+    assert_eq!(
+        snap_b.chunks_built, 0,
+        "T2b: non-sargable FILTER must decline columnar (chunks_built={})",
+        snap_b.chunks_built
+    );
+    assert!(
+        snap_b.declines_by_reason >= 1,
+        "T2b: at least one shape-check decline must be recorded (got {})",
+        snap_b.declines_by_reason
+    );
+
+    // Sanity: both results are valid SPARQL JSON.
+    assert!(json_small.contains("\"results\""), "T2a result must be valid SPARQL JSON");
+    assert!(json_nonsarg.contains("\"results\""), "T2b result must be valid SPARQL JSON");
+}
+
+/// T3 (sq-pntvh.5): ZK composition — when a ZK trace recorder is armed, the columnar
+/// seam declines (I2: ZK-decline fires before the morsel loop) so the proof recorder
+/// receives the complete operator inputs via the scalar path. [SONNET-4.6]
+#[cfg(feature = "zk")]
+#[test]
+fn t3_zk_trace_armed_forces_scalar_path() {
+    use sparq_engine::{reset_stats, stats_snapshot};
+
+    // Use a whole-dataset SUM: columnar_aggregate checks I2 first.
+    let g = ages_graph(400);
+    let q = format!("{}SELECT (SUM(?age) AS ?total) WHERE {{ ?s ex:age ?age }}", PFX);
+
+    // Arm the ZK trace recorder (install() is pub; enabled() is pub(crate) so not callable here).
+    let _zk_guard = sparq_engine::zk::install();
+
+    reset_stats();
+    let json_zk = query_json(&g, &q).expect("T3 ZK-armed query must succeed");
+    let snap = stats_snapshot();
+
+    assert_eq!(
+        snap.chunks_built, 0,
+        "T3: ZK-armed path must decline columnar (chunks_built={}, need 0)",
+        snap.chunks_built
+    );
+    assert!(
+        snap.declines_by_reason >= 1,
+        "T3: ZK decline must be recorded (declines={})",
+        snap.declines_by_reason
+    );
+
+    // The result is still correct (scalar path ran): SUM result must be present.
+    assert!(json_zk.contains("\"total\""), "T3 ZK-armed result must bind ?total");
+    assert!(!json_zk.contains("\"bindings\":[]"), "T3: ZK-armed SUM result must be non-empty");
+}
+
+/// T4 (sq-pntvh.5): budget parity — a budget-armed query (I3 decline => scalar) produces
+/// JSON BYTE-IDENTICAL to the no-budget (columnar) result, confirming the two execution
+/// paths are equivalent on the same input. [SONNET-4.6]
+#[test]
+fn t4_budget_parity_columnar_and_scalar_are_byte_identical() {
+    use sparq_engine::{query_json_with_budget, reset_stats, stats_snapshot, QueryBudget};
+
+    let g = ages_graph(400);
+    // Whole-dataset SUM: columnar path for no-budget, scalar for budget-armed.
+    let q = format!(
+        "{}SELECT (SUM(?age) AS ?total) WHERE {{ ?s ex:age ?age }}",
+        PFX
+    );
+
+    // Columnar run: no budget => columnar_aggregate engages.
+    reset_stats();
+    let json_no_budget = query_json(&g, &q).expect("T4 no-budget query must succeed");
+    let snap_no_budget = stats_snapshot();
+    assert!(
+        snap_no_budget.chunks_built >= 1,
+        "T4: no-budget path must engage columnar (chunks_built={})",
+        snap_no_budget.chunks_built
+    );
+
+    // Budget-armed run: finite max_rows arms budget => I3 decline => scalar fallback.
+    reset_stats();
+    let json_with_budget = query_json_with_budget(
+        &g,
+        &q,
+        &QueryBudget { max_rows: Some(1_000_000), ..Default::default() },
+    ).expect("T4 budget-armed query must succeed");
+    let snap_with_budget = stats_snapshot();
+    assert_eq!(
+        snap_with_budget.chunks_built, 0,
+        "T4: budget-armed path must decline columnar (chunks_built={})",
+        snap_with_budget.chunks_built
+    );
+
+    // Byte-identity: both paths must produce the exact same JSON output.
+    assert_eq!(
+        json_no_budget.as_bytes(),
+        json_with_budget.as_bytes(),
+        "T4: budget-armed (scalar) JSON must be byte-identical to no-budget (columnar) JSON"
+    );
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -541,6 +541,21 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   `crates/sparq-engine/src/exec.rs` (`mod columnar_filter_seam`), plus the native FILTER/aggregate
   baseline bench `crates/sparq-engine/examples/bench_vectorized.rs` (`metric_us`, registered
   `vectorized-eval-micro`, `featured = false`) later phases measure their speedup against.
+  **Phase 5 (`sq-pntvh.5`) adds the shared dispatcher seam** (`src/vec_dispatch.rs`): a single module
+  that owns the I1–I5 decline hierarchy and the I5 probe counters shared by every current and future
+  seam. `VEC_MIN_BATCH` (256) is the minimum batch size below which the scalar path is cheaper;
+  `VEC_MORSEL` (2048) is the decode-buffer size for morsel-by-morsel `apply_filter` execution — each
+  morsel extracts only the one filter column (O(rows × 1), not a full-width transpose). The decline
+  hierarchy (in order): I2 = ZK-trace armed (scalar records the full obligation set); I3 = budget
+  armed (fallback rule — the debit schedule is not uniform-per-row); operator shape check (only a
+  simple sargable `?v OP const` numeric comparison); I4/`VEC_MIN_BATCH` batch-size gate; all-inline
+  dtype precheck. The aggregate seam (Seam B, `group_aggregate` → `columnar_aggregate`) is also
+  wired through the same I2/I3/`VEC_MIN_BATCH` checks. **I5 probe counters (test-facing / unstable)**:
+  `reset_stats()` / `stats_snapshot()` / `VecStats` let acceptance tests assert the seams are
+  non-vacuous (`chunks_built >= 1` for an eligible operator). Thread-local counters are used (not
+  global atomics) so parallel test threads don't interfere. The counters are **not semver-stable** —
+  external callers must not build stable logic on them; they exist only for the acceptance gate in
+  `tests/differentials/vectorized_byte_identity.rs` (T1–T4).
 - **Exact-bitmap semi-join reducer** is the non-default `semijoin-bitmap` cargo feature (M4 plan,
   survey §A3, bead `sq-gr8mb`; CIDR'26 "Not Yannakakis"). When a binary BGP join scans the next
   pattern, the executor first builds a membership filter over the already-materialised side's


### PR DESCRIPTION
> 🤖 SPARQ agent (sq-pntvh.5)

## Summary

- Adds `crates/sparq-engine/src/vec_dispatch.rs` as the single owner of the M4 decline hierarchy (I1–I5) and the I5 probe counters (`reset_stats`/`stats_snapshot`/`VecStats`), shared by every current and future columnar seam.
- Wires `columnar_filter` (Seam A: apply_filter) and `columnar_aggregate` (Seam B: group_aggregate) through `VEC_MIN_BATCH` (256) and `VEC_MORSEL` (2048); adds I2 (ZK-trace armed → decline), I3 (budget armed → decline), all-inline dtype precheck, and morsel-by-morsel `apply_filter` execution that extracts only the one filter column per morsel (O(rows×1) not a full-width transpose).
- Fixes a silent-decline bug: `extract_sargable(expr)?` previously returned `None` without calling `record_decline()` for non-sargable expressions (AND, REGEX, etc.), causing the I5 counter to miss those paths.
- Acceptance tests T1–T4 added to `tests/differentials/vectorized_byte_identity.rs`: T1 non-vacuity (columnar_aggregate engages on ≥256-row SUM, `chunks_built >= 1`, byte-identical to budget-armed scalar), T2 decline paths (sub-threshold aggregate + shape-check FILTER), T3 ZK composition (`#[cfg(feature = "zk")]`), T4 budget parity (byte-identical JSON from both paths). Note: the SPARQL parser combines `FILTER A FILTER B` into `AND(A, B)`, so the double-filter trick for `columnar_filter` does not produce a sargable residual end-to-end; T1/T4 test `columnar_aggregate` instead, which is not intercepted by the fast-path.
- Updates existing Phase-3/4 tests (n=20/40 → n=300) and the ZK decline test (n=8 → n=300) to exceed `VEC_MIN_BATCH=256`.
- README and `skills/sparql-query/SKILL.md` updated with Phase 5 dispatcher documentation.

## Feature flags

- `vectorized` (OFF by default): the entire `vec_dispatch` module and all seam code compiles away when OFF.
- Tested in: default (OFF), `vectorized`, `vectorized,zk`.

## Gates run

- `cargo clippy -p sparq-engine --all-targets -- -D warnings`: GREEN (default + vectorized + vectorized,zk)
- `cargo test -p sparq-engine`: GREEN (default: 259 lib + 42 differentials; vectorized: 291 lib + 25 differentials; vectorized,zk: 295 lib + 42 differentials)
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features -p sparq-engine`: GREEN (intra-doc links to `pub(crate)` items demoted to code spans)
- `python3 scripts/check-readme-template.py --enforce`: 0 deviations

## Deferred beads

- `sq-pntvh.9`: EC2-measure and tune `VEC_MIN_BATCH`/`VEC_MORSEL` constants (placeholder values 256/2048 used here)
- `sq-y5ew5`: extend columnar_filter to partial-morsel scalar delegation (rows_delegated counter reserved but always 0 in Phase 5)

🤖 SPARQ agent