### PR TITLE
perf(core): concurrent permutation-index build, drop the SPO-first serial phase (sq-7d3dj.31)

### DIFF
--- a/crates/sparq-core/src/store.rs
+++ b/crates/sparq-core/src/store.rs
@@ -353,21 +353,57 @@ impl TripleStore {
         TripleStore { perms: std::sync::Arc::new(perms), pred_stats: std::sync::Arc::new(pred_stats), overlay: None }
     }
 
-    /// Builds the [`BUILT`] raw permutation indexes from canonical [s,p,o] triples (all
-    /// six by default; just SPO/POS/OSP under `compact-index`). SPO is sorted (in
-    /// parallel) and deduplicated first; the rest are independent and built concurrently.
+    /// Builds the [`BUILT`] raw permutation indexes from canonical [s,p,o] triples (all six
+    /// by default; just SPO/POS/OSP under `compact-index`). Two `cfg`-selected bodies: the
+    /// PARALLEL build builds every permutation concurrently; the NO-THREADS build keeps the
+    /// single SPO sort+dedup and maps the rest from it. They are separate `fn` definitions so
+    /// the no-threads (wasm) codegen is byte-for-byte the historical body — this change adds
+    /// NOTHING to the feature-off bundle.
+    ///
+    /// [OPUS-4.8 sq-7d3dj.31] Concurrent-N (parallel body): build EVERY BUILT permutation (SPO
+    /// included) concurrently via the O(n) LSD radix sort, each mapping+sorting+deduping its
+    /// OWN copy straight from the raw input. This removes the serial critical-path dependency
+    /// the prior path had — where SPO was `par_sort_unstable`+deduped FIRST and the other five
+    /// could not start until that finished. Measured on this box (8T, 8 M triples, drift-
+    /// cancelled interleaved A/B): the index build (`from_triples`) is ~13-16% faster, because
+    /// the five non-SPO perms no longer wait on the SPO sort — the parallelism gain outweighs
+    /// re-deriving SPO by radix instead of reusing the deduped array. Numbers are non-canonical
+    /// (this box's thermal/contention noise); the *ratio* + the structural reason (no serial
+    /// pre-phase) are the load-bearing points.
+    ///
+    /// Correctness: each perm deduped INDEPENDENTLY yields the identical multiset — a duplicate
+    /// `[s,p,o]` is a duplicate in every column order, and `Vec::dedup` after a full sort
+    /// removes exactly the consecutive equals, so every BUILT perm is byte-identical to the
+    /// reference `sort_unstable`+dedup+permute. Gated by the
+    /// `from_triples_perms_match_reference_sort` differential test.
+    #[cfg(feature = "parallel")]
+    fn build_raw_perms(triples: Vec<[Id; 3]>) -> [PermData; 6] {
+        let built: Vec<(Perm, Vec<[Id; 3]>)> = BUILT
+            .par_iter()
+            .map(|&p| {
+                let order = p.order();
+                // Pre-sized exactly from the known triple count (the mapped iterator is
+                // ExactSize, so `collect` reserves `triples.len()` up front — no grow tail).
+                let mut v: Vec<[Id; 3]> =
+                    triples.iter().map(|t| [t[order[0]], t[order[1]], t[order[2]]]).collect();
+                radix_sort_rows(&mut v);
+                v.dedup();
+                (p, v)
+            })
+            .collect();
+        let mut perms: [PermData; 6] = std::array::from_fn(|_| PermData::default());
+        for (p, v) in built {
+            perms[p as usize] = PermData::Owned(v);
+        }
+        perms
+    }
+
+    /// No-threads build of the permutation indexes (the feature-off sibling of `build_raw_perms`).
+    /// Deduplicates via the SPO ordering first (radix — no parallel sort to beat it here), then
+    /// maps the rest from the deduped array, reusing that array for the SPO slot. Kept
+    /// byte-identical to the historical body so the feature-off wasm bundle is unchanged.
+    #[cfg(not(feature = "parallel"))]
     fn build_raw_perms(mut triples: Vec<[Id; 3]>) -> [PermData; 6] {
-        // Deduplicate via the SPO ordering first. This single large array keeps the
-        // parallel comparison sort: measured on this box, `par_sort_unstable` beats the
-        // sequential radix for one 2M-row array (all cores vs one), so radix here would
-        // REGRESS the SPO/dedup step. The win is below — the FIVE non-SPO permutations move
-        // to the O(n) LSD radix (sq-7d3dj.17), which beats the sequential comparison sort
-        // and is where the flagged sort-family self-time lives (they build concurrently via
-        // par_iter, each a sequential radix). The no-threads build has no parallel sort, so
-        // radix wins the SPO step there too. [OPUS-4.8]
-        #[cfg(feature = "parallel")]
-        triples.par_sort_unstable();
-        #[cfg(not(feature = "parallel"))]
         radix_sort_rows(&mut triples);
         triples.dedup();
 
@@ -384,9 +420,6 @@ impl TripleStore {
 
         // Build every BUILT permutation except SPO (which is the deduped `triples`).
         let to_build: Vec<Perm> = BUILT.iter().copied().filter(|&p| p != Perm::Spo).collect();
-        #[cfg(feature = "parallel")]
-        let built: Vec<Vec<[Id; 3]>> = to_build.par_iter().map(|p| build(p.order())).collect();
-        #[cfg(not(feature = "parallel"))]
         let built: Vec<Vec<[Id; 3]>> = to_build.iter().map(|p| build(p.order())).collect();
 
         // Place each built permutation at its canonical slot; the rest stay empty.
@@ -974,6 +1007,32 @@ mod tests {
                 let got = store.perms[perm as usize].as_slice();
                 assert_eq!(got, &want[..], "permutation {perm:?} differs from the comparison-sort reference");
             }
+        }
+    }
+
+    /// [OPUS-4.8 sq-7d3dj.31] Direct gate on the concurrent-N build's INDEPENDENT per-perm
+    /// dedup: with the parallel build, SPO is no longer deduped-first-then-mapped — every perm
+    /// dedups its own sorted copy. On a heavily-duplicated input (the same handful of triples
+    /// repeated thousands of times) each BUILT perm must still hold EXACTLY the distinct set,
+    /// sorted, with no residual duplicate row — proving independent dedup equals the SPO-first
+    /// dedup it replaced. Non-vacuous: the expected length is the true distinct count.
+    #[test]
+    fn from_triples_independent_dedup_removes_all_duplicates() {
+        let base: [[Id; 3]; 5] = [[3, 1, 9], [1, 2, 2], [1, 2, 8], [7, 4, 4], [3, 1, 5]];
+        let mut triples: Vec<[Id; 3]> = Vec::new();
+        // Repeat the whole set 4000× (20 000 rows, only 5 distinct) plus one lone triple.
+        for _ in 0..4000 {
+            triples.extend_from_slice(&base);
+        }
+        triples.push([9, 9, 9]);
+        let distinct = 6; // the 5 in `base` plus [9,9,9]
+
+        let store = TripleStore::from_triples(triples);
+        for &perm in BUILT {
+            let rows = store.perms[perm as usize].as_slice();
+            assert_eq!(rows.len(), distinct, "permutation {perm:?} still holds duplicate rows");
+            // Fully sorted in this perm's column order, and strictly increasing (no dup).
+            assert!(rows.windows(2).all(|w| w[0] < w[1]), "permutation {perm:?} not strictly sorted/deduped");
         }
     }
 


### PR DESCRIPTION
> 🤖 SPARQ agent — profiling-first bulk-load optimization for the perf-dominance mandate (bead sq-7d3dj.31).

## What

`TripleStore::from_triples` → `build_raw_perms` (the in-memory index build) used to `par_sort_unstable`+dedup **SPO first**, then build the other five permutations by mapping from the deduped array — a serial critical-path pre-phase the five had to wait on. This builds **every BUILT permutation concurrently** via the O(n) LSD radix sort, each mapping+sorting+deduping its own copy straight from the raw input.

## Why (profiling evidence)

Profiled the parallel N-Triples load path (`perf record`, 8 threads, 8M-triple synthetic N-Triples, mimalloc + fat LTO) on the EC2 work box — larger than CI scale. Stage split: parse+intern+merge ~66% of load, index build (`from_parts`) ~35%. Within the index build the LSD radix (sq-7d3dj.17) and the numeric cache are already near-free; the visible cost was the SPO comparison sort sitting on the critical path ahead of the other five.

Removing that serial pre-phase makes the five non-SPO perms start immediately. **Measured (drift-cancelled interleaved A/B, 15 rounds): the index build is ~13–16% faster.** Numbers are **non-canonical** (this box has thermal/contention noise and is not a bench runner) — the load-bearing points are the *ratio* and the *structural* reason (no serial pre-phase). End-to-end in-memory bulk load improves less (~5%), since parse+intern+merge dominates at ~66%; the deeper interning levers are captured as follow-up beads.

## Correctness

Each permutation deduped **independently** yields the identical multiset — a duplicate `[s,p,o]` is a duplicate in every column order, and `Vec::dedup` after a full sort removes exactly the consecutive equals, so every BUILT perm is byte-identical to the reference `sort_unstable`+dedup+permute. Covered by the existing `from_triples_perms_match_reference_sort` differential gate plus a new direct test `from_triples_independent_dedup_removes_all_duplicates` (heavy-duplicate input; asserts each perm holds exactly the distinct set, strictly sorted). The no-threads (`not(feature = "parallel")`, e.g. wasm) build is **unchanged**.

## Gates run

- `cargo clippy -p sparq-core -D warnings` — clean in **default (parallel)**, **`--no-default-features` (parallel off)**, and **`--all-features`**.
- `cargo test -p sparq-core` — green in default, `--no-default-features`, and `--features compact-index` (the 3-permutation path).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean.

## Follow-up beads (root-caused, not fixed here)

- **sq-7d3dj.31.1** — eliminate the double-intern (every term is interned once per parse block into a local dict, then re-interned into the shard dict at merge — `find_iri` 12.9% + `find_iri_parts` 8.1%). The single largest remaining order-of-magnitude lever.
- **sq-7d3dj.31.2** — measure sharded dict-merge scaling on a 32–64 vCPU box (RDFox's ~1.76M t/s claim is at 64 threads; this 8-vCPU box can't exercise that regime; `into_merged` / `build_table` are serial points).