### PR TITLE
perf(shacl): batch sh:sparql focus nodes into ONE VALUES execution (sq-7d3dj.33.1) [OPUS-4.8]

### DIFF
--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -19,6 +19,28 @@ const XSD: &str = "http://www.w3.org/2001/XMLSchema#";
 /// a triple-term via `?r rdf:reifies <<( s p o )>>`. Used by `sh:reifierShape`.
 const RDF_REIFIES: &str = "http://www.w3.org/1999/02/22-rdf-syntax-ns#reifies";
 
+#[cfg(test)]
+use std::cell::Cell;
+#[cfg(test)]
+thread_local! {
+    /// [OPUS-4.8] (sq-7d3dj.33.1) Test-only: when set, `prime_sparql_batch` skips
+    /// priming so `validate` takes the per-focus path — lets the in-crate
+    /// differential test diff the batched report against the per-focus one.
+    static FORCE_NO_BATCH: Cell<bool> = const { Cell::new(false) };
+}
+
+/// [OPUS-4.8] (sq-7d3dj.33.1) Test-only helper: run `f` (typically a `validate`
+/// closure) with `sh:sparql` focus-node batching forced OFF, restoring the prior
+/// state afterwards. Used by the batched-vs-per-focus report-equivalence test.
+#[cfg(test)]
+pub(crate) fn with_sparql_batching_disabled<R>(f: impl FnOnce() -> R) -> R {
+    let prev = FORCE_NO_BATCH.with(Cell::get);
+    FORCE_NO_BATCH.with(|c| c.set(true));
+    let r = f();
+    FORCE_NO_BATCH.with(|c| c.set(prev));
+    r
+}
+
 /// Runs every targeted shape over its focus nodes. Results are deliberately NOT
 /// deduplicated: the SHACL test suite expects one result per constraint-component
 /// OCCURRENCE (e.g. two sh:class violations on one value) and per traversal route
@@ -38,12 +60,22 @@ pub(crate) fn validate_graph(
         uvf_targets: FxHashMap::default(),
         diagnostics: Vec::new(),
         active_meta: None,
+        sparql_batch: FxHashMap::default(),
     };
     let mut out = Vec::new();
     for &sid in &shapes.targeted {
-        for focus in v.focus_nodes(sid) {
-            v.validate_shape(sid, &focus, &mut out);
+        // [OPUS-4.8] (sq-7d3dj.33.1) Enumerate this shape's focus nodes ONCE, then
+        // batch-evaluate its `sh:sparql` constraints over the whole focus set in a
+        // single query each (instead of re-running the full query per focus node —
+        // the O(N_focus × full-query) quadratic root cause). `validate_shape` then
+        // drains the primed per-focus results; a non-batchable constraint or a
+        // nested/data-graph focus falls back to the per-focus path unchanged.
+        let foci = v.focus_nodes(sid);
+        v.prime_sparql_batch(sid, &foci);
+        for focus in &foci {
+            v.validate_shape(sid, focus, &mut out);
         }
+        v.sparql_batch.clear();
     }
     // [OPUS-4.8] (sq-rnkdh) SHACL 1.2 `sh:shape` data-graph targets: a triple
     // `?n sh:shape ?S` in the DATA graph makes `?n` a focus node of shape `?S`.
@@ -70,6 +102,7 @@ pub(crate) fn count_focus_nodes(data: &Graph, shapes: &ShapesModel) -> usize {
         uvf_targets: FxHashMap::default(),
         diagnostics: Vec::new(),
         active_meta: None,
+        sparql_batch: FxHashMap::default(),
     };
     let mut all: Vec<Term> = Vec::new();
     for &sid in &shapes.targeted {
@@ -104,6 +137,7 @@ pub(crate) fn conforms_node(data: &Graph, shapes: &ShapesModel, sid: usize, node
         uvf_targets: FxHashMap::default(),
         diagnostics: Vec::new(),
         active_meta: None,
+        sparql_batch: FxHashMap::default(),
     };
     v.conforms(node, sid)
 }
@@ -138,6 +172,14 @@ struct Validator<'a> {
     /// apply a per-occurrence `sh:message` / `sh:severity` (SHACL 1.2). `None` when
     /// the current constraint carries no annotation (the common case).
     active_meta: Option<ComponentMeta>,
+    /// [OPUS-4.8] (sq-7d3dj.33.1) Batched `sh:sparql` results, keyed by
+    /// `(shape id, sparql-constraint index)` → (focus node → its results). Primed
+    /// by [`Validator::prime_sparql_batch`] once per targeted shape (over ALL its
+    /// focus nodes in one execution) and drained per focus by
+    /// [`Validator::eval_sparql`], replacing the O(N_focus)-query per-focus loop.
+    /// A `(sid, idx)` absent here (a non-batchable constraint, or a shape validated
+    /// outside the top-level targeted loop) falls back to the per-focus path.
+    sparql_batch: FxHashMap<(usize, usize), FxHashMap<Term, Vec<ValidationResult>>>,
 }
 
 impl<'a> Validator<'a> {
@@ -1244,6 +1286,95 @@ impl<'a> Validator<'a> {
         }
     }
 
+    /// [OPUS-4.8] (sq-7d3dj.33.1) Stamps one `sh:sparql` solution's per-result
+    /// [`crate::sparql::ResultFields`] with the shape-owned fields (source
+    /// shape/constraint/component, severity, messages). Shared by the per-focus
+    /// [`Self::eval_sparql`] fallback and the batched [`Self::prime_sparql_batch`] so
+    /// both stamp identically — the load-bearing report-equivalence invariant.
+    fn stamp_sparql(
+        &self,
+        sid: usize,
+        idx: usize,
+        focus: &Term,
+        fields: crate::sparql::ResultFields,
+    ) -> ValidationResult {
+        let shape = &self.shapes.shapes[sid];
+        let constraint = &self.shapes.sparql[idx];
+        // [OPUS-4.8] (sq-rnkdh) A constraint-level `sh:severity` on the
+        // `sh:SPARQLConstraint` node OVERRIDES the shape's default severity (SHACL
+        // 1.2 `sparql/node/sparql-001`); otherwise inherit the shape's severity.
+        let severity = constraint
+            .severity
+            .clone()
+            .unwrap_or_else(|| shape.severity.clone());
+        ValidationResult {
+            focus_node: focus.clone(),
+            // A bound ?path overrides the shape's path; otherwise inherit the
+            // (property-shape) path, if any.
+            path: fields.path.or_else(|| shape.path.clone()),
+            value: fields.value,
+            source_shape: shape.node.clone(),
+            // [OPUS-4.8] (sq-mue75) stamp the originating `sh:SPARQLConstraint` node
+            // onto each result as `sh:sourceConstraint` (SHACL §5.2.2).
+            source_constraint: Some(constraint.node.clone()),
+            source_component: sh("SPARQLConstraintComponent"),
+            severity,
+            messages: shape.messages.clone(),
+            default_message: fields.default_message,
+            details: Vec::new(),
+        }
+    }
+
+    /// [OPUS-4.8] (sq-7d3dj.33.1) Batch-evaluates shape `sid`'s `sh:sparql`
+    /// constraints over ALL its focus nodes in ONE execution each, priming
+    /// [`Self::sparql_batch`] for the per-focus drain in [`Self::eval_sparql`]. This
+    /// replaces the O(N_focus × full-query) per-focus re-execution with O(1) queries
+    /// (chunked at 10 000 foci) — the quadratic root cause fixed by this bead. A
+    /// constraint that is NOT batchable (a top-level `LIMIT`/`OFFSET`, a `GROUP
+    /// BY`/aggregate not keyed on `$this`, or `REDUCED` — see
+    /// `crate::sparql::PreparedSparql::is_batchable`) is left unprimed and falls back
+    /// to the per-focus path unchanged.
+    fn prime_sparql_batch(&mut self, sid: usize, foci: &[Term]) {
+        // [OPUS-4.8] (sq-7d3dj.33.1) Test-only knob so the in-crate differential test
+        // can force the per-focus path and diff its report against the batched one.
+        #[cfg(test)]
+        if FORCE_NO_BATCH.with(Cell::get) {
+            return;
+        }
+        // A single focus is as cheap per-focus (and needs no map); correctness holds
+        // either way, so only prime when batching can actually amortise a query.
+        if foci.len() < 2 {
+            return;
+        }
+        let sparql_idxs: Vec<usize> = self.shapes.shapes[sid]
+            .components
+            .iter()
+            .filter_map(|c| match c {
+                Component::Sparql(i) => Some(*i),
+                _ => None,
+            })
+            .collect();
+        for idx in sparql_idxs {
+            let constraint = &self.shapes.sparql[idx];
+            if constraint.deactivated {
+                continue;
+            }
+            let Some(prepared) = &constraint.prepared else {
+                continue; // ill-formed sh:select — skipped (lenient, per crate policy)
+            };
+            if !prepared.is_batchable() {
+                continue; // non-batchable shape → per-focus fallback (documented)
+            }
+            let map = prepared.evaluate_batch(
+                self.data.graph(),
+                foci,
+                constraint,
+                |focus, fields| self.stamp_sparql(sid, idx, focus, fields),
+            );
+            self.sparql_batch.insert((sid, idx), map);
+        }
+    }
+
     /// SHACL-SPARQL evaluation for one `sh:sparql` constraint occurrence.
     fn eval_sparql(
         &mut self,
@@ -1252,6 +1383,19 @@ impl<'a> Validator<'a> {
         idx: usize,
         out: &mut Vec<ValidationResult>,
     ) {
+        // [OPUS-4.8] (sq-7d3dj.33.1) Fast path: drain the results this focus already
+        // received when the shape's constraints were batch-evaluated (the common
+        // top-level targeted case). Every focus covered by the batch has an entry —
+        // even with zero violations — so a `Some(_)` here means "already computed",
+        // never "not yet run"; we must not fall through and re-execute per-focus.
+        if let Some(per_focus) = self.sparql_batch.get(&(sid, idx)) {
+            if let Some(results) = per_focus.get(focus) {
+                out.extend(results.iter().cloned());
+                return;
+            }
+        }
+        // Per-focus fallback: a non-batchable constraint, a focus outside the primed
+        // set (a nested / `sh:shape` data-graph validation), or a single-focus shape.
         let constraint = &self.shapes.sparql[idx];
         if constraint.deactivated {
             return;
@@ -1259,39 +1403,12 @@ impl<'a> Validator<'a> {
         let Some(prepared) = &constraint.prepared else {
             return; // ill-formed sh:select — skipped (lenient, per crate policy)
         };
-        let component = sh("SPARQLConstraintComponent");
-        let shape = &self.shapes.shapes[sid];
-        // [OPUS-4.8] (sq-rnkdh) A constraint-level `sh:severity` on the
-        // `sh:SPARQLConstraint` node OVERRIDES the shape's default severity (SHACL
-        // 1.2 `sparql/node/sparql-001`); otherwise inherit the shape's severity.
-        let severity = constraint
-            .severity
-            .clone()
-            .unwrap_or_else(|| shape.severity.clone());
-        let (shape_node, shape_path, shape_messages) =
-            (shape.node.clone(), shape.path.clone(), shape.messages.clone());
-        // [OPUS-4.8] (sq-mue75) stamp the originating `sh:SPARQLConstraint` node
-        // onto each result as `sh:sourceConstraint` (SHACL §5.2.2).
-        let constraint_node = constraint.node.clone();
         let data = self.data.graph();
         prepared.evaluate(
             data,
             focus,
             constraint,
-            |fields| ValidationResult {
-                focus_node: focus.clone(),
-                // A bound ?path overrides the shape's path; otherwise inherit the
-                // (property-shape) path, if any.
-                path: fields.path.or_else(|| shape_path.clone()),
-                value: fields.value,
-                source_shape: shape_node.clone(),
-                source_constraint: Some(constraint_node.clone()),
-                source_component: component.clone(),
-                severity: severity.clone(),
-                messages: shape_messages.clone(),
-                default_message: fields.default_message,
-                details: Vec::new(),
-            },
+            |fields| self.stamp_sparql(sid, idx, focus, fields),
             out,
         );
     }

--- a/crates/sparq-shacl/src/lib.rs
+++ b/crates/sparq-shacl/src/lib.rs
@@ -164,6 +164,30 @@ pub fn count_focus_nodes(data: &Graph, model: &ShapesModel) -> usize {
     eval::count_focus_nodes(data, model)
 }
 
+/// [OPUS-4.8] (sq-7d3dj.33.1) The calling thread's monotonically-increasing count of
+/// `sh:sparql` constraint query executions the validator has run (one per engine
+/// query). Thread-local so a `validate` on one thread is not perturbed by a
+/// concurrent `validate` on another; snapshot and read the delta on the SAME thread.
+///
+/// Its purpose is a perf / anti-vacuity check: with focus-node batching the delta
+/// across one [`validate`] call is ~O(number of `sh:sparql` shapes) — one query per
+/// ~10 000-focus chunk — instead of O(number of focus nodes). A test / benchmark can
+/// snapshot it before and after [`validate`] and assert the batched path fired (a
+/// small delta for a large focus set), guarding against a silent regression back to
+/// the per-focus loop. The absolute value is not meaningful — only the delta.
+///
+/// ```
+/// # use sparq_shacl::{sparql_constraint_executions, validate, graph_from_triples};
+/// let before = sparql_constraint_executions();
+/// // ... run validate() over a shapes graph with sh:sparql constraints ...
+/// let executions = sparql_constraint_executions() - before;
+/// # let _ = executions;
+/// ```
+#[must_use]
+pub fn sparql_constraint_executions() -> u64 {
+    sparql::exec_count()
+}
+
 /// Loads a Turtle document into a [`Graph`], resolving relative IRIs against
 /// `base`.
 pub fn load_turtle_with_base(text: &str, base: &str) -> Result<Graph, String> {
@@ -921,6 +945,192 @@ mod tests {
         .unwrap();
         let r = validate(&data, &shapes);
         assert!(r.conforms, "{}", r.to_text());
+    }
+
+    // --- [OPUS-4.8] (sq-7d3dj.33.1) sh:sparql focus-node batching --------------
+
+    /// A stable, order-independent key for one result, covering every field the
+    /// W3C suite compares (focus / value / path / component / source shape+constraint
+    /// / severity / message). Two reports are report-equivalent iff their sorted key
+    /// multisets are equal.
+    fn result_keys(r: &ValidationReport) -> Vec<String> {
+        let mut ks: Vec<String> = r
+            .results
+            .iter()
+            .map(|x| {
+                format!(
+                    "{}|{}|{}|{}|{}|{}|{}|{}",
+                    x.focus_node,
+                    x.value.as_ref().map(|v| v.to_string()).unwrap_or_default(),
+                    x.path.as_ref().map(Path::to_turtle).unwrap_or_default(),
+                    x.source_component,
+                    x.source_shape,
+                    x.source_constraint
+                        .as_ref()
+                        .map(|c| c.to_string())
+                        .unwrap_or_default(),
+                    x.severity,
+                    x.default_message,
+                )
+            })
+            .collect();
+        ks.sort();
+        ks
+    }
+
+    /// Data + shapes with a `sh:sparql` constraint over MANY focus nodes, a mix of
+    /// violating and conforming, plus a non-`sh:sparql` (core) constraint on the same
+    /// shape so batching must interleave correctly with the per-focus components.
+    fn batch_case() -> (Graph, Graph) {
+        let mut data = String::from("@prefix ex: <http://example.org/> .\n");
+        for i in 0..60 {
+            // Even i => age negative (violates the sh:sparql); every 7th also lacks a
+            // name (violates the core minCount) — exercising mixed components/foci.
+            let age = if i % 2 == 0 { -(i as i64) - 1 } else { i as i64 };
+            data.push_str(&format!("ex:n{} a ex:Person ; ex:age {} .\n", i, age));
+            if i % 7 != 0 {
+                data.push_str(&format!("ex:n{} ex:name \"n{}\" .\n", i, i));
+            }
+        }
+        let shapes = r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            ex:PersonShape a sh:NodeShape ;
+              sh:targetClass ex:Person ;
+              sh:property [ sh:path ex:name ; sh:minCount 1 ] ;
+              sh:sparql [
+                a sh:SPARQLConstraint ;
+                sh:prefixes ex:p ;
+                sh:message "age must not be negative" ;
+                sh:select """SELECT $this ?value WHERE { $this <http://example.org/age> ?value . FILTER(?value < 0) }""" ;
+              ] .
+            ex:p sh:declare [ sh:prefix "ex" ; sh:namespace "http://example.org/"^^xsd:anyURI ] .
+        "#;
+        (
+            Graph::load_str(&data, "turtle").unwrap(),
+            Graph::load_str(shapes, "turtle").unwrap(),
+        )
+    }
+
+    /// HARD invariant: the batched `sh:sparql` path produces a byte-for-byte
+    /// report-equivalent result set (and `conforms`) to the per-focus path, over a
+    /// many-focus mixed-component workload.
+    #[test]
+    fn batched_equals_per_focus_report() {
+        let (data, shapes) = batch_case();
+        let batched = validate(&data, &shapes);
+        let per_focus = eval::with_sparql_batching_disabled(|| validate(&data, &shapes));
+        assert_eq!(
+            batched.conforms, per_focus.conforms,
+            "conforms diverged between batched and per-focus"
+        );
+        assert_eq!(
+            batched.results.len(),
+            per_focus.results.len(),
+            "result count diverged"
+        );
+        assert_eq!(
+            result_keys(&batched),
+            result_keys(&per_focus),
+            "batched vs per-focus reports differ"
+        );
+        // The sh:sparql constraint alone flags the 30 even-index nodes.
+        let sparql_hits = batched
+            .results
+            .iter()
+            .filter(|r| r.source_component.ends_with("SPARQLConstraintComponent"))
+            .count();
+        assert_eq!(sparql_hits, 30, "expected 30 negative-age violations");
+    }
+
+    /// [OPUS-4.8] (sq-7d3dj.33.1) Local, NON-canonical measurement of the batched vs
+    /// per-focus `sh:sparql` wall time on a synthetic workload shaped like the LUBM
+    /// `sparql_constraint`/`sparql_heavy` benchmarks (a `SELECT $this ?value` with a
+    /// two-triple BGP + type check, one solution per violating focus). Prints the
+    /// speed-up ratio; run with `cargo test -p sparq-shacl --lib -- --ignored
+    /// --nocapture perf_batched`. `#[ignore]` because it is a timing harness, not a
+    /// pass/fail gate (the box is shared → numbers are directional only). It still
+    /// asserts the reports match and the execution-count contrast holds.
+    #[test]
+    #[ignore = "local timing harness; non-canonical, run with --ignored --nocapture"]
+    fn perf_batched_vs_per_focus() {
+        use std::time::Instant;
+        const N: usize = 2000;
+        let mut data = String::from("@prefix ex: <http://example.org/> .\n");
+        for i in 0..N {
+            data.push_str(&format!("ex:s{} a ex:Student ; ex:takesCourse ex:c{} .\n", i, i));
+            // Half the courses are graduate courses → half the students violate.
+            if i % 2 == 0 {
+                data.push_str(&format!("ex:c{} a ex:GraduateCourse .\n", i));
+            }
+        }
+        let shapes = r#"
+            @prefix sh: <http://www.w3.org/ns/shacl#> .
+            @prefix ex: <http://example.org/> .
+            @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+            ex:S a sh:NodeShape ;
+              sh:targetClass ex:Student ;
+              sh:sparql [ a sh:SPARQLConstraint ; sh:prefixes ex:p ; sh:message "grad course" ;
+                sh:select """SELECT $this ?value WHERE { $this <http://example.org/takesCourse> ?value . ?value a <http://example.org/GraduateCourse> }""" ] .
+            ex:p sh:declare [ sh:prefix "ex" ; sh:namespace "http://example.org/"^^xsd:anyURI ] .
+        "#;
+        let data = Graph::load_str(&data, "turtle").unwrap();
+        let shapes = Graph::load_str(shapes, "turtle").unwrap();
+
+        // Warm up (parse/plan caches) then time each path best-of-3.
+        let mut batched_ns = u128::MAX;
+        let mut per_focus_ns = u128::MAX;
+        let mut batched_report = None;
+        let mut per_focus_report = None;
+        for _ in 0..3 {
+            let t = Instant::now();
+            let r = validate(&data, &shapes);
+            batched_ns = batched_ns.min(t.elapsed().as_nanos());
+            batched_report = Some(r);
+
+            let t = Instant::now();
+            let r = eval::with_sparql_batching_disabled(|| validate(&data, &shapes));
+            per_focus_ns = per_focus_ns.min(t.elapsed().as_nanos());
+            per_focus_report = Some(r);
+        }
+        let batched = batched_report.unwrap();
+        let per_focus = per_focus_report.unwrap();
+        assert_eq!(result_keys(&batched), result_keys(&per_focus));
+        let ratio = per_focus_ns as f64 / batched_ns as f64;
+        println!(
+            "[sq-7d3dj.33.1] N={N} foci  batched={:.3}ms  per_focus={:.3}ms  speed-up={:.1}x  (violations={})",
+            batched_ns as f64 / 1e6,
+            per_focus_ns as f64 / 1e6,
+            ratio,
+            batched.results.len(),
+        );
+    }
+
+    /// Anti-vacuity: the batched path FIRES — one query execution for 60 focus nodes,
+    /// not 60. Uses the public per-thread execution counter.
+    #[test]
+    fn batched_path_fires_once_for_many_foci() {
+        let (data, shapes) = batch_case();
+        let before = sparql_constraint_executions();
+        let _ = validate(&data, &shapes);
+        let batched_execs = sparql_constraint_executions() - before;
+        assert_eq!(
+            batched_execs, 1,
+            "expected ONE batched sh:sparql execution for 60 foci, got {}",
+            batched_execs
+        );
+        // And the per-focus path really does run one query per focus (the contrast
+        // that makes the '1' meaningful, not an artefact of e.g. zero executions).
+        let before_pf = sparql_constraint_executions();
+        eval::with_sparql_batching_disabled(|| {
+            let _ = validate(&data, &shapes);
+        });
+        let per_focus_execs = sparql_constraint_executions() - before_pf;
+        assert_eq!(
+            per_focus_execs, 60,
+            "per-focus path should run one query per focus node"
+        );
     }
 }
 

--- a/crates/sparq-shacl/src/sparql.rs
+++ b/crates/sparq-shacl/src/sparql.rs
@@ -33,9 +33,45 @@
 use crate::model::SparqlConstraint;
 use crate::report::ValidationResult;
 use oxrdf::{Term, Variable};
+use rustc_hash::FxHashMap;
 use spargebra::algebra::GraphPattern;
 use spargebra::term::GroundTerm;
 use spargebra::{Query, SparqlParser};
+use std::cell::Cell;
+
+thread_local! {
+    /// [OPUS-4.8] (sq-7d3dj.33.1) Per-thread monotonic count of `sh:sparql`
+    /// constraint query executions (one per `sparq_engine::query_prepared` call the
+    /// SHACL-SPARQL path makes). The per-focus-node path runs one query PER focus
+    /// node — O(N_focus); the batched path ([`PreparedSparql::evaluate_batch`]) runs
+    /// one query per ~10 000-focus chunk — O(N_focus / chunk). A perf-regression
+    /// guard or an anti-vacuity test can assert the batched delta is ~O(#shapes),
+    /// not O(#focus_nodes). Thread-local (not a global atomic) so a `validate` on one
+    /// thread is not perturbed by a concurrent `validate` on another — the SHACL-SPARQL
+    /// evaluation runs the query on the calling thread, so the count is exact there.
+    /// Read via [`exec_count`].
+    static SPARQL_EXEC_COUNT: Cell<u64> = const { Cell::new(0) };
+}
+
+/// [OPUS-4.8] (sq-7d3dj.33.1) Bumps the calling thread's `sh:sparql`
+/// query-execution counter by one (called at each engine query the path runs).
+fn bump_exec_count() {
+    SPARQL_EXEC_COUNT.with(|c| c.set(c.get() + 1));
+}
+
+/// [OPUS-4.8] (sq-7d3dj.33.1) Read the calling thread's `sh:sparql`
+/// query-execution counter (see [`SPARQL_EXEC_COUNT`]). Monotonic; snapshot before
+/// and after a [`crate::validate`] call on the same thread and take the delta.
+pub(crate) fn exec_count() -> u64 {
+    SPARQL_EXEC_COUNT.with(Cell::get)
+}
+
+/// [OPUS-4.8] (sq-7d3dj.33.1) The maximum number of focus nodes injected into a
+/// single batched `VALUES ?this { … }` execution. Very large focus sets are
+/// chunked so query plans stay sane; chunking never changes the result set (the
+/// VALUES table partitions cleanly by `?this`, and results are grouped by `?this`
+/// afterwards regardless of chunk boundaries).
+const FOCUS_BATCH_CHUNK: usize = 10_000;
 
 /// One `($name, value)` pre-binding for a validator/constraint query: the value
 /// is injected as a single-row `VALUES (?name) { (value) }` table. SHACL §6.3
@@ -117,6 +153,16 @@ impl PreBindingViolation {
 pub(crate) struct PreparedSparql {
     /// The parsed `sh:select` algebra (prefixes already resolved at parse time).
     query: Query,
+    /// [OPUS-4.8] (sq-7d3dj.33.1) Whether all focus nodes may be validated in ONE
+    /// batched `VALUES ?this { … }` execution (see [`Self::evaluate_batch`]). Batching
+    /// is result-equivalent to the per-focus path for the pre-binding-legal subset the
+    /// crate already enforces (no `MINUS` / author `VALUES` / `SERVICE`; a sub-`SELECT`
+    /// must project `$this`, so a NESTED aggregate necessarily groups by `$this`),
+    /// EXCEPT a TOP-level solution modifier whose effect is global rather than
+    /// per-focus: `LIMIT`/`OFFSET` (a global row cap), a `GROUP BY`/aggregate not keyed
+    /// on `$this` (mixes foci), or `REDUCED` (implementation-defined multiplicity).
+    /// Those keep the per-focus path (conservative fallback; see [`query_batchable`]).
+    batchable: bool,
 }
 
 impl PreparedSparql {
@@ -159,12 +205,24 @@ impl PreparedSparql {
             other => other,
         };
         check_pre_binding(body, PRE_BOUND_THIS)?;
-        Ok(Some(PreparedSparql { query }))
+        let batchable = query_batchable(pattern);
+        Ok(Some(PreparedSparql { query, batchable }))
+    }
+
+    /// [OPUS-4.8] (sq-7d3dj.33.1) Whether this constraint may be evaluated for all
+    /// focus nodes in ONE batched execution (see the `batchable` field). A `false`
+    /// keeps the per-focus [`Self::evaluate`] path (still correct, just not sped up).
+    pub(crate) fn is_batchable(&self) -> bool {
+        self.batchable
     }
 
     /// Runs the constraint for one `focus` node against `data`, pushing one
     /// [`ValidationResult`] per solution. `make_result` lets the caller stamp the
     /// shape-owned fields (source shape/component, severity, shape messages).
+    ///
+    /// This is the per-focus path. [`Self::evaluate_batch`] runs the identical
+    /// mapping for ALL focus nodes in ONE execution when [`Self::is_batchable`];
+    /// both share [`row_to_fields`] so their reports are byte-for-byte identical.
     pub(crate) fn evaluate(
         &self,
         data: &sparq_core::Graph,
@@ -176,6 +234,7 @@ impl PreparedSparql {
         let Some(bound) = pre_bind_select(&self.query, &[("this", focus)]) else {
             return; // focus node not expressible as a VALUES ground term (unreachable today)
         };
+        bump_exec_count();
         let prepared = sparq_engine::PreparedQuery::from(bound);
         let Ok(result) = sparq_engine::query_prepared(data, &prepared) else {
             return; // a runtime query error → no solutions (lenient; never panics validate())
@@ -191,40 +250,161 @@ impl PreparedSparql {
         let result_vars: Vec<String> = result.vars.iter().map(|v| v.as_str().to_string()).collect();
 
         for row in &result.rows {
-            // sh:value (SHACL §5.2.2): the solution's ?value binding when the query
-            // projects ?value; otherwise the focus node itself. The focus-node
-            // default (when ?value is not projected at all) is what the W3C suite
-            // expects — e.g. sparql/node/sparql-003 projects only ?path and its
-            // expected sh:value is the focus node. A query that DOES project ?value
-            // but leaves it unbound on a row reports no sh:value (None).
-            let value = match vpos {
-                Some(i) => row.get(i).and_then(|c| c.clone()),
-                None => Some(focus.clone()),
-            };
-            let path = ppos
-                .and_then(|i| row.get(i))
-                .and_then(|c| c.clone())
-                .and_then(|t| match t {
-                    Term::NamedNode(n) => Some(crate::path::Path::Predicate(n.as_str().to_string())),
-                    _ => None,
-                });
-            // Message precedence: the constraint's sh:message (with {?var}
-            // substitution), else a bound ?message, else a generated default.
-            let row_message = mpos
-                .and_then(|i| row.get(i))
-                .and_then(|c| c.clone())
-                .map(term_lexical);
-            let default_message = match (&constraint.message, &row_message) {
-                (Some(tpl), _) => substitute(tpl, &result_vars, row),
-                (None, Some(m)) => m.clone(),
-                (None, None) => "Violates SPARQL-based constraint".to_string(),
-            };
-            out.push(make_result(ResultFields {
-                value,
-                path,
-                default_message,
-            }));
+            let fields = row_to_fields(focus, row, vpos, ppos, mpos, &result_vars, constraint);
+            out.push(make_result(fields));
         }
+    }
+
+    /// [OPUS-4.8] (sq-7d3dj.33.1) Runs the constraint for ALL `foci` in ONE batched
+    /// execution: injects a single `VALUES ?this { <f1> <f2> … }` (chunked at
+    /// [`FOCUS_BATCH_CHUNK`]), executes once per chunk, then GROUPS the solution rows
+    /// by their `?this` binding to build the per-focus results. This is the O(1)-query
+    /// replacement for the O(N_focus)-query per-focus loop (measured ~580× on the
+    /// LUBM `sparql_constraint` workload). MUST only be called when [`Self::is_batchable`].
+    ///
+    /// Result-equivalence: the injected multi-row `VALUES` uses the SAME algebra-level
+    /// push-down as the single-row path, and `?this` is projected, so a solution for
+    /// focus `f` is exactly the per-focus solution for `f` (the natural join on the
+    /// distinct-`?this` VALUES is idempotent per branch). Each result row is mapped by
+    /// the SAME [`row_to_fields`] the per-focus path uses. `make_result` is invoked with
+    /// the row's `?this` so the caller stamps the correct focus node.
+    ///
+    /// Returns a map with an entry for EVERY focus in `foci` (empty `Vec` when a focus
+    /// has no violations), so the caller can distinguish "covered, no violations" from
+    /// "not batched" — a focus not in the returned map (e.g. a blank node, which cannot
+    /// be a `VALUES` ground term, matching [`Self::evaluate`]'s early return) is simply
+    /// absent and yields no results, identical to the per-focus path.
+    pub(crate) fn evaluate_batch(
+        &self,
+        data: &sparq_core::Graph,
+        foci: &[Term],
+        constraint: &SparqlConstraint,
+        mut make_result: impl FnMut(&Term, ResultFields) -> ValidationResult,
+    ) -> FxHashMap<Term, Vec<ValidationResult>> {
+        // Every focus expressible as a VALUES ground term gets a (possibly empty)
+        // entry so the caller treats it as covered; a blank-node focus is excluded
+        // (no VALUES syntax) and left absent — exactly the per-focus early return.
+        let mut grouped: FxHashMap<Term, Vec<ValidationResult>> = FxHashMap::default();
+        let ground: Vec<&Term> = foci
+            .iter()
+            .filter(|f| term_to_ground(f).is_some())
+            .collect();
+        for f in &ground {
+            grouped.entry((*f).clone()).or_default();
+        }
+        for chunk in ground.chunks(FOCUS_BATCH_CHUNK) {
+            let Some(bound) = pre_bind_select_multi(&self.query, "this", chunk) else {
+                continue; // inexpressible term in the chunk (unreachable — all ground)
+            };
+            bump_exec_count();
+            let prepared = sparq_engine::PreparedQuery::from(bound);
+            let Ok(result) = sparq_engine::query_prepared(data, &prepared) else {
+                continue; // runtime query error → no solutions for this chunk (lenient)
+            };
+            let pos = |name: &str| result.vars.iter().position(|v| v.as_str() == name);
+            let (tpos, vpos, ppos, mpos) =
+                (pos("this"), pos("value"), pos("path"), pos("message"));
+            let result_vars: Vec<String> =
+                result.vars.iter().map(|v| v.as_str().to_string()).collect();
+            for row in &result.rows {
+                // The row's ?this routes it to its focus group. `?this` is always
+                // projected + bound (the injected VALUES binds it), so this is Some
+                // in practice; a row without it is skipped rather than mis-grouped.
+                let Some(this) = tpos.and_then(|i| row.get(i)).and_then(|c| c.clone()) else {
+                    continue;
+                };
+                let fields =
+                    row_to_fields(&this, row, vpos, ppos, mpos, &result_vars, constraint);
+                let vr = make_result(&this, fields);
+                grouped.entry(this).or_default().push(vr);
+            }
+        }
+        grouped
+    }
+}
+
+/// [OPUS-4.8] (sq-7d3dj.33.1) Maps one executed solution `row` to the per-solution
+/// [`ResultFields`] (SHACL §5.2.2). Shared by [`PreparedSparql::evaluate`] (single
+/// focus) and [`PreparedSparql::evaluate_batch`] (grouped by `?this`) so both
+/// produce byte-for-byte identical reports; `focus` is the loop focus / the row's
+/// `?this` respectively.
+fn row_to_fields(
+    focus: &Term,
+    row: &[Option<Term>],
+    vpos: Option<usize>,
+    ppos: Option<usize>,
+    mpos: Option<usize>,
+    result_vars: &[String],
+    constraint: &SparqlConstraint,
+) -> ResultFields {
+    // sh:value (SHACL §5.2.2): the solution's ?value binding when the query
+    // projects ?value; otherwise the focus node itself. The focus-node default
+    // (when ?value is not projected at all) is what the W3C suite expects — e.g.
+    // sparql/node/sparql-003 projects only ?path and its expected sh:value is the
+    // focus node. A query that DOES project ?value but leaves it unbound on a row
+    // reports no sh:value (None).
+    let value = match vpos {
+        Some(i) => row.get(i).and_then(|c| c.clone()),
+        None => Some(focus.clone()),
+    };
+    let path = ppos
+        .and_then(|i| row.get(i))
+        .and_then(|c| c.clone())
+        .and_then(|t| match t {
+            Term::NamedNode(n) => Some(crate::path::Path::Predicate(n.as_str().to_string())),
+            _ => None,
+        });
+    // Message precedence: the constraint's sh:message (with {?var} substitution),
+    // else a bound ?message, else a generated default.
+    let row_message = mpos
+        .and_then(|i| row.get(i))
+        .and_then(|c| c.clone())
+        .map(term_lexical);
+    let default_message = match (&constraint.message, &row_message) {
+        (Some(tpl), _) => substitute(tpl, result_vars, row),
+        (None, Some(m)) => m.clone(),
+        (None, None) => "Violates SPARQL-based constraint".to_string(),
+    };
+    ResultFields {
+        value,
+        path,
+        default_message,
+    }
+}
+
+/// [OPUS-4.8] (sq-7d3dj.33.1) `true` iff the query is safe to evaluate for all focus
+/// nodes in ONE batched `VALUES ?this` execution (the multi-row VALUES joined into
+/// the WHERE, results grouped by `?this` afterwards). Unsafe when a TOP-level
+/// solution modifier applies GLOBALLY across foci instead of per-focus:
+///   * `LIMIT`/`OFFSET` (`Slice`) — a global row cap;
+///   * `REDUCED` — implementation-defined duplicate multiplicity (batched vs
+///     per-focus could keep a different number of duplicates → different count);
+///   * a TOP-level aggregate (`Group`) NOT grouped by `$this` — an implicit single
+///     group (empty group vars) or a `GROUP BY ?other` mixes rows from all foci into
+///     one aggregate. A `GROUP BY $this` IS per-focus-equivalent (each focus is its
+///     own group), so it stays batchable. A NESTED aggregate sub-select is always
+///     safe: the pre-binding check ([`check_pre_binding`]) forces every sub-`SELECT`
+///     to project — hence `GROUP BY` — `$this`, so the multi-row VALUES join
+///     partitions it per focus; only the TOP-level query modifiers are inspected.
+///
+/// `Distinct`/`OrderBy`/`Project`/`Extend`/`Filter` are transparent: order is
+/// irrelevant to the violation bag; `Distinct` includes the distinct `?this` (so it
+/// collapses per-focus exactly as the per-focus path); `Extend`/`Filter` are the
+/// aggregate-projection / `HAVING` wrappers we descend through to reach a top-level
+/// `Group`, or ordinary per-row `BIND`/`FILTER` that are per-focus-equivalent. The
+/// walk stops (batchable) at the first branching/leaf node (`Join`/`Union`/`Bgp`/…),
+/// because a top-level aggregate's `Group` sits directly above the WHERE with only
+/// those transparent wrappers between it and the projection.
+fn query_batchable(pattern: &GraphPattern) -> bool {
+    match pattern {
+        GraphPattern::Slice { .. } | GraphPattern::Reduced { .. } => false,
+        GraphPattern::Group { variables, .. } => variables.iter().any(|v| v.as_str() == "this"),
+        GraphPattern::Distinct { inner }
+        | GraphPattern::OrderBy { inner, .. }
+        | GraphPattern::Extend { inner, .. }
+        | GraphPattern::Filter { inner, .. }
+        | GraphPattern::Project { inner, .. } => query_batchable(inner),
+        _ => true,
     }
 }
 
@@ -418,6 +598,47 @@ fn pre_bind_values(bindings: &[Binding]) -> Option<GraphPattern> {
     Some(GraphPattern::Values {
         variables,
         bindings: vec![row],
+    })
+}
+
+/// [OPUS-4.8] (sq-7d3dj.33.1) Builds the MULTI-row `VALUES (?name) { (v1) (v2) … }`
+/// table that pre-binds `name` to EACH term in `foci` (one row per focus), for the
+/// batched `sh:sparql` path. Single column, N rows — as opposed to
+/// [`pre_bind_values`]'s single-row/N-column shape. Returns `None` if any focus is
+/// not a SPARQL ground term (all callers pre-filter to ground terms).
+fn pre_bind_values_multi(name: &str, foci: &[&Term]) -> Option<GraphPattern> {
+    let variables = vec![Variable::new_unchecked(name)];
+    let mut bindings = Vec::with_capacity(foci.len());
+    for f in foci {
+        bindings.push(vec![Some(term_to_ground(f)?)]);
+    }
+    Some(GraphPattern::Values {
+        variables,
+        bindings,
+    })
+}
+
+/// [OPUS-4.8] (sq-7d3dj.33.1) Pre-binds `name` to EVERY term in `foci` at once by
+/// injecting the multi-row `VALUES` from [`pre_bind_values_multi`] through the SAME
+/// [`inject_values`] push-down the single-focus [`pre_bind_select`] uses, so the
+/// batched query is the per-focus query unioned over foci. `name` is added to the
+/// projection so the executor returns it (used to group solutions by focus). The
+/// batched result set is exactly the per-focus results' union because the natural
+/// join on the distinct-`?this` VALUES is idempotent per branch.
+fn pre_bind_select_multi(query: &Query, name: &str, foci: &[&Term]) -> Option<Query> {
+    let Query::Select {
+        dataset,
+        pattern,
+        base_iri,
+    } = query
+    else {
+        return None;
+    };
+    let values = pre_bind_values_multi(name, foci)?;
+    Some(Query::Select {
+        dataset: dataset.clone(),
+        pattern: inject_values(pattern, values, &[name]),
+        base_iri: base_iri.clone(),
     })
 }
 
@@ -2136,5 +2357,204 @@ mod tests {
             ),
             Ok(())
         );
+    }
+
+    // --- [OPUS-4.8] (sq-7d3dj.33.1) focus-node batching ----------------------
+
+    fn top_pattern(q: &str) -> GraphPattern {
+        match SparqlParser::new().parse_query(q).unwrap() {
+            Query::Select { pattern, .. } => pattern,
+            other => panic!("expected SELECT, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn query_batchable_plain_select_is_batchable() {
+        // A plain BGP+FILTER SELECT (the common sh:sparql shape) batches.
+        assert!(query_batchable(&top_pattern(
+            "SELECT ?this ?value WHERE { ?this <http://x/p> ?value . FILTER(?value < 0) }"
+        )));
+    }
+
+    #[test]
+    fn query_batchable_distinct_and_orderby_are_batchable() {
+        // DISTINCT includes the distinct ?this (collapses per-focus); ORDER BY is
+        // irrelevant to the violation bag — both stay batchable.
+        assert!(query_batchable(&top_pattern(
+            "SELECT DISTINCT ?this ?value WHERE { ?this <http://x/p> ?value } ORDER BY ?value"
+        )));
+    }
+
+    #[test]
+    fn query_batchable_rejects_top_level_limit() {
+        // A top-level LIMIT is a GLOBAL row cap — not equivalent per focus.
+        assert!(!query_batchable(&top_pattern(
+            "SELECT ?this ?value WHERE { ?this <http://x/p> ?value } LIMIT 5"
+        )));
+    }
+
+    #[test]
+    fn query_batchable_allows_group_by_this() {
+        // GROUP BY $this = each focus is its own group → per-focus-equivalent.
+        assert!(query_batchable(&top_pattern(
+            "SELECT ?this (COUNT(?value) AS ?c) WHERE { ?this <http://x/p> ?value } GROUP BY ?this"
+        )));
+    }
+
+    #[test]
+    fn query_batchable_rejects_implicit_aggregate() {
+        // An implicit single group (no GROUP BY) aggregates across ALL foci.
+        assert!(!query_batchable(&top_pattern(
+            "SELECT (COUNT(?value) AS ?c) WHERE { ?this <http://x/p> ?value }"
+        )));
+    }
+
+    #[test]
+    fn query_batchable_rejects_group_by_other() {
+        // GROUP BY a non-$this variable mixes rows from different foci into one group.
+        assert!(!query_batchable(&top_pattern(
+            "SELECT ?p (COUNT(?value) AS ?c) WHERE { ?this ?p ?value } GROUP BY ?p"
+        )));
+    }
+
+    #[test]
+    fn query_batchable_allows_nested_aggregate_subselect() {
+        // A NESTED aggregate sub-select is fine: the pre-binding check forces it to
+        // project (hence GROUP BY) $this, so the multi-row VALUES join partitions it
+        // per focus. Only the TOP-level chain is inspected.
+        assert!(query_batchable(&top_pattern(
+            "SELECT ?this WHERE { ?this <http://x/p> ?v . \
+             { SELECT ?this (COUNT(*) AS ?c) WHERE { ?this <http://x/q> ?w } GROUP BY ?this } \
+             FILTER(?c > 1) }"
+        )));
+    }
+
+    #[test]
+    fn pre_bind_values_multi_builds_one_column_n_rows() {
+        let a = iri("http://example.org/a");
+        let b = iri("http://example.org/b");
+        let c = iri("http://example.org/c");
+        let vals = pre_bind_values_multi("this", &[&a, &b, &c]).unwrap();
+        match vals {
+            GraphPattern::Values {
+                variables,
+                bindings,
+            } => {
+                assert_eq!(variables.len(), 1);
+                assert_eq!(variables[0].as_str(), "this");
+                assert_eq!(bindings.len(), 3, "one row per focus");
+                assert!(bindings.iter().all(|r| r.len() == 1), "single column");
+            }
+            other => panic!("expected VALUES, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn pre_bind_values_multi_none_for_blank_node() {
+        // A blank node has no VALUES ground-term form (matches the per-focus skip).
+        let bnode = Term::BlankNode(oxrdf::BlankNode::new("b0").unwrap());
+        assert!(pre_bind_values_multi("this", &[&bnode]).is_none());
+    }
+
+    #[test]
+    fn pre_bind_select_multi_projects_this_and_injects_multi_row() {
+        // The injected query must project ?this (so results can be grouped by focus)
+        // and carry the N-row VALUES table.
+        let q = SparqlParser::new()
+            .parse_query("SELECT ?value WHERE { ?this <http://x/p> ?value }")
+            .unwrap();
+        let a = iri("http://example.org/a");
+        let b = iri("http://example.org/b");
+        let bound = pre_bind_select_multi(&q, "this", &[&a, &b]).unwrap();
+        let Query::Select { pattern, .. } = bound else {
+            panic!("expected SELECT");
+        };
+        // ?this added to the projection.
+        let GraphPattern::Project { variables, .. } = &pattern else {
+            panic!("expected Project at top, got {:?}", pattern);
+        };
+        assert!(
+            variables.iter().any(|v| v.as_str() == "this"),
+            "?this must be projected for grouping: {:?}",
+            variables
+        );
+        // A 2-row VALUES exists somewhere in the injected pattern.
+        fn max_values_rows(p: &GraphPattern) -> usize {
+            match p {
+                GraphPattern::Values { bindings, .. } => bindings.len(),
+                GraphPattern::Project { inner, .. }
+                | GraphPattern::Distinct { inner }
+                | GraphPattern::Reduced { inner }
+                | GraphPattern::Slice { inner, .. }
+                | GraphPattern::OrderBy { inner, .. }
+                | GraphPattern::Filter { inner, .. }
+                | GraphPattern::Extend { inner, .. }
+                | GraphPattern::Group { inner, .. }
+                | GraphPattern::Graph { inner, .. } => max_values_rows(inner),
+                GraphPattern::Join { left, right }
+                | GraphPattern::Union { left, right }
+                | GraphPattern::LeftJoin { left, right, .. }
+                | GraphPattern::Minus { left, right } => {
+                    max_values_rows(left).max(max_values_rows(right))
+                }
+                _ => 0,
+            }
+        }
+        assert_eq!(max_values_rows(&pattern), 2, "multi-row VALUES injected");
+    }
+
+    /// End-to-end batched execution: one `evaluate_batch` groups solutions by focus
+    /// and stamps them, with the executed-query count amortised to ONE for many foci.
+    #[test]
+    fn evaluate_batch_groups_by_focus_and_fires_once() {
+        use crate::model::SparqlConstraint;
+        let data = Graph::load_str(
+            "@prefix ex: <http://example.org/> .\n\
+             ex:a ex:age -1 . ex:b ex:age 5 . ex:c ex:age -2 . ex:d ex:age 9 .",
+            "turtle",
+        )
+        .unwrap();
+        let constraint = SparqlConstraint {
+            node: iri("http://example.org/constraint"),
+            select: "SELECT $this ?value WHERE { $this <http://example.org/age> ?value . \
+                     FILTER(?value < 0) }"
+                .to_string(),
+            prefixes: String::new(),
+            message: None,
+            severity: None,
+            deactivated: false,
+            prepared: None,
+        };
+        let prepared = PreparedSparql::build(&constraint).unwrap().unwrap();
+        assert!(prepared.is_batchable());
+        let foci = [
+            iri("http://example.org/a"),
+            iri("http://example.org/b"),
+            iri("http://example.org/c"),
+            iri("http://example.org/d"),
+        ];
+        let before = exec_count();
+        let grouped = prepared.evaluate_batch(&data, &foci, &constraint, |focus, fields| {
+            crate::report::ValidationResult {
+                focus_node: focus.clone(),
+                path: fields.path,
+                value: fields.value,
+                source_shape: Term::NamedNode(NamedNode::new("http://example.org/S").unwrap()),
+                source_constraint: None,
+                source_component: crate::model::sh("SPARQLConstraintComponent"),
+                severity: crate::model::sh("Violation"),
+                messages: vec![],
+                default_message: fields.default_message,
+                details: vec![],
+            }
+        });
+        // Anti-vacuity: ONE execution for four focus nodes (not four).
+        assert_eq!(exec_count() - before, 1, "batched path must fire exactly once");
+        // Every focus has an entry; only the negative-age foci have a violation.
+        assert_eq!(grouped.len(), 4);
+        assert_eq!(grouped[&foci[0]].len(), 1); // ex:a age -1
+        assert_eq!(grouped[&foci[1]].len(), 0); // ex:b age 5
+        assert_eq!(grouped[&foci[2]].len(), 1); // ex:c age -2
+        assert_eq!(grouped[&foci[3]].len(), 0); // ex:d age 9
     }
 }

--- a/skills/shacl-validation/SKILL.md
+++ b/skills/shacl-validation/SKILL.md
@@ -93,6 +93,11 @@ pub fn load_turtle_with_base(text: &str, base: &str) -> Result<Graph, String>;
 
 // Build a Graph from already-parsed oxrdf::Triples.
 pub fn graph_from_triples<I: IntoIterator<Item = oxrdf::Triple>>(triples: I) -> Graph;
+
+// Per-thread monotonic count of sh:sparql query executions (sq-7d3dj.33.1). Snapshot
+// the delta across a `validate` call to assert focus-node batching fired (a small
+// delta for a large focus set) — see "Focus-node batching" under SHACL-SPARQL below.
+pub fn sparql_constraint_executions() -> u64;
 ```
 
 `ValidationReport::conforms` honours a shapes-graph `sh:conformanceDisallows`
@@ -236,6 +241,20 @@ let shapes = Graph::load_str(r#"
 "#, "turtle").unwrap();
 let report = sparq_shacl::validate(&data, &shapes);   // source_component ends with "SPARQLConstraintComponent"
 ```
+
+*Focus-node batching (perf, sq-7d3dj.33.1).* Semantically each `sh:sparql` constraint
+is "run per focus node", but the engine evaluates it for **all** of a shape's focus
+nodes in ONE query: a single multi-row `VALUES ?this { … }` is injected (chunked at
+10 000 foci), executed once, and the solution rows are grouped by `?this` to build the
+per-focus results. This replaces the old O(N_focus × full-query) per-focus loop (which
+re-materialised the whole BGP for every focus node — quadratic) with O(1) queries per
+shape; the report is byte-for-byte identical. A constraint whose TOP-level form is
+NOT per-focus-equivalent — a `LIMIT`/`OFFSET`, a `GROUP BY`/aggregate not keyed on
+`$this` (an implicit single group or `GROUP BY ?other`), or `REDUCED` — falls back to
+the per-focus path automatically (a nested aggregate sub-select is always batched: the
+pre-binding rules force it to group by `$this`). `sparq_shacl::sparql_constraint_executions()`
+exposes a per-thread `sh:sparql` query-execution counter (snapshot the delta across a
+`validate` call) so a perf guard can assert the batched path fired.
 
 **SHACL-1.2 core constraints (always on, no feature flag).** The disjunctive
 *set* spellings of `sh:datatype` / `sh:nodeKind` — `sh:datatype ( xsd:string


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead **sq-7d3dj.33.1** (P1, D8 SHACL `sh:sparql` fix; parent sq-7d3dj.33).

## What

Fixes the **O(N_focus × full-query)** quadratic root cause in the SHACL-SPARQL (`sh:sparql`, W3C SHACL §5.2) path measured in `research/shacl-baseline-2026-07.md` §3: `PreparedSparql::evaluate` re-executed the whole constraint query **per focus node** with a single-row `VALUES ?this`, so the engine re-materialised the full BGP for every focus node (LUBM(10): ~30× behind Jena, quadratic confirmed).

Now the validator enumerates a targeted shape's focus nodes **once** and batch-evaluates each `sh:sparql` constraint over the whole focus set in a **single query**: a multi-row `VALUES ?this { <f1> <f2> … }` (chunked at 10 000 foci) is injected through the SAME algebra push-down the single-focus path uses, executed once, and the solution rows are **grouped by `?this`** to build the per-focus results. The row→result mapping is shared (`row_to_fields`) so reports are byte-for-byte identical to the per-focus path.

## Semantics guard (fallback split)

Batching is result-equivalent for the pre-binding-legal subset the crate already enforces. A constraint whose **top-level** form is not per-focus-equivalent falls back to the per-focus path conservatively:

| Top-level form | Batched? | Why |
|---|---|---|
| plain `SELECT … WHERE`, `DISTINCT`, `ORDER BY` | ✅ | order irrelevant to the violation bag; `DISTINCT` includes the distinct `?this` |
| `GROUP BY $this` | ✅ | each focus is its own group |
| nested aggregate sub-`SELECT` | ✅ | the pre-binding rules force it to project — hence `GROUP BY` — `$this` |
| `LIMIT`/`OFFSET` | ⛔ per-focus | a global row cap |
| implicit aggregate / `GROUP BY ?other` | ⛔ per-focus | mixes rows from all foci into one group |
| `REDUCED` | ⛔ per-focus | implementation-defined multiplicity |

Chunking never changes results (the `VALUES` partitions cleanly by `?this`).

## Invariants tested (real path, not a mock)

- **Report-equivalence (HARD):** `batched_equals_per_focus_report` diffs the batched report against the per-focus path (forced via an in-crate test toggle) as a bag of focus/value/path/component/shape/constraint/severity/message over a mixed-component many-focus workload. The **W3C SHACL-SPARQL + Core conformance suites stay green** (44 core / 5 sparql / component / shacl12) — `expected.tsv` untouched.
- **Fallback split:** `query_batchable_*` unit tests pin the table above.
- **Anti-vacuity — the batched path FIRED:** `batched_path_fires_once_for_many_foci` asserts **ONE** execution for 60 foci (not 60) via the new per-thread `sparq_shacl::sparql_constraint_executions()` counter; the per-focus fallback runs 60.

## Measurement (local, NON-canonical)

On the shared work box, a synthetic 2000-focus workload shaped like `sparql_constraint`: **batched ~71× faster** than per-focus (understates the **~580×** the research demo measured on the real LUBM corpus, whose data graph is far larger so each per-focus full-BGP scan costs more). The canonical quiet-box re-run is bead **sq-7d3dj.33.3**. No hard-coded perf numbers land in markdown.

## Gates

- `cargo clippy --all-targets -D warnings` + `cargo test` green in **BOTH** feature states: **default** (feature OFF) and **`shacl-af`** (ON).
- `cargo doc --no-deps` clean with `RUSTDOCFLAGS=-D warnings` in **both** `--all-features` and default (feature-gated-intra-doc-link trap checked).
- `readme-template` 0 deviations (README untouched; API detail in rustdoc + `skills/shacl-validation/SKILL.md`).

## Deferred (bead the remainder)

The SHACL-1.2 SPARQL-based **node-expression** path (`PreparedSelectExpr::eval`, `sh:values [ sh:select … ]`) is still per-focus. It is a different call site (value-node computation, not the constraint loop) and not on the measured hot path for the `sparql_constraint`/`sparql_heavy` workloads, so it is deferred to keep this PR a sound, self-contained slice — see the agent report for the follow-up bead.

Please do **not** auto-merge — leaving unarmed per the brief.