### PR TITLE
ci(vectorized-feature-off): per-PR declaration FILES (mechanism V2) — fix the serial-conflict flaw (sq-v3nel-v2)

### DIFF
--- a/.github/workflows/vectorized-feature-off.yml
+++ b/.github/workflows/vectorized-feature-off.yml
@@ -12,9 +12,13 @@
 #     tree vs head (PR/merged) tree — and compares BYTE-FOR-BYTE. No static pin, so NO
 #     merge-order dependence (replaces the retired feature_off_exact exact-byte pin, which
 #     was order-dependent and could not converge under a busy queue). Identical bytes => pass;
-#     differing bytes => pass only if DECLARED (change_token bumped in
-#     bench/feature-off-declaration.json), else fail. The SIZE of an accepted change is
-#     governed SEPARATELY, unchanged, by the wasm_bundle_bytes floor ratchet (±2%) in bench.yml.
+#     differing bytes => pass only if DECLARED. DECLARATION (mechanism V2, sq-v3nel-v2): a PR
+#     adds its OWN file bench/feature-off-declarations/<PR-number>.json — the gate is satisfied
+#     by a set difference on that directory (head has a file base does not), so declaring PRs
+#     never textually CONFLICT (the old shared scalar change_token line did — #1720/#1718 went
+#     DIRTY behind #1726). The legacy scalar change_token is retired but still accepted during a
+#     transition window. The SIZE of an accepted change is governed SEPARATELY, unchanged, by
+#     the wasm_bundle_bytes floor ratchet (±2%) in bench.yml.
 #
 #   Leg 3 (cfg-audit): script asserting every `vectorized` module registration and
 #     evaluator call site in crates/sparq-engine/src/lib.rs and exec.rs is under
@@ -85,6 +89,7 @@ jobs:
               - 'scripts/tests/test_vectorized_feature_off.py'
               - 'bench/perf-baseline.json'
               - 'bench/feature-off-declaration.json'
+              - 'bench/feature-off-declarations/**'
       - name: Decide rust_changed (safe-by-default off the PR path)
         id: decide
         run: |
@@ -143,9 +148,10 @@ jobs:
   # _comment retirement entry).
   #
   # A PR that does NOT touch always-compiled code => identical bytes => auto-pass. A PR that
-  # DOES must DECLARE it (increment change_token in bench/feature-off-declaration.json),
-  # else this leg FAILS. The SIZE of an accepted change is governed SEPARATELY, unchanged,
-  # by the wasm_bundle_bytes floor ratchet (±2% band) in bench.yml.
+  # DOES must DECLARE it (mechanism V2: add bench/feature-off-declarations/<PR-number>.json —
+  # conflict-free per-PR file, sq-v3nel-v2), else this leg FAILS. The SIZE of an accepted
+  # change is governed SEPARATELY, unchanged, by the wasm_bundle_bytes floor ratchet (±2%
+  # band) in bench.yml.
   #
   # Honest scope: proves compile-time ABSENCE via artifact byte-determinism. Does NOT prove
   # runtime perf neutrality (EC2-gated). Job NAME is preserved: the only required check is
@@ -231,6 +237,14 @@ jobs:
           else
             echo '{}' > base-wasm/base-decl.json
           fi
+          # MECHANISM V2 (sq-v3nel-v2): snapshot the base-tree per-PR declarations directory
+          # so leg 2 can set-difference it against the head tree. Absent on pre-V2 base
+          # commits -> synthesize an EMPTY dir (fail-safe: an absent dir reads as no
+          # declarations, so an undeclared byte change still fails).
+          mkdir -p base-wasm/base-declarations
+          if [ -d base-tree/bench/feature-off-declarations ]; then
+            cp -a base-tree/bench/feature-off-declarations/. base-wasm/base-declarations/
+          fi
           echo "Base-tree feature-OFF wasm: $(wc -c < base-wasm/base.wasm) bytes"
 
       - name: Build HEAD-tree feature-OFF wasm
@@ -257,9 +271,13 @@ jobs:
               | tee -a "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
+          # base-declarations may be absent on a cache-hit whose base was built before V2 -
+          # create an empty dir so the path always resolves (script treats it as no decls).
+          mkdir -p base-wasm/base-declarations
           python3 scripts/check-vectorized-feature-off.py \
             --leg2-dynamic base-wasm/base.wasm head.wasm \
             base-wasm/base-decl.json bench/feature-off-declaration.json \
+            --declarations-dirs base-wasm/base-declarations bench/feature-off-declarations \
             2>&1 | tee -a "$GITHUB_STEP_SUMMARY"; exit "${PIPESTATUS[0]}"
 
       - name: Tripwire self-test (leg 2 comparator can fail)

--- a/bench/feature-off-declaration.json
+++ b/bench/feature-off-declaration.json
@@ -35,7 +35,24 @@
     "(head change_token != base change_token), not a strict +1. Three feature-OFF PRs were in",
     "flight at once (#1726/#1720/#1718); if all bumped 0->1 the 2nd-to-merge would see base==head==1",
     "and FALSELY FAIL (order-dependent). So each uses its PR number as a globally-unique token,",
-    "keeping declarations order-independent regardless of merge order."
+    "keeping declarations order-independent regardless of merge order.",
+    "",
+    "[OPUS-4.8] sq-v3nel-v2 (2026-07-07): THIS SCALAR FILE IS RETIRED. Even with unique",
+    "per-PR token VALUES the mechanism had a serial-CONFLICT flaw: every declaring PR edited",
+    "the SAME \"change_token\" line, so the first declared PR to merge made every other declared",
+    "PR textually CONFLICTING in git (#1720 and #1718 both went DIRTY for exactly this after",
+    "#1726's declaration merged). The gate check was order-independent but the FILE was not.",
+    "REPLACEMENT (mechanism V2): a PR now declares by ADDING its OWN file",
+    "bench/feature-off-declarations/<PR-number>.json ({pr, date, reason}); the gate is",
+    "satisfied by a set difference on that directory (head has a file base does not). Different",
+    "PRs add different files, so git NEVER conflicts. See bench/feature-off-declarations/",
+    "README.md and scripts/check-vectorized-feature-off.py (check_leg2_dynamic).",
+    "",
+    "TRANSITION WINDOW: this file is kept PARSEABLE and change_token is FROZEN at 1726 so",
+    "check_leg2_dynamic's fail-safe token read still works, and any in-flight pre-V2 branch",
+    "that already bumped the scalar token (base 1726 != head <prnum>) is still accepted via",
+    "the legacy inequality path until it merges or rebases onto V2. Do NOT bump this token in",
+    "new PRs — add a per-PR declaration file instead."
   ],
   "change_token": 1726
 }

--- a/bench/feature-off-declarations/README.md
+++ b/bench/feature-off-declarations/README.md
@@ -1,0 +1,54 @@
+<!-- [OPUS-4.8] sq-v3nel-v2 (2026-07-07): per-PR feature-OFF change declarations. -->
+
+# feature-OFF wasm-bundle change declarations (mechanism V2)
+
+The `vectorized-feature-off` gate (leg 2,
+`.github/workflows/vectorized-feature-off.yml`) builds the feature-OFF `sparq-wasm`
+bundle from the **base** tree and the **head** tree in the same CI run and compares
+them **byte-for-byte**. Identical bytes pass automatically. If the bytes differ, the
+change must be **declared** — otherwise the gate fails (the whole point: an accidental
+`vectorized`/default-path leak into the feature-OFF build is caught).
+
+## How to declare
+
+If your PR *intentionally* changes always-compiled engine/core code in a way that moves
+the feature-OFF bundle bytes, add **one file** named after your PR number:
+
+```
+bench/feature-off-declarations/<PR-number>.json
+```
+
+with the shape:
+
+```json
+{
+  "pr": 1234,
+  "date": "2026-07-07",
+  "reason": "one line on what always-compiled change moves the feature-OFF bytes"
+}
+```
+
+The gate is satisfied when the head tree's declarations directory contains at least one
+`<digits>.json` (or `.md`) file the base tree's does **not** — a set difference on the
+directory listing. Only names matching `<digits>.json|md` count as declarations, so this
+`README.md` (and any `.gitkeep`) is ignored.
+
+## Why per-PR files (V2)
+
+The previous mechanism stored one scalar `change_token` in
+`bench/feature-off-declaration.json`. Every declaring PR edited the **same line**, so the
+first declared PR to merge made every other declared PR textually **CONFLICTING** in git
+(`#1720` and `#1718` both went `DIRTY` after `#1726`'s declaration merged). The gate check
+was order-independent but the file was not. Per-PR files remove the shared line: different
+PRs add different files, so git never conflicts regardless of merge order.
+
+The legacy scalar file `bench/feature-off-declaration.json` is **retired** (frozen, kept
+parseable). During the transition window the gate still accepts a scalar-token inequality
+so in-flight pre-V2 branches keep working; new PRs must use a per-PR file here instead.
+
+## Scope
+
+This declaration governs **intent** (did you mean to change the feature-OFF bytes at all?).
+The **size** of an accepted change is governed separately, unchanged, by the
+`metrics.wasm_bundle_bytes` floor ratchet (±2% band) in `bench/perf-baseline.json` /
+`bench.yml`. A change moving the bundle > ±2% must also raise that floor.

--- a/scripts/check-vectorized-feature-off.py
+++ b/scripts/check-vectorized-feature-off.py
@@ -14,8 +14,16 @@ Three legs:
                            from the BASE (target-branch/merge-base) tree against the one
                            built from the HEAD (PR/merged) tree IN THE SAME CI RUN. No
                            static byte pin => no merge-order dependence. Identical bytes
-                           => pass. Differing bytes => pass only if DECLARED (change_token
-                           bumped in bench/feature-off-declaration.json); else fail.
+                           => pass. Differing bytes => pass only if DECLARED (see MECHANISM
+                           V2 below); else fail.
+     [--declarations-dirs <base-dir> <head-dir>]
+                           MECHANISM V2 (sq-v3nel-v2): per-PR declaration FILES. A PR
+                           declares by ADDING its own bench/feature-off-declarations/
+                           <PR-number>.json (or .md) file. "declared" == the head-tree
+                           declarations directory contains at least one <digits>.json/.md
+                           file the base-tree directory does NOT (set difference). Different
+                           PRs add different files, so git NEVER textually conflicts (the
+                           old scalar change_token put every declaring PR on the SAME line).
   --leg3                   cfg-audit: every vectorized call site in lib.rs/exec.rs is gated
   --self-test              run built-in tripwires that MUST fail (guard the guards)
 
@@ -30,15 +38,30 @@ byte-identical builds and passes deterministically; a PR that does must DECLARE 
 by bumping change_token (audit-visible, reviewed diff). The SIZE of an accepted change is
 still governed, unchanged, by the wasm_bundle_bytes floor ratchet (+/-2% band) in bench.yml.
 
-Declaration mechanism (least-gameable + audit-visible, chosen over a PR-body line):
-  bench/feature-off-declaration.json carries an integer "change_token". A PR that
-  intentionally changes always-compiled feature-OFF bytes must INCREMENT that token in a
-  reviewed diff (and add a dated rationale line to its _comment). A PR-body marker was
-  REJECTED: it is invisible in merge_group events (no PR body on the merged commit set)
-  and is not part of the reviewed diff. The token lives in its OWN file, NOT inside
-  perf-baseline.json, because scripts/perf-gate.py's auto-ratchet-down rewrite
-  (write_baseline) reconstructs each metric with only floor/threshold/mode and would
-  silently wipe any extra field on the next push-to-main improvement commit.
+Declaration mechanism V2 (sq-v3nel-v2, 2026-07-07): per-PR FILES, not a shared scalar.
+  A PR declares an intentional feature-OFF byte change by ADDING its own
+  bench/feature-off-declarations/<PR-number>.json file (fields: {pr, date, reason}).
+  The gate is satisfied iff the head tree's declarations directory contains at least one
+  <digits>.json/.md file the base tree's does NOT — a set difference on the directory
+  listing. Because different PRs add DIFFERENT files, two declaring PRs never touch the
+  same line and git never marks them CONFLICTING.
+
+  WHY V2 replaced the scalar change_token: the original mechanism stored ONE integer in
+  bench/feature-off-declaration.json, so EVERY declaring PR edited the SAME line. The
+  gate check was order-independent but the FILE was not: the first declared PR to merge
+  made every other declared PR textually CONFLICTING (#1720 and #1718 both went DIRTY for
+  exactly this while #1726's declaration merged). Per-PR files remove the shared line.
+
+  TRANSITION WINDOW: check_leg2_dynamic accepts EITHER mechanism so in-flight branches
+  that already bumped the scalar token do not break. "declared" is true if the scalar
+  change_token differs between base and head (legacy) OR a new declaration file was added
+  (V2). The legacy scalar file bench/feature-off-declaration.json is RETIRED (frozen, kept
+  parseable so the script's fail-safe token read still works) but its inequality path stays
+  live until all pre-V2 branches have merged or rebased.
+
+  WHY A PR-body marker was still REJECTED: it is invisible in merge_group events (no PR
+  body on the merged commit set) and is not part of the reviewed diff. A committed per-PR
+  file is audit-visible, least-gameable, and conflict-free.
 """
 
 from __future__ import annotations
@@ -133,7 +156,11 @@ def check_leg1(metadata_path: str) -> int:
 # ---------------------------------------------------------------------------
 
 def _read_change_token(decl_path: str) -> int:
-    """Read the integer 'change_token' from a feature-off declaration JSON file.
+    """Read the integer 'change_token' from a feature-off declaration JSON file (LEGACY).
+
+    Retained for the TRANSITION WINDOW (sq-v3nel-v2): the scalar mechanism is retired but
+    in-flight branches that already bumped the token must still be accepted. The V2
+    per-PR-file mechanism (_new_declaration_files below) is the going-forward path.
 
     Fail-SAFE default: a missing file, missing field, or non-integer value reads as 0.
     Because an ABSENT declaration reads the same as an UN-bumped one, an undeclared byte
@@ -151,9 +178,40 @@ def _read_change_token(decl_path: str) -> int:
         return 0
 
 
+# MECHANISM V2 (sq-v3nel-v2): a declaration FILE is bench/feature-off-declarations/
+# <PR-number>.json (or .md). Only names matching <digits>.json|md count as declarations,
+# so a README.md / .gitkeep in the directory is NOT mistaken for a declaration.
+_DECL_FILE_RE = re.compile(r'^\d+\.(?:json|md)$')
+
+
+def _list_declaration_files(dir_path: str | None) -> set[str]:
+    """Return the set of per-PR declaration file names in a declarations directory.
+
+    Fail-SAFE: a None / missing / non-directory path reads as the EMPTY set, so an absent
+    directory can never be mistaken for a declaration (keeps the gate fail-closed).
+    Only names matching <digits>.json|md are counted (README.md/.gitkeep are ignored).
+    """
+    if not dir_path or not os.path.isdir(dir_path):
+        return set()
+    return {name for name in os.listdir(dir_path) if _DECL_FILE_RE.match(name)}
+
+
+def _new_declaration_files(base_dir: str | None, head_dir: str | None) -> set[str]:
+    """Return declaration files the HEAD tree has that the BASE tree does NOT (set diff).
+
+    A non-empty result means the PR ADDED at least one bench/feature-off-declarations/
+    <PR-number>.json — i.e. it DECLARED an intentional feature-OFF byte change under
+    mechanism V2. Because each PR adds a distinctly-named file, this never collides with
+    another declaring PR (unlike the old shared scalar token line).
+    """
+    return _list_declaration_files(head_dir) - _list_declaration_files(base_dir)
+
+
 def check_leg2_dynamic(base_wasm: str, head_wasm: str,
-                       base_decl: str, head_decl: str) -> int:
-    """DYNAMIC byte-identity gate for the feature-OFF wasm bundle (sq-v3nel).
+                       base_decl: str, head_decl: str,
+                       base_decls_dir: str | None = None,
+                       head_decls_dir: str | None = None) -> int:
+    """DYNAMIC byte-identity gate for the feature-OFF wasm bundle (sq-v3nel / sq-v3nel-v2).
 
     Compares the feature-OFF wasm built from the BASE (target-branch / merge-base) tree
     against the one built from the HEAD (PR / merged) tree IN THE SAME CI RUN. Same
@@ -163,13 +221,18 @@ def check_leg2_dynamic(base_wasm: str, head_wasm: str,
     Policy:
       * bytes byte-for-byte IDENTICAL  -> PASS. The PR touched no always-compiled code
         that reaches the feature-OFF bundle. (This is the common case for non-engine PRs.)
-      * bytes DIFFER + change DECLARED -> PASS. 'declared' == change_token differs between
-        the base-tree and head-tree bench/feature-off-declaration.json (author bumped it).
+      * bytes DIFFER + change DECLARED -> PASS. 'declared' is satisfied by EITHER mechanism
+        (transition window, sq-v3nel-v2):
+          V2 (going-forward): the head-tree bench/feature-off-declarations/ directory
+            contains a <PR-number>.json/.md file the base tree does NOT (set difference).
+            Conflict-free: each PR adds its own file.
+          LEGACY (retired, still accepted): change_token differs between the base-tree and
+            head-tree bench/feature-off-declaration.json (a pre-V2 branch bumped it).
         The SIZE of the change is governed SEPARATELY, unchanged, by the wasm_bundle_bytes
         floor ratchet (+/-2% band) in bench.yml — this gate governs INTENT, not magnitude.
       * bytes DIFFER + NOT declared    -> FAIL. Either accidental default-path/vectorized
         code leaked into the feature-OFF build (remove / cfg-gate it) or an intentional
-        always-compiled change was not declared (bump change_token).
+        always-compiled change was not declared (add a per-PR declaration file).
 
     Returns 0 on pass, 1 on fail/error.
     """
@@ -199,8 +262,6 @@ def check_leg2_dynamic(base_wasm: str, head_wasm: str,
     # Bytes differ (size and/or content). Require an audit-visible declaration.
     delta = head_len - base_len
     pct = (delta / base_len * 100) if base_len else float("inf")
-    base_tok = _read_change_token(base_decl)
-    head_tok = _read_change_token(head_decl)
 
     print(
         f"[leg2] feature-OFF wasm DIFFERS from the base tree: "
@@ -208,24 +269,45 @@ def check_leg2_dynamic(base_wasm: str, head_wasm: str,
         "Comparison is byte-for-byte, so same-length content changes are also detected."
     )
 
+    # V2 (going-forward): a per-PR declaration FILE was added under
+    # bench/feature-off-declarations/ (set difference on the directory listing). Preferred
+    # because each PR adds a distinct file, so declaring PRs never textually conflict.
+    new_files = _new_declaration_files(base_decls_dir, head_decls_dir)
+    if new_files:
+        print(
+            "[leg2] OK — change DECLARED (mechanism V2): the head tree added "
+            f"bench/feature-off-declarations/{sorted(new_files)} not present in the base "
+            "tree. The feature-OFF byte change is intentional. Its SIZE is governed by the "
+            "wasm_bundle_bytes floor ratchet (+/-2% band) in bench.yml, unchanged by this gate."
+        )
+        return 0
+
+    # LEGACY (retired, accepted during the transition window): the scalar change_token in
+    # bench/feature-off-declaration.json differs between base and head tree. Kept live so
+    # pre-V2 branches that already bumped the token do not break.
+    base_tok = _read_change_token(base_decl)
+    head_tok = _read_change_token(head_decl)
     if head_tok != base_tok:
         print(
-            f"[leg2] OK — change DECLARED: bench/feature-off-declaration.json change_token "
-            f"{base_tok} -> {head_tok}. The feature-OFF byte change is intentional. Its SIZE "
-            "is governed by the wasm_bundle_bytes floor ratchet (+/-2% band) in bench.yml, "
-            "which is unchanged by this gate."
+            f"[leg2] OK — change DECLARED (legacy scalar, transition window): "
+            f"bench/feature-off-declaration.json change_token {base_tok} -> {head_tok}. "
+            "The feature-OFF byte change is intentional. Its SIZE is governed by the "
+            "wasm_bundle_bytes floor ratchet (+/-2% band) in bench.yml, unchanged by this gate. "
+            "NOTE: the scalar mechanism is retired — new PRs should add a per-PR declaration "
+            "file under bench/feature-off-declarations/ (mechanism V2) instead."
         )
         return 0
 
     print(
         f"[leg2] VIOLATION: the feature-OFF wasm bundle changed vs the base tree "
         f"(size delta {delta:+d} bytes, {pct:+.3f}%) but the change is NOT declared "
-        f"(change_token unchanged at {base_tok} in bench/feature-off-declaration.json).\n"
+        f"(no new bench/feature-off-declarations/<PR>.json file added, and the legacy scalar "
+        f"change_token is unchanged at {base_tok}).\n"
         "  - If this is ACCIDENTAL vectorized / default-path code leaking into the "
         "feature-OFF build, REMOVE it or gate it behind #[cfg(feature = \"vectorized\")].\n"
         "  - If this is an INTENTIONAL change to always-compiled engine/core code, DECLARE "
-        "it: increment \"change_token\" in bench/feature-off-declaration.json (add a dated "
-        "rationale line to its _comment). If the SIZE moves > +/-2%, ALSO raise "
+        "it (mechanism V2): add bench/feature-off-declarations/<PR-number>.json with "
+        "{pr, date, reason}. If the SIZE moves > +/-2%, ALSO raise "
         "metrics.wasm_bundle_bytes.floor in bench/perf-baseline.json (the bench.yml ratchet)."
     )
     print("\n[leg2] FAIL — undeclared feature-OFF bundle change. Declare it or remove it.")
@@ -371,13 +453,20 @@ def _leg1_on_dict(meta: dict) -> int:
 
 
 def _leg2_dynamic_on_bytes(base_bytes: bytes, head_bytes: bytes,
-                           base_tok: int | None, head_tok: int | None) -> int:
-    """Run the dynamic leg2 check on in-memory wasm bytes + declaration tokens.
+                           base_tok: int | None, head_tok: int | None,
+                           base_decl_names: list[str] | None = None,
+                           head_decl_names: list[str] | None = None) -> int:
+    """Run the dynamic leg2 check on in-memory wasm bytes + declarations.
 
     A token of None writes an EMPTY declaration file (missing field) to exercise the
     fail-safe default (reads as 0). Otherwise writes {"change_token": <int>}.
+
+    base_decl_names / head_decl_names exercise MECHANISM V2: each is a list of file names
+    materialised inside a temp declarations directory (e.g. ["1720.json", "README.md"]).
+    None => no directory passed (V2 disabled for that side).
     """
     paths: list[str] = []
+    dirs: list[str] = []
 
     def _write(data: bytes | str, suffix: str) -> str:
         mode = "wb" if isinstance(data, bytes) else "w"
@@ -386,15 +475,32 @@ def _leg2_dynamic_on_bytes(base_bytes: bytes, head_bytes: bytes,
             paths.append(tmp.name)
             return tmp.name
 
+    def _mkdir(names: list[str] | None) -> str | None:
+        if names is None:
+            return None
+        d = tempfile.mkdtemp()
+        dirs.append(d)
+        for n in names:
+            with open(os.path.join(d, n), "w") as fh:
+                fh.write("{}")
+        return d
+
     base_wasm = _write(base_bytes, ".wasm")
     head_wasm = _write(head_bytes, ".wasm")
     base_decl = _write("{}" if base_tok is None else json.dumps({"change_token": base_tok}), ".json")
     head_decl = _write("{}" if head_tok is None else json.dumps({"change_token": head_tok}), ".json")
+    base_dir = _mkdir(base_decl_names)
+    head_dir = _mkdir(head_decl_names)
     try:
-        return check_leg2_dynamic(base_wasm, head_wasm, base_decl, head_decl)
+        return check_leg2_dynamic(base_wasm, head_wasm, base_decl, head_decl,
+                                  base_dir, head_dir)
     finally:
         for p in paths:
             os.unlink(p)
+        for d in dirs:
+            for n in os.listdir(d):
+                os.unlink(os.path.join(d, n))
+            os.rmdir(d)
 
 
 def run_self_test() -> int:
@@ -452,6 +558,30 @@ def run_self_test() -> int:
         print("TRIPWIRE 3 (leg2): FAIL — dynamic check rejected a declared change; false positive")
         all_passed = False
 
+    # ----- Tripwire 4: Leg 2 V2 must ACCEPT a per-PR declaration FILE added by head -----
+    # [OPUS-4.8] sq-v3nel-v2: scalar token unchanged, but head added 1720.json not in base.
+    rc = _leg2_dynamic_on_bytes(b"\x00wasm-base", b"\x00wasm-headX", base_tok=0, head_tok=0,
+                                base_decl_names=["README.md"],
+                                head_decl_names=["README.md", "1720.json"])
+    if rc == 0:
+        print("TRIPWIRE 4 (leg2 V2): PASS — dynamic check accepted a DECLARED change via a "
+              "new per-PR file (bench/feature-off-declarations/1720.json added by head)")
+    else:
+        print("TRIPWIRE 4 (leg2 V2): FAIL — V2 file declaration rejected; false positive")
+        all_passed = False
+
+    # ----- Tripwire 5: Leg 2 V2 must REJECT when NO new file is added (README-only) -----
+    # A README.md present on both sides is NOT a declaration; scalar token also unchanged.
+    rc = _leg2_dynamic_on_bytes(b"\x00wasm-base", b"\x00wasm-headX", base_tok=0, head_tok=0,
+                                base_decl_names=["README.md"],
+                                head_decl_names=["README.md"])
+    if rc != 0:
+        print("TRIPWIRE 5 (leg2 V2): PASS — no new per-PR file (only README on both sides) "
+              "correctly rejected as UNDECLARED")
+    else:
+        print("TRIPWIRE 5 (leg2 V2): FAIL — undeclared change slipped through V2; the gate is disabled")
+        all_passed = False
+
     if all_passed:
         print("\n[self-test] OK — all tripwires fired correctly. The guards can fail (and "
               "the dynamic leg2 accepts a declared change).")
@@ -475,11 +605,18 @@ def main() -> int:
     mode.add_argument("--leg2-dynamic", dest="leg2_dynamic", nargs=4,
                       metavar=("BASE_WASM", "HEAD_WASM", "BASE_DECL", "HEAD_DECL"),
                       help="DYNAMIC byte-identity: base-tree vs head-tree feature-OFF wasm "
-                           "+ base/head feature-off-declaration.json (no static pin)")
+                           "+ base/head feature-off-declaration.json (legacy scalar). Add "
+                           "--declarations-dirs for mechanism V2 (per-PR files).")
     mode.add_argument("--leg3", action="store_true",
                       help="cfg-audit of vectorized call sites in lib.rs and exec.rs")
     mode.add_argument("--self-test", dest="self_test", action="store_true",
                       help="run built-in tripwires (both must exit non-zero to pass)")
+    parser.add_argument("--declarations-dirs", dest="declarations_dirs", nargs=2,
+                        metavar=("BASE_DIR", "HEAD_DIR"),
+                        help="MECHANISM V2 (sq-v3nel-v2): base-tree and head-tree "
+                             "bench/feature-off-declarations/ directories. A PR declares by "
+                             "adding its own <PR-number>.json file (set difference). Combined "
+                             "with --leg2-dynamic; either mechanism satisfies the gate.")
     parser.add_argument("--repo-root", default=".",
                         help="repo root for --leg3 (default: cwd)")
     args = parser.parse_args()
@@ -487,8 +624,11 @@ def main() -> int:
     if args.leg1:
         return check_leg1(args.leg1)
     elif args.leg2_dynamic:
+        base_dir = args.declarations_dirs[0] if args.declarations_dirs else None
+        head_dir = args.declarations_dirs[1] if args.declarations_dirs else None
         return check_leg2_dynamic(args.leg2_dynamic[0], args.leg2_dynamic[1],
-                                  args.leg2_dynamic[2], args.leg2_dynamic[3])
+                                  args.leg2_dynamic[2], args.leg2_dynamic[3],
+                                  base_dir, head_dir)
     elif args.leg3:
         return check_leg3(repo_root=args.repo_root)
     elif args.self_test:

--- a/scripts/tests/test_vectorized_feature_off.py
+++ b/scripts/tests/test_vectorized_feature_off.py
@@ -42,13 +42,20 @@ def _leg1_on_dict(meta: dict) -> int:
 
 
 def _leg2_dynamic(base_bytes: bytes, head_bytes: bytes,
-                  base_decl: dict | None, head_decl: dict | None) -> int:
+                  base_decl: dict | None, head_decl: dict | None,
+                  base_decl_names: list[str] | None = None,
+                  head_decl_names: list[str] | None = None) -> int:
     """Run check_leg2_dynamic on in-memory wasm bytes + declaration dicts via temp files.
 
     A None declaration writes NO file (missing path) to exercise the fail-safe default
     (an absent declaration reads change_token as 0).
+
+    base_decl_names / head_decl_names exercise MECHANISM V2 (sq-v3nel-v2): each is a list
+    of file names materialised in a temp declarations directory (e.g. ["1720.json",
+    "README.md"]). None => no directory is passed for that side (V2 disabled).
     """
     paths: list[str] = []
+    dirs: list[str] = []
 
     def _write_bytes(data: bytes) -> str:
         with tempfile.NamedTemporaryFile(mode="wb", suffix=".wasm", delete=False) as tmp:
@@ -65,18 +72,35 @@ def _leg2_dynamic(base_bytes: bytes, head_bytes: bytes,
             paths.append(tmp.name)
             return tmp.name
 
+    def _mkdir(names: list[str] | None) -> str | None:
+        if names is None:
+            return None
+        d = tempfile.mkdtemp()
+        dirs.append(d)
+        for n in names:
+            with open(os.path.join(d, n), "w") as fh:
+                fh.write("{}")
+        return d
+
     base_wasm = _write_bytes(base_bytes)
     head_wasm = _write_bytes(head_bytes)
     base_decl_p = _write_decl(base_decl)
     head_decl_p = _write_decl(head_decl)
+    base_dir = _mkdir(base_decl_names)
+    head_dir = _mkdir(head_decl_names)
     try:
-        return _check.check_leg2_dynamic(base_wasm, head_wasm, base_decl_p, head_decl_p)
+        return _check.check_leg2_dynamic(base_wasm, head_wasm, base_decl_p, head_decl_p,
+                                         base_dir, head_dir)
     finally:
         for p in paths:
             try:
                 os.unlink(p)
             except OSError:
                 pass
+        for d in dirs:
+            for n in os.listdir(d):
+                os.unlink(os.path.join(d, n))
+            os.rmdir(d)
 
 
 # ---------------------------------------------------------------------------
@@ -223,6 +247,83 @@ def test_leg2_both_decls_missing_undeclared_rejected() -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Leg 2 MECHANISM V2 (per-PR declaration files) tests — sq-v3nel-v2
+# ---------------------------------------------------------------------------
+
+def test_leg2_v2_new_file_accepted() -> bool:
+    """Bytes differ + head ADDS a per-PR file not in base => PASS (V2 declaration)."""
+    rc = _leg2_dynamic(_BASE, _HEAD_DIFF, {"change_token": 0}, {"change_token": 0},
+                       base_decl_names=["README.md"],
+                       head_decl_names=["README.md", "1720.json"])
+    if rc == 0:
+        print("  PASS — new per-PR file (1720.json) accepted as a V2 declaration")
+        return True
+    print("  FAIL — V2 file declaration rejected; false positive")
+    return False
+
+
+def test_leg2_v2_no_new_file_rejected() -> bool:
+    """Bytes differ + NO new file (README only, both sides) + token equal => FAIL."""
+    rc = _leg2_dynamic(_BASE, _HEAD_DIFF, {"change_token": 0}, {"change_token": 0},
+                       base_decl_names=["README.md"],
+                       head_decl_names=["README.md"])
+    if rc != 0:
+        print("  PASS — no new per-PR file => undeclared change rejected (fail-closed)")
+        return True
+    print("  FAIL — undeclared change slipped through V2; the gate is disabled")
+    return False
+
+
+def test_leg2_v2_readme_not_a_declaration() -> bool:
+    """A NEW README.md (not <digits>.json|md) is NOT a declaration => FAIL when undeclared."""
+    rc = _leg2_dynamic(_BASE, _HEAD_DIFF, {"change_token": 0}, {"change_token": 0},
+                       base_decl_names=[],
+                       head_decl_names=["README.md", ".gitkeep"])
+    if rc != 0:
+        print("  PASS — README.md/.gitkeep are not declarations; change stays rejected")
+        return True
+    print("  FAIL — a non-PR-numbered file was mistaken for a declaration")
+    return False
+
+
+def test_leg2_v2_md_declaration_accepted() -> bool:
+    """A <digits>.md declaration file is also accepted (json or md permitted)."""
+    rc = _leg2_dynamic(_BASE, _HEAD_DIFF, {"change_token": 0}, {"change_token": 0},
+                       base_decl_names=[],
+                       head_decl_names=["1718.md"])
+    if rc == 0:
+        print("  PASS — <PR-number>.md accepted as a V2 declaration")
+        return True
+    print("  FAIL — .md declaration rejected; false positive")
+    return False
+
+
+def test_leg2_legacy_scalar_still_accepted_in_transition() -> bool:
+    """Transition window: scalar token inequality still declares even with V2 dirs present.
+
+    Mirrors a pre-V2 in-flight branch that bumped the scalar token; head added no new file.
+    """
+    rc = _leg2_dynamic(_BASE, _HEAD_DIFF, {"change_token": 1726}, {"change_token": 1720},
+                       base_decl_names=["README.md"],
+                       head_decl_names=["README.md"])
+    if rc == 0:
+        print("  PASS — legacy scalar inequality still accepted during transition window")
+        return True
+    print("  FAIL — transition window broken; a pre-V2 declared branch would falsely fail")
+    return False
+
+
+def test_leg2_no_dirs_falls_back_to_scalar() -> bool:
+    """No declarations dirs passed at all (None) => V2 disabled, scalar path governs."""
+    rc = _leg2_dynamic(_BASE, _HEAD_DIFF, {"change_token": 0}, {"change_token": 0})
+    if rc != 0:
+        print("  PASS — no dirs + equal scalar token => undeclared change rejected")
+        return True
+    print("  FAIL — missing dirs mishandled")
+    return False
+
+
+# ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
 
@@ -237,6 +338,12 @@ def main() -> int:
         ("leg2 same-length content change caught (byte-for-byte)", test_leg2_same_length_content_change_caught),
         ("leg2 missing base decl defaults to 0", test_leg2_missing_base_decl_defaults_zero),
         ("leg2 both decls absent => undeclared rejected", test_leg2_both_decls_missing_undeclared_rejected),
+        ("leg2 V2 new per-PR file accepted", test_leg2_v2_new_file_accepted),
+        ("leg2 V2 no new file => undeclared rejected", test_leg2_v2_no_new_file_rejected),
+        ("leg2 V2 README/.gitkeep not a declaration", test_leg2_v2_readme_not_a_declaration),
+        ("leg2 V2 <PR>.md declaration accepted", test_leg2_v2_md_declaration_accepted),
+        ("leg2 legacy scalar accepted in transition window", test_leg2_legacy_scalar_still_accepted_in_transition),
+        ("leg2 no dirs falls back to scalar path", test_leg2_no_dirs_falls_back_to_scalar),
     ]
 
     passed = 0


### PR DESCRIPTION
> 🤖 **SPARQ agent** — CI-infra follow-up to #1749 (dynamic feature-OFF wasm gate).

## The flaw

The dynamic wasm gate's declaration mechanism has a **serial-conflict flaw**. `bench/feature-off-declaration.json` holds ONE scalar `change_token`; **every PR that declares edits the same line**. The gate check (`check_leg2_dynamic`) is order-independent, but the *file* is not: the first declared PR to merge makes every other declared PR textually **CONFLICTING** in git.

Evidence: **#1720** and **#1718** both went `DIRTY` / `CONFLICTING` for exactly this reason after **#1726**'s declaration merged. (#1720's auto-merge was dropped by GitHub when it went conflicting.)

## Mechanism V2 (this PR)

A PR now declares an intentional feature-OFF byte change by **ADDING its own file**:

```
bench/feature-off-declarations/<PR-number>.json   # {pr, date, reason}
```

`check_leg2_dynamic` is satisfied iff the **head** tree's declarations directory contains at least one `<digits>.json|md` file the **base** tree's does not — a **set difference** on the directory listing. Different PRs add different files, so **git never textually conflicts** regardless of merge order. Only `<digits>.json|md` names count, so `README.md`/`.gitkeep` are ignored.

### Fail-closed
Bytes differ + no new declaration file (and no legacy scalar bump) → **FAIL**. An absent/missing declarations dir reads as the empty set, so it can never be mistaken for a declaration.

### Transition window
`check_leg2_dynamic` accepts **EITHER** mechanism: a new per-PR file (V2) **OR** the legacy scalar-token inequality. So in-flight pre-V2 branches that already bumped the token keep working. The scalar file `bench/feature-off-declaration.json` is **retired** (frozen at `1726`, kept parseable so the fail-safe token read still works) with a rationale comment inside it. This is why it cannot break in-flight branches.

## What changed
- **`scripts/check-vectorized-feature-off.py`**: `_list_declaration_files` / `_new_declaration_files` (set-diff, `<digits>.json|md` only); `check_leg2_dynamic` gains optional `base_decls_dir`/`head_decls_dir` and prefers V2 then falls back to the legacy scalar; new `--declarations-dirs` CLI flag; self-test gains tripwires **4** (V2 accept) and **5** (V2 reject).
- **`scripts/tests/test_vectorized_feature_off.py`**: +6 V2 unit tests (new-file accept, no-new-file reject, README/`.gitkeep` not a declaration, `.md` accept, transition-window scalar still accepted, no-dirs fallback) → **15 total, all green**.
- **`.github/workflows/vectorized-feature-off.yml`**: path filter adds `bench/feature-off-declarations/**`; base-tree build snapshots the base declarations dir (empty on pre-V2 base — fail-safe); leg 2 passes `--declarations-dirs`.
- **`bench/feature-off-declarations/README.md`**: the convention doc.
- **`bench/feature-off-declaration.json`**: retirement rationale (frozen, parseable).

## Verification (local)
- `python3 -c "import yaml; yaml.safe_load(...)"` → OK; **actionlint** → clean; actions remain SHA-pinned.
- `--self-test` → all 5 tripwires fire (exit 0).
- unit tests → **15 passed, 0 failed**.
- E2E CLI: identical bytes → PASS; differing bytes + head adds `<pr>.json` → PASS; differing bytes + no new file → FAIL(1).

## Gate aggregator
Job names are unchanged (`artifact-exact-equality (wasm bundle feature-OFF)` etc., no `advisory`/`informational` token), so `ci-summary / gate` still picks them up — **this leg still gates**. This PR touches only `.github/workflows/` + `scripts/` + `bench/` — no always-compiled Rust — so the feature-OFF wasm is byte-identical to base and leg 2 passes automatically (no declaration needed).

## Compliance gap
Removes an order-dependence / merge-conflict hazard in the feature-OFF perf-neutrality gate — no change to the honest scope (compile-time absence via artifact byte-determinism; runtime neutrality remains EC2-gated).

Follow-up: #1720/#1718 will be repaired onto this mechanism; #1741's steward notified of the convention.