### PR TITLE
perf(shacl): batch SHACL-1.2 SPARQL node-expression path (PreparedSelectExpr::eval_batch) (sq-7d3dj.33.5)

### DIFF
--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -61,6 +61,7 @@ pub(crate) fn validate_graph(
         diagnostics: Vec::new(),
         active_meta: None,
         sparql_batch: FxHashMap::default(),
+        node_expr_cache: None,
     };
     let mut out = Vec::new();
     for &sid in &shapes.targeted {
@@ -72,10 +73,20 @@ pub(crate) fn validate_graph(
         // nested/data-graph focus falls back to the per-focus path unchanged.
         let foci = v.focus_nodes(sid);
         v.prime_sparql_batch(sid, &foci);
+        // [SONNET-4.6] (sq-7d3dj.33.5) If the shape has a SPARQL node expression
+        // (`sh:values [ sh:select … ]` / `[ sh:sparqlExpr … ]`), batch-evaluate it
+        // over ALL focus nodes in one query execution and cache the result map so
+        // `validate_shape` drains it per focus instead of re-running per focus node.
+        if let Some(idx) = v.shapes.shapes[sid].value_expr {
+            let data = v.data.graph();
+            let map = v.shapes.select_exprs[idx].eval_batch(data, &foci);
+            v.node_expr_cache = Some((sid, map));
+        }
         for focus in &foci {
             v.validate_shape(sid, focus, &mut out);
         }
         v.sparql_batch.clear();
+        v.node_expr_cache = None;
     }
     // [OPUS-4.8] (sq-rnkdh) SHACL 1.2 `sh:shape` data-graph targets: a triple
     // `?n sh:shape ?S` in the DATA graph makes `?n` a focus node of shape `?S`.
@@ -103,6 +114,7 @@ pub(crate) fn count_focus_nodes(data: &Graph, shapes: &ShapesModel) -> usize {
         diagnostics: Vec::new(),
         active_meta: None,
         sparql_batch: FxHashMap::default(),
+        node_expr_cache: None,
     };
     let mut all: Vec<Term> = Vec::new();
     for &sid in &shapes.targeted {
@@ -138,6 +150,7 @@ pub(crate) fn conforms_node(data: &Graph, shapes: &ShapesModel, sid: usize, node
         diagnostics: Vec::new(),
         active_meta: None,
         sparql_batch: FxHashMap::default(),
+        node_expr_cache: None,
     };
     v.conforms(node, sid)
 }
@@ -180,6 +193,13 @@ struct Validator<'a> {
     /// A `(sid, idx)` absent here (a non-batchable constraint, or a shape validated
     /// outside the top-level targeted loop) falls back to the per-focus path.
     sparql_batch: FxHashMap<(usize, usize), FxHashMap<Term, Vec<ValidationResult>>>,
+    /// [SONNET-4.6] (sq-7d3dj.33.5) Pre-computed node-expression value-node map.
+    /// Set to `Some((sid, map))` by [`validate_graph`] before iterating over a
+    /// shape's focus nodes when the shape carries `sh:values [ sh:select … ]` /
+    /// `[ sh:sparqlExpr … ]`, then cleared to `None` after the loop. This allows
+    /// [`validate_shape`] to drain from the pre-computed map instead of re-running
+    /// the SPARQL query per focus node (the O(N_focus) root cause).
+    node_expr_cache: Option<(usize, FxHashMap<Term, Vec<Term>>)>,
 }
 
 impl<'a> Validator<'a> {
@@ -328,7 +348,19 @@ impl<'a> Validator<'a> {
         // the shape's path (set in `result`), so only the value-node SET changes.
         let values: Vec<Term> = match shape.value_expr {
             Some(idx) => {
-                crate::view::dedup(self.shapes.select_exprs[idx].eval(self.data.graph(), focus))
+                // [SONNET-4.6] (sq-7d3dj.33.5) Use the pre-computed batch map when
+                // available (set by `validate_graph` before the focused shape loop);
+                // fall back to per-focus eval for nested/data-graph shapes.
+                let cached = self.node_expr_cache.as_ref().and_then(|(csid, map)| {
+                    if *csid == sid {
+                        map.get(focus).cloned()
+                    } else {
+                        None
+                    }
+                });
+                crate::view::dedup(cached.unwrap_or_else(|| {
+                    self.shapes.select_exprs[idx].eval(self.data.graph(), focus)
+                }))
             }
             None => match &shape.path {
                 Some(path) => path.values(&self.data, focus),

--- a/crates/sparq-shacl/src/sparql.rs
+++ b/crates/sparq-shacl/src/sparql.rs
@@ -478,6 +478,54 @@ impl PreparedSelectExpr {
         Self::run(data, self.query.clone())
     }
 
+    /// [SONNET-4.6] (sq-7d3dj.33.5) Batch-evaluates the node expression for ALL
+    /// `foci` in ONE batched execution: injects a single `VALUES ?this { <f1> … }`
+    /// (chunked at [`FOCUS_BATCH_CHUNK`]), executes once per chunk, then GROUPS the
+    /// first-result-variable bindings by `?this` to build the per-focus value-node
+    /// sets. This is the O(1)-query replacement for calling [`Self::eval`] per focus
+    /// node (the O(N_focus) root cause for `sh:values` property shapes).
+    ///
+    /// Returns a map with an entry for EVERY expressible focus in `foci` (empty
+    /// `Vec` when a focus yields no output nodes). A blank-node focus (not a VALUES
+    /// ground term) is absent — identical to the empty-return of [`Self::eval`].
+    pub(crate) fn eval_batch(
+        &self,
+        data: &sparq_core::Graph,
+        foci: &[Term],
+    ) -> FxHashMap<Term, Vec<Term>> {
+        let mut grouped: FxHashMap<Term, Vec<Term>> = FxHashMap::default();
+        let ground: Vec<&Term> = foci
+            .iter()
+            .filter(|f| term_to_ground(f).is_some())
+            .collect();
+        for f in &ground {
+            grouped.entry((*f).clone()).or_default();
+        }
+        for chunk in ground.chunks(FOCUS_BATCH_CHUNK) {
+            let Some(bound) = pre_bind_select_multi(&self.query, "this", chunk) else {
+                continue; // inexpressible term in chunk (unreachable — all ground)
+            };
+            bump_exec_count();
+            let prepared = sparq_engine::PreparedQuery::from(bound);
+            let Ok(result) = sparq_engine::query_prepared(data, &prepared) else {
+                continue; // runtime query error → no nodes for this chunk (lenient)
+            };
+            // The output nodes are the bindings of the FIRST result variable (position 0).
+            // pre_bind_select_multi appends ?this to the projection when absent, so the
+            // author's first projected variable stays at position 0.
+            let tpos = result.vars.iter().position(|v| v.as_str() == "this");
+            for row in &result.rows {
+                let Some(this) = tpos.and_then(|i| row.get(i)).and_then(|c| c.clone()) else {
+                    continue;
+                };
+                if let Some(Some(node)) = row.first() {
+                    grouped.entry(this).or_default().push(node.clone());
+                }
+            }
+        }
+        grouped
+    }
+
     /// Runs a (possibly pre-bound) SELECT and collects the FIRST-result-variable
     /// bindings, skipping unbound rows. A runtime query error yields no nodes
     /// (lenient; never panics `validate`).
@@ -2243,6 +2291,111 @@ mod tests {
         .unwrap();
         let nodes = expr.eval_target(&data);
         assert_eq!(nodes, vec![iri("http://example.org/bob")]);
+    }
+
+    // --- [SONNET-4.6] (sq-7d3dj.33.5) PreparedSelectExpr::eval_batch ---------------
+    //
+    // Three tests covering the batched node-expression path:
+    //   * anti-vacuity: 4 foci → exactly 1 execution, correct per-focus grouping.
+    //   * equivalence: eval_batch and per-focus eval produce the same value-node sets.
+    //   * blank-node filtering: blank-node foci are absent from the result map.
+
+    const BATCH_DATA: &str = r#"
+        @prefix ex: <http://example.org/> .
+        ex:a ex:color "red"    .
+        ex:b ex:color "blue"   .
+        ex:c ex:color "green"  .
+        ex:d ex:color "yellow" .
+    "#;
+
+    #[test]
+    fn eval_batch_groups_output_nodes_by_focus_and_fires_once() {
+        // [SONNET-4.6] (sq-7d3dj.33.5) 4 foci → exactly ONE query execution (not 4);
+        // each focus's output-node set is correct.
+        let data = graph(BATCH_DATA);
+        let expr = PreparedSelectExpr::build_select(
+            "PREFIX ex: <http://example.org/>",
+            "SELECT ?c WHERE { $this ex:color ?c }",
+        )
+        .unwrap();
+        let foci = [
+            iri("http://example.org/a"),
+            iri("http://example.org/b"),
+            iri("http://example.org/c"),
+            iri("http://example.org/d"),
+        ];
+        let before = exec_count();
+        let grouped = expr.eval_batch(&data, &foci);
+        // Anti-vacuity: 4 foci → 1 execution, not 4.
+        assert_eq!(exec_count() - before, 1, "eval_batch must fire exactly once");
+        // Every expressible focus gets an entry; each has its color literal.
+        assert_eq!(grouped.len(), 4);
+        assert_eq!(
+            grouped[&foci[0]],
+            vec![Term::Literal(oxrdf::Literal::new_simple_literal("red"))]
+        );
+        assert_eq!(
+            grouped[&foci[1]],
+            vec![Term::Literal(oxrdf::Literal::new_simple_literal("blue"))]
+        );
+        assert_eq!(
+            grouped[&foci[2]],
+            vec![Term::Literal(oxrdf::Literal::new_simple_literal("green"))]
+        );
+        assert_eq!(
+            grouped[&foci[3]],
+            vec![Term::Literal(oxrdf::Literal::new_simple_literal("yellow"))]
+        );
+    }
+
+    #[test]
+    fn eval_batch_result_equals_per_focus_eval() {
+        // [SONNET-4.6] (sq-7d3dj.33.5) eval_batch must produce the same value-node
+        // sets as calling eval() once per focus node.
+        let data = graph(BATCH_DATA);
+        let expr = PreparedSelectExpr::build_select(
+            "PREFIX ex: <http://example.org/>",
+            "SELECT ?c WHERE { $this ex:color ?c }",
+        )
+        .unwrap();
+        let foci = [
+            iri("http://example.org/a"),
+            iri("http://example.org/b"),
+            iri("http://example.org/c"),
+            iri("http://example.org/d"),
+        ];
+        let grouped = expr.eval_batch(&data, &foci);
+        for f in &foci {
+            let batched = grouped.get(f).cloned().unwrap_or_default();
+            let per_focus = expr.eval(&data, f);
+            assert_eq!(
+                batched, per_focus,
+                "eval_batch disagrees with eval() for focus {}",
+                f
+            );
+        }
+    }
+
+    #[test]
+    fn eval_batch_skips_blank_node_foci() {
+        // [SONNET-4.6] (sq-7d3dj.33.5) A blank-node focus cannot appear in VALUES
+        // syntax; eval_batch must omit it from the result map (not panic or error).
+        let data = graph(BATCH_DATA);
+        let expr = PreparedSelectExpr::build_select(
+            "PREFIX ex: <http://example.org/>",
+            "SELECT ?c WHERE { $this ex:color ?c }",
+        )
+        .unwrap();
+        let bnode = Term::BlankNode(oxrdf::BlankNode::new("bn0").unwrap());
+        let iri_focus = iri("http://example.org/a");
+        let foci = [bnode.clone(), iri_focus.clone()];
+        let grouped = expr.eval_batch(&data, &foci);
+        // Blank node is absent; the IRI focus has its entry.
+        assert!(
+            !grouped.contains_key(&bnode),
+            "blank-node focus must be absent from eval_batch result"
+        );
+        assert!(grouped.contains_key(&iri_focus));
     }
 
     // --- [OPUS-4.8] (sq-0mjfd) SHACL-SPARQL pre-binding rejection (sht:Failure) --


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead sq-7d3dj.33.5 [SONNET-4.6]

## Summary

- **`PreparedSelectExpr::eval_batch`** — batched analogue of PR #1737's `PreparedSparql::evaluate_batch` for the `sh:values [ sh:select … ]` / `[ sh:sparqlExpr … ]` node-expression path used by SHACL 1.2 property shapes.
- Replaces the O(N_focus) per-focus `eval()` loop with a single `VALUES ?this { <f1> <f2> … }` execution (chunked at 10 000 foci via `FOCUS_BATCH_CHUNK`), grouping first-result-variable bindings by `?this` for per-focus drain.
- `Validator` gains a `node_expr_cache: Option<(usize, FxHashMap<Term, Vec<Term>>)>` field; `validate_graph` pre-computes the map once before the focus loop; `validate_shape` drains from the cache with a per-focus fallback for nested/data-graph shapes (same pattern as the `sparql_batch` field from #1737).

## Files changed

- `crates/sparq-shacl/src/sparql.rs` — `PreparedSelectExpr::eval_batch` + 3 unit tests
- `crates/sparq-shacl/src/eval.rs` — `node_expr_cache` field, priming in `validate_graph`, cache use in `validate_shape`

## Test plan

- [x] `eval_batch_groups_output_nodes_by_focus_and_fires_once` — anti-vacuity: 4 foci → exactly 1 query execution, correct per-focus value-node sets
- [x] `eval_batch_result_equals_per_focus_eval` — result equivalence between batched and per-focus paths
- [x] `eval_batch_skips_blank_node_foci` — blank-node foci absent from result map (no panic/error)
- [x] All existing W3C SHACL SPARQL / SHACL 1.2 test suites still pass
- [x] `cargo clippy -D warnings` + `cargo test` green in both feature states (`default` and `shacl-af`)
- [x] `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps` green in both feature states

🤖 Generated with [Claude Code](https://claude.com/claude-code)