### PR TITLE
docs(metamorph): correct generate.rs predicate-grammar overclaim (LANG/isLiteral not in predicate_atom) (sq-b89wc)

### DIFF
--- a/crates/sparq-metamorph/src/generate.rs
+++ b/crates/sparq-metamorph/src/generate.rs
@@ -17,13 +17,21 @@
 //!   subjects, so predicates over the optional variable hit **unbound-variable
 //!   errors**; and
 //! * the predicate grammar spans comparisons, arithmetic, `BOUND`/`COALESCE`
-//!   (unbound-tolerant forms), `STR`/`LANG`/`DATATYPE`/`isIRI`/`isLiteral`, and the
-//!   error-absorbing connectives `&&`/`||`/`!`.
+//!   (unbound-tolerant forms), the term-inspection functions `STR`/`DATATYPE`/`isIRI`,
+//!   and the error-absorbing connectives `&&`/`||`/`!`.
 //!
 //! The grammar deliberately excludes everything that voids the metamorphic relations
 //! (TLP scope preconditions): no `RAND`/`NOW`/`UUID`/`STRUUID`/`BNODE`
 //! (nondeterminism), no `EXISTS`/`NOT EXISTS` (spec ambiguity), and no blank nodes in
 //! the data (cross-engine label comparison is meaningless — see [`crate::differential`]).
+//!
+//! Grammar note: the term-inspection atoms are exactly the ones `predicate_atom`
+//! emits — `STR`, `DATATYPE`, and `isIRI`. The generator already produces
+//! language-tagged literals (`"…"@fr`) as EBV/type-error fuel, but no atom yet
+//! inspects them via `LANG` or `isLiteral`; any new function must be added in
+//! `predicate_atom` so this list, the TLP scope preconditions, and the exclusion
+//! list above stay in lockstep. (The matching §6.1 paper grammar overclaim is
+//! tracked for the `sq-gum8.7` revision pass.) [OPUS-4.8] sq-b89wc
 
 /// Minimal deterministic PRNG: SplitMix64. Chosen over a `rand` dependency because its
 /// output for a given seed is a *fixed function* specified by three constants — the


### PR DESCRIPTION
> 🤖 SPARQ agent — automated documentation-honesty fix.

## What

Bead `sq-b89wc`. A PC review of `site/papers/sparql-logic-bugs.typ` (sq-gum8.3) found claim/artifact drift: the `crates/sparq-metamorph/src/generate.rs` module doc claimed the generated predicate grammar spans `STR`/`LANG`/`DATATYPE`/`isIRI`/`isLiteral`, but `predicate_atom()` only emits `STR`, `DATATYPE`, `isIRI` (plus `BOUND`/`COALESCE`/comparisons/arithmetic). `LANG` and `isLiteral` are **not** generated.

## Change (DOC-ONLY)

- **before →** grammar list read `` `STR`/`LANG`/`DATATYPE`/`isIRI`/`isLiteral` ``
- **after →** grammar list reads `the term-inspection functions `STR`/`DATATYPE`/`isIRI``, matching the code.
- Added a **grammar note** recording the honest current state: the generator already produces language-tagged literals (`"…"@fr`) as EBV/type-error fuel, but no atom yet inspects them via `LANG`/`isLiteral`; any new function must be added in `predicate_atom` so the doc list, the TLP scope preconditions, and the exclusion list stay in lockstep.

No logic change — this is a module doc-comment edit only. The matching **paper §6.1** grammar overclaim is out of scope here and stays tracked for the `sq-gum8.7` revision pass.

## Verification

`RUSTDOCFLAGS="-D warnings" cargo doc -p sparq-metamorph --no-deps` is clean (EXIT=0, no warnings) in **both** feature states — default and `--features protocol-drivers`. The new note uses code spans (not intra-doc links) for `predicate_atom`, so it dodges the feature-gated / private-item intra-doc-link trap.

## Follow-up (not in this PR)

The bead's alternative "preferable" option — actually *adding* `LANG` + `isLiteral` predicate atoms to exercise the already-generated language-tagged data — is a logic change out of scope for this DOC-ONLY bead; captured for the orchestrator to bead separately.