### PR TITLE
chore(supply-chain): correct misleading criterion/winapi cargo-vet exemption notes (sq-57zih)

### DIFF
--- a/supply-chain/config.toml
+++ b/supply-chain/config.toml
@@ -252,7 +252,7 @@ criteria = "safe-to-deploy"
 [[exemptions.criterion]]
 version = "0.5.1"
 criteria = "safe-to-run"
-notes = "dev-only criterion bench dependency (sq-qonbz.4); not in the shipped or wasm build; no trusted audit available upstream [OPUS-4.8]"
+notes = "LOAD-BEARING trust anchor, NOT the in-tree version. The tree has criterion 0.8.2 (dev-only bench dep, not in the shipped/wasm build), which is certified via the isrg upstream safe-to-run DELTA-audit chain 0.5.1 -> 0.6.0 -> 0.7.0 -> 0.8.0 -> 0.8.1 -> 0.8.2 (supply-chain/imports.lock). That chain needs a base at 0.5.1; this exemption is that base. Removing it un-vets criterion 0.8.2 and fails `cargo vet --frozen` — verified 2026-07-07 (sq-57zih). Keep until a full audit of a later criterion base lands upstream. [OPUS-4.8]"
 
 [[exemptions.crossbeam-deque]]
 version = "0.8.6"
@@ -1409,6 +1409,7 @@ criteria = "safe-to-deploy"
 [[exemptions.winapi-i686-pc-windows-gnu]]
 version = "0.4.0"
 criteria = "safe-to-run"
+notes = "IN-TREE (Windows targets only, --target all) via criterion 0.8.2 -> page_size -> winapi 0.3.9; a dev-only bench-toolchain leaf, not in the shipped/wasm build. Import-stubs with no upstream trusted audit; safe-to-run exemption keeps `cargo vet --frozen` green. Not stale — verified 2026-07-07 (sq-57zih). [OPUS-4.8]"
 
 [[exemptions.winapi-util]]
 version = "0.1.11"
@@ -1417,6 +1418,7 @@ criteria = "safe-to-deploy"
 [[exemptions.winapi-x86_64-pc-windows-gnu]]
 version = "0.4.0"
 criteria = "safe-to-run"
+notes = "IN-TREE (Windows targets only, --target all) via criterion 0.8.2 -> page_size -> winapi 0.3.9; a dev-only bench-toolchain leaf, not in the shipped/wasm build. Import-stubs with no upstream trusted audit; safe-to-run exemption keeps `cargo vet --frozen` green. Not stale — verified 2026-07-07 (sq-57zih). [OPUS-4.8]"
 
 [[exemptions.windows]]
 version = "0.62.2"


### PR DESCRIPTION
> 🤖 **SPARQ agent** — sub-agent working on supply-chain hygiene (bead **sq-57zih**). Not armed; leaving for maintainer review.

## What this does

sq-57zih asked to remove the "stale" `criterion 0.5.1` and `winapi-*-pc-windows-gnu 0.4.0` cargo-vet exemptions from `supply-chain/config.toml`. Following the contract's rule *"verify each exemption is genuinely stale against the CURRENT dependency tree before removing — a load-bearing exemption must stay (report it)"*, I checked both and found **neither is stale** — both are load-bearing. So no exemption is removed; instead the three misleading provenance notes are corrected.

## Honest finding: the bead's stale-premise was wrong

**`criterion 0.5.1` is a delta-audit trust anchor, not a dead entry.** The in-tree version is `criterion 0.8.2` (dev-only bench dep). It is certified `safe-to-run` via the isrg upstream **delta-audit chain** in `supply-chain/imports.lock`:

```
0.5.1 -> 0.6.0 -> 0.7.0 -> 0.8.0 -> 0.8.1 -> 0.8.2
```

That chain needs a base at `0.5.1`, which is exactly this exemption. Reproduced locally — removing it breaks the **gating** `cargo vet --frozen`:

```
Vetting Failed!
1 unvetted dependencies:
  criterion:0.8.2 missing ["safe-to-run"]
```

Keeping the `0.5.1` anchor + trusting the isrg deltas is also the *better* posture than directly exempting `0.8.2` (it self-exempts only the base and inherits upstream review for every delta since).

**`winapi-i686/x86_64-pc-windows-gnu 0.4.0` are still in-tree** (Windows targets only, seen under `cargo tree -i … --target all`) via `criterion 0.8.2 -> page_size -> winapi 0.3.9`. Their `safe-to-run` exemptions are needed to keep the gate green.

## Net change

Notes-only correction on three exemptions. The old `criterion` note claimed *"no trusted audit available upstream"* — false, and the root cause of this bead being filed on a wrong premise. New notes document the load-bearing role of each so a future agent does not remove a delta-chain anchor and break `cargo vet`.

## Gate evidence (reproduced locally, exact CI commands)

| gate | command | result |
|---|---|---|
| cargo-vet | `cargo vet --locked --frozen` | Vetting Succeeded (117 fully / 7 partially / 401 exempted) |
| cargo-deny | `cargo deny check bans sources licenses` | bans ok, licenses ok, sources ok |
| cargo-deny | `cargo deny check advisories` | advisories ok |

TOML validity: `python3 -c "import tomllib; tomllib.load(open('supply-chain/config.toml','rb'))"` passes. Gate aggregator unaffected (no workflow touched; this is a config-only change read by the existing `cargo-vet`/`cargo-deny` legs).

## Compliance impact

No control level change — cargo-vet coverage is unchanged (all crates still audited/exempted). This is a documentation-honesty fix that prevents a regression which would have dropped `criterion 0.8.2` (+ its winapi leaves) out of `safe-to-run` coverage.

Closes sq-57zih.