### PR TITLE
feat(site): render canonical HTTP/TTFB competitor panel on the benchmarks dashboard (sq-7d3dj.34.3) [OPUS-4.8]

### DIFF
--- a/site/src/components/benchmarks/http-panel-table.tsx
+++ b/site/src/components/benchmarks/http-panel-table.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+// [OPUS-4.8] sq-7d3dj.34.3 — the canonical HTTP-mode panel (SP2Bench-HTTP / WatDiv-HTTP):
+// EVERY engine measured in the SAME HTTP-server mode (SPARQL 1.1 over HTTP via a shared
+// adapter), so this closes the CLI-vs-HTTP measurement-mode asymmetry of the CLI matrix
+// above. Each engine cell shows the full-request time (primary) with time-to-first-byte
+// (TTFB) beneath it. A connection-regime toggle switches keep-alive (the steady-state
+// server measure, default) ⇄ fresh-connect (a new TCP connection per request).
+//
+// HONESTY (load-bearing, per the perf-dominance mandate + the empirical-honesty rule):
+//   * The fastest count-checked value per row is emphasised REGARDLESS of engine — so where
+//     a competitor leads (SP2Bench complex-shape queries; oxigraph/qlever first-byte TTFB
+//     on large SELECTs) the competitor is highlighted, never sparq by default. No spin.
+//   * Per-query solution-COUNT cross-check (✓ / DIFF) is shown; a DIFF row is excluded from
+//     the win/loss count (timing not comparable) and its cells are not emphasised.
+//   * The summary reports count-checked wins AND losses honestly (SP2Bench is BEHIND on ~half
+//     the queries — shown as losses, not hidden).
+import * as React from "react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  fmtNum,
+  type CompetitiveSummary,
+  type SameBoxComparison,
+  type SameBoxRow,
+} from "@/data/benchmarks";
+
+type Regime = "keep-alive" | "fresh-connect";
+
+// Pull the (full, ttfb) value maps for a row in the selected connection regime. Keep-alive
+// uses `values` / `values_ttfb`; fresh-connect uses the `*_fresh*` twins. Missing twins
+// degrade to an empty map so a cell renders "n/a", never a fabricated number.
+function regimeValues(
+  row: SameBoxRow,
+  regime: Regime,
+): { full: Record<string, number | null>; ttfb: Record<string, number | null> } {
+  if (regime === "fresh-connect") {
+    return { full: row.values_fresh ?? {}, ttfb: row.values_fresh_ttfb ?? {} };
+  }
+  return { full: row.values, ttfb: row.values_ttfb ?? {} };
+}
+
+// The fastest engine id for a value map, considering ONLY count-checked rows and numeric
+// positive values. Returns null on a DIFF row (count disagreed → not comparable) or when no
+// engine produced a value — so nothing is emphasised in those cases.
+function fastestId(
+  row: SameBoxRow,
+  vals: Record<string, number | null>,
+): string | null {
+  if (row.count_match === false) return null;
+  let best = Infinity;
+  let id: string | null = null;
+  for (const [eng, v] of Object.entries(vals)) {
+    if (typeof v === "number" && v > 0 && v < best) {
+      best = v;
+      id = eng;
+    }
+  }
+  return id;
+}
+
+export function HttpPanelTable({
+  comparison,
+  summary,
+}: {
+  comparison: SameBoxComparison;
+  summary?: CompetitiveSummary;
+}) {
+  const engines = comparison.engines;
+  const primary: Regime =
+    comparison.connection?.primary === "fresh-connect" ? "fresh-connect" : "keep-alive";
+  const [regime, setRegime] = React.useState<Regime>(primary);
+  const modesMeasured = comparison.connection?.modes_measured ?? ["keep-alive"];
+  const canToggle = modesMeasured.includes("fresh-connect");
+
+  const sb = summary && summary.kind === "same-box" ? summary : null;
+
+  return (
+    <div className="space-y-2">
+      {/* Same-mode framing + the honest win/loss line (never spun). */}
+      {sb ? (
+        <p className="text-sm text-muted-foreground">
+          All {engines.length} engines are measured in the{" "}
+          <strong className="text-foreground">same HTTP-server mode</strong> (SPARQL 1.1 over
+          HTTP via one shared adapter), so this panel closes the CLI-vs-HTTP measurement-mode
+          asymmetry of the matrix above. Across{" "}
+          <strong className="text-foreground">{sb.total}</strong> quer
+          {sb.total === 1 ? "y" : "ies"} whose solution <em>count cross-checked</em>, sparq
+          was fastest on <strong className="text-foreground">{sb.wins}</strong>
+          {sb.losses > 0 ? (
+            <>
+              {" "}
+              and a competitor was faster on{" "}
+              <strong className="text-foreground">{sb.losses}</strong>
+            </>
+          ) : null}{" "}
+          (fastest competitor ranged{" "}
+          <strong className="text-foreground">
+            {sb.min}×–{sb.max}×
+          </strong>{" "}
+          sparq&rsquo;s full-request time, median{" "}
+          <strong className="text-foreground">{sb.median}×</strong>).
+          {sb.diffQueries.length > 0 && (
+            <>
+              {" "}
+              {sb.diffQueries.join(", ")}{" "}
+              {sb.diffQueries.length === 1 ? "was" : "were"} excluded from the win/loss count
+              because engines disagreed on the solution count.
+            </>
+          )}
+        </p>
+      ) : null}
+
+      {/* Engine measurement-mode legend + the connection-regime toggle. */}
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+          {engines.map((e) => (
+            <li key={e.id} className="flex items-center gap-1">
+              <span className="font-medium text-foreground">{e.label}</span>
+              {e.mode ? <span title={e.mode}>· HTTP</span> : null}
+              {e.status === "failed" ? (
+                <span className="font-medium text-[var(--warning)]">· failed</span>
+              ) : null}
+            </li>
+          ))}
+        </ul>
+        {canToggle && (
+          <div
+            role="group"
+            aria-label="connection regime"
+            className="inline-flex items-center rounded-md ring-1 ring-foreground/15 text-xs"
+          >
+            {(["keep-alive", "fresh-connect"] as Regime[]).map((r) => (
+              <button
+                key={r}
+                type="button"
+                aria-pressed={regime === r}
+                onClick={() => setRegime(r)}
+                className={
+                  "px-2.5 py-1 font-medium transition-colors first:rounded-l-md last:rounded-r-md " +
+                  (regime === r
+                    ? "bg-primary/10 text-primary"
+                    : "text-muted-foreground hover:bg-muted/60")
+                }
+              >
+                {r}
+                {r === primary ? " ·default" : ""}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="overflow-x-auto rounded-lg ring-1 ring-foreground/10">
+        <table className="w-full border-collapse text-sm">
+          <thead>
+            <tr className="border-b bg-muted/40 text-left">
+              <th className="px-3 py-2 font-medium">Query</th>
+              <th className="px-3 py-2 text-right font-medium">Rows</th>
+              {engines.map((e) => (
+                <th
+                  key={e.id}
+                  className="px-3 py-2 text-right font-medium"
+                  title={[e.mode, e.env].filter(Boolean).join(" — ")}
+                >
+                  {e.label}
+                  {e.version ? (
+                    <code className="ml-1 text-[11px] font-normal text-muted-foreground">
+                      {e.version}
+                    </code>
+                  ) : null}
+                </th>
+              ))}
+              <th
+                className="px-3 py-2 text-center font-medium"
+                title="engines agree on the solution count"
+              >
+                counts
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {comparison.rows.map((r) => {
+              const { full, ttfb } = regimeValues(r, regime);
+              const fastFull = fastestId(r, full);
+              const fastTtfb = fastestId(r, ttfb);
+              return (
+                <tr key={r.query} className="border-b last:border-0 hover:bg-muted/30">
+                  <td className="px-3 py-2 font-mono align-top">{r.query}</td>
+                  <td className="px-3 py-2 text-right font-mono tabular-nums align-top text-muted-foreground">
+                    {fmtNum(r.rows)}
+                  </td>
+                  {engines.map((e) => {
+                    const failed = e.status === "failed";
+                    const fv = full[e.id];
+                    const tv = ttfb[e.id];
+                    return (
+                      <td
+                        key={e.id}
+                        className="px-3 py-2 text-right font-mono tabular-nums align-top"
+                      >
+                        {failed ? (
+                          <span
+                            className="text-muted-foreground"
+                            title={e.failure || "engine failed to load"}
+                          >
+                            failed
+                          </span>
+                        ) : fv == null ? (
+                          <span
+                            className="text-muted-foreground"
+                            title="engine did not produce a timing for this query"
+                          >
+                            n/a
+                          </span>
+                        ) : (
+                          <div className="flex flex-col items-end leading-tight">
+                            <span
+                              className={
+                                fastFull === e.id
+                                  ? "font-semibold text-foreground"
+                                  : undefined
+                              }
+                              title={
+                                fastFull === e.id
+                                  ? "fastest full-request on this count-checked query"
+                                  : undefined
+                              }
+                            >
+                              {fmtNum(fv)} {r.unit}
+                            </span>
+                            <span
+                              className={
+                                "text-[11px] " +
+                                (fastTtfb === e.id
+                                  ? "font-semibold text-foreground"
+                                  : "text-muted-foreground")
+                              }
+                              title={
+                                fastTtfb === e.id
+                                  ? "earliest first byte (TTFB) on this count-checked query"
+                                  : "time to first byte"
+                              }
+                            >
+                              TTFB {tv == null ? "—" : fmtNum(tv)}
+                            </span>
+                          </div>
+                        )}
+                      </td>
+                    );
+                  })}
+                  <td
+                    className="px-3 py-2 text-center font-mono align-top"
+                    title={
+                      r.count_match === false
+                        ? "engines disagreed on the solution count for this query — timing not comparable"
+                        : r.count_match
+                          ? "all engines that produced a count agree (and match the expected rows)"
+                          : "count not cross-checked"
+                    }
+                  >
+                    {r.count_match == null ? "—" : r.count_match ? "✓" : "DIFF"}
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      {/* TTFB / streaming honesty callout — a genuine axis where sparq is BEHIND. */}
+      <p className="text-xs text-muted-foreground">
+        <Badge variant="muted" className="mr-1 align-middle">
+          TTFB
+        </Badge>
+        time-to-first-byte is shown beneath each full-request time. On a large SELECT an
+        engine can win end-to-end (full-request) while another delivers its first byte
+        earlier — a distinct first-byte-latency axis. Where a competitor&rsquo;s TTFB or
+        full-request is fastest, that competitor&rsquo;s value is the emphasised one.
+      </p>
+
+      <p className="text-xs text-muted-foreground">
+        {comparison.canonical === true ? (
+          <strong className="text-foreground">Canonical</strong>
+        ) : (
+          "Non-canonical"
+        )}{" "}
+        same-box HTTP panel · {comparison.scale} · min-of-{comparison.iters} per regime ·{" "}
+        {comparison.env.host_class}
+        {comparison.env.quiet_box ? " (quiet box)" : ""} · git{" "}
+        <code className="text-[11px]">{comparison.git_commit}</code> · counts cross-checked
+        engine-vs-engine and vs expected rows.
+        {comparison.connection?.note ? " " + comparison.connection.note : ""}
+        {comparison.combine ? " " + comparison.combine : ""}
+      </p>
+    </div>
+  );
+}

--- a/site/src/components/benchmarks/suite-group.tsx
+++ b/site/src/components/benchmarks/suite-group.tsx
@@ -13,6 +13,7 @@ import { cn } from "@/lib/utils";
 import { Card } from "@/components/ui/card";
 import { MetricTable } from "@/components/benchmarks/metric-table";
 import { SameBoxTable } from "@/components/benchmarks/same-box-table";
+import { HttpPanelTable } from "@/components/benchmarks/http-panel-table";
 import { ReferencesNote } from "@/components/benchmarks/references-note";
 import { TrendCharts } from "@/components/benchmarks/trend-charts";
 import { ScalingCharts } from "@/components/benchmarks/scaling-charts";
@@ -34,6 +35,10 @@ export interface SuiteGroupData {
   rows: MetricRow[];
   summary: CompetitiveSummary;
   sameBox?: SameBoxComparison;
+  // [OPUS-4.8] sq-7d3dj.34.3 — the canonical same-mode HTTP panel (full-request + TTFB) +
+  // its own honest wins/losses summary, rendered below the CLI matrix when present.
+  httpSameBox?: SameBoxComparison;
+  httpSummary?: CompetitiveSummary;
   references: ReferenceBaseline[];
   trends: TrendSeries[];
   scaling: ScalingFamily[];
@@ -84,6 +89,17 @@ export function SuiteGroup({
             <div className="space-y-2">
               <h4 className="text-sm font-medium">Same-box cross-engine comparison</h4>
               <SameBoxTable comparison={data.sameBox} />
+            </div>
+          )}
+          {data.httpSameBox && (
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium">
+                Same-box HTTP-server panel — full-request + TTFB
+              </h4>
+              <HttpPanelTable
+                comparison={data.httpSameBox}
+                summary={data.httpSummary}
+              />
             </div>
           )}
           <ReferencesNote references={data.references} />

--- a/site/src/data/benchmarks.ts
+++ b/site/src/data/benchmarks.ts
@@ -463,6 +463,11 @@ export interface FullSuiteGroup {
   rows: MetricRow[];
   summary: CompetitiveSummary;
   sameBox?: SameBoxComparison;
+  // [OPUS-4.8] sq-7d3dj.34.3 — the canonical HTTP-mode panel (all engines over HTTP,
+  // full-request + TTFB, keep-alive + fresh-connect) for this suite, plus its own honest
+  // same-mode wins/losses summary. Present only for suites with a `<base>-http` gather.
+  httpSameBox?: SameBoxComparison;
+  httpSummary?: CompetitiveSummary;
   references: ReferenceBaseline[];
   // sq-hsyg: per-suite trend series (one per metric) + scaling families (size-parametrised).
   trends: TrendSeries[];
@@ -474,15 +479,22 @@ export function fullSuiteGroupsForFamily(key: string): FullSuiteGroup[] {
   // is small). Trend/scaling carry a `suite` so the per-suite filter is exact.
   const allTrends = trendSeriesForFamily(key);
   const allScaling = scalingFamiliesForFamily(key);
-  return suiteGroupsForFamily(key).map((g) => ({
-    suite: g.suite,
-    rows: g.rows,
-    summary: g.summary,
-    sameBox: sameBoxFor(g.suite),
-    references: referencesForSuite(g.suite),
-    trends: allTrends.filter((t) => t.suite === g.suite),
-    scaling: allScaling.filter((s) => s.suite === g.suite),
-  }));
+  return suiteGroupsForFamily(key).map((g) => {
+    const httpSameBox = httpSameBoxFor(g.suite);
+    return {
+      suite: g.suite,
+      rows: g.rows,
+      summary: g.summary,
+      sameBox: sameBoxFor(g.suite),
+      httpSameBox,
+      // Computed server-side (no fabrication client-side) — same honesty path as the CLI
+      // matrix, so a SP2Bench HTTP loss shows as a loss, never spun.
+      httpSummary: httpSameBox ? summarizeSameBox(httpSameBox) : undefined,
+      references: referencesForSuite(g.suite),
+      trends: allTrends.filter((t) => t.suite === g.suite),
+      scaling: allScaling.filter((s) => s.suite === g.suite),
+    };
+  });
 }
 
 // ---- LIVE competitive summary (the load-bearing honesty computation) ------------------
@@ -548,7 +560,9 @@ function median(xs: number[]): number {
 
 const round1 = (x: number) => Math.round(x * 10) / 10;
 
-// Find the same_box_comparisons entry whose suite matches (case-insensitive).
+// Find the same_box_comparisons entry whose suite matches (case-insensitive). The
+// fuzzy match deliberately does NOT match the `<base>-http` panel suites (e.g. "sp2b-http"),
+// so a CLI suite group ("SP2Bench") binds to the CLI matrix ("sp2b"), not the HTTP panel.
 function sameBoxFor(suite: string): SameBoxComparison | undefined {
   const norm = suite.toLowerCase();
   return (COMPETITORS.same_box_comparisons || []).find(
@@ -557,6 +571,21 @@ function sameBoxFor(suite: string): SameBoxComparison | undefined {
       norm.includes(c.suite.toLowerCase()) ||
       c.suite.toLowerCase().includes(norm.split(" ")[0]),
   );
+}
+
+// [OPUS-4.8] sq-7d3dj.34.3 — find the canonical HTTP-mode panel (`<base>-http`) for a CLI
+// suite group, so the SP2Bench / WatDiv groups can render the same-mode HTTP full-request +
+// TTFB panel BELOW the CLI matrix. We strip the "-http" suffix and reuse the same fuzzy
+// suite match ("sp2b-http" → "sp2b" matches the "SP2Bench" group). Returns undefined when
+// no HTTP panel exists for the suite, so groups without one are unaffected.
+function httpSameBoxFor(suite: string): SameBoxComparison | undefined {
+  const norm = suite.toLowerCase();
+  return (COMPETITORS.same_box_comparisons || []).find((c) => {
+    const cs = c.suite.toLowerCase();
+    if (!cs.endsWith("-http")) return false;
+    const base = cs.slice(0, -"-http".length);
+    return norm === base || norm.includes(base) || base.includes(norm.split(" ")[0]);
+  });
 }
 
 export function competitiveSummary(
@@ -611,85 +640,95 @@ export function competitiveSummary(
   //     not comparable). We also record the mode asymmetry (in-process CLI vs HTTP adapter)
   //     and any failed engine so the UI can caveat, never a bald "N× faster" headline.
   const sb = sameBoxFor(suite);
-  if (sb) {
-    const ratios: number[] = [];
-    const diffQueries: string[] = [];
-    const engines = new Set<string>();
-    let wins = 0;
-    let losses = 0;
-    for (const row of sb.rows) {
-      const sparq = row.values["sparq"];
-      if (typeof sparq !== "number" || sparq <= 0) continue;
-      if (row.count_match === false) {
-        diffQueries.push(row.query);
-        continue; // engines disagreed on the count — timing not comparable
-      }
-      let best = Infinity;
-      for (const [eng, v] of Object.entries(row.values)) {
-        if (eng === "sparq") continue;
-        if (typeof v === "number" && v > 0) {
-          engines.add(eng);
-          if (v < best) best = v;
-        }
-      }
-      if (best !== Infinity) {
-        const ratio = best / sparq;
-        ratios.push(ratio);
-        if (ratio > 1) wins += 1;
-        else if (ratio < 1) losses += 1;
-      }
-    }
-    // Label + mode grouping comes from THIS comparison's own engines (not the top-level
-    // registry), so a competitor absent from the registry still gets its proper label, and
-    // the CLI-vs-HTTP asymmetry is classified from each engine's recorded `mode`.
-    const isHttp = (e: { mode?: string }) => /http/i.test(e.mode || "");
-    const isCli = (e: { mode?: string }) => /in-process/i.test(e.mode || "");
-    const failedEngines = sb.engines
-      .filter((e) => e.status === "failed")
-      .map((e) => e.label);
-    const competitors = sb.engines
-      .filter((e) => e.id !== "sparq" && engines.has(e.id))
-      .map((e) => e.label);
-    const cliCompetitors = sb.engines
-      .filter((e) => e.id !== "sparq" && isCli(e))
-      .map((e) => e.label);
-    const httpEngines = sb.engines.filter((e) => isHttp(e)).map((e) => e.label);
-    if (ratios.length > 0) {
-      return {
-        kind: "same-box",
-        competitors,
-        cliCompetitors,
-        httpEngines,
-        failedEngines,
-        total: ratios.length,
-        wins,
-        losses,
-        median: round1(median(ratios)),
-        min: round1(Math.min(...ratios)),
-        max: round1(Math.max(...ratios)),
-        diffQueries,
-        canonical: sb.canonical === true,
-        host: sb.env.host_class || "quiet box",
-        scale: sb.scale,
-        gitCommit: sb.git_commit,
-      };
-    }
-    // a same-box gather EXISTS but every competitor cell is null → honest pending
-    return {
-      kind: "pending",
-      reason:
-        "A same-box " +
-        sb.suite +
-        " comparison was run, but competitor timings were not captured this run, so no comparison can be computed yet.",
-      provenance: sb.env.host_class,
-    };
-  }
+  if (sb) return summarizeSameBox(sb);
 
   // (3) nothing comparable on the same box.
   return {
     kind: "sparq-only",
     reason:
       "No same-box competitor baseline has been gathered for this suite yet — sparq's absolute numbers are shown below.",
+  };
+}
+
+// [FABLE-5]-authored data, this UI by [OPUS-4.8] sq-7d3dj.34.3 — the honest same-box
+// summary for ONE comparison (CLI matrix OR HTTP-mode panel). Extracted from
+// competitiveSummary so both the CLI cross-engine table and the HTTP/TTFB panel share the
+// identical count-checked wins/losses computation (no fabrication; a query whose solution
+// count disagreed across engines is EXCLUDED from the ratio, never spun into a win). The
+// ratio is fastest-competitor / sparq per query; wins = queries where sparq was fastest.
+export function summarizeSameBox(sb: SameBoxComparison): CompetitiveSummary {
+  const ratios: number[] = [];
+  const diffQueries: string[] = [];
+  const engines = new Set<string>();
+  let wins = 0;
+  let losses = 0;
+  for (const row of sb.rows) {
+    const sparq = row.values["sparq"];
+    if (typeof sparq !== "number" || sparq <= 0) continue;
+    if (row.count_match === false) {
+      diffQueries.push(row.query);
+      continue; // engines disagreed on the count — timing not comparable
+    }
+    let best = Infinity;
+    for (const [eng, v] of Object.entries(row.values)) {
+      if (eng === "sparq") continue;
+      if (typeof v === "number" && v > 0) {
+        engines.add(eng);
+        if (v < best) best = v;
+      }
+    }
+    if (best !== Infinity) {
+      const ratio = best / sparq;
+      ratios.push(ratio);
+      if (ratio > 1) wins += 1;
+      else if (ratio < 1) losses += 1;
+    }
+  }
+  // Label + mode grouping comes from THIS comparison's own engines (not the top-level
+  // registry), so a competitor absent from the registry still gets its proper label, and
+  // the CLI-vs-HTTP asymmetry is classified from each engine's recorded `mode`. In the
+  // HTTP-mode panel every engine's mode is HTTP, so cliCompetitors is empty and httpEngines
+  // is all — that is the point: the panel measures every engine in the SAME mode.
+  const isHttp = (e: { mode?: string }) => /http/i.test(e.mode || "");
+  const isCli = (e: { mode?: string }) => /in-process/i.test(e.mode || "");
+  const failedEngines = sb.engines
+    .filter((e) => e.status === "failed")
+    .map((e) => e.label);
+  const competitors = sb.engines
+    .filter((e) => e.id !== "sparq" && engines.has(e.id))
+    .map((e) => e.label);
+  const cliCompetitors = sb.engines
+    .filter((e) => e.id !== "sparq" && isCli(e))
+    .map((e) => e.label);
+  const httpEngines = sb.engines.filter((e) => isHttp(e)).map((e) => e.label);
+  if (ratios.length > 0) {
+    return {
+      kind: "same-box",
+      competitors,
+      cliCompetitors,
+      httpEngines,
+      failedEngines,
+      total: ratios.length,
+      wins,
+      losses,
+      median: round1(median(ratios)),
+      min: round1(Math.min(...ratios)),
+      max: round1(Math.max(...ratios)),
+      diffQueries,
+      canonical: sb.canonical === true,
+      host: sb.env.host_class || "quiet box",
+      scale: sb.scale,
+      gitCommit: sb.git_commit,
+    };
+  }
+  // a same-box gather EXISTS but every competitor cell is null → honest pending
+  return {
+    kind: "pending",
+    reason:
+      "A same-box " +
+      sb.suite +
+      " comparison was run, but competitor timings were not captured this run, so no comparison can be computed yet.",
+    provenance: sb.env.host_class,
   };
 }
 


### PR DESCRIPTION
> **SPARQ agent 🤖** — autonomous agent working on sparq (Claude Opus 4.8, 1M context). Bead: **sq-7d3dj.34.3** (parent sq-7d3dj.34, PR #1742 canonical HTTP/TTFB panel; perf-dominance mandate).

## Why
PR #1742 measured + ingested the canonical **2026-07-07 HTTP/TTFB competitor panel** (5 engines, same-box, quiet c6i.4xlarge) into `bench/dashboard/competitors.json` → `site/src/data/benchmarks.generated.json` as the `sp2b-http` / `watdiv-http` same-box suites — each row carrying full-request (`values`), **TTFB** (`values_ttfb`), and the fresh-connect twins (`values_fresh*`) plus a keep-alive-vs-fresh `connection` note. But the site rendered **only the CLI matrix's `.values`** and dropped the `-http` suites + the TTFB/fresh columns — **data-only** (the deferred P3). This PR adds the rendering. **UI-only; no data hand-edited** (the canonical rows flow through `site/scripts/sync-benchmarks.mjs`, already run by #1742).

## What changed (routes: `/benchmarks/sparql`)
- **`site/src/data/benchmarks.ts`** — extract `summarizeSameBox()` from `competitiveSummary` so the CLI matrix and the HTTP panel share the **identical count-checked wins/losses** computation; add `httpSameBoxFor()` (binds `"<base>-http"` to the CLI suite group) and carry `httpSameBox` + a **server-computed** `httpSummary` on `FullSuiteGroup` (no fabrication client-side).
- **`site/src/components/benchmarks/http-panel-table.tsx`** *(new, client)* — all engines in the **same HTTP mode**; each cell shows **full-request (primary) with TTFB beneath**; a **keep-alive ⇄ fresh-connect** regime toggle (default = the envelope's primary). The **fastest count-checked value per row is emphasised REGARDLESS of engine**, so where a competitor leads it is highlighted — never sparq by default.
- **`site/src/components/benchmarks/suite-group.tsx`** — render the HTTP panel below the existing CLI matrix when a `-http` gather exists.

## Honesty check — outcome: PASS (no spin, mirrors the research record)
`research/perf-dominance-gap-2026-07-http-addendum.md` verdicts are reproduced faithfully:
- **SP2Bench HTTP (BEHIND):** the panel summary states sparq was fastest on **6** and **a competitor was faster on 6** count-checked queries (fastest-competitor ratio **0.0×–11.1×**, **median 1.0×** — dead-even at the median, and on the worst rows a correct competitor is ~11–27× faster); `q08`/`q12b` are **excluded + named** because a competitor returned a different solution count (the sound convention — the row data carries only an aggregate `count_match`, so comparing against a possibly-wrong-answer engine is not done). Every behind-row (q03b/c, q07, q09, q11, q12c) is visible with the **leading competitor emphasised**.
- **WatDiv HTTP (AHEAD but not OOM):** fastest-on-16, with the **1.3×–15.4×** range on show — the numbers themselves make the *floor-bound, not orders-of-magnitude* reality plain (vs the CLI matrix's 205–23,453×).
- **TTFB streaming gap (BEHIND):** on the large SELECT (q04) sparq wins full-request but oxigraph's first byte arrives ~48× earlier — surfaced by the **emphasised competitor TTFB** value + a TTFB callout explaining the first-byte axis.

## Verification
- `cd site && npm install && npm run build` → **green, 62/62 static pages**, `check-bundle` PASS (basePath `/sparq` + `images.unoptimized` preserved, no engine-wasm/ZK chunk in first-load). WASM prereq built first (`cd js && npm run build:wasm`, exit 0 — build artifact only).
- `npm run typecheck` (tsc --noEmit) clean · `npm run lint` clean.
- **Real DOM render check** (headless Chromium against the exported `out/`): expanded the SP2Bench group → panel heading + same-mode framing render, sparq q01 keep-alive full **192 µs** renders, TTFB sub-values render, **regime toggle** switches to fresh-connect (sparq q01 **222 µs**), the "a competitor was faster" honesty line and `DIFF` markers render, WatDiv panel renders, **0 page errors**.

## Covered vs deferred
- **Covered:** rendering the `sp2b-http` + `watdiv-http` panels with full-request + TTFB, keep-alive primary / fresh available (toggle), mode + count_match honesty carried as in the CLI matrix.
- **Deferred (not this PR):** the P1 engine fixes the panel motivates — `sq-7d3dj.34.1` (per-request HTTP floor) and `sq-7d3dj.34.2` (stream-before-materialize first byte, PR #1745 in flight).

Do **not** auto-arm — leaving for the verdict pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
