### PR TITLE
fix(site): /capabilities demos expand to full lane width, not a 1/3 tile (sq-67qji) [OPUS-4.8]

### DIFF
--- a/site/src/components/capabilities/capability-lane-grid.tsx
+++ b/site/src/components/capabilities/capability-lane-grid.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+// [OPUS-4.8] sq-67qji — the interactive body of a /capabilities lane (issue #1675).
+//
+// THE BUG. Each lane laid its tiles in a `grid sm:grid-cols-2` inside the lane's `1fr` column,
+// and a demo used to expand IN its own tile — so on desktop a wide interactive demo (the ZK /
+// MPC / GeoSPARQL result tables) was confined to (viewport − 232px spine − gaps)/2 ≈ ONE THIRD
+// of the screen and was cramped and hard to use.
+//
+// THE FIX. This client component owns the lane's open/mounted state and renders, as siblings
+// inside the lane <section>'s `lg:grid-cols-[232px_1fr]` grid:
+//   1. the tile grid (unchanged 2-column tiles), and
+//   2. the OPENED demo's body as a `lg:col-span-2` row BELOW the grid — reclaiming the
+//      numbered-spine column so the demo gets the FULL content width, not a half-column tile.
+// Because it returns a fragment (no wrapper DOM node), both land as direct grid items of the
+// section, so `lg:col-span-2` spans the whole lane. A collapsed body is `display:none`, which
+// removes it from grid layout entirely — so no phantom gap appears below the tiles when nothing
+// is open.
+//
+// LAZY-MOUNT DISCIPLINE PRESERVED (the #1 risk, research/website-redesign.md §3). A demo body
+// is only rendered once its slug has been opened (`mounted` set), and stays mounted — hidden
+// with CSS on collapse — so re-expanding never re-fetches its code-split chunk. This is exactly
+// the invariant e2e/capabilities-lazy.spec.ts + scripts/check-bundle.mjs assert.
+
+import * as React from "react";
+import { AlertTriangle } from "lucide-react";
+
+import { type CapabilityKind } from "@/data/capabilities";
+import {
+  CapabilityRowItem,
+  CapabilityDemoBody,
+} from "@/components/capabilities/capability-row";
+import { hasLazyDemo, type LazyDemoSlug } from "@/components/capabilities/lazy-demo";
+
+/** Serializable row handed down from the server lane (a Surface's lucide `icon` cannot cross
+ *  the RSC boundary, so we pass the slug + kind and resolve the surface client-side). */
+export interface LaneRow {
+  slug: string;
+  kind: CapabilityKind;
+}
+
+export function CapabilityLaneGrid({
+  rows,
+  accent,
+  groupId,
+}: {
+  rows: LaneRow[];
+  accent: string;
+  groupId: string;
+}) {
+  // At most one demo is expanded per lane; `mounted` accumulates every slug that has ever been
+  // opened so its chunk is fetched at most once (collapse hides, never unmounts).
+  const [openSlug, setOpenSlug] = React.useState<string | null>(null);
+  const [mounted, setMounted] = React.useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+
+  const toggle = React.useCallback((slug: string) => {
+    setMounted((prev) =>
+      prev.has(slug) ? prev : new Set(prev).add(slug),
+    );
+    setOpenSlug((cur) => (cur === slug ? null : slug));
+  }, []);
+
+  // The lane's demo slugs that actually have a registered lazy demo (mirrors the row guard in
+  // CapabilityRowItem, so a data-drift "demo" surface without a demo never mounts a body).
+  const demoSlugs = React.useMemo(
+    () =>
+      rows
+        .filter((r) => r.kind === "demo")
+        .map((r) => r.slug)
+        .filter((s): s is LazyDemoSlug => hasLazyDemo(s)),
+    [rows],
+  );
+
+  return (
+    <>
+      <div className="grid gap-3 sm:grid-cols-2">
+        {rows.map((r) => (
+          <CapabilityRowItem
+            key={r.slug}
+            slug={r.slug}
+            kind={r.kind}
+            accent={accent}
+            open={openSlug === r.slug}
+            onToggle={() => toggle(r.slug)}
+          />
+        ))}
+
+        {/* Privacy lane: the explicit research-grade caveat strip (made loud, not a footnote).
+            LIVE privacy-claims honesty — the copy stays qualified (not externally audited). */}
+        {groupId === "privacy" && <PrivacyCaveatStrip />}
+      </div>
+
+      {/* Full-width demo bodies. Only opened slugs are mounted; a collapsed one is display:none
+          (so it neither shows nor reserves a grid row). Each is a direct grid child of the
+          section via this fragment, so `lg:col-span-2` gives it the full lane width. */}
+      {demoSlugs
+        .filter((slug) => mounted.has(slug))
+        .map((slug) => (
+          <CapabilityDemoBody
+            key={slug}
+            slug={slug}
+            open={openSlug === slug}
+            onCollapse={() => toggle(slug)}
+          />
+        ))}
+    </>
+  );
+}
+
+function PrivacyCaveatStrip() {
+  return (
+    <div className="flex items-start gap-3 rounded-[var(--radius-lg)] border border-dashed border-[color-mix(in_oklch,var(--warning)_45%,var(--border))] bg-[color-mix(in_oklch,var(--warning)_7%,transparent)] px-4 py-3 text-[12.7px] text-muted-foreground sm:col-span-2">
+      <AlertTriangle
+        className="mt-0.5 size-4 shrink-0 text-[var(--warning)]"
+        aria-hidden
+      />
+      <span>
+        <span className="font-semibold text-foreground">
+          Research-grade, labelled as such.
+        </span>{" "}
+        The v1 ZK verifier is not externally audited — sound as landed under its
+        stated threat model, pending re-review. MPC runs as a faithful in-tab
+        simulation of the native protocol, not a proof of correctness. Indicative
+        engineering, not an audited cryptographic guarantee.
+      </span>
+    </div>
+  );
+}

--- a/site/src/components/capabilities/capability-lane.tsx
+++ b/site/src/components/capabilities/capability-lane.tsx
@@ -3,15 +3,19 @@
 // Faithful to the approved mockup (web-capabilities.html §LANE): each theme is a horizontal
 // "lane" with a sticky NUMBERED spine (01 / 05) + a per-theme accent (chart-1…5) + a tile grid,
 // so the five capability areas read as five distinct places — scannable without reading every
-// blurb. The tiles are the existing CapabilityRowItem (lazy-mount machinery preserved); the
-// query-data lane carries the "open the workbench" affordance, and the privacy lane carries the
-// explicit research-grade caveat strip (LIVE privacy-claims honesty, made loud not hidden).
+// blurb. The query-data lane carries the "open the workbench" affordance.
+//
+// [OPUS-4.8] sq-67qji (issue #1675) — the interactive tile grid + the expanded demo bodies are
+// delegated to the CapabilityLaneGrid client component. It renders an opened demo's body at full
+// lane width (a `lg:col-span-2` row that reclaims this spine's column) instead of expanding it
+// inside a half-column tile, and carries the privacy lane's research-grade caveat strip. The
+// lazy-mount machinery + honesty caveats are preserved there verbatim.
 
-import { AlertTriangle, PlayCircle } from "lucide-react";
+import { PlayCircle } from "lucide-react";
 
 import { type CapabilityTheme } from "@/data/capabilities";
 import { withBasePath } from "@/lib/base-path";
-import { CapabilityRowItem } from "@/components/capabilities/capability-row";
+import { CapabilityLaneGrid } from "@/components/capabilities/capability-lane-grid";
 import { laneAccent } from "@/components/capabilities/lane-accents";
 
 export function CapabilityLane({
@@ -63,36 +67,15 @@ export function CapabilityLane({
         )}
       </div>
 
-      {/* The tile grid. */}
-      <div className="grid gap-3 sm:grid-cols-2">
-        {rows.map(({ surface, kind }) => (
-          <CapabilityRowItem
-            key={surface.slug}
-            slug={surface.slug}
-            kind={kind}
-            accent={accent}
-          />
-        ))}
-
-        {/* Privacy lane: the explicit research-grade caveat strip (made loud, not a footnote). */}
-        {group.id === "privacy" && (
-          <div className="flex items-start gap-3 rounded-[var(--radius-lg)] border border-dashed border-[color-mix(in_oklch,var(--warning)_45%,var(--border))] bg-[color-mix(in_oklch,var(--warning)_7%,transparent)] px-4 py-3 text-[12.7px] text-muted-foreground sm:col-span-2">
-            <AlertTriangle
-              className="mt-0.5 size-4 shrink-0 text-[var(--warning)]"
-              aria-hidden
-            />
-            <span>
-              <span className="font-semibold text-foreground">
-                Research-grade, labelled as such.
-              </span>{" "}
-              The v1 ZK verifier is not externally audited — sound as landed under its
-              stated threat model, pending re-review. MPC runs as a faithful in-tab
-              simulation of the native protocol, not a proof of correctness. Indicative
-              engineering, not an audited cryptographic guarantee.
-            </span>
-          </div>
-        )}
-      </div>
+      {/* The interactive tile grid + full-width demo bodies (client). A Surface's lucide `icon`
+          is not serializable across the RSC boundary, so we hand down the slug + kind and the
+          client resolves the surface. The fragment it returns lands its children as direct grid
+          items of this section, so an opened demo body can span `lg:col-span-2` (sq-67qji). */}
+      <CapabilityLaneGrid
+        rows={rows.map(({ surface, kind }) => ({ slug: surface.slug, kind }))}
+        accent={accent}
+        groupId={group.id}
+      />
     </section>
   );
 }

--- a/site/src/components/capabilities/capability-row.tsx
+++ b/site/src/components/capabilities/capability-row.tsx
@@ -4,18 +4,22 @@
 //
 // Three shapes (data/capabilities.ts `classify`):
 //   * deep  → a plain link "Open →" to the surface's retained /surface/<slug> deep page.
-//   * demo  → an expand-in-place disclosure "Demo ▸" that LAZILY mounts the surface's existing
-//             interactive component (LazyDemo) only on first expand, plus a "Details & caveats"
-//             <details> holding ONE caveat sentence + README + SKILL links.
+//   * demo  → a "Demo ▸" disclosure. The TILE is just the controlled button (DemoTileButton);
+//             its interactive body (LazyDemo + a "Details & caveats" <details>) is rendered
+//             SEPARATELY at full lane width by CapabilityDemoBody, so the lane grid can lay the
+//             body out as a full-content-width row instead of squeezing it into a half-column
+//             tile (sq-67qji — issue #1675). The lane grid (capability-lane-grid.tsx) owns the
+//             open/mounted state and pairs each button with its body by slug.
 //   * soon  → a non-interactive "Coming soon" row that links out to GitHub.
 //
-// [OPUS-4.8] sq-vw3ax — BOLD redesign: each affordance now renders as a depth TILE (the
-// approved web-capabilities.html lane layout) instead of a flat 64px row, with a per-theme
-// accent line that reveals on hover. The lazy-mount machinery is UNCHANGED — it is the
-// load-bearing #1 risk (research/website-redesign.md §3 COLLAPSE): `mounted` flips true on
-// first expand and the demo chunk is fetched only then (see lazy-demo.tsx). Collapsing keeps
-// `mounted` true so a re-expand never re-fetches; we hide the body with CSS rather than
-// unmounting. The heavy bb.js / noir_js graph stays isolated to the ZK chunk alone.
+// [OPUS-4.8] sq-vw3ax — BOLD redesign: each affordance renders as a depth TILE (the approved
+// web-capabilities.html lane layout) instead of a flat 64px row, with a per-theme accent line
+// that reveals on hover (and pins on while the demo is open). The lazy-mount machinery is
+// UNCHANGED — it is the load-bearing #1 risk (research/website-redesign.md §3 COLLAPSE):
+// `mounted` flips true on first expand and the demo chunk is fetched only then (see
+// lazy-demo.tsx). Collapsing keeps `mounted` true so a re-expand never re-fetches; the body is
+// hidden with CSS rather than unmounted. The heavy bb.js / noir_js graph stays isolated to the
+// ZK chunk alone.
 
 import * as React from "react";
 import Link from "next/link";
@@ -113,11 +117,14 @@ function TileShell({
   accent,
   cta,
   interactive = true,
+  active = false,
 }: {
   surface: Surface;
   accent: string;
   cta: React.ReactNode;
   interactive?: boolean;
+  /** Pins the accent + elevation on (used while a demo tile's body is open). */
+  active?: boolean;
 }) {
   const Icon = surface.icon;
   return (
@@ -126,13 +133,17 @@ function TileShell({
         "relative flex items-start gap-3 overflow-hidden rounded-[var(--radius-lg)] border bg-card px-4 py-3.5 transition-all duration-150",
         interactive &&
           "hover:-translate-y-0.5 hover:border-primary/45 hover:shadow-elevation-2 [&:hover>[data-accent]]:opacity-90",
+        active && "border-primary/45 shadow-elevation-2",
       )}
     >
-      {/* The per-theme accent spine — revealed on hover. */}
+      {/* The per-theme accent spine — revealed on hover, and pinned on while the demo is open. */}
       <span
         data-accent
         aria-hidden
-        className="absolute inset-y-0 left-0 w-[3px] opacity-0 transition-opacity duration-150"
+        className={cn(
+          "absolute inset-y-0 left-0 w-[3px] transition-opacity duration-150",
+          active ? "opacity-90" : "opacity-0",
+        )}
         style={{ background: accent }}
       />
       <span className="flex size-9 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-primary/10 text-primary">
@@ -199,91 +210,141 @@ function SoonTile({ surface, accent }: { surface: Surface; accent: string }) {
   );
 }
 
-/** "Demo ▸" expand-in-place tile — lazily mounts the demo on first expand. */
-function DemoTile({
+/** Internal /showcase route for the flagship demos that have a full end-to-end showcase page.
+ *  Surfaced as an "Open the full showcase" link in the expanded demo, so the maintainer's
+ *  "send me to the showcase" intent (issue #1675) is honoured without leaving the gallery or
+ *  fabricating a showcase page for the six demos that have none. */
+const SHOWCASE_HREF: Partial<Record<LazyDemoSlug, string>> = {
+  zk: "/showcase/zk-car-hire",
+  mpc: "/showcase/mpc-100k",
+};
+
+/** "Demo ▸" tile HEADER — a controlled disclosure button (grid cell). The interactive body is
+ *  rendered separately at full lane width by `CapabilityDemoBody`, so a wide demo is no longer
+ *  confined to a half-column tile (sq-67qji). Open state is owned by the lane grid, which pairs
+ *  this button with its body by slug. */
+function DemoTileButton({
   surface,
-  slug,
   accent,
+  open,
+  onToggle,
 }: {
   surface: Surface;
-  slug: LazyDemoSlug;
   accent: string;
+  open: boolean;
+  onToggle: () => void;
 }) {
-  const [open, setOpen] = React.useState(false);
-  // Once mounted, stay mounted across collapse/re-expand so the chunk is fetched at most once.
-  const [mounted, setMounted] = React.useState(false);
-  const meta = META[slug];
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={open}
+      className="group block w-full rounded-[var(--radius-lg)] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
+    >
+      <TileShell
+        surface={surface}
+        accent={accent}
+        active={open}
+        cta={
+          <span className={CTA_CLASS}>
+            Demo
+            <ChevronRight
+              className={cn("size-3 transition-transform", open && "rotate-90")}
+              aria-hidden
+            />
+          </span>
+        }
+      />
+    </button>
+  );
+}
 
-  const toggle = () => {
-    setOpen((v) => {
-      const next = !v;
-      if (next) setMounted(true);
-      return next;
-    });
-  };
+/** The full-lane-width body for an expanded demo (sq-67qji). The lane grid renders this as a
+ *  `lg:col-span-2` row BELOW the tile grid (capability-lane-grid.tsx), reclaiming the numbered-
+ *  spine column so the interactive demo gets the full content width instead of ~1/3 of it —
+ *  the fix for issue #1675.
+ *
+ *  The lazy mount is UNCHANGED and load-bearing (the #1 risk, research/website-redesign.md §3):
+ *  this body is only rendered once its slug has been opened (the lane grid only mounts opened
+ *  slugs), and it stays mounted — hidden with CSS on collapse — so re-expanding never re-fetches
+ *  the demo's code-split chunk. `data-demo-body` + the CSS-hidden collapse are the invariants the
+ *  e2e lazy-mount test (e2e/capabilities-lazy.spec.ts) asserts, and are preserved verbatim. */
+export function CapabilityDemoBody({
+  slug,
+  open,
+  onCollapse,
+}: {
+  slug: LazyDemoSlug;
+  open: boolean;
+  onCollapse: () => void;
+}) {
+  const surface = surfaceBySlug(slug);
+  const meta = META[slug];
+  const showcaseHref = SHOWCASE_HREF[slug];
+  const Icon = surface?.icon;
 
   return (
-    <div>
-      <button
-        type="button"
-        onClick={toggle}
-        aria-expanded={open}
-        className="group block w-full rounded-[var(--radius-lg)] text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/50"
-      >
-        <TileShell
-          surface={surface}
-          accent={accent}
-          cta={
-            <span className={CTA_CLASS}>
-              Demo
-              <ChevronRight
-                className={cn(
-                  "size-3 transition-transform",
-                  open && "rotate-90",
-                )}
-                aria-hidden
-              />
-            </span>
-          }
-        />
-      </button>
-
-      {/* The body is only present in the DOM once first expanded; CSS hides it on collapse so a
-          re-expand does not re-fetch the chunk (mounted stays true). */}
-      {mounted && (
-        <div className={cn("px-1 pt-3", !open && "hidden")} data-demo-body={slug}>
-          <div className="rounded-[var(--radius-lg)] border bg-muted/20 p-3">
-            <LazyDemo slug={slug} mounted={mounted} />
+    <div data-demo-body={slug} className={cn("lg:col-span-2", !open && "hidden")}>
+      <div className="rounded-[var(--radius-lg)] border bg-muted/20 p-4 sm:p-5">
+        {/* Body header — re-anchors the now full-width demo to its tile and carries the
+            flagship's "full showcase" link + a nearby collapse control (the toggle button now
+            lives up in the grid, so a local collapse keeps the demo usable). */}
+        <div className="mb-4 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 border-b pb-3">
+          <div className="flex items-center gap-2 text-sm font-semibold tracking-tight">
+            {Icon && (
+              <span className="flex size-7 shrink-0 items-center justify-center rounded-[var(--radius-md)] bg-primary/10 text-primary">
+                <Icon className="size-4" aria-hidden />
+              </span>
+            )}
+            {surface?.title}
           </div>
-
-          <details className="mt-3 rounded-[var(--radius-lg)] border bg-card px-3 py-2 text-sm">
-            <summary className="cursor-pointer select-none font-medium text-foreground/90">
-              Details &amp; caveats
-            </summary>
-            <p className="mt-2 text-muted-foreground">{meta.caveat}</p>
-            <div className="mt-2 flex flex-wrap gap-3 text-sm">
-              <a
-                className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
-                href={meta.readme}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                Crate / source <ExternalLink className="size-3.5" />
-              </a>
-              {meta.skill && (
-                <a
-                  className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
-                  href={meta.skill}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  SKILL.md <ExternalLink className="size-3.5" />
-                </a>
-              )}
-            </div>
-          </details>
+          <div className="flex items-center gap-4">
+            {showcaseHref && (
+              <Link href={showcaseHref} className={CTA_CLASS}>
+                Open the full showcase
+                <ArrowRight className="size-3" aria-hidden />
+              </Link>
+            )}
+            <button
+              type="button"
+              onClick={onCollapse}
+              className="inline-flex items-center gap-1 text-[12px] font-medium text-muted-foreground transition-colors hover:text-foreground"
+            >
+              Collapse
+              <ChevronRight className="size-3 -rotate-90" aria-hidden />
+            </button>
+          </div>
         </div>
-      )}
+
+        <LazyDemo slug={slug} mounted />
+      </div>
+
+      <details className="mt-3 rounded-[var(--radius-lg)] border bg-card px-3 py-2 text-sm">
+        <summary className="cursor-pointer select-none font-medium text-foreground/90">
+          Details &amp; caveats
+        </summary>
+        <p className="mt-2 text-muted-foreground">{meta.caveat}</p>
+        <div className="mt-2 flex flex-wrap gap-3 text-sm">
+          <a
+            className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+            href={meta.readme}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Crate / source <ExternalLink className="size-3.5" />
+          </a>
+          {meta.skill && (
+            <a
+              className="inline-flex items-center gap-1 text-primary underline-offset-4 hover:underline"
+              href={meta.skill}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              SKILL.md <ExternalLink className="size-3.5" />
+            </a>
+          )}
+        </div>
+      </details>
     </div>
   );
 }
@@ -296,10 +357,15 @@ export function CapabilityRowItem({
   slug,
   kind,
   accent = "var(--primary)",
+  open = false,
+  onToggle,
 }: {
   slug: string;
   kind: "deep" | "demo" | "soon";
   accent?: string;
+  /** Controlled disclosure state for a demo tile — owned by the lane grid (sq-67qji). */
+  open?: boolean;
+  onToggle?: () => void;
 }) {
   const surface = surfaceBySlug(slug);
   if (!surface) return null; // data drift — a row for an unknown surface; render nothing.
@@ -307,7 +373,14 @@ export function CapabilityRowItem({
   if (kind === "soon") return <SoonTile surface={surface} accent={accent} />;
   // demo — guard against a data drift where a "demo" surface lacks a registered demo.
   if (hasLazyDemo(surface.slug)) {
-    return <DemoTile surface={surface} slug={surface.slug} accent={accent} />;
+    return (
+      <DemoTileButton
+        surface={surface}
+        accent={accent}
+        open={open}
+        onToggle={onToggle ?? (() => {})}
+      />
+    );
   }
   return <SoonTile surface={surface} accent={accent} />;
 }


### PR DESCRIPTION
> 🤖 SPARQ agent — site lane. Fixes the /capabilities demo-width bug reported by the maintainer in #1675 (bead sq-67qji).

## Problem (issue #1675)
On a desktop viewport, a `/capabilities` demo expanded **inside its own half-column tile**. Each lane is `lg:grid-cols-[232px_1fr]` and the tiles are `sm:grid-cols-2` inside the `1fr` column, so an expanded demo (the ZK / MPC / GeoSPARQL result tables, etc.) was confined to `(viewport − 232px − gaps)/2 ≈ one third of the screen` — cramped and hard to use, exactly the maintainer's complaint.

## Fix
Frontend-design skill governs, and its routing rule keeps demos in the **one** `/capabilities` gallery (don't re-proliferate the collapsed `/surface/*` pages — those are now redirect stubs back here, so the bead's literal "route to `/surface/<slug>`" would be circular; only 2 of 8 demos have a `/showcase` page). So this is **Option B done properly**: give the in-place demo the full width.

- New client component `capability-lane-grid.tsx` owns each lane's open/mount state. The tile grid is unchanged, but an **opened demo's body now renders as a full-content-width `lg:col-span-2` row below the grid**, reclaiming the numbered-spine column. Because the component returns a fragment, the body is a direct grid child of the lane `<section>`, so `lg:col-span-2` spans the whole lane. A collapsed body is `display:none`, so it neither shows nor reserves a grid row (no phantom gap, no tile jump).
- The clicked tile pins its accent + elevation while open; the full-width body carries a header with the surface title, a **"Open the full showcase" link for the flagship demos** (`zk` → `/showcase/zk-car-hire`, `mpc` → `/showcase/mpc-100k`) that honours the maintainer's showcase intent, and a nearby Collapse control.

## Load-bearing invariants preserved (verbatim)
- **Lazy-mount (#1 risk, research/website-redesign.md §3):** a demo body is only rendered once its slug has been opened, and stays mounted (CSS-hidden on collapse) — so re-expanding never re-fetches its code-split chunk. Bundle guard confirms **0 heavy chunks** in the `/capabilities` first-load payload.
- The `data-demo-body` + CSS-hidden-collapse contract asserted by `e2e/capabilities-lazy.spec.ts`.
- The **privacy lane's research-grade caveat strip** (LIVE privacy-claims honesty — the v1 ZK verifier is not externally audited; MPC is a faithful in-tab simulation, not a proof of correctness).

## Design note (proceed-and-document)
The bead title suggested "route to a full-width deep/showcase page". That path is only cleanly available for `zk`/`mpc` (the other six demos have no `/showcase` page and their old `/surface/<slug>` routes are redirect stubs pointing back to `/capabilities`). Rather than fabricate six pages and reverse the redesign's page-collapse, I kept the single-gallery IA and made the in-place demo full-width, plus added the showcase link where one exists. Happy to steer to hard-redirects if preferred.

## Files changed (site/ only)
- `site/src/components/capabilities/capability-lane-grid.tsx` (new — client grid + full-width demo bodies + privacy caveat strip)
- `site/src/components/capabilities/capability-row.tsx` (split `DemoTile` → controlled `DemoTileButton` + exported full-width `CapabilityDemoBody`; `TileShell` gains an `active` prop)
- `site/src/components/capabilities/capability-lane.tsx` (delegates the interactive tile grid to `CapabilityLaneGrid`)

No benchmark-data or benchmarks-page files touched (concurrent agent's lane).

## Gates
- `npm install` + `npm run build` (static export) — **green end-to-end**, `/capabilities` emitted to `out/`; `postbuild` bundle guard **PASS** (0 heavy chunks in `/` and `/capabilities` first-load; basePath `/sparq` + `images.unoptimized` preserved). WASM prereq satisfied by reusing prebuilt bundles (build artifact only, no `crates/` change).
- `npm run lint` — clean. `tsc --noEmit` — clean.
- `e2e/capabilities-lazy.spec.ts` — **3/3 pass**. Site unit tests — **309/309 pass**.
- `scripts/check-privacy-claims.sh` — OK. No new dependencies.

Not armed — leaving for review.