### PR TITLE
fix(engine): decline sargable f64 FILTER fast path for f64-inexact xsd:decimal (sq-lr2ii)

### DIFF
--- a/bench/feature-off-declarations/1766.json
+++ b/bench/feature-off-declarations/1766.json
@@ -1,0 +1,5 @@
+{
+  "pr": 1766,
+  "date": "2026-07-07",
+  "reason": "sq-lr2ii: always-compiled sparq-core Graph::has_high_precision_decimal + helpers/field and the sparq-engine extract_sargable/split_sargable &Graph guard move the feature-OFF sparq-wasm bundle bytes"
+}

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -62,6 +62,15 @@ pub struct Graph {
     /// FILTER / ORDER BY / MIN/MAX read the timeline value O(1) from the cache
     /// instead of materialising the term and re-parsing its lexical per row.
     temporals: TempData,
+    /// [OPUS-4.8] (sq-lr2ii) Memoised guard against the engine's f64 sargable-FILTER fast
+    /// path deciding a comparison wrongly for an f64-INEXACT decimal. `0` = not yet computed,
+    /// `1` = known to hold NO such decimal (fast path safe), `2` = holds at least one (the
+    /// engine must decline the fast path and use the exact evaluator). Lazily filled by
+    /// [`has_high_precision_decimal`](Self::has_high_precision_decimal); reset to `0` by a
+    /// delta that appends terms (`apply_delta_mem`) so it is recomputed over the grown
+    /// dictionary. Interior-mutable so a shared `&Graph` can populate it; never observable in
+    /// results (pure correctness gate).
+    high_precision_decimal: std::sync::atomic::AtomicU8,
     /// Named graphs (each a self-contained `Graph`), keyed by their name term. Empty for the
     /// usual single-default-graph load; populated by [`load_dataset`](Self::load_dataset) from
     /// N-Quads / TriG so the engine can evaluate `GRAPH <iri> { … }` / `GRAPH ?g { … }`.
@@ -613,6 +622,39 @@ fn numeric_of(term: &Term) -> f64 {
     match term {
         Term::Literal(l) if is_numeric_dt(l) => l.value().parse::<f64>().unwrap_or(f64::NAN),
         _ => f64::NAN,
+    }
+}
+
+/// [OPUS-4.8] (sq-lr2ii) `true` iff dict id `id` is an `xsd:decimal` literal whose lexical
+/// form carries MORE than 15 significant digits — i.e. its f64 image may be inexact, so the
+/// engine's f64 sargable FILTER fast path is unsafe for it. Only `xsd:decimal` is checked:
+/// integer exactness is handled by the engine's constant-side guard and float/double values
+/// are their own f64. See [`Graph::has_high_precision_decimal`].
+fn is_high_precision_decimal(dict: &Dict, id: Id) -> bool {
+    matches!(dict.term_parts(id),
+        dict::TermParts::Lit { value, datatype, lang: None }
+            if datatype == xsd::DECIMAL.as_str() && decimal_significant_digits(value) > 15)
+}
+
+/// Significant decimal digits of a plain decimal lexical `[+-]?digits(.digits)?`: leading
+/// integer zeros and leading fractional zeros (for a value `< 1`) are not significant, e.g.
+/// `007.50` -> 3, `0.00123` -> 3, `1.000000000000000001` -> 19. `usize::MAX` for a lexical that
+/// is not a plain decimal (treated as unsafe by the `> 15` guard). Kept LOCAL to sparq-core:
+/// this crate is the leanest tier and cannot depend on `sparq-substrate`; the count mirrors the
+/// engine's `sig_digits` (constant-side guard) so the two round-trip decisions stay consistent.
+fn decimal_significant_digits(s: &str) -> usize {
+    let s = s.trim();
+    let s = s.strip_prefix(['+', '-']).unwrap_or(s);
+    let (int, frac) = s.split_once('.').unwrap_or((s, ""));
+    if (int.is_empty() && frac.is_empty()) || !int.bytes().chain(frac.bytes()).all(|c| c.is_ascii_digit()) {
+        return usize::MAX;
+    }
+    let int = int.trim_start_matches('0');
+    let frac = frac.trim_end_matches('0');
+    if int.is_empty() {
+        frac.trim_start_matches('0').len()
+    } else {
+        int.len() + frac.len()
     }
 }
 
@@ -1425,6 +1467,7 @@ impl Graph {
             store,
             numerics,
             temporals,
+            high_precision_decimal: std::sync::atomic::AtomicU8::new(0),
             named: Vec::new(),
             graph_prefix_index: std::sync::Mutex::new(None),
             #[cfg(feature = "mmap")]
@@ -1460,6 +1503,8 @@ impl Graph {
             // numeric literals when sparse, freeing the dense f64-per-term Vec.
             numerics: self.numerics.into_sparse_if_worthwhile(),
             temporals: self.temporals.into_sparse_if_worthwhile(),
+            // sq-lr2ii: re-encoding keeps the same values; recompute the guard lazily.
+            high_precision_decimal: std::sync::atomic::AtomicU8::new(0),
             named: self.named,
             graph_prefix_index: std::sync::Mutex::new(None),
             #[cfg(feature = "mmap")]
@@ -1673,6 +1718,7 @@ impl Graph {
             store,
             numerics,
             temporals,
+            high_precision_decimal: std::sync::atomic::AtomicU8::new(0),
             named,
             graph_prefix_index: std::sync::Mutex::new(None),
             wal: None,
@@ -2455,6 +2501,37 @@ impl Graph {
         }
     }
 
+    /// [OPUS-4.8] (sq-lr2ii) `true` if the graph holds any `xsd:decimal` literal with MORE
+    /// than 15 significant digits — a value the f64 `numerics` cache CANNOT represent exactly,
+    /// so the engine's f64-based sargable FILTER fast path could decide `=`/`<`/`>`/`<=`/`>=`
+    /// WRONGLY for it (e.g. `"1.000000000000000001"^^xsd:decimal` shares the f64 `1.0` with the
+    /// constant `1`, yet is not equal to it). The engine consults this at the sargable-decision
+    /// point to DECLINE that fast path and fall back to the exact general evaluator; a graph
+    /// without any such decimal keeps the fast path (a decimal of `<= 15` significant digits
+    /// round-trips through f64 unambiguously, and a large-integer collision needs a `> 15`-digit
+    /// CONSTANT, which the engine already declines). Integers/float/double are exempt: an
+    /// integer's exactness is the constant-side guard's job and a float/double's value IS its f64.
+    ///
+    /// Memoised (see `high_precision_decimal`): the first call scans the graph's numeric terms
+    /// once (short-circuiting on the first offender); later calls are an atomic load. A delta
+    /// that appends terms resets the memo so it is recomputed over the grown dictionary. This is
+    /// a CONSERVATIVE, graph-wide gate — one offending decimal declines the numeric fast path for
+    /// every comparison on the graph — chosen for safety (correctness is never at risk; only the
+    /// pushdown optimisation is skipped for affected graphs).
+    pub fn has_high_precision_decimal(&self) -> bool {
+        use std::sync::atomic::Ordering::Relaxed;
+        match self.high_precision_decimal.load(Relaxed) {
+            2 => true,
+            1 => false,
+            _ => {
+                let found = (1..=self.dict.len() as Id)
+                    .any(|id| self.numerics.lookup(id).is_some() && is_high_precision_decimal(&self.dict, id));
+                self.high_precision_decimal.store(if found { 2 } else { 1 }, Relaxed);
+                found
+            }
+        }
+    }
+
     pub fn len(&self) -> usize {
         self.store.len()
     }
@@ -2553,6 +2630,8 @@ impl Graph {
             store: self.store.fork(),
             numerics: self.numerics.fork(),
             temporals: self.temporals.fork(),
+            // sq-lr2ii: the fork shares the same values; recompute the guard lazily.
+            high_precision_decimal: std::sync::atomic::AtomicU8::new(0),
             named: self.named.iter().map(|(name, g)| (name.clone(), g.fork())).collect(),
             // A fork is a fresh logical copy; rebuild the prefix index lazily on first use.
             graph_prefix_index: std::sync::Mutex::new(None),
@@ -3047,6 +3126,15 @@ impl Graph {
         // Keep the numeric- and temporal-filter caches covering the grown dictionary.
         self.numerics.extend_for(&self.dict, old_len);
         self.temporals.extend_for(&self.dict, old_len);
+        // sq-lr2ii: an inserted term may be an f64-inexact decimal. If the sargable-safety
+        // guard was memoised as "no such decimal" (1), reset it to recompute over the grown
+        // dictionary; a "found" (2) verdict is monotonic (terms are never removed) and stays.
+        let _ = self.high_precision_decimal.compare_exchange(
+            1,
+            0,
+            std::sync::atomic::Ordering::Relaxed,
+            std::sync::atomic::Ordering::Relaxed,
+        );
         self.store.apply_delta(&ins_ids, &del_ids);
     }
 
@@ -8871,6 +8959,66 @@ mod tests {
         );
         // None: an IRI is not numeric.
         assert_eq!(g.exact_numeric_lexical(g.id_of(&Term::NamedNode(NamedNode::new_unchecked("http://ex/s"))).unwrap()), None);
+    }
+
+    /// [OPUS-4.8] sq-lr2ii — `decimal_significant_digits` counts significant digits, ignoring
+    /// leading integer zeros and leading fractional zeros, and rejects non-decimals.
+    #[test]
+    fn decimal_significant_digits_counts() {
+        assert_eq!(decimal_significant_digits("1"), 1);
+        assert_eq!(decimal_significant_digits("1.5"), 2);
+        assert_eq!(decimal_significant_digits("007.50"), 2, "leading int zeros + trailing frac zeros dropped: 7.5");
+        assert_eq!(decimal_significant_digits("0.00123"), 3, "leading fractional zeros are not significant");
+        assert_eq!(decimal_significant_digits("-1.000000000000000001"), 19, "sign stripped; 19 sig digits");
+        assert_eq!(decimal_significant_digits("+2.5"), 2);
+        assert_eq!(decimal_significant_digits("0.0"), 0, "zero has no significant digits");
+        // Non-decimal lexicals are treated as unsafe (usize::MAX > 15).
+        assert_eq!(decimal_significant_digits("1e5"), usize::MAX);
+        assert_eq!(decimal_significant_digits(""), usize::MAX);
+        assert_eq!(decimal_significant_digits("abc"), usize::MAX);
+    }
+
+    /// [OPUS-4.8] sq-lr2ii — `has_high_precision_decimal` is the engine's sargable-safety gate:
+    /// TRUE iff the graph holds an `xsd:decimal` with > 15 significant digits (an f64-inexact
+    /// value). Integers past 2^53, floats/doubles, and <=15-digit decimals do NOT set it.
+    #[test]
+    fn has_high_precision_decimal_flags_only_inexact_decimals() {
+        let xsd_ = |ty: &str| format!("http://www.w3.org/2001/XMLSchema#{ty}");
+        let build = |obj: &str| {
+            let nt = format!("<http://ex/s> <http://ex/p> {obj} .\n");
+            Graph::load_str(&nt, "ntriples").unwrap()
+        };
+
+        // The bug value: 19-sig-digit decimal collapsing onto f64 1.0.
+        assert!(build(&format!("\"1.000000000000000001\"^^<{}>", xsd_("decimal"))).has_high_precision_decimal());
+        // A <1 high-precision decimal.
+        assert!(build(&format!("\"0.1234567890123456789\"^^<{}>", xsd_("decimal"))).has_high_precision_decimal());
+
+        // NOT flagged: an exactly-representable decimal (<=15 sig digits).
+        assert!(!build(&format!("\"1.5\"^^<{}>", xsd_("decimal"))).has_high_precision_decimal());
+        assert!(!build(&format!("\"123456789012345\"^^<{}>", xsd_("decimal"))).has_high_precision_decimal(), "15 sig digits round-trips");
+        // NOT flagged: a big integer (constant-side guard's job, not this one).
+        assert!(!build(&format!("\"9007199254740993\"^^<{}>", xsd_("integer"))).has_high_precision_decimal());
+        // NOT flagged: a high-precision double — its value IS its f64.
+        assert!(!build(&format!("\"1.000000000000000001\"^^<{}>", xsd_("double"))).has_high_precision_decimal());
+        // NOT flagged: an empty / non-numeric graph.
+        assert!(!build("\"hello\"").has_high_precision_decimal());
+        assert!(!Graph::new().has_high_precision_decimal());
+    }
+
+    /// [OPUS-4.8] sq-lr2ii — the memoised flag must NOT go stale: inserting an f64-inexact
+    /// decimal via a delta AFTER the flag was computed as `false` must flip it to `true`.
+    #[test]
+    fn has_high_precision_decimal_memo_survives_delta_insert() {
+        let mut g = Graph::load_str("<http://ex/s> <http://ex/p> \"3\"^^<http://www.w3.org/2001/XMLSchema#integer> .\n", "ntriples").unwrap();
+        // Compute (and memoise) the flag as false over the integer-only graph.
+        assert!(!g.has_high_precision_decimal());
+        // Insert a high-precision decimal; the memo must be invalidated + recomputed to true.
+        let s = Term::NamedNode(NamedNode::new_unchecked("http://ex/s"));
+        let p = Term::NamedNode(NamedNode::new_unchecked("http://ex/d"));
+        let o = Term::Literal(Literal::new_typed_literal("2.000000000000000003", xsd::DECIMAL));
+        g.apply_delta(&[[s, p, o]], &[]).unwrap();
+        assert!(g.has_high_precision_decimal(), "delta-inserted inexact decimal must flip the memo");
     }
 
     /// The full sorted term-triple set of a graph (overlay merged), for state comparison.

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -1192,7 +1192,7 @@ fn single_pattern_scan_json(graph: &Graph, pattern: &GraphPattern, flush: Option
     }
     // Only pushed-down sargable numeric FILTER(s); a residual filter needs the general
     // expression evaluator.
-    let (pat_filters, residual) = split_sargable(&patterns, &filters);
+    let (pat_filters, residual) = split_sargable(graph, &patterns, &filters);
     if !residual.is_empty() {
         return None;
     }
@@ -1751,7 +1751,7 @@ fn try_capped(graph: &Graph, inner: &GraphPattern, cap: usize) -> Result<Option<
             if patterns.len() != 1 {
                 return Ok(None);
             }
-            let (pat_filters, residual) = split_sargable(&patterns, &filters);
+            let (pat_filters, residual) = split_sargable(graph, &patterns, &filters);
             if !residual.is_empty() {
                 return Ok(None);
             }
@@ -1861,7 +1861,7 @@ fn count_single_filtered(
     // Resolve every filter to (canonical position, comparison); all must be sargable.
     let mut cmps: Vec<(usize, ScanCmp)> = Vec::with_capacity(filters.len());
     for f in filters {
-        let (var, cmp) = extract_sargable(f)?;
+        let (var, cmp) = extract_sargable(graph, f)?;
         let pos = pos_vars.iter().position(|v| v.as_ref() == Some(&var))?;
         cmps.push((pos, cmp));
     }
@@ -2377,7 +2377,7 @@ fn eval_graph_pattern_inner(graph: &Graph, local: &mut LocalVocab, p: &GraphPatt
         // Push sargable numeric FILTERs down into the binary-plan scans (the WCOJ
         // path applies them afterwards); apply the rest normally.
         let (mut b, residual) = if bgp_uses_binary(&patterns) {
-            let (pat_filters, residual) = split_sargable(&patterns, &filters);
+            let (pat_filters, residual) = split_sargable(graph, &patterns, &filters);
             // [OPUS-4.8] (sq-5zf8i / §A4) Acyclic BGP: run the Yannakakis full-semijoin
             // prepass before the binary join when the opt-in `yannakakis` feature is on
             // (it internally cost-gates + falls back to `eval_bgp_binary`, threading the
@@ -3282,7 +3282,14 @@ fn inline_pass_values(cmp: ScanCmp) -> Option<(u32, u32)> {
 /// Recognises a FILTER of the form `?v OP constant` (or the symmetric
 /// `constant OP ?v`) over a numeric or temporal constant, returning the variable
 /// and the comparison to push down.
-fn extract_sargable(e: &Expression) -> Option<(Variable, ScanCmp)> {
+///
+/// [OPUS-4.8] (sq-lr2ii) A NUMERIC comparison is DECLINED (returns `None`) when the graph
+/// holds an f64-inexact decimal ([`Graph::has_high_precision_decimal`]): the f64 `numerics`
+/// cache the scan probes could then decide `=`/`<`/`>`/`<=`/`>=` wrongly for that value (e.g.
+/// `"1.000000000000000001"^^xsd:decimal` collapses onto the f64 `1.0`), so such comparisons
+/// fall back to the exact general evaluator instead. Temporal pushdown is unaffected, and a
+/// graph with no f64-inexact decimal keeps the numeric fast path.
+fn extract_sargable(graph: &Graph, e: &Expression) -> Option<(Variable, ScanCmp)> {
     fn lit_num(e: &Expression) -> Option<f64> {
         match e {
             Expression::Literal(l) if is_numeric_dt(l) => {
@@ -3335,7 +3342,14 @@ fn extract_sargable(e: &Expression) -> Option<(Variable, ScanCmp)> {
     for (var, konst, op) in [(l, r, on_left), (r, l, on_right)] {
         let Some(v) = var_of(var) else { continue };
         if let Some(c) = lit_num(konst) {
-            return Some((v, num_cmp(op, c)));
+            // sq-lr2ii: decline the f64 numeric fast path when the graph holds an f64-inexact
+            // decimal — the scan's per-row f64 compare could be wrong for it. A numeric
+            // constant is never also a temporal one, so declining here yields `None` for this
+            // orientation; the exact general evaluator handles the residual FILTER correctly.
+            if !graph.has_high_precision_decimal() {
+                return Some((v, num_cmp(op, c)));
+            }
+            continue;
         }
         if let Some(t) = lit_temp(konst) {
             return Some((v, ScanCmp::Temp(op, t)));
@@ -3362,7 +3376,7 @@ fn pattern_var_pos(tp: &TriplePattern, var: &Variable) -> Option<usize> {
 /// Splits FILTERs into per-pattern sargable numeric predicates (pushed into the
 /// scan of the first pattern that binds the variable) and the residual filters
 /// (applied normally afterwards).
-pub(crate) fn split_sargable(patterns: &[TriplePattern], filters: &[Expression]) -> (Vec<Option<(usize, ScanCmp)>>, Vec<Expression>) {
+pub(crate) fn split_sargable(graph: &Graph, patterns: &[TriplePattern], filters: &[Expression]) -> (Vec<Option<(usize, ScanCmp)>>, Vec<Expression>) {
     // zk-trace: a sargable FILTER pushed into the scan would make the scan
     // record only the POST-filter rows (the rows that PASSED), losing the
     // FILTER obligation and under-capturing the input set — the proof must
@@ -3377,7 +3391,7 @@ pub(crate) fn split_sargable(patterns: &[TriplePattern], filters: &[Expression])
     let mut pat_filters: Vec<Option<(usize, ScanCmp)>> = vec![None; patterns.len()];
     let mut residual = Vec::new();
     for f in filters {
-        if let Some((var, cmp)) = extract_sargable(f) {
+        if let Some((var, cmp)) = extract_sargable(graph, f) {
             if let Some((i, pos)) = patterns
                 .iter()
                 .enumerate()
@@ -7172,9 +7186,9 @@ fn columnar_filter(graph: &Graph, b: &Bindings, expr: &Expression) -> Option<Vec
     }
 
     // Operator-shape check: only a single sargable NUMERIC comparison is eligible.
-    // NOTE: do NOT use `extract_sargable(expr)?` — the `?` operator returns None without
+    // NOTE: do NOT use `extract_sargable(graph, expr)?` — the `?` operator returns None without
     // recording the decline, making the I5 counter miss non-sargable expressions. [SONNET-4.6]
-    let (var, cmp) = match extract_sargable(expr) {
+    let (var, cmp) = match extract_sargable(graph, expr) {
         None => {
             vec_dispatch::record_decline();
             return None;

--- a/crates/sparq-engine/src/explain.rs
+++ b/crates/sparq-engine/src/explain.rs
@@ -306,7 +306,7 @@ fn render_conjunctive(graph: &Graph, p: &GraphPattern, out: &mut String, d: usiz
     }
 
     // Binary plan: split the sargable filters, then replay the GOO loop.
-    let (pat_filters, residual) = exec::split_sargable(&patterns, &filters);
+    let (pat_filters, residual) = exec::split_sargable(graph, &patterns, &filters);
     let pfilter = |i: usize| -> Option<(usize, ScanCmp)> { pat_filters.get(i).copied().flatten() };
     let _ = writeln!(
         out,

--- a/crates/sparq-engine/tests/sargable_decimal_precision.rs
+++ b/crates/sparq-engine/tests/sargable_decimal_precision.rs
@@ -1,0 +1,125 @@
+//! [OPUS-4.8] sq-lr2ii — regression tests for the sargable FILTER fast path collapsing a
+//! high-precision `xsd:decimal` value onto its (lossy) f64 image.
+//!
+//! The engine pushes a `?v OP constant` numeric FILTER over a single pattern down into the
+//! scan, deciding each row via the O(1) f64 `numerics` cache (`exec::extract_sargable` ->
+//! `ScanCmp::Num`). For a decimal whose value CANNOT be represented exactly in f64 — e.g.
+//! `"1.000000000000000001"^^xsd:decimal`, whose nearest f64 is exactly `1.0` — the f64
+//! verdict is wrong: `?v = 1` wrongly matches, `?v > 1` wrongly misses. The EXPRESSION path
+//! (`BIND((?v = 1) AS ?b)`) is correct (it does the exact `cmp_decimal_str` recheck), so the
+//! two paths DIVERGED on the same data — the load-bearing invariant these tests pin.
+//!
+//! The fix DECLINES the sargable fast path whenever the graph holds an f64-inexact decimal,
+//! routing the comparison to the exact general evaluator (which the BIND oracle below shows
+//! is correct). These assertions are RED before the fix and GREEN after. [OPUS-4.8]
+
+use sparq_core::Graph;
+use sparq_engine::query;
+
+const HP: &str = "1.000000000000000001"; // 19 sig digits; nearest f64 is exactly 1.0
+
+fn graph_with(object: &str) -> Graph {
+    let ttl = format!(
+        "@prefix ex: <http://example.org/> .\n\
+         @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+         ex:n ex:val {object} .\n"
+    );
+    Graph::load_str(&ttl, "turtle").expect("load turtle")
+}
+
+/// Rows returned by `SELECT ?v WHERE { ex:n ex:val ?v . FILTER(<cond>) }` — the SARGABLE
+/// single-pattern + numeric-FILTER shape that `split_sargable`/`extract_sargable` push down.
+fn sargable_count(g: &Graph, cond: &str) -> usize {
+    let q = format!(
+        "PREFIX ex: <http://example.org/> \
+         SELECT ?v WHERE {{ ex:n ex:val ?v . FILTER({cond}) }}"
+    );
+    query(g, &q).expect("query error").rows.len()
+}
+
+/// The oracle: the EXPRESSION path via BIND, which does the exact recheck. `true` iff the
+/// stored value satisfies the condition. Never rides the sargable scan pushdown.
+fn oracle_true(g: &Graph, cond: &str) -> bool {
+    let q = format!(
+        "PREFIX ex: <http://example.org/> \
+         SELECT ?b WHERE {{ ex:n ex:val ?v . BIND(({cond}) AS ?b) }}"
+    );
+    let r = query(g, &q).expect("query error");
+    assert_eq!(r.rows.len(), 1);
+    r.rows[0][0]
+        .as_ref()
+        .map(|t| t.to_string().contains("true"))
+        .unwrap_or(false)
+}
+
+#[test]
+fn high_precision_decimal_equality_does_not_match_integer() {
+    // "1.000000000000000001" != 1, so FILTER(?v = 1) must return ZERO rows.
+    let g = graph_with(&format!(r#""{HP}"^^xsd:decimal"#));
+    assert_eq!(sargable_count(&g, "?v = 1"), 0, "?v = 1 must not match {HP}");
+}
+
+#[test]
+fn high_precision_decimal_greater_than_integer_matches() {
+    // "1.000000000000000001" > 1, so FILTER(?v > 1) must return ONE row.
+    let g = graph_with(&format!(r#""{HP}"^^xsd:decimal"#));
+    assert_eq!(sargable_count(&g, "?v > 1"), 1, "?v > 1 must match {HP}");
+}
+
+#[test]
+fn high_precision_decimal_all_operators_match_oracle() {
+    // Every comparison operator: the sargable count must equal the exact BIND oracle.
+    // Expected (from the bead): = 0, > 1, < 0, >= 1, <= 0.
+    let g = graph_with(&format!(r#""{HP}"^^xsd:decimal"#));
+    for (cond, want) in [("?v = 1", 0), ("?v > 1", 1), ("?v < 1", 0), ("?v >= 1", 1), ("?v <= 1", 0)] {
+        let got = sargable_count(&g, cond);
+        let oracle = usize::from(oracle_true(&g, cond));
+        assert_eq!(got, want, "sargable {cond}: got {got} rows, want {want}");
+        assert_eq!(got, oracle, "sargable {cond} ({got}) diverged from BIND oracle ({oracle})");
+    }
+}
+
+#[test]
+fn ordinary_decimals_still_use_fast_path_correctly() {
+    // A graph WITHOUT any f64-inexact decimal must keep the fast path AND stay correct:
+    // guards against the fix over-declining / regressing exact-representable values.
+    let g = graph_with(r#""1.5"^^xsd:decimal"#);
+    assert_eq!(sargable_count(&g, "?v = 1.5"), 1);
+    assert_eq!(sargable_count(&g, "?v > 1"), 1);
+    assert_eq!(sargable_count(&g, "?v < 2"), 1);
+    assert_eq!(sargable_count(&g, "?v = 1"), 0);
+    assert_eq!(sargable_count(&g, "?v >= 1.5"), 1);
+    assert_eq!(sargable_count(&g, "?v <= 1.4"), 0);
+}
+
+#[test]
+fn integer_fast_path_unaffected() {
+    // Plain integers (no decimal in the graph) keep working across operators.
+    let g = graph_with(r#""3"^^xsd:integer"#);
+    assert_eq!(sargable_count(&g, "?v = 3"), 1);
+    assert_eq!(sargable_count(&g, "?v > 2"), 1);
+    assert_eq!(sargable_count(&g, "?v < 3"), 0);
+    assert_eq!(sargable_count(&g, "?v >= 3"), 1);
+}
+
+#[test]
+fn property_high_precision_decimals_match_oracle() {
+    // Deterministic property guard: for a spread of decimals that collapse onto a small
+    // integer's f64 (fraction just above / just below), the sargable path must agree with
+    // the exact BIND oracle for every operator. No proptest dep — a fixed crafted sample.
+    let cases = [
+        "1.000000000000000001",  // > 1, f64 -> 1.0
+        "0.999999999999999999",  // < 1, f64 -> 1.0
+        "2.000000000000000003",  // > 2, f64 -> 2.0
+        "9.999999999999999999",  // < 10, f64 -> 10.0
+        "1.0000000000000000",    // == 1 exactly (trailing zeros; f64 -> 1.0)
+    ];
+    for val in cases {
+        let g = graph_with(&format!(r#""{val}"^^xsd:decimal"#));
+        for cond in ["?v = 1", "?v > 1", "?v < 1", "?v >= 1", "?v <= 1", "?v = 2", "?v > 2", "?v < 10"] {
+            let got = sargable_count(&g, cond);
+            let oracle = usize::from(oracle_true(&g, cond));
+            assert_eq!(got, oracle, "value {val}, {cond}: sargable {got} != oracle {oracle}");
+        }
+    }
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -379,6 +379,16 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   (a vendored) `spargebra` with `sparql-12` + `sep-0006`.
 - **Only SELECT/ASK** go through `query`/`query_json`/`count`; CONSTRUCT/DESCRIBE have their own
   functions, and a form mismatch is a clean `Err` (e.g. `ask()` on a SELECT).
+- **Numeric FILTER comparisons are VALUE-EXACT, incl. high-precision `xsd:decimal`** (`sq-lr2ii`).
+  A single-pattern `?v OP const` numeric FILTER is normally pushed into the scan and decided via the
+  O(1) f64 `numerics` cache (`extract_sargable`). Because an f64 cannot represent a decimal with
+  `> 15` significant digits exactly (e.g. `"1.000000000000000001"^^xsd:decimal` shares the f64 `1.0`
+  with the integer `1`), that fast path is **declined** whenever the graph holds such a decimal
+  (`Graph::has_high_precision_decimal`) OR the constant itself has `> 15` significant digits — the
+  comparison then falls back to the exact evaluator (`=`/`<`/`>`/`<=`/`>=` decided by exact decimal
+  string arithmetic, matching the `BIND((?v = c) AS ?b)` expression path). The decline is
+  graph-wide/conservative (correctness first): a graph carrying one high-precision decimal skips the
+  numeric-pushdown optimisation for all its numeric FILTERs, never the wrong answer.
 - **`SELECT *`** never exposes blank-node "variables" (`_:x` in a pattern is an existential var).
 - **`update` vs `update_in_place` vs `update_in_place_atomic`** — `update` returns a fresh `Graph`
   (input borrowed, untouched, atomic by construction); `update_in_place(&mut g, …)` mutates via the


### PR DESCRIPTION
> 🤖 SPARQ agent — this PR was authored by an automated SPARQ agent (Opus 4.8, 1M ctx). Please review with that in mind.

Fixes **sq-lr2ii** (P1).

## The bug

The single-pattern `?v OP const` numeric FILTER is pushed into the scan and each row is decided via the O(1) f64 `numerics` cache (`exec::extract_sargable` → `ScanCmp::Num`, probed by `ScanCmp::test_id`). An `xsd:decimal` with **more than 15 significant digits** cannot be represented exactly in f64, so `"1.000000000000000001"^^xsd:decimal` (nearest f64 = `1.0`) **collapses onto the constant `1`**:

| query | before | correct |
|---|---|---|
| `FILTER(?v = 1)` | **1 row** | 0 |
| `FILTER(?v > 1)` | **0 rows** | 1 |
| `FILTER(?v <= 1)` | **1 row** | 0 |
| `FILTER(?v < 1)` | 0 | 0 |
| `FILTER(?v >= 1)` | 1 | 1 |

The EXPRESSION path (`BIND((?v = 1) AS ?b)` → `xsd:boolean false`) was already correct (it does the exact `cmp_decimal_str` recheck), so the sargable FILTER path and the expression path **diverged on the same data**.

Root cause: `crates/sparq-engine/src/exec.rs` `extract_sargable` (`fn extract_sargable` / `num_cmp` → `ScanCmp::Num`) — the pushed-down predicate is decided purely by f64 via the `numerics` cache with no exact recheck for a value whose f64 collides with the threshold.

## The fix (safest shape — decline, don't re-engineer the scan)

At the **sargable-decision point**, decline the numeric f64 fast path whenever the graph could carry an offending value, so the FILTER falls back to the exact general evaluator (which is already correct). No exact-decimal compare engine is added to the hot scan.

- **`sparq-core`** — new `Graph::has_high_precision_decimal()`: memoised (`AtomicU8`, lazy — scans numeric terms once, short-circuits on the first offender), `true` iff the graph holds an `xsd:decimal` with `> 15` significant digits. Reset by a delta that appends terms (monotonic `false`→`true`, since terms are never removed). Integers are exempt (a large-integer collision needs a `> 15`-digit **constant**, which the constant-side guard already declines) and float/double are exempt (their value *is* their f64).
- **`sparq-engine`** — `extract_sargable`/`split_sargable` now take `&Graph` and decline the **numeric** branch when the guard fires (temporal pushdown is unaffected). Single choke point, so the binary-plan, single-pattern-count, and `vectorized` columnar-filter seams all inherit the fix.

**Conservative + correctness-first:** one high-precision decimal declines the numeric pushdown optimisation for that whole graph — never the wrong answer, only a (correct) slower path for affected graphs. The `<= 15`-significant-digit injectivity guarantee (distinct `<= 15`-digit decimals have distinct f64) means a graph with no such decimal keeps the fast path unchanged.

## Red → green evidence

New regression suite `crates/sparq-engine/tests/sargable_decimal_precision.rs` — both bead repro cases + a BIND-oracle cross-check + a property-style guard + controls that ordinary decimals/integers keep the fast path.

**RED on `main` (pre-fix):**
```
running 6 tests
test high_precision_decimal_equality_does_not_match_integer ... FAILED
test high_precision_decimal_greater_than_integer_matches ... FAILED
test high_precision_decimal_all_operators_match_oracle ... FAILED
test property_high_precision_decimals_match_oracle ... FAILED
test ordinary_decimals_still_use_fast_path_correctly ... ok
test integer_fast_path_unaffected ... ok

---- high_precision_decimal_equality_does_not_match_integer ----
assertion `left == right` failed: ?v = 1 must not match 1.000000000000000001
  left: 1
 right: 0
---- high_precision_decimal_greater_than_integer_matches ----
assertion `left == right` failed: ?v > 1 must match 1.000000000000000001
  left: 0
 right: 1
test result: FAILED. 2 passed; 4 failed
```
(Note the control tests `ordinary_decimals_*` / `integer_fast_path_unaffected` pass on `main` — the bug is specific to f64-inexact decimals.)

**GREEN with the fix:** `test result: ok. 6 passed; 0 failed`, plus new sparq-core unit tests `decimal_significant_digits_counts`, `has_high_precision_decimal_flags_only_inexact_decimals`, `has_high_precision_decimal_memo_survives_delta_insert`.

## Gates run (both feature states)

- `cargo clippy --workspace --all-targets -- -D warnings` — clean (default).
- `cargo clippy -p sparq-engine --all-targets --features vectorized,zk,cs-planner,dp-planner,semijoin-bitmap,yannakakis --features sparq-core/mmap -- -D warnings` — clean.
- `cargo test -p sparq-core -p sparq-engine` (default) — all green.
- `cargo test -p sparq-engine --features vectorized,zk,cs-planner,dp-planner,semijoin-bitmap,yannakakis` — all green (incl. the vectorized byte-identity differential — the columnar seam declines identically).
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean (the new public-doc links target the public `has_high_precision_decimal`; no link into a private/cfg-gated item).

## FILTER-rewrite (#1735) interaction — noted, NOT enabled

The bead asks whether this unblocks numeric FILTER-algebra rewrite constants (#1735 fires only for IRI constants partly because of this bug). This fix makes the **runtime numeric comparison** value-exact (via decline-to-exact), so a numeric rewrite would no longer be tripped by the f64-collapse class for equality. However, the guard here declines the f64 fast path rather than making it exact, so enabling numeric rewrite constants is a **separate** decision (it would want the constant-side `> 15`-digit rule + the same exact fallback). **This PR does not enable it** — flagging only, per the bead.

## feature-OFF wasm bundle

The fix is always-compiled `sparq-core`/`sparq-engine` code (a method, two helpers, a field, and the sargable guard), so the feature-OFF `sparq-wasm` bundle bytes move intentionally — declared in `bench/feature-off-declarations/`.

Do **not** auto-merge — leaving arming to the orchestrator.