### PR TITLE
ci(test-selection): additional-readers monotone union closes residuals 1+2 (sq-m4bxc) [FABLE-5]

### DIFF
--- a/ci/path-ownership.toml
+++ b/ci/path-ownership.toml
@@ -18,14 +18,29 @@
 # a `safe=true` entry for a trigger/crate path is unreachable (steps 1-2 win
 # first), and the map-validity + audit tests forbid such an entry anyway.
 #
-# THREE VERDICT FORMS (design §4.2), nothing else:
-#   [[map]] pattern = "<glob>"  crates = ["a", "b"]   # attribute to consumer crates
-#   [[map]] pattern = "<glob>"  safe   = true         # PROVEN inert for the Rust matrix
+# VERDICT FORMS (design §4.2):
+#   [[map]] pattern = "<glob>"  crates  = ["a", "b"]  # attribute an OUT-OF-CRATE path
+#   [[map]] pattern = "<glob>"  safe    = true        # PROVEN inert for the Rust matrix
+#   [[map]] pattern = "<glob>"  readers = ["a", "b"]  # ADDITIONAL-READERS (sq-m4bxc)
 #   (an unmatched path falls through to the implicit mode=full default)
 # `pattern` is repo-relative POSIX; `dir/**` matches the dir or anything beneath
-# it, otherwise fnmatch. Every `crates` name must be a live workspace member and
-# every pattern root must exist on disk OR be a fetched/generated suite (the
-# map-validity test uses a git-ignore + scripts/fetch-*.sh allowlist, #1392).
+# it, otherwise fnmatch. Every `crates`/`readers` name must be a live workspace
+# member and every pattern root must exist on disk OR be a fetched/generated
+# suite (the map-validity test uses a git-ignore + scripts/fetch-*.sh allowlist,
+# #1392).
+#
+# ADDITIONAL-READERS (`readers`, sq-m4bxc [FABLE-5]) — the ONE verdict form the
+# selector consults EVEN FOR A CRATE-OWNED PATH. `crates`/`safe` are consulted
+# only for a path that is neither a trigger nor inside a crate dir (steps 1-2 win
+# first); `readers` is different: it UNIONS the listed crates into the affected
+# set IN ADDITION to the path's normal prefix owner, without changing the
+# ownership verdict. It closes the case where crate R #[cfg(test)]-reads a
+# SIBLING crate O's committed input but a real `R -> O` cargo dep would be a
+# forbidden cycle (so no reverse-closure attribution can reach R). It is MONOTONE
+# / fail-safe: adding a `readers` entry can only ENLARGE the run set (it never
+# rescues an unowned/unmapped path from mode=full), so it never introduces an
+# unsound skip (§2). The out-of-crate-input audit (scripts/ci_audit_inputs.py)
+# treats a sibling read as covered iff the reader is listed here.
 
 # ---------------------------------------------------------------------------
 # [triggers] — INFORMATIONAL MIRROR of ci_select.py `_FULL_TRIGGERS` (§4.1).
@@ -142,6 +157,31 @@ crates = ["sparq-engine"]
 [[map]]
 pattern = "bench/zk-compose/**"
 crates = ["sparq-zk-compose"]
+
+# ---------------------------------------------------------------------------
+# ADDITIONAL-READERS (`readers`, sq-m4bxc [FABLE-5]) — sibling-crate inputs read
+# across a boundary where a real cargo dep edge would be a forbidden CYCLE, so no
+# reverse-dependency closure can attribute them. Each is an AUDIT-PROVEN residual
+# that used to be backstopped only by the nightly FULL run (design §6.1); the
+# monotone union closes it directly. Listing the OWNER crate too is redundant
+# (prefix-ownership already covers it) but harmless and documents every reader.
+# ---------------------------------------------------------------------------
+
+# sparq-zk's #[cfg(test)] module include_str!s sparq-trust's shared secprop-ext
+# vocab (crates/sparq-zk/src/secprop.rs) to assert the two crates' sec-prop IRIs
+# agree. sparq-trust DEPENDS ON sparq-zk (crates/sparq-trust/Cargo.toml), so a
+# sparq-zk -> sparq-trust dep would be a cycle: additional-readers instead.
+[[map]]
+pattern = "crates/sparq-trust/ontologies/zkp-sparql/**"
+readers = ["sparq-zk", "sparq-trust"]
+
+# sparq-reason's compiled-vs-interpreted N3 equivalence + incremental tests read
+# sparq-solid's WAC/ACP/ODRL-spike rule corpus READ-ONLY from ../sparq-solid/rules
+# at runtime. sparq-solid DEPENDS ON sparq-reason (crates/sparq-solid/Cargo.toml),
+# so a sparq-reason -> sparq-solid dep would be a cycle: additional-readers instead.
+[[map]]
+pattern = "crates/sparq-solid/rules/**"
+readers = ["sparq-reason"]
 
 # ---------------------------------------------------------------------------
 # SAFE list — paths AUDIT-PROVEN inert for the Rust matrix (design §4.2). The

--- a/research/change-based-test-selection.md
+++ b/research/change-based-test-selection.md
@@ -140,7 +140,8 @@ selection-logic PR therefore always validates against the full matrix.
 
 ### 4.2 The ownership map — `ci/path-ownership.toml`
 
-A small, checked-in, audited policy file with exactly three verdict forms:
+A small, checked-in, audited policy file. Three ownership-verdict forms plus the
+monotone `readers` union (below):
 
 ```toml
 # Attribute a non-crate path to the crates whose tests read it:
@@ -152,6 +153,12 @@ crates = ["sparq-conformance"]
 [[map]]
 pattern = "research/**"
 safe = true
+
+# Additional-readers: union extra reader crates for a CRATE-OWNED path where a
+# real dep edge would be a cycle (monotone; see below):
+[[map]]
+pattern = "crates/sparq-solid/rules/**"
+readers = ["sparq-reason"]
 
 # Everything unmapped and unowned => mode=full (implicit default).
 ```
@@ -168,6 +175,37 @@ Rules:
 - A map-validity unit test asserts every `crates` name is a current workspace
   member and every literal pattern root exists — the map cannot silently rot
   when crates move.
+
+**Additional-readers (monotone union)** — sq-m4bxc [FABLE-5]. A fourth verdict
+form, `readers = [...]`, added as a *deliberate deviation from pure
+input-relocation*. The two closed residuals were sibling reads across a boundary
+where the "attribute the shared input to both crates" fix is not available: the
+input lives *inside* a crate dir (so crate-prefix ownership, steps 1–2, wins
+before the map is ever consulted for a `crates` attribution) **and** the reading
+crate is not in the owner's reverse-dependency closure. Relocation was rejected
+because it would move a *vendored crypto ontology*
+(`crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl`) and a *crate's core
+authorization rule corpus* (`crates/sparq-solid/rules/*.n3`) out of their owning
+crates and rewrite production `include_str!` / runtime include paths in
+`sparq-trust`, `sparq-solid`, `sparq-zk` and `sparq-reason`. The dep-edge
+alternative is a **cargo cycle** in both cases (`sparq-trust` depends on
+`sparq-zk`; `sparq-solid` depends on `sparq-reason`), so `reason -> solid` /
+`zk -> trust` edges are impossible.
+
+`readers` is the one verdict form consulted **even for a crate-owned path**: it
+UNIONS the listed crates into the changed-crate set *in addition to* the path's
+normal prefix owner, without changing the ownership verdict. This makes it
+strictly **monotone / fail-safe** — adding a `readers` entry can only ENLARGE the
+affected set (it never rescues an unowned/unmapped path from `mode=full`), so it
+cannot introduce the unsound skip §2 forbids; a unit test pins that monotonicity
+property. The out-of-crate-input audit (bead 2) treats a sibling read as covered
+iff the reader is listed in a matching `readers` entry, and the map-validity test
+extends to `readers` names. Residual 3 (`sparq-conformance`'s
+`scoreboard_floors.rs` reading sibling **test sources** at a statically
+unresolvable runtime path) is *not* coverable by `readers` — it stays
+acknowledged, backstopped by the nightly full run, and is tracked for a shared
+floors-crate refactor in its own bead (sq-z1xv8), which conflicts with the
+"no shared test edits" constraint here and so needs its own design pass.
 
 ### 4.3 Fail-closed mechanics
 

--- a/scripts/ci_audit_inputs.py
+++ b/scripts/ci_audit_inputs.py
@@ -107,34 +107,25 @@ class Residual:
 
 
 # --- acknowledged residuals (audit-proven; each has a fix bead) --------------
-# sq-m4bxc tracks relocating these shared inputs to repo-level dirs (mappable)
-# or adding the missing dep edge, so the residual set can shrink to empty.
+# [FABLE-5] sq-m4bxc closed the two sibling-crate include residuals (sparq-zk ->
+# secprop-ext.ttl, sparq-reason -> sparq-solid/rules) with the ci_select
+# additional-readers mechanism (a `readers` entry in ci/path-ownership.toml
+# unions the extra reader into the affected set — monotone, fail-safe). They are
+# now COVERED "additional-readers map" below, not acknowledged. Residual 3 stays:
+# scoreboard_floors.rs reads sibling TEST SOURCES at a runtime-computed workspace
+# path; a `readers` entry cannot cover a statically-unresolvable ('.') read, and
+# the sound fix is a shared floors crate — its own design pass (see the fix bead).
 KNOWN_RESIDUALS: tuple[Residual, ...] = (
-    Residual(
-        "sparq-zk",
-        "crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl",
-        "sparq-zk's #[cfg(test)] module include_str!s sparq-trust's shared "
-        "secprop-ext vocab to assert cross-crate agreement; a sparq-zk -> "
-        "sparq-trust dep is a forbidden cycle (sparq-trust depends on sparq-zk), "
-        "so the reverse closure cannot cover it. Backstop: nightly FULL run "
-        "(design §6.1). Fix: sq-m4bxc (relocate the shared vocab).",
-    ),
-    Residual(
-        "sparq-reason",
-        "crates/sparq-solid/rules",
-        "sparq-reason's incremental-N3 tests read sparq-solid's WAC/ACP rule "
-        "files; sparq-reason has no dep on sparq-solid. Backstop: nightly FULL "
-        "run. Fix: sq-m4bxc (add a dev-dep edge or relocate the rules).",
-    ),
     Residual(
         "sparq-conformance",
         ".",
         "scoreboard_floors.rs reads sibling-crate test sources at a "
         "runtime-computed workspace path to keep floor constants in sync "
         "(sparq-shacl/sparq-geo are dep-covered; sparq-solid is not). The path "
-        "is statically unresolvable (a runtime arg). Backstop: nightly FULL "
-        "run. Fix: sq-m4bxc (assert floors via a shared crate, not by reading "
-        "foreign test sources).",
+        "is statically unresolvable (a runtime arg), so the additional-readers "
+        "mechanism cannot attribute it. Backstop: nightly FULL run (design §6.1). "
+        "Fix: sq-z1xv8 (shared floors crate consumed by the conformance runner "
+        "tests instead of reading foreign test sources — own design pass).",
     ),
 )
 
@@ -361,9 +352,16 @@ def audit_refs(
             )
             continue
 
-        # owner is a different crate D: covered iff reader in reverse-closure(D).
+        # owner is a different crate D: covered iff reader in reverse-closure(D),
+        # OR the ownership map declares this reader an additional-reader for the
+        # path (sq-m4bxc — the selector unions it into the affected set even
+        # though D owns the path; the dep edge that reverse-closure would need is
+        # a forbidden cycle).
         if ref.crate in closures.get(owner, {owner}):
             res.covered.append((ref.crate, ref.resolved, f"dep-closure of {owner}"))
+            continue
+        if ref.crate in cs.additional_readers(ref.resolved, map_entries):
+            res.covered.append((ref.crate, ref.resolved, "additional-readers map"))
             continue
         ack = _ack_for(ref, acks)
         if ack is not None:

--- a/scripts/ci_select.py
+++ b/scripts/ci_select.py
@@ -322,10 +322,13 @@ def _glob_match(path: str, pattern: str) -> bool:
 
 
 def apply_ownership_map(path: str, map_entries: list[dict]) -> tuple[str, list[str]] | None:
-    """First matching map entry wins.
+    """First matching OWNERSHIP-VERDICT entry wins.
 
     Returns ("safe", []) for a SAFE-listed path, ("crates", [names]) for an
-    attributed path, or None if no entry matches (=> caller treats as unowned).
+    attributed path, or None if no verdict entry matches (=> caller treats as
+    unowned). A `readers`-only entry (the additional-readers mechanism, sq-m4bxc)
+    is NOT an ownership verdict — it is applied separately by `additional_readers`
+    — so it is transparent here (skipped, never a verdict and never a raise).
     """
     for entry in map_entries:
         pattern = entry.get("pattern")
@@ -336,9 +339,38 @@ def apply_ownership_map(path: str, map_entries: list[dict]) -> tuple[str, list[s
         crates = entry.get("crates")
         if isinstance(crates, list) and all(isinstance(c, str) for c in crates):
             return ("crates", list(crates))
-        # Malformed entry (matched but neither safe nor a crate list) => fail-safe.
-        raise SelectorError(f"ownership-map entry for {pattern!r} is neither safe nor a crate list")
+        readers = entry.get("readers")
+        if isinstance(readers, list) and all(isinstance(c, str) for c in readers):
+            # additional-readers entry: not an ownership verdict; keep looking so
+            # a later `crates`/`safe` entry can still resolve the path.
+            continue
+        # Matched but neither safe, a crate list, nor readers => fail-safe.
+        raise SelectorError(f"ownership-map entry for {pattern!r} is neither safe, a crate list, nor readers")
     return None
+
+
+def additional_readers(path: str, map_entries: list[dict]) -> list[str]:
+    """[FABLE-5] sq-m4bxc: extra reader crates declared for `path` by `[[map]]`
+    entries carrying a `readers` list — the additional-readers mechanism.
+
+    These crates are UNIONED into the changed-crate set IN ADDITION to `path`'s
+    normal crate-prefix owner (or its `crates` attribution), so a crate that
+    #[cfg(test)] reads a SIBLING crate's committed input — where a real cargo dep
+    edge would be a forbidden cycle (design §4.2) — still has its tests run when
+    that input changes. The union across ALL matching `readers` entries is
+    returned (sorted, deduped). This can only ENLARGE the affected set: it never
+    changes a path's ownership verdict, so the selection is a strict superset of
+    the selection computed WITHOUT these entries (monotone / fail-safe, §2).
+    """
+    out: set[str] = set()
+    for entry in map_entries:
+        pattern = entry.get("pattern")
+        if not isinstance(pattern, str) or not _glob_match(path, pattern):
+            continue
+        readers = entry.get("readers")
+        if isinstance(readers, list) and all(isinstance(c, str) for c in readers):
+            out.update(readers)
+    return sorted(out)
 
 
 # --- the selection ----------------------------------------------------------
@@ -374,18 +406,31 @@ def select(
         if trig is not None:
             file_owners.append((path, "FULL-TRIGGER"))
             return full(trig)
+
+        # [FABLE-5] sq-m4bxc: additional-readers (monotone union). Extra reader
+        # crates declared for this path are added REGARDLESS of ownership — the
+        # union can only ENLARGE the affected set (design §4.2, fail-safe §2). It
+        # never rescues an unowned/unmapped path (that still forces full below),
+        # so the result stays a strict superset of the no-readers selection.
+        extra = additional_readers(path, map_entries)
+        for c in extra:
+            if c not in ws.members:
+                return full(f"ownership map declares unknown additional-reader crate {c!r} for {path}")
+        changed_crates.update(extra)
+        reader_tag = ("+readers:" + "+".join(extra)) if extra else ""
+
         owner = owning_package(path, ws.owners)
         if owner is not None:
             changed_crates.add(owner)
-            file_owners.append((path, owner))
+            file_owners.append((path, owner + reader_tag))
             continue
         verdict = apply_ownership_map(path, map_entries)
         if verdict is None:
-            file_owners.append((path, "UNOWNED"))
+            file_owners.append((path, "UNOWNED" + reader_tag))
             return full(f"unowned, unmapped path forces full run: {path}")
         kind, crates = verdict
         if kind == "safe":
-            file_owners.append((path, "SAFE"))
+            file_owners.append((path, "SAFE" + reader_tag))
             continue
         # kind == "crates": every mapped crate must be a real workspace member,
         # else the map is stale/invalid => fail-safe (design §4.2 validity rule).
@@ -393,7 +438,7 @@ def select(
             if c not in ws.members:
                 return full(f"ownership map attributes {path} to unknown crate {c!r}")
         changed_crates.update(crates)
-        file_owners.append((path, "+".join(crates)))
+        file_owners.append((path, "+".join(crates) + reader_tag))
 
     affected: set[str] = set()
     for c in changed_crates:
@@ -445,15 +490,18 @@ def validate_map(
             continue
         is_safe = entry.get("safe") is True
         crates = entry.get("crates")
-        if not is_safe and crates is None:
-            problems.append(f"{pattern!r}: neither `safe` nor `crates` set")
-        if crates is not None:
-            if not isinstance(crates, list):
-                problems.append(f"{pattern!r}: `crates` must be a list")
+        readers = entry.get("readers")  # sq-m4bxc additional-readers (monotone union)
+        if not is_safe and crates is None and readers is None:
+            problems.append(f"{pattern!r}: none of `safe`, `crates`, `readers` set")
+        for key, val, label in (("crates", crates, "crate"), ("readers", readers, "readers crate")):
+            if val is None:
+                continue
+            if not isinstance(val, list):
+                problems.append(f"{pattern!r}: `{key}` must be a list")
             else:
-                for c in crates:
+                for c in val:
                     if c not in members:
-                        problems.append(f"{pattern!r}: unknown crate {c!r} (not a workspace member)")
+                        problems.append(f"{pattern!r}: unknown {label} {c!r} (not a workspace member)")
         # Pattern-root existence, tolerant of fetched/generated dirs.
         root = pattern[:-3] if pattern.endswith("/**") else pattern
         root = root.split("*", 1)[0].rstrip("/")

--- a/scripts/tests/test_ci_select.py
+++ b/scripts/tests/test_ci_select.py
@@ -37,6 +37,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 CI_SELECT = REPO_ROOT / "scripts" / "ci_select.py"
+MAP_FILE = REPO_ROOT / "ci" / "path-ownership.toml"
 
 
 def _load_module():
@@ -215,9 +216,100 @@ class OwnershipMapTests(unittest.TestCase):
         self.assertIn("unknown crate", sel.reason)
 
     def test_map_malformed_entry_raises(self):
-        m = [{"pattern": "tests/w3c/**"}]  # neither safe nor crates
+        m = [{"pattern": "tests/w3c/**"}]  # neither safe, crates, nor readers
         with self.assertRaises(cs.SelectorError):
             cs.select(["tests/w3c/x"], self.meta, m)
+
+
+class AdditionalReadersTests(unittest.TestCase):
+    """[FABLE-5] sq-m4bxc: the additional-readers (monotone union) mechanism.
+
+    A `readers` entry unions extra reader crates into the affected set EVEN FOR
+    A CRATE-OWNED path, closing a sibling read where a real dep edge would be a
+    forbidden cycle. The load-bearing invariant is MONOTONICITY: adding a
+    `readers` entry can only ENLARGE (never shrink) the selection — so it can
+    never turn a run into an unsound skip (design §2/§4.2)."""
+
+    def setUp(self):
+        self.meta = _synthetic_meta()
+
+    def test_readers_union_enlarges_a_crate_owned_selection(self):
+        # An `app` change alone selects {app}. A readers entry on the app dir
+        # naming `parse` also pulls parse's reverse closure (parse<-engine<-app).
+        base = cs.select(["crates/app/src/lib.rs"], self.meta)
+        self.assertEqual(base.affected, ["app"])
+        m = [{"pattern": "crates/app/**", "readers": ["parse"]}]
+        sel = cs.select(["crates/app/src/lib.rs"], self.meta, m)
+        self.assertEqual(sel.mode, "selected")
+        self.assertEqual(sel.affected, ["app", "engine", "parse"])
+        self.assertIn("parse", sel.affected)  # the extra reader is present
+
+    def test_readers_added_alongside_prefix_owner(self):
+        # The path's normal prefix owner is STILL selected (readers only adds).
+        m = [{"pattern": "crates/app/**", "readers": ["parse"]}]
+        sel = cs.select(["crates/app/src/lib.rs"], self.meta, m)
+        self.assertIn("app", sel.changed_crates)
+        self.assertIn("parse", sel.changed_crates)
+
+    def test_unknown_additional_reader_fails_full(self):
+        # A `readers` naming a non-member cannot silently skip — fail-safe to full.
+        m = [{"pattern": "crates/app/**", "readers": ["ghost-crate"]}]
+        sel = cs.select(["crates/app/src/lib.rs"], self.meta, m)
+        self.assertEqual(sel.mode, "full")
+        self.assertIn("unknown additional-reader", sel.reason)
+        self.assertEqual(sel.affected, ALL_MEMBERS)
+
+    def test_readers_never_rescue_an_unowned_path(self):
+        # MONOTONICITY GUARD: a `readers` entry must NOT convert an otherwise
+        # unowned/unmapped path (which forces full) into a narrow selection —
+        # that would SHRINK the run set. It stays full.
+        m = [{"pattern": "weird/**", "readers": ["core"]}]
+        sel = cs.select(["weird/thing.txt"], self.meta, m)
+        self.assertEqual(sel.mode, "full")
+        self.assertEqual(sel.affected, ALL_MEMBERS)
+
+    def test_readers_entry_is_not_an_ownership_verdict(self):
+        # apply_ownership_map treats a readers-only entry as transparent (None),
+        # so it never provides a `crates`/`safe` verdict nor raises.
+        m = [{"pattern": "data/**", "readers": ["core"]}]
+        self.assertIsNone(cs.apply_ownership_map("data/x", m))
+
+    def test_additional_readers_helper_unions_all_matches(self):
+        m = [
+            {"pattern": "crates/app/**", "readers": ["parse"]},
+            {"pattern": "crates/app/src/**", "readers": ["engine"]},
+        ]
+        self.assertEqual(cs.additional_readers("crates/app/src/lib.rs", m), ["engine", "parse"])
+        self.assertEqual(cs.additional_readers("crates/core/src/x.rs", m), [])
+
+    def test_monotonicity_property_readers_only_enlarges(self):
+        # PROPERTY: for ANY changed-path set, adding a `readers` entry yields an
+        # affected set that is a SUPERSET of the selection without it. Exercise a
+        # spread of cases (leaf / root / mapped / safe / unowned-full).
+        readers_entry = {"pattern": "crates/app/**", "readers": ["parse", "core"]}
+        base_maps = [
+            [],
+            [{"pattern": "research/**", "safe": True}],
+            [{"pattern": "tests/w3c/**", "crates": ["engine"]}],
+        ]
+        path_sets = [
+            ["crates/app/src/lib.rs"],
+            ["crates/core/src/dict.rs"],
+            ["crates/devlib/src/lib.rs"],
+            ["research/x.md", "crates/app/src/lib.rs"],
+            ["tests/w3c/data.ttl", "crates/app/x.rs"],
+            ["docs/unowned.md"],  # forces full in both -> superset (equal) holds
+        ]
+        for base in base_maps:
+            augmented = base + [readers_entry]
+            for paths in path_sets:
+                base_sel = cs.select(paths, self.meta, base)
+                aug_sel = cs.select(paths, self.meta, augmented)
+                self.assertTrue(
+                    set(base_sel.affected).issubset(set(aug_sel.affected)),
+                    f"monotonicity violated for paths={paths}, base={base}: "
+                    f"{base_sel.affected} !subset {aug_sel.affected}",
+                )
 
 
 class MapValidityTests(unittest.TestCase):
@@ -436,6 +528,31 @@ class RealMetadataShapeTests(unittest.TestCase):
         self.assertEqual(sel.mode, "selected")
         self.assertIn("sparq-geo", sel.affected)
         self.assertNotIn("sparq-parse", sel.affected)  # parse does not depend on geo
+
+    # ---- sq-m4bxc additional-readers acceptance, REAL metadata + REAL map ------
+    # These use the SHIPPED ci/path-ownership.toml `readers` entries against live
+    # cargo metadata: a change to sparq-trust's shared secprop vocab must select
+    # sparq-zk (a sparq-zk->sparq-trust dep is a cycle, so the reverse closure
+    # cannot reach it), and a change to sparq-solid's rule corpus must select
+    # sparq-reason (sparq-solid depends on sparq-reason — the reverse cycle).
+    def test_secprop_ext_change_selects_zk_and_trust(self):
+        real_map = cs.load_ownership_map(str(MAP_FILE))
+        sel = cs.select(
+            ["crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl"],
+            self.meta, real_map,
+        )
+        self.assertEqual(sel.mode, "selected")
+        self.assertIn("sparq-zk", sel.affected,
+                      "a secprop-ext.ttl change must run sparq-zk's cross-crate drift test")
+        self.assertIn("sparq-trust", sel.affected)
+
+    def test_solid_rules_change_selects_reason(self):
+        real_map = cs.load_ownership_map(str(MAP_FILE))
+        sel = cs.select(["crates/sparq-solid/rules/wac.n3"], self.meta, real_map)
+        self.assertEqual(sel.mode, "selected")
+        self.assertIn("sparq-reason", sel.affected,
+                      "a sparq-solid/rules change must run sparq-reason's N3-equivalence tests")
+        self.assertIn("sparq-solid", sel.affected)
 
     # ---- phase-2 lane mapping against REAL metadata (bead sq-fmx4u.6) ----------
     def test_lane_seed_crates_are_real_workspace_members(self):

--- a/scripts/tests/test_path_ownership.py
+++ b/scripts/tests/test_path_ownership.py
@@ -290,6 +290,74 @@ class AuditUnitTests(unittest.TestCase):
         self.assertFalse(r.ok)
         self.assertTrue(any("NOT to 'crate-a'" in f for f in r.findings))
 
+    def test_sibling_read_covered_by_additional_readers(self):
+        # [FABLE-5] sq-m4bxc: crate-a reads a file inside crate-c and is NOT in
+        # closure(c) — normally a finding — but a `readers` map entry declaring
+        # crate-a covers it (the selector unions crate-a into the affected set).
+        entries = [{"pattern": "crates/c/**", "readers": ["crate-a"]}]
+        r = self._audit([_ref("crate-a", "crates/c/rules/x.n3")], entries)
+        self.assertTrue(r.ok, r.findings)
+        self.assertIn(("crate-a", "crates/c/rules/x.n3", "additional-readers map"), r.covered)
+
+    def test_sibling_read_not_in_readers_is_still_a_finding(self):
+        # A `readers` entry that does NOT name the reader does not cover it.
+        entries = [{"pattern": "crates/c/**", "readers": ["crate-b"]}]
+        r = self._audit([_ref("crate-a", "crates/c/rules/x.n3")], entries)
+        self.assertFalse(r.ok)
+        self.assertTrue(any("reverse-dependency closure" in f for f in r.findings))
+
+
+class AdditionalReadersMapTests(unittest.TestCase):
+    """[FABLE-5] sq-m4bxc: the shipped map's `readers` entries validate + resolve.
+
+    The two residual sibling-reads (sparq-zk -> secprop-ext, sparq-reason ->
+    sparq-solid/rules) are now closed by additional-readers entries; assert they
+    are present, valid, and MONOTONE (never a trigger-shadow, never an ownership
+    verdict)."""
+
+    def test_shipped_map_has_the_two_readers_entries(self):
+        readers_map = {
+            e["pattern"]: e["readers"]
+            for e in _real_map_entries() if "readers" in e
+        }
+        self.assertEqual(
+            readers_map.get("crates/sparq-trust/ontologies/zkp-sparql/**"),
+            ["sparq-zk", "sparq-trust"],
+        )
+        self.assertEqual(
+            readers_map.get("crates/sparq-solid/rules/**"), ["sparq-reason"],
+        )
+
+    def test_every_readers_name_is_a_real_member(self):
+        members = MapValidityTests()._members()
+        for e in _real_map_entries():
+            for c in e.get("readers", []) or []:
+                self.assertIn(c, members, f"map references unknown reader crate {c!r}")
+
+    def test_additional_readers_resolves_the_residual_paths(self):
+        entries = _real_map_entries()
+        self.assertIn(
+            "sparq-zk",
+            cs.additional_readers(
+                "crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl", entries),
+        )
+        self.assertIn(
+            "sparq-reason",
+            cs.additional_readers("crates/sparq-solid/rules", entries),
+        )
+
+    def test_readers_entry_is_not_an_ownership_verdict(self):
+        # A readers entry must never resolve as a `crates`/`safe` verdict.
+        entries = _real_map_entries()
+        self.assertIsNone(cs.apply_ownership_map("crates/sparq-solid/rules/wac.n3", entries))
+
+    def test_validate_map_rejects_unknown_reader(self):
+        problems = cs.validate_map(
+            [{"pattern": "crates/x/**", "readers": ["nope"]}],
+            members={"sparq-core"}, known_generated_roots={"crates/x"},
+        )
+        self.assertTrue(any("unknown readers crate" in p for p in problems))
+
 
 class ScanRefsTests(unittest.TestCase):
     """The scanner finds escaping include_str! + manifest-join reads in a tempdir."""


### PR DESCRIPTION
> 🤖 SPARQ agent (Opus 4.8, 1M context). Implements bead **sq-m4bxc** under a **[FABLE-5]** Fable *proceed-and-document* design decision.

## Decision (Fable, proceed-and-document)
Adopt **option (b)** — a monotone **additional-readers** enhancement to the change-based test selector — for residuals **1** and **2**, instead of pure input-relocation. Residual **3** is explicitly out of scope (see below).

Why not the "input-relocation" steer the bead described:
- **Relocation** would move a *vendored crypto ontology* (`crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl`) and a *crate's core authorization rule corpus* (`crates/sparq-solid/rules/*.n3`) out of their owning crates and edit **production** `include_str!` / runtime include paths in `sparq-trust`, `sparq-solid`, `sparq-zk`, `sparq-reason`.
- The **dep-edge** alternative is a **cargo cycle both ways**: `sparq-trust` depends on `sparq-zk`, and `sparq-solid` depends on `sparq-reason` (independently confirmed by decision #1195). So `zk -> trust` / `reason -> solid` edges are impossible.

## What changed
1. **`scripts/ci_select.py`** — new `additional_readers()` helper + a `readers = [...]` verdict form. A `[[map]]` entry may declare extra reader crates for a path **even when the path is crate-owned**; those crates are unioned into the changed-crate set *regardless of ownership*, without changing the ownership verdict. This can only **ENLARGE** the affected set (it never rescues an unowned/unmapped path from `mode=full`), so the selection is a strict **superset** of the no-readers selection — **monotone / fail-safe** (design §2/§4.2). `validate_map` + `apply_ownership_map` learn the form (readers-only entries are transparent to ownership resolution and never raise).
2. **`ci/path-ownership.toml`** — two `readers` entries: `crates/sparq-trust/ontologies/zkp-sparql/**` → `sparq-zk` + `sparq-trust`; `crates/sparq-solid/rules/**` → `sparq-reason`.
3. **`scripts/ci_audit_inputs.py`** — residuals 1+2 now **COVERED** `"additional-readers map"` and removed from `KNOWN_RESIDUALS`; residual 3's ack is **kept** (not deletable). The audit now PASSES with only residual 3 acknowledged.
4. **`research/change-based-test-selection.md` §4.2** — an "additional-readers (monotone union)" paragraph documenting the deviation and rationale.
5. **Tests** — a `secprop-ext.ttl` change selects `sparq-zk` + `sparq-trust`; a `sparq-solid/rules` change selects `sparq-reason`; a monotonicity property test; audit-side coverage tests + `readers` map-validity.

## Audit — before / after
```
before: out-of-crate-input audit: 15 covered, 3 acknowledged residual(s), 0 finding(s)
after:  out-of-crate-input audit: 17 covered, 1 acknowledged residual(s), 0 finding(s)   (exit 0)
```
The two moved rows now read:
```
  ok   sparq-reason -> crates/sparq-solid/rules  [additional-readers map]
  ok   sparq-zk -> crates/sparq-trust/ontologies/zkp-sparql/secprop-ext.ttl  [additional-readers map]
  ack  sparq-conformance -> .
```

## Residual 3 — out of scope, split to a new bead
`sparq-conformance`'s `scoreboard_floors.rs` reads sibling-crate **test sources** at a statically-unresolvable **runtime** workspace path (`.`), which a `readers` glob entry cannot attribute. The sound fix is a **shared floors crate** consumed by the conformance runner tests — but that edits *every* runner test, conflicting with this bead's "no shared test edits" constraint, so it needs its own design pass. Tracked as **sq-z1xv8** (discovered-from sq-m4bxc).

## Gates (this is a CI-infra / Python + TOML + markdown change; no Rust crate touched)
- `scripts/tests/test_ci_select.py` (67) ✓ · `test_path_ownership.py` (28) ✓ · `test_ci_select_wiring.py` (32) ✓ · `test_ci_selection_alarm.py` (17) ✓
- `scripts/ci_audit_inputs.py` exit 0 (17 / 1 / 0)
- `check-privacy-claims.sh` ✓ · typos allowlist ✓ · `check-no-perf-numbers.py` ✓
- No selection weakening: monotonicity is asserted by test; a `readers` entry can only add crates. This PR touches `scripts/**` + `ci/path-ownership.toml` (both full-run triggers), so CI validates it against the **full** matrix.

**Do NOT arm** (per brief). 🤖

🤖 Generated with [Claude Code](https://claude.com/claude-code)