### PR TITLE
ci(formal-verification): change-coupled proof enforcement — wire unwired Kani suites, proof-paths manifest + drift gate, shard the dead Miri lane, no-verdict alarm (sq-63ups) [FABLE-5]

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,24 @@
+# [FABLE-5] sq-63ups. 🤖 SPARQ agent.
+#
+# ONLY the `default-miri` profile is configured here — the profile nextest selects
+# AUTOMATICALLY when running under `cargo miri nextest run` (verified on the work box:
+# "Nextest run ID … with nextest profile: default-miri"). Every normal `cargo nextest run`
+# in ci.yml uses the built-in `default` profile, which this file deliberately leaves
+# untouched, so adding this file changes NOTHING outside the Miri lane.
+
+[profile.default-miri]
+# The nightly miri lane (.github/workflows/miri.yml) was cancelled at its 90-minute job
+# ceiling 22 nights running with NO verdict. Under this profile a test that exceeds
+# 20 × 300s = 100 minutes of interpretation is TERMINATED (SIGTERM, then SIGKILL after the
+# grace period) and reported as a NAMED failure — a pathological test now produces a loud,
+# attributable red verdict instead of silently eating the whole shard's ceiling.
+#
+# Cap calibration (work-box measurement, sq-63ups): sparq-core's test set is bimodal under
+# Miri — most tests interpret in ms..seconds (e.g. the store perms test: ~44s), but the
+# heavy end-to-end loader tests run ~50-70+ MINUTES EACH in a fresh interpreter (worst
+# observed still running past 70 min on a near-uncontended core). 100 min sits above the
+# observed heavy band with margin, so a termination signals a genuine hang/livelock (or a
+# new test that must be cfg(miri)-scaled — follow-up bead sq-0s15k), while still
+# guaranteeing the shard reports a verdict inside its 130-minute job ceiling instead of
+# dying verdict-less at it.
+slow-timeout = { period = "300s", terminate-after = 20, grace-period = "30s" }

--- a/.github/workflows/formal-alarm.yml
+++ b/.github/workflows/formal-alarm.yml
@@ -1,0 +1,62 @@
+# formal-alarm — the scheduled formal lanes' NO-VERDICT alarm ([FABLE-5] bead sq-63ups).
+# 🤖 SPARQ agent.
+#
+# WHAT: the kani.yml / miri.yml formal lanes are deliberately nightly-only (no PR
+# check-run — see their headers), which makes their failure mode INVISIBLE: miri.yml was
+# CANCELLED at its 90-minute ceiling for 22 consecutive nights (2026-06-16 → 2026-07-07)
+# with conclusion `cancelled` — never a red `failure` — and nothing noticed. Silence must
+# not look like green. This workflow runs scripts/formal_lane_alarm.py daily: a lane in
+# ci/formal-verification.toml `[[lane]]` whose newest SUCCESSFUL completed run on main is
+# older than `max_verdict_age_hours` (48h = two missed nightly verdicts) REDs this run and
+# files ONE deduped, self-identified SPARQ-agent issue (label `formal-alarm`, keyed by a
+# `<!-- formal-alarm-key: … -->` body marker — the selection-alarm/flow-on idempotency
+# mechanism). The orchestrator reconciles alarm issues into beads out-of-band (we never
+# touch `bd`/`.beads` in CI — same rule as flow-on.yml / selection-alarm.yml).
+#
+# NOT A GATE (same posture as selection-alarm.yml): scheduled on main, files issues,
+# blocks NO merge. Its job name carries no advisory/informational token, but it never
+# creates a check-run on a PR head or merge-group ref, so it can never enter the
+# `ci-summary / gate` poll set. FAIL-LOUD: an alarm-infrastructure error (unreadable
+# manifest, workflow-runs API failure) exits non-zero so THIS run goes red and a human
+# notices the detector itself is broken — masking a dead lane is the one thing the alarm
+# must never do.
+#
+# All actions are SHA-pinned (code-scanning / Scorecard posture). The script is
+# self-tested hermetically as the first step of every run (a broken detector reds the run
+# before it is trusted to watch anything).
+name: formal-alarm
+
+on:
+  # Daily at 07:41 UTC — after miri (05:11) and kani (06:11) have had time to complete,
+  # and offset from the other nightly lanes so it never contends for their runner window.
+  schedule:
+    - cron: "41 7 * * *"
+  # Manual run for validation / triage.
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: formal-alarm-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  alarm:
+    name: formal-lane no-verdict alarm
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read # list each formal lane's completed workflow runs
+      issues: write # file the alarm issue (idempotent, labelled)
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Self-test the alarm (hermetic fixtures)
+        run: python3 scripts/formal_lane_alarm.py --self-test
+      - name: Check every scheduled formal lane for a fresh verdict
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 scripts/formal_lane_alarm.py

--- a/.github/workflows/formal-verification.yml
+++ b/.github/workflows/formal-verification.yml
@@ -1,0 +1,257 @@
+# formal-verification — change-coupled proof enforcement ([FABLE-5] bead sq-63ups).
+# 🤖 SPARQ agent.
+#
+# WHY: the Kani lanes were 100% nightly/advisory and 0% change-coupled — a PR could
+# rewrite a formally-verified function (the vectorized reducer kernels, the compare
+# ORDER-law subject, the dict id-partition encoding) and merge with the proofs never
+# re-run, the nightly lane discovering the break a day later in an informational job
+# nobody gates on. Maintainer mandate: CI must (a) CHECK that the formal verifications
+# hold and (b) FORCE proofs to be re-obligated when the verified code changes.
+#
+# THREE JOBS:
+#   * fv-select (change-based test selection) — scripts/fv_select.py maps this PR's
+#     diff onto ci/formal-verification.toml `proves` paths and emits the suite matrix.
+#     The job name deliberately carries the phrase "change-based test selection": that
+#     is the detection contract with scripts/ci_summary_gate.py (SELECT_RE) — if this
+#     job does not conclude SUCCESS, the required `ci-summary / gate` REDs outright, so
+#     a skipped proof job can never be trusted on the back of a broken selector.
+#   * fv-manifest — scripts/check-fv-manifest.py: the completeness + drift gate. REDs
+#     when a `#[cfg(kani)]` module is uncovered by the manifest, when the source
+#     `#[kani::proof]` inventory and the manifest harness lists disagree in either
+#     direction, or when kani.yml's matrix drifts from the `nightly = true` suites.
+#     Runs on EVERY PR (any PR can introduce a new proof module); it is seconds-cheap.
+#   * kani (change-coupled proofs) — the selected suites' bounded proofs, run with the
+#     same per-harness timeout + step-summary machinery as the nightly kani.yml lane.
+#     GATING: the job name carries NO advisory/informational token, so the ci-summary
+#     aggregator waits on it; a counterexample OR a per-harness timeout is red.
+#
+# GATE SEMANTICS (unchanged aggregator, no ci-summary.yml edit):
+#   * unrelated PR  => fv-select succeeds with an empty matrix => the proof job is
+#     `if:`-skipped => `skipped` is satisfied (select-job-green rule) => no cost.
+#   * verified-path PR => the matching suites RUN and BLOCK the merge until green.
+#   * selector infra failure => fv-select not success => gate REDs (fail-closed).
+#
+# WHICH SUITES CAN GATE: `pr_gate = true` suites only. The two mmap-validator totality
+# suites are `pr_gate = false` (owner sq-og8u8): their harnesses exceed the 20m
+# per-harness CBMC budget on this runner class and have never completed in CI — gating
+# PRs on a proof that cannot terminate would block every dict.rs/store.rs PR on a
+# pre-existing solver-budget problem. They stay on the nightly lane (honest red there)
+# and flip to pr_gate = true when sq-og8u8 bounds them. This is recorded in the
+# manifest itself (`pr_gate_blocked_by`), enforced by the D4 manifest rule.
+#
+# COST CONTROL: the heavy job runs ONLY when a `proves` path changed. Suites are
+# file-precise (e.g. sparq-substrate LFTJ/kernel perf PRs do NOT trigger the compare
+# ORDER-law suite — only compare.rs edits do). The nightly kani.yml lane remains the
+# full-matrix backstop, so a missed coupling degrades to next-nightly detection, and
+# scripts/formal_lane_alarm.py (formal-alarm.yml) alarms if that backstop goes silent.
+#
+# Third-party actions are pinned by full commit SHA (supply-chain hardening); the
+# trailing `# vX.Y.Z` comment is what Dependabot follows to bump the pin. Toolchain
+# pin + install flow match kani.yml so a bump moves them together.
+name: formal-verification
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  # Merge queue: re-run the identical check-set on the queue's merge_group ref so the
+  # required ci-summary gate finds the same siblings there (base_sha/head_sha of the
+  # queue entry give the union-diff — same pairing ci-select.yml uses).
+  merge_group:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: formal-verification-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+  # Same per-harness wall-clock ceiling as the nightly kani.yml lane: a runaway proof
+  # is cut with a clean red TIMEOUT record instead of exhausting the runner.
+  KANI_HARNESS_TIMEOUT: "20m"
+
+jobs:
+  # The selector. MUST stay unconditional (no `if:`/`needs:`): a check-run matching
+  # SELECT_RE with any conclusion other than success (including `skipped`) REDs the
+  # ci-summary gate — that is the fail-closed contract, not an accident.
+  fv-select:
+    name: fv-select (change-based test selection)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      any: ${{ steps.sel.outputs.any }}
+      suites: ${{ steps.sel.outputs.suites }}
+    steps:
+      # Full history so the merge-base for the three-dot diff always resolves; an
+      # unfetchable base fail-closes to running every pr_gate suite anyway.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      # The selector's own fixtures run first so a broken selector cannot silently
+      # mis-select (red here => red gate, fail-closed).
+      - name: Self-test the FV selector (hermetic fixtures)
+        run: python3 scripts/fv_select.py --self-test
+      - name: Select proof suites for this diff (scripts/fv_select.py)
+        id: sel
+        env:
+          EVENT: ${{ github.event_name }}
+          # Exactly one pair is non-empty per event (same wiring as ci-select.yml).
+          BASE: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+        run: |
+          set -euo pipefail
+          python3 scripts/fv_select.py --event "$EVENT" --base "$BASE" --head "$HEAD"
+
+  # The completeness + drift gate. Unconditional: ANY PR can add a `#[cfg(kani)]`
+  # module or touch kani.yml/the manifest, and the check is seconds-cheap (a comment-
+  # aware source scan + two config parses — no cargo, no build).
+  fv-manifest:
+    name: fv-manifest (proof inventory completeness + drift)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: "3.12"
+      - name: Install PyYAML (hash-pinned)
+        # Needed only to parse kani.yml's matrix. HASH-pinned (Scorecard
+        # PinnedDependenciesID) against the same requirements file the docs-quality
+        # YAML jobs use — one pin to bump.
+        run: pip install --require-hashes -r .github/requirements/docs-quality.txt
+      - name: Self-test the drift gate (all drift classes must red)
+        run: python3 scripts/check-fv-manifest.py --self-test
+      - name: Manifest / source-inventory / kani.yml agreement — GATING
+        run: python3 scripts/check-fv-manifest.py
+
+  # The change-coupled bounded proofs. Mirrors the nightly kani.yml job mechanics
+  # (per-harness `--harness` invocation under a wall-clock timeout, solver reap,
+  # step-summary table) — see kani.yml's RUNNER/STRUCTURE header for the rationale.
+  # GATING: no advisory/informational token in the name. Skipped entirely (and
+  # correctly treated as satisfied) when fv-select selected nothing.
+  kani:
+    name: kani ${{ matrix.suite.name }} (change-coupled proofs)
+    needs: fv-select
+    if: needs.fv-select.outputs.any == 'true'
+    runs-on: ubuntu-latest
+    # Cold Kani install + per-harness codegen + the slowest measured suite (the
+    # vectorized reducers: slowest harness ~10 min on the work box, six harnesses)
+    # need generous headroom; a hung harness is cut by KANI_HARNESS_TIMEOUT long
+    # before this backstop fires.
+    timeout-minutes: 120
+    strategy:
+      # One suite's timeout must not cancel another suite's verdict.
+      fail-fast: false
+      matrix:
+        suite: ${{ fromJSON(needs.fv-select.outputs.suites) }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      # Same pinned nightly as kani.yml / miri.yml / asan.yml so a toolchain bump
+      # moves every formal lane together.
+      - name: Install Rust (nightly, pinned)
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # nightly via toolchain input
+        with:
+          toolchain: nightly-2026-06-11
+      - name: Cache cargo + target
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          # Distinct from the nightly lane's `kani-<crate>` keys: the PR tier churns on
+          # branch content and must never poison the nightly backstop's warm cache.
+          key: kani-pr-${{ matrix.suite.crate }}
+      - name: Install Kani
+        run: |
+          cargo install --locked kani-verifier
+          cargo kani setup
+      # Identical loop to kani.yml (see that header for why per-harness + timeout +
+      # summary): every harness's PASS / FAIL / TIMEOUT is recorded before the job
+      # reds, so one cut proof cannot hide another's counterexample.
+      - name: Kani bounded proofs (per-harness, timeout, summary)
+        env:
+          SUITE_NAME: ${{ matrix.suite.name }}
+          SUITE_CRATE: ${{ matrix.suite.crate }}
+          SUITE_FEATURES: ${{ matrix.suite.features }}
+          SUITE_HARNESSES: ${{ matrix.suite.harnesses }}
+        run: |
+          set -u
+          summary="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+          tmo="${KANI_HARNESS_TIMEOUT:-20m}"
+          {
+            echo "### 🤖 Kani change-coupled proof results — ${SUITE_NAME}"
+            echo ""
+            echo "This PR touches source this suite PROVES (ci/formal-verification.toml), so its"
+            echo "bounded proofs are re-obligated here and GATE the merge. Each harness runs as its"
+            echo "own \`cargo kani --harness\` invocation under a \`${tmo}\` wall-clock ceiling."
+            echo ""
+            echo "| Harness | Result | Wall time |"
+            echo "| --- | --- | --- |"
+          } >> "$summary"
+
+          had_fail=0
+          had_timeout=0
+          for h in $SUITE_HARNESSES; do
+            log="kani-${SUITE_CRATE}-${h}.log"
+            start=$(date +%s)
+            # shellcheck disable=SC2086  # SUITE_FEATURES is an intentional word-split arg list.
+            # `&& ec=0 || ec=$?` — capture exit code without triggering `set -e` (bash -e {0}).
+            timeout -k 30s "$tmo" cargo kani -p "$SUITE_CRATE" $SUITE_FEATURES --harness "$h" \
+              > "$log" 2>&1 && ec=0 || ec=$?
+            # Anti-OOM invariant: reap any orphaned solver before the next harness starts.
+            pkill -9 -x cbmc 2>/dev/null || true
+            end=$(date +%s)
+            dur=$((end - start))
+            wall=$(printf '%dm%02ds' $((dur / 60)) $((dur % 60)))
+
+            case "$ec" in
+              0)
+                res="✅ PASS"
+                ;;
+              124 | 137)
+                res="⏱️ TIMEOUT (>${tmo})"
+                had_timeout=1
+                echo "::error title=Kani timeout::${SUITE_CRATE}::${h} exceeded ${tmo} on the PR tier — the changed code's proof no longer fits its budget (see step summary)."
+                ;;
+              *)
+                res="❌ FAIL (exit ${ec})"
+                had_fail=1
+                echo "::error title=Kani proof failed::${SUITE_CRATE}::${h} failed (exit ${ec}) — a reachable panic/OOB/UB counterexample or a build error against this PR's code (see step summary)."
+                ;;
+            esac
+            echo "| \`${h}\` | ${res} | ${wall} |" >> "$summary"
+
+            if [ "$ec" -ne 0 ]; then
+              {
+                echo ""
+                echo "<details><summary>Log tail — <code>${h}</code> (${res})</summary>"
+                echo ""
+                echo '```'
+                tail -n 40 "$log" 2>/dev/null || true
+                echo '```'
+                echo ""
+                echo "</details>"
+              } >> "$summary"
+            fi
+          done
+
+          {
+            echo ""
+            if [ "$had_fail" -eq 1 ]; then
+              echo "**Overall: ❌ FAIL** — this PR's changes break a bounded proof; fix the code or re-derive the harness honestly (never weaken the property to pass)."
+            elif [ "$had_timeout" -eq 1 ]; then
+              echo "**Overall: ⏱️ TIMEOUT** — every harness that finished passed, but this PR pushed one or more proofs past the \`${tmo}\` budget; re-bound the harness or simplify the change."
+            else
+              echo "**Overall: ✅ PASS** — every re-obligated proof verified within budget."
+            fi
+          } >> "$summary"
+
+          if [ "$had_fail" -eq 1 ] || [ "$had_timeout" -eq 1 ]; then
+            exit 1
+          fi

--- a/.github/workflows/kani.yml
+++ b/.github/workflows/kani.yml
@@ -76,10 +76,18 @@
 # to this repo (`gh api /repos/sparq-org/sparq/actions/runners` == 0; every other workflow uses
 # `ubuntu-latest`), so option "beefier runner" is not currently reachable — recorded in the PR.
 #
-# ADDING A SUITE (bead sq-sqtk2.5 wires four new Phase-1 harness suites in): append ONE entry to
+# ADDING A SUITE ([FABLE-5] sq-63ups — the Phase-1 suites are wired in): append ONE entry to
 # the `matrix.suite` list below — `{ name, crate, features, harnesses }`. `harnesses` is the
 # space-separated list of `#[kani::proof]` fn names in that crate. Nothing else changes: the
-# per-harness timeout loop + summary apply uniformly to every suite.
+# per-harness timeout loop + summary apply uniformly to every suite. This matrix is
+# DRIFT-CHECKED: ci/formal-verification.toml is the manifest of every proof suite (name /
+# crate / features / harnesses / the source paths each suite proves), and the gating
+# `fv-manifest` job (.github/workflows/formal-verification.yml, scripts/check-fv-manifest.py)
+# REDs any PR on which this matrix, that manifest and the source `#[kani::proof]` inventory
+# disagree — so a new harness can no longer silently run in no lane. The same manifest drives
+# the change-coupled PR selector (scripts/fv_select.py): PRs touching a suite's `proves`
+# paths run that suite's proofs as a GATING check; this nightly lane stays the full-matrix
+# backstop.
 #
 # HOW (the documented Kani flow — https://model-checking.github.io/kani/install-guide.html):
 #   cargo install --locked kani-verifier              (the cargo-kani driver from crates.io)
@@ -159,15 +167,73 @@ jobs:
             harnesses: >-
               open_from_bytes_never_panics
               open_validated_v2_tail_never_panics
-          - name: "sparq-core (dict validator + id partition)"
+          # [FABLE-5] sq-63ups: the former single sparq-core entry is SPLIT so the five
+          # fast id-partition/domain harnesses (all pass in seconds) report an honest
+          # GREEN job instead of being dragged red every night by the two mmap-validator
+          # totality harnesses, which exceed the per-harness CBMC budget on this runner
+          # class (sq-og8u8). The split also adds the two PR #1536 domain self-checks
+          # (domain_id_partition_regions_are_all_nonempty,
+          # domain_dict_validator_accepts_the_empty_dict) that were present in source but
+          # absent from this list — they previously ran in NO CI lane.
+          - name: "sparq-core (dict id partition + domain self-checks)"
             crate: sparq-core
             features: "--features mmap"
             harnesses: >-
               inline_id_round_trip
               inline_id_out_of_domain_is_none
               id_partition_disjoint
+              domain_id_partition_regions_are_all_nonempty
+              domain_dict_validator_accepts_the_empty_dict
+          - name: "sparq-core (dict mmap validator totality)"
+            crate: sparq-core
+            features: "--features mmap"
+            harnesses: >-
               validate_dict_bytes_never_panics
               validate_dict_bytes_sized_tail_never_panics
+          # [FABLE-5] sq-63ups: the two Phase-1 suites (sq-sqtk2.3 / sq-sqtk2.4) that ran
+          # in no CI lane since merge. Local evidence (61 GB aarch64 work box, Kani 0.67,
+          # suites run concurrently so wall times are upper bounds): every reducer harness
+          # PASSes (slowest ~10 min), every compare harness PASSes (most in seconds).
+          - name: "sparq-engine (vectorized reducer kernels)"
+            crate: sparq-engine
+            features: "--features vectorized"
+            harnesses: >-
+              reduce_sum_equals_reference_fold
+              reduce_count_equals_reference
+              reduce_min_id_equals_reference
+              reduce_max_id_equals_reference
+              narrow_sum_to_i64_iff_in_range
+              domain_reducer_slice_is_adversarial_and_survives_the_bound
+          - name: "sparq-substrate (compare ORDER laws)"
+            crate: sparq-substrate
+            features: "--features compare"
+            harnesses: >-
+              domain_exhibits_the_2p53_collapse
+              reflexivity_numeric_literals_incl_nan
+              reflexivity_nonnumeric_scalars
+              reflexivity_triple_terms
+              antisymmetry_numeric_pairs_incl_nan
+              antisymmetry_numeric_vs_nonnumeric_incl_nan
+              antisymmetry_nonnumeric_scalar_pairs
+              antisymmetry_triple_vs_scalar
+              antisymmetry_triple_pairs
+              within_class_totality_literals_incl_nan
+              within_class_totality_nonliterals
+              transitivity_exact_int_literals_incl_2p53_collapse
+              transitivity_nonliteral_scalars
+              transitivity_int_with_nonliteral_scalars
+              transitivity_double_literals
+              transitivity_mixed_numeric_collapse_free_range
+              domain_cf_numeric_is_collapse_free_with_signed_zero_pair
+              transitivity_string_literals
+              transitivity_strict_typed_literals
+              transitivity_mixed_literal_kinds_incl_nan
+              transitivity_triple_terms_recursive
+              exact_int_order_agreement_incl_2p53_collapse
+              domain_x2_doubles_are_exact
+              witness_mixed_tier_collapse_now_exact
+              witness_numeric_vs_string_now_ranked_by_kind
+              witness_nan_now_totalised_first
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       # Kani pins its own internal toolchain via `cargo kani setup`, but it still needs a host

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -1,16 +1,60 @@
 # miri — undefined-behaviour lane over sparq-core's pure-Rust `unsafe` surface (bead sq-fo28).
-# [OPUS-4.8] authored while Fable unavailable — re-review when Fable returns.
+# [OPUS-4.8] authored while Fable unavailable. [FABLE-5] sq-63ups: SHARDED — see the DEAD-LANE
+# POST-MORTEM below; the single-process form of this lane never produced a verdict.
 #
 # WHY: `sparq-core` is the repo's only crate with `unsafe` (threat-model boundary B5 —
 # `research/threat-model.md`). The closed sq-ky2a corruption sweep + the `fuzz` lane catch
 # slice-bound PANICS / OOM on a hostile on-disk index, but they do NOT detect UNDEFINED
 # BEHAVIOUR — aliasing / pointer-provenance violations / data races. Miri does. This lane
-# interprets `cargo test -p sparq-core` under Miri so a regression that introduces UB in the
+# interprets the sparq-core test suite under Miri so a regression that introduces UB in the
 # pure-Rust unsafe paths (the parallel dict-build scatter writes in `dict.rs`, the POD↔bytes
 # transmutes, the `from_utf8_unchecked` over in-memory buffers, the `set_len`-after-
 # `MaybeUninit` fill) fails a standing check. NOTE: the dict-spill scatter writes
 # (`dictspill.rs`) are NOT in scope here — that module is `#[cfg(feature = "dict-spill")]`,
 # which pulls in `mmap`, and neither feature is enabled in this lane (see below).
+#
+# DEAD-LANE POST-MORTEM ([FABLE-5] sq-63ups, 2026-07-07): the original single job ran
+# `cargo miri test -p sparq-core` under a 90-minute ceiling. EVERY scheduled run since the
+# lane's first night (2026-06-16 — 22 consecutive nights) was CANCELLED at exactly that
+# ceiling: the lane never produced a verdict, and nothing alarmed on it (conclusion
+# `cancelled`, not `failure`). The 2026-07-07 run's log shows the shape of the failure: the
+# lib binary's 97 tests started at 08:36, 45 had completed by 08:50 (~15 min), then the run
+# produced NO further output for the remaining ~75 minutes — one long-lived Miri interpreter
+# process runs every test serially, and its per-test cost inflates dramatically as the
+# process ages (rayon's global pool + crossbeam-epoch state persist across tests, and Miri's
+# borrow-tracking metadata grows monotonically per allocation). The stall is a property of
+# the SINGLE PROCESS, not of any one test: the test at the stall point
+# (store::tests::build_raw_perms_no_capacity_slack, 400 triples) passes in ~44s in a FRESH
+# Miri process on the work box.
+#
+# THE FIX (this file): process-per-test + sharding, coverage IDENTICAL.
+#   1. `cargo miri nextest run` — nextest executes every test in its OWN process, so each
+#      test gets a fresh interpreter (kills the state-accumulation failure mode at the root)
+#      and the runner's cores actually parallelise interpretation (a single `cargo miri
+#      test` process interprets everything on one core, whatever test-threads says).
+#   2. `--partition count:<k>/12` — twelve matrix shards, each a disjoint round-robin slice
+#      of the SAME test list; the union over shards is exactly the old single-run test set
+#      (nextest count-partitioning assigns every test to exactly one shard, and round-robin
+#      spreads the alphabetically-clustered heavy modules across shards).
+#   3. Per-test hard cap (`[profile.default-miri]` slow-timeout in .config/nextest.toml —
+#      the profile nextest selects automatically under Miri, so normal ci.yml nextest runs
+#      are untouched): a test that exceeds the cap is TERMINATED and reported RED BY NAME.
+#      A pathological test now yields a loud, attributable failure verdict instead of
+#      silently eating the job ceiling — cancelled-at-ceiling with no verdict is the one
+#      outcome this lane must never repeat.
+#   4. Doctests: nextest does not run doctests, so the `miri-doctests` job keeps them
+#      covered (`cargo miri test --doc`; sparq-core has one; measured seconds under Miri).
+#      Coverage relative to the old `cargo miri test -p sparq-core` is therefore identical:
+#      same lib/integration test binaries (partitioned exhaustively), same doctests.
+#   Shard count: 12, calibrated from a work-box run of shard 1-of-6 (sq-63ups PR): the test
+#   set is BIMODAL under Miri — most tests are ms..seconds, but ~30% are heavy end-to-end
+#   loader tests at ~50-70 min EACH in a fresh interpreter (the accumulation bug above made
+#   them look infinitely worse in-process, but they are genuinely expensive too). Twelve
+#   round-robin shards put ~2-3 heavies per shard; run in parallel inside the shard they
+#   bound the wall near max(single heavy) ≈ 50-70+ min, inside the 130-minute ceiling with
+#   the 100-min per-test cap guaranteeing a named verdict either way. The REAL cost fix is
+#   cfg(miri)-scaling the heavy tests' input sizes (standard Miri practice) — a crates/
+#   change tracked by follow-up bead sq-0s15k, after which the shard count can drop again.
 #
 # WHAT MIRI COVERS vs CAN'T (measured — see the PR for sq-fo28):
 #   • COVERED (default features = `parallel`): the pure-Rust unsafe sites reachable WITHOUT
@@ -26,9 +70,7 @@
 #     `mmap` / `dict-spill` features are NOT enabled here — they would only abort on the first
 #     `Mmap::map`. That mmap B5 surface is covered instead by the DETERMINISTIC
 #     `mmap_corruption_oracle` test (run in ci.yml under `--features mmap,dict-spill`) + the
-#     `fuzz` lane's mmap-loader target, and is the intended target of a future ASan lane
-#     (deferred — bead noted in the sq-fo28 PR; ASan needs `-Zsanitizer=address` + a non-musl
-#     target and is left out here to keep this lane clean + non-flaky).
+#     `fuzz` lane's mmap-loader target + the standalone ASan lane (asan.yml).
 #
 # MIRIFLAGS (documented, load-bearing):
 #   -Zmiri-tree-borrows  : `rayon` pulls in `crossbeam-epoch`, which violates the default
@@ -37,7 +79,9 @@
 #                          aliasing model). Without this flag Miri aborts inside
 #                          crossbeam-epoch's `internal.rs`, NOT in sparq-core code. Tree
 #                          Borrows is the correct aliasing model for this dependency graph
-#                          and still detects real UB in sparq-core's own unsafe.
+#                          and still detects real UB in sparq-core's own unsafe. (Verified
+#                          again on the work box: the doctest FAILS under Stacked Borrows in
+#                          crossbeam-epoch and PASSES under Tree Borrows.)
 #   -Zmiri-ignore-leaks  : `rayon`'s global thread pool keeps daemon worker threads alive at
 #                          process exit; Miri otherwise fails the run with "the main thread
 #                          terminated without waiting for all remaining threads". This is a
@@ -55,7 +99,9 @@
 # therefore creates NO check-run on a PR head or merge-queue ref, so the required
 # `ci-summary / gate` aggregator (which POLLS sibling check-runs on the head commit) never
 # discovers it and never waits on it — exactly the "nightly safety net, not a per-PR tax"
-# posture of the zk-toolchain / fuzz-nightly lanes.
+# posture of the zk-toolchain / fuzz-nightly lanes. A lane with no verdict for >48h is
+# alarmed by scripts/formal_lane_alarm.py (formal-alarm.yml, [FABLE-5] sq-63ups) — the
+# 22-night silent-cancel streak above is exactly what that alarm exists to catch.
 #
 # Third-party actions are pinned by full commit SHA (supply-chain hardening); the trailing
 # `# vX.Y.Z` comment is what Dependabot follows to bump the pin.
@@ -85,13 +131,23 @@ env:
 
 jobs:
   miri:
-    name: miri (sparq-core unsafe surface, UB)
+    name: miri (sparq-core unsafe surface, UB, shard ${{ matrix.shard }}/12)
     runs-on: ubuntu-latest
-    # Miri interprets every instruction; the parallel dict-build tests are the long pole.
-    # Generous ceiling so a regression that hangs fails with a clear timeout, not a runaway.
-    timeout-minutes: 90
+    # Backstop only: each shard's real ceiling is the 100-min per-test terminate cap in
+    # .config/nextest.toml [profile.default-miri] — a hung/pathological test reds its shard
+    # BY NAME long before this fires. (The old single job hit its ceiling every night and
+    # produced nothing; see the post-mortem in the header.) 130 = the 100-min cap + setup
+    # (checkout/toolchain/sysroot) + the light-test tail, with margin.
+    timeout-minutes: 130
+    strategy:
+      # A pathological test in one shard must not cancel the other shards' verdicts.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
       # Miri ships ONLY on nightly. Pin the nightly channel by DATE so the lane is
       # reproducible and a future nightly regression cannot silently break it; bump the date
       # deliberately (same pinned dtolnay action + nightly the `fuzz` lane uses). The `miri`
@@ -101,20 +157,53 @@ jobs:
         with:
           toolchain: nightly-2026-06-11
           components: miri, rust-src
+      # nextest = the process-per-test runner (see THE FIX above). Same pinned installer
+      # action + tool the ci.yml test shards use.
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@4684b8405694ae9dd42c9f39ba901a70ae83f4a3 # v2.82.9
+        with:
+          tool: nextest
       - name: Cache cargo + target
         uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
         with:
-          # Miri uses its own `target/miri` tree + a built-from-source sysroot; key the cache
-          # so it is not confused with the stable workspace build in ci.yml.
-          key: miri
+          # One cache shared by every shard (identical build artifacts — the shards differ
+          # only in which tests they EXECUTE); Swatinem races on save are first-wins + benign.
+          shared-key: miri
       # Build the Miri sysroot once up front so a sysroot/toolchain problem is reported
       # distinctly from a test failure, and the test run below reuses it.
       - name: Build Miri sysroot
         run: cargo +nightly-2026-06-11 miri setup
       # Default features (= `parallel`). The `mmap` / `dict-spill` features are deliberately
-      # NOT enabled: Miri cannot run file-backed memory mappings (see the header), so they
-      # would only abort on the first `Mmap::map`. This run exercises the pure-Rust unsafe
-      # surface — the parallel scatter writes, POD transmutes, `from_utf8_unchecked`, and the
-      # `MaybeUninit`+`set_len` remap — for aliasing / provenance / data-race UB.
-      - name: cargo miri test -p sparq-core
-        run: cargo +nightly-2026-06-11 miri test -p sparq-core
+      # NOT enabled: Miri cannot run file-backed memory mappings (see the header). nextest
+      # auto-selects its built-in `default-miri` profile under Miri, which picks up the
+      # per-test terminate cap from .config/nextest.toml. --no-fail-fast: a shard reports
+      # EVERY test's verdict even after a failure (this is a verdict lane, not a smoke lane).
+      - name: cargo miri nextest run (shard ${{ matrix.shard }}/12)
+        run: >-
+          cargo +nightly-2026-06-11 miri nextest run -p sparq-core
+          --partition count:${{ matrix.shard }}/12 --no-fail-fast
+
+  # nextest does not execute doctests; keep them covered so this lane's coverage stays
+  # identical to the original `cargo miri test -p sparq-core` (which ran them last —
+  # or would have, had it ever got there). Seconds-cheap: sparq-core has one doctest.
+  miri-doctests:
+    name: miri doctests (sparq-core)
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+      - name: Install Rust (nightly, pinned) + miri
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # nightly via toolchain input
+        with:
+          toolchain: nightly-2026-06-11
+          components: miri, rust-src
+      - name: Cache cargo + target
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          shared-key: miri
+      - name: Build Miri sysroot
+        run: cargo +nightly-2026-06-11 miri setup
+      - name: cargo miri test --doc
+        run: cargo +nightly-2026-06-11 miri test -p sparq-core --doc

--- a/ci/formal-verification.toml
+++ b/ci/formal-verification.toml
@@ -1,0 +1,176 @@
+# [FABLE-5] Formal-verification manifest — proof suites -> the source paths they verify.
+# Bead sq-63ups. 🤖 SPARQ agent.
+#
+# WHO CONSUMES THIS (three scripts, one contract):
+#   * scripts/fv_select.py        — the change-coupled proof selector (formal-verification.yml
+#     `fv-select` job): a PR whose diff touches a suite's `proves` paths RUNS that suite's
+#     Kani harnesses ON THE PR as a GATING check (name carries no advisory/informational
+#     token, so the ci-summary aggregator waits on it). Unrelated PRs skip it entirely.
+#   * scripts/check-fv-manifest.py — the completeness + drift gate (formal-verification.yml
+#     `fv-manifest` job): fails when a `#[cfg(kani)]` module exists in the workspace that no
+#     suite's `proves` covers, when a `#[kani::proof]` harness in source is missing from (or
+#     stale in) this manifest, or when kani.yml's hard-coded matrix drifts from the
+#     `nightly = true` suites here. This is what makes a silently-unwired proof impossible.
+#   * scripts/formal_lane_alarm.py — the no-verdict alarm (formal-alarm.yml, scheduled):
+#     a `[[lane]]` workflow that has produced no successful verdict on main for longer than
+#     `max_verdict_age_hours` becomes a LOUD red run + a deduped GitHub issue. Silence must
+#     not look like green (miri.yml was cancelled at its ceiling 22 nights running with no
+#     verdict and nothing noticed — that class of failure is what this alarm exists for).
+#
+# EDITING RULES:
+#   * Add/move/remove a `#[kani::proof]` harness in source  => update the matching [[suite]]
+#     here AND (for nightly suites) the kani.yml matrix — the fv-manifest gate reds until all
+#     three agree.
+#   * `proves` lists the source files whose correctness the suite's harnesses establish —
+#     the harness file itself plus every file its proof cone imports (e.g. the sparq-engine
+#     reducer harnesses re-derive inline-id constants from sparq-core's dict.rs, so dict.rs
+#     is in their `proves`). Exact repo-relative paths or `dir/**` globs.
+#   * `pr_gate = false` REQUIRES `pr_gate_blocked_by` (an owner bead): an unwired-on-PR suite
+#     must have a reason and an owner, never a silent default. Deliberately NOT triggered on
+#     Cargo.lock/toolchain bumps: every proof cone here is intra-crate pure code (std-only or
+#     sparq-core dict constants), and the nightly kani.yml lane re-proves everything daily as
+#     the full-matrix backstop (same §6.1 posture as change-based test selection).
+#
+# Local reproduction of any suite:
+#   cargo kani -p <crate> [<features>] --harness <name>     (cargo install --locked kani-verifier)
+
+schema = 1
+
+# ---------------------------------------------------------------------------
+# Kani bounded-proof suites. `name` must equal the kani.yml matrix entry name
+# (drift-checked). `harnesses` must equal the `#[kani::proof]` fn names in the
+# `proves` files (drift-checked, comment-aware).
+# ---------------------------------------------------------------------------
+
+[[suite]]
+id = "vectors-spqv-validator"
+name = "sparq-vectors (.spqv validator)"
+crate = "sparq-vectors"
+features = ""
+harnesses = [
+  "open_from_bytes_never_panics",
+  "open_validated_v2_tail_never_panics",
+]
+proves = ["crates/sparq-vectors/src/store.rs"]
+nightly = true
+# Both totality harnesses exceed the 20m per-harness CBMC budget on a standard
+# GitHub runner (TIMEOUT every nightly run — see the kani.yml step summaries).
+# Gating a PR on a proof that has never completed in CI would hard-block every
+# store.rs PR on a pre-existing solver-budget problem, not on the PR's content.
+pr_gate = false
+pr_gate_blocked_by = "sq-og8u8"
+
+[[suite]]
+id = "core-dict-id-partition"
+name = "sparq-core (dict id partition + domain self-checks)"
+crate = "sparq-core"
+features = "--features mmap" # domain_dict_validator_accepts_the_empty_dict is #[cfg(feature = "mmap")]
+harnesses = [
+  "inline_id_round_trip",
+  "inline_id_out_of_domain_is_none",
+  "id_partition_disjoint",
+  "domain_id_partition_regions_are_all_nonempty",
+  "domain_dict_validator_accepts_the_empty_dict",
+]
+proves = ["crates/sparq-core/src/dict.rs"]
+nightly = true
+pr_gate = true
+
+[[suite]]
+id = "core-dict-validator-totality"
+name = "sparq-core (dict mmap validator totality)"
+crate = "sparq-core"
+features = "--features mmap"
+harnesses = [
+  "validate_dict_bytes_never_panics",
+  "validate_dict_bytes_sized_tail_never_panics",
+]
+proves = ["crates/sparq-core/src/dict.rs"]
+nightly = true
+# Same 20m-per-harness CBMC budget overrun as the .spqv validator suite (TIMEOUT
+# every nightly run). dict.rs PRs still get a gating proof leg from the
+# core-dict-id-partition suite above; the totality pair stays nightly-only until
+# the harnesses are bounded.
+pr_gate = false
+pr_gate_blocked_by = "sq-og8u8"
+
+[[suite]]
+id = "engine-vectorized-reducers"
+name = "sparq-engine (vectorized reducer kernels)"
+crate = "sparq-engine"
+features = "--features vectorized"
+harnesses = [
+  "reduce_sum_equals_reference_fold",
+  "reduce_count_equals_reference",
+  "reduce_min_id_equals_reference",
+  "reduce_max_id_equals_reference",
+  "narrow_sum_to_i64_iff_in_range",
+  "domain_reducer_slice_is_adversarial_and_survives_the_bound",
+]
+# The reducer proofs re-derive the inline-id encoding from sparq-core's dict
+# constants (`use sparq_core::dict::{is_inline, Id, INLINE_BASE, NO_ID}`), so a
+# dict.rs change re-obligates them too.
+proves = [
+  "crates/sparq-engine/src/reduce.rs",
+  "crates/sparq-core/src/dict.rs",
+]
+nightly = true
+pr_gate = true
+
+[[suite]]
+id = "substrate-compare-order-laws"
+name = "sparq-substrate (compare ORDER laws)"
+crate = "sparq-substrate"
+features = "--features compare"
+harnesses = [
+  "domain_exhibits_the_2p53_collapse",
+  "reflexivity_numeric_literals_incl_nan",
+  "reflexivity_nonnumeric_scalars",
+  "reflexivity_triple_terms",
+  "antisymmetry_numeric_pairs_incl_nan",
+  "antisymmetry_numeric_vs_nonnumeric_incl_nan",
+  "antisymmetry_nonnumeric_scalar_pairs",
+  "antisymmetry_triple_vs_scalar",
+  "antisymmetry_triple_pairs",
+  "within_class_totality_literals_incl_nan",
+  "within_class_totality_nonliterals",
+  "transitivity_exact_int_literals_incl_2p53_collapse",
+  "transitivity_nonliteral_scalars",
+  "transitivity_int_with_nonliteral_scalars",
+  "transitivity_double_literals",
+  "transitivity_mixed_numeric_collapse_free_range",
+  "domain_cf_numeric_is_collapse_free_with_signed_zero_pair",
+  "transitivity_string_literals",
+  "transitivity_strict_typed_literals",
+  "transitivity_mixed_literal_kinds_incl_nan",
+  "transitivity_triple_terms_recursive",
+  "exact_int_order_agreement_incl_2p53_collapse",
+  "domain_x2_doubles_are_exact",
+  "witness_mixed_tier_collapse_now_exact",
+  "witness_numeric_vs_string_now_ranked_by_kind",
+  "witness_nan_now_totalised_first",
+]
+# compare.rs is std-only self-contained (no crate-internal imports), so the
+# proof cone is exactly this file.
+proves = ["crates/sparq-substrate/src/compare.rs"]
+nightly = true
+pr_gate = true
+
+# ---------------------------------------------------------------------------
+# Scheduled formal lanes watched by the no-verdict alarm (formal-alarm.yml /
+# scripts/formal_lane_alarm.py). `max_verdict_age_hours` — the longest a lane may
+# go without a SUCCESSFUL completed run on main before the alarm goes red and
+# files an issue. Both lanes are nightly, so 48h == two missed verdicts.
+# ---------------------------------------------------------------------------
+
+[[lane]]
+workflow = "kani.yml"
+description = "nightly Kani bounded-proof lane (all [[suite]] entries above with nightly = true)"
+owner_bead = "sq-hkud"
+max_verdict_age_hours = 48
+
+[[lane]]
+workflow = "miri.yml"
+description = "nightly Miri UB lane over sparq-core's pure-Rust unsafe surface (sharded nextest partitions + the doctest leg)"
+owner_bead = "sq-fo28"
+max_verdict_age_hours = 48

--- a/ci/path-ownership.toml
+++ b/ci/path-ownership.toml
@@ -207,3 +207,14 @@ safe = true
 [[map]]
 pattern = ".beads/**"
 safe = true
+
+# [FABLE-5] sq-63ups: the formal-verification manifest (proof suites -> verified
+# paths + the alarmed lanes). Consumed ONLY by the formal-verification.yml /
+# formal-alarm.yml workflows via scripts/fv_select.py / check-fv-manifest.py /
+# formal_lane_alarm.py — no workspace crate reads it, so it is inert for the Rust
+# test matrix. It is NOT inert for the FV workflow itself: scripts/fv_select.py
+# treats a change to this file as an FV full trigger (every pr_gate proof suite
+# runs on that PR), so this safe-listing weakens nothing.
+[[map]]
+pattern = "ci/formal-verification.toml"
+safe = true

--- a/scripts/check-fv-manifest.py
+++ b/scripts/check-fv-manifest.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+# [FABLE-5] Formal-verification manifest completeness + drift gate (bead sq-63ups).
+# 🤖 SPARQ agent.
+#
+# THE INVARIANT THIS GATE ENFORCES: a Kani proof cannot exist half-wired. Every
+# `#[kani::proof]` harness in the workspace is (a) inventoried in
+# ci/formal-verification.toml, (b) covered by a `proves` mapping so the
+# change-coupled PR selector (scripts/fv_select.py) re-runs it when the verified
+# code changes, and (c) — for `nightly = true` suites — present verbatim in the
+# kani.yml matrix. Before this gate, three harnesses sat in source for weeks
+# running in NO CI lane at all because kani.yml's hard-coded list silently
+# drifted from the source inventory; that class of rot is now diff-visible.
+#
+# FOUR CHECK DIRECTIONS:
+#   D1 coverage      — every workspace file containing a `#[cfg(kani)]` module or a
+#                      `#[kani::proof]` harness is matched by >= 1 suite's `proves`.
+#   D2 harness drift — per crate, the set of `#[kani::proof]` fn names in source
+#                      EQUALS the union of that crate's manifest harness lists
+#                      (both directions red: an unlisted new harness AND a stale
+#                      manifest entry). A harness listed in two suites is an error.
+#   D3 kani.yml drift— the kani.yml `matrix.suite` entries EQUAL the manifest's
+#                      `nightly = true` suites: same names, same crate, same
+#                      features, same harness sets.
+#   D4 honesty       — `pr_gate = false` requires `pr_gate_blocked_by` (enforced
+#                      by the shared manifest loader in scripts/fv_select.py).
+#
+# Parsing is COMMENT-AWARE line scanning: an attribute counts only when the
+# (stripped) line starts with it and is not a `//` comment — kani.yml's history
+# includes `#[kani::proof]` mentions inside doc comments (sparq-vectors store.rs)
+# that a naive grep double-counts. Block comments are not tracked (no harness
+# attribute lives inside one; the self-test pins the comment cases we have).
+#
+# Usage:
+#   check-fv-manifest.py                 # gate the live tree (repo root = cwd's git root)
+#   check-fv-manifest.py --root DIR      # explicit root (tests)
+#   check-fv-manifest.py --self-test     # hermetic should-pass + should-fail fixtures
+#
+# Dependencies: stdlib + PyYAML (only for parsing kani.yml; hash-pinned install in
+# the workflow — .github/requirements/docs-quality.txt). Exit 0 clean / 1 offences.
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import re
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+_FN_RE = re.compile(r"\bfn\s+(\w+)")
+
+
+def _load_fv_select():
+    """Import scripts/fv_select.py by path (scripts/ is not a package) so the
+    manifest loader + proves-glob matcher are shared, not duplicated."""
+    path = Path(__file__).resolve().parent / "fv_select.py"
+    spec = importlib.util.spec_from_file_location("fv_select", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# Source scanning (comment-aware)
+# --------------------------------------------------------------------------- #
+def scan_rust_file(text: str) -> tuple[bool, list[str]]:
+    """-> (has_kani_cfg_module, [harness fn names]) for one .rs file."""
+    lines = text.splitlines()
+    has_cfg = False
+    harnesses: list[str] = []
+    i = 0
+    n = len(lines)
+    while i < n:
+        s = lines[i].strip()
+        i += 1
+        if s.startswith("//"):
+            continue  # line/doc comment — attribute mentions in prose don't count
+        if s.startswith("#[cfg(kani)") or s.startswith("#[cfg(all(kani"):
+            has_cfg = True
+        if s.startswith("#[kani::proof]"):
+            # Scan forward past interleaved attributes/comments for the fn name.
+            j = i
+            while j < n:
+                t = lines[j].strip()
+                j += 1
+                if t.startswith("//") or t.startswith("#[") or not t:
+                    continue
+                m = _FN_RE.search(t)
+                if m:
+                    harnesses.append(m.group(1))
+                break
+    return has_cfg, harnesses
+
+
+def crate_name(cargo_toml: Path) -> str | None:
+    import tomllib
+
+    try:
+        with open(cargo_toml, "rb") as fh:
+            data = tomllib.load(fh)
+        return data.get("package", {}).get("name")
+    except (OSError, tomllib.TOMLDecodeError):
+        return None
+
+
+def scan_workspace(root: Path) -> tuple[dict[str, list[str]], set[str], dict[str, str]]:
+    """Scan crates/**/*.rs.
+
+    -> (file -> harness names (only files with >= 1), files with a #[cfg(kani)]
+    module or harness, file -> owning crate name). Paths repo-relative POSIX.
+    """
+    harness_files: dict[str, list[str]] = {}
+    kani_files: set[str] = set()
+    owners: dict[str, str] = {}
+    crate_cache: dict[Path, str | None] = {}
+    for rs in sorted((root / "crates").rglob("*.rs")):
+        try:
+            text = rs.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        if "kani" not in text:
+            continue  # cheap pre-filter
+        has_cfg, harnesses = scan_rust_file(text)
+        if not has_cfg and not harnesses:
+            continue
+        rel = rs.relative_to(root).as_posix()
+        kani_files.add(rel)
+        if harnesses:
+            harness_files[rel] = harnesses
+        # Nearest ancestor Cargo.toml owns the file.
+        for parent in rs.parents:
+            ct = parent / "Cargo.toml"
+            if ct.exists():
+                if ct not in crate_cache:
+                    crate_cache[ct] = crate_name(ct)
+                name = crate_cache[ct]
+                if name:
+                    owners[rel] = name
+                break
+    return harness_files, kani_files, owners
+
+
+# --------------------------------------------------------------------------- #
+# kani.yml matrix
+# --------------------------------------------------------------------------- #
+def load_kani_matrix(kani_yml: Path) -> list[dict]:
+    import yaml  # PyYAML: hash-pinned install in the fv-manifest job
+
+    with open(kani_yml, encoding="utf-8") as fh:
+        doc = yaml.safe_load(fh)
+    try:
+        suites = doc["jobs"]["kani"]["strategy"]["matrix"]["suite"]
+    except (KeyError, TypeError) as exc:
+        raise RuntimeError(f"{kani_yml}: cannot locate jobs.kani.strategy.matrix.suite: {exc}")
+    out = []
+    for s in suites:
+        out.append(
+            {
+                "name": str(s.get("name", "")),
+                "crate": str(s.get("crate", "")),
+                "features": str(s.get("features", "") or "").strip(),
+                "harnesses": sorted(str(s.get("harnesses", "")).split()),
+            }
+        )
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# The checks
+# --------------------------------------------------------------------------- #
+def run_checks(
+    suites: list[dict],
+    harness_files: dict[str, list[str]],
+    kani_files: set[str],
+    owners: dict[str, str],
+    kani_matrix: list[dict],
+    path_matches,
+) -> list[str]:
+    problems: list[str] = []
+
+    # D1 — every kani-bearing file is covered by >= 1 suite's proves.
+    all_proves = [(s["id"], pat) for s in suites for pat in s["proves"]]
+    for rel in sorted(kani_files):
+        if not any(path_matches(rel, pat) for _sid, pat in all_proves):
+            problems.append(
+                f"D1: {rel} contains a #[cfg(kani)] module but NO manifest suite's "
+                f"`proves` covers it — its proofs are invisible to the change-coupled "
+                f"PR selector (add it to a [[suite]].proves in ci/formal-verification.toml)"
+            )
+
+    # D2 — per-crate harness-set equality, both directions + uniqueness.
+    manifest_by_crate: dict[str, list[str]] = {}
+    seen: dict[str, str] = {}
+    for s in suites:
+        for h in s["harnesses"]:
+            if h in seen:
+                problems.append(
+                    f"D2: harness {h!r} listed by two suites ({seen[h]!r} and {s['id']!r})"
+                )
+            seen[h] = s["id"]
+            manifest_by_crate.setdefault(s["crate"], []).append(h)
+    source_by_crate: dict[str, list[str]] = {}
+    for rel, names in harness_files.items():
+        crate = owners.get(rel)
+        if crate is None:
+            problems.append(f"D2: {rel} has harnesses but no resolvable owning crate")
+            continue
+        source_by_crate.setdefault(crate, []).extend(names)
+    for crate in sorted(set(manifest_by_crate) | set(source_by_crate)):
+        src = set(source_by_crate.get(crate, []))
+        man = set(manifest_by_crate.get(crate, []))
+        for h in sorted(src - man):
+            problems.append(
+                f"D2: {crate}: source harness {h!r} (#[kani::proof]) is NOT in the "
+                f"manifest — a proof running in no wired suite"
+            )
+        for h in sorted(man - src):
+            problems.append(
+                f"D2: {crate}: manifest harness {h!r} does not exist in source — "
+                f"stale manifest entry (renamed/removed harness?)"
+            )
+
+    # D3 — kani.yml matrix == the nightly = true manifest suites.
+    nightly = {s["name"]: s for s in suites if s.get("nightly") is True}
+    matrix = {m["name"]: m for m in kani_matrix}
+    for name in sorted(set(nightly) - set(matrix)):
+        problems.append(f"D3: nightly suite {name!r} is missing from the kani.yml matrix")
+    for name in sorted(set(matrix) - set(nightly)):
+        problems.append(f"D3: kani.yml matrix entry {name!r} has no nightly manifest suite")
+    for name in sorted(set(nightly) & set(matrix)):
+        s, m = nightly[name], matrix[name]
+        if s["crate"] != m["crate"]:
+            problems.append(f"D3: {name!r}: crate mismatch ({s['crate']!r} vs {m['crate']!r})")
+        if str(s.get("features", "")).strip() != m["features"]:
+            problems.append(
+                f"D3: {name!r}: features mismatch ({s.get('features', '')!r} vs {m['features']!r})"
+            )
+        if sorted(s["harnesses"]) != m["harnesses"]:
+            problems.append(
+                f"D3: {name!r}: harness list drift (manifest {sorted(s['harnesses'])} "
+                f"vs kani.yml {m['harnesses']})"
+            )
+
+    return problems
+
+
+def check_tree(root: Path, manifest: Path, kani_yml: Path) -> list[str]:
+    fv = _load_fv_select()
+    try:
+        suites = fv.load_manifest(str(manifest))  # raises on shape/D4 problems
+    except Exception as exc:  # noqa: BLE001 — any manifest problem is a finding
+        return [f"manifest: {exc}"]
+    harness_files, kani_files, owners = scan_workspace(root)
+    try:
+        matrix = load_kani_matrix(kani_yml)
+    except Exception as exc:  # noqa: BLE001
+        return [f"kani.yml: {exc}"]
+    return run_checks(suites, harness_files, kani_files, owners, matrix, fv.path_matches)
+
+
+# --------------------------------------------------------------------------- #
+# Hermetic self-test — a consistent fixture tree must pass; each drift class
+# must fail. Runs before the real check in the fv-manifest job so a broken
+# checker can never green the gate.
+# --------------------------------------------------------------------------- #
+_FIXTURE_RS = """\
+//! Fixture crate. The next line is prose, not a harness: `#[kani::proof]`.
+// #[cfg(kani)] in a comment must not count either.
+#[cfg(kani)]
+mod kani_proofs {
+    use super::*;
+    #[kani::proof]
+    #[kani::unwind(9)]
+    fn h1() {}
+    #[kani::proof]
+    // interleaved comment
+    fn h2() {}
+}
+"""
+
+_FIXTURE_MANIFEST = """\
+schema = 1
+[[suite]]
+id = "a"
+name = "crate-a (proofs)"
+crate = "crate-a"
+features = "--features f"
+harnesses = ["h1", "h2"]
+proves = ["crates/ca/src/x.rs"]
+nightly = true
+pr_gate = true
+"""
+
+_FIXTURE_KANI_YML = """\
+jobs:
+  kani:
+    strategy:
+      matrix:
+        suite:
+          - name: "crate-a (proofs)"
+            crate: crate-a
+            features: "--features f"
+            harnesses: >-
+              h1
+              h2
+"""
+
+
+def self_test() -> int:
+    failures: list[str] = []
+
+    def build(td: Path, rs: str = _FIXTURE_RS, man: str = _FIXTURE_MANIFEST,
+              yml: str = _FIXTURE_KANI_YML) -> tuple[Path, Path, Path]:
+        (td / "crates/ca/src").mkdir(parents=True, exist_ok=True)
+        (td / "crates/ca/Cargo.toml").write_text('[package]\nname = "crate-a"\n')
+        (td / "crates/ca/src/x.rs").write_text(rs)
+        (td / "fv.toml").write_text(man)
+        (td / "kani.yml").write_text(yml)
+        return td, td / "fv.toml", td / "kani.yml"
+
+    def expect(problems: list[str], want_clean: bool, label: str, needle: str = "") -> None:
+        if want_clean and problems:
+            failures.append(f"{label}: expected clean, got {problems}")
+        if not want_clean:
+            if not problems:
+                failures.append(f"{label}: expected a finding, got clean")
+            elif needle and not any(needle in p for p in problems):
+                failures.append(f"{label}: no finding mentions {needle!r}: {problems}")
+
+    with tempfile.TemporaryDirectory() as s:
+        td = Path(s)
+        # 0. consistent tree passes (and the comment decoys are NOT counted).
+        expect(check_tree(*build(td)), True, "consistent fixture")
+        # 1. new source harness not in the manifest.
+        expect(check_tree(*build(td, rs=_FIXTURE_RS.replace(
+            "fn h2() {}", "fn h2() {}\n    #[kani::proof]\n    fn h3() {}"))),
+            False, "unlisted source harness", "h3")
+        # 2. stale manifest harness (removed from source).
+        expect(check_tree(*build(td, rs=_FIXTURE_RS.replace(
+            "    #[kani::proof]\n    // interleaved comment\n    fn h2() {}\n", ""))),
+            False, "stale manifest harness", "h2")
+        # 3. kani.yml harness drift.
+        expect(check_tree(*build(td, yml=_FIXTURE_KANI_YML.replace("\n              h2", ""))),
+               False, "kani.yml harness drift", "h2")
+        # 4. kani.yml missing the nightly suite entirely.
+        expect(check_tree(*build(td, yml=_FIXTURE_KANI_YML.replace(
+            "crate-a (proofs)", "crate-a (renamed)"))),
+            False, "kani.yml suite-name drift", "crate-a")
+        # 5. an uncovered #[cfg(kani)] file (no proves entry).
+        (td / "crates/ca/src/y.rs").write_text("#[cfg(kani)]\nmod kani_proofs {}\n")
+        expect(check_tree(td, td / "fv.toml", td / "kani.yml"),
+               False, "uncovered cfg(kani) file", "y.rs")
+        (td / "crates/ca/src/y.rs").unlink()
+        # 6. features drift between manifest and kani.yml.
+        expect(check_tree(*build(td, yml=_FIXTURE_KANI_YML.replace(
+            '"--features f"', '""'))),
+            False, "features drift", "features")
+
+    if failures:
+        for f in failures:
+            print(f"::error::check-fv-manifest self-test FAILED: {f}")
+        return 1
+    print("check-fv-manifest self-test: consistent fixture passes; all 6 drift classes red.")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="FV manifest completeness + drift gate.")
+    p.add_argument("--root", type=Path, default=REPO_ROOT)
+    p.add_argument("--manifest", type=Path)
+    p.add_argument("--kani-yml", type=Path)
+    p.add_argument("--self-test", action="store_true")
+    args = p.parse_args(argv)
+    if args.self_test:
+        return self_test()
+    root = args.root
+    manifest = args.manifest or root / "ci" / "formal-verification.toml"
+    kani_yml = args.kani_yml or root / ".github" / "workflows" / "kani.yml"
+    problems = check_tree(root, manifest, kani_yml)
+    if problems:
+        for prob in problems:
+            print(f"::error::{prob}")
+        print(
+            f"check-fv-manifest: {len(problems)} problem(s). The manifest "
+            f"(ci/formal-verification.toml), the source `#[kani::proof]` inventory and "
+            f"the kani.yml matrix must move together — see the findings above."
+        )
+        return 1
+    print("check-fv-manifest: manifest, source harness inventory and kani.yml matrix agree.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/formal_lane_alarm.py
+++ b/scripts/formal_lane_alarm.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+# [FABLE-5] Formal-lane NO-VERDICT alarm (bead sq-63ups). 🤖 SPARQ agent.
+#
+# WHAT THIS IS: the "silence must not look like green" safeguard for the SCHEDULED
+# formal-verification lanes (kani.yml, miri.yml — the [[lane]] entries in
+# ci/formal-verification.toml). Those lanes are deliberately OFF the per-PR critical
+# path (nightly cron, no PR check-run), which means their failure mode is INVISIBLE:
+# miri.yml was CANCELLED at its 90-minute ceiling 22 consecutive nights (2026-06-16 →
+# 2026-07-07) — conclusion `cancelled`, never `failure` — and no human or gate noticed,
+# because nothing red ever appeared anywhere. This script makes that class of rot loud:
+# a lane whose newest SUCCESSFUL completed run on main is older than the manifest's
+# `max_verdict_age_hours` (48h = two missed nightly verdicts) REDs this checker's own
+# scheduled run AND files ONE deduped, self-identified SPARQ-agent GitHub issue.
+#
+# VERDICT DEFINITION (honest, run-level): a lane "has a verdict" iff a workflow RUN on
+# main completed with conclusion `success` inside the window. A completed FAILURE run is
+# a LOUD verdict for a human (the lane is visibly red in the Actions tab) but it is NOT
+# a successful verdict — per the mandate, >48h without green is alarm-worthy either way;
+# the issue body distinguishes the two cases (SILENT: cancelled/no runs at all vs RED:
+# failing loudly) so triage starts in the right place. Note the consequence, stated
+# plainly: while a lane is red every night on a KNOWN budget problem (e.g. the two
+# mmap-validator totality harnesses, sq-og8u8), this alarm keeps one open issue alive —
+# that is deliberate standing pressure, not noise (the dedupe key caps it at one issue).
+#
+# TWO DESIGN INVARIANTS (mirrors scripts/ci_selection_alarm.py):
+#   1. FAIL-LOUD: an alarm-INFRASTRUCTURE error (cannot read the manifest, cannot list
+#      workflow runs) exits NON-ZERO with a `::error::` annotation — a broken detector
+#      must never look like a quiet green.
+#   2. NON-SPAMMY: one open issue per lane, keyed by a stable
+#      `<!-- formal-alarm-key: <workflow> -->` body marker searched over open
+#      `formal-alarm`-labelled issues before filing (the flow-on idempotency mechanism).
+#
+# NOT A GATE: this runs from a schedule on main (formal-alarm.yml); it creates no
+# check-run on any PR head, so it can never interact with the `ci-summary / gate` poll
+# set. Redding this run blocks nothing — it exists to be SEEN.
+#
+# Usage:
+#   formal_lane_alarm.py                          # real (gh api; env GITHUB_REPOSITORY)
+#   formal_lane_alarm.py --dry-run                # print findings; no gh writes
+#   formal_lane_alarm.py --runs-file runs.json \
+#       --now 2026-07-07T12:00:00Z --dry-run      # hermetic (tests)
+#   formal_lane_alarm.py --self-test              # hermetic fixtures
+#
+# Stdlib only + the `gh` CLI (present on every GitHub runner).
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_MANIFEST = REPO_ROOT / "ci" / "formal-verification.toml"
+
+BASE_LABELS = ["formal-alarm", "auto"]
+KEY_PREFIX = "formal-alarm-key"
+
+
+class AlarmError(Exception):
+    """Alarm-INFRASTRUCTURE failure — surfaced LOUD (non-zero exit)."""
+
+
+# --------------------------------------------------------------------------- #
+# Manifest
+# --------------------------------------------------------------------------- #
+def load_lanes(manifest: Path) -> list[dict]:
+    import tomllib
+
+    try:
+        with open(manifest, "rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise AlarmError(f"cannot read manifest {manifest}: {exc}") from exc
+    lanes = data.get("lane")
+    if not isinstance(lanes, list) or not lanes:
+        raise AlarmError(f"{manifest}: [[lane]] array missing or empty")
+    for i, lane in enumerate(lanes):
+        if "workflow" not in lane or "max_verdict_age_hours" not in lane:
+            raise AlarmError(f"{manifest}: lane #{i} needs workflow + max_verdict_age_hours")
+    return lanes
+
+
+# --------------------------------------------------------------------------- #
+# Run history (gh api, or a hermetic --runs-file)
+# --------------------------------------------------------------------------- #
+def _gh_json(args: list[str]) -> dict:
+    try:
+        out = subprocess.run(
+            ["gh", "api", *args], check=True, capture_output=True, text=True, timeout=120
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise AlarmError(f"gh api {' '.join(args)} failed: {detail}") from exc
+    try:
+        return json.loads(out.stdout)
+    except json.JSONDecodeError as exc:
+        raise AlarmError(f"gh api {' '.join(args)}: unparseable JSON: {exc}") from exc
+
+
+def fetch_lane_runs(repo: str, workflow: str, runs_file: str | None) -> list[dict]:
+    """-> completed runs on main, newest first: [{conclusion, created_at}]."""
+    if runs_file:
+        with open(runs_file, encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data.get(workflow, [])
+    resp = _gh_json(
+        [
+            f"repos/{repo}/actions/workflows/{workflow}/runs"
+            f"?branch=main&status=completed&per_page=20"
+        ]
+    )
+    runs = resp.get("workflow_runs")
+    if runs is None:
+        raise AlarmError(f"{workflow}: response carries no workflow_runs")
+    return [{"conclusion": r.get("conclusion"), "created_at": r.get("created_at")} for r in runs]
+
+
+def _parse_iso(ts: str) -> dt.datetime:
+    return dt.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+
+
+# --------------------------------------------------------------------------- #
+# The check (pure)
+# --------------------------------------------------------------------------- #
+def check_lane(lane: dict, runs: list[dict], now: dt.datetime) -> dict | None:
+    """-> a violation dict, or None when the lane has a fresh successful verdict."""
+    workflow = lane["workflow"]
+    max_age = float(lane["max_verdict_age_hours"])
+    successes = [r for r in runs if r.get("conclusion") == "success"]
+    newest_success = None
+    if successes:
+        newest_success = max(_parse_iso(r["created_at"]) for r in successes)
+        age_h = (now - newest_success).total_seconds() / 3600.0
+        if age_h <= max_age:
+            return None
+    recent = [str(r.get("conclusion")) for r in runs[:7]]
+    # Classification for triage: a lane failing LOUDLY (completed failures) needs a
+    # different first move than one dying SILENTLY (cancelled-at-ceiling / never runs).
+    mode = "RED" if any(c == "failure" for c in recent) else "SILENT"
+    return {
+        "workflow": workflow,
+        "mode": mode,
+        "max_age_hours": max_age,
+        "last_success": newest_success.isoformat() if newest_success else None,
+        "recent_conclusions": recent,
+        "owner_bead": lane.get("owner_bead", ""),
+        "description": lane.get("description", ""),
+    }
+
+
+def render_issue(v: dict) -> tuple[str, str]:
+    since = v["last_success"] or "NEVER (no successful run on main in the fetched window)"
+    title = (
+        f"formal-alarm: {v['workflow']} has produced no successful verdict "
+        f"for >{int(v['max_age_hours'])}h"
+    )
+    body = "\n".join(
+        [
+            "> 🤖 **SPARQ agent** — automated formal-lane no-verdict alarm "
+            "(scripts/formal_lane_alarm.py, bead sq-63ups). @jeswr runs multiple agents "
+            "on this account; this issue was filed by CI automation.",
+            "",
+            f"<!-- {KEY_PREFIX}: {v['workflow']} -->",
+            "",
+            f"The scheduled formal lane `{v['workflow']}` ({v['description']}) has produced "
+            f"**no successful verdict on `main` for more than {int(v['max_age_hours'])} hours**.",
+            "",
+            f"* Failure mode: **{v['mode']}** — "
+            + (
+                "the lane is completing with `failure` (loudly red in the Actions tab); "
+                "read the newest run's step summary for the failing harnesses/tests."
+                if v["mode"] == "RED"
+                else "the lane is being cancelled/never completing (e.g. killed at its "
+                "`timeout-minutes` ceiling) — the failure class that produces NO signal "
+                "anywhere. Read the newest run's log tail to see where it stalled."
+            ),
+            f"* Newest successful run: `{since}`",
+            f"* Recent completed-run conclusions (newest first): {v['recent_conclusions']}",
+            f"* Owner bead: `{v['owner_bead']}`" if v["owner_bead"] else "* Owner bead: (none)",
+            "",
+            "A formal lane with no verdict is NOT green — it is unverified. Fix the lane "
+            "(or the code it verifies); do not mute this alarm. Config: "
+            "`ci/formal-verification.toml` `[[lane]]`.",
+        ]
+    )
+    return title, body
+
+
+# --------------------------------------------------------------------------- #
+# Issue minting (mirrors ci_selection_alarm.py: label upsert + open-issue dedupe)
+# --------------------------------------------------------------------------- #
+def _run_gh(args: list[str]) -> str:
+    try:
+        out = subprocess.run(args, check=True, capture_output=True, text=True, timeout=120)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise AlarmError(f"{' '.join(args)} failed: {detail}") from exc
+    return out.stdout
+
+
+def ensure_labels(repo: str) -> None:
+    for label in BASE_LABELS:
+        _run_gh(["gh", "label", "create", label, "--repo", repo, "--force"])
+
+
+def open_issue_exists(repo: str, workflow: str) -> bool:
+    out = _run_gh(
+        [
+            "gh", "issue", "list", "--repo", repo, "--state", "open",
+            "--label", BASE_LABELS[0], "--json", "number,body", "--limit", "100",
+        ]
+    )
+    marker = f"{KEY_PREFIX}: {workflow}"
+    return any(marker in (item.get("body") or "") for item in json.loads(out or "[]"))
+
+
+def file_issue(repo: str, v: dict) -> None:
+    title, body = render_issue(v)
+    args = ["gh", "issue", "create", "--repo", repo, "--title", title, "--body", body]
+    for label in BASE_LABELS:
+        args += ["--label", label]
+    url = _run_gh(args).strip()
+    print(f"filed: {url}")
+
+
+# --------------------------------------------------------------------------- #
+# main
+# --------------------------------------------------------------------------- #
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Formal-lane no-verdict alarm.")
+    p.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    p.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", ""))
+    p.add_argument("--now", help="ISO timestamp override (tests)")
+    p.add_argument("--runs-file", help="hermetic: JSON {workflow: [{conclusion, created_at}]}")
+    p.add_argument("--dry-run", action="store_true", help="print findings; no gh writes")
+    p.add_argument("--self-test", action="store_true")
+    args = p.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    try:
+        lanes = load_lanes(args.manifest)
+        if not args.repo and not args.runs_file:
+            raise AlarmError("--repo (or GITHUB_REPOSITORY) is required for a live run")
+        now = _parse_iso(args.now) if args.now else dt.datetime.now(dt.timezone.utc)
+
+        violations: list[dict] = []
+        for lane in lanes:
+            runs = fetch_lane_runs(args.repo, lane["workflow"], args.runs_file)
+            v = check_lane(lane, runs, now)
+            if v is None:
+                print(f"OK: {lane['workflow']} has a successful verdict inside "
+                      f"{lane['max_verdict_age_hours']}h")
+            else:
+                violations.append(v)
+                print(f"::error title=formal lane has no verdict::{v['workflow']}: no "
+                      f"successful run on main for >{int(v['max_age_hours'])}h "
+                      f"(mode={v['mode']}; last success={v['last_success']}; "
+                      f"recent={v['recent_conclusions']})")
+
+        if not violations:
+            print("formal-lane alarm: every scheduled formal lane has a fresh verdict.")
+            return 0
+
+        if args.dry_run:
+            for v in violations:
+                title, body = render_issue(v)
+                print(f"--- DRY RUN issue ---\n{title}\n{body}\n")
+        else:
+            ensure_labels(args.repo)
+            for v in violations:
+                if open_issue_exists(args.repo, v["workflow"]):
+                    print(f"dedupe: open formal-alarm issue already tracks {v['workflow']}")
+                else:
+                    file_issue(args.repo, v)
+        # LOUD: the alarm run itself goes red while any lane is verdict-less.
+        return 1
+    except AlarmError as exc:
+        # FAIL-LOUD: infrastructure breakage must never look like a quiet green.
+        print(f"::error title=formal-lane alarm infrastructure error::{exc}")
+        return 2
+
+
+# --------------------------------------------------------------------------- #
+# Hermetic self-test
+# --------------------------------------------------------------------------- #
+_FIXTURE_MANIFEST = """\
+schema = 1
+[[suite]]
+id = "a"
+name = "n"
+crate = "c"
+harnesses = ["h"]
+proves = ["crates/c/src/x.rs"]
+nightly = true
+pr_gate = true
+[[lane]]
+workflow = "kani.yml"
+owner_bead = "sq-hkud"
+max_verdict_age_hours = 48
+[[lane]]
+workflow = "miri.yml"
+max_verdict_age_hours = 48
+"""
+
+
+def self_test() -> int:
+    failures: list[str] = []
+    now = _parse_iso("2026-07-07T12:00:00Z")
+
+    def check(cond: bool, label: str) -> None:
+        if not cond:
+            failures.append(label)
+
+    lane = {"workflow": "miri.yml", "max_verdict_age_hours": 48, "owner_bead": "sq-fo28"}
+    # 1. fresh success => no violation.
+    check(
+        check_lane(lane, [{"conclusion": "success", "created_at": "2026-07-07T05:20:00Z"}], now)
+        is None,
+        "fresh success passes",
+    )
+    # 2. stale success + cancelled tail => SILENT violation.
+    v = check_lane(
+        lane,
+        [
+            {"conclusion": "cancelled", "created_at": "2026-07-07T05:20:00Z"},
+            {"conclusion": "cancelled", "created_at": "2026-07-06T05:20:00Z"},
+            {"conclusion": "success", "created_at": "2026-07-01T05:20:00Z"},
+        ],
+        now,
+    )
+    check(v is not None and v["mode"] == "SILENT", "stale+cancelled is a SILENT violation")
+    # 3. no runs at all => SILENT violation with last_success None.
+    v = check_lane(lane, [], now)
+    check(v is not None and v["last_success"] is None, "no-runs is a violation")
+    # 4. completed failures => RED violation (loud but still verdict-less).
+    v = check_lane(
+        lane, [{"conclusion": "failure", "created_at": "2026-07-07T05:20:00Z"}], now
+    )
+    check(v is not None and v["mode"] == "RED", "failing lane is a RED violation")
+    # 5. success just inside the window passes; just outside fails.
+    check(
+        check_lane(lane, [{"conclusion": "success", "created_at": "2026-07-05T13:00:00Z"}], now)
+        is None,
+        "47h-old success passes",
+    )
+    check(
+        check_lane(lane, [{"conclusion": "success", "created_at": "2026-07-05T11:00:00Z"}], now)
+        is not None,
+        "49h-old success violates",
+    )
+    # 6. end-to-end via main(): hermetic runs-file + dry-run => exit 1 + rendered issue.
+    with tempfile.TemporaryDirectory() as td:
+        man = Path(td) / "fv.toml"
+        man.write_text(_FIXTURE_MANIFEST)
+        runs = Path(td) / "runs.json"
+        runs.write_text(json.dumps({
+            "kani.yml": [{"conclusion": "success", "created_at": "2026-07-07T07:00:00Z"}],
+            "miri.yml": [{"conclusion": "cancelled", "created_at": "2026-07-07T05:20:00Z"}],
+        }))
+        rc = main([
+            "--manifest", str(man), "--runs-file", str(runs),
+            "--now", "2026-07-07T12:00:00Z", "--dry-run", "--repo", "x/y",
+        ])
+        check(rc == 1, "hermetic e2e: one stale lane => exit 1")
+        # 7. all-fresh => exit 0.
+        runs.write_text(json.dumps({
+            "kani.yml": [{"conclusion": "success", "created_at": "2026-07-07T07:00:00Z"}],
+            "miri.yml": [{"conclusion": "success", "created_at": "2026-07-07T06:00:00Z"}],
+        }))
+        rc = main([
+            "--manifest", str(man), "--runs-file", str(runs),
+            "--now", "2026-07-07T12:00:00Z", "--dry-run", "--repo", "x/y",
+        ])
+        check(rc == 0, "hermetic e2e: all fresh => exit 0")
+        # 8. unreadable manifest => infrastructure error exit 2 (fail-loud).
+        rc = main([
+            "--manifest", str(Path(td) / "missing.toml"), "--runs-file", str(runs),
+            "--now", "2026-07-07T12:00:00Z", "--dry-run", "--repo", "x/y",
+        ])
+        check(rc == 2, "missing manifest => fail-loud exit 2")
+
+    if failures:
+        for f in failures:
+            print(f"::error::formal_lane_alarm self-test FAILED: {f}")
+        return 1
+    print("formal_lane_alarm self-test: freshness window, SILENT/RED classification, "
+          "e2e exits all behaved.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/fv_select.py
+++ b/scripts/fv_select.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+# [FABLE-5] Change-coupled formal-verification selector (bead sq-63ups). 🤖 SPARQ agent.
+#
+# WHAT: given a PR / merge-group diff, decide which Kani proof suites from
+# ci/formal-verification.toml must run ON THIS PR as gating checks. A suite is
+# selected iff it is `pr_gate = true` AND the diff touches one of its `proves`
+# paths (the source files whose correctness its harnesses establish). Unrelated
+# PRs select nothing and the heavy proof jobs are `if:`-skipped (the ci-summary
+# aggregator treats `skipped` as satisfied once the selection pre-job succeeded).
+#
+# FAIL-CLOSED CONTRACT (mirrors scripts/ci_select.py, design §4.3 of
+# research/change-based-test-selection.md):
+#   * any FV full-run trigger changed (this manifest, this script, the
+#     completeness gate, the FV workflow, kani.yml)  => ALL pr_gate suites run;
+#   * any diff/infrastructure error with a READABLE manifest => ALL pr_gate
+#     suites run, exit 0 (a selector bug degrades to running more, never less);
+#   * an UNREADABLE/INVALID manifest => exit 1. Unlike ci_select.py we cannot
+#     "run everything" without the manifest (it IS the suite list), so the only
+#     sound degradation is a red select job — and because the job name carries
+#     the phrase "change-based test selection", scripts/ci_summary_gate.py REDs
+#     the whole gate when this job does not conclude success, so the skips on
+#     the commit can never be trusted on the back of a broken selector.
+#
+# OUTPUTS ($GITHUB_OUTPUT):
+#   any    — "true" | "false": whether any suite was selected (job-level guard;
+#            an empty fromJSON matrix is a workflow error, so the proof job is
+#            `if:`-guarded on this instead).
+#   suites — JSON array of {name, crate, features, harnesses} objects (harnesses
+#            space-joined) consumed directly as the proof job's matrix.
+#
+# Usage:
+#   fv_select.py --event pull_request --base <sha> --head <sha>
+#   fv_select.py --event merge_group --base <sha> --head <sha>
+#   fv_select.py --changed-file paths.txt --manifest fv.toml   # hermetic (tests)
+#   fv_select.py --self-test                                   # hermetic fixtures
+#
+# Stdlib only (tomllib >= 3.11). Runs under the runner's system python3 / the
+# CI setup-python 3.12.
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+DEFAULT_MANIFEST = "ci/formal-verification.toml"
+
+# A change to any of these re-obligates EVERY pr_gate suite (the selection
+# policy / harness wiring itself moved — absence of proof means run, mirroring
+# ci_select.py `_FULL_TRIGGERS`). Deliberately NOT keyed on Cargo.lock /
+# toolchain pins: every proof cone in the manifest is intra-crate pure code and
+# the nightly kani.yml lane re-proves the full matrix daily as the backstop.
+FV_FULL_TRIGGERS = (
+    "ci/formal-verification.toml",
+    "scripts/fv_select.py",
+    "scripts/check-fv-manifest.py",
+    ".github/workflows/formal-verification.yml",
+    ".github/workflows/kani.yml",
+)
+
+
+class ManifestError(Exception):
+    """The manifest is unreadable/invalid — the ONE non-fail-open error (exit 1)."""
+
+
+class SelectorError(Exception):
+    """Any other internal failure. main() traps this => all pr_gate suites, exit 0."""
+
+
+def load_manifest(path: str) -> list[dict]:
+    """Return the [[suite]] list. Raises ManifestError on any shape problem."""
+    import tomllib
+
+    try:
+        with open(path, "rb") as fh:
+            data = tomllib.load(fh)
+    except (OSError, tomllib.TOMLDecodeError) as exc:
+        raise ManifestError(f"cannot read manifest {path}: {exc}") from exc
+    suites = data.get("suite")
+    if not isinstance(suites, list) or not suites:
+        raise ManifestError(f"{path}: [[suite]] array missing or empty")
+    for i, s in enumerate(suites):
+        for key in ("id", "name", "crate", "harnesses", "proves"):
+            if key not in s:
+                raise ManifestError(f"{path}: suite #{i} missing key {key!r}")
+        if not isinstance(s["harnesses"], list) or not s["harnesses"]:
+            raise ManifestError(f"{path}: suite {s.get('id')!r}: empty harness list")
+        if not isinstance(s["proves"], list) or not s["proves"]:
+            raise ManifestError(f"{path}: suite {s.get('id')!r}: empty proves list")
+        if s.get("pr_gate") is False and not s.get("pr_gate_blocked_by"):
+            raise ManifestError(
+                f"{path}: suite {s.get('id')!r}: pr_gate=false requires pr_gate_blocked_by"
+            )
+    return suites
+
+
+def path_matches(path: str, pattern: str) -> bool:
+    """`dir/**` matches the dir or anything beneath it; otherwise fnmatch
+    (an exact path is its own fnmatch). Same semantics as ci_select.py's map."""
+    if pattern.endswith("/**"):
+        root = pattern[:-3]
+        return path == root or path.startswith(root + "/")
+    return fnmatch.fnmatch(path, pattern)
+
+
+def select_suites(changed_paths: list[str], suites: list[dict]) -> tuple[list[dict], str]:
+    """Pure core: (changed paths, manifest suites) -> (selected pr_gate suites, reason)."""
+    gate_suites = [s for s in suites if s.get("pr_gate") is True]
+    for path in changed_paths:
+        path = path.strip()
+        if any(path_matches(path, trig) for trig in FV_FULL_TRIGGERS):
+            return gate_suites, f"FV full trigger changed ({path}): all pr_gate suites run"
+    selected: list[dict] = []
+    hits: list[str] = []
+    for s in gate_suites:
+        matched = [
+            p for p in changed_paths if any(path_matches(p.strip(), pat) for pat in s["proves"])
+        ]
+        if matched:
+            selected.append(s)
+            hits.append(f"{s['id']} <= {', '.join(sorted(set(matched)))}")
+    if selected:
+        return selected, "; ".join(hits)
+    return [], "no verified path touched; every proof suite provably unaffected"
+
+
+def to_matrix(selected: list[dict]) -> list[dict]:
+    return [
+        {
+            "name": s["name"],
+            "crate": s["crate"],
+            "features": s.get("features", ""),
+            "harnesses": " ".join(s["harnesses"]),
+        }
+        for s in selected
+    ]
+
+
+def git_changed_paths(base: str, head: str) -> list[str]:
+    # Three-dot = diff against the merge-base; --no-renames reports a move as
+    # delete+add so BOTH paths are attributed (same as ci_select.py).
+    try:
+        out = subprocess.run(
+            ["git", "diff", "--name-only", "--no-renames", f"{base}...{head}"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        raise SelectorError(f"git diff failed: {exc}") from exc
+    return [ln for ln in out.stdout.splitlines() if ln.strip()]
+
+
+def write_outputs(selected: list[dict], reason: str, output_file: str | None,
+                  summary_file: str | None) -> None:
+    matrix = to_matrix(selected)
+    if output_file:
+        with open(output_file, "a", encoding="utf-8") as fh:
+            fh.write(f"any={'true' if matrix else 'false'}\n")
+            fh.write("suites=" + json.dumps(matrix) + "\n")
+    if summary_file:
+        with open(summary_file, "a", encoding="utf-8") as fh:
+            fh.write("### 🤖 Formal-verification selection (fv-select)\n\n")
+            fh.write(f"**Reason:** {reason}\n\n")
+            if matrix:
+                fh.write("| Suite | Crate | Harnesses |\n| --- | --- | --- |\n")
+                for m in matrix:
+                    fh.write(
+                        f"| {m['name']} | `{m['crate']}` | {len(m['harnesses'].split())} |\n"
+                    )
+            else:
+                fh.write("No proof suite selected — the change-coupled Kani job is skipped.\n")
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Change-coupled formal-verification selector.")
+    p.add_argument("--event", default="pull_request")
+    p.add_argument("--base")
+    p.add_argument("--head", default="HEAD")
+    p.add_argument("--changed-file", help="hermetic: newline-delimited changed paths")
+    p.add_argument("--manifest", default=DEFAULT_MANIFEST)
+    p.add_argument("--output-file")
+    p.add_argument("--summary-file")
+    p.add_argument("--self-test", action="store_true")
+    args = p.parse_args(argv)
+
+    if args.self_test:
+        return self_test()
+
+    output_file = args.output_file or os.environ.get("GITHUB_OUTPUT")
+    summary_file = args.summary_file or os.environ.get("GITHUB_STEP_SUMMARY")
+
+    # An unreadable manifest is NOT trapped: red select job => red gate (header).
+    suites = load_manifest(args.manifest)
+
+    try:
+        if args.event not in ("pull_request", "merge_group"):
+            raise SelectorError(f"event {args.event!r} carries no sound diff pair")
+        if args.changed_file:
+            with open(args.changed_file, encoding="utf-8") as fh:
+                changed = [ln for ln in fh.read().splitlines() if ln.strip()]
+        else:
+            if not args.base:
+                raise SelectorError("--base is required for a diff-based run")
+            changed = git_changed_paths(args.base, args.head)
+        selected, reason = select_suites(changed, suites)
+    except SelectorError as exc:
+        # Fail-closed: run every pr_gate suite (more, never less), exit 0.
+        selected = [s for s in suites if s.get("pr_gate") is True]
+        reason = f"selector error, failing closed to all pr_gate suites: {exc}"
+
+    print(json.dumps({"reason": reason, "suites": to_matrix(selected)}, indent=2))
+    try:
+        write_outputs(selected, reason, output_file, summary_file)
+    except OSError as exc:
+        print(f"::error::fv-select could not write outputs: {exc}")
+        return 1
+    return 0
+
+
+# --------------------------------------------------------------------------- #
+# Hermetic self-test (run as a gating step before the real selection)
+# --------------------------------------------------------------------------- #
+_FIXTURE_MANIFEST = """\
+schema = 1
+[[suite]]
+id = "a"
+name = "crate-a (proofs)"
+crate = "crate-a"
+features = "--features f"
+harnesses = ["h1", "h2"]
+proves = ["crates/crate-a/src/x.rs", "crates/shared/src/dep.rs"]
+nightly = true
+pr_gate = true
+[[suite]]
+id = "b"
+name = "crate-b (slow proofs)"
+crate = "crate-b"
+features = ""
+harnesses = ["h3"]
+proves = ["crates/crate-b/src/**"]
+nightly = true
+pr_gate = false
+pr_gate_blocked_by = "sq-xxxx"
+"""
+
+
+def self_test() -> int:
+    import tomllib  # noqa: F401  (assert availability early)
+
+    failures: list[str] = []
+
+    def check(cond: bool, label: str) -> None:
+        if not cond:
+            failures.append(label)
+
+    with tempfile.TemporaryDirectory() as td:
+        man = os.path.join(td, "fv.toml")
+        with open(man, "w", encoding="utf-8") as fh:
+            fh.write(_FIXTURE_MANIFEST)
+        suites = load_manifest(man)
+
+        # 1. touching a proved path selects exactly its suite.
+        sel, _ = select_suites(["crates/crate-a/src/x.rs", "README.md"], suites)
+        check([s["id"] for s in sel] == ["a"], "proved-path selects its suite")
+        # 2. a shared proves path selects every suite listing it.
+        sel, _ = select_suites(["crates/shared/src/dep.rs"], suites)
+        check([s["id"] for s in sel] == ["a"], "shared cone path selects dependents")
+        # 3. an unrelated diff selects nothing.
+        sel, _ = select_suites(["site/app/page.tsx", "docs/x.md"], suites)
+        check(sel == [], "unrelated diff selects nothing")
+        # 4. a pr_gate=false suite is NEVER selected, even on a direct hit.
+        sel, _ = select_suites(["crates/crate-b/src/lib.rs"], suites)
+        check(sel == [], "pr_gate=false suite is never PR-selected")
+        # 5. an FV full trigger selects ALL pr_gate suites.
+        sel, reason = select_suites(["ci/formal-verification.toml"], suites)
+        check([s["id"] for s in sel] == ["a"] and "full trigger" in reason,
+              "full trigger selects all pr_gate suites")
+        # 6. glob proves patterns match beneath the root.
+        check(path_matches("crates/crate-b/src/deep/mod.rs", "crates/crate-b/src/**"),
+              "dir/** glob matches nested path")
+        # 7. malformed manifest => ManifestError (the exit-1 path).
+        bad = os.path.join(td, "bad.toml")
+        with open(bad, "w", encoding="utf-8") as fh:
+            fh.write("[[suite]]\nid = 'x'\n")  # missing required keys
+        try:
+            load_manifest(bad)
+            failures.append("malformed manifest must raise")
+        except ManifestError:
+            pass
+        # 8. pr_gate=false without an owner bead => ManifestError.
+        bad2 = os.path.join(td, "bad2.toml")
+        with open(bad2, "w", encoding="utf-8") as fh:
+            fh.write(_FIXTURE_MANIFEST.replace('pr_gate_blocked_by = "sq-xxxx"\n', ""))
+        try:
+            load_manifest(bad2)
+            failures.append("pr_gate=false without blocked_by must raise")
+        except ManifestError:
+            pass
+
+    if failures:
+        for f in failures:
+            print(f"::error::fv_select self-test FAILED: {f}")
+        return 1
+    print("fv_select self-test: all fixtures behaved (selection + fail modes).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> 🤖 **SPARQ agent** (Claude Fable 5 — [FABLE-5] markers) — bead **sq-63ups**. @jeswr runs multiple agents on this account.

Maintainer mandate: CI must (a) **check that the formal verifications hold** and (b) **force proofs to be re-obligated when the verified code changes**. Before this PR the formal estate was 100% nightly/advisory and 0% change-coupled, 32 of 41 Kani harnesses ran in **no CI lane at all**, and the Miri lane had **never produced a verdict**.

## 1. Unwired Kani suites → wired (`.github/workflows/kani.yml`)

* **sparq-engine `--features vectorized`** (6 reducer result-equivalence harnesses, sq-sqtk2.3) and **sparq-substrate `--features compare`** (26 ORDER-law harnesses, sq-sqtk2.4) added to the nightly matrix.
* The **2** harnesses present in source but absent from kani.yml's hard-coded list are now wired: `domain_id_partition_regions_are_all_nonempty` + `domain_dict_validator_accepts_the_empty_dict` (both dict.rs PR #1536 domain self-checks). The task brief said 3 — a comment-aware sweep of every `#[kani::proof]` in the workspace finds **2** (41 harnesses total: 7 dict + 2 store + 6 reduce + 26 compare); the third was a miscount, presumably double-counting the engine domain self-check that ships inside the engine suite.
* The single sparq-core matrix entry is **split**: the 5 seconds-fast id-partition/domain harnesses now report an honest green job instead of being dragged red nightly by the 2 mmap-validator totality harnesses that exceed the 20m CBMC budget (sq-og8u8, red every night — that red stays, honestly, in its own job).
* Advisory-registry: the kani job-name template (`kani ${{ matrix.suite.name }} (bounded proofs, informational)`) is unchanged, so the registered entry still covers every matrix row; `check-advisory-registry.py` green.

## 2. Proof→paths manifest + change-coupling (NEW gating surface)

**`ci/formal-verification.toml`** — every suite: `{id, name, crate, features, harnesses, proves, nightly, pr_gate[, pr_gate_blocked_by]}` + the alarmed `[[lane]]`s. `proves` is the proof cone: e.g. the reducer harnesses re-derive inline-id constants from `sparq-core/src/dict.rs`, so dict.rs is in their cone; `compare.rs` is std-only self-contained so its cone is exactly itself (file-precise: substrate LFTJ perf PRs do **not** trigger the ORDER-law suite).

**`.github/workflows/formal-verification.yml`** (pull_request + merge_group):
* `fv-select (change-based test selection)` — `scripts/fv_select.py` maps the three-dot diff onto `proves`. The name deliberately matches the ci-summary `SELECT_RE` contract: if this job doesn't conclude success, the required `ci-summary / gate` REDs outright, so a skipped proof job can never be trusted on the back of a broken selector. Fail-closed: FV-trigger paths (manifest/selector/kani.yml/this workflow) or any selector error ⇒ **all** pr_gate suites; unreadable manifest ⇒ red select ⇒ red gate.
* `kani <suite> (change-coupled proofs)` — the selected suites run **on the PR and GATE** (no advisory/informational token; same per-harness timeout + step-summary machinery as the nightly lane). Unrelated PRs: suite job skipped ⇒ satisfied ⇒ zero cost.
* `fv-manifest (proof inventory completeness + drift)` — `scripts/check-fv-manifest.py`, gating on every PR (seconds-cheap, no cargo): REDs when a `#[cfg(kani)]` module is uncovered by any `proves` (D1), when the source `#[kani::proof]` inventory and manifest harness lists disagree **in either direction** (D2), when kani.yml's matrix drifts from the `nightly = true` suites (D3), or when `pr_gate = false` lacks an owner bead (D4). This is what makes a stale/unwired proof impossible to ignore silently — the exact rot this PR found (item 1) can't recur.

**Honest scoping — which suites gate PRs:** the 2 validator-totality suites (`.spqv` + dict-mmap) are `pr_gate = false, pr_gate_blocked_by = "sq-og8u8"`: their harnesses time out at 20m on the CI runner class **every night** and have never completed in CI — gating PRs on a proof that cannot terminate would block every dict.rs/store.rs PR on a pre-existing solver-budget problem, not on PR content. dict.rs PRs still get a gating proof leg (the id-partition suite shares the file). Flip path is recorded in the manifest and noted on sq-og8u8.

Selector behaviour (local, hermetic `--changed-file` runs):
| diff | selected |
|---|---|
| `compare.rs` | substrate ORDER laws only |
| `lftj.rs` + site page | **nothing** (proof jobs skipped) |
| `dict.rs` | core id-partition + engine reducers |
| `kani.yml` | all pr_gate suites (FV full trigger) |

## 3. Dead Miri lane — diagnosis + fix (`.github/workflows/miri.yml`)

**Diagnosis (worse than briefed):** every scheduled run since the lane's first night (2026-06-16, **22 consecutive nights** — not 3) was cancelled at the 90-minute `timeout-minutes` ceiling; the lane has *never* produced a verdict. The 2026-07-07 log: lib binary starts 97 tests at 08:36, 45 complete by 08:50 (~15 min), then **zero output for the remaining ~75 min**. Root cause is the single long-lived interpreter process, not any one test: the test at the stall point (`store::tests::build_raw_perms_no_capacity_slack`, 400 triples) passes in **~44s in a fresh Miri process** on the work box — per-test cost inflates as the process ages (rayon global pool + crossbeam-epoch state persist across tests; Miri's borrow-tracking metadata grows monotonically).

**Fix (coverage identical, root cause addressed):** `cargo miri nextest run -p sparq-core --partition count:k/12 --no-fail-fast` across a 12-shard matrix — process-per-test (fresh interpreter each test, kills the accumulation mode; real multi-core parallelism) with count-partitioning (every test in exactly one shard; round-robin spreads the alphabetically-clustered heavy modules). Doctests kept via a dedicated `miri-doctests` job (nextest doesn't run them; sparq-core has one; seconds under Miri — verified locally, including that it fails under Stacked Borrows and passes under the lane's Tree Borrows flags, re-confirming MIRIFLAGS are load-bearing). New `.config/nextest.toml` configures **only** `[profile.default-miri]` (auto-selected under Miri — verified locally) with a 100-min per-test terminate cap under a 130-min job ceiling, so a pathological test reds its shard **by name** instead of silently eating the ceiling; normal ci.yml nextest runs are untouched.

**Shard calibration (honest):** the local shard-1-of-6 run exposed a second, real cost the accumulation bug was masking — the test set is bimodal under Miri: most tests are ms-to-seconds, but roughly a third are heavy end-to-end loader tests at ~50-70+ min EACH in a fresh interpreter (measured on the work box; worst observed still running past 70 min on a near-uncontended core). Six shards would not have fit comfortably; twelve round-robin shards put ~2-3 heavies per shard, which run in parallel inside the shard, bounding the wall near max(single heavy) — inside the ceiling, with the terminate cap guaranteeing a named verdict either way. The PROPER cost fix is `cfg(miri)` input-scaling of the heavy tests (standard Miri practice, a crates/ change out of this PR's CI-only scope) — follow-up bead sq-0s15k filed; the shard count can drop once that lands. (`.config/nextest.toml` is the one file outside my staging lanes — a test-harness config genuinely required by the fix.)

## 4. No-verdict alarm (`.github/workflows/formal-alarm.yml`)

`scripts/formal_lane_alarm.py` (daily 07:41 UTC + dispatch, mirrors the selection-alarm plumbing): a `[[lane]]` workflow with no **successful** completed run on main inside `max_verdict_age_hours` (48h = two missed nightlies) reds the checker and files ONE deduped SPARQ-agent issue (`formal-alarm` label + `<!-- formal-alarm-key -->` marker — the flow-on idempotency mechanism; issue→bead reconciliation stays out-of-band, CI never touches `.beads/`). SILENT (cancelled/no runs — the Miri failure class) vs RED (failing loudly) is classified in the issue body. Fail-loud: infra errors exit non-zero. Not a gate: scheduled on main, never on a PR head.

**Expect it red at first**, honestly: today's live dry-run flags BOTH lanes (kani = RED ×7 nights on the og8u8 totality timeouts; miri = SILENT ×22). Miri should green once this PR's shard fix runs; kani's alarm issue stays open as standing pressure until sq-og8u8 — deliberate, capped at one issue.

## Local evidence (61 GB aarch64 work box — non-canonical timings, upper bounds: suites ran concurrently)

* **Kani 0.67, all 34 newly-wired harnesses PASS**: substrate 26/26 (total ~27 min; worst `transitivity_mixed_literal_kinds_incl_nan` 929s — flagged on the validation bead as a first-CI-run budget risk vs the 20m ceiling), engine 6/6 (sum 589s / count 335s / min_id 886s / max_id 802s / narrow_sum 7s / domain self-check 11s — worst harness well inside the 20m per-harness budget even under contention), core domain self-checks 22s + 15s (+ `inline_id_round_trip` control 6s).
* **Miri**: `cargo miri nextest run` plumbing + the `default-miri` auto-profile verified locally; the shard run surfaced the bimodal cost profile above (per-test timings in the PR discussion once the local run completes); doctest leg 1/1 in ~3s under the lane's MIRIFLAGS (and it red-fails under default Stacked Borrows — the flags are load-bearing, re-verified).
* Hermetic self-tests green for all three scripts (each runs as a gating step before the real check in its workflow); `check-fv-manifest.py` against the live tree: manifest ⇄ source inventory ⇄ kani.yml agree — and it correctly red-flagged the pre-fix kani.yml drift during development.
* `actionlint` clean on all four workflows; `yaml.safe_load`/`tomllib` clean on every touched file; `test_ci_select_wiring.py` (32), `test_ci_summary_gate.py`, `test_ci_select.py`, `test_path_ownership.py` (28), `check-advisory-registry.py` all green with this tree.

## Compliance framing (honest level)

This closes the "formal verification exists but is not enforced" gap: proofs are now (a) all wired to a lane, (b) drift-locked to source, (c) re-obligated + gating on change, (d) alarmed on silence. It does **not** upgrade the proofs' assurance level itself: bounded model checking with the documented bounds, still `informational` on the nightly tier per the registry's promotion criteria (credentialed formal-methods review, sq-hkud), and the change-coupled tier gates only the suites that can actually terminate in CI.

Self-validating rollout: this PR touches kani.yml (an FV full trigger), so `fv-select` runs **all three pr_gate suites on this very PR** — the change-coupled tier and the GH-runner suite wall-times get their first live validation here, gating this merge. Documented-untested until their scheduled runs: the 6-shard Miri matrix wall-times (nightly-only) and the formal-alarm live issue filing (logic verified by hermetic self-test + a live dry-run). Follow-up validation bead filed.

Do-not-arm: per the task brief this PR is left un-armed for maintainer/orchestrator review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
