### PR TITLE
bench(update): extend PSS update harness to Fuseki + Oxigraph, wrap in envelope (sq-hmd7l.5)

### DIFF
--- a/bench/pss-update-set/compare.py
+++ b/bench/pss-update-set/compare.py
@@ -1,38 +1,49 @@
 #!/usr/bin/env python3
 # [OPUS-4.8] sq-b4lo / gh-52 — written while Fable 5 unavailable; re-review when Fable returns.
-"""sparq vs QLever — WRITE-PATH parity on the PSS (Solid pod-server) update set.
+# [SONNET-4.6] sq-hmd7l.5 — extended to Fuseki + Oxigraph; post-workload store-state oracle added.
+"""sparq vs QLever / Fuseki / Oxigraph — WRITE-PATH parity on the PSS (Solid pod-server) update set.
 
-  compare.py <iters> [--sparq URL] [--qlever URL] [--qlever-token TOK] [--tolerance F]
+  compare.py <iters> [--sparq URL] [--qlever URL] [--qlever-token TOK]
+             [--fuseki URL] [--oxigraph URL] [--tolerance F] [--json-out FILE]
 
 gh-52 locked sparq's Phase-2 serving contract to "N readers against 1 sequenced
 writer + external coordination" (see crates/sparq-server/README.md → "Concurrency
 contract"). The binding acceptance criterion for that single writer is **parity-or-
 better vs the QLever-over-HTTP write path on PSS's actual update set** — NOT bulk
 ingest. This script is that gate: it fires the SAME interactive SPARQL UPDATEs (the
-PSS LDP-CRUD shapes) at BOTH a running sparq-server and a running QLever endpoint
-over HTTP on one box, measures per-update commit latency on each, and FAILS (exit 1)
-if sparq's p99 regresses past QLever's by more than --tolerance (default 1.0 = exact
-parity-or-better).
+PSS LDP-CRUD shapes) at a running sparq-server AND any of QLever / Fuseki / Oxigraph
+endpoints over HTTP on one box, measures per-update commit latency on each, and FAILS
+(exit 1) if sparq's p99 regresses past any competitor's by more than --tolerance
+(default 1.0 = exact parity-or-better).
+
+Store-state oracle (sq-hmd7l.5 INVARIANT): after the workload a COUNT of named-graph
+quads is run against each active engine's query endpoint.  Disagreement is recorded
+honestly in the output — latency numbers are flagged but NOT suppressed (the gate is
+honesty, not a blind pass).
+
+Engine URLs:
+  --sparq    Full SPARQL endpoint URL (query + update via POST; default
+             http://127.0.0.1:7020/sparql). sparq-server accepts both
+             application/sparql-query and application/sparql-update on this path.
+  --qlever   QLever base URL (update via form POST; omit to skip QLever;
+             default None — QLever is skipped unless this flag is provided)
+  --qlever-token TOKEN  QLever access token for the update endpoint (optional)
+  --fuseki   Fuseki dataset base URL (update: <url>/update, query: <url>/query;
+             e.g. http://127.0.0.1:3030/ds; omit to skip Fuseki)
+  --oxigraph Oxigraph base URL (update: <url>/update, query: <url>/query;
+             e.g. http://127.0.0.1:7878; omit to skip Oxigraph)
+  --tolerance FLOAT  p99 parity tolerance multiplier (default 1.0 = exact parity)
+  --json-out FILE    write machine-readable results summary to FILE (JSON)
 
 This intentionally mirrors `bench/qlever-olympics/compare.py` (the READ-path
-comparison) for the WRITE path. Both engines must be running and writable:
+comparison) for the WRITE path. The active engines must be running and writable;
+see scripts/bench/update-same-box.sh for the durable start/stop orchestration.
 
-  # sparq (this repo):
-  cargo run -p sparq-server --release -- --addr 127.0.0.1:7020   # no auth = writable
-
-  # QLever (see bench/qlever-olympics/README.md for the venv + qlever CLI):
-  #   the Qleverfile must enable updates; ACCESS_TOKEN gates the update endpoint.
-  ../../.qlever-venv/bin/qlever start    # serving on :7019, writable with the token
-
-  # then, from this directory:
-  python3 compare.py 5 --qlever-token <ACCESS_TOKEN>
-
-Honesty: QLever's write path is an external Docker-on-host process; its numbers are
-machine-specific and are NOT committed anywhere (repo hygiene forbids hard-coded
-perf). This script measures both live, on the same box, in the same run — the only
-fair way to assert a RELATIVE bar. For a sparq-only smoke (no QLever), use the
-`pss_update_throughput` binary in bench/serve with `--qlever-baseline-ms <recorded>`.
+Honesty: numbers are machine-specific and are NOT committed anywhere (repo hygiene
+forbids hard-coded perf). This script measures engines live, on the same box, in the
+same run — the only fair way to assert a RELATIVE bar.
 """
+import json as _json
 import sys
 import time
 import urllib.error
@@ -44,21 +55,37 @@ def parse_args(argv):
     iters = int(argv[1]) if len(argv) > 1 and not argv[1].startswith("-") else 200
     opts = {
         "sparq": "http://127.0.0.1:7020/sparql",
-        "qlever": "http://127.0.0.1:7019",
+        "qlever": None,
         "qlever_token": None,
+        "fuseki": None,
+        "oxigraph": None,
         "tolerance": 1.0,
+        "json_out": None,
     }
     i = 2 if (len(argv) > 1 and not argv[1].startswith("-")) else 1
     while i < len(argv):
         a = argv[i]
         if a == "--sparq":
-            opts["sparq"] = argv[i + 1]; i += 2
+            opts["sparq"] = argv[i + 1]
+            i += 2
         elif a == "--qlever":
-            opts["qlever"] = argv[i + 1]; i += 2
+            opts["qlever"] = argv[i + 1]
+            i += 2
         elif a == "--qlever-token":
-            opts["qlever_token"] = argv[i + 1]; i += 2
+            opts["qlever_token"] = argv[i + 1]
+            i += 2
+        elif a == "--fuseki":
+            opts["fuseki"] = argv[i + 1]
+            i += 2
+        elif a == "--oxigraph":
+            opts["oxigraph"] = argv[i + 1]
+            i += 2
         elif a == "--tolerance":
-            opts["tolerance"] = float(argv[i + 1]); i += 2
+            opts["tolerance"] = float(argv[i + 1])
+            i += 2
+        elif a == "--json-out":
+            opts["json_out"] = argv[i + 1]
+            i += 2
         else:
             sys.exit(f"unknown arg {a}")
     return iters, opts
@@ -138,11 +165,45 @@ def qlever_update(base, token, sparql):
     data = {"update": sparql}
     if token:
         data["access-token"] = token
-    req = urllib.request.Request(base, data=urllib.parse.urlencode(data).encode(), method="POST")
+    req = urllib.request.Request(
+        base,
+        data=urllib.parse.urlencode(data).encode(),
+        method="POST",
+    )
     with urllib.request.urlopen(req, timeout=60) as r:
         r.read()
         if r.status not in (200, 204):
             raise RuntimeError(f"qlever update HTTP {r.status}")
+
+
+def fuseki_update(base, sparql):
+    """POST SPARQL UPDATE to a Fuseki dataset update endpoint (<base>/update)."""
+    url = base.rstrip("/") + "/update"
+    req = urllib.request.Request(
+        url,
+        data=sparql.encode(),
+        headers={"content-type": "application/sparql-update"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        r.read()
+        if r.status not in (200, 204):
+            raise RuntimeError(f"fuseki update HTTP {r.status}")
+
+
+def oxigraph_update(base, sparql):
+    """POST SPARQL UPDATE to an Oxigraph server update endpoint (<base>/update)."""
+    url = base.rstrip("/") + "/update"
+    req = urllib.request.Request(
+        url,
+        data=sparql.encode(),
+        headers={"content-type": "application/sparql-update"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=60) as r:
+        r.read()
+        if r.status not in (200, 204):
+            raise RuntimeError(f"oxigraph update HTTP {r.status}")
 
 
 def measure(label, fn, updates):
@@ -166,30 +227,191 @@ def pct(sorted_ms, p):
     return sorted_ms[idx]
 
 
+# --- Post-workload store-state oracle (sq-hmd7l.5 INVARIANT) ----------------
+
+# Count named-graph quads as a deterministic store-state fingerprint after the workload.
+_COUNT_Q = "SELECT (COUNT(*) AS ?n) WHERE { GRAPH ?g { ?s ?p ?o } }"
+
+
+def _parse_sparql_count_json(data):
+    """Extract first ?n binding value from SPARQL results JSON bytes."""
+    obj = _json.loads(data)
+    bindings = obj.get("results", {}).get("bindings", [])
+    return bindings[0]["n"]["value"] if bindings else "0"
+
+
+def state_count(query_url):
+    """POST COUNT(*) over named-graph quads to a standard SPARQL query endpoint.
+
+    Returns the count string or 'ERROR:<reason>'.
+    """
+    req = urllib.request.Request(
+        query_url,
+        data=_COUNT_Q.encode(),
+        headers={
+            "content-type": "application/sparql-query",
+            "accept": "application/sparql-results+json",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return _parse_sparql_count_json(r.read())
+    except Exception as exc:  # noqa: BLE001
+        return f"ERROR:{exc}"
+
+
+def state_count_qlever(base, token=None):
+    """COUNT named-graph quads via QLever's form-POST query endpoint."""
+    data = {"query": _COUNT_Q}
+    if token:
+        data["access-token"] = token
+    req = urllib.request.Request(
+        base,
+        data=urllib.parse.urlencode(data).encode(),
+        headers={"accept": "application/sparql-results+json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=30) as r:
+            return _parse_sparql_count_json(r.read())
+    except Exception as exc:  # noqa: BLE001
+        return f"ERROR:{exc}"
+
+
 def main():
     iters, opts = parse_args(sys.argv)
     updates = update_set(iters)
-    print(f"# PSS write-path parity — {len(updates)} interactive LDP-CRUD updates, parity-or-better gate\n")
 
-    sparq = measure("sparq", lambda u: sparq_update(opts["sparq"], u), updates)
-    qlever = measure(
-        "qlever", lambda u: qlever_update(opts["qlever"], opts["qlever_token"], u), updates
+    # --- Build the active engine set -----------------------------------------
+    # List of (label, update_driver) for engines that have a URL configured.
+    active = []
+    if opts["sparq"]:
+        active.append(("sparq", lambda u: sparq_update(opts["sparq"], u)))
+    if opts["qlever"]:
+        tok = opts["qlever_token"]
+        qlever_base = opts["qlever"]
+        active.append(("qlever", lambda u: qlever_update(qlever_base, tok, u)))
+    if opts["fuseki"]:
+        fuseki_base = opts["fuseki"]
+        active.append(("fuseki", lambda u: fuseki_update(fuseki_base, u)))
+    if opts["oxigraph"]:
+        oxi_base = opts["oxigraph"]
+        active.append(("oxigraph", lambda u: oxigraph_update(oxi_base, u)))
+
+    engine_labels = [n for n, _ in active]
+    print(
+        f"# PSS write-path parity — {len(updates)} interactive LDP-CRUD updates,"
+        f" engines: {engine_labels}\n"
     )
 
-    hdr = f"{'engine':<8} {'p50(ms)':>9} {'p99(ms)':>9} {'max(ms)':>9} {'thr(/s)':>9}"
+    # --- Measure each engine sequentially (same box, fair relative comparison) --
+    lat = {}
+    for label, driver in active:
+        lat[label] = measure(label, driver, updates)
+
+    # --- Latency table --------------------------------------------------------
+    hdr = f"{'engine':<10} {'p50(ms)':>9} {'p99(ms)':>9} {'max(ms)':>9} {'thr(/s)':>9}"
     print(hdr)
     print("-" * len(hdr))
-    for label, lat in (("sparq", sparq), ("qlever", qlever)):
-        total = sum(lat) / 1000.0
-        thr = len(lat) / total if total > 0 else float("nan")
-        print(f"{label:<8} {pct(lat,0.5):>9.2f} {pct(lat,0.99):>9.2f} {lat[-1]:>9.2f} {thr:>9.0f}")
+    for label, times in lat.items():
+        total_s = sum(times) / 1000.0
+        thr = len(times) / total_s if total_s > 0 else float("nan")
+        print(
+            f"{label:<10} {pct(times, 0.5):>9.2f} {pct(times, 0.99):>9.2f}"
+            f" {times[-1]:>9.2f} {thr:>9.0f}"
+        )
 
-    s99, q99 = pct(sparq, 0.99), pct(qlever, 0.99)
-    bar = q99 * opts["tolerance"]
-    print(f"\n# parity gate: sparq p99 {s99:.2f}ms vs QLever p99 {q99:.2f}ms × tol {opts['tolerance']} = {bar:.2f}ms")
-    if s99 > bar:
-        sys.exit(f"PARITY FAIL: sparq single-writer p99 {s99:.2f}ms regressed past QLever-parity bar {bar:.2f}ms")
-    print("PARITY OK: sparq single-writer is parity-or-better vs QLever on the PSS update set")
+    # --- Post-workload store-state oracle (sq-hmd7l.5 INVARIANT) ---------------
+    # Count named-graph quads per engine; disagreement is recorded honestly —
+    # latency numbers are NOT suppressed (the gate is honesty, not a blind pass).
+    counts = {}
+    if opts["sparq"]:
+        counts["sparq"] = state_count(opts["sparq"])
+    if opts["qlever"]:
+        counts["qlever"] = state_count_qlever(opts["qlever"], opts["qlever_token"])
+    if opts["fuseki"]:
+        counts["fuseki"] = state_count(opts["fuseki"].rstrip("/") + "/query")
+    if opts["oxigraph"]:
+        counts["oxigraph"] = state_count(opts["oxigraph"].rstrip("/") + "/query")
+
+    non_error_counts = {e: v for e, v in counts.items() if not v.startswith("ERROR")}
+    state_agree = len(set(non_error_counts.values())) <= 1
+
+    print("\n# post-workload named-graph quad COUNT (store-state oracle):")
+    for e, v in counts.items():
+        print(f"#   {e}: {v}")
+    if non_error_counts:
+        print(f"#   all_agree: {state_agree}")
+    if not state_agree:
+        print(
+            "# WARNING: store-state MISMATCH across engines —"
+            " latency rows are flagged but NOT suppressed"
+        )
+
+    # --- Relative parity gate -------------------------------------------------
+    parity_gate = "single-engine-skip"
+    parity_note = "single-engine run — relative parity gate skipped"
+
+    if "sparq" in lat and len(lat) >= 2:
+        s99 = pct(lat["sparq"], 0.99)
+        fails = []
+        for comp, times in lat.items():
+            if comp == "sparq":
+                continue
+            c99 = pct(times, 0.99)
+            bar = c99 * opts["tolerance"]
+            print(
+                f"\n# parity gate: sparq p99 {s99:.2f}ms vs {comp} p99 {c99:.2f}ms"
+                f" × tol {opts['tolerance']} = {bar:.2f}ms"
+            )
+            if s99 > bar:
+                fails.append(
+                    f"PARITY FAIL: sparq single-writer p99 {s99:.2f}ms regressed past"
+                    f" {comp}-parity bar {bar:.2f}ms"
+                )
+        if fails:
+            parity_gate = "fail"
+            parity_note = "; ".join(fails)
+        else:
+            parity_gate = "pass"
+            parity_note = (
+                "sparq single-writer is parity-or-better vs all active engines"
+                " on the PSS update set"
+            )
+
+    print(f"\n# parity_gate: {parity_gate}")
+    print(f"# {parity_note}")
+
+    # --- Optional machine-readable JSON output --------------------------------
+    if opts["json_out"]:
+        latency_ms = {
+            e: {
+                "p50": round(pct(t, 0.5), 3),
+                "p99": round(pct(t, 0.99), 3),
+                "max": round(t[-1], 3),
+            }
+            for e, t in lat.items()
+        }
+        throughput_s = {}
+        for e, t in lat.items():
+            total_s = sum(t) / 1000.0
+            throughput_s[e] = round(len(t) / total_s, 1) if total_s > 0 else 0.0
+
+        summary = {
+            "latency_ms": latency_ms,
+            "throughput_s": throughput_s,
+            "state_count": counts,
+            "state_agree": state_agree,
+            "parity_gate": parity_gate,
+            "parity_note": parity_note,
+        }
+        with open(opts["json_out"], "w", encoding="utf-8") as fh:
+            _json.dump(summary, fh, indent=2)
+            fh.write("\n")
+
+    if parity_gate == "fail":
+        sys.exit(parity_note)
 
 
 if __name__ == "__main__":

--- a/bench/pss-update-set/compare.py
+++ b/bench/pss-update-set/compare.py
@@ -26,7 +26,9 @@ Engine URLs:
              http://127.0.0.1:7020/sparql). sparq-server accepts both
              application/sparql-query and application/sparql-update on this path.
   --qlever   QLever base URL (update via form POST; omit to skip QLever;
-             default None — QLever is skipped unless this flag is provided)
+             default None — QLever is skipped unless this flag is provided,
+             EXCEPT that --qlever-token alone implies http://127.0.0.1:7019
+             for backward-compat with the registered pss-update-parity invoke)
   --qlever-token TOKEN  QLever access token for the update endpoint (optional)
   --fuseki   Fuseki dataset base URL (update: <url>/update, query: <url>/query;
              e.g. http://127.0.0.1:3030/ds; omit to skip Fuseki)
@@ -88,6 +90,11 @@ def parse_args(argv):
             i += 2
         else:
             sys.exit(f"unknown arg {a}")
+    # Backward-compat with the registered pss-update-parity invocation
+    # (bench/benchmarks.toml passes only --qlever-token): a token implies the
+    # historical local QLever endpoint unless --qlever overrides it.
+    if opts["qlever"] is None and opts["qlever_token"] is not None:
+        opts["qlever"] = "http://127.0.0.1:7019"
     return iters, opts
 
 

--- a/research/gap-update-2026-07.md
+++ b/research/gap-update-2026-07.md
@@ -1,0 +1,78 @@
+<!-- [SONNET-4.6] sq-hmd7l.5 — SPARQL-UPDATE competitor gap record. -->
+# SPARQL UPDATE competitor gap — July 2026
+
+Part of the comparative-benchmarking-everything program
+(`research/comparative-benchmarking-everything.md` §4 row 16, epic sq-hmd7l).
+
+## Status
+
+**NON-canonical first read.** The harness (`scripts/bench/update-same-box.sh`) is the
+durable deliverable. Numbers from the shared work box are directional only — do not bake
+into docs or dashboards. Canonical numbers ride sq-hmd7l.26 (quiet EC2 run).
+
+## Harness
+
+`bench/pss-update-set/compare.py` — extended in sq-hmd7l.5 to drive three engines:
+
+| engine | kind | update endpoint | query endpoint |
+|---|---|---|---|
+| sparq | loopback `sparq-server` | `POST /sparql` (application/sparql-update) | `POST /sparql` (application/sparql-query) |
+| fuseki | Docker `stain/jena-fuseki` | `POST /ds/update` | `POST /ds/query` |
+| oxigraph | Docker `oxigraph/oxigraph` | `POST /update` | `POST /query` |
+
+All three engines use the same HTTP `application/sparql-update` POST shape. The
+workload is the PSS LDP-CRUD update set (interleaved DELETE/INSERT/DROP representing a
+Solid pod-server's CRUD stream — `put_document`, `set_acl`, `delete_document` ops).
+
+Shell orchestration: `scripts/bench/update-same-box.sh` (follows the `shacl-same-box.sh`
+template: `ONLY=` engine filtering, `TIMEOUT_S` per-engine cap, `canonical:false` off the
+quiet box, one JSON envelope per run).
+
+## Store-state oracle (invariant)
+
+After each engine completes the full workload, a COUNT query is run against its query
+endpoint:
+
+```sparql
+SELECT (COUNT(*) AS ?n) WHERE { GRAPH ?g { ?s ?p ?o } }
+```
+
+This counts named-graph quads — the only graph layer the PSS update set writes to.
+Disagreement across engines is recorded honestly in `count_crosscheck.all_agree`; latency
+rows are never suppressed on a mismatch. This is the sq-hmd7l.5 INVARIANT.
+
+## Parity gate
+
+Relative only: `sparq p99 ≤ competitor p99 × tolerance` (default tolerance = 1.0). No
+absolute wall-clock threshold is committed (forbidden by AGENTS.md). A single-engine
+smoke run skips the gate entirely.
+
+## Engine availability on this box
+
+| engine | status | note |
+|---|---|---|
+| sparq | built from workspace | `cargo build --release -p sparq-server` |
+| fuseki | Docker (requires daemon + image pull) | `stain/jena-fuseki`, in-memory dataset |
+| oxigraph | Docker (requires daemon + image pull) | `oxigraph/oxigraph` |
+
+Engines not runnable on the current box skip gracefully with `status: absent` in the
+envelope. The smoke test (`ONLY=sparq bash scripts/bench/update-same-box.sh --smoke`)
+exercises only the sparq loopback path.
+
+## First-read rows
+
+**NON-canonical — work box, not a quiet EC2 instance.** All numbers below are
+directional only.
+
+No canonical rows yet. See sq-hmd7l.26 for the scheduled quiet-box harvest.
+
+## BSBM Explore-and-Update
+
+The BSBM Explore-and-Update workload (the standard multi-engine update benchmark suite)
+is a follow-up axis. `bench/bsbm` notes it as EC2/nightly tier — heavier corpus and
+longer run than the PSS interactive-CRUD set. Tracked separately from this record.
+
+## Follow-ups
+
+- sq-hmd7l.26: canonical wave-1 execution on a quiet EC2 box (this record's numbers land there)
+- BSBM Explore-and-Update column: EC2/nightly tier follow-up (see `bench/bsbm`)

--- a/scripts/bench/update-same-box.sh
+++ b/scripts/bench/update-same-box.sh
@@ -1,0 +1,380 @@
+#!/usr/bin/env bash
+# [SONNET-4.6] sq-hmd7l.5 — SPARQL-UPDATE same-box competitor comparison harness:
+# sparq vs Fuseki/TDB2 + Oxigraph server on the PSS LDP-CRUD update set, emitting
+# one canonical-competitor-results ENVELOPE per run (the exact JSON shape expected by
+# the comparative-benchmarking program, research/comparative-benchmarking-everything.md
+# §4 row 16).
+#
+# This script is the companion to bench/pss-update-set/compare.py (which does the
+# per-engine HTTP measurement and store-state oracle) and follows the shacl-same-box.sh
+# template: envelope JSON, TIMEOUT_S, ONLY= filtering, canonical:false off the quiet box.
+#
+# WORKLOAD: the PSS LDP-CRUD update set (bench/pss-update-set/compare.py): interleaved
+# DELETE/INSERT/DROP operations representing a Solid pod-server's CRUD stream. All engines
+# receive the SAME sequence of SPARQL UPDATE POST requests; their post-workload quad
+# COUNT is cross-checked for store-state agreement BEFORE any latency row is trusted.
+#
+# INVARIANT (sq-hmd7l.5): after the workload, a COUNT of named-graph quads is run
+# against each active engine's query endpoint. Disagreement is recorded honestly in the
+# envelope (count_crosscheck.all_agree = false); numbers are never adjusted or suppressed.
+#
+# PARITY GATE: relative — sparq p99 ≤ competitor p99 × tolerance. No absolute wall-clock
+# threshold is ever baked in (forbidden by AGENTS.md). A single-engine (smoke) run skips
+# the gate.
+#
+# USAGE
+#   scripts/bench/update-same-box.sh                     # all engines
+#   ONLY=sparq scripts/bench/update-same-box.sh --smoke  # loopback sparq only (smoke)
+#   ONLY="sparq fuseki" scripts/bench/update-same-box.sh
+#
+# TUNABLES (env; all have safe defaults):
+#   ITERS       update count per engine (default 200; --smoke overrides to 5)
+#   TIMEOUT_S   per-engine workload wall-clock cap, seconds (default 300)
+#   ONLY        engine subset of "sparq fuseki oxigraph" (default all three)
+#   OUT_DIR     envelope output dir (default /tmp/update-same-box-results;
+#               a canonical run points this at bench/canonical-competitor-results/<date>/)
+#   CANONICAL   1 = a dedicated quiet-box run (default 0: NON-canonical)
+#   SPARQ_BIN   sparq-server binary path (default: build from workspace if not present)
+#   SPARQ_PORT  loopback port for sparq-server (default 7020)
+#   FUSEKI_PORT loopback port for the Fuseki Docker container (default 3030)
+#   OXI_PORT    loopback port for the Oxigraph Docker container (default 7878)
+#
+# ENGINES NOT RUNNABLE (Docker unavailable, image pull fails, build fails):
+#   A graceful skip with status "absent" in the envelope. Never a fabricated row.
+#
+# SCRATCH: container images are transient gather-only deps — NOT committed to git.
+# Delete them when done: docker rmi stain/jena-fuseki oxigraph/oxigraph
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "${HERE}/../.." && pwd)"
+cd "${ROOT}"
+
+ITERS="${ITERS:-200}"
+TIMEOUT_S="${TIMEOUT_S:-300}"
+ONLY="${ONLY:-sparq fuseki oxigraph}"
+OUT_DIR="${OUT_DIR:-/tmp/update-same-box-results}"
+CANONICAL="${CANONICAL:-0}"
+SPARQ_PORT="${SPARQ_PORT:-7020}"
+FUSEKI_PORT="${FUSEKI_PORT:-3030}"
+OXI_PORT="${OXI_PORT:-7878}"
+SPARQ_BIN="${SPARQ_BIN:-${ROOT}/target/release/sparq-server}"
+
+SMOKE=0
+for _arg in "$@"; do
+  if [[ "${_arg}" == "--smoke" ]]; then
+    SMOKE=1
+  fi
+done
+if [[ "${SMOKE}" == "1" ]]; then
+  ITERS=5
+fi
+
+log() { printf '[update-same-box] %s\n' "$*" >&2; }
+want() { [[ " ${ONLY} " == *" $1 "* ]]; }
+docker_ok() { docker info >/dev/null 2>&1; }
+
+mkdir -p "${OUT_DIR}"
+TMP="$(mktemp -d /tmp/update-same-box.XXXXXX)"
+
+# --- Cleanup: stop servers on EXIT -------------------------------------------
+SPARQ_PID=""
+FUSEKI_CID=""
+OXI_CID=""
+
+cleanup() {
+  if [[ -n "${SPARQ_PID}" ]]; then
+    kill "${SPARQ_PID}" 2>/dev/null || true
+  fi
+  if [[ -n "${FUSEKI_CID}" ]]; then
+    docker stop "${FUSEKI_CID}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${OXI_CID}" ]]; then
+    docker stop "${OXI_CID}" >/dev/null 2>&1 || true
+  fi
+  rm -rf "${TMP}"
+}
+trap 'cleanup' EXIT
+
+GIT_COMMIT="$(git -C "${ROOT}" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+
+# ---- 1. sparq ---------------------------------------------------------------
+SPARQ_STATUS=absent
+SPARQ_VERSION=""
+if want sparq; then
+  if [[ ! -x "${SPARQ_BIN}" ]]; then
+    log "building sparq-server (cargo build --release -p sparq-server)..."
+    cargo build --release -p sparq-server 2>&1 | tail -3 >&2
+  fi
+  if [[ -x "${SPARQ_BIN}" ]]; then
+    log "starting sparq-server on 127.0.0.1:${SPARQ_PORT}"
+    "${SPARQ_BIN}" --addr "127.0.0.1:${SPARQ_PORT}" \
+      > "${TMP}/sparq-server.log" 2>&1 &
+    SPARQ_PID=$!
+    # probe until ready using sparq's built-in health-probe (up to 30 s)
+    _ready=0
+    for _i in $(seq 1 60); do
+      if "${SPARQ_BIN}" --health-probe \
+            --health-probe-addr "127.0.0.1:${SPARQ_PORT}" \
+            >/dev/null 2>&1; then
+        _ready=1
+        break
+      fi
+      sleep 0.5
+    done
+    if [[ "${_ready}" == "1" ]]; then
+      SPARQ_STATUS=ok
+      SPARQ_VERSION="${GIT_COMMIT}"
+      log "sparq-server ready (pid ${SPARQ_PID})"
+    else
+      log "sparq-server did not become ready in 30 s; status=absent"
+      kill "${SPARQ_PID}" 2>/dev/null || true
+      SPARQ_PID=""
+    fi
+  else
+    log "sparq-server binary not found after build; status=absent"
+  fi
+fi
+
+# ---- 2. Fuseki (Docker / stain/jena-fuseki) ---------------------------------
+FUSEKI_STATUS=absent
+FUSEKI_VERSION=""
+FUSEKI_IMAGE="stain/jena-fuseki"
+if want fuseki; then
+  if docker_ok; then
+    log "pulling ${FUSEKI_IMAGE} (if not cached)..."
+    if timeout 120 docker pull "${FUSEKI_IMAGE}" >/dev/null 2>&1; then
+      log "starting Fuseki on 127.0.0.1:${FUSEKI_PORT} (in-memory /ds, updates enabled)"
+      FUSEKI_CID="$(docker run -d --rm \
+        -p "127.0.0.1:${FUSEKI_PORT}:3030" \
+        "${FUSEKI_IMAGE}" \
+        --update --mem /ds 2>/dev/null)"
+      # probe the Fuseki ping endpoint (up to 30 s)
+      _ready=0
+      for _i in $(seq 1 60); do
+        if curl -sf --max-time 1 \
+              "http://127.0.0.1:${FUSEKI_PORT}/\$/ping" \
+              >/dev/null 2>&1; then
+          _ready=1
+          break
+        fi
+        sleep 0.5
+      done
+      if [[ "${_ready}" == "1" ]]; then
+        FUSEKI_STATUS=ok
+        FUSEKI_VERSION="${FUSEKI_IMAGE}"
+        log "Fuseki ready (container ${FUSEKI_CID})"
+      else
+        log "Fuseki did not become ready in 30 s; status=absent"
+        docker stop "${FUSEKI_CID}" >/dev/null 2>&1 || true
+        FUSEKI_CID=""
+      fi
+    else
+      log "docker pull ${FUSEKI_IMAGE} failed; fuseki status=absent"
+    fi
+  else
+    log "Docker not available; fuseki status=absent"
+  fi
+fi
+
+# ---- 3. Oxigraph (Docker / oxigraph/oxigraph) --------------------------------
+OXI_STATUS=absent
+OXI_VERSION=""
+OXI_IMAGE="oxigraph/oxigraph"
+if want oxigraph; then
+  if docker_ok; then
+    log "pulling ${OXI_IMAGE} (if not cached)..."
+    if timeout 120 docker pull "${OXI_IMAGE}" >/dev/null 2>&1; then
+      log "starting Oxigraph on 127.0.0.1:${OXI_PORT}"
+      OXI_CID="$(docker run -d --rm \
+        -p "127.0.0.1:${OXI_PORT}:7878" \
+        "${OXI_IMAGE}" 2>/dev/null)"
+      # probe the root endpoint (up to 30 s)
+      _ready=0
+      for _i in $(seq 1 60); do
+        if curl -sf --max-time 1 "http://127.0.0.1:${OXI_PORT}/" \
+              >/dev/null 2>&1; then
+          _ready=1
+          break
+        fi
+        sleep 0.5
+      done
+      if [[ "${_ready}" == "1" ]]; then
+        OXI_STATUS=ok
+        OXI_VERSION="${OXI_IMAGE}"
+        log "Oxigraph ready (container ${OXI_CID})"
+      else
+        log "Oxigraph did not become ready in 30 s; status=absent"
+        docker stop "${OXI_CID}" >/dev/null 2>&1 || true
+        OXI_CID=""
+      fi
+    else
+      log "docker pull ${OXI_IMAGE} failed; oxigraph status=absent"
+    fi
+  else
+    log "Docker not available; oxigraph status=absent"
+  fi
+fi
+
+# ---- 4. Build compare.py invocation -----------------------------------------
+COMPARE_ARGS=()
+if [[ "${SPARQ_STATUS}" == "ok" ]]; then
+  COMPARE_ARGS+=(--sparq "http://127.0.0.1:${SPARQ_PORT}/sparql")
+fi
+if [[ "${FUSEKI_STATUS}" == "ok" ]]; then
+  COMPARE_ARGS+=(--fuseki "http://127.0.0.1:${FUSEKI_PORT}/ds")
+fi
+if [[ "${OXI_STATUS}" == "ok" ]]; then
+  COMPARE_ARGS+=(--oxigraph "http://127.0.0.1:${OXI_PORT}")
+fi
+
+# ---- 5. Run the workload through compare.py ----------------------------------
+COMPARE_JSON="${TMP}/compare-out.json"
+COMPARE_LOG="${TMP}/compare.log"
+
+if [[ "${#COMPARE_ARGS[@]}" -gt 0 ]]; then
+  log "running compare.py: iters=${ITERS}, engines=[${COMPARE_ARGS[*]}]"
+  if ! timeout "${TIMEOUT_S}" \
+      python3 "${ROOT}/bench/pss-update-set/compare.py" \
+      "${ITERS}" "${COMPARE_ARGS[@]}" \
+      --json-out "${COMPARE_JSON}" \
+      > "${COMPARE_LOG}" 2>&1; then
+    log "compare.py exited non-zero or timed out (see ${COMPARE_LOG})"
+    # write a minimal stub so the envelope assembly succeeds
+    printf '{"latency_ms":{},"throughput_s":{},"state_count":{},"state_agree":null,"parity_gate":"error","parity_note":"compare.py failed"}\n' \
+      > "${COMPARE_JSON}"
+  fi
+  cat "${COMPARE_LOG}" >&2
+else
+  log "no engines available; skipping workload"
+  printf '{"latency_ms":{},"throughput_s":{},"state_count":{},"state_agree":null,"parity_gate":"no-engines","parity_note":"all engines absent"}\n' \
+    > "${COMPARE_JSON}"
+fi
+
+# ---- 6. Stop servers before assembling the envelope -------------------------
+if [[ -n "${SPARQ_PID}" ]]; then
+  kill "${SPARQ_PID}" 2>/dev/null || true
+  SPARQ_PID=""
+fi
+if [[ -n "${FUSEKI_CID}" ]]; then
+  docker stop "${FUSEKI_CID}" >/dev/null 2>&1 || true
+  FUSEKI_CID=""
+fi
+if [[ -n "${OXI_CID}" ]]; then
+  docker stop "${OXI_CID}" >/dev/null 2>&1 || true
+  OXI_CID=""
+fi
+
+# ---- 7. Assemble the envelope (canonical-competitor-results JSON shape) -----
+TS="$(date -u +%Y%m%dT%H%M%SZ)"
+OUT="${OUT_DIR}/update-${TS}.json"
+
+SPARQ_STATUS="${SPARQ_STATUS}" \
+SPARQ_VERSION="${SPARQ_VERSION}" \
+FUSEKI_STATUS="${FUSEKI_STATUS}" \
+FUSEKI_VERSION="${FUSEKI_VERSION}" \
+OXI_STATUS="${OXI_STATUS}" \
+OXI_VERSION="${OXI_VERSION}" \
+ITERS="${ITERS}" \
+GIT_COMMIT="${GIT_COMMIT}" \
+CANONICAL="${CANONICAL}" \
+TIMEOUT_S="${TIMEOUT_S}" \
+COMPARE_JSON="${COMPARE_JSON}" \
+OUT="${OUT}" \
+python3 - <<'PYEOF'
+import json
+import os
+import platform
+
+canonical = os.environ["CANONICAL"] == "1"
+note_canonical = (
+    "CANONICAL: dedicated quiet box, one engine active at a time on the SAME"
+    " PSS LDP-CRUD update set; min-of-N at each scale; per-engine workload cap recorded."
+    if canonical else
+    "NON-canonical FIRST READ: shared work box (not a dedicated quiet instance)."
+    " Timings are directional only — do NOT bake into docs/dashboards."
+    " The harness (scripts/bench/update-same-box.sh) is the durable deliverable;"
+    " rerun with CANONICAL=1 on a dedicated quiet EC2 box for citable numbers (sq-hmd7l.26)."
+)
+
+cmp_path = os.environ["COMPARE_JSON"]
+cmp = json.load(open(cmp_path)) if os.path.exists(cmp_path) else {}
+
+statuses = {
+    "sparq": os.environ["SPARQ_STATUS"],
+    "fuseki": os.environ["FUSEKI_STATUS"],
+    "oxigraph": os.environ["OXI_STATUS"],
+}
+versions = {
+    "sparq": os.environ["SPARQ_VERSION"],
+    "fuseki": os.environ["FUSEKI_VERSION"],
+    "oxigraph": os.environ["OXI_VERSION"],
+}
+
+engines_meta = {}
+for e, status in statuses.items():
+    if status == "ok":
+        engines_meta[e] = {
+            "status": status,
+            "version": versions[e],
+            "update_endpoint": cmp.get("latency_ms", {}).get(e) and (
+                f"http://127.0.0.1:<port>/sparql" if e == "sparq"
+                else f"http://127.0.0.1:<port>/ds/update" if e == "fuseki"
+                else f"http://127.0.0.1:<port>/update"
+            ) or "(see log)",
+        }
+    else:
+        engines_meta[e] = {"status": status}
+
+# count_crosscheck: per-engine quad count post-workload
+state_counts = cmp.get("state_count", {})
+non_error = {e: v for e, v in state_counts.items() if not str(v).startswith("ERROR")}
+all_agree = len(set(non_error.values())) <= 1 if len(non_error) >= 2 else None
+count_crosscheck = dict(state_counts)
+if all_agree is not None:
+    count_crosscheck["all_agree"] = all_agree
+
+env = {
+    "host": platform.node(),
+    "machine": platform.machine(),
+    "os": platform.platform(),
+    "timeout_s": int(os.environ["TIMEOUT_S"]),
+}
+
+envelope = {
+    "gather": "update-same-box-comparison",
+    "wave": "update-competitor-baseline (sq-hmd7l.5)",
+    "canonical": canonical,
+    "canonical_note": note_canonical,
+    "git_commit": os.environ["GIT_COMMIT"],
+    "suite": "pss-update-parity",
+    "iters": int(os.environ["ITERS"]),
+    "tsv_format": "<engine>\\t<p50_ms>\\t<p99_ms>\\t<max_ms>\\t<thr_per_s>",
+    "engines": engines_meta,
+    "statuses": statuses,
+    "latency_ms": cmp.get("latency_ms", {}),
+    "throughput_s": cmp.get("throughput_s", {}),
+    "count_crosscheck": count_crosscheck,
+    "count_crosscheck_note": (
+        "named-graph quad COUNT after the full PSS update workload, per engine."
+        " all_agree = every engine that produced a non-ERROR count agrees."
+        " A disagreement is recorded HONESTLY (never adjusted); this is why COUNT"
+        " is checked before trusting any latency row (sq-hmd7l.5 INVARIANT)."
+    ),
+    "parity_gate": cmp.get("parity_gate", "not-run"),
+    "parity_note": cmp.get("parity_note", ""),
+    "parity_gate_note": (
+        "RELATIVE gate only (no absolute wall-clock threshold):"
+        " sparq p99 ≤ competitor p99 × tolerance. Single-engine runs skip the gate."
+    ),
+    "env": env,
+}
+
+out_path = os.environ["OUT"]
+with open(out_path, "w", encoding="utf-8") as fh:
+    json.dump(envelope, fh, indent=2)
+    fh.write("\n")
+print(out_path)
+PYEOF
+
+log "envelope: ${OUT}"


### PR DESCRIPTION
> 🤖 SPARQ agent — implements bead **sq-hmd7l.5** (epic **sq-hmd7l**): extend the SPARQL-UPDATE parity harness from QLever-only to Fuseki + Oxigraph and wrap it in a canonical same-box envelope.

## Summary

- **`bench/pss-update-set/compare.py`** — extended from sparq+QLever-only to also drive Fuseki (`POST <base>/update`) and Oxigraph (`POST <base>/update`) using the same `application/sparql-update` HTTP shape. QLever default changed to `None` (skip unless `--qlever URL` is passed). New flags: `--fuseki`, `--oxigraph`, `--json-out`. New drivers: `fuseki_update()`, `oxigraph_update()`. Added the sq-hmd7l.5 INVARIANT: `state_count()` / `state_count_qlever()` run a named-graph quad `COUNT` after the workload; disagreement is recorded honestly in stdout and the `--json-out` summary — never adjusted or suppressed. Parity gate extended to sparq-vs-each-active-competitor; single-engine smoke runs skip the gate.

- **`scripts/bench/update-same-box.sh`** (new) — `shacl-same-box.sh`-style orchestrator. Starts sparq-server (loopback; uses sparq's `--health-probe` flag), Fuseki (`stain/jena-fuseki --update --mem /ds` via Docker), Oxigraph (`oxigraph/oxigraph` via Docker). Each engine gracefully absent when Docker is unavailable or the image pull fails — never a fabricated row. Calls `compare.py` with the active engine URLs + `--json-out`, assembles a `canonical-competitor-results` envelope (`canonical:false` off quiet box). Env tunables: `ONLY=`, `ITERS`, `TIMEOUT_S`, `CANONICAL`, `OUT_DIR`; `--smoke` sets iters=5.

- **`research/gap-update-2026-07.md`** (new) — harness description, engine coverage table, state-oracle invariant, parity gate mechanics, engine availability on this box, first-read rows section (empty, NON-canonical flag). No hard-coded performance numbers. Canonical rows ride sq-hmd7l.26.

## Acceptance (verified locally)

```bash
ONLY=sparq bash scripts/bench/update-same-box.sh --smoke
# exits 0, emits well-formed envelope (python3 -m json.tool ✓)
# sparq: ok (5 updates, quad COUNT = 10, parity_gate: single-engine-skip)
# fuseki: absent, oxigraph: absent
```

All gate checks clean:
- `shellcheck scripts/bench/update-same-box.sh` — 0 warnings
- `ruff check bench/pss-update-set/compare.py` — All checks passed
- `typos` — 0 issues
- `npx markdownlint-cli2@0.18.1 research/gap-update-2026-07.md` — 0 errors

## Test plan

- [x] `ONLY=sparq bash scripts/bench/update-same-box.sh --smoke` exits 0 and emits valid JSON
- [x] `python3 -m json.tool <envelope>` validates the envelope
- [x] Envelope contains `sparq: ok`, `fuseki: absent`, `oxigraph: absent` (correct for this box)
- [x] `count_crosscheck.sparq: "10"` (deterministic after 5 PSS-CRUD updates)
- [x] `parity_gate: "single-engine-skip"` (correct — no competitor to compare against)
- [x] `canonical: false` in envelope
- [ ] Multi-engine run with Fuseki + Oxigraph Docker (requires Docker pull — gather-tier, not CI)
- [ ] Canonical quiet-box numbers: sq-hmd7l.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)