### PR TITLE
fix(bench): un-stale solid run.sh authorized-subset parse after #1629 (sq-yxtkm)

### DIFF
--- a/bench/solid/run.sh
+++ b/bench/solid/run.sh
@@ -54,23 +54,29 @@ trap 'rm -rf "$TMP"' EXIT
 
 # ---- 2. extract the DETERMINISTIC counts from the stdout (pure function of the fixture) ----
 # Each grep targets a stable, anchored phrase the example prints. A missing capture leaves the
-# var empty so the expected.tsv cross-check below fails loudly (never a silent skip).
+# var empty so the expected.tsv cross-check below fails loudly (never a silent skip). NB: each
+# capture ends `|| true` so that under `set -euo pipefail` a NON-matching grep (format drift)
+# yields an empty var + a LOUD expected.tsv failure below, instead of a silent `set -e` abort
+# of the whole script with no diagnostic (the exact bug this file hit after #1629, sq-yxtkm).
 emit() { printf '%s\t%s\t%s\n' "$1" "$2" "count" >> "$TMP/solid.tsv"; }
 : > "$TMP/solid.tsv"
 
 # "WAC fixture: <G> named graphs, <Q> quads"
-wac_graphs=$(grep -oE 'WAC fixture: [0-9]+ named graphs' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1)
-wac_quads=$(grep -oE 'WAC fixture: [0-9]+ named graphs, [0-9]+ quads' "$TMP/solid.out" | grep -oE '[0-9]+ quads' | grep -oE '[0-9]+' | head -1)
+wac_graphs=$(grep -oE 'WAC fixture: [0-9]+ named graphs' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1 || true)
+wac_quads=$(grep -oE 'WAC fixture: [0-9]+ named graphs, [0-9]+ quads' "$TMP/solid.out" | grep -oE '[0-9]+ quads' | grep -oE '[0-9]+' | head -1 || true)
 # The first "auth view: <T> triples" line is the WAC materialisation; the second is ACP.
-mapfile -t auth_triples < <(grep -oE 'auth view: [0-9]+ triples' "$TMP/solid.out" | grep -oE '[0-9]+')
+mapfile -t auth_triples < <(grep -oE 'auth view: [0-9]+ triples' "$TMP/solid.out" | grep -oE '[0-9]+' || true)
 wac_auth=${auth_triples[0]:-}
 acp_auth=${auth_triples[1]:-}
 # "alice readable graphs: <N>"
-alice_graphs=$(grep -oE 'alice readable graphs: [0-9]+' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1)
+alice_graphs=$(grep -oE 'alice readable graphs: [0-9]+' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1 || true)
 # The FULL-dataset GRAPH-?g query row count (first "rows: <N>" line) and the authorized-subset
-# row count (the "rows: <N> (authorized subset)" line — v1 and v2 assert-equal in the example).
-full_rows=$(grep -oE '    rows: [0-9]+' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1)
-auth_rows=$(grep -oE 'rows: [0-9]+ \(authorized subset\)' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1)
+# row count (the "rows: <N> (authorized subset...)" line — v1 and v2 assert-equal in the
+# example). The parenthetical may carry a trailing annotation (e.g. "(authorized subset,
+# union-always)" / "(authorized subset, union)" since #1629), so match up to the closing paren
+# rather than requiring ")" immediately after "subset".
+full_rows=$(grep -oE '    rows: [0-9]+' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1 || true)
+auth_rows=$(grep -oE 'rows: [0-9]+ \(authorized subset[^)]*\)' "$TMP/solid.out" | grep -oE '[0-9]+' | head -1 || true)
 
 [ -n "$wac_graphs" ]  && emit solid_wac_named_graphs      "$wac_graphs"
 [ -n "$wac_quads" ]   && emit solid_wac_quads             "$wac_quads"


### PR DESCRIPTION
> 🤖 SPARQ agent

## Root cause: HARNESS bug, not an engine regression

The main-only Solid WAC/ACP bench suite failed `bench.yml` on every push-to-main since the first bench run after PR #1629 (Actions runs `28904855434`, `28926782551`), with:

```
ERROR: solid run.sh failed (auth-view count regression)
```

Despite the "count regression" wording, **no engine/correctness regression occurred**. All 7 deterministic counts are unchanged and still match `bench/solid/expected.tsv`:

`1148 / 3060 / 3783 / 6355 / 800 / 864 / 599`

**What actually broke:** PR #1629 (`sq-kuazr`, 2026-07-06) changed the `sparq-solid` `bench` example's output line from

```
    rows: 599 (authorized subset)
```
to
```
    rows: 599 (authorized subset, union-always)
    rows: 599 (authorized subset, union)
```

but `bench/solid/run.sh`'s capture still used the anchored pattern `\(authorized subset\)`, which requires `)` **immediately** after `subset`. After #1629 that grep matched nothing.

Because `run.sh` runs under `set -euo pipefail`, the failing `grep ... | head -1` command substitution returned non-zero and `set -e` **aborted the whole script silently** — exit 1 with no stdout/stderr. That is exactly the empty-output failure CI reported (the `cat solid.err` in `ci-bench.sh` printed nothing because `solid.err` was empty).

The solid hook is main-only (PR-tier skips it), which is why the failure only surfaced on push-to-main and PR lanes were unaffected.

## The fix

1. Match `\(authorized subset[^)]*\)` — tolerates the current `, union-always` / `, union` suffix and any future annotation, while still anchoring on the `(authorized subset…)` phrase.
2. Append `|| true` to **every** count-capture pipeline so a non-matching grep leaves the var empty and reaches the file's documented **loud** cross-check (`emitted N, expected M — a count metric vanished`) instead of a silent `set -e` abort. This restores the "missing capture ⇒ fail loudly" contract the comment on line 56 already promised but `pipefail` had defeated — preventing a recurrence of this exact silent-failure class.

## Verification (local, in-worktree)

- `cargo build --release -p sparq-solid --example bench` — clean.
- Example runs; all 7 counts match `expected.tsv`.
- `bench/solid/run.sh` before fix → **exit 1, empty output** (reproduced the CI failure).
- `bench/solid/run.sh` after fix → **exit 0**, emits all 7 `<metric>\t<value>\tcount` rows + `[solid] OK`.
- Simulated format drift (mangled authorized-subset line) → now **fails loudly** with `emitted 6, expected 7 (a count metric vanished — parse break or fixture change)` instead of a silent empty exit.
- `shellcheck -x bench/solid/run.sh` — clean.

No Rust source, README, or doc-comments touched (bench-harness `.sh` only), so coverage-ratchet / readme-template / intra-doc-link gates don't apply.

This unblocks main's `wasm_bundle_bytes` auto-refloor and benchmark-data history continuity.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>