### PR TITLE
perf(engine): anchor-driven + clipped DISTINCT-projection semijoin — SP2Bench q09 (sq-7d3dj.30.10) [FABLE-5]

### DIFF
--- a/bench/feature-off-declarations/1782.json
+++ b/bench/feature-off-declarations/1782.json
@@ -1,0 +1,5 @@
+{
+  "pr": 1782,
+  "date": "2026-07-08",
+  "reason": "sq-7d3dj.30.10: exec.rs adds always-compiled anchor-driven + clipped DISTINCT-projection semijoin machinery (collect_var_ids_sorted, AnchorSet/AnchorCache/cached_anchor_ids, block_intersects_anchor, maybe_anchor_driven/anchor_driven_distinct, clipped block scan) under the default-on distinct_pushdown — moves the feature-OFF sparq-wasm bundle bytes; feature-OFF invariant preserved"
+}

--- a/crates/sparq-engine/src/exec.rs
+++ b/crates/sparq-engine/src/exec.rs
@@ -2316,9 +2316,15 @@ fn try_distinct_pushdown(
     let mut seen: FxHashSet<Id> = FxHashSet::default();
     let mut out_ids: Vec<Id> = Vec::new();
     let mut total_scanned = 0usize;
+    // [FABLE-5] (sq-7d3dj.30.10) Cache the sorted anchor membership set across branches:
+    // UNION branches frequently share the same anchor pattern (SP2Bench q09's two branches
+    // both anchor on `?person rdf:type foaf:Person`), so building the ~20k-member set once
+    // instead of per-branch removes the second full anchor scan+sort. Keyed by the anchor's
+    // prepared id-pattern + join position, which fully determines the set.
+    let mut anchor_cache: AnchorCache = FxHashMap::default();
 
     for branch in &branches {
-        match branch_distinct_values(graph, branch, pvar, &seen)? {
+        match branch_distinct_values(graph, branch, pvar, &seen, &mut anchor_cache)? {
             Some((new_ids, scanned)) => {
                 total_scanned = total_scanned.saturating_add(scanned);
                 for id in new_ids {
@@ -2381,22 +2387,103 @@ fn perm_for_order(order: [usize; 3]) -> Option<sparq_core::store::Perm> {
     sparq_core::store::Perm::ALL.into_iter().find(|p| p.order() == order)
 }
 
-/// The distinct ids appearing at canonical position `target_pos` of `id_pat`'s matching
-/// triples (a variable position — the membership set for a semi-join). `None` declines
-/// under budget pressure so the caller falls back.
-fn collect_var_ids(graph: &Graph, id_pat: &IdPattern, target_pos: usize) -> Option<FxHashSet<Id>> {
-    let scan = graph.store.scan(id_pat);
+/// [FABLE-5] (sq-7d3dj.30.10) The distinct ids at canonical position `target_pos` of
+/// `id_pat`'s matching triples, returned SORTED ASCENDING and deduped. The membership set
+/// for a semi-join, returned as a sorted `Vec<Id>` (rather than a hash set):
+/// it lets the per-predicate existence check gallop the anchor (skipping large
+/// disjoint id runs on the anchor side) instead of a per-join-value hash probe, and it
+/// avoids the `HashMap` rehash cost that dominated the anchor build for a 20k-member
+/// anchor (SP2Bench q09 profile). When the chosen permutation already yields
+/// `target_pos` as its first unbound (leading) column the rows arrive grouped, so we
+/// skip-scan the distinct values directly in sorted order (no post-sort); otherwise we
+/// collect then `sort_unstable`. `None` declines under budget pressure so the caller
+/// falls back to the general path.
+fn collect_var_ids_sorted(graph: &Graph, id_pat: &IdPattern, target_pos: usize) -> Option<Vec<Id>> {
+    // A permutation sorted by `target_pos` as its first UNBOUND column yields the join
+    // values already grouped and ascending — enumerate the distinct run heads directly.
+    let scan = graph.store.scan_sorted(id_pat, target_pos);
     let order = scan.perm.order();
     let k = order.iter().position(|&c| c == target_pos)?;
     let rows = scan.rows.as_ref();
-    let mut set: FxHashSet<Id> = FxHashSet::default();
+    if order.into_iter().find(|&c| id_pat[c].is_none()) == Some(target_pos) {
+        let mut out: Vec<Id> = Vec::new();
+        let mut i = 0usize;
+        while i < rows.len() {
+            if budget::exhausted(out.len()) {
+                return None;
+            }
+            let v = rows[i][k];
+            out.push(v);
+            i += rows[i..].partition_point(|r| r[k] <= v).max(1);
+        }
+        // `out` is strictly increasing by construction (each pushed value exceeds the
+        // previous block's) — already sorted + deduped.
+        return Some(out);
+    }
+    // Not sorted by `target_pos`: collect then sort+dedup.
+    let mut out: Vec<Id> = Vec::with_capacity(rows.len());
     for (n, r) in rows.iter().enumerate() {
-        if n & 4095 == 0 && budget::exhausted(set.len()) {
+        if n & 4095 == 0 && budget::exhausted(out.len()) {
             return None;
         }
-        set.insert(r[k]);
+        out.push(r[k]);
     }
-    Some(set)
+    out.sort_unstable();
+    out.dedup();
+    Some(out)
+}
+
+/// [FABLE-5] (sq-7d3dj.30.10) Existence check for the loose semi-join: does the
+/// join-sorted `block` (join value at column `jk`) share ANY id with `anchor`? Drives from
+/// whichever side is shorter and early-exits on the first common id:
+/// * anchor ≥ block: gallop the block's DISTINCT join values, O(1) hash-probe each into
+///   the anchor (the original per-value probe — best when the block is short or hits fast);
+/// * anchor <  block: walk the (shorter) sorted anchor, binary-searching each member into
+///   the block's join column over a monotonically shrinking window (`O(|anchor|·log|block|)`
+///   — best when a large no-hit block is checked against a smaller anchor).
+///
+/// Both strategies are exact and order-independent; the choice only affects work, never the
+/// boolean. `examined` (distinct values touched) feeds the diagnostic scan counter.
+fn block_intersects_anchor(block: &[[Id; 3]], jk: usize, anchor: &AnchorSet) -> (bool, usize) {
+    // Cost model: the hash gallop touches ~`distinct(block)` values at O(1) each; the
+    // anchor walk does `|anchor|` binary searches at O(log|block|) each. Prefer the anchor
+    // walk only when it is strictly cheaper — i.e. when the anchor is small enough that
+    // `|anchor|·log|block|` beats the block's distinct-value count (bounded by `block.len()`).
+    // A conservative proxy: anchor smaller than `block.len() / ilog2(block.len())`.
+    let block_len = block.len();
+    let log_block = usize::BITS as usize - block_len.leading_zeros() as usize; // ~ceil(log2)
+    let anchor_driven = block_len > 0 && anchor.sorted.len().saturating_mul(log_block.max(1)) < block_len;
+    if !anchor_driven {
+        // Gallop the block's distinct join values; O(1) hash membership.
+        let mut examined = 0usize;
+        let mut bi = 0usize;
+        while bi < block.len() {
+            let jv = block[bi][jk];
+            examined += 1;
+            if anchor.hash.contains(&jv) {
+                return (true, examined);
+            }
+            bi += block[bi..].partition_point(|r| r[jk] <= jv).max(1);
+        }
+        (false, examined)
+    } else {
+        // Walk the shorter sorted anchor; binary-search each member into the block.
+        let mut examined = 0usize;
+        let mut lo = 0usize; // block window shrinks monotonically (both sorted ascending)
+        for &av in &anchor.sorted {
+            examined += 1;
+            let rel = block[lo..].partition_point(|r| r[jk] < av);
+            let at = lo + rel;
+            if at < block.len() && block[at][jk] == av {
+                return (true, examined);
+            }
+            lo = at;
+            if lo >= block.len() {
+                break;
+            }
+        }
+        (false, examined)
+    }
 }
 
 /// Enumerates the DISTINCT ids at canonical position `target_pos` via a loose/skip scan
@@ -2477,6 +2564,7 @@ fn branch_distinct_values(
     branch: &GraphPattern,
     pvar: &Variable,
     seen: &FxHashSet<Id>,
+    anchor_cache: &mut AnchorCache,
 ) -> Result<Option<(Vec<Id>, usize)>, String> {
     if !is_conjunctive(branch) {
         return Ok(None);
@@ -2509,7 +2597,7 @@ fn branch_distinct_values(
     }
     match patterns.len() {
         1 => single_pattern_distinct(graph, &patterns[0], pvar, seen),
-        2 => two_pattern_distinct(graph, &patterns, pvar, seen),
+        2 => two_pattern_distinct(graph, &patterns, pvar, seen, anchor_cache),
         _ => Ok(None),
     }
 }
@@ -2547,6 +2635,7 @@ fn two_pattern_distinct(
     patterns: &[TriplePattern],
     pvar: &Variable,
     seen: &FxHashSet<Id>,
+    anchor_cache: &mut AnchorCache,
 ) -> Result<Option<(Vec<Id>, usize)>, String> {
     let (idp0, pv0, uns0) = prepare_pattern(graph, &patterns[0])?;
     let (idp1, pv1, uns1) = prepare_pattern(graph, &patterns[1])?;
@@ -2554,18 +2643,155 @@ fn two_pattern_distinct(
     let in1 = var_positions_of(&pv1, pvar);
     // `?p` must appear EXACTLY ONCE, in exactly one of the two patterns (that is the probe).
     match (in0.as_slice(), in1.as_slice()) {
-        ([ppos], []) => {
-            probe_anchor_distinct(graph, (&idp0, &pv0, uns0), (&idp1, &pv1, uns1), *ppos, seen)
-        }
-        ([], [ppos]) => {
-            probe_anchor_distinct(graph, (&idp1, &pv1, uns1), (&idp0, &pv0, uns0), *ppos, seen)
-        }
+        ([ppos], []) => probe_anchor_distinct(
+            graph,
+            (&idp0, &pv0, uns0),
+            (&idp1, &pv1, uns1),
+            *ppos,
+            seen,
+            anchor_cache,
+        ),
+        ([], [ppos]) => probe_anchor_distinct(
+            graph,
+            (&idp1, &pv1, uns1),
+            (&idp0, &pv0, uns0),
+            *ppos,
+            seen,
+            anchor_cache,
+        ),
         _ => Ok(None),
     }
 }
 
 /// Prepared-pattern triple `(id_pat, pos_vars, unsat)` passed by reference.
 type PreparedRef<'a> = (&'a IdPattern, &'a [Option<Variable>; 3], bool);
+
+/// [FABLE-5] (sq-7d3dj.30.10) The anchor membership set, in BOTH forms needed by the
+/// per-predicate existence probe: a `hash` set for O(1) membership, and the same ids
+/// `sorted` ascending so a large block can be clipped to the anchor's id window and the
+/// smaller side can drive a galloping intersection.
+struct AnchorSet {
+    hash: FxHashSet<Id>,
+    sorted: Vec<Id>,
+}
+
+/// [FABLE-5] (sq-7d3dj.30.10) Per-pushdown cache of anchor membership sets, keyed by the
+/// anchor's prepared id-pattern plus its join position (which together fully determine the
+/// set). Shared across a DISTINCT pushdown's UNION branches so a repeated anchor
+/// (e.g. SP2Bench q09's shared `?person rdf:type foaf:Person`) is materialised once.
+type AnchorCache = FxHashMap<(IdPattern, usize), std::rc::Rc<AnchorSet>>;
+
+/// The anchor membership set for `(anchor_ip, anchor_jpos)`, memoised in `cache`. Returns
+/// `None` under budget pressure (the pushdown then declines). The set is wrapped in `Rc`
+/// so a cache hit is a cheap clone, not a re-materialisation.
+fn cached_anchor_ids(
+    graph: &Graph,
+    anchor_ip: &IdPattern,
+    anchor_jpos: usize,
+    cache: &mut AnchorCache,
+) -> Option<std::rc::Rc<AnchorSet>> {
+    let key = (*anchor_ip, anchor_jpos);
+    if let Some(v) = cache.get(&key) {
+        return Some(v.clone());
+    }
+    let sorted = collect_var_ids_sorted(graph, anchor_ip, anchor_jpos)?;
+    let hash: FxHashSet<Id> = sorted.iter().copied().collect();
+    let set = std::rc::Rc::new(AnchorSet { hash, sorted });
+    cache.insert(key, set.clone());
+    Some(set)
+}
+
+/// [FABLE-5] (sq-7d3dj.30.10) The "pattern-trick" strategy for the loose semi-join: iterate
+/// the ANCHOR members and, for each member `m`, enumerate the distinct `?p` (at `ppos`) on
+/// probe triples whose join column (`jpos`) equals `m` — accumulating a running result set
+/// that terminates the instant it covers the whole `?p` UNIVERSE (the distinct `?p` in the
+/// probe's range ignoring the join, a superset the answer can never exceed). Returns the new
+/// `?p` values (those not already in `seen`) plus a diagnostic touched-row count, or `None`
+/// to DECLINE — in which case the caller falls back to the per-`?p`-block existence scan.
+///
+/// Correctness: the union over all anchor members `m` of `{ ?p : ∃ probe triple with
+/// jpos=m }` is EXACTLY `{ ?p : ∃ a solution of the (anchor ⋈ probe) branch }` — binding the
+/// join column to each anchor member and taking the union is the definition of the semi-join
+/// projected onto `?p`. The universe early-exit is sound because the collected set is
+/// monotonically growing and bounded above by the universe, so once they are equal no further
+/// member can add a value. Declines when the required per-member permutation is not built or
+/// when a per-member scan cannot skip-enumerate `?p` (so the general block scan answers it).
+fn maybe_anchor_driven(
+    graph: &Graph,
+    probe_ip: &IdPattern,
+    ppos: usize,
+    jpos: usize,
+    anchor: &AnchorSet,
+    seen: &FxHashSet<Id>,
+) -> Result<Option<(Vec<Id>, usize)>, String> {
+    // COST GATE: the per-member scan touches only the anchor's incident probe triples, so it
+    // is a clear win when the anchor is SMALL — then we sweep a handful of members instead of
+    // every candidate `?p`-block. For a LARGE anchor (q09's 20,602 persons) the per-member
+    // machinery dominates, so we decline here and let the caller's cost-aware block scan run.
+    // The threshold is a strategy choice only — either path returns the identical `?p` set.
+    if anchor.sorted.len() > ANCHOR_DRIVEN_MAX {
+        return Ok(None);
+    }
+    anchor_driven_distinct(graph, probe_ip, ppos, jpos, anchor, seen)
+}
+
+/// The largest anchor cardinality for which the per-member ("pattern trick") enumeration is
+/// preferred over the per-`?p`-block existence scan. Above it, sweeping every anchor member
+/// costs more than the block scan (measured: SP2Bench q09's 20k-person anchor is faster on
+/// the block scan). A strategy threshold only — never affects the computed answer.
+const ANCHOR_DRIVEN_MAX: usize = 256;
+
+/// Per-member ("pattern trick") enumeration: for each anchor member `m`, bind the join column
+/// to `m` and skip-enumerate the distinct `?p`, unioning across members and stopping once the
+/// `?p` universe is covered. Declines (→ block-scan fallback) when a per-member scan cannot
+/// skip-enumerate `?p` for the bound join position.
+fn anchor_driven_distinct(
+    graph: &Graph,
+    probe_ip: &IdPattern,
+    ppos: usize,
+    jpos: usize,
+    anchor: &AnchorSet,
+    seen: &FxHashSet<Id>,
+) -> Result<Option<(Vec<Id>, usize)>, String> {
+    // The `?p` universe (distinct `?p` in the probe range, ignoring the join) — a cheap
+    // superset the answer can never exceed, so once we have collected it we can stop reading.
+    let (universe_vals, _) = match skipscan_distinct(graph, probe_ip, ppos) {
+        Some(x) => x,
+        None => return Ok(None),
+    };
+    let universe_len = universe_vals.len();
+    if universe_len == 0 {
+        return Ok(Some((Vec::new(), 0)));
+    }
+    let mut found: FxHashSet<Id> = FxHashSet::default();
+    let mut out: Vec<Id> = Vec::new();
+    let mut scanned = 0usize;
+    for (idx, &m) in anchor.sorted.iter().enumerate() {
+        if idx & 63 == 0 && budget::exhausted(out.len()) {
+            return Ok(None);
+        }
+        // Bind the join column to this anchor member; keep the probe's other positions.
+        let mut member_pat = *probe_ip;
+        member_pat[jpos] = Some(m);
+        let (vals, s) = match skipscan_distinct(graph, &member_pat, ppos) {
+            Some(x) => x,
+            None => return Ok(None),
+        };
+        scanned = scanned.saturating_add(s);
+        for v in vals {
+            if found.insert(v) {
+                if !seen.contains(&v) {
+                    out.push(v);
+                }
+                // Whole `?p` universe covered → no later member can add anything. Stop.
+                if found.len() == universe_len {
+                    return Ok(Some((out, scanned)));
+                }
+            }
+        }
+    }
+    Ok(Some((out, scanned)))
+}
 
 /// The loose semi-join for `{ anchor, probe }`: `probe` binds `?p` (at `ppos`) and the
 /// join variable; `anchor` constrains the join variable. Enumerates distinct `?p` from a
@@ -2577,6 +2803,7 @@ fn probe_anchor_distinct(
     anchor: PreparedRef<'_>,
     ppos: usize,
     seen: &FxHashSet<Id>,
+    anchor_cache: &mut AnchorCache,
 ) -> Result<Option<(Vec<Id>, usize)>, String> {
     let (probe_ip, probe_pv, probe_uns) = probe;
     let (anchor_ip, anchor_pv, anchor_uns) = anchor;
@@ -2599,6 +2826,29 @@ fn probe_anchor_distinct(
     if jpos == ppos {
         return Ok(None);
     }
+    // The anchor's join-variable membership set (hash + sorted), shared across the
+    // pushdown's UNION branches (SP2Bench q09's two branches share the same anchor).
+    let a = match cached_anchor_ids(graph, anchor_ip, anchor_jpos, anchor_cache) {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+    if a.sorted.is_empty() {
+        // Empty anchor → the join is empty → no `?p` qualifies.
+        return Ok(Some((Vec::new(), 0)));
+    }
+    // [FABLE-5] (sq-7d3dj.30.10) ANCHOR-DRIVEN predicate enumeration (the "pattern trick"):
+    // walk the probe range grouped by join value and only descend into the ANCHOR blocks'
+    // `?p` values, terminating once the `?p` universe is covered. This wins when the join
+    // axis is LOW-cardinality (few distinct join values → few blocks to skip): a bound anchor
+    // member set is then cheaper to sweep than the candidate `?p`-blocks. It is NOT a
+    // universal win — when the distinct join values are as numerous as the `?p`-blocks
+    // (SP2Bench q09: ~tens of thousands of distinct subjects/objects) walking every join
+    // block costs as much as the block existence scan — so we gate it on the join axis being
+    // low-cardinality relative to the `?p` universe, else fall through to the (cost-aware,
+    // clipped) block scan below. Both paths return the identical `?p` set.
+    if let Some((new, scanned)) = maybe_anchor_driven(graph, probe_ip, ppos, jpos, &a, seen)? {
+        return Ok(Some((new, scanned)));
+    }
     // We need a permutation ordered `[.., P, J, third]` so a `?p`-block is sorted by the
     // join variable (bounding the per-block existence scan). `scan_sorted(ppos)` only
     // pins the FIRST unbound column, so choose the exact permutation ourselves.
@@ -2620,17 +2870,8 @@ fn probe_anchor_distinct(
     let mut out: Vec<Id> = Vec::new();
     let mut scanned = 0usize;
     let mut i = 0usize;
-    // The anchor's join-variable membership set, with its id range for the O(1)
-    // range-disjointness fast-reject below.
-    let a = match collect_var_ids(graph, anchor_ip, anchor_jpos) {
-        Some(s) => s,
-        None => return Ok(None),
-    };
-    let (a_min, a_max) = match (a.iter().min().copied(), a.iter().max().copied()) {
-        (Some(lo), Some(hi)) => (lo, hi),
-        // Empty anchor → the join is empty → no `?p` qualifies.
-        _ => return Ok(Some((Vec::new(), 0))),
-    };
+    // `a.sorted` is non-empty (checked above) and sorted, so min/max are its ends.
+    let (a_min, a_max) = (a.sorted[0], a.sorted[a.sorted.len() - 1]);
     while i < rows.len() {
         if budget::exhausted(out.len()) {
             return Ok(None);
@@ -2652,20 +2893,22 @@ fn probe_anchor_distinct(
         if bmax < a_min || bmin > a_max {
             continue;
         }
-        // Existence: does any join-variable id in this block belong to the anchor set?
-        // Gallop distinct join values (block is join-sorted), early-exit on the first hit.
-        let mut bi = 0usize;
-        let mut hit = false;
-        while bi < block.len() {
-            let jv = block[bi][jk];
-            scanned += 1;
-            if a.contains(&jv) {
-                hit = true;
-                break;
-            }
-            let jlen = block[bi..].partition_point(|r| r[jk] <= jv).max(1);
-            bi += jlen;
-        }
+        // [FABLE-5] (sq-7d3dj.30.10) CLIP the join-sorted block to the anchor's id window
+        // `[a_min, a_max]` with two binary searches: every anchor member lies in that
+        // window, so no join value OUTSIDE it can be a hit — dropping them cannot change
+        // the answer. When the anchor entities occupy a narrow id band this discards the
+        // bulk of a large no-hit block in O(log n); when they do not it is two cheap
+        // binary searches and the full gallop below still runs.
+        let cs = block.partition_point(|r| r[jk] < a_min);
+        let ce = block.partition_point(|r| r[jk] <= a_max);
+        let clipped = &block[cs..ce];
+        // Existence: does any join value in the clipped block belong to the anchor set?
+        // Drive from whichever side is shorter: gallop the clipped block's distinct values
+        // with an O(1) hash probe when the block (post-clip) is the shorter side; otherwise
+        // walk the sorted anchor and binary-search each member into the block. Early-exit
+        // on the first common id. [FABLE-5] (sq-7d3dj.30.10)
+        let (hit, examined) = block_intersects_anchor(clipped, jk, &a);
+        scanned += examined;
         if hit {
             out.push(pv_id);
         }

--- a/crates/sparq-engine/tests/distinct_pushdown.rs
+++ b/crates/sparq-engine/tests/distinct_pushdown.rs
@@ -365,3 +365,156 @@ fn public_toggle_and_stats() {
     let (fired, emitted, scanned) = distinct_pushdown_testing::stats();
     assert!(!fired && emitted == 0 && scanned == 0, "stats not cleared by reset");
 }
+
+// ── [FABLE-5] (sq-7d3dj.30.10) permutation-metadata / pattern-trick strategy tests ──────
+//
+// bead sq-7d3dj.30.10 added TWO strategies under the existing DISTINCT pushdown, chosen by
+// anchor cardinality, and a shared-anchor cache across UNION branches:
+//   * a small anchor (≤ the internal threshold) uses the per-member "pattern trick"
+//     (bind the join column to each anchor member, skip-enumerate its few `?p`);
+//   * a large anchor uses the cost-aware, anchor-window-CLIPPED per-`?p`-block existence
+//     scan (galloping intersection driven from the shorter side).
+// The load-bearing invariant is unchanged: DISTINCT result-SET equivalence with the pushdown
+// on vs off, on EITHER strategy. These tests straddle the threshold so both fire, and add a
+// randomized differential + Slice(LIMIT/OFFSET)-over-DISTINCT preservation + a mutation guard.
+
+/// A large-anchor q09 corpus: `n` persons (n far exceeds the internal small-anchor
+/// threshold, so the BLOCK-scan strategy is exercised), `docs` documents naming a person as
+/// object with high multiplicity, plus noise predicates on documents that must be excluded.
+#[test]
+fn large_anchor_q09_block_scan_equivalence_and_collapse() {
+    // 1000 persons > the small-anchor threshold → forces the clipped block-scan path.
+    let g = q09_dataset(1000, 4000);
+    let distinct_q = format!("SELECT DISTINCT ?predicate WHERE {{\n{Q09_BODY}\n}}");
+    let bag_q = format!("SELECT ?predicate WHERE {{\n{Q09_BODY}\n}}");
+
+    // Result-set equivalence (the load-bearing invariant) on the large-anchor path.
+    let (off, on) = on_off(&g, &distinct_q);
+    assert_eq!(off, on, "large-anchor q09 DISTINCT differs pushdown on vs off");
+    // Exact set (mutation guard: any wrong/extra/missing predicate fails).
+    let got: Vec<String> = on.iter().map(|r| r[0].clone().unwrap()).collect();
+    assert_eq!(got, expected_q09_predicates(), "large-anchor DISTINCT predicate set wrong");
+
+    // Anti-vacuity on the block-scan path: the loose scan touched far fewer rows than the
+    // full (non-distinct) join it replaces (only when the required PSO perm is built).
+    distinct_pushdown_testing::set_enabled(false);
+    let full_bag = query(&g, &format!("{PFX}{bag_q}")).expect("bag").rows.len();
+    distinct_pushdown_testing::set_enabled(true);
+    distinct_pushdown_testing::reset_stats();
+    let res = query(&g, &format!("{PFX}{distinct_q}")).expect("distinct");
+    let (fired, emitted, scanned) = distinct_pushdown_testing::stats();
+    assert_eq!(res.rows.len(), 5, "fixture answers 5 distinct predicates");
+    if sparq_core::store::BUILT.contains(&sparq_core::store::Perm::Pso) {
+        assert!(fired, "large-anchor q09 pushdown must fire");
+        assert_eq!(emitted, 5);
+        assert!(scanned * 4 < full_bag, "block scan did not collapse: scanned={} full_bag={}", scanned, full_bag);
+    }
+}
+
+/// A small-anchor branch: the anchor (`ex:Book` instances) is well under the threshold, so
+/// the per-member pattern-trick path runs. Equivalence + exact set + the pushdown fires.
+#[test]
+fn small_anchor_pattern_trick_equivalence() {
+    // 12 books (small anchor) each with a title + a person creator; a large mass of noise
+    // triples with unrelated predicates whose subjects/objects are never books.
+    let mut ttl = String::new();
+    for b in 0..12 {
+        ttl.push_str(&format!("ex:book{b} rdf:type ex:Book .\n"));
+        ttl.push_str(&format!("ex:book{b} ex:title \"T{b}\" .\n"));
+        ttl.push_str(&format!("ex:book{b} ex:creator ex:auth{b} .\n"));
+    }
+    // Noise: 3000 articles with their own predicates, none a Book subject/object.
+    for a in 0..3000 {
+        ttl.push_str(&format!("ex:art{a} ex:journal \"J{}\" .\n", a % 50));
+        ttl.push_str(&format!("ex:art{a} ex:year {} .\n", 1990 + (a % 30)));
+    }
+    let g = load(&ttl);
+    // Branch: person(book)-as-subject predicates.
+    let q = "SELECT DISTINCT ?p WHERE { \
+        { ?x rdf:type ex:Book . ?x ?p ?o } UNION { ?x rdf:type ex:Book . ?s ?p ?x } }";
+    let (off, on) = on_off(&g, q);
+    assert_eq!(off, on, "small-anchor pattern-trick differs pushdown on vs off");
+    let mut got: Vec<String> = on.iter().map(|r| r[0].clone().unwrap()).collect();
+    got.sort();
+    // rdf:type + ex:title + ex:creator (book as subject); ex:creator's object is auth, not a
+    // book, so the object-side branch contributes nothing new here.
+    let mut want = vec![
+        "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>".to_string(),
+        "<http://example.org/title>".to_string(),
+        "<http://example.org/creator>".to_string(),
+    ];
+    want.sort();
+    assert_eq!(got, want, "small-anchor DISTINCT predicate set wrong");
+    if sparq_core::store::BUILT.contains(&sparq_core::store::Perm::Pso) {
+        distinct_pushdown_testing::reset_stats();
+        distinct_pushdown_testing::set_enabled(true);
+        let _ = query(&g, &format!("{PFX}{q}")).unwrap();
+        assert!(distinct_pushdown_testing::stats().0, "small-anchor pushdown must fire");
+    }
+}
+
+/// Randomized differential: many small random graphs of the q09 join shape, over anchor
+/// sizes that STRADDLE the internal small/large-anchor threshold, must give an identical
+/// DISTINCT `?predicate` set with the pushdown on vs off — so BOTH strategies are exercised.
+#[test]
+fn randomized_differential_both_strategies() {
+    // Deterministic xorshift PRNG (no dev-dep).
+    let mut state: u64 = 0x9E3779B97F4A7C15;
+    let mut rng = || {
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        state
+    };
+    for trial in 0..40 {
+        // Anchor sizes chosen to straddle the 256 threshold.
+        let n = 1 + (rng() % 400) as usize; // 1..=400 persons
+        let docs = (rng() % 600) as usize;
+        let mut ttl = String::new();
+        for p in 0..n {
+            ttl.push_str(&format!("ex:p{p} rdf:type foaf:Person .\n"));
+            if rng() % 2 == 0 {
+                ttl.push_str(&format!("ex:p{p} foaf:age {} .\n", 20 + (rng() % 40)));
+            }
+            if rng() % 3 == 0 {
+                ttl.push_str(&format!("ex:p{p} foaf:knows ex:p{} .\n", rng() as usize % n));
+            }
+        }
+        for d in 0..docs {
+            ttl.push_str(&format!("ex:d{d} rdf:type ex:Doc .\n"));
+            ttl.push_str(&format!("ex:d{d} ex:title \"T{d}\" .\n"));
+            if rng() % 2 == 0 {
+                ttl.push_str(&format!("ex:d{d} foaf:maker ex:p{} .\n", rng() as usize % n));
+            }
+            if rng() % 4 == 0 {
+                ttl.push_str(&format!("ex:d{d} ex:cites ex:p{} .\n", rng() as usize % n));
+            }
+        }
+        let g = load(&ttl);
+        let q = format!("SELECT DISTINCT ?predicate WHERE {{\n{Q09_BODY}\n}}");
+        let (off, on) = on_off(&g, &q);
+        assert_eq!(off, on, "trial {trial} (n={n}, docs={docs}): pushdown on != off");
+    }
+}
+
+/// A Slice (LIMIT/OFFSET) above the DISTINCT must be preserved: the pushdown produces the
+/// same DISTINCT set, and the slice is applied above it identically on vs off. LIMIT without
+/// ORDER BY is order-insensitive, so we compare the CARDINALITY (the retained-row count),
+/// which the slice must not change relative to the naive path.
+#[test]
+fn slice_over_distinct_preserved() {
+    let g = q09_dataset(20, 60); // small anchor → pattern-trick path
+    for (off_n, lim) in [(0usize, 2usize), (1, 2), (2, 10), (0, 100)] {
+        let q = format!("SELECT DISTINCT ?predicate WHERE {{\n{Q09_BODY}\n}} LIMIT {lim} OFFSET {off_n}");
+        let prev = distinct_pushdown_testing::set_enabled(false);
+        let off_rows = query(&g, &format!("{PFX}{q}")).expect("off").rows.len();
+        distinct_pushdown_testing::set_enabled(true);
+        let on_rows = query(&g, &format!("{PFX}{q}")).expect("on").rows.len();
+        distinct_pushdown_testing::set_enabled(prev);
+        // 5 distinct predicates total; the slice retains max(0, min(lim, 5-off)).
+        let full = 5usize;
+        let want = lim.min(full.saturating_sub(off_n));
+        assert_eq!(off_rows, want, "naive slice count wrong for off={off_n} lim={lim}");
+        assert_eq!(on_rows, want, "pushdown slice count differs from naive for off={off_n} lim={lim}");
+    }
+}

--- a/crates/sparq-engine/tests/distinct_pushdown.rs
+++ b/crates/sparq-engine/tests/distinct_pushdown.rs
@@ -518,3 +518,42 @@ fn slice_over_distinct_preserved() {
         assert_eq!(on_rows, want, "pushdown slice count differs from naive for off={off_n} lim={lim}");
     }
 }
+
+/// [FABLE-5] (sq-7d3dj.30.10) DIRECT coverage of the block-scan strategy's ANCHOR-DRIVEN
+/// intersection side: a LARGE anchor (> the small-anchor threshold, so the block scan runs)
+/// that is nonetheless much smaller than a candidate `?p`-block, so `block_intersects_anchor`
+/// takes its "walk the shorter sorted anchor, binary-search into the block" branch. The
+/// invariant is unchanged — on == off — and the exact predicate set is asserted.
+#[test]
+fn block_scan_anchor_driven_side_equivalence() {
+    // 300 persons (> 256 threshold → block scan) but a huge `ex:bulk` predicate whose 6000
+    // distinct subjects/objects are documents, not persons (a large no-hit block that the
+    // anchor-driven intersection side sweeps by binary-searching the 300 persons into it).
+    let mut ttl = String::new();
+    for p in 0..300 {
+        ttl.push_str(&format!("ex:p{p} rdf:type foaf:Person .\n"));
+        ttl.push_str(&format!("ex:p{p} foaf:name \"N{p}\" .\n"));
+    }
+    for d in 0..6000 {
+        // Documents (higher ids) with a bulk predicate; none is a person.
+        ttl.push_str(&format!("ex:doc{d} ex:bulk ex:val{d} .\n"));
+        // A few documents cite a person as OBJECT (so ex:cites qualifies via the object join).
+        if d % 500 == 0 {
+            ttl.push_str(&format!("ex:doc{d} ex:cites ex:p{} .\n", d % 300));
+        }
+    }
+    let g = load(&ttl);
+    let q = format!("SELECT DISTINCT ?predicate WHERE {{\n{Q09_BODY}\n}}");
+    let (off, on) = on_off(&g, &q);
+    assert_eq!(off, on, "block-scan anchor-driven side differs on vs off");
+    let mut got: Vec<String> = on.iter().map(|r| r[0].clone().unwrap()).collect();
+    got.sort();
+    // name + rdf:type (person subject); cites (person object). ex:bulk must be EXCLUDED.
+    let mut want = vec![
+        "<http://www.w3.org/1999/02/22-rdf-syntax-ns#type>".to_string(),
+        "<http://xmlns.com/foaf/0.1/name>".to_string(),
+        "<http://example.org/cites>".to_string(),
+    ];
+    want.sort();
+    assert_eq!(got, want, "block-scan anchor-driven side predicate set wrong (ex:bulk leaked?)");
+}

--- a/skills/sparql-query/SKILL.md
+++ b/skills/sparql-query/SKILL.md
@@ -591,9 +591,14 @@ let r = query_view(&v, "SELECT ?s WHERE { GRAPH ?g { ?s ?p ?o } }").unwrap(); //
   loose/skip scan that gallops (binary-search) past each value's block — instead of materialising every
   full-width join row and de-duplicating post-hoc. It is the general form of qlever's "pattern trick"
   over sparq's six permutations, and builds **NO new index**. Two branch shapes are enumerated: a single
-  BGP triple (every distinct `?p` is a solution) and an **anchor + probe** pair joined on one variable
-  (distinct `?p` from the probe kept iff its `[P, J]`-ordered block intersects the anchor's join set — a
-  loose semi-join with an O(1) id-range-disjointness fast reject). A **global already-seen `?p` set**
+  BGP triple (every distinct `?p` is a solution) and an **anchor + probe** pair joined on one variable.
+  For the anchor+probe branch the executor picks between two equivalent semi-join strategies by anchor
+  cardinality (bead `sq-7d3dj.30.10`): a **small** anchor uses the per-member *pattern trick* (bind the
+  join column to each anchor member, skip-enumerate its few `?p`, stopping once the `?p` universe is
+  covered); a **large** anchor uses a per-`?p`-block existence scan whose `[P, J]`-ordered block is first
+  **clipped to the anchor's id window** and then intersected by galloping the **shorter** of block/anchor
+  (an O(1) id-range-disjointness fast reject still precedes it). The **sorted anchor set is cached across
+  UNION branches** (q09's two branches share one anchor, built once). A **global already-seen `?p` set**
   makes later branches near-free. It is **conservative**: it fires only for that exact single-variable
   DISTINCT shape and only when a built permutation exposes the required column order (the compact/wasm
   index {SPO, POS, OSP} lacks PSO, so a subject-side probe declines there); every other shape — REDUCED,


### PR DESCRIPTION
> 🤖 SPARQ agent — implementing bead `sq-7d3dj.30.10`.

## What

Extends the DEFAULT-ON DISTINCT-projection loose skip-scan (from `sq-7d3dj.30.4`) so the
**anchor + probe** branch of `SELECT DISTINCT ?p WHERE { … }` no longer scans every
candidate `?p`-block against a freshly-rebuilt anchor hash set. Three changes, all inside
the always-compiled executor, all **result-set identical** to the prior plan:

1. **Cross-branch anchor cache.** A UNION's branches frequently share the same anchor
   (SP2Bench q09's two branches both anchor on `?person rdf:type foaf:Person`). The sorted
   anchor membership set is now built **once** per `(prepared-pattern, join-position)` and
   reused (`Rc`), instead of rebuilt per branch (the 2nd 20k-member `HashMap` build was a
   measurable slice of the profile).

2. **Two anchor-cardinality-selected semi-join strategies** (both exact, chosen only to
   minimise work):
   - **small anchor** → per-member *pattern trick*: bind the join column to each anchor
     member, skip-enumerate its few `?p`, stop once the `?p` universe is covered;
   - **large anchor** → per-`?p`-block existence scan whose block is first **clipped to the
     anchor's id window** (two binary searches) and then intersected by galloping the
     **shorter** of block/anchor (O(1)-hash gallop of the block's distinct values, or a
     monotonic-window binary-search walk of the smaller sorted anchor). The O(1)
     id-range-disjointness fast reject still runs first.

3. Anything not matching the exact single-variable DISTINCT shape executes the **identical
   pre-existing plan** — the clean DECLINE path is preserved bit-for-bit (verified by the
   existing fallback tests: REDUCED, multi-var projection, filters, 3-pattern branches,
   `?p`-as-join-var, repeated-var `?x ?p ?x`, RDF 1.2 quoted-triple terms, empty-view, zk
   armed).

**Honest scope note:** the per-member *pattern trick* is the right tool only when the join
axis is low-cardinality; for q09 the distinct join values (subjects/objects) number in the
tens of thousands, so the **large-anchor clipped block scan** is what wins there. Rather
than force a path that doesn't help, the strategy is cost-selected by anchor cardinality —
q09 takes the block scan; a small-anchor shape takes the pattern trick. Both are
differentially verified.

## Feature flags

**No new feature** — this is an unconditional, semantics-preserving optimisation under the
existing DEFAULT-ON `distinct_pushdown` (matching siblings `.30.4`/`.30.7`). It changes
always-compiled default-path bytes, so a `bench/feature-off-declarations/<PR>.json` is
included (the feature-OFF wasm INVARIANT is preserved — bytes just move).

## Gates (work-box)

- `cargo clippy -p sparq-engine --all-targets -- -D warnings` — clean.
- `cargo test -p sparq-engine` (default features) — **277 + siblings pass, 0 fail**.
- `cargo test -p sparq-engine --features zk,algebra-rewrite,semijoin-bitmap,yannakakis --test distinct_pushdown` — 15 pass (with `zk` the pushdown declines → fallback, still equivalent).
- W3C SPARQL conformance ratchet: **1225 pass / 0 fail / 4 documented divergence** → pass+divergence = 1229, 0 fail (unchanged).
- `scripts/coverage.sh` (sparq-engine) + `coverage-gate.py --check`: **90.46%** ≥ floor 90 → OK.
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --all-features` — clean (no intra-doc link to a private item; new doc-comments use code spans — the feature-gated-link trap avoided).
- Full sp2b light suite row counts match `expected-rows.tsv` (q09=4, q02=6067, q03a=15823, q05b=6933, …).

## Tests

`crates/sparq-engine/tests/distinct_pushdown.rs` (differential on-vs-off is the load-bearing
invariant on **both** strategies):
- `large_anchor_q09_block_scan_equivalence_and_collapse` — 1000-person q09 (block-scan path): on==off, exact set, anti-vacuity collapse.
- `small_anchor_pattern_trick_equivalence` — 12-book anchor (pattern-trick path): on==off, exact set, pushdown fires.
- `block_scan_anchor_driven_side_equivalence` — 300-person / 6000-doc (block scan's anchor-driven intersection side): on==off, `ex:bulk` excluded.
- `randomized_differential_both_strategies` — 40 random graphs straddling the strategy threshold: on==off.
- `slice_over_distinct_preserved` — LIMIT/OFFSET (Slice above Distinct) retained-count identical on-vs-off.
- Mutation-checked: flipping an expected count (5→6) turns a test red (verified locally).

## SP2Bench q09 (250k triples) — NON-canonical work-box diagnostic

Same box / dataset / `sparq-cli bench` harness, release build, before = `origin/main`:

- before: ~5.16 ms/query
- after:  ~4.52 ms/query  (~12.5% faster)

The hotspot (`probe_anchor_distinct` inner existence scan) shrinks; the remaining cost is
the inherent examination of the large no-hit value-typed-predicate blocks (no characteristic
sets today). Work-box timings are diagnostic only — not baked into any committed markdown or
test. The canonical-host payoff is a hypothesis for `sq-0g6g`.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>