### PR TITLE
fix(gui/e2e): unblock the native GUI smoke — omit browserName + clear WebKitGTK/xvfb session stall (sq-t6492)

### DIFF
--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -498,6 +498,7 @@ jobs:
             librsvg2-dev \
             patchelf \
             webkit2gtk-driver \
+            dbus-x11 \
             xvfb
 
       # Drift tripwire + regression guard (bead sq-t6492 / issue #1740). The lane's persistent red
@@ -575,19 +576,23 @@ jobs:
       # first-attempt failures; a single retry keeps the job honest (a pass-on-retry is still
       # logged as a defect to investigate, per §6.3 quarantine policy) without masking real bugs.
       # Failure artifacts are written by the harness on both attempts (artifacts/ dir).
-      - name: Run the tauri-driver smoke (headless under xvfb; retry once on failure)
+      # Run under dbus-run-session + NO_AT_BRIDGE=1 (bead sq-t6492): WebKitGTK under xvfb reaches
+      # for an AT-SPI accessibility bus that does not exist and can stall webview/session startup
+      # ("org.a11y.Bus was not provided"). A private session bus + disabled AT-SPI bridge clears it.
+      - name: Run the tauri-driver smoke (headless under xvfb + dbus; retry once on failure)
         id: tauri-smoke
         working-directory: gui/e2e
         env:
           APP_BINARY: ${{ github.workspace }}/gui/src-tauri/target/debug/sparq-gui
+          NO_AT_BRIDGE: "1"
         run: |
           # [SONNET-4.6] Give each attempt its own artifacts subdir so a second failure does
           # not overwrite the first attempt's screenshot/driver-log evidence.
           ARTIFACTS_DIR="${{ github.workspace }}/gui/e2e/artifacts/attempt-1" \
-            xvfb-run --auto-servernum npm run test:e2e && exit 0
+            xvfb-run --auto-servernum dbus-run-session -- npm run test:e2e && exit 0
           echo "[tauri-e2e-ci] first attempt failed; retrying once (xvfb startup flake check)…"
           ARTIFACTS_DIR="${{ github.workspace }}/gui/e2e/artifacts/attempt-2" \
-            xvfb-run --auto-servernum npm run test:e2e
+            xvfb-run --auto-servernum dbus-run-session -- npm run test:e2e
 
       # Upload failure artifacts (screenshot + driver log) even if the step above succeeded on
       # the retry — the artifacts are only written by the harness when an assertion fails, so
@@ -629,6 +634,7 @@ jobs:
             librsvg2-dev \
             patchelf \
             webkit2gtk-driver \
+            dbus-x11 \
             xvfb
 
       # Drift tripwire + regression guard (bead sq-t6492 / issue #1740): same as tauri-e2e — guards
@@ -685,6 +691,7 @@ jobs:
         working-directory: gui/e2e
         env:
           APP_BINARY: ${{ github.workspace }}/gui/src-tauri/target/debug/sparq-gui
+          NO_AT_BRIDGE: "1"
         run: |
           RUNS=${{ inputs.probe_runs }}
           GREENS=0
@@ -692,7 +699,7 @@ jobs:
           for i in $(seq 1 "$RUNS"); do
             echo "--- probe run $i / $RUNS ---"
             if ARTIFACTS_DIR="${{ github.workspace }}/gui/e2e/artifacts/probe-run-$i" \
-                xvfb-run --auto-servernum npm run test:e2e; then
+                xvfb-run --auto-servernum dbus-run-session -- npm run test:e2e; then
               GREENS=$((GREENS + 1))
             else
               FAILS=$((FAILS + 1))

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -500,14 +500,14 @@ jobs:
             webkit2gtk-driver \
             xvfb
 
-      # Log the installed WebKitWebDriver version. The apt package is matched to the runner
-      # image's webkit2gtk — not independently pinned, but logged here so any drift across
-      # runner image updates is immediately visible in the CI log.
-      - name: Log WebKitWebDriver version
-        run: |
-          WKVER=$(WebKitWebDriver --version 2>&1 || echo "unknown")
-          echo "WebKitWebDriver: $WKVER"
-          echo "webkit2gtk-driver apt: $(dpkg -l webkit2gtk-driver 2>/dev/null | tail -1)"
+      # Drift tripwire (bead sq-t6492 / issue #1740): logs the webkit2gtk + tauri-driver versions
+      # and, on the KNOWN-INCOMPATIBLE pair (tauri-driver 2.0.x + webkit2gtk 2.5x), emits a loud
+      # annotation naming the bead/issue — so the next runner-image webkit2gtk drift is a one-line
+      # diagnosis instead of a 0-byte-driver-log hunt during POST /session capability negotiation.
+      # Diagnostic only (exits 0); this lane is advisory (continue-on-error), so the actual smoke
+      # still decides pass/fail.
+      - name: Drift tripwire — log + detect tauri-driver ↔ webkit2gtk incompatibility
+        run: bash scripts/ci/tauri-driver-drift-tripwire.sh --tauri-driver-version 2.0.6
 
       # wasm32 target is needed to build the lean WASM bundle the in-tab REPL runs.
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -631,9 +631,10 @@ jobs:
             webkit2gtk-driver \
             xvfb
 
-      - name: Log WebKitWebDriver version
-        run: |
-          echo "WebKitWebDriver: $(WebKitWebDriver --version 2>&1 || echo 'unknown')"
+      # Drift tripwire (bead sq-t6492 / issue #1740): same diagnostic as tauri-e2e — logs the
+      # webkit2gtk + tauri-driver versions and flags the known-incompatible pair. Diagnostic only.
+      - name: Drift tripwire — log + detect tauri-driver ↔ webkit2gtk incompatibility
+        run: bash scripts/ci/tauri-driver-drift-tripwire.sh --tauri-driver-version 2.0.6
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -550,11 +550,14 @@ jobs:
           npm install
           (cd gui/app && npm run build:tauri)
 
-      # Build the desktop shell binary (debug). With gui/app/out present, tauri_build embeds
-      # the frontend into the `sparq-gui` binary tauri-driver will launch.
-      - name: Build the GUI shell (debug, embeds the frontend)
+      # Build the desktop shell binary (debug). --features custom-protocol (bead sq-t6492) embeds
+      # + serves the frontendDist static export (gui/app/out, built above) instead of Tauri's
+      # cfg(dev) devUrl (http://localhost:3001) — a plain `cargo build` would make the webview
+      # show "Could not connect to localhost: Connection refused" with no dev server. See
+      # gui/src-tauri/Cargo.toml. `cargo tauri build` sets this automatically; plain cargo must pass it.
+      - name: Build the GUI shell (debug, embeds the frontend via custom-protocol)
         working-directory: gui/src-tauri
-        run: cargo build
+        run: cargo build --features custom-protocol
 
       # Pin tauri-driver to 2.0.6 — the version published for Tauri 2.x (workspace uses 2.11.x).
       # Pinning prevents a crates.io update from silently changing driver behaviour mid-run.
@@ -673,9 +676,11 @@ jobs:
           npm install
           (cd gui/app && npm run build:tauri)
 
-      - name: Build the GUI shell (debug)
+      # --features custom-protocol (bead sq-t6492): embed + serve frontendDist instead of cfg(dev)
+      # devUrl, so the launched binary shows the real UI (not "Connection refused"). See Cargo.toml.
+      - name: Build the GUI shell (debug, embeds the frontend via custom-protocol)
         working-directory: gui/src-tauri
-        run: cargo build
+        run: cargo build --features custom-protocol
 
       - name: Install tauri-driver@2.0.6 (pinned)
         run: cargo install tauri-driver@2.0.6 --locked

--- a/.github/workflows/gui.yml
+++ b/.github/workflows/gui.yml
@@ -500,13 +500,13 @@ jobs:
             webkit2gtk-driver \
             xvfb
 
-      # Drift tripwire (bead sq-t6492 / issue #1740): logs the webkit2gtk + tauri-driver versions
-      # and, on the KNOWN-INCOMPATIBLE pair (tauri-driver 2.0.x + webkit2gtk 2.5x), emits a loud
-      # annotation naming the bead/issue — so the next runner-image webkit2gtk drift is a one-line
-      # diagnosis instead of a 0-byte-driver-log hunt during POST /session capability negotiation.
-      # Diagnostic only (exits 0); this lane is advisory (continue-on-error), so the actual smoke
-      # still decides pass/fail.
-      - name: Drift tripwire — log + detect tauri-driver ↔ webkit2gtk incompatibility
+      # Drift tripwire + regression guard (bead sq-t6492 / issue #1740). The lane's persistent red
+      # was WebKitGTK 2.5x rejecting the client's `browserName: "wry"` capability ("Failed to match
+      # capabilities", 0-byte driver log); the fix is client-side — gui/e2e/run-e2e.mjs now OMITS
+      # browserName. This step FAILS if that regression is re-introduced, and logs the webkit2gtk +
+      # tauri-driver versions so the next runner-image drift is a one-line diagnosis. The version
+      # tripwire is diagnostic; this lane is advisory (continue-on-error) so the actual smoke decides.
+      - name: Drift tripwire — browserName regression guard + version log
         run: bash scripts/ci/tauri-driver-drift-tripwire.sh --tauri-driver-version 2.0.6
 
       # wasm32 target is needed to build the lean WASM bundle the in-tab REPL runs.
@@ -631,9 +631,9 @@ jobs:
             webkit2gtk-driver \
             xvfb
 
-      # Drift tripwire (bead sq-t6492 / issue #1740): same diagnostic as tauri-e2e — logs the
-      # webkit2gtk + tauri-driver versions and flags the known-incompatible pair. Diagnostic only.
-      - name: Drift tripwire — log + detect tauri-driver ↔ webkit2gtk incompatibility
+      # Drift tripwire + regression guard (bead sq-t6492 / issue #1740): same as tauri-e2e — guards
+      # against the `browserName: "wry"` regression and logs the webkit2gtk + tauri-driver versions.
+      - name: Drift tripwire — browserName regression guard + version log
         run: bash scripts/ci/tauri-driver-drift-tripwire.sh --tauri-driver-version 2.0.6
 
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable

--- a/.github/workflows/nightly-full-sweep.yml
+++ b/.github/workflows/nightly-full-sweep.yml
@@ -464,11 +464,15 @@ jobs:
             patchelf \
             webkit2gtk-driver \
             xvfb
-      - name: Log WebKitWebDriver version
+      # Drift tripwire (bead sq-t6492 / issue #1740): logs the webkit2gtk + tauri-driver versions
+      # and, on the KNOWN-INCOMPATIBLE pair (tauri-driver 2.0.x + webkit2gtk 2.5x), emits a loud
+      # annotation so the next runner-image drift is a one-line diagnosis instead of a 0-byte-log
+      # hunt. Runs EARLY (right after the webkit2gtk apt install, before the ~6-min build) with the
+      # pinned tauri-driver version passed explicitly, so the drift is diagnosed fail-fast. Diagnostic
+      # only — it exits 0, keeping this advisory lane's verdict with the actual smoke (§5, advisory-forever).
+      - name: Drift tripwire — log + detect tauri-driver ↔ webkit2gtk incompatibility
         if: needs.config.outputs.mode == 'full'
-        run: |
-          echo "WebKitWebDriver: $(WebKitWebDriver --version 2>&1 || echo unknown)"
-          echo "webkit2gtk-driver apt: $(dpkg -l webkit2gtk-driver 2>/dev/null | tail -1)"
+        run: bash scripts/ci/tauri-driver-drift-tripwire.sh --tauri-driver-version 2.0.6
       - name: Cache cargo (gui e2e)
         if: needs.config.outputs.mode == 'full'
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0

--- a/.github/workflows/nightly-full-sweep.yml
+++ b/.github/workflows/nightly-full-sweep.yml
@@ -464,13 +464,14 @@ jobs:
             patchelf \
             webkit2gtk-driver \
             xvfb
-      # Drift tripwire (bead sq-t6492 / issue #1740): logs the webkit2gtk + tauri-driver versions
-      # and, on the KNOWN-INCOMPATIBLE pair (tauri-driver 2.0.x + webkit2gtk 2.5x), emits a loud
-      # annotation so the next runner-image drift is a one-line diagnosis instead of a 0-byte-log
-      # hunt. Runs EARLY (right after the webkit2gtk apt install, before the ~6-min build) with the
-      # pinned tauri-driver version passed explicitly, so the drift is diagnosed fail-fast. Diagnostic
-      # only — it exits 0, keeping this advisory lane's verdict with the actual smoke (§5, advisory-forever).
-      - name: Drift tripwire — log + detect tauri-driver ↔ webkit2gtk incompatibility
+      # Drift tripwire + regression guard (bead sq-t6492 / issue #1740). The lane's persistent red
+      # was WebKitGTK 2.5x rejecting the client's `browserName: "wry"` capability ("Failed to match
+      # capabilities", 0-byte driver log); the fix is client-side — gui/e2e/run-e2e.mjs now OMITS
+      # browserName. This step (1) FAILS if that regression is re-introduced, and (2) logs the
+      # webkit2gtk + tauri-driver versions so the next runner-image drift is a one-line diagnosis.
+      # Runs EARLY (right after the webkit2gtk apt install, before the ~6-min build) so a regression
+      # is caught fail-fast; the version tripwire is diagnostic (does not gate the advisory lane, §5).
+      - name: Drift tripwire — browserName regression guard + version log
         if: needs.config.outputs.mode == 'full'
         run: bash scripts/ci/tauri-driver-drift-tripwire.sh --tauri-driver-version 2.0.6
       - name: Cache cargo (gui e2e)

--- a/.github/workflows/nightly-full-sweep.yml
+++ b/.github/workflows/nightly-full-sweep.yml
@@ -463,6 +463,7 @@ jobs:
             librsvg2-dev \
             patchelf \
             webkit2gtk-driver \
+            dbus-x11 \
             xvfb
       # Drift tripwire + regression guard (bead sq-t6492 / issue #1740). The lane's persistent red
       # was WebKitGTK 2.5x rejecting the client's `browserName: "wry"` capability ("Failed to match
@@ -512,17 +513,24 @@ jobs:
         if: needs.config.outputs.mode == 'full'
         working-directory: gui/e2e
         run: bash support/no-sleep-gate.sh
-      - name: Run the tauri-driver smoke (headless under xvfb; retry once on failure)
+      # Run under dbus-run-session + NO_AT_BRIDGE=1 (bead sq-t6492): WebKitGTK under xvfb warns
+      # "AT-SPI: Error retrieving accessibility bus address … org.a11y.Bus was not provided" and can
+      # stall webview/session startup when no session D-Bus / a11y bus exists. dbus-run-session gives
+      # the app a private session bus and NO_AT_BRIDGE=1 disables the AT-SPI bridge it was reaching
+      # for — clearing the warning and the stall. (SESSION_CREATE_TIMEOUT_MS raises the cold-launch
+      # session-create ceiling; see run-e2e.mjs.)
+      - name: Run the tauri-driver smoke (headless under xvfb + dbus; retry once on failure)
         if: needs.config.outputs.mode == 'full'
         working-directory: gui/e2e
         env:
           APP_BINARY: ${{ github.workspace }}/gui/src-tauri/target/debug/sparq-gui
+          NO_AT_BRIDGE: "1"
         run: |
           ARTIFACTS_DIR="${{ github.workspace }}/gui/e2e/artifacts/attempt-1" \
-            xvfb-run --auto-servernum npm run test:e2e && exit 0
+            xvfb-run --auto-servernum dbus-run-session -- npm run test:e2e && exit 0
           echo "[tauri-e2e-nightly] first attempt failed; retrying once (xvfb startup flake check)…"
           ARTIFACTS_DIR="${{ github.workspace }}/gui/e2e/artifacts/attempt-2" \
-            xvfb-run --auto-servernum npm run test:e2e
+            xvfb-run --auto-servernum dbus-run-session -- npm run test:e2e
       - name: Upload failure artifacts
         if: always() && needs.config.outputs.mode == 'full'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/nightly-full-sweep.yml
+++ b/.github/workflows/nightly-full-sweep.yml
@@ -498,10 +498,15 @@ jobs:
         run: |
           npm install
           (cd gui/app && npm run build:tauri)
-      - name: Build the GUI shell (debug, embeds the frontend)
+      # --features custom-protocol (bead sq-t6492): a plain `cargo build` sets Tauri's cfg(dev),
+      # which makes the webview load `devUrl` (http://localhost:3001) — "Connection refused" under
+      # the e2e (no dev server). custom-protocol embeds + serves frontendDist (../app/out, built
+      # above). See gui/src-tauri/Cargo.toml. `cargo tauri build` sets this automatically; a plain
+      # cargo build must pass it.
+      - name: Build the GUI shell (debug, embeds the frontend via custom-protocol)
         if: needs.config.outputs.mode == 'full'
         working-directory: gui/src-tauri
-        run: cargo build
+        run: cargo build --features custom-protocol
       - name: Install tauri-driver@2.0.6 (pinned)
         if: needs.config.outputs.mode == 'full'
         run: cargo install tauri-driver@2.0.6 --locked

--- a/gui/e2e/run-e2e.mjs
+++ b/gui/e2e/run-e2e.mjs
@@ -180,12 +180,20 @@ async function main() {
   // rewrites it to "webview2" on Windows), so the fix is client-side: OMIT browserName entirely.
   // The guard only fires when a mismatching name is SUPPLIED, so omitting it matches on BOTH old
   // and new WebKitGTK. tauri:options.application is what actually selects the wry webview binary.
+  // SESSION-CREATE TIMEOUT (bead sq-t6492): a cold DEBUG shell launching a WebKitGTK webview under
+  // xvfb can take well over 30 s to complete POST /session (the webview + native engine cold-start).
+  // The original 30 s ceiling timed out AFTER the capability fix let the session proceed (the app
+  // process did launch — the driver log shows its startup output — but /session did not return in
+  // time). 120 s gives the cold debug launch head-room; overridable via SESSION_CREATE_TIMEOUT_MS.
+  const SESSION_CREATE_TIMEOUT_MS = Number(
+    process.env.SESSION_CREATE_TIMEOUT_MS || 120_000,
+  );
   const browser = await remote({
     hostname: TAURI_DRIVER_HOST,
     port: TAURI_DRIVER_PORT,
     logLevel: "error",
-    connectionRetryTimeout: 30_000,
-    connectionRetryCount: 5,
+    connectionRetryTimeout: SESSION_CREATE_TIMEOUT_MS,
+    connectionRetryCount: 3,
     capabilities: {
       "tauri:options": { application: APP_BINARY },
     },

--- a/gui/e2e/run-e2e.mjs
+++ b/gui/e2e/run-e2e.mjs
@@ -169,6 +169,17 @@ async function main() {
   // Open a WebDriver session through tauri-driver. `tauri:options.application` tells
   // tauri-driver which native binary to launch. connectionRetryCount / connectionRetryTimeout
   // cover transient HTTP hiccups — webdriverio's own retry policy, not arbitrary sleeps.
+  //
+  // CAPABILITIES — DO NOT re-add `browserName: "wry"` (bead sq-t6492 / issue #1740).
+  // WebKit's matchCapabilities (Source/WebDriver/WebDriverService.cpp) rejects a session with
+  // "Failed to match capabilities" whenever a NON-NULL `browserName` is supplied that does not
+  // equal the driver's own reported name. Newer WebKitGTK (the runner's webkit2gtk 2.5x) reports
+  // `browserName: "MiniBrowser"`, so the historic tauri#8828 workaround `browserName: "wry"` now
+  // BACKFIRES: "wry" != "MiniBrowser" → hard reject before any session log (the 0-byte-log
+  // signature). tauri-driver 2.0.6 forwards the client browserName verbatim on Linux (it only
+  // rewrites it to "webview2" on Windows), so the fix is client-side: OMIT browserName entirely.
+  // The guard only fires when a mismatching name is SUPPLIED, so omitting it matches on BOTH old
+  // and new WebKitGTK. tauri:options.application is what actually selects the wry webview binary.
   const browser = await remote({
     hostname: TAURI_DRIVER_HOST,
     port: TAURI_DRIVER_PORT,
@@ -177,7 +188,6 @@ async function main() {
     connectionRetryCount: 5,
     capabilities: {
       "tauri:options": { application: APP_BINARY },
-      browserName: "wry",
     },
   });
 

--- a/gui/src-tauri/Cargo.toml
+++ b/gui/src-tauri/Cargo.toml
@@ -54,6 +54,14 @@ tauri-build = { version = "2", features = [] }
 # cannot. The webview-target build (Pages "Try the GUI live") never links this crate at all.
 default = []
 hdt = ["dep:sparq-hdt"]
+# [FABLE-5] sq-t6492 — embed + serve the frontendDist static export instead of connecting to
+# `devUrl` (http://localhost:3001). Tauri's build script sets `cfg(dev) = !custom-protocol`
+# (tauri build.rs: `let dev = !custom_protocol`), and in dev mode the webview navigates to
+# `devUrl`; a plain `cargo build` (no `custom-protocol`) therefore shows "Could not connect to
+# localhost: Connection refused" when no dev server is running. `cargo tauri build` enables this
+# feature automatically; a plain `cargo build` (e2e/CI) must pass `--features custom-protocol` so
+# the webview loads the embedded assets. Independent of the debug/release profile.
+custom-protocol = ["tauri/custom-protocol"]
 
 [dependencies]
 tauri = { version = "2", features = [] }

--- a/scripts/ci/tauri-driver-drift-tripwire.sh
+++ b/scripts/ci/tauri-driver-drift-tripwire.sh
@@ -1,110 +1,125 @@
 #!/usr/bin/env bash
-# [FABLE-5] sq-t6492 — tauri-driver ↔ webkit2gtk DRIFT TRIPWIRE
+# [FABLE-5] sq-t6492 — tauri-driver ↔ WebKitGTK capability DRIFT TRIPWIRE + regression guard
 #
 # The native GUI smoke (nightly-full-sweep.yml `tauri-smoke`, gui.yml `tauri-e2e`) launches the
 # Tauri shell through `tauri-driver`, which proxies to the runner's WebKitWebDriver (from the
-# `webkit2gtk-driver` apt package). Both the WebDriver server AND the app's webview come from the
-# SAME runner-image apt version of webkit2gtk, so they are internally consistent — the drift that
-# breaks the lane is between the PINNED `tauri-driver` (crates.io) and the runner image's
-# webkit2gtk, which GitHub bumps on ITS schedule, not ours.
+# `webkit2gtk-driver` apt package). The WebDriver server and the app's webview come from the SAME
+# runner-image apt version of webkit2gtk, so they are internally consistent — the drift that broke
+# the lane is between the CLIENT capability shape (gui/e2e/run-e2e.mjs) and the WebKitGTK the runner
+# ships, which GitHub bumps on ITS schedule, not ours.
 #
-# KNOWN-INCOMPATIBLE combination (issue #1740, bead sq-t6492):
-#   tauri-driver 2.0.6 (newest published, May 2026)  +  webkit2gtk 2.52.x  (ubuntu-24.04 noble)
-#   → POST /session fails with "session not created: Failed to match capabilities" DURING
-#     capability negotiation, BEFORE WebKitWebDriver logs a session → the driver log is 0 bytes.
-#   The webdriverio client already sends `browserName: "wry"` (the historic tauri#8828 fix), so
-#   the surviving cause is a WebKitWebDriver 2.5x protocol/behaviour change (corroborated by
-#   `WebKitWebDriver --version` printing its usage banner instead of a version on 2.52.x).
+# CONFIRMED ROOT CAUSE (issue #1740, bead sq-t6492; WebKit source-verified):
+#   WebKit's matchCapabilities (Source/WebDriver/WebDriverService.cpp) rejects a session with
+#   "session not created: Failed to match capabilities" whenever a NON-NULL `browserName` capability
+#   is supplied that does not equal the driver's own reported browser name (case-insensitive). Newer
+#   WebKitGTK (the runner's webkit2gtk 2.5x) reports `browserName: "MiniBrowser"`. The historic
+#   tauri#8828 workaround sent `browserName: "wry"`, so once WebKitGTK began populating that field
+#   `"wry" != "MiniBrowser"` → HARD REJECT during POST /session, BEFORE WebKitWebDriver logs a
+#   session → the driver log is 0 bytes. tauri-driver 2.0.6 forwards the client browserName verbatim
+#   on Linux (it only rewrites to "webview2" on Windows), so the fix is CLIENT-SIDE: OMIT
+#   browserName entirely (the guard only fires when a MISMATCHING name is supplied, so omitting it
+#   matches on both old and new WebKitGTK). See tauri-apps/tauri#8828, #10670, SeleniumHQ/selenium#10178.
 #
-# PURPOSE: turn the NEXT drift from a 0-byte-log hunt into a one-line diagnosis. This script logs
-# both versions and, when it sees the known-incompatible pair, emits a LOUD GitHub Actions
-# annotation naming this bead + issue. It is DIAGNOSTIC, not a gate: it exits 0 by default so the
-# advisory lane's pass/fail is still decided by the actual smoke run (research/web-gui-test-program.md
-# §5 — this Linux smoke is advisory-forever and never gates the merge queue). Pass `--strict` to
-# make a detected known-bad combination exit non-zero (reserved for if the lane is ever promoted
-# to gating; unused today).
+# THIS SCRIPT DOES TWO THINGS:
+#   1. REGRESSION GUARD (primary): fail if gui/e2e/run-e2e.mjs re-introduces `browserName: "wry"`
+#      (or any hard-coded browserName), which would reinstate the exact #1740 failure. This is the
+#      one deterministic check that should NEVER pass silently, so it exits non-zero on a hit.
+#   2. VERSION TRIPWIRE (diagnostic): log the webkit2gtk + tauri-driver versions so the NEXT drift
+#      is a one-line read instead of a 0-byte-log hunt, and surface a loud annotation if a future
+#      WebKitGTK/tauri-driver combination looks suspicious. Diagnostic only — does not gate.
 #
 # Usage:
-#   scripts/ci/tauri-driver-drift-tripwire.sh [--strict] [--tauri-driver-version X.Y.Z]
-# If --tauri-driver-version is omitted it is read from the installed `tauri-driver` binary.
+#   scripts/ci/tauri-driver-drift-tripwire.sh [--strict] [--tauri-driver-version X.Y.Z] [--harness PATH]
+# --strict            also exit non-zero on the version-tripwire suspicion (unused today; reserved
+#                     for a future gating promotion). The regression guard ALWAYS exits non-zero.
+# --harness PATH      path to run-e2e.mjs (default: resolved relative to this script).
+# --tauri-driver-version omit to read from the installed `tauri-driver` binary.
 
 set -euo pipefail
 
 STRICT=0
 TAURI_DRIVER_VERSION=""
+HARNESS=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# repo-root/scripts/ci/… → repo-root is two levels up.
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
     --strict) STRICT=1; shift ;;
     --tauri-driver-version) TAURI_DRIVER_VERSION="${2:-}"; shift 2 ;;
     --tauri-driver-version=*) TAURI_DRIVER_VERSION="${1#*=}"; shift ;;
+    --harness) HARNESS="${2:-}"; shift 2 ;;
+    --harness=*) HARNESS="${1#*=}"; shift ;;
     *) echo "tauri-drift-tripwire: unknown arg: $1" >&2; exit 2 ;;
   esac
 done
 
+[ -n "$HARNESS" ] || HARNESS="$REPO_ROOT/gui/e2e/run-e2e.mjs"
+
 # GitHub Actions annotation helpers degrade to plain echo when run locally (no $GITHUB_ACTIONS).
 notice()  { if [ "${GITHUB_ACTIONS:-}" = "true" ]; then echo "::notice::$*";  else echo "NOTICE: $*";  fi; }
-warning() { if [ "${GITHUB_ACTIONS:-}" = "true" ]; then echo "::warning::$*"; else echo "WARNING: $*"; fi; }
 error()   { if [ "${GITHUB_ACTIONS:-}" = "true" ]; then echo "::error::$*";   else echo "ERROR: $*";   fi; }
 
-# --- Gather versions ---------------------------------------------------------------------------
+echo "── tauri-driver drift tripwire + regression guard (bead sq-t6492 / issue #1740) ──────────"
 
-# webkit2gtk-driver apt version, e.g. "2.52.3-0ubuntu0.24.04.1" → we want the leading "2.52.3".
+# --- 1. REGRESSION GUARD: the client must NOT hard-code a mismatching browserName ---------------
+# The failure is fully attributable to `browserName: "wry"` in the capabilities. Guard against its
+# return. We match a browserName key set to any quoted string inside the capabilities object; the
+# fix is to omit browserName, so ANY hard-coded browserName is treated as the regression.
+if [ ! -f "$HARNESS" ]; then
+  error "e2e harness not found at $HARNESS — cannot run the browserName regression guard (bead sq-t6492)."
+  exit 1
+fi
+
+# Strip line comments so the explanatory '// DO NOT re-add browserName: "wry"' note is not a hit,
+# then look for an ACTIVE `browserName:` capability assignment.
+if grep -vE '^\s*//' "$HARNESS" | grep -qE 'browserName\s*:\s*["'\'']'; then
+  OFFENDING="$(grep -nvE '^\s*//' "$HARNESS" | grep -E 'browserName\s*:\s*["'\'']' | head -1)"
+  error "REGRESSION (bead sq-t6492 / issue #1740): gui/e2e/run-e2e.mjs sets a hard-coded browserName \
+capability — this reinstates the WebKitGTK 'Failed to match capabilities' failure (WebKit rejects a \
+supplied browserName that != the driver's 'MiniBrowser'). OMIT browserName from the capabilities. \
+Offending line: ${OFFENDING}"
+  exit 1
+fi
+echo "  regression guard : PASS — run-e2e.mjs does not hard-code a browserName capability"
+
+# --- 2. VERSION TRIPWIRE (diagnostic) ----------------------------------------------------------
+
 WEBKIT_APT_FULL="$(dpkg-query -W -f='${Version}' webkit2gtk-driver 2>/dev/null || echo "")"
 WEBKIT_VER="$(printf '%s' "$WEBKIT_APT_FULL" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || echo "")"
-
-# WebKitWebDriver banner (informational; on 2.52.x this prints a usage banner, not a version).
 WKWD_BANNER="$(WebKitWebDriver --version 2>&1 | head -1 || echo "unknown")"
 
-# tauri-driver version (from arg, else the installed binary's `--version`).
 if [ -z "$TAURI_DRIVER_VERSION" ]; then
   TAURI_DRIVER_VERSION="$(tauri-driver --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")"
 fi
 
-echo "── tauri-driver drift tripwire (bead sq-t6492 / issue #1740) ──────────────────────────"
-echo "  tauri-driver version   : ${TAURI_DRIVER_VERSION:-unknown}"
-echo "  webkit2gtk-driver apt  : ${WEBKIT_APT_FULL:-unknown}  (parsed: ${WEBKIT_VER:-unknown})"
-echo "  WebKitWebDriver banner : ${WKWD_BANNER}"
+echo "  tauri-driver     : ${TAURI_DRIVER_VERSION:-unknown}"
+echo "  webkit2gtk-driver: ${WEBKIT_APT_FULL:-unknown}  (parsed: ${WEBKIT_VER:-unknown})"
+echo "  WebKitWebDriver  : ${WKWD_BANNER}"
 echo "───────────────────────────────────────────────────────────────────────────────────────"
 
-# --- Detect the known-incompatible combination ------------------------------------------------
-# Known-bad: tauri-driver 2.0.x  AND  webkit2gtk 2.52.x (or any 2.5x ≥ 2.48 — the WebDriver
-# behaviour change first ships in the 2.48 series). We flag 2.48/2.50/2.52 explicitly; anything
-# newer than 2.52 is ALSO suspect and flagged so a future 2.54 bump does not slip past silently.
-
-is_known_bad=0
-case "$TAURI_DRIVER_VERSION" in
-  2.0.*)
-    case "$WEBKIT_VER" in
-      2.4[89].*|2.5[0-9].*|2.[6-9][0-9].*|3.*)
-        is_known_bad=1
-        ;;
-    esac
-    ;;
+# Informational: WebKitGTK >= 2.48 is where the browserName reporting / driver-name tightening
+# lands (the class that made the old "wry" capability fatal). With browserName now OMITTED this is
+# expected to be FINE — but log it so that if the smoke ever fails on capability negotiation again,
+# the version is right there and the next drift is a one-line diagnosis.
+suspect=0
+case "$WEBKIT_VER" in
+  2.4[89].*|2.5[0-9].*|2.[6-9][0-9].*|3.*) suspect=1 ;;
 esac
 
-if [ "$is_known_bad" = "1" ]; then
-  MSG="tauri-driver ${TAURI_DRIVER_VERSION} is KNOWN-INCOMPATIBLE with webkit2gtk ${WEBKIT_VER} \
-(WebKitWebDriver capability negotiation fails: 'session not created: Failed to match capabilities'). \
-This is the documented drift in bead sq-t6492 / issue #1740. The advisory GUI smoke is EXPECTED to \
-be red on this combination. Fix path: build+run against a pinned older webkit2gtk (container, \
-sq-t6492 follow-up) OR wait for a tauri-driver release that supports webkit2gtk 2.5x. Do NOT spend \
-time on the 0-byte driver log — it is empty because the failure precedes any WebDriver session."
+if [ "$suspect" = "1" ] && [ -n "$WEBKIT_VER" ]; then
+  MSG="webkit2gtk ${WEBKIT_VER} is in the range (>=2.48) where WebKitWebDriver enforces browserName \
+matching (bead sq-t6492 / issue #1740). The harness correctly OMITS browserName, so this should \
+pass; if the smoke still fails on 'Failed to match capabilities', the WebKitGTK capability shape \
+changed again — inspect gui/e2e/run-e2e.mjs capabilities and update this tripwire. (The 0-byte \
+driver log is expected on such a failure — it precedes any WebDriver session.)"
   if [ "$STRICT" = "1" ]; then
-    error "$MSG"
-    exit 1
+    error "$MSG"; exit 1
   fi
-  warning "$MSG"
-  exit 0
+  notice "$MSG"
 fi
 
-# Unknown-but-new: tauri-driver 2.0.x with a webkit2gtk we have not yet classified — surface it so
-# the next drift is visible even if it turns out to be fine.
-if [ "${TAURI_DRIVER_VERSION%%.*}" = "2" ] && [ -n "$WEBKIT_VER" ]; then
-  notice "tauri-driver ${TAURI_DRIVER_VERSION} + webkit2gtk ${WEBKIT_VER}: not on the known-bad list. \
-If the smoke fails on capability negotiation, extend the known-bad match in \
-scripts/ci/tauri-driver-drift-tripwire.sh and update bead sq-t6492 / issue #1740."
-fi
-
-echo "tauri-driver drift tripwire: no known-incompatible combination detected."
+echo "tauri-driver drift tripwire: regression guard passed; versions logged."
 exit 0

--- a/scripts/ci/tauri-driver-drift-tripwire.sh
+++ b/scripts/ci/tauri-driver-drift-tripwire.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# [FABLE-5] sq-t6492 — tauri-driver ↔ webkit2gtk DRIFT TRIPWIRE
+#
+# The native GUI smoke (nightly-full-sweep.yml `tauri-smoke`, gui.yml `tauri-e2e`) launches the
+# Tauri shell through `tauri-driver`, which proxies to the runner's WebKitWebDriver (from the
+# `webkit2gtk-driver` apt package). Both the WebDriver server AND the app's webview come from the
+# SAME runner-image apt version of webkit2gtk, so they are internally consistent — the drift that
+# breaks the lane is between the PINNED `tauri-driver` (crates.io) and the runner image's
+# webkit2gtk, which GitHub bumps on ITS schedule, not ours.
+#
+# KNOWN-INCOMPATIBLE combination (issue #1740, bead sq-t6492):
+#   tauri-driver 2.0.6 (newest published, May 2026)  +  webkit2gtk 2.52.x  (ubuntu-24.04 noble)
+#   → POST /session fails with "session not created: Failed to match capabilities" DURING
+#     capability negotiation, BEFORE WebKitWebDriver logs a session → the driver log is 0 bytes.
+#   The webdriverio client already sends `browserName: "wry"` (the historic tauri#8828 fix), so
+#   the surviving cause is a WebKitWebDriver 2.5x protocol/behaviour change (corroborated by
+#   `WebKitWebDriver --version` printing its usage banner instead of a version on 2.52.x).
+#
+# PURPOSE: turn the NEXT drift from a 0-byte-log hunt into a one-line diagnosis. This script logs
+# both versions and, when it sees the known-incompatible pair, emits a LOUD GitHub Actions
+# annotation naming this bead + issue. It is DIAGNOSTIC, not a gate: it exits 0 by default so the
+# advisory lane's pass/fail is still decided by the actual smoke run (research/web-gui-test-program.md
+# §5 — this Linux smoke is advisory-forever and never gates the merge queue). Pass `--strict` to
+# make a detected known-bad combination exit non-zero (reserved for if the lane is ever promoted
+# to gating; unused today).
+#
+# Usage:
+#   scripts/ci/tauri-driver-drift-tripwire.sh [--strict] [--tauri-driver-version X.Y.Z]
+# If --tauri-driver-version is omitted it is read from the installed `tauri-driver` binary.
+
+set -euo pipefail
+
+STRICT=0
+TAURI_DRIVER_VERSION=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --strict) STRICT=1; shift ;;
+    --tauri-driver-version) TAURI_DRIVER_VERSION="${2:-}"; shift 2 ;;
+    --tauri-driver-version=*) TAURI_DRIVER_VERSION="${1#*=}"; shift ;;
+    *) echo "tauri-drift-tripwire: unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+# GitHub Actions annotation helpers degrade to plain echo when run locally (no $GITHUB_ACTIONS).
+notice()  { if [ "${GITHUB_ACTIONS:-}" = "true" ]; then echo "::notice::$*";  else echo "NOTICE: $*";  fi; }
+warning() { if [ "${GITHUB_ACTIONS:-}" = "true" ]; then echo "::warning::$*"; else echo "WARNING: $*"; fi; }
+error()   { if [ "${GITHUB_ACTIONS:-}" = "true" ]; then echo "::error::$*";   else echo "ERROR: $*";   fi; }
+
+# --- Gather versions ---------------------------------------------------------------------------
+
+# webkit2gtk-driver apt version, e.g. "2.52.3-0ubuntu0.24.04.1" → we want the leading "2.52.3".
+WEBKIT_APT_FULL="$(dpkg-query -W -f='${Version}' webkit2gtk-driver 2>/dev/null || echo "")"
+WEBKIT_VER="$(printf '%s' "$WEBKIT_APT_FULL" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+' || echo "")"
+
+# WebKitWebDriver banner (informational; on 2.52.x this prints a usage banner, not a version).
+WKWD_BANNER="$(WebKitWebDriver --version 2>&1 | head -1 || echo "unknown")"
+
+# tauri-driver version (from arg, else the installed binary's `--version`).
+if [ -z "$TAURI_DRIVER_VERSION" ]; then
+  TAURI_DRIVER_VERSION="$(tauri-driver --version 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1 || echo "")"
+fi
+
+echo "── tauri-driver drift tripwire (bead sq-t6492 / issue #1740) ──────────────────────────"
+echo "  tauri-driver version   : ${TAURI_DRIVER_VERSION:-unknown}"
+echo "  webkit2gtk-driver apt  : ${WEBKIT_APT_FULL:-unknown}  (parsed: ${WEBKIT_VER:-unknown})"
+echo "  WebKitWebDriver banner : ${WKWD_BANNER}"
+echo "───────────────────────────────────────────────────────────────────────────────────────"
+
+# --- Detect the known-incompatible combination ------------------------------------------------
+# Known-bad: tauri-driver 2.0.x  AND  webkit2gtk 2.52.x (or any 2.5x ≥ 2.48 — the WebDriver
+# behaviour change first ships in the 2.48 series). We flag 2.48/2.50/2.52 explicitly; anything
+# newer than 2.52 is ALSO suspect and flagged so a future 2.54 bump does not slip past silently.
+
+is_known_bad=0
+case "$TAURI_DRIVER_VERSION" in
+  2.0.*)
+    case "$WEBKIT_VER" in
+      2.4[89].*|2.5[0-9].*|2.[6-9][0-9].*|3.*)
+        is_known_bad=1
+        ;;
+    esac
+    ;;
+esac
+
+if [ "$is_known_bad" = "1" ]; then
+  MSG="tauri-driver ${TAURI_DRIVER_VERSION} is KNOWN-INCOMPATIBLE with webkit2gtk ${WEBKIT_VER} \
+(WebKitWebDriver capability negotiation fails: 'session not created: Failed to match capabilities'). \
+This is the documented drift in bead sq-t6492 / issue #1740. The advisory GUI smoke is EXPECTED to \
+be red on this combination. Fix path: build+run against a pinned older webkit2gtk (container, \
+sq-t6492 follow-up) OR wait for a tauri-driver release that supports webkit2gtk 2.5x. Do NOT spend \
+time on the 0-byte driver log — it is empty because the failure precedes any WebDriver session."
+  if [ "$STRICT" = "1" ]; then
+    error "$MSG"
+    exit 1
+  fi
+  warning "$MSG"
+  exit 0
+fi
+
+# Unknown-but-new: tauri-driver 2.0.x with a webkit2gtk we have not yet classified — surface it so
+# the next drift is visible even if it turns out to be fine.
+if [ "${TAURI_DRIVER_VERSION%%.*}" = "2" ] && [ -n "$WEBKIT_VER" ]; then
+  notice "tauri-driver ${TAURI_DRIVER_VERSION} + webkit2gtk ${WEBKIT_VER}: not on the known-bad list. \
+If the smoke fails on capability negotiation, extend the known-bad match in \
+scripts/ci/tauri-driver-drift-tripwire.sh and update bead sq-t6492 / issue #1740."
+fi
+
+echo "tauri-driver drift tripwire: no known-incompatible combination detected."
+exit 0


### PR DESCRIPTION
> 🤖 **SPARQ agent** — restores the native GUI smoke tracked in bead **sq-t6492** / consolidated issue **#1740**.

The nightly full-sweep **tauri-driver GUI smoke (Linux)** was red every night since the lane was created (Jul 6) — it was **never actually green**. Verifying by dispatching the nightly in `mode=full` on this branch peeled **four** distinct, real blockers, each fixed and independently confirmed by the changing failure signature + artifacts.

## The four layers (each source-verified, each fixed)

**1. Capability match** — `browserName: "wry"` was rejected. WebKit's `matchCapabilities` rejects a supplied `browserName` ≠ the driver's reported name; WebKitGTK 2.5x reports `"MiniBrowser"`, so the historic [tauri#8828](https://github.com/tauri-apps/tauri/issues/8828) workaround now backfires (0-byte log = reject before session).
→ **Fix:** `gui/e2e/run-e2e.mjs` **omits `browserName`** (matches old+new WebKitGTK). *Confirmed:* error changed to a `/session` timeout, driver log became non-empty (app now launches).

**2. WebKitGTK/xvfb session stall** — `/session` timed out; driver log showed `AT-SPI: … org.a11y.Bus was not provided`. WebKitGTK under xvfb reaches for a non-existent accessibility bus and stalls startup.
→ **Fix:** run under `dbus-run-session --` + `NO_AT_BRIDGE=1` (+ `dbus-x11` apt, session-create timeout 30s→120s). *Confirmed:* AT-SPI warning gone, dbus portals activate, harness reaches `[1/3]`.

**3. Frontend load** — `#repl-query` never mounts; the **screenshot** renders `Could not connect to localhost: Connection refused`. The CI shell loaded `devUrl` (`http://localhost:3001`, the Next dev server) instead of the embedded `frontendDist`.
→ **Fix:** build the shell with `--features custom-protocol`. Tauri's `build.rs` sets `dev = !custom-protocol`; in dev mode + `devUrl`, codegen embeds an **empty** asset map and the webview navigates to `devUrl`. A plain `cargo build` doesn't enable `custom-protocol` → `dev=true`. **Profile-independent** (`--release` alone does NOT fix it); `cargo tauri build` only works because it injects the feature. (tauri 2.11.3 `build.rs` + `tauri-codegen` `context.rs`, source-verified.)

**4. Drift diagnosis (mandated tripwire)** — `scripts/ci/tauri-driver-drift-tripwire.sh`, wired into all three native-smoke lanes, (a) **fails** if `browserName: "wry"` is ever re-added (regression guard for layer 1), and (b) logs webkit2gtk + tauri-driver versions and annotates on webkit2gtk ≥ 2.48 — so the next runner drift is a one-line diagnosis, not a 0-byte-log hunt.

## Strategy note (the task's a-d options)
(a) bump tauri-driver — exhausted (2.0.6 newest). (b) apt-pin webkit2gtk / (c) exact runner-image pin — unavailable/insufficient (2.52.3 is the current one; no exact-image `runs-on` label). (d) container — unnecessary: the failures were **client/CI-config bugs**, not a driver-vs-webkit version wall. The confirmed root causes are all in our harness + build/run config.

## Gate / advisory posture
No job name / `runs-on` / `needs` / routing / `ci-summary / gate` aggregator change. Both smoke jobs keep their `advisory` names (excluded from the gate) + `continue-on-error`. No gate weakened — the smoke still runs and reports; the fixes make it able to pass.

## Verification
- Every change validated locally: `node --check`, `shellcheck` clean, `actionlint` exit 0, YAML valid, `Cargo.toml`/feature-graph resolve, tripwire reproduced across 5 cases.
- Layers 1-3 each confirmed by a real branch `mode=full` dispatch (error signature changed + artifacts). The final `custom-protocol` fix is validating on the latest branch dispatch — the green (or next layer, honestly) will be posted. Follow-up **sq-cgmrn** tracks confirming the end-to-end green + auto-closing #1740.

🤖 Generated with [Claude Code](https://claude.com/claude-code)