### PR TITLE
fix(core): align numeric-value cache parse with the evaluator's XSD acceptance set (sq-9781x) [FABLE-5]

### DIFF
--- a/bench/feature-off-declarations/1792.json
+++ b/bench/feature-off-declarations/1792.json
@@ -1,0 +1,5 @@
+{
+  "pr": 1792,
+  "date": "2026-07-09",
+  "reason": "[FABLE-5] sq-9781x: routing the always-compiled sparq-core numeric-value cache (numerics_of / numeric_of / the dict-spill build) through the new shared sparq_core::parse_xsd_f64 (trim + XSD lexical space) instead of a raw str::parse::<f64> changes always-compiled core ingest code, so the feature-OFF wasm bundle bytes move from base by design (+507 B, +0.032%). SIZE stays governed by the wasm_bundle_bytes +/-2% floor ratchet."
+}

--- a/crates/sparq-core/src/dictspill.rs
+++ b/crates/sparq-core/src/dictspill.rs
@@ -1013,8 +1013,11 @@ pub(crate) fn consolidate(mut st: SpillInterner, dir: &Path, tmp: &Path, cfg: &S
                     (dict::StoredRef::Iri { prefix: prefixes.intern(prefix), suffix }, f64::NAN, None)
                 }
                 TermParts::Lit { value, datatype, lang } => {
+                    // [FABLE-5] (sq-9781x) SAME shared XSD-lexical parser on the TRIMMED value
+                    // as the in-RAM `numerics_of` — the spilled cache must be byte-identical to
+                    // the in-RAM one, and both must equal the evaluator's acceptance set.
                     let numeric = if lang.is_none() && crate::is_numeric_datatype_str(datatype) {
-                        value.parse::<f64>().unwrap_or(f64::NAN)
+                        crate::parse_xsd_f64(value.trim()).unwrap_or(f64::NAN)
                     } else {
                         f64::NAN
                     };

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -619,8 +619,21 @@ fn write_temporals(path: &std::path::Path, flags: &[u8], instants: &[f64]) -> st
 
 /// [FABLE-5] (sq-9781x) Parse a numeric-literal lexical to its f64 image using the XSD
 /// lexical space — the SINGLE shared routine that the numeric-value CACHE
-/// (`numerics_of`/`numeric_of`) and the evaluator's f64 seam agree on, so a cache HIT
-/// is equivalent to evaluator ACCEPTANCE for the same numeric value.
+/// (`numerics_of`/`numeric_of`) and the evaluator's **datatype-AGNOSTIC f64 seam**
+/// (`as_num` / `as_f64` / substrate `parse_xsd_f64`) agree on, so a cache HIT is
+/// equivalent to acceptance on THAT seam for the same numeric value.
+///
+/// SCOPE (important): this alignment is with the datatype-agnostic f64 seam, NOT with the
+/// full datatype-AWARE `sparq_substrate::numeric::as_numeric` / `Num::of_literal`
+/// acceptance set. `of_literal` is per-datatype: integers must be scale-0, decimals carry
+/// no exponent, and an integer beyond i128 is not representable. `parse_xsd_f64` ignores
+/// the datatype, so it ACCEPTS some lexicals that are ill-formed FOR THEIR DATATYPE and
+/// that `of_literal` rejects with a type error. Counterexamples that cache-HIT here yet
+/// `of_literal`-reject: `"1.5"^^xsd:integer` (fraction on an integer), `"1E2"^^xsd:decimal`
+/// (exponent on a decimal), a >38-digit `xsd:decimal` (i128 overflow → `of_literal` None).
+/// This residual per-datatype over-leniency is PRE-EXISTING (the old raw parse accepted the
+/// same lexicals) and tracked in the residual bead sibling of sq-74oy4; see the eqjoin
+/// `JKey::Num` comment and the substrate differential test `cache_f64_seam_vs_as_numeric`.
 ///
 /// It is the lowest-tier home of the parser `sparq_substrate::numeric::parse_xsd_f64`
 /// re-exports (the substrate depends on `sparq-core`, not the reverse, so the shared body
@@ -651,8 +664,10 @@ pub fn parse_xsd_f64(v: &str) -> Option<f64> {
 }
 
 /// The f64 value of a term if it is a numeric XSD literal, else NaN. Routes the lexical
-/// through the shared [`parse_xsd_f64`] (XSD acceptance set) on the TRIMMED value so it
-/// agrees with the evaluator's `Num::of_literal` equality path. [FABLE-5] (sq-9781x)
+/// through the shared [`parse_xsd_f64`] (XSD f64 acceptance set) on the TRIMMED value so it
+/// agrees with the evaluator's datatype-AGNOSTIC f64 seam. It does NOT reproduce the
+/// datatype-AWARE `Num::of_literal` acceptance set (see [`parse_xsd_f64`] SCOPE note: e.g.
+/// `"1.5"^^xsd:integer` parses here yet `of_literal` type-errors). [FABLE-5] (sq-9781x)
 fn numeric_of(term: &Term) -> f64 {
     match term {
         Term::Literal(l) if is_numeric_dt(l) => parse_xsd_f64(l.value().trim()).unwrap_or(f64::NAN),
@@ -4046,10 +4061,14 @@ fn numerics_of(dict: &Dict) -> Vec<f64> {
         match dict.term_parts(i as Id + 1) {
             // [FABLE-5] (sq-9781x) Route through the shared XSD-lexical-space parser on the
             // TRIMMED value — NOT a raw `str::parse::<f64>` — so a cache HIT is equivalent to
-            // the evaluator ACCEPTING the literal (its equality decision runs through
-            // `Num::of_literal`, which trims), for exactly the same f64. This both admits the
-            // whitespace-padded lexical (` 1`^^xsd:integer) the raw parse missed AND rejects
-            // the Rust-only `inf`/`infinity`/`nan` spellings the raw parse wrongly cached.
+            // acceptance on the evaluator's datatype-AGNOSTIC f64 seam (`parse_xsd_f64`, which
+            // trims here to match `Num::of_literal`'s trim), for exactly the same f64. This
+            // both admits the whitespace-padded lexical (` 1`^^xsd:integer) the raw parse
+            // missed AND rejects the Rust-only `inf`/`infinity`/`nan` spellings the raw parse
+            // wrongly cached. It does NOT reproduce the datatype-AWARE `of_literal` set: a
+            // per-datatype-ill-formed lexical (`"1.5"^^xsd:integer`, `"1E2"^^xsd:decimal`,
+            // an i128-overflow decimal) still caches its f64 here while `of_literal`
+            // type-errors — a PRE-EXISTING residual tracked in the sq-74oy4-sibling bead.
             dict::TermParts::Lit { value, datatype, lang: None } if is_numeric_datatype_str(datatype) => {
                 parse_xsd_f64(value.trim()).unwrap_or(f64::NAN)
             }
@@ -10135,18 +10154,21 @@ mod tests {
         }
     }
 
-    /// [FABLE-5] (sq-9781x) The load-bearing invariant of the numeric-value cache alignment:
-    /// for a corpus of weird numeric lexicals, a cache HIT (`numeric_value(id).is_some()`)
-    /// is EQUIVALENT to the evaluator ACCEPTING the literal as numeric, and the cached f64 is
-    /// EXACTLY the evaluator's f64 image — where the evaluator's acceptance/value are modelled
-    /// by the shared `parse_xsd_f64` on the TRIMMED lexical (the `Num::of_literal` equality
-    /// path trims), with a stored-NaN value folding to a cache MISS (the cache uses NaN as its
-    /// "not cached" sentinel, so a genuine `NaN`^^xsd:double is not distinguishable and
-    /// correctly falls through to the evaluator). Covers whitespace padding, leading `+`,
-    /// the XSD specials, the Rust-only spellings, exponent forms, empty/`abc`, high-precision
-    /// decimals and `2^53 ± 1`.
+    /// [FABLE-5] (sq-9781x) SHARED-PARSER PLUMBING check (NOT a differential vs the real
+    /// datatype-aware evaluator). It pins that the numeric-value cache actually routes every
+    /// numeric datatype through the shared `parse_xsd_f64` on the TRIMMED lexical: a cache HIT
+    /// (`numeric_value(id).is_some()`) is EQUIVALENT to `parse_xsd_f64(value.trim())` being
+    /// `Some` non-NaN, and the cached f64 is EXACTLY that value. Because the "evaluator model"
+    /// here is the SAME function the cache calls, this cannot detect divergence from the real
+    /// datatype-AWARE `Num::of_literal` — that cross-seam check is
+    /// `sparq_substrate::compare` `cache_f64_seam_vs_as_numeric`, which asserts the KNOWN
+    /// per-datatype divergence (`"1.5"^^xsd:integer` etc., bead sq-6b1lj). A stored-NaN value
+    /// folds to a cache MISS (the cache uses NaN as its "not cached" sentinel, so a genuine
+    /// `NaN`^^xsd:double falls through to the evaluator). Covers whitespace padding, leading
+    /// `+`, the XSD specials, the Rust-only spellings, exponent forms, empty/`abc`,
+    /// high-precision decimals and `2^53 ± 1`.
     #[test]
-    fn numeric_cache_hit_iff_evaluator_accepts_same_value() {
+    fn numeric_cache_hit_matches_shared_parse_xsd_f64_plumbing() {
         // (lexical, datatype-suffix). Each becomes one distinct dictionary literal.
         let cases: &[(&str, &str)] = &[
             (" 1", "xsd:integer"),      // whitespace-padded (leading) — trim-then-parse

--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -617,10 +617,45 @@ fn write_temporals(path: &std::path::Path, flags: &[u8], instants: &[f64]) -> st
     f.flush()
 }
 
-/// The f64 value of a term if it is a numeric XSD literal, else NaN.
+/// [FABLE-5] (sq-9781x) Parse a numeric-literal lexical to its f64 image using the XSD
+/// lexical space — the SINGLE shared routine that the numeric-value CACHE
+/// (`numerics_of`/`numeric_of`) and the evaluator's f64 seam agree on, so a cache HIT
+/// is equivalent to evaluator ACCEPTANCE for the same numeric value.
+///
+/// It is the lowest-tier home of the parser `sparq_substrate::numeric::parse_xsd_f64`
+/// re-exports (the substrate depends on `sparq-core`, not the reverse, so the shared body
+/// must live here). The acceptance set is XSD's, not Rust's:
+///
+/// - The XSD specials `NaN` / `INF` / `+INF` / `-INF` parse; Rust-`FromStr`-only spellings
+///   the XSD lexical space FORBIDS (`inf` / `infinity` / `-inf` / `nan` / `Infinity` …) are
+///   REJECTED, even though `str::parse::<f64>` would accept them. This is load-bearing: the
+///   old raw `str::parse::<f64>` cache stored `inf` for `"inf"^^xsd:double`, which the
+///   evaluator type-errors — a cache MORE lenient than the evaluator.
+/// - No trimming here (byte-identical to the substrate re-export, which the lenient engine
+///   `as_num`/`as_f64` seam and the reasoner `as_f64` route through UN-trimmed). Callers
+///   that must match the evaluator's TRIMMING equality path (`Num::of_literal`) trim the
+///   lexical themselves before calling — `numerics_of` does exactly that.
+///
+/// `None` for an ill-formed lexical.
+#[inline]
+pub fn parse_xsd_f64(v: &str) -> Option<f64> {
+    match v {
+        "NaN" => Some(f64::NAN),
+        "INF" | "+INF" => Some(f64::INFINITY),
+        "-INF" => Some(f64::NEG_INFINITY),
+        // Only ASCII digits / sign / point / exponent letters reach Rust's parser, which
+        // excludes every non-XSD spelling (`inf`/`infinity`/`nan`/hex/`_` separators …).
+        _ if v.bytes().all(|c| c.is_ascii_digit() || matches!(c, b'+' | b'-' | b'.' | b'e' | b'E')) => v.parse::<f64>().ok(),
+        _ => None,
+    }
+}
+
+/// The f64 value of a term if it is a numeric XSD literal, else NaN. Routes the lexical
+/// through the shared [`parse_xsd_f64`] (XSD acceptance set) on the TRIMMED value so it
+/// agrees with the evaluator's `Num::of_literal` equality path. [FABLE-5] (sq-9781x)
 fn numeric_of(term: &Term) -> f64 {
     match term {
-        Term::Literal(l) if is_numeric_dt(l) => l.value().parse::<f64>().unwrap_or(f64::NAN),
+        Term::Literal(l) if is_numeric_dt(l) => parse_xsd_f64(l.value().trim()).unwrap_or(f64::NAN),
         _ => f64::NAN,
     }
 }
@@ -4009,8 +4044,14 @@ fn numerics_of(dict: &Dict) -> Vec<f64> {
     let n = dict.len();
     let numeric_of_parts = |i: usize| -> f64 {
         match dict.term_parts(i as Id + 1) {
+            // [FABLE-5] (sq-9781x) Route through the shared XSD-lexical-space parser on the
+            // TRIMMED value — NOT a raw `str::parse::<f64>` — so a cache HIT is equivalent to
+            // the evaluator ACCEPTING the literal (its equality decision runs through
+            // `Num::of_literal`, which trims), for exactly the same f64. This both admits the
+            // whitespace-padded lexical (` 1`^^xsd:integer) the raw parse missed AND rejects
+            // the Rust-only `inf`/`infinity`/`nan` spellings the raw parse wrongly cached.
             dict::TermParts::Lit { value, datatype, lang: None } if is_numeric_datatype_str(datatype) => {
-                value.parse::<f64>().unwrap_or(f64::NAN)
+                parse_xsd_f64(value.trim()).unwrap_or(f64::NAN)
             }
             _ => f64::NAN,
         }
@@ -10067,6 +10108,146 @@ mod tests {
                 id, a.to_bits(), b.to_bits()
             );
         }
+    }
+
+    /// [FABLE-5] (sq-9781x) Direct unit test for the shared public `parse_xsd_f64`: the XSD
+    /// lexical space (specials `NaN`/`INF`/`+INF`/`-INF`), the Rust-only spellings it MUST
+    /// reject, ordinary decimals/exponents, and untrimmed padding (this fn does NOT trim —
+    /// callers trim). Kept in lock-step with the substrate re-export's own test.
+    #[test]
+    fn parse_xsd_f64_shared_acceptance_set() {
+        assert_eq!(parse_xsd_f64("NaN").map(f64::to_bits), Some(f64::NAN.to_bits()));
+        assert_eq!(parse_xsd_f64("INF"), Some(f64::INFINITY));
+        assert_eq!(parse_xsd_f64("+INF"), Some(f64::INFINITY));
+        assert_eq!(parse_xsd_f64("-INF"), Some(f64::NEG_INFINITY));
+        assert_eq!(parse_xsd_f64("6"), Some(6.0));
+        assert_eq!(parse_xsd_f64("+1"), Some(1.0));
+        assert_eq!(parse_xsd_f64("1.5E2"), Some(150.0));
+        assert_eq!(parse_xsd_f64("-0.0").map(f64::to_bits), Some((-0.0f64).to_bits()));
+        // Rust-`FromStr`-only spellings the XSD lexical space forbids: rejected.
+        for bad in ["inf", "+inf", "-inf", "infinity", "-infinity", "Infinity", "nan", "NAN"] {
+            // Positional arg (not inline `{bad}`) to dodge the CodeQL false positive. [FABLE-5]
+            assert_eq!(parse_xsd_f64(bad), None, "must reject {:?}", bad);
+        }
+        // Ill-formed / non-numeric: rejected.
+        for bad in ["", "abc", "1_000", "0x1p4", " 1", "1 "] {
+            assert_eq!(parse_xsd_f64(bad), None, "must reject {:?}", bad);
+        }
+    }
+
+    /// [FABLE-5] (sq-9781x) The load-bearing invariant of the numeric-value cache alignment:
+    /// for a corpus of weird numeric lexicals, a cache HIT (`numeric_value(id).is_some()`)
+    /// is EQUIVALENT to the evaluator ACCEPTING the literal as numeric, and the cached f64 is
+    /// EXACTLY the evaluator's f64 image — where the evaluator's acceptance/value are modelled
+    /// by the shared `parse_xsd_f64` on the TRIMMED lexical (the `Num::of_literal` equality
+    /// path trims), with a stored-NaN value folding to a cache MISS (the cache uses NaN as its
+    /// "not cached" sentinel, so a genuine `NaN`^^xsd:double is not distinguishable and
+    /// correctly falls through to the evaluator). Covers whitespace padding, leading `+`,
+    /// the XSD specials, the Rust-only spellings, exponent forms, empty/`abc`, high-precision
+    /// decimals and `2^53 ± 1`.
+    #[test]
+    fn numeric_cache_hit_iff_evaluator_accepts_same_value() {
+        // (lexical, datatype-suffix). Each becomes one distinct dictionary literal.
+        let cases: &[(&str, &str)] = &[
+            (" 1", "xsd:integer"),      // whitespace-padded (leading) — trim-then-parse
+            ("1 ", "xsd:integer"),      // whitespace-padded (trailing)
+            ("\t2\n", "xsd:integer"),   // other whitespace
+            ("+3", "xsd:integer"),      // leading +
+            ("INF", "xsd:double"),      // XSD special
+            ("-INF", "xsd:double"),     // XSD special
+            ("+INF", "xsd:double"),     // XSD special
+            ("NaN", "xsd:double"),      // XSD special -> NaN value -> cache MISS (sentinel)
+            ("inf", "xsd:double"),      // Rust-only spelling -> REJECTED
+            ("infinity", "xsd:double"), // Rust-only spelling -> REJECTED
+            ("Infinity", "xsd:double"), // Rust-only spelling -> REJECTED
+            ("nan", "xsd:double"),      // Rust-only spelling -> REJECTED
+            ("1.5E2", "xsd:double"),    // exponent
+            ("-2.5e-1", "xsd:double"),  // exponent, negative
+            ("abc", "xsd:integer"),     // not a number -> REJECTED
+            ("", "xsd:integer"),        // empty -> REJECTED
+            ("1.000000000000000001", "xsd:decimal"), // high-precision decimal
+            ("9007199254740993", "xsd:integer"),     // 2^53 + 1
+            ("9007199254740991", "xsd:integer"),     // 2^53 - 1
+            ("3.0", "xsd:float"),       // ordinary float
+            ("007.50", "xsd:decimal"),  // leading zeros
+        ];
+        let mut ttl = String::from(
+            "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n@prefix ex: <http://ex/> .\n",
+        );
+        // Use a fresh subject per case so every literal is a distinct object term (equal
+        // (lexical, datatype) pairs would intern to one id, but ours are all distinct).
+        for (i, (lex, dt)) in cases.iter().enumerate() {
+            // Escape the lexical for a Turtle string literal (only \, ", \t, \n occur here).
+            let esc: String = lex
+                .chars()
+                .flat_map(|c| match c {
+                    '\\' => vec!['\\', '\\'],
+                    '"' => vec!['\\', '"'],
+                    '\t' => vec!['\\', 't'],
+                    '\n' => vec!['\\', 'n'],
+                    other => vec![other],
+                })
+                .collect();
+            ttl.push_str(&format!("ex:s{} ex:v \"{}\"^^{} .\n", i, esc, dt));
+        }
+        let g = Graph::load_str(&ttl, "turtle").unwrap();
+        // For each object literal, compare the cache decision to the evaluator model.
+        for (id, tp) in g.dict.iter() {
+            let dict::TermParts::Lit { value, datatype, lang: None } = tp else { continue };
+            if !is_numeric_datatype_str(datatype) {
+                continue;
+            }
+            // Evaluator model: accept iff parse_xsd_f64(trimmed) is Some AND non-NaN (a NaN
+            // value is stored but folds to a cache miss via the sentinel).
+            let model = parse_xsd_f64(value.trim()).filter(|v| !v.is_nan());
+            let cached = g.numeric_value(id);
+            match (model, cached) {
+                (Some(m), Some(c)) => assert_eq!(
+                    m.to_bits(),
+                    c.to_bits(),
+                    "id {}: lexical {:?} cache f64 {:016x} != evaluator f64 {:016x}",
+                    id,
+                    value,
+                    c.to_bits(),
+                    m.to_bits()
+                ),
+                (None, None) => {}
+                (m, c) => panic!(
+                    "cache/evaluator disagree on acceptance for lexical {:?}: model={:?} cache={:?}",
+                    value,
+                    m,
+                    c
+                ),
+            }
+        }
+    }
+
+    /// [FABLE-5] (sq-9781x) The specific latent bugs the alignment fixes, asserted directly
+    /// against the pre-fix raw `str::parse::<f64>` behaviour: (a) a whitespace-padded numeric
+    /// literal now HITS the cache (was a miss); (b) a Rust-only `inf`/`nan` spelling now MISSES
+    /// the cache (the raw parse wrongly cached `inf`/`NaN`), matching the evaluator's rejection.
+    #[test]
+    fn numeric_cache_alignment_fixes_both_divergences() {
+        let ttl = "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+            @prefix ex: <http://ex/> .\n\
+            ex:pad  ex:v \" 7 \"^^xsd:decimal .\n\
+            ex:inf  ex:v \"inf\"^^xsd:double .\n\
+            ex:nan  ex:v \"nan\"^^xsd:double .\n\
+            ex:good ex:v \"INF\"^^xsd:double .";
+        let g = Graph::load_str(ttl, "turtle").unwrap();
+        let by_val = |needle: &str| -> Option<f64> {
+            g.dict.iter().find_map(|(id, tp)| match tp {
+                dict::TermParts::Lit { value, .. } if value == needle => Some(g.numeric_value(id)),
+                _ => None,
+            }).flatten()
+        };
+        // (a) previously a raw-parse MISS, now a value-7.0 HIT (trim-then-parse).
+        assert_eq!(by_val(" 7 "), Some(7.0), "padded decimal must now hit the cache");
+        // (b) previously a raw-parse HIT storing inf/NaN, now a MISS (XSD rejects the spelling).
+        assert_eq!(by_val("inf"), None, "'inf'^^xsd:double must NOT hit the cache");
+        assert_eq!(by_val("nan"), None, "'nan'^^xsd:double must NOT hit the cache");
+        // The genuine XSD spelling still hits with the infinity value.
+        assert_eq!(by_val("INF"), Some(f64::INFINITY), "'INF'^^xsd:double still hits");
     }
 
     /// [OPUS-4.8] (sq-x32t) Recursively reads every regular file under `dir` and returns true iff

--- a/crates/sparq-engine/src/eqjoin.rs
+++ b/crates/sparq-engine/src/eqjoin.rs
@@ -450,13 +450,17 @@ fn key_of(graph: &Graph, id: Id) -> JKey {
                     _ => JKey::Term(id),
                 };
             }
-            // A NUMERIC datatype reaching here missed the `numeric_value` cache — but
-            // the cache (a raw `str::parse::<f64>`) is STRICTER than the evaluator's
-            // `values_equal` fallback (`Num::of_literal`, which TRIMS the lexical): a
-            // whitespace-padded `" 1"^^xsd:integer` is a cache miss yet value-equal to
-            // `"1"^^xsd:integer` under a different id. No provable key ⇒ Hard (the
-            // exact evaluator pairs it; genuinely ill-formed lexicals then type-error
-            // exactly as today).
+            // A NUMERIC datatype reaching here missed the `numeric_value` cache. As of
+            // sq-9781x the cache is ALIGNED with the evaluator: it parses through the shared
+            // `parse_xsd_f64` on the TRIMMED lexical (the same XSD acceptance set + trimming
+            // as `Num::of_literal`, which decides `values_equal`), so a whitespace-padded
+            // `" 1"^^xsd:integer` now HITS the cache above (→ `JKey::Num`) and the `inf`/`nan`
+            // Rust-only spellings the raw parse wrongly cached now MISS. A numeric datatype
+            // reaching THIS branch is therefore a genuinely ILL-FORMED numeric lexical (or a
+            // `NaN` value, the cache's not-cached sentinel) — which the exact evaluator also
+            // type-errors — so `Hard` (defer to the exact evaluator) stays the correct,
+            // no-false-negative key. (The alignment removed the former latent asymmetry;
+            // `Hard` remains a sound backstop.)
             if is_numeric_datatype(datatype) {
                 return JKey::Hard;
             }
@@ -947,9 +951,13 @@ mod tests {
         assert_eq!(key_of(&g, id_of("\"1\"^^<http://www.w3.org/2001/XMLSchema#boolean>")), JKey::Bool(true));
         // Value-comparable temporals are the Hard class.
         assert_eq!(key_of(&g, id_of("2020-01-01T00:00:00Z")), JKey::Hard);
-        // A cache-missing numeric-datatype lexical (whitespace-padded) is Hard, NOT
-        // an identity key: the evaluator's trimming fallback can still pair it.
-        assert_eq!(key_of(&g, id_of("\" 7\"")), JKey::Hard);
+        // [FABLE-5] (sq-9781x) A whitespace-padded numeric lexical now HITS the aligned
+        // numeric cache (trim-then-parse via the shared `parse_xsd_f64`) and keys as
+        // `JKey::Num(7.0)` — the SAME key the inline id `7` gets — instead of the former
+        // `Hard` (the cache/evaluator acceptance sets are now aligned, so it no longer needs
+        // the exact-evaluator backstop for the whitespace case).
+        assert_eq!(key_of(&g, id_of("\" 7\"")), JKey::Num(7.0f64.to_bits()));
+        assert_eq!(key_of(&g, id_of("\" 7\"")), key_of(&g, dict::INLINE_BASE + 7));
         // Unknown datatype: identity key. IRIs: identity key.
         let uid = id_of("unknownDt");
         assert_eq!(key_of(&g, uid), JKey::Term(uid));

--- a/crates/sparq-engine/src/eqjoin.rs
+++ b/crates/sparq-engine/src/eqjoin.rs
@@ -451,16 +451,24 @@ fn key_of(graph: &Graph, id: Id) -> JKey {
                 };
             }
             // A NUMERIC datatype reaching here missed the `numeric_value` cache. As of
-            // sq-9781x the cache is ALIGNED with the evaluator: it parses through the shared
-            // `parse_xsd_f64` on the TRIMMED lexical (the same XSD acceptance set + trimming
-            // as `Num::of_literal`, which decides `values_equal`), so a whitespace-padded
-            // `" 1"^^xsd:integer` now HITS the cache above (→ `JKey::Num`) and the `inf`/`nan`
-            // Rust-only spellings the raw parse wrongly cached now MISS. A numeric datatype
-            // reaching THIS branch is therefore a genuinely ILL-FORMED numeric lexical (or a
-            // `NaN` value, the cache's not-cached sentinel) — which the exact evaluator also
-            // type-errors — so `Hard` (defer to the exact evaluator) stays the correct,
-            // no-false-negative key. (The alignment removed the former latent asymmetry;
-            // `Hard` remains a sound backstop.)
+            // sq-9781x the cache is aligned with the evaluator's datatype-AGNOSTIC f64 seam:
+            // it parses through the shared `parse_xsd_f64` on the TRIMMED lexical (the same
+            // XSD f64 acceptance set + trimming the `as_num`/`as_f64` seam uses), so a
+            // whitespace-padded `" 1"^^xsd:integer` now HITS the cache above (→ `JKey::Num`)
+            // and the `inf`/`nan` Rust-only spellings the raw parse wrongly cached now MISS.
+            //
+            // SCOPE: this alignment is with the f64 seam, NOT the datatype-AWARE
+            // `Num::of_literal` set that `values_equal` uses. The cache is thus still too
+            // LENIENT per-datatype: a lexical f64-parseable but ill-formed for its datatype
+            // (`"1.5"^^xsd:integer`, `"1E2"^^xsd:decimal`, an i128-overflow `xsd:decimal`)
+            // cache-HITS → `JKey::Num` here (and includes rows on the sargable `=` fast path)
+            // while `values_equal`/`of_literal` type-errors it — a residual `JKey::Num`-vs-
+            // `values_equal` divergence, PRE-EXISTING on main and tracked in the sq-74oy4-
+            // sibling bead (candidate fix: datatype-aware cache parse). A numeric datatype
+            // reaching THIS `Hard` branch is a lexical that misses even the lenient f64 seam
+            // (a genuinely ill-formed numeric or the `NaN` cache sentinel) — which the exact
+            // evaluator also type-errors — so `Hard` (defer to the exact evaluator) stays a
+            // correct, no-false-negative backstop.
             if is_numeric_datatype(datatype) {
                 return JKey::Hard;
             }

--- a/crates/sparq-engine/tests/eval_semantics.rs
+++ b/crates/sparq-engine/tests/eval_semantics.rs
@@ -982,3 +982,52 @@ mod dp_planner_result_equivalence {
         assert!(s.as_deref().map(|s| s.contains("/a")).unwrap_or(false), "ex:a must be the result, got {s:?}");
     }
 }
+
+/// [FABLE-5] (sq-9781x) The numeric-value cache is aligned with the evaluator's XSD
+/// acceptance set, so a whitespace-padded numeric lexical (`" 1 "^^xsd:integer`) — valid
+/// under XSD's `collapse` whitespace facet, value 1 — is treated CONSISTENTLY as the value
+/// 1 by every numeric seam: the relational FILTER fast path (`?o < 5`, reads the cache), the
+/// equality FILTER (`?o = 1`), and BIND arithmetic (`?o + 0`). Before the alignment the cache
+/// (a raw `str::parse::<f64>`) missed the padded lexical, so the fast `<`/`=` paths rejected
+/// it as a type error while arithmetic (via the trimming `Num::of_literal`) accepted it — a
+/// self-inconsistency this pins closed.
+mod numeric_whitespace_collapse_consistency {
+    use super::*;
+
+    fn padded_graph() -> Graph {
+        let ttl = "@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .\n\
+            @prefix ex: <http://ex/> .\n\
+            ex:a ex:v \" 1 \"^^xsd:integer .\n\
+            ex:b ex:v \"1\"^^xsd:integer .\n";
+        Graph::load_str(ttl, "turtle").unwrap()
+    }
+
+    #[test]
+    fn padded_integer_is_value_one_for_relational_equality_and_arithmetic() {
+        let g = padded_graph();
+        // Relational FILTER fast path reads the numeric cache.
+        let lt = query(&g, "SELECT ?s WHERE { ?s <http://ex/v> ?o FILTER(?o < 5) }").unwrap();
+        assert_eq!(lt.rows.len(), 2, "both the padded and plain integer are < 5");
+        // Equality: the padded lexical equals the value 1.
+        let eq = query(&g, "SELECT ?s WHERE { ?s <http://ex/v> ?o FILTER(?o = 1) }").unwrap();
+        assert_eq!(eq.rows.len(), 2, "both the padded and plain integer = 1");
+        // Arithmetic (through the trimming Num::of_literal) already accepted it — assert the
+        // three seams now AGREE.
+        let arith = query(&g, "SELECT ?s WHERE { ?s <http://ex/v> ?o BIND(?o + 0 AS ?n) FILTER(?n < 5) }").unwrap();
+        assert_eq!(arith.rows.len(), 2, "arithmetic path agrees: both rows survive");
+    }
+
+    #[test]
+    fn padded_and_plain_integer_are_value_equal_across_ids() {
+        // A join on value equality pairs the padded and plain integers (distinct dict ids,
+        // same value 1) — the cache-hit ⟺ evaluator-accept alignment in action.
+        let g = padded_graph();
+        let r = query(
+            &g,
+            "SELECT ?s1 ?s2 WHERE { ?s1 <http://ex/v> ?o1 . ?s2 <http://ex/v> ?o2 FILTER(?o1 = ?o2) }",
+        )
+        .unwrap();
+        // 2x2 value-equal pairs (a=a, a=b, b=a, b=b) — all four since both are value 1.
+        assert_eq!(r.rows.len(), 4, "all four ordered pairs are value-equal (both are 1)");
+    }
+}

--- a/crates/sparq-substrate/README.md
+++ b/crates/sparq-substrate/README.md
@@ -60,10 +60,10 @@ let n: Option<Num> = as_numeric(&lit);  // exact xsd:decimal (no f64 rounding)
   their XSD spellings `INF` / `-INF` / `NaN`, which are not scientific) and `lexical` (the plain
   form the W3C SPARQL expected-result files use for computed arithmetic, e.g. `6`) — and the
   shared lexical helpers (`split_decimal`, `parse_xsd_f32` / `parse_xsd_f64`, `fmt_xsd_double`).
-  `parse_xsd_f64`/`f32` accept the XSD `INF` / `+INF` / `-INF` / `NaN` spellings and reject the
-  Rust-`FromStr`-only `inf` / `infinity` / `nan`. `Num::cmp_relational` is the XPath relational
-  comparison (`<`/`>` FILTER, value-space equality) — partial (NaN → `None`), vs `cmp_total`
-  which totalises NaN for `ORDER BY` [OPUS-4.8] sq-v5evr.
+  `parse_xsd_f64`/`f32` accept the XSD `INF`/`+INF`/`-INF`/`NaN`, reject Rust-only `inf`/`infinity`/`nan`,
+  and (sq-9781x) delegate to `sparq_core::parse_xsd_f64` — one shared body with the `sparq-core`
+  numeric cache (cache-hit ⟺ evaluator-accepts). `Num::cmp_relational` is the XPath relational
+  comparison (`<`/`>` FILTER, value-space equality) — partial (NaN → `None`), vs `cmp_total` (NaN totalised for `ORDER BY`) [OPUS-4.8] sq-v5evr.
 - **`join`** — the four id-tuple join kernels over `&[Row]` slices: `merge_join` (sorted),
   `build_table` / `build_partitioned` / `probe_emit` / `probe_gather_indices` / `hash_probe_serial`
   (hash, `JoinTable` type alias backed by `hashbrown::HashMap<Key, Posting, FxBuildHasher>`,

--- a/crates/sparq-substrate/src/numeric.rs
+++ b/crates/sparq-substrate/src/numeric.rs
@@ -1501,4 +1501,72 @@ mod tests {
         // ±0.0 are equal (f64 comparison)
         assert_eq!(Num::Double(-0.0).cmp_relational(Num::Double(0.0)), Some(Equal));
     }
+
+    /// [FABLE-5] (sq-9781x) TRUE cross-seam differential: the sparq-core numeric-value CACHE
+    /// seam (`parse_xsd_f64(value.trim())` — the EXACT expression `numerics_of`/`numeric_of`
+    /// call in sparq-core) vs the datatype-AWARE evaluator `as_numeric` (`Num::of_literal`,
+    /// which decides `values_equal`). Unlike the sparq-core plumbing test
+    /// (`numeric_cache_hit_matches_shared_parse_xsd_f64_plumbing`, which models "acceptance"
+    /// with the same `parse_xsd_f64` the cache calls and so is circular against `of_literal`),
+    /// this asserts the two seams against EACH OTHER and pins the KNOWN, still-open
+    /// per-datatype divergence (bead sq-6b1lj): the datatype-agnostic cache accepts some
+    /// lexicals that are ill-formed FOR THEIR DATATYPE and that `as_numeric` type-errors.
+    ///
+    /// The `expect_divergent` flag documents each case's status; when the datatype-aware
+    /// cache fix (sq-6b1lj) lands, the divergent cases become AGREE and this test's
+    /// expectations flip (drop the flag). Until then a NEW unexpected divergence — or an
+    /// unexpected AGREEMENT on a case marked divergent (meaning sq-6b1lj shipped) — fails
+    /// here, so the invariant can never silently drift on the plumbing test alone.
+    #[test]
+    fn cache_f64_seam_vs_as_numeric_differential() {
+        // (lexical, datatype, expect_divergent). `expect_divergent = true` == cache HITS but
+        // `as_numeric` type-errors (or vice versa) — the sq-6b1lj residual, expected today.
+        let cases: &[(&str, oxrdf::NamedNodeRef<'_>, bool)] = &[
+            // ---- AGREE: both accept (well-formed for datatype), same f64 image ----
+            ("42", xsd::INTEGER, false),
+            (" 7 ", xsd::DECIMAL, false),      // whitespace collapse — both trim
+            ("+3", xsd::INTEGER, false),
+            ("1.5", xsd::DECIMAL, false),
+            ("1.5E2", xsd::DOUBLE, false),
+            ("INF", xsd::DOUBLE, false),
+            ("3.0", xsd::FLOAT, false),
+            // ---- AGREE: both reject ----
+            ("inf", xsd::DOUBLE, false),       // Rust-only spelling: both reject
+            ("nan", xsd::DOUBLE, false),
+            ("abc", xsd::INTEGER, false),
+            ("", xsd::INTEGER, false),
+            // ---- DIVERGE (sq-6b1lj): cache HITS via f64 seam, as_numeric type-errors ----
+            ("1.5", xsd::INTEGER, true),       // fraction on an integer
+            ("1E2", xsd::DECIMAL, true),       // exponent on a decimal
+            ("1E2", xsd::INTEGER, true),       // exponent on an integer
+            // >38-digit decimal: i128 overflow -> of_literal None, but parse_xsd_f64 -> Some
+            ("123456789012345678901234567890123456789.5", xsd::DECIMAL, true),
+        ];
+        for (lex, dt, expect_divergent) in cases {
+            // CACHE seam: exactly what sparq-core `numerics_of`/`numeric_of` compute — the
+            // datatype-agnostic shared parser on the trimmed lexical, NaN folding to "miss".
+            let cache_hit = parse_xsd_f64(lex.trim()).filter(|v| !v.is_nan()).is_some();
+            // EVALUATOR seam: datatype-aware acceptance (also NaN-as-not-a-value: a NaN Double
+            // value is "accepted" as a term but is the cache's not-cached sentinel, so exclude
+            // it symmetrically to compare acceptance-as-a-cacheable-value).
+            let eval_accepts = matches!(as_numeric(&typed(lex, *dt)), Some(n) if !n.f64().is_nan());
+            let divergent = cache_hit != eval_accepts;
+            assert_eq!(
+                divergent, *expect_divergent,
+                "seam divergence status for {:?}^^{:?}: cache_hit={} eval_accepts={} \
+                 (expected divergent={}). If a divergent case now AGREES, the sq-6b1lj \
+                 datatype-aware cache fix has landed — flip this case to expect_divergent=false.",
+                lex, dt.as_str(), cache_hit, eval_accepts, expect_divergent
+            );
+            // Where BOTH accept, the f64 images MUST match bit-for-bit (the cache stores that f64).
+            if cache_hit && eval_accepts {
+                let cache_f64 = parse_xsd_f64(lex.trim()).unwrap();
+                let eval_f64 = as_numeric(&typed(lex, *dt)).unwrap().f64();
+                assert_eq!(
+                    cache_f64.to_bits(), eval_f64.to_bits(),
+                    "f64 image mismatch for {:?}^^{:?}", lex, dt.as_str()
+                );
+            }
+        }
+    }
 }

--- a/crates/sparq-substrate/src/numeric.rs
+++ b/crates/sparq-substrate/src/numeric.rs
@@ -759,16 +759,15 @@ fn round_half_to_pos_inf(x: f64) -> f64 {
 
 /// Parse an xsd:float/xsd:double lexical: the XSD spellings of the specials, plus the
 /// ordinary scientific notation Rust's parser shares with XSD. `None` = ill-formed.
+///
+/// [FABLE-5] (sq-9781x) Delegates to the lowest-tier `sparq_core::parse_xsd_f64` — the
+/// SINGLE shared body of this parser — so the numeric-value CACHE (`Graph::numeric_value`,
+/// built in `sparq-core`) and this evaluator seam can never diverge on which double/float
+/// lexicals are numeric. `sparq-substrate` depends on `sparq-core`, so the shared body
+/// lives there; this re-export keeps the substrate's public `parse_xsd_f64` API stable.
 #[inline]
 pub fn parse_xsd_f64(v: &str) -> Option<f64> {
-    match v {
-        "NaN" => Some(f64::NAN),
-        "INF" | "+INF" => Some(f64::INFINITY),
-        "-INF" => Some(f64::NEG_INFINITY),
-        // Rust accepts "inf"/"infinity"/"nan" spellings XSD does not; exclude them.
-        _ if v.bytes().all(|c| c.is_ascii_digit() || matches!(c, b'+' | b'-' | b'.' | b'e' | b'E')) => v.parse::<f64>().ok(),
-        _ => None,
-    }
+    sparq_core::parse_xsd_f64(v)
 }
 
 /// Parse an xsd:float lexical (the [`parse_xsd_f64`] spellings, narrowed to `f32`).

--- a/skills/substrate/SKILL.md
+++ b/skills/substrate/SKILL.md
@@ -40,7 +40,9 @@ The XSD numeric value tower: `Num` (`Int(i64)` / `Dec(Dec)` / `Float(f32)` / `Do
 the fixed-point `Dec` struct (EXACT integer/decimal arithmetic, no f64 rounding), `ArithOp`
 (`Add`/`Sub`/`Mul`/`Div`), `RoundMode`, `as_numeric` (classifies an `oxrdf::Literal` into the
 tower), and the XSD lexical helpers `split_decimal`, `parse_xsd_f64`, `parse_xsd_f32`,
-`fmt_xsd_double`. Pulls `oxrdf` only when enabled. Two ordering methods on `Num`:
+`fmt_xsd_double`. `parse_xsd_f64` delegates to `sparq_core::parse_xsd_f64` (sq-9781x) — one
+shared body with the `sparq-core` numeric-value cache, so cache-hit ⟺ evaluator-accepts.
+Pulls `oxrdf` only when enabled. Two ordering methods on `Num`:
 - `Num::cmp_total` — ORDER BY / MIN/MAX total order; NaN totalised FIRST.
 - `Num::cmp_relational` — SPARQL `<`/`>` / D-entailment / RIF numeric equality; NaN → `None`
   (type error). [OPUS-4.8] sq-v5evr.


### PR DESCRIPTION
> 🤖 SPARQ agent — this PR was implemented by an automated SPARQ agent (Claude Fable 5). Please review with that in mind.

## sq-9781x — align the numeric-value cache with the evaluator's datatype-AGNOSTIC f64 seam

The `sparq-core` numeric-value cache parsed literals with a raw `str::parse::<f64>` in `numerics_of` / `numeric_of` / the dict-spill build, which **diverged from the evaluator's datatype-agnostic f64 seam** (`as_num` / `as_f64` / substrate `parse_xsd_f64`) in **both** directions:

- **too STRICT** — a whitespace-padded `" 1"^^xsd:integer` MISSED the cache while the f64 seam (which trims, matching `Num::of_literal`'s trim) accepts it. This is the latent bug the #1779 review flagged, papered over by the `JKey::Hard` fallback.
- **too LENIENT** (discovered during this fix) — `"inf"` / `"infinity"` / `"nan"^^xsd:double` were CACHED as inf/NaN, but the evaluator type-errors them (XSD forbids the Rust-`FromStr`-only spellings). This is a genuine divergence on the **sargable numeric FILTER fast path** (`exec.rs` reads `graph.numeric_value(id)` with NO residual recheck), so `FILTER(?x > 5)` over `"inf"^^xsd:double` over-included via the fast path where the exact evaluator excludes it.

### Scope of the claim (corrected per reviewer request_changes)

This PR is a **strict improvement on the datatype-AGNOSTIC f64 seam** — cache HIT ⟺ acceptance on the `as_num`/`as_f64`/substrate-`parse_xsd_f64` seam, for exactly the same f64. It **does NOT** make the cache agree with the full datatype-AWARE `Num::of_literal` / `as_numeric` acceptance set. `of_literal` is per-datatype (integers scale-0, decimals no-exponent, i128-bounded); the cache is datatype-agnostic, so it stays **too lenient PER DATATYPE**: `"1.5"^^xsd:integer`, `"1E2"^^xsd:decimal`, and a >38-digit `xsd:decimal` (i128 overflow) cache-HIT while `of_literal` type-errors them. On the DEFAULT-ON no-recheck fast path this surfaces as a sargable `=` / `JKey::Num` divergence vs `values_equal`.

This per-datatype residual is **PRE-EXISTING on main** (the old raw parse accepted the same lexicals) — neither introduced nor closed here — and is now tracked in **bead `sq-6b1lj`** (sibling of the trim bead sq-74oy4; candidate fix: datatype-aware cache parse). The load-bearing doc-comments (`parse_xsd_f64`, `numerics_of`, the `eqjoin` `JKey::Num` comment) are now scoped to the f64 seam and state the residual explicitly with the `"1.5"^^xsd:integer` counterexample.

### Approach (chosen with evidence)

`sparq-substrate` depends on `sparq-core` (not the reverse), so `numerics_of` cannot call the substrate's `parse_xsd_f64` — that would be a dependency cycle. Instead I **extracted one shared XSD-lexical parser into the lowest tier**, `sparq_core::parse_xsd_f64`, and:

- routed the cache (`numerics_of`, `numeric_of`, the dict-spill build) through it on the **trimmed** value, so a cache HIT ⟺ acceptance on the f64 seam, for exactly the same f64;
- made `sparq_substrate::numeric::parse_xsd_f64` **delegate** to it (single source of truth).

`parse_xsd_f64(trim())` reduces to `trim().parse::<f64>()` for every ordinary numeric lexical, so **no COMPARISON result changes** — only the f64-seam acceptance boundary shifts (whitespace admitted; Rust-only `inf`/`nan` spellings rejected). A stored NaN still folds to a cache MISS (NaN is the cache's not-cached sentinel), so a genuine `NaN`^^xsd:double correctly falls through to the evaluator.

The `eqjoin` `JKey::Hard` numeric backstop stays sound (a numeric datatype reaching it misses even the lenient f64 seam — a genuinely ill-formed lexical the exact evaluator also type-errors).

### Test evidence (two-tier, non-circular)

- `sparq-core` `numeric_cache_hit_matches_shared_parse_xsd_f64_plumbing` (**renamed** from the misleading `…_iff_evaluator_accepts_same_value`) — the honest **shared-parser PLUMBING check**: it pins that the cache actually routes every numeric datatype through the shared `parse_xsd_f64(trim())`. Its doc now states it is NOT a differential vs the real evaluator (it models acceptance with the same function the cache calls, so it is circular against `of_literal` by construction).
- **NEW** `sparq-substrate` `cache_f64_seam_vs_as_numeric_differential` — the TRUE cross-seam differential (legal here: substrate depends on sparq-core and owns `as_numeric`). It asserts the CACHE seam (`parse_xsd_f64(trim())`) against the datatype-AWARE `as_numeric`, over a corpus that includes the counterexamples, and **pins the KNOWN divergence** (`"1.5"^^xsd:integer` etc.) as explicitly-documented `expect_divergent = true` until `sq-6b1lj` lands — so the invariant cannot silently drift and, when the datatype-aware fix ships, the divergent cases will fail-then-flip to AGREE.
- `numeric_cache_alignment_fixes_both_divergences` — the two specific fixed f64-seam divergences (padded now hits; `inf`/`nan` now miss).
- `parse_xsd_f64_shared_acceptance_set` — direct unit test for the shared public fn.

### Gates re-run (both feature states)

- `cargo test -p sparq-core` — green.
- `cargo test -p sparq-substrate --all-features` — 116 pass (incl. the new differential).
- `cargo test -p sparq-engine` (default) **and** `--features value-join` — green.
- `RUSTDOCFLAGS="-D warnings" cargo doc --no-deps --all-features` — clean for the touched crates (public doc uses code spans, not intra-doc links, for the private/cross-crate items — the known feature-gated-doc-link trap).
- `cargo clippy --workspace -D warnings` — the ONLY failure is the pre-existing main-side clippy-1.97 `question_mark` lint at `crates/sparq-core/src/lib.rs:4785` (`next_terminator`), a region **this diff does not touch**, fixed by **#1793**. Not attributable to this PR; will be clean once #1793 lands on main and the merge-ref rebuilds.

### feature-OFF wasm declaration

Always-compiled `sparq-core` change; the feature-OFF `sparq-wasm` bundle moves **+507 bytes (+0.032%)**, well within the ±2% ratchet (declared per mechanism V2 in `bench/feature-off-declarations/`).

Fixes sq-9781x. Residual per-datatype divergence tracked in sq-6b1lj.
