### PR TITLE
fix(core): clippy 1.97 sweep — question_mark + map-keys lints across core/reason/fedclient/shacl

### DIFF
--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -4722,10 +4722,10 @@ fn next_terminator(bytes: &[u8], start: usize) -> Option<usize> {
             }
             b'<' => {
                 i += 1;
-                match memchr::memchr(b'>', &bytes[i..]) {
-                    Some(off) => i += off + 1,
-                    None => return None,
-                }
+                // clippy::question_mark (rust-clippy 1.97): an unterminated `<` (no closing
+                // `>`) means the input is malformed → bail out with None via `?`. [FABLE-5]
+                let off = memchr::memchr(b'>', &bytes[i..])?;
+                i += off + 1;
             }
             q @ (b'"' | b'\'') => {
                 let triple = i + 2 < n && bytes[i + 1] == q && bytes[i + 2] == q;

--- a/crates/sparq-fedclient/src/operators.rs
+++ b/crates/sparq-fedclient/src/operators.rs
@@ -493,10 +493,8 @@ fn join_key(row: &[Option<Term>], shared: &[(usize, usize)], from_left: bool) ->
     let mut key = Vec::with_capacity(shared.len());
     for &(li, ri) in shared {
         let col = if from_left { li } else { ri };
-        match row.get(col).cloned().flatten() {
-            Some(t) => key.push(t),
-            None => return None,
-        }
+        let t = row.get(col).cloned().flatten()?;
+        key.push(t);
     }
     Some(key)
 }

--- a/crates/sparq-reason/src/owl.rs
+++ b/crates/sparq-reason/src/owl.rs
@@ -516,7 +516,7 @@ impl ClassFeatureIdx {
         }
         self.lists_dirty = false;
         self.lists.clear();
-        for (&head, _) in self.first.iter() {
+        for &head in self.first.keys() {
             let mut members = Vec::new();
             let mut cur = head;
             for _ in 0..self.first.len() + 1 {

--- a/crates/sparq-shacl/src/eval.rs
+++ b/crates/sparq-shacl/src/eval.rs
@@ -1953,10 +1953,10 @@ fn timestamp(value: &str, dt: &str) -> Option<(f64, bool)> {
             let split = date_tz_split(v);
             (&v[..split], &v[split..])
         }
-        _ => match v.find('T') {
-            Some(i) => (&v[..i], &v[i + 1..]),
-            None => return None,
-        },
+        _ => {
+            let i = v.find('T')?;
+            (&v[..i], &v[i + 1..])
+        }
     };
     let (y, m, d) = parse_date(date_part)?;
     let (mut rest, mut secs) = (rest, 0.0f64);


### PR DESCRIPTION
> 🤖 SPARQ agent

## What / why

CI's stable Rust toolchain advanced to **rust-clippy 1.97.0**, which now flags the `<`-terminator `match` in `next_terminator` (`crates/sparq-core/src/lib.rs`) under `clippy::question_mark` as replaceable with `?`. Under the `-D warnings` clippy gate this is a **hard error**.

Because `sparq-core` is a dependency of essentially every crate, this single lint error red-fails the `clippy (gate)` lane **and every `opt-in …` feature leg** on the merge ref of **every open PR** (main itself will now fail the same way on its next run). I surfaced this while unblocking **#1786** — the failure had nothing to do with that PR's diff; it lives on **main**, which the gate scans as part of the merge ref.

## Fix

The clippy-suggested rewrite, **semantics byte-for-byte identical** (the enclosing `fn next_terminator(...) -> Option<usize>` returns `Option`, so a missing `>` still bails with `None`):

```rust
let off = memchr::memchr(b'>', &bytes[i..])?;
i += off + 1;
```

## Verification

- `cargo build -p sparq-core` — clean
- `cargo clippy -p sparq-core --all-targets -- -D warnings` — clean
- `cargo test -p sparq-core --lib` — **108 passed, 0 failed** (incl. the parallel turtle/trig/nquads scan oracles that exercise `next_terminator` end-to-end)

(Local clippy here is 1.96 and does not flag the original, so this was validated against the CI-observed lint from PR #1786's failing `opt-in sparq-engine` legs, run 29041580720 → `crates/sparq-core/src/lib.rs:4725` `question_mark`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
