### PR TITLE
fix(core): satisfy clippy 1.97 question_mark lint in next_terminator

### DIFF
--- a/crates/sparq-core/src/lib.rs
+++ b/crates/sparq-core/src/lib.rs
@@ -4722,10 +4722,11 @@ fn next_terminator(bytes: &[u8], start: usize) -> Option<usize> {
             }
             b'<' => {
                 i += 1;
-                match memchr::memchr(b'>', &bytes[i..]) {
-                    Some(off) => i += off + 1,
-                    None => return None,
-                }
+                // [FABLE-5] clippy 1.97's `question_mark` lint rejects the `match … { Some(off)
+                // => …, None => return None }` shape here; the `?` early-return is behaviour-
+                // identical (unterminated IRI ⇒ `None`).
+                let off = memchr::memchr(b'>', &bytes[i..])?;
+                i += off + 1;
             }
             q @ (b'"' | b'\'') => {
                 let triple = i + 2 < n && bytes[i + 1] == q && bytes[i + 2] == q;


### PR DESCRIPTION
> 🤖 SPARQ agent (Claude Fable 5)

## What

CI's clippy toolchain bumped to **rust 1.97.0**, whose strengthened `clippy::question_mark` lint (fatal under `-D warnings`) now rejects the

```rust
match memchr::memchr(b'>', &bytes[i..]) {
    Some(off) => i += off + 1,
    None => return None,
}
```

shape in `sparq-core::next_terminator` (`crates/sparq-core/src/lib.rs:4725`). Rewritten as the behaviour-identical:

```rust
let off = memchr::memchr(b'>', &bytes[i..])?;
i += off + 1;
```

## Why this is urgent (unblocks the whole PR queue)

This line has been on `main` unchanged since #1766 and passed under the previous (1.96) toolchain. The lint fires on the **merge ref** for **every open PR**, so the `clippy (gate)` lane and **all 40+ opt-in feature-matrix legs** currently go **red** on unrelated PRs (observed on #1785). Nothing merges until `main` carries the fix. Single-line, mechanical, no behaviour change (an unterminated `<…>` IRI still yields `None`).

## Gates

- `cargo build -p sparq-core` — clean.
- `cargo test -p sparq-core --features parallel turtle` — GREEN, incl. `tests/parallel_serial_load_differential.rs` which exercises `next_terminator` via the chunked turtle path.
- (Local clippy here is 1.96, which does not flag it; the rewrite is exactly clippy 1.97's own machine-applicable suggestion from the CI log.)

Do NOT auto-merge — leaving unarmed for review.